### PR TITLE
Disable Oracle on OS X to prevent linking errors.

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -664,6 +664,14 @@ if(mysql)
 endif()
 
 #---Check for Oracle-------------------------------------------------------------------
+# OCCI is compiled with libstdc++ which has a different ABI than libc++.
+# So we better turn of Oracle in this situation to prevent linking errors between
+# ROOT using libc++ and libOracle.so using libstdc++.
+if(oracle AND libcxx)
+    message(WARNING "Oracle not supported when compiling with libc++!")
+    set(oracle OFF CACHE BOOL "" FORCE)
+endif()
+
 if(oracle)
   message(STATUS "Looking for Oracle")
   find_package(Oracle)


### PR DESCRIPTION
libOracle.so is compiled with stdc++ and on OS X we're always
compiling with libc++. To prevent linking errors between libOracle.so
and the generated ROOT code in the STL symbols, we just disable
Oracle on this platform.