### PR TITLE
Fix Reflex dictionary compilation with LLVM/Clang 3.5

### DIFF
--- a/cint/reflex/python/genreflex/gendict.py
+++ b/cint/reflex/python/genreflex/gendict.py
@@ -2223,7 +2223,7 @@ class genDictionary(object) :
         dtorscope = '::' + cl + '::'
     dtorimpl = '%svoid destructor%s(void*, void * o, const std::vector<void*>&, void *) {\n' % ( static, attrs['id'])
     if (attrs['name'][0] != '.'):
-      return dtorimpl + '(((::%s*)o)->%s~%s)();\n}' % ( cl, dtorscope, attrs['name'] )
+      return dtorimpl + '((::%s*)o)->%s~%s();\n}' % ( cl, dtorscope, attrs['name'] )
     else:
       # unnamed; can't call.
       return dtorimpl + '  // unnamed, cannot call destructor\n}'


### PR DESCRIPTION
See the following 5 years old commit in Clang:

```
https://github.com/llvm-mirror/clang/commit/
a78c5c34fbd20fde02261c3f3e21933cd58fcc04
```

Clang forces '(' token after reference to dtor. Reflex uses an extra
parentheses around dtor reference. It force Clang 3.5 to diagnose and fail.

A thread in cfe-dev (Clang) mainling-list was started:

```
http://lists.cs.uiuc.edu/pipermail/cfe-dev/
2014-October/039371.html
```

The following fixes failure in CMSSW with Clang 3.5: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc481/CMSSW_7_3_CLANG_X_2014-10-01-0200/AnalysisDataFormats/TopObjects

Signed-off-by: David Abdurachmanov davidlt@cern.ch
