### PR TITLE
http: correctly handle websocket close

### DIFF
--- a/README/CREDITS
+++ b/README/CREDITS
@@ -544,6 +544,8 @@ N: Sergey Linev
 E: S.Linev@gsi.de
 D: XML interface package
 D: SQL interface extensions, ODBC driver
+D: THttpServer class
+D: JavaScript ROOT package (together with Bertrand Bellenot)
 
 N: Yan Liu
 E: liuyan@fnal.gov

--- a/documentation/HttpServer/HttpServer.md
+++ b/documentation/HttpServer/HttpServer.md
@@ -22,18 +22,21 @@ One could specify several options when creating http server. They could be add a
 
 Following parameters are supported:
 
-   - thrds=N   - number of threads used by the civetweb (default is 5)
+   - thrds=N   - number of threads used by the civetweb (default is 10)
    - top=name  - configure top name, visible in the web browser
    - auth_file=filename  - authentication file name, created with htdigets utility
    - auth_domain=domain   - authentication domain
    - loopback  - bind specified port to loopback 127.0.0.1 address
    - debug  - enable debug mode, server always returns html page with request info
+   - websocket_timeout=tm  - set web sockets timeout in seconds (default 300)
+   - websocket_disable - disable web sockets handling (default enabled)
+   - cors=domain  - define value for CORS header "Access-Control-Allow-Origin" in server response
 
 If necessary, one could bind http server to specific IP address like:
 
     new THttpServer("http:192.168.1.17:8080")
 
-One also can provide extra arguments for THttpServer itself 
+One also can provide extra arguments for THttpServer itself:
 
    - readonly, ro   - use server in read-only mode (default)
    - readwrite, rw  - use server in read-write mode

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -569,7 +569,7 @@ void ROOT::Experimental::TCanvasPainter::ProcessData(unsigned connid, const std:
       conn->fGetMenu = cdata;
    } else if (arg == "QUIT") {
       // use window manager to correctly terminate http server
-      TWebWindowsManager::Instance()->Terminate(0);
+      TWebWindowsManager::Instance()->Terminate();
       return;
    } else if (arg == "RELOAD") {
       conn->fSend = 0; // reset send version, causes new data sending

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -29,7 +29,6 @@
 #include <fstream>
 
 #include "TList.h"
-#include "TApplication.h"
 #include "TROOT.h"
 #include "TClass.h"
 #include "TBufferJSON.h"
@@ -569,8 +568,8 @@ void ROOT::Experimental::TCanvasPainter::ProcessData(unsigned connid, const std:
       cdata.erase(0, 8);
       conn->fGetMenu = cdata;
    } else if (arg == "QUIT") {
-      if (gApplication)
-         gApplication->Terminate(0);
+      // use window manager to correctly terminate http server
+      TWebWindowsManager::Instance()->Terminate(0);
       return;
    } else if (arg == "RELOAD") {
       conn->fSend = 0; // reset send version, causes new data sending

--- a/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
@@ -64,6 +64,10 @@ public:
 
    /// Wait until provided function returns non-zero value
    int WaitFor(WebWindowWaitFunc_t check, double tm);
+
+   /// Terminate http server and ROOT application
+   void Terminate(int code = 0);
+
 };
 
 } // namespace Experimental

--- a/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
@@ -67,7 +67,6 @@ public:
 
    /// Terminate http server and ROOT application
    void Terminate();
-
 };
 
 } // namespace Experimental

--- a/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
@@ -66,7 +66,7 @@ public:
    int WaitFor(WebWindowWaitFunc_t check, double tm);
 
    /// Terminate http server and ROOT application
-   void Terminate(int code = 0);
+   void Terminate();
 
 };
 

--- a/gui/webdisplay/src/TWebWindowsManager.cxx
+++ b/gui/webdisplay/src/TWebWindowsManager.cxx
@@ -31,6 +31,7 @@
 #include "TString.h"
 #include "TStopwatch.h"
 #include "TApplication.h"
+#include "TTimer.h"
 
 /** \class ROOT::Experimental::TWebWindowManager
 \ingroup webdisplay
@@ -323,11 +324,12 @@ int ROOT::Experimental::TWebWindowsManager::WaitFor(WebWindowWaitFunc_t check, d
 //////////////////////////////////////////////////////////////////////////
 /// Terminate http server and ROOT application
 
-void ROOT::Experimental::TWebWindowsManager::Terminate(int code)
+void ROOT::Experimental::TWebWindowsManager::Terminate()
 {
    if (fServer)
       fServer->SetTerminate();
 
+   // use timer to avoid situation when calling object is deleted by terminate
    if (gApplication)
-      gApplication->Terminate(code);
+      TTimer::SingleShot(100, "TApplication", gApplication, "Terminate()");
 }

--- a/gui/webdisplay/src/TWebWindowsManager.cxx
+++ b/gui/webdisplay/src/TWebWindowsManager.cxx
@@ -30,6 +30,7 @@
 #include "TRandom.h"
 #include "TString.h"
 #include "TStopwatch.h"
+#include "TApplication.h"
 
 /** \class ROOT::Experimental::TWebWindowManager
 \ingroup webdisplay
@@ -317,4 +318,16 @@ int ROOT::Experimental::TWebWindowsManager::WaitFor(WebWindowWaitFunc_t check, d
    printf("WAITING RES %d tm %4.2f cnt %d\n", res, spent, cnt);
 
    return res;
+}
+
+//////////////////////////////////////////////////////////////////////////
+/// Terminate http server and ROOT application
+
+void ROOT::Experimental::TWebWindowsManager::Terminate(int code)
+{
+   if (fServer)
+      fServer->SetTerminate();
+
+   if (gApplication)
+      gApplication->Terminate(code);
 }

--- a/net/http/inc/TCivetweb.h
+++ b/net/http/inc/TCivetweb.h
@@ -21,9 +21,9 @@ protected:
    void *fCallbacks; ///<! call-back table for civetweb webserver
    TString fTopName; ///<! name of top item
    Bool_t fDebug;    ///<! debug mode
-   Bool_t fShutdown; ///<! server doing shutdown and not react on requests
+   Bool_t fTerminating; ///<! server doing shutdown and not react on requests
 
-   virtual void Terminate() { fShutdown = kTRUE; }
+   virtual void Terminate() override { fTerminating = kTRUE; }
 
 public:
    TCivetweb();
@@ -35,7 +35,7 @@ public:
 
    Bool_t IsDebugMode() const { return fDebug; }
 
-   Bool_t IsShutdown() const { return fShutdown; }
+   Bool_t IsTerminating() const { return fTerminating; }
 
    Int_t ProcessLog(const char *message);
 

--- a/net/http/inc/TCivetweb.h
+++ b/net/http/inc/TCivetweb.h
@@ -23,13 +23,13 @@ protected:
    Bool_t fDebug;       ///<! debug mode
    Bool_t fTerminating; ///<! server doing shutdown and not react on requests
 
-   virtual void Terminate() override { fTerminating = kTRUE; }
+   virtual void Terminate() { fTerminating = kTRUE; }
 
 public:
    TCivetweb();
    virtual ~TCivetweb();
 
-   virtual Bool_t Create(const char *args) override;
+   virtual Bool_t Create(const char *args);
 
    const char *GetTopName() const { return fTopName.Data(); }
 

--- a/net/http/inc/TCivetweb.h
+++ b/net/http/inc/TCivetweb.h
@@ -21,6 +21,7 @@ protected:
    void *fCallbacks; ///<! call-back table for civetweb webserver
    TString fTopName; ///<! name of top item
    Bool_t fDebug;    ///<! debug mode
+   Bool_t fShutdown; ///<! server doing shutdown and not react on requests
 
 public:
    TCivetweb();
@@ -31,6 +32,8 @@ public:
    const char *GetTopName() const { return fTopName.Data(); }
 
    Bool_t IsDebugMode() const { return fDebug; }
+
+   Bool_t IsShutdown() const { return fShutdown; }
 
    Int_t ProcessLog(const char *message);
 

--- a/net/http/inc/TCivetweb.h
+++ b/net/http/inc/TCivetweb.h
@@ -23,6 +23,8 @@ protected:
    Bool_t fDebug;    ///<! debug mode
    Bool_t fShutdown; ///<! server doing shutdown and not react on requests
 
+   virtual void Terminate() { fShutdown = kTRUE; }
+
 public:
    TCivetweb();
    virtual ~TCivetweb();

--- a/net/http/inc/TCivetweb.h
+++ b/net/http/inc/TCivetweb.h
@@ -17,10 +17,10 @@
 
 class TCivetweb : public THttpEngine {
 protected:
-   void *fCtx;       ///<! civetweb context
-   void *fCallbacks; ///<! call-back table for civetweb webserver
-   TString fTopName; ///<! name of top item
-   Bool_t fDebug;    ///<! debug mode
+   void *fCtx;          ///<! civetweb context
+   void *fCallbacks;    ///<! call-back table for civetweb webserver
+   TString fTopName;    ///<! name of top item
+   Bool_t fDebug;       ///<! debug mode
    Bool_t fTerminating; ///<! server doing shutdown and not react on requests
 
    virtual void Terminate() override { fTerminating = kTRUE; }
@@ -29,7 +29,7 @@ public:
    TCivetweb();
    virtual ~TCivetweb();
 
-   virtual Bool_t Create(const char *args);
+   virtual Bool_t Create(const char *args) override;
 
    const char *GetTopName() const { return fTopName.Data(); }
 

--- a/net/http/inc/TFastCgi.h
+++ b/net/http/inc/TFastCgi.h
@@ -18,17 +18,21 @@ class TThread;
 
 class TFastCgi : public THttpEngine {
 protected:
-   Int_t fSocket;     ///<! socket used by fastcgi
-   Bool_t fDebugMode; ///<! debug mode, may required for fastcgi debugging in other servers
-   TString fTopName;  ///<! name of top item
-   TThread *fThrd;    ///<! thread which takes requests, can be many later
+   Int_t fSocket;       ///<! socket used by fastcgi
+   Bool_t fDebugMode;   ///<! debug mode, may required for fastcgi debugging in other servers
+   TString fTopName;    ///<! name of top item
+   TThread *fThrd;      ///<! thread which takes requests, can be many later
+   Bool_t fTerminating; ///<! set when http server wants to terminate all engines
+
+   virtual void Terminate() override { fTerminating = kTRUE; }
+
 public:
    TFastCgi();
    virtual ~TFastCgi();
 
    Int_t GetSocket() const { return fSocket; }
 
-   virtual Bool_t Create(const char *args);
+   virtual Bool_t Create(const char *args) override;
 
    static void *run_func(void *);
 

--- a/net/http/inc/TFastCgi.h
+++ b/net/http/inc/TFastCgi.h
@@ -24,7 +24,7 @@ protected:
    TThread *fThrd;      ///<! thread which takes requests, can be many later
    Bool_t fTerminating; ///<! set when http server wants to terminate all engines
 
-   virtual void Terminate() override { fTerminating = kTRUE; }
+   virtual void Terminate() { fTerminating = kTRUE; }
 
 public:
    TFastCgi();
@@ -32,7 +32,7 @@ public:
 
    Int_t GetSocket() const { return fSocket; }
 
-   virtual Bool_t Create(const char *args) override;
+   virtual Bool_t Create(const char *args);
 
    static void *run_func(void *);
 

--- a/net/http/inc/THttpEngine.h
+++ b/net/http/inc/THttpEngine.h
@@ -26,6 +26,9 @@ protected:
 
    void SetServer(THttpServer *serv) { fServer = serv; }
 
+   /** Method called when server want to be terminated */
+   virtual void Terminate() {}
+
    /** Method regularly called in main ROOT context */
    virtual void Process() {}
 

--- a/net/http/inc/THttpEngine.h
+++ b/net/http/inc/THttpEngine.h
@@ -33,8 +33,6 @@ protected:
    virtual void Process() {}
 
 public:
-   virtual ~THttpEngine();
-
    /** Method to create all components of engine. Called once from by the server */
    virtual Bool_t Create(const char *) { return kFALSE; }
 
@@ -43,6 +41,5 @@ public:
 
    ClassDef(THttpEngine, 0) // abstract class which should provide http-based protocol for server
 };
-
 
 #endif

--- a/net/http/inc/THttpServer.h
+++ b/net/http/inc/THttpServer.h
@@ -32,6 +32,7 @@ protected:
    TList fEngines;         ///<! engines which runs http server
    THttpTimer *fTimer;     ///<! timer used to access main thread
    TRootSniffer *fSniffer; ///<! sniffer provides access to ROOT objects hierarchy
+   Bool_t fTerminated;     ///<! termination flag, disables all requests processing
 
    Long_t fMainThrdId; ///<! id of the main ROOT process
 
@@ -44,8 +45,7 @@ protected:
    TString fDefaultPageCont; ///<! content of the file content
    TString fDrawPage;        ///<! file name for drawing of single element
    TString fDrawPageCont;    ///<! content of draw page
-   TString
-      fCors; ///<! CORS (cross-origin resource sharing): sets Access-Control-Allow-Origin for ProcessRequest responses
+   TString fCors;            ///<! CORS: sets Access-Control-Allow-Origin header for ProcessRequest responses
 
    std::mutex fMutex; ///<! mutex to protect list with arguments
    TList fCallArgs;   ///<! submitted arguments
@@ -65,6 +65,12 @@ public:
 
    /** returns pointer on objects sniffer */
    TRootSniffer *GetSniffer() const { return fSniffer; }
+
+   /** set termination flag, no any further requests will be processed */
+   void SetTerminate();
+
+   /** returns kTRUE, if server was terminated */
+   Bool_t IsTerminated() const { return fTerminated; }
 
    void SetSniffer(TRootSniffer *sniff);
 

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -60,7 +60,7 @@ int websocket_connect_handler(const struct mg_connection *conn, void *)
       return 1;
 
    TCivetweb *engine = (TCivetweb *)request_info->user_data;
-   if (!engine || engine->IsShutdown())
+   if (!engine || engine->IsTerminating())
       return 1;
    THttpServer *serv = engine->GetServer();
    if (!serv)
@@ -84,7 +84,7 @@ void websocket_ready_handler(struct mg_connection *conn, void *)
    const struct mg_request_info *request_info = mg_get_request_info(conn);
 
    TCivetweb *engine = (TCivetweb *)request_info->user_data;
-   if (!engine || engine->IsShutdown())
+   if (!engine || engine->IsTerminating())
       return;
    THttpServer *serv = engine->GetServer();
    if (!serv)
@@ -112,7 +112,7 @@ int websocket_data_handler(struct mg_connection *conn, int, char *data, size_t l
       return 1;
 
    TCivetweb *engine = (TCivetweb *)request_info->user_data;
-   if (!engine || engine->IsShutdown())
+   if (!engine || engine->IsTerminating())
       return 1;
    THttpServer *serv = engine->GetServer();
    if (!serv)
@@ -142,7 +142,7 @@ void websocket_close_handler(const struct mg_connection *conn, void *)
    const struct mg_request_info *request_info = mg_get_request_info(conn);
 
    TCivetweb *engine = (TCivetweb *)request_info->user_data;
-   if (!engine || engine->IsShutdown())
+   if (!engine || engine->IsTerminating())
       return;
    THttpServer *serv = engine->GetServer();
    if (!serv)
@@ -182,7 +182,7 @@ static int begin_request_handler(struct mg_connection *conn, void *)
    const struct mg_request_info *request_info = mg_get_request_info(conn);
 
    TCivetweb *engine = (TCivetweb *)request_info->user_data;
-   if (!engine || engine->IsShutdown())
+   if (!engine || engine->IsTerminating())
       return 0;
    THttpServer *serv = engine->GetServer();
    if (!serv)

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -60,7 +60,7 @@ int websocket_connect_handler(const struct mg_connection *conn, void *)
       return 1;
 
    TCivetweb *engine = (TCivetweb *)request_info->user_data;
-   if (engine == 0)
+   if ((engine == 0) || engine->IsShutdown())
       return 1;
    THttpServer *serv = engine->GetServer();
    if (serv == 0)
@@ -84,7 +84,7 @@ void websocket_ready_handler(struct mg_connection *conn, void *)
    const struct mg_request_info *request_info = mg_get_request_info(conn);
 
    TCivetweb *engine = (TCivetweb *)request_info->user_data;
-   if (engine == 0)
+   if ((engine == 0) || engine->IsShutdown())
       return;
    THttpServer *serv = engine->GetServer();
    if (serv == 0)
@@ -112,7 +112,7 @@ int websocket_data_handler(struct mg_connection *conn, int, char *data, size_t l
       return 1;
 
    TCivetweb *engine = (TCivetweb *)request_info->user_data;
-   if (engine == 0)
+   if ((engine == 0) || engine->IsShutdown())
       return 1;
    THttpServer *serv = engine->GetServer();
    if (serv == 0)
@@ -142,7 +142,7 @@ void websocket_close_handler(const struct mg_connection *conn, void *)
    const struct mg_request_info *request_info = mg_get_request_info(conn);
 
    TCivetweb *engine = (TCivetweb *)request_info->user_data;
-   if (engine == 0)
+   if ((engine == 0) || engine->IsShutdown())
       return;
    THttpServer *serv = engine->GetServer();
    if (serv == 0)
@@ -182,7 +182,7 @@ static int begin_request_handler(struct mg_connection *conn, void *)
    const struct mg_request_info *request_info = mg_get_request_info(conn);
 
    TCivetweb *engine = (TCivetweb *)request_info->user_data;
-   if (engine == 0)
+   if ((engine == 0) || engine->IsShutdown())
       return 0;
    THttpServer *serv = engine->GetServer();
    if (serv == 0)
@@ -352,7 +352,8 @@ ClassImp(TCivetweb);
 /// constructor
 
 TCivetweb::TCivetweb()
-   : THttpEngine("civetweb", "compact embedded http server"), fCtx(0), fCallbacks(0), fTopName(), fDebug(kFALSE)
+   : THttpEngine("civetweb", "compact embedded http server"), fCtx(0), fCallbacks(0), fTopName(), fDebug(kFALSE),
+     fShutdown(kFALSE)
 {
 }
 
@@ -361,6 +362,7 @@ TCivetweb::TCivetweb()
 
 TCivetweb::~TCivetweb()
 {
+   fShutdown = kTRUE;
    if (fCtx != 0)
       mg_stop((struct mg_context *)fCtx);
    if (fCallbacks != 0)

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -42,7 +42,7 @@ public:
 
    virtual UInt_t GetId() const { return TString::Hash((void *)fWSconn, sizeof(void *)); }
 
-   virtual void ClearHandle() { fWSconn = 0; }
+   virtual void ClearHandle() { fWSconn = nullptr; }
 
    virtual void Send(const void *buf, int len)
    {
@@ -56,14 +56,14 @@ public:
 int websocket_connect_handler(const struct mg_connection *conn, void *)
 {
    const struct mg_request_info *request_info = mg_get_request_info(conn);
-   if (request_info == 0)
+   if (!request_info)
       return 1;
 
    TCivetweb *engine = (TCivetweb *)request_info->user_data;
-   if ((engine == 0) || engine->IsShutdown())
+   if (!engine || engine->IsShutdown())
       return 1;
    THttpServer *serv = engine->GetServer();
-   if (serv == 0)
+   if (!serv)
       return 1;
 
    THttpCallArg arg;
@@ -84,10 +84,10 @@ void websocket_ready_handler(struct mg_connection *conn, void *)
    const struct mg_request_info *request_info = mg_get_request_info(conn);
 
    TCivetweb *engine = (TCivetweb *)request_info->user_data;
-   if ((engine == 0) || engine->IsShutdown())
+   if (!engine || engine->IsShutdown())
       return;
    THttpServer *serv = engine->GetServer();
-   if (serv == 0)
+   if (!serv)
       return;
 
    THttpCallArg arg;
@@ -112,10 +112,10 @@ int websocket_data_handler(struct mg_connection *conn, int, char *data, size_t l
       return 1;
 
    TCivetweb *engine = (TCivetweb *)request_info->user_data;
-   if ((engine == 0) || engine->IsShutdown())
+   if (!engine || engine->IsShutdown())
       return 1;
    THttpServer *serv = engine->GetServer();
-   if (serv == 0)
+   if (!serv)
       return 1;
 
    // seems to be, appears when connection is broken
@@ -142,10 +142,10 @@ void websocket_close_handler(const struct mg_connection *conn, void *)
    const struct mg_request_info *request_info = mg_get_request_info(conn);
 
    TCivetweb *engine = (TCivetweb *)request_info->user_data;
-   if ((engine == 0) || engine->IsShutdown())
+   if (!engine || engine->IsShutdown())
       return;
    THttpServer *serv = engine->GetServer();
-   if (serv == 0)
+   if (!serv)
       return;
 
    THttpCallArg arg;
@@ -182,10 +182,10 @@ static int begin_request_handler(struct mg_connection *conn, void *)
    const struct mg_request_info *request_info = mg_get_request_info(conn);
 
    TCivetweb *engine = (TCivetweb *)request_info->user_data;
-   if ((engine == 0) || engine->IsShutdown())
+   if (!engine || engine->IsShutdown())
       return 0;
    THttpServer *serv = engine->GetServer();
-   if (serv == 0)
+   if (!serv)
       return 0;
 
    THttpCallArg arg;
@@ -352,8 +352,8 @@ ClassImp(TCivetweb);
 /// constructor
 
 TCivetweb::TCivetweb()
-   : THttpEngine("civetweb", "compact embedded http server"), fCtx(0), fCallbacks(0), fTopName(), fDebug(kFALSE),
-     fShutdown(kFALSE)
+   : THttpEngine("civetweb", "compact embedded http server"), fCtx(nullptr), fCallbacks(nullptr), fTopName(),
+     fDebug(kFALSE), fShutdown(kFALSE)
 {
 }
 
@@ -363,12 +363,12 @@ TCivetweb::TCivetweb()
 TCivetweb::~TCivetweb()
 {
    fShutdown = kTRUE;
-   if (fCtx != 0)
+   if (fCtx)
       mg_stop((struct mg_context *)fCtx);
-   if (fCallbacks != 0)
+   if (fCallbacks)
       free(fCallbacks);
-   fCtx = 0;
-   fCallbacks = 0;
+   fCtx = nullptr;
+   fCallbacks = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -499,7 +499,7 @@ Bool_t TCivetweb::Create(const char *args)
    // Start the web server.
    fCtx = mg_start((struct mg_callbacks *)fCallbacks, this, options);
 
-   if (fCtx == 0)
+   if (!fCtx)
       return kFALSE;
 
    mg_set_request_handler((struct mg_context *)fCtx, "/", begin_request_handler, 0);

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -353,7 +353,7 @@ ClassImp(TCivetweb);
 
 TCivetweb::TCivetweb()
    : THttpEngine("civetweb", "compact embedded http server"), fCtx(nullptr), fCallbacks(nullptr), fTopName(),
-     fDebug(kFALSE), fShutdown(kFALSE)
+     fDebug(kFALSE), fTerminating(kFALSE)
 {
 }
 
@@ -362,7 +362,7 @@ TCivetweb::TCivetweb()
 
 TCivetweb::~TCivetweb()
 {
-   fShutdown = kTRUE;
+   fTerminating = kTRUE;
    if (fCtx)
       mg_stop((struct mg_context *)fCtx);
    if (fCallbacks)

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -367,8 +367,6 @@ TCivetweb::~TCivetweb()
       mg_stop((struct mg_context *)fCtx);
    if (fCallbacks)
       free(fCallbacks);
-   fCtx = nullptr;
-   fCallbacks = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/net/http/src/THttpEngine.cxx
+++ b/net/http/src/THttpEngine.cxx
@@ -27,7 +27,7 @@ ClassImp(THttpEngine);
 /// normal constructor
 
 THttpEngine::THttpEngine(const char *name, const char *title)
-   : TNamed(name, title), fServer(0)
+   : TNamed(name, title), fServer(nullptr)
 {
 }
 
@@ -36,5 +36,5 @@ THttpEngine::THttpEngine(const char *name, const char *title)
 
 THttpEngine::~THttpEngine()
 {
-   fServer = 0;
+   fServer = nullptr;
 }

--- a/net/http/src/THttpEngine.cxx
+++ b/net/http/src/THttpEngine.cxx
@@ -26,15 +26,6 @@ ClassImp(THttpEngine);
 ////////////////////////////////////////////////////////////////////////////////
 /// normal constructor
 
-THttpEngine::THttpEngine(const char *name, const char *title)
-   : TNamed(name, title), fServer(nullptr)
+THttpEngine::THttpEngine(const char *name, const char *title) : TNamed(name, title), fServer(nullptr)
 {
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// destructor
-
-THttpEngine::~THttpEngine()
-{
-   fServer = nullptr;
 }

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -86,18 +86,15 @@ public:
    /// constructor
    TLongPollEngine(const char *name, const char *title) : THttpWSEngine(name, title), fPoll(nullptr), fBuf() {}
 
-   /// destructor
-   virtual ~TLongPollEngine() {}
-
    /// returns ID of the engine, created from this pointer
-   virtual UInt_t GetId() const
+   virtual UInt_t GetId() const override
    {
       const void *ptr = (const void *)this;
       return TString::Hash((void *)&ptr, sizeof(void *));
    }
 
    /// clear request, waiting for next portion of data
-   virtual void ClearHandle()
+   virtual void ClearHandle() override
    {
       if (fPoll) {
          fPoll->Set404();
@@ -107,14 +104,14 @@ public:
    }
 
    /// Send binary data via connection - not supported
-   virtual void Send(const void * /*buf*/, int /*len*/)
+   virtual void Send(const void * /*buf*/, int /*len*/) override
    {
       Error("TLongPollEngine::Send", "Should never be called, only text is supported");
    }
 
    /// Send const char data
    /// Either do it immediately or keep in internal buffer
-   virtual void SendCharStar(const char *buf)
+   virtual void SendCharStar(const char *buf) override
    {
       if (fPoll) {
          fPoll->SetContentType("text/plain");

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -56,10 +56,7 @@ public:
 
    /// timeout handler
    /// used to process http requests in main ROOT thread
-   virtual void Timeout()
-   {
-      fServer.ProcessRequests();
-   }
+   virtual void Timeout() { fServer.ProcessRequests(); }
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -49,20 +49,16 @@
 
 class THttpTimer : public TTimer {
 public:
-   THttpServer *fServer; ///!< server processing requests
+   THttpServer &fServer; ///!< server processing requests
 
    /// constructor
-   THttpTimer(Long_t milliSec, Bool_t mode, THttpServer *serv) : TTimer(milliSec, mode), fServer(serv) {}
-
-   /// destructor
-   virtual ~THttpTimer() { fServer = nullptr; }
+   THttpTimer(Long_t milliSec, Bool_t mode, THttpServer &serv) : TTimer(milliSec, mode), fServer(serv) {}
 
    /// timeout handler
    /// used to process http requests in main ROOT thread
    virtual void Timeout()
    {
-      if (fServer)
-         fServer->ProcessRequests();
+      fServer.ProcessRequests();
    }
 };
 
@@ -499,7 +495,7 @@ void THttpServer::SetTimer(Long_t milliSec, Bool_t mode)
       fTimer = nullptr;
    }
    if (milliSec > 0) {
-      fTimer = new THttpTimer(milliSec, mode, this);
+      fTimer = new THttpTimer(milliSec, mode, *this);
       fTimer->TurnOn();
    }
 }

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -339,13 +339,7 @@ void THttpServer::SetSniffer(TRootSniffer *sniff)
 void THttpServer::SetTerminate()
 {
    fTerminated = kTRUE;
-
-   TIter iter(&fEngines);
-   THttpEngine *engine = 0;
-   while ((engine = (THttpEngine *)iter()) != 0)
-      engine->Terminate();
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// returns read-only mode
@@ -445,11 +439,11 @@ void THttpServer::SetDrawPage(const char *filename)
 
 Bool_t THttpServer::CreateEngine(const char *engine)
 {
-   if (engine == 0)
+   if (!engine)
       return kFALSE;
 
    const char *arg = strchr(engine, ':');
-   if (arg == 0)
+   if (!arg)
       return kFALSE;
 
    TString clname;
@@ -465,11 +459,11 @@ Bool_t THttpServer::CreateEngine(const char *engine)
 
    // ensure that required engine class exists before we try to create it
    TClass *engine_class = gROOT->LoadClass(clname.Data());
-   if (engine_class == 0)
+   if (!engine_class)
       return kFALSE;
 
    THttpEngine *eng = (THttpEngine *)engine_class->New();
-   if (eng == 0)
+   if (!eng)
       return kFALSE;
 
    eng->SetServer(this);
@@ -598,7 +592,8 @@ Bool_t THttpServer::IsFileRequested(const char *uri, TString &res) const
 
 Bool_t THttpServer::ExecuteHttp(THttpCallArg *arg)
 {
-   if (fTerminated) return kFALSE;
+   if (fTerminated)
+      return kFALSE;
 
    if ((fMainThrdId != 0) && (fMainThrdId == TThread::SelfId())) {
       // should not happen, but one could process requests directly without any signaling
@@ -629,7 +624,8 @@ Bool_t THttpServer::ExecuteHttp(THttpCallArg *arg)
 
 Bool_t THttpServer::SubmitHttp(THttpCallArg *arg, Bool_t can_run_immediately)
 {
-   if (fTerminated) return kFALSE;
+   if (fTerminated)
+      return kFALSE;
 
    if (can_run_immediately && (fMainThrdId != 0) && (fMainThrdId == TThread::SelfId())) {
       ProcessRequest(arg);
@@ -688,9 +684,12 @@ void THttpServer::ProcessRequests()
 
    // regularly call Process() method of engine to let perform actions in ROOT context
    TIter iter(&fEngines);
-   THttpEngine *engine = 0;
-   while ((engine = (THttpEngine *)iter()) != 0)
+   THttpEngine *engine = nullptr;
+   while ((engine = (THttpEngine *)iter()) != nullptr) {
+      if (fTerminated)
+         engine->Terminate();
       engine->Process();
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Solves two problem with websockets handling, especially when exiting ROOT interactive session.

At that moment normal event loop is no longer running, but closing websocket issues one more event, which requires to be proceed. 

Appears in new webgui, when widgets (canvas or fitpanel) runs in normal web browser, connecting via websocket.

