### PR TITLE
ROOT-9021 Allow more complex jitted defines using lambdas

### DIFF
--- a/graf2d/mathtext/src/fontembedps.cxx
+++ b/graf2d/mathtext/src/fontembedps.cxx
@@ -254,8 +254,8 @@ namespace mathtext {
             segment_header.length =
             bswap_32(segment_header.length);
 #endif // LITTLE_ENDIAN
+            const char *match = "/FontName";
             char *buffer = new char[segment_header.length];
-            char *match = "/FontName";
             char *fname;
 
             memcpy(buffer, &font_data[offset],

--- a/tutorials/dataframe/tdf012_using_jit.C
+++ b/tutorials/dataframe/tdf012_using_jit.C
@@ -1,0 +1,63 @@
+/// \file
+/// \ingroup tutorial_tdataframe
+/// \notebook -nodraw
+///
+/// This tutorial illustrates how to save some typing when using TDataFrame
+/// by invoking functions that perform jit-compiling at runtime.
+///
+/// \macro_code
+///
+/// \date October 2017
+/// \author Guilherme Amadio
+
+#include "TRandom.h"
+#include "ROOT/TDataFrame.hxx"
+
+void tdf012_using_jit()
+{
+   // We will inefficiently calculate an approximation of pi by generating
+   // some data and doing very simple filtering and analysis on it
+
+   // We start by creating an empty dataframe where we will insert 10 million
+   // random points in a square of side 2.0 (that is, with an inscribed circle
+   // of radius 1.0)
+
+   size_t npoints = 10000000;
+   ROOT::Experimental::TDataFrame tdf(npoints);
+
+   // Make generators known to interpreter
+   gInterpreter->ProcessLine("TRandom rx, ry;");
+
+   // Use different seeds for independent streams
+   gInterpreter->ProcessLine("rx.SetSeed(1);");
+   gInterpreter->ProcessLine("ry.SetSeed(2);");
+
+   // Define what we want inside the dataframe. We do not need to define p as an array,
+   // but we do it here to demonstrate how to use jitting with TDataFrame
+
+   // NOTE: Although it's possible to use "for (auto&& x : p)" below, it will
+   // shadow the name of the data column "x", and may cause compilation failures
+   // if the local variable and the data column are of different types or the
+   // local x variable is declared in the global scope of the lambda function
+
+   auto pidf = tdf.Define("x", "rx.Uniform(-1.0, 1.0)")
+                  .Define("y", "ry.Uniform(-1.0, 1.0)")
+                  .Define("p", "std::array<double, 2> v{x, y}; return v;")
+                  .Define("r", "double r2 = 0.0; for (auto&& x : p) r2 += x*x; return sqrt(r2);");
+
+   // Now we have a dataframe with columns x, y, p (which is a point based on x
+   // and y), and the radius r = sqrt(x*x + y*y). In order to approximate pi, we
+   // need to know how many of our data points fall inside the unit circle compared
+   // with the total number of points. The ratio of the areas is
+   //
+   //     A_circle / A_square = pi r*r / l * l, where r = 1.0, and l = 2.0
+   //
+   // Therefore, we can approximate pi with 4 times the number of points inside the
+   // unit circle over the total number of points in our dataframe:
+
+   auto incircle = *(pidf.Filter("r <= 1.0").Count());
+
+   double pi_approx = 4.0 * incircle / npoints;
+
+   std::cout << "pi is approximately equal to " << pi_approx << std::endl;
+}

--- a/tutorials/dataframe/tdf012_using_jit.py
+++ b/tutorials/dataframe/tdf012_using_jit.py
@@ -1,0 +1,51 @@
+## \file
+## \ingroup tutorial_tdataframe
+## \notebook -nodraw
+##
+## This tutorial illustrates how to use jit-compiling features of TDataFrame
+## to define data using C++ code in a Python script
+##
+## \macro_code
+##
+## \date October 2017
+## \author Guilherme Amadio
+
+import ROOT
+
+## We will inefficiently calculate an approximation of pi by generating
+## some data and doing very simple filtering and analysis on it.
+
+## We start by creating an empty dataframe where we will insert 10 million
+## random points in a square of side 2.0 (that is, with an inscribed unit
+## circle).
+
+npoints = 10000000
+tdf = ROOT.ROOT.Experimental.TDataFrame(npoints)
+
+ROOT.gInterpreter.ProcessLine("TRandom rx, ry;")
+ROOT.gInterpreter.ProcessLine("rx.SetSeed(1);")
+ROOT.gInterpreter.ProcessLine("ry.SetSeed(2);")
+
+## Define what data we want inside the dataframe. We do not need to define p
+## as an array, but we do it here to demonstrate how to use jitting with TDataFrame
+
+pidf = tdf.Define("x", "rx.Uniform(-1.0, 1.0)") \
+          .Define("y", "ry.Uniform(-1.0, 1.0)") \
+          .Define("p", "std::array<double, 2> v{x, y}; return v;") \
+          .Define("r", "double r2 = 0.0; for (auto&& w : p) r2 += w*w; return sqrt(r2);")
+
+## Now we have a dataframe with columns x, y, p (which is a point based on x
+## and y), and the radius r = sqrt(x*x + y*y). In order to approximate pi, we
+## need to know how many of our data points fall inside the circle of radius
+## one compared with the total number of points. The ratio of the areas is
+##
+##     A_circle / A_square = pi r*r / l * l, where r = 1.0, and l = 2.0
+##
+## Therefore, we can approximate pi with 4 times the number of points inside
+## the unit circle over the total number of points:
+
+incircle = pidf.Filter("r <= 1.0").Count().GetValue()
+
+pi_approx = 4.0 * incircle / npoints
+
+print("pi is approximately equal to %g" % (pi_approx))


### PR DESCRIPTION
Still need to change the `find("return ")` to something more robust, but this allows defines to be a bit more complex. For filters, we need to do a bit more work (i.e., ensure we get something convertible to boolean).