### PR TITLE
[Math] Avoid redefinition of `VECCORE_ENABLE_VC` macro

### DIFF
--- a/math/mathcore/inc/Math/Math_vectypes.hxx
+++ b/math/mathcore/inc/Math/Math_vectypes.hxx
@@ -1,13 +1,33 @@
+#ifndef ROOT_Math_VecTypes
+#define ROOT_Math_VecTypes
+
 #include "RConfigure.h"
+
 #ifdef R__HAS_VECCORE
  
-  #ifdef R__HAS_VC
-    #define VECCORE_ENABLE_VC 
-  #endif
- 
-  #include <VecCore/VecCore>
-
-  namespace ROOT {
-    using Double_v = typename vecCore::backend::VcVector::Double_v;
-  }
+#if defined(R__HAS_VC) && !defined(VECCORE_ENABLE_VC)
+#define VECCORE_ENABLE_VC
 #endif
+ 
+#include <VecCore/VecCore>
+
+namespace ROOT {
+
+namespace Internal {
+   using ScalarBackend = vecCore::backend::Scalar;
+#ifdef VECCORE_ENABLE_VC
+   using VectorBackend = vecCore::backend::VcVector;
+#else
+   using VectorBackend = vecCore::backend::Scalar;
+#endif
+}
+   using Float_v  = typename Internal::VectorBackend::Float_v;
+   using Double_v = typename Internal::VectorBackend::Double_v;
+   using Int_v    = typename Internal::VectorBackend::Int_v;
+   using Int32_v  = typename Internal::VectorBackend::Int32_v;
+   using UInt_v   = typename Internal::VectorBackend::UInt_v;
+   using UInt32_v = typename Internal::VectorBackend::UInt32_v;
+}
+
+#endif // R__HAS_VECCORE
+#endif // ROOT_Math_VecTypes


### PR DESCRIPTION
The macro should be already set via `${VecCore_DEFINITIONS}`, so setting it unconditionally is redundant and leads to many warnings. However, the build system is not quite ready for setting this only via
`${VecCore_DEFINITIONS}`, so we need to conditionally set it if dependencies are satisfied and it is not set.