### PR TITLE
ROOT-9027 Multi-thread Snapshot action writes only part of the events for large input files

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -1183,8 +1183,6 @@ protected:
                trees[slot] = new TTree(treenameInt.c_str(), treenameInt.c_str());
                trees[slot]->ResetBit(kMustCleanup);
                trees[slot]->SetImplicitMT(false);
-            } else {
-               files[slot]->Write();
             }
             if(r) {
                // not an empty-source TDF

--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -1175,17 +1175,17 @@ protected:
             if(!trees[slot]) {
                // first time this thread executes something, let's create a TBufferMerger output directory
                files[slot] = merger.GetFile();
+               std::tie(dirnameInt, treenameInt) = getDirTreeName(treename);
+               if (!dirnameInt.empty()) {
+                  files[slot]->mkdir(dirnameInt.c_str());
+                  files[slot]->cd(dirnameInt.c_str());
+               }
+               trees[slot] = new TTree(treenameInt.c_str(), treenameInt.c_str());
+               trees[slot]->ResetBit(kMustCleanup);
+               trees[slot]->SetImplicitMT(false);
             } else {
                files[slot]->Write();
             }
-            std::tie(dirnameInt, treenameInt) = getDirTreeName(treename);
-            if (!dirnameInt.empty()) {
-               files[slot]->mkdir(dirnameInt.c_str());
-               files[slot]->cd(dirnameInt.c_str());
-            }
-            trees[slot] = new TTree(treenameInt.c_str(), treenameInt.c_str());
-            trees[slot]->ResetBit(kMustCleanup);
-            trees[slot]->SetImplicitMT(false);
             if(r) {
                // not an empty-source TDF
                auto tree = r->GetTree();


### PR DESCRIPTION
This reverts commit 931f39bbec65b2757e725744e357ff8609047f0a.

The trees in the snapshot action rely on the directory not being restored to write to the right place. Creating a context prevented that from working.