### PR TITLE
optimize xml reading in TMVA (at least for CMS use case)

### DIFF
--- a/tmva/tmva/inc/TMVA/Tools.h
+++ b/tmva/tmva/inc/TMVA/Tools.h
@@ -61,6 +61,8 @@
 
 #include "TString.h"
 
+#include "TMVA/MsgLogger.h"
+
 class TList;
 class TTree;
 class TH1;
@@ -248,6 +250,10 @@ namespace TMVA {
       template<typename T>
          inline void ReadAttr    ( void* node, const char* , T& value );
       void        ReadAttr    ( void* node, const char* attrname, TString& value );
+      void ReadAttr    ( void* node, const char* , float& value );
+      void ReadAttr    ( void* node, const char* , int& value );  
+      void ReadAttr    ( void* node, const char* , short& value );
+
       template<typename T>
          void        AddAttr     ( void* node, const char* , const T& value, Int_t precision = 16 );
       void        AddAttr     ( void* node, const char* attrname, const char* value );
@@ -283,11 +289,15 @@ namespace TMVA {
 
 template<typename T> void TMVA::Tools::ReadAttr( void* node, const char* attrname, T& value )
 {
-   TString val;
-   ReadAttr( node, attrname, val );
-   std::stringstream s(val.Data());
-   // coverity[tainted_data_argument]
-   s >> value;
+  // read attribute from xml
+  const char* val = xmlengine().GetAttr(node, attrname);
+  if ( val == 0 ) {
+    const char * nodename = xmlengine().GetNodeName(node);
+    Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" << Endl;
+  }
+  std::stringstream s(val);
+  // coverity[tainted_data_argument]
+  s >> value;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/inc/TMVA/Tools.h
+++ b/tmva/tmva/inc/TMVA/Tools.h
@@ -250,9 +250,9 @@ namespace TMVA {
       template<typename T>
          inline void ReadAttr    ( void* node, const char* , T& value );
       void        ReadAttr    ( void* node, const char* attrname, TString& value );
-      void ReadAttr    ( void* node, const char* , float& value );
-      void ReadAttr    ( void* node, const char* , int& value );  
-      void ReadAttr    ( void* node, const char* , short& value );
+      void ReadAttr( void* node, const char* , float& value );
+      void ReadAttr( void* node, const char* , int& value );  
+      void ReadAttr( void* node, const char* , short& value );
 
       template<typename T>
          void        AddAttr     ( void* node, const char* , const T& value, Int_t precision = 16 );
@@ -289,15 +289,15 @@ namespace TMVA {
 
 template<typename T> void TMVA::Tools::ReadAttr( void* node, const char* attrname, T& value )
 {
-  // read attribute from xml
-  const char* val = xmlengine().GetAttr(node, attrname);
-  if ( val == 0 ) {
-    const char * nodename = xmlengine().GetNodeName(node);
-    Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" << Endl;
-  }
-  std::stringstream s(val);
-  // coverity[tainted_data_argument]
-  s >> value;
+   // read attribute from xml
+   const char* val = xmlengine().GetAttr(node, attrname);
+   if ( val == 0 ) {
+      const char * nodename = xmlengine().GetNodeName(node);
+      Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" << Endl;
+   }
+   std::stringstream s(val);
+   // coverity[tainted_data_argument]
+   s >> value;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/inc/TMVA/Tools.h
+++ b/tmva/tmva/inc/TMVA/Tools.h
@@ -250,9 +250,9 @@ namespace TMVA {
       template<typename T>
          inline void ReadAttr    ( void* node, const char* , T& value );
       void        ReadAttr    ( void* node, const char* attrname, TString& value );
-      void ReadAttr(void *node, const char*, float& value);
-      void ReadAttr(void *node, const char*, int& value);  
-      void ReadAttr(void *node, const char*, short& value);
+      void ReadAttr(void *node, const char *, float &value);
+      void ReadAttr(void *node, const char *, int &value);
+      void ReadAttr(void *node, const char *, short &value);
 
       template<typename T>
          void        AddAttr     ( void* node, const char* , const T& value, Int_t precision = 16 );
@@ -293,7 +293,7 @@ template<typename T> void TMVA::Tools::ReadAttr( void* node, const char* attrnam
    const char *val = xmlengine().GetAttr(node, attrname);
    if (val == 0) {
       const char *nodename = xmlengine().GetNodeName(node);
-      Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" 
+      Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'"
             << Endl;
    }
    std::stringstream s(val);

--- a/tmva/tmva/inc/TMVA/Tools.h
+++ b/tmva/tmva/inc/TMVA/Tools.h
@@ -250,9 +250,9 @@ namespace TMVA {
       template<typename T>
          inline void ReadAttr    ( void* node, const char* , T& value );
       void        ReadAttr    ( void* node, const char* attrname, TString& value );
-      void ReadAttr( void* node, const char* , float& value );
-      void ReadAttr( void* node, const char* , int& value );  
-      void ReadAttr( void* node, const char* , short& value );
+      void ReadAttr(void *node, const char*, float& value);
+      void ReadAttr(void *node, const char*, int& value);  
+      void ReadAttr(void *node, const char*, short& value);
 
       template<typename T>
          void        AddAttr     ( void* node, const char* , const T& value, Int_t precision = 16 );
@@ -290,10 +290,11 @@ namespace TMVA {
 template<typename T> void TMVA::Tools::ReadAttr( void* node, const char* attrname, T& value )
 {
    // read attribute from xml
-   const char* val = xmlengine().GetAttr(node, attrname);
-   if ( val == 0 ) {
-      const char * nodename = xmlengine().GetNodeName(node);
-      Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" << Endl;
+   const char *val = xmlengine().GetAttr(node, attrname);
+   if (val == 0) {
+      const char *nodename = xmlengine().GetNodeName(node);
+      Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" 
+            << Endl;
    }
    std::stringstream s(val);
    // coverity[tainted_data_argument]

--- a/tmva/tmva/src/Tools.cxx
+++ b/tmva/tmva/src/Tools.cxx
@@ -557,7 +557,7 @@ void TMVA::Tools::UsefulSortAscending( std::vector<vector<Double_t> >& v, std::v
                for (UInt_t k=0; k< nArrays; k++) {
                   temp = v[k][j-1]; v[k][j-1] = v[k][j]; v[k][j] = temp;
                }
-               if (NULL != vs) {
+               if (nullptr != vs) {
                   TString temps = (*vs)[j-1]; (*vs)[j-1] = (*vs)[j]; (*vs)[j] = temps;
                }
             }
@@ -584,7 +584,7 @@ void TMVA::Tools::UsefulSortDescending( std::vector<std::vector<Double_t> >& v, 
                for (UInt_t k=0; k< nArrays; k++) {
                   temp = v[k][j-1]; v[k][j-1] = v[k][j]; v[k][j] = temp;
                }
-               if (NULL != vs) {
+               if (nullptr != vs) {
                   TString temps = (*vs)[j-1]; (*vs)[j-1] = (*vs)[j]; (*vs)[j] = temps;
                }
             }
@@ -1795,7 +1795,7 @@ void TMVA::Tools::ReadAttr(void *node, const char *attrname, float &value)
 {
    // read attribute from xml
    const char *val = xmlengine().GetAttr(node, attrname);
-   if (val == NULL) {
+   if (val == nullptr) {
       const char *nodename = xmlengine().GetNodeName(node);
       Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'"
             << Endl;
@@ -1807,7 +1807,7 @@ void TMVA::Tools::ReadAttr(void *node, const char *attrname, int &value)
 {
    // read attribute from xml
    const char *val = xmlengine().GetAttr(node, attrname);
-   if (val == NULL) {
+   if (val == nullptr) {
       const char *nodename = xmlengine().GetNodeName(node);
       Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'"
             << Endl;
@@ -1819,7 +1819,7 @@ void TMVA::Tools::ReadAttr(void *node, const char *attrname, short &value)
 {
    // read attribute from xml
    const char *val = xmlengine().GetAttr(node, attrname);
-   if (val == NULL) {
+   if (val == nullptr) {
       const char *nodename = xmlengine().GetNodeName(node);
       Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'"
             << Endl;

--- a/tmva/tmva/src/Tools.cxx
+++ b/tmva/tmva/src/Tools.cxx
@@ -1794,35 +1794,35 @@ TH1* TMVA::Tools::GetCumulativeDist( TH1* h)
 void TMVA::Tools::ReadAttr( void* node, const char* attrname, float& value )
 {
    // read attribute from xml
-   const char* val = xmlengine().GetAttr(node, attrname);
-   if ( val == NULL ) {
-      const char * nodename = xmlengine().GetNodeName(node);
-      Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" << Endl;
-   }
-   else 
+   const char *val = xmlengine().GetAttr(node, attrname);
+   if (val == NULL) {
+      const char *nodename = xmlengine().GetNodeName(node);
+      Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" 
+            << Endl;
+   } else 
       value = atof(val);
 }
 
 void TMVA::Tools::ReadAttr( void* node, const char* attrname, int& value )
 {
    // read attribute from xml
-   const char* val = xmlengine().GetAttr(node, attrname);
-   if ( val == NULL ) {
-      const char * nodename = xmlengine().GetNodeName(node);
-      Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" << Endl;
-   }
-   else
+   const char *val = xmlengine().GetAttr(node, attrname);
+   if (val == NULL) {
+      const char *nodename = xmlengine().GetNodeName(node);
+      Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" 
+            << Endl;
+   } else
       value = atoi(val);
 }
 
 void TMVA::Tools::ReadAttr( void* node, const char* attrname, short& value )
 {
    // read attribute from xml
-   const char* val = xmlengine().GetAttr(node, attrname);
-   if ( val == NULL ) {
-      const char * nodename = xmlengine().GetNodeName(node);
-      Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" << Endl;
-   }
-   else
+   const char *val = xmlengine().GetAttr(node, attrname);
+   if (val == NULL) {
+      const char *nodename = xmlengine().GetNodeName(node);
+      Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" 
+            << Endl;
+   } else
       value = atoi(val);
 }

--- a/tmva/tmva/src/Tools.cxx
+++ b/tmva/tmva/src/Tools.cxx
@@ -1795,31 +1795,34 @@ void TMVA::Tools::ReadAttr( void* node, const char* attrname, float& value )
 {
    // read attribute from xml
    const char* val = xmlengine().GetAttr(node, attrname);
-   if ( val == 0 ) {
+   if ( val == NULL ) {
       const char * nodename = xmlengine().GetNodeName(node);
       Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" << Endl;
    }
-   value = atof(val);
+   else 
+      value = atof(val);
 }
 
 void TMVA::Tools::ReadAttr( void* node, const char* attrname, int& value )
 {
    // read attribute from xml
    const char* val = xmlengine().GetAttr(node, attrname);
-   if ( val == 0 ) {
+   if ( val == NULL ) {
       const char * nodename = xmlengine().GetNodeName(node);
       Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" << Endl;
    }
-   value = atoi(val);
+   else
+      value = atoi(val);
 }
 
 void TMVA::Tools::ReadAttr( void* node, const char* attrname, short& value )
 {
    // read attribute from xml
    const char* val = xmlengine().GetAttr(node, attrname);
-   if ( val == 0 ) {
+   if ( val == NULL ) {
       const char * nodename = xmlengine().GetNodeName(node);
       Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" << Endl;
    }
-   value = atoi(val);
+   else
+      value = atoi(val);
 }

--- a/tmva/tmva/src/Tools.cxx
+++ b/tmva/tmva/src/Tools.cxx
@@ -1790,3 +1790,36 @@ TH1* TMVA::Tools::GetCumulativeDist( TH1* h)
    }
    return cumulativeDist;
 }
+
+void TMVA::Tools::ReadAttr( void* node, const char* attrname, float& value )
+{
+  // read attribute from xml
+  const char* val = xmlengine().GetAttr(node, attrname);
+  if ( val == 0 ) {
+    const char * nodename = xmlengine().GetNodeName(node);
+    Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" << Endl;
+  }
+  value = atof(val);
+}
+
+void TMVA::Tools::ReadAttr( void* node, const char* attrname, int& value )
+{
+  // read attribute from xml
+  const char* val = xmlengine().GetAttr(node, attrname);
+  if ( val == 0 ) {
+    const char * nodename = xmlengine().GetNodeName(node);
+    Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" << Endl;
+  }
+  value = atoi(val);
+}
+
+void TMVA::Tools::ReadAttr( void* node, const char* attrname, short& value )
+{
+  // read attribute from xml
+  const char* val = xmlengine().GetAttr(node, attrname);
+  if ( val == 0 ) {
+    const char * nodename = xmlengine().GetNodeName(node);
+    Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" << Endl;
+  }
+  value = atoi(val);
+}

--- a/tmva/tmva/src/Tools.cxx
+++ b/tmva/tmva/src/Tools.cxx
@@ -1793,33 +1793,33 @@ TH1* TMVA::Tools::GetCumulativeDist( TH1* h)
 
 void TMVA::Tools::ReadAttr( void* node, const char* attrname, float& value )
 {
-  // read attribute from xml
-  const char* val = xmlengine().GetAttr(node, attrname);
-  if ( val == 0 ) {
-    const char * nodename = xmlengine().GetNodeName(node);
-    Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" << Endl;
-  }
-  value = atof(val);
+   // read attribute from xml
+   const char* val = xmlengine().GetAttr(node, attrname);
+   if ( val == 0 ) {
+      const char * nodename = xmlengine().GetNodeName(node);
+      Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" << Endl;
+   }
+   value = atof(val);
 }
 
 void TMVA::Tools::ReadAttr( void* node, const char* attrname, int& value )
 {
-  // read attribute from xml
-  const char* val = xmlengine().GetAttr(node, attrname);
-  if ( val == 0 ) {
-    const char * nodename = xmlengine().GetNodeName(node);
-    Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" << Endl;
-  }
-  value = atoi(val);
+   // read attribute from xml
+   const char* val = xmlengine().GetAttr(node, attrname);
+   if ( val == 0 ) {
+      const char * nodename = xmlengine().GetNodeName(node);
+      Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" << Endl;
+   }
+   value = atoi(val);
 }
 
 void TMVA::Tools::ReadAttr( void* node, const char* attrname, short& value )
 {
-  // read attribute from xml
-  const char* val = xmlengine().GetAttr(node, attrname);
-  if ( val == 0 ) {
-    const char * nodename = xmlengine().GetNodeName(node);
-    Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" << Endl;
-  }
-  value = atoi(val);
+   // read attribute from xml
+   const char* val = xmlengine().GetAttr(node, attrname);
+   if ( val == 0 ) {
+      const char * nodename = xmlengine().GetNodeName(node);
+      Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" << Endl;
+   }
+   value = atoi(val);
 }

--- a/tmva/tmva/src/Tools.cxx
+++ b/tmva/tmva/src/Tools.cxx
@@ -1791,37 +1791,37 @@ TH1* TMVA::Tools::GetCumulativeDist( TH1* h)
    return cumulativeDist;
 }
 
-void TMVA::Tools::ReadAttr( void* node, const char* attrname, float& value )
+void TMVA::Tools::ReadAttr(void *node, const char *attrname, float &value)
 {
    // read attribute from xml
    const char *val = xmlengine().GetAttr(node, attrname);
    if (val == NULL) {
       const char *nodename = xmlengine().GetNodeName(node);
-      Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" 
+      Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'"
             << Endl;
-   } else 
+   } else
       value = atof(val);
 }
 
-void TMVA::Tools::ReadAttr( void* node, const char* attrname, int& value )
+void TMVA::Tools::ReadAttr(void *node, const char *attrname, int &value)
 {
    // read attribute from xml
    const char *val = xmlengine().GetAttr(node, attrname);
    if (val == NULL) {
       const char *nodename = xmlengine().GetNodeName(node);
-      Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" 
+      Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'"
             << Endl;
    } else
       value = atoi(val);
 }
 
-void TMVA::Tools::ReadAttr( void* node, const char* attrname, short& value )
+void TMVA::Tools::ReadAttr(void *node, const char *attrname, short &value)
 {
    // read attribute from xml
    const char *val = xmlengine().GetAttr(node, attrname);
    if (val == NULL) {
       const char *nodename = xmlengine().GetNodeName(node);
-      Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'" 
+      Log() << kFATAL << "Trying to read non-existing attribute '" << attrname << "' from xml node '" << nodename << "'"
             << Endl;
    } else
       value = atoi(val);


### PR DESCRIPTION
Primary changes proposed
 - avoiding char to TString to char conversions
 - avoid redundant call to xmlEngine().hasattr(node,att) checking instead for null ptr from getattr.
 - Add specialization of void TMVA::Tools::ReadAttr( void* node, const char* attrname, T& value ) for float,int, short. [which seem to be the ones we use aside from bool, which now is the biggest contributor to ReadAttr* timing.