### PR TITLE
TDavixFile: add support for cross-protocol metalinks

### DIFF
--- a/net/davix/inc/TDavixFile.h
+++ b/net/davix/inc/TDavixFile.h
@@ -105,6 +105,7 @@ public:
     virtual Bool_t ReadBuffers(char *buf, Long64_t *pos, Int_t *len, Int_t nbuf);
     virtual Bool_t ReadBufferAsync(Long64_t offs, Int_t len);
     virtual Bool_t WriteBuffer(const char *buffer, Int_t bufferLength);
+    virtual TString GetNewUrl();
 
     // TDavixFile options
     /// Enable or disable certificate authority check

--- a/net/davix/src/TDavixFileInternal.h
+++ b/net/davix/src/TDavixFileInternal.h
@@ -45,6 +45,7 @@ namespace Davix {
    class Context;
    class RequestParams;
    class DavPosix;
+   class DavFile;
 }
 struct Davix_fd;
 
@@ -117,8 +118,15 @@ private:
 
    void removeDird(void* fd);
 
+   std::vector<std::string> getReplicas()
+   {
+     return replicas;
+   }
+
    TMutex positionLock;
    TMutex openLock;
+
+   std::vector<std::string> replicas;
 
    // DAVIX
    Davix::Context *davixContext;


### PR DESCRIPTION
Original patch by Georgios Bitzes, manual rebase onto master.

Compiles and works correctly against upstream/master on CC7.

See here for more information: https://tmaier.web.cern.ch/tmaier/ROOTDavixRedirection/davix-root-fix.html

Please also backport this patch to 6-08 and 6-10.

Thanks!
Mario