### PR TITLE
Fix ABI compability when linking against OCCI when using clang.

### DIFF
--- a/cmake/modules/CheckCompiler.cmake
+++ b/cmake/modules/CheckCompiler.cmake
@@ -166,6 +166,18 @@ if(gnuinstall)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DR__HAVE_CONFIG")
 endif()
 
+#---Check if we use the new libstdc++ CXX11 ABI-----------------------------------------------------
+# Necessary to compile check_cxx_source_compiles this early
+include(CheckCXXSourceCompiles)
+check_cxx_source_compiles(
+"
+#include <string>
+#if _GLIBCXX_USE_CXX11_ABI == 0
+  #error NOCXX11
+#endif
+int main() {}
+" GLIBCXX_USE_CXX11_ABI)
+
 #---Print the final compiler flags--------------------------------------------------------------------
 message(STATUS "ROOT Platform: ${ROOT_PLATFORM}")
 message(STATUS "ROOT Architecture: ${ROOT_ARCHITECTURE}")

--- a/sql/oracle/CMakeLists.txt
+++ b/sql/oracle/CMakeLists.txt
@@ -8,7 +8,11 @@ add_definitions(${ORACLE_DEFINITIONS})
 ROOT_GENERATE_DICTIONARY(G__Oracle *.h MODULE Oracle LINKDEF LinkDef.h)
 
 ROOT_LINKER_LIBRARY(Oracle *.cxx G__Oracle.cxx LIBRARIES Core ${ORACLE_LIBRARIES} DEPENDENCIES Net RIO)
-if(GCC_MAJOR GREATER 4)
+
+# Check if libstdc++ uses the new string ABI and fall back to the old one if yes.
+# We have to check for this because on the nightly builds we have an old occi
+# installation that uses the old ABI, which results in linking errors.
+if(${GLIBCXX_USE_CXX11_ABI})
   file(GLOB srcs src/TOracle*.cxx)
   set_source_files_properties(${srcs} PROPERTIES COMPILE_DEFINITIONS _GLIBCXX_USE_CXX11_ABI=0)
 endif()


### PR DESCRIPTION
This patch improves the previous check whether the current compiler
is using an incompatible libstdc++ version or not.