### PR TITLE
Utilize git submodules for `roottest`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,6 @@ project.xcworkspace
 /semantic.cache
 /.gdb_history
 /buildtools
-/roottest
 /*.mk
 /.project
 /files

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "roottest"]
+	path = roottest
+	url = https://github.com/root-project/roottest.git
+	branch = master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -364,7 +364,7 @@ if(testing)
                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                     OUTPUT_VARIABLE GIT_BRANCH OUTPUT_STRIP_TRAILING_WHITESPACE)
     #---Is the roottest source directory around?
-    if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/roottest)
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/roottest/CMakeLists.txt)
       set(roottestdir ${CMAKE_CURRENT_SOURCE_DIR}/roottest)
     elseif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../roottest)
       get_filename_component(roottestdir ${CMAKE_CURRENT_SOURCE_DIR}/../roottest ABSOLUTE)
@@ -374,7 +374,9 @@ if(testing)
       add_subdirectory(${roottestdir} roottest)
     else()
       message("-- Could not find roottest directory! Cloning from the repository...")
-      execute_process(COMMAND ${GIT_EXECUTABLE} clone -b ${GIT_BRANCH} http://root.cern.ch/git/roottest.git
+      execute_process(COMMAND ${GIT_EXECUTABLE} submodule init
+                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+      execute_process(COMMAND ${GIT_EXECUTABLE} submodule update
                       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
       add_subdirectory(roottest)
     endif()


### PR DESCRIPTION
The build system appears to assume that `roottest` is, by default, in a subdirectory of the source directory named `roottest`.

I'd love to make it easier to include `roottest` in builds to encourage developers to utilize it: this seems like a great use of `git submodule`!

Here's how a user would clone the `root` and `roottest` repos:
```
git clone https://github.com/root-project/root.git
cd root
git submodule init
git submodule update
```

One would then do the normal build with `cmake`.