### PR TITLE
[cxxmodules] Teach TCling::RegisterModule to work with real module fi…

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1101,7 +1101,6 @@ static bool LoadModule(const std::string &ModuleName, cling::Interpreter &interp
    cling::Transaction* T = nullptr;
    interp.declare("/*This is decl is to get a valid sloc...*/;", &T);
    SourceLocation ValidLoc = T->decls_begin()->m_DGR.getSingleDecl()->getLocStart();
-   // CreateImplicitModuleImportNoInit creates decls.
    cling::Interpreter::PushTransactionRAII RAII(&interp);
    if (clang::Module *M = moduleMap.findModule(ModuleName)) {
       clang::IdentifierInfo *II = PP.getIdentifierInfo(M->Name);

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1098,16 +1098,14 @@ static bool LoadModule(const std::string &ModuleName, cling::Interpreter &interp
    clang::HeaderSearch &headerSearch = PP.getHeaderSearchInfo();
    clang::ModuleMap &moduleMap = headerSearch.getModuleMap();
 
-   cling::Transaction* T = nullptr;
-   interp.declare("/*This is decl is to get a valid sloc...*/;", &T);
-   SourceLocation ValidLoc = T->decls_begin()->m_DGR.getSingleDecl()->getLocStart();
    cling::Interpreter::PushTransactionRAII RAII(&interp);
    if (clang::Module *M = moduleMap.findModule(ModuleName)) {
       clang::IdentifierInfo *II = PP.getIdentifierInfo(M->Name);
-      bool Result = !CI.getSema().ActOnModuleImport(ValidLoc, ValidLoc, std::make_pair(II, ValidLoc)).isInvalid();
+      SourceLocation ValidLoc = M->DefinitionLoc;
+      bool success = !CI.getSema().ActOnModuleImport(ValidLoc, ValidLoc, std::make_pair(II, ValidLoc)).isInvalid();
       // Also make the module visible in the preprocessor to export its macros.
       PP.makeModuleVisible(M, ValidLoc);
-      return Result;
+      return success;
    }
    return false;
 }

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1927,6 +1927,13 @@ void TCling::RegisterModule(const char* modulename,
 
    clang::Sema &TheSema = fInterpreter->getSema();
 
+   if (TheSema.getLangOpts().Modules) {
+     std::string ModuleName = llvm::StringRef(modulename).substr(3).str();
+     bool success = LoadModule(ModuleName, *fInterpreter);
+     if (!success)
+        Info("TCling::RegisterModule", "Failed to load module %s", ModuleName.c_str());
+   }
+
    { // scope within which diagnostics are de-activated
    // For now we disable diagnostics because we saw them already at
    // dictionary generation time. That won't be an issue with the PCMs.

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1932,6 +1932,13 @@ void TCling::RegisterModule(const char* modulename,
       std::string ModuleName = llvm::StringRef(modulename).substr(3).str();
       ModuleWasSuccessfullyLoaded = LoadModule(ModuleName, *fInterpreter);
       if (!ModuleWasSuccessfullyLoaded) {
+         // Only report if we found the module in the modulemap.
+         clang::Preprocessor &PP = TheSema.getPreprocessor();
+         clang::HeaderSearch &headerSearch = PP.getHeaderSearchInfo();
+         clang::ModuleMap &moduleMap = headerSearch.getModuleMap();
+         if (moduleMap.findModule(ModuleName))
+            Info("TCling::RegisterModule", "Module %s in modulemap failed to load.", ModuleName.c_str());
+      }
    }
 
    { // scope within which diagnostics are de-activated

--- a/core/metacling/src/TClingCallbacks.cxx
+++ b/core/metacling/src/TClingCallbacks.cxx
@@ -88,7 +88,11 @@ void TClingCallbacks::InclusionDirective(clang::SourceLocation sLoc/*HashLoc*/,
                                          const clang::FileEntry *FE,
                                          llvm::StringRef /*SearchPath*/,
                                          llvm::StringRef /*RelativePath*/,
-                                         const clang::Module * /*Imported*/) {
+                                         const clang::Module * Imported) {
+   // We found a module. Do not try to do anything else.
+   if (Imported)
+      return;
+
    // Method called via Callbacks->InclusionDirective()
    // in Preprocessor::HandleIncludeDirective(), invoked whenever an
    // inclusion directive has been processed, and allowing us to try

--- a/core/metacling/src/TClingCallbacks.cxx
+++ b/core/metacling/src/TClingCallbacks.cxx
@@ -90,8 +90,15 @@ void TClingCallbacks::InclusionDirective(clang::SourceLocation sLoc/*HashLoc*/,
                                          llvm::StringRef /*RelativePath*/,
                                          const clang::Module * Imported) {
    // We found a module. Do not try to do anything else.
-   if (Imported)
-      return;
+   if (Imported) {
+      Sema &SemaR = m_Interpreter->getSema();
+      // FIXME: We should make the module visible at that point.
+      if (!SemaR.isModuleVisible(Imported))
+         ROOT::TMetaUtils::Info("TClingCallbacks::InclusionDirective",
+                                "Module %s resolved but not visible!", Imported->Name.c_str());
+      else
+        return;
+   }
 
    // Method called via Callbacks->InclusionDirective()
    // in Preprocessor::HandleIncludeDirective(), invoked whenever an


### PR DESCRIPTION
…les.

When we load a library, during its static intialization it calls
TCling::RegisterModule to make ROOT's runtime aware of that load. Regular
ROOT also will do some header parsing to add the minimal infrastructure
in place for cling to be able to call into that library.

C++ modules define away the need to parse. This patch intends to skip all
parsing at this stage and fix recursive parsing issues for C++ modules.