### PR TITLE
Untangle modulemap generation code in CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,16 +172,14 @@ if(cxxmodules)
     set(ROOT_CXXMODULES_COMMONFLAGS "${ROOT_CXXMODULES_COMMONFLAGS} -isystem ${CMAKE_SOURCE_DIR}/graf3d/glew/isystem")
   endif()
 
-  configure_file("${CMAKE_SOURCE_DIR}/build/unix/module.modulemap" "${CMAKE_BINARY_DIR}/include/module.modulemap" COPYONLY)
+  add_custom_target(copymodulemap DEPENDS "${CMAKE_BINARY_DIR}/include/module.modulemap")
+  add_custom_command(
+                    OUTPUT "${CMAKE_BINARY_DIR}/include/module.modulemap"
+                    DEPENDS build/unix/module.modulemap "${CMAKE_BINARY_DIR}/include/module.modulemap.extra"
+                    COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/build/unix/module.modulemap" "${CMAKE_BINARY_DIR}/include/module.modulemap"
+                    COMMAND cat "${CMAKE_BINARY_DIR}/include/module.modulemap.extra" >> "${CMAKE_BINARY_DIR}/include/module.modulemap"
+  )
 
-  add_custom_target(copymodulemap
-                    DEPENDS build/unix/module.modulemap
-                    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/build/unix/module.modulemap ${CMAKE_BINARY_DIR}/include/module.modulemap
-                    )
-  add_custom_command(TARGET copymodulemap POST_BUILD
-                     COMMAND cat "${CMAKE_BINARY_DIR}/include/module.modulemap.extra" >> ${CMAKE_BINARY_DIR}/include/module.modulemap
-                     VERBATIM
-                    )
   add_dependencies(move_artifacts copymodulemap)
 
   # Provide our own modulemap for implementations other than libcxx.


### PR DESCRIPTION
Previously we had some strange dependency net with multiple commands
that sometimes lead to only having half a modulemap in the build dir.
Now there is only one target that depends on the generated modulemap
and exactly one custom command that generates the whole modulemap.