### PR TITLE
Small change to TTree::OptimizeBaskets to avoid disc reads

### DIFF
--- a/README/ReleaseNotes/v610/index.md
+++ b/README/ReleaseNotes/v610/index.md
@@ -84,6 +84,7 @@ The following interfaces have been removed, after deprecation in v6.08.
 - `TTree::Branch()` now complains for wrong leaf list strings, e.g. "value/F[4]" (which should really be spelled as "value[4]/F").
 - Allow reading of older version of TTreePerfStats (ROOT-8520)
 - Introduce TDataFrame which offers a new and highly efficient way to analyse data stored in TTrees
+- In `TTree::OptimizeBaskets()` do not call GetBasket(0) to avoid disc reads
 
 ## 2D Graphics Libraries
 - If one used "col2" or "colz2", the value of `TH1::fMaximum` got modified.

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -6689,7 +6689,7 @@ void TTree::OptimizeBaskets(ULong64_t maxMemory, Float_t minComp, Option_t *opti
          if (bsize > bmax) bsize = bmax;
          UInt_t newBsize = UInt_t(bsize);
          if (pass) { // only on the second pass so that it doesn't interfere with scaling
-            newBsize = newBsize + (fEntries * sizeof(Int_t) * 2); // make room for meta data
+            newBsize = newBsize + (branch->GetEntries() * sizeof(Int_t) * 2); // make room for meta data
             // We used ATLAS fully-split xAOD for testing, which is a rather unbalanced TTree, 10K branches,
             // with 8K having baskets smaller than 512 bytes. To achieve good I/O performance ATLAS uses auto-flush 100,
             // resulting in the smallest baskets being ~300-400 bytes, so this change increases their memory by about 8k*150B =~ 1MB,

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -6689,9 +6689,7 @@ void TTree::OptimizeBaskets(ULong64_t maxMemory, Float_t minComp, Option_t *opti
          if (bsize > bmax) bsize = bmax;
          UInt_t newBsize = UInt_t(bsize);
          if (pass) { // only on the second pass so that it doesn't interfere with scaling
-            if (branch->GetBasket(0) != 0) {
-               newBsize = newBsize + (branch->GetBasket(0)->GetNevBuf() * sizeof(Int_t) * 2); // make room for meta data
-            }
+            newBsize = newBsize + (fEntries * sizeof(Int_t) * 2); // make room for meta data
             // We used ATLAS fully-split xAOD for testing, which is a rather unbalanced TTree, 10K branches,
             // with 8K having baskets smaller than 512 bytes. To achieve good I/O performance ATLAS uses auto-flush 100,
             // resulting in the smallest baskets being ~300-400 bytes, so this change increases their memory by about 8k*150B =~ 1MB,


### PR DESCRIPTION
Hi,

when doing some more testing on the OptimizeBaskets() changes made last year, I found that getting the numbers of entries in the basket causes a disc read for each branch. This could be expensive and it is better to use the numbers of entries in the tree instead, as  OptimizeBaskets() is called only on the first flush and most branches will have only one basket. Larger branches, may have more baskets, but overestimating their size by a few bytes is still a good approximation (and much better than an additional 4,000 disc reads (e.g. for ATLAS xAOD)).

Thanks, Peter