### PR TITLE
webgui: introduce special TMenuItems class 

### DIFF
--- a/core/base/v7/inc/ROOT/TDrawable.hxx
+++ b/core/base/v7/inc/ROOT/TDrawable.hxx
@@ -23,6 +23,7 @@ namespace ROOT {
 namespace Experimental {
 
 class TCanvas;
+class TMenuItems;
 
 namespace Internal {
 
@@ -39,7 +40,7 @@ public:
    virtual void Paint(TVirtualCanvasPainter &) = 0;
 
    /** Method can be used to provide menu items for the drawn object */
-   virtual void PopulateMenu(TVirtualCanvasPainter &){};
+   virtual void PopulateMenu(TMenuItems &){};
 
    virtual void Execute(const std::string &);
 };

--- a/graf2d/gpad/inc/LinkDef.h
+++ b/graf2d/gpad/inc/LinkDef.h
@@ -40,8 +40,11 @@
 #pragma link C++ class ROOT::Experimental::TUniqueDisplayItem<TPad>+;
 #pragma link C++ class ROOT::Experimental::TOrdinaryDisplayItem<TH1>+;
 #pragma link C++ class ROOT::Experimental::Detail::TMenuItem+;
-#pragma link C++ class ROOT::Experimental::Detail::TCheckedMenuItem+;
 #pragma link C++ class std::vector<ROOT::Experimental::Detail::TMenuItem*>+;
+#pragma link C++ class ROOT::Experimental::Detail::TCheckedMenuItem+;
+#pragma link C++ class ROOT::Experimental::Detail::TMenuArgument+;
+#pragma link C++ class std::vector<ROOT::Experimental::Detail::TMenuArgument>+;
+#pragma link C++ class ROOT::Experimental::Detail::TArgsMenuItem+;
 #pragma link C++ class ROOT::Experimental::TMenuItems+;
 #endif
 

--- a/graf2d/gpad/inc/LinkDef.h
+++ b/graf2d/gpad/inc/LinkDef.h
@@ -40,6 +40,7 @@
 #pragma link C++ class ROOT::Experimental::TUniqueDisplayItem<TPad>+;
 #pragma link C++ class ROOT::Experimental::TOrdinaryDisplayItem<TH1>+;
 #pragma link C++ class ROOT::Experimental::Detail::TMenuItem+;
+#pragma link C++ class ROOT::Experimental::Detail::TCheckedMenuItem+;
 #pragma link C++ class std::vector<ROOT::Experimental::Detail::TMenuItem*>+;
 #pragma link C++ class ROOT::Experimental::TMenuItems+;
 #endif

--- a/graf2d/gpad/inc/LinkDef.h
+++ b/graf2d/gpad/inc/LinkDef.h
@@ -40,7 +40,8 @@
 #pragma link C++ class ROOT::Experimental::TUniqueDisplayItem<TPad>+;
 #pragma link C++ class ROOT::Experimental::TOrdinaryDisplayItem<TH1>+;
 #pragma link C++ class ROOT::Experimental::Detail::TMenuItem+;
-#pragma link C++ class std::vector<ROOT::Experimental::Detail::TMenuItem>+;
+#pragma link C++ class std::vector<ROOT::Experimental::Detail::TMenuItem*>+;
+#pragma link C++ class ROOT::Experimental::TMenuItems+;
 #endif
 
 #endif

--- a/graf2d/gpad/v7/inc/ROOT/TMenuItem.hxx
+++ b/graf2d/gpad/v7/inc/ROOT/TMenuItem.hxx
@@ -29,12 +29,9 @@ namespace Detail {
 
 class TMenuItem {
 protected:
-   enum ECheckedState { kNotDefined = -1, kOff = 0, kOn = 1 };
-
-   std::string fName;                    ///<  name of the menu item
-   std::string fTitle;                   ///<  title of menu item
-   ECheckedState fChecked = kNotDefined; ///< -1 not exists, 0 - off, 1 - on
-   std::string fExec;                    ///< execute when item is activated
+   std::string fName;  ///<  name of the menu item
+   std::string fTitle; ///<  title of menu item
+   std::string fExec;  ///< execute when item is activated
 public:
    /** Default constructor */
    TMenuItem() = default;
@@ -42,16 +39,7 @@ public:
    /** Create menu item with the name and title
     *  name used to display item in the object context menu,
     *  title shown as hint info for that item  */
-   TMenuItem(const std::string &name, const std::string &title)
-      : fName(name), fTitle(title), fChecked(kNotDefined), fExec()
-   {
-   }
-
-   /** Set checked state for the item, default is none */
-   void SetChecked(bool on = true) { fChecked = on ? kOff : kOn; }
-
-   /** Disable checked state of the menu item */
-   void DisableChecked() { fChecked = kNotDefined; }
+   TMenuItem(const std::string &name, const std::string &title) : fName(name), fTitle(title), fExec() {}
 
    /** Set execution string with all required arguments,
     * which will be executed when menu item is selected  */
@@ -62,6 +50,27 @@ public:
 
    /** Returns execution string for the menu item */
    const std::string &GetExec() const { return fExec; }
+};
+
+class TCheckedMenuItem : public TMenuItem {
+protected:
+   bool fChecked = false; ///< -1 not exists, 0 - off, 1 - on
+public:
+   /** Default constructor */
+   TCheckedMenuItem() = default;
+
+   /** Create menu item with the name and title
+    *  name used to display item in the object context menu,
+    *  title shown as hint info for that item  */
+   TCheckedMenuItem(const std::string &name, const std::string &title, bool checked = false)
+      : TMenuItem(name, title), fChecked(checked)
+   {
+   }
+
+   /** Set checked state for the item, default is none */
+   void SetChecked(bool on = true) { fChecked = on; }
+
+   bool IsChecked() const { return fChecked; }
 };
 
 } // namespace Detail
@@ -88,8 +97,7 @@ public:
 
    void AddChkMenuItem(const std::string &name, const std::string &title, bool checked, const std::string &toggle)
    {
-      Detail::TMenuItem *item = new Detail::TMenuItem(name, title);
-      item->SetChecked(checked);
+      Detail::TCheckedMenuItem *item = new Detail::TCheckedMenuItem(name, title, checked);
       item->SetExec(toggle);
       Add(item);
    }

--- a/graf2d/gpad/v7/inc/ROOT/TMenuItem.hxx
+++ b/graf2d/gpad/v7/inc/ROOT/TMenuItem.hxx
@@ -19,6 +19,8 @@
 #include <string>
 #include <vector>
 
+class TClass;
+
 namespace ROOT {
 namespace Experimental {
 namespace Detail {
@@ -59,9 +61,7 @@ public:
    /** Default constructor */
    TCheckedMenuItem() = default;
 
-   /** Create menu item with the name and title
-    *  name used to display item in the object context menu,
-    *  title shown as hint info for that item  */
+   /** Create checked menu item  */
    TCheckedMenuItem(const std::string &name, const std::string &title, bool checked = false)
       : TMenuItem(name, title), fChecked(checked)
    {
@@ -71,6 +71,34 @@ public:
    void SetChecked(bool on = true) { fChecked = on; }
 
    bool IsChecked() const { return fChecked; }
+};
+
+class TMenuArgument {
+protected:
+   std::string fName;     ///<  name of call argument
+   std::string fTitle;    ///<  title of call argument
+   std::string fTypeName; ///<  typename
+   std::string fDefault;  ///<  default value
+public:
+   /** Default constructor */
+   TMenuArgument() = default;
+
+   TMenuArgument(const std::string &name, const std::string &title, const std::string &typname, const std::string &dflt)
+      : fName(name), fTitle(title), fTypeName(typname), fDefault(dflt)
+   {
+   }
+};
+
+class TArgsMenuItem : public TMenuItem {
+protected:
+   std::vector<TMenuArgument> fArgs;
+
+public:
+   TArgsMenuItem() = default;
+
+   TArgsMenuItem(const std::string &name, const std::string &title) : TMenuItem(name, title) {}
+
+   void AddArg(const TMenuArgument &arg) { fArgs.push_back(arg); }
 };
 
 } // namespace Detail
@@ -95,6 +123,14 @@ public:
       Add(item);
    }
 
+   Detail::TArgsMenuItem *AddArgsMenuItem(const std::string &name, const std::string &title, const std::string &exec)
+   {
+      Detail::TArgsMenuItem *item = new Detail::TArgsMenuItem(name, title);
+      item->SetExec(exec);
+      Add(item);
+      return item;
+   }
+
    void AddChkMenuItem(const std::string &name, const std::string &title, bool checked, const std::string &toggle)
    {
       Detail::TCheckedMenuItem *item = new Detail::TCheckedMenuItem(name, title, checked);
@@ -103,6 +139,8 @@ public:
    }
 
    void Cleanup();
+
+   void PopulateObjectMenu(void *obj, TClass *cl);
 
    std::string ProduceJSON();
 };

--- a/graf2d/gpad/v7/inc/ROOT/TMenuItem.hxx
+++ b/graf2d/gpad/v7/inc/ROOT/TMenuItem.hxx
@@ -17,6 +17,7 @@
 #define ROOT7_TMenuItem
 
 #include <string>
+#include <vector>
 
 namespace ROOT {
 namespace Experimental {
@@ -53,7 +54,7 @@ public:
    void DisableChecked() { fChecked = kNotDefined; }
 
    /** Set execution string with all required arguments,
-    * which will be executed when manu item is selected  */
+    * which will be executed when menu item is selected  */
    void SetExec(const std::string &exec) { fExec = exec; }
 
    /** Returns menu item name */
@@ -64,6 +65,40 @@ public:
 };
 
 } // namespace Detail
+
+///////////////////////////////////////////////////////////////////////
+
+class TMenuItems {
+protected:
+   std::vector<Detail::TMenuItem *> fItems; ///< list of items in the menu
+public:
+   /** Default constructor */
+   TMenuItems() = default;
+
+   ~TMenuItems() { Cleanup(); }
+
+   void Add(Detail::TMenuItem *item) { fItems.push_back(item); }
+
+   void AddMenuItem(const std::string &name, const std::string &title, const std::string &exec)
+   {
+      Detail::TMenuItem *item = new Detail::TMenuItem(name, title);
+      item->SetExec(exec);
+      Add(item);
+   }
+
+   void AddChkMenuItem(const std::string &name, const std::string &title, bool checked, const std::string &toggle)
+   {
+      Detail::TMenuItem *item = new Detail::TMenuItem(name, title);
+      item->SetChecked(checked);
+      item->SetExec(toggle);
+      Add(item);
+   }
+
+   void Cleanup();
+
+   std::string ProduceJSON();
+};
+
 } // namespace Experimental
 } // namespace ROOT
 

--- a/graf2d/gpad/v7/inc/ROOT/TMenuItem.hxx
+++ b/graf2d/gpad/v7/inc/ROOT/TMenuItem.hxx
@@ -43,6 +43,9 @@ public:
     *  title shown as hint info for that item  */
    TMenuItem(const std::string &name, const std::string &title) : fName(name), fTitle(title), fExec() {}
 
+   /** virtual destructor need for vtable, used when vector of TMenuItem* is stored */
+   virtual ~TMenuItem() {}
+
    /** Set execution string with all required arguments,
     * which will be executed when menu item is selected  */
    void SetExec(const std::string &exec) { fExec = exec; }
@@ -67,6 +70,9 @@ public:
    {
    }
 
+   /** virtual destructor need for vtable, used when vector of TMenuItem* is stored */
+   virtual ~TCheckedMenuItem() {}
+
    /** Set checked state for the item, default is none */
    void SetChecked(bool on = true) { fChecked = on; }
 
@@ -83,10 +89,13 @@ public:
    /** Default constructor */
    TMenuArgument() = default;
 
-   TMenuArgument(const std::string &name, const std::string &title, const std::string &typname, const std::string &dflt)
+   TMenuArgument(const std::string &name, const std::string &title, const std::string &typname,
+                 const std::string &dflt = "")
       : fName(name), fTitle(title), fTypeName(typname), fDefault(dflt)
    {
    }
+
+   void SetDefault(const std::string &dflt) { fDefault = dflt; }
 };
 
 class TArgsMenuItem : public TMenuItem {
@@ -94,9 +103,13 @@ protected:
    std::vector<TMenuArgument> fArgs;
 
 public:
+   /** Default constructor */
    TArgsMenuItem() = default;
 
    TArgsMenuItem(const std::string &name, const std::string &title) : TMenuItem(name, title) {}
+
+   /** virtual destructor need for vtable, used when vector of TMenuItem* is stored */
+   virtual ~TArgsMenuItem() {}
 
    void AddArg(const TMenuArgument &arg) { fArgs.push_back(arg); }
 };
@@ -123,20 +136,14 @@ public:
       Add(item);
    }
 
-   Detail::TArgsMenuItem *AddArgsMenuItem(const std::string &name, const std::string &title, const std::string &exec)
-   {
-      Detail::TArgsMenuItem *item = new Detail::TArgsMenuItem(name, title);
-      item->SetExec(exec);
-      Add(item);
-      return item;
-   }
-
    void AddChkMenuItem(const std::string &name, const std::string &title, bool checked, const std::string &toggle)
    {
       Detail::TCheckedMenuItem *item = new Detail::TCheckedMenuItem(name, title, checked);
       item->SetExec(toggle);
       Add(item);
    }
+
+   unsigned Size() const { return fItems.size(); }
 
    void Cleanup();
 

--- a/graf2d/gpad/v7/inc/ROOT/TObjectDrawable.hxx
+++ b/graf2d/gpad/v7/inc/ROOT/TObjectDrawable.hxx
@@ -38,7 +38,7 @@ public:
    void Paint(TVirtualCanvasPainter &canv) final;
 
    /// Fill menu items for the object
-   void PopulateMenu(TVirtualCanvasPainter &onCanv) final;
+   void PopulateMenu(TMenuItems &) final;
 
    /// Executes menu item
    void Execute(const std::string &) final;

--- a/graf2d/gpad/v7/inc/ROOT/TVirtualCanvasPainter.hxx
+++ b/graf2d/gpad/v7/inc/ROOT/TVirtualCanvasPainter.hxx
@@ -48,11 +48,6 @@ public:
 
    virtual void AddDisplayItem(TDisplayItem *item) = 0;
 
-   virtual void AddMenuItem(const std::string &name, const std::string &title, const std::string &exec) = 0;
-
-   virtual void AddChkMenuItem(const std::string &name, const std::string &title, bool checked,
-                               const std::string &toggle) = 0;
-
    /// Loads the plugin that implements this class.
    static std::unique_ptr<TVirtualCanvasPainter> Create(const TCanvas &canv);
 };

--- a/graf2d/gpad/v7/src/TMenuItem.cxx
+++ b/graf2d/gpad/v7/src/TMenuItem.cxx
@@ -1,0 +1,41 @@
+/// \file TMenuItem.cxx
+/// \ingroup Base ROOT7
+/// \author Sergey Linev
+/// \date 2017-07-18
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/TMenuItem.hxx"
+
+#include "TROOT.h"
+#include "TClass.h"
+#include "TBufferJSON.h"
+
+void ROOT::Experimental::TMenuItems::Cleanup()
+{
+   for (unsigned n = 0; n < fItems.size(); ++n) delete fItems[n];
+
+   fItems.clear();
+}
+
+std::string ROOT::Experimental::TMenuItems::ProduceJSON()
+{
+   TClass *cl = gROOT->GetClass("std::vector<ROOT::Experimental::Detail::TMenuItem*>");
+
+   // printf("Got items %d class %p %s\n", (int) fItems.size(), cl, cl->GetName());
+
+   // FIXME: got problem with std::list<TMenuItem>, can be generic TBufferJSON
+   TString res = TBufferJSON::ConvertToJSON(&fItems, cl);
+
+   // printf("Got JSON %s\n", res.Data());
+
+   return res.Data();
+}

--- a/graf2d/gpad/v7/src/TMenuItem.cxx
+++ b/graf2d/gpad/v7/src/TMenuItem.cxx
@@ -35,7 +35,7 @@ std::string ROOT::Experimental::TMenuItems::ProduceJSON()
    // FIXME: got problem with std::list<TMenuItem>, can be generic TBufferJSON
    TString res = TBufferJSON::ConvertToJSON(&fItems, cl);
 
-   // printf("Got JSON %s\n", res.Data());
+   printf("Got JSON %s\n", res.Data());
 
    return res.Data();
 }

--- a/graf2d/gpad/v7/src/TMenuItem.cxx
+++ b/graf2d/gpad/v7/src/TMenuItem.cxx
@@ -17,6 +17,9 @@
 
 #include "TROOT.h"
 #include "TClass.h"
+#include "TList.h"
+#include "TMethod.h"
+#include "TMethodCall.h"
 #include "TBufferJSON.h"
 
 void ROOT::Experimental::TMenuItems::Cleanup()
@@ -25,6 +28,61 @@ void ROOT::Experimental::TMenuItems::Cleanup()
 
    fItems.clear();
 }
+
+void ROOT::Experimental::TMenuItems::PopulateObjectMenu(void *obj, TClass *cl)
+{
+   Cleanup();
+
+   TList *lst = new TList;
+   cl->GetMenuItems(lst);
+
+   TIter iter(lst);
+   TMethod *m = 0;
+
+   while ((m = (TMethod *)iter()) != 0) {
+
+      if (m->IsMenuItem() == kMenuToggle) {
+         TString getter;
+         if (m->Getter() && strlen(m->Getter()) > 0) {
+            getter = m->Getter();
+         } else if (strncmp(m->GetName(), "Set", 3) == 0) {
+            getter = TString(m->GetName())(3, strlen(m->GetName()) - 3);
+            if (cl->GetMethodAllAny(TString("Has") + getter))
+               getter = TString("Has") + getter;
+            else if (cl->GetMethodAllAny(TString("Get") + getter))
+               getter = TString("Get") + getter;
+            else if (cl->GetMethodAllAny(TString("Is") + getter))
+               getter = TString("Is") + getter;
+            else
+               getter = "";
+         }
+
+         if ((getter.Length() > 0) && cl->GetMethodAllAny(getter)) {
+            // execute getter method to get current state of toggle item
+
+            TMethodCall *call = new TMethodCall(cl, getter, "");
+
+            if (call->ReturnType() == TMethodCall::kLong) {
+               Long_t l(0);
+               call->Execute(obj, l);
+
+               AddChkMenuItem(m->GetName(), m->GetTitle(), l != 0,
+                                     Form("%s(%s)", m->GetName(), (l != 0) ? "0" : "1"));
+
+            } else {
+               // Error("CheckModifiedFlag", "Cannot get toggle value with getter %s", getter.Data());
+            }
+
+            delete call;
+         }
+      } else {
+         AddMenuItem(m->GetName(), m->GetTitle(), Form("%s()", m->GetName()));
+      }
+   }
+
+   delete lst;
+}
+
 
 std::string ROOT::Experimental::TMenuItems::ProduceJSON()
 {

--- a/graf2d/gpad/v7/src/TObjectDrawable.cxx
+++ b/graf2d/gpad/v7/src/TObjectDrawable.cxx
@@ -17,6 +17,7 @@
 
 #include <ROOT/TDisplayItem.hxx>
 #include <ROOT/TLogger.hxx>
+#include <ROOT/TMenuItem.hxx>
 #include <ROOT/TVirtualCanvasPainter.hxx>
 
 #include "TClass.h"
@@ -35,7 +36,7 @@ void ROOT::Experimental::Internal::TObjectDrawable::Paint(TVirtualCanvasPainter 
    canv.AddDisplayItem(res);
 }
 
-void ROOT::Experimental::Internal::TObjectDrawable::PopulateMenu(TVirtualCanvasPainter &onCanv)
+void ROOT::Experimental::Internal::TObjectDrawable::PopulateMenu(TMenuItems &items)
 {
    TObject *obj = fObj.get();
 
@@ -76,7 +77,7 @@ void ROOT::Experimental::Internal::TObjectDrawable::PopulateMenu(TVirtualCanvasP
                Long_t l(0);
                call->Execute(obj, l);
 
-               onCanv.AddChkMenuItem(m->GetName(), m->GetTitle(), l != 0,
+               items.AddChkMenuItem(m->GetName(), m->GetTitle(), l != 0,
                                      Form("%s(%s)", m->GetName(), (l != 0) ? "0" : "1"));
 
             } else {
@@ -86,7 +87,7 @@ void ROOT::Experimental::Internal::TObjectDrawable::PopulateMenu(TVirtualCanvasP
             delete call;
          }
       } else {
-         onCanv.AddMenuItem(m->GetName(), m->GetTitle(), Form("%s()", m->GetName()));
+         items.AddMenuItem(m->GetName(), m->GetTitle(), Form("%s()", m->GetName()));
       }
    }
 }

--- a/graf2d/gpad/v7/src/TObjectDrawable.cxx
+++ b/graf2d/gpad/v7/src/TObjectDrawable.cxx
@@ -21,9 +21,6 @@
 #include <ROOT/TVirtualCanvasPainter.hxx>
 
 #include "TClass.h"
-#include "TList.h"
-#include "TMethod.h"
-#include "TMethodCall.h"
 #include "TROOT.h"
 
 #include <exception>
@@ -41,55 +38,7 @@ void ROOT::Experimental::Internal::TObjectDrawable::PopulateMenu(TMenuItems &ite
    TObject *obj = fObj.get();
 
    // fill context menu items for the ROOT class
-
-   TClass *cl = obj->IsA();
-
-   TList *lst = new TList;
-   cl->GetMenuItems(lst);
-
-   TIter iter(lst);
-   TMethod *m = 0;
-
-   while ((m = (TMethod *)iter()) != 0) {
-
-      if (m->IsMenuItem() == kMenuToggle) {
-         TString getter;
-         if (m->Getter() && strlen(m->Getter()) > 0) {
-            getter = m->Getter();
-         } else if (strncmp(m->GetName(), "Set", 3) == 0) {
-            getter = TString(m->GetName())(3, strlen(m->GetName()) - 3);
-            if (cl->GetMethodAllAny(TString("Has") + getter))
-               getter = TString("Has") + getter;
-            else if (cl->GetMethodAllAny(TString("Get") + getter))
-               getter = TString("Get") + getter;
-            else if (cl->GetMethodAllAny(TString("Is") + getter))
-               getter = TString("Is") + getter;
-            else
-               getter = "";
-         }
-
-         if ((getter.Length() > 0) && cl->GetMethodAllAny(getter)) {
-            // execute getter method to get current state of toggle item
-
-            TMethodCall *call = new TMethodCall(cl, getter, "");
-
-            if (call->ReturnType() == TMethodCall::kLong) {
-               Long_t l(0);
-               call->Execute(obj, l);
-
-               items.AddChkMenuItem(m->GetName(), m->GetTitle(), l != 0,
-                                     Form("%s(%s)", m->GetName(), (l != 0) ? "0" : "1"));
-
-            } else {
-               // Error("CheckModifiedFlag", "Cannot get toggle value with getter %s", getter.Data());
-            }
-
-            delete call;
-         }
-      } else {
-         items.AddMenuItem(m->GetName(), m->GetTitle(), Form("%s()", m->GetName()));
-      }
-   }
+   items.PopulateObjectMenu(obj, obj->IsA());
 }
 
 void ROOT::Experimental::Internal::TObjectDrawable::Execute(const std::string &exec)

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -61,8 +61,6 @@ private:
    WebConnList fWebConn;                             ///<! connections list
    ROOT::Experimental::TPadDisplayItem fDisplayList; ///!< full list of items to display
 
-   MenuItemsVector fMenuItems; ///<! list of menu items
-
    static std::string fAddr;
    static THttpServer *gServer;
 
@@ -96,11 +94,6 @@ public:
    }
 
    virtual void AddDisplayItem(ROOT::Experimental::TDisplayItem *item) final;
-
-   virtual void AddMenuItem(const std::string &name, const std::string &title, const std::string &exec) final;
-
-   virtual void AddChkMenuItem(const std::string &name, const std::string &title, bool checked,
-                               const std::string &toggle) final;
 
    // void ReactToSocketNews(...) override { SendCanvas(); }
 
@@ -274,22 +267,6 @@ Bool_t TCanvasPainter::ProcessWS(THttpCallArg *arg)
    return kTRUE;
 }
 
-void TCanvasPainter::AddMenuItem(const std::string &name, const std::string &title, const std::string &exec)
-{
-   ROOT::Experimental::Detail::TMenuItem item(name, title);
-   item.SetExec(exec);
-   fMenuItems.push_back(item);
-}
-
-void TCanvasPainter::AddChkMenuItem(const std::string &name, const std::string &title, bool checked,
-                                    const std::string &toggle)
-{
-   ROOT::Experimental::Detail::TMenuItem item(name, title);
-   item.SetChecked(checked);
-   item.SetExec(toggle);
-   fMenuItems.push_back(item);
-}
-
 void TCanvasPainter::CheckModifiedFlag()
 {
 
@@ -306,18 +283,14 @@ void TCanvasPainter::CheckModifiedFlag()
          printf("Request menu for object %s found drawable %p\n", conn.fGetMenu.c_str(), drawable);
 
          if (drawable) {
-            fMenuItems.clear();
-            drawable->PopulateMenu(*this);
 
-            TClass *cl = gROOT->GetClass("std::vector<ROOT::Experimental::Detail::TMenuItem>");
+            ROOT::Experimental::TMenuItems items;
 
-            // printf("Got items %d class %p %s\n", (int) fMenuItems.size(), cl, cl->GetName());
+            drawable->PopulateMenu(items);
 
             // FIXME: got problem with std::list<TMenuItem>, can be generic TBufferJSON
             buf = "MENU";
-            buf += TBufferJSON::ConvertToJSON(&fMenuItems, cl);
-
-            fMenuItems.clear();
+            buf.Append(items.ProduceJSON());
          }
 
          conn.fGetMenu = "";

--- a/hist/hist/v7/inc/ROOT/THistDrawable.hxx
+++ b/hist/hist/v7/inc/ROOT/THistDrawable.hxx
@@ -20,6 +20,9 @@
 #include "ROOT/THistDrawOptions.hxx"
 #include "ROOT/TLogger.hxx"
 
+// TODO: from Sergey Linev: should libHist depend from libGpad?
+//#include "ROOT/TMenuItem.hxx"
+
 #include <memory>
 
 class TH1;
@@ -76,10 +79,7 @@ public:
 
    THistDrawableBase &operator=(THistDrawableBase &&);
 
-   void PopulateMenu(TMenuItems &) final
-   {
-      // here should be filling of context menu for the given object
-   }
+   void PopulateMenu(TMenuItems &) final;
 
    void Execute(const std::string &) final
    {

--- a/hist/hist/v7/inc/ROOT/THistDrawable.hxx
+++ b/hist/hist/v7/inc/ROOT/THistDrawable.hxx
@@ -76,7 +76,7 @@ public:
 
    THistDrawableBase &operator=(THistDrawableBase &&);
 
-   void PopulateMenu(TVirtualCanvasPainter &) final
+   void PopulateMenu(TMenuItems &) final
    {
       // here should be filling of context menu for the given object
    }

--- a/hist/hist/v7/src/THistDrawable.cxx
+++ b/hist/hist/v7/src/THistDrawable.cxx
@@ -2,7 +2,8 @@
 /// \ingroup Hist ROOT7
 /// \author Axel Naumann <axel@cern.ch>
 /// \date 2015-09-11
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2015, Rene Brun and Fons Rademakers.               *
@@ -26,106 +27,101 @@
 using namespace ROOT::Experimental;
 using namespace ROOT::Experimental::Internal;
 
-void ROOT::Experimental::Internal::LoadHistPainterLibrary() {
-  gSystem->Load("libHistPainter");
+void ROOT::Experimental::Internal::LoadHistPainterLibrary()
+{
+   gSystem->Load("libHistPainter");
 }
 
+template <int DIMENSION>
+THistPainterBase<DIMENSION>::~THistPainterBase()
+{
+   fgPainter = nullptr;
+}
 
 template <int DIMENSION>
-THistPainterBase<DIMENSION>::~THistPainterBase() { fgPainter = nullptr; }
-
-template <int DIMENSION>
-THistPainterBase<DIMENSION>* THistPainterBase<DIMENSION>::fgPainter = nullptr;
-
+THistPainterBase<DIMENSION> *THistPainterBase<DIMENSION>::fgPainter = nullptr;
 
 Internal::THistDrawableBase::THistDrawableBase() = default;
-Internal::THistDrawableBase::THistDrawableBase(THistDrawableBase&&) = default;
+Internal::THistDrawableBase::THistDrawableBase(THistDrawableBase &&) = default;
 Internal::THistDrawableBase::~THistDrawableBase() = default;
 
-Internal::THistDrawableBase&
-Internal::THistDrawableBase::operator=(THistDrawableBase&&) = default;
+Internal::THistDrawableBase &Internal::THistDrawableBase::operator=(THistDrawableBase &&) = default;
 
+void Internal::THistDrawableBase::PopulateMenu(TMenuItems &)
+{
+   // here should be filling of context menu for the given object
+   // for the moment commented out, while TMenuItems is not available in libHist
 
-template <int DIMENSIONS>
-bool
-THistDrawable<DIMENSIONS>::UpdateOldHist() {
-  auto implBase = fHistImpl.Get();
-  if (!implBase) {
-    fOldHist.reset();
-    return false;
-  }
-
-  std::array<TAxisView, DIMENSIONS> axes;
-  for (int i = 0; i < DIMENSIONS; ++i)
-    axes[i] = implBase->GetAxis(i);
-
-  TH1 *old = nullptr;
-
-  // Create a unique name, for what it's worth.
-  std::string histName;
-  {
-    std::stringstream strm;
-    strm << "drawAdaptor" << this;
-  }
-
-  // Create old histogram; set nbins because TH1::fNcells is not accessible.
-  switch (DIMENSIONS) {
-    case 1:
-      old = new TH1D(histName.c_str(),
-                     implBase->GetTitle().c_str(),
-                     axes[0].GetNBins() - 2, 0., 1.);
-      break;
-    case 2:
-      old = new TH2D(histName.c_str(),
-                     implBase->GetTitle().c_str(),
-                     axes[0].GetNBins() - 2, 0., 1.,
-                     axes[1].GetNBins() - 2, 0., 1.);
-      break;
-    case 3:
-      old = new TH3D(histName.c_str(),
-                     implBase->GetTitle().c_str(),
-                     axes[0].GetNBins() - 2, 0., 1.,
-                     axes[1].GetNBins() - 2, 0., 1.,
-                     axes[2].GetNBins() - 2, 0., 1.);
-      break;
-    default:
-      // And anyway, this should really give a missing symbol due to the export
-      // template.
-      R__ERROR_HERE("Hist") << "Drawing of " << DIMENSIONS
-                            << " dimensional histograms not supported.";
-      return false;
-  }
-
-  old->SetDirectory(nullptr);
-
-  // See TH1::SetBins().
-  std::array<TAxis*, 3> oldAxes{{old->GetXaxis(), old->GetYaxis(), old->GetZaxis()}};
-  for (int i = 0; i < DIMENSIONS; ++i) {
-    oldAxes[i]->SetRange(0, 0);
-    oldAxes[i]->SetTitle(axes[i].GetTitle().c_str());
-    if (axes[i].GetAsEquidistant()) {
-      oldAxes[i]->Set(axes[i].GetNBins() - 2, axes[i].GetFrom(), axes[i].GetTo());
-    } else if (const TAxisIrregular* irr = axes[i].GetAsIrregular()) {
-      oldAxes[i]->Set(axes[i].GetNBins() - 2, &irr->GetBinBorders()[0]);
-    } else {
-      assert(0 && "Logic error; the axis is neither equidistant nor irregular.");
-    }
-  }
-
-  int nBins = implBase->GetNBins();
-  old->SetBinsLength(nBins);
-  if (implBase->HasBinUncertainty())
-    old->Sumw2();
-
-  // Set the bin content + uncertainty.
-  for (int binidx = 0; binidx < nBins; ++binidx) {
-    old->SetBinContent(binidx, implBase->GetBinContentAsDouble(binidx));
-    old->SetBinError(binidx, implBase->GetBinUncertainty(binidx));
-  }
-  fOldHist.reset(old);
-  return true;
+   // items.PopulateObjectMenu(GetOldHist(), GetOldHist()->IsA());
 }
 
+template <int DIMENSIONS>
+bool THistDrawable<DIMENSIONS>::UpdateOldHist()
+{
+   auto implBase = fHistImpl.Get();
+   if (!implBase) {
+      fOldHist.reset();
+      return false;
+   }
+
+   std::array<TAxisView, DIMENSIONS> axes;
+   for (int i = 0; i < DIMENSIONS; ++i) axes[i] = implBase->GetAxis(i);
+
+   TH1 *old = nullptr;
+
+   // Create a unique name, for what it's worth.
+   std::string histName;
+   {
+      std::stringstream strm;
+      strm << "drawAdaptor" << this;
+   }
+
+   // Create old histogram; set nbins because TH1::fNcells is not accessible.
+   switch (DIMENSIONS) {
+   case 1: old = new TH1D(histName.c_str(), implBase->GetTitle().c_str(), axes[0].GetNBins() - 2, 0., 1.); break;
+   case 2:
+      old = new TH2D(histName.c_str(), implBase->GetTitle().c_str(), axes[0].GetNBins() - 2, 0., 1.,
+                     axes[1].GetNBins() - 2, 0., 1.);
+      break;
+   case 3:
+      old = new TH3D(histName.c_str(), implBase->GetTitle().c_str(), axes[0].GetNBins() - 2, 0., 1.,
+                     axes[1].GetNBins() - 2, 0., 1., axes[2].GetNBins() - 2, 0., 1.);
+      break;
+   default:
+      // And anyway, this should really give a missing symbol due to the export
+      // template.
+      R__ERROR_HERE("Hist") << "Drawing of " << DIMENSIONS << " dimensional histograms not supported.";
+      return false;
+   }
+
+   old->SetDirectory(nullptr);
+
+   // See TH1::SetBins().
+   std::array<TAxis *, 3> oldAxes{{old->GetXaxis(), old->GetYaxis(), old->GetZaxis()}};
+   for (int i = 0; i < DIMENSIONS; ++i) {
+      oldAxes[i]->SetRange(0, 0);
+      oldAxes[i]->SetTitle(axes[i].GetTitle().c_str());
+      if (axes[i].GetAsEquidistant()) {
+         oldAxes[i]->Set(axes[i].GetNBins() - 2, axes[i].GetFrom(), axes[i].GetTo());
+      } else if (const TAxisIrregular *irr = axes[i].GetAsIrregular()) {
+         oldAxes[i]->Set(axes[i].GetNBins() - 2, &irr->GetBinBorders()[0]);
+      } else {
+         assert(0 && "Logic error; the axis is neither equidistant nor irregular.");
+      }
+   }
+
+   int nBins = implBase->GetNBins();
+   old->SetBinsLength(nBins);
+   if (implBase->HasBinUncertainty()) old->Sumw2();
+
+   // Set the bin content + uncertainty.
+   for (int binidx = 0; binidx < nBins; ++binidx) {
+      old->SetBinContent(binidx, implBase->GetBinContentAsDouble(binidx));
+      old->SetBinError(binidx, implBase->GetBinUncertainty(binidx));
+   }
+   fOldHist.reset(old);
+   return true;
+}
 
 namespace ROOT {
 namespace Experimental {


### PR DESCRIPTION
It is container for the all menu items, collected for the TDrawable
Now is temporary object, later all items can be preserved until TDrawable::Execute() is called.

Create hierarchy of menu items class:
   - base TMenuItem class
   - TCheckedMenuItem for items which could be toggled
   - TArgsMenuItem for item with several arguments, which should be provided for function call