### PR TITLE
Fix gSystem->Load() failure caused by recent macOS default

### DIFF
--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -4595,6 +4595,18 @@ static const char *DynamicPath(const char *newpath = 0, Bool_t reset = kFALSE)
       if (!ldpath.IsNull())
          ldpath += ":";
       ldpath += gSystem->Getenv("DYLD_FALLBACK_LIBRARY_PATH");
+      if (!ldpath.IsNull())
+         ldpath += ":";
+      // Workaround for recent macOS default behaviour
+      TString dyldpath;
+      // Allow explicit control if override variable defined
+      if (gSystem->Getenv("ROOT_DYLD_LIBRARY_PATH")) {
+         dyldpath = gSystem->Getenv("ROOT_DYLD_LIBRARY_PATH");
+      } else {
+         dyldpath = gSystem->Getenv("PATH");
+         dyldpath.ReplaceAll("/bin", "/lib");
+      }
+      ldpath += dyldpath;
 #else
       ldpath = gSystem->Getenv("LD_LIBRARY_PATH");
 #endif


### PR DESCRIPTION
macOS has introduced feature named System Integrity Protection which prevents DYLD_* and LD_* environment variables to be propageted to a ROOT process.
We must disable the feature to use multiple versions of ROOT with AliBuild.

There are two solution for this:

- Fix gSystem->Load() to allow dynamic loading using another environment variable
  Pros: It just works (possibly) without out of tree modifications. Easy to relocate.
  Cons: It's dirty. Unexpected load paths may be used even if they they have low priority.

- Change all macros ever made so that they call gSystem->Load() with the full path or call AddDynamicPath in advance
  Pros: It's neat. One can control load path precisely.
  Cons: Too many macros to fix. We should fix the macros after relocation of libraries.

This commit implements the former solution.