### PR TITLE
Fix the dictionary generation on Windows

### DIFF
--- a/core/dictgen/src/SelectionRules.cxx
+++ b/core/dictgen/src/SelectionRules.cxx
@@ -17,7 +17,12 @@ The class representing the collection of selection rules.
 #include <iostream>
 #include <sstream>
 #include <algorithm>
+#ifndef WIN32
 #include <fnmatch.h>
+#else
+#include "Shlwapi.h"
+#define fnmatch(glob, path, dummy) PathMatchSpecA(path, glob);
+#endif
 #include "RtypesCore.h"
 #include "SelectionRules.h"
 #include "llvm/Support/raw_ostream.h"

--- a/core/dictgen/src/TModuleGenerator.cxx
+++ b/core/dictgen/src/TModuleGenerator.cxx
@@ -346,35 +346,32 @@ void TModuleGenerator::WriteRegistrationSource(std::ostream &out,
       const std::string &fwdDeclString) const
 {
 
-   std::string fwdDeclStringOS = fwdDeclString;
+   std::string fwdDeclStringSanitized = fwdDeclString;
 #ifdef R__WIN32
    // Visual sudio has a limitation of 2048 characters max in raw strings, so split
    // the potentially huge DICTFWDDCLS raw string into multiple smaller ones
-   const std::string &from = "\n";
-   const std::string &to = "\n)DICTFWDDCLS\"\nR\"DICTFWDDCLS(";
+   constexpr std::string &from = "\n";
+   constexpr std::string &to = "\n)DICTFWDDCLS\"\nR\"DICTFWDDCLS(";
    size_t start_pos = 0;
-   while((start_pos = fwdDeclStringOS.find(from, start_pos)) != std::string::npos) {
-      if (fwdDeclStringOS.find(from, start_pos+1) == std::string::npos) // skip the last
+   while ((start_pos = fwdDeclStringSanitized.find(from, start_pos)) != std::string::npos) {
+      if (fwdDeclStringSanitized.find(from, start_pos + 1) == std::string::npos) // skip the last
          break;
-      if ((fwdDeclStringOS.at(start_pos+1) == '}') ||
-          (fwdDeclStringOS.at(start_pos+1) == '\n') )
+      if ((fwdDeclStringSanitized.at(start_pos + 1) == '}') || (fwdDeclStringSanitized.at(start_pos + 1) == '\n'))
          start_pos += 2;
       else {
-         fwdDeclStringOS.replace(start_pos, from.length(), to);
+         fwdDeclStringSanitized.replace(start_pos, from.length(), to);
          start_pos += to.length(); // In case 'to' contains 'from', like replacing 'x' with 'yx'
       }
    }
 #endif
    std::string fwdDeclStringRAW;
-   if ("nullptr" == fwdDeclStringOS ||
-       "\"\"" == fwdDeclStringOS) {
-      fwdDeclStringRAW = fwdDeclStringOS;
-   }
-   else {
+   if ("nullptr" == fwdDeclStringSanitized || "\"\"" == fwdDeclStringSanitized) {
+      fwdDeclStringRAW = fwdDeclStringSanitized;
+   } else {
       fwdDeclStringRAW = "R\"DICTFWDDCLS(\n";
       fwdDeclStringRAW += "#line 1 \"";
       fwdDeclStringRAW += fDictionaryName +" dictionary forward declarations' payload\"\n";
-      fwdDeclStringRAW += fwdDeclStringOS;
+      fwdDeclStringRAW += fwdDeclStringSanitized;
       fwdDeclStringRAW += ")DICTFWDDCLS\"";
    }
 

--- a/core/dictgen/src/TModuleGenerator.cxx
+++ b/core/dictgen/src/TModuleGenerator.cxx
@@ -350,8 +350,8 @@ void TModuleGenerator::WriteRegistrationSource(std::ostream &out,
 #ifdef R__WIN32
    // Visual sudio has a limitation of 2048 characters max in raw strings, so split
    // the potentially huge DICTFWDDCLS raw string into multiple smaller ones
-   constexpr std::string &from = "\n";
-   constexpr std::string &to = "\n)DICTFWDDCLS\"\nR\"DICTFWDDCLS(";
+   constexpr char from[] = "\n";
+   constexpr char to[] = "\n)DICTFWDDCLS\"\nR\"DICTFWDDCLS(";
    size_t start_pos = 0;
    while ((start_pos = fwdDeclStringSanitized.find(from, start_pos)) != std::string::npos) {
       if (fwdDeclStringSanitized.find(from, start_pos + 1) == std::string::npos) // skip the last
@@ -359,8 +359,8 @@ void TModuleGenerator::WriteRegistrationSource(std::ostream &out,
       if ((fwdDeclStringSanitized.at(start_pos + 1) == '}') || (fwdDeclStringSanitized.at(start_pos + 1) == '\n'))
          start_pos += 2;
       else {
-         fwdDeclStringSanitized.replace(start_pos, from.length(), to);
-         start_pos += to.length(); // In case 'to' contains 'from', like replacing 'x' with 'yx'
+         fwdDeclStringSanitized.replace(start_pos, strlen(from), to);
+         start_pos += strlen(to); // In case 'to' contains 'from', like replacing 'x' with 'yx'
       }
    }
 #endif

--- a/core/dictgen/src/TModuleGenerator.cxx
+++ b/core/dictgen/src/TModuleGenerator.cxx
@@ -346,16 +346,35 @@ void TModuleGenerator::WriteRegistrationSource(std::ostream &out,
       const std::string &fwdDeclString) const
 {
 
-   std::string fwdDeclStringRAW;
-   if ("nullptr" == fwdDeclString ||
-       "\"\"" == fwdDeclString) {
-      fwdDeclStringRAW = fwdDeclString;
+   std::string fwdDeclStringOS = fwdDeclString;
+#ifdef R__WIN32
+   // Visual sudio has a limitation of 2048 characters max in raw strings, so split
+   // the potentially huge DICTFWDDCLS raw string into multiple smaller ones
+   const std::string &from = "\n";
+   const std::string &to = "\n)DICTFWDDCLS\"\nR\"DICTFWDDCLS(";
+   size_t start_pos = 0;
+   while((start_pos = fwdDeclStringOS.find(from, start_pos)) != std::string::npos) {
+      if (fwdDeclStringOS.find(from, start_pos+1) == std::string::npos) // skip the last
+         break;
+      if ((fwdDeclStringOS.at(start_pos+1) == '}') ||
+          (fwdDeclStringOS.at(start_pos+1) == '\n') )
+         start_pos += 2;
+      else {
+         fwdDeclStringOS.replace(start_pos, from.length(), to);
+         start_pos += to.length(); // In case 'to' contains 'from', like replacing 'x' with 'yx'
+      }
    }
-   else{
+#endif
+   std::string fwdDeclStringRAW;
+   if ("nullptr" == fwdDeclStringOS ||
+       "\"\"" == fwdDeclStringOS) {
+      fwdDeclStringRAW = fwdDeclStringOS;
+   }
+   else {
       fwdDeclStringRAW = "R\"DICTFWDDCLS(\n";
       fwdDeclStringRAW += "#line 1 \"";
       fwdDeclStringRAW += fDictionaryName +" dictionary forward declarations' payload\"\n";
-      fwdDeclStringRAW += fwdDeclString;
+      fwdDeclStringRAW += fwdDeclStringOS;
       fwdDeclStringRAW += ")DICTFWDDCLS\"";
    }
 

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -706,8 +706,7 @@ void SetRootSys()
             // $ROOTSYS/bin/rootcling_stage1.exe
             removesubdirs = 2;
             gBuildingROOT = true;
-         }
-         else if (!strncmp(s + 1, "rootcling_stage1", 16)) {
+         } else if (!strncmp(s + 1, "rootcling_stage1", 16)) {
             // $ROOTSYS/core/rootcling_stage1/src/rootcling_stage1
             removesubdirs = 4;
             gBuildingROOT = true;
@@ -2921,7 +2920,7 @@ int  ExtractClassesListAndDeclLines(RScanner &scan,
 #ifdef WIN32
                   if (mangledName[0] == '\01')
                      mangledName.erase(0, 1);
-                  char* demangledTIName = TClassEdit::DemangleName(mangledName.c_str(), errDemangle);
+                  char *demangledTIName = TClassEdit::DemangleName(mangledName.c_str(), errDemangle);
                   if (!errDemangle && demangledTIName) {
                      static const char typeinfoNameFor[] = " `RTTI Type Descriptor'";
                      if (strstr(demangledTIName, typeinfoNameFor)) {
@@ -2948,7 +2947,7 @@ int  ExtractClassesListAndDeclLines(RScanner &scan,
                      } else {
 #ifdef WIN32
                         ROOT::TMetaUtils::Error("ExtractClassesListAndDeclLines",
-                                                "Demangled typeinfo name '%s' does not contains `RTTI Type Descriptor'\n",
+                                                "Demangled typeinfo name '%s' does not contain `RTTI Type Descriptor'\n",
                                                 demangledTIName);
 #else
                         ROOT::TMetaUtils::Error("ExtractClassesListAndDeclLines",
@@ -3867,15 +3866,11 @@ public:
 
    ~TRootClingCallbacks(){};
 
-   virtual void InclusionDirective(clang::SourceLocation /*HashLoc*/,
-                                   const clang::Token &/*IncludeTok*/,
-                                   llvm::StringRef FileName,
-                                   bool IsAngled,
-                                   clang::CharSourceRange /*FilenameRange*/,
-                                   const clang::FileEntry * /*File*/,
-                                   llvm::StringRef /*SearchPath*/,
-                                   llvm::StringRef /*RelativePath*/,
-                                   const clang::Module * /*Imported*/) {
+   virtual void InclusionDirective(clang::SourceLocation /*HashLoc*/, const clang::Token &/*IncludeTok*/,
+                                   llvm::StringRef FileName, bool IsAngled, clang::CharSourceRange /*FilenameRange*/,
+                                   const clang::FileEntry * /*File*/, llvm::StringRef /*SearchPath*/,
+                                   llvm::StringRef /*RelativePath*/, const clang::Module * /*Imported*/)
+   {
       if (isLocked) return;
       if (IsAngled) return;
       auto& PP = m_Interpreter->getCI()->getPreprocessor();

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -3866,7 +3866,7 @@ public:
 
    ~TRootClingCallbacks(){};
 
-   virtual void InclusionDirective(clang::SourceLocation /*HashLoc*/, const clang::Token &/*IncludeTok*/,
+   virtual void InclusionDirective(clang::SourceLocation /*HashLoc*/, const clang::Token & /*IncludeTok*/,
                                    llvm::StringRef FileName, bool IsAngled, clang::CharSourceRange /*FilenameRange*/,
                                    const clang::FileEntry * /*File*/, llvm::StringRef /*SearchPath*/,
                                    llvm::StringRef /*RelativePath*/, const clang::Module * /*Imported*/)


### PR DESCRIPTION
- In SelectionRules.cxx: #define fnmatch (Unix filename pattern matching) as PathMatchSpec (MS-DOS)
- In TModuleGenerator::WriteRegistrationSource, since Visual sudio has a limitation of 2048 characters max in raw strings, split the potentially huge DICTFWDDCLS raw string into multiple smaller ones
- In rootcling_impl.cxx, implement the Windows specific mangled/demangled checks, and convert several backslashs into forward slashs