### PR TITLE
TEfficiency::SetUseWeightedEvents(): Do not assume Sumw2() was called…

### DIFF
--- a/hist/hist/src/TEfficiency.cxx
+++ b/hist/hist/src/TEfficiency.cxx
@@ -3589,10 +3589,10 @@ void TEfficiency::SetUseWeightedEvents(bool on)
 
    SetBit(kUseWeights,on);
 
-   // no need to set sumw2 should be already there
-   if (on) assert(fTotalHistogram->GetSumw2N() > 0 && fPassedHistogram->GetSumw2N() > 0 );
-   //fTotalHistogram->Sumw2(on);
-   //fPassedHistogram->Sumw2(on);
+   if (on && fTotalHistogram->GetSumw2N() == 0)
+      fTotalHistogram->Sumw2();
+   if (on && fPassedHistogram->GetSumw2N() == 0)
+      fPassedHistogram->Sumw2();
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
… on histograms.

In Debug and RelWithDebInfo builds (when assertions are active) the following
code caused an assertion to fire:

root [0] TEfficiency* eff = new TEfficiency;
root [1] eff->SetUseWeightedEvents();
Info in <TROOT::TEfficiency::SetUseWeightedEvents>: Histograms are filled with weights
root.exe: ../hist/hist/src/TEfficiency.cxx:3593: void TEfficiency::SetUseWeightedEvents(bool): Assertion `fTotalHistogram->GetSumw2N() > 0 && fPassedHistogram->GetSumw2N() > 0' failed

This fixes ROOT-9058.