### PR TITLE
Added a modulemap for libc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ if(cxxmodules)
     message(FATAL_ERROR "cxxmodules is not supported by this compiler")
   endif()
 
-  set(ROOT_CXXMODULES_COMMONFLAGS "${ROOT_CXXMODULES_COMMONFLAGS} -fmodules -fmodules-cache-path=${CMAKE_BINARY_DIR}/include/pcms/ -fno-autolink -fdiagnostics-show-note-include-stack")
+  set(ROOT_CXXMODULES_COMMONFLAGS "${ROOT_CXXMODULES_COMMONFLAGS} -fmodules -fmodules-cache-path=${CMAKE_BINARY_DIR}/include/pcms/ -fno-autolink -fdiagnostics-show-note-include-stack -Wno-module-import-in-extern-c")
 
   # FIXME: We should remove this once libc++ supports -fmodules-local-submodule-visibility.
   if (APPLE)
@@ -192,6 +192,7 @@ if(cxxmodules)
     configure_file(${CMAKE_SOURCE_DIR}/build/unix/modulemap.overlay.yaml.in ${CMAKE_BINARY_DIR}/include/modulemap.overlay.yaml @ONLY)
 
     configure_file(${CMAKE_SOURCE_DIR}/build/unix/stl.cppmap ${CMAKE_BINARY_DIR}/include/stl.cppmap)
+    configure_file(${CMAKE_SOURCE_DIR}/build/unix/libc.modulemap ${CMAKE_BINARY_DIR}/include/libc.modulemap)
   endif()
 
   # These vars are useful when we want to compile things without cxxmodules.

--- a/build/rmkdepend/mainroot.cxx
+++ b/build/rmkdepend/mainroot.cxx
@@ -27,12 +27,10 @@
 
 #include <string>
 
-extern "C" {
 #if defined(__sun) && defined(__SUNPRO_CC)
 #include <signal.h>
 #endif
 #include "def.h"
-}
 
 #ifndef WIN32
 #include <unistd.h>

--- a/build/unix/libc.modulemap
+++ b/build/unix/libc.modulemap
@@ -1,0 +1,40 @@
+module "libc" {
+  export *
+  module "assert.h" {
+    export *
+    header "assert.h"
+  }
+  module "ctype.h" {
+    export *
+    header "ctype.h"
+  }
+  module "errno.h" {
+    export *
+    header "errno.h"
+  }
+  module "fenv.h" {
+    export *
+    header "fenv.h"
+  }
+  module "float.h" {
+    export *
+    header "float.h"
+  }
+  module "inttypes.h" {
+    export *
+    header "inttypes.h"
+  }
+
+  module "xlocale.h" {
+    export *
+    header "xlocale.h"
+  }
+  module "math.h" {
+    export *
+    header "math.h"
+  }
+  module "stdio.h" {
+    export *
+    header "stdio.h"
+  }
+}

--- a/build/unix/modulemap.overlay.yaml.in
+++ b/build/unix/modulemap.overlay.yaml.in
@@ -8,6 +8,13 @@
           'external-contents': '@CMAKE_BINARY_DIR@/include/stl.cppmap'
         }
       ]
+    },
+    { 'name': '/usr/include/', 'type': 'directory',
+      'contents': [
+        { 'name': 'module.modulemap', 'type': 'file',
+          'external-contents': '@CMAKE_BINARY_DIR@/include/libc.modulemap'
+        }
+      ]
     }
   ]
 }

--- a/graf2d/asimage/src/TASImage.cxx
+++ b/graf2d/asimage/src/TASImage.cxx
@@ -94,7 +94,6 @@ ROOT tutorials: `$ROOTSYS/tutorials/image/`
 #else
 #   include "Windows4root.h"
 #endif
-extern "C" {
 #ifndef WIN32
 #ifdef R__HAS_COCOA
 #   define X_DISPLAY_MISSING 1
@@ -107,6 +106,7 @@ extern "C" {
 #endif
 #   include <afterimage.h>
 #   include <bmp.h>
+extern "C" {
 #   include <draw.h>
 }
 

--- a/graf2d/asimage/src/TASPaletteEditor.cxx
+++ b/graf2d/asimage/src/TASPaletteEditor.cxx
@@ -40,7 +40,6 @@ It is called by a pull down menu item of TASImage.
 #include "Windows4root.h"
 #endif
 
-extern "C" {
 #ifndef WIN32
 #   include <afterbase.h>
 #else
@@ -48,8 +47,8 @@ extern "C" {
 #   include <win32/afterbase.h>
 #endif
 #   include <afterimage.h>
+extern "C" {
 #   include <bmp.h>
-
 }
 
 

--- a/graf2d/asimage/src/TASPluginGS.cxx
+++ b/graf2d/asimage/src/TASPluginGS.cxx
@@ -30,7 +30,6 @@ Allows to read PS/EPS/PDF files via GhostScript
 #   define popen_flags "r"
 #endif
 
-extern "C" {
 #ifndef WIN32
 #   include <afterbase.h>
 #else
@@ -39,7 +38,6 @@ extern "C" {
 #   define X_DISPLAY_MISSING 1
 #endif
 #   include <import.h>
-}
 
 
 ClassImp(TASPluginGS)


### PR DESCRIPTION
The Linux builds with enabled modules were failing because stdio.h
wasn't provided by a module but textually included. This seemed to
cause merging issues which caused the compilation to fail.

This patch adds a modulemap for a few libc modules that seem to work
without modification as modules inside ROOT.

We had to remove a few 'extern "C"' because importing a module
inside such a context isn't allowed.