### PR TITLE
[cmake][cxxmodules] Fix header globbing in core/cont

### DIFF
--- a/core/cont/CMakeLists.txt
+++ b/core/cont/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/res ${CMAKE_CURRENT_SOURCE_DIR}/../foundation/res)
 
-ROOT_GLOB_HEADERS(headers ${CMAKE_CURRENT_SOURCE_DIR}/inc/*.h)
+ROOT_GLOB_HEADERS(headers ${CMAKE_CURRENT_SOURCE_DIR}/inc/*.h ${CMAKE_CURRENT_SOURCE_DIR}/inc/ROOT/*.hxx)
 set(Cont_dict_headers ${headers} PARENT_SCOPE)
 
 ROOT_OBJECT_LIBRARY(Cont *.cxx)


### PR DESCRIPTION
This CMake globbing expression didn't look for .hxx files, which
caused that some headers weren't part of the dictionary payload.

This causes in the C++ modules build that ROOT couldn't find the
ROOT::TSeqI declarations as it wasn't officially part of the
Core module.