### PR TITLE
webgui: create dictionary for pad/canvas/drawable classes

### DIFF
--- a/core/base/inc/LinkDef3.h
+++ b/core/base/inc/LinkDef3.h
@@ -268,4 +268,8 @@
 #pragma link C++ class TParameter<Long_t>+;
 #pragma link C++ class TParameter<Long64_t>+;
 
+#ifdef ROOT7_TDrawable
+#pragma link C++ class ROOT::Experimental::TDrawable+;
+#endif
+
 #endif

--- a/graf2d/gpad/inc/LinkDef.h
+++ b/graf2d/gpad/inc/LinkDef.h
@@ -50,14 +50,19 @@
 #pragma link C++ class ROOT::Experimental::Detail::TPadUserCoordBase+;
 #pragma link C++ class ROOT::Experimental::Detail::TPadLinearUserCoord+;
 #pragma link C++ struct ROOT::Experimental::Internal::TPadHorizVert+;
-#pragma link C++ class ROOT::Experimental::TPadExtent+;
-#pragma link C++ class ROOT::Experimental::TPadPos+;
+#pragma link C++ struct ROOT::Experimental::TPadExtent+;
+#pragma link C++ struct ROOT::Experimental::TPadPos+;
+#pragma link C++ class std::vector<std::unique_ptr<ROOT::Experimental::TDrawable>>+;
 #pragma link C++ class ROOT::Experimental::Internal::TPadBase+;
 #pragma link C++ class ROOT::Experimental::TPad+;
 #pragma link C++ class ROOT::Experimental::TPadDrawable+;
 #pragma link C++ class ROOT::Experimental::TCanvas+;
 #pragma link C++ class ROOT::Experimental::TPadCoord::Pixel+;
-#pragma link C++ class ROOT::Experimental::TPadCoord::CoordSysBase<ROOT::Experimental::TPadCoord::Pixel>+;
+#pragma link C++ class ROOT::Experimental::TPadCoord::Normal+;
+#pragma link C++ class ROOT::Experimental::TPadCoord::User+;
+//#pragma link C++ class ROOT::Experimental::TPadCoord::CoordSysBase<ROOT::Experimental::TPadCoord::Pixel>+;
+//#pragma link C++ class ROOT::Experimental::TPadCoord::CoordSysBase<ROOT::Experimental::TPadCoord::Normal>+;
+//#pragma link C++ class ROOT::Experimental::TPadCoord::CoordSysBase<ROOT::Experimental::TPadCoord::User>+;
 #endif
 
 #endif

--- a/graf2d/gpad/inc/LinkDef.h
+++ b/graf2d/gpad/inc/LinkDef.h
@@ -46,6 +46,13 @@
 #pragma link C++ class std::vector<ROOT::Experimental::Detail::TMenuArgument>+;
 #pragma link C++ class ROOT::Experimental::Detail::TArgsMenuItem+;
 #pragma link C++ class ROOT::Experimental::TMenuItems+;
+#pragma link C++ class ROOT::Experimental::Detail::TPadUserCoordBase+;
+#pragma link C++ class ROOT::Experimental::Detail::TPadLinearUserCoord+;
+#pragma link C++ class ROOT::Experimental::Internal::TPadBase+;
+#pragma link C++ class ROOT::Experimental::TPad+;
+#pragma link C++ class ROOT::Experimental::TCanvas+;
+#pragma link C++ class ROOT::Experimental::TPadCoord::Pixel+;
+#pragma link C++ class ROOT::Experimental::TPadCoord::CoordSysBase<ROOT::Experimental::TPadCoord::Pixel>+;
 #endif
 
 #endif

--- a/graf2d/gpad/inc/LinkDef.h
+++ b/graf2d/gpad/inc/LinkDef.h
@@ -46,6 +46,7 @@
 #pragma link C++ class std::vector<ROOT::Experimental::Detail::TMenuArgument>+;
 #pragma link C++ class ROOT::Experimental::Detail::TArgsMenuItem+;
 #pragma link C++ class ROOT::Experimental::TMenuItems+;
+#pragma link C++ class ROOT::Experimental::TObjectDrawable+;
 #pragma link C++ class ROOT::Experimental::Detail::TPadUserCoordBase+;
 #pragma link C++ class ROOT::Experimental::Detail::TPadLinearUserCoord+;
 #pragma link C++ struct ROOT::Experimental::Internal::TPadHorizVert+;

--- a/graf2d/gpad/inc/LinkDef.h
+++ b/graf2d/gpad/inc/LinkDef.h
@@ -48,8 +48,12 @@
 #pragma link C++ class ROOT::Experimental::TMenuItems+;
 #pragma link C++ class ROOT::Experimental::Detail::TPadUserCoordBase+;
 #pragma link C++ class ROOT::Experimental::Detail::TPadLinearUserCoord+;
+#pragma link C++ struct ROOT::Experimental::Internal::TPadHorizVert+;
+#pragma link C++ class ROOT::Experimental::TPadExtent+;
+#pragma link C++ class ROOT::Experimental::TPadPos+;
 #pragma link C++ class ROOT::Experimental::Internal::TPadBase+;
 #pragma link C++ class ROOT::Experimental::TPad+;
+#pragma link C++ class ROOT::Experimental::TPadDrawable+;
 #pragma link C++ class ROOT::Experimental::TCanvas+;
 #pragma link C++ class ROOT::Experimental::TPadCoord::Pixel+;
 #pragma link C++ class ROOT::Experimental::TPadCoord::CoordSysBase<ROOT::Experimental::TPadCoord::Pixel>+;

--- a/graf2d/gpad/v7/inc/ROOT/TCanvas.hxx
+++ b/graf2d/gpad/v7/inc/ROOT/TCanvas.hxx
@@ -57,7 +57,14 @@ public:
    /// Create a temporary TCanvas; for long-lived ones please use Create().
    TCanvas() = default;
 
+   /// Return canvas pixel size as array with two elements - width and height
    const std::array<TPadCoord::Pixel, 2> &GetSize() const { return fSize; }
+
+   /// Set canvas pixel size as array with two elements - width and height
+   void SetSize(const std::array<TPadCoord::Pixel, 2> &sz) { fSize = sz; }
+
+   /// Set canvas pixel size - width and height
+   void SetSize(const TPadCoord::Pixel &width, const TPadCoord::Pixel &height) { fSize[0] = width; fSize[1] = height; }
 
    /// Display the canvas.
    void Show(const std::string &where = "");

--- a/graf2d/gpad/v7/inc/ROOT/TCanvas.hxx
+++ b/graf2d/gpad/v7/inc/ROOT/TCanvas.hxx
@@ -37,19 +37,13 @@ class TCanvasSharedPtrMaker;
 
 class TCanvas: public Internal::TPadBase {
 private:
-   /// Title of the canvas.
-   std::string fTitle;
+   std::string fTitle;                    ///< Title of the canvas.
 
-   /// Size of the canvas in pixels.
-   std::array<TPadCoord::Pixel, 2> fSize;
+   std::array<TPadCoord::Pixel, 2> fSize; ///< Size of the canvas in pixels.
 
-   /// Increment counter when canvas modified.
-   uint64_t fModified;
+   uint64_t fModified;                    ///<! Increment counter when canvas modified.
 
-   /// The painter of this canvas, bootstrapping the graphics connection.
-   /// Unmapped canvases (those that never had `Draw()` invoked) might not have
-   /// a painter.
-   std::unique_ptr<Internal::TVirtualCanvasPainter> fPainter;
+   std::unique_ptr<Internal::TVirtualCanvasPainter> fPainter;  ///<! The painter of this canvas, bootstrapping the graphics connection.
 
    /// Disable copy construction for now.
    TCanvas(const TCanvas &) = delete;

--- a/graf2d/gpad/v7/inc/ROOT/TCanvas.hxx
+++ b/graf2d/gpad/v7/inc/ROOT/TCanvas.hxx
@@ -37,13 +37,19 @@ class TCanvasSharedPtrMaker;
 
 class TCanvas: public Internal::TPadBase {
 private:
-   std::string fTitle;                    ///< Title of the canvas.
+   /// Title of the canvas.
+   std::string fTitle;
 
-   std::array<TPadCoord::Pixel, 2> fSize; ///< Size of the canvas in pixels.
+   /// Size of the canvas in pixels,
+   std::array<TPadCoord::Pixel, 2> fSize;
 
-   uint64_t fModified;                    ///<! Increment counter when canvas modified.
+   /// Modify counter, incremented every time canvas is changed
+   uint64_t fModified;                    ///<!
 
-   std::unique_ptr<Internal::TVirtualCanvasPainter> fPainter;  ///<! The painter of this canvas, bootstrapping the graphics connection.
+   /// The painter of this canvas, bootstrapping the graphics connection.
+   /// Unmapped canvases (those that never had `Draw()` invoked) might not have
+   /// a painter.
+   std::unique_ptr<Internal::TVirtualCanvasPainter> fPainter;  ///<!
 
    /// Disable copy construction for now.
    TCanvas(const TCanvas &) = delete;

--- a/graf2d/gpad/v7/inc/ROOT/TObjectDrawable.hxx
+++ b/graf2d/gpad/v7/inc/ROOT/TObjectDrawable.hxx
@@ -31,6 +31,9 @@ class TObjectDrawable: public TDrawable {
    std::string fOpts;                   ///< The drawing options
 
 public:
+
+   TObjectDrawable() = default;
+
    TObjectDrawable(const std::shared_ptr<TObject> &obj, std::string_view opts): fObj(obj), fOpts(opts) {}
 
    /// Paint the histogram

--- a/graf2d/gpad/v7/inc/ROOT/TPad.hxx
+++ b/graf2d/gpad/v7/inc/ROOT/TPad.hxx
@@ -147,6 +147,29 @@ public:
 };
 } // namespace Internal
 
+
+/** \class TPadDrawable
+   Draw a TPad, by drawing its contained graphical elements at the pad offset in the parent pad.'
+   */
+class TPadDrawable: public TDrawable {
+private:
+   const std::unique_ptr<TPad> fPad; ///< The pad to be painted
+   TPadPos fPos;                     ///< Offset with respect to parent TPad.
+
+public:
+   TPadDrawable() = default;
+
+   TPadDrawable(std::unique_ptr<TPad> &&pPad, const TPadPos &pos): fPad(std::move(pPad)), fPos(pos) {}
+
+   /// Paint the pad.
+   void Paint(Internal::TVirtualCanvasPainter & /*canv*/) final
+   {
+      // FIXME: and then what? Something with fPad.GetListOfPrimitives()?
+   }
+
+   TPad *Get() const { return fPad.get(); }
+};
+
 /** \class ROOT::Experimental::TPad
   Graphic container for `TDrawable`-s.
   */
@@ -159,32 +182,15 @@ private:
    /// Size of the pad in the parent's (!) coordinate system.
    TPadExtent fSize;
 
-   /** \class TPadDrawable
-      Draw a TPad, by drawing its contained graphical elements at the pad offset in the parent pad.'
-      */
-   class TPadDrawable: public TDrawable {
-   private:
-      const std::unique_ptr<TPad> fPad; ///< The pad to be painted
-      TPadPos fPos;                     ///< Offset with respect to parent TPad.
 
-   public:
-      TPadDrawable(std::unique_ptr<TPad> &&pPad, const TPadPos &pos): fPad(std::move(pPad)), fPos(pos) {}
-
-      /// Paint the pad.
-      void Paint(Internal::TVirtualCanvasPainter & /*canv*/) final
-      {
-         // FIXME: and then what? Something with fPad.GetListOfPrimitives()?
-      }
-
-      TPad *Get() const { return fPad.get(); }
-   };
+public:
 
    friend std::unique_ptr<TPadDrawable> GetDrawable(std::unique_ptr<TPad> &&pad, const TPadPos &pos)
    {
       return std::make_unique<TPadDrawable>(std::move(pad), pos);
    }
 
-public:
+
    /// Create a child pad.
    TPad(const TPadBase &parent, const TPadExtent &size): fParent(&parent), fSize(size) {}
 

--- a/graf2d/gpad/v7/inc/ROOT/TPad.hxx
+++ b/graf2d/gpad/v7/inc/ROOT/TPad.hxx
@@ -22,7 +22,7 @@
 #include "ROOT/TDrawable.hxx"
 #include "ROOT/TPadExtent.hxx"
 #include "ROOT/TPadPos.hxx"
-#include "ROOT/TPadUserCoord.hxx"
+#include "ROOT/TPadUserCoordBase.hxx"
 #include "ROOT/TypeTraits.hxx"
 
 namespace ROOT {

--- a/graf2d/gpad/v7/inc/ROOT/TPadLinearUserCoord.hxx
+++ b/graf2d/gpad/v7/inc/ROOT/TPadLinearUserCoord.hxx
@@ -1,0 +1,64 @@
+/// \file ROOT/TPadUserCoord.hxx
+/// \ingroup Gpad ROOT7
+/// \author Axel Naumann <axel@cern.ch>
+/// \date 2017-07-15
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_TPadLinearUserCoord
+#define ROOT7_TPadLinearUserCoord
+
+#include <ROOT/TPadUserCoordBase.hxx>
+
+#include <array>
+#include <limits>
+
+namespace ROOT {
+namespace Experimental {
+
+namespace Detail {
+
+/** \class ROOT::Experimental::Detail::TPadLinearUserCoord
+  The default, linear min/max coordinate system for `TPad`, `TCanvas`.
+  */
+
+class TPadLinearUserCoord: public TPadUserCoordBase {
+private:
+   std::array<double, 2> fMin; ///< (x,y) user coordinate of bottom-left corner
+   std::array<double, 2> fMax; ///< (x,y) user coordinate of top-right corner
+
+   /// For (pos-min)/(max-min) calculations, return a sensible, div-by-0 protected denominator.
+   double GetDenominator(int idx) const
+   {
+      if (fMin[idx] < fMax[idx])
+         return std::max(std::numeric_limits<double>::min(), fMin[idx] - fMax[idx]);
+      return std::min(-std::numeric_limits<double>::min(), fMin[idx] - fMax[idx]);
+   }
+
+public:
+   /// Initialize a TPadLinearUserCoord.
+   TPadLinearUserCoord(const std::array<double, 2> &min, const std::array<double, 2> &max): fMin(min), fMax(max) {}
+
+   /// Destructor to have a vtable.
+   virtual ~TPadLinearUserCoord();
+
+   /// Convert user coordinates to normal coordinates.
+   std::array<TPadCoord::Normal, 2> ToNormal(const std::array<TPadCoord::User, 2> &pos) const override
+   {
+      return {{(pos[0] - fMin[0]) / GetDenominator(0), (pos[1] - fMin[1]) / GetDenominator(1)}};
+   }
+};
+
+} // namespace Detail
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/graf2d/gpad/v7/inc/ROOT/TPadUserCoord.hxx
+++ b/graf2d/gpad/v7/inc/ROOT/TPadUserCoord.hxx
@@ -43,7 +43,7 @@ protected:
    TPadUserCoordBase() = default;
 
 public:
-   virtual ~TPadUserCoordBase();
+   virtual ~TPadUserCoordBase() {}
 
    /// Convert user coordinates to normal coordinates.
    virtual std::array<TPadCoord::Normal, 2> ToNormal(const std::array<TPadCoord::User, 2> &) const = 0;
@@ -56,7 +56,7 @@ public:
 class TPadLinearUserCoord: public TPadUserCoordBase {
 private:
    std::array<double, 2> fMin; ///< (x,y) user coordinate of bottom-left corner
-   std::array<double, 2> fMax; ///< (x,y) user coordinate of top-right cornder
+   std::array<double, 2> fMax; ///< (x,y) user coordinate of top-right corner
 
    /// For (pos-min)/(max-min) calculations, return a sensible, div-by-0 protected denominator.
    double GetDenominator(int idx) const
@@ -71,7 +71,7 @@ public:
    TPadLinearUserCoord(const std::array<double, 2> &min, const std::array<double, 2> &max): fMin(min), fMax(max) {}
 
    /// Destructor to have a vtable.
-   virtual ~TPadLinearUserCoord();
+   virtual ~TPadLinearUserCoord() {}
 
    /// Convert user coordinates to normal coordinates.
    std::array<TPadCoord::Normal, 2> ToNormal(const std::array<TPadCoord::User, 2> &pos) const override

--- a/graf2d/gpad/v7/inc/ROOT/TPadUserCoordBase.hxx
+++ b/graf2d/gpad/v7/inc/ROOT/TPadUserCoordBase.hxx
@@ -13,13 +13,12 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#ifndef ROOT7_TPadUserCoord
-#define ROOT7_TPadUserCoord
+#ifndef ROOT7_TPadUserCoordBase
+#define ROOT7_TPadUserCoordBase
 
 #include <ROOT/TPadCoord.hxx>
 
 #include <array>
-#include <limits>
 
 namespace ROOT {
 namespace Experimental {
@@ -43,41 +42,10 @@ protected:
    TPadUserCoordBase() = default;
 
 public:
-   virtual ~TPadUserCoordBase() {}
+   virtual ~TPadUserCoordBase();
 
    /// Convert user coordinates to normal coordinates.
    virtual std::array<TPadCoord::Normal, 2> ToNormal(const std::array<TPadCoord::User, 2> &) const = 0;
-};
-
-/** \class ROOT::Experimental::Detail::TPadLinearUserCoord
-  The default, linear min/max coordinate system for `TPad`, `TCanvas`.
-  */
-
-class TPadLinearUserCoord: public TPadUserCoordBase {
-private:
-   std::array<double, 2> fMin; ///< (x,y) user coordinate of bottom-left corner
-   std::array<double, 2> fMax; ///< (x,y) user coordinate of top-right corner
-
-   /// For (pos-min)/(max-min) calculations, return a sensible, div-by-0 protected denominator.
-   double GetDenominator(int idx) const
-   {
-      if (fMin[idx] < fMax[idx])
-         return std::max(std::numeric_limits<double>::min(), fMin[idx] - fMax[idx]);
-      return std::min(-std::numeric_limits<double>::min(), fMin[idx] - fMax[idx]);
-   }
-
-public:
-   /// Initialize a TPadLinearUserCoord.
-   TPadLinearUserCoord(const std::array<double, 2> &min, const std::array<double, 2> &max): fMin(min), fMax(max) {}
-
-   /// Destructor to have a vtable.
-   virtual ~TPadLinearUserCoord() {}
-
-   /// Convert user coordinates to normal coordinates.
-   std::array<TPadCoord::Normal, 2> ToNormal(const std::array<TPadCoord::User, 2> &pos) const override
-   {
-      return {{(pos[0] - fMin[0]) / GetDenominator(0), (pos[1] - fMin[1]) / GetDenominator(1)}};
-   }
 };
 
 } // namespace Detail

--- a/graf2d/gpad/v7/src/TPadLinearUserCoord.cxx
+++ b/graf2d/gpad/v7/src/TPadLinearUserCoord.cxx
@@ -1,0 +1,12 @@
+/// \file TVirtualCanvasPainter.cxx
+/// \ingroup Gpad ROOT7
+/// \author Axel Naumann <axel@cern.ch>
+/// \date 2017-08-14
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+#include <ROOT/TPadLinearUserCoord.hxx>
+
+ROOT::Experimental::Detail::TPadLinearUserCoord::~TPadLinearUserCoord()
+{
+}

--- a/graf2d/gpad/v7/src/TPadUserCoordBase.cxx
+++ b/graf2d/gpad/v7/src/TPadUserCoordBase.cxx
@@ -1,0 +1,12 @@
+/// \file TVirtualCanvasPainter.cxx
+/// \ingroup Gpad ROOT7
+/// \author Axel Naumann <axel@cern.ch>
+/// \date 2017-08-14
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+#include <ROOT/TPadUserCoordBase.hxx>
+
+ROOT::Experimental::Detail::TPadUserCoordBase::~TPadUserCoordBase()
+{
+}


### PR DESCRIPTION
There are several side effects, especially with current TPadDrawable where std::shared_ptr<TPad> is used. Probably one should change class hierarchy here and derive TPadBase directly from TDrawable class.

Also dictionary for core classes will not be rebuild automatically - see my bug report: 
https://sft.its.cern.ch/jira/browse/ROOT-8949

For the time been - just rebuild this dictionary by hand doing:

    [shell] rm core/base/G__Core.cxx 

At the moment only empty canvas can be stored in the file.
If any sub-pad exists, ROOT will crash.

Also provide SetSize methods for the TCanvas