### PR TITLE
[cxxmodules] Generating private/non-ROOT modulemaps.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,6 +287,8 @@ get_property(__modulemap_extra_content GLOBAL PROPERTY ROOT_CXXMODULES_EXTRA_MOD
 string(REPLACE ";" "" __modulemap_extra_content "${__modulemap_extra_content}")
 file(WRITE "${CMAKE_BINARY_DIR}/include/module.modulemap.extra" "${__modulemap_extra_content}")
 
+# From now on we handled all exposed module and want to make all new modulemaps private to ROOT.
+set(ROOT_CXXMODULES_WRITE_TO_CURRENT_DIR ON)
 
 get_property(__allHeaders GLOBAL PROPERTY ROOT_HEADER_TARGETS)
 add_custom_target(move_headers ALL DEPENDS ${__allHeaders})


### PR DESCRIPTION
Right now we only generate modulemaps for the ROOT libraries which
are exposed to the user. But we also have generate dictionary
calls for dictionaries that are not exposed to the user and should
only be private (such as TBench, TMathCoreUnitDict etc.).

Right now we fail when compiling root on those dictionaries as we
don't have a modulemap for those dictionaries and we don't generate
one. This will also break tests that use the generate dictionary
call as those also don't have a modulemap now.

This patch reuses the existing CMake code for generating modulemaps
and also uses it in those cases to provide a dictionary that
rootcling can use to generate a C++ module.