### PR TITLE
Fix snapshot in v610

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -1177,10 +1177,9 @@ protected:
                files[slot] = merger.GetFile();
             }
             std::tie(dirnameInt, treenameInt) = getDirTreeName(treename);
-            if (!dirnameInt.empty()) {
-               files[slot]->mkdir(dirnameInt.c_str());
-               files[slot]->cd(dirnameInt.c_str());
-            }
+            TDirectory *subdir = files[slot].get();
+            if (!dirnameInt.empty()) subdir = files[slot]->mkdir(dirnameInt.c_str());
+            subdir->cd();
             trees[slot] = new TTree(treenameInt.c_str(), treenameInt.c_str());
             trees[slot]->ResetBit(kMustCleanup);
             trees[slot]->SetImplicitMT(false);

--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -1175,6 +1175,8 @@ protected:
             if(!trees[slot]) {
                // first time this thread executes something, let's create a TBufferMerger output directory
                files[slot] = merger.GetFile();
+            } else {
+               files[slot]->Write();
             }
             std::tie(dirnameInt, treenameInt) = getDirTreeName(treename);
             TDirectory *subdir = files[slot].get();

--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -1175,15 +1175,15 @@ protected:
             if(!trees[slot]) {
                // first time this thread executes something, let's create a TBufferMerger output directory
                files[slot] = merger.GetFile();
-               std::tie(dirnameInt, treenameInt) = getDirTreeName(treename);
-               if (!dirnameInt.empty()) {
-                  files[slot]->mkdir(dirnameInt.c_str());
-                  files[slot]->cd(dirnameInt.c_str());
-               }
-               trees[slot] = new TTree(treenameInt.c_str(), treenameInt.c_str());
-               trees[slot]->ResetBit(kMustCleanup);
-               trees[slot]->SetImplicitMT(false);
             }
+            std::tie(dirnameInt, treenameInt) = getDirTreeName(treename);
+            if (!dirnameInt.empty()) {
+               files[slot]->mkdir(dirnameInt.c_str());
+               files[slot]->cd(dirnameInt.c_str());
+            }
+            trees[slot] = new TTree(treenameInt.c_str(), treenameInt.c_str());
+            trees[slot]->ResetBit(kMustCleanup);
+            trees[slot]->SetImplicitMT(false);
             if(r) {
                // not an empty-source TDF
                auto tree = r->GetTree();


### PR DESCRIPTION
After the fix for ROOT-9027 `Snapshot` could crash or silently write bogus data when more ttree clusters than worker threads were present in the file.