### PR TITLE
CORS and ssl_certificate for THttpServer

### DIFF
--- a/net/http/inc/THttpServer.h
+++ b/net/http/inc/THttpServer.h
@@ -44,6 +44,7 @@ protected:
    TString fDefaultPageCont; ///<! content of the file content
    TString fDrawPage;        ///<! file name for drawing of single element
    TString fDrawPageCont;    ///<! content of draw page
+   TString fCors;            ///<! CORS (cross-origin resource sharing): sets Access-Control-Allow-Origin for ProcessRequest responses
 
    std::mutex fMutex; ///<! mutex to protect list with arguments
    TList fCallArgs;   ///<! submitted arguments
@@ -52,6 +53,12 @@ protected:
    virtual void ProcessRequest(THttpCallArg *arg);
 
    static Bool_t VerifyFilePath(const char *fname);
+
+   /** adds CORS to ProcessRequests() responses */
+   void SetCors(const char *cor) { fCors = cor; }
+
+   const char *GetCors() const { return fCors.Data(); }
+   Bool_t IsCors() const { return fCors.Length() > 0; }
 
 public:
    THttpServer(const char *engine = "civetweb:8080");

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -371,7 +371,7 @@ Bool_t TCivetweb::Create(const char *args)
    //((struct mg_callbacks *) fCallbacks)->begin_request = begin_request_handler;
    ((struct mg_callbacks *)fCallbacks)->log_message = log_message_handler;
    TString sport = "8080", num_threads = "5", websocket_timeout = "300000";
-   TString auth_file, auth_domain, log_file;
+   TString auth_file, auth_domain, log_file, ssl_cert;
 
    // extract arguments
    if ((args != 0) && (strlen(args) > 0)) {
@@ -403,6 +403,9 @@ Bool_t TCivetweb::Create(const char *args)
 
             const char *adomain = url.GetValueFromOptions("auth_domain");
             if (adomain != 0) auth_domain = adomain;
+
+            const char *sslc = url.GetValueFromOptions("ssl_cert");
+            if (sslc != 0) ssl_cert = sslc;
 
             Int_t wtmout = url.GetIntValueFromOptions("websocket_timeout");
             if (wtmout > 0) websocket_timeout.Format("%d", wtmout * 1000);
@@ -437,6 +440,11 @@ Bool_t TCivetweb::Create(const char *args)
       options[op++] = "error_log_file";
       options[op++] = log_file.Data();
    }
+
+   if (ssl_cert.Length() > 0) {
+      options[op++] = "ssl_certificate";
+      options[op++] = ssl_cert.Data();
+   } 
 
    options[op++] = 0;
 


### PR DESCRIPTION
- enables "ssl_certificate" option for civetweb engine in THttpServer (for https)
- adds an option for CORS (Cross-Origin Resource Sharing) headers in THttpServer responses (e.g. json, xml)