### PR TITLE
[cling] Fix TLS in the cling JIT

### DIFF
--- a/interpreter/cling/lib/Interpreter/IncrementalExecutor.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalExecutor.cpp
@@ -72,11 +72,9 @@ CreateHostTargetMachine(const clang::CompilerInstance& CI) {
   std::string MCPU;
   std::string FeaturesStr;
 
-  auto TM = std::unique_ptr<TargetMachine>(TheTarget->createTargetMachine(Triple,
-                                        MCPU, FeaturesStr,
-                                        llvm::TargetOptions(),
-                                        Optional<Reloc::Model>(), CMModel,
-                                        OptLevel));
+  auto TM = std::unique_ptr<TargetMachine>(TheTarget->createTargetMachine(
+      Triple, MCPU, FeaturesStr, llvm::TargetOptions(),
+      Optional<Reloc::Model>(), CMModel, OptLevel));
   TM->Options.EmulatedTLS = true;
   return TM;
 }

--- a/interpreter/cling/lib/Interpreter/IncrementalExecutor.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalExecutor.cpp
@@ -72,11 +72,13 @@ CreateHostTargetMachine(const clang::CompilerInstance& CI) {
   std::string MCPU;
   std::string FeaturesStr;
 
-  return std::unique_ptr<TargetMachine>(TheTarget->createTargetMachine(Triple,
+  auto TM = std::unique_ptr<TargetMachine>(TheTarget->createTargetMachine(Triple,
                                         MCPU, FeaturesStr,
                                         llvm::TargetOptions(),
                                         Optional<Reloc::Model>(), CMModel,
                                         OptLevel));
+  TM->Options.EmulatedTLS = true;
+  return TM;
 }
 
 } // anonymous namespace


### PR DESCRIPTION
TLS is currently not suppored in the JIT. However, it's possible to
enable emulated TLS support in LLVM which means that we now support
TLS across all architectures. The performance downsides of this
should be neglectiable and can be easily worked around (by merging
TLS variables into a single one).

Patch created with a lot of help from Lang Hames and Pavel Labath!