### PR TITLE
Parallel version of Snapshot in TDataFrame using TBufferMerger

### DIFF
--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -79,7 +79,7 @@ private:
    std::mutex fWriteMutex;                                       //< Mutex used for the condition variable
    std::condition_variable fCV;                                  //< Condition variable used to wait for data
    std::queue<TBufferFile *> fQueue;                             //< Queue to which data is pushed and merged
-   std::unique_ptr<TFile> fFile;                                 //< Output file, owned by the user
+   std::unique_ptr<TFile> fFile;                                 //< Output file, owned by this class
    std::unique_ptr<std::thread> fMergingThread;                  //< Worker thread that writes to disk
    std::vector<std::weak_ptr<TBufferMergerFile>> fAttachedFiles; //< Attached files
 

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -280,6 +280,7 @@ TBufferMerger::~TBufferMerger()
    fCV.notify_one();
 
    fMergingThread->join();
+   fFile->Close();
 }
 
 std::shared_ptr<TBufferMergerFile> TBufferMerger::GetFile()


### PR DESCRIPTION
Passes `test_snapshot.C` on my computer. However, I believe there are problems elsewhere when more than one cluster exists in the generated trees (i.e. when ForeachSlot actually has more than one slot). We need to make sure to test TDataFrame with trees with multiple slots in the future.