### PR TITLE
Fix build process for GCC 7.X, based on ROOT-8180

### DIFF
--- a/cint/cint/Module.mk
+++ b/cint/cint/Module.mk
@@ -153,23 +153,12 @@ CINTS2       := $(filter-out $(MODDIRSD)/libstrm.%,$(CINTS2))
  CINTS2       += $(MODDIRSD)/iccstrm.cxx
 endif
 endif
+GCCVERSIONGTEQ4 := $(shell expr `gcc -dumpversion | cut -f1 -d.` \>= 4)
 ifeq ($(GCC_MAJOR),3)
 CINTS2       := $(filter-out $(MODDIRSD)/libstrm.%,$(CINTS2))
 CINTS2       += $(MODDIRSD)/gcc3strm.cxx
 endif
-ifeq ($(GCC_MAJOR),4)
-CINTS2       := $(filter-out $(MODDIRSD)/libstrm.%,$(CINTS2))
-CINTS2       += $(MODDIRSD)/gcc4strm.cxx
-endif
-ifeq ($(GCC_MAJOR),5)
-CINTS2       := $(filter-out $(MODDIRSD)/libstrm.%,$(CINTS2))
-CINTS2       += $(MODDIRSD)/gcc4strm.cxx
-endif
-ifeq ($(GCC_MAJOR),6)
-CINTS2       := $(filter-out $(MODDIRSD)/libstrm.%,$(CINTS2))
-CINTS2       += $(MODDIRSD)/gcc4strm.cxx
-endif
-ifeq ($(GCC_MAJOR),7)
+ifeq ($(GCCVERSIONGTEQ4),1)
 CINTS2       := $(filter-out $(MODDIRSD)/libstrm.%,$(CINTS2))
 CINTS2       += $(MODDIRSD)/gcc4strm.cxx
 endif
@@ -215,24 +204,13 @@ IOSENUMC     := $(CINTDIRIOSEN)/iosenum.cxx
 ifneq ($(CLANG_MAJOR),)
 IOSENUMA     := $(CINTDIRIOSEN)/iosenum.$(ARCH)3
 else
-ifeq ($(GCC_MAJOR),7)
-IOSENUMA     := $(CINTDIRIOSEN)/iosenum.$(ARCH)3
-else
-ifeq ($(GCC_MAJOR),6)
-IOSENUMA     := $(CINTDIRIOSEN)/iosenum.$(ARCH)3
-else
-ifeq ($(GCC_MAJOR),5)
-IOSENUMA     := $(CINTDIRIOSEN)/iosenum.$(ARCH)3
-else
-ifeq ($(GCC_MAJOR),4)
-IOSENUMA     := $(CINTDIRIOSEN)/iosenum.$(ARCH)3
-else
-ifeq ($(GCC_MAJOR),3)
-IOSENUMA     := $(CINTDIRIOSEN)/iosenum.$(ARCH)3
-else
+ifeq ($(GCC_MAJOR),1)
 IOSENUMA     := $(CINTDIRIOSEN)/iosenum.$(ARCH)
-endif
-endif
+else
+ifeq ($(GCC_MAJOR),2)
+IOSENUMA     := $(CINTDIRIOSEN)/iosenum.$(ARCH)
+else
+IOSENUMA     := $(CINTDIRIOSEN)/iosenum.$(ARCH)3
 endif
 endif
 endif
@@ -364,16 +342,9 @@ $(call stripsrc,$(CINTDIRSD)/libstrm.o):  CINTCXXFLAGS += -I$(CINTDIRL)/stream
 $(call stripsrc,$(CINTDIRSD)/sun5strm.o): CINTCXXFLAGS += -I$(CINTDIRL)/sunstrm
 $(call stripsrc,$(CINTDIRSD)/vcstrm.o):   CINTCXXFLAGS += -I$(CINTDIRL)/vcstream
 $(call stripsrc,$(CINTDIRSD)/%strm.o):    CINTCXXFLAGS += -I$(CINTDIRL)/$(notdir $(basename $@))
-ifeq ($(GCC_MAJOR),4)
-$(call stripsrc,$(CINTDIRSD)/gcc4strm.o): CINTCXXFLAGS += -Wno-strict-aliasing
-endif
-ifeq ($(GCC_MAJOR),5)
-$(call stripsrc,$(CINTDIRSD)/gcc4strm.o): CINTCXXFLAGS += -Wno-strict-aliasing
-endif
-ifeq ($(GCC_MAJOR),6)
-$(call stripsrc,$(CINTDIRSD)/gcc4strm.o): CINTCXXFLAGS += -Wno-strict-aliasing
-endif
-ifeq ($(GCC_MAJOR),7)
+# flags for gcc starting at major release 4
+GCCVERSIONGTEQ4 := $(shell expr `gcc -dumpversion | cut -f1 -d.` \>= 4)
+ifeq ($(GCCVERSIONGTEQ4 ),1)
 $(call stripsrc,$(CINTDIRSD)/gcc4strm.o): CINTCXXFLAGS += -Wno-strict-aliasing
 endif
 
@@ -409,8 +380,9 @@ endif
 
 ##### configcint.h
 ifeq ($(CPPPREP),)
+GCCVERSIONGTEQ6 := $(shell expr `gcc -dumpversion | cut -f1 -d.` \>= 6)
 # cannot use "CPPPREP?=", as someone might set "CPPPREP="
-if ($(GCC_MAJOR) GREATER_EQUAL 6)
+ifeq ($(GCCVERSIONGTEQ6),1)
   CPPPREP = $(CXX) -std=c++98 -E -C
 else
   CPPPREP = $(CXX) -E -C

--- a/cint/cint/Module.mk
+++ b/cint/cint/Module.mk
@@ -410,10 +410,7 @@ endif
 ##### configcint.h
 ifeq ($(CPPPREP),)
 # cannot use "CPPPREP?=", as someone might set "CPPPREP="
-ifeq ($(GCC_MAJOR),7)
-  CPPPREP = $(CXX) -std=c++98 -E -C
-else
-ifeq ($(GCC_MAJOR),6)
+if ($(GCC_MAJOR) GREATER_EQUAL 6)
   CPPPREP = $(CXX) -std=c++98 -E -C
 else
   CPPPREP = $(CXX) -E -C

--- a/cint/cint/Module.mk
+++ b/cint/cint/Module.mk
@@ -169,6 +169,10 @@ ifeq ($(GCC_MAJOR),6)
 CINTS2       := $(filter-out $(MODDIRSD)/libstrm.%,$(CINTS2))
 CINTS2       += $(MODDIRSD)/gcc4strm.cxx
 endif
+ifeq ($(GCC_MAJOR),7)
+CINTS2       := $(filter-out $(MODDIRSD)/libstrm.%,$(CINTS2))
+CINTS2       += $(MODDIRSD)/gcc4strm.cxx
+endif
 ifneq ($(CLANG_MAJOR),)
 CINTS2       := $(filter-out $(MODDIRSD)/libstrm.%,$(CINTS2))
 CINTS2       += $(MODDIRSD)/gcc4strm.cxx
@@ -209,6 +213,9 @@ MAKECINT     := bin/makecint$(EXEEXT)
 IOSENUM      := $(call stripsrc,$(MODDIR)/include/iosenum.h)
 IOSENUMC     := $(CINTDIRIOSEN)/iosenum.cxx
 ifneq ($(CLANG_MAJOR),)
+IOSENUMA     := $(CINTDIRIOSEN)/iosenum.$(ARCH)3
+else
+ifeq ($(GCC_MAJOR),7)
 IOSENUMA     := $(CINTDIRIOSEN)/iosenum.$(ARCH)3
 else
 ifeq ($(GCC_MAJOR),6)
@@ -366,6 +373,9 @@ endif
 ifeq ($(GCC_MAJOR),6)
 $(call stripsrc,$(CINTDIRSD)/gcc4strm.o): CINTCXXFLAGS += -Wno-strict-aliasing
 endif
+ifeq ($(GCC_MAJOR),7)
+$(call stripsrc,$(CINTDIRSD)/gcc4strm.o): CINTCXXFLAGS += -Wno-strict-aliasing
+endif
 
 
 $(MAKECINTO) $(CINTO): $(CINTCONF) $(ORDER_) $(CINTINCLUDES)
@@ -400,6 +410,9 @@ endif
 ##### configcint.h
 ifeq ($(CPPPREP),)
 # cannot use "CPPPREP?=", as someone might set "CPPPREP="
+ifeq ($(GCC_MAJOR),7)
+  CPPPREP = $(CXX) -std=c++98 -E -C
+else
 ifeq ($(GCC_MAJOR),6)
   CPPPREP = $(CXX) -std=c++98 -E -C
 else

--- a/cmake/modules/SetUpLinux.cmake
+++ b/cmake/modules/SetUpLinux.cmake
@@ -71,6 +71,8 @@ if(CMAKE_COMPILER_IS_GNUCXX)
   #Settings for cint
   if (GCC_MAJOR EQUAL 6)
     set(CPPPREP "${CXX} -std=c++98 -E -C")
+  elseif (GCC_MAJOR EQUAL 7)
+    set(CPPPREP "${CXX} -std=c++98 -E -C")
   else()
     set(CPPPREP "${CXX} -E -C")
   endif()

--- a/cmake/modules/SetUpLinux.cmake
+++ b/cmake/modules/SetUpLinux.cmake
@@ -69,9 +69,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
   set(CMAKE_C_FLAGS_PROFILE          "-g3 -fno-inline -ftest-coverage -fprofile-arcs")
 
   #Settings for cint
-  if (GCC_MAJOR EQUAL 6)
-    set(CPPPREP "${CXX} -std=c++98 -E -C")
-  elseif (GCC_MAJOR EQUAL 7)
+  if (GCC_MAJOR GREATER_EQUAL 6)
     set(CPPPREP "${CXX} -std=c++98 -E -C")
   else()
     set(CPPPREP "${CXX} -E -C")

--- a/cmake/modules/SetUpLinux.cmake
+++ b/cmake/modules/SetUpLinux.cmake
@@ -69,7 +69,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
   set(CMAKE_C_FLAGS_PROFILE          "-g3 -fno-inline -ftest-coverage -fprofile-arcs")
 
   #Settings for cint
-  if (GCC_MAJOR GREATER_EQUAL 6)
+  if (NOT (GCC_MAJOR LESS 6))
     set(CPPPREP "${CXX} -std=c++98 -E -C")
   else()
     set(CPPPREP "${CXX} -E -C")


### PR DESCRIPTION
The changes to fix the build process with GCC6 mentioned in [ROOT-8180](https://sft.its.cern.ch/jira/browse/ROOT-8180) only apply to GCC6. The same problem occurs again using GCC7 because of the equality check to major version 6. 

The commit is tested on Arch Linux 64Bit and fixes the compile errors.