### PR TITLE
[cmake] Fix that clingutils headers are found in /bin

### DIFF
--- a/core/clingutils/CMakeLists.txt
+++ b/core/clingutils/CMakeLists.txt
@@ -27,6 +27,11 @@ ROOT_INSTALL_HEADERS()
 
 #### STL dictionary (replacement for cintdlls)##############################
 
+# Make a list of header search paths we can iterate over when looking for STL
+# headers. We also add the inc/ directory for things like root_std_complex.h
+get_property(cxx_path GLOBAL PROPERTY ROOT_CLING_CXX_HEADERS_LOCATION)
+string(REPLACE ":" ";" cxx_path "${cxx_path}:${CMAKE_CURRENT_SOURCE_DIR}/inc")
+
 set(stldicts
     vector
     list
@@ -45,12 +50,22 @@ foreach(dict ${stldicts})
   string(REPLACE "2" "" header ${dict})
   string(REPLACE "complex" "root_std_complex.h" header ${header})
   string(REPLACE "multi" "" header ${header})
+
+  # Manually search for the header in our STL folders because the ROOT macros
+  # could pick up other files like /bin/map due to their extensive search paths.
+  find_file(abs_cling_header name ${header} HINTS ${cxx_path} NO_DEFAULT_PATH)
+  if(NOT abs_cling_header)
+    message(WARNING "Couldn't find STL header ${header} in Cling's search"
+                    "paths: ${cxx_path}")
+  endif()
+
   ROOT_STANDARD_LIBRARY_PACKAGE(${dict}Dict
                                 NO_SOURCES NO_INSTALL_HEADERS
                                 STAGE1
-                                HEADERS ${header}
+                                HEADERS "${abs_cling_header}"
                                 LINKDEF src/${dict}Linkdef.h
                                 DEPENDENCIES Core)
+  unset(abs_cling_header CACHE)
 endforeach()
 
 #---Deal with LLVM resource here----------------------------------------------


### PR DESCRIPTION
The ROOT macros use at the moment use a very expansive list
of paths when looking for headers. And right now clingutils rely on
the ROOT_GENERATE_DICTIONARY behaviour that a header that can't
be found will be deferred to runtime loading in cling, but this
strategy starts to fail once people have files named 'map',
'vector' in any path that CMake's find_file searches by default.

When those files are found by our CMake macros, they won't delay
the lookup of for example 'map' to the runtime but instead directly
include '/bin/map' (which is then causing Cling to fail as this
is usually an executable or something like that).

As we can't seem to just fix the find_file behavior, we instead
fix this from clingutils' side by looking up the STL headers
manually via our cling search paths which means we no longer
rely on the 'if-not-found-load-at-runtime' branch in the
ROOT_GENERATE_DICTINARY macro.