### PR TITLE
Xcode/clang 9.0 fixes for ROOT::TFile

### DIFF
--- a/io/io/v7/inc/ROOT/TFile.hxx
+++ b/io/io/v7/inc/ROOT/TFile.hxx
@@ -160,7 +160,7 @@ public:
 
   /// Write an object that is already lifetime managed by this TFileImplBase.
   void Write(std::string_view name) {
-    auto dep = Find(name.to_string());
+    auto dep = Find(std::string(name));
     WriteMemoryWithType(name, dep.GetPointer().get(), dep.GetType());
   }
 

--- a/io/io/v7/src/TFile.cxx
+++ b/io/io/v7/src/TFile.cxx
@@ -97,7 +97,7 @@ public:
   }
 
   void WriteMemoryWithType(std::string_view name, const void* address, TClass* cl) final {
-    fOldFile->WriteObjectAny(address, cl, name.to_string().c_str());
+    fOldFile->WriteObjectAny(address, cl, std::string(name).c_str());
   }
 };
 }
@@ -144,7 +144,7 @@ OpenV6TFile(std::string_view name, const char* mode,
     }
   } setCacheDirRAII(opts.fCachedRead);
 
-  auto v6storage = std::make_unique<TV6Storage>(name.to_string(), GetV6TFileOpts(mode, opts));
+  auto v6storage = std::make_unique<TV6Storage>(std::string(name), GetV6TFileOpts(mode, opts));
 
   using namespace ROOT::Experimental::Internal;
   return std::unique_ptr<TFileStorageInterface>{std::move(v6storage)};
@@ -191,7 +191,7 @@ std::string ROOT::Experimental::TFile::SetCacheDir(std::string_view path) {
   std::lock_guard<std::mutex> lock(GetCacheDirMutex());
 
   std::string ret = ::TFile::GetCacheFileDir();
-  ::TFile::SetCacheFileDir(path.to_string().c_str());
+  ::TFile::SetCacheFileDir(std::string(path).c_str());
   return ret;
 }
 


### PR DESCRIPTION
Added some simple fixes to `ROOT::TFile`, to make it build with Xcode/Clang 9.0 on macOS High Sierra in C++14 mode.

This is to fix the build problem described in https://sft.its.cern.ch/jira/browse/ROOT-9072. (I just thought that I might as well propose a fix, since I fixed it for my local installation anyway.)

I imagine that cherry-picking the fix into the master branch would not be up to me anymore... (Should've read the contribution guidelines... 😛)