### PR TITLE
Fix compilation error on Windows

### DIFF
--- a/graf3d/eve/inc/TEveVector.h
+++ b/graf3d/eve/inc/TEveVector.h
@@ -37,7 +37,17 @@ public:
 
    void Dump() const;
 
+#ifdef R__WIN32
    const TT* Arr() const {
+      if (offsetof(TEveVectorT, fZ) == offsetof(TEveVectorT, fX) + 2*sizeof(TT))
+         Error("TEveVectorT", "Subsequent nembers cannot be accessed as array!");
+      return &fX; }
+   TT* Arr() {
+      if (offsetof(TEveVectorT, fZ) == offsetof(TEveVectorT, fX) + 2*sizeof(TT))
+         Error("TEveVectorT", "Subsequent nembers cannot be accessed as array!");
+      return &fX; }
+#else
+      const TT* Arr() const {
       static_assert(offsetof(TEveVectorT, fZ) == offsetof(TEveVectorT, fX) + 2*sizeof(TT),
                     "Subsequent nembers cannot be accessed as array!");
       return &fX; }
@@ -45,7 +55,8 @@ public:
       static_assert(offsetof(TEveVectorT, fZ) == offsetof(TEveVectorT, fX) + 2*sizeof(TT),
                     "Subsequent nembers cannot be accessed as array!");
       return &fX; }
-
+#endif
+      
    operator const TT*() const { return Arr(); }
    operator       TT*()       { return Arr(); }
 

--- a/graf3d/eve/inc/TEveVector.h
+++ b/graf3d/eve/inc/TEveVector.h
@@ -38,26 +38,26 @@ public:
    void Dump() const;
 
 #ifdef R__WIN32
-   const TT* Arr() const
+   const TT *Arr() const
    {
       if (offsetof(TEveVectorT, fZ) == offsetof(TEveVectorT, fX) + 2 * sizeof(TT))
          Error("TEveVectorT", "Subsequent nembers cannot be accessed as array!");
       return &fX;
    }
-   TT* Arr()
+   TT *Arr()
    {
       if (offsetof(TEveVectorT, fZ) == offsetof(TEveVectorT, fX) + 2 * sizeof(TT))
          Error("TEveVectorT", "Subsequent nembers cannot be accessed as array!");
       return &fX;
    }
 #else
-   const TT* Arr() const
+   const TT *Arr() const
    {
       static_assert(offsetof(TEveVectorT, fZ) == offsetof(TEveVectorT, fX) + 2 * sizeof(TT),
                     "Subsequent nembers cannot be accessed as array!");
       return &fX;
    }
-   TT* Arr()
+   TT *Arr()
    {
       static_assert(offsetof(TEveVectorT, fZ) == offsetof(TEveVectorT, fX) + 2 * sizeof(TT),
                     "Subsequent nembers cannot be accessed as array!");

--- a/graf3d/eve/inc/TEveVector.h
+++ b/graf3d/eve/inc/TEveVector.h
@@ -38,25 +38,33 @@ public:
    void Dump() const;
 
 #ifdef R__WIN32
-   const TT* Arr() const {
-      if (offsetof(TEveVectorT, fZ) == offsetof(TEveVectorT, fX) + 2*sizeof(TT))
+   const TT* Arr() const
+   {
+      if (offsetof(TEveVectorT, fZ) == offsetof(TEveVectorT, fX) + 2 * sizeof(TT))
          Error("TEveVectorT", "Subsequent nembers cannot be accessed as array!");
-      return &fX; }
-   TT* Arr() {
-      if (offsetof(TEveVectorT, fZ) == offsetof(TEveVectorT, fX) + 2*sizeof(TT))
+      return &fX;
+   }
+   TT* Arr()
+   {
+      if (offsetof(TEveVectorT, fZ) == offsetof(TEveVectorT, fX) + 2 * sizeof(TT))
          Error("TEveVectorT", "Subsequent nembers cannot be accessed as array!");
-      return &fX; }
+      return &fX;
+   }
 #else
-      const TT* Arr() const {
-      static_assert(offsetof(TEveVectorT, fZ) == offsetof(TEveVectorT, fX) + 2*sizeof(TT),
+   const TT* Arr() const
+   {
+      static_assert(offsetof(TEveVectorT, fZ) == offsetof(TEveVectorT, fX) + 2 * sizeof(TT),
                     "Subsequent nembers cannot be accessed as array!");
-      return &fX; }
-   TT* Arr()             {
-      static_assert(offsetof(TEveVectorT, fZ) == offsetof(TEveVectorT, fX) + 2*sizeof(TT),
+      return &fX;
+   }
+   TT* Arr()
+   {
+      static_assert(offsetof(TEveVectorT, fZ) == offsetof(TEveVectorT, fX) + 2 * sizeof(TT),
                     "Subsequent nembers cannot be accessed as array!");
-      return &fX; }
+      return &fX;
+   }
 #endif
-      
+
    operator const TT*() const { return Arr(); }
    operator       TT*()       { return Arr(); }
 


### PR DESCRIPTION
This fixes the following error:
```
error G34C21FBE: static_assert expression is not an integral constant expression
        static_assert(offsetof(TEveVectorT, fZ) == offsetof(TEveVectorT, fX) + 2*sizeof(TT),
                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  C:\Program Files (x86)\Windows Kits\10\Include\10.0.15063.0\ucrt\stddef.h:42:31: note: expanded from macro 'offsetof'
          #define offsetof(s,m) ((size_t)&reinterpret_cast<char const volatile&>((((s*)0)->m)))
                                ^
  TEveProjections.h:174:71: note: in instantiation of member function 'TEveVectorT<float>::Arr' requested here
     virtual Float_t*    GetProjectedCenter() { return fProjectedCenter.Arr(); }
                                                                        ^
  TEveVector.h:55:21: note: cast that performs the conversions of a reinterpret_cast is not allowed in a constant expression
        static_assert(offsetof(TEveVectorT, fZ) == offsetof(TEveVectorT, fX) + 2*sizeof(TT),
                      ^
  C:\Program Files (x86)\Windows Kits\10\Include\10.0.15063.0\ucrt\stddef.h:42:32: note: expanded from macro 'offsetof'
          #define offsetof(s,m) ((size_t)&reinterpret_cast<char const volatile&>((((s*)0)->m)))
                                 ^
```