### PR TITLE
Improve finding of Fortran compiler

### DIFF
--- a/cmake/modules/CheckCompiler.cmake
+++ b/cmake/modules/CheckCompiler.cmake
@@ -9,9 +9,23 @@ if(fortran)
   if(DEFINED CMAKE_Fortran_COMPILER AND CMAKE_Fortran_COMPILER MATCHES "^$")
     set(CMAKE_Fortran_COMPILER CMAKE_Fortran_COMPILER-NOTFOUND)
   endif()
-  check_language(Fortran)
   if(CMAKE_Fortran_COMPILER)
+    # CMAKE_Fortran_COMPILER has already been defined somewhere else, so
+    # just check whether it contains a valid compiler
     enable_language(Fortran)
+  else()
+    # CMAKE_Fortran_COMPILER has not been defined, so first check whether
+    # there is a Fortran compiler at all
+    check_language(Fortran)
+    if(CMAKE_Fortran_COMPILER)
+      # Fortran compiler found, however as 'check_language' was executed
+      # in a separate process, the result might not be compatible with
+      # the C++ compiler, so reset the variable, ...
+      unset(CMAKE_Fortran_COMPILER CACHE)
+      # ..., and enable Fortran again, this time prefering compilers
+      # compatible to the C++ compiler
+      enable_language(Fortran)
+    endif()
   endif()
 else()
   set(CMAKE_Fortran_COMPILER CMAKE_Fortran_COMPILER-NOTFOUND)


### PR DESCRIPTION
It turned out that my proposal to fix issue [ROOT-8510](https://sft.its.cern.ch/jira/browse/ROOT-8510) had the side-effect of requiring the environment variable FC to be set to find the correct Fortran compiler under some circumstances. This should now be fixed.

Finding out whether a compiler is found in Cmake seems to be really
hard. In particular a non-found Fortran compiler caused issues on MacOS
(ROOT-8510). The inital check for the compiler was

enable_language(Fortran OPTIONAL)

This does not set the the CMAKE_Fortran_COMPILER variable (or sets it to
NOTFOUND) if a Fortran compiler is not found, but still marks the
Fortran language as being enabled for the current project. This broke
the settings for BLAS/LAPACK.

The second attempt (bb40ede3941d0b4f2db4e23d5f9c32b221eb5fac) was to use

check_language(Fortran)
if(CMAKE_Fortran_COMPILER)
  enable_language(Fortran)
endif()

This does not find the Fortran compiler corresponding to the used C++
compiler. Cmake has some mechanism that if the C++ compiler is a GNU
compiler, it would also prefer GNU Fortran compilers. However, as the
check_language test is running in a separate process it would not know
about the C++ compiler. This is a problem in a set-up with executables
like:

/opt/newgcc/g++
/opt/newgcc/gfortran
/usr/bin/f95 (link to gfortran)
/usr/bin/g++
/usr/bin/gfortran

Two versions of GCC are installed, one by the system, and one more
recent version in a separate directory. The directory to the newer
version is in the environment variable PATH before /usr/bin. In this
case the test from above (second attempt) would use /usr/bin/f95 as the
Fortran compiler, because Cmake usually prefers the executable f95 over
gfortran. This causes problems in case the two Fortran compilers are not
ABI compatible, i.e., gfortran 4.4 installed by the system vs. 4.9 as a
slightly more recent version. A simple enable_language (as in the
initial version) would correctly use /opt/newgcc/gfortran in this case.
This had to be worked around by setting the environment variable
FC=gfortran before running Cmake.

To fix this, check_language is only used to determine whether a Fortran
compiler exists at all. If a compiler is found, then the
CMAKE_Fortran_COMPILER variable is reset, and enable_language again
performs a search of the compiler, this time prefering a compiler from
the same vendor as the C++ compiler.