### PR TITLE
Multiclass ROC

### DIFF
--- a/tmva/tmva/inc/TMVA/Factory.h
+++ b/tmva/tmva/inc/TMVA/Factory.h
@@ -159,10 +159,11 @@ namespace TMVA {
       Double_t GetROCIntegral(DataLoader *loader,TString theMethodName);
       Double_t GetROCIntegral(TString  datasetname,TString theMethodName);
 
-      //methods to get TGraph for a indicate method in dataset
-      //optional tiitle and axis added with fLegend=kTRUE
-      TGraph* GetROCCurve(DataLoader *loader,TString theMethodName,Bool_t fLegend=kTRUE);
-      TGraph* GetROCCurve(TString  datasetname,TString theMethodName,Bool_t fLegend=kTRUE);
+      // Methods to get a TGraph for an indicated method in dataset.
+      // Optional title and axis added with fLegend=kTRUE.
+      // Argument iClass used in multiclass settings, otherwise ignored.
+      TGraph* GetROCCurve(DataLoader *loader,TString theMethodName, Bool_t fLegend=kTRUE, UInt_t iClass=0);
+      TGraph* GetROCCurve(TString datasetname, TString theMethodName, Bool_t fLegend=kTRUE, UInt_t iClass=0);
       
       // Draw all ROC curves for all methods in the dataset.
       TCanvas* GetROCCurve(DataLoader *loader);

--- a/tmva/tmva/inc/TMVA/Factory.h
+++ b/tmva/tmva/inc/TMVA/Factory.h
@@ -162,8 +162,8 @@ namespace TMVA {
       // Methods to get a TGraph for an indicated method in dataset.
       // Optional title and axis added with fLegend=kTRUE.
       // Argument iClass used in multiclass settings, otherwise ignored.
-      TGraph* GetROCCurve(DataLoader *loader,TString theMethodName, Bool_t fLegend=kTRUE, UInt_t iClass=0);
-      TGraph* GetROCCurve(TString datasetname, TString theMethodName, Bool_t fLegend=kTRUE, UInt_t iClass=0);
+      TGraph* GetROCCurve(DataLoader *loader,TString theMethodName, Bool_t useLegend=kTRUE, UInt_t iClass=0);
+      TGraph* GetROCCurve(TString datasetname, TString theMethodName, Bool_t useLegend=kTRUE, UInt_t iClass=0);
       
       // Draw all ROC curves for all methods in the dataset.
       TCanvas* GetROCCurve(DataLoader *loader);

--- a/tmva/tmva/inc/TMVA/Factory.h
+++ b/tmva/tmva/inc/TMVA/Factory.h
@@ -133,7 +133,8 @@ namespace TMVA {
       void DeleteAllMethods( void );
 
       // accessors
-      IMethod* GetMethod( const TString& datasetname, const TString& title )const;
+      IMethod* GetMethod( const TString& datasetname, const TString& title ) const;
+      Bool_t   HasMethod( const TString& datasetname, const TString& title ) const;
 
       Bool_t Verbose( void ) const { return fVerbose; }
       void SetVerbose( Bool_t v=kTRUE );

--- a/tmva/tmva/inc/TMVA/Factory.h
+++ b/tmva/tmva/inc/TMVA/Factory.h
@@ -67,12 +67,13 @@
 #include "TMVA/DataSet.h"
 #endif
 
-class TFile;
-class TTree;
-class TDirectory;
 class TCanvas;
+class TDirectory;
+class TFile;
 class TGraph;
 class TH1F;
+class TMultiGraph;
+class TTree;
 namespace TMVA {
 
    class IMethod;
@@ -162,12 +163,16 @@ namespace TMVA {
       // Methods to get a TGraph for an indicated method in dataset.
       // Optional title and axis added with fLegend=kTRUE.
       // Argument iClass used in multiclass settings, otherwise ignored.
-      TGraph* GetROCCurve(DataLoader *loader,TString theMethodName, Bool_t useLegend=kTRUE, UInt_t iClass=0);
-      TGraph* GetROCCurve(TString datasetname, TString theMethodName, Bool_t useLegend=kTRUE, UInt_t iClass=0);
+      TGraph* GetROCCurve(DataLoader *loader, TString theMethodName, Bool_t setTitles=kTRUE, UInt_t iClass=0);
+      TGraph* GetROCCurve(TString datasetname, TString theMethodName, Bool_t setTitles=kTRUE, UInt_t iClass=0);
+
+      // Methods to get a TMultiGraph for a given class and all methods in dataset.
+      TMultiGraph* GetROCCurveAsMultiGraph(DataLoader *loader, UInt_t iClass);
+      TMultiGraph* GetROCCurveAsMultiGraph(TString datasetname, UInt_t iClass);
       
-      // Draw all ROC curves for all methods in the dataset.
-      TCanvas* GetROCCurve(DataLoader *loader);
-      TCanvas* GetROCCurve(TString datasetname);
+      // Draw all ROC curves of a given class for all methods in the dataset.
+      TCanvas* GetROCCurve(DataLoader *loader, UInt_t iClass=0);
+      TCanvas* GetROCCurve(TString datasetname, UInt_t iClass=0);
 
    private:
 


### PR DESCRIPTION
Adding support for generation of multiclass 1 vs. all ROC curve plots.

I also have two files for testing the binary and multiclass code paths, but am unsure of where to put these if anywhere. They are 2 standalone cxx files to generate data, train classifiers, draw the roc curves and succeeds if they do not crash.