### PR TITLE
Adding command line rootslimtree for removing branches from a tree. 

### DIFF
--- a/main/python/cmdLineUtils.py
+++ b/main/python/cmdLineUtils.py
@@ -789,7 +789,7 @@ def _copyTreeSubset(sourceFile,sourcePathSplit,destFile,destPathSplit,firstEvent
     if branchinclude:
         _setBranchStatus(outputTree,branchinclude,1)
     if branchexclude or branchinclude:
-        outputTree = outputTree.CloneTree(0)
+        outputTree = outputTree.CloneTree()
 
     outputTree.Write()
     return retcode

--- a/main/python/cmdLineUtils.py
+++ b/main/python/cmdLineUtils.py
@@ -747,7 +747,15 @@ def rootCp(sourceList, destFileName, destPathSplit, \
 ##########
 # ROOTEVENTSELECTOR
 
-def _copyTreeSubset(sourceFile,sourcePathSplit,destFile,destPathSplit,firstEvent,lastEvent,selectionString):
+def _setBranchStatus(tree,branchSelectionString,status=0):
+    """This is used by _copyTreeSubset() to turn on/off branches"""
+    for branchToModify in branchSelectionString.split(","):
+        logging.info("Setting branch status to %d for %s"%(status,branchToModify)  )
+        tree.SetBranchStatus(branchToModify,status)
+    return tree
+
+def _copyTreeSubset(sourceFile,sourcePathSplit,destFile,destPathSplit,firstEvent,lastEvent,selectionString,
+    branchinclude, branchexclude):
     """Copy a subset of the tree from (sourceFile,sourcePathSplit)
     to (destFile,destPathSplit) according to options in optDict"""
     retcode = changeDirectory(sourceFile,sourcePathSplit[:-1])
@@ -757,6 +765,7 @@ def _copyTreeSubset(sourceFile,sourcePathSplit,destFile,destPathSplit,firstEvent
     # changeDirectory for the small tree not to be memory-resident
     retcode = changeDirectory(destFile,destPathSplit)
     if retcode != 0: return retcode
+
     smallTree = bigTree.CloneTree(0)
     if lastEvent == -1:
         lastEvent = nbrEntries-1
@@ -767,17 +776,26 @@ def _copyTreeSubset(sourceFile,sourcePathSplit,destFile,destPathSplit,firstEvent
             super(ROOT.TNtuple,smallTree).Fill()
         else:
             smallTree.Fill()
+
+    # "Skim" events based on branch values
     if selectionString:
-        if isNtuple:
-            smallSkimmedTree = super(ROOT.TNtuple,smallTree).CopyTree(selectionString)
-        else:
-            smallSkimmedTree = smallTree.CopyTree(selectionString)
-        smallSkimmedTree.Write()
+        outputTree = smallTree.CopyTree(selectionString)
     else:
-        smallTree.Write()
+        outputTree = smallTree
+
+    # "Slim" tree by removing branches
+    if branchexclude:
+        _setBranchStatus(outputTree,branchexclude,0)
+    if branchinclude:
+        _setBranchStatus(outputTree,branchinclude,1)
+    if branchexclude or branchinclude:
+        outputTree = outputTree.CloneTree(0)
+
+    outputTree.Write()
     return retcode
 
-def _copyTreeSubsets(fileName, pathSplitList, destFile, destPathSplit, first, last, selectionString):
+def _copyTreeSubsets(fileName, pathSplitList, destFile, destPathSplit, first, last, selectionString,
+    branchinclude, branchexclude):
     retcode = 0
     destFileName = destFile.GetName()
     rootFile = openROOTFile(fileName) \
@@ -787,12 +805,13 @@ def _copyTreeSubsets(fileName, pathSplitList, destFile, destPathSplit, first, la
     for pathSplit in pathSplitList:
         if isTree(rootFile,pathSplit):
             retcode += _copyTreeSubset(rootFile,pathSplit, \
-            destFile,destPathSplit,first,last,selectionString)
+            destFile,destPathSplit,first,last,selectionString,branchinclude, branchexclude)
     if fileName != destFileName: rootFile.Close()
     return retcode
 
 def rootEventselector(sourceList, destFileName, destPathSplit, \
-                      compress=None, recreate=False, first=0, last=-1, selectionString=""):
+                      compress=None, recreate=False, first=0, last=-1, selectionString="",
+                      branchinclude="", branchexclude=""):
     # Check arguments
     if sourceList == [] or destFileName == "": return 1
     if recreate and destFileName in sourceList:
@@ -807,7 +826,7 @@ def rootEventselector(sourceList, destFileName, destPathSplit, \
     retcode = 0
     for fileName, pathSplitList in sourceList:
         retcode += _copyTreeSubsets(fileName, pathSplitList, destFile, destPathSplit, \
-                                    first, last, selectionString)
+                                    first, last, selectionString, branchinclude, branchexclude)
     destFile.Close()
     return retcode
 

--- a/main/python/cmdLineUtils.py
+++ b/main/python/cmdLineUtils.py
@@ -766,24 +766,17 @@ def _copyTreeSubset(sourceFile,sourcePathSplit,destFile,destPathSplit,firstEvent
     retcode = changeDirectory(destFile,destPathSplit)
     if retcode != 0: return retcode
 
-    smallTree = bigTree.CloneTree(0)
     if lastEvent == -1:
         lastEvent = nbrEntries-1
-    isNtuple = bigTree.InheritsFrom(ROOT.TNtuple.Class())
-    for i in range(firstEvent, lastEvent+1):
-        bigTree.GetEntry(i)
-        if isNtuple:
-            super(ROOT.TNtuple,smallTree).Fill()
-        else:
-            smallTree.Fill()
+    numberOfEntries = (lastEvent-firstEvent)+1
 
-    # "Skim" events based on branch values
-    if selectionString:
-        outputTree = smallTree.CopyTree(selectionString)
-    else:
-        outputTree = smallTree
+    # "Skim" events based on branch values using selectionString
+    # as well as selecting a range of events by index
+    outputTree = bigTree.CopyTree(selectionString,"",numberOfEntries,firstEvent)
 
-    # "Slim" tree by removing branches
+    # "Slim" tree by removing branches - 
+    # This is done after the skimming to allow for the user to skim on a 
+    # branch they no longer need to keep
     if branchexclude:
         _setBranchStatus(outputTree,branchexclude,0)
     if branchinclude:
@@ -793,6 +786,7 @@ def _copyTreeSubset(sourceFile,sourcePathSplit,destFile,destPathSplit,firstEvent
 
     outputTree.Write()
     return retcode
+
 
 def _copyTreeSubsets(fileName, pathSplitList, destFile, destPathSplit, first, last, selectionString,
     branchinclude, branchexclude):

--- a/main/python/rooteventselector.py
+++ b/main/python/rooteventselector.py
@@ -5,6 +5,11 @@
 # Mail: julien.ripoche@u-psud.fr
 # Date: 20/08/15
 
+# Additions
+# Author: Lawrence Lee
+# Mail: lawrence.lee.jr@cern.ch
+# Date: 1/4/16
+
 """Command line to copy subsets of trees from source ROOT files to new trees on a destination ROOT file"""
 
 import cmdLineUtils
@@ -34,6 +39,12 @@ EPILOG="""Examples:
 
 - rooteventselector -s "(branch1Value > 100)&&( branch2Value )" source.root:tree dest.root
   Copy the tree 'tree' from 'source.root' to 'dest.root' and apply a selection to the output tree.
+
+- rooteventselector -e "muon_*" source.root:tree dest.root
+  Copy the tree 'tree' from 'source.root' to 'dest.root' and remove branches matching "muon_*"
+
+- rooteventselector -e "*" -i "muon_*" source.root:tree dest.root
+  Copy the tree 'tree' from 'source.root' to 'dest.root' and only write branches matching "muon_*"
 """
 
 def execute():
@@ -44,6 +55,8 @@ def execute():
     parser.add_argument("-f","--first", type=int, default=0, help=FIRST_EVENT_HELP)
     parser.add_argument("-l","--last", type=int, default=-1, help=LAST_EVENT_HELP)
     parser.add_argument("-s","--selection", default="")
+    parser.add_argument("-i","--branchinclude", default="")
+    parser.add_argument("-e","--branchexclude", default="")
 
     # Put arguments in shape
     sourceList, destFileName, destPathSplit, optDict = cmdLineUtils.getSourceDestListOptDict(parser)
@@ -51,6 +64,9 @@ def execute():
     # Process rootEventselector
     return cmdLineUtils.rootEventselector(sourceList, destFileName, destPathSplit, \
                                           compress=optDict["compress"], recreate=optDict["recreate"], \
-                                          first=optDict["first"], last=optDict["last"], selectionString=optDict["selection"])
+                                          first=optDict["first"], last=optDict["last"], \
+                                          selectionString=optDict["selection"], \
+                                          branchinclude=optDict["branchinclude"],\
+                                          branchexclude=optDict["branchexclude"])
 
 sys.exit(execute())

--- a/main/python/rootslimtree.py
+++ b/main/python/rootslimtree.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env @python@
+
+# ROOT command line tools: rootslimtree
+# Author: Lawrence Lee via Julien Ripoche's rooteventselector
+# Mail: lawrence.lee.jr@cern.ch
+# Date: 4/4/16
+
+"""Command line to copy trees with subset of branches from source ROOT files to new trees on a destination ROOT file"""
+
+import cmdLineUtils
+import sys
+
+# Help strings
+COMMAND_HELP = "Copy trees with a subset of branches from source ROOT files"
+
+EPILOG="""Examples:
+- rootslimtree source.root:tree dest.root
+  Copy the tree 'tree' from 'source.root' to 'dest.root'.
+
+- rootslimtree --recreate source.root:tree dest.root
+  Recreate the destination file 'dest.root' and copy the tree 'tree' from 'source.root' to 'dest.root'.
+
+- rootslimtree -c 1 source.root:tree dest.root
+  Change the compression factor of the destination file 'dest.root' and  copy the tree 'tree' from 'source.root' to 'dest.root'. For more information about compression settings of ROOT file, please look at the reference guide available on the ROOT site.
+
+- rootslimtree -e "muon_*" source.root:tree dest.root
+  Copy the tree 'tree' from 'source.root' to 'dest.root' and remove branches matching "muon_*"
+
+- rootslimtree -e "*" -i "muon_*" source.root:tree dest.root
+  Copy the tree 'tree' from 'source.root' to 'dest.root' and only write branches matching "muon_*"
+"""
+
+def execute():
+    # Collect arguments with the module argparse
+    parser = cmdLineUtils.getParserSourceDest(COMMAND_HELP, EPILOG)
+    parser.add_argument("-c","--compress", type=int, help=cmdLineUtils.COMPRESS_HELP)
+    parser.add_argument("--recreate", help=cmdLineUtils.RECREATE_HELP, action="store_true")
+    parser.add_argument("-i","--branchinclude", default="")
+    parser.add_argument("-e","--branchexclude", default="")
+
+    # Put arguments in shape
+    sourceList, destFileName, destPathSplit, optDict = cmdLineUtils.getSourceDestListOptDict(parser)
+
+    # Process rootEventselector in simplified slimtree mode
+    return cmdLineUtils.rootEventselector(sourceList, destFileName, destPathSplit, \
+                                          compress=optDict["compress"], recreate=optDict["recreate"], \
+                                          first=0, last=-1, \
+                                          selectionString="", \
+                                          branchinclude=optDict["branchinclude"],\
+                                          branchexclude=optDict["branchexclude"])
+
+sys.exit(execute())


### PR DESCRIPTION
Hi all,

I've added a new command-line tool called rootslimtree which will remove branches from an input tree and write out a new file. This is actually implemented in cmdLineUtils.rootEventselector() and the rooteventselector function has been updated to also have this ability, so in case a user wants to remove both branches and events, this can be done in a single step. 

Related to #149.

Thanks!
-Larry
