### PR TITLE
Fix compilation errors on Windows

### DIFF
--- a/hist/hist/src/AnalyticalIntegrals.cxx
+++ b/hist/hist/src/AnalyticalIntegrals.cxx
@@ -54,7 +54,7 @@ Double_t AnalyticalIntegral(TF1 *f, Double_t a, Double_t b)
       if (formula->TestBit(TFormula::kNormalized) ) 
          result =  amp*( ROOT::Math::gaussian_cdf(xmax, sigma, mean)- ROOT::Math::gaussian_cdf(xmin, sigma, mean) );
       else
-         result =  amp*sqrt(2*M_PI)*sigma*(ROOT::Math::gaussian_cdf(xmax, sigma, mean)- ROOT::Math::gaussian_cdf(xmin, sigma, mean));//
+         result =  amp*sqrt(2*TMath::Pi())*sigma*(ROOT::Math::gaussian_cdf(xmax, sigma, mean)- ROOT::Math::gaussian_cdf(xmin, sigma, mean));//
    }
    else if (num == 400)//landau: root::math::landau(x,mpv=0,sigma=1,bool norm=false)
    {

--- a/hist/hist/src/AnalyticalIntegrals.cxx
+++ b/hist/hist/src/AnalyticalIntegrals.cxx
@@ -51,11 +51,11 @@ Double_t AnalyticalIntegral(TF1 *f, Double_t a, Double_t b)
       double amp   = p[0];
       double mean  = p[1];
       double sigma = p[2];
-      if (formula->TestBit(TFormula::kNormalized) ) 
-         result = amp * ( ROOT::Math::gaussian_cdf(xmax, sigma, mean) - ROOT::Math::gaussian_cdf(xmin, sigma, mean) );
+      if (formula->TestBit(TFormula::kNormalized) )
+         result = amp * (ROOT::Math::gaussian_cdf(xmax, sigma, mean) - ROOT::Math::gaussian_cdf(xmin, sigma, mean));
       else
          result = amp * sqrt(2*TMath::Pi()) * sigma *
-                   (ROOT::Math::gaussian_cdf(xmax, sigma, mean) - ROOT::Math::gaussian_cdf(xmin, sigma, mean)); //
+                  (ROOT::Math::gaussian_cdf(xmax, sigma, mean) - ROOT::Math::gaussian_cdf(xmin, sigma, mean)); //
    }
    else if (num == 400)//landau: root::math::landau(x,mpv=0,sigma=1,bool norm=false)
    {

--- a/hist/hist/src/AnalyticalIntegrals.cxx
+++ b/hist/hist/src/AnalyticalIntegrals.cxx
@@ -52,9 +52,10 @@ Double_t AnalyticalIntegral(TF1 *f, Double_t a, Double_t b)
       double mean  = p[1];
       double sigma = p[2];
       if (formula->TestBit(TFormula::kNormalized) ) 
-         result =  amp*( ROOT::Math::gaussian_cdf(xmax, sigma, mean)- ROOT::Math::gaussian_cdf(xmin, sigma, mean) );
+         result = amp * ( ROOT::Math::gaussian_cdf(xmax, sigma, mean) - ROOT::Math::gaussian_cdf(xmin, sigma, mean) );
       else
-         result =  amp*sqrt(2*TMath::Pi())*sigma*(ROOT::Math::gaussian_cdf(xmax, sigma, mean)- ROOT::Math::gaussian_cdf(xmin, sigma, mean));//
+         result = amp * sqrt(2*TMath::Pi()) * sigma *
+                   (ROOT::Math::gaussian_cdf(xmax, sigma, mean) - ROOT::Math::gaussian_cdf(xmin, sigma, mean)); //
    }
    else if (num == 400)//landau: root::math::landau(x,mpv=0,sigma=1,bool norm=false)
    {

--- a/hist/hist/src/AnalyticalIntegrals.cxx
+++ b/hist/hist/src/AnalyticalIntegrals.cxx
@@ -51,10 +51,10 @@ Double_t AnalyticalIntegral(TF1 *f, Double_t a, Double_t b)
       double amp   = p[0];
       double mean  = p[1];
       double sigma = p[2];
-      if (formula->TestBit(TFormula::kNormalized) )
+      if (formula->TestBit(TFormula::kNormalized))
          result = amp * (ROOT::Math::gaussian_cdf(xmax, sigma, mean) - ROOT::Math::gaussian_cdf(xmin, sigma, mean));
       else
-         result = amp * sqrt(2*TMath::Pi()) * sigma *
+         result = amp * sqrt(2 * TMath::Pi()) * sigma *
                   (ROOT::Math::gaussian_cdf(xmax, sigma, mean) - ROOT::Math::gaussian_cdf(xmin, sigma, mean)); //
    }
    else if (num == 400)//landau: root::math::landau(x,mpv=0,sigma=1,bool norm=false)

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -439,7 +439,7 @@ TF1::TF1(const char *name, const char *formula, Double_t xmin, Double_t xmax, EA
       // Look for single ',' delimiter
       int delimPosition = -1;
       int parenCount = 0;
-      for (uint i = 5; i < strlen(formula) - 1; i++) {
+      for (unsigned int i = 5; i < strlen(formula) - 1; i++) {
          if (formula[i] == '(')
             parenCount++;
          else if (formula[i] == ')')

--- a/hist/histpainter/src/TGraphPainter.cxx
+++ b/hist/histpainter/src/TGraphPainter.cxx
@@ -3320,8 +3320,8 @@ void TGraphPainter::PaintGraphReverse(TGraph *theGraph, Option_t *option)
    Double_t YA2 = theGraph->GetYaxis()->GetXmax();
    Double_t dX  = XA1+XA2;
    Double_t dY  = YA1+YA2;
-   Double_t newX[N];
-   Double_t newY[N];
+   Double_t *newX = new Double_t[N];
+   Double_t *newY = new Double_t[N];
 
    if (lrx) {
       opt.ReplaceAll("rx", "");
@@ -3407,6 +3407,8 @@ void TGraphPainter::PaintGraphReverse(TGraph *theGraph, Option_t *option)
    theHist->GetYaxis()->SetTickLength(TLY);
    theHist->GetXaxis()->SetAxisColor(XACOL);
    theHist->GetYaxis()->SetAxisColor(YACOL);
+   delete [] newX;
+   delete [] newY;
 }
 
 

--- a/hist/histpainter/src/TGraphPainter.cxx
+++ b/hist/histpainter/src/TGraphPainter.cxx
@@ -3407,8 +3407,8 @@ void TGraphPainter::PaintGraphReverse(TGraph *theGraph, Option_t *option)
    theHist->GetYaxis()->SetTickLength(TLY);
    theHist->GetXaxis()->SetAxisColor(XACOL);
    theHist->GetYaxis()->SetAxisColor(YACOL);
-   delete [] newX;
-   delete [] newY;
+   delete[] newX;
+   delete[] newY;
 }
 
 

--- a/hist/histpainter/src/TGraphPainter.cxx
+++ b/hist/histpainter/src/TGraphPainter.cxx
@@ -3320,8 +3320,8 @@ void TGraphPainter::PaintGraphReverse(TGraph *theGraph, Option_t *option)
    Double_t YA2 = theGraph->GetYaxis()->GetXmax();
    Double_t dX  = XA1+XA2;
    Double_t dY  = YA1+YA2;
-   Double_t *newX = new Double_t[N];
-   Double_t *newY = new Double_t[N];
+   std::vector<Double_t> newX(N);
+   std::vector<Double_t> newY(N);
 
    if (lrx) {
       opt.ReplaceAll("rx", "");
@@ -3407,8 +3407,6 @@ void TGraphPainter::PaintGraphReverse(TGraph *theGraph, Option_t *option)
    theHist->GetYaxis()->SetTickLength(TLY);
    theHist->GetXaxis()->SetAxisColor(XACOL);
    theHist->GetYaxis()->SetAxisColor(YACOL);
-   delete[] newX;
-   delete[] newY;
 }
 
 


### PR DESCRIPTION
- Use TMath::Pi() instead of M_PI (undefined on Windows)
- Replace 'uint' with 'unsigned int'
- Fix error C2057: expected constant expression with newX and newY arrays