### PR TITLE
[IMT] Let TTreeView support interleaved TBB task execution

### DIFF
--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -58,7 +58,7 @@ namespace ROOT {
          std::string fTreeName;               ///< Name of the tree
          std::unique_ptr<TFile> fCurrentFile; ///<! Current file object of this view.
          TTree *fCurrentTree;                 ///<! Current tree object of this view.
-         unsigned int fCurrentIdx;            ///<! Index of the current file.
+         std::size_t fCurrentIdx;             ///<! Index of the current file.
          std::vector<TEntryList> fEntryLists; ///< Entry numbers to be processed per tree/file
          TEntryList fCurrentEntryList;        ///< Entry numbers for the current range being processed
 
@@ -161,7 +161,7 @@ namespace ROOT {
             if (clRefTChain == tree.IsA()) {
                // We need to convert the global entry numbers to per-tree entry numbers.
                // This will allow us to build a TEntryList for a given entry range of a tree of the chain.
-               size_t nTrees = fFileNames.size();
+               std::size_t nTrees = fFileNames.size();
                fEntryLists.resize(nTrees);
 
                TChain *chain = dynamic_cast<TChain*>(&tree);

--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -45,6 +45,13 @@ the threaded object.
 
 namespace ROOT {
    namespace Internal {
+
+      struct TreeViewCluster {
+         Long64_t startEntry;
+         Long64_t endEntry;
+         std::size_t filenameIdx;
+      };
+
       class TTreeView {
       private:
          std::vector<std::string> fFileNames; ///< Names of the files
@@ -273,6 +280,7 @@ namespace ROOT {
    private:
       ROOT::TThreadedObject<ROOT::Internal::TTreeView> treeView; ///<! Threaded object with <file,tree> per thread
 
+      std::vector<ROOT::Internal::TreeViewCluster> MakeClusters();
    public:
       TTreeProcessorMT(std::string_view filename, std::string_view treename = "");
       TTreeProcessorMT(const std::vector<std::string_view>& filenames, std::string_view treename = "");

--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -203,14 +203,6 @@ namespace ROOT {
          }
 
          //////////////////////////////////////////////////////////////////////////
-         /// Get the cluster iterator for the current tree of this view, starting
-         /// from entry zero.
-         TTree::TClusterIterator GetClusterIterator()
-         {
-            return fCurrentTree->GetClusterIterator(0);
-         }
-
-         //////////////////////////////////////////////////////////////////////////
          /// Get a TTreeReader for the current tree of this view.
          std::unique_ptr<TTreeReader> GetTreeReader(Long64_t start, Long64_t end)
          {
@@ -246,10 +238,17 @@ namespace ROOT {
          }
 
          //////////////////////////////////////////////////////////////////////////
-         /// Get the number of files of this view.
-         size_t GetNumFiles() const
+         /// Get the filenames for this view.
+         const std::vector<std::string> &GetFileNames() const
          {
-            return fFileNames.size();
+            return fFileNames;
+         }
+
+         //////////////////////////////////////////////////////////////////////////
+         /// Get the name of the tree of this view.
+         std::string GetTreeName() const
+         {
+            return fTreeName;
          }
 
          //////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -64,7 +64,7 @@ std::vector<ROOT::Internal::TreeViewCluster> TTreeProcessorMT::MakeClusters()
    const auto &fileNames = treeView->GetFileNames();
    const auto nFileNames = fileNames.size();
    const auto &treeName = treeView->GetTreeName();
-   for (auto i = 0u; i < nFileNames; ++i) {
+   for (auto i = 0u; i < nFileNames; ++i) { // TTreeViewCluster requires the index of the file the cluster belongs to
       std::unique_ptr<TFile> f(TFile::Open(fileNames[i].c_str())); // need TFile::Open to load plugins if need be
       TTree *t = nullptr;                                          // not a leak, t will be deleted by f
       f->GetObject(treeName.c_str(), t);

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -58,14 +58,15 @@ TTreeProcessorMT::TTreeProcessorMT(TTree &tree, TEntryList &entries) : treeView(
 
 ////////////////////////////////////////////////////////////////////////
 /// Divide input data in clusters, i.e. the workloads to distribute to tasks
-std::vector<ROOT::Internal::TreeViewCluster> TTreeProcessorMT::MakeClusters() {
+std::vector<ROOT::Internal::TreeViewCluster> TTreeProcessorMT::MakeClusters()
+{
    std::vector<ROOT::Internal::TreeViewCluster> clusters;
    const auto &fileNames = treeView->GetFileNames();
    const auto nFileNames = fileNames.size();
    const auto &treeName = treeView->GetTreeName();
    for (auto i = 0u; i < nFileNames; ++i) {
       std::unique_ptr<TFile> f(TFile::Open(fileNames[i].c_str())); // need TFile::Open to load plugins if need be
-      TTree *t = nullptr; // not a leak, t will be deleted by f
+      TTree *t = nullptr;                                          // not a leak, t will be deleted by f
       f->GetObject(treeName.c_str(), t);
       auto clusterIter = t->GetClusterIterator(0);
       Long64_t start = 0, end = 0;


### PR DESCRIPTION
When processing a TTree with TTreeProcessorMT, each thread creates and uses its own TTreeView (by using a TThreadedObject<TTreeView>). 

Until now, in the case of interleaved execution of tasks, the second task could overwrite the first's TFile and TTree, causing crashes when the first task resumed execution.

This PR modifies TTreeView so that it supports several tasks opening and using different TFiles at the same time, solving the issue described above.