### PR TITLE
Revert "Move inline method to implementation file to avoid inline

### DIFF
--- a/interpreter/llvm/src/tools/clang/include/clang/AST/DeclTemplate.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/AST/DeclTemplate.h
@@ -1542,7 +1542,11 @@ public:
   bool hasDefaultArgument() const { return DefaultArgument.isSet(); }
 
   /// \brief Retrieve the default argument, if any.
-  const TemplateArgumentLoc &getDefaultArgument() const;
+  const TemplateArgumentLoc &getDefaultArgument() const {
+    static const TemplateArgumentLoc None;
+    return DefaultArgument.isSet() ? *DefaultArgument.get() : None;
+  }
+
   /// \brief Retrieve the location of the default argument, if any.
   SourceLocation getDefaultArgumentLoc() const;
 

--- a/interpreter/llvm/src/tools/clang/lib/AST/DeclTemplate.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/AST/DeclTemplate.cpp
@@ -613,11 +613,6 @@ TemplateTemplateParmDecl::CreateDeserialized(ASTContext &C, unsigned ID,
   return TTP;
 }
 
-const TemplateArgumentLoc &TemplateTemplateParmDecl::getDefaultArgument() const {
-  static const TemplateArgumentLoc None;
-  return DefaultArgument.isSet() ? *DefaultArgument.get() : None;
-}
-
 SourceLocation TemplateTemplateParmDecl::getDefaultArgumentLoc() const {
   return hasDefaultArgument() ? getDefaultArgument().getLocation()
                               : SourceLocation();


### PR DESCRIPTION
 visibility warnings when linking on OS X. Any other solution to specifically
 add the flag -finline-visibility-hidden to files including DeclTemplate.h is
 not possible because of other includes shared by other parts of the system.
 The only solution would be to apply the flag globally to the whole ROOT
 project"