### PR TITLE
Don't install a SIGPIPE handler

### DIFF
--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -605,7 +605,6 @@ Bool_t TUnixSystem::Init()
    UnixSignal(kSigSegmentationViolation, SigHandler);
    UnixSignal(kSigIllegalInstruction,    SigHandler);
    UnixSignal(kSigSystem,                SigHandler);
-   UnixSignal(kSigPipe,                  SigHandler);
    UnixSignal(kSigAlarm,                 SigHandler);
    UnixSignal(kSigUrgent,                SigHandler);
    UnixSignal(kSigFloatingException,     SigHandler);


### PR DESCRIPTION
The default `SIGPIPE` handler installed by `TUnixSystem` does not do anything except print a message and possibly causing an endless loop of `SIGPIPE` handling:

```
echo 'std::cout << "foo" << std::endl;' | root -l |& true
python -c 'import ROOT; print "foo"' |& true
```

This fixes ROOT-4568 and ROOT-7659.

The alternative would be to remove all pending sigpipe signals which might have occurred while handling the signal itself. This would keep the current behavior and still fix the endless loop. 

However think that not handling SIGPIPE by default would be a wiser choice as I don't see a real use case for printing that a SIGPIPE was received and then continuing normally.