### PR TITLE
Update CMake policy settings to use CMake version 3.4.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,14 @@
 #---Check if cmake has the required version-----------------------------------------------------
+
 cmake_minimum_required(VERSION 3.4.3 FATAL_ERROR)
-cmake_policy(SET CMP0005 NEW)
+
+set(policy_new CMP0068)
+foreach(policy ${policy_new})
+  if(POLICY ${policy})
+    cmake_policy(SET ${policy} NEW)
+  endif()
+endforeach()
+
 include(cmake/modules/CaptureCommandLine.cmake)
 
 #---Set name of the project to "ROOT". Has to be done after check of cmake version--------------

--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -1,9 +1,6 @@
 #---------------------------------------------------------------------------------------------------
 #  RootNewMacros.cmake
 #---------------------------------------------------------------------------------------------------
-cmake_policy(SET CMP0003 NEW) # See "cmake --help-policy CMP0003" for more details
-cmake_policy(SET CMP0011 NEW) # See "cmake --help-policy CMP0011" for more details
-cmake_policy(SET CMP0009 NEW) # See "cmake --help-policy CMP0009" for more details
 
 set(THISDIR ${CMAKE_CURRENT_LIST_DIR})
 


### PR DESCRIPTION
This is the [recommended way](https://cmake.org/cmake/help/latest/command/cmake_policy.html#setting-policies-by-cmake-version) to set CMake policy settings. This means that policies created in versions prior to 3.9 will use the NEW setting by default, and newer policies will generate warnings. Set to 3.9 since that's the highest version currently tested in Jenkins.

The Mac builds are generating a [warning](http://cdash.cern.ch/buildSummary.php?buildid=393980) (shown below) about policy CMP0068, so I'd like to test this
and move to the new policy mechanism once any problems that show up are fixed.

```
CMake Warning (dev):
  Policy CMP0068 is not set: RPATH settings on macOS do not affect
  install_name.  Run "cmake --help-policy CMP0068" for policy details.  Use
  the cmake_policy command to set the policy and suppress this warning.

  For compatibility with older versions of CMake, the install_name fields for
  the following targets are still affected by RPATH settings:

   LTO
   libclang

This warning is for project developers.  Use -Wno-dev to suppres-- Generating done
s it.
```