### PR TITLE
Fix for ROOT-8732

### DIFF
--- a/bindings/pyroot/src/Converters.cxx
+++ b/bindings/pyroot/src/Converters.cxx
@@ -1541,6 +1541,7 @@ namespace {
 // converter factories for ROOT types
    typedef std::pair< const char*, ConverterFactory_t > NFp_t;
 
+// clang-format off
    NFp_t factories_[] = {
    // factories for built-ins
       NFp_t( "bool",                      &CreateBoolConverter               ),
@@ -1624,6 +1625,7 @@ namespace {
       NFp_t( "FILE*",                     &CreateVoidArrayConverter          ),
       NFp_t( "Double32_t",                &CreateDoubleConverter             )
    };
+// clang-format on
 
    struct InitConvFactories_t {
    public:

--- a/bindings/pyroot/src/Converters.cxx
+++ b/bindings/pyroot/src/Converters.cxx
@@ -1621,7 +1621,8 @@ namespace {
       NFp_t( "void**",                    &CreateVoidPtrPtrConverter         ),
       NFp_t( "PyObject*",                 &CreatePyObjectConverter           ),
       NFp_t( "_object*",                  &CreatePyObjectConverter           ),
-      NFp_t( "FILE*",                     &CreateVoidArrayConverter          )
+      NFp_t( "FILE*",                     &CreateVoidArrayConverter          ),
+      NFp_t( "Double32_t",                &CreateDoubleConverter             )
    };
 
    struct InitConvFactories_t {

--- a/bindings/pyroot/src/Converters.cxx
+++ b/bindings/pyroot/src/Converters.cxx
@@ -1541,7 +1541,7 @@ namespace {
 // converter factories for ROOT types
    typedef std::pair< const char*, ConverterFactory_t > NFp_t;
 
-// clang-format off
+   // clang-format off
    NFp_t factories_[] = {
    // factories for built-ins
       NFp_t( "bool",                      &CreateBoolConverter               ),
@@ -1625,7 +1625,7 @@ namespace {
       NFp_t( "FILE*",                     &CreateVoidArrayConverter          ),
       NFp_t( "Double32_t",                &CreateDoubleConverter             )
    };
-// clang-format on
+   // clang-format on
 
    struct InitConvFactories_t {
    public:


### PR DESCRIPTION
PyROOT cannot read/write C++ class fields of Double32_t. Added the missing converter.