### PR TITLE
Fixes numerical instabilities of DNN tests.

### DIFF
--- a/tmva/tmva/test/DNN/TestDerivatives.h
+++ b/tmva/tmva/test/DNN/TestDerivatives.h
@@ -191,7 +191,7 @@ auto testLossFunctionGradients()
           evaluateGradients<Architecture>(X, lf, Y, Z, W);
        };
 
-       error = testGradients<Architecture>(f, df, 5e-6);
+       error = testGradients<Architecture>(f, df, 1.0e-4);
 
        std::cout << "Testing " << static_cast<char>(lf) << ": ";
        std::cout << "Maximum Relative Error = " << error << std::endl;

--- a/tmva/tmva/test/DNN/Utility.h
+++ b/tmva/tmva/test/DNN/Utility.h
@@ -210,8 +210,7 @@ inline T relativeError(const T &x, const T &y)
 
 //______________________________________________________________________________
 template <>
-inline Double_t relativeError(const Double_t &x,
-                              const Double_t &y)
+inline Double_t relativeError(const Double_t &x, const Double_t &y)
 {
    if ((std::abs(x) > 1e-8) && (std::abs(y) > 1e-8)) {
       return std::fabs((x - y) / y);
@@ -222,8 +221,7 @@ inline Double_t relativeError(const Double_t &x,
 
 //______________________________________________________________________________
 template <>
-inline Float_t relativeError(const Float_t &x,
-                             const Float_t &y)
+inline Float_t relativeError(const Float_t &x, const Float_t &y)
 {
    if ((std::abs(x) > 1e-8) && (std::abs(y) > 1e-8)) {
       return std::fabs((x - y) / y);

--- a/tmva/tmva/test/DNN/Utility.h
+++ b/tmva/tmva/test/DNN/Utility.h
@@ -208,6 +208,30 @@ inline T relativeError(const T &x, const T &y)
   return diff / (abs(x) + abs(y));
 }
 
+//______________________________________________________________________________
+template <>
+inline Double_t relativeError(const Double_t &x,
+                              const Double_t &y)
+{
+   if ((std::abs(x) > 1e-8) && (std::abs(y) > 1e-8)) {
+      return std::fabs((x - y) / y);
+   } else {
+      return std::fabs(x - y);
+   }
+}
+
+//______________________________________________________________________________
+template <>
+inline Float_t relativeError(const Float_t &x,
+                             const Float_t &y)
+{
+   if ((std::abs(x) > 1e-8) && (std::abs(y) > 1e-8)) {
+      return std::fabs((x - y) / y);
+   } else {
+      return std::fabs(x - y);
+   }
+}
+
 /*! Compute the maximum, element-wise relative error of the matrices
 *  X and Y normalized by the element of Y. Protected against division
 *  by zero. */


### PR DESCRIPTION
The two specializations for the relative_error functions were removed this [commit](https://github.com/root-project/root/commit/43aac3fb4bc5f215ac3cb7755791372f05a5da72) by @amadio. However, the
general function template does not protect against the division by values that are numerically close
 to zero and lead to large relative errors.