### PR TITLE
[PyMVA] Maintain 1.x and 2.x Keras API in examples

### DIFF
--- a/tutorials/tmva/keras/ApplicationClassificationKeras.py
+++ b/tutorials/tmva/keras/ApplicationClassificationKeras.py
@@ -27,7 +27,7 @@ for branch in signal.GetListOfBranches():
     background.SetBranchAddress(branchName, branches[branchName])
 
 # Book methods
-reader.BookMVA('PyKeras', TString('dataset/weights/TMVAClassification_PyKeras.weights.xml'))
+reader.BookMVA('PyKeras', TString('TMVAClassification/weights/TMVAClassification_PyKeras.weights.xml'))
 
 # Print some example classifications
 print('Some signal example classifications:')

--- a/tutorials/tmva/keras/ApplicationRegressionKeras.py
+++ b/tutorials/tmva/keras/ApplicationRegressionKeras.py
@@ -26,7 +26,7 @@ for branch in tree.GetListOfBranches():
         reader.AddVariable(branchName, branches[branchName])
 
 # Book methods
-reader.BookMVA('PyKeras', TString('dataset/weights/TMVAClassification_PyKeras.weights.xml'))
+reader.BookMVA('PyKeras', TString('TMVARegression/weights/TMVARegression_PyKeras.weights.xml'))
 
 # Print some example regressions
 print('Some example regressions:')

--- a/tutorials/tmva/keras/ClassificationKeras.py
+++ b/tutorials/tmva/keras/ClassificationKeras.py
@@ -5,16 +5,15 @@ from subprocess import call
 from os.path import isfile
 
 from keras.models import Sequential
-from keras.layers.core import Dense, Activation
+from keras.layers import Dense, Activation
 from keras.regularizers import l2
-from keras import initializations
 from keras.optimizers import SGD
 
 # Setup TMVA
 TMVA.Tools.Instance()
 TMVA.PyMethodBase.PyInitialize()
 
-output = TFile.Open('TMVA.root', 'RECREATE')
+output = TFile.Open('TMVAClassification.root', 'RECREATE')
 factory = TMVA.Factory('TMVAClassification', output,
         '!V:!Silent:Color:DrawProgressBar:Transformations=D,G:AnalysisType=Classification')
 
@@ -26,7 +25,7 @@ data = TFile.Open('tmva_class_example.root')
 signal = data.Get('TreeS')
 background = data.Get('TreeB')
 
-dataloader = TMVA.DataLoader('dataset')
+dataloader = TMVA.DataLoader('TMVAClassification')
 for branch in signal.GetListOfBranches():
     dataloader.AddVariable(branch.GetName())
 
@@ -37,15 +36,11 @@ dataloader.PrepareTrainingAndTestTree(TCut(''),
 
 # Generate model
 
-# Define initialization
-def normal(shape, name=None):
-    return initializations.normal(shape, scale=0.05, name=name)
-
 # Define model
 model = Sequential()
-model.add(Dense(64, init=normal, activation='relu', W_regularizer=l2(1e-5), input_dim=4))
-#model.add(Dense(32, init=normal, activation='relu', W_regularizer=l2(1e-5)))
-model.add(Dense(2, init=normal, activation='softmax'))
+model.add(Dense(64, activation='relu', W_regularizer=l2(1e-5), input_dim=4))
+#model.add(Dense(32, activation='relu', W_regularizer=l2(1e-5)))
+model.add(Dense(2, activation='softmax'))
 
 # Set loss and optimizer
 model.compile(loss='categorical_crossentropy', optimizer=SGD(lr=0.01), metrics=['accuracy',])

--- a/tutorials/tmva/keras/GenerateModel.py
+++ b/tutorials/tmva/keras/GenerateModel.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 
 from keras.models import Sequential
-from keras.layers.core import Dense, Activation
+from keras.layers import Dense, Activation
 from keras.regularizers import l2
-from keras import initializations
 from keras.optimizers import SGD
 
 # Setup the model here
@@ -13,29 +12,23 @@ num_hidden_layers = 1
 nodes_hidden_layer = 64
 l2_val = 1e-5
 
-# NOTE: Either you can use predefined initializations (see Keras documentation)
-# or you can define your own initialization in such a function
-
-def normal(shape, name=None):
-    return initializations.normal(shape, scale=0.05, name=name)
-
 model = Sequential()
 
 # Hidden layer 1
 # NOTE: Number of input nodes need to be defined in this layer
-model.add(Dense(nodes_hidden_layer, init=normal, activation='relu', W_regularizer=l2(l2_val), input_dim=num_input_nodes))
+model.add(Dense(nodes_hidden_layer, activation='relu', W_regularizer=l2(l2_val), input_dim=num_input_nodes))
 
 # Hidden layer 2 to num_hidden_layers
 # NOTE: Here, you can do what you want
 for k in range(num_hidden_layers-1):
-    model.add(Dense(nodes_hidden_layer, init=normal, activation='relu', W_regularizer=l2(l2_val)))
+    model.add(Dense(nodes_hidden_layer, activation='relu', W_regularizer=l2(l2_val)))
 
 # Ouput layer
 # NOTE: Use following output types for the different tasks
 # Binary classification: 2 output nodes with 'softmax' activation
 # Regression: 1 output with any activation ('linear' recommended)
 # Multiclass classification: (number of classes) output nodes with 'softmax' activation
-model.add(Dense(num_output_nodes, init=normal, activation='softmax'))
+model.add(Dense(num_output_nodes, activation='softmax'))
 
 # Compile model
 # NOTE: Use following settings for the different tasks

--- a/tutorials/tmva/keras/LaunchClasGUI.C
+++ b/tutorials/tmva/keras/LaunchClasGUI.C
@@ -1,3 +1,3 @@
 void LaunchClasGUI(){
-    TMVA::TMVAGui("TMVA.root");
+   TMVA::TMVAGui("TMVAClassification.root");
 }

--- a/tutorials/tmva/keras/LaunchMultiGUI.C
+++ b/tutorials/tmva/keras/LaunchMultiGUI.C
@@ -1,3 +1,3 @@
 void LaunchMultiGUI(){
-    TMVA::TMVAMultiClassGui("TMVA.root");
+   TMVA::TMVAMultiClassGui("TMVAMulticlass.root");
 }

--- a/tutorials/tmva/keras/LaunchRegGUI.C
+++ b/tutorials/tmva/keras/LaunchRegGUI.C
@@ -1,3 +1,3 @@
 void LaunchRegGUI(){
-    TMVA::TMVARegGui("TMVA.root");
+   TMVA::TMVARegGui("TMVARegression.root");
 }

--- a/tutorials/tmva/keras/MulticlassKeras.py
+++ b/tutorials/tmva/keras/MulticlassKeras.py
@@ -4,16 +4,15 @@ from ROOT import TMVA, TFile, TTree, TCut, gROOT
 from os.path import isfile
 
 from keras.models import Sequential
-from keras.layers.core import Dense, Activation
+from keras.layers import Dense, Activation
 from keras.regularizers import l2
-from keras import initializations
 from keras.optimizers import SGD
 
 # Setup TMVA
 TMVA.Tools.Instance()
 TMVA.PyMethodBase.PyInitialize()
 
-output = TFile.Open('TMVA.root', 'RECREATE')
+output = TFile.Open('TMVAMulticlass.root', 'RECREATE')
 factory = TMVA.Factory('TMVAClassification', output,
     '!V:!Silent:Color:DrawProgressBar:Transformations=D,G:AnalysisType=multiclass')
 
@@ -30,7 +29,7 @@ background0 = data.Get('TreeB0')
 background1 = data.Get('TreeB1')
 background2 = data.Get('TreeB2')
 
-dataloader = TMVA.DataLoader('dataset')
+dataloader = TMVA.DataLoader('TMVAMulticlass')
 for branch in signal.GetListOfBranches():
     dataloader.AddVariable(branch.GetName())
 
@@ -43,15 +42,11 @@ dataloader.PrepareTrainingAndTestTree(TCut(''),
 
 # Generate model
 
-# Define initialization
-def normal(shape, name=None):
-    return initializations.normal(shape, scale=0.05, name=name)
-
 # Define model
 model = Sequential()
-model.add(Dense(32, init=normal, activation='relu', W_regularizer=l2(1e-5), input_dim=4))
-#model.add(Dense(32, init=normal, activation='relu', W_regularizer=l2(1e-5)))
-model.add(Dense(4, init=normal, activation='softmax'))
+model.add(Dense(32, activation='relu', W_regularizer=l2(1e-5), input_dim=4))
+#model.add(Dense(32, activation='relu', W_regularizer=l2(1e-5)))
+model.add(Dense(4, activation='softmax'))
 
 # Set loss and optimizer
 model.compile(loss='categorical_crossentropy', optimizer=SGD(lr=0.01), metrics=['accuracy',])

--- a/tutorials/tmva/keras/RegressionKeras.py
+++ b/tutorials/tmva/keras/RegressionKeras.py
@@ -5,16 +5,15 @@ from subprocess import call
 from os.path import isfile
 
 from keras.models import Sequential
-from keras.layers.core import Dense, Activation
+from keras.layers import Dense, Activation
 from keras.regularizers import l2
-from keras import initializations
 from keras.optimizers import SGD
 
 # Setup TMVA
 TMVA.Tools.Instance()
 TMVA.PyMethodBase.PyInitialize()
 
-output = TFile.Open('TMVA.root', 'RECREATE')
+output = TFile.Open('TMVARegression.root', 'RECREATE')
 factory = TMVA.Factory('TMVARegression', output,
         '!V:!Silent:Color:DrawProgressBar:Transformations=D,G:AnalysisType=Regression')
 
@@ -25,7 +24,7 @@ if not isfile('tmva_reg_example.root'):
 data = TFile.Open('tmva_reg_example.root')
 tree = data.Get('TreeR')
 
-dataloader = TMVA.DataLoader('dataset')
+dataloader = TMVA.DataLoader('TMVARegression')
 for branch in tree.GetListOfBranches():
     name = branch.GetName()
     if name != 'fvalue':
@@ -38,15 +37,11 @@ dataloader.PrepareTrainingAndTestTree(TCut(''),
 
 # Generate model
 
-# Define initialization
-def normal(shape, name=None):
-    return initializations.normal(shape, scale=0.05, name=name)
-
 # Define model
 model = Sequential()
-model.add(Dense(64, init=normal, activation='tanh', W_regularizer=l2(1e-5), input_dim=2))
-#model.add(Dense(32, init=normal, activation='tanh', W_regularizer=l2(1e-5)))
-model.add(Dense(1, init=normal, activation='linear'))
+model.add(Dense(64, activation='tanh', W_regularizer=l2(1e-5), input_dim=2))
+#model.add(Dense(32, activation='tanh', W_regularizer=l2(1e-5)))
+model.add(Dense(1, activation='linear'))
 
 # Set loss and optimizer
 model.compile(loss='mean_squared_error', optimizer=SGD(lr=0.01))


### PR DESCRIPTION
- Maintain 1.x and 2.x Keras API in `root/examples/tmva/keras` scripts
- Nice up the output paths so that all examples can be run without interfering