### PR TITLE
[TDF] Fix initialization of `Max` values

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -877,7 +877,7 @@ public:
    TResultProxy<double> Max(std::string_view branchName = "")
    {
       auto bl = GetBranchNames<T>({branchName}, "calculate the maximum");
-      auto maxV = std::make_shared<double>(std::numeric_limits<double>::min());
+      auto maxV = std::make_shared<double>(std::numeric_limits<double>::lowest());
       return CreateAction<TDFInternal::ActionTypes::Max, T>(bl, maxV);
    }
 

--- a/tree/treeplayer/src/TDFActionHelpers.cxx
+++ b/tree/treeplayer/src/TDFActionHelpers.cxx
@@ -42,7 +42,7 @@ void FillHelper::UpdateMinMax(unsigned int slot, double v)
 
 FillHelper::FillHelper(const std::shared_ptr<Hist_t> &h, unsigned int nSlots)
    : fResultHist(h), fNSlots(nSlots), fBufSize(fgTotalBufSize / nSlots),
-     fMin(nSlots, std::numeric_limits<BufEl_t>::max()), fMax(nSlots, std::numeric_limits<BufEl_t>::min())
+     fMin(nSlots, std::numeric_limits<BufEl_t>::max()), fMax(nSlots, std::numeric_limits<BufEl_t>::lowest())
 {
    fBuffers.reserve(fNSlots);
    fWBuffers.reserve(fNSlots);
@@ -79,7 +79,7 @@ void FillHelper::Finalize()
    BufEl_t globalMax = *std::max_element(fMax.begin(), fMax.end());
 
    if (fResultHist->CanExtendAllAxes() && globalMin != std::numeric_limits<BufEl_t>::max() &&
-       globalMax != std::numeric_limits<BufEl_t>::min()) {
+       globalMax != std::numeric_limits<BufEl_t>::lowest()) {
       fResultHist->SetBins(fResultHist->GetNbinsX(), globalMin, globalMax);
    }
 
@@ -126,7 +126,7 @@ template void MinHelper::Exec(unsigned int, const std::vector<int> &);
 template void MinHelper::Exec(unsigned int, const std::vector<unsigned int> &);
 
 MaxHelper::MaxHelper(const std::shared_ptr<double> &maxVPtr, unsigned int nSlots)
-   : fResultMax(maxVPtr), fMaxs(nSlots, std::numeric_limits<double>::min())
+   : fResultMax(maxVPtr), fMaxs(nSlots, std::numeric_limits<double>::lowest())
 {
 }
 
@@ -137,7 +137,7 @@ void MaxHelper::Exec(unsigned int slot, double v)
 
 void MaxHelper::Finalize()
 {
-   *fResultMax = std::numeric_limits<double>::min();
+   *fResultMax = std::numeric_limits<double>::lowest();
    for (auto &m : fMaxs) {
       *fResultMax = std::max(m, *fResultMax);
    }


### PR DESCRIPTION
`std::numeric_limits<double>::min()` returns the smallest absolute value for floating points, what we want is `std::numeric_limits<double>::lowest()`.