### PR TITLE
[cxxmodules] Fix cyclic include between STL<->clang builtin

### DIFF
--- a/build/unix/stl.modulemap
+++ b/build/unix/stl.modulemap
@@ -105,9 +105,16 @@ module "stl" [system] {
     export *
     header "cstdio"
   }
+  // Causes a cycle between clang's builtin modules
+  // and the STL as clang's builtin modules include
+  // this header (and in turn, the STL also includes
+  // clang's builtin headers).
+  // See the include for stdlib.h (which is forwarded
+  // to this C++ header) in clang's mm_malloc.h for the
+  // problematic code which we can't fix.
   module "cstdlib" {
     export *
-    header "cstdlib"
+    textual header "cstdlib"
   }
   module "cstring" {
     export *


### PR DESCRIPTION
This breaks the module nightlies. There is no nice way for now
to fix this, so we just skip this header and fix any upcoming
merging issues from having it multiple times.