### PR TITLE
[cxxmodules] Remove unnecessary assert

### DIFF
--- a/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
@@ -651,10 +651,6 @@ namespace cling {
     const CompilationOptions& CO
        = m_Consumer->getTransaction()->getCompilationOpts();
 
-    assert(!(S.getLangOpts().Modules
-             && CO.CodeGenerationForModule)
-           && "CodeGenerationForModule to be removed once PCMs are available!");
-
     // Recover resources if we crash before exiting this method.
     llvm::CrashRecoveryContextCleanupRegistrar<Sema> CleanupSema(&S);
 


### PR DESCRIPTION
After some discussion with Axel we decided that there is no point to
assert here. This feature here is not related to C++ modules.