### PR TITLE
[TDF] Move to Profile models also the Profile1D and Profile2D methods of TInterface

### DIFF
--- a/README/ReleaseNotes/v612/index.md
+++ b/README/ReleaseNotes/v612/index.md
@@ -92,7 +92,7 @@ large TClonesArray where each element contains another small vector container.
   - Added `DefineSlot`, a `Define` transformation that is aware of the multi-threading slot where the workload is executed
   - Improvements in Cling drastically enhanced scaling and performance of TDF jitted code
   - Fixed reading of c-style arrays from jitted transformations and actions
-  - pyROOT users can now easily specify parameters for the TDF histograms thanks to the newly introduced tuple-initialization
+  - pyROOT users can now easily specify parameters for the TDF histograms and profiles thanks to the newly introduced tuple-initialization
   - The new TDataSource interface allows developers to pipe any kind of columnar data format into TDataFrame
   - Test coverage has been increased with the introduction of google tests
   - Users can now configure Snapshot to use different file open modes ("RECREATE" or "UPDATE"), compression level, compression algorithm, TTree split-level and autoflush settings

--- a/tree/treeplayer/inc/LinkDef.h
+++ b/tree/treeplayer/inc/LinkDef.h
@@ -116,6 +116,8 @@
 #pragma link C++ class ROOT::Experimental::TDF::TH1DModel-;
 #pragma link C++ class ROOT::Experimental::TDF::TH2DModel-;
 #pragma link C++ class ROOT::Experimental::TDF::TH3DModel-;
+#pragma link C++ class ROOT::Experimental::TDF::TProfile1DModel-;
+#pragma link C++ class ROOT::Experimental::TDF::TProfile2DModel-;
 #pragma link C++ class ROOT::Internal::TDF::TIgnoreErrorLevelRAII-;
 #pragma link C++ class ROOT::Experimental::TDF::TTrivialDS-;
 #pragma link C++ class ROOT::Experimental::TDF::TRootDS-;

--- a/tree/treeplayer/inc/ROOT/TDFHistoModels.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFHistoModels.hxx
@@ -17,6 +17,8 @@
 class TH1D;
 class TH2D;
 class TH3D;
+class TProfile;
+class TProfile2D;
 
 namespace ROOT {
 namespace Experimental {
@@ -73,6 +75,48 @@ struct TH3DModel {
    TH3DModel(const ::TH3D &h);
    TH3DModel(const char *name, const char *title, int nbinsx, double xlow, double xup, int nbinsy, double ylow,
              double yup, int nbinsz, double zlow, double zup);
+};
+
+struct TProfile1DModel {
+   TString fName;
+   TString fTitle;
+   int fNbinsX = 128;
+   double fXLow = 0.;
+   double fXUp = 64.;
+   double fYLow = 0.;
+   double fYUp = 0.;
+   TString fOption;
+
+   TProfile1DModel() = default;
+   TProfile1DModel(const TProfile1DModel &) = default;
+   ~TProfile1DModel();
+   TProfile1DModel(const ::TProfile &h);
+   TProfile1DModel(const char *name, const char *title, int nbinsx, double xlow, double xup, const char *option = "");
+   TProfile1DModel(const char *name, const char *title, int nbinsx, double xlow, double xup, double ylow, double yup,
+                   const char *option = "");
+};
+
+struct TProfile2DModel {
+   TString fName;
+   TString fTitle;
+   int fNbinsX = 128;
+   double fXLow = 0.;
+   double fXUp = 64.;
+   int fNbinsY = 128;
+   double fYLow = 0.;
+   double fYUp = 64.;
+   double fZLow = 0.;
+   double fZUp = 0.;
+   TString fOption;
+
+   TProfile2DModel() = default;
+   TProfile2DModel(const TProfile2DModel &) = default;
+   ~TProfile2DModel();
+   TProfile2DModel(const ::TProfile2D &h);
+   TProfile2DModel(const char *name, const char *title, int nbinsx, double xlow, double xup, int nbinsy, double ylow,
+                   double yup, const char *option = "");
+   TProfile2DModel(const char *name, const char *title, int nbinsx, double xlow, double xup, int nbinsy, double ylow,
+                   double yup, double zlow, double zup, const char *option = "");
 };
 
 } // ns TDF

--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -1144,9 +1144,15 @@ public:
    /// booked but not executed. See TResultProxy documentation.
    /// The user gives up ownership of the model profile object.
    template <typename V1 = TDFDetail::TInferType, typename V2 = TDFDetail::TInferType>
-   TResultProxy<::TProfile> Profile1D(::TProfile &&model, std::string_view v1Name = "", std::string_view v2Name = "")
+   TResultProxy<::TProfile> Profile1D(const TProfile1DModel &model, std::string_view v1Name = "", std::string_view v2Name = "")
    {
-      auto h = std::make_shared<::TProfile>(std::move(model));
+      std::shared_ptr<::TProfile> h(nullptr);
+      {
+         ROOT::Internal::TDF::TIgnoreErrorLevelRAII iel(kError);
+         h = std::make_shared<::TProfile>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp,
+                                          model.fYLow, model.fYUp, model.fOption);
+      }
+
       if (!TDFInternal::HistoUtils<::TProfile>::HasAxisLimits(*h)) {
          throw std::runtime_error("Profiles with no axes limits are not supported yet.");
       }
@@ -1173,9 +1179,15 @@ public:
    template <typename V1 = TDFDetail::TInferType, typename V2 = TDFDetail::TInferType,
              typename W = TDFDetail::TInferType>
    TResultProxy<::TProfile>
-   Profile1D(::TProfile &&model, std::string_view v1Name, std::string_view v2Name, std::string_view wName)
+   Profile1D(const TProfile1DModel &model, std::string_view v1Name, std::string_view v2Name, std::string_view wName)
    {
-      auto h = std::make_shared<::TProfile>(std::move(model));
+      std::shared_ptr<::TProfile> h(nullptr);
+      {
+         ROOT::Internal::TDF::TIgnoreErrorLevelRAII iel(kError);
+         h = std::make_shared<::TProfile>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp,
+                                          model.fYLow, model.fYUp, model.fOption);
+      }
+
       if (!TDFInternal::HistoUtils<::TProfile>::HasAxisLimits(*h)) {
          throw std::runtime_error("Profile histograms with no axes limits are not supported yet.");
       }
@@ -1187,9 +1199,9 @@ public:
    }
 
    template <typename V1, typename V2, typename W>
-   TResultProxy<::TProfile> Profile1D(::TProfile &&model)
+   TResultProxy<::TProfile> Profile1D(const TProfile1DModel &model)
    {
-      return Profile1D<V1, V2, W>(std::move(model), "", "", "");
+      return Profile1D<V1, V2, W>(model, "", "", "");
    }
 
    ////////////////////////////////////////////////////////////////////////////
@@ -1207,10 +1219,16 @@ public:
    /// The user gives up ownership of the model profile.
    template <typename V1 = TDFDetail::TInferType, typename V2 = TDFDetail::TInferType,
              typename V3 = TDFDetail::TInferType>
-   TResultProxy<::TProfile2D> Profile2D(::TProfile2D &&model, std::string_view v1Name = "",
+   TResultProxy<::TProfile2D> Profile2D(const TProfile2DModel &model, std::string_view v1Name = "",
                                         std::string_view v2Name = "", std::string_view v3Name = "")
    {
-      auto h = std::make_shared<::TProfile2D>(std::move(model));
+      std::shared_ptr<::TProfile2D> h(nullptr);
+      {
+         ROOT::Internal::TDF::TIgnoreErrorLevelRAII iel(kError);
+         h = std::make_shared<::TProfile2D>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp, model.fNbinsY,
+                                            model.fYLow, model.fYUp, model.fZLow, model.fZUp, model.fOption);
+      }
+
       if (!TDFInternal::HistoUtils<::TProfile2D>::HasAxisLimits(*h)) {
          throw std::runtime_error("2D profiles with no axes limits are not supported yet.");
       }
@@ -1238,10 +1256,16 @@ public:
    /// The user gives up ownership of the model profile.
    template <typename V1 = TDFDetail::TInferType, typename V2 = TDFDetail::TInferType,
              typename V3 = TDFDetail::TInferType, typename W = TDFDetail::TInferType>
-   TResultProxy<::TProfile2D> Profile2D(::TProfile2D &&model, std::string_view v1Name, std::string_view v2Name,
+   TResultProxy<::TProfile2D> Profile2D(const TProfile2DModel &model, std::string_view v1Name, std::string_view v2Name,
                                         std::string_view v3Name, std::string_view wName)
    {
-      auto h = std::make_shared<::TProfile2D>(std::move(model));
+      std::shared_ptr<::TProfile2D> h(nullptr);
+      {
+         ROOT::Internal::TDF::TIgnoreErrorLevelRAII iel(kError);
+         h = std::make_shared<::TProfile2D>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp, model.fNbinsY,
+                                            model.fYLow, model.fYUp, model.fZLow, model.fZUp, model.fOption);
+      }
+
       if (!TDFInternal::HistoUtils<::TProfile2D>::HasAxisLimits(*h)) {
          throw std::runtime_error("2D profiles with no axes limits are not supported yet.");
       }
@@ -1253,9 +1277,9 @@ public:
    }
 
    template <typename V1, typename V2, typename V3, typename W>
-   TResultProxy<::TProfile2D> Profile2D(::TProfile2D &&model)
+   TResultProxy<::TProfile2D> Profile2D(const TProfile2DModel &model)
    {
-      return Profile2D<V1, V2, V3, W>(std::move(model), "", "", "", "");
+      return Profile2D<V1, V2, V3, W>(model, "", "", "", "");
    }
 
    ////////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/src/TDFHistoModels.cxx
+++ b/tree/treeplayer/src/TDFHistoModels.cxx
@@ -13,6 +13,8 @@
 #include <TH1D.h>
 #include <TH2D.h>
 #include <TH3D.h>
+#include <TProfile.h>
+#include <TProfile2D.h>
 
 /**
 * \class ROOT::Experimental::TDF::TH1DModel
@@ -26,6 +28,14 @@
 * \class ROOT::Experimental::TDF::TH3DModel
 * \ingroup dataframe
 * \brief A struct which stores the parameters of a TH3D
+*
+* \class ROOT::Experimental::TDF::TProfile1DModel
+* \ingroup dataframe
+* \brief A struct which stores the parameters of a TProfile
+*
+* \class ROOT::Experimental::TDF::TProfile2DModel
+* \ingroup dataframe
+* \brief A struct which stores the parameters of a TProfile2D
 */
 
 namespace ROOT {
@@ -74,6 +84,56 @@ TH3DModel::TH3DModel(const char *name, const char *title, int nbinsx, double xlo
 {
 }
 TH3DModel::~TH3DModel()
+{
+}
+
+// Profiles
+
+TProfile1DModel::TProfile1DModel(const ::TProfile &h)
+   : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX()), fXLow(h.GetXaxis()->GetXmin()),
+     fXUp(h.GetXaxis()->GetXmax()), fYLow(h.GetYaxis()->GetXmin()), fYUp(h.GetYaxis()->GetXmax()),
+     fOption(h.GetErrorOption())
+{
+}
+TProfile1DModel::TProfile1DModel(const char *name, const char *title, int nbinsx, double xlow, double xup,
+                                 const char *option)
+   : fName(name), fTitle(title), fNbinsX(nbinsx), fXLow(xlow), fXUp(xup), fOption(option)
+{
+}
+
+TProfile1DModel::TProfile1DModel(const char *name, const char *title, int nbinsx, double xlow, double xup,
+                                 double ylow, double yup, const char *option)
+   : fName(name), fTitle(title), fNbinsX(nbinsx), fXLow(xlow), fXUp(xup), fYLow(ylow), fYUp(yup),
+     fOption(option)
+{
+}
+
+TProfile1DModel::~TProfile1DModel()
+{
+}
+
+TProfile2DModel::TProfile2DModel(const ::TProfile2D &h)
+   : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX()), fXLow(h.GetXaxis()->GetXmin()),
+     fXUp(h.GetXaxis()->GetXmax()), fNbinsY(h.GetNbinsY()), fYLow(h.GetYaxis()->GetXmin()),
+     fYUp(h.GetYaxis()->GetXmax()), fZLow(h.GetZaxis()->GetXmin()), fZUp(h.GetZaxis()->GetXmax()),
+     fOption(h.GetErrorOption())
+{
+}
+TProfile2DModel::TProfile2DModel(const char *name, const char *title, int nbinsx, double xlow, double xup, int nbinsy,
+                                 double ylow, double yup, const char *option)
+   : fName(name), fTitle(title), fNbinsX(nbinsx), fXLow(xlow), fXUp(xup), fNbinsY(nbinsy), fYLow(ylow), fYUp(yup),
+     fOption(option)
+{
+}
+
+TProfile2DModel::TProfile2DModel(const char *name, const char *title, int nbinsx, double xlow, double xup, int nbinsy,
+                                 double ylow, double yup, double zlow, double zup, const char *option)
+   : fName(name), fTitle(title), fNbinsX(nbinsx), fXLow(xlow), fXUp(xup), fNbinsY(nbinsy), fYLow(ylow), fYUp(yup),
+     fZLow(zlow), fZUp(zup), fOption(option)
+{
+}
+
+TProfile2DModel::~TProfile2DModel()
 {
 }
 

--- a/tree/treeplayer/src/TDFHistoModels.cxx
+++ b/tree/treeplayer/src/TDFHistoModels.cxx
@@ -91,8 +91,7 @@ TH3DModel::~TH3DModel()
 
 TProfile1DModel::TProfile1DModel(const ::TProfile &h)
    : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX()), fXLow(h.GetXaxis()->GetXmin()),
-     fXUp(h.GetXaxis()->GetXmax()), fYLow(h.GetYmin()), fYUp(h.GetYmax()),
-     fOption(h.GetErrorOption())
+     fXUp(h.GetXaxis()->GetXmax()), fYLow(h.GetYmin()), fYUp(h.GetYmax()), fOption(h.GetErrorOption())
 {
 }
 TProfile1DModel::TProfile1DModel(const char *name, const char *title, int nbinsx, double xlow, double xup,
@@ -101,10 +100,9 @@ TProfile1DModel::TProfile1DModel(const char *name, const char *title, int nbinsx
 {
 }
 
-TProfile1DModel::TProfile1DModel(const char *name, const char *title, int nbinsx, double xlow, double xup,
-                                 double ylow, double yup, const char *option)
-   : fName(name), fTitle(title), fNbinsX(nbinsx), fXLow(xlow), fXUp(xup), fYLow(ylow), fYUp(yup),
-     fOption(option)
+TProfile1DModel::TProfile1DModel(const char *name, const char *title, int nbinsx, double xlow, double xup, double ylow,
+                                 double yup, const char *option)
+   : fName(name), fTitle(title), fNbinsX(nbinsx), fXLow(xlow), fXUp(xup), fYLow(ylow), fYUp(yup), fOption(option)
 {
 }
 
@@ -115,8 +113,7 @@ TProfile1DModel::~TProfile1DModel()
 TProfile2DModel::TProfile2DModel(const ::TProfile2D &h)
    : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX()), fXLow(h.GetXaxis()->GetXmin()),
      fXUp(h.GetXaxis()->GetXmax()), fNbinsY(h.GetNbinsY()), fYLow(h.GetYaxis()->GetXmin()),
-     fYUp(h.GetYaxis()->GetXmax()), fZLow(h.GetZmin()), fZUp(h.GetZmax()),
-     fOption(h.GetErrorOption())
+     fYUp(h.GetYaxis()->GetXmax()), fZLow(h.GetZmin()), fZUp(h.GetZmax()), fOption(h.GetErrorOption())
 {
 }
 TProfile2DModel::TProfile2DModel(const char *name, const char *title, int nbinsx, double xlow, double xup, int nbinsy,

--- a/tree/treeplayer/src/TDFHistoModels.cxx
+++ b/tree/treeplayer/src/TDFHistoModels.cxx
@@ -91,7 +91,7 @@ TH3DModel::~TH3DModel()
 
 TProfile1DModel::TProfile1DModel(const ::TProfile &h)
    : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX()), fXLow(h.GetXaxis()->GetXmin()),
-     fXUp(h.GetXaxis()->GetXmax()), fYLow(h.GetYaxis()->GetXmin()), fYUp(h.GetYaxis()->GetXmax()),
+     fXUp(h.GetXaxis()->GetXmax()), fYLow(h.GetYmin()), fYUp(h.GetYmax()),
      fOption(h.GetErrorOption())
 {
 }
@@ -115,7 +115,7 @@ TProfile1DModel::~TProfile1DModel()
 TProfile2DModel::TProfile2DModel(const ::TProfile2D &h)
    : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX()), fXLow(h.GetXaxis()->GetXmin()),
      fXUp(h.GetXaxis()->GetXmax()), fNbinsY(h.GetNbinsY()), fYLow(h.GetYaxis()->GetXmin()),
-     fYUp(h.GetYaxis()->GetXmax()), fZLow(h.GetZaxis()->GetXmin()), fZUp(h.GetZaxis()->GetXmax()),
+     fYUp(h.GetYaxis()->GetXmax()), fZLow(h.GetZmin()), fZUp(h.GetZmax()),
      fOption(h.GetErrorOption())
 {
 }

--- a/tutorials/dataframe/tdf003_profiles.C
+++ b/tutorials/dataframe/tdf003_profiles.C
@@ -12,22 +12,13 @@
 
 // A simple helper function to fill a test tree: this makes the example
 // stand-alone.
-void fill_tree(const char *filename, const char *treeName)
+void fill_tree(const char *treeName, const char *fileName)
 {
-   TFile f(filename, "RECREATE");
-   TTree t(treeName, treeName);
-   float px, py, pz;
-   t.Branch("px", &px);
-   t.Branch("py", &py);
-   t.Branch("pz", &pz);
-   for (int i = 0; i < 25000; i++) {
-      gRandom->Rannor(px, py);
-      pz = px * px + py * py;
-      t.Fill();
-   }
-   t.Write();
-   f.Close();
-   return;
+   ROOT::Experimental::TDataFrame d(25000);
+   d.Define("px", [](){return gRandom->Gaus();})
+    .Define("py", [](){return gRandom->Gaus();})
+    .Define("pz", [](double px, double py){return sqrt(px * px + py * py);}, {"px", "py"})
+    .Snapshot(treeName, fileName);
 }
 
 void tdf003_profiles()
@@ -35,7 +26,7 @@ void tdf003_profiles()
    // We prepare an input tree to run on
    auto fileName = "tdf003_profiles.root";
    auto treeName = "myTree";
-   fill_tree(fileName, treeName);
+   fill_tree(treeName, fileName);
 
    // We read the tree from the file and create a TDataFrame.
    ROOT::Experimental::TDataFrame d(treeName, fileName, {"px", "py", "pz"});

--- a/tutorials/dataframe/tdf003_profiles.C
+++ b/tutorials/dataframe/tdf003_profiles.C
@@ -15,10 +15,10 @@
 void fill_tree(const char *treeName, const char *fileName)
 {
    ROOT::Experimental::TDataFrame d(25000);
-   d.Define("px", [](){return gRandom->Gaus();})
-    .Define("py", [](){return gRandom->Gaus();})
-    .Define("pz", [](double px, double py){return sqrt(px * px + py * py);}, {"px", "py"})
-    .Snapshot(treeName, fileName);
+   d.Define("px", []() { return gRandom->Gaus(); })
+      .Define("py", []() { return gRandom->Gaus(); })
+      .Define("pz", [](double px, double py) { return sqrt(px * px + py * py); }, {"px", "py"})
+      .Snapshot(treeName, fileName);
 }
 
 void tdf003_profiles()

--- a/tutorials/dataframe/tdf003_profiles.C
+++ b/tutorials/dataframe/tdf003_profiles.C
@@ -41,8 +41,8 @@ void tdf003_profiles()
    ROOT::Experimental::TDataFrame d(treeName, fileName, {"px", "py", "pz"});
 
    // Create the profiles
-   auto hprof1d = d.Profile1D(TProfile("hprof1d", "Profile of pz versus px", 64, -4, 4));
-   auto hprof2d = d.Profile2D(TProfile2D("hprof2d", "Profile of pz versus px and py", 40, -4, 4, 40, -4, 4, 0, 20));
+   auto hprof1d = d.Profile1D({"hprof1d", "Profile of pz versus px", 64, -4, 4});
+   auto hprof2d = d.Profile2D({"hprof2d", "Profile of pz versus px and py", 40, -4, 4, 40, -4, 4, 0, 20});
 
    // And Draw
    auto c1 = new TCanvas("c1", "Profile histogram example", 200, 10, 700, 500);

--- a/tutorials/dataframe/tdf003_profiles.py
+++ b/tutorials/dataframe/tdf003_profiles.py
@@ -1,0 +1,49 @@
+## \file
+## \ingroup tutorial_tdataframe
+## \notebook -nodraw
+## This tutorial illustrates how to use TProfiles in combination with the
+## TDataFrame. See the documentation of TProfile and TProfile2D to better
+## understand the analogy of this code with the example one.
+##
+## \macro_code
+##
+## \date February 2017
+## \author Danilo Piparo
+
+import ROOT
+TDataFrame = ROOT.ROOT.Experimental.TDataFrame
+
+# A simple helper function to fill a test tree: this makes the example
+# stand-alone.
+def fill_tree(treeName, fileName):
+    d = TDataFrame(25000)
+    d.Define("px", "gRandom->Gaus()")\
+     .Define("py", "gRandom->Gaus()")\
+     .Define("pz", "sqrt(px * px + py * py)")\
+     .Snapshot(treeName, fileName)
+
+
+
+# We prepare an input tree to run on
+fileName = "tdf003_profiles.root"
+treeName = "myTree"
+fill_tree(treeName, fileName)
+
+# We read the tree from the file and create a TDataFrame.
+columns = ROOT.vector('string')()
+columns.push_back("px")
+columns.push_back("py")
+columns.push_back("pz")
+d = TDataFrame(treeName, fileName, columns)
+
+# Create the profiles
+hprof1d = d.Profile1D(("hprof1d", "Profile of pz versus px", 64, -4, 4))
+hprof2d = d.Profile2D(("hprof2d", "Profile of pz versus px and py", 40, -4, 4, 40, -4, 4, 0, 20))
+
+# And Draw
+c1 = ROOT.TCanvas("c1", "Profile histogram example", 200, 10, 700, 500)
+hprof1d.Draw()
+c2 = ROOT.TCanvas("c2", "Profile2D histogram example", 200, 10, 700, 500)
+c2.cd()
+hprof2d.Draw()
+


### PR DESCRIPTION
This is done to get rid of the move semantics and make PyROOT's life easier.