### PR TITLE
Fix compilation errors on Windows

### DIFF
--- a/graf2d/gpad/src/TRatioPlot.cxx
+++ b/graf2d/gpad/src/TRatioPlot.cxx
@@ -997,11 +997,11 @@ Int_t TRatioPlot::BuildLowerPlot()
       std::vector<double> ci1;
       std::vector<double> ci2;
 
-      Double_t x_arr[fH1->GetNbinsX()];
+      Double_t *x_arr = new Double_t[fH1->GetNbinsX()];
       std::fill_n(x_arr, fH1->GetNbinsX(), 0);
-      Double_t ci_arr1[fH1->GetNbinsX()];
+      Double_t *ci_arr1 = new Double_t[fH1->GetNbinsX()];
       std::fill_n(ci_arr1, fH1->GetNbinsX(), 0);
-      Double_t ci_arr2[fH1->GetNbinsX()];
+      Double_t *ci_arr2 = new Double_t[fH1->GetNbinsX()];
       std::fill_n(ci_arr2, fH1->GetNbinsX(), 0);
       for (Int_t i=0; i<fH1->GetNbinsX();++i) {
          x_arr[i] = fH1->GetBinCenter(i+1);
@@ -1083,7 +1083,9 @@ Int_t TRatioPlot::BuildLowerPlot()
          }
 
       }
-
+      delete [] x_arr;
+      delete [] ci_arr1;
+      delete [] ci_arr2;
    } else if (fMode == TRatioPlot::CalculationMode::kDivideHist){
       SetGridlines(divideGridlines, 3);
 

--- a/graf2d/graf/inc/TCandle.h
+++ b/graf2d/graf/inc/TCandle.h
@@ -115,8 +115,8 @@ public:
    Double_t       GetQ3() const {return fBoxDown;}
    Bool_t         IsHorizontal() {return (IsOption(kHorizontal)); }
    Bool_t         IsVertical() {return (!IsOption(kHorizontal)); }
-   Bool_t         IsCandleScaled() {return fScaledCandle; }
-   Bool_t         IsViolinScaled() {return fScaledViolin; }
+   Bool_t         IsCandleScaled();
+   Bool_t         IsViolinScaled();
 
    void           SetOption(CandleOption opt) { fOption = opt; }
    void           SetLog(int x, int y, int z) { fLogX = x; fLogY = y; fLogZ = z;}

--- a/graf2d/graf/src/TCandle.cxx
+++ b/graf2d/graf/src/TCandle.cxx
@@ -182,6 +182,16 @@ TCandle::~TCandle() {
    if (fIsRaw && fProj) delete fProj;
 }
 
+Bool_t TCandle::IsCandleScaled()
+{
+   return fScaledCandle;
+}
+
+Bool_t TCandle::IsViolinScaled()
+{
+   return fScaledViolin;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Static function to set fWhiskerRange, by setting whisker-range, one can force
 /// the whiskers to cover the fraction of the distribution.

--- a/graf2d/mathtext/src/fontembedps.cxx
+++ b/graf2d/mathtext/src/fontembedps.cxx
@@ -255,6 +255,7 @@ namespace mathtext {
             bswap_32(segment_header.length);
 #endif // LITTLE_ENDIAN
             char *buffer = new char[segment_header.length];
+            char *match = "/FontName";
             char *fname;
 
             memcpy(buffer, &font_data[offset],
@@ -275,9 +276,8 @@ namespace mathtext {
                      buffer[segment_header.length - 1] = '\n';
                   }
                   ret.append(buffer, segment_header.length);
-
-                  fname = (char*)memmem(buffer, segment_header.length,
-                                        "/FontName", 9);
+                  fname = std::search(buffer, buffer+segment_header.length,
+                                      match, match+9);
                   if (fname) {
                      fname += 9;
                      while (fname < buffer + segment_header.length &&


### PR DESCRIPTION
 - Fix error C2057: expected constant expression in several array declarations
 - Outline (move from header to source) the IsCandleScaled() and IsViolinScaled() to export them from DLL
 - In fontembedps.cxx, replace unsupported memmem() function by std::search()