### PR TITLE
Added hint path for ccache for Mac nodes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ include(MacroEnsureVersion)
 
 #---Enable CCache ------------------------------------------------------------------------------
 if(ccache)
-   find_program(ccache_cmd NAMES ccache ccache-swig)
+   find_program(ccache_cmd NAMES ccache ccache-swig HINTS /usr/local/bin/)
    mark_as_advanced(ccache_cmd ${ccache_cmd})
    if(ccache_cmd)
       message(STATUS "Using ccache for building")


### PR DESCRIPTION
Previously, CMake would ignore the path on Mac nodes since Mac enables the flag macos_native which ignores paths under `/sw`, `/opt/local`, and `/usr/local` when calling `find_program`. Providing the path as a hint makes it find ccache. 
Tested on macitois13.