### PR TITLE
Fix several issues on Windows in core/base

### DIFF
--- a/core/base/inc/RConfig.h
+++ b/core/base/inc/RConfig.h
@@ -36,10 +36,18 @@
 #define R__ANSISTREAM      /* ANSI C++ Standard Library conformant */
 #define R__SSTREAM         /* use sstream or strstream header */
 
-#if defined(__cplusplus) && (__cplusplus < 201103L)
-# error "ROOT requires support for C++11 or higher."
-# if defined(__GNUC__) || defined(__clang__)
-#  error "Pass `-std=c++11` as compiler argument."
+#if defined(_MSC_VER)
+# if (_MSC_VER < 1910)
+#  error "ROOT requires Visual Studio 2017 or higher."
+# else
+#  define R__NULLPTR
+# endif
+#else
+# if defined(__cplusplus) && (__cplusplus < 201103L)
+#  error "ROOT requires support for C++11 or higher."
+#  if defined(__GNUC__) || defined(__clang__)
+#   error "Pass `-std=c++11` as compiler argument."
+#  endif
 # endif
 #endif
 
@@ -372,7 +380,8 @@
 #   endif
 #   define R__BYTESWAP
 #   define R__ACCESS_IN_SYMBOL
-#   define thread_local static __declspec(thread)
+//#   define __attribute__(X)
+//#   define thread_local static __declspec(thread)
 #endif
 
 #ifdef __SC__

--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -31,6 +31,9 @@
 #include <string.h>
 #include <typeinfo>
 
+#if defined(R__WIN32)
+#define __attribute__(unused)
+#endif
 
 //---- forward declared class types --------------------------------------------
 
@@ -328,7 +331,7 @@ public: \
    namespace ROOT { \
       TGenericClassInfo *GenerateInitInstance(const name*); \
       namespace { \
-         static int _R__UNIQUE_(_NAME2_(R__dummyint,key)) __attribute__ ((unused)) = \
+         static int _R__UNIQUE_(_NAME2_(R__dummyint,key)) __attribute__((unused)) = \
             GenerateInitInstance((name*)0x0)->SetImplFile(__FILE__, __LINE__); \
          R__UseDummy(_R__UNIQUE_(_NAME2_(R__dummyint,key))); \
       } \

--- a/core/base/inc/TObject.h
+++ b/core/base/inc/TObject.h
@@ -209,6 +209,7 @@ public:
    ClassDef(TObject,1)  //Basic ROOT object
 };
 
+#ifndef R__WIN32
 ////////////////////////////////////////////////////////////////////////////////
 /// TObject constructor. It sets the two data words of TObject to their
 /// initial values. The unique ID is set to 0 and the status word is
@@ -250,6 +251,7 @@ inline TObject::TObject(const TObject &obj)
 
    if (R__unlikely(fgObjectStat)) TObject::AddToTObjectTable(this);
 }
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 /// TObject assignment operator.

--- a/core/base/inc/TObject.h
+++ b/core/base/inc/TObject.h
@@ -209,7 +209,6 @@ public:
    ClassDef(TObject,1)  //Basic ROOT object
 };
 
-#ifndef R__WIN32
 ////////////////////////////////////////////////////////////////////////////////
 /// TObject constructor. It sets the two data words of TObject to their
 /// initial values. The unique ID is set to 0 and the status word is
@@ -226,7 +225,11 @@ inline TObject::TObject() : fBits(kNotDeleted) // Need to leave FUniqueID unset
 
    fUniqueID = 0;
 
+#ifdef R__WIN32
+   if (R__unlikely(GetObjectStat())) TObject::AddToTObjectTable(this);
+#else
    if (R__unlikely(fgObjectStat)) TObject::AddToTObjectTable(this);
+#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -249,7 +252,11 @@ inline TObject::TObject(const TObject &obj)
    // Set only after used in above call
    fUniqueID = obj.fUniqueID; // when really unique don't copy
 
+#ifdef R__WIN32
+   if (R__unlikely(GetObjectStat())) TObject::AddToTObjectTable(this);
+#else
    if (R__unlikely(fgObjectStat)) TObject::AddToTObjectTable(this);
+#endif
 }
 #endif
 

--- a/core/base/inc/TObject.h
+++ b/core/base/inc/TObject.h
@@ -258,7 +258,6 @@ inline TObject::TObject(const TObject &obj)
    if (R__unlikely(fgObjectStat)) TObject::AddToTObjectTable(this);
 #endif
 }
-#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 /// TObject assignment operator.

--- a/core/base/inc/TQObject.h
+++ b/core/base/inc/TQObject.h
@@ -103,7 +103,8 @@ public:
       // Activate signal with variable argument list.
       // For internal use and for var arg EmitVA() in RQ_OBJECT.h.
 
-      if (fSignalsBlocked || AreAllSignalsBlocked()) return;
+      if (fSignalsBlocked || AreAllSignalsBlocked())
+         return;
 
       TList classSigLists;
       CollectClassSignalLists(classSigLists, IsA());

--- a/core/base/inc/TQObject.h
+++ b/core/base/inc/TQObject.h
@@ -103,7 +103,7 @@ public:
       // Activate signal with variable argument list.
       // For internal use and for var arg EmitVA() in RQ_OBJECT.h.
 
-      if (fSignalsBlocked || fgAllSignalsBlocked) return;
+      if (fSignalsBlocked || AreAllSignalsBlocked()) return;
 
       TList classSigLists;
       CollectClassSignalLists(classSigLists, IsA());

--- a/core/base/inc/TStorage.h
+++ b/core/base/inc/TStorage.h
@@ -113,7 +113,6 @@ R__INTENTIONALLY_UNINIT_BEGIN
 R__INTENTIONALLY_UNINIT_END
 }
 
-#ifndef WIN32
 inline size_t TStorage::GetMaxBlockSize() { return fgMaxBlockSize; }
 
 inline void TStorage::SetMaxBlockSize(size_t size) { fgMaxBlockSize = size; }
@@ -127,7 +126,5 @@ R__EXTERN FreeIfTMapFile_t *gFreeIfTMapFile;
 R__EXTERN void *gMmallocDesc;
 }
 }
-
-#endif
 
 #endif

--- a/core/base/inc/TString.h
+++ b/core/base/inc/TString.h
@@ -778,7 +778,7 @@ inline Bool_t operator!=(const TString &s1, const TSubString &s2)
 inline Bool_t operator!=(const char *s1, const TSubString &s2)
 { return !(s2 == s1); }
 
-
+#ifndef WIN32
 // To avoid ambiguities.
 inline Bool_t operator==(const char *s1, std::string_view &s2)
 {
@@ -789,6 +789,7 @@ inline Bool_t operator==(std::string_view &s1, const char *s2)
 {
   return s1 == std::string_view(s2);
 }
+#endif
 
 namespace llvm {
    class raw_ostream;

--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -54,50 +54,6 @@ Bool_t TObject::fgObjectStat = kTRUE;
 
 ClassImp(TObject);
 
-#ifdef R__WIN32
-
-////////////////////////////////////////////////////////////////////////////////
-/// TObject constructor. It sets the two data words of TObject to their
-/// initial values. The unique ID is set to 0 and the status word is
-/// set depending if the object is created on the stack or allocated
-/// on the heap. Depending on the ROOT environment variable "Root.MemStat"
-/// (see TEnv) the object is added to the global TObjectTable for
-/// bookkeeping.
-
-TObject::TObject() : fBits(kNotDeleted) // Need to leave FUniqueID unset
-{
-   // This will be reported by valgrind as uninitialized memory reads for
-   // object created on the stack, use $ROOTSYS/etc/valgrind-root.supp
-   if (TStorage::FilledByObjectAlloc(&fUniqueID)) fBits |= kIsOnHeap;
-
-   fUniqueID = 0;
-
-   if (R__unlikely(fgObjectStat)) TObject::AddToTObjectTable(this);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// TObject copy ctor.
-
-TObject::TObject(const TObject &obj)
-{
-   fBits = obj.fBits;
-
-   // This will be reported by valgrind as uninitialized memory reads for
-   // object created on the stack, use $ROOTSYS/etc/valgrind-root.supp
-   if (TStorage::FilledByObjectAlloc(&fUniqueID))
-      fBits |= kIsOnHeap;
-   else
-      fBits &= ~kIsOnHeap;
-
-   fBits &= ~kIsReferenced;
-   fBits &= ~kCanDelete;
-
-   // Set only after used in above call
-   fUniqueID = obj.fUniqueID; // when really unique don't copy
-
-   if (R__unlikely(fgObjectStat)) TObject::AddToTObjectTable(this);
-}
-#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy this to obj.

--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -54,6 +54,51 @@ Bool_t TObject::fgObjectStat = kTRUE;
 
 ClassImp(TObject);
 
+#ifdef R__WIN32
+
+////////////////////////////////////////////////////////////////////////////////
+/// TObject constructor. It sets the two data words of TObject to their
+/// initial values. The unique ID is set to 0 and the status word is
+/// set depending if the object is created on the stack or allocated
+/// on the heap. Depending on the ROOT environment variable "Root.MemStat"
+/// (see TEnv) the object is added to the global TObjectTable for
+/// bookkeeping.
+
+TObject::TObject() : fBits(kNotDeleted) // Need to leave FUniqueID unset
+{
+   // This will be reported by valgrind as uninitialized memory reads for
+   // object created on the stack, use $ROOTSYS/etc/valgrind-root.supp
+   if (TStorage::FilledByObjectAlloc(&fUniqueID)) fBits |= kIsOnHeap;
+
+   fUniqueID = 0;
+
+   if (R__unlikely(fgObjectStat)) TObject::AddToTObjectTable(this);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// TObject copy ctor.
+
+TObject::TObject(const TObject &obj)
+{
+   fBits = obj.fBits;
+
+   // This will be reported by valgrind as uninitialized memory reads for
+   // object created on the stack, use $ROOTSYS/etc/valgrind-root.supp
+   if (TStorage::FilledByObjectAlloc(&fUniqueID))
+      fBits |= kIsOnHeap;
+   else
+      fBits &= ~kIsOnHeap;
+
+   fBits &= ~kIsReferenced;
+   fBits &= ~kCanDelete;
+
+   // Set only after used in above call
+   fUniqueID = obj.fUniqueID; // when really unique don't copy
+
+   if (R__unlikely(fgObjectStat)) TObject::AddToTObjectTable(this);
+}
+#endif
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy this to obj.
 

--- a/core/base/src/TPRegexp.cxx
+++ b/core/base/src/TPRegexp.cxx
@@ -25,6 +25,9 @@ found at : http://perldoc.perl.org/perlre.html
 #include "TObjString.h"
 #include "TError.h"
 
+#ifdef R__WIN32
+#define PCRE_STATIC
+#endif
 #include <pcre.h>
 
 #include <vector>

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -98,7 +98,7 @@ FARPROC dlsym(void *library, const char *function_name)
    FARPROC address = NULL;
    unsigned int i;
    if (library == RTLD_DEFAULT) {
-      if (EnumProcessModules( ::GetCurrentProcess(), hMods, sizeof(hMods), &cbNeeded)) {
+      if (EnumProcessModules(::GetCurrentProcess(), hMods, sizeof(hMods), &cbNeeded)) {
          for (i = 0; i < (cbNeeded / sizeof(HMODULE)); i++) {
             address = ::GetProcAddress((HMODULE)hMods[i], function_name);
             if (address)

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -98,15 +98,15 @@ FARPROC dlsym(void *library, const char *function_name)
    FARPROC address = NULL;
    unsigned int i;
    if (library == RTLD_DEFAULT) {
-      if ( EnumProcessModules( ::GetCurrentProcess(), hMods, sizeof(hMods), &cbNeeded)) {
-         for ( i = 0; i < (cbNeeded / sizeof(HMODULE)); i++ ) {
-               address = ::GetProcAddress((HMODULE)hMods[i], function_name);
-            if (address) return address;
+      if (EnumProcessModules( ::GetCurrentProcess(), hMods, sizeof(hMods), &cbNeeded)) {
+         for (i = 0; i < (cbNeeded / sizeof(HMODULE)); i++) {
+            address = ::GetProcAddress((HMODULE)hMods[i], function_name);
+            if (address)
+               return address;
          }
       }
       return address;
-   }
-   else {
+   } else {
       return ::GetProcAddress((HMODULE)library, function_name);
    }
 }

--- a/core/base/src/TStorage.cxx
+++ b/core/base/src/TStorage.cxx
@@ -518,29 +518,3 @@ Bool_t TStorage::IsOnHeap(void *)
    return false;
 }
 
-#ifdef WIN32
-////////////////////////////////////////////////////////////////////////////////
-///return max block size
-
-size_t TStorage::GetMaxBlockSize()
-{
-   return fgMaxBlockSize;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///set max block size
-
-void TStorage::SetMaxBlockSize(size_t size)
-{
-   fgMaxBlockSize = size;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///return free hook
-
-FreeHookFun_t TStorage::GetFreeHook()
-{
-   return fgFreeHook;
-}
-
-#endif

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -1112,11 +1112,11 @@ Bool_t TSystem::ExpandFileName(TString &fname)
 
 Bool_t TSystem::ExpandFileName(const char *fname, char *xname, const int kBufSize)
 {
-   int         n, ier, iter, lx, ncopy;
-   char       *inp, *out, *x, *t, *buff;
+   int n, ier, iter, lx, ncopy;
+   char *inp, *out, *x, *t, *buff;
    const char *b, *c, *e;
    const char *p;
-   buff = new char[kBufSize*4];
+   buff = new char[kBufSize * 4];
 
    iter = 0; xname[0] = 0; inp = buff + kBufSize; out = inp + kBufSize;
    inp[-1] = ' '; inp[0] = 0; out[-1] = ' ';
@@ -1234,7 +1234,7 @@ again:
    ncopy = (lx >= kBufSize) ? kBufSize-1 : lx;
    xname[0] = 0; strncat(xname, out, ncopy);
 
-   delete [] buff;
+   delete[] buff;
 
    if (ier || ncopy != lx) {
       ::Error("TSystem::ExpandFileName", "input: %s, output: %s", fname, xname);

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -1113,10 +1113,11 @@ Bool_t TSystem::ExpandFileName(TString &fname)
 Bool_t TSystem::ExpandFileName(const char *fname, char *xname, const int kBufSize)
 {
    int         n, ier, iter, lx, ncopy;
-   char       *inp, *out, *x, *t, buff[kBufSize*4];
+   char       *inp, *out, *x, *t, *buff;
    const char *b, *c, *e;
    const char *p;
-   
+   buff = new char[kBufSize*4];
+
    iter = 0; xname[0] = 0; inp = buff + kBufSize; out = inp + kBufSize;
    inp[-1] = ' '; inp[0] = 0; out[-1] = ' ';
    c = fname + strspn(fname, " \t\f\r");
@@ -1232,6 +1233,8 @@ again:
    if (ier && iter < 3) { strlcpy(inp, out, kBufSize); goto again; }
    ncopy = (lx >= kBufSize) ? kBufSize-1 : lx;
    xname[0] = 0; strncat(xname, out, ncopy);
+
+   delete [] buff;
 
    if (ier || ncopy != lx) {
       ::Error("TSystem::ExpandFileName", "input: %s, output: %s", fname, xname);

--- a/core/base/src/TUUID.cxx
+++ b/core/base/src/TUUID.cxx
@@ -119,6 +119,10 @@ system clock catches up.
 #ifdef R__WIN32
 #include "Windows4Root.h"
 #include <Iphlpapi.h>
+#include <process.h>
+#define getpid() _getpid()
+#define srandom(seed) srand(seed)
+#define random() rand()
 #else
 #include <unistd.h>
 #include <sys/time.h>
@@ -152,17 +156,9 @@ TUUID::TUUID()
          system_clock::time_point today = system_clock::now();
          seed = (UInt_t)(system_clock::to_time_t ( today )) + ::getpid();
       }
-#ifdef R__WIN32
-      srand(seed);
-#else
       srandom(seed);
-#endif
       GetCurrentTime(time_last_ptr);
-#ifdef R__WIN32
-      clockseq = 1+(UShort_t)(65536*rand()/(RAND_MAX+1.0));
-#else
       clockseq = 1+(UShort_t)(65536*random()/(RAND_MAX+1.0));
-#endif
       firstTime = kFALSE;
    }
 


### PR DESCRIPTION
- Force using Visual Studio 2017 or higher
- Undefine unsupported __attribute__ keyword
- Move the TObject constructors from the header to the source (prevent a couple of static members to be externally unresolved)
- Use the AreAllSignalsBlocked() method instead of the static fgAllSignalsBlocked (prevent it to be externally unresolved)
- Comment out inline TString operator==() to fix the compiler error C2593: 'operator ==' is ambiguous (!!!)
- Implement a working dlsym function
- Remove some obsolete code