### PR TITLE
Initialize bits local variable.

### DIFF
--- a/tree/tree/src/TIOFeatures.cxx
+++ b/tree/tree/src/TIOFeatures.cxx
@@ -169,7 +169,7 @@ bool TIOFeatures::Set(EIOFeatures input_bits)
 /// and returns kFALSE.
 bool TIOFeatures::Set(const std::string &value)
 {
-   TBasket::EIOBits bits;
+   TBasket::EIOBits bits = static_cast<TBasket::EIOBits>(0);
    TClass *cl = TBasket::Class();
    if (cl == nullptr) {
       Error("Set", "Could not retrieve TBasket's class");


### PR DESCRIPTION
This initialization should be unnecessary, but avoids a warning on some compiler platforms about potentially uninitialized use of the variable.

Most other compiler platforms should optimize away the assignment.

Fixes an issue reported by @pcanal.