### PR TITLE
[TDF] Do not expect to always run `DefineSlot` on all slots

### DIFF
--- a/tree/treeplayer/test/dataframe/datasource_root.cxx
+++ b/tree/treeplayer/test/dataframe/datasource_root.cxx
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm> // std::accumulate
 #include <iostream>
 
 using namespace ROOT::Experimental;
@@ -128,28 +129,23 @@ TEST(TRootTDS, FromATDFWithJitting)
 // NOW MT!-------------
 #ifdef R__USE_IMT
 
-TEST(TRootTDS, DefineSlotCheckMT)
+TEST(TRootTDS, DefineSlotMT)
 {
-   auto nSlots = 4U;
+   const auto nSlots = 4U;
    ROOT::EnableImplicitMT(nSlots);
 
-   std::hash<std::thread::id> hasher;
-   using H_t = decltype(hasher(std::this_thread::get_id()));
-
-   std::vector<H_t> ids(nSlots, 0);
+   std::vector<unsigned int> ids(nSlots, 0u);
    std::unique_ptr<TDataSource> tds(new TRootDS(treeName, fileGlob));
    TDataFrame d(std::move(tds));
    auto m = d.DefineSlot("x", [&](unsigned int slot) {
-                std::this_thread::sleep_for(std::chrono::milliseconds(100));
-                ids[slot] = hasher(std::this_thread::get_id());
-                return 1.;
+                ids[slot] = 1u;
+                return 1;
              }).Max("x");
-
    EXPECT_EQ(1, *m); // just in case
 
-   std::set<H_t> s(ids.begin(), ids.end());
-   EXPECT_EQ(nSlots, s.size());
-   EXPECT_TRUE(s.end() == s.find(0));
+   const auto nUsedSlots = std::accumulate(ids.begin(), ids.end(), 0u);
+   EXPECT_GT(nUsedSlots, 0u);
+   EXPECT_LE(nUsedSlots, nSlots);
 }
 
 TEST(TRootTDS, FromATDFMT)


### PR DESCRIPTION
This assumption was causing rare breakages in test/datasource_root.cxx