### PR TITLE
In TPad::ExecuteAxisEvent protect from using empty zoombox

### DIFF
--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -2356,10 +2356,12 @@ void TPad::ExecuteEventAxis(Int_t event, Int_t px, Int_t py, TAxis *axis)
                zby1 = TMath::Power(10,zby1);
                zby2 = TMath::Power(10,zby2);
             }
-            zoombox->SetX1(zbx1);
-            zoombox->SetY1(zby1);
-            zoombox->SetX2(zbx2);
-            zoombox->SetY2(zby2);
+            if (zoombox) {
+               zoombox->SetX1(zbx1);
+               zoombox->SetY1(zby1);
+               zoombox->SetX2(zbx2);
+               zoombox->SetY2(zby2);
+            }
             gPad->Modified();
             gPad->Update();
          }


### PR DESCRIPTION
Sometime happens that `zoombox == 0` and ROOT crashes.
It happens in our QtROOT interface, where event sequence could be slightly different as with normal X.
Would be nice, if patch also will go into 6.10 branch