### PR TITLE
Protect TThreadExecutor against uninitializations.

### DIFF
--- a/core/imt/inc/ROOT/TThreadExecutor.hxx
+++ b/core/imt/inc/ROOT/TThreadExecutor.hxx
@@ -25,6 +25,7 @@
 #include "ROOT/TExecutor.hxx"
 #include "ROOT/TPoolManager.hxx"
 #include "TROOT.h"
+#include "TError.h"
 #include <functional>
 #include <memory>
 #include <numeric>
@@ -183,7 +184,7 @@ namespace ROOT {
 
    //////////////////////////////////////////////////////////////////////////
    /// Execute func (with no arguments) nTimes in parallel.
-   ///Divides and groups the executions in nChunks with partial reduction;
+   /// Divides and groups the executions in nChunks (if it doesn't make sense will reduce the number of chunks) with partial reduction;
    /// A vector containg partial reductions' results is returned.
    template<class F, class R, class Cond>
    auto TThreadExecutor::Map(F func, unsigned nTimes, R redfunc, unsigned nChunks) -> std::vector<typename std::result_of<F()>::type> {
@@ -192,12 +193,17 @@ namespace ROOT {
          return Map(func, nTimes);
       }
 
-      using retType = decltype(func());
-      std::vector<retType> reslist(nChunks);
       unsigned step = (nTimes + nChunks - 1) / nChunks;
+      // Avoid empty chunks
+      unsigned actualChunks = (nTimes + step - 1) / step;
+      if(actualChunks != nChunks){
+          Warning("ROOT::TThreadExecutor::Map", "The number of chunks has been reduced to %d to avoid empty chunks", actualChunks);
+      }
+      using retType = decltype(func());
+      std::vector<retType> reslist(actualChunks);
       auto lambda = [&](unsigned int i)
       {
-         std::vector<retType> partialResults(step);
+         std::vector<retType> partialResults(std::min(nTimes-i, step));
          for (unsigned j = 0; j < step && (i + j) < nTimes; j++) {
             partialResults[j] = func();
          }
@@ -234,7 +240,8 @@ namespace ROOT {
 
    //////////////////////////////////////////////////////////////////////////
    /// Execute func in parallel, taking an element of a
-   /// sequence as argument. Divides and groups the executions in nChunks with partial reduction;
+   /// sequence as argument.
+   /// Divides and groups the executions in nChunks (if it doesn't make sense will reduce the number of chunks) with partial reduction\n
    /// A vector containg partial reductions' results is returned.
    template<class F, class INTEGER, class R, class Cond>
    auto TThreadExecutor::Map(F func, ROOT::TSeq<INTEGER> args, R redfunc, unsigned nChunks) -> std::vector<typename std::result_of<F(INTEGER)>::type> {
@@ -247,12 +254,17 @@ namespace ROOT {
       unsigned end = *args.end();
       unsigned seqStep = args.step();
       unsigned step = (end - start + nChunks - 1) / nChunks; //ceiling the division
+      // Avoid empty chunks
+      unsigned actualChunks = (end - start + step - 1) / step;
+      if(actualChunks != nChunks){
+          Warning("ROOT::TThreadExecutor::Map", "The number of chunks has been reduced to %d to avoid empty chunks", actualChunks);
+      }
 
       using retType = decltype(func(start));
       std::vector<retType> reslist(nChunks);
       auto lambda = [&](unsigned int i)
       {
-         std::vector<retType> partialResults(step);
+         std::vector<retType> partialResults(std::min(end-i, step));
          for (unsigned j = 0; j < step && (i + j) < end; j+=seqStep) {
             partialResults[j] = func(i + j);
          }
@@ -266,7 +278,8 @@ namespace ROOT {
 /// \cond
     //////////////////////////////////////////////////////////////////////////
    /// Execute func in parallel, taking an element of an
-   /// std::vector as argument. Divides and groups the executions in nChunks with partial reduction;
+   /// std::vector as argument. Divides and groups the executions in nChunks with partial reduction.
+   /// If it doesn't make sense will reduce the number of chunks.\n
    /// A vector containg partial reductions' results is returned.
    template<class F, class T, class R, class Cond>
    auto TThreadExecutor::Map(F func, std::vector<T> &args, R redfunc, unsigned nChunks) -> std::vector<typename std::result_of<F(T)>::type> {
@@ -280,6 +293,11 @@ namespace ROOT {
       unsigned int nToProcess = args.size();
       std::vector<retType> reslist(nChunks);
       unsigned step = (nToProcess + nChunks - 1) / nChunks; //ceiling the division
+      // Avoid empty chunks
+      unsigned actualChunks = (nToProcess + step - 1) / step;
+      if(actualChunks != nChunks){
+          Warning("ROOT::TThreadExecutor::Map", "The number of chunks has been reduced to %d to avoid empty chunks", actualChunks);
+      }
 
       auto lambda = [&](unsigned int i)
       {
@@ -297,7 +315,8 @@ namespace ROOT {
 
     //////////////////////////////////////////////////////////////////////////
    /// Execute func in parallel, taking an element of an
-   /// std::initializer_list as an argument. Divides and groups the executions in nChunks with partial reduction;
+   /// std::initializer_list as an argument. Divides and groups the executions in nChunks with partial reduction.
+   /// If it doesn't make sense will reduce the number of chunks.\n
    /// A vector containg partial reductions' results is returned.
    template<class F, class T, class R, class Cond>
    auto TThreadExecutor::Map(F func, std::initializer_list<T> args, R redfunc, unsigned nChunks) -> std::vector<typename std::result_of<F(T)>::type> {


### PR DESCRIPTION
Thanks to @agarciamontoro that noticed this in his use cases and suggested the solution 👌 