### PR TITLE
TMVA: moved TThreadExecutor fPool object to the class TMVA::Config

### DIFF
--- a/tmva/tmva/inc/TMVA/Config.h
+++ b/tmva/tmva/inc/TMVA/Config.h
@@ -41,13 +41,16 @@
 #endif
 #include "Rtypes.h"
 #include "TString.h"
+#include <ROOT/TThreadExecutor.hxx>
 
 namespace TMVA {
 
    class MsgLogger;
 
    class Config {
-               
+   protected:
+      ROOT::TThreadExecutor fPool;
+
    public:
 
       static Config& Instance();
@@ -64,6 +67,8 @@ namespace TMVA {
 
       Bool_t DrawProgressBar() const { return fDrawProgressBar; }
       void   SetDrawProgressBar( Bool_t d ) { fDrawProgressBar = d; }
+
+      ROOT::TThreadExecutor &GetThreadExecutor() { return fPool; }
 
    public:
 

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu/CpuMatrix.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu/CpuMatrix.h
@@ -21,8 +21,8 @@
 #include <vector>
 
 #include "TMatrix.h"
-#include "ROOT/TThreadExecutor.hxx"
 #include "CpuBuffer.h"
+#include <TMVA/Config.h>
 
 namespace TMVA
 {
@@ -47,7 +47,6 @@ class TCpuMatrix
 {
 private:
 
-   static ROOT::TThreadExecutor fPool;
    static std::vector<AFloat> fOnes;  ///< Vector filled with ones used for BLAS calls.
 
    TCpuBuffer<AFloat> fBuffer; ///< The buffer holding the matrix elements
@@ -103,16 +102,13 @@ public:
    AFloat *       GetRawDataPointer()        {return fBuffer;}
    const AFloat * GetRawDataPointer()  const {return fBuffer;}
 
-   ROOT::TThreadExecutor & GetThreadExecutor() const {return fPool;}
+   ROOT::TThreadExecutor &GetThreadExecutor() const { return Config::Instance().GetThreadExecutor(); }
 
 private:
 
    void Initialize();
 
 };
-
-template<typename AFloat>
-ROOT::TThreadExecutor TCpuMatrix<AFloat>::fPool {};
 
 template<typename AFloat>
 std::vector<AFloat> TCpuMatrix<AFloat>::fOnes {};
@@ -132,7 +128,7 @@ inline void TCpuMatrix<AFloat>::Map(Function_t &f)
       return 0;
    };
 
-   fPool.Map(ff, ROOT::TSeqI(fNCols * fNRows));
+   GetThreadExecutor().Map(ff, ROOT::TSeqI(fNCols * fNRows));
 }
 
 template<typename AFloat>
@@ -148,7 +144,7 @@ inline void TCpuMatrix<AFloat>::MapFrom(Function_t &f, const TCpuMatrix &A)
       return 0;
    };
 
-   fPool.Map(ff, ROOT::TSeqI(fNCols * fNRows));
+   GetThreadExecutor().Map(ff, ROOT::TSeqI(fNCols * fNRows));
 }
 
 } // namespace DNN


### PR DESCRIPTION
 Moved the TThreadExecutor object to TMVA::Config.

O.