### PR TITLE
Add inRange check in RooRealVar constructor

### DIFF
--- a/roofit/roofitcore/src/RooRealVar.cxx
+++ b/roofit/roofitcore/src/RooRealVar.cxx
@@ -128,12 +128,15 @@ RooRealVar::RooRealVar(const char *name, const char *title,
 		       const char *unit) :
   RooAbsRealLValue(name, title, unit), _error(-1), _asymErrLo(1), _asymErrHi(-1), _sharedProp(0)
 {
-  _value = value ;
-  _fast = kTRUE ;
+    _fast = kTRUE ;
+    _binning = new RooUniformBinning(minValue,maxValue,100) ;
+    setRange(minValue,maxValue) ;
 
-  _binning = new RooUniformBinning(minValue,maxValue,100) ;
-  setRange(minValue,maxValue) ;
-  TRACE_CREATE
+    Double_t clipValue ;
+    inRange(value,0,&clipValue) ;
+    _value = clipValue ;
+
+    TRACE_CREATE
 }
 
 


### PR DESCRIPTION
Minor fix for the RooRealVar constructor with value, range and unit.
There was no condition preventing values outside of range:
```
root [0] RooRealVar x("x","x",-10,0,5)
root [1] x.Print()
RooRealVar::x = -10  L(0 - 5)
```
Now an inRange check is added, so value is clipped into range: 
```
root [1] x.Print()
RooRealVar::x = 0  L(0 - 5)
```