### PR TITLE
Zlib cleanup (QAT)

### DIFF
--- a/core/zip/src/Bits.h
+++ b/core/zip/src/Bits.h
@@ -571,6 +571,11 @@ void R__zipMultipleAlgorithm(int cxlevel, int *srcsize, char *src, int *tgtsize,
   int err;
   int method   = Z_DEFLATED;
 
+  if (*srcsize < 1 + HDRSIZE + 1) {
+    *irep = 0;
+    return;
+  }
+
   if (cxlevel <= 0) {
     *irep = 0;
     return;

--- a/core/zip/src/Bits.h
+++ b/core/zip/src/Bits.h
@@ -572,8 +572,8 @@ void R__zipMultipleAlgorithm(int cxlevel, int *srcsize, char *src, int *tgtsize,
   int method   = Z_DEFLATED;
 
   if (*srcsize < 1 + HDRSIZE + 1) {
-    *irep = 0;
-    return;
+     *irep = 0;
+     return;
   }
 
   if (cxlevel <= 0) {
@@ -688,10 +688,10 @@ void R__zipMultipleAlgorithm(int cxlevel, int *srcsize, char *src, int *tgtsize,
     }
 
     while ((err = deflate(&stream, Z_FINISH)) != Z_STREAM_END) {
-      if (err != Z_OK) {
-        deflateEnd(&stream);
-        return;
-      }
+       if (err != Z_OK) {
+          deflateEnd(&stream);
+          return;
+       }
     }
 
     err = deflateEnd(&stream);

--- a/core/zip/src/Bits.h
+++ b/core/zip/src/Bits.h
@@ -682,14 +682,11 @@ void R__zipMultipleAlgorithm(int cxlevel, int *srcsize, char *src, int *tgtsize,
        return;
     }
 
-    err = deflate(&stream, Z_FINISH);
-    if (err != Z_STREAM_END) {
-       deflateEnd(&stream);
-       /* No need to print an error message. We simply abandon the compression
-          the buffer cannot be compressed or compressed buffer would be larger than original buffer
-          printf("error %d in deflate (zlib) is not = %d\n",err,Z_STREAM_END);
-       */
-       return;
+    while ((err = deflate(&stream, Z_FINISH)) != Z_STREAM_END) {
+      if (err != Z_OK) {
+        deflateEnd(&stream);
+        return;
+      }
     }
 
     err = deflateEnd(&stream);

--- a/core/zip/src/ZInflate.c
+++ b/core/zip/src/ZInflate.c
@@ -1188,7 +1188,7 @@ void R__unzip(int *srcsize, uch *src, int *tgtsize, uch *tgt, int *irep)
     int err = 0;
 
     stream.next_in   = (Bytef*)(&src[HDRSIZE]);
-    stream.avail_in  = (uInt)(*srcsize) - HDRSIZE;
+    stream.avail_in = (uInt)(*srcsize) - HDRSIZE;
     stream.next_out  = (Bytef*)tgt;
     stream.avail_out = (uInt)(*tgtsize);
     stream.zalloc    = (alloc_func)0;
@@ -1202,11 +1202,11 @@ void R__unzip(int *srcsize, uch *src, int *tgtsize, uch *tgt, int *irep)
     }
 
     while ((err = inflate(&stream, Z_FINISH)) != Z_STREAM_END) {
-      if (err != Z_OK) {
-        inflateEnd(&stream);
-        fprintf(stderr,"R__unzip: error %d in inflate (zlib)\n", err);
-        return;
-      }
+       if (err != Z_OK) {
+          inflateEnd(&stream);
+          fprintf(stderr, "R__unzip: error %d in inflate (zlib)\n", err);
+          return;
+       }
     }
 
     inflateEnd(&stream);

--- a/core/zip/src/ZInflate.c
+++ b/core/zip/src/ZInflate.c
@@ -1188,7 +1188,7 @@ void R__unzip(int *srcsize, uch *src, int *tgtsize, uch *tgt, int *irep)
     int err = 0;
 
     stream.next_in   = (Bytef*)(&src[HDRSIZE]);
-    stream.avail_in  = (uInt)(*srcsize);
+    stream.avail_in  = (uInt)(*srcsize) - HDRSIZE;
     stream.next_out  = (Bytef*)tgt;
     stream.avail_out = (uInt)(*tgtsize);
     stream.zalloc    = (alloc_func)0;

--- a/core/zip/src/ZInflate.c
+++ b/core/zip/src/ZInflate.c
@@ -1201,11 +1201,12 @@ void R__unzip(int *srcsize, uch *src, int *tgtsize, uch *tgt, int *irep)
       return;
     }
 
-    err = inflate(&stream, Z_FINISH);
-    if (err != Z_STREAM_END) {
-      inflateEnd(&stream);
-      fprintf(stderr,"R__unzip: error %d in inflate (zlib)\n",err);
-      return;
+    while ((err = inflate(&stream, Z_FINISH)) != Z_STREAM_END) {
+      if (err != Z_OK) {
+        inflateEnd(&stream);
+        fprintf(stderr,"R__unzip: error %d in inflate (zlib)\n", err);
+        return;
+      }
     }
 
     inflateEnd(&stream);


### PR DESCRIPTION
These 3 small patches I am using for ROOT + Intel QuickAssist Technology (QAT). QAT provides HW-accelerated (de)compression and crypto (incl. hashing). For easy integration Intel provides zlib-shim and openssl-shim, support the most common interfaces (but not everything). Note, that QAT also has software fallback mechanism.

More details are available in the commit messages.

