### PR TITLE
Set CMake policy CMP0068 to NEW for LLVM

### DIFF
--- a/interpreter/llvm/src/CMakeLists.txt
+++ b/interpreter/llvm/src/CMakeLists.txt
@@ -19,6 +19,10 @@ if(POLICY CMP0057)
   cmake_policy(SET CMP0057 NEW)
 endif()
 
+if(POLICY CMP0068)
+  cmake_policy(SET CMP0068 NEW)
+endif()
+
 if(NOT DEFINED LLVM_VERSION_MAJOR)
   set(LLVM_VERSION_MAJOR 5)
 endif()


### PR DESCRIPTION
This change is to avoid warnings from CMake 3.9.3 and newer on macOS.
See `cmake --help-policy CMP0068` for more information. Fixes [ROOT-9031](https://sft.its.cern.ch/jira/browse/ROOT-9031).