### PR TITLE
Refactored modulemaps to fix ODR errors when using modules.

### DIFF
--- a/build/unix/libc.modulemap
+++ b/build/unix/libc.modulemap
@@ -25,6 +25,10 @@ module "libc" {
     export *
     header "xlocale.h"
   }
+  module "setjmp.h" {
+    export *
+    header "setjmp.h"
+  }
   module "math.h" {
     export *
     header "math.h"

--- a/build/unix/module.modulemap
+++ b/build/unix/module.modulemap
@@ -22,7 +22,6 @@ module ROOT_Types {
   module "RConfigure.h" { textual header "RConfigure.h" export * }
   module "RVersion.h" { textual header "RVersion.h" export * }
   // This should go in RConfig.h as it defines macros.
-  module "TException.h" { textual header "TException.h" export * }
   export *
 }
 
@@ -46,6 +45,7 @@ module ROOT_Core_Config_C {
  exclude header "RtypesImp.h"
  module "Rtypes.h" { header "Rtypes.h" export * }
  module "DllImport.h" { header "DllImport.h" export * } // Should merge in RConfig.h.
+ module "TException.h" { header "TException.h" export * }
  module "TGenericClassInfo.h" { header "TGenericClassInfo.h" export * }
  module "TSchemaHelper.h" { header "TSchemaHelper.h" export * }
  module "RootMetaSelection.h" { header "RootMetaSelection.h" export * }

--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -492,7 +492,7 @@ function (ROOT_CXXMODULES_APPEND_TO_MODULEMAP library library_headers)
                         TSchemaHelper.h ESTLType.h RStringView.h Varargs.h
                         RootMetaSelection.h libcpp_string_view.h
                         RWrap_libcpp_string_view.h
-                        TException.h ThreadLocalStorage.h 
+                        ThreadLocalStorage.h
                         TBranchProxyTemplate.h TGLIncludes.h TGLWSIncludes.h
                         snprintf.h strlcpy.h")
 


### PR DESCRIPTION
We currently have two ODR errors when using modules. One is when
using setjmp, the other is coming from TException. This patch
makes TException non-textual and moves it to the config module
to prevent cyclic dependencies. We also add setjmp to the
modulemap to fix the ODR errors on the setjmp struct.