### PR TITLE
[TDF] Use TArrayBranch instead of array_view

### DIFF
--- a/tree/treeplayer/inc/ROOT/TArrayBranch.hxx
+++ b/tree/treeplayer/inc/ROOT/TArrayBranch.hxx
@@ -1,0 +1,61 @@
+// Author: Enrico Guiraud CERN  10/2017
+
+/*************************************************************************
+ * Copyright (C) 1995-2016, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TDF_TARRAYBRANCH
+#define ROOT_TDF_TARRAYBRANCH
+
+#include "TTreeReaderArray.h"
+#include <iterator>
+
+namespace ROOT {
+namespace Experimental {
+namespace TDF {
+/// When using TDataFrame to read data from a ROOT file, users can specify that the type of a branch is TArrayBranch<T>
+/// to indicate the branch is a c-style array, an STL array or any other type that can/must be accessed through a
+/// TTreeReaderArray<T> (as opposed to a TTreeReaderValue<T>).
+/// Column values of type TArrayBranch perform no copy of the underlying array data and offer a minimal array-like
+/// interface to access the array elements: either via square brackets, or with C++11 range-based for loops.
+template <typename T>
+class TArrayBranch {
+   TTreeReaderArray<T> *fReaderArray = nullptr; ///< Pointer to the TTreeReaderArray that actually owns the data
+public:
+   using iterator = typename TTreeReaderArray<T>::iterator;
+   using const_iterator = typename TTreeReaderArray<T>::const_iterator;
+   using value_type = T;
+
+   TArrayBranch() {} // jitted types must be default-constructible
+   TArrayBranch(TTreeReaderArray<T> &arr) : fReaderArray(&arr)
+   {
+      // trigger loading of entry into TTreeReaderArray
+      // TODO: could we load more lazily? we need to guarantee that when a TArrayBranch is constructed all data
+      // is loaded into the TTreeReaderArray because otherwise Snapshot never triggers this load.
+      // Should we have Snapshot explicitly trigger the loading instead?
+      // N.B. we would not need to trigger the load explicitly if Snapshot did not read the buffer returned by GetData
+      // directly -- e.g. if we wrote a std::vector for each c-style array in input
+      arr.At(0);
+   }
+
+   const T &operator[](std::size_t n) const { return fReaderArray->At(n); }
+
+   // TODO: remove the need of GetData, e.g. by writing out std::vectors instead of c-style arrays
+   T *GetData() { return static_cast<T *>(fReaderArray->GetAddress()); }
+
+   iterator begin() { return fReaderArray->begin(); }
+   iterator end() { return fReaderArray->end(); }
+   const_iterator begin() const { return fReaderArray->cbegin(); }
+   const_iterator end() const { return fReaderArray->cend(); }
+
+   std::size_t size() const { return fReaderArray->GetSize(); }
+};
+}
+}
+}
+
+#endif

--- a/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
@@ -15,7 +15,7 @@
 #include "ROOT/TypeTraits.hxx"
 #include "ROOT/TDFUtils.hxx"
 #include "ROOT/TThreadedObject.hxx"
-#include "ROOT/RArrayView.hxx"
+#include "ROOT/TArrayBranch.hxx"
 #include "TH1.h"
 #include "TTreeReader.h" // for SnapshotHelper
 #include "TFile.h"       // for SnapshotHelper
@@ -249,12 +249,12 @@ public:
 };
 
 // In case of the take helper we have 4 cases:
-// 1. The column is not an array_view, the collection is not a vector
-// 2. The column is not an array_view, the collection is a vector
-// 3. The column is an array_view, the collection is not a vector
-// 4. The column is an array_view, the collection is a vector
+// 1. The column is not an TArrayBranch, the collection is not a vector
+// 2. The column is not an TArrayBranch, the collection is a vector
+// 3. The column is an TArrayBranch, the collection is not a vector
+// 4. The column is an TArrayBranch, the collection is a vector
 
-// Case 1.: The column is not an array_view, the collection is not a vector
+// Case 1.: The column is not an TArrayBranch, the collection is not a vector
 // No optimisations, no transformations: just copies.
 template <typename RealT_t, typename T, typename COLL>
 class TakeHelper {
@@ -289,7 +289,7 @@ public:
    COLL &PartialUpdate(unsigned int slot) { return *fColls[slot].get(); }
 };
 
-// Case 2.: The column is not an array_view, the collection is a vector
+// Case 2.: The column is not an TArrayBranch, the collection is a vector
 // Optimisations, no transformations: just copies.
 template <typename RealT_t, typename T>
 class TakeHelper<RealT_t, T, std::vector<T>> {
@@ -330,14 +330,14 @@ public:
    std::vector<T> &PartialUpdate(unsigned int slot) { return *fColls[slot]; }
 };
 
-// Case 3.: The column is an array_view, the collection is not a vector
-// No optimisations, transformations from array_views to vectors
+// Case 3.: The column is a TArrayBranch, the collection is not a vector
+// No optimisations, transformations from TArrayBranchs to vectors
 template <typename RealT_t, typename COLL>
-class TakeHelper<RealT_t, std::array_view<RealT_t>, COLL> {
+class TakeHelper<RealT_t, TArrayBranch<RealT_t>, COLL> {
    std::vector<std::shared_ptr<COLL>> fColls;
 
 public:
-   using BranchTypes_t = TypeList<std::array_view<RealT_t>>;
+   using BranchTypes_t = TypeList<TArrayBranch<RealT_t>>;
    TakeHelper(const std::shared_ptr<COLL> &resultColl, const unsigned int nSlots)
    {
       fColls.emplace_back(resultColl);
@@ -349,7 +349,7 @@ public:
 
    void InitSlot(TTreeReader *, unsigned int) {}
 
-   void Exec(unsigned int slot, std::array_view<RealT_t> av) { fColls[slot]->emplace_back(av.begin(), av.end()); }
+   void Exec(unsigned int slot, TArrayBranch<RealT_t> av) { fColls[slot]->emplace_back(av.begin(), av.end()); }
 
    void Finalize()
    {
@@ -363,14 +363,14 @@ public:
    }
 };
 
-// Case 4.: The column is an array_view, the collection is a vector
-// Optimisations, transformations from array_views to vectors
+// Case 4.: The column is an TArrayBranch, the collection is a vector
+// Optimisations, transformations from TArrayBranchs to vectors
 template <typename RealT_t>
-class TakeHelper<RealT_t, std::array_view<RealT_t>, std::vector<RealT_t>> {
+class TakeHelper<RealT_t, TArrayBranch<RealT_t>, std::vector<RealT_t>> {
    std::vector<std::shared_ptr<std::vector<std::vector<RealT_t>>>> fColls;
 
 public:
-   using BranchTypes_t = TypeList<std::array_view<RealT_t>>;
+   using BranchTypes_t = TypeList<TArrayBranch<RealT_t>>;
    TakeHelper(const std::shared_ptr<std::vector<std::vector<RealT_t>>> &resultColl, const unsigned int nSlots)
    {
       fColls.emplace_back(resultColl);
@@ -385,7 +385,7 @@ public:
 
    void InitSlot(TTreeReader *, unsigned int) {}
 
-   void Exec(unsigned int slot, std::array_view<RealT_t> av) { fColls[slot]->emplace_back(av.begin(), av.end()); }
+   void Exec(unsigned int slot, TArrayBranch<RealT_t> av) { fColls[slot]->emplace_back(av.begin(), av.end()); }
 
    // This is optimised to treat vectors
    void Finalize()
@@ -571,17 +571,17 @@ extern template void MeanHelper::Exec(unsigned int, const std::vector<int> &);
 extern template void MeanHelper::Exec(unsigned int, const std::vector<unsigned int> &);
 
 template<typename T>
-struct AddRefIfNotArrayView {
+struct AddRefIfNotArrayBranch {
    using type = T&;
 };
 
 template<typename T>
-struct AddRefIfNotArrayView<std::array_view<T>> {
-   using type = std::array_view<T>;
+struct AddRefIfNotArrayBranch<TArrayBranch<T>> {
+   using type = TArrayBranch<T>;
 };
 
 template<typename T>
-using AddRefIfNotArrayView_t = typename AddRefIfNotArrayView<T>::type;
+using AddRefIfNotArrayBranch_t = typename AddRefIfNotArrayBranch<T>::type;
 
 /// Helper object for a single-thread Snapshot action
 template <typename... BranchTypes>
@@ -625,7 +625,7 @@ public:
       fInputTree->AddClone(fOutputTree.get());
    }
 
-   void Exec(unsigned int /* slot */, AddRefIfNotArrayView_t<BranchTypes>... values)
+   void Exec(unsigned int /* slot */, AddRefIfNotArrayBranch_t<BranchTypes>... values)
    {
       if (fIsFirstEvent) {
          using ind_t = GenStaticSeq_t<sizeof...(BranchTypes)>;
@@ -635,7 +635,7 @@ public:
    }
 
    template <int... S>
-   void SetBranches(AddRefIfNotArrayView_t<BranchTypes>... values, StaticSeq<S...> /*dummy*/)
+   void SetBranches(AddRefIfNotArrayBranch_t<BranchTypes>... values, StaticSeq<S...> /*dummy*/)
    {
       // hack to call TTree::Branch on all variadic template arguments
       int expander[] = {(SetBranchesHelper(fBranchNames[S], &values), 0)..., 0};
@@ -649,12 +649,12 @@ public:
       fOutputTree->Branch(name.c_str(), address);
    }
 
-   // This overload is called for columns of type `array_view<T>`. For TDF, these represent c-style arrays in ROOT
+   // This overload is called for columns of type `TArrayBranch<T>`. For TDF, these represent c-style arrays in ROOT
    // files, so we are sure that there are input trees to which we can ask the correct branch title
    template <typename T>
-   void SetBranchesHelper(const std::string &name, std::array_view<T> *arrview)
+   void SetBranchesHelper(const std::string &name, TArrayBranch<T> *ab)
    {
-      fOutputTree->Branch(name.c_str(), const_cast<T*>(arrview->data()), fInputTree->GetBranch(name.c_str())->GetTitle());
+      fOutputTree->Branch(name.c_str(), ab->GetData(), fInputTree->GetBranch(name.c_str())->GetTitle());
    }
 
    void Finalize() { fOutputTree->Write(); }
@@ -718,7 +718,7 @@ public:
       fIsFirstEvent[slot] = 1; // reset first event flag for this slot
    }
 
-   void Exec(unsigned int slot, AddRefIfNotArrayView_t<BranchTypes>... values)
+   void Exec(unsigned int slot, AddRefIfNotArrayBranch_t<BranchTypes>... values)
    {
       if (fIsFirstEvent[slot]) {
          using ind_t = GenStaticSeq_t<sizeof...(BranchTypes)>;
@@ -733,7 +733,7 @@ public:
    }
 
    template <int... S>
-   void SetBranches(unsigned int slot, AddRefIfNotArrayView_t<BranchTypes>... values, StaticSeq<S...> /*dummy*/)
+   void SetBranches(unsigned int slot, AddRefIfNotArrayBranch_t<BranchTypes>... values, StaticSeq<S...> /*dummy*/)
    {
       // hack to call TTree::Branch on all variadic template arguments
       int expander[] = {(SetBranchesHelper(*fOutputTrees[slot], *fInputTrees[slot], fBranchNames[S], &values), 0)...,
@@ -747,12 +747,12 @@ public:
       t.Branch(name.c_str(), address);
    }
 
-   // This overload is called for columns of type `array_view<T>`. For TDF, these represent c-style arrays in ROOT
+   // This overload is called for columns of type `TArrayBranch<T>`. For TDF, these represent c-style arrays in ROOT
    // files, so we are sure that there are input trees to which we can ask the correct branch title
    template <typename T>
-   void SetBranchesHelper(TTree &outputTree, TTree &inputTree, const std::string &name, std::array_view<T> *arrview)
+   void SetBranchesHelper(TTree &outputTree, TTree &inputTree, const std::string &name, TArrayBranch<T> *ab)
    {
-      outputTree.Branch(name.c_str(), const_cast<T*>(arrview->data()), inputTree.GetBranch(name.c_str())->GetTitle());
+      outputTree.Branch(name.c_str(), ab->GetData(), inputTree.GetBranch(name.c_str())->GetTitle());
    }
 
    void Finalize()

--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -283,20 +283,20 @@ namespace TDF {
 template <typename T, typename COLL = std::vector<T>>
 struct TakeRealTypes {
    // We cannot put in the output collection C arrays: the ownership is not defined.
-   // We therefore proceed to check if T is an array_view
+   // We therefore proceed to check if T is an TArrayBranch
    // If yes, we check what type is the output collection and we rebuild it.
-   // E.g. if a vector<V> was the selected collection, where V is array_view<T>,
+   // E.g. if a vector<V> was the selected collection, where V is TArrayBranch<T>,
    // the collection becomes vector<vector<T>>.
-   static constexpr auto isAV = TDFInternal::IsArrayView_t<T>::value;
+   static constexpr auto isAB = TDFInternal::IsTArrayBranch_t<T>::value;
    using RealT_t = typename TDFInternal::ValueType<T>::value_type;
    using VTColl_t = std::vector<RealT_t>;
 
    using NewC0_t =
-      typename std::conditional<isAV && TDFInternal::IsVector_t<COLL>::value, std::vector<VTColl_t>, COLL>::type;
+      typename std::conditional<isAB && TDFInternal::IsVector_t<COLL>::value, std::vector<VTColl_t>, COLL>::type;
    using NewC1_t =
-      typename std::conditional<isAV && TDFInternal::IsList_t<NewC0_t>::value, std::list<VTColl_t>, NewC0_t>::type;
+      typename std::conditional<isAB && TDFInternal::IsList_t<NewC0_t>::value, std::list<VTColl_t>, NewC0_t>::type;
    using NewC2_t =
-      typename std::conditional<isAV && TDFInternal::IsDeque_t<NewC1_t>::value, std::deque<VTColl_t>, NewC1_t>::type;
+      typename std::conditional<isAB && TDFInternal::IsDeque_t<NewC1_t>::value, std::deque<VTColl_t>, NewC1_t>::type;
    using RealColl_t = NewC2_t;
 };
 
@@ -922,7 +922,7 @@ public:
    /// \tparam COLL The type of collection used to store the values.
    /// \param[in] column The name of the column to collect the values of.
    ///
-   /// If the type of the column is std::array_view<T>, i.e. in the ROOT dataset this is
+   /// If the type of the column is TArrayBranch<T>, i.e. in the ROOT dataset this is
    /// a C-style array, the type stored in the return container is a std::vector<T> to
    /// guarantee the lifetime of the data involved.
    /// This action is *lazy*: upon invocation of this method the calculation is

--- a/tree/treeplayer/inc/ROOT/TDFUtils.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFUtils.hxx
@@ -13,7 +13,7 @@
 
 #include "ROOT/TDataSource.hxx" // ColumnName2ColumnTypeName
 #include "ROOT/TypeTraits.hxx"
-#include "ROOT/RArrayView.hxx"
+#include "ROOT/TArrayBranch.hxx"
 #include "Compression.h"
 #include "TH1.h"
 #include "TTreeReaderArray.h"
@@ -153,14 +153,14 @@ const char *ToConstCharPtr(const std::string &s);
 unsigned int GetNSlots();
 
 /// Choose between TTreeReader{Array,Value} depending on whether the branch type
-/// T is a `std::array_view<T>` or any other type (respectively).
+/// T is a `TArrayBranch<T>` or any other type (respectively).
 template <typename T>
 struct TReaderValueOrArray {
    using Proxy_t = TTreeReaderValue<T>;
 };
 
 template <typename T>
-struct TReaderValueOrArray<std::array_view<T>> {
+struct TReaderValueOrArray<TArrayBranch<T>> {
    using Proxy_t = TTreeReaderArray<T>;
 };
 
@@ -347,11 +347,11 @@ struct IsDeque_t<std::deque<T>> : std::true_type {
 };
 
 template <typename>
-struct IsArrayView_t : std::false_type {
+struct IsTArrayBranch_t : std::false_type {
 };
 
 template <typename T>
-struct IsArrayView_t<std::array_view<T>> : std::true_type {
+struct IsTArrayBranch_t<ROOT::Experimental::TDF::TArrayBranch<T>> : std::true_type {
 };
 
 // Check the value_type type of a type with a SFINAE to allow compilation in presence
@@ -363,6 +363,11 @@ struct ValueType {
 
 template <typename T>
 struct ValueType<T, false> {
+   using value_type = T;
+};
+
+template <typename T>
+struct ValueType<ROOT::Experimental::TDF::TArrayBranch<T>, false> {
    using value_type = T;
 };
 

--- a/tree/treeplayer/src/TDFInterface.cxx
+++ b/tree/treeplayer/src/TDFInterface.cxx
@@ -153,9 +153,9 @@ Long_t JitTransformation(void *thisPtr, std::string_view methodName, std::string
    for (unsigned int i = 0; i < usedBranchesTypes.size(); ++i) {
       // We pass by reference to avoid expensive copies
       // It can't be const reference in general, as users might want/need to call non-const methods on the values
-      // In the special case of arguments of type `std::array_view`, it *has* to be a const ref as we will pass in
+      // In the special case of arguments of type `TArrayBranch`, it *has* to be a const ref as we will pass in
       // temporaries converted from TTreeReaderArrays.
-      if (usedBranchesTypes[i].find_first_of("std::array_view<") == 0u)
+      if (usedBranchesTypes[i].find_first_of("ROOT::Experimental::TDF::TArrayBranch<") == 0u)
          ss << "const ";
       // Here we do not replace anything: the name of the parameters of the lambda does not need to be the real
       // column name, it must be an alias to compile.

--- a/tree/treeplayer/src/TDFUtils.cxx
+++ b/tree/treeplayer/src/TDFUtils.cxx
@@ -84,7 +84,7 @@ ColumnName2ColumnTypeName(const std::string &colName, TTree *tree, TCustomColumn
          if (title[title.size() - 3] == ']') {
             // title has the form "varname[size]/X", i.e. it refers to an array (doesn't matter if size is fixed or not)
             // TDataFrame reads it as a TArrayBranch
-            return "TArrayBranch<" + type + ">";
+            return "ROOT::Experimental::TDF::TArrayBranch<" + type + ">";
          } else {
             return type;
          }

--- a/tree/treeplayer/src/TDFUtils.cxx
+++ b/tree/treeplayer/src/TDFUtils.cxx
@@ -83,9 +83,8 @@ ColumnName2ColumnTypeName(const std::string &colName, TTree *tree, TCustomColumn
             type = "bool";
          if (title[title.size() - 3] == ']') {
             // title has the form "varname[size]/X", i.e. it refers to an array (doesn't matter if size is fixed or not)
-            // TDataFrame reads it as an array_view
-            // TODO change array_view to span when available
-            return "std::array_view<" + type + ">";
+            // TDataFrame reads it as a TArrayBranch
+            return "TArrayBranch<" + type + ">";
          } else {
             return type;
          }

--- a/tree/treeplayer/test/dataframe/dataframe_cache.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_cache.cxx
@@ -237,7 +237,7 @@ TEST(Cache, Carrays)
    }
 
    TDataFrame tdf(treeName, fileName);
-   auto cache = tdf.Cache<std::array_view<float>>({"arr"});
+   auto cache = tdf.Cache<TArrayBranch<float>>({"arr"});
    int i = 0;
    auto checkArr = [&i](std::vector<float> av) {
       auto ifloat = float(i);

--- a/tree/treeplayer/test/dataframe/dataframe_simple_tests.hxx
+++ b/tree/treeplayer/test/dataframe/dataframe_simple_tests.hxx
@@ -14,6 +14,7 @@
 #include <set>
 
 using namespace ROOT::Experimental;
+using namespace ROOT::Experimental::TDF;
 
 namespace TEST_CATEGORY {
 
@@ -358,10 +359,10 @@ TEST(TEST_CATEGORY, CArraysFromTree)
    TDataFrame df(treename, filename);
 
    // no jitting
-   auto h = df.Filter([](double b1, unsigned int n, std::array_view<double> b3,
-                         std::array_view<int> b4) { return b3[0] == b1 && b4[0] == 21 && b4.size() == n; },
+   auto h = df.Filter([](double b1, unsigned int n, TArrayBranch<double> b3,
+                         TArrayBranch<int> b4) { return b3[0] == b1 && b4[0] == 21 && b4.size() == n; },
                       {"b1", "n", "b3", "b4"})
-               .Histo1D<std::array_view<double>>("b3");
+               .Histo1D<TArrayBranch<double>>("b3");
    EXPECT_EQ(20, h->GetEntries());
 
    // jitting
@@ -391,7 +392,7 @@ TEST(TEST_CATEGORY, TakeCarrays)
 
    TDataFrame tdf(treeName, fileName);
    // no auto here: we check that the type is a COLL<vector<float>>!
-   using ColType_t = std::array_view<float>;
+   using ColType_t = TDF::TArrayBranch<float>;
    std::vector<std::vector<float>> v = *tdf.Take<ColType_t>("arr");
    std::deque<std::vector<float>> d = *tdf.Take<ColType_t, std::deque<ColType_t>>("arr");
    std::list<std::vector<float>> l = *tdf.Take<ColType_t, std::list<ColType_t>>("arr");

--- a/tree/treeplayer/test/dataframe/dataframe_snapshot.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_snapshot.cxx
@@ -182,8 +182,8 @@ TEST_F(TDFSnapshot, Snapshot_action_with_options)
 void checkSnapshotArrayFile(TInterface<TLoopManager> &df, unsigned int kNEvents)
 {
    // fixedSizeArr and varSizeArr are TResultProxy<vector<vector<T>>>
-   auto fixedSizeArr = df.Take<std::array_view<float>>("fixedSizeArr");
-   auto varSizeArr = df.Take<std::array_view<double>>("varSizeArr");
+   auto fixedSizeArr = df.Take<TArrayBranch<float>>("fixedSizeArr");
+   auto varSizeArr = df.Take<TArrayBranch<double>>("varSizeArr");
    auto size = df.Take<unsigned int>("size");
 
    // check contents of fixedSizeArr
@@ -211,8 +211,8 @@ TEST_F(TDFSnapshotArrays, SingleThread)
    TDataFrame tdf("arrayTree", kFileNames);
    // template Snapshot
    // "size" _must_ be listed before "varSizeArr"!
-   auto dt = tdf.Snapshot<std::array_view<float>, unsigned int, std::array_view<double>>(
-      "outTree", "test_snapshotarray_out.root", {"fixedSizeArr", "size", "varSizeArr"});
+   auto dt = tdf.Snapshot<TArrayBranch<float>, unsigned int, TArrayBranch<double>>(
+      "outTree", "test_snapshotTArrayBranchout.root", {"fixedSizeArr", "size", "varSizeArr"});
 
    checkSnapshotArrayFile(dt, kNEvents);
 }
@@ -222,7 +222,7 @@ TEST_F(TDFSnapshotArrays, SingleThreadJitted)
    TDataFrame tdf("arrayTree", kFileNames);
    // jitted Snapshot
    // "size" _must_ be listed before "varSizeArr"!
-   auto dj = tdf.Snapshot("outTree", "test_snapshotarray_out.root", {"fixedSizeArr", "size", "varSizeArr"});
+   auto dj = tdf.Snapshot("outTree", "test_snapshotTArrayBranchout.root", {"fixedSizeArr", "size", "varSizeArr"});
 
    checkSnapshotArrayFile(dj, kNEvents);
 }
@@ -277,8 +277,8 @@ TEST(TDFSnapshotMore, ManyTasksPerThread)
 void checkSnapshotArrayFileMT(TInterface<TLoopManager> &df, unsigned int kNEvents)
 {
    // fixedSizeArr and varSizeArr are TResultProxy<vector<vector<T>>>
-   auto fixedSizeArr = df.Take<std::array_view<float>>("fixedSizeArr");
-   auto varSizeArr = df.Take<std::array_view<double>>("varSizeArr");
+   auto fixedSizeArr = df.Take<TArrayBranch<float>>("fixedSizeArr");
+   auto varSizeArr = df.Take<TArrayBranch<double>>("varSizeArr");
    auto size = df.Take<unsigned int>("size");
 
    // multi-thread execution might have scrambled events w.r.t. the original file, so we just check overall properties
@@ -292,8 +292,8 @@ TEST_F(TDFSnapshotArrays, MultiThread)
    ROOT::EnableImplicitMT(4);
 
    TDataFrame tdf("arrayTree", kFileNames);
-   auto dt = tdf.Snapshot<std::array_view<float>, unsigned int, std::array_view<double>>(
-      "outTree", "test_snapshotarray_out.root", {"fixedSizeArr", "size", "varSizeArr"});
+   auto dt = tdf.Snapshot<TArrayBranch<float>, unsigned int, TArrayBranch<double>>(
+      "outTree", "test_snapshotTArrayBranchout.root", {"fixedSizeArr", "size", "varSizeArr"});
 
    checkSnapshotArrayFileMT(dt, kNEvents);
 
@@ -305,7 +305,7 @@ TEST_F(TDFSnapshotArrays, MultiThreadJitted)
    ROOT::EnableImplicitMT(4);
 
    TDataFrame tdf("arrayTree", kFileNames);
-   auto dj = tdf.Snapshot("outTree", "test_snapshotarray_out.root", {"fixedSizeArr", "size", "varSizeArr"});
+   auto dj = tdf.Snapshot("outTree", "test_snapshotTArrayBranchout.root", {"fixedSizeArr", "size", "varSizeArr"});
 
    checkSnapshotArrayFileMT(dj, kNEvents);
 

--- a/tree/treeplayer/test/dataframe/dataframe_utils.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_utils.cxx
@@ -111,8 +111,8 @@ TEST(TDataFrameUtils, DeduceAllPODsFromColumns)
                                                      {"Long64_t", "Long64_t"},
                                                      {"ULong64_t", "ULong64_t"},
                                                      {"bool", "bool"},
-                                                     {"arrint", "std::array_view<int>"},
-                                                     {"vararrint", "std::array_view<int>"}};
+                                                     {"arrint", "ROOT::Experimental::TDF::TArrayBranch<int>"},
+                                                     {"vararrint", "ROOT::Experimental::TDF::TArrayBranch<int>"}};
 
    for (auto &nameType : nameTypes) {
       auto typeName = ROOT::Internal::TDF::ColumnName2ColumnTypeName(nameType.first, &t, nullptr);

--- a/tutorials/dataframe/tdf101_h1Analysis.C
+++ b/tutorials/dataframe/tdf101_h1Analysis.C
@@ -9,22 +9,22 @@
 /// \author Axel Naumann
 
 auto Select = [](ROOT::Experimental::TDataFrame &dataFrame) {
-   using Farrayiew_t = std::array_view<float>;
-   using Iarrayiew_t = std::array_view<int>;
+   using Farray_t = ROOT::Experimental::TDF::TArrayBranch<float>;
+   using Iarray_t = ROOT::Experimental::TDF::TArrayBranch<int>;
 
    auto ret =
       dataFrame.Filter("TMath::Abs(md0_d - 1.8646) < 0.04")
          .Filter("ptds_d > 2.5")
          .Filter("TMath::Abs(etads_d) < 1.5")
-         .Filter([](int ik, int ipi, Iarrayiew_t nhitrp) { return nhitrp[ik - 1] * nhitrp[ipi - 1] > 1; },
+         .Filter([](int ik, int ipi, Iarray_t nhitrp) { return nhitrp[ik - 1] * nhitrp[ipi - 1] > 1; },
                  {"ik", "ipi", "nhitrp"})
-         .Filter([](int ik, Farrayiew_t rstart, Farrayiew_t rend) { return rend[ik - 1] - rstart[ik - 1] > 22; },
+         .Filter([](int ik, Farray_t rstart, Farray_t rend) { return rend[ik - 1] - rstart[ik - 1] > 22; },
                  {"ik", "rstart", "rend"})
-         .Filter([](int ipi, Farrayiew_t rstart, Farrayiew_t rend) { return rend[ipi - 1] - rstart[ipi - 1] > 22; },
+         .Filter([](int ipi, Farray_t rstart, Farray_t rend) { return rend[ipi - 1] - rstart[ipi - 1] > 22; },
                  {"ipi", "rstart", "rend"})
-         .Filter([](int ik, Farrayiew_t nlhk) { return nlhk[ik - 1] > 0.1; }, {"ik", "nlhk"})
-         .Filter([](int ipi, Farrayiew_t nlhpi) { return nlhpi[ipi - 1] > 0.1; }, {"ipi", "nlhpi"})
-         .Filter([](int ipis, Farrayiew_t nlhpi) { return nlhpi[ipis - 1] > 0.1; }, {"ipis", "nlhpi"})
+         .Filter([](int ik, Farray_t nlhk) { return nlhk[ik - 1] > 0.1; }, {"ik", "nlhk"})
+         .Filter([](int ipi, Farray_t nlhpi) { return nlhpi[ipi - 1] > 0.1; }, {"ipi", "nlhpi"})
+         .Filter([](int ipis, Farray_t nlhpi) { return nlhpi[ipis - 1] > 0.1; }, {"ipis", "nlhpi"})
          .Filter("njets >= 1");
 
    return ret;


### PR DESCRIPTION
Until now we let users use `array_view` columns to signal that they were reading c-style-array branches from a root file (and therefore we needed a `TTreeReaderArray` as a reader).
We now use our own `TArrayBranch` class for that purpose instead of embedding `array_view` with a meaning it does not have.

This is a breaking interface change.