### PR TITLE
[cxxmodules] Re-enable rootmap loading for modules.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -4943,11 +4943,6 @@ namespace {
 
 Int_t TCling::LoadLibraryMap(const char* rootmapfile)
 {
-   // Don't load any rootmaps when we have are running in modules mode
-   // because we don't want to rely on those forward declarations here.
-   // This functionality is replaced by the 'link' attribute in the modulemap.
-   if (getenv("ROOT_MODULES")) return 0;
-
    R__LOCKGUARD(gInterpreterMutex);
    // open the [system].rootmap files
    if (!fMapfile) {


### PR DESCRIPTION
We still need it to load the library before we get the headers and
initializie some class infos, so we can't just remove it like that.