### PR TITLE
[cxxmodules] Mark libc/STL as system

### DIFF
--- a/build/unix/libc.modulemap
+++ b/build/unix/libc.modulemap
@@ -1,4 +1,4 @@
-module "libc" {
+module "libc" [system] {
   export *
   module "assert.h" {
     export *

--- a/build/unix/stl.cppmap
+++ b/build/unix/stl.cppmap
@@ -1,4 +1,4 @@
-module "stl" {
+module "stl" [system] {
   export *
   module "algorithm" {
     export *


### PR DESCRIPTION
As seen in the posix_memalign workaround in clang, it seems that
marking modules as system actually has more semantic behavior
than just disabling warnings for them. This patch marks both
STL and libc as system to fix those issues.

Also see: https://github.com/Teemperor/clang-modules-bugs/issues/3