### PR TITLE
[cxxmodules] Add sys/types.h to the libc modulemap

### DIFF
--- a/build/unix/libc.modulemap
+++ b/build/unix/libc.modulemap
@@ -41,3 +41,9 @@ module "xlocale.h" [system] {
   export *
   header "xlocale.h"
 }
+
+// System header that we have difficult with merging.
+module "sys_types.h" [system] {
+  export *
+  header "sys/types.h"
+}


### PR DESCRIPTION
In commit b8dbe76844923 we added signal.h to the modulemap to
fix a merging issue coming from sys/types.h. However, we include
this header directly in some other places so we can still encounter
this merging issue. This adds now the sys/types.h header also
to the modulemap to fix this once and for all.