### PR TITLE
Outline BDTEventWrapper::GetVarIndex() to help lld.

### DIFF
--- a/tmva/tmva/inc/TMVA/BDTEventWrapper.h
+++ b/tmva/tmva/inc/TMVA/BDTEventWrapper.h
@@ -66,9 +66,7 @@ namespace TMVA {
 
    private:
 
-      // This is a workaround for OSx where static thread_local data members are
-      // not supported. The C++ solution would indeed be the following:
-      static Int_t& GetVarIndex(){TTHREAD_TLS(Int_t) fVarIndex(0); return fVarIndex;}; // index of the variable to sort on
+      static Int_t& GetVarIndex();
 
       const Event* fEvent;     // pointer to the event
 

--- a/tmva/tmva/src/BDTEventWrapper.cxx
+++ b/tmva/tmva/src/BDTEventWrapper.cxx
@@ -70,8 +70,6 @@ Double_t BDTEventWrapper::GetCumulativeWeight(Bool_t type) const {
 /// Index of the variable to sort on
 
 Int_t& BDTEventWrapper::GetVarIndex() {
-   // This is a workaround for OSx where static thread_local data members are
-   // not supported. The C++ solution would indeed be a thread-local data member.
    TTHREAD_TLS(Int_t) fVarIndex(0);
    return fVarIndex;
 }

--- a/tmva/tmva/src/BDTEventWrapper.cxx
+++ b/tmva/tmva/src/BDTEventWrapper.cxx
@@ -65,3 +65,13 @@ Double_t BDTEventWrapper::GetCumulativeWeight(Bool_t type) const {
    if(type) return fSigWeight;
    return fBkgWeight;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Index of the variable to sort on
+
+Int_t& BDTEventWrapper::GetVarIndex() {
+   // This is a workaround for OSx where static thread_local data members are
+   // not supported. The C++ solution would indeed be a thread-local data member.
+   TTHREAD_TLS(Int_t) fVarIndex(0);
+   return fVarIndex;
+}


### PR DESCRIPTION
ldd has problems with linking tmva due to this function in the header. Outlining it fixes it.

```
/usr/bin/ld: error: can't create dynamic relocation R_X86_64_TLSLD against symbol: TMVA::BDTEventWrapper::GetVarIndex()::fVarIndex in readonly segment; recompile object files with -fPIC
>>> defined in CMakeFiles/TMVA.dir/src/DecisionTree.cxx.o
>>> referenced by BDTEventWrapper.h:64 (/home/axel/build/root/branches/v6-10/cmake/include/TMVA/BDTEventWrapper.h:64)
>>>               CMakeFiles/TMVA.dir/src/DecisionTree.cxx.o:(void std::__introsort_loop<__gnu_cxx::__normal_iterator<TMVA::BDTEventWrapper*, std::vector<TMVA::BDTEventWrapper, std::allocator<TMVA::BDTEventWrapper> > >, long, __gnu_cxx::__ops::_Iter_less_iter>(__gnu_cxx::__normal_iterator<TMVA::BDTEventWrapper*, std::vector<TMVA::BDTEventWrapper, std::allocator<TMVA::BDTEventWrapper> > >, __gnu_cxx::__normal_iterator<TMVA::BDTEventWrapper*, std::vector<TMVA::BDTEventWrapper, std::allocator<TMVA::BDTEventWrapper> > >, long, __gnu_cxx::__ops::_Iter_less_iter) (.isra.194))
```

While it'd be great to submit a reproducer to lld (I didn't manage to create one within the few minutes I invested), this change might be a cheap workaround. Unless it's a hot function where outlining is a real cost?