### PR TITLE
New algorithm for autobinning: revised and cleaned

### DIFF
--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -129,6 +129,9 @@ protected:
    static Bool_t    SameLimitsAndNBins(const TAxis& axis1, const TAxis& axis2);
    Bool_t   IsEmpty() const { return fTsumw == 0 && GetEntries() == 0; } //need to use GetEntries() in case of buffer histograms
 
+   inline static Double_t AutoP2GetPower2(Double_t x, Bool_t next = kTRUE);
+   inline static Int_t AutoP2GetBins(Int_t n);
+   virtual Int_t AutoP2FindLimits(Double_t min, Double_t max);
 
    virtual Double_t DoIntegral(Int_t ix1, Int_t ix2, Int_t iy1, Int_t iy2, Int_t iz1, Int_t iz2, Double_t & err,
                                Option_t * opt, Bool_t doerr = kFALSE) const;
@@ -145,14 +148,16 @@ protected:
 public:
    // TH1 status bits
    enum EStatusBits {
-      kNoStats     = BIT(9),  ///< don't draw stats box
-      kUserContour = BIT(10), ///< user specified contour levels
-    //kCanRebin    = BIT(11), ///< FIXME DEPRECATED - to be removed, replaced by SetCanExtend / CanExtendAllAxes
-      kLogX        = BIT(15), ///< X-axis in log scale
-      kIsZoomed    = BIT(16), ///< bit set when zooming on Y axis
-      kNoTitle     = BIT(17), ///< don't draw the histogram title
-      kIsAverage   = BIT(18), ///< Bin contents are average (used by Add)
-      kIsNotW      = BIT(19)  ///< Histogram is forced to be not weighted even when the histogram is filled with weighted different than 1.
+      kNoStats     = BIT(9),   ///< don't draw stats box
+      kUserContour = BIT(10),  ///< user specified contour levels
+      // kCanRebin    = BIT(11), ///< FIXME DEPRECATED - to be removed, replaced by SetCanExtend / CanExtendAllAxes
+      kLogX        = BIT(15),  ///< X-axis in log scale
+      kIsZoomed   = BIT(16),   ///< bit set when zooming on Y axis
+      kNoTitle     = BIT(17),  ///< don't draw the histogram title
+      kIsAverage   = BIT(18),  ///< Bin contents are average (used by Add)
+      kIsNotW      = BIT(19),  ///< Histogram is forced to be not weighted even when the histogram is filled with weighted
+                               /// different than 1.
+      kAutoBinPTwo = BIT(20)   ///< Use Power(2)-based algorithm for autobinning
    };
    // size of statistics data (size of  array used in GetStats()/ PutStats )
    // s[0]  = sumw       s[1]  = sumw2

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -1235,9 +1235,8 @@ inline Double_t TH1::AutoP2GetPower2(Double_t x, Bool_t next)
 {
    Int_t nn;
    Double_t f2 = std::frexp(x, &nn);
-   return ((next && x > 0.) || (!next && x <= 0.))
-          ? std::ldexp(std::copysign(1., f2), nn)
-          : std::ldexp(std::copysign(1., f2), --nn);
+   return ((next && x > 0.) || (!next && x <= 0.)) ? std::ldexp(std::copysign(1., f2), nn)
+                                                   : std::ldexp(std::copysign(1., f2), --nn);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1249,7 +1248,8 @@ inline Int_t TH1::AutoP2GetBins(Int_t n)
 {
    Int_t nn;
    Double_t f2 = std::frexp(n, &nn);
-   if (TMath::Abs(f2 - .5) > 0.001) return (Int_t) std::ldexp(1., nn);
+   if (TMath::Abs(f2 - .5) > 0.001)
+      return (Int_t)std::ldexp(1., nn);
    return n;
 }
 
@@ -1294,23 +1294,25 @@ Int_t TH1::AutoP2FindLimits(Double_t xmi, Double_t xma)
    Int_t nb = TH1::AutoP2GetBins((Int_t)(rr * GetNbinsX()));
 
    // Adjust using the same bin width and offsets
-   Double_t bw = (xhma - xhmi) / nb ;
+   Double_t bw = (xhma - xhmi) / nb;
    // Bins to left free on each side
    Double_t autoside = gEnv->GetValue("Hist.Binning.Auto.Side", 0.05);
-   Int_t nbside = (Int_t) (nb * autoside);
+   Int_t nbside = (Int_t)(nb * autoside);
 
    // Side up
    Int_t nbup = (xhma - xma) / bw;
-   if (nbup % 2 != 0) nbup++;  // Must be even
+   if (nbup % 2 != 0)
+      nbup++; // Must be even
    if (nbup != nbside) {
       // Accounts also for both case: larger or smaller
       xhma -= bw * (nbup - nbside);
       nb -= (nbup - nbside);
    }
 
-  // Side low
+   // Side low
    Int_t nblw = (xmi - xhmi) / bw;
-   if (nblw % 2 != 0) nblw++; // Must be even
+   if (nblw % 2 != 0)
+      nblw++; // Must be even
    if (nblw != nbside) {
       // Accounts also for both case: larger or smaller
       xhmi += bw * (nblw - nbside);

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -14,9 +14,11 @@
 #include <stdio.h>
 #include <ctype.h>
 #include <sstream>
+#include <cmath>
 
 #include "Riostream.h"
 #include "TROOT.h"
+#include "TEnv.h"
 #include "TClass.h"
 #include "TMath.h"
 #include "THashList.h"
@@ -1221,6 +1223,107 @@ void TH1::AddDirectory(Bool_t add)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Auxilliary function to get the power of 2 next (larger) or previous (smaller)
+/// a given x
+///
+///    next = kTRUE  : next larger
+///    next = kFALSE : previous smaller
+///
+/// Used by the autobin power of 2 algorithm
+
+inline Double_t TH1::AutoP2GetPower2(Double_t x, Bool_t next)
+{
+   Int_t nn;
+   Double_t f2 = std::frexp(x, &nn);
+   return ((next && x > 0.) || (!next && x <= 0.))
+          ? std::ldexp(std::copysign(1., f2), nn)
+          : std::ldexp(std::copysign(1., f2), --nn);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Auxilliary function to get the next power of 2 integer value larger then n
+///
+/// Used by the autobin power of 2 algorithm
+
+inline Int_t TH1::AutoP2GetBins(Int_t n)
+{
+   Int_t nn;
+   Double_t f2 = std::frexp(n, &nn);
+   if (TMath::Abs(f2 - .5) > 0.001) return (Int_t) std::ldexp(1., nn);
+   return n;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Buffer-based estimate of the histogram range using the power of 2 algorithm.
+///
+/// Used by the autobin power of 2 algorithm.
+///
+/// Works on arguments (min and max from fBuffer) and internal inputs: fXmin,
+/// fXmax, NBinsX (from fXaxis), ...
+/// Result save internally in fXaxis.
+///
+/// Overloaded by TH2 and TH3.
+///
+/// Return -1 if internal inputs are incosistent, 0 otherwise.
+///
+
+Int_t TH1::AutoP2FindLimits(Double_t xmi, Double_t xma)
+{
+   // We need meaningful raw limits
+   if (xmi >= xma)
+      return -1;
+
+   THLimitsFinder::GetLimitsFinder()->FindGoodLimits(this, xmi, xma);
+   Double_t xhmi = fXaxis.GetXmin();
+   Double_t xhma = fXaxis.GetXmax();
+
+   // Now adjust
+   if (TMath::Abs(xhma) > TMath::Abs(xhmi)) {
+      // Start from the upper limit
+      xhma = TH1::AutoP2GetPower2(xhma);
+      xhmi = xhma - TH1::AutoP2GetPower2(xhma - xhmi);
+   } else {
+      // Start from the lower limit
+      xhmi = TH1::AutoP2GetPower2(xhmi, kFALSE);
+      xhma = xhmi + TH1::AutoP2GetPower2(xhma - xhmi);
+   }
+
+   // Round the bins to the next power of 2; take into account the possible inflation
+   // of the range
+   Double_t rr = (xhma - xhmi) / (xma - xmi);
+   Int_t nb = TH1::AutoP2GetBins((Int_t)(rr * GetNbinsX()));
+
+   // Adjust using the same bin width and offsets
+   Double_t bw = (xhma - xhmi) / nb ;
+   // Bins to left free on each side
+   Double_t autoside = gEnv->GetValue("Hist.Binning.Auto.Side", 0.05);
+   Int_t nbside = (Int_t) (nb * autoside);
+
+   // Side up
+   Int_t nbup = (xhma - xma) / bw;
+   if (nbup % 2 != 0) nbup++;  // Must be even
+   if (nbup != nbside) {
+      // Accounts also for both case: larger or smaller
+      xhma -= bw * (nbup - nbside);
+      nb -= (nbup - nbside);
+   }
+
+  // Side low
+   Int_t nblw = (xmi - xhmi) / bw;
+   if (nblw % 2 != 0) nblw++; // Must be even
+   if (nblw != nbside) {
+      // Accounts also for both case: larger or smaller
+      xhmi += bw * (nblw - nbside);
+      nb -= (nblw - nbside);
+   }
+
+   // Set everything and project
+   SetBins(nb, xhmi, xhma);
+
+   // Done
+   return 0;
+}
+
 /// Fill histogram with all entries in the buffer.
 ///
 ///  - action = -1 histogram is reset and refilled from the buffer (called by THistPainter::Paint)
@@ -1273,12 +1376,19 @@ Int_t TH1::BufferEmpty(Int_t action)
          if (x > xmax) xmax = x;
       }
       if (fXaxis.GetXmax() <= fXaxis.GetXmin()) {
-         THLimitsFinder::GetLimitsFinder()->FindGoodLimits(this,xmin,xmax);
+         Int_t rc = -1;
+         if (TestBit(TH1::kAutoBinPTwo)) {
+            if ((rc = AutoP2FindLimits(xmin, xmax)) < 0)
+               Warning("BufferEmpty",
+                       "incosistency found by power-of-2 autobin algorithm: fallback to standard method");
+         }
+         if (rc < 0)
+            THLimitsFinder::GetLimitsFinder()->FindGoodLimits(this, xmin, xmax);
       } else {
          fBuffer = 0;
          Int_t keep = fBufferSize; fBufferSize = 0;
-         if (xmin <  fXaxis.GetXmin()) ExtendAxis(xmin,&fXaxis);
-         if (xmax >= fXaxis.GetXmax()) ExtendAxis(xmax,&fXaxis);
+         if (xmin <  fXaxis.GetXmin()) ExtendAxis(xmin, &fXaxis);
+         if (xmax >= fXaxis.GetXmax()) ExtendAxis(xmax, &fXaxis);
          fBuffer = buffer;
          fBufferSize = keep;
       }
@@ -1295,8 +1405,8 @@ Int_t TH1::BufferEmpty(Int_t action)
    if (action > 0) {
       delete [] fBuffer;
       fBuffer = 0;
-      fBufferSize = 0;}
-   else {
+      fBufferSize = 0;
+   } else {
       // if number of entries is consistent with buffer - set it negative to avoid
       // refilling the histogram every time BufferEmpty(0) is called
       // In case it is not consistent, by setting fBuffer[0]=0 is like resetting the buffer

--- a/hist/hist/src/TH1Merger.cxx
+++ b/hist/hist/src/TH1Merger.cxx
@@ -9,7 +9,12 @@
 #include "THashList.h"
 #include "TClass.h"
 #include <iostream>
+#include <limits>
+#include <utility>
 
+#define PRINTRANGE(a, b, bn) \
+   Printf(" base: %f %f %d, %s: %f %f %d", a->GetXmin(), a->GetXmax(), a->GetNbins(), \
+                                       bn, b->GetXmin(), b->GetXmax(), b->GetNbins());
 
 Bool_t TH1Merger::AxesHaveLimits(const TH1 * h) {
    Bool_t hasLimits = h->GetXaxis()->GetXmin() < h->GetXaxis()->GetXmax();
@@ -37,6 +42,9 @@ Bool_t TH1Merger::operator() () {
    if (type == kAllNoLimits)
       return BufferMerge();
 
+   if (type == kAutoP2HaveLimits || (type == kAutoP2NeedLimits && AutoP2BufferMerge()))
+      return AutoP2Merge();
+
    // this is the mixed case - more complicated 
    if (type == kHasNewLimits) {
       // we need to define some new axes     
@@ -50,6 +58,144 @@ Bool_t TH1Merger::operator() () {
    }
    Error("TH1Merger","Unknown type of Merge for histogram %s",fH0->GetName());
    return kFALSE;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+/// Determine final boundaries and number of bins for histograms created in power-of-2
+/// autobin mode.
+///
+/// Return kTRUE if compatible, updating fNewXaxis accordingly; return kFALSE if something
+/// wrong.
+///
+/// The histograms are not merge-compatible if
+///
+///       1. have different variable-size bins
+///       2. larger bin size is not an integer multiple of the smaller one
+///       3. the final estimated range is smalle then the bin size
+///
+
+Bool_t TH1Merger::AutoP2BuildAxes(TH1 *h)
+{
+   // They must be both defined
+   if (!h) {
+      Error("AutoP2BuildAxes", "undefined histogram: %p", h);
+      return kFALSE;
+   }
+
+   // They must be created in power-of-2 autobin mode
+   if (!h->TestBit(TH1::kAutoBinPTwo)) {
+      Error("AutoP2BuildAxes", "not in autobin-power-of-2 mode!");
+      return kFALSE;
+   }
+
+   // Point to axes
+   TAxis *a0 = &fNewXAxis, *a1 = h->GetXaxis();
+
+   // This is for future merging of detached ranges (only possible if no over/underflows)
+   Bool_t canextend = (h->GetBinContent(0) > 0 || h->GetBinContent(a1->GetNbins() + 1) > 0) ? kFALSE : kTRUE;
+
+   // The first time we just copy the boundaries and bins
+   if (a0->GetFirst() == a0->GetLast()) {
+      a0->Set(a1->GetNbins(), a1->GetXmin(), a1->GetXmax());
+      // This is for future merging of detached ranges (only possible if no over/underflows)
+      a0->SetCanExtend(canextend);
+      return kTRUE;
+   }
+
+   // Bin sizes must be in integer ratio
+   Double_t bwmax = (a0->GetXmax() - a0->GetXmin()) / a0->GetNbins() ;
+   Double_t bwmin = (a1->GetXmax() - a1->GetXmin()) / a1->GetNbins() ;
+   Bool_t b0 = kTRUE;
+   if (bwmin > bwmax) {
+      std::swap(bwmax, bwmin);
+      b0 = kFALSE;
+   }
+   if (!(bwmin > 0.)) {
+      PRINTRANGE(a0, a1, h->GetName());
+      Error("AutoP2BuildAxes", "minimal bin width negative or null: %f", bwmin);
+      return kFALSE;
+   }
+
+   Double_t rt;
+   Double_t re = std::modf(bwmax / bwmin, &rt);
+   if (re > std::numeric_limits<Double_t>::epsilon()) {
+      PRINTRANGE(a0, a1, h->GetName());
+      Error("AutoP2BuildAxes", "bin widths not in integer ratio: %f", re);
+      return kFALSE;
+   }
+
+   // Range of the merged histogram, taking into account overlaps
+   Bool_t domax = kFALSE;
+   Double_t xmax, xmin;
+   if (a0->GetXmin() < a1->GetXmin()) {
+      if (a0->GetXmax() < a1->GetXmin()) {
+         if (!a0->CanExtend() || !canextend) {
+            PRINTRANGE(a0, a1, h->GetName());
+            Error("AutoP2BuildAxes", "ranges are disconnected and under/overflows: cannot merge");
+            return kFALSE;
+         }
+         xmax = a1->GetXmax();
+         xmin = a0->GetXmin();
+         domax = b0 ? kTRUE : kFALSE;
+      } else {
+         if (a0->GetXmax() >= a1->GetXmax()) {
+            xmax = a1->GetXmax();
+            xmin = a1->GetXmin();
+            domax = !b0 ? kTRUE : kFALSE;
+         } else {
+            xmax = a0->GetXmax();
+            xmin = a1->GetXmin();
+            domax = !b0 ? kTRUE : kFALSE;
+         }
+      }
+   } else {
+      if (a1->GetXmax() < a0->GetXmin()) {
+         if (!a0->CanExtend() || !canextend) {
+            PRINTRANGE(a0, a1, h->GetName());
+            Error("AutoP2BuildAxes", "ranges are disconnected and under/overflows: cannot merge");
+            return kFALSE;
+         }
+         xmax = a0->GetXmax();
+         xmin = a1->GetXmin();
+         domax = !b0 ? kTRUE : kFALSE;
+      } else {
+         if (a1->GetXmax() >= a0->GetXmax()) {
+            xmax = a0->GetXmax();
+            xmin = a0->GetXmin();
+            domax = b0 ? kTRUE : kFALSE;
+         } else {
+            xmax = a1->GetXmax();
+            xmin = a0->GetXmin();
+            domax = b0 ? kTRUE : kFALSE;
+         }
+      }
+   }
+   Double_t range = xmax - xmin;
+
+   re = std::modf(range / bwmax, &rt);
+   if (rt < 1.) {
+      PRINTRANGE(a0, a1, h->GetName());
+      Error("MergeCompatibleHistograms", "range smaller than bin width: %f %f %f", range, bwmax, rt);
+      return kFALSE;
+   }
+   if (re > std::numeric_limits<Double_t>::epsilon()) {
+      if (domax) {
+         xmax -= bwmax * re;
+      } else {
+         xmin += bwmax * re;
+      }
+   }
+   // Number of bins
+   Int_t nb = (Int_t)rt;
+
+   // Set the result
+   a0->Set(nb, xmin, xmax);
+
+   // This is for future merging of detached ranges (only possible if no over/underflows)
+   if (!a0->CanExtend()) a0->SetCanExtend(canextend);
+
+   // Done
+   return kTRUE;
 }
 
 /**
@@ -80,6 +226,8 @@ TH1Merger::EMergerType TH1Merger::ExamineHistograms() {
    Bool_t foundLabelHist = kFALSE;
    Bool_t haveWeights = kFALSE; 
    
+   Bool_t isAutoP2 = kFALSE;
+
    // TAxis newXAxis;
    // TAxis newYAxis;
    // TAxis newZAxis;
@@ -88,6 +236,8 @@ TH1Merger::EMergerType TH1Merger::ExamineHistograms() {
    TH1 * h = fH0;  // start with fH0
 
    int dimension = fH0->GetDimension(); 
+
+   isAutoP2 = fH0->TestBit(TH1::kAutoBinPTwo) ? kTRUE : kFALSE;
 
    // start looping on the histograms 
 
@@ -111,7 +261,16 @@ TH1Merger::EMergerType TH1Merger::ExamineHistograms() {
       allHaveLimits = allHaveLimits && hasLimits;
       allSameLimits &= allHaveLimits;
 
-      
+      if (isAutoP2 && !h->TestBit(TH1::kAutoBinPTwo)) {
+         Error("Merge", "Cannot merge histogram - some are in autobin-power-of-2 mode, but not %s!", h->GetName());
+         return kNotCompatible;
+      }
+      if (!isAutoP2 && h->TestBit(TH1::kAutoBinPTwo)) {
+         Error("Merge", "Cannot merge histogram - %s is in autobin-power-of-2 mode, but not the previous ones",
+               h->GetName());
+         return kNotCompatible;
+      }
+
       if (hasLimits) {
          h->BufferEmpty();
 
@@ -270,8 +429,16 @@ TH1Merger::EMergerType TH1Merger::ExamineHistograms() {
    }
 
    // in case of weighted histogram set Sumw2() on fH0 is is not weighted
-   if (haveWeights && fH0->GetSumw2N() == 0) fH0->Sumw2(); 
-   
+   if (haveWeights && fH0->GetSumw2N() == 0)
+      fH0->Sumw2();
+
+   // AutoP2
+   if (isAutoP2) {
+      if (allHaveLimits)
+         return kAutoP2HaveLimits;
+      return kAutoP2NeedLimits;
+   }
+
    // return the type of merge
    if (allHaveLabels) return kAllLabel;
    if (allSameLimits) return kAllSameAxes;
@@ -369,7 +536,179 @@ void TH1Merger::DefineNewAxes() {
 
 }
 
-Bool_t TH1Merger::BufferMerge() { 
+void TH1Merger::CopyBuffer(TH1 *hsrc, TH1 *hdes)
+{
+   // Check inputs
+   if (!hsrc || !hsrc->fBuffer || !hdes || !hdes->fBuffer) {
+      void *p1 = hsrc ? hsrc->fBuffer : 0;
+      void *p2 = hdes ? hdes->fBuffer : 0;
+      Warning("TH1Merger::CopyMerge", "invalid inputs: %p, %p, %p, %p -> do nothing", hsrc, hdes, p1, p2);
+   }
+
+   // Entries from buffers have to be filled one by one
+   // because FillN doesn't resize histograms.
+   Int_t nbentries = (Int_t)hsrc->fBuffer[0];
+   if (hdes->fDimension == 1) {
+      for (Int_t i = 0; i < nbentries; i++)
+         hdes->Fill(hsrc->fBuffer[2 * i + 2], hsrc->fBuffer[2 * i + 1]);
+   }
+   if (hdes->fDimension == 2) {
+      auto h2 = dynamic_cast<TH2 *>(hdes);
+      R__ASSERT(h2);
+      for (Int_t i = 0; i < nbentries; i++)
+         h2->Fill(hsrc->fBuffer[3 * i + 2], hsrc->fBuffer[3 * i + 3], hsrc->fBuffer[3 * i + 1]);
+   }
+   if (hdes->fDimension == 3) {
+      auto h3 = dynamic_cast<TH3 *>(hdes);
+      R__ASSERT(h3);
+      for (Int_t i = 0; i < nbentries; i++)
+         h3->Fill(hsrc->fBuffer[4 * i + 2], hsrc->fBuffer[4 * i + 3], hsrc->fBuffer[4 * i + 4],
+                  hsrc->fBuffer[4 * i + 1]);
+   }
+}
+
+Bool_t TH1Merger::AutoP2BufferMerge()
+{
+
+   TH1 *href = 0, *hist = 0;
+   TIter nextref(&fInputList);
+   if (TH1Merger::AxesHaveLimits(fH0)) {
+      href = fH0;
+   } else {
+      while ((hist = (TH1 *)nextref()) && !href) {
+         if (TH1Merger::AxesHaveLimits(hist))
+            href = hist;
+      }
+   }
+   Bool_t resetfH0 = kFALSE;
+   if (!href) {
+      // Merge all histograms to fH0 and do a final projection
+      href = fH0;
+   } else {
+      if (href != fH0) {
+         // Temporary add fH0 to the list for buffer merging
+         fInputList.Add(fH0);
+         resetfH0 = kTRUE;
+      }
+   }
+   TIter next(&fInputList);
+   while ((hist = (TH1 *)next())) {
+      if (!TH1Merger::AxesHaveLimits(hist) && hist->fBuffer) {
+         if (gDebug)
+            Info("AutoP2BufferMerge", "merging buffer of %s into %s", hist->GetName(), href->GetName());
+         CopyBuffer(hist, href);
+         fInputList.Remove(hist);
+      }
+   }
+   // Final projection
+   if (href->fBuffer)
+      href->BufferEmpty(1);
+   // Reset fH0, if already added, to avoid double counting
+   if (resetfH0)
+      fH0->Reset("ICES");
+   // Done, all histos have been processed
+   return kTRUE;
+}
+
+Bool_t TH1Merger::AutoP2Merge()
+{
+
+   Double_t stats[TH1::kNstat], totstats[TH1::kNstat];
+   for (Int_t i = 0; i < TH1::kNstat; i++) {
+      totstats[i] = stats[i] = 0;
+   }
+
+   TIter next(&fInputList);
+   TH1 *hist = 0;
+   // Calculate boundaries and bins
+   Double_t xmin = 0., xmax = 0.;
+   if (!(fH0->IsEmpty())) {
+      hist = fH0;
+   } else {
+      while ((hist = (TH1 *)next())) {
+         if (!hist->IsEmpty())
+            break;
+      }
+   }
+
+   if (!hist) {
+      Warning("TH1Merger::AutoP2Merge", "all histograms look empty!");
+      return kFALSE;
+   }
+
+   // Start building the axes from the reference histogram
+   if (!AutoP2BuildAxes(hist)) {
+      Error("TH1Merger::AutoP2Merge", "cannot create axes from %s", hist->GetName());
+      return kFALSE;
+   }
+   TH1 *h = 0;
+   while ((h = (TH1 *)next())) {
+      if (!AutoP2BuildAxes(h)) {
+         Error("TH1Merger::AutoP2Merge", "cannot merge histogram %s: not merge compatible", h->GetName());
+         return kFALSE;
+      }
+   }
+   xmin = fNewXAxis.GetXmin();
+   xmax = fNewXAxis.GetXmax();
+   Int_t nbins = fNewXAxis.GetNbins();
+
+   // Prepare stats
+   fH0->GetStats(totstats);
+   // Clone fH0 and add it to the list
+   if (!fH0->IsEmpty())
+      fInputList.Add(fH0->Clone());
+
+   // reset fH0
+   fH0->Reset("ICES");
+   // Set the new boundaries
+   fH0->SetBins(nbins, xmin, xmax);
+
+   next.Reset();
+   Double_t nentries = 0.;
+   while ((hist = (TH1 *)next())) {
+      // process only if the histogram has limits; otherwise it was processed before
+      // in the case of an existing buffer (see if statement just before)
+
+      if (gDebug)
+         Info("TH1Merger::AutoP2Merge", "merging histogram %s into %s (entries: %f)", hist->GetName(), fH0->GetName(),
+              hist->GetEntries());
+
+      // skip empty histograms
+      if (hist->IsEmpty())
+         continue;
+
+      // import statistics
+      hist->GetStats(stats);
+      for (Int_t i = 0; i < TH1::kNstat; i++)
+         totstats[i] += stats[i];
+      nentries += hist->GetEntries();
+
+      // Int_t nx = hist->GetXaxis()->GetNbins();
+      // loop on bins of the histogram and do the merge
+      for (Int_t ibin = 0; ibin < hist->fNcells; ibin++) {
+
+         Double_t cu = hist->RetrieveBinContent(ibin);
+         Double_t e1sq = TMath::Abs(cu);
+         if (fH0->fSumw2.fN)
+            e1sq = hist->GetBinErrorSqUnchecked(ibin);
+
+         Double_t xu = hist->GetBinCenter(ibin);
+         Int_t jbin = fH0->FindBin(xu);
+
+         fH0->AddBinContent(jbin, cu);
+         if (fH0->fSumw2.fN)
+            fH0->fSumw2.fArray[jbin] += e1sq;
+      }
+   }
+   // copy merged stats
+   fH0->PutStats(totstats);
+   fH0->SetEntries(nentries);
+
+   return kTRUE;
+}
+
+Bool_t TH1Merger::BufferMerge()
+{
 
    TIter next(&fInputList); 
    while (TH1* hist = (TH1*)next()) {
@@ -378,28 +717,7 @@ Bool_t TH1Merger::BufferMerge() {
 
          if (gDebug)
             Info("TH1Merger::BufferMerge","Merging histogram %s into %s",hist->GetName(), fH0->GetName() );
-
-
-         // case of no limits
-         // Entries from buffers have to be filled one by one
-         // because FillN doesn't resize histograms.
-         Int_t nbentries = (Int_t)hist->fBuffer[0];
-         if (fH0->fDimension  == 1) {
-            for (Int_t i = 0; i < nbentries; i++)
-               fH0->Fill(hist->fBuffer[2*i + 2], hist->fBuffer[2*i + 1]);
-         }
-         if (fH0->fDimension == 2) {
-            auto h2 = dynamic_cast<TH2*>(fH0);
-            R__ASSERT(h2);
-            for (Int_t i = 0; i < nbentries; i++)
-               h2->Fill(hist->fBuffer[3*i + 2], hist->fBuffer[3*i + 3],hist->fBuffer[3*i + 1] );
-         }
-         if (fH0->fDimension == 3) {
-            auto h3 = dynamic_cast<TH3*>(fH0);
-            R__ASSERT(h3);
-            for (Int_t i = 0; i < nbentries; i++)
-               h3->Fill(hist->fBuffer[4*i + 2], hist->fBuffer[4*i + 3],hist->fBuffer[4*i + 4], hist->fBuffer[4*i + 1] );
-         }
+         CopyBuffer(hist, fH0);
          fInputList.Remove(hist);
       }
    }

--- a/hist/hist/src/TH1Merger.cxx
+++ b/hist/hist/src/TH1Merger.cxx
@@ -103,8 +103,8 @@ Bool_t TH1Merger::AutoP2BuildAxes(TH1 *h)
    }
 
    // Bin sizes must be in integer ratio
-   Double_t bwmax = (a0->GetXmax() - a0->GetXmin()) / a0->GetNbins() ;
-   Double_t bwmin = (a1->GetXmax() - a1->GetXmin()) / a1->GetNbins() ;
+   Double_t bwmax = (a0->GetXmax() - a0->GetXmin()) / a0->GetNbins();
+   Double_t bwmin = (a1->GetXmax() - a1->GetXmin()) / a1->GetNbins();
    Bool_t b0 = kTRUE;
    if (bwmin > bwmax) {
       std::swap(bwmax, bwmin);

--- a/hist/hist/src/TH1Merger.cxx
+++ b/hist/hist/src/TH1Merger.cxx
@@ -12,9 +12,9 @@
 #include <limits>
 #include <utility>
 
-#define PRINTRANGE(a, b, bn) \
-   Printf(" base: %f %f %d, %s: %f %f %d", a->GetXmin(), a->GetXmax(), a->GetNbins(), \
-                                       bn, b->GetXmin(), b->GetXmax(), b->GetNbins());
+#define PRINTRANGE(a, b, bn)                                                                                          \
+   Printf(" base: %f %f %d, %s: %f %f %d", a->GetXmin(), a->GetXmax(), a->GetNbins(), bn, b->GetXmin(), b->GetXmax(), \
+          b->GetNbins());
 
 Bool_t TH1Merger::AxesHaveLimits(const TH1 * h) {
    Bool_t hasLimits = h->GetXaxis()->GetXmin() < h->GetXaxis()->GetXmax();
@@ -192,7 +192,8 @@ Bool_t TH1Merger::AutoP2BuildAxes(TH1 *h)
    a0->Set(nb, xmin, xmax);
 
    // This is for future merging of detached ranges (only possible if no over/underflows)
-   if (!a0->CanExtend()) a0->SetCanExtend(canextend);
+   if (!a0->CanExtend())
+      a0->SetCanExtend(canextend);
 
    // Done
    return kTRUE;

--- a/hist/hist/src/TH1Merger.h
+++ b/hist/hist/src/TH1Merger.h
@@ -23,7 +23,9 @@ public:
       kAllSameAxes = 0,   // histogram have all some axes
       kAllNoLimits  = 1,  // all histogram don't have limits (the buffer is used)
       kHasNewLimits  = 2,  // all histogram don't have limits (the buffer is used)
-      kAllLabel = 3  // histogram have labels all axis
+      kAllLabel = 3,  // histogram have labels all axis
+      kAutoP2HaveLimits = 4, // P2 (power-of-2) algorithm: all histogram have limits
+      kAutoP2NeedLimits = 5  // P2 algorithm: some histogram still need projections
    };
 
    static Bool_t AxesHaveLimits(const TH1 * h);
@@ -67,11 +69,19 @@ public:
 
 private: 
 
+   Bool_t AutoP2BuildAxes(TH1 *);
+
    EMergerType ExamineHistograms();
 
    void DefineNewAxes(); 
    
+   void CopyBuffer(TH1 *hsrc, TH1 *hdes);
+
    Bool_t BufferMerge();
+
+   Bool_t AutoP2BufferMerge();
+
+   Bool_t AutoP2Merge();
 
    Bool_t SameAxesMerge();
 

--- a/hist/hist/src/TH1Merger.h
+++ b/hist/hist/src/TH1Merger.h
@@ -16,14 +16,13 @@
 
 class TH1Merger {
 
-public: 
-
+public:
    enum EMergerType {
-      kNotCompatible = -1, // histogram arenot compatible and cannot be merged
-      kAllSameAxes = 0,   // histogram have all some axes
-      kAllNoLimits  = 1,  // all histogram don't have limits (the buffer is used)
-      kHasNewLimits  = 2,  // all histogram don't have limits (the buffer is used)
-      kAllLabel = 3,  // histogram have labels all axis
+      kNotCompatible = -1,   // histogram arenot compatible and cannot be merged
+      kAllSameAxes = 0,      // histogram have all some axes
+      kAllNoLimits = 1,      // all histogram don't have limits (the buffer is used)
+      kHasNewLimits = 2,     // all histogram don't have limits (the buffer is used)
+      kAllLabel = 3,         // histogram have labels all axis
       kAutoP2HaveLimits = 4, // P2 (power-of-2) algorithm: all histogram have limits
       kAutoP2NeedLimits = 5  // P2 algorithm: some histogram still need projections
    };
@@ -67,14 +66,13 @@ public:
    // function douing the actual merge
    Bool_t operator() ();
 
-private: 
-
+private:
    Bool_t AutoP2BuildAxes(TH1 *);
 
    EMergerType ExamineHistograms();
 
-   void DefineNewAxes(); 
-   
+   void DefineNewAxes();
+
    void CopyBuffer(TH1 *hsrc, TH1 *hdes);
 
    Bool_t BufferMerge();

--- a/tutorials/multicore/mt304_fillHistos.C
+++ b/tutorials/multicore/mt304_fillHistos.C
@@ -1,0 +1,92 @@
+/// \file
+/// \ingroup tutorial_multicore
+/// Fill histograms in parallel with automatic binning.
+/// Illustrates use of power-of-two autobin algorithm
+///
+/// \macro_code
+///
+/// \author Gerardo Ganis
+/// \date November 2017
+#include "TH1D.h"
+#include "TH2D.h"
+#include "TH3D.h"
+#include "TList.h"
+#include "TRandom3.h"
+#include "TDirectory.h"
+#include "TROOT.h"
+#include "TCanvas.h"
+#include "TString.h"
+#include "TStyle.h"
+#include "ROOT/TSeq.hxx"
+#include "ROOT/TThreadedObject.hxx"
+
+#include <thread>
+#include <iostream>
+
+
+// The number of workers
+const UInt_t nWorkers = 8U;
+
+// Reference boundaries
+const Double_t xmiref = -1.;
+const Double_t xmaref =  7.;
+
+Int_t mt304_fillHistos(UInt_t nNumbers = 1001)
+{
+
+   // The first, fundamental operation to be performed in order to make ROOT
+   // thread-aware.
+   ROOT::EnableThreadSafety();
+
+   // Histograms to be filled in parallel
+   ROOT::TThreadedObject<TH1D> h1d("h1d", "1D test histogram", 64, 0., -1.);
+   ROOT::TThreadedObject<TH1D> h1dr("h1dr", "1D test histogram w/ ref boundaries", 64, xmiref, xmaref);
+
+   // We define our work item
+   auto workItem = [&](UInt_t workerID) {
+      // One generator, file and ntuple per worker
+      TRandom3 workerRndm(workerID); // Change the seed
+
+      auto wh1d = h1d.Get();
+      wh1d->SetBit(TH1::kAutoBinPTwo);
+      auto wh1dr = h1dr.Get();
+
+      Double_t x;
+      for (UInt_t i = 0; i < nNumbers; ++i) {
+         x = workerRndm.Gaus(3.);
+         wh1d->Fill(x);
+         wh1dr->Fill(x);
+      }
+   };
+
+   // Create the collection which will hold the threads, our "pool"
+   std::vector<std::thread> workers;
+
+   // Fill the "pool" with workers
+   for (auto workerID : ROOT::TSeqI(nWorkers)) {
+      workers.emplace_back(workItem, workerID);
+   }
+
+   // Now join them
+   for (auto && worker : workers) worker.join();
+
+   // Merge
+   auto fh1d = h1d.Merge();
+   auto fh1dr = h1dr.Merge();
+
+   // Make the canvas
+   TCanvas *c = new TCanvas("c", "c", 800, 800);
+   c->Divide(1,2);
+
+   gStyle->SetOptStat(111110);
+   c->cd(1);
+   fh1d->DrawCopy();
+   c->cd(2);
+   fh1dr->DrawCopy();
+
+   c->Update();
+
+   gROOTMutex = 0;
+
+   return 0;
+}

--- a/tutorials/multicore/mt304_fillHistos.C
+++ b/tutorials/multicore/mt304_fillHistos.C
@@ -23,13 +23,12 @@
 #include <thread>
 #include <iostream>
 
-
 // The number of workers
 const UInt_t nWorkers = 8U;
 
 // Reference boundaries
 const Double_t xmiref = -1.;
-const Double_t xmaref =  7.;
+const Double_t xmaref = 7.;
 
 Int_t mt304_fillHistos(UInt_t nNumbers = 1001)
 {
@@ -68,7 +67,8 @@ Int_t mt304_fillHistos(UInt_t nNumbers = 1001)
    }
 
    // Now join them
-   for (auto && worker : workers) worker.join();
+   for (auto &&worker : workers)
+      worker.join();
 
    // Merge
    auto fh1d = h1d.Merge();
@@ -76,7 +76,7 @@ Int_t mt304_fillHistos(UInt_t nNumbers = 1001)
 
    // Make the canvas
    TCanvas *c = new TCanvas("c", "c", 800, 800);
-   c->Divide(1,2);
+   c->Divide(1, 2);
 
    gStyle->SetOptStat(111110);
    c->cd(1);

--- a/tutorials/multicore/mt305_fillHistosAutobin.C
+++ b/tutorials/multicore/mt305_fillHistosAutobin.C
@@ -1,0 +1,133 @@
+/// \file
+/// \ingroup tutorial_multicore
+/// Fill multiple histograms with different functions and automatic binning.
+/// Illustrates merging with the power-of-two autobin algorithm
+///
+/// \macro_code
+///
+/// \author Gerardo Ganis
+/// \date November 2017
+#include "TF1.h"
+#include "TH1D.h"
+#include "TMath.h"
+#include "TF1.h"
+#include "TCanvas.h"
+#include "TRandom3.h"
+#include "TStatistic.h"
+#include "TFile.h"
+#include "TStyle.h"
+
+TF1 *gam = new TF1("gam", "1/(1+0.1*x*0.1*x)", -100., 100.);
+TF1 *gam1 = new TF1("gam", "1/(1+0.1*x*0.1*x)", -1., .25);
+TF1 *iga = new TF1("inv gam", "1.-1/(1+0.1*x*0.1*x)", -100., 100.);
+TF1 *iga1 = new TF1("inv gam", "1.-1/(1+0.1*x*0.1*x)", -.5, 1.);
+
+void mt305_fillHistosAutobin(unsigned opt = 1, unsigned n = 1001)
+{
+
+   UInt_t nh = 10;
+   UInt_t bsize = 1000;
+
+   TRandom3 rndm((Long64_t)time(0));
+
+   // Standard autobinning reference
+   auto href = new TH1D("myhref", "current", 50, 0., -1.);
+   href->SetBuffer(bsize);
+
+   // New autobinning 1-histo reference
+   auto href2 = new TH1D("myhref", "Auto P2, sequential", 50, 0., -1.);
+   href2->SetBit(TH1::kAutoBinPTwo);
+   href2->SetBuffer(bsize);
+
+   TList *hlist = new TList;
+
+   Int_t nbins = 50;
+
+   TStatistic x("min"), y("max"), d("dif"), a("mean"), r("rms");
+   for (UInt_t j = 0; j < nh; ++j) {
+      Double_t xmi = 1e15, xma = -1e15;
+      TStatistic xw("work");
+      TString hname = TString::Format("myh%d", j);
+      auto hw = new TH1D(hname.Data(), "Auto P2, merged", nbins, 0., -1.);
+      hw->SetBit(TH1::kAutoBinPTwo);
+      hw->SetBuffer(bsize);
+
+      Double_t xhma, xhmi, ovf, unf;
+      Bool_t emptied = kFALSE, tofill = kTRUE;
+      Bool_t buffering = kTRUE;
+      for (UInt_t i = 0; i < n; ++i) {
+
+         Double_t xx;
+         switch (opt) {
+         case 1: xx = rndm.Gaus(3, 1); break;
+         case 2: xx = rndm.Rndm() * 100. - 50.; break;
+         case 3: xx = gam->GetRandom(); break;
+         case 4: xx = gam1->GetRandom(); break;
+         case 5: xx = iga->GetRandom(); break;
+         case 6: xx = iga1->GetRandom(); break;
+         default: xx = rndm.Gaus(0, 1);
+         }
+
+         if (buffering) {
+            if (xx > xma)
+               xma = xx;
+            if (xx < xmi)
+               xmi = xx;
+            xw.Fill(xx);
+         }
+         hw->Fill(xx);
+         href->Fill(xx);
+         href2->Fill(xx);
+         if (!hw->GetBuffer()) {
+            // Not buffering anymore
+            buffering = kFALSE;
+         }
+      }
+      x.Fill(xmi);
+      y.Fill(xma);
+      d.Fill(xma - xmi);
+      a.Fill(xw.GetMean());
+      r.Fill(xw.GetRMS());
+
+      hlist->Add(hw);
+   }
+
+   x.Print();
+   y.Print();
+   d.Print();
+   a.Print();
+   r.Print();
+
+   TH1D *h0 = (TH1D *)hlist->First();
+   hlist->Remove(h0);
+   if (!h0->Merge(hlist))
+      return;
+
+   gStyle->SetOptStat(111110);
+
+   if (gROOT->GetListOfCanvases()->FindObject("c3"))
+      delete gROOT->GetListOfCanvases()->FindObject("c3");
+   TCanvas *c3 = new TCanvas("c3", "c3", 800, 800);
+   c3->Divide(1, 3);
+   c3->cd(1);
+   h0->StatOverflows();
+   h0->DrawClone("HIST");
+
+   c3->cd(2);
+   href2->StatOverflows();
+   href2->DrawClone();
+
+   c3->cd(3);
+   href->StatOverflows();
+   href->DrawClone();
+   c3->Update();
+   std::cout << " ent: " << h0->GetEntries() << "\n";
+   h0->Print();
+   href->Print();
+
+   hlist->SetOwner(kTRUE);
+   delete hlist;
+   delete href;
+   delete href2;
+   delete h0;
+}


### PR DESCRIPTION
This is revised version of #1227.
Main change is the addition of an auto adjust mode that removes the need of a final adjust.
Still limited to the 1D case.

The test failure in  MemberComments is due to a missing update of  MemberComments.ref .
A patch for roottest is available already. 

Clang-format not applied this time.