### PR TITLE
Fix stress histogram test

### DIFF
--- a/math/mathcore/inc/TMath.h
+++ b/math/mathcore/inc/TMath.h
@@ -321,7 +321,8 @@ struct Limits {
    }
    inline Bool_t AreEqualRel(Double_t af, Double_t bf, Double_t relPrec) {
       //return kTRUE if relative difference between af and bf is less than relPrec
-      return TMath::Abs(af-bf) <= 0.5*relPrec*(TMath::Abs(af)+TMath::Abs(bf));
+      return TMath::Abs(af - bf) <= 0.5 * relPrec * (TMath::Abs(af) + TMath::Abs(bf)) ||
+             TMath::Abs(af - bf) < Limits<Double_t>::Min(); // handle denormals
    }
 
    /* ******************** */

--- a/test/stressHistogram.cxx
+++ b/test/stressHistogram.cxx
@@ -7030,43 +7030,29 @@ int findBin(ROOT::Fit::BinData& bd, const double *x)
    return -1;
 }
 
-bool operator ==(ROOT::Fit::BinData& bd1, ROOT::Fit::BinData& bd2)
+bool operator==(ROOT::Fit::BinData &bd1, ROOT::Fit::BinData &bd2)
 {
    const unsigned int ndim = bd1.NDim();
    const unsigned int npoints = bd1.NPoints();
+   const double eps = TMath::Limits<double>::Epsilon();
 
-   bool equals = true;
-
-   for ( unsigned int i = 0; i < npoints && equals; ++i )
-   {
+   for (unsigned int i = 0; i < npoints; ++i) {
       double value1 = 0, error1 = 0;
       const double *x1 = bd1.GetPoint(i, value1, error1);
 
-//       std::cout << "i: " << i
-//            << " x: ";
-//       std::copy(x1, x1+ndim, ostream_iterator<double>(std::cout, " "));
-//       std::cout << " val: " << value1
-//            << " error: " << error1
-//            << std::endl;
-
       int bin = findBin(bd2, x1);
-      if ( bin < 0 )
-         Fatal("operator ==(ROOT::Fit::BinData& bd1, ROOT::Fit::BinData& bd2)","BIN NOT FOUND!");
 
       double value2 = 0, error2 = 0;
       const double *x2 = bd2.GetPoint(bin, value2, error2);
 
-      equals &= ( value1 == value2 );
-      equals &= ( error1 == error2 );
-      for ( unsigned int j = 0; j < ndim; ++j )
-      {
-         equals &= fabs(x1[j] - x2[j]) < 1E-15;
-      }
+      if (!TMath::AreEqualRel(value1, value2, eps)) return false;
+      if (!TMath::AreEqualRel(error1, error2, eps)) return false;
+
+      for (unsigned int j = 0; j < ndim; ++j)
+         if (!TMath::AreEqualRel(x1[j], x2[j], eps)) return false;
    }
-
-   return equals;
+   return true;
 }
-
 
 int findBin(ROOT::Fit::SparseData& sd,
             const std::vector<double>& minRef, const std::vector<double>& maxRef,


### PR DESCRIPTION
Replace direct floating point comparison with `AreEqualRel()` comparison with a tolerance.