### PR TITLE
[cxxmodules] Split out xlocale.h into its own module

### DIFF
--- a/build/unix/libc.modulemap
+++ b/build/unix/libc.modulemap
@@ -21,10 +21,6 @@ module "libc" [system] {
     header "inttypes.h"
   }
 
-  module "xlocale.h" {
-    export *
-    header "xlocale.h"
-  }
   module "setjmp.h" {
     export *
     header "setjmp.h"
@@ -37,4 +33,11 @@ module "libc" [system] {
     export *
     header "stdio.h"
   }
+}
+
+// glib specific header. In it's own module because it
+// doesn't exist on some systems with unpatched glib 2.26+
+module "xlocale.h" [system] {
+  export *
+  header "xlocale.h"
 }


### PR DESCRIPTION
This fixes the compilation on systems that no longer have xlocale.h
which is no longer part of glibc since 2.26 it seems.