### PR TITLE
Added recursive print depth meta command.

### DIFF
--- a/core/base/inc/TObject.h
+++ b/core/base/inc/TObject.h
@@ -231,7 +231,7 @@ enum EObjBits {
 };
 
 namespace cling {
-   std::string printValue(TObject *val);
+   std::string printValue(TObject *val, unsigned int);
 }
 
 #ifndef ROOT_TBuffer

--- a/core/base/inc/TString.h
+++ b/core/base/inc/TString.h
@@ -782,9 +782,9 @@ namespace llvm {
 }
 
 namespace cling {
-  std::string printValue(const TString &val);
-  std::string printValue(const TSubString &val);
-  std::string printValue(const std::string_view &val);
+  std::string printValue(const TString *val, unsigned int);
+  std::string printValue(const TSubString *val, unsigned int);
+  std::string printValue(const std::string_view *val, unsigned int);
 }
 
 #endif

--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -1059,7 +1059,7 @@ void TObject::operator delete[](void *ptr)
 ////////////////////////////////////////////////////////////////////////////////
 /// Print value overload
 
-std::string cling::printValue(TObject *val) {
+std::string cling::printValue(TObject *val, unsigned int) {
    std::ostringstream strm;
    strm << "Name: " << val->GetName() << " Title: " << val->GetTitle();
    return strm.str();

--- a/core/base/src/TString.cxx
+++ b/core/base/src/TString.cxx
@@ -2622,24 +2622,24 @@ int strncasecmp(const char *str1, const char *str2, Ssiz_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Print a TString in the cling interpreter:
 
-std::string cling::printValue(const TString &val) {
-   TString s = TString::Format("\"%s\"[%d]", val.Data(), (int)val.Length());
+std::string cling::printValue(const TString *val, unsigned int) {
+   TString s = TString::Format("\"%s\"[%d]", val->Data(), (int)val->Length());
    return s.Data();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Print a TString in the cling interpreter:
 
-std::string cling::printValue(const TSubString &val) {
-   TString s = TString::Format("\"%.*s\"[%d]", (int)val.Length(), val.Data(), (int)val.Length());
+std::string cling::printValue(const TSubString *val, unsigned int) {
+   TString s = TString::Format("\"%.*s\"[%d]", (int)val->Length(), val->Data(), (int)val->Length());
    return s.Data();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Print a TString in the cling interpreter:
 
-std::string cling::printValue(const std::string_view &val) {
-   std::string str(val);
-   TString s = TString::Format("\"%s\"[%d]", str.c_str(), (int)val.length());
+std::string cling::printValue(const std::string_view *val, unsigned int) {
+   std::string str(*val);
+   TString s = TString::Format("\"%s\"[%d]", str.c_str(), (int)val->length());
    return s.Data();
 }

--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -439,7 +439,7 @@ protected:
 };
 
 namespace cling {
-  std::string printValue(TH1 *val);
+  std::string printValue(TH1 *val, unsigned int recursiveDepth);
 }
 
 //________________________________________________________________________

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -8780,9 +8780,9 @@ void TH1::UpdateBinContent(Int_t, Double_t)
 ////////////////////////////////////////////////////////////////////////////////
 /// Print value overload
 
-std::string cling::printValue(TH1 *val) {
+std::string cling::printValue(TH1 *val, unsigned int recursiveDepth) {
   std::ostringstream strm;
-  strm << cling::printValue((TObject*)val) << " NbinsX: " << val->GetNbinsX();
+  strm << cling::printValue((TObject*)val, recursiveDepth) << " NbinsX: " << val->GetNbinsX();
   return strm.str();
 }
 

--- a/interpreter/cling/include/cling/Interpreter/Interpreter.h
+++ b/interpreter/cling/include/cling/Interpreter/Interpreter.h
@@ -170,6 +170,10 @@ namespace cling {
     ///
     bool m_RawInputEnabled;
 
+    ///\brief Depth up to which to recursively print collections.
+    ///
+    unsigned int m_RecursivePrintDepth;
+
     ///\brief Interpreter callbacks.
     ///
     std::unique_ptr<InterpreterCallbacks> m_Callbacks;
@@ -544,6 +548,9 @@ namespace cling {
 
     bool isRawInputEnabled() const { return m_RawInputEnabled; }
     void enableRawInput(bool raw = true) { m_RawInputEnabled = raw; }
+
+    unsigned int getRecursivePrintDepth() const { return m_RecursivePrintDepth; }
+    void setRecursivePrintDepth(unsigned int depth) { m_RecursivePrintDepth = depth; }
 
     clang::CompilerInstance* getCI() const;
     clang::Sema& getSema() const;

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -167,7 +167,7 @@ namespace cling {
   Interpreter::Interpreter(int argc, const char* const *argv,
                            const char* llvmdir /*= 0*/, bool noRuntime) :
     m_UniqueCounter(0), m_PrintDebug(false), m_DynamicLookupDeclared(false),
-    m_DynamicLookupEnabled(false), m_RawInputEnabled(false) {
+    m_DynamicLookupEnabled(false), m_RawInputEnabled(false), m_RecursivePrintDepth(2) {
 
     m_LLVMContext.reset(new llvm::LLVMContext);
     std::vector<unsigned> LeftoverArgsIdx;

--- a/interpreter/cling/lib/Interpreter/ValuePrinter.cpp
+++ b/interpreter/cling/lib/Interpreter/ValuePrinter.cpp
@@ -153,6 +153,8 @@ static std::string executePrintValue(const Value &V, const T &val) {
   printValueSS << "cling::printValue(";
   printValueSS << getTypeString(V);
   printValueSS << (const void *) &val;
+  printValueSS << ", ";
+  printValueSS << Interp->getRecursivePrintDepth();
   printValueSS << ");";
   Value printValueV;
   Interp->evaluate(printValueSS.str(), printValueV);
@@ -362,7 +364,7 @@ static std::string printUnpackedClingValue(const Value &V) {
 namespace cling {
 
   // General fallback - prints the address
-  std::string printValue(const void *ptr) {
+  std::string printValue(const void *ptr, unsigned int) {
     if (!ptr) {
       return "nullptr";
     } else {
@@ -375,7 +377,7 @@ namespace cling {
   }
 
   // void pointer
-  std::string printValue(const void **ptr) {
+  std::string printValue(const void **ptr, unsigned int) {
     if (!*ptr) {
       return "nullptr";
     } else {
@@ -388,7 +390,7 @@ namespace cling {
   }
 
   // Bool
-  std::string printValue(const bool *val) {
+  std::string printValue(const bool *val, unsigned int) {
     return *val ? "true" : "false";
   }
 
@@ -407,88 +409,88 @@ namespace cling {
     return strm.str();
   }
 
-  std::string printValue(const char *val) {
+  std::string printValue(const char *val, unsigned int) {
     return printChar(*val, true);
   }
 
-  std::string printValue(const signed char *val) {
+  std::string printValue(const signed char *val, unsigned int) {
     return printChar(*val, true);
   }
 
-  std::string printValue(const unsigned char *val) {
+  std::string printValue(const unsigned char *val, unsigned int) {
     return printChar(*val, true);
   }
 
   // Ints
-  std::string printValue(const short *val) {
+  std::string printValue(const short *val, unsigned int) {
     std::ostringstream strm;
     strm << *val;
     return strm.str();
   }
 
-  std::string printValue(const unsigned short *val) {
+  std::string printValue(const unsigned short *val, unsigned int) {
     std::ostringstream strm;
     strm << *val;
     return strm.str();
   }
 
-  std::string printValue(const int *val) {
+  std::string printValue(const int *val, unsigned int) {
     std::ostringstream strm;
     strm << *val;
     return strm.str();
   }
 
-  std::string printValue(const unsigned int *val) {
+  std::string printValue(const unsigned int *val, unsigned int) {
     std::ostringstream strm;
     strm << *val;
     return strm.str();
   }
 
-  std::string printValue(const long *val) {
+  std::string printValue(const long *val, unsigned int) {
     std::ostringstream strm;
     strm << *val;
     return strm.str();
   }
 
-  std::string printValue(const unsigned long *val) {
+  std::string printValue(const unsigned long *val, unsigned int) {
     std::ostringstream strm;
     strm << *val;
     return strm.str();
   }
 
-  std::string printValue(const long long *val) {
+  std::string printValue(const long long *val, unsigned int) {
     std::ostringstream strm;
     strm << *val;
     return strm.str();
   }
 
-  std::string printValue(const unsigned long long *val) {
+  std::string printValue(const unsigned long long *val, unsigned int) {
     std::ostringstream strm;
     strm << *val;
     return strm.str();
   }
 
   // Reals
-  std::string printValue(const float *val) {
+  std::string printValue(const float *val, unsigned int) {
     std::ostringstream strm;
     strm << std::showpoint << *val << "f";
     return strm.str();
   }
 
-  std::string printValue(const double *val) {
+  std::string printValue(const double *val, unsigned int) {
     std::ostringstream strm;
     strm << std::showpoint << *val;
     return strm.str();
   }
 
-  std::string printValue(const long double *val) {
+  std::string printValue(const long double *val, unsigned int) {
     std::ostringstream strm;
     strm << *val << "L";
     return strm.str();
   }
 
   // Char pointers
-  std::string printValue(const char *const *val) {
+  std::string printValue(const char *const *val, unsigned int) {
     if (!*val) {
       return "nullptr";
     } else {
@@ -503,17 +505,17 @@ namespace cling {
     }
   }
 
-  std::string printValue(const char **val) {
-    return printValue((const char *const *) val);
+  std::string printValue(const char **val, unsigned int recurseDepth) {
+    return printValue((const char *const *) val, recurseDepth);
   }
 
   // std::string
-  std::string printValue(const std::string *val) {
+  std::string printValue(const std::string *val, unsigned int) {
     return "\"" + *val + "\"";
   }
 
   // cling::Value
-  std::string printValue(const Value *value) {
+  std::string printValue(const Value *value, unsigned int) {
     std::ostringstream strm;
 
     if (!value->isValid()) {

--- a/interpreter/cling/lib/MetaProcessor/MetaParser.cpp
+++ b/interpreter/cling/lib/MetaProcessor/MetaParser.cpp
@@ -124,7 +124,7 @@ namespace cling {
       || isXCommand(actionResult, resultValue) ||isTCommand(actionResult)
       || isAtCommand()
       || isqCommand() || isUCommand(actionResult) || isICommand()
-      || isOCommand() || israwInputCommand()
+      || isOCommand() || israwInputCommand() || isRecursivePrintDepthCommand()
       || isdebugCommand() || isprintDebugCommand()
       || isdynamicExtensionsCommand() || ishelpCommand() || isfileExCommand()
       || isfilesCommand() || isClassCommand() || isNamespaceCommand() || isgCommand()
@@ -376,6 +376,26 @@ namespace cling {
         mode = (MetaSema::SwitchMode)getCurTok().getConstantAsBool();
       m_Actions->actOnrawInputCommand(mode);
       return true;
+    }
+    return false;
+  }
+
+  bool MetaParser::isRecursivePrintDepthCommand() {
+    if (getCurTok().is(tok::ident) &&
+        getCurTok().getIdent().equals("printDepth")) {
+      consumeToken();
+      skipWhitespace();
+      if (getCurTok().is(tok::constant)) {
+        unsigned short depth = getCurTok().getConstant();
+        m_Actions->actOnRecursivePrintDepthCommand(depth);
+        return true;
+      } else if (getCurTok().is(tok::eof)){
+        m_Actions->actOnRecursivePrintDepthCommand((unsigned int)-1);
+        return true;
+      } else {
+        m_Actions->getMetaProcessor().getOuts() << "ERROR: \""
+        << getCurTok().getBufStart() << "\" is not a natural number.\n";
+      }
     }
     return false;
   }

--- a/interpreter/cling/lib/MetaProcessor/MetaParser.h
+++ b/interpreter/cling/lib/MetaProcessor/MetaParser.h
@@ -29,6 +29,7 @@ namespace cling {
   //                 CommandSymbol := '.' | '//.'
   //                 Command := LCommand | XCommand | qCommand | UCommand |
   //                            ICommand | OCommand | RawInputCommand |
+  //                            RecursivePrintDepthCommand |
   //                            PrintDebugCommand | DynamicExtensionsCommand |
   //                            HelpCommand | FileExCommand | FilesCommand |
   //                            ClassCommand | GCommand | StoreStateCommand |
@@ -42,6 +43,7 @@ namespace cling {
   //                 ICommand := 'I' [FilePath]
   //                 OCommand := 'O'[' ']Constant
   //                 RawInputCommand := 'rawInput' [Constant]
+  //                 RecursivePrintDepthCommand := 'printDepth' [Constant]
   //                 PrintDebugCommand := 'printDebug' [Constant]
   //                 DebugCommand := 'debug' [Constant]
   //                 StoreStateCommand := 'storeState' "Ident"
@@ -94,6 +96,7 @@ namespace cling {
     bool isICommand();
     bool isOCommand();
     bool israwInputCommand();
+    bool isRecursivePrintDepthCommand();
     bool isdebugCommand();
     bool isprintDebugCommand();
     bool isstoreStateCommand();

--- a/interpreter/cling/lib/MetaProcessor/MetaSema.cpp
+++ b/interpreter/cling/lib/MetaProcessor/MetaSema.cpp
@@ -215,6 +215,22 @@ namespace cling {
       m_Interpreter.enableRawInput(mode);
   }
 
+  void MetaSema::actOnRecursivePrintDepthCommand(unsigned int depth) const {
+    if(depth == (unsigned int)-1) {
+      if(m_Interpreter.getRecursivePrintDepth() != 2) {
+        m_Interpreter.setRecursivePrintDepth(2);
+      } else {
+        m_Interpreter.setRecursivePrintDepth(0);
+      }
+      m_MetaProcessor.getOuts() << "Recursive print depth set to " << m_Interpreter.getRecursivePrintDepth() << "\n";
+      // TODO maybe only show the value here instead of toggling?
+//      m_MetaProcessor.getOuts() << "Recursive print depth is " << m_Interpreter.getRecursivePrintDepth() << "\n";
+    } else {
+      m_Interpreter.setRecursivePrintDepth(depth);
+      m_MetaProcessor.getOuts() << "Recursive print depth set to " << m_Interpreter.getRecursivePrintDepth() << "\n";
+    }
+  }
+
   void MetaSema::actOndebugCommand(llvm::Optional<int> mode) const {
     clang::CodeGenOptions& CGO = m_Interpreter.getCI()->getCodeGenOpts();
     if (!mode) {
@@ -331,6 +347,9 @@ namespace cling {
       "\n"
       "   " << metaString << "rawInput [0|1]\t\t- Toggle wrapping and printing the"
                              "\n\t\t\t\t  execution results of the input\n"
+      "\n"
+      "   " << metaString << "printDepth [depth]\t\t- Set the recursive depth up to which"
+                             "\n\t\t\t\t  to print nested collections to. depth >= 0\n"
       "\n"
       "   " << metaString << "dynamicExtensions [0|1]\t- Toggles the use of the dynamic scopes and the"
                              "\n\t\t\t\t  late binding\n"

--- a/interpreter/cling/lib/MetaProcessor/MetaSema.h
+++ b/interpreter/cling/lib/MetaProcessor/MetaSema.h
@@ -58,6 +58,7 @@ namespace cling {
     MetaSema(Interpreter& interp, MetaProcessor& meta);
 
     const Interpreter& getInterpreter() const { return m_Interpreter; }
+    const MetaProcessor& getMetaProcessor() const { return m_MetaProcessor; }
     bool isQuitRequested() const { return m_IsQuitRequested; }
 
     ///\brief L command includes the given file or loads the given library.
@@ -142,6 +143,15 @@ namespace cling {
     ///\param[in] mode - either on/off or toggle.
     ///
     void actOnrawInputCommand(SwitchMode mode = kToggle) const;
+
+
+    ///\brief Sets the depth up to which nested collections are printed.
+    ///
+    ///\param[in] depth - number of nested levels to be printed.
+    ///
+    ///
+    void actOnRecursivePrintDepthCommand(unsigned int depth) const;
+
 
     ///\brief Generates debug info for the JIT.
     ///


### PR DESCRIPTION
Implemented corresponding print behavior.
Maybe revise this meta command's behavior in the case of a missing argument (print out the current value, instead of toggling between two defaults), if it turns out to be more intuitive.
