### PR TITLE
Must take cint lock before calling TCint::CallFunc_Factory

### DIFF
--- a/core/meta/src/TMethodCall.cxx
+++ b/core/meta/src/TMethodCall.cxx
@@ -215,9 +215,10 @@ void TMethodCall::InitImplementation(const char *methodname, const char *params,
    // 'methodname' should NOT have any scope information in it.  The scope
    // information should be passed via the TClass or CINT ClassInfo.
 
-   if (!fFunc)
+   if (!fFunc) {
+      R__LOCKGUARD2(gCINTMutex);
       fFunc = gCint->CallFunc_Factory();
-   else
+   } else
       gCint->CallFunc_Init(fFunc);
 
    fClass    = cl;


### PR DESCRIPTION
Helgrind found that TCint::CallFunc_Factory indirectly updates
global cint state. Therefore one must take the cint lock before
calling the function. This was the only place (other than
TSelectorCint::Build) which calls this function without first
taking the lock.
