### PR TITLE
Fix the Visual Studio 2017 directory location (quick and dirty hack)

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -212,8 +212,8 @@ namespace {
                                         opts.NoBuiltinInc ? nullptr : &UnivSDK,
                                         Verbose)) {
         if (!opts.NoCXXInc) {
-          // The Visual Studio 2017 path is very different than the previous versions
-          // (see also GetVisualStudioDirs() in PlatformWin.cpp)
+          // The Visual Studio 2017 path is very different than the previous
+          // versions (see also GetVisualStudioDirs() in PlatformWin.cpp)
           const std::string VSIncl = VSDir + "\\include";
           if (Verbose)
             cling::log() << "Adding VisualStudio SDK: '" << VSIncl << "'\n";

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -212,7 +212,9 @@ namespace {
                                         opts.NoBuiltinInc ? nullptr : &UnivSDK,
                                         Verbose)) {
         if (!opts.NoCXXInc) {
-          const std::string VSIncl = VSDir + "\\VC\\include";
+          // The Visual Studio 2017 path is very different than the previous versions
+          // (see also GetVisualStudioDirs() in PlatformWin.cpp)
+          const std::string VSIncl = VSDir + "\\include";
           if (Verbose)
             cling::log() << "Adding VisualStudio SDK: '" << VSIncl << "'\n";
           sArguments.addArgument("-I", std::move(VSIncl));
@@ -224,6 +226,7 @@ namespace {
               cling::log() << "Adding Windows SDK: '" << WinSDK << "'\n";
             sArguments.addArgument("-I", std::move(WinSDK));
           } else {
+            // Since Visual Studio 2017, this is not valid anymore...
             VSDir.append("\\VC\\PlatformSDK\\Include");
             if (Verbose)
               cling::log() << "Adding Platform SDK: '" << VSDir << "'\n";

--- a/interpreter/cling/lib/Utils/PlatformWin.cpp
+++ b/interpreter/cling/lib/Utils/PlatformWin.cpp
@@ -416,6 +416,16 @@ bool GetVisualStudioDirs(std::string& Path, std::string* WinSDK,
 
   const char* Msg = Verbose ? "compiled" : nullptr;
 
+  // The Visual Studio 2017 path is very different than the previous versions,
+  // and even the registry entries are different, so for now let's try the
+  // trivial way first (using the 'VCToolsInstallDir' environment variable)
+  if (const char* VCToolsInstall = ::getenv("VCToolsInstallDir")) {
+    trimString(VCToolsInstall, "\\DUMMY", Path);
+    if (Verbose)
+      cling::errs() << "Using VCToolsInstallDir '" << VCToolsInstall << "'\n";
+    return true;
+  }
+
   // Try for the version compiled with first
   const int VSVersion = GetVisualStudioVersionCompiledWith();
   if (getVisualStudioVer(VSVersion, Path, Msg)) {


### PR DESCRIPTION
The Visual Studio 2017 path is very different than the previous versions, and even the registry entries are completely different, so for now let's try the trivial way first (using the %VCToolsInstallDir% environment variable)
(to be reviewed)
