### PR TITLE
ROOT I/O performance related updates

### DIFF
--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -249,7 +249,6 @@ private:
              ClassInfo_t *classInfo,
              Bool_t silent);
    void ForceReload (TClass* oldcl);
-   void LoadClassInfo() const;
 
    static TClass     *LoadClassDefault(const char *requestedname, Bool_t silent);
    static TClass     *LoadClassCustom(const char *requestedname, Bool_t silent);
@@ -308,6 +307,8 @@ private:
 private:
    TClass(const TClass& tc) = delete;
    TClass& operator=(const TClass&) = delete;
+
+   void LoadClassInfo() const;
 
 protected:
    TVirtualStreamerInfo     *FindStreamerInfo(TObjArray* arr, UInt_t checksum) const;

--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -12,7 +12,6 @@
 #ifndef ROOT_TClass
 #define ROOT_TClass
 
-
 //////////////////////////////////////////////////////////////////////////
 //                                                                      //
 // TClass                                                               //
@@ -34,6 +33,7 @@
 
 #include <atomic>
 #include "ThreadLocalStorage.h"
+
 class TBaseClass;
 class TBrowser;
 class TDataMember;
@@ -65,6 +65,7 @@ namespace ROOT {
       class TCollectionProxyInfo;
    }
 }
+
 typedef ROOT::TMapTypeToTClass IdMap_t;
 typedef ROOT::TMapDeclIdToTClass DeclIdMap_t;
 
@@ -86,7 +87,8 @@ public:
           kStartWithTObject = BIT(20),  // see comments for IsStartingWithTObject()
           kWarned      = BIT(21),
           kHasNameMapNode = BIT(22),
-          kHasCustomStreamerMember = BIT(23) // The class has a Streamer method and it is implemented by the user or an older (not StreamerInfo based) automatic streamer.
+          kHasCustomStreamerMember = BIT(23) // The class has a Streamer method and it is implemented by the user
+                                             // or an older (not StreamerInfo based) automatic streamer.
    };
    enum ENewType { kRealNew = 0, kClassNew, kDummyNew };
    enum ECheckSum {
@@ -112,7 +114,8 @@ public:
                         // through rootcling/genreflex/TMetaUtils and the library
                         // containing this dictionary has been loaded in memory.
       kLoaded = kHasTClassInit,
-      kNamespaceForMeta // Very transient state necessary to bootstrap namespace entries in ROOT Meta w/o interpreter information
+      kNamespaceForMeta // Very transient state necessary to bootstrap namespace entries
+                        // in ROOT Meta w/o interpreter information
    };
 
 private:
@@ -232,9 +235,9 @@ private:
 
    typedef void (*StreamerImpl_t)(const TClass* pThis, void *obj, TBuffer &b, const TClass *onfile_class);
 #ifdef R__NO_ATOMIC_FUNCTION_POINTER
-   mutable StreamerImpl_t fStreamerImpl;  //! Pointer to the function implementing the right streaming behavior for the class represented by this object.
+   mutable StreamerImpl_t fStreamerImpl; //! Pointer to the function implementing streaming for this class
 #else
-   mutable std::atomic<StreamerImpl_t> fStreamerImpl;  //! Pointer to the function implementing the right streaming behavior for the class represented by this object.
+   mutable std::atomic<StreamerImpl_t> fStreamerImpl; //! Pointer to the function implementing streaming for this class
 #endif
 
    Bool_t             CanSplitBaseAllow();
@@ -273,7 +276,7 @@ private:
    static DeclIdMap_t *GetDeclIdMap();  //Map from DeclId_t to TClass pointer
    static std::atomic<Int_t>     fgClassCount;  //provides unique id for a each class
                                                 //stored in TObject::fUniqueID
-   static TDeclNameRegistry fNoInfoOrEmuOrFwdDeclNameRegistry; // Store the decl names of the forwardd and no info instances
+   static TDeclNameRegistry fNoInfoOrEmuOrFwdDeclNameRegistry; // Store decl names of the forwardd and no info instances
    static Bool_t HasNoInfoOrEmuOrFwdDeclaredDecl(const char*);
 
    // Internal status bits, set and reset only during initialization and thus under the protection of the global lock.
@@ -311,11 +314,11 @@ private:
    void LoadClassInfo() const;
 
 protected:
-   TVirtualStreamerInfo     *FindStreamerInfo(TObjArray* arr, UInt_t checksum) const;
-   void                      GetMissingDictionariesForBaseClasses(TCollection& result, TCollection& visited, bool recurse);
-   void                      GetMissingDictionariesForMembers(TCollection& result, TCollection& visited, bool recurse);
-   void                      GetMissingDictionariesWithRecursionCheck(TCollection& result, TCollection& visited, bool recurse);
-   void                      GetMissingDictionariesForPairElements(TCollection& result, TCollection& visited, bool recurse);
+   TVirtualStreamerInfo *FindStreamerInfo(TObjArray* arr, UInt_t checksum) const;
+   void GetMissingDictionariesForBaseClasses(TCollection& result, TCollection& visited, bool recurse);
+   void GetMissingDictionariesForMembers(TCollection& result, TCollection& visited, bool recurse);
+   void GetMissingDictionariesWithRecursionCheck(TCollection& result, TCollection& visited, bool recurse);
+   void GetMissingDictionariesForPairElements(TCollection& result, TCollection& visited, bool recurse);
 
 public:
    TClass();
@@ -369,7 +372,8 @@ public:
    TVirtualCollectionProxy *GetCollectionProxy() const;
    TVirtualIsAProxy  *GetIsAProxy() const;
    TMethod           *GetClassMethod(const char *name, const char *params, Bool_t objectIsConst = kFALSE);
-   TMethod           *GetClassMethodWithPrototype(const char *name, const char *proto, Bool_t objectIsConst = kFALSE, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch);
+   TMethod *GetClassMethodWithPrototype(const char *name, const char *proto, Bool_t objectIsConst = kFALSE,
+                                        ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch);
    Version_t          GetClassVersion() const { fVersionUsed = kTRUE; return fClassVersion; }
    Int_t              GetClassSize() const { return Size(); }
    TDataMember       *GetDataMember(const char *datamember) const;
@@ -379,7 +383,11 @@ public:
    ROOT::DelFunc_t    GetDelete() const;
    ROOT::DesFunc_t    GetDestructor() const;
    ROOT::DelArrFunc_t GetDeleteArray() const;
-   ClassInfo_t       *GetClassInfo() const { if (fCanLoadClassInfo && !TestBit(kLoading)) LoadClassInfo(); return fClassInfo; }
+   ClassInfo_t *GetClassInfo() const
+   {
+      if (fCanLoadClassInfo && !TestBit(kLoading)) LoadClassInfo();
+      return fClassInfo;
+   }
    const char        *GetContextMenuTitle() const { return fContextMenuTitle; }
    TVirtualStreamerInfo     *GetCurrentStreamerInfo() {
       if (fCurrentInfo.load()) return fCurrentInfo;
@@ -411,7 +419,8 @@ public:
    void               GetMenuItems(TList *listitems);
    TList             *GetMenuList() const;
    TMethod           *GetMethod(const char *method, const char *params, Bool_t objectIsConst = kFALSE);
-   TMethod           *GetMethodWithPrototype(const char *method, const char *proto, Bool_t objectIsConst = kFALSE, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch);
+   TMethod *GetMethodWithPrototype(const char *method, const char *proto, Bool_t objectIsConst = kFALSE,
+                                   ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch);
    TMethod           *GetMethodAny(const char *method);
    TMethod           *GetMethodAllAny(const char *method);
    Int_t              GetNdata();
@@ -543,8 +552,8 @@ public:
 };
 
 namespace ROOT {
-   template <typename T> TClass* GetClass(      T* /* dummy */)        { return TClass::GetClass(typeid(T)); }
-   template <typename T> TClass* GetClass(const T* /* dummy */)        { return TClass::GetClass(typeid(T)); }
+   template <typename T> TClass* GetClass(      T* /* dummy */) { return TClass::GetClass(typeid(T)); }
+   template <typename T> TClass* GetClass(const T* /* dummy */) { return TClass::GetClass(typeid(T)); }
 
 #ifndef R__NO_CLASS_TEMPLATE_SPECIALIZATION
    // This can only be used when the template overload resolution can distinguish between T* and T**

--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -547,8 +547,7 @@ namespace ROOT {
    template <typename T> TClass* GetClass(const T* /* dummy */)        { return TClass::GetClass(typeid(T)); }
 
 #ifndef R__NO_CLASS_TEMPLATE_SPECIALIZATION
-   // This can only be used when the template overload resolution can distringuish between
-   // T* and T**
+   // This can only be used when the template overload resolution can distinguish between T* and T**
    template <typename T> TClass* GetClass(      T**       /* dummy */) { return GetClass((T*)0); }
    template <typename T> TClass* GetClass(const T**       /* dummy */) { return GetClass((T*)0); }
    template <typename T> TClass* GetClass(      T* const* /* dummy */) { return GetClass((T*)0); }

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -5339,9 +5339,9 @@ void TClass::SetClassVersion(Version_t version)
 
 TVirtualStreamerInfo* TClass::DetermineCurrentStreamerInfo()
 {
-   R__LOCKGUARD(gInterpreterMutex);
    if(!fCurrentInfo.load()) {
-     fCurrentInfo=(TVirtualStreamerInfo*)(fStreamerInfo->At(fClassVersion));
+      R__LOCKGUARD(gInterpreterMutex);
+      fCurrentInfo = (TVirtualStreamerInfo*)(fStreamerInfo->At(fClassVersion));
    }
    return fCurrentInfo;
 }

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -3451,38 +3451,31 @@ const char *TClass::GetSharedLibs()
 
 TList *TClass::GetListOfBases()
 {
-   if (!fBase) {
-      if (fCanLoadClassInfo) {
-         if (fState == kHasTClassInit) {
+   if (fBase)
+      return fBase;
 
-            R__LOCKGUARD(gInterpreterMutex);
-            // NOTE: Add test to prevent redo if another thread has already done the work.
-            // if (!fHasRootPcmInfo) {
-
-            // The bases are in our ProtoClass; we don't need the class info.
-            TProtoClass *proto = TClassTable::GetProtoNorm(GetName());
-            if (proto && proto->FillTClass(this)) {
-               // Not sure this code is still needed
-               // R__ASSERT(kFALSE);
-
-               fHasRootPcmInfo = kTRUE;
-            }
-         }
-         // We test again on fCanLoadClassInfo has another thread may have executed it.
-         if (!fHasRootPcmInfo && !fCanLoadClassInfo) {
-            LoadClassInfo();
-         }
-      }
-      if (!fClassInfo) return 0;
-
-      if (!gInterpreter)
-         Fatal("GetListOfBases", "gInterpreter not initialized");
-
+   if (fState == kHasTClassInit) {
       R__LOCKGUARD(gInterpreterMutex);
-      if(!fBase) {
-         gInterpreter->CreateListOfBaseClasses(this);
-      }
+
+      // The bases are in our ProtoClass; we don't need the class info.
+      TProtoClass *proto = TClassTable::GetProtoNorm(GetName());
+      if (proto && proto->FillTClass(this))
+         fHasRootPcmInfo = true;
    }
+
+   if (fCanLoadClassInfo) LoadClassInfo();
+
+   if (!fClassInfo)
+      return nullptr;
+
+   if (!gInterpreter)
+      Fatal("GetListOfBases", "gInterpreter not initialized");
+
+   if(!fBase) {
+      R__LOCKGUARD(gInterpreterMutex);
+      gInterpreter->CreateListOfBaseClasses(this);
+   }
+
    return fBase;
 }
 

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -4448,46 +4448,49 @@ TVirtualStreamerInfo* TClass::GetStreamerInfo(Int_t version /* = 0 */) const
 
 TVirtualStreamerInfo* TClass::GetStreamerInfoAbstractEmulated(Int_t version /* = 0 */) const
 {
-   R__LOCKGUARD(gInterpreterMutex);
+   TVirtualStreamerInfo* sinfo = nullptr;
 
-   TString newname( GetName() );
+   TString newname(GetName());
    newname += "@@emulated";
+
+   R__LOCKGUARD(gInterpreterMutex);
 
    TClass *emulated = TClass::GetClass(newname);
 
-   TVirtualStreamerInfo* sinfo = 0;
-
-   if (emulated) {
+   if (emulated)
       sinfo = emulated->GetStreamerInfo(version);
-   }
+
    if (!sinfo) {
       // The emulated version of the streamerInfo is explicitly requested and has
       // not been built yet.
 
       sinfo = (TVirtualStreamerInfo*) fStreamerInfo->At(version);
+
       if (!sinfo && (version != fClassVersion)) {
          // When the requested version does not exist we return
          // the TVirtualStreamerInfo for the currently loaded class version.
          // FIXME: This arguably makes no sense, we should warn and return nothing instead.
          sinfo = (TVirtualStreamerInfo*) fStreamerInfo->At(fClassVersion);
       }
+
       if (!sinfo) {
          // Let's take the first available StreamerInfo as a start
          Int_t ninfos = fStreamerInfo->GetEntriesFast() - 1;
-         for (Int_t i = -1; sinfo == 0 && i < ninfos; ++i) {
-            sinfo =  (TVirtualStreamerInfo*) fStreamerInfo->UncheckedAt(i);
-         }
+         for (Int_t i = -1; sinfo == 0 && i < ninfos; ++i)
+            sinfo = (TVirtualStreamerInfo*) fStreamerInfo->UncheckedAt(i);
       }
+
       if (sinfo) {
-         sinfo = dynamic_cast<TVirtualStreamerInfo*>( sinfo->Clone() );
+         sinfo = dynamic_cast<TVirtualStreamerInfo*>(sinfo->Clone());
          if (sinfo) {
             sinfo->SetClass(0);
-            sinfo->SetName( newname );
+            sinfo->SetName(newname);
             sinfo->BuildCheck();
             sinfo->BuildOld();
             sinfo->GetClass()->AddRule(TString::Format("sourceClass=%s targetClass=%s",GetName(),newname.Data()));
-         } else
+         } else {
             Error("GetStreamerInfoAbstractEmulated", "could not create TVirtualStreamerInfo");
+         }
       }
    }
    return sinfo;
@@ -4508,36 +4511,38 @@ TVirtualStreamerInfo* TClass::GetStreamerInfoAbstractEmulated(Int_t version /* =
 
 TVirtualStreamerInfo* TClass::FindStreamerInfoAbstractEmulated(UInt_t checksum) const
 {
-   R__LOCKGUARD(gInterpreterMutex);
+   TVirtualStreamerInfo *sinfo = nullptr;
 
-   TString newname( GetName() );
+   TString newname(GetName());
    newname += "@@emulated";
+
+   R__LOCKGUARD(gInterpreterMutex);
 
    TClass *emulated = TClass::GetClass(newname);
 
-   TVirtualStreamerInfo* sinfo = 0;
-
-   if (emulated) {
+   if (emulated)
       sinfo = emulated->FindStreamerInfo(checksum);
-   }
+
    if (!sinfo) {
       // The emulated version of the streamerInfo is explicitly requested and has
       // not been built yet.
 
       sinfo = (TVirtualStreamerInfo*) FindStreamerInfo(checksum);
+
       if (!sinfo && (checksum != fCheckSum)) {
          // When the requested version does not exist we return
          // the TVirtualStreamerInfo for the currently loaded class version.
          // FIXME: This arguably makes no sense, we should warn and return nothing instead.
          sinfo = (TVirtualStreamerInfo*) fStreamerInfo->At(fClassVersion);
       }
+
       if (!sinfo) {
          // Let's take the first available StreamerInfo as a start
          Int_t ninfos = fStreamerInfo->GetEntriesFast() - 1;
-         for (Int_t i = -1; sinfo == 0 && i < ninfos; ++i) {
-            sinfo =  (TVirtualStreamerInfo*) fStreamerInfo->UncheckedAt(i);
-         }
+         for (Int_t i = -1; sinfo == 0 && i < ninfos; ++i)
+            sinfo = (TVirtualStreamerInfo*) fStreamerInfo->UncheckedAt(i);
       }
+
       if (sinfo) {
          sinfo = dynamic_cast<TVirtualStreamerInfo*>( sinfo->Clone() );
          if (sinfo) {
@@ -4546,8 +4551,9 @@ TVirtualStreamerInfo* TClass::FindStreamerInfoAbstractEmulated(UInt_t checksum) 
             sinfo->BuildCheck();
             sinfo->BuildOld();
             sinfo->GetClass()->AddRule(TString::Format("sourceClass=%s targetClass=%s",GetName(),newname.Data()));
-         } else
+         } else {
             Error("GetStreamerInfoAbstractEmulated", "could not create TVirtualStreamerInfo");
+         }
       }
    }
    return sinfo;

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -4383,53 +4383,56 @@ Int_t TTree::Fill()
 {
    Int_t nbytes = 0;
    Int_t nerror = 0;
-   Int_t nb = fBranches.GetEntriesFast();
-   if (nb == 1) {
-      // Case of one single super branch. Automatically update
-      // all the branch addresses if a new object was created.
-      TBranch* branch = (TBranch*) fBranches.UncheckedAt(0);
-      branch->UpdateAddress();
-   }
-   if (fBranchRef) {
-      fBranchRef->Clear();
-   }
+   Int_t nbranches = fBranches.GetEntriesFast();
 
+   // Case of one single super branch. Automatically update
+   // all the branch addresses if a new object was created.
+   if (nbranches == 1)
+      ((TBranch*)fBranches.UncheckedAt(0))->UpdateAddress();
+
+   if (fBranchRef)
+      fBranchRef->Clear();
+
+#ifdef R__USE_IMT
    ROOT::Internal::TBranchIMTHelper imtHelper;
-   #ifdef R__USE_IMT
+
    if (fIMTEnabled) {
       fIMTFlush = true;
       fIMTZipBytes.store(0);
       fIMTTotBytes.store(0);
    }
-   #endif
+#endif
 
-   for (Int_t i = 0; i < nb; ++i) {
+   for (Int_t i = 0; i < nbranches; ++i) {
       // Loop over all branches, filling and accumulating bytes written and error counts.
       TBranch* branch = (TBranch*) fBranches.UncheckedAt(i);
-      if (branch->TestBit(kDoNotProcess)) {
+
+      if (branch->TestBit(kDoNotProcess))
          continue;
-      }
+
+#ifndef R__USE_IMT
+      Int_t nwrite = branch->FillImpl(nullptr);
+#else
       Int_t nwrite = branch->FillImpl(fIMTEnabled ? &imtHelper : nullptr);
-      if (nwrite < 0)  {
-         if (nerror < 2) {
-            Error("Fill", "Failed filling branch:%s.%s, nbytes=%d, entry=%lld\n"
-                  " This error is symptomatic of a Tree created as a memory-resident Tree\n"
-                  " Instead of doing:\n"
-                  "    TTree *T = new TTree(...)\n"
-                  "    TFile *f = new TFile(...)\n"
-                  " you should do:\n"
-                  "    TFile *f = new TFile(...)\n"
-                  "    TTree *T = new TTree(...)",
-                  GetName(), branch->GetName(), nwrite,fEntries+1);
-         } else {
-            Error("Fill", "Failed filling branch:%s.%s, nbytes=%d, entry=%lld", GetName(), branch->GetName(), nwrite,fEntries+1);
-         }
-         ++nerror;
-      } else {
+#endif
+
+      if (nwrite > 0) {
          nbytes += nwrite;
+      } else {
+         ++nerror;
+         Error("Fill", "Failed filling branch:%s.%s, nbytes=%d, entry=%lld\n"
+               " This error is symptomatic of a Tree created as a memory-resident Tree\n"
+               " Instead of doing:\n"
+               "    TTree *T = new TTree(...)\n"
+               "    TFile *f = new TFile(...)\n"
+               " you should do:\n"
+               "    TFile *f = new TFile(...)\n"
+               "    TTree *T = new TTree(...)",
+               GetName(), branch->GetName(), nwrite,fEntries+1);
       }
    }
-   #ifdef R__USE_IMT
+
+#ifdef R__USE_IMT
    if (fIMTFlush) {
       imtHelper.Wait();
       fIMTFlush = false;
@@ -4438,99 +4441,88 @@ Int_t TTree::Fill()
       nbytes += imtHelper.GetNbytes();
       nerror += imtHelper.GetNerrors();
    }
-   #endif
+#endif
 
-   if (fBranchRef) {
+   if (fBranchRef)
       fBranchRef->Fill();
-   }
+
    ++fEntries;
-   if (fEntries > fMaxEntries) {
+
+   if (fEntries > fMaxEntries)
       KeepCircular();
-   }
-   if (gDebug > 0) Info("TTree::Fill", " - A:  %d %lld %lld %lld %lld %lld %lld \n",
-       nbytes, fEntries, fAutoFlush,fAutoSave,GetZipBytes(),fFlushedBytes,fSavedBytes);
 
-   if (fAutoFlush != 0 || fAutoSave != 0) {
-      // Is it time to flush or autosave baskets?
-      if (fFlushedBytes == 0) {
-         // Decision can be based initially either on the number of bytes
-         // or the number of entries written.
+   if (gDebug > 0)
+      Info("TTree::Fill", " - A:  %d %lld %lld %lld %lld %lld %lld \n",
+           nbytes, fEntries, fAutoFlush,fAutoSave,GetZipBytes(),fFlushedBytes,fSavedBytes);
+
+   bool autoFlush = fAutoFlush != 0;
+   bool autoSave  = fAutoSave  != 0;
+
+   if (autoFlush || autoSave) {
+      if (fFlushedBytes > 0) {
+         auto flushEntries = fNClusterRange == 0 ? fEntries : fEntries - fClusterRangeEnd[fNClusterRange-1];
+         autoFlush = flushEntries % fAutoFlush == 0;
+         autoSave  = fEntries % fAutoSave == 0;
+      } else {
          Long64_t zipBytes = GetZipBytes();
-         if ((fAutoFlush<0 && zipBytes > -fAutoFlush)  ||
-             (fAutoSave <0 && zipBytes > -fAutoSave )  ||
-             (fAutoFlush>0 && fEntries%TMath::Max((Long64_t)1,fAutoFlush) == 0) ||
-             (fAutoSave >0 && fEntries%TMath::Max((Long64_t)1,fAutoSave)  == 0) ) {
 
-            //First call FlushBasket to make sure that fTotBytes is up to date.
+         autoFlush = fAutoFlush > 0 ? fEntries == fAutoFlush : zipBytes > -fAutoFlush;
+         autoSave  = fAutoSave  > 0 ? fEntries == fAutoSave  : zipBytes > -fAutoSave;
+
+         // First time that AutoFlush/AutoSave are being called
+         if (autoFlush || autoSave) {
             FlushBaskets();
-            OptimizeBaskets(GetTotBytes(),1,"");
-            if (gDebug > 0) Info("TTree::Fill","OptimizeBaskets called at entry %lld, fZipBytes=%lld, fFlushedBytes=%lld\n",fEntries,GetZipBytes(),fFlushedBytes);
+            OptimizeBaskets(GetTotBytes(), 1, "");
+            autoFlush = false; // already flushed, do not flush again below
+
+            fAutoFlush = fEntries; // switch to test on number of entries
+
+            if (gDebug > 0)
+               Info("TTree::Fill", "OptimizeBaskets called at entry %lld, fZipBytes=%lld, fFlushedBytes=%lld\n",
+                    fEntries, GetZipBytes(), fFlushedBytes);
+
             fFlushedBytes = GetZipBytes();
-            fAutoFlush    = fEntries;  // Use test on entries rather than bytes
 
-            // subsequently in run
-            if (fAutoSave < 0) {
-               // Set fAutoSave to the largest integer multiple of
-               // fAutoFlush events such that fAutoSave*fFlushedBytes
-               // < (minus the input value of fAutoSave)
-               Long64_t totBytes = GetTotBytes();
-               if (zipBytes != 0) {
-                  fAutoSave =  TMath::Max( fAutoFlush, fEntries*((-fAutoSave/zipBytes)/fEntries));
-               } else if (totBytes != 0) {
-                  fAutoSave =  TMath::Max( fAutoFlush, fEntries*((-fAutoSave/totBytes)/fEntries));
-               } else {
-                  TBufferFile b(TBuffer::kWrite, 10000);
-                  TTree::Class()->WriteBuffer(b, (TTree*) this);
-                  Long64_t total = b.Length();
-                  fAutoSave =  TMath::Max( fAutoFlush, fEntries*((-fAutoSave/total)/fEntries));
-               }
-            } else if(fAutoSave > 0) {
-               fAutoSave = fAutoFlush*(fAutoSave/fAutoFlush);
-            }
-            if (fAutoSave!=0 && fEntries >= fAutoSave) AutoSave();    // FlushBaskets not called in AutoSave
-            if (gDebug > 0) Info("TTree::Fill","First AutoFlush.  fAutoFlush = %lld, fAutoSave = %lld\n", fAutoFlush, fAutoSave);
+            // recompute auto save as number of entries if expressed in bytes
+            if (fAutoSave < 0)
+               fAutoSave = -fAutoSave/(zipBytes > 0 ? zipBytes : GetTotBytes());
+
+            // make fAutoSave a multiple of fAutoFlush
+            fAutoSave = TMath::Max(fAutoFlush, fAutoFlush * (fAutoSave/fAutoFlush));
+
+            if (gDebug > 0)
+               Info("TTree::Fill", "First AutoFlush. fAutoFlush = %lld, fAutoSave = %lld\n", fAutoFlush, fAutoSave);
          }
-      } else if (fNClusterRange && fAutoFlush && ( (fEntries-fClusterRangeEnd[fNClusterRange-1]) % fAutoFlush == 0)  ) {
-         if (fAutoSave != 0 && fEntries%fAutoSave == 0) {
-            //We are at an AutoSave point. AutoSave flushes baskets and saves the Tree header
-            AutoSave("flushbaskets");
-            if (gDebug > 0) Info("TTree::Fill","AutoSave called at entry %lld, fZipBytes=%lld, fSavedBytes=%lld\n",fEntries,GetZipBytes(),fSavedBytes);
-         } else {
-            //We only FlushBaskets
-            FlushBaskets();
-            if (gDebug > 0) Info("TTree::Fill","FlushBasket called at entry %lld, fZipBytes=%lld, fFlushedBytes=%lld\n",fEntries,GetZipBytes(),fFlushedBytes);
-         }
-         fFlushedBytes = GetZipBytes();
-      } else if (fNClusterRange == 0 && fEntries > 1 && fAutoFlush && fEntries%fAutoFlush == 0) {
-         if (fAutoSave != 0 && fEntries%fAutoSave == 0) {
-            //We are at an AutoSave point. AutoSave flushes baskets and saves the Tree header
-            AutoSave("flushbaskets");
-            if (gDebug > 0) Info("TTree::Fill","AutoSave called at entry %lld, fZipBytes=%lld, fSavedBytes=%lld\n",fEntries,GetZipBytes(),fSavedBytes);
-         } else {
-            //We only FlushBaskets
-            FlushBaskets();
-            if (gDebug > 0) Info("TTree::Fill","FlushBasket called at entry %lld, fZipBytes=%lld, fFlushedBytes=%lld\n",fEntries,GetZipBytes(),fFlushedBytes);
-         }
-         fFlushedBytes = GetZipBytes();
       }
    }
+
+   if (autoFlush) {
+      FlushBaskets();
+      if (gDebug > 0)
+         Info("TTree::Fill", "FlushBasket called at entry %lld, fZipBytes=%lld, fFlushedBytes=%lld\n",
+              fEntries, GetZipBytes(), fFlushedBytes);
+      fFlushedBytes = GetZipBytes();
+   }
+
+   if (autoSave) {
+      AutoSave();
+      if (gDebug > 0)
+         Info("TTree::Fill", "AutoSave called at entry %lld, fZipBytes=%lld, fSavedBytes=%lld\n",
+              fEntries, GetZipBytes(), fSavedBytes);
+   }
+
    // Check that output file is still below the maximum size.
    // If above, close the current file and continue on a new file.
    // Currently, the automatic change of file is restricted
    // to the case where the tree is in the top level directory.
-   if (!fDirectory) {
-      return nbytes;
+   if (fDirectory) {
+      TFile* file = fDirectory->GetFile();
+      if (file && (file->GetEND() > fgMaxTreeSize))
+         if (fDirectory == (TDirectory*) file)
+            ChangeFile(file);
    }
-   TFile* file = fDirectory->GetFile();
-   if (file && (file->GetEND() > fgMaxTreeSize)) {
-      if (fDirectory == (TDirectory*) file) {
-         ChangeFile(file);
-      }
-   }
-   if (nerror) {
-      return -1;
-   }
-   return nbytes;
+
+   return nerror ? -1 : nbytes;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This branch contains modifications to address some performance issues identifies in JIRA issue [ROOT-8871](https://sft.its.cern.ch/jira/browse/ROOT-8871).

The main changes are:
 * Make `TClass::LoadClassInfo()` private and avoid locking the interpreter unnecessarily
 * Avoid interpreter lock in `TClass::GetListOfBases()` and return existing list if already available
 * Reduce scope of interpreter locks in several places where the lock is taken before necessary
 * Add locks where unprotected use of `gInterpreter` is made
 * Improve code clarity and performance of `TTree::Fill()`
 * Some typo and formatting fixes to improve conformance to coding conventions