### PR TITLE
Properly implement the memory_termination build option.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,11 +103,6 @@ if (JEMALLOC_FOUND)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -ljemalloc -L ${JEMALLOC_LIBRARY_PATH}")
 endif()
 
-#---Add the define for the experimental deallocation code when memory_termination is on---------
-if(memory_termination)
-  add_definitions(-DR__COMPLETE_MEM_TERMINATION)
-endif()
-
 #---Populate the configure arguments returned by 'root-config --config'-------------------------
 get_cmake_property(variables CACHE_VARIABLES)
 foreach(var ${variables})

--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -507,6 +507,11 @@ if(gcctoolchain)
 else()
   set(setgcctoolchain undef)
 endif()
+if(memory_termination)
+  set(memory_term define)
+else()
+  set(memory_term undef)
+endif()
 
 CHECK_CXX_SOURCE_COMPILES("#include <string_view>
   int main() { char arr[3] = {'B', 'a', 'r'}; std::string_view strv(arr, sizeof(arr)); return 0;}" found_stdstringview)

--- a/config/RConfigure.in
+++ b/config/RConfigure.in
@@ -37,6 +37,7 @@
 #@hasstdinvoke@ R__HAS_STD_INVOKE /**/
 #@hasllvm@ R__EXTERN_LLVMDIR @llvmdir@
 #@useimt@ R__USE_IMT   /**/
+#@memory_term@ R__COMPLETE_MEM_TERMINATION /**/
 
 #if defined(R__HAS_VECCORE) && defined(R__HAS_VC)
 #ifndef VECCORE_ENABLE_VC

--- a/configure
+++ b/configure
@@ -2805,6 +2805,10 @@ if test "x$enable_cxxmodules" = "xyes"; then
 fi
 
 ######################################################################
+# Destruct global/static variables. Always off in classic build.
+memory_term="undef"
+
+######################################################################
 #
 ### echo %%% libc++ - compile and link using libc++
 #
@@ -8188,6 +8192,7 @@ sed \
     -e "s|@usec++14@|$usecxx14|"           \
     -e "s|@usec++17@|$usecxx17|"           \
     -e "s|@usecxxmodules@|$usecxxmodules|" \
+    -e "s|@memory_term@|$memory_term|"     \
     -e "s|@uselibc++@|$uselibcxx|"         \
     -e "s|@hasstdstringview@|$hasstdstringview|"       \
     -e "s|@hasstdexpstringview@|$hasstdexpstringview|" \


### PR DESCRIPTION
It seems my last commit doesn't properly implement the way we
add a define to the dictionary. It seems this is the proper way
to do it instead of just calling add_definitions.