### PR TITLE
[TDF] Correctly count number of children nodes in second/third... usages of a TDF

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -132,7 +132,6 @@ public:
       const ColumnNames_t &actualBl = TDFInternal::PickBranchNames(nArgs, bn, defBl);
       using DFF_t = TDFDetail::TFilter<F, Proxied>;
       auto FilterPtr = std::make_shared<DFF_t>(std::move(f), actualBl, *fProxiedPtr, name);
-      fProxiedPtr->IncrChildrenCount();
       df->Book(FilterPtr);
       TInterface<TFilterBase> tdf_f(FilterPtr, fImplWeakPtr);
       return tdf_f;
@@ -213,7 +212,6 @@ public:
       using DFB_t = TDFDetail::TCustomColumn<F, Proxied>;
       const std::string nameInt(name);
       auto BranchPtr = std::make_shared<DFB_t>(nameInt, std::move(expression), actualBl, *fProxiedPtr);
-      fProxiedPtr->IncrChildrenCount();
       df->Book(BranchPtr);
       TInterface<TCustomColumnBase> tdf_b(BranchPtr, fImplWeakPtr);
       return tdf_b;
@@ -352,7 +350,6 @@ public:
       auto df = GetDataFrameChecked();
       using Range_t = TDFDetail::TRange<Proxied>;
       auto RangePtr = std::make_shared<Range_t>(start, stop, stride, *fProxiedPtr);
-      fProxiedPtr->IncrChildrenCount();
       df->Book(RangePtr);
       TInterface<TRangeBase> tdf_r(RangePtr, fImplWeakPtr);
       return tdf_r;
@@ -410,7 +407,6 @@ public:
       using Helper_t = TDFInternal::ForeachSlotHelper<F>;
       using Action_t = TDFInternal::TAction<Helper_t, Proxied>;
       df->Book(std::make_shared<Action_t>(Helper_t(std::move(f)), actualBl, *fProxiedPtr));
-      fProxiedPtr->IncrChildrenCount();
       df->Run();
    }
 
@@ -459,7 +455,6 @@ public:
       using Helper_t = TDFInternal::ReduceHelper<F, T>;
       using Action_t = typename TDFInternal::TAction<Helper_t, Proxied>;
       df->Book(std::make_shared<Action_t>(Helper_t(std::move(f), redObjPtr, nSlots), bl, *fProxiedPtr));
-      fProxiedPtr->IncrChildrenCount();
       return MakeResultProxy(redObjPtr, df);
    }
 
@@ -476,7 +471,6 @@ public:
       using Helper_t = TDFInternal::CountHelper;
       using Action_t = TDFInternal::TAction<Helper_t, Proxied>;
       df->Book(std::make_shared<Action_t>(Helper_t(cSPtr, nSlots), ColumnNames_t({}), *fProxiedPtr));
-      fProxiedPtr->IncrChildrenCount();
       return MakeResultProxy(cSPtr, df);
    }
 
@@ -498,7 +492,6 @@ public:
       using Helper_t = TDFInternal::TakeHelper<T, COLL>;
       using Action_t = TDFInternal::TAction<Helper_t, Proxied>;
       df->Book(std::make_shared<Action_t>(Helper_t(valuesPtr, nSlots), bl, *fProxiedPtr));
-      fProxiedPtr->IncrChildrenCount();
       return MakeResultProxy(valuesPtr, df);
    }
 
@@ -1011,7 +1004,6 @@ private:
       auto df = GetDataFrameChecked();
       unsigned int nSlots = df->GetNSlots();
       BuildAndBook<BranchTypes...>(bl, r, nSlots, (ActionType *)nullptr);
-      fProxiedPtr->IncrChildrenCount();
       return MakeResultProxy(r, df);
    }
 
@@ -1026,7 +1018,6 @@ private:
       auto tree = df->GetTree();
       TDFInternal::JitBuildAndBook(bl, GetNodeTypeName(), this, typeid(std::shared_ptr<ActionResultType>),
                                    typeid(ActionType), &r, tree, nSlots, tmpBranches);
-      fProxiedPtr->IncrChildrenCount();
       return MakeResultProxy(r, df);
    }
 
@@ -1090,7 +1081,6 @@ private:
                                       *fProxiedPtr));
       }
       df->Book(std::move(actionPtr));
-      fProxiedPtr->IncrChildrenCount();
       df->Run();
 
       // create new TDF

--- a/tree/treeplayer/inc/ROOT/TDFNodes.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFNodes.hxx
@@ -294,6 +294,7 @@ public:
    virtual void Update(unsigned int slot, Long64_t entry) = 0;
    virtual void IncrChildrenCount() = 0;
    virtual void StopProcessing() = 0;
+   void ResetChildrenCount() { fNChildren = 0; fNStopsReceived = 0; }
 };
 
 template <typename F, typename PrevData>
@@ -410,6 +411,7 @@ public:
    void PrintReport() const;
    virtual void IncrChildrenCount() = 0;
    virtual void StopProcessing() = 0;
+   void ResetChildrenCount() { fNChildren = 0; fNStopsReceived = 0; }
 };
 
 template <typename FilterF, typename PrevDataFrame>
@@ -524,6 +526,7 @@ public:
    virtual void PartialReport() const = 0;
    virtual void IncrChildrenCount() = 0;
    virtual void StopProcessing() = 0;
+   void ResetChildrenCount() { fNChildren = 0; fNStopsReceived = 0; }
 };
 
 template <typename PrevData>

--- a/tree/treeplayer/inc/ROOT/TDFNodes.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFNodes.hxx
@@ -75,6 +75,7 @@ class TLoopManager : public std::enable_shared_from_this<TLoopManager> {
    void RunAndCheckFilters(unsigned int slot, Long64_t entry);
    void InitAllNodes(TTreeReader *r, unsigned int slot);
    void CreateSlots(unsigned int nSlots);
+   void CleanUp();
 
 public:
    TLoopManager(TTree *tree, const ColumnNames_t &defaultBranches);

--- a/tree/treeplayer/inc/ROOT/TDFNodes.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFNodes.hxx
@@ -234,6 +234,7 @@ public:
    TAction(Helper &&h, const ColumnNames_t &bl, PrevDataFrame &pd)
       : TActionBase(pd.GetImplPtr(), pd.GetTmpBranches()), fHelper(std::move(h)), fBranches(bl), fPrevData(pd)
    {
+      fPrevData.IncrChildrenCount();
    }
 
    TAction(const TAction &) = delete;
@@ -291,7 +292,7 @@ public:
    std::string GetName() const;
    ColumnNames_t GetTmpBranches() const;
    virtual void Update(unsigned int slot, Long64_t entry) = 0;
-   void IncrChildrenCount() { ++fNChildren; }
+   virtual void IncrChildrenCount() = 0;
    virtual void StopProcessing() = 0;
 };
 
@@ -373,6 +374,13 @@ public:
       ++fNStopsReceived;
       if (fNStopsReceived == fNChildren) fPrevData.StopProcessing();
    }
+
+   void IncrChildrenCount()
+   {
+      ++fNChildren;
+      // propagate "children activation" upstream
+      if (fNChildren == 1) fPrevData.IncrChildrenCount();
+   }
 };
 
 class TFilterBase {
@@ -400,7 +408,7 @@ public:
    bool HasName() const;
    virtual void CreateSlots(unsigned int nSlots) = 0;
    void PrintReport() const;
-   void IncrChildrenCount() { ++fNChildren; }
+   virtual void IncrChildrenCount() = 0;
    virtual void StopProcessing() = 0;
 };
 
@@ -481,6 +489,13 @@ public:
       ++fNStopsReceived;
       if (fNStopsReceived == fNChildren) fPrevData.StopProcessing();
    }
+
+   void IncrChildrenCount()
+   {
+      ++fNChildren;
+      // propagate "children activation" upstream
+      if (fNChildren == 1) fPrevData.IncrChildrenCount();
+   }
 };
 
 class TRangeBase {
@@ -507,7 +522,7 @@ public:
    virtual bool CheckFilters(unsigned int slot, Long64_t entry) = 0;
    virtual void Report() const = 0;
    virtual void PartialReport() const = 0;
-   void IncrChildrenCount() { ++fNChildren; }
+   virtual void IncrChildrenCount() = 0;
    virtual void StopProcessing() = 0;
 };
 
@@ -560,6 +575,13 @@ public:
    {
       ++fNStopsReceived;
       if (fNStopsReceived == fNChildren && !fHasStopped) fPrevData.StopProcessing();
+   }
+
+   void IncrChildrenCount()
+   {
+      ++fNChildren;
+      // propagate "children activation" upstream
+      if (fNChildren == 1) fPrevData.IncrChildrenCount();
    }
 };
 

--- a/tree/treeplayer/src/TDFNodes.cxx
+++ b/tree/treeplayer/src/TDFNodes.cxx
@@ -223,7 +223,8 @@ void TLoopManager::RunAndCheckFilters(unsigned int slot, Long64_t entry)
 }
 
 /// Perform clean-up operations. To be called at the end of each event loop.
-void TLoopManager::CleanUp() {
+void TLoopManager::CleanUp()
+{
    fHasRunAtLeastOnce = true;
 
    // forget TActions and detach TResultProxies
@@ -233,7 +234,7 @@ void TLoopManager::CleanUp() {
    }
    fResProxyReadiness.clear();
 
-   // reset children counts  
+   // reset children counts
    fNChildren = 0;
    fNStopsReceived = 0;
    for (auto &ptr : fBookedFilters) ptr->ResetChildrenCount();

--- a/tree/treeplayer/src/TDFNodes.cxx
+++ b/tree/treeplayer/src/TDFNodes.cxx
@@ -222,6 +222,17 @@ void TLoopManager::RunAndCheckFilters(unsigned int slot, Long64_t entry)
    for (auto &namedFilterPtr : fBookedNamedFilters) namedFilterPtr->CheckFilters(slot, entry);
 }
 
+/// Perform clean-up operations. To be called at the end of each event loop.
+void TLoopManager::CleanUp() {
+   fHasRunAtLeastOnce = true;
+   // forget TActions and detach TResultProxies
+   fBookedActions.clear();
+   for (auto readiness : fResProxyReadiness) {
+      *readiness.get() = true;
+   }
+   fResProxyReadiness.clear();
+}
+
 /// Start the event loop with a different mechanism depending on IMT/no IMT, data source/no data source.
 /// Also perform a few setup and clean-up operations (CreateSlots before running, clear booked actions after, etc.).
 void TLoopManager::Run()
@@ -244,13 +255,7 @@ void TLoopManager::Run()
    }
 #endif // R__USE_IMT
 
-   fHasRunAtLeastOnce = true;
-   // forget TActions and detach TResultProxies
-   fBookedActions.clear();
-   for (auto readiness : fResProxyReadiness) {
-      *readiness.get() = true;
-   }
-   fResProxyReadiness.clear();
+   CleanUp();
 }
 
 /// Build TTreeReaderValues for all nodes

--- a/tree/treeplayer/src/TDFNodes.cxx
+++ b/tree/treeplayer/src/TDFNodes.cxx
@@ -225,12 +225,20 @@ void TLoopManager::RunAndCheckFilters(unsigned int slot, Long64_t entry)
 /// Perform clean-up operations. To be called at the end of each event loop.
 void TLoopManager::CleanUp() {
    fHasRunAtLeastOnce = true;
+
    // forget TActions and detach TResultProxies
    fBookedActions.clear();
    for (auto readiness : fResProxyReadiness) {
       *readiness.get() = true;
    }
    fResProxyReadiness.clear();
+
+   // reset children counts  
+   fNChildren = 0;
+   fNStopsReceived = 0;
+   for (auto &ptr : fBookedFilters) ptr->ResetChildrenCount();
+   for (auto &ptr : fBookedRanges) ptr->ResetChildrenCount();
+   for (auto &pair : fBookedBranches) pair.second->ResetChildrenCount();
 }
 
 /// Start the event loop with a different mechanism depending on IMT/no IMT, data source/no data source.


### PR DESCRIPTION
Formerly the children count of each node was not reset after the first event loop,
with the consequence that the event loop would never be quit early, even if all ranges had been exhausted.

Some changes to the children count logic were necessary to correctly handle all cases.