### PR TITLE
Resolve warnings reported by -Wnon-virtual-dtor

### DIFF
--- a/core/dictgen/res/BaseSelectionRule.h
+++ b/core/dictgen/res/BaseSelectionRule.h
@@ -91,6 +91,8 @@ public:
 
    BaseSelectionRule(long index, ESelect sel, const std::string& attributeName, const std::string& attributeValue, cling::Interpreter &interp, const char* selFileName = "",long lineno=-1);
 
+   virtual ~BaseSelectionRule() = default;
+
    virtual void DebugPrint() const;
    virtual void Print(std::ostream &out) const = 0;
 

--- a/core/dictgen/res/OptionParser.h
+++ b/core/dictgen/res/OptionParser.h
@@ -1400,6 +1400,8 @@ struct Parser::Action
     (void) args;
     return true;
   }
+
+  virtual ~Action() = default;
 };
 
 /**
@@ -1718,6 +1720,8 @@ struct PrintUsageImplementation
     virtual void operator()(const char*, int)
     {
     }
+
+    virtual ~IStringWriter() = default;
   };
 
   /**


### PR DESCRIPTION
If a class/struct has virtual method it should also contain a virtual
dtor. This is important if one uses allocator (tcmalloc, jemalloc) with
C++14 sized deallocation. It's needed to provide a proper object size
to deallocation function.

We found that jemalloc (dev branch) tends to deadlock if wrong object
size is provided to deallocation function.

Patch is just as precaution.

Signed-off-by: David Abdurachmanov <david.abdurachmanov@gmail.com>