### PR TITLE
[WIP] Remove ModuleGenForModules

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -2999,7 +2999,7 @@ int FinalizeStreamerInfoWriting(cling::Interpreter &interp, bool writeEmptyRootP
    if (!gDriverConfig->fCloseStreamerInfoROOTFile)
       return 0;
 
-   interp.parseForModule("#include \"TStreamerInfo.h\"\n"
+   interp.declare(         "#include \"TStreamerInfo.h\"\n"
                            "#include \"TFile.h\"\n"
                            "#include \"TObjArray.h\"\n"
                            "#include \"TVirtualArray.h\"\n"

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1847,7 +1847,7 @@ void TCling::RegisterModule(const char* modulename,
          SuspendAutoParsing autoParseRaii(this);
 
          const cling::Transaction* watermark = fInterpreter->getLastTransaction();
-         cling::Interpreter::CompilationResult compRes = fInterpreter->parseForModule(code.Data());
+         cling::Interpreter::CompilationResult compRes = fInterpreter->declare(code.Data());
          if (isACLiC) {
             // Register an unload point.
             fMetaProcessor->registerUnloadPoint(watermark, headers[0]);
@@ -5448,7 +5448,7 @@ static cling::Interpreter::CompilationResult ExecAutoParse(const char *what,
       #endif
       #endif
 
-      cr = interpreter->parseForModule(code);
+      cr = interpreter->declare(code);
    }
    return cr;
 }

--- a/interpreter/cling/include/cling/Interpreter/CompilationOptions.h
+++ b/interpreter/cling/include/cling/Interpreter/CompilationOptions.h
@@ -47,11 +47,6 @@ namespace cling {
     ///
     unsigned CodeGeneration : 1;
 
-    ///\brief When generating executable, select whether to generate all
-    /// the code (when false) or just the code needed when the input is
-    /// describing code coming from an existing library.
-    unsigned CodeGenerationForModule : 1;
-
     ///\brief Prompt input can look weird for the compiler, e.g.
     /// void __cling_prompt() { sin(0.1); } // warning: unused function call
     /// This flag suppresses these warnings; it should be set whenever input
@@ -78,7 +73,6 @@ namespace cling {
       DynamicScoping = 0;
       Debug = 0;
       CodeGeneration = 1;
-      CodeGenerationForModule = 0;
       IgnorePromptDiags = 0;
       OptLevel = 2;
       CheckPointerValidity = 1;
@@ -92,7 +86,6 @@ namespace cling {
         DynamicScoping        == Other.DynamicScoping &&
         Debug                 == Other.Debug &&
         CodeGeneration        == Other.CodeGeneration &&
-        CodeGenerationForModule == Other.CodeGenerationForModule &&
         IgnorePromptDiags     == Other.IgnorePromptDiags &&
         CheckPointerValidity  == Other.CheckPointerValidity &&
         OptLevel              == Other.OptLevel &&
@@ -107,7 +100,6 @@ namespace cling {
         DynamicScoping        != Other.DynamicScoping ||
         Debug                 != Other.Debug ||
         CodeGeneration        != Other.CodeGeneration ||
-        CodeGenerationForModule != Other.CodeGenerationForModule ||
         IgnorePromptDiags     != Other.IgnorePromptDiags ||
         CheckPointerValidity  != Other.CheckPointerValidity ||
         OptLevel              != Other.OptLevel ||

--- a/interpreter/cling/include/cling/Interpreter/Interpreter.h
+++ b/interpreter/cling/include/cling/Interpreter/Interpreter.h
@@ -485,19 +485,6 @@ namespace cling {
     ///
     CompilationResult loadModuleForHeader(const std::string& headerFile);
 
-    ///\brief Parses input line, which doesn't contain statements. Code
-    /// generation needed to make the module functional.
-    ///
-    /// Same as declare without most of the codegening.  Only a few
-    /// things, like inline function are codegened.  Useful when a
-    /// library is loaded and the header files need to be imported.
-    ///
-    ///\param[in] input - The input containing the declarations.
-    ///
-    ///\returns Whether the operation was fully successful.
-    ///
-    CompilationResult parseForModule(const std::string& input);
-
     ///\brief Code completes user input.
     ///
     /// The interface circumvents the most of the extra work necessary to

--- a/interpreter/cling/lib/Interpreter/DeclCollector.cpp
+++ b/interpreter/cling/lib/Interpreter/DeclCollector.cpp
@@ -112,8 +112,6 @@ namespace cling {
   bool DeclCollector::comesFromASTReader(DeclGroupRef DGR) const {
     assert(!DGR.isNull() && "DeclGroupRef is Null!");
     assertHasTransaction(m_CurTransaction);
-    if (m_CurTransaction->getCompilationOpts().CodeGenerationForModule)
-      return true;
 
     // Take the first/only decl in the group.
     Decl* D = *DGR.begin();

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -719,28 +719,6 @@ namespace cling {
   }
 
   Interpreter::CompilationResult
-  Interpreter::parseForModule(const std::string& input) {
-    CompilationOptions CO = makeDefaultCompilationOpts();
-    CO.CodeGenerationForModule = 1;
-    CO.DeclarationExtraction = 0;
-    CO.ValuePrinting = 0;
-    CO.ResultEvaluation = 0;
-
-    // When doing parseForModule avoid warning about the user code
-    // being loaded ... we probably might as well extend this to
-    // ALL warnings ... but this will suffice for now (working
-    // around a real bug in QT :().
-    DiagnosticsEngine& Diag = getDiagnostics();
-    Diag.setSeverity(clang::diag::warn_field_is_uninit,
-                     clang::diag::Severity::Ignored, SourceLocation());
-    CompilationResult Result = DeclareInternal(input, CO);
-    Diag.setSeverity(clang::diag::warn_field_is_uninit,
-                     clang::diag::Severity::Warning, SourceLocation());
-    return Result;
-  }
-
-
-  Interpreter::CompilationResult
   Interpreter::CodeCompleteInternal(const std::string& input, unsigned offset) {
 
     CompilationOptions CO = makeDefaultCompilationOpts();

--- a/interpreter/cling/lib/Interpreter/Transaction.cpp
+++ b/interpreter/cling/lib/Interpreter/Transaction.cpp
@@ -376,8 +376,6 @@ namespace cling {
 
   bool Transaction::comesFromASTReader(DeclGroupRef DGR) const {
     assert(!DGR.isNull() && "DeclGroupRef is Null!");
-    if (getCompilationOpts().CodeGenerationForModule)
-      return true;
 
     // Take the first/only decl in the group.
     Decl* D = *DGR.begin();

--- a/interpreter/cling/lib/Interpreter/TransactionUnloader.cpp
+++ b/interpreter/cling/lib/Interpreter/TransactionUnloader.cpp
@@ -79,6 +79,7 @@ namespace cling {
                                                    DeclUnloader& DeclU) {
     //FIXME: Terrible hack, we *must* get rid of parseForModule by implementing
     // a header file generator in cling.
+    // We need to replace this.
     bool Successful = true;
     for (Transaction::const_reverse_iterator I = T->deserialized_rdecls_begin(),
            E = T->deserialized_rdecls_end(); I != E; ++I) {
@@ -122,14 +123,6 @@ namespace cling {
     Successful = unloadDeclarations(T, DeclU) && Successful;
     Successful = unloadDeserializedDeclarations(T, DeclU) && Successful;
     Successful = unloadFromPreprocessor(T, DeclU) && Successful;
-
-#ifndef NDEBUG
-    //FIXME: Move the nested transaction marker out of the decl lists and
-    // reenable this assertion.
-    //size_t DeclSize = std::distance(T->decls_begin(), T->decls_end());
-    //if (T->getCompilationOpts().CodeGenerationForModule)
-    //  assert (!DeclSize && "No parsed decls must happen in parse for module");
-#endif
 
     if (Successful)
       T->setState(Transaction::kRolledBack);


### PR DESCRIPTION
So, we just removed the assert that makes us aware that we need to
rethink this flag. I don't see a clear solution at the moment, but
this PR at least makes us aware that we need to solve this issue.

For now I just removed it and we see what exactly Jenkins complains
about when it runs the tests.