### PR TITLE
Disable DNN Standard since it is not maintained any more

### DIFF
--- a/test/stressTMVA.cxx
+++ b/test/stressTMVA.cxx
@@ -3036,14 +3036,9 @@ void addClassificationTests( UnitTestSuite& TMVA_test, bool full=true)
       "Regularization=None,TestRepetitions=5, Multithreading=True"
       "|LearningRate=0.001,Momentum=0.0,ConvergenceSteps=20,BatchSize=256,"
       "Regularization=None,TestRepetitions=5, Multithreading=True";
-   TString configStandard = "Architecture=STANDARD:" + config;
    TString configCpu      = "Architecture=CPU:" + config;
    TString configGpu      = "Architecture=GPU:" + config;
 
-
-    TMVA_test.addTest(new MethodUnitTestWithROCLimits(
-                          TMVA::Types::kDNN, "DNN Standard",
-                          configStandard, 0.85, 0.98));
 #ifdef DNNCPU
    TMVA_test.addTest(new MethodUnitTestWithROCLimits(
                          TMVA::Types::kDNN, "DNN CPU", configCpu, 0.85, 0.98)


### PR DESCRIPTION
In response to @dpiparo pointing out this failure http://cdash.cern.ch/testDetails.php?test=25539356&build=359962.

The DNN with architecture=Standard is to phased out. In this case it would make sense to disable the corresponding test, since the failure is not to be fixed.

If this is acceptable, feel free to merge.