### PR TITLE
Fixing an O(N^2) scaling problem caused by TTree::Draw()

### DIFF
--- a/tree/treeplayer/inc/TTreeFormula.h
+++ b/tree/treeplayer/inc/TTreeFormula.h
@@ -84,6 +84,14 @@ protected:
       kMaxIf           = 205
    };
 
+   // Helper struct to hold a cache
+   // that can accelerate calculation of the RealIndex.
+   struct RealInstanceCache {
+      Int_t fInstanceCache = 0;
+      Int_t fLocalIndexCache = 0;
+      Int_t fVirtAccumCache = 0;
+   };
+
    TTree       *fTree;            //! pointer to Tree
    Int_t        fCodes[kMAXCODES]; //  List of leaf numbers referenced in formula
    Int_t       fNdata[kMAXCODES]; //! This caches the physical number of element in the leaf or datamember.
@@ -120,6 +128,8 @@ protected:
    std::vector<std::string>  fAliasesUsed;    //! List of aliases used during the parsing of the expression.
 
    LongDouble_t*        fConstLD;   //! local version of fConsts able to store bigger numbers
+
+   RealInstanceCache fRealInstanceCache; //! Cache accelerating the GetRealInstance function
 
    TTreeFormula(const char *name, const char *formula, TTree *tree, const std::vector<std::string>& aliases);
    void Init(const char *name, const char *formula);

--- a/tree/treeplayer/src/TTreeFormula.cxx
+++ b/tree/treeplayer/src/TTreeFormula.cxx
@@ -3412,8 +3412,14 @@ Int_t TTreeFormula::GetRealInstance(Int_t instance, Int_t codeindex) {
                }
                break;
             case -1: {
-                  local_index = 0;
-                  Int_t virt_accum = 0;
+                  if (instance <= fRealInstanceCache.fInstanceCache) {
+                     fRealInstanceCache.fLocalIndexCache = 0;
+                     fRealInstanceCache.fVirtAccumCache = 0;
+                  }
+                  fRealInstanceCache.fInstanceCache = instance;
+                  local_index = fRealInstanceCache.fLocalIndexCache;
+                  Int_t virt_accum = fRealInstanceCache.fVirtAccumCache;
+
                   Int_t maxloop = fManager->fCumulUsedVarDims->GetSize();
                   if (maxloop == 0) {
                      local_index--;
@@ -3424,12 +3430,15 @@ Int_t TTreeFormula::GetRealInstance(Int_t instance, Int_t codeindex) {
                         virt_accum += fManager->fCumulUsedVarDims->GetArray()[local_index];
                         local_index++;
                      } while( instance >= virt_accum && local_index<maxloop);
-                     if (local_index==maxloop && (instance >= virt_accum)) {
-                        local_index--;
+                     local_index--;
+                     // update the cache
+                     fRealInstanceCache.fVirtAccumCache = virt_accum - fManager->fCumulUsedVarDims->GetArray()[local_index];
+                     fRealInstanceCache.fLocalIndexCache = local_index;
+
+		     if (local_index==(maxloop-1) && (instance >= virt_accum)) {
                         instance = fNdata[0]+1; // out of bounds.
                         if (check) return fNdata[0]+1;
                      } else {
-                        local_index--;
                         if (fManager->fCumulUsedVarDims->At(local_index)) {
                            instance -= (virt_accum - fManager->fCumulUsedVarDims->At(local_index));
                         } else {


### PR DESCRIPTION
This is a first attempt at solving a scaling problem observed during TTree::Draw of a branch that contains a TClonesArray where each element contains another small vector container.

The fix works for me.