### PR TITLE
[tmva] MLP codegen threadsafety

### DIFF
--- a/tmva/tmva/src/MethodANNBase.cxx
+++ b/tmva/tmva/src/MethodANNBase.cxx
@@ -1101,11 +1101,10 @@ void TMVA::MethodANNBase::MakeClassSpecific( std::ostream& fout, const TString& 
    for (Int_t lIdx = 0; lIdx < numLayers; lIdx++) {
       TObjArray *layer = (TObjArray *)fNetwork->At(lIdx);
       int numNodes = layer->GetEntries();
-      fout << "   double fWeights" << lIdx << "[" << numNodes << "];" << std::endl;
-      fout << "   for (int i=0; i<fLayerSize[" << lIdx << "]; i++) fWeights" << lIdx << "[i]=0;" << std::endl;
+      fout << "   std::array<double, " << numNodes << "> fWeights" << lIdx << " {{}};" << std::endl;
    }
    for (Int_t lIdx = 0; lIdx < numLayers - 1; lIdx++) {
-      fout << "   fWeights" << lIdx << "[fLayerSize[" << lIdx << "]-1]=1;" << std::endl;
+      fout << "   fWeights" << lIdx << ".back() = 1.;" << std::endl;
    }
    fout << std::endl;
    fout << "   for (int i=0; i<fLayerSize[0]-1; i++)" << std::endl;
@@ -1132,13 +1131,13 @@ void TMVA::MethodANNBase::MakeClassSpecific( std::ostream& fout, const TString& 
       else { // fNeuronInputType == TNeuronInputChooser::kAbsSum
          fout << "         fWeights" << i + 1 << "[o] += fabs(inputVal);" << std::endl;
       }
-      fout << "      }" << std::endl;
+      fout << "      } // loop over i" << std::endl;
       if (i+1 != numLayers-1) // in the last layer no activation function is applied
          fout << "      fWeights" << i + 1 << "[o] = ActivationFnc(fWeights" << i + 1 << "[o]);" << std::endl;
       else
          fout << "      fWeights" << i + 1 << "[o] = OutputActivationFnc(fWeights" << i + 1 << "[o]);"
               << std::endl; // zjh
-      fout << "   }" << std::endl;
+      fout << "   } // loop over o" << std::endl;
    }
    fout << std::endl;
    fout << "   return fWeights" << numLayers - 1 << "[0];" << std::endl;

--- a/tmva/tmva/src/MethodANNBase.cxx
+++ b/tmva/tmva/src/MethodANNBase.cxx
@@ -1059,7 +1059,6 @@ void TMVA::MethodANNBase::MakeClassSpecific( std::ostream& fout, const TString& 
       numNodesFrom = numNodesTo;
    }
    fout << std::endl;
-   fout << "   double * fWeights["<<numLayers<<"];" << std::endl;
    fout << "};" << std::endl;
 
    fout << std::endl;
@@ -1071,7 +1070,7 @@ void TMVA::MethodANNBase::MakeClassSpecific( std::ostream& fout, const TString& 
    for (Int_t lIdx = 0; lIdx < numLayers; lIdx++) {
       TObjArray* layer = (TObjArray*)fNetwork->At(lIdx);
       int numNodes = layer->GetEntries();
-      fout << "   fLayerSize[" << lIdx << "] = " << numNodes << "; fWeights["<<lIdx<<"] = new double["<<numNodes<<"]; " << std::endl;
+      fout << "   fLayerSize[" << lIdx << "] = " << numNodes << ";" << std::endl;
    }
 
    for (Int_t i = 0; i < numLayers-1; i++) {
@@ -1099,14 +1098,18 @@ void TMVA::MethodANNBase::MakeClassSpecific( std::ostream& fout, const TString& 
    fout << "      return 0;" << std::endl;
    fout << "   }" << std::endl;
    fout << std::endl;
-   fout << "   for (int l=0; l<fLayers; l++)" << std::endl;
-   fout << "      for (int i=0; i<fLayerSize[l]; i++) fWeights[l][i]=0;" << std::endl;
-   fout << std::endl;
-   fout << "   for (int l=0; l<fLayers-1; l++)" << std::endl;
-   fout << "      fWeights[l][fLayerSize[l]-1]=1;" << std::endl;
+   for (Int_t lIdx = 0; lIdx < numLayers; lIdx++) {
+      TObjArray *layer = (TObjArray *)fNetwork->At(lIdx);
+      int numNodes = layer->GetEntries();
+      fout << "   double fWeights" << lIdx << "[" << numNodes << "];" << std::endl;
+      fout << "   for (int i=0; i<fLayerSize[" << lIdx << "]; i++) fWeights" << lIdx << "[i]=0;" << std::endl;
+   }
+   for (Int_t lIdx = 0; lIdx < numLayers - 1; lIdx++) {
+      fout << "   fWeights" << lIdx << "[fLayerSize[" << lIdx << "]-1]=1;" << std::endl;
+   }
    fout << std::endl;
    fout << "   for (int i=0; i<fLayerSize[0]-1; i++)" << std::endl;
-   fout << "      fWeights[0][i]=inputValues[i];" << std::endl;
+   fout << "      fWeights0[i]=inputValues[i];" << std::endl;
    fout << std::endl;
    for (Int_t i = 0; i < numLayers-1; i++) {
       fout << "   // layer " << i << " to " << i+1 << std::endl;
@@ -1117,25 +1120,28 @@ void TMVA::MethodANNBase::MakeClassSpecific( std::ostream& fout, const TString& 
          fout << "   for (int o=0; o<fLayerSize[" << i+1 << "]-1; o++) {" << std::endl;
       }
       fout << "      for (int i=0; i<fLayerSize[" << i << "]; i++) {" << std::endl;
-      fout << "         double inputVal = fWeightMatrix" << i << "to" << i+1 << "[o][i] * fWeights[" << i << "][i];" << std::endl;
+      fout << "         double inputVal = fWeightMatrix" << i << "to" << i + 1 << "[o][i] * fWeights" << i << "[i];"
+           << std::endl;
 
       if ( fNeuronInputType == "sum") {
-         fout << "         fWeights[" << i+1 << "][o] += inputVal;" << std::endl;
+         fout << "         fWeights" << i + 1 << "[o] += inputVal;" << std::endl;
       }
       else if ( fNeuronInputType == "sqsum") {
-         fout << "         fWeights[" << i+1 << "][o] += inputVal*inputVal;" << std::endl;
+         fout << "         fWeights" << i + 1 << "[o] += inputVal*inputVal;" << std::endl;
       }
       else { // fNeuronInputType == TNeuronInputChooser::kAbsSum
-         fout << "         fWeights[" << i+1 << "][o] += fabs(inputVal);" << std::endl;
+         fout << "         fWeights" << i + 1 << "[o] += fabs(inputVal);" << std::endl;
       }
       fout << "      }" << std::endl;
       if (i+1 != numLayers-1) // in the last layer no activation function is applied
-         fout << "      fWeights[" << i+1 << "][o] = ActivationFnc(fWeights[" << i+1 << "][o]);" << std::endl;
-      else      fout << "      fWeights[" << i+1 << "][o] = OutputActivationFnc(fWeights[" << i+1 << "][o]);" << std::endl; //zjh
+         fout << "      fWeights" << i + 1 << "[o] = ActivationFnc(fWeights" << i + 1 << "[o]);" << std::endl;
+      else
+         fout << "      fWeights" << i + 1 << "[o] = OutputActivationFnc(fWeights" << i + 1 << "[o]);"
+              << std::endl; // zjh
       fout << "   }" << std::endl;
    }
    fout << std::endl;
-   fout << "   return fWeights[" << numLayers-1 << "][0];" << std::endl;
+   fout << "   return fWeights" << numLayers - 1 << "[0];" << std::endl;
    fout << "}" << std::endl;
 
    fout << std::endl;
@@ -1148,10 +1154,6 @@ void TMVA::MethodANNBase::MakeClassSpecific( std::ostream& fout, const TString& 
    fout << "// Clean up" << std::endl;
    fout << "inline void " << className << "::Clear() " << std::endl;
    fout << "{" << std::endl;
-   fout << "   // clean up the arrays" << std::endl;
-   fout << "   for (int lIdx = 0; lIdx < "<<numLayers<<"; lIdx++) {" << std::endl;
-   fout << "      delete[] fWeights[lIdx];" << std::endl;
-   fout << "   }" << std::endl;
    fout << "}" << std::endl;
 }
 

--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -2935,6 +2935,7 @@ void TMVA::MethodBase::MakeClass( const TString& theClassFileName ) const
 
    // generate the class
    fout << "" << std::endl;
+   fout << "#include <array>" << std::endl;
    fout << "#include <vector>" << std::endl;
    fout << "#include <cmath>" << std::endl;
    fout << "#include <string>" << std::endl;


### PR DESCRIPTION
as it turnes out the `...class.C` files generated by the TMVA MLP are not thread safe (`fWeights` is a constant array of contant pointers to beginnings of double arrays, and the contents therein vary at runtime inside the GetMvaValue__ method)

So the quick hack here is to replace the class member of dynamically allocated arrays by fixed sized arrays in the function scope.

# QUASICODE OLD

```
class mlp {
  private:
    double *fweights[3]
    mlp() {
      fweights[0] = new double[5];
      fweights[1] = new double[10];
      fweights[2] = new double[1];
    }
    ~mlp() {
      delete fweights[0];
      delete fweights[1];
      delete fweights[2];
    }
    getmvavalue( std::vector<double> input) const {
       fweights[0] = input;
       fweights[1]  = some_function(fweights[0]);
       fweights[2] = some_other_function(fweights[1]);
       return fweights[2][0];
    }
```


# QUASICODE NEW

```
class mlp {
  private:
    mlp() {
    }
    ~mlp() {
    }
    getmvavalue( std::vector<double> input) const {

      double fweights0[5];
      double fweights1[10];
      double fweights2[1];
       fweights0 = input;
       fweights1  = some_function(fweights0);
       fweights2 = some_other_function(fweights1);
       return fweights2[0];
    }
```







