### PR TITLE
Add google benchmark

### DIFF
--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -1225,6 +1225,30 @@ function(ROOT_PATH_TO_STRING resultvar path)
 endfunction(ROOT_PATH_TO_STRING)
 
 #----------------------------------------------------------------------------
+# function ROOT_ADD_GBENCHMARK(<benchmark> source1 source2... LIBRARIES)
+#----------------------------------------------------------------------------
+function(ROOT_ADD_GTEST benchmark)
+  CMAKE_PARSE_ARGUMENTS(ARG "" "" "LIBRARIES" ${ARGN})
+  include_directories(${CMAKE_CURRENT_BINARY_DIR} ${GBENCHMARK_INCLUDE_DIR})
+
+  ROOT_GET_SOURCES(source_files . ${ARG_UNPARSED_ARGUMENTS})
+  # Note we cannot use ROOT_EXECUTABLE without user-specified set of LIBRARIES to link with.
+  # The test suites should choose this in their specific CMakeLists.txt file.
+  # FIXME: For better coherence we could restrict the libraries the test suite could link
+  # against. For example, tests in Core should link only against libCore. This could be tricky
+  # to implement because some ROOT components create more than one library.
+  ROOT_EXECUTABLE(${benchmark} ${source_files} LIBRARIES ${ARG_LIBRARIES})
+  set_property(TARGET ${benchmark} PROPERTY RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  target_link_libraries(${benchmark} gbenchmark)
+
+  ROOT_PATH_TO_STRING(mangled_name ${benchmark} PATH_SEPARATOR_REPLACEMENT "-")
+  ROOT_ADD_TEST(gbench${mangled_name}
+    COMMAND ${benchmark}
+    WORKING_DIR ${CMAKE_CURRENT_BINARY_DIR}
+    LABELS "benchmark")
+endfunction()
+
+#----------------------------------------------------------------------------
 # ROOT_ADD_UNITTEST_DIR(<libraries ...>)
 #----------------------------------------------------------------------------
 function(ROOT_ADD_UNITTEST_DIR)

--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -1245,7 +1245,7 @@ function(ROOT_ADD_GBENCHMARK benchmark)
   ROOT_ADD_TEST(gbench${mangled_name}
     COMMAND ${benchmark}
     WORKING_DIR ${CMAKE_CURRENT_BINARY_DIR}
-    LABELS "benchmark")
+    LABELS "benchmark;longtest")
 endfunction()
 
 #----------------------------------------------------------------------------

--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -1227,7 +1227,7 @@ endfunction(ROOT_PATH_TO_STRING)
 #----------------------------------------------------------------------------
 # function ROOT_ADD_GBENCHMARK(<benchmark> source1 source2... LIBRARIES)
 #----------------------------------------------------------------------------
-function(ROOT_ADD_GTEST benchmark)
+function(ROOT_ADD_GBENCHMARK benchmark)
   CMAKE_PARSE_ARGUMENTS(ARG "" "" "LIBRARIES" ${ARGN})
   include_directories(${CMAKE_CURRENT_BINARY_DIR} ${GBENCHMARK_INCLUDE_DIR})
 

--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -1260,7 +1260,7 @@ endfunction()
 
 #----------------------------------------------------------------------------
 # function ROOT_ADD_GTEST(<testsuite> source1 source2... LIBRARIES)
-#
+#----------------------------------------------------------------------------
 function(ROOT_ADD_GTEST test_suite)
   CMAKE_PARSE_ARGUMENTS(ARG "" "" "LIBRARIES" ${ARGN})
   include_directories(${CMAKE_CURRENT_BINARY_DIR} ${GTEST_INCLUDE_DIR} ${GMOCK_INCLUDE_DIR})
@@ -1278,7 +1278,6 @@ function(ROOT_ADD_GTEST test_suite)
   ROOT_PATH_TO_STRING(mangled_name ${test_suite} PATH_SEPARATOR_REPLACEMENT "-")
   ROOT_ADD_TEST(gtest${mangled_name} COMMAND ${test_suite} WORKING_DIR ${CMAKE_CURRENT_BINARY_DIR})
 endfunction()
-
 
 #----------------------------------------------------------------------------
 # ROOT_ADD_TEST_SUBDIRECTORY( <name> )

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1616,7 +1616,7 @@ if (testing)
                   -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
     # Disable install step
     INSTALL_COMMAND ""
-    BUILD_BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/googletest-prefix/src/libbenchmark.a"
+    BUILD_BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/googlebenchmark-prefix/src/googlebenchmark-build/src/libbenchmark.a"
     # Wrap download, configure and build steps in a script to log output
     LOG_DOWNLOAD ON
     LOG_CONFIGURE ON

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1591,6 +1591,10 @@ if (testing)
   set_property(TARGET gmock PROPERTY IMPORTED_LOCATION ${_G_LIBRARY_PATH}/libgmock.a)
   set_property(TARGET gmock_main PROPERTY IMPORTED_LOCATION ${_G_LIBRARY_PATH}/libgmock_main.a)
 
+  ###################################
+  string(REPLACE "-Woverloaded-virtual" "" GBENCHMARK_CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+  ##################################
+
   # Add google benchmarking tools.
   ExternalProject_Add(
     googlebenchmark
@@ -1608,7 +1612,7 @@ if (testing)
                   -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
                   -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
                   -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-                  -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+                  -DCMAKE_CXX_FLAGS=${GBENCHMARK_CMAKE_CXX_FLAGS}
                   -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
     # Disable install step
     INSTALL_COMMAND ""

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1591,6 +1591,46 @@ if (testing)
   set_property(TARGET gmock PROPERTY IMPORTED_LOCATION ${_G_LIBRARY_PATH}/libgmock.a)
   set_property(TARGET gmock_main PROPERTY IMPORTED_LOCATION ${_G_LIBRARY_PATH}/libgmock_main.a)
 
+  # Add google benchmarking tools.
+  ExternalProject_Add(
+    googlebenchmark
+    GIT_REPOSITORY https://github.com/google/benchmark.git
+    GIT_TAG master
+    UPDATE_COMMAND ""
+    # TIMEOUT 10
+    # # Force separate output paths for debug and release builds to allow easy
+    # # identification of correct lib in subsequent TARGET_LINK_LIBRARIES commands
+    # CMAKE_ARGS -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG:PATH=DebugLibs
+    #            -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE:PATH=ReleaseLibs
+    #            -Dgtest_force_shared_crt=ON
+    CMAKE_ARGS -G ${CMAKE_GENERATOR}
+                  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                  -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                  -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
+                  -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+                  -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+                  -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+    # Disable install step
+    INSTALL_COMMAND ""
+    BUILD_BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/googletest-prefix/src/libbenchmark.a"
+    # Wrap download, configure and build steps in a script to log output
+    LOG_DOWNLOAD ON
+    LOG_CONFIGURE ON
+    LOG_BUILD ON)
+
+  # Specify include dirs for googlebenchmark
+  ExternalProject_Get_Property(googlebenchmark source_dir)
+  set(GBENCHMARK_INCLUDE_DIR ${source_dir}/include)
+
+  # Libraries
+  ExternalProject_Get_Property(googlebenchmark binary_dir)
+  set(_GBENCH_LIBRARY_PATH ${binary_dir}/)
+
+  # Register googlebenchmark
+  add_library(gbenchmark IMPORTED STATIC GLOBAL)
+  set_property(TARGET gbenchmark PROPERTY IMPORTED_LOCATION ${_GBENCH_LIBRARY_PATH}/src/libbenchmark.a)
+  add_dependencies(gbenchmark googlebenchmark)
+
 endif()
 
 #---Report non implemented options---------------------------------------------------

--- a/math/genvector/CMakeLists.txt
+++ b/math/genvector/CMakeLists.txt
@@ -20,9 +20,20 @@ set(headers   Math/Vector2D.h Math/Point2D.h
 set(headers32 Math/Vector2D.h Math/Point2D.h
              Math/Vector3D.h Math/Point3D.h Math/Vector4D.h)
 
+if(veccore)
+  set(GENVECTOR_LIBRARIES ${VecCore_LIBRARIES})
+  set(GENVECTORS_BUILTINS VECCORE)
+endif()
+
+
 ROOT_GENERATE_DICTIONARY(G__${libname}   ${headers} MODULE ${libname} LINKDEF Math/LinkDef_GenVector.h OPTIONS "-writeEmptyRootPCM" DEPENDENCIES Core)
 ROOT_GENERATE_DICTIONARY(G__${libname}32 ${headers32} MULTIDICT MODULE ${libname} LINKDEF Math/LinkDef_GenVector32.h OPTIONS "-writeEmptyRootPCM" DEPENDENCIES Core)
 
-ROOT_LINKER_LIBRARY(${libname} *.cxx G__${libname}.cxx G__${libname}32.cxx LIBRARIES Core)
+ROOT_LINKER_LIBRARY(${libname} *.cxx G__${libname}.cxx G__${libname}32.cxx LIBRARIES ${GENVECTOR_LIBRARIES} DEPENDENCIES Core BUILTINS ${GENVECTORS_BUILTINS})
+
+if(veccore)
+  target_compile_definitions(GenVector INTERFACE ${VecCore_DEFINITIONS})
+endif()
+
 ROOT_INSTALL_HEADERS()
 

--- a/math/genvector/CMakeLists.txt
+++ b/math/genvector/CMakeLists.txt
@@ -2,6 +2,10 @@
 # CMakeLists.txt file for building ROOT math/genvector package
 ############################################################################
 
+if(testing)
+  add_subdirectory(perf)
+endif()
+
 set(libname GenVector)
 
 set(headers   Math/Vector2D.h Math/Point2D.h

--- a/math/genvector/inc/Math/GenVector/Cartesian3D.h
+++ b/math/genvector/inc/Math/GenVector/Cartesian3D.h
@@ -30,8 +30,8 @@
 
 #if defined(R__HAS_VC) && !defined(VECCORE_ENABLE_VC)
 #define VECCORE_ENABLE_VC
-#endif
 #include <VecCore/VecCore>
+#endif
 
 namespace ROOT {
 
@@ -312,5 +312,4 @@ void Cartesian3D<T>::SetEta(Scalar eta) {
 
 #endif
 
-//#endif // R__HAS_VECCORE
 #endif /* ROOT_Math_GenVector_Cartesian3D  */

--- a/math/genvector/inc/Math/GenVector/Cartesian3D.h
+++ b/math/genvector/inc/Math/GenVector/Cartesian3D.h
@@ -28,6 +28,11 @@
 
 #include "Math/GenVector/eta.h"
 
+#if defined(R__HAS_VC) && !defined(VECCORE_ENABLE_VC)
+#define VECCORE_ENABLE_VC
+#endif
+#include <VecCore/VecCore>
+
 namespace ROOT {
 
 namespace Math {
@@ -113,9 +118,9 @@ public :
    Scalar R() const { return sqrt(Mag2()); }
    Scalar Theta() const
    {
-      return (fX == Scalar(0) && fY == Scalar(0) && fZ == Scalar(0)) ? Scalar(0) : atan2(Rho(), Z());
+      return /*(fX == Scalar(0) && fY == Scalar(0) && fZ == Scalar(0)) ? Scalar(0) :*/ atan2(Rho(), Z());
    }
-   Scalar Phi() const { return (fX == Scalar(0) && fY == Scalar(0)) ? Scalar(0) : atan2(fY, fX); }
+   Scalar Phi() const { return /*(fX == Scalar(0) && fY == Scalar(0)) ? Scalar(0) :*/ atan2(fY, fX); }
 
    // pseudorapidity
    Scalar Eta() const {
@@ -307,7 +312,5 @@ void Cartesian3D<T>::SetEta(Scalar eta) {
 
 #endif
 
-
-
-
+//#endif // R__HAS_VECCORE
 #endif /* ROOT_Math_GenVector_Cartesian3D  */

--- a/math/genvector/perf/CMakeLists.txt
+++ b/math/genvector/perf/CMakeLists.txt
@@ -1,0 +1,1 @@
+ROOT_ADD_GBENCHMARK(GenVectorBenchmarks Cartesian3DBenchmarks.cxx LIBRARIES GenVector Vc)

--- a/math/genvector/perf/CMakeLists.txt
+++ b/math/genvector/perf/CMakeLists.txt
@@ -1,4 +1,7 @@
-set(LIBS_TO_LINK GenVector rt)
+set(LIBS_TO_LINK GenVector)
+if(UNIX AND NOT APPLE)
+  set(LIBS_TO_LINK ${LIBS_TO_LINK} rt)
+endif()
 if (veccore)
   set(LIBS_TO_LINK ${LIBS_TO_LINK} ${VecCore_LIBRARIES})
 endif()

--- a/math/genvector/perf/CMakeLists.txt
+++ b/math/genvector/perf/CMakeLists.txt
@@ -1,1 +1,5 @@
-ROOT_ADD_GBENCHMARK(GenVectorBenchmarks Cartesian3DBenchmarks.cxx LIBRARIES GenVector Vc rt)
+set(LIBS_TO_LINK GenVector rt)
+if (veccore)
+  set(LIBS_TO_LINK ${LIBS_TO_LINK} ${VecCore_LIBRARIES})
+endif()
+ROOT_ADD_GBENCHMARK(GenVectorBenchmarks Cartesian3DBenchmarks.cxx LIBRARIES ${LIBS_TO_LINK})

--- a/math/genvector/perf/CMakeLists.txt
+++ b/math/genvector/perf/CMakeLists.txt
@@ -1,1 +1,1 @@
-ROOT_ADD_GBENCHMARK(GenVectorBenchmarks Cartesian3DBenchmarks.cxx LIBRARIES GenVector Vc)
+ROOT_ADD_GBENCHMARK(GenVectorBenchmarks Cartesian3DBenchmarks.cxx LIBRARIES GenVector Vc rt)

--- a/math/genvector/perf/Cartesian3DBenchmarks.cxx
+++ b/math/genvector/perf/Cartesian3DBenchmarks.cxx
@@ -31,12 +31,11 @@ static void BM_Cartesian3D_Theta(benchmark::State &state)
    ROOT::Math::Cartesian3D<T> c(1., 2., 3.);
    // std::cout << is_aligned(&c, 16) << std::endl;
    while (state.KeepRunning()) c.Theta();
-   state.SetComplexityN(state.range(0));
 }
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, double)->Range(8, 8 << 10)->Complexity(benchmark::o1);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, ROOT::Double_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, float)->Range(8, 8 << 10)->Complexity(benchmark::o1);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, ROOT::Float_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, double);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, ROOT::Double_v);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, float);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, ROOT::Float_v);
 
 template <typename T>
 static void BM_Cartesian3D_Phi(benchmark::State &state)
@@ -44,12 +43,11 @@ static void BM_Cartesian3D_Phi(benchmark::State &state)
    ROOT::Math::Cartesian3D<T> c(1., 2., 3.);
    // std::cout << is_aligned(&c, 16) << std::endl;
    while (state.KeepRunning()) c.Phi();
-   state.SetComplexityN(state.range(0));
 }
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, double)->Range(8, 8 << 10)->Complexity(benchmark::o1);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, ROOT::Double_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, float)->Range(8, 8 << 10)->Complexity(benchmark::o1);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, ROOT::Float_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, double);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, ROOT::Double_v);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, float);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, ROOT::Float_v);
 
 template <typename T>
 static void BM_Cartesian3D_Mag2(benchmark::State &state)
@@ -57,10 +55,9 @@ static void BM_Cartesian3D_Mag2(benchmark::State &state)
    ROOT::Math::Cartesian3D<T> c(1., 2., 3.);
    // std::cout << is_aligned(&c, 16) << std::endl;
    while (state.KeepRunning()) c.Mag2();
-   state.SetComplexityN(state.range(0));
 }
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, double)->Range(8, 8 << 10)->Complexity(benchmark::o1);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, ROOT::Double_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, double);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, ROOT::Double_v);
 
 // Define our main.
 BENCHMARK_MAIN();

--- a/math/genvector/perf/Cartesian3DBenchmarks.cxx
+++ b/math/genvector/perf/Cartesian3DBenchmarks.cxx
@@ -110,5 +110,30 @@ BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, ROOT::Double_v)->Range(8 << 10, 8 << 20)
 // BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, float)->Range(8 << 10, 8 << 20);
 // BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, ROOT::Float_v)->Range(8 << 10, 8 << 20);
 
+template <typename T>
+static void BM_Cartesian3D_Scale(benchmark::State &state)
+{
+   using namespace ROOT::Benchmark;
+   // We want the same random numbers for a benchmark family.
+   SetSeed(4);
+   // Allocate N points
+   constexpr size_t VecSize = TypeSize<T>::Get();
+   typename Data<T>::Vector Points(state.range(0) / VecSize);
+   ROOT::Math::Cartesian3D<T> c;
+   T checksum = T();
+   while (state.KeepRunning()) {
+      checksum = T();
+      for (auto &p : Points) {
+         c.SetCoordinates(p.X, p.Y, p.Z);
+         c.Scale(p.X);
+         checksum += c.x() + c.y() + c.z();
+      }
+   }
+
+   ComputeProcessedEntities(state, sizeof(T), VecTraits<T>::Sum(checksum));
+}
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Scale, double)->Range(8 << 10, 8 << 20);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Scale, ROOT::Double_v)->Range(8 << 10, 8 << 20);
+
 // Define our main.
 BENCHMARK_MAIN();

--- a/math/genvector/perf/Cartesian3DBenchmarks.cxx
+++ b/math/genvector/perf/Cartesian3DBenchmarks.cxx
@@ -11,6 +11,14 @@ static bool is_aligned(const void *__restrict__ ptr, size_t align)
    return (uintptr_t)ptr % align == 0;
 }
 
+static void BM_Cartesian3D_Sanity(benchmark::State &state)
+{
+   // Report if we forgot to turn on the explicit vectorisation in ROOT.
+   if (sizeof(double) == sizeof(ROOT::Double_v) || sizeof(float) == sizeof(ROOT::Float_v))
+      state.SkipWithError("Explicit vectorisation is disabled!");
+}
+BENCHMARK(BM_Cartesian3D_Sanity);
+
 static void BM_Cartesian3D_CreateEmpty(benchmark::State &state)
 {
    while (state.KeepRunning()) ROOT::Math::Cartesian3D<ROOT::Double_v> c;

--- a/math/genvector/perf/Cartesian3DBenchmarks.cxx
+++ b/math/genvector/perf/Cartesian3DBenchmarks.cxx
@@ -15,6 +15,13 @@ static void BM_Cartesian3D_Sanity(benchmark::State &state)
    // Report if we forgot to turn on the explicit vectorisation in ROOT.
    if (sizeof(double) == sizeof(ROOT::Double_v) || sizeof(float) == sizeof(ROOT::Float_v))
       state.SkipWithError("Explicit vectorisation is disabled!");
+
+#ifndef NDEBUG
+   // If we compile gbenchmark in debug mode it asserts because this particular benchmark doesn't have
+   // state.KeepRunning() clause. Here this is meant to perform a simple sanity check for the expected configuration.
+   while (state.KeepRunning()) {
+   }
+#endif
 }
 BENCHMARK(BM_Cartesian3D_Sanity);
 

--- a/math/genvector/perf/Cartesian3DBenchmarks.cxx
+++ b/math/genvector/perf/Cartesian3DBenchmarks.cxx
@@ -1,23 +1,4 @@
 #include "Math/Cartesian3D.h"
-#include "Math/Point3D.h"
-#include "Math/Vector3D.h"
-#include "Math/Vector4D.h"
-#include "Math/GenVector/Rotation3D.h"
-#include "Math/GenVector/EulerAngles.h"
-#include "Math/GenVector/AxisAngle.h"
-#include "Math/GenVector/Quaternion.h"
-#include "Math/GenVector/RotationX.h"
-#include "Math/GenVector/RotationY.h"
-#include "Math/GenVector/RotationZ.h"
-#include "Math/GenVector/RotationZYX.h"
-#include "Math/GenVector/LorentzRotation.h"
-#include "Math/GenVector/Boost.h"
-#include "Math/GenVector/BoostX.h"
-#include "Math/GenVector/BoostY.h"
-#include "Math/GenVector/BoostZ.h"
-#include "Math/GenVector/Transform3D.h"
-#include "Math/GenVector/Plane3D.h"
-#include "Math/GenVector/VectorUtil.h"
 
 #include "Math/Math_vectypes.hxx"
 
@@ -29,20 +10,6 @@ static bool is_aligned(const void *__restrict__ ptr, size_t align)
 {
    return (uintptr_t)ptr % align == 0;
 }
-
-template <typename T>
-using Point = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<T>, ROOT::Math::DefaultCoordinateSystemTag>;
-template <typename T>
-using Vector = ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<T>, ROOT::Math::DefaultCoordinateSystemTag>;
-template <typename T>
-using Plane = ROOT::Math::Impl::Plane3D<T>;
-
-static std::default_random_engine ggen;
-
-static std::uniform_real_distribution<double> p_x(1, 2), p_y(2, 3), p_z(3, 4);
-static std::uniform_real_distribution<double> d_x(1, 2), d_y(2, 3), d_z(3, 4);
-static std::uniform_real_distribution<double> c_x(1, 2), c_y(2, 3), c_z(3, 4);
-static std::uniform_real_distribution<double> p0(-0.002, 0.002), p1(-0.2, 0.2), p2(0.97, 0.99), p3(-1300, 1300);
 
 static void BM_Cartesian3D_CreateEmpty(benchmark::State &state)
 {
@@ -78,89 +45,13 @@ BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, ROOT::Float_v)->Range(8, 8 << 10)->Comple
 template <typename T>
 static void BM_Cartesian3D_Mag2(benchmark::State &state)
 {
-
    ROOT::Math::Cartesian3D<T> c(1., 2., 3.);
    // std::cout << is_aligned(&c, 16) << std::endl;
    while (state.KeepRunning()) c.Mag2();
+   state.SetComplexityN(state.range(0));
 }
 BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, double)->Range(8, 8 << 10)->Complexity(benchmark::o1);
 BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, ROOT::Double_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
-
-template <typename T>
-static void BM_Point3D(benchmark::State &state)
-{
-   while (state.KeepRunning()) Point<T> sp1, sp2, sp3, sp4, sp5, sp6;
-}
-
-BENCHMARK_TEMPLATE(BM_Point3D, double)->Range(8, 8 << 10)->Complexity(benchmark::o1);
-BENCHMARK_TEMPLATE(BM_Point3D, ROOT::Double_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
-
-template <typename T>
-static void BM_Point3D_Gen(benchmark::State &state)
-{
-   while (state.KeepRunning()) {
-      Point<T> sp1(p_x(ggen), p_y(ggen), p_z(ggen));
-   }
-}
-BENCHMARK_TEMPLATE(BM_Point3D_Gen, double)->Range(8, 8 << 10)->Complexity(benchmark::o1);
-BENCHMARK_TEMPLATE(BM_Point3D_Gen, ROOT::Double_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
-
-template <typename T>
-static void BM_Transform3D(benchmark::State &state)
-{
-   Point<T> sp1(p_x(ggen), p_y(ggen), p_z(ggen));
-   Point<T> sp2(p_x(ggen), p_y(ggen), p_z(ggen));
-   Point<T> sp3(p_x(ggen), p_y(ggen), p_z(ggen));
-   Point<T> sp4(p_x(ggen), p_y(ggen), p_z(ggen));
-   Point<T> sp5(p_x(ggen), p_y(ggen), p_z(ggen));
-   Point<T> sp6(p_x(ggen), p_y(ggen), p_z(ggen));
-   while (state.KeepRunning()) {
-      ROOT::Math::Impl::Transform3D<T> st(sp1, sp2, sp3, sp4, sp5, sp6);
-      st.Translation();
-   }
-}
-// BENCHMARK_TEMPLATE(BM_Transform3D, double)->Range(8, 8<<10)->Complexity(benchmark::o1);
-// BENCHMARK_TEMPLATE(BM_Transform3D, float)->Range(8, 8<<10)->Complexity(benchmark::o1);
-// BENCHMARK_TEMPLATE(BM_Transform3D, ROOT::Double_v)->Range(8, 8<<10)->Complexity(benchmark::o1);
-// BENCHMARK_TEMPLATE(BM_Transform3D, ROOT::Float_v)->Range(8, 8<<10)->Complexity(benchmark::o1);
-
-template <typename T>
-static void BM_Plane3D(benchmark::State &state)
-{
-   const double a(p0(ggen)), b(p1(ggen)), c(p2(ggen)), d(p3(ggen));
-   while (state.KeepRunning()) {
-      Plane<T> sc_plane(a, b, c, d);
-   }
-}
-BENCHMARK_TEMPLATE(BM_Plane3D, double)->Range(8, 8 << 10)->Complexity(benchmark::o1);
-BENCHMARK_TEMPLATE(BM_Plane3D, ROOT::Double_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
-BENCHMARK_TEMPLATE(BM_Plane3D, ROOT::Float_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
-
-template <typename T>
-static void BM_Plane3D_Hessian(benchmark::State &state)
-{
-   const double a(p0(ggen)), b(p1(ggen)), c(p2(ggen)), d(p3(ggen));
-   while (state.KeepRunning()) {
-      Plane<T> sc_plane(a, b, c, d);
-      sc_plane.HesseDistance();
-   }
-}
-BENCHMARK_TEMPLATE(BM_Plane3D_Hessian, double)->Range(8, 8 << 10)->Complexity(benchmark::o1);
-BENCHMARK_TEMPLATE(BM_Plane3D_Hessian, ROOT::Double_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
-
-template <typename T>
-static void BM_Plane3D_Normal(benchmark::State &state)
-{
-   const double a(p0(ggen)), b(p1(ggen)), c(p2(ggen)), d(p3(ggen));
-   while (state.KeepRunning()) {
-      Plane<T> sc_plane(a, b, c, d);
-      sc_plane.Normal();
-   }
-}
-BENCHMARK_TEMPLATE(BM_Plane3D_Normal, double)->Range(8, 8 << 10)->Complexity(benchmark::o1);
-;
-BENCHMARK_TEMPLATE(BM_Plane3D_Normal, ROOT::Double_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
-BENCHMARK_TEMPLATE(BM_Plane3D_Normal, ROOT::Float_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
 
 // Define our main.
 BENCHMARK_MAIN();

--- a/math/genvector/perf/Cartesian3DBenchmarks.cxx
+++ b/math/genvector/perf/Cartesian3DBenchmarks.cxx
@@ -27,7 +27,8 @@ BENCHMARK(BM_Cartesian3D_Sanity);
 
 static void BM_Cartesian3D_CreateEmpty(benchmark::State &state)
 {
-   while (state.KeepRunning()) ROOT::Math::Cartesian3D<ROOT::Double_v> c;
+   while (state.KeepRunning())
+      ROOT::Math::Cartesian3D<ROOT::Double_v> c;
 }
 BENCHMARK(BM_Cartesian3D_CreateEmpty);
 

--- a/math/genvector/perf/Cartesian3DBenchmarks.cxx
+++ b/math/genvector/perf/Cartesian3DBenchmarks.cxx
@@ -54,10 +54,10 @@ static void BM_Cartesian3D_Theta(benchmark::State &state)
    }
    ComputeProcessedEntities(state, sizeof(T), VecTraits<T>::Sum(checksum));
 }
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, double)->Range(8 << 0, 8 << 10);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, ROOT::Double_v)->Range(8 << 0, 8 << 10);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, float)->Range(8 << 0, 8 << 10);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, ROOT::Float_v)->Range(8 << 0, 8 << 10);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, double)->Range(8 << 10, 8 << 20);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, ROOT::Double_v)->Range(8 << 10, 8 << 20);
+// BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, float)->Range(8 << 10, 8 << 20);
+// BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, ROOT::Float_v)->Range(8 << 10, 8 << 20);
 
 template <typename T>
 static void BM_Cartesian3D_Phi(benchmark::State &state)
@@ -79,10 +79,10 @@ static void BM_Cartesian3D_Phi(benchmark::State &state)
    }
    ComputeProcessedEntities(state, sizeof(T), VecTraits<T>::Sum(checksum));
 }
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, double)->Range(8 << 0, 8 << 10);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, ROOT::Double_v)->Range(8 << 0, 8 << 10);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, float)->Range(8 << 0, 8 << 10);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, ROOT::Float_v)->Range(8 << 0, 8 << 10);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, double)->Range(8 << 10, 8 << 20);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, ROOT::Double_v)->Range(8 << 10, 8 << 20);
+// BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, float)->Range(8 << 10, 8 << 20);
+// BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, ROOT::Float_v)->Range(8 << 10, 8 << 20);
 
 template <typename T>
 static void BM_Cartesian3D_Mag2(benchmark::State &state)
@@ -105,11 +105,10 @@ static void BM_Cartesian3D_Mag2(benchmark::State &state)
 
    ComputeProcessedEntities(state, sizeof(T), VecTraits<T>::Sum(checksum));
 }
-
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, double)->Range(8 << 0, 8 << 10);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, ROOT::Double_v)->Range(8 << 0, 8 << 10);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, float)->Range(8 << 0, 8 << 10);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, ROOT::Float_v)->Range(8 << 0, 8 << 10);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, double)->Range(8 << 10, 8 << 20);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, ROOT::Double_v)->Range(8 << 10, 8 << 20);
+// BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, float)->Range(8 << 10, 8 << 20);
+// BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, ROOT::Float_v)->Range(8 << 10, 8 << 20);
 
 // Define our main.
 BENCHMARK_MAIN();

--- a/math/genvector/perf/Cartesian3DBenchmarks.cxx
+++ b/math/genvector/perf/Cartesian3DBenchmarks.cxx
@@ -2,6 +2,8 @@
 
 #include "Math/Math_vectypes.hxx"
 
+#include "RandomNumberEngine.h"
+
 #include "benchmark/benchmark.h"
 
 #include <random>
@@ -25,39 +27,78 @@ static void BM_Cartesian3D_CreateEmpty(benchmark::State &state)
 }
 BENCHMARK(BM_Cartesian3D_CreateEmpty);
 
+// template <typename T> class Cartesian3D { T x; T y; T z; /*...*/ };
+// // ROOT::Double_v -> double[2]
+// template <> class Cartesian3D<double[2]> { double[2] x; double[2] y; double[2] z; /*...*/ };
+
+// template <> class Cartesian3D<double[2]> { double[2] x = 1.; double[2] y = 2.; double[2] z = 3.; /*...*/ };
+
+static void ComputeProcessedEntities(benchmark::State &state, size_t VecSize)
+{
+   const size_t items_processed = state.iterations() * state.range(0);
+   state.SetItemsProcessed(items_processed);
+   // FIXME: This is not an accurate byte computation. We need to get the sizeof
+   // the underlying type of T.
+   state.SetBytesProcessed(items_processed * VecSize);
+}
+
 template <typename T>
 static void BM_Cartesian3D_Theta(benchmark::State &state)
 {
-   ROOT::Math::Cartesian3D<T> c(1., 2., 3.);
-   // std::cout << is_aligned(&c, 16) << std::endl;
-   while (state.KeepRunning()) c.Theta();
+   using namespace ROOT::Benchmark;
+   // Allocate N points
+   typename Data<T>::Vector Points(state.range(0));
+   constexpr size_t VecSize = TypeSize<T>::Get();
+   ROOT::Math::Cartesian3D<T> c;
+   while (state.KeepRunning())
+      for (size_t i = 0, e = Points.size(); i < e; i += VecSize) {
+         c.SetCoordinates(Points[i].X, Points[i].Y, Points[i].Z);
+         c.Theta();
+      }
+   ComputeProcessedEntities(state, VecSize);
 }
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, double);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, ROOT::Double_v);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, float);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, ROOT::Float_v);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, double)->Range(1 << 0, 1 << 10);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, ROOT::Double_v)->Range(1 << 0, 1 << 10);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, float)->Range(1 << 0, 1 << 10);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, ROOT::Float_v)->Range(1 << 0, 1 << 10);
 
 template <typename T>
 static void BM_Cartesian3D_Phi(benchmark::State &state)
 {
-   ROOT::Math::Cartesian3D<T> c(1., 2., 3.);
-   // std::cout << is_aligned(&c, 16) << std::endl;
-   while (state.KeepRunning()) c.Phi();
+   using namespace ROOT::Benchmark;
+   // Allocate N points
+   typename Data<T>::Vector Points(state.range(0));
+   constexpr size_t VecSize = TypeSize<T>::Get();
+   ROOT::Math::Cartesian3D<T> c;
+   while (state.KeepRunning())
+      for (size_t i = 0, e = Points.size(); i < e; i += VecSize) {
+         c.SetCoordinates(Points[i].X, Points[i].Y, Points[i].Z);
+         c.Phi();
+      }
+   ComputeProcessedEntities(state, VecSize);
 }
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, double);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, ROOT::Double_v);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, float);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, ROOT::Float_v);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, double)->Range(1 << 0, 1 << 10);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, ROOT::Double_v)->Range(1 << 0, 1 << 10);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, float)->Range(1 << 0, 1 << 10);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, ROOT::Float_v)->Range(1 << 0, 1 << 10);
 
 template <typename T>
 static void BM_Cartesian3D_Mag2(benchmark::State &state)
 {
-   ROOT::Math::Cartesian3D<T> c(1., 2., 3.);
-   // std::cout << is_aligned(&c, 16) << std::endl;
-   while (state.KeepRunning()) c.Mag2();
+   using namespace ROOT::Benchmark;
+   // Allocate N points
+   typename Data<T>::Vector Points(state.range(0));
+   constexpr size_t VecSize = TypeSize<T>::Get();
+   ROOT::Math::Cartesian3D<T> c;
+   while (state.KeepRunning())
+      for (size_t i = 0, e = Points.size(); i < e; i += VecSize) {
+         c.SetCoordinates(Points[i].X, Points[i].Y, Points[i].Z);
+         c.Mag2();
+      }
+   ComputeProcessedEntities(state, VecSize);
 }
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, double);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, ROOT::Double_v);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, double)->Range(1 << 0, 1 << 10);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, ROOT::Double_v)->Range(1 << 0, 1 << 10);
 
 // Define our main.
 BENCHMARK_MAIN();

--- a/math/genvector/perf/Cartesian3DBenchmarks.cxx
+++ b/math/genvector/perf/Cartesian3DBenchmarks.cxx
@@ -33,13 +33,11 @@ BENCHMARK(BM_Cartesian3D_CreateEmpty);
 
 // template <> class Cartesian3D<double[2]> { double[2] x = 1.; double[2] y = 2.; double[2] z = 3.; /*...*/ };
 
-static void ComputeProcessedEntities(benchmark::State &state, size_t VecSize)
+static void ComputeProcessedEntities(benchmark::State &state, size_t Size)
 {
    const size_t items_processed = state.iterations() * state.range(0);
    state.SetItemsProcessed(items_processed);
-   // FIXME: This is not an accurate byte computation. We need to get the sizeof
-   // the underlying type of T.
-   state.SetBytesProcessed(items_processed * VecSize);
+   state.SetBytesProcessed(items_processed * Size);
 }
 
 template <typename T>
@@ -55,7 +53,7 @@ static void BM_Cartesian3D_Theta(benchmark::State &state)
          c.SetCoordinates(Points[i].X, Points[i].Y, Points[i].Z);
          c.Theta();
       }
-   ComputeProcessedEntities(state, VecSize);
+   ComputeProcessedEntities(state, sizeof(T));
 }
 BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, double)->Range(1 << 0, 1 << 10);
 BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, ROOT::Double_v)->Range(1 << 0, 1 << 10);
@@ -75,7 +73,7 @@ static void BM_Cartesian3D_Phi(benchmark::State &state)
          c.SetCoordinates(Points[i].X, Points[i].Y, Points[i].Z);
          c.Phi();
       }
-   ComputeProcessedEntities(state, VecSize);
+   ComputeProcessedEntities(state, sizeof(T));
 }
 BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, double)->Range(1 << 0, 1 << 10);
 BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, ROOT::Double_v)->Range(1 << 0, 1 << 10);
@@ -95,7 +93,7 @@ static void BM_Cartesian3D_Mag2(benchmark::State &state)
          c.SetCoordinates(Points[i].X, Points[i].Y, Points[i].Z);
          c.Mag2();
       }
-   ComputeProcessedEntities(state, VecSize);
+   ComputeProcessedEntities(state, sizeof(T));
 }
 BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, double)->Range(1 << 0, 1 << 10);
 BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, ROOT::Double_v)->Range(1 << 0, 1 << 10);

--- a/math/genvector/perf/Cartesian3DBenchmarks.cxx
+++ b/math/genvector/perf/Cartesian3DBenchmarks.cxx
@@ -23,6 +23,8 @@
 
 #include "benchmark/benchmark.h"
 
+#include <random>
+
 static bool is_aligned(const void *__restrict__ ptr, size_t align)
 {
    return (uintptr_t)ptr % align == 0;

--- a/math/genvector/perf/Cartesian3DBenchmarks.cxx
+++ b/math/genvector/perf/Cartesian3DBenchmarks.cxx
@@ -1,0 +1,23 @@
+#include "Math/Cartesian3D.h"
+
+#include "Math/Math_vectypes.hxx"
+
+#include "benchmark/benchmark.h"
+
+static void BM_Cartesian3D_CreateEmpty(benchmark::State &state)
+{
+   while (state.KeepRunning()) ROOT::Math::Cartesian3D<double> c;
+}
+BENCHMARK(BM_Cartesian3D_CreateEmpty);
+
+template <typename T>
+static void BM_Cartesian3D_Theta(benchmark::State &state)
+{
+   ROOT::Math::Cartesian3D<T> c(1, 2, 3);
+   while (state.KeepRunning()) c.Theta();
+}
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, double)->Range(8, 8 << 10);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, ROOT::Double_v)->Range(8, 8 << 10);
+
+// Define our main.
+BENCHMARK_MAIN();

--- a/math/genvector/perf/Cartesian3DBenchmarks.cxx
+++ b/math/genvector/perf/Cartesian3DBenchmarks.cxx
@@ -1,6 +1,6 @@
 #include "Math/Cartesian3D.h"
 
-#include "Math/Math_vectypes.hxx"
+#include "Math/Types.h"
 
 #include "RandomNumberEngine.h"
 

--- a/math/genvector/perf/Cartesian3DBenchmarks.cxx
+++ b/math/genvector/perf/Cartesian3DBenchmarks.cxx
@@ -6,12 +6,9 @@
 
 #include "benchmark/benchmark.h"
 
-#include <random>
+#include <sstream>
 
-static bool is_aligned(const void *__restrict__ ptr, size_t align)
-{
-   return (uintptr_t)ptr % align == 0;
-}
+// FIXME: Reduce the boilerplate code of each benchmark. Maybe setting up a Benchmark Fixture will help.
 
 static void BM_Cartesian3D_Sanity(benchmark::State &state)
 {
@@ -27,76 +24,92 @@ static void BM_Cartesian3D_CreateEmpty(benchmark::State &state)
 }
 BENCHMARK(BM_Cartesian3D_CreateEmpty);
 
-// template <typename T> class Cartesian3D { T x; T y; T z; /*...*/ };
-// // ROOT::Double_v -> double[2]
-// template <> class Cartesian3D<double[2]> { double[2] x; double[2] y; double[2] z; /*...*/ };
-
-// template <> class Cartesian3D<double[2]> { double[2] x = 1.; double[2] y = 2.; double[2] z = 3.; /*...*/ };
-
-static void ComputeProcessedEntities(benchmark::State &state, size_t Size)
+static void ComputeProcessedEntities(benchmark::State &state, size_t Size, double checksum)
 {
    const size_t items_processed = state.iterations() * state.range(0);
    state.SetItemsProcessed(items_processed);
    state.SetBytesProcessed(items_processed * Size);
+   std::stringstream ss;
+   ss << checksum;
+   state.SetLabel(ss.str());
 }
 
 template <typename T>
 static void BM_Cartesian3D_Theta(benchmark::State &state)
 {
    using namespace ROOT::Benchmark;
+   // We want the same random numbers for a benchmark family.
+   SetSeed(1);
    // Allocate N points
-   typename Data<T>::Vector Points(state.range(0));
    constexpr size_t VecSize = TypeSize<T>::Get();
+   typename Data<T>::Vector Points(state.range(0) / VecSize);
    ROOT::Math::Cartesian3D<T> c;
-   while (state.KeepRunning())
-      for (size_t i = 0, e = Points.size(); i < e; i += VecSize) {
-         c.SetCoordinates(Points[i].X, Points[i].Y, Points[i].Z);
-         c.Theta();
+   T checksum = T();
+   while (state.KeepRunning()) {
+      checksum = T();
+      for (auto &p : Points) {
+         c.SetCoordinates(p.X, p.Y, p.Z);
+         checksum += c.Theta();
       }
-   ComputeProcessedEntities(state, sizeof(T));
+   }
+   ComputeProcessedEntities(state, sizeof(T), VecTraits<T>::Sum(checksum));
 }
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, double)->Range(1 << 0, 1 << 10);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, ROOT::Double_v)->Range(1 << 0, 1 << 10);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, float)->Range(1 << 0, 1 << 10);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, ROOT::Float_v)->Range(1 << 0, 1 << 10);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, double)->Range(8 << 0, 8 << 10);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, ROOT::Double_v)->Range(8 << 0, 8 << 10);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, float)->Range(8 << 0, 8 << 10);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, ROOT::Float_v)->Range(8 << 0, 8 << 10);
 
 template <typename T>
 static void BM_Cartesian3D_Phi(benchmark::State &state)
 {
    using namespace ROOT::Benchmark;
+   // We want the same random numbers for a benchmark family.
+   SetSeed(2);
    // Allocate N points
-   typename Data<T>::Vector Points(state.range(0));
    constexpr size_t VecSize = TypeSize<T>::Get();
+   typename Data<T>::Vector Points(state.range(0) / VecSize);
    ROOT::Math::Cartesian3D<T> c;
-   while (state.KeepRunning())
-      for (size_t i = 0, e = Points.size(); i < e; i += VecSize) {
-         c.SetCoordinates(Points[i].X, Points[i].Y, Points[i].Z);
-         c.Phi();
+   T checksum = T();
+   while (state.KeepRunning()) {
+      checksum = T();
+      for (auto &p : Points) {
+         c.SetCoordinates(p.X, p.Y, p.Z);
+         checksum += c.Phi();
       }
-   ComputeProcessedEntities(state, sizeof(T));
+   }
+   ComputeProcessedEntities(state, sizeof(T), VecTraits<T>::Sum(checksum));
 }
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, double)->Range(1 << 0, 1 << 10);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, ROOT::Double_v)->Range(1 << 0, 1 << 10);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, float)->Range(1 << 0, 1 << 10);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, ROOT::Float_v)->Range(1 << 0, 1 << 10);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, double)->Range(8 << 0, 8 << 10);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, ROOT::Double_v)->Range(8 << 0, 8 << 10);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, float)->Range(8 << 0, 8 << 10);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, ROOT::Float_v)->Range(8 << 0, 8 << 10);
 
 template <typename T>
 static void BM_Cartesian3D_Mag2(benchmark::State &state)
 {
    using namespace ROOT::Benchmark;
+   // We want the same random numbers for a benchmark family.
+   SetSeed(3);
    // Allocate N points
-   typename Data<T>::Vector Points(state.range(0));
    constexpr size_t VecSize = TypeSize<T>::Get();
+   typename Data<T>::Vector Points(state.range(0) / VecSize);
    ROOT::Math::Cartesian3D<T> c;
-   while (state.KeepRunning())
-      for (size_t i = 0, e = Points.size(); i < e; i += VecSize) {
-         c.SetCoordinates(Points[i].X, Points[i].Y, Points[i].Z);
-         c.Mag2();
+   T checksum = T();
+   while (state.KeepRunning()) {
+      checksum = T();
+      for (auto &p : Points) {
+         c.SetCoordinates(p.X, p.Y, p.Z);
+         checksum += c.Mag2();
       }
-   ComputeProcessedEntities(state, sizeof(T));
+   }
+
+   ComputeProcessedEntities(state, sizeof(T), VecTraits<T>::Sum(checksum));
 }
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, double)->Range(1 << 0, 1 << 10);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, ROOT::Double_v)->Range(1 << 0, 1 << 10);
+
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, double)->Range(8 << 0, 8 << 10);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, ROOT::Double_v)->Range(8 << 0, 8 << 10);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, float)->Range(8 << 0, 8 << 10);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, ROOT::Float_v)->Range(8 << 0, 8 << 10);
 
 // Define our main.
 BENCHMARK_MAIN();

--- a/math/genvector/perf/Cartesian3DBenchmarks.cxx
+++ b/math/genvector/perf/Cartesian3DBenchmarks.cxx
@@ -23,6 +23,7 @@ static void BM_Cartesian3D_Theta(benchmark::State &state)
    ROOT::Math::Cartesian3D<T> c(1., 2., 3.);
    // std::cout << is_aligned(&c, 16) << std::endl;
    while (state.KeepRunning()) c.Theta();
+   state.SetComplexityN(state.range(0));
 }
 BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, double)->Range(8, 8 << 10)->Complexity(benchmark::o1);
 BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, ROOT::Double_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);

--- a/math/genvector/perf/Cartesian3DBenchmarks.cxx
+++ b/math/genvector/perf/Cartesian3DBenchmarks.cxx
@@ -1,23 +1,164 @@
 #include "Math/Cartesian3D.h"
+#include "Math/Point3D.h"
+#include "Math/Vector3D.h"
+#include "Math/Vector4D.h"
+#include "Math/GenVector/Rotation3D.h"
+#include "Math/GenVector/EulerAngles.h"
+#include "Math/GenVector/AxisAngle.h"
+#include "Math/GenVector/Quaternion.h"
+#include "Math/GenVector/RotationX.h"
+#include "Math/GenVector/RotationY.h"
+#include "Math/GenVector/RotationZ.h"
+#include "Math/GenVector/RotationZYX.h"
+#include "Math/GenVector/LorentzRotation.h"
+#include "Math/GenVector/Boost.h"
+#include "Math/GenVector/BoostX.h"
+#include "Math/GenVector/BoostY.h"
+#include "Math/GenVector/BoostZ.h"
+#include "Math/GenVector/Transform3D.h"
+#include "Math/GenVector/Plane3D.h"
+#include "Math/GenVector/VectorUtil.h"
 
 #include "Math/Math_vectypes.hxx"
 
 #include "benchmark/benchmark.h"
 
+static bool is_aligned(const void *__restrict__ ptr, size_t align)
+{
+   return (uintptr_t)ptr % align == 0;
+}
+
+template <typename T>
+using Point = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<T>, ROOT::Math::DefaultCoordinateSystemTag>;
+template <typename T>
+using Vector = ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<T>, ROOT::Math::DefaultCoordinateSystemTag>;
+template <typename T>
+using Plane = ROOT::Math::Impl::Plane3D<T>;
+
+static std::default_random_engine ggen;
+
+static std::uniform_real_distribution<double> p_x(1, 2), p_y(2, 3), p_z(3, 4);
+static std::uniform_real_distribution<double> d_x(1, 2), d_y(2, 3), d_z(3, 4);
+static std::uniform_real_distribution<double> c_x(1, 2), c_y(2, 3), c_z(3, 4);
+static std::uniform_real_distribution<double> p0(-0.002, 0.002), p1(-0.2, 0.2), p2(0.97, 0.99), p3(-1300, 1300);
+
 static void BM_Cartesian3D_CreateEmpty(benchmark::State &state)
 {
-   while (state.KeepRunning()) ROOT::Math::Cartesian3D<double> c;
+   while (state.KeepRunning()) ROOT::Math::Cartesian3D<ROOT::Double_v> c;
 }
 BENCHMARK(BM_Cartesian3D_CreateEmpty);
 
 template <typename T>
 static void BM_Cartesian3D_Theta(benchmark::State &state)
 {
-   ROOT::Math::Cartesian3D<T> c(1, 2, 3);
+   ROOT::Math::Cartesian3D<T> c(1., 2., 3.);
+   // std::cout << is_aligned(&c, 16) << std::endl;
    while (state.KeepRunning()) c.Theta();
 }
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, double)->Range(8, 8 << 10);
-BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, ROOT::Double_v)->Range(8, 8 << 10);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, double)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, ROOT::Double_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, float)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Theta, ROOT::Float_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+
+template <typename T>
+static void BM_Cartesian3D_Phi(benchmark::State &state)
+{
+   ROOT::Math::Cartesian3D<T> c(1., 2., 3.);
+   // std::cout << is_aligned(&c, 16) << std::endl;
+   while (state.KeepRunning()) c.Phi();
+   state.SetComplexityN(state.range(0));
+}
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, double)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, ROOT::Double_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, float)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Phi, ROOT::Float_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+
+template <typename T>
+static void BM_Cartesian3D_Mag2(benchmark::State &state)
+{
+
+   ROOT::Math::Cartesian3D<T> c(1., 2., 3.);
+   // std::cout << is_aligned(&c, 16) << std::endl;
+   while (state.KeepRunning()) c.Mag2();
+}
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, double)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+BENCHMARK_TEMPLATE(BM_Cartesian3D_Mag2, ROOT::Double_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+
+template <typename T>
+static void BM_Point3D(benchmark::State &state)
+{
+   while (state.KeepRunning()) Point<T> sp1, sp2, sp3, sp4, sp5, sp6;
+}
+
+BENCHMARK_TEMPLATE(BM_Point3D, double)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+BENCHMARK_TEMPLATE(BM_Point3D, ROOT::Double_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+
+template <typename T>
+static void BM_Point3D_Gen(benchmark::State &state)
+{
+   while (state.KeepRunning()) {
+      Point<T> sp1(p_x(ggen), p_y(ggen), p_z(ggen));
+   }
+}
+BENCHMARK_TEMPLATE(BM_Point3D_Gen, double)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+BENCHMARK_TEMPLATE(BM_Point3D_Gen, ROOT::Double_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+
+template <typename T>
+static void BM_Transform3D(benchmark::State &state)
+{
+   Point<T> sp1(p_x(ggen), p_y(ggen), p_z(ggen));
+   Point<T> sp2(p_x(ggen), p_y(ggen), p_z(ggen));
+   Point<T> sp3(p_x(ggen), p_y(ggen), p_z(ggen));
+   Point<T> sp4(p_x(ggen), p_y(ggen), p_z(ggen));
+   Point<T> sp5(p_x(ggen), p_y(ggen), p_z(ggen));
+   Point<T> sp6(p_x(ggen), p_y(ggen), p_z(ggen));
+   while (state.KeepRunning()) {
+      ROOT::Math::Impl::Transform3D<T> st(sp1, sp2, sp3, sp4, sp5, sp6);
+      st.Translation();
+   }
+}
+// BENCHMARK_TEMPLATE(BM_Transform3D, double)->Range(8, 8<<10)->Complexity(benchmark::o1);
+// BENCHMARK_TEMPLATE(BM_Transform3D, float)->Range(8, 8<<10)->Complexity(benchmark::o1);
+// BENCHMARK_TEMPLATE(BM_Transform3D, ROOT::Double_v)->Range(8, 8<<10)->Complexity(benchmark::o1);
+// BENCHMARK_TEMPLATE(BM_Transform3D, ROOT::Float_v)->Range(8, 8<<10)->Complexity(benchmark::o1);
+
+template <typename T>
+static void BM_Plane3D(benchmark::State &state)
+{
+   const double a(p0(ggen)), b(p1(ggen)), c(p2(ggen)), d(p3(ggen));
+   while (state.KeepRunning()) {
+      Plane<T> sc_plane(a, b, c, d);
+   }
+}
+BENCHMARK_TEMPLATE(BM_Plane3D, double)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+BENCHMARK_TEMPLATE(BM_Plane3D, ROOT::Double_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+BENCHMARK_TEMPLATE(BM_Plane3D, ROOT::Float_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+
+template <typename T>
+static void BM_Plane3D_Hessian(benchmark::State &state)
+{
+   const double a(p0(ggen)), b(p1(ggen)), c(p2(ggen)), d(p3(ggen));
+   while (state.KeepRunning()) {
+      Plane<T> sc_plane(a, b, c, d);
+      sc_plane.HesseDistance();
+   }
+}
+BENCHMARK_TEMPLATE(BM_Plane3D_Hessian, double)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+BENCHMARK_TEMPLATE(BM_Plane3D_Hessian, ROOT::Double_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+
+template <typename T>
+static void BM_Plane3D_Normal(benchmark::State &state)
+{
+   const double a(p0(ggen)), b(p1(ggen)), c(p2(ggen)), d(p3(ggen));
+   while (state.KeepRunning()) {
+      Plane<T> sc_plane(a, b, c, d);
+      sc_plane.Normal();
+   }
+}
+BENCHMARK_TEMPLATE(BM_Plane3D_Normal, double)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+;
+BENCHMARK_TEMPLATE(BM_Plane3D_Normal, ROOT::Double_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+BENCHMARK_TEMPLATE(BM_Plane3D_Normal, ROOT::Float_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
 
 // Define our main.
 BENCHMARK_MAIN();

--- a/math/genvector/perf/RandomNumberEngine.h
+++ b/math/genvector/perf/RandomNumberEngine.h
@@ -1,15 +1,47 @@
 
 #include <random>
+#include <type_traits>
+
+namespace fallbacks {
+template <typename T>
+using Allocator = std::allocator<T>;
+}
+namespace Vc_1 {
+// Tell ADL to resolve missing Vc entities from fallbacks namespace.
+using namespace fallbacks;
+} // namespace Vc_1
+namespace Vc = Vc_1;
 
 namespace ROOT {
 namespace Benchmark {
-static std::default_random_engine ggen;
+static std::mt19937 ggen(0);
 
 // FIXME: Those should be taking T, so that we could test against floats.
 static std::uniform_real_distribution<double> p_x(1, 2), p_y(2, 3), p_z(3, 4);
 static std::uniform_real_distribution<double> d_x(1, 2), d_y(2, 3), d_z(3, 4);
 static std::uniform_real_distribution<double> c_x(1, 2), c_y(2, 3), c_z(3, 4);
 static std::uniform_real_distribution<double> p0(-0.002, 0.002), p1(-0.2, 0.2), p2(0.97, 0.99), p3(-1300, 1300);
+
+// Make this a weak symbol in order to keep it in the header.
+// FIXME: Move in a source file if we have more utility functions like this.
+inline void SetSeed(int N)
+{
+   ggen.seed(N);
+   // We do not want our distributions to depend on previous state.
+   p_x.reset();
+   p_y.reset();
+   p_z.reset();
+   d_x.reset();
+   d_y.reset();
+   d_z.reset();
+   c_x.reset();
+   c_y.reset();
+   c_z.reset();
+   p0.reset();
+   p1.reset();
+   p2.reset();
+   p3.reset();
+}
 
 template <typename T>
 class TypeSize {
@@ -30,6 +62,20 @@ public:
    static constexpr size_t Get() { return Get<T>(0); }
 };
 
+template <typename T>
+struct VecTraits {
+   // FIXME: Deduce the underlying vector type instead of hardcoding it to double.
+   static constexpr double Sum(double value) { return value; }
+   template <typename C = T, typename = typename std::enable_if<!std::is_arithmetic<C>::value>::type>
+   static double Sum(C value)
+   {
+      double sum = 0.;
+      for (size_t i = 0, e = TypeSize<T>::Get(); i < e; ++i) sum += value[i];
+      return sum;
+   }
+   bool is_aligned(const void *__restrict__ ptr, size_t align) { return (uintptr_t)ptr % align == 0; }
+};
+
 // FIXME: Generalize this to accomodate N elements, this way we could use it as *the* data token for benchmarking.
 template <typename T>
 struct Data {
@@ -38,16 +84,20 @@ struct Data {
    T Z;
    typedef std::vector<Data, Vc::Allocator<Data>> Vector;
    // Fill with random data.
-   Data() : X(p_x(ggen)), Y(p_y(ggen)), Z(p_z(ggen)) {}
+   template <typename U = T>
+   Data(typename std::enable_if<std::is_arithmetic<U>::value>::type * = 0) : X(p_x(ggen)), Y(p_y(ggen)), Z(p_z(ggen))
+   {
+   }
+   // FIXME: We cannot use std::is_array but we could check if there is subscript operator
+   template <typename U = T>
+   Data(typename std::enable_if<!std::is_arithmetic<U>::value>::type * = 0)
+   {
+      for (size_t i = 0, e = TypeSize<T>::Get(); i < e; ++i) {
+         X[i] = p_x(ggen);
+         Y[i] = p_y(ggen);
+         Z[i] = p_z(ggen);
+      }
+   }
 };
-// template <typename INDATA, typename OUTDATA>
-// void clone(const INDATA &in, OUTDATA &out)
-// {
-//    out.clear();
-//    out.reserve(in.size());
-//    for (const auto &i : in) {
-//       out.emplace_back(i);
-//    }
-// }
 } // namespace Benchmark
 } // namespace ROOT

--- a/math/genvector/perf/RandomNumberEngine.h
+++ b/math/genvector/perf/RandomNumberEngine.h
@@ -1,0 +1,9 @@
+
+#include <random>
+
+static std::default_random_engine ggen;
+
+static std::uniform_real_distribution<double> p_x(1, 2), p_y(2, 3), p_z(3, 4);
+static std::uniform_real_distribution<double> d_x(1, 2), d_y(2, 3), d_z(3, 4);
+static std::uniform_real_distribution<double> c_x(1, 2), c_y(2, 3), c_z(3, 4);
+static std::uniform_real_distribution<double> p0(-0.002, 0.002), p1(-0.2, 0.2), p2(0.97, 0.99), p3(-1300, 1300);

--- a/math/genvector/perf/RandomNumberEngine.h
+++ b/math/genvector/perf/RandomNumberEngine.h
@@ -70,7 +70,8 @@ struct VecTraits {
    static double Sum(C value)
    {
       double sum = 0.;
-      for (size_t i = 0, e = TypeSize<T>::Get(); i < e; ++i) sum += value[i];
+      for (size_t i = 0, e = TypeSize<T>::Get(); i < e; ++i)
+         sum += value[i];
       return sum;
    }
    bool is_aligned(const void *__restrict__ ptr, size_t align) { return (uintptr_t)ptr % align == 0; }

--- a/math/genvector/perf/RandomNumberEngine.h
+++ b/math/genvector/perf/RandomNumberEngine.h
@@ -1,9 +1,53 @@
 
 #include <random>
 
+namespace ROOT {
+namespace Benchmark {
 static std::default_random_engine ggen;
 
+// FIXME: Those should be taking T, so that we could test against floats.
 static std::uniform_real_distribution<double> p_x(1, 2), p_y(2, 3), p_z(3, 4);
 static std::uniform_real_distribution<double> d_x(1, 2), d_y(2, 3), d_z(3, 4);
 static std::uniform_real_distribution<double> c_x(1, 2), c_y(2, 3), c_z(3, 4);
 static std::uniform_real_distribution<double> p0(-0.002, 0.002), p1(-0.2, 0.2), p2(0.97, 0.99), p3(-1300, 1300);
+
+template <typename T>
+class TypeSize {
+   template <typename C>
+   static constexpr size_t Get(decltype(&C::Size))
+   {
+      return C::Size;
+   }
+   template <typename C>
+   static constexpr size_t Get(typename std::enable_if<std::is_arithmetic<C>::value>::type * = 0)
+   {
+      return 1;
+   }
+   // static constexpr size_t Get(...) { return sizeof(C); }
+   // template <typename C>
+   // static constexpr size_t Get(...) { static_assert (0, "Works on vector and arithmetic types!"); return -1; }
+public:
+   static constexpr size_t Get() { return Get<T>(0); }
+};
+
+// FIXME: Generalize this to accomodate N elements, this way we could use it as *the* data token for benchmarking.
+template <typename T>
+struct Data {
+   T X;
+   T Y;
+   T Z;
+   typedef std::vector<Data, Vc::Allocator<Data>> Vector;
+   // Fill with random data.
+   Data() : X(p_x(ggen)), Y(p_y(ggen)), Z(p_z(ggen)) {}
+};
+// template <typename INDATA, typename OUTDATA>
+// void clone(const INDATA &in, OUTDATA &out)
+// {
+//    out.clear();
+//    out.reserve(in.size());
+//    for (const auto &i : in) {
+//       out.emplace_back(i);
+//    }
+// }
+} // namespace Benchmark
+} // namespace ROOT

--- a/math/genvector/perf/Transform3DBenchmarks.cxx
+++ b/math/genvector/perf/Transform3DBenchmarks.cxx
@@ -1,6 +1,6 @@
 #include "Math/GenVector/Transform3D.h"
 
-#include "Math/Math_vectypes.hxx"
+#include "Math/Types.h"
 
 #include "RandomNumberEngine.h"
 

--- a/math/genvector/perf/Transform3DBenchmarks.cxx
+++ b/math/genvector/perf/Transform3DBenchmarks.cxx
@@ -38,7 +38,8 @@ using Point = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<T>, ROOT::Mat
 template <typename T>
 static void BM_Point3D(benchmark::State &state)
 {
-   while (state.KeepRunning()) Point<T> sp1, sp2, sp3, sp4, sp5, sp6;
+   while (state.KeepRunning())
+      Point<T> sp1, sp2, sp3, sp4, sp5, sp6;
 }
 
 BENCHMARK_TEMPLATE(BM_Point3D, double)->Range(8, 8 << 10)->Complexity(benchmark::o1);

--- a/math/genvector/perf/Transform3DBenchmarks.cxx
+++ b/math/genvector/perf/Transform3DBenchmarks.cxx
@@ -1,0 +1,93 @@
+#include "Math/GenVector/Transform3D.h"
+
+#include "Math/Math_vectypes.hxx"
+
+#include "RandomNumberEngine.h"
+
+#include "benchmark/benchmark.h"
+
+template <typename T>
+using Point = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<T>, ROOT::Math::DefaultCoordinateSystemTag>;
+template <typename T>
+using Vector = ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<T>, ROOT::Math::DefaultCoordinateSystemTag>;
+template <typename T>
+using Plane = ROOT::Math::Impl::Plane3D<T>;
+
+Point<T> sp1(p_x(ggen), p_y(ggen), p_z(ggen));
+Point<T> sp2(p_x(ggen), p_y(ggen), p_z(ggen));
+Point<T> sp3(p_x(ggen), p_y(ggen), p_z(ggen));
+Point<T> sp4(p_x(ggen), p_y(ggen), p_z(ggen));
+Point<T> sp5(p_x(ggen), p_y(ggen), p_z(ggen));
+Point<T> sp6(p_x(ggen), p_y(ggen), p_z(ggen));
+
+template <typename T>
+static void BM_Transform3D(benchmark::State &state)
+{
+   while (state.KeepRunning()) {
+      ROOT::Math::Impl::Transform3D<T> st(sp1, sp2, sp3, sp4, sp5, sp6);
+      st.Translation();
+   }
+}
+// BENCHMARK_TEMPLATE(BM_Transform3D, double)->Range(8, 8<<10)->Complexity(benchmark::o1);
+// BENCHMARK_TEMPLATE(BM_Transform3D, float)->Range(8, 8<<10)->Complexity(benchmark::o1);
+// BENCHMARK_TEMPLATE(BM_Transform3D, ROOT::Double_v)->Range(8, 8<<10)->Complexity(benchmark::o1);
+// BENCHMARK_TEMPLATE(BM_Transform3D, ROOT::Float_v)->Range(8, 8<<10)->Complexity(benchmark::o1);
+
+template <typename T>
+using Point = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<T>, ROOT::Math::DefaultCoordinateSystemTag>;
+template <typename T>
+static void BM_Point3D(benchmark::State &state)
+{
+   while (state.KeepRunning()) Point<T> sp1, sp2, sp3, sp4, sp5, sp6;
+}
+
+BENCHMARK_TEMPLATE(BM_Point3D, double)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+BENCHMARK_TEMPLATE(BM_Point3D, ROOT::Double_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+
+template <typename T>
+static void BM_Point3D_Gen(benchmark::State &state)
+{
+   while (state.KeepRunning()) {
+      Point<T> sp1(p_x(ggen), p_y(ggen), p_z(ggen));
+   }
+}
+BENCHMARK_TEMPLATE(BM_Point3D_Gen, double)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+BENCHMARK_TEMPLATE(BM_Point3D_Gen, ROOT::Double_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+
+template <typename T>
+static void BM_Plane3D(benchmark::State &state)
+{
+   const double a(p0(ggen)), b(p1(ggen)), c(p2(ggen)), d(p3(ggen));
+   while (state.KeepRunning()) {
+      Plane<T> sc_plane(a, b, c, d);
+   }
+}
+BENCHMARK_TEMPLATE(BM_Plane3D, double)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+BENCHMARK_TEMPLATE(BM_Plane3D, ROOT::Double_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+BENCHMARK_TEMPLATE(BM_Plane3D, ROOT::Float_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+
+template <typename T>
+static void BM_Plane3D_Hessian(benchmark::State &state)
+{
+   const double a(p0(ggen)), b(p1(ggen)), c(p2(ggen)), d(p3(ggen));
+   while (state.KeepRunning()) {
+      Plane<T> sc_plane(a, b, c, d);
+      sc_plane.HesseDistance();
+   }
+}
+BENCHMARK_TEMPLATE(BM_Plane3D_Hessian, double)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+BENCHMARK_TEMPLATE(BM_Plane3D_Hessian, ROOT::Double_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+
+template <typename T>
+static void BM_Plane3D_Normal(benchmark::State &state)
+{
+   const double a(p0(ggen)), b(p1(ggen)), c(p2(ggen)), d(p3(ggen));
+   while (state.KeepRunning()) {
+      Plane<T> sc_plane(a, b, c, d);
+      sc_plane.Normal();
+   }
+}
+BENCHMARK_TEMPLATE(BM_Plane3D_Normal, double)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+;
+BENCHMARK_TEMPLATE(BM_Plane3D_Normal, ROOT::Double_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+BENCHMARK_TEMPLATE(BM_Plane3D_Normal, ROOT::Float_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);

--- a/math/genvector/perf/Transform3DBenchmarks.cxx
+++ b/math/genvector/perf/Transform3DBenchmarks.cxx
@@ -28,10 +28,10 @@ static void BM_Transform3D(benchmark::State &state)
       st.Translation();
    }
 }
-// BENCHMARK_TEMPLATE(BM_Transform3D, double)->Range(8, 8<<10)->Complexity(benchmark::o1);
-// BENCHMARK_TEMPLATE(BM_Transform3D, float)->Range(8, 8<<10)->Complexity(benchmark::o1);
-// BENCHMARK_TEMPLATE(BM_Transform3D, ROOT::Double_v)->Range(8, 8<<10)->Complexity(benchmark::o1);
-// BENCHMARK_TEMPLATE(BM_Transform3D, ROOT::Float_v)->Range(8, 8<<10)->Complexity(benchmark::o1);
+BENCHMARK_TEMPLATE(BM_Transform3D, double)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+BENCHMARK_TEMPLATE(BM_Transform3D, float)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+BENCHMARK_TEMPLATE(BM_Transform3D, ROOT::Double_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
+BENCHMARK_TEMPLATE(BM_Transform3D, ROOT::Float_v)->Range(8, 8 << 10)->Complexity(benchmark::o1);
 
 template <typename T>
 using Point = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<T>, ROOT::Math::DefaultCoordinateSystemTag>;


### PR DESCRIPTION
This enables us to write performance benchmarks for specific ROOT functional points. Some of the advantages:
  * We can split performance tests from unit tests;
  * We can configure the benchmarks in a uniform way, specifying classes of benchmarks along with their running parameters (such as iterations);
  * We can calculate asymptotic complexity (Big O) of the benchmarked items;
  * Multithreading is a first class citizen;
  * We can fine tune optimization levels (preventing some code to be optimized away);
  * Rich reporting options;
  * Possibility for calculating statistical performance deviations;
  * More can be found [here](https://github.com/google/benchmark).

This would enable finer grained benchmarking of vectorized code.