### PR TITLE
Enable builtin GSL when mathcore=ON, but external GSL is not found

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -413,44 +413,51 @@ if(builtin_afterimage)
 endif()
 
 #---Check for GSL library---------------------------------------------------------------
-if(mathmore OR builtin_gsl)
+if(builtin_gsl)
+  message(STATUS "Using builtin GSL")
+  unset(GSL_FOUND)
+  unset(GSL_FOUND CACHE)
+  set(gsl ON CACHE BOOL "" FORCE)
+elseif(mathmore)
   message(STATUS "Looking for GSL")
-  if(NOT builtin_gsl)
-    find_package(GSL 1.10)
+  if(fail-on-missing)
+    find_package(GSL 1.10 REQUIRED)
     if(NOT GSL_FOUND)
-      if(fail-on-missing)
-        message(FATAL_ERROR "GSL package not found and 'mathmore' component if required ('fail-on-missing' enabled). "
-                            "Alternatively, you can enable the option 'builtin_gsl' to build the GSL libraries internally.")
-      else()
-        message(STATUS "GSL not found. Set variable GSL_DIR to point to your GSL installation")
-        message(STATUS "               Alternatively, you can also enable the option 'builtin_gsl' to build the GSL libraries internally'")
-        message(STATUS "               For the time being switching OFF 'mathmore' option")
-        set(mathmore OFF CACHE BOOL "" FORCE)
-      endif()
+      message(FATAL_ERROR "Could not find GSL.")
     endif()
   else()
-    set(gsl_version 2.1)
-    message(STATUS "Downloading and building GSL version ${gsl_version}")
-    foreach(l gsl gslcblas)
-      list(APPEND GSL_LIBRARIES ${CMAKE_BINARY_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}${l}${CMAKE_STATIC_LIBRARY_SUFFIX})
-    endforeach()
-    ExternalProject_Add(
-      GSL
-      # http://mirror.switch.ch/ftp/mirror/gnu/gsl/gsl-${gsl_version}.tar.gz
-      URL ${lcgpackages}/gsl-${gsl_version}.tar.gz
-      INSTALL_DIR ${CMAKE_BINARY_DIR}
-      CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix <INSTALL_DIR>
-                        --libdir=<INSTALL_DIR>/lib
-                        --enable-shared=no
-                        CC=${CMAKE_C_COMPILER} CFLAGS=${CMAKE_C_FLAGS}
-      LOG_DOWNLOAD 1 LOG_CONFIGURE 1 LOG_BUILD 1 LOG_INSTALL 1
-      BUILD_BYPRODUCTS ${GSL_LIBRARIES}
-    )
-    set(GSL_TARGET GSL)
-    set(mathmore ON CACHE BOOL "" FORCE)
+    find_package(GSL 1.10)
+    if(NOT GSL_FOUND)
+      message(STATUS "GSL not found, but mathmore support is enabled.")
+      message(STATUS "Using builtin GSL, since mathmore depends on it.")
+      set(gsl ON CACHE BOOL "" FORCE)
+      set(builtin_gsl ON CACHE BOOL "" FORCE)
+    endif()
   endif()
 endif()
 
+if(gsl AND NOT GSL_FOUND)
+  set(gsl_version 2.1)
+  message(STATUS "Downloading and building GSL version ${gsl_version}")
+  foreach(l gsl gslcblas)
+    set(LIBNAME "${CMAKE_STATIC_LIBRARY_PREFIX}${l}${CMAKE_STATIC_LIBRARY_SUFFIX}")
+    list(APPEND GSL_LIBRARIES "${CMAKE_BINARY_DIR}/lib/${LIBNAME}")
+    unset(LIBNAME)
+  endforeach()
+  ExternalProject_Add(
+    GSL
+    # http://mirror.switch.ch/ftp/mirror/gnu/gsl/gsl-${gsl_version}.tar.gz
+    URL ${lcgpackages}/gsl-${gsl_version}.tar.gz
+    INSTALL_DIR ${CMAKE_BINARY_DIR}
+    CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix <INSTALL_DIR>
+                      CC=${CMAKE_C_COMPILER} CFLAGS=${CMAKE_C_FLAGS}
+                      --libdir=<INSTALL_DIR>/lib --enable-shared=no
+    LOG_DOWNLOAD 1 LOG_CONFIGURE 1 LOG_BUILD 1 LOG_INSTALL 1
+    BUILD_BYPRODUCTS ${GSL_LIBRARIES}
+    )
+  set(GSL_TARGET GSL)
+  set(mathmore ON CACHE BOOL "" FORCE)
+endif()
 
 #---Check for Python installation-------------------------------------------------------
 if(python OR python3)


### PR DESCRIPTION
There is no equivalent 'gsl' option, so since mathcore is the main
consumer of GSL, it makes sense to enable the builtin version when
the user requests to build mathmore rather than disabling mathmore.
The behavior is still to fail when mathmore is ON and builtin_gsl is OFF,
however. The previous behavior was to turn OFF mathmore instead.

We also have a problem in some build nodes where GSL is installed,
but is not found.
