### PR TITLE
Implement TDirectoryEntry cast to base without TClass

### DIFF
--- a/io/io/v7/inc/ROOT/TFile.hxx
+++ b/io/io/v7/inc/ROOT/TFile.hxx
@@ -161,7 +161,7 @@ public:
   /// Write an object that is already lifetime managed by this TFileImplBase.
   void Write(std::string_view name) {
     auto dep = Find(name.to_string());
-    WriteMemoryWithType(name, dep.GetPointer().get(), dep.GetType());
+    WriteMemoryWithType(name, dep.GetPointer().get(), TClass::GetClass(dep.GetTypeInfo()));
   }
 
   /// Hand over lifetime management of an object to this TFileImplBase, and


### PR DESCRIPTION
This method is based on GNU libstc++/libsupc++ and LLVM libc++(abi) implementations of exception handler matching algorithm. And on the fact that in AMD64 SysV ABI class methods could be called just like ordinary functions with additional first argument (a.k.a. `this` pointer).

I think this method requires more explanation.

It all started from my proposal to rely on Itanium C++ ABI to implement cast. I won't post that mail here because it is written in such a broken English.

On 24/03/17 22:32, Axel Naumann wrote:
> Hi Berserker,
>
> I'm more and more convinced that this is the way to go... I'm talking
> specifically about
> <https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/libsupc%2B%2B/cxxabi.h#L591>
> here.
>
> Do you think you could give it a shot in the form of a PR? 

On 25/03/17 19:06, Berserker Troll wrote:
> Hi Axel,
> 
> __dynamic_cast is standardized, but works only for polymorphic classes, while TClass::DynamicCast and exception-based cast also work for non-polymorphic ones.
> If you want TDirectory to work for all kinds of classes you should consider not dynamic_cast algorithm [1], but exception handler matching one [2].
> Unfortunately, [2] says:
>> Since the RTTI related exception handling routines are "personality specific", no interfaces need to be specified in this document (beyond the layout of the RTTI data).
> 
> In libstdc++/libsupc++, handler matching algorithm is easily accessible directly through std::type_info from standard <typeinfo> header, using __do_catch() member function [3].
> The situation with libcxxabi is a bit more complicated. std::type_info in libcxx <typeinfo> header [4] doesn't have any non-standard member functions, instead it has additional hidden __shim_type_info class [5] between std::type_info and other Itanium C++ ABI type_info derived types. And this __shim_type_info class, in turn, provides access to the handler matching algorithm [6].
> 
> So, if we want this exception hander matching algorithm, there are a couple of options:
> 1) Stick to libsupc++ with its "public" __do_catch() member function
> 2) Implement independent handler matching algorithm ([7] might help), I think it doesn't require anything except standardised list of type_info-derived types [8]
> 3) Take a closer look at noop1() and noop2() virtual methods above [6]. I suspect they were added to make libcxxabi type_info's vtable compatible with one of type_info from libsupc++, because libsupc++'s type_info also has a couple of virtual methods before the method which does catching check (see above [3]). The only difference is that __do_catch() has additional third argument whilst libcxxabi's can_catch() has only two. I think it won't cause problems if one calls two-argument method with three arguments, but doing the opposite might be troublesome. So, finally, if I'm right, we may try to call the method using vtable offset directly.
> 
> [1] https://itanium-cxx-abi.github.io/cxx-abi/abi.html#dynamic_cast-algorithm
> [2] https://itanium-cxx-abi.github.io/cxx-abi/abi.html#exception-matching-algorithm
> [3] https://github.com/gcc-mirror/gcc/blob/8805daa6d1a973e4e85698d7cf65a46c8cc85aac/libstdc%2B%2B-v3/libsupc%2B%2B/typeinfo#L163
> [4] https://github.com/llvm-mirror/libcxx/blob/68fdad67e334de18451c749550908274a5fd2542/include/typeinfo
> [5] https://github.com/llvm-mirror/libcxxabi/blob/1f4353379227ba3d8b44a8694fc54e0ca6de39cd/src/private_typeinfo.h#L20
> [6] https://github.com/llvm-mirror/libcxxabi/blob/1f4353379227ba3d8b44a8694fc54e0ca6de39cd/src/private_typeinfo.h#L26
> [7] https://github.com/llvm-mirror/libcxxabi/blob/1f4353379227ba3d8b44a8694fc54e0ca6de39cd/src/private_typeinfo.cpp#L147
> [8] https://itanium-cxx-abi.github.io/cxx-abi/abi.html#rtti-layout

On 26/03/17 16:54, Berserker Troll wrote:
> I've implemented cast based on direct vtable access [9]. It should work for both libstdc++/libsupc++ and libcxx(abi).
> Also I've updated my TDirectory test so they have the same output format [a]
>
> [9] https://gist.github.com/BerserkerTroll/01debd56c2987ab89b0a94b783373e35
> [a] https://gist.github.com/BerserkerTroll/b94c2d3e3a5848be7c7dd53e323e1cdb