### PR TITLE
Fix ROOT-7121: Stack corruption in RooVectorDataStore 

### DIFF
--- a/roofit/roofitcore/inc/RooVectorDataStore.h
+++ b/roofit/roofitcore/inc/RooVectorDataStore.h
@@ -750,7 +750,6 @@ public:
   mutable Double_t  _curWgtErr ;   // Weight of current event
 
   RooVectorDataStore* _cache ; //! Optimization cache
-  std::vector<RooVectorDataStore::RealVector*> _cacheUpdateList ; //! Pointers to the optimization cache
   RooAbsArg* _cacheOwner ; //! Cache owner
 
   Bool_t _forcedUpdate ; //! Request for forced cache update 

--- a/roofit/roofitcore/inc/RooVectorDataStore.h
+++ b/roofit/roofitcore/inc/RooVectorDataStore.h
@@ -750,6 +750,7 @@ public:
   mutable Double_t  _curWgtErr ;   // Weight of current event
 
   RooVectorDataStore* _cache ; //! Optimization cache
+  std::vector<RooVectorDataStore::RealVector*> _cacheUpdateList ; //! Pointers to the optimization cache
   RooAbsArg* _cacheOwner ; //! Cache owner
 
   Bool_t _forcedUpdate ; //! Request for forced cache update 

--- a/roofit/roofitcore/src/RooVectorDataStore.cxx
+++ b/roofit/roofitcore/src/RooVectorDataStore.cxx
@@ -1300,23 +1300,23 @@ void RooVectorDataStore::recalculateCache( const RooArgSet *projectedArgs, Int_t
 {
   if (!_cache) return ;
 
-  std::vector<RooVectorDataStore::RealVector*> tv;
-  tv.reserve(_cache->_nReal*0.7); //Typically, 30..60% need to be recalculated
+  std::vector<RooVectorDataStore::RealVector *> tv;
+  tv.reserve(_cache->_nReal * 0.7); // Typically, 30..60% need to be recalculated
 
   // Check which items need recalculation
   for (Int_t i=0 ; i<_cache->_nReal ; i++) {
     if ((*(_cache->_firstReal+i))->needRecalc() || _forcedUpdate) {
-      RooVectorDataStore::RealVector* cacheElem = *(_cache->_firstReal+i);
-      tv.push_back(cacheElem);
-      cacheElem->_nativeReal->setOperMode(RooAbsArg::ADirty);
-      cacheElem->_nativeReal->_operMode=RooAbsArg::Auto;
+       RooVectorDataStore::RealVector *cacheElem = *(_cache->_firstReal + i);
+       tv.push_back(cacheElem);
+       cacheElem->_nativeReal->setOperMode(RooAbsArg::ADirty);
+       cacheElem->_nativeReal->_operMode = RooAbsArg::Auto;
     }    
   }
   _forcedUpdate = kFALSE ;
 
   // If no recalculations are needed stop here
   if (tv.empty()) {
-    return;
+     return;
   }
   // Refill caches of elements that require recalculation
 //   cout << "recalc error count before update = " << RooAbsReal::numEvalErrors() << endl ;
@@ -1337,10 +1337,11 @@ void RooVectorDataStore::recalculateCache( const RooArgSet *projectedArgs, Int_t
     get(i) ;    
     Bool_t zeroWeight = (weight()==0) ;
     if (!zeroWeight || !skipZeroWeights) {
-      for (std::vector<RooVectorDataStore::RealVector*>::iterator cacheIt = tv.begin(); cacheIt != tv.end(); ++cacheIt) {
-        (*cacheIt)->_nativeReal->_valueDirty=kTRUE;
-        (*cacheIt)->_nativeReal->getValV((*cacheIt)->_nset ? (*cacheIt)->_nset : usedNset);
-        (*cacheIt)->write(i);
+       for (std::vector<RooVectorDataStore::RealVector *>::iterator cacheIt = tv.begin(); cacheIt != tv.end();
+            ++cacheIt) {
+          (*cacheIt)->_nativeReal->_valueDirty = kTRUE;
+          (*cacheIt)->_nativeReal->getValV((*cacheIt)->_nset ? (*cacheIt)->_nset : usedNset);
+          (*cacheIt)->write(i);
       }
     }
 //     if (zeroWeight) {
@@ -1360,8 +1361,8 @@ void RooVectorDataStore::recalculateCache( const RooArgSet *projectedArgs, Int_t
 //   cout << "recalculate: end of updating" << endl ;
 //   cout << "recalc error count after update = " << RooAbsReal::numEvalErrors() << endl ;
 
-  for (std::vector<RooVectorDataStore::RealVector*>::iterator cacheIt = tv.begin(); cacheIt != tv.end(); ++cacheIt) {
-    (*cacheIt)->_nativeReal->setOperMode(RooAbsArg::AClean) ;
+  for (std::vector<RooVectorDataStore::RealVector *>::iterator cacheIt = tv.begin(); cacheIt != tv.end(); ++cacheIt) {
+     (*cacheIt)->_nativeReal->setOperMode(RooAbsArg::AClean);
   }  
 
   delete ownedNset ;


### PR DESCRIPTION
This is a fix for ROOT-7121.

If a cache is updated in RooVectorDataStore and the cache has more than 1000 elements to be updated, an array on the stack will overrun and smash the stack. roofit will therefore crash.

Solution: RooVectorDataStore uses a std::vector instead of an array[1000] to hold the pointers to the cache elements.

Comments on the speed of the fix:
Using a std::vector placed on the stack (mimicking the original implementation), the fits would get slower. Therefore I added the vector as a member of RooVectorDataStore. This saves the time of constantly having to reallocate the vector.

I tested with my (private) workspace: The crash is fixed. Unfortunately, I cannot provide this workspace.
To give a more meaningful test for you guys, I ran all the roofit/roostats tutorials and diffed the logs to check if roofit gives the same results. The diffs are attached. Apart from out-of-order execution and time measurements, there is no difference.
From the time measurements you can also see that the fixed version is not slower.

[tutorials_roofit.diff.txt](https://github.com/root-mirror/root/files/56546/tutorials_roofit.diff.txt)
[tutorials_roostats.diff.txt](https://github.com/root-mirror/root/files/56547/tutorials_roostats.diff.txt)
