### PR TITLE
Revert "Don't try to remove decls that are not part of the lookup."

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/AST/DeclBase.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/AST/DeclBase.cpp
@@ -1323,8 +1323,8 @@ void DeclContext::removeDecl(Decl *D) {
   if (isa<NamedDecl>(D)) {
     NamedDecl *ND = cast<NamedDecl>(D);
 
-    // Remove only decls that have a name or registered in the lookup.
-    if (!ND->getDeclName() || ND->isHidden()) return;
+    // Remove only decls that have a name
+    if (!ND->getDeclName()) return;
 
     auto *DC = D->getDeclContext();
     do {


### PR DESCRIPTION
This reverts commit 180cd90afe663f2e04017d03bc63111d124010c6.
It breaks lookup of functions with 'using ParentClass::Func'
in combination with modules which reuse the hidden flag for
module purposes.

See https://reviews.llvm.org/D37180 for a clang test case that
tests for regressions like this in the future.