### PR TITLE
Disable 'from ROOT import *' in python3 (ROOT-8931)

### DIFF
--- a/bindings/pyroot/ROOT.py
+++ b/bindings/pyroot/ROOT.py
@@ -427,7 +427,7 @@ class ModuleFacade( types.ModuleType ):
    def __getattr2( self, name ):             # "running" getattr
     # handle "from ROOT import *" ... can be called multiple times
       if name == '__all__':
-         if sys.hexversion >= 0x3060000:
+         if sys.hexversion >= 0x3000000:
             raise ImportError('"from ROOT import *" is not supported in Python 3')
          if _is_ipython:
             import warnings

--- a/bindings/pyroot/ROOT.py
+++ b/bindings/pyroot/ROOT.py
@@ -427,6 +427,8 @@ class ModuleFacade( types.ModuleType ):
    def __getattr2( self, name ):             # "running" getattr
     # handle "from ROOT import *" ... can be called multiple times
       if name == '__all__':
+         if sys.hexversion >= 0x3060000:
+            raise ImportError('"from ROOT import *" is not supported in Python 3')
          if _is_ipython:
             import warnings
             warnings.warn( '"from ROOT import *" is not supported under IPython' )


### PR DESCRIPTION
`from ROOT import *` leads to a segmentation violation when used with Python 3.6.

One could try fixing it instead of disabling it but the code which is used to install the lookup handler in the module `RootModule::SetRootLazyLookup` depends on internal CPython implementation details of the dict class which are not part of the public API. As a consequence keeping this alive will lead to very
fragile code, require continuous effort to adapt to internal changes and cause a lot of #ifdef handling. (as a matter of fact, Python 3.7 would probably already require new changes to this code already). 

Also there's a statement in the bug report that `from ROOT import *`  is broken in Python 3 so I don't understand why it's not disabled as it will only confuse users: https://sft.its.cern.ch/jira/browse/ROOT-8931

As such I would propose to instead have a clear error message that `from ROOT import *` does not work. This pr adds an `ImportError` which is easy to handle but cannot be just ignored by the user.