### PR TITLE
[cxxmodules] Add missing includes to TF1AbsComposition

### DIFF
--- a/hist/hist/inc/TF1AbsComposition.h
+++ b/hist/hist/inc/TF1AbsComposition.h
@@ -11,6 +11,8 @@
 #ifndef ROOT_TF1AbsComposition__
 #define ROOT_TF1AbsComposition__
 
+#include "TObject.h"
+
 #include <iostream>
 #include <memory>
 


### PR DESCRIPTION
This fixes the C++ modules builds as they struggle on this missing
include and fail to compile the module containing it.