### PR TITLE
Fix typo in unfolding function docs

### DIFF
--- a/hist/spectrum/src/TSpectrum.cxx
+++ b/hist/spectrum/src/TSpectrum.cxx
@@ -1785,9 +1785,9 @@ const char *TSpectrum::DeconvolutionRL(Double_t *source, const Double_t *respons
 ///
 ///  -  source: pointer to the vector of source spectrum
 ///  -  respMatrix: pointer to the matrix of response spectra
-///  -  ssizex: length of source spectrum and # of columns of the response
+///  -  ssizex: length of source spectrum and # of rows of the response
 ///      matrix. ssizex must be >= ssizey.
-///  -  ssizey: length of destination spectrum and # of rows of the response
+///  -  ssizey: length of destination coefficients and # of columns of the response
 ///      matrix.
 ///  -  numberIterations: number of iterations
 ///  -  numberRepetitions: number of repetitions for boosted deconvolution.

--- a/hist/spectrum/src/TSpectrum.cxx
+++ b/hist/spectrum/src/TSpectrum.cxx
@@ -1823,7 +1823,7 @@ const char *TSpectrum::DeconvolutionRL(Double_t *source, const Double_t *respons
      x(0) \\
      x(1) \\
      \dots \\
-     x(N_x-1)
+     x(N_y-1)
  \end{bmatrix}
  \f]
 */


### PR DESCRIPTION
Since the formula above is
```
y(i) = \sum_{k=0}^{N_y-1} h(i,k)x(k), i = 0,1,2,...,N_x-1
```
`x` is of size `N_y-1`