### PR TITLE
Correct results list size in TThreadExecutor::Map

### DIFF
--- a/core/imt/inc/ROOT/TThreadExecutor.hxx
+++ b/core/imt/inc/ROOT/TThreadExecutor.hxx
@@ -261,7 +261,7 @@ namespace ROOT {
       }
 
       using retType = decltype(func(start));
-      std::vector<retType> reslist(nChunks);
+      std::vector<retType> reslist(actualChunks);
       auto lambda = [&](unsigned int i)
       {
          std::vector<retType> partialResults(std::min(end-i, step));
@@ -287,18 +287,16 @@ namespace ROOT {
       {
          return Map(func, args);
       }
-      // //check whether func is callable
-      using retType = decltype(func(args.front()));
 
       unsigned int nToProcess = args.size();
-      std::vector<retType> reslist(nChunks);
       unsigned step = (nToProcess + nChunks - 1) / nChunks; //ceiling the division
       // Avoid empty chunks
       unsigned actualChunks = (nToProcess + step - 1) / step;
       if(actualChunks != nChunks){
           Warning("ROOT::TThreadExecutor::Map", "The number of chunks has been reduced to %d to avoid empty chunks", actualChunks);
       }
-
+      using retType = decltype(func(args.front()));
+      std::vector<retType> reslist(actualChunks);
       auto lambda = [&](unsigned int i)
       {
          std::vector<T> partialResults(step);


### PR DESCRIPTION
When chunking and fitting the right amount of elements per chunk you
may end up with empty chunks at the end. This chunks will still consist
of N elements per chunk, but they will not be initialized. Accessing
them was a problem. Solved by reducing the number of chunks (not
allowing empty chunks)