### PR TITLE
[TDF] optimizations to the event loop

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFNodes.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFNodes.hxx
@@ -19,6 +19,7 @@
 
 #include <map>
 #include <numeric> // std::iota for TSlotStack
+#include <string>
 
 namespace ROOT {
 

--- a/tree/treeplayer/inc/ROOT/TDFNodes.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFNodes.hxx
@@ -83,7 +83,6 @@ public:
    TTree *                         GetTree() const;
    TDataFrameBranchBase *GetBookedBranch(const std::string &name) const;
    const std::map<std::string, TmpBranchBasePtr_t> &GetBookedBranches() const { return fBookedBranches; }
-   void *GetTmpBranchValue(const std::string &branch, unsigned int slot);
    ::TDirectory *GetDirectory() const;
    std::string   GetTreeName() const;
    void Book(const ActionBasePtr_t &actionPtr);

--- a/tree/treeplayer/inc/ROOT/TDFNodes.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFNodes.hxx
@@ -158,7 +158,7 @@ public:
    T &Get(Long64_t entry);
 
    template <typename U = T, typename std::enable_if<!std::is_same<ProxyParam_t, U>::value, int>::type = 0>
-   std::array_view<ProxyParam_t> Get(Long64_t entry)
+   std::array_view<ProxyParam_t> Get(Long64_t)
    {
       auto &readerArray = *fReaderArray;
       if (readerArray.GetSize() > 1 && 1 != (&readerArray[1] - &readerArray[0])) {

--- a/tree/treeplayer/inc/ROOT/TDFNodes.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFNodes.hxx
@@ -59,8 +59,8 @@ class TDataFrameImpl : public std::enable_shared_from_this<TDataFrameImpl> {
    };
 
    ROOT::Detail::ActionBaseVec_t fBookedActions;
-   ROOT::Detail::FilterBaseVec_t   fBookedFilters;
-   ROOT::Detail::FilterBaseVec_t   fBookedNamedFilters;
+   ROOT::Detail::FilterBaseVec_t fBookedFilters;
+   ROOT::Detail::FilterBaseVec_t fBookedNamedFilters;
    std::map<std::string, TmpBranchBasePtr_t> fBookedBranches;
    std::vector<std::shared_ptr<bool>> fResProxyReadiness;
    ::TDirectory *                     fDirPtr{nullptr};
@@ -82,7 +82,7 @@ public:
    const BranchNames_t             GetTmpBranches() const { return {}; };
    TTree *                         GetTree() const;
    TDataFrameBranchBase *GetBookedBranch(const std::string &name) const;
-   const std::map<std::string, TmpBranchBasePtr_t>& GetBookedBranches() const { return fBookedBranches; }
+   const std::map<std::string, TmpBranchBasePtr_t> &GetBookedBranches() const { return fBookedBranches; }
    void *GetTmpBranchValue(const std::string &branch, unsigned int slot);
    ::TDirectory *GetDirectory() const;
    std::string   GetTreeName() const;
@@ -92,8 +92,8 @@ public:
    void Book(const std::shared_ptr<bool> &branchPtr);
    bool         CheckFilters(int, unsigned int);
    unsigned int GetNSlots() const;
-   bool HasRunAtLeastOnce() const { return fHasRunAtLeastOnce; }
-   void Report() const;
+   bool         HasRunAtLeastOnce() const { return fHasRunAtLeastOnce; }
+   void         Report() const;
    /// End of recursive chain of calls, does nothing
    void PartialReport() const {}
    void SetTree(TTree *tree) { fTree = tree; }
@@ -134,7 +134,7 @@ class TDataFrameValue {
    std::unique_ptr<TTreeReaderArray<ProxyParam_t>> fReaderArray{nullptr}; //< Owning ptr to a TTreeReaderArray. Used for
                                                                           /// non-temporary columsn and
                                                                           /// T == std::array_view<U>.
-   T *fValuePtr{nullptr}; //< Non-owning ptr to the value of a temporary column. 
+   T *                                 fValuePtr{nullptr}; //< Non-owning ptr to the value of a temporary column.
    ROOT::Detail::TDataFrameBranchBase *fTmpColumn{
       nullptr};            //< Non-owning ptr to the node responsible for the temporary column.
    unsigned int fSlot = 0; //< The slot this value belongs to. Only used for temporary columns, not for real branches.
@@ -158,8 +158,9 @@ public:
                                      int>::type = 0>
    T &Get(Long64_t entry);
 
-   template<typename U = T, typename std::enable_if<!std::is_same<ProxyParam_t, U>::value, int>::type = 0>
-   std::array_view<ProxyParam_t> Get(Long64_t entry) {
+   template <typename U = T, typename std::enable_if<!std::is_same<ProxyParam_t, U>::value, int>::type = 0>
+   std::array_view<ProxyParam_t> Get(Long64_t entry)
+   {
       auto &readerArray = *fReaderArray;
       if (readerArray.GetSize() > 1 && 1 != (&readerArray[1] - &readerArray[0])) {
          std::string exceptionText = "Branch ";
@@ -369,9 +370,9 @@ class TDataFrameFilter final : public TDataFrameFilterBase {
    using BranchTypes_t = typename ROOT::Internal::TDFTraitsUtils::TFunctionTraits<FilterF>::Args_t;
    using TypeInd_t     = typename ROOT::Internal::TDFTraitsUtils::TGenStaticSeq<BranchTypes_t::fgSize>::Type_t;
 
-   FilterF             fFilter;
-   const BranchNames_t fBranches;
-   PrevDataFrame &     fPrevData;
+   FilterF                                                     fFilter;
+   const BranchNames_t                                         fBranches;
+   PrevDataFrame &                                             fPrevData;
    std::vector<ROOT::Internal::TDFValueTuple_t<BranchTypes_t>> fValues;
 
 public:

--- a/tree/treeplayer/inc/ROOT/TDFUtils.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFUtils.hxx
@@ -145,17 +145,17 @@ struct TIsContainer {
 };
 
 // Extract first of possibly many template parameters. For non-template types, the result is the type itself
-template<typename T>
+template <typename T>
 struct TExtractType {
    using type = T;
 };
 
-template<typename T, template<typename...> class U, typename...Extras>
+template <typename T, template <typename...> class U, typename... Extras>
 struct TExtractType<U<T, Extras...>> {
    using type = T;
 };
 
-template<typename T>
+template <typename T>
 using ExtractType_t = typename TExtractType<T>::type;
 
 } // end NS TDFTraitsUtils
@@ -199,16 +199,16 @@ void InitTDFValues(unsigned int slot, TDFValueTuple &valueTuple, TTreeReader &r,
    // branch is a temporary branch created with AddColumn, false if they are
    // actual branches present in the TTree.
    std::array<bool, sizeof...(S)> isTmpColumn;
-   for (auto i = 0u; i < isTmpColumn.size(); ++i)
+   for (auto i       = 0u; i < isTmpColumn.size(); ++i)
       isTmpColumn[i] = std::find(tmpbn.begin(), tmpbn.end(), bn.at(i)) != tmpbn.end();
 
    // hack to expand a parameter pack without c++17 fold expressions.
    // auto defines a variable with type std::initializer_list<int>, containing all zeroes, and SetTmpColumn or
    // SetProxy are conditionally executed as the braced init list is expanded. The final ... expands S and BranchTypes.
-   std::initializer_list<int> expander{
-      (isTmpColumn[S] ? std::get<S>(valueTuple).SetTmpColumn(slot, tmpBranches.at(bn.at(S)).get())
-                      : std::get<S>(valueTuple).MakeProxy(r, bn.at(S)),
-       0)...};
+   std::initializer_list<int> expander{(isTmpColumn[S]
+                                           ? std::get<S>(valueTuple).SetTmpColumn(slot, tmpBranches.at(bn.at(S)).get())
+                                           : std::get<S>(valueTuple).MakeProxy(r, bn.at(S)),
+                                        0)...};
    (void)expander; // avoid "unused variable" warnings for expander on gcc4.9
    (void)slot;     // avoid _bogus_ "unused variable" warnings for slot on gcc 4.9
 }

--- a/tree/treeplayer/inc/ROOT/TDFUtils.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFUtils.hxx
@@ -203,7 +203,7 @@ void InitTDFValues(unsigned int slot, TDFValueTuple &valueTuple, TTreeReader &r,
       isTmpColumn[i] = std::find(tmpbn.begin(), tmpbn.end(), bn.at(i)) != tmpbn.end();
 
    // hack to expand a parameter pack without c++17 fold expressions.
-   // auto defines a variable with type std::initializer_list<int>, containing all zeroes, and SetTmpColumn or
+   // The statement defines a variable with type std::initializer_list<int>, containing all zeroes, and SetTmpColumn or
    // SetProxy are conditionally executed as the braced init list is expanded. The final ... expands S and BranchTypes.
    std::initializer_list<int> expander{(isTmpColumn[S]
                                            ? std::get<S>(valueTuple).SetTmpColumn(slot, tmpBranches.at(bn.at(S)).get())

--- a/tree/treeplayer/src/TDFNodes.cxx
+++ b/tree/treeplayer/src/TDFNodes.cxx
@@ -204,11 +204,6 @@ TDataFrameBranchBase *TDataFrameImpl::GetBookedBranch(const std::string &name) c
    return it == fBookedBranches.end() ? nullptr : it->second.get();
 }
 
-void *TDataFrameImpl::GetTmpBranchValue(const std::string &branch, unsigned int slot)
-{
-   return fBookedBranches.at(branch)->GetValuePtr(slot);
-}
-
 TDirectory *TDataFrameImpl::GetDirectory() const
 {
    return fDirPtr;

--- a/tree/treeplayer/src/TDFNodes.cxx
+++ b/tree/treeplayer/src/TDFNodes.cxx
@@ -222,7 +222,9 @@ TDataFrameBranchBase *TDataFrameImpl::GetBookedBranch(const std::string &name) c
 
 void *TDataFrameImpl::GetTmpBranchValue(const std::string &branch, unsigned int slot, Long64_t entry)
 {
-   return fBookedBranches.at(branch)->GetValue(slot, entry);
+   auto &tmpBranch = fBookedBranches.at(branch);
+   tmpBranch->Update(slot, entry);
+   return tmpBranch->GetValuePtr(slot);
 }
 
 TDirectory *TDataFrameImpl::GetDirectory() const


### PR DESCRIPTION
In particular, all creations and deletions of `shared_ptr`s have been removed from the event loop.

This is a long due optimization that required several changes in the internal behaviour of TDataFrame{Impl,Action,Branch,Filter}. Unfortunately all changes are entangled, so the third commit is quite fat.

The main change to the internal logic is that `TDataFrame{Action,Branch,Filter}` now store a tuple of `TDataFrameValue`s rather than (possibly null) shared pointers to `TTreeReaderValueBase`.
`TDataFrameValue` offers a transparent, unified interface to the different kinds of values that the nodes must handle: temporary columns, to be evaluated on-the-fly, `TTreeReaderArray`s that must be converted to `array_view`s and `TTreeReaderValue`s.
`TDataFrameValue` also incorporates validity checks on the value types, e.g. that arrays read via `TTreeReaderArray` are actually contiguous in memory and that the type of a temporary column is the same as the type expected by the node that makes use of it.