### PR TITLE
[cxxmodules] Add missing dependency rootcling -> complexDict

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -68,6 +68,11 @@ ROOT_EXECUTABLE(rootcling src/rootcling.cxx
                           LIBRARIES RIO Core Cling ${PCRE_LIBRARIES} ${LZMA_LIBRARIES} ${ZLIB_LIBRARIES}
                                     ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT}
                                     ${corelinklibs})
+# rootcling includes the ROOT complex header which would build the complex
+# dictionary with modules. To make sure that rootcling_stage1 builds this
+# dict before we use it, we add a dependency here.
+add_dependencies(rootcling complexDict)
+
 target_include_directories(rootcling PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/../core/metacling/res
         ${CMAKE_CURRENT_SOURCE_DIR}/../core/dictgen/res


### PR DESCRIPTION
Currently there is a chance that rootcling includes and builds
the 'complex' dictionary before it is built, which will cause
the build to fail. To fix this we need this dependency here.

The specific line that includes the complex header is
`core/dictgen/src/rootcling_impl.cxx:3045`.