### PR TITLE
Keep clang-tidy modernize-use-bool-literals happy

### DIFF
--- a/core/base/inc/TError.h
+++ b/core/base/inc/TError.h
@@ -93,12 +93,12 @@ extern void Obsolete(const char *function, const char *asOfVers, const char *rem
 R__EXTERN const char *kAssertMsg;
 R__EXTERN const char *kCheckMsg;
 
-#define R__ASSERT(e) \
-   do { \
+#define R__ASSERT(e)                                                     \
+   do {                                                                  \
       if (!(e)) ::Fatal("", kAssertMsg, _QUOTE_(e), __LINE__, __FILE__); \
    } while (false)
-#define R__CHECK(e) \
-   do { \
+#define R__CHECK(e)                                                       \
+   do {                                                                   \
       if (!(e)) ::Warning("", kCheckMsg, _QUOTE_(e), __LINE__, __FILE__); \
    } while (false)
 

--- a/core/base/inc/TError.h
+++ b/core/base/inc/TError.h
@@ -96,11 +96,11 @@ R__EXTERN const char *kCheckMsg;
 #define R__ASSERT(e) \
    do { \
       if (!(e)) ::Fatal("", kAssertMsg, _QUOTE_(e), __LINE__, __FILE__); \
-   } while (0)
+   } while (false)
 #define R__CHECK(e) \
    do { \
       if (!(e)) ::Warning("", kCheckMsg, _QUOTE_(e), __LINE__, __FILE__); \
-   } while (0)
+   } while (false)
 
 R__EXTERN Int_t  gErrorIgnoreLevel;
 R__EXTERN Int_t  gErrorAbortLevel;


### PR DESCRIPTION
clang-tidy with `modernize-use-bool-literals` complains about the fact that 0 is used in place of false. Given I assume there is no particular reason for using `0` rather than `false`, I suggest to change it to avoid the false positives.