### PR TITLE
Allow for globbing on Google Test sources

### DIFF
--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -1129,7 +1129,7 @@ function(ROOT_ADD_GTEST test_suite)
   CMAKE_PARSE_ARGUMENTS(ARG "" "" "LIBRARIES" ${ARGN})
   include_directories(${CMAKE_CURRENT_BINARY_DIR} ${GTEST_INCLUDE_DIR} ${GMOCK_INCLUDE_DIR})
 
-  set(source_files ${ARG_UNPARSED_ARGUMENTS})
+  ROOT_GLOB_FILES(source_files ${ARG_UNPARSED_ARGUMENTS})
   # Note we cannot use ROOT_EXECUTABLE without user-specified set of LIBRARIES to link with.
   # The test suites should choose this in their specific CMakeLists.txt file.
   # FIXME: For better coherence we could restrict the libraries the test suite could link


### PR DESCRIPTION
This PR enables globbing on ROOT_ADD_GTEST. Instead of specifying a test in CMake as 
```
ROOT_ADD_GTEST(myTest test1.cxx test2.cxx test3.cxx)
```
This PR enables specifying it as:
```
ROOT_ADD_GTEST(myTest test*.cxx)
```