### PR TITLE
Add numbered LinkDef headers to dependencies of Core module

### DIFF
--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -8,10 +8,11 @@ endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/res ${CMAKE_CURRENT_SOURCE_DIR}/../foundation/res)
 
-ROOT_GLOB_HEADERS(Base_dict_headers ${CMAKE_CURRENT_SOURCE_DIR}/inc/T*.h
+ROOT_GLOB_HEADERS(Base_dict_headers ${CMAKE_CURRENT_SOURCE_DIR}/inc/LinkDef?.h
+                                    ${CMAKE_CURRENT_SOURCE_DIR}/inc/T*.h
                                     ${CMAKE_CURRENT_SOURCE_DIR}/inc/GuiTypes.h
                                     ${CMAKE_CURRENT_SOURCE_DIR}/inc/MessageTypes.h
-                                    ${CMAKE_CURRENT_SOURCE_DIR}/inc/KeySymbols.h 
+                                    ${CMAKE_CURRENT_SOURCE_DIR}/inc/KeySymbols.h
                                     ${CMAKE_CURRENT_SOURCE_DIR}/inc/Buttons.h)
 if(root7)
     set(root7src v7/src/*.cxx)


### PR DESCRIPTION
Without this dependency, a change to one of `LinkDef{1,2,3}.h` will
not trigger the regeneration of the `G__Core.cxx` dictionary, since
only the main `LinkDef.h` header was explicily listed.