### PR TITLE
[TDF] Use "column" instead of "branch" where appropriate in UI and docs

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDataFrame.hxx
+++ b/tree/treeplayer/inc/ROOT/TDataFrame.hxx
@@ -9,8 +9,8 @@
  *************************************************************************/
 
 /**
-  \defgroup dataframe Data Frame
-The ROOT Data Frame allows to analyse data stored in TTrees with a high level interface.
+  \defgroup dataframe DataFrame
+ROOT's TDataFrame allows to analyse data stored in TTrees with a high level interface.
 */
 
 #ifndef ROOT_TDATAFRAME


### PR DESCRIPTION
TDataFrame's user guide uses the term "column" interchangeably with "branch". At the same time, "column" is preferred as it is more general and will still be appropriate when TDataFrame will read data formats other than ROOT's. This commit updates the user-facing method signatures and the method documentations to use preferably use "column".

This commit also adds some minor improvements to method descriptions.
It introduces no functional changes.