### PR TITLE
[cxxmodules] Always enable -Rmodule-build

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -4302,12 +4302,9 @@ int RootClingMain(int argc,
       clingArgsInterpreter.push_back("-fmodules-cache-path=" +
                                      llvm::sys::path::parent_path(sharedLibraryPathName).str());
 
-      // If the user has passed ROOT_MODULES with the value 'DEBUG', then we
-      // enable remarks in clang for building on-demand modules. This is useful
-      // to figure out when and why on-demand modules are built by clang.
-      if (llvm::StringRef(getenv("ROOT_MODULES")) == "DEBUG") {
-         clingArgsInterpreter.push_back("-Rmodule-build");
-      }
+      // We enable remarks in clang for building on-demand modules. This is
+      // useful to figure out when and why on-demand modules are built by clang.
+      clingArgsInterpreter.push_back("-Rmodule-build");
    }
 
    // Convert arguments to a C array and check if they are sane

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1258,6 +1258,10 @@ TCling::TCling(const char *name, const char *title)
    if (useCxxModules && !fromRootCling) {
       // We only set this flag, rest is done by the CIFactory.
       interpArgs.push_back("-fmodules");
+      // We should never build modules during runtime, so let's enable the
+      // module build remarks from clang to make it easier to spot when we do
+      // this by accident.
+      interpArgs.push_back("-Rmodule-build");
 
       TString vfsPath = TROOT::GetIncludeDir() + "/modulemap.overlay.yaml";
       // On modules aware build systems (such as OSX) we do not need an overlay file and thus the build system does not


### PR DESCRIPTION
This will be replaced with a proper error message in the future
once we have a reliable way of implmenting such an error. For
now it's already an improvement if we always print a warning
when we build a module on demand.