### PR TITLE
Use TTaskGroup interface to unzip baskets in parallel.

### DIFF
--- a/tree/tree/inc/TTreeCacheUnzip.h
+++ b/tree/tree/inc/TTreeCacheUnzip.h
@@ -25,59 +25,91 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
+#include "Bytes.h"
 #include "TTreeCache.h"
-
+#include "ROOT/TTaskGroup.hxx"
+#include <atomic>
 #include <queue>
+#include <memory>
+#include <vector>
 
-class TTree;
-class TBranch;
-class TThread;
-class TCondition;
 class TBasket;
+class TBranch;
 class TMutex;
+class TTree;
 
 class TTreeCacheUnzip : public TTreeCache {
+
 public:
    // We have three possibilities for the unzipping mode:
    // enable, disable and force
    enum EParUnzipMode { kEnable, kDisable, kForce };
 
+   // Unzipping states for a basket:
+   enum EUnzipState { kUntouched, kProgress, kFinished };
+
 protected:
+   // Unzipping state for baskets
+   struct UnzipState {
+      // Note: we cannot use std::unique_ptr<std::unique_ptr<char[]>[]> or vector of unique_ptr
+      // for fUnzipChunks since std::unique_ptr is not copy constructable.
+      // However, in future upgrade we cannot use make_vector in C++14.
+      std::unique_ptr<char[]> *fUnzipChunks;     ///<! [fNseek] Individual unzipped chunks. Their summed size is kept under control.
+      std::vector<Int_t>       fUnzipLen;        ///<! [fNseek] Length of the unzipped buffers
+      std::atomic<Byte_t>     *fUnzipStatus;     ///<! [fNSeek] 
+
+      UnzipState() {
+         fUnzipChunks = nullptr;
+         fUnzipStatus = nullptr;
+      }
+      ~UnzipState() {
+         if (fUnzipChunks) delete [] fUnzipChunks;
+         if (fUnzipStatus) delete [] fUnzipStatus;
+      }
+      void   Clear(Int_t size);
+      Bool_t IsUntouched(Int_t index) const;
+      Bool_t IsProgress(Int_t index) const;
+      Bool_t IsFinished(Int_t index) const;
+      Bool_t IsUnzipped(Int_t index) const;
+      void   Reset(Int_t oldSize, Int_t newSize);
+      void   SetUntouched(Int_t index);
+      void   SetProgress(Int_t index);
+      void   SetFinished(Int_t index);
+      void   SetMissed(Int_t index);
+      void   SetUnzipped(Int_t index, char* buf, Int_t len);
+      Bool_t TryUnzipping(Int_t index);
+   };
+
+   typedef struct UnzipState UnzipState_t;
+   UnzipState_t fUnzipState;
 
    // Members for paral. managing
-   TThread    *fUnzipThread[10];
-   Bool_t      fActiveThread;          ///< Used to terminate gracefully the unzippers
-   TCondition *fUnzipStartCondition;   ///< Used to signal the threads to start.
-   TCondition *fUnzipDoneCondition;    ///< Used to wait for an unzip tour to finish. Gives the Async feel.
-   Bool_t      fParallel;              ///< Indicate if we want to activate the parallelism (for this instance)
    Bool_t      fAsyncReading;
-   TMutex     *fMutexList;             ///< Mutex to protect the various lists. Used by the condvars.
+   Bool_t      fEmpty;
+   Int_t       fCycle;
+   Bool_t      fParallel; ///< Indicate if we want to activate the parallelism (for this instance)
+
    TMutex     *fIOMutex;
 
-   Int_t       fCycle;
    static TTreeCacheUnzip::EParUnzipMode fgParallel;  ///< Indicate if we want to activate the parallelism
 
-   Int_t       fLastReadPos;
-   Int_t       fBlocksToGo;
+   // IMT TTaskGroup Manager
+#ifdef R__USE_IMT
+   std::unique_ptr<ROOT::Experimental::TTaskGroup> fUnzipTaskGroup;
+#endif
 
    // Unzipping related members
-   Int_t      *fUnzipLen;         ///<! [fNseek] Length of the unzipped buffers
-   char      **fUnzipChunks;      ///<! [fNseek] Individual unzipped chunks. Their summed size is kept under control.
-   Byte_t     *fUnzipStatus;      ///<! [fNSeek] For each blk, tells us if it's unzipped or pending
-   Long64_t    fTotalUnzipBytes;  ///<! The total sum of the currently unzipped blks
-
    Int_t       fNseekMax;         ///<!  fNseek can change so we need to know its max size
+   Int_t       fUnzipGroupSize;   ///<!  Min accumulated size of a group of baskets ready to be unzipped by a IMT task
    Long64_t    fUnzipBufferSize;  ///<!  Max Size for the ready unzipped blocks (default is 2*fBufferSize)
 
    static Double_t fgRelBuffSize; ///< This is the percentage of the TTreeCacheUnzip that will be used
 
    // Members use to keep statistics
-   Int_t       fNUnzip;           ///<! number of blocks that were unzipped
    Int_t       fNFound;           ///<! number of blocks that were found in the cache
-   Int_t       fNStalls;          ///<! number of hits which caused a stall
    Int_t       fNMissed;          ///<! number of blocks that were not found in the cache and were unzipped
-
-   std::queue<Int_t>       fActiveBlks; ///< The blocks which are active now
+   Int_t       fNStalls;          ///<! number of hits which caused a stall
+   Int_t       fNUnzip;           ///<! number of blocks that were unzipped
 
 private:
    TTreeCacheUnzip(const TTreeCacheUnzip &);            //this class cannot be copied
@@ -88,13 +120,12 @@ private:
 
    // Private methods
    void  Init();
-   Int_t StartThreadUnzip(Int_t nthreads);
-   Int_t StopThreadUnzip();
 
 public:
    TTreeCacheUnzip();
    TTreeCacheUnzip(TTree *tree, Int_t buffersize=0);
    virtual ~TTreeCacheUnzip();
+
    virtual Int_t       AddBranch(TBranch *b, Bool_t subbranches = kFALSE);
    virtual Int_t       AddBranch(const char *branch, Bool_t subbranches = kFALSE);
    Bool_t              FillBuffer();
@@ -108,31 +139,29 @@ public:
    static Bool_t        IsParallelUnzip();
    static Int_t         SetParallelUnzip(TTreeCacheUnzip::EParUnzipMode option = TTreeCacheUnzip::kEnable);
 
-   Bool_t               IsActiveThread();
-   Bool_t               IsQueueEmpty();
-
-   void                 WaitUnzipStartSignal();
-   void                 SendUnzipStartSignal(Bool_t broadcast);
-
    // Unzipping related methods
+#ifdef R__USE_IMT
+   Int_t          CreateTasks();
+#endif
    Int_t          GetRecordHeader(char *buf, Int_t maxbytes, Int_t &nbytes, Int_t &objlen, Int_t &keylen);
-   virtual void   ResetCache();
    virtual Int_t  GetUnzipBuffer(char **buf, Long64_t pos, Int_t len, Bool_t *free);
+   Int_t          GetUnzipGroupSize() { return fUnzipGroupSize; }
+   virtual void   ResetCache();
    virtual Int_t  SetBufferSize(Int_t buffersize);
    void           SetUnzipBufferSize(Long64_t bufferSize);
+   void           SetUnzipGroupSize(Int_t groupSize) { fUnzipGroupSize = groupSize; }
    static void    SetUnzipRelBufferSize(Float_t relbufferSize);
    Int_t          UnzipBuffer(char **dest, char *src);
-   Int_t          UnzipCache(Int_t &startindex, Int_t &locbuffsz, char *&locbuff);
+   Int_t          UnzipCache(Int_t index);
 
    // Methods to get stats
    Int_t  GetNUnzip() { return fNUnzip; }
-   Int_t  GetNFound() { return fNFound; }
    Int_t  GetNMissed(){ return fNMissed; }
+   Int_t  GetNFound() { return fNFound; }
 
    void Print(Option_t* option = "") const;
 
    // static members
-   static void* UnzipLoop(void *arg);
    ClassDef(TTreeCacheUnzip,0)  //Specialization of TTreeCache for parallel unzipping
 };
 

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -8383,9 +8383,11 @@ Int_t TTree::SetCacheSizeAux(Bool_t autocache /* = kTRUE */, Long64_t cacheSize 
       return 0;
    }
 
+#ifdef R__USE_IMT
    if(TTreeCacheUnzip::IsParallelUnzip() && file->GetCompressionLevel() > 0)
       pf = new TTreeCacheUnzip(this, cacheSize);
    else
+#endif
       pf = new TTreeCache(this, cacheSize);
 
    pf->SetAutoCreated(autocache);

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -5433,7 +5433,7 @@ Int_t TTree::GetEntry(Long64_t entry, Int_t getall)
 #ifdef R__USE_IMT
    // At most one parallel read with a single branch
    unsigned int nSortedBranches(2);
-   if (nSortedBranches > 1 && ROOT::IsImplicitMTEnabled() && fIMTEnabled) {
+   if (nSortedBranches > 1 && ROOT::IsImplicitMTEnabled() && fIMTEnabled && !TTreeCacheUnzip::IsParallelUnzip()) {
       if (fSortedBranches.empty()) {
         InitializeBranchLists(true);
         nSortedBranches = fSortedBranches.size();

--- a/tree/tree/src/TTreeCacheUnzip.cxx
+++ b/tree/tree/src/TTreeCacheUnzip.cxx
@@ -958,7 +958,7 @@ Int_t TTreeCacheUnzip::UnzipBuffer(char **dest, char *src)
       /* early consistency check */
       UChar_t *bufcur = (UChar_t *) (src + keylen);
       Int_t nin, nbuf;
-      if(R__unzip_header(&nin, bufcur, &nbuf)!=0) {
+      if(objlen > nbytes-keylen && R__unzip_header(&nin, bufcur, &nbuf)!=0) {
          Error("UnzipBuffer", "Inconsistency found in header (nin=%d, nbuf=%d)", nin, nbuf);
          uzlen = -1;
          return uzlen;
@@ -1000,7 +1000,7 @@ Int_t TTreeCacheUnzip::UnzipBuffer(char **dest, char *src)
                Info("UnzipBuffer", "oldcase objlen :%d ", objlen);
 
             //buffer was very likely not compressed in an old version
-            memcpy( *dest + keylen, src + keylen, objlen);
+            memcpy(*dest + keylen, src + keylen, objlen);
             uzlen += objlen;
             return uzlen;
          }

--- a/tree/tree/src/TTreeCacheUnzip.cxx
+++ b/tree/tree/src/TTreeCacheUnzip.cxx
@@ -807,6 +807,7 @@ Int_t TTreeCacheUnzip::GetUnzipBuffer(char **buf, Long64_t pos, Int_t len, Bool_
       // Cache is invalidated and we need to wait for all unzipping tasks to befinished before fill new baskets in cache.
 #ifdef R__USE_IMT
       if(fUnzipTaskGroup) {
+         fUnzipTaskGroup->Cancel();
          fUnzipTaskGroup.reset();
       }
 #endif

--- a/tree/tree/src/TTreeCacheUnzip.cxx
+++ b/tree/tree/src/TTreeCacheUnzip.cxx
@@ -646,6 +646,7 @@ Int_t TTreeCacheUnzip::CreateTasks()
       Int_t accusz = 0;
       std::vector<std::vector<Int_t>> basketIndices;
       std::vector<Int_t> indices;
+      if (fUnzipGroupSize <= 0) fUnzipGroupSize = 102400;
       for (Int_t i = 0; i < fNseek; i++) {
          while (accusz < fUnzipGroupSize) {
             accusz += fSeekLen[i];


### PR DESCRIPTION
@bbockelm @pcanal @dpiparo 

Here is the new imt unzipping basket with TTaskGroup interface.

Comparing to #785 , I noticed there are still 3%(in Real Time) ~ 5%(in CPU Time) performance drops in new implementation. The degradation is caused by tbb function:

tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::receive_or_steal_task(long&)

I suspect the reason is because #785 in the following function:

https://github.com/zzxuanyuan/root/blob/15cceff19b48dfe4a4b0c69c1ec07ea75bd1ccb5/tree/tree/src/TTreeCacheUnzip.cxx#L708

CreateTasks() explicitly creates 2 tasks (empty_task and MappingTask; and set_ref_count(2) means 2 tasks in total). The scheduler might make a better decision here since it knows there will be only one task except empty_task running in future.

On the other hand, TTaskGroup uses tbb::task_group which calls the following function:

https://github.com/01org/tbb/blob/b9805bacadd4d0474fd3358cf0c7153042ce50c3/include/tbb/task_group.h#L108

task_group_base() also first creates a empty_task. However, it only creates 1 task(itself) by setting reference count as 1 (set_ref_count(1)). When it invoke another task by calling 

https://github.com/01org/tbb/blob/b9805bacadd4d0474fd3358cf0c7153042ce50c3/include/tbb/task_group.h#L103

allocate_additional_child() will create a new task as child and increment reference count by 1. I guess accumulating tasks on-the-fly might degrade the performance since the tbb scheduler could spend more time on finding tasks to work on.

In a short, I think explicitly defining the total number of tasks and task graph should have better performance (more efficient for scheduler I guess) than adding more tasks to task_group as the program runs.

There are two alternative approaches that might improve the performance. 
1. Since we have already know we will only have one task (except empty_task) to add into the task_group, we could revise TTaskGroup interface and notify it what task is going to run in advance.
2. We could get rid of TTaskGroup in my current implemention and synchronously map baskets to different tasks.

If we do not mind a little performance drops, the current implementation should be fine.

Thanks,

Zhe  

