### PR TITLE
Patch GetVariableSettings() method to correctly report parameter limits.

### DIFF
--- a/math/minuit2/src/Minuit2Minimizer.cxx
+++ b/math/minuit2/src/Minuit2Minimizer.cxx
@@ -332,9 +332,15 @@ bool Minuit2Minimizer::GetVariableSettings(unsigned int ivar, ROOT::Fit::Paramet
    }
    const MinuitParameter & par = fState.Parameter(ivar);
    varObj.Set( par.Name(), par.Value(), par.Error() );
-   if (par.HasLowerLimit() ) varObj.SetLowerLimit(par.LowerLimit() );
-   else if (par.HasUpperLimit() ) varObj.SetUpperLimit(par.UpperLimit() );
-   else if (par.HasLimits() ) varObj.SetLimits(par.LowerLimit(), par.UpperLimit() );
+   if (par.HasLowerLimit() ) {
+     if (par.HasUpperLimit() ) {
+       varObj.SetLimits(par.LowerLimit(), par.UpperLimit() );
+     } else {
+       varObj.SetLowerLimit(par.LowerLimit() );
+     }
+   } else if (par.HasUpperLimit() ) {
+     varObj.SetUpperLimit(par.UpperLimit() );
+   }
    if (par.IsConst() || par.IsFixed() ) varObj.Fix();
    return true;
 }


### PR DESCRIPTION
Minuit2Minimizer's GetVariableSettings method doesn't correctly report parameter limits.
This PR corrects its logic to report them correctly.

In the old code then a variable with lower+upper limits only has the lower limit reported.