### PR TITLE
[cxxmodules] Added missing PushTransactionRAII to rootcling.

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -3409,6 +3409,9 @@ std::list<std::string> RecordDecl2Headers(const clang::CXXRecordDecl &rcd,
 {
    std::list<std::string> headers;
 
+   // We push a new transaction because we could deserialize decls here
+   cling::Interpreter::PushTransactionRAII RAII(&interp);
+
    // Avoid infinite recursion
    if (!visitedDecls.insert(rcd.getCanonicalDecl()).second)
       return headers;


### PR DESCRIPTION
With modules rootcling can now deserialize decls from this method,
so we need to have a transaction when running this code.