### PR TITLE
Fixing running of fast-math enabled macroses in interpreter

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1161,7 +1161,7 @@ TCling::TCling(const char *name, const char *title)
 #endif
 
 #ifdef R__FAST_MATH
-      interpArgs.push_back("-ffast-math");
+   interpArgs.push_back("-ffast-math");
 #endif
 
 #ifdef R__EXTERN_LLVMDIR

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1160,6 +1160,10 @@ TCling::TCling(const char *name, const char *title)
    }
 #endif
 
+#ifdef R__FAST_MATH
+      interpArgs.push_back("-ffast-math");
+#endif
+
 #ifdef R__EXTERN_LLVMDIR
    TString llvmResourceDir = R__EXTERN_LLVMDIR;
 #else


### PR DESCRIPTION
Adding -ffast-math flag to really activate Optimized builds for interpreter