### PR TITLE
Remove sysroot arg when writing modules to fix assertion failure.

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -2334,7 +2334,7 @@ static bool GenerateModule(TModuleGenerator &modGen, clang::CompilerInstance *CI
       ROOT::TMetaUtils::Warning("GenerateModule", warningMessage.c_str());
    }
 
-   WriteAST(outputFile, CI, includeDir, module);
+   WriteAST(outputFile, CI, "", module);
    return true;
 }
 


### PR DESCRIPTION
The sysroot flag should not be set when writing a module otherwise we
trigger an assertion in ASTWriter.cpp:1245.