### PR TITLE
Remove unimplemented shouldIgnore from IncrementalParser.

### DIFF
--- a/interpreter/cling/lib/Interpreter/DeclCollector.cpp
+++ b/interpreter/cling/lib/Interpreter/DeclCollector.cpp
@@ -22,6 +22,11 @@
 using namespace clang;
 
 namespace {
+  ///\brief Return true if this decl (which comes from an AST file) should
+  /// not be sent to CodeGen. The module is assumed to describe the contents
+  /// of a library; symbols inside the library must thus not be reemitted /
+  /// duplicated by CodeGen.
+  ///
   static bool shouldIgnore(const Decl* D) {
     // This function is called for all "deserialized" decls, where the
     // "deserialized" decl either really comes from an AST file or from

--- a/interpreter/cling/lib/Interpreter/IncrementalParser.h
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.h
@@ -229,13 +229,6 @@ namespace cling {
     ///
     EParseResult ParseInternal(llvm::StringRef input);
 
-    ///\brief Return true if this decl (which comes from an AST file) should
-    /// not be sent to CodeGen. The module is assumed to describe the contents
-    /// of a library; symbols inside the library must thus not be reemitted /
-    /// duplicated by CodeGen.
-    ///
-    bool shouldIgnore(const clang::Decl* D) const;
-
   };
 } // end namespace cling
 #endif // CLING_INCREMENTAL_PARSER_H


### PR DESCRIPTION
The function implementation was moved to a static function in
the DeclCollector in commit 858120920f51a3ea8f689d19f2a2fa1cc3981eb1
about 'Emit Decls as DeclCollector sees them'.