### PR TITLE
TMVA: added protection in case dont compile it with imt

### DIFF
--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -735,7 +735,7 @@ void TFormula::InputFormulaIntoCling()
 
    if (!fClingInitialized && fReadyToExecute && fClingInput.Length() > 0) {
       // add pragma for optimization of the formula
-      fClingInput =  TString("#pragma cling optimize(2)\n") + fClingInput;
+      fClingInput = TString("#pragma cling optimize(2)\n") + fClingInput;
       gCling->Declare(fClingInput);
       fClingInitialized = PrepareEvalMethod();
    }

--- a/tmva/tmva/inc/TMVA/Config.h
+++ b/tmva/tmva/inc/TMVA/Config.h
@@ -41,7 +41,10 @@
 #endif
 #include "Rtypes.h"
 #include "TString.h"
+
+#ifdef R__USE_IMT
 #include <ROOT/TThreadExecutor.hxx>
+#endif
 
 namespace TMVA {
 
@@ -49,7 +52,9 @@ namespace TMVA {
 
    class Config {
    protected:
+#ifdef R__USE_IMT
       ROOT::TThreadExecutor fPool;
+#endif
 
    public:
 
@@ -68,8 +73,9 @@ namespace TMVA {
       Bool_t DrawProgressBar() const { return fDrawProgressBar; }
       void   SetDrawProgressBar( Bool_t d ) { fDrawProgressBar = d; }
 
+#ifdef R__USE_IMT
       ROOT::TThreadExecutor &GetThreadExecutor() { return fPool; }
-
+#endif
    public:
 
       class VariablePlotting;


### PR DESCRIPTION
Small fix to support compilation without imt in class TMVA::Config.

O.