### PR TITLE
Revert "Change the clang default to request bool rather than _Bool"

### DIFF
--- a/interpreter/llvm/src/tools/clang/include/clang/Basic/LangOptions.def
+++ b/interpreter/llvm/src/tools/clang/include/clang/Basic/LangOptions.def
@@ -101,7 +101,7 @@ BENIGN_LANGOPT(ObjCInferRelatedResultType , 1, 1,
 LANGOPT(AppExt , 1, 0, "Objective-C App Extension")
 LANGOPT(Trigraphs         , 1, 0,"trigraphs")
 LANGOPT(LineComment       , 1, 0, "'//' comments")
-LANGOPT(Bool              , 1, 1, "bool, true, and false keywords")
+LANGOPT(Bool              , 1, 0, "bool, true, and false keywords")
 LANGOPT(Half              , 1, 0, "half keyword")
 LANGOPT(WChar             , 1, CPlusPlus, "wchar_t keyword")
 LANGOPT(DeclSpecKeyword   , 1, 0, "__declspec keyword")


### PR DESCRIPTION
This reverts commit 5f7fd3aa6007c04e9d761816fea6d9b3146bd79a.

clang.git patch id: 4412120