### PR TITLE
Fix invalid return type when casting function in TClingCallFunc

### DIFF
--- a/core/metacling/src/TClingCallFunc.cxx
+++ b/core/metacling/src/TClingCallFunc.cxx
@@ -1058,11 +1058,6 @@ void TClingCallFunc::make_narg_call_with_return(const unsigned N, const string &
          for (int i = 0; i < indent_level; ++i) {
             callbuf << kIndentString;
          }
-         if (isReference) {
-            type_name += "&";
-         } else if (isPointer) {
-            type_name += "*";
-         }
          make_narg_call(type_name, N, typedefbuf, callbuf, class_name, indent_level);
          callbuf << ";\n";
          for (int i = 0; i < indent_level; ++i) {

--- a/core/metacling/test/TClingCallFuncTests.cxx
+++ b/core/metacling/test/TClingCallFuncTests.cxx
@@ -51,7 +51,10 @@ TEST(TClingCallFunc, FunctionWrapperPointer)
 
    ASSERT_TRUE(gInterpreter->Declare(wrapper.c_str()));
    // Test that we cast this function to the right function type.
-   ASSERT_TRUE(wrapper.find("((int* (&)(int, float))FunctionWrapperFuncPtr)") != wrapper.npos);
+   auto FirstCallPos = wrapper.find("((int* (&)(int, float))FunctionWrapperFuncPtr)");
+   ASSERT_TRUE(FirstCallPos != wrapper.npos);
+   auto SecondCallPos = wrapper.find("((int* (&)(int, float))FunctionWrapperFuncPtr)", FirstCallPos + 1);
+   ASSERT_TRUE(SecondCallPos != wrapper.npos);
 
    // Cleanup
    gInterpreter->CallFunc_Delete(mc);
@@ -73,7 +76,10 @@ TEST(TClingCallFunc, FunctionWrapperReference)
 
    ASSERT_TRUE(gInterpreter->Declare(wrapper.c_str()));
    // Test that we cast this function to the right function type.
-   ASSERT_TRUE(wrapper.find("((int& (&)(int*, float))FunctionWrapperFuncRef)") != wrapper.npos);
+   auto FirstCallPos = wrapper.find("((int& (&)(int*, float))FunctionWrapperFuncRef)");
+   ASSERT_TRUE(FirstCallPos != wrapper.npos);
+   auto SecondCallPos = wrapper.find("((int& (&)(int*, float))FunctionWrapperFuncRef)", FirstCallPos + 1);
+   ASSERT_TRUE(SecondCallPos != wrapper.npos);
 
    // Cleanup
    gInterpreter->CallFunc_Delete(mc);


### PR DESCRIPTION
We accidentially check and annotate the return type of the function twice for
being a pointer/reference type when we do the "else" part of the
wrapper. This patch removes this wrong second check and extends
the tests to check that the cast in both branches of the if/else
is correct.