### PR TITLE
Fix for test if i686

### DIFF
--- a/math/mathmore/test/testSpecFunc.cxx
+++ b/math/mathmore/test/testSpecFunc.cxx
@@ -186,7 +186,7 @@ int testSpecFunc() {
 
    iret |= compare("hyperg(8, -8, 1, 0.5) ", hyperg(8, -8, 1, 0.5), 0.13671875);
 
-   iret |= compare("laguerre(4, 1.) ", laguerre(4, 1.), -0.6250); // need to find more precise value
+   iret |= compare("laguerre(4, 1.) ", laguerre(4, 1.), -0.6250, 4); // need to find more precise value
 
    iret |= compare("legendre(10, -0.5) ", legendre(10, -0.5), -0.1882286071777345);
 


### PR DESCRIPTION
This fixes a test failure on i686:

     95/593 Test  #45: mathmore-testSpecFunc ......................................***Failed    0.40 sec
    tgamma(9.0)                                       :	 OK
    lgamma(0.1)                                       :	 OK
    inc_gamma(1,0.001)                                :	 OK
    inc_gamma(100,99)                                 :	 OK
    inc_gamma_c(100,99)                               :	 OK
    inc_gamma_c(1000,1000.1)                          :	 OK
    erf(0.5)                                          :	 OK
    erfc(-1.0)                                        :	 OK
    beta(1.0, 5.0)                                    :	 OK
    inc_beta(1,1,1)                                   :	 OK
    inc_beta(0.5,0.1,1.0)                             :	 OK
    assoc_laguerre(4,  2, 0.5)                        :	 OK
    assoc_legendre(10, 1, -0.5)                       :	 OK
    comp_ellint_1(0.50)                               :	 OK
    comp_ellint_2(0.50)                               :	 OK
    comp_ellint_3(0.5, 0.5)                           :	 OK
    conf_hyperg(1, 1.5, 1)                            :	 OK
    cyl_bessel_i(1.0, 1.0)                            :	 OK
    cyl_bessel_j(0.75, 1.0)                           :	 OK
    cyl_bessel_k(1.0, 1.0)                            :	 OK
    cyl_neumann(0.75, 1.0)                            :	 OK
    ellint_1(0.50, PI/3.0)                            :	 OK
    ellint_2(0.50, PI/3.0)                            :	 OK
    ellint_3(-0.50, 0.5, PI/3.0)                      :	 OK
    expint(1.0)                                       :	 OK
    hyperg(8, -8, 1, 0.5)                             :	 OK
    laguerre(4, 1.)                                   :	 FAILED 
    Discrepancy in laguerre(4, 1.) () :
      -0.625000000000000555 != -0.625 discr = 1   (Allowed discrepancy is 4.44089209850062616e-16)
    legendre(10, -0.5)                                :	 OK
    riemann_zeta(-0.5)                                :	 OK
    sph_bessel(1, 10.0)                               :	 OK
    sph_legendre(3, 1, PI/2.)                         :	 OK
    sph_neumann(0, 1.0)                               :	 OK
    airy_Ai(-0.5)                                     :	 OK
    airy_Bi(0.5)                                      :	 OK
    airy_Ai_deriv(-2)                                 :	 OK
    airy_Bi_deriv(-3)                                 :	 OK
    airy_zero_Ai(2)                                   :	 OK
    airy_zero_Bi(2)                                   :	 OK
    airy_zero_Ai_deriv(2)                             :	 OK
    airy_zero_Bi_deriv(2)                             :	 OK
    Error:  Special Functions Test FAILED !!!!!
    CMake Error at /builddir/build/BUILD/root-6.08.06/cmake/modules/RootTestDriver.cmake:201 (message):
      error code: 1
