### PR TITLE
Fix missing SOURCES in treeplayer CMakeLists.txt

### DIFF
--- a/tree/treeplayer/CMakeLists.txt
+++ b/tree/treeplayer/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 
 ROOT_STANDARD_LIBRARY_PACKAGE(TreePlayer
                               HEADERS ${dictHeaders}
+                              SOURCES ${sources}
                               DICTIONARY_OPTIONS "-writeEmptyRootPCM"
                               LIBRARIES ${TBB_LIBRARIES}
                               DEPENDENCIES Tree Graf3d Graf Hist Gpad RIO MathCore MultiProc Imt)


### PR DESCRIPTION
The code before the refatoring parssed the ${sources} to the
dictionary linking, but we forgot to handle this during the
refactoring.