### PR TITLE
[PyMVA] PyKeras fixes / ROOT-8928

### DIFF
--- a/tmva/pymva/src/MethodPyKeras.cxx
+++ b/tmva/pymva/src/MethodPyKeras.cxx
@@ -128,6 +128,8 @@ void MethodPyKeras::Init() {
    _import_array(); // required to use numpy arrays
 
    // Import Keras
+   // NOTE: sys.argv has to be cleared because otherwise TensorFlow breaks
+   PyRunString("import sys; sys.argv = ['']", "Set sys.argv failed");
    PyRunString("import keras", "Import Keras failed");
 
    // Set flag that model is not setup

--- a/tmva/pymva/test/testPyKerasClassification.C
+++ b/tmva/pymva/test/testPyKerasClassification.C
@@ -12,12 +12,11 @@
 TString pythonSrc = "\
 from keras.models import Sequential\n\
 from keras.layers.core import Dense, Activation\n\
-from keras import initializations\n\
 from keras.optimizers import SGD\n\
 \n\
 model = Sequential()\n\
-model.add(Dense(64, init=\"normal\", activation=\"relu\", input_dim=4))\n\
-model.add(Dense(2, init=\"normal\", activation=\"softmax\"))\n\
+model.add(Dense(64, activation=\"relu\", input_dim=4))\n\
+model.add(Dense(2, activation=\"softmax\"))\n\
 model.compile(loss=\"categorical_crossentropy\", optimizer=SGD(lr=0.01), metrics=[\"accuracy\",])\n\
 model.save(\"kerasModelClassification.h5\")\n";
 

--- a/tmva/pymva/test/testPyKerasMulticlass.C
+++ b/tmva/pymva/test/testPyKerasMulticlass.C
@@ -13,12 +13,11 @@
 TString pythonSrc = "\
 from keras.models import Sequential\n\
 from keras.layers.core import Dense, Activation\n\
-from keras import initializations\n\
 from keras.optimizers import Adam\n\
 \n\
 model = Sequential()\n\
-model.add(Dense(64, init=\"glorot_normal\", activation=\"relu\", input_dim=4))\n\
-model.add(Dense(4, init=\"glorot_normal\", activation=\"softmax\"))\n\
+model.add(Dense(64, activation=\"relu\", input_dim=4))\n\
+model.add(Dense(4, activation=\"softmax\"))\n\
 model.compile(loss=\"categorical_crossentropy\", optimizer=Adam(), metrics=[\"accuracy\",])\n\
 model.save(\"kerasModelMulticlass.h5\")\n";
 

--- a/tmva/pymva/test/testPyKerasRegression.C
+++ b/tmva/pymva/test/testPyKerasRegression.C
@@ -12,12 +12,11 @@
 TString pythonSrc = "\
 from keras.models import Sequential\n\
 from keras.layers.core import Dense, Activation\n\
-from keras import initializations\n\
 from keras.optimizers import SGD\n\
 \n\
 model = Sequential()\n\
-model.add(Dense(64, init=\"normal\", activation=\"tanh\", input_dim=2))\n\
-model.add(Dense(1, init=\"normal\", activation=\"linear\"))\n\
+model.add(Dense(64, activation=\"tanh\", input_dim=2))\n\
+model.add(Dense(1, activation=\"linear\"))\n\
 model.compile(loss=\"mean_squared_error\", optimizer=SGD(lr=0.01))\n\
 model.save(\"kerasModelRegression.h5\")\n";
 


### PR DESCRIPTION
- Fix TensorFlow backend for PyKeras (breaks with non-empty sys.argv in Python)
- Make test cases compatible with Keras v1.x and v2.x API

This is a fix for [ROOT-8928](https://sft.its.cern.ch/jira/browse/ROOT-8928).