### PR TITLE
Fix for ROOT-8704: add begin/end of line matches in thisroot.sh and thisroot.csh

### DIFF
--- a/config/thisroot.csh
+++ b/config/thisroot.csh
@@ -59,64 +59,64 @@ setenv ROOTSYS "`(cd ${thisroot}/..;pwd)`"
 
 if ($?old_rootsys) then
    setenv PATH `echo $PATH | sed -e "s;:$old_rootsys/bin:;:;g" \
-                                 -e "s;:$old_rootsys/bin;;g"   \
-                                 -e "s;$old_rootsys/bin:;;g"   \
-                                 -e "s;$old_rootsys/bin;;g"`
+                                 -e "s;:$old_rootsys/bin$$;;g"   \
+                                 -e "s;^$old_rootsys/bin:;;g"   \
+                                 -e "s;^$old_rootsys/bin$$;;g"`
    if ($?LD_LIBRARY_PATH) then
       setenv LD_LIBRARY_PATH `echo $LD_LIBRARY_PATH | \
                              sed -e "s;:$old_rootsys/lib:;:;g" \
-                                 -e "s;:$old_rootsys/lib;;g"   \
-                                 -e "s;$old_rootsys/lib:;;g"   \
-                                 -e "s;$old_rootsys/lib;;g"`
+                                 -e "s;:$old_rootsys/lib$$;;g"   \
+                                 -e "s;^$old_rootsys/lib:;;g"   \
+                                 -e "s;^$old_rootsys/lib$$;;g"`
    endif
    if ($?DYLD_LIBRARY_PATH) then
       setenv DYLD_LIBRARY_PATH `echo $DYLD_LIBRARY_PATH | \
                              sed -e "s;:$old_rootsys/lib:;:;g" \
-                                 -e "s;:$old_rootsys/lib;;g"   \
-                                 -e "s;$old_rootsys/lib:;;g"   \
-                                 -e "s;$old_rootsys/lib;;g"`
+                                 -e "s;:$old_rootsys/lib$$;;g"   \
+                                 -e "s;^$old_rootsys/lib:;;g"   \
+                                 -e "s;^$old_rootsys/lib$$;;g"`
    endif
    if ($?SHLIB_PATH) then
       setenv SHLIB_PATH `echo $SHLIB_PATH | \
                              sed -e "s;:$old_rootsys/lib:;:;g" \
-                                 -e "s;:$old_rootsys/lib;;g"   \
-                                 -e "s;$old_rootsys/lib:;;g"   \
-                                 -e "s;$old_rootsys/lib;;g"`
+                                 -e "s;:$old_rootsys/lib$$;;g"   \
+                                 -e "s;^$old_rootsys/lib:;;g"   \
+                                 -e "s;^$old_rootsys/lib$$;;g"`
    endif
    if ($?LIBPATH) then
       setenv LIBPATH `echo $LIBPATH | \
                              sed -e "s;:$old_rootsys/lib:;:;g" \
-                                 -e "s;:$old_rootsys/lib;;g"   \
-                                 -e "s;$old_rootsys/lib:;;g"   \
-                                 -e "s;$old_rootsys/lib;;g"`
+                                 -e "s;:$old_rootsys/lib$$;;g"   \
+                                 -e "s;^$old_rootsys/lib:;;g"   \
+                                 -e "s;^$old_rootsys/lib$$;;g"`
    endif
    if ($?PYTHONPATH) then
       setenv PYTHONPATH `echo $PYTHONPATH | \
                              sed -e "s;:$old_rootsys/lib:;:;g" \
-                                 -e "s;:$old_rootsys/lib;;g"   \
-                                 -e "s;$old_rootsys/lib:;;g"   \
-                                 -e "s;$old_rootsys/lib;;g"`
+                                 -e "s;:$old_rootsys/lib$$;;g"   \
+                                 -e "s;^$old_rootsys/lib:;;g"   \
+                                 -e "s;^$old_rootsys/lib$$;;g"`
    endif
    if ($?MANPATH) then
       setenv MANPATH `echo $MANPATH | \
                              sed -e "s;:$old_rootsys/man:;:;g" \
-                                 -e "s;:$old_rootsys/man;;g"   \
-                                 -e "s;$old_rootsys/man:;;g"   \
-                                 -e "s;$old_rootsys/man;;g"`
+                                 -e "s;:$old_rootsys/man$$;;g"   \
+                                 -e "s;^$old_rootsys/man:;;g"   \
+                                 -e "s;^$old_rootsys/man$$;;g"`
    endif
    if ($?CMAKE_PREFIX_PATH) then
       setenv CMAKE_PREFIX_PATH `echo $CMAKE_PREFIX_PATH | \
                              sed -e "s;:${old_rootsys}:;:;g" \
-                                 -e "s;:${old_rootsys};;g"   \
-                                 -e "s;${old_rootsys}:;;g"   \
-                                 -e "s;${old_rootsys};;g"`
+                                 -e "s;:${old_rootsys}$$;;g"   \
+                                 -e "s;^${old_rootsys}:;;g"   \
+                                 -e "s;^${old_rootsys}$$;;g"`
    endif
    if ($?JUPYTER_PATH) then
       setenv JUPYTER_PATH `echo $JUPYTER_PATH | \
                              sed -e "s;:$old_rootsys/etc/notebook:;:;g" \
-                                 -e "s;:$old_rootsys/etc/notebook;;g"   \
-                                 -e "s;$old_rootsys/etc/notebook:;;g"   \
-                                 -e "s;$old_rootsys/etc/notebook;;g"`
+                                 -e "s;:$old_rootsys/etc/notebook$$;;g"   \
+                                 -e "s;^$old_rootsys/etc/notebook:;;g"   \
+                                 -e "s;^$old_rootsys/etc/notebook$$;;g"`
    endif
 
 endif

--- a/config/thisroot.csh
+++ b/config/thisroot.csh
@@ -58,65 +58,65 @@ if ($?thisroot) then
 setenv ROOTSYS "`(cd ${thisroot}/..;pwd)`"
 
 if ($?old_rootsys) then
-   setenv PATH `echo $PATH | sed -e "s;:$old_rootsys/bin:;:;g" \
-                                 -e "s;:$old_rootsys/bin$$;;g"   \
+   setenv PATH `set DOLLAR='$'; echo $PATH | sed -e "s;:$old_rootsys/bin:;:;g" \
+                                 -e "s;:$old_rootsys/bin${DOLLAR};;g"   \
                                  -e "s;^$old_rootsys/bin:;;g"   \
-                                 -e "s;^$old_rootsys/bin$$;;g"`
+                                 -e "s;^$old_rootsys/bin${DOLLAR};;g"`
    if ($?LD_LIBRARY_PATH) then
-      setenv LD_LIBRARY_PATH `echo $LD_LIBRARY_PATH | \
+      setenv LD_LIBRARY_PATH `set DOLLAR='$'; echo $LD_LIBRARY_PATH | \
                              sed -e "s;:$old_rootsys/lib:;:;g" \
-                                 -e "s;:$old_rootsys/lib$$;;g"   \
+                                 -e "s;:$old_rootsys/lib${DOLLAR};;g"   \
                                  -e "s;^$old_rootsys/lib:;;g"   \
-                                 -e "s;^$old_rootsys/lib$$;;g"`
+                                 -e "s;^$old_rootsys/lib${DOLLAR};;g"`
    endif
    if ($?DYLD_LIBRARY_PATH) then
-      setenv DYLD_LIBRARY_PATH `echo $DYLD_LIBRARY_PATH | \
+      setenv DYLD_LIBRARY_PATH `set DOLLAR='$'; echo $DYLD_LIBRARY_PATH | \
                              sed -e "s;:$old_rootsys/lib:;:;g" \
-                                 -e "s;:$old_rootsys/lib$$;;g"   \
+                                 -e "s;:$old_rootsys/lib${DOLLAR};;g"   \
                                  -e "s;^$old_rootsys/lib:;;g"   \
-                                 -e "s;^$old_rootsys/lib$$;;g"`
+                                 -e "s;^$old_rootsys/lib${DOLLAR};;g"`
    endif
    if ($?SHLIB_PATH) then
-      setenv SHLIB_PATH `echo $SHLIB_PATH | \
+      setenv SHLIB_PATH `set DOLLAR='$'; echo $SHLIB_PATH | \
                              sed -e "s;:$old_rootsys/lib:;:;g" \
-                                 -e "s;:$old_rootsys/lib$$;;g"   \
+                                 -e "s;:$old_rootsys/lib${DOLLAR};;g"   \
                                  -e "s;^$old_rootsys/lib:;;g"   \
-                                 -e "s;^$old_rootsys/lib$$;;g"`
+                                 -e "s;^$old_rootsys/lib${DOLLAR};;g"`
    endif
    if ($?LIBPATH) then
-      setenv LIBPATH `echo $LIBPATH | \
+      setenv LIBPATH `set DOLLAR='$'; echo $LIBPATH | \
                              sed -e "s;:$old_rootsys/lib:;:;g" \
-                                 -e "s;:$old_rootsys/lib$$;;g"   \
+                                 -e "s;:$old_rootsys/lib${DOLLAR};;g"   \
                                  -e "s;^$old_rootsys/lib:;;g"   \
-                                 -e "s;^$old_rootsys/lib$$;;g"`
+                                 -e "s;^$old_rootsys/lib${DOLLAR};;g"`
    endif
    if ($?PYTHONPATH) then
-      setenv PYTHONPATH `echo $PYTHONPATH | \
+      setenv PYTHONPATH `set DOLLAR='$'; echo $PYTHONPATH | \
                              sed -e "s;:$old_rootsys/lib:;:;g" \
-                                 -e "s;:$old_rootsys/lib$$;;g"   \
+                                 -e "s;:$old_rootsys/lib${DOLLAR};;g"   \
                                  -e "s;^$old_rootsys/lib:;;g"   \
-                                 -e "s;^$old_rootsys/lib$$;;g"`
+                                 -e "s;^$old_rootsys/lib${DOLLAR};;g"`
    endif
    if ($?MANPATH) then
-      setenv MANPATH `echo $MANPATH | \
+      setenv MANPATH `set DOLLAR='$'; echo $MANPATH | \
                              sed -e "s;:$old_rootsys/man:;:;g" \
-                                 -e "s;:$old_rootsys/man$$;;g"   \
+                                 -e "s;:$old_rootsys/man${DOLLAR};;g"   \
                                  -e "s;^$old_rootsys/man:;;g"   \
-                                 -e "s;^$old_rootsys/man$$;;g"`
+                                 -e "s;^$old_rootsys/man${DOLLAR};;g"`
    endif
    if ($?CMAKE_PREFIX_PATH) then
-      setenv CMAKE_PREFIX_PATH `echo $CMAKE_PREFIX_PATH | \
+      setenv CMAKE_PREFIX_PATH `set DOLLAR='$'; echo $CMAKE_PREFIX_PATH | \
                              sed -e "s;:${old_rootsys}:;:;g" \
-                                 -e "s;:${old_rootsys}$$;;g"   \
+                                 -e "s;:${old_rootsys}${DOLLAR};;g"   \
                                  -e "s;^${old_rootsys}:;;g"   \
-                                 -e "s;^${old_rootsys}$$;;g"`
+                                 -e "s;^${old_rootsys}${DOLLAR};;g"`
    endif
    if ($?JUPYTER_PATH) then
-      setenv JUPYTER_PATH `echo $JUPYTER_PATH | \
+      setenv JUPYTER_PATH `set DOLLAR='$'; echo $JUPYTER_PATH | \
                              sed -e "s;:$old_rootsys/etc/notebook:;:;g" \
-                                 -e "s;:$old_rootsys/etc/notebook$$;;g"   \
+                                 -e "s;:$old_rootsys/etc/notebook${DOLLAR};;g"   \
                                  -e "s;^$old_rootsys/etc/notebook:;;g"   \
-                                 -e "s;^$old_rootsys/etc/notebook$$;;g"`
+                                 -e "s;^$old_rootsys/etc/notebook${DOLLAR};;g"`
    endif
 
 endif

--- a/config/thisroot.sh
+++ b/config/thisroot.sh
@@ -19,9 +19,9 @@ drop_from_path()
    drop=$2
 
    newpath=`echo $p | sed -e "s;:${drop}:;:;g" \
-                          -e "s;:${drop};;g"   \
-                          -e "s;${drop}:;;g"   \
-                          -e "s;${drop};;g"`
+                          -e "s;:${drop}\$;;g"   \
+                          -e "s;^${drop}:;;g"   \
+                          -e "s;^${drop}\$;;g"`
 }
 
 if [ -n "${ROOTSYS}" ] ; then


### PR DESCRIPTION
when removing old paths make sure that $path:, :$path and $path are only matched
at the beginning, at the end, or match the whole string.
This fixes a problem with removing parts of a path. For example

```
export ROOTSYS=/my/path
export LD_LIBRARY_PATH=/other/path:/my/path/lib:/my/path/lib/subdir
. thisroot.sh
echo $LD_LIBRARY_PATH
```

would output the path to the root libraries followed by `:/other/path/subdir/`