### PR TITLE
Remove "using namespace" from TMVA/MethodDNN.h

### DIFF
--- a/tmva/tmva/inc/TMVA/MethodDNN.h
+++ b/tmva/tmva/inc/TMVA/MethodDNN.h
@@ -64,12 +64,11 @@ namespace TMVA {
 
 class MethodDNN : public MethodBase
 {
-    using Architecture_t = DNN::TReference<Double_t>;
-    using Net_t          = DNN::TNet<Architecture_t>;
-    using Matrix_t       = typename Architecture_t::Matrix_t;
+   using Architecture_t = DNN::TReference<Double_t>;
+   using Net_t          = DNN::TNet<Architecture_t>;
+   using Matrix_t       = typename Architecture_t::Matrix_t;
 
 private:
-
    using LayoutVector_t   = std::vector<std::pair<int, DNN::EActivationFunction>>;
    using KeyValueVector_t = std::vector<std::map<TString, TString>>;
 

--- a/tmva/tmva/inc/TMVA/MethodDNN.h
+++ b/tmva/tmva/inc/TMVA/MethodDNN.h
@@ -60,19 +60,17 @@
 #include "TMVA/DNN/Architectures/Cuda.h"
 #endif
 
-using namespace TMVA::DNN;
-
 namespace TMVA {
 
 class MethodDNN : public MethodBase
 {
-    using Architecture_t = TReference<Double_t>;
-    using Net_t          = TNet<Architecture_t>;
+    using Architecture_t = DNN::TReference<Double_t>;
+    using Net_t          = DNN::TNet<Architecture_t>;
     using Matrix_t       = typename Architecture_t::Matrix_t;
 
 private:
 
-   using LayoutVector_t   = std::vector<std::pair<int, EActivationFunction>>;
+   using LayoutVector_t   = std::vector<std::pair<int, DNN::EActivationFunction>>;
    using KeyValueVector_t = std::vector<std::map<TString, TString>>;
 
    struct TTrainingSettings
@@ -80,7 +78,7 @@ private:
        size_t                batchSize;
        size_t                testInterval;
        size_t                convergenceSteps;
-       ERegularization       regularization;
+       DNN::ERegularization  regularization;
        Double_t              learningRate;
        Double_t              momentum;
        Double_t              weightDecay;
@@ -95,9 +93,9 @@ private:
    // general helper functions
    void     Init();
 
-   Net_t             fNet;
-   EInitialization   fWeightInitialization;
-   EOutputFunction   fOutputFunction;
+   Net_t                fNet;
+   DNN::EInitialization fWeightInitialization;
+   DNN::EOutputFunction fOutputFunction;
 
    TString                        fLayoutString;
    TString                        fErrorStrategy;

--- a/tmva/tmva/src/MethodDNN.cxx
+++ b/tmva/tmva/src/MethodDNN.cxx
@@ -65,20 +65,17 @@ ClassImp(TMVA::MethodDNN)
 
 namespace TMVA
 {
-    using namespace DNN;
+   using namespace DNN;
 
-////////////////////////////////////////////////////////////////////////////////
-/// standard constructor
+   ////////////////////////////////////////////////////////////////////////////////
+   /// standard constructor
 
-TMVA::MethodDNN::MethodDNN(const TString& jobName,
-                           const TString& methodTitle,
-                           DataSetInfo& theData,
-                           const TString& theOption)
-   : MethodBase( jobName, Types::kDNN, methodTitle, theData, theOption),
-     fWeightInitialization(), fOutputFunction(), fLayoutString(), fErrorStrategy(),
-     fTrainingStrategyString(), fWeightInitializationString(), fArchitectureString(),
-     fTrainingSettings(), fResume(false), fSettings()
-{
+   TMVA::MethodDNN::MethodDNN(const TString &jobName, const TString &methodTitle, DataSetInfo &theData,
+                              const TString &theOption)
+      : MethodBase(jobName, Types::kDNN, methodTitle, theData, theOption), fWeightInitialization(), fOutputFunction(),
+        fLayoutString(), fErrorStrategy(), fTrainingStrategyString(), fWeightInitializationString(),
+        fArchitectureString(), fTrainingSettings(), fResume(false), fSettings()
+   {
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/src/MethodDNN.cxx
+++ b/tmva/tmva/src/MethodDNN.cxx
@@ -63,13 +63,9 @@ REGISTER_METHOD(DNN)
 
 ClassImp(TMVA::MethodDNN)
 
-using TMVA::DNN::EActivationFunction;
-using TMVA::DNN::ELossFunction;
-using TMVA::DNN::EInitialization;
-using TMVA::DNN::EOutputFunction;
-
 namespace TMVA
 {
+    using namespace DNN;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// standard constructor


### PR DESCRIPTION
The `using namespace` in the top level of `TMVA/MethodDNN.h` imported
generic names like `class Layer` into the global scope.

This fixes ROOT-8713.