### PR TITLE
[TMVA/BDT] some head scratchers I stumbled over

### DIFF
--- a/tmva/tmva/inc/TMVA/BinarySearchTreeNode.h
+++ b/tmva/tmva/inc/TMVA/BinarySearchTreeNode.h
@@ -104,11 +104,12 @@ namespace TMVA {
       virtual void AddAttributesToNode(void* node) const;
       virtual void AddContentToNode(std::stringstream& s) const;
 
-   private: 
       // Read the data block
-      virtual void ReadAttributes(void* node, UInt_t tmva_Version_Code = TMVA_VERSION_CODE );
       virtual Bool_t ReadDataRecord( std::istream& is, UInt_t tmva_Version_Code = TMVA_VERSION_CODE );
+      virtual void ReadAttributes(void* node, UInt_t tmva_Version_Code = TMVA_VERSION_CODE );
       virtual void ReadContent(std::stringstream& s);
+
+   private: 
       std::vector<Float_t> fEventV;
       std::vector<Float_t> fTargets;
 

--- a/tmva/tmva/inc/TMVA/CCTreeWrapper.h
+++ b/tmva/tmva/inc/TMVA/CCTreeWrapper.h
@@ -123,14 +123,13 @@ namespace TMVA {
          // test event if it decends the tree at this node to the left 
          inline virtual Bool_t GoesLeft ( const Event& e ) const { return (GetDTNode() != NULL ? 
                                                                            GetDTNode()->GoesLeft(e) : false); }
+         // initialize a node from a data record
+         virtual void ReadAttributes(void* node, UInt_t tmva_Version_Code = TMVA_VERSION_CODE);
+         virtual void ReadContent(std::stringstream& s);
+         virtual Bool_t ReadDataRecord( std::istream& in, UInt_t tmva_Version_Code = TMVA_VERSION_CODE );
       
       private:
 
-         // initialize a node from a data record
-         virtual void ReadAttributes(void* node, UInt_t tmva_Version_Code = TMVA_VERSION_CODE);
-         virtual Bool_t ReadDataRecord( std::istream& in, UInt_t tmva_Version_Code = TMVA_VERSION_CODE );
-         virtual void ReadContent(std::stringstream& s);
-         
          Int_t fNLeafDaughters; //! number of terminal descendants
          Double_t fNodeResubstitutionEstimate; //! R(t) = misclassification rate for node t
          Double_t fResubstitutionEstimate; //! R(T_t) = sum[t' in ~T_t]{ R(t) }

--- a/tmva/tmva/inc/TMVA/DecisionTreeNode.h
+++ b/tmva/tmva/inc/TMVA/DecisionTreeNode.h
@@ -353,6 +353,10 @@ namespace TMVA {
       static bool fgIsTraining; // static variable to flag training phase in which we need fTrainInfo
       static UInt_t fgTmva_Version_Code;  // set only when read from weightfile 
 
+      virtual Bool_t ReadDataRecord( std::istream& is, UInt_t tmva_Version_Code = TMVA_VERSION_CODE );
+      virtual void ReadAttributes(void* node, UInt_t tmva_Version_Code = TMVA_VERSION_CODE );
+      virtual void ReadContent(std::stringstream& s);
+
    protected:
 
       static MsgLogger& Log();
@@ -373,10 +377,6 @@ namespace TMVA {
       mutable DTNodeTrainingInfo* fTrainInfo;
 
    private:
-
-      virtual void ReadAttributes(void* node, UInt_t tmva_Version_Code = TMVA_VERSION_CODE );
-      virtual Bool_t ReadDataRecord( std::istream& is, UInt_t tmva_Version_Code = TMVA_VERSION_CODE );
-      virtual void ReadContent(std::stringstream& s);
 
       ClassDef(DecisionTreeNode,0); // Node for the Decision Tree 
    };

--- a/tmva/tmva/src/MethodBDT.cxx
+++ b/tmva/tmva/src/MethodBDT.cxx
@@ -1714,7 +1714,6 @@ Double_t TMVA::MethodBDT::AdaBoost( std::vector<const TMVA::Event*>& eventSample
    Double_t err=0, sumGlobalw=0, sumGlobalwfalse=0, sumGlobalwfalse2=0;
 
    std::vector<Double_t> sumw(DataInfo().GetNClasses(),0); //for individually re-scaling  each class
-   std::map<Node*,Int_t> sigEventsInNode; // how many signal events of the training tree
 
    Double_t maxDev=0;
    for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();e++) {
@@ -1898,7 +1897,6 @@ Double_t TMVA::MethodBDT::AdaCost( vector<const TMVA::Event*>& eventSample, Deci
    Double_t err=0, sumGlobalWeights=0, sumGlobalCost=0;
 
    std::vector<Double_t> sumw(DataInfo().GetNClasses(),0);      //for individually re-scaling  each class
-   std::map<Node*,Int_t> sigEventsInNode; // how many signal events of the training tree
 
    for (vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();e++) {
       Double_t w = (*e)->GetWeight();


### PR DESCRIPTION
A few items that surprised me when digging through the tmva code:
the Read.... methods are public virtual in the base class `Node` but private in the derived classes

The `sigEventsInNode` looks unused to me (and i have no clue why the compiler doesn't issue a warning).