### PR TITLE
Fixed dependencies for TMVA tutorials

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -276,11 +276,11 @@ endforeach()
 #--dependency for TMVA tutorials
 set (tmva-TMVAClassificationApplication-depends tutorial-tmva-TMVAClassification)
 set (tmva-TMVAClassificationCategory-depends tutorial-tmva-TMVAClassification)
-set (tmva-TMVAClassificationCategoryApplication-depends tutorial-tmva-TMVAClassificationCategory)
-set (tmva-TMVAMulticlass-depends tutorial-tmva-TMVAMultipleBackgroundExample)
-set (tmva-TMVAMulticlassApplication-depends tutorial-tmva-TMVAMulticlass)
+set (tmva-TMVAClassificationCategoryApplication-depends tutorial-tmva-TMVAClassificationCategory tutorial-tmva-TMVAClassificationCategory)
+set (tmva-TMVAMulticlass-depends tutorial-tmva-TMVAMultipleBackgroundExample tutorial-tmva-TMVAClassificationCategory)
 set (tmva-TMVAMulticlassApplication-depends tutorial-tmva-TMVAMulticlass)
 set (tmva-TMVARegressionApplication-depends tutorial-tmva-TMVARegression)
+set (tmva-TMVARegression-depends tutorial-tmva-TMVAMulticlass-depends)
 
 
 #---Loop over all tutorials and define the corresponding test---------


### PR DESCRIPTION
This PR should fix a race condition with some of the TMVA tutorials on ARM, as they all use the same files in the `dataset` folder: http://cdash.cern.ch/testDetails.php?test=22693533&build=331203