### PR TITLE
Remove parentheses from destructor call to fix problem with clang 3.5

### DIFF
--- a/cint/reflex/python/genreflex/gendict.py
+++ b/cint/reflex/python/genreflex/gendict.py
@@ -2223,7 +2223,7 @@ class genDictionary(object) :
         dtorscope = '::' + cl + '::'
     dtorimpl = '%svoid destructor%s(void*, void * o, const std::vector<void*>&, void *) {\n' % ( static, attrs['id'])
     if (attrs['name'][0] != '.'):
-      return dtorimpl + '(((::%s*)o)->%s~%s)();\n}' % ( cl, dtorscope, attrs['name'] )
+      return dtorimpl + '((::%s*)o)->%s~%s();\n}' % ( cl, dtorscope, attrs['name'] )
     else:
       # unnamed; can't call.
       return dtorimpl + '  // unnamed, cannot call destructor\n}'


### PR DESCRIPTION
The clang 3.5 compiler needs a slightly different syntax when calling
the destructor. It does not allow a set of parentheses between the
name of the destructor and the parentheses which cause the call.
