### PR TITLE
Add and apply the new TThreadExecutor::Foreach interface

### DIFF
--- a/core/thread/inc/ROOT/TThreadExecutor.hxx
+++ b/core/thread/inc/ROOT/TThreadExecutor.hxx
@@ -108,7 +108,7 @@ namespace ROOT {
    /// fixed arguments) by wrapping them in a lambda or with std::bind.
    template<class F>
    void TThreadExecutor::Foreach(F func, unsigned nTimes) {
-       ParallelFor(0U, nTimes, 1, [&](unsigned int i){func();});
+       ParallelFor(0U, nTimes, 1, [&](unsigned int){func();});
    }
 
    //////////////////////////////////////////////////////////////////////////

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -4880,7 +4880,7 @@ Int_t TTree::FlushBaskets() const
         Int_t j = pos.fetch_add(1);
 
         auto branch = fSortedBranches[j].second;
-        if (R__unlikely(!branch)) { return 0; }
+        if (R__unlikely(!branch)) { return; }
 
         if (R__unlikely(gDebug > 0)) {
             std::stringstream ss;
@@ -4893,11 +4893,10 @@ Int_t TTree::FlushBaskets() const
 
         if (nbtask < 0) { nerrpar++; }
         else            { nbpar += nbtask; }
-        return 0;
       };
 
       ROOT::TThreadExecutor pool;
-      pool.Map(mapFunction, nb);
+      pool.Foreach(mapFunction, nb);
 
       fIMTFlush = false;
       const_cast<TTree*>(this)->AddTotBytes(fIMTTotBytes);
@@ -5378,11 +5377,10 @@ Int_t TTree::GetEntry(Long64_t entry, Int_t getall)
 
             if (nbtask < 0) errnb = nbtask;
             else            nbpar += nbtask;
-            return 0;
          };
 
       ROOT::TThreadExecutor pool;
-      pool.Map(mapFunction, nbranches);
+      pool.Foreach(mapFunction, nbranches);
 
       if (errnb < 0) {
          nb = errnb;

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -95,10 +95,9 @@ void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
       treeView->SetCurrent(std::get<2>(t));
       auto tr = treeView->GetTreeReader(std::get<0>(t), std::get<1>(t));
       func(*tr);
-      return 0;
    };
 
    // Assume number of threads has been initialized via ROOT::EnableImplicitMT
    TThreadExecutor pool;
-   pool.Map(mapFunction, vTuple);
+   pool.Foreach(mapFunction, vTuple);
 }


### PR DESCRIPTION
This will be the interface to apply for void returning functions (or when you have no need to return the map vector -this implies no reduction- and want to save some space)