### PR TITLE
Fix CMake warnings regarding LINK_INTERFACE_LIBRARIES property.

### DIFF
--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -4,10 +4,6 @@
 cmake_policy(SET CMP0003 NEW) # See "cmake --help-policy CMP0003" for more details
 cmake_policy(SET CMP0011 NEW) # See "cmake --help-policy CMP0011" for more details
 cmake_policy(SET CMP0009 NEW) # See "cmake --help-policy CMP0009" for more details
-if(CMAKE_VERSION VERSION_GREATER 2.8.12)
-  cmake_policy(SET CMP0022 OLD) # See "cmake --help-policy CMP0022" for more details
-endif()
-
 
 set(THISDIR ${CMAKE_CURRENT_LIST_DIR})
 
@@ -596,7 +592,7 @@ function(ROOT_LINKER_LIBRARY library)
   add_dependencies(${library} move_headers)
   set_property(GLOBAL APPEND PROPERTY ROOT_EXPORTED_TARGETS ${library})
   set_target_properties(${library} PROPERTIES OUTPUT_NAME ${library_name})
-  set_target_properties(${library} PROPERTIES LINK_INTERFACE_LIBRARIES "${ARG_DEPENDENCIES}")
+  set_target_properties(${library} PROPERTIES INTERFACE_LINK_LIBRARIES "${ARG_DEPENDENCIES}")
   # Do not add -Dname_EXPORTS to the command-line when building files in this
   # target. Doing so is actively harmful for the modules build because it
   # creates extra module variants, and not useful because we don't use these

--- a/proof/proofd/CMakeLists.txt
+++ b/proof/proofd/CMakeLists.txt
@@ -26,7 +26,7 @@ else()
   endif ()
   ROOT_LINKER_LIBRARY(XrdProofd X*.cxx ${CMAKE_SOURCE_DIR}/net/rpdutils/src/rpdconn.cxx
                          LIBRARIES ${XROOTD_LIBRARIES} rpdutil ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS} BUILTINS XROOTD)
-  set_target_properties(XrdProofd PROPERTIES LINK_INTERFACE_LIBRARIES "")
+  set_target_properties(XrdProofd PROPERTIES INTERFACE_LINK_LIBRARIES "")
   ROOT_EXECUTABLE(proofexecv proofexecv.cxx ${CMAKE_SOURCE_DIR}/net/rpdutils/src/rpdconn.cxx ${CMAKE_SOURCE_DIR}/net/rpdutils/src/rpdpriv.cxx
                          LIBRARIES ${SYSLIBS})
 endif()


### PR DESCRIPTION
This property was renamed in CMake 2.8.12, so we now should use
the newer name on recent CMake versions.