### PR TITLE
[WIP][TDF] Add a column by default which carries the entry number

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -1400,7 +1400,7 @@ public:
       // if this is a TInterface<TLoopManager> on which `Define` has been called, users
       // are calling `Report` on a chain of the form LoopManager->Define->Define->..., which
       // certainly does not contain named filters.
-      // The number 2 takes into account the implicit columns __entry and __slot
+      // The number 2 takes into account the implicit columns for entry and slot number
       if (std::is_same<Proxied, TLoopManager>::value && fValidCustomColumns.size() > 2)
          return;
 
@@ -1451,14 +1451,14 @@ private:
 
       // Entry number column
       auto entryColGen = [](unsigned int, ULong64_t entry) { return entry; };
-      const auto entryColName = "__entry";
+      const auto entryColName = "tdfentry_";
       using EntryCol_t = TDFDetail::TCustomColumn<decltype(entryColGen), TDFDetail::TCCHelperTypes::TSlotAndEntry>;
       lm->Book(std::make_shared<EntryCol_t>(entryColName, std::move(entryColGen), validColNames, lm.get()));
       fValidCustomColumns.emplace_back(entryColName);
 
       // Slot number column
       auto slotColGen = [](unsigned int slot) { return slot; };
-      const auto slotColName = "__slot";
+      const auto slotColName = "tdfslot_";
       using SlotCol_t = TDFDetail::TCustomColumn<decltype(slotColGen), TDFDetail::TCCHelperTypes::TSlot>;
       lm->Book(std::make_shared<SlotCol_t>(slotColName, std::move(slotColGen), validColNames, lm.get()));
       fValidCustomColumns.emplace_back(slotColName);
@@ -1704,7 +1704,6 @@ protected:
               const ColumnNames_t &validColumns, TDataSource *ds)
       : fProxiedPtr(proxied), fImplWeakPtr(impl), fValidCustomColumns(validColumns), fDataSource(ds)
    {
-      AddDefaultColumns();
    }
 
    /// Only enabled when building a TInterface<TLoopManager>

--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -1400,7 +1400,8 @@ public:
       // if this is a TInterface<TLoopManager> on which `Define` has been called, users
       // are calling `Report` on a chain of the form LoopManager->Define->Define->..., which
       // certainly does not contain named filters.
-      if (std::is_same<Proxied, TLoopManager>::value && !fValidCustomColumns.empty())
+      // The number 2 takes into account the implicit columns __entry and __slot
+      if (std::is_same<Proxied, TLoopManager>::value && fValidCustomColumns.size() > 2)
          return;
 
       auto df = GetDataFrameChecked();

--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -1684,8 +1684,8 @@ private:
       (void)expander1;
 
       // Add the defined columns
-      cachedTDF.fValidCustomColumns.assign(columnList.begin(), columnList.end());
-
+      auto &vc = cachedTDF.fValidCustomColumns;
+      vc.insert(vc.end(), columnList.begin(), columnList.end());
       return cachedTDF;
    }
 

--- a/tree/treeplayer/src/TDFUtils.cxx
+++ b/tree/treeplayer/src/TDFUtils.cxx
@@ -240,7 +240,7 @@ ColumnNames_t FindUnknownColumns(const ColumnNames_t &requiredCols, TTree *tree,
 
 bool IsInternalColumn(std::string_view colName)
 {
-   return colName.find("__") == 0;
+   return 0 == colName.find("tdf") && '_' == colName.back();
 }
 
 } // end NS TDF

--- a/tree/treeplayer/src/TDFUtils.cxx
+++ b/tree/treeplayer/src/TDFUtils.cxx
@@ -240,7 +240,7 @@ ColumnNames_t FindUnknownColumns(const ColumnNames_t &requiredCols, TTree *tree,
 
 bool IsInternalColumn(std::string_view colName)
 {
-   return colName.find("__TDF_") == 0;
+   return colName.find("__") == 0;
 }
 
 } // end NS TDF

--- a/tree/treeplayer/test/dataframe/dataframe_cache.py
+++ b/tree/treeplayer/test/dataframe/dataframe_cache.py
@@ -49,5 +49,17 @@ class Cache(unittest.TestCase):
            for i in xrange(4):
                self.assertEqual(float(i), e[i]);
 
+    def test_EntryAndSlotColumns(self):
+       tdf = TDataFrame(8)
+       c = tdf.Filter("tdfentry_ % 2 == 0").Define("myEntry","tdfentry_").Cache()
+       ds_entries = c.Take('UInt64_t')('tdfentry_')
+       ref_ds_entries = [0,1,2,3]
+       for e, eref in zip (ds_entries, ref_ds_entries):
+           self.assertEqual(e, eref)
+       old_entries = c.Take('UInt64_t')('tdfentry_')
+       ref_old_entries = [0,2,4,6]
+       for e, eref in zip (old_entries, ref_old_entries):
+           self.assertEqual(e, eref)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tree/treeplayer/test/dataframe/dataframe_interface.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_interface.cxx
@@ -28,7 +28,7 @@ TEST(TDataFrameInterface, CreateFromContainer)
 
 TEST(TDataFrameInterface, CreateFromInitList)
 {
-   TDataFrame tdf("t", {"f1","f2"});
+   TDataFrame tdf("t", {"f1", "f2"});
 }
 
 TEST(TDataFrameInterface, CreateFromNullTDirectory)
@@ -146,4 +146,16 @@ TEST(TDataFrameInterface, GetColumnNamesFromSource)
    EXPECT_STREQ("b", names[0].c_str());
    EXPECT_STREQ("col0", names[1].c_str());
    EXPECT_EQ(2U, names.size());
+}
+
+TEST(TDataFrameInterface, DefaultColumns)
+{
+   TDataFrame tdf(8);
+   ULong64_t i(0ULL);
+   auto checkSlotAndEntries = [&i](unsigned int slot, ULong64_t entry) {
+      EXPECT_EQ(entry, i);
+      EXPECT_EQ(slot, 0U);
+      i++;
+   };
+   tdf.Foreach(checkSlotAndEntries, {"__slot", "__entry"});
 }

--- a/tree/treeplayer/test/dataframe/dataframe_interface.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_interface.cxx
@@ -119,7 +119,7 @@ TEST(TDataFrameInterface, GetColumnNamesFromScratch)
 {
    TDataFrame f(1);
    auto dummyGen = []() { return 1; };
-   auto names = f.Define("a", dummyGen).Define("b", dummyGen).Define("__TDF_Dummy", dummyGen).GetColumnNames();
+   auto names = f.Define("a", dummyGen).Define("b", dummyGen).Define("tdfDummy_", dummyGen).GetColumnNames();
    EXPECT_STREQ("a", names[0].c_str());
    EXPECT_STREQ("b", names[1].c_str());
    EXPECT_EQ(2U, names.size());
@@ -157,5 +157,15 @@ TEST(TDataFrameInterface, DefaultColumns)
       EXPECT_EQ(slot, 0U);
       i++;
    };
-   tdf.Foreach(checkSlotAndEntries, {"__slot", "__entry"});
+   tdf.Foreach(checkSlotAndEntries, {"tdfslot_", "tdfentry_"});
 }
+
+TEST(TDataFrameInterface, JitDefaultColumns)
+{
+   TDataFrame tdf(8);
+   auto f = tdf.Filter("tdfslot_ + tdfentry_ == 3");
+   auto maxEntry = f.Max("tdfentry_");
+   auto minEntry = f.Min("tdfentry_");
+   EXPECT_EQ(*maxEntry, *minEntry);
+}
+

--- a/tree/treeplayer/test/dataframe/dataframe_interface.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_interface.cxx
@@ -168,4 +168,3 @@ TEST(TDataFrameInterface, JitDefaultColumns)
    auto minEntry = f.Min("tdfentry_");
    EXPECT_EQ(*maxEntry, *minEntry);
 }
-


### PR DESCRIPTION
the column is called __TDF_iEvent__ and is of type ULong64_t.

This is how it works:
```
root [0] ROOT::Experimental::TDataFrame d(10)
(ROOT::Experimental::TDataFrame &) A data frame that will create 10 entries

root [1] d.Foreach([](ULong64_t e){cout << e << endl;}, {"__TDF_iEvent__"})
0
1
2
3
4
5
6
7
8
9
```