### PR TITLE
Copy the stl.cppmap modulemap now during configuration time.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,12 +180,7 @@ if(cxxmodules)
 
     configure_file(${CMAKE_SOURCE_DIR}/build/unix/modulemap.overlay.yaml.in ${CMAKE_BINARY_DIR}/include/modulemap.overlay.yaml @ONLY)
 
-    add_custom_target(copystlmodulemap
-                    DEPENDS build/unix/module.modulemap
-                    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/build/unix/stl.cppmap ${CMAKE_BINARY_DIR}/include/stl.cppmap
-                    )
-
-    add_dependencies(copymodulemap copystlmodulemap)
+    configure_file(${CMAKE_SOURCE_DIR}/build/unix/stl.cppmap ${CMAKE_BINARY_DIR}/include/stl.cppmap)
   endif()
 
   # These vars are useful when we want to compile things without cxxmodules.


### PR DESCRIPTION
The current builds fail because without a valid modulemap the setresuid test failed during configuration time.