### PR TITLE
Fixing filemerger test and usage of __FAST_MATH__ with gcc for Optimized builds

### DIFF
--- a/cmake/modules/SetUpLinux.cmake
+++ b/cmake/modules/SetUpLinux.cmake
@@ -107,7 +107,9 @@ set(CMAKE_M_LIBS -lm)
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -rdynamic")
 
 if(CMAKE_COMPILER_IS_GNUCXX)
-
+  if(CMAKE_BUILD_TYPE STREQUAL Optimized)
+      set(CMAKE_CXX_FLAGS "-ffast-math")
+  endif()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pipe ${BIT_ENVIRONMENT} ${FP_MATH_FLAGS} -Wshadow -Wall -W -Woverloaded-virtual -fsigned-char -fPIC")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pipe ${BIT_ENVIRONMENT} -Wall -W -fPIC")
 


### PR DESCRIPTION
If -Ofast is the optimization level, then -ffast-math should be enabled for GCC builds (Linux) to be able to activate ```__FAST_MATH__``` macros (order  of flags is important apparently too)