### PR TITLE
speedup for .class.C for MLP

### DIFF
--- a/tmva/tmva/src/MethodANNBase.cxx
+++ b/tmva/tmva/src/MethodANNBase.cxx
@@ -1106,7 +1106,43 @@ void TMVA::MethodANNBase::MakeClassSpecific( std::ostream& fout, const TString& 
    fout << "   for (int i=0; i<" << ((TObjArray*)fNetwork->At(0))->GetEntries()-1 << "; i++)" << std::endl;
    fout << "      fWeights0[i]=inputValues[i];" << std::endl;
    fout << std::endl;
-   for (Int_t i = 0; i < numLayers - 1; i++) {
+   for (Int_t i = 0; i < 1; ++i) { // dummy loop to ease up copy&paste
+      fout << "   // layer " << i << " to " << i + 1 << std::endl;
+      if (i + 1 == numLayers - 1) {
+         fout << "   for (int o=0; o<" << ((TObjArray *)fNetwork->At(i + 1))->GetEntries() << "; o++) {" << std::endl;
+      } else {
+         fout << "   for (int o=0; o<" << ((TObjArray *)fNetwork->At(i + 1))->GetEntries() - 1 << "; o++) {"
+              << std::endl;
+      }
+      fout << "      double buffer[" << ((TObjArray *)fNetwork->At(i))->GetEntries() << "];" << std::endl;
+      fout << "      for (int i=0; i<" << ((TObjArray *)fNetwork->At(i))->GetEntries() << "; i++) {" << std::endl;
+      fout << "         buffer[i] = fWeightMatrix" << i << "to" << i + 1 << "[o][i] * fWeights" << i << "[i];"
+           << std::endl;
+      fout << "      } // loop over i" << std::endl;
+      fout << "      for (int i=0; i<" << ((TObjArray *)fNetwork->At(i))->GetEntries() << "; i++) {" << std::endl;
+      if (fNeuronInputType == "sum") {
+         fout << "         fWeights" << i + 1 << "[o] += buffer[i];" << std::endl;
+      } else if (fNeuronInputType == "sqsum") {
+         fout << "         fWeights" << i + 1 << "[o] += buffer[i]*buffer[i];" << std::endl;
+      } else { // fNeuronInputType == TNeuronInputChooser::kAbsSum
+         fout << "         fWeights" << i + 1 << "[o] += fabs(buffer[i]);" << std::endl;
+      }
+      fout << "      } // loop over i" << std::endl;
+      fout << "    } // loop over o" << std::endl;
+      if (i + 1 == numLayers - 1) {
+         fout << "   for (int o=0; o<" << ((TObjArray *)fNetwork->At(i + 1))->GetEntries() << "; o++) {" << std::endl;
+      } else {
+         fout << "   for (int o=0; o<" << ((TObjArray *)fNetwork->At(i + 1))->GetEntries() - 1 << "; o++) {"
+              << std::endl;
+      }
+      if (i+1 != numLayers-1) // in the last layer no activation function is applied
+         fout << "      fWeights" << i + 1 << "[o] = ActivationFnc(fWeights" << i + 1 << "[o]);" << std::endl;
+      else
+         fout << "      fWeights" << i + 1 << "[o] = OutputActivationFnc(fWeights" << i + 1 << "[o]);"
+              << std::endl; // zjh
+      fout << "   } // loop over o" << std::endl;
+   }
+   for (Int_t i = 1; i < numLayers - 1; i++) {
       fout << "   // layer " << i << " to " << i + 1 << std::endl;
       if (i + 1 == numLayers - 1) {
          fout << "   for (int o=0; o<" << ((TObjArray *)fNetwork->At(i + 1))->GetEntries() << "; o++) {" << std::endl;

--- a/tmva/tmva/src/MethodANNBase.cxx
+++ b/tmva/tmva/src/MethodANNBase.cxx
@@ -1064,10 +1064,6 @@ void TMVA::MethodANNBase::MakeClassSpecific( std::ostream& fout, const TString& 
    fout << "inline void " << className << "::Initialize()" << std::endl;
    fout << "{" << std::endl;
    fout << "   // build network structure" << std::endl;
-   for (Int_t lIdx = 0; lIdx < numLayers; lIdx++) {
-      TObjArray* layer = (TObjArray*)fNetwork->At(lIdx);
-      int numNodes = layer->GetEntries();
-   }
 
    for (Int_t i = 0; i < numLayers-1; i++) {
       fout << "   // weight matrix from layer " << i  << " to " << i+1 << std::endl;

--- a/tmva/tmva/src/MethodANNBase.cxx
+++ b/tmva/tmva/src/MethodANNBase.cxx
@@ -1085,8 +1085,10 @@ void TMVA::MethodANNBase::MakeClassSpecific( std::ostream& fout, const TString& 
    // writing of the GetMvaValue__ method
    fout << "inline double " << className << "::GetMvaValue__( const std::vector<double>& inputValues ) const" << std::endl;
    fout << "{" << std::endl;
-   fout << "   if (inputValues.size() != (unsigned int)" << ((TObjArray*)fNetwork->At(0))->GetEntries()-1 << ") {" << std::endl;
-   fout << "      std::cout << \"Input vector needs to be of size \" << " << ((TObjArray*)fNetwork->At(0))->GetEntries()-1 << " << std::endl;" << std::endl;
+   fout << "   if (inputValues.size() != (unsigned int)" << ((TObjArray *)fNetwork->At(0))->GetEntries() - 1 << ") {"
+        << std::endl;
+   fout << "      std::cout << \"Input vector needs to be of size \" << "
+        << ((TObjArray *)fNetwork->At(0))->GetEntries() - 1 << " << std::endl;" << std::endl;
    fout << "      return 0;" << std::endl;
    fout << "   }" << std::endl;
    fout << std::endl;

--- a/tmva/tmva/src/MethodANNBase.cxx
+++ b/tmva/tmva/src/MethodANNBase.cxx
@@ -1108,14 +1108,14 @@ void TMVA::MethodANNBase::MakeClassSpecific( std::ostream& fout, const TString& 
               << std::endl;
       }
       if ( 0 == i ) {
-         fout << "      std::array<double, " << ((TObjArray *)fNetwork->At(i))->GetEntries() << "> buffer {{}};" << std::endl;
+         fout << "      std::array<double, " << ((TObjArray *)fNetwork->At(i))->GetEntries() << "> buffer; // no need to initialise" << std::endl;
          fout << "      for (int i = 0; i<" << ((TObjArray *)fNetwork->At(i))->GetEntries() << " - 1; i++) {" << std::endl;
          fout << "         buffer[i] = fWeightMatrix" << i << "to" << i + 1 << "[o][i] * inputValues[i];"
               << std::endl;
          fout << "      } // loop over i" << std::endl;
          fout << "      buffer.back() = fWeightMatrix" << i << "to" << i + 1 << "[o][" << ((TObjArray *)fNetwork->At(i))->GetEntries() - 1 << "];"
       } else {
-         fout << "      std::array<double, " << ((TObjArray *)fNetwork->At(i))->GetEntries() << "> buffer;" << std::endl;
+         fout << "      std::array<double, " << ((TObjArray *)fNetwork->At(i))->GetEntries() << "> buffer; // no need to initialise" << std::endl;
          fout << "      for (int i=0; i<" << ((TObjArray *)fNetwork->At(i))->GetEntries() << "; i++) {" << std::endl;
          fout << "         buffer[i] = fWeightMatrix" << i << "to" << i + 1 << "[o][i] * fWeights" << i << "[i];"
               << std::endl;

--- a/tmva/tmva/src/MethodANNBase.cxx
+++ b/tmva/tmva/src/MethodANNBase.cxx
@@ -1109,15 +1109,18 @@ void TMVA::MethodANNBase::MakeClassSpecific( std::ostream& fout, const TString& 
          fout << "   for (int o=0; o<" << ((TObjArray *)fNetwork->At(i + 1))->GetEntries() - 1 << "; o++) {"
               << std::endl;
       }
-      if ( 0 == i ) {
-         fout << "      std::array<double, " << ((TObjArray *)fNetwork->At(i))->GetEntries() << "> buffer; // no need to initialise" << std::endl;
-         fout << "      for (int i = 0; i<" << ((TObjArray *)fNetwork->At(i))->GetEntries() << " - 1; i++) {" << std::endl;
-         fout << "         buffer[i] = fWeightMatrix" << i << "to" << i + 1 << "[o][i] * inputValues[i];"
+      if (0 == i) {
+         fout << "      std::array<double, " << ((TObjArray *)fNetwork->At(i))->GetEntries()
+              << "> buffer; // no need to initialise" << std::endl;
+         fout << "      for (int i = 0; i<" << ((TObjArray *)fNetwork->At(i))->GetEntries() << " - 1; i++) {"
               << std::endl;
+         fout << "         buffer[i] = fWeightMatrix" << i << "to" << i + 1 << "[o][i] * inputValues[i];" << std::endl;
          fout << "      } // loop over i" << std::endl;
-         fout << "      buffer.back() = fWeightMatrix" << i << "to" << i + 1 << "[o][" << ((TObjArray *)fNetwork->At(i))->GetEntries() - 1 << "];"
+         fout << "      buffer.back() = fWeightMatrix" << i << "to" << i + 1 << "[o]["
+              << ((TObjArray *)fNetwork->At(i))->GetEntries() - 1 << "];"
       } else {
-         fout << "      std::array<double, " << ((TObjArray *)fNetwork->At(i))->GetEntries() << "> buffer; // no need to initialise" << std::endl;
+         fout << "      std::array<double, " << ((TObjArray *)fNetwork->At(i))->GetEntries()
+              << "> buffer; // no need to initialise" << std::endl;
          fout << "      for (int i=0; i<" << ((TObjArray *)fNetwork->At(i))->GetEntries() << "; i++) {" << std::endl;
          fout << "         buffer[i] = fWeightMatrix" << i << "to" << i + 1 << "[o][i] * fWeights" << i << "[i];"
               << std::endl;

--- a/tmva/tmva/src/MethodANNBase.cxx
+++ b/tmva/tmva/src/MethodANNBase.cxx
@@ -1099,47 +1099,10 @@ void TMVA::MethodANNBase::MakeClassSpecific( std::ostream& fout, const TString& 
       int numNodes = layer->GetEntries();
       fout << "   std::array<double, " << numNodes << "> fWeights" << lIdx << " {{}};" << std::endl;
    }
-   for (Int_t lIdx = 0; lIdx < numLayers - 1; lIdx++) {
+   for (Int_t lIdx = 1; lIdx < numLayers - 1; lIdx++) {
       fout << "   fWeights" << lIdx << ".back() = 1.;" << std::endl;
    }
    fout << std::endl;
-   for (Int_t i = 0; i < 1; ++i) { // dummy loop to ease up copy&paste
-      fout << "   // layer " << i << " to " << i + 1 << std::endl;
-      if (i + 1 == numLayers - 1) {
-         fout << "   for (int o=0; o<" << ((TObjArray *)fNetwork->At(i + 1))->GetEntries() << "; o++) {" << std::endl;
-      } else {
-         fout << "   for (int o=0; o<" << ((TObjArray *)fNetwork->At(i + 1))->GetEntries() - 1 << "; o++) {"
-              << std::endl;
-      }
-      fout << "      std::array<double, " << ((TObjArray *)fNetwork->At(i))->GetEntries() << "> buffer {{}};" << std::endl;
-      fout << "      for (int i = 0; i<" << ((TObjArray *)fNetwork->At(i))->GetEntries() << " - 1; i++) {" << std::endl;
-      fout << "         buffer[i] = fWeightMatrix" << i << "to" << i + 1 << "[o][i] * inputValues[i];"
-           << std::endl;
-      fout << "      } // loop over i" << std::endl;
-      fout << "      buffer.back() = fWeightMatrix" << i << "to" << i + 1 << "[o][" << ((TObjArray *)fNetwork->At(i))->GetEntries() - 1 << "];"
-      fout << "      for (int i=0; i<" << ((TObjArray *)fNetwork->At(i))->GetEntries() << "; i++) {" << std::endl;
-      if (fNeuronInputType == "sum") {
-         fout << "         fWeights" << i + 1 << "[o] += buffer[i];" << std::endl;
-      } else if (fNeuronInputType == "sqsum") {
-         fout << "         fWeights" << i + 1 << "[o] += buffer[i]*buffer[i];" << std::endl;
-      } else { // fNeuronInputType == TNeuronInputChooser::kAbsSum
-         fout << "         fWeights" << i + 1 << "[o] += fabs(buffer[i]);" << std::endl;
-      }
-      fout << "      } // loop over i" << std::endl;
-      fout << "    } // loop over o" << std::endl;
-      if (i + 1 == numLayers - 1) {
-         fout << "   for (int o=0; o<" << ((TObjArray *)fNetwork->At(i + 1))->GetEntries() << "; o++) {" << std::endl;
-      } else {
-         fout << "   for (int o=0; o<" << ((TObjArray *)fNetwork->At(i + 1))->GetEntries() - 1 << "; o++) {"
-              << std::endl;
-      }
-      if (i+1 != numLayers-1) // in the last layer no activation function is applied
-         fout << "      fWeights" << i + 1 << "[o] = ActivationFnc(fWeights" << i + 1 << "[o]);" << std::endl;
-      else
-         fout << "      fWeights" << i + 1 << "[o] = OutputActivationFnc(fWeights" << i + 1 << "[o]);"
-              << std::endl; // zjh
-      fout << "   } // loop over o" << std::endl;
-   }
    for (Int_t i = 1; i < numLayers - 1; i++) {
       fout << "   // layer " << i << " to " << i + 1 << std::endl;
       if (i + 1 == numLayers - 1) {
@@ -1148,11 +1111,20 @@ void TMVA::MethodANNBase::MakeClassSpecific( std::ostream& fout, const TString& 
          fout << "   for (int o=0; o<" << ((TObjArray *)fNetwork->At(i + 1))->GetEntries() - 1 << "; o++) {"
               << std::endl;
       }
-      fout << "      double buffer[" << ((TObjArray *)fNetwork->At(i))->GetEntries() << "];" << std::endl;
-      fout << "      for (int i=0; i<" << ((TObjArray *)fNetwork->At(i))->GetEntries() << "; i++) {" << std::endl;
-      fout << "         buffer[i] = fWeightMatrix" << i << "to" << i + 1 << "[o][i] * fWeights" << i << "[i];"
-           << std::endl;
-      fout << "      } // loop over i" << std::endl;
+      if ( 0 == i ) {
+         fout << "      std::array<double, " << ((TObjArray *)fNetwork->At(i))->GetEntries() << "> buffer {{}};" << std::endl;
+         fout << "      for (int i = 0; i<" << ((TObjArray *)fNetwork->At(i))->GetEntries() << " - 1; i++) {" << std::endl;
+         fout << "         buffer[i] = fWeightMatrix" << i << "to" << i + 1 << "[o][i] * inputValues[i];"
+              << std::endl;
+         fout << "      } // loop over i" << std::endl;
+         fout << "      buffer.back() = fWeightMatrix" << i << "to" << i + 1 << "[o][" << ((TObjArray *)fNetwork->At(i))->GetEntries() - 1 << "];"
+      } else {
+         fout << "      std::array<double, " << ((TObjArray *)fNetwork->At(i))->GetEntries() << "> buffer;" << std::endl;
+         fout << "      for (int i=0; i<" << ((TObjArray *)fNetwork->At(i))->GetEntries() << "; i++) {" << std::endl;
+         fout << "         buffer[i] = fWeightMatrix" << i << "to" << i + 1 << "[o][i] * fWeights" << i << "[i];"
+              << std::endl;
+         fout << "      } // loop over i" << std::endl;
+      }
       fout << "      for (int i=0; i<" << ((TObjArray *)fNetwork->At(i))->GetEntries() << "; i++) {" << std::endl;
       if (fNeuronInputType == "sum") {
          fout << "         fWeights" << i + 1 << "[o] += buffer[i];" << std::endl;

--- a/tmva/tmva/src/MethodANNBase.cxx
+++ b/tmva/tmva/src/MethodANNBase.cxx
@@ -1094,7 +1094,7 @@ void TMVA::MethodANNBase::MakeClassSpecific( std::ostream& fout, const TString& 
    fout << "      return 0;" << std::endl;
    fout << "   }" << std::endl;
    fout << std::endl;
-   for (Int_t lIdx = 0; lIdx < numLayers; lIdx++) {
+   for (Int_t lIdx = 1; lIdx < numLayers; lIdx++) {
       TObjArray *layer = (TObjArray *)fNetwork->At(lIdx);
       int numNodes = layer->GetEntries();
       fout << "   std::array<double, " << numNodes << "> fWeights" << lIdx << " {{}};" << std::endl;
@@ -1102,9 +1102,6 @@ void TMVA::MethodANNBase::MakeClassSpecific( std::ostream& fout, const TString& 
    for (Int_t lIdx = 0; lIdx < numLayers - 1; lIdx++) {
       fout << "   fWeights" << lIdx << ".back() = 1.;" << std::endl;
    }
-   fout << std::endl;
-   fout << "   for (int i=0; i<" << ((TObjArray*)fNetwork->At(0))->GetEntries()-1 << "; i++)" << std::endl;
-   fout << "      fWeights0[i]=inputValues[i];" << std::endl;
    fout << std::endl;
    for (Int_t i = 0; i < 1; ++i) { // dummy loop to ease up copy&paste
       fout << "   // layer " << i << " to " << i + 1 << std::endl;
@@ -1114,11 +1111,12 @@ void TMVA::MethodANNBase::MakeClassSpecific( std::ostream& fout, const TString& 
          fout << "   for (int o=0; o<" << ((TObjArray *)fNetwork->At(i + 1))->GetEntries() - 1 << "; o++) {"
               << std::endl;
       }
-      fout << "      double buffer[" << ((TObjArray *)fNetwork->At(i))->GetEntries() << "];" << std::endl;
-      fout << "      for (int i=0; i<" << ((TObjArray *)fNetwork->At(i))->GetEntries() << "; i++) {" << std::endl;
-      fout << "         buffer[i] = fWeightMatrix" << i << "to" << i + 1 << "[o][i] * fWeights" << i << "[i];"
+      fout << "      std::array<double, " << ((TObjArray *)fNetwork->At(i))->GetEntries() << "> buffer {{}};" << std::endl;
+      fout << "      for (int i = 0; i<" << ((TObjArray *)fNetwork->At(i))->GetEntries() << " - 1; i++) {" << std::endl;
+      fout << "         buffer[i] = fWeightMatrix" << i << "to" << i + 1 << "[o][i] * inputValues[i];"
            << std::endl;
       fout << "      } // loop over i" << std::endl;
+      fout << "      buffer.back() = fWeightMatrix" << i << "to" << i + 1 << "[o][" << ((TObjArray *)fNetwork->At(i))->GetEntries() - 1 << "];"
       fout << "      for (int i=0; i<" << ((TObjArray *)fNetwork->At(i))->GetEntries() << "; i++) {" << std::endl;
       if (fNeuronInputType == "sum") {
          fout << "         fWeights" << i + 1 << "[o] += buffer[i];" << std::endl;

--- a/tmva/tmva/src/MethodANNBase.cxx
+++ b/tmva/tmva/src/MethodANNBase.cxx
@@ -1101,7 +1101,7 @@ void TMVA::MethodANNBase::MakeClassSpecific( std::ostream& fout, const TString& 
       fout << "   fWeights" << lIdx << ".back() = 1.;" << std::endl;
    }
    fout << std::endl;
-   for (Int_t i = 1; i < numLayers - 1; i++) {
+   for (Int_t i = 0; i < numLayers - 1; i++) {
       fout << "   // layer " << i << " to " << i + 1 << std::endl;
       if (i + 1 == numLayers - 1) {
          fout << "   for (int o=0; o<" << ((TObjArray *)fNetwork->At(i + 1))->GetEntries() << "; o++) {" << std::endl;

--- a/tmva/tmva/src/MethodANNBase.cxx
+++ b/tmva/tmva/src/MethodANNBase.cxx
@@ -1048,8 +1048,6 @@ void TMVA::MethodANNBase::MakeClassSpecific( std::ostream& fout, const TString& 
    fout << "   double ActivationFnc(double x) const;" << std::endl;
    fout << "   double OutputActivationFnc(double x) const;" << std::endl;     //zjh
    fout << std::endl;
-   fout << "   int fLayers;" << std::endl;
-   fout << "   int fLayerSize["<<numLayers<<"];" << std::endl;
    int numNodesFrom = -1;
    for (Int_t lIdx = 0; lIdx < numLayers; lIdx++) {
       int numNodesTo = ((TObjArray*)fNetwork->At(lIdx))->GetEntries();
@@ -1066,11 +1064,9 @@ void TMVA::MethodANNBase::MakeClassSpecific( std::ostream& fout, const TString& 
    fout << "inline void " << className << "::Initialize()" << std::endl;
    fout << "{" << std::endl;
    fout << "   // build network structure" << std::endl;
-   fout << "   fLayers = " << numLayers << ";" << std::endl;
    for (Int_t lIdx = 0; lIdx < numLayers; lIdx++) {
       TObjArray* layer = (TObjArray*)fNetwork->At(lIdx);
       int numNodes = layer->GetEntries();
-      fout << "   fLayerSize[" << lIdx << "] = " << numNodes << ";" << std::endl;
    }
 
    for (Int_t i = 0; i < numLayers-1; i++) {
@@ -1093,8 +1089,8 @@ void TMVA::MethodANNBase::MakeClassSpecific( std::ostream& fout, const TString& 
    // writing of the GetMvaValue__ method
    fout << "inline double " << className << "::GetMvaValue__( const std::vector<double>& inputValues ) const" << std::endl;
    fout << "{" << std::endl;
-   fout << "   if (inputValues.size() != (unsigned int)fLayerSize[0]-1) {" << std::endl;
-   fout << "      std::cout << \"Input vector needs to be of size \" << fLayerSize[0]-1 << std::endl;" << std::endl;
+   fout << "   if (inputValues.size() != (unsigned int)" << ((TObjArray*)fNetwork->At(0))->GetEntries()-1 << " {" << std::endl;
+   fout << "      std::cout << \"Input vector needs to be of size \" << " << ((TObjArray*)fNetwork->At(0))->GetEntries()-1 << " << std::endl;" << std::endl;
    fout << "      return 0;" << std::endl;
    fout << "   }" << std::endl;
    fout << std::endl;
@@ -1107,18 +1103,18 @@ void TMVA::MethodANNBase::MakeClassSpecific( std::ostream& fout, const TString& 
       fout << "   fWeights" << lIdx << ".back() = 1.;" << std::endl;
    }
    fout << std::endl;
-   fout << "   for (int i=0; i<fLayerSize[0]-1; i++)" << std::endl;
+   fout << "   for (int i=0; i<" << ((TObjArray*)fNetwork->At(0))->GetEntries()-1 << "; i++)" << std::endl;
    fout << "      fWeights0[i]=inputValues[i];" << std::endl;
    fout << std::endl;
    for (Int_t i = 0; i < numLayers-1; i++) {
       fout << "   // layer " << i << " to " << i+1 << std::endl;
       if (i+1 == numLayers-1) {
-         fout << "   for (int o=0; o<fLayerSize[" << i+1 << "]; o++) {" << std::endl;
+         fout << "   for (int o=0; o<" << ((TObjArray*)fNetwork->At(i+1))->GetEntries() << "; o++) {" << std::endl;
       }
       else {
-         fout << "   for (int o=0; o<fLayerSize[" << i+1 << "]-1; o++) {" << std::endl;
+         fout << "   for (int o=0; o<" << ((TObjArray*)fNetwork->At(i+1))->GetEntries()-1 << "; o++) {" << std::endl;
       }
-      fout << "      for (int i=0; i<fLayerSize[" << i << "]; i++) {" << std::endl;
+      fout << "      for (int i=0; i<" << ((TObjArray*)fNetwork->At(i))->GetEntries() << "; i++) {" << std::endl;
       fout << "         double inputVal = fWeightMatrix" << i << "to" << i + 1 << "[o][i] * fWeights" << i << "[i];"
            << std::endl;
 

--- a/tmva/tmva/src/MethodANNBase.cxx
+++ b/tmva/tmva/src/MethodANNBase.cxx
@@ -1117,7 +1117,7 @@ void TMVA::MethodANNBase::MakeClassSpecific( std::ostream& fout, const TString& 
          fout << "         buffer[i] = fWeightMatrix" << i << "to" << i + 1 << "[o][i] * inputValues[i];" << std::endl;
          fout << "      } // loop over i" << std::endl;
          fout << "      buffer.back() = fWeightMatrix" << i << "to" << i + 1 << "[o]["
-              << ((TObjArray *)fNetwork->At(i))->GetEntries() - 1 << "];"
+              << ((TObjArray *)fNetwork->At(i))->GetEntries() - 1 << "];";
       } else {
          fout << "      std::array<double, " << ((TObjArray *)fNetwork->At(i))->GetEntries()
               << "> buffer; // no need to initialise" << std::endl;

--- a/tmva/tmva/src/MethodANNBase.cxx
+++ b/tmva/tmva/src/MethodANNBase.cxx
@@ -1085,7 +1085,7 @@ void TMVA::MethodANNBase::MakeClassSpecific( std::ostream& fout, const TString& 
    // writing of the GetMvaValue__ method
    fout << "inline double " << className << "::GetMvaValue__( const std::vector<double>& inputValues ) const" << std::endl;
    fout << "{" << std::endl;
-   fout << "   if (inputValues.size() != (unsigned int)" << ((TObjArray*)fNetwork->At(0))->GetEntries()-1 << " {" << std::endl;
+   fout << "   if (inputValues.size() != (unsigned int)" << ((TObjArray*)fNetwork->At(0))->GetEntries()-1 << ") {" << std::endl;
    fout << "      std::cout << \"Input vector needs to be of size \" << " << ((TObjArray*)fNetwork->At(0))->GetEntries()-1 << " << std::endl;" << std::endl;
    fout << "      return 0;" << std::endl;
    fout << "   }" << std::endl;

--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -3032,8 +3032,7 @@ void TMVA::MethodBase::MakeClass( const TString& theClassFileName ) const
    fout << "   " << className << "( std::vector<std::string>& theInputVars )" << std::endl;
    fout << "      : IClassifierReader()," << std::endl;
    fout << "        fClassName( \"" << className << "\" )," << std::endl;
-   fout << "        fNvars( " << GetNvar() << " )," << std::endl;
-   fout << "        fIsNormalised( " << (IsNormalised() ? "true" : "false") << " )" << std::endl;
+   fout << "        fNvars( " << GetNvar() << " )" << std::endl;
    fout << "   {" << std::endl;
    fout << "      // the training input variables" << std::endl;
    fout << "      const char* inputVars[] = { ";
@@ -3114,8 +3113,6 @@ void TMVA::MethodBase::MakeClass( const TString& theClassFileName ) const
    fout << "   char   GetType( int ivar ) const { return fType[ivar]; }" << std::endl;
    fout << std::endl;
    fout << "   // normalisation of input variables" << std::endl;
-   fout << "   const bool fIsNormalised;" << std::endl;
-   fout << "   bool IsNormalised() const { return fIsNormalised; }" << std::endl;
    fout << "   double fVmin[" << GetNvar() << "];" << std::endl;
    fout << "   double fVmax[" << GetNvar() << "];" << std::endl;
    fout << "   double NormVariable( double x, double xmin, double xmax ) const {" << std::endl;
@@ -3147,39 +3144,38 @@ void TMVA::MethodBase::MakeClass( const TString& theClassFileName ) const
    fout << "         retval = 0;" << std::endl;
    fout << "      }" << std::endl;
    fout << "      else {" << std::endl;
-   fout << "         if (IsNormalised()) {" << std::endl;
-   fout << "            // normalise variables" << std::endl;
-   fout << "            std::vector<double> iV;" << std::endl;
-   fout << "            iV.reserve(inputValues.size());" << std::endl;
-   fout << "            int ivar = 0;" << std::endl;
-   fout << "            for (std::vector<double>::const_iterator varIt = inputValues.begin();" << std::endl;
-   fout << "                 varIt != inputValues.end(); varIt++, ivar++) {" << std::endl;
-   fout << "               iV.push_back(NormVariable( *varIt, fVmin[ivar], fVmax[ivar] ));" << std::endl;
-   fout << "            }" << std::endl;
-   if (GetTransformationHandler().GetTransformationList().GetSize()!=0 &&
-       GetMethodType() != Types::kLikelihood &&
-       GetMethodType() != Types::kHMatrix) {
-      fout << "            Transform( iV, -1 );" << std::endl;
+   if (IsNormalised()) {
+     fout << "            // normalise variables" << std::endl;
+     fout << "            std::vector<double> iV;" << std::endl;
+     fout << "            iV.reserve(inputValues.size());" << std::endl;
+     fout << "            int ivar = 0;" << std::endl;
+     fout << "            for (std::vector<double>::const_iterator varIt = inputValues.begin();" << std::endl;
+     fout << "                 varIt != inputValues.end(); varIt++, ivar++) {" << std::endl;
+     fout << "               iV.push_back(NormVariable( *varIt, fVmin[ivar], fVmax[ivar] ));" << std::endl;
+     fout << "            }" << std::endl;
+     if (GetTransformationHandler().GetTransformationList().GetSize()!=0 &&
+         GetMethodType() != Types::kLikelihood &&
+         GetMethodType() != Types::kHMatrix) {
+       fout << "            Transform( iV, -1 );" << std::endl;
+     }
+     fout << "            retval = GetMvaValue__( iV );" << std::endl;
+   } else {
+     if (GetTransformationHandler().GetTransformationList().GetSize()!=0 &&
+         GetMethodType() != Types::kLikelihood &&
+         GetMethodType() != Types::kHMatrix) {
+       fout << "            std::vector<double> iV;" << std::endl;
+       fout << "            int ivar = 0;" << std::endl;
+       fout << "            for (std::vector<double>::const_iterator varIt = inputValues.begin();" << std::endl;
+       fout << "                 varIt != inputValues.end(); varIt++, ivar++) {" << std::endl;
+       fout << "               iV.push_back(*varIt);" << std::endl;
+       fout << "            }" << std::endl;
+       fout << "            Transform( iV, -1 );" << std::endl;
+       fout << "            retval = GetMvaValue__( iV );" << std::endl;
+     }
+     else {
+       fout << "            retval = GetMvaValue__( inputValues );" << std::endl;
+     }
    }
-   fout << "            retval = GetMvaValue__( iV );" << std::endl;
-   fout << "         }" << std::endl;
-   fout << "         else {" << std::endl;
-   if (GetTransformationHandler().GetTransformationList().GetSize()!=0 &&
-       GetMethodType() != Types::kLikelihood &&
-       GetMethodType() != Types::kHMatrix) {
-      fout << "            std::vector<double> iV;" << std::endl;
-      fout << "            int ivar = 0;" << std::endl;
-      fout << "            for (std::vector<double>::const_iterator varIt = inputValues.begin();" << std::endl;
-      fout << "                 varIt != inputValues.end(); varIt++, ivar++) {" << std::endl;
-      fout << "               iV.push_back(*varIt);" << std::endl;
-      fout << "            }" << std::endl;
-      fout << "            Transform( iV, -1 );" << std::endl;
-      fout << "            retval = GetMvaValue__( iV );" << std::endl;
-   }
-   else {
-      fout << "            retval = GetMvaValue__( inputValues );" << std::endl;
-   }
-   fout << "         }" << std::endl;
    fout << "      }" << std::endl;
    fout << std::endl;
    fout << "      return retval;" << std::endl;

--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -3145,31 +3145,28 @@ void TMVA::MethodBase::MakeClass( const TString& theClassFileName ) const
    fout << "      }" << std::endl;
    fout << "      else {" << std::endl;
    if (IsNormalised()) {
-     fout << "            // normalise variables" << std::endl;
-     fout << "            std::vector<double> iV;" << std::endl;
-     fout << "            iV.reserve(inputValues.size());" << std::endl;
-     fout << "            int ivar = 0;" << std::endl;
-     fout << "            for (std::vector<double>::const_iterator varIt = inputValues.begin();" << std::endl;
-     fout << "                 varIt != inputValues.end(); varIt++, ivar++) {" << std::endl;
-     fout << "               iV.push_back(NormVariable( *varIt, fVmin[ivar], fVmax[ivar] ));" << std::endl;
-     fout << "            }" << std::endl;
-     if (GetTransformationHandler().GetTransformationList().GetSize()!=0 &&
-         GetMethodType() != Types::kLikelihood &&
-         GetMethodType() != Types::kHMatrix) {
-       fout << "            Transform( iV, -1 );" << std::endl;
-     }
-     fout << "            retval = GetMvaValue__( iV );" << std::endl;
+      fout << "            // normalise variables" << std::endl;
+      fout << "            std::vector<double> iV;" << std::endl;
+      fout << "            iV.reserve(inputValues.size());" << std::endl;
+      fout << "            int ivar = 0;" << std::endl;
+      fout << "            for (std::vector<double>::const_iterator varIt = inputValues.begin();" << std::endl;
+      fout << "                 varIt != inputValues.end(); varIt++, ivar++) {" << std::endl;
+      fout << "               iV.push_back(NormVariable( *varIt, fVmin[ivar], fVmax[ivar] ));" << std::endl;
+      fout << "            }" << std::endl;
+      if (GetTransformationHandler().GetTransformationList().GetSize() != 0 && GetMethodType() != Types::kLikelihood &&
+          GetMethodType() != Types::kHMatrix) {
+         fout << "            Transform( iV, -1 );" << std::endl;
+      }
+      fout << "            retval = GetMvaValue__( iV );" << std::endl;
    } else {
-     if (GetTransformationHandler().GetTransformationList().GetSize()!=0 &&
-         GetMethodType() != Types::kLikelihood &&
-         GetMethodType() != Types::kHMatrix) {
-       fout << "            std::vector<double> iV(inputValues);" << std::endl;
-       fout << "            Transform( iV, -1 );" << std::endl;
-       fout << "            retval = GetMvaValue__( iV );" << std::endl;
-     }
-     else {
-       fout << "            retval = GetMvaValue__( inputValues );" << std::endl;
-     }
+      if (GetTransformationHandler().GetTransformationList().GetSize() != 0 && GetMethodType() != Types::kLikelihood &&
+          GetMethodType() != Types::kHMatrix) {
+         fout << "            std::vector<double> iV(inputValues);" << std::endl;
+         fout << "            Transform( iV, -1 );" << std::endl;
+         fout << "            retval = GetMvaValue__( iV );" << std::endl;
+      } else {
+         fout << "            retval = GetMvaValue__( inputValues );" << std::endl;
+      }
    }
    fout << "      }" << std::endl;
    fout << std::endl;

--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -3163,12 +3163,7 @@ void TMVA::MethodBase::MakeClass( const TString& theClassFileName ) const
      if (GetTransformationHandler().GetTransformationList().GetSize()!=0 &&
          GetMethodType() != Types::kLikelihood &&
          GetMethodType() != Types::kHMatrix) {
-       fout << "            std::vector<double> iV;" << std::endl;
-       fout << "            int ivar = 0;" << std::endl;
-       fout << "            for (std::vector<double>::const_iterator varIt = inputValues.begin();" << std::endl;
-       fout << "                 varIt != inputValues.end(); varIt++, ivar++) {" << std::endl;
-       fout << "               iV.push_back(*varIt);" << std::endl;
-       fout << "            }" << std::endl;
+       fout << "            std::vector<double> iV(inputValues);" << std::endl;
        fout << "            Transform( iV, -1 );" << std::endl;
        fout << "            retval = GetMvaValue__( iV );" << std::endl;
      }

--- a/tmva/tmva/src/TActivationTanh.cxx
+++ b/tmva/tmva/src/TActivationTanh.cxx
@@ -101,6 +101,7 @@ void TMVA::TActivationTanh::MakeFunction( std::ostream& fout, const TString& fnc
 {
    if (fFAST) {
       fout << "double " << fncName << "(double x) const {" << std::endl;
+      fout << "   // fast hyperbolic tan approximation" << std::endl;
       fout << "   if (x > 4.97) return 1;" << std::endl;
       fout << "   if (x < -4.97) return -1;" << std::endl;
       fout << "   float x2 = x * x;" << std::endl;

--- a/tmva/tmva/src/TActivationTanh.cxx
+++ b/tmva/tmva/src/TActivationTanh.cxx
@@ -101,6 +101,8 @@ void TMVA::TActivationTanh::MakeFunction( std::ostream& fout, const TString& fnc
 {
    if (fFAST) {
       fout << "double " << fncName << "(double x) const {" << std::endl;
+      fout << "   if (x > 4.97) return 1;" << std::endl;
+      fout << "   if (x < -4.97) return -1;" << std::endl;
       fout << "   float x2 = x * x;" << std::endl;
       fout << "   float a = x * (135135.0f + x2 * (17325.0f + x2 * (378.0f + x2)));" << std::endl;
       fout << "   float b = 135135.0f + x2 * (62370.0f + x2 * (3150.0f + x2 * 28.0f));" << std::endl;

--- a/tmva/tmva/src/TActivationTanh.cxx
+++ b/tmva/tmva/src/TActivationTanh.cxx
@@ -99,14 +99,13 @@ TString TMVA::TActivationTanh::GetExpression()
 
 void TMVA::TActivationTanh::MakeFunction( std::ostream& fout, const TString& fncName )
 {
-   if (fFast) {
+   if (fFAST) {
       fout << "double " << fncName << "(double x) const {" << std::endl;
       fout << "   float x2 = x * x;" << std::endl;
       fout << "   float a = x * (135135.0f + x2 * (17325.0f + x2 * (378.0f + x2)));" << std::endl;
       fout << "   float b = 135135.0f + x2 * (62370.0f + x2 * (3150.0f + x2 * 28.0f));" << std::endl;
       fout << "   return a / b;" << std::endl;
       fout << "}" << std::endl;
-}
    } else {
       fout << "double " << fncName << "(double x) const {" << std::endl;
       fout << "   // hyperbolic tan" << std::endl;

--- a/tmva/tmva/src/TActivationTanh.cxx
+++ b/tmva/tmva/src/TActivationTanh.cxx
@@ -99,8 +99,18 @@ TString TMVA::TActivationTanh::GetExpression()
 
 void TMVA::TActivationTanh::MakeFunction( std::ostream& fout, const TString& fncName )
 {
-   fout << "double " << fncName << "(double x) const {" << std::endl;
-   fout << "   // hyperbolic tan" << std::endl;
-   fout << "   return tanh(x);" << std::endl;
-   fout << "}" << std::endl;
+   if (fFast) {
+      fout << "double " << fncName << "(double x) const {" << std::endl;
+      fout << "   float x2 = x * x;" << std::endl;
+      fout << "   float a = x * (135135.0f + x2 * (17325.0f + x2 * (378.0f + x2)));" << std::endl;
+      fout << "   float b = 135135.0f + x2 * (62370.0f + x2 * (3150.0f + x2 * 28.0f));" << std::endl;
+      fout << "   return a / b;" << std::endl;
+      fout << "}" << std::endl;
+}
+   } else {
+      fout << "double " << fncName << "(double x) const {" << std::endl;
+      fout << "   // hyperbolic tan" << std::endl;
+      fout << "   return tanh(x);" << std::endl;
+      fout << "}" << std::endl;
+   }
 }

--- a/tmva/tmva/src/VariableNormalizeTransform.cxx
+++ b/tmva/tmva/src/VariableNormalizeTransform.cxx
@@ -566,7 +566,7 @@ void TMVA::VariableNormalizeTransform::MakeFunction( std::ostream& fout, const T
    UInt_t numC = fMin.size();
    if (part==1) {
       fout << std::endl;
-      fout << "   double fMin_"<<trCounter<<"["<<numC<<"]["<<nVar<<"];" << std::endl;
+      fout << "   double fOff_"<<trCounter<<"["<<numC<<"]["<<nVar<<"];" << std::endl;
       fout << "   double fScal_"<<trCounter<<"["<<numC<<"]["<<nVar<<"];" << std::endl;
    }
 
@@ -575,6 +575,7 @@ void TMVA::VariableNormalizeTransform::MakeFunction( std::ostream& fout, const T
       fout << "//_______________________________________________________________________" << std::endl;
       fout << "inline void " << fcncName << "::InitTransform_"<<trCounter<<"()" << std::endl;
       fout << "{" << std::endl;
+      fout << "   double fMin_"<<trCounter<<"["<<numC<<"]["<<nVar<<"];" << std::endl;
       fout << "   double fMax_"<<trCounter<<"["<<numC<<"]["<<nVar<<"];" << std::endl;
       fout << "   // Normalization transformation, initialisation" << std::endl;
       for (UInt_t ivar=0; ivar<nVar; ivar++) {
@@ -586,6 +587,7 @@ void TMVA::VariableNormalizeTransform::MakeFunction( std::ostream& fout, const T
             fout << "   fMax_"<<trCounter<<"["<<icls<<"]["<<ivar<<"] = " << std::setprecision(12)
                  << max << ";" << std::endl;
             fout << "   fScal_"<<trCounter<<"["<<icls<<"]["<<ivar<<"] = 2.0/(fMax_"<<trCounter<<"[cls][ivar]-fMin_"<<trCounter<<"[cls][ivar]);" << std::endl;
+            fout << "   fOff_"<<trCounter<<"["<<icls<<"]["<<ivar<<"] = fMin_"<<trCounter<<"[cls][ivar]*fScal_"<<trCounter<<"[cls][ivar]-1.;" << std::endl;
          }
       }
       fout << "}" << std::endl;
@@ -606,9 +608,9 @@ void TMVA::VariableNormalizeTransform::MakeFunction( std::ostream& fout, const T
       fout << "   for (int ivar=0; ivar<nVar; ivar++) dv[ivar] = iv[indicesGet.at(ivar)];" << std::endl;
 
       fout << "   for (int ivar=0;ivar<"<<nVar<<";ivar++) {" << std::endl;
-      fout << "      double offset = fMin_"<<trCounter<<"[cls][ivar];" << std::endl;
+      fout << "      double offset = fOff_"<<trCounter<<"[cls][ivar];" << std::endl;
       fout << "      double scale  = fScal_"<<trCounter<<"[cls][ivar];" << std::endl;
-      fout << "      iv[indicesPut.at(ivar)] = scale*dv[ivar]-(offset*scale - 1);" << std::endl;
+      fout << "      iv[indicesPut.at(ivar)] = scale*dv[ivar]-offset;" << std::endl;
       fout << "   }" << std::endl;
       fout << "}" << std::endl;
    }

--- a/tmva/tmva/src/VariableNormalizeTransform.cxx
+++ b/tmva/tmva/src/VariableNormalizeTransform.cxx
@@ -587,7 +587,7 @@ void TMVA::VariableNormalizeTransform::MakeFunction( std::ostream& fout, const T
             fout << "   fMax_"<<trCounter<<"["<<icls<<"]["<<ivar<<"] = " << std::setprecision(12)
                  << max << ";" << std::endl;
             fout << "   fScal_"<<trCounter<<"["<<icls<<"]["<<ivar<<"] = 2.0/(fMax_"<<trCounter<<"["<<icls<<"]["<<ivar<<"]-fMin_"<<trCounter<<"["<<icls<<"]["<<ivar<<"]);" << std::endl;
-            fout << "   fOff_"<<trCounter<<"["<<icls<<"]["<<ivar<<"] = fMin_"<<trCounter<<"["<<icls<<"]["<<ivar<<"]*fScal_"<<trCounter<<"["<<icls<<"]["<<ivar<<"]-1.;" << std::endl;
+            fout << "   fOff_"<<trCounter<<"["<<icls<<"]["<<ivar<<"] = fMin_"<<trCounter<<"["<<icls<<"]["<<ivar<<"]*fScal_"<<trCounter<<"["<<icls<<"]["<<ivar<<"]+1.;" << std::endl;
          }
       }
       fout << "}" << std::endl;

--- a/tmva/tmva/src/VariableNormalizeTransform.cxx
+++ b/tmva/tmva/src/VariableNormalizeTransform.cxx
@@ -610,8 +610,14 @@ void TMVA::VariableNormalizeTransform::MakeFunction( std::ostream& fout, const T
       fout << "   for (int ivar=0;ivar<"<<nVar<<";ivar++) {" << std::endl;
       fout << "      double offset = fOff_"<<trCounter<<"[cls][ivar];" << std::endl;
       fout << "      double scale  = fScal_"<<trCounter<<"[cls][ivar];" << std::endl;
+      fout << "#ifndef NEXTTEST" << std::endl;
       fout << "      iv[indicesPut.at(ivar)] = scale*dv[ivar]-offset;" << std::endl;
       fout << "   }" << std::endl;
+      fout << "#else" << std::endl;
+      fout << "      dv[ivar] = scale*dv[ivar]-offset;" << std::endl;
+      fout << "   }" << std::endl;
+      fout << "   for (int ivar=0; ivar<nVar; ivar++) iv[indicesPut.at(ivar)] = dv[ivar];" << std::endl;
+      fout << "#endif" << std::endl;
       fout << "}" << std::endl;
    }
 }

--- a/tmva/tmva/src/VariableNormalizeTransform.cxx
+++ b/tmva/tmva/src/VariableNormalizeTransform.cxx
@@ -564,28 +564,28 @@ void TMVA::VariableNormalizeTransform::MakeFunction( std::ostream& fout, const T
 {
    UInt_t nVar = fGet.size();
    UInt_t numC = fMin.size();
-   if (part==1) {
+   if (part == 1) {
       fout << std::endl;
       fout << "   double fOff_" << trCounter << "[" << numC << "][" << nVar << "];" << std::endl;
       fout << "   double fScal_" << trCounter << "[" << numC << "][" << nVar << "];" << std::endl;
    }
 
-   if (part==2) {
+   if (part == 2) {
       fout << std::endl;
       fout << "//_______________________________________________________________________" << std::endl;
-      fout << "inline void " << fcncName << "::InitTransform_"<<trCounter<<"()" << std::endl;
+      fout << "inline void " << fcncName << "::InitTransform_" << trCounter << "()" << std::endl;
       fout << "{" << std::endl;
       fout << "   double fMin_" << trCounter << "[" << numC << "][" << nVar << "];" << std::endl;
       fout << "   double fMax_" << trCounter << "[" << numC << "][" << nVar << "];" << std::endl;
       fout << "   // Normalization transformation, initialisation" << std::endl;
-      for (UInt_t ivar=0; ivar<nVar; ivar++) {
+      for (UInt_t ivar = 0; ivar < nVar; ivar++) {
          for (UInt_t icls = 0; icls < numC; icls++) {
-            Double_t min = TMath::Min( FLT_MAX, fMin.at(icls).at(ivar) );
-            Double_t max = TMath::Max(-FLT_MAX, fMax.at(icls).at(ivar) );
-            fout << "   fMin_"<<trCounter<<"["<<icls<<"]["<<ivar<<"] = " << std::setprecision(12)
-                 << min << ";" << std::endl;
-            fout << "   fMax_"<<trCounter<<"["<<icls<<"]["<<ivar<<"] = " << std::setprecision(12)
-                 << max << ";" << std::endl;
+            Double_t min = TMath::Min(FLT_MAX, fMin.at(icls).at(ivar));
+            Double_t max = TMath::Max(-FLT_MAX, fMax.at(icls).at(ivar));
+            fout << "   fMin_" << trCounter << "[" << icls << "][" << ivar << "] = " << std::setprecision(12) << min
+                 << ";" << std::endl;
+            fout << "   fMax_" << trCounter << "[" << icls << "][" << ivar << "] = " << std::setprecision(12) << max
+                 << ";" << std::endl;
             fout << "   fScal_" << trCounter << "[" << icls << "][" << ivar << "] = 2.0/(fMax_" << trCounter << "["
                  << icls << "][" << ivar << "]-fMin_" << trCounter << "[" << icls << "][" << ivar << "]);" << std::endl;
             fout << "   fOff_" << trCounter << "[" << icls << "][" << ivar << "] = fMin_" << trCounter << "[" << icls
@@ -595,21 +595,23 @@ void TMVA::VariableNormalizeTransform::MakeFunction( std::ostream& fout, const T
       fout << "}" << std::endl;
       fout << std::endl;
       fout << "//_______________________________________________________________________" << std::endl;
-      fout << "inline void " << fcncName << "::Transform_"<<trCounter<<"( std::vector<double>& iv, int cls) const" << std::endl;
+      fout << "inline void " << fcncName << "::Transform_" << trCounter << "( std::vector<double>& iv, int cls) const"
+           << std::endl;
       fout << "{" << std::endl;
       fout << "   // Normalization transformation" << std::endl;
-      fout << "   if (cls < 0 || cls > "<<GetNClasses()<<") {"<< std::endl;
-      fout << "   if ("<<GetNClasses()<<" > 1 ) cls = "<<GetNClasses()<<";"<< std::endl;
-      fout << "      else cls = "<<(fMin.size()==1?0:2)<<";"<< std::endl;
-      fout << "   }"<< std::endl;
+      fout << "   if (cls < 0 || cls > " << GetNClasses() << ") {" << std::endl;
+      fout << "   if (" << GetNClasses() << " > 1 ) cls = " << GetNClasses() << ";" << std::endl;
+      fout << "      else cls = " << (fMin.size() == 1 ? 0 : 2) << ";" << std::endl;
+      fout << "   }" << std::endl;
       fout << "   const int nVar = " << nVar << ";" << std::endl << std::endl;
       fout << "   // get indices of used variables" << std::endl;
-      VariableTransformBase::MakeFunction(fout, fcncName, 0, trCounter, 0 );
-      fout << "   static std::vector<double> dv;" << std::endl; // simply made it static so it doesn't need to be re-booked every time
+      VariableTransformBase::MakeFunction(fout, fcncName, 0, trCounter, 0);
+      fout << "   static std::vector<double> dv;"
+           << std::endl; // simply made it static so it doesn't need to be re-booked every time
       fout << "   dv.resize(nVar);" << std::endl;
       fout << "   for (int ivar=0; ivar<nVar; ivar++) dv[ivar] = iv[indicesGet.at(ivar)];" << std::endl;
 
-      fout << "   for (int ivar=0;ivar<"<<nVar<<";ivar++) {" << std::endl;
+      fout << "   for (int ivar=0;ivar<" << nVar << ";ivar++) {" << std::endl;
       fout << "      double offset = fOff_" << trCounter << "[cls][ivar];" << std::endl;
       fout << "      double scale  = fScal_" << trCounter << "[cls][ivar];" << std::endl;
       fout << "      iv[indicesPut.at(ivar)] = scale*dv[ivar]-offset;" << std::endl;

--- a/tmva/tmva/src/VariableNormalizeTransform.cxx
+++ b/tmva/tmva/src/VariableNormalizeTransform.cxx
@@ -585,7 +585,7 @@ void TMVA::VariableNormalizeTransform::MakeFunction( std::ostream& fout, const T
                  << min << ";" << std::endl;
             fout << "   fMax_"<<trCounter<<"["<<icls<<"]["<<ivar<<"] = " << std::setprecision(12)
                  << max << ";" << std::endl;
-            fout << "   fScal_"<<trCounter<<"["<<icls<<"]["<<ivar<<"] = 1.0/(fMax_"<<trCounter<<"[cls][ivar]-fMin_"<<trCounter<<"[cls][ivar]);" << std::endl;
+            fout << "   fScal_"<<trCounter<<"["<<icls<<"]["<<ivar<<"] = 2.0/(fMax_"<<trCounter<<"[cls][ivar]-fMin_"<<trCounter<<"[cls][ivar]);" << std::endl;
          }
       }
       fout << "}" << std::endl;
@@ -608,7 +608,7 @@ void TMVA::VariableNormalizeTransform::MakeFunction( std::ostream& fout, const T
       fout << "   for (int ivar=0;ivar<"<<nVar<<";ivar++) {" << std::endl;
       fout << "      double offset = fMin_"<<trCounter<<"[cls][ivar];" << std::endl;
       fout << "      double scale  = fScal_"<<trCounter<<"[cls][ivar];" << std::endl;
-      fout << "      iv[indicesPut.at(ivar)] = (dv[ivar]-offset)*scale * 2 - 1;" << std::endl;
+      fout << "      iv[indicesPut.at(ivar)] = (dv[ivar]-offset)*scale - 1;" << std::endl;
       fout << "   }" << std::endl;
       fout << "}" << std::endl;
    }

--- a/tmva/tmva/src/VariableNormalizeTransform.cxx
+++ b/tmva/tmva/src/VariableNormalizeTransform.cxx
@@ -608,7 +608,7 @@ void TMVA::VariableNormalizeTransform::MakeFunction( std::ostream& fout, const T
       fout << "   for (int ivar=0;ivar<"<<nVar<<";ivar++) {" << std::endl;
       fout << "      double offset = fMin_"<<trCounter<<"[cls][ivar];" << std::endl;
       fout << "      double scale  = fScal_"<<trCounter<<"[cls][ivar];" << std::endl;
-      fout << "      iv[indicesPut.at(ivar)] = (dv[ivar]-offset)*scale - 1;" << std::endl;
+      fout << "      iv[indicesPut.at(ivar)] = scale*dv[ivar]-(offset*scale - 1);" << std::endl;
       fout << "   }" << std::endl;
       fout << "}" << std::endl;
    }

--- a/tmva/tmva/src/VariableNormalizeTransform.cxx
+++ b/tmva/tmva/src/VariableNormalizeTransform.cxx
@@ -586,8 +586,8 @@ void TMVA::VariableNormalizeTransform::MakeFunction( std::ostream& fout, const T
                  << min << ";" << std::endl;
             fout << "   fMax_"<<trCounter<<"["<<icls<<"]["<<ivar<<"] = " << std::setprecision(12)
                  << max << ";" << std::endl;
-            fout << "   fScal_"<<trCounter<<"["<<icls<<"]["<<ivar<<"] = 2.0/(fMax_"<<trCounter<<"[cls][ivar]-fMin_"<<trCounter<<"[cls][ivar]);" << std::endl;
-            fout << "   fOff_"<<trCounter<<"["<<icls<<"]["<<ivar<<"] = fMin_"<<trCounter<<"[cls][ivar]*fScal_"<<trCounter<<"[cls][ivar]-1.;" << std::endl;
+            fout << "   fScal_"<<trCounter<<"["<<icls<<"]["<<ivar<<"] = 2.0/(fMax_"<<trCounter<<"["<<icls<<"]["<<ivar<<"]-fMin_"<<trCounter<<"["<<icls<<"]["<<ivar<<"]);" << std::endl;
+            fout << "   fOff_"<<trCounter<<"["<<icls<<"]["<<ivar<<"] = fMin_"<<trCounter<<"["<<icls<<"]["<<ivar<<"]*fScal_"<<trCounter<<"["<<icls<<"]["<<ivar<<"]-1.;" << std::endl;
          }
       }
       fout << "}" << std::endl;

--- a/tmva/tmva/src/VariableNormalizeTransform.cxx
+++ b/tmva/tmva/src/VariableNormalizeTransform.cxx
@@ -566,8 +566,8 @@ void TMVA::VariableNormalizeTransform::MakeFunction( std::ostream& fout, const T
    UInt_t numC = fMin.size();
    if (part==1) {
       fout << std::endl;
-      fout << "   double fOff_"<<trCounter<<"["<<numC<<"]["<<nVar<<"];" << std::endl;
-      fout << "   double fScal_"<<trCounter<<"["<<numC<<"]["<<nVar<<"];" << std::endl;
+      fout << "   double fOff_" << trCounter << "[" << numC << "][" << nVar << "];" << std::endl;
+      fout << "   double fScal_" << trCounter << "[" << numC << "][" << nVar << "];" << std::endl;
    }
 
    if (part==2) {
@@ -575,8 +575,8 @@ void TMVA::VariableNormalizeTransform::MakeFunction( std::ostream& fout, const T
       fout << "//_______________________________________________________________________" << std::endl;
       fout << "inline void " << fcncName << "::InitTransform_"<<trCounter<<"()" << std::endl;
       fout << "{" << std::endl;
-      fout << "   double fMin_"<<trCounter<<"["<<numC<<"]["<<nVar<<"];" << std::endl;
-      fout << "   double fMax_"<<trCounter<<"["<<numC<<"]["<<nVar<<"];" << std::endl;
+      fout << "   double fMin_" << trCounter << "[" << numC << "][" << nVar << "];" << std::endl;
+      fout << "   double fMax_" << trCounter << "[" << numC << "][" << nVar << "];" << std::endl;
       fout << "   // Normalization transformation, initialisation" << std::endl;
       for (UInt_t ivar=0; ivar<nVar; ivar++) {
          for (UInt_t icls = 0; icls < numC; icls++) {
@@ -586,8 +586,10 @@ void TMVA::VariableNormalizeTransform::MakeFunction( std::ostream& fout, const T
                  << min << ";" << std::endl;
             fout << "   fMax_"<<trCounter<<"["<<icls<<"]["<<ivar<<"] = " << std::setprecision(12)
                  << max << ";" << std::endl;
-            fout << "   fScal_"<<trCounter<<"["<<icls<<"]["<<ivar<<"] = 2.0/(fMax_"<<trCounter<<"["<<icls<<"]["<<ivar<<"]-fMin_"<<trCounter<<"["<<icls<<"]["<<ivar<<"]);" << std::endl;
-            fout << "   fOff_"<<trCounter<<"["<<icls<<"]["<<ivar<<"] = fMin_"<<trCounter<<"["<<icls<<"]["<<ivar<<"]*fScal_"<<trCounter<<"["<<icls<<"]["<<ivar<<"]+1.;" << std::endl;
+            fout << "   fScal_" << trCounter << "[" << icls << "][" << ivar << "] = 2.0/(fMax_" << trCounter << "["
+                 << icls << "][" << ivar << "]-fMin_" << trCounter << "[" << icls << "][" << ivar << "]);" << std::endl;
+            fout << "   fOff_" << trCounter << "[" << icls << "][" << ivar << "] = fMin_" << trCounter << "[" << icls
+                 << "][" << ivar << "]*fScal_" << trCounter << "[" << icls << "][" << ivar << "]+1.;" << std::endl;
          }
       }
       fout << "}" << std::endl;
@@ -608,8 +610,8 @@ void TMVA::VariableNormalizeTransform::MakeFunction( std::ostream& fout, const T
       fout << "   for (int ivar=0; ivar<nVar; ivar++) dv[ivar] = iv[indicesGet.at(ivar)];" << std::endl;
 
       fout << "   for (int ivar=0;ivar<"<<nVar<<";ivar++) {" << std::endl;
-      fout << "      double offset = fOff_"<<trCounter<<"[cls][ivar];" << std::endl;
-      fout << "      double scale  = fScal_"<<trCounter<<"[cls][ivar];" << std::endl;
+      fout << "      double offset = fOff_" << trCounter << "[cls][ivar];" << std::endl;
+      fout << "      double scale  = fScal_" << trCounter << "[cls][ivar];" << std::endl;
       fout << "      iv[indicesPut.at(ivar)] = scale*dv[ivar]-offset;" << std::endl;
       fout << "   }" << std::endl;
       fout << "}" << std::endl;

--- a/tmva/tmva/src/VariableNormalizeTransform.cxx
+++ b/tmva/tmva/src/VariableNormalizeTransform.cxx
@@ -567,7 +567,7 @@ void TMVA::VariableNormalizeTransform::MakeFunction( std::ostream& fout, const T
    if (part==1) {
       fout << std::endl;
       fout << "   double fMin_"<<trCounter<<"["<<numC<<"]["<<nVar<<"];" << std::endl;
-      fout << "   double fMax_"<<trCounter<<"["<<numC<<"]["<<nVar<<"];" << std::endl;
+      fout << "   double fScal_"<<trCounter<<"["<<numC<<"]["<<nVar<<"];" << std::endl;
    }
 
    if (part==2) {
@@ -575,6 +575,7 @@ void TMVA::VariableNormalizeTransform::MakeFunction( std::ostream& fout, const T
       fout << "//_______________________________________________________________________" << std::endl;
       fout << "inline void " << fcncName << "::InitTransform_"<<trCounter<<"()" << std::endl;
       fout << "{" << std::endl;
+      fout << "   double fMax_"<<trCounter<<"["<<numC<<"]["<<nVar<<"];" << std::endl;
       fout << "   // Normalization transformation, initialisation" << std::endl;
       for (UInt_t ivar=0; ivar<nVar; ivar++) {
          for (UInt_t icls = 0; icls < numC; icls++) {
@@ -584,6 +585,7 @@ void TMVA::VariableNormalizeTransform::MakeFunction( std::ostream& fout, const T
                  << min << ";" << std::endl;
             fout << "   fMax_"<<trCounter<<"["<<icls<<"]["<<ivar<<"] = " << std::setprecision(12)
                  << max << ";" << std::endl;
+            fout << "   fScal_"<<trCounter<<"["<<icls<<"]["<<ivar<<"] = 1.0/(fMax_"<<trCounter<<"[cls][ivar]-fMin_"<<trCounter<<"[cls][ivar]);" << std::endl;
          }
       }
       fout << "}" << std::endl;
@@ -605,7 +607,7 @@ void TMVA::VariableNormalizeTransform::MakeFunction( std::ostream& fout, const T
 
       fout << "   for (int ivar=0;ivar<"<<nVar<<";ivar++) {" << std::endl;
       fout << "      double offset = fMin_"<<trCounter<<"[cls][ivar];" << std::endl;
-      fout << "      double scale  = 1.0/(fMax_"<<trCounter<<"[cls][ivar]-fMin_"<<trCounter<<"[cls][ivar]);" << std::endl;
+      fout << "      double scale  = fScal_"<<trCounter<<"[cls][ivar];" << std::endl;
       fout << "      iv[indicesPut.at(ivar)] = (dv[ivar]-offset)*scale * 2 - 1;" << std::endl;
       fout << "   }" << std::endl;
       fout << "}" << std::endl;

--- a/tmva/tmva/src/VariableNormalizeTransform.cxx
+++ b/tmva/tmva/src/VariableNormalizeTransform.cxx
@@ -610,14 +610,8 @@ void TMVA::VariableNormalizeTransform::MakeFunction( std::ostream& fout, const T
       fout << "   for (int ivar=0;ivar<"<<nVar<<";ivar++) {" << std::endl;
       fout << "      double offset = fOff_"<<trCounter<<"[cls][ivar];" << std::endl;
       fout << "      double scale  = fScal_"<<trCounter<<"[cls][ivar];" << std::endl;
-      fout << "#ifndef NEXTTEST" << std::endl;
       fout << "      iv[indicesPut.at(ivar)] = scale*dv[ivar]-offset;" << std::endl;
       fout << "   }" << std::endl;
-      fout << "#else" << std::endl;
-      fout << "      dv[ivar] = scale*dv[ivar]-offset;" << std::endl;
-      fout << "   }" << std::endl;
-      fout << "   for (int ivar=0; ivar<nVar; ivar++) iv[indicesPut.at(ivar)] = dv[ivar];" << std::endl;
-      fout << "#endif" << std::endl;
       fout << "}" << std::endl;
    }
 }


### PR DESCRIPTION
I ported the changes from [pseyfert/tmva-mlp](https://github.com/pseyfert/tmva-mlp) to the code generation. As a test I just ran the class.C network resulting from tutorials/tmva/TMVAClassification.C (with "MLP") and evaluated it similar to tutorials/tmva/TMVAClassificationApplication.C. According to callgrind the network evaluation is ~17% cpu cycles faster.
NB: i did not port all changes from pseyfert/tmva-mlp - I did not import the SSE/AVX intrinsics and avoided what seemed too difficult (optimising the putIndices and getIndices out) 
