### PR TITLE
webgui: correct close of canvas

### DIFF
--- a/etc/http/scripts/JSRootCore.js
+++ b/etc/http/scripts/JSRootCore.js
@@ -93,7 +93,7 @@
    }
 } (function(JSROOT) {
 
-   JSROOT.version = "dev 27/07/2017";
+   JSROOT.version = "dev 28/07/2017";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;

--- a/etc/http/scripts/JSRootCore.js
+++ b/etc/http/scripts/JSRootCore.js
@@ -695,7 +695,8 @@
          if (typeof user_call_back == 'function') user_call_back.call(xhr, res);
       }
 
-      var pthis = this, method = "GET";
+      var pthis = this, method = "GET", async = true, p = kind.indexOf(";sync");
+      if (p>0) { kind.substr(0,p); async = false; }
       if (kind === "head") method = "HEAD"; else
       if ((kind === "multi") || (kind==="posttext")) method = "POST";
 
@@ -755,7 +756,7 @@
          callback(xhr.response);
       }
 
-      xhr.open(method, url, true);
+      xhr.open(method, url, async);
 
       if ((kind == "bin") || (kind == "buf")) xhr.responseType = 'arraybuffer';
 

--- a/etc/http/scripts/JSRootPainter.hierarchy.js
+++ b/etc/http/scripts/JSRootPainter.hierarchy.js
@@ -2159,6 +2159,7 @@
       if (JSROOT.GetUrlOption("webcanvas")!==null) socket_kind = "websocket"; else
       if (JSROOT.GetUrlOption("longpollcanvas")!==null) socket_kind = "longpoll"; else
       if (JSROOT.GetUrlOption("cef_canvas")!==null) socket_kind = "cefquery";
+      if (JSROOT.GetUrlOption("qt5")!==null) JSROOT.browser.qt5 = true;
 
       if (drawing && socket_kind) {
 
@@ -2173,7 +2174,10 @@
          if (painter.batch_mode) JSROOT.BatchMode = true;
                             else JSROOT.RegisterForResize(painter);
 
-         if (window) window.onbeforeunload = painter.WindowBeforeUnloadHanlder.bind(painter);
+         if (window) {
+            window.onbeforeunload = painter.WindowBeforeUnloadHanlder.bind(painter);
+            if (JSROOT.browser.qt5) window.onqt5unload = window.onbeforeunload;
+         }
 
          return;
       }

--- a/etc/http/scripts/JSRootPainter.js
+++ b/etc/http/scripts/JSRootPainter.js
@@ -2436,7 +2436,7 @@
       this.req = null;
 
       this.nextrequest = function(data, kind) {
-         var url = this.path;
+         var url = this.path, sync = "";
          if (kind === "connect") {
             url+="?connect";
             this.connid = "connect";
@@ -2445,6 +2445,7 @@
             if ((this.connid===null) || (this.connid==="close")) return;
             url+="?connection="+this.connid + "&close";
             this.connid = "close";
+            if (JSROOT.browser.qt5) sync = ";sync"; // use sync mode to close qt5 webengine
          } else
          if ((this.connid===null) || (typeof this.connid!=='number')) {
             return console.error("No connection");
@@ -2460,7 +2461,7 @@
             url += post;
          }
 
-         var req = JSROOT.NewHttpRequest(url, "text", function(res) {
+         var req = JSROOT.NewHttpRequest(url, "text" + sync, function(res) {
             if (res===null) res = this.response; // workaround for WebEngine - it does not handle content correctly
             if (this.handle.req === this) {
                this.handle.req = null; // get response for existing dummy request
@@ -2583,13 +2584,12 @@
       return this;
    }
 
-   TObjectPainter.prototype.CloseWebsocket = function() {
-      if (this._websocket && this._websocket_opened) {
-         this._websocket_opened = false;
+   TObjectPainter.prototype.CloseWebsocket = function(force) {
+      if (this._websocket && this._websocket_state > 0) {
+         this._websocket_state = force ? -1 : 0; // -1 prevent socket from reopening
+         this._websocket.onclose = null; // hide normal handler
          this._websocket.close();
          delete this._websocket;
-         if (typeof this.OnWebsocketClosed == 'function')
-            this.OnWebsocketClosed();
       }
    }
 
@@ -2603,14 +2603,14 @@
 
       // this._websocket = conn;
       this._websocket_kind = socket_kind;
-      this._websocket_opened = false;
+      this._websocket_state = 0;
 
       var pthis = this, sum1 = 0, sum2 = 0, cnt = 0;
 
       function retry_open(first_time) {
 
-      if (pthis._websocket_opened) return;
-      console.log("try open wensocket again");
+      if (pthis._websocket_state != 0) return;
+      console.log("try open wensocket again " + pthis._websocket_state);
       if (pthis._websocket) pthis._websocket.close();
       delete pthis._websocket;
 
@@ -2647,7 +2647,7 @@
 
       conn.onopen = function() {
          console.log('websocket initialized');
-         pthis._websocket_opened = true;
+         pthis._websocket_state = 1;
          if (typeof pthis.OnWebsocketOpened == 'function')
             pthis.OnWebsocketOpened(conn);
       }
@@ -2661,10 +2661,10 @@
       }
 
       conn.onclose = function() {
-         console.log('websocket closed');
          delete pthis._websocket;
-         if (pthis._websocket_opened) {
-            pthis._websocket_opened = false;
+         if (pthis._websocket_state > 0) {
+            console.log('websocket closed');
+            pthis._websocket_state = 0;
             if (typeof pthis.OnWebsocketClosed == 'function')
                pthis.OnWebsocketClosed();
          }
@@ -4912,8 +4912,7 @@
 
    TPadPainter.prototype.WindowBeforeUnloadHanlder = function() {
       // when window closed, close socket
-      this.CloseWebsocket();
-      return null; // one could block close, but not now
+      this.CloseWebsocket(true);
    }
 
    TPadPainter.prototype.GetAllRanges = function() {

--- a/etc/http/scripts/JSRootPainter.js
+++ b/etc/http/scripts/JSRootPainter.js
@@ -4826,8 +4826,10 @@
 
    TPadPainter.prototype.OnWebsocketMsg = function(conn, msg) {
 
-      if (msg.substr(0,5)=='SNAP:') {
-
+      if (msg == "CLOSE") {
+         this.OnWebsocketClosed();
+         this.CloseWebsocket(true);
+      } else if (msg.substr(0,5)=='SNAP:') {
          msg = msg.substr(5);
          var p1 = msg.indexOf(":"),
              snapid = msg.substr(0,p1),
@@ -4885,16 +4887,12 @@
          if (cmd == "SVG") {
             var res = "";
             if (this.CreateSvg) res = this.CreateSvg();
-            console.log('SVG size = ' + res.length);
             conn.send(reply + res);
          } else if (cmd == "PNG") {
             this.ProduceImage(true, 'any.png', function(can) {
                var res = can.toDataURL('image/png'),
                    separ = res.indexOf("base64,");
-               if (separ>0)
-                  conn.send(reply + res.substr(separ+7));
-               else
-                  conn.send(reply);
+               conn.send(reply + ((separ>0) ? res.substr(separ+7) : ""));
             });
          } else {
             console.log('Urecognized command ' + cmd);

--- a/graf2d/gpad/v7/inc/ROOT/TCanvas.hxx
+++ b/graf2d/gpad/v7/inc/ROOT/TCanvas.hxx
@@ -129,6 +129,9 @@ public:
    /// Display the canvas.
    void Show(const std::string &where = "");
 
+   /// Close all canvas displays
+   void Hide();
+
    // Indicates that primitives list was changed or any primitive was modified
    void Modified() { fModified++; }
 

--- a/graf2d/gpad/v7/src/TCanvas.cxx
+++ b/graf2d/gpad/v7/src/TCanvas.cxx
@@ -70,7 +70,7 @@ std::shared_ptr<ROOT::Experimental::TCanvas> ROOT::Experimental::TCanvas::Create
 
 //////////////////////////////////////////////////////////////////////////
 /// Create new display for the canvas
-/// Parameter \par where specified  which program could be used for display creation
+/// Parameter \par where specifies which program could be used for display creation
 /// Possible values:
 ///
 ///      cef - Chromium Embeded Framework, local display, local communication
@@ -99,6 +99,15 @@ void ROOT::Experimental::TCanvas::Show(const std::string &where)
       fPainter->NewDisplay(where);
       fPainter->CanvasUpdated(fModified, true, nullptr); // trigger async display
    }
+}
+
+//////////////////////////////////////////////////////////////////////////
+/// Close all canvas displays
+
+void ROOT::Experimental::TCanvas::Hide()
+{
+   if (fPainter)
+      delete fPainter.release();
 }
 
 void ROOT::Experimental::TCanvas::SaveAs(const std::string &filename, bool async, CanvasCallback_t callback)

--- a/gui/canvaspainter/v7/qt5/rootwebpage.cpp
+++ b/gui/canvaspainter/v7/qt5/rootwebpage.cpp
@@ -25,3 +25,4 @@ void RootWebPage::javaScriptConsoleMessage(JavaScriptConsoleMessageLevel, const 
 
    printf("CONSOLE %s:%d: %s\n", src.data(), lineNumber, ba.data());
 }
+

--- a/gui/canvaspainter/v7/qt5/rootwebpage.cpp
+++ b/gui/canvaspainter/v7/qt5/rootwebpage.cpp
@@ -25,4 +25,3 @@ void RootWebPage::javaScriptConsoleMessage(JavaScriptConsoleMessageLevel, const 
 
    printf("CONSOLE %s:%d: %s\n", src.data(), lineNumber, ba.data());
 }
-

--- a/gui/canvaspainter/v7/qt5/rootwebview.cpp
+++ b/gui/canvaspainter/v7/qt5/rootwebview.cpp
@@ -30,3 +30,11 @@ RootWebView::RootWebView(QWidget *parent) : QWebEngineView(parent)
 RootWebView::~RootWebView()
 {
 }
+
+void RootWebView::closeEvent(QCloseEvent *)
+{
+   page()->runJavaScript("if (window && window.onqt5unload) window.onqt5unload();");
+
+   //printf("run javascript done\n");
+}
+

--- a/gui/canvaspainter/v7/qt5/rootwebview.cpp
+++ b/gui/canvaspainter/v7/qt5/rootwebview.cpp
@@ -25,6 +25,8 @@ RootWebView::RootWebView(QWidget *parent) : QWebEngineView(parent)
    //        this, SLOT(doConsole(JavaScriptConsoleMessageLevel, const QString &, int, const QString &)));
 
    // connect(this, &QWebEngineView::javaScriptConsoleMessage, this, &RootWebView::doConsole);
+
+   connect(page(), &QWebEnginePage::windowCloseRequested, this, &RootWebView::onWindowCloseRequested);
 }
 
 RootWebView::~RootWebView()
@@ -35,6 +37,10 @@ void RootWebView::closeEvent(QCloseEvent *)
 {
    page()->runJavaScript("if (window && window.onqt5unload) window.onqt5unload();");
 
-   //printf("run javascript done\n");
+   // printf("run javascript done\n");
 }
 
+void RootWebView::onWindowCloseRequested()
+{
+   close();
+}

--- a/gui/canvaspainter/v7/qt5/rootwebview.h
+++ b/gui/canvaspainter/v7/qt5/rootwebview.h
@@ -21,6 +21,8 @@
 class RootWebView : public QWebEngineView {
    Q_OBJECT
 protected:
+   virtual void closeEvent(QCloseEvent *);
+
 public:
    RootWebView(QWidget *parent = 0);
    virtual ~RootWebView();

--- a/gui/canvaspainter/v7/qt5/rootwebview.h
+++ b/gui/canvaspainter/v7/qt5/rootwebview.h
@@ -23,6 +23,9 @@ class RootWebView : public QWebEngineView {
 protected:
    virtual void closeEvent(QCloseEvent *);
 
+public slots:
+   void onWindowCloseRequested();
+
 public:
    RootWebView(QWidget *parent = 0);
    virtual ~RootWebView();

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -366,7 +366,7 @@ void TCanvasPainter::NewDisplay(const std::string &where)
    if (symbol_qt5 && (is_native || is_qt5)) {
       typedef void (*FunctionQt5)(const char *, void *, bool);
 
-      addr.Form("://dummy:8080/web7gui/%s/draw.htm?longpollcanvas%s", GetName(), (IsBatchMode() ? "&batch_mode" : ""));
+      addr.Form("://dummy:8080/web7gui/%s/draw.htm?longpollcanvas%s&qt5", GetName(), (IsBatchMode() ? "&batch_mode" : ""));
       // addr.Form("example://localhost:8080/Canvases/%s/draw.htm", Canvas()->GetName());
 
       Info("NewDisplay", "Show canvas in Qt5 window:  %s", addr.Data());

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -237,7 +237,7 @@ private:
 
    void PopFrontCommand(bool res = false);
 
-   virtual Bool_t ProcessWS(THttpCallArg *arg);
+   virtual Bool_t ProcessWS(THttpCallArg *arg) override;
 
    void CancelCommands(bool cancel_all, UInt_t connid = 0);
 
@@ -267,7 +267,7 @@ public:
       // TODO: should we close server when all canvases are closed?
    }
 
-   virtual bool IsBatchMode() const { return fBatchMode; }
+   virtual bool IsBatchMode() const override { return fBatchMode; }
 
    virtual void AddDisplayItem(ROOT::Experimental::TDisplayItem *item) final;
 

--- a/net/http/inc/THttpCallArg.h
+++ b/net/http/inc/THttpCallArg.h
@@ -150,7 +150,8 @@ public:
    void SetFile(const char *filename = 0)
    {
       SetContentType("_file_");
-      if (filename != 0) fContent = filename;
+      if (filename != 0)
+         fContent = filename;
    }
 
    /** set content type as XML */

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -45,7 +45,8 @@ public:
 
    virtual void Send(const void *buf, int len)
    {
-      if (fWSconn) mg_websocket_write(fWSconn, WEBSOCKET_OPCODE_TEXT, (const char *)buf, len);
+      if (fWSconn)
+         mg_websocket_write(fWSconn, WEBSOCKET_OPCODE_TEXT, (const char *)buf, len);
    }
 };
 
@@ -54,12 +55,15 @@ public:
 int websocket_connect_handler(const struct mg_connection *conn, void *)
 {
    const struct mg_request_info *request_info = mg_get_request_info(conn);
-   if (request_info == 0) return 1;
+   if (request_info == 0)
+      return 1;
 
    TCivetweb *engine = (TCivetweb *)request_info->user_data;
-   if (engine == 0) return 1;
+   if (engine == 0)
+      return 1;
    THttpServer *serv = engine->GetServer();
-   if (serv == 0) return 1;
+   if (serv == 0)
+      return 1;
 
    THttpCallArg arg;
    arg.SetPathAndFileName(request_info->uri); // path and file name
@@ -79,9 +83,11 @@ void websocket_ready_handler(struct mg_connection *conn, void *)
    const struct mg_request_info *request_info = mg_get_request_info(conn);
 
    TCivetweb *engine = (TCivetweb *)request_info->user_data;
-   if (engine == 0) return;
+   if (engine == 0)
+      return;
    THttpServer *serv = engine->GetServer();
-   if (serv == 0) return;
+   if (serv == 0)
+      return;
 
    THttpCallArg arg;
    arg.SetPathAndFileName(request_info->uri); // path and file name
@@ -101,12 +107,15 @@ int websocket_data_handler(struct mg_connection *conn, int, char *data, size_t l
    const struct mg_request_info *request_info = mg_get_request_info(conn);
 
    // do not handle empty data
-   if (len == 0) return 1;
+   if (len == 0)
+      return 1;
 
    TCivetweb *engine = (TCivetweb *)request_info->user_data;
-   if (engine == 0) return 1;
+   if (engine == 0)
+      return 1;
    THttpServer *serv = engine->GetServer();
-   if (serv == 0) return 1;
+   if (serv == 0)
+      return 1;
 
    THttpCallArg arg;
    arg.SetPathAndFileName(request_info->uri); // path and file name
@@ -128,9 +137,11 @@ void websocket_close_handler(const struct mg_connection *conn, void *)
    const struct mg_request_info *request_info = mg_get_request_info(conn);
 
    TCivetweb *engine = (TCivetweb *)request_info->user_data;
-   if (engine == 0) return;
+   if (engine == 0)
+      return;
    THttpServer *serv = engine->GetServer();
-   if (serv == 0) return;
+   if (serv == 0)
+      return;
 
    THttpCallArg arg;
    arg.SetPathAndFileName(request_info->uri); // path and file name
@@ -149,7 +160,8 @@ static int log_message_handler(const struct mg_connection *conn, const char *mes
 
    TCivetweb *engine = (TCivetweb *)mg_get_user_data(ctx);
 
-   if (engine) return engine->ProcessLog(message);
+   if (engine)
+      return engine->ProcessLog(message);
 
    // provide debug output
    if ((gDebug > 0) || (strstr(message, "cannot bind to") != 0))
@@ -165,9 +177,11 @@ static int begin_request_handler(struct mg_connection *conn, void *)
    const struct mg_request_info *request_info = mg_get_request_info(conn);
 
    TCivetweb *engine = (TCivetweb *)request_info->user_data;
-   if (engine == 0) return 0;
+   if (engine == 0)
+      return 0;
    THttpServer *serv = engine->GetServer();
-   if (serv == 0) return 0;
+   if (serv == 0)
+      return 0;
 
    THttpCallArg arg;
 
@@ -195,7 +209,8 @@ static int begin_request_handler(struct mg_connection *conn, void *)
       arg.SetQuery(request_info->query_string);  // query arguments
       arg.SetTopName(engine->GetTopName());
       arg.SetMethod(request_info->request_method); // method like GET or POST
-      if (request_info->remote_user != 0) arg.SetUserName(request_info->remote_user);
+      if (request_info->remote_user != 0)
+         arg.SetUserName(request_info->remote_user);
 
       TString header;
       for (int n = 0; n < request_info->num_headers; n++)
@@ -228,7 +243,8 @@ static int begin_request_handler(struct mg_connection *conn, void *)
          cont.Append(TString::Format("  FileName : %s\n", arg.GetFileName()));
          cont.Append(TString::Format("  Query    : %s\n", arg.GetQuery()));
          cont.Append(TString::Format("  PostData : %ld\n", arg.GetPostDataLength()));
-         if (arg.GetUserName()) cont.Append(TString::Format("  User     : %s\n", arg.GetUserName()));
+         if (arg.GetUserName())
+            cont.Append(TString::Format("  User     : %s\n", arg.GetUserName()));
 
          cont.Append("</pre><p>\n");
 
@@ -267,7 +283,8 @@ static int begin_request_handler(struct mg_connection *conn, void *)
          dozip = kFALSE;
          for (int n = 0; n < request_info->num_headers; n++) {
             TString name = request_info->http_headers[n].name;
-            if (name.Index("Accept-Encoding", 0, TString::kIgnoreCase) != 0) continue;
+            if (name.Index("Accept-Encoding", 0, TString::kIgnoreCase) != 0)
+               continue;
             TString value = request_info->http_headers[n].value;
             dozip = (value.Index("gzip", 0, TString::kIgnoreCase) != kNPOS);
             break;
@@ -277,13 +294,15 @@ static int begin_request_handler(struct mg_connection *conn, void *)
       case 3: dozip = kTRUE; break;
       }
 
-      if (dozip) arg.CompressWithGzip();
+      if (dozip)
+         arg.CompressWithGzip();
 
       TString hdr;
       arg.FillHttpHeader(hdr, "HTTP/1.1");
       mg_printf(conn, "%s", hdr.Data());
 
-      if (arg.GetContentLength() > 0) mg_write(conn, arg.GetContent(), (size_t)arg.GetContentLength());
+      if (arg.GetContentLength() > 0)
+         mg_write(conn, arg.GetContent(), (size_t)arg.GetContentLength());
    }
 
    // Returning non-zero tells civetweb that our function has replied to
@@ -323,10 +342,10 @@ static int begin_request_handler(struct mg_connection *conn, void *)
 
 ClassImp(TCivetweb);
 
-   ////////////////////////////////////////////////////////////////////////////////
-   /// constructor
+////////////////////////////////////////////////////////////////////////////////
+/// constructor
 
-   TCivetweb::TCivetweb()
+TCivetweb::TCivetweb()
    : THttpEngine("civetweb", "compact embedded http server"), fCtx(0), fCallbacks(0), fTopName(), fDebug(kFALSE)
 {
 }
@@ -336,8 +355,10 @@ ClassImp(TCivetweb);
 
 TCivetweb::~TCivetweb()
 {
-   if (fCtx != 0) mg_stop((struct mg_context *)fCtx);
-   if (fCallbacks != 0) free(fCallbacks);
+   if (fCtx != 0)
+      mg_stop((struct mg_context *)fCtx);
+   if (fCallbacks != 0)
+      free(fCallbacks);
    fCtx = 0;
    fCallbacks = 0;
 }
@@ -347,7 +368,8 @@ TCivetweb::~TCivetweb()
 
 Int_t TCivetweb::ProcessLog(const char *message)
 {
-   if ((gDebug > 0) || (strstr(message, "cannot bind to") != 0)) Error("Log", "%s", message);
+   if ((gDebug > 0) || (strstr(message, "cannot bind to") != 0))
+      Error("Log", "%s", message);
 
    return 0;
 }
@@ -391,29 +413,38 @@ Bool_t TCivetweb::Create(const char *args)
             url.ParseOptions();
 
             const char *top = url.GetValueFromOptions("top");
-            if (top != 0) fTopName = top;
+            if (top != 0)
+               fTopName = top;
 
             const char *log = url.GetValueFromOptions("log");
-            if (log != 0) log_file = log;
+            if (log != 0)
+               log_file = log;
 
             Int_t thrds = url.GetIntValueFromOptions("thrds");
-            if (thrds > 0) num_threads.Form("%d", thrds);
+            if (thrds > 0)
+               num_threads.Form("%d", thrds);
 
             const char *afile = url.GetValueFromOptions("auth_file");
-            if (afile != 0) auth_file = afile;
+            if (afile != 0)
+               auth_file = afile;
 
             const char *adomain = url.GetValueFromOptions("auth_domain");
-            if (adomain != 0) auth_domain = adomain;
+            if (adomain != 0)
+               auth_domain = adomain;
 
             const char *sslc = url.GetValueFromOptions("ssl_cert");
-            if (sslc != 0) ssl_cert = sslc;
+            if (sslc != 0)
+               ssl_cert = sslc;
 
             Int_t wtmout = url.GetIntValueFromOptions("websocket_timeout");
-            if (wtmout > 0) websocket_timeout.Format("%d", wtmout * 1000);
+            if (wtmout > 0)
+               websocket_timeout.Format("%d", wtmout * 1000);
 
-            if (url.HasOption("debug")) fDebug = kTRUE;
+            if (url.HasOption("debug"))
+               fDebug = kTRUE;
 
-            if (url.HasOption("loopback") && (sport.Index(":") == kNPOS)) sport = TString("127.0.0.1:") + sport;
+            if (url.HasOption("loopback") && (sport.Index(":") == kNPOS))
+               sport = TString("127.0.0.1:") + sport;
          }
       }
    }
@@ -452,7 +483,8 @@ Bool_t TCivetweb::Create(const char *args)
    // Start the web server.
    fCtx = mg_start((struct mg_callbacks *)fCallbacks, this, options);
 
-   if (fCtx == 0) return kFALSE;
+   if (fCtx == 0)
+      return kFALSE;
 
    mg_set_request_handler((struct mg_context *)fCtx, "/", begin_request_handler, 0);
 

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -100,6 +100,9 @@ int websocket_data_handler(struct mg_connection *conn, int, char *data, size_t l
 {
    const struct mg_request_info *request_info = mg_get_request_info(conn);
 
+   // do not handle empty data
+   if (len == 0) return 1;
+
    TCivetweb *engine = (TCivetweb *)request_info->user_data;
    if (engine == 0) return 1;
    THttpServer *serv = engine->GetServer();

--- a/net/http/src/THttpCallArg.cxx
+++ b/net/http/src/THttpCallArg.cxx
@@ -66,14 +66,16 @@ THttpCallArg::~THttpCallArg()
 
 TString THttpCallArg::AccessHeader(TString &buf, const char *name, const char *value, Bool_t doing_set)
 {
-   if (name == 0) return TString();
+   if (name == 0)
+      return TString();
 
    Int_t curr = 0;
 
    while (curr < buf.Length() - 2) {
 
       Int_t next = buf.Index("\r\n", curr);
-      if (next == kNPOS) break; // should never happen
+      if (next == kNPOS)
+         break; // should never happen
 
       if (buf.Index(name, curr) != curr) {
          curr = next + 2;
@@ -91,13 +93,15 @@ TString THttpCallArg::AccessHeader(TString &buf, const char *name, const char *v
       curr++;
       while ((curr < next) && (buf[curr] == ' ')) curr++;
 
-      if (value == 0) return buf(curr, next - curr);
+      if (value == 0)
+         return buf(curr, next - curr);
       buf.Remove(curr, next - curr);
       buf.Insert(curr, value);
       return TString(value);
    }
 
-   if (value == 0) return TString();
+   if (value == 0)
+      return TString();
 
    buf.Append(TString::Format("%s: %s\r\n", name, value));
    return TString(value);
@@ -113,7 +117,8 @@ TString THttpCallArg::CountHeader(const TString &buf, Int_t number) const
    while (curr < buf.Length() - 2) {
 
       Int_t next = buf.Index("\r\n", curr);
-      if (next == kNPOS) break; // should never happen
+      if (next == kNPOS)
+         break; // should never happen
 
       if (cnt == number) {
          // we should extract name of header
@@ -127,7 +132,8 @@ TString THttpCallArg::CountHeader(const TString &buf, Int_t number) const
    }
 
    // return total number of headers
-   if (number == -1111) return TString::Format("%d", cnt);
+   if (number == -1111)
+      return TString::Format("%d", cnt);
    return TString();
 }
 
@@ -139,14 +145,24 @@ TString THttpCallArg::CountHeader(const TString &buf, Int_t number) const
 
 void THttpCallArg::SetPostData(void *data, Long_t length, Bool_t make_copy)
 {
-   if (fPostData) free(fPostData);
+   if (fPostData) {
+      free(fPostData);
+      fPostData = 0;
+      fPostDataLength = 0;
+   }
+
+   if (length <= 0)
+      return;
+
    if (make_copy && data && length) {
       void *newdata = malloc(length + 1);
       memcpy(newdata, data, length);
       data = newdata;
    }
 
-   if (data != 0) *(((char *)data) + length) = 0;
+   if (data != 0)
+      *(((char *)data) + length) = 0;
+
    fPostData = data;
    fPostDataLength = length;
 }
@@ -156,7 +172,8 @@ void THttpCallArg::SetPostData(void *data, Long_t length, Bool_t make_copy)
 
 void THttpCallArg::SetWSHandle(TNamed *handle)
 {
-   if (fWSHandle) delete fWSHandle;
+   if (fWSHandle)
+      delete fWSHandle;
    fWSHandle = handle;
 }
 
@@ -176,7 +193,8 @@ TNamed *THttpCallArg::TakeWSHandle()
 
 void THttpCallArg::SetBinData(void *data, Long_t length)
 {
-   if (fBinData) free(fBinData);
+   if (fBinData)
+      free(fBinData);
    fBinData = data;
    fBinDataLength = length;
 
@@ -195,7 +213,8 @@ void THttpCallArg::SetPathAndFileName(const char *fullpath)
    fPathName.Clear();
    fFileName.Clear();
 
-   if (fullpath == 0) return;
+   if (fullpath == 0)
+      return;
 
    const char *rslash = strrchr(fullpath, '/');
    if (rslash == 0) {
@@ -203,7 +222,8 @@ void THttpCallArg::SetPathAndFileName(const char *fullpath)
    } else {
       while ((fullpath != rslash) && (*fullpath == '/')) fullpath++;
       fPathName.Append(fullpath, rslash - fullpath);
-      if (fPathName == "/") fPathName.Clear();
+      if (fPathName == "/")
+         fPathName.Clear();
       fFileName = rslash + 1;
    }
 }
@@ -213,10 +233,13 @@ void THttpCallArg::SetPathAndFileName(const char *fullpath)
 
 TString THttpCallArg::GetHeader(const char *name)
 {
-   if ((name == 0) || (*name == 0)) return TString();
+   if ((name == 0) || (*name == 0))
+      return TString();
 
-   if (strcmp(name, "Content-Type") == 0) return fContentType;
-   if (strcmp(name, "Content-Length") == 0) return TString::Format("%ld", GetContentLength());
+   if (strcmp(name, "Content-Type") == 0)
+      return fContentType;
+   if (strcmp(name, "Content-Length") == 0)
+      return TString::Format("%ld", GetContentLength());
 
    return AccessHeader(fHeader, name);
 }
@@ -228,7 +251,8 @@ TString THttpCallArg::GetHeader(const char *name)
 
 void THttpCallArg::AddHeader(const char *name, const char *value)
 {
-   if ((name == 0) || (*name == 0) || (strcmp(name, "Content-Length") == 0)) return;
+   if ((name == 0) || (*name == 0) || (strcmp(name, "Content-Length") == 0))
+      return;
 
    if (strcmp(name, "Content-Type") == 0)
       SetContentType(value);
@@ -241,7 +265,8 @@ void THttpCallArg::AddHeader(const char *name, const char *value)
 
 void THttpCallArg::FillHttpHeader(TString &hdr, const char *kind)
 {
-   if (kind == 0) kind = "HTTP/1.1";
+   if (kind == 0)
+      kind = "HTTP/1.1";
 
    if ((fContentType.Length() == 0) || Is404()) {
       hdr.Form("%s 404 Not Found\r\n"
@@ -271,7 +296,8 @@ Bool_t THttpCallArg::CompressWithGzip()
 
    // 10 bytes (ZIP header), compressed data, 8 bytes (CRC and original length)
    Int_t buflen = 10 + objlen + 8;
-   if (buflen < 512) buflen = 512;
+   if (buflen < 512)
+      buflen = 512;
 
    void *buffer = malloc(buflen);
 

--- a/tutorials/v7/draw_v6.cxx
+++ b/tutorials/v7/draw_v6.cxx
@@ -57,4 +57,8 @@ void draw_v6()
    // this function executed in synchronous mode (async = false is default),
    // mean previous file saving will be completed as well at this point
    canvas->SaveAs("draw.svg"); // asynchronous
+
+   // hide canvas after 10 seconds - close all connections and close all opened windows
+   // gSystem->Sleep(10000);
+   // canvas->Hide();
 }

--- a/tutorials/v7/draw_v6.cxx
+++ b/tutorials/v7/draw_v6.cxx
@@ -37,26 +37,27 @@ void draw_v6()
 
    canvas->Show(); // new window should popup and async update will be triggered
 
-   // canvas->Show("/usr/bin/opera");  // one could specify program name which should show canvas
-   // canvas->Show("firefox");         // it could be firefox, opera, chromium; canvas can be shown several times
+   // canvas->Show("opera");   // one could specify program name which should show canvas (like chromium or firefox)
+   // canvas->Show("/usr/bin/chromium --app=$url &"); // one could use $url parameter, which replaced with canvas URL
 
    // synchronous, wait until painting is finished
    canvas->Update(false,
                   [](bool res) { std::cout << "First Update done = " << (res ? "true" : "false") << std::endl; });
 
-   // call again, should return immediately
+   // canvas->Modified(); // when uncommented, invalidate canvas and force repainting with next Update()
+
+   // call Update again, should return immediately if canvas was not modified
    canvas->Update(false,
                   [](bool res) { std::cout << "Second Update done = " << (res ? "true" : "false") << std::endl; });
 
    // request to create PNG file in asynchronous mode and specify lambda function as callback
-   // when request processed by the client, callback called with result value
-   canvas->SaveAs("draw.png", true, [](bool res) {
-      std::cout << "Producing PNG done res = " << (res ? "true" : "false") << std::endl;
-   }); // asynchronous
+   // when request processed by the client, callback invoked with result value
+   canvas->SaveAs("draw.png", true,
+                  [](bool res) { std::cout << "Producing PNG done res = " << (res ? "true" : "false") << std::endl; });
 
    // this function executed in synchronous mode (async = false is default),
    // mean previous file saving will be completed as well at this point
-   canvas->SaveAs("draw.svg"); // asynchronous
+   canvas->SaveAs("draw.svg"); // synchronous
 
    // hide canvas after 10 seconds - close all connections and close all opened windows
    // gSystem->Sleep(10000);


### PR DESCRIPTION
1. Implement Canvas::Hide(). It send "CLOSE" command to all connected clients. 
Normally this causes closing of browser window. Works with CEF, Qt5 and web browsers

2. Handle correctly situation when user closes canvas window himself. At this moment JS client sends websocket::close() command to the server, that CanvasPainter can correctly cleanup connection. 
Requires special handling with Qt5WebView widget, which typically closed too fast by Qt. 

3. Small bug fix with civetweb websocket handler - sometime it calls handler with empty data. Such calls should be just ignored.