### PR TITLE
Fix compilation errors on Windows

### DIFF
--- a/math/mathcore/inc/TMath.h
+++ b/math/mathcore/inc/TMath.h
@@ -490,7 +490,6 @@ struct Limits {
 #if defined(R__WIN32) && !defined(__CINT__)
 #   ifndef finite
 #      define finite _finite
-#      define isnan  _isnan
 #   endif
 #endif
 #if defined(R__AIX) || defined(R__SOLARIS_CC50) || \

--- a/math/mathcore/src/GaussIntegrator.cxx
+++ b/math/mathcore/src/GaussIntegrator.cxx
@@ -14,6 +14,7 @@
 #include "Math/IFunction.h"
 #include "Math/IFunctionfwd.h"
 #include <cmath>
+#include <algorithm>
 
 namespace ROOT {
 namespace Math {

--- a/math/mathcore/src/MixMaxEngineImpl.h
+++ b/math/mathcore/src/MixMaxEngineImpl.h
@@ -8,14 +8,18 @@
 #define ROOT_Math_MixMaxEngineImpl
 
 
-#if (_N==17)
+#if (_NN==17)
 namespace mixmax_17 {
-#elif (_N==240)
+#elif (_NN==240)
 namespace mixmax_240 {
-#elif (_N==256)
+#elif (_NN==256)
 namespace mixmax_256 {
 #else
 namespace { 
+#endif
+
+#ifdef WIN32
+#define __thread __declspec(thread)
 #endif
 
 #include "mixmax.icc"
@@ -27,11 +31,11 @@ namespace {
 
 #include <iostream>
 
-#if (_N==17)
+#if (_NN==17)
 using namespace mixmax_17;
-#elif (_N==240)
+#elif (_NN==240)
 using namespace mixmax_240;
-#elif (_N==256)
+#elif (_NN==256)
 using namespace mixmax_256;
 #endif
 
@@ -61,12 +65,12 @@ namespace ROOT {
 
 
 template<> 
-class MixMaxEngineImpl<_N> {
+class MixMaxEngineImpl<_NN> {
    rng_state_t * fRngState;
 public:
 
-   typedef MixMaxEngine<_N,0>::StateInt_t StateInt_t; 
-   typedef MixMaxEngine<_N,0>::Result_t Result_t;
+   typedef MixMaxEngine<_NN,0>::StateInt_t StateInt_t; 
+   typedef MixMaxEngine<_NN,0>::Result_t Result_t;
    
    MixMaxEngineImpl(uint64_t seed) {
       fRngState = rng_alloc();

--- a/math/mathcore/src/MixMaxEngineImpl.h
+++ b/math/mathcore/src/MixMaxEngineImpl.h
@@ -8,11 +8,11 @@
 #define ROOT_Math_MixMaxEngineImpl
 
 
-#if (_NN==17)
+#if (ROOT_MM_N==17)
 namespace mixmax_17 {
-#elif (_NN==240)
+#elif (ROOT_MM_N==240)
 namespace mixmax_240 {
-#elif (_NN==256)
+#elif (ROOT_MM_N==256)
 namespace mixmax_256 {
 #else
 namespace { 
@@ -31,11 +31,11 @@ namespace {
 
 #include <iostream>
 
-#if (_NN==17)
+#if (ROOT_MM_N==17)
 using namespace mixmax_17;
-#elif (_NN==240)
+#elif (ROOT_MM_N==240)
 using namespace mixmax_240;
-#elif (_NN==256)
+#elif (ROOT_MM_N==256)
 using namespace mixmax_256;
 #endif
 
@@ -65,12 +65,12 @@ namespace ROOT {
 
 
 template<> 
-class MixMaxEngineImpl<_NN> {
+class MixMaxEngineImpl<ROOT_MM_N> {
    rng_state_t * fRngState;
 public:
 
-   typedef MixMaxEngine<_NN,0>::StateInt_t StateInt_t; 
-   typedef MixMaxEngine<_NN,0>::Result_t Result_t;
+   typedef MixMaxEngine<ROOT_MM_N,0>::StateInt_t StateInt_t; 
+   typedef MixMaxEngine<ROOT_MM_N,0>::Result_t Result_t;
    
    MixMaxEngineImpl(uint64_t seed) {
       fRngState = rng_alloc();

--- a/math/mathcore/src/MixMaxEngineImpl17.cxx
+++ b/math/mathcore/src/MixMaxEngineImpl17.cxx
@@ -1,7 +1,7 @@
 
 
 // define number for used to Mixmax
-#define _N 17
+#define _NN 17
 
 #include "MixMaxEngineImpl.h"
 

--- a/math/mathcore/src/MixMaxEngineImpl17.cxx
+++ b/math/mathcore/src/MixMaxEngineImpl17.cxx
@@ -1,7 +1,7 @@
 
 
 // define number for used to Mixmax
-#define _NN 17
+#define ROOT_MM_N 17
 
 #include "MixMaxEngineImpl.h"
 

--- a/math/mathcore/src/MixMaxEngineImpl240.cxx
+++ b/math/mathcore/src/MixMaxEngineImpl240.cxx
@@ -1,7 +1,7 @@
 
 
 // define number for used to Mixmax
-#define _NN 240
+#define ROOT_MM_N 240
 
 #include "MixMaxEngineImpl.h"
 

--- a/math/mathcore/src/MixMaxEngineImpl240.cxx
+++ b/math/mathcore/src/MixMaxEngineImpl240.cxx
@@ -1,7 +1,7 @@
 
 
 // define number for used to Mixmax
-#define _N 240
+#define _NN 240
 
 #include "MixMaxEngineImpl.h"
 

--- a/math/mathcore/src/MixMaxEngineImpl256.cxx
+++ b/math/mathcore/src/MixMaxEngineImpl256.cxx
@@ -1,7 +1,7 @@
 
 
 // define number for used to Mixmax
-#define _N 256
+#define _NN 256
 
 #include "MixMaxEngineImpl.h"
 

--- a/math/mathcore/src/MixMaxEngineImpl256.cxx
+++ b/math/mathcore/src/MixMaxEngineImpl256.cxx
@@ -1,7 +1,7 @@
 
 
 // define number for used to Mixmax
-#define _NN 256
+#define ROOT_MM_N 256
 
 #include "MixMaxEngineImpl.h"
 

--- a/math/mathcore/src/RichardsonDerivator.cxx
+++ b/math/mathcore/src/RichardsonDerivator.cxx
@@ -12,6 +12,7 @@
 #include "Math/IFunctionfwd.h"
 #include <cmath>
 #include <limits>
+#include <algorithm>
 
 #include "Math/Error.h"
 

--- a/math/mathcore/src/mixmax.h
+++ b/math/mathcore/src/mixmax.h
@@ -27,7 +27,7 @@
 //extern "C" {
 //#endif
 
-#ifndef _N
+#ifndef _NN
 #define N 240
 /* The currently recommended generator is the three-parameter MIXMAX with
 N=240, s=487013230256099140, m=2^51+1
@@ -38,7 +38,7 @@ N=240, s=487013230256099140, m=2^51+1
    Since the algorithm is linear in N, the cost per number is almost independent of N.
  */
 #else
-#define N _N
+#define N _NN
 #endif
 
 #ifndef __LP64__

--- a/math/mathcore/src/mixmax.h
+++ b/math/mathcore/src/mixmax.h
@@ -27,7 +27,7 @@
 //extern "C" {
 //#endif
 
-#ifndef _NN
+#ifndef ROOT_MM_N
 #define N 240
 /* The currently recommended generator is the three-parameter MIXMAX with
 N=240, s=487013230256099140, m=2^51+1
@@ -38,7 +38,7 @@ N=240, s=487013230256099140, m=2^51+1
    Since the algorithm is linear in N, the cost per number is almost independent of N.
  */
 #else
-#define N _NN
+#define N ROOT_MM_N
 #endif
 
 #ifndef __LP64__


### PR DESCRIPTION
- Add a couple of missing #include <algorithm>
- Replace _N by _NN (_N is already defined and used in some system math headers on Windows)
- Add #define __thread __declspec(thread)