### PR TITLE
Increased scale/discrepancy for ARM on stressMathCore

### DIFF
--- a/test/stressMathCore.cxx
+++ b/test/stressMathCore.cxx
@@ -1118,7 +1118,15 @@ int testVector(int ngen, bool testio=false) {
    s1 = a.testOperations(v1);  a.print(VecType<V1>::name()+" operations");
    scale = Dim*20;
    if (Dim==3 && VecType<V2>::name() == "RhoEtaPhiVector") scale *= 10; // for problem with RhoEtaPhi
-   if (Dim==4 && VecType<V2>::name() == "PtEtaPhiMVector") scale *= 65;
+
+   if (Dim==4 && VecType<V2>::name() == "PtEtaPhiMVector") {
+#if (defined(__arm__) || defined(__arm64__) || defined(__aarch64__))
+      scale *= 65;
+#else
+      scale *= 10;
+#endif
+   }
+
 #if defined (R__LINUX) && !defined(R__B64)
    // problem of precision on linux 32
    if (Dim ==4) scale = 1000000000;

--- a/test/stressMathCore.cxx
+++ b/test/stressMathCore.cxx
@@ -1118,7 +1118,7 @@ int testVector(int ngen, bool testio=false) {
    s1 = a.testOperations(v1);  a.print(VecType<V1>::name()+" operations");
    scale = Dim*20;
    if (Dim==3 && VecType<V2>::name() == "RhoEtaPhiVector") scale *= 10; // for problem with RhoEtaPhi
-   if (Dim==4 && VecType<V2>::name() == "PtEtaPhiMVector") scale *= 10;
+   if (Dim==4 && VecType<V2>::name() == "PtEtaPhiMVector") scale *= 65;
 #if defined (R__LINUX) && !defined(R__B64)
    // problem of precision on linux 32
    if (Dim ==4) scale = 1000000000;


### PR DESCRIPTION
This PR resolves this failing test on ARM: http://cdash.cern.ch/testDetails.php?test=23147537&build=332879