### PR TITLE
Made smatrix code thread safe by removing statics

### DIFF
--- a/math/smatrix/inc/Math/Dfact.h
+++ b/math/smatrix/inc/Math/Dfact.h
@@ -66,13 +66,13 @@ static bool Dfact(MatRepStd<T,n,idim>& rhs, T& det) {
   //typename MatrixRep::value_type* a = rhs.Array();
 
   /* Local variables */
-  static unsigned int nxch, i, j, k, l;
+  unsigned int nxch, i, j, k, l;
   //static typename MatrixRep::value_type p, q, tf;
-  static T p, q, tf;
+  T p, q, tf;
   
   /* Parameter adjustments */
   //  a -= idim + 1;
-  static int arrayOffset = - int(idim+1);
+  const int arrayOffset = - int(idim+1);
   /* Function Body */
   
   // fact.inc

--- a/math/smatrix/inc/Math/Dfactir.h
+++ b/math/smatrix/inc/Math/Dfactir.h
@@ -58,8 +58,8 @@ bool Dfactir(Matrix& rhs, typename Matrix::value_type& det, unsigned int* ir)
   typename Matrix::value_type* a = rhs.Array();
 
   /* Local variables */
-  static unsigned int nxch, i, j, k, l;
-  static typename Matrix::value_type p, q, tf;
+  unsigned int nxch, i, j, k, l;
+  typename Matrix::value_type p, q, tf;
   
   /* Parameter adjustments */
   a -= idim + 1;

--- a/math/smatrix/inc/Math/Dfinv.h
+++ b/math/smatrix/inc/Math/Dfinv.h
@@ -54,9 +54,9 @@ bool Dfinv(Matrix& rhs, unsigned int* ir) {
   typename Matrix::value_type* a = rhs.Array();
 
   /* Local variables */
-  static unsigned int nxch, i, j, k, m, ij;
-  static unsigned int im2, nm1, nmi;
-  static typename Matrix::value_type s31, s34, ti;
+  unsigned int nxch, i, j, k, m, ij;
+  unsigned int im2, nm1, nmi;
+  typename Matrix::value_type s31, s34, ti;
   
   /* Parameter adjustments */
   a -= idim + 1;

--- a/math/smatrix/inc/Math/Dinv.h
+++ b/math/smatrix/inc/Math/Dinv.h
@@ -78,7 +78,7 @@ public:
       /* Initialized data */
      unsigned int work[n+1] = {0};
 
-     static typename MatrixRep::value_type det(0.0);
+     typename MatrixRep::value_type det(0.0);
       
       if (DfactMatrix(rhs,det,work) != 0) {
 	std::cerr << "Dfact_matrix failed!!" << std::endl;

--- a/math/smatrix/inc/Math/Dsfact.h
+++ b/math/smatrix/inc/Math/Dsfact.h
@@ -74,11 +74,11 @@ static bool Dsfact(MatRepStd<T,n,idim>& rhs, T& det) {
 #endif
 
   /* Local variables */
-  static unsigned int i, j, l;
+  unsigned int i, j, l;
 
   /* Parameter adjustments */
   //  a -= idim + 1;
-  static int arrayOffset = -(idim+1);
+  const int arrayOffset = -(idim+1);
   /* sfactd.inc */
   det = 1.;
   for (j = 1; j <= n; ++j) {

--- a/math/smatrix/inc/Math/Dsinv.h
+++ b/math/smatrix/inc/Math/Dsinv.h
@@ -48,12 +48,12 @@ public:
   inline static bool Dsinv(MatrixRep& rhs) {
 
     /* Local variables */
-    static int i, j, k, l;
-    static T s31, s32;
-    static int jm1, jp1;
+    int i, j, k, l;
+    T s31, s32;
+    int jm1, jp1;
 
     /* Parameter adjustments */
-    static int arrayOffset = -1*(idim + 1);
+    const int arrayOffset = -1*(idim + 1);
 
 
     /* Function Body */


### PR DESCRIPTION
Changed all static variables which were only being used as local variables to be local variables. This avoids threading problems.
