### PR TITLE
Provide actions for text-based streamers

### DIFF
--- a/io/io/inc/TBufferJSON.h
+++ b/io/io/inc/TBufferJSON.h
@@ -428,7 +428,7 @@ protected:
 
    void             JsonStartElement(const TStreamerElement *elem, const TClass *base_class = 0);
 
-   void             PerformPostProcessing(TJSONStackObj *stack, const TStreamerElement *elem = 0);
+   void             PerformPostProcessing(TJSONStackObj *stack, Bool_t is_tobject = kFALSE);
 
    void              JsonWriteBasic(Char_t value);
    void              JsonWriteBasic(Short_t value);

--- a/io/io/inc/TBufferJSON.h
+++ b/io/io/inc/TBufferJSON.h
@@ -361,7 +361,7 @@ public:
    }
    virtual   UShort_t    WriteProcessID(TProcessID * /*pid*/)
    {
-      Error("WriteProcessID", "useless");
+      // Error("WriteProcessID", "useless");
       return 0;
    }
 
@@ -428,7 +428,7 @@ protected:
 
    void             JsonStartElement(const TStreamerElement *elem, const TClass *base_class = 0);
 
-   void             PerformPostProcessing(TJSONStackObj *stack, Bool_t is_tobject = kFALSE);
+   void             PerformPostProcessing(TJSONStackObj *stack, const TClass *obj_cl = 0);
 
    void              JsonWriteBasic(Char_t value);
    void              JsonWriteBasic(Short_t value);

--- a/io/io/inc/TBufferJSON.h
+++ b/io/io/inc/TBufferJSON.h
@@ -421,8 +421,7 @@ protected:
    TJSONStackObj   *Stack(Int_t depth = 0);
 
    void             WorkWithClass(TStreamerInfo *info, const TClass *cl = 0);
-   void             WorkWithElement(TStreamerElement *elem, Int_t comp_type);
-
+   void             WorkWithElement(TStreamerElement *elem, Int_t);
 
    void             JsonDisablePostprocessing();
    Int_t            JsonSpecialClass(const TClass *cl) const;
@@ -459,7 +458,6 @@ protected:
    std::map<const void *, unsigned>  fJsonrMap;   //!  map of recorded objects, used in JsonR to restore references
    unsigned                  fJsonrCnt;     //!  counter for all objects and arrays
    TObjArray                 fStack;        //!  stack of streamer infos
-   Bool_t                    fExpectedChain; //!   flag to resolve situation when several elements of same basic type stored as FastArray
    Int_t                     fCompact;       //!  0 - no any compression, 1 - no spaces in the begin, 2 - no new lines, 3 - no spaces at all
    TString                   fSemicolon;     //!  depending from compression level, " : " or ":"
    TString                   fArraySepar;    //!  depending from compression level, ", " or ","

--- a/io/io/inc/TStreamerInfo.h
+++ b/io/io/inc/TStreamerInfo.h
@@ -112,6 +112,7 @@ private:
    TStreamerInfoActions::TActionSequence *fWriteObjectWise;       ///<! List of write action resulting from the compilation.
    TStreamerInfoActions::TActionSequence *fWriteMemberWise;       ///<! List of write action resulting from the compilation for use in member wise streaming.
    TStreamerInfoActions::TActionSequence *fWriteMemberWiseVecPtr; ///<! List of write action resulting from the compilation for use in member wise streaming.
+   TStreamerInfoActions::TActionSequence *fWriteText;             ///<! List of write action resulting for text output like JSON or XML.
 
    static std::atomic<Int_t>             fgCount;     ///<Number of TStreamerInfo instances
 
@@ -128,6 +129,7 @@ private:
    TStreamerInfo& operator=(const TStreamerInfo&); // TStreamerInfo are copiable.  Not Implemented.
    void AddReadAction(TStreamerInfoActions::TActionSequence *readSequence, Int_t index, TCompInfo *compinfo);
    void AddWriteAction(TStreamerInfoActions::TActionSequence *writeSequence, Int_t index, TCompInfo *compinfo);
+   void AddWriteTextAction(TStreamerInfoActions::TActionSequence *writeSequence, Int_t index, TCompInfo *compinfo);
    void AddReadMemberWiseVecPtrAction(TStreamerInfoActions::TActionSequence *readSequence, Int_t index, TCompInfo *compinfo);
    void AddWriteMemberWiseVecPtrAction(TStreamerInfoActions::TActionSequence *writeSequence, Int_t index, TCompInfo *compinfo);
 
@@ -216,6 +218,7 @@ public:
    TStreamerInfoActions::TActionSequence *GetReadObjectWiseActions() { return fReadObjectWise; }
    TStreamerInfoActions::TActionSequence *GetWriteMemberWiseActions(Bool_t forCollection) { return forCollection ? fWriteMemberWiseVecPtr : fWriteMemberWise; }
    TStreamerInfoActions::TActionSequence *GetWriteObjectWiseActions() { return fWriteObjectWise; }
+   TStreamerInfoActions::TActionSequence *GetWriteTextActions() { return fWriteText; }
    Int_t               GetNdata()   const {return fNdata;}
    Int_t               GetNelement() const { return fElements->GetEntries(); }
    Int_t               GetNumber()  const {return fNumber;}

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -94,6 +94,7 @@ class TArrayIndexProducer {
       TArrayI fIndicies;
       TArrayI fMaxIndex;
       TString fRes;
+      Bool_t fIsArray;
 
    public:
       TArrayIndexProducer(TStreamerElement* elem, Int_t arraylen, const char* separ) :
@@ -102,13 +103,15 @@ class TArrayIndexProducer {
          fSepar(separ),
          fIndicies(),
          fMaxIndex(),
-         fRes()
+         fRes(),
+         fIsArray(kFALSE)
       {
          Bool_t usearrayindx = elem && (elem->GetArrayDim() > 0);
+         Bool_t usearraylen = (arraylen > 1);
 
          if (usearrayindx && (arraylen > 0)) {
             if ((elem->GetType() == TStreamerInfo::kOffsetL + TStreamerInfo::kStreamLoop) ||
-                (elem->GetType() == TStreamerInfo::kStreamLoop)) usearrayindx = kFALSE;
+                (elem->GetType() == TStreamerInfo::kStreamLoop)) { usearrayindx = kFALSE; usearraylen = kTRUE; }
             else
                if (arraylen != elem->GetArrayLength()) {
                   printf("Problem with JSON coding of element %s type %d \n", elem->GetName(), elem->GetType());
@@ -120,11 +123,13 @@ class TArrayIndexProducer {
             fMaxIndex.Set(elem->GetArrayDim());
             for(int dim=0;dim<elem->GetArrayDim();dim++)
                fMaxIndex[dim] = elem->GetMaxIndex(dim);
+            fIsArray = fTotalLen>1;
          } else
-         if (arraylen > 1) {
+         if (usearraylen) {
             fTotalLen = arraylen;
             fMaxIndex.Set(1);
             fMaxIndex[0] = arraylen;
+            fIsArray = kTRUE;
          }
 
          if (fMaxIndex.GetSize() > 0) {
@@ -139,7 +144,8 @@ class TArrayIndexProducer {
          fSepar(separ),
          fIndicies(),
          fMaxIndex(),
-         fRes()
+         fRes(),
+         fIsArray(kFALSE)
       {
          Int_t ndim = member->GetArrayDim();
          if (extradim > 0) ndim++;
@@ -159,6 +165,7 @@ class TArrayIndexProducer {
                fTotalLen *= extradim;
             }
          }
+         fIsArray = fTotalLen>1;
       }
 
       Int_t ReduceDimension()
@@ -171,13 +178,14 @@ class TArrayIndexProducer {
          fMaxIndex.Set(ndim);
          fIndicies.Set(ndim);
          fTotalLen = fTotalLen/len;
+         fIsArray = fTotalLen>1;
          return len;
       }
 
 
       Bool_t IsArray() const
       {
-         return (fTotalLen>1);
+         return fIsArray;
       }
 
       Bool_t IsDone() const

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -2654,31 +2654,38 @@ void  TBufferJSON::WriteFastArray(void *start, const TClass *cl, Int_t n,
       return;
    }
 
-   char *obj = (char *)start;
-   if (!n) n = 1;
-   int size = cl->Size();
-
-   TArrayIndexProducer indexes(Stack(0)->fElem, n, fArraySepar.Data());
-
-   if (indexes.IsArray()) {
+   if (n<0) {
+      // special handling of empty StreamLoop
+      AppendOutput("null");
       JsonDisablePostprocessing();
-      AppendOutput(indexes.GetBegin());
-   }
+   } else {
 
-   for (Int_t j = 0; j < n; j++, obj += size) {
+      char *obj = (char *)start;
+      if (!n) n = 1;
+      int size = cl->Size();
 
-      if (j>0) AppendOutput(indexes.NextSeparator());
+      TArrayIndexProducer indexes(Stack(0)->fElem, n, fArraySepar.Data());
 
-      JsonWriteObject(obj, cl, kFALSE);
-
-      if (indexes.IsArray() && (fValue.Length() > 0)) {
-         AppendOutput(fValue.Data());
-         fValue.Clear();
+      if (indexes.IsArray()) {
+         JsonDisablePostprocessing();
+         AppendOutput(indexes.GetBegin());
       }
-   }
 
-   if (indexes.IsArray())
-      AppendOutput(indexes.GetEnd());
+      for (Int_t j = 0; j < n; j++, obj += size) {
+
+         if (j>0) AppendOutput(indexes.NextSeparator());
+
+         JsonWriteObject(obj, cl, kFALSE);
+
+         if (indexes.IsArray() && (fValue.Length() > 0)) {
+            AppendOutput(fValue.Data());
+            fValue.Clear();
+         }
+      }
+
+      if (indexes.IsArray())
+         AppendOutput(indexes.GetEnd());
+   }
 
    if (Stack(0)->fIndx)
       AppendOutput(Stack(0)->fIndx->NextSeparator());

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -166,6 +166,7 @@ TStreamerInfo::TStreamerInfo()
    fWriteObjectWise = 0;
    fWriteMemberWise = 0;
    fWriteMemberWiseVecPtr = 0;
+   fWriteText = 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -199,6 +200,7 @@ TStreamerInfo::TStreamerInfo(TClass *cl)
    fWriteObjectWise = 0;
    fWriteMemberWise = 0;
    fWriteMemberWiseVecPtr = 0;
+   fWriteText = 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -217,6 +219,7 @@ TStreamerInfo::~TStreamerInfo()
    delete fWriteObjectWise;
    delete fWriteMemberWise;
    delete fWriteMemberWiseVecPtr;
+   delete fWriteText;
 
    if (!fElements) return;
    fElements->Delete();
@@ -2534,6 +2537,7 @@ void TStreamerInfo::Clear(Option_t *option)
       if (fWriteObjectWise) fWriteObjectWise->fActions.clear();
       if (fWriteMemberWise) fWriteMemberWise->fActions.clear();
       if (fWriteMemberWiseVecPtr) fWriteMemberWiseVecPtr->fActions.clear();
+      if (fWriteText) fWriteText->fActions.clear();
    }
 }
 

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -245,7 +245,7 @@ namespace TStreamerInfoActions
 
    /** Direct copy of code from TStreamerInfo::WriteBufferAux,
     * potentially can be used later for non-text streaming */
-   template<bool isText>
+   template<bool kIsTextT>
    INLINE_TEMPLATE_ARGS Int_t WriteSTLp(TBuffer &buf, void *addr, const TConfiguration *config)
    {
       TClass *cl                 = config->fCompInfo->fClass;
@@ -285,7 +285,7 @@ namespace TStreamerInfoActions
          return 0;
       }
       UInt_t pos = buf.WriteVersion(config->fInfo->IsA(),kTRUE);
-      if (isText) {
+      if (kIsTextT) {
          // use same method which is used in kSTL
          buf.WriteFastArray((void **)((char *) addr + ioffset), cl, config->fCompInfo->fLength, kFALSE, 0);
       } else
@@ -309,13 +309,13 @@ namespace TStreamerInfoActions
 
    /** Direct copy of code from TStreamerInfo::WriteBufferAux,
     * potentially can be used later for non-text streaming */
-   template<bool isText>
+   template<bool kIsTextT>
    INLINE_TEMPLATE_ARGS Int_t WriteStreamerLoop(TBuffer &buf, void *addr, const TConfiguration *config)
    {
       UInt_t eoffset = 0; // extra parameter of TStreamerInfo::WriteBufferAux, 0 for all kind of objects writing
       UInt_t ioffset = eoffset + config->fOffset;
 
-      if (!isText && config->fCompInfo->fStreamer) {
+      if (!kIsTextT && config->fCompInfo->fStreamer) {
          // Get any private streamer which was set for the data member.
          TMemberStreamer* pstreamer = config->fCompInfo->fStreamer;
          // -- We have a private streamer.
@@ -341,7 +341,7 @@ namespace TStreamerInfoActions
       // By default assume the file version is the newest.
       Int_t fileVersion = kMaxInt;
 
-      if (!isText) {
+      if (!kIsTextT) {
          // At this point we do *not* have a private streamer.
          // Get the version of the file we are writing to.
          TFile* file = (TFile*) buf.GetParent();
@@ -385,7 +385,7 @@ namespace TStreamerInfoActions
                   } // isPtrPtr
                } // ndx
             } else // vlen
-            if (isText) {
+            if (kIsTextT) {
                // special handling for the text-based streamers
                for (Int_t ndx = 0; ndx < config->fCompInfo->fLength; ++ndx)
                   buf.WriteFastArray((void *) 0, cl, -1, 0);


### PR DESCRIPTION
Idea to create separate actions list, which will be used only for text-based streaming.
Most actions functions can be reused from normal I/O, 
only several cases should be implemented slightly different.

On the long run one could create complimentary actions list for reading data with TBufferXML or TBufferSQL2 and fully isolate text-based and binary I/O

That is in PR:
- creating separate list **fWriteText,** now used only with JSON
- provide new method TStreamerInfo::AddWriteTextAction() to fill actions list
- actions build from the full list of class members (avoid compressed members)
- provide specialized actions for kTNamed, kTObject, kSTLp and kStreamLoop
- make actions for kSTLp and kStreamLoop with template parameter isText, potentially can be reused in binary I/O

PR solves several existing problem with JSON:
- TNamed and TObject as direct data members
- correct store of kSTLp members with arrays
- kStreamLoop member with fCounter==0
- kStreamLoop member with fCounter==1
- rudimentary support for TRef
- store dummy TObject instance

With provided code all my test classes working. I can provide patch for roottest.

P.S. Most probably, Travis-CI check will be unhappy about source-code formatting.
