### PR TITLE
Simplify llvm::Module emission in the JIT.

### DIFF
--- a/interpreter/cling/include/cling/Interpreter/Interpreter.h
+++ b/interpreter/cling/include/cling/Interpreter/Interpreter.h
@@ -764,10 +764,6 @@ namespace cling {
     ///
     void AddAtExitFunc(void (*Func) (void*), void* Arg);
 
-    ///\brief Forwards to cling::IncrementalExecutor::addModule.
-    ///
-    void addModule(llvm::Module* module, int OptLevel);
-
     void GenerateAutoloadingMap(llvm::StringRef inFile, llvm::StringRef outFile,
                                 bool enableMacros = false, bool enableLogs = true);
 

--- a/interpreter/cling/include/cling/Interpreter/Transaction.h
+++ b/interpreter/cling/include/cling/Interpreter/Transaction.h
@@ -64,11 +64,6 @@ namespace cling {
       kCCINumStates
     };
 
-    ///\brief Sort of opaque handle for unloading a transaction from the JIT.
-    struct ExeUnloadHandle {
-      void* m_Opaque;
-    };
-
     ///\brief Each declaration group came through different interface at
     /// different time. We are being conservative and we want to keep all the
     /// call sequence that originally occurred in clang.
@@ -150,10 +145,6 @@ namespace cling {
     ///\brief The llvm Module containing the information that we will revert
     ///
     std::shared_ptr<llvm::Module> m_Module;
-
-    ///\brief The JIT handle allowing a removal of the Transaction's symbols.
-    ///
-    ExeUnloadHandle m_ExeUnload;
 
     ///\brief The Executor to use m_ExeUnload on.
     ///
@@ -466,12 +457,7 @@ namespace cling {
     std::shared_ptr<llvm::Module> getModule() const { return m_Module; }
     void setModule(std::unique_ptr<llvm::Module> M) { m_Module = std::move(M); }
 
-    ExeUnloadHandle getExeUnloadHandle() const { return m_ExeUnload; }
     IncrementalExecutor* getExecutor() const { return m_Exe; }
-    void setExeUnloadHandle(IncrementalExecutor* Exe, ExeUnloadHandle H) {
-      m_Exe = Exe;
-      m_ExeUnload = H;
-    }
 
     clang::FunctionDecl* getWrapperFD() const { return m_WrapperFD; }
 

--- a/interpreter/cling/lib/Interpreter/IncrementalJIT.h
+++ b/interpreter/cling/lib/Interpreter/IncrementalJIT.h
@@ -12,12 +12,6 @@
 
 #include "cling/Utils/Output.h"
 
-#include <map>
-#include <memory>
-#include <set>
-#include <string>
-#include <vector>
-
 #include "llvm/IR/Mangler.h"
 #include "llvm/IR/GlobalValue.h"
 #include "llvm/ExecutionEngine/JITEventListener.h"
@@ -28,6 +22,12 @@
 #include "llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h"
 #include "llvm/ExecutionEngine/RTDyldMemoryManager.h"
 #include "llvm/Target/TargetMachine.h"
+
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
 
 namespace llvm {
 class Module;
@@ -169,10 +169,8 @@ private:
   std::map<ObjectLayerT::ObjSetHandleT, SectionAddrSet, ObjSetHandleCompare>
     m_UnfinalizedSections;
 
-  ///\brief Vector of ModuleSetHandleT. UnloadHandles index into that
-  /// vector.
-  std::vector<ModuleSetHandleT> m_UnloadPoints;
-
+  ///\brief Mapping between \c llvm::Module* and \c ModuleSetHandleT.
+  std::map<llvm::Module*, ModuleSetHandleT> m_UnloadPoints;
 
   std::string Mangle(llvm::StringRef Name) {
     stdstrstream MangledName;
@@ -203,8 +201,8 @@ public:
   llvm::JITSymbol getSymbolAddressWithoutMangling(const std::string& Name,
                                                        bool AlsoInProcess);
 
-  size_t addModules(std::vector<llvm::Module*>&& modules);
-  void removeModules(size_t handle);
+  void addModule(const std::shared_ptr<llvm::Module>& module);
+  void removeModule(const std::shared_ptr<llvm::Module>& module);
 
   IncrementalExecutor& getParent() const { return m_Parent; }
 

--- a/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
@@ -542,10 +542,8 @@ namespace cling {
 
       std::unique_ptr<llvm::Module> M(getCodeGenerator()->ReleaseModule());
 
-      if (M) {
-        m_Interpreter->addModule(M.get(), T->getCompilationOpts().OptLevel);
+      if (M)
         T->setModule(std::move(M));
-      }
 
       if (T->getIssuedDiags() != Transaction::kNone) {
         // Module has been released from Codegen, reset the Diags now.

--- a/interpreter/cling/lib/Interpreter/Transaction.cpp
+++ b/interpreter/cling/lib/Interpreter/Transaction.cpp
@@ -42,7 +42,6 @@ namespace cling {
     m_IssuedDiags = kNone;
     m_Opts = CompilationOptions();
     m_Module = 0;
-    m_ExeUnload = {(void*)(size_t)-1};
     m_WrapperFD = 0;
     m_Next = 0;
     //m_Sema = S;

--- a/interpreter/cling/lib/Interpreter/TransactionUnloader.cpp
+++ b/interpreter/cling/lib/Interpreter/TransactionUnloader.cpp
@@ -101,9 +101,7 @@ namespace cling {
 
     bool Successful = true;
     if (getExecutor() && T->getModule()) {
-      Successful = getExecutor()->unloadFromJIT(T->getModule(),
-                                                T->getExeUnloadHandle())
-        && Successful;
+      Successful = getExecutor()->unloadModule(T->getModule()) && Successful;
 
       // Cleanup the module from unused global values.
       // if (T->getModule()) {


### PR DESCRIPTION
This teaches again the IncrementalExecutor to emit only one module at a time. In the old MCJIT days, the API worked with module sets and cling assumed llvm's jit infrastructure is moving in this direction.

LLVM 5.0 moves away from this concept and works with single llvm::Modules. This patch will make the upgrade to LLVM 5.0 smoother.