### PR TITLE
Add entrylist support to TreeProcessorMP

### DIFF
--- a/tree/tree/inc/TEntryList.h
+++ b/tree/tree/inc/TEntryList.h
@@ -78,7 +78,11 @@ class TEntryList: public TNamed
    virtual Int_t       GetTreeNumber() const { return fTreeNumber; }
    virtual Bool_t      GetReapplyCut() const { return fReapply; };
 
-   Bool_t  IsValid() const { if ((fLists || fBlocks)) return kTRUE; return kFALSE; }
+   Bool_t IsValid() const
+   {
+      if ((fLists || fBlocks)) return kTRUE;
+      return kFALSE;
+   }
 
    virtual Int_t       Merge(TCollection *list);
 

--- a/tree/tree/inc/TEntryList.h
+++ b/tree/tree/inc/TEntryList.h
@@ -77,6 +77,9 @@ class TEntryList: public TNamed
    virtual const char *GetFileName() const { return fFileName.Data(); }
    virtual Int_t       GetTreeNumber() const { return fTreeNumber; }
    virtual Bool_t      GetReapplyCut() const { return fReapply; };
+
+   Bool_t  IsValid() const { if ((fLists || fBlocks)) return kTRUE; return kFALSE; }
+
    virtual Int_t       Merge(TCollection *list);
 
    virtual Long64_t    Next();

--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMP.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMP.hxx
@@ -59,19 +59,19 @@ public:
    /// \param[in] nToProcess Number of entries to process (0 means all)
    /// \param[in] jFirst     First entry to process (0 means the first of the first file)
    ///
-   template<class F> auto Process(const std::vector<std::string>& fileNames, F procFunc, TEntryList *entries,
+   template<class F> auto Process(const std::vector<std::string>& fileNames, F procFunc, TEntryList &entries,
                                   const std::string& treeName = "", ULong64_t nToProcess = 0, ULong64_t jFirst = 0)
                                   -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type;
-   template<class F> auto Process(const std::string& fileName, F procFunc, TEntryList *entries,
+   template<class F> auto Process(const std::string& fileName, F procFunc, TEntryList &entries,
                                   const std::string& treeName = "", ULong64_t nToProcess = 0, ULong64_t jFirst = 0)
                                   -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type;
-   template<class F> auto Process(TFileCollection& collection, F procFunc, TEntryList *entries,
+   template<class F> auto Process(TFileCollection& collection, F procFunc, TEntryList &entries,
                                   const std::string& treeName = "", ULong64_t nToProcess = 0, ULong64_t jFirst = 0)
                                   -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type;
-   template<class F> auto Process(TChain& chain, F procFunc, TEntryList *entries,
+   template<class F> auto Process(TChain& chain, F procFunc, TEntryList &entries,
                                   const std::string& treeName = "", ULong64_t nToProcess = 0, ULong64_t jFirst = 0)
                                   -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type;
-   template<class F> auto Process(TTree& tree, F procFunc, TEntryList *entries,
+   template<class F> auto Process(TTree& tree, F procFunc, TEntryList &entries,
                                   ULong64_t nToProcess = 0, ULong64_t jFirst = 0)
                                   -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type;
 
@@ -122,15 +122,15 @@ public:
    /// \param[in] jFirst     First entry to process (0 means the first of the first file)
    ///
    // these versions require a TSelector
-   TList* Process(const std::vector<std::string>& fileNames, TSelector& selector, TEntryList *entries,
+   TList* Process(const std::vector<std::string>& fileNames, TSelector& selector, TEntryList &entries,
                   const std::string& treeName = "", ULong64_t nToProcess = 0, ULong64_t jFirst = 0);
-   TList* Process(const std::string &fileName, TSelector& selector, TEntryList *entries,
+   TList* Process(const std::string &fileName, TSelector& selector, TEntryList &entries,
                   const std::string& treeName = "", ULong64_t nToProcess = 0, ULong64_t jFirst = 0);
-   TList* Process(TFileCollection& files, TSelector& selector, TEntryList *entries,
+   TList* Process(TFileCollection& files, TSelector& selector, TEntryList &entries,
                   const std::string& treeName = "", ULong64_t nToProcess = 0, ULong64_t jFirst = 0);
-   TList* Process(TChain& files, TSelector& selector, TEntryList *entries,
+   TList* Process(TChain& files, TSelector& selector, TEntryList &entries,
                   const std::string& treeName = "", ULong64_t nToProcess = 0, ULong64_t jFirst = 0);
-   TList* Process(TTree& tree, TSelector& selector, TEntryList *entries,
+   TList* Process(TTree& tree, TSelector& selector, TEntryList &entries,
                   ULong64_t nToProcess = 0, ULong64_t jFirst = 0);
 
 
@@ -186,7 +186,7 @@ private:
 };
 
 template<class F>
-auto TTreeProcessorMP::Process(const std::vector<std::string>& fileNames, F procFunc,  TEntryList *entries,
+auto TTreeProcessorMP::Process(const std::vector<std::string>& fileNames, F procFunc,  TEntryList &entries,
                                const std::string& treeName, ULong64_t nToProcess, ULong64_t jFirst)
                                -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type
 {
@@ -199,8 +199,10 @@ auto TTreeProcessorMP::Process(const std::vector<std::string>& fileNames, F proc
    Reset();
    unsigned nWorkers = GetNWorkers();
 
+   // Check th entry list
+   TEntryList *elist = (entries.IsValid()) ? &entries : nullptr;
    //fork
-   TMPWorkerTreeFunc<F> worker(procFunc, fileNames, entries, treeName, nWorkers, nToProcess, jFirst);
+   TMPWorkerTreeFunc<F> worker(procFunc, fileNames, elist, treeName, nWorkers, nToProcess, jFirst);
    bool ok = Fork(worker);
    if(!ok) {
       Error("TTreeProcessorMP::Process", "[E][C] Could not fork. Aborting operation.");
@@ -245,7 +247,7 @@ auto TTreeProcessorMP::Process(const std::vector<std::string>& fileNames, F proc
 
 
 template<class F>
-auto TTreeProcessorMP::Process(const std::string& fileName, F procFunc,  TEntryList *entries,
+auto TTreeProcessorMP::Process(const std::string& fileName, F procFunc,  TEntryList &entries,
                                const std::string& treeName, ULong64_t nToProcess, ULong64_t jFirst)
                                -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type
 {
@@ -255,7 +257,7 @@ auto TTreeProcessorMP::Process(const std::string& fileName, F procFunc,  TEntryL
 
 
 template<class F>
-auto TTreeProcessorMP::Process(TFileCollection& files, F procFunc, TEntryList *entries,
+auto TTreeProcessorMP::Process(TFileCollection& files, F procFunc, TEntryList &entries,
                                const std::string& treeName, ULong64_t nToProcess, ULong64_t jFirst)
                                -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type
 {
@@ -269,7 +271,7 @@ auto TTreeProcessorMP::Process(TFileCollection& files, F procFunc, TEntryList *e
 
 
 template<class F>
-auto TTreeProcessorMP::Process(TChain& files, F procFunc, TEntryList *entries,
+auto TTreeProcessorMP::Process(TChain& files, F procFunc, TEntryList &entries,
                                const std::string& treeName, ULong64_t nToProcess, ULong64_t jFirst)
                                -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type
 {
@@ -284,7 +286,7 @@ auto TTreeProcessorMP::Process(TChain& files, F procFunc, TEntryList *entries,
 
 
 template<class F>
-auto TTreeProcessorMP::Process(TTree& tree, F procFunc, TEntryList *entries,
+auto TTreeProcessorMP::Process(TTree& tree, F procFunc, TEntryList &entries,
                                ULong64_t nToProcess, ULong64_t jFirst)
                                -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type
 {
@@ -295,8 +297,10 @@ auto TTreeProcessorMP::Process(TTree& tree, F procFunc, TEntryList *entries,
    Reset();
    unsigned nWorkers = GetNWorkers();
 
+   // Check th entry list
+   TEntryList *elist = (entries.IsValid()) ? &entries : nullptr;
    //fork
-   TMPWorkerTreeFunc<F> worker(procFunc, &tree, entries, nWorkers, nToProcess, jFirst);
+   TMPWorkerTreeFunc<F> worker(procFunc, &tree, elist, nWorkers, nToProcess, jFirst);
    bool ok = Fork(worker);
    if(!ok) {
       Error("TTreeProcessorMP::Process", "[E][C] Could not fork. Aborting operation.");
@@ -338,7 +342,8 @@ auto TTreeProcessorMP::Process(const std::vector<std::string>& fileNames, F proc
                                const std::string& treeName, ULong64_t nToProcess, ULong64_t jFirst)
                                -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type
 {
-   return Process(fileNames, procFunc, nullptr, treeName, nToProcess, jFirst);
+   TEntryList noelist;
+   return Process(fileNames, procFunc, noelist, treeName, nToProcess, jFirst);
 }
 
 
@@ -347,7 +352,8 @@ auto TTreeProcessorMP::Process(const std::string& fileName, F procFunc,
                                const std::string& treeName, ULong64_t nToProcess, ULong64_t jFirst)
                                -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type
 {
-   return Process(fileName, procFunc, nullptr, treeName, nToProcess, jFirst);
+   TEntryList noelist;
+   return Process(fileName, procFunc, noelist, treeName, nToProcess, jFirst);
 }
 
 
@@ -356,7 +362,8 @@ auto TTreeProcessorMP::Process(TFileCollection& files, F procFunc,
                                const std::string& treeName, ULong64_t nToProcess, ULong64_t jFirst)
                                -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type
 {
-   return Process(files, procFunc, nullptr, treeName, nToProcess, jFirst);
+   TEntryList noelist;
+   return Process(files, procFunc, noelist, treeName, nToProcess, jFirst);
 }
 
 
@@ -365,7 +372,8 @@ auto TTreeProcessorMP::Process(TChain& files, F procFunc,
                                const std::string& treeName, ULong64_t nToProcess, ULong64_t jFirst)
                                -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type
 {
-   return Process(files, procFunc, nullptr, treeName, nToProcess, jFirst);
+   TEntryList noelist;
+   return Process(files, procFunc, noelist, treeName, nToProcess, jFirst);
 }
 
 
@@ -374,7 +382,8 @@ auto TTreeProcessorMP::Process(TTree& tree, F procFunc,
                                ULong64_t nToProcess, ULong64_t jFirst)
                                -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type
 {
-   return Process(tree, procFunc, nullptr, nToProcess, jFirst);
+   TEntryList noelist;
+   return Process(tree, procFunc, noelist, nToProcess, jFirst);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMP.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMP.hxx
@@ -43,19 +43,121 @@ public:
    TTreeProcessorMP(const TTreeProcessorMP &) = delete;
    TTreeProcessorMP &operator=(const TTreeProcessorMP &) = delete;
 
-   // Process
-   // these versions requires that procFunc returns a ptr to TObject or inheriting classes and takes a TTreeReader& (both enforced at compile-time)
-   template<class F> auto Process(const std::vector<std::string>& fileNames, F procFunc, const std::string& treeName = "", ULong64_t nToProcess = 0) -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type;
-   template<class F> auto Process(const std::string& fileName, F procFunc, const std::string& treeName = "", ULong64_t nToProcess = 0) -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type;
-   template<class F> auto Process(TFileCollection& files, F procFunc, const std::string& treeName = "", ULong64_t nToProcess = 0) -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type;
-   template<class F> auto Process(TChain& files, F procFunc, const std::string& treeName = "", ULong64_t nToProcess = 0) -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type;
-   template<class F> auto Process(TTree& tree, F procFunc, ULong64_t nToProcess = 0) -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type;
+   /// \brief Process a TTree dataset with a functor
+   /// \tparam F functor returning a pointer to TObject or inheriting classes and
+   ///          taking a TTreeReader& (both enforced at compile-time)
+   ///
+   /// Dataset definition:
+   /// \param[in] fileNames  vector of strings with the paths of the files with the TTree to process
+   /// \param[in] fileName   string with the path of the files with the TTree to process
+   /// \param[in] collection TFileCollection with the files with the TTree to process
+   /// \param[in] chain      TChain with the files with the TTree to process
+   /// \param[in] tree       TTree to process
+   ///
+   /// \param[in] entries    TEntryList to filter the dataset
+   /// \param[in] treeName   Name of the TTree to process
+   /// \param[in] nToProcess Number of entries to process (0 means all)
+   /// \param[in] jFirst     First entry to process (0 means the first of the first file)
+   ///
+   template<class F> auto Process(const std::vector<std::string>& fileNames, F procFunc, TEntryList *entries,
+                                  const std::string& treeName = "", ULong64_t nToProcess = 0, ULong64_t jFirst = 0)
+                                  -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type;
+   template<class F> auto Process(const std::string& fileName, F procFunc, TEntryList *entries,
+                                  const std::string& treeName = "", ULong64_t nToProcess = 0, ULong64_t jFirst = 0)
+                                  -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type;
+   template<class F> auto Process(TFileCollection& collection, F procFunc, TEntryList *entries,
+                                  const std::string& treeName = "", ULong64_t nToProcess = 0, ULong64_t jFirst = 0)
+                                  -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type;
+   template<class F> auto Process(TChain& chain, F procFunc, TEntryList *entries,
+                                  const std::string& treeName = "", ULong64_t nToProcess = 0, ULong64_t jFirst = 0)
+                                  -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type;
+   template<class F> auto Process(TTree& tree, F procFunc, TEntryList *entries,
+                                  ULong64_t nToProcess = 0, ULong64_t jFirst = 0)
+                                  -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type;
+
+   /// \brief Process a TTree dataset with a functor: version without entry list
+   /// \tparam F functor returning a pointer to TObject or inheriting classes and
+   ///          taking a TTreeReader& (both enforced at compile-time)
+   ///
+   /// Dataset definition:
+   /// \param[in] fileNames  vector of strings with the paths of the files with the TTree to process
+   /// \param[in] fileName   string with the path of the files with the TTree to process
+   /// \param[in] collection TFileCollection with the files with the TTree to process
+   /// \param[in] chain      TChain with the files with the TTree to process
+   /// \param[in] tree       TTree to process
+   ///
+   /// \param[in] treeName   Name of the TTree to process
+   /// \param[in] nToProcess Number of entries to process (0 means all)
+   /// \param[in] jFirst     First entry to process (0 means the first of the first file)
+   ///
+   template<class F> auto Process(const std::vector<std::string>& fileNames, F procFunc,
+                                  const std::string& treeName = "", ULong64_t nToProcess = 0, ULong64_t jFirst = 0)
+                                  -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type;
+   template<class F> auto Process(const std::string& fileName, F procFunc,
+                                  const std::string& treeName = "", ULong64_t nToProcess = 0, ULong64_t jFirst = 0)
+                                  -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type;
+   template<class F> auto Process(TFileCollection& files, F procFunc,
+                                  const std::string& treeName = "", ULong64_t nToProcess = 0, ULong64_t jFirst = 0)
+                                  -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type;
+   template<class F> auto Process(TChain& files, F procFunc,
+                                  const std::string& treeName = "", ULong64_t nToProcess = 0, ULong64_t jFirst = 0)
+                                  -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type;
+   template<class F> auto Process(TTree& tree, F procFunc, ULong64_t nToProcess = 0, ULong64_t jFirst = 0)
+                                  -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type;
+
+
+   /// \brief Process a TTree dataset with a selector
+   ///
+   /// Dataset definition:
+   /// \param[in] fileNames  vector of strings with the paths of the files with the TTree to process
+   /// \param[in] fileName   string with the path of the files with the TTree to process
+   /// \param[in] collection TFileCollection with the files with the TTree to process
+   /// \param[in] chain      TChain with the files with the TTree to process
+   /// \param[in] tree       TTree to process
+   ///
+   /// \param[in] selector   Instance of TSelector to be applied to the dataset
+   /// \param[in] entries    TEntryList to filter the dataset
+   /// \param[in] treeName   Name of the TTree to process
+   /// \param[in] nToProcess Number of entries to process (0 means all)
+   /// \param[in] jFirst     First entry to process (0 means the first of the first file)
+   ///
    // these versions require a TSelector
-   TList* Process(const std::vector<std::string>& fileNames, TSelector& selector, const std::string& treeName = "", ULong64_t nToProcess = 0);
-   TList* Process(const std::string &fileName, TSelector& selector, const std::string& treeName = "", ULong64_t nToProcess = 0);
-   TList* Process(TFileCollection& files, TSelector& selector, const std::string& treeName = "", ULong64_t nToProcess = 0);
-   TList* Process(TChain& files, TSelector& selector, const std::string& treeName = "", ULong64_t nToProcess = 0);
-   TList* Process(TTree& tree, TSelector& selector, ULong64_t nToProcess = 0);
+   TList* Process(const std::vector<std::string>& fileNames, TSelector& selector, TEntryList *entries,
+                  const std::string& treeName = "", ULong64_t nToProcess = 0, ULong64_t jFirst = 0);
+   TList* Process(const std::string &fileName, TSelector& selector, TEntryList *entries,
+                  const std::string& treeName = "", ULong64_t nToProcess = 0, ULong64_t jFirst = 0);
+   TList* Process(TFileCollection& files, TSelector& selector, TEntryList *entries,
+                  const std::string& treeName = "", ULong64_t nToProcess = 0, ULong64_t jFirst = 0);
+   TList* Process(TChain& files, TSelector& selector, TEntryList *entries,
+                  const std::string& treeName = "", ULong64_t nToProcess = 0, ULong64_t jFirst = 0);
+   TList* Process(TTree& tree, TSelector& selector, TEntryList *entries,
+                  ULong64_t nToProcess = 0, ULong64_t jFirst = 0);
+
+
+   /// \brief Process a TTree dataset with a selector: version without entry list
+   ///
+   /// Dataset definition:
+   /// \param[in] fileNames  vector of strings with the paths of the files with the TTree to process
+   /// \param[in] fileName   string with the path of the files with the TTree to process
+   /// \param[in] collection TFileCollection with the files with the TTree to process
+   /// \param[in] chain      TChain with the files with the TTree to process
+   /// \param[in] tree       TTree to process
+   ///
+   /// \param[in] selector   Instance of TSelector to be applied to the dataset
+   /// \param[in] treeName   Name of the TTree to process
+   /// \param[in] nToProcess Number of entries to process (0 means all)
+   /// \param[in] jFirst     First entry to process (0 means the first of the first file)
+   ///
+   // these versions require a TSelector
+   TList* Process(const std::vector<std::string>& fileNames, TSelector& selector,
+                  const std::string& treeName = "", ULong64_t nToProcess = 0, ULong64_t jFirst = 0);
+   TList* Process(const std::string &fileName, TSelector& selector,
+                  const std::string& treeName = "", ULong64_t nToProcess = 0, ULong64_t jFirst = 0);
+   TList* Process(TFileCollection& files, TSelector& selector,
+                  const std::string& treeName = "", ULong64_t nToProcess = 0, ULong64_t jFirst = 0);
+   TList* Process(TChain& files, TSelector& selector,
+                  const std::string& treeName = "", ULong64_t nToProcess = 0, ULong64_t jFirst = 0);
+   TList* Process(TTree& tree, TSelector& selector, ULong64_t nToProcess = 0, ULong64_t jFirst = 0);
 
    void SetNWorkers(unsigned n) { TMPClient::SetNWorkers(n); }
    unsigned GetNWorkers() const { return TMPClient::GetNWorkers(); }
@@ -84,22 +186,27 @@ private:
 };
 
 template<class F>
-auto TTreeProcessorMP::Process(const std::vector<std::string>& fileNames, F procFunc, const std::string& treeName, ULong64_t nToProcess) -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type
+auto TTreeProcessorMP::Process(const std::vector<std::string>& fileNames, F procFunc,  TEntryList *entries,
+                               const std::string& treeName, ULong64_t nToProcess, ULong64_t jFirst)
+                               -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type
 {
    using retType = typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type;
-   static_assert(std::is_constructible<TObject*, retType>::value, "procFunc must return a pointer to a class inheriting from TObject, and must take a reference to TTreeReader as the only argument");
+   static_assert(std::is_constructible<TObject*, retType>::value,
+                 "procFunc must return a pointer to a class inheriting from TObject,"
+                 " and must take a reference to TTreeReader as the only argument");
 
    //prepare environment
    Reset();
    unsigned nWorkers = GetNWorkers();
 
    //fork
-   TMPWorkerTreeFunc<F> worker(procFunc, fileNames, treeName, nWorkers, nToProcess);
+   TMPWorkerTreeFunc<F> worker(procFunc, fileNames, entries, treeName, nWorkers, nToProcess, jFirst);
    bool ok = Fork(worker);
    if(!ok) {
       Error("TTreeProcessorMP::Process", "[E][C] Could not fork. Aborting operation.");
       return nullptr;
    }
+
 
    if(fileNames.size() < nWorkers) {
       //TTree entry granularity. For each file, we divide entries equally between workers
@@ -138,27 +245,33 @@ auto TTreeProcessorMP::Process(const std::vector<std::string>& fileNames, F proc
 
 
 template<class F>
-auto TTreeProcessorMP::Process(const std::string& fileName, F procFunc, const std::string& treeName, ULong64_t nToProcess) -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type
+auto TTreeProcessorMP::Process(const std::string& fileName, F procFunc,  TEntryList *entries,
+                               const std::string& treeName, ULong64_t nToProcess, ULong64_t jFirst)
+                               -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type
 {
    std::vector<std::string> singleFileName(1, fileName);
-   return Process(singleFileName, procFunc, treeName, nToProcess);
+   return Process(singleFileName, procFunc, entries, treeName, nToProcess, jFirst);
 }
 
 
 template<class F>
-auto TTreeProcessorMP::Process(TFileCollection& files, F procFunc, const std::string& treeName, ULong64_t nToProcess) -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type
+auto TTreeProcessorMP::Process(TFileCollection& files, F procFunc, TEntryList *entries,
+                               const std::string& treeName, ULong64_t nToProcess, ULong64_t jFirst)
+                               -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type
 {
    std::vector<std::string> fileNames(files.GetNFiles());
    unsigned count = 0;
    for(auto f : *static_cast<THashList*>(files.GetList()))
       fileNames[count++] = static_cast<TFileInfo*>(f)->GetCurrentUrl()->GetUrl();
 
-   return Process(fileNames, procFunc, treeName, nToProcess);
+   return Process(fileNames, procFunc, entries, treeName, nToProcess, jFirst);
 }
 
 
 template<class F>
-auto TTreeProcessorMP::Process(TChain& files, F procFunc, const std::string& treeName, ULong64_t nToProcess) -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type
+auto TTreeProcessorMP::Process(TChain& files, F procFunc, TEntryList *entries,
+                               const std::string& treeName, ULong64_t nToProcess, ULong64_t jFirst)
+                               -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type
 {
    TObjArray* filelist = files.GetListOfFiles();
    std::vector<std::string> fileNames(filelist->GetEntries());
@@ -166,12 +279,14 @@ auto TTreeProcessorMP::Process(TChain& files, F procFunc, const std::string& tre
    for(auto f : *filelist)
       fileNames[count++] = f->GetTitle();
 
-   return Process(fileNames, procFunc, treeName, nToProcess);
+   return Process(fileNames, procFunc, entries, treeName, nToProcess, jFirst);
 }
 
 
 template<class F>
-auto TTreeProcessorMP::Process(TTree& tree, F procFunc, ULong64_t nToProcess) -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type
+auto TTreeProcessorMP::Process(TTree& tree, F procFunc, TEntryList *entries,
+                               ULong64_t nToProcess, ULong64_t jFirst)
+                               -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type
 {
    using retType = typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type;
    static_assert(std::is_constructible<TObject*, retType>::value, "procFunc must return a pointer to a class inheriting from TObject, and must take a reference to TTreeReader as the only argument");
@@ -181,7 +296,7 @@ auto TTreeProcessorMP::Process(TTree& tree, F procFunc, ULong64_t nToProcess) ->
    unsigned nWorkers = GetNWorkers();
 
    //fork
-   TMPWorkerTreeFunc<F> worker(procFunc, &tree, nWorkers, nToProcess);
+   TMPWorkerTreeFunc<F> worker(procFunc, &tree, entries, nWorkers, nToProcess, jFirst);
    bool ok = Fork(worker);
    if(!ok) {
       Error("TTreeProcessorMP::Process", "[E][C] Could not fork. Aborting operation.");
@@ -211,6 +326,55 @@ auto TTreeProcessorMP::Process(TTree& tree, F procFunc, ULong64_t nToProcess) ->
    ReapWorkers();
    fTaskType = ETask::kNoTask;
    return static_cast<retType>(res);
+}
+
+
+///
+/// No TEntryList versions of generic processor
+///
+
+template<class F>
+auto TTreeProcessorMP::Process(const std::vector<std::string>& fileNames, F procFunc,
+                               const std::string& treeName, ULong64_t nToProcess, ULong64_t jFirst)
+                               -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type
+{
+   return Process(fileNames, procFunc, nullptr, treeName, nToProcess, jFirst);
+}
+
+
+template<class F>
+auto TTreeProcessorMP::Process(const std::string& fileName, F procFunc,
+                               const std::string& treeName, ULong64_t nToProcess, ULong64_t jFirst)
+                               -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type
+{
+   return Process(fileName, procFunc, nullptr, treeName, nToProcess, jFirst);
+}
+
+
+template<class F>
+auto TTreeProcessorMP::Process(TFileCollection& files, F procFunc,
+                               const std::string& treeName, ULong64_t nToProcess, ULong64_t jFirst)
+                               -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type
+{
+   return Process(files, procFunc, nullptr, treeName, nToProcess, jFirst);
+}
+
+
+template<class F>
+auto TTreeProcessorMP::Process(TChain& files, F procFunc,
+                               const std::string& treeName, ULong64_t nToProcess, ULong64_t jFirst)
+                               -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type
+{
+   return Process(files, procFunc, nullptr, treeName, nToProcess, jFirst);
+}
+
+
+template<class F>
+auto TTreeProcessorMP::Process(TTree& tree, F procFunc,
+                               ULong64_t nToProcess, ULong64_t jFirst)
+                               -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type
+{
+   return Process(tree, procFunc, nullptr, nToProcess, jFirst);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/inc/TMPWorkerTree.h
+++ b/tree/treeplayer/inc/TMPWorkerTree.h
@@ -36,8 +36,8 @@ class TMPWorkerTree : public TMPWorker {
 public:
    TMPWorkerTree();
    TMPWorkerTree(const std::vector<std::string> &fileNames, TEntryList *entries, const std::string &treeName,
-                 unsigned nWorkers, ULong64_t maxEntries, ULong64_t firstEntry);
-   TMPWorkerTree(TTree *tree, TEntryList *entries, unsigned nWorkers, ULong64_t maxEntries, ULong64_t firstEntry);
+                 UInt_t nWorkers, ULong64_t maxEntries, ULong64_t firstEntry);
+   TMPWorkerTree(TTree *tree, TEntryList *entries, UInt_t nWorkers, ULong64_t maxEntries, ULong64_t firstEntry);
    virtual ~TMPWorkerTree();
 
    // It doesn't make sense to copy a TMPWorker (each one has a uniq_ptr to its socket)
@@ -49,11 +49,11 @@ protected:
    void         CloseFile();
    ULong64_t    EvalMaxEntries(ULong64_t maxEntries);
    void         HandleInput(MPCodeBufPair& msg); ///< Execute instructions received from a MP client
-   void         Init(int fd, unsigned workerN);
-   Int_t LoadTree(unsigned int code, MPCodeBufPair &msg, Long64_t &start, Long64_t &finish, TEntryList **enl,
+   void         Init(int fd, UInt_t workerN);
+   Int_t LoadTree(UInt_t code, MPCodeBufPair &msg, Long64_t &start, Long64_t &finish, TEntryList **enl,
                   std::string &errmsg);
    TFile       *OpenFile(const std::string& fileName);
-   virtual void Process(unsigned, MPCodeBufPair&) { }
+   virtual void Process(UInt_t, MPCodeBufPair&) { }
    TTree       *RetrieveTree(TFile *fp);
    virtual void SendResult() { }
    void         Setup();
@@ -79,12 +79,12 @@ template<class F>
 class TMPWorkerTreeFunc : public TMPWorkerTree {
 public:
    TMPWorkerTreeFunc(F procFunc, const std::vector<std::string> &fileNames, TEntryList *entries,
-                     const std::string &treeName, unsigned nWorkers, ULong64_t maxEntries, ULong64_t firstEntry)
+                     const std::string &treeName, UInt_t nWorkers, ULong64_t maxEntries, ULong64_t firstEntry)
       : TMPWorkerTree(fileNames, entries, treeName, nWorkers, maxEntries, firstEntry), fProcFunc(procFunc),
         fReducedResult(), fCanReduce(false)
    {
    }
-   TMPWorkerTreeFunc(F procFunc, TTree *tree, TEntryList *entries, unsigned nWorkers, ULong64_t maxEntries,
+   TMPWorkerTreeFunc(F procFunc, TTree *tree, TEntryList *entries, UInt_t nWorkers, ULong64_t maxEntries,
                      ULong64_t firstEntry)
       : TMPWorkerTree(tree, entries, nWorkers, maxEntries, firstEntry), fProcFunc(procFunc), fReducedResult(),
         fCanReduce(false)
@@ -93,7 +93,7 @@ public:
    virtual ~TMPWorkerTreeFunc() {}
 
 private:
-   void Process(unsigned code, MPCodeBufPair& msg);
+   void Process(UInt_t code, MPCodeBufPair& msg);
    void SendResult();
 
    F  fProcFunc; ///< copy the function to be executed
@@ -104,12 +104,12 @@ private:
 class TMPWorkerTreeSel : public TMPWorkerTree {
 public:
    TMPWorkerTreeSel(TSelector &selector, const std::vector<std::string> &fileNames, TEntryList *entries,
-                    const std::string &treeName, unsigned nWorkers, ULong64_t maxEntries, ULong64_t firstEntry)
+                    const std::string &treeName, UInt_t nWorkers, ULong64_t maxEntries, ULong64_t firstEntry)
       : TMPWorkerTree(fileNames, entries, treeName, nWorkers, maxEntries, firstEntry), fSelector(selector),
         fCallBegin(true)
    {
    }
-   TMPWorkerTreeSel(TSelector &selector, TTree *tree, TEntryList *entries, unsigned nWorkers, ULong64_t maxEntries,
+   TMPWorkerTreeSel(TSelector &selector, TTree *tree, TEntryList *entries, UInt_t nWorkers, ULong64_t maxEntries,
                     ULong64_t firstEntry)
       : TMPWorkerTree(tree, entries, nWorkers, maxEntries, firstEntry), fSelector(selector), fCallBegin(true)
    {
@@ -117,7 +117,7 @@ public:
    virtual ~TMPWorkerTreeSel() {}
 
 private:
-   void Process(unsigned code, MPCodeBufPair& msg);
+   void Process(UInt_t code, MPCodeBufPair& msg);
    void SendResult();
 
    TSelector &fSelector; ///< pointer to the selector to be used to process the tree. It is null if we are not using a TSelector.
@@ -169,7 +169,7 @@ void TMPWorkerTreeFunc<F>::SendResult()
 }
 
 template<class F>
-void TMPWorkerTreeFunc<F>::Process(unsigned code, MPCodeBufPair& msg)
+void TMPWorkerTreeFunc<F>::Process(UInt_t code, MPCodeBufPair& msg)
 {
 
    Long64_t start = 0;

--- a/tree/treeplayer/inc/TMPWorkerTree.h
+++ b/tree/treeplayer/inc/TMPWorkerTree.h
@@ -49,11 +49,11 @@ protected:
    void         CloseFile();
    ULong64_t    EvalMaxEntries(ULong64_t maxEntries);
    void         HandleInput(MPCodeBufPair& msg); ///< Execute instructions received from a MP client
-   void         Init(int fd, UInt_t workerN);
+   void Init(int fd, UInt_t workerN);
    Int_t LoadTree(UInt_t code, MPCodeBufPair &msg, Long64_t &start, Long64_t &finish, TEntryList **enl,
                   std::string &errmsg);
    TFile       *OpenFile(const std::string& fileName);
-   virtual void Process(UInt_t, MPCodeBufPair&) { }
+   virtual void Process(UInt_t, MPCodeBufPair &) {}
    TTree       *RetrieveTree(TFile *fp);
    virtual void SendResult() { }
    void         Setup();
@@ -93,7 +93,7 @@ public:
    virtual ~TMPWorkerTreeFunc() {}
 
 private:
-   void Process(UInt_t code, MPCodeBufPair& msg);
+   void Process(UInt_t code, MPCodeBufPair &msg);
    void SendResult();
 
    F  fProcFunc; ///< copy the function to be executed
@@ -117,7 +117,7 @@ public:
    virtual ~TMPWorkerTreeSel() {}
 
 private:
-   void Process(UInt_t code, MPCodeBufPair& msg);
+   void Process(UInt_t code, MPCodeBufPair &msg);
    void SendResult();
 
    TSelector &fSelector; ///< pointer to the selector to be used to process the tree. It is null if we are not using a TSelector.
@@ -168,8 +168,8 @@ void TMPWorkerTreeFunc<F>::SendResult()
    MPSend(GetSocket(), MPCode::kProcResult, fReducedResult);
 }
 
-template<class F>
-void TMPWorkerTreeFunc<F>::Process(UInt_t code, MPCodeBufPair& msg)
+template <class F>
+void TMPWorkerTreeFunc<F>::Process(UInt_t code, MPCodeBufPair &msg)
 {
 
    Long64_t start = 0;

--- a/tree/treeplayer/inc/TMPWorkerTree.h
+++ b/tree/treeplayer/inc/TMPWorkerTree.h
@@ -35,8 +35,8 @@ class TMPWorkerTree : public TMPWorker {
    /// \endcond
 public:
    TMPWorkerTree();
-   TMPWorkerTree(const std::vector<std::string>& fileNames, TEntryList *entries,
-                 const std::string& treeName, unsigned nWorkers, ULong64_t maxEntries, ULong64_t firstEntry);
+   TMPWorkerTree(const std::vector<std::string> &fileNames, TEntryList *entries, const std::string &treeName,
+                 unsigned nWorkers, ULong64_t maxEntries, ULong64_t firstEntry);
    TMPWorkerTree(TTree *tree, TEntryList *entries, unsigned nWorkers, ULong64_t maxEntries, ULong64_t firstEntry);
    virtual ~TMPWorkerTree();
 
@@ -50,15 +50,14 @@ protected:
    ULong64_t    EvalMaxEntries(ULong64_t maxEntries);
    void         HandleInput(MPCodeBufPair& msg); ///< Execute instructions received from a MP client
    void         Init(int fd, unsigned workerN);
-   Int_t        LoadTree(unsigned int code, MPCodeBufPair& msg,
-                         Long64_t &start, Long64_t &finish, TEntryList **enl, std::string &errmsg);
+   Int_t LoadTree(unsigned int code, MPCodeBufPair &msg, Long64_t &start, Long64_t &finish, TEntryList **enl,
+                  std::string &errmsg);
    TFile       *OpenFile(const std::string& fileName);
    virtual void Process(unsigned, MPCodeBufPair&) { }
    TTree       *RetrieveTree(TFile *fp);
    virtual void SendResult() { }
    void         Setup();
    void         SetupTreeCache(TTree *tree);
-
 
    std::vector<std::string> fFileNames; ///< the files to be processed by all workers
    std::string fTreeName;               ///< the name of the tree to be processed
@@ -79,14 +78,18 @@ private:
 template<class F>
 class TMPWorkerTreeFunc : public TMPWorkerTree {
 public:
-   TMPWorkerTreeFunc(F procFunc, const std::vector<std::string>& fileNames, TEntryList *entries,
-                                 const std::string& treeName, unsigned nWorkers, ULong64_t maxEntries, ULong64_t firstEntry)
-                  : TMPWorkerTree(fileNames, entries, treeName, nWorkers, maxEntries, firstEntry),
-                    fProcFunc(procFunc), fReducedResult(), fCanReduce(false) {}
-   TMPWorkerTreeFunc(F procFunc, TTree *tree, TEntryList *entries,
-                     unsigned nWorkers, ULong64_t maxEntries, ULong64_t firstEntry)
-                  : TMPWorkerTree(tree, entries, nWorkers, maxEntries, firstEntry),
-                    fProcFunc(procFunc), fReducedResult(), fCanReduce(false) {}
+   TMPWorkerTreeFunc(F procFunc, const std::vector<std::string> &fileNames, TEntryList *entries,
+                     const std::string &treeName, unsigned nWorkers, ULong64_t maxEntries, ULong64_t firstEntry)
+      : TMPWorkerTree(fileNames, entries, treeName, nWorkers, maxEntries, firstEntry), fProcFunc(procFunc),
+        fReducedResult(), fCanReduce(false)
+   {
+   }
+   TMPWorkerTreeFunc(F procFunc, TTree *tree, TEntryList *entries, unsigned nWorkers, ULong64_t maxEntries,
+                     ULong64_t firstEntry)
+      : TMPWorkerTree(tree, entries, nWorkers, maxEntries, firstEntry), fProcFunc(procFunc), fReducedResult(),
+        fCanReduce(false)
+   {
+   }
    virtual ~TMPWorkerTreeFunc() {}
 
 private:
@@ -100,15 +103,17 @@ private:
 
 class TMPWorkerTreeSel : public TMPWorkerTree {
 public:
-   TMPWorkerTreeSel(TSelector &selector, const std::vector<std::string>& fileNames, TEntryList *entries,
-                                         const std::string& treeName, unsigned nWorkers,
-                                         ULong64_t maxEntries, ULong64_t firstEntry)
-                  : TMPWorkerTree(fileNames, entries, treeName, nWorkers, maxEntries, firstEntry),
-                    fSelector(selector), fCallBegin(true) {}
-   TMPWorkerTreeSel(TSelector &selector, TTree *tree, TEntryList *entries,
-                    unsigned nWorkers, ULong64_t maxEntries, ULong64_t firstEntry)
-                  : TMPWorkerTree(tree, entries, nWorkers, maxEntries, firstEntry),
-                    fSelector(selector), fCallBegin(true) {}
+   TMPWorkerTreeSel(TSelector &selector, const std::vector<std::string> &fileNames, TEntryList *entries,
+                    const std::string &treeName, unsigned nWorkers, ULong64_t maxEntries, ULong64_t firstEntry)
+      : TMPWorkerTree(fileNames, entries, treeName, nWorkers, maxEntries, firstEntry), fSelector(selector),
+        fCallBegin(true)
+   {
+   }
+   TMPWorkerTreeSel(TSelector &selector, TTree *tree, TEntryList *entries, unsigned nWorkers, ULong64_t maxEntries,
+                    ULong64_t firstEntry)
+      : TMPWorkerTree(tree, entries, nWorkers, maxEntries, firstEntry), fSelector(selector), fCallBegin(true)
+   {
+   }
    virtual ~TMPWorkerTreeSel() {}
 
 private:
@@ -182,8 +187,7 @@ void TMPWorkerTreeFunc<F>::Process(unsigned code, MPCodeBufPair& msg)
 
    TTreeReader::EEntryStatus status = reader.SetEntriesRange(start, finish);
    if(status != TTreeReader::kEntryValid) {
-      reply = sn + "could not set TTreeReader to range "
-                 + std::to_string(start) + " " + std::to_string(finish - 1);
+      reply = sn + "could not set TTreeReader to range " + std::to_string(start) + " " + std::to_string(finish - 1);
       MPSend(GetSocket(), MPCode::kProcError, reply.c_str());
       return;
    }

--- a/tree/treeplayer/src/TMPWorkerTree.cxx
+++ b/tree/treeplayer/src/TMPWorkerTree.cxx
@@ -179,7 +179,8 @@ void TMPWorkerTree::SetupTreeCache(TTree *tree)
 //////////////////////////////////////////////////////////////////////////
 /// Init overload definign max entries
 
-void TMPWorkerTree::Init(Int_t fd, UInt_t workerN) {
+void TMPWorkerTree::Init(Int_t fd, UInt_t workerN)
+{
 
    TMPWorker::Init(fd, workerN);
    fMaxNEntries = EvalMaxEntries(fMaxNEntries);
@@ -235,7 +236,7 @@ void TMPWorkerTreeSel::SendResult()
 }
 
 /// Selector specialization
-void TMPWorkerTreeSel::Process(UInt_t code, MPCodeBufPair& msg)
+void TMPWorkerTreeSel::Process(UInt_t code, MPCodeBufPair &msg)
 {
    //evaluate the index of the file to process in fFileNames
    //(we actually don't need the parameter if code == kProcTree)
@@ -271,8 +272,8 @@ void TMPWorkerTreeSel::Process(UInt_t code, MPCodeBufPair& msg)
 
 /// Load the requierd tree and evaluate the processing range
 
-Int_t TMPWorkerTree::LoadTree(UInt_t code, MPCodeBufPair &msg, Long64_t &start, Long64_t &finish,
-                              TEntryList **enl, std::string &errmsg)
+Int_t TMPWorkerTree::LoadTree(UInt_t code, MPCodeBufPair &msg, Long64_t &start, Long64_t &finish, TEntryList **enl,
+                              std::string &errmsg)
 {
    // evaluate the index of the file to process in fFileNames
    //(we actually don't need the parameter if code == kProcTree)

--- a/tree/treeplayer/src/TMPWorkerTree.cxx
+++ b/tree/treeplayer/src/TMPWorkerTree.cxx
@@ -44,26 +44,30 @@
 /// must be done once _before_ forking, while the initialization of the
 /// members must be done _after_ forking by each of the children processes.
 TMPWorkerTree::TMPWorkerTree()
-              : TMPWorker(), fFileNames(), fTreeName(), fTree(nullptr), fFile(nullptr),
+              : TMPWorker(), fFileNames(), fTreeName(), fTree(nullptr),
+                fFile(nullptr), fEntryList(nullptr), fFirstEntry(0),
                 fTreeCache(0), fTreeCacheIsLearning(kFALSE),
                 fUseTreeCache(kTRUE), fCacheSize(-1)
 {
    Setup();
 }
 
-TMPWorkerTree::TMPWorkerTree(const std::vector<std::string>& fileNames,
+TMPWorkerTree::TMPWorkerTree(const std::vector<std::string>& fileNames, TEntryList *entries,
                              const std::string& treeName,
-                             unsigned nWorkers, ULong64_t maxEntries)
+                             unsigned nWorkers, ULong64_t maxEntries, ULong64_t firstEntry)
               : TMPWorker(nWorkers, maxEntries),
-                fFileNames(fileNames), fTreeName(treeName), fTree(nullptr), fFile(nullptr),
+                fFileNames(fileNames), fTreeName(treeName), fTree(nullptr),
+                fFile(nullptr), fEntryList(entries), fFirstEntry(firstEntry),
                 fTreeCache(0), fTreeCacheIsLearning(kFALSE),
                 fUseTreeCache(kTRUE), fCacheSize(-1)
 {
    Setup();
 }
 
-TMPWorkerTree::TMPWorkerTree(TTree *tree, unsigned nWorkers, ULong64_t maxEntries)
-              : TMPWorker(nWorkers, maxEntries), fTree(tree), fFile(nullptr),
+TMPWorkerTree::TMPWorkerTree(TTree *tree, TEntryList *entries, unsigned nWorkers,
+                             ULong64_t maxEntries, ULong64_t firstEntry)
+              : TMPWorker(nWorkers, maxEntries), fTree(tree),
+                fFile(nullptr), fEntryList(entries), fFirstEntry(firstEntry),
                 fTreeCache(0), fTreeCacheIsLearning(kFALSE),
                 fUseTreeCache(kTRUE), fCacheSize(-1)
 {
@@ -80,9 +84,9 @@ TMPWorkerTree::~TMPWorkerTree()
 /// Auxilliary method for common initializations
 void TMPWorkerTree::Setup()
 {
-  Int_t uc = gEnv->GetValue("MultiProc.UseTreeCache", 0);
-  if (uc != 1) fUseTreeCache = kFALSE;
-  fCacheSize = gEnv->GetValue("MultiProc.CacheSize", -1);
+   Int_t uc = gEnv->GetValue("MultiProc.UseTreeCache", 0);
+   if (uc != 1) fUseTreeCache = kFALSE;
+   fCacheSize = gEnv->GetValue("MultiProc.CacheSize", -1);
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -242,20 +246,65 @@ void TMPWorkerTreeSel::Process(unsigned int code, MPCodeBufPair& msg)
 {
    //evaluate the index of the file to process in fFileNames
    //(we actually don't need the parameter if code == kProcTree)
-   unsigned fileN = 0;
-   unsigned nProcessed = 0;
-   TTree *tree = 0;
+
    Long64_t start = 0;
    Long64_t finish = 0;
+   TEntryList *enl = 0;
+   std::string errmsg;
+   if (LoadTree(code, msg, start, finish, &enl, errmsg) != 0) {
+      SendError(errmsg);
+      return;
+   }
+
+   if(fCallBegin){
+     fSelector.SlaveBegin(nullptr);
+     fCallBegin = false;
+   }
+
+   fSelector.Init(fTree);
+   fSelector.Notify();
+   for(Long64_t entry = start; entry<finish; ++entry) {
+      Long64_t e = (enl) ? enl->GetEntry(entry) : entry;
+      fSelector.Process(e);
+   }
+
+   //update the number of processed entries
+   fProcessedEntries += finish - start;
+
+   MPSend(GetSocket(), MPCode::kIdling);
+
+   return;
+}
+
+
+/// Load the requierd tree and evaluate the processing range
+
+Int_t TMPWorkerTree::LoadTree(unsigned int code, MPCodeBufPair& msg,
+                              Long64_t &start, Long64_t &finish,
+                              TEntryList **enl, std::string &errmsg)
+{
+   //evaluate the index of the file to process in fFileNames
+   //(we actually don't need the parameter if code == kProcTree)
+
+   start = 0;
+   finish = 0;
+   errmsg = "";
+
+   unsigned fileN = 0;
+   unsigned nProcessed = 0;
    bool setupcache = true;
 
+   std::string mgroot = "[S" + std::to_string(GetNWorker()) + "]: ";
+
+   TTree *tree = 0;
    if (code ==  MPCode::kProcTree) {
+
+      mgroot +=  "MPCode::kProcTree: ";
 
       // The tree must be defined at this level
       if(fTree == nullptr) {
-         std::cout << "tree undefined!\n" ;
-         //errors are handled inside RetrieveTree
-         return;
+         errmsg = mgroot + std::string("tree undefined!");
+         return -1;
       }
 
       //retrieve the total number of entries ranges processed so far by TPool
@@ -267,11 +316,12 @@ void TMPWorkerTreeSel::Process(unsigned int code, MPCodeBufPair& msg)
       unsigned nEntries = fTree->GetEntries();
       unsigned nBunch = nEntries / fNWorkers;
       unsigned rangeN = nProcessed % fNWorkers;
-      start = rangeN*nBunch + 1;
-      if(rangeN < (fNWorkers-1))
+      start = rangeN*nBunch;
+      if(rangeN < (fNWorkers-1)) {
          finish = (rangeN+1)*nBunch;
-      else
+      } else {
          finish = nEntries;
+      }
 
       //process tree
       tree = fTree;
@@ -280,37 +330,44 @@ void TMPWorkerTreeSel::Process(unsigned int code, MPCodeBufPair& msg)
          // We need to reopen the file locally (TODO: to understand and fix this)
          if ((fFile = TFile::Open(fTree->GetCurrentFile()->GetName())) && !fFile->IsZombie()) {
             if (!(tree = (TTree *) fFile->Get(fTree->GetName()))) {
-               std::string errmsg = "unable to retrieve tree from open file " +
-                                    std::string(fTree->GetCurrentFile()->GetName());
-               SendError(errmsg);
+               errmsg = mgroot + std::string("unable to retrieve tree from open file ")
+                               + std::string(fTree->GetCurrentFile()->GetName());
+               delete fFile;
+               return -1;
             }
             fTree = tree;
          } else {
             //errors are handled inside OpenFile
-            std::string errmsg = "unable to open file " + std::string(fTree->GetCurrentFile()->GetName());
-            SendError(errmsg);
+            errmsg = mgroot + std::string("unable to open file ")
+                            + std::string(fTree->GetCurrentFile()->GetName());
+            if (fFile && fFile->IsZombie()) delete fFile;
+            return -1;
          }
       }
 
    } else {
 
       if (code == MPCode::kProcRange) {
+         mgroot +=  "MPCode::kProcRange: ";
          //retrieve the total number of entries ranges processed so far by TPool
          nProcessed = ReadBuffer<unsigned>(msg.second.get());
          //evaluate the file and the entries range to process
          fileN = nProcessed / fNWorkers;
-      } else {
+      } else if (code == MPCode::kProcFile) {
+         mgroot +=  "MPCode::kProcFile: ";
          //evaluate the file and the entries range to process
          fileN = ReadBuffer<unsigned>(msg.second.get());
+      } else {
+         errmsg += "MPCode undefined!";
+         return -1;
       }
 
       // Open the file
       fFile = OpenFile(fFileNames[fileN]);
       if (fFile == nullptr) {
          //errors are handled inside OpenFile
-         std::string errmsg = "unable to open file " + fFileNames[fileN];
-         SendError(errmsg);
-         return;
+         errmsg = mgroot + std::string("unable to open file ") + fFileNames[fileN];
+         return -1;
       }
 
       //retrieve the TTree with the specified name from file
@@ -318,9 +375,8 @@ void TMPWorkerTreeSel::Process(unsigned int code, MPCodeBufPair& msg)
       tree = RetrieveTree(fFile);
       if (tree == nullptr) {
          //errors are handled inside RetrieveTree
-         std::string errmsg = "unable to retrieve tree from open file " + fFileNames[fileN];
-         SendError(errmsg);
-         return;
+         errmsg = mgroot + std::string("unable to retrieve tree from open file ") + fFileNames[fileN];
+         return -1;
       }
 
       // Prepare to setup the cache, if required
@@ -337,7 +393,7 @@ void TMPWorkerTreeSel::Process(unsigned int code, MPCodeBufPair& msg)
          unsigned nBunch = nEntries / fNWorkers;
          if(nEntries % fNWorkers) nBunch++;
          unsigned rangeN = nProcessed % fNWorkers;
-         start = rangeN*nBunch + 1;
+         start = rangeN*nBunch;
          if(rangeN < (fNWorkers-1))
             finish = (rangeN+1)*nBunch;
          else
@@ -351,28 +407,41 @@ void TMPWorkerTreeSel::Process(unsigned int code, MPCodeBufPair& msg)
    // Setup the cache, if required
    if (setupcache) SetupTreeCache(fTree);
 
+
+   // Get the entrylist, if required
+   if (fEntryList && enl) {
+      if ((*enl = fEntryList->GetEntryList(fTree->GetName(), TUrl(fFile->GetName()).GetFile()))) {
+         //create entries range
+         if (code == MPCode::kProcRange) {
+            //example: for 21 entries, 4 workers we want ranges 0-5, 5-10, 10-15, 15-21
+            //and this worker must take the rangeN-th range
+            unsigned nEntries = (*enl)->GetN();
+            unsigned nBunch = nEntries / fNWorkers;
+            if(nEntries % fNWorkers) nBunch++;
+            unsigned rangeN = nProcessed % fNWorkers;
+            start = rangeN*nBunch;
+            if(rangeN < (fNWorkers-1))
+               finish = (rangeN+1)*nBunch;
+            else
+               finish = nEntries;
+         } else {
+            start = 0;
+            finish = (*enl)->GetN();
+         }
+      } else {
+         Warning("LoadTree", "failed to get entry list for: %s %s", fTree->GetName(), TUrl(fFile->GetName()).GetFile());
+      }
+   }
+
    //check if we are going to reach the max of entries
    //change finish accordingly
    if (fMaxNEntries)
       if (fProcessedEntries + finish - start > fMaxNEntries)
          finish = start + fMaxNEntries - fProcessedEntries;
 
-   if(fFirstEntry){
-     fSelector.SlaveBegin(nullptr);
-     fFirstEntry = false;
-   }
+   if (gDebug > 0 && fFile)
+      Info("LoadTree", "%s %d %d file: %s %lld %lld", mgroot.c_str(), nProcessed, fileN, fFile->GetName(), start, finish);
 
-   fSelector.Init(tree);
-   fSelector.Notify();
-   for(Long64_t entry = start; entry<finish; ++entry) {
-      fSelector.Process(entry);
-   }
 
-   //update the number of processed entries
-   fProcessedEntries += finish - start;
-
-   MPSend(GetSocket(), MPCode::kIdling);
-
-   return;
+   return 0;
 }
-

--- a/tree/treeplayer/src/TTreeProcessorMP.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMP.cxx
@@ -92,8 +92,8 @@ TTreeProcessorMP::TTreeProcessorMP(unsigned nWorkers) : TMPClient(nWorkers)
 
 //////////////////////////////////////////////////////////////////////////
 /// TSelector-based tree processing: memory resident tree
-TList* TTreeProcessorMP::Process(TTree& tree, TSelector& selector, TEntryList *entries,
-                                 ULong64_t nToProcess, ULong64_t firstEntry)
+TList *TTreeProcessorMP::Process(TTree &tree, TSelector &selector, TEntryList *entries, ULong64_t nToProcess,
+                                 ULong64_t firstEntry)
 {
    //prepare environment
    Reset();
@@ -101,7 +101,7 @@ TList* TTreeProcessorMP::Process(TTree& tree, TSelector& selector, TEntryList *e
    selector.Begin(nullptr);
 
    //fork
-   TMPWorkerTreeSel worker(selector, &tree, entries, nWorkers, nToProcess/nWorkers, firstEntry);
+   TMPWorkerTreeSel worker(selector, &tree, entries, nWorkers, nToProcess / nWorkers, firstEntry);
    bool ok = Fork(worker);
    if(!ok) {
       Error("TTreeProcessorMP::Process", "[E][C] Could not fork. Aborting operation");
@@ -146,9 +146,8 @@ TList* TTreeProcessorMP::Process(TTree& tree, TSelector& selector, TEntryList *e
 
 //////////////////////////////////////////////////////////////////////////
 /// TSelector-based tree processing: dataset as a vector of files
-TList* TTreeProcessorMP::Process(const std::vector<std::string>& fileNames, TSelector& selector,
-                                 TEntryList *entries, const std::string& treeName,
-                                 ULong64_t nToProcess, ULong64_t firstEntry)
+TList *TTreeProcessorMP::Process(const std::vector<std::string> &fileNames, TSelector &selector, TEntryList *entries,
+                                 const std::string &treeName, ULong64_t nToProcess, ULong64_t firstEntry)
 {
 
    //prepare environment
@@ -229,9 +228,8 @@ TList* TTreeProcessorMP::Process(const std::vector<std::string>& fileNames, TSel
 
 //////////////////////////////////////////////////////////////////////////
 /// TSelector-based tree processing: dataset as a TFileCollection
-TList* TTreeProcessorMP::Process(TFileCollection& files, TSelector& selector,
-                                 TEntryList *entries, const std::string& treeName,
-                                 ULong64_t nToProcess, ULong64_t firstEntry)
+TList *TTreeProcessorMP::Process(TFileCollection &files, TSelector &selector, TEntryList *entries,
+                                 const std::string &treeName, ULong64_t nToProcess, ULong64_t firstEntry)
 {
    std::vector<std::string> fileNames(files.GetNFiles());
    unsigned count = 0;
@@ -244,8 +242,7 @@ TList* TTreeProcessorMP::Process(TFileCollection& files, TSelector& selector,
 
 //////////////////////////////////////////////////////////////////////////
 /// TSelector-based tree processing: dataset as a TChain
-TList* TTreeProcessorMP::Process(TChain& files, TSelector& selector,
-                                 TEntryList *entries, const std::string& treeName,
+TList *TTreeProcessorMP::Process(TChain &files, TSelector &selector, TEntryList *entries, const std::string &treeName,
                                  ULong64_t nToProcess, ULong64_t firstEntry)
 {
    TObjArray* filelist = files.GetListOfFiles();
@@ -259,50 +256,45 @@ TList* TTreeProcessorMP::Process(TChain& files, TSelector& selector,
 
 //////////////////////////////////////////////////////////////////////////
 /// TSelector-based tree processing: dataset as a single file
-TList* TTreeProcessorMP::Process(const std::string& fileName, TSelector& selector,
-                                 TEntryList *entries, const std::string& treeName,
-                                 ULong64_t nToProcess, ULong64_t firstEntry)
+TList *TTreeProcessorMP::Process(const std::string &fileName, TSelector &selector, TEntryList *entries,
+                                 const std::string &treeName, ULong64_t nToProcess, ULong64_t firstEntry)
 {
    std::vector<std::string> singleFileName(1, fileName);
    return Process(singleFileName, selector, entries, treeName, nToProcess, firstEntry);
 }
 
-
 ///
 /// No TEntryList versions of selector processor
 ///
 
-TList *TTreeProcessorMP::Process(const std::vector<std::string>& fileNames, TSelector& selector,
-                                 const std::string& treeName, ULong64_t nToProcess, ULong64_t jFirst)
+TList *TTreeProcessorMP::Process(const std::vector<std::string> &fileNames, TSelector &selector,
+                                 const std::string &treeName, ULong64_t nToProcess, ULong64_t jFirst)
 {
    return Process(fileNames, selector, nullptr, treeName, nToProcess, jFirst);
 }
 
-TList *TTreeProcessorMP::Process(const std::string& fileName, TSelector& selector,
-                                 const std::string& treeName, ULong64_t nToProcess, ULong64_t jFirst)
+TList *TTreeProcessorMP::Process(const std::string &fileName, TSelector &selector, const std::string &treeName,
+                                 ULong64_t nToProcess, ULong64_t jFirst)
 {
    return Process(fileName, selector, nullptr, treeName, nToProcess, jFirst);
 }
 
-TList *TTreeProcessorMP::Process(TFileCollection& files, TSelector& selector,
-                                 const std::string& treeName, ULong64_t nToProcess, ULong64_t jFirst)
-{
-   return Process(files, selector, nullptr, treeName, nToProcess, jFirst);
-}
-
-TList *TTreeProcessorMP::Process(TChain& files, TSelector& selector,
-                                 const std::string& treeName, ULong64_t nToProcess, ULong64_t jFirst)
-{
-   return Process(files, selector, nullptr, treeName, nToProcess, jFirst);
-}
-
-TList *TTreeProcessorMP::Process(TTree& tree, TSelector& selector,
+TList *TTreeProcessorMP::Process(TFileCollection &files, TSelector &selector, const std::string &treeName,
                                  ULong64_t nToProcess, ULong64_t jFirst)
+{
+   return Process(files, selector, nullptr, treeName, nToProcess, jFirst);
+}
+
+TList *TTreeProcessorMP::Process(TChain &files, TSelector &selector, const std::string &treeName, ULong64_t nToProcess,
+                                 ULong64_t jFirst)
+{
+   return Process(files, selector, nullptr, treeName, nToProcess, jFirst);
+}
+
+TList *TTreeProcessorMP::Process(TTree &tree, TSelector &selector, ULong64_t nToProcess, ULong64_t jFirst)
 {
    return Process(tree, selector, nullptr, nToProcess, jFirst);
 }
-
-
 
 /// Fix list of lists before merging (to avoid errors about duplicated objects)
 void TTreeProcessorMP::FixLists(std::vector<TObject*> &lists) {

--- a/tree/treeplayer/src/TTreeProcessorMP.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMP.cxx
@@ -274,34 +274,34 @@ TList *TTreeProcessorMP::Process(const std::string &fileName, TSelector &selecto
 TList *TTreeProcessorMP::Process(const std::vector<std::string> &fileNames, TSelector &selector,
                                  const std::string &treeName, ULong64_t nToProcess, ULong64_t jFirst)
 {
-   TEntryList noelist; 
+   TEntryList noelist;
    return Process(fileNames, selector, noelist, treeName, nToProcess, jFirst);
 }
 
 TList *TTreeProcessorMP::Process(const std::string &fileName, TSelector &selector, const std::string &treeName,
                                  ULong64_t nToProcess, ULong64_t jFirst)
 {
-   TEntryList noelist; 
+   TEntryList noelist;
    return Process(fileName, selector, noelist, treeName, nToProcess, jFirst);
 }
 
 TList *TTreeProcessorMP::Process(TFileCollection &files, TSelector &selector, const std::string &treeName,
                                  ULong64_t nToProcess, ULong64_t jFirst)
 {
-   TEntryList noelist; 
+   TEntryList noelist;
    return Process(files, selector, noelist, treeName, nToProcess, jFirst);
 }
 
 TList *TTreeProcessorMP::Process(TChain &files, TSelector &selector, const std::string &treeName, ULong64_t nToProcess,
                                  ULong64_t jFirst)
 {
-   TEntryList noelist; 
+   TEntryList noelist;
    return Process(files, selector, noelist, treeName, nToProcess, jFirst);
 }
 
 TList *TTreeProcessorMP::Process(TTree &tree, TSelector &selector, ULong64_t nToProcess, ULong64_t jFirst)
 {
-   TEntryList noelist; 
+   TEntryList noelist;
    return Process(tree, selector, noelist, nToProcess, jFirst);
 }
 

--- a/tree/treeplayer/src/TTreeProcessorMP.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMP.cxx
@@ -85,7 +85,7 @@ namespace ROOT {
 /// Class constructor.
 /// nWorkers is the number of times this ROOT session will be forked, i.e.
 /// the number of workers that will be spawned.
-TTreeProcessorMP::TTreeProcessorMP(unsigned nWorkers) : TMPClient(nWorkers)
+TTreeProcessorMP::TTreeProcessorMP(UInt_t nWorkers) : TMPClient(nWorkers)
 {
    Reset();
 }
@@ -97,7 +97,7 @@ TList *TTreeProcessorMP::Process(TTree &tree, TSelector &selector, TEntryList *e
 {
    //prepare environment
    Reset();
-   unsigned nWorkers = GetNWorkers();
+   UInt_t nWorkers = GetNWorkers();
    selector.Begin(nullptr);
 
    //fork
@@ -113,7 +113,7 @@ TList *TTreeProcessorMP::Process(TTree &tree, TSelector &selector, TEntryList *e
 
    //tell workers to start processing entries
    fNToProcess = nWorkers; //this is the total number of ranges that will be processed by all workers cumulatively
-   std::vector<unsigned> args(nWorkers);
+   std::vector<UInt_t> args(nWorkers);
    std::iota(args.begin(), args.end(), 0);
    fNProcessed = Broadcast(MPCode::kProcTree, args);
    if (fNProcessed < nWorkers)
@@ -152,7 +152,7 @@ TList *TTreeProcessorMP::Process(const std::vector<std::string> &fileNames, TSel
 
    //prepare environment
    Reset();
-   unsigned nWorkers = GetNWorkers();
+   UInt_t nWorkers = GetNWorkers();
    selector.Begin(nullptr);
 
    //fork
@@ -171,7 +171,7 @@ TList *TTreeProcessorMP::Process(const std::vector<std::string> &fileNames, TSel
          fTaskType = ETask::kProcByRange;
          // Tell workers to start processing entries
          fNToProcess = nWorkers*fileNames.size(); //this is the total number of ranges that will be processed by all workers cumulatively
-         std::vector<unsigned> args(nWorkers);
+         std::vector<UInt_t> args(nWorkers);
          std::iota(args.begin(), args.end(), 0);
          fNProcessed = Broadcast(MPCode::kProcRange, args);
          if (fNProcessed < nWorkers)
@@ -181,7 +181,7 @@ TList *TTreeProcessorMP::Process(const std::vector<std::string> &fileNames, TSel
          // File granularity: each worker processes one whole file as a single task
          fTaskType = ETask::kProcByFile;
          fNToProcess = fileNames.size();
-         std::vector<unsigned> args(nWorkers);
+         std::vector<UInt_t> args(nWorkers);
          std::iota(args.begin(), args.end(), 0);
          fNProcessed = Broadcast(MPCode::kProcFile, args);
          if (fNProcessed < nWorkers)
@@ -193,7 +193,7 @@ TList *TTreeProcessorMP::Process(const std::vector<std::string> &fileNames, TSel
       fTaskType = ETask::kProcByRange;
       // Tell workers to start processing entries
       fNToProcess = nWorkers*fileNames.size(); //this is the total number of ranges that will be processed by all workers cumulatively
-      std::vector<unsigned> args(nWorkers);
+      std::vector<UInt_t> args(nWorkers);
       std::iota(args.begin(), args.end(), 0);
       fNProcessed = Broadcast(MPCode::kProcRange, args);
       if (fNProcessed < nWorkers)
@@ -232,7 +232,7 @@ TList *TTreeProcessorMP::Process(TFileCollection &files, TSelector &selector, TE
                                  const std::string &treeName, ULong64_t nToProcess, ULong64_t firstEntry)
 {
    std::vector<std::string> fileNames(files.GetNFiles());
-   unsigned count = 0;
+   UInt_t count = 0;
    for(auto f : *static_cast<THashList*>(files.GetList()))
       fileNames[count++] = static_cast<TFileInfo*>(f)->GetCurrentUrl()->GetUrl();
 
@@ -247,7 +247,7 @@ TList *TTreeProcessorMP::Process(TChain &files, TSelector &selector, TEntryList 
 {
    TObjArray* filelist = files.GetListOfFiles();
    std::vector<std::string> fileNames(filelist->GetEntries());
-   unsigned count = 0;
+   UInt_t count = 0;
    for(auto f : *filelist)
       fileNames[count++] = f->GetTitle();
 

--- a/tree/treeplayer/src/TTreeProcessorMP.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMP.cxx
@@ -92,7 +92,7 @@ TTreeProcessorMP::TTreeProcessorMP(UInt_t nWorkers) : TMPClient(nWorkers)
 
 //////////////////////////////////////////////////////////////////////////
 /// TSelector-based tree processing: memory resident tree
-TList *TTreeProcessorMP::Process(TTree &tree, TSelector &selector, TEntryList *entries, ULong64_t nToProcess,
+TList *TTreeProcessorMP::Process(TTree &tree, TSelector &selector, TEntryList &entries, ULong64_t nToProcess,
                                  ULong64_t firstEntry)
 {
    //prepare environment
@@ -100,8 +100,10 @@ TList *TTreeProcessorMP::Process(TTree &tree, TSelector &selector, TEntryList *e
    UInt_t nWorkers = GetNWorkers();
    selector.Begin(nullptr);
 
+   // Check the entry list
+   TEntryList *elist = (entries.IsValid()) ? &entries : nullptr;
    //fork
-   TMPWorkerTreeSel worker(selector, &tree, entries, nWorkers, nToProcess / nWorkers, firstEntry);
+   TMPWorkerTreeSel worker(selector, &tree, elist, nWorkers, nToProcess / nWorkers, firstEntry);
    bool ok = Fork(worker);
    if(!ok) {
       Error("TTreeProcessorMP::Process", "[E][C] Could not fork. Aborting operation");
@@ -146,7 +148,7 @@ TList *TTreeProcessorMP::Process(TTree &tree, TSelector &selector, TEntryList *e
 
 //////////////////////////////////////////////////////////////////////////
 /// TSelector-based tree processing: dataset as a vector of files
-TList *TTreeProcessorMP::Process(const std::vector<std::string> &fileNames, TSelector &selector, TEntryList *entries,
+TList *TTreeProcessorMP::Process(const std::vector<std::string> &fileNames, TSelector &selector, TEntryList &entries,
                                  const std::string &treeName, ULong64_t nToProcess, ULong64_t firstEntry)
 {
 
@@ -155,8 +157,10 @@ TList *TTreeProcessorMP::Process(const std::vector<std::string> &fileNames, TSel
    UInt_t nWorkers = GetNWorkers();
    selector.Begin(nullptr);
 
+   // Check the entry list
+   TEntryList *elist = (entries.IsValid()) ? &entries : nullptr;
    //fork
-   TMPWorkerTreeSel worker(selector, fileNames, entries, treeName, nWorkers, nToProcess, firstEntry);
+   TMPWorkerTreeSel worker(selector, fileNames, elist, treeName, nWorkers, nToProcess, firstEntry);
    bool ok = Fork(worker);
    if (!ok) {
       Error("TTreeProcessorMP::Process", "[E][C] Could not fork. Aborting operation");
@@ -228,7 +232,7 @@ TList *TTreeProcessorMP::Process(const std::vector<std::string> &fileNames, TSel
 
 //////////////////////////////////////////////////////////////////////////
 /// TSelector-based tree processing: dataset as a TFileCollection
-TList *TTreeProcessorMP::Process(TFileCollection &files, TSelector &selector, TEntryList *entries,
+TList *TTreeProcessorMP::Process(TFileCollection &files, TSelector &selector, TEntryList &entries,
                                  const std::string &treeName, ULong64_t nToProcess, ULong64_t firstEntry)
 {
    std::vector<std::string> fileNames(files.GetNFiles());
@@ -242,7 +246,7 @@ TList *TTreeProcessorMP::Process(TFileCollection &files, TSelector &selector, TE
 
 //////////////////////////////////////////////////////////////////////////
 /// TSelector-based tree processing: dataset as a TChain
-TList *TTreeProcessorMP::Process(TChain &files, TSelector &selector, TEntryList *entries, const std::string &treeName,
+TList *TTreeProcessorMP::Process(TChain &files, TSelector &selector, TEntryList &entries, const std::string &treeName,
                                  ULong64_t nToProcess, ULong64_t firstEntry)
 {
    TObjArray* filelist = files.GetListOfFiles();
@@ -256,7 +260,7 @@ TList *TTreeProcessorMP::Process(TChain &files, TSelector &selector, TEntryList 
 
 //////////////////////////////////////////////////////////////////////////
 /// TSelector-based tree processing: dataset as a single file
-TList *TTreeProcessorMP::Process(const std::string &fileName, TSelector &selector, TEntryList *entries,
+TList *TTreeProcessorMP::Process(const std::string &fileName, TSelector &selector, TEntryList &entries,
                                  const std::string &treeName, ULong64_t nToProcess, ULong64_t firstEntry)
 {
    std::vector<std::string> singleFileName(1, fileName);
@@ -270,30 +274,35 @@ TList *TTreeProcessorMP::Process(const std::string &fileName, TSelector &selecto
 TList *TTreeProcessorMP::Process(const std::vector<std::string> &fileNames, TSelector &selector,
                                  const std::string &treeName, ULong64_t nToProcess, ULong64_t jFirst)
 {
-   return Process(fileNames, selector, nullptr, treeName, nToProcess, jFirst);
+   TEntryList noelist; 
+   return Process(fileNames, selector, noelist, treeName, nToProcess, jFirst);
 }
 
 TList *TTreeProcessorMP::Process(const std::string &fileName, TSelector &selector, const std::string &treeName,
                                  ULong64_t nToProcess, ULong64_t jFirst)
 {
-   return Process(fileName, selector, nullptr, treeName, nToProcess, jFirst);
+   TEntryList noelist; 
+   return Process(fileName, selector, noelist, treeName, nToProcess, jFirst);
 }
 
 TList *TTreeProcessorMP::Process(TFileCollection &files, TSelector &selector, const std::string &treeName,
                                  ULong64_t nToProcess, ULong64_t jFirst)
 {
-   return Process(files, selector, nullptr, treeName, nToProcess, jFirst);
+   TEntryList noelist; 
+   return Process(files, selector, noelist, treeName, nToProcess, jFirst);
 }
 
 TList *TTreeProcessorMP::Process(TChain &files, TSelector &selector, const std::string &treeName, ULong64_t nToProcess,
                                  ULong64_t jFirst)
 {
-   return Process(files, selector, nullptr, treeName, nToProcess, jFirst);
+   TEntryList noelist; 
+   return Process(files, selector, noelist, treeName, nToProcess, jFirst);
 }
 
 TList *TTreeProcessorMP::Process(TTree &tree, TSelector &selector, ULong64_t nToProcess, ULong64_t jFirst)
 {
-   return Process(tree, selector, nullptr, nToProcess, jFirst);
+   TEntryList noelist; 
+   return Process(tree, selector, noelist, nToProcess, jFirst);
 }
 
 /// Fix list of lists before merging (to avoid errors about duplicated objects)

--- a/tutorials/multicore/mp103_processSelector.C
+++ b/tutorials/multicore/mp103_processSelector.C
@@ -11,7 +11,8 @@
 
 #include "TString.h"
 #include "TROOT.h"
-#include "TTree.h"
+#include "TChain.h"
+#include "TFileCollection.h"
 #include "TH1F.h"
 #include "TTreeReader.h"
 #include "ROOT/TTreeProcessorMP.hxx"
@@ -57,11 +58,13 @@ int mp103_processSelector(){
   sel->GetOutputList()->Delete();
 
   // Prepare datasets: vector of files, TFileCollection
+  TChain ch;
   TFileCollection fc;
   std::vector<std::string> files;
   for (int i = 0; i < 4; i++) {
      files.push_back(fh1[i]);
      fc.Add(new TFileInfo(fh1[i]));
+     ch.Add(fh1[i]);
   }
 
   //TTreeProcessorMP::Process with vector of files and tree name
@@ -71,6 +74,10 @@ int mp103_processSelector(){
 
   //TTreeProcessorMP::Process with TFileCollection, no tree name
   out = pool.Process(fc, *sel);
+  sel->GetOutputList()->Delete();
+
+  //TTreeProcessorMP::Process with TChain, no tree name
+  out = pool.Process(ch, *sel);
   sel->GetOutputList()->Delete();
 
   return 0;

--- a/tutorials/multicore/mp103_processSelector.C
+++ b/tutorials/multicore/mp103_processSelector.C
@@ -76,7 +76,7 @@ int mp103_processSelector(){
   out = pool.Process(fc, *sel);
   sel->GetOutputList()->Delete();
 
-  //TTreeProcessorMP::Process with TChain, no tree name
+  // TTreeProcessorMP::Process with TChain, no tree name
   out = pool.Process(ch, *sel);
   sel->GetOutputList()->Delete();
 

--- a/tutorials/multicore/mp104_processH1.C
+++ b/tutorials/multicore/mp104_processH1.C
@@ -31,12 +31,11 @@ static std::string tutname = "mp104_processH1: ";
 static std::string logfile = "mp104_processH1.log";
 static RedirectHandle_t gRH;
 
-const char *fh1[] = {"http://root.cern.ch/files/h1/dstarmb.root",
-                     "http://root.cern.ch/files/h1/dstarp1a.root",
-                     "http://root.cern.ch/files/h1/dstarp1b.root",
-                     "http://root.cern.ch/files/h1/dstarp2.root"};
+const char *fh1[] = {"http://root.cern.ch/files/h1/dstarmb.root", "http://root.cern.ch/files/h1/dstarp1a.root",
+                     "http://root.cern.ch/files/h1/dstarp1b.root", "http://root.cern.ch/files/h1/dstarp2.root"};
 
-int mp104_processH1(){
+int mp104_processH1()
+{
 
    // MacOSX may generate connection to WindowServer errors
    gROOT->SetBatch(kTRUE);
@@ -49,42 +48,44 @@ int mp104_processH1(){
       files.push_back(fh1[i]);
    }
 
-   // Check and fit lambdas
+// Check and fit lambdas
 #include "mp_H1_lambdas.C"
 
-  ROOT::TTreeProcessorMP pool(3);
+   ROOT::TTreeProcessorMP pool(3);
 
-  std::cout << tutname << "processing the H1 dataset with a lambda \n";
+   std::cout << tutname << "processing the H1 dataset with a lambda \n";
 
-  auto hListFun = pool.Process(files, doH1, "h42");
-  
-  // Check the output
-  if (checkH1(hListFun) < 0) return -1;
+   auto hListFun = pool.Process(files, doH1, "h42");
 
-  // Do the fit
-  if (doFit(hListFun, logfile.c_str()) < 0) return -1;
+   // Check the output
+   if (checkH1(hListFun) < 0) return -1;
 
-  stp.Print(); stp.Start();
+   // Do the fit
+   if (doFit(hListFun, logfile.c_str()) < 0) return -1;
 
-  // Run the analysis with a selector
+   stp.Print();
+   stp.Start();
 
-  TString selectorPath = gROOT->GetTutorialDir();
-  selectorPath += "/tree/h1analysisTreeReader.C+";
-  std::cout << tutname << "processing the H1 dataset with selector '" << selectorPath << "'\n";
-  TSelector *sel = TSelector::GetSelector(selectorPath);
+   // Run the analysis with a selector
 
-  // In a second run we use sel
-  gSystem->RedirectOutput(logfile.c_str(), "w", &gRH);
-  auto hListSel = pool.Process(files, *sel, "h42");
-  gSystem->RedirectOutput(0, 0, &gRH);
-  
-  // Check the output
-  if (checkH1(hListSel) < 0) return -1;
+   TString selectorPath = gROOT->GetTutorialDir();
+   selectorPath += "/tree/h1analysisTreeReader.C+";
+   std::cout << tutname << "processing the H1 dataset with selector '" << selectorPath << "'\n";
+   TSelector *sel = TSelector::GetSelector(selectorPath);
 
-  // Do the fit
-  if (doFit(hListSel, logfile.c_str()) < 0) return -1;
+   // In a second run we use sel
+   gSystem->RedirectOutput(logfile.c_str(), "w", &gRH);
+   auto hListSel = pool.Process(files, *sel, "h42");
+   gSystem->RedirectOutput(0, 0, &gRH);
 
-  stp.Print(); stp.Start();
+   // Check the output
+   if (checkH1(hListSel) < 0) return -1;
 
-  return 0;
+   // Do the fit
+   if (doFit(hListSel, logfile.c_str()) < 0) return -1;
+
+   stp.Print();
+   stp.Start();
+
+   return 0;
 }

--- a/tutorials/multicore/mp104_processH1.C
+++ b/tutorials/multicore/mp104_processH1.C
@@ -1,0 +1,90 @@
+/// \file
+/// \ingroup tutorial_multicore
+/// \notebook -nodraw
+/// Illustrate the usage of the multiproc to process the H1 analysis
+/// example.
+///
+/// \macro_code
+///
+/// \author Gerardo Ganis
+
+#include "TString.h"
+#include "TROOT.h"
+#include "TTree.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TEntryList.h"
+#include "TTreeReader.h"
+#include "TTreeReaderArray.h"
+#include "TTreeReaderValue.h"
+#include "TSystem.h"
+#include "TMath.h"
+#include "TCanvas.h"
+#include "TStyle.h"
+#include "TF1.h"
+#include "TLine.h"
+#include "TPaveStats.h"
+#include "TStopwatch.h"
+#include "ROOT/TTreeProcessorMP.hxx"
+
+static std::string tutname = "mp104_processH1: ";
+static std::string logfile = "mp104_processH1.log";
+static RedirectHandle_t gRH;
+
+const char *fh1[] = {"http://root.cern.ch/files/h1/dstarmb.root",
+                     "http://root.cern.ch/files/h1/dstarp1a.root",
+                     "http://root.cern.ch/files/h1/dstarp1b.root",
+                     "http://root.cern.ch/files/h1/dstarp2.root"};
+
+int mp104_processH1(){
+
+   // MacOSX may generate connection to WindowServer errors
+   gROOT->SetBatch(kTRUE);
+
+   TStopwatch stp;
+
+   // Prepare dataset: vector of files
+   std::vector<std::string> files;
+   for (int i = 0; i < 4; i++) {
+      files.push_back(fh1[i]);
+   }
+
+   // Check and fit lambdas
+#include "mp_H1_lambdas.C"
+
+  ROOT::TTreeProcessorMP pool(3);
+
+  std::cout << tutname << "processing the H1 dataset with a lambda \n";
+
+  auto hListFun = pool.Process(files, doH1, "h42");
+  
+  // Check the output
+  if (checkH1(hListFun) < 0) return -1;
+
+  // Do the fit
+  if (doFit(hListFun, logfile.c_str()) < 0) return -1;
+
+  stp.Print(); stp.Start();
+
+  // Run the analysis with a selector
+
+  TString selectorPath = gROOT->GetTutorialDir();
+  selectorPath += "/tree/h1analysisTreeReader.C+";
+  std::cout << tutname << "processing the H1 dataset with selector '" << selectorPath << "'\n";
+  TSelector *sel = TSelector::GetSelector(selectorPath);
+
+  // In a second run we use sel
+  gSystem->RedirectOutput(logfile.c_str(), "w", &gRH);
+  auto hListSel = pool.Process(files, *sel, "h42");
+  gSystem->RedirectOutput(0, 0, &gRH);
+  
+  // Check the output
+  if (checkH1(hListSel) < 0) return -1;
+
+  // Do the fit
+  if (doFit(hListSel, logfile.c_str()) < 0) return -1;
+
+  stp.Print(); stp.Start();
+
+  return 0;
+}

--- a/tutorials/multicore/mp105_processEntryList.C
+++ b/tutorials/multicore/mp105_processEntryList.C
@@ -1,0 +1,107 @@
+/// \file
+/// \ingroup tutorial_multicore
+/// \notebook -nodraw
+/// Illustrate the usage of the multiproc to process TEntryList with the H1 analysis
+/// example.
+///
+/// \macro_code
+///
+/// \author Gerardo Ganis
+
+#include "TString.h"
+#include "TROOT.h"
+#include "TTree.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TEntryList.h"
+#include "TTreeReader.h"
+#include "TTreeReaderArray.h"
+#include "TTreeReaderValue.h"
+#include "TSystem.h"
+#include "TMath.h"
+#include "TCanvas.h"
+#include "TStyle.h"
+#include "TF1.h"
+#include "TLine.h"
+#include "TPaveStats.h"
+#include "TStopwatch.h"
+#include "ROOT/TTreeProcessorMP.hxx"
+
+static std::string tutname = "mp105_processEntryList: ";
+static std::string logfile = "mp105_processEntryList.log";
+static RedirectHandle_t gRH;
+
+const char *fh1[] = {"http://root.cern.ch/files/h1/dstarmb.root",
+                     "http://root.cern.ch/files/h1/dstarp1a.root",
+                     "http://root.cern.ch/files/h1/dstarp1b.root",
+                     "http://root.cern.ch/files/h1/dstarp2.root"};
+
+
+int mp105_processEntryList(){
+
+   // MacOSX may generate connection to WindowServer errors
+   gROOT->SetBatch(kTRUE);
+
+   TStopwatch stp;
+
+   // Prepare dataset: vector of files
+   std::vector<std::string> files;
+   for (int i = 0; i < 4; i++) {
+      files.push_back(fh1[i]);
+   }
+
+#include "mp_H1_lambdas.C"
+
+  ROOT::TTreeProcessorMP pool(3);
+
+  std::cout << tutname << "creating the entry list \n";
+
+  auto sumElist = pool.Process(files, doH1fillList, "h42");
+
+  // Print the entry list
+  if (sumElist) {
+     sumElist->Print();
+  } else {
+     std::cout << tutname << " ERROR creating the entry list \n";
+     return -1;
+  }
+
+  // Time taken
+  stp.Print(); stp.Start();
+
+  // Let's analyse H1 with the list
+  std::cout << tutname << "processing the entry list with a lambda \n";
+
+  // Run the analysis
+  auto hListFun = pool.Process(files, doH1useList, sumElist, "h42");
+  
+  // Check the output
+  if (checkH1(hListFun) < 0) return -1;
+
+  // Do the fit
+  if (doFit(hListFun, logfile.c_str()) < 0) return -1;
+
+  stp.Print(); stp.Start();
+
+  // Run the analysis with a selector
+  TString selectorPath = gROOT->GetTutorialDir();
+  selectorPath += "/tree/h1analysisTreeReader.C+";
+  std::cout << tutname << "processing the entry list with selector '" << selectorPath << "'\n";
+  TSelector *sel = TSelector::GetSelector(selectorPath);
+
+  // In a second run we use sel
+  sel->SetOption("useList");
+  gSystem->RedirectOutput(logfile.c_str(), "w", &gRH);
+  auto hListSel = pool.Process(files, *sel, sumElist, "h42");
+  gSystem->RedirectOutput(0, 0, &gRH);
+  
+  // Check the output
+  if (checkH1(hListSel) < 0) return -1;
+
+  // Do the fit
+  if (doFit(hListSel, logfile.c_str()) < 0) return -1;
+
+  stp.Print(); stp.Start();
+
+  return 0;
+}

--- a/tutorials/multicore/mp105_processEntryList.C
+++ b/tutorials/multicore/mp105_processEntryList.C
@@ -72,7 +72,7 @@ int mp105_processEntryList()
    std::cout << tutname << "processing the entry list with a lambda \n";
 
    // Run the analysis
-   auto hListFun = pool.Process(files, doH1useList, sumElist, "h42");
+   auto hListFun = pool.Process(files, doH1useList, *sumElist, "h42");
 
    // Check the output
    if (checkH1(hListFun) < 0) return -1;
@@ -92,7 +92,7 @@ int mp105_processEntryList()
    // In a second run we use sel
    sel->SetOption("useList");
    gSystem->RedirectOutput(logfile.c_str(), "w", &gRH);
-   auto hListSel = pool.Process(files, *sel, sumElist, "h42");
+   auto hListSel = pool.Process(files, *sel, *sumElist, "h42");
    gSystem->RedirectOutput(0, 0, &gRH);
 
    // Check the output

--- a/tutorials/multicore/mp105_processEntryList.C
+++ b/tutorials/multicore/mp105_processEntryList.C
@@ -31,13 +31,11 @@ static std::string tutname = "mp105_processEntryList: ";
 static std::string logfile = "mp105_processEntryList.log";
 static RedirectHandle_t gRH;
 
-const char *fh1[] = {"http://root.cern.ch/files/h1/dstarmb.root",
-                     "http://root.cern.ch/files/h1/dstarp1a.root",
-                     "http://root.cern.ch/files/h1/dstarp1b.root",
-                     "http://root.cern.ch/files/h1/dstarp2.root"};
+const char *fh1[] = {"http://root.cern.ch/files/h1/dstarmb.root", "http://root.cern.ch/files/h1/dstarp1a.root",
+                     "http://root.cern.ch/files/h1/dstarp1b.root", "http://root.cern.ch/files/h1/dstarp2.root"};
 
-
-int mp105_processEntryList(){
+int mp105_processEntryList()
+{
 
    // MacOSX may generate connection to WindowServer errors
    gROOT->SetBatch(kTRUE);
@@ -52,56 +50,59 @@ int mp105_processEntryList(){
 
 #include "mp_H1_lambdas.C"
 
-  ROOT::TTreeProcessorMP pool(3);
+   ROOT::TTreeProcessorMP pool(3);
 
-  std::cout << tutname << "creating the entry list \n";
+   std::cout << tutname << "creating the entry list \n";
 
-  auto sumElist = pool.Process(files, doH1fillList, "h42");
+   auto sumElist = pool.Process(files, doH1fillList, "h42");
 
-  // Print the entry list
-  if (sumElist) {
-     sumElist->Print();
-  } else {
-     std::cout << tutname << " ERROR creating the entry list \n";
-     return -1;
-  }
+   // Print the entry list
+   if (sumElist) {
+      sumElist->Print();
+   } else {
+      std::cout << tutname << " ERROR creating the entry list \n";
+      return -1;
+   }
 
-  // Time taken
-  stp.Print(); stp.Start();
+   // Time taken
+   stp.Print();
+   stp.Start();
 
-  // Let's analyse H1 with the list
-  std::cout << tutname << "processing the entry list with a lambda \n";
+   // Let's analyse H1 with the list
+   std::cout << tutname << "processing the entry list with a lambda \n";
 
-  // Run the analysis
-  auto hListFun = pool.Process(files, doH1useList, sumElist, "h42");
-  
-  // Check the output
-  if (checkH1(hListFun) < 0) return -1;
+   // Run the analysis
+   auto hListFun = pool.Process(files, doH1useList, sumElist, "h42");
 
-  // Do the fit
-  if (doFit(hListFun, logfile.c_str()) < 0) return -1;
+   // Check the output
+   if (checkH1(hListFun) < 0) return -1;
 
-  stp.Print(); stp.Start();
+   // Do the fit
+   if (doFit(hListFun, logfile.c_str()) < 0) return -1;
 
-  // Run the analysis with a selector
-  TString selectorPath = gROOT->GetTutorialDir();
-  selectorPath += "/tree/h1analysisTreeReader.C+";
-  std::cout << tutname << "processing the entry list with selector '" << selectorPath << "'\n";
-  TSelector *sel = TSelector::GetSelector(selectorPath);
+   stp.Print();
+   stp.Start();
 
-  // In a second run we use sel
-  sel->SetOption("useList");
-  gSystem->RedirectOutput(logfile.c_str(), "w", &gRH);
-  auto hListSel = pool.Process(files, *sel, sumElist, "h42");
-  gSystem->RedirectOutput(0, 0, &gRH);
-  
-  // Check the output
-  if (checkH1(hListSel) < 0) return -1;
+   // Run the analysis with a selector
+   TString selectorPath = gROOT->GetTutorialDir();
+   selectorPath += "/tree/h1analysisTreeReader.C+";
+   std::cout << tutname << "processing the entry list with selector '" << selectorPath << "'\n";
+   TSelector *sel = TSelector::GetSelector(selectorPath);
 
-  // Do the fit
-  if (doFit(hListSel, logfile.c_str()) < 0) return -1;
+   // In a second run we use sel
+   sel->SetOption("useList");
+   gSystem->RedirectOutput(logfile.c_str(), "w", &gRH);
+   auto hListSel = pool.Process(files, *sel, sumElist, "h42");
+   gSystem->RedirectOutput(0, 0, &gRH);
 
-  stp.Print(); stp.Start();
+   // Check the output
+   if (checkH1(hListSel) < 0) return -1;
 
-  return 0;
+   // Do the fit
+   if (doFit(hListSel, logfile.c_str()) < 0) return -1;
+
+   stp.Print();
+   stp.Start();
+
+   return 0;
 }

--- a/tutorials/multicore/mp_H1_lambdas.C
+++ b/tutorials/multicore/mp_H1_lambdas.C
@@ -1,0 +1,388 @@
+/// \file
+/// \ingroup tutorial_multicore
+/// \notebook -nodraw
+/// Lambdas used to check and fit the result of the H1 analysis.
+/// Used by mp104_processH1.C and mp105_processEntryList.C 
+///
+/// \macro_code
+///
+/// \author Gerardo Ganis
+
+   // This function is used to check the result of the H1 analysis
+   auto checkH1 = [](TList *out) {
+
+      // Make sure the output list is there
+      if (!out) {
+         std::cout << "checkH1 >>> Test failure: output list not found\n";
+         return -1;
+      }
+
+      // Check the 'hdmd' histo
+      TH1F *hdmd = dynamic_cast<TH1F*>(out->FindObject("hdmd"));
+      if (!hdmd) {
+         std::cout << "checkH1 >>> Test failure: 'hdmd' histo not found\n";
+         return -1;
+      }
+      if ((Int_t)(hdmd->GetEntries()) != 7525) {
+         std::cout << "checkH1 >>> Test failure: 'hdmd' histo: wrong number"
+                " of entries (" << (Int_t)(hdmd->GetEntries()) <<": expected 7525) \n";
+         return -1;
+      }
+      if (TMath::Abs((hdmd->GetMean() - 0.15512023) / 0.15512023) > 0.001) {
+         std::cout << "checkH1 >>> Test failure: 'hdmd' histo: wrong mean ("
+                 << hdmd->GetMean() << ": expected 0.15512023) \n";
+         return -1;
+      }
+
+      TH2F *h2 = dynamic_cast<TH2F*>(out->FindObject("h2"));
+      if (!h2) {
+         std::cout << "checkH1 >>> Test failure: 'h2' histo not found\n";
+         return -1;
+      }
+      if ((Int_t)(h2->GetEntries()) != 7525) {
+         std::cout << "checkH1 >>> Test failure: 'h2' histo: wrong number"
+                " of entries (" << (Int_t)(h2->GetEntries()) << ": expected 7525) \n";
+         return -1;
+      }
+      if (TMath::Abs((h2->GetMean() - 0.15245688) / 0.15245688) > 0.001) {
+         std::cout << "checkH1 >>> Test failure: 'h2' histo: wrong mean ("
+                   << h2->GetMean() << ": expected 0.15245688) \n";
+         return -1;
+      }
+
+      // Done
+      return 0;
+   };
+
+   // This function is used to fit the result of the analysis with graphics
+   auto doFit = [](TList *out, const char *logfile = 0) -> Int_t {
+
+      RedirectHandle_t redH;
+      if (logfile) gSystem->RedirectOutput(logfile, "a", &redH);
+
+      auto hdmd = dynamic_cast<TH1F*>(out->FindObject("hdmd"));
+      auto h2 = dynamic_cast<TH2F*>(out->FindObject("h2"));
+
+      // function called at the end of the event loop
+      if (hdmd == 0 || h2 == 0) {
+         std::cout << "doFit: hdmd = " << hdmd <<" , h2 = " << h2 << "\n";
+         return -1;
+         if (logfile) gSystem->RedirectOutput(0, 0, &redH);
+      }
+
+      //create the canvas for the h1analysis fit
+      gStyle->SetOptFit();
+      TCanvas *c1 = new TCanvas("c1","h1analysis analysis",10,10,800,600);
+      c1->SetBottomMargin(0.15);
+      hdmd->GetXaxis()->SetTitle("m_{K#pi#pi} - m_{K#pi}[GeV/c^{2}]");
+      hdmd->GetXaxis()->SetTitleOffset(1.4);
+
+      //fit histogram hdmd with function f5 using the log-likelihood option
+      if (gROOT->GetListOfFunctions()->FindObject("f5"))
+         delete gROOT->GetFunction("f5");
+
+      auto fdm5 = [](Double_t *xx, Double_t *par) -> Double_t {
+         const Double_t dxbin = (0.17-0.13)/40;   // Bin-width
+         Double_t x = xx[0];
+         if (x <= 0.13957) return 0;
+         Double_t xp3 = (x-par[3])*(x-par[3]);
+         Double_t res = dxbin*(par[0]*TMath::Power(x-0.13957, par[1])
+                      + par[2] / 2.5066/par[4]*TMath::Exp(-xp3/2/par[4]/par[4]));
+         return res;
+      };
+
+      TF1 *f5 = new TF1("f5",fdm5,0.139,0.17,5);
+      f5->SetParameters(1000000, .25, 2000, .1454, .001);
+      hdmd->Fit("f5","lr");
+
+      // Check the result of the fit
+      Double_t ref_f5[4] = {959915.0, 0.351114, 1185.03, 0.145569};
+      for (int i : {0,1,2,3} ) {
+         if ((TMath::Abs((f5->GetParameters())[i] - ref_f5[i]) / ref_f5[i]) > 0.001) {
+            std::cout << "\n >>> Test failure: fit to 'f5': parameter '" << f5->GetParName(i)
+                      << "' has wrong value ("
+                      << (f5->GetParameters())[i] << ": expected" << ref_f5[i] << ") \n";
+            if (logfile) gSystem->RedirectOutput(0, 0, &redH);
+            return -1;
+         }
+      }
+
+      //create the canvas for tau d0
+      gStyle->SetOptFit(0);
+      gStyle->SetOptStat(1100);
+      TCanvas *c2 = new TCanvas("c2","tauD0",100,100,800,600);
+      c2->SetGrid();
+      c2->SetBottomMargin(0.15);
+
+      // Project slices of 2-d histogram h2 along X , then fit each slice
+      // with function f2 and make a histogram for each fit parameter
+      // Note that the generated histograms are added to the list of objects
+      // in the current directory.
+      if (gROOT->GetListOfFunctions()->FindObject("f2"))
+         delete gROOT->GetFunction("f2");
+
+      auto fdm2 = [](Double_t *xx, Double_t *par) -> Double_t {
+         const Double_t dxbin = (0.17-0.13)/40;   // Bin-width
+         const Double_t sigma = 0.0012;
+         Double_t x = xx[0];
+         if (x <= 0.13957) return 0;
+         Double_t xp3 = (x-0.1454)*(x-0.1454);
+         Double_t res = dxbin*(par[0]*TMath::Power(x-0.13957, 0.25)
+                      + par[1] / 2.5066/sigma*TMath::Exp(-xp3/2/sigma/sigma));
+         return res;
+      };
+
+      TF1 *f2 = new TF1("f2",fdm2,0.139,0.17,2);
+      f2->SetParameters(10000, 10);
+
+      // Restrict to three bins in this example
+      std::cout << "doFit: restricting fit to two bins only in this example...\n";
+
+      h2->FitSlicesX(f2,10,20,10,"g5 l");
+
+      // Check the result of the fit
+      Double_t ref_f2[2] = {52432.2, 105.481};
+      for (int i : {0,1} ) {
+         if ((TMath::Abs((f2->GetParameters())[i] - ref_f2[i]) / ref_f2[i]) > 0.001) {
+            std::cout << "\n >>> Test failure: fit to 'f2': parameter '" << f2->GetParName(i)
+                      << "' has wrong value ("
+                      << (f2->GetParameters())[i] << ": expected" << ref_f2[i] << ") \n";
+            if (logfile) gSystem->RedirectOutput(0, 0, &redH);
+            return -1;
+         }
+      }
+
+      TH1D *h2_1 = (TH1D*)gDirectory->Get("h2_1");
+      h2_1->GetXaxis()->SetTitle("#tau[ps]");
+      h2_1->SetMarkerStyle(21);
+      h2_1->Draw();
+      c2->Update();
+      TLine *line = new TLine(0,0,0,c2->GetUymax());
+      line->Draw();
+
+      // Have the number of entries on the first histogram (to cross check when running
+      // with entry lists)
+      TPaveStats *psdmd = (TPaveStats *)hdmd->GetListOfFunctions()->FindObject("stats");
+      psdmd->SetOptStat(1110);
+      c1->Modified();
+
+      if (logfile) gSystem->RedirectOutput(0, 0, &redH);
+
+      return 0;
+   };
+
+
+   // This function is used to fit the result of the analysis without graphics
+   auto doFitRaw = [](TList *out, const char *logfile = 0) -> Int_t {
+
+      RedirectHandle_t redH;
+      if (logfile) gSystem->RedirectOutput(logfile, "a", &redH);
+
+      auto hdmd = dynamic_cast<TH1F*>(out->FindObject("hdmd"));
+      auto h2 = dynamic_cast<TH2F*>(out->FindObject("h2"));
+
+      // function called at the end of the event loop
+      if (hdmd == 0 || h2 == 0) {
+         std::cout << "doFit: hdmd = " << hdmd <<" , h2 = " << h2 << "\n";
+         return -1;
+         if (logfile) gSystem->RedirectOutput(0, 0, &redH);
+      }
+
+      //fit histogram hdmd with function f5 using the log-likelihood option
+      if (gROOT->GetListOfFunctions()->FindObject("f5"))
+         delete gROOT->GetFunction("f5");
+
+      auto fdm5 = [](Double_t *xx, Double_t *par) -> Double_t {
+         const Double_t dxbin = (0.17-0.13)/40;   // Bin-width
+         Double_t x = xx[0];
+         if (x <= 0.13957) return 0;
+         Double_t xp3 = (x-par[3])*(x-par[3]);
+         Double_t res = dxbin*(par[0]*TMath::Power(x-0.13957, par[1])
+                      + par[2] / 2.5066/par[4]*TMath::Exp(-xp3/2/par[4]/par[4]));
+         return res;
+      };
+
+      TF1 *f5 = new TF1("f5",fdm5,0.139,0.17,5);
+      f5->SetParameters(1000000, .25, 2000, .1454, .001);
+      hdmd->Fit("f5","lr");
+
+      // Check the result of the fit
+      Double_t ref_f5[4] = {959915.0, 0.351114, 1185.03, 0.145569};
+      for (int i : {0,1,2,3} ) {
+         if ((TMath::Abs((f5->GetParameters())[i] - ref_f5[i]) / ref_f5[i]) > 0.001) {
+            std::cout << "\n >>> Test failure: fit to 'f5': parameter '" << f5->GetParName(i)
+                      << "' has wrong value ("
+                      << (f5->GetParameters())[i] << ": expected" << ref_f5[i] << ") \n";
+            if (logfile) gSystem->RedirectOutput(0, 0, &redH);
+            return -1;
+         }
+      }
+
+      // Project slices of 2-d histogram h2 along X , then fit each slice
+      // with function f2 and make a histogram for each fit parameter
+      // Note that the generated histograms are added to the list of objects
+      // in the current directory.
+      if (gROOT->GetListOfFunctions()->FindObject("f2"))
+         delete gROOT->GetFunction("f2");
+
+      auto fdm2 = [](Double_t *xx, Double_t *par) -> Double_t {
+         const Double_t dxbin = (0.17-0.13)/40;   // Bin-width
+         const Double_t sigma = 0.0012;
+         Double_t x = xx[0];
+         if (x <= 0.13957) return 0;
+         Double_t xp3 = (x-0.1454)*(x-0.1454);
+         Double_t res = dxbin*(par[0]*TMath::Power(x-0.13957, 0.25)
+                      + par[1] / 2.5066/sigma*TMath::Exp(-xp3/2/sigma/sigma));
+         return res;
+      };
+
+      TF1 *f2 = new TF1("f2",fdm2,0.139,0.17,2);
+      f2->SetParameters(10000, 10);
+
+      // Restrict to three bins in this example
+      std::cout << "doFit: restricting fit to two bins only in this example...\n";
+
+      h2->FitSlicesX(f2,10,20,10,"g5 l");
+
+      // Check the result of the fit
+      Double_t ref_f2[2] = {52432.2, 105.481};
+      for (int i : {0,1} ) {
+         if ((TMath::Abs((f2->GetParameters())[i] - ref_f2[i]) / ref_f2[i]) > 0.001) {
+            std::cout << "\n >>> Test failure: fit to 'f2': parameter '" << f2->GetParName(i)
+                      << "' has wrong value ("
+                      << (f2->GetParameters())[i] << ": expected" << ref_f2[i] << ") \n";
+            if (logfile) gSystem->RedirectOutput(0, 0, &redH);
+            return -1;
+         }
+      }
+
+      if (logfile) gSystem->RedirectOutput(0, 0, &redH);
+
+      return 0;
+   };
+
+   // This is the function invoked during the processing of the trees.
+   auto doH1 = [](TTreeReader &reader) {
+      
+      // Histograms
+      auto hdmd = new TH1F("hdmd","Dm_d",40,0.13,0.17);
+      auto h2   = new TH2F("h2","ptD0 vs Dm_d",30,0.135,0.165,30,-3,6);
+      
+      TTreeReaderValue<Float_t>    fPtds_d(reader, "ptds_d");
+      TTreeReaderValue<Float_t>    fEtads_d(reader, "etads_d");
+      TTreeReaderValue<Float_t>    fDm_d(reader, "dm_d");
+      TTreeReaderValue<Int_t>      fIk(reader, "ik");
+      TTreeReaderValue<Int_t>      fIpi(reader, "ipi");
+      TTreeReaderValue<Int_t>      fIpis(reader, "ipis");
+      TTreeReaderValue<Float_t>    fPtd0_d(reader, "ptd0_d");
+      TTreeReaderValue<Float_t>    fMd0_d(reader, "md0_d");
+      TTreeReaderValue<Float_t>    fRpd0_t(reader , "rpd0_t");
+      TTreeReaderArray<Int_t>      fNhitrp(reader, "nhitrp");
+      TTreeReaderArray<Float_t>    fRstart(reader, "rstart");
+      TTreeReaderArray<Float_t>    fRend(reader, "rend");
+      TTreeReaderArray<Float_t>    fNlhk(reader, "nlhk");
+      TTreeReaderArray<Float_t>    fNlhpi(reader, "nlhpi");
+      TTreeReaderValue<Int_t>      fNjets(reader, "njets");
+
+      while (reader.Next()) {
+
+         // Return as soon as a bad entry is detected
+         if (TMath::Abs(*fMd0_d-1.8646) >= 0.04)        continue;
+         if (*fPtds_d <= 2.5)                           continue;
+         if (TMath::Abs(*fEtads_d) >= 1.5)              continue;
+         (*fIk)--; //original fIk used f77 convention starting at 1
+         (*fIpi)--;
+
+         if (fNhitrp.At(*fIk)* fNhitrp.At(*fIpi) <= 1)  continue; 
+
+         if (fRend.At(*fIk) -fRstart.At(*fIk)  <= 22)   continue;
+         if (fRend.At(*fIpi)-fRstart.At(*fIpi) <= 22)   continue;
+         if (fNlhk.At(*fIk) <= 0.1)                     continue;
+         if (fNlhpi.At(*fIpi) <= 0.1)                   continue;
+         (*fIpis)--; if (fNlhpi.At(*fIpis) <= 0.1)      continue;
+         if (*fNjets < 1)                               continue;
+ 
+         // Fill the histograms
+         hdmd->Fill(*fDm_d);
+         h2->Fill(*fDm_d, *fRpd0_t/0.029979*1.8646/ *fPtd0_d);
+      }
+
+      // Return a list
+      auto l = new TList;
+      l->Add(hdmd);
+      l->Add(h2);
+      l->SetOwner(kFALSE);
+
+      return l;
+   };
+
+   // This is the function invoked during the processing of the trees to create a TEntryList
+   auto doH1fillList = [](TTreeReader &reader) {
+      
+      // Entry list
+      auto elist = new TEntryList("elist", "H1 selection from Cut");
+      
+      TTreeReaderValue<Float_t>    fPtds_d(reader, "ptds_d");
+      TTreeReaderValue<Float_t>    fEtads_d(reader, "etads_d");
+      TTreeReaderValue<Int_t>      fIk(reader, "ik");
+      TTreeReaderValue<Int_t>      fIpi(reader, "ipi");
+      TTreeReaderValue<Int_t>      fIpis(reader, "ipis");
+      TTreeReaderValue<Float_t>    fMd0_d(reader, "md0_d");
+      TTreeReaderArray<Int_t>      fNhitrp(reader, "nhitrp");
+      TTreeReaderArray<Float_t>    fRstart(reader, "rstart");
+      TTreeReaderArray<Float_t>    fRend(reader, "rend");
+      TTreeReaderArray<Float_t>    fNlhk(reader, "nlhk");
+      TTreeReaderArray<Float_t>    fNlhpi(reader, "nlhpi");
+      TTreeReaderValue<Int_t>      fNjets(reader, "njets");
+
+      while (reader.Next()) {
+
+         // Return as soon as a bad entry is detected
+         if (TMath::Abs(*fMd0_d-1.8646) >= 0.04)        continue;
+         if (*fPtds_d <= 2.5)                           continue;
+         if (TMath::Abs(*fEtads_d) >= 1.5)              continue;
+         (*fIk)--; //original fIk used f77 convention starting at 1
+         (*fIpi)--;
+
+         if (fNhitrp.At(*fIk)* fNhitrp.At(*fIpi) <= 1)  continue; 
+
+         if (fRend.At(*fIk) -fRstart.At(*fIk)  <= 22)   continue;
+         if (fRend.At(*fIpi)-fRstart.At(*fIpi) <= 22)   continue;
+         if (fNlhk.At(*fIk) <= 0.1)                     continue;
+         if (fNlhpi.At(*fIpi) <= 0.1)                   continue;
+         (*fIpis)--; if (fNlhpi.At(*fIpis) <= 0.1)      continue;
+         if (*fNjets < 1)                               continue;
+
+         // Fill the entry list
+         elist->Enter(reader.GetCurrentEntry(), reader.GetTree());
+      }
+
+      return elist;
+   };
+
+
+   // This is the function invoked during the processing of the trees using a TEntryList
+   auto doH1useList = [](TTreeReader &reader) {
+      
+      // Histograms
+      auto hdmd = new TH1F("hdmd","Dm_d",40,0.13,0.17);
+      auto h2   = new TH2F("h2","ptD0 vs Dm_d",30,0.135,0.165,30,-3,6);
+      
+      TTreeReaderValue<Float_t>    fDm_d(reader, "dm_d");
+      TTreeReaderValue<Float_t>    fPtd0_d(reader, "ptd0_d");
+      TTreeReaderValue<Float_t>    fRpd0_t(reader , "rpd0_t");
+
+      while (reader.Next()) {
+         // Fill the histograms
+         hdmd->Fill(*fDm_d);
+         h2->Fill(*fDm_d, *fRpd0_t/0.029979*1.8646/ *fPtd0_d);
+      }
+
+      // Return a list
+      auto l = new TList;
+      l->Add(hdmd);
+      l->Add(h2);
+      l->SetOwner(kFALSE);
+
+      return l;
+   };

--- a/tutorials/multicore/mp_H1_lambdas.C
+++ b/tutorials/multicore/mp_H1_lambdas.C
@@ -2,387 +2,380 @@
 /// \ingroup tutorial_multicore
 /// \notebook -nodraw
 /// Lambdas used to check and fit the result of the H1 analysis.
-/// Used by mp104_processH1.C and mp105_processEntryList.C 
+/// Used by mp104_processH1.C, mp105_processEntryList.C and roottest/root/multicore/tProcessExecutorH1Test.C
 ///
 /// \macro_code
 ///
 /// \author Gerardo Ganis
 
-   // This function is used to check the result of the H1 analysis
-   auto checkH1 = [](TList *out) {
+// This function is used to check the result of the H1 analysis
+auto checkH1 = [](TList *out) {
 
-      // Make sure the output list is there
-      if (!out) {
-         std::cout << "checkH1 >>> Test failure: output list not found\n";
-         return -1;
-      }
+   // Make sure the output list is there
+   if (!out) {
+      std::cout << "checkH1 >>> Test failure: output list not found\n";
+      return -1;
+   }
 
-      // Check the 'hdmd' histo
-      TH1F *hdmd = dynamic_cast<TH1F*>(out->FindObject("hdmd"));
-      if (!hdmd) {
-         std::cout << "checkH1 >>> Test failure: 'hdmd' histo not found\n";
-         return -1;
-      }
-      if ((Int_t)(hdmd->GetEntries()) != 7525) {
-         std::cout << "checkH1 >>> Test failure: 'hdmd' histo: wrong number"
-                " of entries (" << (Int_t)(hdmd->GetEntries()) <<": expected 7525) \n";
-         return -1;
-      }
-      if (TMath::Abs((hdmd->GetMean() - 0.15512023) / 0.15512023) > 0.001) {
-         std::cout << "checkH1 >>> Test failure: 'hdmd' histo: wrong mean ("
-                 << hdmd->GetMean() << ": expected 0.15512023) \n";
-         return -1;
-      }
+   // Check the 'hdmd' histo
+   TH1F *hdmd = dynamic_cast<TH1F *>(out->FindObject("hdmd"));
+   if (!hdmd) {
+      std::cout << "checkH1 >>> Test failure: 'hdmd' histo not found\n";
+      return -1;
+   }
+   if ((Int_t)(hdmd->GetEntries()) != 7525) {
+      std::cout << "checkH1 >>> Test failure: 'hdmd' histo: wrong number"
+                   " of entries ("
+                << (Int_t)(hdmd->GetEntries()) << ": expected 7525) \n";
+      return -1;
+   }
+   if (TMath::Abs((hdmd->GetMean() - 0.15512023) / 0.15512023) > 0.001) {
+      std::cout << "checkH1 >>> Test failure: 'hdmd' histo: wrong mean (" << hdmd->GetMean()
+                << ": expected 0.15512023) \n";
+      return -1;
+   }
 
-      TH2F *h2 = dynamic_cast<TH2F*>(out->FindObject("h2"));
-      if (!h2) {
-         std::cout << "checkH1 >>> Test failure: 'h2' histo not found\n";
-         return -1;
-      }
-      if ((Int_t)(h2->GetEntries()) != 7525) {
-         std::cout << "checkH1 >>> Test failure: 'h2' histo: wrong number"
-                " of entries (" << (Int_t)(h2->GetEntries()) << ": expected 7525) \n";
-         return -1;
-      }
-      if (TMath::Abs((h2->GetMean() - 0.15245688) / 0.15245688) > 0.001) {
-         std::cout << "checkH1 >>> Test failure: 'h2' histo: wrong mean ("
-                   << h2->GetMean() << ": expected 0.15245688) \n";
-         return -1;
-      }
+   TH2F *h2 = dynamic_cast<TH2F *>(out->FindObject("h2"));
+   if (!h2) {
+      std::cout << "checkH1 >>> Test failure: 'h2' histo not found\n";
+      return -1;
+   }
+   if ((Int_t)(h2->GetEntries()) != 7525) {
+      std::cout << "checkH1 >>> Test failure: 'h2' histo: wrong number"
+                   " of entries ("
+                << (Int_t)(h2->GetEntries()) << ": expected 7525) \n";
+      return -1;
+   }
+   if (TMath::Abs((h2->GetMean() - 0.15245688) / 0.15245688) > 0.001) {
+      std::cout << "checkH1 >>> Test failure: 'h2' histo: wrong mean (" << h2->GetMean() << ": expected 0.15245688) \n";
+      return -1;
+   }
 
-      // Done
-      return 0;
-   };
+   // Done
+   return 0;
+};
 
-   // This function is used to fit the result of the analysis with graphics
-   auto doFit = [](TList *out, const char *logfile = 0) -> Int_t {
+// This function is used to fit the result of the analysis with graphics
+auto doFit = [](TList *out, const char *logfile = 0) -> Int_t {
 
-      RedirectHandle_t redH;
-      if (logfile) gSystem->RedirectOutput(logfile, "a", &redH);
+   RedirectHandle_t redH;
+   if (logfile) gSystem->RedirectOutput(logfile, "a", &redH);
 
-      auto hdmd = dynamic_cast<TH1F*>(out->FindObject("hdmd"));
-      auto h2 = dynamic_cast<TH2F*>(out->FindObject("h2"));
+   auto hdmd = dynamic_cast<TH1F *>(out->FindObject("hdmd"));
+   auto h2 = dynamic_cast<TH2F *>(out->FindObject("h2"));
 
-      // function called at the end of the event loop
-      if (hdmd == 0 || h2 == 0) {
-         std::cout << "doFit: hdmd = " << hdmd <<" , h2 = " << h2 << "\n";
-         return -1;
-         if (logfile) gSystem->RedirectOutput(0, 0, &redH);
-      }
-
-      //create the canvas for the h1analysis fit
-      gStyle->SetOptFit();
-      TCanvas *c1 = new TCanvas("c1","h1analysis analysis",10,10,800,600);
-      c1->SetBottomMargin(0.15);
-      hdmd->GetXaxis()->SetTitle("m_{K#pi#pi} - m_{K#pi}[GeV/c^{2}]");
-      hdmd->GetXaxis()->SetTitleOffset(1.4);
-
-      //fit histogram hdmd with function f5 using the log-likelihood option
-      if (gROOT->GetListOfFunctions()->FindObject("f5"))
-         delete gROOT->GetFunction("f5");
-
-      auto fdm5 = [](Double_t *xx, Double_t *par) -> Double_t {
-         const Double_t dxbin = (0.17-0.13)/40;   // Bin-width
-         Double_t x = xx[0];
-         if (x <= 0.13957) return 0;
-         Double_t xp3 = (x-par[3])*(x-par[3]);
-         Double_t res = dxbin*(par[0]*TMath::Power(x-0.13957, par[1])
-                      + par[2] / 2.5066/par[4]*TMath::Exp(-xp3/2/par[4]/par[4]));
-         return res;
-      };
-
-      TF1 *f5 = new TF1("f5",fdm5,0.139,0.17,5);
-      f5->SetParameters(1000000, .25, 2000, .1454, .001);
-      hdmd->Fit("f5","lr");
-
-      // Check the result of the fit
-      Double_t ref_f5[4] = {959915.0, 0.351114, 1185.03, 0.145569};
-      for (int i : {0,1,2,3} ) {
-         if ((TMath::Abs((f5->GetParameters())[i] - ref_f5[i]) / ref_f5[i]) > 0.001) {
-            std::cout << "\n >>> Test failure: fit to 'f5': parameter '" << f5->GetParName(i)
-                      << "' has wrong value ("
-                      << (f5->GetParameters())[i] << ": expected" << ref_f5[i] << ") \n";
-            if (logfile) gSystem->RedirectOutput(0, 0, &redH);
-            return -1;
-         }
-      }
-
-      //create the canvas for tau d0
-      gStyle->SetOptFit(0);
-      gStyle->SetOptStat(1100);
-      TCanvas *c2 = new TCanvas("c2","tauD0",100,100,800,600);
-      c2->SetGrid();
-      c2->SetBottomMargin(0.15);
-
-      // Project slices of 2-d histogram h2 along X , then fit each slice
-      // with function f2 and make a histogram for each fit parameter
-      // Note that the generated histograms are added to the list of objects
-      // in the current directory.
-      if (gROOT->GetListOfFunctions()->FindObject("f2"))
-         delete gROOT->GetFunction("f2");
-
-      auto fdm2 = [](Double_t *xx, Double_t *par) -> Double_t {
-         const Double_t dxbin = (0.17-0.13)/40;   // Bin-width
-         const Double_t sigma = 0.0012;
-         Double_t x = xx[0];
-         if (x <= 0.13957) return 0;
-         Double_t xp3 = (x-0.1454)*(x-0.1454);
-         Double_t res = dxbin*(par[0]*TMath::Power(x-0.13957, 0.25)
-                      + par[1] / 2.5066/sigma*TMath::Exp(-xp3/2/sigma/sigma));
-         return res;
-      };
-
-      TF1 *f2 = new TF1("f2",fdm2,0.139,0.17,2);
-      f2->SetParameters(10000, 10);
-
-      // Restrict to three bins in this example
-      std::cout << "doFit: restricting fit to two bins only in this example...\n";
-
-      h2->FitSlicesX(f2,10,20,10,"g5 l");
-
-      // Check the result of the fit
-      Double_t ref_f2[2] = {52432.2, 105.481};
-      for (int i : {0,1} ) {
-         if ((TMath::Abs((f2->GetParameters())[i] - ref_f2[i]) / ref_f2[i]) > 0.001) {
-            std::cout << "\n >>> Test failure: fit to 'f2': parameter '" << f2->GetParName(i)
-                      << "' has wrong value ("
-                      << (f2->GetParameters())[i] << ": expected" << ref_f2[i] << ") \n";
-            if (logfile) gSystem->RedirectOutput(0, 0, &redH);
-            return -1;
-         }
-      }
-
-      TH1D *h2_1 = (TH1D*)gDirectory->Get("h2_1");
-      h2_1->GetXaxis()->SetTitle("#tau[ps]");
-      h2_1->SetMarkerStyle(21);
-      h2_1->Draw();
-      c2->Update();
-      TLine *line = new TLine(0,0,0,c2->GetUymax());
-      line->Draw();
-
-      // Have the number of entries on the first histogram (to cross check when running
-      // with entry lists)
-      TPaveStats *psdmd = (TPaveStats *)hdmd->GetListOfFunctions()->FindObject("stats");
-      psdmd->SetOptStat(1110);
-      c1->Modified();
-
+   // function called at the end of the event loop
+   if (hdmd == 0 || h2 == 0) {
+      std::cout << "doFit: hdmd = " << hdmd << " , h2 = " << h2 << "\n";
+      return -1;
       if (logfile) gSystem->RedirectOutput(0, 0, &redH);
+   }
 
-      return 0;
+   // create the canvas for the h1analysis fit
+   gStyle->SetOptFit();
+   TCanvas *c1 = new TCanvas("c1", "h1analysis analysis", 10, 10, 800, 600);
+   c1->SetBottomMargin(0.15);
+   hdmd->GetXaxis()->SetTitle("m_{K#pi#pi} - m_{K#pi}[GeV/c^{2}]");
+   hdmd->GetXaxis()->SetTitleOffset(1.4);
+
+   // fit histogram hdmd with function f5 using the log-likelihood option
+   if (gROOT->GetListOfFunctions()->FindObject("f5")) delete gROOT->GetFunction("f5");
+
+   auto fdm5 = [](Double_t *xx, Double_t *par) -> Double_t {
+      const Double_t dxbin = (0.17 - 0.13) / 40; // Bin-width
+      Double_t x = xx[0];
+      if (x <= 0.13957) return 0;
+      Double_t xp3 = (x - par[3]) * (x - par[3]);
+      Double_t res = dxbin * (par[0] * TMath::Power(x - 0.13957, par[1]) +
+                              par[2] / 2.5066 / par[4] * TMath::Exp(-xp3 / 2 / par[4] / par[4]));
+      return res;
    };
 
+   TF1 *f5 = new TF1("f5", fdm5, 0.139, 0.17, 5);
+   f5->SetParameters(1000000, .25, 2000, .1454, .001);
+   hdmd->Fit("f5", "lr");
 
-   // This function is used to fit the result of the analysis without graphics
-   auto doFitRaw = [](TList *out, const char *logfile = 0) -> Int_t {
-
-      RedirectHandle_t redH;
-      if (logfile) gSystem->RedirectOutput(logfile, "a", &redH);
-
-      auto hdmd = dynamic_cast<TH1F*>(out->FindObject("hdmd"));
-      auto h2 = dynamic_cast<TH2F*>(out->FindObject("h2"));
-
-      // function called at the end of the event loop
-      if (hdmd == 0 || h2 == 0) {
-         std::cout << "doFit: hdmd = " << hdmd <<" , h2 = " << h2 << "\n";
-         return -1;
+   // Check the result of the fit
+   Double_t ref_f5[4] = {959915.0, 0.351114, 1185.03, 0.145569};
+   for (int i : {0, 1, 2, 3}) {
+      if ((TMath::Abs((f5->GetParameters())[i] - ref_f5[i]) / ref_f5[i]) > 0.001) {
+         std::cout << "\n >>> Test failure: fit to 'f5': parameter '" << f5->GetParName(i) << "' has wrong value ("
+                   << (f5->GetParameters())[i] << ": expected" << ref_f5[i] << ") \n";
          if (logfile) gSystem->RedirectOutput(0, 0, &redH);
+         return -1;
       }
+   }
 
-      //fit histogram hdmd with function f5 using the log-likelihood option
-      if (gROOT->GetListOfFunctions()->FindObject("f5"))
-         delete gROOT->GetFunction("f5");
+   // create the canvas for tau d0
+   gStyle->SetOptFit(0);
+   gStyle->SetOptStat(1100);
+   TCanvas *c2 = new TCanvas("c2", "tauD0", 100, 100, 800, 600);
+   c2->SetGrid();
+   c2->SetBottomMargin(0.15);
 
-      auto fdm5 = [](Double_t *xx, Double_t *par) -> Double_t {
-         const Double_t dxbin = (0.17-0.13)/40;   // Bin-width
-         Double_t x = xx[0];
-         if (x <= 0.13957) return 0;
-         Double_t xp3 = (x-par[3])*(x-par[3]);
-         Double_t res = dxbin*(par[0]*TMath::Power(x-0.13957, par[1])
-                      + par[2] / 2.5066/par[4]*TMath::Exp(-xp3/2/par[4]/par[4]));
-         return res;
-      };
+   // Project slices of 2-d histogram h2 along X , then fit each slice
+   // with function f2 and make a histogram for each fit parameter
+   // Note that the generated histograms are added to the list of objects
+   // in the current directory.
+   if (gROOT->GetListOfFunctions()->FindObject("f2")) delete gROOT->GetFunction("f2");
 
-      TF1 *f5 = new TF1("f5",fdm5,0.139,0.17,5);
-      f5->SetParameters(1000000, .25, 2000, .1454, .001);
-      hdmd->Fit("f5","lr");
+   auto fdm2 = [](Double_t *xx, Double_t *par) -> Double_t {
+      const Double_t dxbin = (0.17 - 0.13) / 40; // Bin-width
+      const Double_t sigma = 0.0012;
+      Double_t x = xx[0];
+      if (x <= 0.13957) return 0;
+      Double_t xp3 = (x - 0.1454) * (x - 0.1454);
+      Double_t res = dxbin * (par[0] * TMath::Power(x - 0.13957, 0.25) +
+                              par[1] / 2.5066 / sigma * TMath::Exp(-xp3 / 2 / sigma / sigma));
+      return res;
+   };
 
-      // Check the result of the fit
-      Double_t ref_f5[4] = {959915.0, 0.351114, 1185.03, 0.145569};
-      for (int i : {0,1,2,3} ) {
-         if ((TMath::Abs((f5->GetParameters())[i] - ref_f5[i]) / ref_f5[i]) > 0.001) {
-            std::cout << "\n >>> Test failure: fit to 'f5': parameter '" << f5->GetParName(i)
-                      << "' has wrong value ("
-                      << (f5->GetParameters())[i] << ": expected" << ref_f5[i] << ") \n";
-            if (logfile) gSystem->RedirectOutput(0, 0, &redH);
-            return -1;
-         }
+   TF1 *f2 = new TF1("f2", fdm2, 0.139, 0.17, 2);
+   f2->SetParameters(10000, 10);
+
+   // Restrict to three bins in this example
+   std::cout << "doFit: restricting fit to two bins only in this example...\n";
+
+   h2->FitSlicesX(f2, 10, 20, 10, "g5 l");
+
+   // Check the result of the fit
+   Double_t ref_f2[2] = {52432.2, 105.481};
+   for (int i : {0, 1}) {
+      if ((TMath::Abs((f2->GetParameters())[i] - ref_f2[i]) / ref_f2[i]) > 0.001) {
+         std::cout << "\n >>> Test failure: fit to 'f2': parameter '" << f2->GetParName(i) << "' has wrong value ("
+                   << (f2->GetParameters())[i] << ": expected" << ref_f2[i] << ") \n";
+         if (logfile) gSystem->RedirectOutput(0, 0, &redH);
+         return -1;
       }
+   }
 
-      // Project slices of 2-d histogram h2 along X , then fit each slice
-      // with function f2 and make a histogram for each fit parameter
-      // Note that the generated histograms are added to the list of objects
-      // in the current directory.
-      if (gROOT->GetListOfFunctions()->FindObject("f2"))
-         delete gROOT->GetFunction("f2");
+   TH1D *h2_1 = (TH1D *)gDirectory->Get("h2_1");
+   h2_1->GetXaxis()->SetTitle("#tau[ps]");
+   h2_1->SetMarkerStyle(21);
+   h2_1->Draw();
+   c2->Update();
+   TLine *line = new TLine(0, 0, 0, c2->GetUymax());
+   line->Draw();
 
-      auto fdm2 = [](Double_t *xx, Double_t *par) -> Double_t {
-         const Double_t dxbin = (0.17-0.13)/40;   // Bin-width
-         const Double_t sigma = 0.0012;
-         Double_t x = xx[0];
-         if (x <= 0.13957) return 0;
-         Double_t xp3 = (x-0.1454)*(x-0.1454);
-         Double_t res = dxbin*(par[0]*TMath::Power(x-0.13957, 0.25)
-                      + par[1] / 2.5066/sigma*TMath::Exp(-xp3/2/sigma/sigma));
-         return res;
-      };
+   // Have the number of entries on the first histogram (to cross check when running
+   // with entry lists)
+   TPaveStats *psdmd = (TPaveStats *)hdmd->GetListOfFunctions()->FindObject("stats");
+   psdmd->SetOptStat(1110);
+   c1->Modified();
 
-      TF1 *f2 = new TF1("f2",fdm2,0.139,0.17,2);
-      f2->SetParameters(10000, 10);
+   if (logfile) gSystem->RedirectOutput(0, 0, &redH);
 
-      // Restrict to three bins in this example
-      std::cout << "doFit: restricting fit to two bins only in this example...\n";
+   return 0;
+};
 
-      h2->FitSlicesX(f2,10,20,10,"g5 l");
+// This function is used to fit the result of the analysis without graphics
+auto doFitRaw = [](TList *out, const char *logfile = 0) -> Int_t {
 
-      // Check the result of the fit
-      Double_t ref_f2[2] = {52432.2, 105.481};
-      for (int i : {0,1} ) {
-         if ((TMath::Abs((f2->GetParameters())[i] - ref_f2[i]) / ref_f2[i]) > 0.001) {
-            std::cout << "\n >>> Test failure: fit to 'f2': parameter '" << f2->GetParName(i)
-                      << "' has wrong value ("
-                      << (f2->GetParameters())[i] << ": expected" << ref_f2[i] << ") \n";
-            if (logfile) gSystem->RedirectOutput(0, 0, &redH);
-            return -1;
-         }
-      }
+   RedirectHandle_t redH;
+   if (logfile) gSystem->RedirectOutput(logfile, "a", &redH);
 
+   auto hdmd = dynamic_cast<TH1F *>(out->FindObject("hdmd"));
+   auto h2 = dynamic_cast<TH2F *>(out->FindObject("h2"));
+
+   // function called at the end of the event loop
+   if (hdmd == 0 || h2 == 0) {
+      std::cout << "doFit: hdmd = " << hdmd << " , h2 = " << h2 << "\n";
+      return -1;
       if (logfile) gSystem->RedirectOutput(0, 0, &redH);
+   }
 
-      return 0;
+   // fit histogram hdmd with function f5 using the log-likelihood option
+   if (gROOT->GetListOfFunctions()->FindObject("f5")) delete gROOT->GetFunction("f5");
+
+   auto fdm5 = [](Double_t *xx, Double_t *par) -> Double_t {
+      const Double_t dxbin = (0.17 - 0.13) / 40; // Bin-width
+      Double_t x = xx[0];
+      if (x <= 0.13957) return 0;
+      Double_t xp3 = (x - par[3]) * (x - par[3]);
+      Double_t res = dxbin * (par[0] * TMath::Power(x - 0.13957, par[1]) +
+                              par[2] / 2.5066 / par[4] * TMath::Exp(-xp3 / 2 / par[4] / par[4]));
+      return res;
    };
 
-   // This is the function invoked during the processing of the trees.
-   auto doH1 = [](TTreeReader &reader) {
-      
-      // Histograms
-      auto hdmd = new TH1F("hdmd","Dm_d",40,0.13,0.17);
-      auto h2   = new TH2F("h2","ptD0 vs Dm_d",30,0.135,0.165,30,-3,6);
-      
-      TTreeReaderValue<Float_t>    fPtds_d(reader, "ptds_d");
-      TTreeReaderValue<Float_t>    fEtads_d(reader, "etads_d");
-      TTreeReaderValue<Float_t>    fDm_d(reader, "dm_d");
-      TTreeReaderValue<Int_t>      fIk(reader, "ik");
-      TTreeReaderValue<Int_t>      fIpi(reader, "ipi");
-      TTreeReaderValue<Int_t>      fIpis(reader, "ipis");
-      TTreeReaderValue<Float_t>    fPtd0_d(reader, "ptd0_d");
-      TTreeReaderValue<Float_t>    fMd0_d(reader, "md0_d");
-      TTreeReaderValue<Float_t>    fRpd0_t(reader , "rpd0_t");
-      TTreeReaderArray<Int_t>      fNhitrp(reader, "nhitrp");
-      TTreeReaderArray<Float_t>    fRstart(reader, "rstart");
-      TTreeReaderArray<Float_t>    fRend(reader, "rend");
-      TTreeReaderArray<Float_t>    fNlhk(reader, "nlhk");
-      TTreeReaderArray<Float_t>    fNlhpi(reader, "nlhpi");
-      TTreeReaderValue<Int_t>      fNjets(reader, "njets");
+   TF1 *f5 = new TF1("f5", fdm5, 0.139, 0.17, 5);
+   f5->SetParameters(1000000, .25, 2000, .1454, .001);
+   hdmd->Fit("f5", "lr");
 
-      while (reader.Next()) {
-
-         // Return as soon as a bad entry is detected
-         if (TMath::Abs(*fMd0_d-1.8646) >= 0.04)        continue;
-         if (*fPtds_d <= 2.5)                           continue;
-         if (TMath::Abs(*fEtads_d) >= 1.5)              continue;
-         (*fIk)--; //original fIk used f77 convention starting at 1
-         (*fIpi)--;
-
-         if (fNhitrp.At(*fIk)* fNhitrp.At(*fIpi) <= 1)  continue; 
-
-         if (fRend.At(*fIk) -fRstart.At(*fIk)  <= 22)   continue;
-         if (fRend.At(*fIpi)-fRstart.At(*fIpi) <= 22)   continue;
-         if (fNlhk.At(*fIk) <= 0.1)                     continue;
-         if (fNlhpi.At(*fIpi) <= 0.1)                   continue;
-         (*fIpis)--; if (fNlhpi.At(*fIpis) <= 0.1)      continue;
-         if (*fNjets < 1)                               continue;
- 
-         // Fill the histograms
-         hdmd->Fill(*fDm_d);
-         h2->Fill(*fDm_d, *fRpd0_t/0.029979*1.8646/ *fPtd0_d);
+   // Check the result of the fit
+   Double_t ref_f5[4] = {959915.0, 0.351114, 1185.03, 0.145569};
+   for (int i : {0, 1, 2, 3}) {
+      if ((TMath::Abs((f5->GetParameters())[i] - ref_f5[i]) / ref_f5[i]) > 0.001) {
+         std::cout << "\n >>> Test failure: fit to 'f5': parameter '" << f5->GetParName(i) << "' has wrong value ("
+                   << (f5->GetParameters())[i] << ": expected" << ref_f5[i] << ") \n";
+         if (logfile) gSystem->RedirectOutput(0, 0, &redH);
+         return -1;
       }
+   }
 
-      // Return a list
-      auto l = new TList;
-      l->Add(hdmd);
-      l->Add(h2);
-      l->SetOwner(kFALSE);
+   // Project slices of 2-d histogram h2 along X , then fit each slice
+   // with function f2 and make a histogram for each fit parameter
+   // Note that the generated histograms are added to the list of objects
+   // in the current directory.
+   if (gROOT->GetListOfFunctions()->FindObject("f2")) delete gROOT->GetFunction("f2");
 
-      return l;
+   auto fdm2 = [](Double_t *xx, Double_t *par) -> Double_t {
+      const Double_t dxbin = (0.17 - 0.13) / 40; // Bin-width
+      const Double_t sigma = 0.0012;
+      Double_t x = xx[0];
+      if (x <= 0.13957) return 0;
+      Double_t xp3 = (x - 0.1454) * (x - 0.1454);
+      Double_t res = dxbin * (par[0] * TMath::Power(x - 0.13957, 0.25) +
+                              par[1] / 2.5066 / sigma * TMath::Exp(-xp3 / 2 / sigma / sigma));
+      return res;
    };
 
-   // This is the function invoked during the processing of the trees to create a TEntryList
-   auto doH1fillList = [](TTreeReader &reader) {
-      
-      // Entry list
-      auto elist = new TEntryList("elist", "H1 selection from Cut");
-      
-      TTreeReaderValue<Float_t>    fPtds_d(reader, "ptds_d");
-      TTreeReaderValue<Float_t>    fEtads_d(reader, "etads_d");
-      TTreeReaderValue<Int_t>      fIk(reader, "ik");
-      TTreeReaderValue<Int_t>      fIpi(reader, "ipi");
-      TTreeReaderValue<Int_t>      fIpis(reader, "ipis");
-      TTreeReaderValue<Float_t>    fMd0_d(reader, "md0_d");
-      TTreeReaderArray<Int_t>      fNhitrp(reader, "nhitrp");
-      TTreeReaderArray<Float_t>    fRstart(reader, "rstart");
-      TTreeReaderArray<Float_t>    fRend(reader, "rend");
-      TTreeReaderArray<Float_t>    fNlhk(reader, "nlhk");
-      TTreeReaderArray<Float_t>    fNlhpi(reader, "nlhpi");
-      TTreeReaderValue<Int_t>      fNjets(reader, "njets");
+   TF1 *f2 = new TF1("f2", fdm2, 0.139, 0.17, 2);
+   f2->SetParameters(10000, 10);
 
-      while (reader.Next()) {
+   // Restrict to three bins in this example
+   std::cout << "doFit: restricting fit to two bins only in this example...\n";
 
-         // Return as soon as a bad entry is detected
-         if (TMath::Abs(*fMd0_d-1.8646) >= 0.04)        continue;
-         if (*fPtds_d <= 2.5)                           continue;
-         if (TMath::Abs(*fEtads_d) >= 1.5)              continue;
-         (*fIk)--; //original fIk used f77 convention starting at 1
-         (*fIpi)--;
+   h2->FitSlicesX(f2, 10, 20, 10, "g5 l");
 
-         if (fNhitrp.At(*fIk)* fNhitrp.At(*fIpi) <= 1)  continue; 
-
-         if (fRend.At(*fIk) -fRstart.At(*fIk)  <= 22)   continue;
-         if (fRend.At(*fIpi)-fRstart.At(*fIpi) <= 22)   continue;
-         if (fNlhk.At(*fIk) <= 0.1)                     continue;
-         if (fNlhpi.At(*fIpi) <= 0.1)                   continue;
-         (*fIpis)--; if (fNlhpi.At(*fIpis) <= 0.1)      continue;
-         if (*fNjets < 1)                               continue;
-
-         // Fill the entry list
-         elist->Enter(reader.GetCurrentEntry(), reader.GetTree());
+   // Check the result of the fit
+   Double_t ref_f2[2] = {52432.2, 105.481};
+   for (int i : {0, 1}) {
+      if ((TMath::Abs((f2->GetParameters())[i] - ref_f2[i]) / ref_f2[i]) > 0.001) {
+         std::cout << "\n >>> Test failure: fit to 'f2': parameter '" << f2->GetParName(i) << "' has wrong value ("
+                   << (f2->GetParameters())[i] << ": expected" << ref_f2[i] << ") \n";
+         if (logfile) gSystem->RedirectOutput(0, 0, &redH);
+         return -1;
       }
+   }
 
-      return elist;
-   };
+   if (logfile) gSystem->RedirectOutput(0, 0, &redH);
 
+   return 0;
+};
 
-   // This is the function invoked during the processing of the trees using a TEntryList
-   auto doH1useList = [](TTreeReader &reader) {
-      
-      // Histograms
-      auto hdmd = new TH1F("hdmd","Dm_d",40,0.13,0.17);
-      auto h2   = new TH2F("h2","ptD0 vs Dm_d",30,0.135,0.165,30,-3,6);
-      
-      TTreeReaderValue<Float_t>    fDm_d(reader, "dm_d");
-      TTreeReaderValue<Float_t>    fPtd0_d(reader, "ptd0_d");
-      TTreeReaderValue<Float_t>    fRpd0_t(reader , "rpd0_t");
+// This is the function invoked during the processing of the trees.
+auto doH1 = [](TTreeReader &reader) {
 
-      while (reader.Next()) {
-         // Fill the histograms
-         hdmd->Fill(*fDm_d);
-         h2->Fill(*fDm_d, *fRpd0_t/0.029979*1.8646/ *fPtd0_d);
-      }
+   // Histograms
+   auto hdmd = new TH1F("hdmd", "Dm_d", 40, 0.13, 0.17);
+   auto h2 = new TH2F("h2", "ptD0 vs Dm_d", 30, 0.135, 0.165, 30, -3, 6);
 
-      // Return a list
-      auto l = new TList;
-      l->Add(hdmd);
-      l->Add(h2);
-      l->SetOwner(kFALSE);
+   TTreeReaderValue<Float_t> fPtds_d(reader, "ptds_d");
+   TTreeReaderValue<Float_t> fEtads_d(reader, "etads_d");
+   TTreeReaderValue<Float_t> fDm_d(reader, "dm_d");
+   TTreeReaderValue<Int_t> fIk(reader, "ik");
+   TTreeReaderValue<Int_t> fIpi(reader, "ipi");
+   TTreeReaderValue<Int_t> fIpis(reader, "ipis");
+   TTreeReaderValue<Float_t> fPtd0_d(reader, "ptd0_d");
+   TTreeReaderValue<Float_t> fMd0_d(reader, "md0_d");
+   TTreeReaderValue<Float_t> fRpd0_t(reader, "rpd0_t");
+   TTreeReaderArray<Int_t> fNhitrp(reader, "nhitrp");
+   TTreeReaderArray<Float_t> fRstart(reader, "rstart");
+   TTreeReaderArray<Float_t> fRend(reader, "rend");
+   TTreeReaderArray<Float_t> fNlhk(reader, "nlhk");
+   TTreeReaderArray<Float_t> fNlhpi(reader, "nlhpi");
+   TTreeReaderValue<Int_t> fNjets(reader, "njets");
 
-      return l;
-   };
+   while (reader.Next()) {
+
+      // Return as soon as a bad entry is detected
+      if (TMath::Abs(*fMd0_d - 1.8646) >= 0.04) continue;
+      if (*fPtds_d <= 2.5) continue;
+      if (TMath::Abs(*fEtads_d) >= 1.5) continue;
+      (*fIk)--; // original fIk used f77 convention starting at 1
+      (*fIpi)--;
+
+      if (fNhitrp.At(*fIk) * fNhitrp.At(*fIpi) <= 1) continue;
+
+      if (fRend.At(*fIk) - fRstart.At(*fIk) <= 22) continue;
+      if (fRend.At(*fIpi) - fRstart.At(*fIpi) <= 22) continue;
+      if (fNlhk.At(*fIk) <= 0.1) continue;
+      if (fNlhpi.At(*fIpi) <= 0.1) continue;
+      (*fIpis)--;
+      if (fNlhpi.At(*fIpis) <= 0.1) continue;
+      if (*fNjets < 1) continue;
+
+      // Fill the histograms
+      hdmd->Fill(*fDm_d);
+      h2->Fill(*fDm_d, *fRpd0_t / 0.029979 * 1.8646 / *fPtd0_d);
+   }
+
+   // Return a list
+   auto l = new TList;
+   l->Add(hdmd);
+   l->Add(h2);
+   l->SetOwner(kFALSE);
+
+   return l;
+};
+
+// This is the function invoked during the processing of the trees to create a TEntryList
+auto doH1fillList = [](TTreeReader &reader) {
+
+   // Entry list
+   auto elist = new TEntryList("elist", "H1 selection from Cut");
+
+   TTreeReaderValue<Float_t> fPtds_d(reader, "ptds_d");
+   TTreeReaderValue<Float_t> fEtads_d(reader, "etads_d");
+   TTreeReaderValue<Int_t> fIk(reader, "ik");
+   TTreeReaderValue<Int_t> fIpi(reader, "ipi");
+   TTreeReaderValue<Int_t> fIpis(reader, "ipis");
+   TTreeReaderValue<Float_t> fMd0_d(reader, "md0_d");
+   TTreeReaderArray<Int_t> fNhitrp(reader, "nhitrp");
+   TTreeReaderArray<Float_t> fRstart(reader, "rstart");
+   TTreeReaderArray<Float_t> fRend(reader, "rend");
+   TTreeReaderArray<Float_t> fNlhk(reader, "nlhk");
+   TTreeReaderArray<Float_t> fNlhpi(reader, "nlhpi");
+   TTreeReaderValue<Int_t> fNjets(reader, "njets");
+
+   while (reader.Next()) {
+
+      // Return as soon as a bad entry is detected
+      if (TMath::Abs(*fMd0_d - 1.8646) >= 0.04) continue;
+      if (*fPtds_d <= 2.5) continue;
+      if (TMath::Abs(*fEtads_d) >= 1.5) continue;
+      (*fIk)--; // original fIk used f77 convention starting at 1
+      (*fIpi)--;
+
+      if (fNhitrp.At(*fIk) * fNhitrp.At(*fIpi) <= 1) continue;
+
+      if (fRend.At(*fIk) - fRstart.At(*fIk) <= 22) continue;
+      if (fRend.At(*fIpi) - fRstart.At(*fIpi) <= 22) continue;
+      if (fNlhk.At(*fIk) <= 0.1) continue;
+      if (fNlhpi.At(*fIpi) <= 0.1) continue;
+      (*fIpis)--;
+      if (fNlhpi.At(*fIpis) <= 0.1) continue;
+      if (*fNjets < 1) continue;
+
+      // Fill the entry list
+      elist->Enter(reader.GetCurrentEntry(), reader.GetTree());
+   }
+
+   return elist;
+};
+
+// This is the function invoked during the processing of the trees using a TEntryList
+auto doH1useList = [](TTreeReader &reader) {
+
+   // Histograms
+   auto hdmd = new TH1F("hdmd", "Dm_d", 40, 0.13, 0.17);
+   auto h2 = new TH2F("h2", "ptD0 vs Dm_d", 30, 0.135, 0.165, 30, -3, 6);
+
+   TTreeReaderValue<Float_t> fDm_d(reader, "dm_d");
+   TTreeReaderValue<Float_t> fPtd0_d(reader, "ptd0_d");
+   TTreeReaderValue<Float_t> fRpd0_t(reader, "rpd0_t");
+
+   while (reader.Next()) {
+      // Fill the histograms
+      hdmd->Fill(*fDm_d);
+      h2->Fill(*fDm_d, *fRpd0_t / 0.029979 * 1.8646 / *fPtd0_d);
+   }
+
+   // Return a list
+   auto l = new TList;
+   l->Add(hdmd);
+   l->Add(h2);
+   l->SetOwner(kFALSE);
+
+   return l;
+};


### PR DESCRIPTION
This PR adds in TreeProcessorMP support for processing TTree datasets filtering via a TEntryList.
A new set of Process methods taking a TEntryList * as 3rd argument has been added.
A test for the new functionality is ready to be pushed in roottest once this is pushed.   