### PR TITLE
[cxxmodules] Fix headers paths in Core modulemap.

### DIFF
--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -269,7 +269,7 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
                      macosx meta metacling multiproc newdelete pcre rint
                      rootcling_stage1 textinput thread unix winnt zip)
     foreach(core_folder ${core_folders})
-     string(REPLACE "${CMAKE_SOURCE_DIR}/core/(${core_folders})/inc/" ""  headerfiles "${headerfiles}")
+      string(REPLACE "${CMAKE_SOURCE_DIR}/core/${core_folder}/inc/" ""  headerfiles "${headerfiles}")
     endforeach()
   endif()
 


### PR DESCRIPTION
This replace failed to actually make the paths relative because
of the typo in the variable name and the surrounding parentheses.

This also fixes the nightly modules builds.