### PR TITLE
Revert previous change, case should fall through

### DIFF
--- a/math/mathcore/src/GoFTest.cxx
+++ b/math/mathcore/src/GoFTest.cxx
@@ -246,7 +246,7 @@ namespace Math {
       switch (fDist) {
       case kLogNormal:
          LogSample();
-         break;
+         /* fall through */
       case kGaussian :
          cdf = new ROOT::Math::WrappedMemFunction<GoFTest, Double_t (GoFTest::*)(Double_t) const>(*this, &GoFTest::GaussianCDF);
          break;


### PR DESCRIPTION
Originally tried to fix a computer warning, but case needs to fall through
In order to compute the CDF.