### PR TITLE
Minor modernizations of the TFileMerger.

### DIFF
--- a/io/io/inc/TFileMerger.h
+++ b/io/io/inc/TFileMerger.h
@@ -12,6 +12,7 @@
 #ifndef ROOT_TFileMerger
 #define ROOT_TFileMerger
 
+#include "TList.h"
 #include "TObject.h"
 #include "TString.h"
 #include "TStopwatch.h"
@@ -28,29 +29,31 @@ class TIOFeatures;
 
 class TFileMerger : public TObject {
 private:
-   TFileMerger(const TFileMerger&); // Not implemented
-   TFileMerger& operator=(const TFileMerger&); // Not implemented
+   using TIOFeatures = ROOT::TIOFeatures;
+
+   TFileMerger(const TFileMerger&) = delete;
+   TFileMerger& operator=(const TFileMerger&) = delete;
 
 protected:
-   TStopwatch     fWatch;            ///< Stop watch to measure file copy speed
-   TList         *fFileList;         ///< A list the file (TFile*) which shall be merged
-   TFile         *fOutputFile;       ///< The outputfile for merging
-   TString        fOutputFilename;   ///< The name of the outputfile for merging
-   Bool_t         fFastMethod;       ///< True if using Fast merging algorithm (default)
-   Bool_t         fNoTrees;          ///< True if Trees should not be merged (default is kFALSE)
-   Bool_t         fExplicitCompLevel;///< True if the user explicitly requested a compressio level change (default kFALSE)
-   Bool_t         fCompressionChange;///< True if the output and input have different compression level (default kFALSE)
-   Int_t          fPrintLevel;       ///< How much information to print out at run time
-   TString        fMergeOptions;     ///< Options (in string format) to be passed down to the Merge functions
-   ROOT::TIOFeatures *fIOFeatures{nullptr}; ///< IO features to use in the output file.
-   TString        fMsgPrefix;        ///< Prefix to be used when printing informational message (default TFileMerger)
+   TStopwatch     fWatch;                     ///< Stop watch to measure file copy speed
+   TList          fFileList;                  ///< A list the file (TFile*) which shall be merged
+   TFile         *fOutputFile{nullptr};       ///< The outputfile for merging
+   TString        fOutputFilename;            ///< The name of the outputfile for merging
+   Bool_t         fFastMethod{kTRUE};         ///< True if using Fast merging algorithm (default)
+   Bool_t         fNoTrees{kFALSE};           ///< True if Trees should not be merged (default is kFALSE)
+   Bool_t         fExplicitCompLevel{kFALSE}; ///< True if the user explicitly requested a compressio level change (default kFALSE)
+   Bool_t         fCompressionChange{kFALSE}; ///< True if the output and input have different compression level (default kFALSE)
+   Int_t          fPrintLevel{0};             ///< How much information to print out at run time
+   TString        fMergeOptions;              ///< Options (in string format) to be passed down to the Merge functions
+   TIOFeatures   *fIOFeatures{nullptr};       ///< IO features to use in the output file.
+   TString        fMsgPrefix{"TFileMerger"};  ///< Prefix to be used when printing informational message (default TFileMerger)
 
-   Int_t          fMaxOpenedFiles;  ///< Maximum number of files opened at the same time by the TFileMerger
-   Bool_t         fLocal;           ///< Makes local copies of merging files if True (default is kTRUE)
-   Bool_t         fHistoOneGo;      ///< Merger histos in one go (default is kTRUE)
-   TString        fObjectNames;     ///< List of object names to be either merged exclusively or skipped
-   TList         *fMergeList;       ///< list of TObjString containing the name of the files need to be merged
-   TList         *fExcessFiles;     ///<! List of TObjString containing the name of the files not yet added to fFileList due to user or system limitiation on the max number of files opened.
+   Int_t          fMaxOpenedFiles;            ///< Maximum number of files opened at the same time by the TFileMerger
+   Bool_t         fLocal;                     ///< Makes local copies of merging files if True (default is kTRUE)
+   Bool_t         fHistoOneGo;                ///< Merger histos in one go (default is kTRUE)
+   TString        fObjectNames;               ///< List of object names to be either merged exclusively or skipped
+   TList          fMergeList;                 ///< list of TObjString containing the name of the files need to be merged
+   TList          fExcessFiles;               ///<! List of TObjString containing the name of the files not yet added to fFileList due to user or system limitiation on the max number of files opened.
 
    Bool_t         OpenExcessFiles();
    virtual Bool_t AddFile(TFile *source, Bool_t own, Bool_t cpProgress);
@@ -71,6 +74,7 @@ public:
       kSkipListed     = BIT(5),        ///< Skip objects specified in fObjectNames list
       kKeepCompression= BIT(6)         ///< Keep compression level unchanged for each input files
    };
+
    TFileMerger(Bool_t isLocal = kTRUE, Bool_t histoOneGo = kTRUE);
    virtual ~TFileMerger();
 
@@ -78,7 +82,7 @@ public:
    void        SetPrintLevel(Int_t level) { fPrintLevel = level; }
    Bool_t      HasCompressionChange() const { return fCompressionChange; }
    const char *GetOutputFileName() const { return fOutputFilename; }
-   TList      *GetMergeList() const { return fMergeList;  }
+   TList      *GetMergeList() { return &fMergeList; }
    TFile      *GetOutputFile() const { return fOutputFile; }
    Int_t       GetMaxOpenedFiles() const { return fMaxOpenedFiles; }
    void        SetMaxOpenedFiles(Int_t newmax);
@@ -113,7 +117,7 @@ public:
    virtual void   SetNotrees(Bool_t notrees=kFALSE) {fNoTrees = notrees;}
    virtual void        RecursiveRemove(TObject *obj);
 
-   ClassDef(TFileMerger,5)  // File copying and merging services
+   ClassDef(TFileMerger, 6)  // File copying and merging services
 };
 
 #endif

--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -88,17 +88,11 @@ static Int_t R__GetSystemMaxOpenedFiles()
 /// Create file merger object.
 
 TFileMerger::TFileMerger(Bool_t isLocal, Bool_t histoOneGo)
-            : fOutputFile(0), fFastMethod(kTRUE), fNoTrees(kFALSE), fExplicitCompLevel(kFALSE), fCompressionChange(kFALSE),
-              fPrintLevel(0), fMsgPrefix("TFileMerger"), fMaxOpenedFiles( R__GetSystemMaxOpenedFiles() ),
-              fLocal(isLocal), fHistoOneGo(histoOneGo), fObjectNames()
+            : fMaxOpenedFiles( R__GetSystemMaxOpenedFiles() ),
+              fLocal(isLocal), fHistoOneGo(histoOneGo)
 {
-   fFileList = new TList;
-
-   fMergeList = new TList;
-   fMergeList->SetOwner(kTRUE);
-
-   fExcessFiles = new TList;
-   fExcessFiles->SetOwner(kTRUE);
+   fMergeList.SetOwner(kTRUE);
+   fExcessFiles.SetOwner(kTRUE);
 
    R__LOCKGUARD(gROOTMutex);
    gROOT->GetListOfCleanups()->Add(this);
@@ -113,10 +107,7 @@ TFileMerger::~TFileMerger()
       R__LOCKGUARD(gROOTMutex);
       gROOT->GetListOfCleanups()->Remove(this);
    }
-   SafeDelete(fFileList);
-   SafeDelete(fMergeList);
    SafeDelete(fOutputFile);
-   SafeDelete(fExcessFiles);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -124,9 +115,9 @@ TFileMerger::~TFileMerger()
 
 void TFileMerger::Reset()
 {
-   fFileList->Clear();
-   fMergeList->Clear();
-   fExcessFiles->Clear();
+   fFileList.Clear();
+   fMergeList.Clear();
+   fExcessFiles.Clear();
    fObjectNames.Clear();
 }
 
@@ -136,20 +127,20 @@ void TFileMerger::Reset()
 Bool_t TFileMerger::AddFile(const char *url, Bool_t cpProgress)
 {
    if (fPrintLevel > 0) {
-      Printf("%s Source file %d: %s",fMsgPrefix.Data(),fFileList->GetEntries()+fExcessFiles->GetEntries()+1,url);
+      Printf("%s Source file %d: %s", fMsgPrefix.Data(), fFileList.GetEntries() + fExcessFiles.GetEntries() + 1, url);
    }
 
    TFile *newfile = 0;
    TString localcopy;
 
-   if (fFileList->GetEntries() >= (fMaxOpenedFiles-1)) {
+   if (fFileList.GetEntries() >= (fMaxOpenedFiles-1)) {
 
       TObjString *urlObj = new TObjString(url);
-      fMergeList->Add(urlObj);
+      fMergeList.Add(urlObj);
 
       urlObj = new TObjString(url);
       urlObj->SetBit(kCpProgress);
-      fExcessFiles->Add(urlObj);
+      fExcessFiles.Add(urlObj);
       return kTRUE;
    }
 
@@ -185,10 +176,10 @@ Bool_t TFileMerger::AddFile(const char *url, Bool_t cpProgress)
       if (fOutputFile && fOutputFile->GetCompressionLevel() != newfile->GetCompressionLevel()) fCompressionChange = kTRUE;
 
       newfile->SetBit(kCanDelete);
-      fFileList->Add(newfile);
+      fFileList.Add(newfile);
 
       TObjString *urlObj = new TObjString(url);
-      fMergeList->Add(urlObj);
+      fMergeList.Add(urlObj);
 
       return  kTRUE;
    }
@@ -229,7 +220,7 @@ Bool_t TFileMerger::AddFile(TFile *source, Bool_t own, Bool_t cpProgress)
    }
 
    if (fPrintLevel > 0) {
-      Printf("%s Source file %d: %s",fMsgPrefix.Data(),fFileList->GetEntries()+1,source->GetName());
+      Printf("%s Source file %d: %s",fMsgPrefix.Data(),fFileList.GetEntries()+1,source->GetName());
    }
 
    TFile *newfile = 0;
@@ -269,13 +260,10 @@ Bool_t TFileMerger::AddFile(TFile *source, Bool_t own, Bool_t cpProgress)
       } else {
          newfile->ResetBit(kCanDelete);
       }
-      fFileList->Add(newfile);
+      fFileList.Add(newfile);
 
-      if (!fMergeList) {
-         fMergeList = new TList;
-      }
       TObjString *urlObj = new TObjString(source->GetName());
-      fMergeList->Add(urlObj);
+      fMergeList.Add(urlObj);
 
       if (newfile != source && own) {
          delete source;
@@ -367,8 +355,8 @@ Bool_t TFileMerger::OutputFile(const char *outputfile, const char *mode /* = "RE
 
 void TFileMerger::PrintFiles(Option_t *options)
 {
-   fFileList->Print(options);
-   fExcessFiles->Print(options);
+   fFileList.Print(options);
+   fExcessFiles.Print(options);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -826,12 +814,12 @@ Bool_t TFileMerger::PartialMerge(Int_t in_type)
    }
 
    // Special treament for the single file case ...
-   if ((fFileList->GetEntries() == 1) && !fExcessFiles->GetEntries() &&
+   if ((fFileList.GetEntries() == 1) && !fExcessFiles.GetEntries() &&
       !(in_type & kIncremental) && !fCompressionChange && !fExplicitCompLevel) {
       fOutputFile->Close();
       SafeDelete(fOutputFile);
 
-      TFile *file = (TFile *) fFileList->First();
+      TFile *file = (TFile *) fFileList.First();
       if (!file || (file && file->IsZombie())) {
          Error("PartialMerge", "one-file case: problem attaching to file");
          return kFALSE;
@@ -850,7 +838,7 @@ Bool_t TFileMerger::PartialMerge(Int_t in_type)
          if (gSystem->Unlink(u.GetFile()) != 0)
             Warning("PartialMerge", "problems removing temporary local file '%s'", u.GetFile());
       }
-      fFileList->Clear();
+      fFileList.Clear();
       return result;
    }
 
@@ -860,11 +848,11 @@ Bool_t TFileMerger::PartialMerge(Int_t in_type)
 
    Bool_t result = kTRUE;
    Int_t type = in_type;
-   while (result && fFileList->GetEntries()>0) {
-      result = MergeRecursive(fOutputFile, fFileList, type);
+   while (result && fFileList.GetEntries()>0) {
+      result = MergeRecursive(fOutputFile, &fFileList, type);
 
       // Remove local copies if there are any
-      TIter next(fFileList);
+      TIter next(&fFileList);
       TFile *file;
       while ((file = (TFile*) next())) {
          // close the files
@@ -877,8 +865,8 @@ Bool_t TFileMerger::PartialMerge(Int_t in_type)
             gSystem->Unlink(p);
          }
       }
-      fFileList->Clear();
-      if (result && fExcessFiles->GetEntries() > 0) {
+      fFileList.Clear();
+      if (result && fExcessFiles.GetEntries() > 0) {
          // We merge the first set of files in the output,
          // we now need to open the next set and make
          // sure we accumulate into the output, so we
@@ -914,10 +902,10 @@ Bool_t TFileMerger::PartialMerge(Int_t in_type)
 Bool_t TFileMerger::OpenExcessFiles()
 {
    if (fPrintLevel > 0) {
-      Printf("%s Opening the next %d files",fMsgPrefix.Data(),TMath::Min(fExcessFiles->GetEntries(),(fMaxOpenedFiles-1)));
+      Printf("%s Opening the next %d files", fMsgPrefix.Data(), TMath::Min(fExcessFiles.GetEntries(), fMaxOpenedFiles - 1));
    }
    Int_t nfiles = 0;
-   TIter next(fExcessFiles);
+   TIter next(&fExcessFiles);
    TObjString *url = 0;
    TString localcopy;
    // We want gDirectory untouched by anything going on here
@@ -947,9 +935,9 @@ Bool_t TFileMerger::OpenExcessFiles()
          if (fOutputFile && fOutputFile->GetCompressionLevel() != newfile->GetCompressionLevel()) fCompressionChange = kTRUE;
 
          newfile->SetBit(kCanDelete);
-         fFileList->Add(newfile);
+         fFileList.Add(newfile);
          ++nfiles;
-         fExcessFiles->Remove(url);
+         fExcessFiles.Remove(url);
       }
    }
    return kTRUE;


### PR DESCRIPTION
- Do static initialization in the header where possible.
- Remove unnecessary pointers to `TList` in the `TFileMerger` when the `TList` is owned by the `TFileMerger`, always created, and has the same lifetime.  Avoids unnecessary heap allocations.
- As the data members have changed, increase the `ClassDef` version.