### PR TITLE
[cxxmodules] Also load STL/libc as a core module

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1100,19 +1100,30 @@ static void LoadCoreModules(cling::Interpreter &interp)
 
    clang::HeaderSearch &headerSearch = CI.getPreprocessor().getHeaderSearchInfo();
    clang::ModuleMap &moduleMap = headerSearch.getModuleMap();
+   // List of core modules we can load, but it's ok if they are missing because
+   // the system doesn't have these modules.
+   std::vector<std::string> optionalCoreModuleNames = {"stl", "libc"};
+
    // List of core modules we need to load.
    std::vector<std::string> neededCoreModuleNames = {"Core", "RIO"};
    std::vector<std::string> missingCoreModuleNames;
 
    std::vector<clang::Module *> coreModules;
 
+   // Lookup the optional core modules in the modulemap by name.
+   for (std::string moduleName : optionalCoreModuleNames) {
+      clang::Module *module = moduleMap.findModule(moduleName);
+      // Don't report an error here, the module is optional.
+      if (module)
+         coreModules.push_back(module);
+   }
    // Lookup the core modules in the modulemap by name.
    for (std::string moduleName : neededCoreModuleNames) {
       clang::Module *module = moduleMap.findModule(moduleName);
       if (module) {
          coreModules.push_back(module);
       } else {
-         // If we can't find a module, we record that to report it later.
+         // If we can't find a needed module, we record that to report it later.
          missingCoreModuleNames.push_back(moduleName);
       }
    }

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1162,6 +1162,15 @@ static void LoadCoreModules(cling::Interpreter &interp)
    for (StringRef H : moduleHeaders) {
       declarations << "#include \"" << H.str() << "\"\n";
    }
+
+   // C99 decided that it's a very good idea to name a macro `I` (the letter I).
+   // This seems to screw up nearly all the template code out there as `I` is
+   // common template parameter name and iterator variable name.
+   // Let's follow the GCC recommendation and undefine `I` in case any of the
+   // core modules have defined it:
+   // https://www.gnu.org/software/libc/manual/html_node/Complex-Numbers.html
+   declarations << "#ifdef I\n #undef I\n #endif\n";
+
    auto result = interp.declare(declarations.str());
 
    if (result != cling::Interpreter::CompilationResult::kSuccess) {


### PR DESCRIPTION
Without modules, many STL and libc headers are automatically
provided by ROOT via the attached ROOT PCH. This means that
we don't need to have autloading or explicit includes for STL
or libc headers when running with the PCH attached. This leads
to making user code like this working in ROOT:

```C++
// no includes here that provides assert
int foo() {
  assert(false);
}
```

However, as the modules don't come with this big PCH, we
are now suddenly in the situation where we can't resolve
things such as `assert`. We also can't rely on the
normal autoloading of ROOT as those declarations were
actually never autoloaded, but just provided by the PCH.

To simulate this behavior with modules, we automatically load
those headers that we expect to have in the ROOT PCH
(which are probably the STL and libc headers).