### PR TITLE
Optimizations for TBufferMerger and parallel I/O in general

### DIFF
--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -218,7 +218,7 @@ private:
 
            // fHasRootPcmInfo needs to be atomic as long as GetListOfBases needs to modify it.
            std::atomic<Bool_t> fHasRootPcmInfo;      //!Whether info was loaded from a root pcm.
-   mutable std::atomic<Bool_t> fCanLoadClassInfo;    //!Indicates whether the ClassInfo is supposed to be available.
+   mutable std::atomic<Bool_t> fCanLoadClassInfo;    //!Indicates whether the ClassInfo is supposed to be available but was not yet loaded.
    mutable std::atomic<Bool_t> fIsOffsetStreamerSet; //!saved remember if fOffsetStreamer has been set.
    mutable std::atomic<Bool_t> fVersionUsed;         //!Indicates whether GetClassVersion has been called
 

--- a/math/mathcore/inc/Math/Math_vectypes.hxx
+++ b/math/mathcore/inc/Math/Math_vectypes.hxx
@@ -1,13 +1,31 @@
 #include "RConfigure.h"
+
 #ifdef R__HAS_VECCORE
  
-  #ifdef R__HAS_VC
-    #define VECCORE_ENABLE_VC 
-  #endif
+#if defined(R__HAS_VC) && !defined(VECCORE_ENABLE_VC)
+#define VECCORE_ENABLE_VC
+#endif
  
-  #include <VecCore/VecCore>
+#include <VecCore/VecCore>
 
-  namespace ROOT {
-    using Double_v = typename vecCore::backend::VcVector::Double_v;
-  }
+namespace ROOT {
+
+namespace Internal {
+   using ScalarBackend = vecCore::backend::Scalar;
+#ifdef VECCORE_ENABLE_VC
+   using VectorBackend = vecCore::backend::VcVector;
+#elif defined(VECCORE_ENABLE_UMESIMD)
+   using VectorBackend = vecCore::backend::UMESimd;
+#else
+   using VectorBackend = vecCore::backend::Scalar;
+#endif
+}
+   using Float_v  = typename Internal::VectorBackend::Float_v;
+   using Double_v = typename Internal::VectorBackend::Double_v;
+   using Int_v    = typename Internal::VectorBackend::Int_v;
+   using Int32_v  = typename Internal::VectorBackend::Int32_v;
+   using UInt_v   = typename Internal::VectorBackend::UInt_v;
+   using UInt32_v = typename Internal::VectorBackend::UInt32_v;
+}
+
 #endif


### PR DESCRIPTION
These changes are based on an analysis with VTune that showed that most waiting happened around `TClass::LoadClassInfo()`. Returning early without taking the lock when the information is already loaded yields very significant performance improvements. Images with each thread activity before and after the optimizations are attached. The x-axis represents time, light green means a thread is active, and dark green and brown mean running.

Before changes:
![before](https://user-images.githubusercontent.com/249404/27340439-be419240-55da-11e7-9cba-d881cfdd3104.png)

After changes:
![after](https://user-images.githubusercontent.com/249404/27340446-c57cf018-55da-11e7-9ef2-bbe30b30092f.png)


