### PR TITLE
[TDF] `Count` should really return ULong64_t, not unsigned

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
@@ -34,7 +34,6 @@ using namespace ROOT::TypeTraits;
 using namespace ROOT::Experimental::TDF;
 
 
-using Count_t = unsigned long;
 using Hist_t = ::TH1D;
 
 template <typename F>
@@ -61,12 +60,12 @@ public:
 };
 
 class CountHelper {
-   const std::shared_ptr<unsigned int> fResultCount;
-   std::vector<Count_t> fCounts;
+   const std::shared_ptr<ULong64_t> fResultCount;
+   std::vector<ULong64_t> fCounts;
 
 public:
    using BranchTypes_t = TypeList<>;
-   CountHelper(const std::shared_ptr<unsigned int> &resultCount, const unsigned int nSlots);
+   CountHelper(const std::shared_ptr<ULong64_t> &resultCount, const unsigned int nSlots);
    CountHelper(CountHelper &&) = default;
    CountHelper(const CountHelper &) = delete;
    void InitSlot(TTreeReader *, unsigned int) {}
@@ -391,7 +390,7 @@ extern template void MaxHelper::Exec(unsigned int, const std::vector<unsigned in
 
 class MeanHelper {
    const std::shared_ptr<double> fResultMean;
-   std::vector<Count_t> fCounts;
+   std::vector<ULong64_t> fCounts;
    std::vector<double> fSums;
 
 public:

--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -697,11 +697,11 @@ public:
    /// Useful e.g. for counting the number of entries passing a certain filter (see also `Report`).
    /// This action is *lazy*: upon invocation of this method the calculation is
    /// booked but not executed. See TResultProxy documentation.
-   TResultProxy<unsigned int> Count()
+   TResultProxy<ULong64_t> Count()
    {
       auto df = GetDataFrameChecked();
       const auto nSlots = fProxiedPtr->GetNSlots();
-      auto cSPtr = std::make_shared<unsigned int>(0);
+      auto cSPtr = std::make_shared<ULong64_t>(0);
       using Helper_t = TDFInternal::CountHelper;
       using Action_t = TDFInternal::TAction<Helper_t, Proxied>;
       df->Book(std::make_shared<Action_t>(Helper_t(cSPtr, nSlots), ColumnNames_t({}), *fProxiedPtr));

--- a/tree/treeplayer/src/TDFActionHelpers.cxx
+++ b/tree/treeplayer/src/TDFActionHelpers.cxx
@@ -14,7 +14,7 @@ namespace ROOT {
 namespace Internal {
 namespace TDF {
 
-CountHelper::CountHelper(const std::shared_ptr<unsigned int> &resultCount, const unsigned int nSlots)
+CountHelper::CountHelper(const std::shared_ptr<ULong64_t> &resultCount, const unsigned int nSlots)
    : fResultCount(resultCount), fCounts(nSlots, 0)
 {
 }
@@ -161,7 +161,7 @@ void MeanHelper::Finalize()
 {
    double sumOfSums = 0;
    for (auto &s : fSums) sumOfSums += s;
-   Count_t sumOfCounts = 0;
+   ULong64_t sumOfCounts = 0;
    for (auto &c : fCounts) sumOfCounts += c;
    *fResultMean = sumOfSums / (sumOfCounts > 0 ? sumOfCounts : 1);
 }


### PR DESCRIPTION
`Count` should return the same type that we use to enumerate entries, by definition.

A related PR in roottest updates `test_misc` to comply with the interface change.