### PR TITLE
ROOT Cocoa: fix rendering into bitmaps on high-dpi display.

### DIFF
--- a/graf2d/cocoa/inc/QuartzPixmap.h
+++ b/graf2d/cocoa/inc/QuartzPixmap.h
@@ -40,7 +40,7 @@
    std::vector<unsigned char> fData;
    ROOT::MacOSX::Util::CFScopeGuard<CGContextRef> fContext;
 
-   unsigned       fScaleFactor;
+   CGFloat       fScaleFactor;
 }
 
 - (id) initWithW : (unsigned) width H : (unsigned) height scaleFactor : (CGFloat) scaleFactor;
@@ -55,6 +55,7 @@
 
 - (BOOL) fIsPixmap;
 - (BOOL) fIsOpenGLWidget;
+- (CGFloat) fScaleFactor;
 
 @property (nonatomic, readonly) CGContextRef fContext;
 

--- a/graf2d/cocoa/inc/QuartzWindow.h
+++ b/graf2d/cocoa/inc/QuartzWindow.h
@@ -71,6 +71,7 @@
 
 - (BOOL) fIsPixmap;
 - (BOOL) fIsOpenGLWidget;
+- (CGFloat) fScaleFactor;
 
 //Geometry.
 - (int) fX;
@@ -193,6 +194,7 @@
 
 - (BOOL) fIsPixmap;
 - (BOOL) fIsOpenGLWidget;
+- (CGFloat) fScaleFactor;
 
 @property (nonatomic, assign) CGContextRef fContext;
 

--- a/graf2d/cocoa/inc/X11Drawable.h
+++ b/graf2d/cocoa/inc/X11Drawable.h
@@ -41,6 +41,7 @@
 //to check in TGCocoa, what's the object.
 - (BOOL) fIsPixmap;
 - (BOOL) fIsOpenGLWidget;
+- (CGFloat) fScaleFactor;
 
 //Either [[NSGraphicsContext currentContext] graphicsPort]
 //or bitmap context (pixmap).

--- a/graf2d/cocoa/src/QuartzPixmap.mm
+++ b/graf2d/cocoa/src/QuartzPixmap.mm
@@ -55,7 +55,7 @@ namespace Quartz = ROOT::Quartz;
    assert(width > 0 && "resizeW:H:, Pixmap width must be positive");
    assert(height > 0 && "resizeW:H:, Pixmap height must be positive");
 
-   fScaleFactor = unsigned(scaleFactor + 0.5);
+   fScaleFactor = scaleFactor;
 
    std::vector<unsigned char> memory;
 
@@ -89,7 +89,6 @@ namespace Quartz = ROOT::Quartz;
       CGContextScaleCTM(ctx.Get(), fScaleFactor, fScaleFactor);
 
    fContext.Reset(ctx.Release());
-
 
    //sizes, data.
    fWidth = width;
@@ -156,6 +155,12 @@ namespace Quartz = ROOT::Quartz;
 - (BOOL) fIsOpenGLWidget
 {
    return NO;
+}
+
+//______________________________________________________________________________
+- (CGFloat) fScaleFactor
+{
+   return fScaleFactor;
 }
 
 //______________________________________________________________________________
@@ -359,7 +364,7 @@ namespace Quartz = ROOT::Quartz;
    if (fScaleFactor > 1) {
       //Ooops, and what should I do now???
       const unsigned scaledW = fWidth * fScaleFactor;
-      unsigned char *dst = data + y * fScaleFactor * scaledW * 4 + x * fScaleFactor * 4;
+      unsigned char *dst = data + unsigned(y * fScaleFactor * scaledW * 4) + unsigned(x * fScaleFactor * 4);
 
       for (unsigned i = 0; i < 2; ++i, dst += 4) {
          dst[0] = rgb[0];
@@ -732,6 +737,13 @@ namespace Quartz = ROOT::Quartz;
 - (BOOL) fIsOpenGLWidget
 {
    return NO;
+}
+
+//______________________________________________________________________________
+- (CGFloat) fScaleFactor
+{
+   // TODO: this is to be understood yet ...
+   return 1.;
 }
 
 //______________________________________________________________________________

--- a/graf2d/cocoa/src/QuartzWindow.mm
+++ b/graf2d/cocoa/src/QuartzWindow.mm
@@ -1320,6 +1320,14 @@ void print_mask_info(ULong_t mask)
 }
 
 //______________________________________________________________________________
+- (CGFloat) fScaleFactor
+{
+   if (!self.screen)
+      return 1.;
+   return self.screen.backingScaleFactor;
+}
+
+//______________________________________________________________________________
 - (int) fX
 {
    return X11::GlobalXCocoaToROOT(self.frame.origin.x);
@@ -1929,6 +1937,12 @@ void print_mask_info(ULong_t mask)
 - (BOOL) fIsOpenGLWidget
 {
    return NO;
+}
+
+//______________________________________________________________________________
+- (CGFloat) fScaleFactor
+{
+   return self.fQuartzWindow.fScaleFactor;
 }
 
 //______________________________________________________________________________


### PR DESCRIPTION
From Timur:

When TGQuartz was developed, retina macs did not exist yet and Cocoa
did not provide any API to access scaling-related information.
After they have introduced this API and released retina MacBooks, our GUI
rendering was just fine and worked out of box, our 'pixmap-based' graphics
was fixed by multiplying pixmaps' geometry (by scaling factor) and also setting
the corresponding scaling CTM on the bitmap context. It appears, all these
years we did not know how expensive this scaling transformation is.
As was noticed recently, even a relatively simple poly-line consisting
of 25K segments takes _forever_ to draw - apparently Quartz is working
hard doing hell knows what under the hood (disabling anti-aliasing does not change
anything, for example).

This patch is a possible fix, the proper solution would require a serious redesign
in many places (starting from TVirtualX and TCanvas) - for now we simply cancel
the scaling transformation when rendering potentially complex geometry  and scale
coordinates manually instead.

A macro reproducing this problem on retina display would be:

{
   int n = 5000;
   double xx[n];
   double yy[n];
   TRandom r;
   for (int i=0; i<n; i++) {
      xx[i] = r.Gaus(-1,0.5);
      yy[i] = r.Gaus(1,1.5);
   }
   TGraph *g = new TGraph(n, xx,yy);
   g->Draw("al");
}