### PR TITLE
[cxxmodules][llvm] Backport r303373

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/Sema/SemaDecl.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Sema/SemaDecl.cpp
@@ -16045,8 +16045,10 @@ void Sema::ActOnModuleBegin(SourceLocation DirectiveLoc, Module *Mod) {
   // FIXME: Consider creating a child DeclContext to hold the entities
   // lexically within the module.
   if (getLangOpts().trackLocalOwningModule()) {
-    cast<Decl>(CurContext)->setHidden(true);
-    cast<Decl>(CurContext)->setLocalOwningModule(Mod);
+    for (auto *DC = CurContext; DC; DC = DC->getLexicalParent()) {
+      cast<Decl>(DC)->setHidden(true);
+      cast<Decl>(DC)->setLocalOwningModule(Mod);
+    }
   }
 }
 
@@ -16079,9 +16081,13 @@ void Sema::ActOnModuleEnd(SourceLocation EomLoc, Module *Mod) {
 
   // Any further declarations are in whatever module we returned to.
   if (getLangOpts().trackLocalOwningModule()) {
-    cast<Decl>(CurContext)->setLocalOwningModule(getCurrentModule());
-    if (!getCurrentModule())
-      cast<Decl>(CurContext)->setHidden(false);
+    // The parser guarantees that this is the same context that we entered
+    // the module within.
+    for (auto *DC = CurContext; DC; DC = DC->getLexicalParent()) {
+      cast<Decl>(DC)->setLocalOwningModule(getCurrentModule());
+      if (!getCurrentModule())
+        cast<Decl>(DC)->setHidden(false);
+    }
   }
 }
 


### PR DESCRIPTION
When running rootcling to produce C++ modules we currently run
into this issue that is an issue in this specific LLVM revision
we are using in ROOT. The issue was fixed by Richard upstream
in r303373.

The error we fix with this patch is:
```
While building module 'Core':
While building module 'stl' imported from input_line_1:1:
In file included from <module-includes>:5:
In file included from /cvmfs/sft.cern.ch/lcg/contrib/gcc/6.2.0native/x86_64-slc6/bin/../lib/gcc/x86_64-pc-linux-gnu/6.2.0/../../../../include/c++/6.2.0/ccomplex:39:
In file included from /cvmfs/sft.cern.ch/lcg/contrib/gcc/6.2.0native/x86_64-slc6/bin/../lib/gcc/x86_64-pc-linux-gnu/6.2.0/../../../../include/c++/6.2.0/complex:42:
/cvmfs/sft.cern.ch/lcg/contrib/gcc/6.2.0native/x86_64-slc6/bin/../lib/gcc/x86_64-pc-linux-gnu/6.2.0/../../../../include/c++/6.2.0/bits/cpp_type_traits.h:102:23: error: use of undeclared identifier '_Tp'
    struct __are_same<_Tp, _Tp>
                      ^
/cvmfs/sft.cern.ch/lcg/contrib/gcc/6.2.0native/x86_64-slc6/bin/../lib/gcc/x86_64-pc-linux-gnu/6.2.0/../../../../include/c++/6.2.0/bits/cpp_type_traits.h:318:25: error: use of undeclared identifier '_Tp'
    struct __is_pointer<_Tp*>
                        ^
/cvmfs/sft.cern.ch/lcg/contrib/gcc/6.2.0native/x86_64-slc6/bin/../lib/gcc/x86_64-pc-linux-gnu/6.2.0/../../../../include/c++/6.2.0/bits/cpp_type_traits.h:318:29: error: expected expression
    struct __is_pointer<_Tp*>
                            ^
/cvmfs/sft.cern.ch/lcg/contrib/gcc/6.2.0native/x86_64-slc6/bin/../lib/gcc/x86_64-pc-linux-gnu/6.2.0/../../../../include/c++/6.2.0/bits/cpp_type_traits.h:329:37: error: declaration of '_Tp' must be imported from module 'stl.ccomplex' before it is required
    : public __traitor<__is_integer<_Tp>, __is_floating<_Tp> >
                                    ^
/cvmfs/sft.cern.ch/lcg/contrib/gcc/6.2.0native/x86_64-slc6/bin/../lib/gcc/x86_64-pc-linux-gnu/6.2.0/../../../../include/c++/6.2.0/bits/cpp_type_traits.h:327:21: note: previous declaration is here
  template<typename _Tp>
                    ^
```

Original patch description:

    When we enter a module within a linkage specification, switch the linkage
    specification and the TU to the new module.

    This is necessary to get the module ownership correct for entities that we
    temporarily hang off the TranslationUnitDecl, such as template parameters and
    function parameters.

    git-svn-id: https://llvm.org/svn/llvm-project/cfe/trunk@303373 91177308-0d34-0410-b5e6-96231b3b80d8