### PR TITLE
Added methods to calculate greenwich and local sidereal time.

### DIFF
--- a/core/base/inc/TTimeStamp.h
+++ b/core/base/inc/TTimeStamp.h
@@ -165,6 +165,13 @@ public:
 
    Double_t     AsDouble() const { return fSec + 1e-9 * fNanoSec; }
    Double_t     AsJulianDate() const { return (AsDouble()/86400.0 + 2440587.5); }
+   
+   // return stored time values converted to sidereal time
+   Double_t     AsGMST(Double_t UT1Offset = 0 /*milliseconds*/) const; //rval in hours
+   Double_t     AsGAST(Double_t UT1Offset = 0 /*milliseconds*/) const; //rval in hours
+   Double_t     AsLMST(Double_t Longitude /*degrees*/, Double_t UT1Offset = 0 /*milliseconds*/) const; //rval in hours
+   Double_t     AsLAST(Double_t Longitude /*degrees*/, Double_t UT1Offset = 0 /*milliseconds*/) const; //rval in hours
+
    const char  *AsString(const Option_t *option="") const;
 
    void         Copy(TTimeStamp &ts) const;

--- a/core/base/src/TTimeStamp.cxx
+++ b/core/base/src/TTimeStamp.cxx
@@ -139,6 +139,86 @@ TTimeStamp::TTimeStamp(UInt_t tloc, Bool_t isUTC, Int_t secOffset, Bool_t dosDat
 }
 
 //______________________________________________________________________________
+Double_t TTimeStamp::AsGMST(Double_t UT1Offset) const 
+{
+   // Return Greenwich mean sidereal time (GMST) in hour-angle. Return value 
+   // will always be between 0 and 24 (hours). Sidereal time is most accurately
+   // calculated from UT1. If fSec and fNanoSec are in UTC (which they are by
+   // default), the optional argument UT1Offset can be supplied (in
+   // milliseconds). If UT1Offset is not supplied, conversion has maximum error
+   // of 1s. If offset is supplied error can be reduced to us level. Values for
+   // UT1Offset can be found in IERS Bulletin B: 
+   // ftp://ftp.iers.org/products/eop/bulletinb/format_2009/
+   // The conversion to sidereal time used here is given by 
+   // Aoki et. al. Astron. Astrophys. 105, 359-362 (1982)
+   // http://adsabs.harvard.edu/abs/1982A%26A...105..359A
+
+   Double_t D = (AsJulianDate() + UT1Offset/86400000.0) - 2451545.0;
+   Double_t D_r = D - fmod(2.0*D+1.0, 2.0)/2.0;
+   Double_t T = D_r/36525.0;
+   Double_t sidereal = (24110.54841 + 8640184.812866*T + 0.093142*T*T
+      - 0.0000062*T*T*T + (D - D_r)*86400.0*1.002737909350795)/3600.0;
+   Double_t rval = fmod(sidereal, 24.0);
+   return rval < 0 ? rval + 24.0 : rval;
+}
+
+//______________________________________________________________________________
+Double_t TTimeStamp::AsGAST(Double_t UT1Offset) const
+{
+   // Return Greenwich apparant sidereal time (GAST) in hour-angle. Return
+   // value will always be between 0 and 24 (hours). Sidereal time is most
+   // accurately calculated from UT1. If fSec and fNanoSec are in UTC (which
+   // they are by default), the optional argument UT1Offset can be supplied (in
+   // milliseconds). If UT1Offset is not supplied, conversion has maximum error
+   // of 1s. If offset is supplied error can be reduced to us level. Values for
+   // UT1Offset can be found in IERS Bulletin B: 
+   // ftp://ftp.iers.org/products/eop/bulletinb/format_2009/
+   // Equation of the equinoxes is given by USNO:
+   // http://aa.usno.navy.mil/faq/docs/GAST.php
+
+   Double_t D = (AsJulianDate() + UT1Offset/86400000.0) - 2451545.0;
+   Double_t epsilon = (23.4393 - 0.0000004*D)*TMath::Pi()/180.0;
+   Double_t L = (280.47 + 0.98565*D)*TMath::Pi()/180.0;
+   Double_t Omega = (125.04 - 0.052954*D)*TMath::Pi()/180.0;
+   Double_t Deltapsi = -0.000319*TMath::Sin(Omega) - 0.000024*TMath::Sin(2.0*L);
+   Double_t eqeq = Deltapsi*TMath::Cos(epsilon);
+   Double_t rval = fmod(AsGMST(UT1Offset) + eqeq, 24.0);
+   return rval < 0 ? rval + 24.0 : rval;
+}
+
+//______________________________________________________________________________
+Double_t TTimeStamp::AsLMST(Double_t Longitude, Double_t UT1Offset) const
+{
+   // Return local mean sidereal time (LMST) in hour-angle, given a longitude
+   // in degrees. Return value will always be between 0 and 24 (hours).
+   // Sidereal time is most accurately calculated from UT1. If fSec and
+   // fNanoSec are in UTC (which they are by default), the optional argument
+   // UT1Offset can be supplied (in milliseconds). If UT1Offset is not
+   // supplied, conversion has maximum error of 1s. If offset is supplied error
+   // can be reduced to us level. Values for UT1Offset can be found in IERS
+   // Bulletin B: ftp://ftp.iers.org/products/eop/bulletinb/format_2009/
+
+   Double_t rval = fmod(AsGMST(UT1Offset) + Longitude/15.0, 24.0);
+   return rval < 0 ? rval + 24.0 : rval;
+}
+
+//______________________________________________________________________________
+Double_t TTimeStamp::AsLAST(Double_t Longitude, Double_t UT1Offset) const
+{
+   // Return local apparant sidereal time (LAST) in hour-angle, given a
+   // longitude in degrees. Return value will always be between 0 and 24
+   // (hours). Sidereal time is most accurately calculated from UT1. If fSec
+   // and fNanoSec are in UTC (which they are by default), the optional
+   // argument UT1Offset can be supplied (in milliseconds). If UT1Offset is not
+   // supplied, conversion has maximum error of 1s. If offset is supplied error
+   // can be reduced to us level. Values for UT1Offset can be found in IERS
+   // Bulletin B: ftp://ftp.iers.org/products/eop/bulletinb/format_2009/
+
+   Double_t rval = fmod(AsGAST(UT1Offset) + Longitude/15.0, 24.0);
+   return rval < 0 ? rval + 24.0 : rval;
+}
+
+//______________________________________________________________________________
 const Char_t *TTimeStamp::AsString(Option_t *option) const
 {
    // Return the date & time as a string.


### PR DESCRIPTION
This commit improves the functionality of TTimeStamp class by adding 4 methods to calculate Greenwich/local mean/apparent sidereal time. Calculation was referenced from

Aoki et. al. Astron. Astrophys. 105, 359-362 (1982), http://adsabs.harvard.edu/abs/1982A%26A...105..359A

and

http://aa.usno.navy.mil/faq/docs/GAST.php

In the future, it would be helpful to add a class that pulls the UTC-UT1 offset times from the below repository for enhanced accuracy:

ftp://ftp.iers.org/products/eop/bulletinb/format_2009/
