### PR TITLE
No reason to explicitly load pythia8 due to autoloading

### DIFF
--- a/tutorials/pythia/pythia8.C
+++ b/tutorials/pythia/pythia8.C
@@ -48,13 +48,6 @@ void pythia8(Int_t nev  = 100, Int_t ndeb = 1)
    }
 
 // Load libraries
-#ifndef G__WIN32 // Pythia8 is a static library on Windows
-   if (gSystem->Getenv("PYTHIA8")) {
-      gSystem->Load("$PYTHIA8/lib/libpythia8");
-   } else {
-      gSystem->Load("libpythia8");
-   }
-#endif
    gSystem->Load("libEG");
    gSystem->Load("libEGPythia8");
 // Histograms


### PR DESCRIPTION
Removed explicitly loading pythia8 in pythia8 tutorials. On e.g. Docker, this test fails since the path to pythia8 is not under $PYTHIA8/lib/: http://cdash.cern.ch/testDetails.php?test=28516933&build=390221