### PR TITLE
Revert "[cmake] Fix that clingutils headers are found in /bin"

### DIFF
--- a/core/clingutils/CMakeLists.txt
+++ b/core/clingutils/CMakeLists.txt
@@ -27,11 +27,6 @@ ROOT_INSTALL_HEADERS()
 
 #### STL dictionary (replacement for cintdlls)##############################
 
-# Make a list of header search paths we can iterate over when looking for STL
-# headers. We also add the inc/ directory for things like root_std_complex.h
-get_property(cxx_path GLOBAL PROPERTY ROOT_CLING_CXX_HEADERS_LOCATION)
-string(REPLACE ":" ";" cxx_path "${cxx_path}:${CMAKE_CURRENT_SOURCE_DIR}/inc")
-
 set(stldicts
     vector
     list
@@ -50,22 +45,12 @@ foreach(dict ${stldicts})
   string(REPLACE "2" "" header ${dict})
   string(REPLACE "complex" "root_std_complex.h" header ${header})
   string(REPLACE "multi" "" header ${header})
-
-  # Manually search for the header in our STL folders because the ROOT macros
-  # could pick up other files like /bin/map due to their extensive search paths.
-  find_file(abs_cling_header name ${header} HINTS ${cxx_path} NO_DEFAULT_PATH)
-  if(NOT abs_cling_header)
-    message(WARNING "Couldn't find STL header ${header} in Cling's search"
-                    "paths: ${cxx_path}")
-  endif()
-
   ROOT_STANDARD_LIBRARY_PACKAGE(${dict}Dict
                                 NO_SOURCES NO_INSTALL_HEADERS
                                 STAGE1
-                                HEADERS "${abs_cling_header}"
+                                HEADERS ${header}
                                 LINKDEF src/${dict}Linkdef.h
                                 DEPENDENCIES Core)
-  unset(abs_cling_header CACHE)
 endforeach()
 
 #---Deal with LLVM resource here----------------------------------------------


### PR DESCRIPTION
This reverts commit ea64c7a2a2bb51e8181e8287f39b542b4d344cd6. This
commit broke the dictionaries as the absolute paths to the STL
headers confuse rootcling which now fails to properly add the
include paths to the dictionary payload. E.g. in the new dictionaries
we no longer have the information that we need to include
<set> for this header in there.