### PR TITLE
Column aliases can be defined by the user

### DIFF
--- a/README/ReleaseNotes/v612/index.md
+++ b/README/ReleaseNotes/v612/index.md
@@ -98,6 +98,7 @@ large TClonesArray where each element contains another small vector container.
   - Users can now configure Snapshot to use different file open modes ("RECREATE" or "UPDATE"), compression level, compression algrotihm, TTree split-level and autoflush settings
   - Python tutorials show the new "tuple-initialisation" feature of PyROOT (see below)
   - The possibility to read from data sources was added. An interface for all data sources, TDataSource, is provided by ROOT. Two example data sources have been provided too: the TRootDS and the TTrivialDS. The former allows to read via the novel data source mechanism ROOT data, while the latter is a simple generator, created for testing and didactic purposes. It is therefore now possible to interface *any* kind of dataset/data format to ROOT as long as an adaptor which implements the pure virtual methods of the TDataSource interface can be written in C++.
+  - Column can be aliased with the TInterface method Alias: `auto histo = mytdf.Alias("myAlias", "myColumn").Histo1D("myAlias");`
 
 ## Histogram Libraries
 

--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -110,8 +110,7 @@ using TmpBranchBasePtr_t = std::shared_ptr<TCustomColumnBase>;
 
 Long_t JitTransformation(void *thisPtr, std::string_view methodName, std::string_view interfaceTypeName,
                          std::string_view name, std::string_view expression,
-                         const std::map<std::string, std::string>& aliasMap,
-                         TObjArray *branches,
+                         const std::map<std::string, std::string> &aliasMap, TObjArray *branches,
                          const std::vector<std::string> &customColumns,
                          const std::map<std::string, TmpBranchBasePtr_t> &tmpBookedBranches, TTree *tree,
                          std::string_view returnTypeName, TDataSource *ds);
@@ -435,8 +434,7 @@ public:
    /// \param[in] alias name of the column alias
    /// \param[in] columnName of the column to be aliased
    /// Aliasing an alias is supported.
-   TInterface<Proxied>
-   Alias(std::string_view alias, std::string_view columnName)
+   TInterface<Proxied> Alias(std::string_view alias, std::string_view columnName)
    {
       // The symmetry with Define is clear. We want to:
       // - Create globally the alias and return this very node, unchanged
@@ -450,7 +448,8 @@ public:
       TDFInternal::CheckCustomColumn(alias, loopManager->GetTree(), fValidCustomColumns, dsColumnNames);
 
       const auto validColumnName =
-         TDFInternal::GetValidatedColumnNames(*loopManager, 1, {std::string(columnName)}, fValidCustomColumns, fDataSource)[0];
+         TDFInternal::GetValidatedColumnNames(*loopManager, 1, {std::string(columnName)},
+                                              fValidCustomColumns, fDataSource)[0];
 
       loopManager->AddColumnAlias(std::string(alias), validColumnName);
       TInterface<Proxied> newInterface(fProxiedPtr, fImplWeakPtr, fValidCustomColumns, fDataSource);

--- a/tree/treeplayer/inc/ROOT/TDFNodes.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFNodes.hxx
@@ -105,6 +105,7 @@ class TLoopManager : public std::enable_shared_from_this<TLoopManager> {
    std::string fToJit;        ///< string containing all `BuildAndBook` actions that should be jitted before running
    const std::unique_ptr<TDataSource> fDataSource; ///< Owning pointer to a data-source object. Null if no data-source
    ColumnNames_t fDefinedDataSourceColumns; ///< List of data-source columns that have been `Define`d so far
+   std::map<std::string, std::string> fAliasColumnNameMap; ///< ColumnNameAlias-columnName pairs
 
    void RunEmptySourceMT();
    void RunEmptySource();
@@ -155,6 +156,9 @@ public:
    void Jit(const std::string &s) { fToJit.append(s); }
    const ColumnNames_t &GetDefinedDataSourceColumns() const { return fDefinedDataSourceColumns; }
    void AddDataSourceColumn(std::string_view name) { fDefinedDataSourceColumns.emplace_back(name); }
+   void AddColumnAlias(const std::string &alias, const std::string &colName) { fAliasColumnNameMap[alias] = colName; }
+   const std::map<std::string, std::string> &GetAliasMap() const { return fAliasColumnNameMap; }
+
 };
 } // end ns TDF
 } // end ns Detail

--- a/tree/treeplayer/src/TDFInterface.cxx
+++ b/tree/treeplayer/src/TDFInterface.cxx
@@ -12,6 +12,7 @@
 #include "TRegexp.h"
 
 #include "ROOT/TDFInterface.hxx"
+#include "ROOT/TSeq.hxx"
 
 #include <vector>
 #include <string>
@@ -33,7 +34,8 @@ namespace TDF {
 // Match expression against names of branches passed as parameter
 // Return vector of names of the branches used in the expression
 std::vector<std::string> FindUsedColumnNames(std::string_view expression, TObjArray *branches,
-                                             const ColumnNames_t &customColumns, const ColumnNames_t &dsColumns)
+                                             const ColumnNames_t &customColumns, const ColumnNames_t &dsColumns,
+                                             const std::map<std::string, std::string> &aliasMap)
 {
    // To help matching the regex
    const std::string paddedExpr = " " + std::string(expression) + " ";
@@ -43,7 +45,7 @@ std::vector<std::string> FindUsedColumnNames(std::string_view expression, TObjAr
    std::vector<std::string> usedBranches;
 
    // Check which custom columns match
-   for (auto brName : customColumns) {
+   for (auto &brName : customColumns) {
       std::string bNameRegexContent = regexBit + brName + regexBit;
       TRegexp bNameRegex(bNameRegexContent.c_str());
       if (-1 != bNameRegex.Index(paddedExpr.c_str(), &paddedExprLen)) {
@@ -64,13 +66,25 @@ std::vector<std::string> FindUsedColumnNames(std::string_view expression, TObjAr
    }
 
    // Check which data-source columns match
-   for (auto col : dsColumns) {
+   for (auto &col : dsColumns) {
       std::string bNameRegexContent = regexBit + col + regexBit;
       TRegexp bNameRegex(bNameRegexContent.c_str());
       if (-1 != bNameRegex.Index(paddedExpr.c_str(), &paddedExprLen)) {
-         // if not already found among the custom columns
+         // if not already found among the other columns
          if (std::find(usedBranches.begin(), usedBranches.end(), col) == usedBranches.end())
             usedBranches.emplace_back(col);
+      }
+   }
+
+   // Check which aliases match
+   for (auto &alias_colName : aliasMap) {
+      auto &alias = alias_colName.first;
+      std::string bNameRegexContent = regexBit + alias + regexBit;
+      TRegexp bNameRegex(bNameRegexContent.c_str());
+      if (-1 != bNameRegex.Index(paddedExpr.c_str(), &paddedExprLen)) {
+         // if not already found among the other columns
+         if (std::find(usedBranches.begin(), usedBranches.end(), alias) == usedBranches.end())
+            usedBranches.emplace_back(alias);
       }
    }
 
@@ -80,13 +94,14 @@ std::vector<std::string> FindUsedColumnNames(std::string_view expression, TObjAr
 // Jit a string filter or a string temporary column, call this->Define or this->Filter as needed
 // Return pointer to the new functional chain node returned by the call, cast to Long_t
 Long_t JitTransformation(void *thisPtr, std::string_view methodName, std::string_view interfaceTypeName,
-                         std::string_view name, std::string_view expression, TObjArray *branches,
+                         std::string_view name, std::string_view expression,
+                         const std::map<std::string, std::string> &aliasMap, TObjArray *branches,
                          const std::vector<std::string> &customColumns,
                          const std::map<std::string, TmpBranchBasePtr_t> &tmpBookedBranches, TTree *tree,
                          std::string_view returnTypeName, TDataSource *ds)
 {
    const auto &dsColumns = ds ? ds->GetColumnNames() : ColumnNames_t{};
-   auto usedBranches = FindUsedColumnNames(expression, branches, customColumns, dsColumns);
+   auto usedBranches = FindUsedColumnNames(expression, branches, customColumns, dsColumns, aliasMap);
    auto exprNeedsVariables = !usedBranches.empty();
 
    // Move to the preparation of the jitting
@@ -98,12 +113,17 @@ Long_t JitTransformation(void *thisPtr, std::string_view methodName, std::string
    dummyDecl << "namespace __tdf_" << std::to_string(iNs++) << "{ void f(){\n";
 
    // Declare variables with the same name as the column used by this transformation
+   auto aliasMapEnd = aliasMap.end();
    if (exprNeedsVariables) {
-      for (auto brName : usedBranches) {
+      for (auto &brName : usedBranches) {
+         // Here we replace on the fly the brName with the real one in case brName it's an alias
+         // This is then used to get the type. The variable name will be brName;
+         auto aliasMapIt = aliasMap.find(brName);
+         auto &realBrName = aliasMapEnd == aliasMapIt ? brName : aliasMapIt->second;
          // The map is a const reference, so no operator[]
-         auto tmpBrIt = tmpBookedBranches.find(brName);
+         auto tmpBrIt = tmpBookedBranches.find(realBrName);
          auto tmpBr = tmpBrIt == tmpBookedBranches.end() ? nullptr : tmpBrIt->second.get();
-         auto brTypeName = ColumnName2ColumnTypeName(brName, tree, tmpBr, ds);
+         auto brTypeName = ColumnName2ColumnTypeName(realBrName, tree, tmpBr, ds);
          dummyDecl << brTypeName << " " << brName << ";\n";
          usedBranchesTypes.emplace_back(brTypeName);
       }
@@ -128,6 +148,8 @@ Long_t JitTransformation(void *thisPtr, std::string_view methodName, std::string
       // temporaries converted from TTreeReaderArrays.
       if (usedBranchesTypes[i].find_first_of("std::array_view<") == 0u)
          ss << "const ";
+      // Here we do not replace anything: the name of the parameters of the lambda does not need to be the real
+      // column name, it must be an alias to compile.
       ss << usedBranchesTypes[i] << "& " << usedBranches[i] << ", ";
    }
    if (!usedBranchesTypes.empty())
@@ -148,7 +170,10 @@ Long_t JitTransformation(void *thisPtr, std::string_view methodName, std::string
    }
    ss << filterLambda << ", {";
    for (auto brName : usedBranches) {
-      ss << "\"" << brName << "\", ";
+      // Here we selectively replace the brName with the real column name if it's necessary.
+      auto aliasMapIt = aliasMap.find(brName);
+      auto &realBrName = aliasMapEnd == aliasMapIt ? brName : aliasMapIt->second;
+      ss << "\"" << realBrName << "\", ";
    }
    if (exprNeedsVariables)
       ss.seekp(-2, ss.cur); // remove the last ",
@@ -273,7 +298,7 @@ ColumnNames_t GetValidatedColumnNames(TLoopManager &lm, const unsigned int nColu
                                       const ColumnNames_t &validCustomColumns, TDataSource *ds)
 {
    const auto &defaultColumns = lm.GetDefaultColumnNames();
-   const auto selectedColumns = SelectColumns(nColumns, columns, defaultColumns);
+   auto selectedColumns = SelectColumns(nColumns, columns, defaultColumns);
    const auto unknownColumns = FindUnknownColumns(selectedColumns, lm.GetTree(), validCustomColumns,
                                                   ds ? ds->GetColumnNames() : ColumnNames_t{});
 
@@ -281,11 +306,23 @@ ColumnNames_t GetValidatedColumnNames(TLoopManager &lm, const unsigned int nColu
       // throw
       std::stringstream unknowns;
       std::string delim = unknownColumns.size() > 1 ? "s: " : ": "; // singular/plural
-      for (auto &unknown : unknownColumns) {
-         unknowns << delim << unknown;
+      for (auto &unknownColumn : unknownColumns) {
+         unknowns << delim << unknownColumn;
          delim = ',';
       }
       throw std::runtime_error("Unknown column" + unknowns.str());
+   }
+
+   // Now we need to check within the aliases if some of the yet unknown names can be recovered
+   auto &aliasMap = lm.GetAliasMap();
+   auto aliasMapEnd = aliasMap.end();
+
+   for (auto idx : ROOT::TSeqU(selectedColumns.size())) {
+      const auto &colName = selectedColumns[idx];
+      const auto aliasColumnNameIt = aliasMap.find(colName);
+      if (aliasMapEnd != aliasColumnNameIt) {
+         selectedColumns[idx] = aliasColumnNameIt->second;
+      }
    }
 
    return selectedColumns;

--- a/tree/treeplayer/test/CMakeLists.txt
+++ b/tree/treeplayer/test/CMakeLists.txt
@@ -8,6 +8,7 @@ ROOT_ADD_GTEST(dataframe_interface dataframe/dataframe_interface.cxx LIBRARIES T
 ROOT_ADD_GTEST(dataframe_utils dataframe/dataframe_utils.cxx LIBRARIES TreePlayer)
 ROOT_ADD_GTEST(dataframe_nodes dataframe/dataframe_nodes.cxx LIBRARIES TreePlayer)
 ROOT_ADD_GTEST(dataframe_histomodels dataframe/dataframe_histomodels.cxx LIBRARIES TreePlayer)
+ROOT_ADD_GTEST(dataframe_alias dataframe/dataframe_aliases.cxx LIBRARIES TreePlayer)
 ROOT_ADD_GTEST(datasource_trivial dataframe/datasource_trivial.cxx LIBRARIES TreePlayer)
 ROOT_ADD_GTEST(datasource_root dataframe/datasource_root.cxx LIBRARIES TreePlayer)
 ROOT_ADD_PYUNITTEST(dataframe_histograms dataframe/dataframe_histograms.py)

--- a/tree/treeplayer/test/dataframe/dataframe_aliases.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_aliases.cxx
@@ -1,0 +1,41 @@
+#include "ROOT/TDataFrame.hxx"
+
+#include "gtest/gtest.h"
+
+using namespace ROOT::Experimental;
+
+TEST(Aliases, DefineOnAlias)
+{
+   TDataFrame tdf(2);
+   int i = 1;
+   auto m = tdf.Define("c0", [&i]() { return i++; })
+               .Alias("c1", "c0")
+               .Define("c2", [](int j) { return j + 1; }, {"c1"})
+               .Mean<int>("c2");
+   EXPECT_DOUBLE_EQ(2.5, *m);
+}
+
+TEST(Aliases, FilterOnAlias)
+{
+   TDataFrame tdf(2);
+   int i = 1;
+   auto c =
+      tdf.Define("c0", [&i]() { return i++; }).Alias("c1", "c0").Filter([](int j) { return j > 1; }, {"c1"}).Count();
+   EXPECT_EQ(1U, *c);
+}
+
+TEST(Aliases, DefineOnAliasJit)
+{
+   TDataFrame tdf(2);
+   int i = 1;
+   auto m = tdf.Define("c0", [&i]() { return i++; }).Alias("c1", "c0").Define("c2", "c1+1").Mean<int>("c2");
+   EXPECT_DOUBLE_EQ(2.5, *m);
+}
+
+TEST(Aliases, FilterOnAliasJit)
+{
+   TDataFrame tdf(2);
+   int i = 1;
+   auto c = tdf.Define("c0", [&i]() { return i++; }).Alias("c1", "c0").Filter("c1>1").Count();
+   EXPECT_EQ(1U, *c);
+}

--- a/tree/treeplayer/test/dataframe/dataframe_interface.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_interface.cxx
@@ -36,3 +36,56 @@ TEST(TDataFrameInterface, CreateFromTree)
    auto c = tdf.Count();
    EXPECT_EQ(0U, *c);
 }
+
+TEST(TDataFrameInterface, CreateAliases)
+{
+   TDataFrame tdf(1);
+   auto aliased_tdf = tdf.Define("c0", []() { return 0; }).Alias("c1", "c0").Alias("c2", "c0").Alias("c3", "c1");
+   auto c = aliased_tdf.Count();
+   EXPECT_EQ(1U, *c);
+
+   int ret(1);
+   try {
+      aliased_tdf.Alias("c4", "c");
+   } catch (const std::runtime_error &e) {
+      ret = 0;
+   }
+   EXPECT_EQ(0, ret) << "No exception thrown when trying to alias a non-existing column.";
+
+   ret = 1;
+   try {
+      aliased_tdf.Alias("c0", "c2");
+   } catch (const std::runtime_error &e) {
+      ret = 0;
+   }
+   EXPECT_EQ(0, ret) << "No exception thrown when specifying an alias name which is the name of a column.";
+
+   ret = 1;
+   try {
+      aliased_tdf.Alias("c2", "c1");
+   } catch (const std::runtime_error &e) {
+      ret = 0;
+   }
+   EXPECT_EQ(0, ret) << "No exception thrown when re-using an alias for a different column.";
+}
+
+TEST(TDataFrameInterface, CheckAliasesPerChain)
+{
+   TDataFrame tdf(1);
+   auto d = tdf.Define("c0", []() { return 0; });
+   // Now branch the graph
+   auto ok = [](){return true;};
+   auto f0 = d.Filter(ok);
+   auto f1 = d.Filter(ok);
+   auto f0a = f0.Alias("c1", "c0");
+   // must work
+   auto f0aa = f0a.Alias("c2", "c1");
+   // must fail
+   auto ret = 1;
+   try {
+      auto f1a = f1.Alias("c2", "c1");
+   } catch (const std::runtime_error &e) {
+      ret = 0;
+   }
+   EXPECT_EQ(0, ret) << "No exception thrown when trying to alias a non-existing column.";
+}

--- a/tree/treeplayer/test/dataframe/dataframe_interface.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_interface.cxx
@@ -74,7 +74,7 @@ TEST(TDataFrameInterface, CheckAliasesPerChain)
    TDataFrame tdf(1);
    auto d = tdf.Define("c0", []() { return 0; });
    // Now branch the graph
-   auto ok = [](){return true;};
+   auto ok = []() { return true; };
    auto f0 = d.Filter(ok);
    auto f1 = d.Filter(ok);
    auto f0a = f0.Alias("c1", "c0");


### PR DESCRIPTION
Highlights:
- Aliases to columns can be defined
- Aliases to column aliases can be defined
- Early detection of mistakes: non-existing column names, incoherent aliasing
- Support of aliased columns in actions and transformations, also jitted