### PR TITLE
Allow setting a custom ASTConsumer in CIFactory (NFC).

### DIFF
--- a/core/dictgen/src/LinkdefReader.cxx
+++ b/core/dictgen/src/LinkdefReader.cxx
@@ -1013,7 +1013,8 @@ bool LinkdefReader::Parse(SelectionRules &sr, llvm::StringRef code, const std::v
 
    // Extract all #pragmas
    std::unique_ptr<llvm::MemoryBuffer> memBuf = llvm::MemoryBuffer::getMemBuffer(code, "CLING #pragma extraction");
-   clang::CompilerInstance *pragmaCI = cling::CIFactory::createCI(std::move(memBuf), parserArgsC.size(), &parserArgsC[0], llvmdir, true /*OnlyLex*/);
+   clang::CompilerInstance *pragmaCI = cling::CIFactory::createCI(std::move(memBuf), parserArgsC.size(),
+                                                                  &parserArgsC[0], llvmdir, nullptr, true /*OnlyLex*/);
 
    clang::Preprocessor &PP = pragmaCI->getPreprocessor();
    clang::DiagnosticConsumer &DClient = pragmaCI->getDiagnosticClient();

--- a/interpreter/cling/include/cling/Interpreter/CIFactory.h
+++ b/interpreter/cling/include/cling/Interpreter/CIFactory.h
@@ -21,6 +21,7 @@ namespace llvm {
 
 namespace clang {
   class DiagnosticsEngine;
+  class ASTConsumer;
 }
 
 namespace cling {
@@ -33,11 +34,13 @@ namespace cling {
 
     clang::CompilerInstance* createCI(llvm::StringRef Code,
                                       const InvocationOptions& Opts,
-                                      const char* LLVMDir);
+                                      const char* LLVMDir,
+                                      clang::ASTConsumer* consumer);
 
     clang::CompilerInstance* createCI(MemBufPtr_t Buffer, int Argc,
-                                      const char* const *Argv,
+                                      const char* const* Argv,
                                       const char* LLVMDir,
+                                      clang::ASTConsumer* consumer,
                                       bool OnlyLex = false);
   } // namespace CIFactory
 } // namespace cling

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -697,7 +697,8 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
   static CompilerInstance*
   createCIImpl(std::unique_ptr<llvm::MemoryBuffer> Buffer,
                const CompilerOptions& COpts, const char* LLVMDir,
-               bool OnlyLex, bool HasInput = false) {
+               clang::ASTConsumer* customConsumer, bool OnlyLex,
+               bool HasInput = false) {
     // Follow clang -v convention of printing version on first line
     if (COpts.Verbose)
       cling::log() << "cling version " << ClingStringify(CLING_VERSION) << '\n';
@@ -938,16 +939,15 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
     CI->createASTContext();
 
     if (OnlyLex) {
+      assert(customConsumer == nullptr && "Can't specify a custom consumer"
+                                          " when in OnlyLex mode");
       class IgnoreConsumer: public clang::ASTConsumer {};
       CI->setASTConsumer(
           std::unique_ptr<clang::ASTConsumer>(new IgnoreConsumer()));
     } else {
-      std::unique_ptr<cling::DeclCollector>
-        stateCollector(new cling::DeclCollector());
-
-      // Add the callback keeping track of the macro definitions
-      PP.addPPCallbacks(stateCollector->MakePPAdapter());
-      CI->setASTConsumer(std::move(stateCollector));
+      assert(customConsumer != nullptr && "Need to specify a custom consumer"
+                                          " when not in OnlyLex mode");
+      CI->setASTConsumer(std::unique_ptr<clang::ASTConsumer>(customConsumer));
     }
 
     // Set up Sema
@@ -1008,17 +1008,20 @@ namespace cling {
 
 CompilerInstance* CIFactory::createCI(llvm::StringRef Code,
                                       const InvocationOptions& Opts,
-                                      const char* LLVMDir) {
-  return createCIImpl(llvm::MemoryBuffer::getMemBuffer(Code),
-                      Opts.CompilerOpts, LLVMDir, false /*OnlyLex*/,
+                                      const char* LLVMDir,
+                                      clang::ASTConsumer* consumer) {
+  return createCIImpl(llvm::MemoryBuffer::getMemBuffer(Code), Opts.CompilerOpts,
+                      LLVMDir, consumer, false /*OnlyLex*/,
                       !Opts.IsInteractive());
 }
 
 CompilerInstance* CIFactory::createCI(MemBufPtr_t Buffer, int argc,
-                                      const char* const *argv,
-                                      const char* LLVMDir, bool OnlyLex) {
-  return createCIImpl(std::move(Buffer), CompilerOptions(argc, argv),
-                      LLVMDir, OnlyLex);
+                                      const char* const* argv,
+                                      const char* LLVMDir,
+                                      clang::ASTConsumer* consumer,
+                                      bool OnlyLex) {
+  return createCIImpl(std::move(Buffer), CompilerOptions(argc, argv), LLVMDir,
+                      consumer, OnlyLex);
 }
 
 } // namespace cling

--- a/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
@@ -165,10 +165,11 @@ namespace {
 } // unnamed namespace
 
 namespace cling {
-  IncrementalParser::IncrementalParser(Interpreter* interp, const char* llvmdir):
-    m_Interpreter(interp),
-    m_CI(CIFactory::createCI("", interp->getOptions(), llvmdir)),
-    m_Consumer(nullptr), m_ModuleNo(0) {
+  IncrementalParser::IncrementalParser(Interpreter* interp, const char* llvmdir)
+      : m_Interpreter(interp),
+        m_CI(CIFactory::createCI("", interp->getOptions(), llvmdir,
+                                 m_Consumer = new cling::DeclCollector())),
+        m_ModuleNo(0) {
 
     if (!m_CI) {
       cling::errs() << "Compiler instance could not be created.\n";
@@ -178,11 +179,12 @@ namespace cling {
     if (m_Interpreter->getOptions().CompilerOpts.HasOutput)
       return;
 
-    m_Consumer = dyn_cast<DeclCollector>(&m_CI->getSema().getASTConsumer());
     if (!m_Consumer) {
       cling::errs() << "No AST consumer available.\n";
       return;
     }
+    // Add the callback keeping track of the macro definitions.
+    m_CI->getPreprocessor().addPPCallbacks(m_Consumer->MakePPAdapter());
 
     DiagnosticsEngine& Diag = m_CI->getDiagnostics();
     if (m_CI->getFrontendOpts().ProgramAction != frontend::ParseSyntaxOnly) {


### PR DESCRIPTION
So far we create our DeclCollector in the CIFactory and then tried to
get this variable back in the IncrementalParser by casting the
ASTConsumer of our compiler instance to a DeclCollector. This strategy
fails as soon as we want to have multiple collectors and start using
the clang multiplexer as this call will now fail (e.g. in this case to
have another ASTConsumer that looks in the C++ modules case for what
libraries we need to link - and the best way to add this is via
the multiplexed ASTConsumer that clang provides).

This patch moves the responsibility for the DeclCollector to the
caller that relies on getting a DeclCollector back, which is in this
case the constructor of IncrementalParser.