### PR TITLE
Fix compiler warnings and simplify function

### DIFF
--- a/tree/tree/src/TIOFeatures.cxx
+++ b/tree/tree/src/TIOFeatures.cxx
@@ -169,7 +169,6 @@ bool TIOFeatures::Set(EIOFeatures input_bits)
 /// and returns kFALSE.
 bool TIOFeatures::Set(const std::string &value)
 {
-   TBasket::EIOBits bits = static_cast<TBasket::EIOBits>(0);
    TClass *cl = TBasket::Class();
    if (cl == nullptr) {
       Error("Set", "Could not retrieve TBasket's class");
@@ -180,19 +179,13 @@ bool TIOFeatures::Set(const std::string &value)
       Error("Set", "Could not locate TBasket::EIOBits enum");
       return kFALSE;
    }
-   bool foundConstant = false;
    for (auto constant : ROOT::Detail::TRangeStaticCast<TEnumConstant>(eIOBits->GetConstants())) {
       if (!strcmp(constant->GetName(), value.c_str())) {
-         foundConstant = true;
-         bits = static_cast<TBasket::EIOBits>(constant->GetValue());
-         break;
+         return Set(static_cast<EIOFeatures>(constant->GetValue()));
       }
    }
-   if (!foundConstant) {
-      Error("Set", "Could not locate %s in TBasket::EIOBits", value.c_str());
-      return kFALSE;
-   }
-   return Set(static_cast<EIOFeatures>(bits));
+   Error("Set", "Could not locate %s in TBasket::EIOBits", value.c_str());
+   return kFALSE;
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/tree/tree/test/TBasket.cxx
+++ b/tree/tree/test/TBasket.cxx
@@ -263,7 +263,6 @@ TEST(TBasket, TestVarLengthArrays)
       saved_t1->GetEntry(idx);
       Int_t expected_elem = idx % 9;
       EXPECT_EQ(expected_elem, saved_elem);
-      ASSERT_NE(saved_sample, nullptr);
       for (idx2 = 0; idx2 < expected_elem; idx2++) {
          EXPECT_EQ(saved_sample[idx2], sample[idx2]);
       }
@@ -391,8 +390,6 @@ TEST(TBasket, TestSettingIOBits)
       Int_t expected_elem = idx % 9;
       EXPECT_EQ(expected_elem, saved_elem);
       EXPECT_EQ(expected_elem, saved_elem2);
-      ASSERT_NE(saved_sample, nullptr);
-      ASSERT_NE(saved_sample2, nullptr);
       for (idx2 = 0; idx2 < expected_elem; idx2++) {
          EXPECT_EQ(saved_sample2[idx2], sample[idx2]);
          EXPECT_EQ(saved_sample[idx2], sample[idx2]);


### PR DESCRIPTION
Fix some minor compiler warnings on various platforms.  Simplify the `TIOFeatures::Set` implementation as suggested by @pcanal 

I do not believe any of these indicate real bugs.  Just some code cleanliness.