### PR TITLE
Partially revert "Mark the file entry invalid, ..."

### DIFF
--- a/interpreter/llvm/src/tools/clang/include/clang/Basic/SourceManager.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/Basic/SourceManager.h
@@ -1540,18 +1540,7 @@ public:
       return LocalSLocEntryTable[0];
     }
 
-    // If we invalidated the cache we need to update the SLocEntry, too.
-    // FIXME: This only deals with files coming not from PCH
-    const SrcMgr::SLocEntry& SLocE = getSLocEntryByID(FID.ID, Invalid);
-    if (Invalid && !*Invalid && SLocE.isFile()) {
-      SrcMgr::ContentCache* CC
-        = const_cast<SrcMgr::ContentCache*>(SLocE.getFile().getContentCache());
-      if (!CC) {
-        CC = FileInfos.lookup(CC->OrigEntry);
-        const_cast<SrcMgr::FileInfo&>(SLocE.getFile()).Data = (uintptr_t) CC;
-      }
-    }
-    return SLocE;
+    return getSLocEntryByID(FID.ID, Invalid);
   }
 
   unsigned getNextLocalOffset() const { return NextLocalOffset; }


### PR DESCRIPTION
Partially revert "Mark the file entry invalid, until reread. Invalidate SLocEntry cache, readd it on reread."
    
That change does not make any sense. Kudos to my old self.
    
Resolves ROOT-8956.