### PR TITLE
[cxxmodules] Added missing PushTransactionRAII to GetMangledName

### DIFF
--- a/core/metacling/src/TClingMethodInfo.cxx
+++ b/core/metacling/src/TClingMethodInfo.cxx
@@ -606,6 +606,7 @@ std::string TClingMethodInfo::GetMangledName() const
    const FunctionDecl* D = GetMethodDecl();
 
    R__LOCKGUARD(gInterpreterMutex);
+   cling::Interpreter::PushTransactionRAII RAII(fInterp);
    GlobalDecl GD;
    if (const CXXConstructorDecl* Ctor = dyn_cast<CXXConstructorDecl>(D))
      GD = GlobalDecl(Ctor, Ctor_Complete);


### PR DESCRIPTION
rootcling with modules can reach this method when running with
C++ modules and then starts deserializing decls without a
transaction. This adds the missing PUshTransactionRAII.