### PR TITLE
Range synchronization for histograms filled in parallel in auto-bin mode

### DIFF
--- a/hist/hist/inc/TAxis.h
+++ b/hist/hist/inc/TAxis.h
@@ -138,7 +138,8 @@ public:
                          return (fXbins.GetSize() != 0);
                       }
    virtual void       LabelsOption(Option_t *option="h");  // *MENU*
-           void       RotateTitle(Bool_t rotate=kTRUE); // *TOGGLE* *GETTER=GetRotateTitle
+   virtual void Print(Option_t *) const;
+   void RotateTitle(Bool_t rotate = kTRUE); // *TOGGLE* *GETTER=GetRotateTitle
    virtual void       SaveAttributes(std::ostream &out, const char *name, const char *subname);
    virtual void       Set(Int_t nbins, Double_t xmin, Double_t xmax);
    virtual void       Set(Int_t nbins, const Float_t *xbins);

--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -106,7 +106,7 @@ protected:
     EBinErrorOpt  fBinStatErrOpt;   ///< option for bin statistical errors
     void *fCallbackCtx;             ///<!Context for the function to be called back
     CallbackFunc_t fCallbackFunc;   ///<!Function to be called back, for example to get ranges
-    TString fNameForRanges;         ///<Name to be used to identidy the range
+    TString fNameForRanges;         ///<!Name to be used to identidy the range
     static Int_t  fgBufferSize;     ///<!default buffer size for automatic histograms
     static Bool_t fgAddDirectory;   ///<!flag to add histograms to the directory
     static Bool_t fgStatOverflows;  ///<!flag to use under/overflows in statistics
@@ -114,9 +114,9 @@ protected:
 
     static void *fgCallbackCtx;           ///<!Global context setting for the function to be called back
     static CallbackFunc_t fgCallbackFunc; ///<!Global callback function setting, for example to get ranges
-    static TRWLock fgRefSyncMtx;          ///<Protection of fgRefSync
-    static THashList *fgRefSync;          ///<Range synchronisation information
-    static TString fgStripOffDirs;        ///<Comma/space separated list of tags to be stripped off
+    static TRWLock fgRefSyncMtx;          ///<!Protection of fgRefSync
+    static THashList *fgRefSync;          ///<!Range synchronisation information
+    static TString fgStripOffDirs;        ///<!Comma/space separated list of tags to be stripped off
 
  public:
     static Int_t FitOptionsMake(Option_t *option, Foption_t &Foption);
@@ -470,7 +470,7 @@ protected:
        SetBinError(binx, biny, content);
     }
 
-    ClassDef(TH1, 8) // 1-Dim histogram base class
+    ClassDef(TH1, 7) // 1-Dim histogram base class
 
        protected : virtual Double_t RetrieveBinContent(Int_t bin) const;
     virtual void UpdateBinContent(Int_t bin, Double_t content);

--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -470,7 +470,7 @@ protected:
        SetBinError(binx, biny, content);
     }
 
-    ClassDef(TH1, 7) // 1-Dim histogram base class
+    ClassDef(TH1, 8) // 1-Dim histogram base class
 
        protected : virtual Double_t RetrieveBinContent(Int_t bin) const;
     virtual void UpdateBinContent(Int_t bin, Double_t content);

--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -41,6 +41,8 @@
 
 #include "TFitResultPtr.h"
 
+#include "TRWLock.h"
+
 #include <float.h>
 
 class TF1;
@@ -52,6 +54,7 @@ class TCollection;
 class TVirtualFFT;
 class TVirtualHistPainter;
 
+typedef TList *(*CallbackFunc_t)(void *ctx, TList *buf);
 
 class TH1 : public TNamed, public TAttLine, public TAttFill, public TAttMarker {
 
@@ -101,322 +104,380 @@ protected:
     Double_t     *fIntegral;        ///<!Integral of bins used by GetRandom
     TVirtualHistPainter *fPainter;  ///<!pointer to histogram painter
     EBinErrorOpt  fBinStatErrOpt;   ///< option for bin statistical errors
+    void *fCallbackCtx;             ///<!Context for the function to be called back
+    CallbackFunc_t fCallbackFunc;   ///<!Function to be called back, for example to get ranges
+    TString fNameForRanges;         ///<Name to be used to identidy the range
     static Int_t  fgBufferSize;     ///<!default buffer size for automatic histograms
     static Bool_t fgAddDirectory;   ///<!flag to add histograms to the directory
     static Bool_t fgStatOverflows;  ///<!flag to use under/overflows in statistics
     static Bool_t fgDefaultSumw2;   ///<!flag to call TH1::Sumw2 automatically at histogram creation time
 
-public:
-   static Int_t FitOptionsMake(Option_t *option, Foption_t &Foption);
+    static void *fgCallbackCtx;           ///<!Global context setting for the function to be called back
+    static CallbackFunc_t fgCallbackFunc; ///<!Global callback function setting, for example to get ranges
+    static TRWLock fgRefSyncMtx;          ///<Protection of fgRefSync
+    static THashList *fgRefSync;          ///<Range synchronisation information
+    static TString fgStripOffDirs;        ///<Comma/space separated list of tags to be stripped off
 
-private:
-   Int_t   AxisChoice(Option_t *axis) const;
-   void    Build();
+ public:
+    static Int_t FitOptionsMake(Option_t *option, Foption_t &Foption);
 
-   TH1(const TH1&);
-   TH1& operator=(const TH1&); // Not implemented
+ private:
+    Int_t AxisChoice(Option_t *axis) const;
+    void Build();
 
+    TH1(const TH1 &);
+    TH1 &operator=(const TH1 &); // Not implemented
 
-protected:
-   TH1();
-   TH1(const char *name,const char *title,Int_t nbinsx,Double_t xlow,Double_t xup);
-   TH1(const char *name,const char *title,Int_t nbinsx,const Float_t *xbins);
-   TH1(const char *name,const char *title,Int_t nbinsx,const Double_t *xbins);
-   virtual Int_t    BufferFill(Double_t x, Double_t w);
-   virtual Bool_t   FindNewAxisLimits(const TAxis* axis, const Double_t point, Double_t& newMin, Double_t &newMax);
-   virtual void     SavePrimitiveHelp(std::ostream &out, const char *hname, Option_t *option = "");
-   static Bool_t    RecomputeAxisLimits(TAxis& destAxis, const TAxis& anAxis);
-   static Bool_t    SameLimitsAndNBins(const TAxis& axis1, const TAxis& axis2);
-   Bool_t   IsEmpty() const { return fTsumw == 0 && GetEntries() == 0; } //need to use GetEntries() in case of buffer histograms
+ protected:
+    TH1();
+    TH1(const char *name, const char *title, Int_t nbinsx, Double_t xlow, Double_t xup);
+    TH1(const char *name, const char *title, Int_t nbinsx, const Float_t *xbins);
+    TH1(const char *name, const char *title, Int_t nbinsx, const Double_t *xbins);
+    virtual Int_t BufferFill(Double_t x, Double_t w);
+    virtual Bool_t FindNewAxisLimits(const TAxis *axis, const Double_t point, Double_t &newMin, Double_t &newMax);
+    virtual void SavePrimitiveHelp(std::ostream &out, const char *hname, Option_t *option = "");
+    static Bool_t RecomputeAxisLimits(TAxis &destAxis, const TAxis &anAxis);
+    static Bool_t SameLimitsAndNBins(const TAxis &axis1, const TAxis &axis2);
+    Bool_t IsEmpty() const
+    {
+       return fTsumw == 0 && GetEntries() == 0;
+    } // need to use GetEntries() in case of buffer histograms
 
+    virtual Double_t DoIntegral(Int_t ix1, Int_t ix2, Int_t iy1, Int_t iy2, Int_t iz1, Int_t iz2, Double_t &err,
+                                Option_t *opt, Bool_t doerr = kFALSE) const;
 
-   virtual Double_t DoIntegral(Int_t ix1, Int_t ix2, Int_t iy1, Int_t iy2, Int_t iz1, Int_t iz2, Double_t & err,
-                               Option_t * opt, Bool_t doerr = kFALSE) const;
+    virtual void DoFillN(Int_t ntimes, const Double_t *x, const Double_t *w, Int_t stride = 1);
 
-   virtual void     DoFillN(Int_t ntimes, const Double_t *x, const Double_t *w, Int_t stride=1);
+    virtual void RecalculateAxes(Double_t *b, Int_t n);
+    virtual TList *GetListWithRanges(const char *n);
+    inline TString &GetNameForRanges();
+    virtual Bool_t HasNoLimits();
+    virtual Int_t SetRangesFromList(TList *axl);
 
-   static bool CheckAxisLimits(const TAxis* a1, const TAxis* a2);
-   static bool CheckBinLimits(const TAxis* a1, const TAxis* a2);
-   static bool CheckBinLabels(const TAxis* a1, const TAxis* a2);
-   static bool CheckEqualAxes(const TAxis* a1, const TAxis* a2);
-   static bool CheckConsistentSubAxes(const TAxis *a1, Int_t firstBin1, Int_t lastBin1, const TAxis *a2, Int_t firstBin2=0, Int_t lastBin2=0);
-   static bool CheckConsistency(const TH1* h1, const TH1* h2);
+    static bool CheckAxisLimits(const TAxis *a1, const TAxis *a2);
+    static bool CheckBinLimits(const TAxis *a1, const TAxis *a2);
+    static bool CheckBinLabels(const TAxis *a1, const TAxis *a2);
+    static bool CheckEqualAxes(const TAxis *a1, const TAxis *a2);
+    static bool CheckConsistentSubAxes(const TAxis *a1, Int_t firstBin1, Int_t lastBin1, const TAxis *a2,
+                                       Int_t firstBin2 = 0, Int_t lastBin2 = 0);
+    static bool CheckConsistency(const TH1 *h1, const TH1 *h2);
 
-public:
-   // TH1 status bits
-   enum {
-      kNoStats     = BIT(9),  ///< don't draw stats box
-      kUserContour = BIT(10), ///< user specified contour levels
-    //kCanRebin    = BIT(11), ///< FIXME DEPRECATED - to be removed, replaced by SetCanExtend / CanExtendAllAxes
-      kLogX        = BIT(15), ///< X-axis in log scale
-      kIsZoomed    = BIT(16), ///< bit set when zooming on Y axis
-      kNoTitle     = BIT(17), ///< don't draw the histogram title
-      kIsAverage   = BIT(18), ///< Bin contents are average (used by Add)
-      kIsNotW      = BIT(19)  ///< Histogram is forced to be not weighted even when the histogram is filled with weighted different than 1.
-   };
-   // size of statistics data (size of  array used in GetStats()/ PutStats )
-   // s[0]  = sumw       s[1]  = sumw2
-   // s[2]  = sumwx      s[3]  = sumwx2
-   // s[4]  = sumwy      s[5]  = sumwy2   s[6]  = sumwxy
-   // s[7]  = sumwz      s[8]  = sumwz2   s[9]  = sumwxz   s[10]  = sumwyz
-   // s[11] = sumwt      s[12] = sumwt2                 (11 and 12 used only by TProfile3D)
-   enum {
-      kNstat       = 13  // size of statistics data (up to TProfile3D)
-   };
+ public:
+    // TH1 status bits
+    enum {
+       kNoStats = BIT(9),      ///< don't draw stats box
+       kUserContour = BIT(10), ///< user specified contour levels
+       // kCanRebin    = BIT(11), ///< FIXME DEPRECATED - to be removed, replaced by SetCanExtend / CanExtendAllAxes
+       kLogX = BIT(15),      ///< X-axis in log scale
+       kIsZoomed = BIT(16),  ///< bit set when zooming on Y axis
+       kNoTitle = BIT(17),   ///< don't draw the histogram title
+       kIsAverage = BIT(18), ///< Bin contents are average (used by Add)
+       kIsNotW = BIT(19)     ///< Histogram is forced to be not weighted even when the histogram is filled with weighted
+                             /// different than 1.
+    };
+    // size of statistics data (size of  array used in GetStats()/ PutStats )
+    // s[0]  = sumw       s[1]  = sumw2
+    // s[2]  = sumwx      s[3]  = sumwx2
+    // s[4]  = sumwy      s[5]  = sumwy2   s[6]  = sumwxy
+    // s[7]  = sumwz      s[8]  = sumwz2   s[9]  = sumwxz   s[10]  = sumwyz
+    // s[11] = sumwt      s[12] = sumwt2                 (11 and 12 used only by TProfile3D)
+    enum {
+       kNstat = 13 // size of statistics data (up to TProfile3D)
+    };
 
+    virtual ~TH1();
 
-   virtual ~TH1();
+    virtual Bool_t Add(TF1 *h1, Double_t c1 = 1, Option_t *option = "");
+    virtual Bool_t Add(const TH1 *h1, Double_t c1 = 1);
+    virtual Bool_t Add(const TH1 *h, const TH1 *h2, Double_t c1 = 1, Double_t c2 = 1); // *MENU*
+    virtual void AddBinContent(Int_t bin);
+    virtual void AddBinContent(Int_t bin, Double_t w);
+    static void AddDirectory(Bool_t add = kTRUE);
+    static Bool_t AddDirectoryStatus();
+    virtual void Browse(TBrowser *b);
+    virtual Int_t BufferEmpty(Int_t action = 0);
+    virtual Bool_t CanExtendAllAxes() const;
+    virtual Double_t Chi2Test(const TH1 *h2, Option_t *option = "UU", Double_t *res = 0) const;
+    virtual Double_t Chi2TestX(const TH1 *h2, Double_t &chi2, Int_t &ndf, Int_t &igood, Option_t *option = "UU",
+                               Double_t *res = 0) const;
+    virtual Double_t Chisquare(TF1 *f1, Option_t *option = "") const;
+    virtual void ClearUnderflowAndOverflow();
+    virtual Double_t ComputeIntegral(Bool_t onlyPositive = false);
+    TObject *Clone(const char *newname = 0) const;
+    virtual void Copy(TObject &hnew) const;
+    virtual void DirectoryAutoAdd(TDirectory *);
+    virtual Int_t DistancetoPrimitive(Int_t px, Int_t py);
+    virtual Bool_t Divide(TF1 *f1, Double_t c1 = 1);
+    virtual Bool_t Divide(const TH1 *h1);
+    virtual Bool_t
+    Divide(const TH1 *h1, const TH1 *h2, Double_t c1 = 1, Double_t c2 = 1, Option_t *option = ""); // *MENU*
+    virtual void Draw(Option_t *option = "");
+    virtual TH1 *DrawCopy(Option_t *option = "", const char *name_postfix = "_copy") const;
+    virtual TH1 *DrawNormalized(Option_t *option = "", Double_t norm = 1) const;
+    virtual void DrawPanel(); // *MENU*
+    virtual void Eval(TF1 *f1, Option_t *option = "");
+    virtual void ExecuteEvent(Int_t event, Int_t px, Int_t py);
+    virtual void ExtendAxis(Double_t x, TAxis *axis);
+    virtual TH1 *FFT(TH1 *h_output, Option_t *option);
+    virtual Int_t Fill(Double_t x);
+    virtual Int_t Fill(Double_t x, Double_t w);
+    virtual Int_t Fill(const char *name, Double_t w);
+    virtual void FillN(Int_t ntimes, const Double_t *x, const Double_t *w, Int_t stride = 1);
+    virtual void FillN(Int_t, const Double_t *, const Double_t *, const Double_t *, Int_t) { ; }
+    virtual void FillRandom(const char *fname, Int_t ntimes = 5000);
+    virtual void FillRandom(TH1 *h, Int_t ntimes = 5000);
+    virtual Int_t FindBin(Double_t x, Double_t y = 0, Double_t z = 0);
+    virtual Int_t FindFixBin(Double_t x, Double_t y = 0, Double_t z = 0) const;
+    virtual Int_t FindFirstBinAbove(Double_t threshold = 0, Int_t axis = 1) const;
+    virtual Int_t FindLastBinAbove(Double_t threshold = 0, Int_t axis = 1) const;
+    virtual TObject *FindObject(const char *name) const;
+    virtual TObject *FindObject(const TObject *obj) const;
+    virtual TFitResultPtr Fit(const char *formula, Option_t *option = "", Option_t *goption = "", Double_t xmin = 0,
+                              Double_t xmax = 0); // *MENU*
+    virtual TFitResultPtr
+    Fit(TF1 *f1, Option_t *option = "", Option_t *goption = "", Double_t xmin = 0, Double_t xmax = 0);
+    virtual void FitPanel(); // *MENU*
+    TH1 *GetAsymmetry(TH1 *h2, Double_t c2 = 1, Double_t dc2 = 0);
+    Int_t GetBufferLength() const { return fBuffer ? (Int_t)fBuffer[0] : 0; }
+    Int_t GetBufferSize() const { return fBufferSize; }
+    const Double_t *GetBuffer() const { return fBuffer; }
+    static Int_t GetDefaultBufferSize();
+    virtual Double_t *GetIntegral();
+    TH1 *GetCumulative(Bool_t forward = kTRUE, const char *suffix = "_cumulative") const;
 
-   virtual Bool_t   Add(TF1 *h1, Double_t c1=1, Option_t *option="");
-   virtual Bool_t   Add(const TH1 *h1, Double_t c1=1);
-   virtual Bool_t   Add(const TH1 *h, const TH1 *h2, Double_t c1=1, Double_t c2=1); // *MENU*
-   virtual void     AddBinContent(Int_t bin);
-   virtual void     AddBinContent(Int_t bin, Double_t w);
-   static  void     AddDirectory(Bool_t add=kTRUE);
-   static  Bool_t   AddDirectoryStatus();
-   virtual void     Browse(TBrowser *b);
-   virtual Bool_t   CanExtendAllAxes() const;
-   virtual Double_t Chi2Test(const TH1* h2, Option_t *option = "UU", Double_t *res = 0) const;
-   virtual Double_t Chi2TestX(const TH1* h2, Double_t &chi2, Int_t &ndf, Int_t &igood,Option_t *option = "UU",  Double_t *res = 0) const;
-   virtual Double_t Chisquare(TF1 * f1, Option_t *option = "") const;
-   virtual void     ClearUnderflowAndOverflow();
-   virtual Double_t ComputeIntegral(Bool_t onlyPositive = false);
-   TObject*         Clone(const char* newname=0) const;
-   virtual void     Copy(TObject &hnew) const;
-   virtual void     DirectoryAutoAdd(TDirectory *);
-   virtual Int_t    DistancetoPrimitive(Int_t px, Int_t py);
-   virtual Bool_t   Divide(TF1 *f1, Double_t c1=1);
-   virtual Bool_t   Divide(const TH1 *h1);
-   virtual Bool_t   Divide(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1, Option_t *option=""); // *MENU*
-   virtual void     Draw(Option_t *option="");
-   virtual TH1     *DrawCopy(Option_t *option="", const char * name_postfix = "_copy") const;
-   virtual TH1     *DrawNormalized(Option_t *option="", Double_t norm=1) const;
-   virtual void     DrawPanel(); // *MENU*
-   virtual Int_t    BufferEmpty(Int_t action=0);
-   virtual void     Eval(TF1 *f1, Option_t *option="");
-   virtual void     ExecuteEvent(Int_t event, Int_t px, Int_t py);
-   virtual void     ExtendAxis(Double_t x, TAxis *axis);
-   virtual TH1     *FFT(TH1* h_output, Option_t *option);
-   virtual Int_t    Fill(Double_t x);
-   virtual Int_t    Fill(Double_t x, Double_t w);
-   virtual Int_t    Fill(const char *name, Double_t w);
-   virtual void     FillN(Int_t ntimes, const Double_t *x, const Double_t *w, Int_t stride=1);
-   virtual void     FillN(Int_t, const Double_t *, const Double_t *, const Double_t *, Int_t) {;}
-   virtual void     FillRandom(const char *fname, Int_t ntimes=5000);
-   virtual void     FillRandom(TH1 *h, Int_t ntimes=5000);
-   virtual Int_t    FindBin(Double_t x, Double_t y=0, Double_t z=0);
-   virtual Int_t    FindFixBin(Double_t x, Double_t y=0, Double_t z=0) const;
-   virtual Int_t    FindFirstBinAbove(Double_t threshold=0, Int_t axis=1) const;
-   virtual Int_t    FindLastBinAbove (Double_t threshold=0, Int_t axis=1) const;
-   virtual TObject *FindObject(const char *name) const;
-   virtual TObject *FindObject(const TObject *obj) const;
-   virtual TFitResultPtr    Fit(const char *formula ,Option_t *option="" ,Option_t *goption="", Double_t xmin=0, Double_t xmax=0); // *MENU*
-   virtual TFitResultPtr    Fit(TF1 *f1 ,Option_t *option="" ,Option_t *goption="", Double_t xmin=0, Double_t xmax=0);
-   virtual void     FitPanel(); // *MENU*
-   TH1             *GetAsymmetry(TH1* h2, Double_t c2=1, Double_t dc2=0);
-   Int_t            GetBufferLength() const {return fBuffer ? (Int_t)fBuffer[0] : 0;}
-   Int_t            GetBufferSize  () const {return fBufferSize;}
-   const   Double_t *GetBuffer() const {return fBuffer;}
-   static  Int_t    GetDefaultBufferSize();
-   virtual Double_t *GetIntegral();
-   TH1             *GetCumulative(Bool_t forward = kTRUE, const char* suffix = "_cumulative") const;
+    TList *GetListOfFunctions() const { return fFunctions; }
 
-   TList           *GetListOfFunctions() const { return fFunctions; }
+    virtual Int_t GetNdivisions(Option_t *axis = "X") const;
+    virtual Color_t GetAxisColor(Option_t *axis = "X") const;
+    virtual Color_t GetLabelColor(Option_t *axis = "X") const;
+    virtual Style_t GetLabelFont(Option_t *axis = "X") const;
+    virtual Float_t GetLabelOffset(Option_t *axis = "X") const;
+    virtual Float_t GetLabelSize(Option_t *axis = "X") const;
+    virtual Style_t GetTitleFont(Option_t *axis = "X") const;
+    virtual Float_t GetTitleOffset(Option_t *axis = "X") const;
+    virtual Float_t GetTitleSize(Option_t *axis = "X") const;
+    virtual Float_t GetTickLength(Option_t *axis = "X") const;
+    virtual Float_t GetBarOffset() const { return Float_t(0.001 * Float_t(fBarOffset)); }
+    virtual Float_t GetBarWidth() const { return Float_t(0.001 * Float_t(fBarWidth)); }
+    virtual Int_t GetContour(Double_t *levels = 0);
+    virtual Double_t GetContourLevel(Int_t level) const;
+    virtual Double_t GetContourLevelPad(Int_t level) const;
 
-   virtual Int_t    GetNdivisions(Option_t *axis="X") const;
-   virtual Color_t  GetAxisColor(Option_t *axis="X") const;
-   virtual Color_t  GetLabelColor(Option_t *axis="X") const;
-   virtual Style_t  GetLabelFont(Option_t *axis="X") const;
-   virtual Float_t  GetLabelOffset(Option_t *axis="X") const;
-   virtual Float_t  GetLabelSize(Option_t *axis="X") const;
-   virtual Style_t  GetTitleFont(Option_t *axis="X") const;
-   virtual Float_t  GetTitleOffset(Option_t *axis="X") const;
-   virtual Float_t  GetTitleSize(Option_t *axis="X") const;
-   virtual Float_t  GetTickLength(Option_t *axis="X") const;
-   virtual Float_t  GetBarOffset() const {return Float_t(0.001*Float_t(fBarOffset));}
-   virtual Float_t  GetBarWidth() const  {return Float_t(0.001*Float_t(fBarWidth));}
-   virtual Int_t    GetContour(Double_t *levels=0);
-   virtual Double_t GetContourLevel(Int_t level) const;
-   virtual Double_t GetContourLevelPad(Int_t level) const;
+    virtual Int_t GetBin(Int_t binx, Int_t biny = 0, Int_t binz = 0) const;
+    virtual void GetBinXYZ(Int_t binglobal, Int_t &binx, Int_t &biny, Int_t &binz) const;
+    virtual Double_t GetBinCenter(Int_t bin) const;
+    virtual Double_t GetBinContent(Int_t bin) const;
+    virtual Double_t GetBinContent(Int_t bin, Int_t) const { return GetBinContent(bin); }
+    virtual Double_t GetBinContent(Int_t bin, Int_t, Int_t) const { return GetBinContent(bin); }
+    virtual Double_t GetBinError(Int_t bin) const;
+    virtual Double_t GetBinError(Int_t binx, Int_t biny) const
+    {
+       return GetBinError(GetBin(binx, biny));
+    } // for 2D histograms only
+    virtual Double_t GetBinError(Int_t binx, Int_t biny, Int_t binz) const
+    {
+       return GetBinError(GetBin(binx, biny, binz));
+    } // for 3D histograms only
+    virtual Double_t GetBinErrorLow(Int_t bin) const;
+    virtual Double_t GetBinErrorUp(Int_t bin) const;
+    virtual EBinErrorOpt GetBinErrorOption() const { return fBinStatErrOpt; }
+    virtual Double_t GetBinLowEdge(Int_t bin) const;
+    virtual Double_t GetBinWidth(Int_t bin) const;
+    virtual Double_t
+    GetBinWithContent(Double_t c, Int_t &binx, Int_t firstx = 0, Int_t lastx = 0, Double_t maxdiff = 0) const;
+    virtual void GetCenter(Double_t *center) const;
+    static Bool_t GetDefaultSumw2();
+    TDirectory *GetDirectory() const { return fDirectory; }
+    virtual Double_t GetEntries() const;
+    virtual Double_t GetEffectiveEntries() const;
+    virtual TF1 *GetFunction(const char *name) const;
+    virtual Int_t GetDimension() const { return fDimension; }
+    virtual Double_t GetKurtosis(Int_t axis = 1) const;
+    virtual void GetLowEdge(Double_t *edge) const;
+    virtual Double_t GetMaximum(Double_t maxval = FLT_MAX) const;
+    virtual Int_t GetMaximumBin() const;
+    virtual Int_t GetMaximumBin(Int_t &locmax, Int_t &locmay, Int_t &locmaz) const;
+    virtual Double_t GetMaximumStored() const { return fMaximum; }
+    virtual Double_t GetMinimum(Double_t minval = -FLT_MAX) const;
+    virtual Int_t GetMinimumBin() const;
+    virtual Int_t GetMinimumBin(Int_t &locmix, Int_t &locmiy, Int_t &locmiz) const;
+    virtual Double_t GetMinimumStored() const { return fMinimum; }
+    virtual void GetMinimumAndMaximum(Double_t &min, Double_t &max) const;
+    virtual Double_t GetMean(Int_t axis = 1) const;
+    virtual Double_t GetMeanError(Int_t axis = 1) const;
+    virtual Int_t GetNbinsX() const { return fXaxis.GetNbins(); }
+    virtual Int_t GetNbinsY() const { return fYaxis.GetNbins(); }
+    virtual Int_t GetNbinsZ() const { return fZaxis.GetNbins(); }
+    virtual Int_t GetNcells() const { return fNcells; }
+    virtual Double_t GetNormFactor() const { return fNormFactor; }
+    virtual char *GetObjectInfo(Int_t px, Int_t py) const;
+    Option_t *GetOption() const { return fOption.Data(); }
 
-   virtual Int_t    GetBin(Int_t binx, Int_t biny=0, Int_t binz=0) const;
-   virtual void     GetBinXYZ(Int_t binglobal, Int_t &binx, Int_t &biny, Int_t &binz) const;
-   virtual Double_t GetBinCenter(Int_t bin) const;
-   virtual Double_t GetBinContent(Int_t bin) const;
-   virtual Double_t GetBinContent(Int_t bin, Int_t) const { return GetBinContent(bin); }
-   virtual Double_t GetBinContent(Int_t bin, Int_t, Int_t) const { return GetBinContent(bin); }
-   virtual Double_t GetBinError(Int_t bin) const;
-   virtual Double_t GetBinError(Int_t binx, Int_t biny) const { return GetBinError(GetBin(binx, biny)); } // for 2D histograms only
-   virtual Double_t GetBinError(Int_t binx, Int_t biny, Int_t binz) const { return GetBinError(GetBin(binx, biny, binz)); } // for 3D histograms only
-   virtual Double_t GetBinErrorLow(Int_t bin) const;
-   virtual Double_t GetBinErrorUp(Int_t bin) const;
-   virtual EBinErrorOpt  GetBinErrorOption() const { return fBinStatErrOpt; }
-   virtual Double_t GetBinLowEdge(Int_t bin) const;
-   virtual Double_t GetBinWidth(Int_t bin) const;
-   virtual Double_t GetBinWithContent(Double_t c, Int_t &binx, Int_t firstx=0, Int_t lastx=0,Double_t maxdiff=0) const;
-   virtual void     GetCenter(Double_t *center) const;
-   static  Bool_t   GetDefaultSumw2();
-   TDirectory      *GetDirectory() const {return fDirectory;}
-   virtual Double_t GetEntries() const;
-   virtual Double_t GetEffectiveEntries() const;
-   virtual TF1     *GetFunction(const char *name) const;
-   virtual Int_t    GetDimension() const { return fDimension; }
-   virtual Double_t GetKurtosis(Int_t axis=1) const;
-   virtual void     GetLowEdge(Double_t *edge) const;
-   virtual Double_t GetMaximum(Double_t maxval=FLT_MAX) const;
-   virtual Int_t    GetMaximumBin() const;
-   virtual Int_t    GetMaximumBin(Int_t &locmax, Int_t &locmay, Int_t &locmaz) const;
-   virtual Double_t GetMaximumStored() const {return fMaximum;}
-   virtual Double_t GetMinimum(Double_t minval=-FLT_MAX) const;
-   virtual Int_t    GetMinimumBin() const;
-   virtual Int_t    GetMinimumBin(Int_t &locmix, Int_t &locmiy, Int_t &locmiz) const;
-   virtual Double_t GetMinimumStored() const {return fMinimum;}
-   virtual void     GetMinimumAndMaximum(Double_t& min, Double_t& max) const;
-   virtual Double_t GetMean(Int_t axis=1) const;
-   virtual Double_t GetMeanError(Int_t axis=1) const;
-   virtual Int_t    GetNbinsX() const {return fXaxis.GetNbins();}
-   virtual Int_t    GetNbinsY() const {return fYaxis.GetNbins();}
-   virtual Int_t    GetNbinsZ() const {return fZaxis.GetNbins();}
-   virtual Int_t    GetNcells() const {return fNcells; }
-   virtual Double_t GetNormFactor() const {return fNormFactor;}
-   virtual char    *GetObjectInfo(Int_t px, Int_t py) const;
-   Option_t        *GetOption() const {return fOption.Data();}
+    TVirtualHistPainter *GetPainter(Option_t *option = "");
 
-   TVirtualHistPainter *GetPainter(Option_t *option="");
+    virtual Int_t GetQuantiles(Int_t nprobSum, Double_t *q, const Double_t *probSum = 0);
+    virtual Double_t GetRandom() const;
+    virtual void GetStats(Double_t *stats) const;
+    virtual Double_t GetStdDev(Int_t axis = 1) const;
+    virtual Double_t GetStdDevError(Int_t axis = 1) const;
+    virtual Double_t GetSumOfWeights() const;
+    virtual TArrayD *GetSumw2() { return &fSumw2; }
+    virtual const TArrayD *GetSumw2() const { return &fSumw2; }
+    virtual Int_t GetSumw2N() const { return fSumw2.fN; }
+    Double_t GetRMS(Int_t axis = 1) const { return GetStdDev(axis); }
+    Double_t GetRMSError(Int_t axis = 1) const { return GetStdDevError(axis); }
 
-   virtual Int_t    GetQuantiles(Int_t nprobSum, Double_t *q, const Double_t *probSum=0);
-   virtual Double_t GetRandom() const;
-   virtual void     GetStats(Double_t *stats) const;
-   virtual Double_t GetStdDev(Int_t axis=1) const;
-   virtual Double_t GetStdDevError(Int_t axis=1) const;
-   virtual Double_t GetSumOfWeights() const;
-   virtual TArrayD *GetSumw2() {return &fSumw2;}
-   virtual const TArrayD *GetSumw2() const {return &fSumw2;}
-   virtual Int_t    GetSumw2N() const {return fSumw2.fN;}
-           Double_t GetRMS(Int_t axis=1) const { return GetStdDev(axis); }
-           Double_t GetRMSError(Int_t axis=1) const { return GetStdDevError(axis); }
+    virtual Double_t GetSkewness(Int_t axis = 1) const;
+    TAxis *GetXaxis() { return &fXaxis; }
+    TAxis *GetYaxis() { return &fYaxis; }
+    TAxis *GetZaxis() { return &fZaxis; }
+    const TAxis *GetXaxis() const { return &fXaxis; }
+    const TAxis *GetYaxis() const { return &fYaxis; }
+    const TAxis *GetZaxis() const { return &fZaxis; }
+    virtual Double_t Integral(Option_t *option = "") const;
+    virtual Double_t Integral(Int_t binx1, Int_t binx2, Option_t *option = "") const;
+    virtual Double_t IntegralAndError(Int_t binx1, Int_t binx2, Double_t &err, Option_t *option = "") const;
+    virtual Double_t Interpolate(Double_t x);
+    virtual Double_t Interpolate(Double_t x, Double_t y);
+    virtual Double_t Interpolate(Double_t x, Double_t y, Double_t z);
+    Bool_t IsBinOverflow(Int_t bin, Int_t axis = 0) const;
+    Bool_t IsBinUnderflow(Int_t bin, Int_t axis = 0) const;
+    virtual Double_t AndersonDarlingTest(const TH1 *h2, Option_t *option = "") const;
+    virtual Double_t AndersonDarlingTest(const TH1 *h2, Double_t &advalue) const;
+    virtual Double_t KolmogorovTest(const TH1 *h2, Option_t *option = "") const;
+    virtual void LabelsDeflate(Option_t *axis = "X");
+    virtual void LabelsInflate(Option_t *axis = "X");
+    virtual void LabelsOption(Option_t *option = "h", Option_t *axis = "X");
+    virtual Long64_t Merge(TCollection *list);
+    virtual Bool_t Multiply(TF1 *h1, Double_t c1 = 1);
+    virtual Bool_t Multiply(const TH1 *h1);
+    virtual Bool_t
+    Multiply(const TH1 *h1, const TH1 *h2, Double_t c1 = 1, Double_t c2 = 1, Option_t *option = ""); // *MENU*
+    virtual void Paint(Option_t *option = "");
+    virtual void Print(Option_t *option = "") const;
+    virtual void PutStats(Double_t *stats);
+    virtual TH1 *Rebin(Int_t ngroup = 2, const char *newname = "", const Double_t *xbins = 0); // *MENU*
+    virtual TH1 *RebinX(Int_t ngroup = 2, const char *newname = "") { return Rebin(ngroup, newname, (Double_t *)0); }
+    virtual void Rebuild(Option_t *option = "");
+    virtual void RecursiveRemove(TObject *obj);
+    virtual void Reset(Option_t *option = "");
+    virtual void ResetStats();
+    virtual void SavePrimitive(std::ostream &out, Option_t *option = "");
+    virtual void Scale(Double_t c1 = 1, Option_t *option = "");
+    virtual void SetAxisColor(Color_t color = 1, Option_t *axis = "X");
+    virtual void SetAxisRange(Double_t xmin, Double_t xmax, Option_t *axis = "X");
+    virtual void SetBarOffset(Float_t offset = 0.25) { fBarOffset = Short_t(1000 * offset); }
+    virtual void SetBarWidth(Float_t width = 0.5) { fBarWidth = Short_t(1000 * width); }
+    virtual void SetBinContent(Int_t bin, Double_t content);
+    virtual void SetBinContent(Int_t bin, Int_t, Double_t content) { SetBinContent(bin, content); }
+    virtual void SetBinContent(Int_t bin, Int_t, Int_t, Double_t content) { SetBinContent(bin, content); }
+    virtual void SetBinError(Int_t bin, Double_t error);
+    virtual void SetBinError(Int_t binx, Int_t biny, Double_t error);
+    virtual void SetBinError(Int_t binx, Int_t biny, Int_t binz, Double_t error);
+    virtual void SetBins(Int_t nx, Double_t xmin, Double_t xmax);
+    virtual void SetBins(Int_t nx, const Double_t *xBins);
+    virtual void SetBins(Int_t nx, Double_t xmin, Double_t xmax, Int_t ny, Double_t ymin, Double_t ymax);
+    virtual void SetBins(Int_t nx, const Double_t *xBins, Int_t ny, const Double_t *yBins);
+    virtual void SetBins(Int_t nx, Double_t xmin, Double_t xmax, Int_t ny, Double_t ymin, Double_t ymax, Int_t nz,
+                         Double_t zmin, Double_t zmax);
+    virtual void
+    SetBins(Int_t nx, const Double_t *xBins, Int_t ny, const Double_t *yBins, Int_t nz, const Double_t *zBins);
+    virtual void SetBinsLength(Int_t = -1) {} // redefined in derived classes
+    virtual void SetBinErrorOption(EBinErrorOpt type) { fBinStatErrOpt = type; }
+    virtual void SetBuffer(Int_t buffersize, Option_t *option = "");
 
-   virtual Double_t GetSkewness(Int_t axis=1) const;
-           TAxis*   GetXaxis()  { return &fXaxis; }
-           TAxis*   GetYaxis()  { return &fYaxis; }
-           TAxis*   GetZaxis()  { return &fZaxis; }
-     const TAxis*   GetXaxis() const { return &fXaxis; }
-     const TAxis*   GetYaxis() const { return &fYaxis; }
-     const TAxis*   GetZaxis() const { return &fZaxis; }
-   virtual Double_t Integral(Option_t *option="") const;
-   virtual Double_t Integral(Int_t binx1, Int_t binx2, Option_t *option="") const;
-   virtual Double_t IntegralAndError(Int_t binx1, Int_t binx2, Double_t & err, Option_t *option="") const;
-   virtual Double_t Interpolate(Double_t x);
-   virtual Double_t Interpolate(Double_t x, Double_t y);
-   virtual Double_t Interpolate(Double_t x, Double_t y, Double_t z);
-           Bool_t   IsBinOverflow(Int_t bin, Int_t axis = 0) const;
-           Bool_t   IsBinUnderflow(Int_t bin, Int_t axis = 0) const;
-   virtual Double_t AndersonDarlingTest(const TH1 *h2, Option_t *option="") const;
-   virtual Double_t AndersonDarlingTest(const TH1 *h2, Double_t &advalue) const;
-   virtual Double_t KolmogorovTest(const TH1 *h2, Option_t *option="") const;
-   virtual void     LabelsDeflate(Option_t *axis="X");
-   virtual void     LabelsInflate(Option_t *axis="X");
-   virtual void     LabelsOption(Option_t *option="h", Option_t *axis="X");
-   virtual Long64_t Merge(TCollection *list);
-   virtual Bool_t   Multiply(TF1 *h1, Double_t c1=1);
-   virtual Bool_t   Multiply(const TH1 *h1);
-   virtual Bool_t   Multiply(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1, Option_t *option=""); // *MENU*
-   virtual void     Paint(Option_t *option="");
-   virtual void     Print(Option_t *option="") const;
-   virtual void     PutStats(Double_t *stats);
-   virtual TH1     *Rebin(Int_t ngroup=2, const char*newname="", const Double_t *xbins=0);  // *MENU*
-   virtual TH1     *RebinX(Int_t ngroup=2, const char*newname="") { return Rebin(ngroup,newname, (Double_t*) 0); }
-   virtual void     Rebuild(Option_t *option="");
-   virtual void     RecursiveRemove(TObject *obj);
-   virtual void     Reset(Option_t *option="");
-   virtual void     ResetStats();
-   virtual void     SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void     Scale(Double_t c1=1, Option_t *option="");
-   virtual void     SetAxisColor(Color_t color=1, Option_t *axis="X");
-   virtual void     SetAxisRange(Double_t xmin, Double_t xmax, Option_t *axis="X");
-   virtual void     SetBarOffset(Float_t offset=0.25) {fBarOffset = Short_t(1000*offset);}
-   virtual void     SetBarWidth(Float_t width=0.5) {fBarWidth = Short_t(1000*width);}
-   virtual void     SetBinContent(Int_t bin, Double_t content);
-   virtual void     SetBinContent(Int_t bin, Int_t, Double_t content) { SetBinContent(bin, content); }
-   virtual void     SetBinContent(Int_t bin, Int_t, Int_t, Double_t content) { SetBinContent(bin, content); }
-   virtual void     SetBinError(Int_t bin, Double_t error);
-   virtual void     SetBinError(Int_t binx, Int_t biny, Double_t error);
-   virtual void     SetBinError(Int_t binx, Int_t biny, Int_t binz, Double_t error);
-   virtual void     SetBins(Int_t nx, Double_t xmin, Double_t xmax);
-   virtual void     SetBins(Int_t nx, const Double_t *xBins);
-   virtual void     SetBins(Int_t nx, Double_t xmin, Double_t xmax, Int_t ny, Double_t ymin, Double_t ymax);
-   virtual void     SetBins(Int_t nx, const Double_t *xBins, Int_t ny, const Double_t *yBins);
-   virtual void     SetBins(Int_t nx, Double_t xmin, Double_t xmax, Int_t ny, Double_t ymin, Double_t ymax,
-                            Int_t nz, Double_t zmin, Double_t zmax);
-   virtual void     SetBins(Int_t nx, const Double_t *xBins, Int_t ny, const Double_t * yBins, Int_t nz,
-                            const Double_t *zBins);
-   virtual void     SetBinsLength(Int_t = -1) { } //redefined in derived classes
-   virtual void     SetBinErrorOption(EBinErrorOpt type) { fBinStatErrOpt = type; }
-   virtual void     SetBuffer(Int_t buffersize, Option_t *option="");
-   virtual UInt_t   SetCanExtend(UInt_t extendBitMask);
-   virtual void     SetContent(const Double_t *content);
-   virtual void     SetContour(Int_t nlevels, const Double_t *levels=0);
-   virtual void     SetContourLevel(Int_t level, Double_t value);
-   static  void     SetDefaultBufferSize(Int_t buffersize=1000);
-   static  void     SetDefaultSumw2(Bool_t sumw2=kTRUE);
-   virtual void     SetDirectory(TDirectory *dir);
-   virtual void     SetEntries(Double_t n) {fEntries = n;};
-   virtual void     SetError(const Double_t *error);
-   virtual void     SetLabelColor(Color_t color=1, Option_t *axis="X");
-   virtual void     SetLabelFont(Style_t font=62, Option_t *axis="X");
-   virtual void     SetLabelOffset(Float_t offset=0.005, Option_t *axis="X");
-   virtual void     SetLabelSize(Float_t size=0.02, Option_t *axis="X");
+    // Callback function
+    void SetCallbackFunc(void *c, CallbackFunc_t f)
+    {
+       fCallbackCtx = c;
+       fCallbackFunc = f;
+    }
+    static void SetGlobalCallbackFunc(void *c, CallbackFunc_t f);
 
-   /*
-    * Set the minimum / maximum value for the Y axis (1-D histograms) or Z axis (2-D histograms)
-    *   By default the maximum / minimum value used in drawing is the maximum / minimum value of the histogram
-    * plus a margin of 10%. If these functions are called, the values are used without any extra margin.
-    */
-   virtual void     SetMaximum(Double_t maximum = -1111) { fMaximum = maximum; }; // *MENU*
-   virtual void     SetMinimum(Double_t minimum = -1111) { fMinimum = minimum; }; // *MENU*
+    // List of dir tags to be stripped off
+    static const char *GetStripOffDirs();
+    static void SetStripOffDirs(const char *);
 
-   virtual void     SetName(const char *name); // *MENU*
-   virtual void     SetNameTitle(const char *name, const char *title);
-   virtual void     SetNdivisions(Int_t n=510, Option_t *axis="X");
-   virtual void     SetNormFactor(Double_t factor=1) {fNormFactor = factor;}
-   virtual void     SetStats(Bool_t stats=kTRUE); // *MENU*
-   virtual void     SetOption(Option_t *option=" ") {fOption = option;}
-   virtual void     SetTickLength(Float_t length=0.02, Option_t *axis="X");
-   virtual void     SetTitleFont(Style_t font=62, Option_t *axis="X");
-   virtual void     SetTitleOffset(Float_t offset=1, Option_t *axis="X");
-   virtual void     SetTitleSize(Float_t size=0.02, Option_t *axis="X");
-   virtual void     SetTitle(const char *title);  // *MENU*
-   virtual void     SetXTitle(const char *title) {fXaxis.SetTitle(title);}
-   virtual void     SetYTitle(const char *title) {fYaxis.SetTitle(title);}
-   virtual void     SetZTitle(const char *title) {fZaxis.SetTitle(title);}
-   virtual TH1     *ShowBackground(Int_t niter=20, Option_t *option="same"); // *MENU*
-   virtual Int_t    ShowPeaks(Double_t sigma=2, Option_t *option="", Double_t threshold=0.05); // *MENU*
-   virtual void     Smooth(Int_t ntimes=1, Option_t *option=""); // *MENU*
-   static  void     SmoothArray(Int_t NN, Double_t *XX, Int_t ntimes=1);
-   static  void     StatOverflows(Bool_t flag=kTRUE);
-   virtual void     Sumw2(Bool_t flag = kTRUE);
-   void             UseCurrentStyle();
-   static  TH1     *TransformHisto(TVirtualFFT *fft, TH1* h_output,  Option_t *option);
+    virtual UInt_t SetCanExtend(UInt_t extendBitMask);
+    virtual void SetContent(const Double_t *content);
+    virtual void SetContour(Int_t nlevels, const Double_t *levels = 0);
+    virtual void SetContourLevel(Int_t level, Double_t value);
+    static void SetDefaultBufferSize(Int_t buffersize = 1000);
+    static void SetDefaultSumw2(Bool_t sumw2 = kTRUE);
+    virtual void SetDirectory(TDirectory *dir);
+    virtual void SetEntries(Double_t n) { fEntries = n; };
+    virtual void SetError(const Double_t *error);
+    virtual void SetLabelColor(Color_t color = 1, Option_t *axis = "X");
+    virtual void SetLabelFont(Style_t font = 62, Option_t *axis = "X");
+    virtual void SetLabelOffset(Float_t offset = 0.005, Option_t *axis = "X");
+    virtual void SetLabelSize(Float_t size = 0.02, Option_t *axis = "X");
 
+    /*
+     * Set the minimum / maximum value for the Y axis (1-D histograms) or Z axis (2-D histograms)
+     *   By default the maximum / minimum value used in drawing is the maximum / minimum value of the histogram
+     * plus a margin of 10%. If these functions are called, the values are used without any extra margin.
+     */
+    virtual void SetMaximum(Double_t maximum = -1111) { fMaximum = maximum; }; // *MENU*
+    virtual void SetMinimum(Double_t minimum = -1111) { fMinimum = minimum; }; // *MENU*
 
-   // TODO: Remove obsolete methods in v6-04
-   virtual Double_t GetCellContent(Int_t binx, Int_t biny) const
-                        { Obsolete("GetCellContent", "v6-00", "v6-04"); return GetBinContent(GetBin(binx, biny)); }
-   virtual Double_t GetCellError(Int_t binx, Int_t biny) const
-                        { Obsolete("GetCellError", "v6-00", "v6-04"); return GetBinError(binx, biny); }
-   virtual void     RebinAxis(Double_t x, TAxis *axis)
-                        { Obsolete("RebinAxis", "v6-00", "v6-04"); ExtendAxis(x, axis); }
-   virtual void     SetCellContent(Int_t binx, Int_t biny, Double_t content)
-                        { Obsolete("SetCellContent", "v6-00", "v6-04"); SetBinContent(GetBin(binx, biny), content); }
-   virtual void     SetCellError(Int_t binx, Int_t biny, Double_t content)
-                        { Obsolete("SetCellError", "v6-00", "v6-04"); SetBinError(binx, biny, content); }
+    virtual void SetName(const char *name); // *MENU*
+    virtual void SetNameTitle(const char *name, const char *title);
+    virtual void SetNdivisions(Int_t n = 510, Option_t *axis = "X");
+    virtual void SetNormFactor(Double_t factor = 1) { fNormFactor = factor; }
+    virtual void SetStats(Bool_t stats = kTRUE); // *MENU*
+    virtual void SetOption(Option_t *option = " ") { fOption = option; }
+    virtual void SetTickLength(Float_t length = 0.02, Option_t *axis = "X");
+    virtual void SetTitleFont(Style_t font = 62, Option_t *axis = "X");
+    virtual void SetTitleOffset(Float_t offset = 1, Option_t *axis = "X");
+    virtual void SetTitleSize(Float_t size = 0.02, Option_t *axis = "X");
+    virtual void SetTitle(const char *title); // *MENU*
+    virtual void SetXTitle(const char *title) { fXaxis.SetTitle(title); }
+    virtual void SetYTitle(const char *title) { fYaxis.SetTitle(title); }
+    virtual void SetZTitle(const char *title) { fZaxis.SetTitle(title); }
+    virtual TH1 *ShowBackground(Int_t niter = 20, Option_t *option = "same");                      // *MENU*
+    virtual Int_t ShowPeaks(Double_t sigma = 2, Option_t *option = "", Double_t threshold = 0.05); // *MENU*
+    virtual void Smooth(Int_t ntimes = 1, Option_t *option = "");                                  // *MENU*
+    static void SmoothArray(Int_t NN, Double_t *XX, Int_t ntimes = 1);
+    static void StatOverflows(Bool_t flag = kTRUE);
+    virtual void Sumw2(Bool_t flag = kTRUE);
+    void UseCurrentStyle();
+    static TH1 *TransformHisto(TVirtualFFT *fft, TH1 *h_output, Option_t *option);
 
-   ClassDef(TH1,7)  //1-Dim histogram base class
+    // TODO: Remove obsolete methods in v6-04
+    virtual Double_t GetCellContent(Int_t binx, Int_t biny) const
+    {
+       Obsolete("GetCellContent", "v6-00", "v6-04");
+       return GetBinContent(GetBin(binx, biny));
+    }
+    virtual Double_t GetCellError(Int_t binx, Int_t biny) const
+    {
+       Obsolete("GetCellError", "v6-00", "v6-04");
+       return GetBinError(binx, biny);
+    }
+    virtual void RebinAxis(Double_t x, TAxis *axis)
+    {
+       Obsolete("RebinAxis", "v6-00", "v6-04");
+       ExtendAxis(x, axis);
+    }
+    virtual void SetCellContent(Int_t binx, Int_t biny, Double_t content)
+    {
+       Obsolete("SetCellContent", "v6-00", "v6-04");
+       SetBinContent(GetBin(binx, biny), content);
+    }
+    virtual void SetCellError(Int_t binx, Int_t biny, Double_t content)
+    {
+       Obsolete("SetCellError", "v6-00", "v6-04");
+       SetBinError(binx, biny, content);
+    }
 
-protected:
-   virtual Double_t RetrieveBinContent(Int_t bin) const;
-   virtual void     UpdateBinContent(Int_t bin, Double_t content);
-   virtual Double_t GetBinErrorSqUnchecked(Int_t bin) const { return fSumw2.fN ? fSumw2.fArray[bin] : RetrieveBinContent(bin); }
+    ClassDef(TH1, 7) // 1-Dim histogram base class
+
+       protected : virtual Double_t RetrieveBinContent(Int_t bin) const;
+    virtual void UpdateBinContent(Int_t bin, Double_t content);
+    virtual Double_t GetBinErrorSqUnchecked(Int_t bin) const
+    {
+       return fSumw2.fN ? fSumw2.fArray[bin] : RetrieveBinContent(bin);
+    }
 };
 
 namespace cling {

--- a/hist/hist/inc/TH2.h
+++ b/hist/hist/inc/TH2.h
@@ -35,6 +35,9 @@ protected:
    Double_t     fTsumwy2;         //Total Sum of weight*Y*Y
    Double_t     fTsumwxy;         //Total Sum of weight*X*Y
 
+   static void *fgCallbackCtx;           ///<!Global context setting for the function to be called back
+   static CallbackFunc_t fgCallbackFunc; ///<!Global callback function setting, for example to get ranges
+
    TH2();
    TH2(const char *name,const char *title,Int_t nbinsx,Double_t xlow,Double_t xup
                                          ,Int_t nbinsy,Double_t ylow,Double_t yup);
@@ -57,6 +60,11 @@ protected:
    Int_t    Fill(Double_t); //MayNotUse
    Int_t    Fill(const char*, Double_t) { return Fill(0);}  //MayNotUse
 
+   virtual void RecalculateAxes(Double_t *b, Int_t n);
+   virtual TList *GetListWithRanges(const char *n);
+   virtual Bool_t HasNoLimits();
+   virtual Int_t SetRangesFromList(TList *axl);
+
 private:
 
    TH2(const TH2&);
@@ -64,7 +72,6 @@ private:
 
 public:
    virtual ~TH2();
-   virtual Int_t    BufferEmpty(Int_t action=0);
    virtual void     Copy(TObject &hnew) const;
    virtual Int_t    Fill(Double_t x, Double_t y);
    virtual Int_t    Fill(Double_t x, Double_t y, Double_t w);
@@ -122,6 +129,8 @@ public:
    virtual TH1     *ShowBackground(Int_t niter=20, Option_t *option="same");
    virtual Int_t    ShowPeaks(Double_t sigma=2, Option_t *option="", Double_t threshold=0.05); // *MENU*
    virtual void     Smooth(Int_t ntimes=1, Option_t *option=""); // *MENU*
+
+   static void SetGlobalCallbackFunc(void *c, CallbackFunc_t f);
 
    ClassDef(TH2,4)  //2-Dim histogram base class
 };

--- a/hist/hist/inc/TH2.h
+++ b/hist/hist/inc/TH2.h
@@ -132,7 +132,7 @@ public:
 
    static void SetGlobalCallbackFunc(void *c, CallbackFunc_t f);
 
-   ClassDef(TH2,5)  //2-Dim histogram base class
+   ClassDef(TH2,4)  //2-Dim histogram base class
 };
 
 

--- a/hist/hist/inc/TH2.h
+++ b/hist/hist/inc/TH2.h
@@ -132,7 +132,7 @@ public:
 
    static void SetGlobalCallbackFunc(void *c, CallbackFunc_t f);
 
-   ClassDef(TH2,4)  //2-Dim histogram base class
+   ClassDef(TH2,5)  //2-Dim histogram base class
 };
 
 

--- a/hist/hist/inc/TH3.h
+++ b/hist/hist/inc/TH3.h
@@ -159,7 +159,7 @@ protected:
       return h.DoProject2D(name, title, projX,projY, computeErrors, originalRange, useUF, useOF);
    }
 
-   ClassDef(TH3,6)  //3-Dim histogram base class
+   ClassDef(TH3,5)  //3-Dim histogram base class
 };
 
 //________________________________________________________________________

--- a/hist/hist/inc/TH3.h
+++ b/hist/hist/inc/TH3.h
@@ -39,6 +39,9 @@ protected:
    Double_t     fTsumwxz;         //Total Sum of weight*X*Z
    Double_t     fTsumwyz;         //Total Sum of weight*Y*Z
 
+   static void *fgCallbackCtx;           ///<!Global context setting for the function to be called back
+   static CallbackFunc_t fgCallbackFunc; ///<!Global callback function setting, for example to get ranges
+
    TH3();
    TH3(const char *name,const char *title,Int_t nbinsx,Double_t xlow,Double_t xup
                                   ,Int_t nbinsy,Double_t ylow,Double_t yup
@@ -62,6 +65,11 @@ protected:
    Int_t    Fill(const char*,Double_t,Double_t) {return Fill(0);} //MayNotUse
    Int_t    Fill(const char*,const char*,Double_t) {return Fill(0);} //MayNotUse
 
+   virtual void RecalculateAxes(Double_t *b, Int_t n);
+   virtual TList *GetListWithRanges(const char *n);
+   virtual Bool_t HasNoLimits();
+   virtual Int_t SetRangesFromList(TList *axl);
+
 private:
 
    TH3(const TH3&);
@@ -69,7 +77,6 @@ private:
 
 public:
    virtual ~TH3();
-   virtual Int_t    BufferEmpty(Int_t action=0);
    virtual void     Copy(TObject &hnew) const;
    virtual Int_t    Fill(Double_t x, Double_t y, Double_t z);
    virtual Int_t    Fill(Double_t x, Double_t y, Double_t z, Double_t w);
@@ -127,6 +134,8 @@ public:
    virtual void      SetBinContent(Int_t bin, Int_t, Double_t content) { SetBinContent(bin, content); }
    virtual void      SetBinContent(Int_t binx, Int_t biny, Int_t binz, Double_t content) { SetBinContent(GetBin(binx, biny, binz), content); }
    virtual void     SetShowProjection(const char *option="xy",Int_t nbins=1);   // *MENU*
+
+   static void SetGlobalCallbackFunc(void *c, CallbackFunc_t f);
 
 protected:
 

--- a/hist/hist/inc/TH3.h
+++ b/hist/hist/inc/TH3.h
@@ -159,7 +159,7 @@ protected:
       return h.DoProject2D(name, title, projX,projY, computeErrors, originalRange, useUF, useOF);
    }
 
-   ClassDef(TH3,5)  //3-Dim histogram base class
+   ClassDef(TH3,6)  //3-Dim histogram base class
 };
 
 //________________________________________________________________________

--- a/hist/hist/src/TAxis.cxx
+++ b/hist/hist/src/TAxis.cxx
@@ -1192,3 +1192,10 @@ void TAxis::ZoomOut(Double_t factor, Double_t offset)
    if (first==GetFirst() && last==GetLast()) { first--; last++; }
    SetRange(first,last);
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Print axis bins and ranges
+void TAxis::Print(Option_t *) const
+{
+   printf(" %s\t%s \tNbins= %d, \tmin= %g, \tmax=%g", GetName(), GetTitle(), GetNbins(), GetXmin(), GetXmax());
+}

--- a/hist/hist/src/TAxis.cxx
+++ b/hist/hist/src/TAxis.cxx
@@ -1197,5 +1197,5 @@ void TAxis::ZoomOut(Double_t factor, Double_t offset)
 /// Print axis bins and ranges
 void TAxis::Print(Option_t *) const
 {
-   printf(" %s\t%s \tNbins= %d, \tmin= %g, \tmax=%g", GetName(), GetTitle(), GetNbins(), GetXmin(), GetXmax());
+   Printf(" %s\t%s \tNbins= %d, \tmin= %g, \tmax=%g", GetName(), GetTitle(), GetNbins(), GetXmin(), GetXmax());
 }

--- a/hist/hist/src/TH1Merger.cxx
+++ b/hist/hist/src/TH1Merger.cxx
@@ -92,6 +92,12 @@ TH1Merger::EMergerType TH1Merger::ExamineHistograms() {
 
    do  {
 
+      // Make sure buffers are emptied, in particular when buffersize was too large.
+      // It acts also as synchronizer (via TH1::fgRefSync) in the case of the same histogram
+      // filled with different threads.
+      if (h->GetBuffer())
+         h->SetBuffer(0);
+
       // check first histogram compatibility
       if (h != fH0) {
          if (h->GetDimension() != dimension) {
@@ -110,7 +116,6 @@ TH1Merger::EMergerType TH1Merger::ExamineHistograms() {
 
       
       if (hasLimits) {
-         h->BufferEmpty();
 
 //          // this is done in case the first histograms are empty and
 //          // the histogram have different limits

--- a/tutorials/multicore/mt301_fillHistAutoBin.C
+++ b/tutorials/multicore/mt301_fillHistAutoBin.C
@@ -15,10 +15,11 @@
 #include "TDirectory.h"
 #include "TROOT.h"
 #include "TCanvas.h"
-#include <thread>
-#include <iostream>
 #include "ROOT/TSeq.hxx"
 #include "ROOT/TThreadedObject.hxx"
+
+#include <thread>
+#include <iostream>
 
 // The number of workers
 const UInt_t nWorkers = 8U;
@@ -79,7 +80,8 @@ Int_t mt301_fillHistos(UInt_t nNumbers = 1001, Bool_t ranges = kFALSE)
    auto fh3d = h3d.Merge();
 
    // Make the canvas
-   TCanvas *c = new TCanvas("c", "c", 800, 800);
+   if (gROOT->GetListOfCanvases()->FindObject("c1")) delete gROOT->GetListOfCanvases()->FindObject("c1");
+   TCanvas *c = new TCanvas("c1", "c1", 800, 800);
    c->Divide(2, 2);
 
    c->cd(1);
@@ -89,7 +91,8 @@ Int_t mt301_fillHistos(UInt_t nNumbers = 1001, Bool_t ranges = kFALSE)
    c->cd(3);
    fh3d->DrawClone();
 
-   gROOTMutex = 0;
+   // To be able to re-run in the same ROOT shell
+   // gROOTMutex = 0;
 
    return 0;
 }

--- a/tutorials/multicore/mt301_fillHistAutoBin.C
+++ b/tutorials/multicore/mt301_fillHistAutoBin.C
@@ -1,0 +1,95 @@
+/// \file
+/// \ingroup tutorial_multicore
+/// Fill histograms w/o in parallel with automatic binning.
+/// Illustrates range synchronization
+///
+/// \macro_code
+///
+/// \author Gerardo Ganis
+/// \date August 2017
+#include "TH1D.h"
+#include "TH2D.h"
+#include "TH3D.h"
+#include "TList.h"
+#include "TRandom3.h"
+#include "TDirectory.h"
+#include "TROOT.h"
+#include "TCanvas.h"
+#include <thread>
+#include <iostream>
+#include "ROOT/TSeq.hxx"
+#include "ROOT/TThreadedObject.hxx"
+
+// The number of workers
+const UInt_t nWorkers = 8U;
+
+Int_t mt301_fillHistos(UInt_t nNumbers = 1001, Bool_t ranges = kFALSE)
+{
+
+   // The first, fundamental operation to be performed in order to make ROOT
+   // thread-aware.
+   ROOT::EnableThreadSafety();
+
+   Double_t mi = 0., ma = -1.;
+   if (ranges) {
+      mi = -4.;
+      ma = 4.;
+   }
+
+   // Histograms to be filled in parallel
+   ROOT::TThreadedObject<TH1D> h1d("h1d", "1D test histogram", 64, mi, ma);
+   ROOT::TThreadedObject<TH2D> h2d("h2d", "2D test histogram", 64, mi, ma, 64, mi, ma);
+   ROOT::TThreadedObject<TH3D> h3d("h3d", "3D test histogram", 64, mi, ma, 64, mi, ma, 64, mi, ma);
+
+   // We define our work item
+   auto workItem = [&](UInt_t workerID) {
+      // One generator, file and ntuple per worker
+      TRandom3 workerRndm(workerID); // Change the seed
+
+      auto wh1d = h1d.Get();
+      auto wh2d = h2d.Get();
+      auto wh3d = h3d.Get();
+
+      Double_t x, y;
+
+      for (UInt_t i = 0; i < nNumbers; ++i) {
+         wh1d->Fill(workerRndm.Gaus());
+         workerRndm.Rannor(x, y);
+         wh2d->Fill(x, y);
+         workerRndm.Rannor(x, y);
+         wh3d->Fill(x, y, workerRndm.Gaus());
+      }
+   };
+
+   // Create the collection which will hold the threads, our "pool"
+   std::vector<std::thread> workers;
+
+   // Fill the "pool" with workers
+   for (auto workerID : ROOT::TSeqI(nWorkers)) {
+      workers.emplace_back(workItem, workerID);
+   }
+
+   // Now join them
+   for (auto &&worker : workers)
+      worker.join();
+
+   // Merge
+   auto fh1d = h1d.Merge();
+   auto fh2d = h2d.Merge();
+   auto fh3d = h3d.Merge();
+
+   // Make the canvas
+   TCanvas *c = new TCanvas("c", "c", 800, 800);
+   c->Divide(2, 2);
+
+   c->cd(1);
+   fh1d->DrawClone();
+   c->cd(2);
+   fh2d->DrawClone();
+   c->cd(3);
+   fh3d->DrawClone();
+
+   gROOTMutex = 0;
+
+   return 0;
+}


### PR DESCRIPTION
When filling histograms without limits in parallel a problem to be addressed is how to make sure that the ranges are compatible for the final merging.
This PR proposes a technique based on a static reference list of TAxis, kept as a static in TH1, filled/used by the different threads. The first thread calculates the TAxis ranges and saves it into the list, the others use it. The list is protected by a RW lock .
The logic is implemented in TH1::BufferEmpty and holds for TH{1,2,3}, the specificity of each TH{1,2,3} being moved to a set of new member functions called by TH1::BufferEmpty.

The change in TH1Merger is required to calculate the axis and dump the internal buffers when the internal buffersize has not yet been reached. This treatment can perhaps be improved to get the same result of the single thread case.

The patch also implements the hook for a call back function to implement the same functionality in the case of multi-processing. A patch with adaptation to multiproc will follow.

The tutorial mt301_fillHistAutoBin.C illustrates the usage with TThreadedObject .

NB: many of the changes in TH1.h come from clang-format-{3.8, 3.9, 4.0}