### PR TITLE
Revert "coverity 68746,68745", breaks DNN/Layer

### DIFF
--- a/tmva/tmva/inc/TMVA/DNN/Layer.h
+++ b/tmva/tmva/inc/TMVA/DNN/Layer.h
@@ -249,7 +249,6 @@ TLayer<Architecture_t>::TLayer(const TLayer &layer)
 {
    Architecture_t::Copy(fWeights, layer.GetWeights());
    Architecture_t::Copy(fBiases,  layer.GetBiases());
-   fDropoutProbability = 0.;
 }
 
 //______________________________________________________________________________

--- a/tmva/tmva/src/HyperParameterOptimisation.cxx
+++ b/tmva/tmva/src/HyperParameterOptimisation.cxx
@@ -32,7 +32,6 @@
 TMVA::HyperParameterOptimisationResult::HyperParameterOptimisationResult()
    : fROCAVG(0.0), fROCCurves(std::make_shared<TMultiGraph>())
 {
-   fROCAVG = 0.;
 }
 
 TMVA::HyperParameterOptimisationResult::~HyperParameterOptimisationResult()


### PR DESCRIPTION
This reverts commit ccc0521cfff70b33d3e606ded521ae2ebcd91aa8.

This commit reintroduces a bug fixed previously in commit
910dcb3c24d58c76efb95f7a0acdf0093597de1e. The bug was originally
introduced by commit 9c71b95b0ea069f1aac5f0c2a4ba6bec9c4079de.