### PR TITLE
Fix tab completion for notebooks

### DIFF
--- a/bindings/pyroot/JupyROOT/cppcompleter.py
+++ b/bindings/pyroot/JupyROOT/cppcompleter.py
@@ -18,16 +18,22 @@ std::vector<std::string> _TTabComHook(const char* pattern){
    completed[lineBufSize-1] = '\\0';
    int pLoc = strlen(completed.get());
    std::ostringstream oss;
-   ttc->Hook(completed.get(), &pLoc, oss);
-   auto completions = oss.str();
-   vector<string> completions_v;
-   istringstream f(completions);
-   string s;
-   while (getline(f, s, '\\n')) {
-      //cout << "**" << s << "**" << endl;
-      completions_v.push_back(s);
+   Int_t firstChange = ttc->Hook(completed.get(), &pLoc, oss);
+   if (firstChange == -2) { // got some completions in oss
+      auto completions = oss.str();
+      vector<string> completions_v;
+      istringstream f(completions);
+      string s;
+      while (getline(f, s, '\\n')) {
+         completions_v.push_back(s);
+      }
+      return completions_v;
    }
-   return completions_v;
+   if (firstChange == -1) { // found no completions
+      return vector<string>();
+   }
+   // found exactly one completion
+   return vector<string>(1, completed.get());
 }
 """
 

--- a/bindings/pyroot/JupyROOT/cppcompleter.py
+++ b/bindings/pyroot/JupyROOT/cppcompleter.py
@@ -121,7 +121,7 @@ class CppCompleter(object):
         for accessor in self.accessors:
             tmpAccessorPos = line.rfind(accessor)
             if accessorPos < tmpAccessorPos:
-                accessorPos = tmpAccessorPos+len(accessor) if accessor!="::" else 0
+                accessorPos = tmpAccessorPos+len(accessor)
         return accessorPos
 
     def _completeImpl(self, line):

--- a/bindings/pyroot/JupyROOT/cppcompleter.py
+++ b/bindings/pyroot/JupyROOT/cppcompleter.py
@@ -12,9 +12,13 @@ import ROOT
 _TTabComHookCode = """
 std::vector<std::string> _TTabComHook(const char* pattern){
    static auto ttc = new TTabCom;
-   int pLoc = strlen(pattern);
+   const size_t lineBufSize = 2*1024;  // must be equal to/larger than BUF_SIZE in TTabCom.cxx
+   std::unique_ptr<char[]> completed(new char[lineBufSize]);
+   strncpy(completed.get(), pattern, lineBufSize);
+   completed[lineBufSize-1] = '\\0';
+   int pLoc = strlen(completed.get());
    std::ostringstream oss;
-   ttc->Hook((char* )pattern, &pLoc, oss);
+   ttc->Hook(completed.get(), &pLoc, oss);
    auto completions = oss.str();
    vector<string> completions_v;
    istringstream f(completions);

--- a/bindings/pyroot/JupyROOT/kernel/rootkernel.py
+++ b/bindings/pyroot/JupyROOT/kernel/rootkernel.py
@@ -37,6 +37,8 @@ def Debug(msg):
      print('Kernel main: %r' % msg, file=sys.__stderr__)
 
 class ROOTKernel(MetaKernel):
+    identifier_regex = r'[^\d\W](?:[\w]*(?:\.|->|::)?)*'
+    func_call_regex = r'([^\d\W](?:[\w]*(?:\.|->|::)?)*)\([^\)\()]*\Z'
     implementation = 'ROOT'
     implementation_version = '1.0'
     language = 'c++'

--- a/core/rint/src/TTabCom.cxx
+++ b/core/rint/src/TTabCom.cxx
@@ -144,7 +144,8 @@
 #include "Riostream.h"
 #include "Rstrstream.h"
 
-#define BUF_SIZE    1024        // must match value in C_Getline.c (for bounds checking)
+#define BUF_SIZE 1024 // must be smaller than/equal to fgLineBufSize in Getline.cxx and
+                      // lineBufSize in cppcompleter.py
 #define IfDebug(x)  if(gDebug==TTabCom::kDebug) x
 
 #ifdef R__WIN32

--- a/core/textinput/src/Getline.cxx
+++ b/core/textinput/src/Getline.cxx
@@ -84,7 +84,7 @@ namespace {
       static const size_t fgLineBufSize;
       char* fLineBuf;
    };
-   const size_t ROOTTabCompletion::fgLineBufSize = 16*1024;
+   const size_t ROOTTabCompletion::fgLineBufSize = 16 * 1024; // must be equal to/larger than BUF_SIZE in TTabCom.cxx
 
    class TClingTabCompletion: public TabCompletion {
    public:


### PR DESCRIPTION
These commits fix the tab completion for JupyROOT notebooks. This fixes [ROOT-8346](https://sft.its.cern.ch/jira/browse/ROOT-8346) and [ROOT-8347](https://sft.its.cern.ch/jira/browse/ROOT-8347). There still seem to be issues though, for example
```
TString a (SHIFT+ENTER)
a.D(TAB)a(TAB)
```
completes to
```
a.Data()ta()
```
But to me this seems to be caused outside of ROOT.

The completions were tested using this [test](https://gist.github.com/suhlatwork/ef20df8ffeef8cf9212d6535ef2e8137#file-testtcjupyroot-py).


