### PR TITLE
webgui: cleaner ownership and more documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ CMakeLists.txt.user
 
 # Eclipse
 .settings/*
+.cproject
 
 # Vim
 *.swp

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -626,6 +626,8 @@ void ROOT::Experimental::TCanvasPainter::NewDisplay(const std::string &where)
    if (!fWindow) {
       fWindow = TWebWindowsManager::Instance()->CreateWindow(IsBatchMode());
 
+      fWindow->SetConnLimit(0); // allow any number of connections
+
       fWindow->SetDefaultPage("file:$jsrootsys/files/canvas.htm");
 
       fWindow->SetDataCallBack([this](unsigned connid, const std::string &arg) { ProcessData(connid, arg); });

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -125,24 +125,28 @@ std::string base64_decode(std::string const &encoded_string)
       char_array_4[i++] = encoded_string[in_];
       in_++;
       if (i == 4) {
-         for (i = 0; i < 4; i++) char_array_4[i] = base64_chars.find(char_array_4[i]);
+         for (i = 0; i < 4; i++)
+            char_array_4[i] = base64_chars.find(char_array_4[i]);
 
          char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
          char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
          char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
 
-         for (i = 0; (i < 3); i++) ret += char_array_3[i];
+         for (i = 0; (i < 3); i++)
+            ret += char_array_3[i];
          i = 0;
       }
    }
 
    if (i) {
-      for (j = 0; j < i; j++) char_array_4[j] = base64_chars.find(char_array_4[j]);
+      for (j = 0; j < i; j++)
+         char_array_4[j] = base64_chars.find(char_array_4[j]);
 
       char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
       char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
 
-      for (j = 0; (j < i - 1); j++) ret += char_array_3[j];
+      for (j = 0; (j < i - 1); j++)
+         ret += char_array_3[j];
    }
 
    return ret;
@@ -154,35 +158,33 @@ std::string base64_decode(std::string const &encoded_string)
 
 // new implementation of canvas painter, using TWebWindow
 
-
 namespace ROOT {
 namespace Experimental {
 
-class TCanvasPainter : public Internal::TVirtualCanvasPainter  {
+class TCanvasPainter : public Internal::TVirtualCanvasPainter {
 private:
-
    struct WebConn {
-      unsigned fConnId{0};        ///<! connection id
-      bool fDrawReady{false};     ///!< when first drawing is performed
-      std::string fGetMenu{};     ///<! object id for menu request
-      uint64_t fSend{0};          ///<! indicates version send to connection
-      uint64_t fDelivered{0};     ///<! indicates version confirmed from canvas
+      unsigned fConnId{0};    ///<! connection id
+      bool fDrawReady{false}; ///!< when first drawing is performed
+      std::string fGetMenu{}; ///<! object id for menu request
+      uint64_t fSend{0};      ///<! indicates version send to connection
+      uint64_t fDelivered{0}; ///<! indicates version confirmed from canvas
       WebConn() = default;
    };
 
    struct WebCommand {
-      std::string       fId{};            ///<! command identifier
-      std::string       fName{};          ///<! command name
-      std::string       fArg{};           ///<! command arg
-      bool              fRunning{false};  ///<! true when command submitted
-      CanvasCallback_t  fCallback{};      ///<! callback function associated with command
-      unsigned          fConnId{0};       ///<! connection id was used to send command
+      std::string fId{};            ///<! command identifier
+      std::string fName{};          ///<! command name
+      std::string fArg{};           ///<! command arg
+      bool fRunning{false};         ///<! true when command submitted
+      CanvasCallback_t fCallback{}; ///<! callback function associated with command
+      unsigned fConnId{0};          ///<! connection id was used to send command
       WebCommand() = default;
    };
 
    struct WebUpdate {
-      uint64_t            fVersion{0};   ///<! canvas version
-      CanvasCallback_t    fCallback{};   ///<! callback function associated with command
+      uint64_t fVersion{0};         ///<! canvas version
+      CanvasCallback_t fCallback{}; ///<! callback function associated with command
       WebUpdate() = default;
    };
 
@@ -195,23 +197,23 @@ private:
    typedef std::vector<ROOT::Experimental::Detail::TMenuItem> MenuItemsVector;
 
    /// The canvas we are painting. It might go out of existence while painting.
-   const TCanvas &fCanvas;           ///<!  Canvas
+   const TCanvas &fCanvas; ///<!  Canvas
 
-   bool fBatchMode;                  ///<! indicate if canvas works in batch mode (can be independent from gROOT->isBatch())
+   bool fBatchMode; ///<! indicate if canvas works in batch mode (can be independent from gROOT->isBatch())
 
-   std::shared_ptr<TWebWindow>  fWindow; ///!< configured display
+   std::shared_ptr<TWebWindow> fWindow; ///!< configured display
 
-   WebConnList fWebConn;            ///<! connections list
-   bool fHadWebConn;                ///<! true if any connection were existing
-   TPadDisplayItem fDisplayList;    ///!< full list of items to display
-   WebCommandsList fCmds;           ///!< list of submitted commands
-   uint64_t fCmdsCnt;               ///!< commands counter
-   std::string fWaitingCmdId;       ///!< command id waited for completion
+   WebConnList fWebConn;         ///<! connections list
+   bool fHadWebConn;             ///<! true if any connection were existing
+   TPadDisplayItem fDisplayList; ///!< full list of items to display
+   WebCommandsList fCmds;        ///!< list of submitted commands
+   uint64_t fCmdsCnt;            ///!< commands counter
+   std::string fWaitingCmdId;    ///!< command id waited for completion
 
-   uint64_t fSnapshotVersion;      ///!< version of snapshot
-   std::string fSnapshot;          ///!< last produced snapshot
-   uint64_t fSnapshotDelivered;    ///!< minimal version delivered to all connections
-   WebUpdatesList fUpdatesLst;     ///!< list of callbacks for canvas update
+   uint64_t fSnapshotVersion;   ///!< version of snapshot
+   std::string fSnapshot;       ///!< last produced snapshot
+   uint64_t fSnapshotDelivered; ///!< minimal version delivered to all connections
+   WebUpdatesList fUpdatesLst;  ///!< list of callbacks for canvas update
 
    /// Disable copy construction.
    TCanvasPainter(const TCanvasPainter &) = delete;
@@ -229,8 +231,7 @@ private:
 
    std::string CreateSnapshot(const ROOT::Experimental::TCanvas &can);
 
-   ROOT::Experimental::TDrawable *FindDrawable(const ROOT::Experimental::TCanvas &can,
-                                                const std::string &id);
+   ROOT::Experimental::TDrawable *FindDrawable(const ROOT::Experimental::TCanvas &can, const std::string &id);
 
    void SaveCreatedFile(std::string &reply);
 
@@ -243,35 +244,27 @@ private:
    int CheckWaitingCmd(const std::string &cmdname, double);
 
 public:
-
-   TCanvasPainter(const TCanvas &canv, bool batch_mode) :
-      fCanvas(canv), fBatchMode(batch_mode), fWindow(),
-      fWebConn(), fHadWebConn(false), fDisplayList(), fCmds(), fCmdsCnt(0), fWaitingCmdId(),
-      fSnapshotVersion(0), fSnapshot(), fSnapshotDelivered(0), fUpdatesLst() {}
+   TCanvasPainter(const TCanvas &canv, bool batch_mode)
+      : fCanvas(canv), fBatchMode(batch_mode), fWindow(), fWebConn(), fHadWebConn(false), fDisplayList(), fCmds(),
+        fCmdsCnt(0), fWaitingCmdId(), fSnapshotVersion(0), fSnapshot(), fSnapshotDelivered(0), fUpdatesLst()
+   {
+   }
 
    virtual ~TCanvasPainter();
 
    /// returns true is canvas used in batch mode
-   virtual bool IsBatchMode() const override
-   {
-      return fBatchMode;
-   }
+   virtual bool IsBatchMode() const override { return fBatchMode; }
 
-   virtual void AddDisplayItem(TDisplayItem *item) override
-   {
-      fDisplayList.Add(item);
-   }
+   virtual void AddDisplayItem(TDisplayItem *item) override { fDisplayList.Add(item); }
 
    virtual void CanvasUpdated(uint64_t ver, bool async, ROOT::Experimental::CanvasCallback_t callback) override;
 
    /// return true if canvas modified since last painting
-   virtual bool IsCanvasModified(uint64_t id) const override
-   {
-      return fSnapshotDelivered != id;
-   }
+   virtual bool IsCanvasModified(uint64_t id) const override { return fSnapshotDelivered != id; }
 
    /// perform special action when drawing is ready
-   virtual void DoWhenReady(const std::string &name, const std::string &arg, bool async, CanvasCallback_t callback) override;
+   virtual void
+   DoWhenReady(const std::string &name, const std::string &arg, bool async, CanvasCallback_t callback) override;
 
    virtual void NewDisplay(const std::string &where) override;
 
@@ -282,35 +275,34 @@ public:
         */
 
    class GeneratorImpl : public Generator {
-      public:
-         /// Create a new TCanvasPainter to paint the given TCanvas.
-         std::unique_ptr<TVirtualCanvasPainter> Create(const ROOT::Experimental::TCanvas &canv, bool batch_mode) const override
-         {
-            return std::make_unique<TCanvasPainter>(canv, batch_mode);
+   public:
+      /// Create a new TCanvasPainter to paint the given TCanvas.
+      std::unique_ptr<TVirtualCanvasPainter>
+      Create(const ROOT::Experimental::TCanvas &canv, bool batch_mode) const override
+      {
+         return std::make_unique<TCanvasPainter>(canv, batch_mode);
+      }
+      ~GeneratorImpl() = default;
+
+      /// Set TVirtualCanvasPainter::fgGenerator to a new GeneratorImpl object.
+      static void SetGlobalPainter()
+      {
+         if (GetGenerator()) {
+            R__ERROR_HERE("NewPainter") << "Generator is already set! Skipping second initialization.";
+            return;
          }
-         ~GeneratorImpl() = default;
+         GetGenerator().reset(new GeneratorImpl());
+      }
 
-         /// Set TVirtualCanvasPainter::fgGenerator to a new GeneratorImpl object.
-         static void SetGlobalPainter()
-         {
-            if (GetGenerator()) {
-               R__ERROR_HERE("NewPainter") << "Generator is already set! Skipping second initialization.";
-               return;
-            }
-            GetGenerator().reset(new GeneratorImpl());
-         }
-
-         /// Release the GeneratorImpl object.
-         static void ResetGlobalPainter() { GetGenerator().reset(); }
-      };
-
+      /// Release the GeneratorImpl object.
+      static void ResetGlobalPainter() { GetGenerator().reset(); }
+   };
 };
 
 struct TNewCanvasPainterReg {
    TNewCanvasPainterReg() { TCanvasPainter::GeneratorImpl::SetGlobalPainter(); }
    ~TNewCanvasPainterReg() { TCanvasPainter::GeneratorImpl::ResetGlobalPainter(); }
 } newCanvasPainterReg;
-
 
 } // namespace Experimental
 } // namespace ROOT
@@ -319,15 +311,18 @@ ROOT::Experimental::TCanvasPainter::~TCanvasPainter()
 {
    CancelCommands();
    CancelUpdates();
-   if (fWindow) fWindow->CloseConnections();
+   if (fWindow)
+      fWindow->CloseConnections();
 }
 
 /// Checks if specified version was delivered to all clients
 /// Used to wait for such condition
 int ROOT::Experimental::TCanvasPainter::CheckDeliveredVersion(uint64_t ver, double)
 {
-   if ((fWebConn.size() == 0) && fHadWebConn) return -1;
-   if (fSnapshotDelivered >= ver) return 1;
+   if ((fWebConn.size() == 0) && fHadWebConn)
+      return -1;
+   if (fSnapshotDelivered >= ver)
+      return 1;
    return 0;
 }
 
@@ -371,7 +366,8 @@ void ROOT::Experimental::TCanvasPainter::CheckDataToSend()
          min_delivered = conn.fDelivered;
 
       // check if direct data sending is possible
-      if (!fWindow->CanSend(conn.fConnId, true)) continue;
+      if (!fWindow->CanSend(conn.fConnId, true))
+         continue;
 
       TString buf;
 
@@ -438,7 +434,8 @@ void ROOT::Experimental::TCanvasPainter::CheckDataToSend()
    }
 }
 
-void ROOT::Experimental::TCanvasPainter::CanvasUpdated(uint64_t ver, bool async, ROOT::Experimental::CanvasCallback_t callback)
+void ROOT::Experimental::TCanvasPainter::CanvasUpdated(uint64_t ver, bool async,
+                                                       ROOT::Experimental::CanvasCallback_t callback)
 {
    if (ver && fSnapshotDelivered && (ver <= fSnapshotDelivered)) {
       // if given canvas version was already delivered to clients, can return immediately
@@ -475,7 +472,8 @@ void ROOT::Experimental::TCanvasPainter::CanvasUpdated(uint64_t ver, bool async,
 
 int ROOT::Experimental::TCanvasPainter::CheckWaitingCmd(const std::string &cmdname, double)
 {
-   if ((fWebConn.size() == 0) && fHadWebConn) return -1;
+   if ((fWebConn.size() == 0) && fHadWebConn)
+      return -1;
    if (fWaitingCmdId.empty()) {
       printf("Command %s waiting READY!!!\n", cmdname.c_str());
       return 1;
@@ -484,7 +482,8 @@ int ROOT::Experimental::TCanvasPainter::CheckWaitingCmd(const std::string &cmdna
 }
 
 /// perform special action when drawing is ready
-void ROOT::Experimental::TCanvasPainter::DoWhenReady(const std::string &name, const std::string &arg, bool async, CanvasCallback_t callback)
+void ROOT::Experimental::TCanvasPainter::DoWhenReady(const std::string &name, const std::string &arg, bool async,
+                                                     CanvasCallback_t callback)
 {
    if (!async && !fWaitingCmdId.empty()) {
       R__ERROR_HERE("DoWhenReady") << "Fail to submit sync command when previous is still awaited - use async";
@@ -534,7 +533,7 @@ void ROOT::Experimental::TCanvasPainter::ProcessData(unsigned connid, const std:
 
    WebConn *conn(0);
    auto iter = fWebConn.begin();
-   while (iter!=fWebConn.end()) {
+   while (iter != fWebConn.end()) {
       if (iter->fConnId == connid) {
          conn = &(*iter);
          break;
@@ -542,7 +541,8 @@ void ROOT::Experimental::TCanvasPainter::ProcessData(unsigned connid, const std:
       ++iter;
    }
 
-   if (!conn) return; // no connection found
+   if (!conn)
+      return; // no connection found
 
    printf("Get data %u %.30s\n", connid, arg.c_str());
 
@@ -596,7 +596,7 @@ void ROOT::Experimental::TCanvasPainter::ProcessData(unsigned connid, const std:
       }
    } else if (arg.find("SAVE:") == 0) {
       std::string cdata = arg;
-      cdata.erase(0,5);
+      cdata.erase(0, 5);
       SaveCreatedFile(cdata);
    } else if (arg.find("OBJEXEC:") == 0) {
       std::string cdata = arg;
@@ -637,7 +637,6 @@ void ROOT::Experimental::TCanvasPainter::NewDisplay(const std::string &where)
 
    fWindow->Show(where);
 }
-
 
 /// append window and panel inside canvas window
 
@@ -701,23 +700,24 @@ std::string ROOT::Experimental::TCanvasPainter::CreateSnapshot(const ROOT::Exper
 
    TString res = TBufferJSON::ConvertToJSON(&fDisplayList, gROOT->GetClass("ROOT::Experimental::TPadDisplayItem"));
 
-//   TBufferJSON::ExportToFile("canv.json", &fDisplayList, gROOT->GetClass("ROOT::Experimental::TPadDisplayItem"));
+   //   TBufferJSON::ExportToFile("canv.json", &fDisplayList, gROOT->GetClass("ROOT::Experimental::TPadDisplayItem"));
 
    fDisplayList.Clear();
 
-//   std::ofstream ofs("snap.json");
-//   ofs << res.Data() << std::endl;
+   //   std::ofstream ofs("snap.json");
+   //   ofs << res.Data() << std::endl;
 
    return std::string(res.Data());
 }
 
-ROOT::Experimental::TDrawable *ROOT::Experimental::TCanvasPainter::FindDrawable(const ROOT::Experimental::TCanvas &can,
-                                             const std::string &id)
+ROOT::Experimental::TDrawable *
+ROOT::Experimental::TCanvasPainter::FindDrawable(const ROOT::Experimental::TCanvas &can, const std::string &id)
 {
    std::string search = id;
    size_t pos = search.find("#");
    // exclude extra specifier, later can be used for menu and commands execution
-   if (pos != std::string::npos) search.resize(pos);
+   if (pos != std::string::npos)
+      search.resize(pos);
 
    for (auto &&drawable : can.GetPrimitives()) {
 
@@ -733,13 +733,13 @@ ROOT::Experimental::TDrawable *ROOT::Experimental::TCanvasPainter::FindDrawable(
 void ROOT::Experimental::TCanvasPainter::SaveCreatedFile(std::string &reply)
 {
    size_t pos = reply.find(":");
-   if ((pos == std::string::npos) || (pos==0)) {
+   if ((pos == std::string::npos) || (pos == 0)) {
       R__ERROR_HERE("SaveCreatedFile") << "Not found : separator";
       return;
    }
 
    std::string fname(reply, 0, pos);
-   reply.erase(0, pos+1);
+   reply.erase(0, pos + 1);
 
    std::string binary = base64_decode(reply);
    std::ofstream ofs(fname);

--- a/gui/fitpanel/v7/inc/ROOT/TFitPanel.hxx
+++ b/gui/fitpanel/v7/inc/ROOT/TFitPanel.hxx
@@ -52,17 +52,16 @@ struct TFitPanelModel {
    TFitPanelModel() = default;
 };
 
+class TFitPanel {
 
-class TFitPanel  {
+   std::string fTitle;  ///<! title
+   unsigned fConnId{0}; ///<! connection id
 
-   std::string     fTitle;                ///<! title
-   unsigned       fConnId{0};             ///<! connection id
+   std::shared_ptr<TWebWindow> fWindow; ///!< configured display
 
-   std::shared_ptr<TWebWindow> fWindow;   ///!< configured display
+   std::shared_ptr<TCanvas> fCanvas; ///!< canvas used to display results
 
-   std::shared_ptr<TCanvas> fCanvas;      ///!< canvas used to display results
-
-   std::shared_ptr<TH1D>  fFitHist;       ///!< histogram created when fit is performed
+   std::shared_ptr<TH1D> fFitHist; ///!< histogram created when fit is performed
 
    /// Disable copy construction.
    TFitPanel(const TFitPanel &) = delete;
@@ -74,7 +73,6 @@ class TFitPanel  {
    void ProcessData(unsigned connid, const std::string &arg);
 
 public:
-
    /// normal constructor
    TFitPanel(const std::string &title = "Fit panel") : fTitle(title) {}
 
@@ -95,7 +93,6 @@ public:
 
    /// Dummy function, called when "Fit" button pressed in UI
    void DoFit(const std::string &dname, const std::string &mname);
-
 };
 
 } // namespace Experimental

--- a/gui/fitpanel/v7/inc/ROOT/TFitPanel.hxx
+++ b/gui/fitpanel/v7/inc/ROOT/TFitPanel.hxx
@@ -27,32 +27,42 @@
 namespace ROOT {
 namespace Experimental {
 
+/** struct ROOT::Experimental::ComboBoxItem
+ * \ingroup webdisplay
+ * Descriptor for the openui5 ComboBox, used in FitPanel
+ */
+
 struct ComboBoxItem {
-   std::string fId{};
-   std::string fName{};
+   std::string fId;
+   std::string fName;
    ComboBoxItem() = default;
    ComboBoxItem(const std::string &id, const std::string &name) : fId(id), fName(name) {}
 };
 
+/** struct ROOT::Experimental::TFitPanelModel
+ * \ingroup webdisplay
+ * Model, used to initialized openui5 FitPanel
+ */
+
 struct TFitPanelModel {
-   std::vector<ComboBoxItem> fDataNames{};
-   std::string fSelectDataId{};
-   std::vector<ComboBoxItem> fModelNames{};
-   std::string fSelectModelId{};
+   std::vector<ComboBoxItem> fDataNames;
+   std::string fSelectDataId;
+   std::vector<ComboBoxItem> fModelNames;
+   std::string fSelectModelId;
    TFitPanelModel() = default;
 };
 
 
 class TFitPanel  {
 
-   std::string     fTitle{};              ///<! title
+   std::string     fTitle;                ///<! title
    unsigned       fConnId{0};             ///<! connection id
 
-   std::shared_ptr<TWebWindow> fWindow{}; ///!< configured display
+   std::shared_ptr<TWebWindow> fWindow;   ///!< configured display
 
-   std::shared_ptr<TCanvas> fCanvas{};    ///!< canvas used to display results
+   std::shared_ptr<TCanvas> fCanvas;      ///!< canvas used to display results
 
-   std::shared_ptr<TH1D>  fFitHist{};     ///!< histogram created when fit is performed
+   std::shared_ptr<TH1D>  fFitHist;       ///!< histogram created when fit is performed
 
    /// Disable copy construction.
    TFitPanel(const TFitPanel &) = delete;
@@ -60,23 +70,30 @@ class TFitPanel  {
    /// Disable assignment.
    TFitPanel &operator=(const TFitPanel &) = delete;
 
+   /// process data from UI
    void ProcessData(unsigned connid, const std::string &arg);
 
 public:
 
+   /// normal constructor
    TFitPanel(const std::string &title = "Fit panel") : fTitle(title) {}
 
+   /// destructor
    virtual ~TFitPanel() { printf("Fit panel destructor!!!\n"); }
 
    // method required when any panel want to be inserted into the TCanvas
    std::shared_ptr<TWebWindow> GetWindow();
 
+   /// show FitPanel in specified place
    void Show(const std::string &where = "");
 
+   /// hide FitPanel
    void Hide();
 
+   /// let use canvas to display fit results
    void UseCanvas(std::shared_ptr<TCanvas> &canv);
 
+   /// Dummy function, called when "Fit" button pressed in UI
    void DoFit(const std::string &dname, const std::string &mname);
 
 };

--- a/gui/fitpanel/v7/src/TFitPanel.cxx
+++ b/gui/fitpanel/v7/src/TFitPanel.cxx
@@ -23,13 +23,11 @@
 #include "TROOT.h"
 #include "TBufferJSON.h"
 
-
 /** \class ROOT::Experimental::TFitPanel
 \ingroup webdisplay
 
 web-based FitPanel prototype.
 */
-
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 /// Returns TWebWindow instance, used to display FitPanel
@@ -43,7 +41,7 @@ std::shared_ptr<ROOT::Experimental::TWebWindow> ROOT::Experimental::TFitPanel::G
 
       fWindow->SetDataCallBack([this](unsigned connid, const std::string &arg) { ProcessData(connid, arg); });
 
-      fWindow->SetGeometry(300,500); // configure predefined geometry
+      fWindow->SetGeometry(300, 500); // configure predefined geometry
    }
 
    return fWindow;

--- a/gui/fitpanel/v7/src/TFitPanel.cxx
+++ b/gui/fitpanel/v7/src/TFitPanel.cxx
@@ -23,6 +23,17 @@
 #include "TROOT.h"
 #include "TBufferJSON.h"
 
+
+/** \class ROOT::Experimental::TFitPanel
+\ingroup webdisplay
+
+web-based FitPanel prototype.
+*/
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+/// Returns TWebWindow instance, used to display FitPanel
+
 std::shared_ptr<ROOT::Experimental::TWebWindow> ROOT::Experimental::TFitPanel::GetWindow()
 {
    if (!fWindow) {
@@ -38,10 +49,16 @@ std::shared_ptr<ROOT::Experimental::TWebWindow> ROOT::Experimental::TFitPanel::G
    return fWindow;
 }
 
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+/// Show FitPanel
+
 void ROOT::Experimental::TFitPanel::Show(const std::string &where)
 {
    GetWindow()->Show(where);
 }
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+/// Hide FitPanel
 
 void ROOT::Experimental::TFitPanel::Hide()
 {
@@ -51,11 +68,15 @@ void ROOT::Experimental::TFitPanel::Hide()
    fWindow->CloseConnections();
 }
 
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+/// Process data from FitPanel
+/// OpenUI5-based FitPanel sends commands or status changes
+
 void ROOT::Experimental::TFitPanel::ProcessData(unsigned connid, const std::string &arg)
 {
    if (arg == "CONN_READY") {
       fConnId = connid;
-      printf("Connection established %u\n", fConnId);
+      printf("FitPanel connection established %u\n", fConnId);
       fWindow->Send("INITDONE", fConnId);
 
       TFitPanelModel model;
@@ -77,7 +98,7 @@ void ROOT::Experimental::TFitPanel::ProcessData(unsigned connid, const std::stri
    }
 
    if (arg == "CONN_CLOSED") {
-      printf("Connection closed\n");
+      printf("FitPanel connection closed\n");
       fConnId = 0;
       return;
    }
@@ -91,17 +112,21 @@ void ROOT::Experimental::TFitPanel::ProcessData(unsigned connid, const std::stri
    }
 }
 
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+/// Let use canvas to display fit results
+
 void ROOT::Experimental::TFitPanel::UseCanvas(std::shared_ptr<TCanvas> &canv)
 {
-   if (fCanvas) {
+   if (!fCanvas) {
+      fCanvas = canv;
+   } else {
       R__ERROR_HERE("ShowIn") << "FitPanel already bound to the canvas - change is not yet supported";
-      return;
    }
-
-   fCanvas = canv;
 }
 
-/// method called from the UI
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+/// Dummy function, called when "Fit" button pressed in UI
+
 void ROOT::Experimental::TFitPanel::DoFit(const std::string &dname, const std::string &mname)
 {
    printf("DoFit %s %s\n", dname.c_str(), mname.c_str());

--- a/gui/webdisplay/Readme.md
+++ b/gui/webdisplay/Readme.md
@@ -64,7 +64,9 @@ CEF works with  Xvfb without problem.
 ## Compilation with QT5 WebEngine support
 
 This is alternative implementation of local display, using chromium from Qt5.
-Idea to have easy possibility to embed ROOT panels (TCanvas, TBrowser) in Qt applications.
+It should provide very similar functionality as CEF (beside batch mode).
+Biggest advantage - one gets Qt5 libraris for all platforms through normal package managers.
+Later one will provide possibility to embed ROOT panels (TCanvas, TBrowser, TFitPanel) directly in Qt applications.
 
 1. Install libqt5-qtwebengine and libqt5-qtwebengine-devel packages
 

--- a/gui/webdisplay/inc/ROOT/TWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindow.hxx
@@ -86,7 +86,7 @@ private:
    void CreateWSHandler();
 
    /// Processing of websockets call-backs, invoked from TWebWindowWSHandler
-   bool ProcessWS(THttpCallArg *arg);
+   bool ProcessWS(THttpCallArg &arg);
 
    /// Sends data via specified connection (internal use only)
    void SendDataViaConnection(WebConn &conn, int chid, const std::string &data);

--- a/gui/webdisplay/inc/ROOT/TWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindow.hxx
@@ -67,7 +67,7 @@ private:
    std::string fDefaultPage;                   ///<!  HTML page (or file name) returned when window URL is opened
    std::string fPanelName;                     ///<!  panel name which should be shown in the window
    unsigned fId{0};                            ///<!  unique identifier
-   std::shared_ptr<TWebWindowWSHandler> fWSHandler;  ///<!  specialize websocket handler for all incoming connections
+   std::unique_ptr<TWebWindowWSHandler> fWSHandler;  ///<!  specialize websocket handler for all incoming connections
    bool fShown{false};                         ///<!  true when window was shown at least once
    unsigned fConnCnt{0};                       ///<!  counter of new connections to assign ids
    std::list<WebConn> fConn;                   ///<!  list of all accepted connections
@@ -98,7 +98,7 @@ private:
 public:
 
    /// default constructor
-   TWebWindow() = default;
+   TWebWindow();
 
    /// destructor
    ~TWebWindow();

--- a/gui/webdisplay/inc/ROOT/TWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindow.hxx
@@ -27,11 +27,16 @@ class THttpWSEngine;
 namespace ROOT {
 namespace Experimental {
 
-/** \class ROOT::Experimental::TWebWindowsManager
-  Central handle to open web-based windows like Canvas or FitPanel.
-  */
 
+/// function signature for call-backs from the window clients
+/// first argument is connection id, second is received data
 using WebWindowDataCallback_t = std::function<void(unsigned, const std::string &)>;
+
+/// function signature for waiting call-backs
+/// Such callback used when calling thread need to waits for some special data,
+/// but wants to run application event loop
+/// As argument, spent time in second will be provided
+/// Waiting will be performed until function returns non-zero value
 using WebWindowWaitFunc_t = std::function<int(double)>;
 
 class TWebWindowsManager;
@@ -52,84 +57,124 @@ private:
       int fClientCredits{
          0}; ///<! last received information about credits on client side, helps to resubmit credits back to client
       std::list<std::string>
-         fQueue{}; ///<! small output queue for data which should be send via the connection (including channel)
-      WebWindowDataCallback_t fCallBack{}; ///<! additional data callback for extra channels
+         fQueue; ///<! small output queue for data which should be send via the connection (including channel)
+      WebWindowDataCallback_t fCallBack; ///<! additional data callback for extra channels
       WebConn() = default;
    };
 
-   std::shared_ptr<TWebWindowsManager> fMgr{}; ///<!  display manager
+   std::shared_ptr<TWebWindowsManager> fMgr;   ///<!  display manager
    bool fBatchMode{false};                     ///<!  batch mode
-   std::string fDefaultPage{};                 ///<!  HTML page (or file name) returned when window URL is opened
-   std::string fPanelName{};                   ///<!  panel name which should be shown in the window
+   std::string fDefaultPage;                   ///<!  HTML page (or file name) returned when window URL is opened
+   std::string fPanelName;                     ///<!  panel name which should be shown in the window
    unsigned fId{0};                            ///<!  unique identifier
    TWebWindowWSHandler *fWSHandler{nullptr};   ///<!  specialize websocket handler for all incoming connections
    bool fShown{false};                         ///<!  true when window was shown at least once
    unsigned fConnCnt{0};                       ///<!  counter of new connections to assign ids
-   std::list<WebConn> fConn{};                 ///<!  list of all accepted connections
-   unsigned fConnLimit{0};                     ///<!  number of allowed active connections
+   std::list<WebConn> fConn;                   ///<!  list of all accepted connections
+   unsigned fConnLimit{1};                     ///<!  number of allowed active connections
    static const unsigned fMaxQueueLength{10};  ///<!  maximal number of queue entries
-   WebWindowDataCallback_t fDataCallback{};    ///<!  main callback when data over channel 1 is arrived
+   WebWindowDataCallback_t fDataCallback;      ///<!  main callback when data over channel 1 is arrived
    unsigned fWidth{0};                         ///<!  initial window width when displayed
    unsigned fHeight{0};                        ///<!  initial window height when displayed
 
+   /// Set batch mode, used by TWebWindowsManager
    void SetBatchMode(bool mode) { fBatchMode = mode; }
+
+   /// Set window id, used by TWebWindowsManager
    void SetId(unsigned id) { fId = id; }
 
+   /// Creates websocket handler, used by TWebWindowsManager
    void CreateWSHandler();
 
+   /// Processing of websockets call-backs, invoked from TWebWindowWSHandler
    bool ProcessWS(THttpCallArg *arg);
 
+   /// Sends data via specified connection (internal use only)
    void SendDataViaConnection(WebConn &conn, int chid, const std::string &data);
 
+   /// Checks if new data can be send (internal use only)
    void CheckDataToSend(bool only_once = false);
 
 public:
+
+   /// default constructor
    TWebWindow() = default;
 
+   /// destructor
    ~TWebWindow();
 
+   /// Method returns true if window should run in batch mode - without creating GUI elements
+   /// Can be individually set for different windows - not necessary all windows should be batch
    bool IsBatchMode() const { return fBatchMode; }
+
+   /// Returns true if window was shown at least once
+   /// It can happen that shown window not yet have connections
    bool IsShown() const { return fShown; }
+
+   /// Returns ID for the window - unique inside window manager
    unsigned GetId() const { return fId; }
 
+   /// Set content of default window HTML page
+   /// This page returns when URL address of the window will be requested
+   /// Either HTML code or file name in the form "file:/home/user/data/file.htm"
+   /// One also can use configure JSROOT location like "file:$jsrootsys/files/canvas.htm"
    void SetDefaultPage(const std::string &page) { fDefaultPage = page; }
 
+   /// Configure window to show some of existing JSROOT panels
    void SetPanelName(const std::string &name);
 
-   /// Set window geometry. Will be applied when supported by used web display
+   /// Set window geometry. Will be applied if supported by used web display (like CEF or Chromium)
    void SetGeometry(unsigned width, unsigned height)
    {
       fWidth = width;
       fHeight = height;
    }
 
-   /// returns initial window width (0 - default)
+   /// returns configured window width (0 - default)
+   /// actual window width can be different
    unsigned GetWidth() const { return fWidth; }
 
-   /// returns initial window height (0 - default)
+   /// returns configured window height (0 - default)
    unsigned GetHeight() const { return fHeight; }
 
+   /// Configure maximal number of allowed connections - 0 is unlimited
+   /// Will not affect already existing connections
+   /// Default is 1 - the only client is allowed
+   void SetConnLimit(unsigned lmt = 0) { fConnLimit = lmt; }
+
+   /// Returns current number of active clients connections
    unsigned NumConnections() const { return fConn.size(); }
 
+   /// Closes all connection to clients
+   /// Normally leads to closing of all correspondent browser windows
+   /// Some browsers (like firefox) do not allow by default to close window
    void CloseConnections() { Send("CLOSE", 0, 0); }
 
+   /// Close specified connection
+   /// Connection id usually appears in the correspondent call-backs
    void CloseConnection(unsigned connid)
    {
       if (connid)
          Send("CLOSE", connid, 0);
    }
 
+   /// Show window in specified location
    bool Show(const std::string &where);
 
+   /// Returns true if sending via specified connection can be performed
    bool CanSend(unsigned connid, bool direct = true) const;
 
+   /// Sends data via specified connection
    void Send(const std::string &data, unsigned connid = 0, unsigned chid = 1);
 
+   /// Returns relative URL address for the specified window
    std::string RelativeAddr(std::shared_ptr<TWebWindow> &win);
 
-   void SetDataCallBack(WebWindowDataCallback_t func) { fDataCallback = func; }
+   /// Set call-back function for data, received from the clients via websocket
+   void SetDataCallBack(WebWindowDataCallback_t func);
 
-   bool WaitFor(WebWindowWaitFunc_t check, double tm);
+   /// Waits until provided check function or lambdas returns non-zero value
+   int WaitFor(WebWindowWaitFunc_t check, double tm);
 };
 
 } // namespace Experimental

--- a/gui/webdisplay/inc/ROOT/TWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindow.hxx
@@ -67,7 +67,7 @@ private:
    std::string fDefaultPage;                   ///<!  HTML page (or file name) returned when window URL is opened
    std::string fPanelName;                     ///<!  panel name which should be shown in the window
    unsigned fId{0};                            ///<!  unique identifier
-   TWebWindowWSHandler *fWSHandler{nullptr};   ///<!  specialize websocket handler for all incoming connections
+   std::shared_ptr<TWebWindowWSHandler> fWSHandler;  ///<!  specialize websocket handler for all incoming connections
    bool fShown{false};                         ///<!  true when window was shown at least once
    unsigned fConnCnt{0};                       ///<!  counter of new connections to assign ids
    std::list<WebConn> fConn;                   ///<!  list of all accepted connections

--- a/gui/webdisplay/inc/ROOT/TWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindow.hxx
@@ -27,7 +27,6 @@ class THttpWSEngine;
 namespace ROOT {
 namespace Experimental {
 
-
 /// function signature for call-backs from the window clients
 /// first argument is connection id, second is received data
 using WebWindowDataCallback_t = std::function<void(unsigned, const std::string &)>;
@@ -62,20 +61,20 @@ private:
       WebConn() = default;
    };
 
-   std::shared_ptr<TWebWindowsManager> fMgr;   ///<!  display manager
-   bool fBatchMode{false};                     ///<!  batch mode
-   std::string fDefaultPage;                   ///<!  HTML page (or file name) returned when window URL is opened
-   std::string fPanelName;                     ///<!  panel name which should be shown in the window
-   unsigned fId{0};                            ///<!  unique identifier
-   std::unique_ptr<TWebWindowWSHandler> fWSHandler;  ///<!  specialize websocket handler for all incoming connections
-   bool fShown{false};                         ///<!  true when window was shown at least once
-   unsigned fConnCnt{0};                       ///<!  counter of new connections to assign ids
-   std::list<WebConn> fConn;                   ///<!  list of all accepted connections
-   unsigned fConnLimit{1};                     ///<!  number of allowed active connections
-   static const unsigned fMaxQueueLength{10};  ///<!  maximal number of queue entries
-   WebWindowDataCallback_t fDataCallback;      ///<!  main callback when data over channel 1 is arrived
-   unsigned fWidth{0};                         ///<!  initial window width when displayed
-   unsigned fHeight{0};                        ///<!  initial window height when displayed
+   std::shared_ptr<TWebWindowsManager> fMgr;        ///<!  display manager
+   bool fBatchMode{false};                          ///<!  batch mode
+   std::string fDefaultPage;                        ///<!  HTML page (or file name) returned when window URL is opened
+   std::string fPanelName;                          ///<!  panel name which should be shown in the window
+   unsigned fId{0};                                 ///<!  unique identifier
+   std::unique_ptr<TWebWindowWSHandler> fWSHandler; ///<!  specialize websocket handler for all incoming connections
+   bool fShown{false};                              ///<!  true when window was shown at least once
+   unsigned fConnCnt{0};                            ///<!  counter of new connections to assign ids
+   std::list<WebConn> fConn;                        ///<!  list of all accepted connections
+   unsigned fConnLimit{1};                          ///<!  number of allowed active connections
+   static const unsigned fMaxQueueLength{10};       ///<!  maximal number of queue entries
+   WebWindowDataCallback_t fDataCallback;           ///<!  main callback when data over channel 1 is arrived
+   unsigned fWidth{0};                              ///<!  initial window width when displayed
+   unsigned fHeight{0};                             ///<!  initial window height when displayed
 
    /// Set batch mode, used by TWebWindowsManager
    void SetBatchMode(bool mode) { fBatchMode = mode; }
@@ -96,7 +95,6 @@ private:
    void CheckDataToSend(bool only_once = false);
 
 public:
-
    /// default constructor
    TWebWindow();
 

--- a/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
@@ -32,13 +32,13 @@ namespace Experimental {
 
 class TWebWindowsManager {
 
-friend class TWebWindow;
+   friend class TWebWindow;
 
 private:
-   std::unique_ptr<THttpServer> fServer;              ///<!  central communication with the all used displays
-   std::string fAddr;                                  ///<!   HTTP address of the server
+   std::unique_ptr<THttpServer> fServer; ///<!  central communication with the all used displays
+   std::string fAddr;                    ///<!   HTTP address of the server
    // std::list<std::shared_ptr<TWebWindow>> fDisplays;   ///<! list of existing displays (not used at the moment)
-   unsigned fIdCnt{0};                                 ///<! counter for identifiers
+   unsigned fIdCnt{0}; ///<! counter for identifiers
 
    /// Creates http server, if required - with real http engine (civetweb)
    bool CreateHttpServer(bool with_http = false);

--- a/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
@@ -32,30 +32,37 @@ namespace Experimental {
 
 class TWebWindowsManager {
 
+friend class TWebWindow;
+
 private:
    THttpServer *fServer{0};                            ///<!  central communication with the all used displays
    std::string fAddr;                                  ///<!   HTTP address of the server
-   std::list<std::shared_ptr<TWebWindow>> fDisplays;   ///<! list of existing displays
+   // std::list<std::shared_ptr<TWebWindow>> fDisplays;   ///<! list of existing displays (not used at the moment)
    unsigned fIdCnt{0};                                 ///<! counter for identifiers
 
    /// Creates http server, if required - with real http engine (civetweb)
    bool CreateHttpServer(bool with_http = false);
 
+   /// Release all references to specified window, called from TWebWindow destructor
+   void Unregister(TWebWindow &win);
+
+   /// Show window in specified location, invoked from TWebWindow::Show
+   bool Show(TWebWindow &win, const std::string &where);
+
 public:
-   /// Create a temporary TCanvas
+   /// Default constructor
    TWebWindowsManager() = default;
 
+   /// Destructor
    ~TWebWindowsManager();
 
    /// Returns central instance, which used by standard ROOT widgets like Canvas or FitPanel
    static std::shared_ptr<TWebWindowsManager> &Instance();
 
+   /// Creates new window
    std::shared_ptr<TWebWindow> CreateWindow(bool batch_mode = false);
 
-   void CloseWindow(TWebWindow *);
-
-   bool Show(TWebWindow *display, const std::string &where);
-
+   /// Wait until provided function returns non-zero value
    int WaitFor(WebWindowWaitFunc_t check, double tm);
 };
 

--- a/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
@@ -59,7 +59,7 @@ public:
 
    bool Show(TWebWindow *display, const std::string &where);
 
-   bool WaitFor(WebWindowWaitFunc_t check, double tm);
+   int WaitFor(WebWindowWaitFunc_t check, double tm);
 };
 
 } // namespace Experimental

--- a/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
@@ -18,7 +18,7 @@
 
 #include <memory>
 #include <string>
-#include <list>
+// #include <list>
 
 #include "THttpEngine.h"
 
@@ -35,7 +35,7 @@ class TWebWindowsManager {
 friend class TWebWindow;
 
 private:
-   THttpServer *fServer{0};                            ///<!  central communication with the all used displays
+   std::unique_ptr<THttpServer> fServer;              ///<!  central communication with the all used displays
    std::string fAddr;                                  ///<!   HTTP address of the server
    // std::list<std::shared_ptr<TWebWindow>> fDisplays;   ///<! list of existing displays (not used at the moment)
    unsigned fIdCnt{0};                                 ///<! counter for identifiers
@@ -51,7 +51,7 @@ private:
 
 public:
    /// Default constructor
-   TWebWindowsManager() = default;
+   TWebWindowsManager();
 
    /// Destructor
    ~TWebWindowsManager();

--- a/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
@@ -30,18 +30,15 @@ class THttpWSHandler;
 namespace ROOT {
 namespace Experimental {
 
-/** \class ROOT::Experimental::TWebWindowsManager
-  Central handle to open web-based windows like Canvas or FitPanel.
-  */
-
 class TWebWindowsManager {
 
 private:
    THttpServer *fServer{0};                            ///<!  central communication with the all used displays
-   std::string fAddr{};                                ///<!   HTTP address of the server
-   std::list<std::shared_ptr<TWebWindow>> fDisplays{}; ///<! list of existing displays
+   std::string fAddr;                                  ///<!   HTTP address of the server
+   std::list<std::shared_ptr<TWebWindow>> fDisplays;   ///<! list of existing displays
    unsigned fIdCnt{0};                                 ///<! counter for identifiers
 
+   /// Creates http server, if required - with real http engine (civetweb)
    bool CreateHttpServer(bool with_http = false);
 
 public:

--- a/gui/webdisplay/src/TWebWindow.cxx
+++ b/gui/webdisplay/src/TWebWindow.cxx
@@ -32,13 +32,10 @@ namespace Experimental {
 
 class TWebWindowWSHandler : public THttpWSHandler {
 public:
-   TWebWindow &fDispl; ///<! back-pointer to display
+   TWebWindow &fDispl; ///<! display reference
 
    /// constructor
-   TWebWindowWSHandler(TWebWindow &displ) : THttpWSHandler("name", "title"), fDispl(displ) {}
-
-   /// destructor
-   virtual ~TWebWindowWSHandler() { printf("TWebWindowWSHandler destructor\n"); }
+   TWebWindowWSHandler(TWebWindow &displ, const char *name) : THttpWSHandler(name, "TWebWindow websockets handler"), fDispl(displ) {}
 
    /// returns content of default web-page
    /// THttpWSHandler interface
@@ -78,17 +75,10 @@ using TWebWindow::Send() method and call-back function assigned via TWebWindow::
 
 ROOT::Experimental::TWebWindow::~TWebWindow()
 {
-   printf("TWebWindow destructor\n");
-
    fConn.clear();
 
    if (fMgr)
       fMgr->Unregister(*this);
-
-   if (fWSHandler) {
-      delete fWSHandler;
-      fWSHandler = nullptr;
-   }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -110,10 +100,8 @@ void ROOT::Experimental::TWebWindow::SetPanelName(const std::string &name)
 
 void ROOT::Experimental::TWebWindow::CreateWSHandler()
 {
-   if (!fWSHandler) {
-      fWSHandler = new TWebWindowWSHandler(*this);
-      fWSHandler->SetName(Form("win%u", GetId()));
-   }
+   if (!fWSHandler)
+      fWSHandler = std::make_shared<TWebWindowWSHandler>(*this, Form("win%u", GetId()));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/gui/webdisplay/src/TWebWindow.cxx
+++ b/gui/webdisplay/src/TWebWindow.cxx
@@ -28,15 +28,20 @@
 namespace ROOT {
 namespace Experimental {
 
-/// just wrapper to deliver WS call-backs to the TWebWindow class
+/// just wrapper to deliver websockets call-backs to the TWebWindow class
 
 class TWebWindowWSHandler : public THttpWSHandler {
 public:
    TWebWindow *fDispl; ///<! back-pointer to display
 
+   /// constructor
    TWebWindowWSHandler(TWebWindow *displ) : THttpWSHandler("name", "title"), fDispl(displ) {}
+
+   /// destructor
    ~TWebWindowWSHandler() { fDispl = nullptr; }
 
+   /// returns content of default web-page
+   /// web-socket interface
    virtual TString GetDefaultPageContent() override { return fDispl->fDefaultPage.c_str(); }
 
    virtual Bool_t ProcessWS(THttpCallArg *arg) override { return fDispl->ProcessWS(arg); }
@@ -44,6 +49,19 @@ public:
 
 } // namespace Experimental
 } // namespace ROOT
+
+
+
+/** \class ROOT::Experimental::TWebWindow
+\ingroup webdisplay
+
+Represents web window, which can be shown in web browser or any other supported environment
+
+Each window can be shown several times (if allowed) in different places
+
+
+*/
+
 
 ROOT::Experimental::TWebWindow::~TWebWindow()
 {
@@ -58,6 +76,11 @@ ROOT::Experimental::TWebWindow::~TWebWindow()
    }
 }
 
+//////////////////////////////////////////////////////////////////////////////////////////
+/// Configure window to show some of existing JSROOT panels
+/// It uses "file:$jsrootsys/files/panel.htm" as default HTML page
+/// At the moment only FitPanel is existing
+
 void ROOT::Experimental::TWebWindow::SetPanelName(const std::string &name)
 {
    assert(fConn.size() == 0 && "Cannot configure panel when connection exists");
@@ -65,8 +88,6 @@ void ROOT::Experimental::TWebWindow::SetPanelName(const std::string &name)
    fPanelName = name;
 
    SetDefaultPage("file:$jsrootsys/files/panel.htm");
-
-   fConnLimit = 1;
 }
 
 // TODO: add callback which executed when exactly this window is opened and connection is established
@@ -79,6 +100,8 @@ void ROOT::Experimental::TWebWindow::CreateWSHandler()
    }
 }
 
+/// Show window in specified location
+/// See ROOT::Experimental::TWebWindowsManager::Show() docu for more info
 bool ROOT::Experimental::TWebWindow::Show(const std::string &where)
 {
    bool res = fMgr->Show(this, where);
@@ -259,7 +282,10 @@ void ROOT::Experimental::TWebWindow::CheckDataToSend(bool only_once)
    } while (isany && !only_once);
 }
 
-/// Returns relative address for the window to use when establish connection from the client
+///////////////////////////////////////////////////////////////////////////////////
+/// Returns relative URL address for the specified window
+/// Address can be requried if one needs to access data from one window into another window
+/// Used for instance when inserting panel into canvas
 
 std::string ROOT::Experimental::TWebWindow::RelativeAddr(std::shared_ptr<TWebWindow> &win)
 {
@@ -274,8 +300,10 @@ std::string ROOT::Experimental::TWebWindow::RelativeAddr(std::shared_ptr<TWebWin
    return res;
 }
 
-// returns true if sending via specified connection can be performed
-// if direct==true, requires that direct sending (without queue) is possible
+///////////////////////////////////////////////////////////////////////////////////
+/// returns true if sending via specified connection can be performed
+/// if direct==true, checks if direct sending (without queuing) is possible
+/// if connid==0, all existing connections are checked
 
 bool ROOT::Experimental::TWebWindow::CanSend(unsigned connid, bool direct) const
 {
@@ -293,8 +321,11 @@ bool ROOT::Experimental::TWebWindow::CanSend(unsigned connid, bool direct) const
    return true;
 }
 
-/// Sends data to specified connection
+///////////////////////////////////////////////////////////////////////////////////
+/// Sends data to specified connection/channel
 /// If connid==0, data will be send to all connections
+/// Normally chid==1 (chid==0 is reserved for internal communications)
+
 void ROOT::Experimental::TWebWindow::Send(const std::string &data, unsigned connid, unsigned chid)
 {
    for (auto iter = fConn.begin(); iter != fConn.end(); ++iter) {
@@ -313,11 +344,35 @@ void ROOT::Experimental::TWebWindow::Send(const std::string &data, unsigned conn
 }
 
 /////////////////////////////////////////////////////////////////////////////////
-/// Waits until provided check function returns non-zero value
-/// Runs application mainloop in background
-/// timelimit (in seconds) defines how long to wait (0 - for ever)
+/// Set call-back function for data, received from the clients via websocket
+/// Function should have signature like void func(unsigned connid, const std::string &data)
+/// First argument identifies connection (unique for each window), second argument is received data
+/// There are predefined values for the data:
+///     "CONN_READY"  - appears when new connection is established
+///     "CONN_CLOSED" - when connection closed, no more data will be send/received via connection
+/// Most simple way to assign call-back - use of c++11 lambdas like:
+/// ~~~ {.cpp}
+/// std::shared_ptr<TWebWindow> win = TWebWindowsManager::Instance()->CreateWindow();
+/// win->SetDefaultPage("file:./page.htm");
+/// win->SetDataCallBack([](unsigned connid, const std::string &data) { printf("Conn:%u data:%s\n", connid, data.c_str()); });
+/// win->Show("opera");
+/// ~~~
 
-bool ROOT::Experimental::TWebWindow::WaitFor(WebWindowWaitFunc_t check, double timelimit)
+void ROOT::Experimental::TWebWindow::SetDataCallBack(WebWindowDataCallback_t func)
+{
+   fDataCallback = func;
+}
+
+/////////////////////////////////////////////////////////////////////////////////
+/// Waits until provided check function or lambdas returns non-zero value
+/// Runs application mainloop and short sleeps in-between
+/// timelimit (in seconds) defines how long to wait (0 - forever)
+/// Function has following signature: int func(double spent_tm)
+/// Parameter spent_tm is time in seconds, which already spent inside function
+/// Waiting will be continued, if function returns zero.
+/// First non-zero value breaks waiting loop and result is returned (or 0 is time is expired).
+
+int ROOT::Experimental::TWebWindow::WaitFor(WebWindowWaitFunc_t check, double timelimit)
 {
    return fMgr->WaitFor(check, timelimit);
 }

--- a/gui/webdisplay/src/TWebWindow.cxx
+++ b/gui/webdisplay/src/TWebWindow.cxx
@@ -32,21 +32,21 @@ namespace Experimental {
 
 class TWebWindowWSHandler : public THttpWSHandler {
 public:
-   TWebWindow *fDispl; ///<! back-pointer to display
+   TWebWindow &fDispl; ///<! back-pointer to display
 
    /// constructor
-   TWebWindowWSHandler(TWebWindow *displ) : THttpWSHandler("name", "title"), fDispl(displ) {}
+   TWebWindowWSHandler(TWebWindow &displ) : THttpWSHandler("name", "title"), fDispl(displ) {}
 
    /// destructor
-   ~TWebWindowWSHandler() { fDispl = nullptr; }
+   virtual ~TWebWindowWSHandler() { printf("TWebWindowWSHandler destructor\n"); }
 
    /// returns content of default web-page
    /// THttpWSHandler interface
-   virtual TString GetDefaultPageContent() override { return fDispl->fDefaultPage.c_str(); }
+   virtual TString GetDefaultPageContent() override { return fDispl.fDefaultPage.c_str(); }
 
    /// Process websocket request
    /// THttpWSHandler interface
-   virtual Bool_t ProcessWS(THttpCallArg *arg) override { return fDispl->ProcessWS(arg); }
+   virtual Bool_t ProcessWS(THttpCallArg *arg) override { return fDispl.ProcessWS(arg); }
 };
 
 } // namespace Experimental
@@ -109,7 +109,7 @@ void ROOT::Experimental::TWebWindow::SetPanelName(const std::string &name)
 void ROOT::Experimental::TWebWindow::CreateWSHandler()
 {
    if (!fWSHandler) {
-      fWSHandler = new TWebWindowWSHandler(this);
+      fWSHandler = new TWebWindowWSHandler(*this);
       fWSHandler->SetName(Form("win%u", GetId()));
    }
 }

--- a/gui/webdisplay/src/TWebWindow.cxx
+++ b/gui/webdisplay/src/TWebWindow.cxx
@@ -69,9 +69,16 @@ using TWebWindow::Send() method and call-back function assigned via TWebWindow::
 
 */
 
+//////////////////////////////////////////////////////////////////////////////////////////
+/// TWebWindow constructor
+/// Should be here defined here because of std::unique_ptr<TWebWindowWSHandler>
+
+ROOT::Experimental::TWebWindow::TWebWindow() = default;
+
 
 //////////////////////////////////////////////////////////////////////////////////////////
-/// destructor - closed all connections and remove window from manager
+/// TWebWindow destructor
+/// Closes all connections and remove window from manager
 
 ROOT::Experimental::TWebWindow::~TWebWindow()
 {
@@ -101,7 +108,7 @@ void ROOT::Experimental::TWebWindow::SetPanelName(const std::string &name)
 void ROOT::Experimental::TWebWindow::CreateWSHandler()
 {
    if (!fWSHandler)
-      fWSHandler = std::make_shared<TWebWindowWSHandler>(*this, Form("win%u", GetId()));
+      fWSHandler = std::make_unique<TWebWindowWSHandler>(*this, Form("win%u", GetId()));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/gui/webdisplay/src/TWebWindow.cxx
+++ b/gui/webdisplay/src/TWebWindow.cxx
@@ -35,7 +35,10 @@ public:
    TWebWindow &fDispl; ///<! display reference
 
    /// constructor
-   TWebWindowWSHandler(TWebWindow &displ, const char *name) : THttpWSHandler(name, "TWebWindow websockets handler"), fDispl(displ) {}
+   TWebWindowWSHandler(TWebWindow &displ, const char *name)
+      : THttpWSHandler(name, "TWebWindow websockets handler"), fDispl(displ)
+   {
+   }
 
    /// returns content of default web-page
    /// THttpWSHandler interface
@@ -48,8 +51,6 @@ public:
 
 } // namespace Experimental
 } // namespace ROOT
-
-
 
 /** \class ROOT::Experimental::TWebWindow
 \ingroup webdisplay
@@ -71,10 +72,9 @@ using TWebWindow::Send() method and call-back function assigned via TWebWindow::
 
 //////////////////////////////////////////////////////////////////////////////////////////
 /// TWebWindow constructor
-/// Should be here defined here because of std::unique_ptr<TWebWindowWSHandler>
+/// Should be defined here because of std::unique_ptr<TWebWindowWSHandler>
 
 ROOT::Experimental::TWebWindow::TWebWindow() = default;
-
 
 //////////////////////////////////////////////////////////////////////////////////////////
 /// TWebWindow destructor
@@ -377,7 +377,8 @@ void ROOT::Experimental::TWebWindow::Send(const std::string &data, unsigned conn
 /// ~~~ {.cpp}
 /// std::shared_ptr<TWebWindow> win = TWebWindowsManager::Instance()->CreateWindow();
 /// win->SetDefaultPage("file:./page.htm");
-/// win->SetDataCallBack([](unsigned connid, const std::string &data) { printf("Conn:%u data:%s\n", connid, data.c_str()); });
+/// win->SetDataCallBack([](unsigned connid, const std::string &data) { printf("Conn:%u data:%s\n", connid,
+/// data.c_str()); });
 /// win->Show("opera");
 /// ~~~
 

--- a/gui/webdisplay/src/TWebWindow.cxx
+++ b/gui/webdisplay/src/TWebWindow.cxx
@@ -78,10 +78,12 @@ using TWebWindow::Send() method and call-back function assigned via TWebWindow::
 
 ROOT::Experimental::TWebWindow::~TWebWindow()
 {
+   printf("TWebWindow destructor\n");
+
    fConn.clear();
 
    if (fMgr)
-      fMgr->CloseWindow(this);
+      fMgr->Unregister(*this);
 
    if (fWSHandler) {
       delete fWSHandler;
@@ -120,7 +122,7 @@ void ROOT::Experimental::TWebWindow::CreateWSHandler()
 
 bool ROOT::Experimental::TWebWindow::Show(const std::string &where)
 {
-   bool res = fMgr->Show(this, where);
+   bool res = fMgr->Show(*this, where);
    if (res)
       fShown = true;
    return res;

--- a/gui/webdisplay/src/TWebWindowsManager.cxx
+++ b/gui/webdisplay/src/TWebWindowsManager.cxx
@@ -264,7 +264,7 @@ bool ROOT::Experimental::TWebWindowsManager::Show(ROOT::Experimental::TWebWindow
 /// Runs application mainloop in background
 /// timelimit (in seconds) defines how long to wait (0 - for ever)
 
-bool ROOT::Experimental::TWebWindowsManager::WaitFor(WebWindowWaitFunc_t check, double timelimit)
+int ROOT::Experimental::TWebWindowsManager::WaitFor(WebWindowWaitFunc_t check, double timelimit)
 {
    TStopwatch tm;
    tm.Start();
@@ -278,10 +278,10 @@ bool ROOT::Experimental::TWebWindowsManager::WaitFor(WebWindowWaitFunc_t check, 
       spent = tm.RealTime();
       tm.Continue();
       if ((timelimit > 0) && (spent > timelimit))
-         return false;
+         return 0;
       cnt++;
    }
    printf("WAITING RES %d tm %4.2f cnt %d\n", res, spent, cnt);
 
-   return (res > 0);
+   return res;
 }

--- a/gui/webdisplay/src/TWebWindowsManager.cxx
+++ b/gui/webdisplay/src/TWebWindowsManager.cxx
@@ -49,16 +49,19 @@ std::shared_ptr<ROOT::Experimental::TWebWindowsManager> &ROOT::Experimental::TWe
    return sInstance;
 }
 
+
+//////////////////////////////////////////////////////////////////////////////////////////
+/// window manager constructor
+/// Required here for correct usage of unique_ptr<THttpServer>
+
+ROOT::Experimental::TWebWindowsManager::TWebWindowsManager() = default;
+
 //////////////////////////////////////////////////////////////////////////////////////////
 /// window manager destructor
-/// Closes THttpServer instance
+/// Required here for correct usage of unique_ptr<THttpServer>
 
 ROOT::Experimental::TWebWindowsManager::~TWebWindowsManager()
 {
-   if (fServer) {
-      delete fServer;
-      fServer = 0;
-   }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -67,7 +70,7 @@ ROOT::Experimental::TWebWindowsManager::~TWebWindowsManager()
 bool ROOT::Experimental::TWebWindowsManager::CreateHttpServer(bool with_http)
 {
    if (!fServer)
-      fServer = new THttpServer("dummy");
+      fServer = std::make_unique<THttpServer>("dummy");
 
    if (!with_http || (fAddr.length() > 0))
       return true;
@@ -217,7 +220,7 @@ bool ROOT::Experimental::TWebWindowsManager::Show(ROOT::Experimental::TWebWindow
       printf("Show canvas in Qt5 window:  %s\n", addr.Data());
 
       FunctionQt5 func = (FunctionQt5)symbol_qt5;
-      func(addr.Data(), fServer, batch_mode, win.GetWidth(), win.GetHeight());
+      func(addr.Data(), fServer.get(), batch_mode, win.GetWidth(), win.GetHeight());
       return false;
    }
 
@@ -232,7 +235,7 @@ bool ROOT::Experimental::TWebWindowsManager::Show(ROOT::Experimental::TWebWindow
       printf("Show canvas in CEF window:  %s\n", addr.Data());
 
       FunctionCef3 func = (FunctionCef3)symbol_cef;
-      func(addr.Data(), fServer, batch_mode, rootsys, cef_path, win.GetWidth(), win.GetHeight());
+      func(addr.Data(), fServer.get(), batch_mode, rootsys, cef_path, win.GetWidth(), win.GetHeight());
 
       return true;
    }

--- a/gui/webdisplay/src/TWebWindowsManager.cxx
+++ b/gui/webdisplay/src/TWebWindowsManager.cxx
@@ -128,7 +128,7 @@ std::shared_ptr<ROOT::Experimental::TWebWindow> ROOT::Experimental::TWebWindowsM
 
    win->CreateWSHandler();
 
-   fServer->Register("/web7gui", (THttpWSHandler *)win->fWSHandler);
+   fServer->Register("/web7gui", (THttpWSHandler *)win->fWSHandler.get());
 
    return win;
 }
@@ -139,10 +139,10 @@ std::shared_ptr<ROOT::Experimental::TWebWindow> ROOT::Experimental::TWebWindowsM
 
 void ROOT::Experimental::TWebWindowsManager::Unregister(ROOT::Experimental::TWebWindow &win)
 {
-   // TODO: close all active connections of the display
+   // TODO: close all active connections of the window
 
    if (win.fWSHandler)
-      fServer->Unregister((THttpWSHandler *)win.fWSHandler);
+      fServer->Unregister((THttpWSHandler *)win.fWSHandler.get());
 
 //   for (auto displ = fDisplays.begin(); displ != fDisplays.end(); displ++) {
 //      if (displ->get() == win) {
@@ -178,7 +178,7 @@ bool ROOT::Experimental::TWebWindowsManager::Show(ROOT::Experimental::TWebWindow
       return false;
    }
 
-   THttpWSHandler *handler = (THttpWSHandler *)win.fWSHandler;
+   THttpWSHandler *handler = (THttpWSHandler *)win.fWSHandler.get();
    bool batch_mode = win.IsBatchMode();
 
    TString addr;

--- a/gui/webdisplay/src/TWebWindowsManager.cxx
+++ b/gui/webdisplay/src/TWebWindowsManager.cxx
@@ -49,7 +49,6 @@ std::shared_ptr<ROOT::Experimental::TWebWindowsManager> &ROOT::Experimental::TWe
    return sInstance;
 }
 
-
 //////////////////////////////////////////////////////////////////////////////////////////
 /// window manager constructor
 /// Required here for correct usage of unique_ptr<THttpServer>
@@ -147,12 +146,12 @@ void ROOT::Experimental::TWebWindowsManager::Unregister(ROOT::Experimental::TWeb
    if (win.fWSHandler)
       fServer->Unregister((THttpWSHandler *)win.fWSHandler.get());
 
-//   for (auto displ = fDisplays.begin(); displ != fDisplays.end(); displ++) {
-//      if (displ->get() == win) {
-//         fDisplays.erase(displ);
-//         break;
-//      }
-//   }
+   //   for (auto displ = fDisplays.begin(); displ != fDisplays.end(); displ++) {
+   //      if (displ->get() == win) {
+   //         fDisplays.erase(displ);
+   //         break;
+   //      }
+   //   }
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -119,7 +119,8 @@ int websocket_data_handler(struct mg_connection *conn, int, char *data, size_t l
       return 1;
 
    // seems to be, appears when connection is broken
-   if ((len==2) && ((int)data[0] == 3) && ((int)data[1] == -23)) return 0;
+   if ((len == 2) && ((int)data[0] == 3) && ((int)data[1] == -23))
+      return 0;
 
    THttpCallArg arg;
    arg.SetPathAndFileName(request_info->uri); // path and file name

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -118,6 +118,9 @@ int websocket_data_handler(struct mg_connection *conn, int, char *data, size_t l
    if (serv == 0)
       return 1;
 
+   // seems to be, appears when connection is broken
+   if ((len==2) && ((int)data[0] == 3) && ((int)data[1] == -23)) return 0;
+
    THttpCallArg arg;
    arg.SetPathAndFileName(request_info->uri); // path and file name
    arg.SetQuery(request_info->query_string);  // query arguments


### PR DESCRIPTION
1. Use unique_ptr for owned objects. It is:
   - THttpServer instance in TWebWindowManager
   - TWebWindowWSHandler in TWebWindow
   - move default constructors into source files
2. Remove list of shared_ptr<TWebWindow> from window manager.
    Window owned by the correspondent widget and automatically destroyed with the widget.
3. Use object references in method arguments where object must exists.
4. Provide documentation for all methods in TWebWindow and TWebWindowManager
5. Small workaround for the case of broken websocket in civetweb. Appears when client does not regularly closes the socket. More investigation will be done after upgrade of civetweb code