### PR TITLE
shared_ptr-ize the llvm::Module*.

### DIFF
--- a/interpreter/cling/.clang-format
+++ b/interpreter/cling/.clang-format
@@ -1,6 +1,7 @@
 
 BasedOnStyle: LLVM
 IndentWidth: 2
+NamespaceIndentation: All
 ColumnLimit: 80
 
 Language: Cpp

--- a/interpreter/cling/include/cling/Interpreter/Transaction.h
+++ b/interpreter/cling/include/cling/Interpreter/Transaction.h
@@ -149,7 +149,7 @@ namespace cling {
 
     ///\brief The llvm Module containing the information that we will revert
     ///
-    std::unique_ptr<llvm::Module> m_Module;
+    std::shared_ptr<llvm::Module> m_Module;
 
     ///\brief The JIT handle allowing a removal of the Transaction's symbols.
     ///
@@ -463,8 +463,8 @@ namespace cling {
         m_NestedTransactions->clear();
     }
 
-    llvm::Module* getModule() const { return m_Module.get(); }
-    void setModule(std::unique_ptr<llvm::Module> M) { m_Module.swap(M); }
+    std::shared_ptr<llvm::Module> getModule() const { return m_Module; }
+    void setModule(std::unique_ptr<llvm::Module> M) { m_Module = std::move(M); }
 
     ExeUnloadHandle getExeUnloadHandle() const { return m_ExeUnload; }
     IncrementalExecutor* getExecutor() const { return m_Exe; }

--- a/interpreter/cling/lib/Interpreter/DeclUnloader.cpp
+++ b/interpreter/cling/lib/Interpreter/DeclUnloader.cpp
@@ -867,7 +867,7 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
         }
       }
 
-      llvm::Module* M = m_CurTransaction->getModule();
+      auto M = m_CurTransaction->getModule();
       GlobalValue* GV = M->getNamedValue(mangledName);
       if (GV) { // May be deferred decl and thus 0
         GlobalValueEraser GVEraser(m_CodeGen);

--- a/interpreter/cling/lib/Interpreter/IncrementalExecutor.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalExecutor.cpp
@@ -124,8 +124,8 @@ void IncrementalExecutor::shuttingDown() {
   }
 }
 
-void IncrementalExecutor::AddAtExitFunc(void (*func) (void*), void* arg,
-                                        llvm::Module* M) {
+void IncrementalExecutor::AddAtExitFunc(void (*func)(void*), void* arg,
+                                       const std::shared_ptr<llvm::Module>& M) {
   // Register a CXAAtExit function
   cling::internal::SpinLockGuard slg(m_AtExitFuncsSpinLock);
   m_AtExitFuncs[M].emplace_back(func, arg);
@@ -203,8 +203,8 @@ freeCallersOfUnresolvedSymbols(llvm::SmallVectorImpl<llvm::Function*>&
 
 IncrementalExecutor::ExecutionResult
 IncrementalExecutor::runStaticInitializersOnce(const Transaction& T) {
-  llvm::Module* m = T.getModule();
-  assert(m && "Module must not be null");
+  auto m = T.getModule();
+  assert(m.get() && "Module must not be null");
 
   // We don't care whether something was unresolved before.
   m_unresolvedSymbols.clear();

--- a/interpreter/cling/lib/Interpreter/Transaction.cpp
+++ b/interpreter/cling/lib/Interpreter/Transaction.cpp
@@ -51,6 +51,7 @@ namespace cling {
   }
 
   Transaction::~Transaction() {
+    assert(m_Module.use_count() <= 1 && "There is still a reference!");
     if (hasNestedTransactions())
       for (size_t i = 0; i < m_NestedTransactions->size(); ++i) {
         assert(((*m_NestedTransactions)[i]->getState() == kCommitted

--- a/interpreter/cling/lib/Interpreter/TransactionUnloader.cpp
+++ b/interpreter/cling/lib/Interpreter/TransactionUnloader.cpp
@@ -147,7 +147,8 @@ namespace cling {
     return cling::UnloadDecl(m_Sema, m_CodeGen, D);
   }
 
-  bool TransactionUnloader::unloadModule(llvm::Module* M) {
+  bool
+  TransactionUnloader::unloadModule(const std::shared_ptr<llvm::Module>& M) {
     for (auto& Func: M->functions())
       m_CodeGen->forgetGlobal(&Func);
     for (auto& Glob: M->globals())

--- a/interpreter/cling/lib/Interpreter/TransactionUnloader.h
+++ b/interpreter/cling/lib/Interpreter/TransactionUnloader.h
@@ -10,6 +10,8 @@
 #ifndef CLING_TRANSACTION_UNLOADER
 #define CLING_TRANSACTION_UNLOADER
 
+#include <memory>
+
 namespace llvm {
   class Module;
 }
@@ -40,7 +42,7 @@ namespace cling {
     bool unloadDeserializedDeclarations(Transaction* T,
                                         DeclUnloader& DeclU);
     bool unloadFromPreprocessor(Transaction* T, DeclUnloader& DeclU);
-    bool unloadModule(llvm::Module* M);
+    bool unloadModule(const std::shared_ptr<llvm::Module>& M);
 
   public:
     TransactionUnloader(cling::Interpreter* I, clang::Sema* Sema,


### PR DESCRIPTION
This is in prepare for the upcoming llvm upgrade. The future orc jit compile
layer needs a std::shared_ptr<llvm::Module>. The current design passes a
llvm::Module* around and any conversions to a shared_ptr cause the
destruction of the llvm::Module which is a long-lived object in cling.