### PR TITLE
Correctly set the VFS in the clang FileManager.

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -845,8 +845,14 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
       return CI.release();
     }
 
-    CI->createFileManager();
     clang::CompilerInvocation& Invocation = CI->getInvocation();
+    // Ensure we use the supplied VFS overlay to mount system modulemaps.
+    // FIXME: Drop this commit once the TODO for this in CompilerInstance.cpp
+    // in createFileManager() has been fixed.
+    CI->setVirtualFileSystem(
+        clang::createVFSFromCompilerInvocation(Invocation, *Diags));
+
+    CI->createFileManager();
     std::string& PCHFile = Invocation.getPreprocessorOpts().ImplicitPCHInclude;
     bool InitLang = true, InitTarget = true;
     if (!PCHFile.empty()) {


### PR DESCRIPTION
We use a VFS for modules, but right now clang has a bug that
it ignores the used VFS without this code.

This commit can be dropped once we get this code upstream (which
hopefully should be around clang 6.0).