### PR TITLE
Remove float.h from the libc.modulemap.

### DIFF
--- a/build/unix/libc.modulemap
+++ b/build/unix/libc.modulemap
@@ -16,10 +16,6 @@ module "libc" {
     export *
     header "fenv.h"
   }
-  module "float.h" {
-    export *
-    header "float.h"
-  }
   module "inttypes.h" {
     export *
     header "inttypes.h"


### PR DESCRIPTION
The header is usually not in /usr/include/ but instead in the clang internal directory, so this modulemap is probably wrong.