### PR TITLE
http: improve formatting in THttpServer.cxx

### DIFF
--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <fstream>
 
+////////////////////////////////////////////////////////////////////////////////
+
 //////////////////////////////////////////////////////////////////////////
 //                                                                      //
 // THttpTimer                                                           //
@@ -42,8 +44,6 @@
 // Provides regular call of THttpServer::ProcessRequests() method       //
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
-
-////////////////////////////////////////////////////////////////////////////////
 
 class THttpTimer : public TTimer {
 public:
@@ -67,6 +67,15 @@ public:
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// TLongPollEngine                                                      //
+//                                                                      //
+// Emulation of websocket with long poll requests                       //
+// Allows to send data from server to client without explicit request   //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
 
 class TLongPollEngine : public THttpWSEngine {
 protected:
@@ -150,6 +159,8 @@ public:
 
 // =======================================================
 
+ClassImp(THttpServer)
+
 //////////////////////////////////////////////////////////////////////////
 //                                                                      //
 // THttpServer                                                          //
@@ -187,32 +198,31 @@ public:
 // enable monitoring flag in the browser - than objects view            //
 // will be regularly updated.                                           //
 //                                                                      //
-// More information: http://root.cern.ch/drupal/content/users-guide     //
+// More information: https://root.cern/root/htmldoc/guides/HttpServer/HttpServer.html  //
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-ClassImp(THttpServer);
 
-   ////////////////////////////////////////////////////////////////////////////////
-   /// constructor
-   ///
-   /// As argument, one specifies engine kind which should be
-   /// created like "http:8080". One could specify several engines
-   /// at once, separating them with ; like "http:8080;fastcgi:9000"
-   /// One also can configure readonly flag for sniffer like
-   /// "http:8080;readonly" or "http:8080;readwrite"
-   /// CORS (cross-origine resource sharing) for response of ProcessRequest() 
-   /// can be set in the options like "http:8088s?cors" for all origins ("*") 
-   /// or like "http:8088s?cors=domain" for a specific domain.
-   ///
-   /// Also searches for JavaScript ROOT sources, which are used in web clients
-   /// Typically JSROOT sources located in $ROOTSYS/etc/http directory,
-   /// but one could set JSROOTSYS variable to specify alternative location
+////////////////////////////////////////////////////////////////////////////////
+/// constructor
+///
+/// As argument, one specifies engine kind which should be
+/// created like "http:8080". One could specify several engines
+/// at once, separating them with ; like "http:8080;fastcgi:9000"
+/// One also can configure readonly flag for sniffer like
+/// "http:8080;readonly" or "http:8080;readwrite"
+/// CORS (cross-origine resource sharing) for response of ProcessRequest()
+/// can be set in the options like "http:8088s?cors" for all origins ("*")
+/// or like "http:8088s?cors=domain" for a specific domain.
+///
+/// Also searches for JavaScript ROOT sources, which are used in web clients
+/// Typically JSROOT sources located in $ROOTSYS/etc/http directory,
+/// but one could set JSROOTSYS shell variable to specify alternative location
 
-   THttpServer::THttpServer(const char *engine)
-   : TNamed("http", "ROOT http server"), fEngines(), fTimer(0), fSniffer(0), fMainThrdId(0), fJSROOTSYS(),
-     fTopName("ROOT"), fJSROOT(), fLocations(), fDefaultPage(), fDefaultPageCont(), fDrawPage(), fDrawPageCont(),
-     fCallArgs()
+THttpServer::THttpServer(const char *engine) : TNamed("http", "ROOT http server"),
+   fEngines(), fTimer(0), fSniffer(0), fMainThrdId(0), fJSROOTSYS(),
+   fTopName("ROOT"), fJSROOT(), fLocations(), fDefaultPage(), fDefaultPageCont(),
+   fDrawPage(), fDrawPageCont(), fCallArgs()
 {
    fLocations.SetOwner(kTRUE);
 
@@ -272,7 +282,7 @@ ClassImp(THttpServer);
    // CORS
    if (TString(engine).Index("cors") != kNPOS) {
       TString engine_s = TString(engine);
-      if(engine_s.Index("cors=") == kNPOS ) {
+      if (engine_s.Index("cors=") == kNPOS) {
          SetCors("*");
       } else {
          SetCors(TString(engine_s("[^&]*", engine_s.Index("cors=") + 5)));
@@ -859,7 +869,7 @@ void THttpServer::ProcessRequest(THttpCallArg *arg)
    arg->AddHeader("Cache-Control",
                   "private, no-cache, no-store, must-revalidate, max-age=0, proxy-revalidate, s-maxage=0");
 
-    // potentially add cors header
+   // potentially add cors header
    if (IsCors()) arg->AddHeader("Access-Control-Allow-Origin", GetCors());
 
 }


### PR DESCRIPTION
Improves formatting after #639 

Please ignore complains from travis-ci - it make wrong formatting after ClassImp(THttpServer) 
