### PR TITLE
Switch back to O0.

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -1133,7 +1133,10 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
     CGOpts.CXXCtorDtorAliases = 1;
 #endif
     // Reduce amount of emitted symbols by optimizing more.
-    CGOpts.OptimizationLevel = 2;
+    // FIXME: We have a bug when we switch to -O2, for some cases it takes
+    // several minutes to optimize, while the same code compiled by clang -O2
+    // takes only a few seconds.
+    CGOpts.OptimizationLevel = 0;
     // Taken from a -O2 run of clang:
     CGOpts.DiscardValueNames = 1;
     CGOpts.OmitLeafFramePointer = 1;

--- a/interpreter/cling/test/Pragmas/opt.C
+++ b/interpreter/cling/test/Pragmas/opt.C
@@ -13,10 +13,10 @@ extern "C" int printf(const char*,...);
 #include "cling/Interpreter/Transaction.h"
 
 gCling->getDefaultOptLevel()
-// CHECK: (int) 2
+// CHECK: (int) 0
 
 (int)gCling->getLatestTransaction()->getCompilationOpts().OptLevel
-// CHECK-NEXT: (int) 2
+// CHECK-NEXT: (int) 0
 
 {
 #pragma cling optimize(0)

--- a/interpreter/cling/test/Prompt/MetaProcessor/DotO.C
+++ b/interpreter/cling/test/Prompt/MetaProcessor/DotO.C
@@ -12,13 +12,13 @@ extern "C" int printf(const char*,...);
 #include "cling/Interpreter/Interpreter.h"
 #include "cling/Interpreter/Transaction.h"
 
-gCling->getDefaultOptLevel() // CHECK: (int) 2
-.O // CHECK-NEXT: Current cling optimization level: 2
-(int)gCling->getLatestTransaction()->getCompilationOpts().OptLevel // CHECK-NEXT: (int) 2
-
-.O 0
 gCling->getDefaultOptLevel() // CHECK: (int) 0
 .O // CHECK-NEXT: Current cling optimization level: 0
+(int)gCling->getLatestTransaction()->getCompilationOpts().OptLevel // CHECK-NEXT: (int) 2
+
+.O 2
+gCling->getDefaultOptLevel() // CHECK: (int) 2
+.O // CHECK-NEXT: Current cling optimization level: 2
 
 #pragma cling optimize(1)
 gCling->getDefaultOptLevel() // CHECK: (int) 0


### PR DESCRIPTION
We have a suboptimal behavior in the way cling optimizes code in O2 mode.
Disable it until the issue is understood and fixed.