### PR TITLE
[TMVA] Fix for testDerivativesCpu

### DIFF
--- a/tmva/tmva/test/DNN/TestDerivatives.h
+++ b/tmva/tmva/test/DNN/TestDerivatives.h
@@ -104,7 +104,7 @@ auto testActivationFunctionDerivatives()
       {
          evaluateDerivative<Architecture>(X, af, Y);
       };
-      error = testDerivatives<Architecture>(f, df, 5e-3);
+      error = testDerivatives<Architecture>(f, df, 1.0e-04);
 
       std::cout << "Testing " << static_cast<int>(af) << ": ";
       std::cout << "Maximum Relative Error = " << error << std::endl;


### PR DESCRIPTION
The problem with this test is that it is comparing an analytical
solution of the derivative against the center difference formula
f'(x) = (f(x+dx) - f(x-dx))/(2*dx), and this formula is not exact.
The choice of dx was too large for the tolerance accepted for the
maximum relative error. Using a smaller dx for the center difference
calculation fixes this issue by reducing the error in the numerical
derivative calculation.