### PR TITLE
Prevent unnecessary LTO builds with make when running cmake.

### DIFF
--- a/interpreter/llvm/src/include/llvm/Support/CMakeLists.txt
+++ b/interpreter/llvm/src/include/llvm/Support/CMakeLists.txt
@@ -60,7 +60,9 @@ if(DEFINED llvm_vc)
     PROPERTIES GENERATED TRUE
                HEADER_FILE_ONLY TRUE)
 else()
-  file(WRITE "${version_inc}" "")
+  if(NOT EXISTS "${version_inc}")
+    file(WRITE "${version_inc}" "")
+  endif()
 endif()
 
 add_custom_target(llvm_vcsrevision_h DEPENDS "${version_inc}")


### PR DESCRIPTION
Currently we rebuilt LTO everytime you rerun cmake, as CMake
touches the vcsrevision file that LTO depends on. Make isn't
smart enough to realise it's still just an empty file, so it
retriggers the LTO compilations whenever you run CMake.

Again, this patch will be obsolete on the next LLVM upgrade
as this CMake code is refactored upstream.