### PR TITLE
ROOT I/O bug fixes and improvements

### DIFF
--- a/core/cont/src/TList.cxx
+++ b/core/cont/src/TList.cxx
@@ -540,15 +540,18 @@ TObject *TList::FindObject(const char *name) const
 {
    R__COLLECTION_READ_GUARD();
 
-   if (!name) return 0;
-   TObjLink *lnk = FirstLink();
-   while (lnk) {
-      TObject *obj = lnk->GetObject();
-      const char *objname = obj->GetName();
-      if (objname && !strcmp(name, objname)) return obj;
-      lnk = lnk->Next();
+   if (!name)
+      return nullptr;
+
+   for (TObjLink *lnk = FirstLink(); lnk != nullptr; lnk = lnk->Next()) {
+      if (TObject *obj = lnk->GetObject()) {
+         const char *objname = obj->GetName();
+         if (objname && strcmp(name, objname) == 0)
+            return obj;
+      }
    }
-   return 0;
+
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -12,7 +12,6 @@
 #ifndef ROOT_TClass
 #define ROOT_TClass
 
-
 //////////////////////////////////////////////////////////////////////////
 //                                                                      //
 // TClass                                                               //
@@ -34,6 +33,7 @@
 
 #include <atomic>
 #include "ThreadLocalStorage.h"
+
 class TBaseClass;
 class TBrowser;
 class TDataMember;
@@ -65,6 +65,7 @@ namespace ROOT {
       class TCollectionProxyInfo;
    }
 }
+
 typedef ROOT::TMapTypeToTClass IdMap_t;
 typedef ROOT::TMapDeclIdToTClass DeclIdMap_t;
 
@@ -114,7 +115,8 @@ public:
                         // through rootcling/genreflex/TMetaUtils and the library
                         // containing this dictionary has been loaded in memory.
       kLoaded = kHasTClassInit,
-      kNamespaceForMeta // Very transient state necessary to bootstrap namespace entries in ROOT Meta w/o interpreter information
+      kNamespaceForMeta // Very transient state necessary to bootstrap namespace entries
+                        // in ROOT Meta w/o interpreter information
    };
 
 private:
@@ -234,9 +236,9 @@ private:
 
    typedef void (*StreamerImpl_t)(const TClass* pThis, void *obj, TBuffer &b, const TClass *onfile_class);
 #ifdef R__NO_ATOMIC_FUNCTION_POINTER
-   mutable StreamerImpl_t fStreamerImpl;  //! Pointer to the function implementing the right streaming behavior for the class represented by this object.
+   mutable StreamerImpl_t fStreamerImpl; //! Pointer to the function implementing streaming for this class
 #else
-   mutable std::atomic<StreamerImpl_t> fStreamerImpl;  //! Pointer to the function implementing the right streaming behavior for the class represented by this object.
+   mutable std::atomic<StreamerImpl_t> fStreamerImpl; //! Pointer to the function implementing streaming for this class
 #endif
 
    Bool_t             CanSplitBaseAllow();
@@ -276,7 +278,7 @@ private:
    static DeclIdMap_t *GetDeclIdMap();  //Map from DeclId_t to TClass pointer
    static std::atomic<Int_t>     fgClassCount;  //provides unique id for a each class
                                                 //stored in TObject::fUniqueID
-   static TDeclNameRegistry fNoInfoOrEmuOrFwdDeclNameRegistry; // Store the decl names of the forwardd and no info instances
+   static TDeclNameRegistry fNoInfoOrEmuOrFwdDeclNameRegistry; // Store decl names of the forwardd and no info instances
    static Bool_t HasNoInfoOrEmuOrFwdDeclaredDecl(const char*);
 
    // Internal status bits, set and reset only during initialization and thus under the protection of the global lock.
@@ -312,11 +314,11 @@ private:
    TClass& operator=(const TClass&) = delete;
 
 protected:
-   TVirtualStreamerInfo     *FindStreamerInfo(TObjArray* arr, UInt_t checksum) const;
-   void                      GetMissingDictionariesForBaseClasses(TCollection& result, TCollection& visited, bool recurse);
-   void                      GetMissingDictionariesForMembers(TCollection& result, TCollection& visited, bool recurse);
-   void                      GetMissingDictionariesWithRecursionCheck(TCollection& result, TCollection& visited, bool recurse);
-   void                      GetMissingDictionariesForPairElements(TCollection& result, TCollection& visited, bool recurse);
+   TVirtualStreamerInfo *FindStreamerInfo(TObjArray *arr, UInt_t checksum) const;
+   void GetMissingDictionariesForBaseClasses(TCollection &result, TCollection &visited, bool recurse);
+   void GetMissingDictionariesForMembers(TCollection &result, TCollection &visited, bool recurse);
+   void GetMissingDictionariesWithRecursionCheck(TCollection &result, TCollection &visited, bool recurse);
+   void GetMissingDictionariesForPairElements(TCollection &result, TCollection &visited, bool recurse);
 
 public:
    TClass();
@@ -370,7 +372,9 @@ public:
    TVirtualCollectionProxy *GetCollectionProxy() const;
    TVirtualIsAProxy  *GetIsAProxy() const;
    TMethod           *GetClassMethod(const char *name, const char *params, Bool_t objectIsConst = kFALSE);
-   TMethod           *GetClassMethodWithPrototype(const char *name, const char *proto, Bool_t objectIsConst = kFALSE, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch);
+   TMethod           *GetClassMethodWithPrototype(const char *name, const char *proto,
+                                                  Bool_t objectIsConst = kFALSE,
+                                                  ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch);
    Version_t          GetClassVersion() const { fVersionUsed = kTRUE; return fClassVersion; }
    Int_t              GetClassSize() const { return Size(); }
    TDataMember       *GetDataMember(const char *datamember) const;
@@ -380,7 +384,11 @@ public:
    ROOT::DelFunc_t    GetDelete() const;
    ROOT::DesFunc_t    GetDestructor() const;
    ROOT::DelArrFunc_t GetDeleteArray() const;
-   ClassInfo_t       *GetClassInfo() const { if (fCanLoadClassInfo && !TestBit(kLoading)) LoadClassInfo(); return fClassInfo; }
+   ClassInfo_t       *GetClassInfo() const {
+      if (fCanLoadClassInfo && !TestBit(kLoading))
+         LoadClassInfo();
+      return fClassInfo;
+   }
    const char        *GetContextMenuTitle() const { return fContextMenuTitle; }
    TVirtualStreamerInfo     *GetCurrentStreamerInfo() {
       if (fCurrentInfo.load()) return fCurrentInfo;
@@ -412,7 +420,8 @@ public:
    void               GetMenuItems(TList *listitems);
    TList             *GetMenuList() const;
    TMethod           *GetMethod(const char *method, const char *params, Bool_t objectIsConst = kFALSE);
-   TMethod           *GetMethodWithPrototype(const char *method, const char *proto, Bool_t objectIsConst = kFALSE, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch);
+   TMethod *GetMethodWithPrototype(const char *method, const char *proto, Bool_t objectIsConst = kFALSE,
+                                   ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch);
    TMethod           *GetMethodAny(const char *method);
    TMethod           *GetMethodAllAny(const char *method);
    Int_t              GetNdata();
@@ -544,8 +553,9 @@ public:
 };
 
 namespace ROOT {
-   template <typename T> TClass* GetClass(      T* /* dummy */)        { return TClass::GetClass(typeid(T)); }
-   template <typename T> TClass* GetClass(const T* /* dummy */)        { return TClass::GetClass(typeid(T)); }
+
+template <typename T> TClass *GetClass(T * /* dummy */)       { return TClass::GetClass(typeid(T)); }
+template <typename T> TClass *GetClass(const T * /* dummy */) { return TClass::GetClass(typeid(T)); }
 
 #ifndef R__NO_CLASS_TEMPLATE_SPECIALIZATION
    // This can only be used when the template overload resolution can distinguish between T* and T**

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -4381,7 +4381,7 @@ TVirtualStreamerInfo* TClass::GetStreamerInfo(Int_t version /* = 0 */) const
    if ((version < -1) || (version >= fStreamerInfo->GetSize())) {
       Error("GetStreamerInfo", "class: %s, attempting to access a wrong version: %d", GetName(), version);
       // FIXME: Shouldn't we go to -1 here, or better just abort?
-      version = 0;
+      version = fClassVersion;
    }
 
    sinfo = (TVirtualStreamerInfo *)fStreamerInfo->At(version);

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -4359,29 +4359,33 @@ Int_t TClass::GetNmethods()
 
 TVirtualStreamerInfo* TClass::GetStreamerInfo(Int_t version /* = 0 */) const
 {
-   TVirtualStreamerInfo *guess = fLastReadInfo;
-   if (guess && guess->GetClassVersion() == version) {
-      // If the StreamerInfo is assigned to the fLastReadInfo, we are
-      // guaranteed it was built and compiled.
-      return guess;
-   }
+   TVirtualStreamerInfo *sinfo = fLastReadInfo;
+
+   // Version 0 is special, it means the currently loaded version.
+   // We need to set it at the beginning to be able to guess it correctly.
+
+   if (version == 0)
+      version = fClassVersion;
+
+   // If the StreamerInfo is assigned to the fLastReadInfo, we are
+   // guaranteed it was built and compiled.
+   if (sinfo && sinfo->GetClassVersion() == version)
+      return sinfo;
 
    R__LOCKGUARD(gInterpreterMutex);
 
-   // Handle special version, 0 means currently loaded version.
-   // Warning:  This may be -1 for an emulated class.
-   // If version == -2, the user is requested the emulated streamerInfo
-   // for an abstract base class even though we have a dictionary for it.
-   if (version == 0) {
-      version = fClassVersion;
-   }
-   Int_t ninfos = fStreamerInfo->GetSize();
-   if ((version < -1) || (version >= ninfos)) {
+   // Warning: version may be -1 for an emulated class, or -2 if the
+   //          user requested the emulated streamerInfo for an abstract
+   //          base class, even though we have a dictionary for it.
+
+   if ((version < -1) || (version >= fStreamerInfo->GetSize())) {
       Error("GetStreamerInfo", "class: %s, attempting to access a wrong version: %d", GetName(), version);
       // FIXME: Shouldn't we go to -1 here, or better just abort?
       version = 0;
    }
-   TVirtualStreamerInfo* sinfo = (TVirtualStreamerInfo*) fStreamerInfo->At(version);
+
+   sinfo = (TVirtualStreamerInfo *)fStreamerInfo->At(version);
+
    if (!sinfo && (version != fClassVersion)) {
       // When the requested version does not exist we return
       // the TVirtualStreamerInfo for the currently loaded class version.
@@ -4391,6 +4395,7 @@ TVirtualStreamerInfo* TClass::GetStreamerInfo(Int_t version /* = 0 */) const
       // This is also the code path take for unversioned classes.
       sinfo = (TVirtualStreamerInfo*) fStreamerInfo->At(fClassVersion);
    }
+
    if (!sinfo) {
       // We just were not able to find a streamer info, we have to make a new one.
       TMmallocDescTemp setreset;
@@ -4402,7 +4407,6 @@ TVirtualStreamerInfo* TClass::GetStreamerInfo(Int_t version /* = 0 */) const
       if (HasDataMemberInfo() || fCollectionProxy) {
          // If we do not have a StreamerInfo for this version and we do not
          // have dictionary information nor a proxy, there is nothing to build!
-         //
          sinfo->Build();
       }
    } else {
@@ -4413,12 +4417,15 @@ TVirtualStreamerInfo* TClass::GetStreamerInfo(Int_t version /* = 0 */) const
          sinfo->BuildOld();
       }
    }
+
    // Cache the current info if we now have it.
-   if (version == fClassVersion) {
+   if (version == fClassVersion)
       fCurrentInfo = sinfo;
-   }
+
    // If the compilation succeeded, remember this StreamerInfo.
-   if (sinfo->IsCompiled()) fLastReadInfo = sinfo;
+   if (sinfo->IsCompiled())
+      fLastReadInfo = sinfo;
+
    return sinfo;
 }
 


### PR DESCRIPTION
Fix nullptr dereference bugs in TClass and TList, wrap TClass.cxx to 120 columns to follow coding conventions, and avoid StreamerInfo lookup when it is cached.