### PR TITLE
webgui: run tutorials macros in batch mode, fix compiler warnings

### DIFF
--- a/graf2d/gpad/v7/inc/ROOT/TText.hxx
+++ b/graf2d/gpad/v7/inc/ROOT/TText.hxx
@@ -33,8 +33,8 @@ namespace ROOT {
 namespace Experimental {
 
 /** \class ROOT::Experimental::TText
-  A text.
-  */
+ A text.
+ */
 
 class TText {
 private:
@@ -50,38 +50,49 @@ public:
    TText() = default;
 
    TText(const std::string &str) : fText(str) {}
-};
 
+   void SetText(const std::string &txt) { fText = txt; }
+
+   std::string GetText() const { return fText; }
+
+   void SetPosition(double x, double y)
+   {
+      fX = x;
+      fY = y;
+   }
+
+   double GetX() const { return fX; }
+
+   double GetY() const { return fY; }
+};
 
 class TextDrawingOpts : public TDrawingOptsBase<TextDrawingOpts> {
 
-   TLineAttrs fLine{*this, "Text.Line", TColor::kBlack, TLineAttrs::Width{3} }; ///< The line attributes
-   TFillAttrs fFill{*this, "Text.Fill", TColor::kWhite }; ///< The fill attributes
+   TLineAttrs fLine{*this, "Text.Line", TColor::kBlack, TLineAttrs::Width{3}}; ///< The line attributes
+   TFillAttrs fFill{*this, "Text.Fill", TColor::kWhite};                       ///< The fill attributes
 
 public:
    TextDrawingOpts() = default;
-   explicit TextDrawingOpts(TPadBase &pad) :
-      TDrawingOptsBase<TextDrawingOpts>(pad, "Text") {}
-//      fLine{*this, "Text.Line", TColor::kBlack, TLineAttrs::Width{3}},
-//      fAttr{*this, "Text.Fill", TColor::kWhite}
-//   {}
+   explicit TextDrawingOpts(TPadBase &pad) : TDrawingOptsBase<TextDrawingOpts>(pad, "Text") {}
+   //      fLine{*this, "Text.Line", TColor::kBlack, TLineAttrs::Width{3}},
+   //      fAttr{*this, "Text.Fill", TColor::kWhite}
+   //   {}
 
    /// The color of the line.
    void SetLineColor(const TColor &col) { Update(fLine.fColor, col); }
    TColor &GetLineColor() { return this->Get(fLine.fColor); }
-//   const TColor &GetLineColor() const { return this->Get(fLine.fColor); }
+   //   const TColor &GetLineColor() const { return this->Get(fLine.fColor); }
 
    /// The width of the line.
-//   void SetLineWidth(TLineAttrs::Width width) { this->Update(fLine.fWidth, width); }
-//   TLineAttrs::Width &GetLineWidth() { return this->Get(fLine.fWidth); }
-//   const TLineAttrs::Width GetLineWidth() const { return this->Get(fLine.fWidth); }
+   //   void SetLineWidth(TLineAttrs::Width width) { this->Update(fLine.fWidth, width); }
+   //   TLineAttrs::Width &GetLineWidth() { return this->Get(fLine.fWidth); }
+   //   const TLineAttrs::Width GetLineWidth() const { return this->Get(fLine.fWidth); }
 
    /// The fill color
    void SetFillColor(const TColor &col) { this->Update(fFill.fColor, col); }
    TColor &GetFillColor() { return this->Get(fFill.fColor); }
-//   const TColor &GetFillColor() const { return this->Get(fFill.fColor); }
+   //   const TColor &GetFillColor() const { return this->Get(fFill.fColor); }
 };
-
 
 class TTextDrawable : public TDrawable {
 private:
@@ -93,10 +104,12 @@ private:
    TextDrawingOpts fOpts{};
 
 public:
-
    TTextDrawable() = default;
 
-   TTextDrawable(const std::shared_ptr<ROOT::Experimental::TText> &txt, TPadBase &pad) : TDrawable(), fText(txt), fOpts(pad)  {}
+   TTextDrawable(const std::shared_ptr<ROOT::Experimental::TText> &txt, TPadBase &pad)
+      : TDrawable(), fText(txt), fOpts(pad)
+   {
+   }
 
    TextDrawingOpts &GetOptions() { return fOpts; }
    const TextDrawingOpts &GetOptions() const { return fOpts; }
@@ -105,17 +118,15 @@ public:
    {
       canv.AddDisplayItem(new ROOT::Experimental::TOrdinaryDisplayItem<ROOT::Experimental::TTextDrawable>(this));
    }
-
 };
 
-
-inline std::unique_ptr<ROOT::Experimental::TTextDrawable> GetDrawable(const std::shared_ptr<ROOT::Experimental::TText> &text, TPadBase &pad)
+inline std::unique_ptr<ROOT::Experimental::TTextDrawable>
+GetDrawable(const std::shared_ptr<ROOT::Experimental::TText> &text, TPadBase &pad)
 {
    return std::make_unique<ROOT::Experimental::TTextDrawable>(text, pad);
 }
 
 } // namespace Experimental
 } // namespace ROOT
-
 
 #endif

--- a/gui/canvaspainter/Readme.md
+++ b/gui/canvaspainter/Readme.md
@@ -2,12 +2,12 @@
 
 1. Current code developed with CEF3 3071.
 
-2  Download binary code from http://opensource.spotify.com/cefbuilds/index.html and 
+2  Download binary code from http://opensource.spotify.com/cefbuilds/index.html and
    unpack it in directory without spaces and special symbols: 
 
      [shell] mkdir /d/cef
      [shell] cd /d/cef/
-     [shell] wget http://opensource.spotify.com/cefbuilds/cef_binary_3.3071.1649.g98725e6_linux64.tar.bz2 
+     [shell] wget http://opensource.spotify.com/cefbuilds/cef_binary_3.3071.1649.g98725e6_linux64.tar.bz2
      [shell] tar xjf cef_binary_3.3071.1649.g98725e6_linux64.tar.bz2
 
 3. Set `CEF_PATH` shell variable to unpacked directory:
@@ -29,7 +29,7 @@
 
 7. Run ROOT from the same shell (CEF_PATH and JSROOTSYS variables should be set)
 
-8. Only single canvas is supported at the moment, one get different warnings       
+8. Only single canvas is supported at the moment, one get different warnings
 
 
 ## Using CEF in batch mode on Linux
@@ -61,7 +61,7 @@ CEF works with  Xvfb without problem.
 ## Compilation with QT5 WebEngine support
 
 This is alternative implementation of local display, using chromium from Qt5.
-Idea to have easy possibility to embed ROOT panels (TCanvas, TBrowser) in Qt applications.  
+Idea to have easy possibility to embed ROOT panels (TCanvas, TBrowser) in Qt applications.
 
 1. Install libqt5-qtwebengine and libqt5-qtwebengine-devel packages
 
@@ -69,7 +69,7 @@ Idea to have easy possibility to embed ROOT panels (TCanvas, TBrowser) in Qt app
 
 3. Compile rootqt5 main program (standard Rint plus QApplication)
 
-     [shell] cd gui/canvaspainter/v7/qt5; qmake-qt5 rootqt5.pro; make     
+     [shell] cd gui/canvaspainter/v7/qt5; qmake-qt5 rootqt5.pro; make
 
 4. Run ROOT macros, using rootqt5 executable:
 

--- a/gui/canvaspainter/Readme.md
+++ b/gui/canvaspainter/Readme.md
@@ -1,24 +1,24 @@
-## Compilation with CEF support (https://bitbucket.org/chromiumembedded/cef)     
+## Compilation with CEF support (https://bitbucket.org/chromiumembedded/cef)
 
 1. Current code developed with CEF3 3071.
 
 2  Download binary code from http://opensource.spotify.com/cefbuilds/index.html and 
    unpack it in directory without spaces and special symbols: 
-  
+
      [shell] mkdir /d/cef
      [shell] cd /d/cef/
      [shell] wget http://opensource.spotify.com/cefbuilds/cef_binary_3.3071.1649.g98725e6_linux64.tar.bz2 
      [shell] tar xjf cef_binary_3.3071.1649.g98725e6_linux64.tar.bz2
 
 3. Set `CEF_PATH` shell variable to unpacked directory:
-  
+
      [shell] export CEF_PATH=/d/cef/cef_binary_3.3071.1649.g98725e6_linux64
-     
+
 4. Install prerequicities - see comments in $CEF_PATH/CMakeLists.txt. 
    For the linux it is `build-essential`, `libgtk2.0-dev`, `libgtkglext1-dev`
 
 5. Compile all tests (required for the libcef_dll_wrapper)
-     
+
      [shell] cd $CEF_PATH
      [shell] mkdir build
      [shell] cd build
@@ -48,8 +48,12 @@ CEF works with  Xvfb without problem.
     [shell] Xvfb :99 &
     [shell] export DISPLAY=:99
 
-2. Run macro in batch mode:
-    
+2. Configure **cef** or **chromium** as default display
+
+    [shell] export WEBGUI_WHERE=cef
+
+3. Run macro in batch mode:
+
     [shell] root -l -b draw_v6.cxx -q
 
 
@@ -64,11 +68,10 @@ Idea to have easy possibility to embed ROOT panels (TCanvas, TBrowser) in Qt app
 2. Compile ROOT and call thisroot.sh (ROOTSYS variable should be set)
 
 3. Compile rootqt5 main program (standard Rint plus QApplication)
-  
+
      [shell] cd gui/canvaspainter/v7/qt5; qmake-qt5 rootqt5.pro; make     
 
 4. Run ROOT macros, using rootqt5 executable:
 
      [shell] rootqt5 -l hsimple.C
 
-     

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -609,7 +609,7 @@ void ROOT::Experimental::TCanvasPainter::ProcessData(unsigned connid, const std:
 void ROOT::Experimental::TCanvasPainter::NewDisplay(const std::string &where)
 {
    if (!fWindow) {
-      fWindow = TWebWindowsManager::Instance()->CreateWindow(false);
+      fWindow = TWebWindowsManager::Instance()->CreateWindow(IsBatchMode());
 
       fWindow->SetDefaultPage("file:$jsrootsys/files/canvas.htm");
 
@@ -630,6 +630,11 @@ bool ROOT::Experimental::TCanvasPainter::AddPanel(std::shared_ptr<TWebWindow> wi
 
    if (!fWindow) {
       R__ERROR_HERE("AddPanel") << "Canvas not yet shown";
+      return false;
+   }
+
+   if (IsBatchMode()) {
+      R__ERROR_HERE("AddPanel") << "Canvas shown in batch mode";
       return false;
    }
 

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -508,7 +508,7 @@ void ROOT::Experimental::TCanvasPainter::DoWhenReady(const std::string &name, co
    CheckDataToSend();
 
    if (!async)
-      fWindow->WaitFor(std::bind(&TCanvasPainter::CheckWaitingCmd, this, name, std::placeholders::_1), 100);
+      fWindow->WaitFor([this,name](double tm) { return CheckWaitingCmd(name,tm); }, 100);
 }
 
 void ROOT::Experimental::TCanvasPainter::ProcessData(unsigned connid, const std::string &arg)

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -529,7 +529,7 @@ void ROOT::Experimental::TCanvasPainter::ProcessData(unsigned connid, const std:
 
    if (!conn) return; // no connection found
 
-   printf("Get data %u %s\n", connid, arg.c_str());
+   printf("Get data %u %.30s\n", connid, arg.c_str());
 
    if (arg == "CONN_CLOSED") {
       // special argument from TWebWindow itself

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -444,6 +444,12 @@ void ROOT::Experimental::TCanvasPainter::CanvasUpdated(uint64_t ver, bool async,
       return;
    }
 
+   if (!fWindow || !fWindow->IsShown()) {
+      if (callback)
+         callback(false);
+      return;
+   }
+
    fSnapshotVersion = ver;
    fSnapshot = CreateSnapshot(fCanvas);
 
@@ -480,6 +486,12 @@ void ROOT::Experimental::TCanvasPainter::DoWhenReady(const std::string &name, co
    if (!async && !fWaitingCmdId.empty()) {
       R__ERROR_HERE("DoWhenReady") << "Fail to submit sync command when previous is still awaited - use async";
       async = true;
+   }
+
+   if (!fWindow || !fWindow->IsShown()) {
+      if (callback)
+         callback(false);
+      return;
    }
 
    WebCommand cmd;

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -252,7 +252,7 @@ public:
    virtual ~TCanvasPainter();
 
    /// returns true is canvas used in batch mode
-   virtual bool IsBatchMode() const { return fBatchMode; }
+   virtual bool IsBatchMode() const override { return fBatchMode; }
 
    virtual void AddDisplayItem(TDisplayItem *item) override
    {

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -508,7 +508,7 @@ void ROOT::Experimental::TCanvasPainter::DoWhenReady(const std::string &name, co
    CheckDataToSend();
 
    if (!async)
-      fWindow->WaitFor([this,name](double tm) { return CheckWaitingCmd(name,tm); }, 100);
+      fWindow->WaitFor([this, name](double tm) { return CheckWaitingCmd(name, tm); }, 100);
 }
 
 void ROOT::Experimental::TCanvasPainter::ProcessData(unsigned connid, const std::string &arg)

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -252,7 +252,10 @@ public:
    virtual ~TCanvasPainter();
 
    /// returns true is canvas used in batch mode
-   virtual bool IsBatchMode() const override { return fBatchMode; }
+   virtual bool IsBatchMode() const override
+   {
+      return fBatchMode;
+   }
 
    virtual void AddDisplayItem(TDisplayItem *item) override
    {

--- a/gui/fitpanel/v7/src/TFitPanel.cxx
+++ b/gui/fitpanel/v7/src/TFitPanel.cxx
@@ -26,7 +26,7 @@
 std::shared_ptr<ROOT::Experimental::TWebWindow> ROOT::Experimental::TFitPanel::GetWindow()
 {
    if (!fWindow) {
-      fWindow = TWebWindowsManager::Instance()->CreateWindow(false);
+      fWindow = TWebWindowsManager::Instance()->CreateWindow(gROOT->IsBatch());
 
       fWindow->SetPanelName("FitPanel");
 

--- a/gui/webdisplay/Readme.md
+++ b/gui/webdisplay/Readme.md
@@ -1,29 +1,35 @@
-## Compilation with CEF support (https://bitbucket.org/chromiumembedded/cef)
+## [Compilation with CEF support](https://bitbucket.org/chromiumembedded/cef)
 
 1. Current code tested with CEF3 3163, should work with other releases
 
-2  Download binary code from http://opensource.spotify.com/cefbuilds/index.html and 
-   unpack it in directory without spaces and special symbols: 
+2. Download binary code from [http://opensource.spotify.com/cefbuilds/index.html](http://opensource.spotify.com/cefbuilds/index.html)
+   and unpack it in directory without spaces and special symbols:
 
-     [shell] mkdir /d/cef
-     [shell] cd /d/cef/
-     [shell] wget http://opensource.spotify.com/cefbuilds/cef_binary_3.3163.1671.g700dc25_linux64.tar.bz2
-     [shell] tar xjf cef_binary_3.3163.1671.g700dc25_linux64.tar.bz2
+~~~
+     $ mkdir /d/cef
+     $ cd /d/cef/
+     $ wget http://opensource.spotify.com/cefbuilds/cef_binary_3.3163.1671.g700dc25_linux64.tar.bz2
+     $ tar xjf cef_binary_3.3163.1671.g700dc25_linux64.tar.bz2
+~~~
 
 3. Set `CEF_PATH` shell variable to unpacked directory:
 
-     [shell] export CEF_PATH=/d/cef/cef_binary_3.3163.1671.g700dc25_linux64
+~~~
+     $ export CEF_PATH=/d/cef/cef_binary_3.3163.1671.g700dc25_linux64
+~~~
 
-4. Install prerequicities - see comments in $CEF_PATH/CMakeLists.txt.
+4. Install prerequisites - See comments in `$CEF_PATH/CMakeLists.txt`.
    For the linux it is `build-essential`, `libgtk2.0-dev`, `libgtkglext1-dev`
 
 5. Compile all tests (required for the libcef_dll_wrapper)
 
-     [shell] cd $CEF_PATH
-     [shell] mkdir build
-     [shell] cd build
-     [shell] cmake $CEF_PATH
-     [shell] make -j8
+~~~
+     $ cd $CEF_PATH
+     $ mkdir build
+     $ cd build
+     $ cmake $CEF_PATH
+     $ make -j8
+~~~
 
 6. Compile ROOT from the same shell (CEF_PATH variable should be set)
    Check that files icudtl.dat, natives_blob.bin, snapshot_blob.bin copied into ROOT binaries directory
@@ -31,28 +37,29 @@
 7. Run ROOT from the same shell (CEF_PATH and JSROOTSYS variables should be set)
 
 
-
 ## Using CEF in batch mode on Linux
 
 CEF under Linux uses X11 functionality and therefore requires configured display and running X11 server
-On the long run there is hope, that CEF introduces true headless mode - chromium itself 
+On the long run there is hope, that CEF introduces true headless mode - chromium itself
 [already supports it](https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md).
 
 There is simple workaround for this problem.
 One could use [Xvfb](https://en.wikipedia.org/wiki/Xvfb) as X11 server.
 It does not require any graphics adapter, screen or input device.
-CEF works with  Xvfb without problem. 
+CEF works with  Xvfb without problem.
 
 1. Start Xvfb
 
-    [shell] Xvfb :99 &
-    [shell] export DISPLAY=:99
+~~~
+     $ Xvfb :99 &
+     $ export DISPLAY=:99
+~~~
 
 2. Run macro in batch mode:
 
-    [shell] root -l -b draw_v6.cxx -q
-
-
+~~~
+     $ root -l -b draw_v6.cxx -q
+~~~
 
 ## Compilation with QT5 WebEngine support
 
@@ -67,10 +74,12 @@ Later one will provide possibility to embed ROOT panels (TCanvas, TBrowser, TFit
 
 3. Compile rootqt5 main program (standard Rint plus QApplication)
 
-     [shell] cd gui/canvaspainter/v7/qt5; qmake-qt5 rootqt5.pro; make
+~~~
+     $ cd gui/canvaspainter/v7/qt5; qmake-qt5 rootqt5.pro; make
+~~~
 
 4. Run ROOT macros, using rootqt5 executable:
 
-     [shell] rootqt5 -l hsimple.C
-
-     
+~~~
+     $ rootqt5 -l hsimple.C
+~~~

--- a/gui/webdisplay/Readme.md
+++ b/gui/webdisplay/Readme.md
@@ -1,24 +1,24 @@
-## Compilation with CEF support (https://bitbucket.org/chromiumembedded/cef)     
+## Compilation with CEF support (https://bitbucket.org/chromiumembedded/cef)
 
 1. Current code tested with CEF3 3163, should work with other releases
 
 2  Download binary code from http://opensource.spotify.com/cefbuilds/index.html and 
    unpack it in directory without spaces and special symbols: 
-  
+
      [shell] mkdir /d/cef
      [shell] cd /d/cef/
-     [shell] wget http://opensource.spotify.com/cefbuilds/cef_binary_3.3163.1671.g700dc25_linux64.tar.bz2 
+     [shell] wget http://opensource.spotify.com/cefbuilds/cef_binary_3.3163.1671.g700dc25_linux64.tar.bz2
      [shell] tar xjf cef_binary_3.3163.1671.g700dc25_linux64.tar.bz2
 
 3. Set `CEF_PATH` shell variable to unpacked directory:
-  
+
      [shell] export CEF_PATH=/d/cef/cef_binary_3.3163.1671.g700dc25_linux64
-     
-4. Install prerequicities - see comments in $CEF_PATH/CMakeLists.txt. 
+
+4. Install prerequicities - see comments in $CEF_PATH/CMakeLists.txt.
    For the linux it is `build-essential`, `libgtk2.0-dev`, `libgtkglext1-dev`
 
 5. Compile all tests (required for the libcef_dll_wrapper)
-     
+
      [shell] cd $CEF_PATH
      [shell] mkdir build
      [shell] cd build
@@ -49,7 +49,7 @@ CEF works with  Xvfb without problem.
     [shell] export DISPLAY=:99
 
 2. Run macro in batch mode:
-    
+
     [shell] root -l -b draw_v6.cxx -q
 
 
@@ -57,15 +57,17 @@ CEF works with  Xvfb without problem.
 ## Compilation with QT5 WebEngine support
 
 This is alternative implementation of local display, using chromium from Qt5.
-Idea to have easy possibility to embed ROOT panels (TCanvas, TBrowser) in Qt applications.  
+It should provide very similar functionality as CEF (beside batch mode).
+Biggest advantage - one gets Qt5 libraris for all platforms through normal package managers.
+Later one will provide possibility to embed ROOT panels (TCanvas, TBrowser, TFitPanel) directly in Qt applications.
 
 1. Install libqt5-qtwebengine and libqt5-qtwebengine-devel packages
 
 2. Compile ROOT and call thisroot.sh (ROOTSYS variable should be set)
 
 3. Compile rootqt5 main program (standard Rint plus QApplication)
-  
-     [shell] cd gui/canvaspainter/v7/qt5; qmake-qt5 rootqt5.pro; make     
+
+     [shell] cd gui/canvaspainter/v7/qt5; qmake-qt5 rootqt5.pro; make
 
 4. Run ROOT macros, using rootqt5 executable:
 

--- a/gui/webdisplay/Readme.md
+++ b/gui/webdisplay/Readme.md
@@ -64,9 +64,7 @@ CEF works with  Xvfb without problem.
 ## Compilation with QT5 WebEngine support
 
 This is alternative implementation of local display, using chromium from Qt5.
-It should provide very similar functionality as CEF (beside batch mode).
-Biggest advantage - one gets Qt5 libraris for all platforms through normal package managers.
-Later one will provide possibility to embed ROOT panels (TCanvas, TBrowser, TFitPanel) directly in Qt applications.
+Idea to have easy possibility to embed ROOT panels (TCanvas, TBrowser) in Qt applications.
 
 1. Install libqt5-qtwebengine and libqt5-qtwebengine-devel packages
 

--- a/gui/webdisplay/inc/ROOT/TWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindow.hxx
@@ -59,17 +59,18 @@ private:
 
    std::shared_ptr<TWebWindowsManager> fMgr{}; ///<!  display manager
    bool fBatchMode{false};                     ///<!  batch mode
-   std::string fDefaultPage{};                 ///<! HTML page (or file name) returned when window URL is opened
-   std::string fPanelName{};                   ///<! panel name which should be shown in the window
+   std::string fDefaultPage{};                 ///<!  HTML page (or file name) returned when window URL is opened
+   std::string fPanelName{};                   ///<!  panel name which should be shown in the window
    unsigned fId{0};                            ///<!  unique identifier
    TWebWindowWSHandler *fWSHandler{nullptr};   ///<!  specialize websocket handler for all incoming connections
+   bool fShown{false};                         ///<!  true when window was shown at least once
    unsigned fConnCnt{0};                       ///<!  counter of new connections to assign ids
-   std::list<WebConn> fConn{};                 ///<! list of all accepted connections
-   unsigned fConnLimit{0};                     ///<! number of allowed active connections
+   std::list<WebConn> fConn{};                 ///<!  list of all accepted connections
+   unsigned fConnLimit{0};                     ///<!  number of allowed active connections
    static const unsigned fMaxQueueLength{10};  ///<!  maximal number of queue entries
    WebWindowDataCallback_t fDataCallback{};    ///<!  main callback when data over channel 1 is arrived
-   unsigned fWidth{0};                         ///<! initial window width when displayed
-   unsigned fHeight{0};                        ///<! initial window height when displayed
+   unsigned fWidth{0};                         ///<!  initial window width when displayed
+   unsigned fHeight{0};                        ///<!  initial window height when displayed
 
    void SetBatchMode(bool mode) { fBatchMode = mode; }
    void SetId(unsigned id) { fId = id; }
@@ -88,6 +89,7 @@ public:
    ~TWebWindow();
 
    bool IsBatchMode() const { return fBatchMode; }
+   bool IsShown() const { return fShown; }
    unsigned GetId() const { return fId; }
 
    void SetDefaultPage(const std::string &page) { fDefaultPage = page; }

--- a/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
@@ -55,7 +55,7 @@ public:
 
    std::shared_ptr<TWebWindow> CreateWindow(bool batch_mode = false);
 
-   void CloseDisplay(TWebWindow *display);
+   void CloseWindow(TWebWindow *);
 
    bool Show(TWebWindow *display, const std::string &where);
 

--- a/gui/webdisplay/src/TWebWindow.cxx
+++ b/gui/webdisplay/src/TWebWindow.cxx
@@ -50,7 +50,7 @@ ROOT::Experimental::TWebWindow::~TWebWindow()
    fConn.clear();
 
    if (fMgr)
-      fMgr->CloseDisplay(this);
+      fMgr->CloseWindow(this);
 
    if (fWSHandler) {
       delete fWSHandler;
@@ -81,7 +81,9 @@ void ROOT::Experimental::TWebWindow::CreateWSHandler()
 
 bool ROOT::Experimental::TWebWindow::Show(const std::string &where)
 {
-   return fMgr->Show(this, where);
+   bool res = fMgr->Show(this, where);
+   if (res) fShown = true;
+   return res;
 }
 
 bool ROOT::Experimental::TWebWindow::ProcessWS(THttpCallArg *arg)

--- a/gui/webdisplay/src/TWebWindow.cxx
+++ b/gui/webdisplay/src/TWebWindow.cxx
@@ -147,7 +147,7 @@ bool ROOT::Experimental::TWebWindow::ProcessWS(THttpCallArg *arg)
    const char *buf = (const char *)arg->GetPostData();
    char *str_end = 0;
 
-   printf("Get portion of data %d %s\n", (int)arg->GetPostDataLength(), buf);
+   printf("Get portion of data %d %.30s\n", (int)arg->GetPostDataLength(), buf);
 
    unsigned long ackn_oper = std::strtoul(buf, &str_end, 10);
    assert(str_end != 0 && *str_end == ':' && "missing number of acknowledged operations");

--- a/gui/webdisplay/src/TWebWindow.cxx
+++ b/gui/webdisplay/src/TWebWindow.cxx
@@ -82,7 +82,8 @@ void ROOT::Experimental::TWebWindow::CreateWSHandler()
 bool ROOT::Experimental::TWebWindow::Show(const std::string &where)
 {
    bool res = fMgr->Show(this, where);
-   if (res) fShown = true;
+   if (res)
+      fShown = true;
    return res;
 }
 

--- a/gui/webdisplay/src/TWebWindowsManager.cxx
+++ b/gui/webdisplay/src/TWebWindowsManager.cxx
@@ -214,9 +214,9 @@ bool ROOT::Experimental::TWebWindowsManager::Show(ROOT::Experimental::TWebWindow
          exec.Append(TString::Format(" --window-size=%u,%u", display->GetWidth(), display->GetHeight()));
       if (batch_mode)
          exec.Append(" --headless");
-      exec.Append(" --app="); // use app mode
+      exec.Append(" --app=\'"); // use app mode
       exec.Append(addr.Data());
-      exec.Append(" &");
+      exec.Append("\' &");
    } else if (!is_native && !ic_cef && !is_qt5 && (where != "browser")) {
       if (where.find("$") != std::string::npos) {
          exec = where.c_str();

--- a/gui/webdisplay/src/TWebWindowsManager.cxx
+++ b/gui/webdisplay/src/TWebWindowsManager.cxx
@@ -167,9 +167,7 @@ bool ROOT::Experimental::TWebWindowsManager::Show(ROOT::Experimental::TWebWindow
          where = cwhere;
    }
 
-   bool is_native = where.empty() || (where == "native"),
-        is_qt5 = (where == "qt5"),
-        is_cef = (where == "cef"),
+   bool is_native = where.empty() || (where == "native"), is_qt5 = (where == "qt5"), is_cef = (where == "cef"),
         is_chrome = (where == "chrome") || (where == "chromium");
 
    if (batch_mode) {
@@ -180,7 +178,8 @@ bool ROOT::Experimental::TWebWindowsManager::Show(ROOT::Experimental::TWebWindow
       if (is_cef) {
          const char *displ = gSystem->Getenv("DISPLAY");
          if (!displ || (*displ == 0)) {
-            R__ERROR_HERE("Show") << "For a time been in batch mode DISPLAY variable should be set. See gui/webdisplay/Readme.md for more info";
+            R__ERROR_HERE("Show") << "For a time been in batch mode DISPLAY variable should be set. See "
+                                     "gui/webdisplay/Readme.md for more info";
             return false;
          }
       }

--- a/gui/webdisplay/src/TWebWindowsManager.cxx
+++ b/gui/webdisplay/src/TWebWindowsManager.cxx
@@ -115,7 +115,7 @@ std::shared_ptr<ROOT::Experimental::TWebWindow> ROOT::Experimental::TWebWindowsM
 
    fServer->Register("/web7gui", (THttpWSHandler *)win->fWSHandler);
 
-   return std::move(win);
+   return win;
 }
 
 void ROOT::Experimental::TWebWindowsManager::CloseWindow(ROOT::Experimental::TWebWindow *win)

--- a/gui/webdisplay/src/TWebWindowsManager.cxx
+++ b/gui/webdisplay/src/TWebWindowsManager.cxx
@@ -96,37 +96,37 @@ std::shared_ptr<ROOT::Experimental::TWebWindow> ROOT::Experimental::TWebWindowsM
       return nullptr;
    }
 
-   std::shared_ptr<ROOT::Experimental::TWebWindow> display = std::make_shared<ROOT::Experimental::TWebWindow>();
+   std::shared_ptr<ROOT::Experimental::TWebWindow> win = std::make_shared<ROOT::Experimental::TWebWindow>();
 
-   if (!display) {
-      printf("Window not created!!!\n");
+   if (!win) {
+      R__ERROR_HERE("CreateWindow") << "Fail to create TWebWindow instance";
       return nullptr;
    }
 
-   display->SetBatchMode(batch_mode);
+   win->SetBatchMode(batch_mode);
 
-   display->SetId(++fIdCnt); // set unique ID
+   win->SetId(++fIdCnt); // set unique ID
 
-   fDisplays.push_back(display);
+   fDisplays.push_back(win);
 
-   display->fMgr = Instance();
+   win->fMgr = Instance();
 
-   display->CreateWSHandler();
+   win->CreateWSHandler();
 
-   fServer->Register("/web7gui", (THttpWSHandler *)display->fWSHandler);
+   fServer->Register("/web7gui", (THttpWSHandler *)win->fWSHandler);
 
-   return display;
+   return std::move(win);
 }
 
-void ROOT::Experimental::TWebWindowsManager::CloseDisplay(ROOT::Experimental::TWebWindow *display)
+void ROOT::Experimental::TWebWindowsManager::CloseWindow(ROOT::Experimental::TWebWindow *win)
 {
    // TODO: close all active connections of the display
 
-   if (display->fWSHandler)
-      fServer->Unregister((THttpWSHandler *)display->fWSHandler);
+   if (win->fWSHandler)
+      fServer->Unregister((THttpWSHandler *)win->fWSHandler);
 
    for (auto displ = fDisplays.begin(); displ != fDisplays.end(); displ++) {
-      if (displ->get() == display) {
+      if (displ->get() == win) {
          fDisplays.erase(displ);
          break;
       }
@@ -147,16 +147,15 @@ void ROOT::Experimental::TWebWindowsManager::CloseDisplay(ROOT::Experimental::TW
 ///
 ///  If allowed, same window can be displayed several times (like for TCanvas)
 
-bool ROOT::Experimental::TWebWindowsManager::Show(ROOT::Experimental::TWebWindow *display, const std::string &_where)
+bool ROOT::Experimental::TWebWindowsManager::Show(ROOT::Experimental::TWebWindow *win, const std::string &_where)
 {
-
-   if (!CreateHttpServer()) {
-      assert("Fail to create server");
+   if (!fServer) {
+      R__ERROR_HERE("Show") << "Server instance not exists";
       return false;
    }
 
-   THttpWSHandler *handler = (THttpWSHandler *)display->fWSHandler;
-   bool batch_mode = display->IsBatchMode();
+   THttpWSHandler *handler = (THttpWSHandler *)win->fWSHandler;
+   bool batch_mode = win->IsBatchMode();
 
    TString addr;
    addr.Form("/web7gui/%s/%s", handler->GetName(), (batch_mode ? "?batch_mode" : ""));
@@ -168,7 +167,22 @@ bool ROOT::Experimental::TWebWindowsManager::Show(ROOT::Experimental::TWebWindow
          where = cwhere;
    }
 
-   bool is_native = where.empty() || (where == "native"), is_qt5 = (where == "qt5"), ic_cef = (where == "cef");
+   bool is_native = where.empty() || (where == "native"),
+        is_qt5 = (where == "qt5"),
+        ic_cef = (where == "cef"),
+        is_chrome = (where == "chrome") || (where == "chromium");
+
+   if (batch_mode) {
+      const char *displ = gSystem->Getenv("DISPLAY");
+      if (!displ || (*displ == 0)) {
+         R__ERROR_HERE("Show") << "For a time been in batch mode DISPLAY variable should be set. See gui/webdisplay/Readme.md for more info";
+         return false;
+      }
+      if (!ic_cef && !is_chrome) {
+         R__ERROR_HERE("Show") << "To use batch mode 'cef' or 'chromium' should be configured as output";
+         return false;
+      }
+   }
 
    Func_t symbol_qt5 = gSystem->DynFindSymbol("*", "webgui_start_browser_in_qt5");
 
@@ -178,7 +192,7 @@ bool ROOT::Experimental::TWebWindowsManager::Show(ROOT::Experimental::TWebWindow
       printf("Show canvas in Qt5 window:  %s\n", addr.Data());
 
       FunctionQt5 func = (FunctionQt5)symbol_qt5;
-      func(addr.Data(), fServer, batch_mode, display->GetWidth(), display->GetHeight());
+      func(addr.Data(), fServer, batch_mode, win->GetWidth(), win->GetHeight());
       return false;
    }
 
@@ -193,13 +207,13 @@ bool ROOT::Experimental::TWebWindowsManager::Show(ROOT::Experimental::TWebWindow
       printf("Show canvas in CEF window:  %s\n", addr.Data());
 
       FunctionCef3 func = (FunctionCef3)symbol_cef;
-      func(addr.Data(), fServer, batch_mode, rootsys, cef_path, display->GetWidth(), display->GetHeight());
+      func(addr.Data(), fServer, batch_mode, rootsys, cef_path, win->GetWidth(), win->GetHeight());
 
       return true;
    }
 
    if (!CreateHttpServer(true)) {
-      Error("NewDisplay", "Fail to start HTTP server");
+      R__ERROR_HERE("Show") << "Fail to start real HTTP server";
       return false;
    }
 
@@ -207,11 +221,11 @@ bool ROOT::Experimental::TWebWindowsManager::Show(ROOT::Experimental::TWebWindow
 
    TString exec;
 
-   if ((where == "chrome") || (where == "chromium")) {
+   if (is_chrome) {
       // see https://peter.sh/experiments/chromium-command-line-switches/
       exec = where.c_str();
-      if (display->GetWidth() && display->GetHeight())
-         exec.Append(TString::Format(" --window-size=%u,%u", display->GetWidth(), display->GetHeight()));
+      if (win->GetWidth() && win->GetHeight())
+         exec.Append(TString::Format(" --window-size=%u,%u", win->GetWidth(), win->GetHeight()));
       if (batch_mode)
          exec.Append(" --headless");
       exec.Append(" --app=\'"); // use app mode
@@ -221,16 +235,16 @@ bool ROOT::Experimental::TWebWindowsManager::Show(ROOT::Experimental::TWebWindow
       if (where.find("$") != std::string::npos) {
          exec = where.c_str();
          exec.ReplaceAll("$url", addr);
-         exec.ReplaceAll("$w", std::to_string(display->GetWidth() ? display->GetWidth() : 800).c_str());
-         exec.ReplaceAll("$h", std::to_string(display->GetHeight() ? display->GetHeight() : 600).c_str());
+         exec.ReplaceAll("$w", std::to_string(win->GetWidth() ? win->GetWidth() : 800).c_str());
+         exec.ReplaceAll("$h", std::to_string(win->GetHeight() ? win->GetHeight() : 600).c_str());
       } else {
          exec.Form("%s %s &", where.c_str(), addr.Data());
          // if (batch_mode) exec.Append(" --headless");
       }
    } else if (gSystem->InheritsFrom("TMacOSXSystem")) {
-      exec.Form("open %s", addr.Data());
+      exec.Form("open \'%s\'", addr.Data());
    } else {
-      exec.Form("xdg-open %s &", addr.Data());
+      exec.Form("xdg-open \'%s\' &", addr.Data());
    }
 
    printf("Show canvas in browser with cmd:  %s\n", exec.Data());


### PR DESCRIPTION
Now macros, running in batch mode and using v7 TCanvas, will do nothing.
Only if one explicitly specifies, that canvas should be shown in **cef** or **chromium**, 
batch-mode components will be started. For the cef still X11 functionality required, 
chromium is able to run in "pure" batch, but has problem with shutdown afterwards.

Also resolve compiler warnings, reported by @pcanal 
