### PR TITLE
Add Cancel function in TTaskGroup.

### DIFF
--- a/core/imt/inc/ROOT/TTaskGroup.hxx
+++ b/core/imt/inc/ROOT/TTaskGroup.hxx
@@ -39,8 +39,8 @@ public:
    TTaskGroup &operator=(TTaskGroup &&other);
    ~TTaskGroup();
 
+   void Cancel();
    void Run(const std::function<void(void)> &closure);
-
    void Wait();
 };
 }

--- a/core/imt/src/TTaskGroup.cxx
+++ b/core/imt/src/TTaskGroup.cxx
@@ -71,6 +71,17 @@ TTaskGroup::~TTaskGroup()
 }
 
 /////////////////////////////////////////////////////////////////////////////
+/// Cancel all submitted tasks immediately.
+void TTaskGroup::Cancel()
+{
+#ifdef R__USE_IMT
+   fCanRun = false;
+   ((tbb::task_group *)fTaskContainer)->cancel();
+   fCanRun = true;
+#endif
+}
+
+/////////////////////////////////////////////////////////////////////////////
 /// Add to the group an item of work which will be ran asynchronously.
 /// Adding many small items of work to the TTaskGroup is not efficient,
 /// unless they run for long enough. If the work to be done is little, look


### PR DESCRIPTION
This PR is related to #1010 

I could be more efficient to cancel the tasks immediately than wait for unnecessary tasks to be finished. Especially when cache is invalid, unzipping task has to continue running return function.