### PR TITLE
[TypeTraits] Make CallableTraits SFINAE-friendly

### DIFF
--- a/core/foundation/inc/ROOT/TypeTraits.hxx
+++ b/core/foundation/inc/ROOT/TypeTraits.hxx
@@ -19,12 +19,65 @@
 
 namespace ROOT {
 
-namespace Detail {
-template <typename T> constexpr bool HasCallOp(decltype(&T::operator())*) { return true; }
-template <typename T> constexpr bool HasCallOp(...) { return false; }
-}
-
 /// ROOT type_traits extensions
+namespace TypeTraits {
+/// Lightweight storage for a collection of types.
+/// Differently from std::tuple, no instantiation of objects of stored types is performed
+template <typename... Types>
+struct TypeList {
+   static constexpr std::size_t list_size = sizeof...(Types);
+};
+} // end ns TypeTraits
+
+namespace Detail {
+template <typename T> constexpr auto HasCallOp(int goodOverload) -> decltype(&T::operator(), true) { return true; }
+template <typename T> constexpr bool HasCallOp(char badOverload) { return false; }
+
+/// Extract types from the signature of a callable object. See CallableTraits.
+template <typename T, bool HasCallOp = ROOT::Detail::HasCallOp<T>(0)>
+struct CallableTraitsImpl {};
+
+// Extract signature of operator() and delegate to the appropriate CallableTraitsImpl overloads
+template <typename T>
+struct CallableTraitsImpl<T, true> {
+   using arg_types = typename CallableTraitsImpl<decltype(&T::operator())>::arg_types;
+   using arg_types_nodecay = typename CallableTraitsImpl<decltype(&T::operator())>::arg_types_nodecay;
+   using ret_type = typename CallableTraitsImpl<decltype(&T::operator())>::ret_type;
+};
+
+// lambdas, std::function, const member functions
+template <typename R, typename T, typename... Args>
+struct CallableTraitsImpl<R (T::*)(Args...) const, false> {
+   using arg_types = ROOT::TypeTraits::TypeList<typename std::decay<Args>::type...>;
+   using arg_types_nodecay = ROOT::TypeTraits::TypeList<Args...>;
+   using ret_type = R;
+};
+
+// mutable lambdas and functor classes, non-const member functions
+template <typename R, typename T, typename... Args>
+struct CallableTraitsImpl<R (T::*)(Args...), false> {
+   using arg_types = ROOT::TypeTraits::TypeList<typename std::decay<Args>::type...>;
+   using arg_types_nodecay = ROOT::TypeTraits::TypeList<Args...>;
+   using ret_type = R;
+};
+
+// function pointers
+template <typename R, typename... Args>
+struct CallableTraitsImpl<R (*)(Args...), false> {
+   using arg_types = ROOT::TypeTraits::TypeList<typename std::decay<Args>::type...>;
+   using arg_types_nodecay = ROOT::TypeTraits::TypeList<Args...>;
+   using ret_type = R;
+};
+
+// free functions
+template <typename R, typename... Args>
+struct CallableTraitsImpl<R(Args...), false> {
+   using arg_types = ROOT::TypeTraits::TypeList<typename std::decay<Args>::type...>;
+   using arg_types_nodecay = ROOT::TypeTraits::TypeList<Args...>;
+   using ret_type = R;
+};
+} // end ns Detail
+
 namespace TypeTraits {
 
 ///\class ROOT::TypeTraits::
@@ -74,56 +127,12 @@ struct IsContainer<std::array_view<T>> {
    static constexpr bool value = true;
 };
 
-/// Lightweight storage for a collection of types.
-/// Differently from std::tuple, no instantiation of objects of stored types is performed
-template <typename... Types>
-struct TypeList {
-   static constexpr std::size_t list_size = sizeof...(Types);
-};
-
 /// Extract types from the signature of a callable object.
-template <typename T, bool HasCallOp = ROOT::Detail::HasCallOp<T>(nullptr)>
-struct CallableTraits {};
-
-// Extract signature of operator() and delegate to the appropriate CallableTraits overloads
-template <typename T>
-struct CallableTraits<T, true> {
-   using arg_types = typename CallableTraits<decltype(&T::operator())>::arg_types;
-   using arg_types_nodecay = typename CallableTraits<decltype(&T::operator())>::arg_types_nodecay;
-   using ret_type = typename CallableTraits<decltype(&T::operator())>::ret_type;
-};
-
-// lambdas, std::function, const member functions
-template <typename R, typename T, typename... Args>
-struct CallableTraits<R (T::*)(Args...) const, false> {
-   using arg_types = TypeList<typename std::decay<Args>::type...>;
-   using arg_types_nodecay = TypeList<Args...>;
-   using ret_type = R;
-};
-
-// mutable lambdas and functor classes, non-const member functions
-template <typename R, typename T, typename... Args>
-struct CallableTraits<R (T::*)(Args...), false> {
-   using arg_types = TypeList<typename std::decay<Args>::type...>;
-   using arg_types_nodecay = TypeList<Args...>;
-   using ret_type = R;
-};
-
-// function pointers
-template <typename R, typename... Args>
-struct CallableTraits<R (*)(Args...), false> {
-   using arg_types = TypeList<typename std::decay<Args>::type...>;
-   using arg_types_nodecay = TypeList<Args...>;
-   using ret_type = R;
-};
-
-// free functions
-template <typename R, typename... Args>
-struct CallableTraits<R(Args...), false> {
-   using arg_types = TypeList<typename std::decay<Args>::type...>;
-   using arg_types_nodecay = TypeList<Args...>;
-   using ret_type = R;
-};
+/// The `CallableTraits` struct contains three type aliases:
+///   - arg_types: a `TypeList` of all types in the signature, decayed through std::decay
+///   - arg_types_nodecay: a `TypeList` of all types in the signature, including cv-qualifiers
+template<typename F>
+using CallableTraits = ROOT::Detail::CallableTraitsImpl<F>;
 
 // Return first of a variadic list of types.
 template <typename T, typename... Rest>

--- a/core/foundation/inc/ROOT/TypeTraits.hxx
+++ b/core/foundation/inc/ROOT/TypeTraits.hxx
@@ -30,8 +30,8 @@ struct TypeList {
 } // end ns TypeTraits
 
 namespace Detail {
-template <typename T> constexpr auto HasCallOp(int goodOverload) -> decltype(&T::operator(), true) { return true; }
-template <typename T> constexpr bool HasCallOp(char badOverload) { return false; }
+template <typename T> constexpr auto HasCallOp(int /*goodOverload*/) -> decltype(&T::operator(), true) { return true; }
+template <typename T> constexpr bool HasCallOp(char /*badOverload*/) { return false; }
 
 /// Extract types from the signature of a callable object. See CallableTraits.
 template <typename T, bool HasCallOp = ROOT::Detail::HasCallOp<T>(0)>

--- a/core/foundation/test/testTypeTraits.cxx
+++ b/core/foundation/test/testTypeTraits.cxx
@@ -136,3 +136,21 @@ TEST(TypeTraits, CallableTraits)
                                  CallableTraits<decltype(stdFun2)>::arg_types_nodecay>();
    ::testing::StaticAssertTypeEq<Dummy, CallableTraits<decltype(stdFun2)>::ret_type>();
 }
+
+template<typename F, typename R = typename CallableTraits<F>::ret_type>
+constexpr bool HasRetType(F) { return true; }
+template<typename F, typename...Args>
+constexpr bool HasRetType(F, Args...) { return false; }
+
+TEST(TypeTraits, SFINAEOnCallableTraits)
+{
+   EXPECT_FALSE(HasRetType(int(42)));
+   EXPECT_FALSE(HasRetType(std::vector<int>()));
+   EXPECT_TRUE(HasRetType(freeFun1));
+   EXPECT_TRUE(HasRetType(freeFun2));
+   EXPECT_TRUE(HasRetType(Functor1()));
+   EXPECT_TRUE(HasRetType(Functor2()));
+   EXPECT_TRUE(HasRetType(std::function<void(int)>(Functor1())));
+   EXPECT_TRUE(HasRetType([]() { return 42; }));
+   EXPECT_TRUE(HasRetType([]() { return Dummy(); }));
+}


### PR DESCRIPTION
I thought it was already the case that we could use ROOT::TypeTraits::CallableTraits to do SFINAE but evidently I was wrong. This commit allows code like the following to compile correctly:

```c++
template<typename F, typename R = typename CallableTraits<F>::ret_type>
constexpr bool HasRetType(F) { return true; }
constexpr bool HasRetType(...) { return false; }

static_assert(!HasRetType(int(42)));
static_assert(HasRetType([]() { return Dummy(); }));
```

...as was originally planned and requested by @Axel-Naumann .