### PR TITLE
[clang] Reimplement diag suppression for forward declarations.

### DIFF
--- a/interpreter/llvm/src/tools/clang/include/clang/Sema/Sema.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/Sema/Sema.h
@@ -6112,7 +6112,8 @@ public:
 
   bool CheckTemplateParameterList(TemplateParameterList *NewParams,
                                   TemplateParameterList *OldParams,
-                                  TemplateParamListContext TPC);
+                                  TemplateParamListContext TPC,
+                                  bool Complain = true);
   TemplateParameterList *MatchTemplateParametersToScopeSpecifier(
       SourceLocation DeclStartLoc, SourceLocation DeclLoc,
       const CXXScopeSpec &SS, TemplateIdAnnotation *TemplateId,


### PR DESCRIPTION
This patch reimplements the broken patch in clang: "Fix fwddecls of templates
with tmplt arg defauls coming from dictionaries (CMS / std::less). (#849)"

And partially reimplements:"Disable diags of dupe default args (func, templt)
temporarily."

It also fixes the failing cling test Autoloading/AutoForwarding.C which
is visible when building root with -Dclingtest=On.