### PR TITLE
Fix memory leak in GSLMCIntegrator

### DIFF
--- a/math/mathmore/src/GSLRngWrapper.h
+++ b/math/mathmore/src/GSLRngWrapper.h
@@ -97,6 +97,7 @@ public:
       if (fRngType == 0) SetDefaultType();
       if (fRng != 0 && fOwn) Free();
       fRng = gsl_rng_alloc( fRngType );
+      fOwn = true;
     }
 
     void Free() {


### PR DESCRIPTION
The ctor of `GSLMCIntegrator` creates a `GSLRngWrapper` instance on the heap and calls its `Allocate()` member function which in turn allocates memory for a GSL random number generator via `gsl_rng_alloc()`. When the `GSLMCIntegrator` instance goes out of scope, its dtor is invoked which deletes the `GSLRngWrapper` pointer and thus invokes its dtor as well. However, `~GSLRngWrapper()` frees the allocated memory only if `fOwn` pointer is set to true, which is only set so in the assignment operator, but not in the `Allocate()` member function. Therefore, the `GSLMCIntegrator` class is leaking memory. This poses a problem, when doing a large number of integrations inside a for loop. The leak was discovered by running valgrind and inspecting the code.

Minimal example:
```cpp
#include <Math/GSLMCIntegrator.h> // ROOT::Math::GSLMCIntegrator

/* built with:

g++ -ggdb3 -Og `root-config --cflags` mcintegrator.cpp -o mcintegrator  \
`root-config --libs` -lMathMore

*/

int
main()
{
  for(unsigned i = 0; i < 20000; ++i)
  {
    ROOT::Math::GSLMCIntegrator vegas("vegas", 0., 1.e-1, 10);
  }
  return 0;
}
```

Before fix:
```
valgrind --tool=memcheck --leak-check=full --show-leak-kinds=definite \
--undef-value-errors=no ./mcintegrator

==12320== Memcheck, a memory error detector
==12320== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==12320== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==12320== Command: ./mcintegrator
==12320==
==12320==
==12320== HEAP SUMMARY:
==12320==     in use at exit: 100,655,858 bytes in 44,260 blocks
==12320==   total heap usage: 67,782 allocs, 23,522 frees, 101,539,078 bytes allocated
==12320==
==12320== 99,089,984 (319,984 direct, 98,770,000 indirect) bytes in 19,999 blocks are definitely lost in loss record 3,515 of 3,515
==12320==    at 0x4C2BE7F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==12320==    by 0xAD090F2: gsl_rng_alloc (in /usr/lib/libgsl.so.23.0.0)
==12320==    by 0x8223765: Allocate (GSLRngWrapper.h:99)
==12320==    by 0x8223765: ROOT::Math::GSLMCIntegrator::GSLMCIntegrator(char const*, double, double, unsigned int) (GSLMCIntegrator.cxx:117)
==12320==    by 0x108BF5: main (mcintegrator.cpp:8)
==12320==
==12320== LEAK SUMMARY:
==12320==    definitely lost: 319,984 bytes in 19,999 blocks
==12320==    indirectly lost: 98,770,000 bytes in 19,754 blocks
==12320==      possibly lost: 1,225,000 bytes in 245 blocks
==12320==    still reachable: 340,874 bytes in 4,262 blocks
==12320==         suppressed: 0 bytes in 0 blocks
==12320== Reachable blocks (those to which a pointer was found) are not shown.
==12320== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==12320==
==12320== For counts of detected and suppressed errors, rerun with: -v
==12320== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)
```

After fix:
```
valgrind --tool=memcheck --leak-check=full --show-leak-kinds=definite \
--undef-value-errors=no ./mcintegrator

==14294== Memcheck, a memory error detector
==14294== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==14294== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==14294== Command: ./mcintegrator
==14294==
==14294==
==14294== HEAP SUMMARY:
==14294==     in use at exit: 335,858 bytes in 4,260 blocks
==14294==   total heap usage: 67,782 allocs, 63,522 frees, 101,539,078 bytes allocated
==14294==
==14294== LEAK SUMMARY:
==14294==    definitely lost: 0 bytes in 0 blocks
==14294==    indirectly lost: 0 bytes in 0 blocks
==14294==      possibly lost: 0 bytes in 0 blocks
==14294==    still reachable: 335,858 bytes in 4,260 blocks
==14294==         suppressed: 0 bytes in 0 blocks
==14294== Reachable blocks (those to which a pointer was found) are not shown.
==14294== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==14294==
==14294== For counts of detected and suppressed errors, rerun with: -v
==14294== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```