### PR TITLE
Revert "Force the caching of file / dir lookup failures (ROOT-6865)."

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/Lex/HeaderSearch.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Lex/HeaderSearch.cpp
@@ -354,7 +354,7 @@ const FileEntry *DirectoryLookup::LookupFile(
     return HS.getFileAndSuggestModule(TmpDir, IncludeLoc, getDir(),
                                       isSystemHeaderDirectory(),
                                       RequestingModule, SuggestedModule,
-                                      OpenFile, true /*CacheFailures*/);
+                                      OpenFile);
   }
 
   if (isFramework())


### PR DESCRIPTION
This is partial revert of the commit in clang.git which is partial due to
conflict resolutions over the years.

It doesn't make sense to pass an extra parameter because it defaults to true
anyway.