### PR TITLE
TTree::Draw(): Respect histogram binning when drawing TProfile2D with…

### DIFF
--- a/tree/treeplayer/src/TSelectorDraw.cxx
+++ b/tree/treeplayer/src/TSelectorDraw.cxx
@@ -730,8 +730,7 @@ void TSelectorDraw::Begin(TTree *tree)
          if (fDimension == 3 && opt.Contains("prof")) {
             fNbins[1] = gEnv->GetValue("Hist.Binning.3D.Profy", 20);
             fNbins[2] = gEnv->GetValue("Hist.Binning.3D.Profx", 20);
-         }
-         if (fDimension == 3 && opt.Contains("col")) {
+         } else if (fDimension == 3 && opt.Contains("col")) {
             fNbins[0] = gEnv->GetValue("Hist.Binning.2D.y", 40);
             fNbins[1] = gEnv->GetValue("Hist.Binning.2D.x", 40);
          }


### PR DESCRIPTION
… 'col'.

When drawing a TProfile2D with TTree::Draw() the histogram Y-axis binning was
not set correctly in case the options 'col' and 'prof' where used at the same
time in the TTree::Draw() option argument. For example:

tree->Draw("var:y:x>>h(100,-1,1,200,-2,2)", "", "colzprof)

produced a TProfile2D with 100 bins from -1 to 1 in X, but only 40 bins from -2
to 2 in Y.

This fixes ROOT-9034.