### PR TITLE
Multi regression decision trees

### DIFF
--- a/tmva/tmva/CMakeLists.txt
+++ b/tmva/tmva/CMakeLists.txt
@@ -94,6 +94,7 @@ if(NOT gnuinstall)
 endif()
 
 ROOT_ADD_TEST_SUBDIRECTORY(test/DNN)
+ROOT_ADD_TEST_SUBDIRECTORY(test/DecisionTree)
 
 
 

--- a/tmva/tmva/inc/TMVA/DecisionTree.h
+++ b/tmva/tmva/inc/TMVA/DecisionTree.h
@@ -119,6 +119,7 @@ namespace TMVA {
 
       Double_t CheckEvent( const TMVA::Event * , Bool_t UseYesNoLeaf = kFALSE ) const;     
       TMVA::DecisionTreeNode* GetEventNode(const TMVA::Event & e) const;
+      std::vector<Double_t> GetMultiResponse ( const TMVA::Event* ) const;
 
       // return the individual relative variable importance 
       std::vector< Double_t > GetVariableImportance();
@@ -221,7 +222,8 @@ namespace TMVA {
       Bool_t    fRandomisedTree; // choose at each node splitting a random set of variables 
       Int_t     fUseNvars;       // the number of variables used in randomised trees;
       Bool_t    fUsePoissonNvars; // use "fUseNvars" not as fixed number but as mean of a possion distr. in each split
-    
+      Bool_t    fDoMultiTarget;  //  used for doing multi-target regression
+
       TRandom3  *fMyTrandom;     // random number generator for randomised trees
     
       std::vector< Double_t > fVariableImportance; // the relative importance of the different variables 

--- a/tmva/tmva/inc/TMVA/DecisionTreeNode.h
+++ b/tmva/tmva/inc/TMVA/DecisionTreeNode.h
@@ -171,8 +171,14 @@ namespace TMVA {
       //set the response of the node (for regression)
       void SetResponse( Float_t r ) { fResponse = r;}
 
+      //set the response of the node (for multitask regression)
+      void SetMultiResponse( const std::vector<Double_t>& r ) { fMultiResponse = r;}
+
       //return the response of the node (for regression)
       Float_t GetResponse( void ) const { return fResponse;}
+
+      //return the response of the node (for multitaskregression)
+      std::vector<Double_t> GetMultiResponse( void ) const { return fMultiResponse;}
 
       //set the RMS of the response of the node (for regression)
       void SetRMS( Float_t r ) { fRMS = r;}
@@ -364,6 +370,7 @@ namespace TMVA {
       Short_t  fSelector;        // index of variable used in node selection (decision tree)
 
       Float_t  fResponse;        // response value in case of regression
+      std::vector<Double_t> fMultiResponse; // response in case of multitask regression
       Float_t  fRMS;             // response RMS of the regression node
       Int_t    fNodeType;        // Type of node: -1 == Bkg-leaf, 1 == Signal-leaf, 0 = internal
       Float_t  fPurity;          // the node purity

--- a/tmva/tmva/inc/TMVA/DecisionTreeNode.h
+++ b/tmva/tmva/inc/TMVA/DecisionTreeNode.h
@@ -169,7 +169,7 @@ namespace TMVA {
       void SetPurity( void );
 
       //set the response of the node (for regression)
-      void SetResponse( Float_t r ) { fResponse = r;}
+      void SetResponse( Float_t r ) { fResponse = r; }
 
       //set the response of the node (for multitask regression)
       void SetMultiResponse( const std::vector<Double_t>& r ) { fMultiResponse = r;}
@@ -178,7 +178,7 @@ namespace TMVA {
       Float_t GetResponse( void ) const { return fResponse;}
 
       //return the response of the node (for multitaskregression)
-      std::vector<Double_t> GetMultiResponse( void ) const { return fMultiResponse;}
+      std::vector<Double_t> GetMultiResponse( void ) const { return fMultiResponse; }
 
       //set the RMS of the response of the node (for regression)
       void SetRMS( Float_t r ) { fRMS = r;}

--- a/tmva/tmva/inc/TMVA/MethodBDT.h
+++ b/tmva/tmva/inc/TMVA/MethodBDT.h
@@ -247,7 +247,7 @@ namespace TMVA {
       Bool_t                           fPairNegWeightsGlobal;   // pair ev. with neg. and pos. weights in traning sample and "annihilate" them 
       Bool_t                           fTrainWithNegWeights; // yes there are negative event weights and we don't ignore them
       Bool_t                           fDoBoostMonitor; //create control plot with ROC integral vs tree number
-
+      Bool_t                           fDoMultiTarget;
 
       //some histograms for monitoring
       TTree*                           fMonitorNtuple;   // monitoring ntuple

--- a/tmva/tmva/inc/TMVA/MethodBase.h
+++ b/tmva/tmva/inc/TMVA/MethodBase.h
@@ -170,6 +170,12 @@ namespace TMVA {
                                        Double_t& mInf, Double_t& mInfT, // mutual information
                                        Double_t& corr,
                                        Types::ETreeType type );
+      virtual void     TestMultiRegression( std::vector<Double_t>* bias, std::vector<Double_t>* biasT,
+                                            std::vector<Double_t>* dev,  std::vector<Double_t>* devT,
+                                            std::vector<Double_t>* rms,  std::vector<Double_t>* rmsT,
+                                            std::vector<Double_t>* mInf, std::vector<Double_t>* mInfT,
+                                            std::vector<Double_t>* corr,
+                                            Types::ETreeType type );
 
       // options treatment
       virtual void     Init()           = 0;

--- a/tmva/tmva/inc/TMVA/RegressionVariance.h
+++ b/tmva/tmva/inc/TMVA/RegressionVariance.h
@@ -81,8 +81,14 @@ namespace TMVA {
       Double_t GetSeparationGain( const Double_t nLeft, const Double_t targetLeft, const Double_t target2Left,
                                   const Double_t nTot, const Double_t targetTot, const Double_t target2Tot );
 
+      Double_t GetSeparationGainMulti( const Double_t nLeft, const Double_t* targetLeft, const Double_t target2Left,
+                                       const Double_t nTot,  const Double_t* targetTot, const Double_t target2Tot,
+                                       const UInt_t target_dimension );
+
       // Return the separation index (a measure for "purity" of the sample")
       virtual Double_t GetSeparationIndex( const Double_t n, const Double_t target, const Double_t target2 );
+      virtual Double_t GetSeparationIndexMulti( const Double_t n, const Double_t* target, const Double_t target2,
+                                                UInt_t target_dimension );
 
       // Return the name of the concrete Index implementation
       TString GetName() { return fName; }

--- a/tmva/tmva/src/DecisionTree.cxx
+++ b/tmva/tmva/src/DecisionTree.cxx
@@ -463,7 +463,6 @@ UInt_t TMVA::DecisionTree::BuildTree( const std::vector<const TMVA::Event*> & ev
             else node->SetNodeType(-1);
          }
          if (node->GetDepth() > this->GetTotalTreeDepth()) this->SetTotalTreeDepth(node->GetDepth());
-
       } else {
 
          std::vector<const TMVA::Event*> leftSample; leftSample.reserve(nevents);

--- a/tmva/tmva/src/MethodBDT.cxx
+++ b/tmva/tmva/src/MethodBDT.cxx
@@ -364,7 +364,6 @@ void TMVA::MethodBDT::DeclareOptions()
    }else{
       fBoostType = "AdaBoost";
    }
-   std::cout << "I LIVE HERE" << fBoostType << std::endl;
    DeclareOptionRef(fAdaBoostR2Loss="Quadratic", "AdaBoostR2Loss", "Type of Loss function in AdaBoostR2");
    AddPreDefVal(TString("Linear"));
    AddPreDefVal(TString("Quadratic"));
@@ -699,9 +698,7 @@ void TMVA::MethodBDT::Init( void )
          fMinNodeSize = 5.;
    } else {
       fMaxDepth = 50;
-      std::cout << "DOMULTITARGET" << fDoMultiTarget << std::endl;
       fBoostType      = fDoMultiTarget ? "Bagging" : "AdaBoostR2";
-      std::cout << "BTYPE" << fBoostType << std::endl;
       fAdaBoostR2Loss = "Quadratic";
       if(DataInfo().GetNClasses()!=0) //workaround for multiclass application
          fMinNodeSize  = .2;
@@ -1606,8 +1603,6 @@ Double_t TMVA::MethodBDT::TestTreeQuality( DecisionTree *dt )
 
 Double_t TMVA::MethodBDT::Boost( std::vector<const TMVA::Event*>& eventSample, DecisionTree *dt, UInt_t cls )
 {
-   std::cout << "RIGHT NOW MULTITARGET" << (fDoMultiTarget == kTRUE) << std::endl;
-   std::cout << "RIGHT NOW" << fBoostType << std::endl;
    Double_t returnVal=-1;
    if      (fBoostType=="AdaBoost")    returnVal = this->AdaBoost  (eventSample, dt);
    else if (fBoostType=="AdaCost")     returnVal = this->AdaCost   (eventSample, dt);

--- a/tmva/tmva/src/RegressionVariance.cxx
+++ b/tmva/tmva/src/RegressionVariance.cxx
@@ -84,13 +84,55 @@ Double_t TMVA::RegressionVariance::GetSeparationGain(const Double_t nLeft,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Separation gain in case target has several dimension
+
+Double_t TMVA::RegressionVariance::GetSeparationGainMulti(const Double_t nLeft,
+                                                          const Double_t* targetLeft, const Double_t target2Left,
+                                                          const Double_t nTot,
+                                                          const Double_t* targetTot, const Double_t target2Tot,
+                                                          const UInt_t target_dimension)
+{
+   if  ( nTot==nLeft || nLeft==0 ) return 0.;
+
+   Double_t parentIndex = nTot * this->GetSeparationIndexMulti(nTot,targetTot,target2Tot, target_dimension);
+   Double_t* targetRight = new Double_t [target_dimension];
+   for (UInt_t t_index = 0; t_index < target_dimension; ++t_index) {
+      targetRight[t_index] = targetTot[t_index] - targetLeft[t_index];
+   }
+   Double_t leftIndex   = ( (nTot - nLeft) * this->GetSeparationIndexMulti(nTot-nLeft,targetRight,
+                                                                           target2Tot-target2Left,
+                                                                           target_dimension) );
+   Double_t rightIndex  =    nLeft * this->GetSeparationIndexMulti(nLeft,targetLeft,target2Left,
+                                                                   target_dimension);
+
+   delete[] targetRight;
+   //  return 1/ (leftIndex + rightIndex);
+   return (parentIndex - leftIndex - rightIndex)/(parentIndex);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Separation Index:  a simple Variance
 
 Double_t TMVA::RegressionVariance::GetSeparationIndex(const Double_t n,
-                                                      const Double_t target, const Double_t target2)
+                                                      const Double_t target,const Double_t target2)
 {
    //   return TMath::Sqrt(( target2 - target*target/n) / n);
    return ( target2 - target*target/n) / n;
+
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Separation Index:  Variance summed across dimensions of the target
+
+Double_t TMVA::RegressionVariance::GetSeparationIndexMulti(const Double_t n,
+                                                           const Double_t* target, const Double_t target2,
+                                                           const UInt_t target_dimension)
+{
+   Double_t squared_means_sum = 0.0;
+   for (UInt_t target_index = 0; target_index < target_dimension; ++target_index) {
+      squared_means_sum += target[target_index] * target[target_index];
+   }
+   return ( target2 - squared_means_sum/n ) / n;
 
 }
 

--- a/tmva/tmva/test/CMakeLists.txt
+++ b/tmva/tmva/test/CMakeLists.txt
@@ -7,3 +7,4 @@ project(tmva-tests)
 find_package(ROOT REQUIRED)
 
 ROOT_ADD_TEST_SUBDIRECTORY(DNN)
+ROOT_ADD_TEST_SUBDIRECTORY(DecisionTree)

--- a/tmva/tmva/test/DecisionTree/CMakeLists.txt
+++ b/tmva/tmva/test/DecisionTree/CMakeLists.txt
@@ -1,0 +1,18 @@
+############################################################################
+# CMakeLists.txt file for building TMVA/DecisionTree tests.
+# @author Sergey Divakov
+############################################################################
+
+project(tmva-tests)
+find_package(ROOT REQUIRED)
+
+set(Libraries Core MathCore Matrix TMVA)
+include_directories(${ROOT_INCLUDE_DIRS})
+
+#--- Multi-target Regression tests. ------------------
+
+include_directories(${TBB_INCLUDE_DIRS})
+
+ROOT_ADD_GTEST(TestMultiRegression TestMultiregression.cpp LIBRARIES ${Libraries})
+ROOT_ADD_GTEST(TestMultiVariance TestMultidimensionalVariance.cpp LIBRARIES ${Libraries})
+ROOT_ADD_GTEST(TestMethodDT TestMethodDT.cpp LIBRARIES ${Libraries})

--- a/tmva/tmva/test/DecisionTree/CMakeLists.txt
+++ b/tmva/tmva/test/DecisionTree/CMakeLists.txt
@@ -11,8 +11,12 @@ include_directories(${ROOT_INCLUDE_DIRS})
 
 #--- Multi-target Regression tests. ------------------
 
+add_library(DTreeUtils Utility.cpp)
+
 include_directories(${TBB_INCLUDE_DIRS})
 
 ROOT_ADD_GTEST(TestMultiRegression TestMultiregression.cpp LIBRARIES ${Libraries})
 ROOT_ADD_GTEST(TestMultiVariance TestMultidimensionalVariance.cpp LIBRARIES ${Libraries})
-ROOT_ADD_GTEST(TestMethodDT TestMethodDT.cpp LIBRARIES ${Libraries})
+
+target_link_libraries(TestMultiRegression DTreeUtils)
+target_link_libraries(TestMultiVariance DTreeUtils)

--- a/tmva/tmva/test/DecisionTree/TestMethodDT.cpp
+++ b/tmva/tmva/test/DecisionTree/TestMethodDT.cpp
@@ -1,0 +1,71 @@
+#include <gtest/gtest.h>
+
+#include "TMVA/MethodDT.h"
+#include "TMVA/MethodBDT.h"
+#include "TMVA/Types.h"
+#include "TMVA/Event.h"
+#include "TMVA/DataSetInfo.h"
+#include "TMVA/DataSet.h"
+#include "TMVA/DataSetManager.h"
+
+struct TestDataset {
+	std::unique_ptr<TMVA::DataSetInfo> info;
+	std::unique_ptr<std::vector<TMVA::Event*>> data;
+	~TestDataset() {
+		for (auto ev : *data.get())
+			delete ev;
+	}
+};
+
+bool almost_equal_double(double x, double y) {
+   // the machine epsilon has to be scaled to the magnitude of the values used
+   // and multiplied by the desired precision in ULPs (units in the last place)
+   return std::abs(x-y) < 1E-4;
+}
+
+std::unique_ptr<TestDataset> create_regression_dataset(uint32_t events_number,
+													   uint32_t features_number,
+														   const std::vector<std::pair<double,
+													   			         double>>& target_limits) {
+	std::unique_ptr<TestDataset> dataset (new TestDataset);
+	dataset->info = std::unique_ptr<TMVA::DataSetInfo> (new TMVA::DataSetInfo);
+	dataset->data = std::unique_ptr<std::vector<TMVA::Event*>> (new std::vector<TMVA::Event*>);
+	for (uint32_t feature_index = 0; feature_index < features_number; ++feature_index)
+		dataset->info->AddVariable(std::to_string(feature_index));
+	for (uint32_t target_index = 0; target_index < target_limits.size(); ++target_index)
+		dataset->info->AddTarget("_", "_", "_", target_limits[target_index].first,
+												target_limits[target_index].second);
+	for (uint32_t event_index = 0; event_index < events_number; ++event_index) {
+		std::vector<Float_t> features (features_number, event_index);
+		std::vector<Float_t> targets;
+		for (auto& limit : target_limits) {
+			targets.push_back(limit.first +
+							  (limit.second - limit.first) / events_number * event_index);
+		}
+		dataset->data->emplace_back(new TMVA::Event {std::vector<Float_t> (features_number, event_index),
+														 				   targets});
+	}
+	return dataset;
+}
+
+TEST(MethodDT, Multiregression) {
+	UInt_t test_size = 100;
+	std::vector<std::pair<double, double>> target_limits;
+	for (UInt_t limit_index = 0; limit_index < 10; ++limit_index) {
+		UInt_t lower_limit = rand() % 50;
+		UInt_t upper_limit = lower_limit + 1 + rand() % 50;
+		target_limits.push_back(std::make_pair(lower_limit, upper_limit));
+	}
+	auto data_wrapper = create_regression_dataset(1, test_size, target_limits);
+}
+
+TEST(MethodBDT, Multiregression) { //multitarget regression currenly supported in Bagging
+	UInt_t test_size = 100;
+	std::vector<std::pair<double, double>> target_limits;
+	for (UInt_t limit_index = 0; limit_index < 10; ++limit_index) {
+		UInt_t lower_limit = rand() % 50;
+		UInt_t upper_limit = lower_limit + 1 + rand() % 50;
+		target_limits.push_back(std::make_pair(lower_limit, upper_limit));
+	}
+	auto data_wrapper = create_regression_dataset(1, test_size, target_limits);
+}

--- a/tmva/tmva/test/DecisionTree/TestMultidimensionalVariance.cpp
+++ b/tmva/tmva/test/DecisionTree/TestMultidimensionalVariance.cpp
@@ -3,12 +3,7 @@
 
 #include "TMVA/RegressionVariance.h"
 
-
-bool almost_equal_double(double x, double y) {
-   // the machine epsilon has to be scaled to the magnitude of the values used
-   // and multiplied by the desired precision in ULPs (units in the last place)
-   return std::abs(x-y) < 0.001;
-}
+#include "Utility.h"
 
 TEST(MultiVariance, Simple) {
 	std::vector<UInt_t> dimensions {1, 2, 4, 8};
@@ -31,7 +26,7 @@ TEST(MultiVariance, Simple) {
 				var_truth += variance.GetSeparationIndex(100, means_vector[index], sum_squares[index]);
 			}
 			var_check = variance.GetSeparationIndexMulti(100, &means_vector[0], sum, dim);
-			ASSERT_TRUE(almost_equal_double(var_truth, var_check));
+			ASSERT_TRUE(almost_equal_trivial(var_truth, var_check));
 		}
 	}
 }

--- a/tmva/tmva/test/DecisionTree/TestMultidimensionalVariance.cpp
+++ b/tmva/tmva/test/DecisionTree/TestMultidimensionalVariance.cpp
@@ -1,0 +1,37 @@
+#include <gtest/gtest.h>
+#include <cstdlib>
+
+#include "TMVA/RegressionVariance.h"
+
+
+bool almost_equal_double(double x, double y) {
+   // the machine epsilon has to be scaled to the magnitude of the values used
+   // and multiplied by the desired precision in ULPs (units in the last place)
+   return std::abs(x-y) < 0.001;
+}
+
+TEST(MultiVariance, Simple) {
+	std::vector<UInt_t> dimensions {1, 2, 4, 8};
+	auto variance = TMVA::RegressionVariance();
+	for (UInt_t test_iter = 0; test_iter < 100; ++test_iter) {
+		for (auto dim : dimensions) {
+			std::vector<Double_t> means_vector (dim, 0.0);
+			std::vector<Double_t> sum_squares (dim, 0.0);
+			Double_t sum = 0.0;
+			for (UInt_t index = 0; index < dim; ++index) {
+				means_vector[index] = static_cast <Double_t> ((1.0 - rand() % 3) * (rand()) / 
+									  static_cast <Double_t> (RAND_MAX));
+				sum_squares[index] += dim * means_vector[index] +
+							   		  static_cast <Double_t> (rand()) / static_cast <Double_t> (RAND_MAX);
+				sum += sum_squares[index];
+			}
+			Double_t var_truth = 0.0;
+			Double_t var_check = 0.0;
+			for (UInt_t index = 0; index < dim; ++index) {
+				var_truth += variance.GetSeparationIndex(100, means_vector[index], sum_squares[index]);
+			}
+			var_check = variance.GetSeparationIndexMulti(100, &means_vector[0], sum, dim);
+			ASSERT_TRUE(almost_equal_double(var_truth, var_check));
+		}
+	}
+}

--- a/tmva/tmva/test/DecisionTree/TestMultiregression.cpp
+++ b/tmva/tmva/test/DecisionTree/TestMultiregression.cpp
@@ -9,81 +9,11 @@
 #include "TMVA/DecisionTreeNode.h"
 #include "TMVA/DataSetInfo.h"
 
-struct TestDataset {
-	std::unique_ptr<TMVA::DataSetInfo> info;
-	std::unique_ptr<std::vector<const TMVA::Event*>> data;
-	~TestDataset() {
-		for (auto ev : *data.get())
-			delete ev;
-	}
-};
+#include "Utility.h"
 
-bool almost_equal_double(double x, double y) {
-   // the machine epsilon has to be scaled to the magnitude of the values used
-   // and multiplied by the desired precision in ULPs (units in the last place)
-   return std::abs(x-y) < 1E-4;
-}
-
-std::unique_ptr<TestDataset> create_regression_dataset(uint32_t events_number,
-													   uint32_t features_number,
-														   const std::vector<std::pair<double,
-													   			         double>>& target_limits) {
-	std::unique_ptr<TestDataset> dataset (new TestDataset);
-	dataset->info = std::unique_ptr<TMVA::DataSetInfo> (new TMVA::DataSetInfo);
-	dataset->data = std::unique_ptr<std::vector<const TMVA::Event*>> (new std::vector<const TMVA::Event*>);
-	for (uint32_t feature_index = 0; feature_index < features_number; ++feature_index)
-		dataset->info->AddVariable(std::to_string(feature_index));
-	for (uint32_t target_index = 0; target_index < target_limits.size(); ++target_index)
-		dataset->info->AddTarget("_", "_", "_", target_limits[target_index].first,
-												target_limits[target_index].second);
-	for (uint32_t event_index = 0; event_index < events_number; ++event_index) {
-		std::vector<Float_t> features (features_number, event_index);
-		std::vector<Float_t> targets;
-		for (auto& limit : target_limits) {
-			targets.push_back(limit.first +
-							  (limit.second - limit.first) / events_number * event_index);
-		}
-		dataset->data->emplace_back(new TMVA::Event {std::vector<Float_t> (features_number, event_index),
-														 targets});
-	}
-	return dataset;
-}
-
-void TestSingleTargetRegression() {
-	auto dataset = create_regression_dataset(100, 2, std::vector<std::pair<double, double>> (1,
-													 std::make_pair(0, 50)));
-	TMVA::DecisionTreeNode::fgIsTraining = true;
-	TMVA::DecisionTree tree (nullptr, 2, 0, dataset->info.get(), 0, false, 1, false, 500, 42, 0.01, 1);
-	tree.SetAnalysisType(TMVA::Types::kRegression);
-	tree.SetNVars(2);
-	tree.SetRoot(new TMVA::DecisionTreeNode);
-	tree.BuildTree(*(dataset->data.get()), tree.GetRoot());
-	auto a = tree.CheckEvent(new TMVA::Event {std::vector<Float_t> (2, 10),
-									 		  std::vector<Float_t> (2, 0)});
-	std::cout << a << std::endl;
-	TMVA::DecisionTreeNode::fgIsTraining = false;
-}
-
-void TestMultiTargetRegression() {
-	auto dataset = create_regression_dataset(100, 2, std::vector<std::pair<double, double>> {
-													 std::make_pair(0, 50), std::make_pair(50, 100)});
-	TMVA::DecisionTreeNode::fgIsTraining = true;
-	TMVA::DecisionTree tree (nullptr, 1, 200, dataset->info.get(), 0, false, 1, false, 500, 42, 0.01, 1);
-	tree.SetAnalysisType(TMVA::Types::kMultiRegression);
-	tree.SetNVars(2);
-	tree.SetRoot(new TMVA::DecisionTreeNode);
-	tree.BuildTree(*(dataset->data.get()), tree.GetRoot());
-	auto a = tree.GetMultiResponse(new TMVA::Event {std::vector<Float_t> {101, 101},
-									 		 	    std::vector<Float_t> (2, 0)});
-	for (auto kek : a) {
-		std::cout << kek << std::endl;
-	}
-	TMVA::DecisionTreeNode::fgIsTraining = false;
-}
-
-TEST(Multiregression, SingleVariable) {
+TEST(Multiregression, DifferentDimensions) {
 	UInt_t test_size = 1000;
-	for (UInt_t target_dim = 1; target_dim < 10; ++target_dim) {
+	for (UInt_t target_dim = 2; target_dim < 10; ++target_dim) {
 		std::vector<std::pair<double, double>> target_limits;
 		for (UInt_t limit_index = 0; limit_index < target_dim; ++limit_index) {
 			UInt_t lower_limit = rand() % 50;
@@ -93,7 +23,7 @@ TEST(Multiregression, SingleVariable) {
 		auto dataset = create_regression_dataset (test_size, 1, target_limits);
 		TMVA::DecisionTreeNode::fgIsTraining = true;
 		TMVA::DecisionTree tree (nullptr, 1, test_size, dataset->info.get(), 0, false, 1, false, 500, 42, 0.01, 1);
-		tree.SetAnalysisType(TMVA::Types::kMultiRegression);
+		tree.SetAnalysisType(TMVA::Types::kRegression);
 		tree.SetNVars(1);
 		tree.SetRoot(new TMVA::DecisionTreeNode);
 		tree.BuildTree(*(dataset->data.get()), tree.GetRoot());
@@ -102,7 +32,7 @@ TEST(Multiregression, SingleVariable) {
 			auto response = tree.GetMultiResponse(new TMVA::Event {std::vector<Float_t> {variable},
 															std::vector<Float_t> (target_dim, 0)});
 			for (UInt_t value_index = 0; value_index < target_dim; ++value_index) {
-				ASSERT_TRUE(almost_equal_double(response[value_index], target_limits[value_index].first +
+				ASSERT_TRUE(almost_equal_trivial(response[value_index], target_limits[value_index].first +
 												variable/test_size * (target_limits[value_index].second - 
 												target_limits[value_index].first)));
 			}

--- a/tmva/tmva/test/DecisionTree/TestMultiregression.cpp
+++ b/tmva/tmva/test/DecisionTree/TestMultiregression.cpp
@@ -1,0 +1,112 @@
+#include <iostream>
+#include <memory>
+#include <string>
+#include <gtest/gtest.h>
+
+#include "TMVA/DecisionTree.h"
+#include "TMVA/Types.h"
+#include "TMVA/Event.h"
+#include "TMVA/DecisionTreeNode.h"
+#include "TMVA/DataSetInfo.h"
+
+struct TestDataset {
+	std::unique_ptr<TMVA::DataSetInfo> info;
+	std::unique_ptr<std::vector<const TMVA::Event*>> data;
+	~TestDataset() {
+		for (auto ev : *data.get())
+			delete ev;
+	}
+};
+
+bool almost_equal_double(double x, double y) {
+   // the machine epsilon has to be scaled to the magnitude of the values used
+   // and multiplied by the desired precision in ULPs (units in the last place)
+   return std::abs(x-y) < 1E-4;
+}
+
+std::unique_ptr<TestDataset> create_regression_dataset(uint32_t events_number,
+													   uint32_t features_number,
+														   const std::vector<std::pair<double,
+													   			         double>>& target_limits) {
+	std::unique_ptr<TestDataset> dataset (new TestDataset);
+	dataset->info = std::unique_ptr<TMVA::DataSetInfo> (new TMVA::DataSetInfo);
+	dataset->data = std::unique_ptr<std::vector<const TMVA::Event*>> (new std::vector<const TMVA::Event*>);
+	for (uint32_t feature_index = 0; feature_index < features_number; ++feature_index)
+		dataset->info->AddVariable(std::to_string(feature_index));
+	for (uint32_t target_index = 0; target_index < target_limits.size(); ++target_index)
+		dataset->info->AddTarget("_", "_", "_", target_limits[target_index].first,
+												target_limits[target_index].second);
+	for (uint32_t event_index = 0; event_index < events_number; ++event_index) {
+		std::vector<Float_t> features (features_number, event_index);
+		std::vector<Float_t> targets;
+		for (auto& limit : target_limits) {
+			targets.push_back(limit.first +
+							  (limit.second - limit.first) / events_number * event_index);
+		}
+		dataset->data->emplace_back(new TMVA::Event {std::vector<Float_t> (features_number, event_index),
+														 targets});
+	}
+	return dataset;
+}
+
+void TestSingleTargetRegression() {
+	auto dataset = create_regression_dataset(100, 2, std::vector<std::pair<double, double>> (1,
+													 std::make_pair(0, 50)));
+	TMVA::DecisionTreeNode::fgIsTraining = true;
+	TMVA::DecisionTree tree (nullptr, 2, 0, dataset->info.get(), 0, false, 1, false, 500, 42, 0.01, 1);
+	tree.SetAnalysisType(TMVA::Types::kRegression);
+	tree.SetNVars(2);
+	tree.SetRoot(new TMVA::DecisionTreeNode);
+	tree.BuildTree(*(dataset->data.get()), tree.GetRoot());
+	auto a = tree.CheckEvent(new TMVA::Event {std::vector<Float_t> (2, 10),
+									 		  std::vector<Float_t> (2, 0)});
+	std::cout << a << std::endl;
+	TMVA::DecisionTreeNode::fgIsTraining = false;
+}
+
+void TestMultiTargetRegression() {
+	auto dataset = create_regression_dataset(100, 2, std::vector<std::pair<double, double>> {
+													 std::make_pair(0, 50), std::make_pair(50, 100)});
+	TMVA::DecisionTreeNode::fgIsTraining = true;
+	TMVA::DecisionTree tree (nullptr, 1, 200, dataset->info.get(), 0, false, 1, false, 500, 42, 0.01, 1);
+	tree.SetAnalysisType(TMVA::Types::kMultiRegression);
+	tree.SetNVars(2);
+	tree.SetRoot(new TMVA::DecisionTreeNode);
+	tree.BuildTree(*(dataset->data.get()), tree.GetRoot());
+	auto a = tree.GetMultiResponse(new TMVA::Event {std::vector<Float_t> {101, 101},
+									 		 	    std::vector<Float_t> (2, 0)});
+	for (auto kek : a) {
+		std::cout << kek << std::endl;
+	}
+	TMVA::DecisionTreeNode::fgIsTraining = false;
+}
+
+TEST(Multiregression, SingleVariable) {
+	UInt_t test_size = 1000;
+	for (UInt_t target_dim = 1; target_dim < 10; ++target_dim) {
+		std::vector<std::pair<double, double>> target_limits;
+		for (UInt_t limit_index = 0; limit_index < target_dim; ++limit_index) {
+			UInt_t lower_limit = rand() % 50;
+			UInt_t upper_limit = lower_limit + 1 + rand() % 50;
+			target_limits.push_back(std::make_pair(lower_limit, upper_limit));
+		}
+		auto dataset = create_regression_dataset (test_size, 1, target_limits);
+		TMVA::DecisionTreeNode::fgIsTraining = true;
+		TMVA::DecisionTree tree (nullptr, 1, test_size, dataset->info.get(), 0, false, 1, false, 500, 42, 0.01, 1);
+		tree.SetAnalysisType(TMVA::Types::kMultiRegression);
+		tree.SetNVars(1);
+		tree.SetRoot(new TMVA::DecisionTreeNode);
+		tree.BuildTree(*(dataset->data.get()), tree.GetRoot());
+		for (UInt_t test_index = 0; test_index < test_size; ++test_index) {
+			auto variable = static_cast<Float_t> (rand() % test_size);
+			auto response = tree.GetMultiResponse(new TMVA::Event {std::vector<Float_t> {variable},
+															std::vector<Float_t> (target_dim, 0)});
+			for (UInt_t value_index = 0; value_index < target_dim; ++value_index) {
+				ASSERT_TRUE(almost_equal_double(response[value_index], target_limits[value_index].first +
+												variable/test_size * (target_limits[value_index].second - 
+												target_limits[value_index].first)));
+			}
+		}
+		TMVA::DecisionTreeNode::fgIsTraining = false;
+	}
+}

--- a/tmva/tmva/test/DecisionTree/TestMultiregression.cxx
+++ b/tmva/tmva/test/DecisionTree/TestMultiregression.cxx
@@ -1,0 +1,81 @@
+#include <iostream>
+#include <memory>
+#include <string>
+#include <gtest/gtest.h>
+
+#include "TMVA/DecisionTree.h"
+#include "TMVA/Types.h"
+#include "TMVA/Event.h"
+#include "TMVA/DecisionTreeNode.h"
+#include "TMVA/DataSetInfo.h"
+
+struct TestDataset {
+	std::unique_ptr<TMVA::DataSetInfo> info;
+	std::unique_ptr<std::vector<const TMVA::Event*>> data;
+	~TestDataset() {
+		for (auto ev : *data.get())
+			delete ev;
+	}
+};
+
+std::unique_ptr<TestDataset> create_regression_dataset(uint32_t events_number,
+													   uint32_t features_number,
+														   const std::vector<std::pair<double,
+													   			         double>>& target_limits) {
+	std::unique_ptr<TestDataset> dataset (new TestDataset);
+	dataset->info = std::unique_ptr<TMVA::DataSetInfo> (new TMVA::DataSetInfo);
+	dataset->data = std::unique_ptr<std::vector<const TMVA::Event*>> (new std::vector<const TMVA::Event*>);
+	for (uint32_t feature_index = 0; feature_index < features_number; ++feature_index)
+		dataset->info->AddVariable(std::to_string(feature_index));
+	for (uint32_t target_index = 0; target_index < target_limits.size(); ++target_index)
+		dataset->info->AddTarget("_", "_", "_", target_limits[target_index].first,
+												target_limits[target_index].second);
+	for (uint32_t event_index = 0; event_index < events_number; ++event_index) {
+		std::vector<Float_t> features (features_number, event_index);
+		std::vector<Float_t> targets;
+		for (auto& limit : target_limits) {
+			targets.push_back(limit.first +
+							  (limit.second - limit.first) / events_number * event_index);
+		}
+		dataset->data->emplace_back(new TMVA::Event {std::vector<Float_t> (features_number, event_index),
+														 targets});
+	}
+	return dataset;
+}
+
+void TestSingleTargetRegression() {
+	auto dataset = create_regression_dataset(100, 2, std::vector<std::pair<double, double>> (1,
+													 std::make_pair(0, 50)));
+	TMVA::DecisionTreeNode::fgIsTraining = true;
+	TMVA::DecisionTree tree (nullptr, 2, 0, dataset->info.get(), 0, false, 1, false, 500, 42, 0.01, 1);
+	tree.SetAnalysisType(TMVA::Types::kRegression);
+	tree.SetNVars(2);
+	tree.SetRoot(new TMVA::DecisionTreeNode);
+	tree.BuildTree(*(dataset->data.get()), tree.GetRoot());
+	auto a = tree.CheckEvent(new TMVA::Event {std::vector<Float_t> (2, 10),
+									 		  std::vector<Float_t> (2, 0)});
+	std::cout << a << std::endl;
+	TMVA::DecisionTreeNode::fgIsTraining = false;
+}
+
+void TestMultiTargetRegression() {
+	auto dataset = create_regression_dataset(10, 2, std::vector<std::pair<double, double>> {
+													 std::make_pair(0, 50), std::make_pair(50, 100)});
+	TMVA::DecisionTreeNode::fgIsTraining = true;
+	TMVA::DecisionTree tree (nullptr, 1, 100, dataset->info.get(), 0, false, 1, false, 500, 42, 0.01, 1);
+	tree.SetAnalysisType(TMVA::Types::kMultiRegression);
+	tree.SetNVars(2);
+	tree.SetRoot(new TMVA::DecisionTreeNode);
+	tree.BuildTree(*(dataset->data.get()), tree.GetRoot());
+	auto a = tree.GetMultiResponse(new TMVA::Event {std::vector<Float_t> {5, 5},
+									 		 	    std::vector<Float_t> (2, 0)});
+	for (auto kek : a) {
+		std::cout << kek << std::endl;
+	}
+	TMVA::DecisionTreeNode::fgIsTraining = false;
+}
+
+TEST(Multiregression, ALL) {
+	//TestSingleTargetRegression();
+	TestMultiTargetRegression();
+}

--- a/tmva/tmva/test/DecisionTree/Utility.cpp
+++ b/tmva/tmva/test/DecisionTree/Utility.cpp
@@ -1,0 +1,30 @@
+#include "Utility.h"
+
+bool almost_equal_trivial(double x, double y) {
+   return std::abs(x-y) < 1E-4;
+}
+
+std::unique_ptr<TestDataset> create_regression_dataset(uint32_t events_number,
+													   uint32_t features_number,
+													   const std::vector<std::pair<double,
+												   			         double>>& target_limits) {
+	std::unique_ptr<TestDataset> dataset (new TestDataset);
+	dataset->info = std::unique_ptr<TMVA::DataSetInfo> (new TMVA::DataSetInfo);
+	dataset->data = std::unique_ptr<std::vector<const TMVA::Event*>> (new std::vector<const TMVA::Event*>);
+	for (uint32_t feature_index = 0; feature_index < features_number; ++feature_index)
+		dataset->info->AddVariable(std::to_string(feature_index));
+	for (uint32_t target_index = 0; target_index < target_limits.size(); ++target_index)
+		dataset->info->AddTarget("_", "_", "_", target_limits[target_index].first,
+												target_limits[target_index].second);
+	for (uint32_t event_index = 0; event_index < events_number; ++event_index) {
+		std::vector<Float_t> features (features_number, event_index);
+		std::vector<Float_t> targets;
+		for (auto& limit : target_limits) {
+			targets.push_back(limit.first +
+							  (limit.second - limit.first) / events_number * event_index);
+		}
+		dataset->data->emplace_back(new TMVA::Event {std::vector<Float_t> (features_number, event_index),
+														 targets});
+	}
+	return dataset;
+}

--- a/tmva/tmva/test/DecisionTree/Utility.h
+++ b/tmva/tmva/test/DecisionTree/Utility.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "TMVA/DataSetInfo.h"
+#include "TMVA/Event.h"
+#include <memory>
+
+struct TestDataset {
+	std::unique_ptr<TMVA::DataSetInfo> info;
+	std::unique_ptr<std::vector<const TMVA::Event*>> data;
+	~TestDataset() {
+		for (auto ev : *data.get())
+			delete ev;
+	}
+};
+
+bool almost_equal_trivial(double x, double y);
+
+std::unique_ptr<TestDataset> create_regression_dataset(uint32_t events_number,
+													   uint32_t features_number,
+													   const std::vector<std::pair<double,
+												   			         double>>& target_limits);

--- a/tutorials/tmva/TMVAMultiTaskRegression.C
+++ b/tutorials/tmva/TMVAMultiTaskRegression.C
@@ -1,0 +1,237 @@
+/// \author Andreas Hoecker
+
+#include <cstdlib>
+#include <iostream>
+#include <map>
+#include <string>
+
+#include "TChain.h"
+#include "TFile.h"
+#include "TTree.h"
+#include "TString.h"
+#include "TObjString.h"
+#include "TSystem.h"
+#include "TROOT.h"
+
+#include "TMVA/Tools.h"
+#include "TMVA/Factory.h"
+#include "TMVA/DataLoader.h"
+#include "TMVA/TMVARegGui.h"
+
+
+using namespace TMVA;
+
+void TMVAMultiRegression( TString myMethodList = "" )
+{
+   // The explicit loading of the shared libTMVA is done in TMVAlogon.C, defined in .rootrc
+   // if you use your private .rootrc, or run from a different directory, please copy the
+   // corresponding lines from .rootrc
+
+   // methods to be processed can be given as an argument; use format:
+   //
+   //     mylinux~> root -l TMVARegression.C\(\"myMethod1,myMethod2,myMethod3\"\)
+   //
+
+   //---------------------------------------------------------------
+   // This loads the library
+   TMVA::Tools::Instance();
+
+
+
+   // Default MVA methods to be trained + tested
+   std::map<std::string,int> Use;
+
+   // Methods which currently support multi-target regression:
+   // Mutidimensional likelihood and Nearest-Neighbour methods
+   Use["PDERS"]           = 0;
+   Use["PDEFoam"]         = 1;
+   Use["KNN"]             = 0;
+   
+   // Neural Network
+   Use["MLP"]             = 1;
+   //
+   // Boosted Decision Trees
+   Use["BDT"]             = 1;
+
+   std::cout << std::endl;
+   std::cout << "==> Start TMVARegression" << std::endl;
+
+   // Select methods (don't look at this code - not of interest)
+   if (myMethodList != "") {
+      for (std::map<std::string,int>::iterator it = Use.begin(); it != Use.end(); it++) it->second = 0;
+
+      std::vector<TString> mlist = gTools().SplitString( myMethodList, ',' );
+      for (UInt_t i=0; i<mlist.size(); i++) {
+         std::string regMethod(mlist[i]);
+
+         if (Use.find(regMethod) == Use.end()) {
+            std::cout << "Method \"" << regMethod << "\" not known in TMVA under this name. Choose among the following:" << std::endl;
+            for (std::map<std::string,int>::iterator it = Use.begin(); it != Use.end(); it++) std::cout << it->first << " ";
+            std::cout << std::endl;
+            return;
+         }
+         Use[regMethod] = 1;
+      }
+   }
+
+   // --------------------------------------------------------------------------------------------------
+
+   // Here the preparation phase begins
+
+   // Create a new root output file
+   TString outfileName( "TMVAMultiReg.root" );
+   TFile* outputFile = TFile::Open( outfileName, "RECREATE" );
+
+   // Create the factory object. Later you can choose the methods
+   // whose performance you'd like to investigate. The factory will
+   // then run the performance analysis for you.
+   //
+   // The first argument is the base of the name of all the
+   // weightfiles in the directory weight/
+   //
+   // The second argument is the output file for the training results
+   // All TMVA output can be suppressed by removing the "!" (not) in
+   // front of the "Silent" argument in the option string
+   TMVA::Factory *factory = new TMVA::Factory( "TMVAMultiRegression", outputFile,
+                                               "!V:!Silent:Color:DrawProgressBar:AnalysisType=Regression" );
+
+
+   TMVA::DataLoader *dataloader=new TMVA::DataLoader("dataset");
+   // If you wish to modify default settings
+   // (please check "src/Config.h" to see all available global options)
+   //
+   //     (TMVA::gConfig().GetVariablePlotting()).fTimesRMS = 8.0;
+   //     (TMVA::gConfig().GetIONames()).fWeightFileDir = "myWeightDirectory";
+
+   // Define the input variables that shall be used for the MVA training
+   // note that you may also use variable expressions, such as: "3*var1/var2*abs(var3)"
+   // [all types of expressions that can also be parsed by TTree::Draw( "expression" )]
+   dataloader->AddVariable( "var1", "Variable 1", "units", 'F' );
+   dataloader->AddVariable( "var2", "Variable 2", "units", 'F' );
+
+   // You can add so-called "Spectator variables", which are not used in the MVA training,
+   // but will appear in the final "TestTree" produced by TMVA. This TestTree will contain the
+   // input variables, the response values of all trained MVAs, and the spectator variables
+   dataloader->AddSpectator( "spec1:=var1*2",  "Spectator 1", "units", 'F' );
+   dataloader->AddSpectator( "spec2:=var1*3",  "Spectator 2", "units", 'F' );
+
+   // Add the variable carrying the regression target
+   dataloader->AddTarget( "fvalue" );
+   dataloader->AddTarget( "f3" );
+
+   // Read training and test data (see TMVAClassification for reading ASCII files)
+   // load the signal and background event samples from ROOT trees
+   TFile *input(0);
+   TString fname = "./files/tmva_multireg_example.root";
+   if (!gSystem->AccessPathName( fname )) {
+      input = TFile::Open( fname ); // check if file in local directory exists
+   }
+   else {
+      std::cout << "ERROR: could not open data file" << std::endl;
+      exit(1);
+   }
+   if (!input) {
+      std::cout << "ERROR: could not open data file" << std::endl;
+      exit(1);
+   }
+   std::cout << "--- TMVAMultiTaskRegression           : Using input file: " << input->GetName() << std::endl;
+
+   // Register the regression tree
+   
+   TTree *regTree = (TTree*)input->Get("MultiRegTree");
+
+   // global event weights per tree (see below for setting event-wise weights)
+   Double_t regWeight  = 1.0;
+
+   // You can add an arbitrary number of regression trees
+   dataloader->AddRegressionTree( regTree, regWeight );
+
+   // This would set individual event weights (the variables defined in the
+   // expression need to exist in the original TTree)
+   dataloader->SetWeightExpression( "var1", "Regression" );
+   // Apply additional cuts on the signal and background samples (can be different)
+   TCut mycut = ""; // for example: TCut mycut = "abs(var1)<0.5 && abs(var2-0.5)<1";
+   
+   // tell the DataLoader to use all remaining events in the trees after training for testing:
+   dataloader->PrepareTrainingAndTestTree( mycut,
+                                         "nTrain_Regression=1000:nTest_Regression=0:SplitMode=Random:NormMode=NumEvents:!V" );
+   //
+   //     dataloader->PrepareTrainingAndTestTree( mycut,
+   //            "nTrain_Regression=0:nTest_Regression=0:SplitMode=Random:NormMode=NumEvents:!V" );
+
+   // If no numbers of events are given, half of the events in the tree are used
+   // for training, and the other half for testing:
+   //
+   //     dataloader->PrepareTrainingAndTestTree( mycut, "SplitMode=random:!V" );
+
+   // Book MVA methods
+   //
+   // Please lookup the various method configuration options in the corresponding cxx files, eg:
+   // src/MethoCuts.cxx, etc, or here: http://tmva.sourceforge.net/optionRef.html
+   // it is possible to preset ranges in the option string in which the cut optimisation should be done:
+   // "...:CutRangeMin[2]=-1:CutRangeMax[2]=1"...", where [2] is the third input variable
+   
+   // PDE - RS method
+   if (Use["PDERS"])
+      factory->BookMethod( dataloader,  TMVA::Types::kPDERS, "PDERS",
+                           "!H:!V:NormTree=T:VolumeRangeMode=Adaptive:KernelEstimator=Gauss:GaussSigma=0.3:NEventsMin=40:NEventsMax=60:VarTransform=None" );
+   // And the options strings for the MinMax and RMS methods, respectively:
+   //
+   //      "!H:!V:VolumeRangeMode=MinMax:DeltaFrac=0.2:KernelEstimator=Gauss:GaussSigma=0.3" );
+   //      "!H:!V:VolumeRangeMode=RMS:DeltaFrac=3:KernelEstimator=Gauss:GaussSigma=0.3" );
+
+   if (Use["PDEFoam"])
+       factory->BookMethod( dataloader,  TMVA::Types::kPDEFoam, "PDEFoam",
+			    "!H:!V:MultiTargetRegression=F:TargetSelection=Mpv:TailCut=0.001:VolFrac=0.0666:nActiveCells=500:nSampl=2000:nBin=5:Compress=T:Kernel=None:Nmin=10:VarTransform=None" );
+
+   // K-Nearest Neighbour classifier (KNN)
+   if (Use["KNN"])
+      factory->BookMethod( dataloader,  TMVA::Types::kKNN, "KNN",
+                           "nkNN=20:ScaleFrac=0.8:SigmaFact=1.0:Kernel=Gaus:UseKernel=F:UseWeight=T:!Trim" );
+
+   // Neural network (MLP)
+   if (Use["MLP"])
+      factory->BookMethod( dataloader,  TMVA::Types::kMLP, "MLP", "!H:!V:VarTransform=Norm:NeuronType=tanh:NCycles=20000:HiddenLayers=N+20:TestRate=6:TrainingMethod=BFGS:Sampling=0.3:SamplingEpoch=0.8:ConvergenceImprove=1e-6:ConvergenceTests=15:!UseRegulator" );
+
+   
+   // Boosted Decision Trees
+   // Right now the only supported Boosting Method for handling Multi-target regression is Bagging
+   if (Use["BDT"])
+     factory->BookMethod( dataloader,  TMVA::Types::kBDT, "BDT",
+                           "!H:!V:NTrees=100:MinNodeSize=1.0%:BoostType=Bagging:SeparationType=RegressionVariance:nCuts=20:PruneMethod=CostComplexity:PruneStrength=30" );
+   factory->TrainAllMethods();
+
+   // Evaluate all MVAs using the set of test events
+   factory->TestAllMethods();
+
+   // Evaluate and compare performance of all configured MVAs
+   factory->EvaluateAllMethods();
+
+   // --------------------------------------------------------------
+
+   // Save the output
+   outputFile->Close();
+
+   std::cout << "==> Wrote root file: " << outputFile->GetName() << std::endl;
+   std::cout << "==> TMVARegression is done!" << std::endl;
+
+   delete factory;
+   delete dataloader;
+
+   // Launch the GUI for the root macros
+   if (!gROOT->IsBatch()) TMVA::TMVARegGui( outfileName );
+}
+
+int main( int argc, char** argv )
+{
+   // Select methods (don't look at this code - not of interest)
+   TString methodList;
+   for (int i=1; i<argc; i++) {
+      TString regMethod(argv[i]);
+      if(regMethod=="-b" || regMethod=="--batch") continue;
+      if (!methodList.IsNull()) methodList += TString(",");
+      methodList += regMethod;
+   }
+   TMVAMultiRegression(methodList);
+   return 0;
+}


### PR DESCRIPTION
Hello, Everyone!

My name is Sergey and I am a GSOC student this year. The aim of my project is to implement Multi-Target Regression algorithms to TMVA and to extend the capability of existing ones to handle multiple targets.

In this commit I have modified the DecisionTree, allowing it to solve regression problems for multiple targets. The idea was inspired by how it is done in Clus package. (The variance of each subset resulting from a split is simply summed up from variances for each target).

I have also extended the capability of BDT method to handle multiple targets (The only boosting method available for it right now is Bagging, but  I am planning to implement Multi-target gradient descent based on the paper Boosted multi-task learning (2010) by Olivier Chapelle
Pannagadatta Shivaswamy.
·