### PR TITLE
FIX: Add softmax to MLP multi-class output

### DIFF
--- a/tmva/tmva/src/MethodMLP.cxx
+++ b/tmva/tmva/src/MethodMLP.cxx
@@ -1308,19 +1308,19 @@ void TMVA::MethodMLP::UpdateNetwork(const std::vector<Float_t>& desired, Double_
    // Norm for softmax
    Double_t norm = 0.;
    for (UInt_t i = 0, iEnd = desired.size(); i < iEnd; ++i) {
-      Double_t act = GetOutputNeuron( i )->GetActivationValue();
-      norm += TMath::Exp( act );
+      Double_t act = GetOutputNeuron(i)->GetActivationValue();
+      norm += TMath::Exp(act);
    }
 
    // Get output of network, and apply softmax
    for (UInt_t i = 0, iEnd = desired.size(); i < iEnd; ++i) {
-      Double_t act = GetOutputNeuron( i )->GetActivationValue();
-      Double_t output = TMath::Exp( act ) / norm;
+      Double_t act = GetOutputNeuron(i)->GetActivationValue();
+      Double_t output = TMath::Exp(act) / norm;
       Double_t error = output - desired.at(i);
       error *= eventWeight;
-      GetOutputNeuron( i )->SetError(error);
+      GetOutputNeuron(i)->SetError(error);
    }
-   
+
    // Do backpropagation
    CalculateNeuronDeltas();
    UpdateSynapses();

--- a/tmva/tmva/src/MethodMLP.cxx
+++ b/tmva/tmva/src/MethodMLP.cxx
@@ -1305,11 +1305,23 @@ void TMVA::MethodMLP::UpdateNetwork(Double_t desired, Double_t eventWeight)
 
 void TMVA::MethodMLP::UpdateNetwork(const std::vector<Float_t>& desired, Double_t eventWeight)
 {
+   // Norm for softmax
+   Double_t norm = 0.;
    for (UInt_t i = 0, iEnd = desired.size(); i < iEnd; ++i) {
-      Double_t error = GetOutputNeuron( i )->GetActivationValue() - desired.at(i);
+      Double_t act = GetOutputNeuron( i )->GetActivationValue();
+      norm += TMath::Exp( act );
+   }
+
+   // Get output of network, and apply softmax
+   for (UInt_t i = 0, iEnd = desired.size(); i < iEnd; ++i) {
+      Double_t act = GetOutputNeuron( i )->GetActivationValue();
+      Double_t output = TMath::Exp( act ) / norm;
+      Double_t error = output - desired.at(i);
       error *= eventWeight;
       GetOutputNeuron( i )->SetError(error);
    }
+   
+   // Do backpropagation
    CalculateNeuronDeltas();
    UpdateSynapses();
 }

--- a/tmva/tmva/src/MethodMLP.cxx
+++ b/tmva/tmva/src/MethodMLP.cxx
@@ -1314,9 +1314,9 @@ void TMVA::MethodMLP::UpdateNetwork(const std::vector<Float_t>& desired, Double_
 
    // Get output of network, and apply softmax
    for (UInt_t i = 0, iEnd = desired.size(); i < iEnd; ++i) {
-      Double_t act = GetOutputNeuron(i)->GetActivationValue();
+      Double_t act    = GetOutputNeuron(i)->GetActivationValue();
       Double_t output = TMath::Exp(act) / norm;
-      Double_t error = output - desired.at(i);
+      Double_t error  = output - desired.at(i);
       error *= eventWeight;
       GetOutputNeuron(i)->SetError(error);
    }


### PR DESCRIPTION
Previously the softmax function was only applied MLP multi-class
output when evaluating, not during training.