### PR TITLE
Avoid warnings when overriding nChunks

### DIFF
--- a/core/imt/inc/ROOT/TThreadExecutor.hxx
+++ b/core/imt/inc/ROOT/TThreadExecutor.hxx
@@ -122,7 +122,7 @@ namespace ROOT {
    void TThreadExecutor::Foreach(F func, ROOT::TSeq<INTEGER> args) {
        ParallelFor(*args.begin(), *args.end(), args.step(), [&](unsigned int i){func(i);});
    }
-   
+
    /// \cond
    //////////////////////////////////////////////////////////////////////////
    /// Execute func in parallel, taking an element of a
@@ -196,9 +196,6 @@ namespace ROOT {
       unsigned step = (nTimes + nChunks - 1) / nChunks;
       // Avoid empty chunks
       unsigned actualChunks = (nTimes + step - 1) / step;
-      if(actualChunks != nChunks){
-          Warning("ROOT::TThreadExecutor::Map", "The number of chunks has been reduced to %d to avoid empty chunks", actualChunks);
-      }
       using retType = decltype(func());
       std::vector<retType> reslist(actualChunks);
       auto lambda = [&](unsigned int i)
@@ -256,9 +253,6 @@ namespace ROOT {
       unsigned step = (end - start + nChunks - 1) / nChunks; //ceiling the division
       // Avoid empty chunks
       unsigned actualChunks = (end - start + step - 1) / step;
-      if(actualChunks != nChunks){
-          Warning("ROOT::TThreadExecutor::Map", "The number of chunks has been reduced to %d to avoid empty chunks", actualChunks);
-      }
 
       using retType = decltype(func(start));
       std::vector<retType> reslist(actualChunks);
@@ -292,9 +286,7 @@ namespace ROOT {
       unsigned step = (nToProcess + nChunks - 1) / nChunks; //ceiling the division
       // Avoid empty chunks
       unsigned actualChunks = (nToProcess + step - 1) / step;
-      if(actualChunks != nChunks){
-          Warning("ROOT::TThreadExecutor::Map", "The number of chunks has been reduced to %d to avoid empty chunks", actualChunks);
-      }
+
       using retType = decltype(func(args.front()));
       std::vector<retType> reslist(actualChunks);
       auto lambda = [&](unsigned int i)
@@ -341,7 +333,7 @@ namespace ROOT {
    auto TThreadExecutor::MapReduce(F func, unsigned nTimes, R redfunc, unsigned nChunks) -> typename std::result_of<F()>::type {
       return Reduce(Map(func, nTimes, redfunc, nChunks), redfunc);
    }
-   
+
    template<class F, class INTEGER, class R, class Cond>
    auto TThreadExecutor::MapReduce(F func, ROOT::TSeq<INTEGER> args, R redfunc, unsigned nChunks) -> typename std::result_of<F(INTEGER)>::type {
       return Reduce(Map(func, args, redfunc, nChunks), redfunc);

--- a/core/imt/src/TThreadExecutor.cxx
+++ b/core/imt/src/TThreadExecutor.cxx
@@ -53,7 +53,8 @@
 /// This set of methods behaves exactly like Map, but takes an additional
 /// function as a third argument. This function is applied to the set of
 /// objects returned by the corresponding Map execution to "squash" them
-/// to a single object. 
+/// to a single object. This function should be independent of the size of
+/// the vector returned by Map due to optimization of the number of chunks.
 ///
 /// If this function is a binary operator, the "squashing" will be performed in parallel.
 /// This is exclusive to ROOT::TThreadExecutor and not any other ROOT::TExecutor-derived classes.\n


### PR DESCRIPTION
The warnings were raised by TThreadExecutor trying to be smart when chunking, overriding user specified number of chunks to avoid accessing uninitialized positions of the results vector.

This is annoying f.e. when Fitting, with several calls to Map() with the same "conflictive when chunking" data.