### PR TITLE
IO forward-compatibility feature flags

### DIFF
--- a/README/ReleaseNotes/v612/index.md
+++ b/README/ReleaseNotes/v612/index.md
@@ -66,6 +66,15 @@ or will be set to the address of the histogram read from the file.
 
 - Added a new mechanism for providing clean forward-compatibility breaks in a ``TTree`` (i.e., a newer version of ROOT writes a ``TTree`` an older version cannot read).  When future versions of ROOT utilize an IO feature that this version does not support, ROOT will provide a clear error message instead of crashing or returning garbage data.  In future ROOT6 releases, forward-compatibility breaks will only be allowed if a non-default feature is enabled via the ``ROOT::Experimental`` namespace; it is expected ROOT7 will enable forward-compatibility breaks by default.
 
+   - When a file using an unsupported file format feature is encountered, the error message will be similar to the following:
+      ```
+      Error in <TBasket::Streamer>: The value of fIOBits (00000000000000000000000001111110) contains unknown flags (supported flags are 00000000000000000000000000000001), indicating this was written with a newer version of ROOT utilizing critical IO features this version of ROOT does not support.  Refusing to deserialize.
+      ```
+   - When an older version of ROOT, without this logic, encounters the file, the error message will be similar to the following:
+      ```
+      Error in <TBasket::Streamer>: The value of fNevBufSize is incorrect (-72) ; trying to recover by setting it to zero
+      ```
+
 ## TTree Libraries
 
 - Resolved O(N^2) scaling problem in ```TTree::Draw()``` observed when a branch that contains a

--- a/README/ReleaseNotes/v612/index.md
+++ b/README/ReleaseNotes/v612/index.md
@@ -15,6 +15,7 @@ The following people have contributed to this new version:
 
  Guilherme Amadio, CERN/SFT,\
  Bertrand Bellenot, CERN/SFT,\
+ Brian Bockelman, UNL,\
  Rene Brun, CERN/SFT,\
  Philippe Canal, FNAL,\
  Olivier Couet, CERN/SFT,\
@@ -62,6 +63,8 @@ auto h1 = key->ReadObject<TH1>
 ```
 after which h1 will either be null if the key contains something that is not a TH1 (or derived class)
 or will be set to the address of the histogram read from the file.
+
+- Added a new mechanism for providing clean forward-compatibility breaks in a ``TTree`` (i.e., a newer version of ROOT writes a ``TTree`` an older version cannot read).  When future versions of ROOT utilize an IO feature that this version does not support, ROOT will provide a clear error message instead of crashing or returning garbage data.  In future ROOT6 releases, forward-compatibility breaks will only be allowed if a non-default feature is enabled via the ``ROOT::Experimental`` namespace; it is expected ROOT7 will enable forward-compatibility breaks by default.
 
 ## TTree Libraries
 

--- a/tree/tree/CMakeLists.txt
+++ b/tree/tree/CMakeLists.txt
@@ -9,3 +9,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Tree
                               DICTIONARY_OPTIONS "-writeEmptyRootPCM"
                               LIBRARIES ${TBB_LIBRARIES}
                               DEPENDENCIES Net RIO Thread Imt)
+
+if(testing)
+   add_subdirectory(test)
+endif()

--- a/tree/tree/inc/TBasket.h
+++ b/tree/tree/inc/TBasket.h
@@ -51,8 +51,7 @@ protected:
    Int_t       fNevBuf;          ///< Number of entries in basket
    Int_t       fLast;            ///< Pointer to last used byte in basket
    Bool_t      fHeaderOnly;      ///< True when only the basket header must be read/written
-   UChar_t fIOBits{
-      0}; ///<!IO feature flags.  Serialized in custom portion of streamer to avoid forward compat issues unless needed.
+   UChar_t     fIOBits{0};       ///<!IO feature flags.  Serialized in custom portion of streamer to avoid forward compat issues unless needed.
    Int_t      *fDisplacement;    ///<![fNevBuf] Displacement of entries in fBuffer(TKey)
    Int_t      *fEntryOffset;     ///<[fNevBuf] Offset of entries in fBuffer(TKey)
    TBranch    *fBranch;          ///<Pointer to the basket support branch
@@ -68,7 +67,7 @@ public:
    // If (fIOBits & ~kSupported) is non-zero -- i.e., an unknown IO flag is set
    // in the fIOBits -- then the zombie flag will be set for this object.
    //
-   enum class EIOBits {
+   enum class EIOBits: char {
       // The following to bits are reserved for now; when supported, set
       // kSupported = kGenerateOffsetMap | kBasketClassMap
       // kGenerateOffsetMap = BIT(1),
@@ -82,7 +81,7 @@ public:
    // (kUnsupported | kSupported) should result in the '|' of all IOBits.
    enum class EUnsupportedIOBits { kUnsupported = 0 };
    // The number of known, defined IOBits.
-   static const int kIOBitCount = 0;
+   static constexpr int kIOBitCount = 0;
 
    TBasket();
    TBasket(TDirectory *motherDir);

--- a/tree/tree/inc/TBasket.h
+++ b/tree/tree/inc/TBasket.h
@@ -121,7 +121,7 @@ public:
    virtual void    Update(Int_t newlast, Int_t skipped);
    virtual Int_t   WriteBuffer();
 
-   ClassDef(TBasket,2);  //the TBranch buffers
+   ClassDef(TBasket, 3);  //the TBranch buffers
 };
 
 #endif

--- a/tree/tree/inc/TBasket.h
+++ b/tree/tree/inc/TBasket.h
@@ -67,7 +67,7 @@ public:
    // If (fIOBits & ~kSupported) is non-zero -- i.e., an unknown IO flag is set
    // in the fIOBits -- then the zombie flag will be set for this object.
    //
-   enum class EIOBits: Char_t {
+   enum class EIOBits : Char_t {
       // The following to bits are reserved for now; when supported, set
       // kSupported = kGenerateOffsetMap | kBasketClassMap
       // kGenerateOffsetMap = BIT(1),
@@ -79,7 +79,7 @@ public:
    // changes that are not going go into a supported release.
    //
    // (kUnsupported | kSupported) should result in the '|' of all IOBits.
-   enum class EUnsupportedIOBits: Char_t { kUnsupported = 0 };
+   enum class EUnsupportedIOBits : Char_t { kUnsupported = 0 };
    // The number of known, defined IOBits.
    static constexpr int kIOBitCount = 0;
 

--- a/tree/tree/inc/TBasket.h
+++ b/tree/tree/inc/TBasket.h
@@ -76,7 +76,7 @@ public:
    };
    // This enum covers IOBits that are known to this ROOT release but
    // not supported; provides a mechanism for us to have experimental
-   // changes that doing go into a supported release.
+   // changes that are not going go into a supported release.
    //
    // (kUnsupported | kSupported) should result in the '|' of all IOBits.
    enum class EUnsupportedIOBits: Char_t { kUnsupported = 0 };

--- a/tree/tree/inc/TBasket.h
+++ b/tree/tree/inc/TBasket.h
@@ -67,7 +67,7 @@ public:
    // If (fIOBits & ~kSupported) is non-zero -- i.e., an unknown IO flag is set
    // in the fIOBits -- then the zombie flag will be set for this object.
    //
-   enum class EIOBits: char {
+   enum class EIOBits: Char_t {
       // The following to bits are reserved for now; when supported, set
       // kSupported = kGenerateOffsetMap | kBasketClassMap
       // kGenerateOffsetMap = BIT(1),
@@ -79,7 +79,7 @@ public:
    // changes that doing go into a supported release.
    //
    // (kUnsupported | kSupported) should result in the '|' of all IOBits.
-   enum class EUnsupportedIOBits { kUnsupported = 0 };
+   enum class EUnsupportedIOBits: Char_t { kUnsupported = 0 };
    // The number of known, defined IOBits.
    static constexpr int kIOBitCount = 0;
 

--- a/tree/tree/inc/TBasket.h
+++ b/tree/tree/inc/TBasket.h
@@ -51,7 +51,8 @@ protected:
    Int_t       fNevBuf;          ///< Number of entries in basket
    Int_t       fLast;            ///< Pointer to last used byte in basket
    Bool_t      fHeaderOnly;      ///< True when only the basket header must be read/written
-   UChar_t     fIOBits{0};       ///<!IO feature flags.  Serialized in custom portion of streamer to avoid forward compat issues unless needed.
+   UChar_t fIOBits{
+      0}; ///<!IO feature flags.  Serialized in custom portion of streamer to avoid forward compat issues unless needed.
    Int_t      *fDisplacement;    ///<![fNevBuf] Displacement of entries in fBuffer(TKey)
    Int_t      *fEntryOffset;     ///<[fNevBuf] Offset of entries in fBuffer(TKey)
    TBranch    *fBranch;          ///<Pointer to the basket support branch
@@ -60,7 +61,6 @@ protected:
    Int_t       fLastWriteBufferSize; ///<! Size of the buffer last time we wrote it to disk
 
 public:
-
    // The IO bits flag is to provide improved forward-compatibility detection.
    // Any new non-forward compatibility flags related serialization should be
    // added here.  When a new flag is added, set it in the kSupported field;
@@ -80,9 +80,7 @@ public:
    // changes that doing go into a supported release.
    //
    // (kUnsupported | kSupported) should result in the '|' of all IOBits.
-   enum class EUnsupportedIOBits {
-      kUnsupported = 0
-   };
+   enum class EUnsupportedIOBits { kUnsupported = 0 };
    // The number of known, defined IOBits.
    static const int kIOBitCount = 0;
 
@@ -119,7 +117,7 @@ public:
    virtual void    Update(Int_t newlast, Int_t skipped);
    virtual Int_t   WriteBuffer();
 
-   ClassDef(TBasket, 3);  //the TBranch buffers
+   ClassDef(TBasket, 3); // the TBranch buffers
 };
 
 #endif

--- a/tree/tree/inc/TBasket.h
+++ b/tree/tree/inc/TBasket.h
@@ -70,13 +70,23 @@ public:
    // If (fIOBits & ~kSupported) is non-zero -- i.e., an unknown IO flag is set
    // in the fIOBits -- then the zombie flag will be set for this object.
    //
-   enum EIOBits {
+   enum class EIOBits {
       // The following to bits are reserved for now; when supported, set
       // kSupported = kGenerateOffsetMap | kBasketClassMap
       // kGenerateOffsetMap = BIT(1),
       // kBasketClassMap = BIT(2),
       kSupported = 0
    };
+   // This enum covers IOBits that are known to this ROOT release but
+   // not supported; provides a mechanism for us to have experimental
+   // changes that doing go into a supported release.
+   //
+   // (kUnsupported | kSupported) should result in the '|' of all IOBits.
+   enum class EUnsupportedIOBits {
+      kUnsupported = 0
+   };
+   // The number of known, defined IOBits.
+   static const int kIOBitCount = 0;
 
    TBasket();
    TBasket(TDirectory *motherDir);

--- a/tree/tree/inc/TBasket.h
+++ b/tree/tree/inc/TBasket.h
@@ -12,7 +12,6 @@
 #ifndef ROOT_TBasket
 #define ROOT_TBasket
 
-
 //////////////////////////////////////////////////////////////////////////
 //                                                                      //
 // TBasket                                                              //
@@ -35,6 +34,8 @@ class TBranch;
 
 class TBasket : public TKey {
 
+   friend class TBasket_TestUnsupportedIO_Test;
+
 private:
    TBasket(const TBasket&);            ///< TBasket objects are not copiable.
    TBasket& operator=(const TBasket&); ///< TBasket objects are not copiable.
@@ -52,6 +53,7 @@ protected:
    Int_t       fNevBuf;          ///< Number of entries in basket
    Int_t       fLast;            ///< Pointer to last used byte in basket
    Bool_t      fHeaderOnly;      ///< True when only the basket header must be read/written
+   UChar_t     fIOBits{0};       ///<!IO feature flags.  Serialized in custom portion of streamer to avoid forward compat issues unless needed.
    Int_t      *fDisplacement;    ///<![fNevBuf] Displacement of entries in fBuffer(TKey)
    Int_t      *fEntryOffset;     ///<[fNevBuf] Offset of entries in fBuffer(TKey)
    TBranch    *fBranch;          ///<Pointer to the basket support branch
@@ -60,6 +62,21 @@ protected:
    Int_t       fLastWriteBufferSize; ///<! Size of the buffer last time we wrote it to disk
 
 public:
+
+   // The IO bits flag is to provide improved forward-compatibility detection.
+   // Any new non-forward compatibility flags related serialization should be
+   // added here.  When a new flag is added, set it in the kSupported field;
+   //
+   // If (fIOBits & ~kSupported) is non-zero -- i.e., an unknown IO flag is set
+   // in the fIOBits -- then the zombie flag will be set for this object.
+   //
+   enum EIOBits {
+      // The following to bits are reserved for now; when supported, set
+      // kSupported = kGenerateOffsetMap | kBasketClassMap
+      // kGenerateOffsetMap = BIT(1),
+      // kBasketClassMap = BIT(2),
+      kSupported = 0
+   };
 
    TBasket();
    TBasket(TDirectory *motherDir);

--- a/tree/tree/inc/TBasket.h
+++ b/tree/tree/inc/TBasket.h
@@ -34,8 +34,6 @@ class TBranch;
 
 class TBasket : public TKey {
 
-   friend class TBasket_TestUnsupportedIO_Test;
-
 private:
    TBasket(const TBasket&);            ///< TBasket objects are not copiable.
    TBasket& operator=(const TBasket&); ///< TBasket objects are not copiable.

--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -791,8 +791,10 @@ void TBasket::Streamer(TBuffer &b)
       if (fNevBufSize < 0) {
          fNevBufSize = -fNevBufSize;
          b >> fIOBits;
-         if (!fIOBits || (fIOBits & (1<<7))) {
-            Error("TBasket::Streamer","The value of fNevBufSize (%d) or fIOBits (%d) is incorrect ; setting the buffer to a zombie.",-fNevBufSize, fIOBits);
+         if (!fIOBits || (fIOBits & (1 << 7))) {
+            Error("TBasket::Streamer",
+                  "The value of fNevBufSize (%d) or fIOBits (%d) is incorrect ; setting the buffer to a zombie.",
+                  -fNevBufSize, fIOBits);
             MakeZombie();
             fNevBufSize = 0;
          } else if (fIOBits && (fIOBits & ~static_cast<Int_t>(EIOBits::kSupported))) {
@@ -802,8 +804,8 @@ void TBasket::Streamer(TBuffer &b)
                                  "are %s), indicating this was written with a newer version of ROOT "
                                  "utilizing critical IO features this version of ROOT does not support."
                                  "  Refusing to deserialize.",
-                                 std::bitset<32>(static_cast<Int_t>(fIOBits)).to_string().c_str(),
-                                 std::bitset<32>(static_cast<Int_t>(EIOBits::kSupported)).to_string().c_str());
+                     std::bitset<32>(static_cast<Int_t>(fIOBits)).to_string().c_str(),
+                     std::bitset<32>(static_cast<Int_t>(EIOBits::kSupported)).to_string().c_str());
             } else if (nerrors == 10) {
                Error("Streamer", "Maximum number of errors has been reported; disabling further messages"
                                  "from this location until the process exits.");

--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -816,13 +816,13 @@ void TBasket::Streamer(TBuffer &b)
             Error("TBasket::Streamer","The value of fNevBufSize is incorrect (%d) ; setting the buffer to a zombie.",-fNevBufSize);
             MakeZombie();
             fNevBufSize = 0;
-         } else if (fIOBits && (fIOBits & ~kSupported)) {
+         } else if (fIOBits && (fIOBits & ~static_cast<Int_t>(EIOBits::kSupported))) {
             Error("TKey::Streamer", "The value of fIOBits (%s) contains unknown flags (supported flags "
                                     "are %s), indicating this was written with a newer version of ROOT "
                                     "utilizing critical IO features this version of ROOT does not support."
                                     "  Refusing to deserialize.",
-                                    std::bitset<32>(fIOBits).to_string().c_str(),
-                                    std::bitset<32>(kSupported).to_string().c_str());
+                                    std::bitset<32>(static_cast<Int_t>(fIOBits)).to_string().c_str(),
+                                    std::bitset<32>(static_cast<Int_t>(EIOBits::kSupported)).to_string().c_str());
             fNevBufSize = 0;
             MakeZombie();
          }

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -1147,7 +1147,7 @@ TBasket* TBranch::GetBasket(Int_t basketnumber)
 
    //now read basket
    Int_t badread = basket->ReadBasketBuffers(fBasketSeek[basketnumber],fBasketBytes[basketnumber],file);
-   if (badread || basket->GetSeekKey() != fBasketSeek[basketnumber]) {
+   if (R__unlikely(badread || basket->GetSeekKey() != fBasketSeek[basketnumber] || basket->IsZombie())) {
       nerrors++;
       if (nerrors > 10) return 0;
       if (nerrors == 10) {
@@ -1163,6 +1163,9 @@ TBasket* TBranch::GetBasket(Int_t basketnumber)
          }
       }
       Error("GetBasket","File: %s at byte:%lld, branch:%s, entry:%lld, badread=%d, nerrors=%d, basketnumber=%d",file->GetName(),basket->GetSeekKey(),GetName(),fReadEntry,badread,nerrors.load(),basketnumber);
+      if (basket->IsZombie()) {
+         MakeZombie();
+      }
       return 0;
    }
 

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -1163,9 +1163,6 @@ TBasket* TBranch::GetBasket(Int_t basketnumber)
          }
       }
       Error("GetBasket","File: %s at byte:%lld, branch:%s, entry:%lld, badread=%d, nerrors=%d, basketnumber=%d",file->GetName(),basket->GetSeekKey(),GetName(),fReadEntry,badread,nerrors.load(),basketnumber);
-      if (basket->IsZombie()) {
-         MakeZombie();
-      }
       return 0;
    }
 

--- a/tree/tree/test/CMakeLists.txt
+++ b/tree/tree/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+
+ROOT_ADD_GTEST(testTBasket TBasket.cxx LIBRARIES RIO Tree)
+

--- a/tree/tree/test/TBasket.cxx
+++ b/tree/tree/test/TBasket.cxx
@@ -51,8 +51,9 @@ TEST(TBasket, IOBits)
                 static_cast<Int_t>(TBasket::EUnsupportedIOBits::kUnsupported),
              (1 << static_cast<Int_t>(TBasket::kIOBitCount)) - 1);
 
-   EXPECT_EQ(
-      static_cast<Int_t>(TBasket::EIOBits::kSupported) & static_cast<Int_t>(TBasket::EUnsupportedIOBits::kUnsupported), 0);
+   EXPECT_EQ(static_cast<Int_t>(TBasket::EIOBits::kSupported) &
+                static_cast<Int_t>(TBasket::EUnsupportedIOBits::kUnsupported),
+             0);
 
    TClass *cl = TClass::GetClass("TBasket");
    ASSERT_NE(cl, nullptr);

--- a/tree/tree/test/TBasket.cxx
+++ b/tree/tree/test/TBasket.cxx
@@ -1,12 +1,12 @@
 
 #include "gtest/gtest.h"
 
+#include "TBasket.h"
+#include "TBranch.h"
 #include "TEnum.h"
 #include "TEnumConstant.h"
 #include "TMemFile.h"
 #include "TTree.h"
-#include "TBranch.h"
-#include "TBasket.h"
 
 #include <vector>
 

--- a/tree/tree/test/TBasket.cxx
+++ b/tree/tree/test/TBasket.cxx
@@ -43,6 +43,14 @@ void verifySampleFile(TFile *f)
    }
 }
 
+TEST(TBasket, IOBits)
+{
+   EXPECT_EQ(static_cast<int>(TBasket::EIOBits::kSupported) | static_cast<int>(TBasket::EUnsupportedIOBits::kUnsupported),
+             (1<<static_cast<Int_t>(TBasket::kIOBitCount))-1);
+
+   EXPECT_EQ(static_cast<int>(TBasket::EIOBits::kSupported) & static_cast<int>(TBasket::EUnsupportedIOBits::kUnsupported), 0);
+}
+
 // Basic "sanity check" test -- can we create and delete trees?
 TEST(TBasket, CreateAndDestroy)
 {
@@ -113,13 +121,14 @@ TEST(TBasket, TestUnsupportedIO)
    TBasket *basket = br->GetBasket(0);
    ASSERT_TRUE(basket != nullptr);
 
-   EXPECT_EQ(basket->fIOBits, 0);
+   EXPECT_EQ(static_cast<Int_t>(basket->fIOBits), 0);
 
    // This tests that at least one bit in the bitset is available.
    // When we are down to one bitset, we'll have to expand the field.
-   EXPECT_TRUE(static_cast<UChar_t>(~TBasket::kSupported));
+   UChar_t unsupportedbits = ~static_cast<UChar_t>(TBasket::EIOBits::kSupported);
+   EXPECT_TRUE(unsupportedbits);
 
-   basket->fIOBits = ~TBasket::kSupported;
+   basket->fIOBits = unsupportedbits;
    br->FlushBaskets();
    t1.Write();
    f->Close();

--- a/tree/tree/test/TBasket.cxx
+++ b/tree/tree/test/TBasket.cxx
@@ -21,7 +21,7 @@ void CreateSampleFile(TMemFile *&f)
    Int_t idx;
    t1.Branch("idx", &idx, "idx/I");
 
-   for (idx=0; idx < gSampleEvents; idx++) {
+   for (idx = 0; idx < gSampleEvents; idx++) {
       t1.Fill();
    }
    t1.Write();
@@ -45,10 +45,12 @@ void VerifySampleFile(TFile *f)
 
 TEST(TBasket, IOBits)
 {
-   EXPECT_EQ(static_cast<int>(TBasket::EIOBits::kSupported) | static_cast<int>(TBasket::EUnsupportedIOBits::kUnsupported),
-             (1<<static_cast<Int_t>(TBasket::kIOBitCount))-1);
+   EXPECT_EQ(static_cast<int>(TBasket::EIOBits::kSupported) |
+                static_cast<int>(TBasket::EUnsupportedIOBits::kUnsupported),
+             (1 << static_cast<Int_t>(TBasket::kIOBitCount)) - 1);
 
-   EXPECT_EQ(static_cast<int>(TBasket::EIOBits::kSupported) & static_cast<int>(TBasket::EUnsupportedIOBits::kUnsupported), 0);
+   EXPECT_EQ(
+      static_cast<int>(TBasket::EIOBits::kSupported) & static_cast<int>(TBasket::EUnsupportedIOBits::kUnsupported), 0);
 }
 
 // Basic "sanity check" test -- can we create and delete trees?
@@ -111,7 +113,7 @@ TEST(TBasket, TestUnsupportedIO)
    ASSERT_FALSE(t1.IsZombie());
    Int_t idx;
    t1.Branch("idx", &idx, "idx/I");
-   for (idx=0; idx < gSampleEvents; idx++) {
+   for (idx = 0; idx < gSampleEvents; idx++) {
       t1.Fill();
    }
 
@@ -125,7 +127,7 @@ TEST(TBasket, TestUnsupportedIO)
    ASSERT_NE(cl, nullptr);
    Long_t offset = cl->GetDataMemberOffset("fIOBits");
    ASSERT_GT(offset, 0); // 0 can be returned on error
-   UChar_t *ioBits = reinterpret_cast<UChar_t*>(reinterpret_cast<char*>(basket) + offset);
+   UChar_t *ioBits = reinterpret_cast<UChar_t *>(reinterpret_cast<char *>(basket) + offset);
 
    EXPECT_EQ(*ioBits, 0);
 
@@ -134,7 +136,7 @@ TEST(TBasket, TestUnsupportedIO)
    UChar_t unsupportedbits = ~static_cast<UChar_t>(TBasket::EIOBits::kSupported);
    EXPECT_TRUE(unsupportedbits);
 
-   *ioBits = unsupportedbits & ((1<<7) - 1); // Last bit should always be clear.
+   *ioBits = unsupportedbits & ((1 << 7) - 1); // Last bit should always be clear.
    br->FlushBaskets();
    t1.Write();
    f->Close();
@@ -157,4 +159,3 @@ TEST(TBasket, TestUnsupportedIO)
    // Getting the basket should fail here and an error should have been triggered.
    ASSERT_EQ(basket, nullptr);
 }
-

--- a/tree/tree/test/TBasket.cxx
+++ b/tree/tree/test/TBasket.cxx
@@ -1,12 +1,12 @@
 
-#include "gtest/gtest.h"
-
 #include "TBasket.h"
 #include "TBranch.h"
 #include "TEnum.h"
 #include "TEnumConstant.h"
 #include "TMemFile.h"
 #include "TTree.h"
+
+#include "gtest/gtest.h"
 
 #include <vector>
 

--- a/tree/tree/test/TBasket.cxx
+++ b/tree/tree/test/TBasket.cxx
@@ -134,7 +134,7 @@ TEST(TBasket, TestUnsupportedIO)
    UChar_t unsupportedbits = ~static_cast<UChar_t>(TBasket::EIOBits::kSupported);
    EXPECT_TRUE(unsupportedbits);
 
-   *ioBits = unsupportedbits;
+   *ioBits = unsupportedbits & ((1<<7) - 1); // Last bit should always be clear.
    br->FlushBaskets();
    t1.Write();
    f->Close();
@@ -154,7 +154,6 @@ TEST(TBasket, TestUnsupportedIO)
    ASSERT_NE(br, nullptr);
 
    basket = br->GetBasket(0);
-   EXPECT_TRUE(br->IsZombie());
    // Getting the basket should fail here and an error should have been triggered.
    ASSERT_EQ(basket, nullptr);
 }

--- a/tree/tree/test/TBasket.cxx
+++ b/tree/tree/test/TBasket.cxx
@@ -1,6 +1,8 @@
 
 #include "gtest/gtest.h"
 
+#include "TEnum.h"
+#include "TEnumConstant.h"
 #include "TMemFile.h"
 #include "TTree.h"
 #include "TBranch.h"
@@ -45,12 +47,51 @@ void VerifySampleFile(TFile *f)
 
 TEST(TBasket, IOBits)
 {
-   EXPECT_EQ(static_cast<int>(TBasket::EIOBits::kSupported) |
-                static_cast<int>(TBasket::EUnsupportedIOBits::kUnsupported),
+   EXPECT_EQ(static_cast<Int_t>(TBasket::EIOBits::kSupported) |
+                static_cast<Int_t>(TBasket::EUnsupportedIOBits::kUnsupported),
              (1 << static_cast<Int_t>(TBasket::kIOBitCount)) - 1);
 
    EXPECT_EQ(
-      static_cast<int>(TBasket::EIOBits::kSupported) & static_cast<int>(TBasket::EUnsupportedIOBits::kUnsupported), 0);
+      static_cast<Int_t>(TBasket::EIOBits::kSupported) & static_cast<Int_t>(TBasket::EUnsupportedIOBits::kUnsupported), 0);
+
+   TClass *cl = TClass::GetClass("TBasket");
+   ASSERT_NE(cl, nullptr);
+   TEnum *eIOBits = (TEnum *)cl->GetListOfEnums()->FindObject("EIOBits");
+   ASSERT_NE(eIOBits, nullptr);
+
+   Int_t supported = static_cast<Int_t>(TBasket::EIOBits::kSupported);
+   Bool_t foundSupported = false;
+   for (auto c : *eIOBits->GetConstants()) {
+      TEnumConstant *constant = static_cast<TEnumConstant *>(c);
+
+      printf("Looking at constant %s.\n", constant->GetName());
+      if (!strcmp(constant->GetName(), "kSupported")) {
+         foundSupported = true;
+         continue;
+      }
+      EXPECT_EQ(constant->GetValue() & supported, constant->GetValue());
+      supported -= constant->GetValue();
+   }
+   EXPECT_TRUE(foundSupported);
+   EXPECT_EQ(supported, 0);
+
+   TEnum *eUnsupportedIOBits = (TEnum *)cl->GetListOfEnums()->FindObject("EUnsupportedIOBits");
+   ASSERT_NE(eUnsupportedIOBits, nullptr);
+   Int_t unsupported = static_cast<Int_t>(TBasket::EUnsupportedIOBits::kUnsupported);
+   Bool_t foundUnsupported = false;
+   for (auto c : *eUnsupportedIOBits->GetConstants()) {
+      TEnumConstant *constant = static_cast<TEnumConstant *>(c);
+
+      printf("Looking at constant %s.\n", constant->GetName());
+      if (!strcmp(constant->GetName(), "kUnsupported")) {
+         foundUnsupported = true;
+         continue;
+      }
+      EXPECT_EQ(constant->GetValue() & unsupported, constant->GetValue());
+      unsupported -= constant->GetValue();
+   }
+   EXPECT_TRUE(foundUnsupported);
+   EXPECT_EQ(unsupported, 0);
 }
 
 // Basic "sanity check" test -- can we create and delete trees?

--- a/tree/tree/test/TBasket.cxx
+++ b/tree/tree/test/TBasket.cxx
@@ -61,7 +61,7 @@ TEST(TBasket, IOBits)
 
    Int_t supported = static_cast<Int_t>(TBasket::EIOBits::kSupported);
    Bool_t foundSupported = false;
-   for (auto constant : TRangeStaticCast<TEnumConstant>(eIOBits->GetConstants())) {
+   for (auto constant : ROOT::Detail::TRangeStaticCast<TEnumConstant>(eIOBits->GetConstants())) {
 
       if (!strcmp(constant->GetName(), "kSupported")) {
          foundSupported = true;
@@ -77,7 +77,7 @@ TEST(TBasket, IOBits)
    ASSERT_NE(eUnsupportedIOBits, nullptr);
    Int_t unsupported = static_cast<Int_t>(TBasket::EUnsupportedIOBits::kUnsupported);
    Bool_t foundUnsupported = false;
-   for (auto constant : TRangeStaticCast<TEnumConstant>(eUnsupportedIOBits->GetConstants())) {
+   for (auto constant : ROOT::Detail::TRangeStaticCast<TEnumConstant>(eUnsupportedIOBits->GetConstants())) {
 
       if (!strcmp(constant->GetName(), "kUnsupported")) {
          foundUnsupported = true;

--- a/tree/tree/test/TBasket.cxx
+++ b/tree/tree/test/TBasket.cxx
@@ -61,10 +61,8 @@ TEST(TBasket, IOBits)
 
    Int_t supported = static_cast<Int_t>(TBasket::EIOBits::kSupported);
    Bool_t foundSupported = false;
-   for (auto c : *eIOBits->GetConstants()) {
-      TEnumConstant *constant = static_cast<TEnumConstant *>(c);
+   for (auto constant : TRangeStaticCast<TEnumConstant>(eIOBits->GetConstants())) {
 
-      printf("Looking at constant %s.\n", constant->GetName());
       if (!strcmp(constant->GetName(), "kSupported")) {
          foundSupported = true;
          continue;
@@ -79,10 +77,8 @@ TEST(TBasket, IOBits)
    ASSERT_NE(eUnsupportedIOBits, nullptr);
    Int_t unsupported = static_cast<Int_t>(TBasket::EUnsupportedIOBits::kUnsupported);
    Bool_t foundUnsupported = false;
-   for (auto c : *eUnsupportedIOBits->GetConstants()) {
-      TEnumConstant *constant = static_cast<TEnumConstant *>(c);
+   for (auto constant : TRangeStaticCast<TEnumConstant>(eUnsupportedIOBits->GetConstants())) {
 
-      printf("Looking at constant %s.\n", constant->GetName());
       if (!strcmp(constant->GetName(), "kUnsupported")) {
          foundUnsupported = true;
          continue;

--- a/tree/tree/test/TBasket.cxx
+++ b/tree/tree/test/TBasket.cxx
@@ -1,0 +1,146 @@
+
+#include "gtest/gtest.h"
+
+#include "TMemFile.h"
+#include "TTree.h"
+#include "TBranch.h"
+#include "TBasket.h"
+
+#include <vector>
+
+static const Int_t gSampleEvents = 100;
+
+void createSampleFile(TMemFile *&f)
+{
+   f = new TMemFile("tbasket_test.root", "CREATE");
+   ASSERT_TRUE(f != nullptr);
+   ASSERT_FALSE(f->IsZombie());
+
+   TTree t1("t1", "Simple tree for testing.");
+   ASSERT_FALSE(t1.IsZombie());
+   Int_t idx;
+   t1.Branch("idx", &idx, "idx/I");
+
+   for (idx=0; idx < gSampleEvents; idx++) {
+      t1.Fill();
+   }
+   t1.Write();
+}
+
+void verifySampleFile(TFile *f)
+{
+   TTree *tree = nullptr;
+   f->GetObject("t1", tree);
+   ASSERT_TRUE(tree != nullptr);
+
+   Int_t saved_idx;
+   tree->SetBranchAddress("idx", &saved_idx);
+
+   EXPECT_EQ(tree->GetEntries(), gSampleEvents);
+   for (Int_t idx = 0; idx < tree->GetEntries(); idx++) {
+      tree->GetEntry(idx);
+      EXPECT_EQ(idx, saved_idx);
+   }
+}
+
+// Basic "sanity check" test -- can we create and delete trees?
+TEST(TBasket, CreateAndDestroy)
+{
+   std::vector<char> memBuffer;
+
+   TMemFile *f;
+   createSampleFile(f);
+   f->Close();
+
+   Long64_t maxsize = f->GetSize();
+   memBuffer.reserve(maxsize);
+   f->CopyTo(&memBuffer[0], maxsize);
+
+   delete f;
+
+   TMemFile f2("tbasket_test.root", &memBuffer[0], maxsize, "READ");
+   ASSERT_FALSE(f2.IsZombie());
+   verifySampleFile(&f2);
+}
+
+// Create a TTree, pull out a TBasket.
+TEST(TBasket, CreateAndGetBasket)
+{
+   TMemFile *f;
+   createSampleFile(f);
+   ASSERT_FALSE(f->IsZombie());
+
+   TTree *tree = nullptr;
+   f->GetObject("t1", tree);
+   ASSERT_TRUE(tree != nullptr);
+   ASSERT_FALSE(tree->IsZombie());
+
+   TBranch *br = tree->GetBranch("idx");
+   ASSERT_TRUE(br != nullptr);
+   ASSERT_FALSE(br->IsZombie());
+
+   TBasket *basket = br->GetBasket(0);
+   ASSERT_TRUE(basket != nullptr);
+   ASSERT_FALSE(basket->IsZombie());
+
+   EXPECT_EQ(basket->GetNevBuf(), gSampleEvents);
+   verifySampleFile(f);
+
+   f->Close();
+   delete f;
+}
+
+TEST(TBasket, TestUnsupportedIO)
+{
+   TMemFile *f;
+   // Create a file; not using the createSampleFile helper as
+   // we must corrupt the basket here.
+   f = new TMemFile("tbasket_test.root", "CREATE");
+   ASSERT_TRUE(f != nullptr);
+   ASSERT_FALSE(f->IsZombie());
+
+   TTree t1("t1", "Simple tree for testing.");
+   ASSERT_FALSE(t1.IsZombie());
+   Int_t idx;
+   t1.Branch("idx", &idx, "idx/I");
+   for (idx=0; idx < gSampleEvents; idx++) {
+      t1.Fill();
+   }
+
+   TBranch *br = t1.GetBranch("idx");
+   ASSERT_TRUE(br != nullptr);
+
+   TBasket *basket = br->GetBasket(0);
+   ASSERT_TRUE(basket != nullptr);
+
+   EXPECT_EQ(basket->fIOBits, 0);
+
+   // This tests that at least one bit in the bitset is available.
+   // When we are down to one bitset, we'll have to expand the field.
+   EXPECT_TRUE(static_cast<UChar_t>(~TBasket::kSupported));
+
+   basket->fIOBits = ~TBasket::kSupported;
+   br->FlushBaskets();
+   t1.Write();
+   f->Close();
+
+   std::vector<char> memBuffer;
+   Long64_t maxsize = f->GetSize();
+   memBuffer.reserve(maxsize);
+   f->CopyTo(&memBuffer[0], maxsize);
+
+   TMemFile f2("tbasket_test.root", &memBuffer[0], maxsize, "READ");
+   TTree *tree;
+   f2.GetObject("t1", tree);
+   ASSERT_TRUE(tree != nullptr);
+   ASSERT_FALSE(tree->IsZombie());
+
+   br = tree->GetBranch("idx");
+   ASSERT_TRUE(br != nullptr);
+
+   basket = br->GetBasket(0);
+   EXPECT_TRUE(br->IsZombie());
+   // Getting the basket should fail here and an error should have been triggered.
+   ASSERT_TRUE(basket == nullptr);
+}
+

--- a/tree/tree/test/TBasket.cxx
+++ b/tree/tree/test/TBasket.cxx
@@ -10,7 +10,7 @@
 
 static const Int_t gSampleEvents = 100;
 
-void createSampleFile(TMemFile *&f)
+void CreateSampleFile(TMemFile *&f)
 {
    f = new TMemFile("tbasket_test.root", "CREATE");
    ASSERT_TRUE(f != nullptr);
@@ -27,7 +27,7 @@ void createSampleFile(TMemFile *&f)
    t1.Write();
 }
 
-void verifySampleFile(TFile *f)
+void VerifySampleFile(TFile *f)
 {
    TTree *tree = nullptr;
    f->GetObject("t1", tree);
@@ -57,7 +57,7 @@ TEST(TBasket, CreateAndDestroy)
    std::vector<char> memBuffer;
 
    TMemFile *f;
-   createSampleFile(f);
+   CreateSampleFile(f);
    f->Close();
 
    Long64_t maxsize = f->GetSize();
@@ -68,14 +68,14 @@ TEST(TBasket, CreateAndDestroy)
 
    TMemFile f2("tbasket_test.root", &memBuffer[0], maxsize, "READ");
    ASSERT_FALSE(f2.IsZombie());
-   verifySampleFile(&f2);
+   VerifySampleFile(&f2);
 }
 
 // Create a TTree, pull out a TBasket.
 TEST(TBasket, CreateAndGetBasket)
 {
    TMemFile *f;
-   createSampleFile(f);
+   CreateSampleFile(f);
    ASSERT_FALSE(f->IsZombie());
 
    TTree *tree = nullptr;
@@ -92,7 +92,7 @@ TEST(TBasket, CreateAndGetBasket)
    ASSERT_FALSE(basket->IsZombie());
 
    EXPECT_EQ(basket->GetNevBuf(), gSampleEvents);
-   verifySampleFile(f);
+   VerifySampleFile(f);
 
    f->Close();
    delete f;
@@ -101,7 +101,7 @@ TEST(TBasket, CreateAndGetBasket)
 TEST(TBasket, TestUnsupportedIO)
 {
    TMemFile *f;
-   // Create a file; not using the createSampleFile helper as
+   // Create a file; not using the CreateSampleFile helper as
    // we must corrupt the basket here.
    f = new TMemFile("tbasket_test.root", "CREATE");
    ASSERT_NE(f, nullptr);


### PR DESCRIPTION
This PR introduces (with unit tests!) the concept of a forward-compatibility feature break flag for `TBasket`.

This allows the `TBasket` class to identify if the object being deserialized was written by a newer version of ROOT using a feature that breaks forward-compatibility.  Note that much care was taken so older versions of ROOT that *don't* recognize the new flag will believe the file is corrupt; they will give a misleading error message, but will not silently serve corrupted data.

If this approach goes forward, I intend to backport the flags to older versions of ROOT -- they should be able to recognize files they aren't supposed to read.  I do not plan to backport the new IO features themselves.