### PR TITLE
Add cling binary to the list of target

### DIFF
--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -65,7 +65,7 @@ set(LLVM_TARGETS_TO_BUILD ${ROOT_CLING_TARGET} CACHE STRING "Semicolon-separated
 
 if(clingtest)
   message("-- cling test suite enabled: llvm / clang symbols in libCling will be visible!")
-  set(CLING_INCLUDE_TESTS ON CACHE BOOL "")
+  set(CLING_INCLUDE_TESTS ON CACHE BOOL "" FORCE)
 else()
   #---Build LLVM/Clang with symbol visibility=hidden--------------------------------------------------
   ROOT_ADD_CXX_FLAG(CMAKE_CXX_FLAGS -fvisibility=hidden)

--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -107,8 +107,6 @@ else()
 endif()
 set(CMAKE_BUILD_TYPE ${LLVM_BUILD_TYPE})
 set(BUILD_SHARED_LIBS "NO")
-#--- Do not build cling as part of llvm.
-set(LLVM_NOCLING "YES")
 
 set(CLANG_ENABLE_STATIC_ANALYZER OFF CACHE BOOL "")
 set(CLANG_ENABLE_ARCMT OFF CACHE BOOL "")

--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -66,6 +66,7 @@ set(LLVM_TARGETS_TO_BUILD ${ROOT_CLING_TARGET} CACHE STRING "Semicolon-separated
 if(clingtest)
   message("-- cling test suite enabled: llvm / clang symbols in libCling will be visible!")
   set(CLING_INCLUDE_TESTS ON CACHE BOOL "" FORCE)
+  ROOT_ADD_TEST(clingtest-check-cling COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target check-cling)
 else()
   #---Build LLVM/Clang with symbol visibility=hidden--------------------------------------------------
   ROOT_ADD_CXX_FLAG(CMAKE_CXX_FLAGS -fvisibility=hidden)


### PR DESCRIPTION
This PR fixes -Dclingtest=On to add target cling and check-cling to ROOT. This in turn will build the cling binary and run its test suite.