### PR TITLE
Only download test data if running the test that needs them

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -247,13 +247,14 @@ ROOT_EXECUTABLE(stressHepix stressHepix.cxx LIBRARIES Core)
 
 #--stressProof-------------------------------------------------------------------------------
 if(NOT WIN32)
-  add_custom_target(TestData ALL COMMAND ${CMAKE_COMMAND} -DDST=${CMAKE_SOURCE_DIR}/files -P ${CMAKE_CURRENT_SOURCE_DIR}/rootDownloadData.cmake)
+  add_custom_target(TestData COMMAND ${CMAKE_COMMAND} -DDST=${CMAKE_SOURCE_DIR}/files -P ${CMAKE_CURRENT_SOURCE_DIR}/rootDownloadData.cmake)
   ROOT_EXECUTABLE(stressProof stressProof.cxx LIBRARIES Proof ProofPlayer Hist)
   ROOT_ADD_TEST(test-stressproof COMMAND stressProof lite://
                                          -h1 ${CMAKE_SOURCE_DIR}/files/h1 -event ${CMAKE_SOURCE_DIR}/files/event
                                          -l /tmp/stressProof-%d.log -cleanlog -catlog -noprogress
                                          ENVIRONMENT PATH=${CMAKE_BINARY_DIR}/bin:$ENV{PATH}
-                                         FAILREGEX "FAILED|Error in")
+                                         FAILREGEX "FAILED|Error in"
+                                         DEPENDS TestData)
 endif()
 
 #--testbits----------------------------------------------------------------------------------

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -249,12 +249,12 @@ ROOT_EXECUTABLE(stressHepix stressHepix.cxx LIBRARIES Core)
 if(NOT WIN32)
   add_custom_target(TestData COMMAND ${CMAKE_COMMAND} -DDST=${CMAKE_SOURCE_DIR}/files -P ${CMAKE_CURRENT_SOURCE_DIR}/rootDownloadData.cmake)
   ROOT_EXECUTABLE(stressProof stressProof.cxx LIBRARIES Proof ProofPlayer Hist)
-  ROOT_ADD_TEST(test-stressproof COMMAND stressProof lite://
+  ROOT_ADD_TEST(test-stressproof PRECMD ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target TestData
+                                 COMMAND stressProof lite://
                                          -h1 ${CMAKE_SOURCE_DIR}/files/h1 -event ${CMAKE_SOURCE_DIR}/files/event
                                          -l /tmp/stressProof-%d.log -cleanlog -catlog -noprogress
                                          ENVIRONMENT PATH=${CMAKE_BINARY_DIR}/bin:$ENV{PATH}
-                                         FAILREGEX "FAILED|Error in"
-                                         DEPENDS TestData)
+                                         FAILREGEX "FAILED|Error in")
 endif()
 
 #--testbits----------------------------------------------------------------------------------


### PR DESCRIPTION
The TestData target is currently declared ALL, which means it is always executed during the build.
However, the data it downloads is only used for running the stressProof test, so if this test is not run the downloaded data files are not needed.

By removing the TestData target from ALL and making it a requirement of the test-stressproof target instead, the files are only downloaded if they are needed. Disabling the stressProof test now also disables the download of the data files. This is important when building in an environment without network access.
