### PR TITLE
[TDF] Remove "custom column" nodes from the functional graph

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -1103,6 +1103,12 @@ public:
    /// order as the named filters have been added to the graph.
    void Report()
    {
+      // if this is a TInterface<TLoopManager> on which `Define` has been called, users
+      // are calling `Report` on a chain of the form LoopManager->Define->Define->..., which
+      // certainly does not contain named filters.
+      if (std::is_same<Proxied, TLoopManager>::value && !fValidCustomColumns.empty())
+         return;
+
       auto df = GetDataFrameChecked();
       if (!df->HasRunAtLeastOnce())
          df->Run();

--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -317,7 +317,7 @@ public:
    Define(std::string_view name, F expression, const ColumnNames_t &columns = {})
    {
       auto loopManager = GetDataFrameChecked();
-      TDFInternal::CheckTmpBranch(name, loopManager->GetTree());
+      TDFInternal::CheckCustomColumn(name, loopManager->GetTree(), loopManager->GetCustomColumnNames());
       auto nColumns = TTraits::CallableTraits<F>::arg_types::list_size;
       const auto validColumnNames = GetValidatedColumnNames(*loopManager, nColumns, columns);
       using B_t = TDFDetail::TCustomColumn<F, Proxied>;

--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -446,7 +446,8 @@ public:
       ColumnNames_t selectedColumns;
       selectedColumns.reserve(32);
 
-      const auto customColumns = fProxiedPtr->GetCustomColumns();
+      auto df = GetDataFrameChecked();
+      const auto &customColumns = df->GetCustomColumnNames();
       // Since we support gcc48 and it does not provide in its stl std::regex,
       // we need to use TRegexp
       TRegexp regexp(theRegex);
@@ -457,7 +458,6 @@ public:
          }
       }
 
-      auto df = GetDataFrameChecked();
       auto tree = df->GetTree();
       if (tree) {
          const auto branches = tree->GetListOfBranches();
@@ -1109,7 +1109,7 @@ private:
       auto df = GetDataFrameChecked();
       auto tree = df->GetTree();
       auto branches = tree ? tree->GetListOfBranches() : nullptr;
-      auto customColumns = fProxiedPtr->GetCustomColumns();
+      const auto &customColumns = df->GetCustomColumnNames();
       auto tmpBookedBranches = df->GetBookedColumns();
       const std::string transformInt(transformation);
       const std::string nameInt(nodeName);

--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -1235,7 +1235,7 @@ private:
    {
       const auto &defaultColumns = lm.GetDefaultColumnNames();
       const auto trueColumns = TDFInternal::SelectColumns(nColumns, userColumns, defaultColumns);
-      const auto unknownColumns = TDFInternal::FindUnknownColumns(trueColumns, lm);
+      const auto unknownColumns = TDFInternal::FindUnknownColumns(trueColumns, lm.GetTree(), fValidCustomColumns);
 
       if (!unknownColumns.empty()) {
          // throw

--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -320,8 +320,8 @@ public:
       TDFInternal::CheckCustomColumn(name, loopManager->GetTree(), loopManager->GetCustomColumnNames());
       auto nColumns = TTraits::CallableTraits<F>::arg_types::list_size;
       const auto validColumnNames = GetValidatedColumnNames(*loopManager, nColumns, columns);
-      using NewColumn_t = TDFDetail::TCustomColumn<F, Proxied>;
-      loopManager->Book(std::make_shared<NewColumn_t>(name, std::move(expression), validColumnNames, *fProxiedPtr));
+      using NewCol_t = TDFDetail::TCustomColumn<F>;
+      loopManager->Book(std::make_shared<NewCol_t>(name, std::move(expression), validColumnNames, loopManager.get()));
       TInterface<Proxied> newInterface(fProxiedPtr, fImplWeakPtr, fValidCustomColumns);
       newInterface.fValidCustomColumns.emplace_back(name);
       return newInterface;
@@ -1291,12 +1291,6 @@ template <>
 inline std::string TInterface<TDFDetail::TFilterBase>::GetNodeTypeName()
 {
    return "ROOT::Detail::TDF::TFilterBase";
-}
-
-template <>
-inline std::string TInterface<TDFDetail::TCustomColumnBase>::GetNodeTypeName()
-{
-   return "ROOT::Detail::TDF::TCustomColumnBase";
 }
 
 template <>

--- a/tree/treeplayer/inc/ROOT/TDFNodes.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFNodes.hxx
@@ -56,6 +56,7 @@ class TLoopManager : public std::enable_shared_from_this<TLoopManager> {
    FilterBaseVec_t fBookedFilters;
    FilterBaseVec_t fBookedNamedFilters; ///< Contains a subset of fBookedFilters, i.e. only the named filters
    std::map<std::string, TCustomColumnBasePtr_t> fBookedCustomColumns;
+   ColumnNames_t fCustomColumnNames; ///< Contains names of all custom columns defined in the functional graph.
    RangeBaseVec_t fBookedRanges;
    std::vector<std::shared_ptr<bool>> fResProxyReadiness;
    ::TDirectory *const fDirPtr{nullptr};
@@ -94,6 +95,7 @@ public:
    std::shared_ptr<TLoopManager> GetSharedPtr() { return shared_from_this(); }
    const ColumnNames_t &GetDefaultColumnNames() const;
    const ColumnNames_t GetCustomColumns() const { return {}; };
+   const ColumnNames_t &GetCustomColumnNames() const { return fCustomColumnNames; };
    TTree *GetTree() const;
    TCustomColumnBase *GetBookedBranch(const std::string &name) const;
    const std::map<std::string, TCustomColumnBasePtr_t> &GetBookedColumns() const { return fBookedCustomColumns; }
@@ -275,7 +277,8 @@ public:
 
    void InitSlot(TTreeReader *r, unsigned int slot) final
    {
-      InitTDFValues(slot, fValues[slot], r, fBranches, fTmpBranches, fImplPtr->GetBookedColumns(), TypeInd_t());
+      InitTDFValues(slot, fValues[slot], r, fBranches, fImplPtr->GetCustomColumnNames(), fImplPtr->GetBookedColumns(),
+                    TypeInd_t());
       fHelper.InitSlot(r, slot);
    }
 
@@ -371,8 +374,8 @@ public:
 
    void InitSlot(TTreeReader *r, unsigned int slot) final
    {
-      TDFInternal::InitTDFValues(slot, fValues[slot], r, fBranches, fTmpBranches, fImplPtr->GetBookedColumns(),
-                                 TypeInd_t());
+      TDFInternal::InitTDFValues(slot, fValues[slot], r, fBranches, fImplPtr->GetCustomColumnNames(),
+                                 fImplPtr->GetBookedColumns(), TypeInd_t());
    }
 
    void *GetValuePtr(unsigned int slot) final { return static_cast<void *>(fLastResultPtr[slot].get()); }
@@ -515,8 +518,8 @@ public:
 
    void InitSlot(TTreeReader *r, unsigned int slot) final
    {
-      TDFInternal::InitTDFValues(slot, fValues[slot], r, fBranches, fTmpBranches, fImplPtr->GetBookedColumns(),
-                                 TypeInd_t());
+      TDFInternal::InitTDFValues(slot, fValues[slot], r, fBranches, fImplPtr->GetCustomColumnNames(),
+                                 fImplPtr->GetBookedColumns(), TypeInd_t());
    }
 
    // recursive chain of `Report`s

--- a/tree/treeplayer/inc/ROOT/TDFUtils.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFUtils.hxx
@@ -191,7 +191,7 @@ void CheckSnapshot(unsigned int nTemplateParams, unsigned int nColumnNames);
 const ColumnNames_t SelectColumns(unsigned int nArgs, const ColumnNames_t &bl, const ColumnNames_t &defBl);
 
 /// Check whether column names refer to a valid branch of a TTree or have been `Define`d. Return invalid column names.
-ColumnNames_t FindUnknownColumns(const ColumnNames_t &columns, const TLoopManager &lm);
+ColumnNames_t FindUnknownColumns(const ColumnNames_t &requiredCols, TTree *tree, const ColumnNames_t &definedCols);
 
 namespace ActionTypes {
 struct Histo1D {

--- a/tree/treeplayer/inc/ROOT/TDFUtils.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFUtils.hxx
@@ -161,7 +161,7 @@ void CheckFilter(Filter &)
    static_assert(std::is_same<FilterRet_t, bool>::value, "filter functions must return a bool");
 }
 
-void CheckTmpBranch(std::string_view branchName, TTree *treePtr);
+void CheckCustomColumn(std::string_view definedCol, TTree *treePtr, const ColumnNames_t &customCols);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// Check that the callable passed to TInterface::Reduce:

--- a/tree/treeplayer/inc/ROOT/TDataFrame.hxx
+++ b/tree/treeplayer/inc/ROOT/TDataFrame.hxx
@@ -81,7 +81,6 @@ inline std::string printValue(ROOT::Experimental::TDataFrame *tdf)
    auto df = tdf->GetDataFrameChecked();
    auto *tree = df->GetTree();
    auto defBranches = df->GetDefaultColumnNames();
-   auto customColumns = df->GetCustomColumns();
 
    std::ostringstream ret;
    if (tree) {

--- a/tree/treeplayer/src/TDFInterface.cxx
+++ b/tree/treeplayer/src/TDFInterface.cxx
@@ -67,7 +67,8 @@ std::vector<std::string> FindUsedColumnNames(const std::string expression, TObjA
 Long_t JitTransformation(void *thisPtr, const std::string &methodName, const std::string &interfaceTypeName,
                          const std::string &name, const std::string &expression, TObjArray *branches,
                          const std::vector<std::string> &customColumns,
-                         const std::map<std::string, TmpBranchBasePtr_t> &tmpBookedBranches, TTree *tree)
+                         const std::map<std::string, TmpBranchBasePtr_t> &tmpBookedBranches, TTree *tree,
+                         std::string_view returnTypeName)
 {
    auto usedBranches = FindUsedColumnNames(expression, branches, customColumns);
    auto exprNeedsVariables = !usedBranches.empty();
@@ -134,8 +135,7 @@ Long_t JitTransformation(void *thisPtr, const std::string &methodName, const std
    // The TInterface type to convert the result to. For example, Filter returns a TInterface<TFilter<F,P>> but when
    // returning it from a jitted call we need to convert it to TInterface<TFilterBase> as we are missing information
    // on types F and P at compile time.
-   const auto targetTypeName = std::string("ROOT::Experimental::TDF::TInterface<ROOT::Detail::TDF::") +
-                               (methodName == "Define" ? "TCustomColumnBase" : "TFilterBase") + ">";
+   const auto targetTypeName = std::string("ROOT::Experimental::TDF::TInterface<") + returnTypeName + ">";
 
    // Here we have two cases: filter and column
    ss.str("");

--- a/tree/treeplayer/src/TDFInterface.cxx
+++ b/tree/treeplayer/src/TDFInterface.cxx
@@ -25,7 +25,6 @@ namespace TDF {
 // extern templates
 template class TInterface<TLoopManager>;
 template class TInterface<TFilterBase>;
-template class TInterface<TCustomColumnBase>;
 }
 }
 

--- a/tree/treeplayer/src/TDFNodes.cxx
+++ b/tree/treeplayer/src/TDFNodes.cxx
@@ -284,7 +284,6 @@ void TLoopManager::CleanUpNodes()
    fNStopsReceived = 0;
    for (auto &ptr : fBookedFilters) ptr->ResetChildrenCount();
    for (auto &ptr : fBookedRanges) ptr->ResetChildrenCount();
-   for (auto &pair : fBookedCustomColumns) pair.second->ResetChildrenCount();
 }
 
 /// Perform clean-up operations. To be called at the end of each task execution.

--- a/tree/treeplayer/src/TDFNodes.cxx
+++ b/tree/treeplayer/src/TDFNodes.cxx
@@ -402,7 +402,9 @@ void TLoopManager::Book(const FilterBasePtr_t &filterPtr)
 
 void TLoopManager::Book(const TCustomColumnBasePtr_t &columnPtr)
 {
-   fBookedCustomColumns[columnPtr->GetName()] = columnPtr;
+   const auto &name = columnPtr->GetName();
+   fBookedCustomColumns[name] = columnPtr;
+   fCustomColumnNames.emplace_back(name);
 }
 
 void TLoopManager::Book(const std::shared_ptr<bool> &readinessPtr)

--- a/tree/treeplayer/src/TDFNodes.cxx
+++ b/tree/treeplayer/src/TDFNodes.cxx
@@ -34,8 +34,7 @@ namespace ROOT {
 namespace Internal {
 namespace TDF {
 
-TActionBase::TActionBase(TLoopManager *implPtr, const unsigned int nSlots)
-   : fImplPtr(implPtr), fNSlots(nSlots)
+TActionBase::TActionBase(TLoopManager *implPtr, const unsigned int nSlots) : fImplPtr(implPtr), fNSlots(nSlots)
 {
 }
 

--- a/tree/treeplayer/src/TDFNodes.cxx
+++ b/tree/treeplayer/src/TDFNodes.cxx
@@ -34,8 +34,8 @@ namespace ROOT {
 namespace Internal {
 namespace TDF {
 
-TActionBase::TActionBase(TLoopManager *implPtr, const ColumnNames_t &customColumns, const unsigned int nSlots)
-   : fImplPtr(implPtr), fTmpBranches(customColumns), fNSlots(nSlots)
+TActionBase::TActionBase(TLoopManager *implPtr, const unsigned int nSlots)
+   : fImplPtr(implPtr), fNSlots(nSlots)
 {
 }
 
@@ -43,14 +43,8 @@ TActionBase::TActionBase(TLoopManager *implPtr, const ColumnNames_t &customColum
 } // end NS Internal
 } // end NS ROOT
 
-TCustomColumnBase::TCustomColumnBase(TLoopManager *implPtr, const ColumnNames_t &customColumns, std::string_view name,
-                                     const unsigned int nSlots)
-   : fImplPtr(implPtr), fTmpBranches(customColumns), fName(name), fNSlots(nSlots){};
-
-ColumnNames_t TCustomColumnBase::GetCustomColumns() const
-{
-   return fTmpBranches;
-}
+TCustomColumnBase::TCustomColumnBase(TLoopManager *implPtr, std::string_view name, const unsigned int nSlots)
+   : fImplPtr(implPtr), fName(name), fNSlots(nSlots){};
 
 std::string TCustomColumnBase::GetName() const
 {
@@ -62,21 +56,15 @@ TLoopManager *TCustomColumnBase::GetImplPtr() const
    return fImplPtr;
 }
 
-TFilterBase::TFilterBase(TLoopManager *implPtr, const ColumnNames_t &customColumns, std::string_view name,
-                         const unsigned int nSlots)
-   : fImplPtr(implPtr), fTmpBranches(customColumns), fLastCheckedEntry(nSlots, -1), fLastResult(nSlots),
-     fAccepted(nSlots), fRejected(nSlots), fName(name), fNSlots(nSlots)
+TFilterBase::TFilterBase(TLoopManager *implPtr, std::string_view name, const unsigned int nSlots)
+   : fImplPtr(implPtr), fLastCheckedEntry(nSlots, -1), fLastResult(nSlots), fAccepted(nSlots), fRejected(nSlots),
+     fName(name), fNSlots(nSlots)
 {
 }
 
 TLoopManager *TFilterBase::GetImplPtr() const
 {
    return fImplPtr;
-}
-
-ColumnNames_t TFilterBase::GetCustomColumns() const
-{
-   return fTmpBranches;
 }
 
 bool TFilterBase::HasName() const
@@ -429,18 +417,13 @@ void TLoopManager::Report() const
    for (const auto &fPtr : fBookedNamedFilters) fPtr->PrintReport();
 }
 
-TRangeBase::TRangeBase(TLoopManager *implPtr, const ColumnNames_t &customColumns, unsigned int start, unsigned int stop,
-                       unsigned int stride, const unsigned int nSlots)
-   : fImplPtr(implPtr), fTmpBranches(customColumns), fStart(start), fStop(stop), fStride(stride), fNSlots(nSlots)
+TRangeBase::TRangeBase(TLoopManager *implPtr, unsigned int start, unsigned int stop, unsigned int stride,
+                       const unsigned int nSlots)
+   : fImplPtr(implPtr), fStart(start), fStop(stop), fStride(stride), fNSlots(nSlots)
 {
 }
 
 TLoopManager *TRangeBase::GetImplPtr() const
 {
    return fImplPtr;
-}
-
-ColumnNames_t TRangeBase::GetCustomColumns() const
-{
-   return fTmpBranches;
 }

--- a/tree/treeplayer/src/TDFUtils.cxx
+++ b/tree/treeplayer/src/TDFUtils.cxx
@@ -135,18 +135,18 @@ unsigned int GetNSlots()
 
 void CheckCustomColumn(std::string_view definedCol, TTree *treePtr, const ColumnNames_t &customCols)
 {
+   const std::string definedColStr(definedCol);
    if (treePtr != nullptr) {
       // check if definedCol is already present in TTree
-      const std::string definedColStr(definedCol);
       const auto branch = treePtr->GetBranch(definedColStr.c_str());
       if (branch != nullptr) {
-         const auto msg = "branch \"" + definedCol + "\" already present in TTree";
+         const auto msg = "branch \"" + definedColStr + "\" already present in TTree";
          throw std::runtime_error(msg);
       }
    }
    // check if definedCol has already been `Define`d in the functional graph
    if (std::find(customCols.begin(), customCols.end(), definedCol) != customCols.end()) {
-      const auto msg = "Redefinition of column \"" + definedCol + "\"";
+      const auto msg = "Redefinition of column \"" + definedColStr + "\"";
       throw std::runtime_error(msg);
    }
 }

--- a/tree/treeplayer/src/TDFUtils.cxx
+++ b/tree/treeplayer/src/TDFUtils.cxx
@@ -185,8 +185,7 @@ const ColumnNames_t SelectColumns(unsigned int nRequiredNames, const ColumnNames
    }
 }
 
-ColumnNames_t
-FindUnknownColumns(const ColumnNames_t &requiredCols, TTree *tree, const ColumnNames_t &definedCols)
+ColumnNames_t FindUnknownColumns(const ColumnNames_t &requiredCols, TTree *tree, const ColumnNames_t &definedCols)
 {
    ColumnNames_t unknownColumns;
    for (auto &column : requiredCols) {

--- a/tree/treeplayer/src/TDFUtils.cxx
+++ b/tree/treeplayer/src/TDFUtils.cxx
@@ -133,15 +133,21 @@ unsigned int GetNSlots()
    return nSlots;
 }
 
-void CheckTmpBranch(std::string_view branchName, TTree *treePtr)
+void CheckCustomColumn(std::string_view definedCol, TTree *treePtr, const ColumnNames_t &customCols)
 {
    if (treePtr != nullptr) {
-      std::string branchNameInt(branchName);
-      auto branch = treePtr->GetBranch(branchNameInt.c_str());
+      // check if definedCol is already present in TTree
+      const std::string definedColStr(definedCol);
+      const auto branch = treePtr->GetBranch(definedColStr.c_str());
       if (branch != nullptr) {
-         auto msg = "branch \"" + branchNameInt + "\" already present in TTree";
+         const auto msg = "branch \"" + definedCol + "\" already present in TTree";
          throw std::runtime_error(msg);
       }
+   }
+   // check if definedCol has already been `Define`d in the functional graph
+   if (std::find(customCols.begin(), customCols.end(), definedCol) != customCols.end()) {
+      const auto msg = "Redefinition of column \"" + definedCol + "\"";
+      throw std::runtime_error(msg);
    }
 }
 

--- a/tree/treeplayer/src/TDFUtils.cxx
+++ b/tree/treeplayer/src/TDFUtils.cxx
@@ -179,16 +179,15 @@ const ColumnNames_t SelectColumns(unsigned int nRequiredNames, const ColumnNames
    }
 }
 
-ColumnNames_t FindUnknownColumns(const ColumnNames_t &columns, const TLoopManager &lm)
+ColumnNames_t
+FindUnknownColumns(const ColumnNames_t &requiredCols, TTree *tree, const ColumnNames_t &definedCols)
 {
-   const auto customColumns = lm.GetBookedColumns();
-   auto *const tree = lm.GetTree();
    ColumnNames_t unknownColumns;
-   for (auto &column : columns) {
+   for (auto &column : requiredCols) {
       const auto isTreeBranch = (tree != nullptr && tree->GetBranch(column.c_str()) != nullptr);
       if (isTreeBranch)
          continue;
-      const auto isCustomColumn = (customColumns.find(column) != customColumns.end());
+      const auto isCustomColumn = std::find(definedCols.begin(), definedCols.end(), column) != definedCols.end();
       if (isCustomColumn)
          continue;
       unknownColumns.emplace_back(column);


### PR DESCRIPTION
This PR moves the responsibility of knowing which custom columns have been defined at which point of the functional graph from `TCustomColumn` to `TInterface`. As an added improvement `TInterface` now checks that custom columns do not override each other (which was wrongly allowed before).

As a consequence, `TCustomColumn` nodes are not required to be in the functional graph anymore (their function was to signal the point where a certain column name became valid), allowing simplifications of the graph traversing that TDF does during the event loop (e.g. to check all filters in a functional chain).

`Define` now returns the same type as the node it was called on rather than `TInterface<TCustomColumn<Fun, PrevNode>>`. For this reason this PR is expected to break `test_templateRecursionLimit`, which depends on the exact type returned by `Define`. The test will be fixed by a separate PR to roottest.