### PR TITLE
[cxxmodules] Refactor generation counter in LLVM

### DIFF
--- a/interpreter/llvm/src/tools/clang/include/clang/AST/ASTContext.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/AST/ASTContext.h
@@ -183,6 +183,10 @@ class ASTContext : public RefCountedBase<ASTContext> {
                                      ASTContext&>
     SubstTemplateTemplateParmPacks;
 
+  /// Generation number for this external AST source. Must be increased
+  /// whenever we might have added new redeclarations for existing decls.
+  uint32_t CurrentGeneration = 0;
+
   /// \brief The set of nested name specifiers.
   ///
   /// This set is managed by the NestedNameSpecifier class.
@@ -604,6 +608,15 @@ public:
   }
 
   DynTypedNodeList getParents(const ast_type_traits::DynTypedNode &Node);
+
+  uint32_t getGeneration() const { return CurrentGeneration; }
+  uint32_t incrementGeneration() {
+    uint32_t OldGeneration = CurrentGeneration;
+    CurrentGeneration++;
+    assert(CurrentGeneration > OldGeneration &&
+           "Overflowed generation counter");
+    return OldGeneration;
+  }
 
   const clang::PrintingPolicy &getPrintingPolicy() const {
     return PrintingPolicy;
@@ -2827,7 +2840,7 @@ typename clang::LazyGenerationalUpdatePtr<Owner, T, Update>::ValueType
   // include ASTContext.h. We explicitly instantiate it for all relevant types
   // in ASTContext.cpp.
   if (auto *Source = Ctx.getExternalSource())
-    return new (Ctx) LazyData(Source, Value);
+    return new (Ctx) LazyData(&Ctx, Source, Value);
   return Value;
 }
 

--- a/interpreter/llvm/src/tools/clang/include/clang/Serialization/ASTReader.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/Serialization/ASTReader.h
@@ -1210,6 +1210,12 @@ private:
       : Mod(Mod), ImportedBy(ImportedBy), ImportLoc(ImportLoc) { }
   };
 
+  uint32_t getGenerationOrNull() const {
+    if (ContextObj)
+      return getGeneration(*ContextObj);
+    return 0u;
+  }
+
   ASTReadResult ReadASTCore(StringRef FileName, ModuleKind Type,
                             SourceLocation ImportLoc, ModuleFile *ImportedBy,
                             SmallVectorImpl<ImportedModule> &Loaded,

--- a/interpreter/llvm/src/tools/clang/lib/AST/ExternalASTSource.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/AST/ExternalASTSource.cpp
@@ -23,6 +23,10 @@ using namespace clang;
 
 ExternalASTSource::~ExternalASTSource() { }
 
+uint32_t ExternalASTSource::getGeneration(const ASTContext &C) const {
+  return C.getGeneration();
+}
+
 llvm::Optional<ExternalASTSource::ASTSourceDescriptor>
 ExternalASTSource::getSourceDescriptor(unsigned ID) {
   return None;
@@ -117,19 +121,5 @@ void ExternalASTSource::FindExternalLexicalDecls(
 void ExternalASTSource::getMemoryBufferSizes(MemoryBufferSizes &sizes) const {}
 
 uint32_t ExternalASTSource::incrementGeneration(ASTContext &C) {
-  uint32_t OldGeneration = CurrentGeneration;
-
-  // Make sure the generation of the topmost external source for the context is
-  // incremented. That might not be us.
-  auto *P = C.getExternalSource();
-  if (P && P != this)
-    CurrentGeneration = P->incrementGeneration(C);
-  else {
-    // FIXME: Only bump the generation counter if the current generation number
-    // has been observed?
-    if (!++CurrentGeneration)
-      llvm::report_fatal_error("generation counter overflowed", false);
-  }
-
-  return OldGeneration;
+  return C.incrementGeneration();
 }

--- a/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReader.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReader.cpp
@@ -1902,7 +1902,7 @@ void ASTReader::markIdentifierUpToDate(IdentifierInfo *II) {
 
   // Update the generation for this identifier.
   if (getContext().getLangOpts().Modules)
-    IdentifierGeneration[II] = getGeneration();
+    IdentifierGeneration[II] = getGenerationOrNull();
 }
 
 void ASTReader::resolvePendingMacro(IdentifierInfo *II,
@@ -4037,11 +4037,10 @@ ASTReader::ReadASTCore(StringRef FileName,
                        unsigned ClientLoadCapabilities) {
   ModuleFile *M;
   std::string ErrorStr;
-  ModuleManager::AddModuleResult AddResult
-    = ModuleMgr.addModule(FileName, Type, ImportLoc, ImportedBy,
-                          getGeneration(), ExpectedSize, ExpectedModTime,
-                          ExpectedSignature, readASTFileSignature,
-                          M, ErrorStr);
+  ModuleManager::AddModuleResult AddResult =
+      ModuleMgr.addModule(FileName, Type, ImportLoc, ImportedBy,
+                          getGenerationOrNull(), ExpectedSize, ExpectedModTime,
+                          ExpectedSignature, readASTFileSignature, M, ErrorStr);
 
   switch (AddResult) {
   case ModuleManager::AlreadyLoaded:
@@ -7836,7 +7835,7 @@ void ASTReader::ReadMethodPool(Selector Sel) {
   // Get the selector generation and update it to the current generation.
   unsigned &Generation = SelectorGeneration[Sel];
   unsigned PriorGeneration = Generation;
-  Generation = getGeneration();
+  Generation = getGenerationOrNull();
   SelectorOutOfDate[Sel] = false;
 
   // Search for methods defined with this selector.


### PR DESCRIPTION
Right now the ExternalASTSources in LLVM have an awkward way
of implementing their generation counters, which provide an
incrementing UID for versioning the AST when it is changed
lazily by the ExternalASTSource (for example when more decls
are).

The current implementation is based on having an counter in
each ExternalASTSource, but each ExternalASTSource actually
only refers to the top most ExternalASTSource of the current
ASTContext, which means that the counter suddenly resets
when we add any kind of new ExternalASTSource (and we have
no way to work around this). Also, some ExternalASTSources
like the ASTReader make assumptions that they are the top
most ExternalASTSource which means that as soon as we
overwrite the ASTReader, we suddenly have two counters
running providing conflicting information to anyone
querying the counters.

This patch merges all these counters into one counter
which is in the ASTContext. This should get rid of
any more counter desyncronization problems when we
attach our own external sources or when parts of the
code make invalid assumptions about which external
source is currently the top most one in the ASTContext.

Patch is upstreamed via LLVM phabricator review D39714.