### PR TITLE
Always include <stdio.h> in snprintf.h.

### DIFF
--- a/core/clib/inc/snprintf.h
+++ b/core/clib/inc/snprintf.h
@@ -11,12 +11,12 @@
 #define ROOT_snprintf
 
 #include "RConfig.h"
+#include <stdio.h>
 
 #ifndef __CINT__
 
 #ifdef NEED_SNPRINTF
 
-#include <stdio.h>
 #include <stdarg.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
We always use size_t in this header (at least when we're not running CINT), so we also need to include a header which provides size_t to make sure this compiles on it's own.