### PR TITLE
fix bullets in documentation

### DIFF
--- a/hist/hist/src/TH3.cxx
+++ b/hist/hist/src/TH3.cxx
@@ -2155,17 +2155,17 @@ TH2D *TH3::DoProject2D(const char* name, const char * title, const TAxis* projX,
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Project a 3-d histogram into 1 or 2-d histograms depending on the
-/// option parameter
-/// option may contain a combination of the characters x,y,z,e
-/// option = "x" return the x projection into a TH1D histogram
-/// option = "y" return the y projection into a TH1D histogram
-/// option = "z" return the z projection into a TH1D histogram
-/// option = "xy" return the x versus y projection into a TH2D histogram
-/// option = "yx" return the y versus x projection into a TH2D histogram
-/// option = "xz" return the x versus z projection into a TH2D histogram
-/// option = "zx" return the z versus x projection into a TH2D histogram
-/// option = "yz" return the y versus z projection into a TH2D histogram
-/// option = "zy" return the z versus y projection into a TH2D histogram
+/// option parameter, which may contain a combination of the characters x,y,z,e
+///  - option = "x" return the x projection into a TH1D histogram
+///  - option = "y" return the y projection into a TH1D histogram
+///  - option = "z" return the z projection into a TH1D histogram
+///  - option = "xy" return the x versus y projection into a TH2D histogram
+///  - option = "yx" return the y versus x projection into a TH2D histogram
+///  - option = "xz" return the x versus z projection into a TH2D histogram
+///  - option = "zx" return the z versus x projection into a TH2D histogram
+///  - option = "yz" return the y versus z projection into a TH2D histogram
+///  - option = "zy" return the z versus y projection into a TH2D histogram
+///
 /// NB: the notation "a vs b" means "a" vertical and "b" horizontal
 ///
 /// option = "o" original axis range of the target axes will be


### PR DESCRIPTION
The current documentation doesn't have bullets or newlines and is very confusing.
https://root.cern.ch/doc/master/classTH3.html#a8da3424208d450620f0797f2ee6ab07c
I think this should fix it.