### PR TITLE
Revert "[TDF] Create TTree per slot, instead of per task in snapshot"

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
@@ -511,6 +511,9 @@ public:
       if (!fOutputTrees[slot]) {
          // first time this thread executes something, let's create a TBufferMerger output directory
          fOutputFiles[slot] = fMerger->GetFile();
+      } else {
+         // this thread is now re-executing the task, let's flush the current contents of the TBufferMergerFile
+         fOutputFiles[slot]->Write();
       }
       TDirectory *treeDirectory = fOutputFiles[slot].get();
       if (!fDirName.empty()) {


### PR DESCRIPTION
This reverts commit 4e7e379f8e8afb8fed9ab602c606bfab00577d8c.
We need to create one TTree per slot per task as the input variables
(and their addresses) change each time.