### PR TITLE
Introduce Reentrant Read Write Lock

### DIFF
--- a/core/base/inc/LinkDef3.h
+++ b/core/base/inc/LinkDef3.h
@@ -165,6 +165,7 @@
 #pragma link C++ class TFileCollection+;
 #pragma link C++ class TVirtualAuth;
 #pragma link C++ class TVirtualMutex;
+#pragma link C++ class TVirtualRWMutex;
 #pragma link C++ class TLockGuard;
 #pragma link C++ class TRedirectOutputGuard;
 #pragma link C++ class TVirtualPerfStats;

--- a/core/base/inc/TVirtualMutex.h
+++ b/core/base/inc/TVirtualMutex.h
@@ -29,7 +29,7 @@ class TVirtualMutex;
 // Global mutex set in TThread::Init
 R__EXTERN TVirtualMutex *gGlobalMutex;
 
-class TVirtualMutex : public TObject {
+class TVirtualMutex {
 
 public:
    TVirtualMutex(Bool_t /* recursive */ = kFALSE) { }

--- a/core/base/inc/TVirtualMutex.h
+++ b/core/base/inc/TVirtualMutex.h
@@ -44,7 +44,7 @@ public:
 
    virtual TVirtualMutex *Factory(Bool_t /*recursive*/ = kFALSE) = 0;
 
-   ClassDef(TVirtualMutex,0)  // Virtual mutex lock class
+   ClassDef(TVirtualMutex, 0)  // Virtual mutex lock class
 };
 
 

--- a/core/base/inc/TVirtualRWMutex.h
+++ b/core/base/inc/TVirtualRWMutex.h
@@ -41,7 +41,7 @@ public:
 
    TVirtualRWMutex *Factory(Bool_t /*recursive*/ = kFALSE) override = 0;
 
-   ClassDefOverride(TVirtualRWMutex,0)  // Virtual mutex lock class
+   ClassDefOverride(TVirtualRWMutex, 0)  // Virtual mutex lock class
 };
 
 

--- a/core/base/inc/TVirtualRWMutex.h
+++ b/core/base/inc/TVirtualRWMutex.h
@@ -1,0 +1,49 @@
+// @(#)root/base:$Id$
+// Author: Philippe Canal, 2017
+
+/*************************************************************************
+ * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TVirtualRWMutex
+#define ROOT_TVirtualRWMutex
+
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// TVirtualRWMutex                                                      //
+//                                                                      //
+// This class implements a read-write mutex interface. The actual work  //
+// is done via TRWSpinLock which is available as soon as the thread     //
+// library is loaded.                                                   //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+
+#include "TVirtualMutex.h"
+
+
+class TVirtualRWMutex : public TVirtualMutex  {
+
+public:
+   virtual void ReadLock() = 0;
+   virtual void ReadUnLock() = 0;
+   virtual void WriteLock() = 0;
+   virtual void WriteUnLock() = 0;
+
+   Int_t Lock() override { WriteLock(); return 1; }
+   Int_t TryLock() override { WriteLock(); return 1; }
+   Int_t UnLock() override { WriteUnLock(); return 1; }
+   Int_t CleanUp() override { WriteUnLock(); return 1; }
+
+   TVirtualRWMutex *Factory(Bool_t /*recursive*/ = kFALSE) override = 0;
+
+   ClassDefOverride(TVirtualRWMutex,0)  // Virtual mutex lock class
+};
+
+
+
+#endif

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -497,9 +497,6 @@ namespace Internal {
    /// Enables the global mutex to make ROOT thread safe/aware.
    void EnableThreadSafety()
    {
-      // 'Insure' gROOT is created before initializing the Thread safe behavior
-      // (to make sure we do not have two attempting to create it).
-      GetROOT();
       static void (*sym)() = (void(*)())Internal::GetSymInLibImt("ROOT_TThread_Initialize");
       if (sym)
          sym();

--- a/core/cont/inc/TCollection.h
+++ b/core/cont/inc/TCollection.h
@@ -60,7 +60,7 @@ R__EXTERN TVirtualMutex *gCollectionMutex;
 class TCollection : public TObject {
 
 #ifdef R__CHECK_COLLECTION_MULTI_ACCESS
-protected:
+public:
    class TErrorLock {
       // Warn when multiple thread try to acquire the same 'lock'
       std::atomic<std::thread::id> fWriteCurrent;
@@ -81,7 +81,7 @@ protected:
                           const char *function);
 
    public:
-      TErrorLock() : fWriteCurrentRecurse(0), fReadCurrentRecurse(0) { std::atomic_flag_clear(&fSpinLockFlag); }
+      TErrorLock() : fWriteCurrent(), fWriteCurrentRecurse(0), fReadCurrentRecurse(0) { std::atomic_flag_clear(&fSpinLockFlag); }
 
       class WriteGuard {
          TErrorLock *fLock;

--- a/core/cont/inc/TCollection.h
+++ b/core/cont/inc/TCollection.h
@@ -81,7 +81,10 @@ public:
                           const char *function);
 
    public:
-      TErrorLock() : fWriteCurrent(), fWriteCurrentRecurse(0), fReadCurrentRecurse(0) { std::atomic_flag_clear(&fSpinLockFlag); }
+      TErrorLock() : fWriteCurrent(), fWriteCurrentRecurse(0), fReadCurrentRecurse(0)
+      {
+         std::atomic_flag_clear(&fSpinLockFlag);
+      }
 
       class WriteGuard {
          TErrorLock *fLock;

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -2982,6 +2982,12 @@ Bool_t TCling::HandleNewTransaction(const cling::Transaction &T)
 
 void TCling::RecursiveRemove(TObject* obj)
 {
+   // NOTE: When replacing the mutex by a ReadWrite mutex, we **must**
+   // put in place the Read/Write part here.  Keeping the write lock
+   // here is 'catasptrophic' for scaling as it means that ALL calls
+   // to RecursiveRemove will take the write lock and performance
+   // of many threads trying to access the write lock at the same
+   // time is relatively bad.
    R__LOCKGUARD(gInterpreterMutex);
    // Note that fgSetOfSpecials is supposed to be updated by TClingCallbacks::tryFindROOTSpecialInternal
    // (but isn't at the moment).

--- a/core/thread/CMakeLists.txt
+++ b/core/thread/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 
 set(sources TCondition.cxx TConditionImp.cxx TMutex.cxx TMutexImp.cxx
             TRWLock.cxx TRWSpinLock.cxx TSemaphore.cxx TThread.cxx TThreadFactory.cxx
-            TThreadImp.cxx)
+            TThreadImp.cxx TRWMutexImp.cxx)
 if(NOT WIN32)
   set(sources ${sources} TPosixCondition.cxx TPosixMutex.cxx
                          TPosixThread.cxx TPosixThreadFactory.cxx)

--- a/core/thread/CMakeLists.txt
+++ b/core/thread/CMakeLists.txt
@@ -5,7 +5,7 @@
 set(headers TAtomicCount.h TCondition.h TConditionImp.h TMutex.h TMutexImp.h
             TRWLock.h ROOT/TRWSpinLock.hxx TSemaphore.h TThread.h TThreadFactory.h
             TThreadImp.h ROOT/TThreadedObject.hxx TThreadPool.h
-            ThreadLocalStorage.h ROOT/TSpinMutex.hxx)
+            ThreadLocalStorage.h ROOT/TSpinMutex.hxx ROOT/TReentrantRWLock.hxx)
 if(NOT WIN32)
   set(headers ${headers} TPosixCondition.h TPosixMutex.h
                          TPosixThread.h TPosixThreadFactory.h PosixThreadInc.h)
@@ -18,7 +18,7 @@ endif()
 
 set(sources TCondition.cxx TConditionImp.cxx TMutex.cxx TMutexImp.cxx
             TRWLock.cxx TRWSpinLock.cxx TSemaphore.cxx TThread.cxx TThreadFactory.cxx
-            TThreadImp.cxx TRWMutexImp.cxx)
+            TThreadImp.cxx TRWMutexImp.cxx TReentrantRWLock.cxx)
 if(NOT WIN32)
   set(sources ${sources} TPosixCondition.cxx TPosixMutex.cxx
                          TPosixThread.cxx TPosixThreadFactory.cxx)

--- a/core/thread/CMakeLists.txt
+++ b/core/thread/CMakeLists.txt
@@ -32,3 +32,7 @@ ROOT_GENERATE_DICTIONARY(G__Thread ${headers} STAGE1 MODULE Thread LINKDEF LinkD
 ROOT_OBJECT_LIBRARY(ThreadObjs ${sources} G__Thread.cxx)
 ROOT_LINKER_LIBRARY(Thread $<TARGET_OBJECTS:ThreadObjs> LIBRARIES ${CMAKE_THREAD_LIBS_INIT} DEPENDENCIES Core BUILTINS)
 ROOT_INSTALL_HEADERS(${installoptions})
+
+if(testing)
+    add_subdirectory(test)
+endif()

--- a/core/thread/Module.mk
+++ b/core/thread/Module.mk
@@ -25,7 +25,8 @@ THREADH      := $(MODDIRI)/TCondition.h $(MODDIRI)/TConditionImp.h \
                 $(MODDIRI)/TThreadImp.h $(MODDIRI)/TAtomicCount.h \
                 $(MODDIRI)/TThreadPool.h $(MODDIRI)/ThreadLocalStorage.h \
                 $(MODDIRI)/ROOT/TThreadedObject.hxx \
-                $(MODDIRI)/ROOT/TSpinMutex.hxx
+                $(MODDIRI)/ROOT/TSpinMutex.hxx \
+                $(MODDIRI)/ROOT/TReentrantRWLock.hxx
 
 ifeq ($(IMT),yes)
 THREADH      += $(MODDIRI)/ROOT/TThreadExecutor.hxx
@@ -48,7 +49,7 @@ THREADS      := $(MODDIRS)/TCondition.cxx $(MODDIRS)/TConditionImp.cxx \
                 $(MODDIRS)/TMutex.cxx $(MODDIRS)/TMutexImp.cxx \
                 $(MODDIRS)/TRWLock.cxx $(MODDIRS)/TSemaphore.cxx \
                 $(MODDIRS)/TThread.cxx $(MODDIRS)/TThreadFactory.cxx \
-                $(MODDIRS)/TThreadImp.cxx
+                $(MODDIRS)/TThreadImp.cxx $(MODDIRS)/TReentrantRWLock.cxx
 ifneq ($(ARCH),win32)
 THREADS      += $(MODDIRS)/TPosixCondition.cxx $(MODDIRS)/TPosixMutex.cxx \
                 $(MODDIRS)/TPosixThread.cxx $(MODDIRS)/TPosixThreadFactory.cxx

--- a/core/thread/inc/ROOT/TReentrantRWLock.hxx
+++ b/core/thread/inc/ROOT/TReentrantRWLock.hxx
@@ -1,0 +1,44 @@
+// @(#)root/thread:$Id$
+// Authors: Enric Tejedor CERN  12/09/2016
+//          Philippe Canal FNAL 12/09/2016
+
+/*************************************************************************
+ * Copyright (C) 1995-2016, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TRWSpinLock
+#define ROOT_TRWSpinLock
+
+#include "TSpinMutex.hxx"
+
+#include <atomic>
+#include <condition_variable>
+
+
+namespace ROOT {
+   class TRWSpinLock {
+   private:
+      std::atomic<int>             fReaders; ///<! Number of readers
+      std::atomic<int>             fReaderReservation; ///<! A reader wants access
+      std::atomic<int>             fWriterReservation; ///<! A writer wants access
+      std::atomic<bool>            fWriter;  ///<! Is there a writer?
+      ROOT::TSpinMutex             fMutex;   ///<! RWlock internal mutex
+      std::condition_variable_any  fCond;    ///<! RWlock internal condition variable
+
+   public:
+      ////////////////////////////////////////////////////////////////////////
+      /// Regular constructor.
+      TRWSpinLock() : fReaders(0), fReaderReservation(0), fWriterReservation(0), fWriter(false) {}
+
+      void ReadLock();
+      void ReadUnLock();
+      void WriteLock();
+      void WriteUnLock();
+   };
+} // end of namespace ROOT
+
+#endif

--- a/core/thread/inc/ROOT/TReentrantRWLock.hxx
+++ b/core/thread/inc/ROOT/TReentrantRWLock.hxx
@@ -21,30 +21,129 @@
 #include <unordered_map>
 
 namespace ROOT {
-   template <typename MutexT = ROOT::TSpinMutex>
-   class TReentrantRWLock {
-   private:
-      using ReaderColl_t = std::unordered_map<std::thread::id,int>;
+namespace Internal {
+struct UniqueLockRecurseCount {
+   struct LocalCounts {
+      int fReadersCount = 0;
+      bool fIsWriter = false;
+   };
+   size_t fWriteRecurse = 0; ///<! Number of re-entry in the lock by the same thread.
 
-      std::atomic<int>             fReaders; ///<! Number of readers
-      std::atomic<int>             fReaderReservation; ///<! A reader wants access
-      std::atomic<int>             fWriterReservation; ///<! A writer wants access
-      std::atomic<bool>            fWriter;  ///<! Is there a writer?
-      MutexT                       fMutex;   ///<! RWlock internal mutex
-      std::condition_variable_any  fCond;    ///<! RWlock internal condition variable
-      std::thread::id              fWriterThread; ///<! Holder of the write lock
-      size_t                       fWriteRecurse; ///<! Number of re-entry in the lock by the same thread.
-      ReaderColl_t                 fReadersCount; ///<! Set of reader thread ids
+   UniqueLockRecurseCount();
 
-   public:
-      ////////////////////////////////////////////////////////////////////////
-      /// Regular constructor.
-      TReentrantRWLock() : fReaders(0), fReaderReservation(0), fWriterReservation(0), fWriter(false), fWriteRecurse(0) {}
+   using local_t = LocalCounts*;
 
-      void ReadLock();
-      void ReadUnLock();
-      void WriteLock();
-      void WriteUnLock();
+   local_t GetLocal() {
+      static thread_local LocalCounts gLocal;
+      return &gLocal;
+   }
+
+   void IncrementReadCount(local_t &local) { ++(local->fReadersCount); }
+
+   template <typename MutexT>
+   void IncrementReadCount(local_t &local, MutexT &) { IncrementReadCount(local); }
+
+   void DecrementReadCount(local_t &local) { --(local->fReadersCount); }
+
+   template <typename MutexT>
+   void DecrementReadCount(local_t &local, MutexT &) { DecrementReadCount(local); }
+
+   bool IsNotCurrentWriter(local_t &local) { return !local->fIsWriter; }
+
+   void SetIsWriter(local_t &local)
+   {
+      // if (fWriteRecurse == std::numeric_limits<decltype(fWriteRecurse)>::max()) {
+      //    ::Fatal("TRWSpinLock::WriteLock", "Too many recursions in TRWSpinLock!");
+      // }
+      ++fWriteRecurse;
+      local->fIsWriter = true;
+   }
+
+   void DecrementWriteCount() { --fWriteRecurse; }
+
+   void ResetIsWriter(local_t &local) { local->fIsWriter = false; }
+
+   size_t GetLocalReadersCount(local_t &local) { return local->fReadersCount; }
+};
+
+struct RecurseCounts {
+   using ReaderColl_t = std::unordered_map<std::thread::id, int>;
+   size_t fWriteRecurse; ///<! Number of re-entry in the lock by the same thread.
+
+   std::thread::id fWriterThread; ///<! Holder of the write lock
+   ReaderColl_t fReadersCount;    ///<! Set of reader thread ids
+
+   using local_t = std::thread::id;
+
+   local_t GetLocal() { return std::this_thread::get_id(); }
+
+   void IncrementReadCount(local_t &local) { ++(fReadersCount[local]); }
+
+   template <typename MutexT>
+   void IncrementReadCount(local_t &local, MutexT &mutex)
+   {
+      std::unique_lock<MutexT> lock(mutex);
+      IncrementReadCount(local);
+   }
+
+   void DecrementReadCount(local_t &local) { --(fReadersCount[local]); }
+
+   template <typename MutexT>
+   void DecrementReadCount(local_t &local, MutexT &mutex)
+   {
+      std::unique_lock<MutexT> lock(mutex);
+      DecrementReadCount(local);
+   }
+
+   bool IsNotCurrentWriter(local_t &local) { return fWriterThread != local; }
+
+   void SetIsWriter(local_t &local)
+   {
+      // if (fWriteRecurse == std::numeric_limits<decltype(fWriteRecurse)>::max()) {
+      //    ::Fatal("TRWSpinLock::WriteLock", "Too many recursions in TRWSpinLock!");
+      // }
+      ++fWriteRecurse;
+      fWriterThread = local;
+   }
+
+   void DecrementWriteCount() { --fWriteRecurse; }
+
+   void ResetIsWriter(local_t & /* local */) { fWriterThread = std::thread::id(); }
+
+   size_t GetLocalReadersCount(local_t &local) { return fReadersCount[local]; }
+
+
+};
+} // Internal
+
+template <typename MutexT = ROOT::TSpinMutex, typename RecurseCountsT = Internal::RecurseCounts>
+class TReentrantRWLock {
+private:
+
+   std::atomic<int> fReaders;           ///<! Number of readers
+   std::atomic<int> fReaderReservation; ///<! A reader wants access
+   std::atomic<int> fWriterReservation; ///<! A writer wants access
+   std::atomic<bool> fWriter;           ///<! Is there a writer?
+   MutexT fMutex;                       ///<! RWlock internal mutex
+   std::condition_variable_any fCond;   ///<! RWlock internal condition variable
+
+   RecurseCountsT fRecurseCounts;        ///<! Trackers for re-entry in the lock by the same thread.
+
+   // size_t fWriteRecurse;                ///<! Number of re-entry in the lock by the same thread.
+
+   // std::thread::id fWriterThread; ///<! Holder of the write lock
+   // ReaderColl_t fReadersCount;    ///<! Set of reader thread ids
+
+public:
+   ////////////////////////////////////////////////////////////////////////
+   /// Regular constructor.
+   TReentrantRWLock() : fReaders(0), fReaderReservation(0), fWriterReservation(0), fWriter(false) {}
+
+   void ReadLock();
+   void ReadUnLock();
+   void WriteLock();
+   void WriteUnLock();
+
    };
 } // end of namespace ROOT
 

--- a/core/thread/inc/TMutex.h
+++ b/core/thread/inc/TMutex.h
@@ -47,6 +47,10 @@ public:
    Int_t  UnLock();
    Int_t  CleanUp();
 
+   // Compatibility with standard library
+   void lock() { TMutex::Lock(); }
+   void unlock() { TMutex::UnLock(); }
+
    TVirtualMutex *Factory(Bool_t recursive = kFALSE);
 
    ClassDef(TMutex,0)  // Mutex lock class

--- a/core/thread/src/TMutex.cxx
+++ b/core/thread/src/TMutex.cxx
@@ -23,7 +23,7 @@
 #include "TMutex.h"
 #include "TThreadFactory.h"
 #include <errno.h>
-
+#include "TError.h"
 
 ClassImp(TMutex);
 

--- a/core/thread/src/TRWMutexImp.cxx
+++ b/core/thread/src/TRWMutexImp.cxx
@@ -19,12 +19,14 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "TRWMutexImp.h"
-
+#include "ROOT/TSpinMutex.hxx"
+#include "TMutex.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Take the Read Lock of the mutex.
 
-void TRWMutexImp::ReadLock()
+template <typename MutexT>
+void TRWMutexImp<MutexT>::ReadLock()
 {
    fMutexImp.ReadLock();
 }
@@ -32,7 +34,8 @@ void TRWMutexImp::ReadLock()
 ////////////////////////////////////////////////////////////////////////////////
 /// Take the Write Lock of the mutex.
 
-void TRWMutexImp::WriteLock()
+template <typename MutexT>
+void TRWMutexImp<MutexT>::WriteLock()
 {
    fMutexImp.WriteLock();
 }
@@ -40,7 +43,8 @@ void TRWMutexImp::WriteLock()
 ////////////////////////////////////////////////////////////////////////////////
 /// Release the read lock of the mutex
 
-void TRWMutexImp::ReadUnLock()
+template <typename MutexT>
+void TRWMutexImp<MutexT>::ReadUnLock()
 {
    fMutexImp.ReadUnLock();
 }
@@ -48,7 +52,8 @@ void TRWMutexImp::ReadUnLock()
 ////////////////////////////////////////////////////////////////////////////////
 /// Release the read lock of the mutex
 
-void TRWMutexImp::WriteUnLock()
+template <typename MutexT>
+void TRWMutexImp<MutexT>::WriteUnLock()
 {
    fMutexImp.WriteUnLock();
 }
@@ -56,7 +61,11 @@ void TRWMutexImp::WriteUnLock()
 ////////////////////////////////////////////////////////////////////////////////
 /// Create mutex and return pointer to it.
 
-TVirtualRWMutex *TRWMutexImp::Factory(Bool_t /*recursive = kFALSE*/)
+template <typename MutexT>
+TVirtualRWMutex *TRWMutexImp<MutexT>::Factory(Bool_t /*recursive = kFALSE*/)
 {
    return new TRWMutexImp();
 }
+
+template class TRWMutexImp<TMutex>;
+template class TRWMutexImp<ROOT::TSpinMutex>;

--- a/core/thread/src/TRWMutexImp.cxx
+++ b/core/thread/src/TRWMutexImp.cxx
@@ -1,0 +1,62 @@
+// @(#)root/thread:$Id$
+// Author: Fons Rademakers   26/06/97
+
+/*************************************************************************
+ * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// TRWMutexImp                                                          //
+//                                                                      //
+// This class implements the TVirtualRWMutex interface,                 //
+// based on TRWSpinLock.                                                //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+
+#include "TRWMutexImp.h"
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Take the Read Lock of the mutex.
+
+void TRWMutexImp::ReadLock()
+{
+   fMutexImp.ReadLock();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Take the Write Lock of the mutex.
+
+void TRWMutexImp::WriteLock()
+{
+   fMutexImp.WriteLock();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Release the read lock of the mutex
+
+void TRWMutexImp::ReadUnLock()
+{
+   fMutexImp.ReadUnLock();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Release the read lock of the mutex
+
+void TRWMutexImp::WriteUnLock()
+{
+   fMutexImp.WriteUnLock();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Create mutex and return pointer to it.
+
+TVirtualRWMutex *TRWMutexImp::Factory(Bool_t /*recursive = kFALSE*/)
+{
+   return new TRWMutexImp();
+}

--- a/core/thread/src/TRWMutexImp.cxx
+++ b/core/thread/src/TRWMutexImp.cxx
@@ -25,8 +25,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// Take the Read Lock of the mutex.
 
-template <typename MutexT>
-void TRWMutexImp<MutexT>::ReadLock()
+template <typename MutexT, typename RecurseCountsT>
+void TRWMutexImp<MutexT, RecurseCountsT>::ReadLock()
 {
    fMutexImp.ReadLock();
 }
@@ -34,8 +34,8 @@ void TRWMutexImp<MutexT>::ReadLock()
 ////////////////////////////////////////////////////////////////////////////////
 /// Take the Write Lock of the mutex.
 
-template <typename MutexT>
-void TRWMutexImp<MutexT>::WriteLock()
+template <typename MutexT, typename RecurseCountsT>
+void TRWMutexImp<MutexT, RecurseCountsT>::WriteLock()
 {
    fMutexImp.WriteLock();
 }
@@ -43,8 +43,8 @@ void TRWMutexImp<MutexT>::WriteLock()
 ////////////////////////////////////////////////////////////////////////////////
 /// Release the read lock of the mutex
 
-template <typename MutexT>
-void TRWMutexImp<MutexT>::ReadUnLock()
+template <typename MutexT, typename RecurseCountsT>
+void TRWMutexImp<MutexT, RecurseCountsT>::ReadUnLock()
 {
    fMutexImp.ReadUnLock();
 }
@@ -52,8 +52,8 @@ void TRWMutexImp<MutexT>::ReadUnLock()
 ////////////////////////////////////////////////////////////////////////////////
 /// Release the read lock of the mutex
 
-template <typename MutexT>
-void TRWMutexImp<MutexT>::WriteUnLock()
+template <typename MutexT, typename RecurseCountsT>
+void TRWMutexImp<MutexT, RecurseCountsT>::WriteUnLock()
 {
    fMutexImp.WriteUnLock();
 }
@@ -61,11 +61,13 @@ void TRWMutexImp<MutexT>::WriteUnLock()
 ////////////////////////////////////////////////////////////////////////////////
 /// Create mutex and return pointer to it.
 
-template <typename MutexT>
-TVirtualRWMutex *TRWMutexImp<MutexT>::Factory(Bool_t /*recursive = kFALSE*/)
+template <typename MutexT, typename RecurseCountsT>
+TVirtualRWMutex *TRWMutexImp<MutexT, RecurseCountsT>::Factory(Bool_t /*recursive = kFALSE*/)
 {
    return new TRWMutexImp();
 }
 
 template class TRWMutexImp<TMutex>;
 template class TRWMutexImp<ROOT::TSpinMutex>;
+template class TRWMutexImp<TMutex, ROOT::Internal::UniqueLockRecurseCount>;
+template class TRWMutexImp<ROOT::TSpinMutex, ROOT::Internal::UniqueLockRecurseCount>;

--- a/core/thread/src/TRWMutexImp.h
+++ b/core/thread/src/TRWMutexImp.h
@@ -17,9 +17,9 @@
 
 #include "TBuffer.h" // Needed by ClassDEfInlineOverride
 
-template <typename MutexT>
+template <typename MutexT, typename RecurseCountsT = ROOT::Internal::RecurseCounts>
 class TRWMutexImp : public TVirtualRWMutex  {
-   ROOT::TReentrantRWLock<MutexT> fMutexImp;
+   ROOT::TReentrantRWLock<MutexT, RecurseCountsT> fMutexImp;
 
 public:
 

--- a/core/thread/src/TRWMutexImp.h
+++ b/core/thread/src/TRWMutexImp.h
@@ -18,11 +18,10 @@
 #include "TBuffer.h" // Needed by ClassDEfInlineOverride
 
 template <typename MutexT, typename RecurseCountsT = ROOT::Internal::RecurseCounts>
-class TRWMutexImp : public TVirtualRWMutex  {
+class TRWMutexImp : public TVirtualRWMutex {
    ROOT::TReentrantRWLock<MutexT, RecurseCountsT> fMutexImp;
 
 public:
-
    void ReadLock() override;
    void ReadUnLock() override;
    void WriteLock() override;

--- a/core/thread/src/TRWMutexImp.h
+++ b/core/thread/src/TRWMutexImp.h
@@ -1,0 +1,34 @@
+// Author: Philippe Canal, 2017
+
+/*************************************************************************
+ * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TRWMutexImp
+#define ROOT_TRWMutexImp
+
+#include "TVirtualRWMutex.h"
+#include "ROOT/TRWSpinLock.hxx"
+
+#include "TBuffer.h" // Needed by ClassDEfInlineOverride
+
+class TRWMutexImp : public TVirtualRWMutex  {
+   ROOT::TRWSpinLock fMutexImp;
+
+public:
+
+   void ReadLock() override;
+   void ReadUnLock() override;
+   void WriteLock() override;
+   void WriteUnLock() override;
+
+   TVirtualRWMutex *Factory(Bool_t /*recursive*/ = kFALSE) override;
+
+   ClassDefInlineOverride(TRWMutexImp,0)  // Concrete RW mutex lock class
+};
+
+#endif

--- a/core/thread/src/TRWMutexImp.h
+++ b/core/thread/src/TRWMutexImp.h
@@ -12,12 +12,14 @@
 #define ROOT_TRWMutexImp
 
 #include "TVirtualRWMutex.h"
-#include "ROOT/TRWSpinLock.hxx"
+#include "ROOT/TSpinMutex.hxx"
+#include "ROOT/TReentrantRWLock.hxx"
 
 #include "TBuffer.h" // Needed by ClassDEfInlineOverride
 
+template <typename MutexT>
 class TRWMutexImp : public TVirtualRWMutex  {
-   ROOT::TRWSpinLock fMutexImp;
+   ROOT::TReentrantRWLock<MutexT> fMutexImp;
 
 public:
 

--- a/core/thread/src/TReentrantRWLock.cxx
+++ b/core/thread/src/TReentrantRWLock.cxx
@@ -1,0 +1,111 @@
+// @(#)root/thread:$Id$
+// Authors: Enric Tejedor CERN  12/09/2016
+//          Philippe Canal FNAL 12/09/2016
+
+/*************************************************************************
+ * Copyright (C) 1995-2016, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+/** \class TRWSpinLock
+    \brief An implementation of a read-write lock with an internal spin lock.
+
+This class provides an implementation of a read-write lock that uses an
+internal spin lock and a condition variable to synchronize readers and
+writers when necessary.
+
+The implementation tries to make faster the scenario when readers come
+and go but there is no writer. In that case, readers will not pay the
+price of taking the internal spin lock.
+
+Moreover, this RW lock tries to be fair with writers, giving them the
+possibility to claim the lock and wait for only the remaining readers,
+thus preventing starvation.
+*/
+
+#include "ROOT/TRWSpinLock.hxx"
+
+using namespace ROOT;
+
+////////////////////////////////////////////////////////////////////////////
+/// Acquire the lock in read mode.
+void TRWSpinLock::ReadLock()
+{
+  ++fReaderReservation;
+   if (!fWriter) {
+      // There is no writer, go freely to the critical section
+      ++fReaders;
+      --fReaderReservation;
+   } else {
+      // A writer claimed the RW lock, we will need to wait on the
+      // internal lock
+      --fReaderReservation;
+
+      std::unique_lock<ROOT::TSpinMutex> lock(fMutex);
+
+      // Wait for writers, if any
+      fCond.wait(lock, [this]{ return !fWriter; });
+
+      // This RW lock now belongs to the readers
+      ++fReaders;
+
+      lock.unlock();
+   }
+}
+
+//////////////////////////////////////////////////////////////////////////
+/// Release the lock in read mode.
+void TRWSpinLock::ReadUnLock()
+{
+   --fReaders;
+   if (fWriterReservation && fReaders == 0) {
+      // We still need to lock here to prevent interleaving with a writer
+      std::lock_guard<ROOT::TSpinMutex> lock(fMutex);
+
+      // Make sure you wake up a writer, if any
+      // Note: spurrious wakeups are okay, fReaders
+      // will be checked again in WriteLock
+      fCond.notify_all();
+   }
+}
+
+//////////////////////////////////////////////////////////////////////////
+/// Acquire the lock in write mode.
+void TRWSpinLock::WriteLock()
+{
+   ++fWriterReservation;
+
+   std::unique_lock<ROOT::TSpinMutex> lock(fMutex);
+
+   // Wait for other writers, if any
+   fCond.wait(lock, [this]{ return !fWriter; });
+
+   // Claim the lock for this writer
+   fWriter = true;
+
+   // Wait until all reader reservations finish
+   while(fReaderReservation) {};
+
+   // Wait for remaining readers
+   fCond.wait(lock, [this]{ return fReaders == 0; });
+
+   --fWriterReservation;
+
+   lock.unlock();
+}
+
+//////////////////////////////////////////////////////////////////////////
+/// Release the lock in write mode.
+void TRWSpinLock::WriteUnLock()
+{
+   // We need to lock here to prevent interleaving with a reader
+   std::lock_guard<ROOT::TSpinMutex> lock(fMutex);
+
+   fWriter = false;
+
+   // Notify all potential readers/writers that are waiting
+   fCond.notify_all();
+}

--- a/core/thread/src/TReentrantRWLock.cxx
+++ b/core/thread/src/TReentrantRWLock.cxx
@@ -10,12 +10,17 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-/** \class TRWSpinLock
-    \brief An implementation of a read-write lock with an internal spin lock.
+/** \class TReentrantRWLock
+    \brief An implementation of a reentrant read-write lock with a
+           configurable internal mutex/lock (default Spin Lock).
 
-This class provides an implementation of a read-write lock that uses an
-internal spin lock and a condition variable to synchronize readers and
-writers when necessary.
+This class provides an implementation of a rreentrant ead-write lock
+that uses an internal lock and a condition variable to synchronize
+readers and writers when necessary.
+
+The implementation allows a single reader to take the write lock without
+releasing the reader lock.  It also allows the writer to take a read lock.
+In other word, the lock is re-entrant for both reading and writing.
 
 The implementation tries to make faster the scenario when readers come
 and go but there is no writer. In that case, readers will not pay the
@@ -26,28 +31,39 @@ possibility to claim the lock and wait for only the remaining readers,
 thus preventing starvation.
 */
 
-#include "ROOT/TRWSpinLock.hxx"
+#include "ROOT/TReentrantRWLock.hxx"
+#include "ROOT/TSpinMutex.hxx"
+#include "TMutex.h"
+#include "TError.h"
 
 using namespace ROOT;
 
 ////////////////////////////////////////////////////////////////////////////
 /// Acquire the lock in read mode.
-void TRWSpinLock::ReadLock()
+template <typename MutexT>
+void TReentrantRWLock<MutexT>::ReadLock()
 {
-  ++fReaderReservation;
+   ++fReaderReservation;
+   auto local = std::this_thread::get_id();
    if (!fWriter) {
       // There is no writer, go freely to the critical section
       ++fReaders;
       --fReaderReservation;
+
+      std::unique_lock<MutexT> lock(fMutex);
+      ++(fReadersCount[local]);
    } else {
       // A writer claimed the RW lock, we will need to wait on the
       // internal lock
       --fReaderReservation;
 
-      std::unique_lock<ROOT::TSpinMutex> lock(fMutex);
+      std::unique_lock<MutexT> lock(fMutex);
 
       // Wait for writers, if any
-      fCond.wait(lock, [this]{ return !fWriter; });
+      if (fWriter && fWriterThread != local)
+         fCond.wait(lock, [this]{ return !fWriter; });
+
+      ++(fReadersCount[local]);
 
       // This RW lock now belongs to the readers
       ++fReaders;
@@ -58,39 +74,72 @@ void TRWSpinLock::ReadLock()
 
 //////////////////////////////////////////////////////////////////////////
 /// Release the lock in read mode.
-void TRWSpinLock::ReadUnLock()
+template <typename MutexT>
+void TReentrantRWLock<MutexT>::ReadUnLock()
 {
+   auto local = std::this_thread::get_id();
+
    --fReaders;
    if (fWriterReservation && fReaders == 0) {
       // We still need to lock here to prevent interleaving with a writer
-      std::lock_guard<ROOT::TSpinMutex> lock(fMutex);
+      std::lock_guard<MutexT> lock(fMutex);
+
+      --(fReadersCount[local]);
 
       // Make sure you wake up a writer, if any
       // Note: spurrious wakeups are okay, fReaders
       // will be checked again in WriteLock
       fCond.notify_all();
+   } else {
+      std::lock_guard<MutexT> lock(fMutex);
+
+      --fReadersCount[local];
    }
 }
 
 //////////////////////////////////////////////////////////////////////////
 /// Acquire the lock in write mode.
-void TRWSpinLock::WriteLock()
+template <typename MutexT>
+void TReentrantRWLock<MutexT>::WriteLock()
 {
    ++fWriterReservation;
 
-   std::unique_lock<ROOT::TSpinMutex> lock(fMutex);
+   std::unique_lock<MutexT> lock(fMutex);
+
+   auto local = std::this_thread::get_id();
+
+   // Release this thread's reader lock(s)
+   auto readerCount = fReadersCount[local];
+
+   fReaders -= readerCount;
 
    // Wait for other writers, if any
-   fCond.wait(lock, [this]{ return !fWriter; });
+   if (fWriter && fWriterThread != local) {}
+      if (readerCount && fReaders == 0) {
+          // we decrease fReaders to zero, let's wake up the
+          // other writer.
+          fCond.notify_all();
+      }
+      fCond.wait(lock, [this]{ return !fWriter; });
+   }
+   
+   if (fWriteRecurse == std::numeric_limits<decltype(fWriteRecurse)>::max()) {
+      ::Fatal("TRWSpinLock::WriteLock","Too many recursions in TRWSpinLock!");
+   }
 
    // Claim the lock for this writer
    fWriter = true;
+   ++fWriteRecurse;
+   fWriterThread = local;
 
    // Wait until all reader reservations finish
    while(fReaderReservation) {};
 
    // Wait for remaining readers
    fCond.wait(lock, [this]{ return fReaders == 0; });
+
+   // Restore this thread's reader lock(s)
+   fReaders += readerCount;
 
    --fWriterReservation;
 
@@ -99,13 +148,28 @@ void TRWSpinLock::WriteLock()
 
 //////////////////////////////////////////////////////////////////////////
 /// Release the lock in write mode.
-void TRWSpinLock::WriteUnLock()
+template <typename MutexT>
+void TReentrantRWLock<MutexT>::WriteUnLock()
 {
    // We need to lock here to prevent interleaving with a reader
-   std::lock_guard<ROOT::TSpinMutex> lock(fMutex);
+   std::lock_guard<MutexT> lock(fMutex);
 
-   fWriter = false;
+   if (!fWriter || fWriteRecurse == 0) {
+      Error("TRWSpinLock::WriteUnLock","Write lock already released for %p",this);
+      return;
+   }
 
-   // Notify all potential readers/writers that are waiting
-   fCond.notify_all();
+   --fWriteRecurse;
+
+   if (!fWriteRecurse) {
+      fWriter = false;
+
+      // Notify all potential readers/writers that are waiting
+      fCond.notify_all();
+   }
+}
+
+namespace ROOT {
+   template class TReentrantRWLock<ROOT::TSpinMutex>;
+   template class TReentrantRWLock<TMutex>;
 }

--- a/core/thread/src/TReentrantRWLock.cxx
+++ b/core/thread/src/TReentrantRWLock.cxx
@@ -42,7 +42,7 @@ Internal::UniqueLockRecurseCount::UniqueLockRecurseCount()
 {
    static bool singleton = false;
    if (singleton) {
-      ::Fatal("UniqueLockRecurseCount Ctor","Only one TReentrantRWLock using a UniqueLockRecurseCount is allowed.");
+      ::Fatal("UniqueLockRecurseCount Ctor", "Only one TReentrantRWLock using a UniqueLockRecurseCount is allowed.");
    }
    singleton = true;
 }
@@ -129,9 +129,9 @@ void TReentrantRWLock<MutexT, RecurseCountsT>::WriteLock()
    // Wait for other writers, if any
    if (fWriter && fRecurseCounts.IsNotCurrentWriter(local)) {
       if (readerCount && fReaders == 0) {
-          // we decrease fReaders to zero, let's wake up the
-          // other writer.
-          fCond.notify_all();
+         // we decrease fReaders to zero, let's wake up the
+         // other writer.
+         fCond.notify_all();
       }
       fCond.wait(lock, [this] { return !fWriter; });
    }

--- a/core/thread/src/TThread.cxx
+++ b/core/thread/src/TThread.cxx
@@ -321,6 +321,10 @@ void TThread::Init()
    ::Fatal("Init","_REENTRANT must be #define-d for TThread to work properly.");
 #endif
 
+   // 'Insure' gROOT is created before initializing the Thread safe behavior
+   // (to make sure we do not have two attempting to create it).
+   ROOT::GetROOT();
+
    fgThreadImp = gThreadFactory->CreateThreadImp();
    gMainInternalMutex = new TMutex(kTRUE);
 

--- a/core/thread/test/CMakeLists.txt
+++ b/core/thread/test/CMakeLists.txt
@@ -1,0 +1,1 @@
+ROOT_ADD_UNITTEST_DIR(Core Thread)

--- a/core/thread/test/testRWLock.cxx
+++ b/core/thread/test/testRWLock.cxx
@@ -14,76 +14,87 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 
-void testWriteLockV(TVirtualMutex *m, size_t repetition) {
-   for(size_t i = 0; i < repetition; ++i) {
+void testWriteLockV(TVirtualMutex *m, size_t repetition)
+{
+   for (size_t i = 0; i < repetition; ++i) {
       m->Lock();
    }
 }
 
-void testWriteUnLockV(TVirtualMutex *m, size_t repetition) {
-   for(size_t i = 0; i < repetition; ++i) {
+void testWriteUnLockV(TVirtualMutex *m, size_t repetition)
+{
+   for (size_t i = 0; i < repetition; ++i) {
       m->UnLock();
    }
 }
 
 template <typename M>
-void testWriteTLock(M *m, size_t repetition) {
-   for(size_t i = 0; i < repetition; ++i) {
+void testWriteTLock(M *m, size_t repetition)
+{
+   for (size_t i = 0; i < repetition; ++i) {
       m->Lock();
    }
 }
 
 template <typename M>
-void testWriteLock(M *m, size_t repetition) {
-   for(size_t i = 0; i < repetition; ++i) {
+void testWriteLock(M *m, size_t repetition)
+{
+   for (size_t i = 0; i < repetition; ++i) {
       m->WriteLock();
    }
 }
 
 template <typename M>
-void testReadLock(M *m, size_t repetition) {
-   for(size_t i = 0; i < repetition; ++i) {
+void testReadLock(M *m, size_t repetition)
+{
+   for (size_t i = 0; i < repetition; ++i) {
       m->ReadLock();
    }
 }
 
 template <typename M>
-void testNonReentrantLock(M *m, size_t repetition) {
-   for(size_t i = 0; i < repetition; ++i) {
+void testNonReentrantLock(M *m, size_t repetition)
+{
+   for (size_t i = 0; i < repetition; ++i) {
       m->lock();
       m->unlock();
    }
 }
 
 template <typename M>
-void testWriteTUnLock(M *m, size_t repetition) {
-   for(size_t i = 0; i < repetition; ++i) {
+void testWriteTUnLock(M *m, size_t repetition)
+{
+   for (size_t i = 0; i < repetition; ++i) {
       m->UnLock();
    }
 }
 
 template <typename M>
-void testWriteUnLock(M *m, size_t repetition) {
-   for(size_t i = 0; i < repetition; ++i) {
+void testWriteUnLock(M *m, size_t repetition)
+{
+   for (size_t i = 0; i < repetition; ++i) {
       m->WriteUnLock();
    }
 }
 
 template <typename M>
-void testReadUnLock(M *m, size_t repetition) {
-   for(size_t i = 0; i < repetition; ++i) {
+void testReadUnLock(M *m, size_t repetition)
+{
+   for (size_t i = 0; i < repetition; ++i) {
       m->ReadUnLock();
    }
 }
 
-void testWriteGuard(TVirtualMutex *m, size_t repetition) {
-   for(size_t i = 0; i < repetition; ++i) {
+void testWriteGuard(TVirtualMutex *m, size_t repetition)
+{
+   for (size_t i = 0; i < repetition; ++i) {
       TLockGuard guard(m);
    }
 }
 
-void testReadGuard(TVirtualRWMutex *m, size_t repetition) {
-   for(size_t i = 0; i < repetition; ++i) {
+void testReadGuard(TVirtualRWMutex *m, size_t repetition)
+{
+   for (size_t i = 0; i < repetition; ++i) {
       m->ReadLock();
       m->ReadUnLock();
    }
@@ -95,13 +106,14 @@ struct Globals {
    size_t fThird = 0;
 };
 
-void writer(TVirtualRWMutex *m, Globals *global, size_t repetition) {
-   for(size_t i = 0; i < repetition; ++i) {
+void writer(TVirtualRWMutex *m, Globals *global, size_t repetition)
+{
+   for (size_t i = 0; i < repetition; ++i) {
       {
          TLockGuard guard(m);
          global->fFirst++;
          // Waste some time
-         for(size_t k = 0; k < 100; ++k) {
+         for (size_t k = 0; k < 100; ++k) {
             global->fSecond += global->fThird * global->fFirst + k;
          }
          global->fThird++;
@@ -110,36 +122,39 @@ void writer(TVirtualRWMutex *m, Globals *global, size_t repetition) {
    }
 }
 
-void reader(TVirtualRWMutex *m, Globals *global, size_t repetition) {
-   for(size_t i = 0; i < repetition; ++i) {
+void reader(TVirtualRWMutex *m, Globals *global, size_t repetition)
+{
+   for (size_t i = 0; i < repetition; ++i) {
       m->ReadLock();
-      ASSERT_EQ(global->fFirst,global->fThird);
+      ASSERT_EQ(global->fFirst, global->fThird);
       m->ReadUnLock();
       gSystem->Sleep(1 /* milliseconds */); // give sometimes to the writers
    }
 }
 
-void concurrent(TVirtualRWMutex *m, size_t nwriters, size_t nreaders, size_t repetition) {
+void concurrent(TVirtualRWMutex *m, size_t nwriters, size_t nreaders, size_t repetition)
+{
    // ROOT::EnableThreadSafety();
 
    std::vector<std::thread> threads;
 
    Globals global;
 
-   for(size_t i=0 ; i<nwriters ; ++i){
-      threads.push_back(std::thread([&](){ writer(m,&global,repetition); } ));
+   for (size_t i = 0; i < nwriters; ++i) {
+      threads.push_back(std::thread([&]() { writer(m, &global, repetition); }));
    }
-   for(size_t i=0 ; i<nreaders ; ++i){
-      threads.push_back(std::thread([&](){ reader(m,&global,repetition); } ));
+   for (size_t i = 0; i < nreaders; ++i) {
+      threads.push_back(std::thread([&]() { reader(m, &global, repetition); }));
    }
 
-   for(auto &&th : threads) {
+   for (auto &&th : threads) {
       th.join();
    }
 }
 
 template <typename T>
-void Reentrant(T &m) {
+void Reentrant(T &m)
+{
 
    m.ReadLock();
    m.ReadLock();
@@ -154,7 +169,6 @@ void Reentrant(T &m) {
 
    m.ReadLock();
 
-
    m.ReadUnLock();
    m.WriteUnLock();
    m.ReadUnLock();
@@ -163,7 +177,6 @@ void Reentrant(T &m) {
    m.ReadUnLock();
    m.ReadUnLock();
    m.ReadUnLock();
-
 }
 
 constexpr size_t gRepetition = 10000000;
@@ -177,7 +190,7 @@ auto gSpinMutex = new ROOT::TSpinMutex();
 
 // Intentionally ignore the Fatal error due to the shread thread-local storage.
 // In this test we need to be 'careful' to not use all those mutex at the same time.
-int trigger1 = gErrorIgnoreLevel = kFatal+1;
+int trigger1 = gErrorIgnoreLevel = kFatal + 1;
 auto gReentrantRWMutexTL = new ROOT::TReentrantRWLock<TMutex, ROOT::Internal::UniqueLockRecurseCount>();
 auto gReentrantRWMutexSMTL = new ROOT::TReentrantRWLock<ROOT::TSpinMutex, ROOT::Internal::UniqueLockRecurseCount>();
 auto gRWMutexTL = new TRWMutexImp<TMutex, ROOT::Internal::UniqueLockRecurseCount>();
@@ -194,7 +207,6 @@ TEST(RWLock, MutexUnLockVirtual)
    testWriteTUnLock(gMutex, gRepetition);
 }
 
-
 TEST(RWLock, WriteLockVirtual)
 {
    testWriteLockV(gRWMutex, gRepetition);
@@ -204,7 +216,6 @@ TEST(RWLock, WriteUnLockVirtual)
 {
    testWriteTUnLock(gRWMutex, gRepetition);
 }
-
 
 TEST(RWLock, WriteSpinLockVirtual)
 {
@@ -216,7 +227,6 @@ TEST(RWLock, WriteSpinUnLockVirtual)
    testWriteTUnLock(gRWMutexSpin, gRepetition);
 }
 
-
 TEST(RWLock, WriteLock)
 {
    testWriteLock(gRWMutex, gRepetition);
@@ -226,7 +236,6 @@ TEST(RWLock, WriteUnLock)
 {
    testWriteTUnLock(gRWMutex, gRepetition);
 }
-
 
 TEST(RWLock, WriteSpinLock)
 {
@@ -238,7 +247,6 @@ TEST(RWLock, WriteSpinUnLock)
    testWriteTUnLock(gRWMutexSpin, gRepetition);
 }
 
-
 TEST(RWLock, WriteSpinDirectLock)
 {
    testWriteLock(gReentrantRWMutexSM, gRepetition);
@@ -248,7 +256,6 @@ TEST(RWLock, WriteSpinDirectUnLock)
 {
    testWriteUnLock(gReentrantRWMutexSM, gRepetition);
 }
-
 
 TEST(RWLock, WriteDirectLock)
 {
@@ -260,7 +267,6 @@ TEST(RWLock, WriteDirectUnLock)
    testWriteUnLock(gReentrantRWMutex, gRepetition);
 }
 
-
 TEST(RWLock, ReadLockSpinDirect)
 {
    testReadLock(gReentrantRWMutexSM, gRepetition);
@@ -270,7 +276,6 @@ TEST(RWLock, ReadUnLockSpinDirect)
 {
    testReadUnLock(gReentrantRWMutexSM, gRepetition);
 }
-
 
 TEST(RWLock, ReadLockDirect)
 {
@@ -282,9 +287,6 @@ TEST(RWLock, ReadUnLockDirect)
    testReadUnLock(gReentrantRWMutex, gRepetition);
 }
 
-
-
-
 TEST(RWLock, WriteSpinTLDirectLock)
 {
    testWriteLock(gReentrantRWMutexSMTL, gRepetition);
@@ -294,7 +296,6 @@ TEST(RWLock, WriteSpinTLsDirectUnLock)
 {
    testWriteUnLock(gReentrantRWMutexSMTL, gRepetition);
 }
-
 
 TEST(RWLock, WriteTLDirectLock)
 {
@@ -306,7 +307,6 @@ TEST(RWLock, WriteTLDirectUnLock)
    testWriteUnLock(gReentrantRWMutexTL, gRepetition);
 }
 
-
 TEST(RWLock, ReadLockSpinTLDirect)
 {
    testReadLock(gReentrantRWMutexSMTL, gRepetition);
@@ -316,7 +316,6 @@ TEST(RWLock, ReadUnLockSpinTLDirect)
 {
    testReadUnLock(gReentrantRWMutexSMTL, gRepetition);
 }
-
 
 TEST(RWLock, ReadLockTLDirect)
 {
@@ -328,17 +327,10 @@ TEST(RWLock, ReadUnLockTLDirect)
    testReadUnLock(gReentrantRWMutexTL, gRepetition);
 }
 
-
-
-
-
 TEST(RWLock, SpinMutexLockUnlock)
 {
    testNonReentrantLock(gSpinMutex, gRepetition);
 }
-
-
-
 
 TEST(RWLock, MutexGuard)
 {
@@ -375,20 +367,19 @@ TEST(RWLock, ReentrantTL)
    Reentrant(*gReentrantRWMutexTL);
 }
 
-
 TEST(RWLock, Concurrent)
 {
-   concurrent(gRWMutex,1,2,gRepetition / 10000);
+   concurrent(gRWMutex, 1, 2, gRepetition / 10000);
 }
 
 TEST(RWLock, ConcurrentSpin)
 {
-   concurrent(gRWMutexSpin,1,2,gRepetition / 10000);
+   concurrent(gRWMutexSpin, 1, 2, gRepetition / 10000);
 }
 
 TEST(RWLock, LargeConcurrent)
 {
-   concurrent(gRWMutex,10,20,gRepetition / 1000);
+   concurrent(gRWMutex, 10, 20, gRepetition / 1000);
 }
 
 // TEST(RWLock, LargeConcurrentSpin)
@@ -398,10 +389,10 @@ TEST(RWLock, LargeConcurrent)
 
 TEST(RWLock, ConcurrentTL)
 {
-   concurrent(gRWMutexTL,1,2,gRepetition / 10000);
+   concurrent(gRWMutexTL, 1, 2, gRepetition / 10000);
 }
 
 TEST(RWLock, LargeConcurrentTL)
 {
-   concurrent(gRWMutexTL,10,20,gRepetition / 1000);
+   concurrent(gRWMutexTL, 10, 20, gRepetition / 1000);
 }

--- a/core/thread/test/testRWLock.cxx
+++ b/core/thread/test/testRWLock.cxx
@@ -1,0 +1,330 @@
+// #include "TReentrantRWLock.h"
+#include "TVirtualMutex.h"
+#include "TMutex.h"
+#include "TVirtualRWMutex.h"
+#include "ROOT/TReentrantRWLock.hxx"
+#include "ROOT/TRWSpinLock.hxx"
+
+#include "../src/TRWMutexImp.h"
+
+#include "TSystem.h"
+#include "TROOT.h"
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+void testWriteLockV(TVirtualMutex *m, size_t repetition) {
+   for(size_t i = 0; i < repetition; ++i) {
+      m->Lock();
+   }
+}
+
+void testWriteUnLockV(TVirtualMutex *m, size_t repetition) {
+   for(size_t i = 0; i < repetition; ++i) {
+      m->UnLock();
+   }
+}
+
+template <typename M>
+void testWriteTLock(M *m, size_t repetition) {
+   for(size_t i = 0; i < repetition; ++i) {
+      m->Lock();
+   }
+}
+
+template <typename M>
+void testWriteLock(M *m, size_t repetition) {
+   for(size_t i = 0; i < repetition; ++i) {
+      m->WriteLock();
+   }
+}
+
+template <typename M>
+void testReadLock(M *m, size_t repetition) {
+   for(size_t i = 0; i < repetition; ++i) {
+      m->ReadLock();
+   }
+}
+
+template <typename M>
+void testNonReentrantLock(M *m, size_t repetition) {
+   for(size_t i = 0; i < repetition; ++i) {
+      m->lock();
+      m->unlock();
+   }
+}
+
+template <typename M>
+void testWriteTUnLock(M *m, size_t repetition) {
+   for(size_t i = 0; i < repetition; ++i) {
+      m->UnLock();
+   }
+}
+
+template <typename M>
+void testWriteUnLock(M *m, size_t repetition) {
+   for(size_t i = 0; i < repetition; ++i) {
+      m->WriteUnLock();
+   }
+}
+
+template <typename M>
+void testReadUnLock(M *m, size_t repetition) {
+   for(size_t i = 0; i < repetition; ++i) {
+      m->ReadUnLock();
+   }
+}
+
+void testWriteGuard(TVirtualMutex *m, size_t repetition) {
+   for(size_t i = 0; i < repetition; ++i) {
+      TLockGuard guard(m);
+   }
+}
+
+void testReadGuard(TVirtualRWMutex *m, size_t repetition) {
+   for(size_t i = 0; i < repetition; ++i) {
+      m->ReadLock();
+      m->ReadUnLock();
+   }
+}
+
+struct Globals {
+   size_t fFirst = 0;
+   size_t fSecond = 0;
+   size_t fThird = 0;
+};
+
+void writer(TVirtualRWMutex *m, Globals *global, size_t repetition) {
+   for(size_t i = 0; i < repetition; ++i) {
+      {
+         TLockGuard guard(m);
+         global->fFirst++;
+         // Waste some time
+         for(size_t k = 0; k < 100; ++k) {
+            global->fSecond += global->fThird * global->fFirst + k;
+         }
+         global->fThird++;
+      }
+      gSystem->Sleep(3 /* milliseconds */); // give sometimes to the readers
+   }
+}
+
+void reader(TVirtualRWMutex *m, Globals *global, size_t repetition) {
+   for(size_t i = 0; i < repetition; ++i) {
+      m->ReadLock();
+      ASSERT_EQ(global->fFirst,global->fThird);
+      m->ReadUnLock();
+      gSystem->Sleep(1 /* milliseconds */); // give sometimes to the writers
+   }
+}
+
+void concurrent(TVirtualRWMutex *m, size_t nwriters, size_t nreaders, size_t repetition) {
+   // ROOT::EnableThreadSafety();
+
+   std::vector<std::thread> threads;
+
+   Globals global;
+
+   for(size_t i=0 ; i<nwriters ; ++i){
+      threads.push_back(std::thread([&](){ writer(m,&global,repetition); } ));
+   }
+   for(size_t i=0 ; i<nreaders ; ++i){
+      threads.push_back(std::thread([&](){ reader(m,&global,repetition); } ));
+   }
+
+   for(auto &&th : threads) {
+      th.join();
+   }
+}
+
+template <typename T>
+void Reentrant(T &m) {
+
+   m.ReadLock();
+   m.ReadLock();
+   m.ReadLock();
+
+   m.WriteLock();
+
+   m.ReadLock();
+   m.ReadLock();
+
+   m.WriteLock();
+
+   m.ReadLock();
+
+
+   m.ReadUnLock();
+   m.WriteUnLock();
+   m.ReadUnLock();
+   m.ReadUnLock();
+   m.WriteUnLock();
+   m.ReadUnLock();
+   m.ReadUnLock();
+   m.ReadUnLock();
+
+}
+
+constexpr size_t gRepetition = 10000000;
+
+auto gMutex = new TMutex(kTRUE);
+auto gRWMutex = new TRWMutexImp<TMutex>();
+auto gRWMutexSpin = new TRWMutexImp<ROOT::TSpinMutex>();
+auto gReentrantRWMutex = new ROOT::TReentrantRWLock<TMutex>();
+auto gReentrantRWMutexSM = new ROOT::TReentrantRWLock<ROOT::TSpinMutex>();
+auto gSpinMutex = new ROOT::TSpinMutex();
+
+TEST(RWLock, MutexLockVirtual)
+{
+   testWriteLockV(gMutex, gRepetition);
+}
+
+TEST(RWLock, MutexUnLockVirtual)
+{
+   testWriteTUnLock(gMutex, gRepetition);
+}
+
+
+TEST(RWLock, WriteLockVirtual)
+{
+   testWriteLockV(gRWMutex, gRepetition);
+}
+
+TEST(RWLock, WriteUnLockVirtual)
+{
+   testWriteTUnLock(gRWMutex, gRepetition);
+}
+
+
+TEST(RWLock, WriteSpinLockVirtual)
+{
+   testWriteLock(gRWMutexSpin, gRepetition);
+}
+
+TEST(RWLock, WriteSpinUnLockVirtual)
+{
+   testWriteTUnLock(gRWMutexSpin, gRepetition);
+}
+
+
+TEST(RWLock, WriteLock)
+{
+   testWriteLock(gRWMutex, gRepetition);
+}
+
+TEST(RWLock, WriteUnLock)
+{
+   testWriteTUnLock(gRWMutex, gRepetition);
+}
+
+
+TEST(RWLock, WriteSpinLock)
+{
+   testWriteLock(gRWMutexSpin, gRepetition);
+}
+
+TEST(RWLock, WriteSpinUnLock)
+{
+   testWriteTUnLock(gRWMutexSpin, gRepetition);
+}
+
+
+TEST(RWLock, WriteSpinDirectLock)
+{
+   testWriteLock(gReentrantRWMutexSM, gRepetition);
+}
+
+TEST(RWLock, WriteSpinDirectUnLock)
+{
+   testWriteUnLock(gReentrantRWMutexSM, gRepetition);
+}
+
+
+TEST(RWLock, WriteDirectLock)
+{
+   testWriteLock(gReentrantRWMutex, gRepetition);
+}
+
+TEST(RWLock, WriteDirectUnLock)
+{
+   testWriteUnLock(gReentrantRWMutex, gRepetition);
+}
+
+
+TEST(RWLock, ReadLockSpinDirect)
+{
+   testReadLock(gReentrantRWMutexSM, gRepetition);
+}
+
+TEST(RWLock, ReadUnLockSpinDirect)
+{
+   testReadUnLock(gReentrantRWMutexSM, gRepetition);
+}
+
+
+TEST(RWLock, ReadLockDirect)
+{
+   testReadLock(gReentrantRWMutex, gRepetition);
+}
+
+TEST(RWLock, ReadUnLockDirect)
+{
+   testReadUnLock(gReentrantRWMutex, gRepetition);
+}
+
+
+
+
+TEST(RWLock, SpinMutexLockUnlock)
+{
+   testNonReentrantLock(gSpinMutex, gRepetition);
+}
+
+
+
+
+TEST(RWLock, MutexGuard)
+{
+   testWriteGuard(gMutex, gRepetition);
+}
+
+TEST(RWLock, WriteGuard)
+{
+   testWriteGuard(gRWMutex, gRepetition);
+}
+
+TEST(RWLock, WriteSpinGuard)
+{
+   testWriteGuard(gRWMutexSpin, gRepetition);
+}
+
+TEST(RWLock, ReentrantSpin)
+{
+   Reentrant(*gReentrantRWMutexSM);
+}
+
+TEST(RWLock, Reentrant)
+{
+   Reentrant(*gReentrantRWMutex);
+}
+
+
+TEST(RWLock, Concurrent)
+{
+   concurrent(gRWMutex,1,2,gRepetition / 10000);
+}
+
+TEST(RWLock, ConcurrentSpin)
+{
+   concurrent(gRWMutexSpin,1,2,gRepetition / 10000);
+}
+
+TEST(RWLock, LargeConcurrent)
+{
+   concurrent(gRWMutex,10,20,gRepetition / 1000);
+}
+
+// TEST(RWLock, LargeConcurrentSpin)
+// {
+//    concurrent(gRWMutexSpin,10,20,gRepetition / 1000);
+// }

--- a/core/thread/test/testRWLock.cxx
+++ b/core/thread/test/testRWLock.cxx
@@ -132,7 +132,7 @@ void reader(TVirtualRWMutex *m, Globals *global, size_t repetition)
    }
 }
 
-void concurrent(TVirtualRWMutex *m, size_t nwriters, size_t nreaders, size_t repetition)
+void concurrentReadsAndWrites(TVirtualRWMutex *m, size_t nwriters, size_t nreaders, size_t repetition)
 {
    // ROOT::EnableThreadSafety();
 
@@ -367,32 +367,32 @@ TEST(RWLock, ReentrantTL)
    Reentrant(*gReentrantRWMutexTL);
 }
 
-TEST(RWLock, Concurrent)
+TEST(RWLock, concurrentReadsAndWrites)
 {
-   concurrent(gRWMutex, 1, 2, gRepetition / 10000);
+   concurrentReadsAndWrites(gRWMutex, 1, 2, gRepetition / 10000);
 }
 
-TEST(RWLock, ConcurrentSpin)
+TEST(RWLock, concurrentReadsAndWritesSpin)
 {
-   concurrent(gRWMutexSpin, 1, 2, gRepetition / 10000);
+   concurrentReadsAndWrites(gRWMutexSpin, 1, 2, gRepetition / 10000);
 }
 
-TEST(RWLock, LargeConcurrent)
+TEST(RWLock, LargeconcurrentReadsAndWrites)
 {
-   concurrent(gRWMutex, 10, 20, gRepetition / 1000);
+   concurrentReadsAndWrites(gRWMutex, 10, 20, gRepetition / 1000);
 }
 
-// TEST(RWLock, LargeConcurrentSpin)
+// TEST(RWLock, LargeconcurrentReadsAndWritesSpin)
 // {
-//    concurrent(gRWMutexSpin,10,20,gRepetition / 1000);
+//    concurrentReadsAndWrites(gRWMutexSpin,10,20,gRepetition / 1000);
 // }
 
-TEST(RWLock, ConcurrentTL)
+TEST(RWLock, concurrentReadsAndWritesTL)
 {
-   concurrent(gRWMutexTL, 1, 2, gRepetition / 10000);
+   concurrentReadsAndWrites(gRWMutexTL, 1, 2, gRepetition / 10000);
 }
 
-TEST(RWLock, LargeConcurrentTL)
+TEST(RWLock, LargeconcurrentReadsAndWritesTL)
 {
-   concurrent(gRWMutexTL, 10, 20, gRepetition / 1000);
+   concurrentReadsAndWrites(gRWMutexTL, 10, 20, gRepetition / 1000);
 }


### PR DESCRIPTION
The new internal class is TReentrantRWLock access externally via the abstract interface TVirtualRWMutex.

The next steps after this is to start using by:
1) Replace gROOTMutex by a TRWMutexImp
2) Add R__READLOCKGUARD
3) Add a TListWithRWLock and THashListWithRWLock
4) Use those in TROOT
5) Remove current external locks for those ROOT lists (in particular the ListOfFiles)
6) Update all RecursiveRemove implementation (in particular TCling::RecursiveRemove, without update it destroys scalability) to make use of the Read/Write lock.
7) Introduce scalability test on RecursiveRemove
