### PR TITLE
Root 8994 tformula modulus

### DIFF
--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -160,7 +160,7 @@ static std::unordered_map<std::string,  void *> gClingFunctions = std::unordered
 Bool_t TFormula::IsOperator(const char c)
 {
    // operator ":" must be handled separately
-   char ops[] = { '+','^', '-','/','*','<','>','|','&','!','=','?'};
+   char ops[] = {'+','^','-','/','*','<','>','|','&','!','=','?','%'};
    Int_t opsLen = sizeof(ops)/sizeof(char);
    for(Int_t i = 0; i < opsLen; ++i)
       if(ops[i] == c)

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -139,6 +139,58 @@ ClassImp(TFormula);
     This class is not anymore the base class for the function classes `TF1`, but it has now
     a data member of TF1 which can be accessed via `TF1::GetFormula`.
 
+    ### A note on variables and parameters
+
+    In a TFormula, a variable is a defined by a name such as "x" or "mass" in a
+    formula defined as
+
+    ```
+    TFormula("", "x * mass + 10")
+    ```
+
+    Parameters are very similar but can be unnamed. It is specified using brackets
+    e.g. `[0]`. In the following example `[0]` is the first parameter and `[1]` is
+    the second.
+
+    ```
+    TFormula("", "[0]+[1]*[0]")
+    ```
+
+    Variables and parameters can be combined in the same TFormula. Here we consider
+    a very simple case where we have an exponential decay after some time t and a
+    number of events with timestamps for which we want to evaluate this function.
+
+    ```
+    TFormula tf ("", "[0]*exp(-[1]*t)");
+    tf.SetParameter(0, 1);
+    tf.SetParameter(1, 0.5);
+
+    for (auto & event : events) {
+       tf.Eval(event.t);
+    }
+    ```
+
+    A guiding rule is that values of parameters should be fixed when looping over events, while variables can vary.
+
+    ### A note on operators
+
+    All operators of C/C++ are allowed in a TFormula with a few caveats.
+
+    The operators `|`, `&`, `%` can be used but will raise an error if used in
+    conjunction with a variable or a parameter. Variables and parameters are treated
+    as doubles internally for which these operators are not defined.
+    This means the following command will run successfully
+       ```root -l -q -e TFormula("", "x+(10%3)").Eval(0)```
+    but not
+       ```root -l -q -e TFormula("", "x%10").Eval(0)```.
+
+    The operator `^` is defined to mean exponentiation instead of the C/C++
+    interpretaion xor. `**` is added, also meaning exponentiation.
+
+    The operators `++` and `@` are added, and are shorthand for the a linear
+    function. That means the expression `x@2` will be expanded to
+    ```[n]*x + [n+1]*2``` where n is the first previously unused parameter number.
+
     \class TFormulaFunction
     Helper class for TFormula
 

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -139,21 +139,20 @@ ClassImp(TFormula);
     This class is not anymore the base class for the function classes `TF1`, but it has now
     a data member of TF1 which can be accessed via `TF1::GetFormula`.
 
-    ### A note on variables and parameters
+    ### An expanded note on variables and parameters
 
-    In a TFormula, a variable is a defined by a name such as "x" or "mass" in a
-    formula defined as
-
-    ```
-    TFormula("", "x * mass + 10")
-    ```
-
-    Parameters are very similar but can be unnamed. It is specified using brackets
-    e.g. `[0]`. In the following example `[0]` is the first parameter and `[1]` is
-    the second.
+    In a TFormula, a variable is a defined by a name `x`, `y`, `z` or `t` or an
+    index like `x[0]`, `x[1]`, `x[2]`; that is `x[N]` where N is an integer.
 
     ```
-    TFormula("", "[0]+[1]*[0]")
+    TFormula("", "x[0] * x[1] + 10")
+    ```
+
+    Parameters are similar and can take any name. It is specified using brackets
+    e.g. `[expected_mass]` or `[0]`.
+
+    ```
+    TFormula("", "exp([expected_mass])-1")
     ```
 
     Variables and parameters can be combined in the same TFormula. Here we consider
@@ -170,7 +169,21 @@ ClassImp(TFormula);
     }
     ```
 
-    A guiding rule is that values of parameters should be fixed when looping over events, while variables can vary.
+    The distinction between variables and parameters arose from the TFormula's
+    application in fitting. There parameters are fitted to the data provided
+    through variables. In other applications this distinction can go away.
+
+    Parameter values can be provided dynamically using `TFormula::EvalPar`
+    instead of `TFormula::Eval`. In this way parameters can be used identically
+    to variables. See below for an example that uses only parameters to model a
+    function.
+
+    ```
+    Int_t params[2] = {1, 2}; // {vel_x, vel_y}
+    TFormula tf ("", "[vel_x]/sqrt(([vel_x + vel_y])**2)");
+
+    tf.EvalPar(nullptr, params);
+    ```
 
     ### A note on operators
 


### PR DESCRIPTION
Remedies an inconsistency in how the operator `%` was treated in comparison to e.g. `&`.

Also adds documentation on operators and the difference between variables and parameters.