### PR TITLE
New pymva keras callback: TensorBoard

### DIFF
--- a/tmva/pymva/inc/TMVA/MethodPyKeras.h
+++ b/tmva/pymva/inc/TMVA/MethodPyKeras.h
@@ -79,6 +79,7 @@ namespace TMVA {
       Bool_t fSaveBestOnly; // Store only weights with smallest validation loss
       Int_t fTriesEarlyStopping; // Stop training if validation loss is not decreasing for several epochs
       TString fLearningRateSchedule; // Set new learning rate at specific epochs
+      TString fTensorBoard;          // Store log files during training
 
       bool fModelIsSetup = false; // flag whether model is loaded, neede for getMvaValue during evaluation
       float* fVals = nullptr; // variables array used for GetMvaValue

--- a/tutorials/tmva/keras/ClassificationKeras.py
+++ b/tutorials/tmva/keras/ClassificationKeras.py
@@ -5,9 +5,8 @@ from subprocess import call
 from os.path import isfile
 
 from keras.models import Sequential
-from keras.layers.core import Dense, Activation
+from keras.layers import Dense, Activation
 from keras.regularizers import l2
-from keras import initializations
 from keras.optimizers import SGD
 
 # Setup TMVA
@@ -16,7 +15,7 @@ TMVA.PyMethodBase.PyInitialize()
 
 output = TFile.Open('TMVA.root', 'RECREATE')
 factory = TMVA.Factory('TMVAClassification', output,
-        '!V:!Silent:Color:DrawProgressBar:Transformations=D,G:AnalysisType=Classification')
+                       '!V:!Silent:Color:DrawProgressBar:Transformations=D,G:AnalysisType=Classification')
 
 # Load data
 if not isfile('tmva_class_example.root'):
@@ -33,7 +32,7 @@ for branch in signal.GetListOfBranches():
 dataloader.AddSignalTree(signal, 1.0)
 dataloader.AddBackgroundTree(background, 1.0)
 dataloader.PrepareTrainingAndTestTree(TCut(''),
-        'nTrain_Signal=4000:nTrain_Background=4000:SplitMode=Random:NormMode=NumEvents:!V')
+                                      'nTrain_Signal=4000:nTrain_Background=4000:SplitMode=Random:NormMode=NumEvents:!V')
 
 # Generate model
 
@@ -41,14 +40,16 @@ dataloader.PrepareTrainingAndTestTree(TCut(''),
 def normal(shape, name=None):
     return initializations.normal(shape, scale=0.05, name=name)
 
+
 # Define model
 model = Sequential()
-model.add(Dense(64, init=normal, activation='relu', W_regularizer=l2(1e-5), input_dim=4))
+model.add(Dense(64, activation='relu', W_regularizer=l2(1e-5), input_dim=4))
 #model.add(Dense(32, init=normal, activation='relu', W_regularizer=l2(1e-5)))
-model.add(Dense(2, init=normal, activation='softmax'))
+model.add(Dense(2, activation='softmax'))
 
 # Set loss and optimizer
-model.compile(loss='categorical_crossentropy', optimizer=SGD(lr=0.01), metrics=['accuracy',])
+model.compile(loss='categorical_crossentropy',
+              optimizer=SGD(lr=0.01), metrics=['accuracy', ])
 
 # Store model to file
 model.save('model.h5')
@@ -56,9 +57,9 @@ model.summary()
 
 # Book methods
 factory.BookMethod(dataloader, TMVA.Types.kFisher, 'Fisher',
-        '!H:!V:Fisher:VarTransform=D,G')
+                   '!H:!V:Fisher:VarTransform=D,G')
 factory.BookMethod(dataloader, TMVA.Types.kPyKeras, 'PyKeras',
-        'H:!V:VarTransform=D,G:FilenameModel=model.h5:NumEpochs=20:BatchSize=32')
+                   'H:!V:VarTransform=D,G:FilenameModel=model.h5:NumEpochs=20:BatchSize=32')
 
 # Run training, test and evaluation
 factory.TrainAllMethods()


### PR DESCRIPTION
This PR adds a new callback to the PyKeras method.
I've build ROOT without any errors and run the ctests and all of them passed. 

You can try out this new callback with:
`sudo pip install keras --upgrade`
`sudo pip install tensorflow --upgrade`

And then run: `python tutorials/tmva/keras/ClassificationKeras.py`. The callback will create a new directory called 'logs'.
Then you can call while or after training tensorboard: `tensorboard --logdir=./logs`
Now you can open the link from your terminal and visualize the network and training. 
The `ClassificationKeras.py` script, seems to be not compatible with the Keras 2.x API right now, therefore you can revert the changes of this PR in this specific script after testing.

More information on TensorBoard: https://www.tensorflow.org/get_started/summaries_and_tensorboard

Also pointing to the author of the PyKeras implementation: @stwunsch

Thanks in advance for reviewing this PR!