### PR TITLE
[GL2PS] Fix unused variable warning and use nullptr

### DIFF
--- a/graf3d/gl/src/gl2ps.cxx
+++ b/graf3d/gl/src/gl2ps.cxx
@@ -1537,12 +1537,12 @@ static GLboolean gl2psLess(GLfloat f1, GLfloat f2)
 
 static void gl2psBuildBspTree(GL2PSbsptree *tree, GL2PSlist *primitives)
 {
-  GL2PSprimitive *prim, *frontprim = NULL, *backprim = NULL;
+  GL2PSprimitive *prim = nullptr, *frontprim = nullptr, *backprim = nullptr;
   GL2PSlist *frontlist, *backlist;
   GLint i, index;
 
-  tree->front = NULL;
-  tree->back = NULL;
+  tree->front = nullptr;
+  tree->back = nullptr;
   tree->primitives = gl2psListCreate(1, 2, sizeof(GL2PSprimitive*));
   index = gl2psFindRoot(primitives, &prim);
   gl2psGetPlane(prim, tree->plane);


### PR DESCRIPTION
Fix [this](http://cdash.cern.ch/viewBuildError.php?type=1&buildid=362417) warning:

```
Scanning dependencies of target testRootFinder
[ 96%] Building CXX object math/mathcore/test/CMakeFiles/testRootFinder.dir/testRootFinder.cxx.o
/.../root/graf3d/gl/src/gl2ps.cxx: In function ‘void gl2psBuildBspTree(GL2PSbsptree*, GL2PSlist*)’:
 /.../root/graf3d/gl/src/gl2ps.cxx:1540:19: warning: ‘prim’ may be used uninitialized in this function [-Wmaybe-uninitialized]
    GL2PSprimitive *prim, *frontprim = NULL, *backprim = NULL;
                   ^~~~
```