### PR TITLE
[OpenBSD] Don't assume fileno is a function.

### DIFF
--- a/core/textinput/src/textinput/TerminalDisplayUnix.cpp
+++ b/core/textinput/src/textinput/TerminalDisplayUnix.cpp
@@ -105,10 +105,10 @@ namespace textinput {
     TerminalDisplay(TerminalConfigUnix::Get().IsInteractive()),
     fIsAttached(false), fNColors(16), fOutputID(STDOUT_FILENO)
   {
-    if (::isatty(::fileno(stdin)) && !::isatty(fOutputID)) {
-      // Display prompt, even if stdout is going somewhere else
-      fOutputID = ::open("/dev/tty", O_WRONLY);
-      SetIsTTY(true);
+     if (::isatty(fileno(stdin)) && !::isatty(fOutputID)) {
+        // Display prompt, even if stdout is going somewhere else
+        fOutputID = ::open("/dev/tty", O_WRONLY);
+        SetIsTTY(true);
     }
 
     HandleResizeSignal(); // needs fOutputID


### PR DESCRIPTION
This otherwise leads to compilation errors when we do `::fileno`
as OpenBSD implemented fileno as a macro (which seems to be allowed).