### PR TITLE
[TDF] branch type inference for actions with multiple branches

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFUtils.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFUtils.hxx
@@ -275,6 +275,8 @@ struct Histo3D {
 };
 struct Profile1D {
 };
+struct Profile2D {
+};
 struct Min {
 };
 struct Max {

--- a/tree/treeplayer/inc/ROOT/TDFUtils.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFUtils.hxx
@@ -271,6 +271,8 @@ struct Histo1D {
 };
 struct Histo2D {
 };
+struct Histo3D {
+};
 struct Min {
 };
 struct Max {

--- a/tree/treeplayer/inc/ROOT/TDFUtils.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFUtils.hxx
@@ -283,6 +283,8 @@ struct Max {
 };
 struct Mean {
 };
+struct Fill {
+};
 }
 
 // Utilities to accommodate v7

--- a/tree/treeplayer/inc/ROOT/TDFUtils.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFUtils.hxx
@@ -273,6 +273,8 @@ struct Histo2D {
 };
 struct Histo3D {
 };
+struct Profile1D {
+};
 struct Min {
 };
 struct Max {

--- a/tree/treeplayer/inc/ROOT/TDFUtils.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFUtils.hxx
@@ -269,6 +269,8 @@ const BranchNames_t &PickBranchNames(unsigned int nArgs, const BranchNames_t &bl
 namespace ActionTypes {
 struct Histo1D {
 };
+struct Histo2D {
+};
 struct Min {
 };
 struct Max {

--- a/tree/treeplayer/inc/ROOT/TDFUtils.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFUtils.hxx
@@ -35,6 +35,8 @@ using BranchNames_t = std::vector<std::string>;
 // forward declarations
 namespace Detail {
 class TDataFrameBranchBase; // for ColumnName2ColumnTypeName
+struct TDataFrameGuessedType {
+};
 }
 
 namespace Internal {
@@ -157,6 +159,26 @@ struct TExtractType<U<T, Extras...>> {
 
 template <typename T>
 using ExtractType_t = typename TExtractType<T>::type;
+
+template <typename BranchType, typename... Rest>
+struct TNeedJitting {
+   static constexpr bool value = TNeedJitting<Rest...>::value;
+};
+
+template <typename... Rest>
+struct TNeedJitting<ROOT::Detail::TDataFrameGuessedType, Rest...> {
+   static constexpr bool value = true;
+};
+
+template <typename T>
+struct TNeedJitting<T> {
+   static constexpr bool value = false;
+};
+
+template <>
+struct TNeedJitting<ROOT::Detail::TDataFrameGuessedType> {
+   static constexpr bool value = true;
+};
 
 } // end NS TDFTraitsUtils
 

--- a/tree/treeplayer/inc/ROOT/TDataFrameInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDataFrameInterface.hxx
@@ -646,67 +646,63 @@ public:
 
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Fill and return a two-dimensional profile (*lazy action*)
-   /// \tparam B0 The type of the branch the values of which are used to fill the profile.
-   /// \tparam B1 The type of the branch the values of which are used to fill the profile.
-   /// \param[in] model The model to be considered to build the new return value.
-   /// \param[in] b0BranchName The name of the branch of which the x values are to be collected.
-   /// \param[in] b1BranchName The name of the branch of which the y values are to be collected.
+   /// \tparam V1 The type of the branch used to fill the x axis of the histogram.
+   /// \tparam V2 The type of the branch used to fill the y axis of the histogram.
+   /// \tparam V2 The type of the branch used to fill the z axis of the histogram.
+   /// \param[in] model The returned profile will be constructed using this as a model.
+   /// \param[in] v1Name The name of the branch that will fill the x axis.
+   /// \param[in] v2Name The name of the branch that will fill the y axis.
+   /// \param[in] v3Name The name of the branch that will fill the z axis.
    ///
-   /// The returned profile is independent of the input one.
    /// This action is *lazy*: upon invocation of this method the calculation is
    /// booked but not executed. See TActionResultProxy documentation.
-   /// The user renounces to the ownership of the model. The value to be used is the
-   /// returned one.
-   template <typename B0, typename B1>
-   TActionResultProxy<::TProfile2D> Profile2D(::TProfile2D &&model, const std::string &b0BranchName = "",
-                                              const std::string &b1BranchName = "")
+   /// The user gives up ownership of the model profile.
+   template <typename V1 = ROOT::Detail::TDataFrameGuessedType, typename V2 = ROOT::Detail::TDataFrameGuessedType,
+             typename V3 = ROOT::Detail::TDataFrameGuessedType>
+   TActionResultProxy<::TProfile2D> Profile2D(::TProfile2D &&model, const std::string &v1Name = "",
+                                              const std::string &v2Name = "", const std::string &v3Name = "")
    {
       auto h = std::make_shared<::TProfile2D>(model);
       if (!ROOT::Internal::TDFV7Utils::Histo<::TProfile2D>::HasAxisLimits(*h)) {
          throw std::runtime_error("2D profiles with no axes limits are not supported yet.");
       }
-      auto bl = GetBranchNames<B0, B1>({b0BranchName, b1BranchName}, "fill the profile");
-      using Op_t = ROOT::Internal::Operations::FillTOOperation<::TProfile2D>;
-      using DFA_t = ROOT::Internal::TDataFrameAction<Op_t, Proxied, ROOT::Internal::TDFTraitsUtils::TTypeList<B0, B1>>;
-      auto df = GetDataFrameChecked();
-      auto nSlots = df->GetNSlots();
-      df->Book(std::make_shared<DFA_t>(Op_t(h, nSlots), bl, *fProxiedPtr));
-      fProxiedPtr->IncrChildrenCount();
-      return ROOT::Detail::MakeActionResultProxy(h, df);
+      auto bl = GetBranchNames<V1, V2, V3>({v1Name, v2Name, v3Name}, "fill the 2D profile");
+      return CreateAction<ROOT::Internal::ActionTypes::Profile2D, V1, V2, V3>(bl, h);
    }
 
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Fill and return a two-dimensional profile (*lazy action*)
-   /// \tparam B0 The type of the branch the values of which are used to fill the profile.
-   /// \tparam B1 The type of the branch the values of which are used to fill the profile.
-   /// \tparam W The type of the branch the weights of which are used to fill the profile.
-   /// \param[in] model The model to be considered to build the new return value.
-   /// \param[in] b0BranchName The name of the branch of which the x values are to be collected.
-   /// \param[in] b1BranchName The name of the branch of which the y values are to be collected.
-   /// \param[in] wBranchName The name of the branch of which the weight values are to be collected.
+   /// \tparam V1 The type of the branch used to fill the x axis of the histogram.
+   /// \tparam V2 The type of the branch used to fill the y axis of the histogram.
+   /// \tparam V3 The type of the branch used to fill the z axis of the histogram.
+   /// \tparam W The type of the branch used for the weights of the histogram.
+   /// \param[in] model The returned histogram will be constructed using this as a model.
+   /// \param[in] v1Name The name of the branch that will fill the x axis.
+   /// \param[in] v2Name The name of the branch that will fill the y axis.
+   /// \param[in] v3Name The name of the branch that will fill the z axis.
+   /// \param[in] wName The name of the branch that will provide the weights.
    ///
-   /// The returned profile is independent of the input one.
    /// This action is *lazy*: upon invocation of this method the calculation is
    /// booked but not executed. See TActionResultProxy documentation.
-   /// The user renounces to the ownership of the model. The value to be used is the
-   /// returned one.
-   template <typename B0, typename B1, typename W>
-   TActionResultProxy<::TProfile2D> Profile2D(::TProfile2D &&model, const std::string &b0BranchName = "",
-                                              const std::string &b1BranchName = "", const std::string &wBranchName = "")
+   /// The user gives up ownership of the model profile.
+   template <typename V1 = ROOT::Detail::TDataFrameGuessedType, typename V2 = ROOT::Detail::TDataFrameGuessedType,
+             typename V3 = ROOT::Detail::TDataFrameGuessedType, typename W = ROOT::Detail::TDataFrameGuessedType>
+   TActionResultProxy<::TProfile2D> Profile2D(::TProfile2D &&model, const std::string &v1Name,
+                                              const std::string &v2Name, const std::string &v3Name,
+                                              const std::string &wName)
    {
       auto h = std::make_shared<::TProfile2D>(model);
       if (!ROOT::Internal::TDFV7Utils::Histo<::TProfile2D>::HasAxisLimits(*h)) {
          throw std::runtime_error("2D profiles with no axes limits are not supported yet.");
       }
-      auto bl = GetBranchNames<B0, B1, W>({b0BranchName, b1BranchName, wBranchName}, "fill the profile");
-      using Op_t = ROOT::Internal::Operations::FillTOOperation<::TProfile2D>;
-      using DFA_t =
-         ROOT::Internal::TDataFrameAction<Op_t, Proxied, ROOT::Internal::TDFTraitsUtils::TTypeList<B0, B1, W>>;
-      auto df = GetDataFrameChecked();
-      auto nSlots = df->GetNSlots();
-      df->Book(std::make_shared<DFA_t>(Op_t(h, nSlots), bl, *fProxiedPtr));
-      fProxiedPtr->IncrChildrenCount();
-      return ROOT::Detail::MakeActionResultProxy(h, df);
+      auto bl = GetBranchNames<V1, V2, V3, W>({v1Name, v2Name, v3Name, wName}, "fill the histogram");
+      return CreateAction<ROOT::Internal::ActionTypes::Profile2D, V1, V2, V3, W>(bl, h);
+   }
+
+   template <typename V1, typename V2, typename V3, typename W>
+   TActionResultProxy<::TProfile2D> Profile2D(::TProfile2D &&model)
+   {
+      return Profile2D<V1, V2, V3, W>(std::move(model), "", "", "", "");
    }
 
    ////////////////////////////////////////////////////////////////////////////
@@ -879,6 +875,18 @@ private:
                                            unsigned int nSlots, ROOT::Internal::ActionTypes::Profile1D *)
    {
       using Op_t = ROOT::Internal::Operations::FillTOOperation<::TProfile>;
+      using DFA_t =
+         ROOT::Internal::TDataFrameAction<Op_t, Proxied, ROOT::Internal::TDFTraitsUtils::TTypeList<BranchTypes...>>;
+      auto df = GetDataFrameChecked();
+      df->Book(std::make_shared<DFA_t>(Op_t(h, nSlots), bl, *fProxiedPtr));
+      return ROOT::Detail::MakeActionResultProxy(h, df);
+   }
+
+   template<typename...BranchTypes>
+   TActionResultProxy<::TProfile2D> BuildAndBook(const BranchNames_t &bl, const std::shared_ptr<::TProfile2D> &h,
+                                           unsigned int nSlots, ROOT::Internal::ActionTypes::Profile2D *)
+   {
+      using Op_t = ROOT::Internal::Operations::FillTOOperation<::TProfile2D>;
       using DFA_t =
          ROOT::Internal::TDataFrameAction<Op_t, Proxied, ROOT::Internal::TDFTraitsUtils::TTypeList<BranchTypes...>>;
       auto df = GetDataFrameChecked();

--- a/tree/treeplayer/inc/ROOT/TDataFrameInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDataFrameInterface.hxx
@@ -486,68 +486,57 @@ public:
    }
 
    ////////////////////////////////////////////////////////////////////////////
-   /// \brief Fill and return a two-dimensional histogram with the values of a branch (*lazy action*)
-   /// \tparam B0 The type of the branch the values of which are used to fill the histogram.
-   /// \tparam B1 The type of the branch the values of which are used to fill the histogram.
-   /// \param[in] model The model to be considered to build the new return value.
-   /// \param[in] b0BranchName The name of the branch of which the x values are to be collected.
-   /// \param[in] b1BranchName The name of the branch of which the y values are to be collected.
+   /// \brief Fill and return a two-dimensional histogram (*lazy action*)
+   /// \tparam V1 The type of the branch used to fill the x axis of the histogram.
+   /// \tparam V2 The type of the branch used to fill the y axis of the histogram.
+   /// \param[in] model The returned histogram will be constructed using this as a model.
+   /// \param[in] v1Name The name of the branch that will fill the x axis.
+   /// \param[in] v2Name The name of the branch that will fill the y axis.
    ///
-   /// The returned histogram is independent of the input one.
    /// This action is *lazy*: upon invocation of this method the calculation is
    /// booked but not executed. See TActionResultProxy documentation.
-   /// The user renounces to the ownership of the model. The value to be used is the
-   /// returned one.
-   template <typename B0, typename B1>
-   TActionResultProxy<::TH2F> Histo2D(::TH2F &&model, const std::string &b0BranchName = "",
-                                      const std::string &b1BranchName = "")
+   /// The user gives up ownership of the model histogram.
+   template <typename V1 = ROOT::Detail::TDataFrameGuessedType, typename V2 = ROOT::Detail::TDataFrameGuessedType>
+   TActionResultProxy<::TH2F> Histo2D(::TH2F &&model, const std::string &v1Name = "", const std::string &v2Name = "")
    {
       auto h = std::make_shared<::TH2F>(model);
       if (!ROOT::Internal::TDFV7Utils::Histo<::TH2F>::HasAxisLimits(*h)) {
          throw std::runtime_error("2D histograms with no axes limits are not supported yet.");
       }
-      auto bl = GetBranchNames<B0, B1>({b0BranchName, b1BranchName}, "fill the histogram");
-      using Op_t = ROOT::Internal::Operations::FillTOOperation<::TH2F>;
-      using DFA_t = ROOT::Internal::TDataFrameAction<Op_t, Proxied, ROOT::Internal::TDFTraitsUtils::TTypeList<B0, B1>>;
-      auto df = GetDataFrameChecked();
-      auto nSlots = df->GetNSlots();
-      df->Book(std::make_shared<DFA_t>(Op_t(h, nSlots), bl, *fProxiedPtr));
-      fProxiedPtr->IncrChildrenCount();
-      return ROOT::Detail::MakeActionResultProxy(h, df);
+      auto bl = GetBranchNames<V1, V2>({v1Name, v2Name}, "fill the histogram");
+      return CreateAction<ROOT::Internal::ActionTypes::Histo2D, V1, V2>(bl, h);
    }
 
    ////////////////////////////////////////////////////////////////////////////
-   /// \brief Fill and return a two-dimensional histogram with the values of a branch (*lazy action*)
-   /// \tparam B0 The type of the branch the values of which are used to fill the histogram.
-   /// \tparam B1 The type of the branch the values of which are used to fill the histogram.
-   /// \tparam W The type of the branch the weights of which are used to fill the histogram.
-   /// \param[in] model The model to be considered to build the new return value.
-   /// \param[in] b0BranchName The name of the branch of which the x values are to be collected.
-   /// \param[in] b1BranchName The name of the branch of which the y values are to be collected.
-   /// \param[in] wBranchName The name of the branch of which the weight values are to be collected.
+   /// \brief Fill and return a two-dimensional histogram (*lazy action*)
+   /// \tparam V1 The type of the branch used to fill the x axis of the histogram.
+   /// \tparam V2 The type of the branch used to fill the y axis of the histogram.
+   /// \tparam W The type of the branch used for the weights of the histogram.
+   /// \param[in] model The returned histogram will be constructed using this as a model.
+   /// \param[in] v1Name The name of the branch that will fill the x axis.
+   /// \param[in] v2Name The name of the branch that will fill the y axis.
+   /// \param[in] wName The name of the branch that will provide the weights.
    ///
-   /// The returned histogram is independent of the input one.
    /// This action is *lazy*: upon invocation of this method the calculation is
    /// booked but not executed. See TActionResultProxy documentation.
-   /// The user renounces to the ownership of the model. The value to be used is the
-   /// returned one.
-   template <typename B0, typename B1, typename W>
-   TActionResultProxy<::TH2F> Histo2D(::TH2F &&model, const std::string &b0BranchName = "",
-                                      const std::string &b1BranchName = "", const std::string &wBranchName = "")
+   /// The user gives up ownership of the model histogram.
+   template <typename V1 = ROOT::Detail::TDataFrameGuessedType, typename V2 = ROOT::Detail::TDataFrameGuessedType,
+             typename W = ROOT::Detail::TDataFrameGuessedType>
+   TActionResultProxy<::TH2F> Histo2D(::TH2F &&model, const std::string &v1Name, const std::string &v2Name,
+                                      const std::string &wName)
    {
       auto h = std::make_shared<::TH2F>(model);
       if (!ROOT::Internal::TDFV7Utils::Histo<::TH2F>::HasAxisLimits(*h)) {
          throw std::runtime_error("2D histograms with no axes limits are not supported yet.");
       }
-      auto bl = GetBranchNames<B0, B1, W>({b0BranchName, b1BranchName, wBranchName}, "fill the histogram");
-      using Op_t = ROOT::Internal::Operations::FillTOOperation<::TH2F>;
-      using DFA_t =
-         ROOT::Internal::TDataFrameAction<Op_t, Proxied, ROOT::Internal::TDFTraitsUtils::TTypeList<B0, B1, W>>;
-      auto df = GetDataFrameChecked();
-      auto nSlots = df->GetNSlots();
-      df->Book(std::make_shared<DFA_t>(Op_t(h, nSlots), bl, *fProxiedPtr));
-      fProxiedPtr->IncrChildrenCount();
-      return ROOT::Detail::MakeActionResultProxy(h, df);
+      auto bl = GetBranchNames<V1, V2, W>({v1Name, v2Name, wName}, "fill the histogram");
+      return CreateAction<ROOT::Internal::ActionTypes::Histo2D, V1, V2, W>(bl, h);
+   }
+
+   template <typename V1, typename V2, typename W>
+   TActionResultProxy<::TH2F> Histo2D(::TH2F &&model)
+   {
+      return Histo2D<V1,V2,W>(std::move(model), "", "", "");
    }
 
    ////////////////////////////////////////////////////////////////////////////
@@ -924,6 +913,18 @@ private:
             ROOT::Internal::TDataFrameAction<Op_t, Proxied, ROOT::Internal::TDFTraitsUtils::TTypeList<BranchType>>;
          df->Book(std::make_shared<DFA_t>(Op_t(h, nSlots), bl, *fProxiedPtr));
       }
+      return ROOT::Detail::MakeActionResultProxy(h, df);
+   }
+
+   template<typename...BranchTypes>
+   TActionResultProxy<::TH2F> BuildAndBook(const BranchNames_t &bl, const std::shared_ptr<::TH2F> &h,
+                                           unsigned int nSlots, ROOT::Internal::ActionTypes::Histo2D *)
+   {
+      using Op_t = ROOT::Internal::Operations::FillTOOperation<::TH2F>;
+      using DFA_t =
+         ROOT::Internal::TDataFrameAction<Op_t, Proxied, ROOT::Internal::TDFTraitsUtils::TTypeList<BranchTypes...>>;
+      auto df = GetDataFrameChecked();
+      df->Book(std::make_shared<DFA_t>(Op_t(h, nSlots), bl, *fProxiedPtr));
       return ROOT::Detail::MakeActionResultProxy(h, df);
    }
 

--- a/tree/treeplayer/inc/ROOT/TDataFrameInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDataFrameInterface.hxx
@@ -707,31 +707,23 @@ public:
 
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Fill and return any entity with a Fill method (*lazy action*)
-   /// \tparam BRANCHTYPES The types of the branches the values of which are used to fill the object.
+   /// \tparam BranchTypes The types of the branches the values of which are used to fill the object.
    /// \param[in] model The model to be considered to build the new return value.
    /// \param[in] bl The name of the branches read to fill the object.
    ///
    /// The returned object is independent of the input one.
    /// This action is *lazy*: upon invocation of this method the calculation is
    /// booked but not executed. See TActionResultProxy documentation.
-   /// The user renounces to the ownership of the model. The value to be used is the
-   /// returned one.
+   /// The user gives up ownership of the model object.
    /// It is compulsory to express the branches to be considered.
-   template <typename... BRANCHTYPES, typename T>
+   template <typename...BranchTypes, typename T>
    TActionResultProxy<T> Fill(T &&model, const BranchNames_t &bl)
    {
       auto h = std::make_shared<T>(model);
       if (!ROOT::Internal::TDFV7Utils::Histo<T>::HasAxisLimits(*h)) {
          throw std::runtime_error("The absence of axes limits is not supported yet.");
       }
-      using Op_t = ROOT::Internal::Operations::FillTOOperation<T>;
-      using DFA_t =
-         ROOT::Internal::TDataFrameAction<Op_t, Proxied, ROOT::Internal::TDFTraitsUtils::TTypeList<BRANCHTYPES...>>;
-      auto df = GetDataFrameChecked();
-      auto nSlots = df->GetNSlots();
-      df->Book(std::make_shared<DFA_t>(Op_t(h, nSlots), bl, *fProxiedPtr));
-      fProxiedPtr->IncrChildrenCount();
-      return ROOT::Detail::MakeActionResultProxy(h, df);
+      return CreateAction<ROOT::Internal::ActionTypes::Fill, BranchTypes...>(bl, h);
    }
 
    ////////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/inc/ROOT/TDataFrameInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDataFrameInterface.hxx
@@ -540,77 +540,63 @@ public:
    }
 
    ////////////////////////////////////////////////////////////////////////////
-   /// \brief Fill and return a three-dimensional histogram with the values of a branch (*lazy action*)
-   /// \tparam B0 The type of the branch the values of which are used to fill the histogram.
-   /// \tparam B1 The type of the branch the values of which are used to fill the histogram.
-   /// \tparam B2 The type of the branch the values of which are used to fill the histogram.
-   /// \param[in] model The model to be considered to build the new return value.
-   /// \param[in] b0BranchName The name of the branch of which the x values are to be collected.
-   /// \param[in] b1BranchName The name of the branch of which the y values are to be collected.
-   /// \param[in] b2BranchName The name of the branch of which the z values are to be collected.
+   /// \brief Fill and return a three-dimensional histogram (*lazy action*)
+   /// \tparam V1 The type of the branch used to fill the x axis of the histogram.
+   /// \tparam V2 The type of the branch used to fill the y axis of the histogram.
+   /// \tparam V3 The type of the branch used to fill the z axis of the histogram.
+   /// \param[in] model The returned histogram will be constructed using this as a model.
+   /// \param[in] v1Name The name of the branch that will fill the x axis.
+   /// \param[in] v2Name The name of the branch that will fill the y axis.
+   /// \param[in] v3Name The name of the branch that will fill the z axis.
    ///
-   /// The returned histogram is independent of the input one.
    /// This action is *lazy*: upon invocation of this method the calculation is
    /// booked but not executed. See TActionResultProxy documentation.
-   /// The user renounces to the ownership of the model. The value to be used is the
-   /// returned one.
-   template <typename B0, typename B1, typename B2>
-   TActionResultProxy<::TH3F> Histo3D(::TH3F &&model, const std::string &b0BranchName = "",
-                                      const std::string &b1BranchName = "", const std::string &b2BranchName = "",
-                                      const std::string &wBranchName = "")
+   /// The user gives up ownership of the model histogram.
+   template <typename V1 = ROOT::Detail::TDataFrameGuessedType, typename V2 = ROOT::Detail::TDataFrameGuessedType,
+             typename V3 = ROOT::Detail::TDataFrameGuessedType>
+   TActionResultProxy<::TH3F> Histo3D(::TH3F &&model, const std::string &v1Name = "", const std::string &v2Name = "",
+                                      const std::string &v3Name = "")
    {
       auto h = std::make_shared<::TH3F>(model);
       if (!ROOT::Internal::TDFV7Utils::Histo<::TH3F>::HasAxisLimits(*h)) {
-         throw std::runtime_error("2D histograms with no axes limits are not supported yet.");
+         throw std::runtime_error("3D histograms with no axes limits are not supported yet.");
       }
-      auto bl =
-         GetBranchNames<B0, B1, B2>({b0BranchName, b1BranchName, b2BranchName, wBranchName}, "fill the histogram");
-      using Op_t = ROOT::Internal::Operations::FillTOOperation<::TH3F>;
-      using DFA_t =
-         ROOT::Internal::TDataFrameAction<Op_t, Proxied, ROOT::Internal::TDFTraitsUtils::TTypeList<B0, B1, B2>>;
-      auto df = GetDataFrameChecked();
-      auto nSlots = df->GetNSlots();
-      df->Book(std::make_shared<DFA_t>(Op_t(h, nSlots), bl, *fProxiedPtr));
-      fProxiedPtr->IncrChildrenCount();
-      return ROOT::Detail::MakeActionResultProxy(h, df);
+      auto bl = GetBranchNames<V1, V2, V3>({v1Name, v2Name, v3Name}, "fill the histogram");
+      return CreateAction<ROOT::Internal::ActionTypes::Histo3D, V1, V2, V3>(bl, h);
    }
 
    ////////////////////////////////////////////////////////////////////////////
-   /// \brief Fill and return a three-dimensional histogram with the values of a branch (*lazy action*)
-   /// \tparam B0 The type of the branch the values of which are used to fill the histogram.
-   /// \tparam B1 The type of the branch the values of which are used to fill the histogram.
-   /// \tparam B2 The type of the branch the values of which are used to fill the histogram.
-   /// \tparam W The type of the branch the weights of which are used to fill the histogram.
-   /// \param[in] model The model to be considered to build the new return value.
-   /// \param[in] b0BranchName The name of the branch of which the x values are to be collected.
-   /// \param[in] b1BranchName The name of the branch of which the y values are to be collected.
-   /// \param[in] b2BranchName The name of the branch of which the z values are to be collected.
-   /// \param[in] wBranchName The name of the branch of which the weight values are to be collected.
+   /// \brief Fill and return a three-dimensional histogram (*lazy action*)
+   /// \tparam V1 The type of the branch used to fill the x axis of the histogram.
+   /// \tparam V2 The type of the branch used to fill the y axis of the histogram.
+   /// \tparam V3 The type of the branch used to fill the z axis of the histogram.
+   /// \tparam W The type of the branch used for the weights of the histogram.
+   /// \param[in] model The returned histogram will be constructed using this as a model.
+   /// \param[in] v1Name The name of the branch that will fill the x axis.
+   /// \param[in] v2Name The name of the branch that will fill the y axis.
+   /// \param[in] v3Name The name of the branch that will fill the z axis.
+   /// \param[in] wName The name of the branch that will provide the weights.
    ///
-   /// The returned histogram is independent of the input one.
    /// This action is *lazy*: upon invocation of this method the calculation is
    /// booked but not executed. See TActionResultProxy documentation.
-   /// The user renounces to the ownership of the model. The value to be used is the
-   /// returned one.
-   template <typename B0, typename B1, typename B2, typename W>
-   TActionResultProxy<::TH3F> Histo3D(::TH3F &&model, const std::string &b0BranchName = "",
-                                      const std::string &b1BranchName = "", const std::string &b2BranchName = "",
-                                      const std::string &wBranchName = "")
+   /// The user gives up ownership of the model histogram.
+   template <typename V1 = ROOT::Detail::TDataFrameGuessedType, typename V2 = ROOT::Detail::TDataFrameGuessedType,
+             typename V3 = ROOT::Detail::TDataFrameGuessedType, typename W = ROOT::Detail::TDataFrameGuessedType>
+   TActionResultProxy<::TH3F> Histo3D(::TH3F &&model, const std::string &v1Name, const std::string &v2Name,
+                                      const std::string &v3Name, const std::string &wName)
    {
       auto h = std::make_shared<::TH3F>(model);
       if (!ROOT::Internal::TDFV7Utils::Histo<::TH3F>::HasAxisLimits(*h)) {
-         throw std::runtime_error("2D histograms with no axes limits are not supported yet.");
+         throw std::runtime_error("3D histograms with no axes limits are not supported yet.");
       }
-      auto bl =
-         GetBranchNames<B0, B1, B2, W>({b0BranchName, b1BranchName, b2BranchName, wBranchName}, "fill the histogram");
-      using Op_t = ROOT::Internal::Operations::FillTOOperation<::TH3F>;
-      using DFA_t =
-         ROOT::Internal::TDataFrameAction<Op_t, Proxied, ROOT::Internal::TDFTraitsUtils::TTypeList<B0, B1, B2, W>>;
-      auto df = GetDataFrameChecked();
-      auto nSlots = df->GetNSlots();
-      df->Book(std::make_shared<DFA_t>(Op_t(h, nSlots), bl, *fProxiedPtr));
-      fProxiedPtr->IncrChildrenCount();
-      return ROOT::Detail::MakeActionResultProxy(h, df);
+      auto bl = GetBranchNames<V1, V2, V3, W>({v1Name, v2Name, v3Name, wName}, "fill the histogram");
+      return CreateAction<ROOT::Internal::ActionTypes::Histo3D, V1, V2, V3, W>(bl, h);
+   }
+
+   template <typename V1, typename V2, typename V3, typename W>
+   TActionResultProxy<::TH3F> Histo3D(::TH3F &&model)
+   {
+      return Histo3D<V1, V2, V3, W>(std::move(model), "", "", "", "");
    }
 
    ////////////////////////////////////////////////////////////////////////////
@@ -921,6 +907,18 @@ private:
                                            unsigned int nSlots, ROOT::Internal::ActionTypes::Histo2D *)
    {
       using Op_t = ROOT::Internal::Operations::FillTOOperation<::TH2F>;
+      using DFA_t =
+         ROOT::Internal::TDataFrameAction<Op_t, Proxied, ROOT::Internal::TDFTraitsUtils::TTypeList<BranchTypes...>>;
+      auto df = GetDataFrameChecked();
+      df->Book(std::make_shared<DFA_t>(Op_t(h, nSlots), bl, *fProxiedPtr));
+      return ROOT::Detail::MakeActionResultProxy(h, df);
+   }
+
+   template<typename...BranchTypes>
+   TActionResultProxy<::TH3F> BuildAndBook(const BranchNames_t &bl, const std::shared_ptr<::TH3F> &h,
+                                           unsigned int nSlots, ROOT::Internal::ActionTypes::Histo3D *)
+   {
+      using Op_t = ROOT::Internal::Operations::FillTOOperation<::TH3F>;
       using DFA_t =
          ROOT::Internal::TDataFrameAction<Op_t, Proxied, ROOT::Internal::TDFTraitsUtils::TTypeList<BranchTypes...>>;
       auto df = GetDataFrameChecked();

--- a/tree/treeplayer/inc/ROOT/TDataFrameInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDataFrameInterface.hxx
@@ -37,12 +37,11 @@ namespace ROOT {
 
 namespace Internal {
 
-template <typename TDFNode, typename ActionType, typename BranchType, typename ActionResultType>
+template <typename TDFNode, typename ActionType, typename...BranchTypes, typename ActionResultType>
 ROOT::Experimental::TActionResultProxy<ActionResultType> CallCreateAction(TDFNode *node, const BranchNames_t &bl,
-                                                                          const std::shared_ptr<ActionResultType> &r,
-                                                                          BranchType *)
+                                                                          const std::shared_ptr<ActionResultType> &r)
 {
-   return node->template CreateAction<ActionType, BranchType>(bl, r);
+   return node->template CreateAction<ActionType, BranchTypes...>(bl, r);
 }
 
 std::vector<std::string> GetUsedBranchesNames(const std::string, TObjArray *, const std::vector<std::string> &);
@@ -76,9 +75,9 @@ class TDataFrameInterface {
    friend std::string cling::printValue(ROOT::Experimental::TDataFrame *tdf); // For a nice printing at the prompt
    template <typename T>
    friend class TDataFrameInterface;
-   template <typename TDFNode, typename ActionType, typename BranchType, typename ActionResultType>
+   template <typename TDFNode, typename ActionType, typename... BranchTypes, typename ActionResultType>
    friend TActionResultProxy<ActionResultType> ROOT::Internal::CallCreateAction(
-      TDFNode *, const BranchNames_t &, const std::shared_ptr<ActionResultType> &, BranchType *);
+      TDFNode *, const BranchNames_t &, const std::shared_ptr<ActionResultType> &);
 
 public:
    ////////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/inc/ROOT/TDataFrameInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDataFrameInterface.hxx
@@ -825,6 +825,24 @@ private:
    }
 
    /// \cond HIDDEN_SYMBOLS
+
+   /****** BuildAndBook overloads *******/
+   // BuildAndBook builds a TDataFrameAction with the right operation and book it with the TDataFrameImpl
+
+   // Generic filling (covers Histo2D, Histo3D, Profile1D and Profile2D actions, with and without weights)
+   template<typename...BranchTypes, typename ActionType, typename ActionResultType>
+   TActionResultProxy<ActionResultType> BuildAndBook(const BranchNames_t &bl, const std::shared_ptr<ActionResultType> &h,
+                                           unsigned int nSlots, ActionType *)
+   {
+      using Op_t = ROOT::Internal::Operations::FillTOOperation<ActionResultType>;
+      using DFA_t =
+         ROOT::Internal::TDataFrameAction<Op_t, Proxied, ROOT::Internal::TDFTraitsUtils::TTypeList<BranchTypes...>>;
+      auto df = GetDataFrameChecked();
+      df->Book(std::make_shared<DFA_t>(Op_t(h, nSlots), bl, *fProxiedPtr));
+      return ROOT::Detail::MakeActionResultProxy(h, df);
+   }
+
+   // Histo1D filling (must handle the special case of distinguishing FillTOOperation and FillOperation
    template <typename...BranchTypes>
    TActionResultProxy<::TH1F> BuildAndBook(const BranchNames_t &bl, const std::shared_ptr<::TH1F> &h,
                                            unsigned int nSlots, ROOT::Internal::ActionTypes::Histo1D *)
@@ -846,54 +864,7 @@ private:
       return ROOT::Detail::MakeActionResultProxy(h, df);
    }
 
-   template<typename...BranchTypes>
-   TActionResultProxy<::TH2F> BuildAndBook(const BranchNames_t &bl, const std::shared_ptr<::TH2F> &h,
-                                           unsigned int nSlots, ROOT::Internal::ActionTypes::Histo2D *)
-   {
-      using Op_t = ROOT::Internal::Operations::FillTOOperation<::TH2F>;
-      using DFA_t =
-         ROOT::Internal::TDataFrameAction<Op_t, Proxied, ROOT::Internal::TDFTraitsUtils::TTypeList<BranchTypes...>>;
-      auto df = GetDataFrameChecked();
-      df->Book(std::make_shared<DFA_t>(Op_t(h, nSlots), bl, *fProxiedPtr));
-      return ROOT::Detail::MakeActionResultProxy(h, df);
-   }
-
-   template<typename...BranchTypes>
-   TActionResultProxy<::TH3F> BuildAndBook(const BranchNames_t &bl, const std::shared_ptr<::TH3F> &h,
-                                           unsigned int nSlots, ROOT::Internal::ActionTypes::Histo3D *)
-   {
-      using Op_t = ROOT::Internal::Operations::FillTOOperation<::TH3F>;
-      using DFA_t =
-         ROOT::Internal::TDataFrameAction<Op_t, Proxied, ROOT::Internal::TDFTraitsUtils::TTypeList<BranchTypes...>>;
-      auto df = GetDataFrameChecked();
-      df->Book(std::make_shared<DFA_t>(Op_t(h, nSlots), bl, *fProxiedPtr));
-      return ROOT::Detail::MakeActionResultProxy(h, df);
-   }
-
-   template<typename...BranchTypes>
-   TActionResultProxy<::TProfile> BuildAndBook(const BranchNames_t &bl, const std::shared_ptr<::TProfile> &h,
-                                           unsigned int nSlots, ROOT::Internal::ActionTypes::Profile1D *)
-   {
-      using Op_t = ROOT::Internal::Operations::FillTOOperation<::TProfile>;
-      using DFA_t =
-         ROOT::Internal::TDataFrameAction<Op_t, Proxied, ROOT::Internal::TDFTraitsUtils::TTypeList<BranchTypes...>>;
-      auto df = GetDataFrameChecked();
-      df->Book(std::make_shared<DFA_t>(Op_t(h, nSlots), bl, *fProxiedPtr));
-      return ROOT::Detail::MakeActionResultProxy(h, df);
-   }
-
-   template<typename...BranchTypes>
-   TActionResultProxy<::TProfile2D> BuildAndBook(const BranchNames_t &bl, const std::shared_ptr<::TProfile2D> &h,
-                                           unsigned int nSlots, ROOT::Internal::ActionTypes::Profile2D *)
-   {
-      using Op_t = ROOT::Internal::Operations::FillTOOperation<::TProfile2D>;
-      using DFA_t =
-         ROOT::Internal::TDataFrameAction<Op_t, Proxied, ROOT::Internal::TDFTraitsUtils::TTypeList<BranchTypes...>>;
-      auto df = GetDataFrameChecked();
-      df->Book(std::make_shared<DFA_t>(Op_t(h, nSlots), bl, *fProxiedPtr));
-      return ROOT::Detail::MakeActionResultProxy(h, df);
-   }
-
+   // Min action
    template <typename BranchType>
    TActionResultProxy<double> BuildAndBook(const BranchNames_t &bl, const std::shared_ptr<double> &minV,
                                            unsigned int nSlots, ROOT::Internal::ActionTypes::Min *)
@@ -906,6 +877,7 @@ private:
       return ROOT::Detail::MakeActionResultProxy(minV, df);
    }
 
+   // Max action
    template <typename BranchType>
    TActionResultProxy<double> BuildAndBook(const BranchNames_t &bl, const std::shared_ptr<double> &maxV,
                                            unsigned int nSlots, ROOT::Internal::ActionTypes::Max *)
@@ -918,6 +890,7 @@ private:
       return ROOT::Detail::MakeActionResultProxy(maxV, df);
    }
 
+   // Mean action
    template <typename BranchType>
    TActionResultProxy<double> BuildAndBook(const BranchNames_t &bl, const std::shared_ptr<double> &meanV,
                                            unsigned int nSlots, ROOT::Internal::ActionTypes::Mean *)
@@ -929,6 +902,7 @@ private:
       df->Book(std::make_shared<DFA_t>(Op_t(meanV, nSlots), bl, *fProxiedPtr));
       return ROOT::Detail::MakeActionResultProxy(meanV, df);
    }
+   /****** end BuildAndBook ******/
    /// \endcond
 
    // Type was specified by the user, no need to infer it

--- a/tree/treeplayer/inc/ROOT/TDataFrameInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDataFrameInterface.hxx
@@ -53,7 +53,7 @@ Long_t InterpretCall(void *thisPtr, const std::string &methodName, const std::st
 
 Long_t CreateActionGuessed(const BranchNames_t &bl, const std::string &nodeTypename, void *thisPtr,
                            const std::type_info &art, const std::type_info &at, const void *r, TTree *tree,
-                           ROOT::Detail::TDataFrameBranchBase *bbase);
+                           const std::map<std::string, TmpBranchBasePtr_t> &tmpBranches);
 
 } // namespace Internal
 
@@ -879,7 +879,7 @@ private:
    TActionResultProxy<::TH1F> Histo1DImpl(void *, const BranchNames_t &bl, const std::shared_ptr<::TH1F> &h)
    {
       // perform type guessing if needed and build the action
-      return CreateAction<ROOT::Internal::ActionTypes::Histo1D, X>(bl, h);
+      return CreateAction<ROOT::Internal::ActionTypes::Histo1D, X>(BranchNames_t{bl[0]}, h);
    }
 
    // W != void: histogram w/ weights
@@ -986,11 +986,11 @@ private:
                                                      const std::shared_ptr<ActionResultType> &r)
    {
       auto df = GetDataFrameChecked();
-      const auto &theBranchName = bl[0];
-      auto bbase = df->GetBookedBranch(theBranchName);
+      const auto& tmpBranches = df->GetBookedBranches();
       auto tree = df->GetTree();
-      auto retVal = ROOT::Internal::CreateActionGuessed(
-         bl, GetNodeTypeName(), this, typeid(std::shared_ptr<ActionResultType>), typeid(ActionType), &r, tree, bbase);
+      auto retVal =
+         ROOT::Internal::CreateActionGuessed(bl, GetNodeTypeName(), this, typeid(std::shared_ptr<ActionResultType>),
+                                             typeid(ActionType), &r, tree, tmpBranches);
       return *(TActionResultProxy<ActionResultType> *)retVal;
    }
 

--- a/tree/treeplayer/inc/ROOT/TDataFrameInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDataFrameInterface.hxx
@@ -600,68 +600,58 @@ public:
    }
 
    ////////////////////////////////////////////////////////////////////////////
-   /// \brief Fill and return a profile (*lazy action*)
-   /// \tparam B0 The type of the branch the values of which are used to fill the profile.
-   /// \tparam B1 The type of the branch the values of which are used to fill the profile.
+   /// \brief Fill and return a one-dimensional profile (*lazy action*)
+   /// \tparam V1 The type of the branch the values of which are used to fill the profile.
+   /// \tparam V2 The type of the branch the values of which are used to fill the profile.
    /// \param[in] model The model to be considered to build the new return value.
-   /// \param[in] b0BranchName The name of the branch of which the x values are to be collected.
-   /// \param[in] b1BranchName The name of the branch of which the y values are to be collected.
+   /// \param[in] v1Name The name of the branch that will fill the x axis.
+   /// \param[in] v2Name The name of the branch that will fill the y axis.
    ///
-   /// The returned profile is independent of the input one.
    /// This action is *lazy*: upon invocation of this method the calculation is
    /// booked but not executed. See TActionResultProxy documentation.
-   /// The user renounces to the ownership of the model. The value to be used is the
-   /// returned one.
-   template <typename B0, typename B1>
-   TActionResultProxy<::TProfile> Profile1D(::TProfile &&model, const std::string &b0BranchName = "",
-                                            const std::string &b1BranchName = "")
+   /// The user gives up ownership of the model profile object.
+   template <typename V1 = ROOT::Detail::TDataFrameGuessedType, typename V2 = ROOT::Detail::TDataFrameGuessedType>
+   TActionResultProxy<::TProfile> Profile1D(::TProfile &&model, const std::string &v1Name = "",
+                                            const std::string &v2Name = "")
    {
       auto h = std::make_shared<::TProfile>(model);
       if (!ROOT::Internal::TDFV7Utils::Histo<::TProfile>::HasAxisLimits(*h)) {
          throw std::runtime_error("Profiles with no axes limits are not supported yet.");
       }
-      auto bl = GetBranchNames<B0, B1>({b0BranchName, b1BranchName}, "fill the profile");
-      using Op_t = ROOT::Internal::Operations::FillTOOperation<::TProfile>;
-      using DFA_t = ROOT::Internal::TDataFrameAction<Op_t, Proxied, ROOT::Internal::TDFTraitsUtils::TTypeList<B0, B1>>;
-      auto df = GetDataFrameChecked();
-      auto nSlots = df->GetNSlots();
-      df->Book(std::make_shared<DFA_t>(Op_t(h, nSlots), bl, *fProxiedPtr));
-      fProxiedPtr->IncrChildrenCount();
-      return ROOT::Detail::MakeActionResultProxy(h, df);
+      auto bl = GetBranchNames<V1, V2>({v1Name, v2Name}, "fill the 1D Profile");
+      return CreateAction<ROOT::Internal::ActionTypes::Profile1D, V1, V2>(bl, h);
    }
 
    ////////////////////////////////////////////////////////////////////////////
-   /// \brief Fill and return a profile (*lazy action*)
-   /// \tparam B0 The type of the branch the values of which are used to fill the profile.
-   /// \tparam B1 The type of the branch the values of which are used to fill the profile.
+   /// \brief Fill and return a one-dimensional profile (*lazy action*)
+   /// \tparam V1 The type of the branch the values of which are used to fill the profile.
+   /// \tparam V2 The type of the branch the values of which are used to fill the profile.
    /// \tparam W The type of the branch the weights of which are used to fill the profile.
    /// \param[in] model The model to be considered to build the new return value.
-   /// \param[in] b0BranchName The name of the branch of which the x values are to be collected.
-   /// \param[in] b1BranchName The name of the branch of which the y values are to be collected.
-   /// \param[in] wBranchName The name of the branch of which the weight values are to be collected.
+   /// \param[in] v1Name The name of the branch that will fill the x axis.
+   /// \param[in] v2Name The name of the branch that will fill the y axis.
+   /// \param[in] wName The name of the branch that will provide the weights.
    ///
-   /// The returned profile is independent of the input one.
    /// This action is *lazy*: upon invocation of this method the calculation is
    /// booked but not executed. See TActionResultProxy documentation.
-   /// The user renounces to the ownership of the model. The value to be used is the
-   /// returned one.
-   template <typename B0, typename B1, typename W>
-   TActionResultProxy<::TProfile> Profile1D(::TProfile &&model, const std::string &b0BranchName = "",
-                                            const std::string &b1BranchName = "", const std::string &wBranchName = "")
+   /// The user gives up ownership of the model profile object.
+   template <typename V1 = ROOT::Detail::TDataFrameGuessedType, typename V2 = ROOT::Detail::TDataFrameGuessedType,
+             typename W = ROOT::Detail::TDataFrameGuessedType>
+   TActionResultProxy<::TProfile> Profile1D(::TProfile &&model, const std::string &v1Name,
+                                            const std::string &v2Name, const std::string &wName)
    {
       auto h = std::make_shared<::TProfile>(model);
       if (!ROOT::Internal::TDFV7Utils::Histo<::TProfile>::HasAxisLimits(*h)) {
-         throw std::runtime_error("Profiles with no axes limits are not supported yet.");
+         throw std::runtime_error("Profile histograms with no axes limits are not supported yet.");
       }
-      auto bl = GetBranchNames<B0, B1, W>({b0BranchName, b1BranchName, wBranchName}, "fill the profile");
-      using Op_t = ROOT::Internal::Operations::FillTOOperation<::TProfile>;
-      using DFA_t =
-         ROOT::Internal::TDataFrameAction<Op_t, Proxied, ROOT::Internal::TDFTraitsUtils::TTypeList<B0, B1, W>>;
-      auto df = GetDataFrameChecked();
-      auto nSlots = df->GetNSlots();
-      df->Book(std::make_shared<DFA_t>(Op_t(h, nSlots), bl, *fProxiedPtr));
-      fProxiedPtr->IncrChildrenCount();
-      return ROOT::Detail::MakeActionResultProxy(h, df);
+      auto bl = GetBranchNames<V1, V2, W>({v1Name, v2Name, wName}, "fill the 1D profile");
+      return CreateAction<ROOT::Internal::ActionTypes::Profile1D, V1, V2, W>(bl, h);
+   }
+
+   template <typename V1, typename V2, typename W>
+   TActionResultProxy<::TProfile> Profile1D(::TProfile &&model)
+   {
+      return Profile1D<V1,V2,W>(std::move(model), "", "", "");
    }
 
    ////////////////////////////////////////////////////////////////////////////
@@ -919,6 +909,18 @@ private:
                                            unsigned int nSlots, ROOT::Internal::ActionTypes::Histo3D *)
    {
       using Op_t = ROOT::Internal::Operations::FillTOOperation<::TH3F>;
+      using DFA_t =
+         ROOT::Internal::TDataFrameAction<Op_t, Proxied, ROOT::Internal::TDFTraitsUtils::TTypeList<BranchTypes...>>;
+      auto df = GetDataFrameChecked();
+      df->Book(std::make_shared<DFA_t>(Op_t(h, nSlots), bl, *fProxiedPtr));
+      return ROOT::Detail::MakeActionResultProxy(h, df);
+   }
+
+   template<typename...BranchTypes>
+   TActionResultProxy<::TProfile> BuildAndBook(const BranchNames_t &bl, const std::shared_ptr<::TProfile> &h,
+                                           unsigned int nSlots, ROOT::Internal::ActionTypes::Profile1D *)
+   {
+      using Op_t = ROOT::Internal::Operations::FillTOOperation<::TProfile>;
       using DFA_t =
          ROOT::Internal::TDataFrameAction<Op_t, Proxied, ROOT::Internal::TDFTraitsUtils::TTypeList<BranchTypes...>>;
       auto df = GetDataFrameChecked();

--- a/tree/treeplayer/src/TDataFrameInterface.cxx
+++ b/tree/treeplayer/src/TDataFrameInterface.cxx
@@ -185,12 +185,14 @@ Long_t CreateActionGuessed(const BranchNames_t &bl, const std::string &nodeTypen
    const auto actionTypeName = actionTypeClass->GetName();
    std::stringstream createAction_str;
 
+   // createAction_str will contain the following:
+   // "CallCreateAction<nodeType, actionType, branchType>"
+   // "((nodeType*)thisPtr, *(ROOT::BranchNames_t*)&bl, *(actionResultType*)r, nullptr)"
    createAction_str << "ROOT::Internal::CallCreateAction<" << nodeTypename << ", " << actionTypeName << ", "
-                    << theBranchTypeName << ", " << actionResultTypeName << "::element_type>("
+                    << theBranchTypeName << ">("
                     << "(" << nodeTypename << "*)" << thisPtr << ", "
                     << "*(ROOT::BranchNames_t*)" << &bl << ", "
-                    << "*(" << actionResultTypeName << "*)" << r << ", "
-                    << "nullptr);";
+                    << "*(" << actionResultTypeName << "*)" << r << ");";
    auto retVal = gInterpreter->ProcessLine(createAction_str.str().c_str());
    if (!retVal) {
       std::string exceptionText = "An error occurred while jitting this action ";

--- a/tutorials/dataframe/tdf002_dataModel.C
+++ b/tutorials/dataframe/tdf002_dataModel.C
@@ -109,7 +109,7 @@ int tdf002_dataModel()
                          .Define("tracks_pts", getPt)
                          .Define("tracks_pts_weights", getPtWeights);
 
-   auto trN = augmented_d.Histo1D("tracks_n", 40, -.5, 39.5);
+   auto trN = augmented_d.Histo1D(TH1F{"", "", 40, -.5, 39.5}, "tracks_n");
    auto trPts = augmented_d.Histo1D("tracks_pts");
    auto trWPts = augmented_d.Histo1D<std::vector<double>, std::vector<double>>("tracks_pts", "tracks_pts_weights");
 

--- a/tutorials/dataframe/tdf005_fillAnyObject.C
+++ b/tutorials/dataframe/tdf005_fillAnyObject.C
@@ -8,8 +8,9 @@
 /// \date March 2017
 /// \author Danilo Piparo
 
+#include "TCanvas.h"
 #include "TFile.h"
-#include "TH1F.h"
+#include "TH1.h"
 #include "TTree.h"
 
 #include "ROOT/TDataFrame.hxx"


### PR DESCRIPTION
This PR adds branch type inference to Histo1D with weights, as well as Histo2D, Histo3D, Profile1D and Profile2D both with and without weights.
Code has been simplified. Docs have been updated. A related PR in roottest introduces testing for the new functionality.