### PR TITLE
Removed redundant -fmodule-map-file= compilation flag.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,8 +197,6 @@ if(cxxmodules)
     string(REGEX MATCHALL "[^:]+" __libcpp_full_paths_list "${__libcpp_full_paths}")
     list(GET __libcpp_full_paths_list 0 __libcpp_full_path)
 
-    set(ROOT_CXXMODULES_COMMONFLAGS "${ROOT_CXXMODULES_COMMONFLAGS} -fmodule-map-file=${__libcpp_full_path}/module.modulemap")
-
     configure_file(${CMAKE_SOURCE_DIR}/build/unix/modulemap.overlay.yaml.in ${CMAKE_BINARY_DIR}/include/modulemap.overlay.yaml @ONLY)
 
     configure_file(${CMAKE_SOURCE_DIR}/build/unix/stl.cppmap ${CMAKE_BINARY_DIR}/include/stl.cppmap)


### PR DESCRIPTION
We already have implicit module maps, so this module map
will be automatically discovered by clang.