### PR TITLE
ROOT-8872 Optimize TTree::Fill() to avoid expensive modulo operations

### DIFF
--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -4394,17 +4394,17 @@ void TTree::DropBuffers(Int_t)
 Int_t TTree::Fill()
 {
    Int_t nbytes = 0;
+   Int_t nwrite = 0;
    Int_t nerror = 0;
-   Int_t nb = fBranches.GetEntriesFast();
-   if (nb == 1) {
-      // Case of one single super branch. Automatically update
-      // all the branch addresses if a new object was created.
-      TBranch* branch = (TBranch*) fBranches.UncheckedAt(0);
-      branch->UpdateAddress();
-   }
-   if (fBranchRef) {
+   Int_t nbranches = fBranches.GetEntriesFast();
+
+   // Case of one single super branch. Automatically update
+   // all the branch addresses if a new object was created.
+   if (nbranches == 1)
+      ((TBranch *)fBranches.UncheckedAt(0))->UpdateAddress();
+
+   if (fBranchRef)
       fBranchRef->Clear();
-   }
 
 #ifdef R__USE_IMT
    ROOT::Internal::TBranchIMTHelper imtHelper;
@@ -4415,30 +4415,32 @@ Int_t TTree::Fill()
    }
 #endif
 
-   for (Int_t i = 0; i < nb; ++i) {
+   for (Int_t i = 0; i < nbranches; ++i) {
       // Loop over all branches, filling and accumulating bytes written and error counts.
-      TBranch* branch = (TBranch*) fBranches.UncheckedAt(i);
-      if (branch->TestBit(kDoNotProcess)) {
+      TBranch *branch = (TBranch *)fBranches.UncheckedAt(i);
+
+      if (branch->TestBit(kDoNotProcess))
          continue;
-      }
+
 #ifndef R__USE_IMT
-      Int_t nwrite = branch->FillImpl(nullptr);
+      nwrite = branch->FillImpl(nullptr);
 #else
-      Int_t nwrite = branch->FillImpl(fIMTEnabled ? &imtHelper : nullptr);
+      nwrite = branch->FillImpl(fIMTEnabled ? &imtHelper : nullptr);
 #endif
-      if (nwrite < 0)  {
+      if (nwrite < 0) {
          if (nerror < 2) {
             Error("Fill", "Failed filling branch:%s.%s, nbytes=%d, entry=%lld\n"
-                  " This error is symptomatic of a Tree created as a memory-resident Tree\n"
-                  " Instead of doing:\n"
-                  "    TTree *T = new TTree(...)\n"
-                  "    TFile *f = new TFile(...)\n"
-                  " you should do:\n"
-                  "    TFile *f = new TFile(...)\n"
-                  "    TTree *T = new TTree(...)",
-                  GetName(), branch->GetName(), nwrite,fEntries+1);
+                          " This error is symptomatic of a Tree created as a memory-resident Tree\n"
+                          " Instead of doing:\n"
+                          "    TTree *T = new TTree(...)\n"
+                          "    TFile *f = new TFile(...)\n"
+                          " you should do:\n"
+                          "    TFile *f = new TFile(...)\n"
+                          "    TTree *T = new TTree(...)\n\n",
+                  GetName(), branch->GetName(), nwrite, fEntries + 1);
          } else {
-            Error("Fill", "Failed filling branch:%s.%s, nbytes=%d, entry=%lld", GetName(), branch->GetName(), nwrite,fEntries+1);
+            Error("Fill", "Failed filling branch:%s.%s, nbytes=%d, entry=%lld", GetName(), branch->GetName(), nwrite,
+                  fEntries + 1);
          }
          ++nerror;
       } else {
@@ -4450,22 +4452,24 @@ Int_t TTree::Fill()
    if (fIMTFlush) {
       imtHelper.Wait();
       fIMTFlush = false;
-      const_cast<TTree*>(this)->AddTotBytes(fIMTTotBytes);
-      const_cast<TTree*>(this)->AddZipBytes(fIMTZipBytes);
+      const_cast<TTree *>(this)->AddTotBytes(fIMTTotBytes);
+      const_cast<TTree *>(this)->AddZipBytes(fIMTZipBytes);
       nbytes += imtHelper.GetNbytes();
       nerror += imtHelper.GetNerrors();
    }
 #endif
 
-   if (fBranchRef) {
+   if (fBranchRef)
       fBranchRef->Fill();
-   }
+
    ++fEntries;
-   if (fEntries > fMaxEntries) {
+
+   if (fEntries > fMaxEntries)
       KeepCircular();
-   }
-   if (gDebug > 0) Info("TTree::Fill", " - A:  %d %lld %lld %lld %lld %lld %lld \n",
-       nbytes, fEntries, fAutoFlush,fAutoSave,GetZipBytes(),fFlushedBytes,fSavedBytes);
+
+   if (gDebug > 0)
+      Info("TTree::Fill", " - A: %d %lld %lld %lld %lld %lld %lld \n", nbytes, fEntries, fAutoFlush, fAutoSave,
+           GetZipBytes(), fFlushedBytes, fSavedBytes);
 
    if (fAutoFlush != 0 || fAutoSave != 0) {
       // Is it time to flush or autosave baskets?
@@ -4473,17 +4477,20 @@ Int_t TTree::Fill()
          // Decision can be based initially either on the number of bytes
          // or the number of entries written.
          Long64_t zipBytes = GetZipBytes();
-         if ((fAutoFlush<0 && zipBytes > -fAutoFlush)  ||
-             (fAutoSave <0 && zipBytes > -fAutoSave )  ||
-             (fAutoFlush>0 && fEntries%TMath::Max((Long64_t)1,fAutoFlush) == 0) ||
-             (fAutoSave >0 && fEntries%TMath::Max((Long64_t)1,fAutoSave)  == 0) ) {
+         if ((fAutoFlush < 0 && zipBytes > -fAutoFlush) || (fAutoSave < 0 && zipBytes > -fAutoSave) ||
+             (fAutoFlush > 0 && fEntries % TMath::Max((Long64_t)1, fAutoFlush) == 0) ||
+             (fAutoSave > 0 && fEntries % TMath::Max((Long64_t)1, fAutoSave) == 0)) {
 
-            //First call FlushBasket to make sure that fTotBytes is up to date.
+            // First call FlushBasket to make sure that fTotBytes is up to date.
             FlushBaskets();
-            OptimizeBaskets(GetTotBytes(),1,"");
-            if (gDebug > 0) Info("TTree::Fill","OptimizeBaskets called at entry %lld, fZipBytes=%lld, fFlushedBytes=%lld\n",fEntries,GetZipBytes(),fFlushedBytes);
+            OptimizeBaskets(GetTotBytes(), 1, "");
+
+            if (gDebug > 0)
+               Info("TTree::Fill", "OptimizeBaskets called at entry %lld, fZipBytes=%lld, fFlushedBytes=%lld\n",
+                    fEntries, GetZipBytes(), fFlushedBytes);
+
             fFlushedBytes = GetZipBytes();
-            fAutoFlush    = fEntries;  // Use test on entries rather than bytes
+            fAutoFlush = fEntries; // Use test on entries rather than bytes
 
             // subsequently in run
             if (fAutoSave < 0) {
@@ -4492,61 +4499,79 @@ Int_t TTree::Fill()
                // < (minus the input value of fAutoSave)
                Long64_t totBytes = GetTotBytes();
                if (zipBytes != 0) {
-                  fAutoSave =  TMath::Max( fAutoFlush, fEntries*((-fAutoSave/zipBytes)/fEntries));
+                  fAutoSave = TMath::Max(fAutoFlush, fEntries * ((-fAutoSave / zipBytes) / fEntries));
                } else if (totBytes != 0) {
-                  fAutoSave =  TMath::Max( fAutoFlush, fEntries*((-fAutoSave/totBytes)/fEntries));
+                  fAutoSave = TMath::Max(fAutoFlush, fEntries * ((-fAutoSave / totBytes) / fEntries));
                } else {
                   TBufferFile b(TBuffer::kWrite, 10000);
-                  TTree::Class()->WriteBuffer(b, (TTree*) this);
+                  TTree::Class()->WriteBuffer(b, (TTree *)this);
                   Long64_t total = b.Length();
-                  fAutoSave =  TMath::Max( fAutoFlush, fEntries*((-fAutoSave/total)/fEntries));
+                  fAutoSave = TMath::Max(fAutoFlush, fEntries * ((-fAutoSave / total) / fEntries));
                }
-            } else if(fAutoSave > 0) {
-               fAutoSave = fAutoFlush*(fAutoSave/fAutoFlush);
+            } else if (fAutoSave > 0) {
+               fAutoSave = fAutoFlush * (fAutoSave / fAutoFlush);
             }
-            if (fAutoSave!=0 && fEntries >= fAutoSave) AutoSave();    // FlushBaskets not called in AutoSave
-            if (gDebug > 0) Info("TTree::Fill","First AutoFlush.  fAutoFlush = %lld, fAutoSave = %lld\n", fAutoFlush, fAutoSave);
+
+            if (fAutoSave != 0 && fEntries >= fAutoSave)
+               AutoSave(); // FlushBaskets not called in AutoSave
+
+            if (gDebug > 0)
+               Info("TTree::Fill", "First AutoFlush.  fAutoFlush = %lld, fAutoSave = %lld\n", fAutoFlush, fAutoSave);
          }
-      } else if (fNClusterRange && fAutoFlush && ( (fEntries-fClusterRangeEnd[fNClusterRange-1]) % fAutoFlush == 0)  ) {
-         if (fAutoSave != 0 && fEntries%fAutoSave == 0) {
-            //We are at an AutoSave point. AutoSave flushes baskets and saves the Tree header
+      } else if (fNClusterRange && fAutoFlush &&
+                 ((fEntries - fClusterRangeEnd[fNClusterRange - 1]) % fAutoFlush == 0)) {
+
+         if (fAutoSave != 0 && fEntries % fAutoSave == 0) {
+            // We are at an AutoSave point. AutoSave flushes baskets and saves the Tree header
             AutoSave("flushbaskets");
-            if (gDebug > 0) Info("TTree::Fill","AutoSave called at entry %lld, fZipBytes=%lld, fSavedBytes=%lld\n",fEntries,GetZipBytes(),fSavedBytes);
+            if (gDebug > 0)
+               Info("TTree::Fill", "AutoSave called at entry %lld, fZipBytes=%lld, fSavedBytes=%lld\n", fEntries,
+                    GetZipBytes(), fSavedBytes);
          } else {
-            //We only FlushBaskets
+            // We only FlushBaskets
             FlushBaskets();
-            if (gDebug > 0) Info("TTree::Fill","FlushBasket called at entry %lld, fZipBytes=%lld, fFlushedBytes=%lld\n",fEntries,GetZipBytes(),fFlushedBytes);
+            if (gDebug > 0)
+               Info("TTree::Fill", "FlushBasket called at entry %lld, fZipBytes=%lld, fFlushedBytes=%lld\n", fEntries,
+                    GetZipBytes(), fFlushedBytes);
          }
+
          fFlushedBytes = GetZipBytes();
-      } else if (fNClusterRange == 0 && fEntries > 1 && fAutoFlush && fEntries%fAutoFlush == 0) {
-         if (fAutoSave != 0 && fEntries%fAutoSave == 0) {
-            //We are at an AutoSave point. AutoSave flushes baskets and saves the Tree header
+
+      } else if (fNClusterRange == 0 && fEntries > 1 && fAutoFlush && fEntries % fAutoFlush == 0) {
+
+         if (fAutoSave != 0 && fEntries % fAutoSave == 0) {
+            // We are at an AutoSave point. AutoSave flushes baskets and saves the Tree header
             AutoSave("flushbaskets");
-            if (gDebug > 0) Info("TTree::Fill","AutoSave called at entry %lld, fZipBytes=%lld, fSavedBytes=%lld\n",fEntries,GetZipBytes(),fSavedBytes);
+            if (gDebug > 0)
+               Info("TTree::Fill", "AutoSave called at entry %lld, fZipBytes=%lld, fSavedBytes=%lld\n", fEntries,
+                    GetZipBytes(), fSavedBytes);
          } else {
-            //We only FlushBaskets
+            // We only FlushBaskets
             FlushBaskets();
-            if (gDebug > 0) Info("TTree::Fill","FlushBasket called at entry %lld, fZipBytes=%lld, fFlushedBytes=%lld\n",fEntries,GetZipBytes(),fFlushedBytes);
+            if (gDebug > 0)
+               Info("TTree::Fill", "FlushBasket called at entry %lld, fZipBytes=%lld, fFlushedBytes=%lld\n", fEntries,
+                    GetZipBytes(), fFlushedBytes);
          }
+
          fFlushedBytes = GetZipBytes();
       }
    }
+
    // Check that output file is still below the maximum size.
    // If above, close the current file and continue on a new file.
    // Currently, the automatic change of file is restricted
    // to the case where the tree is in the top level directory.
-   if (!fDirectory) {
+   if (!fDirectory)
       return nbytes;
-   }
-   TFile* file = fDirectory->GetFile();
-   if (file && (file->GetEND() > fgMaxTreeSize)) {
-      if (fDirectory == (TDirectory*) file) {
+
+   TFile *file = fDirectory->GetFile();
+   if (file && (file->GetEND() > fgMaxTreeSize))
+      if (fDirectory == (TDirectory *)file)
          ChangeFile(file);
-      }
-   }
-   if (nerror) {
+
+   if (nerror)
       return -1;
-   }
+
    return nbytes;
 }
 

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -4559,18 +4559,12 @@ Int_t TTree::Fill()
    // If above, close the current file and continue on a new file.
    // Currently, the automatic change of file is restricted
    // to the case where the tree is in the top level directory.
-   if (!fDirectory)
-      return nbytes;
+   if (fDirectory)
+      if (TFile *file = fDirectory->GetFile())
+         if ((TDirectory *)file == fDirectory && (file->GetEND() > fgMaxTreeSize))
+            ChangeFile(file);
 
-   TFile *file = fDirectory->GetFile();
-   if (file && (file->GetEND() > fgMaxTreeSize))
-      if (fDirectory == (TDirectory *)file)
-         ChangeFile(file);
-
-   if (nerror)
-      return -1;
-
-   return nbytes;
+   return nerror == 0 ? nbytes : -1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The figure below gives an idea of possible improvement. For more information see [ROOT-8872](https://sft.its.cern.ch/jira/browse/ROOT-8872).

![ttree-fill-ge-timediff](https://user-images.githubusercontent.com/249404/30871641-cd327d8c-a2e7-11e7-8839-4c770ea32173.png)

A couple of tests don't work after this change, so I will later break this up into several commits to make it easier to test and review.