### PR TITLE
Don't search default paths when looking for numpy

### DIFF
--- a/cmake/modules/FindNumPy.cmake
+++ b/cmake/modules/FindNumPy.cmake
@@ -82,7 +82,8 @@ if("${_VER_CHECK}" STREQUAL "")
     return()
 endif()
 
-find_path(NUMPY_INCLUDE_DIR numpy/numpyconfig.h PATHS ${_numpy_include_path})
+# we already know where it should be so don't search default paths as well.
+find_path(NUMPY_INCLUDE_DIR numpy/numpyconfig.h PATHS ${_numpy_include_path} NO_DEFAULT_PATH)
 if(NUMPY_INCLUDE_DIR)
   set(NUMPY_INCLUDE_DIRS ${NUMPY_INCLUDE_DIR})
 endif()


### PR DESCRIPTION
cmakes `find_path()` function looks first in system directories and then
in the directories listed by `PATHS`.  So if there are numpy includes in
`/usr/include` they will be found first which can break the build.

One way to fix this could be to use `HINTS` instead of `PATHS` which will be
searched before the system paths. But in this case we know which
directory we want as we got it from python so let's just skip all other
paths and just look there by adding `NO_DEFAULT_PATH`.