### PR TITLE
[TDF] Registration of callbacks called on partial analysis results every N entries

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
@@ -83,10 +83,10 @@ class FillHelper {
    std::vector<Buf_t> fBuffers;
    std::vector<Buf_t> fWBuffers;
    const std::shared_ptr<Hist_t> fResultHist;
-   /// Histograms containing "snapshots" of partial results. Non-null only if a registered callback requires it.
-   std::vector<std::unique_ptr<Hist_t>> fPartialHists;
    unsigned int fNSlots;
    unsigned int fBufSize;
+   /// Histograms containing "snapshots" of partial results. Non-null only if a registered callback requires it.
+   std::vector<std::unique_ptr<Hist_t>> fPartialHists;
    Buf_t fMin;
    Buf_t fMax;
 
@@ -245,9 +245,6 @@ public:
    }
    void Finalize() { fTo->Merge(); }
 
-   // Must be implemented to activate callbacks for Histo1D<T> actions.
-   // Currently no-op, meaning we leave the result object as it is:
-   // the result object is already being filled because FillTOHelper keeps it in its working slot 0
    HIST *PartialUpdate(unsigned int slot) { return fTo->GetAtSlotRaw(slot); }
 };
 

--- a/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
@@ -71,6 +71,7 @@ public:
    void InitSlot(TTreeReader *, unsigned int) {}
    void Exec(unsigned int slot);
    void Finalize();
+   ULong64_t *PartialUpdate(unsigned int slot);
 };
 
 class FillHelper {
@@ -246,8 +247,7 @@ public:
    HIST *PartialUpdate(unsigned int slot) { return fTo->GetAtSlotRaw(slot); }
 };
 
-// note: changes to this class should probably be replicated in its partial
-// specialization below
+// IMPORTANT NOTE: changes to this class should probably be replicated in its partial specialization below
 template <typename T, typename COLL>
 class TakeHelper {
    std::vector<std::shared_ptr<COLL>> fColls;
@@ -276,6 +276,8 @@ public:
          }
       }
    }
+
+   COLL *PartialUpdate(unsigned int slot) { return fColls[slot].get(); }
 };
 
 // note: changes to this class should probably be replicated in its unspecialized
@@ -313,6 +315,8 @@ public:
          rColl->insert(rColl->end(), coll->begin(), coll->end());
       }
    }
+
+   std::vector<T> *PartialUpdate(unsigned int slot) { return fColls[slot].get(); }
 };
 
 template <typename F, typename T>
@@ -338,6 +342,8 @@ public:
    {
       for (auto &t : fReduceObjs) *fReduceRes = fReduceFun(*fReduceRes, t);
    }
+
+   T *PartialUpdate(unsigned int slot) { return &fReduceObjs[slot]; }
 };
 
 class MinHelper {

--- a/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
@@ -369,6 +369,8 @@ public:
    }
 
    void Finalize();
+
+   double *PartialUpdate(unsigned int slot) { return &fMins[slot]; }
 };
 
 extern template void MinHelper::Exec(unsigned int, const std::vector<float> &);
@@ -395,6 +397,8 @@ public:
    }
 
    void Finalize();
+
+   double *PartialUpdate(unsigned int slot) { return &fMaxs[slot]; }
 };
 
 extern template void MaxHelper::Exec(unsigned int, const std::vector<float> &);
@@ -407,6 +411,7 @@ class MeanHelper {
    const std::shared_ptr<double> fResultMean;
    std::vector<ULong64_t> fCounts;
    std::vector<double> fSums;
+   std::vector<double> fPartialMeans;
 
 public:
    MeanHelper(const std::shared_ptr<double> &meanVPtr, const unsigned int nSlots);
@@ -425,6 +430,8 @@ public:
    }
 
    void Finalize();
+
+   double *PartialUpdate(unsigned int slot);
 };
 
 extern template void MeanHelper::Exec(unsigned int, const std::vector<float> &);

--- a/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
@@ -239,6 +239,11 @@ public:
       }
    }
    void Finalize() { fTo->Merge(); }
+
+   // Must be implemented to activate callbacks for Histo1D<T> actions.
+   // Currently no-op, meaning we leave the result object as it is:
+   // the result object is already being filled because FillTOHelper keeps it in its working slot 0
+   void PartialUpdate(unsigned int slot) { }
 };
 
 // note: changes to this class should probably be replicated in its partial

--- a/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
@@ -243,7 +243,7 @@ public:
    // Must be implemented to activate callbacks for Histo1D<T> actions.
    // Currently no-op, meaning we leave the result object as it is:
    // the result object is already being filled because FillTOHelper keeps it in its working slot 0
-   void PartialUpdate() { }
+   HIST *PartialUpdate(unsigned int slot) { return fTo->GetAtSlotRaw(slot); }
 };
 
 // note: changes to this class should probably be replicated in its partial

--- a/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
@@ -243,7 +243,7 @@ public:
    // Must be implemented to activate callbacks for Histo1D<T> actions.
    // Currently no-op, meaning we leave the result object as it is:
    // the result object is already being filled because FillTOHelper keeps it in its working slot 0
-   void PartialUpdate(unsigned int slot) { }
+   void PartialUpdate(unsigned int /*slot*/) { }
 };
 
 // note: changes to this class should probably be replicated in its partial

--- a/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
@@ -243,7 +243,7 @@ public:
    // Must be implemented to activate callbacks for Histo1D<T> actions.
    // Currently no-op, meaning we leave the result object as it is:
    // the result object is already being filled because FillTOHelper keeps it in its working slot 0
-   void PartialUpdate(unsigned int /*slot*/) { }
+   void PartialUpdate() { }
 };
 
 // note: changes to this class should probably be replicated in its partial

--- a/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
@@ -83,6 +83,8 @@ class FillHelper {
    std::vector<Buf_t> fBuffers;
    std::vector<Buf_t> fWBuffers;
    const std::shared_ptr<Hist_t> fResultHist;
+   /// Histograms containing "snapshots" of partial results. Non-null only if a registered callback requires it.
+   std::vector<std::unique_ptr<Hist_t>> fPartialHists;
    unsigned int fNSlots;
    unsigned int fBufSize;
    Buf_t fMin;
@@ -123,6 +125,8 @@ public:
          thisWBuf.emplace_back(w); // TODO: Can be optimised in case T == BufEl_t
       }
    }
+
+   Hist_t *PartialUpdate(unsigned int);
 
    void Finalize();
 };

--- a/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
@@ -71,7 +71,7 @@ public:
    void InitSlot(TTreeReader *, unsigned int) {}
    void Exec(unsigned int slot);
    void Finalize();
-   ULong64_t *PartialUpdate(unsigned int slot);
+   ULong64_t &PartialUpdate(unsigned int slot);
 };
 
 class FillHelper {
@@ -126,7 +126,7 @@ public:
       }
    }
 
-   Hist_t *PartialUpdate(unsigned int);
+   Hist_t &PartialUpdate(unsigned int);
 
    void Finalize();
 };
@@ -245,7 +245,7 @@ public:
    }
    void Finalize() { fTo->Merge(); }
 
-   HIST *PartialUpdate(unsigned int slot) { return fTo->GetAtSlotRaw(slot); }
+   HIST &PartialUpdate(unsigned int slot) { return *fTo->GetAtSlotRaw(slot); }
 };
 
 // IMPORTANT NOTE: changes to this class should probably be replicated in its partial specialization below
@@ -278,7 +278,7 @@ public:
       }
    }
 
-   COLL *PartialUpdate(unsigned int slot) { return fColls[slot].get(); }
+   COLL &PartialUpdate(unsigned int slot) { return fColls[slot].get(); }
 };
 
 // note: changes to this class should probably be replicated in its unspecialized
@@ -317,7 +317,7 @@ public:
       }
    }
 
-   std::vector<T> *PartialUpdate(unsigned int slot) { return fColls[slot].get(); }
+   std::vector<T> &PartialUpdate(unsigned int slot) { return *fColls[slot]; }
 };
 
 template <typename F, typename T>
@@ -344,7 +344,7 @@ public:
       for (auto &t : fReduceObjs) *fReduceRes = fReduceFun(*fReduceRes, t);
    }
 
-   T *PartialUpdate(unsigned int slot) { return &fReduceObjs[slot]; }
+   T &PartialUpdate(unsigned int slot) { return fReduceObjs[slot]; }
 };
 
 class MinHelper {
@@ -367,7 +367,7 @@ public:
 
    void Finalize();
 
-   double *PartialUpdate(unsigned int slot) { return &fMins[slot]; }
+   double &PartialUpdate(unsigned int slot) { return fMins[slot]; }
 };
 
 extern template void MinHelper::Exec(unsigned int, const std::vector<float> &);
@@ -395,7 +395,7 @@ public:
 
    void Finalize();
 
-   double *PartialUpdate(unsigned int slot) { return &fMaxs[slot]; }
+   double &PartialUpdate(unsigned int slot) { return fMaxs[slot]; }
 };
 
 extern template void MaxHelper::Exec(unsigned int, const std::vector<float> &);
@@ -428,7 +428,7 @@ public:
 
    void Finalize();
 
-   double *PartialUpdate(unsigned int slot);
+   double &PartialUpdate(unsigned int slot);
 };
 
 extern template void MeanHelper::Exec(unsigned int, const std::vector<float> &);

--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -793,9 +793,10 @@ public:
       auto redObjPtr = std::make_shared<T>(initValue);
       using Helper_t = TDFInternal::ReduceHelper<F, T>;
       using Action_t = typename TDFInternal::TAction<Helper_t, Proxied>;
-      loopManager->Book(std::make_shared<Action_t>(Helper_t(std::move(f), redObjPtr, fProxiedPtr->GetNSlots()),
-                                                   validColumnNames, *fProxiedPtr));
-      return MakeResultProxy(redObjPtr, loopManager);
+      auto action = std::make_shared<Action_t>(Helper_t(std::move(f), redObjPtr, fProxiedPtr->GetNSlots()),
+                                               validColumnNames, *fProxiedPtr);
+      loopManager->Book(action);
+      return MakeResultProxy(redObjPtr, loopManager, action.get());
    }
 
    ////////////////////////////////////////////////////////////////////////////
@@ -825,8 +826,9 @@ public:
       auto cSPtr = std::make_shared<ULong64_t>(0);
       using Helper_t = TDFInternal::CountHelper;
       using Action_t = TDFInternal::TAction<Helper_t, Proxied>;
-      df->Book(std::make_shared<Action_t>(Helper_t(cSPtr, nSlots), ColumnNames_t({}), *fProxiedPtr));
-      return MakeResultProxy(cSPtr, df);
+      auto action = std::make_shared<Action_t>(Helper_t(cSPtr, nSlots), ColumnNames_t({}), *fProxiedPtr);
+      df->Book(action);
+      return MakeResultProxy(cSPtr, df, action.get());
    }
 
    ////////////////////////////////////////////////////////////////////////////
@@ -851,8 +853,9 @@ public:
       using Action_t = TDFInternal::TAction<Helper_t, Proxied>;
       auto valuesPtr = std::make_shared<COLL>();
       const auto nSlots = fProxiedPtr->GetNSlots();
-      loopManager->Book(std::make_shared<Action_t>(Helper_t(valuesPtr, nSlots), validColumnNames, *fProxiedPtr));
-      return MakeResultProxy(valuesPtr, loopManager);
+      auto action = std::make_shared<Action_t>(Helper_t(valuesPtr, nSlots), validColumnNames, *fProxiedPtr);
+      loopManager->Book(action);
+      return MakeResultProxy(valuesPtr, loopManager, action.get());
    }
 
    ////////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -1493,7 +1493,7 @@ private:
                                                 typeid(std::shared_ptr<ActionResultType>), typeid(ActionType), rOnHeap,
                                                 tree, nSlots, customColumns, fDataSource);
       lm->Jit(toJit);
-      return MakeResultProxy(r, lm);
+      return MakeResultProxy(r, lm).first;
    }
 
    ////////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -157,7 +157,7 @@ Long_t JitTransformation(void *thisPtr, std::string_view methodName, std::string
 std::string JitBuildAndBook(const ColumnNames_t &bl, const std::string &prevNodeTypename, void *prevNode,
                             const std::type_info &art, const std::type_info &at, const void *r, TTree *tree,
                             const unsigned int nSlots, const std::map<std::string, TmpBranchBasePtr_t> &customColumns,
-                            TDataSource *ds);
+                            TDataSource *ds, const std::shared_ptr<TActionBase *> * const actionPtrPtr);
 
 // allocate a shared_ptr on the heap, return a reference to it. the user is responsible of deleting the shared_ptr*.
 // this function is meant to only be used by TInterface's action methods, and should be deprecated as soon as we find
@@ -216,7 +216,8 @@ void DefineDataSourceColumns(const std::vector<std::string> &columns, TLoopManag
 /// Convenience function invoked by jitted code to build action nodes at runtime
 template <typename ActionType, typename... BranchTypes, typename PrevNodeType, typename ActionResultType>
 void CallBuildAndBook(PrevNodeType &prevNode, const ColumnNames_t &bl, const unsigned int nSlots,
-                      const std::shared_ptr<ActionResultType> *rOnHeap)
+                      const std::shared_ptr<ActionResultType> *rOnHeap,
+                      const std::shared_ptr<TActionBase *> *actionPtrPtrOnHeap)
 {
    // if we are here it means we are jitting, if we are jitting the loop manager must be alive
    auto &loopManager = *prevNode.GetImplPtr();
@@ -225,8 +226,11 @@ void CallBuildAndBook(PrevNodeType &prevNode, const ColumnNames_t &bl, const uns
    auto ds = loopManager.GetDataSource();
    if (ds)
       DefineDataSourceColumns(bl, loopManager, GenStaticSeq_t<nColumns>(), ColTypes_t(), *ds);
-   BuildAndBook<BranchTypes...>(bl, *rOnHeap, nSlots, loopManager, prevNode, (ActionType *)nullptr);
+   TActionBase *actionPtr =
+      BuildAndBook<BranchTypes...>(bl, *rOnHeap, nSlots, loopManager, prevNode, (ActionType *)nullptr);
+   **actionPtrPtrOnHeap = actionPtr;
    delete rOnHeap;
+   delete actionPtrPtrOnHeap;
 }
 
 } // namespace TDF
@@ -1489,11 +1493,14 @@ private:
       auto upcastNode = TDFInternal::UpcastNode(fProxiedPtr);
       TInterface<TypeTraits::TakeFirstParameter_t<decltype(upcastNode)>> upcastInterface(
          upcastNode, fImplWeakPtr, fValidCustomColumns, fDataSource);
+      auto resultProxyAndActionPtrPtr = MakeResultProxy(r, lm);
+      auto &resultProxy = resultProxyAndActionPtrPtr.first;
+      auto actionPtrPtrOnHeap = TDFInternal::MakeSharedOnHeap(resultProxyAndActionPtrPtr.second);
       auto toJit = TDFInternal::JitBuildAndBook(validColumnNames, upcastInterface.GetNodeTypeName(), upcastNode.get(),
                                                 typeid(std::shared_ptr<ActionResultType>), typeid(ActionType), rOnHeap,
-                                                tree, nSlots, customColumns, fDataSource);
+                                                tree, nSlots, customColumns, fDataSource, actionPtrPtrOnHeap);
       lm->Jit(toJit);
-      return MakeResultProxy(r, lm).first;
+      return resultProxy;
    }
 
    ////////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/inc/ROOT/TDFNodes.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFNodes.hxx
@@ -130,8 +130,8 @@ class TLoopManager : public std::enable_shared_from_this<TLoopManager> {
    const std::unique_ptr<TDataSource> fDataSource; ///< Owning pointer to a data-source object. Null if no data-source
    ColumnNames_t fDefinedDataSourceColumns;        ///< List of data-source columns that have been `Define`d so far
    std::map<std::string, std::string> fAliasColumnNameMap; ///< ColumnNameAlias-columnName pairs
-   std::vector<TLoopCallback> fCallbacks;                  ///< Registered callbacks invoked once per event per slot
-   std::vector<TLoopCallback> fCallbacksOnce; ///< Registered callbacks invoked once per event-loop per slot
+   std::vector<TLoopCallback> fCallbacks; ///< Registered callbacks
+   std::vector<TLoopCallback> fCallbacksOnce; ///< Registered callbacks to invoke just once before running the loop
 
    void RunEmptySourceMT();
    void RunEmptySource();

--- a/tree/treeplayer/inc/ROOT/TDFNodes.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFNodes.hxx
@@ -320,6 +320,7 @@ public:
    virtual void TriggerChildrenCount() = 0;
    virtual void ClearValueReaders(unsigned int slot) = 0;
    unsigned int GetNSlots() const { return fNSlots; }
+   virtual void PartialUpdate(unsigned int /*slot*/) { Warning("PartialUpdate", "Not implemented for this action!"); }
 };
 
 template <typename Helper, typename PrevDataFrame, typename BranchTypes_t = typename Helper::BranchTypes_t>

--- a/tree/treeplayer/inc/ROOT/TDFNodes.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFNodes.hxx
@@ -407,9 +407,9 @@ private:
    // this overload is SFINAE'd out if Helper does not implement `PartialUpdate`
    // the template parameter is required to defer instantiation of the method to SFINAE time
    template <typename H = Helper>
-   auto PartialUpdateImpl(unsigned int slot) -> decltype(std::declval<H>().PartialUpdate(slot))
+   auto PartialUpdateImpl(unsigned int slot) -> decltype(std::declval<H>().PartialUpdate(slot), (void *)(nullptr))
    {
-      return fHelper.PartialUpdate(slot);
+      return &fHelper.PartialUpdate(slot);
    }
    // this one is always available but has lower precedence thanks to `...`
    void *PartialUpdateImpl(...) {

--- a/tree/treeplayer/inc/ROOT/TDFNodes.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFNodes.hxx
@@ -131,6 +131,7 @@ class TLoopManager : public std::enable_shared_from_this<TLoopManager> {
    ColumnNames_t fDefinedDataSourceColumns;        ///< List of data-source columns that have been `Define`d so far
    std::map<std::string, std::string> fAliasColumnNameMap; ///< ColumnNameAlias-columnName pairs
    std::vector<TLoopCallback> fCallbacks;                  ///< Registered callbacks invoked once per event per slot
+   std::vector<TLoopCallback> fCallbacksOnce; ///< Registered callbacks invoked once per event-loop per slot
 
    void RunEmptySourceMT();
    void RunEmptySource();

--- a/tree/treeplayer/inc/ROOT/TResultProxy.hxx
+++ b/tree/treeplayer/inc/ROOT/TResultProxy.hxx
@@ -183,6 +183,7 @@ public:
    ///
    /// \param[in] everyNEvents Frequency at which the callback will be called, as a number of events processed
    /// \param[in] callback a callable with signature `void(Value_t&)` where Value_t is the type of the value contained in this TResultProxy
+   /// \return this TResultProxy, to allow chaining of OnPartialResultSlot with other calls
    ///
    /// The callback must be a callable (lambda, function, functor class...) that takes a reference to the result type as
    /// argument and returns nothing. TDataFrame will invoke registered callbacks passing partial action results as
@@ -218,7 +219,7 @@ public:
    ///   might change between calls
    /// To register a callback that is called by _each_ worker thread (concurrently) every N events one can use
    /// OnPartialResultSlot.
-   void OnPartialResult(ULong64_t everyNEvents, std::function<void(T&)> callback)
+   TResultProxy<T> &OnPartialResult(ULong64_t everyNEvents, std::function<void(T&)> callback)
    {
       auto actionPtrPtr = fActionPtrPtr.get();
       auto c = [actionPtrPtr, callback](unsigned int slot) {
@@ -228,12 +229,14 @@ public:
          callback(*partialResult);
       };
       RegisterCallback(everyNEvents, std::move(c));
+      return *this;
    }
 
    /// Register a callback that TDataFrame will execute in each worker thread concurrently on that thread's partial result.
    ///
    /// \param[in] everyNEvents Frequency at which the callback will be called by each thread, as a number of events processed
    /// \param[in] a callable with signature `void(unsigned int, Value_t&)` where Value_t is the type of the value contained in this TResultProxy
+   /// \return this TResultProxy, to allow chaining of OnPartialResultSlot with other calls
    ///
    /// See `RegisterCallback` for a generic explanation of the callback mechanism.
    /// Compared to `RegisterCallback`, this method has two major differences:
@@ -258,7 +261,7 @@ public:
    /// *c; // trigger the event loop by accessing an action's result
    /// std::cout << "\nDone!" << std::endl;
    /// \endcode
-   void OnPartialResultSlot(ULong64_t everyNEvents, std::function<void(unsigned int, T&)> callback)
+   TResultProxy<T> &OnPartialResultSlot(ULong64_t everyNEvents, std::function<void(unsigned int, T&)> callback)
    {
       auto actionPtrPtr = fActionPtrPtr.get();
       auto c = [actionPtrPtr, callback](unsigned int slot) {
@@ -266,6 +269,7 @@ public:
          callback(slot, *partialResult);
       };
       RegisterCallback(everyNEvents, std::move(c));
+      return *this;
    }
 };
 

--- a/tree/treeplayer/inc/ROOT/TResultProxy.hxx
+++ b/tree/treeplayer/inc/ROOT/TResultProxy.hxx
@@ -68,6 +68,20 @@ If iteration is not supported by the type of the proxied object, a compilation e
 */
 template <typename T>
 class TResultProxy {
+   // private using declarations
+   using SPT_t = std::shared_ptr<T>;
+   using SPTLM_t = std::shared_ptr<TDFDetail::TLoopManager>;
+   using WPTLM_t = std::weak_ptr<TDFDetail::TLoopManager>;
+   using ShrdPtrBool_t = std::shared_ptr<bool>;
+
+   // friend declarations
+   template <typename W>
+   friend TResultProxy<W>
+   TDFDetail::MakeResultProxy(const std::shared_ptr<W> &, const SPTLM_t &, TDFInternal::TActionBase *);
+   template <typename W>
+   friend std::pair<TResultProxy<W>, std::shared_ptr<TDFInternal::TActionBase *>>
+   TDFDetail::MakeResultProxy(const std::shared_ptr<W> &, const SPTLM_t &);
+
    /// \cond HIDDEN_SYMBOLS
    template <typename V, bool isCont = TTraits::IsContainer<V>::value>
    struct TIterationHelper {
@@ -83,21 +97,11 @@ class TResultProxy {
       static Iterator_t GetEnd(const V &v) { return std::end(v); };
    };
    /// \endcond
-   using SPT_t = std::shared_ptr<T>;
-   using SPTLM_t = std::shared_ptr<TDFDetail::TLoopManager>;
-   using WPTLM_t = std::weak_ptr<TDFDetail::TLoopManager>;
-   using ShrdPtrBool_t = std::shared_ptr<bool>;
-   template <typename W>
-   friend TResultProxy<W>
-   TDFDetail::MakeResultProxy(const std::shared_ptr<W> &, const SPTLM_t &, TDFInternal::TActionBase *);
-   template <typename W>
-   friend std::pair<TResultProxy<W>, std::shared_ptr<TDFInternal::TActionBase *>>
-   TDFDetail::MakeResultProxy(const std::shared_ptr<W> &, const SPTLM_t &);
 
-   const ShrdPtrBool_t fReadiness =
-      std::make_shared<bool>(false); ///< State registered also in the TLoopManager until the event loop is executed
-   WPTLM_t fImplWeakPtr;             ///< Points to the TLoopManager at the root of the functional graph
-   const SPT_t fObjPtr;              ///< Shared pointer encapsulating the wrapped result
+   /// State registered also in the TLoopManager until the event loop is executed
+   const ShrdPtrBool_t fReadiness = std::make_shared<bool>(false);
+   WPTLM_t fImplWeakPtr; ///< Points to the TLoopManager at the root of the functional graph
+   const SPT_t fObjPtr;  ///< Shared pointer encapsulating the wrapped result
    /// Shared_ptr to a _pointer_ to the TDF action that produces this result. It is set at construction time for
    /// non-jitted actions, and at jitting time for jitted actions (at the time of writing, this means right
    /// before the event-loop).

--- a/tree/treeplayer/inc/ROOT/TResultProxy.hxx
+++ b/tree/treeplayer/inc/ROOT/TResultProxy.hxx
@@ -155,16 +155,17 @@ public:
    {
       if (everyNevents == 0) {
          Warning("RegisterCallback",
-                 "everyNevents implies the callback will never be executed, so it's not going to be registered.");
+                 "everyNevents==0 implies the callback will never be executed, so it's not going to be registered.");
          return;
       }
+      // TODO remove once useless: at the time of writing jitted actions, Reduce, Take, Count are missing the feature
       if (!fActionPtr)
-         throw std::runtime_error("Callback registration not implemented for this kind of action.");
+         throw std::runtime_error("Callback registration not implemented for this kind of action yet.");
       auto lm = fImplWeakPtr.lock();
       if (!lm)
          throw std::runtime_error("The main TDataFrame is not reachable: did it go out of scope?");
-      auto c = [this, callback](unsigned int slot) {
-         fActionPtr->PartialUpdate(slot);
+      auto c = [this, callback]() {
+         fActionPtr->PartialUpdate();
          callback(*fObjPtr);
       };
       lm->RegisterCallback(std::move(c), everyNevents);

--- a/tree/treeplayer/inc/ROOT/TResultProxy.hxx
+++ b/tree/treeplayer/inc/ROOT/TResultProxy.hxx
@@ -188,8 +188,8 @@ public:
    /// The type of the value contained in a TResultProxy is also available as TResultProxy<T>::Value_t, e.g.
    /// \code{.cpp}
    /// auto h = tdf.Histo1D("x");
+   /// // h.kOnce is 0
    /// // decltype(h)::Value_t is TH1D
-   /// // decltype(h)::kOnce is 0
    /// \endcode
    ///
    /// When implicit multi-threading is enabled, the callback:

--- a/tree/treeplayer/inc/ROOT/TResultProxy.hxx
+++ b/tree/treeplayer/inc/ROOT/TResultProxy.hxx
@@ -115,7 +115,7 @@ class TResultProxy {
 
    void SetActionPtr(TDFInternal::TActionBase *a) { fActionPtr = a; }
 
-   void RegisterCallbackImpl(ULong64_t everyNEvents, std::function<void(unsigned int)> &&c) {
+   void RegisterCallback(ULong64_t everyNEvents, std::function<void(unsigned int)> &&c) {
       if (everyNEvents == 0) {
          Warning("RegisterCallback",
                  "everyNEvents==0 implies the callback will never be executed, so it's not going to be registered.");
@@ -200,7 +200,7 @@ public:
    ///   might change between calls
    /// To register a callback that is called by _each_ worker thread (concurrently) every N events one should use
    /// RegisterCallbackSlot instead.
-   void RegisterCallback(ULong64_t everyNEvents, std::function<void(T&)> callback)
+   void OnPartialResult(ULong64_t everyNEvents, std::function<void(T&)> callback)
    {
       auto actionPtr = fActionPtr; // only variables with automatic storage duration can be captured
       auto c = [actionPtr, callback](unsigned int slot) {
@@ -209,7 +209,7 @@ public:
          auto partialResult = static_cast<Value_t*>(actionPtr->PartialUpdate(slot));
          callback(*partialResult);
       };
-      RegisterCallbackImpl(everyNEvents, std::move(c));
+      RegisterCallback(everyNEvents, std::move(c));
    }
 
    /// Register a callback that TDataFrame will execute "everyNEvents" in each worker thread.
@@ -237,14 +237,14 @@ public:
    /// }
    /// h->Draw(); // trigger event loop and execution of callbacks, finish with a `Draw`
    /// \endcode
-   void RegisterCallbackSlot(ULong64_t everyNEvents, std::function<void(unsigned int, T&)> callback)
+   void OnPartialResultSlot(ULong64_t everyNEvents, std::function<void(unsigned int, T&)> callback)
    {
       auto actionPtr = fActionPtr;
       auto c = [actionPtr, callback](unsigned int slot) {
          auto partialResult = static_cast<Value_t*>(actionPtr->PartialUpdate(slot));
          callback(slot, *partialResult);
       };
-      RegisterCallbackImpl(everyNEvents, std::move(c));
+      RegisterCallback(everyNEvents, std::move(c));
    }
 };
 

--- a/tree/treeplayer/src/TDFActionHelpers.cxx
+++ b/tree/treeplayer/src/TDFActionHelpers.cxx
@@ -163,7 +163,7 @@ template void MaxHelper::Exec(unsigned int, const std::vector<int> &);
 template void MaxHelper::Exec(unsigned int, const std::vector<unsigned int> &);
 
 MeanHelper::MeanHelper(const std::shared_ptr<double> &meanVPtr, const unsigned int nSlots)
-   : fResultMean(meanVPtr), fCounts(nSlots, 0), fSums(nSlots, 0)
+   : fResultMean(meanVPtr), fCounts(nSlots, 0), fSums(nSlots, 0), fPartialMeans(nSlots)
 {
 }
 
@@ -180,6 +180,12 @@ void MeanHelper::Finalize()
    ULong64_t sumOfCounts = 0;
    for (auto &c : fCounts) sumOfCounts += c;
    *fResultMean = sumOfSums / (sumOfCounts > 0 ? sumOfCounts : 1);
+}
+
+double *MeanHelper::PartialUpdate(unsigned int slot)
+{
+   fPartialMeans[slot] = fSums[slot] / fCounts[slot];
+   return &fPartialMeans[slot];
 }
 
 template void MeanHelper::Exec(unsigned int, const std::vector<float> &);

--- a/tree/treeplayer/src/TDFActionHelpers.cxx
+++ b/tree/treeplayer/src/TDFActionHelpers.cxx
@@ -72,6 +72,17 @@ void FillHelper::Exec(unsigned int slot, double v, double w)
    fWBuffers[slot].emplace_back(w);
 }
 
+Hist_t *FillHelper::PartialUpdate(unsigned int slot)
+{
+   auto &partialHist = fPartialHists[slot];
+   // TODO it is inefficient to re-create the partial histogram everytime the callback is called
+   //      ideally we could incrementally fill it with the latest entries in the buffers
+   partialHist.reset(new Hist_t(*fResultHist));
+   auto weights = fWBuffers[slot].empty() ? nullptr : fWBuffers[slot].data();
+   partialHist->FillN(fBuffers[slot].size(), fBuffers[slot].data(), weights);
+   return partialHist.get();
+}
+
 void FillHelper::Finalize()
 {
    for (unsigned int i = 0; i < fNSlots; ++i) {

--- a/tree/treeplayer/src/TDFActionHelpers.cxx
+++ b/tree/treeplayer/src/TDFActionHelpers.cxx
@@ -32,6 +32,11 @@ void CountHelper::Finalize()
    }
 }
 
+ULong64_t *CountHelper::PartialUpdate(unsigned int slot)
+{
+   return &fCounts[slot];
+}
+
 void FillHelper::UpdateMinMax(unsigned int slot, double v)
 {
    auto &thisMin = fMin[slot];

--- a/tree/treeplayer/src/TDFActionHelpers.cxx
+++ b/tree/treeplayer/src/TDFActionHelpers.cxx
@@ -46,7 +46,7 @@ void FillHelper::UpdateMinMax(unsigned int slot, double v)
 }
 
 FillHelper::FillHelper(const std::shared_ptr<Hist_t> &h, const unsigned int nSlots)
-   : fResultHist(h), fNSlots(nSlots), fBufSize(fgTotalBufSize / nSlots),
+   : fResultHist(h), fNSlots(nSlots), fBufSize(fgTotalBufSize / nSlots), fPartialHists(fNSlots),
      fMin(nSlots, std::numeric_limits<BufEl_t>::max()), fMax(nSlots, std::numeric_limits<BufEl_t>::lowest())
 {
    fBuffers.reserve(fNSlots);

--- a/tree/treeplayer/src/TDFActionHelpers.cxx
+++ b/tree/treeplayer/src/TDFActionHelpers.cxx
@@ -32,9 +32,9 @@ void CountHelper::Finalize()
    }
 }
 
-ULong64_t *CountHelper::PartialUpdate(unsigned int slot)
+ULong64_t &CountHelper::PartialUpdate(unsigned int slot)
 {
-   return &fCounts[slot];
+   return fCounts[slot];
 }
 
 void FillHelper::UpdateMinMax(unsigned int slot, double v)
@@ -72,7 +72,7 @@ void FillHelper::Exec(unsigned int slot, double v, double w)
    fWBuffers[slot].emplace_back(w);
 }
 
-Hist_t *FillHelper::PartialUpdate(unsigned int slot)
+Hist_t &FillHelper::PartialUpdate(unsigned int slot)
 {
    auto &partialHist = fPartialHists[slot];
    // TODO it is inefficient to re-create the partial histogram everytime the callback is called
@@ -80,7 +80,7 @@ Hist_t *FillHelper::PartialUpdate(unsigned int slot)
    partialHist.reset(new Hist_t(*fResultHist));
    auto weights = fWBuffers[slot].empty() ? nullptr : fWBuffers[slot].data();
    partialHist->FillN(fBuffers[slot].size(), fBuffers[slot].data(), weights);
-   return partialHist.get();
+   return *partialHist;
 }
 
 void FillHelper::Finalize()
@@ -182,10 +182,10 @@ void MeanHelper::Finalize()
    *fResultMean = sumOfSums / (sumOfCounts > 0 ? sumOfCounts : 1);
 }
 
-double *MeanHelper::PartialUpdate(unsigned int slot)
+double &MeanHelper::PartialUpdate(unsigned int slot)
 {
    fPartialMeans[slot] = fSums[slot] / fCounts[slot];
-   return &fPartialMeans[slot];
+   return fPartialMeans[slot];
 }
 
 template void MeanHelper::Exec(unsigned int, const std::vector<float> &);

--- a/tree/treeplayer/src/TDFInterface.cxx
+++ b/tree/treeplayer/src/TDFInterface.cxx
@@ -203,7 +203,7 @@ Long_t JitTransformation(void *thisPtr, std::string_view methodName, std::string
 std::string JitBuildAndBook(const ColumnNames_t &bl, const std::string &prevNodeTypename, void *prevNode,
                             const std::type_info &art, const std::type_info &at, const void *rOnHeap, TTree *tree,
                             const unsigned int nSlots, const std::map<std::string, TmpBranchBasePtr_t> &customColumns,
-                            TDataSource *ds)
+                            TDataSource *ds, const std::shared_ptr<TActionBase *> * const actionPtrPtr)
 {
    auto nBranches = bl.size();
 
@@ -246,7 +246,8 @@ std::string JitBuildAndBook(const ColumnNames_t &bl, const std::string &prevNode
 
    // createAction_str will contain the following:
    // ROOT::Internal::TDF::CallBuildAndBook<actionType, branchType1, branchType2...>(
-   //   *reinterpret_cast<PrevNodeType*>(prevNode), { bl[0], bl[1], ... }, reinterpret_cast<actionResultType*>(rOnHeap))
+   //   *reinterpret_cast<PrevNodeType*>(prevNode), { bl[0], bl[1], ... }, reinterpret_cast<actionResultType*>(rOnHeap),
+   //   reinterpret_cast<shared_ptr<TActionBase*>*>(actionPtrPtr))
    std::stringstream createAction_str;
    createAction_str << "ROOT::Internal::TDF::CallBuildAndBook"
                     << "<" << actionTypeName;
@@ -257,7 +258,9 @@ std::string JitBuildAndBook(const ColumnNames_t &bl, const std::string &prevNode
          createAction_str << ", ";
       createAction_str << '"' << bl[i] << '"';
    }
-   createAction_str << "}, " << nSlots << ", reinterpret_cast<" << actionResultTypeName << "*>(" << rOnHeap << "));";
+   createAction_str << "}, " << nSlots << ", reinterpret_cast<" << actionResultTypeName << "*>(" << rOnHeap << ")"
+                    << ", reinterpret_cast<const std::shared_ptr<ROOT::Internal::TDF::TActionBase*>*>(" << actionPtrPtr
+                    << "));";
    return createAction_str.str();
 }
 

--- a/tree/treeplayer/src/TDFInterface.cxx
+++ b/tree/treeplayer/src/TDFInterface.cxx
@@ -203,7 +203,7 @@ Long_t JitTransformation(void *thisPtr, std::string_view methodName, std::string
 std::string JitBuildAndBook(const ColumnNames_t &bl, const std::string &prevNodeTypename, void *prevNode,
                             const std::type_info &art, const std::type_info &at, const void *rOnHeap, TTree *tree,
                             const unsigned int nSlots, const std::map<std::string, TmpBranchBasePtr_t> &customColumns,
-                            TDataSource *ds, const std::shared_ptr<TActionBase *> * const actionPtrPtr)
+                            TDataSource *ds, const std::shared_ptr<TActionBase *> *const actionPtrPtr)
 {
    auto nBranches = bl.size();
 

--- a/tree/treeplayer/src/TDFNodes.cxx
+++ b/tree/treeplayer/src/TDFNodes.cxx
@@ -265,6 +265,7 @@ void TLoopManager::RunAndCheckFilters(unsigned int slot, Long64_t entry)
 {
    for (auto &actionPtr : fBookedActions) actionPtr->Run(slot, entry);
    for (auto &namedFilterPtr : fBookedNamedFilters) namedFilterPtr->CheckFilters(slot, entry);
+   for (auto &callback : fCallbacks) callback(slot);
 }
 
 /// Build TTreeReaderValues for all nodes
@@ -440,6 +441,11 @@ bool TLoopManager::CheckFilters(int, unsigned int)
 void TLoopManager::Report() const
 {
    for (const auto &fPtr : fBookedNamedFilters) fPtr->PrintReport();
+}
+
+void TLoopManager::RegisterCallback(std::function<void(unsigned int)> &&f, ULong64_t everyNevents)
+{
+   fCallbacks.emplace_back(std::move(f), everyNevents, fNSlots);
 }
 
 TRangeBase::TRangeBase(TLoopManager *implPtr, unsigned int start, unsigned int stop, unsigned int stride,

--- a/tree/treeplayer/src/TDFNodes.cxx
+++ b/tree/treeplayer/src/TDFNodes.cxx
@@ -265,9 +265,7 @@ void TLoopManager::RunAndCheckFilters(unsigned int slot, Long64_t entry)
 {
    for (auto &actionPtr : fBookedActions) actionPtr->Run(slot, entry);
    for (auto &namedFilterPtr : fBookedNamedFilters) namedFilterPtr->CheckFilters(slot, entry);
-   if (!fCallbacks.empty() && slot == 0)
-      for (auto &callback : fCallbacks)
-         callback();
+   for (auto &callback : fCallbacks) callback(slot);
 }
 
 /// Build TTreeReaderValues for all nodes
@@ -447,9 +445,9 @@ void TLoopManager::Report() const
    for (const auto &fPtr : fBookedNamedFilters) fPtr->PrintReport();
 }
 
-void TLoopManager::RegisterCallback(std::function<void()> &&f, ULong64_t everyNevents)
+void TLoopManager::RegisterCallback(ULong64_t everyNEvents, std::function<void(unsigned int)> &&f)
 {
-   fCallbacks.emplace_back(std::move(f), everyNevents);
+   fCallbacks.emplace_back(everyNEvents, std::move(f), fNSlots);
 }
 
 TRangeBase::TRangeBase(TLoopManager *implPtr, unsigned int start, unsigned int stop, unsigned int stride,

--- a/tree/treeplayer/src/TDFNodes.cxx
+++ b/tree/treeplayer/src/TDFNodes.cxx
@@ -309,6 +309,8 @@ void TLoopManager::CleanUpNodes()
    fNStopsReceived = 0;
    for (auto &ptr : fBookedFilters) ptr->ResetChildrenCount();
    for (auto &ptr : fBookedRanges) ptr->ResetChildrenCount();
+
+   fCallbacks.clear();
 }
 
 /// Perform clean-up operations. To be called at the end of each task execution.

--- a/tree/treeplayer/src/TDFNodes.cxx
+++ b/tree/treeplayer/src/TDFNodes.cxx
@@ -265,7 +265,7 @@ void TLoopManager::RunAndCheckFilters(unsigned int slot, Long64_t entry)
 {
    for (auto &actionPtr : fBookedActions) actionPtr->Run(slot, entry);
    for (auto &namedFilterPtr : fBookedNamedFilters) namedFilterPtr->CheckFilters(slot, entry);
-   if (slot == 0)
+   if (!fCallbacks.empty() && slot == 0)
       for (auto &callback : fCallbacks)
          callback();
 }

--- a/tree/treeplayer/src/TDFNodes.cxx
+++ b/tree/treeplayer/src/TDFNodes.cxx
@@ -265,7 +265,9 @@ void TLoopManager::RunAndCheckFilters(unsigned int slot, Long64_t entry)
 {
    for (auto &actionPtr : fBookedActions) actionPtr->Run(slot, entry);
    for (auto &namedFilterPtr : fBookedNamedFilters) namedFilterPtr->CheckFilters(slot, entry);
-   for (auto &callback : fCallbacks) callback(slot);
+   if (slot == 0)
+      for (auto &callback : fCallbacks)
+         callback();
 }
 
 /// Build TTreeReaderValues for all nodes
@@ -445,9 +447,9 @@ void TLoopManager::Report() const
    for (const auto &fPtr : fBookedNamedFilters) fPtr->PrintReport();
 }
 
-void TLoopManager::RegisterCallback(std::function<void(unsigned int)> &&f, ULong64_t everyNevents)
+void TLoopManager::RegisterCallback(std::function<void()> &&f, ULong64_t everyNevents)
 {
-   fCallbacks.emplace_back(std::move(f), everyNevents, fNSlots);
+   fCallbacks.emplace_back(std::move(f), everyNevents);
 }
 
 TRangeBase::TRangeBase(TLoopManager *implPtr, unsigned int start, unsigned int stop, unsigned int stride,

--- a/tree/treeplayer/test/CMakeLists.txt
+++ b/tree/treeplayer/test/CMakeLists.txt
@@ -14,5 +14,6 @@ ROOT_ADD_GTEST(dataframe_snapshot dataframe/dataframe_snapshot.cxx LIBRARIES Tre
 ROOT_ADD_GTEST(datasource_trivial dataframe/datasource_trivial.cxx LIBRARIES TreePlayer)
 ROOT_ADD_GTEST(datasource_root dataframe/datasource_root.cxx LIBRARIES TreePlayer)
 ROOT_ADD_GTEST(datasource_noncopiable dataframe/datasource_noncopiable.cxx LIBRARIES TreePlayer)
+ROOT_ADD_GTEST(dataframe_callbacks dataframe/dataframe_callbacks.cxx LIBRARIES TreePlayer)
 
 ROOT_ADD_PYUNITTEST(dataframe_histograms dataframe/dataframe_histograms.py)

--- a/tree/treeplayer/test/dataframe/dataframe_callbacks.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_callbacks.cxx
@@ -1,0 +1,72 @@
+#include "ROOT/TDataFrame.hxx"
+#include "TRandom.h"
+#include "gtest/gtest.h"
+using namespace ROOT::Experimental;
+using namespace ROOT::Experimental::TDF;
+using namespace ROOT::Detail::TDF;
+
+// fixture that provides a TDF with no data-source and a single column "x" containing normal-distributed doubles
+class TDFCallbacks : public ::testing::Test {
+protected:
+   const ULong64_t nEvents = 8ull; // must be initialized before fLoopManager
+
+private:
+   TDataFrame fLoopManager;
+   TInterface<TLoopManager> DefineRandomCol()
+   {
+      TRandom r;
+      return fLoopManager.Define("x", [r]() mutable { return r.Gaus(); });
+   }
+
+protected:
+   TDFCallbacks() : fLoopManager(nEvents), tdf(DefineRandomCol()) {}
+   TInterface<TLoopManager> tdf;
+};
+
+TEST_F(TDFCallbacks, Histo1DWithFillTOHelper)
+{
+   auto h = tdf.Histo1D<double>({"", "", 128, -2., 2.}, "x");
+   using value_t = typename decltype(h)::Value_t;
+   ULong64_t i = 0ull;
+   ULong64_t everyN = 1ull;
+   h.RegisterCallback(everyN, [&i, &everyN](value_t &h_) {
+      i += everyN;
+      EXPECT_EQ(h_.GetEntries(), everyN * i);
+   });
+   *h;
+}
+
+TEST_F(TDFCallbacks, MultipleCallbacks)
+{
+   auto h = tdf.Histo1D<double>({"", "", 128, -2., 2.}, "x");
+   using value_t = typename decltype(h)::Value_t;
+   ULong64_t everyN = 1ull;
+   ULong64_t i = 0ull;
+   h.RegisterCallback(everyN, [&i, everyN](value_t &h_) {
+      i += everyN;
+      EXPECT_EQ(h_.GetEntries(), i);
+   });
+
+   everyN = 2ull;
+   ULong64_t i2 = 0ull;
+   h.RegisterCallback(everyN, [&i2, everyN](value_t &h_) {
+      i2 += everyN;
+      EXPECT_EQ(h_.GetEntries(), i2);
+   });
+
+   *h;
+}
+
+TEST_F(TDFCallbacks, MultipleEventLoops)
+{
+   auto h = tdf.Histo1D<double>({"", "", 128, -2., 2.}, "x");
+   using value_t = typename decltype(h)::Value_t;
+   ULong64_t i = 0ull;
+   h.RegisterCallback(1ull, [&i](value_t &) { ++i; });
+   *h;
+
+   auto h2 = tdf.Histo1D<double>({"", "", 128, -2., 2.}, "x");
+   *h2;
+
+   EXPECT_EQ(i, nEvents);
+}

--- a/tree/treeplayer/test/dataframe/dataframe_callbacks.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_callbacks.cxx
@@ -29,7 +29,7 @@ TEST_F(TDFCallbacks, Histo1DWithFillTOHelper)
    using value_t = typename decltype(h)::Value_t;
    ULong64_t i = 0ull;
    ULong64_t everyN = 1ull;
-   h.RegisterCallback(everyN, [&i, &everyN](value_t &h_) {
+   h.OnPartialResult(everyN, [&i, &everyN](value_t &h_) {
       i += everyN;
       EXPECT_EQ(h_.GetEntries(), everyN * i);
    });
@@ -42,14 +42,14 @@ TEST_F(TDFCallbacks, MultipleCallbacks)
    using value_t = typename decltype(h)::Value_t;
    ULong64_t everyN = 1ull;
    ULong64_t i = 0ull;
-   h.RegisterCallback(everyN, [&i, everyN](value_t &h_) {
+   h.OnPartialResult(everyN, [&i, everyN](value_t &h_) {
       i += everyN;
       EXPECT_EQ(h_.GetEntries(), i);
    });
 
    everyN = 2ull;
    ULong64_t i2 = 0ull;
-   h.RegisterCallback(everyN, [&i2, everyN](value_t &h_) {
+   h.OnPartialResult(everyN, [&i2, everyN](value_t &h_) {
       i2 += everyN;
       EXPECT_EQ(h_.GetEntries(), i2);
    });
@@ -62,7 +62,7 @@ TEST_F(TDFCallbacks, MultipleEventLoops)
    auto h = tdf.Histo1D<double>({"", "", 128, -2., 2.}, "x");
    using value_t = typename decltype(h)::Value_t;
    ULong64_t i = 0ull;
-   h.RegisterCallback(1ull, [&i](value_t &) { ++i; });
+   h.OnPartialResult(1ull, [&i](value_t &) { ++i; });
    *h;
 
    auto h2 = tdf.Histo1D<double>({"", "", 128, -2., 2.}, "x");

--- a/tree/treeplayer/test/dataframe/dataframe_callbacks.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_callbacks.cxx
@@ -31,12 +31,8 @@ protected:
 class TDFCallbacksMT : public ::testing::Test {
    class TIMTEnabler {
    public:
-      TIMTEnabler(unsigned int nSlots) {
-         ROOT::EnableImplicitMT(nSlots);
-      }
-      ~TIMTEnabler() {
-         ROOT::DisableImplicitMT();
-      }
+      TIMTEnabler(unsigned int nSlots) { ROOT::EnableImplicitMT(nSlots); }
+      ~TIMTEnabler() { ROOT::DisableImplicitMT(); }
    };
 
 protected:
@@ -56,7 +52,6 @@ protected:
    TDFCallbacksMT() : fIMTEnabler(nSlots), fLoopManager(nEvents), tdf(DefineRandomCol()) {}
    TInterface<TLoopManager> tdf;
 };
-
 
 /********* TESTS *********/
 TEST_F(TDFCallbacks, Histo1DWithFillTOHelper)

--- a/tree/treeplayer/test/dataframe/dataframe_callbacks.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_callbacks.cxx
@@ -8,11 +8,11 @@ using namespace ROOT::Experimental::TDF;
 using namespace ROOT::Detail::TDF;
 
 /********* FIXTURES *********/
+static constexpr ULong64_t nEvents = 8ull;
+static constexpr unsigned int nSlots = 4u;
+
 // fixture that provides a TDF with no data-source and a single column "x" containing normal-distributed doubles
 class TDFCallbacks : public ::testing::Test {
-protected:
-   const ULong64_t nEvents = 8ull; // must be initialized before fLoopManager
-
 private:
    TDataFrame fLoopManager;
    TInterface<TLoopManager> DefineRandomCol()
@@ -63,10 +63,10 @@ TEST_F(TDFCallbacks, Histo1DWithFillTOHelper)
    ULong64_t everyN = 1ull;
    h.OnPartialResult(everyN, [&i, &everyN](value_t &h_) {
       i += everyN;
-      EXPECT_EQ(h_.GetEntries(), everyN * i);
+      EXPECT_EQ(h_.GetEntries(), i);
    });
    *h;
-   EXPECT_EQ(nEvents, everyN * i);
+   EXPECT_EQ(nEvents, i);
 }
 
 TEST_F(TDFCallbacks, JittedHisto1DWithFillTOHelper)
@@ -78,10 +78,10 @@ TEST_F(TDFCallbacks, JittedHisto1DWithFillTOHelper)
    ULong64_t everyN = 1ull;
    h.OnPartialResult(everyN, [&i, &everyN](value_t &h_) {
       i += everyN;
-      EXPECT_EQ(h_.GetEntries(), everyN * i);
+      EXPECT_EQ(h_.GetEntries(), i);
    });
    *h;
-   EXPECT_EQ(nEvents, everyN * i);
+   EXPECT_EQ(nEvents, i);
 }
 
 TEST_F(TDFCallbacks, Histo1DWithFillHelper)
@@ -93,10 +93,10 @@ TEST_F(TDFCallbacks, Histo1DWithFillHelper)
    ULong64_t everyN = 1ull;
    h.OnPartialResult(everyN, [&i, &everyN](value_t &h_) {
       i += everyN;
-      EXPECT_EQ(h_.GetEntries(), everyN * i);
+      EXPECT_EQ(h_.GetEntries(), i);
    });
    *h;
-   EXPECT_EQ(nEvents, everyN * i);
+   EXPECT_EQ(nEvents, i);
 }
 
 TEST_F(TDFCallbacks, JittedHisto1DWithFillHelper)
@@ -108,10 +108,10 @@ TEST_F(TDFCallbacks, JittedHisto1DWithFillHelper)
    ULong64_t everyN = 1ull;
    h.OnPartialResult(everyN, [&i, &everyN](value_t &h_) {
       i += everyN;
-      EXPECT_EQ(h_.GetEntries(), everyN * i);
+      EXPECT_EQ(h_.GetEntries(), i);
    });
    *h;
-   EXPECT_EQ(nEvents, everyN * i);
+   EXPECT_EQ(nEvents, i);
 }
 
 TEST_F(TDFCallbacks, Min)
@@ -123,6 +123,7 @@ TEST_F(TDFCallbacks, Min)
       EXPECT_LE(x, runningMin);
       runningMin = x;
    });
+   *m;
    EXPECT_DOUBLE_EQ(runningMin, *m);
 }
 
@@ -135,6 +136,7 @@ TEST_F(TDFCallbacks, JittedMin)
       EXPECT_LE(x, runningMin);
       runningMin = x;
    });
+   *m;
    EXPECT_DOUBLE_EQ(runningMin, *m);
 }
 
@@ -147,6 +149,7 @@ TEST_F(TDFCallbacks, Max)
       EXPECT_GE(x, runningMax);
       runningMax = x;
    });
+   *m;
    EXPECT_DOUBLE_EQ(runningMax, *m);
 }
 
@@ -159,6 +162,7 @@ TEST_F(TDFCallbacks, JittedMax)
       EXPECT_GE(x, runningMax);
       runningMax = x;
    });
+   *m;
    EXPECT_DOUBLE_EQ(runningMax, *m);
 }
 
@@ -205,6 +209,7 @@ TEST_F(TDFCallbacks, Count)
       ++i;
       EXPECT_EQ(c_, i);
    });
+   *c;
    EXPECT_EQ(*c, i);
 }
 

--- a/tree/treeplayer/test/dataframe/dataframe_callbacks.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_callbacks.cxx
@@ -1,10 +1,12 @@
 #include "ROOT/TDataFrame.hxx"
 #include "TRandom.h"
 #include "gtest/gtest.h"
+#include <limits>
 using namespace ROOT::Experimental;
 using namespace ROOT::Experimental::TDF;
 using namespace ROOT::Detail::TDF;
 
+/********* FIXTURES *********/
 // fixture that provides a TDF with no data-source and a single column "x" containing normal-distributed doubles
 class TDFCallbacks : public ::testing::Test {
 protected:
@@ -23,8 +25,10 @@ protected:
    TInterface<TLoopManager> tdf;
 };
 
+/********* TESTS *********/
 TEST_F(TDFCallbacks, Histo1DWithFillTOHelper)
 {
+   // Histo1D<double> + OnPartialResult + FillTOHelper
    auto h = tdf.Histo1D<double>({"", "", 128, -2., 2.}, "x");
    using value_t = typename decltype(h)::Value_t;
    ULong64_t i = 0ull;
@@ -34,10 +38,127 @@ TEST_F(TDFCallbacks, Histo1DWithFillTOHelper)
       EXPECT_EQ(h_.GetEntries(), everyN * i);
    });
    *h;
+   EXPECT_EQ(nEvents, everyN * i);
+}
+
+TEST_F(TDFCallbacks, JittedHisto1DWithFillTOHelper)
+{
+   // Histo1D + Jitting + OnPartialResult + FillTOHelper
+   auto h = tdf.Histo1D({"", "", 128, -2., 2.}, "x");
+   using value_t = typename decltype(h)::Value_t;
+   ULong64_t i = 0ull;
+   ULong64_t everyN = 1ull;
+   h.OnPartialResult(everyN, [&i, &everyN](value_t &h_) {
+      i += everyN;
+      EXPECT_EQ(h_.GetEntries(), everyN * i);
+   });
+   *h;
+   EXPECT_EQ(nEvents, everyN * i);
+}
+
+TEST_F(TDFCallbacks, Histo1DWithFillHelper)
+{
+   // Histo1D<double> + OnPartialResult + FillHelper
+   auto h = tdf.Histo1D<double>("x");
+   using value_t = typename decltype(h)::Value_t;
+   ULong64_t i = 0ull;
+   ULong64_t everyN = 1ull;
+   h.OnPartialResult(everyN, [&i, &everyN](value_t &h_) {
+      i += everyN;
+      EXPECT_EQ(h_.GetEntries(), everyN * i);
+   });
+   *h;
+   EXPECT_EQ(nEvents, everyN * i);
+}
+
+TEST_F(TDFCallbacks, JittedHisto1DWithFillHelper)
+{
+   // Histo1D + Jitting + OnPartialResult + FillHelper
+   auto h = tdf.Histo1D("x");
+   using value_t = typename decltype(h)::Value_t;
+   ULong64_t i = 0ull;
+   ULong64_t everyN = 1ull;
+   h.OnPartialResult(everyN, [&i, &everyN](value_t &h_) {
+      i += everyN;
+      EXPECT_EQ(h_.GetEntries(), everyN * i);
+   });
+   *h;
+   EXPECT_EQ(nEvents, everyN * i);
+}
+
+TEST_F(TDFCallbacks, Min)
+{
+   // Min + OnPartialResult
+   auto m = tdf.Min<double>("x");
+   double runningMin = std::numeric_limits<double>::max();
+   m.OnPartialResult(2, [&runningMin](double x) {
+      EXPECT_LE(x, runningMin);
+      runningMin = x;
+   });
+   EXPECT_DOUBLE_EQ(runningMin, *m);
+}
+
+TEST_F(TDFCallbacks, JittedMin)
+{
+   // Min + Jitting + OnPartialResult
+   auto m = tdf.Min("x");
+   double runningMin = std::numeric_limits<double>::max();
+   m.OnPartialResult(2, [&runningMin](double x) {
+      EXPECT_LE(x, runningMin);
+      runningMin = x;
+   });
+   EXPECT_DOUBLE_EQ(runningMin, *m);
+}
+
+TEST_F(TDFCallbacks, Max)
+{
+   // Max + OnPartialResult
+   auto m = tdf.Max<double>("x");
+   double runningMax = std::numeric_limits<double>::lowest();
+   m.OnPartialResult(2, [&runningMax](double x) {
+      EXPECT_GE(x, runningMax);
+      runningMax = x;
+   });
+   EXPECT_DOUBLE_EQ(runningMax, *m);
+}
+
+TEST_F(TDFCallbacks, JittedMax)
+{
+   // Max + Jitting + OnPartialResult
+   auto m = tdf.Max("x");
+   double runningMax = std::numeric_limits<double>::lowest();
+   m.OnPartialResult(2, [&runningMax](double x) {
+      EXPECT_GE(x, runningMax);
+      runningMax = x;
+   });
+   EXPECT_DOUBLE_EQ(runningMax, *m);
+}
+
+TEST_F(TDFCallbacks, Mean)
+{
+   // Mean + OnPartialResult
+   auto m = tdf.Mean<double>("x");
+   // TODO find a better way to check that the running mean makes sense
+   bool called = false;
+   m.OnPartialResult(nEvents / 2, [&called](double) { called = true; });
+   *m;
+   EXPECT_TRUE(called);
+}
+
+TEST_F(TDFCallbacks, JittedMean)
+{
+   // Mean + Jitting + OnPartialResult
+   auto m = tdf.Mean("x");
+   // TODO find a better way to check that the running mean makes sense
+   bool called = false;
+   m.OnPartialResult(nEvents / 2, [&called](double) { called = true; });
+   *m;
+   EXPECT_TRUE(called);
 }
 
 TEST_F(TDFCallbacks, MultipleCallbacks)
 {
+   // registration of multiple callbacks on the same partial result
    auto h = tdf.Histo1D<double>({"", "", 128, -2., 2.}, "x");
    using value_t = typename decltype(h)::Value_t;
    ULong64_t everyN = 1ull;
@@ -59,6 +180,7 @@ TEST_F(TDFCallbacks, MultipleCallbacks)
 
 TEST_F(TDFCallbacks, MultipleEventLoops)
 {
+   // callbacks must be de-registered after the event-loop is run
    auto h = tdf.Histo1D<double>({"", "", 128, -2., 2.}, "x");
    using value_t = typename decltype(h)::Value_t;
    ULong64_t i = 0ull;

--- a/tree/treeplayer/test/dataframe/dataframe_callbacks.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_callbacks.cxx
@@ -1,5 +1,6 @@
 #include "ROOT/TDataFrame.hxx"
 #include "TRandom.h"
+#include "TROOT.h"
 #include "gtest/gtest.h"
 #include <limits>
 using namespace ROOT::Experimental;
@@ -24,6 +25,38 @@ protected:
    TDFCallbacks() : fLoopManager(nEvents), tdf(DefineRandomCol()) {}
    TInterface<TLoopManager> tdf;
 };
+
+// fixture that enables implicit MT and provides a TDF with no data-source and a single column "x" containing
+// normal-distributed doubles
+class TDFCallbacksMT : public ::testing::Test {
+   class TIMTEnabler {
+   public:
+      TIMTEnabler(unsigned int nSlots) {
+         ROOT::EnableImplicitMT(nSlots);
+      }
+      ~TIMTEnabler() {
+         ROOT::DisableImplicitMT();
+      }
+   };
+
+protected:
+   const ULong64_t nEvents = 8ull; // must be initialized before fLoopManager
+   const unsigned int nSlots = 4u;
+
+private:
+   TIMTEnabler fIMTEnabler;
+   TDataFrame fLoopManager;
+   TInterface<TLoopManager> DefineRandomCol()
+   {
+      std::vector<TRandom> rs;
+      return fLoopManager.DefineSlot("x", [rs](unsigned int slot) mutable { return rs[slot].Gaus(); });
+   }
+
+protected:
+   TDFCallbacksMT() : fIMTEnabler(nSlots), fLoopManager(nEvents), tdf(DefineRandomCol()) {}
+   TInterface<TLoopManager> tdf;
+};
+
 
 /********* TESTS *********/
 TEST_F(TDFCallbacks, Histo1DWithFillTOHelper)
@@ -218,6 +251,26 @@ TEST_F(TDFCallbacks, OrderOfExecution)
    });
    *c;
    EXPECT_EQ(i, 0u);
+}
+
+TEST_F(TDFCallbacks, ExecuteOnce)
+{
+   // OnPartialResult(kOnce)
+   auto c = tdf.Count();
+   unsigned int callCount = 0;
+   c.OnPartialResult(0, [&callCount](ULong64_t) { callCount++; });
+   *c;
+   EXPECT_EQ(callCount, 1u);
+}
+
+TEST_F(TDFCallbacksMT, ExecuteOncePerSlot)
+{
+   // OnPartialResultSlot(kOnce)
+   auto c = tdf.Count();
+   std::atomic_uint callCount(0u);
+   c.OnPartialResultSlot(c.kOnce, [&callCount](unsigned int, ULong64_t) { callCount++; });
+   *c;
+   EXPECT_EQ(callCount, nSlots);
 }
 
 TEST_F(TDFCallbacks, MultipleCallbacks)


### PR DESCRIPTION
Users can now register one or more callbacks to TResultProxies (i.e.
the results of TDF actions). A callback is just a callable that takes
a reference to the result type as argument and is going to be invoked
by each worker thread once every N entries (users choose N).

It is meant to be used to inspect partial results of the analysis
while the event loop is still running.
For example, in a single-thread event loop, one can draw a histogram
and update the canvas every 100 entries like this:
    
```c++
auto h = tdf.Histo1D("x");
TCanvas c("c","x hist");
// update the canvas every 100 entries
h.RegisterCallback(100, [&c](TH1D &h_) { h_.Draw(); c.Update(); });
// trigger event loop, this `Draw` will be performed afterwards
h->Draw();
```

Each worker thread invokes callbacks sequentially, but the same callback
might be invoked concurrently by different worker threads if implicit multi-threading
is enabled.