### PR TITLE
Revert "Close the file handle if the content comes from a PC[HM]."

### DIFF
--- a/interpreter/llvm/src/tools/clang/include/clang/Basic/FileManager.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/Basic/FileManager.h
@@ -40,7 +40,6 @@ class MemoryBuffer;
 namespace clang {
 
 class FileSystemStatCache;
-class HeaderSearch;
 
 /// \brief Cached information about one directory (either on disk or in
 /// the virtual file system).
@@ -59,6 +58,8 @@ public:
 /// If the 'File' member is valid, then this FileEntry has an open file
 /// descriptor for the file.
 class FileEntry {
+  friend class FileManager;
+
   StringRef Name;             // Name of the file.
   std::string RealPathName;   // Real path to the file; could be empty.
   off_t Size;                 // File size in bytes.
@@ -72,8 +73,6 @@ class FileEntry {
 
   /// \brief The open file, if it is owned by the \p FileEntry.
   mutable std::unique_ptr<vfs::File> File;
-  friend class FileManager;
-  friend class HeaderSearch;
 
 public:
   FileEntry()

--- a/interpreter/llvm/src/tools/clang/lib/Lex/HeaderSearch.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Lex/HeaderSearch.cpp
@@ -1037,10 +1037,6 @@ HeaderFileInfo &HeaderSearch::getFileInfo(const FileEntry *FE) {
       mergeHeaderFileInfo(*HFI, ExternalHFI);
   }
 
-  // Is the file open even though its content comes from an external source?
-  if (HFI->External && FE->File)
-    FE->closeFile();
-
   HFI->IsValid = true;
   // We have local information about this header file, so it's no longer
   // strictly external.
@@ -1062,11 +1058,6 @@ HeaderSearch::getExistingFileInfo(const FileEntry *FE,
     }
 
     HFI = &FileInfo[FE->getUID()];
-
-    // Is the file open even though its content comes from an external source?
-    if (HFI->External && FE->File)
-       FE->closeFile();
-
     if (!WantExternal && (!HFI->IsValid || HFI->External))
       return nullptr;
     if (!HFI->Resolved) {


### PR DESCRIPTION
It looks like we do not overrun file handles on osx.