### PR TITLE
Simplify implementation of TBufferMerger using TFileMerger directly

### DIFF
--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -76,8 +76,8 @@ private:
    void Push(TBufferFile *buffer);
    void WriteOutputFile();
 
-   const char *fName;
-   const char *fOption;
+   const std::string fName;
+   const std::string fOption;
    const Int_t fCompress;
    std::mutex fQueueMutex;                                       //< Mutex used to lock fQueue
    std::mutex fWriteMutex;                                       //< Mutex used for the condition variable

--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -79,7 +79,6 @@ private:
    const char *fName;
    const char *fOption;
    const Int_t fCompress;
-   std::mutex fFilesMutex;                                       //< Mutex used to lock fAttachedFiles
    std::mutex fQueueMutex;                                       //< Mutex used to lock fQueue
    std::mutex fWriteMutex;                                       //< Mutex used for the condition variable
    std::condition_variable fCV;                                  //< Condition variable used to wait for data

--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -58,6 +58,11 @@ public:
     *  At the end, all TBufferMergerFiles get merged into the output file.
     *  The user is responsible to "cd" into the file to associate objects
     *  such as histograms or trees to it.
+    *
+    *  After the creation of this file, the user must reset the kMustCleanup
+    *  bit on any objects attached to it and take care of their deletion, as
+    *  there is a possibility that a race condition will happen that causes
+    *  a crash if ROOT manages these objects.
     */
    std::shared_ptr<TBufferMergerFile> GetFile();
 

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -37,7 +37,6 @@ TBufferMerger::~TBufferMerger()
 
 std::shared_ptr<TBufferMergerFile> TBufferMerger::GetFile()
 {
-   TDirectory::TContext ctxt;
    std::lock_guard<std::mutex> lk(fFilesMutex);
    std::shared_ptr<TBufferMergerFile> f(new TBufferMergerFile(*this));
    fAttachedFiles.push_back(f);

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -11,267 +11,17 @@
 
 #include "ROOT/TBufferMerger.hxx"
 
-#include "TBits.h"
 #include "TBufferFile.h"
-#include "TClass.h"
 #include "TError.h"
-#include "TFileCacheWrite.h"
 #include "TFileMerger.h"
-#include "TKey.h"
-#include "TMath.h"
-#include "TMemFile.h"
-#include "TSystem.h"
-#include "TTimeStamp.h"
-
-namespace {
-
-Bool_t R__NeedInitialMerge(TDirectory *dir)
-{
-   if (dir == 0) return false;
-
-   TIter nextkey(dir->GetListOfKeys());
-   for (TKey *key = (TKey *)nextkey(); key != nullptr; key = (TKey *)nextkey()) {
-      TClass *cl = TClass::GetClass(key->GetClassName());
-      if (cl->InheritsFrom(TDirectory::Class())) {
-         TDirectory *subdir = (TDirectory *)dir->GetList()->FindObject(key->GetName());
-         if (!subdir) {
-            subdir = (TDirectory *)key->ReadObj();
-         }
-         if (R__NeedInitialMerge(subdir)) {
-            return true;
-         }
-      } else {
-         if (0 != cl->GetResetAfterMerge()) {
-            return true;
-         }
-      }
-   }
-   return false;
-}
-
-void R__DeleteObject(TDirectory *dir, Bool_t withReset)
-{
-   if (dir == 0) return;
-
-   TIter nextkey(dir->GetListOfKeys());
-   TKey *key;
-   while ((key = (TKey *)nextkey())) {
-      TClass *cl = TClass::GetClass(key->GetClassName());
-      if (cl->InheritsFrom(TDirectory::Class())) {
-         TDirectory *subdir = (TDirectory *)dir->GetList()->FindObject(key->GetName());
-         if (!subdir) {
-            subdir = (TDirectory *)key->ReadObj();
-         }
-         R__DeleteObject(subdir, withReset);
-      } else {
-         Bool_t todelete = false;
-         if (withReset) {
-            todelete = (0 != cl->GetResetAfterMerge());
-         } else {
-            todelete = (0 == cl->GetResetAfterMerge());
-         }
-         if (todelete) {
-            key->Delete();
-            dir->GetListOfKeys()->Remove(key);
-            delete key;
-         }
-      }
-   }
-}
-
-void R__MigrateKey(TDirectory *destination, TDirectory *source)
-{
-   if (destination == 0 || source == 0) return;
-   TIter nextkey(source->GetListOfKeys());
-
-   TKey *key;
-
-   while ((key = (TKey *)nextkey())) {
-      TClass *cl = TClass::GetClass(key->GetClassName());
-      if (cl->InheritsFrom(TDirectory::Class())) {
-         TDirectory *source_subdir = (TDirectory *)source->GetList()->FindObject(key->GetName());
-         if (!source_subdir) {
-            source_subdir = (TDirectory *)key->ReadObj();
-         }
-         TDirectory *destination_subdir = destination->GetDirectory(key->GetName());
-         if (!destination_subdir) {
-            destination_subdir = destination->mkdir(key->GetName());
-         }
-         R__MigrateKey(destination_subdir, source_subdir);
-      } else {
-         TKey *oldkey = destination->GetKey(key->GetName());
-         if (oldkey) {
-            oldkey->Delete();
-            delete oldkey;
-         }
-         // a priori the files are from the same client
-         TKey *newkey = new TKey(destination, *key, 0 /* pidoffset */);
-         destination->GetFile()->SumBuffer(newkey->GetObjlen());
-         newkey->WriteFile(0);
-         if (destination->GetFile()->TestBit(TFile::kWriteError)) {
-            return;
-         }
-      }
-   }
-   destination->SaveSelf();
-}
-
-struct ClientInfo {
-   TFile *fFile; // This object does *not* own the file, it's owned by the owner of ClientInfo
-   TString fLocalName;
-   UInt_t fContactsCount;
-   TTimeStamp fLastContact;
-   Double_t fTimeSincePrevContact;
-
-   ClientInfo() : fFile(0), fLocalName(), fContactsCount(0), fTimeSincePrevContact(0) {}
-
-   ClientInfo(const char *filename, UInt_t clientId) : fFile(0), fContactsCount(0), fTimeSincePrevContact(0)
-   {
-      fLocalName.Form("%s-%d-%d", filename, clientId, gSystem->GetPid());
-   }
-
-   void Set(TFile *file)
-   {
-      // Register the new file as coming from this client.
-      if (file != fFile) {
-         // We need to keep any of the keys from the previous file that
-         // are not in the new file.
-         if (fFile) {
-            R__MigrateKey(fFile, file);
-            // delete the previous memory file (if any)
-            delete file;
-         } else {
-            fFile = file;
-         }
-      }
-      TTimeStamp now;
-      fTimeSincePrevContact = now.AsDouble() - fLastContact.AsDouble();
-      fLastContact = now;
-      ++fContactsCount;
-   }
-};
-
-struct ThreadFileMerger : public TObject {
-   TString fFilename;
-   TBits fClientsContact;
-   UInt_t fNClientsContact;
-   std::vector<ClientInfo> fClients;
-   TTimeStamp fLastMerge;
-   TFileMerger fMerger;
-
-   ThreadFileMerger(const char *filename, Bool_t writeCache = false)
-      : fFilename(filename), fNClientsContact(0), fMerger(false, true)
-   {
-      fMerger.SetPrintLevel(0);
-      fMerger.OutputFile(filename, "RECREATE");
-      if (writeCache) new TFileCacheWrite(fMerger.GetOutputFile(), 32 * 1024 * 1024);
-   }
-
-   ~ThreadFileMerger()
-   {
-      for (auto &&client : fClients) delete client.fFile;
-   }
-
-   const char *GetName() const { return fFilename; }
-
-   ULong_t Hash() const { return fFilename.Hash(); }
-
-   Bool_t InitialMerge(TFile *input)
-   {
-      fMerger.AddFile(input);
-      Bool_t result = fMerger.PartialMerge(TFileMerger::kIncremental | TFileMerger::kResetable);
-      R__DeleteObject(input, true);
-      return result;
-   }
-
-   Bool_t NeedFinalMerge() { return fClientsContact.CountBits() > 0; }
-
-   Bool_t NeedMerge(Float_t clientThreshold)
-   {
-      if (fClients.size() == 0) {
-         return false;
-      }
-
-      // Calculate average and rms of the time between the last 2 contacts.
-      Double_t sum = 0;
-      Double_t sum2 = 0;
-      for (unsigned int c = 0; c < fClients.size(); ++c) {
-         sum += fClients[c].fTimeSincePrevContact;
-         sum2 += fClients[c].fTimeSincePrevContact * fClients[c].fTimeSincePrevContact;
-      }
-      Double_t avg = sum / fClients.size();
-      Double_t sigma = sum2 ? TMath::Sqrt(sum2 / fClients.size() - avg * avg) : 0;
-      Double_t target = avg + 2 * sigma;
-      TTimeStamp now;
-      if ((now.AsDouble() - fLastMerge.AsDouble()) > target) {
-         return true;
-      }
-      Float_t cut = clientThreshold * fClients.size();
-      return fClientsContact.CountBits() > cut || fNClientsContact > 2 * cut;
-   }
-
-   Bool_t Merge()
-   {
-      // Merge the current inputs into the output file.
-
-      // Remove object that can *not* be incrementally merged
-      // and will *not* be reset by the client code.
-      R__DeleteObject(fMerger.GetOutputFile(), false);
-
-      for (unsigned int f = 0; f < fClients.size(); ++f) {
-         fMerger.AddFile(fClients[f].fFile);
-      }
-
-      Bool_t result = fMerger.PartialMerge(TFileMerger::kAllIncremental);
-
-      // Remove any 'resetable' object (like TTree) from the input file
-      // so that they will not be re-merged. Keep only the object that
-      // always need to be re-merged (Histograms).
-
-      for (unsigned int f = 0; f < fClients.size(); ++f) {
-         if (fClients[f].fFile) {
-            R__DeleteObject(fClients[f].fFile, true);
-         } else {
-            // We back up the file (probably due to memory constraint)
-            TDirectoryFile::TContext ctxt;
-            TFile *file = TFile::Open(fClients[f].fLocalName, "UPDATE");
-            // Remove object that can be incrementally merged and
-            // will be reset by the client code.
-            R__DeleteObject(file, true);
-            file->Write();
-            delete file;
-         }
-      }
-      fLastMerge = TTimeStamp();
-      fNClientsContact = 0;
-      fClientsContact.Clear();
-
-      return result;
-   }
-
-   void RegisterClient(UInt_t clientId, TFile *file)
-   {
-      ++fNClientsContact;
-
-      fClientsContact.SetBitNumber(clientId);
-
-      if (fClients.size() < clientId + 1) {
-         fClients.push_back(ClientInfo(fFilename, clientId));
-      }
-      fClients[clientId].Set(file);
-   }
-};
-
-} // unnamed namespace
 
 namespace ROOT {
 namespace Experimental {
 
-TBufferMerger::TBufferMerger(const char *name, Option_t *option, const char *ftitle, Int_t compress)
-   : fMergingThread(new std::thread([this]() { this->Listen(); }))
+TBufferMerger::TBufferMerger(const char *name, Option_t *option, Int_t compress)
+   : fName(name), fOption(option), fCompress(compress),
+     fMergingThread(new std::thread([&]() { this->WriteOutputFile(); }))
 {
-   TDirectoryFile::TContext ctxt;
-   fFile.reset(TFile::Open(name, option, ftitle, compress));
 }
 
 TBufferMerger::~TBufferMerger()
@@ -283,18 +33,14 @@ TBufferMerger::~TBufferMerger()
    fCV.notify_one();
 
    fMergingThread->join();
-   fFile->Close();
 }
 
 std::shared_ptr<TBufferMergerFile> TBufferMerger::GetFile()
 {
    TDirectory::TContext ctxt;
-   std::shared_ptr<TBufferMergerFile> f;
-   {
-      std::lock_guard<std::mutex> lk(fFilesMutex);
-      f.reset(new TBufferMergerFile(*this));
-      fAttachedFiles.push_back(f);
-   }
+   std::lock_guard<std::mutex> lk(fFilesMutex);
+   std::shared_ptr<TBufferMergerFile> f(new TBufferMergerFile(*this));
+   fAttachedFiles.push_back(f);
    return f;
 }
 
@@ -304,16 +50,17 @@ void TBufferMerger::Push(TBufferFile *buffer)
       std::lock_guard<std::mutex> lock(fQueueMutex);
       fQueue.push(buffer);
    }
-
    fCV.notify_one();
 }
 
-void TBufferMerger::Listen()
+void TBufferMerger::WriteOutputFile()
 {
-   std::unique_lock<std::mutex> wlock(fWriteMutex);
-
    bool done = false;
-   THashTable mergers;
+   std::unique_lock<std::mutex> wlock(fWriteMutex);
+   TDirectoryFile::TContext context;
+   TFileMerger merger(false);
+
+   merger.OutputFile(fName, fOption, fCompress);
 
    while (!done) {
       fCV.wait(wlock, [this]() { return !this->fQueue.empty(); });
@@ -332,52 +79,22 @@ void TBufferMerger::Listen()
             break;
          }
 
+         Long64_t length;
          buffer->SetReadMode();
          buffer->SetBufferOffset();
-
-         Long64_t length;
-         TString filename;
-
-         buffer->ReadTString(filename);
          buffer->ReadLong64(length);
 
-         TDirectory::TContext ctxt;
-         // UPDATE because we need to remove the TTree after merging them.
-         TMemFile *transient = new TMemFile(filename, buffer->Buffer() + buffer->Length(), length, "UPDATE");
-
-         buffer->SetBufferOffset(buffer->Length() + length);
-
-         // control how often the histogram are merged.  Here as soon as half the clients have reported.
-         const Float_t clientThreshold = 0.75;
-
-         ThreadFileMerger *info = (ThreadFileMerger *)mergers.FindObject(filename);
-
-         if (!info) {
-            info = new ThreadFileMerger(filename, false);
-            mergers.Add(info);
+         {
+            TDirectory::TContext ctxt;
+            auto tmp = new TMemFile(fName, buffer->Buffer() + buffer->Length(), length, "READ");
+            buffer->SetBufferOffset(buffer->Length() + length);
+            merger.AddFile(tmp, true);
+            merger.PartialMerge();
+            merger.Reset();
+            delete tmp;
          }
-
-         if (R__NeedInitialMerge(transient)) {
-            info->InitialMerge(transient);
-         }
-
-         info->RegisterClient(0, transient);
-
-         if (info->NeedMerge(clientThreshold)) info->Merge();
-
-         transient = nullptr;
       }
    }
-
-   TIter next(&mergers);
-   ThreadFileMerger *info;
-   while ((info = (ThreadFileMerger *)next())) {
-      if (info->NeedFinalMerge()) {
-         info->Merge();
-      }
-   }
-
-   mergers.Delete();
 }
 
 } // namespace Experimental

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -57,7 +57,7 @@ void TBufferMerger::WriteOutputFile()
    bool done = false;
    std::unique_lock<std::mutex> wlock(fWriteMutex);
    TDirectoryFile::TContext context;
-   TFileMerger merger(false);
+   TFileMerger merger;
 
    merger.OutputFile(fName, fOption, fCompress);
 
@@ -87,10 +87,9 @@ void TBufferMerger::WriteOutputFile()
             TDirectory::TContext ctxt;
             auto tmp = new TMemFile(fName, buffer->Buffer() + buffer->Length(), length, "READ");
             buffer->SetBufferOffset(buffer->Length() + length);
-            merger.AddFile(tmp, true);
+            merger.AddAdoptFile(tmp);
             merger.PartialMerge();
             merger.Reset();
-            delete tmp;
          }
       }
    }

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -64,7 +64,7 @@ void TBufferMerger::WriteOutputFile()
 
    {
       R__LOCKGUARD2(gROOTMutex);
-      merger.OutputFile(fName, fOption, fCompress);
+      merger.OutputFile(fName.c_str(), fOption.c_str(), fCompress);
    }
 
    while (!done) {
@@ -94,7 +94,7 @@ void TBufferMerger::WriteOutputFile()
             TMemFile *tmp;
             {
                R__LOCKGUARD2(gROOTMutex);
-               tmp = new TMemFile(fName, buffer->Buffer() + buffer->Length(), length, "READ");
+               tmp = new TMemFile(fName.c_str(), buffer->Buffer() + buffer->Length(), length, "READ");
             }
             buffer->SetBufferOffset(buffer->Length() + length);
             merger.AddAdoptFile(tmp);

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -62,6 +62,8 @@ void TBufferMerger::WriteOutputFile()
    TDirectoryFile::TContext context;
    TFileMerger merger;
 
+   merger.ResetBit(kMustCleanup);
+
    {
       R__LOCKGUARD2(gROOTMutex);
       merger.OutputFile(fName.c_str(), fOption.c_str(), fCompress);

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -93,14 +93,14 @@ void TBufferMerger::WriteOutputFile()
 
          {
             TDirectory::TContext ctxt;
-            TMemFile *tmp;
+            std::unique_ptr<TMemFile> tmp;
             {
                R__LOCKGUARD2(gROOTMutex);
-               tmp = new TMemFile(fName.c_str(), buffer->Buffer() + buffer->Length(), length, "READ");
+               tmp.reset(new TMemFile(fName.c_str(), buffer->Buffer() + buffer->Length(), length, "read"));
+               buffer->SetBufferOffset(buffer->Length() + length);
+               merger.AddFile(tmp.get(), false);
+               merger.PartialMerge();
             }
-            buffer->SetBufferOffset(buffer->Length() + length);
-            merger.AddAdoptFile(tmp);
-            merger.PartialMerge();
             merger.Reset();
          }
       }

--- a/io/io/src/TBufferMergerFile.cxx
+++ b/io/io/src/TBufferMergerFile.cxx
@@ -17,8 +17,7 @@
 namespace ROOT {
 namespace Experimental {
 
-TBufferMergerFile::TBufferMergerFile(TBufferMerger &m)
-   : TMemFile(m.fFile->GetName(), "RECREATE", "", m.fFile->GetCompressionLevel()), fMerger(m), fClassSent(nullptr)
+TBufferMergerFile::TBufferMergerFile(TBufferMerger &m) : TMemFile(m.fName, "recreate", "", m.fCompress), fMerger(m)
 {
 }
 
@@ -33,50 +32,13 @@ Int_t TBufferMergerFile::Write(const char *name, Int_t opt, Int_t bufsize)
    if (nbytes) {
       TBufferFile *fBuffer = new TBufferFile(TBuffer::kWrite);
 
-      fBuffer->WriteTString(GetName());
       fBuffer->WriteLong64(GetEND());
       CopyTo(*fBuffer);
 
       fMerger.Push(fBuffer);
-
-      // Record StreamerInfo sent to the server
-      Int_t isize = fClassIndex->GetSize();
-      if (!fClassSent) {
-         fClassSent.reset(new TArrayC(isize));
-      } else {
-         if (isize > fClassSent->GetSize()) {
-            fClassSent->Set(isize);
-         }
-      }
-      for (Int_t c = 0; c < isize; ++c) {
-         if (fClassIndex->fArray[c]) {
-            fClassSent->fArray[c] = 1;
-         }
-      }
       ResetAfterMerge(0);
    }
    return nbytes;
-}
-
-void TBufferMergerFile::WriteStreamerInfo()
-{
-   if (!fWritable) return;
-   if (!fClassIndex) return;
-   // no need to update the index if no new classes added to the file
-   if (fClassIndex->fArray[0] == 0) return;
-
-   // clear fClassIndex for anything we already sent.
-   if (fClassSent) {
-      Int_t isize = fClassIndex->GetSize();
-      Int_t ssize = fClassSent->GetSize();
-      for (Int_t c = 0; c < isize && c < ssize; ++c) {
-         if (fClassSent->fArray[c]) {
-            fClassIndex->fArray[c] = 0;
-         }
-      }
-   }
-
-   TMemFile::WriteStreamerInfo();
 }
 
 } // namespace Experimental

--- a/io/io/src/TBufferMergerFile.cxx
+++ b/io/io/src/TBufferMergerFile.cxx
@@ -17,7 +17,8 @@
 namespace ROOT {
 namespace Experimental {
 
-TBufferMergerFile::TBufferMergerFile(TBufferMerger &m) : TMemFile(m.fName, "recreate", "", m.fCompress), fMerger(m)
+TBufferMergerFile::TBufferMergerFile(TBufferMerger &m)
+   : TMemFile(m.fName.c_str(), "recreate", "", m.fCompress), fMerger(m)
 {
 }
 

--- a/io/io/test/TBufferMerger.cxx
+++ b/io/io/test/TBufferMerger.cxx
@@ -30,6 +30,8 @@ TEST(TBufferMerger, CreateAndDestroy)
 
 TEST(TBufferMerger, CreateAndDestroyWithAttachedFiles)
 {
+   ROOT::EnableThreadSafety();
+
    TBufferMerger merger("tbuffermerger_create.root");
 
    auto f1 = merger.GetFile();

--- a/io/io/test/TBufferMerger.cxx
+++ b/io/io/test/TBufferMerger.cxx
@@ -49,7 +49,6 @@ TEST(TBufferMerger, SequentialTreeFill)
       TBufferMerger merger("tbuffermerger_sequential.root");
 
       auto myfile = merger.GetFile();
-      myfile->cd();
       auto mytree = new TTree("mytree", "mytree");
 
       Fill(mytree, 0, nevents);
@@ -70,7 +69,6 @@ TEST(TBufferMerger, ParallelTreeFill)
       for (int i = 0; i < nthreads; ++i) {
          threads.emplace_back([=, &merger]() {
             auto myfile = merger.GetFile();
-            myfile->cd();
             auto mytree = new TTree("mytree", "mytree");
 
             Fill(mytree, i * nevents, nevents);

--- a/io/io/test/TBufferMerger.cxx
+++ b/io/io/test/TBufferMerger.cxx
@@ -12,7 +12,7 @@
 
 using namespace ROOT::Experimental;
 
-static void Fill(TTree* tree, int init, int count)
+static void Fill(TTree *tree, int init, int count)
 {
    int n = 0;
 
@@ -62,6 +62,12 @@ TEST(TBufferMerger, SequentialTreeFill)
       auto myfile = merger.GetFile();
       auto mytree = new TTree("mytree", "mytree");
 
+      // The resetting of the kCleanup bit below is necessary to avoid leaving
+      // the management of this object to ROOT, which leads to a race condition
+      // that may cause a crash once all threads are finished and the final
+      // merge is happening
+      mytree->ResetBit(kMustCleanup);
+
       Fill(mytree, 0, nevents);
       myfile->Write();
    }
@@ -83,6 +89,12 @@ TEST(TBufferMerger, ParallelTreeFill)
          threads.emplace_back([=, &merger]() {
             auto myfile = merger.GetFile();
             auto mytree = new TTree("mytree", "mytree");
+
+            // The resetting of the kCleanup bit below is necessary to avoid leaving
+            // the management of this object to ROOT, which leads to a race condition
+            // that may cause a crash once all threads are finished and the final
+            // merge is happening
+            mytree->ResetBit(kMustCleanup);
 
             Fill(mytree, i * nevents, nevents);
             myfile->Write();

--- a/tutorials/multicore/mt103_fillNtupleFromMultipleThreads.C
+++ b/tutorials/multicore/mt103_fillNtupleFromMultipleThreads.C
@@ -37,8 +37,14 @@ void mt103_fillNtupleFromMultipleThreads()
    // content.
    auto work_function = [&](int seed) {
       auto f = merger.GetFile();
-      f->cd();
       TNtuple ntrand("ntrand", "Random Numbers", "r");
+
+      // The resetting of the kCleanup bit below is necessary to avoid leaving
+      // the management of this object to ROOT, which leads to a race condition
+      // that may cause a crash once all threads are finished and the final
+      // merge is happening
+      ntrand.ResetBit(kMustCleanup);
+
       TRandom rnd(seed);
       for (auto i : ROOT::TSeqI(nEntries)) ntrand.Fill(rnd.Gaus());
       f->Write();


### PR DESCRIPTION
This does not completely resolve the issue of the race conditions, but simplifies the implementation of TBufferMerger a lot by doing away with the ThreadFileMerger imported from GeantV and using TFileMerger directly.