### PR TITLE
Add 1-vs-rest and 1-vs-1 performance measures to TMVA multiclass output

### DIFF
--- a/tmva/tmva/inc/TMVA/MethodBase.h
+++ b/tmva/tmva/inc/TMVA/MethodBase.h
@@ -298,6 +298,7 @@ namespace TMVA {
       virtual Double_t GetTrainingEfficiency(const TString& );
       virtual std::vector<Float_t> GetMulticlassEfficiency( std::vector<std::vector<Float_t> >& purity );
       virtual std::vector<Float_t> GetMulticlassTrainingEfficiency(std::vector<std::vector<Float_t> >& purity );
+      virtual TMatrixD GetMulticlassConfusionMatrix(Double_t effB, Types::ETreeType type);
       virtual Double_t GetSignificance() const;
       virtual Double_t GetROCIntegral(TH1D *histS, TH1D *histB) const;
       virtual Double_t GetROCIntegral(PDF *pdfS=0, PDF *pdfB=0) const;

--- a/tmva/tmva/inc/TMVA/ROCCurve.h
+++ b/tmva/tmva/inc/TMVA/ROCCurve.h
@@ -59,6 +59,8 @@ public:
 
    ~ROCCurve();
 
+   Double_t GetEffSForEffB(Double_t effB, const UInt_t num_points = 41);
+
    Double_t GetROCIntegral(const UInt_t points = 41);
    TGraph *GetROCCurve(const UInt_t points = 100); // n divisions = #points -1
 

--- a/tmva/tmva/inc/TMVA/ResultsMulticlass.h
+++ b/tmva/tmva/inc/TMVA/ResultsMulticlass.h
@@ -75,6 +75,9 @@ namespace TMVA {
       Float_t GetAchievablePur(UInt_t cls){return fAchievablePur.at(cls);}
       std::vector<Float_t>& GetAchievableEff(){return fAchievableEff;}
       std::vector<Float_t>& GetAchievablePur(){return fAchievablePur;}
+
+      TMatrixD GetConfusionMatrix(Double_t effB);
+
       // histogramming
       void CreateMulticlassPerformanceHistos(TString prefix);
       void     CreateMulticlassHistos( TString prefix, Int_t nbins, Int_t nbins_high);

--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -2688,15 +2688,17 @@ TMatrixD TMVA::MethodBase::GetMulticlassConfusionMatrix(Double_t effB, Types::ET
 {
    if (GetAnalysisType() != Types::kMulticlass) {
       Log() << kFATAL << "Cannot get confusion matrix for non-multiclass analysis." << std::endl;
+      return TMatrixD(0, 0);
    }
 
    Data()->SetCurrentType(type);
    ResultsMulticlass *resMulticlass =
       dynamic_cast<ResultsMulticlass *>(Data()->GetResults(GetMethodName(), type, Types::kMulticlass));
 
-   if (!resMulticlass) {
+   if (resMulticlass == nullptr) {
       Log() << kFATAL << Form("Dataset[%s] : ", DataInfo().GetName())
             << "unable to create pointer in GetMulticlassEfficiency, exiting." << Endl;
+      return TMatrixD(0, 0);
    }
 
    return resMulticlass->GetConfusionMatrix(effB);

--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -2664,6 +2664,43 @@ std::vector<Float_t> TMVA::MethodBase::GetMulticlassTrainingEfficiency(std::vect
    return resMulticlass->GetAchievableEff();
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Construct a confusion matrix for a multiclass classifier. The confusion
+/// matrix compares, in turn, each class agaist all other classes in a pair-wise
+/// fashion. In rows with index \f$ k_r = 0 ... K \f$, \f$ k_r \f$ is
+/// considered signal for the sake of comparison and for each column
+/// \f$ k_c = 0 ... K \f$ the corresponding class is considered background.
+///
+/// Note that the diagonal elements will be returned as NaN since this will
+/// compare a class against itself.
+///
+/// \see TMVA::ResultsMulticlass::GetConfusionMatrix
+///
+/// \param[in] effB The background efficiency for which to evaluate.
+/// \param[in] type The data set on which to evaluate (training, testing ...).
+///
+/// \return A matrix containing signal efficiencies for the given background
+///         efficiency. The diagonal elements are NaN since this measure is
+///         meaningless (comparing a class against itself).
+///
+
+TMatrixD TMVA::MethodBase::GetMulticlassConfusionMatrix(Double_t effB, Types::ETreeType type)
+{
+   if (GetAnalysisType() != Types::kMulticlass) {
+      Log() << kFATAL << "Cannot get confusion matrix for non-multiclass analysis." << std::endl;
+   }
+
+   Data()->SetCurrentType(type);
+   ResultsMulticlass *resMulticlass =
+      dynamic_cast<ResultsMulticlass *>(Data()->GetResults(GetMethodName(), type, Types::kMulticlass));
+
+   if (!resMulticlass) {
+      Log() << kFATAL << Form("Dataset[%s] : ", DataInfo().GetName())
+            << "unable to create pointer in GetMulticlassEfficiency, exiting." << Endl;
+   }
+
+   return resMulticlass->GetConfusionMatrix(effB);
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// compute significance of mean difference


### PR DESCRIPTION
Adds a simple comparison technique for multiclass classifiers.
1-vs-rest will do a binary comparison between given class
considered signal and all others collectively considered
background.

1-vs-1 will do pair-wise binary comparisons.

Output is in TMVA::Factory::EvaluateAllMethods