### PR TITLE
Fix GA evalutation of multiclass cuts taking long

### DIFF
--- a/tmva/tmva/inc/TMVA/ResultsMulticlass.h
+++ b/tmva/tmva/inc/TMVA/ResultsMulticlass.h
@@ -100,6 +100,12 @@ namespace TMVA {
       std::vector<Float_t> fAchievableEff;
       std::vector<Float_t> fAchievablePur;
       std::vector<std::vector<Double_t> > fBestCuts;
+
+      // Temporary storage used during GetBestMultiClassCuts
+      std::vector<Float_t> fClassSumWeights;
+      std::vector<Float_t> fEventWeights;
+      std::vector<UInt_t>  fEventClasses;
+
    protected:
        
        ClassDef(ResultsMulticlass,2);


### PR DESCRIPTION
Caches and precomputes data for this calculation, resulting in a
much more cache friendly access pattern. Leads to increased memory
usage during optimisation, which is subsequently released.