### PR TITLE
Enable argument dependent lookup (ADL) in math.

### DIFF
--- a/math/genvector/inc/Math/GenVector/Cartesian2D.h
+++ b/math/genvector/inc/Math/GenVector/Cartesian2D.h
@@ -89,8 +89,8 @@ public :
    Scalar X()     const { return fX;}
    Scalar Y()     const { return fY;}
    Scalar Mag2()  const { return fX*fX + fY*fY; }
-   Scalar R() const { return std::sqrt(Mag2()); }
-   Scalar Phi() const { return (fX == Scalar(0) && fY == Scalar(0)) ? Scalar(0) : std::atan2(fY, fX); }
+   Scalar R() const { return sqrt(Mag2()); }
+   Scalar Phi() const { return (fX == Scalar(0) && fY == Scalar(0)) ? Scalar(0) : atan2(fY, fX); }
 
    /**
        set the x coordinate value keeping y constant
@@ -124,8 +124,8 @@ public :
        rotate by an angle
     */
    void Rotate(Scalar angle) {
-      const Scalar s = std::sin(angle);
-      const Scalar c = std::cos(angle);
+      const Scalar s = sin(angle);
+      const Scalar c = cos(angle);
       SetCoordinates(c * fX - s * fY, s * fX + c * fY);
    }
 
@@ -175,8 +175,8 @@ public :
    Cartesian2D & operator = (const Polar2D<T2> & v)
    {
       const Scalar r = v.R();
-      fX             = r * std::cos(v.Phi());
-      fY             = r * std::sin(v.Phi());
+      fX             = r * cos(v.Phi());
+      fY             = r * sin(v.Phi());
       return *this;
    }
 

--- a/math/genvector/inc/Math/GenVector/Cartesian3D.h
+++ b/math/genvector/inc/Math/GenVector/Cartesian3D.h
@@ -109,13 +109,13 @@ public :
    Scalar Z()     const { return fZ;}
    Scalar Mag2()  const { return fX*fX + fY*fY + fZ*fZ;}
    Scalar Perp2() const { return fX*fX + fY*fY ;}
-   Scalar Rho() const { return std::sqrt(Perp2()); }
-   Scalar R() const { return std::sqrt(Mag2()); }
+   Scalar Rho() const { return sqrt(Perp2()); }
+   Scalar R() const { return sqrt(Mag2()); }
    Scalar Theta() const
    {
-      return (fX == Scalar(0) && fY == Scalar(0) && fZ == Scalar(0)) ? Scalar(0) : std::atan2(Rho(), Z());
+      return (fX == Scalar(0) && fY == Scalar(0) && fZ == Scalar(0)) ? Scalar(0) : atan2(Rho(), Z());
    }
-   Scalar Phi() const { return (fX == Scalar(0) && fY == Scalar(0)) ? Scalar(0) : std::atan2(fY, fX); }
+   Scalar Phi() const { return (fX == Scalar(0) && fY == Scalar(0)) ? Scalar(0) : atan2(fY, fX); }
 
    // pseudorapidity
    Scalar Eta() const {
@@ -210,8 +210,8 @@ public :
    Cartesian3D & operator = (const Polar3D<T2> & v)
    {
       const T rho = v.Rho();
-      fX          = rho * std::cos(v.Phi());
-      fY          = rho * std::sin(v.Phi());
+      fX          = rho * cos(v.Phi());
+      fY          = rho * sin(v.Phi());
       fZ = v.Z();
       return *this;
    }

--- a/math/genvector/inc/Math/GenVector/Cylindrical3D.h
+++ b/math/genvector/inc/Math/GenVector/Cylindrical3D.h
@@ -109,7 +109,7 @@ private:
    inline static Scalar pi() { return Scalar(M_PI); }
    inline void          Restrict()
    {
-      if (fPhi <= -pi() || fPhi > pi()) fPhi = fPhi - std::floor(fPhi / (2 * pi()) + .5) * 2 * pi();
+      if (fPhi <= -pi() || fPhi > pi()) fPhi = fPhi - floor(fPhi / (2 * pi()) + .5) * 2 * pi();
    }
 public:
 
@@ -119,13 +119,13 @@ public:
    Scalar Z()     const { return fZ;   }
    Scalar Phi()   const { return fPhi; }
 
-   Scalar X() const { return fRho * std::cos(fPhi); }
-   Scalar Y() const { return fRho * std::sin(fPhi); }
+   Scalar X() const { return fRho * cos(fPhi); }
+   Scalar Y() const { return fRho * sin(fPhi); }
 
    Scalar Mag2()  const { return fRho*fRho + fZ*fZ;   }
-   Scalar R() const { return std::sqrt(Mag2()); }
+   Scalar R() const { return sqrt(Mag2()); }
    Scalar Perp2() const { return fRho*fRho;           }
-   Scalar Theta() const { return (fRho == Scalar(0) && fZ == Scalar(0)) ? Scalar(0) : std::atan2(fRho, fZ); }
+   Scalar Theta() const { return (fRho == Scalar(0) && fZ == Scalar(0)) ? Scalar(0) : atan2(fRho, fZ); }
 
    // pseudorapidity - use same implementation as in Cartesian3D
    Scalar Eta() const {

--- a/math/genvector/inc/Math/GenVector/CylindricalEta3D.h
+++ b/math/genvector/inc/Math/GenVector/CylindricalEta3D.h
@@ -125,7 +125,7 @@ public :
 private:
    inline static Scalar pi() { return M_PI; }
    inline void Restrict() {
-      if (fPhi <= -pi() || fPhi > pi()) fPhi = fPhi - std::floor(fPhi / (2 * pi()) + .5) * 2 * pi();
+      if (fPhi <= -pi() || fPhi > pi()) fPhi = fPhi - floor(fPhi / (2 * pi()) + .5) * 2 * pi();
       return;
    }
 public:
@@ -135,15 +135,15 @@ public:
    T Rho()   const { return fRho; }
    T Eta()   const { return fEta; }
    T Phi()   const { return fPhi; }
-   T X() const { return fRho * std::cos(fPhi); }
-   T Y() const { return fRho * std::sin(fPhi); }
+   T X() const { return fRho * cos(fPhi); }
+   T Y() const { return fRho * sin(fPhi); }
    T Z() const
    {
-      return fRho > 0 ? fRho * std::sinh(fEta) : fEta == 0 ? 0 : fEta > 0 ? fEta - etaMax<T>() : fEta + etaMax<T>();
+      return fRho > 0 ? fRho * sinh(fEta) : fEta == 0 ? 0 : fEta > 0 ? fEta - etaMax<T>() : fEta + etaMax<T>();
    }
    T R() const
    {
-      return fRho > 0 ? fRho * std::cosh(fEta)
+      return fRho > 0 ? fRho * cosh(fEta)
                       : fEta > etaMax<T>() ? fEta - etaMax<T>() : fEta < -etaMax<T>() ? -fEta - etaMax<T>() : 0;
    }
    T Mag2() const
@@ -152,7 +152,7 @@ public:
       return r * r;
    }
    T Perp2() const { return fRho*fRho;            }
-   T Theta() const { return fRho > 0 ? 2 * std::atan(exp(-fEta)) : (fEta >= 0 ? 0 : pi()); }
+   T Theta() const { return fRho > 0 ? 2 * atan(exp(-fEta)) : (fEta >= 0 ? 0 : pi()); }
 
    // setters (only for data members)
 

--- a/math/genvector/inc/Math/GenVector/LorentzVector.h
+++ b/math/genvector/inc/Math/GenVector/LorentzVector.h
@@ -490,7 +490,7 @@ namespace ROOT {
           //        We should then move the code to a .cpp file.
           const Scalar ee  = E();
           const Scalar ppz = Pz();
-          return Scalar(0.5) * std::log((ee + ppz) / (ee - ppz));
+          return Scalar(0.5) * log((ee + ppz) / (ee - ppz));
        }
 
        /**
@@ -501,7 +501,7 @@ namespace ROOT {
           //        mechanism or at least load a NAN if not.
           const Scalar ee = E();
           const Scalar pp = P();
-          return Scalar(0.5) * std::log((ee + pp) / (ee - pp));
+          return Scalar(0.5) * log((ee + pp) / (ee - pp));
        }
 
        /**
@@ -598,7 +598,7 @@ namespace ROOT {
        */
        Scalar Gamma() const {
           const Scalar v2 = P2();
-          const Scalar t2 = std::pow(E(), 2);
+          const Scalar t2 = pow(E(), 2);
           if (E() == 0) {
              if ( P2() == 0) {
                 return 1;
@@ -614,7 +614,7 @@ namespace ROOT {
           else if ( t2 == v2 ) {
              GenVector::Throw ("LorentzVector::Gamma() - gamma computed for a lightlike LorentzVector. Infinite result");
           }
-          return Scalar(1) / std::sqrt(Scalar(1) - v2 / t2);
+          return Scalar(1) / sqrt(Scalar(1) - v2 / t2);
        } /* gamma */
 
 

--- a/math/genvector/inc/Math/GenVector/Plane3D.h
+++ b/math/genvector/inc/Math/GenVector/Plane3D.h
@@ -222,7 +222,7 @@ protected:
    void Normalize()
    {
       // normalize the plane
-      const SCALAR s = std::sqrt(fA * fA + fB * fB + fC * fC);
+      const SCALAR s = sqrt(fA * fA + fB * fB + fC * fC);
       // what to do if s = 0 ?
       if (s == SCALAR(0)) {
          fD = SCALAR(0);

--- a/math/genvector/inc/Math/GenVector/Polar2D.h
+++ b/math/genvector/inc/Math/GenVector/Polar2D.h
@@ -97,8 +97,8 @@ public :
 
    Scalar R()     const { return fR;}
    Scalar Phi()   const { return fPhi; }
-   Scalar X() const { return fR * std::cos(fPhi); }
-   Scalar Y() const { return fR * std::sin(fPhi); }
+   Scalar X() const { return fR * cos(fPhi); }
+   Scalar Y() const { return fR * sin(fPhi); }
    Scalar Mag2()  const { return fR*fR;}
 
 
@@ -134,7 +134,7 @@ private:
       restrict abgle hi to be between -PI and PI
     */
    inline void Restrict() {
-      if (fPhi <= -pi() || fPhi > pi()) fPhi = fPhi - std::floor(fPhi / (2 * pi()) + .5) * 2 * pi();
+      if (fPhi <= -pi() || fPhi > pi()) fPhi = fPhi - floor(fPhi / (2 * pi()) + .5) * 2 * pi();
    }
 
 public:

--- a/math/genvector/inc/Math/GenVector/Polar3D.h
+++ b/math/genvector/inc/Math/GenVector/Polar3D.h
@@ -110,12 +110,12 @@ public :
    Scalar R()     const { return fR;}
    Scalar Phi()   const { return fPhi; }
    Scalar Theta() const { return fTheta; }
-   Scalar Rho() const { return fR * std::sin(fTheta); }
-   Scalar X() const { return Rho() * std::cos(fPhi); }
-   Scalar Y() const { return Rho() * std::sin(fPhi); }
-   Scalar Z() const { return fR * std::cos(fTheta); }
+   Scalar Rho() const { return fR * sin(fTheta); }
+   Scalar X() const { return Rho() * cos(fPhi); }
+   Scalar Y() const { return Rho() * sin(fPhi); }
+   Scalar Z() const { return fR * cos(fTheta); }
    Scalar Mag2()  const { return fR*fR;}
-   Scalar Perp2() const { return std::pow(Rho(), 2); }
+   Scalar Perp2() const { return pow(Rho(), 2); }
 
    // pseudorapidity
    Scalar Eta() const
@@ -157,7 +157,7 @@ public :
 private:
    inline static Scalar pi()  { return M_PI; }
    inline void Restrict() {
-      if (fPhi <= -pi() || fPhi > pi()) fPhi = fPhi - std::floor(fPhi / (2 * pi()) + .5) * 2 * pi();
+      if (fPhi <= -pi() || fPhi > pi()) fPhi = fPhi - floor(fPhi / (2 * pi()) + .5) * 2 * pi();
    }
 
 public:

--- a/math/genvector/inc/Math/GenVector/PtEtaPhiE4D.h
+++ b/math/genvector/inc/Math/GenVector/PtEtaPhiE4D.h
@@ -137,13 +137,12 @@ public :
 
    // other coordinate representation
 
-   Scalar Px() const { return fPt * std::cos(fPhi); }
+   Scalar Px() const { return fPt * cos(fPhi); }
    Scalar X () const { return Px();         }
-   Scalar Py() const { return fPt * std::sin(fPhi); }
+   Scalar Py() const { return fPt * sin(fPhi); }
    Scalar Y () const { return Py();         }
    Scalar Pz() const {
-      return fPt > 0 ? fPt * std::sinh(fEta)
-                     : fEta == 0 ? 0 : fEta > 0 ? fEta - etaMax<Scalar>() : fEta + etaMax<Scalar>();
+      return fPt > 0 ? fPt * sinh(fEta) : fEta == 0 ? 0 : fEta > 0 ? fEta - etaMax<Scalar>() : fEta + etaMax<Scalar>();
    }
    Scalar Z () const { return Pz(); }
 
@@ -151,7 +150,7 @@ public :
        magnitude of momentum
    */
    Scalar P() const {
-      return fPt > 0 ? fPt * std::cosh(fEta)
+      return fPt > 0 ? fPt * cosh(fEta)
                      : fEta > etaMax<Scalar>() ? fEta - etaMax<Scalar>()
                                                : fEta < -etaMax<Scalar>() ? -fEta - etaMax<Scalar>() : 0;
    }
@@ -182,11 +181,11 @@ public :
    Scalar M() const    {
       const Scalar mm = M2();
       if (mm >= 0) {
-         return std::sqrt(mm);
+         return sqrt(mm);
       } else {
          GenVector::Throw ("PtEtaPhiE4D::M() - Tachyonic:\n"
                            "    Pt and Eta give P such that P^2 > E^2, so the mass would be imaginary");
-         return -std::sqrt(-mm);
+         return -sqrt(-mm);
       }
    }
    Scalar Mag() const    { return M(); }
@@ -208,11 +207,11 @@ public :
    Scalar Mt() const {
       const Scalar mm = Mt2();
       if (mm >= 0) {
-         return std::sqrt(mm);
+         return sqrt(mm);
       } else {
          GenVector::Throw ("PtEtaPhiE4D::Mt() - Tachyonic:\n"
                            "    Pt and Eta give Pz such that Pz^2 > E^2, so the mass would be imaginary");
-         return -std::sqrt(-mm);
+         return -sqrt(-mm);
       }
    }
 
@@ -223,7 +222,7 @@ public :
       transverse energy
    */
    Scalar Et() const {
-      return fE / std::cosh(fEta); // faster using eta
+      return fE / cosh(fEta); // faster using eta
    }
 
    /**
@@ -238,17 +237,14 @@ public :
 private:
    inline static Scalar pi() { return M_PI; }
    inline void Restrict() {
-      if (fPhi <= -pi() || fPhi > pi()) fPhi = fPhi - std::floor(fPhi / (2 * pi()) + .5) * 2 * pi();
+      if (fPhi <= -pi() || fPhi > pi()) fPhi = fPhi - floor(fPhi / (2 * pi()) + .5) * 2 * pi();
    }
 public:
 
    /**
       polar angle
    */
-   Scalar Theta() const {
-     return ( fPt  > 0  ? Scalar(2) * std::atan(std::exp(-fEta)) :
-              fEta >= 0 ? 0 : pi() );
-   }
+   Scalar Theta() const { return (fPt > 0 ? Scalar(2) * atan(exp(-fEta)) : fEta >= 0 ? 0 : pi()); }
 
    // --------- Set Coordinates of this system  ---------------
 

--- a/math/genvector/inc/Math/GenVector/PtEtaPhiM4D.h
+++ b/math/genvector/inc/Math/GenVector/PtEtaPhiM4D.h
@@ -150,13 +150,12 @@ public :
 
    // other coordinate representation
 
-   Scalar Px() const { return fPt * std::cos(fPhi); }
+   Scalar Px() const { return fPt * cos(fPhi); }
    Scalar X () const { return Px();         }
-   Scalar Py() const { return fPt * std::sin(fPhi); }
+   Scalar Py() const { return fPt * sin(fPhi); }
    Scalar Y () const { return Py();         }
    Scalar Pz() const {
-      return fPt > 0 ? fPt * std::sinh(fEta)
-                     : fEta == 0 ? 0 : fEta > 0 ? fEta - etaMax<Scalar>() : fEta + etaMax<Scalar>();
+      return fPt > 0 ? fPt * sinh(fEta) : fEta == 0 ? 0 : fEta > 0 ? fEta - etaMax<Scalar>() : fEta + etaMax<Scalar>();
    }
    Scalar Z () const { return Pz(); }
 
@@ -164,7 +163,7 @@ public :
        magnitude of momentum
    */
    Scalar P() const {
-      return fPt > 0 ? fPt * std::cosh(fEta)
+      return fPt > 0 ? fPt * cosh(fEta)
                      : fEta > etaMax<Scalar>() ? fEta - etaMax<Scalar>()
                                                : fEta < -etaMax<Scalar>() ? -fEta - etaMax<Scalar>() : 0;
    }
@@ -191,7 +190,7 @@ public :
    /**
        Energy (timelike component of momentum-energy 4-vector)
    */
-   Scalar E() const { return std::sqrt(E2()); }
+   Scalar E() const { return sqrt(E2()); }
 
    Scalar T()   const { return E();  }
 
@@ -221,11 +220,11 @@ public :
    Scalar Mt() const {
       const Scalar mm = Mt2();
       if (mm >= 0) {
-         return std::sqrt(mm);
+         return sqrt(mm);
       } else {
          GenVector::Throw  ("PtEtaPhiM4D::Mt() - Tachyonic:\n"
                             "    Pz^2 > E^2 so the transverse mass would be imaginary");
-         return -std::sqrt(-mm);
+         return -sqrt(-mm);
       }
    }
 
@@ -234,20 +233,18 @@ public :
    */
    Scalar Et2() const {
       // a bit faster than et * et
-      return 2. * E2() / (std::cosh(2 * fEta) + 1);
+      return 2. * E2() / (cosh(2 * fEta) + 1);
    }
 
    /**
       transverse energy
    */
-   Scalar Et() const {
-     return E() / std::cosh(fEta);
-   }
+   Scalar Et() const { return E() / cosh(fEta); }
 
 private:
    inline static Scalar pi() { return M_PI; }
    inline void RestrictPhi() {
-      if (fPhi <= -pi() || fPhi > pi()) fPhi = fPhi - std::floor(fPhi / (2 * pi()) + .5) * 2 * pi();
+      if (fPhi <= -pi() || fPhi > pi()) fPhi = fPhi - floor(fPhi / (2 * pi()) + .5) * 2 * pi();
    }
    // restrict the value of negative mass to avoid unphysical negative E2 values
    // M2 must be less than P2 for the tachionic particles - otherwise use positive values
@@ -265,10 +262,7 @@ public:
    /**
       polar angle
    */
-   Scalar Theta() const {
-     return ( fPt  > 0  ? Scalar(2) * std::atan(std::exp(-fEta)) :
-              fEta >= 0 ? 0 : pi() );
-   }
+   Scalar Theta() const { return (fPt > 0 ? Scalar(2) * atan(exp(-fEta)) : fEta >= 0 ? 0 : pi()); }
 
    // --------- Set Coordinates of this system  ---------------
 

--- a/math/genvector/inc/Math/GenVector/PxPyPzE4D.h
+++ b/math/genvector/inc/Math/GenVector/PxPyPzE4D.h
@@ -135,7 +135,7 @@ public :
    /**
       magnitude of spatial components (magnitude of 3-momentum)
    */
-   Scalar P() const { return std::sqrt(P2()); }
+   Scalar P() const { return sqrt(P2()); }
    Scalar R() const { return P(); }
 
    /**
@@ -151,11 +151,11 @@ public :
    {
       const Scalar mm = M2();
       if (mm >= 0) {
-         return std::sqrt(mm);
+         return sqrt(mm);
       } else {
          GenVector::Throw ("PxPyPzE4D::M() - Tachyonic:\n"
                    "    P^2 > E^2 so the mass would be imaginary");
-         return -std::sqrt(-mm);
+         return -sqrt(-mm);
       }
    }
    Scalar Mag() const    { return M(); }
@@ -169,7 +169,7 @@ public :
    /**
       Transverse spatial component (P_perp or rho)
    */
-   Scalar Pt() const { return std::sqrt(Perp2()); }
+   Scalar Pt() const { return sqrt(Perp2()); }
    Scalar Perp() const { return Pt();}
    Scalar Rho()  const { return Pt();}
 
@@ -184,11 +184,11 @@ public :
    Scalar Mt() const {
       const Scalar mm = Mt2();
       if (mm >= 0) {
-         return std::sqrt(mm);
+         return sqrt(mm);
       } else {
          GenVector::Throw ("PxPyPzE4D::Mt() - Tachyonic:\n"
                            "    Pz^2 > E^2 so the transverse mass would be imaginary");
-         return -std::sqrt(-mm);
+         return -sqrt(-mm);
       }
    }
 
@@ -206,22 +206,18 @@ public :
    */
    Scalar Et() const {
       const Scalar etet = Et2();
-      return fT < 0.0 ? -std::sqrt(etet) : std::sqrt(etet);
+      return fT < 0.0 ? -sqrt(etet) : sqrt(etet);
    }
 
    /**
       azimuthal angle
    */
-   Scalar Phi() const  {
-      return (fX == 0.0 && fY == 0.0) ? 0 : std::atan2(fY, fX);
-   }
+   Scalar Phi() const { return (fX == 0.0 && fY == 0.0) ? 0 : atan2(fY, fX); }
 
    /**
       polar angle
    */
-   Scalar Theta() const {
-      return (fX == 0.0 && fY == 0.0 && fZ == 0.0) ? 0 : std::atan2(Pt(), fZ);
-   }
+   Scalar Theta() const { return (fX == 0.0 && fY == 0.0 && fZ == 0.0) ? 0 : atan2(Pt(), fZ); }
 
    /**
        pseudorapidity

--- a/math/genvector/inc/Math/GenVector/PxPyPzM4D.h
+++ b/math/genvector/inc/Math/GenVector/PxPyPzM4D.h
@@ -154,7 +154,7 @@ public :
    /**
       Energy
     */
-   Scalar E() const { return std::sqrt(E2()); }
+   Scalar E() const { return sqrt(E2()); }
 
    Scalar T() const { return E();}
 
@@ -166,7 +166,7 @@ public :
    /**
       magnitude of spatial components (magnitude of 3-momentum)
    */
-   Scalar P() const { return std::sqrt(P2()); }
+   Scalar P() const { return sqrt(P2()); }
    Scalar R() const { return P(); }
 
    /**
@@ -198,7 +198,7 @@ public :
    /**
       Transverse spatial component (P_perp or rho)
    */
-   Scalar Pt() const { return std::sqrt(Perp2()); }
+   Scalar Pt() const { return sqrt(Perp2()); }
    Scalar Perp() const { return Pt();}
    Scalar Rho()  const { return Pt();}
 
@@ -213,11 +213,11 @@ public :
    Scalar Mt() const {
       const Scalar mm = Mt2();
       if (mm >= 0) {
-         return std::sqrt(mm);
+         return sqrt(mm);
       } else {
          GenVector::Throw ("PxPyPzM4D::Mt() - Tachyonic:\n"
                            "    Pz^2 > E^2 so the transverse mass would be imaginary");
-         return -std::sqrt(-mm);
+         return -sqrt(-mm);
       }
    }
 
@@ -235,22 +235,18 @@ public :
    */
    Scalar Et() const {
       const Scalar etet = Et2();
-      return std::sqrt(etet);
+      return sqrt(etet);
    }
 
    /**
       azimuthal angle
    */
-   Scalar Phi() const  {
-      return (fX == 0.0 && fY == 0.0) ? 0.0 : std::atan2(fY, fX);
-   }
+   Scalar Phi() const { return (fX == 0.0 && fY == 0.0) ? 0.0 : atan2(fY, fX); }
 
    /**
       polar angle
    */
-   Scalar Theta() const {
-      return (fX == 0.0 && fY == 0.0 && fZ == 0.0) ? 0 : std::atan2(Pt(), fZ);
-   }
+   Scalar Theta() const { return (fX == 0.0 && fY == 0.0 && fZ == 0.0) ? 0 : atan2(Pt(), fZ); }
 
    /**
        pseudorapidity

--- a/math/genvector/inc/Math/GenVector/RotationX.h
+++ b/math/genvector/inc/Math/GenVector/RotationX.h
@@ -94,13 +94,13 @@ public:
    /**
       Get the angle
    */
-   void GetAngle(Scalar &angle) const { angle = std::atan2(fSin, fCos); }
+   void GetAngle(Scalar &angle) const { angle = atan2(fSin, fCos); }
    void GetComponents ( Scalar & angle ) const { GetAngle(angle); }
 
    /**
       Angle of rotation
    */
-   Scalar Angle() const { return std::atan2(fSin, fCos); }
+   Scalar Angle() const { return atan2(fSin, fCos); }
 
    /**
       Sine or Cosine of the rotation angle

--- a/math/genvector/inc/Math/GenVector/RotationY.h
+++ b/math/genvector/inc/Math/GenVector/RotationY.h
@@ -94,13 +94,13 @@ public:
    /**
       Get the angle
    */
-   void GetAngle(Scalar &angle) const { angle = std::atan2(fSin, fCos); }
+   void GetAngle(Scalar &angle) const { angle = atan2(fSin, fCos); }
    void GetComponents ( Scalar & angle ) const { GetAngle(angle); }
 
    /**
       Angle of rotation
    */
-   Scalar Angle() const { return std::atan2(fSin, fCos); }
+   Scalar Angle() const { return atan2(fSin, fCos); }
 
    /**
       Sine or Cosine of the rotation angle

--- a/math/genvector/inc/Math/GenVector/RotationZ.h
+++ b/math/genvector/inc/Math/GenVector/RotationZ.h
@@ -94,13 +94,13 @@ public:
    /**
       Get the angle
    */
-   void GetAngle(Scalar &angle) const { angle = std::atan2(fSin, fCos); }
+   void GetAngle(Scalar &angle) const { angle = atan2(fSin, fCos); }
    void GetComponents ( Scalar & angle ) const { GetAngle(angle); }
 
    /**
       Angle of rotation
    */
-   Scalar Angle() const { return std::atan2(fSin, fCos); }
+   Scalar Angle() const { return atan2(fSin, fCos); }
 
    /**
       Sine or Cosine of the rotation angle

--- a/math/genvector/inc/Math/GenVector/VectorUtil.h
+++ b/math/genvector/inc/Math/GenVector/VectorUtil.h
@@ -251,8 +251,8 @@ namespace ROOT {
           */
          template <class Vector>
          Vector RotateX(const Vector & v, double alpha) {
-            double sina = std::sin(alpha);
-            double cosa = std::cos(alpha);
+            double sina = sin(alpha);
+            double cosa = cos(alpha);
             double y2 = v.Y() * cosa - v.Z()*sina;
             double z2 = v.Z() * cosa + v.Y() * sina;
             Vector vrot;
@@ -268,8 +268,8 @@ namespace ROOT {
           */
          template <class Vector>
          Vector RotateY(const Vector & v, double alpha) {
-            double sina = std::sin(alpha);
-            double cosa = std::cos(alpha);
+            double sina = sin(alpha);
+            double cosa = cos(alpha);
             double x2 = v.X() * cosa + v.Z() * sina;
             double z2 = v.Z() * cosa - v.X() * sina;
             Vector vrot;
@@ -285,8 +285,8 @@ namespace ROOT {
           */
          template <class Vector>
          Vector RotateZ(const Vector & v, double alpha) {
-            double sina = std::sin(alpha);
-            double cosa = std::cos(alpha);
+            double sina = sin(alpha);
+            double cosa = cos(alpha);
             double x2 = v.X() * cosa - v.Y() * sina;
             double y2 = v.Y() * cosa + v.X() * sina;
             Vector vrot;

--- a/math/genvector/inc/Math/GenVector/eta.h
+++ b/math/genvector/inc/Math/GenVector/eta.h
@@ -49,15 +49,14 @@ namespace ROOT {
            if (rho > 0) {
 
               // value to control Taylor expansion of sqrt
-              static const Scalar big_z_scaled =
-                 std::pow(std::numeric_limits<Scalar>::epsilon(), static_cast<Scalar>(-.25));
+              static const Scalar big_z_scaled = pow(std::numeric_limits<Scalar>::epsilon(), static_cast<Scalar>(-.25));
 
               Scalar z_scaled = z/rho;
               if (std::fabs(z_scaled) < big_z_scaled) {
-                 return std::log(z_scaled + std::sqrt(z_scaled * z_scaled + 1.0));
+                 return log(z_scaled + sqrt(z_scaled * z_scaled + 1.0));
               } else {
                  // apply correction using first order Taylor expansion of sqrt
-                 return z > 0 ? std::log(2.0 * z_scaled + 0.5 / z_scaled) : -std::log(-2.0 * z_scaled);
+                 return z > 0 ? log(2.0 * z_scaled + 0.5 / z_scaled) : -log(-2.0 * z_scaled);
               }
            }
            // case vector has rho = 0
@@ -80,7 +79,7 @@ namespace ROOT {
         */
         template<typename Scalar>
         inline Scalar Eta_FromTheta(Scalar theta, Scalar r) {
-           Scalar tanThetaOver2 = std::tan(theta / 2.);
+           Scalar tanThetaOver2 = tan(theta / 2.);
            if (tanThetaOver2 == 0) {
               return r + etaMax<Scalar>();
            }
@@ -88,7 +87,7 @@ namespace ROOT {
               return -r - etaMax<Scalar>();
            }
            else {
-              return -std::log(tanThetaOver2);
+              return -log(tanThetaOver2);
            }
 
         }

--- a/math/mathcore/inc/Math/Math.h
+++ b/math/mathcore/inc/Math/Math.h
@@ -61,18 +61,41 @@ namespace ROOT {
 
 
    namespace Math {
+   // Enable Vc/VecCore template instantiations to replace std math functions via argument dependent lookup (ADL).
+   // The ADL works with unqualified identifiers thus we must implement our functions without prefixing them with
+   // std. For example MyPow(double) { return pow(); } instead of MyPow(double) { return std::pow(); }.
+   //
+   // This allows template instantiations with a Vc/VecCore type, to add to the lookup candidates its vectorized math
+   // functions.
+   //
+   // We don't want to use 'using namespace std' because it would polute the including headers.
+   using std::atan2;
+   using std::cos;
+   using std::cosh;
+   using std::exp;
+   using std::floor;
+   using std::log;
+   using std::pow;
+   using std::sin;
+   using std::sinh;
+   using std::sqrt;
+   using std::tan;
 
-/**
-    Mathematical constants
-*/
-inline double Pi() { return M_PI; }
+   /**
+       Mathematical constants
+   */
+   inline double Pi()
+   {
+      return M_PI;
+   }
 
-/**
-    declarations for functions which are not implemented by some compilers
-*/
+   /**
+       declarations for functions which are not implemented by some compilers
+   */
 
-/// log(1+x) with error cancelatio when x is small
-inline double log1p( double x) {
+   /// log(1+x) with error cancelatio when x is small
+   inline double log1p(double x)
+   {
 #ifndef HAVE_NO_LOG1P
    return ::log1p(x);
 #else

--- a/test/testGenVectorVc.cxx
+++ b/test/testGenVectorVc.cxx
@@ -1,13 +1,11 @@
-
-// Vc. Must be before the ROOT includes for std:: math functions to work...
-#include <Vc/Vc>
-
 // ROOT
 #include "Math/GenVector/PositionVector3D.h"
 #include "Math/GenVector/DisplacementVector3D.h"
 #include "Math/GenVector/Plane3D.h"
 #include "Math/GenVector/Transform3D.h"
 #include "TStopwatch.h"
+
+#include <Vc/Vc>
 
 // STL
 #include <random>


### PR DESCRIPTION
This allows the header files to spell the std math functions unqualified and
this way to allow template instantiations with vector types to swap them with
vector functions.

Consider:
```cpp

namespace N {
  void call(double);
}

inline namespace __1 {
using N::call; //  Enables ADL in a nicer and more transparent way
template <class T>
struct S {
  int f() {
    using namespace N; // enables ADL but it looks ugly...
    call(T()); // call is an unqualified id, thus ADL will kick in. If we had `N::call(T())` we would have a compiler error.
    return 42;
  }
};
}

namespace N {
  struct V{};
  void call(V);
}

int res = S<N::V>().f(); // The compiler will add lookup candidates from namespace N.

```