### PR TITLE
Unused make variable

### DIFF
--- a/proof/proofd/Module.mk
+++ b/proof/proofd/Module.mk
@@ -270,7 +270,7 @@ $(PROOFDEXEO): CXXFLAGS += $(AUTHFLAGS) -I$(ROOT_SRCDIR)/net/rpdutils/res
 $(PROOFEXECVO): CXXFLAGS += $(AUTHFLAGS) -I$(ROOT_SRCDIR)/net/rpdutils/res
 
 $(XPDO): $(XROOTDMAKE) $(XRDHDRS)
-$(XPDO): CXXFLAGS += $(XPDINCEXTRA) $(EXTRA_XRDFLAGS) $(BONJOURCPPFLAGS) -I$(ROOT_SRCDIR)/net/rpdutils/res
+$(XPDO): CXXFLAGS += $(XPDINCEXTRA) $(EXTRA_XRDFLAGS) -I$(ROOT_SRCDIR)/net/rpdutils/res
 
 ifneq ($(ICC_GE_9),)
 # remove when xrootd has moved from strstream.h -> sstream.


### PR DESCRIPTION
The make variable BONJOURCPPFLAGS and all uses of it was removed in commit cd86add. This one occurrence was reintroduced in commit dc627fb. Remove it again.