### PR TITLE
Defer jitting of actions to right before starting the event loop

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -262,7 +262,9 @@ public:
       std::stringstream snapCall;
       // build a string equivalent to
       // "reinterpret_cast</nodetype/*>(this)->Snapshot<Ts...>(treename,filename,*reinterpret_cast<ColumnNames_t*>(&bnames))"
-      snapCall << "if (gROOTMutex) gROOTMutex->UnLock(); ((" << GetNodeTypeName() << "*)" << this << ")->Snapshot<";
+      snapCall << "if (gROOTMutex) gROOTMutex->UnLock();";
+      snapCall << "reinterpret_cast<ROOT::Experimental::TDF::TInterface<" << GetNodeTypeName() << ">*>(" << this
+               << ")->Snapshot<";
       bool first = true;
       for (auto &b : bnames) {
          if (!first) snapCall << ", ";
@@ -897,11 +899,12 @@ private:
       const std::string transformInt(transformation);
       const std::string nameInt(nodeName);
       const std::string expressionInt(expression);
-      return TDFInternal::JitTransformation(this, transformInt, GetNodeTypeName(), nameInt, expressionInt, branches,
+      const auto thisTypeName = "ROOT::Experimental::TDF::TInterface<" + GetNodeTypeName() + ">";
+      return TDFInternal::JitTransformation(this, transformInt, thisTypeName, nameInt, expressionInt, branches,
                                             tmpBranches, tmpBookedBranches, tree);
    }
 
-   inline const char *GetNodeTypeName() { return ""; };
+   inline std::string GetNodeTypeName();
 
    /// Returns the default branches if needed, takes care of the error handling.
    template <typename T1, typename T2 = void, typename T3 = void, typename T4 = void>
@@ -1016,7 +1019,8 @@ private:
       unsigned int nSlots = df->GetNSlots();
       const auto &tmpBranches = df->GetBookedBranches();
       auto tree = df->GetTree();
-      TDFInternal::JitBuildAndBook(bl, GetNodeTypeName(), this, typeid(std::shared_ptr<ActionResultType>),
+      const auto thisTypeName = "ROOT::Experimental::TDF::TInterface<" + GetNodeTypeName() + ">";
+      TDFInternal::JitBuildAndBook(bl, thisTypeName, this, typeid(std::shared_ptr<ActionResultType>),
                                    typeid(ActionType), &r, tree, nSlots, tmpBranches);
       return MakeResultProxy(r, df);
    }
@@ -1143,27 +1147,27 @@ protected:
 };
 
 template <>
-inline const char *TInterface<TDFDetail::TFilterBase>::GetNodeTypeName()
+inline std::string TInterface<TDFDetail::TFilterBase>::GetNodeTypeName()
 {
-   return "ROOT::Experimental::TDF::TInterface<ROOT::Detail::TDF::TFilterBase>";
+   return "ROOT::Detail::TDF::TFilterBase";
 }
 
 template <>
-inline const char *TInterface<TDFDetail::TCustomColumnBase>::GetNodeTypeName()
+inline std::string TInterface<TDFDetail::TCustomColumnBase>::GetNodeTypeName()
 {
-   return "ROOT::Experimental::TDF::TInterface<ROOT::Detail::TDF::TCustomColumnBase>";
+   return "ROOT::Detail::TDF::TCustomColumnBase";
 }
 
 template <>
-inline const char *TInterface<TDFDetail::TLoopManager>::GetNodeTypeName()
+inline std::string TInterface<TDFDetail::TLoopManager>::GetNodeTypeName()
 {
-   return "ROOT::Experimental::TDF::TInterface<ROOT::Detail::TDF::TLoopManager>";
+   return "ROOT::Detail::TDF::TLoopManager";
 }
 
 template <>
-inline const char *TInterface<TDFDetail::TRangeBase>::GetNodeTypeName()
+inline std::string TInterface<TDFDetail::TRangeBase>::GetNodeTypeName()
 {
-   return "ROOT::Experimental::TDF::TInterface<ROOT::Detail::TDF::TRangeBase>";
+   return "ROOT::Detail::TDF::TRangeBase";
 }
 
 } // end NS TDF

--- a/tree/treeplayer/inc/ROOT/TDFNodes.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFNodes.hxx
@@ -67,6 +67,7 @@ class TLoopManager : public std::enable_shared_from_this<TLoopManager> {
    unsigned int fNChildren{0};      ///< Number of nodes of the functional graph hanging from this object
    unsigned int fNStopsReceived{0}; ///< Number of times that a children node signaled to stop processing entries.
    const ELoopType fLoopType; ///< The kind of event loop that is going to be run (e.g. on ROOT files, on no files)
+   std::string fToJit; ///< string containing all `BuildAndBook` actions that should be jitted before running
 
    void RunEmptySourceMT();
    void RunEmptySource();
@@ -106,6 +107,7 @@ public:
    void SetTree(std::shared_ptr<TTree> tree) { fTree = tree; }
    void IncrChildrenCount() { ++fNChildren; }
    void StopProcessing() { ++fNStopsReceived; }
+   void Jit(const std::string& s) { fToJit.append(s); }
 };
 } // end ns TDF
 } // end ns Detail

--- a/tree/treeplayer/src/TDFInterface.cxx
+++ b/tree/treeplayer/src/TDFInterface.cxx
@@ -163,9 +163,9 @@ Long_t JitTransformation(void *thisPtr, const std::string &methodName, const std
 
 // Jit and call something equivalent to "this->BuildAndBook<BranchTypes...>(params...)"
 // (see comments in the body for actual jitted code)
-void JitBuildAndBook(const ColumnNames_t &bl, const std::string &prevNodeTypename, void *prevNode,
-                     const std::type_info &art, const std::type_info &at, const void *r, TTree *tree,
-                     unsigned int nSlots, const std::map<std::string, TmpBranchBasePtr_t> &tmpBranches)
+std::string JitBuildAndBook(const ColumnNames_t &bl, const std::string &prevNodeTypename, void *prevNode,
+                            const std::type_info &art, const std::type_info &at, const void *r, TTree *tree,
+                            unsigned int nSlots, const std::map<std::string, TmpBranchBasePtr_t> &tmpBranches)
 {
    gInterpreter->ProcessLine("#include \"ROOT/TDataFrame.hxx\"");
    auto nBranches = bl.size();
@@ -178,16 +178,16 @@ void JitBuildAndBook(const ColumnNames_t &bl, const std::string &prevNodeTypenam
    }
 
    // retrieve branch type names as strings
-   std::vector<std::string> branchTypeNames(nBranches);
+   std::vector<std::string> columnTypeNames(nBranches);
    for (auto i = 0u; i < nBranches; ++i) {
-      const auto branchTypeName = ColumnName2ColumnTypeName(bl[i], tree, tmpBranchPtrs[i]);
-      if (branchTypeName.empty()) {
+      const auto columnTypeName = ColumnName2ColumnTypeName(bl[i], tree, tmpBranchPtrs[i]);
+      if (columnTypeName.empty()) {
          std::string exceptionText = "The type of column ";
          exceptionText += bl[i];
          exceptionText += " could not be guessed. Please specify one.";
          throw std::runtime_error(exceptionText.c_str());
       }
-      branchTypeNames[i] = branchTypeName;
+      columnTypeNames[i] = columnTypeName;
    }
 
    // retrieve type of result of the action as a string
@@ -207,24 +207,19 @@ void JitBuildAndBook(const ColumnNames_t &bl, const std::string &prevNodeTypenam
    const auto actionTypeName = actionTypeClass->GetName();
 
    // createAction_str will contain the following:
-   // ROOT::Internal::TDF::CallBuildAndBook<PrevNodeType, actionType, branchType1, branchType2...>(
-   //    *reinterpret_cast<PrevNodeType*>(prevNode), *reinterpret_cast<ROOT::ColumnNames_t*>(&bl),
-   //    *reinterpret_cast<actionResultType*>(r), reinterpret_cast<ActionType*>(nullptr))
+   // ROOT::Internal::TDF::CallBuildAndBook<actionType, branchType1, branchType2...>(
+   //    *reinterpret_cast<PrevNodeType*>(prevNode), { bl[0], bl[1], ... }, *reinterpret_cast<actionResultType*>(r))
    std::stringstream createAction_str;
    createAction_str << "ROOT::Internal::TDF::CallBuildAndBook"
                     << "<" << actionTypeName;
-   for (auto &branchTypeName : branchTypeNames) createAction_str << ", " << branchTypeName;
-   createAction_str << ">"
-                    << "(*reinterpret_cast<" << prevNodeTypename << "*>(" << prevNode << "), "
-                    << "*reinterpret_cast<ROOT::Detail::TDF::ColumnNames_t*>(" << &bl << "), " << nSlots
-                    << ", *reinterpret_cast<" << actionResultTypeName << "*>(" << r << "));";
-   auto error = TInterpreter::EErrorCode::kNoError;
-   gInterpreter->ProcessLine(createAction_str.str().c_str(), &error);
-   if (error) {
-      std::string exceptionText = "An error occurred while jitting this action:\n";
-      exceptionText += createAction_str.str();
-      throw std::runtime_error(exceptionText.c_str());
+   for (auto &colType : columnTypeNames) createAction_str << ", " << colType;
+   createAction_str << ">(*reinterpret_cast<" << prevNodeTypename << "*>(" << prevNode << "), {";
+   for (auto i = 0u; i < bl.size(); ++i) {
+      if (i != 0u) createAction_str << ", ";
+      createAction_str << '"' << bl[i] << '"';
    }
+   createAction_str << "}, " << nSlots << ", *reinterpret_cast<" << actionResultTypeName << "*>(" << r << "));";
+   return createAction_str.str();
 }
 } // end ns TDF
 } // end ns Internal


### PR DESCRIPTION
`gInterpreter::ProcessLine` has an important run-time cost.
Instead of calling it everytime the jitting of an action is required, we now store all the strings that are to jit in TLoopManager and do a single call to `gInterpreter::ProcessLine` before running the event-loop.

A couple of life-time issues had to be resolved for this to work properly: in order to let result proxies and action helpers share ownership of the result object, I introduced (simple) manual lifetime management of a shared_ptr (weird, I know). In order to deal with deferred jitting of an action that hangs from a node whose `TInterface` has already been destroyed (can happen due to the deferral of jitting) all `BuildAndBook` functions have been made independent of `TInterface`.

In the long term it might be possible to refactor the jitting mechanism so that the `TAction` (and the `TTreeReaderValue/Array`s that it contains) is jitted but the action helpers are not, lifting the requirement of manual lifetime management of a shared_ptr. Although this should be possible in principle, I currently don't see how we could integrate it with the existing logic, so I decided for this much less invasive solution.

Before/after runtimes for two extreme scenarios:

`test_inference.cxx` (which performs a lot of jitting).
compile time: ~8s -> ~9s
run time: ~40s -> ~7s

50 jitted Histo1D calls in a loop (thanks to Attila for the use-case):
run time: ~35s -> <2s

This PR conflicts with #713 . Depending on which one gets merged first I will rebase the other.