### PR TITLE
[WIP] Vectorization of TMath

### DIFF
--- a/math/mathcore/CMakeLists.txt
+++ b/math/mathcore/CMakeLists.txt
@@ -15,12 +15,13 @@ set(MATHCORE_HEADERS TRandom.h
   Math/ChebyshevPol.h Math/KDTree.h Math/TDataPoint.h Math/TDataPointN.h Math/Delaunay2D.h
   Math/Random.h Math/TRandomEngine.h Math/RandomFunctions.h Math/StdEngine.h
   Math/MersenneTwisterEngine.h Math/MixMaxEngine.h   TRandomGen.h Math/LCGEngine.h
-  Math/Math_vectypes.hxx
+  Math/Math_vectypes.hxx TMathVectorized.h
 )
 
 if(veccore)
   set(MATHCORE_LIBRARIES ${VecCore_LIBRARIES})
   set(MATHCORE_BUILTINS VECCORE)
+  # set(MATHCORE_HEADERS ${MATHCORE_HEADERS} TMathVectorized.h)
 endif()
 
 add_definitions(-DUSE_ROOT_ERROR)

--- a/math/mathcore/inc/TMathVectorized.h
+++ b/math/mathcore/inc/TMathVectorized.h
@@ -1,0 +1,112 @@
+// @(#)root/mathcore:$Id$
+// Author: Alejandro García Montoro 06/2017
+
+/*************************************************************************
+ * Copyright (C) 2017, CERN                                              *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TMathVectorized
+#define ROOT_TMathVectorized
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// TMathVectorized                                                      //
+//                                                                      //
+// Encapsulate vectorized version of the most frequently used Math      //
+// functions.                                                           //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+
+#include "Rtypes.h"
+#include "TError.h"
+#include "Math/Math_vectypes.hxx"
+//
+#include <algorithm>
+#include <limits>
+#include <cmath>
+
+#ifdef R__HAS_VECCORE
+
+#include <VecCore/VecCore>
+
+/* **************************************** */
+/* *         Base math functions          * */
+/* * Linear versions defined in TMathBase * */
+/* **************************************** */
+namespace TMath {
+
+template <class NotCompileIfScalarBackend = std::enable_if<!(std::is_same<double, ROOT::Double_v>::value)>>
+inline ROOT::Double_v Min(ROOT::Double_v a, ROOT::Double_v b)
+{
+   return vecCore::math::Min(a, b);
+}
+}
+
+/* ************************************ */
+/* *       Usual math functions       * */
+/* * Linear versions defined in TMath * */
+/* ************************************ */
+namespace TMath {
+
+/* ************************** */
+/* * Mathematical Functions * */
+/* ************************** */
+
+/* *********************** */
+/* * Statistic Functions * */
+/* *********************** */
+
+template <class NotCompileIfScalarBackend = std::enable_if<!(std::is_same<double, ROOT::Double_v>::value)>>
+ROOT::Double_v BreitWigner(ROOT::Double_v &x, Double_t mean = 0, Double_t gamma = 1)
+{
+   ROOT::Double_v bw = gamma / ((x - mean) * (x - mean) + gamma * gamma / 4);
+   return bw / (2 * Pi());
+}
+
+template <class NotCompileIfScalarBackend = std::enable_if<!(std::is_same<double, ROOT::Double_v>::value)>>
+ROOT::Double_v CauchyDist(ROOT::Double_v &x, Double_t t = 0, Double_t s = 1)
+{
+   ROOT::Double_v temp = (x - t) * (x - t) / (s * s);
+   ROOT::Double_v result = 1 / (s * Pi() * (1 + temp));
+   return result;
+}
+
+template <class NotCompileIfScalarBackend = std::enable_if<!(std::is_same<double, ROOT::Double_v>::value)>>
+ROOT::Double_v Gaus(ROOT::Double_v &x, Double_t mean = 0, Double_t sigma = 1, Bool_t norm = kFALSE)
+{
+   if (sigma == 0)
+      return vecCore::NumericLimits<ROOT::Double_v>::Infinity();
+
+   ROOT::Double_v arg = (x - mean) / sigma;
+
+   // Compute the function only when the arg meets the criteria
+   ROOT::Double_v res =
+      vecCore::Blend<ROOT::Double_v>(vecCore::math::Abs(arg) < 39.0, vecCore::math::Exp(-0.5 * arg * arg), 0.0);
+
+   return norm ? res / (2.50662827463100024 * sigma) : res; // sqrt(2*Pi)=2.50662827463100024
+}
+
+template <class NotCompileIfScalarBackend = std::enable_if<!(std::is_same<double, ROOT::Double_v>::value)>>
+ROOT::Double_v LaplaceDist(ROOT::Double_v &x, Double_t alpha = 0, Double_t beta = 1)
+{
+   ROOT::Double_v result;
+   result = vecCore::math::Exp(-vecCore::math::Abs((x - alpha) / beta));
+   result /= (2. * beta);
+   return result;
+}
+
+template <class NotCompileIfScalarBackend = std::enable_if<!(std::is_same<double, ROOT::Double_v>::value)>>
+ROOT::Double_v LaplaceDistI(ROOT::Double_v &x, Double_t alpha = 0, Double_t beta = 1)
+{
+   ROOT::Double_v temp = 0.5 * vecCore::math::Exp(-vecCore::math::Abs((x - alpha) / beta));
+   return vecCore::Blend(x <= alpha, temp, 1 - temp);
+}
+} // namespace TMath
+
+#endif // ROOT_TMathVectorized
+
+#endif // R__HAS_VECCORE

--- a/math/mathcore/test/CMakeLists.txt
+++ b/math/mathcore/test/CMakeLists.txt
@@ -80,4 +80,7 @@ ROOT_ADD_GTEST(stressMathCoreUnit stress/testSMatrix.cxx stress/testGenVector.cx
         LIBRARIES Core MathCore Hist RIO Tree GenVector)
 
 ROOT_ADD_GTEST(GradientUnit testGradient.cxx
-       LIBRARIES Core MathCore Hist RIO Tree GenVector)
+        LIBRARIES Core MathCore Hist RIO Tree GenVector)
+
+ ROOT_ADD_GTEST(vectorizationMathCoreUnit vectorization/testTMathBase.cxx vectorization/testTMathStatistic.cxx
+        LIBRARIES Core MathCore)

--- a/math/mathcore/test/vectorization/testTMathBase.cxx
+++ b/math/mathcore/test/vectorization/testTMathBase.cxx
@@ -1,0 +1,84 @@
+#include "TMath.h"
+#include "TMathVectorized.h"
+
+#include "Math/Random.h"
+#include "TRandom1.h"
+#include "TStopwatch.h"
+
+#include "gtest/gtest.h"
+
+#include <iostream>
+#include <random>
+
+#ifdef R__HAS_VECCORE
+
+#include <VecCore/VecCore>
+
+/**
+ * Common data and set up for testing vectorized functions from TMathBase
+ */
+class TVectorizedMathBaseTest : public ::testing::Test {
+protected:
+   TVectorizedMathBaseTest()
+   {
+      // Randomize linear input data in ]0, 1]
+      TRandom1 rndmzr;
+      rndmzr.RndmArray(fInputSize * vecCore::VectorSize<ROOT::Double_v>(), fLinearInputA);
+      rndmzr.RndmArray(fInputSize * vecCore::VectorSize<ROOT::Double_v>(), fLinearInputB);
+
+      // Transform input linear data to ]-1000, 1000] and copy to the vectorized array
+      for (size_t caseIdx = 0; caseIdx < fInputSize; caseIdx++) {
+         for (size_t vecIdx = 0; vecIdx < vecCore::VectorSize<ROOT::Double_v>(); vecIdx++) {
+            size_t linear_index = vecCore::VectorSize<ROOT::Double_v>() * caseIdx + vecIdx;
+
+            // Transform data ]0, 1] -> ]-1000, 1000]
+            fLinearInputA[linear_index] *= 2000;
+            fLinearInputA[linear_index] -= 1000;
+
+            vecCore::Set(fVectorInputA[caseIdx], vecIdx, fLinearInputA[linear_index]);
+            vecCore::Set(fVectorInputB[caseIdx], vecIdx, fLinearInputB[linear_index]);
+         }
+      }
+   }
+
+   // Data available to all tests in this suite
+
+   static const int fInputSize = 1000;
+
+   // Vectorized and linear input
+   ROOT::Double_v fVectorInputA[fInputSize];
+   ROOT::Double_v fVectorInputB[fInputSize];
+   Double_t fLinearInputA[fInputSize * vecCore::VectorSize<ROOT::Double_v>()];
+   Double_t fLinearInputB[fInputSize * vecCore::VectorSize<ROOT::Double_v>()];
+
+   // Vectorized and linear output
+   ROOT::Double_v fVectorOutput[fInputSize];
+   Double_t fLinearOutput[fInputSize * vecCore::VectorSize<ROOT::Double_v>()];
+};
+
+// Test scalar and vectorial versions of TMath::Min produce the same results
+TEST_F(TVectorizedMathBaseTest, VectorizedMin)
+{
+   // Compute output with vectorized function
+   for (size_t caseIdx = 0; caseIdx < fInputSize; caseIdx++) {
+      fVectorOutput[caseIdx] = TMath::Min(fVectorInputA[caseIdx], fVectorInputB[caseIdx]);
+   }
+
+   // Compute output with linear function
+   for (size_t caseIdx = 0; caseIdx < fInputSize; caseIdx++) {
+      for (size_t vecIdx = 0; vecIdx < vecCore::VectorSize<ROOT::Double_v>(); vecIdx++) {
+         size_t idx = caseIdx * vecCore::VectorSize<ROOT::Double_v>() + vecIdx;
+         fLinearOutput[idx] = TMath::Min(fLinearInputA[idx], fLinearInputB[idx]);
+      }
+   }
+
+   // Compare linear and vector output
+   for (size_t caseIdx = 0; caseIdx < fInputSize; caseIdx++) {
+      for (size_t vecIdx = 0; vecIdx < vecCore::VectorSize<ROOT::Double_v>(); vecIdx++) {
+         EXPECT_EQ(fLinearOutput[caseIdx * vecCore::VectorSize<ROOT::Double_v>() + vecIdx],
+                   vecCore::Get(fVectorOutput[caseIdx], vecIdx));
+      }
+   }
+}
+
+#endif // R__HAS_VECCORE

--- a/math/mathcore/test/vectorization/testTMathStatistic.cxx
+++ b/math/mathcore/test/vectorization/testTMathStatistic.cxx
@@ -1,0 +1,194 @@
+#include "TMath.h"
+#include "TMathVectorized.h"
+
+#include "Math/Random.h"
+#include "TRandom1.h"
+#include "TStopwatch.h"
+
+#include "gtest/gtest.h"
+
+#include <iostream>
+#include <random>
+
+#ifdef R__HAS_VECCORE
+
+#include <VecCore/VecCore>
+
+/**
+* Common data and set up for testing vectorized functions from TMath
+*/
+class TVectorizedMathTest : public ::testing::Test {
+protected:
+   TVectorizedMathTest()
+   {
+      // Randomize input data and parameters
+      TRandom1 rndmzr;
+      rndmzr.RndmArray(fInputSize * vecCore::VectorSize<ROOT::Double_v>(), fLinearInput);
+      rndmzr.RndmArray(fInputSize * vecCore::VectorSize<ROOT::Double_v>(), fLinearProbabilities);
+      rndmzr.RndmArray(fInputSize, fMean);
+      rndmzr.RndmArray(fInputSize, fSigma);
+
+      // Set -100 < mean < 100 and 0 < sigma < 200
+      for (size_t i = 0; i < fInputSize; i++) {
+         fMean[i] = fMean[i] * 200 - 100;
+         fSigma[i] *= 200;
+      }
+
+      // Copy input linear data to the vectorized array
+      for (size_t caseIdx = 0; caseIdx < fInputSize; caseIdx++) {
+         for (size_t vecIdx = 0; vecIdx < vecCore::VectorSize<ROOT::Double_v>(); vecIdx++) {
+            vecCore::Set(fVectorInput[caseIdx], vecIdx,
+                         fLinearInput[vecCore::VectorSize<ROOT::Double_v>() * caseIdx + vecIdx]);
+            vecCore::Set(fVectorProbabilities[caseIdx], vecIdx,
+                         fLinearProbabilities[vecCore::VectorSize<ROOT::Double_v>() * caseIdx + vecIdx]);
+         }
+      }
+   }
+
+   // Data available to all tests in this suite
+
+   static const int fInputSize = 100000;
+
+   // Probabilities (values in (0,1)) input
+   ROOT::Double_v fVectorProbabilities[fInputSize];
+   Double_t fLinearProbabilities[fInputSize * vecCore::VectorSize<ROOT::Double_v>()];
+
+   // Vectorized and linear input
+   ROOT::Double_v fVectorInput[fInputSize];
+   Double_t fLinearInput[fInputSize * vecCore::VectorSize<ROOT::Double_v>()];
+
+   // Vectorized and linear output
+   ROOT::Double_v fVectorOutput[fInputSize];
+   Double_t fLinearOutput[fInputSize * vecCore::VectorSize<ROOT::Double_v>()];
+
+   // Parameters vector
+   Double_t fMean[fInputSize];
+   Double_t fSigma[fInputSize];
+};
+
+// Check that the scalar and vectorial versions of TMath::Gaus produce the same results
+TEST_F(TVectorizedMathTest, VectorizedGaus)
+{
+   // Compute the vectorized output
+   for (size_t caseIdx = 0; caseIdx < fInputSize; caseIdx++) {
+      fVectorOutput[caseIdx] = TMath::Gaus(fVectorInput[caseIdx], fMean[caseIdx], fSigma[caseIdx]);
+   }
+
+   // Compute the linear output
+   for (size_t caseIdx = 0; caseIdx < fInputSize; caseIdx++) {
+      for (size_t vecIdx = 0; vecIdx < vecCore::VectorSize<ROOT::Double_v>(); vecIdx++) {
+         size_t linear_index = caseIdx * vecCore::VectorSize<ROOT::Double_v>() + vecIdx;
+         fLinearOutput[linear_index] = TMath::Gaus(fLinearInput[linear_index], fMean[caseIdx], fSigma[caseIdx]);
+      }
+   }
+
+   // Compare linear and vectorized output
+   for (size_t caseIdx = 0; caseIdx < fInputSize; caseIdx++) {
+      for (size_t vecIdx = 0; vecIdx < vecCore::VectorSize<ROOT::Double_v>(); vecIdx++) {
+         size_t linear_index = caseIdx * vecCore::VectorSize<ROOT::Double_v>() + vecIdx;
+         EXPECT_NEAR(fLinearOutput[linear_index], vecCore::Get<ROOT::Double_v>(fVectorOutput[caseIdx], vecIdx), 1e-15);
+      }
+   }
+}
+
+// Check that the scalar and vectorial versions of TMath::BretiWigner produce the same results
+TEST_F(TVectorizedMathTest, VectorizedBreitWigner)
+{
+   // Compute the vectorized output
+   for (size_t caseIdx = 0; caseIdx < fInputSize; caseIdx++) {
+      fVectorOutput[caseIdx] = TMath::BreitWigner(fVectorInput[caseIdx], fMean[caseIdx], fSigma[caseIdx]);
+   }
+
+   // Compute the linear output
+   for (size_t caseIdx = 0; caseIdx < fInputSize; caseIdx++) {
+      for (size_t vecIdx = 0; vecIdx < vecCore::VectorSize<ROOT::Double_v>(); vecIdx++) {
+         size_t linear_index = caseIdx * vecCore::VectorSize<ROOT::Double_v>() + vecIdx;
+         fLinearOutput[linear_index] = TMath::BreitWigner(fLinearInput[linear_index], fMean[caseIdx], fSigma[caseIdx]);
+      }
+   }
+
+   // Compare linear and vectorized output
+   for (size_t caseIdx = 0; caseIdx < fInputSize; caseIdx++) {
+      for (size_t vecIdx = 0; vecIdx < vecCore::VectorSize<ROOT::Double_v>(); vecIdx++) {
+         size_t linear_index = caseIdx * vecCore::VectorSize<ROOT::Double_v>() + vecIdx;
+         EXPECT_NEAR(fLinearOutput[linear_index], vecCore::Get<ROOT::Double_v>(fVectorOutput[caseIdx], vecIdx), 1e-15);
+      }
+   }
+}
+
+// Check that the scalar and vectorial versions of TMath::CauchyDist produce the same results
+TEST_F(TVectorizedMathTest, VectorizedCauchyDist)
+{
+   // Compute the vectorized output
+   for (size_t caseIdx = 0; caseIdx < fInputSize; caseIdx++) {
+      fVectorOutput[caseIdx] = TMath::CauchyDist(fVectorInput[caseIdx], fMean[caseIdx], fSigma[caseIdx]);
+   }
+
+   // Compute the linear output
+   for (size_t caseIdx = 0; caseIdx < fInputSize; caseIdx++) {
+      for (size_t vecIdx = 0; vecIdx < vecCore::VectorSize<ROOT::Double_v>(); vecIdx++) {
+         size_t linear_index = caseIdx * vecCore::VectorSize<ROOT::Double_v>() + vecIdx;
+         fLinearOutput[linear_index] = TMath::CauchyDist(fLinearInput[linear_index], fMean[caseIdx], fSigma[caseIdx]);
+      }
+   }
+
+   // Compare linear and vectorized output
+   for (size_t caseIdx = 0; caseIdx < fInputSize; caseIdx++) {
+      for (size_t vecIdx = 0; vecIdx < vecCore::VectorSize<ROOT::Double_v>(); vecIdx++) {
+         size_t linear_index = caseIdx * vecCore::VectorSize<ROOT::Double_v>() + vecIdx;
+         EXPECT_NEAR(fLinearOutput[linear_index], vecCore::Get<ROOT::Double_v>(fVectorOutput[caseIdx], vecIdx), 1e-15);
+      }
+   }
+}
+
+// Check that the scalar and vectorial versions of TMath::LaplaceDist produce the same results
+TEST_F(TVectorizedMathTest, VectorizedLaplaceDist)
+{
+   // Compute the vectorized output
+   for (size_t caseIdx = 0; caseIdx < fInputSize; caseIdx++) {
+      fVectorOutput[caseIdx] = TMath::LaplaceDist(fVectorInput[caseIdx], fMean[caseIdx], fSigma[caseIdx]);
+   }
+
+   // Compute the linear output
+   for (size_t caseIdx = 0; caseIdx < fInputSize; caseIdx++) {
+      for (size_t vecIdx = 0; vecIdx < vecCore::VectorSize<ROOT::Double_v>(); vecIdx++) {
+         size_t linear_index = caseIdx * vecCore::VectorSize<ROOT::Double_v>() + vecIdx;
+         fLinearOutput[linear_index] = TMath::LaplaceDist(fLinearInput[linear_index], fMean[caseIdx], fSigma[caseIdx]);
+      }
+   }
+
+   // Compare linear and vectorized output
+   for (size_t caseIdx = 0; caseIdx < fInputSize; caseIdx++) {
+      for (size_t vecIdx = 0; vecIdx < vecCore::VectorSize<ROOT::Double_v>(); vecIdx++) {
+         size_t linear_index = caseIdx * vecCore::VectorSize<ROOT::Double_v>() + vecIdx;
+         EXPECT_NEAR(fLinearOutput[linear_index], vecCore::Get<ROOT::Double_v>(fVectorOutput[caseIdx], vecIdx), 1e-15);
+      }
+   }
+}
+
+// Check that the scalar and vectorial versions of TMath::LaplaceDistI produce the same results
+TEST_F(TVectorizedMathTest, VectorizedLaplaceDistI)
+{
+   // Compute the vectorized output
+   for (size_t caseIdx = 0; caseIdx < fInputSize; caseIdx++) {
+      fVectorOutput[caseIdx] = TMath::LaplaceDistI(fVectorInput[caseIdx], fMean[caseIdx], fSigma[caseIdx]);
+   }
+
+   // Compute the linear output
+   for (size_t caseIdx = 0; caseIdx < fInputSize; caseIdx++) {
+      for (size_t vecIdx = 0; vecIdx < vecCore::VectorSize<ROOT::Double_v>(); vecIdx++) {
+         size_t linear_index = caseIdx * vecCore::VectorSize<ROOT::Double_v>() + vecIdx;
+         fLinearOutput[linear_index] = TMath::LaplaceDistI(fLinearInput[linear_index], fMean[caseIdx], fSigma[caseIdx]);
+      }
+   }
+
+   // Compare linear and vectorized output
+   for (size_t caseIdx = 0; caseIdx < fInputSize; caseIdx++) {
+      for (size_t vecIdx = 0; vecIdx < vecCore::VectorSize<ROOT::Double_v>(); vecIdx++) {
+         size_t linear_index = caseIdx * vecCore::VectorSize<ROOT::Double_v>() + vecIdx;
+         EXPECT_NEAR(fLinearOutput[linear_index], vecCore::Get<ROOT::Double_v>(fVectorOutput[caseIdx], vecIdx), 1e-15);
+      }
+   }
+}
+
+#endif // R__HAS_VECCORE


### PR DESCRIPTION
This PR adds vectorized implementations of several functions in TMath. It is a work in progress, just to receive early feedback. Currently, the following functions are vectorized and tested:

- TMath::Min
- TMath::Gaus
- TMath::BreitWigner
- TMath::CauchyDist
- TMath::LaplaceDist
- TMath::LaplaceDistI

TODO:
- [ ] Refactor the tests to avoid repeated code.
- [ ] Implement remaining functions.
- [ ] Discuss what to do with functions that, i.e., receive an Int_t and return a Double_t. When vectorizing this kind of patterns, one problem arises: the length of integers and double vectors cannot be assumed to be the same.

Any comment is more than welcome.