### PR TITLE
Implement "miss cache" for TTreeCache

### DIFF
--- a/tree/tree/inc/TTreeCache.h
+++ b/tree/tree/inc/TTreeCache.h
@@ -38,39 +38,39 @@ public:
    enum EPrefillType { kNoPrefill, kAllBranches };
 
 protected:
-   Long64_t fEntryMin{0};      ///<! first entry in the cache
-   Long64_t fEntryMax{1};      ///<! last entry in the cache
-   Long64_t fEntryCurrent{-1}; ///<! current lowest entry number in the cache
-   Long64_t fEntryNext{-1};    ///<! next entry number where cache must be filled
-   Int_t fNbranches{0};        ///<! Number of branches in the cache
-   Int_t fNReadOk{0};          ///<  Number of blocks read and found in the cache
-   Int_t fNMissReadOk{0};      ///<  Number of blocks read, not found in the primary cache, and found in the secondary cache.
-   Int_t fNReadMiss{0};        ///<  Number of blocks read and not found in the cache
-   Int_t fNMissReadMiss{0};          ///<  Number of blocks read and not found in either cache.
-   Int_t fNReadPref{0};              ///<  Number of blocks that were prefetched
-   Int_t fNMissReadPref{0};          ///<  Number of blocks read into the secondary ("miss") cache.
-   TObjArray *fBranches{nullptr};    ///<! List of branches to be stored in the cache
-   TList *fBrNames{nullptr};         ///<! list of branch names in the cache
-   TTree *fTree{nullptr};            ///<! pointer to the current Tree
-   Bool_t fIsLearning{kTRUE};        ///<! true if cache is in learning mode
-   Bool_t fIsManual{kFALSE};         ///<! true if cache is StopLearningPhase was used
-   Bool_t fFirstBuffer{kTRUE};       ///<! true if first buffer is used for prefetching
-   Bool_t fOneTime{kFALSE};          ///<! used in the learning phase
-   Bool_t fReverseRead{kFALSE};      ///<! reading in reverse mode
-   Int_t fFillTimes{0};              ///<! how many times we can fill the current buffer
-   Bool_t fFirstTime{kTRUE};         ///<! save the fact that we processes the first entry
-   Long64_t fFirstEntry{-1};         ///<! save the value of the first entry
-   Bool_t fReadDirectionSet{kFALSE}; ///<! read direction established
-   Bool_t fEnabled{kTRUE};           ///<! cache enabled for cached reading
-   EPrefillType fPrefillType;        ///<  Whether a pre-filling is enabled (and if applicable which type)
-   static Int_t fgLearnEntries;      ///<  number of entries used for learning mode
-   Bool_t fAutoCreated{kFALSE};      ///<! true if cache was automatically created
+   Long64_t     fEntryMin{0};         ///<! first entry in the cache
+   Long64_t     fEntryMax{1};         ///<! last entry in the cache
+   Long64_t     fEntryCurrent{-1};    ///<! current lowest entry number in the cache
+   Long64_t     fEntryNext{-1};       ///<! next entry number where cache must be filled
+   Int_t        fNbranches{0};        ///<! Number of branches in the cache
+   Int_t        fNReadOk{0};          ///<  Number of blocks read and found in the cache
+   Int_t        fNMissReadOk{0};      ///<  Number of blocks read, not found in the primary cache, and found in the secondary cache.
+   Int_t        fNReadMiss{0};        ///<  Number of blocks read and not found in the cache
+   Int_t        fNMissReadMiss{0};    ///<  Number of blocks read and not found in either cache.
+   Int_t        fNReadPref{0};        ///<  Number of blocks that were prefetched
+   Int_t        fNMissReadPref{0};    ///<  Number of blocks read into the secondary ("miss") cache.
+   TObjArray   *fBranches{nullptr};   ///<! List of branches to be stored in the cache
+   TList       *fBrNames{nullptr};    ///<! list of branch names in the cache
+   TTree       *fTree{nullptr};       ///<! pointer to the current Tree
+   Bool_t       fIsLearning{kTRUE};   ///<! true if cache is in learning mode
+   Bool_t       fIsManual{kFALSE};    ///<! true if cache is StopLearningPhase was used
+   Bool_t       fFirstBuffer{kTRUE};  ///<! true if first buffer is used for prefetching
+   Bool_t       fOneTime{kFALSE};     ///<! used in the learning phase
+   Bool_t       fReverseRead{kFALSE}; ///<! reading in reverse mode
+   Int_t        fFillTimes{0};        ///<! how many times we can fill the current buffer
+   Bool_t       fFirstTime{kTRUE};    ///<! save the fact that we processes the first entry
+   Long64_t     fFirstEntry{-1};      ///<! save the value of the first entry
+   Bool_t       fReadDirectionSet{kFALSE}; ///<! read direction established
+   Bool_t       fEnabled{kTRUE};      ///<! cache enabled for cached reading
+   EPrefillType fPrefillType;         ///<  Whether a pre-filling is enabled (and if applicable which type)
+   static Int_t fgLearnEntries;       ///<  number of entries used for learning mode
+   Bool_t       fAutoCreated{kFALSE}; ///<! true if cache was automatically created
 
    // These members hold cached data for missed branches when miss optimization
    // is enabled.  Pointers are only initialized if the miss cache is enabled.
-   Bool_t fOptimizeMisses{kFALSE}; //! true if we should optimize cache misses.
-   Long64_t fFirstMiss{-1};        //! set to the event # of the first miss.
-   Long64_t fLastMiss{-1};         //! set to the event # of the last miss.
+   Bool_t   fOptimizeMisses{kFALSE}; ///<! true if we should optimize cache misses.
+   Long64_t fFirstMiss{-1};          ///<! set to the event # of the first miss.
+   Long64_t fLastMiss{-1};           ///<! set to the event # of the last miss.
 
    // Representation of a positioned buffer IO.
    // {0,0} designates the uninitialized - or invalid - buffer.
@@ -120,7 +120,7 @@ private:
    Bool_t CalculateMissCache();    // Calculate the appropriate miss cache to fetch; helper function for FillMissCache
    IOPos FindBranchBasketPos(TBranch &, Long64_t entry); // Given a branch and an entry, determine the file location
                                                          // (offset / size) of the corresponding basket.
-   TBranch *CalculateMissEntries(Long64_t, int, bool); // Given an file read, try to determine the corresponding branch.
+   TBranch *CalculateMissEntries(Long64_t, int, bool);   // Given an file read, try to determine the corresponding branch.
    Bool_t
    ProcessMiss(Long64_t pos, int len); // Given a file read not in the miss cache, handle (possibly) loading the data.
 

--- a/tree/tree/inc/TTreeCache.h
+++ b/tree/tree/inc/TTreeCache.h
@@ -86,12 +86,12 @@ protected:
          Entry(IOPos io) : fIO(io) {}
 
          IOPos fIO;
-         ULong64_t fIndex{0}; //! Location in fData corresponding to this entry.
+         ULong64_t fIndex{0}; ///<! Location in fData corresponding to this entry.
          friend bool operator<(const Entry &a, const Entry &b) { return a.fIO.fPos < b.fIO.fPos; }
       };
-      std::vector<Entry> fEntries;      //! Description of buffers in the miss cache.
-      std::vector<TBranch *> fBranches; //! list of branches that we read on misses.
-      std::vector<char> fData;          //! Actual data in the cache.
+      std::vector<Entry> fEntries;      ///<! Description of buffers in the miss cache.
+      std::vector<TBranch *> fBranches; ///<! list of branches that we read on misses.
+      std::vector<char> fData;          ///<! Actual data in the cache.
 
       void clear()
       {
@@ -101,10 +101,10 @@ protected:
       }
    };
 
-   std::unique_ptr<MissCache> fMissCache; //! Cache contents for misses
+   std::unique_ptr<MissCache> fMissCache; ///<! Cache contents for misses
 
 private:
-   TTreeCache(const TTreeCache &) = delete; // this class cannot be copied
+   TTreeCache(const TTreeCache &) = delete; ///< this class cannot be copied
    TTreeCache &operator=(const TTreeCache &) = delete;
 
    // These are all functions related to the "miss cache": this attempts to
@@ -115,14 +115,13 @@ private:
    // for local work (i.e., laptop with SSD), this CPU cost may outweight the
    // benefit.
    Bool_t CheckMissCache(char *buf, Long64_t pos,
-                         int len); // Check the miss cache for a particular buffer, fetching if deemed necessary.
-   Bool_t FillMissCache();         // Fill the miss cache from the current set of active branches.
-   Bool_t CalculateMissCache();    // Calculate the appropriate miss cache to fetch; helper function for FillMissCache
-   IOPos FindBranchBasketPos(TBranch &, Long64_t entry); // Given a branch and an entry, determine the file location
-                                                         // (offset / size) of the corresponding basket.
-   TBranch *CalculateMissEntries(Long64_t, int, bool);   // Given an file read, try to determine the corresponding branch.
-   Bool_t
-   ProcessMiss(Long64_t pos, int len); // Given a file read not in the miss cache, handle (possibly) loading the data.
+                         int len); ///< Check the miss cache for a particular buffer, fetching if deemed necessary.
+   Bool_t FillMissCache();         ///< Fill the miss cache from the current set of active branches.
+   Bool_t CalculateMissCache();    ///< Calculate the appropriate miss cache to fetch; helper function for FillMissCache
+   IOPos  FindBranchBasketPos(TBranch &, Long64_t entry); ///< Given a branch and an entry, determine the file location
+                                                          ///< (offset / size) of the corresponding basket.
+   TBranch *CalculateMissEntries(Long64_t, int, bool);    ///< Given an file read, try to determine the corresponding branch.
+   Bool_t   ProcessMiss(Long64_t pos, int len); ///<! Given a file read not in the miss cache, handle (possibly) loading the data.
 
 public:
 

--- a/tree/tree/inc/TTreeCache.h
+++ b/tree/tree/inc/TTreeCache.h
@@ -125,18 +125,17 @@ public:
    virtual Int_t        DropBranch(const char *branch, Bool_t subbranches = kFALSE);
    virtual void         Disable() {fEnabled = kFALSE;}
    virtual void         Enable() {fEnabled = kTRUE;}
-   void                 SetOptimizeMisses(bool opt);
    bool                 GetOptimizeMisses() const {return fOptimizeMisses;}
    const TObjArray     *GetCachedBranches() const { return fBranches; }
    EPrefillType         GetConfiguredPrefillType() const;
    Double_t             GetEfficiency() const;
    Double_t             GetEfficiencyRel() const;
-   double               GetMissEfficiency() const;
-   double               GetMissEfficiencyRel() const;
    virtual Int_t        GetEntryMin() const {return fEntryMin;}
    virtual Int_t        GetEntryMax() const {return fEntryMax;}
    static Int_t         GetLearnEntries();
    virtual EPrefillType GetLearnPrefill() const {return fPrefillType;}
+   double               GetMissEfficiency() const;
+   double               GetMissEfficiencyRel() const;
    TTree               *GetTree() const {return fTree;}
    Bool_t               IsAutoCreated() const {return fAutoCreated;}
    virtual Bool_t       IsEnabled() const {return fEnabled;}
@@ -157,6 +156,7 @@ public:
    virtual void         SetFile(TFile *file, TFile::ECacheAction action=TFile::kDisconnect);
    virtual void         SetLearnPrefill(EPrefillType type = kNoPrefill);
    static void          SetLearnEntries(Int_t n = 10);
+   void                 SetOptimizeMisses(bool opt);
    void                 StartLearningPhase();
    virtual void         StopLearningPhase();
    virtual void         UpdateBranches(TTree *tree);

--- a/tree/tree/inc/TTreeCache.h
+++ b/tree/tree/inc/TTreeCache.h
@@ -38,33 +38,33 @@ public:
    enum EPrefillType { kNoPrefill, kAllBranches };
 
 protected:
-   Long64_t        fEntryMin;         ///<! first entry in the cache
-   Long64_t        fEntryMax;         ///<! last entry in the cache
-   Long64_t        fEntryCurrent;     ///<! current lowest entry number in the cache
-   Long64_t        fEntryNext;        ///<! next entry number where cache must be filled
-   Int_t           fNbranches;        ///<! Number of branches in the cache
-   Int_t           fNReadOk;          ///<  Number of blocks read and found in the cache
-   Int_t           fNMissReadOk{0};   ///<  Number of blocks read, not found in the primary cache, and found in the secondary cache.
-   Int_t           fNReadMiss;        ///<  Number of blocks read and not found in the cache
-   Int_t           fNMissReadMiss{0}; ///<  Number of blocks read and not found in either cache.
-   Int_t           fNReadPref;        ///<  Number of blocks that were prefetched
-   Int_t           fNMissReadPref{0}; ///<  Number of blocks read into the secondary ("miss") cache.
-   TObjArray      *fBranches;         ///<! List of branches to be stored in the cache
-   TList          *fBrNames;          ///<! list of branch names in the cache
-   TTree          *fTree;             ///<! pointer to the current Tree
-   Bool_t          fIsLearning;       ///<! true if cache is in learning mode
-   Bool_t          fIsManual;         ///<! true if cache is StopLearningPhase was used
-   Bool_t          fFirstBuffer;      ///<! true if first buffer is used for prefetching
-   Bool_t          fOneTime;          ///<! used in the learning phase
-   Bool_t          fReverseRead;      ///<! reading in reverse mode
-   Int_t           fFillTimes;        ///<! how many times we can fill the current buffer
-   Bool_t          fFirstTime;        ///<! save the fact that we processes the first entry
-   Long64_t        fFirstEntry;       ///<! save the value of the first entry
-   Bool_t          fReadDirectionSet; ///<! read direction established
-   Bool_t          fEnabled;          ///<! cache enabled for cached reading
-   EPrefillType    fPrefillType;      ///<  Whether a pre-filling is enabled (and if applicable which type)
-   static  Int_t   fgLearnEntries;    ///<  number of entries used for learning mode
-   Bool_t          fAutoCreated;      ///<! true if cache was automatically created
+   Long64_t        fEntryMin{0};               ///<! first entry in the cache
+   Long64_t        fEntryMax{1};              ///<! last entry in the cache
+   Long64_t        fEntryCurrent{-1};         ///<! current lowest entry number in the cache
+   Long64_t        fEntryNext{-1};            ///<! next entry number where cache must be filled
+   Int_t           fNbranches{0};             ///<! Number of branches in the cache
+   Int_t           fNReadOk{0};               ///<  Number of blocks read and found in the cache
+   Int_t           fNMissReadOk{0};           ///<  Number of blocks read, not found in the primary cache, and found in the secondary cache.
+   Int_t           fNReadMiss{0};             ///<  Number of blocks read and not found in the cache
+   Int_t           fNMissReadMiss{0};         ///<  Number of blocks read and not found in either cache.
+   Int_t           fNReadPref{0};             ///<  Number of blocks that were prefetched
+   Int_t           fNMissReadPref{0};         ///<  Number of blocks read into the secondary ("miss") cache.
+   TObjArray      *fBranches{nullptr};        ///<! List of branches to be stored in the cache
+   TList          *fBrNames{nullptr};         ///<! list of branch names in the cache
+   TTree          *fTree{nullptr};            ///<! pointer to the current Tree
+   Bool_t          fIsLearning{kTRUE};        ///<! true if cache is in learning mode
+   Bool_t          fIsManual{kFALSE};         ///<! true if cache is StopLearningPhase was used
+   Bool_t          fFirstBuffer{kTRUE};       ///<! true if first buffer is used for prefetching
+   Bool_t          fOneTime{kFALSE};          ///<! used in the learning phase
+   Bool_t          fReverseRead{kFALSE};      ///<! reading in reverse mode
+   Int_t           fFillTimes{0};             ///<! how many times we can fill the current buffer
+   Bool_t          fFirstTime{kTRUE};         ///<! save the fact that we processes the first entry
+   Long64_t        fFirstEntry{-1};           ///<! save the value of the first entry
+   Bool_t          fReadDirectionSet{kFALSE}; ///<! read direction established
+   Bool_t          fEnabled{kTRUE};           ///<! cache enabled for cached reading
+   EPrefillType    fPrefillType;              ///<  Whether a pre-filling is enabled (and if applicable which type)
+   static  Int_t   fgLearnEntries;            ///<  number of entries used for learning mode
+   Bool_t          fAutoCreated{kFALSE};      ///<! true if cache was automatically created
 
    // These members hold cached data for missed branches when miss optimization
    // is enabled.  Pointers are only initialized if the miss cache is enabled.

--- a/tree/tree/inc/TTreeCache.h
+++ b/tree/tree/inc/TTreeCache.h
@@ -72,11 +72,13 @@ protected:
    Long64_t        fFirstMiss {-1}; //! set to the event # of the first miss.
    Long64_t        fLastMiss  {-1}; //! set to the event # of the last miss.
 
+   // Representation of a positioned buffer IO.
+   // {0,0} designates the uninitialized - or invalid - buffer.
    struct IOPos {
-      IOPos(ULong64_t pos, UInt_t len) : fPos(pos), fLen(len) {}
+      IOPos(Long64_t pos, Int_t len) : fPos(pos), fLen(len) {}
 
-      ULong64_t fPos{0};  //! Position in file of cache entry.
-      UInt_t fLen{0};  //! Length of cache entry.
+      Long64_t fPos{0};  //! Position in file of cache entry.
+      Int_t fLen{0};  //! Length of cache entry.
    };
    struct MissCache {
       struct Entry {
@@ -110,7 +112,7 @@ private:
    Bool_t CheckMissCache(char *buf, Long64_t pos, int len);  // Check the miss cache for a particular buffer, fetching if deemed necessary.
    Bool_t FillMissCache();  // Fill the miss cache from the current set of active branches.
    Bool_t CalculateMissCache();  // Calculate the appropriate miss cache to fetch; helper function for FillMissCache
-   IOPos FindBranchBasket(TBranch &);  // Given a branch, determine the location of its basket for the current entry.
+   IOPos FindBranchBasketPos(TBranch &, Long64_t entry);  // Given a branch and an entry, determine the file location (offset / size) of the corresponding basket.
    TBranch* CalculateMissEntries(Long64_t, int, bool);   // Given an file read, try to determine the corresponding branch.
    Bool_t ProcessMiss(Long64_t pos, int len);   // Given a file read not in the miss cache, handle (possibly) loading the data.
 

--- a/tree/tree/inc/TTreeCache.h
+++ b/tree/tree/inc/TTreeCache.h
@@ -68,7 +68,7 @@ protected:
 
    // These members hold cached data for missed branches when miss optimization
    // is enabled.  Pointers are only initialized if the miss cache is enabled.
-   bool            fOptimizeMisses {false}; //! true if we should optimize cache misses.
+   Bool_t          fOptimizeMisses {kFALSE}; //! true if we should optimize cache misses.
    Long64_t        fFirstMiss {-1}; //! set to the event # of the first miss.
    Long64_t        fLastMiss  {-1}; //! set to the event # of the last miss.
 
@@ -92,7 +92,7 @@ protected:
       std::vector<TBranch*> fBranches;  //! list of branches that we read on misses.
       std::vector<char> fData;  //! Actual data in the cache.
 
-      void clear() {fEntries.clear(); fBranches.clear(); fData.clear();}
+      void clear() { fEntries.clear(); fBranches.clear(); fData.clear(); }
    };
    std::unique_ptr<MissCache> fMissCache;  //! Cache contents for misses
 
@@ -107,12 +107,12 @@ private:
    // The miss cache is more CPU-intensive than the rest of the TTreeCache code;
    // for local work (i.e., laptop with SSD), this CPU cost may outweight the
    // benefit.
-   bool CheckMissCache(char *buf, Long64_t pos, int len);  // Check the miss cache for a particular buffer, fetching if deemed necessary.
-   bool FillMissCache();  // Fill the miss cache from the current set of active branches.
-   bool CalculateMissCache();  // Calculate the appropriate miss cache to fetch; helper function for FillMissCache
+   Bool_t CheckMissCache(char *buf, Long64_t pos, int len);  // Check the miss cache for a particular buffer, fetching if deemed necessary.
+   Bool_t FillMissCache();  // Fill the miss cache from the current set of active branches.
+   Bool_t CalculateMissCache();  // Calculate the appropriate miss cache to fetch; helper function for FillMissCache
    IOPos FindBranchBasket(TBranch &);  // Given a branch, determine the location of its basket for the current entry.
    TBranch* CalculateMissEntries(Long64_t, int, bool);   // Given an file read, try to determine the corresponding branch.
-   bool ProcessMiss(Long64_t pos, int len);   // Given a file read not in the miss cache, handle (possibly) loading the data.
+   Bool_t ProcessMiss(Long64_t pos, int len);   // Given a file read not in the miss cache, handle (possibly) loading the data.
 
 public:
 
@@ -125,7 +125,7 @@ public:
    virtual Int_t        DropBranch(const char *branch, Bool_t subbranches = kFALSE);
    virtual void         Disable() {fEnabled = kFALSE;}
    virtual void         Enable() {fEnabled = kTRUE;}
-   bool                 GetOptimizeMisses() const {return fOptimizeMisses;}
+   Bool_t               GetOptimizeMisses() const { return fOptimizeMisses; }
    const TObjArray     *GetCachedBranches() const { return fBranches; }
    EPrefillType         GetConfiguredPrefillType() const;
    Double_t             GetEfficiency() const;
@@ -134,8 +134,8 @@ public:
    virtual Int_t        GetEntryMax() const {return fEntryMax;}
    static Int_t         GetLearnEntries();
    virtual EPrefillType GetLearnPrefill() const {return fPrefillType;}
-   double               GetMissEfficiency() const;
-   double               GetMissEfficiencyRel() const;
+   Double_t             GetMissEfficiency() const;
+   Double_t             GetMissEfficiencyRel() const;
    TTree               *GetTree() const {return fTree;}
    Bool_t               IsAutoCreated() const {return fAutoCreated;}
    virtual Bool_t       IsEnabled() const {return fEnabled;}
@@ -156,7 +156,7 @@ public:
    virtual void         SetFile(TFile *file, TFile::ECacheAction action=TFile::kDisconnect);
    virtual void         SetLearnPrefill(EPrefillType type = kNoPrefill);
    static void          SetLearnEntries(Int_t n = 10);
-   void                 SetOptimizeMisses(bool opt);
+   void                 SetOptimizeMisses(Bool_t opt);
    void                 StartLearningPhase();
    virtual void         StopLearningPhase();
    virtual void         UpdateBranches(TTree *tree);

--- a/tree/tree/inc/TTreeCache.h
+++ b/tree/tree/inc/TTreeCache.h
@@ -38,69 +38,74 @@ public:
    enum EPrefillType { kNoPrefill, kAllBranches };
 
 protected:
-   Long64_t        fEntryMin{0};               ///<! first entry in the cache
-   Long64_t        fEntryMax{1};              ///<! last entry in the cache
-   Long64_t        fEntryCurrent{-1};         ///<! current lowest entry number in the cache
-   Long64_t        fEntryNext{-1};            ///<! next entry number where cache must be filled
-   Int_t           fNbranches{0};             ///<! Number of branches in the cache
-   Int_t           fNReadOk{0};               ///<  Number of blocks read and found in the cache
-   Int_t           fNMissReadOk{0};           ///<  Number of blocks read, not found in the primary cache, and found in the secondary cache.
-   Int_t           fNReadMiss{0};             ///<  Number of blocks read and not found in the cache
-   Int_t           fNMissReadMiss{0};         ///<  Number of blocks read and not found in either cache.
-   Int_t           fNReadPref{0};             ///<  Number of blocks that were prefetched
-   Int_t           fNMissReadPref{0};         ///<  Number of blocks read into the secondary ("miss") cache.
-   TObjArray      *fBranches{nullptr};        ///<! List of branches to be stored in the cache
-   TList          *fBrNames{nullptr};         ///<! list of branch names in the cache
-   TTree          *fTree{nullptr};            ///<! pointer to the current Tree
-   Bool_t          fIsLearning{kTRUE};        ///<! true if cache is in learning mode
-   Bool_t          fIsManual{kFALSE};         ///<! true if cache is StopLearningPhase was used
-   Bool_t          fFirstBuffer{kTRUE};       ///<! true if first buffer is used for prefetching
-   Bool_t          fOneTime{kFALSE};          ///<! used in the learning phase
-   Bool_t          fReverseRead{kFALSE};      ///<! reading in reverse mode
-   Int_t           fFillTimes{0};             ///<! how many times we can fill the current buffer
-   Bool_t          fFirstTime{kTRUE};         ///<! save the fact that we processes the first entry
-   Long64_t        fFirstEntry{-1};           ///<! save the value of the first entry
-   Bool_t          fReadDirectionSet{kFALSE}; ///<! read direction established
-   Bool_t          fEnabled{kTRUE};           ///<! cache enabled for cached reading
-   EPrefillType    fPrefillType;              ///<  Whether a pre-filling is enabled (and if applicable which type)
-   static  Int_t   fgLearnEntries;            ///<  number of entries used for learning mode
-   Bool_t          fAutoCreated{kFALSE};      ///<! true if cache was automatically created
+   Long64_t fEntryMin{0};      ///<! first entry in the cache
+   Long64_t fEntryMax{1};      ///<! last entry in the cache
+   Long64_t fEntryCurrent{-1}; ///<! current lowest entry number in the cache
+   Long64_t fEntryNext{-1};    ///<! next entry number where cache must be filled
+   Int_t fNbranches{0};        ///<! Number of branches in the cache
+   Int_t fNReadOk{0};          ///<  Number of blocks read and found in the cache
+   Int_t fNMissReadOk{0}; ///<  Number of blocks read, not found in the primary cache, and found in the secondary cache.
+   Int_t fNReadMiss{0};   ///<  Number of blocks read and not found in the cache
+   Int_t fNMissReadMiss{0};          ///<  Number of blocks read and not found in either cache.
+   Int_t fNReadPref{0};              ///<  Number of blocks that were prefetched
+   Int_t fNMissReadPref{0};          ///<  Number of blocks read into the secondary ("miss") cache.
+   TObjArray *fBranches{nullptr};    ///<! List of branches to be stored in the cache
+   TList *fBrNames{nullptr};         ///<! list of branch names in the cache
+   TTree *fTree{nullptr};            ///<! pointer to the current Tree
+   Bool_t fIsLearning{kTRUE};        ///<! true if cache is in learning mode
+   Bool_t fIsManual{kFALSE};         ///<! true if cache is StopLearningPhase was used
+   Bool_t fFirstBuffer{kTRUE};       ///<! true if first buffer is used for prefetching
+   Bool_t fOneTime{kFALSE};          ///<! used in the learning phase
+   Bool_t fReverseRead{kFALSE};      ///<! reading in reverse mode
+   Int_t fFillTimes{0};              ///<! how many times we can fill the current buffer
+   Bool_t fFirstTime{kTRUE};         ///<! save the fact that we processes the first entry
+   Long64_t fFirstEntry{-1};         ///<! save the value of the first entry
+   Bool_t fReadDirectionSet{kFALSE}; ///<! read direction established
+   Bool_t fEnabled{kTRUE};           ///<! cache enabled for cached reading
+   EPrefillType fPrefillType;        ///<  Whether a pre-filling is enabled (and if applicable which type)
+   static Int_t fgLearnEntries;      ///<  number of entries used for learning mode
+   Bool_t fAutoCreated{kFALSE};      ///<! true if cache was automatically created
 
    // These members hold cached data for missed branches when miss optimization
    // is enabled.  Pointers are only initialized if the miss cache is enabled.
-   Bool_t          fOptimizeMisses {kFALSE}; //! true if we should optimize cache misses.
-   Long64_t        fFirstMiss {-1}; //! set to the event # of the first miss.
-   Long64_t        fLastMiss  {-1}; //! set to the event # of the last miss.
+   Bool_t fOptimizeMisses{kFALSE}; //! true if we should optimize cache misses.
+   Long64_t fFirstMiss{-1};        //! set to the event # of the first miss.
+   Long64_t fLastMiss{-1};         //! set to the event # of the last miss.
 
    // Representation of a positioned buffer IO.
    // {0,0} designates the uninitialized - or invalid - buffer.
    struct IOPos {
       IOPos(Long64_t pos, Int_t len) : fPos(pos), fLen(len) {}
 
-      Long64_t fPos{0};  //! Position in file of cache entry.
-      Int_t fLen{0};  //! Length of cache entry.
+      Long64_t fPos{0}; //! Position in file of cache entry.
+      Int_t fLen{0};    //! Length of cache entry.
    };
+
    struct MissCache {
       struct Entry {
          Entry(IOPos io) : fIO(io) {}
 
          IOPos fIO;
-         ULong64_t fIndex{0};  //! Location in fData corresponding to this entry.
-         friend bool operator< (const Entry &a, const Entry &b) {
-           return a.fIO.fPos < b.fIO.fPos;
-         }
+         ULong64_t fIndex{0}; //! Location in fData corresponding to this entry.
+         friend bool operator<(const Entry &a, const Entry &b) { return a.fIO.fPos < b.fIO.fPos; }
       };
-      std::vector<Entry> fEntries;  //! Description of buffers in the miss cache.
-      std::vector<TBranch*> fBranches;  //! list of branches that we read on misses.
-      std::vector<char> fData;  //! Actual data in the cache.
+      std::vector<Entry> fEntries;      //! Description of buffers in the miss cache.
+      std::vector<TBranch *> fBranches; //! list of branches that we read on misses.
+      std::vector<char> fData;          //! Actual data in the cache.
 
-      void clear() { fEntries.clear(); fBranches.clear(); fData.clear(); }
+      void clear()
+      {
+         fEntries.clear();
+         fBranches.clear();
+         fData.clear();
+      }
    };
-   std::unique_ptr<MissCache> fMissCache;  //! Cache contents for misses
+
+   std::unique_ptr<MissCache> fMissCache; //! Cache contents for misses
 
 private:
-   TTreeCache(const TTreeCache &);            //this class cannot be copied
-   TTreeCache& operator=(const TTreeCache &);
+   TTreeCache(const TTreeCache &) = delete; // this class cannot be copied
+   TTreeCache &operator=(const TTreeCache &) = delete;
 
    // These are all functions related to the "miss cache": this attempts to
    // optimize ROOT's behavior when the TTreeCache has a cache miss.  In this
@@ -109,12 +114,15 @@ private:
    // The miss cache is more CPU-intensive than the rest of the TTreeCache code;
    // for local work (i.e., laptop with SSD), this CPU cost may outweight the
    // benefit.
-   Bool_t CheckMissCache(char *buf, Long64_t pos, int len);  // Check the miss cache for a particular buffer, fetching if deemed necessary.
-   Bool_t FillMissCache();  // Fill the miss cache from the current set of active branches.
-   Bool_t CalculateMissCache();  // Calculate the appropriate miss cache to fetch; helper function for FillMissCache
-   IOPos FindBranchBasketPos(TBranch &, Long64_t entry);  // Given a branch and an entry, determine the file location (offset / size) of the corresponding basket.
-   TBranch* CalculateMissEntries(Long64_t, int, bool);   // Given an file read, try to determine the corresponding branch.
-   Bool_t ProcessMiss(Long64_t pos, int len);   // Given a file read not in the miss cache, handle (possibly) loading the data.
+   Bool_t CheckMissCache(char *buf, Long64_t pos,
+                         int len); // Check the miss cache for a particular buffer, fetching if deemed necessary.
+   Bool_t FillMissCache();         // Fill the miss cache from the current set of active branches.
+   Bool_t CalculateMissCache();    // Calculate the appropriate miss cache to fetch; helper function for FillMissCache
+   IOPos FindBranchBasketPos(TBranch &, Long64_t entry); // Given a branch and an entry, determine the file location
+                                                         // (offset / size) of the corresponding basket.
+   TBranch *CalculateMissEntries(Long64_t, int, bool); // Given an file read, try to determine the corresponding branch.
+   Bool_t
+   ProcessMiss(Long64_t pos, int len); // Given a file read not in the miss cache, handle (possibly) loading the data.
 
 public:
 
@@ -127,7 +135,7 @@ public:
    virtual Int_t        DropBranch(const char *branch, Bool_t subbranches = kFALSE);
    virtual void         Disable() {fEnabled = kFALSE;}
    virtual void         Enable() {fEnabled = kTRUE;}
-   Bool_t               GetOptimizeMisses() const { return fOptimizeMisses; }
+   Bool_t GetOptimizeMisses() const { return fOptimizeMisses; }
    const TObjArray     *GetCachedBranches() const { return fBranches; }
    EPrefillType         GetConfiguredPrefillType() const;
    Double_t             GetEfficiency() const;
@@ -136,8 +144,8 @@ public:
    virtual Int_t        GetEntryMax() const {return fEntryMax;}
    static Int_t         GetLearnEntries();
    virtual EPrefillType GetLearnPrefill() const {return fPrefillType;}
-   Double_t             GetMissEfficiency() const;
-   Double_t             GetMissEfficiencyRel() const;
+   Double_t GetMissEfficiency() const;
+   Double_t GetMissEfficiencyRel() const;
    TTree               *GetTree() const {return fTree;}
    Bool_t               IsAutoCreated() const {return fAutoCreated;}
    virtual Bool_t       IsEnabled() const {return fEnabled;}
@@ -151,14 +159,14 @@ public:
    virtual Int_t        ReadBufferNormal(char *buf, Long64_t pos, Int_t len);
    virtual Int_t        ReadBufferPrefetch(char *buf, Long64_t pos, Int_t len);
    virtual void         ResetCache();
-   void                 ResetMissCache();  // Reset the miss cache.
+   void ResetMissCache(); // Reset the miss cache.
    void                 SetAutoCreated(Bool_t val) {fAutoCreated = val;}
    virtual Int_t        SetBufferSize(Int_t buffersize);
    virtual void         SetEntryRange(Long64_t emin,   Long64_t emax);
    virtual void         SetFile(TFile *file, TFile::ECacheAction action=TFile::kDisconnect);
    virtual void         SetLearnPrefill(EPrefillType type = kNoPrefill);
    static void          SetLearnEntries(Int_t n = 10);
-   void                 SetOptimizeMisses(Bool_t opt);
+   void SetOptimizeMisses(Bool_t opt);
    void                 StartLearningPhase();
    virtual void         StopLearningPhase();
    virtual void         UpdateBranches(TTree *tree);

--- a/tree/tree/inc/TTreeCache.h
+++ b/tree/tree/inc/TTreeCache.h
@@ -44,8 +44,8 @@ protected:
    Long64_t fEntryNext{-1};    ///<! next entry number where cache must be filled
    Int_t fNbranches{0};        ///<! Number of branches in the cache
    Int_t fNReadOk{0};          ///<  Number of blocks read and found in the cache
-   Int_t fNMissReadOk{0}; ///<  Number of blocks read, not found in the primary cache, and found in the secondary cache.
-   Int_t fNReadMiss{0};   ///<  Number of blocks read and not found in the cache
+   Int_t fNMissReadOk{0};      ///<  Number of blocks read, not found in the primary cache, and found in the secondary cache.
+   Int_t fNReadMiss{0};        ///<  Number of blocks read and not found in the cache
    Int_t fNMissReadMiss{0};          ///<  Number of blocks read and not found in either cache.
    Int_t fNReadPref{0};              ///<  Number of blocks that were prefetched
    Int_t fNMissReadPref{0};          ///<  Number of blocks read into the secondary ("miss") cache.
@@ -135,7 +135,7 @@ public:
    virtual Int_t        DropBranch(const char *branch, Bool_t subbranches = kFALSE);
    virtual void         Disable() {fEnabled = kFALSE;}
    virtual void         Enable() {fEnabled = kTRUE;}
-   Bool_t GetOptimizeMisses() const { return fOptimizeMisses; }
+   Bool_t               GetOptimizeMisses() const { return fOptimizeMisses; }
    const TObjArray     *GetCachedBranches() const { return fBranches; }
    EPrefillType         GetConfiguredPrefillType() const;
    Double_t             GetEfficiency() const;
@@ -144,8 +144,8 @@ public:
    virtual Int_t        GetEntryMax() const {return fEntryMax;}
    static Int_t         GetLearnEntries();
    virtual EPrefillType GetLearnPrefill() const {return fPrefillType;}
-   Double_t GetMissEfficiency() const;
-   Double_t GetMissEfficiencyRel() const;
+   Double_t             GetMissEfficiency() const;
+   Double_t             GetMissEfficiencyRel() const;
    TTree               *GetTree() const {return fTree;}
    Bool_t               IsAutoCreated() const {return fAutoCreated;}
    virtual Bool_t       IsEnabled() const {return fEnabled;}
@@ -159,14 +159,14 @@ public:
    virtual Int_t        ReadBufferNormal(char *buf, Long64_t pos, Int_t len);
    virtual Int_t        ReadBufferPrefetch(char *buf, Long64_t pos, Int_t len);
    virtual void         ResetCache();
-   void ResetMissCache(); // Reset the miss cache.
+   void                 ResetMissCache(); // Reset the miss cache.
    void                 SetAutoCreated(Bool_t val) {fAutoCreated = val;}
    virtual Int_t        SetBufferSize(Int_t buffersize);
    virtual void         SetEntryRange(Long64_t emin,   Long64_t emax);
    virtual void         SetFile(TFile *file, TFile::ECacheAction action=TFile::kDisconnect);
    virtual void         SetLearnPrefill(EPrefillType type = kNoPrefill);
    static void          SetLearnEntries(Int_t n = 10);
-   void SetOptimizeMisses(Bool_t opt);
+   void                 SetOptimizeMisses(Bool_t opt);
    void                 StartLearningPhase();
    virtual void         StopLearningPhase();
    virtual void         UpdateBranches(TTree *tree);

--- a/tree/tree/inc/TTreeCache.h
+++ b/tree/tree/inc/TTreeCache.h
@@ -171,7 +171,7 @@ public:
    virtual void         StopLearningPhase();
    virtual void         UpdateBranches(TTree *tree);
 
-   ClassDef(TTreeCache,2)  //Specialization of TFileCacheRead for a TTree
+   ClassDef(TTreeCache,3)  //Specialization of TFileCacheRead for a TTree
 };
 
 #endif

--- a/tree/tree/inc/TTreeCache.h
+++ b/tree/tree/inc/TTreeCache.h
@@ -69,13 +69,13 @@ protected:
    // These members hold cached data for missed branches when miss optimization
    // is enabled.  Pointers are only initialized if the miss cache is enabled.
    bool            fOptimizeMisses {false}; //! true if we should optimize cache misses.
-   int64_t         fFirstMiss {-1}; //! set to the event # of the first miss.
-   int64_t         fLastMiss  {-1}; //! set to the event # of the last miss.
+   Long64_t        fFirstMiss {-1}; //! set to the event # of the first miss.
+   Long64_t        fLastMiss  {-1}; //! set to the event # of the last miss.
    std::unique_ptr<std::vector<TBranch*>> fMissBranches; //! list of branches that we read on misses.
    std::unique_ptr<std::vector<char>> fMissCache; //! Cache contents for misses
    // TODO: there's a 1-1 correspondence between an element in fEntries and an element in fEntryOffsets
    // Instead of munging std::pairs, put this into a simple struct.
-   std::unique_ptr<std::vector<std::pair<uint64_t, uint32_t>>> fEntries;  //! Buffers in the miss cache.
+   std::unique_ptr<std::vector<std::pair<ULong64_t, UInt_t>>> fEntries;  //! Buffers in the miss cache.
    std::unique_ptr<std::vector<size_t>> fEntryOffsets;  //! Map from (offset, pos) in fEntries to memory location in fMissCache
 
 private:
@@ -89,12 +89,12 @@ private:
    // The miss cache is more CPU-intensive than the rest of the TTreeCache code;
    // for local work (i.e., laptop with SSD), this CPU cost may outweight the
    // benefit.
-   bool CheckMissCache(char *buf, int64_t pos, int len);  // Check the miss cache for a particular buffer, fetching if deemed necessary.
+   bool CheckMissCache(char *buf, Long64_t pos, int len);  // Check the miss cache for a particular buffer, fetching if deemed necessary.
    bool FillMissCache();  // Fill the miss cache from the current set of active branches.
    bool CalculateMissCache();  // Calculate the appropriate miss cache to fetch; helper function for FillMissCache
-   std::pair<uint64_t, uint32_t> FindBranchBasket(TBranch &);  // Given a branch, determine the location of its basket for the current entry.
-   TBranch* CalculateMissEntries(int64_t, int, bool);   // Given an file read, try to determine the corresponding branch.
-   bool ProcessMiss(int64_t pos, int len);   // Given a file read not in the miss cache, handle (possibly) loading the data.
+   std::pair<ULong64_t, UInt_t> FindBranchBasket(TBranch &);  // Given a branch, determine the location of its basket for the current entry.
+   TBranch* CalculateMissEntries(Long64_t, int, bool);   // Given an file read, try to determine the corresponding branch.
+   bool ProcessMiss(Long64_t pos, int len);   // Given a file read not in the miss cache, handle (possibly) loading the data.
 
 public:
 

--- a/tree/tree/inc/TTreeCache.h
+++ b/tree/tree/inc/TTreeCache.h
@@ -24,6 +24,11 @@
 #include "TFileCacheRead.h"
 #include "TObjArray.h"
 
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
 class TTree;
 class TBranch;
 
@@ -39,8 +44,11 @@ protected:
    Long64_t        fEntryNext;        ///<! next entry number where cache must be filled
    Int_t           fNbranches;        ///<! Number of branches in the cache
    Int_t           fNReadOk;          ///<  Number of blocks read and found in the cache
+   Int_t           fNMissReadOk{0};   ///<  Number of blocks read, not found in the primary cache, and found in the secondary cache.
    Int_t           fNReadMiss;        ///<  Number of blocks read and not found in the cache
+   Int_t           fNMissReadMiss{0}; ///<  Number of blocks read and not found in either cache.
    Int_t           fNReadPref;        ///<  Number of blocks that were prefetched
+   Int_t           fNMissReadPref{0}; ///<  Number of blocks read into the secondary ("miss") cache.
    TObjArray      *fBranches;         ///<! List of branches to be stored in the cache
    TList          *fBrNames;          ///<! list of branch names in the cache
    TTree          *fTree;             ///<! pointer to the current Tree
@@ -58,9 +66,35 @@ protected:
    static  Int_t   fgLearnEntries;    ///<  number of entries used for learning mode
    Bool_t          fAutoCreated;      ///<! true if cache was automatically created
 
+   // These members hold cached data for missed branches when miss optimization
+   // is enabled.  Pointers are only initialized if the miss cache is enabled.
+   bool            fOptimizeMisses {false}; //! true if we should optimize cache misses.
+   int64_t         fFirstMiss {-1}; //! set to the event # of the first miss.
+   int64_t         fLastMiss  {-1}; //! set to the event # of the last miss.
+   std::unique_ptr<std::vector<TBranch*>> fMissBranches; //! list of branches that we read on misses.
+   std::unique_ptr<std::vector<char>> fMissCache; //! Cache contents for misses
+   // TODO: there's a 1-1 correspondence between an element in fEntries and an element in fEntryOffsets
+   // Instead of munging std::pairs, put this into a simple struct.
+   std::unique_ptr<std::vector<std::pair<uint64_t, uint32_t>>> fEntries;  //! Buffers in the miss cache.
+   std::unique_ptr<std::vector<size_t>> fEntryOffsets;  //! Map from (offset, pos) in fEntries to memory location in fMissCache
+
 private:
    TTreeCache(const TTreeCache &);            //this class cannot be copied
    TTreeCache& operator=(const TTreeCache &);
+
+   // These are all functions related to the "miss cache": this attempts to
+   // optimize ROOT's behavior when the TTreeCache has a cache miss.  In this
+   // case, we try to read several branches for the event with the miss.
+   //
+   // The miss cache is more CPU-intensive than the rest of the TTreeCache code;
+   // for local work (i.e., laptop with SSD), this CPU cost may outweight the
+   // benefit.
+   bool CheckMissCache(char *buf, int64_t pos, int len);  // Check the miss cache for a particular buffer, fetching if deemed necessary.
+   bool FillMissCache();  // Fill the miss cache from the current set of active branches.
+   bool CalculateMissCache();  // Calculate the appropriate miss cache to fetch; helper function for FillMissCache
+   std::pair<uint64_t, uint32_t> FindBranchBasket(TBranch &);  // Given a branch, determine the location of its basket for the current entry.
+   TBranch* CalculateMissEntries(int64_t, int, bool);   // Given an file read, try to determine the corresponding branch.
+   bool ProcessMiss(int64_t pos, int len);   // Given a file read not in the miss cache, handle (possibly) loading the data.
 
 public:
 
@@ -73,10 +107,14 @@ public:
    virtual Int_t        DropBranch(const char *branch, Bool_t subbranches = kFALSE);
    virtual void         Disable() {fEnabled = kFALSE;}
    virtual void         Enable() {fEnabled = kTRUE;}
+   void                 SetOptimizeMisses(bool opt);
+   bool                 GetOptimizeMisses() const {return fOptimizeMisses;}
    const TObjArray     *GetCachedBranches() const { return fBranches; }
    EPrefillType         GetConfiguredPrefillType() const;
    Double_t             GetEfficiency() const;
    Double_t             GetEfficiencyRel() const;
+   double               GetMissEfficiency() const;
+   double               GetMissEfficiencyRel() const;
    virtual Int_t        GetEntryMin() const {return fEntryMin;}
    virtual Int_t        GetEntryMax() const {return fEntryMax;}
    static Int_t         GetLearnEntries();
@@ -94,6 +132,7 @@ public:
    virtual Int_t        ReadBufferNormal(char *buf, Long64_t pos, Int_t len);
    virtual Int_t        ReadBufferPrefetch(char *buf, Long64_t pos, Int_t len);
    virtual void         ResetCache();
+   void                 ResetMissCache();  // Reset the miss cache.
    void                 SetAutoCreated(Bool_t val) {fAutoCreated = val;}
    virtual Int_t        SetBufferSize(Int_t buffersize);
    virtual void         SetEntryRange(Long64_t emin,   Long64_t emax);

--- a/tree/tree/src/TTreeCache.cxx
+++ b/tree/tree/src/TTreeCache.cxx
@@ -829,7 +829,7 @@ Bool_t TTreeCache::CheckMissCache(char *buf, Long64_t pos, int len)
 
    if (iter != fMissCache->fEntries.end()) {
       if (len > iter->fIO.fLen) {
-         fNMissReadMiss++;
+         ++fNMissReadMiss;
          return kFALSE;
       }
       auto offset = iter->fIndex;

--- a/tree/tree/src/TTreeCache.cxx
+++ b/tree/tree/src/TTreeCache.cxx
@@ -265,20 +265,16 @@ ClassImp(TTreeCache);
 ////////////////////////////////////////////////////////////////////////////////
 /// Default Constructor.
 
-TTreeCache::TTreeCache() : TFileCacheRead(),
-   fPrefillType(GetConfiguredPrefillType())
+TTreeCache::TTreeCache() : TFileCacheRead(), fPrefillType(GetConfiguredPrefillType())
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor.
 
-TTreeCache::TTreeCache(TTree *tree, Int_t buffersize) : TFileCacheRead(tree->GetCurrentFile(),buffersize,tree),
-   fEntryMax(tree->GetEntriesFast()),
-   fEntryNext(0),
-   fBrNames(new TList),
-   fTree(tree),
-   fPrefillType(GetConfiguredPrefillType())
+TTreeCache::TTreeCache(TTree *tree, Int_t buffersize)
+   : TFileCacheRead(tree->GetCurrentFile(), buffersize, tree), fEntryMax(tree->GetEntriesFast()), fEntryNext(0),
+     fBrNames(new TList), fTree(tree), fPrefillType(GetConfiguredPrefillType())
 {
    fEntryNext = fEntryMin + fgLearnEntries;
    Int_t nleaves = tree->GetListOfLeaves()->GetEntries();
@@ -599,7 +595,8 @@ Int_t TTreeCache::DropBranch(const char *bname, Bool_t subbranches /*= kFALSE*/)
 /// The first time this is called on a TTreeCache object, the corresponding
 /// data structures will be allocated.  Subsequent enable / disables will
 /// simply turn the functionality on/off.
-void TTreeCache::SetOptimizeMisses(Bool_t opt) {
+void TTreeCache::SetOptimizeMisses(Bool_t opt)
+{
 
    if (opt && !fMissCache) {
       ResetMissCache();
@@ -612,7 +609,8 @@ void TTreeCache::SetOptimizeMisses(Bool_t opt) {
 ///
 /// The contents of the miss cache will be emptied as well as the list of
 /// branches used.
-void TTreeCache::ResetMissCache() {
+void TTreeCache::ResetMissCache()
+{
 
    fLastMiss = -1;
    fFirstMiss = -1;
@@ -630,28 +628,30 @@ void TTreeCache::ResetMissCache() {
 /// Returns:
 /// - IOPos describing the IO operation necessary for the basket on this branch
 /// - On failure, IOPos.length will be set to 0.
-TTreeCache::IOPos TTreeCache::FindBranchBasketPos(TBranch &b, Long64_t entry) {
+TTreeCache::IOPos TTreeCache::FindBranchBasketPos(TBranch &b, Long64_t entry)
+{
    if (R__unlikely(b.GetDirectory() == 0)) {
-      //printf("Branch at %p has no valid directory.\n", &b);
+      // printf("Branch at %p has no valid directory.\n", &b);
       return IOPos{0, 0};
    }
    if (R__unlikely(b.GetDirectory()->GetFile() != fFile)) {
-      //printf("Branch at %p is in wrong file (branch file %p, my file %p).\n", &b, b.GetDirectory()->GetFile(), fFile);
+      // printf("Branch at %p is in wrong file (branch file %p, my file %p).\n", &b, b.GetDirectory()->GetFile(),
+      // fFile);
       return IOPos{0, 0};
    }
 
-   //printf("Trying to find a basket for branch %p\n", &b);
+   // printf("Trying to find a basket for branch %p\n", &b);
    // Pull in metadata about branch; make sure it is valid
-   Int_t *lbaskets   = b.GetBasketBytes();
+   Int_t *lbaskets = b.GetBasketBytes();
    Long64_t *entries = b.GetBasketEntry();
    if (R__unlikely(!lbaskets || !entries)) {
-      //printf("No baskets or entries.\n");
+      // printf("No baskets or entries.\n");
       return IOPos{0, 0};
    }
-   //Int_t blistsize = b.GetListOfBaskets()->GetSize();
+   // Int_t blistsize = b.GetListOfBaskets()->GetSize();
    Int_t blistsize = b.GetWriteBasket();
    if (R__unlikely(blistsize <= 0)) {
-      //printf("Basket list is size 0.\n");
+      // printf("Basket list is size 0.\n");
       return IOPos{0, 0};
    }
 
@@ -659,16 +659,15 @@ TTreeCache::IOPos TTreeCache::FindBranchBasketPos(TBranch &b, Long64_t entry) {
    // are only interested in a single basket per branch - we don't try to fill the cache.
    Long64_t basketOffset = TMath::BinarySearch(blistsize, entries, entry);
    if (basketOffset < 0) { // No entry found.
-      //printf("No entry offset found for entry %ld\n", fTree->GetReadEntry());
+      // printf("No entry offset found for entry %ld\n", fTree->GetReadEntry());
       return IOPos{0, 0};
    }
 
    // Check to see if there's already a copy of this basket in memory.  If so, don't fetch it
-   if ((basketOffset < blistsize) &&
-           b.GetListOfBaskets()->UncheckedAt(basketOffset)) {
+   if ((basketOffset < blistsize) && b.GetListOfBaskets()->UncheckedAt(basketOffset)) {
 
-       //printf("Basket is already in memory.\n");
-       return IOPos{0, 0};
+      // printf("Basket is already in memory.\n");
+      return IOPos{0, 0};
    }
 
    Long64_t pos = b.GetBasketSeek(basketOffset);
@@ -679,10 +678,10 @@ TTreeCache::IOPos TTreeCache::FindBranchBasketPos(TBranch &b, Long64_t entry) {
          printf("Basket entry %d, first event %d, pos %ld\n", idx, entries[idx], b.GetBasketSeek(idx));
       }*/
       return IOPos{0, 0};
-    } // Sanity check
+   } // Sanity check
    // Do not cache a basket if it is bigger than the cache size!
    if (R__unlikely(len > fBufferSizeMin)) {
-      //printf("Basket size is greater than the cache size.\n");
+      // printf("Basket size is greater than the cache size.\n");
       return IOPos{0, 0};
    }
 
@@ -703,7 +702,8 @@ TTreeCache::IOPos TTreeCache::FindBranchBasketPos(TBranch &b, Long64_t entry) {
 ///   this IO operation.
 /// - If no corresponding branch could be found (or an error occurs), this
 ///   returns nullptr.
-TBranch *TTreeCache::CalculateMissEntries(Long64_t pos, Int_t len, Bool_t all) {
+TBranch *TTreeCache::CalculateMissEntries(Long64_t pos, Int_t len, Bool_t all)
+{
    if (R__unlikely((pos < 0) || (len < 0))) {
       return nullptr;
    }
@@ -714,11 +714,13 @@ TBranch *TTreeCache::CalculateMissEntries(Long64_t pos, Int_t len, Bool_t all) {
    Bool_t found_request = kFALSE;
    TBranch *resultBranch = nullptr;
    Long64_t entry = fTree->GetReadEntry();
-   //printf("Will search %d branches for basket at %ld.\n", count, pos);
-   for (int i=0; i<count; i++) {
-      TBranch *b = all ? static_cast<TBranch*>(static_cast<TLeaf*>((fTree->GetListOfLeaves())->UncheckedAt(i))->GetBranch()) : fMissCache->fBranches[i];
+   // printf("Will search %d branches for basket at %ld.\n", count, pos);
+   for (int i = 0; i < count; i++) {
+      TBranch *b =
+         all ? static_cast<TBranch *>(static_cast<TLeaf *>((fTree->GetListOfLeaves())->UncheckedAt(i))->GetBranch())
+             : fMissCache->fBranches[i];
       IOPos iopos = FindBranchBasketPos(*b, entry);
-      if (iopos.fLen == 0) {  // Error indicator
+      if (iopos.fLen == 0) { // Error indicator
          continue;
       }
       if (iopos.fPos == pos && iopos.fLen == len) {
@@ -737,7 +739,6 @@ TBranch *TTreeCache::CalculateMissEntries(Long64_t pos, Int_t len, Bool_t all) {
    return resultBranch;
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 ///
 /// Process a cache miss; (pos, len) isn't in the buffer.
@@ -745,14 +746,15 @@ TBranch *TTreeCache::CalculateMissEntries(Long64_t pos, Int_t len, Bool_t all) {
 /// The first time we have a miss, we buffer as many baskets we can (up to the
 /// maximum size of the TTreeCache) in memory from all branches that are not in
 /// the prefetch list.
-/// 
+///
 /// Subsequent times, we fetch all the buffers corresponding to branches that
 /// had previously seen misses.  If it turns out the (pos, len) isn't in the
 /// list of branches, we treat this as if it was the first miss.
 ///
 /// Returns true if we were able to pull the data into the miss cache.
 ///
-Bool_t TTreeCache::ProcessMiss(Long64_t pos, int len) {
+Bool_t TTreeCache::ProcessMiss(Long64_t pos, int len)
+{
 
    Bool_t firstMiss = kFALSE;
    if (fFirstMiss == -1) {
@@ -768,7 +770,7 @@ Bool_t TTreeCache::ProcessMiss(Long64_t pos, int len) {
          b = CalculateMissEntries(pos, len, kTRUE);
       }
       if (!b) {
-         //printf("ProcessMiss: pos %ld does not appear to correspond to a buffer in this file.\n", pos);
+         // printf("ProcessMiss: pos %ld does not appear to correspond to a buffer in this file.\n", pos);
          // We have gone through all the branches in this file and the requested basket
          // doesn't appear to be in any of them.  Likely a logic error / bug.
          fMissCache->fEntries.clear();
@@ -782,17 +784,19 @@ Bool_t TTreeCache::ProcessMiss(Long64_t pos, int len) {
    std::sort(fMissCache->fEntries.begin(), fMissCache->fEntries.end());
 
    // Now, fetch the buffer.
-   std::vector<Long64_t> positions; positions.reserve(fMissCache->fEntries.size());
-   std::vector<Int_t> lengths; lengths.reserve(fMissCache->fEntries.size());
+   std::vector<Long64_t> positions;
+   positions.reserve(fMissCache->fEntries.size());
+   std::vector<Int_t> lengths;
+   lengths.reserve(fMissCache->fEntries.size());
    ULong64_t cumulative = 0;
    for (auto &mcentry : fMissCache->fEntries) {
-         positions.push_back(mcentry.fIO.fPos);
-         lengths.push_back(mcentry.fIO.fLen);
-         mcentry.fIndex = cumulative;
-         cumulative += mcentry.fIO.fLen;
+      positions.push_back(mcentry.fIO.fPos);
+      lengths.push_back(mcentry.fIO.fLen);
+      mcentry.fIndex = cumulative;
+      cumulative += mcentry.fIO.fLen;
    }
    fMissCache->fData.reserve(cumulative);
-   //printf("Reading %lu bytes into miss cache for %lu entries.\n", cumulative, fEntries->size());
+   // printf("Reading %lu bytes into miss cache for %lu entries.\n", cumulative, fEntries->size());
    fNMissReadPref += fMissCache->fEntries.size();
    fFile->ReadBuffers(&(fMissCache->fData[0]), &(positions[0]), &(lengths[0]), fMissCache->fEntries.size());
    fFirstMiss = fLastMiss = fEntryCurrent;
@@ -807,7 +811,8 @@ Bool_t TTreeCache::ProcessMiss(Long64_t pos, int len) {
 /// Returns true if the IO operation was successful and the contents of buf
 /// were populated with the requested data.
 ///
-Bool_t TTreeCache::CheckMissCache(char *buf, Long64_t pos, int len) {
+Bool_t TTreeCache::CheckMissCache(char *buf, Long64_t pos, int len)
+{
 
    if (!fOptimizeMisses) {
       return kFALSE;
@@ -816,7 +821,7 @@ Bool_t TTreeCache::CheckMissCache(char *buf, Long64_t pos, int len) {
       return kFALSE;
    }
 
-   //printf("Checking the miss cache for offset=%ld, length=%d\n", pos, len);
+   // printf("Checking the miss cache for offset=%ld, length=%d\n", pos, len);
 
    // First, binary search to see if the desired basket is already cached.
    MissCache::Entry mcentry{IOPos{pos, len}};
@@ -829,17 +834,17 @@ Bool_t TTreeCache::CheckMissCache(char *buf, Long64_t pos, int len) {
       }
       auto offset = iter->fIndex;
       memcpy(buf, &(fMissCache->fData[offset]), len);
-      //printf("Returning data from pos=%ld in miss cache.\n", offset);
-      fNMissReadOk++;
+      // printf("Returning data from pos=%ld in miss cache.\n", offset);
+      ++fNMissReadOk;
       return kTRUE;
    }
 
-   //printf("Data not in miss cache.\n");
+   // printf("Data not in miss cache.\n");
 
    // Update the cache, looking for this (pos, len).
    if (!ProcessMiss(pos, len)) {
-      //printf("Unable to pull data into miss cache.\n");
-      fNMissReadMiss++;
+      // printf("Unable to pull data into miss cache.\n");
+      ++fNMissReadMiss;
       return kFALSE;
    }
 
@@ -849,15 +854,15 @@ Bool_t TTreeCache::CheckMissCache(char *buf, Long64_t pos, int len) {
 
    if (iter != fMissCache->fEntries.end()) {
       auto offset = iter->fIndex;
-      //printf("Expecting data at offset %ld in miss cache.\n", offset);
+      // printf("Expecting data at offset %ld in miss cache.\n", offset);
       memcpy(buf, &(fMissCache->fData[offset]), len);
-      fNMissReadOk++;
+      ++fNMissReadOk;
       return kTRUE;
    }
 
-   // This must be a logic bug.  ProcessMiss should return false if (pos, len) 
+   // This must be a logic bug.  ProcessMiss should return false if (pos, len)
    // wasn't put into fEntries.
-   fNMissReadMiss++;
+   ++fNMissReadMiss;
    return kFALSE;
 }
 
@@ -865,11 +870,11 @@ Bool_t TTreeCache::CheckMissCache(char *buf, Long64_t pos, int len) {
 /// End of methods for miss cache.
 ////////////////////////////////////////////////////////////////////////////////
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill the cache buffer with the branches in the cache.
 
-Bool_t TTreeCache::FillBuffer() {
+Bool_t TTreeCache::FillBuffer()
+{
 
    if (fNbranches <= 0) return kFALSE;
    TTree *tree = ((TBranch*)fBranches->UncheckedAt(0))->GetTree();
@@ -1211,7 +1216,9 @@ Double_t TTreeCache::GetEfficiency() const
 
 Double_t TTreeCache::GetMissEfficiency() const
 {
-   if ( !fNMissReadPref ) {return 0;}
+   if (!fNMissReadPref) {
+      return 0;
+   }
    return static_cast<double>(fNMissReadOk) / static_cast<double>(fNMissReadPref);
 }
 
@@ -1233,7 +1240,9 @@ Double_t TTreeCache::GetEfficiencyRel() const
 
 Double_t TTreeCache::GetMissEfficiencyRel() const
 {
-   if (!fNMissReadOk && !fNMissReadMiss) {return 0;}
+   if (!fNMissReadOk && !fNMissReadMiss) {
+      return 0;
+   }
 
    return static_cast<double>(fNMissReadOk) / static_cast<double>(fNMissReadOk + fNMissReadMiss);
 }
@@ -1314,7 +1323,9 @@ Int_t TTreeCache::ReadBufferNormal(char *buf, Long64_t pos, Int_t len){
 
       return res;
    }
-   if (CheckMissCache(buf, pos, len)) {return 1;}
+   if (CheckMissCache(buf, pos, len)) {
+      return 1;
+   }
 
    fNReadMiss++;
 

--- a/tree/tree/src/TTreeCache.cxx
+++ b/tree/tree/src/TTreeCache.cxx
@@ -266,29 +266,7 @@ ClassImp(TTreeCache);
 /// Default Constructor.
 
 TTreeCache::TTreeCache() : TFileCacheRead(),
-   fEntryMin(0),
-   fEntryMax(1),
-   fEntryCurrent(-1),
-   fEntryNext(-1),
-   fNbranches(0),
-   fNReadOk(0),
-   fNReadMiss(0),
-   fNReadPref(0),
-   fBranches(0),
-   fBrNames(0),
-   fTree(0),
-   fIsLearning(kTRUE),
-   fIsManual(kFALSE),
-   fFirstBuffer(kTRUE),
-   fOneTime(kFALSE),
-   fReverseRead(0),
-   fFillTimes(0),
-   fFirstTime(kTRUE),
-   fFirstEntry(-1),
-   fReadDirectionSet(kFALSE),
-   fEnabled(kTRUE),
-   fPrefillType(GetConfiguredPrefillType()),
-   fAutoCreated(kFALSE)
+   fPrefillType(GetConfiguredPrefillType())
 {
 }
 
@@ -296,29 +274,11 @@ TTreeCache::TTreeCache() : TFileCacheRead(),
 /// Constructor.
 
 TTreeCache::TTreeCache(TTree *tree, Int_t buffersize) : TFileCacheRead(tree->GetCurrentFile(),buffersize,tree),
-   fEntryMin(0),
    fEntryMax(tree->GetEntriesFast()),
-   fEntryCurrent(-1),
    fEntryNext(0),
-   fNbranches(0),
-   fNReadOk(0),
-   fNReadMiss(0),
-   fNReadPref(0),
-   fBranches(0),
    fBrNames(new TList),
    fTree(tree),
-   fIsLearning(kTRUE),
-   fIsManual(kFALSE),
-   fFirstBuffer(kTRUE),
-   fOneTime(kFALSE),
-   fReverseRead(0),
-   fFillTimes(0),
-   fFirstTime(kTRUE),
-   fFirstEntry(-1),
-   fReadDirectionSet(kFALSE),
-   fEnabled(kTRUE),
-   fPrefillType(GetConfiguredPrefillType()),
-   fAutoCreated(kFALSE)
+   fPrefillType(GetConfiguredPrefillType())
 {
    fEntryNext = fEntryMin + fgLearnEntries;
    Int_t nleaves = tree->GetListOfLeaves()->GetEntries();

--- a/tree/tree/src/TTreeCache.cxx
+++ b/tree/tree/src/TTreeCache.cxx
@@ -258,19 +258,6 @@ of effective system reads for a given file with a code like
 #include "TMath.h"
 #include <limits.h>
 
-// TODO: Copied from TBranch.cxx
-#if (__GNUC__ >= 3) || defined(__INTEL_COMPILER)
-#if !defined(R__unlikely)
-  #define R__unlikely(expr) __builtin_expect(!!(expr), 0)
-#endif
-#if !defined(R__likely)
-  #define R__likely(expr) __builtin_expect(!!(expr), 1)
-#endif
-#else
-  #define R__unlikely(expr) expr
-  #define R__likely(expr) expr
-#endif
-
 Int_t TTreeCache::fgLearnEntries = 100;
 
 ClassImp(TTreeCache);


### PR DESCRIPTION
The _miss cache_, implemented in this pull request, implements an optimization when the TTreeCache fails to work.

The miss cache will keep track of any branch that has been accessed; when there is a TTC miss, it automatically fetches the current basket for all active branches.  This should have a worst case read size equal to the size of the file's cluster size, but potentially a significant savings in the number of IO operations.  The latter is extremely useful if we're doing IO on high-latency links.

This optimization works well for the "trigger pattern," where the user may examine a number of branches and, when the event contents for those branches passes a particular filter, reads out the remaining branches.  If there are 100 additional branches, this would do all reads in a single network round-trip as opposed to 100 round trips.

The approach has served us well in CMS and been utilized as a layer on top of ROOT for about 3 years.

Unfortunately, we must iterate through a set of branches and find the correct basket.  This is not necessarily a cheap CPU operation and may be too expensive if the underlying filesystem is SSD-based.  Hence, we turn this optimization off by default.
