### PR TITLE
[cxxmodules] Revert broken cling patch again

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/AST/DeclBase.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/AST/DeclBase.cpp
@@ -1352,7 +1352,7 @@ void DeclContext::removeDecl(Decl *D) {
     NamedDecl *ND = cast<NamedDecl>(D);
 
     // Remove only decls that have a name or registered in the lookup.
-    if (!ND->getDeclName() || ND->isHidden()) return;
+    if (!ND->getDeclName()) return;
 
     auto *DC = D->getDeclContext();
     do {


### PR DESCRIPTION
We already reverted this patch, but the LLVM upgrade to 5.0 seems
to have ignored this reversion.