### PR TITLE
Revert "disable cmake warnings of clang in ROOT build"

### DIFF
--- a/interpreter/llvm/src/tools/clang/CMakeLists.txt
+++ b/interpreter/llvm/src/tools/clang/CMakeLists.txt
@@ -392,17 +392,6 @@ if(CLANG_ENABLE_STATIC_ANALYZER)
   add_definitions(-DCLANG_ENABLE_STATIC_ANALYZER)
 endif()
 
-option(CLANG_ENABLE_FORMAT "Build clang-format." ON)
-if(CLANG_ENABLE_FORMAT)
-  add_definitions(-DCLANG_ENABLE_FORMAT)
-endif()
-
-option(CLANG_ENABLE_COMPILER "Build clang compilers." ON)
-if(CLANG_ENABLE_COMPILER)
-  add_definitions(-DCLANG_ENABLE_COMPILER)
-endif()
-
-
 # Clang version information
 set(CLANG_EXECUTABLE_VERSION
      "${CLANG_VERSION_MAJOR}.${CLANG_VERSION_MINOR}" CACHE STRING

--- a/interpreter/llvm/src/tools/clang/tools/CMakeLists.txt
+++ b/interpreter/llvm/src/tools/clang/tools/CMakeLists.txt
@@ -1,6 +1,9 @@
 create_subdirectory_options(CLANG TOOL)
 
 add_clang_subdirectory(diagtool)
+add_clang_subdirectory(driver)
+add_clang_subdirectory(clang-format)
+add_clang_subdirectory(clang-format-vs)
 add_clang_subdirectory(clang-fuzzer)
 add_clang_subdirectory(clang-import-test)
 add_clang_subdirectory(clang-offload-bundler)
@@ -16,15 +19,6 @@ if(CLANG_ENABLE_STATIC_ANALYZER)
   add_clang_subdirectory(clang-check)
   add_clang_subdirectory(scan-build)
   add_clang_subdirectory(scan-view)
-endif()
-
-if(CLANG_ENABLE_FORMAT)
-  add_clang_subdirectory(clang-format)
-  add_clang_subdirectory(clang-format-vs)
-endif()
-
-if(CLANG_ENABLE_COMPILER)
-  add_clang_subdirectory(driver)
 endif()
 
 # We support checking out the clang-tools-extra repository into the 'extra'


### PR DESCRIPTION
Technically this is not revert because of the faulty merge commit.