### PR TITLE
For the HasConsistentHashMember shortcut, don't use Class_Name.

### DIFF
--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -295,7 +295,7 @@ private:                                                                        
          return false;                                                                                          \
       } else if (recurseBlocker++ == 0) {                                                                       \
          ::ROOT::Internal::THashConsistencyHolder<decltype(*this)>::fgHashConsistency =                         \
-            ::ROOT::Internal::HasConsistentHashMember(Class_Name()) ||                                          \
+            ::ROOT::Internal::HasConsistentHashMember(_QUOTE_(name)) ||                                          \
             ::ROOT::Internal::HasConsistentHashMember(*IsA());                                                  \
          ++recurseBlocker;                                                                                      \
          return ::ROOT::Internal::THashConsistencyHolder<decltype(*this)>::fgHashConsistency;                   \

--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -226,7 +226,6 @@ template <typename T>
 class ClassDefGenerateInitInstanceLocalInjector:
    public TCDGIILIBase {
       static atomic_TClass_ptr fgIsA;
-      static std::string fgName;
       static ::ROOT::TGenericClassInfo *fgGenericInfo;
    public:
       static void *New(void *p) { return p ? new(p) T : new T; };
@@ -252,16 +251,15 @@ class ClassDefGenerateInitInstanceLocalInjector:
       static TClass *Dictionary() { fgIsA = fgGenericInfo->GetClass(); return fgIsA; }
       static TClass *Class() { SetfgIsA(fgIsA, &Dictionary); return fgIsA; }
       static const char* Name() {
-         if (fgName.empty())
-            SetName(TTypeNameExtraction<T>::Get(), fgName);
-         return fgName.c_str();
+         static std::string gName;
+         if (gName.empty())
+            SetName(TTypeNameExtraction<T>::Get(), gName);
+         return gName.c_str();
       }
    };
 
    template<typename T>
    atomic_TClass_ptr ClassDefGenerateInitInstanceLocalInjector<T>::fgIsA{};
-   template<typename T>
-   std::string ClassDefGenerateInitInstanceLocalInjector<T>::fgName{};
    template<typename T>
    ::ROOT::TGenericClassInfo *ClassDefGenerateInitInstanceLocalInjector<T>::fgGenericInfo {
       ClassDefGenerateInitInstanceLocalInjector<T>::GenerateInitInstanceLocal()

--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -293,7 +293,7 @@ private:                                                                        
          return false;                                                                                          \
       } else if (recurseBlocker++ == 0) {                                                                       \
          ::ROOT::Internal::THashConsistencyHolder<decltype(*this)>::fgHashConsistency =                         \
-            ::ROOT::Internal::HasConsistentHashMember(_QUOTE_(name)) ||                                          \
+            ::ROOT::Internal::HasConsistentHashMember(_QUOTE_(name)) ||                                         \
             ::ROOT::Internal::HasConsistentHashMember(*IsA());                                                  \
          ++recurseBlocker;                                                                                      \
          return ::ROOT::Internal::THashConsistencyHolder<decltype(*this)>::fgHashConsistency;                   \
@@ -328,11 +328,11 @@ public: \
    static const char *ImplFileName() { return 0; }                                                               \
    static const char *Class_Name()                                                                               \
    {                                                                                                             \
-      return ::ROOT::Internal::ClassDefGenerateInitInstanceLocalInjector<name>::Name();               \
+      return ::ROOT::Internal::ClassDefGenerateInitInstanceLocalInjector<name>::Name();                          \
    }                                                                                                             \
    static TClass *Dictionary()                                                                                   \
    {                                                                                                             \
-      return ::ROOT::Internal::ClassDefGenerateInitInstanceLocalInjector<name>::Dictionary();         \
+      return ::ROOT::Internal::ClassDefGenerateInitInstanceLocalInjector<name>::Dictionary();                    \
    }                                                                                                             \
    static TClass *Class() { return ::ROOT::Internal::ClassDefGenerateInitInstanceLocalInjector<name>::Class(); } \
    virtual_keyword void Streamer(TBuffer &R__b) overrd { ::ROOT::Internal::DefaultStreamer(R__b, name::Class(), this); }

--- a/core/base/inc/TString.h
+++ b/core/base/inc/TString.h
@@ -784,12 +784,12 @@ inline Bool_t operator!=(const char *s1, const TSubString &s2)
 
 #ifndef WIN32
 // To avoid ambiguities.
-inline Bool_t operator==(const char *s1, std::string_view &s2)
+inline Bool_t operator==(const char *s1, const std::string_view &s2)
 {
   return std::string_view(s1) == s2;
 }
 
-inline Bool_t operator==(std::string_view &s1, const char *s2)
+inline Bool_t operator==(const std::string_view &s1, const char *s2)
 {
   return s1 == std::string_view(s2);
 }

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -6982,6 +6982,7 @@ Bool_t ROOT::Internal::HasConsistentHashMember(const char *cname)
    static const char *handVerified[] = {
       "TEnvRec",    "TDataType",      "TObjArray",    "TList",   "THashList",
       "TClass",     "TCling",         "TInterpreter", "TMethod", "ROOT::Internal::TCheckHashRecurveRemoveConsistency",
+      "TCheckHashRecurveRemoveConsistency",
       "TDirectory", "TDirectoryFile", "TObject",      "TH1"};
 
    if (cname && cname[0]) {


### PR DESCRIPTION
Use Class_Name leads to:

error: explicit specialization of 'Class_Name' after instantiation

when compiling with modules on