### PR TITLE
Replaced <math.h> with <cmath> to fix clang compilation.

### DIFF
--- a/hist/hist/src/TFormula_v5.cxx
+++ b/hist/hist/src/TFormula_v5.cxx
@@ -9,7 +9,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include <math.h>
+#include <cmath>
 
 #include "Riostream.h"
 #include "TROOT.h"


### PR DESCRIPTION
We use the math functions in the std namespace, so math.h was wrong here.