### PR TITLE
JSROOT 5.3.0

### DIFF
--- a/etc/http/changes.md
+++ b/etc/http/changes.md
@@ -1,20 +1,73 @@
 # JSROOT changelog
 
-## Changes in dev
-1. Provide shape parameters in TGeo tooltips
-2. Let inspect selected TGeoNode
-3. Change in JSROOT.draw functionality. Now valid painter instance can be only obtained via call-back
-   function - forth argument of JSROOT.draw() function. 
-4. Refactor JSROOT scripts structure - extract histograms and hierarchy painters into separate scripts 
-5. Use latest three.js r86 with improved Projector and CanvasRenderer
-   Still use own SVGRenderer which supported direct text dump
-6. Provide text info when geometry drawing takes too long 
-7. Preliminary support of TEfficiency
-8. Automatic title positioning of vertical axis when fTitleOffset==0
-9. Optionally use openui5 for GUI functionality - like Menu creation.
-   On the long run will completely replace jquery-ui widgets
-10. In all sources specify "use strict" derictive, fix several connected errors.   
-11. Implement PFC, PLC and PMC draw options for TMultiGraph
+## Changes in 5.3.0
+1. New supported classes:
+    - TGraphPolar
+    - TGraphTime
+    - TSpline3
+    - TSpline5
+    - TPolyLine3D
+    - TPolyMarker
+    - TEfficiency
+    - TH1K
+2. New supported options:
+     "PFC" - auto fill color (histograms and graphs)
+     "PLC" - auto line color
+     "PMC" - auto marker color
+     "A"  - fully disables axes drawing for histograms painters
+     "TEXT" - for TH2Poly
+     "SAMES" - draw stat box for superimposed histograms
+     "NOCOL" - ignore stored in the TCanvas colors list
+     "NOPAL" - ignore stored in the TCanvas color palette
+3. Improvements in existing painters:
+     - use color palette stored in the TCanvas
+     - draw stats box when really required
+     - let resize frames and paves in all eight directions
+     - support lines, boxes and arbitrary text positions in TPaveText
+     - automatic title positioning of vertical axis when fTitleOffset==0
+     - when pad.fTickx/y==2 draw axes labels on opposite side
+     - editing of TGraph objects - moving of the graph bins
+     - draw X/Y/Z axis titles in lego plots
+     - use canvas Theta/Phi angles to set initial camera position in 3D plots
+4. New TLatex processor supports most ROOT features, still MathJax can be used
+5. New X/Y projections display for TH2 histograms (aka TH2::SetShowProjectionX/Y)
+6. New in geometry viewer:
+    - provide shape parameters in TGeo tooltips
+    - let inspect selected TGeoNode
+    - provide text info when geometry drawing takes too long
+7. Change in JSROOT.draw functionality. Now valid painter instance can be only
+   obtained via call-back - forth argument of JSROOT.draw() function.
+8. Use latest three.js r86 with improved Projector and CanvasRenderer
+   Still use own SVGRenderer which supported direct SVG text dump
+9. Introduce openui5 components for webgui functionality
+10. In all sources specify "use strict" directive
+
+
+## Changes in 5.2.4
+1. Fix - support pow(x,n) function in formula
+2. Fix - use pad.fFillColor for frame when fFrameFillColor==0
+3. Fix - correctly identify horizontal TGaxis with reverse scale
+4. Fix - correctly handle negative line width in exclusion
+5. Fix - tooltips handling for TF1
+
+
+## Changes in 5.2.3
+1. Fix - potential mix-up in marker attributes handling
+2. Fix - unzomming of log scale https://root-forum.cern.ch/t/25889
+3. Fix - ignore not-supported options in TMultiGraph https://root-forum.cern.ch/t/25888
+4. Fix - correctly use fGridColor from TStyle
+5. Fix - prevent error when TPaveText includes TLine or TBox in list of lines
+6. Fix - bin errors calculations in TProfile
+
+
+## Changes in 5.2.2
+1. Fix several problems, discovered with "use strict" directive
+
+
+## Changes in 5.2.1
+1. Fix - correctly handle new TF1 parameter coding convention (#132)
+2. Fix - Check if pad name can be used as element id (#133)
+3. Fix - adjust title position for vertical axis with fTitleOffset==0
 
 
 ## Changes in 5.2.0

--- a/etc/http/openui5/controller/Canvas.controller.js
+++ b/etc/http/openui5/controller/Canvas.controller.js
@@ -1,6 +1,6 @@
 sap.ui.define([
    'jquery.sap.global',
-	'sap/ui/core/mvc/Controller',
+   'sap/ui/core/mvc/Controller',
    'sap/ui/model/json/JSONModel',
    'sap/m/MessageToast',
    'sap/m/Dialog',
@@ -9,71 +9,73 @@ sap.ui.define([
    'sap/m/Input',
    'sap/m/Button',
    'sap/m/Label',
+   'sap/ui/layout/Splitter',
    'sap/ui/layout/SplitterLayoutData',
    'sap/ui/unified/Menu',
    'sap/ui/unified/MenuItem'
 
-], function (jQuery, Controller, JSONModel, MessageToast, Dialog, List, InputListItem, Input, Button, Label, SplitterLayoutData, Menu, MenuItem) {
-	"use strict";
+], function (jQuery, Controller, JSONModel, MessageToast, Dialog, List, InputListItem, Input, Button, Label, Splitter, SplitterLayoutData, Menu, MenuItem) {
+   "use strict";
 
-	var CController = Controller.extend("sap.ui.jsroot.controller.Canvas", {
-		onInit : function() {
-		   this._Page = this.getView().byId("CanvasMainPage");
+   var CController = Controller.extend("sap.ui.jsroot.controller.Canvas", {
+      onInit : function() {
+         this._Page = this.getView().byId("CanvasMainPage");
+         this.bottomVisible = false;
 
-         var model = new JSONModel({ GedIcon: "", StatusIcon: "",
+         var model = new JSONModel({ GedIcon: "", StatusIcon: "", ToolbarIcon: "", TooltipIcon: "sap-icon://accept",
                                      StatusLbl1:"", StatusLbl2:"", StatusLbl3:"", StatusLbl4:"" });
          this.getView().setModel(model);
 
-		   // this.toggleGedEditor();
-		},
+         // this.toggleGedEditor();
+      },
 
-		getCanvasPainter : function(also_without_websocket) {
-         var elem = this.getView().byId("jsroot_canvas");
+      getCanvasPainter : function(also_without_websocket) {
+         var elem = this.getView().byId("MainPanel");
 
          var p = elem ? elem.getController().canvas_painter : null;
 
          return (p && (p._websocket || also_without_websocket)) ? p : null;
-		},
+      },
 
-		closeMethodDialog : function(method, call_back) {
+      closeMethodDialog : function(method, call_back) {
 
          var args = "";
 
-		   if (method) {
-		      var cont = this.methodDialog.getContent();
+         if (method) {
+            var cont = this.methodDialog.getContent();
 
             var items = cont[0].getItems();
 
             if (method.fArgs.length !== items.length)
                alert('Mismatch between method description' + method.fArgs.length + ' and args list in dialog ' + items.length);
 
-		      // console.log('ITEMS', method.fArgs.length, items.length);
+            // console.log('ITEMS', method.fArgs.length, items.length);
 
-		      for (var k=0;k<method.fArgs.length;++k) {
-		         var arg = method.fArgs[k];
-		         var value = items[k].getContent()[0].getValue();
+            for (var k=0;k<method.fArgs.length;++k) {
+               var arg = method.fArgs[k];
+               var value = items[k].getContent()[0].getValue();
 
-		         if (value==="") value = arg.fDefault;
+               if (value==="") value = arg.fDefault;
 
-		         if ((arg.fTitle=="Option_t*") || (arg.fTitle=="const char*")) {
-		            // check quotes,
-		            // TODO: need to make more precise checking of escape characters
-		            if (!value) value = '""';
-		            if (value[0]!='"') value = '"' + value;
-		            if (value[value.length-1] != '"') value += '"';
-		         }
+               if ((arg.fTitle=="Option_t*") || (arg.fTitle=="const char*")) {
+                  // check quotes,
+                  // TODO: need to make more precise checking of escape characters
+                  if (!value) value = '""';
+                  if (value[0]!='"') value = '"' + value;
+                  if (value[value.length-1] != '"') value += '"';
+               }
 
-		         args += (k>0 ? "," : "") + value;
-		      }
-		   }
+               args += (k>0 ? "," : "") + value;
+            }
+         }
 
          this.methodDialog.close();
          this.methodDialog.destroy();
          JSROOT.CallBack(call_back, args);
-		},
+      },
 
-		showMethodsDialog : function(method, call_back) {
-		   var items = [];
+      showMethodsDialog : function(method, call_back) {
+         var items = [];
 
          for (var n=0;n<method.fArgs.length;++n) {
             var arg = method.fArgs[n];
@@ -113,9 +115,9 @@ sap.ui.define([
          // this.getView().addDependent(this.methodDialog);
 
          this.methodDialog.open();
-		},
+      },
 
-		onFileMenuAction : function (oEvent) {
+      onFileMenuAction : function (oEvent) {
          //var oItem = oEvent.getParameter("item"),
          //    sItemPath = "";
          //while (oItem instanceof sap.m.MenuItem) {
@@ -124,10 +126,10 @@ sap.ui.define([
          //}
          //sItemPath = sItemPath.substr(0, sItemPath.lastIndexOf(" > "));
 
-		   var p = this.getCanvasPainter();
-		   if (!p) return;
+         var p = this.getCanvasPainter();
+         if (!p) return;
 
-		   var name = oEvent.getParameter("item").getText();
+         var name = oEvent.getParameter("item").getText();
 
          switch (name) {
             case "Close canvas": p.OnWebsocketClosed(); p.CloseWebsocket(true); break;
@@ -141,55 +143,54 @@ sap.ui.define([
          }
 
          MessageToast.show("Action triggered on item: " + name);
-		},
+      },
 
-		onCloseCanvasPress : function() {
-		   var p = this.getCanvasPainter();
+      onCloseCanvasPress : function() {
+         var p = this.getCanvasPainter();
          if (p) {
             p.OnWebsocketClosed();
             p.CloseWebsocket(true);
          }
-		},
+      },
 
-		onInterruptPress : function() {
-		   var p = this.getCanvasPainter();
+      onInterruptPress : function() {
+         var p = this.getCanvasPainter();
          if (p) p.SendWebsocket("INTERRUPT");
-		},
+      },
 
-		onQuitRootPress : function() {
-		   var p = this.getCanvasPainter();
+      onQuitRootPress : function() {
+         var p = this.getCanvasPainter();
          if (p) p.SendWebsocket("QUIT");
-		},
+      },
 
-		onReloadPress : function() {
+      onReloadPress : function() {
          var p = this.getCanvasPainter();
          if (p) p.SendWebsocket("RELOAD");
-		},
+      },
 
-		showGeEditor : function(new_state) {
+      showGeEditor : function(new_state) {
          this.showLeftArea(new_state ? "Ged" : "");
-		},
+      },
 
-		getGed : function() {
-		   if (this.getView().getModel().getProperty("/LeftArea") != "Ged") return null;
-		   var split = this.getView().byId("MainAreaSplitter");
+      getLeftController : function(name) {
+         if (this.getView().getModel().getProperty("/LeftArea") != name) return null;
+         var split = this.getView().byId("MainAreaSplitter");
          return split ? split.getContentAreas()[0].getController() : null;
-		},
+      },
 
-		toggleGedEditor : function() {
-		   var new_state = this.getView().getModel().getProperty("/LeftArea") != "Ged";
-		   this.showGeEditor(new_state);
-		   var p = this.getCanvasPainter();
-		   if (new_state && p) p.SelectObjectPainter(p);
+      toggleGedEditor : function() {
+         var new_state = this.getView().getModel().getProperty("/LeftArea") != "Ged";
+         this.showGeEditor(new_state);
+         var p = this.getCanvasPainter();
+         if (new_state && p) p.SelectObjectPainter(p);
+      },
 
-		},
-
-		showLeftArea : function(panel_name) {
+      showLeftArea : function(panel_name) {
          var split = this.getView().byId("MainAreaSplitter");
          if (!split) return;
 
-		   var curr = this.getView().getModel().getProperty("/LeftArea");
-		   if (curr == panel_name) return;
+         var curr = this.getView().getModel().getProperty("/LeftArea");
+         if (curr == panel_name) return;
 
          // first need to remove existing
          if (curr) split.removeContentArea(split.getContentAreas()[0]);
@@ -207,62 +208,150 @@ sap.ui.define([
 
          var oContent = sap.ui.xmlview({
             viewName : "sap.ui.jsroot.view." + panel_name,
-            layoutData: oLd
+            layoutData: oLd,
+            height: panel_name=="Panel" ? "100%" : undefined
          });
 
          split.insertContentArea(oContent, 0);
 
          return oContent.getController(); // return controller of new panel
-		},
-
-	   ShowCanvasStatus : function (text1,text2,text3,text4) {
-	      var model = this.getView().getModel();
-	      model.setProperty("/StatusLbl1", text1);
-	      model.setProperty("/StatusLbl2", text2);
-	      model.setProperty("/StatusLbl3", text3);
-	      model.setProperty("/StatusLbl4", text4);
       },
 
-		isStatusShown : function() {
-		   return this._Page.getShowFooter();
-		},
+      getBottomController : function(can, call_back) {
+         if (!this.bottomVisible) return null;
+         var split = this.getView().byId("MainAreaSplitter");
+         var cont = split.getContentAreas();
+         var vsplit = cont[cont.length-1];
+         var vcont = vsplit.getContentAreas();
+         var bottom = vcont[vcont.length-1];
+         return bottom ? bottom.getController() : null;
+      },
 
-		toggleShowStatus : function() {
-		   var new_state = !this.isStatusShown();
+      drawInProjectionArea : function(can, opt, call_back) {
+         var ctrl = this.getBottomController();
+         if (!ctrl) ctrl = this.getLeftController("Panel");
+
+         if (ctrl && ctrl.drawCanvas)
+            ctrl.drawCanvas(can, opt, call_back);
+         else
+            JSROOT.CallBack(call_back, null);
+      },
+
+      showProjectionArea : function(kind, call_back) {
+         var bottom = this.showBottomArea(kind == "X");
+         var left = this.showLeftArea(kind == "Y" ? "Panel" : "");
+
+         var ctrl = bottom || left;
+
+         if (!ctrl || ctrl.getView().getDomRef())
+            return JSROOT.CallBack(call_back, !!ctrl);
+
+         // FIXME: one should have much easier way to get callback when rendering done
+         ctrl.after_render_callback = call_back;
+      },
+
+      showBottomArea : function(is_on) {
+
+         if (this.bottomVisible == is_on) return this.getBottomController();
+
+         var split = this.getView().byId("MainAreaSplitter");
+
+         if (!split) return null;
+
+         var cont = split.getContentAreas();
+
+         this.bottomVisible = !this.bottomVisible;
+
+         if (this.bottomVisible == false) {
+            // vertical splitter exists - toggle it
+
+            var vsplit = cont[cont.length-1];
+            var main = vsplit.removeContentArea(0);
+            vsplit.destroyContentAreas();
+            split.removeContentArea(vsplit);
+            split.addContentArea(main);
+            return null;
+         }
+
+         // remove panel with normal drawing
+         split.removeContentArea(cont[cont.length-1]);
+         var vsplit = new Splitter({orientation: "Vertical"});
+
+         split.addContentArea(vsplit);
+
+         vsplit.addContentArea(cont[cont.length-1]);
+
+         var oLd = new SplitterLayoutData({
+            resizable : true,
+            size      : "200px",
+            maxSize   : "500px"
+         });
+
+         var oContent = sap.ui.xmlview({
+            viewName : "sap.ui.jsroot.view.Panel",
+            layoutData: oLd,
+            height: "100%"
+         });
+
+         vsplit.addContentArea(oContent);
+
+         return oContent.getController();
+      },
+
+      ShowCanvasStatus : function (text1,text2,text3,text4) {
+         var model = this.getView().getModel();
+         model.setProperty("/StatusLbl1", text1);
+         model.setProperty("/StatusLbl2", text2);
+         model.setProperty("/StatusLbl3", text3);
+         model.setProperty("/StatusLbl4", text4);
+      },
+
+      isStatusShown : function() {
+         return this._Page.getShowFooter();
+      },
+
+      toggleShowStatus : function(new_state) {
+         if (new_state === undefined) new_state = !this.isStatusShown();
 
          this._Page.setShowFooter(new_state);
          this.getView().getModel().setProperty("/StatusIcon", new_state ? "sap-icon://accept" : "");
-		},
+      },
 
-		onViewMenuAction : function (oEvent) {
+      toggleToolBar : function(new_state) {
+         if (new_state === undefined) new_state = !this.getView().getModel().getProperty("/ToolbarIcon");
 
-         var item = oEvent.getParameter("item"),
-             name = item.getText();
+         this._Page.setShowSubHeader(new_state);
 
-         if (name=="Editor") return this.toggleGedEditor();
-         if (name=="Event statusbar") return this.toggleShowStatus();
+         this.getView().getModel().setProperty("/ToolbarIcon", new_state ? "sap-icon://accept" : "");
+      },
 
+      toggleToolTip : function(new_state) {
+         if (new_state === undefined) new_state = !this.getView().getModel().getProperty("/TooltipIcon");
+
+         this.getView().getModel().setProperty("/TooltipIcon", new_state ? "sap-icon://accept" : "");
 
          var p = this.getCanvasPainter(true);
-         if (!p) return;
+         if (p) p.SetTooltipAllowed(new_state);
+      },
 
-         var new_state = !item.getIcon();
+      setShowMenu : function(new_state) {
+         this._Page.setShowHeader(new_state);
+      },
 
-         switch (name) {
-            case "Toolbar":
-               this._Page.setShowSubHeader(new_state)
-               break;
-            case "Tooltip info":
-               p.SetTooltipAllowed(new_state);
-               break;
-            default: return;
+
+      onViewMenuAction : function (oEvent) {
+
+         var item = oEvent.getParameter("item");
+
+         switch (item.getText()) {
+            case "Editor": this.toggleGedEditor(); break;
+            case "Event statusbar": this.toggleShowStatus(); break;
+            case "Toolbar": this.toggleToolBar(); break;
+            case "Tooltip info": this.toggleToolTip(); break;
          }
-         item.setIcon(new_state ? "sap-icon://accept" : "");
+      },
 
-         // MessageToast.show("Action triggered on item: " + name);
-		},
-
-		onToolsMenuAction : function(oEvent) {
+      onToolsMenuAction : function(oEvent) {
          var item = oEvent.getParameter("item"),
              name = item.getText();
 
@@ -271,15 +360,27 @@ sap.ui.define([
          var curr = this.getView().getModel().getProperty("/LeftArea");
 
          this.showLeftArea(curr == "FitPanel" ? "" : "FitPanel");
-		},
+      },
 
-		showMessage : function(msg) {
-		   MessageToast.show(msg);
-		}
+      showMessage : function(msg) {
+         MessageToast.show(msg);
+      },
 
-	});
+      showSection : function(that, on) {
+         // this function call when section state changed from server side
+         switch(that) {
+            case "Menu": this.setShowMenu(on); break;
+            case "StatusBar": this.toggleShowStatus(on); break;
+            case "Editor": this.showGeEditor(on); break;
+            case "ToolBar": this.toggleToolBar(on); break;
+            case "ToolTips": this.toggleToolTip(on); break;
+         }
+      }
 
 
-	return CController;
+   });
+
+
+   return CController;
 
 });

--- a/etc/http/openui5/controller/CanvasPanel.controller.js
+++ b/etc/http/openui5/controller/CanvasPanel.controller.js
@@ -1,0 +1,77 @@
+sap.ui.define([
+   'sap/ui/core/mvc/Controller',
+   'sap/ui/core/ResizeHandler'
+], function (Controller, ResizeHandler) {
+   "use strict";
+
+   return Controller.extend("sap.ui.jsroot.controller.CanvasPanel", {
+
+      onBeforeRendering: function() {
+      },
+
+      onAfterRendering: function() {
+         if (this.after_render_callback) {
+            JSROOT.CallBack(this.after_render_callback);
+            delete this.after_render_callback;
+         }
+
+         if (this.canvas_painter && this.canvas_painter._configured_socket_kind) {
+            this.canvas_painter.SetDivId(this.getView().getDomRef(), -1);
+            this.canvas_painter.OpenWebsocket(this.canvas_painter._configured_socket_kind);
+            delete this.canvas_painter._configured_socket_kind;
+         }
+      },
+
+      onResize: function(event) {
+         // use timeout
+         if (this.resize_tmout) clearTimeout(this.resize_tmout);
+         this.resize_tmout = setTimeout(this.onResizeTimeout.bind(this), 300); // minimal latency
+      },
+
+      drawCanvas : function(can, opt, call_back) {
+         if (this.canvas_painter) {
+            this.canvas_painter.Cleanup();
+            delete this.canvas_painter;
+         }
+
+         if (!this.getView().getDomRef()) return JSROOT.CallBack(call_back, null);
+
+         var oController = this;
+         JSROOT.draw(this.getView().getDomRef(), can, opt, function(painter) {
+            oController.canvas_painter = painter;
+            JSROOT.CallBack(call_back, painter);
+         });
+      },
+
+      onResizeTimeout: function() {
+         delete this.resize_tmout;
+         if (this.canvas_painter)
+            this.canvas_painter.CheckCanvasResize();
+      },
+
+      onInit: function() {
+         // this.canvas_painter = JSROOT.openui5_canvas_painter;
+         // delete JSROOT.openui5_canvas_painter;
+
+         var oModel = sap.ui.getCore().getModel(this.getView().getId());
+         if (oModel) {
+            var oData = oModel.getData();
+
+            if (oData.canvas_painter) {
+               this.canvas_painter = oData.canvas_painter;
+               delete oData.canvas_painter;
+            }
+         }
+
+         ResizeHandler.register(this.getView(), this.onResize.bind(this));
+      },
+
+      onExit: function() {
+         if (this.canvas_painter) {
+            this.canvas_painter.Cleanup();
+            delete this.canvas_painter;
+         }
+      }
+   });
+
+});

--- a/etc/http/openui5/controller/Panel.controller.js
+++ b/etc/http/openui5/controller/Panel.controller.js
@@ -1,48 +1,122 @@
 sap.ui.define([
    'sap/ui/core/mvc/Controller',
-   'sap/ui/core/ResizeHandler',
-   'sap/m/Dialog',
-   'sap/m/Button'
-], function (Controller, ResizeHandler, Dialog, Button) {
+   'sap/ui/core/ResizeHandler'
+], function (Controller, ResizeHandler) {
    "use strict";
 
    return Controller.extend("sap.ui.jsroot.controller.Panel", {
 
-       onAfterRendering: function() {
-          if (this.canvas_painter && this.canvas_painter._configured_socket_kind) {
-             this.canvas_painter.SetDivId(this.getView().getDomRef(), -1);
-             this.canvas_painter.OpenWebsocket(this.canvas_painter._configured_socket_kind);
-             delete this.canvas_painter._configured_socket_kind;
-          }
-       },
-
-       onBeforeRendering: function() {
-       },
-
-       onResize : function(event) {
-          // use timeout
-          if (this.resize_tmout) clearTimeout(this.resize_tmout);
-          this.resize_tmout = setTimeout(this.onResizeTimeout.bind(this), 300); // minimal latency
-       },
-
-       onResizeTimeout : function() {
-          delete this.resize_tmout;
-          if (this.canvas_painter)
-             this.canvas_painter.CheckCanvasResize();
-       },
-
-       onInit : function() {
-          this.canvas_painter = JSROOT.openui5_canvas_painter;
-          delete JSROOT.openui5_canvas_painter;
-
-          ResizeHandler.register(this.getView(), this.onResize.bind(this));
+      onBeforeRendering: function() {
+         console.log("Cleanup Panel", this.getView().getId());
+         if (this.object_painter) {
+            this.object_painter.Cleanup();
+            delete this.object_painter;
+         }
+         this.rendering_perfromed = false;
       },
 
-      onExit : function() {
-         if (this.canvas_painter)
-            this.canvas_painter.Cleanup();
+      drawObject: function(obj, options) {
 
-         delete this.canvas_painter;
+         if (!this.rendering_perfromed) {
+            this.panel_data = { object: obj, opt: opt };
+            return;
+         }
+
+         var oController = this;
+         oController.object = obj;
+         d3.select(oController.getView().getDomRef()).style('overflow','hidden');
+
+         JSROOT.draw(oController.getView().getDomRef(), oController.object, options, function(painter) {
+            console.log("object painting finished");
+            oController.object_painter = painter;
+            oController.get_callbacks.forEach(function(cb) { JSROOT.CallBack(cb,painter); });
+            oController.get_callbacks = [];
+         });
+      },
+
+      drawModel: function(model) {
+         if (!model) return;
+         if (!this.rendering_perfromed) {
+            this.panel_data = model;
+            return;
+         }
+
+         var oController = this;
+         if (model.object) {
+            oController.drawObject(model.object, model.opt);
+         } else if (model.jsonfilename) {
+            JSROOT.NewHttpRequest(model.jsonfilename, 'object', function(obj) {
+               oController.drawObject(obj, model.opt);
+            }).send();
+         } else if (model.filename) {
+            JSROOT.OpenFile(model.filename, function(file) {
+               file.ReadObject(model.itemname, function(obj) {
+                  oController.drawObject(obj, model.opt);
+               });
+            });
+         }
+      },
+
+      /** method to access object painter
+         if object already painted and exists, it will be returned as result
+         but it may take time to complete object drawing, therefore callback function should be used like
+            var panel = sap.ui.getCore().byId("YourPanelId");
+            var object_painter = null;
+            panel.getController().getPainter(funciton(painter) {
+               object_painter = painter;
+            });
+      */
+      getPainter: function(call_back) {
+
+         if (this.object_painter) {
+            JSROOT.CallBack(call_back, this.object_painter);
+         } else if (call_back) {
+            this.get_callbacks.push(call_back);
+         }
+         return this.object_painter;
+      },
+
+      onAfterRendering: function() {
+         this.rendering_perfromed = true;
+         if (this.panel_data) this.drawModel(this.panel_data);
+      },
+
+      onResize: function(event) {
+         // use timeout
+         if (this.resize_tmout) clearTimeout(this.resize_tmout);
+         this.resize_tmout = setTimeout(this.onResizeTimeout.bind(this), 300); // minimal latency
+      },
+
+      onResizeTimeout: function() {
+         delete this.resize_tmout;
+         if (this.object_painter)
+            this.object_painter.CheckResize();
+      },
+
+      onInit: function() {
+
+         this.get_callbacks = []; // list of callbacks
+
+         this.rendering_perfromed = false;
+
+         var id = this.getView().getId();
+
+         console.log("Initialization of JSROOT Panel", id);
+
+         var oModel = sap.ui.getCore().getModel(id);
+         if (!oModel && (id.indexOf("__xmlview0--")==0)) oModel = sap.ui.getCore().getModel(id.substr(12));
+
+         if (oModel)
+            this.panel_data = oModel.getData();
+
+         ResizeHandler.register(this.getView(), this.onResize.bind(this));
+      },
+
+      onExit: function() {
+         if (this.object_painter) {
+            this.object_painter.Cleanup();
+            delete this.object_painter;
+         }
       }
    });
 

--- a/etc/http/openui5/view/Canvas.view.xml
+++ b/etc/http/openui5/view/Canvas.view.xml
@@ -1,99 +1,99 @@
-<mvc:View
-    	height="100%"
-    	controllerName="sap.ui.jsroot.controller.Canvas"
-    	xmlns:mvc="sap.ui.core.mvc"
-    	xmlns:l="sap.ui.layout"
-    	xmlns="sap.m">
-   	<Page title="" showNavButton="false" showFooter="false" showSubHeader="false" id="CanvasMainPage" >
-    		<headerContent>
-	         <OverflowToolbar id="otb1">
-	            <Button icon="sap-icon://system-exit" type="Transparent" tooltip="Quit ROOT session" press="onQuitRootPress"/>
-	            <Button icon="sap-icon://refresh" type="Transparent" tooltip="Reload canvas from server" press="onReloadPress"/>
-	            <Button icon="sap-icon://user-edit" type="Transparent" tooltip="Toggle GED editor" press="toggleGedEditor"/>
-	            <MenuButton text="File">
-                  <menu>
-                     <Menu itemSelected="onFileMenuAction">
-                       <items>
+<mvc:View height="100%" controllerName="sap.ui.jsroot.controller.Canvas"
+   xmlns:mvc="sap.ui.core.mvc" xmlns:l="sap.ui.layout" xmlns="sap.m">
+   <Page title="" showNavButton="false" showFooter="false"
+      showSubHeader="false" id="CanvasMainPage">
+      <headerContent>
+         <OverflowToolbar id="otb1">
+            <Button icon="sap-icon://system-exit" type="Transparent"
+               tooltip="Quit ROOT session" press="onQuitRootPress" />
+            <Button icon="sap-icon://refresh" type="Transparent"
+               tooltip="Reload canvas from server" press="onReloadPress" />
+            <Button icon="sap-icon://user-edit" type="Transparent"
+               tooltip="Toggle GED editor" press="toggleGedEditor" />
+            <MenuButton text="File">
+               <menu>
+                  <Menu itemSelected="onFileMenuAction">
+                     <items>
                         <MenuItem text="Open" icon="sap-icon://open-folder" />
                         <MenuItem text="Close canvas" icon="sap-icon://decline" />
-                        <MenuItem text="Save" startsSection="true" icon="sap-icon://save">
-                          <items>
-                            <MenuItem text="Canvas.png"/>
-                            <MenuItem text="Canvas.svg"/>
-                            <MenuItem text="Canvas.jpeg"/>
-                          </items>
+                        <MenuItem text="Save" startsSection="true"
+                           icon="sap-icon://save">
+                           <items>
+                              <MenuItem text="Canvas.png" />
+                              <MenuItem text="Canvas.svg" />
+                              <MenuItem text="Canvas.jpeg" />
+                           </items>
                         </MenuItem>
                         <MenuItem text="Save as ..." icon="sap-icon://save" />
-                        <MenuItem text="Interrupt" startsSection="true" icon="sap-icon://stop" />
+                        <MenuItem text="Interrupt"
+                           startsSection="true" icon="sap-icon://stop" />
                         <MenuItem text="Quit ROOT" icon="sap-icon://system-exit" />
-                         
-                      </items>
-                     </Menu>
-                  </menu>
-                </MenuButton>
-                <Button text="Edit" type="Transparent"></Button>
-                <MenuButton text="View" type="Transparent">
-                  <menu>
-                     <Menu itemSelected="onViewMenuAction">
-                       <items>
-                        <MenuItem text="Editor" icon="{/GedIcon}"/>
-                        <MenuItem text="Toolbar"/>
-                        <MenuItem text="Event statusbar" icon="{/StatusIcon}"/>
-                        <MenuItem text="Tooltip info" icon="sap-icon://accept"/>
+
+                     </items>
+                  </Menu>
+               </menu>
+            </MenuButton>
+            <Button text="Edit" type="Transparent"></Button>
+            <MenuButton text="View" type="Transparent">
+               <menu>
+                  <Menu itemSelected="onViewMenuAction">
+                     <items>
+                        <MenuItem text="Editor" icon="{/GedIcon}" />
+                        <MenuItem text="Toolbar" icon="{/ToolbarIcon} "/>
+                        <MenuItem text="Event statusbar" icon="{/StatusIcon}" />
+                        <MenuItem text="Tooltip info" icon="{/TooltipIcon}" />
                         <MenuItem text="Colors" startsSection="true" />
-                        <MenuItem text="Fonts"/>
-                        <MenuItem text="Markers"/>
-                      </items>
-                     </Menu>
-                  </menu>
-                </MenuButton>
-	             <Button text="Options" type="Transparent"></Button>
-	             <MenuButton text="Tools" type="Transparent">
-                  <menu>
-                     <Menu itemSelected="onToolsMenuAction">
-                       <items>
-                        <MenuItem text="Fit panel"/>
-                        <MenuItem text="Browser" enabled="false"/>
-                      </items>
-                     </Menu>
-                  </menu>
-	             </MenuButton>
-	             <ToolbarSpacer />
-	             <Button text="Help" type="Transparent"></Button>
-	         </OverflowToolbar>
-    		</headerContent>
-    		<subHeader>
-    		  <OverflowToolbar>
-    		     <Button icon="sap-icon://open-folder" type="Transparent" />
-    		     <Button icon="sap-icon://decline" type="Transparent" press="onCloseCanvasPress"/>
-              <Button icon="sap-icon://stop" type="Transparent" press="onInterruptPress"/>
-              <Button icon="sap-icon://system-exit" type="Transparent" tooltip="Quit ROOT session" press="onQuitRootPress"/>
-    		  </OverflowToolbar>
-    		</subHeader>
-    		<content>
-    			<l:Splitter orientation="Horizontal" id="MainAreaSplitter">
-    			   <!-- 
-		         <Button height="100%" width="100%" text="Content 1">
-			         <layoutData><l:SplitterLayoutData size="300px" /></layoutData>
-		         </Button>
-		          -->
-		         <mvc:XMLView id="jsroot_canvas" width="100%" height="100%" viewName="sap.ui.jsroot.view.Panel">
-		         </mvc:XMLView>
-		         <!-- 
-		         <Button height="100%" width="100%" text="Content 2">
-			          <layoutData><l:SplitterLayoutData size="auto" /></layoutData>
-		         </Button>
-		          -->
-	         </l:Splitter>
-    		</content>
-    		<footer>
-    			<OverflowToolbar>
-       		   <Label text="{/StatusLbl1}" id="FooterLbl1"/>
-       		   <Label text="{/StatusLbl2}" id="FooterLbl2"/>
-       		   <Label text="{/StatusLbl3}" id="FooterLbl3"/>
-       		   <Label text="{/StatusLbl4}" id="FooterLbl4"/>
-    			</OverflowToolbar>
-    		</footer>
-    	</Page>
+                        <MenuItem text="Fonts" />
+                        <MenuItem text="Markers" />
+                     </items>
+                  </Menu>
+               </menu>
+            </MenuButton>
+            <Button text="Options" type="Transparent"></Button>
+            <MenuButton text="Tools" type="Transparent">
+               <menu>
+                  <Menu itemSelected="onToolsMenuAction">
+                     <items>
+                        <MenuItem text="Fit panel" />
+                        <MenuItem text="Browser" enabled="false" />
+                     </items>
+                  </Menu>
+               </menu>
+            </MenuButton>
+            <ToolbarSpacer />
+            <Button text="Help" type="Transparent"></Button>
+         </OverflowToolbar>
+      </headerContent>
+      <subHeader>
+         <OverflowToolbar>
+            <Button icon="sap-icon://open-folder" type="Transparent" />
+            <Button icon="sap-icon://decline" type="Transparent"
+               press="onCloseCanvasPress" />
+            <Button icon="sap-icon://stop" type="Transparent"
+               press="onInterruptPress" />
+            <Button icon="sap-icon://system-exit" type="Transparent"
+               tooltip="Quit ROOT session" press="onQuitRootPress" />
+         </OverflowToolbar>
+      </subHeader>
+      <content>
+         <l:Splitter orientation="Horizontal" id="MainAreaSplitter">
+            <!-- <Button height="100%" width="100%" text="Content 1"> <layoutData><l:SplitterLayoutData 
+               size="300px" /></layoutData> </Button> -->
+            <mvc:XMLView id="MainPanel" width="100%"
+               height="100%" viewName="sap.ui.jsroot.view.CanvasPanel">
+            </mvc:XMLView>
+            <!-- <Button height="100%" width="100%" text="Content 2"> <layoutData><l:SplitterLayoutData 
+               size="auto" /></layoutData> </Button> -->
+         </l:Splitter>
+      </content>
+      <footer>
+         <OverflowToolbar>
+            <Label text="{/StatusLbl1}" id="FooterLbl1" />
+            <Label text="{/StatusLbl2}" id="FooterLbl2" />
+            <Label text="{/StatusLbl3}" id="FooterLbl3" />
+            <Label text="{/StatusLbl4}" id="FooterLbl4" />
+         </OverflowToolbar>
+      </footer>
+   </Page>
 </mvc:View>
 

--- a/etc/http/openui5/view/CanvasPanel.view.xml
+++ b/etc/http/openui5/view/CanvasPanel.view.xml
@@ -1,5 +1,5 @@
 <core:View
    xmlns="sap.m"
    xmlns:core="sap.ui.core"
-   controllerName="sap.ui.jsroot.controller.Panel">
+   controllerName="sap.ui.jsroot.controller.CanvasPanel">
 </core:View>

--- a/etc/http/openui5/view/FitPanel.view.xml
+++ b/etc/http/openui5/view/FitPanel.view.xml
@@ -1,19 +1,14 @@
-<mvc:View
-  	height="100%"
-   controllerName="sap.ui.jsroot.controller.FitPanel"
-  	xmlns:mvc="sap.ui.core.mvc"
-  	xmlns="sap.m">
-  	<Page
-  		id="fitpanel_page"
-  		title="Fit Panel"
-      showHeader="true" >
-    	<footer>
-    	   <Bar>
-    			<contentRight>
-    				<Button id="fitpanel_Fit" text="Fit" press="handleFitPress" />
-    				<Button id="fitpanel_Close" text="Close" press="handleClosePress" />
-    			</contentRight>
-    		</Bar>
-    	</footer>
+<mvc:View height="100%" controllerName="sap.ui.jsroot.controller.FitPanel"
+   xmlns:mvc="sap.ui.core.mvc" xmlns="sap.m">
+   <Page id="fitpanel_page" title="Fit Panel" showHeader="true">
+      <footer>
+         <Bar>
+            <contentRight>
+               <Button id="fitpanel_Fit" text="Fit" press="handleFitPress" />
+               <Button id="fitpanel_Close" text="Close"
+                  press="handleClosePress" />
+            </contentRight>
+         </Bar>
+      </footer>
    </Page>
 </mvc:View>

--- a/etc/http/openui5/view/Ged.view.xml
+++ b/etc/http/openui5/view/Ged.view.xml
@@ -1,22 +1,19 @@
 <mvc:View
-  	height="100%"
+   height="100%"
    controllerName="sap.ui.jsroot.controller.Ged"
-  	xmlns:mvc="sap.ui.core.mvc"
-  	xmlns="sap.m">
-  	<Page
-  		id="ged_page"
-  		title="class: {/SelectedClass}"
-      showHeader="true" >
+   xmlns:mvc="sap.ui.core.mvc"
+   xmlns="sap.m">
+   <Page id="ged_page" title="class: {/SelectedClass}" showHeader="true">
 <!-- 
-    	<footer>
-    	   <Bar>
-    			<contentRight>
-    				<Button id="edit" text="Edit" press="handleEditPress" />
-    				<Button id="save" text="Save" type="Emphasized" visible="false" press="handleSavePress" />
-    				<Button id="cancel" text="Cancel" visible="false" press="handleCancelPress" />
-    			</contentRight>
-    		</Bar>
-    	</footer>
- -->    	
+    <footer>
+       <Bar>
+          <contentRight>
+             <Button id="edit" text="Edit" press="handleEditPress" />
+             <Button id="save" text="Save" type="Emphasized" visible="false" press="handleSavePress" />
+             <Button id="cancel" text="Cancel" visible="false" press="handleCancelPress" />
+          </contentRight>
+       </Bar>
+    </footer>
+ -->
    </Page>
 </mvc:View>

--- a/etc/http/openui5/view/Inspector.fragment.xml
+++ b/etc/http/openui5/view/Inspector.fragment.xml
@@ -1,12 +1,10 @@
 <core:FragmentDefinition xmlns="sap.m" xmlns:core="sap.ui.core" xmlns:mvc="sap.ui.core.mvc">
- 
-	<Dialog title="Inspect" contentWidth="75%">
-		<content>
-  		   <mvc:XMLView id="object_inspector" viewName="sap.ui.jsroot.view.Inspector"></mvc:XMLView>
-		</content>
-		<endButton>
-		 	<Button text="Close It" press="closeObjectInspector" />
-		</endButton>
-	</Dialog>
- 
+   <Dialog title="Inspect" contentWidth="75%">
+      <content>
+           <mvc:XMLView id="object_inspector" viewName="sap.ui.jsroot.view.Inspector"></mvc:XMLView>
+      </content>
+      <endButton>
+          <Button text="Close It" press="closeObjectInspector" />
+      </endButton>
+   </Dialog>
 </core:FragmentDefinition>

--- a/etc/http/openui5/view/Inspector.view.xml
+++ b/etc/http/openui5/view/Inspector.view.xml
@@ -1,5 +1,5 @@
 <core:View
-	xmlns="sap.m"
+   xmlns="sap.m"
    xmlns:core="sap.ui.core"
    controllerName="sap.ui.jsroot.controller.Inspector">
 </core:View>

--- a/etc/http/openui5/view/TAttFill.fragment.xml
+++ b/etc/http/openui5/view/TAttFill.fragment.xml
@@ -1,44 +1,44 @@
-    <core:FragmentDefinition
-    	xmlns="sap.m"
-    	xmlns:l="sap.ui.layout"
-    	xmlns:f="sap.ui.layout.form"
-    	xmlns:core="sap.ui.core">
-    	<VBox class="sapUiSmallMargin">
-    		<f:SimpleForm id="TAttFill"
-    			editable="true"
-    			layout="ResponsiveGridLayout"
-    			title="TAttFill"
-    			labelSpanXL="1"
-    			labelSpanL="2"
-    			labelSpanM="4"
-    			labelSpanS="6"
-    			adjustLabelSpan="false"
-    			emptySpanXL="0"
-    			emptySpanL="0"
-    			emptySpanM="0"
-    			emptySpanS="0"
-    			columnsXL="1"
-    			columnsL="1"
-    			columnsM="1"
-    			breakpointXL="800"
-    			breakpointL="500"
-    			breakpointM="300"
-    			singleContainerFullSize="false" >
-    			<f:content>
-    				<Label text="Style" />
-    				<Select selectedKey="{/pattern}">
-					  <items>
-						 <core:Item text="none" key="0"/>
-						 <core:Item text="solid" key="1001"/>
-						 <core:Item text="3001" key="3001"/>
-						 <core:Item text="3002" key="3002"/>
-						 <core:Item text="3003" key="3003"/>
-						 <core:Item text="3004" key="3004"/>
-					  </items>
-				   </Select>
-    				<Label text="Color" />
-    				<Button text="{/color}" press="processTAttFill_Color"/>
-    			</f:content>
-    		</f:SimpleForm>
-    	</VBox>
-    </core:FragmentDefinition>
+<core:FragmentDefinition
+       xmlns="sap.m"
+       xmlns:l="sap.ui.layout"
+       xmlns:f="sap.ui.layout.form"
+       xmlns:core="sap.ui.core">
+       <VBox class="sapUiSmallMargin">
+          <f:SimpleForm id="TAttFill"
+             editable="true"
+             layout="ResponsiveGridLayout"
+             title="TAttFill"
+             labelSpanXL="1"
+             labelSpanL="2"
+             labelSpanM="4"
+             labelSpanS="6"
+             adjustLabelSpan="false"
+             emptySpanXL="0"
+             emptySpanL="0"
+             emptySpanM="0"
+             emptySpanS="0"
+             columnsXL="1"
+             columnsL="1"
+             columnsM="1"
+             breakpointXL="800"
+             breakpointL="500"
+             breakpointM="300"
+             singleContainerFullSize="false" >
+             <f:content>
+                <Label text="Style" />
+                <Select selectedKey="{/pattern}">
+                 <items>
+                   <core:Item text="none" key="0"/>
+                   <core:Item text="solid" key="1001"/>
+                   <core:Item text="3001" key="3001"/>
+                   <core:Item text="3002" key="3002"/>
+                   <core:Item text="3003" key="3003"/>
+                   <core:Item text="3004" key="3004"/>
+                 </items>
+               </Select>
+                <Label text="Color" />
+                <Button text="{/color}" press="processTAttFill_Color"/>
+             </f:content>
+          </f:SimpleForm>
+       </VBox>
+</core:FragmentDefinition>

--- a/etc/http/openui5/view/TAttLine.fragment.xml
+++ b/etc/http/openui5/view/TAttLine.fragment.xml
@@ -1,60 +1,60 @@
-    <core:FragmentDefinition
-    	xmlns="sap.m"
-    	xmlns:l="sap.ui.layout"
-    	xmlns:f="sap.ui.layout.form"
-    	xmlns:core="sap.ui.core">
-    	<VBox class="sapUiSmallMargin">
-    		<f:SimpleForm id="TAttLine"
-    			editable="true"
-    			layout="ResponsiveGridLayout"
-    			title="TAttLine"
-    			labelSpanXL="1"
-    			labelSpanL="2"
-    			labelSpanM="4"
-    			labelSpanS="6"
-    			adjustLabelSpan="false"
-    			emptySpanXL="0"
-    			emptySpanL="0"
-    			emptySpanM="0"
-    			emptySpanS="0"
-    			columnsXL="1"
-    			columnsL="1"
-    			columnsM="1"
-    			breakpointXL="800"
-    			breakpointL="500"
-    			breakpointM="300"
-    			singleContainerFullSize="false" >
-    			<f:content>
-    				<Label text="Style" />
-    				<Select selectedKey="{/style}">
-					  <items>
-						 <core:Item text="none" key="0"/>
-						 <core:Item text="1" key="1"/>
-						 <core:Item text="2" key="2"/>
-						 <core:Item text="3" key="3"/>
-						 <core:Item text="4" key="4"/>
-						 <core:Item text="5" key="5"/>
-						 <core:Item text="6" key="6"/>
-						 <core:Item text="7" key="7"/>
-						 <core:Item text="8" key="8"/>
-						 <core:Item text="9" key="9"/>
-						 <core:Item text="10" key="10"/>
-					  </items>
-				   </Select>
-    				<Label text="Width"/>
-    				<Select selectedKey="{/width}">
-					  <items>
-						 <core:Item text="1" key="1"/>
-						 <core:Item text="2" key="2"/>
-						 <core:Item text="3" key="3"/>
-						 <core:Item text="4" key="4"/>
-						 <core:Item text="5" key="5"/>
-						 <core:Item text="6" key="6"/>
-					  </items>
-				   </Select>
-    				<Label text="Color" />
-    				<Button text="{/color}" press="processTAttLine_Color"/>
-    			</f:content>
-    		</f:SimpleForm>
-    	</VBox>
-    </core:FragmentDefinition>
+<core:FragmentDefinition
+       xmlns="sap.m"
+       xmlns:l="sap.ui.layout"
+       xmlns:f="sap.ui.layout.form"
+       xmlns:core="sap.ui.core">
+       <VBox class="sapUiSmallMargin">
+          <f:SimpleForm id="TAttLine"
+             editable="true"
+             layout="ResponsiveGridLayout"
+             title="TAttLine"
+             labelSpanXL="1"
+             labelSpanL="2"
+             labelSpanM="4"
+             labelSpanS="6"
+             adjustLabelSpan="false"
+             emptySpanXL="0"
+             emptySpanL="0"
+             emptySpanM="0"
+             emptySpanS="0"
+             columnsXL="1"
+             columnsL="1"
+             columnsM="1"
+             breakpointXL="800"
+             breakpointL="500"
+             breakpointM="300"
+             singleContainerFullSize="false" >
+             <f:content>
+                <Label text="Style" />
+                <Select selectedKey="{/style}">
+                 <items>
+                   <core:Item text="none" key="0"/>
+                   <core:Item text="1" key="1"/>
+                   <core:Item text="2" key="2"/>
+                   <core:Item text="3" key="3"/>
+                   <core:Item text="4" key="4"/>
+                   <core:Item text="5" key="5"/>
+                   <core:Item text="6" key="6"/>
+                   <core:Item text="7" key="7"/>
+                   <core:Item text="8" key="8"/>
+                   <core:Item text="9" key="9"/>
+                   <core:Item text="10" key="10"/>
+                 </items>
+               </Select>
+                <Label text="Width"/>
+                <Select selectedKey="{/width}">
+                 <items>
+                   <core:Item text="1" key="1"/>
+                   <core:Item text="2" key="2"/>
+                   <core:Item text="3" key="3"/>
+                   <core:Item text="4" key="4"/>
+                   <core:Item text="5" key="5"/>
+                   <core:Item text="6" key="6"/>
+                 </items>
+               </Select>
+                <Label text="Color" />
+                <Button text="{/color}" press="processTAttLine_Color"/>
+             </f:content>
+          </f:SimpleForm>
+       </VBox>
+</core:FragmentDefinition>

--- a/etc/http/openui5/view/TAttMarker.fragment.xml
+++ b/etc/http/openui5/view/TAttMarker.fragment.xml
@@ -1,60 +1,60 @@
-    <core:FragmentDefinition
-    	xmlns="sap.m"
-    	xmlns:l="sap.ui.layout"
-    	xmlns:f="sap.ui.layout.form"
-    	xmlns:core="sap.ui.core">
-    	<VBox class="sapUiSmallMargin">
-    		<f:SimpleForm id="TAttMarker"
-    			editable="true"
-    			layout="ResponsiveGridLayout"
-    			title="TAttMarker"
-    			labelSpanXL="1"
-    			labelSpanL="2"
-    			labelSpanM="4"
-    			labelSpanS="6"
-    			adjustLabelSpan="false"
-    			emptySpanXL="0"
-    			emptySpanL="0"
-    			emptySpanM="0"
-    			emptySpanS="0"
-    			columnsXL="1"
-    			columnsL="1"
-    			columnsM="1"
-    			breakpointXL="800"
-    			breakpointL="500"
-    			breakpointM="300"
-    			singleContainerFullSize="false" >
-    			<f:content>
-    				<Label text="Style" />
-    				<Select selectedKey="{/style}">
-					  <items>
-						 <core:Item text="none" key="0"/>
-						 <core:Item text="1" key="1"/>
-						 <core:Item text="2" key="2"/>
-						 <core:Item text="3" key="3"/>
-						 <core:Item text="4" key="4"/>
-						 <core:Item text="5" key="5"/>
-						 <core:Item text="6" key="6"/>
-						 <core:Item text="7" key="7"/>
-						 <core:Item text="8" key="8"/>
-						 <core:Item text="9" key="9"/>
-						 <core:Item text="10" key="10"/>
-					  </items>
-				   </Select>
-    				<Label text="Size"/>
-    				<Select selectedKey="{/size}">
-					  <items>
-						 <core:Item text="1" key="1"/>
-						 <core:Item text="2" key="2"/>
-						 <core:Item text="3" key="3"/>
-						 <core:Item text="4" key="4"/>
-						 <core:Item text="5" key="5"/>
-						 <core:Item text="6" key="6"/>
-					  </items>
-				   </Select>
-    				<Label text="Color" />
-    				<Button text="{/color}" press="processTAttMarker_Color"/>
-    			</f:content>
-    		</f:SimpleForm>
-    	</VBox>
-    </core:FragmentDefinition>
+<core:FragmentDefinition
+       xmlns="sap.m"
+       xmlns:l="sap.ui.layout"
+       xmlns:f="sap.ui.layout.form"
+       xmlns:core="sap.ui.core">
+       <VBox class="sapUiSmallMargin">
+          <f:SimpleForm id="TAttMarker"
+             editable="true"
+             layout="ResponsiveGridLayout"
+             title="TAttMarker"
+             labelSpanXL="1"
+             labelSpanL="2"
+             labelSpanM="4"
+             labelSpanS="6"
+             adjustLabelSpan="false"
+             emptySpanXL="0"
+             emptySpanL="0"
+             emptySpanM="0"
+             emptySpanS="0"
+             columnsXL="1"
+             columnsL="1"
+             columnsM="1"
+             breakpointXL="800"
+             breakpointL="500"
+             breakpointM="300"
+             singleContainerFullSize="false" >
+             <f:content>
+                <Label text="Style" />
+                <Select selectedKey="{/style}">
+                 <items>
+                   <core:Item text="none" key="0"/>
+                   <core:Item text="1" key="1"/>
+                   <core:Item text="2" key="2"/>
+                   <core:Item text="3" key="3"/>
+                   <core:Item text="4" key="4"/>
+                   <core:Item text="5" key="5"/>
+                   <core:Item text="6" key="6"/>
+                   <core:Item text="7" key="7"/>
+                   <core:Item text="8" key="8"/>
+                   <core:Item text="9" key="9"/>
+                   <core:Item text="10" key="10"/>
+                 </items>
+               </Select>
+                <Label text="Size"/>
+                <Select selectedKey="{/size}">
+                 <items>
+                   <core:Item text="1" key="1"/>
+                   <core:Item text="2" key="2"/>
+                   <core:Item text="3" key="3"/>
+                   <core:Item text="4" key="4"/>
+                   <core:Item text="5" key="5"/>
+                   <core:Item text="6" key="6"/>
+                 </items>
+               </Select>
+                <Label text="Color" />
+                <Button text="{/color}" press="processTAttMarker_Color"/>
+             </f:content>
+          </f:SimpleForm>
+       </VBox>
+</core:FragmentDefinition>

--- a/etc/http/scripts/JSRootCore.js
+++ b/etc/http/scripts/JSRootCore.js
@@ -95,7 +95,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 24/08/2017";
+   JSROOT.version = "5.3.0 26/09/2017";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;
@@ -109,21 +109,19 @@
    // JSROOT.use_full_libs = true;
 
    JSROOT.touches = false;
-   JSROOT.browser = { isOpera:false, isFirefox:true, isSafari:false, isChrome:false, isIE:false, isWin:false };
+   JSROOT.browser = { isOpera: false, isFirefox: true, isSafari: false, isChrome: false, isIE: false, isWin: false };
 
    if ((typeof document !== "undefined") && (typeof window !== "undefined")) {
       var scripts = document.getElementsByTagName('script');
       for (var n = 0; n < scripts.length; ++n) {
-         var src = scripts[n].src;
-         if ((src===undefined) || (typeof src !== 'string')) continue;
+         if (!scripts[n].src || (typeof scripts[n].src !== 'string')) continue;
 
-         var pos = src.indexOf("scripts/JSRootCore.");
+         var pos = scripts[n].src.indexOf("scripts/JSRootCore.");
          if (pos<0) continue;
 
-         JSROOT.source_dir = src.substr(0, pos);
-         JSROOT.source_min = src.indexOf("scripts/JSRootCore.min.js") >= 0;
-
-         JSROOT.source_fullpath = src;
+         JSROOT.source_dir = scripts[n].src.substr(0, pos);
+         JSROOT.source_min = scripts[n].src.indexOf("scripts/JSRootCore.min.js") >= 0;
+         JSROOT.source_fullpath = scripts[n].src;
 
          if ((console!==undefined) && (typeof console.log == 'function'))
             console.log("Set JSROOT.source_dir to " + JSROOT.source_dir + ", " + JSROOT.version);
@@ -139,7 +137,7 @@
       JSROOT.browser.isWin = navigator.platform.indexOf('Win') >= 0;
    }
 
-   JSROOT.browser.isWebKit = JSROOT.browser.isChrome || JSROOT.browser.isSafari;
+   JSROOT.browser.isWebKit = JSROOT.browser.isChrome || JSROOT.browser.isSafari || JSROOT.browser.isOpera;
 
    // default draw styles, can be changed after loading of JSRootCore.js
    // this style also can be changed providing style=itemname in the URL
@@ -159,7 +157,8 @@
          AutoStat : true,
          FrameNDC : { fX1NDC: 0.07, fY1NDC: 0.12, fX2NDC: 0.95, fY2NDC: 0.88 },
          Palette : 57,
-         MathJax : 0,  // 0 - never, 1 - only for complex cases, 2 - always
+         Latex : 2,    // 0 - never, 1 - only latex symbols, 2 - normal TLatex processing (default), 3 - use MathJax for complex case, 4 - use MathJax always
+         // MathJax : 0,  // depricated, will be supported till JSROOT 6.0, use Latex variable  0 - never, 1 - only for complex cases, 2 - always
          ProgressBox : true,  // show progress box
          Embed3DinSVG : 2,  // 0 - no embed, only 3D plot, 1 - overlay over SVG (IE/WebKit), 2 - embed into SVG (only Firefox)
          NoWebGL : false, // if true, WebGL will be disabled,
@@ -205,13 +204,13 @@
          fOptFit : 0,
          fNumberContours : 20,
          fGridColor : 0,
-         fGridStyle : 11,
+         fGridStyle : 3,
          fGridWidth : 1,
          fFrameFillColor : 0,
-         fFrameLineColor : 1,
          fFrameFillStyle : 1001,
-         fFrameLineStyle : 1,
+         fFrameLineColor : 1,
          fFrameLineWidth : 1,
+         fFrameLineStyle : 1,
          fFrameBorderSize : 1,
          fFrameBorderMode : 0,
          fEndErrorSize : 2,   // size in pixels of end error for E1 draw options
@@ -232,24 +231,6 @@
          kIsZoomed      : JSROOT.BIT(16), // bit set when zooming on Y axis
          kNoTitle       : JSROOT.BIT(17), // don't draw the histogram title
          kIsAverage     : JSROOT.BIT(18)  // Bin contents are average (used by Add)
-   };
-
-   JSROOT.EAxisBits = {
-         kTickPlus      : JSROOT.BIT(9),
-         kTickMinus     : JSROOT.BIT(10),
-         kAxisRange     : JSROOT.BIT(11),
-         kCenterTitle   : JSROOT.BIT(12),
-         kCenterLabels  : JSROOT.BIT(14),
-         kRotateTitle   : JSROOT.BIT(15),
-         kPalette       : JSROOT.BIT(16),
-         kNoExponent    : JSROOT.BIT(17),
-         kLabelsHori    : JSROOT.BIT(18),
-         kLabelsVert    : JSROOT.BIT(19),
-         kLabelsDown    : JSROOT.BIT(20),
-         kLabelsUp      : JSROOT.BIT(21),
-         kIsInteger     : JSROOT.BIT(22),
-         kMoreLogLabels : JSROOT.BIT(23),
-         kDecimals      : JSROOT.BIT(11)
    };
 
    // wrapper for console.log, avoids missing console in IE
@@ -767,7 +748,7 @@
       return xhr;
    }
 
-   JSROOT.loadScript = function(urllist, callback, debugout) {
+   JSROOT.loadScript = function(urllist, callback, debugout, from_previous) {
       // dynamic script loader using callback
       // (as loading scripts may be asynchronous)
       // one could specify list of scripts or style files, separated by semicolon ';'
@@ -776,33 +757,30 @@
       // by the position of JSRootCore.js file, which must be loaded by normal methods:
       // <script type="text/javascript" src="scripts/JSRootCore.js"></script>
 
-      function completeLoad() {
+      delete JSROOT.complete_script_load;
 
-         JSROOT.complete_script_load = null;
-
+      if (from_previous) {
          if (debugout)
             document.getElementById(debugout).innerHTML = "";
          else
             JSROOT.progress();
 
-         if (urllist)
-            return JSROOT.loadScript(urllist, callback, debugout);
-
-         JSROOT.CallBack(callback);
+         if (!urllist) return JSROOT.CallBack(callback);
       }
 
-      if (!urllist)
-         return completeLoad();
+      if (!urllist) return JSROOT.CallBack(callback);
 
       var filename = urllist, separ = filename.indexOf(";"),
           isrootjs = false, isbower = false;
 
       if (separ>0) {
          filename = filename.substr(0, separ);
-         urllist = urllist.slice(separ+1);
+         urllist = urllist.substr(separ+1);
       } else {
          urllist = "";
       }
+
+      var completeLoad = JSROOT.loadScript.bind(JSROOT, urllist, callback, debugout, true);
 
       if (filename.indexOf('&&&scripts/')===0) {
          isrootjs = true;
@@ -813,7 +791,7 @@
          isrootjs = true;
          filename = filename.slice(3);
          if ((filename.indexOf("style/")==0) && JSROOT.source_min &&
-             (filename.lastIndexOf('.css')==filename.length-3) &&
+             (filename.lastIndexOf('.css')==filename.length-4) &&
              (filename.indexOf('.min.css')<0))
             filename = filename.slice(0, filename.length-4) + '.min.css';
       } else
@@ -880,13 +858,13 @@
          element.onreadystatechange = function() {
             if (element.readyState == "loaded" || element.readyState == "complete") {
                element.onreadystatechange = null;
-               if (JSROOT.complete_script_load) completeLoad();
+               if (JSROOT.complete_script_load) JSROOT.complete_script_load();
             }
          }
       } else { // Other browsers
          element.onload = function() {
             element.onload = null;
-            if (JSROOT.complete_script_load) completeLoad();
+            if (JSROOT.complete_script_load) JSROOT.complete_script_load();
          }
       }
 
@@ -897,7 +875,7 @@
       // one could specify kind of requirements
       //     'io'  TFile functionality
       //   'tree'  TTree support
-      //     '2d'  basic 2d graphic (TCanvas)
+      //     '2d'  basic 2d graphic (TCanvas/TPad/TFrame)
       //     '3d'  basic 3d graphic (three.js)
       //   'hist'  histograms 2d graphic
       // 'hist3d'  histograms 3d graphic
@@ -970,7 +948,7 @@
             modules.push('JSRootTree');
          }
 
-      if ((kind.indexOf('2d;')>=0) || (kind.indexOf("3d;")>=0) || (kind.indexOf("geom;")>=0)) {
+      if ((kind.indexOf('2d;')>=0) || (kind.indexOf("3d;")>=0) || (kind.indexOf("geom;")>=0) || (kind.indexOf("openui5;")>=0)) {
          if (jsroot._test_d3_ === undefined) {
             if ((typeof d3 == 'object') && d3.version && (d3.version[0]==="4"))  {
                jsroot.console('Reuse existing d3.js ' + d3.version + ", expected 4.4.4", debugout);
@@ -1053,6 +1031,7 @@
       }
 
       if (kind.indexOf("mathjax;")>=0) {
+
          if (typeof MathJax == 'undefined') {
             mainfiles += (use_bower ? "###MathJax/MathJax.js" : "https://root.cern/js/mathjax/latest/MathJax.js") +
                            "?config=TeX-AMS-MML_SVG&delayStartupUntil=configured";
@@ -1076,7 +1055,6 @@
                normal_callback();
             }
          }
-         if (jsroot.gStyle.MathJax == 0) jsroot.gStyle.MathJax = 1;
       }
 
       if (kind.indexOf("simple;")>=0) {
@@ -1351,6 +1329,15 @@
             JSROOT.extend(obj, { fFunctions: JSROOT.Create("TList"), fGraphs: JSROOT.Create("TList"),
                                  fHistogram: null, fMaximum: -1111, fMinimum: -1111 });
             break;
+         case 'TGraphPolargram':
+            JSROOT.Create("TNamed", obj);
+            JSROOT.Create("TAttText", obj);
+            JSROOT.Create("TAttLine", obj);
+            JSROOT.extend(obj, { fRadian: true, fDegree: false, fGrad: false, fPolarLabelColor: 1, fRadialLabelColor: 1,
+                                 fAxisAngle: 0, fPolarOffset: 0.04, fPolarTextSize: 0.04, fRadialOffset: 0.025, fRadialTextSize: 0.035,
+                                 fRwrmin: 0, fRwrmax: 1, fRwtmin: 0, fRwtmax: 2*Math.PI, fTickpolarSize: 0.02,
+                                 fPolarLabelFont: 62, fRadialLabelFont: 62, fCutRadial: 0, fNdivRad: 508, fNdivPol: 508 });
+            break;
          case 'TPolyLine':
             JSROOT.Create("TObject", obj);
             JSROOT.Create("TAttLine", obj);
@@ -1360,11 +1347,11 @@
          case 'TGaxis':
             JSROOT.Create("TLine", obj);
             JSROOT.Create("TAttText", obj);
-            JSROOT.extend(obj, { _fChopt: "", fFunctionName: "", fGridLength: 0,
-                                  fLabelColor: 1, fLabelFont: 42, fLabelOffset: 0.005, fLabelSize: 0.035,
-                                  fName: "", fNdiv: 12, fTickSize: 0.02, fTimeFormat: "",
-                                  fTitle: "", fTitleOffset: 1, fTitleSize: 0.035,
-                                  fWmax: 100, fWmin: 0 });
+            JSROOT.extend(obj, { fChopt: "", fFunctionName: "", fGridLength: 0,
+                                 fLabelColor: 1, fLabelFont: 42, fLabelOffset: 0.005, fLabelSize: 0.035,
+                                 fName: "", fNdiv: 12, fTickSize: 0.02, fTimeFormat: "",
+                                 fTitle: "", fTitleOffset: 1, fTitleSize: 0.035,
+                                 fWmax: 100, fWmin: 0 });
             break;
          case 'TAttPad':
             JSROOT.extend(obj, { fLeftMargin: JSROOT.gStyle.fPadLeftMargin,
@@ -1373,10 +1360,10 @@
                                  fTopMargin: JSROOT.gStyle.fPadTopMargin,
                                  fXfile: 2, fYfile: 2, fAfile: 1, fXstat: 0.99, fYstat: 0.99, fAstat: 2,
                                  fFrameFillColor: JSROOT.gStyle.fFrameFillColor,
-                                 fFrameLineColor: JSROOT.gStyle.fFrameLineColor,
                                  fFrameFillStyle: JSROOT.gStyle.fFrameFillStyle,
-                                 fFrameLineStyle: JSROOT.gStyle.fFrameLineStyle,
+                                 fFrameLineColor: JSROOT.gStyle.fFrameLineColor,
                                  fFrameLineWidth: JSROOT.gStyle.fFrameLineWidth,
+                                 fFrameLineStyle: JSROOT.gStyle.fFrameLineStyle,
                                  fFrameBorderSize: JSROOT.gStyle.fFrameBorderSize,
                                  fFrameBorderMode: JSROOT.gStyle.fFrameBorderMode });
             break;
@@ -1579,7 +1566,7 @@
 
       if ((typename === "TPaveText") || (typename === "TPaveStats")) {
          m.AddText = function(txt) {
-            this.fLines.Add({ _typename: 'TText', fTitle: txt, fTextColor: 1 });
+            this.fLines.Add({ _typename: 'TLatex', fTitle: txt, fTextColor: 1 });
          }
          m.Clear = function() {
             this.fLines.Clear();
@@ -1642,6 +1629,7 @@
                            .replace(/\b(cos)\b/gi, 'Math.cos')
                            .replace(/\b(tan)\b/gi, 'Math.tan')
                            .replace(/\b(exp)\b/gi, 'Math.exp')
+                           .replace(/\b(pow)\b/gi, 'Math.pow')
                            .replace(/pi/g, 'Math.PI');
               for (var n=2;n<10;++n)
                  _func = _func.replace('x^'+n, 'Math.pow(x,'+n+')');
@@ -1666,18 +1654,24 @@
             return this._func(x, y);
          }
          m.GetParName = function(n) {
-            if (('fFormula' in this) && ('fParams' in this.fFormula)) return this.fFormula.fParams[n].first;
-            if ('fNames' in this) return this.fNames[n];
-            return "Par"+n;
+            if (this.fFormula && this.fFormula.fParams) return this.fFormula.fParams[n].first;
+            if (this.fNames && this.fNames[n]) return this.fNames[n];
+            return "p"+n;
          }
          m.GetParValue = function(n) {
-            if (('fFormula' in this) && ('fClingParameters' in this.fFormula)) return this.fFormula.fClingParameters[n];
-            if (('fParams' in this) && (this.fParams!=null))  return this.fParams[n];
-            return null;
+            if (this.fFormula && this.fFormula.fClingParameters) return this.fFormula.fClingParameters[n];
+            if (this.fParams) return this.fParams[n];
+            return undefined;
+         }
+         m.GetParError = function(n) {
+            return this.fParErrors ? this.fParErrors[n] : undefined;
+         }
+         m.GetNumPars = function() {
+            return this.fNpar;
          }
       }
 
-      if ((typename.indexOf("TGraph") == 0) || (typename == "TCutG")) {
+      if (((typename.indexOf("TGraph") == 0) || (typename == "TCutG")) && (typename != "TGraphPolargram") && (typename != "TGraphTime")) {
          // check if point inside figure specified by the TGraph
          m.IsInside = function(xp,yp) {
             var i, j = this.fNpoints - 1, x = this.fX, y = this.fY, oddNodes = false;
@@ -1981,6 +1975,7 @@
       if (JSROOT.GetUrlOption('3d', src)!=null) prereq += "3d;";
       if (JSROOT.GetUrlOption('math', src)!=null) prereq += "math;";
       if (JSROOT.GetUrlOption('mathjax', src)!=null) prereq += "mathjax;";
+      if (JSROOT.GetUrlOption('openui5', src)!=null) prereq += "openui5;";
       var user = JSROOT.GetUrlOption('load', src),
           onload = JSROOT.GetUrlOption('onload', src),
           bower = JSROOT.GetUrlOption('bower', src);

--- a/etc/http/scripts/JSRootGeoPainter.js
+++ b/etc/http/scripts/JSRootGeoPainter.js
@@ -143,6 +143,7 @@
       JSROOT.TObjectPainter.call(this, obj);
 
       this.no_default_title = true; // do not set title to main DIV
+      this.mode3d = true; // indication of 3D mode
 
       this.Cleanup(true);
    }
@@ -2533,6 +2534,14 @@
    }
 
    TGeoPainter.prototype.Render3D = function(tmout, measure) {
+      // call 3D rendering of the geometry drawing
+      // tmout specifies delay, after which actual rendering will be invoked
+      // Timeout used to avoid multiple rendering of the picture when several 3D drawings
+      // superimposed with each other.
+      // If tmeout<=0, rendering performed immediately
+      // Several special values are used:
+      //   -2222 - rendering performed only if there were previous calls, which causes timeout activation
+
       if (!this._renderer) {
          console.warn('renderer object not exists - check code');
          return;
@@ -2541,8 +2550,11 @@
       if (tmout === undefined) tmout = 5; // by default, rendering happens with timeout
 
       if ((tmout <= 0) || this._usesvg) {
-         if ('render_tmout' in this)
+         if ('render_tmout' in this) {
             clearTimeout(this.render_tmout);
+         } else {
+            if (tmout === -2222) return; // special case to check if rendering timeout was active
+         }
 
          var tm1 = new Date();
 

--- a/etc/http/scripts/JSRootIOEvolution.js
+++ b/etc/http/scripts/JSRootIOEvolution.js
@@ -2462,6 +2462,14 @@
          marker.fName = (ver > 1) ? buf.ReadTString() : "TPolyMarker3D";
       };
 
+      cs['TPolyLine3D'] = function(buf, obj) {
+         buf.ClassStreamer(obj, "TObject");
+         buf.ClassStreamer(obj, "TAttLine");
+         obj.fN = buf.ntoi4();
+         obj.fP = buf.ReadFastArray(obj.fN*3, JSROOT.IO.kFloat);
+         obj.fOption = buf.ReadTString();
+      };
+
       cs['TStreamerInfo'] = function(buf, obj) {
          // stream an object of class TStreamerInfo from the I/O buffer
          buf.ClassStreamer(obj, "TNamed");
@@ -2629,6 +2637,11 @@
       ds['TQObject'] = function(buf,obj) {
          // do nothing
       };
+
+      ds['TGraphStruct'] = ds['TGraphNode'] = ds['TGraphEdge'] = function(buf,obj) {
+         // do nothing
+      };
+
 
       ds['TDatime'] = function(buf,obj) {
          obj.fDatime = buf.ntou4();

--- a/etc/http/scripts/JSRootPainter.hierarchy.js
+++ b/etc/http/scripts/JSRootPainter.hierarchy.js
@@ -2166,7 +2166,7 @@
       if (drawing && socket_kind) {
 
          var painter = new JSROOT.TCanvasPainter(null);
-         painter.plain_layout = painter.batch_mode = JSROOT.GetUrlOption("batch_mode") !== null;
+         painter.batch_mode = JSROOT.GetUrlOption("batch_mode") !== null;
          if (painter.batch_mode) JSROOT.BatchMode = true;
 
          if (window) {
@@ -2176,13 +2176,15 @@
 
          if (use_openui && !painter.batch_mode) {
 
-            painter.plain_layout = true;
-
             painter._configured_socket_kind = socket_kind;
-
-            JSROOT.openui5_canvas_painter = painter;
+            painter.use_openui = true;
 
             return JSROOT.AssertPrerequisites('openui5', function() {
+            
+               var oData = { canvas_painter: painter };
+               var oModel = new sap.ui.model.json.JSONModel(oData);
+               sap.ui.getCore().setModel(oModel, "TopCanvasId--MainPanel");
+               
                new JSROOT.sap.ui.xmlview({
                   id: "TopCanvasId",
                   viewName: "sap.ui.jsroot.view.Canvas"
@@ -2586,6 +2588,7 @@
    GridDisplay.prototype = Object.create(MDIDisplay.prototype);
 
    GridDisplay.prototype.CreateGroup = function(handle, main, num, childs, sizes) {
+
       if (!sizes) sizes = new Array(num);
       var sum1 = 0, sum2 = 0;
       for (var n=0;n<num;++n) sum1 += (sizes[n] || 1);

--- a/etc/http/scripts/JSRootPainter.js
+++ b/etc/http/scripts/JSRootPainter.js
@@ -163,67 +163,12 @@
                        'oArial', 'bArial', 'boArial', 'Courier New',
                        'oCourier New', 'bCourier New', 'boCourier New',
                        'Symbol', 'Times New Roman', 'Wingdings', 'Symbol', 'Verdana'],
-          superscript_symbols_map: {
-                '1': '\xB9',
-                '2': '\xB2',
-                '3': '\xB3',
-                'o': '\xBA',
-                '0': '\u2070',
-                'i': '\u2071',
-                '4': '\u2074',
-                '5': '\u2075',
-                '6': '\u2076',
-                '7': '\u2077',
-                '8': '\u2078',
-                '9': '\u2079',
-                '+': '\u207A',
-                '-': '\u207B',
-                '=': '\u207C',
-                '(': '\u207D',
-                ')': '\u207E',
-                'n': '\u207F',
-                'a': '\xAA',
-                'v': '\u2C7D',
-                'h': '\u02B0',
-                'j': '\u02B2',
-                'r': '\u02B3',
-                'w': '\u02B7',
-                'y': '\u02B8',
-                'l': '\u02E1',
-                's': '\u02E2',
-                'x': '\u02E3'
-          },
-          subscript_symbols_map: {
-                  '0': '\u2080',
-                  '1': '\u2081',
-                  '2': '\u2082',
-                  '3': '\u2083',
-                  '4': '\u2084',
-                  '5': '\u2085',
-                  '6': '\u2086',
-                  '7': '\u2087',
-                  '8': '\u2088',
-                  '9': '\u2089',
-                  '+': '\u208A',
-                  '-': '\u208B',
-                  '=': '\u208C',
-                  '(': '\u208D',
-                  ')': '\u208E',
-                  'a': '\u2090',
-                  'e': '\u2091',
-                  'o': '\u2092',
-                  'x': '\u2093',
-                  'ə': '\u2094',
-                  'h': '\u2095',
-                  'k': '\u2096',
-                  'l': '\u2097',
-                  'm': '\u2098',
-                  'n': '\u2099',
-                  'p': '\u209A',
-                  's': '\u209B',
-                  't': '\u209C',
-                  'j': '\u2C7C'
-          },
+          // taken from https://www.math.utah.edu/~beebe/fonts/afm-widths.html
+          root_fonts_aver_width: [ 0.537, 0.514,
+                                   0.535, 0.520, 0.537,
+                                   0.54, 0.556, 0.56, 0.6,
+                                   0.6, 0.6, 0.6,
+                                   0.587, 0.514, 0.896, 0.587, 0.55 ],
           symbols_map: {
                 // greek letters
                 '#alpha': '\u03B1',
@@ -280,9 +225,10 @@
                 '#Zeta': '\u0396',
                 '#varUpsilon': '\u03D2',
                 '#epsilon': '\u03B5',
-                // math symbols
 
+                // only required for MathJax to provide correct replacement
                 '#sqrt': '\u221A',
+                '#bar': '',
 
                 // from TLatex tables #2 & #3
                 '#leq': '\u2264',
@@ -365,7 +311,6 @@
                 '#GT': '\x3E',
                 '#forall': '\u2200',
                 '#exists': '\u2203',
-                '#bar': '',
                 '#vec': '',
                 '#dot': '\u22C5',
                 '#hat': '\xB7',
@@ -390,23 +335,6 @@
                 '#club':"\\clubsuit",
                 '#spade':"\\spadesuit",
                 '#heart':"\\heartsuit",
-                '#diamond':"\\diamondsuit",
-                '#voidn':"\\wp",
-                '#voidb':"f",
-                '#copyright':"(c)",
-                '#ocopyright':"(c)",
-                '#trademark':"TM",
-                '#void3':"TM",
-                '#oright':"R",
-                '#void1':"R",
-                '#3dots':"\\ldots",
-                '#lbar':"\\mid",
-                '#void8':"\\mid",
-                '#divide':"\\div",
-                '#Jgothic':"\\Im",
-                '#Rgothic':"\\Re",
-                '#doublequote':"\"",
-                '#plus':"+",
                 '#diamond':"\\diamondsuit",
                 '#voidn':"\\wp",
                 '#voidb':"f",
@@ -511,8 +439,11 @@
       var tt = JSROOT.GetUrlOption("tooltip", url);
       if (tt !== null) JSROOT.gStyle.Tooltip = parseInt(tt);
 
-      var mathjax = JSROOT.GetUrlOption("mathjax", url);
-      if ((mathjax!==null) && (mathjax!="0")) JSROOT.gStyle.MathJax = 1;
+      var mathjax = JSROOT.GetUrlOption("mathjax", url),
+          latex = JSROOT.GetUrlOption("latex", url);
+
+      if ((mathjax!==null) && (mathjax!="0") && (latex===null)) latex = "math";
+      if (latex!==null) JSROOT.gStyle.Latex = latex; // decoding will be performed with the first text drawing
 
       if (JSROOT.GetUrlOption("nomenu", url)!=null) JSROOT.gStyle.ContextMenu = false;
       if (JSROOT.GetUrlOption("noprogress", url)!=null) JSROOT.gStyle.ProgressBox = false;
@@ -675,6 +606,10 @@
       return "M" + (x+this.x0).toFixed(this.ndig)+ "," + (y+this.y0).toFixed(this.ndig) + this.marker;
    }
 
+   TAttMarkerHandler.prototype.GetFullSize = function() {
+      return this.scale*this.size;
+   }
+
    TAttMarkerHandler.prototype.Change = function(color, style, size) {
       this.changed = true;
 
@@ -701,8 +636,8 @@
          return true;
       }
 
-      var marker_kind = ((this.style > 0) && (this.style < Painter.root_markers.length)) ? Painter.root_markers[this.style] : 100;
-      var shape = marker_kind % 100;
+      var marker_kind = Painter.root_markers[this.style] || 100,
+          shape = marker_kind % 100;
 
       this.fill = (marker_kind>=100);
 
@@ -713,7 +648,7 @@
          default: this.size = size; this.scale = 8;
       }
 
-      size = this.size*this.scale;
+      size = this.GetFullSize();
 
       this.ndig = (size>7) ? 0 : ((size>2) ? 1 : 2);
       if (shape == 6) this.ndig++;
@@ -722,7 +657,7 @@
       switch(shape) {
          case 0: // circle
             this.x0 = -size/2;
-            this.marker = "a"+half+","+half+" 0 1,0 "+full+",0a"+half+","+half+" 0 1,0 -"+full+",0z";
+            this.marker = "a"+half+","+half+",0,1,0,"+full+",0a"+half+","+half+",0,1,0,-"+full+",0z";
             break;
          case 1: // cross
             var d = (size/3).toFixed(this.ndig);
@@ -739,18 +674,18 @@
             break;
          case 4: // triangle-up
             this.y0 = size/2;
-            this.marker = "l-"+ half+",-"+full+"h"+full+"z";
+            this.marker = "l-"+half+",-"+full+"h"+full+"z";
             break;
          case 5: // triangle-down
             this.y0 = -size/2;
-            this.marker = "l-"+ half+","+full+"h"+full+"z";
+            this.marker = "l-"+half+","+full+"h"+full+"z";
             break;
          case 6: // star
             this.y0 = -size/2;
-            this.marker = "l" + (size/3).toFixed(this.ndig)+","+full +
-                         "l-"+ (5/6*size).toFixed(this.ndig) + ",-" + (5/8*size).toFixed(this.ndig) +
-                         "h" + full +
-                         "l-" + (5/6*size).toFixed(this.ndig) + "," + (5/8*size).toFixed(this.ndig) + "z";
+            this.marker = "l"  + (size/3).toFixed(this.ndig) + "," + full +
+                          "l-" + (5/6*size).toFixed(this.ndig) + ",-" + (5/8*size).toFixed(this.ndig) +
+                          "h"  + full +
+                          "l-" + (5/6*size).toFixed(this.ndig) + "," + (5/8*size).toFixed(this.ndig) + "z";
             break;
          case 7: // asterisk
             this.x0 = this.y0 = -size/2;
@@ -768,7 +703,7 @@
             break;
          default: // diamand
             this.x0 = -size/2;
-            this.marker = "l"+half+",-"+half+"l"+half+","+half+"l-"+half+","+half + "z";
+            this.marker = "l"+half+",-"+half+"l"+half+","+half+"l-"+half+","+half+"z";
             break;
       }
 
@@ -803,13 +738,12 @@
       this.width = _width;
       this.style = style;
       if (can_excl) {
-         this.excl_side = 0;
-         this.excl_width = 0;
+         this.excl_side = this.excl_width = 0;
          if (Math.abs(this.width) > 99) {
             // exclusion graph
             this.excl_side = (this.width < 0) ? -1 : 1;
             this.excl_width = Math.floor(this.width / 100) * 5;
-            this.width = this.width % 100; // line width
+            this.width = Math.abs(this.width % 100); // line width
          }
       }
 
@@ -1027,7 +961,8 @@
    Painter.getFontDetails = function(fontIndex, size) {
 
       var res = { name: "Arial", size: Math.round(size || 11), weight: null, style: null },
-          fontName = Painter.root_fonts[Math.floor(fontIndex / 10)] || "";
+          indx = Math.floor(fontIndex / 10),
+          fontName = Painter.root_fonts[indx] || "";
 
       while (fontName.length > 0) {
          if (fontName[0]==='b') res.weight = "bold"; else
@@ -1040,34 +975,20 @@
          res.weight = res.style = null;
 
       res.name = fontName;
+      res.aver_width = Painter.root_fonts_aver_width[indx] || 0.55;
 
-      res.SetFont = function(selection) {
-         selection.attr("font-family", this.name)
-                  .attr("font-size", this.size)
-                  .attr("xml:space","preserve");
+      res.setFont = function(selection, arg) {
+         selection.attr("font-family", this.name);
+         if (arg != 'without-size')
+            selection.attr("font-size", this.size)
+                     .attr("xml:space", "preserve");
          if (this.weight)
             selection.attr("font-weight", this.weight);
          if (this.style)
             selection.attr("font-style", this.style);
       }
 
-      res.asStyle = function(sz) {
-         return (sz ? sz : this.size) + "px " + this.name;
-      }
-
-      res.stringWidth = function(svg, line) {
-         /* compute the bounding box of a string by using temporary svg:text */
-         var text = svg.append("svg:text")
-                     .attr("xml:space","preserve")
-                     .style("opacity", 0)
-                     .text(line);
-         this.SetFont(text);
-         var w = text.node().getBBox().width;
-         text.remove();
-         return w;
-      }
-
-      res.func = res.SetFont.bind(res);
+      res.func = res.setFont.bind(res);
 
       return res;
    }
@@ -1117,74 +1038,86 @@
           msec = next(" ", 0, 999);
 
       var dt = new Date(Date.UTC(year, month, day, hour, min, sec, msec));
-      return dt.getTime();
-   }
 
-   Painter.translateSuperscript = function(_exp) {
-      var res = "";
-      for (var n=0;n<_exp.length;++n)
-         res += (this.superscript_symbols_map[_exp[n]] || _exp[n]);
-      return res;
-   }
+      var offset = dt.getTime();
 
-   Painter.translateSubscript = function(_sub) {
-      var res = "";
-      for (var n=0;n<_sub.length;++n)
-         res += (this.subscript_symbols_map[_sub[n]] || _sub[n]);
-      return res;
-   }
+      // now also handle suffix like GMT or GMT -0600
+      sof = sof.toUpperCase();
 
-   Painter.formatExp = function(label) {
-      var str = label.toLowerCase().replace('e+', 'x10@').replace('e-', 'x10@-'),
-          pos = str.indexOf('@'),
-          exp = Painter.translateSuperscript(str.substr(pos+1)),
-          str = str.substr(0, pos);
+      if (sof.indexOf('GMT')==0) {
+         offset += dt.getTimezoneOffset()*60000;
+         sof = sof.substr(4).trim();
+         if (sof.length > 3) {
+            var p = 0, sign = 1000;
+            if (sof[0]=='-') { p = 1; sign = -1000; }
+            offset -= sign * (parseInt(sof.substr(p,2))*3600 + parseInt(sof.substr(p+2,2))*60);
+         }
+      }
 
-      return ((str === "1x10") ? "10" : str) + exp;
+      return offset;
    }
 
    Painter.translateLaTeX = function(str) {
-      var i, lstr = str.match(/\^{(.*?)}/gi);
-      if (lstr)
-         for (i = 0; i < lstr.length; ++i)
-            str = str.replace(lstr[i], Painter.translateSuperscript(lstr[i].substr(2, lstr[i].length-3)));
+      while ((str.length>2) && (str[0]=='{') && (str[str.length-1]=='}'))
+         str = str.substr(1,str.length-2);
 
-      lstr = str.match(/\_{(.*?)}/gi);
-      if (lstr)
-         for (i = 0; i < lstr.length; ++i)
-            str = str.replace(lstr[i], Painter.translateSubscript(lstr[i].substr(2, lstr[i].length-3)));
+      // str = str.replace(/\^2/gi, '^{2}').replace(/\^3/gi,'^{3}');
 
-      lstr = str.match(/\#sqrt{(.*?)}/gi);
-      if (lstr)
-         for (i = 0; i < lstr.length; ++i)
-            str = str.replace(lstr[i], lstr[i].replace(' ', '').replace('#sqrt{', '#sqrt').replace('}', ''));
+      for (var i in this.symbols_map)
+         str = str.replace(new RegExp(i,'g'), this.symbols_map[i]);
 
-      for (i in Painter.symbols_map)
-         str = str.replace(new RegExp(i,'g'), Painter.symbols_map[i]);
+      return str;
+   }
 
-      // simple workaround for simple #splitline{first_line}{second_line}
-      if ((str.indexOf("#splitline{")==0) && (str[str.length-1]=="}")) {
-         var pos = str.indexOf("}{");
-         if ((pos>0) && (pos === str.lastIndexOf("}{")))
-            str = str.replace("}{", "\n ").slice(11, str.length-1)
-      }
+   Painter.approxTextWidth = function(font, label) {
+      // returns approximate width of given label, required for reasonable scaling of text in node.js
 
-      return str.replace(/\^2/gi,'\xB2').replace(/\^3/gi,'\xB3');
+      return label.length * font.size * font.aver_width;
    }
 
    Painter.isAnyLatex = function(str) {
       return (str.indexOf("#")>=0) || (str.indexOf("\\")>=0) || (str.indexOf("{")>=0);
    }
 
-   Painter.translateMath = function(str, kind, color) {
+   Painter.translateMath = function(str, kind, color, painter) {
       // function translate ROOT TLatex into MathJax format
 
-      if (kind!=2) {
+      if (kind != 2) {
          for (var x in Painter.math_symbols_map)
             str = str.replace(new RegExp(x,'g'), Painter.math_symbols_map[x]);
 
          for (var x in Painter.symbols_map)
             str = str.replace(new RegExp(x,'g'), "\\" + x.substr(1));
+
+         // replace all #color[]{} occurances
+         var clean = "", first = true;
+         while (str) {
+            var p = str.indexOf("#color[");
+            if ((p<0) && first) { clean = str; break; }
+            first = false;
+            if (p!=0) {
+               var norm = (p<0) ? str : str.substr(0, p);
+               clean += norm;
+               if (p<0) break;
+            }
+
+            str = str.substr(p+7);
+            p = str.indexOf("]{");
+            if (p<=0) break;
+            var colindx = parseInt(str.substr(0,p));
+            if (isNaN(colindx)) break;
+            var col = painter.get_color(colindx);
+            str = str.substr(p+2);
+            p = str.indexOf("}");
+            if (p<0) break;
+
+            var part = str.substr(0,p);
+            str = str.substr(p+1);
+            if (part)
+               clean += "\\color{" + col + '}{' + part + "}";
+         }
+
+         str = clean;
       } else {
          str = str.replace(/\\\^/g, "\\hat");
       }
@@ -1301,10 +1234,12 @@
       return chld.painter;
    }
 
-   TBasePainter.prototype.Cleanup = function() {
+   TBasePainter.prototype.Cleanup = function(keep_origin) {
       // generic method to cleanup painter
 
-      this.layout_main('simple');
+      var origin = this.select_main('origin');
+      if (!origin.empty() && !keep_origin) origin.html("");
+      this.set_layout_kind('simple');
       this.AccessTopPainter(false);
       this.divid = null;
 
@@ -1320,12 +1255,14 @@
 
       this._ready_called_ = true;
       if (this._ready_callback_ !== undefined) {
+         var callbacks = this._ready_callback_;
          if (!this._return_res_painter) res_painter = this;
-                                   else delete this._return_res_painter;
 
-         while (this._ready_callback_.length)
-            JSROOT.CallBack(this._ready_callback_.shift(), res_painter);
+         delete this._return_res_painter;
          delete this._ready_callback_;
+
+         while (callbacks.length)
+            JSROOT.CallBack(callbacks.shift(), res_painter);
       }
       return this;
    }
@@ -1368,7 +1305,7 @@
 
    TBasePainter.prototype.select_main = function(is_direct) {
       // return d3.select for main element for drawing, defined with divid
-      // if main element was layout, returns main element inside layout
+      // if main element was layouted, returns main element inside layout
 
       if (!this.divid) return d3.select(null);
       var id = this.divid;
@@ -1377,17 +1314,10 @@
       if (res.empty() || (is_direct==='origin')) return res;
 
       var use_enlarge = res.property('use_enlarge'),
-          layout = res.property('layout');
+          layout = res.property('layout') || 'simple',
+          layout_selector = (layout=='simple') ? "" : res.property('layout_selector');
 
-      if (layout && (layout !=="simple")) {
-         switch(is_direct) {
-            case 'header': res = res.select(".canvas_header"); break;
-            case 'footer': res = res.select(".canvas_footer"); break;
-            default: res = res.select(".canvas_main");
-         }
-      } else {
-         if (typeof is_direct === 'string') return d3.select(null);
-      }
+      if (layout_selector) res = res.select(layout_selector);
 
       // one could redirect here
       if (!is_direct && !res.empty() && use_enlarge) res = d3.select("#jsroot_enlarge_div");
@@ -1395,53 +1325,21 @@
       return res;
    }
 
-   TBasePainter.prototype.layout_main = function(kind) {
+   TBasePainter.prototype.get_layout_kind = function() {
+      var origin = this.select_main('origin'),
+          layout = origin.empty() ? "" : origin.property('layout');
 
-      kind = kind || "simple";
+      return layout || 'simple';
+   }
 
-      // first extract all childs
+   TBasePainter.prototype.set_layout_kind = function(kind, main_selector) {
+      // change layout settings
       var origin = this.select_main('origin');
-      if (origin.empty() || (origin.property('layout') === kind)) return false;
-
-      var main = this.select_main(), lst = [];
-
-      while (main.node().firstChild)
-         lst.push(main.node().removeChild(main.node().firstChild));
-
-      if (kind === "simple") {
-         // simple layout - nothing inside
-         origin.html("");
-         main = origin;
-      } else {
-
-         // now create all necessary divs
-
-         var maindiv = origin.html("")
-                          .append("div")
-                          .attr("class","jsroot")
-                          .style('display','flex')
-                          .style('flex-direction','column')
-                          .style('width','100%')
-                          .style('height','100%');
-
-         var header = maindiv.append("div").attr('class','canvas_header').style('width','100%');
-
-         main = maindiv.append("div")
-                       .style('flex',1) // use all available vertical space in the parent div
-                       .style('width','100%')
-                       .style("position","relative") // one should use absolute position for
-                       .attr("class", "canvas_main");
-
-         var footer = maindiv.append("div").attr('class','canvas_footer').style('width','100%');
+      if (!origin.empty()) {
+         if (!kind) kind = 'simple';
+         origin.property('layout', kind);
+         origin.property('layout_selector', (kind!='simple') && main_selector ? main_selector : null);
       }
-
-      // now append all childs to the newmain
-      for (var k=0;k<lst.length;++k)
-         main.node().appendChild(lst[k]);
-
-      origin.property('layout', kind);
-
-      return lst.length > 0; // return true when layout changed and there are elements inside
    }
 
    TBasePainter.prototype.check_main_resize = function(check_level, new_size, height_factor) {
@@ -1628,12 +1526,17 @@
    TObjectPainter.prototype = Object.create(TBasePainter.prototype);
 
    TObjectPainter.prototype.Cleanup = function() {
+      // generic method to cleanup painters
+      // first of all, remove object drawaing and in case of main painter - also main HTML components
 
       this.RemoveDrawG();
 
-      // generic method to cleanup painters
-      //if (this.is_main_painter())
-      //   this.select_main().html("");
+      var keep_origin = true;
+
+      if (this.is_main_painter()) {
+         var pp = this.pad_painter(true);
+         if (!pp || pp.normal_canvas === false) keep_origin = false;
+      }
 
       // cleanup all existing references
       this.pad_name = "";
@@ -1648,7 +1551,7 @@
       delete this._drawopt;
       delete this.root_colors;
 
-      TBasePainter.prototype.Cleanup.call(this);
+      TBasePainter.prototype.Cleanup.call(this, keep_origin);
    }
 
    TObjectPainter.prototype.GetObject = function() {
@@ -1708,6 +1611,18 @@
       return jsarr[indx];
    }
 
+   TObjectPainter.prototype.add_color = function(color) {
+      var jsarr = this.root_colors;
+      if (!jsarr) {
+         var pp = this.pad_painter();
+         jsarr = this.root_colors = (pp && pp.root_colors) ? pp.root_colors : JSROOT.Painter.root_colors;
+      }
+      var indx = jsarr.indexOf(color);
+      if (indx >= 0) return indx;
+      jsarr.push(color);
+      return jsarr.length-1;
+   }
+
    TObjectPainter.prototype.CheckResize = function(arg) {
       // no painter - no resize
       var pad_painter = this.pad_painter();
@@ -1726,27 +1641,42 @@
       }
    }
 
+   TObjectPainter.prototype.RecreateDrawG = function(usepad, layer) {
+      // keep old function for a while - later
+      console.warn("Obsolete RecreateDrawG is used, will be removed soon. Change to CreateG");
+      return this.CreateG(usepad ? undefined : layer);
+   }
+
    /** function (re)creates svg:g element used for specific object drawings
-     *  either one attached svg:g to pad (take_pad==true) or to the frame (take_pad==false)
-     *  svg:g element can be attached to different layers */
-   TObjectPainter.prototype.RecreateDrawG = function(take_pad, layer) {
+     *  either one attach svg:g to pad list of primitives (default)
+     *  or svg:g element created in specified frame layer (default main_layer) */
+   TObjectPainter.prototype.CreateG = function(frame_layer) {
       if (this.draw_g) {
          // one should keep svg:g element on its place
          // d3.selectAll(this.draw_g.node().childNodes).remove();
          this.draw_g.selectAll('*').remove();
       } else
-      if (take_pad) {
-         if (typeof layer != 'string') layer = "text_layer";
-         if (layer[0] == ".") layer = layer.substr(1);
-         this.draw_g = this.svg_layer(layer).append("svg:g");
+      if (frame_layer) {
+         var frame = this.svg_frame();
+         if (frame.empty()) return frame;
+         if (typeof frame_layer != 'string') frame_layer = "main_layer";
+         var layer = frame.select("." + frame_layer);
+         if (layer.empty()) layer = frame.select(".main_layer");
+         this.draw_g = layer.append("svg:g");
       } else {
-         if (typeof layer != 'string') layer = ".main_layer";
-         if (layer[0] != ".") layer = "." + layer;
-         this.draw_g = this.svg_frame().select(layer).append("svg:g");
+         var layer = this.svg_layer("primitives_layer");
+         this.draw_g = layer.append("svg:g");
+
+         // layer.selectAll(".most_upper_primitives").raise();
+         var up = [], chlds = layer.node().childNodes;
+         for (var n=0;n<chlds.length;++n)
+            if (d3.select(chlds[n]).classed("most_upper_primitives")) up.push(chlds[n]);
+
+         up.forEach(function(top) { d3.select(top).raise(); });
       }
 
       // set attributes for debugging
-      if (this.draw_object!==null) {
+      if (this.draw_object) {
          this.draw_g.attr('objname', encodeURI(this.draw_object.fName || "name"));
          this.draw_g.attr('objtype', encodeURI(this.draw_object._typename || "type"));
       }
@@ -1754,7 +1684,7 @@
       return this.draw_g;
    }
 
-   /** This is main graphical SVG element, where all Canvas drawing are performed */
+   /** This is main graphical SVG element, where all drawings are performed */
    TObjectPainter.prototype.svg_canvas = function() {
       return this.select_main().select(".root_canvas");
    }
@@ -1764,7 +1694,7 @@
       var c = this.svg_canvas();
       if (pad_name === undefined) pad_name = this.pad_name;
       if (pad_name && !c.empty())
-         c = c.select(".subpads_layer").select("[pad=" + pad_name + ']');
+         c = c.select(".primitives_layer").select("[pad=" + pad_name + ']');
       return c;
    }
 
@@ -1773,8 +1703,12 @@
       var svg = this.svg_pad(pad_name);
       if (svg.empty()) return svg;
 
-      var node = svg.node().firstChild;
+      if (name.indexOf("prim#")==0) {
+         svg = svg.select(".primitives_layer");
+         name = name.substr(5);
+      }
 
+      var node = svg.node().firstChild;
       while (node!==null) {
          var elem = d3.select(node);
          if (elem.classed(name)) return elem;
@@ -1815,16 +1749,20 @@
 
    /** Converts x or y coordinate into SVG pad coordinates,
     *  which could be used directly for drawing in the pad.
-    *  Parameters: axis should be "x" or "y", value to convert
+    *  Parameters: axis should be "x" or "y", value to convert.
+    *  \par kind can be:
+    *  undefined or false - this is coordinate inside frame
+    *  true - when NDC coordinates are used
+    *  "pad" - when pad coordinates relative to pad ranges are specified
     *  Always return rounded values */
-   TObjectPainter.prototype.AxisToSvg = function(axis, value, isndc) {
+   TObjectPainter.prototype.AxisToSvg = function(axis, value, kind) {
       var main = this.main_painter();
-      if (main && !isndc) {
+      if (main && !kind) {
          // this is frame coordinates
          value = (axis=="y") ? main.gry(value) + main.frame_y()
                              : main.grx(value) + main.frame_x();
       } else {
-         if (!isndc) value = this.ConvertToNDC(axis, value);
+         if (kind !== true) value = this.ConvertToNDC(axis, value);
          value = (axis=="y") ? (1-value)*this.pad_height() : value*this.pad_width();
       }
       return Math.round(value);
@@ -1832,7 +1770,7 @@
 
    /** This is SVG element with current frame */
    TObjectPainter.prototype.svg_frame = function(pad_name) {
-      return this.svg_pad(pad_name).select(".root_frame");
+      return this.svg_layer("primitives_layer", pad_name).select(".root_frame");
    }
 
    TObjectPainter.prototype.frame_painter = function() {
@@ -1851,24 +1789,27 @@
       return isNaN(res) ? 0 : res;
    }
 
+   TObjectPainter.prototype.frame_property = function(name) {
+      var res = this.svg_frame();
+      if (res.empty()) return 0;
+      res = res.property(name);
+      return (res===undefined) || isNaN(res) ? 0 : res;
+   }
+
    TObjectPainter.prototype.frame_x = function() {
-      var res = this.svg_frame().property("draw_x");
-      return isNaN(res) ? 0 : res;
+      return this.frame_property("draw_x");
    }
 
    TObjectPainter.prototype.frame_y = function() {
-      var res = this.svg_frame().property("draw_y");
-      return isNaN(res) ? 0 : res;
+      return this.frame_property("draw_y");
    }
 
    TObjectPainter.prototype.frame_width = function() {
-      var res = this.svg_frame().property("draw_width");
-      return isNaN(res) ? 0 : res;
+      return this.frame_property("draw_width");
    }
 
    TObjectPainter.prototype.frame_height = function() {
-      var res = this.svg_frame().property("draw_height");
-      return isNaN(res) ? 0 : res;
+      return this.frame_property("draw_height");
    }
 
    TObjectPainter.prototype.embed_3d = function() {
@@ -2015,23 +1956,25 @@
 
       if (size.can3d > 1) {
 
-         var layer = this.svg_layer("special_layer");
+         elem = this.svg_layer(size.clname);
 
-         elem = layer.select("." + size.clname);
+         // elem = layer.select("." + size.clname);
          if (onlyget) return elem;
+
+         var svg = this.svg_pad();
 
          if (size.can3d === 3) {
             // this is SVG mode
 
             if (elem.empty())
-               elem = layer.append("g").attr("class", size.clname);
+               elem = svg.insert("g",".primitives_layer").attr("class", size.clname);
 
             elem.attr("transform", "translate(" + size.x + "," + size.y + ")");
 
          } else {
 
             if (elem.empty())
-               elem = layer.append("foreignObject").attr("class", size.clname);
+               elem = svg.insert("foreignObject",".primitives_layer").attr("class", size.clname);
 
             elem.attr('x', size.x)
                 .attr('y', size.y)
@@ -2211,8 +2154,7 @@
    TObjectPainter.prototype.AddDrag = function(callback) {
       if (!JSROOT.gStyle.MoveResize) return;
 
-      var pthis = this, drag_tm = null, drag_rect = null,
-          pad_w = 1, pad_h = 1, acc_x1 = 0, acc_y1 = 0, acc_x2 = 0, acc_y2 = 0;
+      var pthis = this, drag_rect = null;
 
       function detectRightButton(event) {
          if ('buttons' in event) return event.buttons === 2;
@@ -2224,72 +2166,34 @@
       function rect_width() { return Number(pthis.draw_g.attr("width")); }
       function rect_height() { return Number(pthis.draw_g.attr("height")); }
 
-      var resize_nw = this.draw_g.select('.resize_nw'),
-          resize_ne = this.draw_g.select('.resize_ne'),
-          resize_sw = this.draw_g.select('.resize_sw'),
-          resize_se = this.draw_g.select('.resize_se'),
-          resize_w = this.draw_g.select('.resize_w'),
-          resize_n = this.draw_g.select('.resize_n'),
-          resize_e = this.draw_g.select('.resize_e'),
-          resize_s = this.draw_g.select('.resize_s');
+      function MakeResizeElements(group, width, height, handler) {
+         function make(cursor,d) {
+            var clname = "js_" + cursor.replace('-','_'),
+                elem = group.select('.'+clname);
+            if (elem.empty()) elem = group.append('path').classed(clname,true);
+            elem.style('opacity', 0).style('cursor', cursor).attr('d',d);
+            if (handler) elem.call(handler);
+         }
 
-      if (resize_nw.empty())
-         resize_nw = this.draw_g.append("path")
-                              .attr('class','resize_nw')
-                              .attr("d","M2,2 h15 v-5 h-20 v20 h5 Z");
+         make("nw-resize", "M2,2h15v-5h-20v20h5Z");
+         make("ne-resize", "M" + (width-2) + ",2h-15v-5h20v20h-5 Z");
+         make("sw-resize", "M2," + (height-2) + "h15v5h-20v-20h5Z");
+         make("se-resize", "M" + (width-2) + "," + (height-2) + "h-15v5h20v-20h-5Z");
 
-      if (resize_ne.empty())
-         resize_ne = this.draw_g.append("path")
-                                .attr('class','resize_ne')
-                                .attr("d","M-2,2 h-15 v-5 h20 v20 h-5 Z");
-      if (resize_sw.empty())
-         resize_sw = this.draw_g.append("path")
-                                .attr('class','resize_sw')
-                                .attr("d","M2,-2 h15 v5 h-20 v-20 h5 Z");
-
-      if (resize_se.empty())
-         resize_se = this.draw_g.append("path")
-                              .attr('class','resize_se')
-                              .attr("d","M-2,-2 h-15 v5 h20 v-20 h-5 Z");
-
-      if (resize_w.empty())
-         resize_w = this.draw_g.append("rect")
-                        .attr('class','resize_w')
-                        .attr("x","-3").attr("y","18").attr("width","5");
-
-      if (resize_n.empty())
-         resize_n = this.draw_g.append("rect")
-                        .attr('class','resize_n')
-                        .attr("x","18").attr("y","-3").attr("height","5");
-
-      if (resize_e.empty())
-         resize_e = this.draw_g.append("rect")
-                        .attr('class','resize_e')
-                        .attr("x","-2").attr("y","18").attr("width","5");
-
-      if (resize_s.empty())
-         resize_s = this.draw_g.append("rect")
-                        .attr('class','resize_s')
-                        .attr("x","18").attr("y","-2").attr("height","5");
-
-      resize_nw.style('opacity', 0).style('cursor',"nw-resize");
-      resize_ne.style('opacity', 0).style('cursor',"ne-resize")
-                      .attr("transform", "translate(" + rect_width() + "," + 0 + ")");
-      resize_sw.style('opacity', 0).style('cursor',"sw-resize")
-                      .attr("transform", "translate(" + 0 + "," + rect_height() + ")");
-      resize_se.style('opacity', 0).style('cursor',"se-resize")
-                      .attr("transform", "translate(" + rect_width() + "," + rect_height() + ")");
-
-      resize_w.style('opacity',0).style('cursor',"w-resize").attr("height", Math.max(0, rect_height() - 2*18));
-      resize_n.style('opacity',0).style('cursor',"n-resize").attr("width", Math.max(0, rect_width() - 2*18));
-
-      resize_e.style('opacity',0).style('cursor',"e-resize").attr("height", Math.max(0, rect_height() - 2*18))
-                                                            .attr("transform", "translate(" + rect_width() + "," + 0 + ")");
-      resize_s.style('opacity',0).style('cursor',"s-resize").attr("width", Math.max(0, rect_width() - 2*18))
-                                                            .attr("transform", "translate(" + 0 + "," + rect_height() + ")");
+         make("w-resize", "M-3,18h5v" + Math.max(0, height - 2*18) + "h-5Z");
+         make("e-resize", "M" + (width+3) + ",18h-5v" + Math.max(0, height - 2*18) + "h5Z");
+         make("n-resize", "M18,-3v5h" + Math.max(0, width - 2*18) + "v-5Z");
+         make("s-resize", "M18," + (height+3) + "v-5h" + Math.max(0, width - 2*18) + "v5Z");
+      }
 
       function complete_drag() {
          drag_rect.style("cursor", "auto");
+
+         if (!pthis.draw_g) {
+            drag_rect.remove();
+            drag_rect = null;
+            return false;
+         }
 
          var oldx = Number(pthis.draw_g.attr("x")),
              oldy = Number(pthis.draw_g.attr("y")),
@@ -2313,13 +2217,7 @@
 
          pthis.SwitchTooltip(true);
 
-         resize_ne.attr("transform", "translate(" + newwidth + "," + 0 + ")");
-         resize_sw.attr("transform", "translate(" + 0 + "," + newheight + ")");
-         resize_se.attr("transform", "translate(" + newwidth + "," + newheight + ")");
-         resize_w.attr("height", Math.max(0, newheight - 2*18));
-         resize_n.attr("width", Math.max(0, newwidth - 2*18));
-         resize_e.attr("height", Math.max(0, newheight - 2*18)).attr("transform", "translate(" + newwidth + "," + 0 + ")");
-         resize_s.attr("width", Math.max(0, newwidth - 2*18)).attr("transform", "translate(" + 0 + "," + newheight + ")");
+         MakeResizeElements(pthis.draw_g, newwidth, newheight);
 
          if (change_size || change_pos) {
             if (change_size && ('resize' in callback)) callback.resize(newwidth, newheight);
@@ -2361,41 +2259,49 @@
             d3.event.sourceEvent.preventDefault();
             d3.event.sourceEvent.stopPropagation();
 
-            acc_x1 = Number(pthis.draw_g.attr("x"));
-            acc_y1 = Number(pthis.draw_g.attr("y"));
-            pad_w = pthis.pad_width() - rect_width();
-            pad_h = pthis.pad_height() - rect_height();
-
-            drag_tm = new Date();
+            var handle = {
+               acc_x1: Number(pthis.draw_g.attr("x")),
+               acc_y1: Number(pthis.draw_g.attr("y")),
+               pad_w: pthis.pad_width() - rect_width(),
+               pad_h: pthis.pad_height() - rect_height(),
+               drag_tm: new Date()
+            };
 
             drag_rect = d3.select(pthis.draw_g.node().parentNode).append("rect")
                  .classed("zoom", true)
-                 .attr("x", acc_x1)
-                 .attr("y", acc_y1)
+                 .attr("x", handle.acc_x1)
+                 .attr("y", handle.acc_y1)
                  .attr("width", rect_width())
                  .attr("height", rect_height())
                  .style("cursor", "move")
-                 .style("pointer-events","none"); // let forward double click to underlying elements
+                 .style("pointer-events","none") // let forward double click to underlying elements
+                 .property('drag_handle', handle);
+
+
           }).on("drag", function() {
                if (!drag_rect) return;
 
                d3.event.sourceEvent.preventDefault();
                d3.event.sourceEvent.stopPropagation();
 
-               acc_x1 += d3.event.dx;
-               acc_y1 += d3.event.dy;
+               var handle = drag_rect.property('drag_handle');
 
-               drag_rect.attr("x", Math.min( Math.max(acc_x1, 0), pad_w))
-                        .attr("y", Math.min( Math.max(acc_y1, 0), pad_h));
+               handle.acc_x1 += d3.event.dx;
+               handle.acc_y1 += d3.event.dy;
+
+               drag_rect.attr("x", Math.min( Math.max(handle.acc_x1, 0), handle.pad_w))
+                        .attr("y", Math.min( Math.max(handle.acc_y1, 0), handle.pad_h));
 
           }).on(prefix+"end", function() {
                if (!drag_rect) return;
 
                d3.event.sourceEvent.preventDefault();
 
+               var handle = drag_rect.property('drag_handle');
+
                if (complete_drag() === false) {
-                  var spent = (new Date()).getTime() - drag_tm.getTime();
-                  if(callback.ctxmenu && (spent > 600)) {
+                  var spent = (new Date()).getTime() - handle.drag_tm.getTime();
+                  if (callback.ctxmenu && (spent > 600)) {
                      var rrr = resize_se.node().getBoundingClientRect();
                      pthis.ShowContextMenu('main', { clientX: rrr.left, clientY: rrr.top } );
                   } else if (callback.canselect && (spent <= 600)) {
@@ -2414,41 +2320,46 @@
 
            pthis.SwitchTooltip(false); // disable tooltip
 
-           acc_x1 = Number(pthis.draw_g.attr("x"));
-           acc_y1 = Number(pthis.draw_g.attr("y"));
-           acc_x2 = acc_x1 + rect_width();
-           acc_y2 = acc_y1 + rect_height();
+           var handle = {
+              acc_x1: Number(pthis.draw_g.attr("x")),
+              acc_y1: Number(pthis.draw_g.attr("y")),
+              pad_w:  pthis.pad_width(),
+              pad_h:  pthis.pad_height()
+           };
 
-           pad_w = pthis.pad_width();
-           pad_h = pthis.pad_height();
+           handle.acc_x2 = handle.acc_x1 + rect_width();
+           handle.acc_y2 = handle.acc_y1 + rect_height();
 
            drag_rect = d3.select(pthis.draw_g.node().parentNode)
                          .append("rect")
                          .classed("zoom", true)
                          .style("cursor", d3.select(this).style("cursor"))
-                         .attr("x", acc_x1)
-                         .attr("y", acc_y1)
-                         .attr("width", acc_x2 - acc_x1)
-                         .attr("height", acc_y2 - acc_y1);
+                         .attr("x", handle.acc_x1)
+                         .attr("y", handle.acc_y1)
+                         .attr("width", handle.acc_x2 - handle.acc_x1)
+                         .attr("height", handle.acc_y2 - handle.acc_y1)
+                         .property('drag_handle', handle);
+
          }).on("drag", function() {
             if (!drag_rect) return;
 
             d3.event.sourceEvent.preventDefault();
             d3.event.sourceEvent.stopPropagation();
 
-            var dx = d3.event.dx, dy = d3.event.dy, elem = d3.select(this);
+            var handle = drag_rect.property('drag_handle'),
+                dx = d3.event.dx, dy = d3.event.dy, elem = d3.select(this);
 
-            if (elem.classed('resize_nw')) { acc_x1 += dx; acc_y1 += dy; }
-            else if (elem.classed('resize_ne')) { acc_x2 += dx; acc_y1 += dy; }
-            else if (elem.classed('resize_sw')) { acc_x1 += dx; acc_y2 += dy; }
-            else if (elem.classed('resize_se')) { acc_x2+=dx; acc_y2 += dy; }
-            else if (elem.classed('resize_w')) { acc_x1 += dx; }
-            else if (elem.classed('resize_n')) { acc_y1 += dy; }
-            else if (elem.classed('resize_e')) { acc_x2 += dx; }
-            else if (elem.classed('resize_s')) { acc_y2 += dy; }
+            if (elem.classed('js_nw_resize')) { handle.acc_x1 += dx; handle.acc_y1 += dy; }
+            else if (elem.classed('js_ne_resize')) { handle.acc_x2 += dx; handle.acc_y1 += dy; }
+            else if (elem.classed('js_sw_resize')) { handle.acc_x1 += dx; handle.acc_y2 += dy; }
+            else if (elem.classed('js_se_resize')) { handle.acc_x2 += dx; handle.acc_y2 += dy; }
+            else if (elem.classed('js_w_resize')) { handle.acc_x1 += dx; }
+            else if (elem.classed('js_n_resize')) { handle.acc_y1 += dy; }
+            else if (elem.classed('js_e_resize')) { handle.acc_x2 += dx; }
+            else if (elem.classed('js_s_resize')) { handle.acc_y2 += dy; }
 
-            var x1 = Math.max(0, acc_x1), x2 = Math.min(acc_x2, pad_w),
-                y1 = Math.max(0, acc_y1), y2 = Math.min(acc_y2, pad_h);
+            var x1 = Math.max(0, handle.acc_x1), x2 = Math.min(handle.acc_x2, handle.pad_w),
+                y1 = Math.max(0, handle.acc_y1), y2 = Math.min(handle.acc_y2, handle.pad_h);
 
             drag_rect.attr("x", x1).attr("y", y1).attr("width", Math.max(0, x2-x1)).attr("height", Math.max(0, y2-y1));
 
@@ -2463,14 +2374,7 @@
       if (!callback.only_resize)
          this.draw_g.style("cursor", "move").call(drag_move);
 
-      resize_nw.call(drag_resize);
-      resize_ne.call(drag_resize);
-      resize_sw.call(drag_resize);
-      resize_se.call(drag_resize);
-      resize_w.call(drag_resize);
-      resize_n.call(drag_resize);
-      resize_e.call(drag_resize);
-      resize_s.call(drag_resize);
+      MakeResizeElements(this.draw_g, rect_width(), rect_height(), drag_resize);
    }
 
    TObjectPainter.prototype.startTouchMenu = function(kind) {
@@ -2829,10 +2733,10 @@
       retry_open(true); // call for the first time
    }
 
-   TObjectPainter.prototype.ExecuteMenuCommand = function(item) {
+   TObjectPainter.prototype.ExecuteMenuCommand = function(method) {
       // execute selected menu command, either locally or remotely
 
-      if (item.fName == "Inspect") {
+      if (method.fName == "Inspect") {
          this.ShowInpsector();
          return true;
       }
@@ -2840,13 +2744,13 @@
       var canvp = this.pad_painter();
       if (!canvp) return false;
 
-      if ((item.fName == "FitPanel") && canvp.ActivateFitPanel) {
+      if ((method.fName == "FitPanel") && canvp.ActivateFitPanel) {
          canvp.ActivateFitPanel(this);
          return true;
       }
 
-      if (canvp.ActivateGed && ((item.fName == "DrawPanel") || (item.fName == "SetLineAttributes")
-            || (item.fName == "SetFillAttributes") || (item.fName == "SetMarkerAttributes"))) {
+      if (canvp.ActivateGed && ((method.fName == "DrawPanel") || (method.fName == "SetLineAttributes")
+            || (method.fName == "SetFillAttributes") || (method.fName == "SetMarkerAttributes"))) {
          canvp.ActivateGed(this); // activate GED
          return true;
       }
@@ -2867,10 +2771,10 @@
 
          if (!item || !item.fName) return;
 
-         if (this.ExecuteMenuCommand(item)) return;
-
          if (canvp.MethodsDialog && (item.fArgs!==undefined))
             return canvp.MethodsDialog(this, item, this.args_menu_id);
+
+         if (this.ExecuteMenuCommand(item)) return;
 
          if (canvp._websocket && this.args_menu_id) {
             console.log('execute method ' + item.fExec + ' for object ' + this.args_menu_id);
@@ -2894,8 +2798,14 @@
             this.args_menu_items = items;
             this.args_menu_id = replyid;
 
+            var lastclname;
+
             for (var n=0;n<items.length;++n) {
                var item = items[n];
+
+               if (item.fClassName && lastclname && (lastclname!=item.fClassName)) _menu.add("separator");
+               lastclname = item.fClassName;
+
                if ((item.fChecked === undefined) || (item.fChecked < 0))
                   _menu.add(item.fName, n, DoExecMenu);
                else
@@ -3197,14 +3107,13 @@
 
       if (!draw_g) draw_g = this.draw_g;
 
-      var font = JSROOT.Painter.getFontDetails(font_face, font_size);
+      var font = (font_size==='font') ? font_face : JSROOT.Painter.getFontDetails(font_face, font_size);
 
       draw_g.call(font.func);
 
       draw_g.property('draw_text_completed', false)
             .property('text_font', font)
             .property('mathjax_use', false)
-            .property('normaltext_use', false)
             .property('text_factor', 0.)
             .property('max_text_width', 0) // keep maximal text width, use it later
             .property('max_font_size', max_font_size);
@@ -3281,12 +3190,6 @@
             font.size = draw_g.property('max_font_size');
          draw_g.call(font.func);
          font_size = font.size;
-      } else {
-         //if (!draw_g.property('normaltext_use') && JSROOT.browser.isFirefox && (font.size<20)) {
-         //   // workaround for firefox, where mathjax has problem when font size too small
-         //   font.size = 20;
-         //   draw_g.call(font.func);
-         //}
       }
 
       // first analyze all MathJax SVG and repair width/height attributes
@@ -3323,15 +3226,17 @@
 
          vvv.attr("width", width).attr('height', height).attr("style",null);
 
-         fo_g.property('_valign', valign);
-
          if (!JSROOT.nodejs) {
             var box = painter.GetBoundarySizes(fo_g.node());
             width = 1.05*box.width; height = 1.05*box.height;
          }
 
-         if (fo_g.property('_scale'))
-            svg_factor = Math.max(svg_factor, width / fo_g.property('_width'), height / fo_g.property('_height'));
+         var arg = fo_g.property("_arg");
+
+         arg.valign = valign;
+
+         if (arg.scale)
+            svg_factor = Math.max(svg_factor, width / arg.width, height / arg.height);
       });
 
       if (svgs)
@@ -3340,7 +3245,7 @@
          // only direct parent
          if (fo_g.node().parentNode !== draw_g.node()) return;
 
-         var valign = fo_g.property('_valign'),
+         var arg = fo_g.property("_arg"),
              m = fo_g.select("svg"), // MathJax svg
              mw = parseInt(m.attr("width")),
              mh = parseInt(m.attr("height"));
@@ -3357,41 +3262,98 @@
             mh = box.height || mh || 10;
          }
 
-         if ((svg_factor > 0.) && valign) valign = valign/svg_factor;
+         if ((svg_factor > 0.) && arg.valign) arg.valign = arg.valign/svg_factor;
 
-         if (valign===null) valign = (font_size - mh)/2;
-
-         var align = fo_g.property('_align'),
-             rotate = fo_g.property('_rotate'),
-             fo_w = fo_g.property('_width'),
-             fo_h = fo_g.property('_height'),
-             tr = { x: fo_g.property('_x'), y: fo_g.property('_y') };
+         if (arg.valign===null) arg.valign = (font_size - mh)/2;
 
          var sign = { x:1, y:1 }, nx = "x", ny = "y";
-         if (rotate == 180) { sign.x = sign.y = -1; } else
-         if ((rotate == 270) || (rotate == 90)) {
-            sign.x = (rotate===270) ? -1 : 1;
+         if (arg.rotate == 180) { sign.x = sign.y = -1; } else
+         if ((arg.rotate == 270) || (arg.rotate == 90)) {
+            sign.x = (arg.rotate == 270) ? -1 : 1;
             sign.y = -sign.x;
             nx = "y"; ny = "x"; // replace names to which align applied
          }
 
-         if (!fo_g.property('_scale')) fo_w = fo_h = 0;
+         if (arg.align[0] == 'middle') arg[nx] += sign.x*(arg.width - mw)/2; else
+         if (arg.align[0] == 'end')    arg[nx] += sign.x*(arg.width - mw);
 
-         if (align[0] == 'middle') tr[nx] += sign.x*(fo_w - mw)/2; else
-         if (align[0] == 'end')    tr[nx] += sign.x*(fo_w - mw);
+         if (arg.align[1] == 'middle') arg[ny] += sign.y*(arg.height - mh)/2; else
+         if (arg.align[1] == 'bottom') arg[ny] += sign.y*(arg.height - mh); else
+         if (arg.align[1] == 'bottom-base') arg[ny] += sign.y*(arg.height - mh - arg.valign);
 
-         if (align[1] == 'middle') tr[ny] += sign.y*(fo_h - mh)/2; else
-         if (align[1] == 'bottom') tr[ny] += sign.y*(fo_h - mh); else
-         if (align[1] == 'bottom-base') tr[ny] += sign.y*(fo_h - mh - valign);
+         var trans = "translate("+arg.x+","+arg.y+")";
+         if (arg.rotate) trans += " rotate("+arg.rotate+")";
 
-         var trans = "translate("+tr.x+","+tr.y+")";
-         if (rotate!==0) trans += " rotate("+rotate+",0,0)";
-
-         fo_g.attr('transform', trans).attr('visibility', null);
+         fo_g.attr('transform', trans).attr('visibility', null).property('_arg',null);
       });
 
       // now hidden text after rescaling can be shown
-      draw_g.selectAll('.hidden_text').attr('opacity', '1').classed('hidden_text',false);
+      draw_g.selectAll('.hidden_text').attr('visibility', null).attr('class', null).each(function() {
+         // case when scaling is changed and we can shift text position only after final text size is defined
+         var txt = d3.select(this),
+             arg = txt.property("_arg");
+
+         txt.property("_arg", null);
+
+         if (!arg) return;
+
+         if (JSROOT.nodejs) {
+            if (arg.scale && (f>0)) { arg.box.width = arg.box.width/f; arg.box.height = arg.box.height/f; }
+         } else if (!arg.plain) {
+            // exact box dimension only required when complex text was build
+            arg.box = painter.GetBoundarySizes(txt.node());
+         }
+
+         // if (arg.text.length>20) console.log(arg.box, arg.align, arg.x, arg.y, 'plain', arg.plain, 'inside', arg.width, arg.height);
+
+         if (arg.width) {
+            // adjust x position when scale into specified rectangle
+            if (arg.align[0]=="middle") arg.x += arg.width/2; else
+            if (arg.align[0]=="end") arg.x += arg.width;
+         }
+
+         arg.dx = arg.dy = 0;
+
+         if (arg.plain) {
+            txt.attr("text-anchor", arg.align[0]);
+         } else {
+            txt.attr("text-anchor", "start");
+            arg.dx = ((arg.align[0]=="middle") ? -0.5 : ((arg.align[0]=="end") ? -1 : 0)) * arg.box.width;
+         }
+
+         if (arg.height) {
+            if (arg.align[1].indexOf('bottom')===0) arg.y += arg.height; else
+            if (arg.align[1] == 'middle') arg.y += arg.height/2;
+         }
+
+         if (arg.plain) {
+            if (arg.align[1] == 'top') txt.attr("dy", ".8em"); else
+            if (arg.align[1] == 'middle') {
+               if (JSROOT.browser.isIE || JSROOT.nodejs) txt.attr("dy", ".4em"); else txt.attr("dominant-baseline", "middle");
+            }
+         } else {
+            arg.dy = ((arg.align[1] == 'top') ? (arg.top_shift || 1) : (arg.align[1] == 'middle') ? (arg.mid_shift || 0.5) : 0) * arg.box.height;
+         }
+
+         // if (arg.text.length>20) console.log(arg.x, arg.y, arg.dx, arg.dy);
+
+         if (!arg.rotate) { arg.x += arg.dx; arg.y += arg.dy; arg.dx = arg.dy = 0; }
+
+         // use translate and then rotate to avoid complex sign calculations
+         var trans = (arg.x || arg.y) ? "translate("+Math.round(arg.x)+","+Math.round(arg.y)+")" : "";
+         if (arg.rotate) trans += " rotate("+Math.round(arg.rotate)+")";
+         if (arg.dx || arg.dy) trans += " translate("+Math.round(arg.dx)+","+Math.round(arg.dy)+")";
+         if (trans) txt.attr("transform", trans);
+
+         if (JSROOT.browser.isWebKit && draw_g.node().insertAdjacentHTML && arg.large_latex) {
+            // this is workaround for sporadic placement problem in Chrome/Opera
+            // Due to unclear reasons tspan elements placed wrongly
+            // Full refresh of created elements (including text itself) solves problem
+            var html = txt.node().outerHTML;
+            txt.remove();
+            draw_g.node().insertAdjacentHTML( 'beforeend', html );
+         }
+      });
 
       if (!call_ready) call_ready = draw_g.node().text_callback;
       draw_g.node().text_callback = null;
@@ -3404,109 +3366,662 @@
       return draw_g.property('max_text_width');
    }
 
-   TObjectPainter.prototype.DrawText = function(align_arg, x, y, w, h, label, tcolor, latex_kind, draw_g) {
+   TObjectPainter.prototype.produceLatex = function(node, label, arg, curr) {
+      // attempt to implement subset of TLatex with plain SVG text and tspan elements
 
-      if (!draw_g) draw_g = this.draw_g;
-      var align;
-
-      if (typeof align_arg == 'string') {
-         align = align_arg.split(";");
-         if (align.length==1) align.push('middle');
-      } else {
-         align = ['start', 'middle'];
-         if ((align_arg / 10) >= 3) align[0] = 'end'; else
-         if ((align_arg / 10) >= 2) align[0] = 'middle';
-         if ((align_arg % 10) == 0) align[1] = 'bottom'; else
-         if ((align_arg % 10) == 1) align[1] = 'bottom-base'; else
-         if ((align_arg % 10) == 3) align[1] = 'top';
+      if (!curr) {
+         // initial dy = -0.1 is to move complete from very bottom line like with normal text drawing
+         curr = { lvl: 0, x: 0, y: 0, dx: 0, dy: -0.1, fsize: arg.font_size, parent: null };
+         arg.mainnode = node.node();
       }
 
-      var scale = (w>0) && (h>0);
+      function extend_pos(pos, value) {
 
-      if (latex_kind==null) latex_kind = 1;
-      if (latex_kind<2)
-         if (!JSROOT.Painter.isAnyLatex(label)) latex_kind = 0;
+         var dx1, dx2, dy1, dy2;
 
-      var use_normal_text = ((JSROOT.gStyle.MathJax<1) && (latex_kind!==2)) || (latex_kind<1),
-          font = draw_g.property('text_font');
+         if (typeof value == 'string') {
+            if (!pos.rect) pos.rect = { x: pos.x, y: pos.y, height: 0, width: 0 };
+            dx1 = -pos.x;
+            pos.x += value.length * arg.font.aver_width * pos.fsize;
+            dx2 = pos.x;
+            dy1 = -(pos.y-pos.fsize*1.1);
+            dy2 = pos.y + pos.fsize*0.1;
+         } else {
+            if (!pos.rect) pos.rect = JSROOT.extend({}, value);
+            dx1 = -value.x;
+            dx2 = value.x+value.width;
+            dy1 = -value.y;
+            dy2 = value.y+value.height;
+         }
+
+         var rect = pos.rect;
+
+         dx1 += rect.x;
+         dx2 -= (rect.x+rect.width);
+         dy1 += rect.y;
+         dy2 -= (rect.y+rect.height);
+
+         if (dx1>0) { rect.x -= dx1; rect.width += dx1; }
+         if (dx2>0) rect.width += dx2;
+         if (dy1>0) { rect.y -= dy1; rect.height += dy1; }
+         if (dy2>0) rect.height+=dy2;
+
+         if (pos.parent) return extend_pos(pos.parent, rect)
+
+         // calculate dimensions for the
+         arg.text_rect = rect;
+
+         var h = rect.height, mid = rect.y + rect.height/2;
+
+         if (h>0) {
+            arg.mid_shift = -mid/h || 0.001;        // relative shift to get latex middle at given point
+            arg.top_shift = -rect.y/h || 0.001; // relative shift to get latex top at given point
+         }
+      }
+
+      function makeem(value) {
+         if (Math.abs(value)<1e-2) return null; // very small values not needed, attribute will be removed
+         if (value==Math.round(value)) return Math.round(value) + "em";
+         var res = value.toFixed(2);
+         if (res.indexOf("0.")==0) res = res.substr(1); else
+         if (res.indexOf("-0.")==0) res = "-." + res.substr(3);
+         if (res[res.length-1]=='0') res = res.substr(0, res.length-1);
+         return res+"em";
+      }
+
+      function get_boundary(painter, element, approx_rect) {
+         // actually, it is workaround for getBBox() or getElementBounday,
+         // which is not implemented for tspan element in Firefox
+
+         if (JSROOT.nodejs || !element || element.empty())
+            return approx_rect || { height: 0, width: 0 };
+
+         var important = [], prnt = element.node();
+
+         // if (element.node().getBBox && !JSROOT.browser.isFirefox) return element.node().getBBox();
+
+         while (prnt && (prnt!=arg.mainnode)) {
+            important.push(prnt);
+            prnt = prnt.parentNode;
+         }
+
+         element.selectAll('tspan').each(function() { important.push(this) });
+
+         var tspans = d3.select(arg.mainnode).selectAll('tspan');
+
+         // this is just workaround to know that many elements are created and in Chrome we need to redo them once again
+         if (tspans.size()>3)  arg.large_latex = true;
+
+         tspans.each(function() { if (important.indexOf(this)<0) d3.select(this).attr('display', 'none'); });
+         var box = painter.GetBoundarySizes(arg.mainnode);
+
+         tspans.each(function() { if (important.indexOf(this)<0) d3.select(this).attr('display', null); });
+
+         return box;
+      }
+
+      var features = [
+          { name: "#it{" }, // italic
+          { name: "#bf{" }, // bold
+          { name: "kern[", arg: 'float' }, // horizontal shift
+          { name: "lower[", arg: 'float' },  // vertical shift
+          { name: "scale[", arg: 'float' },  // font scale
+          { name: "#color[", arg: 'int' },
+          { name: "#font[", arg: 'int' },
+          { name: "_{" },  // subscript
+          { name: "^{" },   // superscript
+          { name: "#bar{", accent: "\u02C9" }, // "\u0305"
+          { name: "#hat{", accent: "\u02C6" }, // "\u0302"
+          { name: "#check{", accent: "\u02C7" }, // "\u030C"
+          { name: "#acute{", accent: "\u02CA" }, // "\u0301"
+          { name: "#grave{", accent: "\u02CB" }, // "\u0300"
+          { name: "#dot{", accent: "\u02D9" }, // "\u0307"
+          { name: "#ddot{", accent: "\u02BA" }, // "\u0308"
+          { name: "#tilde{", accent: "\u02DC" }, // "\u0303"
+          { name: "#slash{", accent: "\u2215" }, // "\u0337"
+          { name: "#vec{", accent: "\u02ED" }, // "\u0350" arrowhead
+          { name: "#frac{" },
+          { name: "#splitline{" },
+          { name: "#sqrt[", arg: 'int' }, // root with arbitrary power (now only 3 or 4)
+          { name: "#sqrt{" },
+          { name: "#sum", special: '\u2211', w: 0.8, h: 0.9 },
+          { name: "#int", special: '\u222B', w: 0.3, h: 1.0 },
+          { name: "#left[", right: "#right]", braces: "[]" },
+          { name: "#left(", right: "#right)", braces: "()" },
+          { name: "#left{", right: "#right}", braces: "{}" },
+          { name: "#left|", right: "#right|", braces: "||" },
+          { name: "#[]{", braces: "[]" },
+          { name: "#(){", braces: "()" },
+          { name: "#{}{", braces: "{}" },
+          { name: "#||{", braces: "||" }
+       ];
+
+      var isany = false, best, found, foundarg, pos, n, subnode, subnode1, subpos = null, prevsubpos = null;
+
+      while (label) {
+
+         best = label.length; found = null; foundarg = null;
+
+         for(n=0;n<features.length;++n) {
+            pos = label.indexOf(features[n].name);
+            if ((pos>=0) && (pos<best)) { best = pos; found = features[n]; }
+         }
+
+         if (!found && !isany) {
+            var s = JSROOT.Painter.translateLaTeX(label);
+            if (!curr.lvl && (s==label)) return 0; // indicate that nothing found - plain string
+            extend_pos(curr, s);
+
+            if (curr.accent && (s.length==1)) {
+               var elem = node.append('svg:tspan').text(s),
+                   rect = get_boundary(this, elem, { width : 10000 }),
+                   w = Math.min(rect.width/curr.fsize, 0.5); // at maximum, 0.5 should be used
+
+               node.append('svg:tspan').attr('dx', makeem(curr.dx-w)).attr('dy', makeem(curr.dy-0.2)).text(curr.accent);
+               curr.dy = 0.2;; // compensate hat
+               curr.dx = Math.max(0.2, w-0.2); // extra horizontal gap
+               curr.accent = false;
+            } else {
+               node.text(s);
+            }
+            return true;
+         }
+
+         if (best>0) {
+            var s = JSROOT.Painter.translateLaTeX(label.substr(0,best));
+            if (s.length>0) {
+               extend_pos(curr, s);
+               node.append('svg:tspan')
+                   .attr('dx', makeem(curr.dx))
+                   .attr('dy', makeem(curr.dy))
+                   .text(s);
+               curr.dx = curr.dy = 0;
+            }
+            subpos = null; // indicate that last element is plain
+            delete curr.special; // and any special handling is also over
+            delete curr.next_super_dy; // remove potential shift
+         }
+
+         if (!found) return true;
+
+         // remove preceeding block and tag itself
+         label = label.substr(best + found.name.length);
+
+         subnode1 = subnode = node.append('svg:tspan');
+
+         prevsubpos = subpos;
+
+         subpos = { lvl: curr.lvl+1, x: curr.x, y: curr.y, fsize: curr.fsize, dx:0, dy: 0, parent: curr };
+
+         isany = true;
+
+         if (found.arg) {
+            pos = label.indexOf("]{");
+            if (pos < 0) { console.log('missing argument for ', found.name); return false; }
+            foundarg = label.substr(0,pos);
+            if (found.arg == 'int') {
+               foundarg = parseInt(foundarg);
+               if (isNaN(foundarg)) { console.log('wrong int argument', label.substr(0,pos)); return false; }
+            } else if (found.arg == 'float') {
+               foundarg = parseFloat(foundarg);
+               if (isNaN(foundarg)) { console.log('wrong float argument', label.substr(0,pos)); return false; }
+            }
+            label = label.substr(pos + 2);
+         }
+
+         var nextdy = curr.dy, nextdx = curr.dx, trav = null,
+             scale = 1, left_brace = "{", right_brace = "}"; // this will be applied to the next element
+
+         curr.dy = curr.dx = 0; // relative shift for elements
+
+         if (found.special) {
+            subnode.attr('dx', makeem(nextdx)).attr('dy', makeem(nextdy)).text(found.special);
+            nextdx = nextdy = 0;
+            curr.special = found;
+
+            var rect = get_boundary(this, subnode);
+            if (rect.width && rect.height) {
+               found.w = rect.width/curr.fsize;
+               found.h = rect.height/curr.fsize-0.1;
+            }
+            continue; // just create special node
+         }
+
+         if (found.braces) {
+            // special handling of large braces
+            subpos.left_cont = subnode.append('svg:tspan'); // container for left brace
+            subpos.left = subpos.left_cont.append('svg:tspan').text(found.braces[0]);
+            subnode1 = subnode.append('svg:tspan');
+            subpos.left_rect = { y: curr.y - curr.fsize*1.1, height: curr.fsize*1.2, x: curr.x, width: curr.fsize*0.6 };
+            extend_pos(curr, subpos.left_rect);
+            subpos.braces = found; // indicate braces handling
+            if (found.right) {
+               left_brace = found.name;
+               right_brace = found.right;
+            }
+         } else if (found.accent) {
+            subpos.accent = found.accent;
+         } else
+         switch(found.name) {
+            case "#color[":
+               if (this.get_color(foundarg))
+                   subnode.attr('fill', this.get_color(foundarg));
+               break;
+           case "#kern[": // horizontal shift
+              nextdx += foundarg;
+              break;
+           case "#lower[": // after vertical shift one need to compensate it back
+              curr.dy -= foundarg;
+              nextdy += foundarg;
+              break;
+           case "scale[":
+              scale = foundarg;
+              break;
+           case "#font[":
+              JSROOT.Painter.getFontDetails(foundarg).setFont(subnode,'without-size');
+              break;
+           case "#it{":
+              curr.italic = true;
+              trav = curr;
+              while (trav = trav.parent)
+                 if (trav.italic!==undefined) {
+                    curr.italic = !trav.italic;
+                    break;
+                 }
+              subnode.attr('font-style', curr.italic ? 'italic' : 'normal');
+              break;
+           case "#bf{":
+              curr.bold = true;
+              trav = curr;
+              while (trav = trav.parent)
+                 if (trav.bold!==undefined) {
+                    curr.bold = !trav.bold;
+                    break;
+                 }
+              subnode.attr('font-weight', curr.bold ? 'bold' : 'normal');
+              break;
+           case "_{":
+              scale = 0.6;
+              subpos.script = 'sub';
+
+              if (curr.special) {
+                 curr.dx = curr.special.w;
+                 curr.dy = -0.7;
+                 nextdx -= curr.dx;
+                 nextdy -= curr.dy;
+              } else {
+                 nextdx += 0.1*scale;
+                 nextdy += 0.4*scale;
+                 subpos.y += 0.4*subpos.fsize;
+                 curr.dy = -0.4*scale; // compensate vertical shift back
+
+                 if (prevsubpos && (prevsubpos.script === 'super')) {
+                    var rect = get_boundary(this, prevsubpos.node, prevsubpos.rect);
+                    subpos.width_limit = rect.width;
+                    nextdx -= (rect.width/subpos.fsize+0.1)*scale;
+                 }
+              }
+              break;
+           case "^{":
+              scale = 0.6;
+              subpos.script = 'super';
+
+              if (curr.special) {
+                 curr.dx = curr.special.w;
+                 curr.dy = curr.special.h;
+                 nextdx -= curr.dx;
+                 nextdy -= curr.dy;
+              } else {
+
+                 curr.dy = 0.6*scale; // compensate vertical shift afterwards
+                 if (curr.next_super_dy) curr.dy -= curr.next_super_dy;
+
+                 nextdx += 0.1*scale;
+                 nextdy -= curr.dy;
+
+                 subpos.y -= 0.4*subpos.fsize;
+
+                 if (prevsubpos && (prevsubpos.script === 'sub')) {
+                    var rect = get_boundary(this, prevsubpos.node, prevsubpos.rect);
+                    subpos.width_limit = rect.width;
+                    nextdx -= (rect.width/subpos.fsize+0.1)*scale;
+                 }
+              }
+              break;
+           case "#frac{":
+           case "#splitline{":
+              subpos.first = subnode;
+              subpos.two_lines = true;
+              subpos.need_middle = (found.name == "#frac{");
+              subpos.x0 = subpos.x;
+              nextdy -= 0.6;
+              curr.dy = -0.6;
+              break;
+           case "#sqrt{":
+              foundarg = 2;
+           case "#sqrt[":
+              subpos.square_root = subnode.append('svg:tspan');
+              subpos.square_root.append('svg:tspan').text((foundarg==3) ? '\u221B' : ((foundarg==4) ? '\u221C' : '\u221A')); // unicode square, cubic and fourth root
+              subnode1 = subnode.append('svg:tspan');
+              subpos.sqrt_rect = { y: curr.y - curr.fsize*1.1, height: curr.fsize*1.2, x: 0, width: curr.fsize*0.7 };
+              extend_pos(curr, subpos.sqrt_rect); // just dummy symbol instead of square root
+              break;
+         }
+
+         if (scale!==1) {
+            // handle centrally change of scale factor
+            subnode.attr('font-size', Math.round(scale*100)+'%');
+            subpos.fsize *= scale;
+            nextdx = nextdx/scale;
+            nextdy = nextdy/scale;
+         }
+
+         if (curr.special && !subpos.script) delete curr.special;
+         delete curr.next_super_dy;
+
+         subpos.node = subnode; // remember node where sublement is build
+
+         while (true) {
+            // loop need to create two lines for #frac or #splitline
+            // normally only one sub-element is created
+
+            // moving cursor with the tspan
+            subpos.x += nextdx*subpos.fsize;
+            subpos.y += nextdy*subpos.fsize;
+
+            subnode.attr('dx', makeem(nextdx)).attr('dy', makeem(nextdy));
+            nextdx = nextdy = 0;
+
+            pos = -1; n = 1;
+
+            while ((n!=0) && (++pos < label.length)) {
+               if (label.indexOf(left_brace, pos) === pos) n++; else
+               if (label.indexOf(right_brace, pos) === pos) n--;
+            }
+
+            if (n!=0) {
+               console.log('mismatch with open ' + left_brace + ' and close ' + right_brace + ' braces in Latex', label);
+               return false;
+            }
+
+            var sublabel = label.substr(0,pos);
+
+            // if (subpos.square_root) sublabel = "#frac{a}{bc}";
+
+            if (!this.produceLatex(subnode1, sublabel, arg, subpos)) return false;
+
+            // takeover current possition and deltas
+            curr.x = subpos.x;
+            curr.y = subpos.y;
+
+            curr.dx += subpos.dx*subpos.fsize/curr.fsize;
+            curr.dy += subpos.dy*subpos.fsize/curr.fsize;
+
+            label = label.substr(pos+right_brace.length);
+
+            if (subpos.width_limit) {
+               // special handling for the case when created element does not reach its minimal width
+               // use when super-script and subscript should be combined together
+
+               var rect = get_boundary(this,  subnode1, subpos.rect);
+               if (rect.width < subpos.width_limit)
+                  curr.dx += (subpos.width_limit-rect.width)/curr.fsize;
+               delete subpos.width_limit;
+            }
+
+            if (curr.special) {
+               // case over #sum or #integral one need to compensate width
+               var rect = get_boundary(this,  subnode1, subpos.rect);
+               curr.dx -= rect.width/curr.fsize; // compensate width as much as we can
+            }
+
+            if (subpos.square_root) {
+               // creating cap for square root
+               // while overline symbol does not match with square root, use empty text with overline
+               var len = 2, scale = 1, sqrt_dy = 0, yscale = 1,
+                   bs = get_boundary(this, subpos.square_root, subpos.sqrt_rect),
+                   be = get_boundary(this, subnode1, subpos.rect);
+
+               // we can compare y coordinates while both nodes (root and element) on the same level
+               if ((be.height > bs.height) && (bs.height > 0)) {
+                  yscale = be.height/bs.height*1.2;
+                  sqrt_dy = ((be.y+be.height) - (bs.y+bs.height))/curr.fsize/yscale;
+                  subpos.square_root.style('font-size', Math.round(100*yscale)+'%').attr('dy', makeem(sqrt_dy));
+               }
+
+               // we taking into account only element width
+               len = be.width / subpos.fsize / yscale;
+
+               var a = "", nn = Math.round(Math.max(len*3,2));
+               while (nn--) a += '\u203E'; // unicode overline
+
+               subpos.square_root.append('svg:tspan').attr("dy", makeem(-0.25)).text(a);
+
+               subpos.square_root.append('svg:tspan').attr("dy", makeem(0.25-sqrt_dy)).attr("dx", makeem(-a.length/3-0.2)).text('\u2009'); // unicode tiny space
+
+               break;
+            }
+
+            if (subpos.braces) {
+               // handling braces
+
+               var bs = get_boundary(this, subpos.left_cont, subpos.left_rect),
+                   be = get_boundary(this, subnode1, subpos.rect),
+                   yscale = 1, brace_dy = 0;
+
+               // console.log('braces height', bs.height, ' entry height', be.height);
+
+               if (1.2*bs.height < be.height) {
+                  // make scaling
+                  yscale = be.height/bs.height;
+                  // brace_dy = ((be.y+be.height) - (bs.y+bs.height))/curr.fsize/yscale - 0.15;
+                  brace_dy = 0;
+                  subpos.left.style('font-size', Math.round(100*yscale)+'%').attr('dy', makeem(brace_dy));
+                  // unicode tiny space, used to return cursor on vertical position
+                  subpos.left_cont.append('svg:tspan').attr("dx",makeem(-0.2))
+                                                  .attr("dy", makeem(-brace_dy*yscale)).text('\u2009');
+                  curr.next_super_dy = -0.3*yscale; // special shift for next comming superscript
+               }
+
+               subpos.left_rect.y = curr.y;
+               subpos.left_rect.height *= yscale;
+
+               extend_pos(curr, subpos.left_rect); // just dummy symbol instead of right brace for accounting
+
+               var right_cont = subnode.append('svg:tspan')
+                                       .attr("dx", makeem(curr.dx))
+                                       .attr("dy", makeem(curr.dy));
+
+               curr.dx = curr.dy = 0;
+
+               if (yscale!=1) right_cont.append('svg:tspan').attr("dx",makeem(-0.2)).text('\u2009'); // unicode tiny space if larger brace is used
+
+               var right = right_cont.append('svg:tspan').text(subpos.braces.braces[1]);
+
+               if (yscale!=1) {
+                  right.style('font-size', Math.round(100*yscale)+'%').attr('dy', makeem(brace_dy));
+                  curr.dy = -brace_dy*yscale; // compensation of right brace
+               }
+
+               break;
+            }
+
+            if (subpos.first && subpos.second) {
+               // when two lines created, adjust horizontal position and place divider if required
+
+               var rect1 = get_boundary(this, subpos.first, subpos.rect1),
+                   rect2 = get_boundary(this, subpos.second, subpos.rect),
+                   l1 = rect1.width / subpos.fsize,
+                   l2 = rect2.width / subpos.fsize,
+                   l3 = Math.max(l2, l1);
+
+               if (subpos.need_middle) {
+                  // starting from content len 1.2 two -- will be inserted
+                  l3 = Math.round(Math.max(l3,1)+0.3);
+                  var a = "";
+                  while (a.length < l3) a += '\u2014';
+                  node.append('svg:tspan')
+                       .attr("dx", makeem(-0.5*(l3+l2)))
+                       .attr("dy", makeem(curr.dy-0.2))
+                       .text(a);
+                  curr.dy = 0.2; // return to the normal level
+                  curr.dx = 0.2; // extra spacing
+               } else {
+                  curr.dx = 0.2;
+                  if (l2<l1) curr.dx += 0.5*(l1-l2);
+               }
+
+               if (subpos.need_middle || arg.align[0]=='middle') {
+                  subpos.first.attr("dx", makeem(0.5*(l3-l1)));
+                  subpos.second.attr("dx", makeem(-0.5*(l2+l1)));
+               } else if (arg.align[0]=='end') {
+                  if (l1<l2) subpos.first.attr("dx", makeem(l2-l1));
+                  subpos.second.attr("dx", makeem(-l2));
+               } else {
+                  subpos.second.attr("dx", makeem(-l1));
+               }
+
+               delete subpos.first;
+               delete subpos.second;
+            }
+
+            if (!subpos.two_lines) break;
+
+            if (label[0] != '{') {
+               console.log('missing { for second line', label);
+               return false;
+            }
+
+            label = label.substr(1);
+
+            subnode = subnode1 = node.append('svg:tspan');
+
+            subpos.two_lines = false;
+            subpos.rect1 = subpos.rect; // remember first rect
+            delete subpos.rect;     // reset rectangle calculations
+            subpos.x = subpos.x0;   // it is used only for SVG, make it more realistic
+            subpos.second = subnode;
+
+            nextdy = curr.dy + 1.6;
+            curr.dy = -0.4;
+         }
+
+      }
+
+      return true;
+   }
+
+   TObjectPainter.prototype.DrawText = function(arg) {
+      // following arguments can be supplied
+      //  align - either int value or text
+      //  x,y - position
+      //  width, height - dimension (optional)
+      //  text - text to draw
+      //  latex - 0 - plain text, 1 - normal TLatex, 2 - math
+      //  color - text color
+      //  rotate - rotaion angle (optional)
+      //  font_size - fixed font size (optional)
+      //  draw_g - element where to place text
+
+      var label = arg.text || "",
+          align = ['start', 'middle'];
+
+      if (typeof arg.align == 'string') {
+         align = arg.align.split(";");
+         if (align.length==1) align.push('middle');
+      } else if (typeof arg.align == 'number') {
+         if ((arg.align / 10) >= 3) align[0] = 'end'; else
+         if ((arg.align / 10) >= 2) align[0] = 'middle';
+         if ((arg.align % 10) == 0) align[1] = 'bottom'; else
+         if ((arg.align % 10) == 1) align[1] = 'bottom-base'; else
+         if ((arg.align % 10) == 3) align[1] = 'top';
+      }
+
+      arg.draw_g = arg.draw_g || this.draw_g;
+      if (arg.latex===undefined) arg.latex = 1; //  latex 0-text, 1-latex, 2-math
+      arg.align = align;
+      arg.x = arg.x || 0;
+      arg.y = arg.y || 0;
+      arg.scale = arg.width && arg.height && !arg.font_size;
+      arg.width = arg.width || 0;
+      arg.height = arg.height || 0;
+
+      if (JSROOT.gStyle.MathJax !== undefined) {
+         switch (JSROOT.gStyle.MathJax) {
+            case 0: JSROOT.gStyle.Latex = 2; break;
+            case 2: JSROOT.gStyle.Latex = 4; break;
+            default: JSROOT.gStyle.Latex = 3;
+         }
+         delete JSROOT.gStyle.MathJax;
+      }
+
+      if (typeof JSROOT.gStyle.Latex == 'string') {
+         switch (JSROOT.gStyle.Latex) {
+            case "off": JSROOT.gStyle.Latex = 0; break;
+            case "symbols": JSROOT.gStyle.Latex = 1; break;
+            case "MathJax":
+            case "mathjax":
+            case "math":   JSROOT.gStyle.Latex = 3; break;
+            case "AlwaysMathJax":
+            case "alwaysmath":
+            case "alwaysmathjax": JSROOT.gStyle.Latex = 4; break;
+            default:
+               var code = parseInt(JSROOT.gStyle.Latex);
+               JSROOT.gStyle.Latex = (!isNaN(code) && (code>=0) && (code<=4)) ? code : 2;
+         }
+      }
+
+      var font = arg.draw_g.property('text_font'),
+          use_mathjax = (arg.latex == 2);
+
+      if (arg.latex === 1)
+         use_mathjax = (JSROOT.gStyle.Latex > 3) || ((JSROOT.gStyle.Latex == 3) && JSROOT.Painter.isAnyLatex(label));
 
       // only Firefox can correctly rotate incapsulated SVG, produced by MathJax
       // if (!use_normal_text && (h<0) && !JSROOT.browser.isFirefox) use_normal_text = true;
 
-      if (use_normal_text) {
-         if (latex_kind>0) label = JSROOT.Painter.translateLaTeX(label);
+      if (!use_mathjax || arg.nomathjax) {
 
-         var pos_x = x.toFixed(0), pos_y = y.toFixed(0), pos_dy = "", middleline = false;
+         var txt = arg.draw_g.append("svg:text");
 
-         if (w>0) {
-            // adjust x position when scale into specified rectangle
-            if (align[0]=="middle") pos_x = (x+w*0.5).toFixed(0); else
-            if (align[0]=="end") pos_x = (x+w).toFixed(0);
+         if (arg.color) txt.attr("fill", arg.color);
+
+         if (arg.font_size) txt.attr("font-size", arg.font_size);
+                       else arg.font_size = font.size;
+
+         arg.font = font; // use in latex conversion
+
+         arg.plain = !arg.latex || (JSROOT.gStyle.Latex < 2) || (this.produceLatex(txt, label, arg) === 0);
+
+         if (arg.plain) {
+            if (arg.latex && (JSROOT.gStyle.Latex == 1)) label = Painter.translateLaTeX(label); // replace latex symbols
+            txt.text(label);
          }
 
-         if (h>0) {
-            if (align[1].indexOf('bottom')===0) pos_y = (y+h).toFixed(0); else
-            if (align[1] == 'top') pos_dy = ".8em"; else {
-               pos_y = (y + h/2 + 1).toFixed(0);
-               if (JSROOT.browser.isIE) pos_dy = ".4em"; else middleline = true;
-            }
-         } else {
-            if (align[1] == 'top') pos_dy = ".8em"; else
-            if (align[1] == 'middle') {
-               if (JSROOT.browser.isIE) pos_dy = ".4em"; else middleline = true;
-            }
-         }
+         // complete rectangle with very rougth size estimations
+         arg.box = JSROOT.nodejs ? (arg.text_rect || { height: arg.font_size*1.2, width: JSROOT.Painter.approxTextWidth(font, label) })
+                                 : this.GetBoundarySizes(txt.node());
 
-         // use translate and then rotate to avoid complex sign calculations
-         var trans = "translate("+pos_x+","+pos_y+")";
-         if (!scale && (h<0)) trans += " rotate("+(-h)+",0,0)";
+         // if (label.length>20) console.log('label', label, 'box', arg.box);
 
-         var txt = draw_g.append("text")
-                         .attr("text-anchor", align[0])
-                         .attr("x", 0)
-                         .attr("y", 0)
-                         .attr("fill", tcolor ? tcolor : null)
-                         .attr("transform", trans)
-                         .text(label);
-         if (pos_dy) txt.attr("dy", pos_dy);
-         if (middleline) txt.attr("dominant-baseline", "middle");
+         txt.attr('class','hidden_text')
+             .attr('visibility','hidden') // hide elements until text drawing is finished
+             .property("_arg", arg);
 
-         draw_g.property('normaltext_use', true);
+         if (arg.box.width > arg.draw_g.property('max_text_width')) arg.draw_g.property('max_text_width', arg.box.width);
+         if (arg.scale) this.TextScaleFactor(1.05*arg.box.width/arg.width, arg.draw_g);
+         if (arg.scale) this.TextScaleFactor(1.*arg.box.height/arg.height, arg.draw_g);
 
-         // workaround for Node.js - use primitive estimation of textbox size
-         // later can be done with Node.js (via SVG) or with alternative implementation of jsdom
-         var box = !JSROOT.nodejs ? this.GetBoundarySizes(txt.node()) :
-                    { height: Math.round(font.size*1.2), width: Math.round(label.length*font.size*0.4) };
-
-         if (scale) txt.classed('hidden_text',true).attr('opacity','0'); // hide rescale elements
-
-         if (box.width > draw_g.property('max_text_width')) draw_g.property('max_text_width', box.width);
-         if ((w>0) && scale) this.TextScaleFactor(1.05*box.width / w, draw_g);
-         if ((h>0) && scale) this.TextScaleFactor(1.*box.height / h, draw_g);
-
-         return box.width;
+         return arg.box.width;
       }
 
-      w = Math.round(w); h = Math.round(h);
-      x = Math.round(x); y = Math.round(y);
-
-      var rotate = 0;
-
-      if (!scale && h<0) { rotate = Math.abs(h); h = 0; }
-
-      var mtext = JSROOT.Painter.translateMath(label, latex_kind, tcolor),
-          fo_g = draw_g.append("svg:g")
+      var mtext = JSROOT.Painter.translateMath(label, arg.latex, arg.color, this),
+          fo_g = arg.draw_g.append("svg:g")
                        .attr('class', 'math_svg')
                        .attr('visibility','hidden')
-                       .property('_x',x) // used for translation later
-                       .property('_y',y)
-                       .property('_width',w) // used to check scaling
-                       .property('_height',h)
-                       .property('_scale', scale)
-                       .property('_rotate', rotate)
-                       .property('_align', align);
+                       .property('_arg', arg);
 
-      draw_g.property('mathjax_use', true);  // one need to know that mathjax is used
+      arg.draw_g.property('mathjax_use', true);  // one need to know that mathjax is used
 
       if (JSROOT.nodejs) {
          // special handling for Node.js
@@ -3525,7 +4040,7 @@
 
          JSROOT.nodejs_mathjax.typeset({
             jsroot_painter: this,
-            jsroot_drawg: draw_g,
+            jsroot_drawg: arg.draw_g,
             jsroot_fog: fo_g,
             ex: font.size,
             math: mtext,
@@ -3559,9 +4074,9 @@
 
       JSROOT.AssertPrerequisites('mathjax', function() {
 
-         MathJax.Hub.Typeset(element, ["FinishMathjax", painter, draw_g, fo_g]);
+         MathJax.Hub.Typeset(element, ["FinishMathjax", painter, arg.draw_g, fo_g]);
 
-         MathJax.Hub.Queue(["FinishMathjax", painter, draw_g, fo_g]); // repeat once again, while Typeset not always invoke callback
+         MathJax.Hub.Queue(["FinishMathjax", painter, arg.draw_g, fo_g]); // repeat once again, while Typeset not always invoke callback
       });
 
       return 0;
@@ -3571,18 +4086,43 @@
       // function should be called when processing of element is completed
 
       if (fo_g.node().parentNode !== draw_g.node()) return;
+
       var entry = fo_g.property('_element');
       if (!entry) return;
 
       var vvv = d3.select(entry).select("svg");
-      if (vvv.empty()) return; // not yet finished
+
+      if (vvv.empty()) {
+
+         var merr = d3.select(entry).select("merror"); // indication of error
+
+         if (merr.empty()) return; // not yet finished
+
+         console.warn('MathJax error', merr.text());
+
+         var arg = fo_g.property('_arg');
+
+         if (arg && arg.latex!=2) {
+            arg.nomathjax = true;
+            fo_g.remove(); // delete special entry
+            this.DrawText(arg);
+         } else
+            fo_g.append("svg").attr('width', Math.min(20, merr.text().length + 5) + 'ex')
+                              .attr('height', '3ex')
+                              .style('vertical-align','0ex')
+                              .append("text")
+                              .style('font-size','12px')
+                              .style('fill','red')
+                              .attr('x','0')
+                              .attr('y','2ex')
+                              .text("Err: " + merr.text());
+      } else {
+         vvv.remove();
+         fo_g.append(function() { return vvv.node(); });
+      }
 
       fo_g.property('_element', null);
-
-      vvv.remove();
       document.body.removeChild(entry);
-
-      fo_g.append(function() { return vvv.node(); });
 
       this.FinishTextDrawing(draw_g); // check if all other elements are completed
    }
@@ -3592,8 +4132,8 @@
 
    function TFramePainter(tframe) {
       TObjectPainter.call(this, tframe);
-      this.tooltip_enabled = true;
-      this.tooltip_allowed = (JSROOT.gStyle.Tooltip > 0);
+      this.tooltip_enabled = true;  // this is internally used flag to temporary disbale/enable tooltib
+      this.tooltip_allowed = (JSROOT.gStyle.Tooltip > 0); // this is interactively changed property
    }
 
    TFramePainter.prototype = Object.create(TObjectPainter.prototype);
@@ -3637,20 +4177,19 @@
       }
 
       if (this.fillatt === undefined) {
-         if (tframe)
-            this.fillatt = this.createAttFill(tframe);
-         else
-         if (pad)
-            this.fillatt = this.createAttFill(null, pad.fFrameFillStyle, pad.fFrameFillColor);
-         else
-            this.fillatt = this.createAttFill(null, 1001, 0);
+         if (tframe) this.fillatt = this.createAttFill(tframe);
+         else if (pad) this.fillatt = pad.fFrameFillColor ? this.createAttFill(null, pad.fFrameFillStyle, pad.fFrameFillColor) : this.createAttFill(pad);
+         else this.fillatt = this.createAttFill(null, 1001, 0);
 
          // force white color for the frame
-         // if (this.fillatt.color == 'none') this.fillatt.color = 'white';
+         if (!tframe && (this.fillatt.color == 'none') && this.pad_painter(true) && this.pad_painter(true).iscan) {
+            this.fillatt.color = 'white';
+         }
       }
 
       if (this.lineatt === undefined)
-         this.lineatt = new TAttLineHandler(tframe ? tframe : 'black');
+         if (pad) this.lineatt = new TAttLineHandler({ fLineColor: pad.fFrameLineColor, fLineWidth: pad.fFrameLineWidth, fLineStyle: pad.fFrameLineStyle });
+             else this.lineatt = new TAttLineHandler(tframe ? tframe : 'black');
    }
 
    TFramePainter.prototype.SizeChanged = function() {
@@ -3694,17 +4233,25 @@
           lm = Math.round(width * this.fX1NDC),
           w = Math.round(width * (this.fX2NDC - this.fX1NDC)),
           tm = Math.round(height * (1 - this.fY2NDC)),
-          h = Math.round(height * (this.fY2NDC - this.fY1NDC));
+          h = Math.round(height * (this.fY2NDC - this.fY1NDC)),
+          rotate = false, fixpos = false, pp = this.pad_painter();
+
+      if (pp && pp.options) {
+         if (pp.options.RotateFrame) rotate = true;
+         if (pp.options.FixFrame) fixpos = true;
+      }
 
       // this is svg:g object - container for every other items belonging to frame
-      this.draw_g = this.svg_frame();
-      if (this.draw_g.empty())
-         return console.error('did not found frame layer');
+      this.draw_g = this.svg_layer("primitives_layer").select(".root_frame");
 
-      var top_rect = this.draw_g.select("rect"),
-          main_svg = this.draw_g.select(".main_layer");
+      var top_rect, main_svg;
 
-      if (main_svg.empty()) {
+      if (this.draw_g.empty()) {
+
+         var layer = this.svg_layer("primitives_layer");
+
+         this.draw_g = layer.append("svg:g").attr("class", "root_frame");
+
          this.draw_g.append("svg:title").text("");
 
          top_rect = this.draw_g.append("svg:rect");
@@ -3720,6 +4267,15 @@
 
          this.draw_g.append('svg:g').attr('class','axis_layer');
          this.draw_g.append('svg:g').attr('class','upper_layer');
+      } else {
+         top_rect = this.draw_g.select("rect");
+         main_svg = this.draw_g.select(".main_layer");
+      }
+
+      var trans = "translate(" + lm + "," + tm + ")";
+      if (rotate) {
+         trans += " rotate(-90) " + "translate(" + -h + ",0)";
+         var d = w; w = h; h = d;
       }
 
       this.draw_g.property('frame_painter', this) // simple way to access painter via frame container
@@ -3727,7 +4283,7 @@
                  .property('draw_y', tm)
                  .property('draw_width', w)
                  .property('draw_height', h)
-                 .attr("transform", "translate(" + lm + "," + tm + ")");
+                 .attr("transform", trans);
 
       top_rect.attr("x", 0)
               .attr("y", 0)
@@ -3742,16 +4298,16 @@
 
       var tooltip_rect = this.draw_g.select(".interactive_rect");
 
-      if ((JSROOT.gStyle.Tooltip === 0) || JSROOT.BatchMode)
-         return tooltip_rect.remove();
+      if (JSROOT.BatchMode) return tooltip_rect.remove();
 
       this.draw_g.attr("x", lm)
                  .attr("y", tm)
                  .attr("width", w)
                  .attr("height", h);
 
-      this.AddDrag({ obj: this, only_resize: true, minwidth: 20, minheight: 20,
-                     redraw: this.SizeChanged.bind(this) });
+      if (!rotate && !fixpos)
+         this.AddDrag({ obj: this, only_resize: true, minwidth: 20, minheight: 20,
+                        redraw: this.SizeChanged.bind(this) });
 
       var painter = this;
 
@@ -3798,12 +4354,11 @@
                   .attr("width", w)
                   .attr("height", h);
 
-      var hintsg = this.svg_layer("stat_layer").select(".objects_hints");
+      var hintsg = this.hints_layer().select(".objects_hints");
       // if tooltips were visible before, try to reconstruct them after short timeout
-      if (!hintsg.empty() && (JSROOT.gStyle.Tooltip > 0))
+      if (!hintsg.empty() && this.tooltip_allowed)
          setTimeout(this.ProcessTooltipEvent.bind(this, hintsg.property('last_point')), 10);
    }
-
 
    TFramePainter.prototype.FillContextMenu = function(menu) {
       // fill context menu for the frame
@@ -3857,10 +4412,18 @@
       });
    }
 
+   TFramePainter.prototype.hints_layer = function() {
+      // return layer where frame tooltips are shown
+      // only canvas info_layer can be used while other pads can overlay
+
+      var canp = this.pad_painter();
+      return canp ? canp.svg_layer("info_layer") : d3.select(null);
+   }
+
    TFramePainter.prototype.IsTooltipShown = function() {
       // return true if tooltip is shown, use to prevent some other action
-      if (JSROOT.gStyle.Tooltip < 1) return false;
-      return ! (this.svg_layer("stat_layer").select(".objects_hints").empty());
+      if (!this.tooltip_allowed || !this.tooltip_enabled) return false;
+      return ! (this.hints_layer().select(".objects_hints").empty());
    }
 
    TFramePainter.prototype.ProcessTooltipEvent = function(pnt, enabled) {
@@ -3874,7 +4437,6 @@
           pad_width = this.pad_width(),
           frame_x = this.frame_x(),
           pp = this.pad_painter(true),
-          maxhinty = this.pad_height() - this.draw_g.property('draw_y'),
           font = JSROOT.Painter.getFontDetails(160, textheight),
           status_func = this.GetShowStatusFunc(),
           disable_tootlips = !this.tooltip_allowed || !this.tooltip_enabled;
@@ -3917,7 +4479,7 @@
          }
       }
 
-      var layer = this.svg_layer("stat_layer"),
+      var layer = this.hints_layer(),
           hintsg = layer.select(".objects_hints"); // group with all tooltips
 
       if (status_func) {
@@ -3963,8 +4525,14 @@
                        .attr("class", "objects_hints")
                        .style("pointer-events","none");
 
+      var frame_shift = { x: 0, y: 0 }, trans = this.draw_g.attr("transform");
+      if (!pp.iscan) {
+         pp.CalcAbsolutePosition(this.svg_pad(), frame_shift);
+         trans = "translate(" + frame_shift.x + "," + frame_shift.y + ") " + trans;
+      }
+
       // copy transform attributes from frame itself
-      hintsg.attr("transform", this.draw_g.attr("transform"));
+      hintsg.attr("transform", trans);
 
       hintsg.property("last_point", pnt);
 
@@ -4002,7 +4570,9 @@
 
       var curry = 10, // normal y coordinate
           gapy = 10,  // y coordinate, taking into account all gaps
-          gapminx = -1111, gapmaxx = -1111;
+          gapminx = -1111, gapmaxx = -1111,
+          minhinty = -frame_shift.y,
+          maxhinty = this.pad_height("") - this.draw_g.property('draw_y') - frame_shift.y;
 
       function FindPosInGap(y) {
          for (var n=0;(n<hints.length) && (y < maxhinty); ++n) {
@@ -4043,6 +4613,7 @@
 
          group.attr("x", posx)
               .attr("y", curry)
+              .property("curry", curry)
               .property("gapy", gapy);
 
          curry += hint.height + 5;
@@ -4118,10 +4689,16 @@
          svgs.attr("x", posx);
       }
 
+
       // if gap not very big, apply gapy coordinate to open view on the histogram
-      if ((viewmode !== "single") && (gapy < maxhinty) && (gapy !== curry))
+      if ((viewmode !== "single") && (gapy < maxhinty) && (gapy !== curry)) {
          if ((gapminx <= posx+actualw+5) && (gapmaxx >= posx-5))
             svgs.attr("y", function() { return d3.select(this).property('gapy'); });
+      } else if ((viewmode !== 'single') && (curry > maxhinty)) {
+         var shift = Math.max((maxhinty - curry - 10), minhinty);
+         if (shift<0)
+            svgs.attr("y", function() { return d3.select(this).property('curry') + shift; });
+      }
 
       if (actualw > 10)
          svgs.attr("width", actualw)
@@ -4196,6 +4773,26 @@
       TObjectPainter.prototype.Cleanup.call(this);
    }
 
+   TPadPainter.prototype.CleanPrimitives = function(selector) {
+      if (!selector || (typeof selector !== 'function')) return;
+
+      for (var k=this.painters.length-1;k>=0;--k) {
+         var p = this.painters[k];
+         if (selector(p)) {
+            p.Cleanup();
+            this.painters.splice(k--, 1);
+         }
+      }
+   }
+
+   TPadPainter.prototype.GetCurrentPrimitiveIndx = function() {
+      return this._current_primitive_indx || 0;
+   }
+
+   TPadPainter.prototype.GetNumPrimitives = function() {
+      return this._num_primitives || 1;
+   }
+
    TPadPainter.prototype.ForEachPainterInPad = function(userfunc, onlypadpainters) {
       userfunc(this);
       for (var k = 0; k < this.painters.length; ++k) {
@@ -4210,9 +4807,18 @@
       return Math.round((!fact ? 1 : fact) * (this.iscan || !this.has_canvas ? 16 : 12));
    }
 
+   TPadPainter.prototype.IsTooltipAllowed = function() {
+      var res = undefined;
+      this.ForEachPainterInPad(function(fp) {
+         if ((res===undefined) && (fp.tooltip_allowed!==undefined)) res = fp.tooltip_allowed;
+      });
+      return res !== undefined ? res : false;
+   }
+
    TPadPainter.prototype.SetTooltipAllowed = function(on) {
-      var fp = this.frame_painter();
-      fp.tooltip_allowed = !!on;
+      this.ForEachPainterInPad(function(fp) {
+         if (fp.tooltip_allowed!==undefined) fp.tooltip_allowed = on;
+      });
    }
 
    TPadPainter.prototype.SelectObjectPainter = function(painter) {
@@ -4229,6 +4835,8 @@
 
          svg = this.svg_canvas();
 
+         if (svg.empty()) return false;
+
          factor = svg.property('height_factor');
 
          rect = this.check_main_resize(check_resize, null, factor);
@@ -4236,9 +4844,6 @@
          if (!rect.changed) return false;
 
       } else {
-
-         if (this._websocket && !this.plain_layout)
-            this.CreateCanvasMenu();
 
          var render_to = this.select_main();
 
@@ -4261,11 +4866,8 @@
                  .on("click", this.SelectObjectPainter.bind(this, this))
                  .on("mouseenter", this.ShowObjectStatus.bind(this));
 
-         svg.append("svg:g").attr("class","root_frame");
-         svg.append("svg:g").attr("class","subpads_layer");
-         svg.append("svg:g").attr("class","special_layer");
-         svg.append("svg:g").attr("class","text_layer");
-         svg.append("svg:g").attr("class","stat_layer");
+         svg.append("svg:g").attr("class","primitives_layer");
+         svg.append("svg:g").attr("class","info_layer");
          svg.append("svg:g").attr("class","btns_layer");
 
          if (JSROOT.gStyle.ContextMenu)
@@ -4325,8 +4927,8 @@
          .property('draw_height', rect.height);
 
       svg.select(".canvas_fillrect")
-         .attr("width",rect.width)
-         .attr("height",rect.height)
+         .attr("width", rect.width)
+         .attr("height", rect.height)
          .call(this.fillatt.func);
 
       this.svg_layer("btns_layer")
@@ -4392,7 +4994,7 @@
          svg_rect = svg_pad.select(".root_pad_border");
          btns = this.svg_layer("btns_layer", this.this_pad_name);
       } else {
-         svg_pad = svg_can.select(".subpads_layer")
+         svg_pad = svg_can.select(".primitives_layer")
              .append("g")
              .attr("class", "root_pad")
              .attr("pad", this.this_pad_name) // set extra attribute  to mark pad name
@@ -4400,10 +5002,7 @@
              .property('mainpainter', null); // this is custom property
          svg_rect = svg_pad.append("svg:rect").attr("class", "root_pad_border");
 
-         svg_pad.append("svg:g").attr("class","root_frame");
-         svg_pad.append("svg:g").attr("class","special_layer");
-         svg_pad.append("svg:g").attr("class","text_layer");
-         svg_pad.append("svg:g").attr("class","stat_layer");
+         svg_pad.append("svg:g").attr("class","primitives_layer");
          btns = svg_pad.append("svg:g").attr("class","btns_layer");
 
          if (JSROOT.gStyle.ContextMenu)
@@ -4448,37 +5047,49 @@
       return pad_visible;
    }
 
-   TPadPainter.prototype.CheckColors = function(can) {
+   TPadPainter.prototype.CheckSpecial = function(obj) {
+
+      if (!obj || (obj._typename!=="TObjArray")) return false;
+
+      if (obj.name == "ListOfColors") {
+         if (!this.options || this.options.GlobalColors) // set global list of colors
+            Painter.adoptRootColors(obj);
+         if (this.options && this.options.LocalColors) {
+            // copy existing colors and extend with new values
+            this.root_colors = [];
+            for (var n=0;n<JSROOT.Painter.root_colors.length;++n)
+               this.root_colors[n] = JSROOT.Painter.root_colors[n];
+            Painter.extendRootColors(this.root_colors, obj);
+         }
+         return true;
+      }
+
+      if (obj.name == "CurrentColorPalette") {
+         var arr = [], missing = false;
+         for (var n = 0; n < obj.arr.length; ++n) {
+            var col = obj.arr[n];
+            if (col && (col._typename == 'TColor')) {
+               arr[n] = Painter.MakeColorRGB(col);
+            } else {
+               console.log('Missing color with index ' + n); missing = true;
+            }
+         }
+         if (!this.options || (!missing && !this.options.IgnorePalette)) this.CanvasPalette = new ColorPalette(arr);
+         return true;
+      }
+
+      return false;
+   }
+
+   TPadPainter.prototype.CheckSpecialsInPrimitives = function(can) {
       var lst = can ? can.fPrimitives : null;
       if (!lst) return;
       for (var i = 0; i < lst.arr.length; ++i) {
-         var obj = lst.arr[i];
-         if (!obj || (obj._typename!=="TObjArray")) continue;
-         if (obj.name == "ListOfColors") {
-            if (this.options.GlobalColors) // set global list of colors
-               Painter.adoptRootColors(obj);
-            if (this.options.LocalColors) {
-               // copy existing colors and extend with new values
-               this.root_colors = [];
-               for (var n=0;n<JSROOT.Painter.root_colors.length;++n)
-                  this.root_colors[n] = JSROOT.Painter.root_colors[n];
-               Painter.extendRootColors(this.root_colors, obj);
-            }
-         } else if (obj.name == "CurrentColorPalette") {
-            var arr = [], missing = false;
-            for (var n = 0; n < obj.arr.length; ++n) {
-               var col = obj.arr[n];
-               if (col && (col._typename == 'TColor')) {
-                  arr[n] = Painter.MakeColorRGB(col);
-               } else {
-                  console.log('Missing color with index ' + n); missing = true;
-               }
-            }
-            if (!missing && !this.options.IgnorePalette) this.CanvasPalette = new ColorPalette(arr);
-         } else continue;
-         lst.arr.splice(i,1);
-         lst.opt.splice(i,1);
-         i--;
+         if (this.CheckSpecial(lst.arr[i])) {
+            lst.arr.splice(i,1);
+            lst.opt.splice(i,1);
+            i--;
+         }
       }
    }
 
@@ -4519,13 +5130,35 @@
       return false;
    }
 
-   TPadPainter.prototype.DrawPrimitive = function(indx, callback, ppainter) {
-      if (ppainter) ppainter._primitive = true; // mark painter as belonging to primitives
+   TPadPainter.prototype.DrawPrimitives = function(indx, callback, ppainter) {
 
-      if (!this.pad || (indx >= this.pad.fPrimitives.arr.length))
-         return JSROOT.CallBack(callback);
+      if (indx===0) {
+         // flag used to prevent immediate pad redraw during normal drawing sequence
+         this._doing_pad_draw = true;
 
-      JSROOT.draw(this.divid, this.pad.fPrimitives.arr[indx], this.pad.fPrimitives.opt[indx], this.DrawPrimitive.bind(this, indx+1, callback));
+         // set number of primitves
+         this._num_primitives = this.pad && this.pad.fPrimitives ? this.pad.fPrimitives.arr.length : 0;
+      }
+
+      while (true) {
+         if (ppainter) ppainter._primitive = true; // mark painter as belonging to primitives
+
+         if (!this.pad || (indx >= this.pad.fPrimitives.arr.length)) {
+            delete this._doing_pad_draw;
+            return JSROOT.CallBack(callback);
+         }
+
+         // handle use to invoke callback only when necessary
+         var handle = { func: this.DrawPrimitives.bind(this, indx+1, callback) };
+
+         // set current index
+         this._current_primitive_indx = indx;
+
+         ppainter = JSROOT.draw(this.divid, this.pad.fPrimitives.arr[indx], this.pad.fPrimitives.opt[indx], handle);
+
+         if (!handle.completed) return;
+         indx++;
+      }
    }
 
    TPadPainter.prototype.GetTooltips = function(pnt) {
@@ -4555,34 +5188,39 @@
       else
          menu.add("header: Canvas");
 
-      menu.addchk((JSROOT.gStyle.Tooltip > 0), "Enable tooltips (global)", function() {
-         JSROOT.gStyle.Tooltip = (JSROOT.gStyle.Tooltip === 0) ? 1 : -JSROOT.gStyle.Tooltip;
-         var can_painter = this;
-         if (!this.iscan && this.has_canvas) can_painter = this.pad_painter();
-         if (can_painter && can_painter.ForEachPainterInPad)
-            can_painter.ForEachPainterInPad(function(fp) {
-               if (fp.tooltip_allowed!==undefined) fp.tooltip_allowed = (JSROOT.gStyle.Tooltip > 0);
-            });
-      });
+      var tooltipon = this.IsTooltipAllowed();
+      menu.addchk(tooltipon, "Show tooltips", this.SetTooltipAllowed.bind(this, !tooltipon));
 
       if (!this._websocket) {
 
-         function ToggleField(arg) {
+         function ToggleGridField(arg) {
             this.pad[arg] = this.pad[arg] ? 0 : 1;
             var main = this.svg_pad(this.this_pad_name).property('mainpainter');
-            if (!main) return;
-
-            if ((arg.indexOf('fGrid')==0) && (typeof main.DrawGrids == 'function'))
-               return main.DrawGrids();
-
-            if ((arg.indexOf('fTick')==0) && (typeof main.DrawAxes == 'function'))
-               return main.DrawAxes();
+            if (main && (typeof main.DrawGrids == 'function')) main.DrawGrids();
          }
 
-         menu.addchk(this.pad.fGridx, 'Grid x', 'fGridx', ToggleField);
-         menu.addchk(this.pad.fGridy, 'Grid y', 'fGridy', ToggleField);
-         menu.addchk(this.pad.fTickx, 'Tick x', 'fTickx', ToggleField);
-         menu.addchk(this.pad.fTicky, 'Tick y', 'fTicky', ToggleField);
+         function SetTickField(arg) {
+            this.pad[arg.substr(1)] = parseInt(arg[0]);
+
+            var main = this.svg_pad(this.this_pad_name).property('mainpainter');
+            if (main && (typeof main.DrawAxes == 'function')) main.DrawAxes();
+         }
+
+         menu.addchk(this.pad.fGridx, 'Grid x', 'fGridx', ToggleGridField);
+         menu.addchk(this.pad.fGridy, 'Grid y', 'fGridy', ToggleGridField);
+         menu.add("sub:Ticks x");
+         menu.addchk(this.pad.fTickx == 0, "normal", "0fTickx", SetTickField);
+         menu.addchk(this.pad.fTickx == 1, "ticks on both sides", "1fTickx", SetTickField);
+         menu.addchk(this.pad.fTickx == 2, "labels up", "2fTickx", SetTickField);
+         menu.add("endsub:");
+         menu.add("sub:Ticks y");
+         menu.addchk(this.pad.fTicky == 0, "normal", "0fTicky", SetTickField);
+         menu.addchk(this.pad.fTicky == 1, "ticks on both side", "1fTicky", SetTickField);
+         menu.addchk(this.pad.fTicky == 2, "labels right", "2fTicky", SetTickField);
+         menu.add("endsub:");
+
+         //menu.addchk(this.pad.fTickx, 'Tick x', 'fTickx', ToggleField);
+         //menu.addchk(this.pad.fTicky, 'Tick y', 'fTicky', ToggleField);
 
          this.FillAttContextMenu(menu);
       }
@@ -4630,6 +5268,9 @@
    }
 
    TPadPainter.prototype.Redraw = function(resize) {
+
+      // prevent redrawing
+      if (this._doing_pad_draw) return console.log('Prevent redrawing', this.pad.fName);
 
       var showsubitems = true;
 
@@ -4691,6 +5332,9 @@
    TPadPainter.prototype.UpdateObject = function(obj) {
       if (!obj) return false;
 
+      this.pad.fBits = obj.fBits;
+      this.pad.fTitle = obj.fTitle;
+
       this.pad.fGridx = obj.fGridx;
       this.pad.fGridy = obj.fGridy;
       this.pad.fTickx = obj.fTickx;
@@ -4715,7 +5359,7 @@
       this.pad.fLineStyle = obj.fLineStyle;
       this.pad.fLineWidth = obj.fLineWidth;
 
-      if (this.iscan) this.CheckColors(obj);
+      if (this.iscan) this.CheckSpecialsInPrimitives(obj);
 
       var fp = this.frame_painter();
       if (fp) fp.UpdateAttributes(!fp.modified_NDC);
@@ -4739,94 +5383,120 @@
       // function called when drawing next snapshot from the list
       // it is also used as callback for drawing of previous snap
 
-      if (objpainter && lst && lst[indx] && (typeof objpainter.snapid === 'undefined')) {
-         // keep snap id in painter, will be used for the
-         if (this.painters.indexOf(objpainter)<0) this.painters.push(objpainter);
-         objpainter.snapid = lst[indx].fObjectID;
+      if (indx===0) {
+         // flag used to prevent immediate pad redraw during first draw
+         this._doing_pad_draw = true;
+         this._snaps_map = {}; // to control how much snaps are drawn
+         this._num_primitives = lst ? lst.length : 0;
       }
 
-      ++indx; // change to the next snap
+      while (true) {
 
-      if (!lst || indx >= lst.length) return JSROOT.CallBack(call_back, this);
-
-      var snap = lst[indx], painter = null;
-
-      // first find existing painter for the object
-      for (var k=0; k<this.painters.length; ++k) {
-         if (this.painters[k].snapid === snap.fObjectID) { painter = this.painters[k]; break;  }
-      }
-
-      // function which should be called when drawing of next item finished
-      var draw_callback = this.DrawNextSnap.bind(this, lst, indx, call_back);
-
-      if (painter) {
-
-         if (snap.fKind === 1) { // object itself
-            if (painter.UpdateObject(snap.fSnapshot, snap.fOption)) painter.Redraw();
-            return draw_callback(painter); // call next
+         if (objpainter && lst && lst[indx] && objpainter.snapid === undefined) {
+            // keep snap id in painter, will be used for the
+            if (this.painters.indexOf(objpainter)<0) this.painters.push(objpainter);
+            objpainter.snapid = lst[indx].fObjectID;
          }
 
-         if (snap.fKind === 2) { // update SVG
-            if (painter.UpdateObject(snap.fSnapshot)) painter.Redraw();
-            return draw_callback(painter); // call next
+         objpainter = null;
+
+         ++indx; // change to the next snap
+
+         if (!lst || indx >= lst.length) {
+            delete this._doing_pad_draw;
+            delete this._snaps_map;
+            return JSROOT.CallBack(call_back, this);
+         }
+
+         var snap = lst[indx],
+             snapid = snap.fObjectID,
+             cnt = this._snaps_map[snapid];
+
+         if (cnt) cnt++; else cnt=1;
+         this._snaps_map[snapid] = cnt; // check how many objects with same snapid drawn, use them again
+
+         this._current_primitive_indx = indx;
+
+         // first appropriate painter for the object
+         // if same object drawn twice, two painters will exists
+         for (var k=0; k<this.painters.length; ++k) {
+            if (this.painters[k].snapid === snapid)
+               if (--cnt === 0) { objpainter = this.painters[k]; break;  }
+         }
+
+         // function which should be called when drawing of next item finished
+         var draw_callback = this.DrawNextSnap.bind(this, lst, indx, call_back);
+
+         if (objpainter) {
+
+            if (snap.fKind === 1) { // object itself
+               if (objpainter.UpdateObject(snap.fSnapshot, snap.fOption)) objpainter.Redraw();
+               continue; // call next
+            }
+
+            if (snap.fKind === 2) { // update SVG
+               if (objpainter.UpdateObject(snap.fSnapshot)) objpainter.Redraw();
+               continue; // call next
+            }
+
+            if (snap.fKind === 3) { // subpad
+               return objpainter.RedrawPadSnap(snap, draw_callback);
+            }
+
+            continue; // call next
+         }
+
+         if (snap.fKind === 4) { // specials like list of colors
+            this.CheckSpecial(snap.fSnapshot);
+            continue;
          }
 
          if (snap.fKind === 3) { // subpad
-            return painter.RedrawPadSnap(snap, draw_callback);
+
+            if (snap.fPrimitives._typename) {
+               alert("Problem in JSON I/O with primitves for sub-pad");
+               snap.fPrimitives = [ snap.fPrimitives ];
+            }
+
+            var subpad = snap.fPrimitives[0].fSnapshot;
+
+            subpad.fPrimitives = null; // clear primitives, they just because of I/O
+
+            var padpainter = new TPadPainter(subpad, false);
+            padpainter.DecodeOptions(snap.fPrimitives[0].fOption);
+            padpainter.SetDivId(this.divid); // pad painter will be registered in the canvas painters list
+            padpainter.snapid = snap.fObjectID;
+
+            padpainter.CreatePadSvg();
+
+            if (padpainter.MatchObjectType("TPad") && snap.fPrimitives.length > 1) {
+               padpainter.AddButton(JSROOT.ToolbarIcons.camera, "Create PNG", "PadSnapShot");
+               padpainter.AddButton(JSROOT.ToolbarIcons.circle, "Enlarge pad", "EnlargePad");
+
+               if (JSROOT.gStyle.ContextMenu)
+                  padpainter.AddButton(JSROOT.ToolbarIcons.question, "Access context menus", "PadContextMenus");
+            }
+
+            // we select current pad, where all drawing is performed
+            var prev_name = padpainter.CurrentPadName(padpainter.this_pad_name);
+            padpainter.DrawNextSnap(snap.fPrimitives, 0, function() {
+               padpainter.CurrentPadName(prev_name);
+               draw_callback(padpainter);
+            });
+            return;
          }
 
-         return draw_callback(painter); // call next
+         var handle = { func: draw_callback };
+
+         // here the case of normal drawing, can be improved
+         if (snap.fKind === 1)
+            objpainter = JSROOT.draw(this.divid, snap.fSnapshot, snap.fOption, handle);
+
+         if (snap.fKind === 2)
+            objpainter = JSROOT.draw(this.divid, snap.fSnapshot, snap.fOption, handle);
+
+         if (!handle.completed) return; // if callback will be invoked, break while loop
       }
-
-      if (snap.fKind === 3) { // subpad
-
-         if (snap.fPrimitives._typename) snap.fPrimitives = [ snap.fPrimitives ];
-
-         var subpad = snap.fPrimitives[0].fSnapshot;
-
-         subpad.fPrimitives = null; // clear primitives, they just because of I/O
-
-         var padpainter = new TPadPainter(subpad, false);
-         padpainter.DecodeOptions(snap.fPrimitives[0].fOption);
-         padpainter.SetDivId(this.divid); // pad painter will be registered in the canvas painters list
-         padpainter.snapid = snap.fObjectID;
-
-         padpainter.CreatePadSvg();
-
-         if (padpainter.MatchObjectType("TPad") && snap.fPrimitives.length > 1) {
-            padpainter.AddButton(JSROOT.ToolbarIcons.camera, "Create PNG", "PadSnapShot");
-            padpainter.AddButton(JSROOT.ToolbarIcons.circle, "Enlarge pad", "EnlargePad");
-
-            if (JSROOT.gStyle.ContextMenu)
-              padpainter.AddButton(JSROOT.ToolbarIcons.question, "Access context menus", "PadContextMenus");
-         }
-
-         // we select current pad, where all drawing is performed
-         var prev_name = padpainter.CurrentPadName(padpainter.this_pad_name);
-         padpainter.DrawNextSnap(snap.fPrimitives, 0, function() {
-            padpainter.CurrentPadName(prev_name);
-            draw_callback(padpainter);
-         });
-         return;
-      }
-
-      // here the case of normal drawing, can be improved
-      if (snap.fKind === 1) {
-         var obj = snap.fSnapshot;
-         if (obj) obj.$snapid = snap.fObjectID; // mark object itself, workaround for stats drawing
-
-         // TODO: frame should be created in histogram painters
-         //if (obj._typename != "TFrame" && this.svg_frame().select(".main_layer").empty()) {
-         //   JSROOT.Painter.drawFrame(this.divid, null);
-         //}
-
-         return JSROOT.draw(this.divid, obj, snap.fOption, draw_callback);
-      }
-
-      if (snap.fKind === 2)
-         return JSROOT.draw(this.divid, snap.fSnapshot, snap.fOption, draw_callback);
-
-      draw_callback(null);
    }
 
    TPadPainter.prototype.FindSnap = function(snapid) {
@@ -4859,7 +5529,7 @@
       // if (snap.fPrimitives._typename) snap.fPrimitives = [ snap.fPrimitives ];
 
       var first = snap.fPrimitives[0].fSnapshot;
-      first.fPrimitives = null; // primitives are not interesting, just cannot disable in IO
+      first.fPrimitives = null; // primitives are not interesting, just cannot disable it in IO
 
       if (this.snapid === undefined) {
          // first time getting snap, create all gui elements first
@@ -4930,13 +5600,9 @@
           prev_name = padpainter.CurrentPadName(padpainter.this_pad_name);
 
       padpainter.DrawNextSnap(snap.fPrimitives, 0, function() {
-          padpainter.CurrentPadName(prev_name);
-          call_back(padpainter);
+         padpainter.CurrentPadName(prev_name);
+         call_back(padpainter);
       });
-
-      // this.DrawNextSnap(snap.fPrimitives, 0, call_back, null); // update all snaps after each other
-
-      // show we redraw all other painters without snapid?
    }
 
    TPadPainter.prototype.CreateImage = function(format, call_back) {
@@ -5095,8 +5761,8 @@
          //rrr.setSize(sz.width, sz.height);
          //rrr.render(main.scene, main.camera);
 
-          main.svg_layer("special_layer")      // select layer
-              .append("g")                     // create special group
+          main
+              .insert("g",".primitives_layer")             // create special group
               .attr("class","temp_saveaspng")
               .attr("transform", "translate(" + sz.x + "," + sz.y + ")")
               .node().appendChild(svg3d);      // add code
@@ -5309,6 +5975,15 @@
          this.pad_painter().AddButton(btn, tooltip, funcname);
    }
 
+   TPadPainter.prototype.DrawingReady = function(res_painter) {
+
+      var main = this.main_painter();
+
+      if (main && main.mode3d && typeof main.Render3D == 'function') main.Render3D(-2222);
+
+      TBasePainter.prototype.DrawingReady.call(this, res_painter);
+   }
+
    TPadPainter.prototype.DecodeOptions = function(opt) {
       var pad = this.GetObject();
       if (!pad) return;
@@ -5317,11 +5992,13 @@
 
       if (d.check('WEBSOCKET')) this.OpenWebsocket();
 
-      this.options = { GlobalColors: true, LocalColors: false, IgnorePalette: false };
+      this.options = { GlobalColors: true, LocalColors: false, IgnorePalette: false, RotateFrame: false, FixFrame: false };
 
       if (d.check('NOCOLORS') || d.check('NOCOL')) this.options.GlobalColors = this.options.LocalColors = false;
       if (d.check('LCOLORS') || d.check('LCOL')) { this.options.GlobalColors = false; this.options.LocalColors = true; }
       if (d.check('NOPALETTE') || d.check('NOPAL')) this.options.IgnorePalette = true;
+      if (d.check('ROTATE')) this.options.RotateFrame = true;
+      if (d.check('FIXFRAME')) this.options.FixFrame = true;
 
       if (d.check('WHITE')) pad.fFillColor = 0;
       if (d.check('LOGX')) pad.fLogx = 1;
@@ -5359,13 +6036,11 @@
             painter.AddButton(JSROOT.ToolbarIcons.question, "Access context menus", "PadContextMenus");
       }
 
-      var prev_name;
+      // we select current pad, where all drawing is performed
+      var prev_name = painter.has_canvas ? painter.CurrentPadName(painter.this_pad_name) : undefined;
 
-      if (painter.has_canvas)
-         // we select current pad, where all drawing is performed
-         prev_name = painter.CurrentPadName(painter.this_pad_name);
-
-      painter.DrawPrimitive(0, function() {
+      // flag used to prevent immediate pad redraw during first draw
+      painter.DrawPrimitives(0, function() {
          // we restore previous pad name
          painter.CurrentPadName(prev_name);
          painter.DrawingReady();
@@ -5383,92 +6058,119 @@
 
    TCanvasPainter.prototype = Object.create(TPadPainter.prototype);
 
-   TCanvasPainter.prototype.CreateCanvasMenu = function() {
-      // FIXME: temporary solution, should be removed
-      if (this.enlarge_main('state')==='on') return;
+   TCanvasPainter.prototype.ChangeLayout = function(layout_kind, call_back) {
+      var current = this.get_layout_kind();
+      if (current == layout_kind) return JSROOT.CallBack(call_back, true);
 
-      this.layout_main("canvas");
+      var origin = this.select_main('origin'),
+          sidebar = origin.select('.side_panel'),
+          main = this.select_main(), lst = [];
 
-      var header = this.select_main('header');
+      while (main.node().firstChild)
+         lst.push(main.node().removeChild(main.node().firstChild));
 
-      header.html("").style('background','lightgrey');
+      if (!sidebar.empty()) JSROOT.cleanup(sidebar.node());
 
-      var items = ['File','Edit','View','Options','Tools','Help'];
-      var painter = this;
-      for (var k in items) {
-         var elem = header.append("p").attr("class","canvas_menu").text(items[k]);
-         if (items[k]=='Help') elem.style('float','right');
-         elem.on('click', this.ShowCanvasMenu.bind(this, items[k]));
-      }
-   }
+      this.set_layout_kind("simple"); // restore defaults
+      origin.html(""); // cleanup origin
 
-   TCanvasPainter.prototype.ShowCanvasMenu = function(name) {
-
-      d3.event.stopPropagation(); // disable main context menu
-      d3.event.preventDefault();  // disable browser context menu
-
-      var evnt = d3.event;
-
-      function HandleClick(arg) {
-         if (!this._websocket) return;
-
-         switch (arg) {
-            case "Close canvas": this.OnWebsocketClosed(); this.CloseWebsocket(true); break;
-            case "Interrupt": this.SendWebsocket("INTERRUPT"); break;
-            case "Quit ROOT": this.SendWebsocket("QUIT"); break;
-            default: console.log('click', arg);
-         }
+      if (layout_kind == 'simple') {
+         main = origin;
+         for (var k=0;k<lst.length;++k)
+            main.node().appendChild(lst[k]);
+         this.set_layout_kind(layout_kind);
+         // JSROOT.resize(main.node());
+         return JSROOT.CallBack(call_back, true);
       }
 
-      JSROOT.Painter.createMenu(this, function(menu) {
+      var pthis = this;
 
-         switch(name) {
-            case "File": {
-               menu.add("Close canvas", HandleClick);
-               menu.add("separator");
-               menu.add("Save PNG", HandleClick);
-               var ext = ["ps","eps","pdf","tex","gif","jpg","png","C","root"];
-               menu.add("sub:Save");
-               for (var k in ext) menu.add("canvas."+ext[k], HandleClick);
-               menu.add("endsub:");
-               menu.add("separator");
-               menu.add("Interrupt", HandleClick);
-               menu.add("separator");
-               menu.add("Quit ROOT", HandleClick);
-               break;
-            }
-            case "Edit":
-               menu.add("Clear pad", HandleClick);
-               menu.add("Clear canvas", HandleClick);
-               break;
-            case "View": {
-               menu.addchk(menu.painter.HasEventStatus(), "Event status", menu.painter.ToggleEventStatus.bind(menu.painter));
-               var fp = menu.painter.frame_painter();
-               menu.addchk(fp && fp.tooltip_allowed, "Tooltip info", function() { if (fp) fp.tooltip_allowed = !fp.tooltip_allowed; });
-               break;
-            }
-            case "Options": {
-               var main = menu.painter.main_painter();
-               menu.addchk(main && main.ToggleStat('only-check'), "Statistic", function() { if (main) main.ToggleStat(); });
-               menu.addchk(main && main.ToggleTitle('only-check'), "Histogram title",  function() { if (main) main.ToggleTitle(); });
-               menu.addchk(main && main.ToggleStat('fitpar-check'), "Fit parameters", function() { if (main) main.ToggleStat('fitpar-toggle'); });
-               break;
-            }
-            case "Tools":
-               menu.add("Inspector", HandleClick);
-               break;
-            case "Help":
-               menu.add("header:Basic help on...");
-               menu.add("Canvas", HandleClick);
-               menu.add("Menu", HandleClick);
-               menu.add("Browser", HandleClick);
-               menu.add("separator");
-               menu.add("About ROOT", HandleClick);
-               break;
+      JSROOT.AssertPrerequisites("jq2d", function() {
+
+         var grid = new JSROOT.GridDisplay(origin.node(), layout_kind);
+
+         if (layout_kind.indexOf("vert")==0) {
+            main = d3.select(grid.GetFrame(0));
+            sidebar = d3.select(grid.GetFrame(1));
+         } else {
+            main = d3.select(grid.GetFrame(1));
+            sidebar = d3.select(grid.GetFrame(0));
          }
-         if (menu.size()>0) menu.show(evnt);
+
+         main.classed("central_panel", true).style('position','relative');
+         sidebar.classed("side_panel", true).style('position','relative');
+
+         // now append all childs to the new main
+         for (var k=0;k<lst.length;++k)
+            main.node().appendChild(lst[k]);
+
+         pthis.set_layout_kind(layout_kind, ".central_panel");
+
+         JSROOT.CallBack(call_back, true);
       });
    }
+
+   TCanvasPainter.prototype.ToggleProjection = function(kind, call_back) {
+      delete this.proj_painter;
+
+      if (kind) this.proj_painter = 1; // just indicator that drawing can be preformed
+
+      if (this.use_openui && this.ShowUI5ProjectionArea)
+         return this.ShowUI5ProjectionArea(kind, call_back);
+
+      var layout = 'simple';
+
+      if (kind == "X") layout = 'vert2_31'; else
+      if (kind == "Y") layout = 'horiz2_13';
+
+      this.ChangeLayout(layout, call_back);
+   }
+
+   TCanvasPainter.prototype.DrawProjection = function(kind,hist) {
+      if (!this.proj_painter) return; // ignore drawing if projection not configured
+
+      if (this.proj_painter === 1) {
+
+         var canv = JSROOT.Create("TCanvas"), pthis = this, pad = this.root_pad(), main = this.main_painter(), drawopt;
+
+         if (kind == "X") {
+            canv.fLeftMargin = pad.fLeftMargin;
+            canv.fRightMargin = pad.fRightMargin;
+            canv.fLogx = main.logx ? 1 : 0;
+            canv.fUxmin = main.logx ? JSROOT.log10(main.scale_xmin) : main.scale_xmin;
+            canv.fUxmax = main.logx ? JSROOT.log10(main.scale_xmax) : main.scale_xmax;
+            drawopt = "fixframe";
+         } else {
+            canv.fBottomMargin = pad.fBottomMargin;
+            canv.fTopMargin = pad.fTopMargin;
+            canv.fLogx = main.logy ? 1 : 0;
+            canv.fUxmin = main.logy ? JSROOT.log10(main.scale_ymin) : main.scale_ymin;
+            canv.fUxmax = main.logy ? JSROOT.log10(main.scale_ymax) : main.scale_ymax;
+            drawopt = "rotate";
+         }
+
+         canv.fPrimitives.Add(hist, "hist");
+
+         if (this.use_openui && this.DrawInUI5ProjectionArea ) {
+            // copy frame attributes
+            this.DrawInUI5ProjectionArea(canv, drawopt, function(painter) { pthis.proj_painter = painter; })
+         } else {
+            this.DrawInSidePanel(canv, drawopt, function(painter) { pthis.proj_painter = painter; })
+         }
+      } else {
+         var hp = this.proj_painter.main_painter();
+         if (hp) hp.UpdateObject(hist, "hist");
+         this.proj_painter.RedrawPad();
+      }
+   }
+
+
+   TCanvasPainter.prototype.DrawInSidePanel = function(canv, opt, call_back) {
+      var side = this.select_main('origin').select(".side_panel");
+      if (side.empty()) return JSROOT.CallBack(call_back, null);
+      JSROOT.draw(side.node(), canv, opt, call_back);
+   }
+
 
    TCanvasPainter.prototype.ShowMessage = function(msg) {
       JSROOT.progress(msg, 7000);
@@ -5504,31 +6206,33 @@
          msg = msg.substr(5);
          var p1 = msg.indexOf(":"),
              snapid = msg.substr(0,p1),
-             snap = JSROOT.parse(msg.substr(p1+1));
-
-         if (typeof this.RedrawPadSnap === 'function') {
-            var pthis = this;
-            this.RedrawPadSnap(snap, function() {
-               conn.send("SNAPDONE:" + snapid); // send ready message back when drawing completed
-            });
-         } else {
-            conn.send('READY'); // send ready message back
-         }
+             snap = JSROOT.parse(msg.substr(p1+1)),
+             pthis = this;
+         this.RedrawPadSnap(snap, function() {
+            conn.send("SNAPDONE:" + snapid); // send ready message back when drawing completed
+         });
       } else if (msg.substr(0,6)=='SNAP6:') {
          // This is snapshot, produced with ROOT6, handled slighly different
 
-         var snap = JSROOT.parse(msg.substr(6));
+         this.root6_canvas = true; // indicate that drawing of root6 canvas is peformed
+         // if (!this.snap_cnt) this.snap_cnt = 1; else this.snap_cnt++;
 
-         if (typeof this.RedrawPadSnap === 'function') {
-            var pthis = this;
-            this.RedrawPadSnap(snap, function() {
-               var reply = pthis.GetAllRanges();
-               // if (reply) console.log("ranges: " + reply);
-               conn.send(reply ? "RREADY:" + reply : "RREADY:" ); // send ready message back when drawing completed
-            });
-         } else {
-            conn.send('READY'); // send ready message back
-         }
+         msg = msg.substr(6);
+         var p1 = msg.indexOf(":"),
+             snapid = msg.substr(0,p1),
+             snap = JSROOT.parse(msg.substr(p1+1)),
+             pthis = this;
+
+         // console.log('Get SNAP6', this.snap_cnt);
+
+         this.RedrawPadSnap(snap, function() {
+            // console.log('Complete SNAP6', pthis.snap_cnt);
+            pthis.CompeteCanvasSnapDrawing();
+            var ranges = pthis.GetAllRanges();
+            if (ranges) ranges = ":" + ranges;
+            // if (ranges) console.log("ranges: " + ranges);
+            conn.send("RREADY:" + snapid + ranges); // send ready message back when drawing completed
+         });
 
       } else if (msg.substr(0,4)=='JSON') {
          var obj = JSROOT.parse(msg.substr(4));
@@ -5560,56 +6264,59 @@
             console.log('Unrecognized command ' + cmd);
             conn.send(reply);
          }
-
+      } else if ((msg.substr(0,7)=='DXPROJ:') || (msg.substr(0,7)=='DYPROJ:')) {
+         var kind = msg[1],
+             hist = JSROOT.parse(msg.substr(7));
+         conn.send('READY'); // special message, confirm that sending is ready
+         this.DrawProjection(kind, hist);
+      } else if (msg.substr(0,5)=='SHOW:') {
+         conn.send('READY'); // confirm that sending is ready
+         var that = msg.substr(5),
+             on = that[that.length-1] == '1';
+         this.ShowSection(that.substr(0,that.length-2), on);
       } else {
          console.log("unrecognized msg " + msg);
       }
    }
 
-   TCanvasPainter.prototype.HasEventStatus = function() {
-      return this.has_event_status;
+   TCanvasPainter.prototype.ShowSection = function(that, on) {
+      switch(that) {
+         case "Menu": break;
+         case "StatusBar": break;
+         case "Editor": break;
+         case "ToolBar": break;
+         case "ToolTips": this.SetTooltipAllowed(on); break;
+      }
    }
 
-   TCanvasPainter.prototype.ToggleEventStatus = function() {
-      // when function called, jquery should be already loaded
+   JSROOT.TCanvasStatusBits = {
+      kShowEventStatus  : JSROOT.BIT(15),
+      kAutoExec         : JSROOT.BIT(16),
+      kMenuBar          : JSROOT.BIT(17),
+      kShowToolBar      : JSROOT.BIT(18),
+      kShowEditor       : JSROOT.BIT(19),
+      kMoveOpaque       : JSROOT.BIT(20),
+      kResizeOpaque     : JSROOT.BIT(21),
+      kIsGrayscale      : JSROOT.BIT(22),
+      kShowToolTips     : JSROOT.BIT(23)
+   };
 
-      if ((this.enlarge_main('state')==='on') || this.plain_layout) return;
+   TCanvasPainter.prototype.CompeteCanvasSnapDrawing = function() {
+      if (!this.pad) return;
 
-      this.has_event_status = !this.has_event_status;
-      if (JSROOT.Painter.ShowStatus) this.has_event_status = false;
+      if (document) document.title = this.pad.fTitle;
 
-      var resized = this.layout_main(this.has_event_status || this._websocket ? "canvas" : "simple");
+      if (this._all_sections_showed) return;
+      this._all_sections_showed = true;
+      this.ShowSection("Menu", this.pad.TestBit(JSROOT.TCanvasStatusBits.kMenuBar));
+      this.ShowSection("StatusBar", this.pad.TestBit(JSROOT.TCanvasStatusBits.kShowEventStatus));
+      this.ShowSection("ToolBar", this.pad.TestBit(JSROOT.TCanvasStatusBits.kShowToolBar));
+      this.ShowSection("Editor", this.pad.TestBit(JSROOT.TCanvasStatusBits.kShowEditor));
+      this.ShowSection("ToolTips", this.pad.TestBit(JSROOT.TCanvasStatusBits.kShowToolTips));
+   }
 
-      var footer = this.select_main('footer');
-
-      if (!this.has_event_status) {
-         footer.html("");
-         delete this.status_layout;
-         delete this.ShowStatus;
-         delete this.ShowStatusFunc;
-      } else {
-
-         this.status_layout = new JSROOT.GridDisplay(footer.node(), 'horizx4_1213');
-
-         var frame_titles = ['object name','object title','mouse coordinates','object info'];
-         for (var k=0;k<4;++k)
-            d3.select(this.status_layout.GetFrame(k)).attr('title', frame_titles[k]).style('overflow','hidden')
-            .append("label").attr("class","jsroot_status_label");
-
-         this.ShowStatusFunc = function(name, title, info, coordinates) {
-            if (!this.status_layout) return;
-            $(this.status_layout.GetFrame(0)).children('label').text(name || "");
-            $(this.status_layout.GetFrame(1)).children('label').text(title || "");
-            $(this.status_layout.GetFrame(2)).children('label').text(coordinates || "");
-            $(this.status_layout.GetFrame(3)).children('label').text(info || "");
-         }
-
-         this.ShowStatus = this.ShowStatusFunc.bind(this);
-
-         this.ShowStatus("canvas","title","info","");
-      }
-
-      if (resized) this.CheckCanvasResize(); // redraw with resize
+   TCanvasPainter.prototype.HasEventStatus = function() {
+      return this.has_event_status;
    }
 
    Painter.drawCanvas = function(divid, can, opt) {
@@ -5618,9 +6325,10 @@
 
       var painter = new TCanvasPainter(can);
       painter.DecodeOptions(opt);
+      painter.normal_canvas = !nocanvas;
 
       painter.SetDivId(divid, -1); // just assign id
-      painter.CheckColors(can);
+      painter.CheckSpecialsInPrimitives(can);
       painter.CreateCanvasSvg(0);
       painter.SetDivId(divid);  // now add to painters list
 
@@ -5634,7 +6342,31 @@
       if (nocanvas && opt.indexOf("noframe") < 0)
          JSROOT.Painter.drawFrame(divid, null);
 
-      painter.DrawPrimitive(0, function() { painter.DrawingReady(); });
+      painter.DrawPrimitives(0, function() { painter.DrawingReady(); });
+      return painter;
+   }
+
+   Painter.drawPadSnapshot = function(divid, snap, opt) {
+      // just for debugging without running web canvas
+
+      var can = JSROOT.Create("TCanvas");
+
+      var painter = new TCanvasPainter(can);
+      painter.normal_canvas = false;
+
+      painter.SetDivId(divid, -1); // just assign id
+
+      painter.AddButton(JSROOT.ToolbarIcons.camera, "Create PNG", "CanvasSnapShot", "Ctrl PrintScreen");
+      if (JSROOT.gStyle.ContextMenu)
+         painter.AddButton(JSROOT.ToolbarIcons.question, "Access context menus", "PadContextMenus");
+
+      if (painter.enlarge_main('verify'))
+         painter.AddButton(JSROOT.ToolbarIcons.circle, "Enlarge canvas", "EnlargePad");
+
+      // JSROOT.Painter.drawFrame(divid, null);
+
+      painter.RedrawPadSnap(snap, function() { painter.DrawingReady(); });
+
       return painter;
    }
 
@@ -5657,7 +6389,7 @@
          var txt = this.txt.value;
          if (typeof txt != 'string') txt = "<undefined>";
 
-         var mathjax = this.txt.mathjax || (JSROOT.gStyle.MathJax>1);
+         var mathjax = this.txt.mathjax || (JSROOT.gStyle.Latex == 4);
 
          if (!mathjax && !('as_is' in this.txt)) {
             var arr = txt.split("\n"); txt = "";
@@ -5731,9 +6463,9 @@
    JSROOT.addDrawFunc({ name: "TPad", icon: "img_canvas", func: JSROOT.Painter.drawPad, opt: ";grid;gridx;gridy;tick;tickx;ticky;log;logx;logy;logz", expand_item: "fPrimitives" });
    JSROOT.addDrawFunc({ name: "TSlider", icon: "img_canvas", func: JSROOT.Painter.drawPad });
    JSROOT.addDrawFunc({ name: "TFrame", icon: "img_frame", func: JSROOT.Painter.drawFrame });
-   JSROOT.addDrawFunc({ name: "TPaveText", icon: "img_pavetext", prereq: "hist", func: "JSROOT.Painter.drawPaveText" });
-   JSROOT.addDrawFunc({ name: "TPaveStats", icon: "img_pavetext", prereq: "hist", func: "JSROOT.Painter.drawPaveText" });
-   JSROOT.addDrawFunc({ name: "TPaveLabel", icon: "img_pavelabel", prereq: "hist", func: "JSROOT.Painter.drawPaveText" });
+   JSROOT.addDrawFunc({ name: "TPaveText", icon: "img_pavetext", prereq: "hist", func: "JSROOT.Painter.drawPave" });
+   JSROOT.addDrawFunc({ name: "TPaveStats", icon: "img_pavetext", prereq: "hist", func: "JSROOT.Painter.drawPave" });
+   JSROOT.addDrawFunc({ name: "TPaveLabel", icon: "img_pavelabel", prereq: "hist", func: "JSROOT.Painter.drawPave" });
    JSROOT.addDrawFunc({ name: "TLatex", icon: "img_text", prereq: "more2d", func: "JSROOT.Painter.drawText", direct: true });
    JSROOT.addDrawFunc({ name: "TMathText", icon: "img_text", prereq: "more2d", func: "JSROOT.Painter.drawText", direct: true });
    JSROOT.addDrawFunc({ name: "TText", icon: "img_text", prereq: "more2d", func: "JSROOT.Painter.drawText", direct: true });
@@ -5744,13 +6476,19 @@
    JSROOT.addDrawFunc({ name: /^TH2/, icon: "img_histo2d", prereq: "hist", func: "JSROOT.Painter.drawHistogram2D", opt:";COL;COLZ;COL0;COL1;COL0Z;COL1Z;COLA;BOX;BOX1;SCAT;TEXT;CONT;CONT1;CONT2;CONT3;CONT4;ARR;SURF;SURF1;SURF2;SURF4;SURF6;E;A;LEGO;LEGO0;LEGO1;LEGO2;LEGO3;LEGO4;same", ctrl: "colz" });
    JSROOT.addDrawFunc({ name: "TProfile2D", sameas: "TH2" });
    JSROOT.addDrawFunc({ name: /^TH3/, icon: 'img_histo3d', prereq: "hist3d", func: "JSROOT.Painter.drawHistogram3D", opt:";SCAT;BOX;BOX2;BOX3;GLBOX1;GLBOX2;GLCOL" });
-   JSROOT.addDrawFunc({ name: "THStack", icon: "img_histo1d", prereq: "hist", func: "JSROOT.Painter.drawHStack", expand_item: "fHists" });
+   JSROOT.addDrawFunc({ name: "THStack", icon: "img_histo1d", prereq: "hist", func: "JSROOT.Painter.drawHStack", expand_item: "fHists", opt: "PFC;PLC" });
    JSROOT.addDrawFunc({ name: "TPolyMarker3D", icon: 'img_histo3d', prereq: "hist3d", func: "JSROOT.Painter.drawPolyMarker3D" });
-   JSROOT.addDrawFunc({ name: "TGraphPolargram" }); // just dummy entry to avoid drawing of this object
-   JSROOT.addDrawFunc({ name: "TGraph2D", icon:"img_graph", prereq: "hist3d", func: "JSROOT.Painter.drawGraph2D", opt:";P;PCOL"});
-   JSROOT.addDrawFunc({ name: "TGraph2DErrors", icon:"img_graph", prereq: "hist3d", func: "JSROOT.Painter.drawGraph2D", opt:";P;PCOL;ERR"});
-   JSROOT.addDrawFunc({ name: /^TGraph/, icon:"img_graph", prereq: "more2d", func: "JSROOT.Painter.drawGraph", opt:";L;P"});
-   JSROOT.addDrawFunc({ name: "TEfficiency", icon:"img_graph", prereq: "more2d", func: "JSROOT.Painter.drawEfficiency", opt:";AP"});
+   JSROOT.addDrawFunc({ name: "TPolyLine3D", icon: 'img_graph', prereq: "3d", func: "JSROOT.Painter.drawPolyLine3D", direct: true });
+   JSROOT.addDrawFunc({ name: "TGraphStruct" });
+   JSROOT.addDrawFunc({ name: "TGraphNode" });
+   JSROOT.addDrawFunc({ name: "TGraphEdge" });
+   JSROOT.addDrawFunc({ name: "TGraphTime", icon:"img_graph", prereq: "more2d", func: "JSROOT.Painter.drawGraphTime", opt: "once;repeat;first", theonly: true });
+   JSROOT.addDrawFunc({ name: "TGraph2D", icon:"img_graph", prereq: "hist3d", func: "JSROOT.Painter.drawGraph2D", opt: ";P;PCOL", theonly: true });
+   JSROOT.addDrawFunc({ name: "TGraph2DErrors", icon:"img_graph", prereq: "hist3d", func: "JSROOT.Painter.drawGraph2D", opt: ";P;PCOL;ERR", theonly: true });
+   JSROOT.addDrawFunc({ name: "TGraphPolargram", icon:"img_graph", prereq: "more2d", func: "JSROOT.Painter.drawGraphPolargram", theonly: true });
+   JSROOT.addDrawFunc({ name: "TGraphPolar", icon:"img_graph", prereq: "more2d", func: "JSROOT.Painter.drawGraphPolar", opt: ";F;L;P;PE", theonly: true });
+   JSROOT.addDrawFunc({ name: /^TGraph/, icon:"img_graph", prereq: "more2d", func: "JSROOT.Painter.drawGraph", opt: ";L;P" });
+   JSROOT.addDrawFunc({ name: "TEfficiency", icon:"img_graph", prereq: "more2d", func: "JSROOT.Painter.drawEfficiency", opt: ";AP" });
    JSROOT.addDrawFunc({ name: "TCutG", sameas: "TGraph" });
    JSROOT.addDrawFunc({ name: /^RooHist/, sameas: "TGraph" });
    JSROOT.addDrawFunc({ name: /^RooCurve/, sameas: "TGraph" });
@@ -5759,15 +6497,18 @@
    JSROOT.addDrawFunc({ name: "TStreamerInfoList", icon: 'img_question', prereq: "hierarchy",  func: "JSROOT.Painter.drawStreamerInfo" });
    JSROOT.addDrawFunc({ name: "TPaletteAxis", icon: "img_colz", prereq: "hist", func: "JSROOT.Painter.drawPaletteAxis" });
    JSROOT.addDrawFunc({ name: "TWebPainting", icon: "img_graph", prereq: "more2d", func: "JSROOT.Painter.drawWebPainting" });
+   JSROOT.addDrawFunc({ name: "TPadWebSnapshot", icon: "img_canvas", func: JSROOT.Painter.drawPadSnapshot });
    JSROOT.addDrawFunc({ name: "kind:Text", icon: "img_text", func: JSROOT.Painter.drawRawText });
    JSROOT.addDrawFunc({ name: "TF1", icon: "img_tf1", prereq: "math;more2d", func: "JSROOT.Painter.drawFunction" });
-   JSROOT.addDrawFunc({ name: "TF2", icon: "img_tf2", prereq: "math;more2d", func: "JSROOT.Painter.drawTF2" });
+   JSROOT.addDrawFunc({ name: "TF2", icon: "img_tf2", prereq: "math;hist", func: "JSROOT.Painter.drawTF2" });
+   JSROOT.addDrawFunc({ name: "TSpline3", icon: "img_tf1", prereq: "more2d", func: "JSROOT.Painter.drawSpline" });
+   JSROOT.addDrawFunc({ name: "TSpline5", icon: "img_tf1", prereq: "more2d", func: "JSROOT.Painter.drawSpline" });
    JSROOT.addDrawFunc({ name: "TEllipse", icon: 'img_graph', prereq: "more2d", func: "JSROOT.Painter.drawEllipse", direct: true });
    JSROOT.addDrawFunc({ name: "TLine", icon: 'img_graph', prereq: "more2d", func: "JSROOT.Painter.drawLine", direct: true });
    JSROOT.addDrawFunc({ name: "TArrow", icon: 'img_graph', prereq: "more2d", func: "JSROOT.Painter.drawArrow", direct: true });
    JSROOT.addDrawFunc({ name: "TPolyLine", icon: 'img_graph', prereq: "more2d", func: "JSROOT.Painter.drawPolyLine", direct: true });
    JSROOT.addDrawFunc({ name: "TGaxis", icon: "img_graph", prereq: "hist", func: "JSROOT.Painter.drawGaxis" });
-   JSROOT.addDrawFunc({ name: "TLegend", icon: "img_pavelabel", prereq: "hist", func: "JSROOT.Painter.drawLegend" });
+   JSROOT.addDrawFunc({ name: "TLegend", icon: "img_pavelabel", prereq: "hist", func: "JSROOT.Painter.drawPave" });
    JSROOT.addDrawFunc({ name: "TBox", icon: 'img_graph', prereq: "more2d", func: "JSROOT.Painter.drawBox", direct: true });
    JSROOT.addDrawFunc({ name: "TWbox", icon: 'img_graph', prereq: "more2d", func: "JSROOT.Painter.drawBox", direct: true });
    JSROOT.addDrawFunc({ name: "TSliderBox", icon: 'img_graph', prereq: "more2d", func: "JSROOT.Painter.drawBox", direct: true });
@@ -5953,13 +6694,27 @@
 
    /** @fn JSROOT.draw(divid, obj, opt, callback)
     * Draw object in specified HTML element with given draw options  */
-   JSROOT.draw = function(divid, obj, opt, callback) {
+   JSROOT.draw = function(divid, obj, opt, drawcallback) {
+
+      var isdirectdraw = true; // indicates if extra callbacks (via AssertPrerequisites) was invoked to process
 
       function completeDraw(painter) {
-         if (painter && callback && (typeof painter.WhenReady == 'function'))
-            painter.WhenReady(callback);
+         var callbackfunc = null, ishandle = false;
+         if (typeof drawcallback == 'function') callbackfunc = drawcallback; else
+            if (drawcallback && (typeof drawcallback == 'object') && (typeof drawcallback.func=='function')) {
+               callbackfunc = drawcallback.func;
+               ishandle = true;
+            }
+
+         if (ishandle && isdirectdraw) {
+            // if there is no painter or drawing is already completed, return directly
+            if (!painter || painter._ready_called_) { drawcallback.completed = true; return painter; }
+         }
+
+         if (painter && drawcallback && (typeof painter.WhenReady == 'function'))
+            painter.WhenReady(callbackfunc);
          else
-            JSROOT.CallBack(callback, painter);
+            JSROOT.CallBack(callbackfunc, painter);
          return painter;
       }
 
@@ -5981,12 +6736,11 @@
       if (!handle) return completeDraw(null);
 
       if (handle.draw_field && obj[handle.draw_field])
-         return JSROOT.draw(divid, obj[handle.draw_field], opt, callback);
+         return JSROOT.draw(divid, obj[handle.draw_field], opt, drawcallback);
 
       if (!handle.func) return completeDraw(null);
 
       function performDraw() {
-
          if (handle.direct) {
             painter = new TObjectPainter(obj);
             painter.SetDivId(divid, 2);
@@ -6024,6 +6778,8 @@
       }
 
       if (prereq.length === 0) return completeDraw(null);
+
+      isdirectdraw = false;
 
       JSROOT.AssertPrerequisites(prereq, function() {
          var func = JSROOT.findFunction(funcname);

--- a/etc/http/scripts/JSRootPainter.more.js
+++ b/etc/http/scripts/JSRootPainter.more.js
@@ -31,38 +31,41 @@
       var text = this.GetObject(),
           w = this.pad_width(), h = this.pad_height(),
           pos_x = text.fX, pos_y = text.fY,
-          tcolor = JSROOT.Painter.root_colors[text.fTextColor],
-          use_pad = true, latex_kind = 0, fact = 1.;
+          tcolor = this.get_color(text.fTextColor),
+          use_frame = false,
+          fact = 1., textsize = text.fTextSize || 0.05,
+          main = this.main_painter();
 
       if (text.TestBit(JSROOT.BIT(14))) {
          // NDC coordinates
          pos_x = pos_x * w;
          pos_y = (1 - pos_y) * h;
-      } else
-      if (this.main_painter() !== null) {
-         w = this.frame_width(); h = this.frame_height(); use_pad = false;
-         pos_x = this.main_painter().grx(pos_x);
-         pos_y = this.main_painter().gry(pos_y);
-      } else
-      if (this.root_pad() !== null) {
+      } else if (main && !main.mode3d) {
+         w = this.frame_width(); h = this.frame_height(); use_frame = "upper_layer";
+         pos_x = main.grx(pos_x);
+         pos_y = main.gry(pos_y);
+      } else if (this.root_pad() !== null) {
          pos_x = this.ConvertToNDC("x", pos_x) * w;
          pos_y = (1 - this.ConvertToNDC("y", pos_y)) * h;
       } else {
          text.fTextAlign = 22;
          pos_x = w/2;
          pos_y = h/2;
-         if (text.fTextSize === 0) text.fTextSize = 0.05;
-         if (text.fTextColor === 0) text.fTextColor = 1;
+         if (!tcolor) tcolor = 'black';
       }
 
-      this.RecreateDrawG(use_pad, use_pad ? "text_layer" : "upper_layer");
+      this.CreateG(use_frame);
 
-      if (text._typename == 'TLatex') { latex_kind = 1; fact = 0.9; } else
-      if (text._typename == 'TMathText') { latex_kind = 2; fact = 0.8; }
+      var arg = { align: text.fTextAlign, x: Math.round(pos_x), y: Math.round(pos_y), text: text.fTitle, color: tcolor, latex: 0 };
 
-      this.StartTextDrawing(text.fTextFont, Math.round(text.fTextSize*Math.min(w,h)*fact));
+      if (text.fTextAngle) arg.rotate = -text.fTextAngle;
 
-      this.DrawText(text.fTextAlign, Math.round(pos_x), Math.round(pos_y), 0, 0, text.fTitle, tcolor, latex_kind);
+      if (text._typename == 'TLatex') { arg.latex = 1; fact = 0.9; } else
+      if (text._typename == 'TMathText') { arg.latex = 2; fact = 0.8; }
+
+      this.StartTextDrawing(text.fTextFont, Math.round((textsize>1) ? textsize : textsize*Math.min(w,h)*fact));
+
+      this.DrawText(arg);
 
       this.FinishTextDrawing();
    }
@@ -77,7 +80,7 @@
           isndc = line.TestBit(kLineNDC);
 
       // create svg:g container for line drawing
-      this.RecreateDrawG(true, "text_layer");
+      this.CreateG();
 
       this.draw_g
           .append("svg:line")
@@ -100,7 +103,7 @@
           cmd = "";
 
       // create svg:g container for polyline drawing
-      this.RecreateDrawG(true, "text_layer");
+      this.CreateG();
 
       for (var n=0;n<=polyline.fLastPoint;++n)
          cmd += ((n>0) ? "L" : "M") +
@@ -126,7 +129,7 @@
       if (!this.fillatt) this.fillatt = this.createAttFill(ellipse);
 
       // create svg:g container for ellipse drawing
-      this.RecreateDrawG(true, "text_layer");
+      this.CreateG();
 
       var x = this.AxisToSvg("x", ellipse.fX1, false),
           y = this.AxisToSvg("y", ellipse.fY1, false),
@@ -156,12 +159,12 @@
           y2 = -dx2*st - dy2*ct;
 
       this.draw_g
-         .attr("transform","translate("+x.toFixed(1)+","+y.toFixed(1)+")")
+         .attr("transform","translate("+Math.round(x)+","+Math.round(y)+")")
          .append("svg:path")
-         .attr("d", "M 0,0" +
-                    " L " + x1.toFixed(1) + "," + y1.toFixed(1) +
-                    " A " + rx.toFixed(1) + " " + ry.toFixed(1) + " " + -ellipse.fTheta.toFixed(1) + " 1 0 " + x2.toFixed(1) + "," + y2.toFixed(1) +
-                    " L 0,0 Z")
+         .attr("d", "M0,0" +
+                    "L" + Math.round(x1) + "," + Math.round(y1) +
+                    "A" + Math.round(rx) + "," + Math.round(ry) + "," + Math.round(-ellipse.fTheta) + ",1,0," + Math.round(x2) + "," + Math.round(y2) +
+                    "Z")
          .call(this.lineatt.func).call(this.fillatt.func);
    }
 
@@ -175,7 +178,7 @@
           fillatt = this.createAttFill(box);
 
       // create svg:g container for box drawing
-      this.RecreateDrawG(true, "text_layer");
+      this.CreateG();
 
       var x1 = this.AxisToSvg("x", box.fX1, false),
           x2 = this.AxisToSvg("x", box.fX2, false),
@@ -204,13 +207,13 @@
           isndc = marker.TestBit(kMarkerNDC);
 
       // create svg:g container for box drawing
-      this.RecreateDrawG(true, "text_layer");
+      this.CreateG();
 
       var x = this.AxisToSvg("x", marker.fX, isndc),
           y = this.AxisToSvg("y", marker.fY, isndc),
           path = att.create(x,y);
 
-      if (path && path.length > 0)
+      if (path)
          this.draw_g.append("svg:path")
              .attr("d", path)
              .call(att.func);
@@ -224,7 +227,7 @@
           isndc = false;
 
       // create svg:g container for box drawing
-      this.RecreateDrawG(true, "text_layer");
+      this.CreateG();
 
       var path = "";
 
@@ -245,19 +248,18 @@
       if (!this.lineatt) this.lineatt = new JSROOT.TAttLineHandler(arrow);
       if (!this.fillatt) this.fillatt = this.createAttFill(arrow);
 
-      var wsize = Math.max(this.pad_width(), this.pad_height()) * arrow.fArrowSize;
-      if (wsize<3) wsize = 3;
-      var hsize = wsize * Math.tan(arrow.fAngle/2 * (Math.PI/180));
+      var wsize = Math.max(3, Math.round(Math.max(this.pad_width(), this.pad_height()) * arrow.fArrowSize)),
+          hsize = Math.round(wsize * Math.tan(arrow.fAngle/2*Math.PI/180));
 
       // create svg:g container for line drawing
-      this.RecreateDrawG(true, "text_layer");
+      this.CreateG();
 
       var x1 = this.AxisToSvg("x", arrow.fX1, false),
           y1 = this.AxisToSvg("y", arrow.fY1, false),
           x2 = this.AxisToSvg("x", arrow.fX2, false),
           y2 = this.AxisToSvg("y", arrow.fY2, false),
-          right_arrow = "M0,0" + " L"+wsize.toFixed(1) +","+hsize.toFixed(1) + " L0," + (hsize*2).toFixed(1),
-          left_arrow =  "M" + wsize.toFixed(1) + ", 0" + " L 0," + hsize.toFixed(1) + " L " + wsize.toFixed(1) + "," + (hsize*2).toFixed(1),
+          right_arrow = "M0,0" + "L"+wsize+","+hsize + "L0,"+(2*hsize),
+          left_arrow =  "M"+wsize+",0" + "L0,"+hsize + "L"+wsize+"," + (2*hsize),
           m_start = null, m_mid = null, m_end = null, defs = null,
           oo = arrow.fOption, len = oo.length;
 
@@ -267,10 +269,10 @@
          m_start = "jsroot_arrowmarker_" +  JSROOT.id_counter++;
          var beg = defs.append("svg:marker")
                        .attr("id", m_start)
-                       .attr("markerWidth", wsize.toFixed(1))
-                       .attr("markerHeight", (hsize*2).toFixed(1))
+                       .attr("markerWidth", wsize)
+                       .attr("markerHeight", 2*hsize)
                        .attr("refX", "0")
-                       .attr("refY", hsize.toFixed(1))
+                       .attr("refY", hsize)
                        .attr("orient", "auto")
                        .attr("markerUnits", "userSpaceOnUse")
                        .append("svg:path")
@@ -293,10 +295,10 @@
 
          var mid = defs.append("svg:marker")
                       .attr("id", m_mid)
-                      .attr("markerWidth", wsize.toFixed(1))
-                      .attr("markerHeight", (hsize*2).toFixed(1))
-                      .attr("refX", (wsize*0.5).toFixed(1))
-                      .attr("refY", hsize.toFixed(1))
+                      .attr("markerWidth", wsize)
+                      .attr("markerHeight", 2*hsize)
+                      .attr("refX", Math.round(wsize*0.5))
+                      .attr("refY", hsize)
                       .attr("orient", "auto")
                       .attr("markerUnits", "userSpaceOnUse")
                       .append("svg:path")
@@ -313,10 +315,10 @@
          m_end = "jsroot_arrowmarker_" + JSROOT.id_counter++;
          var end = defs.append("svg:marker")
                        .attr("id", m_end)
-                       .attr("markerWidth", wsize.toFixed(1))
-                       .attr("markerHeight", (hsize*2).toFixed(1))
-                       .attr("refX", wsize.toFixed(1))
-                       .attr("refY", hsize.toFixed(1))
+                       .attr("markerWidth", wsize)
+                       .attr("markerHeight", 2*hsize)
+                       .attr("refX", wsize)
+                       .attr("refY", hsize)
                        .attr("orient", "auto")
                        .attr("markerUnits", "userSpaceOnUse")
                        .append("svg:path")
@@ -328,9 +330,9 @@
 
       var path = this.draw_g
            .append("svg:path")
-           .attr("d",  "M" + x1 + "," + y1 +
-                       ((m_mid == null) ? "" : "L" + (x1/2+x2/2).toFixed(1) + "," + (y1/2+y2/2).toFixed(1)) +
-                       " L" + x2 + "," + y2)
+           .attr("d",  "M"+x1+","+y1 +
+                       ((m_mid == null) ? "" : "L" + Math.round(x1/2+x2/2) + "," + Math.round(y1/2+y2/2)) +
+                       "L"+x2+","+y2)
             .call(this.lineatt.func);
 
       if (m_start) path.style("marker-start","url(#" + m_start + ")");
@@ -401,7 +403,7 @@
          return res;
       }
 
-      var xmin = tf1.fXmin, xmax = tf1.fXmax, logx = false, pad = this.root_pad();
+      var xmin = tf1.fXmin, xmax = tf1.fXmax, logx = false;
 
       if (gxmin !== gxmax) {
          if (gxmin > xmin) xmin = gxmin;
@@ -432,7 +434,7 @@
       var xmin = 0, xmax = 1, ymin = 0, ymax = 1,
           bins = this.CreateBins(true);
 
-      if ((bins!==null) && (bins.length > 0)) {
+      if (bins && (bins.length > 0)) {
 
          xmin = xmax = bins[0].x;
          ymin = ymax = bins[0].y;
@@ -452,15 +454,7 @@
           tf1 = this.GetObject();
 
       histo.fName = tf1.fName + "_hist";
-      if (tf1.fTitle.indexOf(';')!==0) {
-         var array = tf1.fTitle.split(';');
-         histo.fTitle = array[0];
-         if (array.length>1)
-            histo.fXaxis.fTitle = array[1];
-         if (array.length>2)
-            histo.fYaxis.fTitle = array[2];
-      }
-      else histo.fTitle = tf1.fTitle;
+      histo.fTitle = tf1.fTitle;
 
       histo.fXaxis.fXmin = xmin;
       histo.fXaxis.fXmax = xmax;
@@ -470,7 +464,7 @@
       return histo;
    }
 
-   TF1Painter.prototype.ProcessTooltipFunc = function(pnt) {
+   TF1Painter.prototype.ProcessTooltip = function(pnt) {
       var cleanup = false;
 
       if ((pnt === null) || (this.bins === null)) {
@@ -514,11 +508,11 @@
                   color1: this.lineatt.color,
                   color2: this.fillatt.color,
                   lines: [],
-                  exact : (Math.abs(bin.grx - pnt.x) < radius) && (Math.abs(bin.gry - pnt.y) < radius) };
+                  exact: (Math.abs(bin.grx - pnt.x) < radius) && (Math.abs(bin.gry - pnt.y) < radius) };
 
       res.changed = gbin.property("current_bin") !== best;
       res.menu = res.exact;
-      res.menu_dist = Math.sqrt((bin.grx-pnt.x)*(bin.grx-pnt.x) + (bin.gry-pnt.y)*(bin.grx-pnt.x));
+      res.menu_dist = Math.sqrt((bin.grx-pnt.x)*(bin.grx-pnt.x) + (bin.gry-pnt.y)*(bin.gry-pnt.y));
 
       if (res.changed)
          gbin.attr("cx", bin.grx)
@@ -537,30 +531,26 @@
 
    TF1Painter.prototype.Redraw = function() {
 
-      var w = this.frame_width(), h = this.frame_height(), tf1 = this.GetObject();
+      var w = this.frame_width(), h = this.frame_height(),
+          tf1 = this.GetObject(), pmain = this.main_painter(),
+          name = this.GetTipName("\n");
 
-      this.RecreateDrawG(false, "main_layer");
+      this.CreateG(true);
 
       // recalculate drawing bins when necessary
       this.bins = this.CreateBins(false);
 
-      var pthis = this;
-      var pmain = this.main_painter();
-      var name = this.GetTipName("\n");
-
       if (!this.lineatt)
          this.lineatt = new JSROOT.TAttLineHandler(tf1);
       this.lineatt.used = false;
+
       if (!this.fillatt)
          this.fillatt = this.createAttFill(tf1, undefined, undefined, 1);
       this.fillatt.used = false;
 
-      var n, bin;
       // first calculate graphical coordinates
-      for(n=0; n<this.bins.length; ++n) {
-         bin = this.bins[n];
-         //bin.grx = Math.round(pmain.grx(bin.x));
-         //bin.gry = Math.round(pmain.gry(bin.y));
+      for(var n=0; n<this.bins.length; ++n) {
+         var bin = this.bins[n];
          bin.grx = pmain.grx(bin.x);
          bin.gry = pmain.gry(bin.y);
       }
@@ -589,11 +579,6 @@
                .style("stroke", "none")
                .call(this.fillatt.func);
       }
-
-      delete this.ProcessTooltip;
-
-     if (JSROOT.gStyle.Tooltip > 0)
-        this.ProcessTooltip = this.ProcessTooltipFunc;
    }
 
    TF1Painter.prototype.CanZoomIn = function(axis,min,max) {
@@ -678,8 +663,13 @@
 
       if (this.has_errors) res.Errors = 1;
 
+      res._pfc = d.check("PFC");
+      res._plc = d.check("PLC");
+      res._pmc = d.check("PMC");
+
       if (d.check('L')) res.Line = 1;
       if (d.check('F')) res.Fill = 1;
+      if (d.check('IA')) res.Axis = "A"; else
       if (d.check('A')) res.Axis = "AXIS";
       if (d.check('X+')) res.Axis += "X+";
       if (d.check('Y+')) res.Axis += "Y+";
@@ -848,7 +838,7 @@
 
    TGraphPainter.prototype.DrawBins = function() {
 
-      this.RecreateDrawG(false, "main_layer");
+      this.CreateG(true);
 
       var pthis = this,
           pmain = this.main_painter(),
@@ -856,6 +846,25 @@
           h = this.frame_height(),
           graph = this.GetObject(),
           excl_width = 0;
+
+      if (this.options._pfc || this.options._plc || this.options._pmc) {
+         if (!this.pallette && JSROOT.Painter.GetColorPalette)
+            this.palette = JSROOT.Painter.GetColorPalette();
+
+         var pp = this.pad_painter(true);
+         if (this.palette && pp) {
+            var indx = pp.GetCurrentPrimitiveIndx(), num = pp.GetNumPrimitives();
+
+            var color = this.palette.calcColor(indx, num);
+            var icolor = this.add_color(color);
+
+            if (this.options._pfc) { graph.fFillColor = icolor; delete this.fillatt; }
+            if (this.options._plc) { graph.fLineColor = icolor; delete this.lineatt; }
+            if (this.options._pmc) { graph.fMarkerColor = icolor; delete this.markeratt; }
+         }
+
+         this.options._pfc = this.options._plc = this.options._pmc = false;
+      }
 
       if (!this.lineatt)
          this.lineatt = new JSROOT.TAttLineHandler(graph, undefined, true);
@@ -867,9 +876,9 @@
       this.draw_kind = "none"; // indicate if special svg:g were created for each bin
       this.marker_size = 0; // indicate if markers are drawn
 
-      if (this.lineatt.excl_side!=0) {
-         excl_width = this.lineatt.excl_side * this.lineatt.excl_width;
-         if (this.lineatt.width>0) this.options.Line = 1;
+      if (this.lineatt.excl_side != 0) {
+         excl_width = this.lineatt.excl_width;
+         if (this.lineatt.width > 0) this.options.Line = 1;
       }
 
       var drawbins = null;
@@ -1117,7 +1126,7 @@
          else
             this.markeratt.Change(undefined, this.options.Mark - 100);
 
-         this.marker_size = this.markeratt.size;
+         this.marker_size = this.markeratt.GetFullSize();
 
          this.markeratt.reset_pos();
 
@@ -1287,7 +1296,7 @@
 
       var radius = Math.max(this.lineatt.width + 3, 4);
 
-      if (this.marker_size > 0) radius = Math.max(Math.round(this.marker_size*7), radius);
+      if (this.marker_size > 0) radius = Math.max(this.marker_size, radius);
 
       if (bestbin !== null)
          bestdist = Math.sqrt(Math.pow(pnt.x-pmain.grx(bestbin.x),2) + Math.pow(pnt.y-pmain.gry(bestbin.y),2));
@@ -1301,7 +1310,7 @@
 
       if (bestbin === null) bestindx = -1;
 
-      var res = { bin: bestbin, indx: bestindx, dist: bestdist, radius: radius };
+      var res = { bin: bestbin, indx: bestindx, dist: bestdist, radius: Math.round(radius) };
 
       if ((bestbin===null) && islines) {
 
@@ -1440,18 +1449,18 @@
                  .attr("class","h1bin")
                  .style("pointer-events","none")
                  .style("opacity", "0.3")
-                 .attr("x", (hint.x - hint.radius).toFixed(1))
-                 .attr("y", (hint.y - hint.radius).toFixed(1))
-                 .attr("width", (2*hint.radius).toFixed(1))
-                 .attr("height", (2*hint.radius).toFixed(1));
+                 .attr("x", Math.round(hint.x - hint.radius))
+                 .attr("y", Math.round(hint.y - hint.radius))
+                 .attr("width", 2*hint.radius)
+                 .attr("height", 2*hint.radius);
          } else {
-            ttbin.append("svg:circle").attr("cy", hint.gry1.toFixed(1))
+            ttbin.append("svg:circle").attr("cy", Math.round(hint.gry1))
             if (Math.abs(hint.gry1-hint.gry2) > 1)
-               ttbin.append("svg:circle").attr("cy", hint.gry2.toFixed(1));
+               ttbin.append("svg:circle").attr("cy", Math.round(hint.gry2));
 
             var elem = ttbin.selectAll("circle")
                             .attr("r", hint.radius)
-                            .attr("cx", hint.x.toFixed(1));
+                            .attr("cx", Math.round(hint.x));
 
             if (!hint.islines) {
                elem.style('stroke', hint.color1 == 'black' ? 'green' : 'black').style('fill','none');
@@ -1516,20 +1525,19 @@
       return menu.size() > 0;
    }
 
-
-   TGraphPainter.prototype.ExecuteMenuCommand = function(item) {
-      if (JSROOT.TObjectPainter.prototype.ExecuteMenuCommand.call(this,item)) return true;
+   TGraphPainter.prototype.ExecuteMenuCommand = function(method, args) {
+      if (JSROOT.TObjectPainter.prototype.ExecuteMenuCommand.call(this,method,args)) return true;
 
       var canp = this.pad_painter(), fp = this.frame_painter();
 
-      if ((item.fName == 'RemovePoint') || (item.fName == 'InsertPoint')) {
+      if ((method.fName == 'RemovePoint') || (method.fName == 'InsertPoint')) {
          var pnt = fp ? fp.GetLastEventPos() : null;
 
          if (!canp || !fp || !pnt) return true; // ignore function
 
          var hint = this.ExtractTooltip(pnt);
 
-         if (item.fName == 'InsertPoint') {
+         if (method.fName == 'InsertPoint') {
             var main = this.main_painter(),
                 userx = main && main.RevertX ? main.RevertX(pnt.x) : 0,
                 usery = main && main.RevertY ? main.RevertY(pnt.y) : 0;
@@ -1543,7 +1551,6 @@
 
          return true; // call is processed
       }
-
 
       return false;
    }
@@ -1599,6 +1606,84 @@
       return true;
    }
 
+   TGraphPainter.prototype.FindFunc = function() {
+      var gr = this.GetObject();
+      if (gr && gr.fFunctions)
+         for (var i = 0; i < gr.fFunctions.arr.length; ++i) {
+            var func = gr.fFunctions.arr[i];
+            if ((func._typename == 'TF1') || (func._typename == 'TF2')) return func;
+         }
+      return func;
+   }
+
+   TGraphPainter.prototype.FindStat = function() {
+      var gr = this.GetObject();
+      if (gr && gr.fFunctions)
+         for (var i = 0; i < gr.fFunctions.arr.length; ++i) {
+            var func = gr.fFunctions.arr[i];
+            if ((func._typename == 'TPaveStats') && (func.fName == 'stats')) return func;
+         }
+
+      return null;
+   }
+
+   TGraphPainter.prototype.CreateStat = function() {
+      var func = this.FindFunc();
+      if (!func) return null;
+
+      var stats = this.FindStat();
+      if (stats) return stats;
+
+      // do not create stats box when drawing canvas
+      var pp = this.pad_painter();
+      if (pp && pp.normal_canvas) return null;
+
+      this.create_stats = true;
+
+      var st = JSROOT.gStyle;
+
+      stats = JSROOT.Create('TPaveStats');
+      JSROOT.extend(stats, { fName : 'stats',
+                             fOptStat: 0,
+                             fOptFit: st.fOptFit || 111,
+                             fBorderSize : 1} );
+
+      stats.fX1NDC = st.fStatX - st.fStatW;
+      stats.fY1NDC = st.fStatY - st.fStatH;
+      stats.fX2NDC = st.fStatX;
+      stats.fY2NDC = st.fStatY;
+
+      stats.fFillColor = st.fStatColor;
+      stats.fFillStyle = st.fStatStyle;
+
+      stats.fTextAngle = 0;
+      stats.fTextSize = st.fStatFontSize; // 9 ??
+      stats.fTextAlign = 12;
+      stats.fTextColor = st.fStatTextColor;
+      stats.fTextFont = st.fStatFont;
+
+      stats.AddText(func.fName);
+
+      // while TF1 was found, one can be sure that stats is existing
+      this.GetObject().fFunctions.Add(stats);
+
+      return stats;
+   }
+
+   TGraphPainter.prototype.FillStatistic = function(stat, dostat, dofit) {
+
+      // cannot fill stats without func
+      var func = this.FindFunc();
+
+      if (!func || !dofit || !this.create_stats) return false;
+
+      stat.ClearPave();
+
+      stat.FillFunctionStat(func, dofit);
+
+      return true;
+   }
+
    TGraphPainter.prototype.DrawNextFunction = function(indx, callback) {
       // method draws next function from the functions list
 
@@ -1607,8 +1692,13 @@
       if (!graph.fFunctions || (indx >= graph.fFunctions.arr.length))
          return JSROOT.CallBack(callback);
 
-      JSROOT.draw(this.divid, graph.fFunctions.arr[indx], graph.fFunctions.opt[indx],
-                  this.DrawNextFunction.bind(this, indx+1, callback));
+      var func = graph.fFunctions.arr[indx], opt = graph.fFunctions.opt[indx];
+
+      //  required for stats filling
+      // TODO: use weak reference (via pad list of painters and any kind of string)
+      func.$main_painter = this;
+
+      JSROOT.draw(this.divid, func, opt, this.DrawNextFunction.bind(this, indx+1, callback));
    }
 
    TGraphPainter.prototype.PerformDrawing = function(divid, hpainter) {
@@ -1629,6 +1719,8 @@
 
       painter.CreateBins();
 
+      painter.CreateStat();
+
       if (!painter.main_painter()) {
          if (!graph.fHistogram)
             graph.fHistogram = painter.CreateHistogram();
@@ -1638,6 +1730,778 @@
       }
 
       return painter;
+   }
+
+   // ==============================================================
+
+   function TGraphPolargramPainter(polargram) {
+      JSROOT.TObjectPainter.call(this, polargram);
+      this.$polargram = true; // indicate that this is polargram
+   }
+
+   TGraphPolargramPainter.prototype = Object.create(JSROOT.TObjectPainter.prototype);
+
+   TGraphPolargramPainter.prototype.translate = function(angle, radius, keep_float) {
+
+      var rx = this.r(radius),
+          ry = rx/this.szx*this.szy;
+
+      var pos = {
+         x: rx * Math.cos(-angle - this.angle),
+         y: ry * Math.sin(-angle - this.angle)
+      }
+
+      if (!keep_float) { pos.x = Math.round(pos.x); pos.y = Math.round(pos.y); }
+      pos.rx = rx;
+      pos.ry = ry;
+
+      return pos;
+   }
+
+   TGraphPolargramPainter.prototype.format = function(radius) {
+      // used to format label for radius ticks
+
+      if (radius === Math.round(radius)) return radius.toString();
+      if (this.ndig>10) return radius.toExponential(4);
+
+      return radius.toFixed((this.ndig > 0) ? this.ndig : 0);
+   }
+
+   TGraphPolargramPainter.prototype.Redraw = function() {
+      if (!this.is_main_painter()) return;
+
+      var pad = this.root_pad(), polar = this.GetObject(),
+          w = this.pad_width(), h = this.pad_height(),
+          midx = Math.round(w/2), midy = Math.round(h/2),
+          szx = Math.round(Math.max(0.1, 0.5 - Math.max(pad.fLeftMargin, pad.fRightMargin))*w),
+          szy = Math.round(Math.max(0.1, 0.5 - Math.max(pad.fBottomMargin, pad.fTopMargin))*h);
+
+      this.CreateG();
+
+      this.draw_g.attr("transform", "translate(" + midx + "," + midy + ")");
+
+      this.r = d3.scaleLinear().domain([polar.fRwrmin, polar.fRwrmax]).range([ 0, szx ]);
+      this.szx = szx;
+      this.szy = szy;
+      this.angle = polar.fAxisAngle || 0;
+
+      var ticks = this.r.ticks(5),
+          nminor = Math.floor((polar.fNdivRad % 10000) / 100);
+
+      if (!this.lineatt) this.lineatt = new JSROOT.TAttLineHandler(polar);
+      if (!this.gridatt) this.gridatt = new JSROOT.TAttLineHandler({ fLineColor: polar.fLineColor, fLineStyle: 2, fLineWidth: 1 });
+
+
+      var range = Math.abs(polar.fRwrmax - polar.fRwrmin);
+      this.ndig = (range <= 0) ? -3 : Math.round(JSROOT.log10(ticks.length / range));
+
+      // verify that all radius labels are unique
+      var lbls = [], indx = 0;
+      while (indx<ticks.length) {
+         var lbl = this.format(ticks[indx]);
+         if (lbls.indexOf(lbl)>=0) {
+            if (++this.ndig>10) break;
+            lbls = []; indx = 0; continue;
+          }
+         lbls.push(lbl);
+         indx++;
+      }
+
+      var exclude_last = false;
+
+      if (ticks[ticks.length-1] < polar.fRwrmax) {
+         ticks.push(polar.fRwrmax);
+         exclude_last = true;
+      }
+
+      this.StartTextDrawing(polar.fRadialLabelFont, Math.round(polar.fRadialTextSize * szy * 2));
+
+      for (var n=0;n<ticks.length;++n) {
+         var rx = this.r(ticks[n]), ry = rx/szx*szy;
+         this.draw_g.append("ellipse")
+             .attr("cx",0)
+             .attr("cy",0)
+             .attr("rx",Math.round(rx))
+             .attr("ry",Math.round(ry))
+             .style("fill", "none")
+             .call(this.lineatt.func);
+
+         if ((n < ticks.length-1) || !exclude_last)
+            this.DrawText({ align: 23, x: Math.round(rx), y: Math.round(polar.fRadialTextSize * szy * 0.5),
+                            text: this.format(ticks[n]), color: this.get_color[polar.fRadialLabelColor], latex: 0 });
+
+         if ((nminor>1) && ((n < ticks.length-1) || !exclude_last)) {
+            var dr = (ticks[1] - ticks[0]) / nminor;
+            for (var nn=1;nn<nminor;++nn) {
+               var gridr = ticks[n] + dr*nn;
+               if (gridr>polar.fRwrmax) break;
+               rx = this.r(gridr); ry = rx/szx*szy;
+               this.draw_g.append("ellipse")
+                   .attr("cx",0)
+                   .attr("cy",0)
+                   .attr("rx",Math.round(rx))
+                   .attr("ry",Math.round(ry))
+                   .style("fill", "none")
+                   .call(this.gridatt.func);
+            }
+         }
+
+      }
+
+      this.FinishTextDrawing();
+
+      var fontsize = Math.round(polar.fPolarTextSize * szy * 2);
+      this.StartTextDrawing(polar.fPolarLabelFont, fontsize);
+
+      var nmajor = polar.fNdivPol % 100;
+      if ((nmajor !== 8) && (nmajor !== 3)) nmajor = 8;
+
+      var lbls = (nmajor==8) ? ["0", "#frac{#pi}{4}", "#frac{#pi}{2}", "#frac{3#pi}{4}", "#pi", "#frac{5#pi}{4}", "#frac{3#pi}{2}", "#frac{7#pi}{4}"] : ["0", "#frac{2#pi}{3}", "#frac{4#pi}{3}"],
+          aligns = [12, 11, 21, 31, 32, 33, 23, 13 ];
+
+      for (var n=0;n<nmajor;++n) {
+         var angle = -n*2*Math.PI/nmajor - this.angle;
+         this.draw_g.append("line")
+             .attr("x1",0)
+             .attr("y1",0)
+             .attr("x2", Math.round(szx*Math.cos(angle)))
+             .attr("y2", Math.round(szy*Math.sin(angle)))
+             .call(this.lineatt.func);
+
+         var aindx = Math.round(16 -angle/Math.PI*4) % 8; // index in align table, here absolute angle is important
+
+         this.DrawText({ align: aligns[aindx], x: Math.round((szx+fontsize)*Math.cos(angle)), y: Math.round((szy + fontsize/szx*szy)*(Math.sin(angle))),
+                       text: lbls[n],
+                       color: this.get_color[polar.fPolarLabelColor], latex: 1 });
+      }
+
+      this.FinishTextDrawing();
+
+      var nminor = Math.floor((polar.fNdivPol % 10000) / 100);
+
+      if (nminor > 1)
+         for (var n=0;n<nmajor*nminor;++n) {
+            if (n % nminor === 0) continue;
+            var angle = -n*2*Math.PI/nmajor/nminor - this.angle;
+            this.draw_g.append("line")
+                .attr("x1",0)
+                .attr("y1",0)
+                .attr("x2", Math.round(szx*Math.cos(angle)))
+                .attr("y2", Math.round(szy*Math.sin(angle)))
+                .call(this.gridatt.func);
+         }
+   }
+
+   JSROOT.Painter.drawGraphPolargram = function(divid, polargram, opt) {
+
+      var painter = new TGraphPolargramPainter(polargram);
+
+      painter.SetDivId(divid, -1); // just to get access to existing elements
+
+      var main = painter.main_painter();
+
+      if (main) {
+         if (main.GetObject() !== polargram)
+             console.error('Cannot superimpose TGraphPolargram with any other drawings');
+          return null;
+      }
+      painter.SetDivId(divid, 4); // main object without need of frame
+      painter.Redraw();
+      return painter.DrawingReady();
+   }
+
+   // ==============================================================
+
+   function TGraphPolarPainter(graph) {
+      JSROOT.TObjectPainter.call(this, graph);
+   }
+
+   TGraphPolarPainter.prototype = Object.create(JSROOT.TObjectPainter.prototype);
+
+   TGraphPolarPainter.prototype.Redraw = function() {
+      this.DrawBins();
+   }
+
+   TGraphPolarPainter.prototype.DecodeOptions = function(opt) {
+
+      var d = new JSROOT.DrawOptions(opt || "L");
+
+      this.options = {
+          mark: d.check("P"),
+          err: d.check("E"),
+          fill: d.check("F"),
+          line: d.check("L"),
+          curve: d.check("C")
+      }
+   }
+
+   TGraphPolarPainter.prototype.DrawBins = function() {
+      var graph = this.GetObject(),
+          main = this.main_painter();
+
+      if (!graph || !main || !main.$polargram) return;
+
+      if (this.options.mark && !this.markeratt) this.markeratt = new JSROOT.TAttMarkerHandler(graph);
+      if ((this.options.err || this.options.line || this.options.curve) && !this.lineatt) this.lineatt = new JSROOT.TAttLineHandler(graph);
+      if (this.options.fill && !this.fillatt) this.fillatt = this.createAttFill(graph);
+
+      this.CreateG();
+
+      this.draw_g.attr("transform", main.draw_g.attr("transform"));
+
+      var mpath = "", epath = "", lpath = "", bins = [];
+
+      for (var n=0;n<graph.fNpoints;++n) {
+         if (this.options.err) {
+            var pos1 = main.translate(graph.fX[n], graph.fY[n] - graph.fEY[n]),
+                pos2 = main.translate(graph.fX[n], graph.fY[n] + graph.fEY[n]);
+            epath += "M" + pos1.x + "," + pos1.y + "L" + pos2.x + "," + pos2.y;
+
+            pos1 = main.translate(graph.fX[n] + graph.fEX[n], graph.fY[n]);
+            pos2 = main.translate(graph.fX[n] - graph.fEX[n], graph.fY[n]);
+
+            epath += "M" + pos1.x + "," + pos1.y + "A" + pos2.rx + "," + pos2.ry+ ",0,0,1," +pos2.x + "," + pos2.y;
+         }
+
+         var pos = main.translate(graph.fX[n], graph.fY[n]);
+
+         if (this.options.mark) {
+            mpath += this.markeratt.create(pos.x, pos.y);
+         }
+
+         if (this.options.line || this.options.fill) {
+            lpath += (lpath ? "L" : "M") + pos.x + "," + pos.y;
+         }
+
+         if (this.options.curve) {
+            pos.grx = pos.x;
+            pos.gry = pos.y;
+            bins.push(pos);
+         }
+      }
+
+      if (this.options.fill && lpath)
+         this.draw_g.append("svg:path")
+             .attr("d",lpath + "Z")
+             .style("stroke","none")
+             .call(this.fillatt.func);
+
+      if (this.options.line && lpath)
+         this.draw_g.append("svg:path")
+             .attr("d", lpath)
+             .style("fill", "none")
+             .call(this.lineatt.func);
+
+      if (this.options.curve && bins.length)
+         this.draw_g.append("svg:path")
+                 .attr("d", JSROOT.Painter.BuildSvgPath("bezier", bins).path)
+                 .style("fill", "none")
+                 .call(this.lineatt.func);
+
+      if (epath)
+         this.draw_g.append("svg:path")
+             .attr("d",epath)
+             .style("fill","none")
+             .call(this.lineatt.func);
+
+      if (mpath)
+         this.draw_g.append("svg:path")
+               .attr("d",mpath)
+               .call(this.markeratt.func);
+
+   }
+
+   TGraphPolarPainter.prototype.CreatePolargram = function() {
+      var polargram = JSROOT.Create("TGraphPolargram"),
+          gr = this.GetObject();
+
+      var rmin = gr.fY[0] || 0, rmax = rmin;
+      for (var n=0;n<gr.fNpoints;++n) {
+         rmin = Math.min(rmin, gr.fY[n] - gr.fEY[n]);
+         rmax = Math.max(rmax, gr.fY[n] + gr.fEY[n]);
+      }
+
+      polargram.fRwrmin = rmin - (rmax-rmin)*0.1;
+      polargram.fRwrmax = rmax + (rmax-rmin)*0.1;
+
+      return polargram;
+   }
+
+   TGraphPolarPainter.prototype.PerformDrawing = function(divid) {
+      this.SetDivId(divid);
+      this.DrawBins();
+      this.DrawingReady();
+   }
+
+   JSROOT.Painter.drawGraphPolar = function(divid, graph, opt) {
+
+      var painter = new TGraphPolarPainter(graph);
+
+      painter.DecodeOptions(opt);
+
+      painter.SetDivId(divid, -1); // just to get access to existing elements
+
+      var main = painter.main_painter();
+      if (main) {
+         if (!main.$polargram) {
+            console.error('Cannot superimpose TGraphPolar with plain histograms');
+            return null;
+         }
+         painter.PerformDrawing(divid);
+      } else {
+         if (!graph.fPolargram) graph.fPolargram = painter.CreatePolargram();
+
+         JSROOT.draw(divid, graph.fPolargram, "", painter.PerformDrawing.bind(painter, divid));
+      }
+
+      return painter;
+   }
+
+   // ==============================================================
+
+   function TSplinePainter(spline) {
+      JSROOT.TObjectPainter.call(this, spline);
+      this.bins = null;
+   }
+
+   TSplinePainter.prototype = Object.create(JSROOT.TObjectPainter.prototype);
+
+   TSplinePainter.prototype.UpdateObject = function(obj, opt) {
+      var spline = this.GetObject();
+
+      if (spline._typename != obj._typename) return false;
+
+      if (spline !== obj) JSROOT.extend(spline, obj);
+
+      if (opt !== undefined) this.DecodeOptions(opt);
+
+      return true;
+   }
+
+   TSplinePainter.prototype.Eval = function(knot, x) {
+      var dx = x - knot.fX;
+
+      if (knot._typename == "TSplinePoly3")
+         return knot.fY + dx*(knot.fB + dx*(knot.fC + dx*knot.fD));
+
+      if (knot._typename == "TSplinePoly5")
+         return knot.fY + dx*(knot.fB + dx*(knot.fC + dx*(knot.fD + dx*(knot.fE + dx*knot.fF))));
+
+      return knot.fY + dx;
+   }
+
+   TSplinePainter.prototype.FindX = function(x) {
+      var spline = this.GetObject(),
+          klow = 0, khig = spline.fNp - 1;
+
+      if (x <= spline.fXmin) return 0;
+      if (x >= spline.fXmax) return khig;
+
+      if(spline.fKstep) {
+         // Equidistant knots, use histogramming
+         klow = Math.round((x - spline.fXmin)/spline.fDelta);
+         // Correction for rounding errors
+         if (x < spline.fPoly[klow].fX) {
+            klow = Math.max(klow-1,0);
+         } else if (klow < khig) {
+            if (x > spline.fPoly[klow+1].fX) ++klow;
+         }
+      } else {
+         // Non equidistant knots, binary search
+         while(khig-klow>1) {
+            var khalf = Math.round((klow+khig)/2);
+            if(x > spline.fPoly[khalf].fX) klow = khalf;
+                                      else khig = khalf;
+         }
+      }
+      return klow;
+   }
+
+   TSplinePainter.prototype.CreateDummyHisto = function() {
+
+      var xmin = 0, xmax = 1, ymin = 0, ymax = 1,
+          spline = this.GetObject();
+
+      if (spline && spline.fPoly) {
+
+         xmin = xmax = spline.fPoly[0].fX;
+         ymin = ymax = spline.fPoly[0].fY;
+
+         spline.fPoly.forEach(function(knot) {
+            xmin = Math.min(knot.fX, xmin);
+            xmax = Math.max(knot.fX, xmax);
+            ymin = Math.min(knot.fY, ymin);
+            ymax = Math.max(knot.fY, ymax);
+         });
+
+         if (ymax > 0.0) ymax *= 1.05;
+         if (ymin < 0.0) ymin *= 1.05;
+      }
+
+      var histo = JSROOT.Create("TH1I");
+
+      histo.fName = spline.fName + "_hist";
+      histo.fTitle = spline.fTitle;
+
+      histo.fXaxis.fXmin = xmin;
+      histo.fXaxis.fXmax = xmax;
+      histo.fYaxis.fXmin = ymin;
+      histo.fYaxis.fXmax = ymax;
+
+      return histo;
+   }
+
+   TSplinePainter.prototype.ProcessTooltip = function(pnt) {
+
+      var cleanup = false,
+          spline = this.GetObject(),
+          main = this.main_painter(),
+          xx, yy, knot = null, indx = 0;
+
+      if ((pnt === null) || !spline || !main) {
+         cleanup = true;
+      } else {
+         xx = main.RevertX(pnt.x);
+         indx = this.FindX(xx);
+         knot = spline.fPoly[indx];
+         yy = this.Eval(knot, xx);
+
+         if ((indx < spline.fN-1) && (Math.abs(spline.fPoly[indx+1].fX-xx) < Math.abs(xx-knot.fX))) knot = spline.fPoly[++indx];
+
+         if (Math.abs(main.grx(knot.fX) - pnt.x) < 0.5*this.knot_size) {
+            xx = knot.fX; yy = knot.fY;
+         } else {
+            knot = null;
+            if ((xx < spline.fXmin) || (xx > spline.fXmax)) cleanup = true;
+         }
+      }
+
+      if (cleanup) {
+         if (this.draw_g !== null)
+            this.draw_g.select(".tooltip_bin").remove();
+         return null;
+      }
+
+      var gbin = this.draw_g.select(".tooltip_bin"),
+          radius = this.lineatt.width + 3;
+
+      if (gbin.empty())
+         gbin = this.draw_g.append("svg:circle")
+                           .attr("class", "tooltip_bin")
+                           .style("pointer-events","none")
+                           .attr("r", radius)
+                           .style("fill", "none")
+                           .call(this.lineatt.func);
+
+      var res = { name: this.GetObject().fName,
+                  title: this.GetObject().fTitle,
+                  x: main.grx(xx),
+                  y: main.gry(yy),
+                  color1: this.lineatt.color,
+                  lines: [],
+                  exact: (knot !== null) || (Math.abs(main.gry(yy) - pnt.y) < radius) };
+
+      res.changed = gbin.property("current_xx") !== xx;
+      res.menu = res.exact;
+      res.menu_dist = Math.sqrt((res.x-pnt.x)*(res.x-pnt.x) + (res.y-pnt.y)*(res.y-pnt.y));
+
+      if (res.changed)
+         gbin.attr("cx", Math.round(res.x))
+             .attr("cy", Math.round(res.y))
+             .property("current_xx", xx);
+
+      var name = this.GetTipName();
+      if (name.length > 0) res.lines.push(name);
+      res.lines.push("x = " + main.AxisAsText("x", xx))
+      res.lines.push("y = " + main.AxisAsText("y", yy));
+      if (knot !== null) {
+         res.lines.push("knot = " + indx);
+         res.lines.push("B = " + JSROOT.FFormat(knot.fB, JSROOT.gStyle.fStatFormat));
+         res.lines.push("C = " + JSROOT.FFormat(knot.fC, JSROOT.gStyle.fStatFormat));
+         res.lines.push("D = " + JSROOT.FFormat(knot.fD, JSROOT.gStyle.fStatFormat));
+         if ((knot.fE!==undefined) && (knot.fF!==undefined)) {
+            res.lines.push("E = " + JSROOT.FFormat(knot.fE, JSROOT.gStyle.fStatFormat));
+            res.lines.push("F = " + JSROOT.FFormat(knot.fF, JSROOT.gStyle.fStatFormat));
+         }
+      }
+
+      return res;
+   }
+
+   TSplinePainter.prototype.Redraw = function() {
+
+      var w = this.frame_width(),
+          h = this.frame_height(),
+          spline = this.GetObject(),
+          pmain = this.main_painter(),
+          name = this.GetTipName("\n");
+
+      this.CreateG(true);
+
+      this.knot_size = 5; // used in tooltip handling
+
+      if (!this.lineatt) this.lineatt = new JSROOT.TAttLineHandler(spline);
+
+      if (this.options.Line || this.options.Curve) {
+
+         var npx = Math.max(10, spline.fNpx);
+
+         var xmin = Math.max(pmain.scale_xmin, spline.fXmin),
+             xmax = Math.min(pmain.scale_xmax, spline.fXmax),
+             indx = this.FindX(xmin),
+             bins = []; // index of current knot
+
+         if (pmain.logx) {
+            xmin = Math.log(xmin);
+            xmax = Math.log(xmax);
+         }
+
+         for (var n=0;n<npx;++n) {
+            var xx = xmin + (xmax-xmin)/npx*(n-1);
+            if (pmain.logx) xx = Math.exp(xx);
+
+            while ((indx < spline.fNp-1) && (xx > spline.fPoly[indx+1].fX)) ++indx;
+
+            var yy = this.Eval(spline.fPoly[indx], xx);
+
+            bins.push({ x: xx, y: yy, grx: pmain.grx(xx), gry: pmain.gry(yy) });
+         }
+
+         var h0 = h;  // use maximal frame height for filling
+         if ((pmain.hmin!==undefined) && (pmain.hmin>=0)) {
+            h0 = Math.round(pmain.gry(0));
+            if ((h0 > h) || (h0 < 0)) h0 = h;
+         }
+
+         var path = JSROOT.Painter.BuildSvgPath("bezier", bins, h0, 2);
+
+         this.draw_g.append("svg:path")
+             .attr("class", "line")
+             .attr("d", path.path)
+             .style("fill", "none")
+             .call(this.lineatt.func);
+      }
+
+      if (this.options.Mark) {
+
+         // for tooltips use markers only if nodes where not created
+         var path = "";
+
+         if (!this.markeratt)
+            this.markeratt = new JSROOT.TAttMarkerHandler(spline);
+
+         this.markeratt.reset_pos();
+
+         this.knot_size = this.markeratt.GetFullSize();
+
+         for (var n=0; n<spline.fPoly.length; n++) {
+            var knot = spline.fPoly[n],
+                grx = pmain.grx(knot.fX);
+            if ((grx > -this.knot_size) && (grx < w + this.knot_size)) {
+               var gry = pmain.gry(knot.fY);
+               if ((gry > -this.knot_size) && (gry < h + this.knot_size)) {
+                  path += this.markeratt.create(grx, gry);
+               }
+            }
+         }
+
+         if (path)
+            this.draw_g.append("svg:path")
+                       .attr("d", path)
+                       .call(this.markeratt.func);
+      }
+
+   }
+
+   TSplinePainter.prototype.CanZoomIn = function(axis,min,max) {
+      if (axis!=="x") return false;
+
+      var spline = this.GetObject();
+      if (!spline) return false;
+
+      // if function calculated, one always could zoom inside
+      return true;
+   }
+
+   TSplinePainter.prototype.DecodeOptions = function(opt) {
+      var d = new JSROOT.DrawOptions(opt);
+
+      this.options = {
+         Same: d.check('SAME'),
+         Line: d.check('L'),
+         Curve: d.check('C'),
+         Mark: d.check('P')
+      }
+   }
+
+   TSplinePainter.prototype.FirstDraw = function() {
+      this.SetDivId(this.divid);
+      this.Redraw();
+      return this.DrawingReady();
+   }
+
+   JSROOT.Painter.drawSpline = function(divid, spline, opt) {
+
+      var painter = new TSplinePainter(spline);
+
+      painter.SetDivId(divid, -1);
+      painter.DecodeOptions(opt);
+
+      if (!painter.main_painter()) {
+         if (painter.options.Same) {
+            console.warn('TSpline painter requires histogram to be drawn');
+            return null;
+         }
+         var histo = painter.CreateDummyHisto();
+         JSROOT.draw(divid, histo, "AXIS", painter.FirstDraw.bind(painter));
+         return painter;
+      }
+
+      return painter.FirstDraw();
+   }
+
+   // =============================================================
+
+   function TGraphTimePainter(gr) {
+      JSROOT.TObjectPainter.call(this, gr);
+   }
+
+   TGraphTimePainter.prototype = Object.create(JSROOT.TObjectPainter.prototype);
+
+   TGraphTimePainter.prototype.Redraw = function() {
+      if (this.step === undefined) this.StartDrawing(false);
+   }
+
+   TGraphTimePainter.prototype.DecodeOptions = function(opt) {
+
+      var d = new JSROOT.DrawOptions(opt || "REPEAT");
+
+      this.options = {
+          once: d.check("ONCE"),
+          repeat: d.check("REPEAT"),
+          first: d.check("FIRST")
+      }
+   }
+
+   TGraphTimePainter.prototype.DrawPrimitives = function(indx, callback, ppainter) {
+
+      if (indx===0) {
+         this._doing_primitives = true;
+      }
+
+      var lst = this.GetObject().fSteps.arr[this.step];
+
+      while (true) {
+         if (ppainter) ppainter.$grtimeid = this.selfid; // indicator that painter created by ourself
+
+         if (!lst || (indx >= lst.arr.length)) {
+            delete this._doing_primitives;
+            return JSROOT.CallBack(callback);
+         }
+
+         // handle use to invoke callback only when necessary
+         var handle = { func: this.DrawPrimitives.bind(this, indx+1, callback) };
+
+         ppainter = JSROOT.draw(this.divid, lst.arr[indx], lst.opt[indx], handle);
+
+         if (!handle.completed) return;
+         indx++;
+      }
+   }
+
+   TGraphTimePainter.prototype.Selector = function(p) {
+      return p && (p.$grtimeid === this.selfid);
+   }
+
+   TGraphTimePainter.prototype.ContineDrawing = function() {
+      var gr = this.GetObject();
+
+      if (!this.ready_called) {
+         this.ready_called = true;
+         this.DrawingReady(); // do it already here, animation will continue in background
+      }
+
+      if (this.options.first) {
+         // draw only single frame, cancel all others
+         delete this.step;
+         return;
+      }
+
+      if (this.wait_animation_frame) {
+         delete this.wait_animation_frame;
+
+         // clear pad
+         var pp = this.pad_painter(true);
+         if (!pp) {
+            // most probably, pad is cleared
+            delete this.step;
+            return;
+         }
+
+         // clear primitives produced by the TGraphTime
+         pp.CleanPrimitives(this.Selector.bind(this));
+
+         // draw ptrimitives again
+         this.DrawPrimitives(0, this.ContineDrawing.bind(this));
+      } else if (this.running_timeout) {
+         clearTimeout(this.running_timeout);
+         delete this.running_timeout;
+
+         this.wait_animation_frame = true;
+         // use animation frame to disable update in inactive form
+         requestAnimationFrame(this.ContineDrawing.bind(this));
+      } else {
+
+         var sleeptime = gr.fSleepTime;
+         if (!sleeptime || (sleeptime<100)) sleeptime = 10;
+
+         if (++this.step > gr.fSteps.arr.length) {
+            if (this.options.repeat) {
+               this.step = 0; // start again
+               sleeptime = Math.max(5000, 5*sleeptime); // increase sleep time
+            } else {
+               delete this.step;    // clear indicator that animation running
+               return;
+            }
+         }
+
+         this.running_timeout = setTimeout(this.ContineDrawing.bind(this), sleeptime);
+      }
+   }
+
+   TGraphTimePainter.prototype.StartDrawing = function(once_again) {
+      if (once_again!==false) this.SetDivId(this.divid);
+
+      this.step = 0;
+
+      this.DrawPrimitives(0, this.ContineDrawing.bind(this));
+   }
+
+   JSROOT.Painter.drawGraphTime = function(divid,gr,opt) {
+
+      var painter = new TGraphTimePainter(gr);
+      painter.SetDivId(divid,-1);
+
+      if (painter.main_painter()) {
+         console.error('Cannot draw graph time on top of other histograms');
+         return null;
+      }
+
+      if (!gr.fFrame) {
+         console.error('Frame histogram not exists');
+         return null;
+      }
+
+      painter.DecodeOptions(opt);
+
+      if (!gr.fFrame.fTitle && gr.fTitle) gr.fFrame.fTitle = gr.fTitle;
+
+      painter.selfid = "grtime" + JSROOT.id_counter++; // use to identify primitives which should be clean
+
+      JSROOT.draw(divid, gr.fFrame, "AXIS", painter.StartDrawing.bind(painter));
+
+      return painter;
+
    }
 
    // =============================================================
@@ -1874,12 +2738,10 @@
       if (mgraph.fMaximum != -1111)
          rw.ymax = maximum = mgraph.fMaximum;
 
-      if (minimum < 0 && rw.ymin >= 0 && logy)
-         minimum = 0.9 * rw.ymin;
-      if (maximum > 0 && rw.ymax <= 0 && logy)
-         maximum = 1.1 * rw.ymax;
-      if (minimum <= 0 && logy)
-         minimum = 0.001 * maximum;
+      if (minimum < 0 && rw.ymin >= 0 && logy) minimum = 0.9 * rw.ymin;
+      if (maximum > 0 && rw.ymax <= 0 && logy) maximum = 1.1 * rw.ymax;
+      if (minimum <= 0 && logy) minimum = 0.001 * maximum;
+      if (!logy && minimum > 0 && minimum < 0.05*maximum) minimum = 0;
       if (uxmin <= 0 && logx)
          uxmin = (uxmax > 1000) ? 1 : 0.001 * uxmax;
 
@@ -1926,8 +2788,10 @@
       var graphs = this.GetObject().fGraphs;
 
       // at the end of graphs drawing draw functions (if any)
-      if (indx >= graphs.arr.length)
+      if (indx >= graphs.arr.length) {
+         this._pfc = this._plc = this._pmc = false; // disable auto coloring at the end
          return this.DrawNextFunction(0, this.DrawingReady.bind(this));
+      }
 
       // if there is auto colors assignment, try to provide it
       if (this._pfc || this._plc || this._pmc) {
@@ -1935,17 +2799,13 @@
             this.palette = JSROOT.Painter.GetColorPalette();
          if (this.palette) {
             var color = this.palette.calcColor(indx, graphs.arr.length+1);
-            var icolor = JSROOT.Painter.root_colors.indexOf(color);
-            if (icolor<0) {
-               icolor = JSROOT.Painter.root_colors.length;
-               JSROOT.Painter.root_colors.push(color);
-            }
+            var icolor = this.add_color(color);
+
             if (this._pfc) graphs.arr[indx].fFillColor = icolor;
             if (this._plc) graphs.arr[indx].fLineColor = icolor;
             if (this._pmc) graphs.arr[indx].fMarkerColor = icolor;
          }
       }
-
 
       JSROOT.draw(this.divid, graphs.arr[indx], graphs.opt[indx] || opt,
                   this.DrawNextGraph.bind(this, indx+1, opt));
@@ -1995,7 +2855,7 @@
              lineatt = null, fillatt = null, markeratt = null;
          if (!obj || !obj.fOper) return;
 
-         this.RecreateDrawG(true, "special_layer");
+         this.CreateG();
 
          for (var k=0;k<obj.fOper.arr.length;++k) {
             var oper = obj.fOper.opt[k];
@@ -2011,20 +2871,21 @@
                       x2 = this.AxisToSvg("x", obj.fBuf[indx++]),
                       y2 = this.AxisToSvg("y", obj.fBuf[indx++]);
 
-                  if (!lineatt) lineatt = new JSROOT.TAttLineHandler(attr);
-
                   var rect = this.draw_g
                      .append("svg:rect")
                      .attr("x", Math.min(x1,x2))
                      .attr("y", Math.min(y1,y2))
                      .attr("width", Math.abs(x2-x1))
-                     .attr("height", Math.abs(y1-y2))
-                     .call(lineatt.func);
+                     .attr("height", Math.abs(y1-y2));
 
                   if (oper === "box") {
                      if (!fillatt) fillatt = this.createAttFill(attr);
-                     rect.call(fillatt.func);
+                     rect.call(fillatt.func).style('stroke','none');
+                  } else {
+                     if (!lineatt) lineatt = new JSROOT.TAttLineHandler(attr);
+                     rect.call(lineatt.func).style('fill','none');
                   }
+
                   continue;
                }
                case "line":
@@ -2046,26 +2907,27 @@
                }
                case "polyline":
                case "polylinendc":
-               case "fillarea": {
+               case "fillarea":
+               case "fillareandc": {
 
-                  var npoints = parseInt(obj.fOper.arr[k].fString), cmd = "";
-
-                  if (!lineatt) lineatt = new JSROOT.TAttLineHandler(attr);
+                  var npoints = parseInt(obj.fOper.arr[k].fString),
+                      cmd = "", isndc = (oper.indexOf("ndc") > 0);
 
                   for (var n=0;n<npoints;++n)
                      cmd += ((n>0) ? "L" : "M") +
-                            this.AxisToSvg("x", obj.fBuf[indx++], false) + "," +
-                            this.AxisToSvg("y", obj.fBuf[indx++], false);
+                            this.AxisToSvg("x", obj.fBuf[indx++], isndc) + "," +
+                            this.AxisToSvg("y", obj.fBuf[indx++], isndc);
 
-                  if (oper == "fillarea") cmd+="Z";
-                  var path = this.draw_g
-                          .append("svg:path")
-                          .attr("d", cmd)
-                          .call(lineatt.func);
+                  if (oper.indexOf("fillarea") == 0) cmd+="Z";
 
-                  if (oper == "fillarea") {
+                  var path = this.draw_g.append("svg:path").attr("d", cmd);
+
+                  if (oper.indexOf("fillarea") == 0) {
                      if (!fillatt) fillatt = this.createAttFill(attr);
-                     path.call(fillatt.func);
+                     path.call(fillatt.func).attr('stroke','none');
+                  } else {
+                     if (!lineatt) lineatt = new JSROOT.TAttLineHandler(attr);
+                     path.call(lineatt.func).attr('fill', 'none');
                   }
 
                   continue;
@@ -2102,12 +2964,10 @@
 
                      var angle = attr.fTextAngle;
                      angle -= Math.floor(angle/360) * 360;
-                     if (angle>0) angle = -360 + angle; // rotation angle in ROOT and SVG has different meaning
-
-                     var enable_latex = 0; // 0-off, 1 - when make sense, 2 - always
 
                      // todo - correct support of angle
-                     this.DrawText(attr.fTextAlign, xx, yy, 0, angle, obj.fOper.arr[k].fString, JSROOT.Painter.root_colors[attr.fTextColor], enable_latex, group);
+                     this.DrawText({ align: attr.fTextAlign, x: xx, y: yy, rotate: angle,
+                                     text: obj.fOper.arr[k].fString, color: JSROOT.Painter.root_colors[attr.fTextColor], latex: 0, draw_g: group });
 
                      this.FinishTextDrawing(group);
                   }
@@ -2130,7 +2990,6 @@
       return painter.DrawingReady();
    }
 
-
    JSROOT.Painter.drawText = drawText;
    JSROOT.Painter.drawLine = drawLine;
    JSROOT.Painter.drawPolyLine = drawPolyLine;
@@ -2144,7 +3003,9 @@
 
    JSROOT.TF1Painter = TF1Painter;
    JSROOT.TGraphPainter = TGraphPainter;
+   JSROOT.TGraphPolarPainter = TGraphPolarPainter;
    JSROOT.TMultiGraphPainter = TMultiGraphPainter;
+   JSROOT.TSplinePainter = TSplinePainter;
 
    return JSROOT;
 

--- a/etc/http/scripts/JSRootPainter.openui5.js
+++ b/etc/http/scripts/JSRootPainter.openui5.js
@@ -31,7 +31,7 @@
    JSROOT.sources.push("openui5");
 
    var load_callback = JSROOT.complete_script_load;
-   JSROOT.complete_script_load = null; // normal callback is intercepted - we need to instantiate openui5
+   delete JSROOT.complete_script_load; // normal callback is intercepted - we need to instantiate openui5
 
    JSROOT.completeUI5Loading = function() {
       // console.log('complete ui5 loading', typeof sap);
@@ -58,14 +58,14 @@
    element.setAttribute('data-sap-ui-compatVersion', 'edge');
    // element.setAttribute('data-sap-ui-bindingSyntax', 'complex');
 
-   element.setAttribute('data-sap-ui-preload', 'async');
-   // for the moment specify path in the THttpServer, later can adjust for offline case
-   element.setAttribute('data-sap-ui-resourceroots', '{ "sap.ui.jsroot": "/jsrootsys/openui5/" }');
+   element.setAttribute('data-sap-ui-preload', 'async'); // '' to disable Component-preload.js
+
+   // configure path for openui5 scripts
+   element.setAttribute('data-sap-ui-resourceroots', '{ "sap.ui.jsroot": "' + JSROOT.source_dir + 'openui5/" }');
 
    element.setAttribute('data-sap-ui-evt-oninit', "JSROOT.completeUI5Loading()");
 
    document.getElementsByTagName("head")[0].appendChild(element);
-
 
    // function allows to create menu with openui
    // for the moment deactivated - can be used later
@@ -73,7 +73,7 @@
 
       var menu = { painter: painter,  element: null, cnt: 1, stack: [], items: [], separ: false };
 
-      // this is slighly modified version of original MenuItem.render function.
+      // this is slightly modified version of original MenuItem.render function.
       // need to be updated with any further changes
       function RenderCustomItem(rm, oItem, oMenu, oInfo) {
          var oSubMenu = oItem.getSubmenu();
@@ -336,7 +336,7 @@
 
    JSROOT.TCanvasPainter.prototype.SelectObjectPainter = function(painter) {
       var main = JSROOT.sap.ui.getCore().byId("TopCanvasId");
-      var ged = main ? main.getController().getGed() : null;
+      var ged = main ? main.getController().getLeftController("Ged") : null;
       if (ged) ged.onObjectSelect(this, painter);
    }
 
@@ -355,9 +355,24 @@
       if (main) main.getController().ShowCanvasStatus(lbl1,lbl2,lbl3,lbl4);
    }
 
+   JSROOT.TCanvasPainter.prototype.ShowUI5ProjectionArea = function(kind, call_back) {
+      var main = JSROOT.sap.ui.getCore().byId("TopCanvasId");
+      if (main) main.getController().showProjectionArea(kind, call_back);
+   }
+
+   JSROOT.TCanvasPainter.prototype.DrawInUI5ProjectionArea = function(obj, opt, call_back) {
+      var main = JSROOT.sap.ui.getCore().byId("TopCanvasId");
+      if (main) main.getController().drawInProjectionArea(obj, opt, call_back);
+   }
+
    JSROOT.TCanvasPainter.prototype.ShowMessage = function(msg) {
       var main = JSROOT.sap.ui.getCore().byId("TopCanvasId");
       if (main) main.getController().showMessage(msg);
+   }
+
+   JSROOT.TCanvasPainter.prototype.ShowSection = function(that, on) {
+      var main = JSROOT.sap.ui.getCore().byId("TopCanvasId");
+      if (main) main.getController().showSection(that, on);
    }
 
    JSROOT.TCanvasPainter.prototype.MethodsDialog = function(painter, method, menu_obj_id) {
@@ -372,6 +387,8 @@
       if ((menu_obj_id.indexOf("#x")>0) || (menu_obj_id.indexOf("#y")>0) || (menu_obj_id.indexOf("#z")>0)) method.fClassName = "TAxis";
 
       main.getController().showMethodsDialog(method, function(args) {
+
+         if (painter.ExecuteMenuCommand(method, args)) return;
 
          var exec = method.fExec;
          if (args) exec = exec.substr(0,exec.length-1) + args + ')';


### PR DESCRIPTION
1. New supported classes:
    - TGraphPolar
    - TGraphTime
    - TSpline3
    - TSpline5
    - TPolyLine3D
    - TPolyMarker
    - TEfficiency
    - TH1K
2. New supported options:
     "PFC" - auto fill color (histograms and graphs)
     "PLC" - auto line color
     "PMC" - auto marker color
     "A"  - fully disables axes drawing for histograms painters
     "TEXT" - for TH2Poly
     "SAMES" - draw stat box for superimposed histograms
     "NOCOL" - ignore stored in the TCanvas colors list
     "NOPAL" - ignore stored in the TCanvas color palette
3. Improvements in existing painters:
     - use color palette stored in the TCanvas
     - draw stats box when really required
     - let resize frames and paves in all eight directions
     - support lines, boxes and arbitrary text positions in TPaveText
     - automatic title positioning of vertical axis when fTitleOffset==0
     - when pad.fTickx/y==2 draw axes labels on opposite side
     - editing of TGraph objects - moving of the graph bins
     - draw X/Y/Z axis titles in lego plots
     - use canvas Theta/Phi angles to set initial camera position in 3D
plots
4. New TLatex processor supports most ROOT features, still MathJax can
be used
5. New X/Y projections display for TH2 histograms (aka
TH2::SetShowProjectionX/Y)
6. New in geometry viewer:
    - provide shape parameters in TGeo tooltips
    - let inspect selected TGeoNode
    - provide text info when geometry drawing takes too long
7. Change in JSROOT.draw functionality. Now valid painter instance can
be only
   obtained via call-back - forth argument of JSROOT.draw() function.
8. Use latest three.js r86 with improved Projector and CanvasRenderer
   Still use own SVGRenderer which supported direct SVG text dump
9. Introduce openui5 components for webgui functionality
10. In all sources specify "use strict" directive