### PR TITLE
Fix some more warnings on Windows

### DIFF
--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -93,7 +93,6 @@ char *dlerror() {
 FARPROC dlsym(void *library, const char *function_name)
 {
    HMODULE hMods[1024];
-   HANDLE hProcess;
    DWORD cbNeeded;
    FARPROC address = NULL;
    unsigned int i;

--- a/core/metacling/src/TClingCallbacks.cxx
+++ b/core/metacling/src/TClingCallbacks.cxx
@@ -88,7 +88,7 @@ void TClingCallbacks::InclusionDirective(clang::SourceLocation sLoc/*HashLoc*/,
                                          const clang::FileEntry *FE,
                                          llvm::StringRef /*SearchPath*/,
                                          llvm::StringRef /*RelativePath*/,
-                                         const clang::Module */*Imported*/) {
+                                         const clang::Module * /*Imported*/) {
    // Method called via Callbacks->InclusionDirective()
    // in Preprocessor::HandleIncludeDirective(), invoked whenever an
    // inclusion directive has been processed, and allowing us to try

--- a/core/metacling/src/TClingCallbacks.h
+++ b/core/metacling/src/TClingCallbacks.h
@@ -63,10 +63,10 @@ public:
                                    llvm::StringRef FileName,
                                    bool /*IsAngled*/,
                                    clang::CharSourceRange /*FilenameRange*/,
-                                   const clang::FileEntry */*File*/,
+                                   const clang::FileEntry * /*File*/,
                                    llvm::StringRef /*SearchPath*/,
                                    llvm::StringRef /*RelativePath*/,
-                                   const clang::Module */*Imported*/);
+                                   const clang::Module * /*Imported*/);
 
    // Preprocessor callbacks used to handle special cases like for example:
    // #include "myMacro.C+"

--- a/graf2d/win32gdk/inc/TGWin32ProxyDefs.h
+++ b/graf2d/win32gdk/inc/TGWin32ProxyDefs.h
@@ -35,7 +35,7 @@
 
 static int gDebugProxy = 0; // if kTRUE - use debug & profile interface
 
-static enum { kDebugProfile = -123, kDebugTrace = -1234 };
+enum { kDebugProfile = -123, kDebugTrace = -1234 };
 
 static unsigned int total = 0;
 static double total_time = 0;

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -2913,7 +2913,7 @@ void TBufferJSON::ReadTString(TString & /*s*/)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads a std::string
 
-void TBufferJSON::ReadStdString(std::string */*s*/)
+void TBufferJSON::ReadStdString(std::string * /*s*/)
 {
 }
 

--- a/proof/pq2/src/pq2actions.cxx
+++ b/proof/pq2/src/pq2actions.cxx
@@ -1115,7 +1115,7 @@ void do_anadist_getkey(TUrl *u, TString &key)
 /// Create the plot for the histogram, and save to 'fnout'.
 /// Format determined by th extension of fnout.
 
-int do_anadist_plot(TH1D *h1d, const char */*fnout*/)
+int do_anadist_plot(TH1D *h1d, const char * /*fnout*/)
 {
    Printf("do_anadist_plot: will be doing a plot here ... ");
 

--- a/proof/proof/src/TLockPath.cxx
+++ b/proof/proof/src/TLockPath.cxx
@@ -20,10 +20,9 @@ Path locking class allowing shared and exclusive locks
 #include "TSystem.h"
 #if defined(R__WIN32) && !defined(R__WINGCC)
 #include <io.h>
-#define lseek(fd, offset, origin) _lseek(fd, offset, origin)
-#define close(fd) _close(fd)
-#define open(fd, oflag, pmode) _open(fd, oflag, pmode)
-#define open(fd, oflag) _open(fd, oflag)
+#define lseek _lseek
+#define close _close
+#define open _open
 #define O_CREAT _O_CREAT
 #define O_RDWR _O_RDWR
 #else


### PR DESCRIPTION
Fix mostly warning C4138: '*/' found outside of comment, but also:
warning C4101: 'hProcess': unreferenced local variable
warning C4005: 'open': macro redefinition
warning C4002: too many actual parameters for macro 'open'
warning C4091: 'static ': ignored on left of '' when no variable is declared