### PR TITLE
[DOC] Improve TDataFrame-related entries in codeowners file.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,6 +56,6 @@
 /graf2d/ios/ @TimurP
 /graf3d/eve/ @osschar
 /net/http/ @linev
-/tree/treeplayer/inc/ROOT/TDataFrame* @dpiparo @bluehood
-/tree/treeplayer/src/TDF* @dpiparo @bluehood
+/tree/treeplayer/**/TDataFrame.* @dpiparo @bluehood
+/tree/treeplayer/**/TDF* @dpiparo @bluehood
 CMakeLists.txt @peremato


### PR DESCRIPTION
Hi,
I noticed the TDataFrame entries for the code owners were a bit weird.

I'm not sure how to test I did not screw up the syntax (the `**` pattern was explained [here](https://git-scm.com/docs/gitignore) and codeowners should allow the same pattern matching syntax).