### PR TITLE
Disable unnecessary rebuilds on git changes

### DIFF
--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -95,6 +95,9 @@ set(CLANG_ENABLE_FORMAT OFF CACHE BOOL "")
 #---Remove the inherited include_directories()
 set_directory_properties(PROPERTIES INCLUDE_DIRECTORIES "")
 
+#---Disable VCS writing to prevent that we always have to rebuild when someone touched the git HEAD
+set(LLVM_APPEND_VC_REV OFF CACHE BOOL "Disabled LLVM revision dependency" FORCE)
+
 #---Add the sub-directory excluding all the targets from all-----------------------------------------
 if(CMAKE_GENERATOR MATCHES "Xcode")
   add_subdirectory(llvm/src)

--- a/interpreter/llvm/src/include/llvm/Support/CMakeLists.txt
+++ b/interpreter/llvm/src/include/llvm/Support/CMakeLists.txt
@@ -38,6 +38,13 @@ set(version_inc "${CMAKE_CURRENT_BINARY_DIR}/VCSRevision.h")
 
 set(get_svn_script "${LLVM_CMAKE_PATH}/GenerateVersionFromCVS.cmake")
 
+# Ugly hack to prevent rebuilding LLVM whenever the git HEAD timestamp
+# changes. This is properly solved by setting LLVM_APPEND_VC_REV to OFF
+# but this only really works once this review is included in our LLVM
+# version: https://reviews.llvm.org/D35377
+# Once our LLVM version includes this review, this code can be removed
+# as we properly set LLVM_APPEND_VC_REV in interpreter/CMakeLists.txt.
+set(llvm_vc)
 if(DEFINED llvm_vc)
   # Create custom target to generate the VC revision include.
   add_custom_command(OUTPUT "${version_inc}"


### PR DESCRIPTION
This fixes that we often rebuild parts of ROOT by just doing simple git things. Before this change
we had this dependency on the header VCSRevision.h which is used by different parts of LLVM:
```
interpreter/llvm/src/include/llvm/Support/VCSRevision.h:
  input: CUSTOM_COMMAND
    /home/teemperor/root/root-trunk2/.git/logs/HEAD <- Timestamp of this changes a lot!
    /home/teemperor/root/root-trunk2/interpreter/llvm/src/cmake/modules/GenerateVersionFromCVS.cmake
  outputs:
    interpreter/llvm/src/include/llvm/Support/llvm_vcsrevision_h
    interpreter/llvm/src/include/llvm/Support/CMakeFiles/llvm_vcsrevision_h
```

After this change we no longer have the git head in here:

```
teemperor@ftlserver ~/r/trunk-build2> ninja -t query interpreter/llvm/src/include/llvm/Support/VCSRevision.h
interpreter/llvm/src/include/llvm/Support/VCSRevision.h:
  outputs:
    interpreter/llvm/src/include/llvm/Support/CMakeFiles/llvm_vcsrevision_h
```

I added two commits: One that fixes the current builds in a hacky way and one that is doing it properly but only goes into effect once we have the next LLVM upgrade (as the flag for configuring this is just added recently).