### PR TITLE
Add example CODEOWNERS file.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
-
 # This file annotates code ownership within ROOT.
 # It's not meant to be a strict - or comprehensive - file, but
 # helpful guidance on who to coordinate with for various areas.
@@ -9,12 +8,51 @@
 #   - https://github.com/blog/2392-introducing-code-owners
 
 # Coarse-grained ownership
+* @Axel-Naumann
+bindings/* @peremato
+cmake/* @peremato
+core/* @Axel-Naumann
+documentation/* @couet
+fonts/* @bellenot
+geom/* @agheata
+graf2d/* @couet
+graf3d/* @couet
+gui/* @bellenot
+hist/* @lmoneta
+html/* @Axel-Naumann
+icons/* @bellenot
 interpreter/* @Axel-Naumann
 io/* @pcanal
+main/* @pcanal
+math/* @lmoneta
+misc/* @Axel-Naumann
+montecarlo/* @peremato
+net/* @gganis
+proof/* @gganis
+roofit/* @lmoneta
+rootx/* @Axel-Naumann
+sql/* @pcanal
+test/* @peremato
+tmva/* @lmoneta
 tree/* @pcanal
-cmake/* @peremato
+tutorials/* @couet
 
 # Projects that span over several code modules:
+bindings/pyroot/* @peremato
+bindings/pyroot/JupyROOT @etejedor
+bindings/r/* @omazapa
+core/base/* @pcanal
+core/cont/* @pcanal
+core/imt/* @dpiparo
+core/lz4/* @pcanal
+core/lzma/* @pcanal
+core/multiproc/* @gganis
+core/thread/* @pcanal
+core/multiproc/* @gganis
+graf2d/qt/* @bellenot
+graf2d/cocoa/* @TimurP
+graf2d/ios/* @TimurP
+graf3d/eve/* @osschar
+net/http/* @linev
 tree/treeplayer/inc/ROOT/TDataFrame* @dpiparo @bluehood
 tree/treeplayer/src/TDF* @dpiparo @bluehood
-

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+
+# This file annotates code ownership within ROOT.
+# It's not meant to be a strict - or comprehensive - file, but
+# helpful guidance on who to coordinate with for various areas.
+# This should also help provide suggested reviewers for PRs.
+
+# For more information, see:
+# 
+#   - https://github.com/blog/2392-introducing-code-owners
+
+# Coarse-grained ownership
+interpreter/* @Axel-Naumann
+io/* @pcanal
+tree/* @pcanal
+cmake/* @peremato
+
+# Projects that span over several code modules:
+tree/treeplayer/inc/ROOT/TDataFrame* @dpiparo @bluehood
+tree/treeplayer/src/TDF* @dpiparo @bluehood
+


### PR DESCRIPTION
The code owner's file helps establish a relationship between individuals / groups and code.  Currently, it's used to provide hints as to who should be a reviewer for a specific PR.  It's a hint, not a requirement -- although GitHub has the ability to require a review for protected branches.

See https://github.com/blog/2392-introducing-code-owners for more information.

Certainly the ownership is quite incomplete - but should provide a sufficient starting point.