### PR TITLE
[WIP] Add "one-basket-per-cluster" mode.

### DIFF
--- a/README/ReleaseNotes/v616/index.md
+++ b/README/ReleaseNotes/v616/index.md
@@ -13,6 +13,7 @@ For more information, see:
 The following people have contributed to this new version:
 
  Bertrand Bellenot, CERN/SFT,\
+ Brian Bockelman, University of Nebraska-Lincoln,\
  Rene Brun, CERN/SFT,\
  Philippe Canal, FNAL,\
  Olivier Couet, CERN/SFT,\
@@ -27,9 +28,9 @@ The following people have contributed to this new version:
  Enric Tejedor Saavedra, CERN/SFT,\
  Matevz Tadel, UCSD/CMS,\
  Vassil Vassilev, Princeton/CMS,\
- Wouter Verkerke, NIKHEF/Atlas, \
- Jan Musinsky, SAS Kosice
- Enrico Guiraud, CERN, \
+ Wouter Verkerke, NIKHEF/Atlas,\
+ Jan Musinsky, SAS Kosice, \
+ Enrico Guiraud, CERN,\
  Massimo Tumolo, Politecnico di Torino
 
 ## Deprecation and Removal
@@ -74,6 +75,12 @@ Instead, use `Root.CompressionAlgorithm` which sets the compression algorithm ac
   - Optimise the creation of the set of branches names of an input dataset,
   doing the work once and caching it in the RInterface.
   - Add StdDev action
+
+### TTree
+  - TTrees can be forced to only create new baskets at event cluster boundaries.
+    This simplifies file layout and I/O at the cost of memory.  Recommended for
+    simple file formats such as ntuples but not more complex data types.  To
+    enable, invoke `tree->SetBit(TTree::kOnlyFlushAtCluster)`.
 
 ## Histogram Libraries
 

--- a/README/ReleaseNotes/v616/index.md
+++ b/README/ReleaseNotes/v616/index.md
@@ -29,7 +29,7 @@ The following people have contributed to this new version:
  Matevz Tadel, UCSD/CMS,\
  Vassil Vassilev, Princeton/CMS,\
  Wouter Verkerke, NIKHEF/Atlas,\
- Jan Musinsky, SAS Kosice, \
+ Jan Musinsky, SAS Kosice,\
  Enrico Guiraud, CERN,\
  Massimo Tumolo, Politecnico di Torino
 

--- a/core/base/inc/ROOT/RConfig.h
+++ b/core/base/inc/ROOT/RConfig.h
@@ -579,5 +579,11 @@
   #define R__likely(expr) expr
 #endif
 
+// Setting this define causes ROOT to keep statistics about memory buffer allocation
+// time within the TTree.  Given that this is a "hot-path", we provide a mechanism
+// for enabling / disabling this at compile time by developers; default is disabled.
+#ifndef R__TRACK_BASKET_ALLOC_TIME
+//#define R__TRACK_BASKET_ALLOC_TIME 1
+#endif
 
 #endif

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -2946,7 +2946,7 @@ void TFile::MakeProject(const char *dirname, const char * /*classes*/,
          fprintf(fpMAKE,"genreflex %sProjectHeaders.h -o %sProjectDict.cxx --comments --iocomments %s ",subdirname.Data(),subdirname.Data(),gSystem->GetIncludePath());
          path.Form("%s/%sSelection.xml",clean_dirname.Data(),subdirname.Data());
       } else {
-         fprintf(fpMAKE,"rootcint -v1 -f %sProjectDict.cxx -c %s ",subdirname.Data(),gSystem->GetIncludePath());
+         fprintf(fpMAKE,"rootcint -v1 -f %sProjectDict.cxx -c %s ", subdirname.Data(), gSystem->GetIncludePath());
          path.Form("%s/%sLinkDef.h",clean_dirname.Data(),subdirname.Data());
       }
    } else {

--- a/tree/tree/inc/TBasket.h
+++ b/tree/tree/inc/TBasket.h
@@ -67,7 +67,6 @@ protected:
                                                   /// of `-1` indicates that the offset generation MUST be performed on first read.
    TBranch    *fBranch{nullptr};                  ///<Pointer to the basket support branch
    TBuffer    *fCompressedBufferRef{nullptr};     ///<! Compressed buffer.
-   Int_t       fLastWriteBufferSize{0};           ///<! Size of the buffer last time we wrote it to disk
    Int_t       fLastWriteBufferSize[3] = {0,0,0}; ///<! Size of the buffer last three buffers we wrote it to disk
 #ifdef R__TRACK_BASKET_ALLOC_TIME
    ULong64_t   fResetAllocationTime{0};           ///<! Time spent reallocating baskets in microseconds during last Reset operation.

--- a/tree/tree/inc/TBasket.h
+++ b/tree/tree/inc/TBasket.h
@@ -129,7 +129,7 @@ public:
            Int_t   ReadBasketBytes(Long64_t pos, TFile *file);
    virtual void    Reset();
 
-   // Time spent reseting basket sizes (typically, at event cluster boundaries), in microseconds
+// Time spent reseting basket sizes (typically, at event cluster boundaries), in microseconds
 #ifdef R__TRACK_BASKET_ALLOC_TIME
    ULong64_t ResetAllocationTime() const { return fResetAllocationTime; }
 #endif

--- a/tree/tree/inc/TBasket.h
+++ b/tree/tree/inc/TBasket.h
@@ -69,7 +69,9 @@ protected:
    TBuffer    *fCompressedBufferRef{nullptr};     ///<! Compressed buffer.
    Int_t       fLastWriteBufferSize{0};           ///<! Size of the buffer last time we wrote it to disk
    Int_t       fLastWriteBufferSize[3] = {0,0,0}; ///<! Size of the buffer last three buffers we wrote it to disk
+#ifdef R__TRACK_BASKET_ALLOC_TIME
    ULong64_t   fResetAllocationTime{0};           ///<! Time spent reallocating baskets in microseconds during last Reset operation.
+#endif
    Bool_t      fResetAllocation{false};           ///<! True if last reset re-allocated the memory
    Short_t     fNextBufferSizeRecord{0};          ///<! Size of the buffer last time we wrote it to disk
 
@@ -128,7 +130,9 @@ public:
    virtual void    Reset();
 
    // Time spent reseting basket sizes (typically, at event cluster boundaries), in microseconds
+#ifdef R__TRACK_BASKET_ALLOC_TIME
    ULong64_t ResetAllocationTime() const { return fResetAllocationTime; }
+#endif
    // Count of resets performed of basket size.
    Bool_t ResetAllocationCount() const { return fResetAllocation; }
 

--- a/tree/tree/inc/TBasket.h
+++ b/tree/tree/inc/TBasket.h
@@ -54,20 +54,24 @@ private:
    Bool_t CanGenerateOffsetArray();
 
 protected:
-   Int_t       fBufferSize{0};                ///< fBuffer length in bytes
-   Int_t       fNevBufSize{0};                ///< Length in Int_t of fEntryOffset OR fixed length of each entry if fEntryOffset is null!
-   Int_t       fNevBuf{0};                    ///< Number of entries in basket
-   Int_t       fLast{0};                      ///< Pointer to last used byte in basket
-   Bool_t      fHeaderOnly{kFALSE};           ///< True when only the basket header must be read/written
-   UChar_t     fIOBits{0};                    ///<!IO feature flags.  Serialized in custom portion of streamer to avoid forward compat issues unless needed.
-   Bool_t      fOwnsCompressedBuffer{kFALSE}; ///<! Whether or not we own the compressed buffer.
-   Bool_t      fReadEntryOffset{kFALSE};      ///<!Set to true if offset array was read from a file.
-   Int_t      *fDisplacement{nullptr};        ///<![fNevBuf] Displacement of entries in fBuffer(TKey)
-   Int_t      *fEntryOffset{nullptr};         ///<[fNevBuf] Offset of entries in fBuffer(TKey); generated at runtime.  Special value
-                                              /// of `-1` indicates that the offset generation MUST be performed on first read.
-   TBranch    *fBranch{nullptr};              ///<Pointer to the basket support branch
-   TBuffer    *fCompressedBufferRef{nullptr}; ///<! Compressed buffer.
-   Int_t       fLastWriteBufferSize{0};       ///<! Size of the buffer last time we wrote it to disk
+   Int_t       fBufferSize{0};                    ///< fBuffer length in bytes
+   Int_t       fNevBufSize{0};                    ///< Length in Int_t of fEntryOffset OR fixed length of each entry if fEntryOffset is null!
+   Int_t       fNevBuf{0};                        ///< Number of entries in basket
+   Int_t       fLast{0};                          ///< Pointer to last used byte in basket
+   Bool_t      fHeaderOnly{kFALSE};               ///< True when only the basket header must be read/written
+   UChar_t     fIOBits{0};                        ///<!IO feature flags.  Serialized in custom portion of streamer to avoid forward compat issues unless needed.
+   Bool_t      fOwnsCompressedBuffer{kFALSE};     ///<! Whether or not we own the compressed buffer.
+   Bool_t      fReadEntryOffset{kFALSE};          ///<!Set to true if offset array was read from a file.
+   Int_t      *fDisplacement{nullptr};            ///<![fNevBuf] Displacement of entries in fBuffer(TKey)
+   Int_t      *fEntryOffset{nullptr};             ///<[fNevBuf] Offset of entries in fBuffer(TKey); generated at runtime.  Special value
+                                                  /// of `-1` indicates that the offset generation MUST be performed on first read.
+   TBranch    *fBranch{nullptr};                  ///<Pointer to the basket support branch
+   TBuffer    *fCompressedBufferRef{nullptr};     ///<! Compressed buffer.
+   Int_t       fLastWriteBufferSize{0};           ///<! Size of the buffer last time we wrote it to disk
+   Int_t       fLastWriteBufferSize[3] = {0,0,0}; ///<! Size of the buffer last three buffers we wrote it to disk
+   ULong64_t   fResetAllocationTime{0};           ///<! Time spent reallocating baskets in microseconds during last Reset operation.
+   Bool_t      fResetAllocation{false};           ///<! True if last reset re-allocated the memory
+   Short_t     fNextBufferSizeRecord{0};          ///<! Size of the buffer last time we wrote it to disk
 
 public:
    // The IO bits flag is to provide improved forward-compatibility detection.
@@ -122,6 +126,11 @@ public:
            Int_t   ReadBasketBuffers(Long64_t pos, Int_t len, TFile *file);
            Int_t   ReadBasketBytes(Long64_t pos, TFile *file);
    virtual void    Reset();
+
+           // Time spent reseting basket sizes (typically, at event cluster boundaries), in microseconds
+           ULong64_t ResetAllocationTime() const {return fResetAllocationTime;}
+           // Count of resets performed of basket size.
+           Bool_t  ResetAllocationCount() const {return fResetAllocation;}
 
            Int_t   LoadBasketBuffers(Long64_t pos, Int_t len, TFile *file, TTree *tree = 0);
    Long64_t        CopyTo(TFile *to);

--- a/tree/tree/inc/TBasket.h
+++ b/tree/tree/inc/TBasket.h
@@ -68,11 +68,11 @@ protected:
    TBranch    *fBranch{nullptr};                  ///<Pointer to the basket support branch
    TBuffer    *fCompressedBufferRef{nullptr};     ///<! Compressed buffer.
    Int_t       fLastWriteBufferSize[3] = {0,0,0}; ///<! Size of the buffer last three buffers we wrote it to disk
+   Bool_t      fResetAllocation{false};           ///<! True if last reset re-allocated the memory
+   UChar_t     fNextBufferSizeRecord{0};          ///<! Index into fLastWriteBufferSize of the last buffer written to disk
 #ifdef R__TRACK_BASKET_ALLOC_TIME
    ULong64_t   fResetAllocationTime{0};           ///<! Time spent reallocating baskets in microseconds during last Reset operation.
 #endif
-   Bool_t      fResetAllocation{false};           ///<! True if last reset re-allocated the memory
-   Short_t     fNextBufferSizeRecord{0};          ///<! Size of the buffer last time we wrote it to disk
 
 public:
    // The IO bits flag is to provide improved forward-compatibility detection.
@@ -130,12 +130,12 @@ public:
 
 // Time spent reseting basket sizes (typically, at event cluster boundaries), in microseconds
 #ifdef R__TRACK_BASKET_ALLOC_TIME
-   ULong64_t ResetAllocationTime() const { return fResetAllocationTime; }
+   ULong64_t       GetResetAllocationTime() const { return fResetAllocationTime; }
 #endif
    // Count of resets performed of basket size.
-   Bool_t ResetAllocationCount() const { return fResetAllocation; }
+   Bool_t          GetResetAllocationCount() const { return fResetAllocation; }
 
-   Int_t LoadBasketBuffers(Long64_t pos, Int_t len, TFile *file, TTree *tree = 0);
+   Int_t           LoadBasketBuffers(Long64_t pos, Int_t len, TFile *file, TTree *tree = 0);
    Long64_t        CopyTo(TFile *to);
 
            void    SetBranch(TBranch *branch) { fBranch = branch; }

--- a/tree/tree/inc/TBasket.h
+++ b/tree/tree/inc/TBasket.h
@@ -127,12 +127,12 @@ public:
            Int_t   ReadBasketBytes(Long64_t pos, TFile *file);
    virtual void    Reset();
 
-           // Time spent reseting basket sizes (typically, at event cluster boundaries), in microseconds
-           ULong64_t ResetAllocationTime() const {return fResetAllocationTime;}
-           // Count of resets performed of basket size.
-           Bool_t  ResetAllocationCount() const {return fResetAllocation;}
+   // Time spent reseting basket sizes (typically, at event cluster boundaries), in microseconds
+   ULong64_t ResetAllocationTime() const { return fResetAllocationTime; }
+   // Count of resets performed of basket size.
+   Bool_t ResetAllocationCount() const { return fResetAllocation; }
 
-           Int_t   LoadBasketBuffers(Long64_t pos, Int_t len, TFile *file, TTree *tree = 0);
+   Int_t LoadBasketBuffers(Long64_t pos, Int_t len, TFile *file, TTree *tree = 0);
    Long64_t        CopyTo(TFile *to);
 
            void    SetBranch(TBranch *branch) { fBranch = branch; }

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -130,8 +130,8 @@ protected:
    UInt_t         fNEntriesSinceSorting;  ///<! Number of entries processed since the last re-sorting of branches
    std::vector<std::pair<Long64_t,TBranch*>> fSortedBranches; ///<! Branches to be processed in parallel when IMT is on, sorted by average task time
    std::vector<TBranch*> fSeqBranches;    ///<! Branches to be processed sequentially when IMT is on
-   Float_t fTargetMemoryRatio{1.1}; ///<! Ratio for memory usage in uncompressed buffers versus actual occupancy.  1.0
-                                    /// indicates basket should be resized to exact memory usage, but causes significant
+   Float_t fTargetMemoryRatio{1.1f}; ///<! Ratio for memory usage in uncompressed buffers versus actual occupancy.  1.0
+                                     /// indicates basket should be resized to exact memory usage, but causes significant
 /// memory churn.
 #ifdef R__TRACK_BASKET_ALLOC_TIME
    ULong64_t fAllocationTime{0}; ///<! Time spent reallocating basket memory buffers, in microseconds.

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -133,7 +133,9 @@ protected:
    Float_t fTargetMemoryRatio{1.1}; ///<! Ratio for memory usage in uncompressed buffers versus actual occupancy.  1.0
                                     /// indicates basket should be resized to exact memory usage, but causes significant
    /// memory churn.
+#ifdef R__TRACK_BASKET_ALLOC_TIME
    ULong64_t fAllocationTime{0}; ///<! Time spent reallocating basket memory buffers, in microseconds.
+#endif
    UInt_t fAllocationCount{0};   ///<! Number of reallocations basket memory buffers.
 
    static Int_t     fgBranchStyle;        ///<  Old/New branch style
@@ -306,7 +308,9 @@ public:
    virtual void            AddTotBytes(Int_t tot) { if (fIMTFlush) { fIMTTotBytes += tot; } else { fTotBytes += tot; } }
    virtual void            AddZipBytes(Int_t zip) { if (fIMTFlush) { fIMTZipBytes += zip; } else { fZipBytes += zip; } }
    // NOTE: these counters aren't thread safe like the ones above.
+#ifdef R__TRACK_BASKET_ALLOC_TIME
    void AddAllocationTime(ULong64_t time) { fAllocationTime += time; }
+#endif
    void AddAllocationCount(UInt_t count) { fAllocationCount += count; }
    virtual Long64_t        AutoSave(Option_t* option = "");
    virtual Int_t           Branch(TCollection* list, Int_t bufsize = 32000, Int_t splitlevel = 99, const char* name = "");
@@ -378,7 +382,9 @@ public:
    virtual Int_t           FlushBaskets(Bool_t create_cluster = true) const;
    virtual const char     *GetAlias(const char* aliasName) const;
    UInt_t GetAllocationCount() const { return fAllocationCount; }
+#ifdef R__TRACK_BASKET_ALLOC_TIME
    ULong64_t GetAllocationTime() const { return fAllocationTime; }
+#endif
    virtual Long64_t        GetAutoFlush() const {return fAutoFlush;}
    virtual Long64_t        GetAutoSave()  const {return fAutoSave;}
    virtual TBranch        *GetBranch(const char* name);

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -130,10 +130,11 @@ protected:
    UInt_t         fNEntriesSinceSorting;  ///<! Number of entries processed since the last re-sorting of branches
    std::vector<std::pair<Long64_t,TBranch*>> fSortedBranches; ///<! Branches to be processed in parallel when IMT is on, sorted by average task time
    std::vector<TBranch*> fSeqBranches;    ///<! Branches to be processed sequentially when IMT is on
-   Float_t        fTargetMemoryRatio{1.1}; ///<! Ratio for memory usage in uncompressed buffers versus actual occupancy.  1.0 indicates basket should be resized to exact memory usage, but causes significant memory churn.
-   ULong64_t      fAllocationTime{0};        ///<! Time spent reallocating basket memory buffers, in microseconds.
-   UInt_t         fAllocationCount{0};       ///<! Number of reallocations basket memory buffers.
-
+   Float_t fTargetMemoryRatio{1.1}; ///<! Ratio for memory usage in uncompressed buffers versus actual occupancy.  1.0
+                                    /// indicates basket should be resized to exact memory usage, but causes significant
+   /// memory churn.
+   ULong64_t fAllocationTime{0}; ///<! Time spent reallocating basket memory buffers, in microseconds.
+   UInt_t fAllocationCount{0};   ///<! Number of reallocations basket memory buffers.
 
    static Int_t     fgBranchStyle;        ///<  Old/New branch style
    static Long64_t  fgMaxTreeSize;        ///<  Maximum size of a file containing a Tree
@@ -228,9 +229,11 @@ public:
 
    // TTree status bits
    enum EStatusBits {
-      kForceRead   = BIT(11),
-      kCircular    = BIT(12),
-      kFlushAtCluster = BIT(13)     // If set, the branch's buffers will grow until an event cluster boundary is hit, guaranteeing a basket per cluster.  This mode does not provide any guarantee on the memory bounds in the case of extremely large events.
+      kForceRead      = BIT(11),
+      kCircular       = BIT(12),
+      kFlushAtCluster = BIT(13) // If set, the branch's buffers will grow until an event cluster boundary is hit,
+                                // guaranteeing a basket per cluster.  This mode does not provide any guarantee on the
+                                // memory bounds in the case of extremely large events.
    };
 
    // Split level modifier
@@ -303,8 +306,8 @@ public:
    virtual void            AddTotBytes(Int_t tot) { if (fIMTFlush) { fIMTTotBytes += tot; } else { fTotBytes += tot; } }
    virtual void            AddZipBytes(Int_t zip) { if (fIMTFlush) { fIMTZipBytes += zip; } else { fZipBytes += zip; } }
    // NOTE: these counters aren't thread safe like the ones above.
-           void            AddAllocationTime(ULong64_t time) { fAllocationTime += time; }
-           void            AddAllocationCount(UInt_t count) { fAllocationCount += count; }
+   void AddAllocationTime(ULong64_t time) { fAllocationTime += time; }
+   void AddAllocationCount(UInt_t count) { fAllocationCount += count; }
    virtual Long64_t        AutoSave(Option_t* option = "");
    virtual Int_t           Branch(TCollection* list, Int_t bufsize = 32000, Int_t splitlevel = 99, const char* name = "");
    virtual Int_t           Branch(TList* list, Int_t bufsize = 32000, Int_t splitlevel = 99);
@@ -374,8 +377,8 @@ public:
    virtual Int_t           Fit(const char* funcname, const char* varexp, const char* selection = "", Option_t* option = "", Option_t* goption = "", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0); // *MENU*
    virtual Int_t           FlushBaskets(Bool_t create_cluster = true) const;
    virtual const char     *GetAlias(const char* aliasName) const;
-           UInt_t          GetAllocationCount() const {return fAllocationCount;}
-           ULong64_t       GetAllocationTime() const {return fAllocationTime;}
+   UInt_t GetAllocationCount() const { return fAllocationCount; }
+   ULong64_t GetAllocationTime() const { return fAllocationTime; }
    virtual Long64_t        GetAutoFlush() const {return fAutoFlush;}
    virtual Long64_t        GetAutoSave()  const {return fAutoSave;}
    virtual TBranch        *GetBranch(const char* name);
@@ -447,7 +450,7 @@ public:
    virtual TTree          *GetTree() const { return const_cast<TTree*>(this); }
    virtual TVirtualIndex  *GetTreeIndex() const { return fTreeIndex; }
    virtual Int_t           GetTreeNumber() const { return 0; }
-           Float_t         GetTargetMemoryRatio() const { return fTargetMemoryRatio; }
+   Float_t GetTargetMemoryRatio() const { return fTargetMemoryRatio; }
    virtual Int_t           GetUpdate() const { return fUpdate; }
    virtual TList          *GetUserInfo();
    // See TSelectorDraw::GetVar
@@ -576,7 +579,7 @@ public:
    virtual void            SetParallelUnzip(Bool_t opt=kTRUE, Float_t RelSize=-1);
    virtual void            SetPerfStats(TVirtualPerfStats* perf);
    virtual void            SetScanField(Int_t n = 50) { fScanField = n; } // *MENU*
-           void            SetTargetMemoryRatio(Float_t ratio) { fTargetMemoryRatio = ratio; }
+   void SetTargetMemoryRatio(Float_t ratio) { fTargetMemoryRatio = ratio; }
    virtual void            SetTimerInterval(Int_t msec = 333) { fTimerInterval=msec; }
    virtual void            SetTreeIndex(TVirtualIndex* index);
    virtual void            SetWeight(Double_t w = 1, Option_t* option = "");

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -229,9 +229,9 @@ public:
 
    // TTree status bits
    enum EStatusBits {
-      kForceRead      = BIT(11),
-      kCircular       = BIT(12),
-      kFlushAtCluster = BIT(13) // If set, the branch's buffers will grow until an event cluster boundary is hit,
+      kForceRead          = BIT(11),
+      kCircular           = BIT(12),
+      kOnlyFlushAtCluster = BIT(13) // If set, the branch's buffers will grow until an event cluster boundary is hit,
                                 // guaranteeing a basket per cluster.  This mode does not provide any guarantee on the
                                 // memory bounds in the case of extremely large events.
    };

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -233,7 +233,7 @@ public:
    enum EStatusBits {
       kForceRead          = BIT(11),
       kCircular           = BIT(12),
-      kOnlyFlushAtCluster = BIT(13) // If set, the branch's buffers will grow until an event cluster boundary is hit,
+      kOnlyFlushAtCluster = BIT(14) // If set, the branch's buffers will grow until an event cluster boundary is hit,
                                 // guaranteeing a basket per cluster.  This mode does not provide any guarantee on the
                                 // memory bounds in the case of extremely large events.
    };

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -132,11 +132,11 @@ protected:
    std::vector<TBranch*> fSeqBranches;    ///<! Branches to be processed sequentially when IMT is on
    Float_t fTargetMemoryRatio{1.1}; ///<! Ratio for memory usage in uncompressed buffers versus actual occupancy.  1.0
                                     /// indicates basket should be resized to exact memory usage, but causes significant
-   /// memory churn.
+/// memory churn.
 #ifdef R__TRACK_BASKET_ALLOC_TIME
    ULong64_t fAllocationTime{0}; ///<! Time spent reallocating basket memory buffers, in microseconds.
 #endif
-   UInt_t fAllocationCount{0};   ///<! Number of reallocations basket memory buffers.
+   UInt_t fAllocationCount{0}; ///<! Number of reallocations basket memory buffers.
 
    static Int_t     fgBranchStyle;        ///<  Old/New branch style
    static Long64_t  fgMaxTreeSize;        ///<  Maximum size of a file containing a Tree
@@ -231,11 +231,11 @@ public:
 
    // TTree status bits
    enum EStatusBits {
-      kForceRead          = BIT(11),
-      kCircular           = BIT(12),
+      kForceRead = BIT(11),
+      kCircular = BIT(12),
       kOnlyFlushAtCluster = BIT(14) // If set, the branch's buffers will grow until an event cluster boundary is hit,
-                                // guaranteeing a basket per cluster.  This mode does not provide any guarantee on the
-                                // memory bounds in the case of extremely large events.
+      // guaranteeing a basket per cluster.  This mode does not provide any guarantee on the
+      // memory bounds in the case of extremely large events.
    };
 
    // Split level modifier
@@ -307,7 +307,7 @@ public:
    // manner only when we are flushing multiple baskets in parallel.
    virtual void            AddTotBytes(Int_t tot) { if (fIMTFlush) { fIMTTotBytes += tot; } else { fTotBytes += tot; } }
    virtual void            AddZipBytes(Int_t zip) { if (fIMTFlush) { fIMTZipBytes += zip; } else { fZipBytes += zip; } }
-   // NOTE: these counters aren't thread safe like the ones above.
+// NOTE: these counters aren't thread safe like the ones above.
 #ifdef R__TRACK_BASKET_ALLOC_TIME
    void AddAllocationTime(ULong64_t time) { fAllocationTime += time; }
 #endif

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -130,13 +130,13 @@ protected:
    UInt_t         fNEntriesSinceSorting;  ///<! Number of entries processed since the last re-sorting of branches
    std::vector<std::pair<Long64_t,TBranch*>> fSortedBranches; ///<! Branches to be processed in parallel when IMT is on, sorted by average task time
    std::vector<TBranch*> fSeqBranches;    ///<! Branches to be processed sequentially when IMT is on
-   Float_t fTargetMemoryRatio{1.1f}; ///<! Ratio for memory usage in uncompressed buffers versus actual occupancy.  1.0
-                                     /// indicates basket should be resized to exact memory usage, but causes significant
+   Float_t fTargetMemoryRatio{1.1f};      ///<! Ratio for memory usage in uncompressed buffers versus actual occupancy.  1.0
+                                           /// indicates basket should be resized to exact memory usage, but causes significant
 /// memory churn.
 #ifdef R__TRACK_BASKET_ALLOC_TIME
-   ULong64_t fAllocationTime{0}; ///<! Time spent reallocating basket memory buffers, in microseconds.
+   mutable std::atomic<ULong64_t> fAllocationTime{0}; ///<! Time spent reallocating basket memory buffers, in microseconds.
 #endif
-   UInt_t fAllocationCount{0}; ///<! Number of reallocations basket memory buffers.
+   mutable std::atomic<UInt_t> fAllocationCount{0};   ///<! Number of reallocations basket memory buffers.
 
    static Int_t     fgBranchStyle;        ///<  Old/New branch style
    static Long64_t  fgMaxTreeSize;        ///<  Maximum size of a file containing a Tree
@@ -381,9 +381,9 @@ public:
    virtual Int_t           Fit(const char* funcname, const char* varexp, const char* selection = "", Option_t* option = "", Option_t* goption = "", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0); // *MENU*
    virtual Int_t           FlushBaskets(Bool_t create_cluster = true) const;
    virtual const char     *GetAlias(const char* aliasName) const;
-   UInt_t GetAllocationCount() const { return fAllocationCount; }
+   UInt_t                  GetAllocationCount() const { return fAllocationCount; }
 #ifdef R__TRACK_BASKET_ALLOC_TIME
-   ULong64_t GetAllocationTime() const { return fAllocationTime; }
+   ULong64_t               GetAllocationTime() const { return fAllocationTime; }
 #endif
    virtual Long64_t        GetAutoFlush() const {return fAutoFlush;}
    virtual Long64_t        GetAutoSave()  const {return fAutoSave;}

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -130,6 +130,10 @@ protected:
    UInt_t         fNEntriesSinceSorting;  ///<! Number of entries processed since the last re-sorting of branches
    std::vector<std::pair<Long64_t,TBranch*>> fSortedBranches; ///<! Branches to be processed in parallel when IMT is on, sorted by average task time
    std::vector<TBranch*> fSeqBranches;    ///<! Branches to be processed sequentially when IMT is on
+   Float_t        fTargetMemoryRatio{1.1}; ///<! Ratio for memory usage in uncompressed buffers versus actual occupancy.  1.0 indicates basket should be resized to exact memory usage, but causes significant memory churn.
+   ULong64_t      fAllocationTime{0};        ///<! Time spent reallocating basket memory buffers, in microseconds.
+   UInt_t         fAllocationCount{0};       ///<! Number of reallocations basket memory buffers.
+
 
    static Int_t     fgBranchStyle;        ///<  Old/New branch style
    static Long64_t  fgMaxTreeSize;        ///<  Maximum size of a file containing a Tree
@@ -225,7 +229,8 @@ public:
    // TTree status bits
    enum EStatusBits {
       kForceRead   = BIT(11),
-      kCircular    = BIT(12)
+      kCircular    = BIT(12),
+      kFlushAtCluster = BIT(13)     // If set, the branch's buffers will grow until an event cluster boundary is hit, guaranteeing a basket per cluster.  This mode does not provide any guarantee on the memory bounds in the case of extremely large events.
    };
 
    // Split level modifier
@@ -297,6 +302,9 @@ public:
    // manner only when we are flushing multiple baskets in parallel.
    virtual void            AddTotBytes(Int_t tot) { if (fIMTFlush) { fIMTTotBytes += tot; } else { fTotBytes += tot; } }
    virtual void            AddZipBytes(Int_t zip) { if (fIMTFlush) { fIMTZipBytes += zip; } else { fZipBytes += zip; } }
+   // NOTE: these counters aren't thread safe like the ones above.
+           void            AddAllocationTime(ULong64_t time) { fAllocationTime += time; }
+           void            AddAllocationCount(UInt_t count) { fAllocationCount += count; }
    virtual Long64_t        AutoSave(Option_t* option = "");
    virtual Int_t           Branch(TCollection* list, Int_t bufsize = 32000, Int_t splitlevel = 99, const char* name = "");
    virtual Int_t           Branch(TList* list, Int_t bufsize = 32000, Int_t splitlevel = 99);
@@ -366,6 +374,8 @@ public:
    virtual Int_t           Fit(const char* funcname, const char* varexp, const char* selection = "", Option_t* option = "", Option_t* goption = "", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0); // *MENU*
    virtual Int_t           FlushBaskets(Bool_t create_cluster = true) const;
    virtual const char     *GetAlias(const char* aliasName) const;
+           UInt_t          GetAllocationCount() const {return fAllocationCount;}
+           ULong64_t       GetAllocationTime() const {return fAllocationTime;}
    virtual Long64_t        GetAutoFlush() const {return fAutoFlush;}
    virtual Long64_t        GetAutoSave()  const {return fAutoSave;}
    virtual TBranch        *GetBranch(const char* name);
@@ -437,6 +447,7 @@ public:
    virtual TTree          *GetTree() const { return const_cast<TTree*>(this); }
    virtual TVirtualIndex  *GetTreeIndex() const { return fTreeIndex; }
    virtual Int_t           GetTreeNumber() const { return 0; }
+           Float_t         GetTargetMemoryRatio() const { return fTargetMemoryRatio; }
    virtual Int_t           GetUpdate() const { return fUpdate; }
    virtual TList          *GetUserInfo();
    // See TSelectorDraw::GetVar
@@ -565,6 +576,7 @@ public:
    virtual void            SetParallelUnzip(Bool_t opt=kTRUE, Float_t RelSize=-1);
    virtual void            SetPerfStats(TVirtualPerfStats* perf);
    virtual void            SetScanField(Int_t n = 50) { fScanField = n; } // *MENU*
+           void            SetTargetMemoryRatio(Float_t ratio) { fTargetMemoryRatio = ratio; }
    virtual void            SetTimerInterval(Int_t msec = 333) { fTimerInterval=msec; }
    virtual void            SetTreeIndex(TVirtualIndex* index);
    virtual void            SetWeight(Double_t w = 1, Option_t* option = "");

--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -749,7 +749,7 @@ void TBasket::Reset()
    // The above code block is meant to protect against extremely large events.
 
    Float_t target_mem_ratio = fBranch->GetTree()->GetTargetMemoryRatio();
-   ssize_t max_size = std::max(fLastWriteBufferSize[0], std::max(fLastWriteBufferSize[1], fLastWriteBufferSize[2]));
+   Int_t max_size = std::max(fLastWriteBufferSize[0], std::max(fLastWriteBufferSize[1], fLastWriteBufferSize[2]));
    Int_t target_size = static_cast<Int_t>(target_mem_ratio * Float_t(max_size));
    if (max_size && (curSize > target_size) && (newSize == -1)) {
       newSize = target_size;

--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -748,15 +748,17 @@ void TBasket::Reset()
 
    Float_t target_mem_ratio = fBranch->GetTree()->GetTargetMemoryRatio();
    ssize_t max_size = std::max(fLastWriteBufferSize[0], std::max(fLastWriteBufferSize[1], fLastWriteBufferSize[2]));
-   Int_t target_size = static_cast<Int_t>(target_mem_ratio*Float_t(max_size));
+   Int_t target_size = static_cast<Int_t>(target_mem_ratio * Float_t(max_size));
    if (max_size && (curSize > target_size) && (newSize == -1)) {
       newSize = target_size;
-      newSize = newSize + 512 - newSize % 512;  // Wiggle room and alignment, as above.
+      newSize = newSize + 512 - newSize % 512; // Wiggle room and alignment, as above.
       // We only bother with a resize if it saves 8KB (two normal memory pages).
-      if ((newSize > curSize - 8*1024) || (static_cast<Float_t>(curSize)/static_cast<Float_t>(newSize) < target_mem_ratio)){
+      if ((newSize > curSize - 8 * 1024) ||
+          (static_cast<Float_t>(curSize) / static_cast<Float_t>(newSize) < target_mem_ratio)) {
          newSize = -1;
       } else if (gDebug > 0) {
-         Info("TBasket::Reset", "Resizing to %ld bytes (was %d); last three sizes were [%d, %d, %d].", newSize, curSize, fLastWriteBufferSize[0], fLastWriteBufferSize[1], fLastWriteBufferSize[2]);
+         Info("TBasket::Reset", "Resizing to %ld bytes (was %d); last three sizes were [%d, %d, %d].", newSize, curSize,
+              fLastWriteBufferSize[0], fLastWriteBufferSize[1], fLastWriteBufferSize[2]);
       }
    }
 
@@ -772,7 +774,7 @@ void TBasket::Reset()
 
    // Record the actual occupied size of the buffer.
    fLastWriteBufferSize[fNextBufferSizeRecord] = curLen;
-   fNextBufferSizeRecord = (fNextBufferSizeRecord+1) % 3;
+   fNextBufferSizeRecord = (fNextBufferSizeRecord + 1) % 3;
 
    TKey::Reset();
 

--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -759,7 +759,7 @@ void TBasket::Reset()
           (static_cast<Float_t>(curSize) / static_cast<Float_t>(newSize) < target_mem_ratio)) {
          newSize = -1;
       } else if (gDebug > 0) {
-         Info("TBasket::Reset", "Resizing to %ld bytes (was %d); last three sizes were [%d, %d, %d].", newSize, curSize,
+         Info("Reset", "Resizing to %ld bytes (was %d); last three sizes were [%d, %d, %d].", newSize, curSize,
               fLastWriteBufferSize[0], fLastWriteBufferSize[1], fLastWriteBufferSize[2]);
       }
    }

--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -749,7 +749,7 @@ void TBasket::Reset()
    // The above code block is meant to protect against extremely large events.
 
    Float_t target_mem_ratio = fBranch->GetTree()->GetTargetMemoryRatio();
-   Int_t max_size = std::max(fLastWriteBufferSize[0], std::max(fLastWriteBufferSize[1], fLastWriteBufferSize[2]));
+   Int_t max_size = TMath::Max(fLastWriteBufferSize[0], std::max(fLastWriteBufferSize[1], fLastWriteBufferSize[2]));
    Int_t target_size = static_cast<Int_t>(target_mem_ratio * Float_t(max_size));
    if (max_size && (curSize > target_size) && (newSize == -1)) {
       newSize = target_size;

--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -708,7 +708,9 @@ void TBasket::Reset()
 {
    // By default, we don't reallocate.
    fResetAllocation = false;
+#ifdef R__TRACK_BASKET_ALLOC_TIME
    fResetAllocationTime = 0;
+#endif
 
    // Name, Title, fClassName, fBranch
    // stay the same.
@@ -764,12 +766,16 @@ void TBasket::Reset()
 
    if (newSize != -1) {
       fResetAllocation = true;
+#ifdef R__TRACK_BASKET_ALLOC_TIME
       std::chrono::time_point<std::chrono::system_clock> start, end;
       start = std::chrono::high_resolution_clock::now();
+#endif
       fBufferRef->Expand(newSize,kFALSE);     // Expand without copying the existing data.
+#ifdef R__TRACK_BASKET_ALLOC_TIME
       end = std::chrono::high_resolution_clock::now();
       auto us = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
       fResetAllocationTime = us.count();
+#endif
    }
 
    // Record the actual occupied size of the buffer.

--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -8,6 +8,8 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+#include <chrono>
+
 #include "TBasket.h"
 #include "TBuffer.h"
 #include "TBufferFile.h"
@@ -128,6 +130,10 @@ void TBasket::AdjustSize(Int_t newsize)
    }
    fBranch->GetTree()->IncrementTotalBuffers(newsize-fBufferSize);
    fBufferSize  = newsize;
+   fLastWriteBufferSize[0] = newsize;
+   fLastWriteBufferSize[1] = 0;
+   fLastWriteBufferSize[2] = 0;
+   fNextBufferSizeRecord = 1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -700,10 +706,17 @@ Int_t TBasket::ReadBasketBytes(Long64_t pos, TFile *file)
 
 void TBasket::Reset()
 {
+   // By default, we don't reallocate.
+   fResetAllocation = false;
+   fResetAllocationTime = 0;
+
    // Name, Title, fClassName, fBranch
    // stay the same.
 
    // Downsize the buffer if needed.
+   // See if our current buffer size is significantly larger (>2x) than the historical average.
+   // If so, try decreasing it at this flush boundary to closer to the size from OptimizeBaskets
+   // (or this historical average).
    Int_t curSize = fBufferRef->BufferSize();
    // fBufferLen at this point is already reset, so use indirect measurements
    Int_t curLen = (GetObjlen() + GetKeylen());
@@ -725,19 +738,41 @@ void TBasket::Reset()
          }
       }
    }
-   /*
-      Philippe has asked us to keep this turned off until we finish memory fragmentation studies.
-   // If fBufferRef grew since we last saw it, shrink it to 105% of the occupied size
-   if (curSize > fLastWriteBufferSize) {
-      if (newSize == -1) {
-         newSize = Int_t(1.05*Float_t(fBufferRef->Length()));
+   // If fBufferRef grew since we last saw it, shrink it to "target memory ratio" of the occupied size
+   // This discourages us from having poorly-occupied buffers on branches with little variability.
+   //
+   // Does not help protect against a burst in event sizes, but does help in the cases where the basket
+   // size jumps from 4MB to 8MB while filling the basket, but we only end up utilizing 4.1MB.
+   //
+   // The above code block is meant to protect against extremely large events.
+
+   Float_t target_mem_ratio = fBranch->GetTree()->GetTargetMemoryRatio();
+   ssize_t max_size = std::max(fLastWriteBufferSize[0], std::max(fLastWriteBufferSize[1], fLastWriteBufferSize[2]));
+   Int_t target_size = static_cast<Int_t>(target_mem_ratio*Float_t(max_size));
+   if (max_size && (curSize > target_size) && (newSize == -1)) {
+      newSize = target_size;
+      newSize = newSize + 512 - newSize % 512;  // Wiggle room and alignment, as above.
+      // We only bother with a resize if it saves 8KB (two normal memory pages).
+      if ((newSize > curSize - 8*1024) || (static_cast<Float_t>(curSize)/static_cast<Float_t>(newSize) < target_mem_ratio)){
+         newSize = -1;
+      } else if (gDebug > 0) {
+         Info("TBasket::Reset", "Resizing to %ld bytes (was %d); last three sizes were [%d, %d, %d].", newSize, curSize, fLastWriteBufferSize[0], fLastWriteBufferSize[1], fLastWriteBufferSize[2]);
       }
-      fLastWriteBufferSize = newSize;
    }
-   */
+
    if (newSize != -1) {
+      fResetAllocation = true;
+      std::chrono::time_point<std::chrono::system_clock> start, end;
+      start = std::chrono::high_resolution_clock::now();
       fBufferRef->Expand(newSize,kFALSE);     // Expand without copying the existing data.
+      end = std::chrono::high_resolution_clock::now();
+      auto us = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+      fResetAllocationTime = us.count();
    }
+
+   // Record the actual occupied size of the buffer.
+   fLastWriteBufferSize[fNextBufferSizeRecord] = curLen;
+   fNextBufferSizeRecord = (fNextBufferSizeRecord+1) % 3;
 
    TKey::Reset();
 

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -881,11 +881,9 @@ Int_t TBranch::FillImpl(ROOT::Internal::TBranchIMTHelper *imtHelper)
    // first event cluster is written out and *then* enable one-basket-per-cluster mode.
    bool noFlushAtCluster = !fTree->TestBit(TTree::kFlushAtCluster) || (fTree->GetAutoFlush() < 0);
 
-   if (noFlushAtCluster &&
-       !fTree->TestBit(TTree::kCircular) &&
-         ((fSkipZip && (lnew >= TBuffer::kMinimalSize)) ||
-          (buf->TestBit(TBufferFile::kNotDecompressed)) ||
-          ((lnew + (2 * nsize) + nbytes) >= fBasketSize))) {
+   if (noFlushAtCluster && !fTree->TestBit(TTree::kCircular) &&
+       ((fSkipZip && (lnew >= TBuffer::kMinimalSize)) || (buf->TestBit(TBufferFile::kNotDecompressed)) ||
+        ((lnew + (2 * nsize) + nbytes) >= fBasketSize))) {
       Int_t nout = WriteBasketImpl(basket, fWriteBasket, imtHelper);
       if (nout < 0) Error("TBranch::Fill", "Failed to write out basket.\n");
       return (nout >= 0) ? nbytes : -1;

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -879,7 +879,7 @@ Int_t TBranch::FillImpl(ROOT::Internal::TBranchIMTHelper *imtHelper)
    // based upon the number of bytes already flushed.  This is incompatible with one-basket-per-cluster
    // (since we will grow the basket indefinitely and never flush!).  Hence, we wait until the
    // first event cluster is written out and *then* enable one-basket-per-cluster mode.
-   bool noFlushAtCluster = !fTree->TestBit(TTree::kFlushAtCluster) || (fTree->GetAutoFlush() < 0);
+   bool noFlushAtCluster = !fTree->TestBit(TTree::kOnlyFlushAtCluster) || (fTree->GetAutoFlush() < 0);
 
    if (noFlushAtCluster && !fTree->TestBit(TTree::kCircular) &&
        ((fSkipZip && (lnew >= TBuffer::kMinimalSize)) || (buf->TestBit(TBufferFile::kNotDecompressed)) ||

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -2811,7 +2811,9 @@ Int_t TBranch::WriteBasketImpl(TBasket* basket, Int_t where, ROOT::Internal::TBr
          fTotBytes += addbytes;
          fTree->AddTotBytes(addbytes);
          fTree->AddZipBytes(nout);
+#ifdef R__TRACK_BASKET_ALLOC_TIME
          fTree->AddAllocationTime(reusebasket->ResetAllocationTime());
+#endif
          fTree->AddAllocationCount(reusebasket->ResetAllocationCount());
       }
 

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -2812,9 +2812,9 @@ Int_t TBranch::WriteBasketImpl(TBasket* basket, Int_t where, ROOT::Internal::TBr
          fTree->AddTotBytes(addbytes);
          fTree->AddZipBytes(nout);
 #ifdef R__TRACK_BASKET_ALLOC_TIME
-         fTree->AddAllocationTime(reusebasket->ResetAllocationTime());
+         fTree->AddAllocationTime(reusebasket->GetResetAllocationTime());
 #endif
-         fTree->AddAllocationCount(reusebasket->ResetAllocationCount());
+         fTree->AddAllocationCount(reusebasket->GetResetAllocationCount());
       }
 
       if (where==fWriteBasket) {

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -883,7 +883,9 @@ TTree::~TTree()
 {
    if (fAllocationCount && (gDebug > 0)) {
       Info("TTree::~TTree", "For tree %s, allocation count is %u.", GetName(), fAllocationCount);
+#ifdef R__TRACK_BASKET_ALLOC_TIME
       Info("TTree::~TTree", "For tree %s, allocation time is %lluus.", GetName(), fAllocationTime);
+#endif
    }
 
    if (fDirectory) {

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -4482,8 +4482,8 @@ Int_t TTree::Fill()
             autoFlush = false; // avoid auto flushing again later
 
             // When we are in one-basket-per-cluster mode, there is no need to optimize basket:
-            // they will automatically grow to the size needed for an event cluster (with the basket)
-            // shrinking preventing them from growing too much larger than the actually-used space.
+            // they will automatically grow to the size needed for an event cluster (with the basket
+            // shrinking preventing them from growing too much larger than the actually-used space).
             if (!TestBit(TTree::kOnlyFlushAtCluster)) {
                OptimizeBaskets(GetTotBytes(), 1, "");
                if (gDebug > 0)

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -4484,7 +4484,7 @@ Int_t TTree::Fill()
             // When we are in one-basket-per-cluster mode, there is no need to optimize basket:
             // they will automatically grow to the size needed for an event cluster (with the basket)
             // shrinking preventing them from growing too much larger than the actually-used space.
-            if (!TestBit(TTree::kFlushAtCluster)) {
+            if (!TestBit(TTree::kOnlyFlushAtCluster)) {
                OptimizeBaskets(GetTotBytes(), 1, "");
                if (gDebug > 0)
                   Info("TTree::Fill", "OptimizeBaskets called at entry %lld, fZipBytes=%lld, fFlushedBytes=%lld\n",

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -882,9 +882,9 @@ TTree::TTree(const char* name, const char* title, Int_t splitlevel /* = 99 */,
 TTree::~TTree()
 {
    if (fAllocationCount && (gDebug > 0)) {
-      Info("TTree::~TTree", "For tree %s, allocation count is %u.", GetName(), fAllocationCount);
+      Info("TTree::~TTree", "For tree %s, allocation count is %u.", GetName(), fAllocationCount.load());
 #ifdef R__TRACK_BASKET_ALLOC_TIME
-      Info("TTree::~TTree", "For tree %s, allocation time is %lluus.", GetName(), fAllocationTime);
+      Info("TTree::~TTree", "For tree %s, allocation time is %lluus.", GetName(), fAllocationTime.load());
 #endif
    }
 

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -4485,7 +4485,7 @@ Int_t TTree::Fill()
             // they will automatically grow to the size needed for an event cluster (with the basket)
             // shrinking preventing them from growing too much larger than the actually-used space.
             if (!TestBit(TTree::kFlushAtCluster)) {
-               OptimizeBaskets(GetTotBytes(),1,"");
+               OptimizeBaskets(GetTotBytes(), 1, "");
                if (gDebug > 0)
                   Info("TTree::Fill", "OptimizeBaskets called at entry %lld, fZipBytes=%lld, fFlushedBytes=%lld\n",
                        fEntries, GetZipBytes(), fFlushedBytes);

--- a/tree/tree/test/CMakeLists.txt
+++ b/tree/tree/test/CMakeLists.txt
@@ -2,4 +2,5 @@
 ROOT_ADD_GTEST(testTBasket TBasket.cxx LIBRARIES RIO Tree)
 ROOT_ADD_GTEST(testTBranch TBranch.cxx LIBRARIES RIO Tree MathCore)
 ROOT_ADD_GTEST(testTIOFeatures TIOFeatures.cxx LIBRARIES RIO Tree)
+ROOT_ADD_GTEST(testTTreeCluster TTreeClusterTest.cxx LIBRARIES RIO Tree MathCore)
 

--- a/tree/tree/test/TTreeClusterTest.cxx
+++ b/tree/tree/test/TTreeClusterTest.cxx
@@ -1,0 +1,55 @@
+#include "TFile.h"
+#include "TTree.h"
+#include "TBranch.h"
+#include "TRandom.h"
+
+#include "gtest/gtest.h"
+
+class TTreeClusterTest : public ::testing::Test {
+protected:
+   virtual void SetUp()
+   {
+      auto random = new TRandom(836);
+      auto file = new TFile("TTreeClusterTest.root", "RECREATE");
+      auto tree = new TTree("tree", "A test tree");
+      auto tree2 = new TTree("tree2", "A test tree with one-basket-per-cluster");
+      tree2->SetBit(TTree::kOnlyFlushAtCluster);
+      tree->SetAutoFlush(500);
+      tree2->SetAutoFlush(500);
+      Double_t data = 0;
+      auto branch = tree->Branch("branch", &data);
+      auto branch2 = tree2->Branch("branch", &data);
+
+      for (Int_t ev = 0; ev < 1000; ev++) {
+         data = random->Gaus(100, 7);
+         tree->Fill();
+         tree2->Fill();
+         if (ev == 100) {
+            // 8 bytes per double; 500 doubles per event cluster; we need at
+            // least 4000 bytes to hold the data of one cluster.  Setting the
+            // basket size well under this to force multiple baskets per event
+            // cluster in "regular mode".
+            branch->SetBasketSize(100);
+            branch2->SetBasketSize(100);
+         }
+      }
+      file->Write();
+      delete random;
+      delete tree;
+      delete file;
+   }
+};
+
+TEST_F(TTreeClusterTest, countBaskets)
+{
+   auto file = new TFile("TTreeClusterTest.root");
+   auto tree = static_cast<TTree *>(file->Get("tree"));
+   auto tree2 = static_cast<TTree *>(file->Get("tree2"));
+   auto branch = tree->GetBranch("branch");
+   auto branch2 = tree2->GetBranch("branch");
+
+   ASSERT_TRUE(branch->GetWriteBasket() == 102);
+   ASSERT_TRUE(branch2->GetWriteBasket() == 2);
+
+   delete file;
+}


### PR DESCRIPTION
By setting a new bit in the TTree object, `kFlushAtCluster`, one can enter the "one basket per event cluster" mode.  This forces baskets to line up with event clusters, at the cost of extra memory use.

This new mode simplifies the basket layout within the file, reducing the amount of time handling special cases for the bulk IO mode.

Because the baskets *must* grow to the size of an event cluster, we do not invoke `OptimizeBaskets` when one-basket-per-cluster mode is enabled.

As this mode is expected to cause increased memory usage (the memory utilized by the `TTree` is more strongly tied to the variations in event size), we combine this with a technique borrowed from a CMS patchset to more aggressively shrink basket sizes after very large objects.

The new basket shrinking algorithm will trigger whenever the basket is flushed.  If the actual object size in the last clusters is significantly below the buffer size, then the basket will be shrunk.  Given this tradeoff, I do not currently see this being enabled by default.

The ideal ratio of `(basket buffer size)/(occupied buffer size)` is controlled by a new tunable in the `TTree`, defaulting to 1.1.  A lower setting reduces overall memory usage at the cost of extra allocations; a higher setting increases aggregate memory usage.

In writing out a 10k event CMS file (total CPU time is 32 minutes):

- Base case (without this patch):
   - 888MB RSS
   - 30 reallocations (shrinking of baskets due to low occupancy).
   - 0.173ms taken for reallocation.
- New shrinking algorithm (this patch with defaults):
   - 866MB RSS
   - 4434 reallocations
   - 97.0ms
- One basket per cluster mode with new shrinking algorithm:
   - 902MB RSS
   - 2882 reallocations
   - 93.6ms

The CPU-time cost of the reallocation is 0.005% of total runtime (considering the file has to be read also, maybe 0.01% of output time?)

This patch purposely leaves in the code that measures reallocation time in order to allow others to experiment; the intent is to disable / remove the code before a final release.