### PR TITLE
[CLANG] Increase default value for `-ftemplate-depth` to 1024

### DIFF
--- a/interpreter/llvm/src/tools/clang/include/clang/Basic/LangOptions.def
+++ b/interpreter/llvm/src/tools/clang/include/clang/Basic/LangOptions.def
@@ -234,7 +234,7 @@ ENUM_LANGOPT(SignedOverflowBehavior, SignedOverflowBehaviorTy, 2, SOB_Undefined,
 
 BENIGN_LANGOPT(ArrowDepth, 32, 256,
                "maximum number of operator->s to follow")
-BENIGN_LANGOPT(InstantiationDepth, 32, 256,
+BENIGN_LANGOPT(InstantiationDepth, 32, 1024,
                "maximum template instantiation depth")
 BENIGN_LANGOPT(ConstexprCallDepth, 32, 512,
                "maximum constexpr call depth")

--- a/interpreter/llvm/src/tools/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1894,7 +1894,7 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
   Opts.ElideConstructors = !Args.hasArg(OPT_fno_elide_constructors);
   Opts.MathErrno = !Opts.OpenCL && Args.hasArg(OPT_fmath_errno);
   Opts.InstantiationDepth =
-      getLastArgIntValue(Args, OPT_ftemplate_depth, 256, Diags);
+      getLastArgIntValue(Args, OPT_ftemplate_depth, 1024, Diags);
   Opts.ArrowDepth =
       getLastArgIntValue(Args, OPT_foperator_arrow_depth, 256, Diags);
   Opts.ConstexprCallDepth =


### PR DESCRIPTION
This is a backport from llvm revision 278983:
"PR18417: Increase -ftemplate-depth to the value 1024 recommended
by the C++ standard's Annex B"

Motivation: the current template instantiation depth limit (256) makes
it impossible to move-construct std::tuple's of size equal or greater than 17.

Thanks @vgvassilev for pointing me to the right llvm patch.