### PR TITLE
Fix TReentrantRWLock on macOS

### DIFF
--- a/core/thread/inc/ROOT/TReentrantRWLock.hxx
+++ b/core/thread/inc/ROOT/TReentrantRWLock.hxx
@@ -13,6 +13,7 @@
 #ifndef ROOT_TRWSpinLock
 #define ROOT_TRWSpinLock
 
+#include "ThreadLocalStorage.h"
 #include "TSpinMutex.hxx"
 
 #include <atomic>
@@ -34,7 +35,7 @@ struct UniqueLockRecurseCount {
    using local_t = LocalCounts*;
 
    local_t GetLocal() {
-      static thread_local LocalCounts gLocal;
+      TTHREAD_TLS_DECL(LocalCounts, gLocal);
       return &gLocal;
    }
 


### PR DESCRIPTION
There is no support for thread_local on macOS, so variables with
thread local storage must use the ROOT macros for this purpose.