### PR TITLE
Block Travis-CI builds on legacy branches.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+
+# Block Travis-CI builds on historical branches to
+# avoid confusion for PRs.
+branches:
+  except:
+    v5-34-00-patches
+


### PR DESCRIPTION
Add a dummy Travis-CI build file that does nothing but excludes this branch from Travis-CI tests.

@vgvassilev