### PR TITLE
Made TClass::fgCallingNew a thread_local file scope static

### DIFF
--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -168,7 +168,6 @@ private:
    void StreamerDefault(void *object, TBuffer &b, const TClass *onfile_class) const;
    
    static IdMap_t    *GetIdMap();       //Map from typeid to TClass pointer
-   static ENewType    fgCallingNew;     //Intent of why/how TClass::New() is called
    static Int_t       fgClassCount;     //provides unique id for a each class
                                         //stored in TObject::fUniqueID
    // Internal status bits

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -93,8 +93,8 @@ namespace {
    };
 }
 
+static thread_local TClass::ENewType    fgCallingNew = TClass::kRealNew;  //Intent of why/how TClass::New() is called
 Int_t TClass::fgClassCount;
-TClass::ENewType TClass::fgCallingNew = kRealNew;
 
 struct ObjRepoValue {
    ObjRepoValue(const TClass *what, Version_t version) : fClass(what),fVersion(version) {}


### PR DESCRIPTION
In order to avoid thread-safety issues, the static class member
TClass::fgCallingNew is no longer a class member and is instead
a file scoped static declared thread_local. It was necessary to
not have it is a class member since CINT could not parse the new
thread_local keyword.
