### PR TITLE
[TDF] Fix memory leak in non-jitted actions

### DIFF
--- a/tree/treeplayer/src/TDFInterface.cxx
+++ b/tree/treeplayer/src/TDFInterface.cxx
@@ -164,7 +164,7 @@ Long_t JitTransformation(void *thisPtr, const std::string &methodName, const std
 // Jit and call something equivalent to "this->BuildAndBook<BranchTypes...>(params...)"
 // (see comments in the body for actual jitted code)
 std::string JitBuildAndBook(const ColumnNames_t &bl, const std::string &prevNodeTypename, void *prevNode,
-                            const std::type_info &art, const std::type_info &at, const void *r, TTree *tree,
+                            const std::type_info &art, const std::type_info &at, const void *rOnHeap, TTree *tree,
                             unsigned int nSlots, const std::map<std::string, TmpBranchBasePtr_t> &tmpBranches)
 {
    gInterpreter->ProcessLine("#include \"ROOT/TDataFrame.hxx\"");
@@ -208,7 +208,7 @@ std::string JitBuildAndBook(const ColumnNames_t &bl, const std::string &prevNode
 
    // createAction_str will contain the following:
    // ROOT::Internal::TDF::CallBuildAndBook<actionType, branchType1, branchType2...>(
-   //    *reinterpret_cast<PrevNodeType*>(prevNode), { bl[0], bl[1], ... }, *reinterpret_cast<actionResultType*>(r))
+   //   *reinterpret_cast<PrevNodeType*>(prevNode), { bl[0], bl[1], ... }, reinterpret_cast<actionResultType*>(rOnHeap))
    std::stringstream createAction_str;
    createAction_str << "ROOT::Internal::TDF::CallBuildAndBook"
                     << "<" << actionTypeName;
@@ -218,7 +218,7 @@ std::string JitBuildAndBook(const ColumnNames_t &bl, const std::string &prevNode
       if (i != 0u) createAction_str << ", ";
       createAction_str << '"' << bl[i] << '"';
    }
-   createAction_str << "}, " << nSlots << ", *reinterpret_cast<" << actionResultTypeName << "*>(" << r << "));";
+   createAction_str << "}, " << nSlots << ", reinterpret_cast<" << actionResultTypeName << "*>(" << rOnHeap << "));";
    return createAction_str.str();
 }
 } // end ns TDF


### PR DESCRIPTION
Fix a memory leak (only present in master, not in 6.10) that was hitting non-jitted actions.

The shared_ptr-on-the-heap trick is only needed for jitted actions,
but we were using it for all of them -- forgetting to delete the
shared_ptr in the non-jitted case.

Now only the code path with jitting makes use of the heap-allocated
shared_ptr, removing the leak.