### PR TITLE
Fix for bug introduced in PR 779

### DIFF
--- a/tmva/tmva/inc/TMVA/DNN/DataLoader.h
+++ b/tmva/tmva/inc/TMVA/DNN/DataLoader.h
@@ -35,7 +35,7 @@ namespace DNN  {
 // Input Data Types
 //______________________________________________________________________________
 using MatrixInput_t = std::tuple<const TMatrixT<Double_t> &, const TMatrixT<Double_t> &, const TMatrixT<Double_t> &>;
-using TMVAInput_t = std::tuple<std::vector<Event *>, DataSetInfo &>;
+using TMVAInput_t = std::tuple<const std::vector<Event *> &, const DataSetInfo &>;
 
 using IndexIterator_t = typename std::vector<size_t>::iterator;
 
@@ -132,7 +132,7 @@ private:
    using Matrix_t        = typename AArchitecture::Matrix_t;
    using BatchIterator_t = TBatchIterator<Data_t, AArchitecture>;
 
-   const Data_t  & fData;
+   const Data_t &fData;
 
    size_t fNSamples;
    size_t fBatchSize;

--- a/tmva/tmva/inc/TMVA/DNN/DataLoader.h
+++ b/tmva/tmva/inc/TMVA/DNN/DataLoader.h
@@ -35,7 +35,8 @@ namespace DNN  {
 // Input Data Types
 //______________________________________________________________________________
 using MatrixInput_t = std::tuple<const TMatrixT<Double_t> &, const TMatrixT<Double_t> &, const TMatrixT<Double_t> &>;
-using TMVAInput_t = std::tuple<const std::vector<Event *> &, const DataSetInfo &>;
+using TMVAInput_t =
+    std::tuple<const std::vector<Event *> &, const DataSetInfo &>;
 
 using IndexIterator_t = typename std::vector<size_t>::iterator;
 

--- a/tmva/tmva/src/DNN/Architectures/Cpu/CpuBuffer.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Cpu/CpuBuffer.cxx
@@ -198,7 +198,7 @@ void TDataLoader<TMVAInput_t, TCpu<Double_t>>::CopyOutput(
     IndexIterator_t sampleIterator,
     size_t batchSize)
 {
-   DataSetInfo &info = std::get<1>(fData);
+   const DataSetInfo &info = std::get<1>(fData);
    size_t n = buffer.GetSize() / batchSize;
 
    // Copy target(s).
@@ -264,7 +264,7 @@ void TDataLoader<TMVAInput_t, TCpu<Real_t>>::CopyOutput(
     IndexIterator_t sampleIterator,
     size_t batchSize)
 {
-   DataSetInfo &info = std::get<1>(fData);
+   const DataSetInfo &info = std::get<1>(fData);
    size_t n       = buffer.GetSize() / batchSize;
 
    // Copy target(s).

--- a/tmva/tmva/src/DNN/Architectures/Cpu/CpuBuffer.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Cpu/CpuBuffer.cxx
@@ -198,33 +198,33 @@ void TDataLoader<TMVAInput_t, TCpu<Double_t>>::CopyOutput(
     IndexIterator_t sampleIterator,
     size_t batchSize)
 {
-   const DataSetInfo &info = std::get<1>(fData);
-   size_t n = buffer.GetSize() / batchSize;
+  const DataSetInfo &info = std::get<1>(fData);
+  size_t n = buffer.GetSize() / batchSize;
 
-   // Copy target(s).
+  // Copy target(s).
 
-   for (size_t i = 0; i < batchSize; i++) {
-      size_t sampleIndex = * sampleIterator++;
-      Event *event = std::get<0>(fData)[sampleIndex];
-      for (size_t j = 0; j < n; j++) {
-         // Copy output matrices.
-         size_t bufferIndex = j * batchSize + i;
-         // Classification
-         if (event->GetNTargets() == 0) {
-            if (n == 1) {
-               // Binary.
-               buffer[bufferIndex] = (info.IsSignal(event)) ? 1.0 : 0.0;
-            } else {
-               // Multiclass.
-               buffer[bufferIndex] = 0.0;
-               if (j == event->GetClass()) {
-                  buffer[bufferIndex] = 1.0;
-               }
-            }
-         } else {
-            buffer[bufferIndex] = static_cast<Real_t>(event->GetTarget(j));
-         }
+  for (size_t i = 0; i < batchSize; i++) {
+    size_t sampleIndex = *sampleIterator++;
+    Event *event = std::get<0>(fData)[sampleIndex];
+    for (size_t j = 0; j < n; j++) {
+      // Copy output matrices.
+      size_t bufferIndex = j * batchSize + i;
+      // Classification
+      if (event->GetNTargets() == 0) {
+        if (n == 1) {
+          // Binary.
+          buffer[bufferIndex] = (info.IsSignal(event)) ? 1.0 : 0.0;
+        } else {
+          // Multiclass.
+          buffer[bufferIndex] = 0.0;
+          if (j == event->GetClass()) {
+            buffer[bufferIndex] = 1.0;
+          }
+        }
+      } else {
+        buffer[bufferIndex] = static_cast<Real_t>(event->GetTarget(j));
       }
+    }
    }
 }
 
@@ -264,33 +264,33 @@ void TDataLoader<TMVAInput_t, TCpu<Real_t>>::CopyOutput(
     IndexIterator_t sampleIterator,
     size_t batchSize)
 {
-   const DataSetInfo &info = std::get<1>(fData);
-   size_t n       = buffer.GetSize() / batchSize;
+  const DataSetInfo &info = std::get<1>(fData);
+  size_t n = buffer.GetSize() / batchSize;
 
-   // Copy target(s).
+  // Copy target(s).
 
-   for (size_t i = 0; i < batchSize; i++) {
-      size_t sampleIndex = * sampleIterator++;
-      Event *event = std::get<0>(fData)[sampleIndex];
-      for (size_t j = 0; j < n; j++) {
-         // Copy output matrices.
-         size_t bufferIndex = j * batchSize + i;
-         // Classification
-         if (event->GetNTargets() == 0) {
-            if (n == 1) {
-               // Binary.
-               buffer[bufferIndex] = (info.IsSignal(event)) ? 1.0 : 0.0;
-            } else {
-               // Multiclass.
-               buffer[bufferIndex] = 0.0;
-               if (j == event->GetClass()) {
-                  buffer[bufferIndex] = 1.0;
-               }
-            }
-         } else {
-            buffer[bufferIndex] = static_cast<Real_t>(event->GetTarget(j));
-         }
+  for (size_t i = 0; i < batchSize; i++) {
+    size_t sampleIndex = *sampleIterator++;
+    Event *event = std::get<0>(fData)[sampleIndex];
+    for (size_t j = 0; j < n; j++) {
+      // Copy output matrices.
+      size_t bufferIndex = j * batchSize + i;
+      // Classification
+      if (event->GetNTargets() == 0) {
+        if (n == 1) {
+          // Binary.
+          buffer[bufferIndex] = (info.IsSignal(event)) ? 1.0 : 0.0;
+        } else {
+          // Multiclass.
+          buffer[bufferIndex] = 0.0;
+          if (j == event->GetClass()) {
+            buffer[bufferIndex] = 1.0;
+          }
+        }
+      } else {
+        buffer[bufferIndex] = static_cast<Real_t>(event->GetTarget(j));
       }
+    }
    }
 }
 

--- a/tmva/tmva/src/DNN/Architectures/Cuda/CudaBuffers.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Cuda/CudaBuffers.cxx
@@ -219,7 +219,7 @@ void TDataLoader<TMVAInput_t, TCuda<float>>::CopyOutput(
     IndexIterator_t sampleIterator,
     size_t batchSize)
 {
-   DataSetInfo &info = std::get<1>(fData);
+   const DataSetInfo &info = std::get<1>(fData);
    size_t n       = buffer.GetSize() / batchSize;
 
    // Copy target(s).
@@ -335,7 +335,7 @@ void TDataLoader<TMVAInput_t, TCuda<double>>::CopyOutput(
     IndexIterator_t sampleIterator,
     size_t batchSize)
 {
-   DataSetInfo &info = std::get<1>(fData);
+   const DataSetInfo &info = std::get<1>(fData);
    size_t n       = buffer.GetSize() / batchSize;
 
    // Copy target(s).

--- a/tmva/tmva/src/DNN/Architectures/Cuda/CudaBuffers.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Cuda/CudaBuffers.cxx
@@ -219,33 +219,33 @@ void TDataLoader<TMVAInput_t, TCuda<float>>::CopyOutput(
     IndexIterator_t sampleIterator,
     size_t batchSize)
 {
-   const DataSetInfo &info = std::get<1>(fData);
-   size_t n       = buffer.GetSize() / batchSize;
+  const DataSetInfo &info = std::get<1>(fData);
+  size_t n = buffer.GetSize() / batchSize;
 
-   // Copy target(s).
+  // Copy target(s).
 
-   for (size_t i = 0; i < batchSize; i++) {
-      size_t sampleIndex = *sampleIterator++;
-      Event *event = std::get<0>(fData)[sampleIndex];
-      for (size_t j = 0; j < n; j++) {
-         // Copy output matrices.
-         size_t bufferIndex = j * batchSize + i;
-         // Classification
-         if (event->GetNTargets() == 0) {
-            if (n == 1) {
-               // Binary.
-               buffer[bufferIndex] = (info.IsSignal(event)) ? 1.0 : 0.0;
-            } else {
-               // Multiclass.
-               buffer[bufferIndex] = 0.0;
-               if (j == event->GetClass()) {
-                  buffer[bufferIndex] = 1.0;
-               }
-            }
-         } else {
-            buffer[bufferIndex] = static_cast<float>(event->GetTarget(j));
-         }
+  for (size_t i = 0; i < batchSize; i++) {
+    size_t sampleIndex = *sampleIterator++;
+    Event *event = std::get<0>(fData)[sampleIndex];
+    for (size_t j = 0; j < n; j++) {
+      // Copy output matrices.
+      size_t bufferIndex = j * batchSize + i;
+      // Classification
+      if (event->GetNTargets() == 0) {
+        if (n == 1) {
+          // Binary.
+          buffer[bufferIndex] = (info.IsSignal(event)) ? 1.0 : 0.0;
+        } else {
+          // Multiclass.
+          buffer[bufferIndex] = 0.0;
+          if (j == event->GetClass()) {
+            buffer[bufferIndex] = 1.0;
+          }
+        }
+      } else {
+        buffer[bufferIndex] = static_cast<float>(event->GetTarget(j));
       }
+    }
    }
 }
 
@@ -335,33 +335,33 @@ void TDataLoader<TMVAInput_t, TCuda<double>>::CopyOutput(
     IndexIterator_t sampleIterator,
     size_t batchSize)
 {
-   const DataSetInfo &info = std::get<1>(fData);
-   size_t n       = buffer.GetSize() / batchSize;
+  const DataSetInfo &info = std::get<1>(fData);
+  size_t n = buffer.GetSize() / batchSize;
 
-   // Copy target(s).
+  // Copy target(s).
 
-   for (size_t i = 0; i < batchSize; i++) {
-      size_t sampleIndex = *sampleIterator++;
-      Event *event = std::get<0>(fData)[sampleIndex];
-      for (size_t j = 0; j < n; j++) {
-         // Copy output matrices.
-         size_t bufferIndex = j * batchSize + i;
-         // Classification
-         if (event->GetNTargets() == 0) {
-               // Binary.
-            if (n == 1) {
-               buffer[bufferIndex] = (info.IsSignal(event)) ? 1.0 : 0.0;
-            } else {
-               // Multiclass.
-               buffer[bufferIndex] = 0.0;
-               if (j == event->GetClass()) {
-                  buffer[bufferIndex] = 1.0;
-               }
-            }
-         } else {
-            buffer[bufferIndex] = event->GetTarget(j);
-         }
+  for (size_t i = 0; i < batchSize; i++) {
+    size_t sampleIndex = *sampleIterator++;
+    Event *event = std::get<0>(fData)[sampleIndex];
+    for (size_t j = 0; j < n; j++) {
+      // Copy output matrices.
+      size_t bufferIndex = j * batchSize + i;
+      // Classification
+      if (event->GetNTargets() == 0) {
+        // Binary.
+        if (n == 1) {
+          buffer[bufferIndex] = (info.IsSignal(event)) ? 1.0 : 0.0;
+        } else {
+          // Multiclass.
+          buffer[bufferIndex] = 0.0;
+          if (j == event->GetClass()) {
+            buffer[bufferIndex] = 1.0;
+          }
+        }
+      } else {
+        buffer[bufferIndex] = event->GetTarget(j);
       }
+    }
    }
 }
 

--- a/tmva/tmva/src/DNN/Architectures/Reference/DataLoader.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Reference/DataLoader.cxx
@@ -146,7 +146,7 @@ template <>
 void TDataLoader<TMVAInput_t, TReference<Real_t>>::CopyOutput(TMatrixT<Real_t> &matrix, IndexIterator_t sampleIterator)
 {
    Event *event = std::get<0>(fData).front();
-   DataSetInfo &info = std::get<1>(fData);
+   const DataSetInfo &info = std::get<1>(fData);
    Int_t m = matrix.GetNrows();
    Int_t n = matrix.GetNcols();
 
@@ -211,7 +211,7 @@ void TDataLoader<TMVAInput_t, TReference<Double_t>>::CopyOutput(TMatrixT<Double_
                                                                 IndexIterator_t sampleIterator)
 {
    Event *event = std::get<0>(fData).front();
-   DataSetInfo &info = std::get<1>(fData);
+   const DataSetInfo &info = std::get<1>(fData);
    Int_t m = matrix.GetNrows();
    Int_t n = matrix.GetNcols();
 

--- a/tmva/tmva/src/MethodDNN.cxx
+++ b/tmva/tmva/src/MethodDNN.cxx
@@ -841,10 +841,12 @@ void TMVA::MethodDNN::TrainGpu()
       using DataLoader_t = TDataLoader<TMVAInput_t, TCuda<>>;
 
       size_t nThreads = 1;
-      DataLoader_t trainingData(std::tie(GetEventCollection(Types::kTraining), DataInfo()), nTrainingSamples,
-                                net.GetBatchSize(), net.GetInputWidth(), net.GetOutputWidth(), nThreads);
-      DataLoader_t testData(std::tie(GetEventCollection(Types::kTesting), DataInfo()), nTestSamples,
-                            testNet.GetBatchSize(), net.GetInputWidth(), net.GetOutputWidth(), nThreads);
+      TMVAInput_t trainingTuple = std::tie(GetEventCollection(Types::kTraining), DataInfo());
+      TMVAInput_t testTuple = std::tie(GetEventCollection(Types::kTesting), DataInfo());
+      DataLoader_t trainingData(trainingTuple, nTrainingSamples, net.GetBatchSize(),
+                                net.GetInputWidth(), net.GetOutputWidth(), nThreads);
+      DataLoader_t testData(testTuple,  nTestSamples, testNet.GetBatchSize(),
+          net.GetInputWidth(), net.GetOutputWidth(), nThreads);
       DNN::TGradientDescent<TCuda<>> minimizer(settings.learningRate,
                                              settings.convergenceSteps,
                                              settings.testInterval);
@@ -1005,10 +1007,12 @@ void TMVA::MethodDNN::TrainCpu()
       using DataLoader_t = TDataLoader<TMVAInput_t, TCpu<>>;
 
       size_t nThreads = 1;
-      DataLoader_t trainingData(std::tie(GetEventCollection(Types::kTraining), DataInfo()), nTrainingSamples,
-                                net.GetBatchSize(), net.GetInputWidth(), net.GetOutputWidth(), nThreads);
-      DataLoader_t testData(std::tie(GetEventCollection(Types::kTesting), DataInfo()), nTestSamples,
-                            testNet.GetBatchSize(), net.GetInputWidth(), net.GetOutputWidth(), nThreads);
+      TMVAInput_t trainingTuple = std::tie(GetEventCollection(Types::kTraining), DataInfo());
+      TMVAInput_t testTuple = std::tie(GetEventCollection(Types::kTesting), DataInfo());
+      DataLoader_t trainingData(trainingTuple, nTrainingSamples, net.GetBatchSize(),
+                                net.GetInputWidth(), net.GetOutputWidth(), nThreads);
+      DataLoader_t testData(testTuple, nTestSamples, testNet.GetBatchSize(),
+                            net.GetInputWidth(), net.GetOutputWidth(), nThreads);
       DNN::TGradientDescent<TCpu<>> minimizer(settings.learningRate,
                                                settings.convergenceSteps,
                                                settings.testInterval);

--- a/tmva/tmva/src/MethodDNN.cxx
+++ b/tmva/tmva/src/MethodDNN.cxx
@@ -841,12 +841,16 @@ void TMVA::MethodDNN::TrainGpu()
       using DataLoader_t = TDataLoader<TMVAInput_t, TCuda<>>;
 
       size_t nThreads = 1;
-      TMVAInput_t trainingTuple = std::tie(GetEventCollection(Types::kTraining), DataInfo());
-      TMVAInput_t testTuple = std::tie(GetEventCollection(Types::kTesting), DataInfo());
-      DataLoader_t trainingData(trainingTuple, nTrainingSamples, net.GetBatchSize(),
-                                net.GetInputWidth(), net.GetOutputWidth(), nThreads);
-      DataLoader_t testData(testTuple,  nTestSamples, testNet.GetBatchSize(),
-          net.GetInputWidth(), net.GetOutputWidth(), nThreads);
+      TMVAInput_t trainingTuple =
+          std::tie(GetEventCollection(Types::kTraining), DataInfo());
+      TMVAInput_t testTuple =
+          std::tie(GetEventCollection(Types::kTesting), DataInfo());
+      DataLoader_t trainingData(trainingTuple, nTrainingSamples,
+                                net.GetBatchSize(), net.GetInputWidth(),
+                                net.GetOutputWidth(), nThreads);
+      DataLoader_t testData(testTuple, nTestSamples, testNet.GetBatchSize(),
+                            net.GetInputWidth(), net.GetOutputWidth(),
+                            nThreads);
       DNN::TGradientDescent<TCuda<>> minimizer(settings.learningRate,
                                              settings.convergenceSteps,
                                              settings.testInterval);
@@ -1007,12 +1011,16 @@ void TMVA::MethodDNN::TrainCpu()
       using DataLoader_t = TDataLoader<TMVAInput_t, TCpu<>>;
 
       size_t nThreads = 1;
-      TMVAInput_t trainingTuple = std::tie(GetEventCollection(Types::kTraining), DataInfo());
-      TMVAInput_t testTuple = std::tie(GetEventCollection(Types::kTesting), DataInfo());
-      DataLoader_t trainingData(trainingTuple, nTrainingSamples, net.GetBatchSize(),
-                                net.GetInputWidth(), net.GetOutputWidth(), nThreads);
+      TMVAInput_t trainingTuple =
+          std::tie(GetEventCollection(Types::kTraining), DataInfo());
+      TMVAInput_t testTuple =
+          std::tie(GetEventCollection(Types::kTesting), DataInfo());
+      DataLoader_t trainingData(trainingTuple, nTrainingSamples,
+                                net.GetBatchSize(), net.GetInputWidth(),
+                                net.GetOutputWidth(), nThreads);
       DataLoader_t testData(testTuple, nTestSamples, testNet.GetBatchSize(),
-                            net.GetInputWidth(), net.GetOutputWidth(), nThreads);
+                            net.GetInputWidth(), net.GetOutputWidth(),
+                            nThreads);
       DNN::TGradientDescent<TCpu<>> minimizer(settings.learningRate,
                                                settings.convergenceSteps,
                                                settings.testInterval);


### PR DESCRIPTION
Reference to temporary object lead to crashes when copying input data.
This has been fixed.