### PR TITLE
JSON: Special handling of STL containers with len=1

### DIFF
--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -107,11 +107,12 @@ class TArrayIndexProducer {
          fIsArray(kFALSE)
       {
          Bool_t usearrayindx = elem && (elem->GetArrayDim() > 0);
-         Bool_t usearraylen = (arraylen > 1);
+         Bool_t isloop = (elem->GetType() == TStreamerInfo::kOffsetL + TStreamerInfo::kStreamLoop) ||
+                         (elem->GetType() == TStreamerInfo::kStreamLoop);
+         Bool_t usearraylen = (arraylen > (isloop ? 0 : 1));
 
          if (usearrayindx && (arraylen > 0)) {
-            if ((elem->GetType() == TStreamerInfo::kOffsetL + TStreamerInfo::kStreamLoop) ||
-                (elem->GetType() == TStreamerInfo::kStreamLoop)) { usearrayindx = kFALSE; usearraylen = kTRUE; }
+            if (isloop) { usearrayindx = kFALSE; usearraylen = kTRUE; }
             else
                if (arraylen != elem->GetArrayLength()) {
                   printf("Problem with JSON coding of element %s type %d \n", elem->GetName(), elem->GetType());

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -108,7 +108,7 @@ class TArrayIndexProducer {
       {
          Bool_t usearrayindx = elem && (elem->GetArrayDim() > 0);
          Bool_t isloop = elem && ((elem->GetType() == TStreamerInfo::kStreamLoop) ||
-                         (elem->GetType() == TStreamerInfo::kOffsetL + TStreamerInfo::kStreamLoop));
+                                  (elem->GetType() == TStreamerInfo::kOffsetL + TStreamerInfo::kStreamLoop));
          Bool_t usearraylen = (arraylen > (isloop ? 0 : 1));
 
          if (usearrayindx && (arraylen > 0)) {
@@ -1105,9 +1105,9 @@ void TBufferJSON::JsonWriteObject(const void *obj, const TClass *cl, Bool_t chec
                // Create entries like { '$pair': 'typename' , 'first' : key, 'second' : value }
 
                TString pairtype = cl->GetName();
-               if (pairtype.Index("multimap<")==0)
+               if (pairtype.Index("multimap<") == 0)
                   pairtype.Replace(0, 9, "pair<");
-               else if (pairtype.Index("map<")==0)
+               else if (pairtype.Index("map<") == 0)
                   pairtype.Replace(0, 4, "pair<");
                else
                   pairtype = "TPair";


### PR DESCRIPTION
It solves problem I recognize for the first time with ROOT7 webgui.
It was wrong representation for container like: std::vector<UserClass>
Patch for roottest will follow very soon.