### PR TITLE
ROOT-9002 TBufferMerger buffered flush to disk

### DIFF
--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -75,6 +75,16 @@ public:
     */
    void RegisterCallback(const std::function<void(void)> &f);
 
+   /** By default, TBufferMerger will call TFileMerger::PartialMerge() for each
+    *  buffer pushed onto its merge queue. This function lets the user change
+    *  this behaviour by telling TBufferMerger to accumulate at least @param size
+    *  bytes in memory before performing a partial merge and flushing to disk.
+    *  This can be useful to avoid an excessive amount of work to happen in the
+    *  output thread, as the number of TTree headers (which require compression)
+    *  written to disk can be reduced.
+    */
+   void SetAutoSave(size_t size);
+
    friend class TBufferMergerFile;
 
 private:
@@ -93,6 +103,7 @@ private:
    const std::string fName;
    const std::string fOption;
    const Int_t fCompress;
+   size_t fAutoSave;                                             //< AutoSave only every fAutoSave bytes
    std::mutex fQueueMutex;                                       //< Mutex used to lock fQueue
    std::condition_variable fDataAvailable;                       //< Condition variable used to wait for data
    std::queue<TBufferFile *> fQueue;                             //< Queue to which data is pushed and merged

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -21,7 +21,7 @@ namespace ROOT {
 namespace Experimental {
 
 TBufferMerger::TBufferMerger(const char *name, Option_t *option, Int_t compress)
-   : fName(name), fOption(option), fCompress(compress),
+   : fName(name), fOption(option), fCompress(compress), fAutoSave(0),
      fMergingThread(new std::thread([&]() { this->WriteOutputFile(); }))
 {
 }
@@ -63,9 +63,15 @@ void TBufferMerger::Push(TBufferFile *buffer)
    fDataAvailable.notify_one();
 }
 
+void TBufferMerger::SetAutoSave(size_t size)
+{
+   fAutoSave = size;
+}
+
 void TBufferMerger::WriteOutputFile()
 {
-   std::unique_ptr<TMemFile> memfile;
+   size_t buffered = 0;
+   std::vector<TMemFile *> memfiles;
    std::unique_ptr<TBufferFile> buffer;
    TFileMerger merger;
 
@@ -84,25 +90,36 @@ void TBufferMerger::WriteOutputFile()
       fQueue.pop();
       lock.unlock();
 
-      if (!buffer) return;
+      if (!buffer)
+         break;
 
       Long64_t length;
       buffer->SetReadMode();
       buffer->SetBufferOffset();
       buffer->ReadLong64(length);
+      buffered += length;
 
       {
          R__LOCKGUARD(gROOTMutex);
-         memfile.reset(new TMemFile(fName.c_str(), buffer->Buffer() + buffer->Length(), length, "read"));
+         memfiles.push_back(new TMemFile(fName.c_str(), buffer->Buffer() + buffer->Length(), length, "read"));
          buffer->SetBufferOffset(buffer->Length() + length);
-         merger.AddFile(memfile.get(), false);
-         merger.PartialMerge();
+         merger.AddFile(memfiles.back(), false);
+
+         if (buffered > fAutoSave) {
+            buffered = 0;
+            merger.PartialMerge();
+            merger.Reset();
+            memfiles.clear();
+         }
       }
-      merger.Reset();
 
       if (fCallback)
          fCallback();
    }
+
+   R__LOCKGUARD(gROOTMutex);
+   merger.PartialMerge();
+   merger.Reset();
 }
 
 } // namespace Experimental

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -65,7 +65,6 @@ void TBufferMerger::Push(TBufferFile *buffer)
 
 void TBufferMerger::WriteOutputFile()
 {
-   TDirectoryFile::TContext context;
    std::unique_ptr<TMemFile> memfile;
    std::unique_ptr<TBufferFile> buffer;
    TFileMerger merger;
@@ -93,16 +92,13 @@ void TBufferMerger::WriteOutputFile()
       buffer->ReadLong64(length);
 
       {
-         TDirectory::TContext ctxt;
-         {
-            R__LOCKGUARD(gROOTMutex);
-            memfile.reset(new TMemFile(fName.c_str(), buffer->Buffer() + buffer->Length(), length, "read"));
-            buffer->SetBufferOffset(buffer->Length() + length);
-            merger.AddFile(memfile.get(), false);
-            merger.PartialMerge();
-         }
-         merger.Reset();
+         R__LOCKGUARD(gROOTMutex);
+         memfile.reset(new TMemFile(fName.c_str(), buffer->Buffer() + buffer->Length(), length, "read"));
+         buffer->SetBufferOffset(buffer->Length() + length);
+         merger.AddFile(memfile.get(), false);
+         merger.PartialMerge();
       }
+      merger.Reset();
 
       if (fCallback)
          fCallback();

--- a/io/io/test/TBufferMerger.cxx
+++ b/io/io/test/TBufferMerger.cxx
@@ -116,6 +116,54 @@ TEST(TBufferMerger, ParallelTreeFill)
    EXPECT_TRUE(FileExists("tbuffermerger_parallel.root"));
 }
 
+TEST(TBufferMerger, AutoSave)
+{
+   int nevents = 16384;
+   int nthreads = 8;
+   int events_per_thread = nevents / nthreads;
+
+   ROOT::EnableThreadSafety();
+
+   {
+      TBufferMerger merger("tbuffermerger_autosave.root");
+
+      merger.SetAutoSave(16 * 1024 * 1024); // Auto save every 16MB
+
+      std::vector<std::thread> threads;
+      for (int i = 0; i < nthreads; ++i) {
+         threads.emplace_back([=, &merger]() {
+            auto myfile = merger.GetFile();
+            auto mytree = new TTree("mytree", "mytree");
+
+            // The resetting of the kCleanup bit below is necessary to avoid leaving
+            // the management of this object to ROOT, which leads to a race condition
+            // that may cause a crash once all threads are finished and the final
+            // merge is happening
+            mytree->ResetBit(kMustCleanup);
+
+            Fill(mytree, i * events_per_thread, events_per_thread);
+            myfile->Write();
+         });
+      }
+
+      for (auto &&t : threads)
+         t.join();
+   }
+
+   EXPECT_TRUE(FileExists("tbuffermerger_autosave.root"));
+
+   { // sum of all branch values in sequential mode
+      TFile f("tbuffermerger_autosave.root");
+      auto t = (TTree *)f.Get("mytree");
+
+      int nentries = (int)t->GetEntries();
+
+      EXPECT_EQ(nevents, nentries);
+   }
+
+   remove("tbuffermerger_autosave.root");
+}
+
 TEST(TBufferMerger, CheckTreeFillResults)
 {
    int sum_s, sum_p;

--- a/io/io/test/TBufferMerger.cxx
+++ b/io/io/test/TBufferMerger.cxx
@@ -28,6 +28,8 @@ static void Fill(TTree *tree, int init, int count)
       n = init + i;
       tree->Fill();
    }
+
+   tree->ResetBranchAddresses();
 }
 
 static bool FileExists(const char *name)

--- a/io/io/test/TBufferMerger.cxx
+++ b/io/io/test/TBufferMerger.cxx
@@ -41,6 +41,8 @@ static bool FileExists(const char *name)
 TEST(TBufferMerger, CreateAndDestroy)
 {
    TBufferMerger merger("tbuffermerger_create.root");
+
+   remove("tbuffermerger_create.root");
 }
 
 TEST(TBufferMerger, CreateAndDestroyWithAttachedFiles)
@@ -56,6 +58,8 @@ TEST(TBufferMerger, CreateAndDestroyWithAttachedFiles)
    }
 
    EXPECT_TRUE(FileExists("tbuffermerger_create.root"));
+
+   remove("tbuffermerger_create.root");
 }
 
 TEST(TBufferMerger, SequentialTreeFill)
@@ -210,6 +214,9 @@ TEST(TBufferMerger, CheckTreeFillResults)
 
    EXPECT_EQ(523776, sum_s);
    EXPECT_EQ(523776, sum_p);
+
+   remove("tbuffermerger_sequential.root");
+   remove("tbuffermerger_parallel.root");
 }
 
 TEST(TBufferMerger, RegisterCallbackThreads)


### PR DESCRIPTION
This introduces a `SetAutoSave()` function to `TBufferMerger` that lets users choose how often data is merged into the output file. This avoid excessive writing of TTree headers, which are compressed and causes the output thread to do too much work if merges happen at every buffer read from the queue.