### PR TITLE
[TDF] Remove clang warnings

### DIFF
--- a/tree/treeplayer/test/dataframe/TStreamingDS.hxx
+++ b/tree/treeplayer/test/dataframe/TStreamingDS.hxx
@@ -29,7 +29,7 @@ public:
       for (auto i = 0u; i < fNSlots; ++i)
          ranges[i] = std::make_pair(fCounter*fNSlots + i, fCounter*fNSlots + i + 1);
       ++fCounter;
-      return std::move(ranges);
+      return ranges;
    }
    void SetEntry(unsigned int, ULong64_t) {}
    void Initialise() { fCounter = 0; }


### PR DESCRIPTION
Today I learned: returning a local variable calls the move-ctor by default if available.