### PR TITLE
Fix inf loop in test on arm

### DIFF
--- a/tmva/tmva/src/ResultsMulticlass.cxx
+++ b/tmva/tmva/src/ResultsMulticlass.cxx
@@ -114,7 +114,7 @@ Double_t TMVA::ResultsMulticlass::EstimatorFunction( std::vector<Double_t> & cut
    Float_t effTimesPur = eff*pur;
 
    Float_t toMinimize = std::numeric_limits<float>::max();
-   if( effTimesPur > 0 )
+   if (effTimesPur > std::numeric_limits<float>::min())
       toMinimize = 1./(effTimesPur); // we want to minimize 1/efficiency*purity
 
    fAchievableEff.at(fClassToOptimize) = eff;


### PR DESCRIPTION
There was an infinite loop on the arm platform when running TMVAMulticlass.root. When compiling with the -ffast-math flag, sometimes a nan would be generated in the GA part of the cut optimisation.

@dpiparo @martinmine Hopefully this resolves your issue. Tried it on the build machine I was given access to and it works there now. We in the TMVA team still need to revisit this part at some point, but for now I think this should be ok.