### PR TITLE
Fix build when builtin_veccore=ON

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1377,15 +1377,15 @@ elseif(veccore)
 endif()
 
 if(veccore AND NOT VecCore_FOUND)
-  set(VecCore_VERSION "0.4.0")
+  set(VecCore_VERSION "0.4.1")
   set(VecCore_PROJECT "VecCore-${VecCore_VERSION}")
   set(VecCore_SRC_URI "${lcgpackages}/${VecCore_PROJECT}.tar.gz")
-  set(VecCore_SRC_MD5 "c719909eaffbcc1d7a7680b25b6e5019")
+  set(VecCore_SRC_MD5 "7728dc706744e54a79fcb80059a31529")
   set(VecCore_DESTDIR "${CMAKE_BINARY_DIR}/VECCORE-prefix/install")
   set(VecCore_ROOTDIR "${VecCore_DESTDIR}/${CMAKE_INSTALL_PREFIX}")
 
   if(builtin_vc)
-    set(Vc_VERSION "1.3.1") # version built by VecCore
+    set(Vc_VERSION "1.3.2") # version built by VecCore
     set(Vc_LIBNAME "${CMAKE_STATIC_LIBRARY_PREFIX}Vc${CMAKE_STATIC_LIBRARY_SUFFIX}")
     set(Vc_LIBRARY "${VecCore_ROOTDIR}/lib/${Vc_LIBNAME}")
   endif()

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1443,6 +1443,20 @@ if(veccore AND NOT VecCore_FOUND)
     REQUIRED_VARS VecCore_INCLUDE_DIRS
     VERSION_VAR VecCore_VERSION)
 
+  # The following few lines are a temporary fix for a breakage introduced
+  # recently in math/mathcore VecCore integration. Once the proper solution
+  # is found, the lines below should be removed from here and added to the
+  # proper targets.
+  add_definitions(${VecCore_DEFINITIONS})
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${VecCore_DEFINITIONS}")
+  include_directories(SYSTEM BEFORE ${VecCore_INCLUDE_DIRS})
+
+  # Copy Vc and VecCore headers to build directory, otherwise dictionary generation breaks
+  add_custom_command(TARGET VECCORE POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${VecCore_INCLUDE_DIRS}/ ${CMAKE_BINARY_DIR}/include)
+
+  ### End of temporary fix
+
   install(DIRECTORY ${VecCore_ROOTDIR}/ DESTINATION ".")
 endif()
 

--- a/math/mathcore/inc/Fit/FitUtil.h
+++ b/math/mathcore/inc/Fit/FitUtil.h
@@ -367,14 +367,14 @@ namespace FitUtil {
 
             const T * x = nullptr;
             if(data.NDim() > 1) {
-                std::vector<T> xc;
-                xc.resize(data.NDim());
-                xc[0] = x1;
-                for (unsigned int j = 1; j < data.NDim(); ++j)
-                    vecCore::Load<T>(xc[j], data.GetCoordComponent(i * vecSize, j));
-                    x = xc.data();
+               std::vector<T> xc;
+               xc.resize(data.NDim());
+               xc[0] = x1;
+               for (unsigned int j = 1; j < data.NDim(); ++j)
+                  vecCore::Load<T>(xc[j], data.GetCoordComponent(i * vecSize, j));
+               x = xc.data();
             } else {
-                    x = &x1;
+               x = &x1;
             }
 
             T fval{};
@@ -484,14 +484,14 @@ namespace FitUtil {
 
             const T * x = nullptr;
             if(data.NDim() > 1) {
-                std::vector<T> xc;
-                xc.resize(data.NDim());
-                xc[0] = x1;
-                for (unsigned int j = 1; j < data.NDim(); ++j)
-                    vecCore::Load<T>(xc[j], data.GetCoordComponent(i * vecSize, j));
-                    x = xc.data();
+               std::vector<T> xc;
+               xc.resize(data.NDim());
+               xc[0] = x1;
+               for (unsigned int j = 1; j < data.NDim(); ++j)
+                  vecCore::Load<T>(xc[j], data.GetCoordComponent(i * vecSize, j));
+               x = xc.data();
             } else {
-                    x = &x1;
+               x = &x1;
             }
 
 #ifdef USE_PARAMCACHE


### PR DESCRIPTION
I realized this was broken when updating the VecCore version to 0.4.1. The new version now downloads Vc and UME::SIMD from LCG packages repository, and uses http instead of https, in order to avoid problems in systems in which curl has no support for https. I also took the oportunity to fix a few warnings due to wrong indentation of the code.