### PR TITLE
[TDF] Fix ROOT-8975: TDF crashed when `Define`ing an existing branch

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -337,6 +337,9 @@ public:
    /// Refer to the first overload of this method for the full documentation.
    TInterface<TCustomColumnBase> Define(std::string_view name, std::string_view expression)
    {
+      auto loopManager = GetDataFrameChecked();
+      // this check must be done before jitting lest we throw exceptions in jitted code
+      TDFInternal::CheckTmpBranch(name, loopManager->GetTree());
       auto retVal = CallJitTransformation("Define", name, expression);
       return *(TInterface<TCustomColumnBase> *)retVal;
    }


### PR DESCRIPTION
A [related PR](https://github.com/root-project/roottest/pull/74) in roottest adds a test for this case.
The fix will be backported to v6.10.