### PR TITLE
[TMVA] Add option to suppress correlations output

### DIFF
--- a/documentation/tmva/UsersGuide/optiontables/DataSetFactory.tex
+++ b/documentation/tmva/UsersGuide/optiontables/DataSetFactory.tex
@@ -8,5 +8,6 @@
         nTrain\_Background  &  \mc{1}{c}{--}  &                0  &  \mc{1}{l}{--}  &  Number of training events of class Background (default: 0 = all) \\
          nTest\_Background  &  \mc{1}{c}{--}  &                0  &  \mc{1}{l}{--}  &  Number of test events of class Background (default: 0 = all) \\
                         V  &  \mc{1}{c}{--}  &            False  &  \mc{1}{l}{--}  &  Verbosity (default: true) \\
-             VerboseLevel  &  \mc{1}{c}{--}  &             Info  &  Debug, Verbose, Info  &  VerboseLevel (Debug/Verbose/Info) 
+             VerboseLevel  &  \mc{1}{c}{--}  &             Info  &  Debug, Verbose, Info  &  VerboseLevel (Debug/Verbose/Info) \\
+             Correlations  &  \mc{1}{c}{--}  &            True   &  \mc{1}{l}{--}  &  Whether to show variable correlations output (default: true)
 \end{optiontableAuto}

--- a/tmva/tmva/inc/TMVA/DataSetFactory.h
+++ b/tmva/tmva/inc/TMVA/DataSetFactory.h
@@ -286,6 +286,9 @@ namespace TMVA {
       Bool_t                     fVerbose;           // Verbosity
       TString                    fVerboseLevel;      // VerboseLevel
 
+      // Printing
+      Bool_t fCorrelations; // Whether to print correlations or not
+
       Bool_t                     fScaleWithPreselEff; // how to deal with requested #events in connection with preselection cuts 
 
       // the event
@@ -302,8 +305,7 @@ namespace TMVA {
       MsgLogger*                 fLogger;          //! message logger
       MsgLogger& Log() const { return *fLogger; }
    public:
-       
-       ClassDef(DataSetFactory,1);
+      ClassDef(DataSetFactory, 2);
    };
 }
 

--- a/tmva/tmva/src/DataSetFactory.cxx
+++ b/tmva/tmva/src/DataSetFactory.cxx
@@ -133,7 +133,9 @@ TMVA::DataSet* TMVA::DataSetFactory::CreateDataSet( TMVA::DataSetInfo& dsi,
       for (UInt_t cl = 0; cl< dsi.GetNClasses(); cl++) {
          const TString className = dsi.GetClassInfo(cl)->GetName();
          dsi.SetCorrelationMatrix( className, CalcCorrelationMatrix( ds, cl ) );
-         dsi.PrintCorrelationMatrix( className );
+         if (fCorrelations) {
+            dsi.PrintCorrelationMatrix(className);
+         }
       }
       //Log() << kHEADER <<  Endl;
       Log() << kHEADER << Form("[%s] : ",dsi.GetName()) << " " << Endl << Endl;
@@ -650,6 +652,9 @@ TMVA::DataSetFactory::InitOptions( TMVA::DataSetInfo& dsi,
    splitSpecs.AddPreDefVal(TString("Debug"));
    splitSpecs.AddPreDefVal(TString("Verbose"));
    splitSpecs.AddPreDefVal(TString("Info"));
+
+   fCorrelations = kTRUE;
+   splitSpecs.DeclareOptionRef(fCorrelations, "Correlations", "Boolean to show correlation output (Default: true)");
 
    splitSpecs.ParseOptions();
    splitSpecs.CheckForUnusedOptions();


### PR DESCRIPTION
Add the possibility to suppress correlations output to the dataset factory. Previously only the correlations output from the Factory could be suppressed.