### PR TITLE
[cxxmodules] Directly load all headers with modules enabled

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1103,6 +1103,8 @@ TCling::TCling(const char *name, const char *title)
 #ifdef R__USE_CXXMODULES
    useCxxModules = true;
 #endif
+   if (useCxxModules)
+     fHeaderParsingOnDemand = false;
 
    llvm::install_fatal_error_handler(&exceptionErrorHandler);
 


### PR DESCRIPTION
With C++ modules we can just directly `#include` all headers
from the module payload and initialize the classes as we don't
actually parse the included headers as the user is supposed
to provide a module for those headers.