### PR TITLE
cppcheck: fix some reports

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -454,7 +454,7 @@ void AnnotateFieldDecl(clang::FieldDecl &decl,
    // We may look for a smarter algorithm.
 
    // Nothing to do then ...
-   if (fieldSelRules.size() == 0) return;
+   if (fieldSelRules.empty()) return;
 
    clang::ASTContext &C = decl.getASTContext();
    clang::SourceRange commentRange; // Empty: this is a fake comment
@@ -4570,7 +4570,7 @@ int RootClingMain(int argc,
                            inlineInputHeader,
                            sharedLibraryPathName);
 
-   if (!gDriverConfig->fBuildingROOTStage1 && filesIncludedByLinkdef.size() !=0) {
+   if (!gDriverConfig->fBuildingROOTStage1 && !filesIncludedByLinkdef.empty()) {
       pcmArgs.push_back(argv[linkdefLoc]);
    }
 

--- a/core/winnt/src/TWinNTSystem.cxx
+++ b/core/winnt/src/TWinNTSystem.cxx
@@ -5031,8 +5031,8 @@ int TWinNTSystem::GetSockOpt(int socket, int opt, int *val)
          if (sock == INVALID_SOCKET) {
             ::SysError("GetSockOpt", "INVALID_SOCKET");
          }
-         return -1;
          *val = flg; //  & O_NDELAY;  It is not been defined for WIN32
+         return -1;
       }
       break;
 #if 0

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -319,7 +319,7 @@ ROOT::Experimental::TCanvasPainter::~TCanvasPainter()
 /// Used to wait for such condition
 int ROOT::Experimental::TCanvasPainter::CheckDeliveredVersion(uint64_t ver, double)
 {
-   if ((fWebConn.size() == 0) && fHadWebConn)
+   if (fWebConn.empty() && fHadWebConn)
       return -1;
    if (fSnapshotDelivered >= ver)
       return 1;
@@ -371,7 +371,7 @@ void ROOT::Experimental::TCanvasPainter::CheckDataToSend()
 
       TString buf;
 
-      if (conn.fDrawReady && (fCmds.size() > 0) && !fCmds.front().fRunning) {
+      if (conn.fDrawReady && !fCmds.empty() && !fCmds.front().fRunning) {
          WebCommand &cmd = fCmds.front();
          cmd.fRunning = true;
          buf = "CMD:";
@@ -416,7 +416,7 @@ void ROOT::Experimental::TCanvasPainter::CheckDataToSend()
    }
 
    // if there are updates submitted, but all connections disappeared - cancel all updates
-   if ((fWebConn.size() == 0) && fSnapshotDelivered)
+   if (fWebConn.empty() && fSnapshotDelivered)
       return CancelUpdates();
 
    if (fSnapshotDelivered != min_delivered) {
@@ -472,7 +472,7 @@ void ROOT::Experimental::TCanvasPainter::CanvasUpdated(uint64_t ver, bool async,
 
 int ROOT::Experimental::TCanvasPainter::CheckWaitingCmd(const std::string &cmdname, double)
 {
-   if ((fWebConn.size() == 0) && fHadWebConn)
+   if (fWebConn.empty() && fHadWebConn)
       return -1;
    if (fWaitingCmdId.empty()) {
       printf("Command %s waiting READY!!!\n", cmdname.c_str());
@@ -584,7 +584,7 @@ void ROOT::Experimental::TCanvasPainter::ProcessData(unsigned connid, const std:
       std::string id;
       if (separ)
          id.append(sid, separ - sid);
-      if (fCmds.size() == 0) {
+      if (fCmds.empty()) {
          printf("Get REPLY without command\n");
       } else if (!fCmds.front().fRunning) {
          printf("Front command is not running when get reply\n");
@@ -784,7 +784,7 @@ bool ROOT::Experimental::TCanvasPainter::FrontCommandReplied(const std::string &
 
 void ROOT::Experimental::TCanvasPainter::PopFrontCommand(bool result)
 {
-   if (fCmds.size() == 0)
+   if (fCmds.empty())
       return;
 
    // simple condition, which will be checked in waiting loop

--- a/html/src/TDocParser.cxx
+++ b/html/src/TDocParser.cxx
@@ -681,7 +681,7 @@ void TDocParser::DecorateKeywords(TString& line)
       TDataMember *datamem = 0;
       TMethod *meth = 0;
       const char* globalTypeName = 0;
-      if (!currentType.size()) {
+      if (currentType.empty()) {
          Warning("DecorateKeywords", "type context is empty!");
          currentType.push_back(0);
       }

--- a/math/mathcore/src/SparseData.cxx
+++ b/math/mathcore/src/SparseData.cxx
@@ -96,8 +96,8 @@ namespace ROOT {
             while ( isIn && boxit != b2.fMin.end() )
             {
                if ( (*boxit) >= (*bigit) ) isIn = false;
-               boxit++;
-               bigit++;
+               ++boxit;
+               ++bigit;
             }
 
             boxit = b2.fMax.begin();
@@ -105,8 +105,8 @@ namespace ROOT {
             while ( isIn && boxit != b2.fMax.end() )
             {
                if ( (*boxit) <= (*bigit) ) isIn = false;
-               boxit++;
-               bigit++;
+               ++boxit;
+               ++bigit;
             }
 
             return isIn;
@@ -131,7 +131,7 @@ namespace ROOT {
 //             if ( TMath::AreEqualRel(value, (*fIter), fLimit) )
                fThereIsArea = false;
 
-            fIter++;
+            ++fIter;
          }
 
          bool IsThereArea() { return fThereIsArea; }

--- a/math/mathcore/src/TMath.cxx
+++ b/math/mathcore/src/TMath.cxx
@@ -823,11 +823,11 @@ Double_t TMath::KolmogorovTest(Int_t na, const Double_t *a, Int_t nb, const Doub
       } else {
          // special cases for the ties
          double x = a[ia];
-         while(a[ia] == x && ia < na) {
+         while(ia < na && a[ia] == x) {
             rdiff -= sa;
             ia++;
          }
-         while(b[ib] == x && ib < nb) {
+         while(ib < nb && b[ib] == x) {
             rdiff += sb;
             ib++;
          }

--- a/math/mathcore/src/triangle.c
+++ b/math/mathcore/src/triangle.c
@@ -15431,8 +15431,9 @@ struct behavior *b;
       worstaspect = triaspect2;
     }
     aspectindex = 0;
-    while ((triaspect2 > ratiotable[aspectindex] * ratiotable[aspectindex])
-           && (aspectindex < 15)) {
+    while ((aspectindex < 15) &&
+            (triaspect2 > ratiotable[aspectindex] * ratiotable[aspectindex])
+          ) {
       aspectindex++;
     }
     aspecttable[aspectindex]++;

--- a/math/minuit/src/TFitter.cxx
+++ b/math/minuit/src/TFitter.cxx
@@ -138,6 +138,8 @@ void TFitter::GetConfidenceIntervals(Int_t n, Int_t ndim, const Double_t *x, Dou
    if (!matr){
       delete [] grad;
       delete [] sum_vector;
+      if (fixed)
+         delete [] fixed;
       return;
    }
   

--- a/math/minuit2/src/Minuit2Minimizer.cxx
+++ b/math/minuit2/src/Minuit2Minimizer.cxx
@@ -666,7 +666,7 @@ const double * Minuit2Minimizer::Errors() const {
 
 double Minuit2Minimizer::CovMatrix(unsigned int i, unsigned int j) const {
    // get value of covariance matrices (transform from external to internal indices)
-   if ( i >= fDim || i >= fDim) return 0;
+   if ( i >= fDim || j >= fDim) return 0;
    if (  !fState.HasCovariance()    ) return 0; // no info available when minimization has failed
    if (fState.Parameter(i).IsFixed() || fState.Parameter(i).IsConst() ) return 0;
    if (fState.Parameter(j).IsFixed() || fState.Parameter(j).IsConst() ) return 0;
@@ -733,7 +733,7 @@ bool Minuit2Minimizer::GetHessianMatrix(double * hess) const {
 
 double Minuit2Minimizer::Correlation(unsigned int i, unsigned int j) const {
    // get correlation between parameter i and j
-   if ( i >= fDim || i >= fDim) return 0;
+   if ( i >= fDim || j >= fDim) return 0;
    if (  !fState.HasCovariance()    ) return 0; // no info available when minimization has failed
    if (fState.Parameter(i).IsFixed() || fState.Parameter(i).IsConst() ) return 0;
    if (fState.Parameter(j).IsFixed() || fState.Parameter(j).IsConst() ) return 0;
@@ -750,7 +750,7 @@ double Minuit2Minimizer::GlobalCC(unsigned int i) const {
    // the correlation between the i-th parameter  and that linear combination of all other parameters which
    // is most strongly correlated with i.
 
-   if ( i >= fDim || i >= fDim) return 0;
+   if ( i >= fDim ) return 0;
     // no info available when minimization has failed or has some problems
    if ( !fState.HasGlobalCC()    ) return 0;
    if (fState.Parameter(i).IsFixed() || fState.Parameter(i).IsConst() ) return 0;

--- a/math/minuit2/src/MnContours.cxx
+++ b/math/minuit2/src/MnContours.cxx
@@ -150,7 +150,7 @@ ContoursError MnContours::Contour(unsigned int px, unsigned int py, unsigned int
       double dy = idist1->second - (idist2)->second;
       double bigdis = scalx*scalx*dx*dx + scaly*scaly*dy*dy;
 
-      for(std::vector<std::pair<double,double> >::iterator ipair = result.begin(); ipair != result.end()-1; ipair++) {
+      for(std::vector<std::pair<double,double> >::iterator ipair = result.begin(); ipair != result.end()-1; ++ipair) {
          double distx = ipair->first - (ipair+1)->first;
          double disty = ipair->second - (ipair+1)->second;
          double dist = scalx*scalx*distx*distx + scaly*scaly*disty*disty;

--- a/math/minuit2/src/MnPlot.cxx
+++ b/math/minuit2/src/MnPlot.cxx
@@ -22,7 +22,7 @@ void MnPlot::operator()(const std::vector<std::pair<double,double> >& points) co
    std::vector<double> y; y.reserve(points.size());
    std::vector<char> chpt; chpt.reserve(points.size());
 
-   for(std::vector<std::pair<double,double> >::const_iterator ipoint = points.begin(); ipoint != points.end(); ipoint++) {
+   for(std::vector<std::pair<double,double> >::const_iterator ipoint = points.begin(); ipoint != points.end(); ++ipoint) {
       x.push_back((*ipoint).first);
       y.push_back((*ipoint).second);
       chpt.push_back('*');
@@ -44,7 +44,7 @@ void MnPlot::operator()(double xmin, double ymin, const std::vector<std::pair<do
    chpt.push_back(' ');
    chpt.push_back('X');
 
-   for(std::vector<std::pair<double,double> >::const_iterator ipoint = points.begin(); ipoint != points.end(); ipoint++) {
+   for(std::vector<std::pair<double,double> >::const_iterator ipoint = points.begin(); ipoint != points.end(); ++ipoint) {
       x.push_back((*ipoint).first);
       y.push_back((*ipoint).second);
       chpt.push_back('*');

--- a/math/minuit2/src/MnPrint.cxx
+++ b/math/minuit2/src/MnPrint.cxx
@@ -117,7 +117,7 @@ std::ostream& operator<<(std::ostream& os, const MnUserParameters& par) {
 
    bool atLoLim = false;
    bool atHiLim = false;
-   for(std::vector<MinuitParameter>::const_iterator ipar = par.Parameters().begin(); ipar != par.Parameters().end(); ipar++) {
+   for(std::vector<MinuitParameter>::const_iterator ipar = par.Parameters().begin(); ipar != par.Parameters().end(); ++ipar) {
       os << std::setw(4) << (*ipar).Number() << std::setw(5) << "||";
       os << std::setw(10) << (*ipar).Name()   << std::setw(3) << "||";
       if((*ipar).IsConst()) {
@@ -364,7 +364,7 @@ std::ostream& operator<<(std::ostream& os, const ContoursError& ce) {
    os << ce.YMinosError() << std::endl;
    MnPlot plot;
    plot(ce.XMin(), ce.YMin(), ce());
-   for(std::vector<std::pair<double,double> >::const_iterator ipar = ce().begin(); ipar != ce().end(); ipar++) {
+   for(std::vector<std::pair<double,double> >::const_iterator ipar = ce().begin(); ipar != ce().end(); ++ipar) {
       os << ipar - ce().begin() <<"  "<< (*ipar).first <<"  "<< (*ipar).second <<std::endl;
    }
    os << std::endl;

--- a/math/minuit2/src/MnUserParameterState.cxx
+++ b/math/minuit2/src/MnUserParameterState.cxx
@@ -30,7 +30,7 @@ MnUserParameterState::MnUserParameterState(const MnUserParameters& par) :
    fValid(true), fCovarianceValid(false), fGCCValid(false), fCovStatus(-1), fFVal(0.), fEDM(0.), fNFcn(0), fParameters(par), fCovariance(MnUserCovariance()), fGlobalCC(MnGlobalCorrelationCoeff()), fIntParameters(std::vector<double>()), fIntCovariance(MnUserCovariance()) {
    // construct from user parameters (befor minimization)
 
-   for(std::vector<MinuitParameter>::const_iterator ipar = MinuitParameters().begin(); ipar != MinuitParameters().end(); ipar++) {
+   for(std::vector<MinuitParameter>::const_iterator ipar = MinuitParameters().begin(); ipar != MinuitParameters().end(); ++ipar) {
       if((*ipar).IsConst() || (*ipar).IsFixed()) continue;
       if((*ipar).HasLimits())
          fIntParameters.push_back(Ext2int((*ipar).Number(), (*ipar).Value()));
@@ -78,7 +78,7 @@ MnUserParameterState::MnUserParameterState(const MnUserParameters& par, const Mn
    // MnUserParameters and MnUserCovariance objects
 
    fIntCovariance.Scale(0.5);
-   for(std::vector<MinuitParameter>::const_iterator ipar = MinuitParameters().begin(); ipar != MinuitParameters().end(); ipar++) {
+   for(std::vector<MinuitParameter>::const_iterator ipar = MinuitParameters().begin(); ipar != MinuitParameters().end(); ++ipar) {
       if((*ipar).IsConst() || (*ipar).IsFixed()) continue;
       if((*ipar).HasLimits())
          fIntParameters.push_back(Ext2int((*ipar).Number(), (*ipar).Value()));
@@ -102,7 +102,7 @@ MnUserParameterState::MnUserParameterState(const MinimumState& st, double up, co
    //
    //std::cout << "build a MnUSerParameterState after minimization.." << std::endl;
    
-   for(std::vector<MinuitParameter>::const_iterator ipar = trafo.Parameters().begin(); ipar != trafo.Parameters().end(); ipar++) {
+   for(std::vector<MinuitParameter>::const_iterator ipar = trafo.Parameters().begin(); ipar != trafo.Parameters().end(); ++ipar) {
       if((*ipar).IsConst()) {
          Add((*ipar).GetName(), (*ipar).Value());
       } else if((*ipar).IsFixed()) {

--- a/math/minuit2/src/MnUserTransformation.cxx
+++ b/math/minuit2/src/MnUserTransformation.cxx
@@ -235,7 +235,7 @@ std::vector<double> MnUserTransformation::Errors() const {
    // return std::vector of double with parameter errors
    std::vector<double> result; result.reserve(fParameters.size());
    for(std::vector<MinuitParameter>::const_iterator ipar = Parameters().begin();
-       ipar != Parameters().end(); ipar++)
+       ipar != Parameters().end(); ++ipar)
       result.push_back((*ipar).Error());
 
    return result;

--- a/misc/table/src/TFileIter.cxx
+++ b/misc/table/src/TFileIter.cxx
@@ -465,7 +465,7 @@ TKey *TFileIter::NextEventKey(UInt_t eventNumber, UInt_t runNumber, const char *
       if (runNumber != UInt_t(-1)) {
          UInt_t thisRunNumber = thisKey.RunNumber();
          if (thisRunNumber < runNumber) continue;
-         if (thisRunNumber < runNumber) { key = 0; break; }
+         if (thisRunNumber > runNumber) { key = 0; break; }
       }
       // Check "event number"
       if (eventNumber != UInt_t(-1)) {

--- a/misc/table/src/TTable.cxx
+++ b/misc/table/src/TTable.cxx
@@ -1576,7 +1576,7 @@ Char_t *TTable::Print(Char_t *strbuf,Int_t lenbuf) const
    TTableDescriptor::iterator dsc  = dscT->begin();
    TTableDescriptor::iterator dscE = dscT->end();
    TDataSetIter nextComment(dscT->MakeCommentField(kFALSE));
-   for (;dsc != dscE; dsc++) {
+   for (;dsc != dscE; ++dsc) {
       TROOT::IndentLevel();
       TString name = GetTypeName(EColumnType((*dsc).fType));
       if (lenbuf>0) {
@@ -1688,7 +1688,7 @@ const Char_t *TTable::Print(Int_t row, Int_t rownumber, const Char_t *, const Ch
       TTableDescriptor::iterator   dscE = dscT->end();
       TDataSetIter nextComment(dscT->MakeCommentField(kFALSE));
 
-      for (; member != dscE; member++){
+      for (; member != dscE; ++member){
          TString membertype = GetTypeName(EColumnType((*member).fType));
          isdate = kFALSE;
          if (strcmp((*member).fColumnName,"fDatime") == 0 && EColumnType((*member).fType) == kUInt)
@@ -1859,7 +1859,7 @@ void TTable::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 //              Member loop
    TTableDescriptor::iterator member  = dscT->begin();
    TTableDescriptor::iterator   dscE  = dscT->end();
-   for (; member != dscE; member++) {  //LOOP over members
+   for (; member != dscE; ++member) {  //LOOP over members
       TString memberType = GetTypeName(EColumnType((*member).fType));
       TString memberName((*member).fColumnName);
 
@@ -2452,7 +2452,7 @@ TTable::piterator::piterator(const TTable *t,EColumnType type): fCurrentRowIndex
       TTableDescriptor::iterator ptr     = tabsDsc->begin();
       TTableDescriptor::iterator lastPtr = tabsDsc->end();
       UInt_t i =0;
-      for( i = 0; ptr != lastPtr; ptr++,i++)
+      for( i = 0; ptr != lastPtr; ++ptr,++i)
          if ( tabsDsc->ColumnType(i) == type ) fPtrs.push_back(tabsDsc->Offset(i));
       if (fPtrs.size()==0) {
          MakeEnd(t->GetNRows());

--- a/net/auth/src/TAuthenticate.cxx
+++ b/net/auth/src/TAuthenticate.cxx
@@ -4202,6 +4202,7 @@ Int_t TAuthenticate::ReadRootAuthrc()
       if (!tmp) {
          ::Error("TAuthenticate::ReadRootAuthrc",
                  "could not allocate temporary buffer");
+         fclose(fd);
          return 0;
       }
       strlcpy(tmp, line, tmpSize);

--- a/net/monalisa/src/TMonaLisaWriter.cxx
+++ b/net/monalisa/src/TMonaLisaWriter.cxx
@@ -386,7 +386,7 @@ TMonaLisaWriter::~TMonaLisaWriter()
       std::map<UInt_t, MonitoredTFileInfo *>::iterator iter = fMonInfoRepo->begin();
       while (iter != fMonInfoRepo->end()) {
          delete iter->second;
-         iter++;
+         ++iter;
       }
 
       fMonInfoRepo->clear();
@@ -946,15 +946,20 @@ Bool_t TMonaLisaWriter::SendFileCheckpoint(TFile *file)
          iter->second = 0;
       }
 
-      iter++;
+      ++iter;
       if (iter != fMonInfoRepo->end())
          mi = iter->second;
       else
          mi = 0;
    }
 
-   for (iter = fMonInfoRepo->begin(); iter != fMonInfoRepo->end(); iter++)
-      if (!iter->second) fMonInfoRepo->erase(iter);
+   for (iter = fMonInfoRepo->begin(); iter != fMonInfoRepo->end(); ) 
+   {
+      if (!iter->second)
+         iter = fMonInfoRepo->erase(iter);
+      else
+         ++iter;
+   }
 
    // This info is a summary valid for all the monitored files at once.
    // It makes no sense at all to send data relative to a specific file here

--- a/proof/proof/src/TDataSetManagerAliEn.cxx
+++ b/proof/proof/src/TDataSetManagerAliEn.cxx
@@ -959,7 +959,7 @@ std::vector<Int_t> *TDataSetManagerAliEn::ExpandRunSpec(TString &runSpec) {
     while (itr != runNums.end()) {
       if ((itr == runNums.begin()) || (prevVal != *itr)) {
         prevVal = *itr;
-        itr++;
+        ++itr;
       }
       else {
         itr = runNums.erase(itr);

--- a/proof/proofd/src/XrdProofSched.cxx
+++ b/proof/proofd/src/XrdProofSched.cxx
@@ -281,7 +281,7 @@ int XrdProofSched::Enqueue(XrdProofdProofServ *xps, XrdProofQuery *query)
 
    if (xps->Enqueue(query) == 1) {
       std::list<XrdProofdProofServ *>::iterator ii;
-      for (ii = fQueue.begin(); ii != fQueue.end(); ii++) {
+      for (ii = fQueue.begin(); ii != fQueue.end(); ++ii) {
          if ((*ii)->Status() == kXPD_running) break;
       }
       if (ii != fQueue.end()) {
@@ -307,7 +307,7 @@ void XrdProofSched::DumpQueues(const char *prefix)
    TRACE(ALL," +++ # of waiting sessions: "<<fQueue.size());
    std::list<XrdProofdProofServ *>::iterator ii;
    int i = 0;
-   for (ii = fQueue.begin(); ii != fQueue.end(); ii++) {
+   for (ii = fQueue.begin(); ii != fQueue.end(); ++ii) {
       TRACE(ALL," +++ #"<<++i<<" client:"<< (*ii)->Client()<<" # of queries: "<< (*ii)->Queries()->size());
    }
    TRACE(ALL," ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ ");
@@ -473,7 +473,7 @@ int XrdProofSched::GetWorkers(XrdProofdProofServ *xps,
 
          std::list<XrdProofWorker *>::iterator nxWrk = acws->begin();
          while (nw--) {
-            nxWrk++;
+            ++nxWrk;
             // Add export version of the info
             // (stats are updated in XrdProofdProtocol::GetWorkers)
             wrks->push_back(*nxWrk);
@@ -510,8 +510,8 @@ int XrdProofSched::GetWorkers(XrdProofdProofServ *xps,
          std::list<XrdProofWorker *>::iterator xWrk = acws->begin();
          if ((*xWrk)->Active() < maxnum) {
             acwseff->push_back(*xWrk);
-            xWrk++;
-            for (; xWrk != acws->end(); xWrk++) {
+            ++xWrk;
+            for (; xWrk != acws->end(); ++xWrk) {
                if ((*xWrk)->Active() < maxnum) {
                   acwseff->push_back(*xWrk);
                   ok = 1;
@@ -597,8 +597,8 @@ int XrdProofSched::GetWorkers(XrdProofdProofServ *xps,
          int namx = -1;
          int i = 1;
          std::list<XrdProofWorker *>::iterator iwk = acws->begin();
-         iwk++; // Skip master
-         for ( ; iwk != acws->end(); iwk++) {
+         ++iwk; // Skip master
+         for ( ; iwk != acws->end(); ++iwk) {
             vwrk[i] = *iwk;
             int na = (*iwk)->Active();
             printf(" %d", na);
@@ -657,7 +657,7 @@ int XrdProofSched::GetWorkers(XrdProofdProofServ *xps,
          int nw = fWorkerMax;
          while (nw--) {
             while (iw != fNextWrk) {
-               nxWrk++;
+               ++nxWrk;
                iw++;
             }
             // Add export version of the info
@@ -675,11 +675,11 @@ int XrdProofSched::GetWorkers(XrdProofdProofServ *xps,
    } else {
       // The full list
       std::list<XrdProofWorker *>::iterator iw = acws->begin();
-      iw++;
+      ++iw;
       while (iw != acws->end()) {
          // Add to the list (stats are updated in XrdProofdProtocol::GetWorkers)
          wrks->push_back(*iw);
-         iw++;
+         ++iw;
       }
    }
 

--- a/proof/proofd/src/XrdProofWorker.cxx
+++ b/proof/proofd/src/XrdProofWorker.cxx
@@ -325,7 +325,7 @@ void XrdProofWorker::Sort(std::list<XrdProofWorker *> *lst,
    // Fill a temp array with the current status
    XrdProofWorker **ta = new XrdProofWorker *[lst->size() - 1];
    std::list<XrdProofWorker *>::iterator i = lst->begin();
-   i++; // skip master
+   ++i; // skip master
    int n = 0;
    for (; i != lst->end(); ++i)
       ta[n++] = *i;

--- a/proof/proofd/src/XrdProofdAdmin.cxx
+++ b/proof/proofd/src/XrdProofdAdmin.cxx
@@ -187,7 +187,7 @@ int XrdProofdAdmin::Config(bool rcf)
    if (fExportPaths.size() > 0) {
       TRACE(ALL, "additional paths which can be browsed by all users: ");
       std::list<XrdOucString>::iterator is = fExportPaths.begin();
-      while (is != fExportPaths.end()) { TRACE(ALL, "   "<<*is); is++; }
+      while (is != fExportPaths.end()) { TRACE(ALL, "   "<<*is); ++is; }
    }
    // Allowed / supported copy commands
    TRACE(ALL, "allowed/supported copy commands: "<<fCpCmds);
@@ -1746,7 +1746,7 @@ int XrdProofdAdmin::CheckPath(bool superuser, const char *sbdir,
             notfound = 0;
             break;
          }
-         si++;
+         ++si;
       }
       if (notfound) {
          emsg = "CheckPath: not allowed to run the requested action on ";

--- a/proof/proofd/src/XrdProofdAux.cxx
+++ b/proof/proofd/src/XrdProofdAux.cxx
@@ -2010,7 +2010,7 @@ bool XrdProofdMultiStr::Matches(const char *s)
             str.replace(fHead,"");
             str.replace(fTail,"");
             std::list<XrdProofdMultiStrToken>::iterator it = fTokens.begin();
-            for (; it != fTokens.end(); it++) {
+            for (; it != fTokens.end(); ++it) {
                if ((*it).Matches(str.c_str()))
                   return 1;
             }
@@ -2030,7 +2030,7 @@ XrdOucString XrdProofdMultiStr::Export()
    str = "";
    if (fN > 0) {
       std::list<XrdProofdMultiStrToken>::iterator it = fTokens.begin();
-      for (; it != fTokens.end(); it++) {
+      for (; it != fTokens.end(); ++it) {
          int n = (*it).N(), j = -1;
          while (n--) {
             str += fHead;
@@ -2056,7 +2056,7 @@ XrdOucString XrdProofdMultiStr::Get(int i)
 
    if (i >= 0) {
       std::list<XrdProofdMultiStrToken>::iterator it = fTokens.begin();
-      for (; it != fTokens.end(); it++) {
+      for (; it != fTokens.end(); ++it) {
          int n = (*it).N(), j = -1;
          if ((i + 1) > n) {
             i -= n;

--- a/proof/proofd/src/XrdProofdClient.cxx
+++ b/proof/proofd/src/XrdProofdClient.cxx
@@ -696,7 +696,7 @@ void XrdProofdClient::ResetSessions()
 
    XrdSysMutexHelper mh(fMutex);
    std::vector<XrdProofdProofServ *>::iterator ip;
-   for (ip = fProofServs.begin(); ip != fProofServs.end(); ip++) {
+   for (ip = fProofServs.begin(); ip != fProofServs.end(); ++ip) {
       // Reset (invalidate) the server instance
       if (*ip) (*ip)->Reset();
    }

--- a/proof/proofd/src/XrdProofdManager.cxx
+++ b/proof/proofd/src/XrdProofdManager.cxx
@@ -265,7 +265,7 @@ XrdProofdManager::XrdProofdManager(char *parms, XrdProtocol_Config *pi, XrdSysEr
    std::list<XrdOucString>::iterator ia = fRootdArgs.begin();
    while (ia != fRootdArgs.end()) {
       fRootdArgsPtrs[i] = (*ia).c_str();
-      i++; ia++;
+      ++i; ++ia;
    }
    fRootdArgsPtrs[fRootdArgs.size() + 1] = 0;
    // Started with 'system' (not 'fork')
@@ -727,11 +727,11 @@ int XrdProofdManager::GetWorkers(XrdOucString &lw, XrdProofdProofServ *xps,
       // If in remote PLite mode, we need to isolate the number of workers
       // per unique node
       if (fRemotePLite) {
-         for (iw = wrks.begin(); iw != wrks.end() ; iw++) {
+         for (iw = wrks.begin(); iw != wrks.end() ; ++iw) {
             XrdProofWorker *w = *iw;
             // Do we have it already in the unique list?
             bool isnew = 1;
-            for (iaw = uwrks.begin(); iaw != uwrks.end() ; iaw++) {
+            for (iaw = uwrks.begin(); iaw != uwrks.end() ; ++iaw) {
                XrdProofWorker *uw = *iaw;
                if (w->fHost == uw->fHost && w->fPort == uw->fPort) {
                   uw->fNwrks += 1;
@@ -756,7 +756,7 @@ int XrdProofdManager::GetWorkers(XrdOucString &lw, XrdProofdProofServ *xps,
                w->AddProofServ(xps);
             }
          }
-         for (iw = uwrks.begin(); iw != uwrks.end() ; iw++) {
+         for (iw = uwrks.begin(); iw != uwrks.end() ; ++iw) {
             XrdProofWorker *w = *iw;
             // Master at the beginning
             if (w->fType == 'M') {
@@ -773,7 +773,7 @@ int XrdProofdManager::GetWorkers(XrdOucString &lw, XrdProofdProofServ *xps,
       } else {
 
          // The full list
-         for (iw = wrks.begin(); iw != wrks.end() ; iw++) {
+         for (iw = wrks.begin(); iw != wrks.end() ; ++iw) {
             XrdProofWorker *w = *iw;
             // Count (fActive is increased inside here)
             if (ii == -1)
@@ -801,7 +801,7 @@ int XrdProofdManager::GetWorkers(XrdOucString &lw, XrdProofdProofServ *xps,
    if (TRACING(REQ)) fNetMgr->Dump();
 
    // Clear the temp list
-   if (uwrks.size() > 0) {
+   if (!uwrks.empty()) {
       iw = uwrks.begin();
       while (iw != uwrks.end()) {
          XrdProofWorker *w = *iw;
@@ -1058,17 +1058,17 @@ int XrdProofdManager::Config(bool rcf)
                ii = fDataSetSrcs.erase(ii);
             } else {
                // Check next
-               ii++;
+               ++ii;
             }
          } else {
             // Validate only "file" datasets
             TRACE(ALL, "Skipping validation (no \"file\" type dataset source)");
-            ii++;
+            ++ii;
          }
       }
       if (fDataSetSrcs.size() > 0) {
          TRACE(ALL, fDataSetSrcs.size() << " dataset sources defined");
-         for (ii = fDataSetSrcs.begin(); ii != fDataSetSrcs.end(); ii++) {
+         for (ii = fDataSetSrcs.begin(); ii != fDataSetSrcs.end(); ++ii) {
             TRACE(ALL, ">> Valid dataset: " << (*ii)->ToString());
             if ((*ii)->fLocal && (*ii)->fRW) {
                if (fDataSetExp.length() > 0) fDataSetExp += ",";
@@ -1286,7 +1286,7 @@ int XrdProofdManager::Config(bool rcf)
          while (ia != fRootdAllow.end()) {
             if (hhs.length() > 0) hhs += ",";
             hhs += (*ia).c_str();
-            ia++;
+            ++ia;
          }
          TRACE(ALL, "serving files with: '" << fRootdExe <<"' (protocol: 'rootd://') to ALLOWED hosts");
          TRACE(ALL, "rootd-allowed hosts: "<< hhs);
@@ -1935,7 +1935,7 @@ int XrdProofdManager::DoDirectiveDataSetSrc(char *val, XrdOucStream *cfg, bool)
       // If first local, add it in front
       std::list<XrdProofdDSInfo *>::iterator ii = fDataSetSrcs.begin();
       bool haslocal = 0;
-      for (ii = fDataSetSrcs.begin(); ii != fDataSetSrcs.end(); ii++) {
+      for (ii = fDataSetSrcs.begin(); ii != fDataSetSrcs.end(); ++ii) {
          if ((*ii)->fLocal) {
             haslocal = 1;
             break;
@@ -2074,7 +2074,7 @@ int XrdProofdManager::DoDirectiveRootd(char *val, XrdOucStream *cfg, bool)
    std::list<XrdOucString>::iterator ia = fRootdArgs.begin();
    while (ia != fRootdArgs.end()) {
       fRootdArgsPtrs[i] = (*ia).c_str();
-      i++; ia++;
+      ++i; ++ia;
    }
    fRootdArgsPtrs[fRootdArgs.size() + 1] = 0;
 
@@ -2172,7 +2172,7 @@ bool XrdProofdManager::IsRootdAllowed(const char *host)
    std::list<XrdOucString>::iterator ia = fRootdAllow.begin();
    while (ia != fRootdAllow.end()) {
       if (h.matches((*ia).c_str(), '*') > 0) return 1;
-      ia++;
+      ++ia;
    }
 
    // Done

--- a/proof/proofd/src/XrdProofdNetMgr.cxx
+++ b/proof/proofd/src/XrdProofdNetMgr.cxx
@@ -268,7 +268,7 @@ void XrdProofdNetMgr::BalanceNodesOrder()
    bool deleted;
 
    // Fill the information store with the first data (number of nodes).
-   for (iter = fNodes.begin(); iter != fNodes.end(); iter++) {
+   for (iter = fNodes.begin(); iter != fNodes.end(); ++iter) {
       // The next code is not the same as this:
       //info[*iter].available = count(fWorkers.begin(), fWorkers.end(), *iter);
       // The previous piece of STL code only checks the pointer of the value
@@ -277,7 +277,7 @@ void XrdProofdNetMgr::BalanceNodesOrder()
       // doing a 'manually' matching since statically configured nodes are
       // created in multiple ways.
       info[*iter].available = 0;
-      for (iter2 = fWorkers.begin(); iter2 != fWorkers.end(); iter2++) {
+      for (iter2 = fWorkers.begin(); iter2 != fWorkers.end(); ++iter2) {
          if ((*iter)->Matches(*iter2)) {
             info[*iter].available++;
          }
@@ -292,7 +292,7 @@ void XrdProofdNetMgr::BalanceNodesOrder()
 
    // Now, calculate the number of workers to add in each iteration of the
    // round robin, scaling to the smaller number.
-   for (iter = fNodes.begin(); iter != fNodes.end(); iter++) {
+   for (iter = fNodes.begin(); iter != fNodes.end(); ++iter) {
       if (info[*iter].available > 1) {
          info[*iter].per_iteration = (unsigned int)floor((double)info[*iter].available / (double)min);
       } else {
@@ -309,7 +309,7 @@ void XrdProofdNetMgr::BalanceNodesOrder()
    // Finally, do the round robin assignment of nodes.
    // Stop when every node has its workers processed.
    while (total_added < total) {
-      for (map<XrdProofWorker *, BalancerInfo>::iterator i = info.begin(); i != info.end(); i++) {
+      for (map<XrdProofWorker *, BalancerInfo>::iterator i = info.begin(); i != info.end(); ++i) {
          if (i->second.added < i->second.available) {
             // Be careful with the remainders (on prime number of nodes).
             unsigned int to_add = xrdmin(i->second.per_iteration,
@@ -353,7 +353,7 @@ void XrdProofdNetMgr::BalanceNodesOrder()
       }
       // Do not forget to increase the iterator.
       if (!deleted)
-         iter3++;
+         ++iter3;
    }
 
    // Then, substitute the current fWorkers list with the balanced one.
@@ -559,7 +559,7 @@ int XrdProofdNetMgr::BroadcastCtrlC(const char *usr)
          }
       }
       // Next worker
-      iw++;
+      ++iw;
    }
 
    // Done
@@ -617,7 +617,7 @@ int XrdProofdNetMgr::Broadcast(int type, const char *msg, const char *usr,
          }
       }
       // Next worker
-      iw++;
+      ++iw;
    }
 
    // Done
@@ -1364,7 +1364,7 @@ char *XrdProofdNetMgr::ReadLogPaths(const char *msg, int isess)
          }
       }
       // Next worker
-      iw++;
+      ++iw;
    }
 
    // Done
@@ -1407,7 +1407,7 @@ void XrdProofdNetMgr::CreateDefaultPROOFcfg()
 
    // Copy the list
    std::list<XrdProofWorker *>::iterator w = fDfltWorkers.begin();
-   for (; w != fDfltWorkers.end(); w++) {
+   for (; w != fDfltWorkers.end(); ++w) {
       fWorkers.push_back(*w);
    }
 
@@ -1465,7 +1465,7 @@ void XrdProofdNetMgr::Dump()
    XPDPRT("+ ");
 
    std::list<XrdProofWorker *>::iterator iw;
-   for (iw = fWorkers.begin(); iw != fWorkers.end(); iw++) {
+   for (iw = fWorkers.begin(); iw != fWorkers.end(); ++iw) {
       XPDPRT("+ wrk: " << (*iw)->fHost << ":" << (*iw)->fPort << " type:" << (*iw)->fType <<
              " active sessions:" << (*iw)->Active());
    }
@@ -1567,8 +1567,8 @@ int XrdProofdNetMgr::ReadPROOFcfg(bool reset)
       // Deactivate all current active workers
       std::list<XrdProofWorker *>::iterator w = fRegWorkers.begin();
       // Skip the master line
-      w++;
-      for (; w != fRegWorkers.end(); w++) {
+      ++w;
+      for (; w != fRegWorkers.end(); ++w) {
          (*w)->fActive = 0;
       }
    }
@@ -1615,7 +1615,7 @@ int XrdProofdNetMgr::ReadPROOFcfg(bool reset)
          // Check if we have already it
          std::list<XrdProofWorker *>::iterator w = fRegWorkers.begin();
          // Skip the master line
-         w++;
+         ++w;
          bool haveit = 0;
          while (w != fRegWorkers.end()) {
             if (!((*w)->fActive)) {
@@ -1626,7 +1626,7 @@ int XrdProofdNetMgr::ReadPROOFcfg(bool reset)
                }
             }
             // Go to next
-            w++;
+            ++w;
          }
          // If we do not have it, build a new worker object
          if (!haveit) {
@@ -1646,7 +1646,7 @@ int XrdProofdNetMgr::ReadPROOFcfg(bool reset)
          fWorkers.push_back(*w);
          nw++;
       }
-      w++;
+      ++w;
    }
 
    // Close files
@@ -1678,11 +1678,11 @@ int XrdProofdNetMgr::FindUniqueNodes()
    // Build the list of unique nodes (skip the master line);
    if (fWorkers.size() > 1) {
       std::list<XrdProofWorker *>::iterator w = fWorkers.begin();
-      w++;
-      for (; w != fWorkers.end(); w++) if ((*w)->fActive) {
+      ++w;
+      for (; w != fWorkers.end(); ++w) if ((*w)->fActive) {
             bool add = 1;
             std::list<XrdProofWorker *>::iterator n;
-            for (n = fNodes.begin() ; n != fNodes.end(); n++) {
+            for (n = fNodes.begin() ; n != fNodes.end(); ++n) {
                if ((*n)->Matches(*w)) {
                   add = 0;
                   break;

--- a/proof/proofd/src/XrdProofdPriorityMgr.cxx
+++ b/proof/proofd/src/XrdProofdPriorityMgr.cxx
@@ -291,7 +291,7 @@ static int CreateActiveList(const char *, XrdProofdSessionEntry *e, void *s)
                e->fFracEff = ef;
                bool pushed = 0;
                std::list<XrdProofdSessionEntry *>::iterator ssvi;
-               for (ssvi = sorted->begin() ; ssvi != sorted->end(); ssvi++) {
+               for (ssvi = sorted->begin() ; ssvi != sorted->end(); ++ssvi) {
                   if (ef >= (*ssvi)->fFracEff) {
                      sorted->insert(ssvi, e);
                      pushed = 1;
@@ -379,7 +379,7 @@ int XrdProofdPriorityMgr::SetNiceValues(int opt)
       int i = 0;
       std::list<XrdProofdSessionEntry *>::iterator ssvi;
       if (TRACING(HDBG)) {
-         for (ssvi = sorted.begin() ; ssvi != sorted.end(); ssvi++)
+         for (ssvi = sorted.begin() ; ssvi != sorted.end(); ++ssvi)
             TRACE(HDBG, i++ <<" eff: "<< (*ssvi)->fFracEff);
       }
 
@@ -393,14 +393,14 @@ int XrdProofdPriorityMgr::SetNiceValues(int opt)
          int nice = 20 - fPriorityMax;
          (*ssvi)->SetPriority(nice);
          // The others have priorities rescaled wrt their effective fractions
-         ssvi++;
+         ++ssvi;
          while (ssvi != sorted.end()) {
             int xpri = (int) ((*ssvi)->fFracEff / xmax * (fPriorityMax - fPriorityMin))
                                                       + fPriorityMin;
             nice = 20 - xpri;
             TRACE(DBG,  "    --> nice value for client "<< (*ssvi)->fUser<<" is "<<nice);
             (*ssvi)->SetPriority(nice);
-            ssvi++;
+            ++ssvi;
          }
       } else {
          TRACE(XERR, "negative or null max effective fraction: "<<xmax);

--- a/proof/proofd/src/XrdProofdProofServ.cxx
+++ b/proof/proofd/src/XrdProofdProofServ.cxx
@@ -69,7 +69,7 @@ XrdProofdProofServ::~XrdProofdProofServ()
    SafeDel(fPingSem);
 
    std::vector<XrdClientID *>::iterator i;
-   for (i = fClients.begin(); i != fClients.end(); i++)
+   for (i = fClients.begin(); i != fClients.end(); ++i)
        if (*i)
           delete (*i);
    fClients.clear();
@@ -891,7 +891,7 @@ void XrdProofdProofServ::DumpQueries()
              ", # of queries: "<< fQueries.size());
    std::list<XrdProofQuery *>::iterator ii;
    int i = 0;
-   for (ii = fQueries.begin(); ii != fQueries.end(); ii++) {
+   for (ii = fQueries.begin(); ii != fQueries.end(); ++ii) {
       i++;
       TRACE(ALL," +++ #"<<i<<" tag:"<< (*ii)->GetTag()<<" dset: "<<
                 (*ii)->GetDSName()<<" size:"<<(*ii)->GetDSSize());
@@ -912,7 +912,7 @@ XrdProofQuery *XrdProofdProofServ::GetQuery(const char *tag)
    if (fQueries.size() <= 0) return q;
 
    std::list<XrdProofQuery *>::iterator ii;
-   for (ii = fQueries.begin(); ii != fQueries.end(); ii++) {
+   for (ii = fQueries.begin(); ii != fQueries.end(); ++ii) {
       q = *ii;
       if (!strcmp(tag, q->GetTag())) break;
       q = 0;
@@ -934,7 +934,7 @@ void XrdProofdProofServ::RemoveQuery(const char *tag)
    if (fQueries.size() <= 0) return;
 
    std::list<XrdProofQuery *>::iterator ii;
-   for (ii = fQueries.begin(); ii != fQueries.end(); ii++) {
+   for (ii = fQueries.begin(); ii != fQueries.end(); ++ii) {
       q = *ii;
       if (!strcmp(tag, q->GetTag())) break;
       q = 0;

--- a/proof/proofd/src/XrdProofdProofServMgr.cxx
+++ b/proof/proofd/src/XrdProofdProofServMgr.cxx
@@ -385,12 +385,12 @@ int XrdProofdProofServMgr::Config(bool rcf)
       XPDPRT("RC settings: "<< fProofServRCs.size());
       if (fProofServRCs.size() > 0) {
          std::list<XpdEnv>::iterator ircs = fProofServRCs.begin();
-         for ( ; ircs != fProofServRCs.end(); ircs++) { (*ircs).Print("rc"); }
+         for ( ; ircs != fProofServRCs.end(); ++ircs) { (*ircs).Print("rc"); }
       }
       XPDPRT("ENV settings: "<< fProofServEnvs.size());
       if (fProofServEnvs.size() > 0) {
          std::list<XpdEnv>::iterator ienvs = fProofServEnvs.begin();
-         for ( ; ienvs != fProofServEnvs.end(); ienvs++) { (*ienvs).Print("env"); }
+         for ( ; ienvs != fProofServEnvs.end(); ++ienvs) { (*ienvs).Print("env"); }
       }
    }
 
@@ -834,7 +834,7 @@ int XrdProofdProofServMgr::RecoverActiveSessions()
    {  XrdSysMutexHelper mhp(fRecoverMutex);
       if (fRecoverClients->size() > 0) {
          std::list<XpdClientSessions* >::iterator ii = fRecoverClients->begin();
-         for (; ii != fRecoverClients->end(); ii++) {
+         for (; ii != fRecoverClients->end(); ++ii) {
             rc += (*ii)->fProofServs.size();
          }
       }
@@ -872,7 +872,7 @@ bool XrdProofdProofServMgr::IsClientRecovering(const char *usr, const char *grp,
    {  XrdSysMutexHelper mhp(fRecoverMutex);
       if (fRecoverClients && fRecoverClients->size() > 0) {
          std::list<XpdClientSessions *>::iterator ii = fRecoverClients->begin();
-         for (; ii != fRecoverClients->end(); ii++) {
+         for (; ii != fRecoverClients->end(); ++ii) {
             if ((*ii)->fClient && (*ii)->fClient->Match(usr, grp)) {
                rc = true;
                deadline = fRecoverDeadline;
@@ -1152,10 +1152,10 @@ int XrdProofdProofServMgr::CleanClientSessions(const char *usr, int srvtype)
             active = 1;
             break;
          }
-         ixps++;
+         ++ixps;
       }
       if (!active) fSessions.Del(key.c_str());
-      ii++;
+      ++ii;
    }
 
    // Done
@@ -2468,7 +2468,7 @@ int XrdProofdProofServMgr::ResolveSession(const char *fpid)
    while (ii != fRecoverClients->end()) {
       if ((*ii)->fClient == c)
          break;
-      ii++;
+      ++ii;
    }
    if (ii != fRecoverClients->end()) {
       (*ii)->fProofServs.push_back(xps);
@@ -3053,7 +3053,7 @@ int XrdProofdProofServMgr::SetProofServEnvOld(XrdProofdProtocol *p, void *input)
          // Hash list of the directives applying to this {user, group, svn, version}
          XrdOucHash<XpdEnv> sessenvs;
          std::list<XpdEnv>::iterator ienvs = fProofServEnvs.begin();
-         for ( ; ienvs != fProofServEnvs.end(); ienvs++) {
+         for ( ; ienvs != fProofServEnvs.end(); ++ienvs) {
             int envmatch = (*ienvs).Matches(p->Client()->User(), p->Client()->Group(),
                                             p->Client()->ROOT()->VersionCode());
             if (envmatch >= 0) {
@@ -3574,7 +3574,7 @@ int XrdProofdProofServMgr::CreateProofServEnvFile(XrdProofdProtocol *p, void *in
          // Hash list of the directives applying to this {user, group, svn, version}
          XrdOucHash<XpdEnv> sessenvs;
          std::list<XpdEnv>::iterator ienvs = fProofServEnvs.begin();
-         for ( ; ienvs != fProofServEnvs.end(); ienvs++) {
+         for ( ; ienvs != fProofServEnvs.end(); ++ienvs) {
             int envmatch = (*ienvs).Matches(p->Client()->User(), p->Client()->Group(),
                                             p->Client()->ROOT()->VersionCode());
             if (envmatch >= 0) {
@@ -3839,7 +3839,7 @@ int XrdProofdProofServMgr::CreateProofServRootRc(XrdProofdProtocol *p,
          // Hash list of the directives applying to this {user, group, svn, version}
          XrdOucHash<XpdEnv> sessrcs;
          std::list<XpdEnv>::iterator ircs = fProofServRCs.begin();
-         for ( ; ircs != fProofServRCs.end(); ircs++) {
+         for ( ; ircs != fProofServRCs.end(); ++ircs) {
             int rcmatch = (*ircs).Matches(p->Client()->User(), p->Client()->Group(),
                                           p->Client()->ROOT()->VersionCode());
             if (rcmatch >= 0) {
@@ -3868,7 +3868,7 @@ int XrdProofdProofServMgr::CreateProofServRootRc(XrdProofdProtocol *p,
       fprintf(frc, "# Dataset sources\n");
       XrdOucString rc("Proof.DataSetManager: ");
       std::list<XrdProofdDSInfo *>::iterator ii;
-      for (ii = fMgr->DataSetSrcs()->begin(); ii != fMgr->DataSetSrcs()->end(); ii++) {
+      for (ii = fMgr->DataSetSrcs()->begin(); ii != fMgr->DataSetSrcs()->end(); ++ii) {
          if (ii != fMgr->DataSetSrcs()->begin()) rc += ", ";
          rc += (*ii)->fType;
          rc += " dir:";
@@ -3950,7 +3950,7 @@ int XrdProofdProofServMgr::CleanupLostProofServ()
    int pid, ia, a;
    XrdOucString cmd, apath, pidpath, sessiondir, emsg, rest, after;
    std::map<int,XrdOucString>::iterator ip;
-   for (ip = procs.begin(); ip != procs.end(); ip++) {
+   for (ip = procs.begin(); ip != procs.end(); ++ip) {
       pid = ip->first;
       cmd = ip->second;
       if ((ia = cmd.find("xpdpath:")) != STR_NPOS) {
@@ -4360,7 +4360,7 @@ int XrdProofdProofServMgr::SetUserOwnerships(XrdProofdProtocol *p,
       XrdProofUI ui;
       XrdProofdAux::GetUserInfo(XrdProofdProtocol::EUidAtStartup(), ui);
       std::list<XrdProofdDSInfo *>::iterator ii;
-      for (ii = fMgr->DataSetSrcs()->begin(); ii != fMgr->DataSetSrcs()->end(); ii++) {
+      for (ii = fMgr->DataSetSrcs()->begin(); ii != fMgr->DataSetSrcs()->end(); ++ii) {
          TRACE(ALL, "Checking dataset source: url:"<<(*ii)->fUrl<<", local:"
                                                    <<(*ii)->fLocal<<", rw:"<<(*ii)->fRW);
          if ((*ii)->fLocal && (*ii)->fRW) {
@@ -4562,7 +4562,7 @@ void XrdProofdProofServMgr::BroadcastClusterInfo()
          tot++;
          if ((*si)->Status() == kXPD_running) act++;
       }
-      si++;
+      ++si;
    }
    if (tot > 0) {
       XPDPRT("tot: "<<tot<<", act: "<<act);
@@ -4571,7 +4571,7 @@ void XrdProofdProofServMgr::BroadcastClusterInfo()
       while (si != fActiveSessions.end()) {
          if ((*si)->Status() == kXPD_running &&
             (*si)->SrvType() != kXPD_Worker) (*si)->SendClusterInfo(tot, act);
-         si++;
+         ++si;
       }
    } else {
       TRACE(DBG, "No master or submaster controlled by this manager");
@@ -4642,10 +4642,10 @@ bool XrdProofdProofServMgr::Alive(XrdProofdProtocol* p)
       int rect = now - iter->second;
       if (rect < fReconnectTimeOut) {
          if (p == iter->first) alive = false;
+         ++iter;
       } else {
-         fDestroyTimes.erase(iter);
+         iter = fDestroyTimes.erase(iter);
       }
-      iter++;
    }
 
    return alive;

--- a/proof/proofd/src/XrdProofdProtocol.cxx
+++ b/proof/proofd/src/XrdProofdProtocol.cxx
@@ -529,7 +529,7 @@ void XrdProofdProtocol::Reset()
    std::vector<XrdProofdResponse *>::iterator ii = fResponses.begin(); // One per each logical connection
    while (ii != fResponses.end()) {
       (*ii)->Reset();
-      ii++;
+      ++ii;
    }
 }
 

--- a/proof/proofd/src/XrdProofdSandbox.cxx
+++ b/proof/proofd/src/XrdProofdSandbox.cxx
@@ -464,7 +464,7 @@ int XrdProofdSandbox::GuessTag(XrdOucString &tag, int ridx)
       }
       found = (rc == 1) ? 1 : 0;
 
-      if (!found && staglst.size() > 0) {
+      if (!found && !staglst.empty()) {
          // Take last one, if required
          if (last) {
             tag = staglst.front()->c_str();
@@ -474,7 +474,7 @@ int XrdProofdSandbox::GuessTag(XrdOucString &tag, int ridx)
                int itag = ridx;
                // Reiterate back
                std::list<XrdOucString *>::iterator i;
-               for (i = staglst.begin(); i != staglst.end(); i++) {
+               for (i = staglst.begin(); i != staglst.end(); ++i) {
                   if (itag == 0) {
                      tag = (*i)->c_str();
                      found = 1;
@@ -568,7 +568,7 @@ int XrdProofdSandbox::RemoveSession(const char *tag)
 
    // If active sessions still exist, write out new composition
    bool unlk = 1;
-   if (actln.size() > 0) {
+   if (!actln.empty()) {
       unlk = 0;
       std::list<XrdOucString *>::iterator i;
       for (i = actln.begin(); i != actln.end(); ++i) {

--- a/proof/proofd/src/XrdROOT.cxx
+++ b/proof/proofd/src/XrdROOT.cxx
@@ -377,7 +377,7 @@ int XrdROOTMgr::Config(bool rcf)
                delete (*tri);
                tri = fROOT.erase(tri);
             } else {
-               tri++;
+               ++tri;
             }
          }
       }
@@ -487,7 +487,7 @@ int XrdROOTMgr::DoDirectiveRootSys(char *val, XrdOucStream *cfg, bool)
                                    a[1].c_str(), a[2].c_str(), a[3].c_str());
       // Check if already validated
       std::list<XrdROOT *>::iterator ori;
-      for (ori = fROOT.begin(); ori != fROOT.end(); ori++) {
+      for (ori = fROOT.begin(); ori != fROOT.end(); ++ori) {
          if ((*ori)->Match(rootc->Dir(), rootc->Tag())) {
             if ((*ori)->IsParked()) {
                (*ori)->SetValid();

--- a/proof/proofplayer/src/TStatus.cxx
+++ b/proof/proofplayer/src/TStatus.cxx
@@ -191,7 +191,7 @@ void TStatus::Streamer(TBuffer &R__b)
             return;
          }
          std::set<std::string>::const_iterator it;
-         for (it = msgs.begin(); it != msgs.end(); it++) {
+         for (it = msgs.begin(); it != msgs.end(); ++it) {
             fMsgs.Add(new TObjString((*it).c_str()));
          }
          if (R__v > 2) {

--- a/proof/proofx/src/TXSocket.cxx
+++ b/proof/proofx/src/TXSocket.cxx
@@ -1519,7 +1519,7 @@ TXSockBuf *TXSocket::PopUpSpare(Int_t size)
    Int_t maxsz = 0;
    if (fgSQue.size() > 0) {
       list<TXSockBuf *>::iterator i;
-      for (i = fgSQue.begin(); i != fgSQue.end(); i++) {
+      for (i = fgSQue.begin(); i != fgSQue.end(); ++i) {
          maxsz = ((*i)->fSiz > maxsz) ? (*i)->fSiz : maxsz;
          if ((*i) && (*i)->fSiz >= size) {
             buf = *i;

--- a/roofit/histfactory/src/ConfigParser.cxx
+++ b/roofit/histfactory/src/ConfigParser.cxx
@@ -487,28 +487,28 @@ HistFactory::Measurement ConfigParser::CreateMeasurementFromDriverNode( TXMLNode
       }
 
       if (type=="Gamma" && rel!=0) {
-	for (vector<string>::const_iterator it=syst.begin(); it!=syst.end(); it++) {
+	for (vector<string>::const_iterator it=syst.begin(); it!=syst.end(); ++it) {
 	  // Fix Here...?
 	  measurement.GetGammaSyst()[(*it).c_str()] = rel;
 	}
       }
 	
       if (type=="Uniform" && rel!=0) {
-	for (vector<string>::const_iterator it=syst.begin(); it!=syst.end(); it++) {
+	for (vector<string>::const_iterator it=syst.begin(); it!=syst.end(); ++it) {
 	  // Fix Here...?
 	  measurement.GetUniformSyst()[(*it).c_str()] = rel;
 	}
       }
 	
       if (type=="LogNormal" && rel!=0) {
-	for (vector<string>::const_iterator it=syst.begin(); it!=syst.end(); it++) {
+	for (vector<string>::const_iterator it=syst.begin(); it!=syst.end(); ++it) {
 	  // Fix Here...?
 	  measurement.GetLogNormSyst()[(*it).c_str()] = rel;
 	}
       }
 	
       if (type=="NoConstraint") {
-	for (vector<string>::const_iterator it=syst.begin(); it!=syst.end(); it++) {
+	for (vector<string>::const_iterator it=syst.begin(); it!=syst.end(); ++it) {
 	  // Fix Here...?
 	  measurement.GetNoSyst()[(*it).c_str()] = 1.0; // MB : dummy value
 	}

--- a/roofit/histfactory/src/Helper.cxx
+++ b/roofit/histfactory/src/Helper.cxx
@@ -43,7 +43,7 @@ namespace RooStats {
       vector< pair<std::string, std::string> > list;
       for(vector<std::string>::iterator itr=names.begin(); itr!=names.end(); ++itr){
 	vector<std::string>::iterator itr2=itr; 
-	for(itr2++; itr2!=names.end(); ++itr2){
+	for(++itr2; itr2!=names.end();++itr2){
 	  list.push_back(pair<std::string, std::string>(*itr, *itr2));
 	}
       }

--- a/roofit/roofit/src/RooIntegralMorph.cxx
+++ b/roofit/roofit/src/RooIntegralMorph.cxx
@@ -372,7 +372,7 @@ void RooIntegralMorph::MorphCacheElem::calculate(TIterator* dIter)
   while(true) {
     // Find next gap
     Int_t igapHigh = igapLow+1 ;
-    while(_yatX[igapHigh]<0 && igapHigh<(_yatXmax)) igapHigh++ ;
+    while(igapHigh<(_yatXmax) && _yatX[igapHigh]<0) igapHigh++ ;
 
     // Fill the gap (iteratively and/or using interpolation)
     fillGap(igapLow-1,igapHigh) ;

--- a/roofit/roofitcore/src/BidirMMapPipe.cxx
+++ b/roofit/roofitcore/src/BidirMMapPipe.cxx
@@ -1877,6 +1877,7 @@ childcloses:
             int retVal = pipe->close();
             if (retVal) {
                 std::cout << "[PARENT]: child exited with code " << retVal << std::endl;
+                delete[] s;
                 return retVal;
             }
             delete pipe;

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -277,9 +277,7 @@ void RooAbsArg::setStringAttribute(const Text_t* key, const Text_t* value)
   if (value) {
     _stringAttrib[key] = value ;
   } else {
-    if (_stringAttrib.find(key)!=_stringAttrib.end()) {
-      _stringAttrib.erase(key) ;
-    }
+    _stringAttrib.erase(key) ;
   }
 }
 
@@ -2485,7 +2483,7 @@ void RooAbsArg::ioStreamerPass2Finalize()
     // Save iterator position for deletion after increment
     map<RooAbsArg*,TRefArray*>::iterator iter_tmp = iter ;
     
-    iter++ ;
+    ++iter ;
     
     // Delete TRefArray and remove from list
     delete iter_tmp->second ;

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1419,13 +1419,13 @@ RooFitResult* RooAbsPdf::fitTo(RooAbsData& data, const RooLinkedList& cmdList)
 	
 	// Calculated corrected errors for weighted likelihood fits
 	RooFitResult* rw = m.save() ;
-	for (list<RooNLLVar*>::iterator iter1=nllComponents.begin() ; iter1!=nllComponents.end() ; iter1++) {
+	for (list<RooNLLVar*>::iterator iter1=nllComponents.begin() ; iter1!=nllComponents.end() ; ++iter1) {
 	  (*iter1)->applyWeightSquared(kTRUE) ;
 	}
 	coutI(Fitting) << "RooAbsPdf::fitTo(" << GetName() << ") Calculating sum-of-weights-squared correction matrix for covariance matrix" << endl ;
 	m.hesse() ;
 	RooFitResult* rw2 = m.save() ;
-	for (list<RooNLLVar*>::iterator iter2=nllComponents.begin() ; iter2!=nllComponents.end() ; iter2++) {
+	for (list<RooNLLVar*>::iterator iter2=nllComponents.begin() ; iter2!=nllComponents.end() ; ++iter2) {
 	  (*iter2)->applyWeightSquared(kFALSE) ;
 	}
 	

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -2817,7 +2817,7 @@ RooPlot* RooAbsReal::plotOnWithErrorBand(RooPlot* frame,const RooFitResult& fr, 
     // Cleanup
     delete paramPdf ;
     delete cloneFunc ;
-    for (vector<RooCurve*>::iterator i=cvec.begin() ; i!=cvec.end() ; i++) {
+    for (vector<RooCurve*>::iterator i=cvec.begin() ; i!=cvec.end() ; ++i) {
       delete (*i) ;
     }
 
@@ -2912,10 +2912,10 @@ RooPlot* RooAbsReal::plotOnWithErrorBand(RooPlot* frame,const RooFitResult& fr, 
 
     // Cleanup
     delete cloneFunc ;
-    for (vector<RooCurve*>::iterator i=plusVar.begin() ; i!=plusVar.end() ; i++) {
+    for (vector<RooCurve*>::iterator i=plusVar.begin() ; i!=plusVar.end() ; ++i) {
       delete (*i) ;
     }
-    for (vector<RooCurve*>::iterator i=minusVar.begin() ; i!=minusVar.end() ; i++) {
+    for (vector<RooCurve*>::iterator i=minusVar.begin() ; i!=minusVar.end() ; ++i) {
       delete (*i) ;
     }
 

--- a/roofit/roofitcore/src/RooArgSet.cxx
+++ b/roofit/roofitcore/src/RooArgSet.cxx
@@ -86,7 +86,7 @@ void RooArgSet::cleanup()
   while(iter!=_memPoolList.end()) {
     free(iter->_base) ;
     iter->_base=0 ;
-    iter++ ;
+    ++iter ;
   }
   _memPoolList.clear() ;
 }

--- a/roofit/roofitcore/src/RooBinIntegrator.cxx
+++ b/roofit/roofitcore/src/RooBinIntegrator.cxx
@@ -223,7 +223,7 @@ Double_t RooBinIntegrator::integral(const Double_t *)
 
   if (_function->getDimension()==1) {
     list<Double_t>::iterator iter = _binb[0]->begin() ;
-    Double_t xlo = *iter ; iter++ ;
+    Double_t xlo = *iter ; ++iter ;
     for (; iter!=_binb[0]->end() ; ++iter) {
       Double_t xhi = *iter ;
       Double_t xcenter = (xhi+xlo)/2 ;
@@ -238,14 +238,14 @@ Double_t RooBinIntegrator::integral(const Double_t *)
 
     list<Double_t>::iterator iter1 = _binb[0]->begin() ;
 
-    Double_t x1lo = *iter1 ; iter1++ ;
+    Double_t x1lo = *iter1 ; ++iter1 ;
     for (; iter1!=_binb[0]->end() ; ++iter1) {
 
       Double_t x1hi = *iter1 ;
       Double_t x1center = (x1hi+x1lo)/2 ;
       
       list<Double_t>::iterator iter2 = _binb[1]->begin() ;
-      Double_t x2lo = *iter2 ; iter2++ ;
+      Double_t x2lo = *iter2 ; ++iter2 ;
       for (; iter2!=_binb[1]->end() ; ++iter2) {
 
 	Double_t x2hi = *iter2 ;
@@ -264,21 +264,21 @@ Double_t RooBinIntegrator::integral(const Double_t *)
 
     list<Double_t>::iterator iter1 = _binb[0]->begin() ;
 
-    Double_t x1lo = *iter1 ; iter1++ ;
+    Double_t x1lo = *iter1 ; ++iter1 ;
     for (; iter1!=_binb[0]->end() ; ++iter1) {
 
       Double_t x1hi = *iter1 ;
       Double_t x1center = (x1hi+x1lo)/2 ;
       
       list<Double_t>::iterator iter2 = _binb[1]->begin() ;
-      Double_t x2lo = *iter2 ; iter2++ ;
+      Double_t x2lo = *iter2 ; ++iter2 ;
       for (; iter2!=_binb[1]->end() ; ++iter2) {
 
 	Double_t x2hi = *iter2 ;
 	Double_t x2center = (x2hi+x2lo)/2 ;
 
 	list<Double_t>::iterator iter3 = _binb[2]->begin() ;
-	Double_t x3lo = *iter3 ; iter3++ ;
+	Double_t x3lo = *iter3 ; ++iter3 ;
 	for (; iter3!=_binb[2]->end() ; ++iter3) {
 
 	  Double_t x3hi = *iter3 ;

--- a/roofit/roofitcore/src/RooCurve.cxx
+++ b/roofit/roofitcore/src/RooCurve.cxx
@@ -373,7 +373,7 @@ void RooCurve::addPoints(const RooAbsFunc &func, Double_t xlo, Double_t xhi,
   step=1 ;
   while(true) {
     x1= x2;
-    iter2++ ;
+    ++iter2 ;
     if (iter2==xval->end()) {
       break ;
     }
@@ -796,11 +796,11 @@ void RooCurve::calcBandInterval(const vector<RooCurve*>& plusVar, const vector<R
 {
   vector<double> y_plus(plusVar.size()), y_minus(minusVar.size()) ;
   Int_t j(0) ;
-  for (vector<RooCurve*>::const_iterator iter=plusVar.begin() ; iter!=plusVar.end() ; iter++) {
+  for (vector<RooCurve*>::const_iterator iter=plusVar.begin() ; iter!=plusVar.end() ; ++iter) {
     y_plus[j++] = (*iter)->interpolate(GetX()[i]) ;    
   }
   j=0 ;
-  for (vector<RooCurve*>::const_iterator iter=minusVar.begin() ; iter!=minusVar.end() ; iter++) {
+  for (vector<RooCurve*>::const_iterator iter=minusVar.begin() ; iter!=minusVar.end() ; ++iter) {
     y_minus[j++] = (*iter)->interpolate(GetX()[i]) ;
   }
   Double_t y_cen = GetY()[i] ;
@@ -827,7 +827,7 @@ void RooCurve::calcBandInterval(const vector<RooCurve*>& variations,Int_t i,Doub
 {
   vector<double> y(variations.size()) ;
   Int_t j(0) ;
-  for (vector<RooCurve*>::const_iterator iter=variations.begin() ; iter!=variations.end() ; iter++) {
+  for (vector<RooCurve*>::const_iterator iter=variations.begin() ; iter!=variations.end() ; ++iter) {
     y[j++] = (*iter)->interpolate(GetX()[i]) ;
 }
 

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -1070,7 +1070,7 @@ RooDataHist::~RooDataHist()
   vector<const RooAbsBinning*>::iterator iter = _lvbins.begin() ;
   while(iter!=_lvbins.end()) {
     delete *iter ;
-    iter++ ;
+    ++iter ;
   }
 
    removeFromDir(this) ;
@@ -1108,7 +1108,7 @@ Int_t RooDataHist::calcTreeIndex() const
   for (;iter!=_lvvars.end() ; ++iter) {
     const RooAbsBinning* binning = (*biter) ;
     masterIdx += _idxMult[i++]*(*iter)->getBin(binning) ;
-    biter++ ;
+    ++biter ;
   }
   return masterIdx ;
 }

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -85,7 +85,7 @@ void RooDataSet::cleanup()
   while(iter!=_memPoolList.end()) {
     free(iter->_base) ;
     iter->_base=0 ;
-    iter++ ;
+    ++iter ;
   }
   _memPoolList.clear() ;
 }
@@ -1260,7 +1260,7 @@ Bool_t RooDataSet::merge(list<RooDataSet*>dsetList)
 
   checkInit() ;
   // Sanity checks: data sets must have the same size
-  for (list<RooDataSet*>::iterator iter = dsetList.begin() ; iter != dsetList.end() ; iter++) {
+  for (list<RooDataSet*>::iterator iter = dsetList.begin() ; iter != dsetList.end() ; ++iter) {
     if (numEntries()!=(*iter)->numEntries()) {
       coutE(InputArguments) << "RooDataSet::merge(" << GetName() << ") ERROR: datasets have different size" << endl ;
       return kTRUE ;    
@@ -1269,7 +1269,7 @@ Bool_t RooDataSet::merge(list<RooDataSet*>dsetList)
 
   // Extend vars with elements of other dataset
   list<RooAbsDataStore*> dstoreList ;
-  for (list<RooDataSet*>::iterator iter = dsetList.begin() ; iter != dsetList.end() ; iter++) {
+  for (list<RooDataSet*>::iterator iter = dsetList.begin() ; iter != dsetList.end() ; ++iter) {
     _vars.addClone((*iter)->_vars,kTRUE) ;
     dstoreList.push_back((*iter)->store()) ;
   }

--- a/roofit/roofitcore/src/RooExpensiveObjectCache.cxx
+++ b/roofit/roofitcore/src/RooExpensiveObjectCache.cxx
@@ -178,7 +178,7 @@ const TObject* RooExpensiveObjectCache::retrieveObject(const char* name, TClass*
 
 const TObject* RooExpensiveObjectCache::getObj(Int_t uid) 
 {
-  for (std::map<TString,ExpensiveObject*>::iterator iter = _map.begin() ; iter !=_map.end() ; iter++) {
+  for (std::map<TString,ExpensiveObject*>::iterator iter = _map.begin() ; iter !=_map.end() ; ++iter) {
     if (iter->second->uid() == uid) {
       return iter->second->payload() ;
     }
@@ -194,7 +194,7 @@ const TObject* RooExpensiveObjectCache::getObj(Int_t uid)
 
 Bool_t RooExpensiveObjectCache::clearObj(Int_t uid) 
 {
-  for (std::map<TString,ExpensiveObject*>::iterator iter = _map.begin() ; iter !=_map.end() ; iter++) {
+  for (std::map<TString,ExpensiveObject*>::iterator iter = _map.begin() ; iter !=_map.end() ; ++iter) {
     if (iter->second->uid() == uid) {
       _map.erase(iter->first) ;
       return kFALSE ;
@@ -211,7 +211,7 @@ Bool_t RooExpensiveObjectCache::clearObj(Int_t uid)
 
 Bool_t RooExpensiveObjectCache::setObj(Int_t uid, TObject* obj) 
 {
-  for (std::map<TString,ExpensiveObject*>::iterator iter = _map.begin() ; iter !=_map.end() ; iter++) {
+  for (std::map<TString,ExpensiveObject*>::iterator iter = _map.begin() ; iter !=_map.end() ; ++iter) {
     if (iter->second->uid() == uid) {
       iter->second->setPayload(obj) ;
       return kFALSE ;

--- a/roofit/roofitcore/src/RooFactoryWSTool.cxx
+++ b/roofit/roofitcore/src/RooFactoryWSTool.cxx
@@ -318,8 +318,8 @@ RooAbsArg* RooFactoryWSTool::createArg(const char* className, const char* objNam
   
   try {
     Int_t i(0) ;
-    list<string>::iterator ti = ca.first.begin() ; ti++ ; ti++ ;
-    for (vector<string>::iterator ai = _args.begin() ; ai != _args.end() ; ai++,ti++,i++) {
+    list<string>::iterator ti = ca.first.begin() ; ++ti ; ++ti ;
+    for (vector<string>::iterator ai = _args.begin() ; ai != _args.end() ; ++ai,++ti,++i) {
       if ((*ti)=="RooAbsReal&" || (*ti)=="const RooAbsReal&") {
 	RooFactoryWSTool::as_FUNC(i) ;
 	cintExpr += Form(",RooFactoryWSTool::as_FUNC(%d)",i) ;
@@ -958,11 +958,11 @@ std::string RooFactoryWSTool::processCompositeExpression(const char* token)
 
   string ret ;
   list<char>::iterator ic = separator.begin() ;
-  for (list<string>::iterator ii = singleExpr.begin() ; ii!=singleExpr.end() ; ii++) {
+  for (list<string>::iterator ii = singleExpr.begin() ; ii!=singleExpr.end() ; ++ii) {
     ret += processSingleExpression(ii->c_str()) ;
     if (ic != separator.end()) {
       ret += *ic ;
-      ic++ ;
+      ++ic ;
     }
   }
 
@@ -1186,7 +1186,7 @@ string RooFactoryWSTool::processListExpression(const char* arg)
     if (!_autoNamePrefix.empty()) {
       _autoNamePrefix.pop() ;
     }
-    iter++ ;
+    ++iter ;
     i++ ;
   }
   ret += "}" ;
@@ -1330,7 +1330,7 @@ string RooFactoryWSTool::processCreateVar(string& func, vector<string>& args)
 
     // Create a RooAbsCategory
     string allStates ;
-    for (vector<string>::iterator ai = args.begin() ; ai!=args.end() ; ai++) {
+    for (vector<string>::iterator ai = args.begin() ; ai!=args.end() ; ++ai) {
       if (allStates.size()>0) {
 	allStates += "," ;
       }
@@ -1377,12 +1377,12 @@ string RooFactoryWSTool::processCreateArg(string& func, vector<string>& args)
     _autoNamePrefix.pop() ;
     strlcat(pargs,tmp.c_str(),BUFFER_SIZE) ;
     pargv.push_back(tmp) ;
-    iter++ ;
+    ++iter ;
     iarg++ ;
   }
 
   // Look up if func is a special
-  for (map<string,IFace*>::iterator ii=hooks().begin() ; ii!=hooks().end() ; ii++) {
+  for (map<string,IFace*>::iterator ii=hooks().begin() ; ii!=hooks().end() ; ++ii) {
   }
   if (hooks().find(className) != hooks().end()) {
     IFace* iface = hooks()[className] ;
@@ -1410,7 +1410,7 @@ std::string RooFactoryWSTool::processMetaArg(std::string& func, std::vector<std:
     string tmp = processExpression(iter->c_str()) ;
     strlcat(pargs,tmp.c_str(),BUFFER_SIZE) ;
     pargv.push_back(tmp) ;
-    iter++ ;
+    ++iter ;
   }
 
   string ret = func+"("+pargs+")" ;  
@@ -1939,7 +1939,7 @@ std::string RooFactoryWSTool::SpecialsIFace::create(RooFactoryWSTool& ft, const 
     string tmp = ft.processExpression(iter->c_str()) ;
     strlcat(pargs,tmp.c_str(),BUFFER_SIZE) ;
     pargv.push_back(tmp) ;
-    iter++ ;
+    ++iter ;
   }
 
   // Handling of special operator pdf class names

--- a/roofit/roofitcore/src/RooMappedCategory.cxx
+++ b/roofit/roofitcore/src/RooMappedCategory.cxx
@@ -197,7 +197,7 @@ void RooMappedCategory::printMultiline(std::ostream& os, Int_t content, Bool_t v
     _defCat->printStream(os,kName|kValue,kSingleLine);
 
     os << indent << "  Mapping rules:" << std::endl;
-    for (std::map<std::string,Entry>::const_iterator iter = _mapArray.begin() ; iter!=_mapArray.end() ; iter++) {
+    for (std::map<std::string,Entry>::const_iterator iter = _mapArray.begin() ; iter!=_mapArray.end() ; ++iter) {
       os << indent << "  " << iter->first << " -> " << iter->second.outCat().GetName() << std::endl ;
     }
   }
@@ -270,7 +270,7 @@ void RooMappedCategory::printMetaArgs(std::ostream& os) const
   RooCatType prevOutCat ;
   Bool_t first(kTRUE) ;
   os << "map=(" ;
-  for (std::map<std::string,Entry>::const_iterator iter = _mapArray.begin() ; iter!=_mapArray.end() ; iter++) {
+  for (std::map<std::string,Entry>::const_iterator iter = _mapArray.begin() ; iter!=_mapArray.end() ; ++iter) {
     if (iter->second.outCat().getVal()!=prevOutCat.getVal()) {
       if (!first) { os << " " ; }
       first=kFALSE ;
@@ -303,7 +303,7 @@ void RooMappedCategory::writeToStream(std::ostream& os, Bool_t compact) const
     // Scan array of regexps
     RooCatType prevOutCat ;
     Bool_t first(kTRUE) ;
-    for (std::map<std::string,Entry>::const_iterator iter = _mapArray.begin() ; iter!=_mapArray.end() ; iter++) {
+    for (std::map<std::string,Entry>::const_iterator iter = _mapArray.begin() ; iter!=_mapArray.end() ; ++iter) {
       if (iter->second.outCat().getVal()!=prevOutCat.getVal()) {
         if (!first) { os << " " ; }
         first=kFALSE ;

--- a/roofit/roofitcore/src/RooMultiVarGaussian.cxx
+++ b/roofit/roofitcore/src/RooMultiVarGaussian.cxx
@@ -90,7 +90,7 @@ RooMultiVarGaussian::RooMultiVarGaussian(const char *name, const char *title,
   }
   
   // Fill X vector in same order as mu vector
-  for (list<string>::iterator iter=munames.begin() ; iter!=munames.end() ; iter++) {
+  for (list<string>::iterator iter=munames.begin() ; iter!=munames.end() ; ++iter) {
     RooRealVar* xvar = (RooRealVar*) xvec.find(iter->c_str()) ;
     _x.add(*xvar) ;      
   }

--- a/roofit/roofitcore/src/RooNLLVar.cxx
+++ b/roofit/roofitcore/src/RooNLLVar.cxx
@@ -131,13 +131,13 @@ RooNLLVar::RooNLLVar(const char *name, const char *title, RooAbsPdf& pdf, RooAbs
       std::list<Double_t>::iterator biter = boundaries->begin() ;
       _binw.resize(boundaries->size()-1) ;
       Double_t lastBound = (*biter) ;
-      biter++ ;
+      ++biter ;
       int ibin=0 ;
       while (biter!=boundaries->end()) {
 	_binw[ibin] = (*biter) - lastBound ;
 	lastBound = (*biter) ;
 	ibin++ ;
-	biter++ ;
+	++biter ;
       }
     }
   }
@@ -173,13 +173,13 @@ RooNLLVar::RooNLLVar(const char *name, const char *title, RooAbsPdf& pdf, RooAbs
       std::list<Double_t>::iterator biter = boundaries->begin() ;
       _binw.resize(boundaries->size()-1) ;
       Double_t lastBound = (*biter) ;
-      biter++ ;
+      ++biter ;
       int ibin=0 ;
       while (biter!=boundaries->end()) {
 	_binw[ibin] = (*biter) - lastBound ;
 	lastBound = (*biter) ;
 	ibin++ ;
-	biter++ ;
+	++biter ;
       }
     }
   }

--- a/roofit/roofitcore/src/RooRealBinding.cxx
+++ b/roofit/roofitcore/src/RooRealBinding.cxx
@@ -139,7 +139,7 @@ void RooRealBinding::saveXVec() const
   list<Double_t>::iterator si = _compSave.begin() ;
   while(ci!=_compList.end()) {
     *si = (*ci)->_value ;
-    si++ ; ci++ ;
+    ++si ; ++ci ;
   }
   
   for (UInt_t i=0 ; i<getDimension() ; i++) {
@@ -163,7 +163,7 @@ void RooRealBinding::restoreXVec() const
   list<Double_t>::iterator si = _compSave.begin() ;
   while (ci!=_compList.end()) {
     (*ci)->_value = *si ;
-    ci++ ; si++ ;
+    ++ci ; ++si ;
   }
 
   for (UInt_t i=0 ; i<getDimension() ; i++) {

--- a/roofit/roofitcore/src/RooSimWSTool.cxx
+++ b/roofit/roofitcore/src/RooSimWSTool.cxx
@@ -571,7 +571,7 @@ RooSimultaneous* RooSimWSTool::executeBuild(const char* simPdfName, ObjBuildConf
 	// Find selected state list 
 	
 	list<const RooCatType*> slist = obc._restr[splitCat] ;    
-	if (slist.size()==0) {
+	if (slist.empty()) {
 	  continue ;
 	}
 	
@@ -867,7 +867,7 @@ void RooSimWSTool::ObjBuildConfig::print()
   map<RooAbsPdf*,ObjSplitRule>::iterator ri ;
   for (ri = _pdfmap.begin() ; ri != _pdfmap.end() ; ++ri ) {    
     cout << "Splitrule for p.d.f " << ri->first->GetName() << " with state list " ;
-    for (std::list<const RooCatType*>::iterator misi= ri->second._miStateList.begin() ; misi!=ri->second._miStateList.end() ; misi++) {
+    for (std::list<const RooCatType*>::iterator misi= ri->second._miStateList.begin() ; misi!=ri->second._miStateList.end() ; ++misi) {
       cout << (*misi)->GetName() << " " ;
     }
     cout << endl ;
@@ -887,7 +887,7 @@ void RooSimWSTool::ObjBuildConfig::print()
   for (riter=_restr.begin() ; riter!=_restr.end() ; ++riter) {
     cout << "Restricting build in category " << riter->first->GetName() << " to states " ;
     list<const RooCatType*>::iterator i ;
-    for (i=riter->second.begin() ; i!=riter->second.end() ; i++) {
+    for (i=riter->second.begin() ; i!=riter->second.end() ; ++i) {
       if (i!=riter->second.begin()) cout << "," ;
       cout << (*i)->GetName() ;
     }

--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -159,7 +159,7 @@ void RooSimultaneous::initialize(RooAbsCategoryLValue& inIndexCat, std::map<std:
 {
   // First see if there are any RooSimultaneous input components
   Bool_t simComps(kFALSE) ;
-  for (map<string,RooAbsPdf*>::iterator iter=pdfMap.begin() ; iter!=pdfMap.end() ; iter++) {    
+  for (map<string,RooAbsPdf*>::iterator iter=pdfMap.begin() ; iter!=pdfMap.end() ; ++iter) {
     if (dynamic_cast<RooSimultaneous*>(iter->second)) {
       simComps = kTRUE ;
       break ;
@@ -168,7 +168,7 @@ void RooSimultaneous::initialize(RooAbsCategoryLValue& inIndexCat, std::map<std:
 
   // If there are no simultaneous component p.d.f. do simple processing through addPdf()
   if (!simComps) {
-    for (map<string,RooAbsPdf*>::iterator iter=pdfMap.begin() ; iter!=pdfMap.end() ; iter++) {    
+    for (map<string,RooAbsPdf*>::iterator iter=pdfMap.begin() ; iter!=pdfMap.end() ; ++iter) {
       addPdf(*iter->second,iter->first.c_str()) ;
     }
     return ;
@@ -182,7 +182,7 @@ void RooSimultaneous::initialize(RooAbsCategoryLValue& inIndexCat, std::map<std:
 
   RooArgSet allAuxCats ;
   map<string,RooSimultaneousAux::CompInfo> compMap ;
-  for (map<string,RooAbsPdf*>::iterator iter=pdfMap.begin() ; iter!=pdfMap.end() ; iter++) {    
+  for (map<string,RooAbsPdf*>::iterator iter=pdfMap.begin() ; iter!=pdfMap.end() ; ++iter) {
     RooSimultaneousAux::CompInfo ci ;
     ci.pdf = iter->second ;
     RooSimultaneous* simComp = dynamic_cast<RooSimultaneous*>(iter->second) ;
@@ -206,7 +206,7 @@ void RooSimultaneous::initialize(RooAbsCategoryLValue& inIndexCat, std::map<std:
   RooSuperCategory* superIndex = new RooSuperCategory(siname.c_str(),siname.c_str(),allCats) ;
   
   // Now process each of original pdf/state map entries
-  for (map<string,RooSimultaneousAux::CompInfo>::iterator citer = compMap.begin() ; citer != compMap.end() ; citer++) {
+  for (map<string,RooSimultaneousAux::CompInfo>::iterator citer = compMap.begin() ; citer != compMap.end() ; ++citer) {
 
     RooArgSet repliCats(allAuxCats) ;
     if (citer->second.subIndexComps) {

--- a/roofit/roofitcore/src/RooStudyManager.cxx
+++ b/roofit/roofitcore/src/RooStudyManager.cxx
@@ -251,7 +251,7 @@ void RooStudyManager::processBatchOutput(const char* filePat)
 
 void RooStudyManager::aggregateData(TList* olist) 
 {
-  for (list<RooAbsStudy*>::iterator iter=_pkg->studies().begin() ; iter!=_pkg->studies().end() ; iter++) {
+  for (list<RooAbsStudy*>::iterator iter=_pkg->studies().begin() ; iter!=_pkg->studies().end() ; ++iter) {
     (*iter)->aggregateSummaryOutput(olist) ;
   }  
 }

--- a/roofit/roofitcore/src/RooStudyPackage.cxx
+++ b/roofit/roofitcore/src/RooStudyPackage.cxx
@@ -103,7 +103,7 @@ void RooStudyPackage::driver(Int_t nExperiments)
 
 void RooStudyPackage::initialize() 
 {
-  for (list<RooAbsStudy*>::iterator iter=_studies.begin() ; iter!=_studies.end() ; iter++) {
+  for (list<RooAbsStudy*>::iterator iter=_studies.begin() ; iter!=_studies.end() ; ++iter) {
     (*iter)->attach(*_ws) ;
     (*iter)->initialize() ;
   }
@@ -131,7 +131,7 @@ void RooStudyPackage::run(Int_t nExperiments)
 
 void RooStudyPackage::runOne() 
 {
-  for (list<RooAbsStudy*>::iterator iter=_studies.begin() ; iter!=_studies.end() ; iter++) {
+  for (list<RooAbsStudy*>::iterator iter=_studies.begin() ; iter!=_studies.end() ; ++iter) {
     (*iter)->execute() ;
   }    
 }
@@ -144,7 +144,7 @@ void RooStudyPackage::runOne()
 
 void RooStudyPackage::finalize() 
 {   
-  for (list<RooAbsStudy*>::iterator iter=_studies.begin() ; iter!=_studies.end() ; iter++) {
+  for (list<RooAbsStudy*>::iterator iter=_studies.begin() ; iter!=_studies.end() ; ++iter) {
     (*iter)->finalize() ;
   }
 }
@@ -156,7 +156,7 @@ void RooStudyPackage::finalize()
 
 void RooStudyPackage::exportData(TList* olist, Int_t seqno)
 {
-  for (list<RooAbsStudy*>::iterator iter=_studies.begin() ; iter!=_studies.end() ; iter++) {
+  for (list<RooAbsStudy*>::iterator iter=_studies.begin() ; iter!=_studies.end() ; ++iter) {
 
     (*iter)->finalize() ;
 

--- a/roofit/roofitcore/src/RooTreeDataStore.cxx
+++ b/roofit/roofitcore/src/RooTreeDataStore.cxx
@@ -1063,7 +1063,7 @@ RooAbsDataStore* RooTreeDataStore::merge(const RooArgSet& allVars, list<RooAbsDa
     mergedStore->_vars = *get(i) ;
       
     // Copy variables from merge sets
-    for (list<RooAbsDataStore*>::iterator iter = dstoreList.begin() ; iter!=dstoreList.end() ; iter++) {
+    for (list<RooAbsDataStore*>::iterator iter = dstoreList.begin() ; iter!=dstoreList.end() ; ++iter) {
       const RooArgSet* partSet = (*iter)->get(i) ;
       mergedStore->_vars = *partSet ;
     }

--- a/roofit/roofitcore/src/RooVectorDataStore.cxx
+++ b/roofit/roofitcore/src/RooVectorDataStore.cxx
@@ -1024,7 +1024,7 @@ RooAbsDataStore* RooVectorDataStore::merge(const RooArgSet& allVars, list<RooAbs
     mergedStore->_vars = *get(i) ;
       
     // Copy variables from merge sets
-    for (list<RooAbsDataStore*>::iterator iter = dstoreList.begin() ; iter!=dstoreList.end() ; iter++) {
+    for (list<RooAbsDataStore*>::iterator iter = dstoreList.begin() ; iter!=dstoreList.end() ; ++iter) {
       const RooArgSet* partSet = (*iter)->get(i) ;
       mergedStore->_vars = *partSet ;
     }

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -2467,7 +2467,7 @@ void RooWorkspace::Print(Option_t* opts) const
   if (_namedSets.size()>0) {
     cout << "named sets" << endl ;
     cout << "----------" << endl ;
-    for (map<string,RooArgSet>::const_iterator it = _namedSets.begin() ; it != _namedSets.end() ; it++) {
+    for (map<string,RooArgSet>::const_iterator it = _namedSets.begin() ; it != _namedSets.end() ; ++it) {
        if (verbose || !TString(it->first.c_str()).BeginsWith("CACHE_")) {
           cout << it->first << ":" << it->second << endl;
        }
@@ -2729,20 +2729,20 @@ void RooWorkspace::Streamer(TBuffer &R__b)
      // Reinstate clients here
 
      
-     for (map<RooAbsArg*,list<RooAbsArg*> >::iterator iterx = extClients.begin() ; iterx!=extClients.end() ; iterx++) {
-       for (list<RooAbsArg*>::iterator citer = iterx->second.begin() ; citer!=iterx->second.end() ; citer++) {
+     for (map<RooAbsArg*,list<RooAbsArg*> >::iterator iterx = extClients.begin() ; iterx!=extClients.end() ; ++iterx) {
+       for (list<RooAbsArg*>::iterator citer = iterx->second.begin() ; citer!=iterx->second.end() ; ++citer) {
 	 iterx->first->_clientList.Add(*citer) ;
        }
      }
 
-     for (map<RooAbsArg*,list<RooAbsArg*> >::iterator iterx = extValueClients.begin() ; iterx!=extValueClients.end() ; iterx++) {
-       for (list<RooAbsArg*>::iterator citer = iterx->second.begin() ; citer!=iterx->second.end() ; citer++) {
+     for (map<RooAbsArg*,list<RooAbsArg*> >::iterator iterx = extValueClients.begin() ; iterx!=extValueClients.end() ; ++iterx) {
+       for (list<RooAbsArg*>::iterator citer = iterx->second.begin() ; citer!=iterx->second.end() ; ++citer) {
 	 iterx->first->_clientListValue.Add(*citer) ;
        }
      }
 
-     for (map<RooAbsArg*,list<RooAbsArg*> >::iterator iterx = extShapeClients.begin() ; iterx!=extShapeClients.end() ; iterx++) {
-       for (list<RooAbsArg*>::iterator citer = iterx->second.begin() ; citer!=iterx->second.end() ; citer++) {
+     for (map<RooAbsArg*,list<RooAbsArg*> >::iterator iterx = extShapeClients.begin() ; iterx!=extShapeClients.end() ; ++iterx) {
+       for (list<RooAbsArg*>::iterator citer = iterx->second.begin() ; citer!=iterx->second.end() ; ++citer) {
 	 iterx->first->_clientListShape.Add(*citer) ;
        }
      }
@@ -2866,7 +2866,7 @@ Bool_t RooWorkspace::CodeRepo::compileClasses()
       fdecl << eiter->second._hfile.Data();
       fdecl.close();
    }
-   eiter++;
+   ++eiter;
       }
     }
     

--- a/roofit/roofitcore/src/RooXYChi2Var.cxx
+++ b/roofit/roofitcore/src/RooXYChi2Var.cxx
@@ -360,7 +360,7 @@ Double_t RooXYChi2Var::fy() const
   } else {
     Double_t volume(1) ;
     _rrvIter->Reset() ;
-    for (list<RooAbsBinning*>::const_iterator iter = _binList.begin() ; iter != _binList.end() ; iter++) {
+    for (list<RooAbsBinning*>::const_iterator iter = _binList.begin() ; iter != _binList.end() ; ++iter) {
       RooRealVar* x = (RooRealVar*) _rrvIter->Next() ;
       Double_t xmin = x->getVal() + x->getErrorLo() ;
       Double_t xmax = x->getVal() + x->getErrorHi() ;

--- a/roofit/roostats/src/BayesianCalculator.cxx
+++ b/roofit/roostats/src/BayesianCalculator.cxx
@@ -272,7 +272,7 @@ private:
       if (fHasNorm && fUseOldValues) {
          // look in the map of the stored cdf values the closes one
          std::map<double,double>::iterator itr = fNormCdfValues.upper_bound(x);
-         itr--;   // upper bound returns a position 1 up of the value we want
+         --itr;   // upper bound returns a position 1 up of the value we want
          if (itr != fNormCdfValues.end() ) {
             fXmin[0] = itr->first;
             normcdf0 = itr->second;

--- a/roofit/roostats/src/HypoTestInverterResult.cxx
+++ b/roofit/roostats/src/HypoTestInverterResult.cxx
@@ -301,7 +301,7 @@ int HypoTestInverterResult::ExclusionCleanup()
       continue;
     } else { // keep
       CLsobsprev = CLsobs;
-      itr++;
+      ++itr;
     }
   }
 

--- a/roofit/roostats/src/RooStatsUtils.cxx
+++ b/roofit/roostats/src/RooStatsUtils.cxx
@@ -231,7 +231,7 @@ namespace RooStats {
 
          ~BranchStore() {
             if (fTree) {
-               for(std::map<TString, Double_t>::iterator it = fVarVals.begin();it!=fVarVals.end();it++) {
+               for(std::map<TString, Double_t>::iterator it = fVarVals.begin();it!=fVarVals.end();++it) {
                   TBranch *br = fTree->GetBranch( it->first );
                   if (br) br->ResetAddress();
                }
@@ -240,13 +240,13 @@ namespace RooStats {
 
          void AssignToTTree(TTree &myTree) {
             fTree = &myTree;
-            for(std::map<TString, Double_t>::iterator it = fVarVals.begin();it!=fVarVals.end();it++) {
+            for(std::map<TString, Double_t>::iterator it = fVarVals.begin();it!=fVarVals.end();++it) {
                const TString& name = it->first;
                myTree.Branch( name, &fVarVals[name], TString::Format("%s/D", name.Data()));
             }
          }
          void ResetValues() {
-            for(std::map<TString, Double_t>::iterator it = fVarVals.begin();it!=fVarVals.end();it++) {
+            for(std::map<TString, Double_t>::iterator it = fVarVals.begin();it!=fVarVals.end();++it) {
                const TString& name = it->first;
                fVarVals[name] = fInval;
             }

--- a/sql/oracle/src/TOracleStatement.cxx
+++ b/sql/oracle/src/TOracleStatement.cxx
@@ -508,7 +508,7 @@ Bool_t TOracleStatement::SetVLong(Int_t npar, const std::vector<Long_t> value, c
       std::vector<Number> nvec;
       for (std::vector<Long_t>::const_iterator it = value.begin();
            it != value.end();
-           it++) {
+           ++it) {
          nvec.push_back(Number(*it));
       }
       setVector(fStmt, npar+1, nvec, schemaName, typeName);
@@ -530,7 +530,7 @@ Bool_t TOracleStatement::SetVLong64(Int_t npar, const std::vector<Long64_t> valu
       std::vector<Number> nvec;
       for (std::vector<Long64_t>::const_iterator it = value.begin();
            it != value.end();
-           it++) {
+           ++it) {
         nvec.push_back(Number((long double)*it));
       }
       setVector(fStmt, npar+1, nvec, schemaName, typeName);
@@ -552,7 +552,7 @@ Bool_t TOracleStatement::SetVULong64(Int_t npar, std::vector<ULong64_t> value, c
       std::vector<Number> nvec;
       for (std::vector<ULong64_t>::const_iterator it = value.begin();
            it != value.end();
-           it++) {
+           ++it) {
         nvec.push_back(Number((long double)*it));
       }
       setVector(fStmt, npar+1, nvec, schemaName, typeName);
@@ -1167,7 +1167,7 @@ Bool_t TOracleStatement::GetVLong(Int_t npar, std::vector<Long_t> &value)
          getVector(fResult, npar+1, res);
       for (std::vector<Number>::const_iterator it = res.begin();
            it != res.end();
-           it++ ) {
+           ++it ) {
          value.push_back((Long_t)*it);
       }
       return kTRUE;
@@ -1189,7 +1189,7 @@ Bool_t TOracleStatement::GetVLong64(Int_t npar, std::vector<Long64_t> &value)
          getVector(fResult, npar+1, res);
       for (std::vector<Number>::const_iterator it = res.begin();
            it != res.end();
-           it++ ) {
+           ++it ) {
          value.push_back((Long_t)*it);
       }
       return kTRUE;
@@ -1211,7 +1211,7 @@ Bool_t TOracleStatement::GetVULong64(Int_t npar, std::vector<ULong64_t> &value)
          getVector(fResult, npar+1, res);
       for (std::vector<Number>::const_iterator it = res.begin();
            it != res.end();
-           it++ ) {
+           ++it ) {
         value.push_back((Long_t)(long double)*it);
       }
       return kTRUE;

--- a/tmva/tmva/src/BinarySearchTree.cxx
+++ b/tmva/tmva/src/BinarySearchTree.cxx
@@ -101,7 +101,7 @@ TMVA::BinarySearchTree::BinarySearchTree( const BinarySearchTree &b)
 TMVA::BinarySearchTree::~BinarySearchTree( void )
 {
    for(std::vector< std::pair<Double_t, const TMVA::Event*> >::iterator pIt = fNormalizeTreeTable.begin();
-       pIt != fNormalizeTreeTable.end(); pIt++) {
+       pIt != fNormalizeTreeTable.end(); ++pIt) {
       delete pIt->second;
    }
 }
@@ -302,7 +302,7 @@ void TMVA::BinarySearchTree::NormalizeTree ( std::vector< std::pair<Double_t, co
    if (leftBound == rightBound) return;
 
    if (actDim == fPeriod)  actDim = 0;
-   for (std::vector< std::pair<Double_t, const TMVA::Event*> >::iterator i=leftBound; i!=rightBound; i++) {
+   for (std::vector< std::pair<Double_t, const TMVA::Event*> >::iterator i=leftBound; i!=rightBound; ++i) {
       i->first = i->second->GetValue( actDim );
    }
 
@@ -313,11 +313,11 @@ void TMVA::BinarySearchTree::NormalizeTree ( std::vector< std::pair<Double_t, co
 
    // meet in the middle
    while (true) {
-      rightTemp--;
+      --rightTemp;
       if (rightTemp == leftTemp ) {
          break;
       }
-      leftTemp++;
+      ++leftTemp;
       if (leftTemp  == rightTemp) {
          break;
       }
@@ -326,11 +326,11 @@ void TMVA::BinarySearchTree::NormalizeTree ( std::vector< std::pair<Double_t, co
    std::vector< std::pair<Double_t, const TMVA::Event*> >::iterator mid     = leftTemp;
    std::vector< std::pair<Double_t, const TMVA::Event*> >::iterator midTemp = mid;
 
-   if (mid!=leftBound) midTemp--;
+   if (mid!=leftBound)--midTemp;
 
    while (mid != leftBound && mid->second->GetValue( actDim ) == midTemp->second->GetValue( actDim ))  {
-      mid--;
-      midTemp--;
+      --mid;
+      --midTemp;
    }
 
    Insert( mid->second );
@@ -339,7 +339,7 @@ void TMVA::BinarySearchTree::NormalizeTree ( std::vector< std::pair<Double_t, co
    //    std::cout << std::endl << std::endl;
 
    NormalizeTree( leftBound, mid, actDim+1 );
-   mid++;
+   ++mid;
    //    Print(std::cout);
    //    std::cout << std::endl << std::endl;
    NormalizeTree( mid, rightBound, actDim+1 );

--- a/tmva/tmva/src/BinarySearchTreeNode.cxx
+++ b/tmva/tmva/src/BinarySearchTreeNode.cxx
@@ -66,7 +66,7 @@ TMVA::BinarySearchTreeNode::BinarySearchTreeNode( const Event* e, UInt_t /* sign
 {
    if (e!=0) {
       for (UInt_t ivar=0; ivar<e->GetNVariables(); ivar++) fEventV.push_back(e->GetValue(ivar));
-      for (std::vector<Float_t>::const_iterator it = e->GetTargets().begin(); it < e->GetTargets().end(); it++ ) {
+      for (std::vector<Float_t>::const_iterator it = e->GetTargets().begin(); it < e->GetTargets().end(); ++it ) {
          fTargets.push_back( (*it) );
       }
    }
@@ -153,7 +153,7 @@ void TMVA::BinarySearchTreeNode::Print( std::ostream& os ) const
    os << "< ***  " << std::endl << " node.Data: ";
    std::vector<Float_t>::const_iterator it=fEventV.begin();
    os << fEventV.size() << " vars: ";
-   for (;it!=fEventV.end(); it++) os << " " << std::setw(10) << *it;
+   for (;it!=fEventV.end(); ++it) os << " " << std::setw(10) << *it;
    os << "  EvtWeight " << std::setw(10) << fWeight;
    os << std::setw(10) << "Class: " << GetClass() << std::endl;
 
@@ -175,7 +175,7 @@ void TMVA::BinarySearchTreeNode::PrintRec( std::ostream& os ) const
       << " data: " <<  std::endl;
    std::vector<Float_t>::const_iterator it=fEventV.begin();
    os << fEventV.size() << " vars: ";
-   for (;it!=fEventV.end(); it++) os << " " << std::setw(10) << *it;
+   for (;it!=fEventV.end(); ++it) os << " " << std::setw(10) << *it;
    os << "  EvtWeight " << std::setw(10) << fWeight;
    os << std::setw(10) << "Class: " << GetClass() << std::endl;
 

--- a/tmva/tmva/src/ConvergenceTest.cxx
+++ b/tmva/tmva/src/ConvergenceTest.cxx
@@ -123,7 +123,7 @@ Float_t TMVA::ConvergenceTest::SpeedControl( UInt_t ofSteps )
    Int_t n = 0;
    Int_t sum = 0;
    std::deque<Short_t>::iterator vec = fSuccessList.begin();
-   for (; vec != fSuccessList.end() ; vec++) {
+   for (; vec != fSuccessList.end() ; ++vec) {
       sum += *vec;
       n++;
    }

--- a/tmva/tmva/src/DataInputHandler.cxx
+++ b/tmva/tmva/src/DataInputHandler.cxx
@@ -195,7 +195,7 @@ void TMVA::DataInputHandler::ClearTreeList( const TString& className )
 std::vector< TString >* TMVA::DataInputHandler::GetClassList() const
 {
    std::vector< TString >* ret = new std::vector< TString >();
-   for ( std::map< TString, std::vector<TreeInfo> >::iterator it = fInputTrees.begin(); it != fInputTrees.end(); it++ ){
+   for ( std::map< TString, std::vector<TreeInfo> >::iterator it = fInputTrees.begin(); it != fInputTrees.end(); ++it ){
       ret->push_back( it->first );
    }
    return ret;
@@ -208,7 +208,7 @@ UInt_t TMVA::DataInputHandler::GetEntries(const std::vector<TreeInfo>& tiV) cons
 {
    UInt_t entries = 0;
    std::vector<TreeInfo>::const_iterator tiIt = tiV.begin();
-   for (;tiIt != tiV.end(); tiIt++) entries += tiIt->GetEntries();
+   for (;tiIt != tiV.end();++tiIt) entries += tiIt->GetEntries();
    return entries;
 }
 
@@ -218,7 +218,7 @@ UInt_t TMVA::DataInputHandler::GetEntries(const std::vector<TreeInfo>& tiV) cons
 UInt_t TMVA::DataInputHandler::GetEntries() const
 {
    UInt_t number = 0;
-   for (std::map< TString, std::vector<TreeInfo> >::iterator it = fInputTrees.begin(); it != fInputTrees.end(); it++) {
+   for (std::map< TString, std::vector<TreeInfo> >::iterator it = fInputTrees.begin(); it != fInputTrees.end(); ++it) {
       number += GetEntries( it->second );
    }
    return number;

--- a/tmva/tmva/src/DataLoader.cxx
+++ b/tmva/tmva/src/DataLoader.cxx
@@ -105,7 +105,7 @@ TMVA::DataLoader::~DataLoader( void )
    // destructor
 
    std::vector<TMVA::VariableTransformBase*>::iterator trfIt = fDefaultTrfs.begin();
-   for (;trfIt != fDefaultTrfs.end(); trfIt++) delete (*trfIt);
+   for (;trfIt != fDefaultTrfs.end(); ++trfIt) delete (*trfIt);
 
    delete fDataInputHandler;
 
@@ -538,7 +538,7 @@ TMVA::DataSetInfo& TMVA::DataLoader::DefaultDataSetInfo()
 void TMVA::DataLoader::SetInputVariables( std::vector<TString>* theVariables )
 {
    for (std::vector<TString>::iterator it=theVariables->begin();
-        it!=theVariables->end(); it++) AddVariable(*it);
+        it!=theVariables->end(); ++it) AddVariable(*it);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -853,12 +853,12 @@ TMVA::DataLoader* TMVA::DataLoader::MakeCopy(TString name)
 
 void TMVA::DataLoaderCopy(TMVA::DataLoader* des, TMVA::DataLoader* src)
 {
-   for( std::vector<TreeInfo>::const_iterator treeinfo=src->DataInput().Sbegin();treeinfo!=src->DataInput().Send();treeinfo++)
+   for( std::vector<TreeInfo>::const_iterator treeinfo=src->DataInput().Sbegin();treeinfo!=src->DataInput().Send();++treeinfo)
    {
       des->AddSignalTree( (*treeinfo).GetTree(), (*treeinfo).GetWeight(),(*treeinfo).GetTreeType());
    }
 
-   for( std::vector<TreeInfo>::const_iterator treeinfo=src->DataInput().Bbegin();treeinfo!=src->DataInput().Bend();treeinfo++)
+   for( std::vector<TreeInfo>::const_iterator treeinfo=src->DataInput().Bbegin();treeinfo!=src->DataInput().Bend();++treeinfo)
    {
       des->AddBackgroundTree( (*treeinfo).GetTree(), (*treeinfo).GetWeight(),(*treeinfo).GetTreeType());
    }

--- a/tmva/tmva/src/DataSet.cxx
+++ b/tmva/tmva/src/DataSet.cxx
@@ -129,8 +129,8 @@ TMVA::DataSet::~DataSet()
 
    fBlockBelongToTraining.clear();
    // delete results
-   for (std::vector< std::map< TString, Results* > >::iterator it = fResults.begin(); it != fResults.end(); it++) {
-      for (std::map< TString, Results* >::iterator itMap = (*it).begin(); itMap != (*it).end(); itMap++) {
+   for (std::vector< std::map< TString, Results* > >::iterator it = fResults.begin(); it != fResults.end(); ++it) {
+      for (std::map< TString, Results* >::iterator itMap = (*it).begin(); itMap != (*it).end(); ++itMap) {
          delete itMap->second;
       }
    }
@@ -255,7 +255,7 @@ void TMVA::DataSet::SetEventCollection(std::vector<TMVA::Event*>* events, Types:
    ClearNClassEvents( type );
    //pointer to std::vector is not serializable,
    fEventCollection.at(t) = *events;
-   for (std::vector<Event*>::iterator it = fEventCollection.at(t).begin(); it < fEventCollection.at(t).end(); it++) {
+   for (std::vector<Event*>::iterator it = fEventCollection.at(t).begin(); it < fEventCollection.at(t).end(); ++it) {
       IncrementNClassEvents( t, (*it)->GetClass() );
    }
 }
@@ -500,7 +500,7 @@ void TMVA::DataSet::CreateSampling() const
    evtList.assign( fSamplingEventList.at(treeIdx).begin(), fSamplingEventList.at(treeIdx).end() );
 
    // sum up all the weights (internal weights for importance sampling)
-   for (evtListIt = evtList.begin(); evtListIt != evtList.end(); evtListIt++) {
+   for (evtListIt = evtList.begin(); evtListIt != evtList.end(); ++evtListIt) {
       sumWeights += (*evtListIt).first;
    }
    evtListIt = evtList.begin();
@@ -527,11 +527,11 @@ void TMVA::DataSet::CreateSampling() const
          fSamplingSelected.at(treeIdx).push_back( (*evtListIt) );
          evtListIt = evtList.erase( evtListIt );
 
-         rndsIt++;
+         ++rndsIt;
          if (rndsIt == rnds.end() ) break;
       }
       else {
-         evtListIt++;
+         ++evtListIt;
       }
    }
 }
@@ -621,7 +621,7 @@ TTree* TMVA::DataSet::GetTree( Types::ETreeType type )
    // create all branches for the variables
    Int_t n = 0;
    for (std::vector<VariableInfo>::const_iterator itVars = fdsi->GetVariableInfos().begin();
-        itVars != fdsi->GetVariableInfos().end(); itVars++) {
+        itVars != fdsi->GetVariableInfos().end(); ++itVars) {
 
       // has to be changed to take care of types different than float: TODO
       tree->Branch( (*itVars).GetInternalName(), &varVals[n], (*itVars).GetInternalName()+TString("/F") );
@@ -630,7 +630,7 @@ TTree* TMVA::DataSet::GetTree( Types::ETreeType type )
    // create the branches for the targets
    n = 0;
    for (std::vector<VariableInfo>::const_iterator itTgts = fdsi->GetTargetInfos().begin();
-        itTgts != fdsi->GetTargetInfos().end(); itTgts++) {
+        itTgts != fdsi->GetTargetInfos().end(); ++itTgts) {
       // has to be changed to take care of types different than float: TODO
       tree->Branch( (*itTgts).GetInternalName(), &tgtVals[n], (*itTgts).GetInternalName()+TString("/F") );
       n++;
@@ -638,7 +638,7 @@ TTree* TMVA::DataSet::GetTree( Types::ETreeType type )
    // create the branches for the spectator variables
    n = 0;
    for (std::vector<VariableInfo>::const_iterator itVis = fdsi->GetSpectatorInfos().begin();
-        itVis != fdsi->GetSpectatorInfos().end(); itVis++) {
+        itVis != fdsi->GetSpectatorInfos().end(); ++itVis) {
       // has to be changed to take care of types different than float: TODO
       tree->Branch( (*itVis).GetInternalName(), &visVals[n], (*itVis).GetInternalName()+TString("/F") );
       n++;
@@ -649,7 +649,7 @@ TTree* TMVA::DataSet::GetTree( Types::ETreeType type )
    // create all the branches for the results
    n = 0;
    for (std::map< TString, Results* >::iterator itMethod = fResults.at(t).begin();
-        itMethod != fResults.at(t).end(); itMethod++) {
+        itMethod != fResults.at(t).end(); ++itMethod) {
 
 
       Log() << kDEBUG << Form("Dataset[%s] : ",fdsi->GetName()) << "analysis type: " << (itMethod->second->GetAnalysisType()==Types::kRegression ? "Regression" :
@@ -709,7 +709,7 @@ TTree* TMVA::DataSet::GetTree( Types::ETreeType type )
       // loop through all the results and write the branches
       n=0;
       for (std::map<TString, Results*>::iterator itMethod = fResults.at(t).begin();
-           itMethod != fResults.at(t).end(); itMethod++) {
+           itMethod != fResults.at(t).end(); ++itMethod) {
          Results* results = itMethod->second;
 
          const std::vector< Float_t >& vals = results->operator[](iEvt);

--- a/tmva/tmva/src/DataSetFactory.cxx
+++ b/tmva/tmva/src/DataSetFactory.cxx
@@ -108,11 +108,11 @@ TMVA::DataSetFactory::~DataSetFactory()
 {
    std::vector<TTreeFormula*>::const_iterator formIt;
 
-   for (formIt = fInputFormulas.begin()    ; formIt!=fInputFormulas.end()    ; formIt++) if (*formIt) delete *formIt;
-   for (formIt = fTargetFormulas.begin()   ; formIt!=fTargetFormulas.end()   ; formIt++) if (*formIt) delete *formIt;
-   for (formIt = fCutFormulas.begin()      ; formIt!=fCutFormulas.end()      ; formIt++) if (*formIt) delete *formIt;
-   for (formIt = fWeightFormula.begin()    ; formIt!=fWeightFormula.end()    ; formIt++) if (*formIt) delete *formIt;
-   for (formIt = fSpectatorFormulas.begin(); formIt!=fSpectatorFormulas.end(); formIt++) if (*formIt) delete *formIt;
+   for (formIt = fInputFormulas.begin()    ; formIt!=fInputFormulas.end()    ; ++formIt) if (*formIt) delete *formIt;
+   for (formIt = fTargetFormulas.begin()   ; formIt!=fTargetFormulas.end()   ; ++formIt) if (*formIt) delete *formIt;
+   for (formIt = fCutFormulas.begin()      ; formIt!=fCutFormulas.end()      ; ++formIt) if (*formIt) delete *formIt;
+   for (formIt = fWeightFormula.begin()    ; formIt!=fWeightFormula.end()    ; ++formIt) if (*formIt) delete *formIt;
+   for (formIt = fSpectatorFormulas.begin(); formIt!=fSpectatorFormulas.end(); ++formIt) if (*formIt) delete *formIt;
 
    delete fLogger;
 }
@@ -175,7 +175,7 @@ TMVA::DataSet* TMVA::DataSetFactory::BuildDynamicDataSet( TMVA::DataSetInfo& dsi
 
    std::vector<VariableInfo>& spectatorinfos = dsi.GetSpectatorInfos();
    it = spectatorinfos.begin();
-   for (;it!=spectatorinfos.end();it++) evdyn->push_back( (Float_t*)(*it).GetExternalLink() );
+   for (;it!=spectatorinfos.end();++it) evdyn->push_back( (Float_t*)(*it).GetExternalLink() );
 
    TMVA::Event * ev = new Event((const std::vector<Float_t*>*&)evdyn, varinfos.size());
    std::vector<Event*>* newEventVector = new std::vector<Event*>;
@@ -203,7 +203,7 @@ TMVA::DataSetFactory::BuildInitialDataSet( DataSetInfo& dsi,
    // register the classes in the datasetinfo-object
    // information comes from the trees in the dataInputHandler-object
    std::vector< TString >* classList = dataInput.GetClassList();
-   for (std::vector<TString>::iterator it = classList->begin(); it< classList->end(); it++) {
+   for (std::vector<TString>::iterator it = classList->begin(); it< classList->end(); ++it) {
       dsi.AddClass( (*it) );
    }
    delete classList;
@@ -297,7 +297,7 @@ void TMVA::DataSetFactory::ChangeToNewTree( TreeInfo& tinfo, const DataSetInfo &
    // 1) the input variable formulas
    Log() << kDEBUG << Form("Dataset[%s] : ",dsi.GetName()) << "transform input variables" << Endl;
    std::vector<TTreeFormula*>::const_iterator formIt, formItEnd;
-   for (formIt = fInputFormulas.begin(), formItEnd=fInputFormulas.end(); formIt!=formItEnd; formIt++) if (*formIt) delete *formIt;
+   for (formIt = fInputFormulas.begin(), formItEnd=fInputFormulas.end(); formIt!=formItEnd; ++formIt) if (*formIt) delete *formIt;
    fInputFormulas.clear();
    TTreeFormula* ttf = 0;
 
@@ -312,7 +312,7 @@ void TMVA::DataSetFactory::ChangeToNewTree( TreeInfo& tinfo, const DataSetInfo &
    // targets
    //
    Log() << kDEBUG << Form("Dataset[%s] : ",dsi.GetName()) << "transform regression targets" << Endl;
-   for (formIt = fTargetFormulas.begin(), formItEnd = fTargetFormulas.end(); formIt!=formItEnd; formIt++) if (*formIt) delete *formIt;
+   for (formIt = fTargetFormulas.begin(), formItEnd = fTargetFormulas.end(); formIt!=formItEnd; ++formIt) if (*formIt) delete *formIt;
    fTargetFormulas.clear();
    for (UInt_t i=0; i<dsi.GetNTargets(); i++) {
       ttf = new TTreeFormula( Form( "Formula%s", dsi.GetTargetInfo(i).GetInternalName().Data() ),
@@ -325,7 +325,7 @@ void TMVA::DataSetFactory::ChangeToNewTree( TreeInfo& tinfo, const DataSetInfo &
    // spectators
    //
    Log() << kDEBUG << Form("Dataset[%s] : ",dsi.GetName()) << "transform spectator variables" << Endl;
-   for (formIt = fSpectatorFormulas.begin(), formItEnd = fSpectatorFormulas.end(); formIt!=formItEnd; formIt++) if (*formIt) delete *formIt;
+   for (formIt = fSpectatorFormulas.begin(), formItEnd = fSpectatorFormulas.end(); formIt!=formItEnd; ++formIt) if (*formIt) delete *formIt;
    fSpectatorFormulas.clear();
    for (UInt_t i=0; i<dsi.GetNSpectators(); i++) {
       ttf = new TTreeFormula( Form( "Formula%s", dsi.GetSpectatorInfo(i).GetInternalName().Data() ),
@@ -338,7 +338,7 @@ void TMVA::DataSetFactory::ChangeToNewTree( TreeInfo& tinfo, const DataSetInfo &
    // the cuts (one per class, if non-existent: formula pointer = 0)
    //
    Log() << kDEBUG << Form("Dataset[%s] : ",dsi.GetName()) << "transform cuts" << Endl;
-   for (formIt = fCutFormulas.begin(), formItEnd = fCutFormulas.end(); formIt!=formItEnd; formIt++) if (*formIt) delete *formIt;
+   for (formIt = fCutFormulas.begin(), formItEnd = fCutFormulas.end(); formIt!=formItEnd; ++formIt) if (*formIt) delete *formIt;
    fCutFormulas.clear();
    for (UInt_t clIdx=0; clIdx<dsi.GetNClasses(); clIdx++) {
       const TCut& tmpCut = dsi.GetClassInfo(clIdx)->GetCut();
@@ -359,7 +359,7 @@ void TMVA::DataSetFactory::ChangeToNewTree( TreeInfo& tinfo, const DataSetInfo &
    // the weights (one per class, if non-existent: formula pointer = 0)
    //
    Log() << kDEBUG << Form("Dataset[%s] : ",dsi.GetName()) << "transform weights" << Endl;
-   for (formIt = fWeightFormula.begin(), formItEnd = fWeightFormula.end(); formIt!=formItEnd; formIt++) if (*formIt) delete *formIt;
+   for (formIt = fWeightFormula.begin(), formItEnd = fWeightFormula.end(); formIt!=formItEnd; ++formIt) if (*formIt) delete *formIt;
    fWeightFormula.clear();
    for (UInt_t clIdx=0; clIdx<dsi.GetNClasses(); clIdx++) {
       const TString tmpWeight = dsi.GetClassInfo(clIdx)->GetWeight();
@@ -390,7 +390,7 @@ void TMVA::DataSetFactory::ChangeToNewTree( TreeInfo& tinfo, const DataSetInfo &
       tr->SetBranchStatus("*",0);
       Log() << kDEBUG << Form("Dataset[%s] : ",dsi.GetName()) << "enable branches: input variables" << Endl;
       // input vars
-      for (formIt = fInputFormulas.begin(); formIt!=fInputFormulas.end(); formIt++) {
+      for (formIt = fInputFormulas.begin(); formIt!=fInputFormulas.end(); ++formIt) {
          ttf = *formIt;
          for (Int_t bi = 0; bi<ttf->GetNcodes(); bi++) {
             tr->SetBranchStatus( ttf->GetLeaf(bi)->GetBranch()->GetName(), 1 );
@@ -398,21 +398,21 @@ void TMVA::DataSetFactory::ChangeToNewTree( TreeInfo& tinfo, const DataSetInfo &
       }
       // targets
       Log() << kDEBUG << Form("Dataset[%s] : ",dsi.GetName()) << "enable branches: targets" << Endl;
-      for (formIt = fTargetFormulas.begin(); formIt!=fTargetFormulas.end(); formIt++) {
+      for (formIt = fTargetFormulas.begin(); formIt!=fTargetFormulas.end(); ++formIt) {
          ttf = *formIt;
          for (Int_t bi = 0; bi<ttf->GetNcodes(); bi++)
             tr->SetBranchStatus( ttf->GetLeaf(bi)->GetBranch()->GetName(), 1 );
       }
       // spectators
       Log() << kDEBUG << Form("Dataset[%s] : ",dsi.GetName()) << "enable branches: spectators" << Endl;
-      for (formIt = fSpectatorFormulas.begin(); formIt!=fSpectatorFormulas.end(); formIt++) {
+      for (formIt = fSpectatorFormulas.begin(); formIt!=fSpectatorFormulas.end(); ++formIt) {
          ttf = *formIt;
          for (Int_t bi = 0; bi<ttf->GetNcodes(); bi++)
             tr->SetBranchStatus( ttf->GetLeaf(bi)->GetBranch()->GetName(), 1 );
       }
       // cuts
       Log() << kDEBUG << Form("Dataset[%s] : ",dsi.GetName()) << "enable branches: cuts" << Endl;
-      for (formIt = fCutFormulas.begin(); formIt!=fCutFormulas.end(); formIt++) {
+      for (formIt = fCutFormulas.begin(); formIt!=fCutFormulas.end(); ++formIt) {
          ttf = *formIt;
          if (!ttf) continue;
          for (Int_t bi = 0; bi<ttf->GetNcodes(); bi++)
@@ -420,7 +420,7 @@ void TMVA::DataSetFactory::ChangeToNewTree( TreeInfo& tinfo, const DataSetInfo &
       }
       // weights
       Log() << kDEBUG << Form("Dataset[%s] : ",dsi.GetName()) << "enable branches: weights" << Endl;
-      for (formIt = fWeightFormula.begin(); formIt!=fWeightFormula.end(); formIt++) {
+      for (formIt = fWeightFormula.begin(); formIt!=fWeightFormula.end(); ++formIt) {
          ttf = *formIt;
          if (!ttf) continue;
          for (Int_t bi = 0; bi<ttf->GetNcodes(); bi++)
@@ -730,7 +730,7 @@ TMVA::DataSetFactory::BuildEventVector( TMVA::DataSetInfo& dsi,
       TString currentFileName("");
 
       std::vector<TreeInfo>::const_iterator treeIt(dataInput.begin(dsi.GetClassInfo(cl)->GetName()));
-      for (;treeIt!=dataInput.end(dsi.GetClassInfo(cl)->GetName()); treeIt++) {
+      for (;treeIt!=dataInput.end(dsi.GetClassInfo(cl)->GetName()); ++treeIt) {
 
          // read first the variables
          std::vector<Float_t> vars(nvars);

--- a/tmva/tmva/src/DataSetInfo.cxx
+++ b/tmva/tmva/src/DataSetInfo.cxx
@@ -140,7 +140,7 @@ TMVA::ClassInfo* TMVA::DataSetInfo::AddClass( const TString& className )
 
 TMVA::ClassInfo* TMVA::DataSetInfo::GetClassInfo( const TString& name ) const
 {
-   for (std::vector<ClassInfo*>::iterator it = fClasses.begin(); it < fClasses.end(); it++) {
+   for (std::vector<ClassInfo*>::iterator it = fClasses.begin(); it < fClasses.end(); ++it) {
       if ((*it)->GetName() == name) return (*it);
    }
    return 0;
@@ -191,7 +191,7 @@ std::vector<Float_t>*  TMVA::DataSetInfo::GetTargetsForMulticlass( const TMVA::E
 Bool_t TMVA::DataSetInfo::HasCuts() const
 {
    Bool_t hasCuts = kFALSE;
-   for (std::vector<ClassInfo*>::iterator it = fClasses.begin(); it < fClasses.end(); it++) {
+   for (std::vector<ClassInfo*>::iterator it = fClasses.begin(); it < fClasses.end(); ++it) {
       if( TString((*it)->GetCut()) != TString("") ) hasCuts = kTRUE;
    }
    return hasCuts;
@@ -323,7 +323,7 @@ void TMVA::DataSetInfo::SetWeightExpression( const TString& expr, const TString&
       if (fClasses.empty()) {
          Log() << kWARNING << Form("Dataset[%s] : ",fName.Data()) << "No classes registered yet, cannot specify weight expression!" << Endl;
       }
-      for (std::vector<ClassInfo*>::iterator it = fClasses.begin(); it < fClasses.end(); it++) {
+      for (std::vector<ClassInfo*>::iterator it = fClasses.begin(); it < fClasses.end(); ++it) {
          (*it)->SetWeight( expr );
       }
    }
@@ -342,7 +342,7 @@ void TMVA::DataSetInfo::SetCorrelationMatrix( const TString& className, TMatrixD
 void TMVA::DataSetInfo::SetCut( const TCut& cut, const TString& className )
 {
    if (className == "") {  // if no className has been given set the cut for all the classes
-      for (std::vector<ClassInfo*>::iterator it = fClasses.begin(); it < fClasses.end(); it++) {
+      for (std::vector<ClassInfo*>::iterator it = fClasses.begin(); it < fClasses.end(); ++it) {
          (*it)->SetCut( cut );
       }
    }
@@ -358,7 +358,7 @@ void TMVA::DataSetInfo::SetCut( const TCut& cut, const TString& className )
 void TMVA::DataSetInfo::AddCut( const TCut& cut, const TString& className )
 {
    if (className == "") {  // if no className has been given set the cut for all the classes
-      for (std::vector<ClassInfo*>::iterator it = fClasses.begin(); it < fClasses.end(); it++) {
+      for (std::vector<ClassInfo*>::iterator it = fClasses.begin(); it < fClasses.end(); ++it) {
          const TCut& oldCut = (*it)->GetCut();
          (*it)->SetCut( oldCut+cut );
       }
@@ -376,7 +376,7 @@ std::vector<TString> TMVA::DataSetInfo::GetListOfVariables() const
 {
    std::vector<TString> vNames;
    std::vector<TMVA::VariableInfo>::const_iterator viIt = GetVariableInfos().begin();
-   for(;viIt != GetVariableInfos().end(); viIt++) vNames.push_back( (*viIt).GetExpression() );
+   for(;viIt != GetVariableInfos().end(); ++viIt) vNames.push_back( (*viIt).GetExpression() );
 
    return vNames;
 }

--- a/tmva/tmva/src/Envelope.cxx
+++ b/tmva/tmva/src/Envelope.cxx
@@ -290,7 +290,7 @@ void TMVA::Envelope::WriteDataInformation(TMVA::DataSetInfo &fDataSetInfo, TMVA:
 
    std::vector<TString> trfsDef = gTools().SplitString(processTrfs, ';');
    std::vector<TString>::iterator trfsDefIt = trfsDef.begin();
-   for (; trfsDefIt != trfsDef.end(); trfsDefIt++) {
+   for (; trfsDefIt != trfsDef.end(); ++trfsDefIt) {
       trfs.push_back(new TMVA::TransformationHandler(fDataSetInfo, "Envelope"));
       TString trfS = (*trfsDefIt);
 
@@ -307,7 +307,7 @@ void TMVA::Envelope::WriteDataInformation(TMVA::DataSetInfo &fDataSetInfo, TMVA:
    // apply all transformations
    std::vector<TMVA::TransformationHandler *>::iterator trfIt = trfs.begin();
 
-   for (; trfIt != trfs.end(); trfIt++) {
+   for (; trfIt != trfs.end(); ++trfIt) {
       // setting a Root dir causes the variables distributions to be saved to the root file
       (*trfIt)->SetRootDir(RootBaseDir()->GetDirectory(fDataSetInfo.GetName())); // every dataloader have its own dir
       (*trfIt)->CalcTransformations(inputEvents);
@@ -316,6 +316,6 @@ void TMVA::Envelope::WriteDataInformation(TMVA::DataSetInfo &fDataSetInfo, TMVA:
       identityTrHandler->PrintVariableRanking();
 
    // clean up
-   for (trfIt = trfs.begin(); trfIt != trfs.end(); trfIt++)
+   for (trfIt = trfs.begin(); trfIt != trfs.end(); ++trfIt)
       delete *trfIt;
 }

--- a/tmva/tmva/src/Factory.cxx
+++ b/tmva/tmva/src/Factory.cxx
@@ -297,7 +297,7 @@ Bool_t TMVA::Factory::IsModelPersistence()
 TMVA::Factory::~Factory( void )
 {
    std::vector<TMVA::VariableTransformBase*>::iterator trfIt = fDefaultTrfs.begin();
-   for (;trfIt != fDefaultTrfs.end(); trfIt++) delete (*trfIt);
+   for (;trfIt != fDefaultTrfs.end(); ++trfIt) delete (*trfIt);
 
    this->DeleteAllMethods();
 
@@ -316,12 +316,12 @@ void TMVA::Factory::DeleteAllMethods( void )
 {
    std::map<TString,MVector*>::iterator itrMap;
 
-   for(itrMap = fMethodsMap.begin();itrMap != fMethodsMap.end();itrMap++)
+   for(itrMap = fMethodsMap.begin();itrMap != fMethodsMap.end();++itrMap)
    {
       MVector *methods=itrMap->second;
       // delete methods
       MVector::iterator itrMethod = methods->begin();
-      for (; itrMethod != methods->end(); itrMethod++) {
+      for (; itrMethod != methods->end(); ++itrMethod) {
      Log() << kDEBUG << "Delete method: " << (*itrMethod)->GetName() << Endl;
      delete (*itrMethod);
       }
@@ -494,7 +494,7 @@ TMVA::IMethod* TMVA::Factory::GetMethod(const TString& datasetname,  const TStri
 
    MVector::const_iterator itrMethod;
    //
-   for (itrMethod    = methods->begin(); itrMethod != methods->end(); itrMethod++) {
+   for (itrMethod    = methods->begin(); itrMethod != methods->end(); ++itrMethod) {
       MethodBase* mva = dynamic_cast<MethodBase*>(*itrMethod);
       if ( (mva->GetMethodName())==methodTitle ) return mva;
    }
@@ -583,7 +583,7 @@ void TMVA::Factory::WriteDataInformation(DataSetInfo&     fDataSetInfo)
 
    std::vector<TString> trfsDef = gTools().SplitString(processTrfs,';');
    std::vector<TString>::iterator trfsDefIt = trfsDef.begin();
-   for (; trfsDefIt!=trfsDef.end(); trfsDefIt++) {
+   for (; trfsDefIt!=trfsDef.end(); ++trfsDefIt) {
       trfs.push_back(new TMVA::TransformationHandler(fDataSetInfo, "Factory"));
       TString trfS = (*trfsDefIt);
 
@@ -602,7 +602,7 @@ void TMVA::Factory::WriteDataInformation(DataSetInfo&     fDataSetInfo)
    // apply all transformations
    std::vector<TMVA::TransformationHandler*>::iterator trfIt = trfs.begin();
 
-   for (;trfIt != trfs.end(); trfIt++) {
+   for (;trfIt != trfs.end(); ++trfIt) {
       // setting a Root dir causes the variables distributions to be saved to the root file
       (*trfIt)->SetRootDir(RootBaseDir()->GetDirectory(fDataSetInfo.GetName()));// every dataloader have its own dir
       (*trfIt)->CalcTransformations(inputEvents);
@@ -610,7 +610,7 @@ void TMVA::Factory::WriteDataInformation(DataSetInfo&     fDataSetInfo)
    if(identityTrHandler) identityTrHandler->PrintVariableRanking();
 
    // clean up
-   for (trfIt = trfs.begin(); trfIt != trfs.end(); trfIt++) delete *trfIt;
+   for (trfIt = trfs.begin(); trfIt != trfs.end(); ++trfIt) delete *trfIt;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -624,14 +624,14 @@ std::map<TString,Double_t> TMVA::Factory::OptimizeAllMethods(TString fomType, TS
 
    std::map<TString,MVector*>::iterator itrMap;
    std::map<TString,Double_t> TunedParameters;
-   for(itrMap = fMethodsMap.begin();itrMap != fMethodsMap.end();itrMap++)
+   for(itrMap = fMethodsMap.begin();itrMap != fMethodsMap.end();++itrMap)
    {
       MVector *methods=itrMap->second;
 
       MVector::iterator itrMethod;
 
       // iterate over methods and optimize
-      for( itrMethod = methods->begin(); itrMethod != methods->end(); itrMethod++ ) {
+      for( itrMethod = methods->begin(); itrMethod != methods->end(); ++itrMethod ) {
      Event::SetIsTraining(kTRUE);
      MethodBase* mva = dynamic_cast<MethodBase*>(*itrMethod);
      if (!mva) {
@@ -1038,13 +1038,13 @@ void TMVA::Factory::TrainAllMethods()
 
    std::map<TString,MVector*>::iterator itrMap;
 
-   for(itrMap = fMethodsMap.begin();itrMap != fMethodsMap.end();itrMap++)
+   for(itrMap = fMethodsMap.begin();itrMap != fMethodsMap.end();++itrMap)
    {
       MVector *methods=itrMap->second;
       MVector::iterator itrMethod;
 
       // iterate over methods and train
-      for( itrMethod = methods->begin(); itrMethod != methods->end(); itrMethod++ ) {
+      for( itrMethod = methods->begin(); itrMethod != methods->end(); ++itrMethod ) {
      Event::SetIsTraining(kTRUE);
      MethodBase* mva = dynamic_cast<MethodBase*>(*itrMethod);
 
@@ -1084,7 +1084,7 @@ void TMVA::Factory::TrainAllMethods()
      // variable ranking
      //Log() << Endl;
      Log() << kINFO << "Ranking input variables (method specific)..." << Endl;
-     for (itrMethod = methods->begin(); itrMethod != methods->end(); itrMethod++) {
+     for (itrMethod = methods->begin(); itrMethod != methods->end(); ++itrMethod) {
        MethodBase* mva = dynamic_cast<MethodBase*>(*itrMethod);
        if (mva && mva->Data()->GetNTrainingEvents() >= MinNoTrainingEvents) {
 
@@ -1165,13 +1165,13 @@ void TMVA::Factory::TestAllMethods()
    }
    std::map<TString,MVector*>::iterator itrMap;
 
-   for(itrMap = fMethodsMap.begin();itrMap != fMethodsMap.end();itrMap++)
+   for(itrMap = fMethodsMap.begin();itrMap != fMethodsMap.end();++itrMap)
    {
       MVector *methods=itrMap->second;
       MVector::iterator itrMethod;
 
       // iterate over methods and test
-      for( itrMethod = methods->begin(); itrMethod != methods->end(); itrMethod++ ) {
+      for( itrMethod = methods->begin(); itrMethod != methods->end(); ++itrMethod ) {
      Event::SetIsTraining(kFALSE);
      MethodBase* mva = dynamic_cast<MethodBase*>(*itrMethod);
      if(mva==0) continue;
@@ -1201,7 +1201,7 @@ void TMVA::Factory::MakeClass(const TString& datasetname , const TString& method
       // no classifier specified, print all help messages
       MVector *methods=fMethodsMap.find(datasetname)->second;
       MVector::const_iterator itrMethod;
-      for (itrMethod    = methods->begin(); itrMethod != methods->end(); itrMethod++) {
+      for (itrMethod    = methods->begin(); itrMethod != methods->end(); ++itrMethod) {
          MethodBase* method = dynamic_cast<MethodBase*>(*itrMethod);
          if(method==0) continue;
          Log() << kINFO << "Make response class for classifier: " << method->GetMethodName() << Endl;
@@ -1229,7 +1229,7 @@ void TMVA::Factory::PrintHelpMessage(const TString& datasetname , const TString&
       // no classifier specified, print all help messages
       MVector *methods=fMethodsMap.find(datasetname)->second;
       MVector::const_iterator itrMethod ;
-      for (itrMethod    = methods->begin(); itrMethod != methods->end(); itrMethod++) {
+      for (itrMethod    = methods->begin(); itrMethod != methods->end(); ++itrMethod) {
          MethodBase* method = dynamic_cast<MethodBase*>(*itrMethod);
          if(method==0) continue;
          Log() << kINFO << "Print help message for classifier: " << method->GetMethodName() << Endl;
@@ -1267,7 +1267,7 @@ void TMVA::Factory::EvaluateAllMethods( void )
    }
    std::map<TString,MVector*>::iterator itrMap;
 
-   for(itrMap = fMethodsMap.begin();itrMap != fMethodsMap.end();itrMap++)
+   for(itrMap = fMethodsMap.begin();itrMap != fMethodsMap.end();++itrMap)
    {
       MVector *methods=itrMap->second;
 
@@ -1328,7 +1328,7 @@ void TMVA::Factory::EvaluateAllMethods( void )
       Bool_t doMulticlass = kFALSE;
 
       // iterate over methods and evaluate
-      for (MVector::iterator itrMethod =methods->begin(); itrMethod != methods->end(); itrMethod++) {
+      for (MVector::iterator itrMethod =methods->begin(); itrMethod != methods->end(); ++itrMethod) {
      Event::SetIsTraining(kFALSE);
      MethodBase* theMethod = dynamic_cast<MethodBase*>(*itrMethod);
      if(theMethod==0) continue;
@@ -1551,7 +1551,7 @@ void TMVA::Factory::EvaluateAllMethods( void )
       Int_t ivar = 0;
       std::vector<TString>* theVars = new std::vector<TString>;
       std::vector<ResultsClassification*> mvaRes;
-      for (MVector::iterator itrMethod = methodsNoCuts.begin(); itrMethod != methodsNoCuts.end(); itrMethod++, ivar++) {
+      for (MVector::iterator itrMethod = methodsNoCuts.begin(); itrMethod != methodsNoCuts.end(); ++itrMethod, ++ivar) {
           MethodBase* m = dynamic_cast<MethodBase*>(*itrMethod);
           if(m==0) continue;
           theVars->push_back( m->GetTestvarName() );

--- a/tmva/tmva/src/FitterBase.cxx
+++ b/tmva/tmva/src/FitterBase.cxx
@@ -74,7 +74,7 @@ TMVA::FitterBase::FitterBase( IFitterTarget& target,
 Double_t TMVA::FitterBase::Run()
 {
    std::vector<Double_t> pars;
-   for (std::vector<Interval*>::const_iterator parIt = fRanges.begin(); parIt != fRanges.end(); parIt++) {
+   for (std::vector<Interval*>::const_iterator parIt = fRanges.begin(); parIt != fRanges.end(); ++parIt) {
       pars.push_back( (*parIt)->GetMean() );
    }
 

--- a/tmva/tmva/src/GeneticAlgorithm.cxx
+++ b/tmva/tmva/src/GeneticAlgorithm.cxx
@@ -228,7 +228,7 @@ Double_t TMVA::GeneticAlgorithm::SpreadControl( Int_t ofSteps, Int_t successStep
    Int_t n = 0;
    Int_t sum = 0;
    std::deque<Int_t>::iterator vec = fSuccessList.begin();
-   for (; vec != fSuccessList.end() ; vec++) {
+   for (; vec != fSuccessList.end() ; ++vec) {
       sum += *vec;
       n++;
    }

--- a/tmva/tmva/src/GeneticPopulation.cxx
+++ b/tmva/tmva/src/GeneticPopulation.cxx
@@ -83,7 +83,7 @@ TMVA::GeneticPopulation::~GeneticPopulation()
    if (fRandomGenerator != NULL) delete fRandomGenerator;
 
    std::vector<GeneticRange*>::iterator it = fRanges.begin();
-   for (;it!=fRanges.end(); it++) delete *it;
+   for (;it!=fRanges.end(); ++it) delete *it;
 
    delete fLogger;
 }
@@ -214,7 +214,7 @@ void TMVA::GeneticPopulation::Print( Int_t untilIndex )
          }
          Log() << "fitness: " << fGenePool[it].GetFitness() << "    ";
          for (vector< Double_t >::iterator vec = fGenePool[it].GetFactors().begin();
-              vec < fGenePool[it].GetFactors().end(); vec++ ) {
+              vec < fGenePool[it].GetFactors().end(); ++vec ) {
             Log() << "f_" << n++ << ": " << (*vec) << "     ";
          }
          Log() << Endl;
@@ -235,7 +235,7 @@ void TMVA::GeneticPopulation::Print( ostream & out, Int_t untilIndex )
       }
       out << "fitness: " << fGenePool[it].GetFitness() << "    ";
       for (vector< Double_t >::iterator vec = fGenePool[it].GetFactors().begin();
-           vec < fGenePool[it].GetFactors().end(); vec++ ) {
+           vec < fGenePool[it].GetFactors().end(); ++vec ) {
          out << "f_" << n++ << ": " << (*vec) << "     ";
       }
       out << std::endl;
@@ -283,7 +283,7 @@ vector<Double_t> TMVA::GeneticPopulation::VariableDistribution( Int_t /*varNumbe
 void TMVA::GeneticPopulation::AddPopulation( GeneticPopulation *strangers )
 {
    for (std::vector<TMVA::GeneticGenes>::iterator it = strangers->fGenePool.begin();
-        it != strangers->fGenePool.end(); it++ ) {
+        it != strangers->fGenePool.end(); ++it ) {
       GiveHint( it->GetFactors(), it->GetFitness() );
    }
 }

--- a/tmva/tmva/src/LossFunction.cxx
+++ b/tmva/tmva/src/LossFunction.cxx
@@ -251,7 +251,7 @@ void TMVA::HuberLossFunctionBDT::Init(std::map<const TMVA::Event*, LossFunctionE
 void TMVA::HuberLossFunctionBDT::SetTargets(std::vector<const TMVA::Event*>& evs, std::map< const TMVA::Event*, LossFunctionEventInfo >& evinfomap){
 
    std::vector<LossFunctionEventInfo> eventvec;
-   for (std::vector<const TMVA::Event*>::const_iterator e=evs.begin(); e!=evs.end();e++){
+   for (std::vector<const TMVA::Event*>::const_iterator e=evs.begin(); e!=evs.end();++e){
       eventvec.push_back(LossFunctionEventInfo(evinfomap[*e].trueValue, evinfomap[*e].predictedValue, (*e)->GetWeight()));
    }
 
@@ -261,7 +261,7 @@ void TMVA::HuberLossFunctionBDT::SetTargets(std::vector<const TMVA::Event*>& evs
    SetSumOfWeights(eventvec); // This was already set in init, but may change if there is subsampling for each tree
    SetTransitionPoint(eventvec);
 
-   for (std::vector<const TMVA::Event*>::const_iterator e=evs.begin(); e!=evs.end();e++) {
+   for (std::vector<const TMVA::Event*>::const_iterator e=evs.begin(); e!=evs.end();++e) {
          const_cast<TMVA::Event*>(*e)->SetTarget(0,Target(evinfomap[*e]));
    }
 }
@@ -384,11 +384,11 @@ void TMVA::LeastSquaresLossFunctionBDT::Init(std::map<const TMVA::Event*, LossFu
 void TMVA::LeastSquaresLossFunctionBDT::SetTargets(std::vector<const TMVA::Event*>& evs, std::map< const TMVA::Event*, LossFunctionEventInfo >& evinfomap){
 
    std::vector<LossFunctionEventInfo> eventvec;
-   for (std::vector<const TMVA::Event*>::const_iterator e=evs.begin(); e!=evs.end();e++){
+   for (std::vector<const TMVA::Event*>::const_iterator e=evs.begin(); e!=evs.end();++e){
       eventvec.push_back(LossFunctionEventInfo(evinfomap[*e].trueValue, evinfomap[*e].predictedValue, (*e)->GetWeight()));
    }
 
-   for (std::vector<const TMVA::Event*>::const_iterator e=evs.begin(); e!=evs.end();e++) {
+   for (std::vector<const TMVA::Event*>::const_iterator e=evs.begin(); e!=evs.end();++e) {
          const_cast<TMVA::Event*>(*e)->SetTarget(0,Target(evinfomap[*e]));
    }
 }
@@ -497,11 +497,11 @@ void TMVA::AbsoluteDeviationLossFunctionBDT::Init(std::map<const TMVA::Event*, L
 void TMVA::AbsoluteDeviationLossFunctionBDT::SetTargets(std::vector<const TMVA::Event*>& evs, std::map< const TMVA::Event*, LossFunctionEventInfo >& evinfomap){
 
    std::vector<LossFunctionEventInfo> eventvec;
-   for (std::vector<const TMVA::Event*>::const_iterator e=evs.begin(); e!=evs.end();e++){
+   for (std::vector<const TMVA::Event*>::const_iterator e=evs.begin(); e!=evs.end();++e){
       eventvec.push_back(LossFunctionEventInfo(evinfomap[*e].trueValue, evinfomap[*e].predictedValue, (*e)->GetWeight()));
    }
 
-   for (std::vector<const TMVA::Event*>::const_iterator e=evs.begin(); e!=evs.end();e++) {
+   for (std::vector<const TMVA::Event*>::const_iterator e=evs.begin(); e!=evs.end();++e) {
          const_cast<TMVA::Event*>(*e)->SetTarget(0,Target(evinfomap[*e]));
    }
 }

--- a/tmva/tmva/src/MCFitter.cxx
+++ b/tmva/tmva/src/MCFitter.cxx
@@ -107,7 +107,7 @@ Double_t TMVA::MCFitter::Run( std::vector<Double_t>& pars )
    // initial parameters (given by argument) are ignored
    std::vector< TMVA::Interval* >::const_iterator rIt;
    Double_t val;
-   for (rIt = fRanges.begin(); rIt<fRanges.end(); rIt++) {
+   for (rIt = fRanges.begin(); rIt<fRanges.end(); ++rIt) {
       rndRanges.push_back( new TMVA::GeneticRange( rnd, (*rIt) ) );
       val = rndRanges.back()->Random();
       parameters.push_back( val );
@@ -129,16 +129,16 @@ Double_t TMVA::MCFitter::Run( std::vector<Double_t>& pars )
       parIt = parameters.begin();
       if (fSigma > 0.0) {
          parBestIt = bestParameters.begin();
-         for (std::vector<TMVA::GeneticRange*>::iterator rndIt = rndRanges.begin(); rndIt<rndRanges.end(); rndIt++) {
+         for (std::vector<TMVA::GeneticRange*>::iterator rndIt = rndRanges.begin(); rndIt<rndRanges.end(); ++rndIt) {
             (*parIt) = (*rndIt)->Random( kTRUE, (*parBestIt), fSigma );
-            parIt++;
-            parBestIt++;
+            ++parIt;
+            ++parBestIt;
          }
       }
       else {
-         for (std::vector<TMVA::GeneticRange*>::iterator rndIt = rndRanges.begin(); rndIt<rndRanges.end(); rndIt++) {
+         for (std::vector<TMVA::GeneticRange*>::iterator rndIt = rndRanges.begin(); rndIt<rndRanges.end(); ++rndIt) {
             (*parIt) = (*rndIt)->Random();
-            parIt++;
+            ++parIt;
          }
       }
 

--- a/tmva/tmva/src/MethodANNBase.cxx
+++ b/tmva/tmva/src/MethodANNBase.cxx
@@ -199,7 +199,7 @@ std::vector<Int_t>* TMVA::MethodANNBase::ParseLayoutString(TString layerSpec)
       layout->push_back(1);  // one output node (for signal/background classification)
 
    int n = 0;
-   for( std::vector<Int_t>::iterator it = layout->begin(); it != layout->end(); it++ ){
+   for( std::vector<Int_t>::iterator it = layout->begin(); it != layout->end(); ++it ){
       n++;
    }
 
@@ -1022,15 +1022,15 @@ void TMVA::MethodANNBase::WriteMonitoringHistosToFile() const
       epochdir = BaseDir()->mkdir( Form("EpochMonitoring_%4d",epochVal) );
 
    epochdir->cd();
-   for (std::vector<TH1*>::const_iterator it = fEpochMonHistS.begin(); it != fEpochMonHistS.end(); it++) {
+   for (std::vector<TH1*>::const_iterator it = fEpochMonHistS.begin(); it != fEpochMonHistS.end(); ++it) {
       (*it)->Write();
       delete (*it);
    }
-   for (std::vector<TH1*>::const_iterator it = fEpochMonHistB.begin(); it != fEpochMonHistB.end(); it++) {
+   for (std::vector<TH1*>::const_iterator it = fEpochMonHistB.begin(); it != fEpochMonHistB.end(); ++it) {
       (*it)->Write();
       delete (*it);
    }
-   for (std::vector<TH1*>::const_iterator it = fEpochMonHistW.begin(); it != fEpochMonHistW.end(); it++) {
+   for (std::vector<TH1*>::const_iterator it = fEpochMonHistW.begin(); it != fEpochMonHistW.end(); ++it) {
       (*it)->Write();
       delete (*it);
    }

--- a/tmva/tmva/src/MethodBDT.cxx
+++ b/tmva/tmva/src/MethodBDT.cxx
@@ -1099,7 +1099,7 @@ std::map<TString,Double_t>  TMVA::MethodBDT::OptimizeTuningParameters(TString fo
 
    Log()<<kINFO << " the following BDT parameters will be tuned on the respective *grid*\n"<<Endl;
    std::map<TString,TMVA::Interval*>::iterator it;
-   for(it=tuneParameters.begin(); it!= tuneParameters.end(); it++){
+   for(it=tuneParameters.begin(); it!= tuneParameters.end(); ++it){
       Log() << kWARNING << it->first << Endl;
       std::ostringstream oss;
       (it->second)->Print(oss);
@@ -1120,7 +1120,7 @@ std::map<TString,Double_t>  TMVA::MethodBDT::OptimizeTuningParameters(TString fo
 void TMVA::MethodBDT::SetTuneParameters(std::map<TString,Double_t> tuneParameters)
 {
    std::map<TString,Double_t>::iterator it;
-   for(it=tuneParameters.begin(); it!= tuneParameters.end(); it++){
+   for(it=tuneParameters.begin(); it!= tuneParameters.end(); ++it){
       Log() << kWARNING << it->first << " = " << it->second << Endl;
       if (it->first ==  "MaxDepth"       ) SetMaxDepth        ((Int_t)it->second);
       else if (it->first ==  "MinNodeSize"    ) SetMinNodeSize     (it->second);
@@ -1476,7 +1476,7 @@ void TMVA::MethodBDT::UpdateTargets(std::vector<const TMVA::Event*>& eventSample
 void TMVA::MethodBDT::UpdateTargetsRegression(std::vector<const TMVA::Event*>& eventSample, Bool_t first)
 {
    if(!first){
-      for (std::vector<const TMVA::Event*>::const_iterator e=fEventSample.begin(); e!=fEventSample.end();e++) {
+      for (std::vector<const TMVA::Event*>::const_iterator e=fEventSample.begin(); e!=fEventSample.end();++e) {
          fLossFunctionEventInfo[*e].predictedValue += fForest.back()->CheckEvent(*e,kFALSE);
       }
    }
@@ -1526,7 +1526,7 @@ Double_t TMVA::MethodBDT::GradBoostRegression(std::vector<const TMVA::Event*>& e
    // get the vector of events for each terminal so that we can calculate the constant fit value in each
    // terminal node
    std::map<TMVA::DecisionTreeNode*,vector< TMVA::LossFunctionEventInfo > > leaves;
-   for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();e++) {
+   for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();++e) {
       TMVA::DecisionTreeNode* node = dt->GetEventNode(*(*e));
       (leaves[node]).push_back(fLossFunctionEventInfo[*e]);
    }
@@ -1553,7 +1553,7 @@ void TMVA::MethodBDT::InitGradBoost( std::vector<const TMVA::Event*>& eventSampl
    //                                     return (a->GetTarget(0) < b->GetTarget(0)); });
    fSepType=NULL; //set fSepType to NULL (regression trees are used for both classification an regression)
    if(DoRegression()){
-      for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();e++) {
+      for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();++e) {
          fLossFunctionEventInfo[*e]= TMVA::LossFunctionEventInfo((*e)->GetTarget(0), 0, (*e)->GetWeight());
       }
 
@@ -1563,7 +1563,7 @@ void TMVA::MethodBDT::InitGradBoost( std::vector<const TMVA::Event*>& eventSampl
    }
    else if(DoMulticlass()){
       UInt_t nClasses = DataInfo().GetNClasses();
-      for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();e++) {
+      for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();++e) {
          for (UInt_t i=0;i<nClasses;i++){
             //Calculate initial residua, assuming equal probability for all classes
             Double_t r = (*e)->GetClass()==i?(1-1.0/nClasses):(-1.0/nClasses);
@@ -1573,7 +1573,7 @@ void TMVA::MethodBDT::InitGradBoost( std::vector<const TMVA::Event*>& eventSampl
       }
    }
    else{
-      for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();e++) {
+      for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();++e) {
          Double_t r = (DataInfo().IsSignal(*e)?1:0)-0.5; //Calculate initial residua
          const_cast<TMVA::Event*>(*e)->SetTarget(0,r);
          fResiduals[*e].push_back(0);
@@ -1740,7 +1740,7 @@ Double_t TMVA::MethodBDT::AdaBoost( std::vector<const TMVA::Event*>& eventSample
    std::vector<Double_t> sumw(DataInfo().GetNClasses(),0); //for individually re-scaling  each class
 
    Double_t maxDev=0;
-   for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();e++) {
+   for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();++e) {
       Double_t w = (*e)->GetWeight();
       sumGlobalw += w;
       UInt_t iclass=(*e)->GetClass();
@@ -1779,7 +1779,7 @@ Double_t TMVA::MethodBDT::AdaBoost( std::vector<const TMVA::Event*>& eventSample
       }
       else if (fAdaBoostR2Loss=="exponential"){
          err = 0;
-         for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();e++) {
+         for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();++e) {
             Double_t w = (*e)->GetWeight();
             Double_t  tmpDev = TMath::Abs(dt->CheckEvent(*e,kFALSE) - (*e)->GetTarget(0) );
             err += w * (1 - exp (-tmpDev/maxDev)) / sumGlobalw;
@@ -1835,7 +1835,7 @@ Double_t TMVA::MethodBDT::AdaBoost( std::vector<const TMVA::Event*>& eventSample
    Results* results = Data()->GetResults(GetMethodName(),Types::kTraining, Types::kMaxAnalysisType);
 
 
-   for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();e++) {
+   for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();++e) {
 
       if (fUseYesNoLeaf||DoRegression()){
          if ((!( (dt->CheckEvent(*e,fUseYesNoLeaf) > fNodePurityLimit ) == DataInfo().IsSignal(*e))) || DoRegression()) {
@@ -1879,7 +1879,7 @@ Double_t TMVA::MethodBDT::AdaBoost( std::vector<const TMVA::Event*>& eventSample
    Log() << kDEBUG << "new Nsig="<<newSumw[0]*globalNormWeight << " new Nbkg="<<newSumw[1]*globalNormWeight << Endl;
 
 
-   for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();e++) {
+   for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();++e) {
       //      if (fRenormByClass) (*e)->ScaleBoostWeight( normWeightByClass[(*e)->GetClass()] );
       //      else                (*e)->ScaleBoostWeight( globalNormWeight );
       //      else                (*e)->ScaleBoostWeight( globalNormWeight );
@@ -1922,7 +1922,7 @@ Double_t TMVA::MethodBDT::AdaCost( vector<const TMVA::Event*>& eventSample, Deci
 
    std::vector<Double_t> sumw(DataInfo().GetNClasses(),0);      //for individually re-scaling  each class
 
-   for (vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();e++) {
+   for (vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();++e) {
       Double_t w = (*e)->GetWeight();
       sumGlobalWeights += w;
       UInt_t iclass=(*e)->GetClass();
@@ -1969,7 +1969,7 @@ Double_t TMVA::MethodBDT::AdaCost( vector<const TMVA::Event*>& eventSample, Deci
 
    Results* results = Data()->GetResults(GetMethodName(),Types::kTraining, Types::kMaxAnalysisType);
 
-   for (vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();e++) {
+   for (vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();++e) {
       Double_t dtoutput = (dt->CheckEvent(*e,false) - 0.5)*2.;
       Int_t    trueType;
       Bool_t   isTrueSignal = DataInfo().IsSignal(*e);
@@ -2004,7 +2004,7 @@ Double_t TMVA::MethodBDT::AdaCost( vector<const TMVA::Event*>& eventSample, Deci
    Log() << kDEBUG << "new Nsig="<<newSumClassWeights[0]*globalNormWeight << " new Nbkg="<<newSumClassWeights[1]*globalNormWeight << Endl;
 
 
-   for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();e++) {
+   for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();++e) {
       // if (fRenormByClass) (*e)->ScaleBoostWeight( normWeightByClass[(*e)->GetClass()] );
       // else                (*e)->ScaleBoostWeight( globalNormWeight );
       if (DataInfo().IsSignal(*e))(*e)->ScaleBoostWeight( globalNormWeight * fSigToBkgFraction );
@@ -2046,7 +2046,7 @@ void TMVA::MethodBDT::GetBaggedSubSample(std::vector<const TMVA::Event*>& eventS
 
    if (!fSubSample.empty()) fSubSample.clear();
 
-   for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();e++) {
+   for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();++e) {
       n = trandom->PoissonD(fBaggedSampleFraction);
       for (Int_t i=0;i<n;i++) fSubSample.push_back(*e);
    }
@@ -2086,7 +2086,7 @@ Double_t TMVA::MethodBDT::AdaBoostR2( std::vector<const TMVA::Event*>& eventSamp
 
    Double_t err=0, sumw=0, sumwfalse=0, sumwfalse2=0;
    Double_t maxDev=0;
-   for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();e++) {
+   for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();++e) {
       Double_t w = (*e)->GetWeight();
       sumw += w;
 
@@ -2105,7 +2105,7 @@ Double_t TMVA::MethodBDT::AdaBoostR2( std::vector<const TMVA::Event*>& eventSamp
    }
    else if (fAdaBoostR2Loss=="exponential"){
       err = 0;
-      for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();e++) {
+      for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();++e) {
          Double_t w = (*e)->GetWeight();
          Double_t  tmpDev = TMath::Abs(dt->CheckEvent(*e,kFALSE) - (*e)->GetTarget(0) );
          err += w * (1 - exp (-tmpDev/maxDev)) / sumw;
@@ -2150,7 +2150,7 @@ Double_t TMVA::MethodBDT::AdaBoostR2( std::vector<const TMVA::Event*>& eventSamp
 
    Results* results = Data()->GetResults(GetMethodName(), Types::kTraining, Types::kMaxAnalysisType);
 
-   for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();e++) {
+   for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();++e) {
       Double_t boostfactor =  TMath::Power(boostWeight,(1.-TMath::Abs(dt->CheckEvent(*e,kFALSE) - (*e)->GetTarget(0) )/maxDev ) );
       results->GetHist("BoostWeights")->Fill(boostfactor);
       //      std::cout << "R2  " << boostfactor << "   " << boostWeight << "   " << (1.-TMath::Abs(dt->CheckEvent(*e,kFALSE) - (*e)->GetTarget(0) )/maxDev)  << std::endl;
@@ -2178,7 +2178,7 @@ Double_t TMVA::MethodBDT::AdaBoostR2( std::vector<const TMVA::Event*>& eventSamp
 
    // re-normalise the weights
    Double_t normWeight =  sumw / newSumw;
-   for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();e++) {
+   for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();++e) {
       //Helge    (*e)->ScaleBoostWeight( sumw/newSumw);
       // (*e)->ScaleBoostWeight( normWeight);
       (*e)->SetBoostWeight( (*e)->GetBoostWeight() * normWeight );

--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -393,7 +393,7 @@ TMVA::MethodBase::~MethodBase( void )
    for (Int_t i = 0; i < 2; i++ ) {
       if (fEventCollections.at(i)) {
          for (std::vector<Event*>::const_iterator it = fEventCollections.at(i)->begin();
-              it != fEventCollections.at(i)->end(); it++) {
+              it != fEventCollections.at(i)->end(); ++it) {
             delete (*it);
          }
          delete fEventCollections.at(i);
@@ -1674,10 +1674,10 @@ void TMVA::MethodBase::WriteVarsToStream( std::ostream& o, const TString& prefix
 {
    o << prefix << "NVar " << DataInfo().GetNVariables() << std::endl;
    std::vector<VariableInfo>::const_iterator varIt = DataInfo().GetVariableInfos().begin();
-   for (; varIt!=DataInfo().GetVariableInfos().end(); varIt++) { o << prefix; varIt->WriteToStream(o); }
+   for (; varIt!=DataInfo().GetVariableInfos().end(); ++varIt) { o << prefix; varIt->WriteToStream(o); }
    o << prefix << "NSpec " << DataInfo().GetNSpectators() << std::endl;
    varIt = DataInfo().GetSpectatorInfos().begin();
-   for (; varIt!=DataInfo().GetSpectatorInfos().end(); varIt++) { o << prefix; varIt->WriteToStream(o); }
+   for (; varIt!=DataInfo().GetSpectatorInfos().end(); ++varIt) { o << prefix; varIt->WriteToStream(o); }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1701,7 +1701,7 @@ void TMVA::MethodBase::ReadVarsFromStream( std::istream& istr )
    VariableInfo varInfo;
    std::vector<VariableInfo>::iterator varIt = DataInfo().GetVariableInfos().begin();
    int varIdx = 0;
-   for (; varIt!=DataInfo().GetVariableInfos().end(); varIt++, varIdx++) {
+   for (; varIt!=DataInfo().GetVariableInfos().end(); ++varIt, ++varIdx) {
       varInfo.ReadFromStream(istr);
       if (varIt->GetExpression() == varInfo.GetExpression()) {
          varInfo.SetExternalLink((*varIt).GetExternalLink());
@@ -2780,6 +2780,8 @@ Double_t TMVA::MethodBase::GetROCIntegral(TH1D *histS, TH1D *histB) const
       integral += (1-pdfB->GetIntegral(cut,xmax)) * pdfS->GetVal(cut);
       cut+=step;
    }
+   delete pdfS;
+   delete pdfB;
    return integral*step;
 }
 

--- a/tmva/tmva/src/MethodCategory.cxx
+++ b/tmva/tmva/src/MethodCategory.cxx
@@ -219,10 +219,10 @@ TMVA::DataSetInfo& TMVA::MethodCategory::CreateCategoryDSI(const TCut& theCut,
    // copy the targets and spectators from the old dsi to the new dsi
    std::vector<VariableInfo>::iterator itrVarInfo;
 
-   for (itrVarInfo = oldDSI.GetTargetInfos().begin(); itrVarInfo != oldDSI.GetTargetInfos().end(); itrVarInfo++)
+   for (itrVarInfo = oldDSI.GetTargetInfos().begin(); itrVarInfo != oldDSI.GetTargetInfos().end(); ++itrVarInfo)
       dsi->AddTarget(*itrVarInfo);
 
-   for (itrVarInfo = oldDSI.GetSpectatorInfos().begin(); itrVarInfo != oldDSI.GetSpectatorInfos().end(); itrVarInfo++)
+   for (itrVarInfo = oldDSI.GetSpectatorInfos().begin(); itrVarInfo != oldDSI.GetSpectatorInfos().end(); ++itrVarInfo)
       dsi->AddSpectator(*itrVarInfo);
 
    // split string that contains the variables into tiny little pieces
@@ -237,11 +237,11 @@ TMVA::DataSetInfo& TMVA::MethodCategory::CreateCategoryDSI(const TCut& theCut,
    Bool_t found = kFALSE;
 
    // iterate over all variables in 'variables' and add them
-   for (itrVariables = variables.begin(); itrVariables != variables.end(); itrVariables++) {
+   for (itrVariables = variables.begin(); itrVariables != variables.end(); ++itrVariables) {
       counter=0;
 
       // check the variables of the old dsi for the variable that we want to add
-      for (itrVarInfo = oldDSI.GetVariableInfos().begin(); itrVarInfo != oldDSI.GetVariableInfos().end(); itrVarInfo++) {
+      for (itrVarInfo = oldDSI.GetVariableInfos().begin(); itrVarInfo != oldDSI.GetVariableInfos().end(); ++itrVarInfo) {
          if((*itrVariables==itrVarInfo->GetLabel()) ) { // || (*itrVariables==itrVarInfo->GetExpression())) {
             // don't compare the expression, since the user might take two times the same expression, but with different labels
             // and apply different transformations to the variables.
@@ -253,7 +253,7 @@ TMVA::DataSetInfo& TMVA::MethodCategory::CreateCategoryDSI(const TCut& theCut,
       }
 
       // check the spectators of the old dsi for the variable that we want to add
-      for (itrVarInfo = oldDSI.GetSpectatorInfos().begin(); itrVarInfo != oldDSI.GetSpectatorInfos().end(); itrVarInfo++) {
+      for (itrVarInfo = oldDSI.GetSpectatorInfos().begin(); itrVarInfo != oldDSI.GetSpectatorInfos().end(); ++itrVarInfo) {
          if((*itrVariables==itrVarInfo->GetLabel()) ) { // || (*itrVariables==itrVarInfo->GetExpression())) {
             // don't compare the expression, since the user might take two times the same expression, but with different labels
             // and apply different transformations to the variables.
@@ -425,7 +425,7 @@ void TMVA::MethodCategory::Train()
 
       // variable ranking
       Log() << kINFO << "Begin ranking of input variables..." << Endl;
-      for (itrMethod = fMethods.begin(); itrMethod != fMethods.end(); itrMethod++) {
+      for (itrMethod = fMethods.begin(); itrMethod != fMethods.end(); ++itrMethod) {
          MethodBase* mva = dynamic_cast<MethodBase*>(*itrMethod);
          if (mva && mva->Data()->GetNTrainingEvents() >= MinNoTrainingEvents) {
             const Ranking* ranking = (*itrMethod)->CreateRanking();

--- a/tmva/tmva/src/MethodCompositeBase.cxx
+++ b/tmva/tmva/src/MethodCompositeBase.cxx
@@ -94,7 +94,7 @@ TMVA::IMethod* TMVA::MethodCompositeBase::GetMethod( const TString &methodTitle 
    std::vector<IMethod*>::const_iterator itrMethod    = fMethods.begin();
    std::vector<IMethod*>::const_iterator itrMethodEnd = fMethods.end();
 
-   for (; itrMethod != itrMethodEnd; itrMethod++) {
+   for (; itrMethod != itrMethodEnd; ++itrMethod) {
       MethodBase* mva = dynamic_cast<MethodBase*>(*itrMethod);
       if ( (mva->GetMethodName())==methodTitle ) return mva;
    }
@@ -144,7 +144,7 @@ void TMVA::MethodCompositeBase::AddWeightsXMLTo( void* parent ) const
 TMVA::MethodCompositeBase::~MethodCompositeBase( void )
 {
    std::vector<IMethod*>::iterator itrMethod = fMethods.begin();
-   for (; itrMethod != fMethods.end(); itrMethod++) {
+   for (; itrMethod != fMethods.end(); ++itrMethod) {
       Log() << kVERBOSE << "Delete method: " << (*itrMethod)->GetName() << Endl;
       delete (*itrMethod);
    }

--- a/tmva/tmva/src/MethodFDA.cxx
+++ b/tmva/tmva/src/MethodFDA.cxx
@@ -396,7 +396,7 @@ void TMVA::MethodFDA::Train( void )
 
    // starting values (not used by all fitters)
    fBestPars.clear();
-   for (std::vector<Interval*>::const_iterator parIt = fParRange.begin(); parIt != fParRange.end(); parIt++) {
+   for (std::vector<Interval*>::const_iterator parIt = fParRange.begin(); parIt != fParRange.end(); ++parIt) {
       fBestPars.push_back( (*parIt)->GetMean() );
    }
 

--- a/tmva/tmva/src/MethodLD.cxx
+++ b/tmva/tmva/src/MethodLD.cxx
@@ -120,7 +120,7 @@ TMVA::MethodLD::~MethodLD( void )
    if (fSumValMatx) { delete fSumValMatx; fSumValMatx = 0; }
    if (fCoeffMatx)  { delete fCoeffMatx;  fCoeffMatx  = 0; }
    if (fLDCoeff) {
-      for (vector< vector< Double_t >* >::iterator vi=fLDCoeff->begin(); vi!=fLDCoeff->end(); vi++){
+      for (vector< vector< Double_t >* >::iterator vi=fLDCoeff->begin(); vi!=fLDCoeff->end(); ++vi){
          if (*vi) { delete *vi; *vi = 0; }
       }
       delete fLDCoeff; fLDCoeff = 0;
@@ -389,7 +389,7 @@ void TMVA::MethodLD::ReadWeightsFromXML( void* wghtnode )
 
    // create vector with coefficients (double vector due to arbitrary output dimension)
    if (fLDCoeff) {
-      for (vector< vector< Double_t >* >::iterator vi=fLDCoeff->begin(); vi!=fLDCoeff->end(); vi++){
+      for (vector< vector< Double_t >* >::iterator vi=fLDCoeff->begin(); vi!=fLDCoeff->end(); ++vi){
          if (*vi) { delete *vi; *vi = 0; }
       }
       delete fLDCoeff; fLDCoeff = 0;

--- a/tmva/tmva/src/MethodPDERS.cxx
+++ b/tmva/tmva/src/MethodPDERS.cxx
@@ -411,7 +411,7 @@ const std::vector< Float_t >& TMVA::MethodPDERS::GetRegressionValues()
 
    Event * evT = new Event(*ev);
    UInt_t ivar = 0;
-   for (std::vector<Float_t>::iterator it = fRegressionReturnVal->begin(); it != fRegressionReturnVal->end(); it++ ) {
+   for (std::vector<Float_t>::iterator it = fRegressionReturnVal->begin(); it != fRegressionReturnVal->end(); ++it ) {
       evT->SetTarget(ivar,(*it));
       ivar++;
    }
@@ -750,7 +750,7 @@ void TMVA::MethodPDERS::GetSample( const Event& e,
 
          //counting the fkNNMin-th element
          std::vector<Double_t>::iterator wsk = distances->begin();
-         for (Int_t j=0;j<fkNNMin-1;j++) wsk++;
+         for (Int_t j=0;j<fkNNMin-1;++j) ++wsk;
          std::nth_element( distances->begin(), wsk, distances->end() );
 
          //getting all elements that are closer than fkNNMin-th element
@@ -844,7 +844,7 @@ Double_t TMVA::MethodPDERS::CKernelEstimate( const Event & event,
    Double_t pdfSumB = 0;
 
    // Iteration over sample points
-   for (std::vector<const BinarySearchTreeNode*>::iterator iev = events.begin(); iev != events.end(); iev++) {
+   for (std::vector<const BinarySearchTreeNode*>::iterator iev = events.begin(); iev != events.end(); ++iev) {
 
       // First switch to the one dimensional distance
       Double_t normalized_distance = GetNormalizedDistance (event, *(*iev), dim_normalization);
@@ -891,7 +891,7 @@ void TMVA::MethodPDERS::RKernelEstimate( const Event & event,
       pdfSum->push_back( 0 );
 
    // Iteration over sample points
-   for (std::vector<const BinarySearchTreeNode*>::iterator iev = events.begin(); iev != events.end(); iev++) {
+   for (std::vector<const BinarySearchTreeNode*>::iterator iev = events.begin(); iev != events.end(); ++iev) {
 
       // First switch to the one dimensional distance
       Double_t normalized_distance = GetNormalizedDistance (event, *(*iev), dim_normalization);

--- a/tmva/tmva/src/MethodRuleFit.cxx
+++ b/tmva/tmva/src/MethodRuleFit.cxx
@@ -679,7 +679,7 @@ void TMVA::MethodRuleFit::MakeClassRuleCuts( std::ostream& fout ) const
    fout << "   //" << std::endl;
    //
    for ( std::list< std::pair<double,int> >::reverse_iterator itpair = sortedRules.rbegin();
-         itpair != sortedRules.rend(); itpair++ ) {
+         itpair != sortedRules.rend(); ++itpair ) {
       UInt_t ir     = itpair->second;
       Double_t impr = itpair->first;
       ruleCut = (*rules)[ir]->GetRuleCut();

--- a/tmva/tmva/src/MethodSVM.cxx
+++ b/tmva/tmva/src/MethodSVM.cxx
@@ -779,7 +779,7 @@ std::map<TString,Double_t> TMVA::MethodSVM::OptimizeTuningParameters(TString fom
          tuneParameters.insert(std::pair<TString,Interval*>("C",new Interval(0.01,1.,100)));
       }
       else{
-         for(iter=optVars.begin(); iter!=optVars.end(); iter++){
+         for(iter=optVars.begin(); iter!=optVars.end(); ++iter){
             if( iter->first == "Gamma" || iter->first == "C"){
                tuneParameters.insert(std::pair<TString,Interval*>(iter->first, new Interval(iter->second.at(0),iter->second.at(1),iter->second.at(2))));
             }
@@ -797,7 +797,7 @@ std::map<TString,Double_t> TMVA::MethodSVM::OptimizeTuningParameters(TString fom
          tuneParameters.insert(std::pair<TString,Interval*>("C", new Interval(0.01,1.,100)));
       }
       else{
-         for(iter=optVars.begin(); iter!=optVars.end(); iter++){
+         for(iter=optVars.begin(); iter!=optVars.end(); ++iter){
             if( iter->first == "Theta" || iter->first == "C"){
                tuneParameters.insert(std::pair<TString,Interval*>(iter->first, new Interval(iter->second.at(0),iter->second.at(1),iter->second.at(2))));
             }
@@ -821,7 +821,7 @@ std::map<TString,Double_t> TMVA::MethodSVM::OptimizeTuningParameters(TString fom
          }
          tuneParameters.insert(std::pair<TString,Interval*>("C",new Interval(0.01,1.,100)));
       } else {
-         for(iter=optVars.begin(); iter!=optVars.end(); iter++){
+         for(iter=optVars.begin(); iter!=optVars.end(); ++iter){
             if( iter->first == "GammaList"){
                for(int j=0; j<fNumVars; j++){
                   stringstream s;
@@ -898,7 +898,7 @@ std::map<TString,Double_t> TMVA::MethodSVM::OptimizeTuningParameters(TString fom
    }
    Log() << kINFO << " the following SVM parameters will be tuned on the respective *grid*\n" << Endl;
    std::map<TString,TMVA::Interval*>::iterator it;
-   for(it=tuneParameters.begin(); it!=tuneParameters.end(); it++){
+   for(it=tuneParameters.begin(); it!=tuneParameters.end(); ++it){
       Log() << kWARNING << it->first <<Endl;
       std::ostringstream oss;
       (it->second)->Print(oss);
@@ -918,7 +918,7 @@ void TMVA::MethodSVM::SetTuneParameters(std::map<TString,Double_t> tuneParameter
 {
    std::map<TString,Double_t>::iterator it;
    if( fTheKernel == "RBF" ){
-      for(it=tuneParameters.begin(); it!=tuneParameters.end(); it++){
+      for(it=tuneParameters.begin(); it!=tuneParameters.end(); ++it){
          Log() << kWARNING << it->first << " = " << it->second << Endl;
          if (it->first == "Gamma"){
             SetGamma (it->second);
@@ -940,7 +940,7 @@ void TMVA::MethodSVM::SetTuneParameters(std::map<TString,Double_t> tuneParameter
          Log() << kWARNING << tuneParameters.find(str)->first << " = " << tuneParameters.find(str)->second << Endl;
          fmGamma.push_back(tuneParameters.find(str)->second);
       }
-      for(it=tuneParameters.begin(); it!=tuneParameters.end(); it++){
+      for(it=tuneParameters.begin(); it!=tuneParameters.end(); ++it){
          if (it->first == "C"){
             Log() << kWARNING << it->first << " = " << it->second << Endl;
             SetCost(it->second);
@@ -949,7 +949,7 @@ void TMVA::MethodSVM::SetTuneParameters(std::map<TString,Double_t> tuneParameter
       }
    }
    else if( fTheKernel == "Polynomial" ){
-      for(it=tuneParameters.begin(); it!=tuneParameters.end(); it++){
+      for(it=tuneParameters.begin(); it!=tuneParameters.end(); ++it){
          Log() << kWARNING << it->first << " = " << it->second << Endl;
          if (it->first == "Order"){
             SetOrder(it->second);
@@ -969,7 +969,7 @@ void TMVA::MethodSVM::SetTuneParameters(std::map<TString,Double_t> tuneParameter
    }
    else if( fTheKernel == "Prod" || fTheKernel == "Sum"){
       fmGamma.clear();
-      for(it=tuneParameters.begin(); it!=tuneParameters.end(); it++){
+      for(it=tuneParameters.begin(); it!=tuneParameters.end(); ++it){
          bool foundParam = false;
          Log() << kWARNING << it->first << " = " << it->second << Endl;
          for(int i=0; i<fNumVars; i++){

--- a/tmva/tmva/src/MethodTMlpANN.cxx
+++ b/tmva/tmva/src/MethodTMlpANN.cxx
@@ -168,7 +168,7 @@ void TMVA::MethodTMlpANN::CreateMLPOptions( TString layerSpec )
    std::vector<TString>::iterator itrVar    = (*fInputVars).begin();
    std::vector<TString>::iterator itrVarEnd = (*fInputVars).end();
    fMLPBuildOptions = "";
-   for (; itrVar != itrVarEnd; itrVar++) {
+   for (; itrVar != itrVarEnd; ++itrVar) {
       if (EnforceNormalization__) fMLPBuildOptions += "@";
       TString myVar = *itrVar; ;
       fMLPBuildOptions += myVar;

--- a/tmva/tmva/src/OptimizeConfigParameters.cxx
+++ b/tmva/tmva/src/OptimizeConfigParameters.cxx
@@ -81,7 +81,7 @@ TMVA::OptimizeConfigParameters::OptimizeConfigParameters(MethodBase * const meth
          << GetMethod()->GetName() << " uses:" << Endl;
 
    std::map<TString,TMVA::Interval*>::iterator it;
-   for (it=fTuneParameters.begin(); it!=fTuneParameters.end();it++) {
+   for (it=fTuneParameters.begin(); it!=fTuneParameters.end();++it) {
       Log() << kINFO << it->first
             << " in range from: " << it->second->GetMin()
             << " to: " << it->second->GetMax()
@@ -136,7 +136,7 @@ std::map<TString,Double_t> TMVA::OptimizeConfigParameters::optimize()
 
    Log() << kINFO << "For " << GetMethod()->GetName() << " the optimized Parameters are: " << Endl;
    std::map<TString,Double_t>::iterator it;
-   for(it=fTunedParameters.begin(); it!= fTunedParameters.end(); it++){
+   for(it=fTunedParameters.begin(); it!= fTunedParameters.end(); ++it){
       Log() << kINFO << it->first << " = " << it->second << Endl;
    }
    return fTunedParameters;
@@ -175,7 +175,7 @@ void TMVA::OptimizeConfigParameters::optimizeScan()
    currentParameters.clear();
    fTunedParameters.clear();
 
-   for (it=fTuneParameters.begin(); it!=fTuneParameters.end(); it++){
+   for (it=fTuneParameters.begin(); it!=fTuneParameters.end(); ++it){
       currentParameters.insert(std::pair<TString,Double_t>(it->first,it->second->GetMin()));
       fTunedParameters.insert(std::pair<TString,Double_t>(it->first,it->second->GetMin()));
    }
@@ -185,7 +185,7 @@ void TMVA::OptimizeConfigParameters::optimizeScan()
    // of arrays (the different values of the tune parameter)
 
    std::vector< std::vector <Double_t> > v;
-   for (it=fTuneParameters.begin(); it!=fTuneParameters.end(); it++){
+   for (it=fTuneParameters.begin(); it!=fTuneParameters.end(); ++it){
       std::vector< Double_t > tmp;
       for (Int_t k=0; k<it->second->GetNbins(); k++){
          tmp.push_back(it->second->GetElement(k));
@@ -203,13 +203,13 @@ void TMVA::OptimizeConfigParameters::optimizeScan()
    for (int i=0; i<Ntot; i++){
       UInt_t index=0;
       std::vector<int> indices = GetScanIndices(i, Nindividual );
-      for (it=fTuneParameters.begin(), index=0; index< indices.size(); index++, it++){
+      for (it=fTuneParameters.begin(), index=0; index< indices.size(); ++index, ++it){
          currentParameters[it->first] = v[index][indices[index]];
       }
       Log() << kINFO << "--------------------------" << Endl;
       Log() << kINFO <<"Settings being evaluated:" << Endl;
       for (std::map<TString,Double_t>::iterator it_print=currentParameters.begin();
-           it_print!=currentParameters.end(); it_print++){
+           it_print!=currentParameters.end(); ++it_print){
          Log() << kINFO << "  " << it_print->first  << " = " << it_print->second << Endl;
       }
 
@@ -228,7 +228,7 @@ void TMVA::OptimizeConfigParameters::optimizeScan()
       if (currentFOM > bestFOM) {
          bestFOM = currentFOM;
          for (std::map<TString,Double_t>::iterator iter=currentParameters.begin();
-              iter != currentParameters.end(); iter++){
+              iter != currentParameters.end(); ++iter){
             fTunedParameters[iter->first]=iter->second;
          }
       }
@@ -247,7 +247,7 @@ void TMVA::OptimizeConfigParameters::optimizeFit()
    std::map<TString, TMVA::Interval*>::iterator it;
    std::vector<Double_t> pars;    // current (starting) fit parameters
 
-   for (it=fTuneParameters.begin(); it != fTuneParameters.end(); it++){
+   for (it=fTuneParameters.begin(); it != fTuneParameters.end(); ++it){
       ranges.push_back(new TMVA::Interval(*(it->second)));
       pars.push_back( (it->second)->GetMean() );  // like this the order is "right". Always keep the
       // order in the vector "pars" the same as the iterator
@@ -294,7 +294,7 @@ void TMVA::OptimizeConfigParameters::optimizeFit()
 
    fTunedParameters.clear();
    Int_t jcount=0;
-   for (it=fTuneParameters.begin(); it!=fTuneParameters.end(); it++){
+   for (it=fTuneParameters.begin(); it!=fTuneParameters.end(); ++it){
       fTunedParameters.insert(std::pair<TString,Double_t>(it->first,pars[jcount++]));
    }
 
@@ -320,7 +320,7 @@ Double_t TMVA::OptimizeConfigParameters::EstimatorFunction( std::vector<Double_t
       Int_t icount =0; // map "pars" to the  map of Tuneparameter, make sure
                        // you never screw up this order!!
       std::map<TString, TMVA::Interval*>::iterator it;
-      for (it=fTuneParameters.begin(); it!=fTuneParameters.end(); it++){
+      for (it=fTuneParameters.begin(); it!=fTuneParameters.end(); ++it){
          currentParameters[it->first] = pars[icount++];
       }
       GetMethod()->Reset();

--- a/tmva/tmva/src/Ranking.cxx
+++ b/tmva/tmva/src/Ranking.cxx
@@ -111,7 +111,7 @@ void TMVA::Ranking::AddRank( const Rank& rank )
 void TMVA::Ranking::Print() const
 {
    Int_t maxL = 0;
-   for (std::vector<Rank>::const_iterator ir = fRanking.begin(); ir != fRanking.end(); ir++ )
+   for (std::vector<Rank>::const_iterator ir = fRanking.begin(); ir != fRanking.end(); ++ir )
       if ((*ir).GetVariable().Length() > maxL) maxL = (*ir).GetVariable().Length();
 
    TString hline = "";
@@ -124,7 +124,7 @@ void TMVA::Ranking::Print() const
          << std::resetiosflags(std::ios::right)
          << " : " << fRankingDiscriminatorName << Endl;
    Log() << kINFO << hline << Endl;
-   for (std::vector<Rank>::const_iterator ir = fRanking.begin(); ir != fRanking.end(); ir++ ) {
+   for (std::vector<Rank>::const_iterator ir = fRanking.begin(); ir != fRanking.end(); ++ir ) {
       Log() << kINFO
             << Form( "%4i : ",(*ir).GetRank() )
             << std::setw(TMath::Max(maxL+0,9)) << (*ir).GetVariable().Data()

--- a/tmva/tmva/src/Reader.cxx
+++ b/tmva/tmva/src/Reader.cxx
@@ -171,7 +171,7 @@ TMVA::Reader::Reader( std::vector<TString>& inputVars, const TString& theOption,
 
    // arguments: names of input variables (vector)
    //            verbose flag
-   for (std::vector<TString>::iterator ivar = inputVars.begin(); ivar != inputVars.end(); ivar++)
+   for (std::vector<TString>::iterator ivar = inputVars.begin(); ivar != inputVars.end(); ++ivar)
       DataInfo().AddVariable( *ivar );
 
    Init();
@@ -201,7 +201,7 @@ TMVA::Reader::Reader( std::vector<std::string>& inputVars, const TString& theOpt
 
    // arguments: names of input variables (vector)
    //            verbose flag
-   for (std::vector<std::string>::iterator ivar = inputVars.begin(); ivar != inputVars.end(); ivar++)
+   for (std::vector<std::string>::iterator ivar = inputVars.begin(); ivar != inputVars.end(); ++ivar)
       DataInfo().AddVariable( ivar->c_str() );
 
    Init();
@@ -536,7 +536,7 @@ Double_t TMVA::Reader::EvaluateMVA( const TString& methodTag, Double_t aux )
    if (it == fMethodMap.end()) {
       Log() << kINFO << "<EvaluateMVA> unknown classifier in map; "
             << "you looked for \"" << methodTag << "\" within available methods: " << Endl;
-      for (it = fMethodMap.begin(); it!=fMethodMap.end(); it++) Log() << " --> " << it->first << Endl;
+      for (it = fMethodMap.begin(); it!=fMethodMap.end(); ++it) Log() << "--> " << it->first << Endl;
       Log() << "Check calling string" << kFATAL << Endl;
    }
 
@@ -587,7 +587,7 @@ const std::vector< Float_t >& TMVA::Reader::EvaluateRegression( const TString& m
    if (it == fMethodMap.end()) {
       Log() << kINFO << "<EvaluateMVA> unknown method in map; "
             << "you looked for \"" << methodTag << "\" within available methods: " << Endl;
-      for (it = fMethodMap.begin(); it!=fMethodMap.end(); it++) Log() << " --> " << it->first << Endl;
+      for (it = fMethodMap.begin(); it!=fMethodMap.end(); ++it) Log() << "--> " << it->first << Endl;
       Log() << "Check calling string" << kFATAL << Endl;
    }
    else method = it->second;
@@ -652,7 +652,7 @@ const std::vector< Float_t >& TMVA::Reader::EvaluateMulticlass( const TString& m
    if (it == fMethodMap.end()) {
       Log() << kINFO << "<EvaluateMVA> unknown method in map; "
             << "you looked for \"" << methodTag << "\" within available methods: " << Endl;
-      for (it = fMethodMap.begin(); it!=fMethodMap.end(); it++) Log() << " --> " << it->first << Endl;
+      for (it = fMethodMap.begin(); it!=fMethodMap.end(); ++it) Log() << "--> " << it->first << Endl;
       Log() << "Check calling string" << kFATAL << Endl;
    }
    else method = it->second;
@@ -734,7 +734,7 @@ Double_t TMVA::Reader::GetProba( const TString& methodTag,  Double_t ap_sig, Dou
    IMethod* method = 0;
    std::map<TString, IMethod*>::iterator it = fMethodMap.find( methodTag );
    if (it == fMethodMap.end()) {
-      for (it = fMethodMap.begin(); it!=fMethodMap.end(); it++) Log() << "M" << it->first << Endl;
+      for (it = fMethodMap.begin(); it!=fMethodMap.end(); ++it) Log() << "M" << it->first << Endl;
       Log() << kFATAL << "<EvaluateMVA> unknown classifier in map: " << method << "; "
             << "you looked for " << methodTag<< " while the available methods are : " << Endl;
    }
@@ -765,7 +765,7 @@ Double_t TMVA::Reader::GetRarity( const TString& methodTag, Double_t mvaVal )
    IMethod* method = 0;
    std::map<TString, IMethod*>::iterator it = fMethodMap.find( methodTag );
    if (it == fMethodMap.end()) {
-      for (it = fMethodMap.begin(); it!=fMethodMap.end(); it++) Log() << "M" << it->first << Endl;
+      for (it = fMethodMap.begin(); it!=fMethodMap.end(); ++it) Log() << "M" << it->first << Endl;
       Log() << kFATAL << "<EvaluateMVA> unknown classifier in map: \"" << method << "\"; "
             << "you looked for \"" << methodTag<< "\" while the available methods are : " << Endl;
    }

--- a/tmva/tmva/src/ResultsMulticlass.cxx
+++ b/tmva/tmva/src/ResultsMulticlass.cxx
@@ -220,7 +220,7 @@ std::vector<Double_t> TMVA::ResultsMulticlass::GetBestMultiClassCuts(UInt_t targ
    fBestCuts.at(targetClass) = result;
 
    UInt_t n = 0;
-   for( std::vector<Double_t>::iterator it = result.begin(); it<result.end(); it++ ){
+   for( std::vector<Double_t>::iterator it = result.begin(); it<result.end(); ++it ){
       Log() << kINFO << "  cutValue[" <<dsi->GetClassInfo( n )->GetName()  << "] = " << (*it) << ";"<< Endl;
       n++;
    }

--- a/tmva/tmva/src/RuleCut.cxx
+++ b/tmva/tmva/src/RuleCut.cxx
@@ -123,7 +123,7 @@ void TMVA::RuleCut::MakeCuts( const std::vector<const Node*> & nodes )
    Int_t nsel=0;
    Bool_t firstMin=kTRUE;
    Bool_t firstMax=kTRUE;
-   for ( std::list<SelCut_t>::const_iterator it = allsel.begin(); it!=allsel.end(); it++ ) {
+   for ( std::list<SelCut_t>::const_iterator it = allsel.begin(); it!=allsel.end(); ++it ) {
       sel = (*it).first;
       val = (*it).second.first;
       dir = (*it).second.second;

--- a/tmva/tmva/src/RuleEnsemble.cxx
+++ b/tmva/tmva/src/RuleEnsemble.cxx
@@ -121,7 +121,7 @@ TMVA::RuleEnsemble::RuleEnsemble()
 
 TMVA::RuleEnsemble::~RuleEnsemble()
 {
-   for ( std::vector<Rule *>::iterator itrRule = fRules.begin(); itrRule != fRules.end(); itrRule++ ) {
+   for ( std::vector<Rule *>::iterator itrRule = fRules.begin(); itrRule != fRules.end(); ++itrRule ) {
       delete *itrRule;
    }
    // NOTE: Should not delete the histos fLinPDFB/S since they are delete elsewhere
@@ -389,11 +389,11 @@ void TMVA::RuleEnsemble::CalcRuleSupport()
    Double_t ew;
    //
    if ((nrules>0) && (events->size()>0)) {
-      for ( std::vector< Rule * >::iterator itrRule=fRules.begin(); itrRule!=fRules.end(); itrRule++ ) {
+      for ( std::vector< Rule * >::iterator itrRule=fRules.begin(); itrRule!=fRules.end(); ++itrRule ) {
          s=0.0;
          ssig=0.0;
          sbkg=0.0;
-         for ( std::vector<const Event * >::const_iterator itrEvent=events->begin(); itrEvent!=events->end(); itrEvent++ ) {
+         for ( std::vector<const Event * >::const_iterator itrEvent=events->begin(); itrEvent!=events->end(); ++itrEvent ) {
             if ((*itrRule)->EvalEvent( *(*itrEvent) )) {
                ew = (*itrEvent)->GetWeight();
                s += ew;
@@ -1036,7 +1036,7 @@ void TMVA::RuleEnsemble::Print() const
       Log() << kmtype << "Printing the first " << printN << " rules, ordered in importance." << Endl;
       int pind=0;
       for ( std::list< std::pair<double,int> >::reverse_iterator itpair = sortedImp.rbegin();
-            itpair != sortedImp.rend(); itpair++ ) {
+            itpair != sortedImp.rend(); ++itpair ) {
          ind = itpair->second;
          //    if (pind==0) impref =
          //         Log() << kmtype << "Rule #" <<

--- a/tmva/tmva/src/RuleFit.cxx
+++ b/tmva/tmva/src/RuleFit.cxx
@@ -308,7 +308,7 @@ void TMVA::RuleFit::MakeForest()
 void TMVA::RuleFit::SaveEventWeights()
 {
    fEventWeights.clear();
-   for (std::vector<const Event*>::iterator e=fTrainingEvents.begin(); e!=fTrainingEvents.end(); e++) {
+   for (std::vector<const Event*>::iterator e=fTrainingEvents.begin(); e!=fTrainingEvents.end(); ++e) {
       Double_t w = (*e)->GetBoostWeight();
       fEventWeights.push_back(w);
    }
@@ -324,7 +324,7 @@ void TMVA::RuleFit::RestoreEventWeights()
       Log() << kERROR << "RuleFit::RestoreEventWeights() called without having called SaveEventWeights() before!" << Endl;
       return;
    }
-   for (std::vector<const Event*>::iterator e=fTrainingEvents.begin(); e!=fTrainingEvents.end(); e++) {
+   for (std::vector<const Event*>::iterator e=fTrainingEvents.begin(); e!=fTrainingEvents.end(); ++e) {
       (*e)->SetBoostWeight(fEventWeights[ie]);
       ie++;
    }
@@ -342,7 +342,7 @@ void TMVA::RuleFit::Boost( DecisionTree *dt )
    //
    std::vector<Char_t> correctSelected; // <--- boolean stored
    //
-   for (std::vector<const Event*>::iterator e=fTrainingEvents.begin(); e!=fTrainingEvents.end(); e++) {
+   for (std::vector<const Event*>::iterator e=fTrainingEvents.begin(); e!=fTrainingEvents.end(); ++e) {
       Bool_t isSignalType = (dt->CheckEvent(*e,kTRUE) > 0.5 );
       Double_t w = (*e)->GetWeight();
       sumw += w;
@@ -364,7 +364,7 @@ void TMVA::RuleFit::Boost( DecisionTree *dt )
    Double_t newSumw=0.0;
    UInt_t ie=0;
    // set new weight to misclassified events
-   for (std::vector<const Event*>::iterator e=fTrainingEvents.begin(); e!=fTrainingEvents.end(); e++) {
+   for (std::vector<const Event*>::iterator e=fTrainingEvents.begin(); e!=fTrainingEvents.end(); ++e) {
       if (!correctSelected[ie])
          (*e)->SetBoostWeight( (*e)->GetBoostWeight() * boostWeight);
       newSumw+=(*e)->GetWeight();
@@ -372,7 +372,7 @@ void TMVA::RuleFit::Boost( DecisionTree *dt )
    }
    // reweight all events
    Double_t scale = sumw/newSumw;
-   for (std::vector<const Event*>::iterator e=fTrainingEvents.begin(); e!=fTrainingEvents.end(); e++) {
+   for (std::vector<const Event*>::iterator e=fTrainingEvents.begin(); e!=fTrainingEvents.end(); ++e) {
       (*e)->SetBoostWeight( (*e)->GetBoostWeight() * scale);
    }
    Log() << kDEBUG << "boostWeight = " << boostWeight << "    scale = " << scale << Endl;

--- a/tmva/tmva/src/SVWorkingSet.cxx
+++ b/tmva/tmva/src/SVWorkingSet.cxx
@@ -137,7 +137,7 @@ Bool_t TMVA::SVWorkingSet::ExamineExample( TMVA::SVEvent* jevt )
       std::vector<TMVA::SVEvent*>::iterator idIter;
 
       UInt_t k=0;
-      for(idIter = fInputData->begin(); idIter != fInputData->end(); idIter++){
+      for(idIter = fInputData->begin(); idIter != fInputData->end(); ++idIter){
          if((*idIter)->GetAlpha()>0)
             fErrorC_J += (*idIter)->GetAlpha()*(*idIter)->GetTypeFlag()*fKVals[k];
          k++;
@@ -309,7 +309,7 @@ Bool_t TMVA::SVWorkingSet::TakeStep(TMVA::SVEvent* ievt,TMVA::SVEvent* jevt )
    Float_t dL_J = type_J * ( newAlpha_J - alpha_J );
 
    Int_t k = 0;
-   for(idIter = fInputData->begin(); idIter != fInputData->end(); idIter++){
+   for(idIter = fInputData->begin(); idIter != fInputData->end(); ++idIter){
       k++;
       if((*idIter)->GetIdx()==0){
          Float_t ii = fKMatrix->GetElement(ievt->GetNs(), (*idIter)->GetNs());
@@ -333,7 +333,7 @@ Bool_t TMVA::SVWorkingSet::TakeStep(TMVA::SVEvent* ievt,TMVA::SVEvent* jevt )
    fB_low = -1*1e30;
    fB_up = 1e30;
 
-   for(idIter = fInputData->begin(); idIter != fInputData->end(); idIter++){
+   for(idIter = fInputData->begin(); idIter != fInputData->end(); ++idIter){
       if((*idIter)->GetIdx()==0){
          if((*idIter)->GetErrorCache()> fB_low){
             fB_low = (*idIter)->GetErrorCache();
@@ -399,13 +399,13 @@ void TMVA::SVWorkingSet::Train(UInt_t nMaxIter)
      if (fExitFromTraining && *fExitFromTraining) break;
       numChanged = 0;
       if (examineAll) {
-         for (idIter = fInputData->begin(); idIter!=fInputData->end(); idIter++){
+         for (idIter = fInputData->begin(); idIter!=fInputData->end(); ++idIter){
             if(!fdoRegression) numChanged += (UInt_t)ExamineExample(*idIter);
             else numChanged += (UInt_t)ExamineExampleReg(*idIter);
          }
       }
       else {
-         for (idIter = fInputData->begin(); idIter!=fInputData->end(); idIter++) {
+         for (idIter = fInputData->begin(); idIter!=fInputData->end(); ++idIter) {
             if ((*idIter)->IsInI0()) {
                if(!fdoRegression) numChanged += (UInt_t)ExamineExample(*idIter);
                else numChanged += (UInt_t)ExamineExampleReg(*idIter);
@@ -461,7 +461,7 @@ void TMVA::SVWorkingSet::PrintStat()
 {
    std::vector<TMVA::SVEvent*>::iterator idIter;
    UInt_t counter = 0;
-   for( idIter = fInputData->begin(); idIter != fInputData->end(); idIter++)
+   for( idIter = fInputData->begin(); idIter != fInputData->end(); ++idIter)
       if((*idIter)->GetAlpha() !=0) counter++;
 }
 
@@ -473,7 +473,7 @@ std::vector<TMVA::SVEvent*>* TMVA::SVWorkingSet::GetSupportVectors()
    if( fSupVec != 0) {delete fSupVec; fSupVec = 0; }
    fSupVec = new std::vector<TMVA::SVEvent*>(0);
 
-   for( idIter = fInputData->begin(); idIter != fInputData->end(); idIter++){
+   for( idIter = fInputData->begin(); idIter != fInputData->end(); ++idIter){
       if((*idIter)->GetDeltaAlpha() !=0){
          fSupVec->push_back((*idIter));
       }
@@ -635,7 +635,7 @@ Bool_t TMVA::SVWorkingSet::TakeStepReg(TMVA::SVEvent* ievt,TMVA::SVEvent* jevt )
 
       //update error cache
       Int_t k = 0;
-      for(idIter = fInputData->begin(); idIter != fInputData->end(); idIter++){
+      for(idIter = fInputData->begin(); idIter != fInputData->end(); ++idIter){
          k++;
          //there will be some changes in Idx notation
          if((*idIter)->GetIdx()==0){
@@ -659,7 +659,7 @@ Bool_t TMVA::SVWorkingSet::TakeStepReg(TMVA::SVEvent* ievt,TMVA::SVEvent* jevt )
       fB_low = -1*1e30;
       fB_up =1e30;
 
-      for(idIter = fInputData->begin(); idIter != fInputData->end(); idIter++){
+      for(idIter = fInputData->begin(); idIter != fInputData->end(); ++idIter){
          if((!(*idIter)->IsInI3()) && ((*idIter)->GetErrorCache()> fB_low)){
             fB_low = (*idIter)->GetErrorCache();
             fTEventLow = (*idIter);
@@ -691,7 +691,7 @@ Bool_t TMVA::SVWorkingSet::ExamineExampleReg(TMVA::SVEvent* jevt)
       std::vector<TMVA::SVEvent*>::iterator idIter;
 
       UInt_t k=0;
-      for(idIter = fInputData->begin(); idIter != fInputData->end(); idIter++){
+      for(idIter = fInputData->begin(); idIter != fInputData->end(); ++idIter){
          fErrorC_J -= (*idIter)->GetDeltaAlpha()*fKVals[k];
          k++;
       }

--- a/tmva/tmva/src/Tools.cxx
+++ b/tmva/tmva/src/Tools.cxx
@@ -724,7 +724,7 @@ Bool_t TMVA::Tools::CheckForVerboseOption( const TString& cs ) const
    s.ToLower();
    s.ReplaceAll(" ","");
    std::vector<TString> v = SplitString( s, ':' );
-   for (std::vector<TString>::iterator it = v.begin(); it != v.end(); it++) {
+   for (std::vector<TString>::iterator it = v.begin(); it != v.end(); ++it) {
       if ((*it == "v" || *it == "verbose") && !it->Contains("!")) isVerbose = kTRUE;
    }
 

--- a/tmva/tmva/src/TransformationHandler.cxx
+++ b/tmva/tmva/src/TransformationHandler.cxx
@@ -86,7 +86,7 @@ TMVA::TransformationHandler::TransformationHandler( DataSetInfo& dsi, const TStr
 TMVA::TransformationHandler::~TransformationHandler()
 {
    std::vector<Ranking*>::const_iterator it = fRanking.begin();
-   for (; it != fRanking.end(); it++) delete *it;
+   for (; it != fRanking.end(); ++it) delete *it;
 
    fTransformations.SetOwner();
    delete fLogger;
@@ -148,7 +148,7 @@ const TMVA::Event* TMVA::TransformationHandler::Transform( const Event* ev ) con
    while (VariableTransformBase *trf = (VariableTransformBase*) trIt()) {
       if (rClsIt == fTransformationsReferenceClasses.end()) Log() << kFATAL<< "invalid read in TransformationHandler::Transform " <<Endl;
       trEv = trf->Transform(trEv, (*rClsIt) );
-      rClsIt++;
+      ++rClsIt;
    }
    return trEv;
 }
@@ -164,7 +164,7 @@ const TMVA::Event* TMVA::TransformationHandler::InverseTransform( const Event* e
    // the inverse transformation
    TListIter trIt(&fTransformations, kIterBackward);
    std::vector< Int_t >::const_iterator rClsIt = fTransformationsReferenceClasses.end();
-   rClsIt--;
+   --rClsIt;
    const Event* trEv = ev;
    UInt_t nvars = 0, ntgts = 0, nspcts = 0;
    while (VariableTransformBase *trf = (VariableTransformBase*) trIt() ) { // shouldn't be the transformation called in the inverse order for the inversetransformation?????
@@ -220,7 +220,7 @@ const std::vector<TMVA::Event*>* TMVA::TransformationHandler::CalcTransformation
          for (UInt_t ievt = 0; ievt<transformedEvents->size(); ievt++) {  // loop through all events
             *(*transformedEvents)[ievt] = *trf->Transform((*transformedEvents)[ievt],(*rClsIt));
          }
-         rClsIt++;
+         ++rClsIt;
       }
    }
 
@@ -383,7 +383,7 @@ void TMVA::TransformationHandler::MakeFunction( std::ostream& fout, const TStrin
    UInt_t trCounter=1;
    while (VariableTransformBase *trf = (VariableTransformBase*) trIt() ) {
       trf->MakeFunction(fout, fncName, part, trCounter++, (*rClsIt) );
-      rClsIt++;
+      ++rClsIt;
    }
    if (part==1) {
       for (Int_t i=0; i<fTransformations.GetSize(); i++) {
@@ -842,7 +842,7 @@ void TMVA::TransformationHandler::WriteToStream( std::ostream& o ) const
       if (ci == 0 ) clsName = "AllClasses";
       else clsName = ci->GetName();
       o << "ReferenceClass " << clsName << std::endl;
-      rClsIt++;
+      ++rClsIt;
    }
 }
 
@@ -917,7 +917,7 @@ void TMVA::TransformationHandler::PrintVariableRanking() const
   //Log() << kINFO << " " << Endl;
    Log() << kINFO << "Ranking input variables (method unspecific)..." << Endl;
    std::vector<Ranking*>::const_iterator it = fRanking.begin();
-   for (; it != fRanking.end(); it++) (*it)->Print();
+   for (; it != fRanking.end(); ++it) (*it)->Print();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/src/Types.cxx
+++ b/tmva/tmva/src/Types.cxx
@@ -139,7 +139,7 @@ TString TMVA::Types::GetMethodName( TMVA::Types::EMVA method ) const
    std::lock_guard<std::mutex> guard(gTypesMutex);
 #endif
    std::map<TString, EMVA>::const_iterator it = fStr2type.begin();
-   for (; it!=fStr2type.end(); it++) if (it->second == method) return it->first;
+   for (; it!=fStr2type.end(); ++it) if (it->second == method) return it->first;
    Log() << kFATAL << "Unknown method index in map: " << method << Endl;
    return "";
 }

--- a/tmva/tmva/src/VarTransformHandler.cxx
+++ b/tmva/tmva/src/VarTransformHandler.cxx
@@ -293,12 +293,12 @@ void TMVA::VarTransformHandler::CalcNorm()
 ////////////////////////////////////////////////////////////////////////////////
 void TMVA::VarTransformHandler::CopyDataLoader(TMVA::DataLoader* des, TMVA::DataLoader* src)
 {
-   for( std::vector<TreeInfo>::const_iterator treeinfo=src->DataInput().Sbegin();treeinfo!=src->DataInput().Send();treeinfo++)
+   for( std::vector<TreeInfo>::const_iterator treeinfo=src->DataInput().Sbegin();treeinfo!=src->DataInput().Send();++treeinfo)
    {
       des->AddSignalTree( (*treeinfo).GetTree(), (*treeinfo).GetWeight(),(*treeinfo).GetTreeType());
    }
 
-   for( std::vector<TreeInfo>::const_iterator treeinfo=src->DataInput().Bbegin();treeinfo!=src->DataInput().Bend();treeinfo++)
+   for( std::vector<TreeInfo>::const_iterator treeinfo=src->DataInput().Bbegin();treeinfo!=src->DataInput().Bend();++treeinfo)
    {
       des->AddBackgroundTree( (*treeinfo).GetTree(), (*treeinfo).GetWeight(),(*treeinfo).GetTreeType());
    }

--- a/tmva/tmva/src/VariableDecorrTransform.cxx
+++ b/tmva/tmva/src/VariableDecorrTransform.cxx
@@ -64,7 +64,7 @@ TMVA::VariableDecorrTransform::VariableDecorrTransform( DataSetInfo& dsi )
 
 TMVA::VariableDecorrTransform::~VariableDecorrTransform()
 {
-   for (std::vector<TMatrixD*>::iterator it = fDecorrMatrices.begin(); it != fDecorrMatrices.end(); it++) {
+   for (std::vector<TMatrixD*>::iterator it = fDecorrMatrices.begin(); it != fDecorrMatrices.end(); ++it) {
       if ((*it) != 0) delete (*it);
    }
 }
@@ -245,7 +245,7 @@ void TMVA::VariableDecorrTransform::CalcSQRMats( const std::vector< Event*>& eve
 {
    // delete old matrices if any
    for (std::vector<TMatrixD*>::iterator it = fDecorrMatrices.begin();
-        it != fDecorrMatrices.end(); it++)
+        it != fDecorrMatrices.end(); ++it)
       if (0 != (*it) ) { delete (*it); *it=0; }
 
 
@@ -273,7 +273,7 @@ void TMVA::VariableDecorrTransform::WriteTransformationToStream( std::ostream& o
 {
    Int_t cls = 0;
    Int_t dp = o.precision();
-   for (std::vector<TMatrixD*>::const_iterator itm = fDecorrMatrices.begin(); itm != fDecorrMatrices.end(); itm++) {
+   for (std::vector<TMatrixD*>::const_iterator itm = fDecorrMatrices.begin(); itm != fDecorrMatrices.end(); ++itm) {
       o << "# correlation matrix " << std::endl;
       TMatrixD* mat = (*itm);
       o << cls << " " << mat->GetNrows() << " x " << mat->GetNcols() << std::endl;
@@ -299,7 +299,7 @@ void TMVA::VariableDecorrTransform::AttachXMLTo(void* parent)
 
    VariableTransformBase::AttachXMLTo( trf );
 
-   for (std::vector<TMatrixD*>::const_iterator itm = fDecorrMatrices.begin(); itm != fDecorrMatrices.end(); itm++) {
+   for (std::vector<TMatrixD*>::const_iterator itm = fDecorrMatrices.begin(); itm != fDecorrMatrices.end(); ++itm) {
       TMatrixD* mat = (*itm);
       /*void* decmat = gTools().xmlengine().NewChild(trf, 0, "Matrix");
         gTools().xmlengine().NewAttr(decmat,0,"Rows", gTools().StringFromInt(mat->GetNrows()) );
@@ -322,7 +322,7 @@ void TMVA::VariableDecorrTransform::AttachXMLTo(void* parent)
 void TMVA::VariableDecorrTransform::ReadFromXML( void* trfnode )
 {
    // first delete the old matrices
-   for( std::vector<TMatrixD*>::iterator it = fDecorrMatrices.begin(); it != fDecorrMatrices.end(); it++ )
+   for( std::vector<TMatrixD*>::iterator it = fDecorrMatrices.begin(); it != fDecorrMatrices.end(); ++it )
       if( (*it) != 0 ) delete (*it);
    fDecorrMatrices.clear();
 
@@ -413,7 +413,7 @@ void TMVA::VariableDecorrTransform::ReadTransformationFromStream( std::istream& 
 void TMVA::VariableDecorrTransform::PrintTransformation( std::ostream& )
 {
    Int_t cls = 0;
-   for (std::vector<TMatrixD*>::iterator itm = fDecorrMatrices.begin(); itm != fDecorrMatrices.end(); itm++) {
+   for (std::vector<TMatrixD*>::iterator itm = fDecorrMatrices.begin(); itm != fDecorrMatrices.end(); ++itm) {
       Log() << kINFO << "Transformation matrix "<< cls <<":" << Endl;
       (*itm)->Print();
    }

--- a/tmva/tmva/src/VariableGaussTransform.cxx
+++ b/tmva/tmva/src/VariableGaussTransform.cxx
@@ -337,7 +337,7 @@ void TMVA::VariableGaussTransform::GetCumulativeDist( const std::vector< Event*>
          vsForBinning[icl][ivar].push_back(ev_value-eps);
          vsForBinning[icl][ivar].push_back(ev_value);
 
-         for (it=listsForBinning[icl][ivar].begin(); it != listsForBinning[icl][ivar].end(); it++){
+         for (it=listsForBinning[icl][ivar].begin(); it != listsForBinning[icl][ivar].end(); ++it){
             sum+= it->GetWeight();
             if (sum >= sumPerBin) {
                ev_value=it->GetValue();

--- a/tmva/tmva/src/VariableNormalizeTransform.cxx
+++ b/tmva/tmva/src/VariableNormalizeTransform.cxx
@@ -233,7 +233,7 @@ void TMVA::VariableNormalizeTransform::CalcNormalizationParams( const std::vecto
    }
 
    std::vector<Event*>::const_iterator evIt = events.begin();
-   for (;evIt!=events.end();evIt++) { // loop over all events
+   for (;evIt!=events.end();++evIt) { // loop over all events
       const TMVA::Event* event = (*evIt);   // get the event
 
       UInt_t cls = (*evIt)->GetClass(); // get the class of this event

--- a/tmva/tmvagui/src/MovieMaker.cxx
+++ b/tmva/tmvagui/src/MovieMaker.cxx
@@ -44,7 +44,7 @@ void TMVA::DrawNetworkMovie(TString dataset, TFile* file, const TString& methodT
 
       // check if done already      
       Bool_t isOld = kFALSE;
-      for (std::vector<TString>::const_iterator it = epochList.begin(); it < epochList.end(); it++) {
+      for (std::vector<TString>::const_iterator it = epochList.begin(); it < epochList.end(); ++it) {
          if (*it == es) isOld = kTRUE; 
       }
       if (isOld) continue;

--- a/tmva/tmvagui/src/rulevisCorr.cxx
+++ b/tmva/tmvagui/src/rulevisCorr.cxx
@@ -190,7 +190,7 @@ void TMVA::rulevisCorr( TDirectory *rfdir, TDirectory *vardir, TDirectory *corrd
          TKey* hkey = corrdir->GetKey(bgname);
          TH2F* bgd = (TH2F*)hkey->ReadObj();
          if (bgd == NULL) {
-            cout << "ERROR!!! couldn't find backgroung histo for" << hname << endl;
+            cout << "ERROR!!! couldn't find background histo for" << hname << endl;
             return;
          }
          const Int_t rebin=6;

--- a/tmva/tmvagui/src/tmvaglob.cxx
+++ b/tmva/tmvagui/src/tmvaglob.cxx
@@ -446,7 +446,7 @@ std::vector<TString> TMVA::TMVAGlob::GetInputVariableNames(TDirectory *dir)
       while(iter != names.end()){
          if(name.CompareTo(*iter)==0)
             hasname=true;
-         iter++;
+         ++iter;
       }
       if(!hasname)
          names.push_back(name);
@@ -500,7 +500,7 @@ std::vector<TString> TMVA::TMVAGlob::GetClassNames(TDirectory *dir )
       while(iter != names.end()){
          if(name.CompareTo(*iter)==0)
             hasname=true;
-         iter++;
+         ++iter;
       }
       if(!hasname)
          names.push_back(name);

--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -849,7 +849,7 @@ void TBasket::Streamer(TBuffer &b)
       b >> flag;
       if (fLast > fBufferSize) fBufferSize = fLast;
       Bool_t mustGenerateOffsets = false;
-      if (flag && (flag >= 80)) {
+      if (flag >= 80) {
          mustGenerateOffsets = true;
          flag -= 80;
       }

--- a/tree/tree/src/TBranchBrowsable.cxx
+++ b/tree/tree/src/TBranchBrowsable.cxx
@@ -140,7 +140,7 @@ Int_t TVirtualBranchBrowsable::FillListOfBrowsables(TList& li, const TBranch* br
    if (!fgGeneratorsSet) RegisterDefaultGenerators();
    std::list<MethodCreateListOfBrowsables_t>::iterator iGenerator;
    Int_t numCreated=0;
-   for (iGenerator=fgGenerators.begin(); iGenerator!=fgGenerators.end(); iGenerator++)
+   for (iGenerator=fgGenerators.begin(); iGenerator!=fgGenerators.end(); ++iGenerator)
       numCreated+=(*(*iGenerator))(li, branch, parent);
    return numCreated;
 }

--- a/tree/tree/src/TLeaf.cxx
+++ b/tree/tree/src/TLeaf.cxx
@@ -219,10 +219,12 @@ TLeaf* TLeaf::GetLeafCounter(Int_t& countval) const
    // Now search a branch name with a leaf name = countname
    if (fBranch == 0) {
       Error("GetLeafCounter","TLeaf %s is not setup properly, fBranch is null.",GetName());
+      delete[] countname;
       return 0;
    }
    if (fBranch->GetTree() == 0) {
       Error("GetLeafCounter","For Leaf %s, the TBranch %s is not setup properly, fTree is null.",GetName(),fBranch->GetName());
+      delete[] countname;
       return 0;
    }
    TTree* pTree = fBranch->GetTree();

--- a/tree/treeplayer/src/TSelectorDraw.cxx
+++ b/tree/treeplayer/src/TSelectorDraw.cxx
@@ -376,8 +376,8 @@ void TSelectorDraw::Begin(TTree *tree)
          if (!fOldHistogram && oldObject && !oldObject->InheritsFrom(TH1::Class())) {
             abrt.Form("An object of type '%s' has the same name as the requested histo (%s)", oldObject->IsA()->GetName(), hname);
             Abort(abrt);
-            return;
             delete[] varexp;
+            return;
          }
          if (fOldHistogram && !hnameplus) fOldHistogram->Reset();  // reset unless adding is wanted
 


### PR DESCRIPTION
[net/monalisa/src/TMonaLisaWriter.cxx:956] -> [net/monalisa/src/TMonaLisaWriter.cxx:957]: (error) Iterator 'iter' used after element has been erased.
[proof/proofd/src/XrdProofdProofServMgr.cxx:4648] -> [proof/proofd/src/XrdProofdProofServMgr.cxx:4646]: (error) Iterator 'iter' used after element has been erased.

[math/minuit2/src/Minuit2Minimizer.cxx:669] -> [math/minuit2/src/Minuit2Minimizer.cxx:669]: (style) Same expression on both sides of '||'.
[math/minuit2/src/Minuit2Minimizer.cxx:736] -> [math/minuit2/src/Minuit2Minimizer.cxx:736]: (style) Same expression on both sides of '||'.
[math/minuit2/src/Minuit2Minimizer.cxx:753] -> [math/minuit2/src/Minuit2Minimizer.cxx:753]: (style) Same expression on both sides of '||'.

[tree/tree/src/TBasket.cxx:852]: (style) Redundant condition: If 'flag >= 80', the comparison 'flag' is always true.
[misc/table/src/TFileIter.cxx:467] -> [misc/table/src/TFileIter.cxx:468]: (warning) Identical condition 'thisRunNumber<runNumber', second condition is always false

[math/mathcore/src/TMath.cxx:826]: (style) Array index 'ia' is used before limits check.
[math/mathcore/src/TMath.cxx:830]: (style) Array index 'ib' is used before limits check.
[math/mathcore/src/triangle.c:15434]: (style) Array index 'aspectindex' is used before limits check.
[roofit/roofit/src/RooIntegralMorph.cxx:375]: (style) Array index 'igapHigh' is used before limits check.

[core/winnt/src/TWinNTSystem.cxx:5035]: (style) Statements following return, break, continue, goto or throw will never be executed.
[tree/treeplayer/src/TSelectorDraw.cxx:380]: (style) Statements following return, break, continue, goto or throw will never be executed.

[net/auth/src/TAuthenticate.cxx:4205]: (error) Resource leak: fd
[roofit/roofitcore/src/BidirMMapPipe.cxx:1880]: (error) Memory leak: s
[tree/tree/src/TLeaf.cxx:222]: (error) Memory leak: countname
[tree/tree/src/TLeaf.cxx:226]: (error) Memory leak: countname
[tmva/tmva/src/MethodBase.cxx:2783]: (error) Memory leak: pdfS
[tmva/tmva/src/MethodBase.cxx:2783]: (error) Memory leak: pdfB

[roofit/roofitcore/src/RooAbsArg.cxx:280]: (style) Redundant checking of STL container element existence before removing it.

[core/dictgen/src/rootcling_impl.cxx:457]: (performance) Possible inefficient checking for 'fieldSelRules' emptiness.
[core/dictgen/src/rootcling_impl.cxx:4573]: (performance) Possible inefficient checking for 'filesIncludedByLinkdef' emptiness.
[gui/canvaspainter/v7/src/TCanvasPainter.cxx:322]: (performance) Possible inefficient checking for 'fWebConn' emptiness.
[gui/canvaspainter/v7/src/TCanvasPainter.cxx:374]: (performance) Possible inefficient checking for 'fCmds' emptiness.
[gui/canvaspainter/v7/src/TCanvasPainter.cxx:419]: (performance) Possible inefficient checking for 'fWebConn' emptiness.
[gui/canvaspainter/v7/src/TCanvasPainter.cxx:475]: (performance) Possible inefficient checking for 'fWebConn' emptiness.
[gui/canvaspainter/v7/src/TCanvasPainter.cxx:587]: (performance) Possible inefficient checking for 'fCmds' emptiness.
[gui/canvaspainter/v7/src/TCanvasPainter.cxx:787]: (performance) Possible inefficient checking for 'fCmds' emptiness.
[html/src/TDocParser.cxx:684]: (performance) Possible inefficient checking for 'currentType' emptiness.
[proof/proofd/src/XrdProofdManager.cxx:804]: (performance) Possible inefficient checking for 'uwrks' emptiness.
[proof/proofd/src/XrdProofdSandbox.cxx:467]: (performance) Possible inefficient checking for 'staglst' emptiness.
[proof/proofd/src/XrdProofdSandbox.cxx:571]: (performance) Possible inefficient checking for 'actln' emptiness.
[roofit/roofitcore/src/RooSimWSTool.cxx:574]: (performance) Possible inefficient checking for 'slist' emptiness.

all the reports Prefer prefix ++/-- operators for non-primitive types