### PR TITLE
Avoid spurrious errors message about iteration not set in ClassInfo.

### DIFF
--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -70,7 +70,7 @@ static std::string FullyQualifiedName(const Decl *decl) {
 
 TClingClassInfo::TClingClassInfo(cling::Interpreter *interp, Bool_t all)
    : fInterp(interp), fFirstTime(true), fDescend(false), fIterAll(all),
-     fDecl(0), fType(0), fOffsetCache(0)
+     fIsIter(true), fDecl(0), fType(0), fOffsetCache(0)
 {
    TranslationUnitDecl *TU =
       interp->getCI()->getASTContext().getTranslationUnitDecl();
@@ -81,6 +81,7 @@ TClingClassInfo::TClingClassInfo(cling::Interpreter *interp, Bool_t all)
    else
       fIter = TU->noload_decls_begin();
 
+   // Set
    InternalNext();
    fFirstTime = true;
    // CINT had this odd behavior where a ClassInfo created without any
@@ -100,7 +101,7 @@ TClingClassInfo::TClingClassInfo(cling::Interpreter *interp, Bool_t all)
 }
 
 TClingClassInfo::TClingClassInfo(cling::Interpreter *interp, const char *name)
-   : fInterp(interp), fFirstTime(true), fDescend(false), fIterAll(kTRUE), fDecl(0),
+   : fInterp(interp), fFirstTime(true), fDescend(false), fIterAll(kTRUE), fIsIter(false), fDecl(0),
      fType(0), fTitle(""), fOffsetCache(0)
 {
    const cling::LookupHelper& lh = fInterp->getLookupHelper();
@@ -136,7 +137,7 @@ TClingClassInfo::TClingClassInfo(cling::Interpreter *interp, const char *name)
 TClingClassInfo::TClingClassInfo(cling::Interpreter *interp,
                                  const Type &tag)
    : fInterp(interp), fFirstTime(true), fDescend(false), fIterAll(kTRUE),
-     fDecl(0), fType(0), fTitle(""), fOffsetCache(0)
+     fIsIter(false), fDecl(0), fType(0), fTitle(""), fOffsetCache(0)
 {
    Init(tag);
 }
@@ -682,6 +683,7 @@ void TClingClassInfo::Init(const char *name)
 {
    fFirstTime = true;
    fDescend = false;
+   fIsIter = false;
    fIter = DeclContext::decl_iterator();
    fDecl = 0;
    fType = 0;
@@ -710,6 +712,7 @@ void TClingClassInfo::Init(const Decl* decl)
 {
    fFirstTime = true;
    fDescend = false;
+   fIsIter = false;
    fIter = DeclContext::decl_iterator();
    fDecl = decl;
    fType = 0;
@@ -835,9 +838,9 @@ int TClingClassInfo::InternalNext()
 
    R__LOCKGUARD(gInterpreterMutex);
 
-   if (!*fIter) {
-      // Iterator is already invalid.
-      if (fFirstTime && fDecl) {
+   if (!fIsIter) {
+      // Object was not setup for iteration.
+      if (fDecl) {
          std::string buf;
          if (const NamedDecl* ND =
                llvm::dyn_cast<NamedDecl>(fDecl)) {
@@ -847,7 +850,10 @@ int TClingClassInfo::InternalNext()
             ND->getNameForDiagnostic(stream, Policy, /*Qualified=*/false);
          }
          Error("TClingClassInfo::InternalNext",
-            "Next called but iteration not prepared for %s!", buf.c_str());
+               "Next called but iteration not prepared for %s!", buf.c_str());
+      } else {
+         Error("TClingClassInfo::InternalNext",
+               "Next called but iteration not prepared!");
       }
       return 0;
    }
@@ -857,6 +863,9 @@ int TClingClassInfo::InternalNext()
       if (fFirstTime) {
          // The cint semantics are strange.
          fFirstTime = false;
+         if (!*fIter) {
+            return 0;
+         }
       }
       else {
          // Advance the iterator one decl, descending into the current decl

--- a/core/metacling/src/TClingClassInfo.h
+++ b/core/metacling/src/TClingClassInfo.h
@@ -55,9 +55,10 @@ class TClingClassInfo {
 private:
 
    cling::Interpreter   *fInterp; // Cling interpreter, we do *not* own.
-   bool                  fFirstTime; // We need to skip the first increment to support the cint Next() semantics.
-   bool                  fDescend; // Flag for signaling the need to descend on this advancement.
-   bool                  fIterAll; // Flag whether iteration should be as complete as possible.
+   bool                  fFirstTime: 1; // We need to skip the first increment to support the cint Next() semantics.
+   bool                  fDescend : 1;  // Flag for signaling the need to descend on this advancement.
+   bool                  fIterAll : 1;  // Flag whether iteration should be as complete as possible.
+   bool                  fIsIter : 1;   // Flag whether this object was setup for iteration.
    clang::DeclContext::decl_iterator fIter; // Current decl in scope.
    const clang::Decl    *fDecl; // Current decl, we do *not* own.
    const clang::Type    *fType; // Type representing the decl (conserves typedefs like Double32_t). (we do *not* own)


### PR DESCRIPTION
In some circumstance, the Translation Unit can devoid of any decl
useable by ClassInfo (i.e. it has only forward declaration and typedefs).

This can happen at the beginning of the process when none of the
rootmap files declares a namespace.

When this happens there is no "valid" iterator for TClingClassInfo
to use as the 'first' iterator and thus the existing invariant test,
'first' iterator must not point to nullptr, is incorrect.

To solve the problem use an explicit way of telling whether the
TClingClassInfo was setup for iteration (rather than deducing from
the value of the iterator pointee) and void memory growth by
using bit field for the bool data members.