### PR TITLE
Use full path for loading CDLL

### DIFF
--- a/bindings/pyroot/JupyROOT/handlers.py
+++ b/bindings/pyroot/JupyROOT/handlers.py
@@ -12,8 +12,9 @@ from threading import Thread
 from time import sleep as timeSleep
 from resource import setrlimit, RLIMIT_STACK, RLIM_INFINITY
 from sys import platform
+from os import path
 
-_lib = CDLL("libJupyROOT.so")
+_lib = CDLL(path.join(path.dirname(path.dirname(__file__)), 'libJupyROOT.so'))
 
 class IOHandler(object):
     r'''Class used to capture output from C/C++ libraries.


### PR DESCRIPTION
This helps when python modules are not in the default library path, e.g. when installed in the default system location for python modules like /usr/lib64/pythonX.X/site-packages.
