### PR TITLE
Don't reset global in TClass::New

### DIFF
--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -3925,8 +3925,9 @@ void *TClass::New(ENewType defConstructor) const
       // FIXME: Partial Answer: Is this because we may never actually deregister them???
 
       Bool_t statsave = GetObjectStat();
-      SetObjectStat(kFALSE);
-
+      if(statsave) {
+	SetObjectStat(kFALSE);
+      }
       TVirtualStreamerInfo* sinfo = GetStreamerInfo();
       if (!sinfo) {
          Error("New", "Cannot construct class '%s' version %d, no streamer info available!", GetName(), fClassVersion);
@@ -3939,7 +3940,9 @@ void *TClass::New(ENewType defConstructor) const
 
       // FIXME: Mistake?  See note above at the GetObjectStat() call.
       // Allow TObject's to be registered again.
-      SetObjectStat(statsave);
+      if(statsave) {
+	SetObjectStat(statsave);
+      }
 
       // Register the object for special handling in the destructor.
       if (p) {
@@ -4008,7 +4011,9 @@ void *TClass::New(void *arena, ENewType defConstructor) const
       // Do not register any TObject's that we create
       // as a result of creating this object.
       Bool_t statsave = GetObjectStat();
-      SetObjectStat(kFALSE);
+      if(statsave) {
+	SetObjectStat(kFALSE);
+      }
 
       TVirtualStreamerInfo* sinfo = GetStreamerInfo();
       if (!sinfo) {
@@ -4022,7 +4027,9 @@ void *TClass::New(void *arena, ENewType defConstructor) const
 
       // ???BUG???
       // Allow TObject's to be registered again.
-      SetObjectStat(statsave);
+      if(statsave) {
+	SetObjectStat(statsave);
+      }
 
       // Register the object for special handling in the destructor.
       if (p) {
@@ -4092,7 +4099,9 @@ void *TClass::NewArray(Long_t nElements, ENewType defConstructor) const
       // Do not register any TObject's that we create
       // as a result of creating this object.
       Bool_t statsave = GetObjectStat();
-      SetObjectStat(kFALSE);
+      if(statsave) {
+	SetObjectStat(kFALSE);
+      }
 
       TVirtualStreamerInfo* sinfo = GetStreamerInfo();
       if (!sinfo) {
@@ -4106,7 +4115,9 @@ void *TClass::NewArray(Long_t nElements, ENewType defConstructor) const
 
       // ???BUG???
       // Allow TObject's to be registered again.
-      SetObjectStat(statsave);
+      if(statsave) {
+	SetObjectStat(statsave);
+      }
 
       // Register the object for special handling in the destructor.
       if (p) {
@@ -4175,7 +4186,9 @@ void *TClass::NewArray(Long_t nElements, void *arena, ENewType defConstructor) c
       // Do not register any TObject's that we create
       // as a result of creating this object.
       Bool_t statsave = GetObjectStat();
-      SetObjectStat(kFALSE);
+      if(statsave) {
+	SetObjectStat(kFALSE);
+      }
 
       TVirtualStreamerInfo* sinfo = GetStreamerInfo();
       if (!sinfo) {
@@ -4189,7 +4202,9 @@ void *TClass::NewArray(Long_t nElements, void *arena, ENewType defConstructor) c
 
       // ???BUG???
       // Allow TObject's to be registered again.
-      SetObjectStat(statsave);
+      if(statsave) {
+	SetObjectStat(statsave);
+      }
 
       if (fStreamerType & kEmulated) {
          // We always register emulated objects, we need to always


### PR DESCRIPTION
Helgrind was complaining about a global being written without a lock.
In this case, the global is not actually changed so we do a check
to see if the old value was the same as the value we set and if
so, we don't bother to change it.
