### PR TITLE
Fix Transform3D * Plane3D multiplication operator

### DIFF
--- a/math/genvector/inc/Math/GenVector/Transform3D.h
+++ b/math/genvector/inc/Math/GenVector/Transform3D.h
@@ -712,15 +712,23 @@ public:
    /**
       Transformation on a 3D plane
    */
-   Plane3D<T> operator()(const Plane3D<T> &plane) const
+   template <typename TYPE>
+   Plane3D<TYPE> operator()(const Plane3D<TYPE> &plane) const
    {
       // transformations on a 3D plane
-      const Vector n = plane.Normal();
+      const auto n = plane.Normal();
       // take a point on the plane. Use origin projection on the plane
       // ( -ad, -bd, -cd) if (a**2 + b**2 + c**2 ) = 1
-      const T d = plane.HesseDistance();
-      Point   p(-d * n.X(), -d * n.Y(), -d * n.Z());
-      return Plane3D<T>(operator()(n), operator()(p));
+      const auto d = plane.HesseDistance();
+      Point p(-d * n.X(), -d * n.Y(), -d * n.Z());
+      return Plane3D<TYPE>(operator()(n), operator()(p));
+   }
+
+   /// Multiplication operator for 3D plane
+   template <typename TYPE>
+   Plane3D<TYPE> operator*(const Plane3D<TYPE> &plane) const
+   {
+      return operator()(plane);
    }
 
    // skip transformation for arbitrary vectors - not really defined if point or displacement vectors


### PR DESCRIPTION
This PR fixes a regression introduced in a recent update to extend the templation in GenVector (PR #394). It turns out that this update broke the multiplication of a Transform3D by a Plane3D. This regression was spotted in the LHCb nightly build which tests against the master of ROOT. e.g.

https://lhcb-nightlies.cern.ch/logs/build/nightly/lhcb-lcg-dev3/105/x86_64-centos7-gcc62-opt/LHCb/#show_error1538

The error is

```
/build/jenkins-build-new/workspace/nightly-builds/build/build/LHCB/LHCB_HEAD/Det/RichDet/src/Lib/DeRichHPDPanel.cpp:673:52: error: no match for 'operator*' (operand types are 'const Transform3D {aka const ROOT::Math::Impl::Transform3D<double>}' and 'Gaudi::Plane3D {aka ROOT::Math::Impl::Plane3D<double>}')
	   m_localPlane       = geometry()->toLocalMatrix() * m_detectionPlane;

/build/jenkins-build-new/workspace/nightly-builds/build/build/LHCB/LHCB_HEAD/Det/RichDet/src/Lib/DeRichPMTPanel.cpp:407:46: error: no match for 'operator*' (operand types are 'const Transform3D {aka const ROOT::Math::Impl::Transform3D<double>}' and 'Gaudi::Plane3D {aka ROOT::Math::Impl::Plane3D<double>}')
	   m_localPlane = geometry()->toLocalMatrix() * m_detectionPlane;
```

This PR fixes this by adding an explicit operator for this.

I have also extended the GenVector Vc test to explicitly cover this operation, as it was clearly one not covered in the ROOT tests so far.