### PR TITLE
Fix that rootcling always succeeds.

### DIFF
--- a/core/clingutils/res/TClingUtils.h
+++ b/core/clingutils/res/TClingUtils.h
@@ -107,7 +107,6 @@ typedef void (*CallWriteStreamer_t)(const AnnotatedRecordDecl &cl,
 
 const int kInfo            =      0;
 const int kNote            =    500;
-const int kThrowOnWarning  =    999;
 const int kWarning         =   1000;
 const int kError           =   2000;
 const int kSysError        =   3000;
@@ -694,12 +693,22 @@ void ReplaceAll(std::string& str, const std::string& from, const std::string& to
 // Functions for the printouts -------------------------------------------------
 
 //______________________________________________________________________________
-inline unsigned int &GetNumberOfWarningsAndErrors(){
-   static unsigned  int gNumberOfWarningsAndErrors = 0;
-   return gNumberOfWarningsAndErrors;
+inline unsigned int &GetNumberOfErrors()
+{
+   static unsigned int gNumberOfErrors = 0;
+   return gNumberOfErrors;
 }
 
 //______________________________________________________________________________
+// True if printing a warning should increase GetNumberOfErrors
+inline bool &GetWarningsAreErrors()
+{
+   static bool gWarningsAreErrors = false;
+   return gWarningsAreErrors;
+}
+
+//______________________________________________________________________________
+// Inclusive minimum error level a message needs to get handled
 inline int &GetErrorIgnoreLevel() {
    static int gErrorIgnoreLevel = ROOT::TMetaUtils::kError;
    return gErrorIgnoreLevel;
@@ -717,7 +726,7 @@ inline void LevelPrint(bool prefix, int level, const char *location, const char 
       type = "Info";
    if (level >= ROOT::TMetaUtils::kNote)
       type = "Note";
-   if (level >= ROOT::TMetaUtils::kThrowOnWarning)
+   if (level >= ROOT::TMetaUtils::kWarning)
       type = "Warning";
    if (level >= ROOT::TMetaUtils::kError)
       type = "Error";
@@ -737,11 +746,10 @@ inline void LevelPrint(bool prefix, int level, const char *location, const char 
 
    fflush(stderr);
 
-   if (GetErrorIgnoreLevel() == ROOT::TMetaUtils::kThrowOnWarning ||
-      GetErrorIgnoreLevel() > ROOT::TMetaUtils::kError){
-      ++GetNumberOfWarningsAndErrors();
-      }
-
+   // Keep track of the warnings/errors we printed.
+   if (level >= ROOT::TMetaUtils::kError || (level == ROOT::TMetaUtils::kWarning && GetWarningsAreErrors())) {
+      ++GetNumberOfErrors();
+   }
 }
 
 //______________________________________________________________________________

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -4152,8 +4152,13 @@ int RootClingMain(int argc,
          }
 
          if (strcmp("-failOnWarnings", argv[ic]) == 0) {
+            using namespace ROOT::TMetaUtils;
             // Fail on Warnings and Errors
-            ROOT::TMetaUtils::GetErrorIgnoreLevel() = ROOT::TMetaUtils::kThrowOnWarning;
+            // If warnings are disabled with the current verbosity settings, lower
+            // it so that the user sees the warning that caused the failure.
+            if (GetErrorIgnoreLevel() > kWarning)
+               GetErrorIgnoreLevel() = kWarning;
+            GetWarningsAreErrors() = true;
             ic += 1;
             continue;
          }
@@ -6011,7 +6016,7 @@ int ROOT_rootcling_Driver(int argc, char **argv, const ROOT::Internal::RootCling
 
    gDriverConfig = nullptr;
 
-   auto nerrors = ROOT::TMetaUtils::GetNumberOfWarningsAndErrors();
+   auto nerrors = ROOT::TMetaUtils::GetNumberOfErrors();
    if (nerrors > 0){
       ROOT::TMetaUtils::Info(0,"Problems have been detected during the generation of the dictionary.\n");
       return 1;


### PR DESCRIPTION
Since we enabled warnings by default in rootcling, which pointed
out a bunch of warnings in the code base, we also set rootcling
into a mode in which it is unable to ever fail.

The reason for this is this faulty if statement. If we enable warnings,
we set the errorIgnoreLevel to kWarning. But this if statement only records
any errors if the errorIgnoreLevel is NOT kWarning (which is between
kThrowOnWarning and kError).

The new if statements only checks if the the printed message is an error
or higher (which would include any kind of fatal error). If the errorIgnoreLevel
is set higher, we already correctly filter this at the start of the method
where we return on filtered messages.