### PR TITLE
Jupyter notebook graphics compression

### DIFF
--- a/bindings/pyroot/JupyROOT/utils.py
+++ b/bindings/pyroot/JupyROOT/utils.py
@@ -27,6 +27,7 @@ from JupyROOT import handlers
 
 #Notebook-trimming imports
 import json
+import webbrowser
 
 # We want iPython to take over the graphics
 ROOT.gROOT.SetBatch()
@@ -63,7 +64,7 @@ _jsCode = """
        Core.draw("{jsDivId}", obj, "{jsDrawOptions}");
      }}
  );
-</script>
+</script> 
 """
 
 TBufferJSONErrorMessage="The TBufferJSON class is necessary for JS visualisation to work and cannot be found. Did you enable the http module (-D http=ON for CMake)?"
@@ -396,7 +397,7 @@ class NotebookDrawer(object):
     def _removeTColors(self,object_json):
 	'''
 	This function trims the json by trimming the list of TColors that are not used in JS rendering, and hence can
-	be safety removed, reducing the size of notebooks with TCanvases markedly
+	be safely removed, reducing the size of notebooks with TCanvases markedly
 	'''
 	
 	"""Test JSON that isn't a TCanvas
@@ -439,11 +440,13 @@ class NotebookDrawer(object):
         # Workaround to have ConvertToJSON work
         
         #<class 'ROOT.TString'>
-        object_json = ROOT.TBufferJSON.ConvertToJSON(self.drawableObject,3)
+        object_json = ROOT.TBufferJSON.ConvertToJSONGraphics(self.drawableObject,3)
+	webbrowser.open("https://root.cern/js/latest/", new=1, autoraise=True);
+
         #<type 'dict'>
-        parsed_json = json.loads(str(object_json))
+        #parsed_json = json.loads(str(object_json))
         #<type 'dict'>
-        trimmed_json = self._trimJSONForGraphics(parsed_json)
+        #trimmed_json = self._trimJSONForGraphics(parsed_json)
 
         	
         # Here we could optimise the string manipulation
@@ -461,7 +464,7 @@ class NotebookDrawer(object):
         thisJsCode = _jsCode.format(jsCanvasWidth = height,
                                     jsCanvasHeight = width,
                                     jsROOTSourceDir = _jsROOTSourceDir,
-                                    jsonContent = json.dumps(trimmed_json),
+                                    jsonContent = object_json.Data(),#json.dumps(trimmed_json),
                                     jsDrawOptions = options,
                                     jsDivId = divId)
         return thisJsCode

--- a/bindings/pyroot/JupyROOT/utils.py
+++ b/bindings/pyroot/JupyROOT/utils.py
@@ -394,6 +394,11 @@ class NotebookDrawer(object):
         return True
 
     def _removeTColors(self,object_json):
+	'''
+	This function trims the json by trimming the list of TColors that are not used in JS rendering, and hence can
+	be safety removed, reducing the size of notebooks with TCanvases markedly
+	'''
+	
 	"""Test JSON that isn't a TCanvas
 	>>> self._removeTColors({"_typename": "NotTCanvas"})
 	{'_typename': 'NotTCanvas'}

--- a/bindings/pyroot/JupyROOT/utils.py
+++ b/bindings/pyroot/JupyROOT/utils.py
@@ -27,7 +27,6 @@ from JupyROOT import handlers
 
 #Notebook-trimming imports
 import json
-import pprint 
 
 # We want iPython to take over the graphics
 ROOT.gROOT.SetBatch()
@@ -396,15 +395,15 @@ class NotebookDrawer(object):
 
     def _removeTColors(self,object_json):
 	"""Test JSON that isn't a TCanvas
-	>>> _removeTColors({"_typename": "NotTCanvas"})
+	>>> self._removeTColors({"_typename": "NotTCanvas"})
 	{'_typename': 'NotTCanvas'}
 
 	Test TCanvas with TColorArray is deleted successfully
-	>>> _removeTColors({"_typename": "TCanvas", "fPrimitives" : { "arr": [ {"arr":[{"_typename": "TColor"}],"_typename":"TObjArray","name":"ListOfColors", } ]}})
+	>>> self._removeTColors({"_typename": "TCanvas", "fPrimitives" : { "arr": [ {"arr":[{"_typename": "TColor"}],"_typename":"TObjArray","name":"ListOfColors", } ]}})
 	{'_typename': 'TCanvas', 'fPrimitives': {'arr': [{'_typename': 'TObjArray', 'name': 'ListOfColors'}]}}
 
 	Test TCanvas with No TColorArray is not changed
-	>>> _removeTColors({"_typename": "TCanvas", "fPrimitives" : { "arr": [ {"arr":[{"_typename": "NotTColor"}],"_typename":"NotObjArray","name":"ListOfColors", } ]}})
+	>>> self._removeTColors({"_typename": "TCanvas", "fPrimitives" : { "arr": [ {"arr":[{"_typename": "NotTColor"}],"_typename":"NotObjArray","name":"ListOfColors", } ]}})
 	{'_typename': 'TCanvas', 'fPrimitives': {'arr': [{'arr': [{'_typename': 'NotTColor'}], '_typename': 'NotObjArray', 'name': 'ListOfColors'}]}}
 	"""
 	
@@ -426,15 +425,20 @@ class NotebookDrawer(object):
 	'''
 	Function that calls helper functions to trim redundant information in JSON graphics files to reduce size
 	'''
-	final_json =self._removeTColors(object_json)
-	return final_json 
+	trimmed_json =self._removeTColors(object_json)
+	return trimmed_json 
 
       
     def _getJsCode(self):
         # Workaround to have ConvertToJSON work
+        
+        #<class 'ROOT.TString'>
         object_json = ROOT.TBufferJSON.ConvertToJSON(self.drawableObject,3)
+        #<type 'dict'>
         parsed_json = json.loads(str(object_json))
-        final_json = self._trimJSONForGraphics(parsed_json)
+        #<type 'dict'>
+        trimmed_json = self._trimJSONForGraphics(parsed_json)
+
         	
         # Here we could optimise the string manipulation
         divId = 'root_plot_' + str(self._getUID())
@@ -451,7 +455,7 @@ class NotebookDrawer(object):
         thisJsCode = _jsCode.format(jsCanvasWidth = height,
                                     jsCanvasHeight = width,
                                     jsROOTSourceDir = _jsROOTSourceDir,
-                                    jsonContent = json.dumps(final_json),
+                                    jsonContent = json.dumps(trimmed_json),
                                     jsDrawOptions = options,
                                     jsDivId = divId)
         return thisJsCode

--- a/bindings/pyroot/JupyROOT/utils.py
+++ b/bindings/pyroot/JupyROOT/utils.py
@@ -409,15 +409,16 @@ class NotebookDrawer(object):
 	"""
 	
 	#Only TCanvas JSON objects have TColors to remove in the first place
-	if object_json["_typename"]!="TCanvas":
+	if "_typename" in object_json and object_json["_typename"]!="TCanvas":
 	    return object_json
 
 	#TColor objects are known to have this fixed nested structure in the TCanvas as follows:
 	#TCanvas -> fPrimitives-> arr-> TObjArray (an element in arr)
-	nest = object_json["fPrimitives"]["arr"]
-	for element in nest:
-	    if element["_typename"] == "TObjArray":
-		del element["arr"]
+	if "fPrimitives" in object_json:
+	    fPrimitives_array = object_json["fPrimitives"]["arr"]
+	    for element in fPrimitives_array:
+		if element["_typename"] == "TObjArray" and "arr" in element:
+		    del element["arr"]
 
 	return object_json
   
@@ -434,7 +435,7 @@ class NotebookDrawer(object):
         object_json = ROOT.TBufferJSON.ConvertToJSON(self.drawableObject,3)
         parsed_json = json.loads(str(object_json))
         final_json = self._trimJSONForGraphics(parsed_json)
-	
+        	
         # Here we could optimise the string manipulation
         divId = 'root_plot_' + str(self._getUID())
  

--- a/bindings/pyroot/JupyROOT/utils.py
+++ b/bindings/pyroot/JupyROOT/utils.py
@@ -394,22 +394,17 @@ class NotebookDrawer(object):
         return True
 
     def _removeTColors(self,object_json):
-	'''
-	This function trims the json by trimming the list of TColors that are not used in JS rendering, and hence can
-	be safety removed, reducing the size of notebooks with TCanvases markedly
-	'''
-      
 	"""Test JSON that isn't a TCanvas
 	>>> self._removeTColors({"_typename": "NotTCanvas"})
 	{'_typename': 'NotTCanvas'}
 
 	Test TCanvas with TColorArray is deleted successfully
 	>>> self._removeTColors({"_typename": "TCanvas", "fPrimitives" : { "arr": [ {"arr":[{"_typename": "TColor"}],"_typename":"TObjArray","name":"ListOfColors", } ]}})
-	{'_typename': 'TCanvas', 'fPrimitives': {'arr': [{'_typename': 'TObjArray', 'name': 'ListOfColors'}]}}
+	{'_typename': 'TCanvas', 'fPrimitives': {'arr': [{}]}}
 
 	Test TCanvas with No TColorArray is not changed
-	>>> self._removeTColors({"_typename": "TCanvas", "fPrimitives" : { "arr": [ {"arr":[{"_typename": "NotTColor"}],"_typename":"NotObjArray","name":"ListOfColors", } ]}})
-	{'_typename': 'TCanvas', 'fPrimitives': {'arr': [{'arr': [{'_typename': 'NotTColor'}], '_typename': 'NotObjArray', 'name': 'ListOfColors'}]}}
+	>>> self._removeTColors({"_typename": "TCanvas", "fPrimitives" : { "arr": [ {"arr":[{"_typename": "NotTColor"}],"_typename":"NotObjArray","name":"ListOfOthers", } ]}})
+	{'_typename': 'TCanvas', 'fPrimitives': {'arr': [{'arr': [{'_typename': 'NotTColor'}], '_typename': 'NotObjArray', 'name': 'ListOfOthers'}]}}
 	"""
 	
 	#Only TCanvas JSON objects have TColors to remove in the first place
@@ -421,8 +416,9 @@ class NotebookDrawer(object):
 	if "fPrimitives" in object_json:
 	    fPrimitives_array = object_json["fPrimitives"]["arr"]
 	    for element in fPrimitives_array:
-		if element["_typename"] == "TObjArray" and "arr" in element:
-		    del element["arr"]
+		if element["_typename"] == "TObjArray" and element["name"] == "ListOfColors":
+		    element.clear()
+
 
 	return object_json
   

--- a/bindings/pyroot/JupyROOT/utils.py
+++ b/bindings/pyroot/JupyROOT/utils.py
@@ -394,6 +394,11 @@ class NotebookDrawer(object):
         return True
 
     def _removeTColors(self,object_json):
+	'''
+	This function trims the json by trimming the list of TColors that are not used in JS rendering, and hence can
+	be safety removed, reducing the size of notebooks with TCanvases markedly
+	'''
+      
 	"""Test JSON that isn't a TCanvas
 	>>> self._removeTColors({"_typename": "NotTCanvas"})
 	{'_typename': 'NotTCanvas'}

--- a/io/io/inc/TBufferJSON.h
+++ b/io/io/inc/TBufferJSON.h
@@ -35,7 +35,7 @@ public:
    virtual ~TBufferJSON();
 
    void SetCompact(int level);
-
+   static TString   ConvertToJSONGraphics(const TObject *obj, Int_t compact = 0, const char *member_name = 0);
    static TString   ConvertToJSON(const TObject *obj, Int_t compact = 0, const char *member_name = 0);
    static TString   ConvertToJSON(const void *obj, const TClass *cl, Int_t compact = 0, const char *member_name = 0);
    static TString   ConvertToJSON(const void *obj, TDataMember *member, Int_t compact = 0, Int_t arraylen = -1);

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -38,6 +38,8 @@
 #include <string.h>
 #include <locale.h>
 
+#include <fstream>
+
 #include "Compression.h"
 
 #include "TArrayI.h"
@@ -342,6 +344,18 @@ TBufferJSON::~TBufferJSON()
    if (fNumericLocale.Length()>0)
       setlocale(LC_NUMERIC, fNumericLocale.Data());
 }
+
+TString TBufferJSON::ConvertToJSONGraphics(const TObject *obj, Int_t compact, const char *member_name)
+{
+	TString initialJSONString = TBufferJSON::ConvertToJSON(obj,compact); 
+    std::ofstream ofs;
+    ofs.open ("HarryTest.txt");
+    ofs << initialJSONString;
+    ofs.close();
+	return initialJSONString;
+
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Converts object, inherited from TObject class, to JSON string


### PR DESCRIPTION
This patch affords trimming of redundant Jupyter notebook information contained within TCanvas .JSON objects. Specifically this includes the removing the list of TColors which reduces the size of a benchmark notebook (a compiled test notebook of Root Primer graphics) by up to 80% upon preliminary tests. 