### PR TITLE
Several improvements and bugfixes for TF1

### DIFF
--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -264,12 +264,6 @@ protected:
       DoInitialize(addToGlobList);
    };
 
-   template<class Func>
-   EFType templScalarOrVectorized(Func &)
-   {
-      using Fnc_t = typename ROOT::Internal::GetFunctorType<decltype(ROOT::Internal::GetTheRightOp(&Func::operator()))>::type;
-      return std::is_same<Fnc_t, double>::value? TF1::EFType::kTemplScalar : TF1::EFType::kTemplVec;
-   }
 
 public:
 
@@ -315,8 +309,11 @@ public:
 
    template <class T>
    TF1(const char *name, std::function<T(const T *data, const Double_t *param)> &fcn, Double_t xmin = 0, Double_t xmax = 1, Int_t npar = 0, Int_t ndim = 1, EAddToList addToGlobList = EAddToList::kDefault):
-      TF1(templScalarOrVectorized(fcn), name, xmin, xmax, npar, ndim, addToGlobList, new TF1Parameters(npar), new TF1FunctorPointerImpl<T>(fcn))
-   {}
+      TF1(EFType::kTemplScalar, name, xmin, xmax, npar, ndim, addToGlobList, new TF1Parameters(npar), new TF1FunctorPointerImpl<T>(fcn))
+   {
+      using Fnc_t = typename ROOT::Internal::GetFunctorType<decltype(fcn)>::type;
+      fType = std::is_same<Fnc_t, double>::value? TF1::EFType::kTemplScalar : TF1::EFType::kTemplVec;
+   }
 
    ////////////////////////////////////////////////////////////////////////////////
    /// Constructor using a pointer to function.
@@ -332,7 +329,7 @@ public:
 
    template <class T>
    TF1(const char *name, T(*fcn)(const T *, const Double_t *), Double_t xmin = 0, Double_t xmax = 1, Int_t npar = 0, Int_t ndim = 1, EAddToList addToGlobList = EAddToList::kDefault):
-      TF1(templScalarOrVectorized(fcn), name, xmin, xmax, npar, ndim, addToGlobList, new TF1Parameters(npar), new TF1FunctorPointerImpl<T>(fcn))
+      TF1(EFType::kTemplVec, name, xmin, xmax, npar, ndim, addToGlobList, new TF1Parameters(npar), new TF1FunctorPointerImpl<T>(fcn))
    {}
 
    // Constructors using functors (compiled mode only)
@@ -358,9 +355,10 @@ public:
 
    template <typename Func>
    TF1(const char *name, Func f, Double_t xmin, Double_t xmax, Int_t npar, const char *, EAddToList addToGlobList = EAddToList::kDefault) :
-      TF1(templScalarOrVectorized(f), name, xmin, xmax, npar, 1, addToGlobList, new TF1Parameters(npar))
+      TF1(EFType::kTemplScalar, name, xmin, xmax, npar, 1, addToGlobList, new TF1Parameters(npar))
    {
       using Fnc_t = typename ROOT::Internal::GetFunctorType<decltype(ROOT::Internal::GetTheRightOp(&Func::operator()))>::type;
+      fType = std::is_same<Fnc_t, double>::value? TF1::EFType::kTemplScalar : TF1::EFType::kTemplVec;
       fFunctor = new TF1FunctorPointerImpl<Fnc_t>(ROOT::Math::ParamFunctorTempl<Fnc_t>(f));
    }
 

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -745,12 +745,15 @@ inline T TF1::EvalParVec(const T *data, const Double_t *params)
 inline double TF1::EvalParVec(const Double_t *data, const Double_t *params)
 {
    assert(fType == EFType::kTemplated);
-   ROOT::Double_v d, res;
+   std::vector<ROOT::Double_v> d(fNdim);
+   ROOT::Double_v res;
 
-   d = *data;
+   for(auto i=0; i<fNdim; i++) {
+      d[i] = ROOT::Double_v(data[i]);
+   }
 
    if (fFunctor) {
-      res = ((TF1FunctorPointerImpl<ROOT::Double_v> *)fFunctor)->fImpl(&d, params);
+      res = ((TF1FunctorPointerImpl<ROOT::Double_v> *) fFunctor)->fImpl(d.data(), params);
    } else {
       //    res = GetSave(x);
       return TMath::SignalingNaN();

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -411,10 +411,6 @@ public:
    virtual Double_t Eval(Double_t x, Double_t y = 0, Double_t z = 0, Double_t t = 0) const;
    virtual Double_t EvalPar(const Double_t *x, const Double_t *params = 0);
    template <class T> T EvalPar(const T *x, const Double_t *params = 0);
-   template <class T> T EvalParTempl(const T *data, const Double_t *params = 0);
-#ifdef R__HAS_VECCORE
-   inline double EvalParVec(const Double_t *data, const Double_t *params);
-#endif
    virtual Double_t operator()(Double_t x, Double_t y = 0, Double_t z = 0, Double_t t = 0) const;
    virtual Double_t operator()(const Double_t *x, const Double_t *params = 0);
    template <class T> T operator()(const T *data, const Double_t *params);
@@ -670,6 +666,12 @@ public:
    static  void     CalcGaussLegendreSamplingPoints(Int_t num, Double_t *x, Double_t *w, Double_t eps = 3.0e-11);
 
    ClassDef(TF1, 9) //The Parametric 1-D function
+
+private:
+   template <class T> T EvalParTempl(const T *data, const Double_t *params = 0);
+#ifdef R__HAS_VECCORE
+   inline double EvalParVec(const Double_t *data, const Double_t *params);
+#endif
 };
 
 namespace ROOT {

--- a/hist/hist/src/HFitImpl.cxx
+++ b/hist/hist/src/HFitImpl.cxx
@@ -236,7 +236,7 @@ TFitResultPtr HFit::Fit(FitObject * h1, TF1 *f1 , Foption_t & fitOption , const 
    if ( (linear || fitOption.Gradient) )
       fitter->SetFunction(ROOT::Math::WrappedMultiTF1(*f1));
 #ifdef R__HAS_VECCORE      
-   else if(f1->IsTemplated())
+   else if(f1->IsVectorized())
       fitter->SetFunction(static_cast<const ROOT::Math::IParamMultiFunctionTempl<ROOT::Double_v> &>(ROOT::Math::WrappedMultiTF1Templ<ROOT::Double_v>(*f1)));
 #endif
    else

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -1110,11 +1110,11 @@ void TF1::DrawF1(Double_t xmin, Double_t xmax, Option_t *option)
 
 Double_t TF1::Eval(Double_t x, Double_t y, Double_t z, Double_t t) const
 {
-   if (fType == 0) return fFormula->Eval(x, y, z, t);
+   if (fType == EFType::kFormula) return fFormula->Eval(x, y, z, t);
 
    Double_t xx[4] = {x, y, z, t};
    Double_t *pp = (Double_t *)fParams->GetParameters();
-   if (fType == 2)((TF1 *)this)->InitArgs(xx, pp);
+   if (fType == EFType::KInterpreted)((TF1 *)this)->InitArgs(xx, pp);
    return ((TF1 *)this)->EvalPar(xx, pp);
 }
 
@@ -1141,7 +1141,7 @@ Double_t TF1::EvalPar(const Double_t *x, const Double_t *params)
 {
    //fgCurrent = this;
 
-   if (fType == 0) {
+   if (fType == EFType::kFormula) {
       assert(fFormula);
 
       if (fNormalized && fNormIntegral != 0)
@@ -1150,7 +1150,7 @@ Double_t TF1::EvalPar(const Double_t *x, const Double_t *params)
          return fFormula->EvalPar(x, params);
    }
    Double_t result = 0;
-   if (fType == 1)  {
+   if (fType == EFType::kPtrScalarFreeFcn)  {
       if (fFunctor) {
          assert(fParams);
          if (params) result = ((TF1FunctorPointerImpl<Double_t> *)fFunctor)->fImpl((Double_t *)x, (Double_t *)params);
@@ -1163,7 +1163,7 @@ Double_t TF1::EvalPar(const Double_t *x, const Double_t *params)
 
       return result;
    }
-   if (fType == 2) {
+   if (fType == EFType::KInterpreted) {
       if (fMethodCall) fMethodCall->Execute(result);
       else             result = GetSave(x);
 
@@ -1173,7 +1173,7 @@ Double_t TF1::EvalPar(const Double_t *x, const Double_t *params)
       return result;
    }
 
-   if (fType == 3) {
+   if (fType == EFType::kTemplated) {
       if (fFunctor) {
          if (params) result =  EvalParVec(x, params);
          else result =  EvalParVec(x, (Double_t *) fParams->GetParameters());
@@ -2594,12 +2594,12 @@ Bool_t TF1::IsValid() const
 
 void TF1::Print(Option_t *option) const
 {
-   if (fType == 0) {
+   if (fType == EFType::kFormula) {
       printf("Formula based function:     %s \n", GetName());
       assert(fFormula);
       fFormula->Print(option);
    } else if (fType >  0) {
-      if (fType == 2)
+      if (fType == EFType::kFormula)
          printf("Interpreted based function: %s(double *x, double *p).  Ndim = %d, Npar = %d  \n", GetName(), GetNpar(), GetNdim());
       else {
          if (fFunctor)

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -1114,7 +1114,7 @@ Double_t TF1::Eval(Double_t x, Double_t y, Double_t z, Double_t t) const
 
    Double_t xx[4] = {x, y, z, t};
    Double_t *pp = (Double_t *)fParams->GetParameters();
-   if (fType == EFType::KInterpreted)((TF1 *)this)->InitArgs(xx, pp);
+   if (fType == EFType::kInterpreted)((TF1 *)this)->InitArgs(xx, pp);
    return ((TF1 *)this)->EvalPar(xx, pp);
 }
 
@@ -1150,7 +1150,7 @@ Double_t TF1::EvalPar(const Double_t *x, const Double_t *params)
          return fFormula->EvalPar(x, params);
    }
    Double_t result = 0;
-   if (fType == EFType::kPtrScalarFreeFcn)  {
+   if (fType == EFType::kPtrScalarFreeFcn || fType == EFType::kTemplScalar)  {
       if (fFunctor) {
          assert(fParams);
          if (params) result = ((TF1FunctorPointerImpl<Double_t> *)fFunctor)->fImpl((Double_t *)x, (Double_t *)params);
@@ -1163,7 +1163,7 @@ Double_t TF1::EvalPar(const Double_t *x, const Double_t *params)
 
       return result;
    }
-   if (fType == EFType::KInterpreted) {
+   if (fType == EFType::kInterpreted) {
       if (fMethodCall) fMethodCall->Execute(result);
       else             result = GetSave(x);
 
@@ -1173,7 +1173,7 @@ Double_t TF1::EvalPar(const Double_t *x, const Double_t *params)
       return result;
    }
 
-   if (fType == EFType::kTemplated) {
+   if (fType == EFType::kTemplVec) {
       if (fFunctor) {
          if (params) result =  EvalParVec(x, params);
          else result =  EvalParVec(x, (Double_t *) fParams->GetParameters());

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -1173,6 +1173,7 @@ Double_t TF1::EvalPar(const Double_t *x, const Double_t *params)
       return result;
    }
 
+#ifdef R__HAS_VECCORE
    if (fType == EFType::kTemplVec) {
       if (fFunctor) {
          if (params) result =  EvalParVec(x, params);
@@ -1187,6 +1188,7 @@ Double_t TF1::EvalPar(const Double_t *x, const Double_t *params)
 
       return result; 
    }
+#endif
    return result;
 }
 


### PR DESCRIPTION
This patch allows to tell vectorized from scalar evaluations and will fix the multidimensional scalar evaluation of a vectorized TF1 on non-SIMD data.