### PR TITLE
[cxxmodules] Backport D39416

### DIFF
--- a/interpreter/llvm/src/tools/clang/include/clang/Sema/MultiplexExternalSemaSource.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/Sema/MultiplexExternalSemaSource.h
@@ -148,8 +148,10 @@ public:
   /// \brief Print any statistics that have been gathered regarding
   /// the external AST source.
   void PrintStats() override;
-  
-  
+
+  /// \brief Retrieve the module that corresponds to the given module ID.
+  Module *getModule(unsigned ID) override;
+
   /// \brief Perform layout on the given record.
   ///
   /// This routine allows the external AST source to provide an specific 

--- a/interpreter/llvm/src/tools/clang/lib/Sema/MultiplexExternalSemaSource.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Sema/MultiplexExternalSemaSource.cpp
@@ -166,6 +166,13 @@ void MultiplexExternalSemaSource::PrintStats() {
     Sources[i]->PrintStats();
 }
 
+Module *MultiplexExternalSemaSource::getModule(unsigned ID) {
+  for (size_t i = 0; i < Sources.size(); ++i)
+    if (auto M = Sources[i]->getModule(ID))
+      return M;
+  return nullptr;
+}
+
 bool MultiplexExternalSemaSource::layoutRecordType(const RecordDecl *Record,
                                                    uint64_t &Size, 
                                                    uint64_t &Alignment,


### PR DESCRIPTION
See https://reviews.llvm.org/D39416 for more details. Original commit message:

The MultiplexExternalSemaSource doesn't correctly overload the getModule function,
causing the multiplexer to not forward this call as intended.