### PR TITLE
webgui: Introducing CEF and Qt5 implementation of ROOT7 Canvas

### DIFF
--- a/gui/canvaspainter/CMakeLists.txt
+++ b/gui/canvaspainter/CMakeLists.txt
@@ -4,4 +4,31 @@
 
 set(libname ROOTCanvasPainter)
 
-ROOT_LINKER_LIBRARY(${libname} *.cxx v7/src/ DEPENDENCIES Gpad RHTTP)
+set(CEF_LIBRARY "")
+set(CEF_LIB_DEPENDENCY "")
+set(CEF_DLL_WRAPPER "")
+set(CEF_SRC "")
+ROOT_GLOB_SOURCES(sources v7/src/*.cxx)
+
+if(DEFINED ENV{CEF_PATH})
+if(EXISTS $ENV{CEF_PATH})
+   include_directories($ENV{CEF_PATH})
+   add_definitions(-DWEBGUI_WITH_CEF)
+   ROOT_GLOB_SOURCES(sources v7/src/*.cxx v7/cef/simple_app.cxx v7/cef/simple_handler.cxx v7/cef/simple_handler_linux.cxx)
+   configure_file($ENV{CEF_PATH}/Resources/icudtl.dat "../../bin/icudtl.dat" COPYONLY)
+   configure_file($ENV{CEF_PATH}/Release/natives_blob.bin "../../bin/natives_blob.bin" COPYONLY)
+   configure_file($ENV{CEF_PATH}/Release/snapshot_blob.bin "../../bin/snapshot_blob.bin" COPYONLY)
+   set(CEF_LIBRARY $ENV{CEF_PATH}/Release/libcef.so)
+   set(CEF_DLL_WRAPPER $ENV{CEF_PATH}/libcef_dll_wrapper/libcef_dll_wrapper.a)
+   set(CEF_LIB_DEPENDENCY ${X11_LIBRARIES})
+   set(CEF_MAIN "v7/cef/cef_main.cxx")
+endif()
+endif()
+
+ROOT_LINKER_LIBRARY(${libname} ${sources} LIBRARIES Core ${CEF_LIBRARY} ${CEF_DLL_WRAPPER} ${CEF_LIB_DEPENDENCY} DEPENDENCIES Gpad RHTTP)
+
+# ROOT_LINKER_LIBRARY(${libname} *.cxx v7/src/ DEPENDENCIES Gpad RHTTP)
+
+if(DEFINED CEF_MAIN)
+  ROOT_EXECUTABLE(cef_main ${CEF_MAIN} LIBRARIES ${CEF_LIBRARY} ${CEF_DLL_WRAPPER})
+endif()

--- a/gui/canvaspainter/Readme.md
+++ b/gui/canvaspainter/Readme.md
@@ -1,0 +1,48 @@
+## Compilation with CEF support (https://bitbucket.org/chromiumembedded/cef)     
+
+1. Download binary code from http://opensource.spotify.com/cefbuilds/index.html
+
+2. Unpack it in directory without spaces and special symbols like
+  
+     [shell] mkdir /d/cef
+     [shell] cd /d/cef/
+     [shell] wget http://opensource.spotify.com/cefbuilds/cef_binary_3.3029.1604.g364cd86_linux64.tar.bz2
+     [shell] tar xjf cef_binary_3.3029.1604.g364cd86_linux64.tar.bz2  
+
+3. Set shell variable to unpacked directory
+  
+     [shell] export CEF_PATH=/d/cef/cef_binary_3.3029.1604.g364cd86_linux64
+     
+4. Install prerequicities - see comments in $CEF_PATH/CMakeLists.txt. 
+   For the linux it is `build-essential`, `libgtk2.0-dev`, `libgtkglext1-dev`
+
+5. Compile all tests (required for the libcef_dll_wrapper)
+     
+     [shell] mkdir /d/cef/tests
+     [shell] cd /d/cef/tests
+     [shell] cmake $CEF_PATH
+     [shell] make -j8
+     [shell] cp -r libcef_dll_wrapper $CEF_PATH
+
+6. Compile ROOT from the same shell (CEF_PATH variable should be set)
+
+7. Run ROOT from the same shell (CEF_PATH and JSROOTSYS variables should be set)
+
+8. Only single canvas is supported at the moment, one get different warnings       
+
+
+
+## Compilation with QT5 WebEngine support
+
+1. Install libqt5-qtwebengine and libqt5-qtwebengine-devel packages
+
+2. Compile rootqt5 main program (standard Rint plus QApplication)
+  
+     [shell] cd gui/canvaspainter/v7/qt5; qmake-qt5 rootqt5.pro; make     
+
+3. Run ROOT macros, using rootqt5 executable:
+
+     [shell] rootqt5 -l hsimple.C
+     
+
+     

--- a/gui/canvaspainter/v7/cef/LICENSE.txt
+++ b/gui/canvaspainter/v7/cef/LICENSE.txt
@@ -1,0 +1,29 @@
+// Copyright (c) 2008-2014 Marshall A. Greenblatt. Portions Copyright (c)
+// 2006-2009 Google Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the name Chromium Embedded
+// Framework nor the names of its contributors may be used to endorse
+// or promote products derived from this software without specific prior
+// written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/gui/canvaspainter/v7/cef/cef_main.cxx
+++ b/gui/canvaspainter/v7/cef/cef_main.cxx
@@ -1,0 +1,29 @@
+// Copyright (c) 2013 The Chromium Embedded Framework Authors. All rights
+// reserved. Use of this source code is governed by a BSD-style license that
+// can be found in the LICENSE file.
+
+#include "simple_app.h"
+
+#include <unistd.h>
+
+#include "include/base/cef_logging.h"
+
+
+// Entry point function for all processes.
+int main(int argc, char* argv[]) {
+  // Provide CEF with command-line arguments.
+  CefMainArgs main_args(argc, argv);
+
+  // CEF applications have multiple sub-processes (render, plugin, GPU, etc)
+  // that share the same executable. This function checks the command-line and,
+  // if this is a sub-process, executes the appropriate logic.
+  int exit_code = CefExecuteProcess(main_args, NULL, NULL);
+  if (exit_code >= 0) {
+    // The sub-process has completed so return here.
+    return exit_code;
+  }
+
+  printf("do nothing\n");
+
+  return 0;
+}

--- a/gui/canvaspainter/v7/cef/cef_main.cxx
+++ b/gui/canvaspainter/v7/cef/cef_main.cxx
@@ -8,22 +8,22 @@
 
 #include "include/base/cef_logging.h"
 
-
 // Entry point function for all processes.
-int main(int argc, char* argv[]) {
-  // Provide CEF with command-line arguments.
-  CefMainArgs main_args(argc, argv);
+int main(int argc, char *argv[])
+{
+   // Provide CEF with command-line arguments.
+   CefMainArgs main_args(argc, argv);
 
-  // CEF applications have multiple sub-processes (render, plugin, GPU, etc)
-  // that share the same executable. This function checks the command-line and,
-  // if this is a sub-process, executes the appropriate logic.
-  int exit_code = CefExecuteProcess(main_args, NULL, NULL);
-  if (exit_code >= 0) {
-    // The sub-process has completed so return here.
-    return exit_code;
-  }
+   // CEF applications have multiple sub-processes (render, plugin, GPU, etc)
+   // that share the same executable. This function checks the command-line and,
+   // if this is a sub-process, executes the appropriate logic.
+   int exit_code = CefExecuteProcess(main_args, NULL, NULL);
+   if (exit_code >= 0) {
+      // The sub-process has completed so return here.
+      return exit_code;
+   }
 
-  printf("do nothing\n");
+   printf("do nothing\n");
 
-  return 0;
+   return 0;
 }

--- a/gui/canvaspainter/v7/cef/simple_app.cxx
+++ b/gui/canvaspainter/v7/cef/simple_app.cxx
@@ -1,0 +1,130 @@
+// Copyright (c) 2013 The Chromium Embedded Framework Authors. All rights
+// reserved. Use of this source code is governed by a BSD-style license that
+// can be found in the LICENSE file.
+
+#include "simple_app.h"
+
+#include <string>
+
+#include "simple_handler.h"
+#include "include/cef_browser.h"
+#include "include/views/cef_browser_view.h"
+#include "include/views/cef_window.h"
+#include "include/wrapper/cef_helpers.h"
+
+namespace {
+
+// When using the Views framework this object provides the delegate
+// implementation for the CefWindow that hosts the Views-based browser.
+class SimpleWindowDelegate : public CefWindowDelegate {
+ public:
+  explicit SimpleWindowDelegate(CefRefPtr<CefBrowserView> browser_view)
+      : browser_view_(browser_view) {
+  }
+
+  void OnWindowCreated(CefRefPtr<CefWindow> window) OVERRIDE {
+    // Add the browser view and show the window.
+    window->AddChildView(browser_view_);
+    window->Show();
+
+    // Give keyboard focus to the browser view.
+    browser_view_->RequestFocus();
+  }
+
+  void OnWindowDestroyed(CefRefPtr<CefWindow> window) OVERRIDE {
+    browser_view_ = NULL;
+  }
+
+  bool CanClose(CefRefPtr<CefWindow> window) OVERRIDE {
+    // Allow the window to close if the browser says it's OK.
+    CefRefPtr<CefBrowser> browser = browser_view_->GetBrowser();
+    if (browser)
+      return browser->GetHost()->TryCloseBrowser();
+    return true;
+  }
+
+ private:
+  CefRefPtr<CefBrowserView> browser_view_;
+
+  IMPLEMENT_REFCOUNTING(SimpleWindowDelegate);
+  DISALLOW_COPY_AND_ASSIGN(SimpleWindowDelegate);
+};
+
+}  // namespace
+
+SimpleApp::SimpleApp(const std::string &url, const std::string &cef_main) :
+   fUrl(url), fCefMain(cef_main) {
+}
+
+SimpleApp::~SimpleApp() {
+}
+
+
+void SimpleApp::OnBeforeCommandLineProcessing(
+   const CefString& process_type,
+   CefRefPtr<CefCommandLine> command_line)
+{
+   std::string name = process_type.ToString();
+   std::string prog = command_line->GetProgram().ToString();
+
+   printf("Start process %s %s\n", name.c_str(), prog.c_str());
+}
+
+
+void SimpleApp::OnBeforeChildProcessLaunch(
+        CefRefPtr<CefCommandLine> command_line) {
+
+   std::string newprog = fCefMain;
+
+   command_line->SetProgram(newprog);
+
+   std::string prog = command_line->GetProgram().ToString();
+
+   printf("OnBeforeChildProcessLaunch %s\n", prog.c_str());
+}
+
+
+
+
+
+void SimpleApp::OnContextInitialized() {
+  CEF_REQUIRE_UI_THREAD();
+
+#if defined(OS_WIN) || defined(OS_LINUX)
+  // Create the browser using the Views framework if "--use-views" is specified
+  // via the command-line. Otherwise, create the browser using the native
+  // platform framework. The Views framework is currently only supported on
+  // Windows and Linux.
+  const bool use_views = false;
+#else
+  const bool use_views = false;
+#endif
+
+  // SimpleHandler implements browser-level callbacks.
+  CefRefPtr<SimpleHandler> handler(new SimpleHandler(use_views));
+
+  // Specify CEF browser settings here.
+  CefBrowserSettings browser_settings;
+
+  if (use_views) {
+    // Create the BrowserView.
+    CefRefPtr<CefBrowserView> browser_view = CefBrowserView::CreateBrowserView(
+        handler, fUrl, browser_settings, NULL, NULL);
+
+    // Create the Window. It will show itself after creation.
+    CefWindow::CreateTopLevelWindow(new SimpleWindowDelegate(browser_view));
+  } else {
+    // Information used when creating the native window.
+    CefWindowInfo window_info;
+
+#if defined(OS_WIN)
+    // On Windows we need to specify certain flags that will be passed to
+    // CreateWindowEx().
+    window_info.SetAsPopup(NULL, "cefsimple");
+#endif
+
+    // Create the first browser window.
+    CefBrowserHost::CreateBrowser(window_info, handler, fUrl, browser_settings,
+                                  NULL);
+  }
+}

--- a/gui/canvaspainter/v7/cef/simple_app.cxx
+++ b/gui/canvaspainter/v7/cef/simple_app.cxx
@@ -17,52 +17,47 @@ namespace {
 // When using the Views framework this object provides the delegate
 // implementation for the CefWindow that hosts the Views-based browser.
 class SimpleWindowDelegate : public CefWindowDelegate {
- public:
-  explicit SimpleWindowDelegate(CefRefPtr<CefBrowserView> browser_view)
-      : browser_view_(browser_view) {
-  }
+public:
+   explicit SimpleWindowDelegate(CefRefPtr<CefBrowserView> browser_view) : browser_view_(browser_view) {}
 
-  void OnWindowCreated(CefRefPtr<CefWindow> window) OVERRIDE {
-    // Add the browser view and show the window.
-    window->AddChildView(browser_view_);
-    window->Show();
+   void OnWindowCreated(CefRefPtr<CefWindow> window) OVERRIDE
+   {
+      // Add the browser view and show the window.
+      window->AddChildView(browser_view_);
+      window->Show();
 
-    // Give keyboard focus to the browser view.
-    browser_view_->RequestFocus();
-  }
+      // Give keyboard focus to the browser view.
+      browser_view_->RequestFocus();
+   }
 
-  void OnWindowDestroyed(CefRefPtr<CefWindow> window) OVERRIDE {
-    browser_view_ = NULL;
-  }
+   void OnWindowDestroyed(CefRefPtr<CefWindow> window) OVERRIDE { browser_view_ = NULL; }
 
-  bool CanClose(CefRefPtr<CefWindow> window) OVERRIDE {
-    // Allow the window to close if the browser says it's OK.
-    CefRefPtr<CefBrowser> browser = browser_view_->GetBrowser();
-    if (browser)
-      return browser->GetHost()->TryCloseBrowser();
-    return true;
-  }
+   bool CanClose(CefRefPtr<CefWindow> window) OVERRIDE
+   {
+      // Allow the window to close if the browser says it's OK.
+      CefRefPtr<CefBrowser> browser = browser_view_->GetBrowser();
+      if (browser) return browser->GetHost()->TryCloseBrowser();
+      return true;
+   }
 
- private:
-  CefRefPtr<CefBrowserView> browser_view_;
+private:
+   CefRefPtr<CefBrowserView> browser_view_;
 
-  IMPLEMENT_REFCOUNTING(SimpleWindowDelegate);
-  DISALLOW_COPY_AND_ASSIGN(SimpleWindowDelegate);
+   IMPLEMENT_REFCOUNTING(SimpleWindowDelegate);
+   DISALLOW_COPY_AND_ASSIGN(SimpleWindowDelegate);
 };
 
-}  // namespace
+} // namespace
 
-SimpleApp::SimpleApp(const std::string &url, const std::string &cef_main) :
-   fUrl(url), fCefMain(cef_main) {
+SimpleApp::SimpleApp(const std::string &url, const std::string &cef_main) : fUrl(url), fCefMain(cef_main)
+{
 }
 
-SimpleApp::~SimpleApp() {
+SimpleApp::~SimpleApp()
+{
 }
 
-
-void SimpleApp::OnBeforeCommandLineProcessing(
-   const CefString& process_type,
-   CefRefPtr<CefCommandLine> command_line)
+void SimpleApp::OnBeforeCommandLineProcessing(const CefString &process_type, CefRefPtr<CefCommandLine> command_line)
 {
    std::string name = process_type.ToString();
    std::string prog = command_line->GetProgram().ToString();
@@ -70,9 +65,8 @@ void SimpleApp::OnBeforeCommandLineProcessing(
    printf("Start process %s %s\n", name.c_str(), prog.c_str());
 }
 
-
-void SimpleApp::OnBeforeChildProcessLaunch(
-        CefRefPtr<CefCommandLine> command_line) {
+void SimpleApp::OnBeforeChildProcessLaunch(CefRefPtr<CefCommandLine> command_line)
+{
 
    std::string newprog = fCefMain;
 
@@ -83,48 +77,44 @@ void SimpleApp::OnBeforeChildProcessLaunch(
    printf("OnBeforeChildProcessLaunch %s\n", prog.c_str());
 }
 
-
-
-
-
-void SimpleApp::OnContextInitialized() {
-  CEF_REQUIRE_UI_THREAD();
+void SimpleApp::OnContextInitialized()
+{
+   CEF_REQUIRE_UI_THREAD();
 
 #if defined(OS_WIN) || defined(OS_LINUX)
-  // Create the browser using the Views framework if "--use-views" is specified
-  // via the command-line. Otherwise, create the browser using the native
-  // platform framework. The Views framework is currently only supported on
-  // Windows and Linux.
-  const bool use_views = false;
+   // Create the browser using the Views framework if "--use-views" is specified
+   // via the command-line. Otherwise, create the browser using the native
+   // platform framework. The Views framework is currently only supported on
+   // Windows and Linux.
+   const bool use_views = false;
 #else
-  const bool use_views = false;
+   const bool use_views = false;
 #endif
 
-  // SimpleHandler implements browser-level callbacks.
-  CefRefPtr<SimpleHandler> handler(new SimpleHandler(use_views));
+   // SimpleHandler implements browser-level callbacks.
+   CefRefPtr<SimpleHandler> handler(new SimpleHandler(use_views));
 
-  // Specify CEF browser settings here.
-  CefBrowserSettings browser_settings;
+   // Specify CEF browser settings here.
+   CefBrowserSettings browser_settings;
 
-  if (use_views) {
-    // Create the BrowserView.
-    CefRefPtr<CefBrowserView> browser_view = CefBrowserView::CreateBrowserView(
-        handler, fUrl, browser_settings, NULL, NULL);
+   if (use_views) {
+      // Create the BrowserView.
+      CefRefPtr<CefBrowserView> browser_view =
+         CefBrowserView::CreateBrowserView(handler, fUrl, browser_settings, NULL, NULL);
 
-    // Create the Window. It will show itself after creation.
-    CefWindow::CreateTopLevelWindow(new SimpleWindowDelegate(browser_view));
-  } else {
-    // Information used when creating the native window.
-    CefWindowInfo window_info;
+      // Create the Window. It will show itself after creation.
+      CefWindow::CreateTopLevelWindow(new SimpleWindowDelegate(browser_view));
+   } else {
+      // Information used when creating the native window.
+      CefWindowInfo window_info;
 
 #if defined(OS_WIN)
-    // On Windows we need to specify certain flags that will be passed to
-    // CreateWindowEx().
-    window_info.SetAsPopup(NULL, "cefsimple");
+      // On Windows we need to specify certain flags that will be passed to
+      // CreateWindowEx().
+      window_info.SetAsPopup(NULL, "cefsimple");
 #endif
 
-    // Create the first browser window.
-    CefBrowserHost::CreateBrowser(window_info, handler, fUrl, browser_settings,
-                                  NULL);
-  }
+      // Create the first browser window.
+      CefBrowserHost::CreateBrowser(window_info, handler, fUrl, browser_settings, NULL);
+   }
 }

--- a/gui/canvaspainter/v7/cef/simple_app.h
+++ b/gui/canvaspainter/v7/cef/simple_app.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2013 The Chromium Embedded Framework Authors. All rights
+// reserved. Use of this source code is governed by a BSD-style license that
+// can be found in the LICENSE file.
+
+#ifndef CEF_TESTS_CEFSIMPLE_SIMPLE_APP_H_
+#define CEF_TESTS_CEFSIMPLE_SIMPLE_APP_H_
+
+#include "include/cef_app.h"
+
+// Implement application-level callbacks for the browser process.
+class SimpleApp : public CefApp,
+                  public CefBrowserProcessHandler {
+protected:
+   std::string fUrl; ///<! first URL to open
+   std::string fCefMain; ///!< executable used for extra processed
+ public:
+   SimpleApp(const std::string &url, const std::string &cef_main);
+   virtual ~SimpleApp();
+
+  // CefApp methods:
+  virtual CefRefPtr<CefBrowserProcessHandler> GetBrowserProcessHandler()
+      OVERRIDE { return this; }
+
+  // CefBrowserProcessHandler methods:
+  virtual void OnContextInitialized() OVERRIDE;
+
+  void OnBeforeCommandLineProcessing(
+        const CefString& process_type,
+        CefRefPtr<CefCommandLine> command_line) OVERRIDE;
+
+  void OnBeforeChildProcessLaunch(
+          CefRefPtr<CefCommandLine> command_line) OVERRIDE;
+ private:
+  // Include the default reference counting implementation.
+  IMPLEMENT_REFCOUNTING(SimpleApp);
+};
+
+#endif  // CEF_TESTS_CEFSIMPLE_SIMPLE_APP_H_

--- a/gui/canvaspainter/v7/cef/simple_app.h
+++ b/gui/canvaspainter/v7/cef/simple_app.h
@@ -8,31 +8,27 @@
 #include "include/cef_app.h"
 
 // Implement application-level callbacks for the browser process.
-class SimpleApp : public CefApp,
-                  public CefBrowserProcessHandler {
+class SimpleApp : public CefApp, public CefBrowserProcessHandler {
 protected:
-   std::string fUrl; ///<! first URL to open
+   std::string fUrl;     ///<! first URL to open
    std::string fCefMain; ///!< executable used for extra processed
- public:
+public:
    SimpleApp(const std::string &url, const std::string &cef_main);
    virtual ~SimpleApp();
 
-  // CefApp methods:
-  virtual CefRefPtr<CefBrowserProcessHandler> GetBrowserProcessHandler()
-      OVERRIDE { return this; }
+   // CefApp methods:
+   virtual CefRefPtr<CefBrowserProcessHandler> GetBrowserProcessHandler() OVERRIDE { return this; }
 
-  // CefBrowserProcessHandler methods:
-  virtual void OnContextInitialized() OVERRIDE;
+   // CefBrowserProcessHandler methods:
+   virtual void OnContextInitialized() OVERRIDE;
 
-  void OnBeforeCommandLineProcessing(
-        const CefString& process_type,
-        CefRefPtr<CefCommandLine> command_line) OVERRIDE;
+   void OnBeforeCommandLineProcessing(const CefString &process_type, CefRefPtr<CefCommandLine> command_line) OVERRIDE;
 
-  void OnBeforeChildProcessLaunch(
-          CefRefPtr<CefCommandLine> command_line) OVERRIDE;
- private:
-  // Include the default reference counting implementation.
-  IMPLEMENT_REFCOUNTING(SimpleApp);
+   void OnBeforeChildProcessLaunch(CefRefPtr<CefCommandLine> command_line) OVERRIDE;
+
+private:
+   // Include the default reference counting implementation.
+   IMPLEMENT_REFCOUNTING(SimpleApp);
 };
 
-#endif  // CEF_TESTS_CEFSIMPLE_SIMPLE_APP_H_
+#endif // CEF_TESTS_CEFSIMPLE_SIMPLE_APP_H_

--- a/gui/canvaspainter/v7/cef/simple_handler.cxx
+++ b/gui/canvaspainter/v7/cef/simple_handler.cxx
@@ -1,0 +1,134 @@
+// Copyright (c) 2013 The Chromium Embedded Framework Authors. All rights
+// reserved. Use of this source code is governed by a BSD-style license that
+// can be found in the LICENSE file.
+
+#include "simple_handler.h"
+
+#include <sstream>
+#include <string>
+
+#include "include/base/cef_bind.h"
+#include "include/cef_app.h"
+#include "include/views/cef_browser_view.h"
+#include "include/views/cef_window.h"
+#include "include/wrapper/cef_closure_task.h"
+#include "include/wrapper/cef_helpers.h"
+
+
+namespace {
+
+SimpleHandler* g_instance = NULL;
+
+}  // namespace
+
+SimpleHandler::SimpleHandler(bool use_views)
+    : use_views_(use_views),
+      is_closing_(false) {
+  DCHECK(!g_instance);
+  g_instance = this;
+}
+
+SimpleHandler::~SimpleHandler() {
+  g_instance = NULL;
+}
+
+// static
+SimpleHandler* SimpleHandler::GetInstance() {
+  return g_instance;
+}
+
+void SimpleHandler::OnTitleChange(CefRefPtr<CefBrowser> browser,
+                                  const CefString& title) {
+  CEF_REQUIRE_UI_THREAD();
+
+  if (use_views_) {
+    // Set the title of the window using the Views framework.
+    CefRefPtr<CefBrowserView> browser_view =
+        CefBrowserView::GetForBrowser(browser);
+    if (browser_view) {
+      CefRefPtr<CefWindow> window = browser_view->GetWindow();
+      if (window)
+        window->SetTitle(title);
+    }
+  } else {
+    // Set the title of the window using platform APIs.
+    PlatformTitleChange(browser, title);
+  }
+}
+
+void SimpleHandler::OnAfterCreated(CefRefPtr<CefBrowser> browser) {
+  CEF_REQUIRE_UI_THREAD();
+
+  // Add to the list of existing browsers.
+  browser_list_.push_back(browser);
+}
+
+bool SimpleHandler::DoClose(CefRefPtr<CefBrowser> browser) {
+  CEF_REQUIRE_UI_THREAD();
+
+  // Closing the main window requires special handling. See the DoClose()
+  // documentation in the CEF header for a detailed destription of this
+  // process.
+  if (browser_list_.size() == 1) {
+    // Set a flag to indicate that the window close should be allowed.
+    is_closing_ = true;
+  }
+
+  // Allow the close. For windowed browsers this will result in the OS close
+  // event being sent.
+  return false;
+}
+
+void SimpleHandler::OnBeforeClose(CefRefPtr<CefBrowser> browser) {
+  CEF_REQUIRE_UI_THREAD();
+
+  // Remove from the list of existing browsers.
+  BrowserList::iterator bit = browser_list_.begin();
+  for (; bit != browser_list_.end(); ++bit) {
+    if ((*bit)->IsSame(browser)) {
+      browser_list_.erase(bit);
+      break;
+    }
+  }
+
+  if (browser_list_.empty()) {
+    // All browser windows have closed. Quit the application message loop.
+    CefQuitMessageLoop();
+  }
+}
+
+void SimpleHandler::OnLoadError(CefRefPtr<CefBrowser> browser,
+                                CefRefPtr<CefFrame> frame,
+                                ErrorCode errorCode,
+                                const CefString& errorText,
+                                const CefString& failedUrl) {
+  CEF_REQUIRE_UI_THREAD();
+
+  // Don't display an error for downloaded files.
+  if (errorCode == ERR_ABORTED)
+    return;
+
+  // Display a load error message.
+  std::stringstream ss;
+  ss << "<html><body bgcolor=\"white\">"
+        "<h2>Failed to load URL " << std::string(failedUrl) <<
+        " with error " << std::string(errorText) << " (" << errorCode <<
+        ").</h2></body></html>";
+  frame->LoadString(ss.str(), failedUrl);
+}
+
+void SimpleHandler::CloseAllBrowsers(bool force_close) {
+  if (!CefCurrentlyOn(TID_UI)) {
+    // Execute on the UI thread.
+    CefPostTask(TID_UI,
+        base::Bind(&SimpleHandler::CloseAllBrowsers, this, force_close));
+    return;
+  }
+
+  if (browser_list_.empty())
+    return;
+
+  BrowserList::const_iterator it = browser_list_.begin();
+  for (; it != browser_list_.end(); ++it)
+    (*it)->GetHost()->CloseBrowser(force_close);
+}

--- a/gui/canvaspainter/v7/cef/simple_handler.cxx
+++ b/gui/canvaspainter/v7/cef/simple_handler.cxx
@@ -14,121 +14,117 @@
 #include "include/wrapper/cef_closure_task.h"
 #include "include/wrapper/cef_helpers.h"
 
-
 namespace {
 
-SimpleHandler* g_instance = NULL;
+SimpleHandler *g_instance = NULL;
 
-}  // namespace
+} // namespace
 
-SimpleHandler::SimpleHandler(bool use_views)
-    : use_views_(use_views),
-      is_closing_(false) {
-  DCHECK(!g_instance);
-  g_instance = this;
+SimpleHandler::SimpleHandler(bool use_views) : use_views_(use_views), is_closing_(false)
+{
+   DCHECK(!g_instance);
+   g_instance = this;
 }
 
-SimpleHandler::~SimpleHandler() {
-  g_instance = NULL;
+SimpleHandler::~SimpleHandler()
+{
+   g_instance = NULL;
 }
 
 // static
-SimpleHandler* SimpleHandler::GetInstance() {
-  return g_instance;
+SimpleHandler *SimpleHandler::GetInstance()
+{
+   return g_instance;
 }
 
-void SimpleHandler::OnTitleChange(CefRefPtr<CefBrowser> browser,
-                                  const CefString& title) {
-  CEF_REQUIRE_UI_THREAD();
+void SimpleHandler::OnTitleChange(CefRefPtr<CefBrowser> browser, const CefString &title)
+{
+   CEF_REQUIRE_UI_THREAD();
 
-  if (use_views_) {
-    // Set the title of the window using the Views framework.
-    CefRefPtr<CefBrowserView> browser_view =
-        CefBrowserView::GetForBrowser(browser);
-    if (browser_view) {
-      CefRefPtr<CefWindow> window = browser_view->GetWindow();
-      if (window)
-        window->SetTitle(title);
-    }
-  } else {
-    // Set the title of the window using platform APIs.
-    PlatformTitleChange(browser, title);
-  }
+   if (use_views_) {
+      // Set the title of the window using the Views framework.
+      CefRefPtr<CefBrowserView> browser_view = CefBrowserView::GetForBrowser(browser);
+      if (browser_view) {
+         CefRefPtr<CefWindow> window = browser_view->GetWindow();
+         if (window) window->SetTitle(title);
+      }
+   } else {
+      // Set the title of the window using platform APIs.
+      PlatformTitleChange(browser, title);
+   }
 }
 
-void SimpleHandler::OnAfterCreated(CefRefPtr<CefBrowser> browser) {
-  CEF_REQUIRE_UI_THREAD();
+void SimpleHandler::OnAfterCreated(CefRefPtr<CefBrowser> browser)
+{
+   CEF_REQUIRE_UI_THREAD();
 
-  // Add to the list of existing browsers.
-  browser_list_.push_back(browser);
+   // Add to the list of existing browsers.
+   browser_list_.push_back(browser);
 }
 
-bool SimpleHandler::DoClose(CefRefPtr<CefBrowser> browser) {
-  CEF_REQUIRE_UI_THREAD();
+bool SimpleHandler::DoClose(CefRefPtr<CefBrowser> browser)
+{
+   CEF_REQUIRE_UI_THREAD();
 
-  // Closing the main window requires special handling. See the DoClose()
-  // documentation in the CEF header for a detailed destription of this
-  // process.
-  if (browser_list_.size() == 1) {
-    // Set a flag to indicate that the window close should be allowed.
-    is_closing_ = true;
-  }
+   // Closing the main window requires special handling. See the DoClose()
+   // documentation in the CEF header for a detailed destription of this
+   // process.
+   if (browser_list_.size() == 1) {
+      // Set a flag to indicate that the window close should be allowed.
+      is_closing_ = true;
+   }
 
-  // Allow the close. For windowed browsers this will result in the OS close
-  // event being sent.
-  return false;
+   // Allow the close. For windowed browsers this will result in the OS close
+   // event being sent.
+   return false;
 }
 
-void SimpleHandler::OnBeforeClose(CefRefPtr<CefBrowser> browser) {
-  CEF_REQUIRE_UI_THREAD();
+void SimpleHandler::OnBeforeClose(CefRefPtr<CefBrowser> browser)
+{
+   CEF_REQUIRE_UI_THREAD();
 
-  // Remove from the list of existing browsers.
-  BrowserList::iterator bit = browser_list_.begin();
-  for (; bit != browser_list_.end(); ++bit) {
-    if ((*bit)->IsSame(browser)) {
-      browser_list_.erase(bit);
-      break;
-    }
-  }
+   // Remove from the list of existing browsers.
+   BrowserList::iterator bit = browser_list_.begin();
+   for (; bit != browser_list_.end(); ++bit) {
+      if ((*bit)->IsSame(browser)) {
+         browser_list_.erase(bit);
+         break;
+      }
+   }
 
-  if (browser_list_.empty()) {
-    // All browser windows have closed. Quit the application message loop.
-    CefQuitMessageLoop();
-  }
+   if (browser_list_.empty()) {
+      // All browser windows have closed. Quit the application message loop.
+      CefQuitMessageLoop();
+   }
 }
 
-void SimpleHandler::OnLoadError(CefRefPtr<CefBrowser> browser,
-                                CefRefPtr<CefFrame> frame,
-                                ErrorCode errorCode,
-                                const CefString& errorText,
-                                const CefString& failedUrl) {
-  CEF_REQUIRE_UI_THREAD();
+void SimpleHandler::OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, ErrorCode errorCode,
+                                const CefString &errorText, const CefString &failedUrl)
+{
+   CEF_REQUIRE_UI_THREAD();
 
-  // Don't display an error for downloaded files.
-  if (errorCode == ERR_ABORTED)
-    return;
+   // Don't display an error for downloaded files.
+   if (errorCode == ERR_ABORTED) return;
 
-  // Display a load error message.
-  std::stringstream ss;
-  ss << "<html><body bgcolor=\"white\">"
-        "<h2>Failed to load URL " << std::string(failedUrl) <<
-        " with error " << std::string(errorText) << " (" << errorCode <<
-        ").</h2></body></html>";
-  frame->LoadString(ss.str(), failedUrl);
+   // Display a load error message.
+   std::stringstream ss;
+   ss << "<html><body bgcolor=\"white\">"
+         "<h2>Failed to load URL "
+      << std::string(failedUrl) << " with error " << std::string(errorText) << " (" << errorCode
+      << ").</h2></body></html>";
+   frame->LoadString(ss.str(), failedUrl);
 }
 
-void SimpleHandler::CloseAllBrowsers(bool force_close) {
-  if (!CefCurrentlyOn(TID_UI)) {
-    // Execute on the UI thread.
-    CefPostTask(TID_UI,
-        base::Bind(&SimpleHandler::CloseAllBrowsers, this, force_close));
-    return;
-  }
+void SimpleHandler::CloseAllBrowsers(bool force_close)
+{
+   if (!CefCurrentlyOn(TID_UI)) {
+      // Execute on the UI thread.
+      CefPostTask(TID_UI, base::Bind(&SimpleHandler::CloseAllBrowsers, this, force_close));
+      return;
+   }
 
-  if (browser_list_.empty())
-    return;
+   if (browser_list_.empty()) return;
 
-  BrowserList::const_iterator it = browser_list_.begin();
-  for (; it != browser_list_.end(); ++it)
-    (*it)->GetHost()->CloseBrowser(force_close);
+   BrowserList::const_iterator it = browser_list_.begin();
+   for (; it != browser_list_.end(); ++it) (*it)->GetHost()->CloseBrowser(force_close);
 }

--- a/gui/canvaspainter/v7/cef/simple_handler.h
+++ b/gui/canvaspainter/v7/cef/simple_handler.h
@@ -1,0 +1,73 @@
+// Copyright (c) 2013 The Chromium Embedded Framework Authors. All rights
+// reserved. Use of this source code is governed by a BSD-style license that
+// can be found in the LICENSE file.
+
+#ifndef CEF_TESTS_CEFSIMPLE_SIMPLE_HANDLER_H_
+#define CEF_TESTS_CEFSIMPLE_SIMPLE_HANDLER_H_
+
+#include "include/cef_client.h"
+
+#include <list>
+
+class SimpleHandler : public CefClient,
+                      public CefDisplayHandler,
+                      public CefLifeSpanHandler,
+                      public CefLoadHandler {
+ public:
+  explicit SimpleHandler(bool use_views);
+  ~SimpleHandler();
+
+  // Provide access to the single global instance of this object.
+  static SimpleHandler* GetInstance();
+
+  // CefClient methods:
+  virtual CefRefPtr<CefDisplayHandler> GetDisplayHandler() OVERRIDE {
+    return this;
+  }
+  virtual CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() OVERRIDE {
+    return this;
+  }
+  virtual CefRefPtr<CefLoadHandler> GetLoadHandler() OVERRIDE {
+    return this;
+  }
+
+  // CefDisplayHandler methods:
+  virtual void OnTitleChange(CefRefPtr<CefBrowser> browser,
+                             const CefString& title) OVERRIDE;
+
+  // CefLifeSpanHandler methods:
+  virtual void OnAfterCreated(CefRefPtr<CefBrowser> browser) OVERRIDE;
+  virtual bool DoClose(CefRefPtr<CefBrowser> browser) OVERRIDE;
+  virtual void OnBeforeClose(CefRefPtr<CefBrowser> browser) OVERRIDE;
+
+  // CefLoadHandler methods:
+  virtual void OnLoadError(CefRefPtr<CefBrowser> browser,
+                           CefRefPtr<CefFrame> frame,
+                           ErrorCode errorCode,
+                           const CefString& errorText,
+                           const CefString& failedUrl) OVERRIDE;
+
+  // Request that all existing browser windows close.
+  void CloseAllBrowsers(bool force_close);
+
+  bool IsClosing() const { return is_closing_; }
+
+ private:
+  // Platform-specific implementation.
+  void PlatformTitleChange(CefRefPtr<CefBrowser> browser,
+                           const CefString& title);
+
+  // True if the application is using the Views framework.
+  const bool use_views_;
+
+  // List of existing browser windows. Only accessed on the CEF UI thread.
+  typedef std::list<CefRefPtr<CefBrowser> > BrowserList;
+  BrowserList browser_list_;
+
+  bool is_closing_;
+
+  // Include the default reference counting implementation.
+  IMPLEMENT_REFCOUNTING(SimpleHandler);
+};
+
+#endif  // CEF_TESTS_CEFSIMPLE_SIMPLE_HANDLER_H_

--- a/gui/canvaspainter/v7/cef/simple_handler.h
+++ b/gui/canvaspainter/v7/cef/simple_handler.h
@@ -9,65 +9,51 @@
 
 #include <list>
 
-class SimpleHandler : public CefClient,
-                      public CefDisplayHandler,
-                      public CefLifeSpanHandler,
-                      public CefLoadHandler {
- public:
-  explicit SimpleHandler(bool use_views);
-  ~SimpleHandler();
+class SimpleHandler : public CefClient, public CefDisplayHandler, public CefLifeSpanHandler, public CefLoadHandler {
+public:
+   explicit SimpleHandler(bool use_views);
+   ~SimpleHandler();
 
-  // Provide access to the single global instance of this object.
-  static SimpleHandler* GetInstance();
+   // Provide access to the single global instance of this object.
+   static SimpleHandler *GetInstance();
 
-  // CefClient methods:
-  virtual CefRefPtr<CefDisplayHandler> GetDisplayHandler() OVERRIDE {
-    return this;
-  }
-  virtual CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() OVERRIDE {
-    return this;
-  }
-  virtual CefRefPtr<CefLoadHandler> GetLoadHandler() OVERRIDE {
-    return this;
-  }
+   // CefClient methods:
+   virtual CefRefPtr<CefDisplayHandler> GetDisplayHandler() OVERRIDE { return this; }
+   virtual CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() OVERRIDE { return this; }
+   virtual CefRefPtr<CefLoadHandler> GetLoadHandler() OVERRIDE { return this; }
 
-  // CefDisplayHandler methods:
-  virtual void OnTitleChange(CefRefPtr<CefBrowser> browser,
-                             const CefString& title) OVERRIDE;
+   // CefDisplayHandler methods:
+   virtual void OnTitleChange(CefRefPtr<CefBrowser> browser, const CefString &title) OVERRIDE;
 
-  // CefLifeSpanHandler methods:
-  virtual void OnAfterCreated(CefRefPtr<CefBrowser> browser) OVERRIDE;
-  virtual bool DoClose(CefRefPtr<CefBrowser> browser) OVERRIDE;
-  virtual void OnBeforeClose(CefRefPtr<CefBrowser> browser) OVERRIDE;
+   // CefLifeSpanHandler methods:
+   virtual void OnAfterCreated(CefRefPtr<CefBrowser> browser) OVERRIDE;
+   virtual bool DoClose(CefRefPtr<CefBrowser> browser) OVERRIDE;
+   virtual void OnBeforeClose(CefRefPtr<CefBrowser> browser) OVERRIDE;
 
-  // CefLoadHandler methods:
-  virtual void OnLoadError(CefRefPtr<CefBrowser> browser,
-                           CefRefPtr<CefFrame> frame,
-                           ErrorCode errorCode,
-                           const CefString& errorText,
-                           const CefString& failedUrl) OVERRIDE;
+   // CefLoadHandler methods:
+   virtual void OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, ErrorCode errorCode,
+                            const CefString &errorText, const CefString &failedUrl) OVERRIDE;
 
-  // Request that all existing browser windows close.
-  void CloseAllBrowsers(bool force_close);
+   // Request that all existing browser windows close.
+   void CloseAllBrowsers(bool force_close);
 
-  bool IsClosing() const { return is_closing_; }
+   bool IsClosing() const { return is_closing_; }
 
- private:
-  // Platform-specific implementation.
-  void PlatformTitleChange(CefRefPtr<CefBrowser> browser,
-                           const CefString& title);
+private:
+   // Platform-specific implementation.
+   void PlatformTitleChange(CefRefPtr<CefBrowser> browser, const CefString &title);
 
-  // True if the application is using the Views framework.
-  const bool use_views_;
+   // True if the application is using the Views framework.
+   const bool use_views_;
 
-  // List of existing browser windows. Only accessed on the CEF UI thread.
-  typedef std::list<CefRefPtr<CefBrowser> > BrowserList;
-  BrowserList browser_list_;
+   // List of existing browser windows. Only accessed on the CEF UI thread.
+   typedef std::list<CefRefPtr<CefBrowser>> BrowserList;
+   BrowserList browser_list_;
 
-  bool is_closing_;
+   bool is_closing_;
 
-  // Include the default reference counting implementation.
-  IMPLEMENT_REFCOUNTING(SimpleHandler);
+   // Include the default reference counting implementation.
+   IMPLEMENT_REFCOUNTING(SimpleHandler);
 };
 
-#endif  // CEF_TESTS_CEFSIMPLE_SIMPLE_HANDLER_H_
+#endif // CEF_TESTS_CEFSIMPLE_SIMPLE_HANDLER_H_

--- a/gui/canvaspainter/v7/cef/simple_handler_linux.cxx
+++ b/gui/canvaspainter/v7/cef/simple_handler_linux.cxx
@@ -1,0 +1,54 @@
+// Copyright (c) 2014 The Chromium Embedded Framework Authors. All rights
+// reserved. Use of this source code is governed by a BSD-style license that
+// can be found in the LICENSE file.
+
+#include "simple_handler.h"
+
+
+#include <X11/Xatom.h>
+#include <X11/Xlib.h>
+#include <string>
+
+#include "include/base/cef_logging.h"
+#include "include/cef_browser.h"
+
+void SimpleHandler::PlatformTitleChange(CefRefPtr<CefBrowser> browser,
+                                        const CefString& title) {
+  std::string titleStr(title);
+
+  // Retrieve the X11 display shared with Chromium.
+  ::Display* display = cef_get_xdisplay();
+  DCHECK(display);
+
+  // Retrieve the X11 window handle for the browser.
+  ::Window window = browser->GetHost()->GetWindowHandle();
+  DCHECK(window != kNullWindowHandle);
+
+  // Retrieve the atoms required by the below XChangeProperty call.
+  const char* kAtoms[] = {
+    "_NET_WM_NAME",
+    "UTF8_STRING"
+  };
+  Atom atoms[2];
+  int result = XInternAtoms(display, const_cast<char**>(kAtoms), 2, false,
+                            atoms);
+  if (!result)
+    NOTREACHED();
+
+  // Set the window title.
+  XChangeProperty(display,
+                  window,
+                  atoms[0],
+                  atoms[1],
+                  8,
+                  PropModeReplace,
+                  reinterpret_cast<const unsigned char*>(titleStr.c_str()),
+                  titleStr.size());
+
+  // TODO(erg): This is technically wrong. So XStoreName and friends expect
+  // this in Host Portable Character Encoding instead of UTF-8, which I believe
+  // is Compound Text. This shouldn't matter 90% of the time since this is the
+  // fallback to the UTF8 property above.
+  XStoreName(display, browser->GetHost()->GetWindowHandle(), titleStr.c_str());
+}
+

--- a/gui/canvaspainter/v7/cef/simple_handler_linux.cxx
+++ b/gui/canvaspainter/v7/cef/simple_handler_linux.cxx
@@ -4,7 +4,6 @@
 
 #include "simple_handler.h"
 
-
 #include <X11/Xatom.h>
 #include <X11/Xlib.h>
 #include <string>
@@ -12,43 +11,31 @@
 #include "include/base/cef_logging.h"
 #include "include/cef_browser.h"
 
-void SimpleHandler::PlatformTitleChange(CefRefPtr<CefBrowser> browser,
-                                        const CefString& title) {
-  std::string titleStr(title);
+void SimpleHandler::PlatformTitleChange(CefRefPtr<CefBrowser> browser, const CefString &title)
+{
+   std::string titleStr(title);
 
-  // Retrieve the X11 display shared with Chromium.
-  ::Display* display = cef_get_xdisplay();
-  DCHECK(display);
+   // Retrieve the X11 display shared with Chromium.
+   ::Display *display = cef_get_xdisplay();
+   DCHECK(display);
 
-  // Retrieve the X11 window handle for the browser.
-  ::Window window = browser->GetHost()->GetWindowHandle();
-  DCHECK(window != kNullWindowHandle);
+   // Retrieve the X11 window handle for the browser.
+   ::Window window = browser->GetHost()->GetWindowHandle();
+   DCHECK(window != kNullWindowHandle);
 
-  // Retrieve the atoms required by the below XChangeProperty call.
-  const char* kAtoms[] = {
-    "_NET_WM_NAME",
-    "UTF8_STRING"
-  };
-  Atom atoms[2];
-  int result = XInternAtoms(display, const_cast<char**>(kAtoms), 2, false,
-                            atoms);
-  if (!result)
-    NOTREACHED();
+   // Retrieve the atoms required by the below XChangeProperty call.
+   const char *kAtoms[] = {"_NET_WM_NAME", "UTF8_STRING"};
+   Atom atoms[2];
+   int result = XInternAtoms(display, const_cast<char **>(kAtoms), 2, false, atoms);
+   if (!result) NOTREACHED();
 
-  // Set the window title.
-  XChangeProperty(display,
-                  window,
-                  atoms[0],
-                  atoms[1],
-                  8,
-                  PropModeReplace,
-                  reinterpret_cast<const unsigned char*>(titleStr.c_str()),
-                  titleStr.size());
+   // Set the window title.
+   XChangeProperty(display, window, atoms[0], atoms[1], 8, PropModeReplace,
+                   reinterpret_cast<const unsigned char *>(titleStr.c_str()), titleStr.size());
 
-  // TODO(erg): This is technically wrong. So XStoreName and friends expect
-  // this in Host Portable Character Encoding instead of UTF-8, which I believe
-  // is Compound Text. This shouldn't matter 90% of the time since this is the
-  // fallback to the UTF8 property above.
-  XStoreName(display, browser->GetHost()->GetWindowHandle(), titleStr.c_str());
+   // TODO(erg): This is technically wrong. So XStoreName and friends expect
+   // this in Host Portable Character Encoding instead of UTF-8, which I believe
+   // is Compound Text. This shouldn't matter 90% of the time since this is the
+   // fallback to the UTF8 property above.
+   XStoreName(display, browser->GetHost()->GetWindowHandle(), titleStr.c_str());
 }
-

--- a/gui/canvaspainter/v7/cef/simple_handler_mac.mm
+++ b/gui/canvaspainter/v7/cef/simple_handler_mac.mm
@@ -1,0 +1,18 @@
+// Copyright (c) 2013 The Chromium Embedded Framework Authors. All rights
+// reserved. Use of this source code is governed by a BSD-style license that
+// can be found in the LICENSE file.
+
+#include "tests/cefsimple/simple_handler.h"
+
+#import <Cocoa/Cocoa.h>
+
+#include "include/cef_browser.h"
+
+void SimpleHandler::PlatformTitleChange(CefRefPtr<CefBrowser> browser,
+                                        const CefString& title) {
+  NSView* view = (NSView*)browser->GetHost()->GetWindowHandle();
+  NSWindow* window = [view window];
+  std::string titleStr(title);
+  NSString* str = [NSString stringWithUTF8String:titleStr.c_str()];
+  [window setTitle:str];
+}

--- a/gui/canvaspainter/v7/cef/simple_handler_mac.mm
+++ b/gui/canvaspainter/v7/cef/simple_handler_mac.mm
@@ -8,11 +8,11 @@
 
 #include "include/cef_browser.h"
 
-void SimpleHandler::PlatformTitleChange(CefRefPtr<CefBrowser> browser,
-                                        const CefString& title) {
-  NSView* view = (NSView*)browser->GetHost()->GetWindowHandle();
-  NSWindow* window = [view window];
-  std::string titleStr(title);
-  NSString* str = [NSString stringWithUTF8String:titleStr.c_str()];
-  [window setTitle:str];
+void SimpleHandler::PlatformTitleChange(CefRefPtr<CefBrowser> browser, const CefString &title)
+{
+   NSView *view = (NSView *)browser->GetHost()->GetWindowHandle();
+   NSWindow *window = [view window];
+   std::string titleStr(title);
+   NSString *str = [NSString stringWithUTF8String:titleStr.c_str()];
+   [window setTitle:str];
 }

--- a/gui/canvaspainter/v7/qt5/.gitignore
+++ b/gui/canvaspainter/v7/qt5/.gitignore
@@ -1,0 +1,4 @@
+Makefile
+rootqt5
+moc_rootwebview.cpp
+.qmake.stash

--- a/gui/canvaspainter/v7/qt5/.gitignore
+++ b/gui/canvaspainter/v7/qt5/.gitignore
@@ -2,3 +2,4 @@ Makefile
 rootqt5
 moc_rootwebview.cpp
 .qmake.stash
+moc_predefs.h

--- a/gui/canvaspainter/v7/qt5/.gitignore
+++ b/gui/canvaspainter/v7/qt5/.gitignore
@@ -1,5 +1,6 @@
 Makefile
 rootqt5
 moc_rootwebview.cpp
+moc_rootwebpage.cpp
 .qmake.stash
 moc_predefs.h

--- a/gui/canvaspainter/v7/qt5/rootqt5.cpp
+++ b/gui/canvaspainter/v7/qt5/rootqt5.cpp
@@ -1,0 +1,275 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: http://www.qt.io/licensing/
+**
+** This file is part of the examples of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:BSD$
+** You may use this file under the terms of the BSD license as follows:
+**
+** "Redistribution and use in source and binary forms, with or without
+** modification, are permitted provided that the following conditions are
+** met:
+**   * Redistributions of source code must retain the above copyright
+**     notice, this list of conditions and the following disclaimer.
+**   * Redistributions in binary form must reproduce the above copyright
+**     notice, this list of conditions and the following disclaimer in
+**     the documentation and/or other materials provided with the
+**     distribution.
+**   * Neither the name of The Qt Company Ltd nor the names of its
+**     contributors may be used to endorse or promote products derived
+**     from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+** "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+** LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+** A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+** OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+** LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+** DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+** THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+** (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include <QApplication>
+// #include <QQmlApplicationEngine>
+#include <qwebengineview.h>
+#include <qtwebengineglobal.h>
+#include <QThread>
+
+
+#include <QWebEngineUrlSchemeHandler>
+#include <QWebEngineProfile>
+#include <QWebEngineUrlRequestJob>
+#include <QWebEngineUrlRequestInterceptor>
+#include <QWebEngineUrlRequestInfo>
+#include <QBuffer>
+#include <QFile>
+
+#include "TROOT.h"
+#include "TApplication.h"
+#include "TRint.h"
+#include "TTimer.h"
+#include "TThread.h"
+#include "THttpServer.h"
+#include "THttpCallArg.h"
+
+#include "rootwebview.h"
+
+class TQt5Timer : public TTimer {
+public:
+   TQt5Timer(Long_t milliSec, Bool_t mode) : TTimer(milliSec, mode)
+   {
+      // construtor
+   }
+   virtual ~TQt5Timer()
+   {
+      // destructor
+   }
+   virtual void Timeout()
+   {
+      // timeout handler
+      // used to process http requests in main ROOT thread
+
+      QApplication::sendPostedEvents();
+      QApplication::processEvents();
+   }
+};
+
+THttpServer *server = 0;
+
+
+// TODO: memory cleanup of these arguments
+class TWebGuiCallArg : public THttpCallArg {
+protected:
+
+   QWebEngineUrlRequestJob *fRequest;
+   int  fDD;
+
+public:
+   TWebGuiCallArg(QWebEngineUrlRequestJob *req) : THttpCallArg(), fRequest(req), fDD(0) {  }
+   virtual ~TWebGuiCallArg() { if (fDD!=1) printf("FAAAAAAAAAAAAAIL %d\n", fDD); }
+
+   void SendFile(const char *fname) {
+      const char *mime = THttpServer::GetMimeType(fname);
+
+      printf("Sending file %s\n", fname);
+
+      QBuffer *buffer = new QBuffer;
+      fRequest->connect(fRequest, SIGNAL(destroyed()), buffer, SLOT(deleteLater()));
+
+      QFile file(fname);
+      buffer->open(QIODevice::WriteOnly);
+      if (file.open(QIODevice::ReadOnly)) {
+         QByteArray arr = file.readAll();
+         buffer->write(arr);
+      }
+      file.close();
+      buffer->close();
+
+      fRequest->reply(mime, buffer); fDD++;
+   }
+
+   virtual void HttpReplied() {
+
+      if (Is404()) {
+         printf("Request MISS %s %s\n", GetPathName(), GetFileName());
+
+         fRequest->fail(QWebEngineUrlRequestJob::UrlNotFound); fDD++;
+         // abort request
+      } else if (IsFile()) {
+         // send file
+         SendFile((const char *)GetContent());
+      } else {
+
+         // printf("Reply %s %s typ:%s res:%ld\n", GetPathName(), GetFileName(), GetContentType(), GetContentLength());
+         // if (GetContentLength()<100) printf("BODY:%s\n", (const char*) GetContent());
+
+         QBuffer *buffer = new QBuffer;
+         fRequest->connect(fRequest, SIGNAL(destroyed()), buffer, SLOT(deleteLater()));
+
+         buffer->setData((const char *) GetContent(), GetContentLength());
+
+         fRequest->reply(GetContentType(), buffer); fDD++;
+      }
+   }
+
+};
+
+class ROOTSchemeHandler : public QWebEngineUrlSchemeHandler {
+public:
+   ROOTSchemeHandler(QObject *p = Q_NULLPTR) : QWebEngineUrlSchemeHandler(p) {}
+
+   virtual void requestStarted(QWebEngineUrlRequestJob *request) {
+
+      QUrl url = request->requestUrl();
+
+      QByteArray ba = url.toString().toLatin1();
+
+      // printf("[%ld] Request started %s\n", TThread::SelfId(), ba.data());
+
+      if (server==0) {
+         server = (THttpServer*) gROOT->ProcessLine("TWebGuiFactory::GetHttpServer()");
+         printf("Get HTTP server %p\n", server);
+         if (!server) {
+            printf("FAIL to get server\n");
+            return;
+         }
+      }
+
+      TWebGuiCallArg* arg = new TWebGuiCallArg(request);
+
+      QString inp_path = url.path();
+      QString inp_query = url.query();
+      QString inp_method = request->requestMethod();
+
+      TString fname;
+
+      if (server->IsFileRequested(inp_path.toLatin1().data(), fname)) {
+
+         arg->SendFile(fname.Data());
+         delete arg;
+         // process file
+         return;
+      }
+
+      arg->SetPathAndFileName(inp_path.toLatin1().data());
+      arg->SetQuery(inp_query.toLatin1().data());
+      arg->SetMethod(inp_method.toLatin1().data());
+      arg->SetTopName("webgui");
+
+      // TODO: POST buffer
+
+      // printf("SUBMIT %s %s\n", arg->GetPathName(), arg->GetFileName());
+
+      server->SubmitHttp(arg);
+   }
+};
+
+class ROOTRequestInterceptor : public QWebEngineUrlRequestInterceptor {
+public:
+    ROOTRequestInterceptor(QObject *p = Q_NULLPTR) : QWebEngineUrlRequestInterceptor(p) {}
+    virtual void interceptRequest(QWebEngineUrlRequestInfo &info) {
+
+       QUrl url = info.requestUrl();
+
+       QByteArray ba = url.toString().toLatin1();
+
+       printf("[%ld] Request intercepted %s\n", TThread::SelfId(), ba.data());
+
+    }
+};
+
+extern "C" void webgui_start_browser_new(const char *url)
+{
+
+   // webgui_initapp();
+
+   printf("Start %s\n", url);
+
+   RootWebView *view = new RootWebView();
+   view->load(QUrl(url));
+   view->show();
+}
+
+
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+
+    int argc2 = 1;
+    char *argv2[10];
+    argv2[0] = argv[0];
+
+    // printf("[%ld] Start minimal app\n", TThread::SelfId());
+
+    QApplication app(argc2, argv2);
+
+
+    QtWebEngine::initialize();
+
+    //QQmlApplicationEngine engine;
+    //engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
+    //engine.load(QUrl("http://jsroot.gsi.de/dev/examples.htm"));
+
+    TRint* d = new TRint("Rint", &argc, argv);
+    TQt5Timer *timer = new TQt5Timer(10, kTRUE);
+    timer->TurnOn();
+
+
+    // use only for debugging or may be for redirection
+    //QWebEngineProfile::defaultProfile()->setRequestInterceptor(new ROOTRequestInterceptor());
+
+    const QByteArray EXAMPLE_SCHEMA_HANDLER = QByteArray("example");
+
+    ROOTSchemeHandler* handler = new ROOTSchemeHandler();
+
+    QWebEngineProfile::defaultProfile()->installUrlSchemeHandler(EXAMPLE_SCHEMA_HANDLER, handler);
+
+    // const QWebEngineUrlSchemeHandler* installed = QWebEngineProfile::defaultProfile()->urlSchemeHandler(EXAMPLE_SCHEMA_HANDLER);
+
+    //QWebEngineView *view = new QWebEngineView();
+    //view->load(QUrl("http://jsroot.gsi.de/dev/examples.htm"));
+    //view->show();
+
+    d->Run();
+
+    //while (true) {
+    //   QApplication::processEvents();
+    //   QApplication::sendPostedEvents();
+    //   QThread::msleep(10);
+    // }
+
+    return 0;
+
+    // return app.exec();
+}
+

--- a/gui/canvaspainter/v7/qt5/rootqt5.cpp
+++ b/gui/canvaspainter/v7/qt5/rootqt5.cpp
@@ -2,8 +2,8 @@
 /// \ingroup CanvasPainter ROOT7
 /// \author Sergey Linev <S.Linev@gsi.de>
 /// \date 2017-06-29
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
-
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
@@ -18,7 +18,6 @@
 #include <qwebengineview.h>
 #include <qtwebengineglobal.h>
 #include <QThread>
-
 
 #include <QWebEngineUrlSchemeHandler>
 #include <QWebEngineProfile>
@@ -60,19 +59,21 @@ public:
 
 THttpServer *server = 0;
 
-
 // TODO: memory cleanup of these arguments
 class TWebGuiCallArg : public THttpCallArg {
 protected:
-
    QWebEngineUrlRequestJob *fRequest;
-   int  fDD;
+   int fDD;
 
 public:
-   TWebGuiCallArg(QWebEngineUrlRequestJob *req) : THttpCallArg(), fRequest(req), fDD(0) {  }
-   virtual ~TWebGuiCallArg() { if (fDD!=1) printf("FAAAAAAAAAAAAAIL %d\n", fDD); }
+   TWebGuiCallArg(QWebEngineUrlRequestJob *req) : THttpCallArg(), fRequest(req), fDD(0) {}
+   virtual ~TWebGuiCallArg()
+   {
+      if (fDD != 1) printf("FAAAAAAAAAAAAAIL %d\n", fDD);
+   }
 
-   void SendFile(const char *fname) {
+   void SendFile(const char *fname)
+   {
       const char *mime = THttpServer::GetMimeType(fname);
 
       printf("Sending file %s\n", fname);
@@ -89,15 +90,18 @@ public:
       file.close();
       buffer->close();
 
-      fRequest->reply(mime, buffer); fDD++;
+      fRequest->reply(mime, buffer);
+      fDD++;
    }
 
-   virtual void HttpReplied() {
+   virtual void HttpReplied()
+   {
 
       if (Is404()) {
          printf("Request MISS %s %s\n", GetPathName(), GetFileName());
 
-         fRequest->fail(QWebEngineUrlRequestJob::UrlNotFound); fDD++;
+         fRequest->fail(QWebEngineUrlRequestJob::UrlNotFound);
+         fDD++;
          // abort request
       } else if (IsFile()) {
          // send file
@@ -110,19 +114,20 @@ public:
          QBuffer *buffer = new QBuffer;
          fRequest->connect(fRequest, SIGNAL(destroyed()), buffer, SLOT(deleteLater()));
 
-         buffer->setData((const char *) GetContent(), GetContentLength());
+         buffer->setData((const char *)GetContent(), GetContentLength());
 
-         fRequest->reply(GetContentType(), buffer); fDD++;
+         fRequest->reply(GetContentType(), buffer);
+         fDD++;
       }
    }
-
 };
 
 class ROOTSchemeHandler : public QWebEngineUrlSchemeHandler {
 public:
    ROOTSchemeHandler(QObject *p = Q_NULLPTR) : QWebEngineUrlSchemeHandler(p) {}
 
-   virtual void requestStarted(QWebEngineUrlRequestJob *request) {
+   virtual void requestStarted(QWebEngineUrlRequestJob *request)
+   {
 
       QUrl url = request->requestUrl();
 
@@ -130,8 +135,8 @@ public:
 
       // printf("[%ld] Request started %s\n", TThread::SelfId(), ba.data());
 
-      if (server==0) {
-         server = (THttpServer*) gROOT->ProcessLine("TWebGuiFactory::GetHttpServer()");
+      if (server == 0) {
+         server = (THttpServer *)gROOT->ProcessLine("TWebGuiFactory::GetHttpServer()");
          printf("Get HTTP server %p\n", server);
          if (!server) {
             printf("FAIL to get server\n");
@@ -139,7 +144,7 @@ public:
          }
       }
 
-      TWebGuiCallArg* arg = new TWebGuiCallArg(request);
+      TWebGuiCallArg *arg = new TWebGuiCallArg(request);
 
       QString inp_path = url.path();
       QString inp_query = url.query();
@@ -170,16 +175,16 @@ public:
 
 class ROOTRequestInterceptor : public QWebEngineUrlRequestInterceptor {
 public:
-    ROOTRequestInterceptor(QObject *p = Q_NULLPTR) : QWebEngineUrlRequestInterceptor(p) {}
-    virtual void interceptRequest(QWebEngineUrlRequestInfo &info) {
+   ROOTRequestInterceptor(QObject *p = Q_NULLPTR) : QWebEngineUrlRequestInterceptor(p) {}
+   virtual void interceptRequest(QWebEngineUrlRequestInfo &info)
+   {
 
-       QUrl url = info.requestUrl();
+      QUrl url = info.requestUrl();
 
-       QByteArray ba = url.toString().toLatin1();
+      QByteArray ba = url.toString().toLatin1();
 
-       printf("[%ld] Request intercepted %s\n", TThread::SelfId(), ba.data());
-
-    }
+      printf("[%ld] Request intercepted %s\n", TThread::SelfId(), ba.data());
+   }
 };
 
 extern "C" void webgui_start_browser_new(const char *url)
@@ -194,57 +199,53 @@ extern "C" void webgui_start_browser_new(const char *url)
    view->show();
 }
 
-
-
 int main(int argc, char *argv[])
 {
-    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+   QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 
-    int argc2 = 1;
-    char *argv2[10];
-    argv2[0] = argv[0];
+   int argc2 = 1;
+   char *argv2[10];
+   argv2[0] = argv[0];
 
-    // printf("[%ld] Start minimal app\n", TThread::SelfId());
+   // printf("[%ld] Start minimal app\n", TThread::SelfId());
 
-    QApplication app(argc2, argv2);
+   QApplication app(argc2, argv2);
 
+   QtWebEngine::initialize();
 
-    QtWebEngine::initialize();
+   // QQmlApplicationEngine engine;
+   // engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
+   // engine.load(QUrl("http://jsroot.gsi.de/dev/examples.htm"));
 
-    //QQmlApplicationEngine engine;
-    //engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
-    //engine.load(QUrl("http://jsroot.gsi.de/dev/examples.htm"));
+   TRint *d = new TRint("Rint", &argc, argv);
+   TQt5Timer *timer = new TQt5Timer(10, kTRUE);
+   timer->TurnOn();
 
-    TRint* d = new TRint("Rint", &argc, argv);
-    TQt5Timer *timer = new TQt5Timer(10, kTRUE);
-    timer->TurnOn();
+   // use only for debugging or may be for redirection
+   // QWebEngineProfile::defaultProfile()->setRequestInterceptor(new ROOTRequestInterceptor());
 
+   const QByteArray EXAMPLE_SCHEMA_HANDLER = QByteArray("example");
 
-    // use only for debugging or may be for redirection
-    //QWebEngineProfile::defaultProfile()->setRequestInterceptor(new ROOTRequestInterceptor());
+   ROOTSchemeHandler *handler = new ROOTSchemeHandler();
 
-    const QByteArray EXAMPLE_SCHEMA_HANDLER = QByteArray("example");
+   QWebEngineProfile::defaultProfile()->installUrlSchemeHandler(EXAMPLE_SCHEMA_HANDLER, handler);
 
-    ROOTSchemeHandler* handler = new ROOTSchemeHandler();
+   // const QWebEngineUrlSchemeHandler* installed =
+   // QWebEngineProfile::defaultProfile()->urlSchemeHandler(EXAMPLE_SCHEMA_HANDLER);
 
-    QWebEngineProfile::defaultProfile()->installUrlSchemeHandler(EXAMPLE_SCHEMA_HANDLER, handler);
+   // QWebEngineView *view = new QWebEngineView();
+   // view->load(QUrl("http://jsroot.gsi.de/dev/examples.htm"));
+   // view->show();
 
-    // const QWebEngineUrlSchemeHandler* installed = QWebEngineProfile::defaultProfile()->urlSchemeHandler(EXAMPLE_SCHEMA_HANDLER);
+   d->Run();
 
-    //QWebEngineView *view = new QWebEngineView();
-    //view->load(QUrl("http://jsroot.gsi.de/dev/examples.htm"));
-    //view->show();
+   // while (true) {
+   //   QApplication::processEvents();
+   //   QApplication::sendPostedEvents();
+   //   QThread::msleep(10);
+   // }
 
-    d->Run();
+   return 0;
 
-    //while (true) {
-    //   QApplication::processEvents();
-    //   QApplication::sendPostedEvents();
-    //   QThread::msleep(10);
-    // }
-
-    return 0;
-
-    // return app.exec();
+   // return app.exec();
 }
-

--- a/gui/canvaspainter/v7/qt5/rootqt5.cpp
+++ b/gui/canvaspainter/v7/qt5/rootqt5.cpp
@@ -1,42 +1,17 @@
-/****************************************************************************
-**
-** Copyright (C) 2016 The Qt Company Ltd.
-** Contact: http://www.qt.io/licensing/
-**
-** This file is part of the examples of the Qt Toolkit.
-**
-** $QT_BEGIN_LICENSE:BSD$
-** You may use this file under the terms of the BSD license as follows:
-**
-** "Redistribution and use in source and binary forms, with or without
-** modification, are permitted provided that the following conditions are
-** met:
-**   * Redistributions of source code must retain the above copyright
-**     notice, this list of conditions and the following disclaimer.
-**   * Redistributions in binary form must reproduce the above copyright
-**     notice, this list of conditions and the following disclaimer in
-**     the documentation and/or other materials provided with the
-**     distribution.
-**   * Neither the name of The Qt Company Ltd nor the names of its
-**     contributors may be used to endorse or promote products derived
-**     from this software without specific prior written permission.
-**
-**
-** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-** "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-** LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-** A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-** OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-** LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-** DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-** THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-** (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
-**
-** $QT_END_LICENSE$
-**
-****************************************************************************/
+/// \file rootqt5.cpp
+/// \ingroup CanvasPainter ROOT7
+/// \author Sergey Linev <S.Linev@gsi.de>
+/// \date 2017-06-29
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+
+
+/*************************************************************************
+ * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
 
 #include <QApplication>
 // #include <QQmlApplicationEngine>

--- a/gui/canvaspainter/v7/qt5/rootqt5.pro
+++ b/gui/canvaspainter/v7/qt5/rootqt5.pro
@@ -1,0 +1,18 @@
+TEMPLATE = app
+
+QT += webengine webenginewidgets
+
+HEADERS += rootwebview.h
+
+SOURCES += rootwebview.cpp rootqt5.cpp
+
+# RESOURCES += qml.qrc
+
+target.path = .
+# INSTALLS += target
+
+INCLUDEPATH += $$system(root-config --incdir)
+
+LIBS += $$system(root-config --glibs) -lRHTTP
+
+#LIBS += -Wl,-rpath,/home/linev/soft/build6/lib -L/home/linev/soft/build6/lib -lGui -lCore -lRIO -lNet -lHist -lGraf -lGraf3d -lGpad -lTree -lRint -lPostscript -lMatrix -lPhysics -lMathCore -lThread -lMultiProc -pthread -lm -ldl -rdynamic

--- a/gui/canvaspainter/v7/qt5/rootqt5.pro
+++ b/gui/canvaspainter/v7/qt5/rootqt5.pro
@@ -2,9 +2,12 @@ TEMPLATE = app
 
 QT += webengine webenginewidgets
 
-HEADERS += rootwebview.h
+HEADERS += rootwebpage.h \
+           rootwebview.h
 
-SOURCES += rootwebview.cpp rootqt5.cpp
+SOURCES += rootwebpage.cpp \
+           rootwebview.cpp \
+           rootqt5.cpp
 
 target.path = .
 

--- a/gui/canvaspainter/v7/qt5/rootqt5.pro
+++ b/gui/canvaspainter/v7/qt5/rootqt5.pro
@@ -6,13 +6,8 @@ HEADERS += rootwebview.h
 
 SOURCES += rootwebview.cpp rootqt5.cpp
 
-# RESOURCES += qml.qrc
-
 target.path = .
-# INSTALLS += target
 
 INCLUDEPATH += $$system(root-config --incdir)
 
 LIBS += $$system(root-config --glibs) -lRHTTP
-
-#LIBS += -Wl,-rpath,/home/linev/soft/build6/lib -L/home/linev/soft/build6/lib -lGui -lCore -lRIO -lNet -lHist -lGraf -lGraf3d -lGpad -lTree -lRint -lPostscript -lMatrix -lPhysics -lMathCore -lThread -lMultiProc -pthread -lm -ldl -rdynamic

--- a/gui/canvaspainter/v7/qt5/rootwebpage.cpp
+++ b/gui/canvaspainter/v7/qt5/rootwebpage.cpp
@@ -1,4 +1,4 @@
-/// \file rootwebview.h
+/// \file rootwebpage.cpp
 /// \ingroup CanvasPainter ROOT7
 /// \author Sergey Linev <S.Linev@gsi.de>
 /// \date 2017-06-29
@@ -12,19 +12,16 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#ifndef ROOT_RootWebView
-#define ROOT_RootWebView
 
-#include <QWebEngineView>
+#include "rootwebpage.h"
 
-class RootWebView : public QWebEngineView {
-   Q_OBJECT
-protected:
+#include <stdio.h>
 
-public:
-   RootWebView(QWidget* parent = 0);
-   virtual ~RootWebView();
+void RootWebPage::javaScriptConsoleMessage(JavaScriptConsoleMessageLevel,
+                      const QString &message, int lineNumber, const QString &sourceID)
+{
+   QByteArray ba = message.toLatin1();
+   QByteArray src = sourceID.toLatin1();
 
-};
-
-#endif
+   printf("CONSOLE %s:%d: %s\n", src.data(), lineNumber, ba.data());
+}

--- a/gui/canvaspainter/v7/qt5/rootwebpage.cpp
+++ b/gui/canvaspainter/v7/qt5/rootwebpage.cpp
@@ -2,7 +2,8 @@
 /// \ingroup CanvasPainter ROOT7
 /// \author Sergey Linev <S.Linev@gsi.de>
 /// \date 2017-06-29
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
@@ -12,13 +13,12 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-
 #include "rootwebpage.h"
 
 #include <stdio.h>
 
-void RootWebPage::javaScriptConsoleMessage(JavaScriptConsoleMessageLevel,
-                      const QString &message, int lineNumber, const QString &sourceID)
+void RootWebPage::javaScriptConsoleMessage(JavaScriptConsoleMessageLevel, const QString &message, int lineNumber,
+                                           const QString &sourceID)
 {
    QByteArray ba = message.toLatin1();
    QByteArray src = sourceID.toLatin1();

--- a/gui/canvaspainter/v7/qt5/rootwebpage.h
+++ b/gui/canvaspainter/v7/qt5/rootwebpage.h
@@ -1,4 +1,4 @@
-/// \file rootwebview.h
+/// \file rootwebpage.h
 /// \ingroup CanvasPainter ROOT7
 /// \author Sergey Linev <S.Linev@gsi.de>
 /// \date 2017-06-29
@@ -12,18 +12,21 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#ifndef ROOT_RootWebView
-#define ROOT_RootWebView
+#ifndef ROOT_RootWebPage
+#define ROOT_RootWebPage
 
-#include <QWebEngineView>
+#include <QWebEnginePage>
 
-class RootWebView : public QWebEngineView {
+class RootWebPage : public QWebEnginePage {
    Q_OBJECT
 protected:
+   virtual void javaScriptConsoleMessage(QWebEnginePage::JavaScriptConsoleMessageLevel level,
+                      const QString &message, int lineNumber, const QString &sourceID);
 
 public:
-   RootWebView(QWidget* parent = 0);
-   virtual ~RootWebView();
+
+   RootWebPage(QObject *parent = 0) : QWebEnginePage(parent) {}
+   virtual ~RootWebPage() {}
 
 };
 

--- a/gui/canvaspainter/v7/qt5/rootwebpage.h
+++ b/gui/canvaspainter/v7/qt5/rootwebpage.h
@@ -2,7 +2,8 @@
 /// \ingroup CanvasPainter ROOT7
 /// \author Sergey Linev <S.Linev@gsi.de>
 /// \date 2017-06-29
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
@@ -20,14 +21,12 @@
 class RootWebPage : public QWebEnginePage {
    Q_OBJECT
 protected:
-   virtual void javaScriptConsoleMessage(QWebEnginePage::JavaScriptConsoleMessageLevel level,
-                      const QString &message, int lineNumber, const QString &sourceID);
+   virtual void javaScriptConsoleMessage(QWebEnginePage::JavaScriptConsoleMessageLevel level, const QString &message,
+                                         int lineNumber, const QString &sourceID);
 
 public:
-
    RootWebPage(QObject *parent = 0) : QWebEnginePage(parent) {}
    virtual ~RootWebPage() {}
-
 };
 
 #endif

--- a/gui/canvaspainter/v7/qt5/rootwebview.cpp
+++ b/gui/canvaspainter/v7/qt5/rootwebview.cpp
@@ -1,0 +1,28 @@
+#include "rootwebview.h"
+
+
+
+void RootWebPage::javaScriptConsoleMessage(JavaScriptConsoleMessageLevel level,
+                      const QString &message, int lineNumber, const QString &sourceID)
+{
+   QByteArray ba = message.toLatin1();
+   QByteArray src = sourceID.toLatin1();
+
+   printf("CONSOLE %s:%d: %s\n", src.data(), lineNumber, ba.data());
+}
+
+
+RootWebView::RootWebView(QWidget* parent) : QWebEngineView(parent)
+{
+   setPage(new RootWebPage());
+
+   //connect(this, SIGNAL(javaScriptConsoleMessage(JavaScriptConsoleMessageLevel, const QString &, int, const QString &)),
+   //        this, SLOT(doConsole(JavaScriptConsoleMessageLevel, const QString &, int, const QString &)));
+
+   // connect(this, &QWebEngineView::javaScriptConsoleMessage, this, &RootWebView::doConsole);
+}
+
+RootWebView::~RootWebView()
+{
+
+}

--- a/gui/canvaspainter/v7/qt5/rootwebview.cpp
+++ b/gui/canvaspainter/v7/qt5/rootwebview.cpp
@@ -2,7 +2,8 @@
 /// \ingroup CanvasPainter ROOT7
 /// \author Sergey Linev <S.Linev@gsi.de>
 /// \date 2017-06-29
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
@@ -15,11 +16,12 @@
 #include "rootwebview.h"
 #include "rootwebpage.h"
 
-RootWebView::RootWebView(QWidget* parent) : QWebEngineView(parent)
+RootWebView::RootWebView(QWidget *parent) : QWebEngineView(parent)
 {
    setPage(new RootWebPage());
 
-   //connect(this, SIGNAL(javaScriptConsoleMessage(JavaScriptConsoleMessageLevel, const QString &, int, const QString &)),
+   // connect(this, SIGNAL(javaScriptConsoleMessage(JavaScriptConsoleMessageLevel, const QString &, int, const QString
+   // &)),
    //        this, SLOT(doConsole(JavaScriptConsoleMessageLevel, const QString &, int, const QString &)));
 
    // connect(this, &QWebEngineView::javaScriptConsoleMessage, this, &RootWebView::doConsole);

--- a/gui/canvaspainter/v7/qt5/rootwebview.cpp
+++ b/gui/canvaspainter/v7/qt5/rootwebview.cpp
@@ -1,16 +1,19 @@
+/// \file rootwebview.cpp
+/// \ingroup CanvasPainter ROOT7
+/// \author Sergey Linev <S.Linev@gsi.de>
+/// \date 2017-06-29
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
 #include "rootwebview.h"
-
-
-
-void RootWebPage::javaScriptConsoleMessage(JavaScriptConsoleMessageLevel level,
-                      const QString &message, int lineNumber, const QString &sourceID)
-{
-   QByteArray ba = message.toLatin1();
-   QByteArray src = sourceID.toLatin1();
-
-   printf("CONSOLE %s:%d: %s\n", src.data(), lineNumber, ba.data());
-}
-
+#include "rootwebpage.h"
 
 RootWebView::RootWebView(QWidget* parent) : QWebEngineView(parent)
 {
@@ -24,5 +27,4 @@ RootWebView::RootWebView(QWidget* parent) : QWebEngineView(parent)
 
 RootWebView::~RootWebView()
 {
-
 }

--- a/gui/canvaspainter/v7/qt5/rootwebview.h
+++ b/gui/canvaspainter/v7/qt5/rootwebview.h
@@ -1,0 +1,36 @@
+#ifndef RootWebView_h
+#define RootWebView_h
+
+#include <QWebEngineView>
+#include <QWebEnginePage>
+
+
+class RootWebPage : public QWebEnginePage {
+   Q_OBJECT
+protected:
+   virtual void javaScriptConsoleMessage(QWebEnginePage::JavaScriptConsoleMessageLevel level,
+                      const QString &message, int lineNumber, const QString &sourceID);
+
+public:
+
+   RootWebPage(QObject *parent = 0) : QWebEnginePage(parent) {}
+   virtual ~RootWebPage() {}
+
+};
+
+class RootWebView : public QWebEngineView {
+   Q_OBJECT
+protected:
+
+
+public:
+   RootWebView(QWidget* parent = 0);
+   virtual ~RootWebView();
+
+};
+
+
+
+
+
+#endif

--- a/gui/canvaspainter/v7/qt5/rootwebview.h
+++ b/gui/canvaspainter/v7/qt5/rootwebview.h
@@ -2,7 +2,8 @@
 /// \ingroup CanvasPainter ROOT7
 /// \author Sergey Linev <S.Linev@gsi.de>
 /// \date 2017-06-29
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
@@ -20,11 +21,9 @@
 class RootWebView : public QWebEngineView {
    Q_OBJECT
 protected:
-
 public:
-   RootWebView(QWidget* parent = 0);
+   RootWebView(QWidget *parent = 0);
    virtual ~RootWebView();
-
 };
 
 #endif


### PR DESCRIPTION
How to compile code see Readme in gui/canvaspainter

Code is not yet used - I will provide another patch after this PR and #717 are merged.

CEF-related makefile should be improved. 
One can use **cefsimple** cmake files as an example

https://bitbucket.org/chromiumembedded/cef/src/8e69e3dcea8b/tests/cefsimple/?at=master

**cefsimple** has some specialization for linux, mac and windows. 
I used only linux till now. One could try mac - for that one should include simple_handler_mac.mm into compilation instead of simple_handler_linux.cxx.

Same is for cef_main.cxx. Formally one need to create separate versions for mac, linux and windows.
You can see example also in **cefsimple**. These are different platform-specific error handlers.

Building of Qt5 part is not called from makefile. I hope, one can add it into makefile when qt5-webengine is discovered. Also rootqt5 executable should be moved into $ROOTSYS/bin directory


