### PR TITLE
[WIP] Faster, less memory-consuming jitting of Define calls in TDF

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFNodes.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFNodes.hxx
@@ -182,6 +182,7 @@ public:
    void Book(const ActionBasePtr_t &actionPtr);
    void Book(const FilterBasePtr_t &filterPtr);
    void Book(const TCustomColumnBasePtr_t &branchPtr);
+   void BookJitted(const TCustomColumnBasePtr_t &branchPtr);
    void Book(const std::shared_ptr<bool> &branchPtr);
    void Book(const RangeBasePtr_t &rangePtr);
    bool CheckFilters(int, unsigned int);
@@ -197,6 +198,7 @@ public:
    const ColumnNames_t &GetDefinedDataSourceColumns() const { return fDefinedDataSourceColumns; }
    void AddDataSourceColumn(std::string_view name) { fDefinedDataSourceColumns.emplace_back(name); }
    void AddColumnAlias(const std::string &alias, const std::string &colName) { fAliasColumnNameMap[alias] = colName; }
+   void AddCustomColumn(std::string_view name) { fCustomColumnNames.emplace_back(name); }
    const std::map<std::string, std::string> &GetAliasMap() const { return fAliasColumnNameMap; }
    void RegisterCallback(ULong64_t everyNEvents, std::function<void(unsigned int)> &&f);
 };

--- a/tree/treeplayer/src/TDFInterface.cxx
+++ b/tree/treeplayer/src/TDFInterface.cxx
@@ -88,14 +88,13 @@ std::vector<std::string> FindUsedColumnNames(std::string_view expression, const 
    return usedBranches;
 }
 
-// Jit a string filter or a string temporary column, call this->Define or this->Filter as needed
+// Jit a string filter, and jit-and-call this->Filter with the appropriate arguments
 // Return pointer to the new functional chain node returned by the call, cast to Long_t
-Long_t JitTransformation(void *thisPtr, std::string_view methodName, std::string_view interfaceTypeName,
-                         std::string_view name, std::string_view expression,
-                         const std::map<std::string, std::string> &aliasMap, const ColumnNames_t &branches,
-                         const std::vector<std::string> &customColumns,
-                         const std::map<std::string, TmpBranchBasePtr_t> &tmpBookedBranches, TTree *tree,
-                         std::string_view returnTypeName, TDataSource *ds)
+Long_t JitFilter(void *thisPtr, std::string_view interfaceTypeName, std::string_view name, std::string_view expression,
+                 const std::map<std::string, std::string> &aliasMap, const ColumnNames_t &branches,
+                 const std::vector<std::string> &customColumns,
+                 const std::map<std::string, TmpBranchBasePtr_t> &tmpBookedBranches, TTree *tree,
+                 std::string_view returnTypeName, TDataSource *ds)
 {
    const auto &dsColumns = ds ? ds->GetColumnNames() : ColumnNames_t{};
    auto usedBranches = FindUsedColumnNames(expression, branches, customColumns, dsColumns, aliasMap);
@@ -107,7 +106,7 @@ Long_t JitTransformation(void *thisPtr, std::string_view methodName, std::string
    std::vector<std::string> usedBranchesTypes;
    static unsigned int iNs = 0U;
    std::stringstream dummyDecl;
-   dummyDecl << "namespace __tdf_" << std::to_string(iNs++) << "{ auto __tdf_lambda = []() {";
+   dummyDecl << "namespace __tdf_" << std::to_string(iNs++) << "{ auto __tdf_filterlambda = []() {";
 
    // Declare variables with the same name as the column used by this transformation
    auto aliasMapEnd = aliasMap.end();
@@ -175,10 +174,7 @@ Long_t JitTransformation(void *thisPtr, std::string_view methodName, std::string
 
    // Here we have two cases: filter and column
    ss.str("");
-   ss << targetTypeName << "(((" << interfaceTypeName << "*)" << thisPtr << ")->" << methodName << "(";
-   if (methodName == "Define") {
-      ss << "\"" << name << "\", ";
-   }
+   ss << targetTypeName << "(((" << interfaceTypeName << "*)" << thisPtr << ")->Filter(";
    ss << filterLambda << ", {";
    for (auto brName : usedBranches) {
       // Here we selectively replace the brName with the real column name if it's necessary.
@@ -188,18 +184,124 @@ Long_t JitTransformation(void *thisPtr, std::string_view methodName, std::string
    }
    if (exprNeedsVariables)
       ss.seekp(-2, ss.cur); // remove the last ",
-   ss << "}";
-
-   if (methodName == "Filter") {
-      ss << ", \"" << name << "\"";
-   }
-
-   ss << "));";
+   ss << "}, \"" << name << "\"));";
 
    TInterpreter::EErrorCode interpErrCode;
    auto retVal = gInterpreter->Calc(ss.str().c_str(), &interpErrCode);
    if (TInterpreter::EErrorCode::kNoError != interpErrCode || !retVal) {
-      std::string msg = "Cannot interpret the invocation to " + std::string(methodName) + ":  ";
+      std::string msg = "Cannot interpret the invocation to Filter:  ";
+      msg += ss.str();
+      if (TInterpreter::EErrorCode::kNoError != interpErrCode) {
+         msg += "\nInterpreter error code is " + std::to_string(interpErrCode) + ".";
+      }
+      throw std::runtime_error(msg);
+   }
+   return retVal;
+}
+
+// Jit a string filter, produce string that calls this->Define with the appropriate arguments
+// Return this string, for deferred jitting
+Long_t JitDefine(void *thisPtr, std::string_view interfaceTypeName, std::string_view name, std::string_view expression,
+                 const std::map<std::string, std::string> &aliasMap, const ColumnNames_t &branches,
+                 const std::vector<std::string> &customColumns,
+                 const std::map<std::string, TmpBranchBasePtr_t> &tmpBookedBranches, TTree *tree,
+                 std::string_view returnTypeName, TDataSource *ds)
+{
+   const auto &dsColumns = ds ? ds->GetColumnNames() : ColumnNames_t{};
+   auto usedBranches = FindUsedColumnNames(expression, branches, customColumns, dsColumns, aliasMap);
+   auto exprNeedsVariables = !usedBranches.empty();
+
+   // Move to the preparation of the jitting
+   // We put all of the jitted entities in function f in namespace __tdf_N, where N is a monotonically increasing index
+   // and then try to declare that function to make sure column names, types and expression are proper C++
+   std::vector<std::string> usedBranchesTypes;
+   static unsigned int iNs = 0U;
+   std::stringstream dummyDecl;
+   dummyDecl << "namespace __tdf_" << std::to_string(iNs++) << "{ auto __tdf_definelambda = []() {";
+
+   // Declare variables with the same name as the column used by this transformation
+   auto aliasMapEnd = aliasMap.end();
+   if (exprNeedsVariables) {
+      for (auto &brName : usedBranches) {
+         // Here we replace on the fly the brName with the real one in case brName it's an alias
+         // This is then used to get the type. The variable name will be brName;
+         auto aliasMapIt = aliasMap.find(brName);
+         auto &realBrName = aliasMapEnd == aliasMapIt ? brName : aliasMapIt->second;
+         // The map is a const reference, so no operator[]
+         auto tmpBrIt = tmpBookedBranches.find(realBrName);
+         auto tmpBr = tmpBrIt == tmpBookedBranches.end() ? nullptr : tmpBrIt->second.get();
+         auto brTypeName = ColumnName2ColumnTypeName(realBrName, tree, tmpBr, ds);
+         dummyDecl << brTypeName << " " << brName << ";\n";
+         usedBranchesTypes.emplace_back(brTypeName);
+      }
+   }
+
+   TRegexp re("[^a-zA-Z0-9_]return[^a-zA-Z0-9_]");
+   int exprSize = expression.size();
+   bool hasReturnStmt = re.Index(std::string(expression), &exprSize) != -1;
+
+   // Now that branches are declared as variables, put the body of the
+   // lambda in dummyDecl and close scopes of f and namespace __tdf_N
+   if (hasReturnStmt)
+      dummyDecl << expression << "\n;};}";
+   else
+      dummyDecl << "return " << expression << "\n;};}";
+
+   // Try to declare the dummy lambda, error out if it does not compile
+   if (!gInterpreter->Declare(dummyDecl.str().c_str())) {
+      auto msg =
+         "Cannot interpret the following expression:\n" + std::string(expression) + "\n\nMake sure it is valid C++.";
+      throw std::runtime_error(msg);
+   }
+
+   // Now we build the lambda and we invoke the method with it in the jitted world
+   std::stringstream ss;
+   ss << "[](";
+   for (unsigned int i = 0; i < usedBranchesTypes.size(); ++i) {
+      // We pass by reference to avoid expensive copies
+      // It can't be const reference in general, as users might want/need to call non-const methods on the values
+      // In the special case of arguments of type `TArrayBranch`, it *has* to be a const ref as we will pass in
+      // temporaries converted from TTreeReaderArrays.
+      if (usedBranchesTypes[i].find_first_of("ROOT::Experimental::TDF::TArrayBranch<") == 0u)
+         ss << "const ";
+      // Here we do not replace anything: the name of the parameters of the lambda does not need to be the real
+      // column name, it must be an alias to compile.
+      ss << usedBranchesTypes[i] << "& " << usedBranches[i] << ", ";
+   }
+   if (!usedBranchesTypes.empty())
+      ss.seekp(-2, ss.cur);
+
+   if (hasReturnStmt)
+      ss << "){\n" << expression << "\n}";
+   else
+      ss << "){return " << expression << "\n;}";
+
+   auto defineLambda = ss.str();
+
+   // The TInterface type to convert the result to. For example, Filter returns a TInterface<TFilter<F,P>> but when
+   // returning it from a jitted call we need to convert it to TInterface<TFilterBase> as we are missing information
+   // on types F and P at compile time.
+   const auto targetTypeName = "ROOT::Experimental::TDF::TInterface<" + std::string(returnTypeName) + ">";
+
+   // Here we have two cases: filter and column
+   ss.str("");
+   ss << targetTypeName << "(((" << interfaceTypeName << "*)" << thisPtr << ")->Define(\"" << name << "\", "
+      << defineLambda << ", {";
+
+   for (auto brName : usedBranches) {
+      // Here we selectively replace the brName with the real column name if it's necessary.
+      auto aliasMapIt = aliasMap.find(brName);
+      auto &realBrName = aliasMapEnd == aliasMapIt ? brName : aliasMapIt->second;
+      ss << "\"" << realBrName << "\", ";
+   }
+   if (exprNeedsVariables)
+      ss.seekp(-2, ss.cur); // remove the last ",
+   ss << "}));";
+
+   TInterpreter::EErrorCode interpErrCode;
+   auto retVal = gInterpreter->Calc(ss.str().c_str(), &interpErrCode);
+   if (TInterpreter::EErrorCode::kNoError != interpErrCode || !retVal) {
+      std::string msg = "Cannot interpret the invocation to Define:  ";
       msg += ss.str();
       if (TInterpreter::EErrorCode::kNoError != interpErrCode) {
          msg += "\nInterpreter error code is " + std::to_string(interpErrCode) + ".";

--- a/tree/treeplayer/src/TDFNodes.cxx
+++ b/tree/treeplayer/src/TDFNodes.cxx
@@ -431,6 +431,14 @@ void TLoopManager::Book(const TCustomColumnBasePtr_t &columnPtr)
    fCustomColumnNames.emplace_back(name);
 }
 
+void TLoopManager::BookJitted(const TCustomColumnBasePtr_t &columnPtr)
+{
+   const auto &name = columnPtr->GetName();
+   fBookedCustomColumns[name] = columnPtr;
+   // jitted custom columns register the name in the TLoopManger much before (Define call time) thane when the node is
+   // actually created and booked (jitting time)
+}
+
 void TLoopManager::Book(const std::shared_ptr<bool> &readinessPtr)
 {
    fResProxyReadiness.emplace_back(readinessPtr);


### PR DESCRIPTION
Just opening the PR to discuss the problem:
Jitting many `Define` (or `Filter`) calls currently incurs in major runtime and memory consumption penalties. This is because repeated calls to `Calc` or `ProcessLine` have a significant overhead w.r.t. a single call that jits the same code in a single go.

Jitting all `Define` calls together (and together with all jitted actions) greatly reduces runtime and memory consumption.

**Current issue:**
in code such as

```c++
d.Define("x", "42").Min("x")
```

the `Min` action has no way to know the type of `x` because the lambda that produces `x` has not been jitted yet. Maybe we could defer even the creation of the strings to jit for the actions to _after_ we have jitted all the `Define`s, but this will require more thinking and more refactoring.
EDIT: the same goes for jitted `Snapshot`s, the formation of the string to jit must be deferred to after we have jitted and executed all `Define`s.