### PR TITLE
Fix libCling compilation on Windows

### DIFF
--- a/core/metacling/src/CMakeLists.txt
+++ b/core/metacling/src/CMakeLists.txt
@@ -10,9 +10,9 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../res
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CLING_CXXFLAGS}")
 
 if(MSVC)
-set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/TClingCallbacks.cxx COMPILE_FLAGS -GR-)
+  set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/TClingCallbacks.cxx COMPILE_FLAGS -GR-)
 else()
-set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/TClingCallbacks.cxx COMPILE_FLAGS -fno-rtti)
+  set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/TClingCallbacks.cxx COMPILE_FLAGS -fno-rtti)
 endif()
 
 # This to avoid warning coming from llvm/src/tools/clang/include/clang/Sema/Lookup.h:441
@@ -38,8 +38,23 @@ ROOT_LINKER_LIBRARY(Cling
         $<TARGET_OBJECTS:MetaCling>
         LIBRARIES ${CLING_LIBRARIES})
 
+if(MSVC)
+  set_target_properties(Cling PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
+  set(cling_exports ??1Value@cling@@QAE@XZ
+      ?setValueNoAlloc@internal@runtime@cling@@YAXPAX00D_K@Z
+      ?printValue@cling@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PB_N@Z
+      ?EvaluateDynamicExpression@internal@runtime@cling@@YA?AVValue@3@PAVInterpreter@3@PAVDynamicExprInfo@123@PAVDeclContext@clang@@@Z
+  )
+  foreach(sym ${cling_exports})
+    set(cling_link_str "${cling_link_str} /EXPORT:${sym}")
+  endforeach(sym ${cling_exports})
+  set_property(TARGET Cling APPEND_STRING PROPERTY LINK_FLAGS ${cling_link_str})
+  add_dependencies(Cling Core RIO)
+  target_link_libraries(Cling Core RIO)
+endif()
+
 if(APPLE)
-target_link_libraries(Cling -Wl,-bind_at_load -Wl,-undefined -Wl,dynamic_lookup)
-else()
-target_link_libraries(Cling -Wl,--unresolved-symbols=ignore-in-object-files)
+  target_link_libraries(Cling -Wl,-bind_at_load -Wl,-undefined -Wl,dynamic_lookup)
+elseif(NOT MSVC)
+  target_link_libraries(Cling -Wl,--unresolved-symbols=ignore-in-object-files)
 endif()

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -4728,18 +4728,18 @@ int TCling::ReadRootmapFile(const char *rootmapfile, TUniqueString *uniqueString
    const std::map<char, unsigned int> keyLenMap = {{'c',6},{'n',10},{'t',8},{'h',7},{'e',5},{'v',4}};
 
    if (rootmapfile && *rootmapfile) {
-      std::string rmapfile(rootmapfile);
+      std::string rootmapfileNoBackslash(rootmapfile);
 #ifdef _MSC_VER
-      std::replace(rmapfile.begin(), rmapfile.end(), '\\', '/');
+      std::replace(rootmapfileNoBackslash.begin(), rootmapfileNoBackslash.end(), '\\', '/');
 #endif
       // Add content of a specific rootmap file
-      if (fRootmapFiles->FindObject(rmapfile.c_str()))
+      if (fRootmapFiles->FindObject(rootmapfileNoBackslash.c_str()))
          return -1;
 
       if (uniqueString)
-         uniqueString->Append(std::string("\n#line 1 \"Forward declarations from ") + rmapfile + "\"\n");
+         uniqueString->Append(std::string("\n#line 1 \"Forward declarations from ") + rootmapfileNoBackslash + "\"\n");
 
-      std::ifstream file(rmapfile);
+      std::ifstream file(rootmapfileNoBackslash);
       std::string line; line.reserve(200);
       std::string lib_name; line.reserve(100);
       bool newFormat=false;
@@ -4757,7 +4757,8 @@ int TCling::ReadRootmapFile(const char *rootmapfile, TUniqueString *uniqueString
             while (getline(file, line, '\n')) {
                if (line[0] == '[') break;
                if (!uniqueString) {
-                  Error("ReadRootmapFile", "Cannot handle \"{ decls }\" sections in custom rootmap file %s", rmapfile.c_str());
+                  Error("ReadRootmapFile", "Cannot handle \"{ decls }\" sections in custom rootmap file %s",
+                        rootmapfileNoBackslash.c_str());
                   return -4;
                }
                uniqueString->Append(line);

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1677,9 +1677,8 @@ void TCling::RegisterModule(const char* modulename,
          if (!dyLibHandle) {
 #ifdef R__WIN32
             char dyLibError[1000];
-            FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, NULL, GetLastError(),
-                          MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), dyLibError,
-                          sizeof(dyLibError), NULL);
+            FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, NULL, GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                           dyLibError, sizeof(dyLibError), NULL);
 #else
             const char* dyLibError = dlerror();
             if (dyLibError)
@@ -4746,7 +4745,7 @@ int TCling::ReadRootmapFile(const char *rootmapfile, TUniqueString *uniqueString
       bool newFormat=false;
       while (getline(file, line, '\n')) {
          if (!newFormat &&
-             (strstr(line.c_str(),"Library.") != nullptr || strstr(line.c_str(),"Declare.") != nullptr)) {
+             (strstr(line.c_str(), "Library.") != nullptr || strstr(line.c_str(), "Declare.") != nullptr)) {
             file.close();
             return -3; // old format
          }
@@ -4758,7 +4757,7 @@ int TCling::ReadRootmapFile(const char *rootmapfile, TUniqueString *uniqueString
             while (getline(file, line, '\n')) {
                if (line[0] == '[') break;
                if (!uniqueString) {
-                  Error("ReadRootmapFile", "Cannot handle \"{ decls }\" sections in custom rootmap file %s", rmapfile);
+                  Error("ReadRootmapFile", "Cannot handle \"{ decls }\" sections in custom rootmap file %s", rmapfile.c_str());
                   return -4;
                }
                uniqueString->Append(line);


### PR DESCRIPTION
- add dependencied on Core and IO (needed to resolve the symbols at link time on Windows)
- add a few symbols to be exported
- use the ANSI version of system functions
- convert the backslashs to forward slashs in the rootmap file path