### PR TITLE
Define histograms of TDF via histomodels and not move semantics

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFHistoModels.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFHistoModels.hxx
@@ -30,7 +30,7 @@ struct TH1DModel {
    double fXUp;
 
    TH1DModel() = delete;
-   TH1DModel(const TH1DModel &) = delete;
+   TH1DModel(const TH1DModel &) = default;
    TH1DModel(const ::TH1D &h);
    TH1DModel(const char *name, const char *title, int nbinsx, double xlow, double xup);
 };
@@ -46,7 +46,7 @@ struct TH2DModel {
    double fYUp;
 
    TH2DModel() = delete;
-   TH2DModel(const TH2DModel &) = delete;
+   TH2DModel(const TH2DModel &) = default;
    TH2DModel(const ::TH2D &h);
    TH2DModel(const char *name, const char *title, int nbinsx, double xlow, double xup, int nbinsy, double ylow,
              double yup);
@@ -66,7 +66,7 @@ struct TH3DModel {
    double fZUp;
 
    TH3DModel() = delete;
-   TH3DModel(const TH3DModel &) = delete;
+   TH3DModel(const TH3DModel &) = default;
    TH3DModel(const ::TH3D &h);
    TH3DModel(const char *name, const char *title, int nbinsx, double xlow, double xup, int nbinsy, double ylow,
              double yup, int nbinsz, double zlow, double zup);

--- a/tree/treeplayer/inc/ROOT/TDFHistoModels.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFHistoModels.hxx
@@ -1,0 +1,94 @@
+// Author: Enrico Guiraud, Danilo Piparo CERN  09/2017
+
+/*************************************************************************
+ * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TDFHISTOMODELS
+#define ROOT_TDFHISTOMODELS
+
+#include <TH1D.h>
+#include <TH2D.h>
+#include <TH3D.h>
+#include <memory>
+
+namespace ROOT {
+namespace Experimental {
+namespace TDF {
+
+class TH1DModel {
+public:
+   TString fName;
+   TString fTitle;
+   int fNbinsX;
+   double fXLow;
+   double fXUp;
+
+   TH1DModel() = delete;
+   TH1DModel(const TH1DModel &) = delete;
+   TH1DModel(const ::TH1D &h) : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX()), fXLow(h.GetXaxis()->GetXmin()), fXUp(h.GetXaxis()->GetXmax())
+   {
+   }
+   TH1DModel(const char *name, const char *title, int nbinsx, double xlow, double xup)
+   : fName(name), fTitle(title), fNbinsX(nbinsx), fXLow(xlow), fXUp(xup)
+   {
+   }
+};
+
+class TH2DModel {
+public:
+   TString fName;
+   TString fTitle;
+   int fNbinsX;
+   double fXLow;
+   double fXUp;
+   int fNbinsY;
+   double fYLow;
+   double fYUp;
+
+   TH2DModel() = delete;
+   TH2DModel(const TH2DModel &) = delete;
+   TH2DModel(const ::TH2D &h) : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX()), fXLow(h.GetXaxis()->GetXmin()), fXUp(h.GetXaxis()->GetXmax()), fNbinsY(h.GetNbinsY()), fYLow(h.GetYaxis()->GetXmin()), fYUp(h.GetYaxis()->GetXmax())
+   {
+   }
+   TH2DModel(const char *name, const char *title, int nbinsx, double xlow, double xup, int nbinsy, double ylow, double yup)
+   : fName(name), fTitle(title), fNbinsX(nbinsx), fXLow(xlow), fXUp(xup), fNbinsY(nbinsy), fYLow(ylow), fYUp(yup)
+   {
+   }
+};
+
+class TH3DModel {
+public:
+   TString fName;
+   TString fTitle;
+   int fNbinsX;
+   double fXLow;
+   double fXUp;
+   int fNbinsY;
+   double fYLow;
+   double fYUp;
+   int fNbinsZ;
+   double fZLow;
+   double fZUp;
+
+   TH3DModel() = delete;
+   TH3DModel(const TH3DModel &) = delete;
+   TH3DModel(const ::TH3D &h) : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX()), fXLow(h.GetXaxis()->GetXmin()), fXUp(h.GetXaxis()->GetXmax()), fNbinsY(h.GetNbinsY()), fYLow(h.GetYaxis()->GetXmin()), fYUp(h.GetYaxis()->GetXmax()), fNbinsZ(h.GetNbinsZ()), fZLow(h.GetZaxis()->GetXmin()), fZUp(h.GetZaxis()->GetXmax())
+   {
+   }
+   TH3DModel(const char *name, const char *title, int nbinsx, double xlow, double xup, int nbinsy, double ylow, double yup, int nbinsz, double zlow, double zup)
+   : fName(name), fTitle(title), fNbinsX(nbinsx), fXLow(xlow), fXUp(xup), fNbinsY(nbinsy), fYLow(ylow), fYUp(yup), fNbinsZ(nbinsz), fZLow(zlow), fZUp(zup)
+   {
+   }
+};
+
+
+} // ns TDF
+} // ns Experimental
+} // ns ROOT
+
+#endif // ROOT_TDFHISTOMODELS

--- a/tree/treeplayer/inc/ROOT/TDFHistoModels.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFHistoModels.hxx
@@ -11,17 +11,18 @@
 #ifndef ROOT_TDFHISTOMODELS
 #define ROOT_TDFHISTOMODELS
 
-#include <TH1D.h>
-#include <TH2D.h>
-#include <TH3D.h>
+#include <TString.h>
 #include <memory>
+
+class TH1D;
+class TH2D;
+class TH3D;
 
 namespace ROOT {
 namespace Experimental {
 namespace TDF {
 
-class TH1DModel {
-public:
+struct TH1DModel {
    TString fName;
    TString fTitle;
    int fNbinsX;
@@ -30,19 +31,11 @@ public:
 
    TH1DModel() = delete;
    TH1DModel(const TH1DModel &) = delete;
-   TH1DModel(const ::TH1D &h)
-      : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX()), fXLow(h.GetXaxis()->GetXmin()),
-        fXUp(h.GetXaxis()->GetXmax())
-   {
-   }
-   TH1DModel(const char *name, const char *title, int nbinsx, double xlow, double xup)
-      : fName(name), fTitle(title), fNbinsX(nbinsx), fXLow(xlow), fXUp(xup)
-   {
-   }
+   TH1DModel(const ::TH1D &h);
+   TH1DModel(const char *name, const char *title, int nbinsx, double xlow, double xup);
 };
 
-class TH2DModel {
-public:
+struct TH2DModel {
    TString fName;
    TString fTitle;
    int fNbinsX;
@@ -54,21 +47,12 @@ public:
 
    TH2DModel() = delete;
    TH2DModel(const TH2DModel &) = delete;
-   TH2DModel(const ::TH2D &h)
-      : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX()), fXLow(h.GetXaxis()->GetXmin()),
-        fXUp(h.GetXaxis()->GetXmax()), fNbinsY(h.GetNbinsY()), fYLow(h.GetYaxis()->GetXmin()),
-        fYUp(h.GetYaxis()->GetXmax())
-   {
-   }
+   TH2DModel(const ::TH2D &h);
    TH2DModel(const char *name, const char *title, int nbinsx, double xlow, double xup, int nbinsy, double ylow,
-             double yup)
-      : fName(name), fTitle(title), fNbinsX(nbinsx), fXLow(xlow), fXUp(xup), fNbinsY(nbinsy), fYLow(ylow), fYUp(yup)
-   {
-   }
+             double yup);
 };
 
-class TH3DModel {
-public:
+struct TH3DModel {
    TString fName;
    TString fTitle;
    int fNbinsX;
@@ -83,19 +67,9 @@ public:
 
    TH3DModel() = delete;
    TH3DModel(const TH3DModel &) = delete;
-   TH3DModel(const ::TH3D &h)
-      : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX()), fXLow(h.GetXaxis()->GetXmin()),
-        fXUp(h.GetXaxis()->GetXmax()), fNbinsY(h.GetNbinsY()), fYLow(h.GetYaxis()->GetXmin()),
-        fYUp(h.GetYaxis()->GetXmax()), fNbinsZ(h.GetNbinsZ()), fZLow(h.GetZaxis()->GetXmin()),
-        fZUp(h.GetZaxis()->GetXmax())
-   {
-   }
+   TH3DModel(const ::TH3D &h);
    TH3DModel(const char *name, const char *title, int nbinsx, double xlow, double xup, int nbinsy, double ylow,
-             double yup, int nbinsz, double zlow, double zup)
-      : fName(name), fTitle(title), fNbinsX(nbinsx), fXLow(xlow), fXUp(xup), fNbinsY(nbinsy), fYLow(ylow), fYUp(yup),
-        fNbinsZ(nbinsz), fZLow(zlow), fZUp(zup)
-   {
-   }
+             double yup, int nbinsz, double zlow, double zup);
 };
 
 } // ns TDF

--- a/tree/treeplayer/inc/ROOT/TDFHistoModels.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFHistoModels.hxx
@@ -30,11 +30,13 @@ public:
 
    TH1DModel() = delete;
    TH1DModel(const TH1DModel &) = delete;
-   TH1DModel(const ::TH1D &h) : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX()), fXLow(h.GetXaxis()->GetXmin()), fXUp(h.GetXaxis()->GetXmax())
+   TH1DModel(const ::TH1D &h)
+      : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX()), fXLow(h.GetXaxis()->GetXmin()),
+        fXUp(h.GetXaxis()->GetXmax())
    {
    }
    TH1DModel(const char *name, const char *title, int nbinsx, double xlow, double xup)
-   : fName(name), fTitle(title), fNbinsX(nbinsx), fXLow(xlow), fXUp(xup)
+      : fName(name), fTitle(title), fNbinsX(nbinsx), fXLow(xlow), fXUp(xup)
    {
    }
 };
@@ -52,11 +54,15 @@ public:
 
    TH2DModel() = delete;
    TH2DModel(const TH2DModel &) = delete;
-   TH2DModel(const ::TH2D &h) : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX()), fXLow(h.GetXaxis()->GetXmin()), fXUp(h.GetXaxis()->GetXmax()), fNbinsY(h.GetNbinsY()), fYLow(h.GetYaxis()->GetXmin()), fYUp(h.GetYaxis()->GetXmax())
+   TH2DModel(const ::TH2D &h)
+      : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX()), fXLow(h.GetXaxis()->GetXmin()),
+        fXUp(h.GetXaxis()->GetXmax()), fNbinsY(h.GetNbinsY()), fYLow(h.GetYaxis()->GetXmin()),
+        fYUp(h.GetYaxis()->GetXmax())
    {
    }
-   TH2DModel(const char *name, const char *title, int nbinsx, double xlow, double xup, int nbinsy, double ylow, double yup)
-   : fName(name), fTitle(title), fNbinsX(nbinsx), fXLow(xlow), fXUp(xup), fNbinsY(nbinsy), fYLow(ylow), fYUp(yup)
+   TH2DModel(const char *name, const char *title, int nbinsx, double xlow, double xup, int nbinsy, double ylow,
+             double yup)
+      : fName(name), fTitle(title), fNbinsX(nbinsx), fXLow(xlow), fXUp(xup), fNbinsY(nbinsy), fYLow(ylow), fYUp(yup)
    {
    }
 };
@@ -77,15 +83,20 @@ public:
 
    TH3DModel() = delete;
    TH3DModel(const TH3DModel &) = delete;
-   TH3DModel(const ::TH3D &h) : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX()), fXLow(h.GetXaxis()->GetXmin()), fXUp(h.GetXaxis()->GetXmax()), fNbinsY(h.GetNbinsY()), fYLow(h.GetYaxis()->GetXmin()), fYUp(h.GetYaxis()->GetXmax()), fNbinsZ(h.GetNbinsZ()), fZLow(h.GetZaxis()->GetXmin()), fZUp(h.GetZaxis()->GetXmax())
+   TH3DModel(const ::TH3D &h)
+      : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX()), fXLow(h.GetXaxis()->GetXmin()),
+        fXUp(h.GetXaxis()->GetXmax()), fNbinsY(h.GetNbinsY()), fYLow(h.GetYaxis()->GetXmin()),
+        fYUp(h.GetYaxis()->GetXmax()), fNbinsZ(h.GetNbinsZ()), fZLow(h.GetZaxis()->GetXmin()),
+        fZUp(h.GetZaxis()->GetXmax())
    {
    }
-   TH3DModel(const char *name, const char *title, int nbinsx, double xlow, double xup, int nbinsy, double ylow, double yup, int nbinsz, double zlow, double zup)
-   : fName(name), fTitle(title), fNbinsX(nbinsx), fXLow(xlow), fXUp(xup), fNbinsY(nbinsy), fYLow(ylow), fYUp(yup), fNbinsZ(nbinsz), fZLow(zlow), fZUp(zup)
+   TH3DModel(const char *name, const char *title, int nbinsx, double xlow, double xup, int nbinsy, double ylow,
+             double yup, int nbinsz, double zlow, double zup)
+      : fName(name), fTitle(title), fNbinsX(nbinsx), fXLow(xlow), fXUp(xup), fNbinsY(nbinsy), fYLow(ylow), fYUp(yup),
+        fNbinsZ(nbinsz), fZLow(zlow), fZUp(zup)
    {
    }
 };
-
 
 } // ns TDF
 } // ns Experimental

--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -228,11 +228,12 @@ class TInterface {
    template <typename T>
    friend class TInterface;
 
-   const std::shared_ptr<Proxied> fProxiedPtr; ///< Smart pointer to the graph node encapsulated by this TInterface.
+   const std::shared_ptr<Proxied> fProxiedPtr;     ///< Smart pointer to the graph node encapsulated by this TInterface.
    const std::weak_ptr<TLoopManager> fImplWeakPtr; ///< Weak pointer to the TLoopManager at the root of the graph.
    ColumnNames_t fValidCustomColumns; ///< Names of columns `Define`d for this branch of the functional graph.
    /// Non-owning pointer to a data-source object. Null if no data-source. TLoopManager has ownership of the object.
-   TDataSource * const fDataSource = nullptr;
+   TDataSource *const fDataSource = nullptr;
+
 public:
    /// \cond HIDDEN_SYMBOLS
    // Template conversion operator, meant to use to convert TInterfaces of certain node types to TInterfaces of base
@@ -437,8 +438,9 @@ public:
    ///
    /// This function returns a `TDataFrame` built with the output tree as a source.
    template <typename... BranchTypes>
-   TInterface<TLoopManager> Snapshot(std::string_view treename, std::string_view filename,
-                                     const ColumnNames_t &columnList, const TSnapshotOptions &options = TSnapshotOptions())
+   TInterface<TLoopManager>
+   Snapshot(std::string_view treename, std::string_view filename, const ColumnNames_t &columnList,
+            const TSnapshotOptions &options = TSnapshotOptions())
    {
       return SnapshotImpl<BranchTypes...>(treename, filename, columnList, options);
    }
@@ -453,7 +455,8 @@ public:
    /// This function returns a `TDataFrame` built with the output tree as a source.
    /// The types of the columns are automatically inferred and do not need to be specified.
    TInterface<TLoopManager> Snapshot(std::string_view treename, std::string_view filename,
-                                     const ColumnNames_t &columnList, const TSnapshotOptions &options = TSnapshotOptions())
+                                     const ColumnNames_t &columnList,
+                                     const TSnapshotOptions &options = TSnapshotOptions())
    {
       auto df = GetDataFrameChecked();
       auto tree = df->GetTree();
@@ -496,7 +499,8 @@ public:
    /// This function returns a `TDataFrame` built with the output tree as a source.
    /// The types of the columns are automatically inferred and do not need to be specified.
    TInterface<TLoopManager> Snapshot(std::string_view treename, std::string_view filename,
-                                     std::string_view columnNameRegexp = "", const TSnapshotOptions &options = TSnapshotOptions())
+                                     std::string_view columnNameRegexp = "",
+                                     const TSnapshotOptions &options = TSnapshotOptions())
    {
       const auto theRegexSize = columnNameRegexp.size();
       std::string theRegex(columnNameRegexp);
@@ -744,7 +748,7 @@ public:
    /// booked but not executed. See TResultProxy documentation.
    /// The user gives up ownership of the model histogram.
    template <typename V = TDFDetail::TInferType>
-   TResultProxy<::TH1D> Histo1D(const TH1DModel& model = {"", "", 128u, 0., 0.}, std::string_view vName = "")
+   TResultProxy<::TH1D> Histo1D(const TH1DModel &model = {"", "", 128u, 0., 0.}, std::string_view vName = "")
    {
       const auto userColumns = vName.empty() ? ColumnNames_t() : ColumnNames_t({std::string(vName)});
       std::shared_ptr<::TH1D> h(nullptr);
@@ -774,7 +778,7 @@ public:
    ///
    /// See the description of the first Histo1D overload for more details.
    template <typename V = TDFDetail::TInferType, typename W = TDFDetail::TInferType>
-   TResultProxy<::TH1D> Histo1D(const TH1DModel& model, std::string_view vName, std::string_view wName)
+   TResultProxy<::TH1D> Histo1D(const TH1DModel &model, std::string_view vName, std::string_view wName)
    {
       auto columnViews = {vName, wName};
       const auto userColumns = TDFInternal::AtLeastOneEmptyString(columnViews)
@@ -812,7 +816,7 @@ public:
    /// This overload will use the first two default columns as column names.
    /// See the description of the first Histo1D overload for more details.
    template <typename V, typename W>
-   TResultProxy<::TH1D> Histo1D(const TH1DModel& model = {"", "", 128u, 0., 0.})
+   TResultProxy<::TH1D> Histo1D(const TH1DModel &model = {"", "", 128u, 0., 0.})
    {
       return Histo1D<V, W>(model, "", "");
    }
@@ -833,12 +837,13 @@ public:
    /// booked but not executed. See TResultProxy documentation.
    /// The user gives up ownership of the model histogram.
    template <typename V1 = TDFDetail::TInferType, typename V2 = TDFDetail::TInferType>
-   TResultProxy<::TH2D> Histo2D(const TH2DModel& model, std::string_view v1Name = "", std::string_view v2Name = "")
+   TResultProxy<::TH2D> Histo2D(const TH2DModel &model, std::string_view v1Name = "", std::string_view v2Name = "")
    {
       std::shared_ptr<::TH2D> h(nullptr);
       {
          Internal::TDF::TIgnoreErrorLevelRAAI iel(kError);
-         h = std::make_shared<::TH2D>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp, model.fNbinsY, model.fYLow, model.fYUp);
+         h = std::make_shared<::TH2D>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp, model.fNbinsY,
+                                      model.fYLow, model.fYUp);
       }
       if (!TDFInternal::HistoUtils<::TH2D>::HasAxisLimits(*h)) {
          throw std::runtime_error("2D histograms with no axes limits are not supported yet.");
@@ -865,13 +870,14 @@ public:
    /// The user gives up ownership of the model histogram.
    template <typename V1 = TDFDetail::TInferType, typename V2 = TDFDetail::TInferType,
              typename W = TDFDetail::TInferType>
-   TResultProxy<::TH2D> Histo2D(const TH2DModel& model, std::string_view v1Name, std::string_view v2Name,
-                                std::string_view wName)
+   TResultProxy<::TH2D>
+   Histo2D(const TH2DModel &model, std::string_view v1Name, std::string_view v2Name, std::string_view wName)
    {
       std::shared_ptr<::TH2D> h(nullptr);
       {
          Internal::TDF::TIgnoreErrorLevelRAAI iel(kError);
-         h = std::make_shared<::TH2D>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp,  model.fNbinsY, model.fYLow, model.fYUp);
+         h = std::make_shared<::TH2D>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp, model.fNbinsY,
+                                      model.fYLow, model.fYUp);
       }
       if (!TDFInternal::HistoUtils<::TH2D>::HasAxisLimits(*h)) {
          throw std::runtime_error("2D histograms with no axes limits are not supported yet.");
@@ -884,7 +890,7 @@ public:
    }
 
    template <typename V1, typename V2, typename W>
-   TResultProxy<::TH2D> Histo2D(const TH2DModel& model)
+   TResultProxy<::TH2D> Histo2D(const TH2DModel &model)
    {
       return Histo2D<V1, V2, W>(model, "", "", "");
    }
@@ -904,13 +910,14 @@ public:
    /// The user gives up ownership of the model histogram.
    template <typename V1 = TDFDetail::TInferType, typename V2 = TDFDetail::TInferType,
              typename V3 = TDFDetail::TInferType>
-   TResultProxy<::TH3D> Histo3D(const TH3DModel& model, std::string_view v1Name = "", std::string_view v2Name = "",
+   TResultProxy<::TH3D> Histo3D(const TH3DModel &model, std::string_view v1Name = "", std::string_view v2Name = "",
                                 std::string_view v3Name = "")
    {
       std::shared_ptr<::TH3D> h(nullptr);
       {
          Internal::TDF::TIgnoreErrorLevelRAAI iel(kError);
-         h = std::make_shared<::TH3D>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp, model.fNbinsY, model.fYLow, model.fYUp, model.fNbinsZ, model.fZLow, model.fZUp);
+         h = std::make_shared<::TH3D>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp, model.fNbinsY,
+                                      model.fYLow, model.fYUp, model.fNbinsZ, model.fZLow, model.fZUp);
       }
       if (!TDFInternal::HistoUtils<::TH3D>::HasAxisLimits(*h)) {
          throw std::runtime_error("3D histograms with no axes limits are not supported yet.");
@@ -939,13 +946,14 @@ public:
    /// The user gives up ownership of the model histogram.
    template <typename V1 = TDFDetail::TInferType, typename V2 = TDFDetail::TInferType,
              typename V3 = TDFDetail::TInferType, typename W = TDFDetail::TInferType>
-   TResultProxy<::TH3D> Histo3D(const TH3DModel& model, std::string_view v1Name, std::string_view v2Name,
+   TResultProxy<::TH3D> Histo3D(const TH3DModel &model, std::string_view v1Name, std::string_view v2Name,
                                 std::string_view v3Name, std::string_view wName)
    {
       std::shared_ptr<::TH3D> h(nullptr);
       {
          Internal::TDF::TIgnoreErrorLevelRAAI iel(kError);
-         h = std::make_shared<::TH3D>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp, model.fNbinsY, model.fYLow, model.fYUp, model.fNbinsZ, model.fZLow, model.fZUp);
+         h = std::make_shared<::TH3D>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp, model.fNbinsY,
+                                      model.fYLow, model.fYUp, model.fNbinsZ, model.fZLow, model.fZUp);
       }
       if (!TDFInternal::HistoUtils<::TH3D>::HasAxisLimits(*h)) {
          throw std::runtime_error("3D histograms with no axes limits are not supported yet.");
@@ -958,7 +966,7 @@ public:
    }
 
    template <typename V1, typename V2, typename V3, typename W>
-   TResultProxy<::TH3D> Histo3D(const TH3DModel& model)
+   TResultProxy<::TH3D> Histo3D(const TH3DModel &model)
    {
       return Histo3D<V1, V2, V3, W>(model, "", "", "", "");
    }
@@ -1003,8 +1011,8 @@ public:
    /// The user gives up ownership of the model profile object.
    template <typename V1 = TDFDetail::TInferType, typename V2 = TDFDetail::TInferType,
              typename W = TDFDetail::TInferType>
-   TResultProxy<::TProfile> Profile1D(::TProfile &&model, std::string_view v1Name, std::string_view v2Name,
-                                      std::string_view wName)
+   TResultProxy<::TProfile>
+   Profile1D(::TProfile &&model, std::string_view v1Name, std::string_view v2Name, std::string_view wName)
    {
       auto h = std::make_shared<::TProfile>(std::move(model));
       if (!TDFInternal::HistoUtils<::TProfile>::HasAxisLimits(*h)) {
@@ -1258,8 +1266,8 @@ private:
    // this action is taken equal to nColumns, otherwise it is assumed to be sizeof...(BranchTypes)
    template <typename ActionType, typename... BranchTypes, typename ActionResultType,
              typename std::enable_if<TDFInternal::TNeedJitting<BranchTypes...>::value, int>::type = 0>
-   TResultProxy<ActionResultType> CreateAction(const ColumnNames_t &columns, const std::shared_ptr<ActionResultType> &r,
-                                               const int nColumns = -1)
+   TResultProxy<ActionResultType>
+   CreateAction(const ColumnNames_t &columns, const std::shared_ptr<ActionResultType> &r, const int nColumns = -1)
    {
       auto lm = GetDataFrameChecked();
       auto realNColumns = (nColumns > -1 ? nColumns : sizeof...(BranchTypes));
@@ -1310,13 +1318,15 @@ private:
          // single-thread snapshot
          using Helper_t = TDFInternal::SnapshotHelper<BranchTypes...>;
          using Action_t = TDFInternal::TAction<Helper_t, Proxied, TTraits::TypeList<BranchTypes...>>;
-         actionPtr.reset(new Action_t(Helper_t(filename, dirname, treename, columnList, options), columnList, *fProxiedPtr));
+         actionPtr.reset(
+            new Action_t(Helper_t(filename, dirname, treename, columnList, options), columnList, *fProxiedPtr));
       } else {
          // multi-thread snapshot
          using Helper_t = TDFInternal::SnapshotHelperMT<BranchTypes...>;
          using Action_t = TDFInternal::TAction<Helper_t, Proxied>;
-         actionPtr.reset(new Action_t(Helper_t(fProxiedPtr->GetNSlots(), filename, dirname, treename, columnList, options),
-                                      columnList, *fProxiedPtr));
+         actionPtr.reset(
+            new Action_t(Helper_t(fProxiedPtr->GetNSlots(), filename, dirname, treename, columnList, options),
+                         columnList, *fProxiedPtr));
       }
       auto df = GetDataFrameChecked();
       df->Book(std::move(actionPtr));
@@ -1359,7 +1369,7 @@ protected:
    {
    }
 
-   const std::shared_ptr<Proxied>& GetProxiedPtr() const { return fProxiedPtr; }
+   const std::shared_ptr<Proxied> &GetProxiedPtr() const { return fProxiedPtr; }
 };
 
 template <>

--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -15,6 +15,7 @@
 #include "ROOT/TDataSource.hxx"
 #include "ROOT/TDFNodes.hxx"
 #include "ROOT/TDFActionHelpers.hxx"
+#include "ROOT/TDFHistoModels.hxx"
 #include "ROOT/TDFUtils.hxx"
 #include "TChain.h"
 #include "TH1.h" // For Histo actions
@@ -743,10 +744,15 @@ public:
    /// booked but not executed. See TResultProxy documentation.
    /// The user gives up ownership of the model histogram.
    template <typename V = TDFDetail::TInferType>
-   TResultProxy<::TH1D> Histo1D(::TH1D &&model = ::TH1D{"", "", 128u, 0., 0.}, std::string_view vName = "")
+   TResultProxy<::TH1D> Histo1D(const TH1DModel& model = {"", "", 128u, 0., 0.}, std::string_view vName = "")
    {
       const auto userColumns = vName.empty() ? ColumnNames_t() : ColumnNames_t({std::string(vName)});
-      auto h = std::make_shared<::TH1D>(std::move(model));
+      std::shared_ptr<::TH1D> h(nullptr);
+      {
+         Internal::TDF::TIgnoreErrorLevelRAAI iel(kError);
+         h = std::make_shared<::TH1D>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp);
+      }
+
       if (h->GetXaxis()->GetXmax() == h->GetXaxis()->GetXmin())
          TDFInternal::HistoUtils<::TH1D>::SetCanExtendAllAxes(*h);
       return CreateAction<TDFInternal::ActionTypes::Histo1D, V>(userColumns, h);
@@ -755,7 +761,7 @@ public:
    template <typename V = TDFDetail::TInferType>
    TResultProxy<::TH1D> Histo1D(std::string_view vName)
    {
-      return Histo1D<V>(::TH1D{"", "", 128u, 0., 0.}, vName);
+      return Histo1D<V>({"", "", 128u, 0., 0.}, vName);
    }
 
    ////////////////////////////////////////////////////////////////////////////
@@ -768,13 +774,17 @@ public:
    ///
    /// See the description of the first Histo1D overload for more details.
    template <typename V = TDFDetail::TInferType, typename W = TDFDetail::TInferType>
-   TResultProxy<::TH1D> Histo1D(::TH1D &&model, std::string_view vName, std::string_view wName)
+   TResultProxy<::TH1D> Histo1D(const TH1DModel& model, std::string_view vName, std::string_view wName)
    {
       auto columnViews = {vName, wName};
       const auto userColumns = TDFInternal::AtLeastOneEmptyString(columnViews)
                                   ? ColumnNames_t()
                                   : ColumnNames_t(columnViews.begin(), columnViews.end());
-      auto h = std::make_shared<::TH1D>(std::move(model));
+      std::shared_ptr<::TH1D> h(nullptr);
+      {
+         Internal::TDF::TIgnoreErrorLevelRAAI iel(kError);
+         h = std::make_shared<::TH1D>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp);
+      }
       return CreateAction<TDFInternal::ActionTypes::Histo1D, V, W>(userColumns, h);
    }
 
@@ -790,7 +800,7 @@ public:
    template <typename V = TDFDetail::TInferType, typename W = TDFDetail::TInferType>
    TResultProxy<::TH1D> Histo1D(std::string_view vName, std::string_view wName)
    {
-      return Histo1D<V, W>(::TH1D{"", "", 128u, 0., 0.}, vName, wName);
+      return Histo1D<V, W>({"", "", 128u, 0., 0.}, vName, wName);
    }
 
    ////////////////////////////////////////////////////////////////////////////
@@ -802,9 +812,9 @@ public:
    /// This overload will use the first two default columns as column names.
    /// See the description of the first Histo1D overload for more details.
    template <typename V, typename W>
-   TResultProxy<::TH1D> Histo1D(::TH1D &&model = ::TH1D{"", "", 128u, 0., 0.})
+   TResultProxy<::TH1D> Histo1D(const TH1DModel& model = {"", "", 128u, 0., 0.})
    {
-      return Histo1D<V, W>(std::move(model), "", "");
+      return Histo1D<V, W>(model, "", "");
    }
 
    ////////////////////////////////////////////////////////////////////////////
@@ -823,9 +833,13 @@ public:
    /// booked but not executed. See TResultProxy documentation.
    /// The user gives up ownership of the model histogram.
    template <typename V1 = TDFDetail::TInferType, typename V2 = TDFDetail::TInferType>
-   TResultProxy<::TH2D> Histo2D(::TH2D &&model, std::string_view v1Name = "", std::string_view v2Name = "")
+   TResultProxy<::TH2D> Histo2D(const TH2DModel& model, std::string_view v1Name = "", std::string_view v2Name = "")
    {
-      auto h = std::make_shared<::TH2D>(std::move(model));
+      std::shared_ptr<::TH2D> h(nullptr);
+      {
+         Internal::TDF::TIgnoreErrorLevelRAAI iel(kError);
+         h = std::make_shared<::TH2D>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp, model.fNbinsY, model.fYLow, model.fYUp);
+      }
       if (!TDFInternal::HistoUtils<::TH2D>::HasAxisLimits(*h)) {
          throw std::runtime_error("2D histograms with no axes limits are not supported yet.");
       }
@@ -851,10 +865,14 @@ public:
    /// The user gives up ownership of the model histogram.
    template <typename V1 = TDFDetail::TInferType, typename V2 = TDFDetail::TInferType,
              typename W = TDFDetail::TInferType>
-   TResultProxy<::TH2D> Histo2D(::TH2D &&model, std::string_view v1Name, std::string_view v2Name,
+   TResultProxy<::TH2D> Histo2D(const TH2DModel& model, std::string_view v1Name, std::string_view v2Name,
                                 std::string_view wName)
    {
-      auto h = std::make_shared<::TH2D>(std::move(model));
+      std::shared_ptr<::TH2D> h(nullptr);
+      {
+         Internal::TDF::TIgnoreErrorLevelRAAI iel(kError);
+         h = std::make_shared<::TH2D>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp,  model.fNbinsY, model.fYLow, model.fYUp);
+      }
       if (!TDFInternal::HistoUtils<::TH2D>::HasAxisLimits(*h)) {
          throw std::runtime_error("2D histograms with no axes limits are not supported yet.");
       }
@@ -866,9 +884,9 @@ public:
    }
 
    template <typename V1, typename V2, typename W>
-   TResultProxy<::TH2D> Histo2D(::TH2D &&model)
+   TResultProxy<::TH2D> Histo2D(const TH2DModel& model)
    {
-      return Histo2D<V1, V2, W>(std::move(model), "", "", "");
+      return Histo2D<V1, V2, W>(model, "", "", "");
    }
 
    ////////////////////////////////////////////////////////////////////////////
@@ -886,10 +904,14 @@ public:
    /// The user gives up ownership of the model histogram.
    template <typename V1 = TDFDetail::TInferType, typename V2 = TDFDetail::TInferType,
              typename V3 = TDFDetail::TInferType>
-   TResultProxy<::TH3D> Histo3D(::TH3D &&model, std::string_view v1Name = "", std::string_view v2Name = "",
+   TResultProxy<::TH3D> Histo3D(const TH3DModel& model, std::string_view v1Name = "", std::string_view v2Name = "",
                                 std::string_view v3Name = "")
    {
-      auto h = std::make_shared<::TH3D>(std::move(model));
+      std::shared_ptr<::TH3D> h(nullptr);
+      {
+         Internal::TDF::TIgnoreErrorLevelRAAI iel(kError);
+         h = std::make_shared<::TH3D>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp, model.fNbinsY, model.fYLow, model.fYUp, model.fNbinsZ, model.fZLow, model.fZUp);
+      }
       if (!TDFInternal::HistoUtils<::TH3D>::HasAxisLimits(*h)) {
          throw std::runtime_error("3D histograms with no axes limits are not supported yet.");
       }
@@ -917,10 +939,14 @@ public:
    /// The user gives up ownership of the model histogram.
    template <typename V1 = TDFDetail::TInferType, typename V2 = TDFDetail::TInferType,
              typename V3 = TDFDetail::TInferType, typename W = TDFDetail::TInferType>
-   TResultProxy<::TH3D> Histo3D(::TH3D &&model, std::string_view v1Name, std::string_view v2Name,
+   TResultProxy<::TH3D> Histo3D(const TH3DModel& model, std::string_view v1Name, std::string_view v2Name,
                                 std::string_view v3Name, std::string_view wName)
    {
-      auto h = std::make_shared<::TH3D>(std::move(model));
+      std::shared_ptr<::TH3D> h(nullptr);
+      {
+         Internal::TDF::TIgnoreErrorLevelRAAI iel(kError);
+         h = std::make_shared<::TH3D>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp, model.fNbinsY, model.fYLow, model.fYUp, model.fNbinsZ, model.fZLow, model.fZUp);
+      }
       if (!TDFInternal::HistoUtils<::TH3D>::HasAxisLimits(*h)) {
          throw std::runtime_error("3D histograms with no axes limits are not supported yet.");
       }
@@ -932,9 +958,9 @@ public:
    }
 
    template <typename V1, typename V2, typename V3, typename W>
-   TResultProxy<::TH3D> Histo3D(::TH3D &&model)
+   TResultProxy<::TH3D> Histo3D(const TH3DModel& model)
    {
-      return Histo3D<V1, V2, V3, W>(std::move(model), "", "", "", "");
+      return Histo3D<V1, V2, V3, W>(model, "", "", "", "");
    }
 
    ////////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/inc/ROOT/TDFUtils.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFUtils.hxx
@@ -81,15 +81,10 @@ using namespace ROOT::Experimental::TDF;
 class TIgnoreErrorLevelRAAI {
 private:
    int fCurIgnoreErrorLevel = gErrorIgnoreLevel;
+
 public:
-   TIgnoreErrorLevelRAAI(int errorIgnoreLevel)
-   {
-      gErrorIgnoreLevel = errorIgnoreLevel;
-   }
-   ~TIgnoreErrorLevelRAAI()
-   {
-      gErrorIgnoreLevel = fCurIgnoreErrorLevel;
-   }
+   TIgnoreErrorLevelRAAI(int errorIgnoreLevel) { gErrorIgnoreLevel = errorIgnoreLevel; }
+   ~TIgnoreErrorLevelRAAI() { gErrorIgnoreLevel = fCurIgnoreErrorLevel; }
 };
 
 /// Compile-time integer sequence generator
@@ -140,7 +135,8 @@ struct TNeedJitting<TInferType> {
 using TVBPtr_t = std::shared_ptr<TTreeReaderValueBase>;
 using TVBVec_t = std::vector<TVBPtr_t>;
 
-std::string ColumnName2ColumnTypeName(const std::string &colName, TTree *, TCustomColumnBase *, TDataSource * = nullptr);
+std::string
+ColumnName2ColumnTypeName(const std::string &colName, TTree *, TCustomColumnBase *, TDataSource * = nullptr);
 
 const char *ToConstCharPtr(const char *s);
 const char *ToConstCharPtr(const std::string &s);

--- a/tree/treeplayer/inc/ROOT/TDFUtils.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFUtils.hxx
@@ -78,6 +78,20 @@ using namespace ROOT::TypeTraits;
 using namespace ROOT::Detail::TDF;
 using namespace ROOT::Experimental::TDF;
 
+class TIgnoreErrorLevelRAAI {
+private:
+   int fCurIgnoreErrorLevel = gErrorIgnoreLevel;
+public:
+   TIgnoreErrorLevelRAAI(int errorIgnoreLevel)
+   {
+      gErrorIgnoreLevel = errorIgnoreLevel;
+   }
+   ~TIgnoreErrorLevelRAAI()
+   {
+      gErrorIgnoreLevel = fCurIgnoreErrorLevel;
+   }
+};
+
 /// Compile-time integer sequence generator
 /// e.g. calling GenStaticSeq<3>::type() instantiates a StaticSeq<0,1,2>
 template <int...>

--- a/tree/treeplayer/src/TDFHistoModels.cxx
+++ b/tree/treeplayer/src/TDFHistoModels.cxx
@@ -1,0 +1,73 @@
+// Author: Enrico Guiraud, Danilo Piparo CERN  09/2017
+
+/*************************************************************************
+ * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include <ROOT/TDFHistoModels.hxx>
+
+#include <TH1D.h>
+#include <TH2D.h>
+#include <TH3D.h>
+
+/**
+* \class ROOT::Experimental::TDF::TH1DModel
+* \ingroup dataframe
+* \brief A struct which stores the parameters of a TH1D
+*
+* \class ROOT::Experimental::TDF::TH2DModel
+* \ingroup dataframe
+* \brief A struct which stores the parameters of a TH2D
+*
+* \class ROOT::Experimental::TDF::TH3DModel
+* \ingroup dataframe
+* \brief A struct which stores the parameters of a TH3D
+*/
+
+namespace ROOT {
+namespace Experimental {
+namespace TDF {
+
+TH1DModel::TH1DModel(const ::TH1D &h)
+   : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX()), fXLow(h.GetXaxis()->GetXmin()),
+     fXUp(h.GetXaxis()->GetXmax())
+{
+}
+TH1DModel::TH1DModel(const char *name, const char *title, int nbinsx, double xlow, double xup)
+   : fName(name), fTitle(title), fNbinsX(nbinsx), fXLow(xlow), fXUp(xup)
+{
+}
+
+TH2DModel::TH2DModel(const ::TH2D &h)
+   : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX()), fXLow(h.GetXaxis()->GetXmin()),
+     fXUp(h.GetXaxis()->GetXmax()), fNbinsY(h.GetNbinsY()), fYLow(h.GetYaxis()->GetXmin()),
+     fYUp(h.GetYaxis()->GetXmax())
+{
+}
+TH2DModel::TH2DModel(const char *name, const char *title, int nbinsx, double xlow, double xup, int nbinsy, double ylow,
+                     double yup)
+   : fName(name), fTitle(title), fNbinsX(nbinsx), fXLow(xlow), fXUp(xup), fNbinsY(nbinsy), fYLow(ylow), fYUp(yup)
+{
+}
+
+TH3DModel::TH3DModel(const ::TH3D &h)
+   : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX()), fXLow(h.GetXaxis()->GetXmin()),
+     fXUp(h.GetXaxis()->GetXmax()), fNbinsY(h.GetNbinsY()), fYLow(h.GetYaxis()->GetXmin()),
+     fYUp(h.GetYaxis()->GetXmax()), fNbinsZ(h.GetNbinsZ()), fZLow(h.GetZaxis()->GetXmin()),
+     fZUp(h.GetZaxis()->GetXmax())
+{
+}
+TH3DModel::TH3DModel(const char *name, const char *title, int nbinsx, double xlow, double xup, int nbinsy, double ylow,
+                     double yup, int nbinsz, double zlow, double zup)
+   : fName(name), fTitle(title), fNbinsX(nbinsx), fXLow(xlow), fXUp(xup), fNbinsY(nbinsy), fYLow(ylow), fYUp(yup),
+     fNbinsZ(nbinsz), fZLow(zlow), fZUp(zup)
+{
+}
+
+} // ns TDF
+} // ns Experimental
+} // ns ROOT

--- a/tree/treeplayer/test/CMakeLists.txt
+++ b/tree/treeplayer/test/CMakeLists.txt
@@ -7,5 +7,6 @@ ROOT_ADD_GTEST(dataframe_regression dataframe/dataframe_regression.cxx LIBRARIES
 ROOT_ADD_GTEST(dataframe_interface dataframe/dataframe_interface.cxx LIBRARIES TreePlayer)
 ROOT_ADD_GTEST(dataframe_utils dataframe/dataframe_utils.cxx LIBRARIES TreePlayer)
 ROOT_ADD_GTEST(dataframe_nodes dataframe/dataframe_nodes.cxx LIBRARIES TreePlayer)
+ROOT_ADD_GTEST(dataframe_histomodels dataframe/dataframe_histomodels.cxx LIBRARIES TreePlayer)
 ROOT_ADD_GTEST(datasource_trivial dataframe/datasource_trivial.cxx LIBRARIES TreePlayer)
 ROOT_ADD_GTEST(datasource_root dataframe/datasource_root.cxx LIBRARIES TreePlayer)

--- a/tree/treeplayer/test/dataframe/dataframe_histomodels.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_histomodels.cxx
@@ -8,54 +8,53 @@ TEST(TDataFrameHistoModels, Histo1D)
 {
    TDataFrame tdf(10);
    auto x = 0.;
-   auto d = tdf.Define("x",[&x](){return x++;}).Define("w",[&x](){return x+1.;});
-   auto h1 = d.Histo1D(::TH1D("h1","h1",64,0,10), "x");
-   auto h2 = d.Histo1D({"h2","h2",64,0,10}, "x");
-   auto h1w = d.Histo1D(::TH1D("h0w","h0w",64,0,10), "x","w");
-   auto h2w = d.Histo1D({"h2w","h2w",64,0,10}, "x","w");
+   auto d = tdf.Define("x", [&x]() { return x++; }).Define("w", [&x]() { return x + 1.; });
+   auto h1 = d.Histo1D(::TH1D("h1", "h1", 64, 0, 10), "x");
+   auto h2 = d.Histo1D({"h2", "h2", 64, 0, 10}, "x");
+   auto h1w = d.Histo1D(::TH1D("h0w", "h0w", 64, 0, 10), "x", "w");
+   auto h2w = d.Histo1D({"h2w", "h2w", 64, 0, 10}, "x", "w");
 
-   TDF::TH1DModel m0("m0","m0",64,0,10);
-   TDF::TH1DModel m1(::TH1D("m1","m1",64,0,10));
+   TDF::TH1DModel m0("m0", "m0", 64, 0, 10);
+   TDF::TH1DModel m1(::TH1D("m1", "m1", 64, 0, 10));
 
    auto hm0 = d.Histo1D(m0, "x");
    auto hm1 = d.Histo1D(m1, "x");
-   auto hm0w = d.Histo1D(m0, "x","w");
-   auto hm1w = d.Histo1D(m1, "x","w");
-
+   auto hm0w = d.Histo1D(m0, "x", "w");
+   auto hm1w = d.Histo1D(m1, "x", "w");
 }
 
 TEST(TDataFrameHistoModels, Histo2D)
 {
    TDataFrame tdf(10);
    auto x = 0.;
-   auto d = tdf.Define("x",[&x](){return x++;}).Define("y",[&x](){return x+.1;});
-   auto h1 = d.Histo2D(::TH2D("h1","h1",64,0,10,64,0,10), "x","y");
-   auto h2 = d.Histo2D({"h2","h2",64,0,10,64,0,10}, "x","y");
+   auto d = tdf.Define("x", [&x]() { return x++; }).Define("y", [&x]() { return x + .1; });
+   auto h1 = d.Histo2D(::TH2D("h1", "h1", 64, 0, 10, 64, 0, 10), "x", "y");
+   auto h2 = d.Histo2D({"h2", "h2", 64, 0, 10, 64, 0, 10}, "x", "y");
 
-   TDF::TH2DModel m0("m0","m0",64,0,10,64,0,10);
-   TDF::TH2DModel m1(::TH2D("m1","m1",64,0,10,64,0,10));
+   TDF::TH2DModel m0("m0", "m0", 64, 0, 10, 64, 0, 10);
+   TDF::TH2DModel m1(::TH2D("m1", "m1", 64, 0, 10, 64, 0, 10));
 
-   auto hm0 = d.Histo2D(m0, "x","y");
-   auto hm1 = d.Histo2D(m1, "x","y");
-   auto hm0w = d.Histo2D(m0, "x","y","x");
-   auto hm1w = d.Histo2D(m1, "x","y","x");
-
+   auto hm0 = d.Histo2D(m0, "x", "y");
+   auto hm1 = d.Histo2D(m1, "x", "y");
+   auto hm0w = d.Histo2D(m0, "x", "y", "x");
+   auto hm1w = d.Histo2D(m1, "x", "y", "x");
 }
 
 TEST(TDataFrameHistoModels, Histo3D)
 {
    TDataFrame tdf(10);
    auto x = 0.;
-   auto d = tdf.Define("x",[&x](){return x++;}).Define("y",[&x](){return x+.1;}).Define("z",[&x](){return x+.1;});
-   auto h1 = d.Histo3D(::TH3D("h1","h1",64,0,10,64,0,10,64,0,10), "x","y","z");
-   auto h2 = d.Histo3D({"h2","h2",64,0,10,64,0,10,64,0,10}, "x","y","z");
+   auto d = tdf.Define("x", [&x]() { return x++; }).Define("y", [&x]() { return x + .1; }).Define("z", [&x]() {
+      return x + .1;
+   });
+   auto h1 = d.Histo3D(::TH3D("h1", "h1", 64, 0, 10, 64, 0, 10, 64, 0, 10), "x", "y", "z");
+   auto h2 = d.Histo3D({"h2", "h2", 64, 0, 10, 64, 0, 10, 64, 0, 10}, "x", "y", "z");
 
-   TDF::TH3DModel m0("m0","m0",64,0,10,64,0,10,64,0,10);
-   TDF::TH3DModel m1(::TH3D("m1","m1",64,0,10,64,0,10,64,0,10));
+   TDF::TH3DModel m0("m0", "m0", 64, 0, 10, 64, 0, 10, 64, 0, 10);
+   TDF::TH3DModel m1(::TH3D("m1", "m1", 64, 0, 10, 64, 0, 10, 64, 0, 10));
 
-   auto hm0 = d.Histo3D(m0, "x","y","z");
-   auto hm1 = d.Histo3D(m1, "x","y","z");
-   auto hm0w = d.Histo3D(m0, "x","y","z","z");
-   auto hm1w = d.Histo3D(m1, "x","y","z","z");
-
+   auto hm0 = d.Histo3D(m0, "x", "y", "z");
+   auto hm1 = d.Histo3D(m1, "x", "y", "z");
+   auto hm0w = d.Histo3D(m0, "x", "y", "z", "z");
+   auto hm1w = d.Histo3D(m1, "x", "y", "z", "z");
 }

--- a/tree/treeplayer/test/dataframe/dataframe_histomodels.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_histomodels.cxx
@@ -1,0 +1,61 @@
+#include "ROOT/TDataFrame.hxx"
+
+#include "gtest/gtest.h"
+
+using namespace ROOT::Experimental;
+
+TEST(TDataFrameHistoModels, Histo1D)
+{
+   TDataFrame tdf(10);
+   auto x = 0.;
+   auto d = tdf.Define("x",[&x](){return x++;}).Define("w",[&x](){return x+1.;});
+   auto h1 = d.Histo1D(::TH1D("h1","h1",64,0,10), "x");
+   auto h2 = d.Histo1D({"h2","h2",64,0,10}, "x");
+   auto h1w = d.Histo1D(::TH1D("h0w","h0w",64,0,10), "x","w");
+   auto h2w = d.Histo1D({"h2w","h2w",64,0,10}, "x","w");
+
+   TDF::TH1DModel m0("m0","m0",64,0,10);
+   TDF::TH1DModel m1(::TH1D("m1","m1",64,0,10));
+
+   auto hm0 = d.Histo1D(m0, "x");
+   auto hm1 = d.Histo1D(m1, "x");
+   auto hm0w = d.Histo1D(m0, "x","w");
+   auto hm1w = d.Histo1D(m1, "x","w");
+
+}
+
+TEST(TDataFrameHistoModels, Histo2D)
+{
+   TDataFrame tdf(10);
+   auto x = 0.;
+   auto d = tdf.Define("x",[&x](){return x++;}).Define("y",[&x](){return x+.1;});
+   auto h1 = d.Histo2D(::TH2D("h1","h1",64,0,10,64,0,10), "x","y");
+   auto h2 = d.Histo2D({"h2","h2",64,0,10,64,0,10}, "x","y");
+
+   TDF::TH2DModel m0("m0","m0",64,0,10,64,0,10);
+   TDF::TH2DModel m1(::TH2D("m1","m1",64,0,10,64,0,10));
+
+   auto hm0 = d.Histo2D(m0, "x","y");
+   auto hm1 = d.Histo2D(m1, "x","y");
+   auto hm0w = d.Histo2D(m0, "x","y","x");
+   auto hm1w = d.Histo2D(m1, "x","y","x");
+
+}
+
+TEST(TDataFrameHistoModels, Histo3D)
+{
+   TDataFrame tdf(10);
+   auto x = 0.;
+   auto d = tdf.Define("x",[&x](){return x++;}).Define("y",[&x](){return x+.1;}).Define("z",[&x](){return x+.1;});
+   auto h1 = d.Histo3D(::TH3D("h1","h1",64,0,10,64,0,10,64,0,10), "x","y","z");
+   auto h2 = d.Histo3D({"h2","h2",64,0,10,64,0,10,64,0,10}, "x","y","z");
+
+   TDF::TH3DModel m0("m0","m0",64,0,10,64,0,10,64,0,10);
+   TDF::TH3DModel m1(::TH3D("m1","m1",64,0,10,64,0,10,64,0,10));
+
+   auto hm0 = d.Histo3D(m0, "x","y","z");
+   auto hm1 = d.Histo3D(m1, "x","y","z");
+   auto hm0w = d.Histo3D(m0, "x","y","z","z");
+   auto hm1w = d.Histo3D(m1, "x","y","z","z");
+
+}

--- a/tutorials/dataframe/tdf002_dataModel.C
+++ b/tutorials/dataframe/tdf002_dataModel.C
@@ -94,7 +94,7 @@ int tdf002_dataModel()
                          .Define("tracks_pts", getPt)
                          .Define("tracks_pts_weights", getPtWeights);
 
-   auto trN = augmented_d.Histo1D(TH1D{"", "", 40, -.5, 39.5}, "tracks_n");
+   auto trN = augmented_d.Histo1D({"", "", 40, -.5, 39.5}, "tracks_n");
    auto trPts = augmented_d.Histo1D("tracks_pts");
    auto trWPts = augmented_d.Histo1D("tracks_pts", "tracks_pts_weights");
 

--- a/tutorials/dataframe/tdf101_h1Analysis.C
+++ b/tutorials/dataframe/tdf101_h1Analysis.C
@@ -108,9 +108,9 @@ void tdf101_h1Analysis()
 
    ROOT::Experimental::TDataFrame dataFrame(chain);
    auto selected = Select(dataFrame);
-   auto hdmdARP = selected.Histo1D(TH1D("hdmd", "Dm_d", 40, 0.13, 0.17), "dm_d");
+   auto hdmdARP = selected.Histo1D({"hdmd", "Dm_d", 40, 0.13, 0.17}, "dm_d");
    auto selectedAddedBranch = selected.Define("h2_y", "rpd0_t / 0.029979f * 1.8646f / ptd0_d");
-   auto h2ARP = selectedAddedBranch.Histo2D(TH2D("h2", "ptD0 vs Dm_d", 30, 0.135, 0.165, 30, -3, 6), "dm_d", "h2_y");
+   auto h2ARP = selectedAddedBranch.Histo2D({"h2", "ptD0 vs Dm_d", 30, 0.135, 0.165, 30, -3, 6}, "dm_d", "h2_y");
 
    FitAndPlotHdmd(*hdmdARP);
    FitAndPlotH2(*h2ARP);


### PR DESCRIPTION
This allows seamless usage of PyROOT and the forthcoming list initialisation.