### PR TITLE
cppcheck: fix some reports

### DIFF
--- a/core/base/src/TStyle.cxx
+++ b/core/base/src/TStyle.cxx
@@ -1505,7 +1505,7 @@ void TStyle::SaveSource(const char *filename, Option_t *option)
    Int_t lenfname = strlen(fname);
    char *sname = new char[lenfname + 1];
    Int_t i = 0;
-   while ((fname[i] != '.') && (i < lenfname)) {
+   while ((i < lenfname) && (fname[i] != '.')) {
       sname[i] = fname[i];
       i++;
    }

--- a/geom/geocad/src/TGeoToOCC.cxx
+++ b/geom/geocad/src/TGeoToOCC.cxx
@@ -524,10 +524,10 @@ TopoDS_Shape TGeoToOCC::OCC_Cuttub(Double_t rmin, Double_t rmax, Double_t dz,
    BRepBuilderAPI_Transform theTR(TR);
    theTR.Perform(tubs, Standard_True);
    tubs=theTR.Shape();
-   if ((Nhigh[0]>-1e-4)||(Nhigh[0]<1e-4)) nhigh0=0;
-   if ((Nhigh[1]>-1e-4)||(Nhigh[1]<1e-4)) nhigh1=0;
-   if ((Nlow[0]>-1e-4)||(Nlow[0]<1e-4)) nlow0=0;
-   if ((Nlow[1]>-1e-4)||(Nlow[1]<1e-4)) nlow1=0;
+   if ((Nhigh[0]>-1e-4)&&(Nhigh[0]<1e-4)) nhigh0=0;
+   if ((Nhigh[1]>-1e-4)&&(Nhigh[1]<1e-4)) nhigh1=0;
+   if ((Nlow[0]>-1e-4)&&(Nlow[0]<1e-4)) nlow0=0;
+   if ((Nlow[1]>-1e-4)&&(Nlow[1]<1e-4)) nlow1=0;
    Handle(Geom_Plane) pH = new Geom_Plane (gp_Pnt(0,0,dz), gp_Dir(nhigh0,nhigh1,Nhigh[2]));
    Handle(Geom_Plane) pL = new Geom_Plane (gp_Pnt(0,0,-dz), gp_Dir(nlow0,nlow1,Nlow[2]));
 

--- a/geom/geom/src/TGeoNavigator.cxx
+++ b/geom/geom/src/TGeoNavigator.cxx
@@ -2216,7 +2216,7 @@ Int_t TGeoNavigator::GetTouchedCluster(Int_t start, Double_t *point,
    }
 
    Int_t jst=0, i, j;
-   while ((ovlps[jst]<=check_list[start]) && (jst<novlps))  jst++;
+   while ((jst<novlps) && (ovlps[jst]<=check_list[start]))  jst++;
    if (jst==novlps) return 0;
    for (i=start; i<ncheck; i++) {
       for (j=jst; j<novlps; j++) {

--- a/geom/geom/src/TGeoParaboloid.cxx
+++ b/geom/geom/src/TGeoParaboloid.cxx
@@ -454,7 +454,7 @@ Double_t TGeoParaboloid::Safety(const Double_t *point, Bool_t in) const
 
 void TGeoParaboloid::SetParaboloidDimensions(Double_t rlo, Double_t rhi, Double_t dz)
 {
-   if ((rlo<0) || (rlo<0) || (dz<=0) || TMath::Abs(rlo-rhi)<TGeoShape::Tolerance()) {
+   if ((rlo<0) || (rhi<0) || (dz<=0) || TMath::Abs(rlo-rhi)<TGeoShape::Tolerance()) {
       SetShapeBit(kGeoRunTimeShape);
       Error("SetParaboloidDimensions", "Dimensions of %s invalid: check (rlo>=0) (rhi>=0) (rlo!=rhi) dz>0",GetName());
       return;

--- a/graf2d/asimage/src/libAfterImage/char2uni.c
+++ b/graf2d/asimage/src/libAfterImage/char2uni.c
@@ -811,8 +811,8 @@ parse_charset_name( const char *name )
 		return CHARSET_ISO8859_1;
 	}else if( name[0] == 'I' || name[0] == 'i' ) /* ISO... or IBM819*/
 	{
-		if( name[1] == 'S' && name[1] == 's' )
-			if( name[2] == 'O' && name[2] == 'o' )
+		if( name[1] == 'S' || name[1] == 's' )
+			if( name[2] == 'O' || name[2] == 'o' )
 			{
 				int pos = ( name[3] == '-' || name[3] == '_' )?4:3 ;
 				if( name[pos] == '8' )

--- a/graf2d/asimage/src/libAfterImage/imencdec.c
+++ b/graf2d/asimage/src/libAfterImage/imencdec.c
@@ -373,7 +373,7 @@ start_image_decoding( ASVisual *asv,ASImage *im, ASFlagType filter,
 
 		if( bevel->left_outline == 0 && bevel->right_outline == 0 &&
 			bevel->top_outline == 0 && bevel->bottom_outline == 0 &&
-			bevel->left_inline == 0 && bevel->left_inline == 0 &&
+			bevel->left_inline == 0 && bevel->right_inline == 0 &&
 			bevel->top_inline == 0 && bevel->bottom_inline == 0 )
 			imdec->bevel = bevel = NULL ;
 	}


### PR DESCRIPTION
[core/base/src/TStyle.cxx:1508]: (style) Array index 'i' is used before limits check
[geom/geom/src/TGeoNavigator.cxx:2219]: (style) Array index 'jst' is used before limits check

[geom/geocad/src/TGeoToOCC.cxx:527]: (warning) Logical disjunction always evaluates to true: EXPR > -1e-4 || EXPR < 1e-4
[geom/geocad/src/TGeoToOCC.cxx:528]: (warning) Logical disjunction always evaluates to true: EXPR > -1e-4 || EXPR < 1e-4
[geom/geocad/src/TGeoToOCC.cxx:529]: (warning) Logical disjunction always evaluates to true: EXPR > -1e-4 || EXPR < 1e-4
[geom/geocad/src/TGeoToOCC.cxx:530]: (warning) Logical disjunction always evaluates to true: EXPR > -1e-4 || EXPR < 1e-4
[graf2d/asimage/src/libAfterImage/char2uni.c:814]: (warning) Logical conjunction always evaluates to false: EXPR == 'S' && EXPR == 's'
[graf2d/asimage/src/libAfterImage/char2uni.c:815]: (warning) Logical conjunction always evaluates to false: EXPR == 'O' && EXPR == 'o'

[graf2d/asimage/src/libAfterImage/imencdec.c:376] -> [graf2d/asimage/src/libAfterImage/imencdec.c:376]: (style) Same expression on both sides of '&&'
[geom/geom/src/TGeoParaboloid.cxx:457] -> [geom/geom/src/TGeoParaboloid.cxx:457]: (style) Same expression on both sides of '||'