### PR TITLE
Implement non-blocking callback mechanism in TBufferMerger

### DIFF
--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -15,6 +15,7 @@
 #include "TMemFile.h"
 
 #include <condition_variable>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <queue>
@@ -64,6 +65,16 @@ public:
     */
    std::shared_ptr<TBufferMergerFile> GetFile();
 
+   /** Returns the number of buffers currently in the queue. */
+   size_t GetQueueSize() const;
+
+   /** Register a user callback function to be called after a buffer has been
+    *  removed from the merging queue and finished being processed. This
+    *  function can be useful to allow asynchronous launching of new tasks to
+    *  push more data into the queue once its size satisfies user requirements.
+    */
+   void RegisterCallback(const std::function<void(void)> &f);
+
    friend class TBufferMergerFile;
 
 private:
@@ -87,6 +98,7 @@ private:
    std::queue<TBufferFile *> fQueue;                             //< Queue to which data is pushed and merged
    std::unique_ptr<std::thread> fMergingThread;                  //< Worker thread that writes to disk
    std::vector<std::weak_ptr<TBufferMergerFile>> fAttachedFiles; //< Attached files
+   std::function<void(void)> fCallback;                          //< Callback for when data is removed from queue
 
    ClassDef(TBufferMerger, 0);
 };

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -44,6 +44,16 @@ std::shared_ptr<TBufferMergerFile> TBufferMerger::GetFile()
    return f;
 }
 
+size_t TBufferMerger::GetQueueSize() const
+{
+   return fQueue.size();
+}
+
+void TBufferMerger::RegisterCallback(const std::function<void(void)> &f)
+{
+   fCallback = f;
+}
+
 void TBufferMerger::Push(TBufferFile *buffer)
 {
    {
@@ -93,6 +103,9 @@ void TBufferMerger::WriteOutputFile()
          }
          merger.Reset();
       }
+
+      if (fCallback)
+         fCallback();
    }
 }
 

--- a/io/io/test/TBufferMerger.cxx
+++ b/io/io/test/TBufferMerger.cxx
@@ -1,9 +1,12 @@
 #include "ROOT/TBufferMerger.hxx"
+#include "ROOT/TTaskGroup.hxx"
 
 #include "TFile.h"
 #include "TROOT.h"
 #include "TTree.h"
 
+#include <cstdio>
+#include <future>
 #include <memory>
 #include <thread>
 #include <sys/stat.h>
@@ -101,7 +104,8 @@ TEST(TBufferMerger, ParallelTreeFill)
          });
       }
 
-      for (auto &&t : threads) t.join();
+      for (auto &&t : threads)
+         t.join();
    }
 
    EXPECT_TRUE(FileExists("tbuffermerger_parallel.root"));
@@ -153,4 +157,172 @@ TEST(TBufferMerger, CheckTreeFillResults)
 
    EXPECT_EQ(523776, sum_s);
    EXPECT_EQ(523776, sum_p);
+}
+
+TEST(TBufferMerger, RegisterCallbackThreads)
+{
+   const char *testfile = "tbuffermerger_threads.root";
+   std::mutex m;
+   int events = 1000;
+   int events_per_task = 50;
+   int tasks = events / events_per_task;
+   int launched = 0;
+   int processed = 0;
+
+   {
+      ROOT::EnableThreadSafety();
+      TBufferMerger merger(testfile);
+
+      /* define a task: create and push some events */
+      auto task = [&]() {
+         auto myfile = merger.GetFile();
+         auto mytree = new TTree("mytree", "mytree");
+
+         mytree->ResetBit(kMustCleanup);
+
+         int n = 1;
+         mytree->Branch("n", &n, "n/I");
+
+         for (int i = 0; i < events_per_task; ++i)
+            mytree->Fill();
+
+         myfile->Write();
+
+         std::lock_guard<std::mutex> lk(m);
+         processed += events_per_task;
+      };
+
+      std::vector<std::thread> workers;
+
+      /* callback: launches new tasks when called */
+      merger.RegisterCallback([&]() {
+         int i = 0;
+         while (launched < tasks && ++i <= 2) {
+            workers.emplace_back(task);
+            ++launched;
+         }
+      });
+
+      launched = 1;
+      workers.emplace_back(task);
+
+      /* wait until all tasks have been launched */
+      while (launched != tasks)
+         ;
+
+      /* wait until all tasks have finished running */
+      for (auto &w : workers)
+         w.join();
+
+      ASSERT_EQ(processed, events);
+   }
+
+   ASSERT_TRUE(FileExists(testfile));
+
+   /* open file and check data integrity */
+   {
+      TFile f(testfile);
+      auto t = (TTree *)f.Get("mytree");
+
+      int n, sum = 0;
+      int nentries = (int)t->GetEntries();
+
+      EXPECT_EQ(nentries, events);
+
+      t->SetBranchAddress("n", &n);
+
+      for (int i = 0; i < nentries; ++i) {
+         t->GetEntry(i);
+         sum += n;
+      }
+
+      EXPECT_EQ(sum, events);
+   }
+
+   remove(testfile);
+}
+
+TEST(TBufferMerger, RegisterCallbackTasks)
+{
+   using namespace ROOT::Experimental;
+
+   const char *testfile = "tbuffermerger_tasks.root";
+
+   std::mutex m;
+   int events = 1000;
+   int events_per_task = 50;
+   int tasks = events / events_per_task;
+   int launched = 0;
+   int processed = 0;
+
+   {
+      ROOT::EnableImplicitMT();
+      TBufferMerger merger(testfile);
+
+      /* define a task: create and push some events */
+      auto task = [&]() {
+         auto myfile = merger.GetFile();
+         auto mytree = new TTree("mytree", "mytree");
+
+         mytree->ResetBit(kMustCleanup);
+
+         int n = 1;
+         mytree->Branch("n", &n, "n/I");
+
+         for (int i = 0; i < events_per_task; ++i)
+            mytree->Fill();
+
+         myfile->Write();
+
+         std::lock_guard<std::mutex> lk(m);
+         processed += events_per_task;
+      };
+
+      TTaskGroup tg;
+
+      /* callback: launches new tasks when called */
+      merger.RegisterCallback([&]() {
+         int i = 0;
+         while (launched < tasks && ++i <= 2) {
+            tg.Run(task);
+            ++launched;
+         }
+      });
+
+      launched = 1;
+      tg.Run(task);
+
+      /* wait until all tasks have been launched */
+      while (launched != tasks)
+         ;
+
+      /* wait until all tasks have finished running */
+      tg.Wait();
+
+      ASSERT_EQ(processed, events);
+   }
+
+   ASSERT_TRUE(FileExists(testfile));
+
+   /* open file and check data integrity */
+   {
+      TFile f(testfile);
+      auto t = (TTree *)f.Get("mytree");
+
+      int n, sum = 0;
+      int nentries = (int)t->GetEntries();
+
+      EXPECT_EQ(nentries, events);
+
+      t->SetBranchAddress("n", &n);
+
+      for (int i = 0; i < nentries; ++i) {
+         t->GetEntry(i);
+         sum += n;
+      }
+
+      EXPECT_EQ(sum, events);
+   }
+
+   remove(testfile);
 }


### PR DESCRIPTION
Add methods TBufferMerger::GetQueueSize() and TBufferMerger::RegisterCallback() to alow user
to control the rate at which data is pushed into the merging queue. In our test, we use the callback
function to launch tasks asynchronously whenever a buffer is done processing.