### PR TITLE
Streamline expression of Python unit tests and test TDF histogramming in python

### DIFF
--- a/bindings/pyroot/test/CMakeLists.txt
+++ b/bindings/pyroot/test/CMakeLists.txt
@@ -1,10 +1,2 @@
-find_package(ROOT REQUIRED)
-set(ROOT_ENV ROOTSYS=${ROOTSYS}
-             PATH=${ROOTSYS}/bin:$ENV{PATH}
-             LD_LIBRARY_PATH=${ROOTSYS}/lib:$ENV{LD_LIBRARY_PATH}
-             PYTHONPATH=${ROOTSYS}/lib:$ENV{PYTHONPATH})
-
-ROOT_ADD_TEST(pyroot-unittests
-              COMMAND ${PYTHON_EXECUTABLE} -m unittest discover -s ${CMAKE_CURRENT_SOURCE_DIR} -p "*.py" -v
-              ENVIRONMENT ${ROOT_ENV})
+ROOT_ADD_PYUNITTESTS(pyroot)
 

--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -242,7 +242,7 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
           list(APPEND _list_of_header_dependencies ${f})
         endif()
       endforeach()
-    elseif(CMAKE_PROJECT_NAME STREQUAL ROOT AND 
+    elseif(CMAKE_PROJECT_NAME STREQUAL ROOT AND
            EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${fp}) # only for ROOT project
       list(APPEND headerfiles ${CMAKE_CURRENT_SOURCE_DIR}/${fp})
       list(APPEND _list_of_header_dependencies ${CMAKE_CURRENT_SOURCE_DIR}/${fp})
@@ -261,7 +261,7 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
       unset(headerFile CACHE)
     endif()
   endforeach()
-  string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/inc/" ""  headerfiles "${headerfiles}") 
+  string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/inc/" ""  headerfiles "${headerfiles}")
   # Replace the non-standard folder layout of Core.
   if (ARG_STAGE1 AND ARG_MODULE STREQUAL "Core")
     # FIXME: Glob these folders.
@@ -805,7 +805,7 @@ function(ROOT_INSTALL_HEADERS)
     ROOT_GLOB_FILES(include_files
       RECURSE
       RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/${d}
-      FILTER ${filter} 
+      FILTER ${filter}
       ${d}/*.h ${d}/*.hxx ${d}/*.icc )
     foreach (include_file ${include_files})
       set (src ${CMAKE_CURRENT_SOURCE_DIR}/${d}/${include_file})
@@ -815,7 +815,7 @@ function(ROOT_INSTALL_HEADERS)
         COMMAND ${CMAKE_COMMAND} -E copy ${src} ${dst}
         COMMENT "Copying header ${src} to /include"
         DEPENDS ${src})
-      list(APPEND dst_list ${dst})  
+      list(APPEND dst_list ${dst})
     endforeach()
     set_property(GLOBAL APPEND PROPERTY ROOT_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/${d})
   endforeach()
@@ -1236,7 +1236,7 @@ endfunction()
 function(ROOT_ADD_GTEST test_suite)
   CMAKE_PARSE_ARGUMENTS(ARG "" "" "LIBRARIES" ${ARGN})
   include_directories(${CMAKE_CURRENT_BINARY_DIR} ${GTEST_INCLUDE_DIR} ${GMOCK_INCLUDE_DIR})
-  
+
   ROOT_GET_SOURCES(source_files . ${ARG_UNPARSED_ARGUMENTS})
   # Note we cannot use ROOT_EXECUTABLE without user-specified set of LIBRARIES to link with.
   # The test suites should choose this in their specific CMakeLists.txt file.
@@ -1258,6 +1258,36 @@ endfunction()
 function(ROOT_ADD_TEST_SUBDIRECTORY subdir)
   file(RELATIVE_PATH subdir ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/${subdir})
   set_property(GLOBAL APPEND PROPERTY ROOT_TEST_SUBDIRS ${subdir})
+endfunction()
+
+#----------------------------------------------------------------------------
+# ROOT_ADD_PYUNITTESTS( <name> )
+#----------------------------------------------------------------------------
+function(ROOT_ADD_PYUNITTESTS name)
+  set(ROOT_ENV ROOTSYS=${ROOTSYS}
+      PATH=${ROOTSYS}/bin:$ENV{PATH}
+      LD_LIBRARY_PATH=${ROOTSYS}/lib:$ENV{LD_LIBRARY_PATH}
+      PYTHONPATH=${ROOTSYS}/lib:$ENV{PYTHONPATH})
+  string(REGEX REPLACE "[_]" "-" good_name "${name}")
+  ROOT_ADD_TEST(pyunittests-${good_name}
+                COMMAND ${PYTHON_EXECUTABLE} -m unittest discover -s ${CMAKE_CURRENT_SOURCE_DIR} -p "*.py" -v
+                ENVIRONMENT ${ROOT_ENV})
+endfunction()
+
+#----------------------------------------------------------------------------
+# ROOT_ADD_PYUNITTEST( <name> <file>)
+#----------------------------------------------------------------------------
+function(ROOT_ADD_PYUNITTEST name file)
+  set(ROOT_ENV ROOTSYS=${ROOTSYS}
+      PATH=${ROOTSYS}/bin:$ENV{PATH}
+      LD_LIBRARY_PATH=${ROOTSYS}/lib:$ENV{LD_LIBRARY_PATH}
+      PYTHONPATH=${ROOTSYS}/lib:$ENV{PYTHONPATH})
+  string(REGEX REPLACE "[_]" "-" good_name "${name}")
+  get_filename_component(file_name ${file} NAME)
+  get_filename_component(file_dir ${file} DIRECTORY)
+  ROOT_ADD_TEST(pyunittests-${good_name}
+                COMMAND ${PYTHON_EXECUTABLE} -m unittest discover -s ${CMAKE_CURRENT_SOURCE_DIR}/${file_dir} -p ${file_name} -v
+                ENVIRONMENT ${ROOT_ENV})
 endfunction()
 
 #----------------------------------------------------------------------------

--- a/tree/treeplayer/test/CMakeLists.txt
+++ b/tree/treeplayer/test/CMakeLists.txt
@@ -10,3 +10,4 @@ ROOT_ADD_GTEST(dataframe_nodes dataframe/dataframe_nodes.cxx LIBRARIES TreePlaye
 ROOT_ADD_GTEST(dataframe_histomodels dataframe/dataframe_histomodels.cxx LIBRARIES TreePlayer)
 ROOT_ADD_GTEST(datasource_trivial dataframe/datasource_trivial.cxx LIBRARIES TreePlayer)
 ROOT_ADD_GTEST(datasource_root dataframe/datasource_root.cxx LIBRARIES TreePlayer)
+ROOT_ADD_PYUNITTEST(dataframe_histograms dataframe/dataframe_histograms.py)

--- a/tree/treeplayer/test/dataframe/dataframe_histograms.py
+++ b/tree/treeplayer/test/dataframe/dataframe_histograms.py
@@ -1,0 +1,28 @@
+import unittest
+import ROOT
+
+class HistogramsFromTDF(unittest.TestCase):
+    @classmethod
+    def setUp(cls):
+        ROOT.gRandom.SetSeed(1)
+
+    def test_histo1D(self):
+    	ROOT.gRandom.SetSeed(1)
+    	tdf = ROOT.ROOT.Experimental.TDataFrame(64)
+    	g = tdf.Define("r","gRandom->Gaus(0,1)")
+    	h1Proxy = g.Histo1D(("h1","h1",64, -2., 2.),"r")
+    	h1 = h1Proxy.GetValue()
+
+        cppCode = 'gRandom->SetSeed(1);' + \
+                  'ROOT::Experimental::TDataFrame tdf(64);' + \
+                  'auto g = tdf.Define("r","gRandom->Gaus(0,1)");' + \
+                  'auto h2Proxy = g.Histo1D({"h1","h1",64, -2., 2.},"r");'
+        ROOT.gInterpreter.ProcessLine(cppCode)
+        h2 = ROOT.h2Proxy.GetValue()
+
+        self.assertEqual(h1.GetEntries(), h2.GetEntries())
+        self.assertEqual(h1.GetMean(), h2.GetMean())
+        self.assertEqual(h1.GetStdDev(), h2.GetStdDev())
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tree/treeplayer/test/dataframe/dataframe_histograms.py
+++ b/tree/treeplayer/test/dataframe/dataframe_histograms.py
@@ -7,11 +7,11 @@ class HistogramsFromTDF(unittest.TestCase):
         ROOT.gRandom.SetSeed(1)
 
     def test_histo1D(self):
-    	ROOT.gRandom.SetSeed(1)
-    	tdf = ROOT.ROOT.Experimental.TDataFrame(64)
-    	g = tdf.Define("r","gRandom->Gaus(0,1)")
-    	h1Proxy = g.Histo1D(("h1","h1",64, -2., 2.),"r")
-    	h1 = h1Proxy.GetValue()
+        ROOT.gRandom.SetSeed(1)
+        tdf = ROOT.ROOT.Experimental.TDataFrame(64)
+        g = tdf.Define("r","gRandom->Gaus(0,1)")
+        h1Proxy = g.Histo1D(("h1","h1",64, -2., 2.),"r")
+        h1 = h1Proxy.GetValue()
 
         cppCode = 'gRandom->SetSeed(1);' + \
                   'ROOT::Experimental::TDataFrame tdf(64);' + \


### PR DESCRIPTION
This PR introduces a new way to express python unit tests with two CMake functions (see commit message) and leverages the new mechanism to re-formulate the PyROOT unit tests and to add new tests for the TDF pyROOT interface.