### PR TITLE
Enable rootcling warnings and fix existing warnings.

### DIFF
--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -374,13 +374,6 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
     list(APPEND _implicitdeps CXX ${_dep})
   endforeach()
 
-  set(genverbosity "")
-  # Set -v2 when generating modules in cxxmodules mode to get warnings if the
-  # modulemap doesn't fit to the structure of our dictionaries.
-  if (cxxmodules)
-      set(genverbosity "-v2")
-  endif(cxxmodules)
-
   set(module_dependencies "")
   foreach(dep ${ARG_DEPENDENCIES})
     if(TARGET ROOTCLING_${dep})
@@ -392,7 +385,7 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
 
   #---call rootcint------------------------------------------
   add_custom_command(OUTPUT ${dictionary}.cxx ${pcm_name} ${rootmap_name}
-                     COMMAND ${command} ${genverbosity} -f  ${dictionary}.cxx ${newargs} ${excludepathsargs} ${rootmapargs}
+                     COMMAND ${command} -v2 -f  ${dictionary}.cxx ${newargs} ${excludepathsargs} ${rootmapargs}
                                         ${ARG_OPTIONS} ${definitions} ${includedirs} ${headerfiles} ${_linkdef}
                      IMPLICIT_DEPENDS ${_implicitdeps}
                      DEPENDS ${_list_of_header_dependencies} ${_linkdef} ${ROOTCINTDEP} ${ARG_DEPENDENCIES})

--- a/core/imt/inc/LinkDef.h
+++ b/core/imt/inc/LinkDef.h
@@ -5,7 +5,7 @@
 #pragma link off all functions;
 
 // Only for the autoload, autoparse. No IO of these classes is foreseen!
-#pragma link C++ class ROOT::TPoolManager-;
+#pragma link C++ class ROOT::Internal::TPoolManager-;
 #pragma link C++ class ROOT::TThreadExecutor-;
 
 #endif

--- a/core/meta/inc/LinkDef.h
+++ b/core/meta/inc/LinkDef.h
@@ -32,7 +32,6 @@
 #pragma link C++ class TEnum+;
 #pragma link C++ class TFunction;
 #pragma link C++ class TFunctionTemplate+;
-#pragma link C++ class ROOT::Internal::TSchemaMatch+;
 #pragma link C++ class ROOT::TSchemaRule+;
 #pragma link C++ class ROOT::TSchemaRule::TSources+;
 #pragma link C++ class ROOT::Detail::TSchemaRuleSet-;

--- a/core/multiproc/inc/LinkDef.h
+++ b/core/multiproc/inc/LinkDef.h
@@ -17,7 +17,6 @@
 
 #pragma link C++ class TMPClient+;
 #pragma link C++ class TMPWorker+;
-#pragma link C++ class TMPInterruptHandler+;
 #pragma link C++ class ROOT::TProcessExecutor+;
 #pragma link C++ class TProcPool;  // Deprecated but still needed for backward compatibility
 

--- a/math/mathcore/test/stress/TrackMathCoreLinkDef.h
+++ b/math/mathcore/test/stress/TrackMathCoreLinkDef.h
@@ -17,14 +17,14 @@
 #pragma link C++ class std::vector < TrackErrD > +;
 
 // typedefs must also be defined in the dictionaries
-#pragma link C++ typedef Vector4D;
-#pragma link C++ typedef Vector4D32;
+#pragma link C++ typedef Vector4D_t;
+#pragma link C++ typedef Vector4D32_t;
 
-#pragma link C++ typedef Point3D;
-#pragma link C++ typedef Point3D32;
+#pragma link C++ typedef Point3D_t;
+#pragma link C++ typedef Point3D32_t;
 
-#pragma link C++ typedef Matrix4D;
-#pragma link C++ typedef Matrix4D32;
+#pragma link C++ typedef Matrix4D_t;
+#pragma link C++ typedef Matrix4D32_t;
 
-#pragma link C++ typedef SymMatrix6D;
-#pragma link C++ typedef SymMatrix6D32;
+#pragma link C++ typedef SymMatrix6D_t;
+#pragma link C++ typedef SymMatrix6D32_t;

--- a/tmva/tmva/CMakeLists.txt
+++ b/tmva/tmva/CMakeLists.txt
@@ -33,7 +33,7 @@ set(headers3 Config.h KDEKernel.h Interval.h LogInterval.h FitterBase.h MCFitter
 set(headers4 NeuralNet.h TNeuron.h TSynapse.h TActivationChooser.h TActivation.h TActivationSigmoid.h TActivationIdentity.h
          TActivationTanh.h TActivationRadial.h TActivationReLU.h TNeuronInputChooser.h TNeuronInput.h TNeuronInputSum.h
 	     TNeuronInputSqSum.h TNeuronInputAbs.h Types.h Ranking.h RuleFit.h RuleFitAPI.h IMethod.h MsgLogger.h
-	     VariableTransformBase.h VariableIdentityTransform.h VariableDecorrTransform.h VariablePCATransform.h 
+	     VariableTransformBase.h VarTransformHandler.h VariableIdentityTransform.h VariableDecorrTransform.h VariablePCATransform.h
 	     VariableGaussTransform.h VariableNormalizeTransform.h VariableRearrangeTransform.h VariableTransform.h ROCCalc.h ROCCurve.h)
 
 set(headers5 Envelope.h VariableImportance.h CrossValidation.h HyperParameterOptimisation.h Event.h Results.h ResultsClassification.h ResultsRegression.h ResultsMulticlass.h VariableInfo.h ClassInfo.h DataLoader.h DataSet.h DataSetInfo.h DataInputHandler.h DataSetManager.h DataSetFactory.h LossFunction.h)

--- a/tmva/tmva/inc/LinkDef1.h
+++ b/tmva/tmva/inc/LinkDef1.h
@@ -36,7 +36,6 @@
 #pragma link C++ class TMVA::DataSetInfo+;
 #pragma link C++ class TMVA::DataSetManager+;
 #pragma link C++ class TMVA::DataSetFactory+;
-#pragma link C++ class TMVA::DataSetFactory::EventStats+;
 
 // the classifiers
 #pragma link C++ class TMVA::MethodBase+;


### PR DESCRIPTION
We should enable rootcling warnings and just fix the issues
they point out. This patch enables those warnings and
fixes the warnings that have accumulated over the past years.

The specific actions to fix each warnings were:

* We remove TSchemaWarning as this class was removed in commit
  3803a99.

* We remove TMPInterruptHandler as this class was removed in commit
  780e16a.

* We rename the ROOT::TPoolManager selection rule to the correct
  ROOT::Internal::TPoolManager.

* We added the VarTransformHandler.h to the headers passed to rootcling
  in TMVA.

* We remove the selection rule for TMVA::DataSetFactory::EventStats
  because the class is private/protected.

* Fixed missing "_t" in the TrackMathCoreLinkDef.h.