### PR TITLE
[llvm] Backport D37416 - Use the VFS from the CompilerInvocation

### DIFF
--- a/interpreter/llvm/src/tools/clang/include/clang/Frontend/CompilerInstance.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/Frontend/CompilerInstance.h
@@ -633,7 +633,9 @@ public:
                     const CodeGenOptions *CodeGenOpts = nullptr);
 
   /// Create the file manager and replace any existing one with it.
-  void createFileManager();
+  ///
+  /// \return The new file manager on success, or null on failure.
+  FileManager *createFileManager();
 
   /// Create the source manager and replace any existing one with it.
   void createSourceManager(FileManager &FileMgr);

--- a/interpreter/llvm/src/tools/clang/lib/Frontend/CompilerInstance.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Frontend/CompilerInstance.cpp
@@ -299,12 +299,16 @@ CompilerInstance::createDiagnostics(DiagnosticOptions *Opts,
 
 // File Manager
 
-void CompilerInstance::createFileManager() {
+FileManager *CompilerInstance::createFileManager() {
   if (!hasVirtualFileSystem()) {
-    // TODO: choose the virtual file system based on the CompilerInvocation.
-    setVirtualFileSystem(vfs::getRealFileSystem());
+    if (IntrusiveRefCntPtr<vfs::FileSystem> VFS =
+            createVFSFromCompilerInvocation(getInvocation(), getDiagnostics()))
+      setVirtualFileSystem(VFS);
+    else
+      return nullptr;
   }
   FileMgr = new FileManager(getFileSystemOpts(), VirtualFileSystem);
+  return FileMgr.get();
 }
 
 // Source Manager

--- a/interpreter/llvm/src/tools/clang/lib/Frontend/FrontendAction.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Frontend/FrontendAction.cpp
@@ -565,18 +565,12 @@ bool FrontendAction::BeginSourceFile(CompilerInstance &CI,
     return true;
   }
 
-  if (!CI.hasVirtualFileSystem()) {
-    if (IntrusiveRefCntPtr<vfs::FileSystem> VFS =
-          createVFSFromCompilerInvocation(CI.getInvocation(),
-                                          CI.getDiagnostics()))
-      CI.setVirtualFileSystem(VFS);
-    else
-      goto failure;
-  }
-
   // Set up the file and source managers, if needed.
-  if (!CI.hasFileManager())
-    CI.createFileManager();
+  if (!CI.hasFileManager()) {
+    if (!CI.createFileManager()) {
+      goto failure;
+    }
+  }
   if (!CI.hasSourceManager())
     CI.createSourceManager(CI.getFileManager());
 


### PR DESCRIPTION
Necessary to make cling pickup the VFS from root which fixes all the merging
problems that we have in STL/libc.

Original description:

Title: Use the VFS from the CompilerInvocation by default

The CompilerInstance should create its default VFS from its CompilerInvocation. Right now the
user has to manually create the VFS before creating the FileManager even though
`-ivfsoverlay file.yaml` was passed via the CompilerInvocation (which is exactly how we worked
around this issue in `FrontendAction.cpp` so far).

This patch uses the invocation's VFS by default and also tests this behavior now from the
point of view of a program that uses the clang API.