### PR TITLE
Fix cxxmodules build failing because of rtti-requirement in Rtypes.h

### DIFF
--- a/build/unix/module.modulemap
+++ b/build/unix/module.modulemap
@@ -18,11 +18,20 @@ module ROOT_Types {
   export *
 }
 
+module ROOT_IsAProxy {
+ module "TIsAProxy.h" { header "TIsAProxy.h" export * }
+ module "TVirtualIsAProxy.h" { header "TVirtualIsAProxy.h" export * }
+ export *
+}
+
 // This module is special, it contains headers which don't require rtti support
 // to build (eg. don't use dynamic_cast or typeid). They are also needed when
 // compiling rootcling with -fno-rtti. We have to keep them outside module ROOT
 // to avoid -fno-rtti invocation to trigger building of entire module ROOT
 // some of whose headers require -frtti.
+// Rtypes.h however has an optional dependency on rtti unless one defines
+// R__NO_INLINE_CLASSDEF. We therefore keep two versions of this module: One
+// with rtti and one without rtti.
 module ROOT_Core_Config_C {
  //requires cplusplus
  
@@ -42,6 +51,8 @@ module ROOT_Core_Config_C {
  // Should we marked textual because of inclusion libcpp_string_view.h,
  // using macros to set up the header file.
  module "RWrap_libcpp_string_view.h" {  textual header "RWrap_libcpp_string_view.h" export * }
+
+ config_macros R__NO_INLINE_CLASSDEF
 
  export *
 }

--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -425,6 +425,7 @@ function (ROOT_CXXMODULES_APPEND_TO_MODULEMAP library library_headers)
 
   set(excluded_headers "RConfig.h RVersion.h RtypesImp.h TVersionCheck.h
                         Rtypes.h RtypesCore.h TClassEdit.h
+                        TIsAProxy.h TVirtualIsAProxy.h
                         DllImport.h TGenericClassInfo.h
                         TSchemaHelper.h ESTLType.h RStringView.h Varargs.h
                         RootMetaSelection.h libcpp_string_view.h

--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -183,7 +183,6 @@ namespace ROOT {
 // The macros below use TGenericClassInfo and TInstrumentedIsAProxy, so let's
 // ensure they are included.
 #include "TGenericClassInfo.h"
-#include "TIsAProxy.h"
 
 typedef std::atomic<TClass*> atomic_TClass_ptr;
 
@@ -191,6 +190,8 @@ typedef std::atomic<TClass*> atomic_TClass_ptr;
 // Hide the following declaration (that is only needed by ClassDefInline) for
 // these cases by #defining R__NO_INLINE_CLASSDEF:
 #ifndef R__NO_INLINE_CLASSDEF
+
+#include "TIsAProxy.h"
 
 namespace ROOT { namespace Internal {
 struct TTypeNameExtractionBase {

--- a/core/dictgen/CMakeLists.txt
+++ b/core/dictgen/CMakeLists.txt
@@ -19,9 +19,9 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CLING_CXXFLAGS}")
 CHECK_CXX_COMPILER_FLAG("-fno-rtti" CXX_HAS_fno_rtti)
 if(CXX_HAS_fno_rtti)
-    set_source_files_properties(src/rootcling_impl.cxx   PROPERTIES COMPILE_FLAGS "-fno-rtti")
-    set_source_files_properties(src/LinkdefReader.cxx    PROPERTIES COMPILE_FLAGS "-fno-rtti")
-    set_source_files_properties(src/TModuleGenerator.cxx PROPERTIES COMPILE_FLAGS "-fno-rtti")
+    set_source_files_properties(src/rootcling_impl.cxx   PROPERTIES COMPILE_FLAGS "-fno-rtti -DR__NO_INLINE_CLASSDEF")
+    set_source_files_properties(src/LinkdefReader.cxx    PROPERTIES COMPILE_FLAGS "-fno-rtti -DR__NO_INLINE_CLASSDEF")
+    set_source_files_properties(src/TModuleGenerator.cxx PROPERTIES COMPILE_FLAGS "-fno-rtti -DR__NO_INLINE_CLASSDEF")
 endif()
 
 ROOT_OBJECT_LIBRARY(Dictgen

--- a/core/meta/inc/TIsAProxy.h
+++ b/core/meta/inc/TIsAProxy.h
@@ -13,8 +13,9 @@
 #define ROOT_TIsAProxy
 
 #include "TVirtualIsAProxy.h"
-#include "Rtypes.h"
+#include "RtypesCore.h"
 #include <atomic>
+#include <typeinfo>
 
 class TClass;
 

--- a/core/metacling/CMakeLists.txt
+++ b/core/metacling/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CLING_CXXFLAGS}")
 if(MSVC)
 set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/src/TClingCallbacks.cxx COMPILE_FLAGS -GR-)
 else()
-set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/src/TClingCallbacks.cxx COMPILE_FLAGS -fno-rtti)
+set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/src/TClingCallbacks.cxx PROPERTIES COMPILE_FLAGS "-fno-rtti -DR__NO_INLINE_CLASSDEF")
 endif()
 
 # This to avoid warning coming from  message coming from llvm/src/tools/clang/include/clang/Sema/Lookup.h:441

--- a/interpreter/cling/CMakeLists.txt
+++ b/interpreter/cling/CMakeLists.txt
@@ -213,7 +213,7 @@ string(REPLACE "-fvisibility=hidden" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
 if(MSVC)
   add_definitions(/GR- /DNOMINMAX)
 else()
-  add_definitions(-fno-rtti)
+  add_definitions(-fno-rtti -DR__NO_INLINE_CLASSDEF)
 endif()
 
 if (APPLE)


### PR DESCRIPTION
This PR contains the approach with using config_macro to generate a RTTI and a non-RTTI module