### PR TITLE
Add support for named arguments

### DIFF
--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -468,7 +468,48 @@ void TApplication::GetOptions(Int_t *argc, char **argv)
          } else {
             Warning("GetOptions", "-e must be followed by an expression.");
          }
+      } else if (!strcmp(argv[i], "--#")) {
+         TObjString* macro = nullptr;
+         bool warnShown = false;
 
+         if (fFiles) {
+            for (auto f: *fFiles) {
+               TObjString* file = dynamic_cast<TObjString*>(f);
+
+               if (file->TestBit(kExpression))
+                  continue;
+               if (file->String().EndsWith(".root"))
+                  continue;
+               if (file->String().Contains('('))
+                  continue;
+
+               if (macro && !warnShown && (warnShown = true))
+                  Warning("GetOptions", "--# is used with several macros. "
+                                        "The arguments will be passed to the last one.");
+
+               macro = file;
+            }
+         }
+
+         if (macro) {
+            argv[i] = null;
+            ++i;
+            TString& str = macro->String();
+
+            str += "(#";
+            for (; i < *argc; i++) {
+               str += argv[i];
+               str += ',';
+               argv[i] = null;
+            }
+            str.EndsWith(",") ? str[str.Length() - 1] = '#' : str += '#';
+            str += ')';
+         } else {
+            Warning("GetOptions", "no macro to pass arguments to was provided. "
+                                  "Everything after the --# will be ignored.");
+            for (; i < *argc; i++)
+               argv[i] = null;
+         }
       } else if (argv[i][0] != '-' && argv[i][0] != '+') {
          Long64_t size;
          Long_t id, flags, modtime;

--- a/interpreter/cling/include/cling/MetaProcessor/MetaProcessor.h
+++ b/interpreter/cling/include/cling/MetaProcessor/MetaProcessor.h
@@ -79,6 +79,17 @@ namespace cling {
       ~MaybeRedirectOutputRAII();
     };
 
+    static std::string positionalizeArgs(cling::Interpreter* Interpreter,
+                                         llvm::StringRef FuncName,
+                                         llvm::StringRef args);
+    static std::string positionalizeArgs(cling::Interpreter* Interpreter,
+                                         const Transaction* T,
+                                         llvm::StringRef FuncName,
+                                         llvm::StringRef args);
+    static std::string positionalizeArgs(cling::Interpreter* Interpreter,
+                                         const clang::FunctionDecl* fdecl,
+                                         llvm::StringRef args);
+
   public:
     MetaProcessor(Interpreter& interp, llvm::raw_ostream& outs);
     ~MetaProcessor();


### PR DESCRIPTION
when macro function is invoked from command line or by `.x macro.C` metacommand
i.e. `root 'macro.C(#arg3 = 13,  arg1 = {42, 43}, arg5 = "string"#)'` (compiled macros are also supported) or from ROOT REPL: `.x macro.C(#arg3 = 13,  arg1 = {42, 43}, arg5 = "string"#)`.
**N.B.! No space between parentheses and `#`.**
Calling from REPL as `macro(#arg3 = 13,  arg1 = {42, 43}, arg5 = "string"#)` is not supported (yet?).

Passing arguments as options (`root macro.C+ --# arg3=13 'arg1={42, 43}' 'arg5="string"'`), like in #616 ~~will be implemented if this PR merged~~ is implemented.

Some implementation decisions, e.g. error reporting, are suboptimal so discussion, suggestions, criticism are welcome.