### PR TITLE
Make THashList::RecursiveRemove loop over the list element thread-aware.

### DIFF
--- a/core/base/inc/LinkDef1.h
+++ b/core/base/inc/LinkDef1.h
@@ -170,7 +170,7 @@
 #pragma link C++ class TControlBarImp+;
 #pragma link C++ class TInspectorImp+;
 #pragma link C++ class TDatime-;
-#pragma link C++ class TDirectory;
+#pragma link C++ class TDirectory-;
 #pragma link C++ class TEnv+;
 #pragma link C++ class TEnvRec+;
 #pragma link C++ class TFileHandler+;

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -108,6 +108,9 @@ TDirectory::~TDirectory()
    }
 
    if (fList) {
+      if (!fList->IsUsingRWLock())
+         Fatal("~TDirectory","In %s:%p the fList (%p) is not using the RWLock\n",
+               GetName(),this,fList);
       fList->Delete("slow");
       SafeDelete(fList);
    }

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -1296,3 +1296,30 @@ void TDirectory::TContext::CdNull()
 {
    gDirectory = 0;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// TDirectory Streamer.
+void TDirectory::Streamer(TBuffer &R__b)
+{
+   // Stream an object of class TDirectory.
+
+   UInt_t R__s, R__c;
+   if (R__b.IsReading()) {
+      Version_t R__v = R__b.ReadVersion(&R__s, &R__c); if (R__v) { }
+      TNamed::Streamer(R__b);
+      R__b >> fMother;
+      R__b >> fList;
+      fList->UseRWLock();
+      fUUID.Streamer(R__b);
+      R__b.StreamObject(&(fSpinLock),typeid(fSpinLock));
+      R__b.CheckByteCount(R__s, R__c, TDirectory::IsA());
+   } else {
+      R__c = R__b.WriteVersion(TDirectory::IsA(), kTRUE);
+      TNamed::Streamer(R__b);
+      R__b << fMother;
+      R__b << fList;
+      fUUID.Streamer(R__b);
+      R__b.StreamObject(&(fSpinLock),typeid(fSpinLock));
+      R__b.SetByteCount(R__c, kTRUE);
+   }
+}

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -236,9 +236,12 @@ void TDirectory::Build(TFile* /*motherFile*/, TDirectory* motherDir)
 
 void TDirectory::CleanTargets()
 {
-   while (fContext) {
-      fContext->fDirectory = 0;
-      fContext = fContext->fNext;
+   {
+      ROOT::Internal::TSpinLockGuard slg(fSpinLock);
+      while (fContext) {
+         fContext->fDirectory = 0;
+         fContext = fContext->fNext;
+      }
    }
 
    if (gDirectory == this) {

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -543,7 +543,10 @@ void TDirectory::Clear(Option_t *)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Delete all objects from memory and directory structure itself.
-
+/// if option is "slow", iterate through the containers in a way to can handle
+///    'external' modification (induced by recursions)
+/// if option is "nodelete", write the TDirectory but do not delete the contained
+///    objects.
 void TDirectory::Close(Option_t *option)
 {
    if (!fList) {
@@ -553,26 +556,30 @@ void TDirectory::Close(Option_t *option)
    // Save the directory key list and header
    Save();
 
-   Bool_t slow = option ? (!strcmp(option, "slow") ? kTRUE : kFALSE) : kFALSE;
-   if (!slow) {
-      // Check if it is wise to use the fast deletion path.
-      TObjLink *lnk = fList->FirstLink();
-      while (lnk) {
-         if (lnk->GetObject()->IsA() == TDirectory::Class()) {
-            slow = kTRUE;
-            break;
-         }
-         lnk = lnk->Next();
-      }
-   }
+   Bool_t nodelete = option ? (!strcmp(option, "nodelete") ? kTRUE : kFALSE) : kFALSE;
 
-   // Delete objects from directory list, this in turn, recursively closes all
-   // sub-directories (that were allocated on the heap)
-   // if this dir contains subdirs, we must use the slow option for Delete!
-   // we must avoid "slow" as much as possible, in particular Delete("slow")
-   // with a large number of objects (eg >10^5) would take for ever.
-   if (slow) fList->Delete("slow");
-   else      fList->Delete();
+   if (!nodelete) {
+      Bool_t slow = option ? (!strcmp(option, "slow") ? kTRUE : kFALSE) : kFALSE;
+      if (!slow) {
+         // Check if it is wise to use the fast deletion path.
+         TObjLink *lnk = fList->FirstLink();
+         while (lnk) {
+            if (lnk->GetObject()->IsA() == TDirectory::Class()) {
+               slow = kTRUE;
+               break;
+            }
+            lnk = lnk->Next();
+         }
+      }
+
+      // Delete objects from directory list, this in turn, recursively closes all
+      // sub-directories (that were allocated on the heap)
+      // if this dir contains subdirs, we must use the slow option for Delete!
+      // we must avoid "slow" as much as possible, in particular Delete("slow")
+      // with a large number of objects (eg >10^5) would take for ever.
+      if (slow) fList->Delete("slow");
+      else      fList->Delete();
+   }
 
    CleanTargets();
 }

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -1089,7 +1089,8 @@ namespace {
             // is not seen as part of the list.
             // We will later, remove all the object (see files->Clear()
             cursor->SetObject(&harmless); // this must not be zero otherwise things go wrong.
-            dir->Close();
+            // See related comment at the files->Clear("nodelete");
+            dir->Close("nodelete");
             // Put it back
             cursor->SetObject(dir);
          }

--- a/core/cont/src/THashTable.cxx
+++ b/core/cont/src/THashTable.cxx
@@ -373,7 +373,7 @@ TObject *THashTable::Remove(TObject *obj)
 TObject *THashTable::RemoveSlow(TObject *obj)
 {
 
-   R__COLLECTION_READ_LOCKGUARD(ROOT::gCoreMutex);
+   R__COLLECTION_WRITE_LOCKGUARD(ROOT::gCoreMutex);
 
    for (int i = 0; i < fSize; i++) {
       if (fCont[i]) {

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -2732,6 +2732,7 @@ Int_t TClass::GetBaseClassOffset(const TClass *toBase, void *address, bool isDer
    ClassInfo_t* derived = GetClassInfo();
    ClassInfo_t* base = toBase->GetClassInfo();
    if(derived && base) {
+      // TClingClassInfo::GetBaseOffset takes the lock.
       return gCling->ClassInfo_GetBaseOffset(derived, base, address, isDerivedObject);
    }
    else {

--- a/core/thread/src/TThread.cxx
+++ b/core/thread/src/TThread.cxx
@@ -347,7 +347,9 @@ void TThread::Init()
    {
      R__LOCKGUARD(gGlobalMutex);
      if (!ROOT::gCoreMutex) {
-       ROOT::gCoreMutex = new ROOT::TRWMutexImp<TMutex, ROOT::Internal::UniqueLockRecurseCount>();
+        // To avoid dead locks, caused by shared library opening and/or static initialization
+        // taking the same lock as 'tls_get_addr_tail', we can not use UniqueLockRecurseCount.
+        ROOT::gCoreMutex = new ROOT::TRWMutexImp<TMutex, ROOT::Internal::RecurseCounts>();
      }
      gInterpreterMutex = ROOT::gCoreMutex;
      gROOTMutex = gInterpreterMutex;

--- a/io/io/src/TDirectoryFile.cxx
+++ b/io/io/src/TDirectoryFile.cxx
@@ -317,6 +317,7 @@ void TDirectoryFile::Build(TFile* motherFile, TDirectory* motherDir)
    fSeekKeys   = 0;
    fList       = new THashList(100,50);
    fKeys       = new THashList(100,50);
+   fList->UseRWLock();
    fMother     = motherDir;
    fFile       = motherFile ? motherFile : TFile::CurrentFile();
    SetBit(kCanDelete);
@@ -1686,6 +1687,7 @@ void TDirectoryFile::Streamer(TBuffer &b)
             fUUID.Streamer(b);
          }
       }
+      fList->UseRWLock();
       R__LOCKGUARD(gROOTMutex);
       gROOT->GetUUIDs()->AddUUID(fUUID,this);
       if (fSeekKeys) ReadKeys();

--- a/io/io/src/TDirectoryFile.cxx
+++ b/io/io/src/TDirectoryFile.cxx
@@ -532,7 +532,7 @@ TDirectory *TDirectoryFile::GetDirectory(const char *apath,
 ////////////////////////////////////////////////////////////////////////////////
 /// Delete all objects from memory and directory structure itself.
 
-void TDirectoryFile::Close(Option_t *)
+void TDirectoryFile::Close(Option_t *option)
 {
    if (!fList || !fSeekDir) {
       return;
@@ -541,20 +541,24 @@ void TDirectoryFile::Close(Option_t *)
    // Save the directory key list and header
    Save();
 
-   Bool_t fast = kTRUE;
-   TObjLink *lnk = fList->FirstLink();
-   while (lnk) {
-      if (lnk->GetObject()->IsA() == TDirectoryFile::Class()) {fast = kFALSE;break;}
-      lnk = lnk->Next();
-   }
-   // Delete objects from directory list, this in turn, recursively closes all
-   // sub-directories (that were allocated on the heap)
-   // if this dir contains subdirs, we must use the slow option for Delete!
-   // we must avoid "slow" as much as possible, in particular Delete("slow")
-   // with a large number of objects (eg >10^5) would take for ever.
-   {
-      if (fast) fList->Delete();
-      else      fList->Delete("slow");
+   Bool_t nodelete = option ? (!strcmp(option, "nodelete") ? kTRUE : kFALSE) : kFALSE;
+
+   if (!nodelete) {
+      Bool_t fast = kTRUE;
+      TObjLink *lnk = fList->FirstLink();
+      while (lnk) {
+         if (lnk->GetObject()->IsA() == TDirectoryFile::Class()) {fast = kFALSE;break;}
+         lnk = lnk->Next();
+      }
+      // Delete objects from directory list, this in turn, recursively closes all
+      // sub-directories (that were allocated on the heap)
+      // if this dir contains subdirs, we must use the slow option for Delete!
+      // we must avoid "slow" as much as possible, in particular Delete("slow")
+      // with a large number of objects (eg >10^5) would take for ever.
+      {
+         if (fast) fList->Delete();
+         else      fList->Delete("slow");
+      }
    }
 
    // Delete keys from key list (but don't delete the list header)

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -546,6 +546,17 @@ TFile::~TFile()
 {
    Close();
 
+   // In case where the TFile is still open at 'tear-down' time the order of operation will be
+   // call Close("nodelete")
+   // then later call delete TFile
+   // which means that at this point we might still have object held and those
+   // might requires a 'valid' TFile object in their desctructor (for example,
+   // TTree call's GetReadCache which expects a non-null fCacheReadMap).
+   // So delete the objects (if any) now.
+
+   if (fList)
+      fList->Delete("slow");
+
    SafeDelete(fAsyncHandle);
    SafeDelete(fCacheRead);
    SafeDelete(fCacheReadMap);


### PR DESCRIPTION
Prior to this change, the tranversal might be cut short if one of the RecursiveRemove request the write lock and
thus let another thread modify the list; if this happens some of the node might now have a nullptr payload and
the previous would cut short the traversal.