### PR TITLE
Root 8563 fix out of bounds index

### DIFF
--- a/tmva/tmva/inc/TMVA/NeuralNet.icc
+++ b/tmva/tmva/inc/TMVA/NeuralNet.icc
@@ -819,15 +819,17 @@ template <typename LAYERDATA>
                             std::tuple<double,std::vector<double>> result = f.get ();
                             testError += std::get<0>(result) / batches.size ();
                             std::vector<double> output = std::get<1>(result);
-                            
-                            auto output_iterator = output.begin();
-                            for (auto pattern_it = itBatch->begin(); pattern_it != itBatch->end(); ++pattern_it) 
+                            if (output.size() == outputSize() * itBatch->size())
                             {
-                                for (size_t output_index = 0; output_index < outputSize(); ++output_index)
+                                auto output_iterator = output.begin();
+                                for (auto pattern_it = itBatch->begin(); pattern_it != itBatch->end(); ++pattern_it) 
                                 {
-                                    settings.testSample (0, *output_iterator, (*pattern_it).output ().at (0),
-                                                                              (*pattern_it).weight ());
-                                    ++output_iterator;
+                                    for (size_t output_index = 0; output_index < outputSize(); ++output_index)
+                                    {
+                                        settings.testSample (0, *output_iterator, (*pattern_it).output ().at (0),
+                                                                                  (*pattern_it).weight ());
+                                        ++output_iterator;
+                                    }
                                 }
                             }
                         ++itBatch;
@@ -846,15 +848,17 @@ template <typename LAYERDATA>
                             output.clear ();
                         pass_through_type passThrough (settings, batch, dropContainerTest);
                             double testPatternError = (*this) (passThrough, weights, ModeOutput::FETCH, output);
-                        
-                        auto output_iterator = output.begin();
-                        for (auto pattern_it = batch.begin(); pattern_it != batch.end(); ++pattern_it) 
+                        if (output.size() == outputSize() * batch.size())
                         {
-                            for (size_t output_index = 0; output_index < outputSize(); ++output_index)
+                            auto output_iterator = output.begin();
+                            for (auto pattern_it = batch.begin(); pattern_it != batch.end(); ++pattern_it) 
                             {
-                                settings.testSample (0, *output_iterator, (*pattern_it).output ().at (0),
+                                for (size_t output_index = 0; output_index < outputSize(); ++output_index)
+                                {
+                                    settings.testSample (0, *output_iterator, (*pattern_it).output ().at (0),
                                                                               (*pattern_it).weight ());
-                                ++output_iterator;
+                                    ++output_iterator;
+                                }
                             }
                         }
                         testError += testPatternError; /// batch.size ();

--- a/tmva/tmva/inc/TMVA/NeuralNet.icc
+++ b/tmva/tmva/inc/TMVA/NeuralNet.icc
@@ -819,12 +819,12 @@ template <typename LAYERDATA>
                             std::tuple<double,std::vector<double>> result = f.get ();
                             testError += std::get<0>(result) / batches.size ();
                             std::vector<double> output = std::get<1>(result);
-                            if (output.size() == outputSize() * itBatch->size())
+                            if (output.size() == (outputSize() - 1) * itBatch->size())
                             {
                                 auto output_iterator = output.begin();
                                 for (auto pattern_it = itBatch->begin(); pattern_it != itBatch->end(); ++pattern_it) 
                                 {
-                                    for (size_t output_index = 0; output_index < outputSize(); ++output_index)
+                                    for (size_t output_index = 1; output_index < outputSize(); ++output_index)
                                     {
                                         settings.testSample (0, *output_iterator, (*pattern_it).output ().at (0),
                                                                                   (*pattern_it).weight ());
@@ -848,12 +848,12 @@ template <typename LAYERDATA>
                             output.clear ();
                         pass_through_type passThrough (settings, batch, dropContainerTest);
                             double testPatternError = (*this) (passThrough, weights, ModeOutput::FETCH, output);
-                        if (output.size() == outputSize() * batch.size())
+                        if (output.size() == (outputSize() - 1) * batch.size())
                         {
                             auto output_iterator = output.begin();
                             for (auto pattern_it = batch.begin(); pattern_it != batch.end(); ++pattern_it) 
                             {
-                                for (size_t output_index = 0; output_index < outputSize(); ++output_index)
+                                for (size_t output_index = 1; output_index < outputSize(); ++output_index)
                                 {
                                     settings.testSample (0, *output_iterator, (*pattern_it).output ().at (0),
                                                                               (*pattern_it).weight ());

--- a/tmva/tmva/inc/TMVA/NeuralNet.icc
+++ b/tmva/tmva/inc/TMVA/NeuralNet.icc
@@ -830,19 +830,6 @@ template <typename LAYERDATA>
                                     ++output_iterator;
                                 }
                             }
-
-                            /*
-                            //if (output.size () == testPattern.size ())
-                            {
-                                //auto it = begin (testPattern);
-                                auto it = (*itBatch).begin ();
-                                for (double out : output)
-                                {
-                                    settings.testSample (0, out, (*it).output ().at (0), (*it).weight ());
-                                    ++it;
-                                }
-                            }
-                            */
                         ++itBatch;
                         }
                     
@@ -870,17 +857,6 @@ template <typename LAYERDATA>
                                 ++output_iterator;
                             }
                         }
-                        
-                        /*
-                        auto it = batch.begin ();
-                        for (double out : output)
-                            {
-                            settings.testSample (0, out, (*it).output ().at (0), (*it).weight ());
-                            ++it;
-                            }
-                            //weightSum += fabs (weight);
-                            //testError += testPatternError*weight;
-                        */
                         testError += testPatternError; /// batch.size ();
                         }
                     // testError /= testPattern.size ();

--- a/tmva/tmva/inc/TMVA/NeuralNet.icc
+++ b/tmva/tmva/inc/TMVA/NeuralNet.icc
@@ -822,14 +822,14 @@ template <typename LAYERDATA>
                             
                             auto output_iterator = output.begin();
                             for (auto pattern_it = itBatch->begin(); pattern_it != itBatch->end(); ++pattern_it) 
+                            {
+                                for (size_t output_index = 0; output_index < outputSize(); ++output_index)
                                 {
-                                    for (size_t output_index = 0; output_index < outputSize(); ++output_index)
-                                        {
-                                        settings.testSample (0, *output_iterator, (*pattern_it).output ().at (0),
-                                                                                  (*pattern_it).weight ());
-                                        ++output_iterator;
-                                        }
+                                    settings.testSample (0, *output_iterator, (*pattern_it).output ().at (0),
+                                                                              (*pattern_it).weight ());
+                                    ++output_iterator;
                                 }
+                            }
 
                             /*
                             //if (output.size () == testPattern.size ())
@@ -862,14 +862,15 @@ template <typename LAYERDATA>
                         
                         auto output_iterator = output.begin();
                         for (auto pattern_it = batch.begin(); pattern_it != batch.end(); ++pattern_it) 
+                        {
+                            for (size_t output_index = 0; output_index < outputSize(); ++output_index)
                             {
-                                for (size_t output_index = 0; output_index < outputSize(); ++output_index)
-                                    {
-                                    settings.testSample (0, *output_iterator, (*pattern_it).output ().at (0),
+                                settings.testSample (0, *output_iterator, (*pattern_it).output ().at (0),
                                                                               (*pattern_it).weight ());
-                                    ++output_iterator;
-                                    }
+                                ++output_iterator;
                             }
+                        }
+                        
                         /*
                         auto it = batch.begin ();
                         for (double out : output)

--- a/tmva/tmva/inc/TMVA/NeuralNet.icc
+++ b/tmva/tmva/inc/TMVA/NeuralNet.icc
@@ -819,7 +819,19 @@ template <typename LAYERDATA>
                             std::tuple<double,std::vector<double>> result = f.get ();
                             testError += std::get<0>(result) / batches.size ();
                             std::vector<double> output = std::get<1>(result);
+                            
+                            auto output_iterator = output.begin();
+                            for (auto pattern_it = itBatch->begin(); pattern_it != itBatch->end(); ++pattern_it) 
+                                {
+                                    for (size_t output_index = 0; output_index < outputSize(); ++output_index)
+                                        {
+                                        settings.testSample (0, *output_iterator, (*pattern_it).output ().at (0),
+                                                                                  (*pattern_it).weight ());
+                                        ++output_iterator;
+                                        }
+                                }
 
+                            /*
                             //if (output.size () == testPattern.size ())
                             {
                                 //auto it = begin (testPattern);
@@ -830,6 +842,7 @@ template <typename LAYERDATA>
                                     ++it;
                                 }
                             }
+                            */
                         ++itBatch;
                         }
                     
@@ -846,7 +859,18 @@ template <typename LAYERDATA>
                             output.clear ();
                         pass_through_type passThrough (settings, batch, dropContainerTest);
                             double testPatternError = (*this) (passThrough, weights, ModeOutput::FETCH, output);
-
+                        
+                        auto output_iterator = output.begin();
+                        for (auto pattern_it = batch.begin(); pattern_it != batch.end(); ++pattern_it) 
+                            {
+                                for (size_t output_index = 0; output_index < outputSize(); ++output_index)
+                                    {
+                                    settings.testSample (0, *output_iterator, (*pattern_it).output ().at (0),
+                                                                              (*pattern_it).weight ());
+                                    ++output_iterator;
+                                    }
+                            }
+                        /*
                         auto it = batch.begin ();
                         for (double out : output)
                             {
@@ -855,6 +879,7 @@ template <typename LAYERDATA>
                             }
                             //weightSum += fabs (weight);
                             //testError += testPatternError*weight;
+                        */
                         testError += testPatternError; /// batch.size ();
                         }
                     // testError /= testPattern.size ();


### PR DESCRIPTION
fixed crash from the issue tracker ROOT-8563
"TMVA Multiclass example crash when running with argument "DNN""
The problem during logging the output from the last layer, due to the difference of sizes of testPattern and Output. Now the code takes into account the fact that there may be multiple outputs from the last layer of the Neural Net.