### PR TITLE
Fix ROOT-8995

### DIFF
--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -5492,7 +5492,7 @@ void TTree::InitializeBranchLists(bool checkLeafCount)
    }
 
    // The special branch fBranchRef also needs to be processed sequentially
-   if (fBranchRef) {
+   if (fBranchRef && fBranches.FindObject(fBranchRef)) {
       fSeqBranches.push_back(fBranchRef);
    }
 


### PR DESCRIPTION
fBranchRef might not included in fBranches. We need to check its presence before adding it to fSeqBranches.