### PR TITLE
Rename print_wrapper to get_wrapper_code.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -6863,7 +6863,7 @@ std::string TCling::CallFunc_GetWrapperCode(CallFunc_t *func) const
    TClingCallFunc *f = (TClingCallFunc *)func;
    std::string wrapper_name;
    std::string wrapper;
-   f->print_wrapper(wrapper_name, wrapper);
+   f->get_wrapper_code(wrapper_name, wrapper);
    return wrapper;
 }
 

--- a/core/metacling/src/TClingCallFunc.cxx
+++ b/core/metacling/src/TClingCallFunc.cxx
@@ -574,7 +574,7 @@ void TClingCallFunc::make_narg_ctor_with_return(const unsigned N, const string &
    buf << "}\n";
 }
 
-int TClingCallFunc::print_wrapper(std::string &wrapper_name, std::string &wrapper)
+int TClingCallFunc::get_wrapper_code(std::string &wrapper_name, std::string &wrapper)
 {
    const FunctionDecl *FD = GetDecl();
    assert(FD && "generate_wrapper called without a function decl!");
@@ -1087,7 +1087,7 @@ tcling_callfunc_Wrapper_t TClingCallFunc::make_wrapper()
    string wrapper_name;
    string wrapper;
 
-   if (print_wrapper(wrapper_name, wrapper) == 0) return 0;
+   if (get_wrapper_code(wrapper_name, wrapper) == 0) return 0;
 
    //fprintf(stderr, "%s\n", wrapper.c_str());
    //

--- a/core/metacling/src/TClingCallFunc.h
+++ b/core/metacling/src/TClingCallFunc.h
@@ -187,7 +187,7 @@ public:
       return fDecl;
    }
 
-   int print_wrapper(std::string &wrapper_name, std::string &wrapper);
+   int get_wrapper_code(std::string &wrapper_name, std::string &wrapper);
 
    const clang::FunctionDecl* GetDecl() const {
       if (fDecl)


### PR DESCRIPTION
To stay consistent with the interface method.