### PR TITLE
Fix  makepchinput on Windows

### DIFF
--- a/build/unix/makepchinput.py
+++ b/build/unix/makepchinput.py
@@ -138,13 +138,15 @@ def getSTLIncludes():
                      "atomic",
                      "thread",
                      "mutex",
-                     "future",
                      "condition_variable",
                      "ciso646",
                      "ccomplex",
                      "ctgmath",
                      "cstdalign",
                      "cstdbool")
+
+   if sys.platform != 'win32':
+      stlHeadersList += ("future",)
 
    allHeadersPartContent = "// STL headers\n"
 
@@ -461,6 +463,12 @@ def makePCHInput():
    allHeadersFilename = os.path.join(outdir,"allHeaders.h")
    allLinkdefsFilename = os.path.join(outdir,"allLinkDefs.h")
    cppFlagsFilename = os.path.join(outdir, "allCppflags.txt")
+
+   if sys.platform == 'win32':
+      outdir.replace("\\","/")
+      allHeadersFilename.replace("\\","/")
+      allLinkdefsFilename.replace("\\","/")
+      cppFlagsFilename.replace("\\","/")
 
    mkdirIfNotThere(outdir)
    removeFiles((allHeadersFilename,allLinkdefsFilename))


### PR DESCRIPTION
 - remove "future" from the list of STL includes on Windows (it generates many errors)
 - replace backslashes by forward slashes in paths