### PR TITLE
Fix Imt configure in the classic build

### DIFF
--- a/configure
+++ b/configure
@@ -6713,7 +6713,7 @@ check_explicit "$enable_tbb" "$enable_tbb_explicit" \
 #
 useimt="undef"
 if test "x$enable_imt" = "xyes"; then
-        usecxxmodules="define"
+        useimt="define"
         result "yes"
 fi
 


### PR DESCRIPTION
Obviously we shouldn't activate C++ modules when people want Imt.
