### PR TITLE
[TDF] Misc Fixes

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -1541,7 +1541,8 @@ private:
    {
 
       // Check at compile time that the columns types are copy constructible
-      constexpr bool areCopyConstructible = TDFInternal::TEvalAnd<std::is_copy_constructible<BranchTypes>::value...>::value;
+      constexpr bool areCopyConstructible =
+         TDFInternal::TEvalAnd<std::is_copy_constructible<BranchTypes>::value...>::value;
       static_assert(areCopyConstructible, "Columns of a type which is not copy constructible cannot be cached yet.");
 
       // We share bits and pieces with snapshot. De facto this is a snapshot

--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -1539,6 +1539,11 @@ private:
    template <typename... BranchTypes, int... S>
    TInterface<TLoopManager> CacheImpl(const ColumnNames_t &columnList, TDFInternal::StaticSeq<S...>)
    {
+
+      // Check at compile time that the columns types are copy constructible
+      constexpr bool areCopyConstructible = TDFInternal::TEvalAnd<std::is_copy_constructible<BranchTypes>::value...>::value;
+      static_assert(areCopyConstructible, "Columns of a type which is not copy constructible cannot be cached yet.");
+
       // We share bits and pieces with snapshot. De facto this is a snapshot
       // in memory!
       TDFInternal::CheckSnapshot(sizeof...(BranchTypes), columnList.size());

--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -1376,19 +1376,18 @@ private:
       ColumnNames_t selectedColumns;
       selectedColumns.reserve(32);
 
-      auto df = GetDataFrameChecked();
-      const auto &customColumns = df->GetCustomColumnNames();
       // Since we support gcc48 and it does not provide in its stl std::regex,
       // we need to use TRegexp
       TRegexp regexp(theRegex);
       int dummy;
-      for (auto &&branchName : customColumns) {
+      for (auto &&branchName : fValidCustomColumns) {
          if ((isEmptyRegex || -1 != regexp.Index(branchName.c_str(), &dummy)) &&
              !TDFInternal::IsInternalColumn(branchName)) {
             selectedColumns.emplace_back(branchName);
          }
       }
 
+      auto df = GetDataFrameChecked();
       auto tree = df->GetTree();
       if (tree) {
          const auto branches = tree->GetListOfBranches();

--- a/tree/treeplayer/inc/ROOT/TDFUtils.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFUtils.hxx
@@ -306,11 +306,12 @@ struct RemoveFirstTwoParametersIf<true, TypeList> {
 bool IsInternalColumn(std::string_view colName);
 
 // Check if a condition is true for all types
-template<bool...> struct TBoolPack;
-template<bool... bs>
+template <bool...>
+struct TBoolPack;
+template <bool... bs>
 using IsTrueForAllImpl_t = typename std::is_same<TBoolPack<bs..., true>, TBoolPack<true, bs...>>;
 
-template<bool... Conditions>
+template <bool... Conditions>
 struct TEvalAnd {
    static constexpr bool value = IsTrueForAllImpl_t<Conditions...>::value;
 };

--- a/tree/treeplayer/inc/ROOT/TDFUtils.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFUtils.hxx
@@ -305,6 +305,16 @@ struct RemoveFirstTwoParametersIf<true, TypeList> {
 
 bool IsInternalColumn(std::string_view colName);
 
+// Check if a condition is true for all types
+template<bool...> struct TBoolPack;
+template<bool... bs>
+using IsTrueForAllImpl_t = typename std::is_same<TBoolPack<bs..., true>, TBoolPack<true, bs...>>;
+
+template<bool... Conditions>
+struct TEvalAnd {
+   static constexpr bool value = IsTrueForAllImpl_t<Conditions...>::value;
+};
+
 } // end NS TDF
 } // end NS Internal
 } // end NS ROOT

--- a/tree/treeplayer/src/TRootDS.cxx
+++ b/tree/treeplayer/src/TRootDS.cxx
@@ -4,6 +4,7 @@
 #include <TClass.h>
 #include <TROOT.h>         // For the gROOTMutex
 #include <TVirtualMutex.h> // For the R__LOCKGUARD
+#include <ROOT/RMakeUnique.hxx>
 
 #include <algorithm>
 #include <vector>
@@ -138,8 +139,7 @@ void TRootDS::SetNSlots(unsigned int nSlots)
 
 TDataFrame MakeRootDataFrame(std::string_view treeName, std::string_view fileNameGlob)
 {
-   std::unique_ptr<TDF::TRootDS> tds(new TDF::TRootDS(treeName, fileNameGlob));
-   ROOT::Experimental::TDataFrame tdf(std::move(tds));
+   ROOT::Experimental::TDataFrame tdf(std::make_unique<TRootDS>(treeName, fileNameGlob));
    return tdf;
 }
 

--- a/tree/treeplayer/src/TTrivialDS.cxx
+++ b/tree/treeplayer/src/TTrivialDS.cxx
@@ -1,6 +1,7 @@
 #include <ROOT/TDFUtils.hxx>
 #include <ROOT/TSeq.hxx>
 #include <ROOT/TTrivialDS.hxx>
+#include <ROOT/RMakeUnique.hxx>
 
 namespace ROOT {
 namespace Experimental {
@@ -75,8 +76,7 @@ void TTrivialDS::SetNSlots(unsigned int nSlots)
 
 TDataFrame MakeTrivialDataFrame(ULong64_t size)
 {
-   std::unique_ptr<TTrivialDS> tds(new TTrivialDS(size));
-   ROOT::Experimental::TDataFrame tdf(std::move(tds));
+   ROOT::Experimental::TDataFrame tdf(std::make_unique<TTrivialDS>(size));
    return tdf;
 }
 

--- a/tree/treeplayer/test/CMakeLists.txt
+++ b/tree/treeplayer/test/CMakeLists.txt
@@ -12,4 +12,5 @@ ROOT_ADD_GTEST(dataframe_alias dataframe/dataframe_aliases.cxx LIBRARIES TreePla
 ROOT_ADD_GTEST(dataframe_cache dataframe/dataframe_cache.cxx LIBRARIES TreePlayer)
 ROOT_ADD_GTEST(datasource_trivial dataframe/datasource_trivial.cxx LIBRARIES TreePlayer)
 ROOT_ADD_GTEST(datasource_root dataframe/datasource_root.cxx LIBRARIES TreePlayer)
+ROOT_ADD_GTEST(datasource_noncopiable dataframe/datasource_noncopiable.cxx LIBRARIES TreePlayer)
 ROOT_ADD_PYUNITTEST(dataframe_histograms dataframe/dataframe_histograms.py)

--- a/tree/treeplayer/test/dataframe/TNonCopiableDS.hxx
+++ b/tree/treeplayer/test/dataframe/TNonCopiableDS.hxx
@@ -3,37 +3,35 @@
 #include <vector>
 #include <map>
 
-
 class TNonCopiable {
 public:
    using type = unsigned int;
    unsigned int fValue = 42;
-   TNonCopiable(const TNonCopiable&) = delete;
+   TNonCopiable(const TNonCopiable &) = delete;
    TNonCopiable() = default;
 };
 
 class NonCopiableDS final : public ROOT::Experimental::TDF::TDataSource {
 private:
-   std::vector<std::pair<ULong64_t, ULong64_t>> fEntryRanges = {{0UL,1UL}};
+   std::vector<std::pair<ULong64_t, ULong64_t>> fEntryRanges = {{0UL, 1UL}};
    std::vector<std::string> fColNames{fgColumnName};
    TNonCopiable fNonCopiable;
-   TNonCopiable * fCounterAddr = &fNonCopiable;
-   std::vector<void *> GetColumnReadersImpl(std::string_view, const std::type_info &){
-      std::vector<void *> ret {(void *) (&fCounterAddr)};
+   TNonCopiable *fCounterAddr = &fNonCopiable;
+   std::vector<void *> GetColumnReadersImpl(std::string_view, const std::type_info &)
+   {
+      std::vector<void *> ret{(void *)(&fCounterAddr)};
       return ret;
    }
 
 public:
    using NonCopiable_t = TNonCopiable;
    constexpr const static auto fgColumnName = "nonCopiable";
-   NonCopiableDS() {};
-   ~NonCopiableDS() {};
-   const std::vector<std::string> &GetColumnNames() const {return fColNames;};
-   bool HasColumn(std::string_view colName) const {return colName == fColNames[0];};
-   std::string GetTypeName(std::string_view) const {return "TNonCopiable";};
-   const std::vector<std::pair<ULong64_t, ULong64_t>> &GetEntryRanges() const {return fEntryRanges;};
-   void SetEntry(unsigned int , ULong64_t ) {};
-   void SetNSlots(unsigned int ) {};
+   NonCopiableDS(){};
+   ~NonCopiableDS(){};
+   const std::vector<std::string> &GetColumnNames() const { return fColNames; };
+   bool HasColumn(std::string_view colName) const { return colName == fColNames[0]; };
+   std::string GetTypeName(std::string_view) const { return "TNonCopiable"; };
+   const std::vector<std::pair<ULong64_t, ULong64_t>> &GetEntryRanges() const { return fEntryRanges; };
+   void SetEntry(unsigned int, ULong64_t){};
+   void SetNSlots(unsigned int){};
 };
-
-

--- a/tree/treeplayer/test/dataframe/TNonCopiableDS.hxx
+++ b/tree/treeplayer/test/dataframe/TNonCopiableDS.hxx
@@ -1,0 +1,39 @@
+#include "ROOT/TDataSource.hxx"
+#include <string>
+#include <vector>
+#include <map>
+
+
+class TNonCopiable {
+public:
+   using type = unsigned int;
+   unsigned int fValue = 42;
+   TNonCopiable(const TNonCopiable&) = delete;
+   TNonCopiable() = default;
+};
+
+class NonCopiableDS final : public ROOT::Experimental::TDF::TDataSource {
+private:
+   std::vector<std::pair<ULong64_t, ULong64_t>> fEntryRanges = {{0UL,1UL}};
+   std::vector<std::string> fColNames{fgColumnName};
+   TNonCopiable fNonCopiable;
+   TNonCopiable * fCounterAddr = &fNonCopiable;
+   std::vector<void *> GetColumnReadersImpl(std::string_view, const std::type_info &){
+      std::vector<void *> ret {(void *) (&fCounterAddr)};
+      return ret;
+   }
+
+public:
+   using NonCopiable_t = TNonCopiable;
+   constexpr const static auto fgColumnName = "nonCopiable";
+   NonCopiableDS() {};
+   ~NonCopiableDS() {};
+   const std::vector<std::string> &GetColumnNames() const {return fColNames;};
+   bool HasColumn(std::string_view colName) const {return colName == fColNames[0];};
+   std::string GetTypeName(std::string_view) const {return "TNonCopiable";};
+   const std::vector<std::pair<ULong64_t, ULong64_t>> &GetEntryRanges() const {return fEntryRanges;};
+   void SetEntry(unsigned int , ULong64_t ) {};
+   void SetNSlots(unsigned int ) {};
+};
+
+

--- a/tree/treeplayer/test/dataframe/dataframe_cache.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_cache.cxx
@@ -4,6 +4,8 @@
 #include "TH1F.h"
 #include "TRandom.h"
 
+#include "TNonCopiableDS.hxx"
+
 #include "gtest/gtest.h"
 
 #include <algorithm>
@@ -146,4 +148,17 @@ TEST(Cache, Regex)
    auto cached = tdfs.Cache();
    auto m = cached.Max<ULong64_t>("col0");
    EXPECT_EQ(3UL, *m);
+}
+
+TEST(Cache, NonCopiable)
+{
+   std::unique_ptr<TDataSource> tds(new NonCopiableDS());
+   TDataFrame tdf(std::move(tds));
+   int ret(1);
+   try {
+      tdf.Cache(NonCopiableDS::fgColumnName);
+   } catch (const std::runtime_error &e) {
+      ret = 0;
+   }
+   EXPECT_EQ(0, ret) << "The static assert was not triggered even if caching of columns of a non copiable type was requested";
 }

--- a/tree/treeplayer/test/dataframe/dataframe_cache.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_cache.cxx
@@ -160,5 +160,6 @@ TEST(Cache, NonCopiable)
    } catch (const std::runtime_error &e) {
       ret = 0;
    }
-   EXPECT_EQ(0, ret) << "The static assert was not triggered even if caching of columns of a non copiable type was requested";
+   EXPECT_EQ(0, ret)
+      << "The static assert was not triggered even if caching of columns of a non copiable type was requested";
 }

--- a/tree/treeplayer/test/dataframe/datasource_noncopiable.cxx
+++ b/tree/treeplayer/test/dataframe/datasource_noncopiable.cxx
@@ -1,0 +1,21 @@
+#include <ROOT/TDataFrame.hxx>
+
+#include "TNonCopiableDS.hxx"
+
+#include "gtest/gtest.h"
+
+using namespace ROOT::Experimental;
+using namespace ROOT::Experimental::TDF;
+
+TEST(TNonCopiableDS, UseNonCopiableColumnType)
+{
+   std::unique_ptr<TDataSource> tds(new NonCopiableDS());
+   TDataFrame tdf(std::move(tds));
+
+   auto getNCVal = [](NonCopiableDS::NonCopiable_t& nc ){return nc.fValue;};
+   auto m = *tdf.Define("val", getNCVal,{NonCopiableDS::fgColumnName}).Min<NonCopiableDS::NonCopiable_t::type>("val");
+
+   NonCopiableDS::NonCopiable_t dummy;
+
+   EXPECT_EQ(dummy.fValue, m);
+}

--- a/tree/treeplayer/test/dataframe/datasource_noncopiable.cxx
+++ b/tree/treeplayer/test/dataframe/datasource_noncopiable.cxx
@@ -12,8 +12,8 @@ TEST(TNonCopiableDS, UseNonCopiableColumnType)
    std::unique_ptr<TDataSource> tds(new NonCopiableDS());
    TDataFrame tdf(std::move(tds));
 
-   auto getNCVal = [](NonCopiableDS::NonCopiable_t& nc ){return nc.fValue;};
-   auto m = *tdf.Define("val", getNCVal,{NonCopiableDS::fgColumnName}).Min<NonCopiableDS::NonCopiable_t::type>("val");
+   auto getNCVal = [](NonCopiableDS::NonCopiable_t &nc) { return nc.fValue; };
+   auto m = *tdf.Define("val", getNCVal, {NonCopiableDS::fgColumnName}).Min<NonCopiableDS::NonCopiable_t::type>("val");
 
    NonCopiableDS::NonCopiable_t dummy;
 


### PR DESCRIPTION
1) Match only the custom columns of the node and not all when using regexpressions
2) Prompt an understandable compile time error in case a cache of columns the type of which is non copyable is requested
3) Test the ability of the data source to serve non copyable items