### PR TITLE
[modules] Protect possible deserialization.

### DIFF
--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -3864,6 +3864,8 @@ clang::QualType ROOT::TMetaUtils::GetNormalizedType(const clang::QualType &type,
 {
    clang::ASTContext &ctxt = interpreter.getCI()->getASTContext();
 
+   // Modules can trigger deserialization.
+   cling::Interpreter::PushTransactionRAII RAII(const_cast<cling::Interpreter*>(&interpreter));
    clang::QualType normalizedType = cling::utils::Transform::GetPartiallyDesugaredType(ctxt, type, normCtxt.GetConfig(), true /* fully qualify */);
 
    // Readd missing default template parameters

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -1119,6 +1119,10 @@ long TClingClassInfo::Property() const
 
    long property = 0L;
    property |= kIsCPPCompiled;
+
+   // Modules can deserialize while querying the various decls for information.
+   cling::Interpreter::PushTransactionRAII RAII(fInterp);
+
    const clang::DeclContext *ctxt = fDecl->getDeclContext();
    clang::NamespaceDecl *std_ns =fInterp->getSema().getStdNamespace();
    while (! ctxt->isTranslationUnit())  {


### PR DESCRIPTION
When querying decls for information we can start a deserialization.

This fixes 4 tests for runtime cxxmodules.