### PR TITLE
Quote variable to avoid CMake syntax warning

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1593,6 +1593,12 @@ if (testing)
     ${_gtest_byproduct_binary_dir}/libgmock_main.a
     )
 
+  if(MSVC)
+    set(EXTRA_GTEST_OPTS
+      -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG:PATH=\\\"\\\"
+      -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE:PATH=\\\"\\\")
+  endif()
+
   ExternalProject_Add(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
@@ -1611,8 +1617,7 @@ if (testing)
                   -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                   -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
                   -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
-                  -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG:PATH=""
-                  -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE:PATH=""
+                  ${EXTRA_GTEST_OPTS}
     # Disable install step
     INSTALL_COMMAND ""
     BUILD_BYPRODUCTS ${_gtest_byproducts}


### PR DESCRIPTION
This should fix the warning below:
```
CMake Warning (dev) at
googletest-prefix/src/googletest-stamp/googletest-configure-RelWithDebInfo.cmake:3:
  Syntax Warning in cmake code at column 471

  Argument not separated from preceding token by whitespace.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

Warning introduced by f892e5e99c0e92326fd54eab059fc5a801762210.