### PR TITLE
It seems that cmake is smart enough finding cling.

### DIFF
--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -10,7 +10,6 @@ set(LLVM_TOOL_LLVM_AR_BUILD OFF CACHE BOOL "")
 set(CLANG_TOOL_CLANG_OFFLOAD_BUNDLER_BUILD OFF CACHE BOOL "")
 set(LLVM_FORCE_USE_OLD_TOOLCHAIN ON CACHE BOOL "")
 set(LLVM_EXTERNAL_CLING_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cling" CACHE STRING "")
-set(LLVM_EXTERNAL_PROJECTS "cling" CACHE STRING "")
 # We only use llvm/clang through TCling which is (with the help of core/meta) already taking a lock
 # to serialize access to llvm.  We can later review how to make this finer grained by using llvm's own locking
 # mechanism.


### PR DESCRIPTION
The llvm upgrade broke users builds because it double finds the llvm external
project cling.

Remove the overspecification.

Note that if there is still an issue with the incrementals one needs to delete
CMakeCache.txt file in the main directory.