### PR TITLE
[cmake] Enable clang's ThinLTO mode for Optimized builds

### DIFF
--- a/cmake/modules/CheckCompiler.cmake
+++ b/cmake/modules/CheckCompiler.cmake
@@ -206,6 +206,15 @@ if(gnuinstall)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DR__HAVE_CONFIG")
 endif()
 
+# Enable ThinLTO for clang in release build modes if the current clang version
+# supports it. We don't add it to Release mode because it increases build times.
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  if(NOT ${uppercase_CMAKE_BUILD_TYPE} STREQUAL DEBUG)
+    ROOT_ADD_CXX_FLAG(CMAKE_CXX_FLAGS "-flto=thin")
+    ROOT_ADD_C_FLAG(CMAKE_C_FLAGS "-flto=thin")
+  endif()
+endif()
+
 #---Check if we use the new libstdc++ CXX11 ABI-----------------------------------------------------
 # Necessary to compile check_cxx_source_compiles this early
 include(CheckCXXSourceCompiles)


### PR DESCRIPTION
Clang has a quite new LTO mode that doesn't blow up linking
times as much as with vanilla LTO but still brings similar
performance improvements. It's quite easy for us to migrate
to this new mode, so it would make sense to just activate
it in Optimized builds where users are obviously looking
for performance.

More information: https://clang.llvm.org/docs/ThinLTO.html