### PR TITLE
optimise includes in math

### DIFF
--- a/math/mathmore/inc/Math/GSLQuasiRandom.h
+++ b/math/mathmore/inc/Math/GSLQuasiRandom.h
@@ -32,7 +32,6 @@
 #define ROOT_Math_GSLQuasiRandom
 
 #include <string>
-#include <vector>
 
 namespace ROOT {
 namespace Math {

--- a/math/mathmore/inc/Math/MCParameters.h
+++ b/math/mathmore/inc/Math/MCParameters.h
@@ -26,7 +26,7 @@
 #ifndef ROOT_Math_MCParameters
 #define ROOT_Math_MCParameters
 
-#include <cstring>   // for size_t
+#include <stddef.h>   // for size_t
 
 namespace ROOT {
 namespace Math {

--- a/math/mathmore/inc/Math/Vavilov.h
+++ b/math/mathmore/inc/Math/Vavilov.h
@@ -38,7 +38,6 @@
  */
 
 
-#include <iostream>
 
 namespace ROOT {
 namespace Math {

--- a/math/mathmore/inc/Math/VavilovAccurateCdf.h
+++ b/math/mathmore/inc/Math/VavilovAccurateCdf.h
@@ -35,8 +35,6 @@
 #include "Math/IParamFunction.h"
 #include "Math/VavilovAccurate.h"
 
-#include <memory>
-
 namespace ROOT {
 namespace Math {
 

--- a/math/mathmore/inc/Math/VavilovAccurateQuantile.h
+++ b/math/mathmore/inc/Math/VavilovAccurateQuantile.h
@@ -35,8 +35,6 @@
 #include "Math/IParamFunction.h"
 #include "Math/VavilovAccurate.h"
 
-#include <memory>
-
 namespace ROOT {
 namespace Math {
 

--- a/math/mathmore/src/GSLError.h
+++ b/math/mathmore/src/GSLError.h
@@ -32,10 +32,6 @@
 
 #include "gsl/gsl_errno.h"
 
-#include "TError.h"
-#include "TSystem.h"
-
-
 namespace ROOT {
    namespace Math {
 

--- a/math/mathmore/src/GSLMCIntegrator.cxx
+++ b/math/mathmore/src/GSLMCIntegrator.cxx
@@ -27,10 +27,8 @@
 //
 //
 
-#include "Math/IFunctionfwd.h"
 #include "Math/IFunction.h"
 #include "Math/Error.h"
-#include <vector>
 
 #include "GSLMonteFunctionWrapper.h"
 

--- a/math/mathmore/src/GSLMultiFitFunctionAdapter.h
+++ b/math/mathmore/src/GSLMultiFitFunctionAdapter.h
@@ -39,8 +39,6 @@
 
 #include <cassert>
 
-#include <iostream>
-
 namespace ROOT {
 namespace Math {
 

--- a/math/mathmore/src/GSLNLSMinimizer.cxx
+++ b/math/mathmore/src/GSLNLSMinimizer.cxx
@@ -26,7 +26,6 @@
 #include <iostream>
 #include <iomanip>
 #include <cassert>
-#include <memory>
 
 namespace ROOT {
 

--- a/math/mathmore/src/GSLQuasiRandom.cxx
+++ b/math/mathmore/src/GSLQuasiRandom.cxx
@@ -30,6 +30,7 @@
 
 // need to be included later
 #include <time.h>
+#include <vector>
 #include <stdlib.h>
 #include <cassert>
 

--- a/math/mathmore/src/GSLRndmEngines.cxx
+++ b/math/mathmore/src/GSLRndmEngines.cxx
@@ -33,7 +33,6 @@
 
 // need to be included later
 #include <time.h>
-#include <stdlib.h>
 #include <cassert>
 
 #include "gsl/gsl_rng.h"

--- a/math/mathmore/src/GSLRootFinderDeriv.cxx
+++ b/math/mathmore/src/GSLRootFinderDeriv.cxx
@@ -39,7 +39,6 @@
 #include "gsl/gsl_roots.h"
 #include "gsl/gsl_errno.h"
 
-#include <iostream>
 #include <cmath>
 
 namespace ROOT {

--- a/math/mathmore/src/Vavilov.cxx
+++ b/math/mathmore/src/Vavilov.cxx
@@ -36,15 +36,7 @@
 #include "Math/SpecFuncMathCore.h"
 #include "Math/SpecFuncMathMore.h"
 
-#include <cassert>
-#include <iostream>
 #include <cmath>
-#include <iomanip>
-#include <cmath>
-#include <cstdlib>
-#include <string>
-#include <sstream>
-
 
 namespace ROOT {
 namespace Math {

--- a/math/mathmore/src/VavilovFast.cxx
+++ b/math/mathmore/src/VavilovFast.cxx
@@ -37,7 +37,6 @@
 #include "Math/SpecFuncMathCore.h"
 #include "Math/SpecFuncMathMore.h"
 
-#include <cassert>
 #include <iostream>
 #include <cmath>
 #include <limits>

--- a/math/physics/inc/TRobustEstimator.h
+++ b/math/physics/inc/TRobustEstimator.h
@@ -18,7 +18,7 @@
 
 #include "TArrayI.h"
 #include "TMatrixDSym.h"
-#include "TMatrixDSymEigen.h"
+#include "TVectorD.h"
 
 class TRobustEstimator : public TObject {
 

--- a/math/physics/src/TFeldmanCousins.cxx
+++ b/math/physics/src/TFeldmanCousins.cxx
@@ -45,7 +45,7 @@ see note about: "Should I use TRolke, TFeldmanCousins, TLimit?"
 Copyright Liverpool University 2001       bevan@slac.stanford.edu
 */
 
-#include "Riostream.h"
+#include <iostream>
 #include "TMath.h"
 #include "TFeldmanCousins.h"
 

--- a/math/physics/src/TGenPhaseSpace.cxx
+++ b/math/physics/src/TGenPhaseSpace.cxx
@@ -23,7 +23,6 @@ Note that Momentum, Energy units are Gev/C, GeV
 #include "TGenPhaseSpace.h"
 #include "TRandom.h"
 #include "TMath.h"
-#include <stdlib.h>
 
 const Int_t kMAXP = 18;
 

--- a/math/physics/src/TLorentzRotation.cxx
+++ b/math/physics/src/TLorentzRotation.cxx
@@ -129,7 +129,6 @@ operator of the TLorentzVector class.:
 ~~~
 */
 
-#include "TError.h"
 #include "TLorentzRotation.h"
 
 ClassImp(TLorentzRotation)

--- a/math/physics/src/TLorentzVector.cxx
+++ b/math/physics/src/TLorentzVector.cxx
@@ -241,8 +241,7 @@ be used by the Transform() member function, the *= or
 #include "TLorentzVector.h"
 
 #include "TBuffer.h"
-#include "TClass.h"
-#include "TError.h"
+#include "TString.h"
 #include "TLorentzRotation.h"
 
 ClassImp(TLorentzVector)

--- a/math/physics/src/TQuaternion.cxx
+++ b/math/physics/src/TQuaternion.cxx
@@ -91,6 +91,7 @@ http://en.wikipedia.org/wiki/Quaternion
 
 #include "TMath.h"
 #include "TQuaternion.h"
+#include "TString.h"
 
 ClassImp(TQuaternion)
 

--- a/math/physics/src/TRobustEstimator.cxx
+++ b/math/physics/src/TRobustEstimator.cxx
@@ -94,10 +94,9 @@ Technical details of the algorithm:
 */
 
 #include "TRobustEstimator.h"
+#include "TMatrixDSymEigen.h"
 #include "TRandom.h"
 #include "TMath.h"
-#include "TH1D.h"
-#include "TPaveLabel.h"
 #include "TDecompChol.h"
 
 ClassImp(TRobustEstimator)

--- a/math/physics/src/TRolke.cxx
+++ b/math/physics/src/TRolke.cxx
@@ -164,7 +164,7 @@
 
 #include "TRolke.h"
 #include "TMath.h"
-#include "Riostream.h"
+#include <iostream>
 
 ClassImp(TRolke)
 

--- a/math/physics/src/TRotation.cxx
+++ b/math/physics/src/TRotation.cxx
@@ -184,7 +184,6 @@ TVector3 class:
 #include "TRotation.h"
 #include "TMath.h"
 #include "TQuaternion.h"
-#include "TError.h"
 
 ClassImp(TRotation)
 

--- a/math/physics/src/TVector2.cxx
+++ b/math/physics/src/TVector2.cxx
@@ -18,7 +18,6 @@ the description of different vectors in 2D.
 
 #include "TROOT.h"
 #include "TVector2.h"
-#include "TClass.h"
 #include "TMath.h"
 
 Double_t const  kPI        = TMath::Pi();

--- a/math/physics/src/TVector3.cxx
+++ b/math/physics/src/TVector3.cxx
@@ -167,12 +167,12 @@ theta plane) to the (x,y,z) frame.
 */
 
 
+#include "TMatrix.h"
 #include "TVector3.h"
 
 #include "TBuffer.h"
 #include "TRotation.h"
 #include "TMath.h"
-#include "TClass.h"
 
 ClassImp(TVector3)
 


### PR DESCRIPTION
cleaning up a few includes in math/mathmore and math/physics.
NB:
1. root builds for me with these changes but i didn't check for platform independence (when it comes to system headers)
2. removing includes from headers may break 3rd party code including those headers i manipulated.
