### PR TITLE
T Color tracking

### DIFF
--- a/core/base/src/TColor.cxx
+++ b/core/base/src/TColor.cxx
@@ -43,6 +43,7 @@ namespace {
 static Int_t   gHighestColorIndex = 0;   ///< Highest color index defined
 static Float_t gColorThreshold    = -1.; ///< Color threshold used by GetColor
 static Int_t   gDefinedColors     = 0;  ///< Number of defined colors.
+static Int_t gLastDefinedColors = 0; ///< Previous number of defined colors
 
 #define fgGrayscaleMode TColor__GrayScaleMode()
 #define fgPalette TColor__Palette()
@@ -1405,7 +1406,9 @@ Bool_t TColor::DefinedColors()
 {
    // After initialization gDefinedColors == 649. If it is bigger it means some new
    // colors have been defined
-   return (gDefinedColors-649 > 50);
+   Bool_t hasChanged = (gDefinedColors - gLastDefinedColors) > 50;
+   gLastDefinedColors = gDefinedColors;
+   return hasChanged;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/base/src/TColor.cxx
+++ b/core/base/src/TColor.cxx
@@ -43,7 +43,7 @@ namespace {
 static Int_t   gHighestColorIndex = 0;   ///< Highest color index defined
 static Float_t gColorThreshold    = -1.; ///< Color threshold used by GetColor
 static Int_t   gDefinedColors     = 0;  ///< Number of defined colors.
-static Int_t gLastDefinedColors = 0; ///< Previous number of defined colors
+static Int_t gLastDefinedColors = 649; ///< Previous number of defined colors
 
 #define fgGrayscaleMode TColor__GrayScaleMode()
 #define fgPalette TColor__Palette()


### PR DESCRIPTION
Added resetting state logic in the TColor class that uses a flag to check for changes in the palette such that the Jupyter notebook cells will cause the list of TColors to be streamed independently of other cells, only if they are needed.