### PR TITLE
webgui: Introduce TText class

### DIFF
--- a/documentation/HttpServer/HttpServer.md
+++ b/documentation/HttpServer/HttpServer.md
@@ -430,3 +430,68 @@ To use `multi.json` request from the JavaScript, one should create special 'POST
 
 Here argument "multi" identifies, that server response should be parsed with `JSROOT.parse_multi()` function, which correctly interprets JSON code, produced by `multi.json` request. When sending such request to the server, one should provide list of objects names and not forget "?number=N" parameter in the request URL string.
 
+
+## Websockets supports
+
+Websockets support available starting from ROOT v6.12. 
+Minimal example provided in `$ROOTSYS/tutorials/http/ws.C` macro.
+
+To work with websockets, subclass of THttpWSHandler should be created and registered to THttpServer:
+
+    #include "THttpWSHandler.h"
+
+    class TUserHandler : public THttpWSHandler {
+    public:
+       TUserHandler(const char *name, const char *title) : THttpWSHandler(name, title) {}
+
+       // provide custom HTML page when open correpondent address
+       TString GetDefaultPageContent() { return ""; }
+
+       virtual Bool_t ProcessWS(THttpCallArg *arg);
+    };
+  
+Central method is `TUserHandler::ProcessWS(THttpCallArg *arg)`, where four kinds of websockets events should be handled:
+  
+   * WS_CONNECT - clients attempts to create websockets, return false when refusing connection
+   * WS_READY   - connection is ready to use, **wsid** can be obtained with `arg->GetWSId()` calls   
+   * WS_DATA    - new portion of data received by webcosket 
+   * WS_CLOSE   - connection closed by the client, **wsid** is no longer valid  
+
+These kinds are coded as method name of THttpCallArg class and can be used like:
+
+    Bool_t TUserHandler::ProcessWS(THttpCallArg *arg)
+    {
+       if (arg->IsMethod("WS_CONNECT")) {
+          return kTRUE; // accept all connections
+       }
+
+       if (arg->IsMethod("WS_READY")) {
+          SendCharStartWS(arg->GetWSId(), "Init"); // immediately send message to the web socket
+          return kTRUE;
+       }
+
+       if (arg->IsMethod("WS_CLOSE")) {
+          return kTRUE; // just confirm connection
+       }
+
+       if (arg->IsMethod("WS_DATA")) {
+          TString str = arg->GetPostDataAsString();
+          printf("Client msg: %s\n", str.Data());
+          SendCharStarWS(arg->GetWSId(), "Confirm");
+          return kTRUE;
+       }
+
+       return kFALSE; // ignore all other kind of requests
+    }
+ 
+Instance of **TUserHandler** should be registered to the THttpServer like:
+
+    THttpServer *serv = new THttpServer("http:8080");
+    TUserHandler *handler = new TUserHandler("name1","title");
+    serv->Register(handler);
+    
+After that web socket connection can be established with the address `ws://host_name:8080/name1/root.websocket`
+Example client code can be found in `$ROOTSYS/tutorials/http/ws.htm` file. Actually, custom HTML page for
+websocket handler can be specified with `TUserHandler::GetDefaultPageContent()` method returning `"file:ws.htm"`.
+ 
+ 

--- a/documentation/JSROOT/JSROOT.md
+++ b/documentation/JSROOT/JSROOT.md
@@ -44,6 +44,7 @@ To automate files loading and objects drawing, one can provide number of URL par
 - interactive - enable/disable interactive functions 0-disable all, 1-enable all
 - noselect - hide file-selection part in the browser (only when file name is specified)
 - mathjax - use MathJax for latex output
+- latex - 'off', 'symbols', 'normal', 'mathjax', 'alwaysmath' control of TLatex processor
 - style - name of TStyle object to define global JSROOT style
 - toolbar - show canvas tool buttons 'off', 'on' and 'popup'
 
@@ -87,6 +88,7 @@ List of supported classes and draw options:
 [*](https://root.cern/js/latest/examples.htm#th1_star),
 [l](https://root.cern/js/latest/examples.htm#th1_l),
 [lf2](https://root.cern/js/latest/examples.htm#th1_lf2),
+[a](https://root.cern/js/latest/examples.htm#th1_a),
 [e](https://root.cern/js/latest/examples.htm#th1_e),
 [e0](https://root.cern/js/latest/examples.htm#th1_e0),
 [e1](https://root.cern/js/latest/examples.htm#th1_e1),
@@ -139,7 +141,8 @@ List of supported classes and draw options:
 - TProfile2D : [example](https://root.cern/js/latest/examples.htm#misc_profile2d)
 - THStack : [example](https://root.cern/js/latest/examples.htm#thstack)
 - TF1 : [example](https://root.cern/js/latest/examples.htm#tf1_canv)
-- TF2 : [example](https://root.cern/js/latest/examples.htm#misc_tf2)
+- TF2 : [example](https://root.cern/js/latest/examples.htm#tf2_tf2)
+- TSpline : [example](https://root.cern/js/latest/examples.htm#misc_spline)
 - TGraph : [dflt](https://root.cern/js/latest/examples.htm#tgraph),
 [L](https://root.cern/js/latest/examples.htm#tgraph_l),
 [P](https://root.cern/js/latest/examples.htm#tgraph_p),
@@ -160,6 +163,7 @@ List of supported classes and draw options:
 [5](https://root.cern/js/latest/examples.htm#tgrapherrors_5),
 - TGraphAsymmErrors : [dflt](https://root.cern/js/latest/examples.htm#tgraphasymmerrors),
 [z](https://root.cern/js/latest/examples.htm#tgraphasymmerrors_z) and other from TGraphErrors
+- TGraphPolar : [example](https://root.cern/js/latest/examples.htm#tgraphpolar)
 - TMultiGraph : [example](https://root.cern/js/latest/examples.htm#tmultigraph_c3), [exclusion](https://root.cern/js/latest/examples.htm#tmultigraph_exclusion)
 - TGraph2D : [example](https://root.cern/js/latest/examples.htm#tgraph2d)
 - TLatex : [example](https://root.cern/js/latest/examples.htm#tlatex_latex)
@@ -519,7 +523,8 @@ Here, the default location of JSROOT is specified. One could have a local copy o
 
 In URL string with JSRootCore.js script one can specify which JSROOT functionality should be loaded:
 
-    + '2d' normal drawing for objects like TH1/TCanvas/TGraph
+    + '2d' basic drawing functionality, support TPad/TCanvas/TFrame
+    + 'hist' histograms drawing
     + 'more2d' more classes for 2D drawing like TH2/TF1/TEllipse
     + '3d' 3D drawing for 2D/3D histograms
     + 'geo' 3D drawing of TGeo classes
@@ -527,6 +532,7 @@ In URL string with JSRootCore.js script one can specify which JSROOT functionali
     + 'tree' TTree functionality
     + 'math' advanced mathemathical functions
     + 'mathjax' loads MathJax.js and use it for latex output
+    + 'openui5' load and configure OpenUI5 toolkit
     + 'gui' default gui for offline/online applications
     + 'load' name of user script(s) to load
     + 'onload' name of function to call when scripts loading completed
@@ -595,6 +601,13 @@ Here is complete [running example](https://root.cern/js/latest/api.htm#custom_ht
        JSROOT.draw("drawing", obj, "lego");
     }).send();
 
+In very seldom cases one need to access painter object, created in JSROOT.draw() function. This can be done via
+call back (forth argument) like: 
+
+    JSROOT.draw("drawing", obj, "colz", function(painter) {
+       console.log('Object type in painter', painter.GetObject()._typename);
+    });
+
 One is also able to update the drawing with a new version of the object:
 
     // after some interval request object again
@@ -618,7 +631,7 @@ To correctly cleanup JSROOT drawings from HTML element, one should call:
 
 ### File API
 
-JSROOT defines the JSROOT.TFile class, which can be used to access binary ROOT files.
+JSROOT defines the TFile class, which can be used to access binary ROOT files.
 One should always remember that all I/O operations are asynchronous in JSROOT.
 Therefore, callback functions are used to react when the I/O operation completed.
 For example, reading an object from a file and displaying it will look like:
@@ -747,3 +760,41 @@ create SVG output. For example, open create SVG image with lego plot, one should
         });
      });               
  
+
+### Use with OpenUI5
+
+[OpenUI5](http://openui5.org/) is  a web toolkit for developers to ease and speed up the development of full-blown HTML5 web applications. Since version 5.3.0 JSROOT provides possibility to use OpenUI5 functionality together with JSROOT.
+
+First problem is bootstraping of OpenUI5. Most easy solution - specify openui5 URL parameter when loading JSROOT:
+
+   
+      <script type="text/javascript" 
+              src="https://root.cern/js/latest/scripts/JSRootCore.min.js?openui5&onload=doInit">
+      </script>
+ 
+ JSROOT uses https://openui5.hana.ondemand.com to load latest stable version of OpenUI5. After loading is completed, 
+ specified initialization function will be called, where `JSROOT.sap` can be used as normal `sap` variable.
+ Simple way to start any custom application is:
+ 
+      <script type="text/javascript">
+         function doInit() {
+            jQuery.sap.registerModulePath("sap.m.sample.NavContainer", "./");
+            new JSROOT.sap.m.App ({
+              pages: [
+                new JSROOT.sap.m.Page({
+                  title: "Nav Container",
+                    enableScrolling : true,
+                    content: [ new sap.ui.core.ComponentContainer({
+                         name : "sap.m.sample.NavContainer"
+                    })]
+                })
+              ]
+            }).placeAt("content");
+         } 
+      </script>
+
+There are small details when using OpenUI5 with THttpServer. First of all, location of JSROOT scripts should be specified 
+as `jsrootsys/scripts/JSRootCore.js`. And when trying to access files from local disk, one should specify `/currentdir/` folder:
+
+    jQuery.sap.registerModulePath("sap.m.sample.NavContainer", "/currentdir/");
+    

--- a/etc/http/scripts/JSRootCore.js
+++ b/etc/http/scripts/JSRootCore.js
@@ -36,6 +36,7 @@
             'JSRootPainter.openui5': dir+'JSRootPainter.openui5'+ext,
             'JSRootPainter.v7'     : dir+'JSRootPainter.v7'+ext,
             'JSRootPainter.v7hist' : dir+'JSRootPainter.v7hist'+ext,
+            'JSRootPainter.v7more' : dir+'JSRootPainter.v7more'+ext,
             'JSRoot3DPainter'      : dir+'JSRoot3DPainter'+ext,
             'ThreeCSG'             : dir+'ThreeCSG'+ext,
             'JSRootGeoBase'        : dir+'JSRootGeoBase'+ext,
@@ -97,7 +98,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 23/10/2017";
+   JSROOT.version = "dev 27/10/2017";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;
@@ -883,7 +884,8 @@
       // 'hist3d'  histograms 3d graphic
       // 'more2d'  extra 2d graphic (TGraph, TF1)
       //     'v7'  ROOT v7 graphics
-      // 'v7hist'  ROOT v7 histogram graphics
+      // 'v7hist'  ROOT v7 histograms
+      // 'v7more'  ROOT v7 special classes
       //   'math'  some methods from TMath class
       //     'jq'  jQuery and jQuery-ui
       // 'hierarchy' hierarchy browser
@@ -998,6 +1000,11 @@
       if ((kind.indexOf('v7hist;')>=0) && (jsroot.sources.indexOf("v7hist")<0)) {
          mainfiles += '$$$scripts/JSRootPainter.v7hist' + ext + ".js;";
          modules.push('JSRootPainter.v7hist');
+      }
+
+      if ((kind.indexOf('v7more;')>=0) && (jsroot.sources.indexOf("v7more")<0)) {
+         mainfiles += '$$$scripts/JSRootPainter.v7more' + ext + ".js;";
+         modules.push('JSRootPainter.v7more');
       }
 
       if ((kind.indexOf('more2d;')>=0) && (jsroot.sources.indexOf("more2d")<0)) {

--- a/etc/http/scripts/JSRootPainter.openui5.js
+++ b/etc/http/scripts/JSRootPainter.openui5.js
@@ -398,7 +398,18 @@
 
          pthis.SendWebsocket('OBJEXEC:' + menu_obj_id + ":" + exec);
       });
+   }
 
+   // ====================================================================================
+
+   if (JSROOT.v7 && JSROOT.v7.TCanvasPainter)
+
+   JSROOT.v7.TCanvasPainter.prototype.ActivatePanel = function(name, handle, callback) {
+      // function used to actiavte FitPanel
+
+      var main = JSROOT.sap.ui.getCore().byId("TopCanvasId");
+      if (!main) return JSROOT.CallBack(callback, false);
+      main.getController().showPanelInLeftArea(name, handle, callback);
    }
 
    return JSROOT;

--- a/etc/http/scripts/JSRootPainter.v7hist.js
+++ b/etc/http/scripts/JSRootPainter.v7hist.js
@@ -42,6 +42,16 @@
 
    THistPainter.prototype = Object.create(JSROOT.TObjectPainter.prototype);
 
+   // function ensure that frame is drawn on the canvas
+   THistPainter.prototype.PrepareFrame = function(divid) {
+      this.SetDivId(divid, -1);
+
+      if (!this.frame_painter())
+         JSROOT.v7.drawFrame(divid, null);
+
+      this.SetDivId(divid);
+   }
+
    THistPainter.prototype.GetHisto = function() {
       var obj = this.GetObject(), histo = null;
       if (obj && obj.fHistImpl)
@@ -1714,7 +1724,7 @@
       // create painter and add it to canvas
       var painter = new TH1Painter(histo);
 
-      painter.SetDivId(divid);
+      painter.PrepareFrame(divid);
 
       painter.options = { Hist: 1, Bar: 0, Error: 0, errorX: 0, Zero: 0, Mark: 0, Line: 0, Text: 0, Lego: 0, Surf: 0,
                           fBarOffset: 0, fBarWidth: 1000, fMarkerSize: 1, BaseLine: false };
@@ -3563,7 +3573,7 @@
       // create painter and add it to canvas
       var painter = new TH2Painter(obj);
 
-      painter.SetDivId(divid);
+      painter.PrepareFrame(divid);
 
       painter.options = { Hist: 0, Bar: 0, Error: 0, errorX: 0, Zero: 0, Mark: 0, Line: 0, Text: 1, Lego: 0, Surf: 0,
                           fBarOffset: 0, fBarWidth: 1000, BaseLine: false,

--- a/etc/http/scripts/JSRootPainter.v7more.js
+++ b/etc/http/scripts/JSRootPainter.v7more.js
@@ -1,0 +1,67 @@
+/// @file JSRootPainter.v7more.js
+/// JavaScript ROOT v7 graphics for different classes
+
+(function( factory ) {
+   if ( typeof define === "function" && define.amd ) {
+      define( ['JSRootPainter', 'd3'], factory );
+   } else
+   if (typeof exports === 'object' && typeof module !== 'undefined') {
+       factory(require("./JSRootCore.js"), require("./d3.min.js"));
+   } else {
+
+      if (typeof d3 != 'object')
+         throw new Error('This extension requires d3.js', 'JSRootPainter.v7hist.js');
+
+      if (typeof JSROOT == 'undefined')
+         throw new Error('JSROOT is not defined', 'JSRootPainter.v7hist.js');
+
+      if (typeof JSROOT.Painter != 'object')
+         throw new Error('JSROOT.Painter not defined', 'JSRootPainter.v7hist.js');
+
+      factory(JSROOT, d3);
+   }
+} (function(JSROOT, d3) {
+
+   "use strict";
+
+   JSROOT.sources.push("v7more");
+
+   // =================================================================================
+
+
+   function drawText() {
+      var drawable = this.GetObject(),
+          pp = this.pad_painter(),
+          w = this.pad_width(),
+          h = this.pad_height(),
+          use_frame = false,
+          text_font = 42,
+          text_size = 40;
+
+      var text = drawable && drawable.fText ? drawable.fText.fWeakForIO : null,
+          opts = drawable.fOpts;
+
+      var fillcolor = pp.GetNewColor(opts.fFill.fColor.fIdx);
+
+      this.CreateG(use_frame);
+
+      var arg = { align: 13, x: Math.round(text.fX*w), y: Math.round(text.fY*h), text: text.fText, color: fillcolor, latex: 1 };
+
+      // if (text.fTextAngle) arg.rotate = -text.fTextAngle;
+      // if (text._typename == 'TLatex') { arg.latex = 1; fact = 0.9; } else
+      // if (text._typename == 'TMathText') { arg.latex = 2; fact = 0.8; }
+
+      this.StartTextDrawing(text_font, text_size);
+
+      this.DrawText(arg);
+
+      this.FinishTextDrawing();
+   }
+
+   // ================================================================================
+
+   JSROOT.v7.drawText = drawText;
+
+   return JSROOT;
+
+}));

--- a/graf2d/gpad/inc/LinkDef.h
+++ b/graf2d/gpad/inc/LinkDef.h
@@ -81,6 +81,13 @@
 #pragma link C++ class ROOT::Experimental::TDrawingOptsBaseNoDefault::OptsAttrRefArr<long long>+;
 #pragma link C++ class ROOT::Experimental::TDrawingOptsBaseNoDefault::OptsAttrRefArr<double>+;
 #pragma link C++ class ROOT::Experimental::TOrdinaryDisplayItem<ROOT::Experimental::TCanvas>+;
+#pragma link C++ class ROOT::Experimental::TText+;
+#pragma link C++ class ROOT::Experimental::TextDrawingOpts+;
+#pragma link C++ class ROOT::Experimental::TDrawingOptsBase<ROOT::Experimental::TextDrawingOpts>+;
+#pragma link C++ class ROOT::Experimental::TTextDrawable+;
+#pragma link C++ class ROOT::Experimental::Internal::TUniWeakPtr<ROOT::Experimental::TText>+;
+#pragma link C++ class ROOT::Experimental::TOrdinaryDisplayItem<ROOT::Experimental::TTextDrawable>+;
+
 
 //#pragma link C++ class ROOT::Experimental::TPadCoord::CoordSysBase<ROOT::Experimental::TPadCoord::Pixel>+;
 //#pragma link C++ class ROOT::Experimental::TPadCoord::CoordSysBase<ROOT::Experimental::TPadCoord::Normal>+;

--- a/graf2d/gpad/v7/inc/ROOT/TText.hxx
+++ b/graf2d/gpad/v7/inc/ROOT/TText.hxx
@@ -1,0 +1,139 @@
+/// \file ROOT/TText.hxx
+/// \ingroup Graf ROOT7
+/// \author Olivier Couet <Olivier.Couet@cern.ch>
+/// \date 2017-10-16
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_TText
+#define ROOT7_TText
+
+#include <ROOT/TDrawingOptsBase.hxx>
+
+#include <ROOT/TDrawable.hxx>
+#include <ROOT/TPad.hxx>
+#include <ROOT/TDisplayItem.hxx>
+#include <ROOT/TVirtualCanvasPainter.hxx>
+
+#include <ROOT/TDrawingAttrs.hxx>
+
+#include <initializer_list>
+#include <memory>
+#include <string>
+
+namespace ROOT {
+namespace Experimental {
+
+/** \class ROOT::Experimental::TText
+  A text.
+  */
+
+class TText {
+private:
+   std::string fText{};
+
+   /// Text's X position
+   double fX{0.};
+
+   /// Text's Y position
+   double fY{0.};
+
+public:
+   TText() = default;
+
+   TText(const std::string &str) : fText(str) {}
+};
+
+
+struct TTextCoreAttrs {
+   /// Index of the line color in TCanvas's color table.
+   //TDrawingAttrRef<TColor> fLineColorIndex{*this, "Hist.Line.Color"};
+   //TDrawingAttrRef<long long> fLineColorIndex{*this, "Hist.Line.Width"};
+   TLineAttrs fLine; ///< The histogram line attributes
+   TFillAttrs fFill; ///< The histogram fill attributes
+
+   TTextCoreAttrs() = default;
+   TTextCoreAttrs(TDrawingOptsBaseNoDefault &opts, const std::string &name):
+      fLine{opts, name + ".Line", TColor::kBlack, TLineAttrs::Width{3}},
+      fFill{opts, name + ".Fill", TColor::kWhite}
+      {}
+};
+
+
+
+class TextDrawingOpts : public TDrawingOptsBase<TextDrawingOpts> {
+    // TLineAttrs fLine; ///< The line attributes
+   //TTextCoreAttrs fAttr{*this, "Text"}; ///< The fill attributes
+
+   TLineAttrs fLine{*this, "Text.Line", TColor::kBlack, TLineAttrs::Width{3} }; ///< The line attributes
+   TFillAttrs fFill{*this, "Text.Fill", TColor::kWhite }; ///< The fill attributes
+
+public:
+   TextDrawingOpts() = default;
+   explicit TextDrawingOpts(TPadBase &pad) :
+      TDrawingOptsBase<TextDrawingOpts>(pad, "Text") {}
+//      fLine{*this, "Text.Line", TColor::kBlack, TLineAttrs::Width{3}},
+//      fAttr{*this, "Text.Fill", TColor::kWhite}
+//   {}
+
+   /// The color of the line.
+   void SetLineColor(const TColor &col) { Update(fLine.fColor, col); }
+   TColor &GetLineColor() { return this->Get(fLine.fColor); }
+//   const TColor &GetLineColor() const { return this->Get(fLine.fColor); }
+
+   /// The width of the line.
+//   void SetLineWidth(TLineAttrs::Width width) { this->Update(fLine.fWidth, width); }
+//   TLineAttrs::Width &GetLineWidth() { return this->Get(fLine.fWidth); }
+//   const TLineAttrs::Width GetLineWidth() const { return this->Get(fLine.fWidth); }
+
+   /// The fill color
+   void SetFillColor(const TColor &col) { this->Update(fFill.fColor, col); }
+   TColor &GetFillColor() { return this->Get(fFill.fColor); }
+//   const TColor &GetFillColor() const { return this->Get(fFill.fColor); }
+};
+
+
+class TTextDrawable : public TDrawable {
+private:
+   /// Text string to be drawn
+
+   Internal::TUniWeakPtr<ROOT::Experimental::TText> fText{};
+
+   /// Text attributes
+   TextDrawingOpts fOpts{};
+
+public:
+
+   TTextDrawable() = default;
+
+   TTextDrawable(const std::shared_ptr<ROOT::Experimental::TText> &txt, TPadBase &pad) : TDrawable(), fText(txt), fOpts(pad)  {}
+
+   TextDrawingOpts &GetOptions() { return fOpts; }
+   const TextDrawingOpts &GetOptions() const { return fOpts; }
+
+   void Paint(Internal::TVirtualCanvasPainter &canv) final
+   {
+      canv.AddDisplayItem(new ROOT::Experimental::TOrdinaryDisplayItem<ROOT::Experimental::TTextDrawable>(this));
+   }
+
+};
+
+
+inline std::unique_ptr<ROOT::Experimental::TTextDrawable> GetDrawable(const std::shared_ptr<ROOT::Experimental::TText> &text, TPadBase &pad)
+{
+   return std::make_unique<ROOT::Experimental::TTextDrawable>(text, pad);
+}
+
+} // namespace Experimental
+} // namespace ROOT
+
+
+#endif

--- a/graf2d/gpad/v7/inc/ROOT/TText.hxx
+++ b/graf2d/gpad/v7/inc/ROOT/TText.hxx
@@ -53,25 +53,7 @@ public:
 };
 
 
-struct TTextCoreAttrs {
-   /// Index of the line color in TCanvas's color table.
-   //TDrawingAttrRef<TColor> fLineColorIndex{*this, "Hist.Line.Color"};
-   //TDrawingAttrRef<long long> fLineColorIndex{*this, "Hist.Line.Width"};
-   TLineAttrs fLine; ///< The histogram line attributes
-   TFillAttrs fFill; ///< The histogram fill attributes
-
-   TTextCoreAttrs() = default;
-   TTextCoreAttrs(TDrawingOptsBaseNoDefault &opts, const std::string &name):
-      fLine{opts, name + ".Line", TColor::kBlack, TLineAttrs::Width{3}},
-      fFill{opts, name + ".Fill", TColor::kWhite}
-      {}
-};
-
-
-
 class TextDrawingOpts : public TDrawingOptsBase<TextDrawingOpts> {
-    // TLineAttrs fLine; ///< The line attributes
-   //TTextCoreAttrs fAttr{*this, "Text"}; ///< The fill attributes
 
    TLineAttrs fLine{*this, "Text.Line", TColor::kBlack, TLineAttrs::Width{3} }; ///< The line attributes
    TFillAttrs fFill{*this, "Text.Fill", TColor::kWhite }; ///< The fill attributes

--- a/graf2d/gpad/v7/src/TText.cxx
+++ b/graf2d/gpad/v7/src/TText.cxx
@@ -1,0 +1,18 @@
+/// \file TText.cxx
+/// \ingroup Graf ROOT7
+/// \author Olivier Couet <Olivier.Couet@cern.ch>
+/// \date 2017-07-07
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/TText.hxx"
+
+using namespace ROOT::Experimental;

--- a/tutorials/v7/text.cxx
+++ b/tutorials/v7/text.cxx
@@ -23,7 +23,7 @@ R__LOAD_LIBRARY(libGpad);
 #include "ROOT/TFile.hxx"
 #include "ROOT/TCanvas.hxx"
 #include "ROOT/TColor.hxx"
-//#include "ROOT/TDirectory.hxx"
+#include "ROOT/TDirectory.hxx"
 #include "ROOT/TText.hxx"
 
 void text()
@@ -36,7 +36,10 @@ void text()
   auto text = std::make_shared<ROOT::Experimental::TText>("Hello World");
   canvas->Draw(text).SetFillColor(Experimental::TColor::kRed);
 
-   canvas->Show("opera");
+  // Register the text with ROOT: now it lives even after draw() ends.
+  Experimental::TDirectory::Heap().Add("text", text);
+
+  canvas->Show("opera");
 
   TFile *f = TFile::Open("canv7.root", "recreate");
   f->WriteObject(canvas.get(), "canv_text");

--- a/tutorials/v7/text.cxx
+++ b/tutorials/v7/text.cxx
@@ -16,15 +16,13 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-// #include "Rtypes.h"
-
 R__LOAD_LIBRARY(libGpad);
 
-#include "ROOT/TFile.hxx"
+// #include "ROOT/TFile.hxx"
 #include "ROOT/TCanvas.hxx"
 #include "ROOT/TColor.hxx"
-#include "ROOT/TDirectory.hxx"
 #include "ROOT/TText.hxx"
+#include "ROOT/TDirectory.hxx"
 
 void text()
 {
@@ -41,8 +39,7 @@ void text()
 
   canvas->Show("opera");
 
-  TFile *f = TFile::Open("canv7.root", "recreate");
-  f->WriteObject(canvas.get(), "canv_text");
-  delete f;
-
+  // TFile *f = TFile::Open("canv7.root", "recreate");
+  // f->WriteObject(canvas.get(), "canv_text");
+  // delete f;
 }

--- a/tutorials/v7/text.cxx
+++ b/tutorials/v7/text.cxx
@@ -1,0 +1,45 @@
+/// \file
+/// \ingroup tutorial_v7
+///
+/// \macro_code
+///
+/// \date 2017-10-17
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+/// \author Olivier couet <Olivier.Couet@cern.ch>
+
+/*************************************************************************
+ * Copyright (C) 1995-2015, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+// #include "Rtypes.h"
+
+R__LOAD_LIBRARY(libGpad);
+
+#include "ROOT/TFile.hxx"
+#include "ROOT/TCanvas.hxx"
+#include "ROOT/TColor.hxx"
+//#include "ROOT/TDirectory.hxx"
+#include "ROOT/TText.hxx"
+
+void text()
+{
+   using namespace ROOT;
+
+   // Create a canvas to be displayed.
+   auto canvas = Experimental::TCanvas::Create("Canvas Title");
+
+  auto text = std::make_shared<ROOT::Experimental::TText>("Hello World");
+  canvas->Draw(text).SetFillColor(Experimental::TColor::kRed);
+
+   canvas->Show("opera");
+
+  TFile *f = TFile::Open("canv7.root", "recreate");
+  f->WriteObject(canvas.get(), "canv_text");
+  delete f;
+
+}


### PR DESCRIPTION
Put it into graf2d/gpad.

For the moment it is not possible to add v7 TText into graf2d/graf due to cross-referencing between libGpad and libGraf in that case. Normally libGpad linked against libGraf, but if one adds v7 TText into libGraf, one need several v7 classes (including TCanvas) from libGpad. One gets circular dependency. Should be resolved after Axel redesigns draw attributes container. 

Also include JSROOT code for FitPanel and TText

Update docu for THttpServer and JSROOT