### PR TITLE
Push a new transaction in the DictSelectionReader.

### DIFF
--- a/core/dictgen/res/DictSelectionReader.h
+++ b/core/dictgen/res/DictSelectionReader.h
@@ -28,6 +28,9 @@ namespace ROOT {
       class TNormalizedCtxt;
    }
 }
+namespace cling {
+class Interpreter;
+}
 
 namespace clang {
    class ASTContext;
@@ -236,7 +239,8 @@ class DictSelectionReader
 public:
    /// Take the selection rules as input (for consistency w/ other selector
    /// interfaces)
-   DictSelectionReader(SelectionRules &, const clang::ASTContext &, ROOT::TMetaUtils::TNormalizedCtxt &);
+   DictSelectionReader(cling::Interpreter &interp, SelectionRules &, const clang::ASTContext &,
+                       ROOT::TMetaUtils::TNormalizedCtxt &);
 
    /// Visit the entities that needs to be selected
    bool VisitRecordDecl(clang::RecordDecl *);

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -4577,7 +4577,7 @@ int RootClingMain(int argc,
    clang::CompilerInstance *CI = interp.getCI();
    const unsigned int selRulesInitialSize = selectionRules.Size();
    if (dictSelection && !onepcm)
-      DictSelectionReader dictSelReader(selectionRules, CI->getASTContext(), normCtxt);
+      DictSelectionReader dictSelReader(interp, selectionRules, CI->getASTContext(), normCtxt);
 
    bool dictSelRulesPresent = selectionRules.Size() > selRulesInitialSize;
 


### PR DESCRIPTION
In the modules case it's possible that we deserialize declarations
while traversing the AST. This means we also need to have a new
transaction during this part of the code.