### PR TITLE
Update TMVA scripts for ROOT6

### DIFF
--- a/tmva/test/CorrGui.C
+++ b/tmva/test/CorrGui.C
@@ -45,8 +45,8 @@ void CorrGui(  TString fin = "TMVA.root", TString dirName = "InputVariables_Id",
 
    // how many variables  are in the directory?
    Int_t noVar = TMVAGlob::GetNumberOfInputVariables(dir);
-   cout << "found number of variables='" << noVar<< endl;
-   TString Var[noVar]; 
+   cout << "found number of variables: " << noVar<< endl;
+   vector<TString> Var(noVar);
 
    TIter next(dir->GetListOfKeys());
    Int_t it=0;
@@ -69,7 +69,7 @@ void CorrGui(  TString fin = "TMVA.root", TString dirName = "InputVariables_Id",
          }
       }
    }
-   cout << "found histos for "<< it <<" variables='" << endl;
+   cout << "found histos for "<< it <<" variables." << endl;
   
    for (Int_t ic=0;ic<it;ic++) {    
       cbar->AddButton( (Var[ic].Contains("_target") ? 

--- a/tmva/test/paracoor.C
+++ b/tmva/test/paracoor.C
@@ -1,5 +1,12 @@
 #include "tmvaglob.C"
 
+#include "TParallelCoord.h"
+#include "TParallelCoordVar.h"
+#include "TParallelCoordRange.h"
+#include "TTree.h"
+#include "TLeaf.h"
+#include "TFile.h"
+
 // plot parallel coordinates
 
 void paracoor( TString fin = "TMVA.root", Bool_t useTMVAStyle = kTRUE )
@@ -45,14 +52,14 @@ void paracoor( TString fin = "TMVA.root", Bool_t useTMVAStyle = kTRUE )
    const Int_t nmva = mvas.size();
    TCanvas* csig[nmva];
    TCanvas* cbkg[nmva];
-   for (Int_t imva=0; imva<mvas.size(); imva++) {
+   for (UInt_t imva=0; imva<mvas.size(); imva++) {
       cout << "--- Plotting parallel coordinates for : " << mvas[imva] << " & input variables" << endl;
 
       for (Int_t itype=0; itype<2; itype++) {
 
          // create draw option
          TString varstr = mvas[imva] + ":";
-         for (Int_t ivar=0; ivar<vars.size(); ivar++) varstr += vars[ivar] + ":";
+         for (UInt_t ivar=0; ivar<vars.size(); ivar++) varstr += vars[ivar] + ":";
          varstr.Resize( varstr.Last( ':' ) );
 
          // create canvas

--- a/tmva/test/probas.C
+++ b/tmva/test/probas.C
@@ -1,5 +1,7 @@
 #include "tmvaglob.C"
 
+#include "TH2F.h"
+
 // this macro plots the MVA probability distributions (Signal and
 // Background overlayed) of different MVA methods run in TMVA
 // (e.g. running TMVAnalysis.C).
@@ -72,7 +74,7 @@ void probas( TString fin = "TMVA.root", Bool_t useTMVAStyle = kTRUE )
          TString methodTitle;
          TMVAGlob::GetMethodTitle(methodTitle,instDir);
          Bool_t found = kFALSE;
-         while (hkey = (TKey*)nextInDir()) {
+         while ((hkey = (TKey*)nextInDir())) {
             TH1 *th1 = (TH1*)hkey->ReadObj();
             TString hname= th1->GetName();
             if (hname.Contains( suffixSig ) && !hname.Contains( "Cut") && 
@@ -147,7 +149,7 @@ void probas( TString fin = "TMVA.root", Bool_t useTMVAStyle = kTRUE )
                      Float_t ymin = 0;
                      Float_t ymax = TMath::Max( sig->GetMaximum(), bgd->GetMaximum() )*1.5;
             
-                     if (Draw_CFANN_Logy && mvaName[imva] == "CFANN") ymin = 0.01;
+                     if (Draw_CFANN_Logy && methodTitle == "CFANN") ymin = 0.01;
             
                      // build a frame
                      Int_t nb = 500;
@@ -160,7 +162,7 @@ void probas( TString fin = "TMVA.root", Bool_t useTMVAStyle = kTRUE )
                      // eventually: draw the frame
                      frame->Draw();  
             
-                     if (Draw_CFANN_Logy && mvaName[imva] == "CFANN") c->SetLogy();
+                     if (Draw_CFANN_Logy && methodTitle == "CFANN") c->SetLogy();
             
                      // overlay signal and background histograms
                      sig->SetMarkerColor( TMVAGlob::c_SignalLine );


### PR DESCRIPTION
Fixes the method-independent macros available from TMVAGui.C to work with cling. Correlation scatter plots are still broken because of ")" in strings passed to other macros (reported to D. Piparo)
