### PR TITLE
[cxxmodules] Revert broken VFS CMake patch / add -vfsoverlay to rootcling/TCling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,7 +216,7 @@ if (NOT libcxx)
   file(WRITE ${CMAKE_BINARY_DIR}/include/modulemap.overlay.yaml "{'version' : 0, 'roots' : []}")
   set(__vfs_overlay "-ivfsoverlay ${CMAKE_BINARY_DIR}/include/modulemap.overlay.yaml")
 
-  if (cxxmodules OR runtime_modules)
+  if (cxxmodules)
     set(ROOT_CXXMODULES_COMMONFLAGS "${ROOT_CXXMODULES_COMMONFLAGS} ${__vfs_overlay}")
   endif()
 

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -4266,6 +4266,7 @@ int RootClingMain(int argc,
    std::string outputFile;
    // Data is in 'outputFile', therefore in the same scope.
    StringRef moduleName;
+   std::string vfsArg;
    // Adding -fmodules to the args will break lexing with __CINT__ defined,
    // and we actually do lex with __CINT__ and reuse this variable later,
    // we have to copy it now.
@@ -4284,6 +4285,10 @@ int RootClingMain(int argc,
 
       clingArgsInterpreter.push_back("-fmodule-name");
       clingArgsInterpreter.push_back(moduleName.str());
+
+      std::string vfsPath = std::string(gDriverConfig->fTROOT__GetIncludeDir()) + "/modulemap.overlay.yaml";
+      vfsArg = "-ivfsoverlay" + vfsPath;
+      clingArgsInterpreter.push_back(vfsArg.c_str());
 
       // Set the C++ modules output directory to the directory where we generate
       // the shared library.

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1149,9 +1149,14 @@ TCling::TCling(const char *name, const char *title)
    // Activate C++ modules support. If we are running within rootcling, it's up
    // to rootcling to set this flag depending on whether it wants to produce
    // C++ modules.
+   std::string vfsArg;
    if (!fromRootCling) {
       // We only set this flag, rest is done by the CIFactory.
       interpArgs.push_back("-fmodules");
+
+      std::string vfsPath = std::string(TROOT::GetIncludeDir()) + "/modulemap.overlay.yaml";
+      vfsArg = "-ivfsoverlay" + vfsPath;
+      interpArgs.push_back(vfsArg.c_str());
    }
 #endif
 


### PR DESCRIPTION
See the specific comments for the changes.