### PR TITLE
[cxxmodules] Also load TreePlayer to fix TDataFrame tests.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1163,6 +1163,15 @@ static void LoadCoreModules(cling::Interpreter &interp)
    for (StringRef H : moduleHeaders) {
       declarations << "#include \"" << H.str() << "\"\n";
    }
+
+   // C99 decided that it's a very good idea to name a macro `I` (the letter I).
+   // This seems to screw up nearly all the template code out there as `I` is
+   // common template parameter name and iterator variable name.
+   // Let's follow the GCC recommendation and undefine `I` in case any of the
+   // core modules have defined it:
+   // https://www.gnu.org/software/libc/manual/html_node/Complex-Numbers.html
+   declarations << "#ifdef I\n #undef I\n #endif\n";
+
    auto result = interp.declare(declarations.str());
 
    if (result != cling::Interpreter::CompilationResult::kSuccess) {

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1101,19 +1101,30 @@ static void LoadCoreModules(cling::Interpreter &interp)
 
    clang::HeaderSearch &headerSearch = CI.getPreprocessor().getHeaderSearchInfo();
    clang::ModuleMap &moduleMap = headerSearch.getModuleMap();
+   // List of core modules we can load, but it's ok if they are missing because
+   // the system doesn't have these modules.
+   std::vector<std::string> optionalCoreModuleNames = {"stl", "libc"};
+
    // List of core modules we need to load.
    std::vector<std::string> neededCoreModuleNames = {"Core", "RIO"};
    std::vector<std::string> missingCoreModuleNames;
 
    std::vector<clang::Module *> coreModules;
 
+   // Lookup the optional core modules in the modulemap by name.
+   for (std::string moduleName : optionalCoreModuleNames) {
+      clang::Module *module = moduleMap.findModule(moduleName);
+      // Don't report an error here, the module is optional.
+      if (module)
+         coreModules.push_back(module);
+   }
    // Lookup the core modules in the modulemap by name.
    for (std::string moduleName : neededCoreModuleNames) {
       clang::Module *module = moduleMap.findModule(moduleName);
       if (module) {
          coreModules.push_back(module);
       } else {
-         // If we can't find a module, we record that to report it later.
+         // If we can't find a needed module, we record that to report it later.
          missingCoreModuleNames.push_back(moduleName);
       }
    }

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1106,7 +1106,10 @@ static void LoadCoreModules(cling::Interpreter &interp)
    std::vector<std::string> optionalCoreModuleNames = {"stl", "libc"};
 
    // List of core modules we need to load.
-   std::vector<std::string> neededCoreModuleNames = {"Core", "RIO"};
+   // FIXME: TreePlayer is here because the rootmap loading doesn't work with
+   // TDataFrame. This should be gone once we no longer rely on rootmap files
+   // for loading a module.
+   std::vector<std::string> neededCoreModuleNames = {"Core", "RIO", "TreePlayer"};
    std::vector<std::string> missingCoreModuleNames;
 
    std::vector<clang::Module *> coreModules;


### PR DESCRIPTION
Depends on: #1317, adds only one other commit:

    It seems automatically loading TreePlayer when TDataFrame is used
    without the appropriate include never worked. This was previously
    fixed by just adding TreePlayer (which contains TDF) to the PCH.
    
    As always, let's recreate this hack with modules to make restore
    the old behavior with modules turned on.
