### PR TITLE
Fixed handling of signal and background classes in DNN

### DIFF
--- a/tmva/tmva/inc/TMVA/DNN/DataLoader.h
+++ b/tmva/tmva/inc/TMVA/DNN/DataLoader.h
@@ -26,13 +26,16 @@
 #include "TMVA/Event.h"
 
 namespace TMVA {
+
+class DataSetInfo;
+
 namespace DNN  {
 
 //
 // Input Data Types
 //______________________________________________________________________________
 using MatrixInput_t = std::tuple<const TMatrixT<Double_t> &, const TMatrixT<Double_t> &, const TMatrixT<Double_t> &>;
-using TMVAInput_t      = std::vector<Event*>;
+using TMVAInput_t      = std::tuple<std::vector<Event*>, DataSetInfo&>;
 
 using IndexIterator_t = typename std::vector<size_t>::iterator;
 

--- a/tmva/tmva/inc/TMVA/DNN/DataLoader.h
+++ b/tmva/tmva/inc/TMVA/DNN/DataLoader.h
@@ -35,7 +35,7 @@ namespace DNN  {
 // Input Data Types
 //______________________________________________________________________________
 using MatrixInput_t = std::tuple<const TMatrixT<Double_t> &, const TMatrixT<Double_t> &, const TMatrixT<Double_t> &>;
-using TMVAInput_t      = std::tuple<std::vector<Event*>, DataSetInfo&>;
+using TMVAInput_t = std::tuple<std::vector<Event *>, DataSetInfo &>;
 
 using IndexIterator_t = typename std::vector<size_t>::iterator;
 

--- a/tmva/tmva/src/DNN/Architectures/Cpu/CpuBuffer.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Cpu/CpuBuffer.cxx
@@ -15,6 +15,7 @@
 
 #include <vector>
 #include <memory>
+#include "TMVA/DataSetInfo.h"
 #include "TMVA/DNN/DataLoader.h"
 #include "TMVA/DNN/Architectures/Cpu.h"
 #include "Rtypes.h"
@@ -178,14 +179,11 @@ template <>
 void TDataLoader<TMVAInput_t, TCpu<Double_t>>::CopyInput(TCpuBuffer<Double_t> &buffer, IndexIterator_t sampleIterator,
                                                          size_t batchSize)
 {
-   Event * event  = fData.front();
+   Event *event = std::get<0>(fData)[0];
    size_t n  = event->GetNVariables();
-
-   // Copy input variables.
-
    for (size_t i = 0; i < batchSize; i++) {
       size_t sampleIndex = * sampleIterator++;
-      event = fData[sampleIndex];
+      event = std::get<0>(fData)[sampleIndex];
       for (size_t j = 0; j < n; j++) {
          size_t bufferIndex = j * batchSize + i;
          buffer[bufferIndex] = event->GetValue(j);
@@ -200,14 +198,14 @@ void TDataLoader<TMVAInput_t, TCpu<Double_t>>::CopyOutput(
     IndexIterator_t sampleIterator,
     size_t batchSize)
 {
-   Event * event  = fData.front();
-   size_t n       = buffer.GetSize() / batchSize;
+   DataSetInfo &info = std::get<1>(fData);
+   size_t n = buffer.GetSize() / batchSize;
 
    // Copy target(s).
 
    for (size_t i = 0; i < batchSize; i++) {
       size_t sampleIndex = * sampleIterator++;
-      event = fData[sampleIndex];
+      Event *event = std::get<0>(fData)[sampleIndex];
       for (size_t j = 0; j < n; j++) {
          // Copy output matrices.
          size_t bufferIndex = j * batchSize + i;
@@ -215,7 +213,7 @@ void TDataLoader<TMVAInput_t, TCpu<Double_t>>::CopyOutput(
          if (event->GetNTargets() == 0) {
             if (n == 1) {
                // Binary.
-               buffer[bufferIndex] = (event->GetClass() == 0) ? 1.0 : 0.0;
+               buffer[bufferIndex] = (info.IsSignal(event)) ? 1.0 : 0.0;
             } else {
                // Multiclass.
                buffer[bufferIndex] = 0.0;
@@ -235,11 +233,9 @@ template <>
 void TDataLoader<TMVAInput_t, TCpu<Double_t>>::CopyWeights(TCpuBuffer<Double_t> &buffer, IndexIterator_t sampleIterator,
                                                            size_t batchSize)
 {
-   Event *event = fData.front();
-
    for (size_t i = 0; i < batchSize; i++) {
       size_t sampleIndex = *sampleIterator++;
-      event = fData[sampleIndex];
+      Event *event = std::get<0>(fData)[sampleIndex];
       buffer[i] = event->GetWeight();
    }
 }
@@ -249,14 +245,11 @@ template <>
 void TDataLoader<TMVAInput_t, TCpu<Real_t>>::CopyInput(TCpuBuffer<Real_t> &buffer, IndexIterator_t sampleIterator,
                                                        size_t batchSize)
 {
-   Event * event  = fData.front();
+   Event *event = std::get<0>(fData)[0];
    size_t n  = event->GetNVariables();
-
-   // Copy input variables.
-
    for (size_t i = 0; i < batchSize; i++) {
       size_t sampleIndex = * sampleIterator++;
-      event = fData[sampleIndex];
+      event = std::get<0>(fData)[sampleIndex];
       for (size_t j = 0; j < n; j++) {
          size_t bufferIndex = j * batchSize + i;
          buffer[bufferIndex] = static_cast<Real_t>(event->GetValue(j));
@@ -271,14 +264,14 @@ void TDataLoader<TMVAInput_t, TCpu<Real_t>>::CopyOutput(
     IndexIterator_t sampleIterator,
     size_t batchSize)
 {
-   Event * event  = fData.front();
+   DataSetInfo &info = std::get<1>(fData);
    size_t n       = buffer.GetSize() / batchSize;
 
    // Copy target(s).
 
    for (size_t i = 0; i < batchSize; i++) {
       size_t sampleIndex = * sampleIterator++;
-      event = fData[sampleIndex];
+      Event *event = std::get<0>(fData)[sampleIndex];
       for (size_t j = 0; j < n; j++) {
          // Copy output matrices.
          size_t bufferIndex = j * batchSize + i;
@@ -286,7 +279,7 @@ void TDataLoader<TMVAInput_t, TCpu<Real_t>>::CopyOutput(
          if (event->GetNTargets() == 0) {
             if (n == 1) {
                // Binary.
-               buffer[bufferIndex] = (event->GetClass() == 0) ? 1.0 : 0.0;
+                buffer[bufferIndex] = (info.IsSignal(event)) ? 1.0 : 0.0;
             } else {
                // Multiclass.
                buffer[bufferIndex] = 0.0;
@@ -303,14 +296,14 @@ void TDataLoader<TMVAInput_t, TCpu<Real_t>>::CopyOutput(
 
 //______________________________________________________________________________
 template <>
-void TDataLoader<TMVAInput_t, TCpu<Real_t>>::CopyWeights(TCpuBuffer<Real_t> &buffer, IndexIterator_t sampleIterator,
-                                                         size_t batchSize)
+void TDataLoader<TMVAInput_t, TCpu<Real_t>>::CopyWeights(
+    TCpuBuffer<Real_t> &buffer,
+    IndexIterator_t sampleIterator,
+    size_t batchSize)
 {
-   Event *event = fData.front();
-
    for (size_t i = 0; i < batchSize; i++) {
       size_t sampleIndex = *sampleIterator++;
-      event = fData[sampleIndex];
+      Event *event = std::get<0>(fData)[sampleIndex];
       buffer[i] = static_cast<Real_t>(event->GetWeight());
    }
 }

--- a/tmva/tmva/src/DNN/Architectures/Cpu/CpuBuffer.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Cpu/CpuBuffer.cxx
@@ -279,7 +279,7 @@ void TDataLoader<TMVAInput_t, TCpu<Real_t>>::CopyOutput(
          if (event->GetNTargets() == 0) {
             if (n == 1) {
                // Binary.
-                buffer[bufferIndex] = (info.IsSignal(event)) ? 1.0 : 0.0;
+               buffer[bufferIndex] = (info.IsSignal(event)) ? 1.0 : 0.0;
             } else {
                // Multiclass.
                buffer[bufferIndex] = 0.0;
@@ -296,10 +296,8 @@ void TDataLoader<TMVAInput_t, TCpu<Real_t>>::CopyOutput(
 
 //______________________________________________________________________________
 template <>
-void TDataLoader<TMVAInput_t, TCpu<Real_t>>::CopyWeights(
-    TCpuBuffer<Real_t> &buffer,
-    IndexIterator_t sampleIterator,
-    size_t batchSize)
+void TDataLoader<TMVAInput_t, TCpu<Real_t>>::CopyWeights(TCpuBuffer<Real_t> &buffer, IndexIterator_t sampleIterator,
+                                                         size_t batchSize)
 {
    for (size_t i = 0; i < batchSize; i++) {
       size_t sampleIndex = *sampleIterator++;

--- a/tmva/tmva/src/DNN/Architectures/Cuda/CudaBuffers.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Cuda/CudaBuffers.cxx
@@ -225,7 +225,7 @@ void TDataLoader<TMVAInput_t, TCuda<float>>::CopyOutput(
    // Copy target(s).
 
    for (size_t i = 0; i < batchSize; i++) {
-      size_t sampleIndex = * sampleIterator++;
+      size_t sampleIndex = *sampleIterator++;
       Event *event = std::get<0>(fData)[sampleIndex];
       for (size_t j = 0; j < n; j++) {
          // Copy output matrices.
@@ -234,7 +234,7 @@ void TDataLoader<TMVAInput_t, TCuda<float>>::CopyOutput(
          if (event->GetNTargets() == 0) {
             if (n == 1) {
                // Binary.
-                buffer[bufferIndex] = (info.IsSignal(event)) ? 1.0 : 0.0;
+               buffer[bufferIndex] = (info.IsSignal(event)) ? 1.0 : 0.0;
             } else {
                // Multiclass.
                buffer[bufferIndex] = 0.0;
@@ -341,7 +341,7 @@ void TDataLoader<TMVAInput_t, TCuda<double>>::CopyOutput(
    // Copy target(s).
 
    for (size_t i = 0; i < batchSize; i++) {
-      size_t sampleIndex = * sampleIterator++;
+      size_t sampleIndex = *sampleIterator++;
       Event *event = std::get<0>(fData)[sampleIndex];
       for (size_t j = 0; j < n; j++) {
          // Copy output matrices.
@@ -350,7 +350,7 @@ void TDataLoader<TMVAInput_t, TCuda<double>>::CopyOutput(
          if (event->GetNTargets() == 0) {
                // Binary.
             if (n == 1) {
-                buffer[bufferIndex] = (info.IsSignal(event)) ? 1.0 : 0.0;
+               buffer[bufferIndex] = (info.IsSignal(event)) ? 1.0 : 0.0;
             } else {
                // Multiclass.
                buffer[bufferIndex] = 0.0;

--- a/tmva/tmva/src/DNN/Architectures/Cuda/CudaBuffers.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Cuda/CudaBuffers.cxx
@@ -13,6 +13,7 @@
 // Implementation of device and host buffers for CUDA architectures.  //
 ////////////////////////////////////////////////////////////////////////
 
+#include "TMVA/DataSetInfo.h"
 #include "TMVA/DNN/DataLoader.h"
 #include "TMVA/DNN/Architectures/Cuda.h"
 #include "TMVA/DNN/Architectures/Cuda/CudaBuffers.h"
@@ -199,14 +200,11 @@ void TDataLoader<TMVAInput_t, TCuda<float>>::CopyInput(
     IndexIterator_t sampleIterator,
     size_t batchSize)
 {
-   Event * event  = fData.front();
+   Event *event = std::get<0>(fData)[0];
    size_t n  = event->GetNVariables();
-
-   // Copy input variables.
-
    for (size_t i = 0; i < batchSize; i++) {
       size_t sampleIndex = * sampleIterator++;
-      event = fData[sampleIndex];
+      event = std::get<0>(fData)[sampleIndex];
       for (size_t j = 0; j < n; j++) {
          size_t bufferIndex = j * batchSize + i;
          buffer[bufferIndex] = static_cast<float>(event->GetValue(j));
@@ -221,14 +219,14 @@ void TDataLoader<TMVAInput_t, TCuda<float>>::CopyOutput(
     IndexIterator_t sampleIterator,
     size_t batchSize)
 {
-   Event * event  = fData.front();
+   DataSetInfo &info = std::get<1>(fData);
    size_t n       = buffer.GetSize() / batchSize;
 
    // Copy target(s).
 
    for (size_t i = 0; i < batchSize; i++) {
-       size_t sampleIndex = * sampleIterator++;
-       event = fData[sampleIndex];
+      size_t sampleIndex = * sampleIterator++;
+      Event *event = std::get<0>(fData)[sampleIndex];
       for (size_t j = 0; j < n; j++) {
          // Copy output matrices.
          size_t bufferIndex = j * batchSize + i;
@@ -236,7 +234,7 @@ void TDataLoader<TMVAInput_t, TCuda<float>>::CopyOutput(
          if (event->GetNTargets() == 0) {
             if (n == 1) {
                // Binary.
-               buffer[bufferIndex] = (event->GetClass() == 0) ? 1.0 : 0.0;
+                buffer[bufferIndex] = (info.IsSignal(event)) ? 1.0 : 0.0;
             } else {
                // Multiclass.
                buffer[bufferIndex] = 0.0;
@@ -256,11 +254,9 @@ template <>
 void TDataLoader<TMVAInput_t, TCuda<float>>::CopyWeights(TCudaHostBuffer<float> &buffer, IndexIterator_t sampleIterator,
                                                          size_t batchSize)
 {
-   Event *event = fData.front();
-
    for (size_t i = 0; i < batchSize; i++) {
       size_t sampleIndex = *sampleIterator++;
-      event = fData[sampleIndex];
+      Event *event = std::get<0>(fData)[sampleIndex];
       buffer[i] = static_cast<float>(event->GetWeight());
    }
 }
@@ -320,14 +316,11 @@ template <>
 void TDataLoader<TMVAInput_t, TCuda<double>>::CopyInput(TCudaHostBuffer<double> &buffer, IndexIterator_t sampleIterator,
                                                         size_t batchSize)
 {
-   Event * event  = fData.front();
+   Event *event = std::get<0>(fData)[0];
    size_t n  = event->GetNVariables();
-
-   // Copy input variables.
-
    for (size_t i = 0; i < batchSize; i++) {
       size_t sampleIndex = * sampleIterator++;
-      event = fData[sampleIndex];
+      event = std::get<0>(fData)[sampleIndex];
       for (size_t j = 0; j < n; j++) {
          size_t bufferIndex = j * batchSize + i;
          buffer[bufferIndex] = event->GetValue(j);
@@ -342,14 +335,14 @@ void TDataLoader<TMVAInput_t, TCuda<double>>::CopyOutput(
     IndexIterator_t sampleIterator,
     size_t batchSize)
 {
-   Event * event  = fData.front();
+   DataSetInfo &info = std::get<1>(fData);
    size_t n       = buffer.GetSize() / batchSize;
 
    // Copy target(s).
 
    for (size_t i = 0; i < batchSize; i++) {
-       size_t sampleIndex = * sampleIterator++;
-       event = fData[sampleIndex];
+      size_t sampleIndex = * sampleIterator++;
+      Event *event = std::get<0>(fData)[sampleIndex];
       for (size_t j = 0; j < n; j++) {
          // Copy output matrices.
          size_t bufferIndex = j * batchSize + i;
@@ -357,7 +350,7 @@ void TDataLoader<TMVAInput_t, TCuda<double>>::CopyOutput(
          if (event->GetNTargets() == 0) {
                // Binary.
             if (n == 1) {
-               buffer[bufferIndex] = (event->GetClass() == 0) ? 1.0 : 0.0;
+                buffer[bufferIndex] = (info.IsSignal(event)) ? 1.0 : 0.0;
             } else {
                // Multiclass.
                buffer[bufferIndex] = 0.0;
@@ -377,11 +370,9 @@ template <>
 void TDataLoader<TMVAInput_t, TCuda<double>>::CopyWeights(TCudaHostBuffer<double> &buffer,
                                                           IndexIterator_t sampleIterator, size_t batchSize)
 {
-   Event *event = fData.front();
-
    for (size_t i = 0; i < batchSize; i++) {
       size_t sampleIndex = *sampleIterator++;
-      event = fData[sampleIndex];
+      Event *event = std::get<0>(fData)[sampleIndex];
       buffer[i] = static_cast<double>(event->GetWeight());
    }
 }

--- a/tmva/tmva/src/DNN/Architectures/Reference/DataLoader.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Reference/DataLoader.cxx
@@ -15,6 +15,7 @@
 /////////////////////////////////////////////////////////////
 
 #include "TMVA/DNN/Architectures/Reference.h"
+#include "TMVA/DataSetInfo.h"
 
 namespace TMVA {
 namespace DNN {
@@ -124,7 +125,8 @@ void TDataLoader<MatrixInput_t, TReference<Double_t>>::CopyWeights(TMatrixT<Doub
 template <>
 void TDataLoader<TMVAInput_t, TReference<Real_t>>::CopyInput(TMatrixT<Real_t> &matrix, IndexIterator_t sampleIterator)
 {
-   Event *event = fData.front();
+   Event *event = nullptr;
+
    Int_t m = matrix.GetNrows();
    Int_t n = event->GetNVariables();
 
@@ -132,7 +134,7 @@ void TDataLoader<TMVAInput_t, TReference<Real_t>>::CopyInput(TMatrixT<Real_t> &m
 
    for (Int_t i = 0; i < m; i++) {
       Int_t sampleIndex = *sampleIterator++;
-      event = fData[sampleIndex];
+      event = std::get<0>(fData)[sampleIndex];
       for (Int_t j = 0; j < n; j++) {
          matrix(i, j) = event->GetValue(j);
       }
@@ -143,19 +145,20 @@ void TDataLoader<TMVAInput_t, TReference<Real_t>>::CopyInput(TMatrixT<Real_t> &m
 template <>
 void TDataLoader<TMVAInput_t, TReference<Real_t>>::CopyOutput(TMatrixT<Real_t> &matrix, IndexIterator_t sampleIterator)
 {
-   Event *event = fData.front();
+   Event *event = std::get<0>(fData).front();
+   DataSetInfo &info = std::get<1>(fData);
    Int_t m = matrix.GetNrows();
    Int_t n = matrix.GetNcols();
 
    for (Int_t i = 0; i < m; i++) {
       Int_t sampleIndex = *sampleIterator++;
-      event = fData[sampleIndex];
+      event = std::get<0>(fData)[sampleIndex];
       for (Int_t j = 0; j < n; j++) {
          // Classification
          if (event->GetNTargets() == 0) {
             if (n == 1) {
                // Binary.
-               matrix(i, j) = (event->GetClass() == 0) ? 1.0 : 0.0;
+               matrix(i, j) = (info.IsSignal(event)) ? 1.0 : 0.0;
             } else {
                // Multiclass.
                matrix(i, j) = 0.0;
@@ -174,11 +177,10 @@ void TDataLoader<TMVAInput_t, TReference<Real_t>>::CopyOutput(TMatrixT<Real_t> &
 template <>
 void TDataLoader<TMVAInput_t, TReference<Real_t>>::CopyWeights(TMatrixT<Real_t> &matrix, IndexIterator_t sampleIterator)
 {
-   Event *event = fData.front();
-
+   Event *event = std::get<0>(fData).front();
    for (Int_t i = 0; i < matrix.GetNrows(); i++) {
       Int_t sampleIndex = *sampleIterator++;
-      event = fData[sampleIndex];
+      event = std::get<0>(fData)[sampleIndex];
       matrix(i, 0) = event->GetWeight();
    }
 }
@@ -188,7 +190,7 @@ template <>
 void TDataLoader<TMVAInput_t, TReference<Double_t>>::CopyInput(TMatrixT<Double_t> &matrix,
                                                                IndexIterator_t sampleIterator)
 {
-   Event *event = fData.front();
+   Event *event = std::get<0>(fData).front();
    Int_t m = matrix.GetNrows();
    Int_t n = event->GetNVariables();
 
@@ -196,7 +198,7 @@ void TDataLoader<TMVAInput_t, TReference<Double_t>>::CopyInput(TMatrixT<Double_t
 
    for (Int_t i = 0; i < m; i++) {
       Int_t sampleIndex = *sampleIterator++;
-      event = fData[sampleIndex];
+      event = std::get<0>(fData)[sampleIndex];
       for (Int_t j = 0; j < n; j++) {
          matrix(i, j) = event->GetValue(j);
       }
@@ -208,19 +210,20 @@ template <>
 void TDataLoader<TMVAInput_t, TReference<Double_t>>::CopyOutput(TMatrixT<Double_t> &matrix,
                                                                 IndexIterator_t sampleIterator)
 {
-   Event *event = fData.front();
+   Event *event = std::get<0>(fData).front();
+   DataSetInfo &info = std::get<1>(fData);
    Int_t m = matrix.GetNrows();
    Int_t n = matrix.GetNcols();
 
    for (Int_t i = 0; i < m; i++) {
       Int_t sampleIndex = *sampleIterator++;
-      event = fData[sampleIndex];
+      event = std::get<0>(fData)[sampleIndex];
       for (Int_t j = 0; j < n; j++) {
          // Classification
          if (event->GetNTargets() == 0) {
             if (n == 1) {
                // Binary.
-               matrix(i, j) = (event->GetClass() == 0) ? 1.0 : 0.0;
+               matrix(i, j) = (info.IsSignal(event)) ? 1.0 : 0.0;
             } else {
                // Multiclass.
                matrix(i, j) = 0.0;
@@ -240,11 +243,11 @@ template <>
 void TDataLoader<TMVAInput_t, TReference<Double_t>>::CopyWeights(TMatrixT<Double_t> &matrix,
                                                                  IndexIterator_t sampleIterator)
 {
-   Event *event = fData.front();
+   Event *event = nullptr;
 
    for (Int_t i = 0; i < matrix.GetNrows(); i++) {
       Int_t sampleIndex = *sampleIterator++;
-      event = fData[sampleIndex];
+      event = std::get<0>(fData)[sampleIndex];
       matrix(i, 0) = event->GetWeight();
    }
 }

--- a/tmva/tmva/src/MethodDNN.cxx
+++ b/tmva/tmva/src/MethodDNN.cxx
@@ -841,12 +841,12 @@ void TMVA::MethodDNN::TrainGpu()
       using DataLoader_t = TDataLoader<TMVAInput_t, TCuda<>>;
 
       size_t nThreads = 1;
-      DataLoader_t trainingData(GetEventCollection(Types::kTraining),
+      DataLoader_t trainingData(std::tie(GetEventCollection(Types::kTraining), DataInfo()),
                                 nTrainingSamples,
                                 net.GetBatchSize(),
                                 net.GetInputWidth(),
                                 net.GetOutputWidth(), nThreads);
-      DataLoader_t testData(GetEventCollection(Types::kTesting),
+      DataLoader_t testData(std::tie(GetEventCollection(Types::kTesting), DataInfo()),
                             nTestSamples,
                             testNet.GetBatchSize(),
                             net.GetInputWidth(),
@@ -1011,12 +1011,12 @@ void TMVA::MethodDNN::TrainCpu()
       using DataLoader_t = TDataLoader<TMVAInput_t, TCpu<>>;
 
       size_t nThreads = 1;
-      DataLoader_t trainingData(GetEventCollection(Types::kTraining),
+      DataLoader_t trainingData(std::tie(GetEventCollection(Types::kTraining), DataInfo()),
                                 nTrainingSamples,
                                 net.GetBatchSize(),
                                 net.GetInputWidth(),
                                 net.GetOutputWidth(), nThreads);
-      DataLoader_t testData(GetEventCollection(Types::kTesting),
+      DataLoader_t testData(std::tie(GetEventCollection(Types::kTesting), DataInfo()),
                             nTestSamples,
                             testNet.GetBatchSize(),
                             net.GetInputWidth(),

--- a/tmva/tmva/src/MethodDNN.cxx
+++ b/tmva/tmva/src/MethodDNN.cxx
@@ -841,16 +841,10 @@ void TMVA::MethodDNN::TrainGpu()
       using DataLoader_t = TDataLoader<TMVAInput_t, TCuda<>>;
 
       size_t nThreads = 1;
-      DataLoader_t trainingData(std::tie(GetEventCollection(Types::kTraining), DataInfo()),
-                                nTrainingSamples,
-                                net.GetBatchSize(),
-                                net.GetInputWidth(),
-                                net.GetOutputWidth(), nThreads);
-      DataLoader_t testData(std::tie(GetEventCollection(Types::kTesting), DataInfo()),
-                            nTestSamples,
-                            testNet.GetBatchSize(),
-                            net.GetInputWidth(),
-                            net.GetOutputWidth(), nThreads);
+      DataLoader_t trainingData(std::tie(GetEventCollection(Types::kTraining), DataInfo()), nTrainingSamples,
+                                net.GetBatchSize(), net.GetInputWidth(), net.GetOutputWidth(), nThreads);
+      DataLoader_t testData(std::tie(GetEventCollection(Types::kTesting), DataInfo()), nTestSamples,
+                            testNet.GetBatchSize(), net.GetInputWidth(), net.GetOutputWidth(), nThreads);
       DNN::TGradientDescent<TCuda<>> minimizer(settings.learningRate,
                                              settings.convergenceSteps,
                                              settings.testInterval);
@@ -1011,16 +1005,10 @@ void TMVA::MethodDNN::TrainCpu()
       using DataLoader_t = TDataLoader<TMVAInput_t, TCpu<>>;
 
       size_t nThreads = 1;
-      DataLoader_t trainingData(std::tie(GetEventCollection(Types::kTraining), DataInfo()),
-                                nTrainingSamples,
-                                net.GetBatchSize(),
-                                net.GetInputWidth(),
-                                net.GetOutputWidth(), nThreads);
-      DataLoader_t testData(std::tie(GetEventCollection(Types::kTesting), DataInfo()),
-                            nTestSamples,
-                            testNet.GetBatchSize(),
-                            net.GetInputWidth(),
-                            net.GetOutputWidth(), nThreads);
+      DataLoader_t trainingData(std::tie(GetEventCollection(Types::kTraining), DataInfo()), nTrainingSamples,
+                                net.GetBatchSize(), net.GetInputWidth(), net.GetOutputWidth(), nThreads);
+      DataLoader_t testData(std::tie(GetEventCollection(Types::kTesting), DataInfo()), nTestSamples,
+                            testNet.GetBatchSize(), net.GetInputWidth(), net.GetOutputWidth(), nThreads);
       DNN::TGradientDescent<TCpu<>> minimizer(settings.learningRate,
                                                settings.convergenceSteps,
                                                settings.testInterval);


### PR DESCRIPTION
Fixes the dependence of the correct handling of the signal and background classes
on the order in which in which data sets are filled. This was described here:
https://root-forum.cern.ch/t/tmva-signal-background-target-responses-inverted