### PR TITLE
TMVA various fixes

### DIFF
--- a/tmva/tmva/inc/TMVA/Factory.h
+++ b/tmva/tmva/inc/TMVA/Factory.h
@@ -74,6 +74,7 @@ namespace TMVA {
    class DataSetInfo;
    class DataSetManager;
    class DataLoader;
+   class ROCCurve;
    class VariableTransformBase;
    
 
@@ -149,8 +150,8 @@ namespace TMVA {
       Bool_t IsSilentFile();
       Bool_t IsModelPersistence();
       
-      Double_t GetROCIntegral(DataLoader *loader,TString theMethodName);
-      Double_t GetROCIntegral(TString  datasetname,TString theMethodName);
+      Double_t GetROCIntegral(DataLoader *loader,TString theMethodName, UInt_t iClass=0);
+      Double_t GetROCIntegral(TString  datasetname,TString theMethodName, UInt_t iClass=0);
 
       // Methods to get a TGraph for an indicated method in dataset.
       // Optional title and axis added with fLegend=kTRUE.
@@ -179,6 +180,10 @@ namespace TMVA {
       TH1F* EvaluateImportanceRandom( DataLoader *loader,UInt_t nseeds, Types::EMVA theMethod,  TString methodTitle, const char *theOption = "" );
       
       TH1F* GetImportance(const int nbits,std::vector<Double_t> importances,std::vector<TString> varNames);
+
+      // Helpers for public facing ROC methods
+      ROCCurve * GetROC(DataLoader *loader, TString theMethodName, UInt_t iClass=0);
+      ROCCurve * GetROC(TString datasetname, TString theMethodName, UInt_t iClass=0);
       
       void WriteDataInformation(DataSetInfo&     fDataSetInfo);
 

--- a/tmva/tmva/inc/TMVA/Factory.h
+++ b/tmva/tmva/inc/TMVA/Factory.h
@@ -149,9 +149,9 @@ namespace TMVA {
 
       Bool_t IsSilentFile();
       Bool_t IsModelPersistence();
-      
-      Double_t GetROCIntegral(DataLoader *loader,TString theMethodName, UInt_t iClass=0);
-      Double_t GetROCIntegral(TString  datasetname,TString theMethodName, UInt_t iClass=0);
+
+      Double_t GetROCIntegral(DataLoader *loader, TString theMethodName, UInt_t iClass = 0);
+      Double_t GetROCIntegral(TString datasetname, TString theMethodName, UInt_t iClass = 0);
 
       // Methods to get a TGraph for an indicated method in dataset.
       // Optional title and axis added with fLegend=kTRUE.
@@ -182,9 +182,9 @@ namespace TMVA {
       TH1F* GetImportance(const int nbits,std::vector<Double_t> importances,std::vector<TString> varNames);
 
       // Helpers for public facing ROC methods
-      ROCCurve * GetROC(DataLoader *loader, TString theMethodName, UInt_t iClass=0);
-      ROCCurve * GetROC(TString datasetname, TString theMethodName, UInt_t iClass=0);
-      
+      ROCCurve *GetROC(DataLoader *loader, TString theMethodName, UInt_t iClass = 0);
+      ROCCurve *GetROC(TString datasetname, TString theMethodName, UInt_t iClass = 0);
+
       void WriteDataInformation(DataSetInfo&     fDataSetInfo);
 
       void SetInputTreesFromEventAssignTrees();

--- a/tmva/tmva/src/Factory.cxx
+++ b/tmva/tmva/src/Factory.cxx
@@ -661,51 +661,58 @@ std::map<TString,Double_t> TMVA::Factory::OptimizeAllMethods(TString fomType, TS
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Private method to generate an instance of a ROCCurve regardless of 
+/// Private method to generate an instance of a ROCCurve regardless of
 /// analysis type.
 ///
 /// \note You own the retured pointer.
-/// 
+///
 
-TMVA::ROCCurve * TMVA::Factory::GetROC(TMVA::DataLoader *loader, TString theMethodName, UInt_t iClass) {
+TMVA::ROCCurve *TMVA::Factory::GetROC(TMVA::DataLoader *loader, TString theMethodName, UInt_t iClass)
+{
    return GetROC((TString)loader->GetName(), theMethodName, iClass);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Private method to generate an instance of a ROCCurve regardless of 
+/// Private method to generate an instance of a ROCCurve regardless of
 /// analysis type.
 ///
 /// \note You own the retured pointer.
-/// 
- 
-TMVA::ROCCurve * TMVA::Factory::GetROC(TString datasetname, TString theMethodName, UInt_t iClass) {
+///
+
+TMVA::ROCCurve *TMVA::Factory::GetROC(TString datasetname, TString theMethodName, UInt_t iClass)
+{
    if (fMethodsMap.find(datasetname) == fMethodsMap.end()) {
       Log() << kERROR << Form("DataSet = %s not found in methods map.", datasetname.Data()) << Endl;
       return nullptr;
    }
-   
-   if ( ! this->HasMethod(datasetname, theMethodName) ) {
-      Log() << kERROR << Form("Method = %s not found with Dataset = %s ", theMethodName.Data(), datasetname.Data()) << Endl;
+
+   if (!this->HasMethod(datasetname, theMethodName)) {
+      Log() << kERROR << Form("Method = %s not found with Dataset = %s ", theMethodName.Data(), datasetname.Data())
+            << Endl;
       return nullptr;
    }
 
    std::set<Types::EAnalysisType> allowedAnalysisTypes = {Types::kClassification, Types::kMulticlass};
-   if ( allowedAnalysisTypes.count(this->fAnalysisType) == 0 ) {
-      Log() << kERROR << Form("Can only generate ROC curves for analysis type kClassification and kMulticlass.") << Endl;
+   if (allowedAnalysisTypes.count(this->fAnalysisType) == 0) {
+      Log() << kERROR << Form("Can only generate ROC curves for analysis type kClassification and kMulticlass.")
+            << Endl;
       return nullptr;
    }
 
-   TMVA::MethodBase *method  = dynamic_cast<TMVA::MethodBase *>( this->GetMethod(datasetname, theMethodName) );
-   TMVA::DataSet    *dataset = method->Data();
-   TMVA::Results    *results = dataset->GetResults(theMethodName, Types::kTesting, this->fAnalysisType);
-   
+   TMVA::MethodBase *method = dynamic_cast<TMVA::MethodBase *>(this->GetMethod(datasetname, theMethodName));
+   TMVA::DataSet *dataset = method->Data();
+   TMVA::Results *results = dataset->GetResults(theMethodName, Types::kTesting, this->fAnalysisType);
+
    UInt_t nClasses = method->DataInfo().GetNClasses();
-   if ( this->fAnalysisType == Types::kMulticlass && iClass >= nClasses ) {
-      Log() << kERROR << Form("Given class number (iClass = %i) does not exist. There are %i classes in dataset.", iClass, nClasses) << Endl;
+   if (this->fAnalysisType == Types::kMulticlass && iClass >= nClasses) {
+      Log() << kERROR
+            << Form("Given class number (iClass = %i) does not exist. There are %i classes in dataset.", iClass,
+                    nClasses)
+            << Endl;
       return nullptr;
    }
 
-   TMVA::ROCCurve * rocCurve = nullptr;
+   TMVA::ROCCurve *rocCurve = nullptr;
    if (this->fAnalysisType == Types::kClassification) {
 
       std::vector<Float_t> *mvaRes = dynamic_cast<ResultsClassification *>(results)->GetValueVector();
@@ -725,9 +732,9 @@ TMVA::ROCCurve * TMVA::Factory::GetROC(TString datasetname, TString theMethodNam
       std::vector<Bool_t> mvaResTypes;
       std::vector<Float_t> mvaResWeights;
 
-      std::vector<std::vector<Float_t>> * rawMvaRes = dynamic_cast<ResultsMulticlass *>(results)->GetValueVector();
-      
-      // Vector transpose due to values being stored as 
+      std::vector<std::vector<Float_t>> *rawMvaRes = dynamic_cast<ResultsMulticlass *>(results)->GetValueVector();
+
+      // Vector transpose due to values being stored as
       //    [ [0, 1, 2], [0, 1, 2], ... ]
       // in ResultsMulticlass::GetValueVector.
       mvaRes.reserve(rawMvaRes->size());
@@ -752,23 +759,23 @@ TMVA::ROCCurve * TMVA::Factory::GetROC(TString datasetname, TString theMethodNam
 ////////////////////////////////////////////////////////////////////////////////
 /// Calculate the integral of the ROC curve, also known as the area under curve
 /// (AUC), for a given method.
-/// 
-/// Argument iClass specifies the class to generate the ROC curve in a 
+///
+/// Argument iClass specifies the class to generate the ROC curve in a
 /// multiclass setting. It is ignored for binary classification.
-/// 
+///
 
 Double_t TMVA::Factory::GetROCIntegral(TMVA::DataLoader *loader, TString theMethodName, UInt_t iClass)
 {
-  return GetROCIntegral((TString)loader->GetName(), theMethodName, iClass);
+   return GetROCIntegral((TString)loader->GetName(), theMethodName, iClass);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Calculate the integral of the ROC curve, also known as the area under curve
 /// (AUC), for a given method.
-/// 
-/// Argument iClass specifies the class to generate the ROC curve in a 
+///
+/// Argument iClass specifies the class to generate the ROC curve in a
 /// multiclass setting. It is ignored for binary classification.
-/// 
+///
 
 Double_t TMVA::Factory::GetROCIntegral(TString datasetname, TString theMethodName, UInt_t iClass)
 {
@@ -784,13 +791,17 @@ Double_t TMVA::Factory::GetROCIntegral(TString datasetname, TString theMethodNam
 
    std::set<Types::EAnalysisType> allowedAnalysisTypes = {Types::kClassification, Types::kMulticlass};
    if ( allowedAnalysisTypes.count(this->fAnalysisType) == 0 ) {
-      Log() << kERROR << Form("Can only generate ROC integral for analysis type kClassification. and kMulticlass.") << Endl;
+      Log() << kERROR << Form("Can only generate ROC integral for analysis type kClassification. and kMulticlass.")
+            << Endl;
       return 0;
    }
 
    TMVA::ROCCurve *rocCurve = GetROC(datasetname, theMethodName, iClass);
    if (!rocCurve) {
-      Log() << kFATAL << Form("ROCCurve object was not created in Method = %s not found with Dataset = %s ", theMethodName.Data(), datasetname.Data()) << Endl;
+      Log() << kFATAL
+            << Form("ROCCurve object was not created in Method = %s not found with Dataset = %s ", theMethodName.Data(),
+                    datasetname.Data())
+            << Endl;
    }
 
    Int_t npoints = TMVA::gConfig().fVariablePlotting.fNbinsXOfROCCurve + 1;
@@ -1364,7 +1375,6 @@ void TMVA::Factory::EvaluateAllMethods( void )
         doMulticlass = kTRUE;
         Log() << kINFO << "Evaluate multiclass classification method: " << theMethod->GetMethodName() << Endl;
 
-
         // This part uses a genetic alg. to evaluate the optimal sig eff * sig pur.
         // This is why it is disabled for now.
         // Find approximate optimal working point w.r.t. signalEfficiency * signalPurity.
@@ -1734,7 +1744,7 @@ void TMVA::Factory::EvaluateAllMethods( void )
 
          // This part uses a genetic alg. to evaluate the optimal sig eff * sig pur.
          // This is why it is disabled for now.
-         // 
+         //
          // // --- Acheivable signal efficiency * signal purity
          // // --------------------------------------------------------------------
          // Log() << kINFO << Endl;
@@ -1946,7 +1956,8 @@ void TMVA::Factory::EvaluateAllMethods( void )
 
                   TMVA::DataSet *dataset = theMethod->Data();
                   TMVA::Results *results = dataset->GetResults(methodName, Types::kTesting, this->fAnalysisType);
-                  std::vector<Bool_t> *mvaResType = dynamic_cast<ResultsClassification *>(results)->GetValueVectorTypes();
+                  std::vector<Bool_t> *mvaResType =
+                     dynamic_cast<ResultsClassification *>(results)->GetValueVectorTypes();
 
                   Double_t rocIntegral = 0.0;
                   if (mvaResType->size() != 0) {
@@ -1955,7 +1966,8 @@ void TMVA::Factory::EvaluateAllMethods( void )
 
                   if (sep[k][i] < 0 || sig[k][i] < 0) {
                      // cannot compute separation/significance -> no MVA (usually for Cuts)
-                     Log() << kINFO << Form("%-13s %-15s: %#1.3f", datasetName.Data(), methodName.Data(), effArea[k][i]) << Endl;
+                     Log() << kINFO << Form("%-13s %-15s: %#1.3f", datasetName.Data(), methodName.Data(), effArea[k][i])
+                           << Endl;
 
                      //               Log() << kDEBUG << Form("%-20s %-15s: %#1.3f(%02i)  %#1.3f(%02i)  %#1.3f(%02i)
                      //               %#1.3f       %#1.3f | --       --",
@@ -1966,7 +1978,8 @@ void TMVA::Factory::EvaluateAllMethods( void )
                      //                       eff30[k][i], Int_t(1000*eff30err[k][i]),
                      //                       effArea[k][i],rocIntegral) << Endl;
                   } else {
-                     Log() << kINFO << Form("%-13s %-15s: %#1.3f", datasetName.Data(), methodName.Data(), rocIntegral) << Endl;
+                     Log() << kINFO << Form("%-13s %-15s: %#1.3f", datasetName.Data(), methodName.Data(), rocIntegral)
+                           << Endl;
                      //               Log() << kDEBUG << Form("%-20s %-15s: %#1.3f(%02i)  %#1.3f(%02i)  %#1.3f(%02i)
                      //               %#1.3f       %#1.3f | %#1.3f    %#1.3f",
                      //                       datasetName.Data(),

--- a/tmva/tmva/src/Factory.cxx
+++ b/tmva/tmva/src/Factory.cxx
@@ -705,9 +705,8 @@ TMVA::ROCCurve *TMVA::Factory::GetROC(TString datasetname, TString theMethodName
 
    UInt_t nClasses = method->DataInfo().GetNClasses();
    if (this->fAnalysisType == Types::kMulticlass && iClass >= nClasses) {
-      Log() << kERROR
-            << Form("Given class number (iClass = %i) does not exist. There are %i classes in dataset.", iClass,
-                    nClasses)
+      Log() << kERROR << Form("Given class number (iClass = %i) does not exist. There are %i classes in dataset.",
+                              iClass, nClasses)
             << Endl;
       return nullptr;
    }
@@ -798,9 +797,8 @@ Double_t TMVA::Factory::GetROCIntegral(TString datasetname, TString theMethodNam
 
    TMVA::ROCCurve *rocCurve = GetROC(datasetname, theMethodName, iClass);
    if (!rocCurve) {
-      Log() << kFATAL
-            << Form("ROCCurve object was not created in Method = %s not found with Dataset = %s ", theMethodName.Data(),
-                    datasetname.Data())
+      Log() << kFATAL << Form("ROCCurve object was not created in Method = %s not found with Dataset = %s ",
+                              theMethodName.Data(), datasetname.Data())
             << Endl;
       return 0;
    }

--- a/tmva/tmva/src/Factory.cxx
+++ b/tmva/tmva/src/Factory.cxx
@@ -660,12 +660,23 @@ std::map<TString,Double_t> TMVA::Factory::OptimizeAllMethods(TString fomType, TS
 
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Private method to generate an instance of a ROCCurve regardless of 
+/// analysis type.
+///
+/// \note You own the retured pointer.
+/// 
+
 TMVA::ROCCurve * TMVA::Factory::GetROC(TMVA::DataLoader *loader, TString theMethodName, UInt_t iClass) {
    return GetROC((TString)loader->GetName(), theMethodName, iClass);
 }
 
-///////
-/// NOTE: You own the retured pointer.
+////////////////////////////////////////////////////////////////////////////////
+/// Private method to generate an instance of a ROCCurve regardless of 
+/// analysis type.
+///
+/// \note You own the retured pointer.
+/// 
  
 TMVA::ROCCurve * TMVA::Factory::GetROC(TString datasetname, TString theMethodName, UInt_t iClass) {
    if (fMethodsMap.find(datasetname) == fMethodsMap.end()) {
@@ -739,6 +750,12 @@ TMVA::ROCCurve * TMVA::Factory::GetROC(TString datasetname, TString theMethodNam
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Calculate the integral of the ROC curve, also known as the area under curve
+/// (AUC), for a given method.
+/// 
+/// Argument iClass specifies the class to generate the ROC curve in a 
+/// multiclass setting. It is ignored for binary classification.
+/// 
 
 Double_t TMVA::Factory::GetROCIntegral(TMVA::DataLoader *loader, TString theMethodName, UInt_t iClass)
 {
@@ -746,6 +763,12 @@ Double_t TMVA::Factory::GetROCIntegral(TMVA::DataLoader *loader, TString theMeth
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Calculate the integral of the ROC curve, also known as the area under curve
+/// (AUC), for a given method.
+/// 
+/// Argument iClass specifies the class to generate the ROC curve in a 
+/// multiclass setting. It is ignored for binary classification.
+/// 
 
 Double_t TMVA::Factory::GetROCIntegral(TString datasetname, TString theMethodName, UInt_t iClass)
 {
@@ -759,9 +782,9 @@ Double_t TMVA::Factory::GetROCIntegral(TString datasetname, TString theMethodNam
       return 0;
    }
 
-   std::set<Types::EAnalysisType> allowedAnalysisTypes = {Types::kClassification/*, Types::kMulticlass*/};
+   std::set<Types::EAnalysisType> allowedAnalysisTypes = {Types::kClassification, Types::kMulticlass};
    if ( allowedAnalysisTypes.count(this->fAnalysisType) == 0 ) {
-      Log() << kERROR << Form("Can only generate ROC integral for analysis type kClassification."/*"and kMulticlass."*/) << Endl;
+      Log() << kERROR << Form("Can only generate ROC integral for analysis type kClassification. and kMulticlass.") << Endl;
       return 0;
    }
 

--- a/tmva/tmva/src/Factory.cxx
+++ b/tmva/tmva/src/Factory.cxx
@@ -1364,10 +1364,12 @@ void TMVA::Factory::EvaluateAllMethods( void )
         doMulticlass = kTRUE;
         Log() << kINFO << "Evaluate multiclass classification method: " << theMethod->GetMethodName() << Endl;
 
-        theMethod->TestMulticlass();
 
+        // This part uses a genetic alg. to evaluate the optimal sig eff * sig pur.
+        // This is why it is disabled for now.
         // Find approximate optimal working point w.r.t. signalEfficiency * signalPurity.
-        multiclass_testEff.push_back(theMethod->GetMulticlassEfficiency(multiclass_testPur));
+        // theMethod->TestMulticlass(); // This is where the actual GA calc is done
+        // multiclass_testEff.push_back(theMethod->GetMulticlassEfficiency(multiclass_testPur));
 
         // Confusion matrix at three background efficiency levels
         multiclass_testConfusionEffB01.push_back(theMethod->GetMulticlassConfusionMatrix(0.01, Types::kTesting));
@@ -1730,37 +1732,40 @@ void TMVA::Factory::EvaluateAllMethods( void )
          TString hLine =
             "-------------------------------------------------------------------------------------------------------";
 
-         // --- Acheivable signal efficiency * signal purity
-         // --------------------------------------------------------------------
-         Log() << kINFO << Endl;
-         Log() << kINFO << "Evaluation results ranked by best signal efficiency times signal purity " << Endl;
-         Log() << kINFO << hLine << Endl;
+         // This part uses a genetic alg. to evaluate the optimal sig eff * sig pur.
+         // This is why it is disabled for now.
+         // 
+         // // --- Acheivable signal efficiency * signal purity
+         // // --------------------------------------------------------------------
+         // Log() << kINFO << Endl;
+         // Log() << kINFO << "Evaluation results ranked by best signal efficiency times signal purity " << Endl;
+         // Log() << kINFO << hLine << Endl;
 
-         // iterate over methods and evaluate
-         for (MVector::iterator itrMethod = methods->begin(); itrMethod != methods->end(); itrMethod++) {
-            MethodBase *theMethod = dynamic_cast<MethodBase *>(*itrMethod);
-            if (theMethod == 0) {
-               continue;
-            }
+         // // iterate over methods and evaluate
+         // for (MVector::iterator itrMethod = methods->begin(); itrMethod != methods->end(); itrMethod++) {
+         //    MethodBase *theMethod = dynamic_cast<MethodBase *>(*itrMethod);
+         //    if (theMethod == 0) {
+         //       continue;
+         //    }
 
-            TString header = "DataSet Name     MVA Method     ";
-            for (UInt_t icls = 0; icls < theMethod->fDataSetInfo.GetNClasses(); ++icls) {
-               header += Form("%-12s ", theMethod->fDataSetInfo.GetClassInfo(icls)->GetName());
-            }
+         //    TString header = "DataSet Name     MVA Method     ";
+         //    for (UInt_t icls = 0; icls < theMethod->fDataSetInfo.GetNClasses(); ++icls) {
+         //       header += Form("%-12s ", theMethod->fDataSetInfo.GetClassInfo(icls)->GetName());
+         //    }
 
-            Log() << kINFO << header << Endl;
-            Log() << kINFO << hLine << Endl;
-            for (Int_t i = 0; i < nmeth_used[0]; i++) {
-               TString res = Form("[%-14s] %-15s", theMethod->fDataSetInfo.GetName(), (const char *)mname[0][i]);
-               for (UInt_t icls = 0; icls < theMethod->fDataSetInfo.GetNClasses(); ++icls) {
-                  res += Form("%#1.3f        ", (multiclass_testEff[i][icls]) * (multiclass_testPur[i][icls]));
-               }
-               Log() << kINFO << res << Endl;
-            }
+         //    Log() << kINFO << header << Endl;
+         //    Log() << kINFO << hLine << Endl;
+         //    for (Int_t i = 0; i < nmeth_used[0]; i++) {
+         //       TString res = Form("[%-14s] %-15s", theMethod->fDataSetInfo.GetName(), (const char *)mname[0][i]);
+         //       for (UInt_t icls = 0; icls < theMethod->fDataSetInfo.GetNClasses(); ++icls) {
+         //          res += Form("%#1.3f        ", (multiclass_testEff[i][icls]) * (multiclass_testPur[i][icls]));
+         //       }
+         //       Log() << kINFO << res << Endl;
+         //    }
 
-            Log() << kINFO << hLine << Endl;
-            Log() << kINFO << Endl;
-         }
+         //    Log() << kINFO << hLine << Endl;
+         //    Log() << kINFO << Endl;
+         // }
 
          // --- 1 vs Rest ROC AUC, signal efficiency @ given background efficiency
          // --------------------------------------------------------------------

--- a/tmva/tmva/src/Factory.cxx
+++ b/tmva/tmva/src/Factory.cxx
@@ -802,6 +802,7 @@ Double_t TMVA::Factory::GetROCIntegral(TString datasetname, TString theMethodNam
             << Form("ROCCurve object was not created in Method = %s not found with Dataset = %s ", theMethodName.Data(),
                     datasetname.Data())
             << Endl;
+      return 0;
    }
 
    Int_t npoints = TMVA::gConfig().fVariablePlotting.fNbinsXOfROCCurve + 1;

--- a/tmva/tmva/src/MethodDNN.cxx
+++ b/tmva/tmva/src/MethodDNN.cxx
@@ -122,12 +122,11 @@ Bool_t TMVA::MethodDNN::HasAnalysisType(Types::EAnalysisType type,
 void TMVA::MethodDNN::Init()
 {
    // TODO: Remove once weights are considered by the method.
-   auto & dsi = this->DataInfo();
+   auto &dsi = this->DataInfo();
    auto numClasses = dsi.GetNClasses();
    for (UInt_t i = 0; i < numClasses; ++i) {
       if (dsi.GetWeightExpression(i) != TString("")) {
-         Log() << kERROR
-         << "Currently event weights are not considered properly by this method." << Endl;
+         Log() << kERROR << "Currently event weights are not considered properly by this method." << Endl;
          Log() << kFATAL << "See above." << Endl;
       }
    }
@@ -418,47 +417,63 @@ void TMVA::MethodDNN::ProcessOptions()
    }
 
    if (fArchitectureString == "STANDARD") {
-      Log() << kERROR << "The STANDARD architecture has been deprecated. "
-                         "Please use Architecture=CPU or Architecture=CPU."
-                         "See the TMVA Users' Guide for instructions if you "
-                         "encounter problems." << Endl;
-      Log() << kFATAL << "The STANDARD architecture has been deprecated. "
-                         "Please use Architecture=CPU or Architecture=CPU."
-                         "See the TMVA Users' Guide for instructions if you "
-                         "encounter problems." << Endl;
+      Log() << kERROR
+            << "The STANDARD architecture has been deprecated. "
+               "Please use Architecture=CPU or Architecture=CPU."
+               "See the TMVA Users' Guide for instructions if you "
+               "encounter problems."
+            << Endl;
+      Log() << kFATAL
+            << "The STANDARD architecture has been deprecated. "
+               "Please use Architecture=CPU or Architecture=CPU."
+               "See the TMVA Users' Guide for instructions if you "
+               "encounter problems."
+            << Endl;
    }
 
    if (fArchitectureString == "OPENCL") {
-      Log() << kERROR << "The OPENCL architecture has not been implemented yet. "
-                         "Please use Architecture=CPU or Architecture=CPU for the "
-                         "time being. See the TMVA Users' Guide for instructions "
-                         "if you encounter problems." << Endl;
-      Log() << kFATAL << "The OPENCL architecture has not been implemented yet. "
-                         "Please use Architecture=CPU or Architecture=CPU for the "
-                         "time being. See the TMVA Users' Guide for instructions "
-                         "if you encounter problems." << Endl;
+      Log() << kERROR
+            << "The OPENCL architecture has not been implemented yet. "
+               "Please use Architecture=CPU or Architecture=CPU for the "
+               "time being. See the TMVA Users' Guide for instructions "
+               "if you encounter problems."
+            << Endl;
+      Log() << kFATAL
+            << "The OPENCL architecture has not been implemented yet. "
+               "Please use Architecture=CPU or Architecture=CPU for the "
+               "time being. See the TMVA Users' Guide for instructions "
+               "if you encounter problems."
+            << Endl;
    }
 
    if (fArchitectureString == "GPU") {
-      #ifndef DNNCUDA // Included only if DNNCUDA flag is _not_ set.
-      Log() << kERROR << "CUDA backend not enabled. Please make sure "
-                         "you have CUDA installed and it was successfully "
-                         "detected by CMAKE." << Endl;
-      Log() << kFATAL << "CUDA backend not enabled. Please make sure "
-                         "you have CUDA installed and it was successfully "
-                         "detected by CMAKE." << Endl;
-      #endif // DNNCUDA
+#ifndef DNNCUDA // Included only if DNNCUDA flag is _not_ set.
+      Log() << kERROR
+            << "CUDA backend not enabled. Please make sure "
+               "you have CUDA installed and it was successfully "
+               "detected by CMAKE."
+            << Endl;
+      Log() << kFATAL
+            << "CUDA backend not enabled. Please make sure "
+               "you have CUDA installed and it was successfully "
+               "detected by CMAKE."
+            << Endl;
+#endif // DNNCUDA
    }
 
    if (fArchitectureString == "CPU") {
-      #ifndef DNNCPU // Included only if DNNCPU flag is _not_ set.
-      Log() << kERROR << "Multi-core CPU backend not enabled. Please make sure "
-                      "you have a BLAS implementation and it was successfully "
-                      "detected by CMake as well that the imt CMake flag is set." << Endl;
-      Log() << kFATAL << "Multi-core CPU backend not enabled. Please make sure "
-                      "you have a BLAS implementation and it was successfully "
-                      "detected by CMake as well that the imt CMake flag is set." << Endl;
-      #endif // DNNCPU
+#ifndef DNNCPU // Included only if DNNCPU flag is _not_ set.
+      Log() << kERROR
+            << "Multi-core CPU backend not enabled. Please make sure "
+               "you have a BLAS implementation and it was successfully "
+               "detected by CMake as well that the imt CMake flag is set."
+            << Endl;
+      Log() << kFATAL
+            << "Multi-core CPU backend not enabled. Please make sure "
+               "you have a BLAS implementation and it was successfully "
+               "detected by CMake as well that the imt CMake flag is set."
+            << Endl;
+#endif // DNNCPU
    }
 
    //

--- a/tmva/tmva/src/MethodDNN.cxx
+++ b/tmva/tmva/src/MethodDNN.cxx
@@ -121,6 +121,16 @@ Bool_t TMVA::MethodDNN::HasAnalysisType(Types::EAnalysisType type,
 
 void TMVA::MethodDNN::Init()
 {
+   // TODO: Remove once weights are considered by the method.
+   auto & dsi = this->DataInfo();
+   auto numClasses = dsi.GetNClasses();
+   for (UInt_t i = 0; i < numClasses; ++i) {
+      if (dsi.GetWeightExpression(i) != TString("")) {
+         Log() << kERROR
+         << "Currently event weights are not considered properly by this method." << Endl;
+         Log() << kFATAL << "See above." << Endl;
+      }
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/src/MethodDNN.cxx
+++ b/tmva/tmva/src/MethodDNN.cxx
@@ -417,6 +417,50 @@ void TMVA::MethodDNN::ProcessOptions()
             << Endl;
    }
 
+   if (fArchitectureString == "STANDARD") {
+      Log() << kERROR << "The STANDARD architecture has been deprecated. "
+                         "Please use Architecture=CPU or Architecture=CPU."
+                         "See the TMVA Users' Guide for instructions if you "
+                         "encounter problems." << Endl;
+      Log() << kFATAL << "The STANDARD architecture has been deprecated. "
+                         "Please use Architecture=CPU or Architecture=CPU."
+                         "See the TMVA Users' Guide for instructions if you "
+                         "encounter problems." << Endl;
+   }
+
+   if (fArchitectureString == "OPENCL") {
+      Log() << kERROR << "The OPENCL architecture has not been implemented yet. "
+                         "Please use Architecture=CPU or Architecture=CPU for the "
+                         "time being. See the TMVA Users' Guide for instructions "
+                         "if you encounter problems." << Endl;
+      Log() << kFATAL << "The OPENCL architecture has not been implemented yet. "
+                         "Please use Architecture=CPU or Architecture=CPU for the "
+                         "time being. See the TMVA Users' Guide for instructions "
+                         "if you encounter problems." << Endl;
+   }
+
+   if (fArchitectureString == "GPU") {
+      #ifndef DNNCUDA // Included only if DNNCUDA flag is _not_ set.
+      Log() << kERROR << "CUDA backend not enabled. Please make sure "
+                         "you have CUDA installed and it was successfully "
+                         "detected by CMAKE." << Endl;
+      Log() << kFATAL << "CUDA backend not enabled. Please make sure "
+                         "you have CUDA installed and it was successfully "
+                         "detected by CMAKE." << Endl;
+      #endif // DNNCUDA
+   }
+
+   if (fArchitectureString == "CPU") {
+      #ifndef DNNCPU // Included only if DNNCPU flag is _not_ set.
+      Log() << kERROR << "Multi-core CPU backend not enabled. Please make sure "
+                      "you have a BLAS implementation and it was successfully "
+                      "detected by CMake as well that the imt CMake flag is set." << Endl;
+      Log() << kFATAL << "Multi-core CPU backend not enabled. Please make sure "
+                      "you have a BLAS implementation and it was successfully "
+                      "detected by CMake as well that the imt CMake flag is set." << Endl;
+      #endif // DNNCPU
+   }
+
    //
    // Set network structure.
    //

--- a/tmva/tmva/src/MethodDNN.cxx
+++ b/tmva/tmva/src/MethodDNN.cxx
@@ -417,61 +417,53 @@ void TMVA::MethodDNN::ProcessOptions()
    }
 
    if (fArchitectureString == "STANDARD") {
-      Log() << kERROR
-            << "The STANDARD architecture has been deprecated. "
-               "Please use Architecture=CPU or Architecture=CPU."
-               "See the TMVA Users' Guide for instructions if you "
-               "encounter problems."
+      Log() << kERROR << "The STANDARD architecture has been deprecated. "
+                         "Please use Architecture=CPU or Architecture=CPU."
+                         "See the TMVA Users' Guide for instructions if you "
+                         "encounter problems."
             << Endl;
-      Log() << kFATAL
-            << "The STANDARD architecture has been deprecated. "
-               "Please use Architecture=CPU or Architecture=CPU."
-               "See the TMVA Users' Guide for instructions if you "
-               "encounter problems."
+      Log() << kFATAL << "The STANDARD architecture has been deprecated. "
+                         "Please use Architecture=CPU or Architecture=CPU."
+                         "See the TMVA Users' Guide for instructions if you "
+                         "encounter problems."
             << Endl;
    }
 
    if (fArchitectureString == "OPENCL") {
-      Log() << kERROR
-            << "The OPENCL architecture has not been implemented yet. "
-               "Please use Architecture=CPU or Architecture=CPU for the "
-               "time being. See the TMVA Users' Guide for instructions "
-               "if you encounter problems."
+      Log() << kERROR << "The OPENCL architecture has not been implemented yet. "
+                         "Please use Architecture=CPU or Architecture=CPU for the "
+                         "time being. See the TMVA Users' Guide for instructions "
+                         "if you encounter problems."
             << Endl;
-      Log() << kFATAL
-            << "The OPENCL architecture has not been implemented yet. "
-               "Please use Architecture=CPU or Architecture=CPU for the "
-               "time being. See the TMVA Users' Guide for instructions "
-               "if you encounter problems."
+      Log() << kFATAL << "The OPENCL architecture has not been implemented yet. "
+                         "Please use Architecture=CPU or Architecture=CPU for the "
+                         "time being. See the TMVA Users' Guide for instructions "
+                         "if you encounter problems."
             << Endl;
    }
 
    if (fArchitectureString == "GPU") {
 #ifndef DNNCUDA // Included only if DNNCUDA flag is _not_ set.
-      Log() << kERROR
-            << "CUDA backend not enabled. Please make sure "
-               "you have CUDA installed and it was successfully "
-               "detected by CMAKE."
+      Log() << kERROR << "CUDA backend not enabled. Please make sure "
+                         "you have CUDA installed and it was successfully "
+                         "detected by CMAKE."
             << Endl;
-      Log() << kFATAL
-            << "CUDA backend not enabled. Please make sure "
-               "you have CUDA installed and it was successfully "
-               "detected by CMAKE."
+      Log() << kFATAL << "CUDA backend not enabled. Please make sure "
+                         "you have CUDA installed and it was successfully "
+                         "detected by CMAKE."
             << Endl;
 #endif // DNNCUDA
    }
 
    if (fArchitectureString == "CPU") {
 #ifndef DNNCPU // Included only if DNNCPU flag is _not_ set.
-      Log() << kERROR
-            << "Multi-core CPU backend not enabled. Please make sure "
-               "you have a BLAS implementation and it was successfully "
-               "detected by CMake as well that the imt CMake flag is set."
+      Log() << kERROR << "Multi-core CPU backend not enabled. Please make sure "
+                         "you have a BLAS implementation and it was successfully "
+                         "detected by CMake as well that the imt CMake flag is set."
             << Endl;
-      Log() << kFATAL
-            << "Multi-core CPU backend not enabled. Please make sure "
-               "you have a BLAS implementation and it was successfully "
-               "detected by CMake as well that the imt CMake flag is set."
+      Log() << kFATAL << "Multi-core CPU backend not enabled. Please make sure "
+                         "you have a BLAS implementation and it was successfully "
+                         "detected by CMake as well that the imt CMake flag is set."
             << Endl;
 #endif // DNNCPU
    }

--- a/tmva/tmva/src/ROCCurve.cxx
+++ b/tmva/tmva/src/ROCCurve.cxx
@@ -144,7 +144,6 @@ std::vector<Double_t> TMVA::ROCCurve::ComputeSpecificity(const UInt_t num_points
       specificity_vector.push_back(specificity);
    }
 
-
    specificity_vector.push_back(1.0);
    return specificity_vector;
 }

--- a/tmva/tmva/src/ROCCurve.cxx
+++ b/tmva/tmva/src/ROCCurve.cxx
@@ -144,6 +144,7 @@ std::vector<Double_t> TMVA::ROCCurve::ComputeSpecificity(const UInt_t num_points
       specificity_vector.push_back(specificity);
    }
 
+
    specificity_vector.push_back(1.0);
    return specificity_vector;
 }


### PR DESCRIPTION
Multiclass: Better support in Factory methods. Disable costly effS*purS calc.
Classification: Textual output now considers event weights when calc ROC curve.

DNN: Deprecate arch=STANDARD, now fails earlier when using CPU/GPU on unsupported build. Add warning about event weights not being considered.
