### PR TITLE
Workaround compilation problem with Intel Compiler.

### DIFF
--- a/interpreter/llvm/src/lib/IR/Attributes.cpp
+++ b/interpreter/llvm/src/lib/IR/Attributes.cpp
@@ -788,14 +788,12 @@ std::string AttributeSetNode::getAsString(bool InAttrGrp) const {
 // AttributeListImpl Definition
 //===----------------------------------------------------------------------===//
 
-/// Map from AttributeList index to the internal array index. Adding one works:
-///   FunctionIndex: ~0U -> 0
-///   ReturnIndex:    0  -> 1
-///   FirstArgIndex: 1.. -> 2..
+/// Map from AttributeList index to the internal array index. Adding one happens
+/// to work, but it relies on unsigned integer wrapping. MSVC warns about
+/// unsigned wrapping in constexpr functions, so write out the conditional. LLVM
+/// folds it to add anyway.
 static constexpr unsigned attrIdxToArrayIdx(unsigned Index) {
-  // MSVC warns about '~0U + 1' wrapping around when this is called on
-  // FunctionIndex, so cast to int first.
-  return static_cast<int>(Index) + 1;
+  return Index == AttributeList::FunctionIndex ? 0 : Index + 1;
 }
 
 AttributeListImpl::AttributeListImpl(LLVMContext &C,


### PR DESCRIPTION
Intel Compiler cannot compile this piece of code:

static constexpr unsigned attrIdxToArrayIdx(unsigned Index) {
  // MSVC warns about '~0U + 1' wrapping around when this is called on
  // FunctionIndex, so cast to int first.
  return static_cast<int>(Index) + 1;
}

int main(int, char**) {

  static_assert(attrIdxToArrayIdx(~0U) == 0U, "FOO");
  return 0;
}

The problem can be worked around by including the uncessary cast in an #ifdef
for MSVC, which is the only compiler that needs it.