### PR TITLE
Add ROOT::GetAvailableThreads() helper.

### DIFF
--- a/core/base/inc/TROOT.h
+++ b/core/base/inc/TROOT.h
@@ -73,7 +73,7 @@ namespace Internal {
       TParBranchProcessingRAII()  { EnableParBranchProcessing();  }
       ~TParBranchProcessingRAII() { DisableParBranchProcessing(); }
    };
-      
+
    // Manage parallel tree processing
    void EnableParTreeProcessing();
    void DisableParTreeProcessing();
@@ -95,6 +95,7 @@ namespace ROOT {
    void DisableImplicitMT();
    Bool_t IsImplicitMTEnabled();
    UInt_t GetImplicitMTPoolSize();
+   UInt_t GetAvailableThreads();
 }
 
 class TROOT : public TDirectory {

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -577,6 +577,22 @@ namespace Internal {
 #endif
    }
 
+   ////////////////////////////////////////////////////////////////////////////////
+   /// Returns the maximum number of threads the user can instantiate.
+   UInt_t GetAvailableThreads()
+   {
+#ifdef R__USE_IMT
+      static UInt_t (*sym)() = (UInt_t(*)())Internal::GetSymInLibImt("ROOT_TImplicitMT_GetAvailableThreads");
+      if (sym)
+         return sym();
+      else
+         return 0;
+#else
+      SysInfo_t s;
+      gSystem->GetSysInfo(&s);
+      return s.fCpus;
+#endif
+   }
 }
 
 TROOT *ROOT::Internal::gROOTLocal = ROOT::GetROOT();

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -578,19 +578,18 @@ namespace Internal {
    }
 
    ////////////////////////////////////////////////////////////////////////////////
-   /// Returns the maximum number of threads the user can instantiate.
-   UInt_t GetAvailableThreads()
+   /// Returns the number of concurrent threads supported by the implementation.
+   /// In the IMT case returns the number of logical CPUs available to the current process in accordance with its TBB affinity mask.
+   UInt_t GetNThreadsAvailable()
    {
 #ifdef R__USE_IMT
-      static UInt_t (*sym)() = (UInt_t(*)())Internal::GetSymInLibImt("ROOT_TImplicitMT_GetAvailableThreads");
+      static UInt_t (*sym)() = (UInt_t(*)())Internal::GetSymInLibImt("ROOT_TImplicitMT_GetNThreadsAvailable");
       if (sym)
          return sym();
       else
          return 0;
 #else
-      SysInfo_t s;
-      gSystem->GetSysInfo(&s);
-      return s.fCpus;
+      return std::thread::hardware_concurrency();
 #endif
    }
 }

--- a/core/imt/inc/ROOT/TPoolManager.hxx
+++ b/core/imt/inc/ROOT/TPoolManager.hxx
@@ -74,9 +74,9 @@ namespace ROOT {
       std::shared_ptr<TPoolManager> GetPoolManager(UInt_t nThreads = 0);
 
 
-      /// Get the maximum number of logical CPUs available.
-      /// In case of having an affinity mask (TBB), return the logical CPU available to the current process in accordance with it.
-      Int_t GetMaxNThreadsAvailable();
+      /// Get the number of logical CPUs in the system.
+      /// In case of having an affinity mask (TBB), return the number of logical CPUs available to the current process in accordance with it.
+      Int_t GetNThreadsAvailable();
    }
 }
 

--- a/core/imt/inc/ROOT/TPoolManager.hxx
+++ b/core/imt/inc/ROOT/TPoolManager.hxx
@@ -72,6 +72,11 @@ namespace ROOT {
       /// The number of threads will be able to change calling the factory function again after the last
       /// remaining shared_ptr owning the object is destroyed or reasigned, which will trigger the destructor of the manager.
       std::shared_ptr<TPoolManager> GetPoolManager(UInt_t nThreads = 0);
+
+
+      /// Get the maximum number of logical CPUs available.
+      /// In case of having an affinity mask (TBB), return the logical CPU available to the current process in accordance with it.
+      Int_t GetMaxNThreadsAvailable();
    }
 }
 

--- a/core/imt/src/TImplicitMT.cxx
+++ b/core/imt/src/TImplicitMT.cxx
@@ -80,9 +80,9 @@ extern "C" UInt_t ROOT_TImplicitMT_GetImplicitMTPoolSize()
    return ROOT::Internal::TPoolManager::GetPoolSize();
 };
 
-extern "C" UInt_t ROOT_TImplicitMT_GetAvailableThreads()
+extern "C" UInt_t ROOT_TImplicitMT_GetNThreadsAvailable()
 {
-   return ROOT::Internal::GetMaxNThreadsAvailable();
+   return ROOT::Internal::GetNThreadsAvailable();
 };
 
 extern "C" void ROOT_TImplicitMT_EnableParBranchProcessing()

--- a/core/imt/src/TImplicitMT.cxx
+++ b/core/imt/src/TImplicitMT.cxx
@@ -80,6 +80,10 @@ extern "C" UInt_t ROOT_TImplicitMT_GetImplicitMTPoolSize()
    return ROOT::Internal::TPoolManager::GetPoolSize();
 };
 
+extern "C" UInt_t ROOT_TImplicitMT_GetAvailableThreads()
+{
+   return ROOT::Internal::GetMaxNThreadsAvailable();
+};
 
 extern "C" void ROOT_TImplicitMT_EnableParBranchProcessing()
 {

--- a/core/imt/src/TPoolManager.cxx
+++ b/core/imt/src/TPoolManager.cxx
@@ -51,6 +51,7 @@ namespace ROOT {
          if (GetWP().expired()) {
             std::shared_ptr<TPoolManager> shared(new TPoolManager(nThreads));
             GetWP() = shared;
+            return GetWP().lock();
          }
          return GetWP().lock();
       }

--- a/core/imt/src/TPoolManager.cxx
+++ b/core/imt/src/TPoolManager.cxx
@@ -55,7 +55,7 @@ namespace ROOT {
          return GetWP().lock();
       }
 
-      Int_t GetMaxNThreadsAvailable()
+      Int_t GetNThreadsAvailable()
       {
          return tbb::task_scheduler_init::default_num_threads();
       }

--- a/core/imt/src/TPoolManager.cxx
+++ b/core/imt/src/TPoolManager.cxx
@@ -51,9 +51,13 @@ namespace ROOT {
          if (GetWP().expired()) {
             std::shared_ptr<TPoolManager> shared(new TPoolManager(nThreads));
             GetWP() = shared;
-            return GetWP().lock();
          }
          return GetWP().lock();
+      }
+
+      Int_t GetMaxNThreadsAvailable()
+      {
+         return tbb::task_scheduler_init::default_num_threads();
       }
    }
 }


### PR DESCRIPTION
Introduce a new helper returning the number of logical CPUs available to the current process. In case of having an affinity mask, it will return in accordance to it (IMT & tbb required for this).

Function naming can be improved. I wanted to keep tbb away from ImplicitMT and that's why the core function is defined in TPoolManager.hxx. Should it be a member of the class?

Also delete useless return.

