### PR TITLE
Fix CMake errors on non-english systems (ROOT-8917).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,13 @@ include(cmake/modules/CaptureCommandLine.cmake)
 project(ROOT)
 set(IntegratedBuild ON)
 
+#---Set the locale to default C to prevent issued due to localization of commands---------------
+# This is necessary as we for example call `clang -v` and parse its output. But on a localized
+# program, the output parsing is much more error prone as certrain strings we're looking for
+# could be missing or be in a different order. To prevent those errors, let's just force all
+# output to use the default C locale which is more or less identical on all systems.
+set(ENV{LANG} C)
+
 #---Set pathes where to put the libraries, executables and headers------------------------------
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)


### PR DESCRIPTION
We often parse the output of commands to get certain system
information. This however fails as soon as the system locale changes
which results in cryptic errors where certain variables have the
wrong content on an otherwise perfectly fine working system.

This patch sets LANG=C from CMake to force all subprocesses that
we run to use the stable C locale that should prevent all those
errors in the future.