### PR TITLE
[cxxmodules] Add signal.h to modulemap

### DIFF
--- a/build/unix/libc.modulemap
+++ b/build/unix/libc.modulemap
@@ -33,6 +33,10 @@ module "libc" [system] {
     export *
     header "math.h"
   }
+  module "signal.h" {
+    export *
+    header "signal.h"
+  }
   module "stdio.h" {
     export *
     header "stdio.h"


### PR DESCRIPTION
We currently fail to create a module for RootFit with the following error
message when merging a union in signal.h:
```
In file included from input_line_12:67:
In file included from /build/jenkins/workspace/root-nightly-runtime-cxxmodules/BUILDTYPE/Debug/COMPILER/gcc62/LABEL/slc6/build/include/RooErrorHandler.h:20:
In file included from /usr/include/signal.h:394:
/usr/include/bits/pthreadtypes.h:130:3: error: typedef redefinition with different types ('union pthread_cond_t' vs 'union pthread_cond_t')
} pthread_cond_t;
  ^
/usr/include/sys/types.h:271:11: note: '/usr/include/bits/pthreadtypes.h' included multiple times, additional include site in header from module 'Hist.Foption.h'
          ^
/build/jenkins/workspace/root-nightly-runtime-cxxmodules/BUILDTYPE/Debug/COMPILER/gcc62/LABEL/slc6/build/include/module.modulemap:820:10: note: Hist.Foption.h defined here
  module "Foption.h" { header "Foption.h" export * }
         ^
/usr/include/signal.h:394:11: note: '/usr/include/bits/pthreadtypes.h' included multiple times, additional include site in header from module 'RooFitCore.RooErrorHandler.h'
          ^
/build/jenkins/workspace/root-nightly-runtime-cxxmodules/BUILDTYPE/Debug/COMPILER/gcc62/LABEL/slc6/build/include/module.modulemap:2449:10: note: RooFitCore.RooErrorHandler.h defined here
  module "RooErrorHandler.h" { header "RooErrorHandler.h" export * }
         ^
Error: /build/jenkins/workspace/root-nightly-runtime-cxxmodules/BUILDTYPE/Debug/COMPILER/gcc62/LABEL/slc6/build/bin/rootcling: compilation failure (/build/jenkins/workspace/root-nightly-runtime-cxxmodules/BUILDTYPE/Debug/COMPILER/gcc62/LABEL/slc6/build/lib/libRooFitCorecbd7d3c40e_dictUmbrella.h)
make[2]: *** [roofit/roofitcore/G__RooFitCore.cxx] Error 1
```

This patch adds the header to the modulemap which prevents us from
trying to merge this struct.