### PR TITLE
[TDF] Early validation of column names

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFUtils.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFUtils.hxx
@@ -43,6 +43,8 @@ using ColumnNames_t = std::vector<std::string>;
 
 // fwd decl for ColumnName2ColumnTypeName
 class TCustomColumnBase;
+// fwd decl for FindUnknownColumns
+class TLoopManager;
 
 // type used for tag dispatching
 struct TInferType {
@@ -181,8 +183,11 @@ void CheckReduce(F &, T)
    static_assert(sizeof(F) == 0, "reduce function must take exactly two arguments of the same type");
 }
 
-/// Returns local BranchNames or default BranchNames according to which one should be used
+/// Return local BranchNames or default BranchNames according to which one should be used
 const ColumnNames_t SelectColumns(unsigned int nArgs, const ColumnNames_t &bl, const ColumnNames_t &defBl);
+
+/// Check whether column names refer to a valid branch of a TTree or have been `Define`d. Return invalid column names.
+ColumnNames_t FindUnknownColumns(const ColumnNames_t &columns, const TLoopManager &lm);
 
 namespace ActionTypes {
 struct Histo1D {

--- a/tree/treeplayer/src/TDFUtils.cxx
+++ b/tree/treeplayer/src/TDFUtils.cxx
@@ -9,7 +9,7 @@
  *************************************************************************/
 
 #include "RConfigure.h"      // R__USE_IMT
-#include "ROOT/TDFNodes.hxx" // ColumnName2ColumnTypeName requires TCustomColumnBase
+#include "ROOT/TDFNodes.hxx" // ColumnName2ColumnTypeName -> TCustomColumnBase, FindUnknownColumns -> TLoopManager
 #include "ROOT/TDFUtils.hxx"
 #include "TBranch.h"
 #include "TBranchElement.h"
@@ -163,6 +163,21 @@ const ColumnNames_t SelectColumns(unsigned int nRequiredNames, const ColumnNames
                                   std::to_string(names.size()) + " were provided.");
       return names;
    }
+}
+
+ColumnNames_t FindUnknownColumns(const ColumnNames_t &columns, const TLoopManager &lm)
+{
+   const auto customColumns = lm.GetBookedBranches();
+   auto *const tree = lm.GetTree();
+   ColumnNames_t unknownColumns;
+   for (auto &column : columns) {
+      const auto isTreeBranch = (tree != nullptr && tree->GetBranch(column.c_str()) != nullptr);
+      if (isTreeBranch) continue;
+      const auto isCustomColumn = (customColumns.find(column) != customColumns.end());
+      if (isCustomColumn) continue;
+      unknownColumns.emplace_back(column);
+   }
+   return unknownColumns;
 }
 
 } // end NS TDF


### PR DESCRIPTION
This PR solves ROOT-8873 "Reinforce the mechanism to detect non existing branches".

All transformations and actions now throw an exception right when called if at least one of the columns they will work on is not present in the data nor is a custom column (created via `Define`).

`test_missingBranches` is expected to start failing -- a PR in roottest will update the reference file.