### PR TITLE
[RGL] Allow disabling of display list usage

### DIFF
--- a/config/rootrc.in
+++ b/config/rootrc.in
@@ -291,6 +291,12 @@ OpenGL.SavePictureFallbackToBB:             yes
 OpenGL.Framebuffer.Multisample:             0
 # Flag to set CanvasPreferGL via gStyle
 OpenGL.CanvasPreferGL:                      0
+# Some MesaGL implementations (since 2016) have trouble (segv) when one tries
+# to store vertex array operations into display lists. The practice is indeed
+# somewhat questionable :) The following options allow complete or partial
+# disablement of display list usage.
+OpenGL.UseDisplayLists:                     1
+OpenGL.UseDisplayListsForVertexArrays:      1
 
 # EVE options (defaults are shown)
 # Autmoatically hide/roll up GL viewer menu-bars.

--- a/graf3d/gl/inc/TGLLogicalShape.h
+++ b/graf3d/gl/inc/TGLLogicalShape.h
@@ -60,6 +60,9 @@ protected:
 
    static  Bool_t     fgIgnoreSizeForCameraInterest;
 
+   static  Bool_t     fgUseDLs;            //! global flag for usage of display-lists
+   static  Bool_t     fgUseDLsForVertArrs; //! global flag for usage of display-lists in shapes that use vertex arrays
+
 public:
    TGLLogicalShape();
    TGLLogicalShape(TObject* obj);
@@ -112,6 +115,8 @@ public:
 
    static Bool_t GetIgnoreSizeForCameraInterest();
    static void   SetIgnoreSizeForCameraInterest(Bool_t isfci);
+
+   static void   SetEnvDefaults();
 
    ClassDef(TGLLogicalShape,0) // a logical (non-placed, local frame) drawable object
 };

--- a/graf3d/gl/inc/TGLUtil.h
+++ b/graf3d/gl/inc/TGLUtil.h
@@ -91,7 +91,7 @@ public:
    TGLVertex3(Double_t x, Double_t y, Double_t z);
    TGLVertex3(Double_t* v);
    TGLVertex3(const TGLVertex3 & other);
-   virtual ~TGLVertex3();
+   ~TGLVertex3();
 
    Bool_t       operator == (const TGLVertex3 & rhs) const;
    TGLVertex3 & operator =  (const TGLVertex3 & rhs);
@@ -127,7 +127,7 @@ public:
 
    void Dump() const;
 
-   ClassDef(TGLVertex3,1); // GL 3 component vertex helper/wrapper class
+   ClassDefNV(TGLVertex3,1); // GL 3 component vertex helper/wrapper class
 };
 
 //______________________________________________________________________________
@@ -250,7 +250,7 @@ public:
    TGLVector3(Double_t x, Double_t y, Double_t z);
    TGLVector3(const Double_t *src);
    TGLVector3(const TGLVector3 & other);
-   virtual ~TGLVector3();
+   ~TGLVector3();
 
    TGLVector3& operator = (const TGLVertex3& v)
    { fVals[0] = v[0]; fVals[1] = v[1]; fVals[2] = v[2]; return *this; }
@@ -261,7 +261,7 @@ public:
    Double_t Mag() const;
    void     Normalise();
 
-   ClassDef(TGLVector3,1); // GL 3 component vector helper/wrapper class
+   ClassDefNV(TGLVector3,1); // GL 3 component vector helper/wrapper class
 };
 
 // Inline for TGLVertex3 requiring full TGLVector definition

--- a/graf3d/gl/src/TGLLogicalShape.cxx
+++ b/graf3d/gl/src/TGLLogicalShape.cxx
@@ -13,6 +13,7 @@
 #include "TBuffer3D.h"
 #include "TClass.h"
 #include "TContextMenu.h"
+#include "TEnv.h"
 
 
 /** \class TGLLogicalShape
@@ -63,6 +64,9 @@ viewer architecture and how external viewer clients use it.
 ClassImp(TGLLogicalShape);
 
 Bool_t TGLLogicalShape::fgIgnoreSizeForCameraInterest = kFALSE;
+
+Bool_t TGLLogicalShape::fgUseDLs            = kTRUE;
+Bool_t TGLLogicalShape::fgUseDLsForVertArrs = kTRUE;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor.
@@ -284,7 +288,7 @@ Bool_t TGLLogicalShape::SetDLCache(Bool_t cache)
 
 Bool_t TGLLogicalShape::ShouldDLCache(const TGLRnrCtx& rnrCtx) const
 {
-   if (!fDLCache || !fScene   ||
+   if (!fDLCache || !fScene ||
        (rnrCtx.SecSelection() && SupportsSecondarySelect()))
    {
       return kFALSE;
@@ -382,7 +386,7 @@ entry_point:
    // MT: I can't see how this could happen right now ... with
    // rendering from a flat drawable-list.
 
-   if (!ShouldDLCache(rnrCtx) || rnrCtx.IsDLCaptureOpen())
+   if (!fgUseDLs || !ShouldDLCache(rnrCtx) || rnrCtx.IsDLCaptureOpen())
    {
       DirectDraw(rnrCtx);
       return;
@@ -485,4 +489,19 @@ Bool_t TGLLogicalShape::GetIgnoreSizeForCameraInterest()
 void TGLLogicalShape::SetIgnoreSizeForCameraInterest(Bool_t isfci)
 {
    fgIgnoreSizeForCameraInterest = isfci;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Load GL shape settings from ROOT's TEnv into static data members.
+
+void TGLLogicalShape::SetEnvDefaults()
+{
+   fgUseDLs            = gEnv->GetValue("OpenGL.UseDisplayLists", 1);
+   fgUseDLsForVertArrs = gEnv->GetValue("OpenGL.UseDisplayListsForVertexArrays", 1);
+
+   if (!fgUseDLs || !fgUseDLsForVertArrs)
+   {
+      printf("TGLLogicalShape::SetEnvDefaults() fgUseDLs=%d, fgUseDLsForVertArrs=%d\n",
+             fgUseDLs, fgUseDLsForVertArrs);
+   }
 }

--- a/graf3d/gl/src/TGLScene.cxx
+++ b/graf3d/gl/src/TGLScene.cxx
@@ -281,7 +281,10 @@ TGLScene::TGLScene() :
    fInSmartRefresh(kFALSE),
    fLastPointSizeScale (0),
    fLastLineWidthScale (0)
-{}
+{
+   if (fSceneID == 1)
+      TGLLogicalShape::SetEnvDefaults();
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Destroy scene objects


### PR DESCRIPTION
Some MesaGL implementations (since 2016) have trouble (segv) when one tries
to store vertex array operations into display lists. The following options allow complete or partial
disablement of display list usage.
OpenGL.UseDisplayLists:                     1
OpenGL.UseDisplayListsForVertexArrays:      1

OpenGL.UseDisplayLists already works.

Handling of OpenGL.UseDisplayListsForVertexArrays still needs to be
implemented as it requires review of all GL rendering classes but the cover-all case should allow people to get past this hurdle already.