### PR TITLE
Fix for ROOT-8949 - cmake does not rebuild core dictionary when LinkDef1/2/3 changed

### DIFF
--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -584,7 +584,6 @@ function(ROOT_LINKER_LIBRARY library)
   endif()
   if(TARGET G__${library})
     add_dependencies(${library} G__${library})
-    message("${library} --> G__${library}")
   else()
     # Uncomment to see if we maybe forgot to add a dependency between linking
     # a dictionary and generating the G__*.cxx file. We can't have this by

--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -380,18 +380,20 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
   endforeach()
 
   #---call rootcint------------------------------------------
-  add_custom_command(OUTPUT ${dictionary}.cxx ${pcm_name} ${rootmap_name}
+  add_custom_command(OUTPUT ${dictionary}.stamp
+                     BYPRODUCTS ${dictionary}.cxx ${pcm_name} ${rootmap_name}
                      COMMAND ${command} -v2 -f  ${dictionary}.cxx ${newargs} ${excludepathsargs} ${rootmapargs}
                                         ${ARG_OPTIONS} ${definitions} ${includedirs} ${headerfiles} ${_linkdef}
+                     COMMAND ${CMAKE_COMMAND} -E touch ${dictionary}.stamp
                      IMPLICIT_DEPENDS ${_implicitdeps}
                      DEPENDS ${_list_of_header_dependencies} ${_linkdef} ${ROOTCINTDEP} ${ARG_DEPENDENCIES})
   get_filename_component(dictname ${dictionary} NAME)
 
   #---roottest compability
   if(ARG_NOINSTALL OR CMAKE_ROOTTEST_DICT OR (NOT DEFINED CMAKE_LIBRARY_OUTPUT_DIRECTORY))
-    add_custom_target(${dictname} DEPENDS ${dictionary}.cxx)
+    add_custom_target(${dictname} DEPENDS ${dictionary}.stamp)
   else()
-    add_custom_target(${dictname} DEPENDS ${dictionary}.cxx)
+    add_custom_target(${dictname} DEPENDS ${dictionary}.stamp)
 
     set_property(GLOBAL APPEND PROPERTY ROOT_DICTIONARY_TARGETS ${dictname})
     set_property(GLOBAL APPEND PROPERTY ROOT_DICTIONARY_FILES ${CMAKE_CURRENT_BINARY_DIR}/${dictionary}.cxx)
@@ -582,6 +584,7 @@ function(ROOT_LINKER_LIBRARY library)
   endif()
   if(TARGET G__${library})
     add_dependencies(${library} G__${library})
+    message("${library} --> G__${library}")
   else()
     # Uncomment to see if we maybe forgot to add a dependency between linking
     # a dictionary and generating the G__*.cxx file. We can't have this by

--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -34,6 +34,9 @@ ROOT_GENERATE_DICTIONARY(G__Core
                          OPTIONS ${dict_opts}
                          LINKDEF LinkDef.h)
 
+# This is needed becuase LinkDef.h includes other LinkDef starting from  ${CMAKE_SOURCE_DIR}
+set_property(TARGET G__Core PROPERTY INCLUDE_DIRECTORIES ${CMAKE_SOURCE_DIR})
+
 list(REMOVE_ITEM sources TROOT.cxx roota.cxx)
 ROOT_OBJECT_LIBRARY(Base G__Core.cxx ${sources})
 


### PR DESCRIPTION
This is fix for ROOT-8949 following the suggestions from the CMake developers at https://gitlab.kitware.com/cmake/cmake/issues/16830