### PR TITLE
Re-enable C++14 for GCC 4.9 in Interpretator

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -399,10 +399,10 @@ namespace {
     // I would claim that the check should be relaxed to:
 
     if (Opts.CPlusPlus) {
-#if __cplusplus >= 201703L
+#if __cplusplus > 201402L
       Opts.CPlusPlus1z = 1;
 #endif
-#if __cplusplus >= 201402L
+#if __cplusplus > 201103L
       Opts.CPlusPlus14 = 1;
 #endif
 #if __cplusplus >= 201103L


### PR DESCRIPTION
GCC 4.9 only defines '__cplusplus' to the value 201300L and not to
201402L as expected for C++14. This makes the check for the available
C++ standards in the interpreter fail to enable C++14 (which in turn
means that ROOT cannot be compiled with GCC 4.9 if C++14 was enabled in
Cmake). Similarly, for C++17 apart from the proper value 201703L other
values seems to be floating around (e.g. 201406L as defined by the
version of LLVM included with ROOT). The requirement for '__cplusplus_'
to enable certain C++ standards in the interpreter is made less strict
and just needs to be larger than the previous final value.

This basically reinstates commit
0a62e34aa86b812651cfcf9526ba03b975adaa5c which was undone by commit
702298d9ad83866d0be62f0422c03ac8ea6687f1.