### PR TITLE
TMVA: Prevent stack corruption for input trees

### DIFF
--- a/tmva/tmva/src/DataSetFactory.cxx
+++ b/tmva/tmva/src/DataSetFactory.cxx
@@ -288,6 +288,7 @@ void TMVA::DataSetFactory::ChangeToNewTree( TreeInfo& tinfo, const DataSetInfo &
    TTree *tr = tinfo.GetTree()->GetTree();
 
    tr->SetBranchStatus("*",1);
+   tr->ResetBranchAddresses();
 
    Bool_t hasDollar = kFALSE;
 


### PR DESCRIPTION
When TMVA is reading an input tree it is possible for the user to have forgotten
to remove pointers to out-of-scope variables. This patch prevents TMVA from
messing up the stack in that case.

The user should *always* call ResetBranchAddresses on their trees
when they are done with them, but in case they forgot this can save
some debugging time at no cost.