### PR TITLE
[WIP] Adapt ROOT::Fit::Fitter to work with templated gradient functions.

### DIFF
--- a/math/mathcore/inc/Fit/Fitter.h
+++ b/math/mathcore/inc/Fit/Fitter.h
@@ -83,8 +83,10 @@ public:
    using IModelFunctionTempl =                             ROOT::Math::IParamMultiFunctionTempl<T>;
 #ifdef R__HAS_VECCORE
    typedef ROOT::Math::IParametricFunctionMultiDimTempl<ROOT::Double_v>  IModelFunction_v;
+   typedef ROOT::Math::IParamMultiGradFunctionTempl<ROOT::Double_v> IGradModelFunction_v;
 #else
    typedef ROOT::Math::IParamMultiFunction                 IModelFunction_v;
+   typedef ROOT::Math::IParamMultiGradFunction IGradModelFunction_v;
 #endif
    typedef ROOT::Math::IParamMultiGradFunction             IGradModelFunction;
    typedef ROOT::Math::IParamFunction                      IModel1DFunction;
@@ -132,8 +134,13 @@ public:
        Pre-requisite on the function:
        it must implement the 1D or multidimensional parametric function interface
    */
-   template < class Data , class Function, class cond = typename std::enable_if<!(std::is_same<Function, int>::value), Function>::type>
-   bool Fit( const Data & data, const Function & func, const ROOT::Fit::ExecutionPolicy &executionPolicy = ROOT::Fit::ExecutionPolicy::kSerial) {
+   template <class Data, class Function,
+             class cond = typename std::enable_if<!(std::is_same<Function, ROOT::Fit::ExecutionPolicy>::value ||
+                                                    std::is_same<Function, int>::value),
+                                                  Function>::type>
+   bool Fit(const Data &data, const Function &func,
+            const ROOT::Fit::ExecutionPolicy &executionPolicy = ROOT::Fit::ExecutionPolicy::kSerial)
+   {
       SetFunction(func);
       return Fit(data, executionPolicy);
    }
@@ -332,7 +339,10 @@ public:
    */
 #ifdef R__HAS_VECCORE
    template <class NotCompileIfScalarBackend = std::enable_if<!(std::is_same<double, ROOT::Double_v>::value)>>
-   void SetFunction(const IModelFunction_v &func);
+   void SetFunction(const IModelFunction_v &func, bool useGradient = false);
+
+   template <class NotCompileIfScalarBackend = std::enable_if<!(std::is_same<double, ROOT::Double_v>::value)>>
+   void SetFunction(const IGradModelFunction_v &func, bool useGradient = true);
 #endif
    /**
       Set the fitted function from a parametric 1D function interface
@@ -525,12 +535,38 @@ bool Fitter::GetDataFromFCN()  {
 
 #ifdef R__HAS_VECCORE
 template <class NotCompileIfScalarBackend>
-void Fitter::SetFunction(const IModelFunction_v &func)
+void Fitter::SetFunction(const IModelFunction_v &func, bool useGradient)
 {
+   fUseGradient = useGradient;
+   if (fUseGradient) {
+      const IGradModelFunction_v *gradFunc = dynamic_cast<const IGradModelFunction_v *>(&func);
+      if (gradFunc) {
+         SetFunction(*gradFunc, true);
+         return;
+      } else {
+         MATH_WARN_MSG("Fitter::SetFunction",
+                       "Requested function does not provide gradient - use it as non-gradient function ");
+      }
+   }
+
    //  set the fit model function (clone the given one and keep a copy )
-   // std::cout << "set a non-grad function" << std::endl;
+   //  std::cout << "set a non-grad function" << std::endl;
    fUseGradient = false;
    fFunc_v = std::shared_ptr<IModelFunction_v>(dynamic_cast<IModelFunction_v *>(func.Clone()));
+   assert(fFunc_v);
+
+   // creates the parameter  settings
+   fConfig.CreateParamsSettings(*fFunc_v);
+   fFunc.reset();
+}
+
+template <class NotCompileIfScalarBackend>
+void Fitter::SetFunction(const IGradModelFunction_v &func, bool useGradient)
+{
+   fUseGradient = useGradient;
+
+   //  set the fit model function (clone the given one and keep a copy )
+   fFunc_v = std::shared_ptr<IModelFunction_v>(dynamic_cast<IGradModelFunction_v *>(func.Clone()));
    assert(fFunc_v);
 
    // creates the parameter  settings

--- a/math/mathcore/src/Fitter.cxx
+++ b/math/mathcore/src/Fitter.cxx
@@ -327,27 +327,23 @@ bool Fitter::EvalFCN() {
    return true;
 }
 
-
-bool Fitter::DoLeastSquareFit(const ROOT::Fit::ExecutionPolicy &executionPolicy) {
+bool Fitter::DoLeastSquareFit(const ROOT::Fit::ExecutionPolicy &executionPolicy)
+{
 
    // perform a chi2 fit on a set of binned data
    std::shared_ptr<BinData> data = std::dynamic_pointer_cast<BinData>(fData);
    assert(data);
 
    // check function
-   if (!fFunc ) {
-      if (!fFunc_v ) {
-         MATH_ERROR_MSG("Fitter::DoLeastSquareFit","model function is not set");
-         return false;
-      } else{
-         Chi2FCN<BaseFunc, IModelFunction_v> chi2(data, fFunc_v, executionPolicy);
-         fFitType = chi2.Type();
-         return DoMinimization (chi2);
-     }
+   if (!fFunc && !fFunc_v) {
+      MATH_ERROR_MSG("Fitter::DoLeastSquareFit", "model function is not set");
+      return false;
    } else {
 
 #ifdef DEBUG
-   std::cout << "Fitter ParamSettings " << Config().ParamsSettings()[3].IsBound() << " lower limit " <<  Config().ParamsSettings()[3].LowerLimit() << " upper limit " <<  Config().ParamsSettings()[3].UpperLimit() << std::endl;
+      std::cout << "Fitter ParamSettings " << Config().ParamsSettings()[3].IsBound() << " lower limit "
+                << Config().ParamsSettings()[3].LowerLimit() << " upper limit "
+                << Config().ParamsSettings()[3].UpperLimit() << std::endl;
 #endif
 
       fBinFit = true;
@@ -355,56 +351,69 @@ bool Fitter::DoLeastSquareFit(const ROOT::Fit::ExecutionPolicy &executionPolicy)
       // check if fFunc provides gradient
       if (!fUseGradient) {
          // do minimzation without using the gradient
-         Chi2FCN<BaseFunc> chi2(data,fFunc, executionPolicy);
-         fFitType = chi2.Type();
-         return DoMinimization (chi2);
-      }
-      else {
+         if (fFunc_v) {
+            Chi2FCN<BaseFunc, IModelFunction_v> chi2(data, fFunc_v, executionPolicy);
+            fFitType = chi2.Type();
+            return DoMinimization(chi2);
+         } else {
+            Chi2FCN<BaseFunc> chi2(data, fFunc, executionPolicy);
+            fFitType = chi2.Type();
+            return DoMinimization(chi2);
+         }
+      } else {
          // use gradient
          if (fConfig.MinimizerOptions().PrintLevel() > 0)
-            MATH_INFO_MSG("Fitter::DoLeastSquareFit","use gradient from model function");
-         std::shared_ptr<IGradModelFunction> gradFun = std::dynamic_pointer_cast<IGradModelFunction>(fFunc);
-         if (gradFun) {
-            Chi2FCN<BaseGradFunc> chi2(data,gradFun);
-            fFitType = chi2.Type();
-            return DoMinimization (chi2);
+            MATH_INFO_MSG("Fitter::DoLeastSquareFit", "use gradient from model function");
+
+         if (fFunc_v) {
+            std::shared_ptr<IGradModelFunction_v> gradFun = std::dynamic_pointer_cast<IGradModelFunction_v>(fFunc_v);
+            if (gradFun) {
+               Chi2FCN<BaseGradFunc, IModelFunction_v> chi2(data, gradFun);
+               fFitType = chi2.Type();
+               return DoMinimization(chi2);
+            }
+         } else {
+            std::shared_ptr<IGradModelFunction> gradFun = std::dynamic_pointer_cast<IGradModelFunction>(fFunc);
+            if (gradFun) {
+               Chi2FCN<BaseGradFunc> chi2(data, gradFun);
+               fFitType = chi2.Type();
+               return DoMinimization(chi2);
+            }
          }
-         MATH_ERROR_MSG("Fitter::DoLeastSquareFit","wrong type of function - it does not provide gradient");
+         MATH_ERROR_MSG("Fitter::DoLeastSquareFit", "wrong type of function - it does not provide gradient");
       }
-  }
-  return false;
+   }
+   return false;
 }
 
-bool Fitter::DoBinnedLikelihoodFit(bool extended, const ROOT::Fit::ExecutionPolicy &executionPolicy) {
+bool Fitter::DoBinnedLikelihoodFit(bool extended, const ROOT::Fit::ExecutionPolicy &executionPolicy)
+{
    // perform a likelihood fit on a set of binned data
    // The fit is extended (Poisson logl_ by default
 
    std::shared_ptr<BinData> data = std::dynamic_pointer_cast<BinData>(fData);
    assert(data);
 
-   bool  useWeight = fConfig.UseWeightCorrection();
+   bool useWeight = fConfig.UseWeightCorrection();
 
    // check function
-   if (!fFunc)
-      if (!fFunc_v) {
-         MATH_ERROR_MSG("Fitter::DoBinnedLikelihoodFit", "model function is not set");
-         return false;
-      }
+   if (!fFunc && !fFunc_v) {
+      MATH_ERROR_MSG("Fitter::DoBinnedLikelihoodFit", "model function is not set");
+      return false;
+   }
 
    // logl fit (error should be 0.5) set if different than default values (of 1)
-   if (fConfig.MinimizerOptions().ErrorDef() == gDefaultErrorDef ) {
+   if (fConfig.MinimizerOptions().ErrorDef() == gDefaultErrorDef) {
       fConfig.MinimizerOptions().SetErrorDef(0.5);
    }
 
-   if (useWeight && fConfig.MinosErrors() ) {
-      MATH_INFO_MSG("Fitter::DoBinnedLikelihoodFit","MINOS errors cannot be computed in weighted likelihood fits");
+   if (useWeight && fConfig.MinosErrors()) {
+      MATH_INFO_MSG("Fitter::DoBinnedLikelihoodFit", "MINOS errors cannot be computed in weighted likelihood fits");
       fConfig.SetMinosErrors(false);
    }
 
-
    fBinFit = true;
    fDataSize = data->Size();
-
 
    if (!fUseGradient) {
       // do minimization without using the gradient
@@ -414,10 +423,12 @@ bool Fitter::DoBinnedLikelihoodFit(bool extended, const ROOT::Fit::ExecutionPoli
          PoissonLikelihoodFCN<BaseFunc, IModelFunction_v> logl(data, fFunc_v, useWeight, extended, executionPolicy);
          fFitType = logl.Type();
          // do minimization
-         if (!DoMinimization(logl, &chi2)) return false;
+         if (!DoMinimization(logl, &chi2))
+            return false;
          if (useWeight) {
             logl.UseSumOfWeightSquare();
-            if (!ApplyWeightCorrection(logl)) return false;
+            if (!ApplyWeightCorrection(logl))
+               return false;
          }
       } else {
          // create a chi2 function to be used for the equivalent chi-square
@@ -425,40 +436,64 @@ bool Fitter::DoBinnedLikelihoodFit(bool extended, const ROOT::Fit::ExecutionPoli
          PoissonLikelihoodFCN<BaseFunc> logl(data, fFunc, useWeight, extended, executionPolicy);
          fFitType = logl.Type();
          // do minimization
-         if (!DoMinimization(logl, &chi2)) return false;
+         if (!DoMinimization(logl, &chi2))
+            return false;
          if (useWeight) {
             logl.UseSumOfWeightSquare();
-            if (!ApplyWeightCorrection(logl)) return false;
+            if (!ApplyWeightCorrection(logl))
+               return false;
          }
       }
    } else {
-      // create a chi2 function to be used for the equivalent chi-square
-      Chi2FCN<BaseFunc> chi2(data, fFunc);
-      if (fConfig.MinimizerOptions().PrintLevel() > 0)
-         MATH_INFO_MSG("Fitter::DoLikelihoodFit","use gradient from model function");
-      // check if fFunc provides gradient
-      std::shared_ptr<IGradModelFunction> gradFun = std::dynamic_pointer_cast<IGradModelFunction>(fFunc);
-      if (!gradFun) {
-         MATH_ERROR_MSG("Fitter::DoBinnedLikelihoodFit","wrong type of function - it does not provide gradient");
-         return false;
-      }
-      // use gradient for minimization
-      // not-extended is not impelemented in this case
-      if (!extended) {
-         MATH_WARN_MSG("Fitter::DoBinnedLikelihoodFit","Not-extended binned fit with gradient not yet supported - do an extended fit");
-      }
-      PoissonLikelihoodFCN<BaseGradFunc> logl(data, gradFun, useWeight, true, executionPolicy);
-      fFitType = logl.Type();
-      // do minimization
-      if (!DoMinimization (logl, &chi2) ) return false;
-      if (useWeight) {
-         logl.UseSumOfWeightSquare();
-         if (!ApplyWeightCorrection(logl) ) return false;
+      if (fFunc_v) {
+         // create a chi2 function to be used for the equivalent chi-square
+         Chi2FCN<BaseFunc, IModelFunction_v> chi2(data, fFunc_v);
+         std::shared_ptr<IGradModelFunction_v> gradFun = std::dynamic_pointer_cast<IGradModelFunction_v>(fFunc_v);
+         if (!gradFun) {
+            MATH_ERROR_MSG("Fitter::DoBinnedLikelihoodFit", "wrong type of function - it does not provide gradient");
+            return false;
+         }
+         PoissonLikelihoodFCN<BaseGradFunc, IModelFunction_v> logl(data, gradFun, useWeight, true, executionPolicy);
+         fFitType = logl.Type();
+         // do minimization
+         if (!DoMinimization(logl, &chi2))
+            return false;
+         if (useWeight) {
+            logl.UseSumOfWeightSquare();
+            if (!ApplyWeightCorrection(logl))
+               return false;
+         }
+      } else {
+         // create a chi2 function to be used for the equivalent chi-square
+         Chi2FCN<BaseFunc> chi2(data, fFunc);
+         if (fConfig.MinimizerOptions().PrintLevel() > 0)
+            MATH_INFO_MSG("Fitter::DoLikelihoodFit", "use gradient from model function");
+         // check if fFunc provides gradient
+         std::shared_ptr<IGradModelFunction> gradFun = std::dynamic_pointer_cast<IGradModelFunction>(fFunc);
+         if (!gradFun) {
+            MATH_ERROR_MSG("Fitter::DoBinnedLikelihoodFit", "wrong type of function - it does not provide gradient");
+            return false;
+         }
+         // use gradient for minimization
+         // not-extended is not impelemented in this case
+         if (!extended) {
+            MATH_WARN_MSG("Fitter::DoBinnedLikelihoodFit",
+                          "Not-extended binned fit with gradient not yet supported - do an extended fit");
+         }
+         PoissonLikelihoodFCN<BaseGradFunc> logl(data, gradFun, useWeight, true, executionPolicy);
+         fFitType = logl.Type();
+         // do minimization
+         if (!DoMinimization(logl, &chi2))
+            return false;
+         if (useWeight) {
+            logl.UseSumOfWeightSquare();
+            if (!ApplyWeightCorrection(logl))
+               return false;
+         }
       }
    }
    return true;
 }
-
 
 bool Fitter::DoUnbinnedLikelihoodFit(bool extended, const ROOT::Fit::ExecutionPolicy &executionPolicy) {
    // perform a likelihood fit on a set of unbinned data
@@ -468,8 +503,7 @@ bool Fitter::DoUnbinnedLikelihoodFit(bool extended, const ROOT::Fit::ExecutionPo
 
    bool useWeight = fConfig.UseWeightCorrection();
 
-   if (!fFunc)
-     if(!fFunc_v) {
+   if (!fFunc && !fFunc_v) {
       MATH_ERROR_MSG("Fitter::DoUnbinnedLikelihoodFit","model function is not set");
       return false;
    }
@@ -517,23 +551,50 @@ bool Fitter::DoUnbinnedLikelihoodFit(bool extended, const ROOT::Fit::ExecutionPo
      }
    } else {
       // use gradient : check if fFunc provides gradient
-      if (fConfig.MinimizerOptions().PrintLevel() > 0)
-         MATH_INFO_MSG("Fitter::DoUnbinnedLikelihoodFit","use gradient from model function");
-      std::shared_ptr<IGradModelFunction>  gradFun = std::dynamic_pointer_cast<IGradModelFunction>(fFunc);
-      if (gradFun) {
-         if (extended) {
-            MATH_WARN_MSG("Fitter::DoUnbinnedLikelihoodFit","Extended unbinned fit with gradient not yet supported - do a not-extended fit");
+      if (fFunc_v) {
+         if (fConfig.MinimizerOptions().PrintLevel() > 0)
+            MATH_INFO_MSG("Fitter::DoUnbinnedLikelihoodFit", "use gradient from model function");
+         std::shared_ptr<IGradModelFunction_v> gradFun = std::dynamic_pointer_cast<IGradModelFunction_v>(fFunc_v);
+         if (gradFun) {
+            if (extended) {
+               MATH_WARN_MSG("Fitter::DoUnbinnedLikelihoodFit",
+                             "Extended unbinned fit with gradient not yet supported - do a not-extended fit");
+            }
+            LogLikelihoodFCN<BaseGradFunc, IModelFunction_v> logl(data, gradFun, useWeight, extended);
+            fFitType = logl.Type();
+            if (!DoMinimization(logl))
+               return false;
+            if (useWeight) {
+               logl.UseSumOfWeightSquare();
+               if (!ApplyWeightCorrection(logl))
+                  return false;
+            }
+            return true;
          }
-         LogLikelihoodFCN<BaseGradFunc> logl(data,gradFun,useWeight, extended);
-         fFitType = logl.Type();
-         if (!DoMinimization (logl) ) return false;
-         if (useWeight) {
-            logl.UseSumOfWeightSquare();
-            if (!ApplyWeightCorrection(logl) ) return false;
+         MATH_ERROR_MSG("Fitter::DoUnbinnedLikelihoodFit", "wrong type of function - it does not provide gradient");
+
+      } else {
+         if (fConfig.MinimizerOptions().PrintLevel() > 0)
+            MATH_INFO_MSG("Fitter::DoUnbinnedLikelihoodFit", "use gradient from model function");
+         std::shared_ptr<IGradModelFunction> gradFun = std::dynamic_pointer_cast<IGradModelFunction>(fFunc);
+         if (gradFun) {
+            if (extended) {
+               MATH_WARN_MSG("Fitter::DoUnbinnedLikelihoodFit",
+                             "Extended unbinned fit with gradient not yet supported - do a not-extended fit");
+            }
+            LogLikelihoodFCN<BaseGradFunc> logl(data, gradFun, useWeight, extended);
+            fFitType = logl.Type();
+            if (!DoMinimization(logl))
+               return false;
+            if (useWeight) {
+               logl.UseSumOfWeightSquare();
+               if (!ApplyWeightCorrection(logl))
+                  return false;
+            }
+            return true;
          }
-         return true;
+         MATH_ERROR_MSG("Fitter::DoUnbinnedLikelihoodFit", "wrong type of function - it does not provide gradient");
       }
-      MATH_ERROR_MSG("Fitter::DoUnbinnedLikelihoodFit","wrong type of function - it does not provide gradient");
    }
    return false;
 }
@@ -939,4 +1000,3 @@ void Fitter::ExamineFCN()  {
    } // end namespace Fit
 
 } // end namespace ROOT
-

--- a/math/mathcore/test/CMakeLists.txt
+++ b/math/mathcore/test/CMakeLists.txt
@@ -81,3 +81,6 @@ ROOT_ADD_GTEST(stressMathCoreUnit stress/testSMatrix.cxx stress/testGenVector.cx
 
 ROOT_ADD_GTEST(GradientUnit testGradient.cxx
        LIBRARIES Core MathCore Hist RIO Tree GenVector)
+
+ROOT_ADD_GTEST(GradientFittingUnit testGradientFitting.cxx
+      LIBRARIES Core MathCore Hist RIO Tree GenVector)

--- a/math/mathcore/test/testGradientFitting.cxx
+++ b/math/mathcore/test/testGradientFitting.cxx
@@ -1,0 +1,174 @@
+// @(#)root/test:$Id$
+// Author: Alejandro García Montoro 08/2017
+
+#include "Fit/BinData.h"
+#include "Fit/UnBinData.h"
+#include "Fit/Fitter.h"
+#include "HFitInterface.h"
+#include "TH2.h"
+#include "TF2.h"
+
+#include "gtest/gtest.h"
+
+#include <iostream>
+#include <string>
+
+// Gradient 2D function
+template <class T>
+class GradFunc2D : public ROOT::Math::IParamMultiGradFunctionTempl<T> {
+public:
+   void SetParameters(const double *p) { std::copy(p, p + NPar(), fParameters); }
+
+   const double *Parameters() const { return fParameters; }
+
+   ROOT::Math::IBaseFunctionMultiDimTempl<T> *Clone() const
+   {
+      GradFunc2D<T> *f = new GradFunc2D<T>();
+      f->SetParameters(fParameters);
+      return f;
+   }
+
+   unsigned int NDim() const { return 2; }
+
+   unsigned int NPar() const { return 5; }
+
+   void ParameterGradient(const T *x, const double *, T *grad) const
+   {
+      grad[0] = x[0] * x[0];
+      grad[1] = x[0];
+      grad[2] = x[1] * x[1];
+      grad[3] = x[1];
+      grad[4] = 1;
+   }
+
+private:
+   T DoEvalPar(const T *x, const double *p) const
+   {
+      return p[0] * x[0] * x[0] + p[1] * x[0] + p[2] * x[1] * x[1] + p[3] * x[1] + p[4];
+   }
+
+   T DoParameterDerivative(const T *x, const double *p, unsigned int ipar) const
+   {
+      std::vector<T> grad(NPar());
+      ParameterGradient(x, p, &grad[0]);
+      return grad[ipar];
+   }
+
+   double fParameters[5];
+};
+
+template <typename U, typename V>
+struct GradientFittingTestTraits {
+   using DataType = U;
+   using FittingDataType = V;
+};
+
+// Typedefs of GradientTestTraits for scalar (binned and unbinned) data
+using ScalarBinned = GradientFittingTestTraits<Double_t, ROOT::Fit::BinData>;
+using ScalarUnBinned = GradientFittingTestTraits<Double_t, ROOT::Fit::UnBinData>;
+
+// Typedefs of GradientTestTraits for vectorial (binned and unbinned) data
+#ifdef R__HAS_VECCORE
+using VectorialBinned = GradientFittingTestTraits<ROOT::Double_v, ROOT::Fit::BinData>;
+using VectorialUnBinned = GradientFittingTestTraits<ROOT::Double_v, ROOT::Fit::UnBinData>;
+#endif
+
+template <class T>
+class GradientFittingTest : public ::testing::Test {
+protected:
+   virtual void SetUp()
+   {
+      // Create TF2 from model function and initialize the fit function
+      std::stringstream streamTF2;
+      streamTF2 << "f" << this;
+      std::string nameTF2 = streamTF2.str();
+
+      GradFunc2D<typename T::DataType> fitFunction;
+      fFunction = new TF2(nameTF2.c_str(), fitFunction, 0., 10., 0, 10, 5);
+      double p0[5] = {1., 2., 0.5, 1., 3.};
+      fFunction->SetParameters(p0);
+      assert(fFunction->GetNpar() == 5);
+
+      // Assure the to-be-created histogram does not replace an old one
+      std::stringstream streamTH1;
+      streamTH1 << "h" << this;
+      std::string nameTH2 = streamTH1.str();
+
+      auto oldTH2 = gROOT->FindObject(nameTH2.c_str());
+      if (oldTH2)
+         delete oldTH2;
+
+      fHistogram = new TH2D(nameTH2.c_str(), nameTH2.c_str(), fNumPoints, 0, 10., 30, 0., 10.);
+
+      // Fill the histogram
+      for (int i = 0; i < 10000; ++i) {
+         double x, y = 0;
+         fFunction->GetRandom2(x, y);
+         fHistogram->Fill(x, y);
+      }
+
+      // Fill the binned or unbinned data
+      FillData();
+
+      // Create the function
+      GradFunc2D<typename T::DataType> function;
+
+      double p[5] = {2., 1., 1, 2., 100.};
+      function.SetParameters(p);
+
+      // Create the fitter from the function
+      fFitter.SetFunction(function);
+      fFitter.Config().SetMinimizer("Minuit");
+   }
+
+   // Fill binned data
+   template <class U = typename T::FittingDataType>
+   typename std::enable_if<std::is_same<U, typename T::FittingDataType>::value &&
+                           std::is_same<U, ROOT::Fit::BinData>::value>::type
+   FillData()
+   {
+      // fill fit data
+      fData = new ROOT::Fit::BinData(fNumPoints, 2);
+      ROOT::Fit::FillData(*fData, fHistogram, fFunction);
+   }
+
+   // Fill unbinned data
+   template <class U = typename T::FittingDataType>
+   typename std::enable_if<std::is_same<U, typename T::FittingDataType>::value &&
+                           std::is_same<U, ROOT::Fit::UnBinData>::value>::type
+   FillData()
+   {
+      fData = new ROOT::Fit::UnBinData(fNumPoints, 2);
+
+      TAxis *x = fHistogram->GetXaxis();
+      TAxis *y = fHistogram->GetYaxis();
+
+      for (unsigned i = 0; i < fNumPoints; i++)
+         fData->Add(x->GetBinCenter(i), y->GetBinCenter(i));
+   }
+
+   TF2 *fFunction;
+   typename T::FittingDataType *fData;
+   TH2D *fHistogram;
+   ROOT::Fit::Fitter fFitter;
+
+   static const unsigned fNumPoints = 6801;
+};
+
+// Types used by Google Test to instantiate the tests.
+#ifdef R__HAS_VECCORE
+typedef ::testing::Types<ScalarBinned, ScalarUnBinned, VectorialBinned, VectorialUnBinned> TestTypes;
+#else
+typedef ::testing::Types<ScalarBinned, ScalarUnBinned> TestTypes;
+#endif
+
+// Declare that the GradientFittingTest class should be instantiated with the types defined by TestTypes
+TYPED_TEST_CASE(GradientFittingTest, TestTypes);
+
+// Test the fitting using the gradient is successful
+TYPED_TEST(GradientFittingTest, GradientFitting)
+{
+   // TestFixture::fFitter.Config().MinimizerOptions().SetPrintLevel(3);
+   EXPECT_TRUE(TestFixture::fFitter.Fit(*TestFixture::fData));
+   TestFixture::fFitter.Result().Print(std::cout);
+}


### PR DESCRIPTION
Fitter class can now receive vectorized gradient functions; i.e., `IParamMultiGradFunctionTempl<ROOT::Double_v>` objects.

TODO:
 - [ ] Fix the failing test.