### PR TITLE
Fix ROOT-9117: "TDF: Reports on Filters booked after the first event loop do not re-trigger the event loop"

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -1523,7 +1523,9 @@ public:
          return;
 
       auto df = GetDataFrameChecked();
-      if (!df->HasRunAtLeastOnce())
+      // TODO: we could do better and check if the Report was asked for Filters that have already run
+      // and in that case skip the event-loop
+      if (df->MustRunNamedFilters())
          df->Run();
       fProxiedPtr->Report();
    }

--- a/tree/treeplayer/inc/ROOT/TDFNodes.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFNodes.hxx
@@ -600,7 +600,13 @@ public:
    }
    virtual void TriggerChildrenCount() = 0;
    unsigned int GetNSlots() const { return fNSlots; }
-   virtual void ResetReportCount() = 0;
+   void ResetReportCount()
+   {
+      assert(!fName.empty()); // this method is to only be called on named filters
+      // fAccepted and fRejected could be different than 0 if this is not the first event-loop run using this filter
+      std::fill(fAccepted.begin(), fAccepted.end(), 0);
+      std::fill(fRejected.begin(), fRejected.end(), 0);
+   }
    virtual void ClearValueReaders(unsigned int slot) = 0;
 };
 
@@ -684,14 +690,6 @@ public:
    {
       assert(!fName.empty()); // this method is to only be called on named filters
       fPrevData.IncrChildrenCount();
-   }
-
-   void ResetReportCount() final
-   {
-      assert(!fName.empty()); // this method is to only be called on named filters
-      // fAccepted and fRejected could be different than 0 if this is not the first event-loop run using this filter
-      std::fill(fAccepted.begin(), fAccepted.end(), 0);
-      std::fill(fRejected.begin(), fRejected.end(), 0);
    }
 
    virtual void ClearValueReaders(unsigned int slot) final { ResetTDFValueTuple(fValues[slot], TypeInd_t()); }

--- a/tree/treeplayer/inc/ROOT/TDFNodes.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFNodes.hxx
@@ -136,7 +136,7 @@ class TLoopManager : public std::enable_shared_from_this<TLoopManager> {
    const ColumnNames_t fDefaultColumns;
    const ULong64_t fNEmptyEntries{0};
    const unsigned int fNSlots{1};
-   bool fHasRunAtLeastOnce{false};
+   bool fMustRunNamedFilters{true};
    unsigned int fNChildren{0};      ///< Number of nodes of the functional graph hanging from this object
    unsigned int fNStopsReceived{0}; ///< Number of times that a children node signaled to stop processing entries.
    const ELoopType fLoopType; ///< The kind of event loop that is going to be run (e.g. on ROOT files, on no files)
@@ -186,7 +186,7 @@ public:
    void Book(const RangeBasePtr_t &rangePtr);
    bool CheckFilters(int, unsigned int);
    unsigned int GetNSlots() const { return fNSlots; }
-   bool HasRunAtLeastOnce() const { return fHasRunAtLeastOnce; }
+   bool MustRunNamedFilters() const { return fMustRunNamedFilters; }
    void Report() const;
    /// End of recursive chain of calls, does nothing
    void PartialReport() const {}

--- a/tree/treeplayer/src/TDFNodes.cxx
+++ b/tree/treeplayer/src/TDFNodes.cxx
@@ -311,7 +311,7 @@ void TLoopManager::InitNodes()
 /// Perform clean-up operations. To be called at the end of each event loop.
 void TLoopManager::CleanUpNodes()
 {
-   fHasRunAtLeastOnce = true;
+   fMustRunNamedFilters = false;
 
    // forget TActions and detach TResultProxies
    fBookedActions.clear();
@@ -421,6 +421,7 @@ void TLoopManager::Book(const FilterBasePtr_t &filterPtr)
    fBookedFilters.emplace_back(filterPtr);
    if (filterPtr->HasName()) {
       fBookedNamedFilters.emplace_back(filterPtr);
+      fMustRunNamedFilters = true;
    }
 }
 


### PR DESCRIPTION
Backport of #1377 