### PR TITLE
[cxxmodules] Fix assert failure when printing fwd delcs

### DIFF
--- a/interpreter/cling/lib/Interpreter/ForwardDeclPrinter.cpp
+++ b/interpreter/cling/lib/Interpreter/ForwardDeclPrinter.cpp
@@ -177,80 +177,80 @@ namespace cling {
 
      auto &smgr = m_SMgr;
      auto getIncludeFileName = [D, &smgr](PresumedLoc loc) {
-        clang::SourceLocation includeLoc = smgr.getSpellingLoc(loc.getIncludeLoc());
-        bool invalid = true;
-        const char* includeText = smgr.getCharacterData(includeLoc, &invalid);
-        assert(!invalid && "Invalid source data");
-        assert(includeText && "Cannot find #include location");
-        // With C++ modules it's possible that we get 'include <header>'
-        // instead of just '<header>' here. Let's just skip this text at the
-        // start in this case as the '<header>' still has the correct value.
-        // FIXME: Once the C++ modules replaced the forward decls, remove this.
-        if (D->getASTContext().getLangOpts().Modules &&
-            llvm::StringRef(includeText).startswith("include ")) {
-          includeText += strlen("include ");
-        }
+       clang::SourceLocation includeLoc =
+           smgr.getSpellingLoc(loc.getIncludeLoc());
+       bool invalid = true;
+       const char* includeText = smgr.getCharacterData(includeLoc, &invalid);
+       assert(!invalid && "Invalid source data");
+       assert(includeText && "Cannot find #include location");
+       // With C++ modules it's possible that we get 'include <header>'
+       // instead of just '<header>' here. Let's just skip this text at the
+       // start in this case as the '<header>' still has the correct value.
+       // FIXME: Once the C++ modules replaced the forward decls, remove this.
+       if (D->getASTContext().getLangOpts().Modules &&
+           llvm::StringRef(includeText).startswith("include ")) {
+         includeText += strlen("include ");
+       }
 
-        assert((includeText[0] == '<' || includeText[0] == '"')
-               && "Unexpected #include delimiter");
-        char endMarker = includeText[0] == '<' ? '>' : '"';
-        ++includeText;
-        const char* includeEnd = includeText;
-        while (*includeEnd != endMarker && *includeEnd) {
-           ++includeEnd;
-        }
-        assert(includeEnd && "Cannot find end of #include file name");
-        return llvm::StringRef(includeText, includeEnd - includeText);
-    };
+       assert((includeText[0] == '<' || includeText[0] == '"') &&
+              "Unexpected #include delimiter");
+       char endMarker = includeText[0] == '<' ? '>' : '"';
+       ++includeText;
+       const char* includeEnd = includeText;
+       while (*includeEnd != endMarker && *includeEnd) {
+         ++includeEnd;
+       }
+       assert(includeEnd && "Cannot find end of #include file name");
+       return llvm::StringRef(includeText, includeEnd - includeText);
+     };
 
-    auto &PP = m_PP;
-    auto isDirectlyReacheable = [&PP](llvm::StringRef FileName) {
-      const FileEntry* FE = nullptr;
-      SourceLocation fileNameLoc;
-      bool isAngled = false;
-      const DirectoryLookup* FromDir = nullptr;
-      const FileEntry* FromFile = nullptr;
-      const DirectoryLookup* CurDir = nullptr;
+     auto& PP = m_PP;
+     auto isDirectlyReacheable = [&PP](llvm::StringRef FileName) {
+       const FileEntry* FE = nullptr;
+       SourceLocation fileNameLoc;
+       bool isAngled = false;
+       const DirectoryLookup* FromDir = nullptr;
+       const FileEntry* FromFile = nullptr;
+       const DirectoryLookup* CurDir = nullptr;
 
-      FE = PP.LookupFile(fileNameLoc, FileName, isAngled,
-                          FromDir, FromFile, CurDir, /*SearchPath*/0,
-                          /*RelativePath*/ 0, /*suggestedModule*/0,
-                          /*IsMapped*/0, /*SkipCache*/ false,
+       FE = PP.LookupFile(fileNameLoc, FileName, isAngled, FromDir, FromFile,
+                          CurDir, /*SearchPath*/ 0,
+                          /*RelativePath*/ 0, /*suggestedModule*/ 0,
+                          /*IsMapped*/ 0, /*SkipCache*/ false,
                           /*OpenFile*/ false, /*CacheFail*/ true);
-      // Return true if we can '#include' the given filename
-      return FE != nullptr;
-    };
+       // Return true if we can '#include' the given filename
+       return FE != nullptr;
+     };
 
-    SourceLocation spellingLoc = m_SMgr.getSpellingLoc(D->getLocStart());
-    // Walk up the include chain.
-    PresumedLoc PLoc = m_SMgr.getPresumedLoc(spellingLoc);
-    llvm::SmallVector<PresumedLoc, 16> PLocs;
-    llvm::SmallVector<StringRef, 16> PLocNames;
-    while (!m_IgnoreFile(PLoc)) {
-      if (!m_SMgr.getPresumedLoc(PLoc.getIncludeLoc()).isValid())
-        break;
-      PLocs.push_back(PLoc);
-      StringRef name( getIncludeFileName(PLoc) );
+     SourceLocation spellingLoc = m_SMgr.getSpellingLoc(D->getLocStart());
+     // Walk up the include chain.
+     PresumedLoc PLoc = m_SMgr.getPresumedLoc(spellingLoc);
+     llvm::SmallVector<PresumedLoc, 16> PLocs;
+     llvm::SmallVector<StringRef, 16> PLocNames;
+     while (!m_IgnoreFile(PLoc)) {
+       if (!m_SMgr.getPresumedLoc(PLoc.getIncludeLoc()).isValid()) break;
+       PLocs.push_back(PLoc);
+       StringRef name(getIncludeFileName(PLoc));
 
-      // We record in PLocNames only the include file names that can be
-      // reached directly.  Whenever a #include is parsed in addition to
-      // the record include path, the directory where the file containing
-      // the #include is located is also added implicitly and temporarily
-      // to the include path.  So if the include path is empty and a file
-      // is include via a full pathname it can still #include file in its
-      // (sub)directory using their relative path.
-      // Similarly a file included via a sub-directory of the include path
-      // (eg. #include "Product/mainheader.h") can include header files in
-      // the same subdirectory without mentioning it
-      // (eg. #include "otherheader_in_Product.h")
-      // Since we do not (want to) record the actual directory in which is
-      // located the header with the #include we are looking at, if the
-      // #include is relative to that directory we will not be able to find
-      // it back and thus there is no point in recording it.
-      if (isDirectlyReacheable(name)) {
-        PLocNames.push_back(name);
-      }
-      PLoc = m_SMgr.getPresumedLoc(PLoc.getIncludeLoc());
+       // We record in PLocNames only the include file names that can be
+       // reached directly.  Whenever a #include is parsed in addition to
+       // the record include path, the directory where the file containing
+       // the #include is located is also added implicitly and temporarily
+       // to the include path.  So if the include path is empty and a file
+       // is include via a full pathname it can still #include file in its
+       // (sub)directory using their relative path.
+       // Similarly a file included via a sub-directory of the include path
+       // (eg. #include "Product/mainheader.h") can include header files in
+       // the same subdirectory without mentioning it
+       // (eg. #include "otherheader_in_Product.h")
+       // Since we do not (want to) record the actual directory in which is
+       // located the header with the #include we are looking at, if the
+       // #include is relative to that directory we will not be able to find
+       // it back and thus there is no point in recording it.
+       if (isDirectlyReacheable(name)) {
+         PLocNames.push_back(name);
+       }
+       PLoc = m_SMgr.getPresumedLoc(PLoc.getIncludeLoc());
     }
 
     if (PLocs.empty() /* declared in dictionary payload*/)


### PR DESCRIPTION
With C++ modules we fail here because we get this extra 'include '
text before the actual header. As the header itself is correct
it seems, we just skip this extra text with modules enabled as
this code is anyway supposed to be replaced with modules
functionality.