### PR TITLE
Readd support in ClassDef for classes with same name as data member.

### DIFF
--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -290,15 +290,15 @@ private:                                                                        
    {                                                                                                            \
       static std::atomic<UChar_t> recurseBlocker(0);                                                            \
       if (R__likely(recurseBlocker >= 2)) {                                                                     \
-         return ::ROOT::Internal::THashConsistencyHolder<name>::fgHashConsistency;                              \
+         return ::ROOT::Internal::THashConsistencyHolder<decltype(*this)>::fgHashConsistency;                   \
       } else if (recurseBlocker == 1) {                                                                         \
          return false;                                                                                          \
       } else if (recurseBlocker++ == 0) {                                                                       \
-         ::ROOT::Internal::THashConsistencyHolder<name>::fgHashConsistency =                                    \
+         ::ROOT::Internal::THashConsistencyHolder<decltype(*this)>::fgHashConsistency =                         \
             ::ROOT::Internal::HasConsistentHashMember(Class_Name()) ||                                          \
             ::ROOT::Internal::HasConsistentHashMember(*IsA());                                                  \
          ++recurseBlocker;                                                                                      \
-         return ::ROOT::Internal::THashConsistencyHolder<name>::fgHashConsistency;                              \
+         return ::ROOT::Internal::THashConsistencyHolder<decltype(*this)>::fgHashConsistency;                   \
       }                                                                                                         \
       return false; /* unreacheable */                                                                          \
    }                                                                                                            \
@@ -330,11 +330,11 @@ public: \
    static const char *ImplFileName() { return 0; }                                                               \
    static const char *Class_Name()                                                                               \
    {                                                                                                             \
-      return ::ROOT::Internal::ClassDefGenerateInitInstanceLocalInjector<name>::Name();                          \
+      return ::ROOT::Internal::ClassDefGenerateInitInstanceLocalInjector<name>::Name();               \
    }                                                                                                             \
    static TClass *Dictionary()                                                                                   \
    {                                                                                                             \
-      return ::ROOT::Internal::ClassDefGenerateInitInstanceLocalInjector<name>::Dictionary();                    \
+      return ::ROOT::Internal::ClassDefGenerateInitInstanceLocalInjector<name>::Dictionary();         \
    }                                                                                                             \
    static TClass *Class() { return ::ROOT::Internal::ClassDefGenerateInitInstanceLocalInjector<name>::Class(); } \
    virtual_keyword void Streamer(TBuffer &R__b) overrd { ::ROOT::Internal::DefaultStreamer(R__b, name::Class(), this); }

--- a/core/meta/test/testHashRecursiveRemove.cxx
+++ b/core/meta/test/testHashRecursiveRemove.cxx
@@ -117,6 +117,17 @@ const char *gCode = R"CODE(
       ClassDefInline(WrongSetup, 2);
    };
 
+   // This example is valid according to C++11, 9.2/16: In addition, if class T has a user-declared constructor (12.1),
+   // every non-static data member of class T shall have a name different from T.
+   //
+   class Rho: public TObject
+   {
+      public:
+      Float_t Rho; // rho energy density
+      Float_t Edges[2]; // pseudorapidity range edges
+
+      ClassDef(Rho, 1)
+   };
 )CODE";
 
 class WrongSetup : public TObject {


### PR DESCRIPTION
For example:

class Rho: public TObject
{
   public:
   Float_t Rho; // rho energy density
   Float_t Edges[2]; // pseudorapidity range edges

   ClassDef(Rho, 1)
};

This leads to a compilation error when doing

  THashConsistencyHolder<name>

and lead to

 error: template argument for template type parameter must be a type

because in that context the data member hid the class name
So we now do

  THashConsistencyHolder<decltype(*this)>