### PR TITLE
Cache improvements for non-sequential reads

### DIFF
--- a/README/ReleaseNotes/v612/index.md
+++ b/README/ReleaseNotes/v612/index.md
@@ -18,6 +18,7 @@ The following people have contributed to this new version:
  Brian Bockelman, UNL,\
  Rene Brun, CERN/SFT,\
  Philippe Canal, FNAL,\
+ David Clark, ANL (SULI),\
  Olivier Couet, CERN/SFT,\
  Gerri Ganis, CERN/SFT,\
  Andrei Gheata, CERN/SFT,\
@@ -29,6 +30,7 @@ The following people have contributed to this new version:
  Danilo Piparo, CERN/SFT,\
  Fons Rademakers, CERN/SFT,\
  Enric Tejedor Saavedra, CERN/SFT,\
+ Peter van Gemmeren, ANL,\
  Vassil Vassilev, Fermilab/CMS,\
  Wouter Verkerke, NIKHEF/Atlas, RooFit
 
@@ -81,6 +83,11 @@ or will be set to the address of the histogram read from the file.
 large TClonesArray where each element contains another small vector container.
 - `TTree::TTree()` now takes the `TDirectory*` that the tree should be constructed in.
   Defaults to `gDirectory`, i.e. the default behavior did not change.
+- To prepare for multi-threaded workflows, a preloading and retaining clusters feature is introduced.
+  This change will prevent additional reads from occurring when reading events out of sequence.
+  By setting TTree::SetClusterPrefetch(), an entire clusters will be loaded into memory, rather than single baskets.
+  By setting the MaxVirtualSize of the tree to a negative value, previous clusters will be retained
+  (the absolute value of MaxVirtualSize indicates how many additional clusters will be kept in memory).
 
 ### TDataFrame
   - Improved documentation

--- a/tree/tree/inc/TBranch.h
+++ b/tree/tree/inc/TBranch.h
@@ -124,6 +124,7 @@ protected:
    void     Init(const char *name, const char *leaflist, Int_t compress);
 
    TBasket *GetFreshBasket();
+   TBasket *GetFreshCluster();
    Int_t    WriteBasket(TBasket* basket, Int_t where) { return WriteBasketImpl(basket, where, nullptr); }
 
    TString  GetRealFileName() const;

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -119,6 +119,7 @@ protected:
    UInt_t         fFriendLockStatus;      ///<! Record which method is locking the friend recursion
    TBuffer       *fTransientBuffer;       ///<! Pointer to the current transient buffer.
    Bool_t         fCacheDoAutoInit;       ///<! true if cache auto creation or resize check is needed
+   Bool_t         fCacheDoClusterPrefetch;///<! true if cache is prefetching whole clusters
    Bool_t         fCacheUserSet;          ///<! true if the cache setting was explicitly given by user
    Bool_t         fIMTEnabled;            ///<! true if implicit multi-threading is enabled for this tree
    UInt_t         fNEntriesSinceSorting;  ///<! Number of entries processed since the last re-sorting of branches
@@ -252,6 +253,10 @@ public:
       // of this next cluster
       Long64_t Next();
 
+      // Move on to the previous cluster and return the starting entry
+      // of this previous cluster
+      Long64_t Previous();
+
       // Return the start entry of the current cluster.
       Long64_t GetStartEntry() {
          return fStartEntry;
@@ -363,6 +368,7 @@ public:
    virtual TClusterIterator GetClusterIterator(Long64_t firstentry);
    virtual Long64_t        GetChainEntryNumber(Long64_t entry) const { return entry; }
    virtual Long64_t        GetChainOffset() const { return fChainOffset; }
+   virtual Bool_t          GetClusterPrefetch() const { return fCacheDoClusterPrefetch; }
    TFile                  *GetCurrentFile() const;
            Int_t           GetDefaultEntryOffsetLen() const {return fDefaultEntryOffsetLen;}
            Long64_t        GetDebugMax()  const { return fDebugMax; }
@@ -517,6 +523,7 @@ public:
    virtual void            SetCacheLearnEntries(Int_t n=10);
    virtual void            SetChainOffset(Long64_t offset = 0) { fChainOffset=offset; }
    virtual void            SetCircular(Long64_t maxEntries);
+   virtual void            SetClusterPrefetch(Bool_t enabled) { fCacheDoClusterPrefetch = enabled; }
    virtual void            SetDebug(Int_t level = 1, Long64_t min = 0, Long64_t max = 9999999); // *MENU*
    virtual void            SetDefaultEntryOffsetLen(Int_t newdefault, Bool_t updateExisting = kFALSE);
    virtual void            SetDirectory(TDirectory* dir);

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -1128,7 +1128,7 @@ TBasket* TBranch::GetBasket(Int_t basketnumber)
    if (file == 0) {
       return 0;
    }
-   basket = GetFreshBasket();
+   basket = (fTree->GetMaxVirtualSize() < 0 || fTree->GetClusterPrefetch()) ? GetFreshCluster() : GetFreshBasket();
 
    // fSkipZip is old stuff still maintained for CDF
    if (fSkipZip) basket->SetBit(TBufferFile::kNotDecompressed);
@@ -1278,6 +1278,14 @@ Int_t TBranch::GetEntry(Long64_t entry, Int_t getall)
             fFirstBasketEntry = -1;
             fNextBasketEntry = -1;
             return -1;
+         }
+         if (fTree->GetMaxVirtualSize()< 0 || fTree->GetClusterPrefetch()) {
+            TTree::TClusterIterator clusterIterator = fTree->GetClusterIterator(entry);
+            clusterIterator.Next();
+            Int_t nextClusterEntry = clusterIterator.GetNextEntry();
+            for (Int_t i = fReadBasket; i < fMaxBaskets && fBasketEntry[i] < nextClusterEntry; i++) {
+               GetBasket(i);
+            }
          }
       }
       fCurrentBasket = basket;
@@ -1486,6 +1494,72 @@ TBasket* TBranch::GetFreshBasket()
    } else {
       basket = fTree->CreateBasket(this);
    }
+   return basket;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Drops the cluster two behind the current cluster and returns a fresh basket
+/// by either reusing or creating a new one
+
+TBasket *TBranch::GetFreshCluster()
+{
+   TBasket *basket = 0;
+
+   // If GetClusterIterator is called with a negative entry then GetStartEntry will be 0
+   // So we need to check if we reach the zero before we have gone back (1-VirtualSize) clusters
+   // if this is the case, we want to keep everything in memory so we return a new basket
+   TTree::TClusterIterator iter = fTree->GetClusterIterator(fBasketEntry[fReadBasket]);
+   if (iter.GetStartEntry() == 0) {
+      return fTree->CreateBasket(this);
+   }
+
+   // Iterate backwards (1-VirtualSize) clusters to reach cluster to be unloaded from memory,
+   // skipped if VirtualSize > 0.
+   for (Int_t j = 0; j < -fTree->GetMaxVirtualSize(); j++) {
+      if (iter.Previous() == 0) {
+         return fTree->CreateBasket(this);
+      }
+   }
+
+   Int_t entryToUnload = iter.Previous();
+   // Finds the basket to unload from memory. Since the basket should be close to current
+   // basket, just iterate backwards until the correct basket is reached. This should
+   // be fast as long as the number of baskets per cluster is small
+   Int_t basketToUnload = fReadBasket;
+   while (fBasketEntry[basketToUnload] != entryToUnload) {
+      basketToUnload--;
+      if (basketToUnload < 0) {
+         return fTree->CreateBasket(this);
+      }
+   }
+
+   // Retrieves the basket that is going to be unloaded from memory. If the basket did not
+   // exist, create a new one
+   basket = (TBasket *)fBaskets.UncheckedAt(basketToUnload);
+   if (basket) {
+      fBaskets.AddAt(0, basketToUnload);
+      --fNBaskets;
+   } else {
+      basket = fTree->CreateBasket(this);
+   }
+   ++basketToUnload;
+
+   // Clear the rest of the baskets. While it would be ideal to reuse these baskets
+   // for other baskets in the new cluster. It would require the function to go
+   // beyond its current scope. In the ideal case when each cluster only has 1 basket
+   // this will perform well
+   iter.Next();
+   while (fBasketEntry[basketToUnload] < iter.GetStartEntry()) {
+      TBasket *oldbasket = (TBasket *)fBaskets.UncheckedAt(basketToUnload);
+      if (oldbasket) {
+         oldbasket->DropBuffers();
+         delete oldbasket;
+         fBaskets.AddAt(0, basketToUnload);
+         --fNBaskets;
+      }
+      ++basketToUnload;
+   }
+   fBaskets.SetLast(-1);
    return basket;
 }
 

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -1279,11 +1279,11 @@ Int_t TBranch::GetEntry(Long64_t entry, Int_t getall)
             fNextBasketEntry = -1;
             return -1;
          }
-         if (fTree->GetMaxVirtualSize()< 0 || fTree->GetClusterPrefetch()) {
+         if (fTree->GetMaxVirtualSize() < 0 || fTree->GetClusterPrefetch()) {
             TTree::TClusterIterator clusterIterator = fTree->GetClusterIterator(entry);
             clusterIterator.Next();
             Int_t nextClusterEntry = clusterIterator.GetNextEntry();
-            for (Int_t i = fReadBasket; i < fMaxBaskets && fBasketEntry[i] < nextClusterEntry; i++) {
+            for (Int_t i = fReadBasket + 1; i < fMaxBaskets && fBasketEntry[i] < nextClusterEntry; i++) {
                GetBasket(i);
             }
          }

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -1128,7 +1128,12 @@ TBasket* TBranch::GetBasket(Int_t basketnumber)
    if (file == 0) {
       return 0;
    }
-   basket = (fTree->GetMaxVirtualSize() < 0 || fTree->GetClusterPrefetch()) ? GetFreshCluster() : GetFreshBasket();
+   // if cluster pre-fetching or retaining is on, do not re-use existing baskets
+   // unless a new cluster is used.
+   if (fTree->GetMaxVirtualSize() < 0 || fTree->GetClusterPrefetch())
+      basket = GetFreshCluster();
+   else
+      basket = GetFreshBasket();
 
    // fSkipZip is old stuff still maintained for CDF
    if (fSkipZip) basket->SetBit(TBufferFile::kNotDecompressed);
@@ -1279,7 +1284,7 @@ Int_t TBranch::GetEntry(Long64_t entry, Int_t getall)
             fNextBasketEntry = -1;
             return -1;
          }
-         if (fTree->GetMaxVirtualSize() < 0 || fTree->GetClusterPrefetch()) {
+         if (fTree->GetClusterPrefetch()) {
             TTree::TClusterIterator clusterIterator = fTree->GetClusterIterator(entry);
             clusterIterator.Next();
             Int_t nextClusterEntry = clusterIterator.GetNextEntry();

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -639,6 +639,44 @@ Long64_t TTree::TClusterIterator::Next()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Move on to the previous cluster and return the starting entry
+/// of this previous cluster
+
+Long64_t TTree::TClusterIterator::Previous()
+{
+   fNextEntry = fStartEntry;
+   if ( fTree->GetAutoFlush() <= 0 ) {
+      // Case of old files before November 9 2009
+      Long64_t clusterEstimate = GetEstimatedClusterSize();
+      fStartEntry = fNextEntry - clusterEstimate;
+   } else {
+      if (fClusterRange == 0) {
+         // We are looking at the last range ; its size
+         // is defined by AutoFlush itself and goes to the GetEntries.
+         fStartEntry -= fTree->GetAutoFlush();
+      } else {
+         if (fNextEntry <= fTree->fClusterRangeEnd[fClusterRange]) {
+            --fClusterRange;
+         }
+         if (fClusterRange == 0) {
+            // We are looking at the first range
+            fStartEntry = 0;
+         } else {
+            Long64_t clusterSize = fTree->fClusterSize[fClusterRange];
+            if (clusterSize == 0) {
+               clusterSize = GetEstimatedClusterSize();
+            }
+            fStartEntry -= clusterSize;
+         }
+      }
+   }
+   if (fStartEntry < 0) {
+      fStartEntry = 0;
+   }
+   return fStartEntry;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -703,6 +741,7 @@ TTree::TTree()
 , fFriendLockStatus(0)
 , fTransientBuffer(0)
 , fCacheDoAutoInit(kTRUE)
+, fCacheDoClusterPrefetch(kFALSE)
 , fCacheUserSet(kFALSE)
 , fIMTEnabled(ROOT::IsImplicitMTEnabled())
 , fNEntriesSinceSorting(0)
@@ -782,6 +821,7 @@ TTree::TTree(const char* name, const char* title, Int_t splitlevel /* = 99 */,
 , fFriendLockStatus(0)
 , fTransientBuffer(0)
 , fCacheDoAutoInit(kTRUE)
+, fCacheDoClusterPrefetch(kFALSE)
 , fCacheUserSet(kFALSE)
 , fIMTEnabled(ROOT::IsImplicitMTEnabled())
 , fNEntriesSinceSorting(0)

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -606,7 +606,7 @@ Long64_t TTree::TClusterIterator::Next()
       fNextEntry = fStartEntry + clusterEstimate;
    } else {
       if (fClusterRange == fTree->fNClusterRange) {
-         // We are looking at the last range ; its size
+         // We are looking at a range which size
          // is defined by AutoFlush itself and goes to the GetEntries.
          fNextEntry += fTree->GetAutoFlush();
       } else {
@@ -645,21 +645,21 @@ Long64_t TTree::TClusterIterator::Next()
 Long64_t TTree::TClusterIterator::Previous()
 {
    fNextEntry = fStartEntry;
-   if ( fTree->GetAutoFlush() <= 0 ) {
+   if (fTree->GetAutoFlush() <= 0) {
       // Case of old files before November 9 2009
       Long64_t clusterEstimate = GetEstimatedClusterSize();
       fStartEntry = fNextEntry - clusterEstimate;
    } else {
-      if (fClusterRange == 0) {
-         // We are looking at the last range ; its size
-         // is defined by AutoFlush itself and goes to the GetEntries.
+      if (fClusterRange == 0 || fTree->fNClusterRange == 0) {
+         // We are looking at a range which size
+         // is defined by AutoFlush itself.
          fStartEntry -= fTree->GetAutoFlush();
       } else {
          if (fNextEntry <= fTree->fClusterRangeEnd[fClusterRange]) {
             --fClusterRange;
          }
          if (fClusterRange == 0) {
-            // We are looking at the first range
+            // We are looking at the first range.
             fStartEntry = 0;
          } else {
             Long64_t clusterSize = fTree->fClusterSize[fClusterRange];

--- a/tree/tree/test/CMakeLists.txt
+++ b/tree/tree/test/CMakeLists.txt
@@ -1,3 +1,4 @@
 
 ROOT_ADD_GTEST(testTBasket TBasket.cxx LIBRARIES RIO Tree)
+ROOT_ADD_GTEST(testTBranch TBranch.cxx LIBRARIES RIO Tree MathCore)
 

--- a/tree/tree/test/TBranch.cxx
+++ b/tree/tree/test/TBranch.cxx
@@ -6,47 +6,47 @@
 #include "gtest/gtest.h"
 
 class TBranchTest : public ::testing::Test {
-   protected:
-      virtual void SetUp()
-      {
-         random = new TRandom(837);
-         f = new TFile("TBranchTestTree.root","RECREATE");
-         myTree = new TTree("myTree", "A test tree");
-         myTree->SetAutoSave(10);
-         Float_t data = 0;
-         myTree->Branch("branch0", &data);
+protected:
+   virtual void SetUp()
+   {
+      random = new TRandom(837);
+      f = new TFile("TBranchTestTree.root", "RECREATE");
+      myTree = new TTree("myTree", "A test tree");
+      myTree->SetAutoSave(10);
+      Float_t data = 0;
+      myTree->Branch("branch0", &data);
 
-         for(Int_t ev = 0; ev < 100; ev++) {
-            data = random->Gaus(100,7);
-            myTree->Fill();
-            if (ev % 10 == 7) {
-               myTree->FlushBaskets();
-            }
+      for (Int_t ev = 0; ev < 100; ev++) {
+         data = random->Gaus(100, 7);
+         myTree->Fill();
+         if (ev % 10 == 7) {
+            myTree->FlushBaskets();
          }
-         f->Write();
-         delete myTree;
-         delete f;
       }
+      f->Write();
+      delete myTree;
+      delete f;
+   }
 
-      virtual void TearDown()
-      {
-         myTree->DropBaskets();
-         delete branch;
-         delete myTree;
-         delete random;
-         delete f;
-      }
+   virtual void TearDown()
+   {
+      myTree->DropBaskets();
+      delete branch;
+      delete myTree;
+      delete random;
+      delete f;
+   }
 
-      TRandom *random;
-      TTree *myTree;
-      TFile *f;
-      TBranch *branch;
+   TRandom *random;
+   TTree *myTree;
+   TFile *f;
+   TBranch *branch;
 };
 
 TEST_F(TBranchTest, nonePreviousTest)
 {
    f = new TFile("TBranchTestTree.root");
-   myTree = (TTree*)f->Get("myTree");
+   myTree = (TTree *)f->Get("myTree");
    branch = myTree->GetBranch("branch0");
 
    myTree->SetClusterPrefetch(false);
@@ -68,7 +68,7 @@ TEST_F(TBranchTest, nonePreviousTest)
 TEST_F(TBranchTest, onePreviousTest)
 {
    f = new TFile("TBranchTestTree.root");
-   myTree = (TTree*)f->Get("myTree");
+   myTree = (TTree *)f->Get("myTree");
    branch = myTree->GetBranch("branch0");
 
    // Checks to make sure only first basket is loaded
@@ -116,7 +116,7 @@ TEST_F(TBranchTest, onePreviousTest)
 TEST_F(TBranchTest, twoPreviousTest)
 {
    f = new TFile("TBranchTestTree.root");
-   myTree = (TTree*)f->Get("myTree");
+   myTree = (TTree *)f->Get("myTree");
    branch = myTree->GetBranch("branch0");
 
    myTree->SetMaxVirtualSize(-2);

--- a/tree/tree/test/TBranch.cxx
+++ b/tree/tree/test/TBranch.cxx
@@ -1,0 +1,156 @@
+#include "TFile.h"
+#include "TTree.h"
+#include "TBranch.h"
+#include "TRandom.h"
+
+#include "gtest/gtest.h"
+
+class TBranchTest : public ::testing::Test {
+   protected:
+      virtual void SetUp()
+      {
+         random = new TRandom(837);
+         f = new TFile("TBranchTestTree.root","RECREATE");
+         myTree = new TTree("myTree", "A test tree");
+         myTree->SetAutoSave(10);
+         Float_t data = 0;
+         myTree->Branch("branch0", &data);
+
+         for(Int_t ev = 0; ev < 100; ev++) {
+            data = random->Gaus(100,7);
+            myTree->Fill();
+            if (ev % 10 == 7) {
+               myTree->FlushBaskets();
+            }
+         }
+         f->Write();
+         delete myTree;
+         delete f;
+      }
+
+      virtual void TearDown()
+      {
+         myTree->DropBaskets();
+         delete branch;
+         delete myTree;
+         delete random;
+         delete f;
+      }
+
+      TRandom *random;
+      TTree *myTree;
+      TFile *f;
+      TBranch *branch;
+};
+
+TEST_F(TBranchTest, nonePreviousTest)
+{
+   f = new TFile("TBranchTestTree.root");
+   myTree = (TTree*)f->Get("myTree");
+   branch = myTree->GetBranch("branch0");
+
+   myTree->SetClusterPrefetch(false);
+   myTree->SetMaxVirtualSize(0);
+
+   // Checks for normal behavior when change is
+   // not being used
+   branch->GetEntry(0);
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(0));
+   ASSERT_FALSE(branch->GetListOfBaskets()->At(1));
+
+   branch->GetEntry(10);
+   ASSERT_FALSE(branch->GetListOfBaskets()->At(0));
+   ASSERT_FALSE(branch->GetListOfBaskets()->At(1));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(2));
+   ASSERT_FALSE(branch->GetListOfBaskets()->At(3));
+}
+
+TEST_F(TBranchTest, onePreviousTest)
+{
+   f = new TFile("TBranchTestTree.root");
+   myTree = (TTree*)f->Get("myTree");
+   branch = myTree->GetBranch("branch0");
+
+   // Checks to make sure only first basket is loaded
+   branch->GetEntry(0);
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(0));
+   ASSERT_FALSE(branch->GetListOfBaskets()->At(1));
+
+   myTree->SetClusterPrefetch(true);
+
+   // Checks to make sure the whole cluster is loaded
+   branch->GetEntry(10);
+   ASSERT_FALSE(branch->GetListOfBaskets()->At(0));
+   ASSERT_FALSE(branch->GetListOfBaskets()->At(1));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(2));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(3));
+
+   // Checks to make sure clusters are being removed
+   // from memory, with none retained
+   branch->GetEntry(20);
+   ASSERT_FALSE(branch->GetListOfBaskets()->At(2));
+   ASSERT_FALSE(branch->GetListOfBaskets()->At(3));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(4));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(5));
+
+   myTree->SetMaxVirtualSize(-1);
+
+   // Checks to make sure previous is retained in memory
+   branch->GetEntry(30);
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(4));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(5));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(6));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(7));
+
+   // Checks to make sure clusters are being removed
+   // from memory
+   branch->GetEntry(40);
+   ASSERT_FALSE(branch->GetListOfBaskets()->At(4));
+   ASSERT_FALSE(branch->GetListOfBaskets()->At(5));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(6));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(7));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(8));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(9));
+}
+
+TEST_F(TBranchTest, twoPreviousTest)
+{
+   f = new TFile("TBranchTestTree.root");
+   myTree = (TTree*)f->Get("myTree");
+   branch = myTree->GetBranch("branch0");
+
+   myTree->SetMaxVirtualSize(-2);
+
+   // Checks to make sure the whole cluster is loaded
+   branch->GetEntry(0);
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(0));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(1));
+
+   // Checks to make sure previous is retained in memory
+   branch->GetEntry(10);
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(0));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(1));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(2));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(3));
+
+   // Checks to make sure previous is retained in memory
+   branch->GetEntry(20);
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(0));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(1));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(2));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(3));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(4));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(5));
+
+   // Checks to make sure clusters are being removed
+   // from memory
+   branch->GetEntry(30);
+   ASSERT_FALSE(branch->GetListOfBaskets()->At(0));
+   ASSERT_FALSE(branch->GetListOfBaskets()->At(1));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(2));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(3));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(4));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(5));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(6));
+   ASSERT_TRUE(branch->GetListOfBaskets()->At(7));
+}


### PR DESCRIPTION
After messing up my git repository, I closed pull request 796 and re-created this one with the same changes.

This pull request is the result of work done by David Clark as a summer intern at Argonne:
To prepare for multi-threaded workflows, a preloading and retaining clusters feature is introduced. This change will prevent additional reads from occurring when reading events out of sequence.
By setting TTree::SetClusterPrefetch(), an entire clusters will be loaded into memory, rather than single baskets.
By setting the MaxVirtualSize of the tree to a negative value, previous clusters will be retained - the absolute value of MaxVirtualSize indicates how many additional clusters will be kept in memory.

If TTree CacheDoClusterPrefetch is set to true, GetEntry() will load the entire cluster into memory, not just the first basket. For this, GetBasket() is modified to call a new function GetFreshCluster(). This function is responsible for returning a new basket and clearing out clusters from memory. Because clusters can have varying numbers of baskets, GetFreshCluster() reuses the first basket and clear the rest of the baskets. Reusing all baskets may be more efficient, but adds significant complexity and would not affect the typical case where each cluster only contains a single basket (all the baskets will be reused here).

To test the performance of the change, I read 1000 entries (about 1 GB) from a tree of randomly generated data consisting of 2000 branches. Every read had a 2.5% chance of reading 10 entries back or a 2.5% chance of reading 10 entries forward from the current entry.
Without the change enables there were 1.5 GB read in 31102 read calls.
With MaxVirtualSize set to -1 and CacheDoClusterPrefetch true, there were 1.1 GB read in 90 read calls.