### PR TITLE
Add Async and TFuture tutorials: MERGE AFTER PR1208

### DIFF
--- a/tutorials/multicore/mt303_AsyncSimple.C
+++ b/tutorials/multicore/mt303_AsyncSimple.C
@@ -8,7 +8,6 @@
 /// \author Danilo Piparo
 /// \date August 2017
 
-
 #include "TROOT.h"
 #include "ROOT/TFuture.hxx"
 
@@ -26,7 +25,10 @@ void mt303_AsyncSimple()
    ROOT::EnableImplicitMT(1);
 
    auto wi0 = ROOT::Experimental::Async(workItem0);
-   auto wi1 = ROOT::Experimental::Async([](){printf("Running workItem1...\n"); return 1;});
+   auto wi1 = ROOT::Experimental::Async([]() {
+      printf("Running workItem1...\n");
+      return 1;
+   });
 
    printf("Running something in the \"main\" thread\n");
 
@@ -34,7 +36,10 @@ void mt303_AsyncSimple()
    std::cout << "The result of the work item 1 is " << wi1.get() << std::endl;
 
    printf("All work completed.\n");
-
 }
 
-int main(){mt303_AsyncSimple(); return 0;}
+int main()
+{
+   mt303_AsyncSimple();
+   return 0;
+}

--- a/tutorials/multicore/mt303_AsyncSimple.C
+++ b/tutorials/multicore/mt303_AsyncSimple.C
@@ -1,0 +1,40 @@
+/// \file
+/// \ingroup tutorial_multicore
+/// \notebook -js
+/// Shows how to run items of work asynchronously with Async.
+///
+/// \macro_code
+///
+/// \author Danilo Piparo
+/// \date August 2017
+
+
+#include "TROOT.h"
+#include "ROOT/TFuture.hxx"
+
+#include <iostream>
+
+int workItem0()
+{
+   printf("Running workItem0...\n");
+   return 0;
+}
+
+void mt303_AsyncSimple()
+{
+
+   ROOT::EnableImplicitMT(1);
+
+   auto wi0 = ROOT::Experimental::Async(workItem0);
+   auto wi1 = ROOT::Experimental::Async([](){printf("Running workItem1...\n"); return 1;});
+
+   printf("Running something in the \"main\" thread\n");
+
+   std::cout << "The result of the work item 0 is " << wi0.get() << std::endl;
+   std::cout << "The result of the work item 1 is " << wi1.get() << std::endl;
+
+   printf("All work completed.\n");
+
+}
+
+int main(){mt303_AsyncSimple(); return 0;}

--- a/tutorials/multicore/mt304_AsyncNested.C
+++ b/tutorials/multicore/mt304_AsyncNested.C
@@ -1,0 +1,38 @@
+/// \file
+/// \ingroup tutorial_multicore
+/// \notebook -js
+/// Calculate Fibonacci numbers exploiting nested parallelism through Async.
+///
+/// \macro_code
+///
+/// \author Danilo Piparo
+/// \date August 2017
+
+#include "TROOT.h"
+#include "ROOT/TFuture.hxx"
+
+#include <future>
+#include <iostream>
+
+
+int Fibonacci(int n) {
+   if( n<2 ) {
+      return n;
+   } else {
+      auto fut1 = ROOT::Experimental::Async(Fibonacci, n-1);
+      auto fut2 = ROOT::Experimental::Async(Fibonacci, n-2);
+      auto res = fut1.get() + fut2.get();
+      return res;
+   }
+}
+
+void mt304_AsyncNested()
+{
+
+   ROOT::EnableImplicitMT(4);
+
+   std::cout << "Fibonacci(33) = " << Fibonacci(33) << std::endl;
+
+}
+
+int main(){mt304_AsyncNested(); return 0;}

--- a/tutorials/multicore/mt304_AsyncNested.C
+++ b/tutorials/multicore/mt304_AsyncNested.C
@@ -14,13 +14,13 @@
 #include <future>
 #include <iostream>
 
-
-int Fibonacci(int n) {
-   if( n<2 ) {
+int Fibonacci(int n)
+{
+   if (n < 2) {
       return n;
    } else {
-      auto fut1 = ROOT::Experimental::Async(Fibonacci, n-1);
-      auto fut2 = ROOT::Experimental::Async(Fibonacci, n-2);
+      auto fut1 = ROOT::Experimental::Async(Fibonacci, n - 1);
+      auto fut2 = ROOT::Experimental::Async(Fibonacci, n - 2);
       auto res = fut1.get() + fut2.get();
       return res;
    }
@@ -32,7 +32,10 @@ void mt304_AsyncNested()
    ROOT::EnableImplicitMT(4);
 
    std::cout << "Fibonacci(33) = " << Fibonacci(33) << std::endl;
-
 }
 
-int main(){mt304_AsyncNested(); return 0;}
+int main()
+{
+   mt304_AsyncNested();
+   return 0;
+}

--- a/tutorials/multicore/mt305_TFuture.C
+++ b/tutorials/multicore/mt305_TFuture.C
@@ -1,0 +1,39 @@
+/// \file
+/// \ingroup tutorial_multicore
+/// \notebook -js
+/// Shows how to use the Future class of ROOT as a wrapper of std::future.
+///
+/// \macro_code
+///
+/// \author Danilo Piparo
+/// \date August 2017
+
+#include "ROOT/TFuture.hxx"
+
+#include <future>
+#include <iostream>
+#include <thread>
+
+void mt305_TFuture()
+{
+   using namespace ROOT::Experimental;
+
+   // future from a packaged_task
+   std::packaged_task<int()> task([]() { return 7; }); // wrap the function
+   TFuture<int> f1 = task.get_future();                // get a future
+   std::thread(std::move(task)).detach();              // launch on a thread
+
+   // future from an async()
+   TFuture<int> f2 = std::async(std::launch::async, []() { return 8; });
+
+   // future from a promise
+   std::promise<int> p;
+   TFuture<int> f3 (p.get_future());
+   std::thread([&p] { p.set_value(9); }).detach();
+
+   std::cout << "Waiting..." << std::flush;
+   f1.wait();
+   f2.wait();
+   f3.wait();
+   std::cout << "Done!\nResults are: " << f1.get() << ' ' << f2.get() << ' ' << f3.get() << '\n';
+}

--- a/tutorials/multicore/mt305_TFuture.C
+++ b/tutorials/multicore/mt305_TFuture.C
@@ -28,7 +28,7 @@ void mt305_TFuture()
 
    // future from a promise
    std::promise<int> p;
-   TFuture<int> f3 (p.get_future());
+   TFuture<int> f3(p.get_future());
    std::thread([&p] { p.set_value(9); }).detach();
 
    std::cout << "Waiting..." << std::flush;


### PR DESCRIPTION
This PR adds the Async and TFuture tutorials to the multicore examples collections. This PR shall be merged only after PR1208, which allows the usage of TLS in interpreted code.