### PR TITLE
[Math] Replace std::auto_ptr with std::unique_ptr

### DIFF
--- a/math/mathcore/CMakeLists.txt
+++ b/math/mathcore/CMakeLists.txt
@@ -2,8 +2,6 @@
 # CMakeLists.txt file for building ROOT io/io package
 ############################################################################
 
-ROOT_ADD_CXX_FLAG(CMAKE_CXX_FLAGS -Wno-deprecated-declarations) # auto_ptr...
-
 set(MATHCORE_HEADERS TRandom.h
   TRandom1.h TRandom2.h TRandom3.h TKDTree.h TKDTreeBinning.h TStatistic.h
   Math/Error.h Math/IParamFunction.h Math/IFunction.h Math/ParamFunctor.h Math/Functor.h
@@ -46,7 +44,3 @@ endif()
 ROOT_INSTALL_HEADERS()
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)
-
-
-
-

--- a/math/mathcore/inc/Math/Functor.h
+++ b/math/mathcore/inc/Math/Functor.h
@@ -435,7 +435,7 @@ public:
       ImplBase()
    {
       if (rhs.fImpl)
-         fImpl = std::unique_ptr<Impl>( (rhs.fImpl)->Copy() );
+         fImpl = std::unique_ptr<Impl>((rhs.fImpl)->Copy());
    }
    // need a specialization in order to call base classes and use  clone
 
@@ -445,12 +445,7 @@ public:
    */
    Functor & operator = (const Functor & rhs)  {
       Functor copy(rhs);
-      // swap the poiter 
-      fImpl.swap( copy.fImpl);
-      // // swap unique_ptr by hand
-      // Impl * p = fImpl.release();
-      // fImpl.reset(copy.fImpl.release());
-      // copy.fImpl.reset(p);
+      fImpl.swap(copy.fImpl);
       return *this;
    }
 
@@ -508,7 +503,7 @@ public:
     */
    template <typename Func>
    Functor1D(const Func & f) :
-      fImpl(new FunctorHandler<Functor1D,Func>(f) )
+      fImpl(new FunctorHandler<Functor1D,Func>(f))
    {}
 
 
@@ -544,18 +539,12 @@ public:
    */
    Functor1D & operator = (const Functor1D & rhs)  {
       Functor1D copy(rhs);
-      fImpl.swap( copy.fImpl);
-      // swap auto_ptr by hand
-      // Impl * p = fImpl.release();
-      // fImpl.reset(copy.fImpl.release());
-      // copy.fImpl.reset(p);
+      fImpl.swap(copy.fImpl);
       return *this;
    }
 
-
    // clone of the function handler (use copy-ctor)
    ImplBase * Clone() const { return new Functor1D(*this); }
-
 
 private :
 
@@ -563,10 +552,7 @@ private :
       return (*fImpl)(x);
    }
 
-
    std::unique_ptr<Impl> fImpl;   // pointer to base functor handler
-
-
 };
 
 /**
@@ -644,7 +630,7 @@ public:
       ImplBase()
    {
       if (rhs.fImpl)
-         fImpl = std::unique_ptr<Impl>( rhs.fImpl->Copy() );
+         fImpl = std::unique_ptr<Impl>(rhs.fImpl->Copy());
    }
 
    /**
@@ -653,10 +639,6 @@ public:
    GradFunctor & operator = (const GradFunctor & rhs)  {
       GradFunctor copy(rhs);
       fImpl.swap(copy.fImpl);
-      // swap auto_ptr by hand      
-      // Impl * p = fImpl.release();
-      // fImpl.reset(copy.fImpl.release());
-      // copy.fImpl.reset(p);
       return *this;
    }
 
@@ -773,10 +755,6 @@ public:
    GradFunctor1D & operator = (const GradFunctor1D & rhs)  {
       GradFunctor1D copy(rhs);
       fImpl.swap(copy.fImpl);
-      // swap auto_ptr by hand
-      // Impl * p = fImpl.release();
-      // fImpl.reset(copy.fImpl.release());
-      // copy.fImpl.reset(p);
       return *this;
    }
 

--- a/math/mathcore/inc/Math/MinimTransformFunction.h
+++ b/math/mathcore/inc/Math/MinimTransformFunction.h
@@ -68,7 +68,7 @@ public:
 
    unsigned int NTot() const { return fFunc->NDim(); }
 
-   /// clone:  not supported (since auto_ptr used in the fVariables)
+   /// clone:  not supported (since unique_ptr used in the fVariables)
    IMultiGenFunction * Clone() const {
       return 0;
    }

--- a/math/mathcore/inc/Math/MinimTransformVariable.h
+++ b/math/mathcore/inc/Math/MinimTransformVariable.h
@@ -87,7 +87,7 @@ public:
       fFix(rhs.fFix), fLowBound(rhs.fLowBound), fUpBound(rhs.fUpBound), fBounds(rhs.fBounds),
       fLower(rhs.fLower), fUpper(rhs.fUpper)
    {
-      // swap auto_ptr
+      // swap unique_ptr
       fTransform.swap( const_cast<MinimTransformVariable &>( rhs).fTransform) ;
    }
 
@@ -100,7 +100,7 @@ public:
       fBounds   = rhs.fBounds;
       fLower = rhs.fLower;  fUpper = rhs.fUpper;
 
-      // swap auto_ptr
+      // swap unique_ptr
       fTransform.swap( const_cast<MinimTransformVariable &>( rhs).fTransform) ;
       return *this;
    }

--- a/math/mathcore/inc/Math/ParamFunctor.h
+++ b/math/mathcore/inc/Math/ParamFunctor.h
@@ -328,7 +328,7 @@ public:
       fImpl(0)
    {
 //       if (rhs.fImpl.get() != 0)
-//          fImpl = std::auto_ptr<Impl>( (rhs.fImpl)->Clone() );
+//          fImpl = std::unique_ptr<Impl>( (rhs.fImpl)->Clone() );
       if (rhs.fImpl != 0)  fImpl = rhs.fImpl->Clone();
    }
 
@@ -337,7 +337,7 @@ public:
    */
    ParamFunctorTempl & operator = (const ParamFunctorTempl & rhs)  {
 //      ParamFunctor copy(rhs);
-      // swap auto_ptr by hand
+      // swap unique_ptr by hand
 //       Impl * p = fImpl.release();
 //       fImpl.reset(copy.fImpl.release());
 //       copy.fImpl.reset(p);
@@ -373,7 +373,7 @@ public:
 private :
 
 
-   //std::auto_ptr<Impl> fImpl;
+   //std::unique_ptr<Impl> fImpl;
    Impl * fImpl;
 
 

--- a/math/mathcore/inc/Math/WrappedParamFunction.h
+++ b/math/mathcore/inc/Math/WrappedParamFunction.h
@@ -57,7 +57,7 @@ public:
 //    /**
 //       Constructor a wrapped function from a non-const pointer to a callable object, the function dimension and number of parameters
 //       which are set to zero by default
-//       This constructor is needed in the case FuncPtr is a std::auto_ptr which has a copy ctor taking non const objects
+//       This constructor is needed in the case FuncPtr is a std::unique_ptr which has a copy ctor taking non const objects
 //    */
 //    WrappedParamFunction (FuncPtr & func, unsigned int dim = 1, unsigned int npar = 0, double * par = 0) :
 //       fFunc(func),
@@ -80,7 +80,7 @@ public:
 
 //    /**
 //       Constructor a wrapped function from a non - const pointer to a callable object, the function dimension and an iterator specifying begin and end of parameters.
-//       This constructor is needed in the case FuncPtr is a std::auto_ptr which has a copy ctor taking non const objects
+//       This constructor is needed in the case FuncPtr is a std::unique_ptr which has a copy ctor taking non const objects
 //    */
 //    template<class Iterator>
 //    WrappedParamFunction (FuncPtr func, unsigned int dim, Iterator begin, Iterator end) :
@@ -158,7 +158,7 @@ public:
 
    /**
       Constructor as before but taking now a non - const pointer to a callable object.
-      This constructor is needed in the case FuncPtr is a std::auto_ptr which has a copy ctor taking non const objects
+      This constructor is needed in the case FuncPtr is a std::unique_ptr which has a copy ctor taking non const objects
    */
    WrappedParamFunctionGen (FuncPtr & func, unsigned int dim, unsigned int npar, const double * par, const unsigned int * idx) :
       fFunc(func),

--- a/math/mathcore/src/Fitter.cxx
+++ b/math/mathcore/src/Fitter.cxx
@@ -91,7 +91,7 @@ Fitter & Fitter::operator = (const Fitter &rhs)
 //    fBinFit = rhs.fBinFit;
 //    fResult = rhs.fResult;
 //    fConfig = rhs.fConfig;
-//    // function is copied and managed by FitResult (maybe should use an auto_ptr)
+//    // function is copied and managed by FitResult (maybe should use an unique_ptr)
 //    fFunc = fResult.ModelFunction();
 //    if (rhs.fFunc != 0 && fResult.ModelFunction() == 0) { // case no fit has been done yet - then clone
 //       if (fFunc) delete fFunc;
@@ -827,7 +827,7 @@ bool Fitter::ApplyWeightCorrection(const ROOT::Math::IMultiGenFunction & loglw2,
       return false;
    }
    // need to re-init the minimizer and set w2
-   fObjFunction = std::auto_ptr<ROOT::Math::IMultiGenFunction> ( loglw2.Clone() );
+   fObjFunction = std::unique_ptr<ROOT::Math::IMultiGenFunction> ( loglw2.Clone() );
    // need to re-initialize the minimizer for the changes applied in the
    // objective functions
    if (!DoInitMinimizer()) return false;

--- a/math/mathmore/src/ChebyshevApprox.cxx
+++ b/math/mathmore/src/ChebyshevApprox.cxx
@@ -130,30 +130,24 @@ std::pair<double, double>  ChebyshevApprox::EvalErr( double x, size_t n) const {
    return std::make_pair( result, error);
 }
 
-
-
-ChebyshevApprox *   ChebyshevApprox::Deriv() {
-   // calculate derivative. Returna pointer to a new series
-   // used auto_ptr (supprseed since not good support on some compilers)
-   ChebyshevApprox * deriv = new ChebyshevApprox(fOrder);
+ChebyshevApprox *ChebyshevApprox::Deriv()
+{
+   // calculate derivative. Returns pointer to a new series
+   ChebyshevApprox *deriv = new ChebyshevApprox(fOrder);
 
    // check for errors ?
-   gsl_cheb_calc_deriv( (deriv->fSeries)->get(), fSeries->get() );
+   gsl_cheb_calc_deriv((deriv->fSeries)->get(), fSeries->get());
    return deriv;
-   // diable auto_ptr to fix AIX compilation
-   //   std::auto_ptr<Chebyshev> pDeriv(deriv);
-   //   return pDeriv;
 }
 
-ChebyshevApprox * ChebyshevApprox::Integral() {
+ChebyshevApprox *ChebyshevApprox::Integral()
+{
    // integral (return pointer)
-   ChebyshevApprox * integ = new ChebyshevApprox(fOrder);
+   ChebyshevApprox *integ = new ChebyshevApprox(fOrder);
 
    // check for errors ?
-   gsl_cheb_calc_integ( (integ->fSeries)->get(), fSeries->get() );
+   gsl_cheb_calc_integ((integ->fSeries)->get(), fSeries->get());
    return integ;
-   //   std::auto_ptr<Chebyshev> pInteg(integ);
-   //   return pInteg;
 }
 
 } // namespace Math

--- a/math/unuran/src/TUnuran.cxx
+++ b/math/unuran/src/TUnuran.cxx
@@ -94,7 +94,7 @@ bool TUnuran::Init(const TUnuranContDist & distr, const std::string  & method)
 {
    // initialization with a distribution and and generator
    // the distribution object is copied in and managed by this class
-   // use auto_ptr to manage previously existing distribution objects
+   // use std::unique_ptr to manage previously existing distribution objects
    TUnuranContDist * distNew = distr.Clone();
    fDist.reset(distNew);
 
@@ -110,7 +110,7 @@ bool TUnuran::Init(const TUnuranMultiContDist & distr, const std::string  & meth
 {
    //  initialization with a distribution and method
    // the distribution object is copied in and managed by this class
-   // use auto_ptr to manage previously existing distribution objects
+   // use std::unique_ptr to manage previously existing distribution objects
    TUnuranMultiContDist * distNew = distr.Clone();
    fDist.reset(distNew);
 
@@ -125,7 +125,7 @@ bool TUnuran::Init(const TUnuranMultiContDist & distr, const std::string  & meth
 bool TUnuran::Init(const TUnuranDiscrDist & distr, const std::string & method ) {
    //   initialization with a distribution and and generator
    // the distribution object is copied in and managed by this class
-   // use auto_ptr to manage previously existing distribution objects
+   // use std::unique_ptr to manage previously existing distribution objects
    TUnuranDiscrDist * distNew = distr.Clone();
    fDist.reset(distNew);
 
@@ -139,7 +139,7 @@ bool TUnuran::Init(const TUnuranDiscrDist & distr, const std::string & method ) 
 bool TUnuran::Init(const TUnuranEmpDist & distr, const std::string & method ) {
    //   initialization with a distribution and and generator
    // the distribution object is copied in and managed by this class
-   // use auto_ptr to manage previously existing distribution objects
+   // use std::unique_ptr to manage previously existing distribution objects
    TUnuranEmpDist * distNew = distr.Clone();
    fDist.reset(distNew);
 


### PR DESCRIPTION
Get rid of `std::auto_ptr` usage in mathcore. Most changes are in comments.