### PR TITLE
Fix calling variadic functions through TClingCallFunc (Fixes roottest-python-cling-cling on ICC).

### DIFF
--- a/core/metacling/src/TClingCallFunc.cxx
+++ b/core/metacling/src/TClingCallFunc.cxx
@@ -433,6 +433,8 @@ void TClingCallFunc::make_narg_call(const std::string &return_type, const unsign
             ROOT::TMetaUtils::GetNormalizedName(arg_type, QT, *fInterp, fNormCtxt);
             callbuf << arg_type;
          }
+         if (FD->isVariadic())
+            callbuf << ", ...";
          callbuf << ")";
       }
 

--- a/core/metacling/test/TClingCallFuncTests.cxx
+++ b/core/metacling/test/TClingCallFuncTests.cxx
@@ -106,6 +106,28 @@ TEST(TClingCallFunc, FunctionWrapperVoid)
    gInterpreter->ClassInfo_Delete(GlobalNamespace);
 }
 
+TEST(TClingCallFunc, FunctionWrapperVariadic)
+{
+   gInterpreter->Declare(R"cpp(
+                           void FunctionWrapperFuncVariadic(int j, ...) {}
+                           )cpp");
+
+   ClassInfo_t *GlobalNamespace = gInterpreter->ClassInfo_Factory("");
+   CallFunc_t *mc = gInterpreter->CallFunc_Factory();
+   long offset = 0;
+
+   gInterpreter->CallFunc_SetFuncProto(mc, GlobalNamespace, "FunctionWrapperFuncVariadic", "int", &offset);
+   std::string wrapper = gInterpreter->CallFunc_GetWrapperCode(mc);
+
+   ASSERT_TRUE(gInterpreter->Declare(wrapper.c_str()));
+   // Make sure we didn't forget the ... in the variadic function signature.
+   ASSERT_TRUE(wrapper.find("((void (&)(int, ...))FunctionWrapperFuncVariadic)") != wrapper.npos);
+
+   // Cleanup
+   gInterpreter->CallFunc_Delete(mc);
+   gInterpreter->ClassInfo_Delete(GlobalNamespace);
+}
+
 TEST(TClingCallFunc, FunctionWrapperDefaultArg)
 {
    gInterpreter->Declare(R"cpp(


### PR DESCRIPTION
The casting of the function to improve lookup didn't took
variadic functions into aspect, causing ABI issues when generating
the code for calling this function. This correctly appends the
annotation for a variadic function to the function type.

This fixes the roottest-python-cling-cling test when compiling
with icc.