### PR TITLE
Status bits rationalization ....

### DIFF
--- a/README/ReleaseNotes/v610/index.md
+++ b/README/ReleaseNotes/v610/index.md
@@ -41,8 +41,8 @@ The following interfaces have been removed, after deprecation in v6.08.
 
 ### Core
 
-- The enum constant TRef::kNotComputed was never used and has been removed.
-- The enum constantTClonesArray::kNoSplit has not been used since v2.26 and has been removed.
+- The enum constant `TRef::kNotComputed`, `TLink::kObjIsParent` were never used and have been removed.
+- The enum constant `TClonesArray::kNoSplit` has not been used since v2.26 and has been removed.
 
 ## Interpreter
 

--- a/README/ReleaseNotes/v610/index.md
+++ b/README/ReleaseNotes/v610/index.md
@@ -39,6 +39,11 @@ The following interfaces have been removed, after deprecation in v6.08.
 - `SetFCN(void*)` from TVirtualFitter, TFitter, TBackCompFitter, TMinuit
 - `TFoam::SetRhoInt(void*)`
 
+### Core
+
+- The enum constant TRef::kNotComputed was never used and has been removed.
+- The enum constantTClonesArray::kNoSplit has not been used since v2.26 and has been removed.
+
 ## Interpreter
 
 - Automatic declaration of variables (`h = new TH1F(...)`) is *only* available at the prompt. The side-effects of relying on this in source files is simply too grave. Due to a bug (ROOT-8538), automatically declared variables must currently reside on the top-most scope, i.e. not inside an `if` block etc.

--- a/core/base/inc/TApplication.h
+++ b/core/base/inc/TApplication.h
@@ -41,8 +41,8 @@ class TApplication : public TObject, public TQObject {
 public:
    // TApplication specific bits
    enum EStatusBits {
-      kProcessRemotely = BIT(15),   // TRUE if this line has to be processed remotely
-      kDefaultApplication = BIT(16) // TRUE if created via CreateApplication()
+      kProcessRemotely    = BIT(15), // TRUE if this line has to be processed remotely
+      kDefaultApplication = BIT(16)  // TRUE if created via CreateApplication()
    };
    // TApplication specific bits for fFiles
    enum EFileBits {

--- a/core/base/inc/TBrowser.h
+++ b/core/base/inc/TBrowser.h
@@ -49,7 +49,7 @@ protected:
    Bool_t         fNeedRefresh;        //True if the browser needs refresh
 
 public:
-   enum {
+   enum EStatusBits {
       kNoHidden     = BIT(9)   // don't show '.' files and directories
    };
 

--- a/core/base/inc/TBuffer.h
+++ b/core/base/inc/TBuffer.h
@@ -68,8 +68,10 @@ protected:
 
 public:
    enum EMode { kRead = 0, kWrite = 1 };
-   enum { kIsOwner = BIT(16) };                        //if set TBuffer owns fBuffer
-   enum { kCannotHandleMemberWiseStreaming = BIT(17)}; //if set TClonesArray should not use member wise streaming
+   enum EStatusBits {
+     kIsOwner = BIT(16), //if set TBuffer owns fBuffer
+     kCannotHandleMemberWiseStreaming = BIT(17) //if set TClonesArray should not use member wise streaming
+   };
    enum { kInitialSize = 1024, kMinimalSize = 128 };
 
    TBuffer(EMode mode);

--- a/core/base/inc/TObject.h
+++ b/core/base/inc/TObject.h
@@ -56,11 +56,15 @@ public:
    //----- any given hierarchy).
    enum EStatusBits {
       kCanDelete        = BIT(0),   ///< if object in a list can be deleted
+      // 2 is taken by TDataMember
       kMustCleanup      = BIT(3),   ///< if object destructor must call RecursiveRemove()
       kIsReferenced     = BIT(4),   ///< if object is referenced by a TRef or TRefArray
       kHasUUID          = BIT(5),   ///< if object has a TUUID (its fUniqueID=UUIDNumber)
       kCannotPick       = BIT(6),   ///< if object in a pad cannot be picked
+      // 7 is taken by TAxis.
       kNoContextMenu    = BIT(8),   ///< if object does not want context menu
+      // 9, 10 are taken by TH1, TF1, TAxis and a few others
+      // 12 is taken by TAxis
       kInvalidObject    = BIT(13)   ///< if object ctor succeeded but object should not be used
    };
 

--- a/core/base/inc/TObject.h
+++ b/core/base/inc/TObject.h
@@ -57,12 +57,15 @@ public:
    enum EStatusBits {
       kCanDelete        = BIT(0),   ///< if object in a list can be deleted
       kMustCleanup      = BIT(3),   ///< if object destructor must call RecursiveRemove()
-      kObjInCanvas      = BIT(3),   ///< for backward compatibility only, use kMustCleanup
       kIsReferenced     = BIT(4),   ///< if object is referenced by a TRef or TRefArray
       kHasUUID          = BIT(5),   ///< if object has a TUUID (its fUniqueID=UUIDNumber)
       kCannotPick       = BIT(6),   ///< if object in a pad cannot be picked
       kNoContextMenu    = BIT(8),   ///< if object does not want context menu
       kInvalidObject    = BIT(13)   ///< if object ctor succeeded but object should not be used
+   };
+
+   enum EDeprecatedStatusBits {
+      kObjInCanvas      = BIT(3)   ///< for backward compatibility only, use kMustCleanup
    };
 
    //----- Private bits, clients can only test but not change them

--- a/core/base/inc/TRef.h
+++ b/core/base/inc/TRef.h
@@ -38,8 +38,6 @@ protected:
    static TObject    *fgObject; //In: this, Out: pointer to object (used by Action on Demand)
 
 public:
-   //status bits
-   enum { kNotComputed = BIT(12)};
 
    TRef(): fPID(0) { }
    TRef(TObject *obj);

--- a/core/base/inc/TSystem.h
+++ b/core/base/inc/TSystem.h
@@ -467,6 +467,7 @@ public:
    virtual Func_t          DynFindSymbol(const char *module, const char *entry);
    virtual int             Load(const char *module, const char *entry = "", Bool_t system = kFALSE);
    virtual void            Unload(const char *module);
+   virtual UInt_t          LoadAllLibraries();
    virtual void            ListSymbols(const char *module, const char *re = "");
    virtual void            ListLibraries(const char *regexp = "");
    virtual const char     *GetLibraries(const char *regexp = "",

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -52,6 +52,7 @@ allows a simple partial implementation for new OS'es.
 #include "TVersionCheck.h"
 #include "compiledata.h"
 #include "RConfigure.h"
+#include "THashList.h"
 
 const char *gRootDir;
 const char *gProgName;
@@ -1943,6 +1944,55 @@ int TSystem::Load(const char *module, const char *entry, Bool_t system)
    Func_t f = DynFindSymbol(module, entry);
    if (f) return 0;
    return -1;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// Load all libraries known to ROOT via the rootmap system.
+/// Returns the number of top level libraries successfully loaded.
+
+UInt_t TSystem::LoadAllLibraries()
+{
+   UInt_t nlibs = 0;
+
+   TEnv* mapfile = gInterpreter->GetMapfile();
+   if (!mapfile || !mapfile->GetTable()) return 0;
+
+   std::set<std::string> loadedlibs;
+   std::set<std::string> failedlibs;
+
+   TEnvRec* rec = 0;
+   TIter iEnvRec(mapfile->GetTable());
+   while ((rec = (TEnvRec*) iEnvRec())) {
+      TString libs = rec->GetValue();
+      TString lib;
+      Ssiz_t pos = 0;
+      while (libs.Tokenize(lib, pos)) {
+         // check that none of the libs failed to load
+         if (failedlibs.find(lib.Data()) != failedlibs.end()) {
+            // don't load it or any of its dependencies
+            libs = "";
+            break;
+         }
+      }
+      pos = 0;
+      while (libs.Tokenize(lib, pos)) {
+         // ignore libCore - it's already loaded
+         if (lib.BeginsWith("libCore"))
+            continue;
+
+         if (loadedlibs.find(lib.Data()) == loadedlibs.end()) {
+            // just load the first library - TSystem will do the rest.
+            auto res = gSystem->Load(lib);
+            if (res >=0) {
+               if (res == 0) ++nlibs;
+               loadedlibs.insert(lib.Data());
+            } else {
+               failedlibs.insert(lib.Data());
+            }
+         }
+      }
+   }
+   return nlibs;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/cont/inc/TClonesArray.h
+++ b/core/cont/inc/TClonesArray.h
@@ -36,7 +36,7 @@ protected:
    TObjArray    *fKeep;        //!Saved copies of pointers to objects
 
 public:
-   enum {
+   enum EStatusBits {
       kForgetBits     = BIT(0),   // Do not create branches for fBits, fUniqueID
       kBypassStreamer = BIT(12)   // Class Streamer not called (default)
    };

--- a/core/cont/inc/TClonesArray.h
+++ b/core/cont/inc/TClonesArray.h
@@ -38,7 +38,6 @@ protected:
 public:
    enum {
       kForgetBits     = BIT(0),   // Do not create branches for fBits, fUniqueID
-      kNoSplit        = BIT(1),   // Array not split by TTree::Branch
       kBypassStreamer = BIT(12)   // Class Streamer not called (default)
    };
 

--- a/core/cont/inc/TClonesArray.h
+++ b/core/cont/inc/TClonesArray.h
@@ -37,8 +37,8 @@ protected:
 
 public:
    enum EStatusBits {
-      kForgetBits     = BIT(0),   // Do not create branches for fBits, fUniqueID
-      kBypassStreamer = BIT(12)   // Class Streamer not called (default)
+      kBypassStreamer = BIT(12),  // Class Streamer not called (default)
+      kForgetBits     = BIT(15)   // Do not create branches for fBits, fUniqueID
    };
 
    TClonesArray();

--- a/core/cont/inc/TCollection.h
+++ b/core/cont/inc/TCollection.h
@@ -135,7 +135,7 @@ private:
    void operator=(const TCollection &); //are too complex to be automatically copied
 
 protected:
-   enum { kIsOwner = BIT(14) };
+   enum EStatusBits { kIsOwner = BIT(14) };
 
    TString   fName;               //name of the collection
    Int_t     fSize;               //number of elements in collection

--- a/core/cont/inc/TMap.h
+++ b/core/cont/inc/TMap.h
@@ -48,7 +48,7 @@ private:
    TMap& operator=(const TMap& map);  // not implemented
 
 protected:
-   enum { kIsOwnerValue = BIT(15) };
+   enum EStatusBits { kIsOwnerValue = BIT(15) };
 
    virtual void        PrintCollectionEntry(TObject* entry, Option_t* option, Int_t recurse) const;
 

--- a/core/cont/inc/TRefTable.h
+++ b/core/cont/inc/TRefTable.h
@@ -59,7 +59,7 @@ protected:
 
 public:
 
-   enum {
+   enum EStatusBits {
       kHaveWarnedReadingOld = BIT(14)
    };
 

--- a/core/meta/CMakeLists.txt
+++ b/core/meta/CMakeLists.txt
@@ -12,3 +12,6 @@ ROOT_OBJECT_LIBRARY(Meta ${sources})
 
 ROOT_INSTALL_HEADERS()
 
+if(testing)
+  add_subdirectory(test)
+endif()

--- a/core/meta/inc/LinkDef.h
+++ b/core/meta/inc/LinkDef.h
@@ -71,6 +71,7 @@
 #pragma link C++ class TListOfEnums+;
 #pragma link C++ class TListOfEnumsWithLock+;
 #pragma link C++ class TListOfEnumsWithLockIter;
+#pragma link C++ class ROOT::Detail::TStatusBitsChecker-;
 //for new protoclasses
 #pragma link C++ class std::vector<TDataMember * >+;
 #pragma link C++ class std::vector<TProtoClass::TProtoRealData >+;

--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -77,16 +77,18 @@ friend class TProtoClass;
 
 public:
    // TClass status bits
-   enum { kClassSaved  = BIT(12), kIgnoreTObjectStreamer = BIT(15),
-          kUnloaded    = BIT(16), // The library containing the dictionary for this class was
-                                  // loaded and has been unloaded from memory.
-          kIsTObject = BIT(17),
-          kIsForeign   = BIT(18),
-          kIsEmulation = BIT(19), // Deprecated
-          kStartWithTObject = BIT(20),  // see comments for IsStartingWithTObject()
-          kWarned      = BIT(21),
-          kHasNameMapNode = BIT(22),
-          kHasCustomStreamerMember = BIT(23) // The class has a Streamer method and it is implemented by the user or an older (not StreamerInfo based) automatic streamer.
+   enum EStatusBits {
+      kClassSaved  = BIT(12),
+      kIgnoreTObjectStreamer = BIT(15),
+      kUnloaded    = BIT(16), // The library containing the dictionary for this class was
+                              // loaded and has been unloaded from memory.
+      kIsTObject = BIT(17),
+      kIsForeign   = BIT(18),
+      kIsEmulation = BIT(19), // Deprecated
+      kStartWithTObject = BIT(20),  // see comments for IsStartingWithTObject()
+      kWarned      = BIT(21),
+      kHasNameMapNode = BIT(22),
+      kHasCustomStreamerMember = BIT(23) // The class has a Streamer method and it is implemented by the user or an older (not StreamerInfo based) automatic streamer.
    };
    enum ENewType { kRealNew = 0, kClassNew, kDummyNew };
    enum ECheckSum {

--- a/core/meta/inc/TDataMember.h
+++ b/core/meta/inc/TDataMember.h
@@ -31,7 +31,9 @@ class TMethodCall;
 class TDataMember : public TDictionary {
 
 private:
-   enum { kObjIsPersistent = BIT(2) };
+   enum EStatusBits {
+      kObjIsPersistent = BIT(2)
+   };
 
    DataMemberInfo_t   *fInfo;         //!pointer to CINT data member info
    TClass             *fClass;        //!pointer to the class

--- a/core/meta/inc/TProtoClass.h
+++ b/core/meta/inc/TProtoClass.h
@@ -41,7 +41,7 @@ public:
       Int_t  fClassIndex; // index of class belonging to in list of dep classes
       char   fStatusFlag; // status of the real data member (if bit 0 set is an object, if bit 1 set is transient if bit 2 set is a pointer)
 
-      enum  {
+      enum EStatusFlags {
          kIsObject    = BIT(0),    // member is object
          kIsTransient = BIT(1),    // data member is transient
          kIsPointer   = BIT(2),    // data member is a pointer

--- a/core/meta/inc/TRealData.h
+++ b/core/meta/inc/TRealData.h
@@ -40,7 +40,7 @@ private:
    TRealData& operator=(const TRealData& rhs);  // Copying TRealData in not allowed.
 
 public:
-   enum {
+   enum EStatusBits {
       kTransient = BIT(14)  // The member is transient.
    };
 

--- a/core/meta/inc/TStatusBitsChecker.h
+++ b/core/meta/inc/TStatusBitsChecker.h
@@ -1,0 +1,55 @@
+// @(#)root/meta:$Id$
+// Author: Philippe Canal, 2017
+
+/*************************************************************************
+ * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TStatusBitsChecker
+#define ROOT_TStatusBitsChecker
+
+#include <string>
+#include <map>
+#include <list>
+
+#include "Rtypes.h"
+
+class TClass;
+
+namespace ROOT {
+namespace Detail {
+
+class TStatusBitsChecker {
+protected:
+   static UChar_t ConvertToBit(Long64_t constant, TClass &classRef, const char *constantName);
+
+public:
+   class Registry {
+   protected:
+      struct Info;
+
+      std::map<UChar_t, std::list<Info>> fRegister; ///<! Register of bits seen so far.
+
+   public:
+
+      void RegisterBits(TClass &classRef);
+
+      bool Check(TClass &classRef, bool verbose = false);
+
+      Registry();  // Implemented in source file to allow hiding of the Info struct.
+      ~Registry(); // Implemented in source file to allow hiding of the Info struct.
+   };
+
+   static bool Check(TClass &classRef, bool verbose = false);
+   static bool Check(const char *classname, bool verbose = false);
+   static bool CheckAllClasses(bool verbosity = false);
+};
+
+} // Details
+} // ROOT
+
+#endif // ROOT__TStatusBitsChecker

--- a/core/meta/inc/TStreamerElement.h
+++ b/core/meta/inc/TStreamerElement.h
@@ -88,7 +88,7 @@ public:
       // we can not change its value without breaking forward compatibility.
       // Furthermore, TObject::kInvalidObject and its semantic is not (and should not be)
       // used in TStreamerElement
-      kDoNotDelete  = TStreamerElement::kDoNotDelete,
+      kDoNotDelete = TStreamerElement::kDoNotDelete,
 
       // This bit duplicates TObject::kCannotPick. As the semantic of kHasRange is a persistent,
       // we can not change its value without breaking forward compatibility.

--- a/core/meta/inc/TStreamerElement.h
+++ b/core/meta/inc/TStreamerElement.h
@@ -83,6 +83,21 @@ public:
       kWholeObject  = BIT(14)
    };
 
+   enum class EStatusBitsDupExceptions {
+      // This bit duplicates TObject::kInvalidObject. As the semantic of kDoNotDelete is a persistent,
+      // we can not change its value without breaking forward compatibility.
+      // Furthermore, TObject::kInvalidObject and its semantic is not (and should not be)
+      // used in TStreamerElement
+      kDoNotDelete  = TStreamerElement::kDoNotDelete,
+
+      // This bit duplicates TObject::kCannotPick. As the semantic of kHasRange is a persistent,
+      // we can not change its value without breaking forward compatibility.
+      // Furthermore, TObject::kCannotPick and its semantic is not (and should not be)
+      // used in TStreamerElement
+      kHasRange = TStreamerElement::kHasRange
+   };
+
+
    TStreamerElement();
    TStreamerElement(const char *name, const char *title, Int_t offset, Int_t dtype, const char *typeName);
    virtual         ~TStreamerElement();

--- a/core/meta/inc/TStreamerElement.h
+++ b/core/meta/inc/TStreamerElement.h
@@ -73,7 +73,7 @@ public:
       kSTLbitset            = ROOT::kSTLbitset
    };
    // TStreamerElement status bits
-   enum {
+   enum EStatusBits {
       kHasRange     = BIT(6),
       kCache        = BIT(9),
       kRepeat       = BIT(10),
@@ -374,7 +374,7 @@ public:
 //________________________________________________________________________
 class TStreamerSTL : public TStreamerElement {
 
-   enum {
+   enum EStatusBits {
       kWarned       = BIT(21)
    };
 

--- a/core/meta/inc/TVirtualStreamerInfo.h
+++ b/core/meta/inc/TVirtualStreamerInfo.h
@@ -62,7 +62,8 @@ protected:
 public:
 
    //status bits
-   enum { kCannotOptimize        = BIT(12),
+   enum EStatusBits {
+          kCannotOptimize        = BIT(12),
           kIgnoreTObjectStreamer = BIT(13),  // eventhough BIT(13) is taken up by TObject (to preserve forward compatibility)
           kRecovered             = BIT(14),
           kNeedCheck             = BIT(15),

--- a/core/meta/inc/TVirtualStreamerInfo.h
+++ b/core/meta/inc/TVirtualStreamerInfo.h
@@ -72,6 +72,14 @@ public:
           kBuildRunning          = BIT(18)
    };
 
+   enum class EStatusBitsDupExceptions {
+        // This bit duplicates TObject::kInvalidObject. As the semantic of kIgnoreTObjectStreamer is a persistent,
+        // we can not change its value without breaking forward compatibility.
+        // Furthermore, TObject::kInvalidObject and its semantic is not (and should not be)
+        // used in TVirtualStreamerInfo
+        kIgnoreTObjectStreamer  = TVirtualStreamerInfo::kIgnoreTObjectStreamer,
+   };
+
    enum EReadWrite {
       kBase        =  0,  kOffsetL = 20,  kOffsetP = 40,  kCounter =  6,  kCharStar = 7,
       kChar        =  1,  kShort   =  2,  kInt     =  3,  kLong    =  4,  kFloat    = 5,

--- a/core/meta/inc/TVirtualStreamerInfo.h
+++ b/core/meta/inc/TVirtualStreamerInfo.h
@@ -63,21 +63,21 @@ public:
 
    //status bits
    enum EStatusBits {
-          kCannotOptimize        = BIT(12),
-          kIgnoreTObjectStreamer = BIT(13),  // eventhough BIT(13) is taken up by TObject (to preserve forward compatibility)
-          kRecovered             = BIT(14),
-          kNeedCheck             = BIT(15),
-          kIsCompiled            = BIT(16),
-          kBuildOldUsed          = BIT(17),
-          kBuildRunning          = BIT(18)
+      kCannotOptimize        = BIT(12),
+      kIgnoreTObjectStreamer = BIT(13),  // eventhough BIT(13) is taken up by TObject (to preserve forward compatibility)
+      kRecovered             = BIT(14),
+      kNeedCheck             = BIT(15),
+      kIsCompiled            = BIT(16),
+      kBuildOldUsed          = BIT(17),
+      kBuildRunning          = BIT(18)
    };
 
    enum class EStatusBitsDupExceptions {
-        // This bit duplicates TObject::kInvalidObject. As the semantic of kIgnoreTObjectStreamer is a persistent,
-        // we can not change its value without breaking forward compatibility.
-        // Furthermore, TObject::kInvalidObject and its semantic is not (and should not be)
-        // used in TVirtualStreamerInfo
-        kIgnoreTObjectStreamer  = TVirtualStreamerInfo::kIgnoreTObjectStreamer,
+      // This bit duplicates TObject::kInvalidObject. As the semantic of kIgnoreTObjectStreamer is a persistent,
+      // we can not change its value without breaking forward compatibility.
+      // Furthermore, TObject::kInvalidObject and its semantic is not (and should not be)
+      // used in TVirtualStreamerInfo
+      kIgnoreTObjectStreamer  = TVirtualStreamerInfo::kIgnoreTObjectStreamer,
    };
 
    enum EReadWrite {

--- a/core/meta/src/TStatusBitsChecker.cxx
+++ b/core/meta/src/TStatusBitsChecker.cxx
@@ -99,15 +99,21 @@ TStatusBitsChecker::Registry::~Registry() = default;
 UChar_t TStatusBitsChecker::ConvertToBit(Long64_t constant, TClass &classRef, const char *constantName)
 {
 
-   if (constant < 0) {
+   if (constant <= 0) {
       Error("TStatusBitsChecker::ConvertBit", "In %s the value of %s is %lld which was not produced by BIT macro.",
             classRef.GetName(), constantName, constant);
       return 255;
    }
 
-   auto backshift = std::log2(constant);
+   int backshift;
+   double fraction = std::frexp(constant, &backshift);
+   // frexp doc is:
+   //    if no errors occur,
+   //    returns the value x in the range (-1;-0.5], [0.5; 1)
+   //    and stores an integer value in *exp such that x×2^(*exp) = arg
+   --backshift; // frexp is such that BIT(0) == 1 == 0.5*2^(*exp) with *exp == 1
 
-   if (std::abs(std::nearbyint(backshift) - backshift) > 0.00001f) {
+   if (backshift < 0 || std::abs(0.5 - fraction) > 0.00001f) {
       Error("TStatusBitsChecker::ConvertBit", "In %s the value of %s is %lld which was not produced by BIT macro.",
             classRef.GetName(), constantName, constant);
       return 255;

--- a/core/meta/src/TStatusBitsChecker.cxx
+++ b/core/meta/src/TStatusBitsChecker.cxx
@@ -1,0 +1,274 @@
+// Author: Philippe Canal, 2017
+
+/*************************************************************************
+ * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+/** \class TStatusBitsChecker
+
+   TStatusBitsChecker::Check and TStatusBitsChecker::CheckAllClasses will
+   determine if the set of "status bit" declared in the class and its
+   base classes presents any overlap.  The status bit are declared in
+   a given class by declaring an enum type named EStatusBits.
+   If some of the duplication is intentional, those duplication can
+   be registered in an enum type named EStatusBitsDupExceptions.
+
+   ~~~ {.cpp}
+   // TStreamerElement status bits
+   enum EStatusBits {
+      kHasRange     = BIT(6),
+      kCache        = BIT(9),
+      kRepeat       = BIT(10),
+      kRead         = BIT(11),
+      kWrite        = BIT(12),
+      kDoNotDelete  = BIT(13),
+      kWholeObject  = BIT(14)
+   };
+
+   enum class EStatusBitsDupExceptions {
+      // This bit duplicates TObject::kInvalidObject. As the semantic of kDoNotDelete is a persistent,
+      // we can not change its value without breaking forward compatibility.
+      // Furthermore, TObject::kInvalidObject and its semantic is not (and should not be)
+      // used in TStreamerElement
+      kDoNotDelete  = TStreamerElement::kDoNotDelete,
+
+      // This bit duplicates TObject::kCannotPick. As the semantic of kHasRange is a persistent,
+      // we can not change its value without breaking forward compatibility.
+      // Furthermore, TObject::kCannotPick and its semantic is not (and should not be)
+      // used in TStreamerElement
+      kHasRange = TStreamerElement::kHasRange
+   };
+  ~~~ {.cpp}
+
+  Without the EStatusBitsDupExceptions enum you would see
+
+  ~~~ {.cpp}
+TStatusBitsChecker::Check("TStreamerElement");
+
+Error in <TStatusBitsChecker>: In TStreamerElement class hierarchy, there are duplicates bits:
+Error in <TStatusBitsChecker>:    Bit   6 used in TStreamerElement as kHasRange
+Error in <TStatusBitsChecker>:    Bit   6 used in TObject as kCannotPick
+Error in <TStatusBitsChecker>:    Bit  13 used in TStreamerElement as kDoNotDelete
+Error in <TStatusBitsChecker>:    Bit  13 used in TObject as kInvalidObject
+  ~~~ {.cpp}
+
+*/
+
+#include "TStatusBitsChecker.h"
+
+#include "TBaseClass.h"
+#include "TClass.h"
+#include "TClassTable.h"
+#include "TEnum.h"
+#include "TEnumConstant.h"
+#include "TError.h"
+
+#include <cmath>
+
+namespace ROOT {
+namespace Detail {
+
+struct TStatusBitsChecker::Registry::Info {
+   Info() = default;
+   Info(const Info &) = default;
+   Info(Info &&) = default;
+
+   Info(TClass &o, std::string &&n, bool intentionalDup) : fOwner(&o), fConstantName(n), fIntentionalDup(intentionalDup)
+   {
+   }
+
+   ~Info() = default;
+
+   TClass *fOwner;
+   std::string fConstantName;
+   bool fIntentionalDup = false;
+};
+
+/// Default constructor. Implemented in source file to allow hiding of the Info struct.
+TStatusBitsChecker::Registry::Registry() = default;
+
+/// Default destructor. Implemented in source file to allow hiding of the Info struct.
+TStatusBitsChecker::Registry::~Registry() = default;
+
+/// Figure out which bit the constant has been set from/to.
+/// Return 255 if the constant is not an integer or out of range.
+UChar_t TStatusBitsChecker::ConvertToBit(Long64_t constant, TClass &classRef, const char *constantName)
+{
+
+   if (constant < 0) {
+      Error("TStatusBitsChecker::ConvertBit", "In %s the value of %s is %lld which was not produced by BIT macro.",
+            classRef.GetName(), constantName, constant);
+      return 255;
+   }
+
+   auto backshift = std::log2(constant);
+
+   if (std::abs(std::nearbyint(backshift) - backshift) > 0.00001f) {
+      Error("TStatusBitsChecker::ConvertBit", "In %s the value of %s is %lld which was not produced by BIT macro.",
+            classRef.GetName(), constantName, constant);
+      return 255;
+   }
+
+   if (backshift > 24) {
+      Error("TStatusBitsChecker::ConvertBit", "In %s the value of %s is %lld (>23) which is ignored by SetBit.",
+            classRef.GetName(), constantName, constant);
+
+      if (backshift > 255) // really we could snip it sooner.
+         backshift = 255;
+   }
+
+   return backshift;
+}
+
+/// @brief Add to fRegister the Info about the bits in this class and its base
+/// classes.
+void TStatusBitsChecker::Registry::RegisterBits(TClass &classRef /* = false */)
+{
+   TEnum *eStatusBits = (TEnum *)classRef.GetListOfEnums()->FindObject("EStatusBits");
+   TEnum *exceptionBits = (TEnum *)classRef.GetListOfEnums()->FindObject("EStatusBitsDupExceptions");
+
+   if (eStatusBits) {
+
+      for (auto c : *eStatusBits->GetConstants()) {
+         TEnumConstant *constant = static_cast<TEnumConstant *>(c);
+
+         // Ignore the known/intentional duplication.
+         bool intentionalDup = exceptionBits && exceptionBits->GetConstant(constant->GetName());
+
+         auto value = constant->GetValue();
+         auto bit = ConvertToBit(value, classRef, constant->GetName());
+
+         if (bit < 24) {
+            bool need = true;
+            for (auto reg : fRegister[bit]) {
+               if (reg.fOwner == &classRef) {
+                  // We have a duplicate declared in the same class
+                  // let's accept this as an alias.
+                  need = false;
+               }
+            }
+
+            if (need)
+               fRegister[bit].emplace_back(classRef, std::string(constant->GetName()), intentionalDup);
+         }
+      }
+   }
+
+   TList *lb = classRef.GetListOfBases();
+   if (lb) {
+      for (auto b : *lb) {
+         TBaseClass *base = static_cast<TBaseClass *>(b);
+
+         RegisterBits(*(base->GetClassPointer()));
+      }
+   }
+}
+
+/// @brief Return false and print error messages if there is any unexpected
+/// duplicates BIT constant in the class hierarchy or any of the bits
+/// already registered.
+/// If verbose is true, also print all the bit declare in this class
+/// and all its bases.
+bool TStatusBitsChecker::Registry::Check(TClass &classRef, bool verbose /* = false */)
+{
+   RegisterBits(classRef);
+
+   if (verbose) {
+      for (auto cursor : fRegister) {
+         for (auto constant : cursor.second) {
+            Printf("Bit %3d declared in %s as %s", cursor.first, constant.fOwner->GetName(),
+                   constant.fConstantName.c_str());
+         }
+      }
+   }
+
+   bool issuedHeader = false;
+   bool result = true;
+   for (auto cursor : fRegister) {
+      unsigned int nDuplicate = 0;
+      for (auto constant : cursor.second) {
+         if (!constant.fIntentionalDup)
+            ++nDuplicate;
+      }
+      if (nDuplicate > 1) {
+         if (!issuedHeader) {
+            Error("TStatusBitsChecker", "In %s class hierarchy, there are duplicates bits:", classRef.GetName());
+            issuedHeader = true;
+         }
+         for (auto constant : cursor.second) {
+            if (!constant.fIntentionalDup) {
+               Error("TStatusBitsChecker", "   Bit %3d used in %s as %s", cursor.first, constant.fOwner->GetName(),
+                     constant.fConstantName.c_str());
+               result = false;
+            }
+         }
+      }
+   }
+
+   return result;
+}
+
+/// Return false and print error messages if there is any unexpected
+/// duplicates BIT constant in the class hierarchy.
+/// If verbose is true, also print all the bit declare in this class
+/// and all its bases.
+bool TStatusBitsChecker::Check(TClass &classRef, bool verbose /* = false */)
+{
+   return Registry().Check(classRef, verbose);
+}
+
+/// Return false and print error messages if there is any unexpected
+/// duplicates BIT constant in the class hierarchy.
+/// If verbose is true, also print all the bit declare in this class
+/// and all its bases.
+bool TStatusBitsChecker::Check(const char *classname, bool verbose)
+{
+   TClass *cl = TClass::GetClass(classname);
+   if (cl)
+      return Check(*cl, verbose);
+   else
+      return true;
+}
+
+/// Return false and print error messages if there is any unexpected
+/// duplicates BIT constant in any of the class hierarchy knows
+/// to TClassTable.
+/// If verbose is true, also print all the bit declare in eacho of the classes
+/// and all their bases.
+bool TStatusBitsChecker::CheckAllClasses(bool verbosity /* = false */)
+{
+   bool result = true;
+
+   // Start from beginning
+   gClassTable->Init();
+
+   std::set<std::string> rootLibs;
+   TList classesDeclFileNotFound;
+   TList classesImplFileNotFound;
+
+   Int_t totalNumberOfClasses = gClassTable->Classes();
+   for (Int_t i = 0; i < totalNumberOfClasses; i++) {
+
+      // get class name
+      const char *cname = gClassTable->Next();
+      if (!cname)
+         continue;
+
+      // get class & filename - use TROOT::GetClass, as we also
+      // want those classes without decl file name!
+      TClass *classPtr = TClass::GetClass((const char *)cname, kTRUE);
+      if (!classPtr)
+         continue;
+
+      result = Check(*classPtr, verbosity) && result;
+   }
+
+   return result;
+}
+
+} // namespace Details
+} // namespace ROOT

--- a/core/meta/test/CMakeLists.txt
+++ b/core/meta/test/CMakeLists.txt
@@ -1,0 +1,1 @@
+ROOT_ADD_GTEST(testStatusBitsChecker testStatusBitsChecker.cxx LIBRARIES Core)

--- a/core/meta/test/testStatusBitsChecker.cxx
+++ b/core/meta/test/testStatusBitsChecker.cxx
@@ -1,0 +1,32 @@
+#include "TStatusBitsChecker.h"
+
+#include "TClass.h"
+#include "TInterpreter.h"
+
+#include "gtest/gtest.h"
+
+const char* gCode = R"CODE(
+   struct ClassWithOverlap : public TObject {
+      enum EStatusBits {
+         kOverlappingBit = BIT(13)
+      };
+   };
+)CODE";
+
+void MakeClassWithOverlap() {
+   gInterpreter->Declare(gCode);
+}
+
+TEST(StatusBitsChecker,NoOverlap)
+{
+   EXPECT_TRUE(ROOT::Detail::TStatusBitsChecker::Check("TObject"));
+   EXPECT_TRUE(ROOT::Detail::TStatusBitsChecker::Check("TNamed"));
+   EXPECT_TRUE(ROOT::Detail::TStatusBitsChecker::Check("TStreamerElement"));
+}
+
+TEST(StatusBitsChecker,Overlap)
+{
+   MakeClassWithOverlap();
+   EXPECT_NE(nullptr,TClass::GetClass("ClassWithOverlap"));
+   EXPECT_FALSE(ROOT::Detail::TStatusBitsChecker::Check("ClassWithOverlap"));
+}

--- a/graf2d/graf/inc/TLink.h
+++ b/graf2d/graf/inc/TLink.h
@@ -22,7 +22,7 @@ protected:
    void   *fLink;           ///< pointer to object
 
 public:
-   enum { kObjIsParent = BIT(1) , kIsStarStar = BIT(2)};
+   enum EStatusBits { kObjIsParent = BIT(1) , kIsStarStar = BIT(2)};
    TLink();
    TLink(Double_t x, Double_t y, void *pointer);
    virtual ~TLink();

--- a/graf2d/graf/inc/TLink.h
+++ b/graf2d/graf/inc/TLink.h
@@ -22,7 +22,7 @@ protected:
    void   *fLink;           ///< pointer to object
 
 public:
-   enum EStatusBits { kObjIsParent = BIT(1) , kIsStarStar = BIT(2)};
+   enum EStatusBits { kIsStarStar = BIT(2)};
    TLink();
    TLink(Double_t x, Double_t y, void *pointer);
    virtual ~TLink();

--- a/graf2d/graf/inc/TLink.h
+++ b/graf2d/graf/inc/TLink.h
@@ -22,7 +22,7 @@ protected:
    void   *fLink;           ///< pointer to object
 
 public:
-   enum EStatusBits { kIsStarStar = BIT(2)};
+   enum EStatusBits { kIsStarStar = BIT(2) };
    TLink();
    TLink(Double_t x, Double_t y, void *pointer);
    virtual ~TLink();

--- a/hist/hist/inc/TAxis.h
+++ b/hist/hist/inc/TAxis.h
@@ -54,7 +54,7 @@ private:
 
 public:
    // TAxis status bits
-   enum {
+   enum EStatusBits {
           kDecimals      = BIT(7),
           kTickPlus      = BIT(9),
           kTickMinus     = BIT(10),

--- a/hist/hist/inc/TAxis.h
+++ b/hist/hist/inc/TAxis.h
@@ -55,21 +55,21 @@ private:
 public:
    // TAxis status bits
    enum EStatusBits {
-          kDecimals      = BIT(7),
-          kTickPlus      = BIT(9),
-          kTickMinus     = BIT(10),
-          kAxisRange     = BIT(11),
-          kCenterTitle   = BIT(12),
-          kCenterLabels  = BIT(14), //bit 13 is used by TObject
-          kRotateTitle   = BIT(15),
-          kPalette       = BIT(16),
-          kNoExponent    = BIT(17),
-          kLabelsHori    = BIT(18),
-          kLabelsVert    = BIT(19),
-          kLabelsDown    = BIT(20),
-          kLabelsUp      = BIT(21),
-          kIsInteger     = BIT(22),
-          kMoreLogLabels = BIT(23)
+      kDecimals      = BIT(7),
+      kTickPlus      = BIT(9),
+      kTickMinus     = BIT(10),
+      kAxisRange     = BIT(11),
+      kCenterTitle   = BIT(12),
+      kCenterLabels  = BIT(14), //bit 13 is used by TObject
+      kRotateTitle   = BIT(15),
+      kPalette       = BIT(16),
+      kNoExponent    = BIT(17),
+      kLabelsHori    = BIT(18),
+      kLabelsVert    = BIT(19),
+      kLabelsDown    = BIT(20),
+      kLabelsUp      = BIT(21),
+      kIsInteger     = BIT(22),
+      kMoreLogLabels = BIT(23)
    };
 
    TAxis();

--- a/hist/hist/inc/TBackCompFitter.h
+++ b/hist/hist/inc/TBackCompFitter.h
@@ -49,7 +49,7 @@ public:
 
 public:
 
-   enum {
+   enum EStatusBits {
       kCanDeleteLast = BIT(9)  // object can be deleted before creating a new one
    };
 

--- a/hist/hist/inc/TEfficiency.h
+++ b/hist/hist/inc/TEfficiency.h
@@ -59,11 +59,11 @@ protected:
       Double_t      fWeight;                 //weight for all events (default = 1)
 
       enum EStatusBits {
-         kIsBayesian       = BIT(14),              //bayesian statistics are used
-         kPosteriorMode    = BIT(15),              //use posterior mean for best estimate (Bayesian statistics)
-         kShortestInterval = BIT(16),              // use shortest interval
-         kUseBinPrior      = BIT(17),              // use a different prior for each bin
-         kUseWeights       = BIT(18)               // use weights
+         kIsBayesian       = BIT(14),  //bayesian statistics are used
+         kPosteriorMode    = BIT(15),  //use posterior mean for best estimate (Bayesian statistics)
+         kShortestInterval = BIT(16),  // use shortest interval
+         kUseBinPrior      = BIT(17),  // use a different prior for each bin
+         kUseWeights       = BIT(18)   // use weights
       };
 
       void          Build(const char* name,const char* title);

--- a/hist/hist/inc/TEfficiency.h
+++ b/hist/hist/inc/TEfficiency.h
@@ -58,7 +58,7 @@ protected:
       TH1*          fTotalHistogram;         //histogram for total number of events
       Double_t      fWeight;                 //weight for all events (default = 1)
 
-      enum{
+      enum EStatusBits {
          kIsBayesian       = BIT(14),              //bayesian statistics are used
          kPosteriorMode    = BIT(15),              //use posterior mean for best estimate (Bayesian statistics)
          kShortestInterval = BIT(16),              // use shortest interval

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -301,12 +301,9 @@ public:
    virtual void GetRange(Double_t *xmin, Double_t *xmax) const;
    virtual TH1 *DoCreateHistogram(Double_t xmin, Double_t xmax, Bool_t recreate = kFALSE);
 
-   enum {
-      kNotGlobal   = BIT(10),  // don't register in global list of functions
-   };
-
    // TF1 status bits
-   enum {
+   enum EStatusBits {
+      kNotGlobal   = BIT(10),  // don't register in global list of functions
       kNotDraw     = BIT(9)  // don't draw the function when in a TH1
    };
 

--- a/hist/hist/inc/TFormula.h
+++ b/hist/hist/inc/TFormula.h
@@ -145,7 +145,7 @@ protected:
 
 public:
 
-   enum {
+   enum EStatusBits {
       kNotGlobal     = BIT(10),    // don't store in gROOT->GetListOfFunction (it should be protected)
       kNormalized    = BIT(14),    // set to true if the TFormula (ex gausn) is normalized
       kLinear        = BIT(16),    //set to true if the TFormula is for linear fitting

--- a/hist/hist/inc/TGraph.h
+++ b/hist/hist/inc/TGraph.h
@@ -66,7 +66,7 @@ protected:
 
 public:
    // TGraph status bits
-   enum {
+   enum EStatusBits {
       kClipFrame     = BIT(10),  ///< clip to the frame boundary
       kResetHisto    = BIT(17),  ///< fHistogram must be reset in GetHistogram
       kNotEditable   = BIT(18),  ///< bit set if graph is non editable

--- a/hist/hist/inc/TGraph2D.h
+++ b/hist/hist/inc/TGraph2D.h
@@ -65,7 +65,7 @@ private:
 
    Bool_t      fUserHisto;   // True when SetHistogram has been called
 
-   enum {
+   enum EStatusBits {
       kOldInterpolation =  BIT(15)
    };
 

--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -144,7 +144,7 @@ protected:
 
 public:
    // TH1 status bits
-   enum {
+   enum EStatusBits {
       kNoStats     = BIT(9),  ///< don't draw stats box
       kUserContour = BIT(10), ///< user specified contour levels
     //kCanRebin    = BIT(11), ///< FIXME DEPRECATED - to be removed, replaced by SetCanExtend / CanExtendAllAxes

--- a/hist/histpainter/inc/TPaletteAxis.h
+++ b/hist/histpainter/inc/TPaletteAxis.h
@@ -35,7 +35,7 @@ protected:
 
 public:
    // TPaletteAxis status bits
-   enum EStatusBits { kHasView   = BIT(11) };
+   enum EStatusBits { kHasView = BIT(11) };
 
    TPaletteAxis();
    TPaletteAxis(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2, TH1 *h);

--- a/hist/histpainter/inc/TPaletteAxis.h
+++ b/hist/histpainter/inc/TPaletteAxis.h
@@ -35,7 +35,7 @@ protected:
 
 public:
    // TPaletteAxis status bits
-   enum { kHasView   = BIT(11)};
+   enum EStatusBits { kHasView   = BIT(11) };
 
    TPaletteAxis();
    TPaletteAxis(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2, TH1 *h);

--- a/html/src/THtml.cxx
+++ b/html/src/THtml.cxx
@@ -2202,39 +2202,7 @@ Bool_t THtml::IsNamespace(const TClass*cl)
 
 void THtml::LoadAllLibs()
 {
-   TEnv* mapfile = gInterpreter->GetMapfile();
-   if (!mapfile || !mapfile->GetTable()) return;
-
-   std::set<std::string> loadedlibs;
-   std::set<std::string> failedlibs;
-
-   TEnvRec* rec = 0;
-   TIter iEnvRec(mapfile->GetTable());
-   while ((rec = (TEnvRec*) iEnvRec())) {
-      TString libs = rec->GetValue();
-      TString lib;
-      Ssiz_t pos = 0;
-      while (libs.Tokenize(lib, pos)) {
-         // check that none of the libs failed to load
-         if (failedlibs.find(lib.Data()) != failedlibs.end()) {
-            // don't load it or any of its dependencies
-            libs = "";
-            break;
-         }
-      }
-      pos = 0;
-      while (libs.Tokenize(lib, pos)) {
-         // ignore libCore - it's already loaded
-         if (lib.BeginsWith("libCore"))
-            continue;
-
-         if (loadedlibs.find(lib.Data()) == loadedlibs.end()) {
-            // just load the first library - TSystem will do the rest.
-            gSystem->Load(lib);
-            loadedlibs.insert(lib.Data());
-         }
-      }
-   }
+   gSystem->LoadAllLibraries();
 }
 
 

--- a/html/src/THtml.cxx
+++ b/html/src/THtml.cxx
@@ -1557,7 +1557,7 @@ void THtml::CreateListOfClasses(const char* filter)
 
    fDocEntityInfo.fClassFilter = filter;
 
-   // start from begining
+   // start from beginning
    gClassTable->Init();
    if (filter && (!filter[0] || !strcmp(filter, "*")))
       filter = ".*";

--- a/io/io/inc/TBufferFile.h
+++ b/io/io/inc/TBufferFile.h
@@ -79,9 +79,12 @@ public:
    enum { kMapSize = 503 };
    enum { kStreamedMemberWise = BIT(14) }; //added to version number to know if a collection has been stored member-wise
    enum EStatusBits {
-     kNotDecompressed = BIT(15),    //indicates a weird buffer, used by TBasket
+     kNotDecompressed    = BIT(15),    //indicates a weird buffer, used by TBasket
      kTextBasedStreaming = BIT(18), //indicates if buffer used for XML/SQL object streaming
-     kUser1 = BIT(21), kUser2 = BIT(22), kUser3 = BIT(23) //free for user
+
+     kUser1 = BIT(21), //free for user
+     kUser2 = BIT(22), //free for user
+     kUser3 = BIT(23)  //free for user
    };
 
    TBufferFile(TBuffer::EMode mode);

--- a/io/io/inc/TBufferFile.h
+++ b/io/io/inc/TBufferFile.h
@@ -78,9 +78,11 @@ protected:
 public:
    enum { kMapSize = 503 };
    enum { kStreamedMemberWise = BIT(14) }; //added to version number to know if a collection has been stored member-wise
-   enum { kNotDecompressed = BIT(15) };    //indicates a weird buffer, used by TBasket
-   enum { kTextBasedStreaming = BIT(18) }; //indicates if buffer used for XML/SQL object streaming
-   enum { kUser1 = BIT(21), kUser2 = BIT(22), kUser3 = BIT(23)}; //free for user
+   enum EStatusBits {
+     kNotDecompressed = BIT(15),    //indicates a weird buffer, used by TBasket
+     kTextBasedStreaming = BIT(18), //indicates if buffer used for XML/SQL object streaming
+     kUser1 = BIT(21), kUser2 = BIT(22), kUser3 = BIT(23) //free for user
+   };
 
    TBufferFile(TBuffer::EMode mode);
    TBufferFile(TBuffer::EMode mode, Int_t bufsiz);

--- a/io/io/inc/TStreamerInfo.h
+++ b/io/io/inc/TStreamerInfo.h
@@ -136,12 +136,13 @@ private:
 public:
 
    /// Status bits
-   enum { kCannotOptimize        = BIT(12),
-          kIgnoreTObjectStreamer = BIT(13),  ///< Eventhough BIT(13) is taken up by TObject (to preserverse forward compatibility)
-          kRecovered             = BIT(14),
-          kNeedCheck             = BIT(15),
-          kIsCompiled            = BIT(16),
-          kBuildOldUsed          = BIT(17)
+   enum EStatusBits {
+      kCannotOptimize        = BIT(12),
+      kIgnoreTObjectStreamer = BIT(13),  ///< Eventhough BIT(13) is taken up by TObject (to preserverse forward compatibility)
+      kRecovered             = BIT(14),
+      kNeedCheck             = BIT(15),
+      kIsCompiled            = BIT(16),
+      kBuildOldUsed          = BIT(17)
    };
 
 /// EReadWrite Enumerator

--- a/io/io/inc/TStreamerInfo.h
+++ b/io/io/inc/TStreamerInfo.h
@@ -138,28 +138,28 @@ public:
    /// Status bits
    /// See TVirtualStreamerInfo::EStatusBits for the values.
 
-/// EReadWrite Enumerator
-/// | Enum Constant | Description   |
-/// |----------|--------------------|
-/// | kBase    | Base class element |
-/// | kOffsetL | Fixed size array |
-/// | kOffsetP | Pointer to object |
-/// | kCounter | Counter for array size |
-/// | kCharStar| Pointer to array of char |
-/// | kLegacyChar | Equal to TDataType's kchar |
-/// | kBits    | TObject::fBits in case of a referenced object |
-/// | kObject  | Class  derived from TObject, or for TStreamerSTL::fCtype non-pointer elements |
-/// | kObjectp | Class* derived from TObject and with    comment field //->Class, or for TStreamerSTL::fCtype: pointer elements |
-/// | kObjectP | Class* derived from TObject and with NO comment field //->Class |
-/// | kAny     | Class  not derived from TObject |
-/// | kAnyp    | Class* not derived from TObject with    comment field //->Class |
-/// | kAnyP    | Class* not derived from TObject with NO comment field //->Class |
-/// | kAnyPnoVT | Class* not derived from TObject with NO comment field //->Class and Class has NO virtual table |
-/// | kSTLp    | Pointer to STL container |
-/// | kTString | TString, special case |
-/// | kTObject | TObject, special case |
-/// | kTNamed  | TNamed , special case |
-/// | kCache   | Cache the value in memory than is not part of the object but is accessible via a SchemaRule |
+   /// EReadWrite Enumerator
+   /// | Enum Constant | Description   |
+   /// |-------------|--------------------|
+   /// | kBase       | Base class element |
+   /// | kOffsetL    | Fixed size array |
+   /// | kOffsetP    | Pointer to object |
+   /// | kCounter    | Counter for array size |
+   /// | kCharStar   | Pointer to array of char |
+   /// | kLegacyChar | Equal to TDataType's kchar |
+   /// | kBits       | TObject::fBits in case of a referenced object |
+   /// | kObject     | Class  derived from TObject, or for TStreamerSTL::fCtype non-pointer elements |
+   /// | kObjectp    | Class* derived from TObject and with    comment field //->Class, or for TStreamerSTL::fCtype: pointer elements |
+   /// | kObjectP    | Class* derived from TObject and with NO comment field //->Class |
+   /// | kAny        | Class  not derived from TObject |
+   /// | kAnyp       | Class* not derived from TObject with    comment field //->Class |
+   /// | kAnyP       | Class* not derived from TObject with NO comment field //->Class |
+   /// | kAnyPnoVT   | Class* not derived from TObject with NO comment field //->Class and Class has NO virtual table |
+   /// | kSTLp       | Pointer to STL container |
+   /// | kTString    | TString, special case |
+   /// | kTObject    | TObject, special case |
+   /// | kTNamed     | TNamed , special case |
+   /// | kCache      | Cache the value in memory than is not part of the object but is accessible via a SchemaRule |
    enum EReadWrite {
       kBase        =  0,  kOffsetL = 20,  kOffsetP = 40,  kCounter =  6,  kCharStar = 7,
       kChar        =  1,  kShort   =  2,  kInt     =  3,  kLong    =  4,  kFloat    = 5,

--- a/io/io/inc/TStreamerInfo.h
+++ b/io/io/inc/TStreamerInfo.h
@@ -136,14 +136,7 @@ private:
 public:
 
    /// Status bits
-   enum EStatusBits {
-      kCannotOptimize        = BIT(12),
-      kIgnoreTObjectStreamer = BIT(13),  ///< Eventhough BIT(13) is taken up by TObject (to preserverse forward compatibility)
-      kRecovered             = BIT(14),
-      kNeedCheck             = BIT(15),
-      kIsCompiled            = BIT(16),
-      kBuildOldUsed          = BIT(17)
-   };
+   /// See TVirtualStreamerInfo::EStatusBits for the values.
 
 /// EReadWrite Enumerator
 /// | Enum Constant | Description   |

--- a/net/net/inc/TApplicationRemote.h
+++ b/net/net/inc/TApplicationRemote.h
@@ -43,13 +43,13 @@ class TApplicationRemote : public TApplication {
 
 public:
    enum ESendFileOpt {
-      kAscii            = 0x0,
-      kBinary           = 0x1,
-      kForce            = 0x2
+      kAscii  = 0x0,
+      kBinary = 0x1,
+      kForce  = 0x2
    };
    // TApplication specific bits
    enum EStatusBits {
-      kCollecting       = BIT(17)   // TRUE while collecting from server
+      kCollecting = BIT(17)   // TRUE while collecting from server
    };
 
 private:

--- a/net/net/inc/TApplicationRemote.h
+++ b/net/net/inc/TApplicationRemote.h
@@ -49,7 +49,7 @@ public:
    };
    // TApplication specific bits
    enum EStatusBits {
-      kCollecting       = BIT(16)   // TRUE while collecting from server
+      kCollecting       = BIT(17)   // TRUE while collecting from server
    };
 
 private:

--- a/proof/proof/inc/TProofServ.h
+++ b/proof/proof/inc/TProofServ.h
@@ -69,7 +69,7 @@ friend class TProofServLite;
 friend class TXProofServ;
 
 public:
-   enum EStatusBits { kHighMemory = BIT(16) };
+   enum EStatusBits { kHighMemory = BIT(17) };
    enum EQueryAction { kQueryOK, kQueryModify, kQueryStop, kQueryEnqueued };
 
 private:

--- a/proof/proof/inc/TVirtualProofPlayer.h
+++ b/proof/proof/inc/TVirtualProofPlayer.h
@@ -43,7 +43,7 @@ class TSelector;
 class TVirtualProofPlayer : public TObject, public TQObject {
 
 public:
-   enum EStatusBits { kIsSubmerger = BIT(16) };
+   enum EStatusBits { kIsSubmerger = BIT(14) };
    // TDSet status bits
    enum EExitStatus { kFinished, kStopped, kAborted };
 

--- a/tree/tree/inc/TBranch.h
+++ b/tree/tree/inc/TBranch.h
@@ -62,6 +62,12 @@ protected:
 
    // TBranch status bits
    enum EStatusBits {
+      kDoNotProcess = ::kDoNotProcess, // Active bit for branches
+      kIsClone      = ::kIsClone, // to indicate a TBranchClones
+      kBranchObject = ::kBranchObject, // branch is a TObject*
+      kBranchAny    = ::kBranchAny, // branch is an object*
+      // kMapObject    = kBranchObject | kBranchAny;
+
       kAutoDelete = BIT(15),
       kDoNotUseBufferMap = BIT(22) // If set, at least one of the entry in the branch will use the buffer's map of classname and objects.
    };

--- a/tree/tree/inc/TBranch.h
+++ b/tree/tree/inc/TBranch.h
@@ -63,12 +63,12 @@ protected:
    // TBranch status bits
    enum EStatusBits {
       kDoNotProcess = ::kDoNotProcess, // Active bit for branches
-      kIsClone      = ::kIsClone, // to indicate a TBranchClones
+      kIsClone      = ::kIsClone,      // to indicate a TBranchClones
       kBranchObject = ::kBranchObject, // branch is a TObject*
-      kBranchAny    = ::kBranchAny, // branch is an object*
+      kBranchAny    = ::kBranchAny,    // branch is an object*
       // kMapObject    = kBranchObject | kBranchAny;
+      kAutoDelete   = BIT(15),
 
-      kAutoDelete = BIT(15),
       kDoNotUseBufferMap = BIT(22) // If set, at least one of the entry in the branch will use the buffer's map of classname and objects.
    };
 

--- a/tree/tree/inc/TBranchElement.h
+++ b/tree/tree/inc/TBranchElement.h
@@ -49,13 +49,13 @@ class TBranchElement : public TBranch {
 // Types
 protected:
    enum EStatusBits {
-      kBranchFolder = BIT(14),
-      kDeleteObject = BIT(16),  ///<  We are the owner of fObject.
-      kCache        = BIT(18),  ///<  Need to pushd/pop fOnfileObject.
-      kOwnOnfileObj = BIT(19),  ///<  We are the owner of fOnfileObject.
-      kAddressSet   = BIT(20),  ///<  The addressing set have been called for this branch
-      kMakeClass    = BIT(21),  ///<  This branch has been switched to using the MakeClass Mode
-      kDecomposedObj= BIT(21)   ///<  More explicit alias for kMakeClass.
+      kBranchFolder  = BIT(14),
+      kDeleteObject  = BIT(16), ///<  We are the owner of fObject.
+      kCache         = BIT(18), ///<  Need to pushd/pop fOnfileObject.
+      kOwnOnfileObj  = BIT(19), ///<  We are the owner of fOnfileObject.
+      kAddressSet    = BIT(20), ///<  The addressing set have been called for this branch
+      kMakeClass     = BIT(21), ///<  This branch has been switched to using the MakeClass Mode
+      kDecomposedObj = BIT(21)  ///<  More explicit alias for kMakeClass.
    };
 
    // Note on fType values:

--- a/tree/tree/inc/TBranchElement.h
+++ b/tree/tree/inc/TBranchElement.h
@@ -48,7 +48,7 @@ class TBranchElement : public TBranch {
 
 // Types
 protected:
-   enum {
+   enum EStatusBits {
       kBranchFolder = BIT(14),
       kDeleteObject = BIT(16),  ///<  We are the owner of fObject.
       kCache        = BIT(18),  ///<  Need to pushd/pop fOnfileObject.

--- a/tree/tree/inc/TBranchObject.h
+++ b/tree/tree/inc/TBranchObject.h
@@ -26,7 +26,18 @@
 class TBranchObject : public TBranch {
 
 protected:
-   enum EStatusBits { kWarn = BIT(12) };
+   enum EStatusBits {
+      kWarn = BIT(14)
+   };
+
+   // In version of ROOT older then v6.12, kWarn was set to BIT(12)
+   // which overlaps with TBranch::kBranchObject.  Since it stored
+   // in ROOT files as part of the TBranchObject and that we want
+   // to reset in TBranchObject::Streamer, we need to keep track
+   // of the old value.
+   enum EStatusBitsOldValues {
+      kOldWarn = BIT(12)
+   };
 
    TString     fClassName;        ///< Class name of referenced object
    TObject     *fOldObject;       ///< !Pointer to old object

--- a/tree/tree/inc/TBranchObject.h
+++ b/tree/tree/inc/TBranchObject.h
@@ -26,7 +26,7 @@
 class TBranchObject : public TBranch {
 
 protected:
-   enum { kWarn = BIT(12) };
+   enum EStatusBits { kWarn = BIT(12) };
 
    TString     fClassName;        ///< Class name of referenced object
    TObject     *fOldObject;       ///< !Pointer to old object

--- a/tree/tree/inc/TChain.h
+++ b/tree/tree/inc/TChain.h
@@ -55,7 +55,7 @@ protected:
 
 public:
    // TChain constants
-   enum {
+   enum EStatusBits {
       kGlobalWeight   = BIT(15),
       kAutoDelete     = BIT(16),
       kProofUptodate  = BIT(17),

--- a/tree/tree/inc/TFriendElement.h
+++ b/tree/tree/inc/TFriendElement.h
@@ -45,7 +45,7 @@ protected:
    friend void TFriendElement__SetTree(TTree *tree, TList *frlist);
 
 public:
-   enum { kFromChain = BIT(11) };
+   enum EStatusBits { kFromChain = BIT(11) };
    TFriendElement();
    TFriendElement(TTree *tree, const char *treename, const char *filename);
    TFriendElement(TTree *tree, const char *treename, TFile *file);

--- a/tree/tree/inc/TLeaf.h
+++ b/tree/tree/inc/TLeaf.h
@@ -50,7 +50,7 @@ protected:
   };
 
 public:
-   enum {
+   enum EStatusBits {
       kIndirectAddress = BIT(11), ///< Data member is a pointer to an array of basic types.
       kNewValue = BIT(12)         ///< Set if we own the value buffer and so must delete it ourselves.
    };

--- a/tree/tree/inc/TLeafObject.h
+++ b/tree/tree/inc/TLeafObject.h
@@ -36,7 +36,7 @@ protected:
    Bool_t       fVirtual;        ///<  Support for polymorphism, when set classname is written with object.
 
 public:
-   enum { kWarn = BIT(12) };
+   enum EStatusBits { kWarn = BIT(12) };
 
    TLeafObject();
    TLeafObject(TBranch *parent, const char *name, const char *type);

--- a/tree/tree/inc/TLeafObject.h
+++ b/tree/tree/inc/TLeafObject.h
@@ -36,7 +36,18 @@ protected:
    Bool_t       fVirtual;        ///<  Support for polymorphism, when set classname is written with object.
 
 public:
-   enum EStatusBits { kWarn = BIT(12) };
+   enum EStatusBits {
+      kWarn = BIT(14)
+   };
+
+   // In version of ROOT older then v6.12, kWarn was set to BIT(12)
+   // which overlaps with TBranch::kBranchObject.  Since it stored
+   // in ROOT files as part of the TBranchObject and that we want
+   // to reset in TBranchObject::Streamer, we need to keep track
+   // of the old value.
+   enum EStatusBitsOldValues {
+      kOldWarn = BIT(12)
+   };
 
    TLeafObject();
    TLeafObject(TBranch *parent, const char *name, const char *type);

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -215,7 +215,7 @@ public:
    };
 
    // TTree status bits
-   enum {
+   enum EStatusBits {
       kForceRead   = BIT(11),
       kCircular    = BIT(12)
    };

--- a/tree/tree/src/TBranchObject.cxx
+++ b/tree/tree/src/TBranchObject.cxx
@@ -548,6 +548,9 @@ void TBranchObject::Streamer(TBuffer& R__b)
 {
    if (R__b.IsReading()) {
       R__b.ReadClassBuffer(TBranchObject::Class(), this);
+      // We should rewarn in this process.
+      ResetBit(kWarn);
+      ResetBit(kOldWarn);
    } else {
       TDirectory* dirsav = fDirectory;
       fDirectory = 0;  // to avoid recursive calls

--- a/tree/tree/src/TLeafObject.cxx
+++ b/tree/tree/src/TLeafObject.cxx
@@ -200,6 +200,11 @@ void TLeafObject::Streamer(TBuffer &b)
          fObjAddress = 0;
          fClass  = TClass::GetClass(fTitle.Data());
          if (!fClass) Warning("Streamer","Cannot find class:%s",fTitle.Data());
+
+         // We should rewarn in this process.
+         ResetBit(kWarn);
+         ResetBit(kOldWarn);
+
          return;
       }
       //====process old versions before automatic schema evolution
@@ -210,6 +215,8 @@ void TLeafObject::Streamer(TBuffer &b)
       if (R__v  < 1) fVirtual = kFALSE;
       if (R__v == 1) fVirtual = kTRUE;
       if (R__v == 3) b >> fVirtual;
+      // We should rewarn in this process.
+      ResetBit(kOldWarn);
       //====end of old versions
 
    } else {

--- a/tree/treeplayer/inc/TSelectorDraw.h
+++ b/tree/treeplayer/inc/TSelectorDraw.h
@@ -31,7 +31,7 @@ class TEntryListArray;
 class TSelectorDraw : public TSelector {
 
 protected:
-   enum { kWarn = BIT(12) };
+   enum EStatusBits { kWarn = BIT(12) };
 
    TTree         *fTree;           //  Pointer to current Tree
    TTreeFormula **fVar;            //![fDimension] Array of pointers to variables formula

--- a/tree/treeplayer/inc/TTreeFormula.h
+++ b/tree/treeplayer/inc/TTreeFormula.h
@@ -60,7 +60,7 @@ class TTreeFormula : public ROOT::v5::TFormula {
 friend class TTreeFormulaManager;
 
 protected:
-   enum {
+   enum EStatusBits {
       kIsCharacter = BIT(12),
       kMissingLeaf = BIT(15), // true if some of the needed leaves are missing in the current TTree
       kIsInteger   = BIT(17), // true if the branch contains an integer variable

--- a/tree/treeplayer/inc/TTreeReader.h
+++ b/tree/treeplayer/inc/TTreeReader.h
@@ -223,7 +223,7 @@ protected:
 
 private:
 
-   enum EPropertyBits {
+   enum EStatusBits {
       kBitIsChain = BIT(14), ///< our tree is a chain
       kBitHaveWarnedAboutEntryListAttachedToTTree = BIT(15) ///< the tree had a TEntryList and we have warned about that
    };

--- a/tree/treeviewer/inc/TParallelCoord.h
+++ b/tree/treeviewer/inc/TParallelCoord.h
@@ -27,7 +27,7 @@ class TSelectorDraw;
 
 class TParallelCoord : public TNamed {
 public:
-   enum {
+   enum EStatusBits {
       kVertDisplay      =BIT(14),      // If the axes are drawn vertically, false if horizontally.
       kCurveDisplay     =BIT(15),      // If the polylines are replaced by interpolated curves.
       kPaintEntries     =BIT(16),      // To prentry the TParallelCoord to paint all the entries.

--- a/tree/treeviewer/inc/TParallelCoord.h
+++ b/tree/treeviewer/inc/TParallelCoord.h
@@ -28,13 +28,13 @@ class TSelectorDraw;
 class TParallelCoord : public TNamed {
 public:
    enum EStatusBits {
-      kVertDisplay      =BIT(14),      // If the axes are drawn vertically, false if horizontally.
-      kCurveDisplay     =BIT(15),      // If the polylines are replaced by interpolated curves.
-      kPaintEntries     =BIT(16),      // To prentry the TParallelCoord to paint all the entries.
-      kLiveUpdate       =BIT(17),      // To paint the entries when being modified.
-      kGlobalScale      =BIT(19),      // Every variable is on the same scale.
-      kCandleChart      =BIT(20),      // To produce a candle chart.
-      kGlobalLogScale   =BIT(21)       // Every variable in log scale.
+      kVertDisplay     = BIT(14),      // If the axes are drawn vertically, false if horizontally.
+      kCurveDisplay    = BIT(15),      // If the polylines are replaced by interpolated curves.
+      kPaintEntries    = BIT(16),      // To prentry the TParallelCoord to paint all the entries.
+      kLiveUpdate      = BIT(17),      // To paint the entries when being modified.
+      kGlobalScale     = BIT(19),      // Every variable is on the same scale.
+      kCandleChart     = BIT(20),      // To produce a candle chart.
+      kGlobalLogScale  = BIT(21)       // Every variable in log scale.
    };
 
 private:

--- a/tree/treeviewer/inc/TParallelCoordRange.h
+++ b/tree/treeviewer/inc/TParallelCoordRange.h
@@ -24,7 +24,7 @@ class TString;
 
 class TParallelCoordRange : public TNamed, public TAttLine {
 public:
-   enum {
+   enum EStatusBits {
       kShowOnPad = BIT(15),
       kLiveUpdate = BIT(16)
    };

--- a/tree/treeviewer/inc/TParallelCoordVar.h
+++ b/tree/treeviewer/inc/TParallelCoordVar.h
@@ -24,9 +24,9 @@ class TH1F;
 class TParallelCoordVar : public TNamed, public TAttLine, public TAttFill {
 public:
    enum EStatusBits {
-      kLogScale      =BIT(14),
-      kShowBox       =BIT(15),
-      kShowBarHisto  =BIT(16)
+      kLogScale      = BIT(14),
+      kShowBox       = BIT(15),
+      kShowBarHisto  = BIT(16)
    };
 private:
    Int_t             fNbins;        // Number of bins in fHistogram.

--- a/tree/treeviewer/inc/TParallelCoordVar.h
+++ b/tree/treeviewer/inc/TParallelCoordVar.h
@@ -23,7 +23,7 @@ class TH1F;
 
 class TParallelCoordVar : public TNamed, public TAttLine, public TAttFill {
 public:
-   enum {
+   enum EStatusBits {
       kLogScale      =BIT(14),
       kShowBox       =BIT(15),
       kShowBarHisto  =BIT(16)


### PR DESCRIPTION
This introduces TStatusBitsChecker which allows to check whether there is 'Status bits' overlap in a given class hierarchy.

Expectedly, there are several overlaps ....

This merge request also annotate (by properly naming the enum type as EStatusBits) as needed and resolves the reported errors in core, io/io, tree/tree and hist/hist.

Some overlaps can not be resolve to preserve forward compatibility and after analysis of which bit is overlapping should be 'harmless' and thus are marked to be ignored by the checker tools (by adding a enum type named EStatusBitsDupExceptions).

Usage example:
```
return TStatusBitsChecker::CheckAlClasses();

// or without EStatusBitsDupExceptions in TStreamerElement.
TStatusBitsChecker::Check("TStreamerElement");

Error in <TStatusBitsChecker>: In TStreamerElement class hierarchy, there are duplicates bits:
Error in <TStatusBitsChecker>:    Bit   6 used in TStreamerElement as kHasRange
Error in <TStatusBitsChecker>:    Bit   6 used in TObject as kCannotPick
Error in <TStatusBitsChecker>:    Bit  13 used in TStreamerElement as kDoNotDelete
Error in <TStatusBitsChecker>:    Bit  13 used in TObject as kInvalidObject
```