### PR TITLE
http: provide websocket id for all related operations

### DIFF
--- a/net/http/inc/THttpCallArg.h
+++ b/net/http/inc/THttpCallArg.h
@@ -29,6 +29,7 @@ protected:
    Long_t fPostDataLength;       //! length of binary data
 
    TNamed *fWSHandle;            //!  web-socket handle, derived from TNamed class
+   void   *fWSId;                //! websocket identifier, used in web-socket related operations
 
    std::condition_variable fCond; //! condition used to wait for processing
 
@@ -106,6 +107,21 @@ public:
    void SetWSHandle(TNamed* handle);
 
    TNamed* TakeWSHandle();
+
+   void SetWSId(void* id)
+   {
+      // set web-socket id
+
+      fWSId = id;
+   }
+
+   void* GetWSId() const
+   {
+      // get web-socket id
+
+      return fWSId;
+   }
+
 
    void SetRequestHeader(const char* h)
    {

--- a/net/http/inc/THttpEngine.h
+++ b/net/http/inc/THttpEngine.h
@@ -63,13 +63,15 @@ protected:
 public:
    virtual ~THttpWSEngine();
 
+   virtual void* GetId() const = 0;
+
    virtual void ClearHandle() = 0;
 
    virtual void Send(const void* buf, int len) = 0;
 
    virtual void ProcessData(THttpCallArg* arg);
 
-   // --------- method to work with
+   // --------- method to work with Canvas (temporary solution)
 
    virtual void AssignCanvas(TCanvas* canv);
 

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -37,6 +37,12 @@ class TCivetwebWSEngine : public THttpWSEngine {
       {
       }
 
+      virtual void* GetId() const
+      {
+         return (void *) fWSconn;
+      }
+
+
       virtual void ClearHandle()
       {
          fWSconn = 0;
@@ -68,6 +74,7 @@ int websocket_connect_handler(const struct mg_connection *conn, void*)
    THttpCallArg arg;
    arg.SetPathAndFileName(request_info->uri); // path and file name
    arg.SetQuery(request_info->query_string);  // query arguments
+   arg.SetWSId((void *) conn);
    arg.SetMethod("WS_CONNECT");
 
    Bool_t execres = serv->ExecuteHttp(&arg);
@@ -95,6 +102,7 @@ void websocket_ready_handler(struct mg_connection *conn, void*)
    arg.SetQuery(request_info->query_string);  // query arguments
    arg.SetMethod("WS_READY");
 
+   arg.SetWSId((void *) conn);
    arg.SetWSHandle(new TCivetwebWSEngine("websocket", "title", conn));
 
    serv->ExecuteHttp(&arg);
@@ -114,6 +122,7 @@ int websocket_data_handler(struct mg_connection *conn, int, char *data, size_t l
    THttpCallArg arg;
    arg.SetPathAndFileName(request_info->uri); // path and file name
    arg.SetQuery(request_info->query_string);  // query arguments
+   arg.SetWSId((void *) conn);
    arg.SetMethod("WS_DATA");
 
    void* buf = malloc(len+1); // one byte more for null-termination
@@ -152,6 +161,7 @@ void websocket_close_handler(const struct mg_connection *conn, void*)
    THttpCallArg arg;
    arg.SetPathAndFileName(request_info->uri); // path and file name
    arg.SetQuery(request_info->query_string);  // query arguments
+   arg.SetWSId((void *) conn);
    arg.SetMethod("WS_CLOSE");
 
    serv->ExecuteHttp(&arg);

--- a/net/http/src/THttpCallArg.cxx
+++ b/net/http/src/THttpCallArg.cxx
@@ -32,6 +32,7 @@ THttpCallArg::THttpCallArg() :
    fPostData(0),
    fPostDataLength(0),
    fWSHandle(0),
+   fWSId(0),
    fContentType(),
    fRequestHeader(),
    fHeader(),


### PR DESCRIPTION
One could have many web-sockets connections associated with given URL.
websocket id allows to distinguish them