### PR TITLE
TH1 KolmogorovTest infinite loop

### DIFF
--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -3362,8 +3362,9 @@ void TH1::FillRandom(TH1 *h, Int_t ntimes)
    if (fDimension != h->GetDimension()) {
       Error("FillRandom", "Histograms with different dimensions"); return;
    }
-   if (std::isnan( h->ComputeIntegral(true) )) {
-      Error("FillRandom", "Histograms contains negative bins, does not represent probabilities"); return;
+   if (std::isnan(h->ComputeIntegral(true))) {
+      Error("FillRandom", "Histograms contains negative bins, does not represent probabilities");
+      return;
    }
 
    //in case the target histogram has the same binning and ntimes much greater
@@ -7485,13 +7486,14 @@ Double_t TH1::KolmogorovTest(const TH1 *h2, Option_t *option) const
    const Int_t nEXPT = 1000;
    if (opt.Contains("X") && !(afunc1 || afunc2 ) ) {
       Double_t dSEXPT;
-      TH1 *h1_cpy = (TH1*)(gDirectory ? gDirectory->CloneObject(this,kFALSE) : gROOT->CloneObject(this,kFALSE));
+      TH1 *h1_cpy = (TH1 *)(gDirectory ? gDirectory->CloneObject(this, kFALSE) : gROOT->CloneObject(this, kFALSE));
       TH1 *hExpt = (TH1*)(gDirectory ? gDirectory->CloneObject(this,kFALSE) : gROOT->CloneObject(this,kFALSE));
 
       if (h1_cpy->GetMinimum() < 0.0) {
-        // With negative bins we can't draw random samples in a meaningful way.
-         Warning("KolmogorovTest", "Detected bins with negative weights, these have been ignored and output might be skewed. Reduce number of bins for histogram?");
-         while(h1_cpy->GetMinimum() < 0.0) {
+         // With negative bins we can't draw random samples in a meaningful way.
+         Warning("KolmogorovTest", "Detected bins with negative weights, these have been ignored and output might be "
+                                   "skewed. Reduce number of bins for histogram?");
+         while (h1_cpy->GetMinimum() < 0.0) {
             Int_t idx = h1_cpy->GetMinimumBin();
             h1_cpy->SetBinContent(idx, 0.0);
          }
@@ -7501,7 +7503,7 @@ Double_t TH1::KolmogorovTest(const TH1 *h2, Option_t *option) const
       prb3 = 0;
       for (Int_t i=0; i < nEXPT; i++) {
          hExpt->Reset();
-         hExpt->FillRandom(h1_cpy,(Int_t)esum2);
+         hExpt->FillRandom(h1_cpy, (Int_t)esum2);
          dSEXPT = KolmogorovTest(hExpt,"M");
          if (dSEXPT>dfmax) prb3 += 1.0;
       }

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -3362,6 +3362,9 @@ void TH1::FillRandom(TH1 *h, Int_t ntimes)
    if (fDimension != h->GetDimension()) {
       Error("FillRandom", "Histograms with different dimensions"); return;
    }
+   if (std::isnan( h->ComputeIntegral(true) )) {
+      Error("FillRandom", "Histograms contains negative bins, does not represent probabilities"); return;
+   }
 
    //in case the target histogram has the same binning and ntimes much greater
    //than the number of bins we can use a fast method

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -7482,16 +7482,28 @@ Double_t TH1::KolmogorovTest(const TH1 *h2, Option_t *option) const
    const Int_t nEXPT = 1000;
    if (opt.Contains("X") && !(afunc1 || afunc2 ) ) {
       Double_t dSEXPT;
+      TH1 *h1_cpy = (TH1*)(gDirectory ? gDirectory->CloneObject(this,kFALSE) : gROOT->CloneObject(this,kFALSE));
       TH1 *hExpt = (TH1*)(gDirectory ? gDirectory->CloneObject(this,kFALSE) : gROOT->CloneObject(this,kFALSE));
+
+      if (h1_cpy->GetMinimum() < 0.0) {
+        // With negative bins we can't draw random samples in a meaningful way.
+         Warning("KolmogorovTest", "Detected bins with negative weights, these have been ignored and output might be skewed. Reduce number of bins for histogram?");
+         while(h1_cpy->GetMinimum() < 0.0) {
+            Int_t idx = h1_cpy->GetMinimumBin();
+            h1_cpy->SetBinContent(idx, 0.0);
+         }
+      }
+
       // make nEXPT experiments (this should be a parameter)
       prb3 = 0;
       for (Int_t i=0; i < nEXPT; i++) {
          hExpt->Reset();
-         hExpt->FillRandom(h1,(Int_t)esum2);
+         hExpt->FillRandom(h1_cpy,(Int_t)esum2);
          dSEXPT = KolmogorovTest(hExpt,"M");
          if (dSEXPT>dfmax) prb3 += 1.0;
       }
       prb3 /= (Double_t)nEXPT;
+      delete h1_cpy;
       delete hExpt;
    }
 


### PR DESCRIPTION
[EDIT]: 2017-07-20 dropped commit (6953483).

See the commit messages for detailed descriptions of the changes. In essence, when comparing some data with the KolmogorovTest an infinite loop was triggered.

(bba95dd) We want to get an approximate solution to the test despite there being some bins with neg. content
(06024c8) To prevent the infinite loop in other cases, calling FillRandom with a histogram with negative content is now an error.
(6953483) The caching inside GetRandom can violate an invariant of the function. (Always return NaN when there is a bin with neg. content in the source histogram). [EDIT] Removed after discussion with Lorenzo. The recomputation of the integral here was deemed too expensive as the function is intended to be called in tight loops.

Since these changes might have far reaching effects I am up for discussion whether any commits should be dropped.

A reproducer in can be found [here](https://gist.github.com/ashlaban/05552ab5f5a7aa05e9c9b73229b2dba4).