### PR TITLE
Add Geant4 formulas for calculation of RadLen and IntLen

### DIFF
--- a/geom/geom/CMakeLists.txt
+++ b/geom/geom/CMakeLists.txt
@@ -13,7 +13,8 @@ set(headers1 TGeoAtt.h TGeoStateInfo.h TGeoBoolNode.h
              TGeoScaledShape.h TVirtualGeoPainter.h TVirtualGeoTrack.h
              TVirtualGeoConverter.h TGeoPolygon.h TGeoXtru.h TGeoPhysicalNode.h
              TGeoHelix.h TGeoParaboloid.h TGeoElement.h TGeoHalfSpace.h
-             TGeoBuilder.h TGeoNavigator.h)
+             TGeoBuilder.h TGeoNavigator.h TGeoPhysicalConstants.h
+             TGeoSystemOfUnits.h)
 set(headers2 TGeoPatternFinder.h TGeoCache.h TVirtualMagField.h
              TGeoUniformMagField.h TGeoGlobalMagField.h TGeoBranchArray.h
              TGeoExtension.h TGeoParallelWorld.h)

--- a/geom/geom/inc/TGeoElement.h
+++ b/geom/geom/inc/TGeoElement.h
@@ -52,6 +52,11 @@ protected:
 private:
   TGeoElement(const TGeoElement &other);
   TGeoElement &operator=(const TGeoElement &other);
+  void                      ComputeDerivedQuantities(); // Calculate properties for an atomic number
+  void                      ComputeCoulombFactor(); // Compute the Coulomb correction factor
+  void                      ComputeLradTsaiFactor(); // Compute the Tsai formula for the radiation length
+  Double_t                  fCoulomb;    // Coulomb correction factor
+  Double_t                  fRadTsai;    // Tsai formula for the radiation length
 
 public:
    // constructors
@@ -81,7 +86,10 @@ public:
    void                     SetDefined(Bool_t flag=kTRUE) {TObject::SetBit(kElemDefined,flag);}
    void                     SetUsed(Bool_t flag=kTRUE) {TObject::SetBit(kElemUsed,flag);}
    static TGeoElementTable *GetElementTable();
-
+   // Coulomb correction factor
+   inline Double_t          GetfCoulomb() const {return fCoulomb;}
+   // Tsai formula for the radiation length
+   inline Double_t          GetfRadTsai() const {return fRadTsai;}
 
    ClassDef(TGeoElement, 2)              // base element class
 };

--- a/geom/geom/inc/TGeoMaterial.h
+++ b/geom/geom/inc/TGeoMaterial.h
@@ -145,6 +145,7 @@ protected :
    Double_t                *fAmixture;   // [fNelements] array of A of the elements
    Double_t                *fWeights;    // [fNelements] array of relative proportions by mass
    Int_t                   *fNatoms;     // [fNelements] array of numbers of atoms
+   Double_t                *VecNbOfAtomsPerVolume; //[fNelements] array of numbers of atoms per unit volume
    TObjArray               *fElements;   // array of elements composing the mixture
 // methods
    TGeoMixture(const TGeoMixture&); // Not implemented
@@ -187,6 +188,9 @@ public:
    virtual void             SetA(Double_t a) {fA = a;}
    virtual void             SetZ(Double_t z) {fZ = z;}
    virtual void             SetDensity(Double_t density) {fDensity = density; AverageProperties();}
+   void                     ComputeDerivedQuantities();
+   void                     ComputeRadiationLength();
+   void                     ComputeNuclearInterLength();
 
    ClassDef(TGeoMixture, 2)              // material mixtures
 };

--- a/geom/geom/inc/TGeoPhysicalConstants.h
+++ b/geom/geom/inc/TGeoPhysicalConstants.h
@@ -1,0 +1,133 @@
+// -*- C++ -*-
+// $Id: PhysicalConstants.h,v 1.4 2010/06/16 17:12:28 garren Exp $
+// ----------------------------------------------------------------------
+// HEP coherent Physical Constants
+//
+// This file has been provided by Geant4 (simulation toolkit for HEP).
+//
+// The basic units are :
+//  		millimeter  
+// 		nanosecond  
+// 		Mega electron Volt  
+// 		positon charge 
+// 		degree Kelvin
+//              amount of substance (mole)
+//              luminous intensity (candela)
+// 		radian  
+//              steradian 
+//
+// Below is a non exhaustive list of Physical CONSTANTS,
+// computed in the Internal HEP System Of Units.
+//
+// Most of them are extracted from the Particle Data Book :
+//        Phys. Rev. D  volume 50 3-1 (1994) page 1233
+// 
+//        ...with a meaningful (?) name ...
+//
+// You can add your own constants.
+//
+// Author: M.Maire
+//
+// History:
+//
+// 23.02.96 Created
+// 26.03.96 Added constants for standard conditions of temperature
+//          and pressure; also added Gas threshold.
+// 29.04.08   use PDG 2006 values
+// 03.11.08   use PDG 2008 values
+// 02.10.17   addopted constant from CLHEP 2.3.4.3
+
+#ifndef TGEO_PHYSICAL_CONSTANTS_H
+#define TGEO_PHYSICAL_CONSTANTS_H
+
+#include "TGeoSystemOfUnits.h"
+
+namespace TGeoUnit {
+
+//
+// 
+//
+static constexpr double Avogadro = 6.02214179e+23/mole;
+
+//
+// c   = 299.792458 mm/ns
+// c^2 = 898.7404 (mm/ns)^2 
+//
+static constexpr double c_light   = 2.99792458e+8 * m/s;
+static constexpr double c_squared = c_light * c_light;
+
+//
+// h     = 4.13566e-12 MeV*ns
+// hbar  = 6.58212e-13 MeV*ns
+// hbarc = 197.32705e-12 MeV*mm
+//
+static constexpr double h_Planck      = 6.62606896e-34 * joule*s;
+static constexpr double hbar_Planck   = h_Planck/twopi;
+static constexpr double hbarc         = hbar_Planck * c_light;
+static constexpr double hbarc_squared = hbarc * hbarc;
+
+//
+//
+//
+static constexpr double electron_charge = - eplus; // see SystemOfUnits.h
+static constexpr double e_squared = eplus * eplus;
+
+//
+// amu_c2 - atomic equivalent mass unit
+//        - AKA, unified atomic mass unit (u)
+// amu    - atomic mass unit
+//
+static constexpr double electron_mass_c2 = 0.510998910 * MeV;
+static constexpr double   proton_mass_c2 = 938.272013 * MeV;
+static constexpr double  neutron_mass_c2 = 939.56536 * MeV;
+static constexpr double           amu_c2 = 931.494028 * MeV;
+static constexpr double              amu = amu_c2/c_squared;
+
+//
+// permeability of free space mu0    = 2.01334e-16 Mev*(ns*eplus)^2/mm
+// permittivity of free space epsil0 = 5.52636e+10 eplus^2/(MeV*mm)
+//
+static constexpr double mu0      = 4*pi*1.e-7 * henry/m;
+static constexpr double epsilon0 = 1./(c_squared*mu0);
+
+//
+// electromagnetic coupling = 1.43996e-12 MeV*mm/(eplus^2)
+//
+static constexpr double elm_coupling           = e_squared/(4*pi*epsilon0);
+static constexpr double fine_structure_const   = elm_coupling/hbarc;
+static constexpr double classic_electr_radius  = elm_coupling/electron_mass_c2;
+static constexpr double electron_Compton_length = hbarc/electron_mass_c2;
+static constexpr double Bohr_radius = electron_Compton_length/fine_structure_const;
+
+static constexpr double alpha_rcl2 = fine_structure_const
+                                   *classic_electr_radius
+                                   *classic_electr_radius;
+
+static constexpr double twopi_mc2_rcl2 = twopi*electron_mass_c2
+                                             *classic_electr_radius
+                                             *classic_electr_radius;
+//
+//
+//
+static constexpr double k_Boltzmann = 8.617343e-11 * MeV/kelvin;
+
+//
+//
+//
+static constexpr double STP_Temperature = 273.15*kelvin;
+static constexpr double STP_Pressure    = 1.*atmosphere;
+static constexpr double kGasThreshold   = 10.*mg/cm3;
+
+//
+//
+//
+static constexpr double universe_mean_density = 1.e-25*g/cm3;
+
+}  // namespace TGeoUnit
+
+#endif /* TGEO_PHYSICAL_CONSTANTS_H */
+
+
+
+
+

--- a/geom/geom/inc/TGeoSystemOfUnits.h
+++ b/geom/geom/inc/TGeoSystemOfUnits.h
@@ -1,0 +1,324 @@
+// -*- C++ -*-
+// $Id: SystemOfUnits.h,v 1.4 2010/06/16 17:12:28 garren Exp $
+// ----------------------------------------------------------------------
+// HEP coherent system of Units
+//
+// This file has been provided to CLHEP by Geant4 (simulation toolkit for HEP).
+//
+// The basic units are :
+// millimeter              (millimeter)
+// nanosecond              (nanosecond)
+// Mega electron Volt      (MeV)
+// positron charge         (eplus)
+// degree Kelvin           (kelvin)
+// the amount of substance (mole)
+// luminous intensity      (candela)
+// radian                  (radian)
+// steradian               (steradian)
+//
+// Below is a non exhaustive list of derived and pratical units
+// (i.e. mostly the SI units).
+// You can add your own units.
+//
+// The SI numerical value of the positron charge is defined here,
+// as it is needed for conversion factor : positron charge = e_SI (coulomb)
+//
+// The others physical constants are defined in the header file :
+// PhysicalConstants.h
+//
+// Authors: M.Maire, S.Giani
+//
+// History:
+//
+// 06.02.96   Created.
+// 28.03.96   Added miscellaneous constants.
+// 05.12.97   E.Tcherniaev: Redefined pascal (to avoid warnings on WinNT)
+// 20.05.98   names: meter, second, gram, radian, degree
+//            (from Brian.Lasiuk@yale.edu (STAR)). Added luminous units.
+// 05.08.98   angstrom, picobarn, microsecond, picosecond, petaelectronvolt
+// 01.03.01   parsec    
+// 31.01.06   kilogray, milligray, microgray    
+// 29.04.08   use PDG 2006 value of e_SI
+// 03.11.08   use PDG 2008 value of e_SI
+// 19.08.15   added liter and its sub units (mma)
+// 12.01.16   added symbols for microsecond (us) and picosecond (ps) (mma)
+// 02.10.17   addopted units from CLHEP 2.3.4.3 and converted to TGeo unit base 
+
+#ifndef TGEO_SYSTEM_OF_UNITS_H
+#define TGEO_SYSTEM_OF_UNITS_H
+
+namespace TGeoUnit {
+
+  //
+  // TGeo follows Geant3 convetion as specified in manual
+  // "Unless otherwise specified, the following units are used throughout the program:
+  // centimeter, second, degree, GeV"
+
+  //
+  //
+  //
+  static constexpr double     pi  = 3.14159265358979323846;
+  static constexpr double  twopi  = 2*pi;
+  static constexpr double halfpi  = pi/2;
+  static constexpr double     pi2 = pi*pi;
+
+  // 
+  // Length [L]
+  //
+  static constexpr double millimeter  = 0.1;                         
+  static constexpr double millimeter2 = millimeter*millimeter;
+  static constexpr double millimeter3 = millimeter*millimeter*millimeter;
+
+  static constexpr double centimeter  = 10.*millimeter; // Base unit
+  static constexpr double centimeter2 = centimeter*centimeter;
+  static constexpr double centimeter3 = centimeter*centimeter*centimeter;
+
+  static constexpr double meter  = 1000.*millimeter;                  
+  static constexpr double meter2 = meter*meter;
+  static constexpr double meter3 = meter*meter*meter;
+
+  static constexpr double kilometer = 1000.*meter;                   
+  static constexpr double kilometer2 = kilometer*kilometer;
+  static constexpr double kilometer3 = kilometer*kilometer*kilometer;
+
+  static constexpr double parsec = 3.0856775807e+16*meter;
+
+  static constexpr double micrometer = 1.e-6 *meter;             
+  static constexpr double  nanometer = 1.e-9 *meter;
+  static constexpr double  angstrom  = 1.e-10*meter;
+  static constexpr double  fermi     = 1.e-15*meter;
+
+  static constexpr double      barn = 1.e-28*meter2;
+  static constexpr double millibarn = 1.e-3 *barn;
+  static constexpr double microbarn = 1.e-6 *barn;
+  static constexpr double  nanobarn = 1.e-9 *barn;
+  static constexpr double  picobarn = 1.e-12*barn;
+
+  // symbols
+  static constexpr double nm  = nanometer;                        
+  static constexpr double um  = micrometer;                        
+
+  static constexpr double mm  = millimeter;                        
+  static constexpr double mm2 = millimeter2;
+  static constexpr double mm3 = millimeter3;
+
+  static constexpr double cm  = centimeter;   
+  static constexpr double cm2 = centimeter2;
+  static constexpr double cm3 = centimeter3;
+
+  static constexpr double liter = 1.e+3*cm3;
+  static constexpr double  L = liter;
+  static constexpr double dL = 1.e-1*liter;
+  static constexpr double cL = 1.e-2*liter;
+  static constexpr double mL = 1.e-3*liter;       
+
+  static constexpr double m  = meter;                  
+  static constexpr double m2 = meter2;
+  static constexpr double m3 = meter3;
+
+  static constexpr double km  = kilometer;                   
+  static constexpr double km2 = kilometer2;
+  static constexpr double km3 = kilometer3;
+
+  static constexpr double pc = parsec;
+
+  //
+  // Angle
+  //
+  static constexpr double degree      = 1.0; // Base unit
+  static constexpr double radian      = (180.0/pi)*degree;                  
+  static constexpr double milliradian = 1.e-3*radian;
+
+  static constexpr double   steradian = 1.;
+  
+  // symbols
+  static constexpr double rad  = radian;
+  static constexpr double mrad = milliradian;
+  static constexpr double sr   = steradian;
+  static constexpr double deg  = degree;
+
+  //
+  // Time [T]
+  //
+  static constexpr double nanosecond  = 1.e-9;
+  static constexpr double second      = 1.e+9 *nanosecond; // Base unit
+  static constexpr double millisecond = 1.e-3 *second;
+  static constexpr double microsecond = 1.e-6 *second;
+  static constexpr double  picosecond = 1.e-12*second;
+
+  static constexpr double hertz = 1./second;
+  static constexpr double kilohertz = 1.e+3*hertz;
+  static constexpr double megahertz = 1.e+6*hertz;
+
+  // symbols
+  static constexpr double ns = nanosecond;
+  static constexpr double  s = second;
+  static constexpr double ms = millisecond;
+  static constexpr double us = microsecond;
+  static constexpr double ps = picosecond;
+
+  //
+  // Electric charge [Q]
+  //
+  static constexpr double eplus = 1. ;// positron charge
+  static constexpr double e_SI  = 1.602176487e-19;// positron charge in coulomb
+  static constexpr double coulomb = eplus/e_SI;// coulomb = 6.24150 e+18 * eplus
+
+  //
+  // Energy [E]
+  //
+  static constexpr double megaelectronvolt = 1.e-3;
+  static constexpr double     electronvolt = 1.e-6*megaelectronvolt;
+  static constexpr double kiloelectronvolt = 1.e-3*megaelectronvolt;
+  static constexpr double gigaelectronvolt = 1.e+3*megaelectronvolt; // Base unit
+  static constexpr double teraelectronvolt = 1.e+6*megaelectronvolt;
+  static constexpr double petaelectronvolt = 1.e+9*megaelectronvolt;
+
+  static constexpr double joule = electronvolt/e_SI;// joule = 6.24150 e+12 * MeV
+
+  // symbols
+  static constexpr double MeV = megaelectronvolt;
+  static constexpr double  eV = electronvolt;
+  static constexpr double keV = kiloelectronvolt;
+  static constexpr double GeV = gigaelectronvolt;
+  static constexpr double TeV = teraelectronvolt;
+  static constexpr double PeV = petaelectronvolt;
+
+  //
+  // Mass [E][T^2][L^-2]
+  //
+  static constexpr double  kilogram = joule*second*second/(meter*meter);   
+  static constexpr double      gram = 1.e-3*kilogram;
+  static constexpr double milligram = 1.e-3*gram;
+
+  // symbols
+  static constexpr double  kg = kilogram;
+  static constexpr double   g = gram;
+  static constexpr double  mg = milligram;
+
+  //
+  // Power [E][T^-1]
+  //
+  static constexpr double watt = joule/second;// watt = 6.24150 e+3 * MeV/ns
+
+  //
+  // Force [E][L^-1]
+  //
+  static constexpr double newton = joule/meter;// newton = 6.24150 e+9 * MeV/mm
+
+  //
+  // Pressure [E][L^-3]
+  //
+#define pascal hep_pascal                          // a trick to avoid warnings 
+  static constexpr double hep_pascal = newton/m2;   // pascal = 6.24150 e+3 * MeV/mm3
+  static constexpr double bar        = 100000*pascal; // bar    = 6.24150 e+8 * MeV/mm3
+  static constexpr double atmosphere = 101325*pascal; // atm    = 6.32420 e+8 * MeV/mm3
+
+  //
+  // Electric current [Q][T^-1]
+  //
+  static constexpr double      ampere = coulomb/second; // ampere = 6.24150 e+9 * eplus/ns
+  static constexpr double milliampere = 1.e-3*ampere;
+  static constexpr double microampere = 1.e-6*ampere;
+  static constexpr double  nanoampere = 1.e-9*ampere;
+
+  //
+  // Electric potential [E][Q^-1]
+  //
+  static constexpr double megavolt = megaelectronvolt/eplus;
+  static constexpr double kilovolt = 1.e-3*megavolt;
+  static constexpr double     volt = 1.e-6*megavolt;
+
+  //
+  // Electric resistance [E][T][Q^-2]
+  //
+  static constexpr double ohm = volt/ampere;// ohm = 1.60217e-16*(MeV/eplus)/(eplus/ns)
+
+  //
+  // Electric capacitance [Q^2][E^-1]
+  //
+  static constexpr double farad = coulomb/volt;// farad = 6.24150e+24 * eplus/Megavolt
+  static constexpr double millifarad = 1.e-3*farad;
+  static constexpr double microfarad = 1.e-6*farad;
+  static constexpr double  nanofarad = 1.e-9*farad;
+  static constexpr double  picofarad = 1.e-12*farad;
+
+  //
+  // Magnetic Flux [T][E][Q^-1]
+  //
+  static constexpr double weber = volt*second;// weber = 1000*megavolt*ns
+
+  //
+  // Magnetic Field [T][E][Q^-1][L^-2]
+  //
+  static constexpr double tesla     = volt*second/meter2;// tesla =0.001*megavolt*ns/mm2
+
+  static constexpr double gauss     = 1.e-4*tesla;
+  static constexpr double kilogauss = 1.e-1*tesla;
+
+  //
+  // Inductance [T^2][E][Q^-2]
+  //
+  static constexpr double henry = weber/ampere;// henry = 1.60217e-7*MeV*(ns/eplus)**2
+
+  //
+  // Temperature
+  //
+  static constexpr double kelvin = 1.;
+
+  //
+  // Amount of substance
+  //
+  static constexpr double mole = 1.;
+
+  //
+  // Activity [T^-1]
+  //
+  static constexpr double becquerel = 1./second ;
+  static constexpr double curie = 3.7e+10 * becquerel;
+  static constexpr double kilobecquerel = 1.e+3*becquerel;
+  static constexpr double megabecquerel = 1.e+6*becquerel;
+  static constexpr double gigabecquerel = 1.e+9*becquerel;
+  static constexpr double millicurie = 1.e-3*curie;
+  static constexpr double microcurie = 1.e-6*curie;
+  static constexpr double Bq = becquerel;
+  static constexpr double kBq = kilobecquerel;
+  static constexpr double MBq = megabecquerel;
+  static constexpr double GBq = gigabecquerel;
+  static constexpr double Ci = curie;
+  static constexpr double mCi = millicurie;
+  static constexpr double uCi = microcurie;
+
+  //
+  // Absorbed dose [L^2][T^-2]
+  //
+  static constexpr double      gray = joule/kilogram ;
+  static constexpr double  kilogray = 1.e+3*gray;
+  static constexpr double milligray = 1.e-3*gray;
+  static constexpr double microgray = 1.e-6*gray;
+
+  //
+  // Luminous intensity [I]
+  //
+  static constexpr double candela = 1.;
+
+  //
+  // Luminous flux [I]
+  //
+  static constexpr double lumen = candela*steradian;
+
+  //
+  // Illuminance [I][L^-2]
+  //
+  static constexpr double lux = lumen/meter2;
+
+  //
+  // Miscellaneous
+  //
+  static constexpr double perCent     = 0.01 ;
+  static constexpr double perThousand = 0.001;
+  static constexpr double perMillion  = 0.000001;
+
+}  // namespace TGeoUnit
+
+#endif /* TGEO_SYSTEM_OF_UNITS_H */

--- a/geom/geom/src/TGeoElement.cxx
+++ b/geom/geom/src/TGeoElement.cxx
@@ -45,6 +45,7 @@ Table of elements
 #include "TGeoManager.h"
 #include "TGeoElement.h"
 #include "TMath.h"
+#include "TGeoPhysicalConstants.h"
 
 // statics and globals
 static const Int_t gMaxElem  = 110;
@@ -94,6 +95,7 @@ TGeoElement::TGeoElement()
    fA = 0.0;
    fIsotopes = NULL;
    fAbundances = NULL;
+   ComputeDerivedQuantities();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -110,6 +112,7 @@ TGeoElement::TGeoElement(const char *name, const char *title, Int_t z, Double_t 
    fA = a;
    fIsotopes = NULL;
    fAbundances = NULL;
+   ComputeDerivedQuantities();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -126,6 +129,7 @@ TGeoElement::TGeoElement(const char *name, const char *title, Int_t nisotopes)
    fA = 0.0;
    fIsotopes = new TObjArray(nisotopes);
    fAbundances = new Double_t[nisotopes];
+   ComputeDerivedQuantities();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -142,8 +146,48 @@ TGeoElement::TGeoElement(const char *name, const char *title, Int_t z, Int_t n, 
    fA = a;
    fIsotopes = NULL;
    fAbundances = NULL;
+   ComputeDerivedQuantities();
 }
+////////////////////////////////////////////////////////////////////////////////
+/// Calculate properties for an atomic number
 
+void TGeoElement::ComputeDerivedQuantities()
+{
+   // Radiation Length
+   ComputeCoulombFactor();
+   ComputeLradTsaiFactor();
+}
+////////////////////////////////////////////////////////////////////////////////
+/// Compute Coulomb correction factor (Phys Rev. D50 3-1 (1994) page 1254)
+
+void TGeoElement::ComputeCoulombFactor()
+{
+   static const Double_t k1 = 0.0083 , k2 = 0.20206 ,k3 = 0.0020 , k4 = 0.0369 ;
+
+   Double_t az2 = (TGeoUnit::fine_structure_const*fZ)*(TGeoUnit::fine_structure_const*fZ);
+   Double_t az4 = az2 * az2;
+
+   fCoulomb = (k1*az4 + k2 + 1./(1.+az2))*az2 - (k3*az4 + k4)*az4;
+}
+////////////////////////////////////////////////////////////////////////////////
+/// Compute Tsai's Expression for the Radiation Length (Phys Rev. D50 3-1 (1994) page 1254)
+
+void TGeoElement::ComputeLradTsaiFactor()
+{
+   static const Double_t Lrad_light[]  = {5.31  , 4.79  , 4.74 ,  4.71} ;
+   static const Double_t Lprad_light[] = {6.144 , 5.621 , 5.805 , 5.924} ;
+
+   const Double_t logZ3 = TMath::Log(fZ)/3.;
+
+   Double_t Lrad, Lprad;
+   Int_t iz = static_cast<Int_t>(fZ+0.5) - 1 ; // The static cast comes from G4lrint
+   static const Double_t log184 = TMath::Log(184.15);
+   static const Double_t log1194 = TMath::Log(1194.);
+   if (iz <= 3) { Lrad = Lrad_light[iz] ;  Lprad = Lprad_light[iz] ; }
+   else { Lrad = log184 - logZ3 ; Lprad = log1194 - 2*logZ3;}
+
+   fRadTsai = 4*TGeoUnit::alpha_rcl2*fZ*(fZ*(Lrad-fCoulomb) + Lprad);
+}
 ////////////////////////////////////////////////////////////////////////////////
 /// Print this isotope
 


### PR DESCRIPTION
This PR adds to TGeoElement the functions 
 - ComputeCoulombFactor
 - GetfRadTsai

and to TGeoMaterial/Mixture
 - ComputeRadiationLength
 - ComputeNuclearInterLength

mimicking Geant4 behaviour. 

The aim is that Geant4 and ROOT provide the same result for RadLen and IntLen which is not the case now.



