### PR TITLE
Add IO benchmarks

### DIFF
--- a/io/io/CMakeLists.txt
+++ b/io/io/CMakeLists.txt
@@ -20,6 +20,7 @@ ROOT_INSTALL_HEADERS()
 
 if(testing)
   add_subdirectory(test)
+  add_subdirectory(perf)
 endif()
 
 #--- Extra rules ----------------------------------------------------------

--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -22,6 +22,7 @@
 #include <thread>
 
 class TBufferFile;
+class TFile;
 
 namespace ROOT {
 namespace Experimental {
@@ -49,6 +50,8 @@ public:
     * @param compression Output file compression level
     */
    TBufferMerger(const char *name, Option_t *option = "RECREATE", Int_t compress = 1);
+
+   TBufferMerger(std::unique_ptr<TFile>);
 
    /** Destructor */
    virtual ~TBufferMerger();
@@ -100,9 +103,7 @@ private:
    void Push(TBufferFile *buffer);
    void WriteOutputFile();
 
-   const std::string fName;
-   const std::string fOption;
-   const Int_t fCompress;
+   TFile *fOutputFile;                                           //< Output file.
    size_t fAutoSave;                                             //< AutoSave only every fAutoSave bytes
    std::mutex fQueueMutex;                                       //< Mutex used to lock fQueue
    std::condition_variable fDataAvailable;                       //< Condition variable used to wait for data

--- a/io/io/inc/TFileMerger.h
+++ b/io/io/inc/TFileMerger.h
@@ -16,6 +16,8 @@
 #include "TString.h"
 #include "TStopwatch.h"
 
+#include <memory>
+
 class TList;
 class TFile;
 class TDirectory;
@@ -97,6 +99,7 @@ public:
    virtual Bool_t OutputFile(const char *url, Bool_t force, Int_t compressionLevel);
    virtual Bool_t OutputFile(const char *url, const char *mode = "RECREATE");
    virtual Bool_t OutputFile(const char *url, const char *mode, Int_t compressionLevel);
+   virtual Bool_t OutputFile(std::unique_ptr<TFile> file);
    virtual void   PrintFiles(Option_t *options);
    virtual Bool_t Merge(Bool_t = kTRUE);
    virtual Bool_t PartialMerge(Int_t type = kAll | kIncremental);

--- a/io/io/perf/CMakeLists.txt
+++ b/io/io/perf/CMakeLists.txt
@@ -1,0 +1,1 @@
+ROOT_ADD_GBENCHMARK(IOBenchmarks TBufferMergerBenchmarks.cxx LIBRARIES ${libname} TreePlayer)

--- a/io/io/perf/TBufferMergerBenchmarks.cxx
+++ b/io/io/perf/TBufferMergerBenchmarks.cxx
@@ -1,0 +1,117 @@
+#include "ROOT/TBufferMerger.hxx"
+
+#include "TROOT.h" // For EnableThreadSafety
+
+#include "TTree.h"
+
+#include "benchmark/benchmark.h"
+
+#include <random>
+#include <string>
+#include <sys/stat.h>
+
+static inline bool FileExists(const std::string &name)
+{
+   struct stat buffer;
+   return (stat(name.c_str(), &buffer) == 0);
+}
+
+using namespace ROOT::Experimental;
+
+static void BM_TBufferFile_CreateEmpty(benchmark::State &state)
+{
+   const char *filename = "empty.root";
+   while (state.KeepRunning()) {
+      TBufferMerger m(filename);
+   }
+
+   // FIXME: Should we be writing to disk an empty file?
+   assert(FileExists(filename));
+   std::remove(filename);
+}
+BENCHMARK(BM_TBufferFile_CreateEmpty);
+
+TBufferMerger *Merger = nullptr;
+static void BM_TBufferFile_GetFile(benchmark::State &state)
+{
+   ROOT::EnableThreadSafety();
+   using namespace ROOT::Experimental;
+   if (state.thread_index == 0) {
+      // Setup code here.
+      Merger = new TBufferMerger("single_file_on_disk.root");
+   }
+   while (state.KeepRunning()) {
+      // Run the test as normal.
+      auto myFile = Merger->GetFile();
+   }
+   if (state.thread_index == 0) {
+      // Teardown code here.
+      delete Merger;
+      // FIXME: Should we be writing to disk an empty file?
+      const char *filename = "single_file_on_disk.root";
+      assert(FileExists(filename));
+      std::remove(filename);
+   }
+}
+BENCHMARK(BM_TBufferFile_GetFile);
+BENCHMARK(BM_TBufferFile_GetFile)->UseRealTime()->ThreadPerCpu();
+BENCHMARK(BM_TBufferFile_GetFile)->ThreadPerCpu();
+BENCHMARK(BM_TBufferFile_GetFile)->UseRealTime()->ThreadRange(1, 64);
+BENCHMARK(BM_TBufferFile_GetFile)->ThreadRange(1, 64);
+
+/// Creates a TMemFile, fills a TTree with random numbers. The data is written if it exceeds 32MB.
+inline void FillTreeWithRandomData(TBufferMerger &merger, size_t nEntriesPerWorker = 24 * 1024)
+{
+   thread_local std::default_random_engine g;
+   std::uniform_real_distribution<double> dist(0.0, 1.0);
+
+   auto f = merger.GetFile();
+   auto t = new TTree("random", "random");
+   t->ResetBit(kMustCleanup);
+   t->SetAutoFlush(-32 * 1024 * 1024); // Flush at exceeding 32MB
+
+   double rng;
+
+   t->Branch("random", &rng);
+
+   long entries = 0;
+   for (size_t i = 0; i < nEntriesPerWorker; ++i) {
+      rng = dist(g);
+      t->Fill();
+      ++entries;
+      auto atflush = t->GetAutoFlush();
+      if (entries == atflush) {
+         entries = 0;
+         f->Write();
+      }
+   }
+   f->Write();
+}
+
+static void BM_TBufferFile_FillTreeWithRandomData(benchmark::State &state)
+{
+   ROOT::EnableThreadSafety();
+   using namespace ROOT::Experimental;
+   if (state.thread_index == 0) {
+      // Setup code here.
+      Merger = new TBufferMerger("single_file_on_disk.root");
+   }
+   while (state.KeepRunning()) FillTreeWithRandomData(*Merger);
+
+   if (state.thread_index == 0) {
+      // Teardown code here.
+      delete Merger;
+      // FIXME: Should we be writing to disk an empty file?
+      const char *filename = "single_file_on_disk.root";
+      assert(FileExists(filename));
+      std::remove(filename);
+   }
+}
+BENCHMARK(BM_TBufferFile_FillTreeWithRandomData);
+BENCHMARK(BM_TBufferFile_FillTreeWithRandomData)->UseRealTime()->ThreadPerCpu();
+BENCHMARK(BM_TBufferFile_FillTreeWithRandomData)->ThreadPerCpu();
+BENCHMARK(BM_TBufferFile_FillTreeWithRandomData)->UseRealTime()->ThreadRange(1, 64);
+BENCHMARK(BM_TBufferFile_FillTreeWithRandomData)->ThreadRange(1, 64);
+
+// Define our main.
+BENCHMARK_MAIN();

--- a/io/io/perf/TBufferMergerBenchmarks.cxx
+++ b/io/io/perf/TBufferMergerBenchmarks.cxx
@@ -55,7 +55,7 @@ static void BM_TBufferFile_GetFile(benchmark::State &state)
 }
 BENCHMARK(BM_TBufferFile_GetFile);
 BENCHMARK(BM_TBufferFile_GetFile)->UseRealTime()->ThreadPerCpu();
-BENCHMARK(BM_TBufferFile_GetFile)->UseRealTime()->ThreadRange(1, 64);
+BENCHMARK(BM_TBufferFile_GetFile)->UseRealTime()->ThreadRange(1, 256);
 
 /// Creates a TMemFile, fills a TTree with random numbers. The data is written if it exceeds 32MB.
 inline void FillTreeWithRandomData(TBufferMerger &merger, size_t nEntriesPerWorker = 24 * 1024)
@@ -107,7 +107,7 @@ static void BM_TBufferFile_FillTreeWithRandomData(benchmark::State &state)
 }
 BENCHMARK(BM_TBufferFile_FillTreeWithRandomData);
 BENCHMARK(BM_TBufferFile_FillTreeWithRandomData)->UseRealTime()->ThreadPerCpu();
-BENCHMARK(BM_TBufferFile_FillTreeWithRandomData)->UseRealTime()->ThreadRange(1, 64);
+BENCHMARK(BM_TBufferFile_FillTreeWithRandomData)->UseRealTime()->ThreadRange(1, 256);
 
 // Define our main.
 BENCHMARK_MAIN();

--- a/io/io/perf/TBufferMergerBenchmarks.cxx
+++ b/io/io/perf/TBufferMergerBenchmarks.cxx
@@ -53,9 +53,9 @@ static void BM_TBufferFile_GetFile(benchmark::State &state)
       std::remove(filename);
    }
 }
-BENCHMARK(BM_TBufferFile_GetFile);
-BENCHMARK(BM_TBufferFile_GetFile)->UseRealTime()->ThreadPerCpu();
-BENCHMARK(BM_TBufferFile_GetFile)->UseRealTime()->ThreadRange(1, 256);
+BENCHMARK(BM_TBufferFile_GetFile)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_TBufferFile_GetFile)->Unit(benchmark::kMicrosecond)->UseRealTime()->ThreadPerCpu();
+BENCHMARK(BM_TBufferFile_GetFile)->Unit(benchmark::kMicrosecond)->UseRealTime()->ThreadRange(1, 256);
 
 /// Creates a TMemFile, fills a TTree with random numbers. The data is written if it exceeds 32MB.
 inline void FillTreeWithRandomData(TBufferMerger &merger, size_t nEntriesPerWorker = 24 * 1024)
@@ -105,9 +105,9 @@ static void BM_TBufferFile_FillTreeWithRandomData(benchmark::State &state)
       std::remove(filename);
    }
 }
-BENCHMARK(BM_TBufferFile_FillTreeWithRandomData);
-BENCHMARK(BM_TBufferFile_FillTreeWithRandomData)->UseRealTime()->ThreadPerCpu();
-BENCHMARK(BM_TBufferFile_FillTreeWithRandomData)->UseRealTime()->ThreadRange(1, 256);
+BENCHMARK(BM_TBufferFile_FillTreeWithRandomData)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_TBufferFile_FillTreeWithRandomData)->Unit(benchmark::kMicrosecond)->UseRealTime()->ThreadPerCpu();
+BENCHMARK(BM_TBufferFile_FillTreeWithRandomData)->Unit(benchmark::kMicrosecond)->UseRealTime()->ThreadRange(1, 256);
 
 // Define our main.
 BENCHMARK_MAIN();

--- a/io/io/perf/TBufferMergerBenchmarks.cxx
+++ b/io/io/perf/TBufferMergerBenchmarks.cxx
@@ -55,9 +55,7 @@ static void BM_TBufferFile_GetFile(benchmark::State &state)
 }
 BENCHMARK(BM_TBufferFile_GetFile);
 BENCHMARK(BM_TBufferFile_GetFile)->UseRealTime()->ThreadPerCpu();
-BENCHMARK(BM_TBufferFile_GetFile)->ThreadPerCpu();
 BENCHMARK(BM_TBufferFile_GetFile)->UseRealTime()->ThreadRange(1, 64);
-BENCHMARK(BM_TBufferFile_GetFile)->ThreadRange(1, 64);
 
 /// Creates a TMemFile, fills a TTree with random numbers. The data is written if it exceeds 32MB.
 inline void FillTreeWithRandomData(TBufferMerger &merger, size_t nEntriesPerWorker = 24 * 1024)
@@ -109,9 +107,7 @@ static void BM_TBufferFile_FillTreeWithRandomData(benchmark::State &state)
 }
 BENCHMARK(BM_TBufferFile_FillTreeWithRandomData);
 BENCHMARK(BM_TBufferFile_FillTreeWithRandomData)->UseRealTime()->ThreadPerCpu();
-BENCHMARK(BM_TBufferFile_FillTreeWithRandomData)->ThreadPerCpu();
 BENCHMARK(BM_TBufferFile_FillTreeWithRandomData)->UseRealTime()->ThreadRange(1, 64);
-BENCHMARK(BM_TBufferFile_FillTreeWithRandomData)->ThreadRange(1, 64);
 
 // Define our main.
 BENCHMARK_MAIN();

--- a/io/io/src/TBufferMergerFile.cxx
+++ b/io/io/src/TBufferMergerFile.cxx
@@ -18,7 +18,7 @@ namespace ROOT {
 namespace Experimental {
 
 TBufferMergerFile::TBufferMergerFile(TBufferMerger &m)
-   : TMemFile(m.fName.c_str(), "recreate", "", m.fCompress), fMerger(m)
+   : TMemFile(m.fOutputFile->GetName(), "recreate", "", m.fOutputFile->GetCompressionSettings()), fMerger(m)
 {
 }
 

--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -321,10 +321,35 @@ Bool_t TFileMerger::OutputFile(const char *outputfile, const char *mode, Int_t c
 
    // We want gDirectory untouched by anything going on here
    TDirectory::TContext ctxt;
-   if (!(fOutputFile = TFile::Open(outputfile, mode, "", compressionLevel)) || fOutputFile->IsZombie()) {
-      Error("OutputFile", "cannot open the MERGER output file %s", fOutputFilename.Data());
+   if (TFile *outputFile = TFile::Open(outputfile, mode, "", compressionLevel))
+      return OutputFile(std::unique_ptr<TFile>(outputFile));
+
+   Error("OutputFile", "cannot open the MERGER output file %s", fOutputFilename.Data());
+   return kFALSE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set an output file opened externally by the users
+
+Bool_t TFileMerger::OutputFile(std::unique_ptr<TFile> outputfile)
+{
+   if (!outputfile || outputfile->IsZombie()) {
+      Error("OutputFile", "cannot open the MERGER output file %s", (outputfile) ? outputfile->GetName() : "");
       return kFALSE;
    }
+
+   fExplicitCompLevel = kTRUE;
+
+   TFile *oldfile = fOutputFile;
+   fOutputFile = 0; // This avoids the complaint from RecursiveRemove about the file being deleted which is here
+                    // spurrious. (see RecursiveRemove).
+   SafeDelete(oldfile);
+
+   fOutputFilename = outputfile->GetName();
+   // We want gDirectory untouched by anything going on here
+   TDirectory::TContext ctxt;
+   fOutputFile = outputfile.release(); // Transfer the ownership of the file.
+
    return kTRUE;
 }
 

--- a/io/io/test/CMakeLists.txt
+++ b/io/io/test/CMakeLists.txt
@@ -1,1 +1,1 @@
-ROOT_ADD_GTEST(testTBufferMerger TBufferMerger.cxx LIBRARIES RIO Tree)
+ROOT_ADD_GTEST(IOTests TBufferMerger.cxx TFileMergerTests.cxx  LIBRARIES RIO Tree)

--- a/io/io/test/TBufferMerger.cxx
+++ b/io/io/test/TBufferMerger.cxx
@@ -196,6 +196,7 @@ TEST(TBufferMerger, CheckTreeFillResults)
    { // sum of all branch values in parallel mode
       TFile f("tbuffermerger_parallel.root");
       auto t = (TTree *)f.Get("mytree");
+      ASSERT_TRUE(t != nullptr);
 
       int n, sum = 0;
       int nentries = (int)t->GetEntries();

--- a/io/io/test/TFileMergerTests.cxx
+++ b/io/io/test/TFileMergerTests.cxx
@@ -1,0 +1,48 @@
+#include "TFileMerger.h"
+
+#include "TMemFile.h"
+#include "TTree.h"
+
+#include "gtest/gtest.h"
+
+static void CreateATuple(TMemFile &file, const char *name, double value)
+{
+   auto mytree = new TTree(name, "A tree");
+   mytree->Branch(name, &value);
+   mytree->Fill();
+   file.Write();
+}
+
+static void CheckTree(TMemFile &file, const char *name, double expectedValue)
+{
+   auto t = static_cast<TTree *>(file.Get(name));
+   ASSERT_TRUE(t != nullptr);
+
+   double d;
+   t->SetBranchAddress(name, &d);
+   t->GetEntry(0);
+   EXPECT_EQ(expectedValue, d);
+}
+
+TEST(TFileMerger, CreateWithTFilePointer)
+{
+   TMemFile a("a.root", "CREATE");
+   CreateATuple(a, "a_tree", 1.);
+
+   // FIXME: Calling this out of order causes two values to be written to the second file.
+   TMemFile b("b.root", "CREATE");
+   CreateATuple(b, "b_tree", 2.);
+
+   TFileMerger merger;
+   auto output = new TMemFile("output.root", "CREATE");
+   output->ResetBit(kMustCleanup);
+   merger.OutputFile(std::unique_ptr<TFile>(output));
+
+   merger.AddFile(&a, false);
+   merger.AddFile(&b, false);
+   // FIXME: Calling merger.Merge() will call Close() and *delete* output.
+   merger.PartialMerge();
+
+   CheckTree(*output, "a_tree", 1);
+   CheckTree(*output, "b_tree", 2);
+}


### PR DESCRIPTION
This patch adds a few IO benchmarks. Some of them were hosted by @amadio in an external repository.

The nature of some of the benchmarks is to create multiple times files on disk. Running repeatedly, this can wear out machines disk drives. For that reason we extend the `TFileMerger` to work with `TFile*` directly. Passing an externally created `TFile*` allows us to pass a `TMemFile`.

Being able to benchmark based on in-memory files gives us another advantage: we can emulate very fast drives or certain delay patterns.