### PR TITLE
[cxxmodules] Also preload TMVA/TreePlayer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,7 +343,7 @@ endif()
 
 if(runtime_cxxmodules)
   # Dummy target that does nothing, we don't need a PCH for modules.
-  add_custom_target(onepcm)
+  add_custom_target(onepcm DEPENDS TreePlayer TMVA Graf)
 else()
   add_custom_command(OUTPUT etc/allDict.cxx.pch
                     COMMAND ${CMAKE_COMMAND} -E env ROOTIGNOREPREFIX=1 ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/etc/dictpch/makepch.py etc/allDict.cxx.pch ${__allIncludes} -I${CMAKE_BINARY_DIR}/include

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1341,9 +1341,6 @@ TCling::TCling(const char *name, const char *title)
                             "using namespace std;");
    }
 
-   // Setup core C++ modules if we have any to setup.
-   LoadCoreModules(*fInterpreter);
-
    // We are now ready (enough is loaded) to init the list of opaque typedefs.
    fNormalizedCtxt = new ROOT::TMetaUtils::TNormalizedCtxt(fInterpreter->getLookupHelper());
    fLookupHelper = new ROOT::TMetaUtils::TClingLookupHelper(*fInterpreter, *fNormalizedCtxt, TClingLookupHelper__ExistingTypeCheck, TClingLookupHelper__AutoParse);
@@ -1416,6 +1413,9 @@ TCling::~TCling()
 void TCling::Initialize()
 {
    fClingCallbacks->Initialize();
+
+   // Setup core C++ modules if we have any to setup.
+   LoadCoreModules(*fInterpreter);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1099,6 +1099,8 @@ static void LoadCoreModules(cling::Interpreter &interp)
    if (!CI.getLangOpts().Modules)
       return;
 
+   bool fromRootCling = dlsym(RTLD_DEFAULT, "usedToIdentifyRootClingByDlSym");
+
    clang::HeaderSearch &headerSearch = CI.getPreprocessor().getHeaderSearchInfo();
    clang::ModuleMap &moduleMap = headerSearch.getModuleMap();
    // List of core modules we can load, but it's ok if they are missing because
@@ -1107,6 +1109,12 @@ static void LoadCoreModules(cling::Interpreter &interp)
 
    // List of core modules we need to load.
    std::vector<std::string> neededCoreModuleNames = {"Core", "RIO"};
+
+   if (!fromRootCling) {
+      neededCoreModuleNames.push_back("TreePlayer");
+      neededCoreModuleNames.push_back("TMVA");
+   }
+
    std::vector<std::string> missingCoreModuleNames;
 
    std::vector<clang::Module *> coreModules;

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1113,6 +1113,7 @@ static void LoadCoreModules(cling::Interpreter &interp)
    if (!fromRootCling) {
       neededCoreModuleNames.push_back("TreePlayer");
       neededCoreModuleNames.push_back("TMVA");
+      neededCoreModuleNames.push_back("Graf");
    }
 
    std::vector<std::string> missingCoreModuleNames;


### PR DESCRIPTION
ROOT can't autoparse classes inside namespaces with the rootmap
system (as the loading callbacks don't correctly land where
they are supposed to land with our injected namespaces). As this
turns out to be a feature of some kind, let's preload TMVA/TreePlayer
to fix all failing tests that are related to this feature/bug with
modules enabled.