### PR TITLE
Use tolerance to compare floating point numbers in testGenVector.cxx

### DIFF
--- a/math/genvector/test/testGenVector.cxx
+++ b/math/genvector/test/testGenVector.cxx
@@ -701,7 +701,9 @@ int testTransform3D() {
      Transform3D tr(EulerAngles(10, -10, 10), XYZVector(10, -10, 0));
      auto r1 = tr.ApplyInverse(vector);
      auto r2 = tr.Inverse()(vector);
-     iret |= compare((r1 == r2), true, "ApplyInverse/Vector");
+     iret |= compare(r1.X(), r2.X(), "ApplyInverse/Vector", 10);
+     iret |= compare(r1.Y(), r2.Y(), "ApplyInverse/Vector", 10);
+     iret |= compare(r1.Z(), r2.Z(), "ApplyInverse/Vector", 10);
   }
 
   if (iret == 0) std::cout << "OK\n";


### PR DESCRIPTION
The exact comparison [fails](http://cdash.cern.ch/testDetails.php?test=23864693&build=342450) in some architectures where rounding may occur.