### PR TITLE
Fix misnamed variable in RooRandomizeParamMCSModule

### DIFF
--- a/roofit/roofitcore/src/RooRandomizeParamMCSModule.cxx
+++ b/roofit/roofitcore/src/RooRandomizeParamMCSModule.cxx
@@ -264,13 +264,13 @@ Bool_t RooRandomizeParamMCSModule::initializeInstance()
   
   // Loop over all gaussian smearing parameters
   std::list<UniParam>::iterator giter ;
-  for (giter= _unifParams.begin() ; giter!= _unifParams.end() ; ++giter) {
+  for (giter= _gausParams.begin() ; giter!= _gausParams.end() ; ++giter) {
 
     // Check that listed variable is actual generator model parameter
     RooRealVar* actualPar = static_cast<RooRealVar*>(genParams()->find(giter->_param->GetName())) ;
     if (!actualPar) {
       oocoutW((TObject*)0,InputArguments) << "RooRandomizeParamMCSModule::initializeInstance: variable " << giter->_param->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;
-      giter = _unifParams.erase(giter) ;
+      giter = _gausParams.erase(giter) ;
       continue ;
     }
     giter->_param = actualPar ;

--- a/roofit/roofitcore/src/RooRandomizeParamMCSModule.cxx
+++ b/roofit/roofitcore/src/RooRandomizeParamMCSModule.cxx
@@ -263,7 +263,7 @@ Bool_t RooRandomizeParamMCSModule::initializeInstance()
   }
   
   // Loop over all gaussian smearing parameters
-  std::list<UniParam>::iterator giter ;
+  std::list<GausParam>::iterator giter ;
   for (giter= _gausParams.begin() ; giter!= _gausParams.end() ; ++giter) {
 
     // Check that listed variable is actual generator model parameter


### PR DESCRIPTION
`RooRandomizeParamMCSModule::sampleGaussian` results in a segfault as the corresponding `_gen` parameter is never set up.

This PR is untested so there may be additional issues.