### PR TITLE
Add padding to all vectors in FitData and its children

### DIFF
--- a/math/mathcore/inc/Fit/FitData.h
+++ b/math/mathcore/inc/Fit/FitData.h
@@ -24,6 +24,7 @@ Classes for describing the input data for fitting
 
 #include "Fit/DataOptions.h"
 #include "Fit/DataRange.h"
+#include "Math/Math_vectypes.hxx"
 
 #include <vector>
 #include <cassert>
@@ -183,7 +184,7 @@ namespace ROOT {
             fCoordsPtr.resize(fDim);
 
             for (unsigned int i = 0; i < fDim; i++) {
-               fCoords[i].resize(fMaxPoints);
+               fCoords[i].resize(fMaxPoints + VectorPadding(fMaxPoints));
                fCoordsPtr[i] = &fCoords[i].front();
             }
 
@@ -350,13 +351,36 @@ namespace ROOT {
             fCoords.resize(fDim);
             for (unsigned int i = 0; i < fDim; i++) {
                assert(fCoordsPtr[i]);
-               fCoords[i].resize(fNPoints);
-               std::copy(fCoordsPtr[i], fCoordsPtr[i] + fNPoints, fCoords[i].begin());
+               unsigned padding = VectorPadding(fNPoints);
+               fCoords[i].resize(fNPoints + padding);
+               std::copy(fCoordsPtr[i], fCoordsPtr[i] + fNPoints + padding, fCoords[i].begin());
                fCoordsPtr[i] = &fCoords[i].front();
             }
 
             fWrapped = false;
          }
+
+#ifdef R__HAS_VECCORE
+         /**
+          * Compute the number that should be added to dataSize in order to have a
+          * multiple of SIMD vector size.
+          */
+         static unsigned VectorPadding(unsigned dataSize)
+         {
+            unsigned padding = 0;
+            unsigned modP = (dataSize) % vecCore::VectorSize<ROOT::Double_v>();
+            if (modP > 0)
+               padding = vecCore::VectorSize<ROOT::Double_v>() - modP;
+            return padding;
+         }
+#else
+         /**
+          * If VecCore is not defined, there is no vectorization available and the SIMD vector
+          * size will always be one. Then, as every number is a multiple of SIMD vector size, the
+          * padding will always be zero.
+          */
+         static constexpr unsigned VectorPadding(const unsigned) { return 0; }
+#endif
 
       protected:
          bool          fWrapped;
@@ -400,4 +424,3 @@ namespace ROOT {
 
 
 #endif /* ROOT_Fit_Data */
-

--- a/math/mathcore/src/BinData.cxx
+++ b/math/mathcore/src/BinData.cxx
@@ -366,8 +366,8 @@ namespace ROOT {
 
       if ( kNoError == fErrorType )
       {
-        fDataError.resize( fNPoints );
-        fDataErrorPtr = &fDataError.front();
+         fDataError.resize(fNPoints + FitData::VectorPadding(fNPoints));
+         fDataErrorPtr = &fDataError.front();
       }
 
       for ( unsigned int i=0; i < fNPoints; i++ )
@@ -627,15 +627,7 @@ namespace ROOT {
 
     void BinData::InitDataVector ()
     {
-#ifdef R__HAS_VECCORE
-       // Add padding to be a multiple of SIMD vector size and help looping
-       auto extraP = 0; 
-       unsigned int modP = (fMaxPoints) % vecCore::VectorSize<ROOT::Double_v>();
-       if (modP > 0) extraP = vecCore::VectorSize<ROOT::Double_v>() - modP; 
-       fData.resize(fMaxPoints + extraP);
-#else
-       fData.resize(fMaxPoints);
-#endif
+       fData.resize(fMaxPoints + FitData::VectorPadding(fMaxPoints));
        fDataPtr = &fData.front();
     }
 
@@ -673,9 +665,9 @@ namespace ROOT {
         fCoordErrors.resize( fDim );
         for( unsigned int i=0; i < fDim; i++ )
         {
-          fCoordErrors[i].resize( fMaxPoints );
+           fCoordErrors[i].resize(fMaxPoints + FitData::VectorPadding(fMaxPoints));
 
-          fCoordErrorsPtr[i] = &fCoordErrors[i].front();
+           fCoordErrorsPtr[i] = &fCoordErrors[i].front();
         }
 
         fpTmpCoordErrorVector = new double[fDim];
@@ -688,24 +680,24 @@ namespace ROOT {
 
       if ( kValueError == fErrorType || kCoordError == fErrorType )
       {
-        fDataError.resize( fMaxPoints );
-        fDataErrorPtr = &fDataError.front();
+         fDataError.resize(fMaxPoints + FitData::VectorPadding(fMaxPoints));
+         fDataErrorPtr = &fDataError.front();
 
-        fDataErrorHigh.clear();
-        fDataErrorHighPtr = NULL;
-        fDataErrorLow.clear();
-        fDataErrorLowPtr = NULL;
+         fDataErrorHigh.clear();
+         fDataErrorHighPtr = NULL;
+         fDataErrorLow.clear();
+         fDataErrorLowPtr = NULL;
       }
       else if ( fErrorType == kAsymError )
       {
-        fDataErrorHigh.resize( fMaxPoints );
-        fDataErrorHighPtr = &fDataErrorHigh.front();
+         fDataErrorHigh.resize(fMaxPoints + FitData::VectorPadding(fMaxPoints));
+         fDataErrorHighPtr = &fDataErrorHigh.front();
 
-        fDataErrorLow.resize( fMaxPoints );
-        fDataErrorLowPtr = &fDataErrorLow.front();
+         fDataErrorLow.resize(fMaxPoints + FitData::VectorPadding(fMaxPoints));
+         fDataErrorLowPtr = &fDataErrorLow.front();
 
-        fDataError.clear();
-        fDataErrorPtr = NULL;
+         fDataError.clear();
+         fDataErrorPtr = NULL;
       }
       else
       {
@@ -719,7 +711,7 @@ namespace ROOT {
 
       for( unsigned int i=0; i<fDim; i++ )
       {
-        fBinEdge[i].reserve( fMaxPoints );
+         fBinEdge[i].reserve(fMaxPoints + FitData::VectorPadding(fMaxPoints));
       }
 
       if ( fpTmpBinEdgeVector )
@@ -744,7 +736,8 @@ namespace ROOT {
       assert( fData.empty() );
       assert( fDataPtr );
 
-      fData.resize( fNPoints );
+      unsigned vectorPadding = FitData::VectorPadding(fNPoints);
+      fData.resize(fNPoints + vectorPadding);
       std::copy( fDataPtr, fDataPtr + fNPoints, fData.begin() );
       fDataPtr = &fData.front();
 
@@ -759,8 +752,8 @@ namespace ROOT {
         assert( fDataError.empty() );
         assert( fDataErrorPtr );
 
-        fDataError.resize( fNPoints );
-        std::copy( fDataErrorPtr, fDataErrorPtr + fNPoints, fDataError.begin() );
+        fDataError.resize(fNPoints + vectorPadding);
+        std::copy(fDataErrorPtr, fDataErrorPtr + fNPoints + vectorPadding, fDataError.begin());
         fDataErrorPtr = &fDataError.front();
       }
 
@@ -778,8 +771,8 @@ namespace ROOT {
         for( unsigned int i=0; i < fDim; i++ )
         {
           assert( fCoordErrorsPtr[i] );
-          fCoordErrors[i].resize( fNPoints );
-          std::copy( fCoordErrorsPtr[i], fCoordErrorsPtr[i] + fNPoints, fCoordErrors[i].begin() );
+          fCoordErrors[i].resize(fNPoints + vectorPadding);
+          std::copy(fCoordErrorsPtr[i], fCoordErrorsPtr[i] + fNPoints + vectorPadding, fCoordErrors[i].begin());
           fCoordErrorsPtr[i] = &fCoordErrors[i].front();
         }
 
@@ -789,10 +782,10 @@ namespace ROOT {
           assert( fDataErrorLow.empty() );
           assert( fDataErrorHighPtr && fDataErrorLowPtr );
 
-          fDataErrorHigh.resize( fNPoints );
-          fDataErrorLow.resize( fNPoints );
-          std::copy( fDataErrorHighPtr, fDataErrorHighPtr + fNPoints, fDataErrorHigh.begin() );
-          std::copy( fDataErrorLowPtr, fDataErrorLowPtr + fNPoints, fDataErrorLow.begin() );
+          fDataErrorHigh.resize(fNPoints + vectorPadding);
+          fDataErrorLow.resize(fNPoints + vectorPadding);
+          std::copy(fDataErrorHighPtr, fDataErrorHighPtr + fNPoints + vectorPadding, fDataErrorHigh.begin());
+          std::copy(fDataErrorLowPtr, fDataErrorLowPtr + fNPoints + vectorPadding, fDataErrorLow.begin());
           fDataErrorHighPtr = &fDataErrorHigh.front();
           fDataErrorLowPtr = &fDataErrorLow.front();
         }
@@ -805,4 +798,3 @@ namespace ROOT {
   } // end namespace Fit
 
 } // end namespace ROOT
-


### PR DESCRIPTION
Until now, in the case where `VecCore` is enabled, only `BinData::fData` was padded to protect vectorized loops against memory access errors. This commit adds the same padding in the case `VecCore` is enabled to all coordinate, data and error vectors of `FitData` family; in particular:
* `FitData::fCoords[i]` (for every `i`)
* `BinData::fCoordErrors[i]` (for every `i`)
* `BinData::fData`, `BinData::fDataError`
* `BinData::fDataErrorHigh`
* `BinData::fDataErrorLow`
* `BinData::fBinEdge[i]` (for every `i`)