### PR TITLE
Allow user to turn off support for libAfterImage

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -306,7 +306,7 @@ if(asimage)
 endif()
 
 #---Check for AfterImage---------------------------------------------------------------
-if(NOT builtin_afterimage)
+if(asimage AND NOT builtin_afterimage)
   message(STATUS "Looking for AfterImage")
   find_package(AfterImage)
   if(NOT AFTERIMAGE_FOUND)


### PR DESCRIPTION
The current setup builds the bundled libAfterImage by force,
even when support for X11 is disabled, which is a problem when
building ROOT on a headless server or with the Intel compiler.