### PR TITLE
Temp workaround for ccache home dir issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,12 @@ include(RootNewMacros)
 include(CheckCompiler)
 include(MacroEnsureVersion)
 
+#---Set home directory to avoid CCache issue----------------------------------------------------
+# Temporairly workaround as CCache has issues reading the config file due to kerb
+if ((NOT APPLE) AND (NOT WIN32))
+   set(ENV{HOME} /build/)
+endif()
+
 #---Enable CCache ------------------------------------------------------------------------------
 if(ccache)
    find_program(ccache_cmd NAMES ccache ccache-swig HINTS /usr/local/bin/)


### PR DESCRIPTION
Ccache has an issue reading the config file on some Linux distros when using an invalid kerberos ticket. For some reason it will attempt to access a ccache config file in the home directory which it does does not have permission to do causing ccache to exit. Approach suggested by @dpiparo 