### PR TITLE
Allow http requests submitting

### DIFF
--- a/net/http/inc/THttpCallArg.h
+++ b/net/http/inc/THttpCallArg.h
@@ -50,6 +50,8 @@ protected:
    void *fBinData;        ///<! binary data, assigned with http call
    Long_t fBinDataLength; ///<! length of binary data
 
+   Bool_t fNotifyFlag;    ///<!  indicate that notification called
+
    Bool_t IsBinData() const { return fBinData && fBinDataLength > 0; }
 
    TString AccessHeader(TString &buf, const char *name, const char *value = 0, Bool_t doing_set = kFALSE);

--- a/net/http/inc/THttpCallArg.h
+++ b/net/http/inc/THttpCallArg.h
@@ -50,7 +50,7 @@ protected:
    void *fBinData;        ///<! binary data, assigned with http call
    Long_t fBinDataLength; ///<! length of binary data
 
-   Bool_t fNotifyFlag;    ///<!  indicate that notification called
+   Bool_t fNotifyFlag; ///<!  indicate that notification called
 
    Bool_t IsBinData() const { return fBinData && fBinDataLength > 0; }
 

--- a/net/http/inc/THttpCallArg.h
+++ b/net/http/inc/THttpCallArg.h
@@ -141,7 +141,7 @@ public:
    /** mark reply as 404 error - page/request not exists or refused */
    void Set404() { SetContentType("_404_"); }
 
-   /** mark reply as 404 error - page/request not exists or refused */
+   /** mark reply as postponed - submitting thread will not be inform */
    void SetPostponed() { SetContentType("_postponed_"); }
 
    /** indicate that http request should response with file content */
@@ -206,6 +206,8 @@ public:
    const void *GetContent() const { return IsBinData() ? fBinData : fContent.Data(); }
 
    void NotifyCondition();
+
+   virtual void HttpReplied();
 
    ClassDef(THttpCallArg, 0) // Arguments for single HTTP call
 };

--- a/net/http/inc/THttpServer.h
+++ b/net/http/inc/THttpServer.h
@@ -92,6 +92,9 @@ public:
    /** Execute HTTP request */
    Bool_t ExecuteHttp(THttpCallArg *arg);
 
+   /** Submit HTTP request */
+   Bool_t SubmitHttp(THttpCallArg *arg, Bool_t can_run_immediately = kFALSE);
+
    /** Process submitted requests, must be called from main thread */
    void ProcessRequests();
 

--- a/net/http/src/THttpCallArg.cxx
+++ b/net/http/src/THttpCallArg.cxx
@@ -319,5 +319,15 @@ Bool_t THttpCallArg::CompressWithGzip()
 
 void THttpCallArg::NotifyCondition()
 {
-   if (!IsPostponed()) fCond.notify_one();
+   if (!IsPostponed()) HttpReplied();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// virtual method to inform object that http request is processed
+/// Normally condition is notified and waiting thread will be awaked
+/// One could reimplement this method in sub-class
+
+void THttpCallArg::HttpReplied()
+{
+   fCond.notify_one();
 }

--- a/net/http/src/THttpCallArg.cxx
+++ b/net/http/src/THttpCallArg.cxx
@@ -32,7 +32,7 @@ ClassImp(THttpCallArg)
    THttpCallArg::THttpCallArg()
    : TObject(), fTopName(), fMethod(), fPathName(), fFileName(), fUserName(), fQuery(), fPostData(0),
      fPostDataLength(0), fWSHandle(0), fWSId(0), fContentType(), fRequestHeader(), fHeader(), fContent(), fZipping(0),
-     fBinData(0), fBinDataLength(0)
+     fBinData(0), fBinDataLength(0), fNotifyFlag(kFALSE)
 {
 }
 
@@ -319,7 +319,10 @@ Bool_t THttpCallArg::CompressWithGzip()
 
 void THttpCallArg::NotifyCondition()
 {
-   if (!IsPostponed()) HttpReplied();
+   if (!fNotifyFlag && !IsPostponed()) {
+      fNotifyFlag = kTRUE;
+      HttpReplied();
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -116,10 +116,16 @@ public:
       // function called in the user code before processing correspondent websocket data
       // returns kTRUE when user should ignore such http request - it is for internal use
 
+      // this is normal request, deliver and process it as any other
+      if (!strstr(arg->GetQuery(), "&dummy")) return kFALSE;
+
+      if (arg==fPoll) { Error("PreviewData", "NEVER SHOULD HAPPEN"); exit(12); }
+
       if (fPoll) {
+         Info("PreviewData", "Get dummy request when previous not completed");
          // if there are pending request, reply it immediately
          fPoll->SetContentType("text/plain");
-         fPoll->SetContent("");
+         fPoll->SetContent("<<nope>>"); // normally should never happen
          fPoll->NotifyCondition();
          fPoll = 0;
       }
@@ -134,7 +140,7 @@ public:
       }
 
       // if arguments has "&dummy" string, user should not process it
-      return strstr(arg->GetQuery(), "&dummy") != 0;
+      return kTRUE;
    }
 };
 

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -119,7 +119,10 @@ public:
       // this is normal request, deliver and process it as any other
       if (!strstr(arg->GetQuery(), "&dummy")) return kFALSE;
 
-      if (arg==fPoll) { Error("PreviewData", "NEVER SHOULD HAPPEN"); exit(12); }
+      if (arg == fPoll) {
+         Error("PreviewData", "NEVER SHOULD HAPPEN");
+         exit(12);
+      }
 
       if (fPoll) {
          Info("PreviewData", "Get dummy request when previous not completed");
@@ -553,7 +556,6 @@ Bool_t THttpServer::SubmitHttp(THttpCallArg *arg, Bool_t can_run_immediately)
    return kFALSE;
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Process requests, submitted for execution
 /// Regularly invoked by THttpTimer, when somewhere in the code
@@ -592,8 +594,7 @@ void THttpServer::ProcessRequests()
       }
 
       // workaround for longpoll handle, it sometime notifies condition before server
-      if (!arg->fNotifyFlag)
-         arg->NotifyCondition();
+      if (!arg->fNotifyFlag) arg->NotifyCondition();
    }
 
    // regularly call Process() method of engine to let perform actions in ROOT context
@@ -829,17 +830,16 @@ void THttpServer::ProcessRequest(THttpCallArg *arg)
             arg->SetContentType("text/plain");
          } else {
             arg->SetMethod("WS_DATA");
-            const char* post = url.GetValueFromOptions("post");
+            const char *post = url.GetValueFromOptions("post");
             if (post) {
                // posted data transferred as URL parameter
                // done due to limitation of webengine in qt
                Int_t len = strlen(post);
-               void *buf = malloc(len/2+1);
-               char *sbuf = (char *) buf;
-               for (int n=0;n<len;n+=2)
-                  sbuf[n/2] = TString::BaseConvert(TString(post+n, 2), 16, 10).Atoi();
-               sbuf[len/2] = 0; // just in case of zero-terminated string
-               arg->SetPostData(buf, len/2);
+               void *buf = malloc(len / 2 + 1);
+               char *sbuf = (char *)buf;
+               for (int n = 0; n < len; n += 2) sbuf[n / 2] = TString::BaseConvert(TString(post + n, 2), 16, 10).Atoi();
+               sbuf[len / 2] = 0; // just in case of zero-terminated string
+               arg->SetPostData(buf, len / 2);
             }
          }
          if (false /*!canv->GetCanvasImp()->ProcessWSRequest(arg)*/) arg->Set404();

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -525,6 +525,30 @@ Bool_t THttpServer::ExecuteHttp(THttpCallArg *arg)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Submit http request, specified in THttpCallArg structure
+/// Contrary to ExecuteHttp, it will not block calling thread.
+/// User should reimplement THttpCallArg::HttpReplied() method
+/// to react when HTTP request is executed.
+/// Method can be called from any thread
+/// Actual execution will be done in main ROOT thread, where analysis code is running.
+/// When called from main thread and can_run_immediately==kTRUE, will be
+/// executed immediately. Returns kTRUE when was executed.
+
+Bool_t THttpServer::SubmitHttp(THttpCallArg *arg, Bool_t can_run_immediately)
+{
+   if (can_run_immediately && (fMainThrdId != 0) && (fMainThrdId == TThread::SelfId())) {
+      ProcessRequest(arg);
+      return kTRUE;
+   }
+
+   // add call arg to the list
+   std::unique_lock<std::mutex> lk(fMutex);
+   fCallArgs.Add(arg);
+   return kFALSE;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
 /// Process requests, submitted for execution
 /// Regularly invoked by THttpTimer, when somewhere in the code
 /// gSystem->ProcessEvents() is called.
@@ -561,7 +585,9 @@ void THttpServer::ProcessRequests()
          fSniffer->SetCurrentCallArg(0);
       }
 
-      arg->NotifyCondition();
+      // workaround for longpoll handle, it sometime notifies condition before server
+      if (!arg->fNotifyFlag)
+         arg->NotifyCondition();
    }
 
    // regularly call Process() method of engine to let perform actions in ROOT context
@@ -797,6 +823,18 @@ void THttpServer::ProcessRequest(THttpCallArg *arg)
             arg->SetContentType("text/plain");
          } else {
             arg->SetMethod("WS_DATA");
+            const char* post = url.GetValueFromOptions("post");
+            if (post) {
+               // posted data transferred as URL parameter
+               // done due to limitation of webengine in qt
+               Int_t len = strlen(post);
+               void *buf = malloc(len/2+1);
+               char *sbuf = (char *) buf;
+               for (int n=0;n<len;n+=2)
+                  sbuf[n/2] = TString::BaseConvert(TString(post+n, 2), 16, 10).Atoi();
+               sbuf[len/2] = 0; // just in case of zero-terminated string
+               arg->SetPostData(buf, len/2);
+            }
          }
          if (false /*!canv->GetCanvasImp()->ProcessWSRequest(arg)*/) arg->Set404();
       }


### PR DESCRIPTION
Before all http requests were executed, using extra threads from civetweb or fastcgi.

With new engines (like from Qt WebEngine) such threads do not exists.
Therefore http requests should be submitted and processed async.

Also fix problem in longpoll socket