### PR TITLE
Instantiate VecVore math functions for vector types

### DIFF
--- a/math/mathcore/src/TMath.cxx
+++ b/math/mathcore/src/TMath.cxx
@@ -3114,3 +3114,20 @@ Double_t TMath::VavilovDenEval(Double_t rlam, Double_t *AC, Double_t *HC, Int_t 
    }
    return v;
 }
+
+
+//explicity instantiate template functions from VecCore
+#ifdef R__HAS_VECCORE
+#include <Math/Types.h>
+template ROOT::Double_v vecCore::math::Sin(const ROOT::Double_v & x);
+template ROOT::Double_v vecCore::math::Cos(const ROOT::Double_v & x);
+template ROOT::Double_v vecCore::math::ASin(const ROOT::Double_v & x);
+template ROOT::Double_v vecCore::math::ATan(const ROOT::Double_v & x);
+template ROOT::Double_v vecCore::math::ATan2(const ROOT::Double_v & x,const ROOT::Double_v & y);
+// missing in veccore
+// template ROOT::Double_v vecCore::math::ACos(const ROOT::Double_v & x);
+// template ROOT::Double_v vecCore::math::Sinh(const ROOT::Double_v & x);
+// template ROOT::Double_v vecCore::math::Cosh(const ROOT::Double_v & x);
+// template ROOT::Double_v vecCore::math::Tanh(const ROOT::Double_v & x);
+// template ROOT::Double_v vecCore::math::Cbrt(const ROOT::Double_v & x);
+#endif


### PR DESCRIPTION
This PR makes the vectorised version of the mathematical functions provided by VecCore available to ROOT vey instantiating them in ROOT Mathcore. 
The symbols will be available automatically at the ROOT prompt and by bringing in the Vc symbols, functions like std::sin or std::cos with vector types (std::sin(ROOT::Double_v) will be available 