### PR TITLE
[DOC] Let doxygen document EnableImplicitMT default parameter

### DIFF
--- a/core/base/inc/TROOT.h
+++ b/core/base/inc/TROOT.h
@@ -89,7 +89,8 @@ namespace ROOT {
    // Enable support for multi-threading within the ROOT code,
    // in particular, enables the global mutex to make ROOT thread safe/aware.
    void EnableThreadSafety();
-   // Manage implicit multi-threading within ROOT
+   /// \brief Enable ROOT's implicit multi-threading for all objects and methods that provide an internal
+   /// parallelisation mechanism.
    void EnableImplicitMT(UInt_t numthreads = 0);
    void DisableImplicitMT();
    Bool_t IsImplicitMTEnabled();

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -503,8 +503,6 @@ namespace Internal {
    }
 
    ////////////////////////////////////////////////////////////////////////////////
-   /// \brief Enable ROOT's implicit multi-threading for all objects and methods that provide an internal
-   /// parallelisation mechanism.
    /// @param[in] numthreads Number of threads to use. If not specified or
    ///                       set to zero, the number of threads is automatically
    ///                       decided by the implementation. Any other value is


### PR DESCRIPTION
@couet and I agreed this was a reasonable solution to the problem of ROOT not documenting that `EnableImplicitMT` has a default value for the `numThreads` parameter.