### PR TITLE
json: limit float/double value which can be stored as integer

### DIFF
--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -43,6 +43,7 @@
 #include "TArrayI.h"
 #include "TObjArray.h"
 #include "TROOT.h"
+#include "TMath.h"
 #include "TClass.h"
 #include "TClassTable.h"
 #include "TClassEdit.h"
@@ -3232,7 +3233,7 @@ void TBufferJSON::CompactFloatString(char* sbuf, unsigned len)
 void TBufferJSON::JsonWriteBasic(Float_t value)
 {
    char buf[200];
-   if (value == floor(value)) {
+   if ((value == floor(value)) && (TMath::Abs(value) < 1e15)) {
       snprintf(buf, sizeof(buf), "%1.0f", value);
    } else {
       snprintf(buf, sizeof(buf), fgFloatFmt, value);
@@ -3247,7 +3248,7 @@ void TBufferJSON::JsonWriteBasic(Float_t value)
 void TBufferJSON::JsonWriteBasic(Double_t value)
 {
    char buf[200];
-   if (value == floor(value)) {
+   if ((value == floor(value)) && (TMath::Abs(value) < 1e25)) {
       snprintf(buf, sizeof(buf), "%1.0f", value);
    } else {
       snprintf(buf, sizeof(buf), fgDoubleFmt, value);

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -43,7 +43,6 @@
 #include "TArrayI.h"
 #include "TObjArray.h"
 #include "TROOT.h"
-#include "TMath.h"
 #include "TClass.h"
 #include "TClassTable.h"
 #include "TClassEdit.h"
@@ -3233,7 +3232,7 @@ void TBufferJSON::CompactFloatString(char* sbuf, unsigned len)
 void TBufferJSON::JsonWriteBasic(Float_t value)
 {
    char buf[200];
-   if ((value == floor(value)) && (TMath::Abs(value) < 1e15)) {
+   if ((value == std::nearbyint(value)) && (std::abs(value) < 1e15)) {
       snprintf(buf, sizeof(buf), "%1.0f", value);
    } else {
       snprintf(buf, sizeof(buf), fgFloatFmt, value);
@@ -3248,7 +3247,7 @@ void TBufferJSON::JsonWriteBasic(Float_t value)
 void TBufferJSON::JsonWriteBasic(Double_t value)
 {
    char buf[200];
-   if ((value == floor(value)) && (TMath::Abs(value) < 1e25)) {
+   if ((value == std::nearbyint(value)) && (std::abs(value) < 1e25)) {
       snprintf(buf, sizeof(buf), "%1.0f", value);
    } else {
       snprintf(buf, sizeof(buf), fgDoubleFmt, value);

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -3232,6 +3232,8 @@ void TBufferJSON::CompactFloatString(char* sbuf, unsigned len)
 void TBufferJSON::JsonWriteBasic(Float_t value)
 {
    char buf[200];
+   // this is just check if float value looks like integer and can be stored in more compact form
+   // default should be storage with fgFloatFmt, which will be optimized afterwards anyway
    if ((value == std::nearbyint(value)) && (std::abs(value) < 1e15)) {
       snprintf(buf, sizeof(buf), "%1.0f", value);
    } else {
@@ -3247,6 +3249,8 @@ void TBufferJSON::JsonWriteBasic(Float_t value)
 void TBufferJSON::JsonWriteBasic(Double_t value)
 {
    char buf[200];
+   // this is just check if float value looks like integer and can be stored in more compact form
+   // default should be storage with fgDoubleFmt, which will be optimized afterwards anyway
    if ((value == std::nearbyint(value)) && (std::abs(value) < 1e25)) {
       snprintf(buf, sizeof(buf), "%1.0f", value);
    } else {


### PR DESCRIPTION
Before only condition value==floor(value) was checked.
But it can be true also for very large floats or doubles.
Up to certain limit it does not make sense.
Moreover, it can produce wrong output while value large 1e200 cannot be
stored at all