### PR TITLE
Revert #e089bc3 and ignore tmva tutorials on ARM

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -275,11 +275,10 @@ endforeach()
 #--dependency for TMVA tutorials
 set (tmva-TMVAClassificationApplication-depends tutorial-tmva-TMVAClassification)
 set (tmva-TMVAClassificationCategory-depends tutorial-tmva-TMVAClassification)
-set (tmva-TMVAClassificationCategoryApplication-depends tutorial-tmva-TMVAClassificationCategory tutorial-tmva-TMVAClassificationApplication)
-set (tmva-TMVAMulticlass-depends tutorial-tmva-TMVAMultipleBackgroundExample tutorial-tmva-TMVAClassificationCategory)
-set (tmva-TMVAMulticlassApplication-depends tutorial-tmva-TMVAMulticlass tutorial-tmva-TMVAClassificationCategoryApplication)
-set (tmva-TMVARegressionApplication-depends tutorial-tmva-TMVARegression tutorial-tmva-TMVAMulticlassApplication)
-set (tmva-TMVARegression-depends tutorial-tmva-TMVAMulticlass)
+set (tmva-TMVAClassificationCategoryApplication-depends tutorial-tmva-TMVAClassificationCategory)
+set (tmva-TMVAMulticlass-depends tutorial-tmva-TMVAMultipleBackgroundExample)
+set (tmva-TMVAMulticlassApplication-depends tutorial-tmva-TMVAMulticlass)
+set (tmva-TMVARegressionApplication-depends tutorial-tmva-TMVARegression)
 
 
 #---Loop over all tutorials and define the corresponding test---------

--- a/tutorials/CTestCustom.cmake
+++ b/tutorials/CTestCustom.cmake
@@ -8,7 +8,15 @@ endif()
 
 if (CTEST_BUILD_NAME MATCHES aarch64 AND CTEST_BUILD_NAME MATCHES dbg)
   # these tutorials are disabled as they timeout
-  list(APPEND CTEST_CUSTOM_TESTS_IGNORE tutorial-roostats-StandardBayesianNumericalDemo tutorial-roostats-OneSidedFrequentistUpperLimitWithBands tutorial-tmva-TMVAClassification tutorial-tmva-TMVARegression tutorial-tmva-TMVAMulticlass  tutorial-roostats-TwoSidedFrequentistUpperLimitWithBands)
+  list(APPEND CTEST_CUSTOM_TESTS_IGNORE
+       tutorial-roostats-StandardBayesianNumericalDemo
+       tutorial-roostats-OneSidedFrequentistUpperLimitWithBands
+       tutorial-tmva-TMVAClassification
+       tutorial-tmva-TMVARegression
+       tutorial-tmva-TMVAMulticlass
+       tutorial-tmva-TMVAMulticlassApplication
+       tutorial-tmva-TMVARegressionApplication
+       tutorial-roostats-TwoSidedFrequentistUpperLimitWithBands)
 endif()
 
 if (CTEST_BUILD_NAME MATCHES aarch64)


### PR DESCRIPTION
This PR undoes part of #426 for simplification and ignores some tutorials that depends on tutorials which are already ignored on ARM.