### PR TITLE
Made cassert a textual header.

### DIFF
--- a/build/unix/libc.modulemap
+++ b/build/unix/libc.modulemap
@@ -2,7 +2,7 @@ module "libc" {
   export *
   module "assert.h" {
     export *
-    header "assert.h"
+    textual header "assert.h"
   }
   module "ctype.h" {
     export *

--- a/build/unix/stl.cppmap
+++ b/build/unix/stl.cppmap
@@ -16,10 +16,7 @@ module "stl" {
     export *
     header "bitset"
   }
-  module "cassert" {
-    export *
-    header "cassert"
-  }
+  // no module for cassert to stay consistent with the OS X modulemap
   module "ccomplex" {
     export *
     header "ccomplex"


### PR DESCRIPTION
It's AST supposed to depend on NDEBUG, so having this as a module is
wrong.