### PR TITLE
[llvm] Backport D33366 to prevent that alloc functions are hidden.

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/Sema/SemaExprCXX.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Sema/SemaExprCXX.cpp
@@ -2658,6 +2658,8 @@ void Sema::DeclareGlobalAllocationFunction(DeclarationName Name,
         Context, GlobalCtx, SourceLocation(), SourceLocation(), Name,
         FnType, /*TInfo=*/nullptr, SC_None, false, true);
     Alloc->setImplicit();
+    // Global allocation functions should always be visible.
+    Alloc->setHidden(false);
 
     // Implicit sized deallocation functions always have default visibility.
     Alloc->addAttr(


### PR DESCRIPTION
See https://reviews.llvm.org/D33366 for more.