### PR TITLE
[cxxmodules] Unify *32 dictionaries into one

### DIFF
--- a/math/genvector/CMakeLists.txt
+++ b/math/genvector/CMakeLists.txt
@@ -14,11 +14,21 @@ set(headers   Math/Vector2D.h Math/Point2D.h
               Math/Transform3D.h Math/Translation3D.h Math/Plane3D.h
               Math/VectorUtil.h)
 set(headers32 Math/Vector2D.h Math/Point2D.h
-             Math/Vector3D.h Math/Point3D.h Math/Vector4D.h)
+              Math/VectorUtil.h Math/Vector2D.h Math/Point2D.h
+              Math/Vector3D.h Math/Point3D.h Math/Vector4D.h)
 
-ROOT_GENERATE_DICTIONARY(G__${libname}   ${headers} MODULE ${libname} LINKDEF Math/LinkDef_GenVector.h OPTIONS "-writeEmptyRootPCM" DEPENDENCIES Core)
-ROOT_GENERATE_DICTIONARY(G__${libname}32 ${headers32} MULTIDICT MODULE ${libname} LINKDEF Math/LinkDef_GenVector32.h OPTIONS "-writeEmptyRootPCM" DEPENDENCIES Core)
 
-ROOT_LINKER_LIBRARY(${libname} *.cxx G__${libname}.cxx G__${libname}32.cxx LIBRARIES Core)
+if (runtime_cxxmodules)
+  # With runtime_cxxmodules we have a hard time making two identical modules
+  # with the same files in them but different LinkDefs, so we just merge
+  # them into one.
+  ROOT_GENERATE_DICTIONARY(G__${libname}   ${headers} MODULE ${libname} LINKDEF Math/LinkDef_GenVectorAll.h OPTIONS "-writeEmptyRootPCM" DEPENDENCIES Core)
+  ROOT_LINKER_LIBRARY(${libname} *.cxx G__${libname}.cxx LIBRARIES Core)
+else()
+  ROOT_GENERATE_DICTIONARY(G__${libname}   ${headers} MODULE ${libname} LINKDEF Math/LinkDef_GenVector.h OPTIONS "-writeEmptyRootPCM" DEPENDENCIES Core)
+  ROOT_GENERATE_DICTIONARY(G__${libname}32 ${headers32} MULTIDICT MODULE ${libname} LINKDEF Math/LinkDef_GenVector32.h OPTIONS "-writeEmptyRootPCM" DEPENDENCIES Core)
+
+  ROOT_LINKER_LIBRARY(${libname} *.cxx G__${libname}.cxx G__${libname}32.cxx LIBRARIES Core)
+endif()
 ROOT_INSTALL_HEADERS()
 

--- a/math/smatrix/CMakeLists.txt
+++ b/math/smatrix/CMakeLists.txt
@@ -4,18 +4,32 @@
 
 set(libname Smatrix)
 
-ROOT_GENERATE_DICTIONARY(G__${libname}    Math/SMatrix.h     Math/SVector.h
-                                          Math/SMatrixDfwd.h Math/SMatrixFfwd.h
-                                          MODULE ${libname}
-                                          LINKDEF LinkDef.h OPTIONS "-writeEmptyRootPCM"
-                                          DEPENDENCIES Core)
+if (runtime_cxxmodules)
+  # With runtime_cxxmodules we have a hard time making two identical modules
+  # with the same files in them but different LinkDefs, so we just merge
+  # them into one.
+  ROOT_GENERATE_DICTIONARY(G__${libname}    Math/SMatrix.h     Math/SVector.h
+                                            Math/SMatrixDfwd.h Math/SMatrixFfwd.h
+                                            MODULE ${libname}
+                                            LINKDEF LinkDefAll.h OPTIONS "-writeEmptyRootPCM"
+                                            DEPENDENCIES Core)
 
-ROOT_GENERATE_DICTIONARY(G__${libname}32  Math/SMatrix.h     Math/SVector.h
-                                          Math/SMatrixDfwd.h Math/SMatrixFfwd.h
-                                          MULTIDICT MODULE ${libname}
-                                          LINKDEF LinkDefD32.h OPTIONS "-writeEmptyRootPCM"
-                                          DEPENDENCIES Core)
+  ROOT_LINKER_LIBRARY(${libname} G__${libname}.cxx LIBRARIES Core)
+else()
+  ROOT_GENERATE_DICTIONARY(G__${libname}    Math/SMatrix.h     Math/SVector.h
+                                            Math/SMatrixDfwd.h Math/SMatrixFfwd.h
+                                            MODULE ${libname}
+                                            LINKDEF LinkDef.h OPTIONS "-writeEmptyRootPCM"
+                                            DEPENDENCIES Core)
 
-ROOT_LINKER_LIBRARY(${libname} G__${libname}.cxx G__${libname}32.cxx LIBRARIES Core)
+  ROOT_GENERATE_DICTIONARY(G__${libname}32  Math/SMatrix.h     Math/SVector.h
+                                            Math/SMatrixDfwd.h Math/SMatrixFfwd.h
+                                            MULTIDICT MODULE ${libname}
+                                            LINKDEF LinkDefD32.h OPTIONS "-writeEmptyRootPCM"
+                                            DEPENDENCIES Core)
+
+  ROOT_LINKER_LIBRARY(${libname} G__${libname}.cxx G__${libname}32.cxx LIBRARIES Core)
+endif()
 ROOT_INSTALL_HEADERS()
+
 


### PR DESCRIPTION
With C++ modules we are supposed to have a unique module name where
each module contains different headers. But smatrix(32) or genvector(32)
currently have the same contents and also the same name. As we
anyway also have a combined LinkDef file for both cases, we just
unify those two dictionaries when using runtime_modules and have
only a single module in the end which has an unique name and
unique contents.