### PR TITLE
Make TEnv::GetValue functions const

### DIFF
--- a/core/base/inc/TEnv.h
+++ b/core/base/inc/TEnv.h
@@ -132,22 +132,22 @@ private:
    TEnv(const TEnv&);            // not implemented
    TEnv& operator=(const TEnv&); // not implemented
 
-   const char       *Getvalue(const char *name);
+   const char       *Getvalue(const char *name) const;
 
 public:
    TEnv(const char *name="");
    virtual ~TEnv();
 
    THashList          *GetTable() const { return fTable; }
-   Bool_t              Defined(const char *name)
+   Bool_t              Defined(const char *name) const
                                     { return Getvalue(name) != 0; }
 
    virtual const char *GetRcName() const { return fRcName; }
    virtual void        SetRcName(const char *name) { fRcName = name; }
 
-   virtual Int_t       GetValue(const char *name, Int_t dflt);
-   virtual Double_t    GetValue(const char *name, Double_t dflt);
-   virtual const char *GetValue(const char *name, const char *dflt);
+   virtual Int_t       GetValue(const char *name, Int_t dflt) const;
+   virtual Double_t    GetValue(const char *name, Double_t dflt) const;
+   virtual const char *GetValue(const char *name, const char *dflt) const;
 
    virtual void        SetValue(const char *name, const char *value,
                                 EEnvLevel level = kEnvChange,
@@ -156,7 +156,7 @@ public:
    virtual void        SetValue(const char *name, Int_t value);
    virtual void        SetValue(const char *name, Double_t value);
 
-   virtual TEnvRec    *Lookup(const char *n);
+   virtual TEnvRec    *Lookup(const char *n) const;
    virtual Int_t       ReadFile(const char *fname, EEnvLevel level);
    virtual Int_t       WriteFile(const char *fname, EEnvLevel level = kEnvAll);
    virtual void        Save();

--- a/core/base/src/TEnv.cxx
+++ b/core/base/src/TEnv.cxx
@@ -438,7 +438,7 @@ TEnv::~TEnv()
 ////////////////////////////////////////////////////////////////////////////////
 /// Returns the character value for a named resource.
 
-const char *TEnv::Getvalue(const char *name)
+const char *TEnv::Getvalue(const char *name) const
 {
    Bool_t haveProgName = kFALSE;
    if (gProgName && strlen(gProgName) > 0)
@@ -488,7 +488,7 @@ const char *TEnv::Getvalue(const char *name)
 /// Returns the integer value for a resource. If the resource is not found
 /// return the default value.
 
-Int_t TEnv::GetValue(const char *name, Int_t dflt)
+Int_t TEnv::GetValue(const char *name, Int_t dflt) const
 {
    const char *cp = TEnv::Getvalue(name);
    if (cp) {
@@ -515,7 +515,7 @@ Int_t TEnv::GetValue(const char *name, Int_t dflt)
 /// Returns the double value for a resource. If the resource is not found
 /// return the default value.
 
-Double_t TEnv::GetValue(const char *name, Double_t dflt)
+Double_t TEnv::GetValue(const char *name, Double_t dflt) const
 {
    const char *cp = TEnv::Getvalue(name);
    if (cp) {
@@ -532,7 +532,7 @@ Double_t TEnv::GetValue(const char *name, Double_t dflt)
 /// Returns the character value for a named resource. If the resource is
 /// not found the default value is returned.
 
-const char *TEnv::GetValue(const char *name, const char *dflt)
+const char *TEnv::GetValue(const char *name, const char *dflt) const
 {
    const char *cp = TEnv::Getvalue(name);
    if (cp)
@@ -544,7 +544,7 @@ const char *TEnv::GetValue(const char *name, const char *dflt)
 /// Loop over all resource records and return the one with name.
 /// Return 0 in case name is not in the resource table.
 
-TEnvRec *TEnv::Lookup(const char *name)
+TEnvRec *TEnv::Lookup(const char *name) const
 {
    if (!fTable) return 0;
    return (TEnvRec*) fTable->FindObject(name);


### PR DESCRIPTION
Requires that TEnv:: Getvalue, Lookup are const as well.
Also mark Defined const.

Local compilation of ROOT succeeds after the patch.