### PR TITLE
[cxxmodules] Set fastmath for rootcling_stage1

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -4361,6 +4361,11 @@ int RootClingMain(int argc,
          interpPtr->setCallbacks(std::move(callBacks));
       }
    } else {
+#ifdef R__FAST_MATH
+      // Same setting as in TCling.cxx.
+      clingArgsC.push_back("-ffast-math");
+#endif
+
       owningInterpPtr.reset(new cling::Interpreter(clingArgsC.size(), &clingArgsC[0],
                                                    resourceDir.c_str()));
       interpPtr = owningInterpPtr.get();

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1165,6 +1165,7 @@ TCling::TCling(const char *name, const char *title)
    }
 
 #ifdef R__FAST_MATH
+   // Same setting as in rootcling_impl.cxx.
    interpArgs.push_back("-ffast-math");
 #endif
 


### PR DESCRIPTION
When building ROOT in optimized mode, we enable fast math which then
disables errno on math functions. But this only happens in TCling,
so all modules built by rootcling_stage1 are suddenly out of sync
and we get errors like this:
```
error: errno in math functions was enabled in PCH file but is currently disabled
```

This patch just applies the same setting in _stage1. In theory we
should make a central place where we have these extra flags, but
that's out of scope for now.