### PR TITLE
Fixed redifinition error on 'Compare'

### DIFF
--- a/math/mathcore/test/stdsort.cxx
+++ b/math/mathcore/test/stdsort.cxx
@@ -28,6 +28,7 @@ bool showGraphics = false;
 bool verbose = false;
 //std::string plotFile;
 
+namespace {
 template<typename T>
 struct Compare {
 
@@ -39,6 +40,7 @@ struct Compare {
 
    const T * fData;
 };
+}
 
 template <typename T> bool testSort(const int n, double* tTMath, double* tStd)
 {


### PR DESCRIPTION
We have another class with the name Compare in TMatrixTBase.h, so we add a
anonymous namespace here that we don't fail on this test when building with
enabled modules.