### PR TITLE
Arthur-tsang-Vectorized_Tformula

### DIFF
--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -659,7 +659,7 @@ public:
    virtual void     SetRange(Double_t xmin, Double_t ymin, Double_t zmin,  Double_t xmax, Double_t ymax, Double_t zmax);
    virtual void     SetSavedPoint(Int_t point, Double_t value);
    virtual void     SetTitle(const char *title = ""); // *MENU*
-   virtual void SetVectorized(Bool_t vectorized)
+   virtual void     SetVectorized(Bool_t vectorized)
    {
       if (fType == EFType::kFormula && fFormula)
          fFormula->SetVectorized(vectorized);

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -422,7 +422,7 @@ public:
    virtual void     FixParameter(Int_t ipar, Double_t value);
    bool      IsVectorized()
    {
-      return fType == EFType::kTemplVec;
+      return (fType == EFType::kTemplVec) || (fType == EFType::kFormula && fFormula && fFormula->IsVectorized());
    }
    Double_t     GetChisquare() const
    {
@@ -654,6 +654,13 @@ public:
    virtual void     SetRange(Double_t xmin, Double_t ymin, Double_t zmin,  Double_t xmax, Double_t ymax, Double_t zmax);
    virtual void     SetSavedPoint(Int_t point, Double_t value);
    virtual void     SetTitle(const char *title = ""); // *MENU*
+   virtual void SetVectorized(Bool_t vectorized)
+   {
+      if (fType == EFType::kFormula && fFormula)
+         fFormula->SetVectorized(vectorized);
+      else
+         Warning("SetVectorized", "Can only set vectorized flag on formula-based TF1");
+   }
    virtual void     Update();
 
    static  TF1     *GetCurrent();

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -414,7 +414,11 @@ public:
    virtual void     DrawF1(Double_t xmin, Double_t xmax, Option_t *option = "");
    virtual Double_t Eval(Double_t x, Double_t y = 0, Double_t z = 0, Double_t t = 0) const;
    virtual Double_t EvalPar(const Double_t *x, const Double_t *params = 0);
+#ifdef R__HAS_VECCORE
+   virtual ROOT::Double_v
+   Eval(ROOT::Double_v x, ROOT::Double_v y = 0, ROOT::Double_v z = 0, ROOT::Double_v t = 0) const;
    virtual ROOT::Double_v EvalPar(const ROOT::Double_v *x, const Double_t *params = 0);
+#endif
    template <class T> T EvalPar(const T *x, const Double_t *params = 0);
    virtual Double_t operator()(Double_t x, Double_t y = 0, Double_t z = 0, Double_t t = 0) const;
    template <class T> T operator()(const T *x, const Double_t *params = nullptr);

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -414,6 +414,7 @@ public:
    virtual void     DrawF1(Double_t xmin, Double_t xmax, Option_t *option = "");
    virtual Double_t Eval(Double_t x, Double_t y = 0, Double_t z = 0, Double_t t = 0) const;
    virtual Double_t EvalPar(const Double_t *x, const Double_t *params = 0);
+   virtual ROOT::Double_v EvalPar(const ROOT::Double_v *x, const Double_t *params = 0);
    template <class T> T EvalPar(const T *x, const Double_t *params = 0);
    virtual Double_t operator()(Double_t x, Double_t y = 0, Double_t z = 0, Double_t t = 0) const;
    template <class T> T operator()(const T *x, const Double_t *params = nullptr);
@@ -744,8 +745,8 @@ T TF1::EvalPar(const T *x, const Double_t *params)
 {
   if (fType == EFType::kTemplVec || fType == EFType::kTemplScalar) {
     return EvalParTempl(x, params);
-   } else
-      return TF1::EvalPar((double *) x, params);
+  } else
+     return TF1::EvalPar((double *)x, params);
 }
 
 // Internal to TF1. Evaluates Templated interfaces

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -414,12 +414,8 @@ public:
    virtual TObject *DrawIntegral(Option_t *option = "al"); // *MENU*
    virtual void     DrawF1(Double_t xmin, Double_t xmax, Option_t *option = "");
    virtual Double_t Eval(Double_t x, Double_t y = 0, Double_t z = 0, Double_t t = 0) const;
+   //template <class T> T Eval(T x, T y = 0, T z = 0, T t = 0) const; 
    virtual Double_t EvalPar(const Double_t *x, const Double_t *params = 0);
-#ifdef R__HAS_VECCORE
-   virtual ROOT::Double_v
-   Eval(ROOT::Double_v x, ROOT::Double_v y = 0, ROOT::Double_v z = 0, ROOT::Double_v t = 0) const;
-   virtual ROOT::Double_v EvalPar(const ROOT::Double_v *x, const Double_t *params = 0);
-#endif
    template <class T> T EvalPar(const T *x, const Double_t *params = 0);
    virtual Double_t operator()(Double_t x, Double_t y = 0, Double_t z = 0, Double_t t = 0) const;
    template <class T> T operator()(const T *x, const Double_t *params = nullptr);
@@ -752,14 +748,31 @@ inline T TF1::operator()(const T *x, const Double_t *params)
    return EvalPar(x, params);
 }
 
+////////////////////////////////////////////////////////////////////////////////
+///   EvalPar for vectorized
 template <class T>
 T TF1::EvalPar(const T *x, const Double_t *params)
 {
   if (fType == EFType::kTemplVec || fType == EFType::kTemplScalar) {
-    return EvalParTempl(x, params);
+     return EvalParTempl(x, params);
+  } else if (fType == EFType::kFormula) {
+     return fFormula->EvalPar(x, params);
   } else
      return TF1::EvalPar((double *)x, params);
 }
+
+////////////////////////////////////////////////////////////////////////////////
+///   Eval for vectorized functions
+// template <class T>
+// T TF1::Eval(T x, T y, T z, T t) const 
+// {
+//    if (fType == EFType::kFormula)
+//       return fFormula->Eval(x, y, z, t);
+
+//    T xx[] = {x, y, z, t};
+//    Double_t *pp = (Double_t *)fParams->GetParameters();
+//    return ((TF1 *)this)->EvalPar(xx, pp);
+// }
 
 // Internal to TF1. Evaluates Templated interfaces
 template <class T>

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -312,7 +312,8 @@ public:
    };
 
    TF1();
-   TF1(const char *name, const char *formula, Double_t xmin = 0, Double_t xmax = 1, EAddToList addToGlobList = EAddToList::kDefault);
+   TF1(const char *name, const char *formula, Double_t xmin = 0, Double_t xmax = 1, EAddToList addToGlobList = EAddToList::kDefault, bool vectorize = false);
+   TF1(const char *name, const char *formula, Double_t xmin, Double_t xmax, Option_t * option);  // same as above but using a string for option
    TF1(const char *name, Double_t xmin, Double_t xmax, Int_t npar, Int_t ndim = 1, EAddToList addToGlobList = EAddToList::kDefault);
    TF1(const char *name, Double_t (*fcn)(Double_t *, Double_t *), Double_t xmin = 0, Double_t xmax = 1, Int_t npar = 0, Int_t ndim = 1, EAddToList addToGlobList = EAddToList::kDefault);
    TF1(const char *name, Double_t (*fcn)(const Double_t *, const Double_t *), Double_t xmin = 0, Double_t xmax = 1, Int_t npar = 0, Int_t ndim = 1, EAddToList addToGlobList = EAddToList::kDefault);

--- a/hist/hist/inc/TF12.h
+++ b/hist/hist/inc/TF12.h
@@ -38,6 +38,7 @@ public:
    virtual TF1     *DrawCopy(Option_t *option="") const;
    virtual Double_t Eval(Double_t x, Double_t y=0, Double_t z=0, Double_t t=0) const;
    virtual Double_t EvalPar(const Double_t *x, const Double_t *params=0);
+   using TF1::EvalPar; // to not hide the vectorized version
    virtual Double_t GetXY() const {return fXY;}
    virtual void     SavePrimitive(std::ostream &out, Option_t *option = "");
    virtual void     SetXY(Double_t xy);  // *MENU*

--- a/hist/hist/inc/TF12.h
+++ b/hist/hist/inc/TF12.h
@@ -38,7 +38,12 @@ public:
    virtual TF1     *DrawCopy(Option_t *option="") const;
    virtual Double_t Eval(Double_t x, Double_t y=0, Double_t z=0, Double_t t=0) const;
    virtual Double_t EvalPar(const Double_t *x, const Double_t *params=0);
+
+#ifdef R__HAS_VECCORE
+   using TF1::Eval;    // to not hide the vectorized version
    using TF1::EvalPar; // to not hide the vectorized version
+#endif
+
    virtual Double_t GetXY() const {return fXY;}
    virtual void     SavePrimitive(std::ostream &out, Option_t *option = "");
    virtual void     SetXY(Double_t xy);  // *MENU*

--- a/hist/hist/inc/TF2.h
+++ b/hist/hist/inc/TF2.h
@@ -36,7 +36,7 @@ protected:
 
 public:
    TF2();
-   TF2(const char *name, const char *formula, Double_t xmin=0, Double_t xmax=1, Double_t ymin=0, Double_t ymax=1);
+   TF2(const char *name, const char *formula, Double_t xmin=0, Double_t xmax=1, Double_t ymin=0, Double_t ymax=1, Option_t * opt = nullptr);
 #ifndef __CINT__
    TF2(const char *name, Double_t (*fcn)(Double_t *, Double_t *), Double_t xmin=0, Double_t xmax=1, Double_t ymin=0, Double_t ymax=1, Int_t npar=0,Int_t ndim = 2);
    TF2(const char *name, Double_t (*fcn)(const Double_t *, const Double_t *), Double_t xmin=0, Double_t xmax=1, Double_t ymin=0, Double_t ymax=1, Int_t npar=0, Int_t ndim = 2);

--- a/hist/hist/inc/TF3.h
+++ b/hist/hist/inc/TF3.h
@@ -35,7 +35,7 @@ protected:
 public:
    TF3();
    TF3(const char *name, const char *formula, Double_t xmin=0, Double_t xmax=1, Double_t ymin=0,
-       Double_t ymax=1, Double_t zmin=0, Double_t zmax=1);
+       Double_t ymax=1, Double_t zmin=0, Double_t zmax=1, Option_t * opt = nullptr);
 #ifndef __CINT__
    TF3(const char *name, Double_t (*fcn)(Double_t *, Double_t *), Double_t xmin=0, Double_t xmax=1, Double_t ymin=0,
        Double_t ymax=1, Double_t zmin=0, Double_t zmax=1, Int_t npar=0, Int_t ndim = 3);

--- a/hist/hist/inc/TFormula.h
+++ b/hist/hist/inc/TFormula.h
@@ -21,7 +21,7 @@
 #include <vector>
 #include <list>
 #include <map>
-#include <Math/Math_vectypes.hxx>
+#include <Math/Types.h>
 
 class TFormulaFunction
 {

--- a/hist/hist/inc/TFormula.h
+++ b/hist/hist/inc/TFormula.h
@@ -158,7 +158,7 @@ public:
                   TFormula();
    virtual        ~TFormula();
    TFormula&      operator=(const TFormula &rhs);
-   TFormula(const char *name, const char * formula = "", bool addToGlobList = true);
+   TFormula(const char *name, const char * formula = "", bool addToGlobList = true, bool vectorize = false);
    TFormula(const char *name, const char * formula, int ndim, int npar, bool addToGlobList = true);
                   TFormula(const TFormula &formula);
    //               TFormula(const char *name, Int_t nparams, Int_t ndims);

--- a/hist/hist/inc/TFormula.h
+++ b/hist/hist/inc/TFormula.h
@@ -92,7 +92,7 @@ private:
    Bool_t            fReadyToExecute;       //! trasient to force initialization
    Bool_t            fClingInitialized;  //!  transient to force re-initialization
    Bool_t            fAllParametersSetted;    // flag to control if all parameters are setted
-   TMethodCall*      fMethod;        //! pointer to methocall
+   TMethodCall *fMethod;                      //! pointer to methodcall
    TString           fClingName;     //! unique name passed to Cling to define the function ( double clingName(double*x, double*p) )
 
    TInterpreter::CallFuncIFacePtr_t::Generic_t fFuncPtr;   //!  function pointer

--- a/hist/hist/inc/TFormula.h
+++ b/hist/hist/inc/TFormula.h
@@ -124,7 +124,7 @@ protected:
    Int_t                          fNpar;  //!
    Int_t                          fNumber;  //!
    std::vector<TObject*>          fLinearParts;  // vector of linear functions
-   Bool_t fVectorized = false; // whether we should use vectorized or regular variables
+   Bool_t fVectorized = false;                   // whether we should use vectorized or regular variables
    // (we default to false since a lot of functions still cannot be expressed in vectorized form)
 
    static Bool_t IsOperator(const char c);
@@ -175,6 +175,7 @@ public:
    Double_t       Eval(Double_t x, Double_t y , Double_t z , Double_t t ) const;
    Double_t       EvalPar(const Double_t *x, const Double_t *params=0) const;
 #ifdef R__HAS_VECCORE
+   ROOT::Double_v Eval(ROOT::Double_v x, ROOT::Double_v y = 0, ROOT::Double_v z = 0, ROOT::Double_v t = 0) const;
    ROOT::Double_v EvalPar(const ROOT::Double_v *x, const Double_t *params = 0) const;
 #endif
    TString        GetExpFormula(Option_t *option="") const;

--- a/hist/hist/inc/TFormula.h
+++ b/hist/hist/inc/TFormula.h
@@ -214,6 +214,6 @@ public:
    void           SetVariables(const std::pair<TString,Double_t> *vars, const Int_t size);
    void SetVectorized(Bool_t vectorized);
 
-   ClassDef(TFormula,10)
+   ClassDef(TFormula,11)
 };
 #endif

--- a/hist/hist/inc/TFormula.h
+++ b/hist/hist/inc/TFormula.h
@@ -1,4 +1,3 @@
-
 // @(#)root/hist:$Id$
 // Author: Maciej Zimnoch   30/09/2013
 
@@ -22,7 +21,7 @@
 #include <vector>
 #include <list>
 #include <map>
-
+#include <Math/Math_vectypes.hxx>
 
 class TFormulaFunction
 {
@@ -126,6 +125,12 @@ protected:
    Int_t                          fNumber;  //!
    std::vector<TObject*>          fLinearParts;  // vector of linear functions
 
+#ifdef R__HAS_VECCORE
+   Bool_t fVectorized = true; // whether we should use vectorized or regular variables
+#else
+   Bool_t fVectorized = false; // whether we should use vectorized or regular variables
+#endif
+
    static Bool_t IsOperator(const char c);
    static Bool_t IsBracket(const char c);
    static Bool_t IsFunctionNameChar(const char c);
@@ -142,6 +147,9 @@ protected:
    void   SetPredefinedParamNames(); 
 
    Double_t       DoEval(const Double_t * x, const Double_t * p = nullptr) const;
+#ifdef R__HAS_VECCORE
+   ROOT::Double_v DoEvalVec(const ROOT::Double_v *x, const Double_t *p = nullptr) const;
+#endif
 
 public:
 
@@ -170,6 +178,9 @@ public:
    Double_t       Eval(Double_t x, Double_t y , Double_t z) const;
    Double_t       Eval(Double_t x, Double_t y , Double_t z , Double_t t ) const;
    Double_t       EvalPar(const Double_t *x, const Double_t *params=0) const;
+#ifdef R__HAS_VECCORE
+   ROOT::Double_v EvalPar(const ROOT::Double_v *x, const Double_t *params = 0) const;
+#endif
    TString        GetExpFormula(Option_t *option="") const;
    const TObject *GetLinearPart(Int_t i) const;
    Int_t          GetNdim() const {return fNdim;}
@@ -185,6 +196,7 @@ public:
    Int_t          GetVarNumber(const char *name) const;
    TString        GetVarName(Int_t ivar) const;
    Bool_t         IsValid() const { return fReadyToExecute && fClingInitialized; }
+   Bool_t IsVectorized() const { return fVectorized; }
    Bool_t         IsLinear() const { return TestBit(kLinear); }
    void           Print(Option_t *option = "") const;
    void           SetName(const char* name);
@@ -202,6 +214,7 @@ public:
                              *name8="p8",const char *name9="p9",const char *name10="p10"); // *MENU*
    void           SetVariable(const TString &name, Double_t value);
    void           SetVariables(const std::pair<TString,Double_t> *vars, const Int_t size);
+   void SetVectorized(Bool_t vectorized);
 
    ClassDef(TFormula,10)
 };

--- a/hist/hist/inc/TFormula.h
+++ b/hist/hist/inc/TFormula.h
@@ -124,12 +124,8 @@ protected:
    Int_t                          fNpar;  //!
    Int_t                          fNumber;  //!
    std::vector<TObject*>          fLinearParts;  // vector of linear functions
-
-#ifdef R__HAS_VECCORE
-   Bool_t fVectorized = true; // whether we should use vectorized or regular variables
-#else
    Bool_t fVectorized = false; // whether we should use vectorized or regular variables
-#endif
+   // (we default to false since a lot of functions still cannot be expressed in vectorized form)
 
    static Bool_t IsOperator(const char c);
    static Bool_t IsBracket(const char c);

--- a/hist/hist/inc/TFormula.h
+++ b/hist/hist/inc/TFormula.h
@@ -175,9 +175,14 @@ public:
    Double_t       Eval(Double_t x, Double_t y , Double_t z) const;
    Double_t       Eval(Double_t x, Double_t y , Double_t z , Double_t t ) const;
    Double_t       EvalPar(const Double_t *x, const Double_t *params=0) const;
+   // template <class T>
+   // T Eval(T x, T y = 0, T z = 0, T t = 0) const;
+   template <class T>
+   T EvalPar(const T *x, const Double_t *params = 0) const {
+      return  EvalParVec(x, params);
+   }
 #ifdef R__HAS_VECCORE
-   ROOT::Double_v Eval(ROOT::Double_v x, ROOT::Double_v y = 0, ROOT::Double_v z = 0, ROOT::Double_v t = 0) const;
-   ROOT::Double_v EvalPar(const ROOT::Double_v *x, const Double_t *params = 0) const;
+   ROOT::Double_v EvalParVec(const ROOT::Double_v *x, const Double_t *params = 0) const;
 #endif
    TString        GetExpFormula(Option_t *option="") const;
    const TObject *GetLinearPart(Int_t i) const;

--- a/hist/hist/inc/TFormula.h
+++ b/hist/hist/inc/TFormula.h
@@ -111,6 +111,7 @@ private:
    static Bool_t   IsDefaultVariableName(const TString &name);
    void ReplaceAllNames(TString &formula, std::map<TString, TString> &substitutions);
    void FillParametrizedFunctions(std::map<std::pair<TString, Int_t>, std::pair<TString, TString>> &functions);
+   void FillVecFunctionsShurtCuts(); 
 
 protected:
 

--- a/hist/hist/inc/TFormula.h
+++ b/hist/hist/inc/TFormula.h
@@ -125,7 +125,7 @@ protected:
    Int_t                          fNpar;  //!
    Int_t                          fNumber;  //!
    std::vector<TObject*>          fLinearParts;  // vector of linear functions
-   Bool_t fVectorized = false;                   // whether we should use vectorized or regular variables
+   Bool_t                         fVectorized = false;      // whether we should use vectorized or regular variables
    // (we default to false since a lot of functions still cannot be expressed in vectorized form)
 
    static Bool_t IsOperator(const char c);

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -1403,9 +1403,9 @@ ROOT::Double_v TF1::EvalPar(const ROOT::Double_v *x, const Double_t *params)
    if (fType == EFType::kTemplVec || fType == EFType::kTemplScalar) {
       return EvalParTempl(x, params);
    } else if (fType == EFType::kFormula) {
-      if (!fFormula->IsVectorized())
-         Warning("EvalPar", "Switching formula to vectorized");
-      fFormula->SetVectorized(true);
+      // if (!fFormula->IsVectorized()) // todo rethink how to do this
+      //    Warning("EvalPar", "Switching formula to vectorized");
+      // fFormula->SetVectorized(true);
 
       return fFormula->EvalPar(x, params);
    } else

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -1403,10 +1403,6 @@ ROOT::Double_v TF1::EvalPar(const ROOT::Double_v *x, const Double_t *params)
    if (fType == EFType::kTemplVec || fType == EFType::kTemplScalar) {
       return EvalParTempl(x, params);
    } else if (fType == EFType::kFormula) {
-      // if (!fFormula->IsVectorized()) // todo rethink how to do this
-      //    Warning("EvalPar", "Switching formula to vectorized");
-      // fFormula->SetVectorized(true);
-
       return fFormula->EvalPar(x, params);
    } else
       return TF1::EvalPar((double *)x, params);

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -1309,7 +1309,7 @@ Double_t TF1::Eval(Double_t x, Double_t y, Double_t z, Double_t t) const
 
    Double_t xx[4] = {x, y, z, t};
    Double_t *pp = (Double_t *)fParams->GetParameters();
-   if (fType == EFType::kInterpreted)((TF1 *)this)->InitArgs(xx, pp);
+   // if (fType == EFType::kInterpreted)((TF1 *)this)->InitArgs(xx, pp);
    return ((TF1 *)this)->EvalPar(xx, pp);
 }
 
@@ -1406,13 +1406,6 @@ ROOT::Double_v TF1::Eval(ROOT::Double_v x, ROOT::Double_v y, ROOT::Double_v z, R
 
    ROOT::Double_v xx[] = {x, y, z, t};
    Double_t *pp = (Double_t *)fParams->GetParameters();
-   if (fMethodCall) {
-      // todo test this case
-      Long_t args[2];
-      args[0] = (Long_t)xx;
-      args[1] = (Long_t)pp;
-      fMethodCall->SetParamPtrs(args);
-   }
    return ((TF1 *)this)->EvalPar(xx, pp);
 }
 

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -1395,6 +1395,23 @@ Double_t TF1::EvalPar(const Double_t *x, const Double_t *params)
    return result;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+///   EvalPar for vectorized
+#ifdef R__HAS_VECCORE
+ROOT::Double_v TF1::EvalPar(const ROOT::Double_v *x, const Double_t *params)
+{
+   if (fType == EFType::kTemplVec || fType == EFType::kTemplScalar) {
+      return EvalParTempl(x, params);
+   } else if (fType == EFType::kFormula) {
+      if (!fFormula->IsVectorized())
+         Warning("EvalPar", "Switching formula to vectorized");
+      fFormula->SetVectorized(true);
+
+      return fFormula->EvalPar(x, params);
+   } else
+      return TF1::EvalPar((double *)x, params);
+}
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Execute action corresponding to one event.

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -565,7 +565,8 @@ TF1::TF1(const char *name, const char *formula, Double_t xmin, Double_t xmax, EA
    } else { // regular TFormula
       fFormula = new TFormula(name, formula, false, vectorize);
       fNpar = fFormula->GetNpar();
-      fNdim = fFormula->GetNdim();
+      // TFormula can have dimension zero, but since this is a TF1 minimal dim is 1
+      fNdim = fFormula->GetNdim() == 0 ? 1 : fFormula->GetNdim();
    }
    if (fNpar) {
       fParErrors.resize(fNpar);

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -580,6 +580,7 @@ TF1::TF1(const char *name, const char *formula, Double_t xmin, Double_t xmax, EA
    DoInitialize(addToGlobList);
 }
 TF1::EAddToList GetGlobalListOption(Option_t * opt)  {
+   if (opt == nullptr) return TF1::EAddToList::kDefault; 
    TString option(opt);
    option.ToUpper();
    if (option.Contains("NL")) return TF1::EAddToList::kNo;
@@ -587,6 +588,7 @@ TF1::EAddToList GetGlobalListOption(Option_t * opt)  {
    return TF1::EAddToList::kDefault; 
 }
 bool GetVectorizedOption(Option_t * opt)  {
+   if (opt == nullptr) return false; 
    TString option(opt);
    option.ToUpper();
    if (option.Contains("VEC")) return true;

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -422,7 +422,7 @@ TF1::TF1():
 /// the formula string is "fffffff" and "xxxx" and "yyyy" are the
 /// titles for the X and Y axis respectively.
 
-TF1::TF1(const char *name, const char *formula, Double_t xmin, Double_t xmax, EAddToList addToGlobList) :
+TF1::TF1(const char *name, const char *formula, Double_t xmin, Double_t xmax, EAddToList addToGlobList, bool vectorize) :
    TNamed(name, formula), TAttLine(), TAttFill(), TAttMarker(), fType(EFType::kFormula)
 {
    if (xmin < xmax) {
@@ -563,7 +563,7 @@ TF1::TF1(const char *name, const char *formula, Double_t xmin, Double_t xmax, EA
       }
 
    } else { // regular TFormula
-      fFormula = new TFormula(name, formula, false);
+      fFormula = new TFormula(name, formula, false, vectorize);
       fNpar = fFormula->GetNpar();
       fNdim = fFormula->GetNdim();
    }
@@ -579,7 +579,30 @@ TF1::TF1(const char *name, const char *formula, Double_t xmin, Double_t xmax, EA
 
    DoInitialize(addToGlobList);
 }
-
+TF1::EAddToList GetGlobalListOption(Option_t * opt)  {
+   TString option(opt);
+   option.ToUpper();
+   if (option.Contains("NL")) return TF1::EAddToList::kNo;
+   if (option.Contains("GL")) return TF1::EAddToList::kAdd;   
+   return TF1::EAddToList::kDefault; 
+}
+bool GetVectorizedOption(Option_t * opt)  {
+   TString option(opt);
+   option.ToUpper();
+   if (option.Contains("VEC")) return true;
+   return false; 
+}
+TF1::TF1(const char *name, const char *formula, Double_t xmin, Double_t xmax, Option_t * opt) :
+////////////////////////////////////////////////////////////////////////////////
+/// Same constructor as above (for TFormula based function) but passing an option strings
+///  available options
+///  VEC -  vectorize the formula expressions (not possible for lambda based expressions)
+///  NL   - function is not stores in the global list of functions
+///  GL   -  function will be always stored in the global list of functions ,
+///         independently of the global setting of TF1::DefaultAddToGlobalList
+///////////////////////////////////////////////////////////////////////////////////
+   TF1(name, formula, xmin, xmax, GetGlobalListOption(opt), GetVectorizedOption(opt) )
+{}
 ////////////////////////////////////////////////////////////////////////////////
 /// F1 constructor using name of an interpreted function.
 ///

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -1421,34 +1421,6 @@ Double_t TF1::EvalPar(const Double_t *x, const Double_t *params)
    return result;
 }
 
-#ifdef R__HAS_VECCORE
-////////////////////////////////////////////////////////////////////////////////
-///   Eval for vectorized functions
-
-ROOT::Double_v TF1::Eval(ROOT::Double_v x, ROOT::Double_v y, ROOT::Double_v z, ROOT::Double_v t) const
-{
-   if (fType == EFType::kFormula)
-      return fFormula->Eval(x, y, z, t);
-
-   ROOT::Double_v xx[] = {x, y, z, t};
-   Double_t *pp = (Double_t *)fParams->GetParameters();
-   return ((TF1 *)this)->EvalPar(xx, pp);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///   EvalPar for vectorized
-
-ROOT::Double_v TF1::EvalPar(const ROOT::Double_v *x, const Double_t *params)
-{
-   if (fType == EFType::kTemplVec || fType == EFType::kTemplScalar) {
-      return EvalParTempl(x, params);
-   } else if (fType == EFType::kFormula) {
-      return fFormula->EvalPar(x, params);
-   } else
-      return TF1::EvalPar((double *)x, params);
-}
-#endif
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Execute action corresponding to one event.
 ///

--- a/hist/hist/src/TF2.cxx
+++ b/hist/hist/src/TF2.cxx
@@ -55,8 +55,8 @@ TF2::TF2(): TF1(),fYmin(0),fYmax(0),fNpy(100)
 /// the formula string is "fffffff" and "xxxx" and "yyyy" are the
 /// titles for the X and Y axis respectively.
 
-TF2::TF2(const char *name,const char *formula, Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax)
-      :TF1(name,formula,xmax,xmin)
+TF2::TF2(const char *name,const char *formula, Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Option_t * opt)
+   :TF1(name,formula,xmax,xmin,opt)
 {
    if (ymin < ymax) {
       fYmin   = ymin;

--- a/hist/hist/src/TF3.cxx
+++ b/hist/hist/src/TF3.cxx
@@ -46,8 +46,8 @@ TF3::TF3(): TF2()
 ///
 /// See TFormula constructor for explanation of the formula syntax.
 
-TF3::TF3(const char *name,const char *formula, Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Double_t zmin, Double_t zmax)
-      :TF2(name,formula,xmin,xmax,ymax,ymin)
+TF3::TF3(const char *name,const char *formula, Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Double_t zmin, Double_t zmax, Option_t * opt)
+   :TF2(name,formula,xmin,xmax,ymax,ymin,opt)
 {
    fZmin   = zmin;
    fZmax   = zmax;

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -455,43 +455,8 @@ TFormula::TFormula(const char *name, const char *formula, int ndim, int npar, bo
 TFormula::TFormula(const TFormula &formula) :
    TNamed(formula.GetName(),formula.GetTitle())
 {
-   fReadyToExecute = false;
-   fClingInitialized = false;
-   fMethod = 0;
-   fNdim = formula.GetNdim();
-   fNpar = formula.GetNpar();
-   fNumber = formula.GetNumber();
-   fFormula = formula.GetExpFormula();   // returns fFormula in case of Lambda's
-   fLambdaPtr = nullptr;
-   fFuncPtr = nullptr;
-
-   // case of function based on a C++  expression (lambda's) which is ready to be compiled
-   if (formula.fLambdaPtr && formula.TestBit(TFormula::kLambda)) {
-
-      fClingInput = fFormula;
-      fParams = formula.fParams;
-      fClingParameters = formula.fClingParameters;
-      fAllParametersSetted = formula.fAllParametersSetted;
-
-      bool ret = InitLambdaExpression(fFormula);
-
-      if (ret)  {
-         SetBit(TFormula::kLambda);
-         fReadyToExecute = true;
-      }
-      else
-         Error("TFormula","Syntax error in building the lambda expression %s", fFormula.Data() );
-
-   }
-   else {
-
-      FillDefaults();
-
-      PreProcessFormula(fFormula);
-      PrepareFormula(fFormula);
-   }
-
-
+   formula.Copy(*this);
+ 
    if (!TestBit(TFormula::kNotGlobal) && gROOT ) {
       R__LOCKGUARD(gROOTMutex);
       TFormula *old = (TFormula*)gROOT->GetListOfFunctions()->FindObject(formula.GetName());
@@ -612,6 +577,7 @@ void TFormula::Copy(TObject &obj) const
    fnew.fNdim = fNdim;
    fnew.fNpar = fNpar;
    fnew.fNumber = fNumber;
+   fnew.fVectorized = fVectorized; 
    fnew.SetParameters(GetParameters());
    // copy Linear parts (it is a vector of TFormula pointers) needs to be copied one by one
    // looping at all the elements

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -810,10 +810,13 @@ void TFormula::FillDefaults()
 #ifdef R__HAS_VECCORE  
     const pair<TString,TString> vecFunShortcuts[] =
       { {"sin","vecCore::math::Sin" },
-        {"cos","veccore::math::Cos" }, {"exp","vecCore::math::Exp"}, {"log","vecCore::math::Log"}, {"log10","vecCore::math::Log10"},
-        {"tan","vecCore::math::Tan"}, {"sinh","vecCore::math::SinH"}, {"cosh","vecCore::math::CosH"},
-        {"tanh","vecCore::math::TanH"}, {"asin","vecCore::math::ASin"}, {"acos","vecCore::math::ACos"},
-        {"atan","ATan"}, {"atan2","vecCore::math::ATan2"}, {"sqrt","vecCore::math::Sqrt"},
+        {"cos","vecCore::math::Cos" }, {"exp","vecCore::math::Exp"}, {"log","vecCore::math::Log"}, {"log10","vecCore::math::Log10"},
+        {"tan","vecCore::math::Tan"},
+        //{"sinh","vecCore::math::Sinh"}, {"cosh","vecCore::math::Cosh"},{"tanh","vecCore::math::Tanh"},
+        {"asin","vecCore::math::ASin"},
+        {"acos","TMath::Pi()/2-vecCore::math::ASin"},
+        {"atan","vecCore::math::ATan"},
+        {"atan2","vecCore::math::ATan2"}, {"sqrt","vecCore::math::Sqrt"},
         {"ceil","vecCore::math::Ceil"}, {"floor","vecCore::math::Floor"}, {"pow","vecCore::math::Pow"},
         {"cbrt","vecCore::math::Cbrt"},{"abs","vecCore::math::Abs"},
         {"min","vecCore::math::Min"},{"max","vecCore::math::Max"},{"sign","vecCore::math::Sign" }
@@ -2989,6 +2992,7 @@ void TFormula::SetVectorized(Bool_t vectorized)
          fMethod->Delete();
       fMethod = nullptr;
 
+      FillDefaults();  // to replace with the right vectorized signature (e.g. sin  -> vecCore::math::Sin)
       PreProcessFormula(fFormula);
       PrepareFormula(fFormula);
    }
@@ -3201,9 +3205,13 @@ ROOT::Double_v TFormula::DoEvalVec(const ROOT::Double_v *x, const double *params
 
    ROOT::Double_v *vars = const_cast<ROOT::Double_v *>(x);
    args[0] = &vars;
-   if (fNpar <= 0)
+   if (fNpar <= 0) {
+      if (fNdim>1) 
+      std::cout << "called function with value " << vars[0] << "  " << vars[1] << std::endl;
       (*fFuncPtr)(0, 1, args, &result);
-   else {
+      if (fNdim>1) 
+      std::cout << "called function with value " << vars[0] << "  " << vars[1] << " result " << result << std::endl;
+   }else {
       double *pars = (params) ? const_cast<double *>(params) : const_cast<double *>(fClingParameters.data());
       args[1] = &pars;
       (*fFuncPtr)(0, 2, args, &result);

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -2995,13 +2995,13 @@ Double_t TFormula::EvalPar(const Double_t *x,const Double_t *params) const
 
 ////////////////////////////////////////////////////////////////////////////////
 #ifdef R__HAS_VECCORE
-ROOT::Double_v TFormula::Eval(ROOT::Double_v x, ROOT::Double_v y, ROOT::Double_v z, ROOT::Double_v t) const
-{
-   ROOT::Double_v xxx[] = {x, y, z, t};
-   return EvalPar(xxx, nullptr);
-}
+// ROOT::Double_v TFormula::Eval(ROOT::Double_v x, ROOT::Double_v y, ROOT::Double_v z, ROOT::Double_v t) const
+// {
+//    ROOT::Double_v xxx[] = {x, y, z, t};
+//    return EvalPar(xxx, nullptr);
+// }
 
-ROOT::Double_v TFormula::EvalPar(const ROOT::Double_v *x, const Double_t *params) const
+ROOT::Double_v TFormula::EvalParVec(const ROOT::Double_v *x, const Double_t *params) const
 {
    if (fVectorized)
       return DoEvalVec(x, params);

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -1708,8 +1708,6 @@ Bool_t TFormula::PrepareFormula(TString &formula)
 
    // use inputFormula for Cling
    ProcessFormula(fClingInput);
-   std::cout << "done with ProcessFormula" << std::endl; // todo remove
-   std::cout << "fNumber is " << fNumber << std::endl;
 
    // for pre-defined functions (need after processing)
    if (fNumber != 0) SetPredefinedParamNames();
@@ -2268,22 +2266,13 @@ void TFormula::ProcessFormula(TString &formula)
 
    // clean up un-used default variables in case formula is valid
    if (fClingInitialized && fReadyToExecute) {
-      std::cout << "cleanup stage" << std::endl; // todo remove
-
-      auto itvar = fVars.begin();
-      do {
-         std::cout << "start do-loop" << std::endl; // todo remove
-         if (!itvar->second.fFound) {
-            std::cout << "Erase variable " << itvar->first << std::endl; // todo comment
-            itvar = fVars.erase(itvar);
-         } else {
-            std::cout << "increment itvar++ from " << itvar->first << std::endl; // todo remove
-            itvar++;
+      for (auto itvar : fVars) {
+         if (!itvar.second.fFound) {
+            // std::cout << "Erase variable " << itvar.first << std::endl;
+            fVars.erase(itvar.first);
          }
-      } while (itvar != fVars.end());
+      }
    }
-
-   std::cout << "done with ProcessFormula (1)" << std::endl;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2985,12 +2974,10 @@ void TFormula::SetVectorized(Bool_t vectorized)
 ////////////////////////////////////////////////////////////////////////////////
 Double_t TFormula::EvalPar(const Double_t *x,const Double_t *params) const
 {
-   std::cout << "fNdim is " << fNdim << std::endl; // todo remove line
-
    if (!fVectorized)
       return DoEval(x, params);
 
-   if (fNdim == 0)
+   if (fNdim == 0 || !x)
       return DoEvalVec(nullptr, params)[0];
 
 // otherwise, regular Double_t inputs on a vectorized function
@@ -3021,8 +3008,8 @@ ROOT::Double_v TFormula::EvalPar(const ROOT::Double_v *x, const Double_t *params
    if (fVectorized)
       return DoEvalVec(x, params);
 
-   if (fNdim == 0)
-      return DoEval(nullptr, params);
+   if (fNdim == 0 || !x)
+      return DoEval(nullptr, params); // automatic conversion to vectorized
 
    // otherwise, trying to input vectors into a scalar function
 

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -2958,12 +2958,13 @@ Double_t TFormula::EvalPar(const Double_t *x,const Double_t *params) const
    if (!fVectorized)
       return DoEval(x, params);
 
+#ifdef R__HAS_VECCORE
+
    if (fNdim == 0 || !x)
       return DoEvalVec(nullptr, params)[0];
 
-// otherwise, regular Double_t inputs on a vectorized function
+    // otherwise, regular Double_t inputs on a vectorized function
 
-#ifdef R__HAS_VECCORE
    // convert our input into vectors then convert back
    if (gDebug)
       Info("EvalPar", "Function is vectorized - converting Double_t into ROOT::Double_v and back");

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -2948,6 +2948,8 @@ void TFormula::SetVectorized(Bool_t vectorized)
          Error("SetVectorized", "Cannot set vectorized to %d -- Formula is missing", vectorized);
 
       fVectorized = vectorized;
+      // no need to JIT a new signature in case of zero dimension
+      if (fNdim== 0) return; 
       fClingInitialized = false;
       fReadyToExecute = false;
       fClingName = "";
@@ -3171,11 +3173,7 @@ ROOT::Double_v TFormula::DoEvalVec(const ROOT::Double_v *x, const double *params
    ROOT::Double_v *vars = const_cast<ROOT::Double_v *>(x);
    args[0] = &vars;
    if (fNpar <= 0) {
-      if (fNdim>1) 
-      std::cout << "called function with value " << vars[0] << "  " << vars[1] << std::endl;
       (*fFuncPtr)(0, 1, args, &result);
-      if (fNdim>1) 
-      std::cout << "called function with value " << vars[0] << "  " << vars[1] << " result " << result << std::endl;
    }else {
       double *pars = (params) ? const_cast<double *>(params) : const_cast<double *>(fClingParameters.data());
       args[1] = &pars;

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -734,6 +734,8 @@ void TFormula::InputFormulaIntoCling()
 {
 
    if (!fClingInitialized && fReadyToExecute && fClingInput.Length() > 0) {
+      // add pragma for optimization of the formula
+      fClingInput =  TString("#pragma cling optimize(2)\n") + fClingInput;
       gCling->Declare(fClingInput);
       fClingInitialized = PrepareEvalMethod();
    }

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -2985,7 +2985,8 @@ Double_t TFormula::EvalPar(const Double_t *x,const Double_t *params) const
 
 #ifdef R__HAS_VECCORE
    // convert our input into vectors then convert back
-   Warning("EvalPar", "Function is vectorized - converting Double_t into ROOT::Double_v and back");
+   if (gDebug)
+      Info("EvalPar", "Function is vectorized - converting Double_t into ROOT::Double_v and back");
 
    ROOT::Double_v xvec[fNdim];
    for (int i = 0; i < fNdim; i++)
@@ -3020,7 +3021,8 @@ ROOT::Double_v TFormula::EvalPar(const ROOT::Double_v *x, const Double_t *params
 
    // otherwise, trying to input vectors into a scalar function
 
-   Warning("EvalPar", "Function is not vectorized - converting ROOT::Double_v into Double_t and back");
+   if (gDebug)
+      Info("EvalPar", "Function is not vectorized - converting ROOT::Double_v into Double_t and back");
 
    int vecSize = x[0].size();
    Double_t xscalars[vecSize][fNdim];

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -2169,7 +2169,7 @@ void TFormula::ProcessFormula(TString &formula)
       // does not make sense to vectorize function which is of FNDim=0
       if (!hasVariables) fVectorized=false;
       // when there are no variables but only parameter we still need to ad
-      Bool_t hasBoth = hasVariables && hasParameters; 
+      //Bool_t hasBoth = hasVariables && hasParameters; 
       Bool_t inputIntoCling = (formula.Length() > 0);
       if (inputIntoCling) {
          // save copy of inputFormula in a std::strig for the unordered map

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -374,7 +374,10 @@ TFormula::TFormula(const char *name, const char *formula, bool addToGlobList, bo
    fNumber = 0;
    fMethod = 0;
    fLambdaPtr = nullptr;
-   fVectorized = vectorize; 
+   fVectorized = vectorize;
+#ifndef R__HAS_VECCORE
+   fVectorized = false; 
+#endif
 
    FillDefaults();
 

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -2956,9 +2956,12 @@ void TFormula::SetVectorized(Bool_t vectorized)
       fVectorized = vectorized;
       fClingInitialized = false;
       fReadyToExecute = false;
-      fMethod = nullptr; // (todo check for memory leaks?)
       fClingName = "";
       fClingInput = fFormula;
+
+      if (fMethod)
+         fMethod->Delete();
+      fMethod = nullptr;
 
       PreProcessFormula(fFormula);
       PrepareFormula(fFormula);
@@ -2972,8 +2975,6 @@ void TFormula::SetVectorized(Bool_t vectorized)
 ////////////////////////////////////////////////////////////////////////////////
 Double_t TFormula::EvalPar(const Double_t *x,const Double_t *params) const
 {
-   std::cout << "starting evalpar" << std::endl; // todo remove
-
    if (!fVectorized)
       return DoEval(x, params);
 
@@ -3160,10 +3161,7 @@ ROOT::Double_v TFormula::DoEvalVec(const ROOT::Double_v *x, const double *params
    ROOT::Double_v result = 0;
    void *args[2];
 
-   // todo: to get the fClingVariables part working will require some more work,
-   // because all the "AddVariables" etc code assumes that the variables are
-   // doubles
-   ROOT::Double_v *vars = const_cast<ROOT::Double_v *>(x); // backup plan: fClingVariables.data()
+   ROOT::Double_v *vars = const_cast<ROOT::Double_v *>(x);
    args[0] = &vars;
    if (fNpar <= 0)
       (*fFuncPtr)(0, 1, args, &result);

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -807,6 +807,21 @@ void TFormula::FillDefaults()
         {"min","TMath::Min"},{"max","TMath::Max"},{"sign","TMath::Sign" },
         {"sq","TMath::Sq"}
       };
+#ifdef R__HAS_VECCORE  
+    const pair<TString,TString> vecFunShortcuts[] =
+      { {"sin","vecCore::math::Sin" },
+        {"cos","veccore::math::Cos" }, {"exp","vecCore::math::Exp"}, {"log","vecCore::math::Log"}, {"log10","vecCore::math::Log10"},
+        {"tan","vecCore::math::Tan"}, {"sinh","vecCore::math::SinH"}, {"cosh","vecCore::math::CosH"},
+        {"tanh","vecCore::math::TanH"}, {"asin","vecCore::math::ASin"}, {"acos","vecCore::math::ACos"},
+        {"atan","ATan"}, {"atan2","vecCore::math::ATan2"}, {"sqrt","vecCore::math::Sqrt"},
+        {"ceil","vecCore::math::Ceil"}, {"floor","vecCore::math::Floor"}, {"pow","vecCore::math::Pow"},
+        {"cbrt","vecCore::math::Cbrt"},{"abs","vecCore::math::Abs"},
+        {"min","vecCore::math::Min"},{"max","vecCore::math::Max"},{"sign","vecCore::math::Sign" }
+        //{"sq","TMath::Sq"}, {"binomial","TMath::Binomial"}  // this last two functions will not work in vectorized mode
+      };
+#else
+    const pair<TString,TString> vecFunShortcuts[] = funShortcuts;
+#endif 
 
    std::vector<TString> defvars2(10);
    for (int i = 0; i < 9; ++i)
@@ -829,8 +844,15 @@ void TFormula::FillDefaults()
    for (auto con : defconsts) {
       fConsts[con.first] = con.second;
    }
-   for (auto fun : funShortcuts) {
-      fFunctionsShortcuts[fun.first] = fun.second;
+   if (fVectorized) {
+      // for vectorized case use vecCore functions
+      for (auto fun : vecFunShortcuts) {
+         fFunctionsShortcuts[fun.first] = fun.second;
+      }
+   } else {
+      for (auto fun : funShortcuts) {
+         fFunctionsShortcuts[fun.first] = fun.second;
+      }
    }
 
    /*** - old code to support C++03

--- a/test/TFormulaTests.cxx
+++ b/test/TFormulaTests.cxx
@@ -13,6 +13,7 @@
 #include <TRandom.h>
 #include <iostream>
 #include "TFormulaParsingTests.h"
+#include "TFormulaVecTests.h"
 
 using namespace std;
 
@@ -55,8 +56,8 @@ public:
    Bool_t      SetPars2();
    Bool_t      Eval();
    Bool_t      Stress(Int_t n = 10000);
-
    Bool_t      Parser();
+   Bool_t      Vectorize();
 
    
 
@@ -496,7 +497,15 @@ bool TFormulaTests::Parser() {
    return true; 
 }
    
-
+bool TFormulaTests::Vectorize() {
+   std::cout << "Test creating vectorized Formula" << std::endl;
+   bool ok = testVecFormula(); 
+   if (!ok) {
+      std::cout << "ERROR - Creating Vectorized TFormula failed " << std::endl;
+      return false;
+   }
+   return true; 
+}
 
 
 int main(int argc, char **argv)
@@ -563,6 +572,7 @@ int main(int argc, char **argv)
 #endif
    printf("Stress test:%s\n",(test->Stress(n) ? "PASSED" : "FAILED"));
    printf("Parsing test:%s\n",(test->Parser() ? "PASSED" : "FAILED"));
+   printf("Vectorization test:%s\n",(test->Vectorize() ? "PASSED" : "FAILED"));
 
    return 0;
 }

--- a/test/TFormulaTests.cxx
+++ b/test/TFormulaTests.cxx
@@ -514,7 +514,7 @@ int main(int argc, char **argv)
 
    TApplication theApp("App", &argc, argv);
    gBenchmark = new TBenchmark();
-   Int_t n = 200;
+   Int_t n = 100;
    if(argc > 1) 
       n = TString(argv[1]).Atoi();
    printf("************************************************\n");

--- a/test/TFormulaVecTests.h
+++ b/test/TFormulaVecTests.h
@@ -1,0 +1,113 @@
+#include <TF1.h>
+#include <TF2.h>
+#include <iostream>
+#include <TString.h>
+
+bool verbose  = true; 
+//#define VEC_IN_CTOR
+
+bool CheckValues(const TString & testName, double r, double r0) { 
+
+   bool ret =  TMath::AreEqualAbs(r,r0,1.E-12);
+   if (!ret) {
+      std::cout << "Test failed for " << testName << "  : " <<  r << "   " << r0 <<  std::endl;
+   }
+   else
+      if (verbose) std::cout << testName << "\t ok\n";
+   
+   return ret; 
+}
+
+
+typedef double ( * FreeFunc1D) (double );
+bool testVec1D(TF1 * f1, const TString & formula, FreeFunc1D func, double x ) {
+  
+   auto y = f1->Eval(x);
+   auto y0 = func(x); 
+
+   bool ret = CheckValues(formula, y, y0);
+
+   // check passing double_v interface   
+   ROOT::Double_v vx = x;
+   ROOT::Double_v vy = f1->EvalPar(&vx, nullptr);
+   ret &= CheckValues(formula+TString("_v"), vy[0], y0); 
+   
+   return ret; 
+}
+bool testVec1D(const TString & formula, FreeFunc1D func, double x = 1.) {
+   
+   // test first by vectorizing in the constructor
+   auto f1 = new TF1("f",formula,0,1,"VEC");
+   bool ret = testVec1D(f1,formula,func,x);
+   // test by vectorizing afterwards calling SetVectorized
+   auto f2 = new TF1("f2",formula);
+   f2->SetVectorized(true);
+   //std::cout << "set vectprization" << std::endl;
+   //f2->Print("V");
+   ret &=  testVec1D(f2,formula,func,x);
+   // test by removing vectorization
+   f2->SetVectorized(false);
+   ret &=  testVec1D(f1,formula,func,x);
+   return ret; 
+}
+
+
+typedef double ( * FreeFunc2D) (double, double );
+bool testVec2D(TF2 * f1, const TString & formula, FreeFunc2D func, double x, double y ) {
+   
+   auto r = f1->Eval(x,y);
+   auto r0 = func(x,y); 
+
+   bool ret = CheckValues(formula,r,r0);
+
+   // check passing double_v interface   
+   ROOT::Double_v vx[2] = { x, y};
+   ROOT::Double_v vy = f1->EvalPar(vx, nullptr);
+   
+   ret &= CheckValues(formula+TString("_v"), vy[0], r0); 
+   return ret; 
+  
+}
+
+bool testVec2D(const TString & formula, FreeFunc2D func, double x = 1., double y = 1.) {
+
+   auto f1 = new TF2("f",formula,0,1,0,1,"VEC");
+   bool ret = testVec2D(f1, formula, func, x, y); 
+
+   auto f2 = new TF2("f",formula);
+   f2->SetVectorized(true);
+   ret &=  testVec2D(f2,formula,func,x,y);
+   return ret;
+}
+ 
+
+double constant_function(double ) { return 3; }
+
+
+bool testVecFormula() {
+
+   bool ok = true;
+
+   ok &= testVec1D("3+[0]",constant_function, 3.333);
+   ok &= testVec1D("3",constant_function, 3.333);
+   ok &= testVec1D("sin(x)",std::sin,1);
+   ok &= testVec1D("cos(x)",std::cos,1);
+   ok &= testVec1D("exp(x)",std::exp,1);
+   ok &= testVec1D("log(x)",std::log,2);
+   ok &= testVec1D("log10(x)",TMath::Log10,2);
+   ok &= testVec1D("tan(x)",std::tan,1);
+   //ok &= testVec1D("sinh(x)",std::sinh,1);
+   //ok &= testVec1D("cosh(x)",std::cosh,1);
+   //ok &= testVec1D("tanh(x)",std::tanh,1);
+   ok &= testVec1D("asin(x)",std::asin,.1);
+   ok &= testVec1D("acos(x)",std::acos,.1);
+   ok &= testVec1D("atan(x)",std::atan,.1);
+   ok &= testVec1D("sqrt(x)",std::sqrt,2);
+   ok &= testVec1D("abs(x)",std::abs,-1);
+   ok &= testVec2D("pow(x,y)",std::pow,2,3);
+   ok &= testVec2D("min(x,y)",TMath::Min,2,3);
+   ok &= testVec2D("max(x,y)",TMath::Max,2,3);
+   ok &= testVec2D("atan2(x,y)",TMath::ATan2,2,3);
+
+   return ok; 
+}

--- a/test/TFormulaVecTests.h
+++ b/test/TFormulaVecTests.h
@@ -31,7 +31,8 @@ bool testVec1D(TF1 * f1, const TString & formula, FreeFunc1D func, double x ) {
 #ifdef R__HAS_VECCORE
    ROOT::Double_v vx = x;
    ROOT::Double_v vy = f1->EvalPar(&vx, nullptr);
-   ret &= CheckValues(formula+TString("_v"), vy[0], y0);
+   double y2 = vecCore::Get(vy,0);
+   ret &= CheckValues(formula+TString("_v"), y2, y0);
 #endif
 
    return ret;
@@ -66,7 +67,8 @@ bool testVec2D(TF2 * f1, const TString & formula, FreeFunc2D func, double x, dou
 #ifdef R__HAS_VECCORE
    ROOT::Double_v vx[2] = { x, y};
    ROOT::Double_v vy = f1->EvalPar(vx, nullptr);
-   ret &= CheckValues(formula+TString("_v"), vy[0], r0);
+   double r2 = vecCore::Get(vy,0);
+   ret &= CheckValues(formula+TString("_v"), r2, r0);
 #endif
 
    return ret;

--- a/test/TFormulaVecTests.h
+++ b/test/TFormulaVecTests.h
@@ -14,28 +14,30 @@ bool CheckValues(const TString & testName, double r, double r0) {
    }
    else
       if (verbose) std::cout << testName << "\t ok\n";
-   
-   return ret; 
+
+   return ret;
 }
 
 
 typedef double ( * FreeFunc1D) (double );
 bool testVec1D(TF1 * f1, const TString & formula, FreeFunc1D func, double x ) {
-  
+
    auto y = f1->Eval(x);
-   auto y0 = func(x); 
+   auto y0 = func(x);
 
    bool ret = CheckValues(formula, y, y0);
 
-   // check passing double_v interface   
+   // check passing double_v interface
+#ifdef R__HAS_VECCORE
    ROOT::Double_v vx = x;
    ROOT::Double_v vy = f1->EvalPar(&vx, nullptr);
-   ret &= CheckValues(formula+TString("_v"), vy[0], y0); 
-   
-   return ret; 
+   ret &= CheckValues(formula+TString("_v"), vy[0], y0);
+#endif
+
+   return ret;
 }
 bool testVec1D(const TString & formula, FreeFunc1D func, double x = 1.) {
-   
+
    // test first by vectorizing in the constructor
    auto f1 = new TF1("f",formula,0,1,"VEC");
    bool ret = testVec1D(f1,formula,func,x);
@@ -48,38 +50,39 @@ bool testVec1D(const TString & formula, FreeFunc1D func, double x = 1.) {
    // test by removing vectorization
    f2->SetVectorized(false);
    ret &=  testVec1D(f1,formula,func,x);
-   return ret; 
+   return ret;
 }
 
 
 typedef double ( * FreeFunc2D) (double, double );
 bool testVec2D(TF2 * f1, const TString & formula, FreeFunc2D func, double x, double y ) {
-   
+
    auto r = f1->Eval(x,y);
-   auto r0 = func(x,y); 
+   auto r0 = func(x,y);
 
    bool ret = CheckValues(formula,r,r0);
 
-   // check passing double_v interface   
+   // check passing double_v interface
+#ifdef R__HAS_VECCORE
    ROOT::Double_v vx[2] = { x, y};
    ROOT::Double_v vy = f1->EvalPar(vx, nullptr);
-   
-   ret &= CheckValues(formula+TString("_v"), vy[0], r0); 
-   return ret; 
-  
+   ret &= CheckValues(formula+TString("_v"), vy[0], r0);
+#endif
+
+   return ret;
 }
 
 bool testVec2D(const TString & formula, FreeFunc2D func, double x = 1., double y = 1.) {
 
    auto f1 = new TF2("f",formula,0,1,0,1,"VEC");
-   bool ret = testVec2D(f1, formula, func, x, y); 
+   bool ret = testVec2D(f1, formula, func, x, y);
 
    auto f2 = new TF2("f",formula);
    f2->SetVectorized(true);
    ret &=  testVec2D(f2,formula,func,x,y);
    return ret;
 }
- 
+
 
 double constant_function(double ) { return 3; }
 

--- a/tutorials/fit/fitNormSum.C
+++ b/tutorials/fit/fitNormSum.C
@@ -18,7 +18,7 @@
 /// \macro_output
 /// \macro_code
 ///
-/// \author Rene Brun
+/// \author Lorenzo Moneta
 
 #include <TMath.h>
 #include <TCanvas.h>

--- a/tutorials/fit/vectorizedFit.C
+++ b/tutorials/fit/vectorizedFit.C
@@ -1,0 +1,87 @@
+/// \file
+/// \ingroup tutorial_fit
+/// \notebook                                                                                                                              /// Tutorial for creating a Vectorized TF1 function using a formunla expression and
+/// use it for fitting an histogram
+///
+/// To create a vectorized function (if ROOT has been compiled with support for vectorization)
+/// is very easy. One needs to create the TF1 object with the option "VEC" or call the method
+/// TF1::SetVectorized
+///
+/// \macro_image
+/// \macro output
+/// \macro_code
+///
+/// \author Lorenzo Moneta
+
+void vectorizedFit() {
+
+   gStyle->SetOptFit(111111);
+   
+
+   ROOT::Math::MinimizerOptions::SetDefaultMinimizer("Minuit2");
+
+   int nbins = 40000;
+   auto h1 = new TH1D("h1","h1",nbins,-3,3);
+   h1->FillRandom("gaus",nbins*50);
+   auto c1 = new TCanvas("Fit","Fit",800,1000);
+   c1->Divide(1,2);
+   c1->cd(1);
+   TStopwatch w;
+
+   std::cout << "Doing Serial Gaussian Fit " << std::endl;
+   auto f1 = new TF1("f1","gaus");
+   f1->SetNpx(nbins*10);
+   w.Start();
+   h1->Fit(f1);
+   h1->Fit(f1,"L+");
+   w.Print();
+
+   std::cout << "Doing Vectorized Gaussian Fit " << std::endl;
+   auto f2 = new TF1("f2","gaus",-3,3,"VEC");
+   // alternativly you can also use the TF1::SetVectorized function
+   //f2->SetVectorized(true); 
+   w.Start();
+   h1->Fit(f2);
+   h1->Fit(f2,"L+");
+   w.Print();
+   // rebin histograms and scale it back to the function
+   h1->Rebin(nbins/100);
+   h1->Scale(100./nbins);
+   ((TF1 *)h1->GetListOfFunctions()->At(0))->SetTitle("Chi2 Fit");
+   ((TF1 *)h1->GetListOfFunctions()->At(1))->SetTitle("Likelihood Fit");
+   ((TF1 *)h1->GetListOfFunctions()->At(1))->SetLineColor(kBlue);
+   //c1->cd(1)->BuildLegend();
+
+   /// Do a polynomail fit now
+   c1->cd(2);
+   auto f3 = new TF1("f3","[A]*x^2+[B]*x+[C]",0,10);
+   f3->SetParameters(0.5,3,2);
+   f3->SetNpx(nbins*10);
+   // generate the events
+   auto h2 = new TH1D("h2","h2",nbins,0,10);
+   h2->FillRandom("f3",10*nbins);
+   std::cout << "Doing Serial Polynomial Fit " << std::endl;
+   f3->SetParameters(2,2,2);
+   w.Start();
+   h2->Fit(f3);
+   h2->Fit(f3,"L+");
+   w.Print();
+
+   std::cout << "Doing Vectorized Polynomial Fit " << std::endl;
+   auto f4 = new TF1("f4","[A]*x*x+[B]*x+[C]",0,10);
+   f4->SetVectorized(true);
+   f4->SetParameters(2,2,2);
+   w.Start();
+   h2->Fit(f4);
+   h2->Fit(f4,"L+");
+   w.Print();
+
+   // rebin histograms and scale it back to the function
+   h2->Rebin(nbins/100);
+   h2->Scale(100./nbins);
+   ((TF1 *)h2->GetListOfFunctions()->At(0))->SetTitle("Chi2 Fit");
+   ((TF1 *)h2->GetListOfFunctions()->At(1))->SetTitle("Likelihood Fit");
+   ((TF1 *)h2->GetListOfFunctions()->At(1))->SetLineColor(kBlue);
+   //c1->cd(2)->BuildLegend();
+
+}


### PR DESCRIPTION
This PR enables the support to create Vectorized TFormula expression by adding a signature using 
ROOT::Double_v

The functionality is available if ROOT has been compiled with VecCore support, 
i.e. the macro R__HAS__VECCORE is defined 