### PR TITLE
Add support for LZ4 in classic build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,10 @@ project.xcworkspace
 # /core/lzma/src/
 /core/lzma/src/xz-5.2.1
 
+# /core/lz4/src
+/core/lz4/src/*.tar.gz
+/core/lz4/src/lz4-*
+
 # /core/metautils/src/
 /core/metautils/src/stlLoader_set.cc
 /core/metautils/src/stlLoader_map2.cc

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ MODULES       = build interpreter/llvm interpreter/cling core/foundation \
                 core/clingutils core/dictgen core/metacling \
                 core/pcre core/clib \
                 core/textinput core/base core/cont core/meta core/thread \
-                io/rootpcm io/io math/mathcore net/net core/zip core/lzma \
+                io/rootpcm io/io math/mathcore net/net core/zip core/lzma core/lz4 \
                 math/matrix \
                 core/newdelete hist/hist hist/unfold tree/tree graf2d/freetype \
                 graf2d/mathtext graf2d/graf graf2d/gpad graf3d/g3d \
@@ -587,7 +587,7 @@ COREDICTHDEP  = $(BASEDICTH) $(CONTH) $(METAH) $(SYSTEMDH) \
 		$(ZIPDICTH) $(CLIBHH) $(FOUNDATIONH) $(TEXTINPUTH)
 COREDICTH     = $(BASEDICTH) $(CONTH) $(METAH) $(SYSTEMDICTH) \
                 $(ZIPDICTH) $(CLIBHH) $(FOUNDATIONH) $(TEXTINPUTH)
-COREO         = $(BASEO) $(CONTO) $(FOUNDATIONO) $(METAO) $(SYSTEMO) $(ZIPO) $(LZMAO) \
+COREO         = $(BASEO) $(CONTO) $(FOUNDATIONO) $(METAO) $(SYSTEMO) $(ZIPO) $(LZMAO) $(LZ4O) \
                 $(CLIBO) $(TEXTINPUTO)
 
 CORELIB      := $(LPATH)/libCore.$(SOEXT)
@@ -604,6 +604,14 @@ STATICEXTRALIBS += $(LZMALIBDIR) $(LZMACLILIB)
 else
 CORELIBEXTRA    += $(LZMALIB)
 STATICEXTRALIBS += $(LZMALIB)
+endif
+
+ifneq ($(BUILTINLZ4),yes)
+CORELIBEXTRA    += $(LZ4LIBDIR) $(LZ4CLILIB)
+STATICEXTRALIBS += $(LZ4LIBDIR) $(LZ4CLILIB)
+else
+CORELIBEXTRA    += $(LZ4LIB)
+STATICEXTRALIBS += $(LZ4LIB)
 endif
 
 ##### In case shared libs need to resolve all symbols (e.g.: aix, win32) #####

--- a/config/Makefile.in
+++ b/config/Makefile.in
@@ -137,6 +137,11 @@ LZMALIBDIR     := @lzmalibdir@
 LZMACLILIB     := @lzmalib@
 LZMAINCDIR     := $(filter-out /usr/include, @lzmaincdir@)
 
+BUILTINLZ4     := @builtinlz4@
+LZ4LIBDIR      := @lz4libdir@
+LZ4CLILIB      := @lz4lib@
+LZ4INCDIR      := $(filter-out /usr/include, @lz4incdir@)
+
 BUILDGL        := @buildgl@
 OPENGLLIBDIR   := @opengllibdir@
 OPENGLULIB     := @openglulib@

--- a/configure
+++ b/configure
@@ -67,6 +67,7 @@ options="                    \
    enable_builtin_unuran     \
    enable_builtin_zlib       \
    enable_builtin_lzma       \
+   enable_builtin_lz4        \
    enable_builtin_llvm       \
    enable_cxx14              \
    enable_cxx17              \
@@ -204,6 +205,7 @@ enable_builtin_pcre=no
 enable_builtin_unuran=no
 enable_builtin_zlib=no
 enable_builtin_lzma=no
+enable_builtin_lz4=yes
 enable_builtin_llvm=yes
 enable_afdsmgrd=no
 enable_search_usrlocal=yes
@@ -236,6 +238,7 @@ LIBTIFF          \
 LIBJPEG          \
 LIBPNG           \
 LZMA             \
+LZ4              \
 OPENGL           \
 MYSQL            \
 ORACLE           \
@@ -1732,6 +1735,7 @@ enable/disable options, prefix with either --enable- or --disable-
   builtin-unuran     Build included libunuran, or use system libunuran
   builtin-zlib       Build included libz, or use system libz
   builtin-lzma       Build included liblzma, or use system liblzma
+  builtin-lz4        Build included liblz4, or use system liblz4
   libcxx             Build using libc++, required by clang option (MacOS X only, for the time being)
   cxx14              Build using C++14 compatible mode, requires gcc > 4.9.x or clang
   cxx17              Build using C++14 compatible mode, requires gcc > 7.1.x or clang > 3.9
@@ -2083,6 +2087,7 @@ win32)
    enable_builtin_unuran="yes"
    enable_builtin_zlib="yes"
    enable_builtin_lzma="yes"
+   enable_builtin_lz4="yes"
    top_builddir=`cygpath -u $top_builddir`
    top_srcdir=`cygpath -u $top_srcdir`
    ;;
@@ -3484,6 +3489,48 @@ if test "x$enable_builtin_lzma" = "xno" ; then
 fi
 message "Checking whether to build included lzma"
 result "$enable_builtin_lzma"
+
+######################################################################
+#
+### echo %%% Use included lz4 or use systems
+#
+# (See http://lz4.github.io/lz4/)
+#
+if test "x$enable_builtin_lz4" = "xno" ; then
+    check_header "lz4.h" "" \
+        $LZ4 ${LZ4:+$LZ4/include} \
+        ${finkdir:+$finkdir/include} \
+        /usr/local/include /usr/include \
+        /usr/local/include/lz4 /usr/include/lz4 \
+        /opt/lz4/include
+    if test "x$found_dir" = "x" ; then
+        enable_builtin_lz4=yes
+    else
+        lz4inc=$found_hdr
+        lz4incdir=$found_dir
+    fi
+
+    check_library "liblz4" "$enable_shared" "" \
+        $LZ4 ${LZ4:+$LZ4/lib} \
+        ${finkdir:+$finkdir/lib} \
+        /usr/local/lz4/lib /usr/local/lib \
+        /usr/lib/lz4 /usr/local/lib/lz4 /usr/lz4/lib /usr/lib \
+        /usr/lz4 /usr/local/lz4 /opt/lz4 /opt/lz4/lib
+    if test "x$found_lib" = "x" ; then
+        lz4lib=""
+        lz4libdir=""
+        enable_builtin_lz4="yes"
+    else
+        lz4lib="$found_lib"
+        lz4libdir="$found_dir"
+    fi
+
+    if test "x$lz4incdir" = "x" || test "x$lz4lib" = "x"; then
+        enable_builtin_lz4="yes"
+    fi
+fi
+message "Checking whether to build included lz4"
+result "$enable_builtin_lz4"
 
 ######################################################################
 #
@@ -7849,6 +7896,10 @@ sed -e "s|@aclocaldir@|$aclocaldir|"            \
     -e "s|@lzmaincdir@|$lzmaincdir|"            \
     -e "s|@lzmalib@|$lzmalib|"                  \
     -e "s|@lzmalibdir@|$lzmalibdir|"            \
+    -e "s|@builtinlz4@|$enable_builtin_lz4|"  \
+    -e "s|@lz4incdir@|$lz4incdir|"            \
+    -e "s|@lz4lib@|$lz4lib|"                  \
+    -e "s|@lz4libdir@|$lz4libdir|"            \
     -e "s|@buildroofit@|$enable_roofit|"        \
     -e "s|@buildminuit2@|$enable_minuit2|"      \
     -e "s|@buildunuran@|$enable_unuran|"        \

--- a/core/lz4/Module.mk
+++ b/core/lz4/Module.mk
@@ -1,0 +1,199 @@
+# Module.mk for lz4 module
+# Copyright (c) 2017 Rene Brun and Fons Rademakers
+#
+# Author: Brian Bockelman, 29/5/2017
+
+MODNAME      := lz4
+MODDIR       := $(ROOT_SRCDIR)/core/$(MODNAME)
+MODDIRS      := $(MODDIR)/src
+MODDIRI      := $(MODDIR)/inc
+
+LZ4DIR      := $(MODDIR)
+LZ4DIRS     := $(LZ4DIR)/src
+LZ4DIRI     := $(LZ4DIR)/inc
+
+LZ4VERS     := 1.7.5
+ifeq ($(BUILTINLZ4),yes)
+LZ4LIBDIRS  := $(call stripsrc,$(MODDIRS)/lz4-$(LZ4VERS))
+LZ4LIBDIRI  := -I$(LZ4LIBDIRS)/lib
+else
+LZ4LIBDIRS  :=
+LZ4LIBDIRI  := $(LZ4INCDIR:%=-I%)
+endif
+
+##### liblz4.a #####
+ifeq ($(BUILTINLZ4),yes)
+ifeq ($(PLATFORM),win32)
+LZ4LIBDIRI  := -I$(LZ4LIBDIRS)/include
+LZ4LIBS     := $(MODDIRS)/$(LZ4VERS).tar.gz
+LZ4LIBA     := $(LZ4LIBDIRS)/lib/liblz4.lib
+LZ4DLLA     := $(LZ4LIBDIRS)/lib/liblz4.dll
+LZ4LIB      := $(LPATH)/liblz4.lib
+else
+LZ4LIBS     := $(MODDIRS)/$(LZ4VERS).tar.gz
+LZ4LIBA     := $(LZ4LIBDIRS)/lib/liblz4.a
+LZ4LIB      := $(LPATH)/liblz4.a
+endif
+LZ4LIBDEP   := $(LZ4LIB)
+else
+LZ4LIBA     := $(LZ4LIBDIR) $(LZ4CLILIB)
+LZ4LIB      := $(LZ4LIBDIR) $(LZ4CLILIB)
+LZ4LIBDEP   :=
+endif
+
+##### ZipLZ4, part of libCore #####
+LZ4H        := $(MODDIRI)/ZipLZ4.h
+LZ4S        := $(MODDIRS)/ZipLZ4.c
+LZ4O        := $(call stripsrc,$(LZ4S:.c=.o))
+
+LZ4DEP      := $(LZ4O:.o=.d)
+
+ifeq ($(BUILTINLZ4),yes)
+ifeq ($(PLATFORM),win32)
+LZ4DLL      := bin/liblz4.dll
+ALLLIBS += $(LZ4DLL)
+endif
+endif
+
+# used in the main Makefile
+ALLHDRS      += $(patsubst $(MODDIRI)/%.h,include/%.h,$(LZ4H))
+
+# include all dependency files
+INCLUDEFILES += $(LZ4DEP)
+
+##### local rules #####
+.PHONY:         all-$(MODNAME) clean-$(MODNAME) distclean-$(MODNAME)
+
+include/%.h:    $(LZ4DIRI)/%.h
+		cp $< $@
+
+ifeq ($(BUILTINLZ4),yes)
+$(LZ4LIB):     $(LZ4LIBA)
+		cp $< $@
+endif
+
+ifeq ($(PLATFORM),win32)
+$(LZ4DLL):      $(LZ4LIBA)
+		cp $(LZ4DLLA) $@
+endif
+
+$(LZ4LIBA):
+		$(MAKEDIR)
+ifeq ($(PLATFORM),win32)
+		@(if [ -d $(LZ4LIBDIRS) ]; then \
+			rm -rf $(LZ4LIBDIRS); \
+		fi; \
+                echo "*** Downloading http://github.com/lz4/v$(LZ4VERS).tar.gz..."; \
+                curl -L https://github.com/lz4/lz4/archive/v$(LZ4VERS).tar.gz > $(LZ4LIBS) \
+		echo "*** Extracting $@..."; \
+		cd $(call stripsrc,$(LZ4DIRS)); \
+		if [ ! -d lz4-$(LZ4VERS) ]; then \
+			gunzip -c $(LZ4LIBS) | tar xf -; \
+		fi; \
+		touch $(LZ4VERS)/lib/liblz4.lib;)
+else
+		@(if [ -d $(LZ4LIBDIRS) ]; then \
+			rm -rf $(LZ4LIBDIRS); \
+		fi; \
+                echo "*** Downloading http://github.com/lz4/v$(LZ4VERS).tar.gz..."; \
+                curl -L https://github.com/lz4/lz4/archive/v$(LZ4VERS).tar.gz > $(LZ4LIBS); \
+		echo "*** Building $@..."; \
+		cd $(call stripsrc,$(LZ4DIRS)); \
+		if [ ! -d lz4-$(LZ4VERS) ]; then \
+			gunzip -c $(LZ4LIBS) | tar xf -; \
+		fi; \
+		cd lz4-$(LZ4VERS); \
+		LZ4CC="$(CC)"; \
+		if [ "$(CC)" = "icc" ]; then \
+			LZ4CC="icc -wd188 -wd181 -wd1292 -wd10006 -wd10156 -wd2259 -wd981 -wd128"; \
+		fi; \
+		if [ $(ARCH) = "linux" ]; then \
+			LZ4CC="$$LZ4CC -m32"; \
+			LZ4_CFLAGS="-m32"; \
+		fi; \
+		if [ $(ARCH) = "linuxx8664gcc" ]; then \
+			LZ4CC="$$LZ4CC -m64"; \
+			LZ4_CFLAGS="-m64"; \
+		fi; \
+		if [ $(ARCH) = "linuxx32gcc" ]; then \
+			LZ4CC="$$LZ4CC -mx32"; \
+			LZ4_CFLAGS="-mx32"; \
+		fi; \
+		if [ $(ARCH) = "linuxicc" ]; then \
+			LZ4CC="$$LZ4CC -m32"; \
+			LZ4_CFLAGS="-m32"; \
+		fi; \
+		if [ $(ARCH) = "linuxx8664icc" ]; then \
+			LZ4CC="$$LZ4CC -m64"; \
+			LZ4_CFLAGS="-m64"; \
+		fi; \
+		if [ $(ARCH) = "linuxx8664k1omicc" ]; then \
+			LZ4CC="$$LZ4CC -m64 $(MICFLAGS)"; \
+			LZ4_CFLAGS="-m64 $(MICFLAGS)"; \
+			LZ4_HOST="--host=x86_64-unknown-linux-gnu"; \
+		fi; \
+		if [ $(ARCH) = "macosx" ]; then \
+			LZ4CC="$$LZ4CC -m32"; \
+			LZ4_CFLAGS="-m32"; \
+		fi; \
+		if [ $(ARCH) = "macosx64" ]; then \
+			LZ4CC="$$LZ4CC -m64"; \
+			LZ4_CFLAGS="-m64"; \
+		fi; \
+		if [ $(ARCH) = "iossim" ]; then \
+			LZ4_CFLAGS="-arch i386 -isysroot $(IOSSDK) -miphoneos-version-min=$(IOSVERS)"; \
+			LZ4_HOST="--host=i686-apple-darwin10"; \
+		fi; \
+		if [ $(ARCH) = "ios" ]; then \
+			LZ4_CFLAGS="-arch armv7 -isysroot $(IOSSDK) -miphoneos-version-min=$(IOSVERS)"; \
+			LZ4_HOST="--host=arm-apple-darwin10"; \
+		fi; \
+		if [ $(ARCH) = "solaris64CC5" ]; then \
+			LZ4CC="$$LZ4CC -m64"; \
+			LZ4_CFLAGS="-m64"; \
+		fi; \
+		if [ $(ARCH) = "linuxppc64gcc" ]; then \
+			LZ4CC="$$LZ4CC -m64"; \
+			LZ4_CFLAGS="-m64"; \
+		fi; \
+		if [ $(ARCH) = "linuxppcgcc" ]; then \
+			LZ4CC="$$LZ4CC -m32"; \
+			LZ4_CFLAGS="-m32"; \
+		fi; \
+		if [ $(ARCH) = "hpuxia64acc" ]; then \
+			LZ4CC="cc"; \
+			LZ4_CFLAGS="+DD64 -Ae +W863"; \
+		fi; \
+		GNUMAKE=$(MAKE) CC=$$LZ4CC CFLAGS="$$LZ4_CFLAGS -fPIC -O" \
+		$(MAKE) lib)
+endif
+
+all-$(MODNAME): $(LZ4O)
+
+clean-$(MODNAME):
+		@rm -f $(LZ4O)
+ifeq ($(BUILTINLZ4),yes)
+ifneq ($(PLATFORM),win32)
+		-@(if [ -d $(LZ4LIBDIRS) ]; then \
+			cd $(LZ4LIBDIRS); \
+			$(MAKE) clean; \
+		fi)
+endif
+endif
+
+clean::         clean-$(MODNAME)
+
+distclean-$(MODNAME): clean-$(MODNAME)
+		@rm -f $(LZ4DEP)
+		@rm -rf $(call stripsrc,$(LZ4DIRS)/$(LZ4VERS))
+		@rm -f $(LPATH)/liblz4.*
+ifeq ($(PLATFORM),win32)
+		@rm -f $(LZ4DLL)
+endif
+
+distclean::     distclean-$(MODNAME)
+
+##### extra rules ######
+$(LZ4O): $(LZ4LIBDEP)
+$(LZ4O): CFLAGS += $(LZ4LIBDIRI)
+

--- a/core/zip/src/Bits.h
+++ b/core/zip/src/Bits.h
@@ -16,7 +16,7 @@
 #include "Compression.h"
 #include "RConfigure.h"
 #include "ZipLZMA.h"
-//#include "ZipLZ4.h"
+#include "ZipLZ4.h"
 
 #include <stdio.h>
 #include <assert.h>
@@ -595,7 +595,7 @@ void R__zipMultipleAlgorithm(int cxlevel, int *srcsize, char *src, int *tgtsize,
      R__zipLZMA(cxlevel, srcsize, src, tgtsize, tgt, irep);
      return;
   } else if (compressionAlgorithm == kLZ4) {
-     // R__zipLZ4(cxlevel, srcsize, src, tgtsize, tgt, irep);
+     R__zipLZ4(cxlevel, srcsize, src, tgtsize, tgt, irep);
      return;
   }
 

--- a/core/zip/src/ZInflate.c
+++ b/core/zip/src/ZInflate.c
@@ -20,7 +20,7 @@ static const int qflag = 0;
 #include "zlib.h"
 #include "RConfigure.h"
 #include "ZipLZMA.h"
- // #include "ZipLZ4.h"
+#include "ZipLZ4.h"
 
 /* inflate.c -- put in the public domain by Mark Adler
    version c14o, 23 August 1994 */
@@ -1239,7 +1239,7 @@ void R__unzip(int *srcsize, uch *src, int *tgtsize, uch *tgt, int *irep)
      R__unzipLZMA(srcsize, src, tgtsize, tgt, irep);
      return;
   } else if (is_valid_header_lz4(src)) {
-     // R__unzipLZ4(srcsize, src, tgtsize, tgt, irep);
+     R__unzipLZ4(srcsize, src, tgtsize, tgt, irep);
      return;
   }
 


### PR DESCRIPTION
This PR adds support for LZ4 in the "classic" configure/Makefile build, adding near-parity to the `cmake`-based build.

The exception is `win32` -- `core/lz4/Module.mk` will need to be heavily tackled by someone with a Windows background (I do not have access to a Windows-based host).

@pcanal - note that this reverts the commit disabling LZ4 for the `cmake`-based build.