### PR TITLE
[TDF] Do not expect to always run `DefineSlot` on all slots

### DIFF
--- a/tree/treeplayer/test/dataframe/dataframe_simple_tests.hxx
+++ b/tree/treeplayer/test/dataframe/dataframe_simple_tests.hxx
@@ -308,24 +308,19 @@ TEST(TEST_CATEGORY, DefineSlot)
 
 TEST(TEST_CATEGORY, DefineSlotCheckMT)
 {
-   auto nSlots = NSLOTS;
+   const auto nSlots = NSLOTS;
 
-   std::hash<std::thread::id> hasher;
-   using H_t = decltype(hasher(std::this_thread::get_id()));
-
-   std::vector<H_t> ids(nSlots, 0);
+   std::vector<unsigned int> ids(nSlots, 0u);
    TDataFrame d(nSlots);
    auto m = d.DefineSlot("x", [&](unsigned int slot) {
-                std::this_thread::sleep_for(std::chrono::milliseconds(100));
-                ids[slot] = hasher(std::this_thread::get_id());
-                return 1.;
+                ids[slot] = 1u;
+                return 1;
              }).Max("x");
-
    EXPECT_EQ(1, *m); // just in case
 
-   std::set<H_t> s(ids.begin(), ids.end());
-   EXPECT_EQ(nSlots, s.size());
-   EXPECT_TRUE(s.end() == s.find(0));
+   const auto nUsedSlots = std::accumulate(ids.begin(), ids.end(), 0u);
+   EXPECT_GT(nUsedSlots, 0u);
+   EXPECT_LE(nUsedSlots, nSlots);
 }
 
 TEST(TEST_CATEGORY, DefineSlotEntry)

--- a/tree/treeplayer/test/dataframe/datasource_csv.cxx
+++ b/tree/treeplayer/test/dataframe/datasource_csv.cxx
@@ -149,26 +149,21 @@ TEST(TCsvDS, FromATDFWithJitting)
 
 TEST(TCsvDS, DefineSlotCheckMT)
 {
-   auto nSlots = 4U;
+   const auto nSlots = 4U;
    ROOT::EnableImplicitMT(nSlots);
 
-   std::hash<std::thread::id> hasher;
-   using H_t = decltype(hasher(std::this_thread::get_id()));
-
-   std::vector<H_t> ids(nSlots, 0);
+   std::vector<unsigned int> ids(nSlots, 0u);
    std::unique_ptr<TDataSource> tds(new TCsvDS(fileName0));
    TDataFrame d(std::move(tds));
    auto m = d.DefineSlot("x", [&](unsigned int slot) {
-                std::this_thread::sleep_for(std::chrono::milliseconds(100));
-                ids[slot] = hasher(std::this_thread::get_id());
-                return 1.;
+                ids[slot] = 1u;
+                return 1;
              }).Max("x");
-
    EXPECT_EQ(1, *m); // just in case
 
-   std::set<H_t> s(ids.begin(), ids.end());
-   EXPECT_EQ(nSlots, s.size());
-   EXPECT_TRUE(s.end() == s.find(0));
+   const auto nUsedSlots = std::accumulate(ids.begin(), ids.end(), 0u);
+   EXPECT_GT(nUsedSlots, 0u);
+   EXPECT_LE(nUsedSlots, nSlots);
 }
 
 TEST(TCsvDS, FromATDFMT)


### PR DESCRIPTION
This assumption caused a breakage in datasource_csv.cxx ([here](http://cdash.cern.ch/viewTest.php?onlyfailed&buildid=424155)) and it's the same that caused breakages in datasource_root.cxx (fixed by commit feab873bacc8476dc931d60b41a125bb7d4c6fa2).