### PR TITLE
Add new general and sequential executors.

### DIFF
--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -12,7 +12,9 @@ ROOT_GLOB_HEADERS(Base_dict_headers ${CMAKE_CURRENT_SOURCE_DIR}/inc/T*.h
                                     ${CMAKE_CURRENT_SOURCE_DIR}/inc/GuiTypes.h
                                     ${CMAKE_CURRENT_SOURCE_DIR}/inc/MessageTypes.h
                                     ${CMAKE_CURRENT_SOURCE_DIR}/inc/KeySymbols.h 
-                                    ${CMAKE_CURRENT_SOURCE_DIR}/inc/Buttons.h)
+                                    ${CMAKE_CURRENT_SOURCE_DIR}/inc/Buttons.h,
+                                    ${CMAKE_CURRENT_SOURCE_DIR}/inc/ROOT/TExecutor.hxx,
+                                    ${CMAKE_CURRENT_SOURCE_DIR}/inc/ROOT/TSequentialExecutor.hxx)
 if(root7)
     set(root7src v7/src/*.cxx)
     ROOT_GLOB_HEADERS(Base_v7_dict_headers ${CMAKE_CURRENT_SOURCE_DIR}/v7/inc/ROOT/T*.hxx)

--- a/core/base/inc/ExecutionPolicy.hxx
+++ b/core/base/inc/ExecutionPolicy.hxx
@@ -2,7 +2,7 @@
 #define ROOT_Fit_FitExecutionPolicy
 namespace ROOT {
    namespace Internal {
-      enum class ExecutionPolicy { kSerial, kMultithread, kMultiprocess };
+      enum class ExecutionPolicy { kSequential, kMultithread, kMultiprocess };
     }
 }
 

--- a/core/base/inc/ExecutionPolicy.hxx
+++ b/core/base/inc/ExecutionPolicy.hxx
@@ -1,7 +1,7 @@
 #ifndef ROOT_Fit_FitExecutionPolicy
 #define ROOT_Fit_FitExecutionPolicy
-namespace ROOT{
-   namespace Fit{
+namespace ROOT {
+   namespace Internal {
       enum class ExecutionPolicy { kSerial, kMultithread, kMultiprocess };
     }
 }

--- a/core/base/inc/ROOT/TExecutor.hxx
+++ b/core/base/inc/ROOT/TExecutor.hxx
@@ -1,5 +1,5 @@
 // @(#)root/thread:$Id$
-// Author: Xavier Valls March 2016
+// Author: Xavier Valls November 2017
 
 /*************************************************************************
  * Copyright (C) 1995-2006, Rene Brun and Fons Rademakers.               *
@@ -8,188 +8,317 @@
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
-
 #ifndef ROOT_TExecutor
 #define ROOT_TExecutor
 
-#include "ROOT/TSeq.hxx"
-#include "TList.h"
-#include <vector>
+#include "ROOT/TExecutorBaseImpl.hxx"
+#include "ROOT/TSequentialExecutor.hxx"
+#include "ROOT/TThreadExecutor.hxx"
+#include "ROOT/TProcessExecutor.hxx"
+#include "TROOT.h"
+#include "Fit/FitExecutionPolicy.h"
+#include <memory>
+#include <thread>
 
-//////////////////////////////////////////////////////////////////////////
-///
-/// \class ROOT::TExecutor
-/// \brief This class defines an interface to execute the same task
-/// multiple times in parallel, possibly with different arguments every
-/// time. The classes implementing it mimic the behaviour of python's pool.Map method. 
-///
-/// ###ROOT::TExecutor::Map
-/// The two possible usages of the Map method are:\n
-/// * Map(F func, unsigned nTimes): func is executed nTimes with no arguments
-/// * Map(F func, T& args): func is executed on each element of the collection of arguments args
-///
-/// For either signature, func is executed as many times as needed by a pool of
-/// nThreads threads; It defaults to the number of cores.\n
-/// A collection containing the result of each execution is returned.\n
-/// **Note:** the user is responsible for the deletion of any object that might
-/// be created upon execution of func, returned objects included: ROOT::TExecutor never
-/// deletes what it returns, it simply forgets it.\n
-///
-/// \param func
-/// \parblock
-/// a lambda expression, an std::function, a loaded macro, a
-/// functor class or a function that takes zero arguments (for the first signature)
-/// or one (for the second signature).
-/// \endparblock
-/// \param args
-/// \parblock
-/// a standard vector, a ROOT::TSeq of integer type or an initializer list for the second signature.
-/// An integer only for the first.\n
-/// \endparblock
-///
-/// **Note:** in cases where the function to be executed takes more than
-/// zero/one argument but all are fixed except zero/one, the function can be wrapped
-/// in a lambda or via std::bind to give it the right signature.\n
-///
-/// #### Return value:
-/// An std::vector. The elements in the container
-/// will be the objects returned by func.
 
-namespace ROOT {
+namespace ROOT{
 
-template<class subc>
-class TExecutor {
+namespace Internal{
+class TExecutor: public TExecutorBaseImpl<TExecutor> {
 public:
-   explicit TExecutor() = default;
-   explicit TExecutor(size_t /* nThreads */ ){};
 
-   template< class F, class... T>
-   using noReferenceCond = typename std::enable_if<"Function can't return a reference" && !(std::is_reference<typename std::result_of<F(T...)>::type>::value)>::type;
+   explicit TExecutor(unsigned nProcessingUnits = -1) :
+    TExecutor(ROOT::IsImplicitMTEnabled() ? ROOT::Fit::ExecutionPolicy::kMultithread :ROOT::Fit::ExecutionPolicy::kSerial, nProcessingUnits) {}
 
-   // // Map
-   // //these late return types allow for a compile-time check of compatibility between function signatures and args,
-   // //and a compile-time check that the argument list implements a front() method (all STL sequence containers have it)
+   explicit TExecutor(ROOT::Fit::ExecutionPolicy execPolicy, unsigned nProcessingUnits = -1) : fExecPolicy(execPolicy) {
+      fExecPolicy = execPolicy;
+      auto poolSize = nProcessingUnits != -1 ? nProcessingUnits: std::thread::hardware_concurrency();
+      switch(fExecPolicy) {
+        case ROOT::Fit::ExecutionPolicy::kSerial:
+           fSeqPool = std::unique_ptr<ROOT::TSequentialExecutor>(new ROOT::TSequentialExecutor());
+           break;
+#ifdef R__USE_IMT
+        case ROOT::Fit::ExecutionPolicy::kMultithread:
+           fThreadPool = std::unique_ptr<ROOT::TThreadExecutor>(new ROOT::TThreadExecutor(poolSize));
+           break;
+#endif
+        case ROOT::Fit::ExecutionPolicy::kMultiprocess:
+           fProcPool = std::unique_ptr<ROOT::TProcessExecutor>(new ROOT::TProcessExecutor(poolSize));
+           break;
+      }
+   }
+
+   TExecutor(TExecutor &) = delete;
+   TExecutor &operator=(TExecutor &) = delete;
+
+   using TExecutorBaseImpl<TExecutor>::Map;
    template<class F, class Cond = noReferenceCond<F>>
    auto Map(F func, unsigned nTimes) -> std::vector<typename std::result_of<F()>::type>;
    template<class F, class INTEGER, class Cond = noReferenceCond<F, INTEGER>>
    auto Map(F func, ROOT::TSeq<INTEGER> args) -> std::vector<typename std::result_of<F(INTEGER)>::type>;
-   /// \cond
-   template<class F, class T, class Cond = noReferenceCond<F, T>>
-   auto Map(F func, std::initializer_list<T> args) -> std::vector<typename std::result_of<F(T)>::type>;
-   /// \endcond
    template<class F, class T, class Cond = noReferenceCond<F, T>>
    auto Map(F func, std::vector<T> &args) -> std::vector<typename std::result_of<F(T)>::type>;
 
    // // MapReduce
    // // the late return types also check at compile-time whether redfunc is compatible with func,
    // // other than checking that func is compatible with the type of arguments.
-   // // a static_assert check in TExecutor<subc>::Reduce is used to check that redfunc is compatible with the type returned by func
+   // // a static_assert check in TExecutor::Reduce is used to check that redfunc is compatible with the type returned by func
+   using TExecutorBaseImpl<TExecutor>::MapReduce;
+   template<class F, class R, class Cond = noReferenceCond<F>>
+   auto MapReduce(F func, unsigned nTimes, R redfunc) -> typename std::result_of<F()>::type;
+   template<class F, class R, class Cond = noReferenceCond<F>>
+   auto MapReduce(F func, unsigned nTimes, R redfunc, unsigned nChunks) -> typename std::result_of<F()>::type;
    template<class F, class INTEGER, class R, class Cond = noReferenceCond<F, INTEGER>>
-   auto MapReduce(F func, ROOT::TSeq<INTEGER> args, R redfunc) -> typename std::result_of<F(INTEGER)>::type;
+   auto MapReduce(F func, ROOT::TSeq<INTEGER> args, R redfunc, unsigned nChunks) -> typename std::result_of<F(INTEGER)>::type;
    /// \cond
    template<class F, class T, class R, class Cond = noReferenceCond<F, T>>
-   auto MapReduce(F func, std::initializer_list<T> args, R redfunc) -> typename std::result_of<F(T)>::type;
+   auto MapReduce(F func, std::initializer_list<T> args, R redfunc, unsigned nChunks) -> typename std::result_of<F(T)>::type;
    /// \endcond
-   template<class F, class T, class Cond = noReferenceCond<F, T>>
-   T* MapReduce(F func, std::vector<T*> &args);
+   template<class F, class T, class R, class Cond = noReferenceCond<F, T>>
+   auto MapReduce(F func, std::vector<T> &args, R redfunc) -> typename std::result_of<F(T)>::type;
+   template<class F, class T, class R, class Cond = noReferenceCond<F, T>>
+   auto MapReduce(F func, std::vector<T> &args, R redfunc, unsigned nChunks) -> typename std::result_of<F(T)>::type;
 
-   template<class T> T* Reduce(const std::vector<T*> &mergeObjs);
+   using TExecutorBaseImpl<TExecutor>::Reduce;
+   template<class T, class R> auto Reduce(const std::vector<T> &objs, R redfunc) -> decltype(redfunc(objs));
+
+protected:
+   template<class F, class R, class Cond = noReferenceCond<F>>
+   auto Map(F func, unsigned nTimes, R redfunc, unsigned nChunks) -> std::vector<typename std::result_of<F()>::type>;
+   template<class F, class INTEGER, class R, class Cond = noReferenceCond<F, INTEGER>>
+   auto Map(F func, ROOT::TSeq<INTEGER> args, R redfunc, unsigned nChunks) -> std::vector<typename std::result_of<F(INTEGER)>::type>;
+   template<class F, class T, class R, class Cond = noReferenceCond<F, T>>
+   auto Map(F func, std::vector<T> &args, R redfunc, unsigned nChunks) -> std::vector<typename std::result_of<F(T)>::type>;
+   template<class F, class T, class R, class Cond = noReferenceCond<F, T>>
+   auto Map(F func, std::initializer_list<T> args, R redfunc, unsigned nChunks) -> std::vector<typename std::result_of<F(T)>::type>;
 
 private:
-  inline subc & Derived()
-  {
-    return *static_cast<subc*>(this);
-  }
+    ROOT::Fit::ExecutionPolicy fExecPolicy;
+#ifdef R__USE_IMT
+    std::unique_ptr<ROOT::TThreadExecutor> fThreadPool;
+#endif
+    std::unique_ptr<ROOT::TProcessExecutor> fProcPool;
+    std::unique_ptr<ROOT::TSequentialExecutor> fSeqPool;
 };
 
-//////////////////////////////////////////////////////////////////////////
-/// Execute func (with no arguments) nTimes in parallel.
-/// A vector containg executions' results is returned.
-/// Functions that take more than zero arguments can be executed (with
-/// fixed arguments) by wrapping them in a lambda or with std::bind.
-template<class subc> template<class F, class Cond>
-auto TExecutor<subc>::Map(F func, unsigned nTimes) -> std::vector<typename std::result_of<F()>::type>
-{
-   return Derived().Map(func, nTimes);
-}
 
 //////////////////////////////////////////////////////////////////////////
-/// Execute func in parallel, taking an element of a
-/// sequence as argument. Divides and groups the executions in nChunks with partial reduction;
-/// A vector containg partial reductions' results is returned.
-template<class subc> template<class F, class INTEGER, class Cond>
-auto TExecutor<subc>::Map(F func, ROOT::TSeq<INTEGER> args) -> std::vector<typename std::result_of<F(INTEGER)>::type>
-{
-  return Derived().Map(func, args);
+   /// Execute func (with no arguments) nTimes in parallel.
+   /// A vector containg executions' results is returned.
+   /// Functions that take more than zero arguments can be executed (with
+   /// fixed arguments) by wrapping them in a lambda or with std::bind.
+   template<class F, class Cond>
+   auto TExecutor::Map(F func, unsigned nTimes) -> std::vector<typename std::result_of<F()>::type> {
+      using retType = decltype(func());
+      std::vector<retType> res;;
+      switch(fExecPolicy){
+         case ROOT::Fit::ExecutionPolicy::kSerial:
+            res = fSeqPool->Map(func, nTimes);
+            break;
+#ifdef R__USE_IMT
+         case ROOT::Fit::ExecutionPolicy::kMultithread:
+            res = fThreadPool->Map(func, nTimes);
+            break;
+#endif
+         case ROOT::Fit::ExecutionPolicy::kMultiprocess:
+            res = fProcPool->Map(func, nTimes);
+            break;
+      }
+      return res;
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+   /// Execute func in parallel, taking an element of a
+   /// sequence as argument.
+   /// A vector containg executions' results is returned.
+   template<class F, class INTEGER, class Cond>
+   auto TExecutor::Map(F func, ROOT::TSeq<INTEGER> args) -> std::vector<typename std::result_of<F(INTEGER)>::type> {
+      using retType = decltype(func(args.front()));
+      std::vector<retType> res;
+
+      switch(fExecPolicy){
+         case ROOT::Fit::ExecutionPolicy::kSerial:
+            res = fSeqPool->Map(func, args);
+            break;
+#ifdef R__USE_IMT
+         case ROOT::Fit::ExecutionPolicy::kMultithread:
+            res = fThreadPool->Map(func, args);
+            break;
+#endif
+         case ROOT::Fit::ExecutionPolicy::kMultiprocess:
+            res = fProcPool->Map(func, args);
+            break;
+      }
+      return res;
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+   /// Execute func (with no arguments) nTimes in parallel.
+   /// Divides and groups the executions in nChunks (if it doesn't make sense will reduce the number of chunks) with partial reduction;
+   /// A vector containg partial reductions' results is returned.
+   template<class F, class R, class Cond>
+   auto TExecutor::Map(F func, unsigned nTimes, R redfunc, unsigned nChunks) -> std::vector<typename std::result_of<F()>::type> {
+      using retType = decltype(func());
+      std::vector<retType> res;;
+      switch(fExecPolicy){
+        case ROOT::Fit::ExecutionPolicy::kSerial:
+            //arbitrary value for the number of chunks so the returned vector is not big
+            res = fSeqPool->Map(func, nTimes, redfunc, 3);
+            break;
+  #ifdef R__USE_IMT
+        case ROOT::Fit::ExecutionPolicy::kMultithread:
+            res = fThreadPool->Map(func, nTimes, redfunc, nChunks);
+            break;
+  #endif
+        case ROOT::Fit::ExecutionPolicy::kMultiprocess:
+            res = fProcPool->Map(func, nTimes, redfunc, nChunks);
+            break;
+      }
+      return res;
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+   /// Execute func in parallel, taking an element of an
+   /// std::vector as argument.
+   /// A vector containg executions' results is returned.
+   // actual implementation of the Map method. all other calls with arguments eventually
+   // call this one
+   template<class F, class T, class Cond>
+   auto TExecutor::Map(F func, std::vector<T> &args) -> std::vector<typename std::result_of<F(T)>::type> {
+      // //check whether func is callable
+      using retType = decltype(func(args.front()));
+      std::vector<retType> res;;
+      switch(fExecPolicy){
+         case ROOT::Fit::ExecutionPolicy::kSerial:
+            res = fSeqPool->Map(func, args);
+            break;
+#ifdef R__USE_IMT
+         case ROOT::Fit::ExecutionPolicy::kMultithread:
+            res = fThreadPool->Map(func, args);
+            break;
+#endif
+         case ROOT::Fit::ExecutionPolicy::kMultiprocess:
+            res = fProcPool->Map(func, args);
+            break;
+      }
+      return res;
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+   /// Execute func in parallel, taking an element of a
+   /// sequence as argument.
+   /// Divides and groups the executions in nChunks (if it doesn't make sense will reduce the number of chunks) with partial reduction\n
+   /// A vector containg partial reductions' results is returned.
+   template<class F, class INTEGER, class R, class Cond>
+   auto TExecutor::Map(F func, ROOT::TSeq<INTEGER> args, R redfunc, unsigned nChunks) -> std::vector<typename std::result_of<F(INTEGER)>::type> {
+    using retType = decltype(func(args.front()));
+    std::vector<retType> res;;
+    switch(fExecPolicy){
+       case ROOT::Fit::ExecutionPolicy::kSerial:
+          //arbitrary value for the number of chunks so the returned vector is not big
+          res = fSeqPool->Map(func, args, redfunc, 3);
+          break;
+#ifdef R__USE_IMT
+       case ROOT::Fit::ExecutionPolicy::kMultithread:
+          res = fThreadPool->Map(func, args, redfunc, nChunks);
+          break;
+#endif
+       case ROOT::Fit::ExecutionPolicy::kMultiprocess:
+          res = fProcPool->Map(func, args, redfunc, nChunks);
+          break;
+    }
+    return res;
+   }
+
+/// \cond
+    //////////////////////////////////////////////////////////////////////////
+   /// Execute func in parallel, taking an element of an
+   /// std::vector as argument. Divides and groups the executions in nChunks with partial reduction.
+   /// If it doesn't make sense will reduce the number of chunks.\n
+   /// A vector containg partial reductions' results is returned.
+   template<class F, class T, class R, class Cond>
+   auto TExecutor::Map(F func, std::vector<T> &args, R redfunc, unsigned nChunks) -> std::vector<typename std::result_of<F(T)>::type> {
+      using retType = decltype(func(args.front()));
+      std::vector<retType> res;;
+      switch(fExecPolicy){
+        case ROOT::Fit::ExecutionPolicy::kSerial:
+            //arbitrary value for the number of chunks so the returned vector is not big
+            res = fSeqPool->Map(func, args, redfunc, 3);
+            break;
+#ifdef R__USE_IMT
+        case ROOT::Fit::ExecutionPolicy::kMultithread:
+            res = fThreadPool->Map(func, args, redfunc, nChunks);
+            break;
+#endif
+        case ROOT::Fit::ExecutionPolicy::kMultiprocess:
+            res = fProcPool->Map(func, args, redfunc, nChunks);
+            break;
+      }
+      return res;
+   }
+
+    //////////////////////////////////////////////////////////////////////////
+   /// Execute func in parallel, taking an element of an
+   /// std::initializer_list as an argument. Divides and groups the executions in nChunks with partial reduction.
+   /// If it doesn't make sense will reduce the number of chunks.\n
+   /// A vector containg partial reductions' results is returned.
+   template<class F, class T, class R, class Cond>
+   auto TExecutor::Map(F func, std::initializer_list<T> args, R redfunc, unsigned nChunks) -> std::vector<typename std::result_of<F(T)>::type> {
+      std::vector<T> vargs(std::move(args));
+      const auto &reslist = Map(func, vargs, redfunc, nChunks);
+      return reslist;
+   }
+/// \endcond
+
+
+   //////////////////////////////////////////////////////////////////////////
+   /// This method behaves just like Map, but an additional redfunc function
+   /// must be provided. redfunc is applied to the vector Map would return and
+   /// must return the same type as func. In practice, redfunc can be used to
+   /// "squash" the vector returned by Map into a single object by merging,
+   /// adding, mixing the elements of the vector.\n
+   /// The fourth argument indicates the number of chunks we want to divide our work in.
+   template<class F, class R, class Cond>
+   auto TExecutor::MapReduce(F func, unsigned nTimes, R redfunc) -> typename std::result_of<F()>::type {
+      return Reduce(Map(func, nTimes), redfunc);
+   }
+
+   template<class F, class R, class Cond>
+   auto TExecutor::MapReduce(F func, unsigned nTimes, R redfunc, unsigned nChunks) -> typename std::result_of<F()>::type {
+      return Reduce(Map(func, nTimes, redfunc, nChunks), redfunc);
+   }
+
+   template<class F, class INTEGER, class R, class Cond>
+   auto TExecutor::MapReduce(F func, ROOT::TSeq<INTEGER> args, R redfunc, unsigned nChunks) -> typename std::result_of<F(INTEGER)>::type {
+      return Reduce(Map(func, args, redfunc, nChunks), redfunc);
+   }
+   /// \cond
+   template<class F, class T, class R, class Cond>
+   auto TExecutor::MapReduce(F func, std::initializer_list<T> args, R redfunc, unsigned nChunks) -> typename std::result_of<F(T)>::type {
+      return Reduce(Map(func, args, redfunc, nChunks), redfunc);
+   }
+   /// \endcond
+
+   template<class F, class T, class R, class Cond>
+   auto TExecutor::MapReduce(F func, std::vector<T> &args, R redfunc) -> typename std::result_of<F(T)>::type {
+      return Reduce(Map(func, args), redfunc);
+   }
+
+   template<class F, class T, class R, class Cond>
+   auto TExecutor::MapReduce(F func, std::vector<T> &args, R redfunc, unsigned nChunks) -> typename std::result_of<F(T)>::type {
+      return Reduce(Map(func, args, redfunc, nChunks), redfunc);
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+   /// "Reduce" an std::vector into a single object by passing a
+   /// function as the second argument defining the reduction operation.
+   template<class T, class R>
+   auto TExecutor::Reduce(const std::vector<T> &objs, R redfunc) -> decltype(redfunc(objs))
+   {
+      // check we can apply reduce to objs
+      static_assert(std::is_same<decltype(redfunc(objs)), T>::value, "redfunc does not have the correct signature");
+      return redfunc(objs);
+   }
 }
-
-//////////////////////////////////////////////////////////////////////////
-/// Execute func in parallel, taking an element of the std::initializer_list
-/// as argument. Divides and groups the executions in nChunks with partial reduction;
-/// A vector containg partial reductions' results is returned.
-template<class subc> template<class F, class T, class Cond>
-auto TExecutor<subc>::Map(F func, std::initializer_list<T> args) -> std::vector<typename std::result_of<F(T)>::type>
-{
-   std::vector<T> vargs(std::move(args));
-   const auto &reslist = Map(func, vargs);
-   return reslist;
 }
-
-//////////////////////////////////////////////////////////////////////////
-/// Execute func in parallel, taking an element of an
-/// std::vector as argument.
-/// A vector containg executions' results is returned.
-// actual implementation of the Map method. all other calls with arguments eventually
-// call this one
-template<class subc> template<class F, class T, class Cond>
-auto TExecutor<subc>::Map(F func, std::vector<T> &args) -> std::vector<typename std::result_of<F(T)>::type>
-{
-   return Derived().Map(func, args);
-}
-
-//////////////////////////////////////////////////////////////////////////
-/// This method behaves just like Map, but an additional redfunc function
-/// must be provided. redfunc is applied to the vector Map would return and
-/// must return the same type as func. In practice, redfunc can be used to
-/// "squash" the vector returned by Map into a single object by merging,
-/// adding, mixing the elements of the vector.
-template<class subc> template<class F, class INTEGER, class R, class Cond>
-auto TExecutor<subc>::MapReduce(F func, ROOT::TSeq<INTEGER> args, R redfunc) -> typename std::result_of<F(INTEGER)>::type
-{
-  std::vector<INTEGER> vargs(args.size());
-  std::copy(args.begin(), args.end(), vargs.begin());
-  return Derived().MapReduce(func, vargs, redfunc);
-}
-
-template<class subc> template<class F, class T, class R, class Cond>
-auto TExecutor<subc>::MapReduce(F func, std::initializer_list<T> args, R redfunc) -> typename std::result_of<F(T)>::type
-{
-   std::vector<T> vargs(std::move(args));
-   return Derived().MapReduce(func, vargs, redfunc);
-}
-
-template<class subc> template<class F, class T, class Cond>
-T* TExecutor<subc>::MapReduce(F func, std::vector<T*> &args)
-{
-   return Derived().Reduce(Map(func, args));
-}
-
-//////////////////////////////////////////////////////////////////////////
-/// "Reduce" an std::vector into a single object by using the object's Merge
-//Reduction for objects with the Merge() method
-template<class subc> template<class T>
-T* TExecutor<subc>::Reduce(const std::vector<T*> &mergeObjs)
-{
-   TList l;
-  for(unsigned i =1; i<mergeObjs.size(); i++){
-    l.Add(mergeObjs[i]);
-  }
-  // use clone to return a new object 
-  auto retHist = dynamic_cast<T*>((mergeObjs.front())->Clone());
-  if (retHist) retHist->Merge(&l);
-  return retHist;
-}
-
-} // end namespace ROOT
-
 #endif

--- a/core/base/inc/ROOT/TExecutor.hxx
+++ b/core/base/inc/ROOT/TExecutor.hxx
@@ -28,13 +28,13 @@ class TExecutor: public TExecutorBaseImpl<TExecutor> {
 public:
 
    explicit TExecutor(unsigned nProcessingUnits = -1) :
-    TExecutor(ROOT::IsImplicitMTEnabled() ? ROOT::Internal::ExecutionPolicy::kMultithread :ROOT::Internal::ExecutionPolicy::kSerial, nProcessingUnits) {}
+    TExecutor(ROOT::IsImplicitMTEnabled() ? ROOT::Internal::ExecutionPolicy::kMultithread :ROOT::Internal::ExecutionPolicy::kSequential, nProcessingUnits) {}
 
    explicit TExecutor(ROOT::Internal::ExecutionPolicy execPolicy, unsigned nProcessingUnits = -1) : fExecPolicy(execPolicy) {
       fExecPolicy = execPolicy;
       auto poolSize = nProcessingUnits != -1 ? nProcessingUnits: std::thread::hardware_concurrency();
       switch(fExecPolicy) {
-        case ROOT::Internal::ExecutionPolicy::kSerial:
+        case ROOT::Internal::ExecutionPolicy::kSequential:
            fSeqPool = std::unique_ptr<ROOT::TSequentialExecutor>(new ROOT::TSequentialExecutor());
            break;
 #ifdef R__USE_IMT
@@ -112,7 +112,7 @@ private:
       using retType = decltype(func());
       std::vector<retType> res;;
       switch(fExecPolicy){
-         case ROOT::Internal::ExecutionPolicy::kSerial:
+         case ROOT::Internal::ExecutionPolicy::kSequential:
             res = fSeqPool->Map(func, nTimes);
             break;
 #ifdef R__USE_IMT
@@ -137,7 +137,7 @@ private:
       std::vector<retType> res;
 
       switch(fExecPolicy){
-         case ROOT::Internal::ExecutionPolicy::kSerial:
+         case ROOT::Internal::ExecutionPolicy::kSequential:
             res = fSeqPool->Map(func, args);
             break;
 #ifdef R__USE_IMT
@@ -161,7 +161,7 @@ private:
       using retType = decltype(func());
       std::vector<retType> res;;
       switch(fExecPolicy){
-        case ROOT::Internal::ExecutionPolicy::kSerial:
+        case ROOT::Internal::ExecutionPolicy::kSequential:
             //arbitrary value for the number of chunks so the returned vector is not big
             res = fSeqPool->Map(func, nTimes, redfunc, 3);
             break;
@@ -189,7 +189,7 @@ private:
       using retType = decltype(func(args.front()));
       std::vector<retType> res;;
       switch(fExecPolicy){
-         case ROOT::Internal::ExecutionPolicy::kSerial:
+         case ROOT::Internal::ExecutionPolicy::kSequential:
             res = fSeqPool->Map(func, args);
             break;
 #ifdef R__USE_IMT
@@ -214,7 +214,7 @@ private:
     using retType = decltype(func(args.front()));
     std::vector<retType> res;;
     switch(fExecPolicy){
-       case ROOT::Internal::ExecutionPolicy::kSerial:
+       case ROOT::Internal::ExecutionPolicy::kSequential:
           //arbitrary value for the number of chunks so the returned vector is not big
           res = fSeqPool->Map(func, args, redfunc, 3);
           break;
@@ -241,7 +241,7 @@ private:
       using retType = decltype(func(args.front()));
       std::vector<retType> res;;
       switch(fExecPolicy){
-        case ROOT::Internal::ExecutionPolicy::kSerial:
+        case ROOT::Internal::ExecutionPolicy::kSequential:
             //arbitrary value for the number of chunks so the returned vector is not big
             res = fSeqPool->Map(func, args, redfunc, 3);
             break;

--- a/core/base/inc/ROOT/TExecutorBaseImpl.hxx
+++ b/core/base/inc/ROOT/TExecutorBaseImpl.hxx
@@ -21,7 +21,7 @@
 /// \class ROOT::TExecutorBaseImpl
 /// \brief This class defines an interface to execute the same task
 /// multiple times in parallel, possibly with different arguments every
-/// time. The classes implementing it mimic the behaviour of python's pool.Map method. 
+/// time. The classes implementing it mimic the behaviour of python's pool.Map method.
 ///
 /// ###ROOT::TExecutorBaseImpl::Map
 /// The two possible usages of the Map method are:\n
@@ -184,10 +184,10 @@ T* TExecutorBaseImpl<subc>::Reduce(const std::vector<T*> &mergeObjs)
   for(unsigned i =1; i<mergeObjs.size(); i++){
     l.Add(mergeObjs[i]);
   }
-  // use clone to return a new object 
+  // use clone to return a new object
   auto retHist = dynamic_cast<T*>((mergeObjs.front())->Clone());
   if (retHist) retHist->Merge(&l);
-  return retHist; 
+  return retHist;
 }
 
 } // end namespace ROOT

--- a/core/base/inc/ROOT/TExecutorBaseImpl.hxx
+++ b/core/base/inc/ROOT/TExecutorBaseImpl.hxx
@@ -1,0 +1,194 @@
+// @(#)root/core/base:$Id$
+// Author: Xavier Valls March 2016
+
+/*************************************************************************
+ * Copyright (C) 1995-2006, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+ #ifndef ROOT_TExecutorBaseImpl
+#define ROOT_TExecutorBaseImpl
+
+#include "ROOT/TSeq.hxx"
+#include "TList.h"
+#include <vector>
+
+//////////////////////////////////////////////////////////////////////////
+///
+/// \class ROOT::TExecutorBaseImpl
+/// \brief This class defines an interface to execute the same task
+/// multiple times in parallel, possibly with different arguments every
+/// time. The classes implementing it mimic the behaviour of python's pool.Map method. 
+///
+/// ###ROOT::TExecutorBaseImpl::Map
+/// The two possible usages of the Map method are:\n
+/// * Map(F func, unsigned nTimes): func is executed nTimes with no arguments
+/// * Map(F func, T& args): func is executed on each element of the collection of arguments args
+///
+/// For either signature, func is executed as many times as needed by a pool of
+/// nThreads threads; It defaults to the number of cores.\n
+/// A collection containing the result of each execution is returned.\n
+/// **Note:** the user is responsible for the deletion of any object that might
+/// be created upon execution of func, returned objects included: ROOT::TExecutorBaseImpl never
+/// deletes what it returns, it simply forgets it.\n
+///
+/// \param func
+/// \parblock
+/// a lambda expression, an std::function, a loaded macro, a
+/// functor class or a function that takes zero arguments (for the first signature)
+/// or one (for the second signature).
+/// \endparblock
+/// \param args
+/// \parblock
+/// a standard vector, a ROOT::TSeq of integer type or an initializer list for the second signature.
+/// An integer only for the first.\n
+/// \endparblock
+///
+/// **Note:** in cases where the function to be executed takes more than
+/// zero/one argument but all are fixed except zero/one, the function can be wrapped
+/// in a lambda or via std::bind to give it the right signature.\n
+///
+/// #### Return value:
+/// An std::vector. The elements in the container
+/// will be the objects returned by func.
+
+namespace ROOT {
+
+template<class subc>
+class TExecutorBaseImpl {
+public:
+   explicit TExecutorBaseImpl() = default;
+   explicit TExecutorBaseImpl(size_t /* nThreads */ ){};
+
+   template< class F, class... T>
+   using noReferenceCond = typename std::enable_if<"Function can't return a reference" && !(std::is_reference<typename std::result_of<F(T...)>::type>::value)>::type;
+
+   // // Map
+   // //these late return types allow for a compile-time check of compatibility between function signatures and args,
+   // //and a compile-time check that the argument list implements a front() method (all STL sequence containers have it)
+   template<class F, class Cond = noReferenceCond<F>>
+   auto Map(F func, unsigned nTimes) -> std::vector<typename std::result_of<F()>::type>;
+   template<class F, class INTEGER, class Cond = noReferenceCond<F, INTEGER>>
+   auto Map(F func, ROOT::TSeq<INTEGER> args) -> std::vector<typename std::result_of<F(INTEGER)>::type>;
+   /// \cond
+   template<class F, class T, class Cond = noReferenceCond<F, T>>
+   auto Map(F func, std::initializer_list<T> args) -> std::vector<typename std::result_of<F(T)>::type>;
+   /// \endcond
+   template<class F, class T, class Cond = noReferenceCond<F, T>>
+   auto Map(F func, std::vector<T> &args) -> std::vector<typename std::result_of<F(T)>::type>;
+
+   // // MapReduce
+   // // the late return types also check at compile-time whether redfunc is compatible with func,
+   // // other than checking that func is compatible with the type of arguments.
+   // // a static_assert check in TExecutorBaseImpl<subc>::Reduce is used to check that redfunc is compatible with the type returned by func
+   template<class F, class INTEGER, class R, class Cond = noReferenceCond<F, INTEGER>>
+   auto MapReduce(F func, ROOT::TSeq<INTEGER> args, R redfunc) -> typename std::result_of<F(INTEGER)>::type;
+   /// \cond
+   template<class F, class T, class R, class Cond = noReferenceCond<F, T>>
+   auto MapReduce(F func, std::initializer_list<T> args, R redfunc) -> typename std::result_of<F(T)>::type;
+   /// \endcond
+   template<class F, class T, class Cond = noReferenceCond<F, T>>
+   T* MapReduce(F func, std::vector<T*> &args);
+
+   template<class T> T* Reduce(const std::vector<T*> &mergeObjs);
+
+private:
+  inline subc & Derived()
+  {
+    return *static_cast<subc*>(this);
+  }
+};
+
+//////////////////////////////////////////////////////////////////////////
+/// Execute func (with no arguments) nTimes in parallel.
+/// A vector containg executions' results is returned.
+/// Functions that take more than zero arguments can be executed (with
+/// fixed arguments) by wrapping them in a lambda or with std::bind.
+template<class subc> template<class F, class Cond>
+auto TExecutorBaseImpl<subc>::Map(F func, unsigned nTimes) -> std::vector<typename std::result_of<F()>::type>
+{
+   return Derived().Map(func, nTimes);
+}
+
+//////////////////////////////////////////////////////////////////////////
+/// Execute func in parallel, taking an element of a
+/// sequence as argument. Divides and groups the executions in nChunks with partial reduction;
+/// A vector containg partial reductions' results is returned.
+template<class subc> template<class F, class INTEGER, class Cond>
+auto TExecutorBaseImpl<subc>::Map(F func, ROOT::TSeq<INTEGER> args) -> std::vector<typename std::result_of<F(INTEGER)>::type>
+{
+  return Derived().Map(func, args);
+}
+
+//////////////////////////////////////////////////////////////////////////
+/// Execute func in parallel, taking an element of the std::initializer_list
+/// as argument. Divides and groups the executions in nChunks with partial reduction;
+/// A vector containg partial reductions' results is returned.
+template<class subc> template<class F, class T, class Cond>
+auto TExecutorBaseImpl<subc>::Map(F func, std::initializer_list<T> args) -> std::vector<typename std::result_of<F(T)>::type>
+{
+   std::vector<T> vargs(std::move(args));
+   const auto &reslist = Map(func, vargs);
+   return reslist;
+}
+
+//////////////////////////////////////////////////////////////////////////
+/// Execute func in parallel, taking an element of an
+/// std::vector as argument.
+/// A vector containg executions' results is returned.
+// actual implementation of the Map method. all other calls with arguments eventually
+// call this one
+template<class subc> template<class F, class T, class Cond>
+auto TExecutorBaseImpl<subc>::Map(F func, std::vector<T> &args) -> std::vector<typename std::result_of<F(T)>::type>
+{
+   return Derived().Map(func, args);
+}
+
+//////////////////////////////////////////////////////////////////////////
+/// This method behaves just like Map, but an additional redfunc function
+/// must be provided. redfunc is applied to the vector Map would return and
+/// must return the same type as func. In practice, redfunc can be used to
+/// "squash" the vector returned by Map into a single object by merging,
+/// adding, mixing the elements of the vector.
+template<class subc> template<class F, class INTEGER, class R, class Cond>
+auto TExecutorBaseImpl<subc>::MapReduce(F func, ROOT::TSeq<INTEGER> args, R redfunc) -> typename std::result_of<F(INTEGER)>::type
+{
+  std::vector<INTEGER> vargs(args.size());
+  std::copy(args.begin(), args.end(), vargs.begin());
+  return Derived().MapReduce(func, vargs, redfunc);
+}
+
+template<class subc> template<class F, class T, class R, class Cond>
+auto TExecutorBaseImpl<subc>::MapReduce(F func, std::initializer_list<T> args, R redfunc) -> typename std::result_of<F(T)>::type
+{
+   std::vector<T> vargs(std::move(args));
+   return Derived().MapReduce(func, vargs, redfunc);
+}
+
+template<class subc> template<class F, class T, class Cond>
+T* TExecutorBaseImpl<subc>::MapReduce(F func, std::vector<T*> &args)
+{
+   return Derived().Reduce(Map(func, args));
+}
+
+//////////////////////////////////////////////////////////////////////////
+/// "Reduce" an std::vector into a single object by using the object's Merge
+//Reduction for objects with the Merge() method
+template<class subc> template<class T>
+T* TExecutorBaseImpl<subc>::Reduce(const std::vector<T*> &mergeObjs)
+{
+   TList l;
+  for(unsigned i =1; i<mergeObjs.size(); i++){
+    l.Add(mergeObjs[i]);
+  }
+  // use clone to return a new object 
+  auto retHist = dynamic_cast<T*>((mergeObjs.front())->Clone());
+  if (retHist) retHist->Merge(&l);
+  return retHist; 
+}
+
+} // end namespace ROOT
+#endif

--- a/core/base/inc/ROOT/TSequentialExecutor.hxx
+++ b/core/base/inc/ROOT/TSequentialExecutor.hxx
@@ -67,7 +67,7 @@ namespace ROOT {
    /// fixed arguments) by wrapping them in a lambda or with std::bind.
    template<class F>
    void TSequentialExecutor::Foreach(F func, unsigned nTimes) {
-       for(auto i: ROOT::TSeqI(nTimes)) func();
+       for(auto i = 0u; i < nTimes; i++) func();
    }
 
    //////////////////////////////////////////////////////////////////////////

--- a/core/base/inc/ROOT/TSequentialExecutor.hxx
+++ b/core/base/inc/ROOT/TSequentialExecutor.hxx
@@ -1,0 +1,164 @@
+// @(#)root/thread:$Id$
+// Author: Xavier Valls November 2017
+
+/*************************************************************************
+ * Copyright (C) 1995-2006, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+#ifndef ROOT_TSequentialExecutor
+#define ROOT_TSequentialExecutor
+
+#include "RConfigure.h"
+
+#include "ROOT/TExecutorBaseImpl.hxx"
+#include <numeric>
+#include <vector>
+
+namespace ROOT {
+
+   class TSequentialExecutor: public TExecutorBaseImpl<TSequentialExecutor> {
+   public:
+      explicit TSequentialExecutor(){};
+
+      TSequentialExecutor(TSequentialExecutor &) = delete;
+      TSequentialExecutor &operator=(TSequentialExecutor &) = delete;
+
+      template<class F>
+      void Foreach(F func, unsigned nTimes);
+      template<class F, class INTEGER>
+      void Foreach(F func, ROOT::TSeq<INTEGER> args);
+      /// \cond
+      template<class F, class T>
+      void Foreach(F func, std::initializer_list<T> args);
+      /// \endcond
+      template<class F, class T>
+      void Foreach(F func, std::vector<T> &args);
+
+      using TExecutorBaseImpl<TSequentialExecutor>::Map;
+      template<class F, class Cond = noReferenceCond<F>>
+      auto Map(F func, unsigned nTimes) -> std::vector<typename std::result_of<F()>::type>;
+      template<class F, class INTEGER, class Cond = noReferenceCond<F, INTEGER>>
+      auto Map(F func, ROOT::TSeq<INTEGER> args) -> std::vector<typename std::result_of<F(INTEGER)>::type>;
+      template<class F, class T, class Cond = noReferenceCond<F, T>>
+      auto Map(F func, std::vector<T> &args) -> std::vector<typename std::result_of<F(T)>::type>;
+
+      // // MapReduce
+      // // the late return types also check at compile-time whether redfunc is compatible with func,
+      // // other than checking that func is compatible with the type of arguments.
+      // // a static_assert check in TSequentialExecutor::Reduce is used to check that redfunc is compatible with the type returned by func
+      using TExecutorBaseImpl<TSequentialExecutor>::MapReduce;
+      template<class F, class R, class Cond = noReferenceCond<F>>
+      auto MapReduce(F func, unsigned nTimes, R redfunc) -> typename std::result_of<F()>::type;
+      template<class F, class T, class R, class Cond = noReferenceCond<F, T>>
+      auto MapReduce(F func, std::vector<T> &args, R redfunc) -> typename std::result_of<F(T)>::type;
+      
+      using TExecutorBaseImpl<TSequentialExecutor>::Reduce;
+      template<class T, class R> auto Reduce(const std::vector<T> &objs, R redfunc) -> decltype(redfunc(objs));
+   };
+
+   /************ TEMPLATE METHODS IMPLEMENTATION ******************/
+
+   //////////////////////////////////////////////////////////////////////////
+   /// Execute func (with no arguments) nTimes.
+   /// Functions that take more than zero arguments can be executed (with
+   /// fixed arguments) by wrapping them in a lambda or with std::bind.
+   template<class F>
+   void TSequentialExecutor::Foreach(F func, unsigned nTimes) {
+       for(auto i: ROOT::TSeqI(nTimes)) func();
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+   /// Execute func, taking an element of a
+   /// sequence as argument.
+   template<class F, class INTEGER>
+   void TSequentialExecutor::Foreach(F func, ROOT::TSeq<INTEGER> args) {
+       for(auto i : args) func(i);
+   }
+
+   /// \cond
+   //////////////////////////////////////////////////////////////////////////
+   /// Execute func, taking an element of a
+   /// initializer_list as argument.
+   template<class F, class T>
+   void TSequentialExecutor::Foreach(F func, std::initializer_list<T> args) {
+       std::vector<T> vargs(std::move(args));
+       Foreach(func, vargs);
+   }
+   /// \endcond
+
+   //////////////////////////////////////////////////////////////////////////
+   /// Execute func, taking an element of an
+   /// std::vector as argument.
+   template<class F, class T>
+   void TSequentialExecutor::Foreach(F func, std::vector<T> &args) {
+        unsigned int nToProcess = args.size();
+        for(auto i: ROOT::TSeqI(nToProcess)) func(args[i]);
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+   /// Execute func (with no arguments) nTimes.
+   /// A vector containg executions' results is returned.
+   /// Functions that take more than zero arguments can be executed (with
+   /// fixed arguments) by wrapping them in a lambda or with std::bind.
+   template<class F, class Cond>
+   auto TSequentialExecutor::Map(F func, unsigned nTimes) -> std::vector<typename std::result_of<F()>::type> {
+      using retType = decltype(func());
+      std::vector<retType> reslist(nTimes);
+      for(auto i: ROOT::TSeqI(nTimes)) reslist[i] = func();
+      return reslist;
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+   /// Execute func, taking an element of a
+   /// sequence as argument.
+   /// A vector containg executions' results is returned.
+   template<class F, class INTEGER, class Cond>
+   auto TSequentialExecutor::Map(F func, ROOT::TSeq<INTEGER> args) -> std::vector<typename std::result_of<F(INTEGER)>::type> {
+      using retType = decltype(func(*args.begin()));
+      std::vector<retType> reslist(*args.end()-*args.begin());
+      for(auto i: args) reslist[i] = func();
+      return reslist;
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+   /// Execute func, taking an element of an
+   /// std::vector as argument.
+   /// A vector containg executions' results is returned.
+   // actual implementation of the Map method. all other calls with arguments eventually
+   // call this one
+   template<class F, class T, class Cond>
+   auto TSequentialExecutor::Map(F func, std::vector<T> &args) -> std::vector<typename std::result_of<F(T)>::type> {
+      // //check whether func is callable
+      using retType = decltype(func(args.front()));
+      unsigned int nToProcess = args.size();
+      std::vector<retType> reslist(nToProcess);
+      for(auto i: ROOT::TSeqI(nToProcess)) reslist[i] = func(args[i]);
+      return reslist;
+   }
+
+   template<class F, class R, class Cond>
+   auto TSequentialExecutor::MapReduce(F func, unsigned nTimes, R redfunc) -> typename std::result_of<F()>::type {
+      return Reduce(Map(func, nTimes), redfunc);
+   }
+
+   template<class F, class T, class R, class Cond>
+   auto TSequentialExecutor::MapReduce(F func, std::vector<T> &args, R redfunc) -> typename std::result_of<F(T)>::type {
+      return Reduce(Map(func, args), redfunc);
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+   /// "Reduce" an std::vector into a single object by passing a
+   /// function as the second argument defining the reduction operation.
+   template<class T, class R>
+   auto TSequentialExecutor::Reduce(const std::vector<T> &objs, R redfunc) -> decltype(redfunc(objs))
+   {
+      // check we can apply reduce to objs
+      static_assert(std::is_same<decltype(redfunc(objs)), T>::value, "redfunc does not have the correct signature");
+      return redfunc(objs);
+   }
+
+} // namespace ROOT
+#endif

--- a/core/imt/inc/ROOT/TThreadExecutor.hxx
+++ b/core/imt/inc/ROOT/TThreadExecutor.hxx
@@ -22,17 +22,15 @@
 # endif
 #else
 
-#include "ROOT/TExecutor.hxx"
+#include "ROOT/TExecutorBaseImpl.hxx"
 #include "ROOT/TPoolManager.hxx"
 #include "TROOT.h"
-#include "TError.h"
-#include <functional>
 #include <memory>
 #include <numeric>
 
 namespace ROOT {
 
-   class TThreadExecutor: public TExecutor<TThreadExecutor> {
+   class TThreadExecutor: public TExecutorBaseImpl<TThreadExecutor> {
    public:
       explicit TThreadExecutor();
 
@@ -52,7 +50,7 @@ namespace ROOT {
       template<class F, class T>
       void Foreach(F func, std::vector<T> &args);
 
-      using TExecutor<TThreadExecutor>::Map;
+      using TExecutorBaseImpl<TThreadExecutor>::Map;
       template<class F, class Cond = noReferenceCond<F>>
       auto Map(F func, unsigned nTimes) -> std::vector<typename std::result_of<F()>::type>;
       template<class F, class INTEGER, class Cond = noReferenceCond<F, INTEGER>>
@@ -64,7 +62,7 @@ namespace ROOT {
       // // the late return types also check at compile-time whether redfunc is compatible with func,
       // // other than checking that func is compatible with the type of arguments.
       // // a static_assert check in TThreadExecutor::Reduce is used to check that redfunc is compatible with the type returned by func
-      using TExecutor<TThreadExecutor>::MapReduce;
+      using TExecutorBaseImpl<TThreadExecutor>::MapReduce;
       template<class F, class R, class Cond = noReferenceCond<F>>
       auto MapReduce(F func, unsigned nTimes, R redfunc) -> typename std::result_of<F()>::type;
       template<class F, class R, class Cond = noReferenceCond<F>>
@@ -80,7 +78,7 @@ namespace ROOT {
       template<class F, class T, class R, class Cond = noReferenceCond<F, T>>
       auto MapReduce(F func, std::vector<T> &args, R redfunc, unsigned nChunks) -> typename std::result_of<F(T)>::type;
 
-      using TExecutor<TThreadExecutor>::Reduce;
+      using TExecutorBaseImpl<TThreadExecutor>::Reduce;
       template<class T, class BINARYOP> auto Reduce(const std::vector<T> &objs, BINARYOP redfunc) -> decltype(redfunc(objs.front(), objs.front()));
       template<class T, class R> auto Reduce(const std::vector<T> &objs, R redfunc) -> decltype(redfunc(objs));
 

--- a/core/imt/inc/ROOT/TThreadExecutor.hxx
+++ b/core/imt/inc/ROOT/TThreadExecutor.hxx
@@ -25,6 +25,7 @@
 #include "ROOT/TExecutorBaseImpl.hxx"
 #include "ROOT/TPoolManager.hxx"
 #include "TROOT.h"
+
 #include <memory>
 #include <numeric>
 
@@ -356,6 +357,7 @@ namespace ROOT {
    //////////////////////////////////////////////////////////////////////////
    /// "Reduce" an std::vector into a single object in parallel by passing a
    /// binary operator as the second argument to act on pairs of elements of the std::vector.
+   /// Only works for doubles and floats
    template<class T, class BINARYOP>
    auto TThreadExecutor::Reduce(const std::vector<T> &objs, BINARYOP redfunc) -> decltype(redfunc(objs.front(), objs.front()))
    {

--- a/core/imt/src/TThreadExecutor.cxx
+++ b/core/imt/src/TThreadExecutor.cxx
@@ -1,5 +1,6 @@
 #include "ROOT/TThreadExecutor.hxx"
 #include "tbb/tbb.h"
+#include <functional> // std::function
 
 //////////////////////////////////////////////////////////////////////////
 ///

--- a/core/multiproc/inc/ROOT/TProcessExecutor.hxx
+++ b/core/multiproc/inc/ROOT/TProcessExecutor.hxx
@@ -23,7 +23,7 @@
 #include "TFileInfo.h"
 #include "THashList.h"
 #include "TMPClient.h"
-#include "ROOT/TExecutor.hxx"
+#include "ROOT/TExecutorBaseImpl.hxx"
 #include "TMPWorkerExecutor.h"
 #include <algorithm> //std::generate
 #include <numeric> //std::iota
@@ -34,7 +34,7 @@
 
 namespace ROOT {
 
-class TProcessExecutor : public TExecutor<TProcessExecutor>, private TMPClient {
+class TProcessExecutor : public TExecutorBaseImpl<TProcessExecutor>, private TMPClient {
 public:
    explicit TProcessExecutor(unsigned nWorkers = 0); //default number of workers is the number of processors
    ~TProcessExecutor() = default;
@@ -43,7 +43,7 @@ public:
    TProcessExecutor &operator=(const TProcessExecutor &) = delete;
 
    // Map
-   using TExecutor<TProcessExecutor>::Map;
+   using TExecutorBaseImpl<TProcessExecutor>::Map;
    template<class F, class Cond = noReferenceCond<F>>
    auto Map(F func, unsigned nTimes) -> std::vector<typename std::result_of<F()>::type>;
    template<class F, class INTEGER, class Cond = noReferenceCond<F, INTEGER>>
@@ -54,13 +54,13 @@ public:
    void SetNWorkers(unsigned n) { TMPClient::SetNWorkers(n); }
    unsigned GetNWorkers() const { return TMPClient::GetNWorkers(); }
 
-   using TExecutor<TProcessExecutor>::MapReduce;
+   using TExecutorBaseImpl<TProcessExecutor>::MapReduce;
    template<class F, class R, class Cond = noReferenceCond<F>>
    auto MapReduce(F func, unsigned nTimes, R redfunc) -> typename std::result_of<F()>::type;
    template<class F, class T, class R, class Cond = noReferenceCond<F, T>>
    auto MapReduce(F func, std::vector<T> &args, R redfunc) -> typename std::result_of<F(T)>::type;
 
-   using TExecutor<TProcessExecutor>::Reduce;
+   using TExecutorBaseImpl<TProcessExecutor>::Reduce;
    template<class T, class R> T Reduce(const std::vector<T> &objs, R redfunc);
 
 private:

--- a/hist/hist/inc/Foption.h
+++ b/hist/hist/inc/Foption.h
@@ -19,7 +19,7 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-#include "Fit/FitExecutionPolicy.h"
+#include "ExecutionPolicy.hxx"
 
 struct Foption_t {
 //*-*      chopt may be the concatenation of the following options:
@@ -49,7 +49,7 @@ struct Foption_t {
    int StoreResult; // "S": Stores the result in a TFitResult structure
    int BinVolume;   // "WIDTH": scale content by the bin width/volume
    double hRobust;  //  value of h parameter used in robust fitting
-   ROOT::Fit::ExecutionPolicy ExecPolicy;  //  Choose the execution Policy: "SERIAL", "MULTITHREAD" or "MULTIPROCESS"
+   ROOT::Internal::ExecutionPolicy ExecPolicy;  //  Choose the execution Policy: "SERIAL", "MULTITHREAD" or "MULTIPROCESS"
 
   Foption_t() :
       Quiet        (0),
@@ -75,7 +75,7 @@ struct Foption_t {
       StoreResult  (0),
       BinVolume    (0),
       hRobust      (0),
-      ExecPolicy   (ROOT::Fit::ExecutionPolicy::kSerial)
+      ExecPolicy   (ROOT::Internal::ExecutionPolicy::kSerial)
    {}
 };
 

--- a/hist/hist/inc/Foption.h
+++ b/hist/hist/inc/Foption.h
@@ -75,7 +75,7 @@ struct Foption_t {
       StoreResult  (0),
       BinVolume    (0),
       hRobust      (0),
-      ExecPolicy   (ROOT::Internal::ExecutionPolicy::kSerial)
+      ExecPolicy   (ROOT::Internal::ExecutionPolicy::kSequential)
    {}
 };
 

--- a/hist/hist/src/HFitImpl.cxx
+++ b/hist/hist/src/HFitImpl.cxx
@@ -682,7 +682,7 @@ void ROOT::Fit::FitOptionsMake(EFitObjectType type, const char *option, Foption_
    //   - Decode list of options into fitOption (used by both TGraph and TH1)
    //  works for both histograms and graph depending on the enum FitObjectType defined in HFit
    if(ROOT::IsImplicitMTEnabled()) {
-      fitOption.ExecPolicy = ROOT::Fit::ExecutionPolicy::kMultithread;
+      fitOption.ExecPolicy = ROOT::Internal::ExecutionPolicy::kMultithread;
    }
 
    if (option == 0) return;
@@ -712,12 +712,12 @@ void ROOT::Fit::FitOptionsMake(EFitObjectType type, const char *option, Foption_
       // }
 
       if (opt.Contains("SERIAL")) {
-         fitOption.ExecPolicy = ROOT::Fit::ExecutionPolicy::kSerial;
+         fitOption.ExecPolicy = ROOT::Internal::ExecutionPolicy::kSerial;
          opt.ReplaceAll("SERIAL","");
       }
 
       if (opt.Contains("MULTITHREAD")) {
-         fitOption.ExecPolicy = ROOT::Fit::ExecutionPolicy::kMultithread;
+         fitOption.ExecPolicy = ROOT::Internal::ExecutionPolicy::kMultithread;
          opt.ReplaceAll("MULTITHREAD","");
       }
 

--- a/hist/hist/src/HFitImpl.cxx
+++ b/hist/hist/src/HFitImpl.cxx
@@ -712,7 +712,7 @@ void ROOT::Fit::FitOptionsMake(EFitObjectType type, const char *option, Foption_
       // }
 
       if (opt.Contains("SERIAL")) {
-         fitOption.ExecPolicy = ROOT::Internal::ExecutionPolicy::kSerial;
+         fitOption.ExecPolicy = ROOT::Internal::ExecutionPolicy::kSequential;
          opt.ReplaceAll("SERIAL","");
       }
 

--- a/math/mathcore/CMakeLists.txt
+++ b/math/mathcore/CMakeLists.txt
@@ -38,7 +38,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(MathCore HEADERS TComplex.h TMath.h ${MATHCORE_HEA
                               SOURCES *.cxx *.c
                               DICTIONARY_OPTIONS "-writeEmptyRootPCM"
                               LIBRARIES ${CMAKE_THREAD_LIBS_INIT} ${MATHCORE_LIBRARIES}
-                              DEPENDENCIES Core ${MATHCORE_DEPENDENCIES}
+                              DEPENDENCIES Core MultiProc ${MATHCORE_DEPENDENCIES}
                               BUILTINS ${MATHCORE_BUILTINS})
 
 if(veccore)

--- a/math/mathcore/inc/Fit/Chi2FCN.h
+++ b/math/mathcore/inc/Fit/Chi2FCN.h
@@ -63,7 +63,7 @@ public:
    /**
       Constructor from data set (binned ) and model function
    */
-   Chi2FCN (const std::shared_ptr<BinData> & data, const std::shared_ptr<IModelFunction> & func, const ROOT::Fit::ExecutionPolicy &executionPolicy = ROOT::Fit::ExecutionPolicy::kSerial) :
+   Chi2FCN (const std::shared_ptr<BinData> & data, const std::shared_ptr<IModelFunction> & func, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial) :
       BaseFCN( data, func),
       fNEffPoints(0),
       fGrad ( std::vector<double> ( func->NPar() ) ),
@@ -74,7 +74,7 @@ public:
       Same Constructor from data set (binned ) and model function but now managed by the user
       we clone the function but not the data
    */
-   Chi2FCN ( const BinData & data, const IModelFunction & func, const ROOT::Fit::ExecutionPolicy &executionPolicy = ROOT::Fit::ExecutionPolicy::kSerial) :
+   Chi2FCN ( const BinData & data, const IModelFunction & func, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial) :
       BaseFCN(std::shared_ptr<BinData>(const_cast<BinData*>(&data), DummyDeleter<BinData>()), std::shared_ptr<IModelFunction>(dynamic_cast<IModelFunction*>(func.Clone() ) ) ),
       fNEffPoints(0),
       fGrad ( std::vector<double> ( func.NPar() ) ),
@@ -162,7 +162,7 @@ private:
    mutable unsigned int fNEffPoints;  // number of effective points used in the fit
 
    mutable std::vector<double> fGrad; // for derivatives
-   ROOT::Fit::ExecutionPolicy fExecutionPolicy;
+   ROOT::Internal::ExecutionPolicy fExecutionPolicy;
 
 };
 

--- a/math/mathcore/inc/Fit/Chi2FCN.h
+++ b/math/mathcore/inc/Fit/Chi2FCN.h
@@ -63,7 +63,7 @@ public:
    /**
       Constructor from data set (binned ) and model function
    */
-   Chi2FCN (const std::shared_ptr<BinData> & data, const std::shared_ptr<IModelFunction> & func, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial) :
+   Chi2FCN (const std::shared_ptr<BinData> & data, const std::shared_ptr<IModelFunction> & func, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential) :
       BaseFCN( data, func),
       fNEffPoints(0),
       fGrad ( std::vector<double> ( func->NPar() ) ),
@@ -74,7 +74,7 @@ public:
       Same Constructor from data set (binned ) and model function but now managed by the user
       we clone the function but not the data
    */
-   Chi2FCN ( const BinData & data, const IModelFunction & func, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial) :
+   Chi2FCN ( const BinData & data, const IModelFunction & func, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential) :
       BaseFCN(std::shared_ptr<BinData>(const_cast<BinData*>(&data), DummyDeleter<BinData>()), std::shared_ptr<IModelFunction>(dynamic_cast<IModelFunction*>(func.Clone() ) ) ),
       fNEffPoints(0),
       fGrad ( std::vector<double> ( func.NPar() ) ),

--- a/math/mathcore/inc/Fit/FitUtil.h
+++ b/math/mathcore/inc/Fit/FitUtil.h
@@ -282,7 +282,7 @@ namespace FitUtil {
   */
   void EvaluateChi2Gradient(const IModelFunction &func, const BinData &data, const double *x, double *grad,
                             unsigned int &nPoints,
-                            ROOT::Internal::ExecutionPolicy executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial,
+                            ROOT::Internal::ExecutionPolicy executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential,
                             unsigned nChunks = 0);
 
   /**
@@ -298,7 +298,7 @@ namespace FitUtil {
   */
   void EvaluateLogLGradient(const IModelFunction &func, const UnBinData &data, const double *x, double *grad,
                             unsigned int &nPoints,
-                            ROOT::Internal::ExecutionPolicy executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial,
+                            ROOT::Internal::ExecutionPolicy executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential,
                             unsigned nChunks = 0);
 
   // #ifdef R__HAS_VECCORE
@@ -322,7 +322,7 @@ namespace FitUtil {
   */
   void EvaluatePoissonLogLGradient(const IModelFunction &func, const BinData &data, const double *x, double *grad,
                                    unsigned int &nPoints,
-                                   ROOT::Internal::ExecutionPolicy executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial,
+                                   ROOT::Internal::ExecutionPolicy executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential,
                                    unsigned nChunks = 0);
 
   // methods required by dedicate minimizer like Fumili
@@ -455,13 +455,13 @@ namespace FitUtil {
          // If IMT is disabled, force the execution policy to the serial case
          if (executionPolicy == ROOT::Internal::ExecutionPolicy::kMultithread) {
             Warning("FitUtil::EvaluateChi2", "Multithread execution policy requires IMT, which is disabled. Changing "
-                                             "to ROOT::Internal::ExecutionPolicy::kSerial.");
-            executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial;
+                                             "to ROOT::Internal::ExecutionPolicy::kSequential.");
+            executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential;
          }
 #endif
 
          T res{};
-         if (executionPolicy == ROOT::Internal::ExecutionPolicy::kSerial) {
+         if (executionPolicy == ROOT::Internal::ExecutionPolicy::kSequential) {
             for (unsigned int i = 0; i < (data.Size() / vecSize); i++) {
                res += mapFunction(i);
             }
@@ -476,7 +476,7 @@ namespace FitUtil {
             //   ROOT::TProcessExecutor pool;
             //   res = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, data.Size()/vecSize), redFunction);
          } else {
-            Error("FitUtil::EvaluateChi2", "Execution policy unknown. Avalaible choices:\n ROOT::Internal::ExecutionPolicy::kSerial (default)\n ROOT::Internal::ExecutionPolicy::kMultithread (requires IMT)\n");
+            Error("FitUtil::EvaluateChi2", "Execution policy unknown. Avalaible choices:\n ROOT::Internal::ExecutionPolicy::kSequential (default)\n ROOT::Internal::ExecutionPolicy::kMultithread (requires IMT)\n");
          }
          nPoints = n;
 
@@ -632,15 +632,15 @@ namespace FitUtil {
          // If IMT is disabled, force the execution policy to the serial case
          if (executionPolicy == ROOT::Internal::ExecutionPolicy::kMultithread) {
             Warning("FitUtil::EvaluateLogL", "Multithread execution policy requires IMT, which is disabled. Changing "
-                                             "to ROOT::Internal::ExecutionPolicy::kSerial.");
-            executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial;
+                                             "to ROOT::Internal::ExecutionPolicy::kSequential.");
+            executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential;
          }
 #endif
 
          T logl_v{};
          T sumW_v{};
          T sumW2_v{};
-         if (executionPolicy == ROOT::Internal::ExecutionPolicy::kSerial) {
+         if (executionPolicy == ROOT::Internal::ExecutionPolicy::kSequential) {
             for (unsigned int i = 0; i < numVectors; ++i) {
                auto resArray = mapFunction(i);
                logl_v += resArray.logvalue;
@@ -660,7 +660,7 @@ namespace FitUtil {
             // res = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, n), redFunction);
 #endif
          } else {
-            Error("FitUtil::EvaluateLogL", "Execution policy unknown. Avalaible choices:\n ROOT::Internal::ExecutionPolicy::kSerial (default)\n ROOT::Internal::ExecutionPolicy::kMultithread (requires IMT)\n");
+            Error("FitUtil::EvaluateLogL", "Execution policy unknown. Avalaible choices:\n ROOT::Internal::ExecutionPolicy::kSequential (default)\n ROOT::Internal::ExecutionPolicy::kMultithread (requires IMT)\n");
          }
 
          // Compute the contribution from the remaining points ( Last padded SIMD vector of elements )
@@ -853,13 +853,13 @@ namespace FitUtil {
          if (executionPolicy == ROOT::Internal::ExecutionPolicy::kMultithread) {
             Warning("FitUtil::Evaluate<T>::EvalPoissonLogL",
                     "Multithread execution policy requires IMT, which is disabled. Changing "
-                    "to ROOT::Internal::ExecutionPolicy::kSerial.");
-            executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial;
+                    "to ROOT::Internal::ExecutionPolicy::kSequential.");
+            executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential;
          }
 #endif
 
          T res{};
-         if (executionPolicy == ROOT::Internal::ExecutionPolicy::kSerial) {
+         if (executionPolicy == ROOT::Internal::ExecutionPolicy::kSequential) {
             for (unsigned int i = 0; i < (data.Size() / vecSize); i++) {
                res += mapFunction(i);
             }
@@ -875,7 +875,7 @@ namespace FitUtil {
          } else {
             Error(
                "FitUtil::Evaluate<T>::EvalPoissonLogL",
-               "Execution policy unknown. Avalaible choices:\n ROOT::Internal::ExecutionPolicy::kSerial (default)\n ROOT::Internal::ExecutionPolicy::kMultithread (requires IMT)\n");
+               "Execution policy unknown. Avalaible choices:\n ROOT::Internal::ExecutionPolicy::kSequential (default)\n ROOT::Internal::ExecutionPolicy::kMultithread (requires IMT)\n");
          }
 
          // Last padded SIMD vector of elements
@@ -909,7 +909,7 @@ namespace FitUtil {
 
       static void EvalChi2Gradient(const IModelFunctionTempl<T> &f, const BinData &data, const double *p, double *grad,
                                    unsigned int &nPoints,
-                                   ROOT::Internal::ExecutionPolicy executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial,
+                                   ROOT::Internal::ExecutionPolicy executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential,
                                    unsigned nChunks = 0)
       {
          // evaluate the gradient of the chi2 function
@@ -1035,12 +1035,12 @@ namespace FitUtil {
          if (executionPolicy == ROOT::Internal::ExecutionPolicy::kMultithread) {
             Warning("FitUtil::EvaluateChi2Gradient",
                     "Multithread execution policy requires IMT, which is disabled. Changing "
-                    "to ROOT::Internal::ExecutionPolicy::kSerial.");
-            executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial;
+                    "to ROOT::Internal::ExecutionPolicy::kSequential.");
+            executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential;
          }
 #endif
 
-         if (executionPolicy == ROOT::Internal::ExecutionPolicy::kSerial) {
+         if (executionPolicy == ROOT::Internal::ExecutionPolicy::kSequential) {
             std::vector<std::vector<T>> allGradients(numVectors);
             for (unsigned int i = 0; i < numVectors; ++i) {
                allGradients[i] = mapFunction(i);
@@ -1119,7 +1119,7 @@ namespace FitUtil {
       static void
       EvalPoissonLogLGradient(const IModelFunctionTempl<T> &f, const BinData &data, const double *p, double *grad,
                               unsigned int &,
-                              ROOT::Internal::ExecutionPolicy executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial,
+                              ROOT::Internal::ExecutionPolicy executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential,
                               unsigned nChunks = 0)
       {
          // evaluate the gradient of the Poisson log likelihood function
@@ -1226,12 +1226,12 @@ namespace FitUtil {
          if (executionPolicy == ROOT::Internal::ExecutionPolicy::kMultithread) {
             Warning("FitUtil::EvaluatePoissonLogLGradient",
                     "Multithread execution policy requires IMT, which is disabled. Changing "
-                    "to ROOT::Internal::ExecutionPolicy::kSerial.");
-            executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial;
+                    "to ROOT::Internal::ExecutionPolicy::kSequential.");
+            executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential;
          }
 #endif
 
-         if (executionPolicy == ROOT::Internal::ExecutionPolicy::kSerial) {
+         if (executionPolicy == ROOT::Internal::ExecutionPolicy::kSequential) {
             std::vector<std::vector<T>> allGradients(numVectors);
             for (unsigned int i = 0; i < numVectors; ++i) {
                allGradients[i] = mapFunction(i);
@@ -1252,7 +1252,7 @@ namespace FitUtil {
          // }
          else {
             Error("FitUtil::EvaluatePoissonLogLGradient", "Execution policy unknown. Avalaible choices:\n "
-                                                          "ROOT::Internal::ExecutionPolicy::kSerial (default)\n "
+                                                          "ROOT::Internal::ExecutionPolicy::kSequential (default)\n "
                                                           "ROOT::Internal::ExecutionPolicy::kMultithread (requires IMT)\n");
          }
 
@@ -1282,7 +1282,7 @@ namespace FitUtil {
 
       static void EvalLogLGradient(const IModelFunctionTempl<T> &f, const UnBinData &data, const double *p,
                                    double *grad, unsigned int &,
-                                   ROOT::Internal::ExecutionPolicy executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial,
+                                   ROOT::Internal::ExecutionPolicy executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential,
                                    unsigned nChunks = 0)
       {
          // evaluate the gradient of the log likelihood function
@@ -1384,12 +1384,12 @@ namespace FitUtil {
          if (executionPolicy == ROOT::Internal::ExecutionPolicy::kMultithread) {
             Warning("FitUtil::EvaluateLogLGradient",
                     "Multithread execution policy requires IMT, which is disabled. Changing "
-                    "to ROOT::Internal::ExecutionPolicy::kSerial.");
-            executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial;
+                    "to ROOT::Internal::ExecutionPolicy::kSequential.");
+            executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential;
          }
 #endif
 
-         if (executionPolicy == ROOT::Internal::ExecutionPolicy::kSerial) {
+         if (executionPolicy == ROOT::Internal::ExecutionPolicy::kSequential) {
             std::vector<std::vector<T>> allGradients(numVectors);
             for (unsigned int i = 0; i < numVectors; ++i) {
                allGradients[i] = mapFunction(i);
@@ -1409,7 +1409,7 @@ namespace FitUtil {
          // }
          else {
             Error("FitUtil::EvaluateLogLGradient", "Execution policy unknown. Avalaible choices:\n "
-                                                   "ROOT::Internal::ExecutionPolicy::kSerial (default)\n "
+                                                   "ROOT::Internal::ExecutionPolicy::kSequential (default)\n "
                                                    "ROOT::Internal::ExecutionPolicy::kMultithread (requires IMT)\n");
          }
 
@@ -1476,7 +1476,7 @@ namespace FitUtil {
       }
       static void EvalChi2Gradient(const IModelFunctionTempl<double> &func, const BinData &data, const double *p,
                                    double *g, unsigned int &nPoints,
-                                   ROOT::Internal::ExecutionPolicy executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial,
+                                   ROOT::Internal::ExecutionPolicy executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential,
                                    unsigned nChunks = 0)
       {
          FitUtil::EvaluateChi2Gradient(func, data, p, g, nPoints, executionPolicy, nChunks);
@@ -1495,7 +1495,7 @@ namespace FitUtil {
       static void
       EvalPoissonLogLGradient(const IModelFunctionTempl<double> &func, const BinData &data, const double *p, double *g,
                               unsigned int &nPoints,
-                              ROOT::Internal::ExecutionPolicy executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial,
+                              ROOT::Internal::ExecutionPolicy executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential,
                               unsigned nChunks = 0)
       {
          FitUtil::EvaluatePoissonLogLGradient(func, data, p, g, nPoints, executionPolicy, nChunks);
@@ -1503,7 +1503,7 @@ namespace FitUtil {
 
       static void EvalLogLGradient(const IModelFunctionTempl<double> &func, const UnBinData &data, const double *p,
                                    double *g, unsigned int &nPoints,
-                                   ROOT::Internal::ExecutionPolicy executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial,
+                                   ROOT::Internal::ExecutionPolicy executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential,
                                    unsigned nChunks = 0)
       {
          FitUtil::EvaluateLogLGradient(func, data, p, g, nPoints, executionPolicy, nChunks);

--- a/math/mathcore/inc/Fit/FitUtil.h
+++ b/math/mathcore/inc/Fit/FitUtil.h
@@ -600,7 +600,7 @@ namespace FitUtil {
 
          auto chunks = nChunks != 0 ? nChunks : setAutomaticChunking(data.Size() / vecSize);
          ROOT::Internal::TExecutor pool(executionPolicy);
-         LikelihoodAux<T> res = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, data.Size() / vecSize), redFunction, chunks);
+         auto res = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, data.Size() / vecSize), redFunction, chunks);
 
          // Compute the contribution from the remaining points ( Last padded SIMD vector of elements )
          unsigned int remainingPoints = n % vecSize;

--- a/math/mathcore/inc/Fit/Fitter.h
+++ b/math/mathcore/inc/Fit/Fitter.h
@@ -25,7 +25,7 @@ Classes used for fitting (regression analysis) and estimation of parameter value
 #include "Fit/BinData.h"
 #include "Fit/UnBinData.h"
 #include "Fit/FitConfig.h"
-#include "Fit/FitExecutionPolicy.h"
+#include "ExecutionPolicy.hxx"
 #include "Fit/FitResult.h"
 #include "Math/IParamFunction.h"
 #include <memory>
@@ -135,11 +135,11 @@ public:
        it must implement the 1D or multidimensional parametric function interface
    */
    template <class Data, class Function,
-             class cond = typename std::enable_if<!(std::is_same<Function, ROOT::Fit::ExecutionPolicy>::value ||
+             class cond = typename std::enable_if<!(std::is_same<Function, ROOT::Internal::ExecutionPolicy>::value ||
                                                     std::is_same<Function, int>::value),
                                                   Function>::type>
    bool Fit(const Data &data, const Function &func,
-            const ROOT::Fit::ExecutionPolicy &executionPolicy = ROOT::Fit::ExecutionPolicy::kSerial)
+            const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial)
    {
       SetFunction(func);
       return Fit(data, executionPolicy);
@@ -148,11 +148,11 @@ public:
    /**
        Fit a binned data set using a least square fit (default method)
    */
-   bool Fit(const BinData & data, const ROOT::Fit::ExecutionPolicy &executionPolicy = ROOT::Fit::ExecutionPolicy::kSerial) {
+   bool Fit(const BinData & data, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial) {
       SetData(data);
       return DoLeastSquareFit(executionPolicy);
    }
-   bool Fit(const std::shared_ptr<BinData> & data, const ROOT::Fit::ExecutionPolicy &executionPolicy = ROOT::Fit::ExecutionPolicy::kSerial) {
+   bool Fit(const std::shared_ptr<BinData> & data, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial) {
       SetData(data);
       return DoLeastSquareFit(executionPolicy);
    }
@@ -167,7 +167,7 @@ public:
    /**
        fit an unbinned data set using loglikelihood method
    */
-   bool Fit(const UnBinData & data, bool extended = false, const ROOT::Fit::ExecutionPolicy &executionPolicy = ROOT::Fit::ExecutionPolicy::kSerial) {
+   bool Fit(const UnBinData & data, bool extended = false, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial) {
       SetData(data);
       return DoUnbinnedLikelihoodFit(extended, executionPolicy);
    }
@@ -176,24 +176,24 @@ public:
       Binned Likelihood fit. Default is extended
     */
    bool LikelihoodFit(const BinData &data, bool extended = true,
-                      const ROOT::Fit::ExecutionPolicy &executionPolicy = ROOT::Fit::ExecutionPolicy::kSerial) {
+                      const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial) {
       SetData(data);
       return DoBinnedLikelihoodFit(extended, executionPolicy);
    }
 
    bool LikelihoodFit(const std::shared_ptr<BinData> &data, bool extended = true,
-                      const ROOT::Fit::ExecutionPolicy &executionPolicy = ROOT::Fit::ExecutionPolicy::kSerial) {
+                      const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial) {
       SetData(data);
       return DoBinnedLikelihoodFit(extended, executionPolicy);
    }
    /**
       Unbinned Likelihood fit. Default is not extended
     */
-   bool LikelihoodFit(const UnBinData & data, bool extended = false, const ROOT::Fit::ExecutionPolicy &executionPolicy = ROOT::Fit::ExecutionPolicy::kSerial) {
+   bool LikelihoodFit(const UnBinData & data, bool extended = false, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial) {
       SetData(data);
       return DoUnbinnedLikelihoodFit(extended, executionPolicy);
    }
-   bool LikelihoodFit(const std::shared_ptr<UnBinData> & data, bool extended = false, const ROOT::Fit::ExecutionPolicy &executionPolicy = ROOT::Fit::ExecutionPolicy::kSerial) {
+   bool LikelihoodFit(const std::shared_ptr<UnBinData> & data, bool extended = false, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial) {
       SetData(data);
       return DoUnbinnedLikelihoodFit(extended, executionPolicy);
    }
@@ -441,11 +441,11 @@ protected:
 
 
    /// least square fit
-   bool DoLeastSquareFit(const ROOT::Fit::ExecutionPolicy &executionPolicy = ROOT::Fit::ExecutionPolicy::kSerial);
+   bool DoLeastSquareFit(const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial);
    /// binned likelihood fit
-   bool DoBinnedLikelihoodFit(bool extended = true, const ROOT::Fit::ExecutionPolicy &executionPolicy = ROOT::Fit::ExecutionPolicy::kSerial);
+   bool DoBinnedLikelihoodFit(bool extended = true, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial);
    /// un-binned likelihood fit
-   bool DoUnbinnedLikelihoodFit( bool extended = false, const ROOT::Fit::ExecutionPolicy &executionPolicy = ROOT::Fit::ExecutionPolicy::kSerial);
+   bool DoUnbinnedLikelihoodFit( bool extended = false, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial);
    /// linear least square fit
    bool DoLinearFit();
 

--- a/math/mathcore/inc/Fit/Fitter.h
+++ b/math/mathcore/inc/Fit/Fitter.h
@@ -139,7 +139,7 @@ public:
                                                     std::is_same<Function, int>::value),
                                                   Function>::type>
    bool Fit(const Data &data, const Function &func,
-            const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial)
+            const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential)
    {
       SetFunction(func);
       return Fit(data, executionPolicy);
@@ -148,11 +148,11 @@ public:
    /**
        Fit a binned data set using a least square fit (default method)
    */
-   bool Fit(const BinData & data, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial) {
+   bool Fit(const BinData & data, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential) {
       SetData(data);
       return DoLeastSquareFit(executionPolicy);
    }
-   bool Fit(const std::shared_ptr<BinData> & data, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial) {
+   bool Fit(const std::shared_ptr<BinData> & data, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential) {
       SetData(data);
       return DoLeastSquareFit(executionPolicy);
    }
@@ -167,7 +167,7 @@ public:
    /**
        fit an unbinned data set using loglikelihood method
    */
-   bool Fit(const UnBinData & data, bool extended = false, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial) {
+   bool Fit(const UnBinData & data, bool extended = false, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential) {
       SetData(data);
       return DoUnbinnedLikelihoodFit(extended, executionPolicy);
    }
@@ -176,24 +176,24 @@ public:
       Binned Likelihood fit. Default is extended
     */
    bool LikelihoodFit(const BinData &data, bool extended = true,
-                      const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial) {
+                      const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential) {
       SetData(data);
       return DoBinnedLikelihoodFit(extended, executionPolicy);
    }
 
    bool LikelihoodFit(const std::shared_ptr<BinData> &data, bool extended = true,
-                      const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial) {
+                      const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential) {
       SetData(data);
       return DoBinnedLikelihoodFit(extended, executionPolicy);
    }
    /**
       Unbinned Likelihood fit. Default is not extended
     */
-   bool LikelihoodFit(const UnBinData & data, bool extended = false, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial) {
+   bool LikelihoodFit(const UnBinData & data, bool extended = false, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential) {
       SetData(data);
       return DoUnbinnedLikelihoodFit(extended, executionPolicy);
    }
-   bool LikelihoodFit(const std::shared_ptr<UnBinData> & data, bool extended = false, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial) {
+   bool LikelihoodFit(const std::shared_ptr<UnBinData> & data, bool extended = false, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential) {
       SetData(data);
       return DoUnbinnedLikelihoodFit(extended, executionPolicy);
    }
@@ -441,11 +441,11 @@ protected:
 
 
    /// least square fit
-   bool DoLeastSquareFit(const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial);
+   bool DoLeastSquareFit(const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential);
    /// binned likelihood fit
-   bool DoBinnedLikelihoodFit(bool extended = true, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial);
+   bool DoBinnedLikelihoodFit(bool extended = true, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential);
    /// un-binned likelihood fit
-   bool DoUnbinnedLikelihoodFit( bool extended = false, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial);
+   bool DoUnbinnedLikelihoodFit( bool extended = false, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential);
    /// linear least square fit
    bool DoLinearFit();
 

--- a/math/mathcore/inc/Fit/LogLikelihoodFCN.h
+++ b/math/mathcore/inc/Fit/LogLikelihoodFCN.h
@@ -55,7 +55,7 @@ public:
    /**
       Constructor from unbin data set and model function (pdf)
    */
-   LogLikelihoodFCN (const std::shared_ptr<UnBinData> & data, const std::shared_ptr<IModelFunction> & func, int weight = 0, bool extended = false, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial) :
+   LogLikelihoodFCN (const std::shared_ptr<UnBinData> & data, const std::shared_ptr<IModelFunction> & func, int weight = 0, bool extended = false, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential) :
       BaseFCN( data, func),
       fIsExtended(extended),
       fWeight(weight),
@@ -67,7 +67,7 @@ public:
       /**
       Constructor from unbin data set and model function (pdf) for object managed by users
    */
-   LogLikelihoodFCN (const UnBinData & data, const IModelFunction & func, int weight = 0, bool extended = false, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial) :
+   LogLikelihoodFCN (const UnBinData & data, const IModelFunction & func, int weight = 0, bool extended = false, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential) :
       BaseFCN(std::shared_ptr<UnBinData>(const_cast<UnBinData*>(&data), DummyDeleter<UnBinData>()), std::shared_ptr<IModelFunction>(dynamic_cast<IModelFunction*>(func.Clone() ) ) ),
       fIsExtended(extended),
       fWeight(weight),

--- a/math/mathcore/inc/Fit/LogLikelihoodFCN.h
+++ b/math/mathcore/inc/Fit/LogLikelihoodFCN.h
@@ -55,7 +55,7 @@ public:
    /**
       Constructor from unbin data set and model function (pdf)
    */
-   LogLikelihoodFCN (const std::shared_ptr<UnBinData> & data, const std::shared_ptr<IModelFunction> & func, int weight = 0, bool extended = false, const ROOT::Fit::ExecutionPolicy &executionPolicy = ROOT::Fit::ExecutionPolicy::kSerial) :
+   LogLikelihoodFCN (const std::shared_ptr<UnBinData> & data, const std::shared_ptr<IModelFunction> & func, int weight = 0, bool extended = false, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial) :
       BaseFCN( data, func),
       fIsExtended(extended),
       fWeight(weight),
@@ -67,7 +67,7 @@ public:
       /**
       Constructor from unbin data set and model function (pdf) for object managed by users
    */
-   LogLikelihoodFCN (const UnBinData & data, const IModelFunction & func, int weight = 0, bool extended = false, const ROOT::Fit::ExecutionPolicy &executionPolicy = ROOT::Fit::ExecutionPolicy::kSerial) :
+   LogLikelihoodFCN (const UnBinData & data, const IModelFunction & func, int weight = 0, bool extended = false, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial) :
       BaseFCN(std::shared_ptr<UnBinData>(const_cast<UnBinData*>(&data), DummyDeleter<UnBinData>()), std::shared_ptr<IModelFunction>(dynamic_cast<IModelFunction*>(func.Clone() ) ) ),
       fIsExtended(extended),
       fWeight(weight),
@@ -173,7 +173,7 @@ private:
 
    mutable std::vector<double> fGrad; // for derivatives
 
-   ROOT::Fit::ExecutionPolicy fExecutionPolicy; // Execution policy
+   ROOT::Internal::ExecutionPolicy fExecutionPolicy; // Execution policy
 };
       // define useful typedef's
       // using LogLikelihoodFunction_v = LogLikelihoodFCN<ROOT::Math::IMultiGenFunction, ROOT::Math::IParametricFunctionMultiDimTempl<T>>;

--- a/math/mathcore/inc/Fit/PoissonLikelihoodFCN.h
+++ b/math/mathcore/inc/Fit/PoissonLikelihoodFCN.h
@@ -60,7 +60,7 @@ public:
    /**
       Constructor from unbin data set and model function (pdf)
    */
-   PoissonLikelihoodFCN (const std::shared_ptr<BinData> & data, const std::shared_ptr<IModelFunction> & func, int weight = 0, bool extended = true, const ROOT::Fit::ExecutionPolicy &executionPolicy = ROOT::Fit::ExecutionPolicy::kSerial ) :
+   PoissonLikelihoodFCN (const std::shared_ptr<BinData> & data, const std::shared_ptr<IModelFunction> & func, int weight = 0, bool extended = true, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial ) :
       BaseFCN( data, func),
       fIsExtended(extended),
       fWeight(weight),
@@ -72,7 +72,7 @@ public:
    /**
       Constructor from unbin data set and model function (pdf) managed by the users
    */
-   PoissonLikelihoodFCN (const BinData & data, const IModelFunction & func, int weight = 0, bool extended = true, const ROOT::Fit::ExecutionPolicy &executionPolicy = ROOT::Fit::ExecutionPolicy::kSerial ) :
+   PoissonLikelihoodFCN (const BinData & data, const IModelFunction & func, int weight = 0, bool extended = true, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial ) :
       BaseFCN(std::shared_ptr<BinData>(const_cast<BinData*>(&data), DummyDeleter<BinData>()), std::shared_ptr<IModelFunction>(dynamic_cast<IModelFunction*>(func.Clone() ) ) ),
       fIsExtended(extended),
       fWeight(weight),
@@ -183,7 +183,7 @@ private:
 
    mutable std::vector<double> fGrad; // for derivatives
 
-   ROOT::Fit::ExecutionPolicy fExecutionPolicy; // Execution policy
+   ROOT::Internal::ExecutionPolicy fExecutionPolicy; // Execution policy
 };
 
       // define useful typedef's

--- a/math/mathcore/inc/Fit/PoissonLikelihoodFCN.h
+++ b/math/mathcore/inc/Fit/PoissonLikelihoodFCN.h
@@ -60,7 +60,7 @@ public:
    /**
       Constructor from unbin data set and model function (pdf)
    */
-   PoissonLikelihoodFCN (const std::shared_ptr<BinData> & data, const std::shared_ptr<IModelFunction> & func, int weight = 0, bool extended = true, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial ) :
+   PoissonLikelihoodFCN (const std::shared_ptr<BinData> & data, const std::shared_ptr<IModelFunction> & func, int weight = 0, bool extended = true, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential ) :
       BaseFCN( data, func),
       fIsExtended(extended),
       fWeight(weight),
@@ -72,7 +72,7 @@ public:
    /**
       Constructor from unbin data set and model function (pdf) managed by the users
    */
-   PoissonLikelihoodFCN (const BinData & data, const IModelFunction & func, int weight = 0, bool extended = true, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial ) :
+   PoissonLikelihoodFCN (const BinData & data, const IModelFunction & func, int weight = 0, bool extended = true, const ROOT::Internal::ExecutionPolicy &executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential ) :
       BaseFCN(std::shared_ptr<BinData>(const_cast<BinData*>(&data), DummyDeleter<BinData>()), std::shared_ptr<IModelFunction>(dynamic_cast<IModelFunction*>(func.Clone() ) ) ),
       fIsExtended(extended),
       fWeight(weight),

--- a/math/mathcore/src/FitUtil.cxx
+++ b/math/mathcore/src/FitUtil.cxx
@@ -378,13 +378,13 @@ namespace ROOT {
   // If IMT is disabled, force the execution policy to the serial case
   if (executionPolicy == ROOT::Internal::ExecutionPolicy::kMultithread) {
      Warning("FitUtil::EvaluateChi2", "Multithread execution policy requires IMT, which is disabled. Changing "
-                                      "to ROOT::Internal::ExecutionPolicy::kSerial.");
-     executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial;
+                                      "to ROOT::Internal::ExecutionPolicy::kSequential.");
+     executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential;
   }
 #endif
 
   double res{};
-  if(executionPolicy == ROOT::Internal::ExecutionPolicy::kSerial){
+  if(executionPolicy == ROOT::Internal::ExecutionPolicy::kSequential){
     for (unsigned int i=0; i<n; ++i) {
       res += mapFunction(i);
     }
@@ -398,7 +398,7 @@ namespace ROOT {
     // ROOT::TProcessExecutor pool;
     // res = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, n), redFunction);
   } else{
-    Error("FitUtil::EvaluateChi2","Execution policy unknown. Avalaible choices:\n ROOT::Internal::ExecutionPolicy::kSerial (default)\n ROOT::Internal::ExecutionPolicy::kMultithread (requires IMT)\n");
+    Error("FitUtil::EvaluateChi2","Execution policy unknown. Avalaible choices:\n ROOT::Internal::ExecutionPolicy::kSequential (default)\n ROOT::Internal::ExecutionPolicy::kMultithread (requires IMT)\n");
   }
 
    return res;
@@ -788,12 +788,12 @@ void FitUtil::EvaluateChi2Gradient(const IModelFunction &f, const BinData &data,
    // If IMT is disabled, force the execution policy to the serial case
    if (executionPolicy == ROOT::Internal::ExecutionPolicy::kMultithread) {
       Warning("FitUtil::EvaluateChi2Gradient", "Multithread execution policy requires IMT, which is disabled. Changing "
-                                               "to ROOT::Internal::ExecutionPolicy::kSerial.");
-      executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial;
+                                               "to ROOT::Internal::ExecutionPolicy::kSequential.");
+      executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential;
    }
 #endif
 
-   if (executionPolicy == ROOT::Internal::ExecutionPolicy::kSerial) {
+   if (executionPolicy == ROOT::Internal::ExecutionPolicy::kSequential) {
       std::vector<std::vector<double>> allGradients(initialNPoints);
       for (unsigned int i = 0; i < initialNPoints; ++i) {
          allGradients[i] = mapFunction(i);
@@ -1028,15 +1028,15 @@ double FitUtil::EvaluateLogL(const IModelFunctionTempl<double> &func, const UnBi
   // If IMT is disabled, force the execution policy to the serial case
   if (executionPolicy == ROOT::Internal::ExecutionPolicy::kMultithread) {
      Warning("FitUtil::EvaluateLogL", "Multithread execution policy requires IMT, which is disabled. Changing "
-                                      "to ROOT::Internal::ExecutionPolicy::kSerial.");
-     executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial;
+                                      "to ROOT::Internal::ExecutionPolicy::kSequential.");
+     executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential;
   }
 #endif
 
   double logl{};
   double sumW{};
   double sumW2{};
-  if(executionPolicy == ROOT::Internal::ExecutionPolicy::kSerial){
+  if(executionPolicy == ROOT::Internal::ExecutionPolicy::kSequential){
     for (unsigned int i=0; i<n; ++i) {
       auto resArray = mapFunction(i);
       logl+=resArray.logvalue;
@@ -1056,7 +1056,7 @@ double FitUtil::EvaluateLogL(const IModelFunctionTempl<double> &func, const UnBi
     // ROOT::TProcessExecutor pool;
     // res = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, n), redFunction);
   } else{
-    Error("FitUtil::EvaluateLogL","Execution policy unknown. Avalaible choices:\n ROOT::Internal::ExecutionPolicy::kSerial (default)\n ROOT::Internal::ExecutionPolicy::kMultithread (requires IMT)\n");
+    Error("FitUtil::EvaluateLogL","Execution policy unknown. Avalaible choices:\n ROOT::Internal::ExecutionPolicy::kSequential (default)\n ROOT::Internal::ExecutionPolicy::kMultithread (requires IMT)\n");
   }
 
   if (extended) {
@@ -1213,12 +1213,12 @@ void FitUtil::EvaluateLogLGradient(const IModelFunction &f, const UnBinData &dat
    // If IMT is disabled, force the execution policy to the serial case
    if (executionPolicy == ROOT::Internal::ExecutionPolicy::kMultithread) {
       Warning("FitUtil::EvaluateLogLGradient", "Multithread execution policy requires IMT, which is disabled. Changing "
-                                               "to ROOT::Internal::ExecutionPolicy::kSerial.");
-      executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial;
+                                               "to ROOT::Internal::ExecutionPolicy::kSequential.");
+      executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential;
    }
 #endif
 
-   if (executionPolicy == ROOT::Internal::ExecutionPolicy::kSerial) {
+   if (executionPolicy == ROOT::Internal::ExecutionPolicy::kSequential) {
       std::vector<std::vector<double>> allGradients(initialNPoints);
       for (unsigned int i = 0; i < initialNPoints; ++i) {
          allGradients[i] = mapFunction(i);
@@ -1239,7 +1239,7 @@ void FitUtil::EvaluateLogLGradient(const IModelFunction &f, const UnBinData &dat
    // }
    else {
       Error("FitUtil::EvaluateLogLGradient", "Execution policy unknown. Avalaible choices:\n "
-                                             "ROOT::Internal::ExecutionPolicy::kSerial (default)\n "
+                                             "ROOT::Internal::ExecutionPolicy::kSequential (default)\n "
                                              "ROOT::Internal::ExecutionPolicy::kMultithread (requires IMT)\n");
    }
 
@@ -1538,13 +1538,13 @@ double FitUtil::EvaluatePoissonLogL(const IModelFunction &func, const BinData &d
    // If IMT is disabled, force the execution policy to the serial case
    if (executionPolicy == ROOT::Internal::ExecutionPolicy::kMultithread) {
       Warning("FitUtil::EvaluatePoissonLogL", "Multithread execution policy requires IMT, which is disabled. Changing "
-                                              "to ROOT::Internal::ExecutionPolicy::kSerial.");
-      executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial;
+                                              "to ROOT::Internal::ExecutionPolicy::kSequential.");
+      executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential;
    }
 #endif
 
    double res{};
-   if (executionPolicy == ROOT::Internal::ExecutionPolicy::kSerial) {
+   if (executionPolicy == ROOT::Internal::ExecutionPolicy::kSequential) {
       for (unsigned int i = 0; i < n; ++i) {
          res += mapFunction(i);
       }
@@ -1559,7 +1559,7 @@ double FitUtil::EvaluatePoissonLogL(const IModelFunction &func, const BinData &d
       // res = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, n), redFunction);
    } else {
       Error("FitUtil::EvaluatePoissonLogL",
-            "Execution policy unknown. Avalaible choices:\n ROOT::Internal::ExecutionPolicy::kSerial (default)\n ROOT::Internal::ExecutionPolicy::kMultithread (requires IMT)\n");
+            "Execution policy unknown. Avalaible choices:\n ROOT::Internal::ExecutionPolicy::kSequential (default)\n ROOT::Internal::ExecutionPolicy::kMultithread (requires IMT)\n");
    }
 
 #ifdef DEBUG
@@ -1707,12 +1707,12 @@ void FitUtil::EvaluatePoissonLogLGradient(const IModelFunction &f, const BinData
    if (executionPolicy == ROOT::Internal::ExecutionPolicy::kMultithread) {
       Warning("FitUtil::EvaluatePoissonLogLGradient",
               "Multithread execution policy requires IMT, which is disabled. Changing "
-              "to ROOT::Internal::ExecutionPolicy::kSerial.");
-      executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial;
+              "to ROOT::Internal::ExecutionPolicy::kSequential.");
+      executionPolicy = ROOT::Internal::ExecutionPolicy::kSequential;
    }
 #endif
 
-   if (executionPolicy == ROOT::Internal::ExecutionPolicy::kSerial) {
+   if (executionPolicy == ROOT::Internal::ExecutionPolicy::kSequential) {
       std::vector<std::vector<double>> allGradients(initialNPoints);
       for (unsigned int i = 0; i < initialNPoints; ++i) {
          allGradients[i] = mapFunction(i);

--- a/math/mathcore/src/FitUtil.cxx
+++ b/math/mathcore/src/FitUtil.cxx
@@ -224,7 +224,7 @@ namespace ROOT {
 //___________________________________________________________________________________________________________________________
 
       double FitUtil::EvaluateChi2(const IModelFunction &func, const BinData &data, const double *p, unsigned int &,
-                                   ROOT::Fit::ExecutionPolicy executionPolicy, unsigned nChunks)
+                                   ROOT::Internal::ExecutionPolicy executionPolicy, unsigned nChunks)
       {
          // evaluate the chi2 given a  function reference  , the data and returns the value and also in nPoints
          // the actual number of used points
@@ -376,20 +376,20 @@ namespace ROOT {
   (void)nChunks;
 
   // If IMT is disabled, force the execution policy to the serial case
-  if (executionPolicy == ROOT::Fit::ExecutionPolicy::kMultithread) {
+  if (executionPolicy == ROOT::Internal::ExecutionPolicy::kMultithread) {
      Warning("FitUtil::EvaluateChi2", "Multithread execution policy requires IMT, which is disabled. Changing "
-                                      "to ROOT::Fit::ExecutionPolicy::kSerial.");
-     executionPolicy = ROOT::Fit::ExecutionPolicy::kSerial;
+                                      "to ROOT::Internal::ExecutionPolicy::kSerial.");
+     executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial;
   }
 #endif
 
   double res{};
-  if(executionPolicy == ROOT::Fit::ExecutionPolicy::kSerial){
+  if(executionPolicy == ROOT::Internal::ExecutionPolicy::kSerial){
     for (unsigned int i=0; i<n; ++i) {
       res += mapFunction(i);
     }
 #ifdef R__USE_IMT
-  } else if(executionPolicy == ROOT::Fit::ExecutionPolicy::kMultithread) {
+  } else if(executionPolicy == ROOT::Internal::ExecutionPolicy::kMultithread) {
     auto chunks = nChunks !=0? nChunks: setAutomaticChunking(data.Size());
     ROOT::TThreadExecutor pool;
     res = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, n), redFunction, chunks);
@@ -398,7 +398,7 @@ namespace ROOT {
     // ROOT::TProcessExecutor pool;
     // res = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, n), redFunction);
   } else{
-    Error("FitUtil::EvaluateChi2","Execution policy unknown. Avalaible choices:\n ROOT::Fit::ExecutionPolicy::kSerial (default)\n ROOT::Fit::ExecutionPolicy::kMultithread (requires IMT)\n");
+    Error("FitUtil::EvaluateChi2","Execution policy unknown. Avalaible choices:\n ROOT::Internal::ExecutionPolicy::kSerial (default)\n ROOT::Internal::ExecutionPolicy::kMultithread (requires IMT)\n");
   }
 
    return res;
@@ -636,7 +636,7 @@ double FitUtil::EvaluateChi2Residual(const IModelFunction & func, const BinData 
 }
 
 void FitUtil::EvaluateChi2Gradient(const IModelFunction &f, const BinData &data, const double *p, double *grad,
-                                   unsigned int &nPoints, ROOT::Fit::ExecutionPolicy executionPolicy, unsigned nChunks)
+                                   unsigned int &nPoints, ROOT::Internal::ExecutionPolicy executionPolicy, unsigned nChunks)
 {
    // evaluate the gradient of the chi2 function
    // this function is used when the model function knows how to calculate the derivative and we can
@@ -786,14 +786,14 @@ void FitUtil::EvaluateChi2Gradient(const IModelFunction &f, const BinData &data,
 
 #ifndef R__USE_IMT
    // If IMT is disabled, force the execution policy to the serial case
-   if (executionPolicy == ROOT::Fit::ExecutionPolicy::kMultithread) {
+   if (executionPolicy == ROOT::Internal::ExecutionPolicy::kMultithread) {
       Warning("FitUtil::EvaluateChi2Gradient", "Multithread execution policy requires IMT, which is disabled. Changing "
-                                               "to ROOT::Fit::ExecutionPolicy::kSerial.");
-      executionPolicy = ROOT::Fit::ExecutionPolicy::kSerial;
+                                               "to ROOT::Internal::ExecutionPolicy::kSerial.");
+      executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial;
    }
 #endif
 
-   if (executionPolicy == ROOT::Fit::ExecutionPolicy::kSerial) {
+   if (executionPolicy == ROOT::Internal::ExecutionPolicy::kSerial) {
       std::vector<std::vector<double>> allGradients(initialNPoints);
       for (unsigned int i = 0; i < initialNPoints; ++i) {
          allGradients[i] = mapFunction(i);
@@ -801,7 +801,7 @@ void FitUtil::EvaluateChi2Gradient(const IModelFunction &f, const BinData &data,
       g = redFunction(allGradients);
    }
 #ifdef R__USE_IMT
-   else if (executionPolicy == ROOT::Fit::ExecutionPolicy::kMultithread) {
+   else if (executionPolicy == ROOT::Internal::ExecutionPolicy::kMultithread) {
       auto chunks = nChunks != 0 ? nChunks : setAutomaticChunking(initialNPoints);
       ROOT::TThreadExecutor pool;
       g = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, initialNPoints), redFunction, chunks);
@@ -897,7 +897,7 @@ double FitUtil::EvaluatePdf(const IModelFunction & func, const UnBinData & data,
 
 double FitUtil::EvaluateLogL(const IModelFunctionTempl<double> &func, const UnBinData &data, const double *p,
                              int iWeight, bool extended, unsigned int &nPoints,
-                             ROOT::Fit::ExecutionPolicy executionPolicy, unsigned nChunks)
+                             ROOT::Internal::ExecutionPolicy executionPolicy, unsigned nChunks)
 {
    // evaluate the LogLikelihood
 
@@ -1026,17 +1026,17 @@ double FitUtil::EvaluateLogL(const IModelFunctionTempl<double> &func, const UnBi
   (void)nChunks;
 
   // If IMT is disabled, force the execution policy to the serial case
-  if (executionPolicy == ROOT::Fit::ExecutionPolicy::kMultithread) {
+  if (executionPolicy == ROOT::Internal::ExecutionPolicy::kMultithread) {
      Warning("FitUtil::EvaluateLogL", "Multithread execution policy requires IMT, which is disabled. Changing "
-                                      "to ROOT::Fit::ExecutionPolicy::kSerial.");
-     executionPolicy = ROOT::Fit::ExecutionPolicy::kSerial;
+                                      "to ROOT::Internal::ExecutionPolicy::kSerial.");
+     executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial;
   }
 #endif
 
   double logl{};
   double sumW{};
   double sumW2{};
-  if(executionPolicy == ROOT::Fit::ExecutionPolicy::kSerial){
+  if(executionPolicy == ROOT::Internal::ExecutionPolicy::kSerial){
     for (unsigned int i=0; i<n; ++i) {
       auto resArray = mapFunction(i);
       logl+=resArray.logvalue;
@@ -1044,7 +1044,7 @@ double FitUtil::EvaluateLogL(const IModelFunctionTempl<double> &func, const UnBi
       sumW2+=resArray.weight2;
     }
 #ifdef R__USE_IMT
-  } else if(executionPolicy == ROOT::Fit::ExecutionPolicy::kMultithread) {
+  } else if(executionPolicy == ROOT::Internal::ExecutionPolicy::kMultithread) {
     auto chunks = nChunks !=0? nChunks: setAutomaticChunking(data.Size());
     ROOT::TThreadExecutor pool;
     auto resArray = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, n), redFunction, chunks);
@@ -1056,7 +1056,7 @@ double FitUtil::EvaluateLogL(const IModelFunctionTempl<double> &func, const UnBi
     // ROOT::TProcessExecutor pool;
     // res = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, n), redFunction);
   } else{
-    Error("FitUtil::EvaluateLogL","Execution policy unknown. Avalaible choices:\n ROOT::Fit::ExecutionPolicy::kSerial (default)\n ROOT::Fit::ExecutionPolicy::kMultithread (requires IMT)\n");
+    Error("FitUtil::EvaluateLogL","Execution policy unknown. Avalaible choices:\n ROOT::Internal::ExecutionPolicy::kSerial (default)\n ROOT::Internal::ExecutionPolicy::kMultithread (requires IMT)\n");
   }
 
   if (extended) {
@@ -1124,7 +1124,7 @@ double FitUtil::EvaluateLogL(const IModelFunctionTempl<double> &func, const UnBi
 }
 
 void FitUtil::EvaluateLogLGradient(const IModelFunction &f, const UnBinData &data, const double *p, double *grad,
-                                   unsigned int &, ROOT::Fit::ExecutionPolicy executionPolicy, unsigned nChunks)
+                                   unsigned int &, ROOT::Internal::ExecutionPolicy executionPolicy, unsigned nChunks)
 {
    // evaluate the gradient of the log likelihood function
 
@@ -1211,14 +1211,14 @@ void FitUtil::EvaluateLogLGradient(const IModelFunction &f, const UnBinData &dat
 
 #ifndef R__USE_IMT
    // If IMT is disabled, force the execution policy to the serial case
-   if (executionPolicy == ROOT::Fit::ExecutionPolicy::kMultithread) {
+   if (executionPolicy == ROOT::Internal::ExecutionPolicy::kMultithread) {
       Warning("FitUtil::EvaluateLogLGradient", "Multithread execution policy requires IMT, which is disabled. Changing "
-                                               "to ROOT::Fit::ExecutionPolicy::kSerial.");
-      executionPolicy = ROOT::Fit::ExecutionPolicy::kSerial;
+                                               "to ROOT::Internal::ExecutionPolicy::kSerial.");
+      executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial;
    }
 #endif
 
-   if (executionPolicy == ROOT::Fit::ExecutionPolicy::kSerial) {
+   if (executionPolicy == ROOT::Internal::ExecutionPolicy::kSerial) {
       std::vector<std::vector<double>> allGradients(initialNPoints);
       for (unsigned int i = 0; i < initialNPoints; ++i) {
          allGradients[i] = mapFunction(i);
@@ -1226,21 +1226,21 @@ void FitUtil::EvaluateLogLGradient(const IModelFunction &f, const UnBinData &dat
       g = redFunction(allGradients);
    }
 #ifdef R__USE_IMT
-   else if (executionPolicy == ROOT::Fit::ExecutionPolicy::kMultithread) {
+   else if (executionPolicy == ROOT::Internal::ExecutionPolicy::kMultithread) {
       auto chunks = nChunks != 0 ? nChunks : setAutomaticChunking(initialNPoints);
       ROOT::TThreadExecutor pool;
       g = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, initialNPoints), redFunction, chunks);
    }
 #endif
 
-   // else if(executionPolicy == ROOT::Fit::ExecutionPolicy::kMultiprocess){
+   // else if(executionPolicy == ROOT::Internal::ExecutionPolicy::kMultiprocess){
    //    ROOT::TProcessExecutor pool;
    //    g = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, n), redFunction);
    // }
    else {
       Error("FitUtil::EvaluateLogLGradient", "Execution policy unknown. Avalaible choices:\n "
-                                             "ROOT::Fit::ExecutionPolicy::kSerial (default)\n "
-                                             "ROOT::Fit::ExecutionPolicy::kMultithread (requires IMT)\n");
+                                             "ROOT::Internal::ExecutionPolicy::kSerial (default)\n "
+                                             "ROOT::Internal::ExecutionPolicy::kMultithread (requires IMT)\n");
    }
 
 #ifndef R__USE_IMT
@@ -1369,7 +1369,7 @@ double FitUtil::EvaluatePoissonBinPdf(const IModelFunction & func, const BinData
 }
 
 double FitUtil::EvaluatePoissonLogL(const IModelFunction &func, const BinData &data, const double *p, int iWeight,
-                                    bool extended, unsigned int &nPoints, ROOT::Fit::ExecutionPolicy executionPolicy,
+                                    bool extended, unsigned int &nPoints, ROOT::Internal::ExecutionPolicy executionPolicy,
                                     unsigned nChunks)
 {
    // evaluate the Poisson Log Likelihood
@@ -1536,20 +1536,20 @@ double FitUtil::EvaluatePoissonLogL(const IModelFunction &func, const BinData &d
    (void)nChunks;
 
    // If IMT is disabled, force the execution policy to the serial case
-   if (executionPolicy == ROOT::Fit::ExecutionPolicy::kMultithread) {
+   if (executionPolicy == ROOT::Internal::ExecutionPolicy::kMultithread) {
       Warning("FitUtil::EvaluatePoissonLogL", "Multithread execution policy requires IMT, which is disabled. Changing "
-                                              "to ROOT::Fit::ExecutionPolicy::kSerial.");
-      executionPolicy = ROOT::Fit::ExecutionPolicy::kSerial;
+                                              "to ROOT::Internal::ExecutionPolicy::kSerial.");
+      executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial;
    }
 #endif
 
    double res{};
-   if (executionPolicy == ROOT::Fit::ExecutionPolicy::kSerial) {
+   if (executionPolicy == ROOT::Internal::ExecutionPolicy::kSerial) {
       for (unsigned int i = 0; i < n; ++i) {
          res += mapFunction(i);
       }
 #ifdef R__USE_IMT
-   } else if (executionPolicy == ROOT::Fit::ExecutionPolicy::kMultithread) {
+   } else if (executionPolicy == ROOT::Internal::ExecutionPolicy::kMultithread) {
       auto chunks = nChunks != 0 ? nChunks : setAutomaticChunking(data.Size());
       ROOT::TThreadExecutor pool;
       res = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, n), redFunction, chunks);
@@ -1559,7 +1559,7 @@ double FitUtil::EvaluatePoissonLogL(const IModelFunction &func, const BinData &d
       // res = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, n), redFunction);
    } else {
       Error("FitUtil::EvaluatePoissonLogL",
-            "Execution policy unknown. Avalaible choices:\n ROOT::Fit::ExecutionPolicy::kSerial (default)\n ROOT::Fit::ExecutionPolicy::kMultithread (requires IMT)\n");
+            "Execution policy unknown. Avalaible choices:\n ROOT::Internal::ExecutionPolicy::kSerial (default)\n ROOT::Internal::ExecutionPolicy::kMultithread (requires IMT)\n");
    }
 
 #ifdef DEBUG
@@ -1570,7 +1570,7 @@ double FitUtil::EvaluatePoissonLogL(const IModelFunction &func, const BinData &d
 }
 
 void FitUtil::EvaluatePoissonLogLGradient(const IModelFunction &f, const BinData &data, const double *p, double *grad,
-                                          unsigned int &, ROOT::Fit::ExecutionPolicy executionPolicy, unsigned nChunks)
+                                          unsigned int &, ROOT::Internal::ExecutionPolicy executionPolicy, unsigned nChunks)
 {
    // evaluate the gradient of the Poisson log likelihood function
 
@@ -1704,15 +1704,15 @@ void FitUtil::EvaluatePoissonLogLGradient(const IModelFunction &f, const BinData
 
 #ifndef R__USE_IMT
    // If IMT is disabled, force the execution policy to the serial case
-   if (executionPolicy == ROOT::Fit::ExecutionPolicy::kMultithread) {
+   if (executionPolicy == ROOT::Internal::ExecutionPolicy::kMultithread) {
       Warning("FitUtil::EvaluatePoissonLogLGradient",
               "Multithread execution policy requires IMT, which is disabled. Changing "
-              "to ROOT::Fit::ExecutionPolicy::kSerial.");
-      executionPolicy = ROOT::Fit::ExecutionPolicy::kSerial;
+              "to ROOT::Internal::ExecutionPolicy::kSerial.");
+      executionPolicy = ROOT::Internal::ExecutionPolicy::kSerial;
    }
 #endif
 
-   if (executionPolicy == ROOT::Fit::ExecutionPolicy::kSerial) {
+   if (executionPolicy == ROOT::Internal::ExecutionPolicy::kSerial) {
       std::vector<std::vector<double>> allGradients(initialNPoints);
       for (unsigned int i = 0; i < initialNPoints; ++i) {
          allGradients[i] = mapFunction(i);
@@ -1720,7 +1720,7 @@ void FitUtil::EvaluatePoissonLogLGradient(const IModelFunction &f, const BinData
       g = redFunction(allGradients);
    }
 #ifdef R__USE_IMT
-   else if (executionPolicy == ROOT::Fit::ExecutionPolicy::kMultithread) {
+   else if (executionPolicy == ROOT::Internal::ExecutionPolicy::kMultithread) {
       auto chunks = nChunks != 0 ? nChunks : setAutomaticChunking(initialNPoints);
       ROOT::TThreadExecutor pool;
       g = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, initialNPoints), redFunction, chunks);

--- a/math/mathcore/src/Fitter.cxx
+++ b/math/mathcore/src/Fitter.cxx
@@ -327,7 +327,7 @@ bool Fitter::EvalFCN() {
    return true;
 }
 
-bool Fitter::DoLeastSquareFit(const ROOT::Fit::ExecutionPolicy &executionPolicy)
+bool Fitter::DoLeastSquareFit(const ROOT::Internal::ExecutionPolicy &executionPolicy)
 {
 
    // perform a chi2 fit on a set of binned data
@@ -386,7 +386,7 @@ bool Fitter::DoLeastSquareFit(const ROOT::Fit::ExecutionPolicy &executionPolicy)
    return false;
 }
 
-bool Fitter::DoBinnedLikelihoodFit(bool extended, const ROOT::Fit::ExecutionPolicy &executionPolicy)
+bool Fitter::DoBinnedLikelihoodFit(bool extended, const ROOT::Internal::ExecutionPolicy &executionPolicy)
 {
    // perform a likelihood fit on a set of binned data
    // The fit is extended (Poisson logl_ by default
@@ -495,7 +495,7 @@ bool Fitter::DoBinnedLikelihoodFit(bool extended, const ROOT::Fit::ExecutionPoli
    return true;
 }
 
-bool Fitter::DoUnbinnedLikelihoodFit(bool extended, const ROOT::Fit::ExecutionPolicy &executionPolicy) {
+bool Fitter::DoUnbinnedLikelihoodFit(bool extended, const ROOT::Internal::ExecutionPolicy &executionPolicy) {
    // perform a likelihood fit on a set of unbinned data
 
    std::shared_ptr<UnBinData> data = std::dynamic_pointer_cast<UnBinData>(fData);

--- a/math/mathcore/test/fit/testLogLExecPolicy.cxx
+++ b/math/mathcore/test/fit/testLogLExecPolicy.cxx
@@ -177,7 +177,7 @@ public:
       fitter.SetFunction(*wfSeq, false);
       fitter.Config().ParamsSettings() = paramSettings; 
       start = std::chrono::system_clock::now();
-      bool ret = fitter.Fit(*dataSB, 0, ROOT::Fit::ExecutionPolicy::kMultithread);
+      bool ret = fitter.Fit(*dataSB, 0, ROOT::Internal::ExecutionPolicy::kMultithread);
       end =  std::chrono::system_clock::now();
       duration = end - start;
       std::cout << "Time for the parallel test: " << duration.count() << std::endl;
@@ -191,7 +191,7 @@ public:
       fitter.SetFunction(*wfSeq, false);
       fitter.Config().ParamsSettings() = paramSettings; 
       start = std::chrono::system_clock::now();
-      bool ret = fitter.Fit(*dataSB, 0, ROOT::Fit::ExecutionPolicy::kMultiprocess);
+      bool ret = fitter.Fit(*dataSB, 0, ROOT::Internal::ExecutionPolicy::kMultiprocess);
       end =  std::chrono::system_clock::now();
       duration = end - start;
       std::cout << "Time for the multiprocess test:" << duration.count() << std::endl;
@@ -220,7 +220,7 @@ public:
       fitter.SetFunction(*wfVec);
       fitter.Config().ParamsSettings() = paramSettings; 
       start = std::chrono::system_clock::now();
-      bool ret = fitter.Fit(*dataSB, 0, ROOT::Fit::ExecutionPolicy::kMultithread);
+      bool ret = fitter.Fit(*dataSB, 0, ROOT::Internal::ExecutionPolicy::kMultithread);
       end =  std::chrono::system_clock::now();
       duration = end - start;
       std::cout << "Time for the parallel+vectorized test: " << duration.count() << std::endl;
@@ -234,7 +234,7 @@ public:
       fitter.SetFunction(*wfVec);
       fitter.Config().ParamsSettings() = paramSettings; 
       start = std::chrono::system_clock::now();
-      bool ret = fitter.Fit(*dataSB, 0, ROOT::Fit::ExecutionPolicy::kMultiprocess);
+      bool ret = fitter.Fit(*dataSB, 0, ROOT::Internal::ExecutionPolicy::kMultiprocess);
       end =  std::chrono::system_clock::now();
       duration = end - start;
       std::cout << "Time for the multiprocess+vectorized test:" << duration.count() << std::endl;

--- a/math/mathcore/test/testGradient.cxx
+++ b/math/mathcore/test/testGradient.cxx
@@ -61,10 +61,10 @@ char mthreadStr[] = "Multithread";
 
 // Typedefs of GradientTestTraits for scalar (serial and multithreaded)
 // scenarios
-using ScalarSerial1D = GradientTestTraits<Double_t, ROOT::Internal::ExecutionPolicy::kSerial, 1, scalarStr, serialStr>;
+using ScalarSerial1D = GradientTestTraits<Double_t, ROOT::Internal::ExecutionPolicy::kSequential, 1, scalarStr, serialStr>;
 using ScalarMultithread1D =
    GradientTestTraits<Double_t, ROOT::Internal::ExecutionPolicy::kMultithread, 1, scalarStr, mthreadStr>;
-using ScalarSerial2D = GradientTestTraits<Double_t, ROOT::Internal::ExecutionPolicy::kSerial, 2, scalarStr, serialStr>;
+using ScalarSerial2D = GradientTestTraits<Double_t, ROOT::Internal::ExecutionPolicy::kSequential, 2, scalarStr, serialStr>;
 using ScalarMultithread2D =
    GradientTestTraits<Double_t, ROOT::Internal::ExecutionPolicy::kMultithread, 2, scalarStr, mthreadStr>;
 
@@ -73,11 +73,11 @@ using ScalarMultithread2D =
 // Typedefs of GradientTestTraits for vectorial (serial and multithreaded)
 // scenarios
 using VectorialSerial1D =
-   GradientTestTraits<ROOT::Double_v, ROOT::Internal::ExecutionPolicy::kSerial, 1, vectorStr, serialStr>;
+   GradientTestTraits<ROOT::Double_v, ROOT::Internal::ExecutionPolicy::kSequential, 1, vectorStr, serialStr>;
 using VectorialMultithread1D =
    GradientTestTraits<ROOT::Double_v, ROOT::Internal::ExecutionPolicy::kMultithread, 1, vectorStr, mthreadStr>;
 using VectorialSerial2D =
-   GradientTestTraits<ROOT::Double_v, ROOT::Internal::ExecutionPolicy::kSerial, 2, vectorStr, serialStr>;
+   GradientTestTraits<ROOT::Double_v, ROOT::Internal::ExecutionPolicy::kSequential, 2, vectorStr, serialStr>;
 using VectorialMultithread2D =
    GradientTestTraits<ROOT::Double_v, ROOT::Internal::ExecutionPolicy::kMultithread, 2, vectorStr, mthreadStr>;
 
@@ -263,7 +263,7 @@ struct GradientTestEvaluation {
 
    // Basic type to compare against
    using ScalarSerial =
-      GradientTestTraits<double, ROOT::Internal::ExecutionPolicy::kSerial, T::Dimensions(), scalarStr, serialStr>;
+      GradientTestTraits<double, ROOT::Internal::ExecutionPolicy::kSequential, T::Dimensions(), scalarStr, serialStr>;
 
    GradientTestEvaluation()
    {

--- a/math/mathcore/test/testGradient.cxx
+++ b/math/mathcore/test/testGradient.cxx
@@ -2,7 +2,7 @@
 // Author: Alejandro García Montoro 07/2017
 
 #include "Fit/BinData.h"
-#include "Fit/FitExecutionPolicy.h"
+#include "ExecutionPolicy.hxx"
 #include "Fit/FitUtil.h"
 #include "Fit/UnBinData.h"
 #include "Math/WrappedMultiTF1.h"
@@ -34,10 +34,10 @@
 //    "Scalar", "Vectorial")
 //    PolicyInfoStr points to a human-readable string describing
 //    ExecutionPolicyType (e.g., "Serial", "Multithread")
-template <typename U, ROOT::Fit::ExecutionPolicy V, int W, const char *dataInfoStr, const char *policyInfoStr>
+template <typename U, ROOT::Internal::ExecutionPolicy V, int W, const char *dataInfoStr, const char *policyInfoStr>
 struct GradientTestTraits {
    using DataType = U;
-   static constexpr ROOT::Fit::ExecutionPolicy ExecutionPolicyType() { return V; };
+   static constexpr ROOT::Internal::ExecutionPolicy ExecutionPolicyType() { return V; };
    static constexpr int Dimensions() { return W; };
 
    static void PrintTypeInfo(const std::string &fittingInfo)
@@ -61,25 +61,25 @@ char mthreadStr[] = "Multithread";
 
 // Typedefs of GradientTestTraits for scalar (serial and multithreaded)
 // scenarios
-using ScalarSerial1D = GradientTestTraits<Double_t, ROOT::Fit::ExecutionPolicy::kSerial, 1, scalarStr, serialStr>;
+using ScalarSerial1D = GradientTestTraits<Double_t, ROOT::Internal::ExecutionPolicy::kSerial, 1, scalarStr, serialStr>;
 using ScalarMultithread1D =
-   GradientTestTraits<Double_t, ROOT::Fit::ExecutionPolicy::kMultithread, 1, scalarStr, mthreadStr>;
-using ScalarSerial2D = GradientTestTraits<Double_t, ROOT::Fit::ExecutionPolicy::kSerial, 2, scalarStr, serialStr>;
+   GradientTestTraits<Double_t, ROOT::Internal::ExecutionPolicy::kMultithread, 1, scalarStr, mthreadStr>;
+using ScalarSerial2D = GradientTestTraits<Double_t, ROOT::Internal::ExecutionPolicy::kSerial, 2, scalarStr, serialStr>;
 using ScalarMultithread2D =
-   GradientTestTraits<Double_t, ROOT::Fit::ExecutionPolicy::kMultithread, 2, scalarStr, mthreadStr>;
+   GradientTestTraits<Double_t, ROOT::Internal::ExecutionPolicy::kMultithread, 2, scalarStr, mthreadStr>;
 
 #ifdef R__HAS_VECCORE
 
 // Typedefs of GradientTestTraits for vectorial (serial and multithreaded)
 // scenarios
 using VectorialSerial1D =
-   GradientTestTraits<ROOT::Double_v, ROOT::Fit::ExecutionPolicy::kSerial, 1, vectorStr, serialStr>;
+   GradientTestTraits<ROOT::Double_v, ROOT::Internal::ExecutionPolicy::kSerial, 1, vectorStr, serialStr>;
 using VectorialMultithread1D =
-   GradientTestTraits<ROOT::Double_v, ROOT::Fit::ExecutionPolicy::kMultithread, 1, vectorStr, mthreadStr>;
+   GradientTestTraits<ROOT::Double_v, ROOT::Internal::ExecutionPolicy::kMultithread, 1, vectorStr, mthreadStr>;
 using VectorialSerial2D =
-   GradientTestTraits<ROOT::Double_v, ROOT::Fit::ExecutionPolicy::kSerial, 2, vectorStr, serialStr>;
+   GradientTestTraits<ROOT::Double_v, ROOT::Internal::ExecutionPolicy::kSerial, 2, vectorStr, serialStr>;
 using VectorialMultithread2D =
-   GradientTestTraits<ROOT::Double_v, ROOT::Fit::ExecutionPolicy::kMultithread, 2, vectorStr, mthreadStr>;
+   GradientTestTraits<ROOT::Double_v, ROOT::Internal::ExecutionPolicy::kMultithread, 2, vectorStr, mthreadStr>;
 
 #endif
 
@@ -263,7 +263,7 @@ struct GradientTestEvaluation {
 
    // Basic type to compare against
    using ScalarSerial =
-      GradientTestTraits<double, ROOT::Fit::ExecutionPolicy::kSerial, T::Dimensions(), scalarStr, serialStr>;
+      GradientTestTraits<double, ROOT::Internal::ExecutionPolicy::kSerial, T::Dimensions(), scalarStr, serialStr>;
 
    GradientTestEvaluation()
    {

--- a/math/mathcore/test/testGradientFitting.cxx
+++ b/math/mathcore/test/testGradientFitting.cxx
@@ -234,7 +234,7 @@ protected:
       fExecutionPolicy = executionPolicy;
       if (printLevel>0) { 
          std::cout << "**************************************\n";
-         if (fExecutionPolicy == ROOT::Internal::ExecutionPolicy::kSerial)
+         if (fExecutionPolicy == ROOT::Internal::ExecutionPolicy::kSequential)
             std::cout << "   RUN SEQUENTIAL \n";
          else if (fExecutionPolicy == ROOT::Internal::ExecutionPolicy::kMultithread)
             std::cout << "   RUN MULTI-THREAD \n";
@@ -253,7 +253,7 @@ protected:
    typename T::FittingDataType *fData;
    TH2D *fHistogram;
    ROOT::Fit::Fitter fFitter;
-   ROOT::Internal::ExecutionPolicy fExecutionPolicy = ROOT::Internal::ExecutionPolicy::kSerial; 
+   ROOT::Internal::ExecutionPolicy fExecutionPolicy = ROOT::Internal::ExecutionPolicy::kSequential;
    static const unsigned fNumPoints = 401;
 };
 
@@ -274,7 +274,7 @@ TYPED_TEST_CASE_P(GradientFittingTest);
 // Test the fitting using the gradient is successful
 TYPED_TEST_P(GradientFittingTest, Sequential)
 {
-   EXPECT_TRUE(TestFixture::RunFit(ROOT::Internal::ExecutionPolicy::kSerial));
+   EXPECT_TRUE(TestFixture::RunFit(ROOT::Internal::ExecutionPolicy::kSequential));
 }
 
 TYPED_TEST_P(GradientFittingTest, Multithread)

--- a/math/mathcore/test/testGradientFitting.cxx
+++ b/math/mathcore/test/testGradientFitting.cxx
@@ -230,15 +230,15 @@ protected:
 
    // function actually running the test.
    // We define here the condition to say that the test is valid
-   bool RunFit(ROOT::Fit::ExecutionPolicy executionPolicy) {
+   bool RunFit(ROOT::Internal::ExecutionPolicy executionPolicy) {
       fExecutionPolicy = executionPolicy;
       if (printLevel>0) { 
          std::cout << "**************************************\n";
-         if (fExecutionPolicy == ROOT::Fit::ExecutionPolicy::kSerial)
+         if (fExecutionPolicy == ROOT::Internal::ExecutionPolicy::kSerial)
             std::cout << "   RUN SEQUENTIAL \n";
-         else if (fExecutionPolicy == ROOT::Fit::ExecutionPolicy::kMultithread)
+         else if (fExecutionPolicy == ROOT::Internal::ExecutionPolicy::kMultithread)
             std::cout << "   RUN MULTI-THREAD \n";
-         else if (fExecutionPolicy == ROOT::Fit::ExecutionPolicy::kMultiprocess)
+         else if (fExecutionPolicy == ROOT::Internal::ExecutionPolicy::kMultiprocess)
             std::cout << "   RUN MULTI-PROCESS \n";
 
          std::cout << "**************************************\n";
@@ -253,7 +253,7 @@ protected:
    typename T::FittingDataType *fData;
    TH2D *fHistogram;
    ROOT::Fit::Fitter fFitter;
-   ROOT::Fit::ExecutionPolicy fExecutionPolicy = ROOT::Fit::ExecutionPolicy::kSerial; 
+   ROOT::Internal::ExecutionPolicy fExecutionPolicy = ROOT::Internal::ExecutionPolicy::kSerial; 
    static const unsigned fNumPoints = 401;
 };
 
@@ -274,12 +274,12 @@ TYPED_TEST_CASE_P(GradientFittingTest);
 // Test the fitting using the gradient is successful
 TYPED_TEST_P(GradientFittingTest, Sequential)
 {
-   EXPECT_TRUE(TestFixture::RunFit(ROOT::Fit::ExecutionPolicy::kSerial));
+   EXPECT_TRUE(TestFixture::RunFit(ROOT::Internal::ExecutionPolicy::kSerial));
 }
 
 TYPED_TEST_P(GradientFittingTest, Multithread)
 {
-   EXPECT_TRUE(TestFixture::RunFit(ROOT::Fit::ExecutionPolicy::kMultithread));
+   EXPECT_TRUE(TestFixture::RunFit(ROOT::Internal::ExecutionPolicy::kMultithread));
 }
 
 REGISTER_TYPED_TEST_CASE_P(GradientFittingTest,Sequential,Multithread);


### PR DESCRIPTION
Disclaimer: not everyone tagged in this comment agreed to the totality of my changes, and all dissenting comments have been considered. Anything included this PR is carved in stone and everything is open for discussion

I'm proposing a generalized executor interface that resolves to the specific ones (```TThreadExecutor```, ```TProcessExecutor```, a new ```SequentialExecutor```) with an execution policy received as a parameter. This is a use case that we found in places such as ```TMVA``` (@omazapa, @lmoneta) and the various fitting functions, where currently we rely on several if-else instructions where we check the execution policy (or even if ROOT has been compiled with IMT) to instantiate the right executor.


My suggestion is to move ```TExecutor``` to ```ROOT::TExecutorBaseImpl``` (maybe in ```ROOT::Internals```?) and reuse the name. This breaks ROOT's very strict source compatibility requirements: "we should only break source compatibility if the ROOT constructs were actively harmful in some way, the volume of affected ROOT code is relatively small, and we can provide source compatibility and migration".

As discussed with @pcanal,  and with TExecutor introduced in ROOT 6.08, there's little possibilities any user has implemented a new derived class from TExecutor. If this happened, the user is most probably advanced enough to be able to change the implementation. In any case, the volume of affected ROOT code will be relatively small.  

As suggested by @dpiparo, for the moment we will keep the new ```TExecutor``` in ```ROOT::Internals```, not exposing it to the user. The executor usage will look as following:

```cpp   
ROOT::Internal::TExecutor pool(ROOT::Fit::ExecutionPolicy::kSerial);
auto mapFunction =  [](unsigned i){return 1u;};
auto reductionFunction =  [](const std::vector<unsigned> &v) {
      return std::accumulate(v.begin(), v.end(), 0u);
   };

pool.MapReduce(ROOT::Fit::ExecutionPolicy::kSerial, mapFunction, ROOT::TSeq<unsigned>(20), reductionFunction);
```



**TLDR;** This PR changes the behaviour of existing executors and introduces
new ones:

* TExecutor: changes its functionality to be a general Executor, while
TExecutorBaseImpl takes the role of the previous TExecutor. TExecutor
now acts as a general interface to the executors. The executor it will
resolve to is specified by a execution policy parameter in its
constructor.

* TExecutorBaseImpl: Plays the previous role of TExecutor.

* TSequentialExecutor: provides a sequential implementation of the
executor model, defined by TExecutorBaseImpl.

This PR is not finished, but I'm opening it for discussion. Things left:
- [x] Change kSerial to kSequential.

- [x]  Move Execution Policies to ROOT::Internal

- [x] Adapt Fitting functions to use the new TExecutor instead of if statements.

A test can be found here: https://github.com/root-project/roottest/pull/106
