### PR TITLE
Use file cache when accessing remote files during testing

### DIFF
--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -2330,8 +2330,8 @@ Begin_Macro(source)
    Double_t lat2 = 50;
    TH2Poly *p = new TH2Poly("USA","USA Population",lon1,lon2,lat1,lat2);
 
-   TFile *f;
-   f = TFile::Open("http://root.cern.ch/files/usa.root");
+   TFile::SetCacheFileDir(".");
+   TFile *f = TFile::Open("http://root.cern.ch/files/usa.root", "CACHEREAD");
 
    TMultiGraph *mg;
    TKey *key;

--- a/test/stressGraphics.cxx
+++ b/test/stressGraphics.cxx
@@ -1984,7 +1984,8 @@ void th2poly()
    Double_t lat2 = 50;
    TH2Poly *p = new TH2Poly("USA","USA Population",lon1,lon2,lat1,lat2);
 
-   TFile *f = TFile::Open("http://root.cern.ch/files/usa.root");
+   TFile::SetCacheFileDir(".");
+   TFile *f = TFile::Open("http://root.cern.ch/files/usa.root", "CACHEREAD");
 
    if (!f) {
       printf("Cannot access usa.root. Is internet working ?\n");

--- a/test/stressHistogram.cxx
+++ b/test/stressHistogram.cxx
@@ -10215,7 +10215,8 @@ int stressHistogram()
       refFile = TFile::Open(refFileName, "RECREATE");
    }
    else {
-      refFile = TFile::Open(refFileName);
+      TFile::SetCacheFileDir(".");
+      refFile = TFile::Open(refFileName, "CACHEREAD");
    }
 
    if ( refFile != 0 ) {

--- a/test/stressRooFit.cxx
+++ b/test/stressRooFit.cxx
@@ -78,10 +78,11 @@ Int_t stressRooFit(const char* refFile, Bool_t writeRef, Int_t doVerbose, Int_t 
          cout << "stressRooFit ERROR: reference file must be local file in writing mode" << endl ;
          return 1;
       }
-      fref = new TWebFile(refFile) ;
+      TFile::SetCacheFileDir(".");
+      fref = TFile::Open(refFile,"CACHEREAD") ;
       //std::cout << "using WEB file " << refFile << std::endl;
     } else {
-      fref = new TFile(refFile,writeRef?"RECREATE":"") ;
+      fref = TFile::Open(refFile,writeRef?"RECREATE":"") ;
       //std::cout << "using file " << refFile << std::endl;
     }
     if (fref->IsZombie()) {

--- a/test/stressTMVA.cxx
+++ b/test/stressTMVA.cxx
@@ -2018,21 +2018,15 @@ void MethodUnitTestWithROCLimits::run()
   dataloader->AddVariable( _VariableNames->at(3),                "Variable 4", "units", 'F' );
 
   TFile* input(0);
-
   FileStat_t stat;
 
-  TString fname = "../tmva/test/data/toy_sigbkg.root"; //tmva_example.root";
-  const char *fcname = gSystem->ExpandPathName("$ROOTSYS/tmva/test/data/toy_sigbkg.root");
+  TString fname = "./tmva_class_example.root";
   if(!gSystem->GetPathInfo(fname,stat)) {
      input = TFile::Open( fname );
-  } else if(!gSystem->GetPathInfo("../"+fname,stat)) {
-     input = TFile::Open( "../"+fname );
-  } else if(fcname && !gSystem->GetPathInfo(fcname,stat)) {
-     input = TFile::Open( fcname );
   } else {
-     input = TFile::Open( "http://root.cern.ch/files/tmva_class_example.root" );
+     TFile::SetCacheFileDir(".");
+     input = TFile::Open("http://root.cern.ch/files/tmva_class_example.root", "CACHEREAD");
   }
-  delete [] fcname;
   if (input == NULL) {
      cerr << "broken/inaccessible input file" << endl;
   }
@@ -2449,14 +2443,12 @@ void RegressionUnitTestWithDeviation::run()
    TFile* input(0);
    FileStat_t stat;
 
-   // FIXME:: give the filename of the sample somewhere else?
-   TString fname = "../tmva/test/tmva_reg_example.root";
+   TString fname = "./tmva_reg_example.root";
    if(!gSystem->GetPathInfo(fname,stat)) {
       input = TFile::Open( fname );
-   } else if(!gSystem->GetPathInfo("../"+fname,stat)) {
-      input = TFile::Open( "../"+fname );
    } else {
-      input = TFile::Open( "http://root.cern.ch/files/tmva_reg_example.root" );
+      TFile::SetCacheFileDir(".");
+      input = TFile::Open("http://root.cern.ch/files/tmva_reg_example.root", "CACHEREAD");
    }
    if (input == NULL) {
       cerr << "broken/inaccessible input file" << endl;

--- a/tmva/pymva/test/Classification.C
+++ b/tmva/pymva/test/Classification.C
@@ -27,23 +27,26 @@ void Classification()
    TMVA::Factory *factory = new TMVA::Factory("TMVAClassification", outputFile,
          "!V:!Silent:Color:DrawProgressBar:Transformations=I;D;P;G,D:AnalysisType=Classification");
 
-
    factory->AddVariable("myvar1 := var1+var2", 'F');
    factory->AddVariable("myvar2 := var1-var2", "Expression 2", "", 'F');
    factory->AddVariable("var3",                "Variable 3", "units", 'F');
    factory->AddVariable("var4",                "Variable 4", "units", 'F');
-
-
    factory->AddSpectator("spec1 := var1*2",  "Spectator 1", "units", 'F');
    factory->AddSpectator("spec2 := var1*3",  "Spectator 2", "units", 'F');
 
-
+   TFile *input(0);
    TString fname = "./tmva_class_example.root";
-
-   if (gSystem->AccessPathName(fname))    // file does not exist in local directory
-      gSystem->Exec("curl -O http://root.cern.ch/files/tmva_class_example.root");
-
-   TFile *input = TFile::Open(fname);
+   if (!gSystem->AccessPathName( fname )) {
+      input = TFile::Open( fname ); // check if file in local directory exists
+   }
+   else {
+      TFile::SetCacheFileDir(".");
+      input = TFile::Open("http://root.cern.ch/files/tmva_class_example.root", "CACHEREAD");
+   }
+   if (!input) {
+      std::cout << "ERROR: could not open data file" << std::endl;
+      exit(1);
+   }
 
    std::cout << "--- TMVAClassification       : Using input file: " << input->GetName() << std::endl;
 

--- a/tmva/rmva/test/Classification.C
+++ b/tmva/rmva/test/Classification.C
@@ -36,12 +36,19 @@ void Classification()
    factory->AddSpectator("spec1 := var1*2",  "Spectator 1", "units", 'F');
    factory->AddSpectator("spec2 := var1*3",  "Spectator 2", "units", 'F');
 
+   TFile *input(0);
    TString fname = "./tmva_class_example.root";
-
-   if (gSystem->AccessPathName(fname))    // file does not exist in local directory
-      gSystem->Exec("curl -O http://root.cern.ch/files/tmva_class_example.root");
-
-   TFile *input = TFile::Open(fname);
+   if (!gSystem->AccessPathName( fname )) {
+      input = TFile::Open( fname ); // check if file in local directory exists
+   }
+   else {
+      TFile::SetCacheFileDir(".");
+      input = TFile::Open("http://root.cern.ch/files/tmva_class_example.root", "CACHEREAD");
+   }
+   if (!input) {
+      std::cout << "ERROR: could not open data file" << std::endl;
+      exit(1);
+   }
 
    std::cout << "--- TMVAClassification       : Using input file: " << input->GetName() << std::endl;
 

--- a/tutorials/hist/th2polyUSA.C
+++ b/tutorials/hist/th2polyUSA.C
@@ -49,8 +49,8 @@ void th2polyUSA()
    Double_t lat2 = 50;
    TH2Poly *p = new TH2Poly("USA","USA Population",lon1,lon2,lat1,lat2);
 
-   TFile *f;
-   f = TFile::Open("http://root.cern.ch/files/usa.root");
+   TFile::SetCacheFileDir(".");
+   TFile *f = TFile::Open("http://root.cern.ch/files/usa.root", "CACHEREAD");
 
    if (!f) {
       printf("Cannot access usa.root. Is internet working ?\n");

--- a/tutorials/tmva/TMVAClassification.C
+++ b/tutorials/tmva/TMVAClassification.C
@@ -164,13 +164,19 @@ int TMVAClassification( TString myMethodList = "" )
 
    // Read training and test data
    // (it is also possible to use ASCII format as input -> see TMVA Users Guide)
+   TFile *input(0);
    TString fname = "./tmva_class_example.root";
-
-   if (gSystem->AccessPathName( fname ))  // file does not exist in local directory
-      gSystem->Exec("curl -O http://root.cern.ch/files/tmva_class_example.root");
-
-   TFile *input = TFile::Open( fname );
-
+   if (!gSystem->AccessPathName( fname )) {
+      input = TFile::Open( fname ); // check if file in local directory exists
+   }
+   else {
+      TFile::SetCacheFileDir(".");
+      input = TFile::Open("http://root.cern.ch/files/tmva_class_example.root", "CACHEREAD");
+   }
+   if (!input) {
+      std::cout << "ERROR: could not open data file" << std::endl;
+      exit(1);
+   }
    std::cout << "--- TMVAClassification       : Using input file: " << input->GetName() << std::endl;
 
    // Register the training and test trees

--- a/tutorials/tmva/TMVAClassificationApplication.C
+++ b/tutorials/tmva/TMVAClassificationApplication.C
@@ -232,12 +232,14 @@ void TMVAClassificationApplication( TString myMethodList = "" )
    // we'll later on use only the "signal" events for the test in this example.
    //
    TFile *input(0);
-   TString fname = "./tmva_example.root";
-   if (!gSystem->AccessPathName( fname ))
+   TString fname = "./tmva_class_example.root";
+   if (!gSystem->AccessPathName( fname )) {
       input = TFile::Open( fname ); // check if file in local directory exists
-   else
-      input = TFile::Open( "http://root.cern.ch/files/tmva_class_example.root" ); // if not: download from ROOT server
-
+   }
+   else {
+      TFile::SetCacheFileDir(".");
+      input = TFile::Open("http://root.cern.ch/files/tmva_class_example.root", "CACHEREAD"); // if not: download from ROOT server
+   }
    if (!input) {
       std::cout << "ERROR: could not open data file" << std::endl;
       exit(1);

--- a/tutorials/tmva/TMVACrossValidation.C
+++ b/tutorials/tmva/TMVACrossValidation.C
@@ -26,10 +26,19 @@ void TMVACrossValidation()
    TMVA::Tools::Instance();
 
    // Load data
+   TFile *input(0);
    TString fname = "./tmva_class_example.root";
-   if (gSystem->AccessPathName(fname))
-      gSystem->Exec("curl -O http://root.cern.ch/files/tmva_class_example.root");
-   TFile *input = TFile::Open(fname);
+   if (!gSystem->AccessPathName( fname )) {
+      input = TFile::Open( fname ); // check if file in local directory exists
+   }
+   else {
+      TFile::SetCacheFileDir(".");
+      input = TFile::Open("http://root.cern.ch/files/tmva_class_example.root", "CACHEREAD");
+   }
+   if (!input) {
+      std::cout << "ERROR: could not open data file" << std::endl;
+      exit(1);
+   }
 
    TTree* signalTree = (TTree*)input->Get("TreeS");
    TTree* background = (TTree*)input->Get("TreeB");

--- a/tutorials/tmva/TMVARegression.C
+++ b/tutorials/tmva/TMVARegression.C
@@ -166,11 +166,13 @@ void TMVARegression( TString myMethodList = "" )
    // load the signal and background event samples from ROOT trees
    TFile *input(0);
    TString fname = "./tmva_reg_example.root";
-   if (!gSystem->AccessPathName( fname ))
+   if (!gSystem->AccessPathName( fname )) {
       input = TFile::Open( fname ); // check if file in local directory exists
-   else
-      input = TFile::Open( "http://root.cern.ch/files/tmva_reg_example.root" ); // if not: download from ROOT server
-
+   }
+   else {
+      TFile::SetCacheFileDir(".");
+      input = TFile::Open("http://root.cern.ch/files/tmva_reg_example.root", "CACHEREAD"); // if not: download from ROOT server
+   }
    if (!input) {
       std::cout << "ERROR: could not open data file" << std::endl;
       exit(1);

--- a/tutorials/tmva/TMVARegressionApplication.C
+++ b/tutorials/tmva/TMVARegressionApplication.C
@@ -128,16 +128,16 @@ void TMVARegressionApplication( TString myMethodList = "" )
    // Prepare input tree (this must be replaced by your data source)
    // in this example, there is a toy tree with signal and one with background events
    // we'll later on use only the "signal" events for the test in this example.
-   //   
+   //
    TFile *input(0);
    TString fname = "./tmva_reg_example.root";
    if (!gSystem->AccessPathName( fname )) {
       input = TFile::Open( fname ); // check if file in local directory exists
-   } 
-   else { 
-      input = TFile::Open( "http://root.cern.ch/files/tmva_reg_example.root" ); // if not: download from ROOT server
    }
-   
+   else {
+      TFile::SetCacheFileDir(".");
+      input = TFile::Open("http://root.cern.ch/files/tmva_reg_example.root", "CACHEREAD"); // if not: download from ROOT server
+   }
    if (!input) {
       std::cout << "ERROR: could not open data file" << std::endl;
       exit(1);


### PR DESCRIPTION
This makes it possible to create a pre-downloaded cache before running the tests, so that it is possible to run the tests in an environment without network access.
