### PR TITLE
[TDF] Add `DefineSlot` transformation

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFNodes.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFNodes.hxx
@@ -415,7 +415,7 @@ public:
 
    template <int... S, typename... BranchTypes>
    void UpdateHelper(unsigned int slot, Long64_t entry, TDFInternal::StaticSeq<S...>, TypeList<BranchTypes...>,
-                     std::true_type shouldPassSlotNumber)
+                     std::true_type /*shouldPassSlotNumber*/)
    {
       *fLastResultPtr[slot] = fExpression(slot, std::get<S>(fValues[slot]).Get(entry)...);
       // silence "unused parameter" warnings in gcc
@@ -425,7 +425,7 @@ public:
 
    template <int... S, typename... BranchTypes>
    void UpdateHelper(unsigned int slot, Long64_t entry, TDFInternal::StaticSeq<S...>, TypeList<BranchTypes...>,
-                     std::false_type shouldPassSlotNumber)
+                     std::false_type /*shouldPassSlotNumber*/)
    {
       *fLastResultPtr[slot] = fExpression(std::get<S>(fValues[slot]).Get(entry)...);
       // silence "unused parameter" warnings in gcc

--- a/tree/treeplayer/test/dataframe/dataframe_simple_tests.hxx
+++ b/tree/treeplayer/test/dataframe/dataframe_simple_tests.hxx
@@ -229,6 +229,17 @@ TEST(TEST_CATEGORY, Define_jitted_Filter_named_jitted)
    EXPECT_EQ(7.867497533559811628, *m);
 }
 
+TEST(TEST_CATEGORY, DefineSlot)
+{
+   std::array<int, NSLOTS> values;
+   for (auto i = 0u; i < NSLOTS; ++i)
+      values[i] = i;
+   TDataFrame df(NSLOTS);
+   auto ddf = df.DefineSlot("s", [values](unsigned int slot) { return values[slot]; });
+   auto m = ddf.Max("s");
+   EXPECT_EQ(*m, NSLOTS-1); // no matter the order of processing, the higher slot number is always taken at least once
+}
+
 TEST(TEST_CATEGORY, Snapshot_update)
 {
    using SnapshotOptions = ROOT::Experimental::TDF::SnapshotOptions;


### PR DESCRIPTION
Example usage:

```c++
// generate random numbers and fill a histogram in parallel
constexpr auto nSlots = 4u;
ROOT::EnableImplicitMT(nSlots);
std::array<TRandom, nSlots> r;
TDataFrame d(1e8);
d.DefineSlot("x", [&r](unsigned int slot) { return r[slot].Gaus(); }, {})
 .Histo1D("x");
```

More unit tests are needed.