### PR TITLE
[llvm] Backport D35536 to prevent nulling TUScope.

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/Sema/Sema.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Sema/Sema.cpp
@@ -832,7 +832,8 @@ void Sema::ActOnEndOfTranslationUnit() {
     emitAndClearUnusedLocalTypedefWarnings();
 
     // Modules don't need any of the checking below.
-    TUScope = nullptr;
+    if (!PP.isIncrementalProcessingEnabled())
+      TUScope = nullptr;
     return;
   }
 


### PR DESCRIPTION
See https://reviews.llvm.org/D35536 for more.