### PR TITLE
[ROOT7] Use std::string instead of std::string_view

### DIFF
--- a/core/base/v7/inc/ROOT/TLogger.hxx
+++ b/core/base/v7/inc/ROOT/TLogger.hxx
@@ -93,10 +93,10 @@ namespace Experimental {
 
   public:
     TLogEntry() = default;
-    TLogEntry(ELogLevel level, std::string_view group):
+    TLogEntry(ELogLevel level, const std::string &group):
        fGroup(group), fLevel(level) {}
-    TLogEntry(ELogLevel level, std::string_view group, std::string_view filename,
-           int line, std::string_view funcname):
+    TLogEntry(ELogLevel level, const std::string &group, const std::string &filename,
+           int line, const std::string &funcname):
     fGroup(group), fFile(filename), fFuncName(funcname), fLine(line),
     fLevel(level) {}
 

--- a/graf2d/gpad/v7/inc/ROOT/TObjectDrawable.hxx
+++ b/graf2d/gpad/v7/inc/ROOT/TObjectDrawable.hxx
@@ -32,7 +32,7 @@ class TObjectDrawable : public TDrawable {
    std::string fOpts;                   ///< The drawing options
 
 public:
-   TObjectDrawable(const std::shared_ptr<TObject> &obj, std::string_view opts) : fObj(obj), fOpts(opts) {}
+   TObjectDrawable(const std::shared_ptr<TObject> &obj, const std::string &opts) : fObj(obj), fOpts(opts) {}
 
    /// Paint the histogram
    void Paint(TVirtualCanvasPainter &canv) final;
@@ -50,7 +50,7 @@ public:
 /// Interface to graphics taking a shared_ptr<TObject>.
 /// Must be on global scope, else lookup cannot find it (no ADL for TObject).
 inline std::unique_ptr<ROOT::Experimental::Internal::TDrawable> GetDrawable(const std::shared_ptr<TObject> &obj,
-                                                                            std::string_view opts = {})
+                                                                            const std::string &opts = {})
 {
    return std::make_unique<ROOT::Experimental::Internal::TObjectDrawable>(obj, opts);
 }

--- a/hist/hist/v7/speed/speedtest.cxx
+++ b/hist/hist/v7/speed/speedtest.cxx
@@ -111,13 +111,10 @@ void GenerateInput(std::vector<T> &numbers, double minVal, double maxVal, UInt_t
    }
 }
 
-std::string MakeTitle(std::string_view version,
-                      std::string_view histname,
-                      std::string_view title,
-                      std::string_view axis)
+std::string MakeTitle(const std::string &version, const std::string &histname, const std::string &title,
+                      const std::string &axis)
 {
-   std::string result = std::string(version) + " " + std::string(histname) + " " + title.to_string() + " [" + axis.to_string() + "]";
-   return result;
+   return version + " " + histname + " " + title + " [" + axis + "]";
 }
 
 template <int dim, typename type> const char *GetHist();
@@ -144,8 +141,8 @@ namespace R7 {
       // This is odd ...
       using InputType_t = double;
 
-      using FillFunc_t = std::add_pointer_t<long(ExpTH2 &hist, std::vector<InputType_t> &input, std::string_view type)>;
-
+      using FillFunc_t =
+         std::add_pointer_t<long(ExpTH2 &hist, std::vector<InputType_t> &input, const std::string &type)>;
 
       struct EE {
          static constexpr const char * const gType = "regular bin size  ";
@@ -178,7 +175,8 @@ namespace R7 {
          }
       };
 
-      inline static long fillN(ExpTH2 &hist, std::vector<InputType_t> &input, std::string_view gType) {
+      inline static long fillN(ExpTH2 &hist, std::vector<InputType_t> &input, const std::string &gType)
+      {
 
          // This is odd :( ...
          using array_t = std::array<InputType_t, 2>;
@@ -194,8 +192,8 @@ namespace R7 {
          return hist.GetNDim();
       }
 
-
-      inline static long fillBuffered(ExpTH2 &hist, std::vector<InputType_t> &input, std::string_view gType) {
+      inline static long fillBuffered(ExpTH2 &hist, std::vector<InputType_t> &input, const std::string &gType)
+      {
          Experimental::THistBufferedFill<ExpTH2> filler(hist);
          std::string title = MakeTitle(gVersion, GetHist<kNDim, T>(),"fills (buffered)   ", gType);
          {
@@ -206,7 +204,8 @@ namespace R7 {
          return hist.GetNDim();
       }
 
-      inline static long fill(ExpTH2 &hist, std::vector<InputType_t> &input, std::string_view gType) {
+      inline static long fill(ExpTH2 &hist, std::vector<InputType_t> &input, const std::string &gType)
+      {
          std::string title = MakeTitle(gVersion, GetHist<kNDim, T>(),"fills              ", gType);
          {
             Timer t(title.c_str(),input.size()/2);
@@ -227,8 +226,8 @@ namespace R7 {
       // This is odd ...
       using InputType_t = double;
 
-      using FillFunc_t = std::add_pointer_t<long(ExpTH1 &hist, std::vector<InputType_t> &input, std::string_view type)>;
-
+      using FillFunc_t =
+         std::add_pointer_t<long(ExpTH1 &hist, std::vector<InputType_t> &input, const std::string &type)>;
 
       struct EE {
          static constexpr const char * const gType = "regular bin size  ";
@@ -261,7 +260,8 @@ namespace R7 {
          }
       };
 
-      inline static long fillN(ExpTH1 &hist, std::vector<InputType_t> &input, std::string_view gType) {
+      inline static long fillN(ExpTH1 &hist, std::vector<InputType_t> &input, const std::string &gType)
+      {
 
          // This is odd :( ...
          using array_t = std::array<InputType_t, 1>;
@@ -277,8 +277,8 @@ namespace R7 {
          return hist.GetNDim();
       }
 
-
-      inline static long fillBuffered(ExpTH1 &hist, std::vector<InputType_t> &input, std::string_view gType) {
+      inline static long fillBuffered(ExpTH1 &hist, std::vector<InputType_t> &input, const std::string &gType)
+      {
          Experimental::THistBufferedFill<ExpTH1> filler(hist);
          std::string title = MakeTitle(gVersion, GetHist<kNDim, T>(),"fills (buffered)   ", gType);
          {
@@ -289,7 +289,8 @@ namespace R7 {
          return hist.GetNDim();
       }
 
-      inline static long fill(ExpTH1 &hist, std::vector<InputType_t> &input, std::string_view gType) {
+      inline static long fill(ExpTH1 &hist, std::vector<InputType_t> &input, const std::string &gType)
+      {
          std::string title = MakeTitle(gVersion, GetHist<kNDim, T>(),"fills              ", gType);
          {
             Timer t(title.c_str(),input.size());
@@ -327,8 +328,8 @@ namespace R6 {
       // This is odd ...
       using InputType_t = double;
 
-      using FillFunc_t = std::add_pointer_t<long(HistType_t &hist, std::vector<InputType_t> &input, std::string_view type)>;
-
+      using FillFunc_t =
+         std::add_pointer_t<long(HistType_t &hist, std::vector<InputType_t> &input, const std::string &type)>;
 
       struct EE {
 
@@ -363,8 +364,8 @@ namespace R6 {
          }
       };
 
-
-      static long fillBuffered(HistType_t &hist, std::vector<InputType_t> &input, std::string_view gType) {
+      static long fillBuffered(HistType_t &hist, std::vector<InputType_t> &input, const std::string &gType)
+      {
          std::string title = MakeTitle(gVersion, GetHist<kNDim,T>(),"fills (buffered)   ", gType);
          hist.SetBuffer(TH1::GetDefaultBufferSize());
          {
@@ -376,8 +377,8 @@ namespace R6 {
          return (long)hist.GetEntries();
       }
 
-
-      static long fillN(HistType_t &hist, std::vector<InputType_t> &input, std::string_view gType) {
+      static long fillN(HistType_t &hist, std::vector<InputType_t> &input, const std::string &gType)
+      {
          std::string title = MakeTitle(gVersion, GetHist<kNDim,T>(),"fills N (stride 32)", gType);
          constexpr size_t stride = gStride;
          {
@@ -389,7 +390,8 @@ namespace R6 {
          return (long)hist.GetEntries();
       }
 
-      static long fill(HistType_t &hist, std::vector<InputType_t> &input, std::string_view gType) {
+      static long fill(HistType_t &hist, std::vector<InputType_t> &input, const std::string &gType)
+      {
          std::string title = MakeTitle(gVersion, GetHist<kNDim,T>(),"fills              ", gType);
          {
             //Timer t("R6 2D fills [regular bins size]",input.size()/2);
@@ -410,8 +412,8 @@ namespace R6 {
       // This is odd ...
       using InputType_t = double;
 
-      using FillFunc_t = std::add_pointer_t<long(HistType_t &hist, std::vector<InputType_t> &input, std::string_view type)>;
-
+      using FillFunc_t =
+         std::add_pointer_t<long(HistType_t &hist, std::vector<InputType_t> &input, const std::string &type)>;
 
       struct EE {
 
@@ -446,8 +448,8 @@ namespace R6 {
          }
       };
 
-
-      static long fillBuffered(HistType_t &hist, std::vector<InputType_t> &input, std::string_view gType) {
+      static long fillBuffered(HistType_t &hist, std::vector<InputType_t> &input, const std::string &gType)
+      {
          std::string title = MakeTitle(gVersion, GetHist<kNDim,T>(),"fills (buffered)   ", gType);
          hist.SetBuffer(TH1::GetDefaultBufferSize());
          {
@@ -459,8 +461,8 @@ namespace R6 {
          return (long)hist.GetEntries();
       }
 
-
-      static long fillN(HistType_t &hist, std::vector<InputType_t> &input, std::string_view gType) {
+      static long fillN(HistType_t &hist, std::vector<InputType_t> &input, const std::string &gType)
+      {
          std::string title = MakeTitle(gVersion, GetHist<kNDim,T>(),"fills N (stride 32)", gType);
          constexpr size_t stride = gStride;
          {
@@ -472,7 +474,8 @@ namespace R6 {
          return (long)hist.GetEntries();
       }
 
-      static long fill(HistType_t &hist, std::vector<InputType_t> &input, std::string_view gType) {
+      static long fill(HistType_t &hist, std::vector<InputType_t> &input, const std::string &gType)
+      {
          std::string title = MakeTitle(gVersion, GetHist<kNDim,T>(),"fills              ", gType);
          {
             //Timer t("R6 2D fills [regular bins size]",input.size()/2);

--- a/io/io/v7/inc/ROOT/TFile.hxx
+++ b/io/io/v7/inc/ROOT/TFile.hxx
@@ -19,8 +19,8 @@
 
 #include "TClass.h"
 
-#include "RStringView.h"
 #include <memory>
+#include <string>
 #include <typeinfo>
 
 namespace ROOT {
@@ -49,8 +49,7 @@ private:
 
   /// Serialize the object at address, using the object's TClass.
   //FIXME: what about `cl` "pointing" to a base class?
-  void WriteMemoryWithType(std::string_view name, const void *address,
-                           TClass *cl);
+  void WriteMemoryWithType(const std::string &name, const void *address, TClass *cl);
 
   friend Internal::TFileSharedPtrCtor;
 
@@ -82,36 +81,32 @@ public:
   /// Open a file with `name` for reading.
   ///
   /// \note: Synchronizes multi-threaded accesses through locks.
-  static TFilePtr Open(std::string_view name,
-                       const Options_t &opts = Options_t());
+  static TFilePtr Open(const std::string &name, const Options_t &opts = Options_t());
 
   /// Open an existing file with `name` for reading and writing. If a file with
   /// that name does not exist, an invalid TFilePtr will be returned.
   ///
   /// \note: Synchronizes multi-threaded accesses through locks.
-  static TFilePtr OpenForUpdate(std::string_view name,
-                                const Options_t &opts = Options_t());
+  static TFilePtr OpenForUpdate(const std::string &name, const Options_t &opts = Options_t());
 
   /// Open a file with `name` for reading and writing. Fail (return an invalid
   /// `TFilePtr`) if a file with this name already exists.
   ///
   /// \note: Synchronizes multi-threaded accesses through locks.
-  static TFilePtr Create(std::string_view name,
-                         const Options_t &opts = Options_t());
+  static TFilePtr Create(const std::string &name, const Options_t &opts = Options_t());
 
   /// Open a file with `name` for reading and writing. If a file with this name
   /// already exists, delete it and create a new one. Else simply create a new file.
   ///
   /// \note: Synchronizes multi-threaded accesses through locks.
-  static TFilePtr Recreate(std::string_view name,
-                           const Options_t &opts = Options_t());
+  static TFilePtr Recreate(const std::string &name, const Options_t &opts = Options_t());
 
   ///\}
 
   /// Set the new directory used for cached reads, returns the old directory.
   ///
   /// \note: Synchronizes multi-threaded accesses through locks.
-  static std::string SetCacheDir(std::string_view path);
+  static std::string SetCacheDir(const std::string &path);
 
   /// Get the directory used for cached reads.
   static std::string GetCacheDir();
@@ -137,7 +132,7 @@ public:
   /// \throws TDirectoryTypeMismatch if the object stored under this name is of
   ///   a type different from `T`.
   template<class T>
-  std::unique_ptr<T> Read(std::string_view name) {
+  std::unique_ptr<T> Read(const std::string &name) {
     // FIXME: need separate collections for a TDirectory's key/value and registered objects. Here, we want to emit a read and must look through the key/values without attaching an object to the TDirectory.
       // FIXME: do not register read object in TDirectory
       // FIXME: implement actual read
@@ -148,29 +143,30 @@ public:
 
   /// Write an object that is not lifetime managed by this TFileImplBase.
   template<class T>
-  void Write(std::string_view name, const T &obj) {
+  void Write(const std::string &name, const T &obj) {
     WriteMemoryWithType(name, &obj, TClass::GetClass(typeid(T)));
   }
 
   /// Write an object that is not lifetime managed by this TFileImplBase.
   template<class T>
-  void Write(std::string_view name, const T *obj) {
+  void Write(const std::string &name, const T *obj) {
     WriteMemoryWithType(name, obj, TClass::GetClass(typeid(T)));
   }
 
   /// Write an object that is already lifetime managed by this TFileImplBase.
-  void Write(std::string_view name) {
-    auto dep = Find(name.to_string());
+  void Write(const std::string &name) {
+    auto dep = Find(name);
     WriteMemoryWithType(name, dep.GetPointer().get(), dep.GetType());
   }
 
   /// Hand over lifetime management of an object to this TFileImplBase, and
   /// write it.
   template<class T>
-  void Write(std::string_view name, std::shared_ptr <T> &&obj) {
-    Add(name, obj);
-    // FIXME: use an iterator from the insertion to write instead of a second name lookup.
-    Write(name);
+  void Write(const std::string &name, std::shared_ptr<T> &&obj)
+  {
+     Add(name, obj);
+     // FIXME: use an iterator from the insertion to write instead of a second name lookup.
+     Write(name);
   }
 };
 


### PR DESCRIPTION
The interfaces of ROOT's `string_view` and `std::string_view` are
different (e.g., no `to_string()` member function in `std::string_view`).

Reference: http://en.cppreference.com/w/cpp/header/string_view