### PR TITLE
Backport D37416: Use the VFS from the CompilerInvocation by default

### DIFF
--- a/interpreter/llvm/src/tools/clang/include/clang/Frontend/CompilerInstance.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/Frontend/CompilerInstance.h
@@ -640,7 +640,9 @@ public:
                     const CodeGenOptions *CodeGenOpts = nullptr);
 
   /// Create the file manager and replace any existing one with it.
-  void createFileManager();
+  ///
+  /// \return The new file manager on success, or null on failure.
+  FileManager *createFileManager();
 
   /// Create the source manager and replace any existing one with it.
   void createSourceManager(FileManager &FileMgr);

--- a/interpreter/llvm/src/tools/clang/lib/Frontend/CompilerInstance.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Frontend/CompilerInstance.cpp
@@ -300,12 +300,16 @@ CompilerInstance::createDiagnostics(DiagnosticOptions *Opts,
 
 // File Manager
 
-void CompilerInstance::createFileManager() {
+FileManager *CompilerInstance::createFileManager() {
   if (!hasVirtualFileSystem()) {
-    // TODO: choose the virtual file system based on the CompilerInvocation.
-    setVirtualFileSystem(vfs::getRealFileSystem());
+    if (IntrusiveRefCntPtr<vfs::FileSystem> VFS =
+            createVFSFromCompilerInvocation(getInvocation(), getDiagnostics()))
+      setVirtualFileSystem(VFS);
+    else
+      return nullptr;
   }
   FileMgr = new FileManager(getFileSystemOpts(), VirtualFileSystem);
+  return FileMgr.get();
 }
 
 // Source Manager

--- a/interpreter/llvm/src/tools/clang/lib/Frontend/FrontendAction.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Frontend/FrontendAction.cpp
@@ -633,18 +633,12 @@ bool FrontendAction::BeginSourceFile(CompilerInstance &CI,
     return true;
   }
 
-  if (!CI.hasVirtualFileSystem()) {
-    if (IntrusiveRefCntPtr<vfs::FileSystem> VFS =
-          createVFSFromCompilerInvocation(CI.getInvocation(),
-                                          CI.getDiagnostics()))
-      CI.setVirtualFileSystem(VFS);
-    else
-      goto failure;
-  }
-
   // Set up the file and source managers, if needed.
-  if (!CI.hasFileManager())
-    CI.createFileManager();
+  if (!CI.hasFileManager()) {
+    if (!CI.createFileManager()) {
+      goto failure;
+    }
+  }
   if (!CI.hasSourceManager())
     CI.createSourceManager(CI.getFileManager());
 


### PR DESCRIPTION
This patch hasn't landed in 5.0, so the LLVM upgrade overwrote this
patch without bringing in the upstreamed fixed version.

Original commit message:

The default VFS for the FileManager should be created from the CompilerInvocation
instead of assuming there is none.