### PR TITLE
Embed all header files (as zip) in the PCH.

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -4219,6 +4219,8 @@ int RootClingMain(int argc,
    clingArgs.push_back("-fsyntax-only");
    clingArgs.push_back("-fPIC");
    clingArgs.push_back("-Xclang");
+   clingArgs.push_back("-fmodules-embed-all-files");
+   clingArgs.push_back("-Xclang");
    clingArgs.push_back("-main-file-name");
    clingArgs.push_back("-Xclang");
    clingArgs.push_back((dictname + ".h").c_str());
@@ -4264,6 +4266,9 @@ int RootClingMain(int argc,
       interpPtr = owningInterpPtr.get();
    }
    cling::Interpreter &interp = *interpPtr;
+   // FIXME: Remove this once we switch cling to use the driver. This would handle  -fmodules-embed-all-files for us.
+   interp.getCI()->getFrontendOpts().ModulesEmbedAllFiles = true;
+   interp.getCI()->getSourceManager().setAllFilesAreTransient(true);
 
    if (ROOT::TMetaUtils::GetErrorIgnoreLevel() == ROOT::TMetaUtils::kInfo) {
       ROOT::TMetaUtils::Info(0, "\n");

--- a/interpreter/llvm/src/tools/clang/include/clang/Serialization/ASTReader.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/Serialization/ASTReader.h
@@ -709,9 +709,6 @@ private:
   /// added to the global preprocessing entity ID to produce a local ID.
   GlobalPreprocessedEntityMapType GlobalPreprocessedEntityMap;
 
-  /// \brief Known stem mapping for resolveFileThroughHeaderSearch.
-  llvm::StringMap<std::string> HSStemMap;
-
   /// \name CodeGen-relevant special data
   /// \brief Fields containing data that is relevant to CodeGen.
   //@{

--- a/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReader.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReader.cpp
@@ -2131,12 +2131,7 @@ InputFile ASTReader::getInputFile(ModuleFile &F, unsigned ID, bool Complain) {
         Diag(diag::note_pch_rebuild_required) << TopLevelPCHName;
     }
 
-    //IsOutOfDate = true;
-    // Force the match of the file from the live filesystem to the
-    // file in teh PCH. Size and time are used as part of the key;
-    // they must agree on both sides.
-    FileMgr.modifyFileEntry(const_cast<FileEntry*>(File),
-                            StoredSize, StoredTime);
+    IsOutOfDate = true;
   }
   // FIXME: If the file is overridden and we've already opened it,
   // issue an error (or split it into a separate FileEntry).

--- a/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReader.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReader.cpp
@@ -1672,9 +1672,6 @@ bool HeaderFileInfoTrait::EqualKey(internal_key_ref a, internal_key_ref b) {
   if (llvm::sys::path::is_absolute(a.Filename) && a.Filename == b.Filename)
     return true;
 
-  if (StringRef(b.Filename).endswith(a.Filename))
-    return true;
-
   // Determine whether the actual files are equivalent.
   FileManager &FileMgr = Reader.getFileManager();
   auto GetFile = [&](const internal_key_type &Key) -> const FileEntry* {

--- a/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReader.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReader.cpp
@@ -1241,45 +1241,6 @@ bool ASTReader::ReadSourceManagerBlock(ModuleFile &F) {
   }
 }
 
-/// \brief Attempt to resolve the location based on PP header search.
-/// Find the first match with the longest trailing part.
-static StringRef
-resolveFileThroughHeaderSearch(Preprocessor& PP, StringRef Filename) {
-  HeaderSearch& HdrSearch = PP.getHeaderSearchInfo();
-   bool isAbsolute = true;
-   // Find the longest available match.
-   for (llvm::sys::path::const_iterator
-           IDir = llvm::sys::path::begin(Filename),
-           EDir = llvm::sys::path::end(Filename);
-        IDir != EDir; ++IDir) {
-      if (isAbsolute) {
-         // skip "/" part
-         isAbsolute = false;
-         continue;
-      }
-      size_t lenTrailing = Filename.size() - (IDir->data() - Filename.data());
-      llvm::StringRef trailingPart(IDir->data(), lenTrailing);
-      assert(trailingPart.data() + trailingPart.size()
-             == Filename.data() + Filename.size()
-             && "Mismatched partitioning of file name!");
-      const DirectoryLookup* FoundDir = 0;
-      const FileEntry* FE
-        = HdrSearch.LookupFile(trailingPart, SourceLocation(), true/*isAngled*/,
-                               0/*FromDir*/, FoundDir,
-                               ArrayRef<std::pair<const FileEntry *, const DirectoryEntry *>>() /*Includers*/,
-                               0/*Searchpath*/, 0/*RelPath*/,
-                               0/*RequestingModule*/, 0/*SuggestedModule*/,
-                               0/*IsMapped*/,
-                               false /*SkipCache*/,
-                               false /*BuildSystemModule*/,
-                               false /*OpenFile*/,
-                               true /*CacheFailure*/);
-      if (FE)
-        return FE->getName();
-   }
-   return StringRef();
-}
-
 /// \brief If a header file is not found at the path that we expect it to be
 /// and the PCH file was moved from its original location, try to resolve the
 /// file by assuming that header+PCH were moved together and the header is in
@@ -2088,11 +2049,6 @@ InputFile ASTReader::getInputFile(ModuleFile &F, unsigned ID, bool Complain) {
                                                             CurrentDir);
     if (!Resolved.empty())
       File = FileMgr.getFile(Resolved);
-    if (!File) {
-      StringRef PPResolved = resolveFileThroughHeaderSearch(PP, Filename);
-      if (!PPResolved.empty())
-        File = FileMgr.getFile(PPResolved);
-    }
   }
 
   // For an overridden file, create a virtual file with the stored


### PR DESCRIPTION
This should reduce the amount of patches we have in clang making the PCH
relocatable.