### PR TITLE
Made the overlay file work with ROOT's clang version.

### DIFF
--- a/build/unix/modulemap.overlay.yaml.in
+++ b/build/unix/modulemap.overlay.yaml.in
@@ -1,6 +1,5 @@
 {
   'version': 0,
-  'ignore-non-existent-contents': false,
   'roots': [
     { 'name': '@__libcpp_full_path@', 'type': 'directory',
       'contents': [


### PR DESCRIPTION
Seems like ignore-non-existent-contents is quite new,
so we just remove it for now to avoid crashing on
parsing this file with the old clang version inside
ROOT.