### PR TITLE
[TDF] Revert "Also look for valid column names in friend trees"

### DIFF
--- a/tree/treeplayer/src/TDFUtils.cxx
+++ b/tree/treeplayer/src/TDFUtils.cxx
@@ -239,7 +239,7 @@ ColumnNames_t FindUnknownColumns(const ColumnNames_t &requiredCols, TTree *tree,
       if (friends) {
          bool isFriendBranch = false;
          for (auto friendTree : *friends) {
-            const auto friendBranch = static_cast<TFriendElement *>(friendTree)->GetTree()->GetBranch(column.c_str());
+            const auto friendBranch = static_cast<TFriendElement*>(friendTree)->GetTree()->GetBranch(column.c_str());
             if (friendBranch != nullptr) {
                isFriendBranch = true;
                break;

--- a/tree/treeplayer/src/TDFUtils.cxx
+++ b/tree/treeplayer/src/TDFUtils.cxx
@@ -9,13 +9,11 @@
  *************************************************************************/
 
 #include "RConfigure.h"      // R__USE_IMT
-#include "ROOT/RMakeUnique.hxx" // std::make_unique
 #include "ROOT/TDFNodes.hxx" // ColumnName2ColumnTypeName -> TCustomColumnBase, FindUnknownColumns -> TLoopManager
 #include "ROOT/TDFUtils.hxx"
 #include "TBranch.h"
 #include "TBranchElement.h"
 #include "TClassRef.h"
-#include "TFriendElement.h"
 #include "TROOT.h" // IsImplicitMTEnabled, GetImplicitMTPoolSize
 
 #include <stdexcept>
@@ -224,7 +222,6 @@ ColumnNames_t FindUnknownColumns(const ColumnNames_t &requiredCols, TTree *tree,
                                  const ColumnNames_t &dataSourceColumns)
 {
    ColumnNames_t unknownColumns;
-   const auto friends = tree ? tree->GetListOfFriends() : static_cast<TList*>(nullptr);
    for (auto &column : requiredCols) {
       const auto isTreeBranch = (tree != nullptr && tree->GetBranch(column.c_str()) != nullptr);
       if (isTreeBranch)
@@ -236,19 +233,6 @@ ColumnNames_t FindUnknownColumns(const ColumnNames_t &requiredCols, TTree *tree,
          std::find(dataSourceColumns.begin(), dataSourceColumns.end(), column) != dataSourceColumns.end();
       if (isDataSourceColumn)
          continue;
-      if (friends) {
-         bool isFriendBranch = false;
-         for (auto friendTree : *friends) {
-            const auto friendBranch = static_cast<TFriendElement*>(friendTree)->GetTree()->GetBranch(column.c_str());
-            if (friendBranch != nullptr) {
-               isFriendBranch = true;
-               break;
-            }
-         }
-         if (isFriendBranch)
-            continue;
-      }
-
       unknownColumns.emplace_back(column);
    }
    return unknownColumns;

--- a/tree/treeplayer/test/dataframe/dataframe_friends.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_friends.cxx
@@ -106,3 +106,16 @@ TEST_F(TDFAndFriends, FriendArrayByPointer)
    };
    d.Foreach(checkArr, {"arr"});
 }
+
+TEST_F(TDFAndFriends, QualifiedBranchName)
+{
+   TFile f1(kFile1);
+   TTree *t1 = static_cast<TTree *>(f1.Get("t"));
+   t1->AddFriend("t2", kFile2);
+   TDataFrame d(*t1);
+   auto x = d.Min<int>("x");
+   EXPECT_EQ(*x, 1);
+   auto t = d.Take<int>("t2.y");
+   for (auto v : t)
+      EXPECT_EQ(v, 2);
+}


### PR DESCRIPTION
Turns out this change was useless. Recent gtests (that absolutely need to be augmented) should show that we can run fine without this extra code. 