### PR TITLE
Fix nullptr dereference bug in TList::RecursiveRemove()

### DIFF
--- a/core/cont/src/TList.cxx
+++ b/core/cont/src/TList.cxx
@@ -713,30 +713,31 @@ void TList::RecursiveRemove(TObject *obj)
    TObjLink *next = 0;
    while (lnk) {
       next = lnk->Next();
-      TObject *ob = lnk->GetObject();
-      if (ob->TestBit(kNotDeleted)) {
-         if (ob->IsEqual(obj)) {
-            if (lnk == fFirst) {
-               fFirst = next;
-               if (lnk == fLast)
-                  fLast = fFirst;
-               else
-                  fFirst->fPrev = 0;
-               DeleteLink(lnk);
-            } else if (lnk == fLast) {
-               fLast = lnk->Prev();
-               fLast->fNext = 0;
-               DeleteLink(lnk);
-            } else {
-               lnk->Prev()->fNext = next;
-               lnk->Next()->fPrev = lnk->Prev();
-               DeleteLink(lnk);
-            }
-            fSize--;
-            fCache = 0;
-            Changed();
-         } else
-            ob->RecursiveRemove(obj);
+      if (TObject* ob = lnk->GetObject()) {
+         if (ob->TestBit(kNotDeleted)) {
+            if (ob->IsEqual(obj)) {
+               if (lnk == fFirst) {
+                  fFirst = next;
+                  if (lnk == fLast)
+                     fLast = fFirst;
+                  else
+                     fFirst->fPrev = 0;
+                  DeleteLink(lnk);
+               } else if (lnk == fLast) {
+                  fLast = lnk->Prev();
+                  fLast->fNext = 0;
+                  DeleteLink(lnk);
+               } else {
+                  lnk->Prev()->fNext = next;
+                  lnk->Next()->fPrev = lnk->Prev();
+                  DeleteLink(lnk);
+               }
+               fSize--;
+               fCache = 0;
+               Changed();
+            } else
+               ob->RecursiveRemove(obj);
+         }
       }
       lnk = next;
    }


### PR DESCRIPTION
When multiple threads are touching the list of cleanups, another thread can delete the object retrieved via TObjLink::GetObject(), and then when it is dereferenced in ob->TestBit(...) it causes a crash in ROOT.

Stack trace (simplified):
```
in TObject::TestBit (this=0x0, f=33554432) at TObject.h:159
                          ^^^
in TList::RecursiveRemove (this=0xb3c3e0, obj=0x7ff3547da6b0)
  at root/core/cont/src/TList.cxx:717
                                  ^^^
in THashList::RecursiveRemove (this=0xb504b0, obj=0x7ff3547da6b0)
  at root/core/cont/src/THashList.cxx:286
in TObject::~TObject (this=0x7ff3547da6b0, __in_chrg=<optimized out>)
  at root/core/base/src/TObject.cxx:88
```