### PR TITLE
Re-enable sub-directory support in TXMLFile

### DIFF
--- a/io/sql/inc/TBufferSQL2.h
+++ b/io/sql/inc/TBufferSQL2.h
@@ -1,7 +1,6 @@
 // @(#)root/sql
 // Author: Sergey Linev  20/11/2005
 
-
 #ifndef ROOT_TBufferSQL2
 #define ROOT_TBufferSQL2
 
@@ -29,282 +28,289 @@ class TSQLClassInfo;
 
 class TBufferSQL2 : public TBufferFile {
 
-friend class TSQLStructure;
+   friend class TSQLStructure;
 
 protected:
-
-   TSQLFile*        fSQL;                  ///<!   instance of TSQLFile
-   TSQLStructure*   fStructure;            ///<!   structures, created by object storing
-   TSQLStructure*   fStk;                  ///<!   pointer on current active structure (stack head)
-   TExMap*          fObjMap;               ///<!   Map between stored objects and object id
-   TString          fReadBuffer;           ///<!   Buffer for read value
-   Int_t            fErrorFlag;            ///<!   Error id value
-   Bool_t           fExpectedChain;        ///<!   flag to resolve situation when several elements of same basic type stored as FastArray
-   Int_t            fCompressLevel;        ///<!   compress level used to minimize size of data in database
-   Int_t            fReadVersionBuffer;    ///<!   buffer, used to by ReadVersion method
-   Long64_t         fObjIdCounter;         ///<!   counter of objects id
-   Bool_t           fIgnoreVerification;   ///<!   ignore verification of names
-   TSQLObjectData*  fCurrentData;          ///<!
-   TObjArray*       fObjectsInfos;         ///<!   array of objects info for selected key
-   Long64_t         fFirstObjId;           ///<!   id of first object to be read from the database
-   Long64_t         fLastObjId;            ///<!   id of last object correspond to this key
-   TMap*            fPoolsMap;             ///<!   map of pools with data from different tables
+   TSQLFile *fSQL;            ///<!   instance of TSQLFile
+   TSQLStructure *fStructure; ///<!   structures, created by object storing
+   TSQLStructure *fStk;       ///<!   pointer on current active structure (stack head)
+   TExMap *fObjMap;           ///<!   Map between stored objects and object id
+   TString fReadBuffer;       ///<!   Buffer for read value
+   Int_t fErrorFlag;          ///<!   Error id value
+   Bool_t fExpectedChain; ///<!   flag to resolve situation when several elements of same basic type stored as FastArray
+   Int_t fCompressLevel;  ///<!   compress level used to minimize size of data in database
+   Int_t fReadVersionBuffer;     ///<!   buffer, used to by ReadVersion method
+   Long64_t fObjIdCounter;       ///<!   counter of objects id
+   Bool_t fIgnoreVerification;   ///<!   ignore verification of names
+   TSQLObjectData *fCurrentData; ///<!
+   TObjArray *fObjectsInfos;     ///<!   array of objects info for selected key
+   Long64_t fFirstObjId;         ///<!   id of first object to be read from the database
+   Long64_t fLastObjId;          ///<!   id of last object correspond to this key
+   TMap *fPoolsMap;              ///<!   map of pools with data from different tables
 
    // TBufferSQL2 objects cannot be copied or assigned
-   TBufferSQL2(const TBufferSQL2 &);       // not implemented
-   void operator=(const TBufferSQL2 &);    // not implemented
+   TBufferSQL2(const TBufferSQL2 &);    // not implemented
+   void operator=(const TBufferSQL2 &); // not implemented
 
    TBufferSQL2();
 
    // redefined protected virtual functions
 
-   virtual void     WriteObjectClass(const void *actualObjStart, const TClass *actualClass);
+   virtual void WriteObjectClass(const void *actualObjStart, const TClass *actualClass);
 
    // end redefined protected virtual functions
 
-   TSQLStructure*   PushStack();
-   TSQLStructure*   PopStack();
-   TSQLStructure*   Stack(Int_t depth = 0);
+   TSQLStructure *PushStack();
+   TSQLStructure *PopStack();
+   TSQLStructure *Stack(Int_t depth = 0);
 
-   void             WorkWithClass(const char* classname, Version_t classversion);
-   void             WorkWithElement(TStreamerElement* elem, Int_t comp_type);
+   void WorkWithClass(const char *classname, Version_t classversion);
+   void WorkWithElement(TStreamerElement *elem, Int_t comp_type);
 
-   Int_t            SqlReadArraySize();
-   Bool_t           SqlObjectInfo(Long64_t objid, TString& clname, Version_t& version);
-   TSQLObjectData*  SqlObjectData(Long64_t objid, TSQLClassInfo* sqlinfo);
+   Int_t SqlReadArraySize();
+   Bool_t SqlObjectInfo(Long64_t objid, TString &clname, Version_t &version);
+   TSQLObjectData *SqlObjectData(Long64_t objid, TSQLClassInfo *sqlinfo);
 
-   Bool_t           SqlWriteBasic(Char_t value);
-   Bool_t           SqlWriteBasic(Short_t value);
-   Bool_t           SqlWriteBasic(Int_t value);
-   Bool_t           SqlWriteBasic(Long_t value);
-   Bool_t           SqlWriteBasic(Long64_t value);
-   Bool_t           SqlWriteBasic(Float_t value);
-   Bool_t           SqlWriteBasic(Double_t value);
-   Bool_t           SqlWriteBasic(Bool_t value);
-   Bool_t           SqlWriteBasic(UChar_t value);
-   Bool_t           SqlWriteBasic(UShort_t value);
-   Bool_t           SqlWriteBasic(UInt_t value);
-   Bool_t           SqlWriteBasic(ULong_t value);
-   Bool_t           SqlWriteBasic(ULong64_t value);
-   Bool_t           SqlWriteValue(const char* value, const char* tname);
+   Bool_t SqlWriteBasic(Char_t value);
+   Bool_t SqlWriteBasic(Short_t value);
+   Bool_t SqlWriteBasic(Int_t value);
+   Bool_t SqlWriteBasic(Long_t value);
+   Bool_t SqlWriteBasic(Long64_t value);
+   Bool_t SqlWriteBasic(Float_t value);
+   Bool_t SqlWriteBasic(Double_t value);
+   Bool_t SqlWriteBasic(Bool_t value);
+   Bool_t SqlWriteBasic(UChar_t value);
+   Bool_t SqlWriteBasic(UShort_t value);
+   Bool_t SqlWriteBasic(UInt_t value);
+   Bool_t SqlWriteBasic(ULong_t value);
+   Bool_t SqlWriteBasic(ULong64_t value);
+   Bool_t SqlWriteValue(const char *value, const char *tname);
 
-   void             SqlReadBasic(Char_t& value);
-   void             SqlReadBasic(Short_t& value);
-   void             SqlReadBasic(Int_t& value);
-   void             SqlReadBasic(Long_t& value);
-   void             SqlReadBasic(Long64_t& value);
-   void             SqlReadBasic(Float_t& value);
-   void             SqlReadBasic(Double_t& value);
-   void             SqlReadBasic(Bool_t& value);
-   void             SqlReadBasic(UChar_t& value);
-   void             SqlReadBasic(UShort_t& value);
-   void             SqlReadBasic(UInt_t& value);
-   void             SqlReadBasic(ULong_t& value);
-   void             SqlReadBasic(ULong64_t& value);
-   const char*      SqlReadValue(const char* tname);
-   const char*      SqlReadCharStarValue();
+   void SqlReadBasic(Char_t &value);
+   void SqlReadBasic(Short_t &value);
+   void SqlReadBasic(Int_t &value);
+   void SqlReadBasic(Long_t &value);
+   void SqlReadBasic(Long64_t &value);
+   void SqlReadBasic(Float_t &value);
+   void SqlReadBasic(Double_t &value);
+   void SqlReadBasic(Bool_t &value);
+   void SqlReadBasic(UChar_t &value);
+   void SqlReadBasic(UShort_t &value);
+   void SqlReadBasic(UInt_t &value);
+   void SqlReadBasic(ULong_t &value);
+   void SqlReadBasic(ULong64_t &value);
+   const char *SqlReadValue(const char *tname);
+   const char *SqlReadCharStarValue();
 
-   Int_t            SqlWriteObject(const void* obj, const TClass* objClass, TMemberStreamer *streamer = 0, Int_t streamer_index = 0);
-   void*            SqlReadObject(void* obj, TClass** cl = 0, TMemberStreamer *streamer = 0, Int_t streamer_index = 0, const TClass *onFileClass=0);
-   void*            SqlReadObjectDirect(void* obj, TClass** cl, Long64_t objid, TMemberStreamer *streamer = 0, Int_t streamer_index = 0, const TClass *onFileClass = 0);
+   Int_t
+   SqlWriteObject(const void *obj, const TClass *objClass, TMemberStreamer *streamer = 0, Int_t streamer_index = 0);
+   void *SqlReadObject(void *obj, TClass **cl = 0, TMemberStreamer *streamer = 0, Int_t streamer_index = 0,
+                       const TClass *onFileClass = 0);
+   void *SqlReadObjectDirect(void *obj, TClass **cl, Long64_t objid, TMemberStreamer *streamer = 0,
+                             Int_t streamer_index = 0, const TClass *onFileClass = 0);
 
 public:
-
    TBufferSQL2(TBuffer::EMode mode);
-   TBufferSQL2(TBuffer::EMode mode, TSQLFile* file);
+   TBufferSQL2(TBuffer::EMode mode, TSQLFile *file);
    virtual ~TBufferSQL2();
 
-   void             SetCompressionLevel(int level) { fCompressLevel = level; }
+   void SetCompressionLevel(int level) { fCompressLevel = level; }
 
-   TSQLStructure*   GetStructure() const { return fStructure; }
+   TSQLStructure *GetStructure() const { return fStructure; }
 
-   Int_t            GetErrorFlag() const { return fErrorFlag; }
+   Int_t GetErrorFlag() const { return fErrorFlag; }
 
-   void             SetIgnoreVerification() { fIgnoreVerification = kTRUE; }
+   void SetIgnoreVerification() { fIgnoreVerification = kTRUE; }
 
-   TSQLStructure*   SqlWriteAny(const void* obj, const TClass* cl, Long64_t objid);
+   TSQLStructure *SqlWriteAny(const void *obj, const TClass *cl, Long64_t objid);
 
-   void*            SqlReadAny(Long64_t keyid, Long64_t objid, TClass** cl, void* obj = 0);
+   void *SqlReadAny(Long64_t keyid, Long64_t objid, TClass **cl, void *obj = 0);
 
    // suppress class writing/reading
 
-   virtual TClass*  ReadClass(const TClass* cl = 0, UInt_t* objTag = 0);
-   virtual void     WriteClass(const TClass* cl);
+   virtual TClass *ReadClass(const TClass *cl = 0, UInt_t *objTag = 0);
+   virtual void WriteClass(const TClass *cl);
 
    // redefined virtual functions of TBuffer
 
-   virtual Int_t    CheckByteCount(UInt_t startpos, UInt_t bcnt, const TClass *clss); // SL
-   virtual Int_t    CheckByteCount(UInt_t startpos, UInt_t bcnt, const char *classname); // SL
-   virtual void     SetByteCount(UInt_t cntpos, Bool_t packInVersion = kFALSE);  // SL
+   virtual Int_t CheckByteCount(UInt_t startpos, UInt_t bcnt, const TClass *clss);    // SL
+   virtual Int_t CheckByteCount(UInt_t startpos, UInt_t bcnt, const char *classname); // SL
+   virtual void SetByteCount(UInt_t cntpos, Bool_t packInVersion = kFALSE);           // SL
 
-   virtual void      SkipVersion(const TClass *cl = 0);
-   virtual Version_t ReadVersion(UInt_t *start = 0, UInt_t *bcnt = 0, const TClass *cl = 0);  // SL
-   virtual UInt_t    WriteVersion(const TClass *cl, Bool_t useBcnt = kFALSE);  // SL
+   virtual void SkipVersion(const TClass *cl = 0);
+   virtual Version_t ReadVersion(UInt_t *start = 0, UInt_t *bcnt = 0, const TClass *cl = 0); // SL
+   virtual UInt_t WriteVersion(const TClass *cl, Bool_t useBcnt = kFALSE);                   // SL
 
-   virtual void*    ReadObjectAny(const TClass* clCast);
-   virtual void     SkipObjectAny();
+   virtual void *ReadObjectAny(const TClass *clCast);
+   virtual void SkipObjectAny();
 
-   virtual void     IncrementLevel(TVirtualStreamerInfo*);
-   virtual void     SetStreamerElementNumber(TStreamerElement *elem, Int_t comp_type);
-   virtual void     DecrementLevel(TVirtualStreamerInfo*);
+   virtual void IncrementLevel(TVirtualStreamerInfo *);
+   virtual void SetStreamerElementNumber(TStreamerElement *elem, Int_t comp_type);
+   virtual void DecrementLevel(TVirtualStreamerInfo *);
 
-   virtual void     ClassBegin(const TClass*, Version_t = -1);
-   virtual void     ClassEnd(const TClass*);
-   virtual void     ClassMember(const char* name, const char* typeName = 0, Int_t arrsize1 = -1, Int_t arrsize2 = -1);
+   virtual void ClassBegin(const TClass *, Version_t = -1);
+   virtual void ClassEnd(const TClass *);
+   virtual void ClassMember(const char *name, const char *typeName = 0, Int_t arrsize1 = -1, Int_t arrsize2 = -1);
 
-   virtual void     WriteObject(const TObject *obj);
+   virtual void WriteObject(const TObject *obj);
 
-   virtual void     ReadFloat16 (Float_t *f, TStreamerElement *ele=0);
-   virtual void     WriteFloat16(Float_t *f, TStreamerElement *ele=0);
-   virtual void     ReadDouble32 (Double_t *d, TStreamerElement *ele=0);
-   virtual void     WriteDouble32(Double_t *d, TStreamerElement *ele=0);
-   virtual void     ReadWithFactor(Float_t *ptr, Double_t factor, Double_t minvalue);
-   virtual void     ReadWithNbits(Float_t *ptr, Int_t nbits);
-   virtual void     ReadWithFactor(Double_t *ptr, Double_t factor, Double_t minvalue);
-   virtual void     ReadWithNbits(Double_t *ptr, Int_t nbits);
+   virtual void ReadFloat16(Float_t *f, TStreamerElement *ele = 0);
+   virtual void WriteFloat16(Float_t *f, TStreamerElement *ele = 0);
+   virtual void ReadDouble32(Double_t *d, TStreamerElement *ele = 0);
+   virtual void WriteDouble32(Double_t *d, TStreamerElement *ele = 0);
+   virtual void ReadWithFactor(Float_t *ptr, Double_t factor, Double_t minvalue);
+   virtual void ReadWithNbits(Float_t *ptr, Int_t nbits);
+   virtual void ReadWithFactor(Double_t *ptr, Double_t factor, Double_t minvalue);
+   virtual void ReadWithNbits(Double_t *ptr, Int_t nbits);
 
-   virtual Int_t    ReadArray(Bool_t    *&b);
-   virtual Int_t    ReadArray(Char_t    *&c);
-   virtual Int_t    ReadArray(UChar_t   *&c);
-   virtual Int_t    ReadArray(Short_t   *&h);
-   virtual Int_t    ReadArray(UShort_t  *&h);
-   virtual Int_t    ReadArray(Int_t     *&i);
-   virtual Int_t    ReadArray(UInt_t    *&i);
-   virtual Int_t    ReadArray(Long_t    *&l);
-   virtual Int_t    ReadArray(ULong_t   *&l);
-   virtual Int_t    ReadArray(Long64_t  *&l);
-   virtual Int_t    ReadArray(ULong64_t *&l);
-   virtual Int_t    ReadArray(Float_t   *&f);
-   virtual Int_t    ReadArray(Double_t  *&d);
-   virtual Int_t    ReadArrayFloat16(Float_t  *&f, TStreamerElement *ele=0);
-   virtual Int_t    ReadArrayDouble32(Double_t  *&d, TStreamerElement *ele=0);
+   virtual Int_t ReadArray(Bool_t *&b);
+   virtual Int_t ReadArray(Char_t *&c);
+   virtual Int_t ReadArray(UChar_t *&c);
+   virtual Int_t ReadArray(Short_t *&h);
+   virtual Int_t ReadArray(UShort_t *&h);
+   virtual Int_t ReadArray(Int_t *&i);
+   virtual Int_t ReadArray(UInt_t *&i);
+   virtual Int_t ReadArray(Long_t *&l);
+   virtual Int_t ReadArray(ULong_t *&l);
+   virtual Int_t ReadArray(Long64_t *&l);
+   virtual Int_t ReadArray(ULong64_t *&l);
+   virtual Int_t ReadArray(Float_t *&f);
+   virtual Int_t ReadArray(Double_t *&d);
+   virtual Int_t ReadArrayFloat16(Float_t *&f, TStreamerElement *ele = 0);
+   virtual Int_t ReadArrayDouble32(Double_t *&d, TStreamerElement *ele = 0);
 
-   virtual Int_t    ReadStaticArray(Bool_t    *b);
-   virtual Int_t    ReadStaticArray(Char_t    *c);
-   virtual Int_t    ReadStaticArray(UChar_t   *c);
-   virtual Int_t    ReadStaticArray(Short_t   *h);
-   virtual Int_t    ReadStaticArray(UShort_t  *h);
-   virtual Int_t    ReadStaticArray(Int_t     *i);
-   virtual Int_t    ReadStaticArray(UInt_t    *i);
-   virtual Int_t    ReadStaticArray(Long_t    *l);
-   virtual Int_t    ReadStaticArray(ULong_t   *l);
-   virtual Int_t    ReadStaticArray(Long64_t  *l);
-   virtual Int_t    ReadStaticArray(ULong64_t *l);
-   virtual Int_t    ReadStaticArray(Float_t   *f);
-   virtual Int_t    ReadStaticArray(Double_t  *d);
-   virtual Int_t    ReadStaticArrayFloat16(Float_t  *f, TStreamerElement *ele=0);
-   virtual Int_t    ReadStaticArrayDouble32(Double_t  *d, TStreamerElement *ele=0);
+   virtual Int_t ReadStaticArray(Bool_t *b);
+   virtual Int_t ReadStaticArray(Char_t *c);
+   virtual Int_t ReadStaticArray(UChar_t *c);
+   virtual Int_t ReadStaticArray(Short_t *h);
+   virtual Int_t ReadStaticArray(UShort_t *h);
+   virtual Int_t ReadStaticArray(Int_t *i);
+   virtual Int_t ReadStaticArray(UInt_t *i);
+   virtual Int_t ReadStaticArray(Long_t *l);
+   virtual Int_t ReadStaticArray(ULong_t *l);
+   virtual Int_t ReadStaticArray(Long64_t *l);
+   virtual Int_t ReadStaticArray(ULong64_t *l);
+   virtual Int_t ReadStaticArray(Float_t *f);
+   virtual Int_t ReadStaticArray(Double_t *d);
+   virtual Int_t ReadStaticArrayFloat16(Float_t *f, TStreamerElement *ele = 0);
+   virtual Int_t ReadStaticArrayDouble32(Double_t *d, TStreamerElement *ele = 0);
 
-   virtual void     ReadFastArray(Bool_t    *b, Int_t n);
-   virtual void     ReadFastArray(Char_t    *c, Int_t n);
-   virtual void     ReadFastArray(UChar_t   *c, Int_t n);
-   virtual void     ReadFastArray(Short_t   *h, Int_t n);
-   virtual void     ReadFastArray(UShort_t  *h, Int_t n);
-   virtual void     ReadFastArray(Int_t     *i, Int_t n);
-   virtual void     ReadFastArray(UInt_t    *i, Int_t n);
-   virtual void     ReadFastArray(Long_t    *l, Int_t n);
-   virtual void     ReadFastArray(ULong_t   *l, Int_t n);
-   virtual void     ReadFastArray(Long64_t  *l, Int_t n);
-   virtual void     ReadFastArray(ULong64_t *l, Int_t n);
-   virtual void     ReadFastArray(Float_t   *f, Int_t n);
-   virtual void     ReadFastArray(Double_t  *d, Int_t n);
-   virtual void     ReadFastArrayFloat16(Float_t  *f, Int_t n, TStreamerElement *ele=0);
-   virtual void     ReadFastArrayDouble32(Double_t  *d, Int_t n, TStreamerElement *ele=0);
-   virtual void     ReadFastArrayWithFactor(Float_t *ptr, Int_t n, Double_t factor, Double_t minvalue) ;
-   virtual void     ReadFastArrayWithNbits(Float_t *ptr, Int_t n, Int_t nbits);
-   virtual void     ReadFastArrayWithFactor(Double_t *ptr, Int_t n, Double_t factor, Double_t minvalue);
-   virtual void     ReadFastArrayWithNbits(Double_t *ptr, Int_t n, Int_t nbits) ;
+   virtual void ReadFastArray(Bool_t *b, Int_t n);
+   virtual void ReadFastArray(Char_t *c, Int_t n);
+   virtual void ReadFastArray(UChar_t *c, Int_t n);
+   virtual void ReadFastArray(Short_t *h, Int_t n);
+   virtual void ReadFastArray(UShort_t *h, Int_t n);
+   virtual void ReadFastArray(Int_t *i, Int_t n);
+   virtual void ReadFastArray(UInt_t *i, Int_t n);
+   virtual void ReadFastArray(Long_t *l, Int_t n);
+   virtual void ReadFastArray(ULong_t *l, Int_t n);
+   virtual void ReadFastArray(Long64_t *l, Int_t n);
+   virtual void ReadFastArray(ULong64_t *l, Int_t n);
+   virtual void ReadFastArray(Float_t *f, Int_t n);
+   virtual void ReadFastArray(Double_t *d, Int_t n);
+   virtual void ReadFastArrayFloat16(Float_t *f, Int_t n, TStreamerElement *ele = 0);
+   virtual void ReadFastArrayDouble32(Double_t *d, Int_t n, TStreamerElement *ele = 0);
+   virtual void ReadFastArrayWithFactor(Float_t *ptr, Int_t n, Double_t factor, Double_t minvalue);
+   virtual void ReadFastArrayWithNbits(Float_t *ptr, Int_t n, Int_t nbits);
+   virtual void ReadFastArrayWithFactor(Double_t *ptr, Int_t n, Double_t factor, Double_t minvalue);
+   virtual void ReadFastArrayWithNbits(Double_t *ptr, Int_t n, Int_t nbits);
 
-   virtual void     WriteArray(const Bool_t    *b, Int_t n);
-   virtual void     WriteArray(const Char_t    *c, Int_t n);
-   virtual void     WriteArray(const UChar_t   *c, Int_t n);
-   virtual void     WriteArray(const Short_t   *h, Int_t n);
-   virtual void     WriteArray(const UShort_t  *h, Int_t n);
-   virtual void     WriteArray(const Int_t     *i, Int_t n);
-   virtual void     WriteArray(const UInt_t    *i, Int_t n);
-   virtual void     WriteArray(const Long_t    *l, Int_t n);
-   virtual void     WriteArray(const ULong_t   *l, Int_t n);
-   virtual void     WriteArray(const Long64_t  *l, Int_t n);
-   virtual void     WriteArray(const ULong64_t *l, Int_t n);
-   virtual void     WriteArray(const Float_t   *f, Int_t n);
-   virtual void     WriteArray(const Double_t  *d, Int_t n);
-   virtual void     WriteArrayFloat16(const Float_t  *f, Int_t n, TStreamerElement *ele=0);
-   virtual void     WriteArrayDouble32(const Double_t  *d, Int_t n, TStreamerElement *ele=0);
-   virtual void     ReadFastArray(void  *start , const TClass *cl, Int_t n=1, TMemberStreamer *s=0, const TClass *onFileClass=0 );
-   virtual void     ReadFastArray(void **startp, const TClass *cl, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s=0, const TClass *onFileClass=0);
+   virtual void WriteArray(const Bool_t *b, Int_t n);
+   virtual void WriteArray(const Char_t *c, Int_t n);
+   virtual void WriteArray(const UChar_t *c, Int_t n);
+   virtual void WriteArray(const Short_t *h, Int_t n);
+   virtual void WriteArray(const UShort_t *h, Int_t n);
+   virtual void WriteArray(const Int_t *i, Int_t n);
+   virtual void WriteArray(const UInt_t *i, Int_t n);
+   virtual void WriteArray(const Long_t *l, Int_t n);
+   virtual void WriteArray(const ULong_t *l, Int_t n);
+   virtual void WriteArray(const Long64_t *l, Int_t n);
+   virtual void WriteArray(const ULong64_t *l, Int_t n);
+   virtual void WriteArray(const Float_t *f, Int_t n);
+   virtual void WriteArray(const Double_t *d, Int_t n);
+   virtual void WriteArrayFloat16(const Float_t *f, Int_t n, TStreamerElement *ele = 0);
+   virtual void WriteArrayDouble32(const Double_t *d, Int_t n, TStreamerElement *ele = 0);
+   virtual void
+   ReadFastArray(void *start, const TClass *cl, Int_t n = 1, TMemberStreamer *s = 0, const TClass *onFileClass = 0);
+   virtual void ReadFastArray(void **startp, const TClass *cl, Int_t n = 1, Bool_t isPreAlloc = kFALSE,
+                              TMemberStreamer *s = 0, const TClass *onFileClass = 0);
 
-   virtual void     WriteFastArray(const Bool_t    *b, Int_t n);
-   virtual void     WriteFastArray(const Char_t    *c, Int_t n);
-   virtual void     WriteFastArray(const UChar_t   *c, Int_t n);
-   virtual void     WriteFastArray(const Short_t   *h, Int_t n);
-   virtual void     WriteFastArray(const UShort_t  *h, Int_t n);
-   virtual void     WriteFastArray(const Int_t     *i, Int_t n);
-   virtual void     WriteFastArray(const UInt_t    *i, Int_t n);
-   virtual void     WriteFastArray(const Long_t    *l, Int_t n);
-   virtual void     WriteFastArray(const ULong_t   *l, Int_t n);
-   virtual void     WriteFastArray(const Long64_t  *l, Int_t n);
-   virtual void     WriteFastArray(const ULong64_t *l, Int_t n);
-   virtual void     WriteFastArray(const Float_t   *f, Int_t n);
-   virtual void     WriteFastArray(const Double_t  *d, Int_t n);
-   virtual void     WriteFastArrayFloat16(const Float_t  *f, Int_t n, TStreamerElement *ele=0);
-   virtual void     WriteFastArrayDouble32(const Double_t  *d, Int_t n, TStreamerElement *ele=0);
-   virtual void     WriteFastArray(void  *start,  const TClass *cl, Int_t n=1, TMemberStreamer *s=0);
-   virtual Int_t    WriteFastArray(void **startp, const TClass *cl, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s=0);
+   virtual void WriteFastArray(const Bool_t *b, Int_t n);
+   virtual void WriteFastArray(const Char_t *c, Int_t n);
+   virtual void WriteFastArray(const UChar_t *c, Int_t n);
+   virtual void WriteFastArray(const Short_t *h, Int_t n);
+   virtual void WriteFastArray(const UShort_t *h, Int_t n);
+   virtual void WriteFastArray(const Int_t *i, Int_t n);
+   virtual void WriteFastArray(const UInt_t *i, Int_t n);
+   virtual void WriteFastArray(const Long_t *l, Int_t n);
+   virtual void WriteFastArray(const ULong_t *l, Int_t n);
+   virtual void WriteFastArray(const Long64_t *l, Int_t n);
+   virtual void WriteFastArray(const ULong64_t *l, Int_t n);
+   virtual void WriteFastArray(const Float_t *f, Int_t n);
+   virtual void WriteFastArray(const Double_t *d, Int_t n);
+   virtual void WriteFastArrayFloat16(const Float_t *f, Int_t n, TStreamerElement *ele = 0);
+   virtual void WriteFastArrayDouble32(const Double_t *d, Int_t n, TStreamerElement *ele = 0);
+   virtual void WriteFastArray(void *start, const TClass *cl, Int_t n = 1, TMemberStreamer *s = 0);
+   virtual Int_t
+   WriteFastArray(void **startp, const TClass *cl, Int_t n = 1, Bool_t isPreAlloc = kFALSE, TMemberStreamer *s = 0);
 
-   virtual void     StreamObject(void *obj, const std::type_info &typeinfo, const TClass* onFileClass = 0);
-   virtual void     StreamObject(void *obj, const char *className, const TClass* onFileClass = 0 );
-   virtual void     StreamObject(void *obj, const TClass *cl, const TClass* onFileClass = 0 );
-   virtual void     StreamObject(TObject *obj);
-   virtual void     StreamObject(void *obj, TMemberStreamer *streamer, const TClass *cl, Int_t n = 0, const TClass *onFileClass = 0);
+   virtual void StreamObject(void *obj, const std::type_info &typeinfo, const TClass *onFileClass = 0);
+   virtual void StreamObject(void *obj, const char *className, const TClass *onFileClass = 0);
+   virtual void StreamObject(void *obj, const TClass *cl, const TClass *onFileClass = 0);
+   virtual void StreamObject(TObject *obj);
+   virtual void
+   StreamObject(void *obj, TMemberStreamer *streamer, const TClass *cl, Int_t n = 0, const TClass *onFileClass = 0);
 
-   virtual   void     ReadBool(Bool_t       &b);
-   virtual   void     ReadChar(Char_t       &c);
-   virtual   void     ReadUChar(UChar_t     &c);
-   virtual   void     ReadShort(Short_t     &s);
-   virtual   void     ReadUShort(UShort_t   &s);
-   virtual   void     ReadInt(Int_t         &i);
-   virtual   void     ReadUInt(UInt_t       &i);
-   virtual   void     ReadLong(Long_t       &l);
-   virtual   void     ReadULong(ULong_t     &l);
-   virtual   void     ReadLong64(Long64_t   &l);
-   virtual   void     ReadULong64(ULong64_t &l);
-   virtual   void     ReadFloat(Float_t     &f);
-   virtual   void     ReadDouble(Double_t   &d);
-   virtual   void     ReadCharP(Char_t      *c);
-   virtual   void     ReadTString(TString   &s);
-   virtual   void     ReadStdString(std::string *s);
-   using              TBuffer::ReadStdString;
-   virtual   void     ReadCharStar(char* &s);
+   virtual void ReadBool(Bool_t &b);
+   virtual void ReadChar(Char_t &c);
+   virtual void ReadUChar(UChar_t &c);
+   virtual void ReadShort(Short_t &s);
+   virtual void ReadUShort(UShort_t &s);
+   virtual void ReadInt(Int_t &i);
+   virtual void ReadUInt(UInt_t &i);
+   virtual void ReadLong(Long_t &l);
+   virtual void ReadULong(ULong_t &l);
+   virtual void ReadLong64(Long64_t &l);
+   virtual void ReadULong64(ULong64_t &l);
+   virtual void ReadFloat(Float_t &f);
+   virtual void ReadDouble(Double_t &d);
+   virtual void ReadCharP(Char_t *c);
+   virtual void ReadTString(TString &s);
+   virtual void ReadStdString(std::string *s);
+   using TBuffer::ReadStdString;
+   virtual void ReadCharStar(char *&s);
 
-   virtual   void     WriteBool(Bool_t       b);
-   virtual   void     WriteChar(Char_t       c);
-   virtual   void     WriteUChar(UChar_t     c);
-   virtual   void     WriteShort(Short_t     s);
-   virtual   void     WriteUShort(UShort_t   s);
-   virtual   void     WriteInt(Int_t         i);
-   virtual   void     WriteUInt(UInt_t       i);
-   virtual   void     WriteLong(Long_t       l);
-   virtual   void     WriteULong(ULong_t     l);
-   virtual   void     WriteLong64(Long64_t   l);
-   virtual   void     WriteULong64(ULong64_t l);
-   virtual   void     WriteFloat(Float_t     f);
-   virtual   void     WriteDouble(Double_t   d);
-   virtual   void     WriteCharP(const Char_t *c);
-   virtual   void     WriteTString(const TString  &s);
-   virtual   void     WriteStdString(const std::string *s);
-   using              TBuffer::WriteStdString;
-   virtual   void     WriteCharStar(char *s);
+   virtual void WriteBool(Bool_t b);
+   virtual void WriteChar(Char_t c);
+   virtual void WriteUChar(UChar_t c);
+   virtual void WriteShort(Short_t s);
+   virtual void WriteUShort(UShort_t s);
+   virtual void WriteInt(Int_t i);
+   virtual void WriteUInt(UInt_t i);
+   virtual void WriteLong(Long_t l);
+   virtual void WriteULong(ULong_t l);
+   virtual void WriteLong64(Long64_t l);
+   virtual void WriteULong64(ULong64_t l);
+   virtual void WriteFloat(Float_t f);
+   virtual void WriteDouble(Double_t d);
+   virtual void WriteCharP(const Char_t *c);
+   virtual void WriteTString(const TString &s);
+   virtual void WriteStdString(const std::string *s);
+   using TBuffer::WriteStdString;
+   virtual void WriteCharStar(char *s);
 
    virtual Int_t ApplySequence(const TStreamerInfoActions::TActionSequence &sequence, void *object);
-   virtual Int_t ApplySequenceVecPtr(const TStreamerInfoActions::TActionSequence &sequence, void *start_collection, void *end_collection);
-   virtual Int_t ApplySequence(const TStreamerInfoActions::TActionSequence &sequence, void *start_collection, void *end_collection);
+   virtual Int_t ApplySequenceVecPtr(const TStreamerInfoActions::TActionSequence &sequence, void *start_collection,
+                                     void *end_collection);
+   virtual Int_t
+   ApplySequence(const TStreamerInfoActions::TActionSequence &sequence, void *start_collection, void *end_collection);
 
-   static    void     SetFloatFormat(const char* fmt = "%e");
-   static const char* GetFloatFormat();
+   static void SetFloatFormat(const char *fmt = "%e");
+   static const char *GetFloatFormat();
 
    // end of redefined virtual functions
 
-   ClassDef(TBufferSQL2, 0);    //a specialized TBuffer to convert data to SQL statements or read data from SQL tables
+   ClassDef(TBufferSQL2, 0); // a specialized TBuffer to convert data to SQL statements or read data from SQL tables
 };
 
 #endif

--- a/io/sql/inc/TKeySQL.h
+++ b/io/sql/inc/TKeySQL.h
@@ -9,7 +9,6 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-
 #ifndef ROOT_TKeySQL
 #define ROOT_TKeySQL
 
@@ -20,53 +19,53 @@ class TSQLFile;
 class TKeySQL : public TKey {
 
 private:
-   TKeySQL(const TKeySQL&);            // TKeySQL objects are not copiable.
-   TKeySQL& operator=(const TKeySQL&); // TKeySQL objects are not copiable.
+   TKeySQL(const TKeySQL &);            // TKeySQL objects are not copiable.
+   TKeySQL &operator=(const TKeySQL &); // TKeySQL objects are not copiable.
 
 protected:
    TKeySQL();
 
-   virtual Int_t     Read(const char *name) { return TKey::Read(name); }
-   void              StoreKeyObject(const void* obj, const TClass* cl);
-   void*             ReadKeyObject(void* obj, const TClass* expectedClass);
+   virtual Int_t Read(const char *name) { return TKey::Read(name); }
+   void StoreKeyObject(const void *obj, const TClass *cl);
+   void *ReadKeyObject(void *obj, const TClass *expectedClass);
 
-   Long64_t          fKeyId;    ///<!  key identifier in KeysTables
-   Long64_t          fObjId;    ///<!  stored object identifer
+   Long64_t fKeyId; ///<!  key identifier in KeysTables
+   Long64_t fObjId; ///<!  stored object identifer
 
 public:
-   TKeySQL(TDirectory* mother, const TObject* obj, const char* name, const char* title = 0);
-   TKeySQL(TDirectory* mother, const void* obj, const TClass* cl, const char* name, const char* title = 0);
-   TKeySQL(TDirectory* mother, Long64_t keyid, Long64_t objid,
-           const char* name, const char* title,
-           const char* keydatetime, Int_t cycle, const char* classname);
+   TKeySQL(TDirectory *mother, const TObject *obj, const char *name, const char *title = 0);
+   TKeySQL(TDirectory *mother, const void *obj, const TClass *cl, const char *name, const char *title = 0);
+   TKeySQL(TDirectory *mother, Long64_t keyid, Long64_t objid, const char *name, const char *title,
+           const char *keydatetime, Int_t cycle, const char *classname);
    virtual ~TKeySQL();
 
-   Bool_t            IsKeyModified(const char* keyname, const char* keytitle, const char* keydatime, Int_t cycle, const char* classname);
+   Bool_t
+   IsKeyModified(const char *keyname, const char *keytitle, const char *keydatime, Int_t cycle, const char *classname);
 
-   Long64_t          GetDBKeyId() const { return fKeyId; }
-   Long64_t          GetDBObjId() const { return fObjId; }
-   Long64_t          GetDBDirId() const;
+   Long64_t GetDBKeyId() const { return fKeyId; }
+   Long64_t GetDBObjId() const { return fObjId; }
+   Long64_t GetDBDirId() const;
 
    // redefined TKey Methods
-   virtual void      Delete(Option_t *option="");
-   virtual void      DeleteBuffer() {}
-   virtual void      FillBuffer(char *&) {}
-   virtual char     *GetBuffer() const { return 0; }
-   virtual Long64_t  GetSeekKey() const  { return GetDBObjId() > 0 ? GetDBObjId() : 0; }
-   virtual Long64_t  GetSeekPdir() const { return GetDBDirId() > 0 ? GetDBDirId() : 0; }
-   virtual void      Keep() {}
+   virtual void Delete(Option_t *option = "");
+   virtual void DeleteBuffer() {}
+   virtual void FillBuffer(char *&) {}
+   virtual char *GetBuffer() const { return 0; }
+   virtual Long64_t GetSeekKey() const { return GetDBObjId() > 0 ? GetDBObjId() : 0; }
+   virtual Long64_t GetSeekPdir() const { return GetDBDirId() > 0 ? GetDBDirId() : 0; }
+   virtual void Keep() {}
 
-   virtual Int_t     Read(TObject* obj);
-   virtual TObject  *ReadObj();
-   virtual TObject  *ReadObjWithBuffer(char *bufferRead);
-   virtual void     *ReadObjectAny(const TClass *expectedClass);
+   virtual Int_t Read(TObject *obj);
+   virtual TObject *ReadObj();
+   virtual TObject *ReadObjWithBuffer(char *bufferRead);
+   virtual void *ReadObjectAny(const TClass *expectedClass);
 
-   virtual void      ReadBuffer(char *&) {}
-   virtual Bool_t    ReadFile() { return kTRUE; }
-   virtual void      SetBuffer() { fBuffer = 0; }
-   virtual Int_t     WriteFile(Int_t =1, TFile* = 0) { return 0; }
+   virtual void ReadBuffer(char *&) {}
+   virtual Bool_t ReadFile() { return kTRUE; }
+   virtual void SetBuffer() { fBuffer = 0; }
+   virtual Int_t WriteFile(Int_t = 1, TFile * = 0) { return 0; }
 
-   ClassDef(TKeySQL,1) // a special TKey for SQL data base
+   ClassDef(TKeySQL, 1) // a special TKey for SQL data base
 };
 
 #endif

--- a/io/sql/inc/TSQLClassInfo.h
+++ b/io/sql/inc/TSQLClassInfo.h
@@ -22,19 +22,17 @@ class TSQLClassColumnInfo : public TObject {
 
 public:
    TSQLClassColumnInfo();
-   TSQLClassColumnInfo(const char* name,
-                       const char* sqlname,
-                       const char* sqltype);
+   TSQLClassColumnInfo(const char *name, const char *sqlname, const char *sqltype);
    virtual ~TSQLClassColumnInfo();
 
-   virtual const char* GetName() const { return fName.Data(); }
-   const char* GetSQLName() const { return fSQLName.Data(); }
-   const char* GetSQLType() const { return fSQLType.Data(); }
+   virtual const char *GetName() const { return fName.Data(); }
+   const char *GetSQLName() const { return fSQLName.Data(); }
+   const char *GetSQLType() const { return fSQLType.Data(); }
 
 protected:
-   TString   fName;
-   TString   fSQLName;
-   TString   fSQLType;
+   TString fName;
+   TString fSQLName;
+   TString fSQLType;
 
    ClassDef(TSQLClassColumnInfo, 1); //  Keeps information about single column in class table
 };
@@ -44,42 +42,38 @@ protected:
 class TSQLClassInfo : public TObject {
 public:
    TSQLClassInfo();
-   TSQLClassInfo(Long64_t classid,
-                 const char* classname,
-                 Int_t version);
+   TSQLClassInfo(Long64_t classid, const char *classname, Int_t version);
    virtual ~TSQLClassInfo();
-
 
    Long64_t GetClassId() const { return fClassId; }
 
-   virtual const char* GetName() const { return fClassName.Data(); }
+   virtual const char *GetName() const { return fClassName.Data(); }
    Int_t GetClassVersion() const { return fClassVersion; }
 
-   void SetClassTableName(const char* name) { fClassTable = name; }
-   void SetRawTableName(const char* name) { fRawTable = name; }
+   void SetClassTableName(const char *name) { fClassTable = name; }
+   void SetRawTableName(const char *name) { fRawTable = name; }
 
-   const char* GetClassTableName() const { return fClassTable.Data(); }
-   const char* GetRawTableName() const { return fRawTable.Data(); }
+   const char *GetClassTableName() const { return fClassTable.Data(); }
+   const char *GetRawTableName() const { return fRawTable.Data(); }
 
-   void SetTableStatus(TObjArray* columns = 0, Bool_t israwtable = kFALSE);
-   void SetColumns(TObjArray* columns);
+   void SetTableStatus(TObjArray *columns = 0, Bool_t israwtable = kFALSE);
+   void SetColumns(TObjArray *columns);
    void SetRawExist(Bool_t on) { fRawtableExist = on; }
 
-   Bool_t IsClassTableExist() const { return GetColumns()!=0; }
+   Bool_t IsClassTableExist() const { return GetColumns() != 0; }
    Bool_t IsRawTableExist() const { return fRawtableExist; }
 
-   TObjArray* GetColumns() const { return fColumns; }
-   Int_t FindColumn(const char* name, Bool_t sqlname = kFALSE);
+   TObjArray *GetColumns() const { return fColumns; }
+   Int_t FindColumn(const char *name, Bool_t sqlname = kFALSE);
 
 protected:
-
-   TString    fClassName;            ///<! class name
-   Int_t      fClassVersion;         ///<! class version
-   Long64_t      fClassId;           ///<! sql class id
-   TString    fClassTable;           ///<! name of table with class data
-   TString    fRawTable;             ///<! name of table with raw data
-   TObjArray* fColumns;              ///<! name and type of columns - array of TNamed
-   Bool_t     fRawtableExist;        ///<! indicate that raw table is exist
+   TString fClassName;    ///<! class name
+   Int_t fClassVersion;   ///<! class version
+   Long64_t fClassId;     ///<! sql class id
+   TString fClassTable;   ///<! name of table with class data
+   TString fRawTable;     ///<! name of table with raw data
+   TObjArray *fColumns;   ///<! name and type of columns - array of TNamed
+   Bool_t fRawtableExist; ///<! indicate that raw table is exist
 
    ClassDef(TSQLClassInfo, 1); //  Keeps the table information relevant for one class
 };

--- a/io/sql/inc/TSQLFile.h
+++ b/io/sql/inc/TSQLFile.h
@@ -38,231 +38,220 @@ class TSQLFile : public TFile {
    friend class TSqlCmdsBuffer;
 
 protected:
-   enum ELockingKinds {
-       kLockFree  = 0,
-       kLockBusy  = 1
-   };
+   enum ELockingKinds { kLockFree = 0, kLockBusy = 1 };
 
    // Interface to basic system I/O routines, suppressed
-   virtual Int_t     SysOpen(const char*, Int_t, UInt_t) { return 0; }
-   virtual Int_t     SysClose(Int_t) { return 0; }
-   virtual Int_t     SysRead(Int_t, void*, Int_t) { return 0; }
-   virtual Int_t     SysWrite(Int_t, const void*, Int_t) { return 0; }
-   virtual Long64_t  SysSeek(Int_t, Long64_t, Int_t) { return 0; }
-   virtual Int_t     SysStat(Int_t, Long_t*, Long64_t*, Long_t*, Long_t*) { return 0; }
-   virtual Int_t     SysSync(Int_t) { return 0; }
+   virtual Int_t SysOpen(const char *, Int_t, UInt_t) { return 0; }
+   virtual Int_t SysClose(Int_t) { return 0; }
+   virtual Int_t SysRead(Int_t, void *, Int_t) { return 0; }
+   virtual Int_t SysWrite(Int_t, const void *, Int_t) { return 0; }
+   virtual Long64_t SysSeek(Int_t, Long64_t, Int_t) { return 0; }
+   virtual Int_t SysStat(Int_t, Long_t *, Long64_t *, Long_t *, Long_t *) { return 0; }
+   virtual Int_t SysSync(Int_t) { return 0; }
 
    // Overwrite methods for directory I/O
-   virtual Long64_t DirCreateEntry(TDirectory*);
-   virtual Int_t    DirReadKeys(TDirectory*);
-   virtual void     DirWriteKeys(TDirectory*);
-   virtual void     DirWriteHeader(TDirectory*);
+   virtual Long64_t DirCreateEntry(TDirectory *);
+   virtual Int_t DirReadKeys(TDirectory *);
+   virtual void DirWriteKeys(TDirectory *);
+   virtual void DirWriteHeader(TDirectory *);
 
    // functions to manipulate basic tables (Configurations, Objects, Keys) in database
-   void              SaveToDatabase();
-   Bool_t            ReadConfigurations();
-   Bool_t            IsTablesExists();
-   void              InitSqlDatabase(Bool_t create);
-   void              CreateBasicTables();
-   void              IncrementModifyCounter();
-   void              SetLocking(Int_t mode);
-   Int_t             GetLocking();
+   void SaveToDatabase();
+   Bool_t ReadConfigurations();
+   Bool_t IsTablesExists();
+   void InitSqlDatabase(Bool_t create);
+   void CreateBasicTables();
+   void IncrementModifyCounter();
+   void SetLocking(Int_t mode);
+   Int_t GetLocking();
 
    // function for read/write access infos
-   Bool_t            IsWriteAccess();
-   Bool_t            IsReadAccess();
+   Bool_t IsWriteAccess();
+   Bool_t IsReadAccess();
 
    // generic sql functions
-   TSQLResult*       SQLQuery(const char* cmd, Int_t flag = 0, Bool_t* res = 0);
-   Bool_t            SQLCanStatement();
-   TSQLStatement*    SQLStatement(const char* cmd, Int_t bufsize = 1000);
-   void              SQLDeleteStatement(TSQLStatement* stmt);
-   Bool_t            SQLApplyCommands(TObjArray* cmds);
-   Bool_t            SQLTestTable(const char* tablename);
-   Long64_t          SQLMaximumValue(const char* tablename, const char* columnname);
-   void              SQLDeleteAllTables();
-   Bool_t            SQLStartTransaction();
-   Bool_t            SQLCommit();
-   Bool_t            SQLRollback();
-   Int_t             SQLMaxIdentifierLength();
+   TSQLResult *SQLQuery(const char *cmd, Int_t flag = 0, Bool_t *res = 0);
+   Bool_t SQLCanStatement();
+   TSQLStatement *SQLStatement(const char *cmd, Int_t bufsize = 1000);
+   void SQLDeleteStatement(TSQLStatement *stmt);
+   Bool_t SQLApplyCommands(TObjArray *cmds);
+   Bool_t SQLTestTable(const char *tablename);
+   Long64_t SQLMaximumValue(const char *tablename, const char *columnname);
+   void SQLDeleteAllTables();
+   Bool_t SQLStartTransaction();
+   Bool_t SQLCommit();
+   Bool_t SQLRollback();
+   Int_t SQLMaxIdentifierLength();
 
    // operation with keys structures in database
-   void              DeleteKeyFromDB(Long64_t keyid);
-   Bool_t            WriteKeyData(TKeySQL* key);
-   Bool_t            UpdateKeyData(TKeySQL* key);
-   TKeySQL*          FindSQLKey(TDirectory* dir, Long64_t keyid);
-   Long64_t          DefineNextKeyId();
-   Int_t             StreamKeysForDirectory(TDirectory* dir, Bool_t doupdate, Long64_t specialkeyid = -1, TKeySQL** specialkey = 0);
+   void DeleteKeyFromDB(Long64_t keyid);
+   Bool_t WriteKeyData(TKeySQL *key);
+   Bool_t UpdateKeyData(TKeySQL *key);
+   TKeySQL *FindSQLKey(TDirectory *dir, Long64_t keyid);
+   Long64_t DefineNextKeyId();
+   Int_t StreamKeysForDirectory(TDirectory *dir, Bool_t doupdate, Long64_t specialkeyid = -1, TKeySQL **specialkey = 0);
 
    // handling SQL class info structures
-   TSQLClassInfo*    FindSQLClassInfo(const char* clname, Int_t version);
-   TSQLClassInfo*    FindSQLClassInfo(const TClass* cl);
-   TSQLClassInfo*    RequestSQLClassInfo(const char* clname, Int_t version);
-   TSQLClassInfo*    RequestSQLClassInfo(const TClass* cl);
-   Bool_t            CreateClassTable(TSQLClassInfo* sqlinfo, TObjArray* colinfos);
-   Bool_t            CreateRawTable(TSQLClassInfo* sqlinfo);
+   TSQLClassInfo *FindSQLClassInfo(const char *clname, Int_t version);
+   TSQLClassInfo *FindSQLClassInfo(const TClass *cl);
+   TSQLClassInfo *RequestSQLClassInfo(const char *clname, Int_t version);
+   TSQLClassInfo *RequestSQLClassInfo(const TClass *cl);
+   Bool_t CreateClassTable(TSQLClassInfo *sqlinfo, TObjArray *colinfos);
+   Bool_t CreateRawTable(TSQLClassInfo *sqlinfo);
 
-   Bool_t            ProduceClassSelectQuery(TVirtualStreamerInfo* info, TSQLClassInfo* sqlinfo, TString& columns, TString& tables, Int_t& tablecnt);
-   void              AddIdEntry(Long64_t tableid, Int_t subid, Int_t type,
-                                const char* name, const char* sqlname, const char* info);
-   void              ReadSQLClassInfos();
-   TString           DefineTableName(const char* clname, Int_t version, Bool_t rawtable);
-   Bool_t            HasTable(const char* name);
+   Bool_t ProduceClassSelectQuery(TVirtualStreamerInfo *info, TSQLClassInfo *sqlinfo, TString &columns, TString &tables,
+                                  Int_t &tablecnt);
+   void AddIdEntry(Long64_t tableid, Int_t subid, Int_t type, const char *name, const char *sqlname, const char *info);
+   void ReadSQLClassInfos();
+   TString DefineTableName(const char *clname, Int_t version, Bool_t rawtable);
+   Bool_t HasTable(const char *name);
 
    // operations with long string table
-   TString           CodeLongString(Long64_t objid, Int_t strid);
-   Int_t             IsLongStringCode(Long64_t objid, const char* value);
-   Bool_t            VerifyLongStringTable();
-   Bool_t            GetLongString(Long64_t objid, Int_t strid, TString& value);
+   TString CodeLongString(Long64_t objid, Int_t strid);
+   Int_t IsLongStringCode(Long64_t objid, const char *value);
+   Bool_t VerifyLongStringTable();
+   Bool_t GetLongString(Long64_t objid, Int_t strid, TString &value);
 
    // operation with object tables in database
-   Long64_t          VerifyObjectTable();
-   Bool_t            SQLObjectInfo(Long64_t objid, TString& clname, Version_t &version);
-   TObjArray*        SQLObjectsInfo(Long64_t keyid);
-   TSQLResult*       GetNormalClassData(Long64_t objid, TSQLClassInfo* sqlinfo);
-   TSQLResult*       GetNormalClassDataAll(Long64_t minobjid, Long64_t maxobjid, TSQLClassInfo* sqlinfo);
-   TSQLResult*       GetBlobClassData(Long64_t objid, TSQLClassInfo* sqlinfo);
-   TSQLStatement*    GetBlobClassDataStmt(Long64_t objid, TSQLClassInfo* sqlinfo);
-   Long64_t          StoreObjectInTables(Long64_t keyid, const void* obj, const TClass* cl);
-   Bool_t            WriteSpecialObject(Long64_t keyid, TObject* obj, const char* name, const char* title);
-   TObject*          ReadSpecialObject(Long64_t keyid, TObject* obj = 0);
+   Long64_t VerifyObjectTable();
+   Bool_t SQLObjectInfo(Long64_t objid, TString &clname, Version_t &version);
+   TObjArray *SQLObjectsInfo(Long64_t keyid);
+   TSQLResult *GetNormalClassData(Long64_t objid, TSQLClassInfo *sqlinfo);
+   TSQLResult *GetNormalClassDataAll(Long64_t minobjid, Long64_t maxobjid, TSQLClassInfo *sqlinfo);
+   TSQLResult *GetBlobClassData(Long64_t objid, TSQLClassInfo *sqlinfo);
+   TSQLStatement *GetBlobClassDataStmt(Long64_t objid, TSQLClassInfo *sqlinfo);
+   Long64_t StoreObjectInTables(Long64_t keyid, const void *obj, const TClass *cl);
+   Bool_t WriteSpecialObject(Long64_t keyid, TObject *obj, const char *name, const char *title);
+   TObject *ReadSpecialObject(Long64_t keyid, TObject *obj = 0);
 
    // sql specific types
-   const char*       SQLCompatibleType(Int_t typ) const;
-   const char*       SQLIntType() const;
-   const char*       SQLSmallTextType() const      { return fOtherTypes[0]; }
-   Int_t             SQLSmallTextTypeLimit() const { return atoi(fOtherTypes[1]); }
-   const char*       SQLBigTextType() const        { return fOtherTypes[2]; }
-   const char*       SQLDatetimeType() const       { return fOtherTypes[3]; }
-   const char*       SQLIdentifierQuote() const    { return fOtherTypes[4]; }
-   const char*       SQLDirIdColumn() const        { return fOtherTypes[5]; }
-   const char*       SQLKeyIdColumn() const        { return fOtherTypes[6]; }
-   const char*       SQLObjectIdColumn() const     { return fOtherTypes[7]; }
-   const char*       SQLRawIdColumn() const        { return fOtherTypes[8]; }
-   const char*       SQLStrIdColumn() const        { return fOtherTypes[9]; }
-   const char*       SQLNameSeparator() const      { return fOtherTypes[10]; }
-   const char*       SQLValueQuote() const         { return fOtherTypes[11]; }
-   const char*       SQLDefaultTableType() const   { return fOtherTypes[12]; }
+   const char *SQLCompatibleType(Int_t typ) const;
+   const char *SQLIntType() const;
+   const char *SQLSmallTextType() const { return fOtherTypes[0]; }
+   Int_t SQLSmallTextTypeLimit() const { return atoi(fOtherTypes[1]); }
+   const char *SQLBigTextType() const { return fOtherTypes[2]; }
+   const char *SQLDatetimeType() const { return fOtherTypes[3]; }
+   const char *SQLIdentifierQuote() const { return fOtherTypes[4]; }
+   const char *SQLDirIdColumn() const { return fOtherTypes[5]; }
+   const char *SQLKeyIdColumn() const { return fOtherTypes[6]; }
+   const char *SQLObjectIdColumn() const { return fOtherTypes[7]; }
+   const char *SQLRawIdColumn() const { return fOtherTypes[8]; }
+   const char *SQLStrIdColumn() const { return fOtherTypes[9]; }
+   const char *SQLNameSeparator() const { return fOtherTypes[10]; }
+   const char *SQLValueQuote() const { return fOtherTypes[11]; }
+   const char *SQLDefaultTableType() const { return fOtherTypes[12]; }
 
-   TSQLServer*       fSQL;             ///<! interface to SQL database
+   TSQLServer *fSQL; ///<! interface to SQL database
 
-   TList*            fSQLClassInfos;   ///<! list of SQL class infos
+   TList *fSQLClassInfos; ///<! list of SQL class infos
 
-   Bool_t            fUseSuffixes;     ///<! use suffixes in column names like fValue:Int_t or fObject:pointer
-   Int_t             fSQLIOversion;    ///<! version of SQL I/O which is stored in configurations
-   Int_t             fArrayLimit;      ///<! limit for array size. when array bigger, its content converted to raw format
-   Bool_t            fCanChangeConfig; ///<! variable indicates can be basic configuration changed or not
-   TString           fTablesType;      ///<! type, used in CREATE TABLE statements
-   Int_t             fUseTransactions; ///<! use transaction statements for writing data into the tables
-   Int_t             fUseIndexes;      ///<! use indexes for tables: 0 - off, 1 - only for basic tables, 2  + normal class tables, 3 - all tables
-   Int_t             fModifyCounter;   ///<! indicates how many changes was done with database tables
-   Int_t             fQuerisCounter;   ///<! how many query was applied
+   Bool_t fUseSuffixes;     ///<! use suffixes in column names like fValue:Int_t or fObject:pointer
+   Int_t fSQLIOversion;     ///<! version of SQL I/O which is stored in configurations
+   Int_t fArrayLimit;       ///<! limit for array size. when array bigger, its content converted to raw format
+   Bool_t fCanChangeConfig; ///<! variable indicates can be basic configuration changed or not
+   TString fTablesType;     ///<! type, used in CREATE TABLE statements
+   Int_t fUseTransactions;  ///<! use transaction statements for writing data into the tables
+   Int_t fUseIndexes;    ///<! use indexes for tables: 0 - off, 1 - only for basic tables, 2  + normal class tables, 3 -
+                         ///all tables
+   Int_t fModifyCounter; ///<! indicates how many changes was done with database tables
+   Int_t fQuerisCounter; ///<! how many query was applied
 
-   const char**      fBasicTypes;      ///<! pointer on list of basic types specific for currently connected SQL server
-   const char**      fOtherTypes;      ///<! pointer on list of other SQL types like TEXT or blob
+   const char **fBasicTypes; ///<! pointer on list of basic types specific for currently connected SQL server
+   const char **fOtherTypes; ///<! pointer on list of other SQL types like TEXT or blob
 
-   TString           fUserName;        ///<! user name, used to access objects from database
+   TString fUserName; ///<! user name, used to access objects from database
 
-   std::ofstream*    fLogFile;         ///<! log file with SQL statements
+   std::ofstream *fLogFile; ///<! log file with SQL statements
 
-   Bool_t            fIdsTableExists;  ///<! indicate if IdsTable exists
-   Int_t             fStmtCounter;     ///<! count numbers of active statements
+   Bool_t fIdsTableExists; ///<! indicate if IdsTable exists
+   Int_t fStmtCounter;     ///<! count numbers of active statements
 
 private:
-   //let the compiler do the job. gcc complains when the following line is activated
-   //TSQLFile(const TSQLFile &) {}            //Files cannot be copied
+   // let the compiler do the job. gcc complains when the following line is activated
+   // TSQLFile(const TSQLFile &) {}            //Files cannot be copied
    void operator=(const TSQLFile &);
 
 public:
-   enum ETransactionKinds {
-       kTransactionsOff  = 0,
-       kTransactionsAuto = 1,
-       kTransactionsUser = 2
-   };
+   enum ETransactionKinds { kTransactionsOff = 0, kTransactionsAuto = 1, kTransactionsUser = 2 };
 
-   enum EIndexesKinds {
-       kIndexesNone      = 0,
-       kIndexesBasic     = 1,
-       kIndexesClass     = 2,
-       kIndexesAll       = 3
-   };
+   enum EIndexesKinds { kIndexesNone = 0, kIndexesBasic = 1, kIndexesClass = 2, kIndexesAll = 3 };
 
    TSQLFile();
-   TSQLFile(const char* dbname, Option_t* option = "read", const char* user = "user", const char* pass = "pass");
+   TSQLFile(const char *dbname, Option_t *option = "read", const char *user = "user", const char *pass = "pass");
    virtual ~TSQLFile();
 
    // configuration of SQL
-   Bool_t            GetUseSuffixes() const { return fUseSuffixes; }
-   void              SetUseSuffixes(Bool_t on = kTRUE);
-   Int_t             GetArrayLimit() const { return fArrayLimit; }
-   void              SetArrayLimit(Int_t limit = 20);
-   void              SkipArrayLimit() { SetArrayLimit(-1); }
-   void              SetTablesType(const char* table_type);
-   const char*       GetTablesType() const { return fTablesType.Data(); }
-   void              SetUseTransactions(Int_t mode = kTransactionsAuto);
-   Int_t             GetUseTransactions() const { return fUseTransactions; }
-   void              SetUseIndexes(Int_t use_type = kIndexesBasic);
-   Int_t             GetUseIndexes() const { return fUseIndexes; }
-   Int_t             GetQuerisCounter() const { return fQuerisCounter; }
+   Bool_t GetUseSuffixes() const { return fUseSuffixes; }
+   void SetUseSuffixes(Bool_t on = kTRUE);
+   Int_t GetArrayLimit() const { return fArrayLimit; }
+   void SetArrayLimit(Int_t limit = 20);
+   void SkipArrayLimit() { SetArrayLimit(-1); }
+   void SetTablesType(const char *table_type);
+   const char *GetTablesType() const { return fTablesType.Data(); }
+   void SetUseTransactions(Int_t mode = kTransactionsAuto);
+   Int_t GetUseTransactions() const { return fUseTransactions; }
+   void SetUseIndexes(Int_t use_type = kIndexesBasic);
+   Int_t GetUseIndexes() const { return fUseIndexes; }
+   Int_t GetQuerisCounter() const { return fQuerisCounter; }
 
-   TString           MakeSelectQuery(TClass* cl);
-   Bool_t            StartTransaction();
-   Bool_t            Commit();
-   Bool_t            Rollback();
+   TString MakeSelectQuery(TClass *cl);
+   Bool_t StartTransaction();
+   Bool_t Commit();
+   Bool_t Rollback();
 
    // log file for SQL statements
-   void              StartLogFile(const char* fname);  // *MENU*
-   void              StopLogFile();                    // *MENU*
+   void StartLogFile(const char *fname); // *MENU*
+   void StopLogFile();                   // *MENU*
 
-   virtual void      Close(Option_t *option="");       // *MENU*
-   virtual TKey*     CreateKey(TDirectory* mother, const TObject* obj, const char* name, Int_t bufsize);
-   virtual TKey*     CreateKey(TDirectory* mother, const void* obj, const TClass* cl, const char* name, Int_t bufsize);
-   virtual void      DrawMap(const char* ="*",Option_t* ="") {}
-   virtual void      FillBuffer(char* &) {}
-   virtual void      Flush() {}
+   virtual void Close(Option_t *option = ""); // *MENU*
+   virtual TKey *CreateKey(TDirectory *mother, const TObject *obj, const char *name, Int_t bufsize);
+   virtual TKey *CreateKey(TDirectory *mother, const void *obj, const TClass *cl, const char *name, Int_t bufsize);
+   virtual void DrawMap(const char * = "*", Option_t * = "") {}
+   virtual void FillBuffer(char *&) {}
+   virtual void Flush() {}
 
-   virtual Long64_t  GetEND() const { return 0; }
-   virtual Int_t     GetErrno() const { return 0; }
-   virtual void      ResetErrno() const {}
+   virtual Long64_t GetEND() const { return 0; }
+   virtual Int_t GetErrno() const { return 0; }
+   virtual void ResetErrno() const {}
 
-   const char*       GetDataBaseName() const;
-   virtual Int_t     GetNfree() const { return 0; }
-   virtual Int_t     GetNbytesInfo() const {return 0; }
-   virtual Int_t     GetNbytesFree() const {return 0; }
-   virtual Long64_t  GetSeekFree() const {return 0; }
-   virtual Long64_t  GetSeekInfo() const {return 0; }
-   virtual Long64_t  GetSize() const { return 0; }
-   virtual TList*    GetStreamerInfoList();
+   const char *GetDataBaseName() const;
+   virtual Int_t GetNfree() const { return 0; }
+   virtual Int_t GetNbytesInfo() const { return 0; }
+   virtual Int_t GetNbytesFree() const { return 0; }
+   virtual Long64_t GetSeekFree() const { return 0; }
+   virtual Long64_t GetSeekInfo() const { return 0; }
+   virtual Long64_t GetSize() const { return 0; }
+   virtual TList *GetStreamerInfoList();
 
-   Bool_t            IsMySQL() const;
-   virtual Bool_t    IsOpen() const;
-   Bool_t            IsOracle() const;
-   Bool_t            IsODBC() const;
+   Bool_t IsMySQL() const;
+   virtual Bool_t IsOpen() const;
+   Bool_t IsOracle() const;
+   Bool_t IsODBC() const;
 
-   virtual void      MakeFree(Long64_t, Long64_t) {}
-   virtual void      MakeProject(const char *, const char* ="*", Option_t* ="new") {} // *MENU*
-   virtual void      Map(Option_t *) {} //
-   virtual void      Map() {} //
-   virtual void      Paint(Option_t* ="") {}
-   virtual void      Print(Option_t* ="") const {}
-   virtual Bool_t    ReadBuffer(char*, Int_t) { return kFALSE; }
-   virtual Bool_t    ReadBuffer(char*, Long64_t, Int_t) { return kFALSE; }
-   virtual void      ReadFree() {}
-   virtual Int_t     Recover() { return 0; }
-   virtual Int_t     ReOpen(Option_t *mode);
-   virtual void      Seek(Long64_t, ERelativeTo=kBeg) {}
+   virtual void MakeFree(Long64_t, Long64_t) {}
+   virtual void MakeProject(const char *, const char * = "*", Option_t * = "new") {} // *MENU*
+   virtual void Map(Option_t *) {}                                                   //
+   virtual void Map() {}                                                             //
+   virtual void Paint(Option_t * = "") {}
+   virtual void Print(Option_t * = "") const {}
+   virtual Bool_t ReadBuffer(char *, Int_t) { return kFALSE; }
+   virtual Bool_t ReadBuffer(char *, Long64_t, Int_t) { return kFALSE; }
+   virtual void ReadFree() {}
+   virtual Int_t Recover() { return 0; }
+   virtual Int_t ReOpen(Option_t *mode);
+   virtual void Seek(Long64_t, ERelativeTo = kBeg) {}
 
-   virtual void      SetEND(Long64_t) {}
-   virtual Int_t     Sizeof() const { return 0; }
+   virtual void SetEND(Long64_t) {}
+   virtual Int_t Sizeof() const { return 0; }
 
-   virtual Bool_t    WriteBuffer(const char*, Int_t) { return kFALSE; }
-   virtual Int_t     Write(const char* =0, Int_t=0, Int_t=0) { return 0; }
-   virtual Int_t     Write(const char* =0, Int_t=0, Int_t=0) const { return 0; }
-   virtual void      WriteFree() {}
-   virtual void      WriteHeader();
-   virtual void      WriteStreamerInfo();
+   virtual Bool_t WriteBuffer(const char *, Int_t) { return kFALSE; }
+   virtual Int_t Write(const char * = 0, Int_t = 0, Int_t = 0) { return 0; }
+   virtual Int_t Write(const char * = 0, Int_t = 0, Int_t = 0) const { return 0; }
+   virtual void WriteFree() {}
+   virtual void WriteHeader();
+   virtual void WriteStreamerInfo();
 
-   ClassDef(TSQLFile,1)   // ROOT TFile interface to SQL database
+   ClassDef(TSQLFile, 1) // ROOT TFile interface to SQL database
 };
 
 #endif

--- a/io/sql/inc/TSQLObjectData.h
+++ b/io/sql/inc/TSQLObjectData.h
@@ -23,26 +23,23 @@ class TSQLResult;
 class TSQLRow;
 class TSQLStatement;
 
-
 class TSQLObjectInfo : public TObject {
 
 public:
-
    TSQLObjectInfo();
-   TSQLObjectInfo(Long64_t objid, const char* classname, Version_t version);
+   TSQLObjectInfo(Long64_t objid, const char *classname, Version_t version);
    virtual ~TSQLObjectInfo();
 
-   Long64_t          GetObjId() const { return fObjId; }
-   const char*       GetObjClassName() const { return fClassName.Data(); }
-   Version_t         GetObjVersion() const { return fVersion; }
+   Long64_t GetObjId() const { return fObjId; }
+   const char *GetObjClassName() const { return fClassName.Data(); }
+   Version_t GetObjVersion() const { return fVersion; }
 
 protected:
-   Long64_t          fObjId;
-   TString           fClassName;
-   Version_t         fVersion;
+   Long64_t fObjId;
+   TString fClassName;
+   Version_t fVersion;
 
-   ClassDef(TSQLObjectInfo, 1)  //Info (classname, version) about object in database
-
+   ClassDef(TSQLObjectInfo, 1) // Info (classname, version) about object in database
 };
 
 //=======================================================================
@@ -52,58 +49,53 @@ class TSQLObjectData : public TObject {
 public:
    TSQLObjectData();
 
-   TSQLObjectData(TSQLClassInfo* sqlinfo,
-                  Long64_t       objid,
-                  TSQLResult*    classdata,
-                  TSQLRow*       classrow,
-                  TSQLResult*    blobdata,
-                  TSQLStatement* blobstmt);
+   TSQLObjectData(TSQLClassInfo *sqlinfo, Long64_t objid, TSQLResult *classdata, TSQLRow *classrow,
+                  TSQLResult *blobdata, TSQLStatement *blobstmt);
 
    virtual ~TSQLObjectData();
 
-   Long64_t          GetObjId() const { return fObjId; }
-   TSQLClassInfo*    GetInfo() const { return fInfo; }
+   Long64_t GetObjId() const { return fObjId; }
+   TSQLClassInfo *GetInfo() const { return fInfo; }
 
-   Bool_t            LocateColumn(const char* colname, Bool_t isblob = kFALSE);
-   Bool_t            IsBlobData() const { return fCurrentBlob || (fUnpack!=0); }
-   void              ShiftToNextValue();
+   Bool_t LocateColumn(const char *colname, Bool_t isblob = kFALSE);
+   Bool_t IsBlobData() const { return fCurrentBlob || (fUnpack != 0); }
+   void ShiftToNextValue();
 
-   void              AddUnpack(const char* tname, const char* value);
-   void              AddUnpackInt(const char* tname, Int_t value);
+   void AddUnpack(const char *tname, const char *value);
+   void AddUnpackInt(const char *tname, Int_t value);
 
-   const char*       GetValue() const { return fLocatedValue; }
-   const char*       GetLocatedField() const { return fLocatedField; }
-   const char*       GetBlobPrefixName() const { return fBlobPrefixName; }
-   const char*       GetBlobTypeName() const { return fBlobTypeName; }
+   const char *GetValue() const { return fLocatedValue; }
+   const char *GetLocatedField() const { return fLocatedField; }
+   const char *GetBlobPrefixName() const { return fBlobPrefixName; }
+   const char *GetBlobTypeName() const { return fBlobTypeName; }
 
-   Bool_t            VerifyDataType(const char* tname, Bool_t errormsg = kTRUE);
-   Bool_t            PrepareForRawData();
+   Bool_t VerifyDataType(const char *tname, Bool_t errormsg = kTRUE);
+   Bool_t PrepareForRawData();
 
 protected:
-   Bool_t            ExtractBlobValues();
-   Bool_t            ShiftBlobRow();
+   Bool_t ExtractBlobValues();
+   Bool_t ShiftBlobRow();
 
-   Int_t             GetNumClassFields();
-   const char*       GetClassFieldName(Int_t n);
+   Int_t GetNumClassFields();
+   const char *GetClassFieldName(Int_t n);
 
-   TSQLClassInfo*    fInfo;           //!
-   Long64_t          fObjId;          //!
-   Bool_t            fOwner;          //!
-   TSQLResult*       fClassData;      //!
-   TSQLResult*       fBlobData;       //!
-   TSQLStatement*    fBlobStmt;       //!
-   Int_t             fLocatedColumn;  //!
-   TSQLRow*          fClassRow;       //!
-   TSQLRow*          fBlobRow;        //!
-   const char*       fLocatedField;   //!
-   const char*       fLocatedValue;   //!
-   Bool_t            fCurrentBlob;    //!
-   const char*       fBlobPrefixName; ///<! name prefix in current blob row
-   const char*       fBlobTypeName;   ///<! name type (without prefix) in current blob row
-   TObjArray*        fUnpack;         //!
+   TSQLClassInfo *fInfo;        //!
+   Long64_t fObjId;             //!
+   Bool_t fOwner;               //!
+   TSQLResult *fClassData;      //!
+   TSQLResult *fBlobData;       //!
+   TSQLStatement *fBlobStmt;    //!
+   Int_t fLocatedColumn;        //!
+   TSQLRow *fClassRow;          //!
+   TSQLRow *fBlobRow;           //!
+   const char *fLocatedField;   //!
+   const char *fLocatedValue;   //!
+   Bool_t fCurrentBlob;         //!
+   const char *fBlobPrefixName; ///<! name prefix in current blob row
+   const char *fBlobTypeName;   ///<! name type (without prefix) in current blob row
+   TObjArray *fUnpack;          //!
 
    ClassDef(TSQLObjectData, 1) // Keeps the data requested from the SQL server for an object.
-
 };
 
 // ======================================================================
@@ -117,22 +109,20 @@ class TSQLObjectDataPool : public TObject {
 
 public:
    TSQLObjectDataPool();
-   TSQLObjectDataPool(TSQLClassInfo* info, TSQLResult* data);
+   TSQLObjectDataPool(TSQLClassInfo *info, TSQLResult *data);
    virtual ~TSQLObjectDataPool();
 
-   TSQLClassInfo*    GetSqlInfo() const { return fInfo; }
-   TSQLResult*       GetClassData() const { return fClassData; }
-   TSQLRow*          GetObjectRow(Long64_t objid);
+   TSQLClassInfo *GetSqlInfo() const { return fInfo; }
+   TSQLResult *GetClassData() const { return fClassData; }
+   TSQLRow *GetObjectRow(Long64_t objid);
 
 protected:
+   TSQLClassInfo *fInfo;   ///<!  classinfo, for which pool is created
+   TSQLResult *fClassData; ///<!  results with request to selected table
+   Bool_t fIsMoreRows;     ///<!  indicates if class data has not yet read rows
+   TList *fRowsPool;       ///<!  pool of extrcted, but didnot used rows
 
-   TSQLClassInfo*    fInfo;          ///<!  classinfo, for which pool is created
-   TSQLResult*       fClassData;     ///<!  results with request to selected table
-   Bool_t            fIsMoreRows;    ///<!  indicates if class data has not yet read rows
-   TList*            fRowsPool;      ///<!  pool of extrcted, but didnot used rows
-
-   ClassDef(TSQLObjectDataPool,1) // XML object keeper class
-
+   ClassDef(TSQLObjectDataPool, 1) // XML object keeper class
 };
 
 #endif

--- a/io/sql/inc/TSQLStructure.h
+++ b/io/sql/inc/TSQLStructure.h
@@ -28,7 +28,6 @@
 #undef False
 #endif
 
-
 class TStreamerInfo;
 class TStreamerInfo;
 class TStreamerElement;
@@ -42,23 +41,20 @@ class TBufferSQL2;
 class TSQLColumnData : public TObject {
 
 protected:
-   TString     fName;             ///<!  name of the table column
-   TString     fType;             ///<!  type of the table column
-   TString     fValue;            ///<!  value of the table column
-   Bool_t      fNumeric;          ///<!  for numeric quotes (double quotes) are not required
+   TString fName;   ///<!  name of the table column
+   TString fType;   ///<!  type of the table column
+   TString fValue;  ///<!  value of the table column
+   Bool_t fNumeric; ///<!  for numeric quotes (double quotes) are not required
 public:
    TSQLColumnData();
-   TSQLColumnData(const char* name,
-                  const char* sqltype,
-                  const char* value,
-                  Bool_t numeric);
+   TSQLColumnData(const char *name, const char *sqltype, const char *value, Bool_t numeric);
 
-   TSQLColumnData(const char* name, Long64_t value);
+   TSQLColumnData(const char *name, Long64_t value);
    virtual ~TSQLColumnData();
 
-   virtual const char* GetName() const { return fName.Data(); }
-   const char* GetType() const { return fType.Data(); }
-   const char* GetValue() const { return fValue.Data(); }
+   virtual const char *GetName() const { return fName.Data(); }
+   const char *GetType() const { return fType.Data(); }
+   const char *GetValue() const { return fValue.Data(); }
    Bool_t IsNumeric() const { return fNumeric; }
 
    ClassDef(TSQLColumnData, 1); // Single SQL column data.
@@ -69,28 +65,25 @@ public:
 class TSQLTableData : public TObject {
 
 protected:
-   TSQLFile*      fFile;           ///<!
-   TSQLClassInfo* fInfo;           ///<!
-   TObjArray      fColumns;        ///<! collection of columns
-   TObjArray*     fColInfos;       ///<! array with TSQLClassColumnInfo, used later for TSQLClassInfo
+   TSQLFile *fFile;      ///<!
+   TSQLClassInfo *fInfo; ///<!
+   TObjArray fColumns;   ///<! collection of columns
+   TObjArray *fColInfos; ///<! array with TSQLClassColumnInfo, used later for TSQLClassInfo
 
-   TString DefineSQLName(const char* fullname);
-   Bool_t HasSQLName(const char* sqlname);
+   TString DefineSQLName(const char *fullname);
+   Bool_t HasSQLName(const char *sqlname);
 
 public:
-   TSQLTableData(TSQLFile* f = 0, TSQLClassInfo* info = 0);
+   TSQLTableData(TSQLFile *f = 0, TSQLClassInfo *info = 0);
    virtual ~TSQLTableData();
 
-   void AddColumn(const char* name, Long64_t value);
-   void AddColumn(const char* name,
-                  const char* sqltype,
-                  const char* value,
-                  Bool_t numeric);
+   void AddColumn(const char *name, Long64_t value);
+   void AddColumn(const char *name, const char *sqltype, const char *value, Bool_t numeric);
 
-   TObjArray* TakeColInfos();
+   TObjArray *TakeColInfos();
 
    Int_t GetNumColumns();
-   const char* GetColumn(Int_t n);
+   const char *GetColumn(Int_t n);
    Bool_t IsNumeric(Int_t n);
 
    ClassDef(TSQLTableData, 1); // Collection of columns data for single SQL table
@@ -100,131 +93,125 @@ public:
 
 class TSQLStructure : public TObject {
 protected:
+   Bool_t CheckNormalClassPair(TSQLStructure *vers, TSQLStructure *info);
 
-   Bool_t           CheckNormalClassPair(TSQLStructure* vers, TSQLStructure* info);
+   Long64_t FindMaxObjectId();
+   void PerformConversion(TSqlRegistry *reg, TSqlRawBuffer *blobs, const char *topname, Bool_t useblob = kFALSE);
+   Bool_t StoreObject(TSqlRegistry *reg, Long64_t objid, TClass *cl, Bool_t registerobj = kTRUE);
+   Bool_t StoreObjectInNormalForm(TSqlRegistry *reg);
+   Bool_t StoreClassInNormalForm(TSqlRegistry *reg);
+   Bool_t StoreElementInNormalForm(TSqlRegistry *reg, TSQLTableData *columns);
+   Bool_t TryConvertObjectArray(TSqlRegistry *reg, TSqlRawBuffer *blobs);
 
-   Long64_t         FindMaxObjectId();
-   void             PerformConversion(TSqlRegistry* reg, TSqlRawBuffer* blobs, const char* topname, Bool_t useblob = kFALSE);
-   Bool_t           StoreObject(TSqlRegistry* reg, Long64_t objid, TClass* cl, Bool_t registerobj = kTRUE);
-   Bool_t           StoreObjectInNormalForm(TSqlRegistry* reg);
-   Bool_t           StoreClassInNormalForm(TSqlRegistry* reg);
-   Bool_t           StoreElementInNormalForm(TSqlRegistry* reg, TSQLTableData* columns);
-   Bool_t           TryConvertObjectArray(TSqlRegistry* reg, TSqlRawBuffer* blobs);
+   Bool_t StoreTObject(TSqlRegistry *reg);
+   Bool_t StoreTString(TSqlRegistry *reg);
+   Bool_t RecognizeTString(const char *&value);
 
-   Bool_t           StoreTObject(TSqlRegistry* reg);
-   Bool_t           StoreTString(TSqlRegistry* reg);
-   Bool_t           RecognizeTString(const char* &value);
-
-   TSQLStructure*   fParent;     //!
-   Int_t            fType;       //!
-   const void*      fPointer;    //!
-   TString          fValue;      //!
-   Int_t            fArrayIndex; //!
-   Int_t            fRepeatCnt;  //!
-   TObjArray        fChilds;     //!
+   TSQLStructure *fParent; //!
+   Int_t fType;            //!
+   const void *fPointer;   //!
+   TString fValue;         //!
+   Int_t fArrayIndex;      //!
+   Int_t fRepeatCnt;       //!
+   TObjArray fChilds;      //!
 
 public:
    TSQLStructure();
    virtual ~TSQLStructure();
 
-   TSQLStructure*   GetParent() const { return fParent; }
-   void             SetParent(TSQLStructure* p) { fParent = p; }
-   Int_t            NumChilds() const;
-   TSQLStructure*   GetChild(Int_t n) const;
+   TSQLStructure *GetParent() const { return fParent; }
+   void SetParent(TSQLStructure *p) { fParent = p; }
+   Int_t NumChilds() const;
+   TSQLStructure *GetChild(Int_t n) const;
 
-   void             SetType(Int_t typ) { fType = typ; }
-   Int_t            GetType() const { return fType; }
+   void SetType(Int_t typ) { fType = typ; }
+   Int_t GetType() const { return fType; }
 
    // this part requried for writing to SQL tables
-   void             SetObjectRef(Long64_t refid, const TClass* cl);
-   void             SetObjectPointer(Long64_t ptrid);
-   void             SetVersion(const TClass* cl, Int_t version = -100);
-   void             SetClassStreamer(const TClass* cl);
-   void             SetStreamerInfo(const TStreamerInfo* info);
-   void             SetStreamerElement(const TStreamerElement* elem, Int_t number);
-   void             SetCustomClass(const TClass* cl, Version_t version);
-   void             SetCustomElement(TStreamerElement* elem);
-   void             SetValue(const char* value, const char* tname = 0);
-   void             SetArrayIndex(Int_t indx, Int_t cnt=1);
-   void             SetArray(Int_t sz = -1);
-   void             ChangeValueOnly(const char* value);
+   void SetObjectRef(Long64_t refid, const TClass *cl);
+   void SetObjectPointer(Long64_t ptrid);
+   void SetVersion(const TClass *cl, Int_t version = -100);
+   void SetClassStreamer(const TClass *cl);
+   void SetStreamerInfo(const TStreamerInfo *info);
+   void SetStreamerElement(const TStreamerElement *elem, Int_t number);
+   void SetCustomClass(const TClass *cl, Version_t version);
+   void SetCustomElement(TStreamerElement *elem);
+   void SetValue(const char *value, const char *tname = 0);
+   void SetArrayIndex(Int_t indx, Int_t cnt = 1);
+   void SetArray(Int_t sz = -1);
+   void ChangeValueOnly(const char *value);
 
-   TClass*          GetObjectClass() const;
-   TClass*          GetVersionClass() const;
-   TStreamerInfo*   GetStreamerInfo() const;
-   TStreamerElement* GetElement() const;
-   Int_t            GetElementNumber() const;
-   TClass*          GetCustomClass() const;
-   Version_t        GetCustomClassVersion() const;
-   Bool_t           GetClassInfo(TClass* &cl, Version_t &version);
-   const char*      GetValueType() const;
-   const char*      GetValue() const;
-   Int_t            GetArrayIndex() const { return fArrayIndex; }
-   Int_t            GetRepeatCounter() const { return fRepeatCnt; }
+   TClass *GetObjectClass() const;
+   TClass *GetVersionClass() const;
+   TStreamerInfo *GetStreamerInfo() const;
+   TStreamerElement *GetElement() const;
+   Int_t GetElementNumber() const;
+   TClass *GetCustomClass() const;
+   Version_t GetCustomClassVersion() const;
+   Bool_t GetClassInfo(TClass *&cl, Version_t &version);
+   const char *GetValueType() const;
+   const char *GetValue() const;
+   Int_t GetArrayIndex() const { return fArrayIndex; }
+   Int_t GetRepeatCounter() const { return fRepeatCnt; }
 
-   void             Add(TSQLStructure* child);
-   void             AddVersion(const TClass* cl, Int_t version = -100);
-   void             AddValue(const char* value, const char* tname = 0);
-   void             ChildArrayIndex(Int_t index, Int_t cnt = 1);
+   void Add(TSQLStructure *child);
+   void AddVersion(const TClass *cl, Int_t version = -100);
+   void AddValue(const char *value, const char *tname = 0);
+   void ChildArrayIndex(Int_t index, Int_t cnt = 1);
 
    // this is part specially for reading of sql tables
 
-   Long64_t         DefineObjectId(Bool_t recursive = kTRUE);
+   Long64_t DefineObjectId(Bool_t recursive = kTRUE);
 
-   void             SetObjectData(TSQLObjectData* objdata);
-   void             AddObjectData(TSQLObjectData* objdata);
-   TSQLObjectData*  GetObjectData(Bool_t search = false);
+   void SetObjectData(TSQLObjectData *objdata);
+   void AddObjectData(TSQLObjectData *objdata);
+   TSQLObjectData *GetObjectData(Bool_t search = false);
 
-   virtual void     Print(Option_t* option = "") const;
-   void             PrintLevel(Int_t level) const;
+   virtual void Print(Option_t *option = "") const;
+   void PrintLevel(Int_t level) const;
 
-   Bool_t           ConvertToTables(TSQLFile* f, Long64_t keyid, TObjArray* cmds);
+   Bool_t ConvertToTables(TSQLFile *f, Long64_t keyid, TObjArray *cmds);
 
-   Int_t            LocateElementColumn(TSQLFile* f, TBufferSQL2* buf, TSQLObjectData* data);
+   Int_t LocateElementColumn(TSQLFile *f, TBufferSQL2 *buf, TSQLObjectData *data);
 
-   static Bool_t    UnpackTObject(TSQLFile* f, TBufferSQL2* buf, TSQLObjectData* data, Long64_t objid, Int_t clversion);
-   static Bool_t    UnpackTString(TSQLFile* f, TBufferSQL2* buf, TSQLObjectData* data, Long64_t objid, Int_t clversion);
-   static Bool_t    IsNumericType(Int_t typ);
-   static const char* GetSimpleTypeName(Int_t typ);
-   static TString   MakeArrayIndex(TStreamerElement* elem, Int_t n);
-   static Int_t     DefineElementColumnType(TStreamerElement* elem, TSQLFile* f);
-   static TString   DefineElementColumnName(TStreamerElement* elem, TSQLFile* f, Int_t indx = 0);
-   static void      AddStrBrackets(TString &s, const char* quote);
+   static Bool_t UnpackTObject(TSQLFile *f, TBufferSQL2 *buf, TSQLObjectData *data, Long64_t objid, Int_t clversion);
+   static Bool_t UnpackTString(TSQLFile *f, TBufferSQL2 *buf, TSQLObjectData *data, Long64_t objid, Int_t clversion);
+   static Bool_t IsNumericType(Int_t typ);
+   static const char *GetSimpleTypeName(Int_t typ);
+   static TString MakeArrayIndex(TStreamerElement *elem, Int_t n);
+   static Int_t DefineElementColumnType(TStreamerElement *elem, TSQLFile *f);
+   static TString DefineElementColumnName(TStreamerElement *elem, TSQLFile *f, Int_t indx = 0);
+   static void AddStrBrackets(TString &s, const char *quote);
 
    enum ESQLTypes {
-      kSqlObject       = 10001,
-      kSqlPointer      = 10002,
-      kSqlVersion      = 10003,
+      kSqlObject = 10001,
+      kSqlPointer = 10002,
+      kSqlVersion = 10003,
       kSqlStreamerInfo = 10004,
-      kSqlClassStreamer= 10005,
-      kSqlElement      = 10006,
-      kSqlValue        = 10007,
-      kSqlArray        = 10008,
-      kSqlObjectData   = 10009,
-      kSqlCustomClass  = 10010,
-      kSqlCustomElement= 10011
+      kSqlClassStreamer = 10005,
+      kSqlElement = 10006,
+      kSqlValue = 10007,
+      kSqlArray = 10008,
+      kSqlObjectData = 10009,
+      kSqlCustomClass = 10010,
+      kSqlCustomElement = 10011
    };
 
    enum ESQLColumns {
-      kColUnknown      = 0,
-      kColSimple       = 1,
-      kColSimpleArray  = 2,
-      kColParent       = 3,
-      kColObject       = 4,
-      kColObjectArray  = 5,
-      kColNormObject   = 6,
+      kColUnknown = 0,
+      kColSimple = 1,
+      kColSimpleArray = 2,
+      kColParent = 3,
+      kColObject = 4,
+      kColObjectArray = 5,
+      kColNormObject = 6,
       kColNormObjectArray = 7,
-      kColObjectPtr    = 8,
-      kColTString      = 9,
-      kColRawData      = 10
+      kColObjectPtr = 8,
+      kColTString = 9,
+      kColRawData = 10
    };
 
-   enum ESQLIdType {
-      kIdTable    = 0,
-      kIdRawTable = 1,
-      kIdColumn   = 2
-   };
-
+   enum ESQLIdType { kIdTable = 0, kIdRawTable = 1, kIdColumn = 2 };
 
    ClassDef(TSQLStructure, 1); // Table/structure description used internally by TBufferSQL.
 };
@@ -233,94 +220,94 @@ public:
 
 namespace sqlio {
 
-   extern Long64_t atol64(const char* value);
+extern Long64_t atol64(const char *value);
 
-   extern const Int_t Ids_NullPtr;
-   extern const Int_t Ids_RootDir;
-   extern const Int_t Ids_TSQLFile;
-   extern const Int_t Ids_StreamerInfos;
-   extern const Int_t Ids_FirstKey;
-   extern const Int_t Ids_FirstObject;
+extern const Int_t Ids_NullPtr;
+extern const Int_t Ids_RootDir;
+extern const Int_t Ids_TSQLFile;
+extern const Int_t Ids_StreamerInfos;
+extern const Int_t Ids_FirstKey;
+extern const Int_t Ids_FirstObject;
 
-   extern const char* ObjectRef;
-   extern const char* ObjectRef_Arr;
-   extern const char* ObjectPtr;
-   extern const char* ObjectInst;
-   extern const char* Version;
-   extern const char* TObjectUniqueId;
-   extern const char* TObjectBits;
-   extern const char* TObjectProcessId;
-   extern const char* TStringValue;
-   extern const char* IndexSepar;
-   extern const char* RawSuffix;
-   extern const char* ParentSuffix;
-   extern const char* ObjectSuffix;
-   extern const char* PointerSuffix;
-   extern const char* StrSuffix;
-   extern const char* LongStrPrefix;
+extern const char *ObjectRef;
+extern const char *ObjectRef_Arr;
+extern const char *ObjectPtr;
+extern const char *ObjectInst;
+extern const char *Version;
+extern const char *TObjectUniqueId;
+extern const char *TObjectBits;
+extern const char *TObjectProcessId;
+extern const char *TStringValue;
+extern const char *IndexSepar;
+extern const char *RawSuffix;
+extern const char *ParentSuffix;
+extern const char *ObjectSuffix;
+extern const char *PointerSuffix;
+extern const char *StrSuffix;
+extern const char *LongStrPrefix;
 
-   extern const char* Array;
-   extern const char* Bool;
-   extern const char* Char;
-   extern const char* Short;
-   extern const char* Int;
-   extern const char* Long;
-   extern const char* Long64;
-   extern const char* Float;
-   extern const char* Double;
-   extern const char* UChar;
-   extern const char* UShort;
-   extern const char* UInt;
-   extern const char* ULong;
-   extern const char* ULong64;
-   extern const char* CharStar;
-   extern const char* True;
-   extern const char* False;
+extern const char *Array;
+extern const char *Bool;
+extern const char *Char;
+extern const char *Short;
+extern const char *Int;
+extern const char *Long;
+extern const char *Long64;
+extern const char *Float;
+extern const char *Double;
+extern const char *UChar;
+extern const char *UShort;
+extern const char *UInt;
+extern const char *ULong;
+extern const char *ULong64;
+extern const char *CharStar;
+extern const char *True;
+extern const char *False;
 
-   extern const char* KeysTable;
-   extern const char* KeysTableIndex;
-   extern const char* KT_Name;
-   extern const char* KT_Title;
-   extern const char* KT_Datetime;
-   extern const char* KT_Cycle;
-   extern const char* KT_Class;
+extern const char *KeysTable;
+extern const char *KeysTableIndex;
+extern const char *KT_Name;
+extern const char *KT_Title;
+extern const char *KT_Datetime;
+extern const char *KT_Cycle;
+extern const char *KT_Class;
 
-   extern const char* DT_Create;
-   extern const char* DT_Modified;
-   extern const char* DT_UUID;
+extern const char *DT_Create;
+extern const char *DT_Modified;
+extern const char *DT_UUID;
 
-   extern const char* ObjectsTable;
-   extern const char* ObjectsTableIndex;
-   extern const char* OT_Class;
-   extern const char* OT_Version;
+extern const char *ObjectsTable;
+extern const char *ObjectsTableIndex;
+extern const char *OT_Class;
+extern const char *OT_Version;
 
-   extern const char* IdsTable;
-   extern const char* IdsTableIndex;
-   extern const char* IT_TableID;
-   extern const char* IT_SubID;
-   extern const char* IT_Type;
-   extern const char* IT_FullName;
-   extern const char* IT_SQLName;
-   extern const char* IT_Info;
+extern const char *IdsTable;
+extern const char *IdsTableIndex;
+extern const char *IT_TableID;
+extern const char *IT_SubID;
+extern const char *IT_Type;
+extern const char *IT_FullName;
+extern const char *IT_SQLName;
+extern const char *IT_Info;
 
-   extern const char* BT_Field;
-   extern const char* BT_Value;
+extern const char *BT_Field;
+extern const char *BT_Value;
 
-   extern const char* StringsTable;
-   extern const char* ST_Value;
+extern const char *StringsTable;
+extern const char *ST_Value;
 
-   extern const char* ConfigTable;
-   extern const char* CT_Field;
-   extern const char* CT_Value;
+extern const char *ConfigTable;
+extern const char *CT_Field;
+extern const char *CT_Value;
 
-   extern const char* cfg_Version;
-   extern const char* cfg_UseSufixes;
-   extern const char* cfg_ArrayLimit;
-   extern const char* cfg_TablesType;
-   extern const char* cfg_UseTransactions;
-   extern const char* cfg_UseIndexes;
-   extern const char* cfg_LockingMode;
-   extern const char* cfg_ModifyCounter;
+extern const char *cfg_Version;
+extern const char *cfg_UseSufixes;
+extern const char *cfg_ArrayLimit;
+extern const char *cfg_TablesType;
+extern const char *cfg_UseTransactions;
+extern const char *cfg_UseIndexes;
+extern const char *cfg_LockingMode;
+extern const char *cfg_ModifyCounter;
 }
 
 #endif

--- a/io/sql/src/TBufferSQL2.cxx
+++ b/io/sql/src/TBufferSQL2.cxx
@@ -53,11 +53,11 @@ few other, which can not be converted to SQL (yet).
 #include "TSQLClassInfo.h"
 
 #ifdef R__VISUAL_CPLUSPLUS
-#define FLong64    "%I64d"
-#define FULong64   "%I64u"
+#define FLong64 "%I64d"
+#define FULong64 "%I64u"
 #else
-#define FLong64    "%lld"
-#define FULong64   "%llu"
+#define FLong64 "%lld"
+#define FULong64 "%llu"
 #endif
 
 ClassImp(TBufferSQL2);
@@ -65,49 +65,21 @@ ClassImp(TBufferSQL2);
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor, should not be used
 
-TBufferSQL2::TBufferSQL2() :
-   TBufferFile(),
-   fSQL(0),
-   fStructure(0),
-   fStk(0),
-   fObjMap(0),
-   fReadBuffer(),
-   fErrorFlag(0),
-   fExpectedChain(kFALSE),
-   fCompressLevel(0),
-   fReadVersionBuffer(-1),
-   fObjIdCounter(1),
-   fIgnoreVerification(kFALSE),
-   fCurrentData(0),
-   fObjectsInfos(0),
-   fFirstObjId(0),
-   fLastObjId(0),
-   fPoolsMap(0)
+TBufferSQL2::TBufferSQL2()
+   : TBufferFile(), fSQL(0), fStructure(0), fStk(0), fObjMap(0), fReadBuffer(), fErrorFlag(0), fExpectedChain(kFALSE),
+     fCompressLevel(0), fReadVersionBuffer(-1), fObjIdCounter(1), fIgnoreVerification(kFALSE), fCurrentData(0),
+     fObjectsInfos(0), fFirstObjId(0), fLastObjId(0), fPoolsMap(0)
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Creates buffer object to serailize/deserialize data to/from sql.
+/// Creates buffer object to serialize/deserialize data to/from sql.
 /// Mode should be either TBuffer::kRead or TBuffer::kWrite.
 
-TBufferSQL2::TBufferSQL2(TBuffer::EMode mode) :
-   TBufferFile(mode),
-   fSQL(0),
-   fStructure(0),
-   fStk(0),
-   fObjMap(0),
-   fReadBuffer(),
-   fErrorFlag(0),
-   fExpectedChain(kFALSE),
-   fCompressLevel(0),
-   fReadVersionBuffer(-1),
-   fObjIdCounter(1),
-   fIgnoreVerification(kFALSE),
-   fCurrentData(0),
-   fObjectsInfos(0),
-   fFirstObjId(0),
-   fLastObjId(0),
-   fPoolsMap(0)
+TBufferSQL2::TBufferSQL2(TBuffer::EMode mode)
+   : TBufferFile(mode), fSQL(0), fStructure(0), fStk(0), fObjMap(0), fReadBuffer(), fErrorFlag(0),
+     fExpectedChain(kFALSE), fCompressLevel(0), fReadVersionBuffer(-1), fObjIdCounter(1), fIgnoreVerification(kFALSE),
+     fCurrentData(0), fObjectsInfos(0), fFirstObjId(0), fLastObjId(0), fPoolsMap(0)
 {
    SetParent(0);
    SetBit(kCannotHandleMemberWiseStreaming);
@@ -115,28 +87,14 @@ TBufferSQL2::TBufferSQL2(TBuffer::EMode mode) :
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Creates buffer object to serailize/deserialize data to/from sql.
+/// Creates buffer object to serialize/deserialize data to/from sql.
 /// This constructor should be used, if data from buffer supposed to be stored in file.
 /// Mode should be either TBuffer::kRead or TBuffer::kWrite.
 
-TBufferSQL2::TBufferSQL2(TBuffer::EMode mode, TSQLFile* file) :
-   TBufferFile(mode),
-   fSQL(0),
-   fStructure(0),
-   fStk(0),
-   fObjMap(0),
-   fReadBuffer(),
-   fErrorFlag(0),
-   fExpectedChain(kFALSE),
-   fCompressLevel(0),
-   fReadVersionBuffer(-1),
-   fObjIdCounter(1),
-   fIgnoreVerification(kFALSE),
-   fCurrentData(0),
-   fObjectsInfos(0),
-   fFirstObjId(0),
-   fLastObjId(0),
-   fPoolsMap(0)
+TBufferSQL2::TBufferSQL2(TBuffer::EMode mode, TSQLFile *file)
+   : TBufferFile(mode), fSQL(0), fStructure(0), fStk(0), fObjMap(0), fReadBuffer(), fErrorFlag(0),
+     fExpectedChain(kFALSE), fCompressLevel(0), fReadVersionBuffer(-1), fObjIdCounter(1), fIgnoreVerification(kFALSE),
+     fCurrentData(0), fObjectsInfos(0), fFirstObjId(0), fLastObjId(0), fPoolsMap(0)
 {
    fBufSize = 1000000000;
 
@@ -146,7 +104,7 @@ TBufferSQL2::TBufferSQL2(TBuffer::EMode mode, TSQLFile* file) :
 
    SetParent(file);
    fSQL = file;
-   if (file!=0)
+   if (file != 0)
       SetCompressionLevel(file->GetCompressionLevel());
 }
 
@@ -155,19 +113,20 @@ TBufferSQL2::TBufferSQL2(TBuffer::EMode mode, TSQLFile* file) :
 
 TBufferSQL2::~TBufferSQL2()
 {
-   if (fObjMap) delete fObjMap;
+   if (fObjMap)
+      delete fObjMap;
 
-   if (fStructure!=0) {
+   if (fStructure != 0) {
       delete fStructure;
       fStructure = 0;
    }
 
-   if (fObjectsInfos!=0) {
+   if (fObjectsInfos != 0) {
       fObjectsInfos->Delete();
       delete fObjectsInfos;
    }
 
-   if (fPoolsMap!=0) {
+   if (fPoolsMap != 0) {
       fPoolsMap->DeleteValues();
       delete fPoolsMap;
    }
@@ -178,7 +137,7 @@ TBufferSQL2::~TBufferSQL2()
 /// Return pointer on created TSQLStructure
 /// TSQLStructure object will be owned by TBufferSQL2
 
-TSQLStructure* TBufferSQL2::SqlWriteAny(const void* obj, const TClass* cl, Long64_t objid)
+TSQLStructure *TBufferSQL2::SqlWriteAny(const void *obj, const TClass *cl, Long64_t objid)
 {
    fErrorFlag = 0;
 
@@ -189,8 +148,8 @@ TSQLStructure* TBufferSQL2::SqlWriteAny(const void* obj, const TClass* cl, Long6
 
    SqlWriteObject(obj, cl);
 
-   if (gDebug>3)
-      if (fStructure!=0) {
+   if (gDebug > 3)
+      if (fStructure != 0) {
          std::cout << "==== Printout of Sql structures ===== " << std::endl;
          fStructure->Print("*");
          std::cout << "=========== End printout ============ " << std::endl;
@@ -204,10 +163,12 @@ TSQLStructure* TBufferSQL2::SqlWriteAny(const void* obj, const TClass* cl, Long6
 /// Return pointer to read object.
 /// if (cl!=0) returns pointer to class of object
 
-void* TBufferSQL2::SqlReadAny(Long64_t keyid, Long64_t objid, TClass** cl, void* obj)
+void *TBufferSQL2::SqlReadAny(Long64_t keyid, Long64_t objid, TClass **cl, void *obj)
 {
-   if (cl) *cl = 0;
-   if (fSQL==0) return 0;
+   if (cl)
+      *cl = 0;
+   if (fSQL == 0)
+      return 0;
 
    fCurrentData = 0;
    fErrorFlag = 0;
@@ -215,12 +176,13 @@ void* TBufferSQL2::SqlReadAny(Long64_t keyid, Long64_t objid, TClass** cl, void*
    fReadVersionBuffer = -1;
 
    fObjectsInfos = fSQL->SQLObjectsInfo(keyid);
-//   fObjectsInfos = 0;
+   //   fObjectsInfos = 0;
    fFirstObjId = objid;
    fLastObjId = objid;
-   if (fObjectsInfos!=0) {
-      TSQLObjectInfo* objinfo = (TSQLObjectInfo*) fObjectsInfos->Last();
-      if (objinfo!=0) fLastObjId = objinfo->GetObjId();
+   if (fObjectsInfos != 0) {
+      TSQLObjectInfo *objinfo = (TSQLObjectInfo *)fObjectsInfos->Last();
+      if (objinfo != 0)
+         fLastObjId = objinfo->GetObjId();
    }
 
    return SqlReadObjectDirect(obj, cl, objid);
@@ -228,44 +190,47 @@ void* TBufferSQL2::SqlReadAny(Long64_t keyid, Long64_t objid, TClass** cl, void*
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Returns object info like classname and version
-/// Should be taken from buffer, which is produced in the begginnig
+/// Should be taken from buffer, which is produced in the beginning
 
-Bool_t TBufferSQL2::SqlObjectInfo(Long64_t objid, TString& clname, Version_t& version)
+Bool_t TBufferSQL2::SqlObjectInfo(Long64_t objid, TString &clname, Version_t &version)
 {
-   if ((objid<0) || (fObjectsInfos==0)) return kFALSE;
+   if ((objid < 0) || (fObjectsInfos == 0))
+      return kFALSE;
 
- //  if (fObjectsInfos==0) return fSQL->SQLObjectInfo(objid, clname, version);
+   //  if (fObjectsInfos==0) return fSQL->SQLObjectInfo(objid, clname, version);
 
    // suppose that objects info are sorted out
 
    Long64_t shift = objid - fFirstObjId;
 
-   TSQLObjectInfo* info = 0;
-   if ((shift>=0) && (shift<=fObjectsInfos->GetLast())) {
-      info = (TSQLObjectInfo*) fObjectsInfos->At(shift);
-      if (info->GetObjId()!=objid) info = 0;
+   TSQLObjectInfo *info = 0;
+   if ((shift >= 0) && (shift <= fObjectsInfos->GetLast())) {
+      info = (TSQLObjectInfo *)fObjectsInfos->At(shift);
+      if (info->GetObjId() != objid)
+         info = 0;
    }
 
-   if (info==0) {
+   if (info == 0) {
       // I hope, i will never get inside it
       Info("SqlObjectInfo", "Standard not works %lld", objid);
-      for (Int_t n=0;n<=fObjectsInfos->GetLast();n++) {
-         info = (TSQLObjectInfo*) fObjectsInfos->At(n);
-         if (info->GetObjId()==objid) break;
+      for (Int_t n = 0; n <= fObjectsInfos->GetLast(); n++) {
+         info = (TSQLObjectInfo *)fObjectsInfos->At(n);
+         if (info->GetObjId() == objid)
+            break;
          info = 0;
       }
    }
 
-   if (info==0) return kFALSE;
+   if (info == 0)
+      return kFALSE;
 
    clname = info->GetObjClassName();
    version = info->GetObjVersion();
    return kTRUE;
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
-/// Creates TSQLObjectData for specifed object id and specified class
+/// Creates TSQLObjectData for specified object id and specified class
 ///
 /// Object data for each class can be stored in two different tables.
 /// First table contains data in column-wise form for simple types like integer,
@@ -274,52 +239,57 @@ Bool_t TBufferSQL2::SqlObjectInfo(Long64_t objid, TString& clname, Version_t& ve
 /// TSQLObjectData will contain results of the requests to both such tables for
 /// concrete object id.
 
-TSQLObjectData* TBufferSQL2::SqlObjectData(Long64_t objid, TSQLClassInfo* sqlinfo)
+TSQLObjectData *TBufferSQL2::SqlObjectData(Long64_t objid, TSQLClassInfo *sqlinfo)
 {
    TSQLResult *classdata = 0;
    TSQLRow *classrow = 0;
 
    if (sqlinfo->IsClassTableExist()) {
 
-      TSQLObjectDataPool* pool = 0;
+      TSQLObjectDataPool *pool = 0;
 
-      if (fPoolsMap!=0)
-        pool = (TSQLObjectDataPool*) fPoolsMap->GetValue(sqlinfo);
+      if (fPoolsMap != 0)
+         pool = (TSQLObjectDataPool *)fPoolsMap->GetValue(sqlinfo);
 
-      if ((pool==0) && (fLastObjId>=fFirstObjId)) {
-         if (gDebug>4) Info("SqlObjectData","Before request to %s",sqlinfo->GetClassTableName());
+      if ((pool == 0) && (fLastObjId >= fFirstObjId)) {
+         if (gDebug > 4)
+            Info("SqlObjectData", "Before request to %s", sqlinfo->GetClassTableName());
          TSQLResult *alldata = fSQL->GetNormalClassDataAll(fFirstObjId, fLastObjId, sqlinfo);
-         if (gDebug>4) Info("SqlObjectData","After request res = 0x%lx",(Long_t)alldata);
-         if (alldata==0) {
-            Error("SqlObjectData","Cannot get data from table %s",sqlinfo->GetClassTableName());
+         if (gDebug > 4)
+            Info("SqlObjectData", "After request res = 0x%lx", (Long_t)alldata);
+         if (alldata == 0) {
+            Error("SqlObjectData", "Cannot get data from table %s", sqlinfo->GetClassTableName());
             return 0;
          }
 
-         if (fPoolsMap==0) fPoolsMap = new TMap();
+         if (fPoolsMap == 0)
+            fPoolsMap = new TMap();
          pool = new TSQLObjectDataPool(sqlinfo, alldata);
          fPoolsMap->Add(sqlinfo, pool);
       }
 
-      if (pool==0) return 0;
+      if (pool == 0)
+         return 0;
 
-      if (pool->GetSqlInfo()!=sqlinfo) {
-         Error("SqlObjectData","Missmatch in pools map !!! CANNOT BE !!!");
+      if (pool->GetSqlInfo() != sqlinfo) {
+         Error("SqlObjectData", "Missmatch in pools map !!! CANNOT BE !!!");
          return 0;
       }
 
       classdata = pool->GetClassData();
 
       classrow = pool->GetObjectRow(objid);
-      if (classrow==0) {
-         Error("SqlObjectData","Can not find row for objid = %lld in table %s", objid, sqlinfo->GetClassTableName());
+      if (classrow == 0) {
+         Error("SqlObjectData", "Can not find row for objid = %lld in table %s", objid, sqlinfo->GetClassTableName());
          return 0;
       }
    }
 
    TSQLResult *blobdata = 0;
-   TSQLStatement* blobstmt = fSQL->GetBlobClassDataStmt(objid, sqlinfo);
+   TSQLStatement *blobstmt = fSQL->GetBlobClassDataStmt(objid, sqlinfo);
 
-   if (blobstmt==0) blobdata = fSQL->GetBlobClassData(objid, sqlinfo);
+   if (blobstmt == 0)
+      blobdata = fSQL->GetBlobClassData(objid, sqlinfo);
 
    return new TSQLObjectData(sqlinfo, objid, classdata, classrow, blobdata, blobstmt);
 }
@@ -340,31 +310,31 @@ void TBufferSQL2::WriteObject(const TObject *obj)
 /// If object was written before, only pointer will be stored
 /// Return id of saved object
 
-Int_t TBufferSQL2::SqlWriteObject(const void* obj, const TClass* cl, TMemberStreamer *streamer, Int_t streamer_index)
+Int_t TBufferSQL2::SqlWriteObject(const void *obj, const TClass *cl, TMemberStreamer *streamer, Int_t streamer_index)
 {
-   if (gDebug>1)
+   if (gDebug > 1)
       std::cout << " SqlWriteObject " << obj << " : cl = " << (cl ? cl->GetName() : "null") << std::endl;
 
    PushStack();
 
    Long64_t objid = -1;
 
-   if (cl==0) obj = 0;
+   if (cl == 0)
+      obj = 0;
 
-   if (obj==0)
+   if (obj == 0)
       objid = 0;
-   else
-   if (fObjMap!=0) {
-      ULong_t hash = TString::Hash(&obj, sizeof(void*));
-      Long_t value = fObjMap->GetValue(hash, (Long_t) obj);
-      if (value>0)
+   else if (fObjMap != 0) {
+      ULong_t hash = TString::Hash(&obj, sizeof(void *));
+      Long_t value = fObjMap->GetValue(hash, (Long_t)obj);
+      if (value > 0)
          objid = fFirstObjId + value - 1;
    }
 
-   if (gDebug>1)
+   if (gDebug > 1)
       std::cout << "    Find objectid = " << objid << std::endl;
 
-   if (objid>=0) {
+   if (objid >= 0) {
       Stack()->SetObjectPointer(objid);
       PopStack();
       return objid;
@@ -374,17 +344,18 @@ Int_t TBufferSQL2::SqlWriteObject(const void* obj, const TClass* cl, TMemberStre
 
    Stack()->SetObjectRef(objid, cl);
 
-   ULong_t hash = TString::Hash(&obj, sizeof(void*));
-   if (fObjMap==0) fObjMap = new TExMap();
-   if (fObjMap->GetValue(hash, (Long_t) obj)==0)
-      fObjMap->Add(hash, (Long_t) obj, (Long_t) objid - fFirstObjId + 1);
+   ULong_t hash = TString::Hash(&obj, sizeof(void *));
+   if (fObjMap == 0)
+      fObjMap = new TExMap();
+   if (fObjMap->GetValue(hash, (Long_t)obj) == 0)
+      fObjMap->Add(hash, (Long_t)obj, (Long_t)objid - fFirstObjId + 1);
 
-   if (streamer!=0)
-      (*streamer)(*this, (void*) obj, streamer_index);
+   if (streamer != 0)
+      (*streamer)(*this, (void *)obj, streamer_index);
    else
-      ((TClass*)cl)->Streamer((void*)obj, *this);
+      ((TClass *)cl)->Streamer((void *)obj, *this);
 
-   if (gDebug>1)
+   if (gDebug > 1)
       std::cout << "Done write of " << cl->GetName() << std::endl;
 
    PopStack();
@@ -395,17 +366,20 @@ Int_t TBufferSQL2::SqlWriteObject(const void* obj, const TClass* cl, TMemberStre
 ////////////////////////////////////////////////////////////////////////////////
 /// Read object from the buffer
 
-void* TBufferSQL2::SqlReadObject(void* obj, TClass** cl, TMemberStreamer *streamer, Int_t streamer_index, const TClass *onFileClass)
+void *TBufferSQL2::SqlReadObject(void *obj, TClass **cl, TMemberStreamer *streamer, Int_t streamer_index,
+                                 const TClass *onFileClass)
 {
-   if (cl) *cl = 0;
+   if (cl)
+      *cl = 0;
 
-   if (fErrorFlag>0) return obj;
+   if (fErrorFlag > 0)
+      return obj;
 
    Bool_t findptr = kFALSE;
 
-   const char* refid = fCurrentData->GetValue();
-   if ((refid==0) || (strlen(refid)==0)) {
-      Error("SqlReadObject","Invalid object reference value");
+   const char *refid = fCurrentData->GetValue();
+   if ((refid == 0) || (strlen(refid) == 0)) {
+      Error("SqlReadObject", "Invalid object reference value");
       fErrorFlag = 1;
       return obj;
    }
@@ -413,26 +387,25 @@ void* TBufferSQL2::SqlReadObject(void* obj, TClass** cl, TMemberStreamer *stream
    Long64_t objid = -1;
    sscanf(refid, FLong64, &objid);
 
-   if (gDebug>2)
-      Info("SqlReadObject","Starting objid = %lld column=%s", objid, fCurrentData->GetLocatedField());
+   if (gDebug > 2)
+      Info("SqlReadObject", "Starting objid = %lld column=%s", objid, fCurrentData->GetLocatedField());
 
-   if (!fCurrentData->IsBlobData() ||
-       fCurrentData->VerifyDataType(sqlio::ObjectPtr,kFALSE)) {
-      if (objid==0) {
+   if (!fCurrentData->IsBlobData() || fCurrentData->VerifyDataType(sqlio::ObjectPtr, kFALSE)) {
+      if (objid == 0) {
          obj = 0;
          findptr = kTRUE;
       } else {
-         if (objid==-1) {
+         if (objid == -1) {
             findptr = kTRUE;
          } else {
-            if ((fObjMap!=0) && (objid>=fFirstObjId)) {
-               void* obj1 = (void*) (Long_t)fObjMap->GetValue((Long_t) objid - fFirstObjId);
-               if (obj1!=0) {
+            if ((fObjMap != 0) && (objid >= fFirstObjId)) {
+               void *obj1 = (void *)(Long_t)fObjMap->GetValue((Long_t)objid - fFirstObjId);
+               if (obj1 != 0) {
                   obj = obj1;
                   findptr = kTRUE;
                   TString clname;
                   Version_t version;
-                  if ((cl!=0) && SqlObjectInfo(objid, clname, version))
+                  if ((cl != 0) && SqlObjectInfo(objid, clname, version))
                      *cl = TClass::GetClass(clname);
                }
             }
@@ -440,9 +413,9 @@ void* TBufferSQL2::SqlReadObject(void* obj, TClass** cl, TMemberStreamer *stream
       }
    }
 
-   if ((gDebug>3) && findptr)
-      std::cout << "    Found pointer " << (obj ? obj : 0)
-           << " class = " << ((cl && *cl) ? (*cl)->GetName() : "null") << std::endl;
+   if ((gDebug > 3) && findptr)
+      std::cout << "    Found pointer " << (obj ? obj : 0) << " class = " << ((cl && *cl) ? (*cl)->GetName() : "null")
+                << std::endl;
 
    if (findptr) {
       fCurrentData->ShiftToNextValue();
@@ -451,14 +424,14 @@ void* TBufferSQL2::SqlReadObject(void* obj, TClass** cl, TMemberStreamer *stream
 
    if (fCurrentData->IsBlobData())
       if (!fCurrentData->VerifyDataType(sqlio::ObjectRef)) {
-         Error("SqlReadObject","Object reference or pointer is not found in blob data");
+         Error("SqlReadObject", "Object reference or pointer is not found in blob data");
          fErrorFlag = 1;
          return obj;
       }
 
    fCurrentData->ShiftToNextValue();
 
-   if ((gDebug>2) || (objid<0))
+   if ((gDebug > 2) || (objid < 0))
       std::cout << "Found object reference " << objid << std::endl;
 
    return SqlReadObjectDirect(obj, cl, objid, streamer, streamer_index, onFileClass);
@@ -468,46 +441,50 @@ void* TBufferSQL2::SqlReadObject(void* obj, TClass** cl, TMemberStreamer *stream
 /// Read object data.
 /// Class name and version are taken from special objects table.
 
-void* TBufferSQL2::SqlReadObjectDirect(void* obj, TClass** cl, Long64_t objid, TMemberStreamer *streamer, Int_t streamer_index, const TClass *onFileClass)
+void *TBufferSQL2::SqlReadObjectDirect(void *obj, TClass **cl, Long64_t objid, TMemberStreamer *streamer,
+                                       Int_t streamer_index, const TClass *onFileClass)
 {
    TString clname;
    Version_t version;
 
-   if (!SqlObjectInfo(objid, clname, version)) return obj;
+   if (!SqlObjectInfo(objid, clname, version))
+      return obj;
 
-   if (gDebug>2)
-      Info("SqlReadObjectDirect","objid = %lld clname = %s ver = %d",objid, clname.Data(), version);
+   if (gDebug > 2)
+      Info("SqlReadObjectDirect", "objid = %lld clname = %s ver = %d", objid, clname.Data(), version);
 
-   TSQLClassInfo* sqlinfo = fSQL->FindSQLClassInfo(clname.Data(), version);
+   TSQLClassInfo *sqlinfo = fSQL->FindSQLClassInfo(clname.Data(), version);
 
-   TClass* objClass = TClass::GetClass(clname);
-   if (objClass == TDirectory::Class()) objClass = TDirectoryFile::Class();
+   TClass *objClass = TClass::GetClass(clname);
+   if (objClass == TDirectory::Class())
+      objClass = TDirectoryFile::Class();
 
-   if ((objClass==0) || (sqlinfo==0)) {
-      Error("SqlReadObjectDirect","Class %s is not known", clname.Data());
+   if ((objClass == 0) || (sqlinfo == 0)) {
+      Error("SqlReadObjectDirect", "Class %s is not known", clname.Data());
       return obj;
    }
 
-   if (obj==0) obj = objClass->New();
+   if (obj == 0)
+      obj = objClass->New();
 
-   if (fObjMap==0) fObjMap = new TExMap();
+   if (fObjMap == 0)
+      fObjMap = new TExMap();
 
-   fObjMap->Add((Long_t) objid - fFirstObjId, (Long_t) obj);
+   fObjMap->Add((Long_t)objid - fFirstObjId, (Long_t)obj);
 
    PushStack()->SetObjectRef(objid, objClass);
 
-   TSQLObjectData* olddata = fCurrentData;
+   TSQLObjectData *olddata = fCurrentData;
 
    if (sqlinfo->IsClassTableExist()) {
       // TObject and TString classes treated differently
-      if ((objClass==TObject::Class()) || (objClass==TString::Class())) {
+      if ((objClass == TObject::Class()) || (objClass == TString::Class())) {
 
-         TSQLObjectData* objdata = new TSQLObjectData;
-         if (objClass==TObject::Class())
+         TSQLObjectData *objdata = new TSQLObjectData;
+         if (objClass == TObject::Class())
             TSQLStructure::UnpackTObject(fSQL, this, objdata, objid, version);
-         else
-            if (objClass==TString::Class())
-               TSQLStructure::UnpackTString(fSQL, this, objdata, objid, version);
+         else if (objClass == TString::Class())
+            TSQLStructure::UnpackTString(fSQL, this, objdata, objid, version);
 
          Stack()->AddObjectData(objdata);
          fCurrentData = objdata;
@@ -516,9 +493,10 @@ void* TBufferSQL2::SqlReadObjectDirect(void* obj, TClass** cl, Long64_t objid, T
          // then streamer functions of TStreamerInfo class
          fReadVersionBuffer = version;
    } else {
-      TSQLObjectData* objdata = SqlObjectData(objid, sqlinfo);
-      if ((objdata==0) || !objdata->PrepareForRawData()) {
-         Error("SqlReadObjectDirect","No found raw data for obj %lld in class %s version %d table", objid, clname.Data(), version);
+      TSQLObjectData *objdata = SqlObjectData(objid, sqlinfo);
+      if ((objdata == 0) || !objdata->PrepareForRawData()) {
+         Error("SqlReadObjectDirect", "No found raw data for obj %lld in class %s version %d table", objid,
+               clname.Data(), version);
          fErrorFlag = 1;
          return obj;
       }
@@ -528,19 +506,20 @@ void* TBufferSQL2::SqlReadObjectDirect(void* obj, TClass** cl, Long64_t objid, T
       fCurrentData = objdata;
    }
 
-   if (streamer!=0) {
-      streamer->SetOnFileClass( onFileClass );
-      (*streamer)(*this, (void*)obj, streamer_index);
+   if (streamer != 0) {
+      streamer->SetOnFileClass(onFileClass);
+      (*streamer)(*this, (void *)obj, streamer_index);
    } else {
-      objClass->Streamer((void*)obj, *this, onFileClass);
+      objClass->Streamer((void *)obj, *this, onFileClass);
    }
 
    PopStack();
 
-   if (gDebug>1)
+   if (gDebug > 1)
       std::cout << "Read object of class " << objClass->GetName() << " done" << std::endl << std::endl;
 
-   if (cl!=0) *cl = objClass;
+   if (cl != 0)
+      *cl = objClass;
 
    fCurrentData = olddata;
 
@@ -553,13 +532,14 @@ void* TBufferSQL2::SqlReadObjectDirect(void* obj, TClass** cl, Long64_t objid, T
 /// This call indicates, that TStreamerInfo functions starts streaming
 /// object data of correspondent class
 
-void  TBufferSQL2::IncrementLevel(TVirtualStreamerInfo* info)
+void TBufferSQL2::IncrementLevel(TVirtualStreamerInfo *info)
 {
-   if (info==0) return;
+   if (info == 0)
+      return;
 
-   PushStack()->SetStreamerInfo((TStreamerInfo*)info);
+   PushStack()->SetStreamerInfo((TStreamerInfo *)info);
 
-   if (gDebug>2)
+   if (gDebug > 2)
       std::cout << " IncrementLevel " << info->GetName() << std::endl;
 
    WorkWithClass(info->GetName(), info->GetClassVersion());
@@ -569,18 +549,19 @@ void  TBufferSQL2::IncrementLevel(TVirtualStreamerInfo* info)
 /// Function is called from TStreamerInfo WriteBuffer and Readbuffer functions
 /// and decrease level in sql structure.
 
-void  TBufferSQL2::DecrementLevel(TVirtualStreamerInfo* info)
+void TBufferSQL2::DecrementLevel(TVirtualStreamerInfo *info)
 {
-   TSQLStructure* curr = Stack();
-   if (curr->GetElement()) PopStack(); // for element
-   PopStack();  // for streamerinfo
+   TSQLStructure *curr = Stack();
+   if (curr->GetElement())
+      PopStack(); // for element
+   PopStack();    // for streamerinfo
 
    // restore value of object data
    fCurrentData = Stack()->GetObjectData(kTRUE);
 
    fExpectedChain = kFALSE;
 
-   if (gDebug>2)
+   if (gDebug > 2)
       std::cout << " DecrementLevel " << info->GetClass()->GetName() << std::endl;
 }
 
@@ -591,19 +572,19 @@ void  TBufferSQL2::DecrementLevel(TVirtualStreamerInfo* info)
 
 void TBufferSQL2::SetStreamerElementNumber(TStreamerElement *elem, Int_t comp_type)
 {
-   if (Stack()->GetElement()) PopStack(); // was with if (number > 0), i.e. not first element.
-   TSQLStructure* curr = Stack();
+   if (Stack()->GetElement())
+      PopStack(); // was with if (number > 0), i.e. not first element.
+   TSQLStructure *curr = Stack();
 
-   TStreamerInfo* info = curr->GetStreamerInfo();
-   if (info==0) {
-      Error("SetStreamerElementNumber","Error in structures stack");
+   TStreamerInfo *info = curr->GetStreamerInfo();
+   if (info == 0) {
+      Error("SetStreamerElementNumber", "Error in structures stack");
       return;
    }
 
    Int_t elem_type = elem->GetType();
 
-   fExpectedChain = ((elem_type>0) && (elem_type<20)) &&
-      (comp_type - elem_type == TStreamerInfo::kOffsetL);
+   fExpectedChain = ((elem_type > 0) && (elem_type < 20)) && (comp_type - elem_type == TStreamerInfo::kOffsetL);
 
    WorkWithElement(elem, comp_type);
 }
@@ -623,30 +604,32 @@ void TBufferSQL2::SetStreamerElementNumber(TStreamerElement *elem, Int_t comp_ty
 /// procedure, but should be read back in custom streamer.
 /// For example, custom streamer of TNamed class may look like:
 
-void TBufferSQL2::ClassBegin(const TClass* cl, Version_t classversion)
+void TBufferSQL2::ClassBegin(const TClass *cl, Version_t classversion)
 {
-// void TNamed::Streamer(TBuffer &b)
-//   UInt_t R__s, R__c;
-//   if (b.IsReading()) {
-//      Version_t R__v = b.ReadVersion(&R__s, &R__c);
-//      b.ClassBegin(TNamed::Class(), R__v);
-//      b.ClassMember("TObject");
-//      TObject::Streamer(b);
-//      b.ClassMember("fName","TString");
-//      fName.Streamer(b);
-//      b.ClassMember("fTitle","TString");
-//      fTitle.Streamer(b);
-//      b.ClassEnd(TNamed::Class());
-//      b.SetBufferOffset(R__s+R__c+sizeof(UInt_t));
-//   } else {
-//      TNamed::Class()->WriteBuffer(b,this);
-//   }
+   // void TNamed::Streamer(TBuffer &b)
+   //   UInt_t R__s, R__c;
+   //   if (b.IsReading()) {
+   //      Version_t R__v = b.ReadVersion(&R__s, &R__c);
+   //      b.ClassBegin(TNamed::Class(), R__v);
+   //      b.ClassMember("TObject");
+   //      TObject::Streamer(b);
+   //      b.ClassMember("fName","TString");
+   //      fName.Streamer(b);
+   //      b.ClassMember("fTitle","TString");
+   //      fTitle.Streamer(b);
+   //      b.ClassEnd(TNamed::Class());
+   //      b.SetBufferOffset(R__s+R__c+sizeof(UInt_t));
+   //   } else {
+   //      TNamed::Class()->WriteBuffer(b,this);
+   //   }
 
-   if (classversion<0) classversion = cl->GetClassVersion();
+   if (classversion < 0)
+      classversion = cl->GetClassVersion();
 
    PushStack()->SetCustomClass(cl, classversion);
 
-   if (gDebug>2) Info("ClassBegin", "%s", cl->GetName());
+   if (gDebug > 2)
+      Info("ClassBegin", "%s", cl->GetName());
 
    WorkWithClass(cl->GetName(), classversion);
 }
@@ -655,18 +638,20 @@ void TBufferSQL2::ClassBegin(const TClass* cl, Version_t classversion)
 /// Method indicates end of streaming of classdata in custom streamer.
 /// See ClassBegin() method for more details.
 
-void TBufferSQL2::ClassEnd(const TClass* cl)
+void TBufferSQL2::ClassEnd(const TClass *cl)
 {
-   TSQLStructure* curr = Stack();
-   if (curr->GetType()==TSQLStructure::kSqlCustomElement) PopStack(); // for element
-   PopStack();  // for streamerinfo
+   TSQLStructure *curr = Stack();
+   if (curr->GetType() == TSQLStructure::kSqlCustomElement)
+      PopStack(); // for element
+   PopStack();    // for streamerinfo
 
    // restore value of object data
    fCurrentData = Stack()->GetObjectData(kTRUE);
 
    fExpectedChain = kFALSE;
 
-   if (gDebug>2) Info("ClassEnd","%s",cl->GetName());
+   if (gDebug > 2)
+      Info("ClassEnd", "%s", cl->GetName());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -675,12 +660,13 @@ void TBufferSQL2::ClassEnd(const TClass* cl)
 /// Following combinations are supported:
 /// see TBufferXML::ClassMember for the details.
 
-void TBufferSQL2::ClassMember(const char* name, const char* typeName, Int_t arrsize1, Int_t arrsize2)
+void TBufferSQL2::ClassMember(const char *name, const char *typeName, Int_t arrsize1, Int_t arrsize2)
 {
-   if (typeName==0) typeName = name;
+   if (typeName == 0)
+      typeName = name;
 
-   if ((name==0) || (strlen(name)==0)) {
-      Error("ClassMember","Invalid member name");
+   if ((name == 0) || (strlen(name) == 0)) {
+      Error("ClassMember", "Invalid member name");
       fErrorFlag = 1;
       return;
    }
@@ -689,31 +675,32 @@ void TBufferSQL2::ClassMember(const char* name, const char* typeName, Int_t arrs
 
    Int_t typ_id = -1;
 
-   if (strcmp(typeName,"raw:data")==0)
+   if (strcmp(typeName, "raw:data") == 0)
       typ_id = TStreamerInfo::kMissing;
 
-   if (typ_id<0) {
+   if (typ_id < 0) {
       TDataType *dt = gROOT->GetType(typeName);
-      if (dt!=0)
-         if ((dt->GetType()>0) && (dt->GetType()<20))
+      if (dt != 0)
+         if ((dt->GetType() > 0) && (dt->GetType() < 20))
             typ_id = dt->GetType();
    }
 
-   if (typ_id<0)
-      if (strcmp(name, typeName)==0) {
-         TClass* cl = TClass::GetClass(tname.Data());
-         if (cl!=0) typ_id = TStreamerInfo::kBase;
+   if (typ_id < 0)
+      if (strcmp(name, typeName) == 0) {
+         TClass *cl = TClass::GetClass(tname.Data());
+         if (cl != 0)
+            typ_id = TStreamerInfo::kBase;
       }
 
-   if (typ_id<0) {
+   if (typ_id < 0) {
       Bool_t isptr = kFALSE;
-      if (tname[tname.Length()-1]=='*') {
-         tname.Resize(tname.Length()-1);
+      if (tname[tname.Length() - 1] == '*') {
+         tname.Resize(tname.Length() - 1);
          isptr = kTRUE;
       }
-      TClass* cl = TClass::GetClass(tname.Data());
-      if (cl==0) {
-         Error("ClassMember","Invalid class specifier %s", typeName);
+      TClass *cl = TClass::GetClass(tname.Data());
+      if (cl == 0) {
+         Error("ClassMember", "Invalid class specifier %s", typeName);
          fErrorFlag = 1;
          return;
       }
@@ -723,66 +710,66 @@ void TBufferSQL2::ClassMember(const char* name, const char* typeName, Int_t arrs
       else
          typ_id = isptr ? TStreamerInfo::kAnyp : TStreamerInfo::kAny;
 
-      if ((cl==TString::Class()) && !isptr)
+      if ((cl == TString::Class()) && !isptr)
          typ_id = TStreamerInfo::kTString;
    }
 
-   TStreamerElement* elem = 0;
+   TStreamerElement *elem = 0;
 
    if (typ_id == TStreamerInfo::kMissing) {
-      elem = new TStreamerElement(name,"title",0, typ_id, "raw:data");
+      elem = new TStreamerElement(name, "title", 0, typ_id, "raw:data");
    } else
 
-   if (typ_id==TStreamerInfo::kBase) {
-      TClass* cl = TClass::GetClass(tname.Data());
-      if (cl!=0) {
-         TStreamerBase* b = new TStreamerBase(tname.Data(), "title", 0);
+      if (typ_id == TStreamerInfo::kBase) {
+      TClass *cl = TClass::GetClass(tname.Data());
+      if (cl != 0) {
+         TStreamerBase *b = new TStreamerBase(tname.Data(), "title", 0);
          b->SetBaseVersion(cl->GetClassVersion());
          elem = b;
       }
    } else
 
-   if ((typ_id>0) && (typ_id<20)) {
+      if ((typ_id > 0) && (typ_id < 20)) {
       elem = new TStreamerBasicType(name, "title", 0, typ_id, typeName);
    } else
 
-   if ((typ_id==TStreamerInfo::kObject) ||
-       (typ_id==TStreamerInfo::kTObject) ||
-       (typ_id==TStreamerInfo::kTNamed)) {
+      if ((typ_id == TStreamerInfo::kObject) || (typ_id == TStreamerInfo::kTObject) ||
+          (typ_id == TStreamerInfo::kTNamed)) {
       elem = new TStreamerObject(name, "title", 0, tname.Data());
    } else
 
-   if (typ_id==TStreamerInfo::kObjectp) {
+      if (typ_id == TStreamerInfo::kObjectp) {
       elem = new TStreamerObjectPointer(name, "title", 0, tname.Data());
    } else
 
-   if (typ_id==TStreamerInfo::kAny) {
+      if (typ_id == TStreamerInfo::kAny) {
       elem = new TStreamerObjectAny(name, "title", 0, tname.Data());
    } else
 
-   if (typ_id==TStreamerInfo::kAnyp) {
+      if (typ_id == TStreamerInfo::kAnyp) {
       elem = new TStreamerObjectAnyPointer(name, "title", 0, tname.Data());
    } else
 
-   if (typ_id==TStreamerInfo::kTString) {
+      if (typ_id == TStreamerInfo::kTString) {
       elem = new TStreamerString(name, "title", 0);
    }
 
-   if (elem==0) {
-      Error("ClassMember","Invalid combination name = %s type = %s", name, typeName);
+   if (elem == 0) {
+      Error("ClassMember", "Invalid combination name = %s type = %s", name, typeName);
       fErrorFlag = 1;
       return;
    }
 
-   if (arrsize1>0) {
-      elem->SetArrayDim(arrsize2>0 ? 2 : 1);
+   if (arrsize1 > 0) {
+      elem->SetArrayDim(arrsize2 > 0 ? 2 : 1);
       elem->SetMaxIndex(0, arrsize1);
-      if (arrsize2>0)
+      if (arrsize2 > 0)
          elem->SetMaxIndex(1, arrsize2);
    }
 
    // return stack to CustomClass node
-   if (Stack()->GetType()==TSQLStructure::kSqlCustomElement) PopStack();
+   if (Stack()->GetType() == TSQLStructure::kSqlCustomElement)
+      PopStack();
 
    fExpectedChain = kFALSE;
 
@@ -794,41 +781,42 @@ void TBufferSQL2::ClassMember(const char* name, const char* typeName, Int_t arrs
 /// This function is a part of IncrementLevel method.
 /// Also used in StartClass method
 
-void TBufferSQL2::WorkWithClass(const char* classname, Version_t classversion)
+void TBufferSQL2::WorkWithClass(const char *classname, Version_t classversion)
 {
    fExpectedChain = kFALSE;
 
    if (IsReading()) {
       Long64_t objid = 0;
 
-//      if ((fCurrentData!=0) && fCurrentData->VerifyDataType(sqlio::ObjectInst, kFALSE))
-//        if (!fCurrentData->IsBlobData()) Info("WorkWithClass","Big problem %s", fCurrentData->GetValue());
+      //      if ((fCurrentData!=0) && fCurrentData->VerifyDataType(sqlio::ObjectInst, kFALSE))
+      //        if (!fCurrentData->IsBlobData()) Info("WorkWithClass","Big problem %s", fCurrentData->GetValue());
 
-      if ((fCurrentData!=0) && fCurrentData->IsBlobData() &&
+      if ((fCurrentData != 0) && fCurrentData->IsBlobData() &&
           fCurrentData->VerifyDataType(sqlio::ObjectInst, kFALSE)) {
          objid = atoi(fCurrentData->GetValue());
          fCurrentData->ShiftToNextValue();
          TString sobjid;
-         sobjid.Form("%lld",objid);
+         sobjid.Form("%lld", objid);
          Stack()->ChangeValueOnly(sobjid.Data());
       } else
          objid = Stack()->DefineObjectId(kTRUE);
-      if (objid<0) {
-         Error("WorkWithClass","cannot define object id");
+      if (objid < 0) {
+         Error("WorkWithClass", "cannot define object id");
          fErrorFlag = 1;
          return;
       }
 
-      TSQLClassInfo* sqlinfo = fSQL->FindSQLClassInfo(classname, classversion);
-      if (sqlinfo==0) {
-         Error("WorkWithClass","Can not find table for class %s version %d", classname, classversion);
+      TSQLClassInfo *sqlinfo = fSQL->FindSQLClassInfo(classname, classversion);
+      if (sqlinfo == 0) {
+         Error("WorkWithClass", "Can not find table for class %s version %d", classname, classversion);
          fErrorFlag = 1;
          return;
       }
 
-      TSQLObjectData* objdata = SqlObjectData(objid, sqlinfo);
-      if (objdata==0) {
-         Error("WorkWithClass","Request error for data of object %lld for class %s version %d", objid, classname, classversion);
+      TSQLObjectData *objdata = SqlObjectData(objid, sqlinfo);
+      if (objdata == 0) {
+         Error("WorkWithClass", "Request error for data of object %lld for class %s version %d", objid, classname,
+               classversion);
          fErrorFlag = 1;
          return;
       }
@@ -845,24 +833,24 @@ void TBufferSQL2::WorkWithClass(const char* classname, Version_t classversion)
 /// Used also in ReadFastArray methods to resolve problem of compressed data,
 /// when several data memebers of the same basic type streamed with single ...FastArray call
 
-void TBufferSQL2::WorkWithElement(TStreamerElement* elem, Int_t /* comp_type */)
+void TBufferSQL2::WorkWithElement(TStreamerElement *elem, Int_t /* comp_type */)
 {
-   if (gDebug>2)
-      Info("WorkWithElement","elem = %s",elem->GetName());
+   if (gDebug > 2)
+      Info("WorkWithElement", "elem = %s", elem->GetName());
 
-   TSQLStructure* stack = Stack(1);
-   TStreamerInfo* info = stack->GetStreamerInfo();
+   TSQLStructure *stack = Stack(1);
+   TStreamerInfo *info = stack->GetStreamerInfo();
    Int_t number = info ? info->GetElements()->IndexOf(elem) : -1;
 
-   if (number>=0)
+   if (number >= 0)
       PushStack()->SetStreamerElement(elem, number);
    else
       PushStack()->SetCustomElement(elem);
 
    if (IsReading()) {
 
-      if (fCurrentData==0) {
-         Error("WorkWithElement","Object data is lost");
+      if (fCurrentData == 0) {
+         Error("WorkWithElement", "Object data is lost");
          fErrorFlag = 1;
          return;
       }
@@ -871,24 +859,22 @@ void TBufferSQL2::WorkWithElement(TStreamerElement* elem, Int_t /* comp_type */)
 
       Int_t located = Stack()->LocateElementColumn(fSQL, this, fCurrentData);
 
-      if (located==TSQLStructure::kColUnknown) {
-         Error("WorkWithElement","Cannot locate correct column in the table");
+      if (located == TSQLStructure::kColUnknown) {
+         Error("WorkWithElement", "Cannot locate correct column in the table");
          fErrorFlag = 1;
          return;
-      } else
-         if ((located==TSQLStructure::kColObject) ||
-             (located==TSQLStructure::kColObjectArray) ||
-             (located==TSQLStructure::kColParent)) {
-            // search again for object data while for BLOB it should be already assign
-            fCurrentData = Stack()->GetObjectData(kTRUE);
-         }
+      } else if ((located == TSQLStructure::kColObject) || (located == TSQLStructure::kColObjectArray) ||
+                 (located == TSQLStructure::kColParent)) {
+         // search again for object data while for BLOB it should be already assign
+         fCurrentData = Stack()->GetObjectData(kTRUE);
+      }
    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Suppressed function of TBuffer
 
-TClass* TBufferSQL2::ReadClass(const TClass*, UInt_t*)
+TClass *TBufferSQL2::ReadClass(const TClass *, UInt_t *)
 {
    return 0;
 }
@@ -896,14 +882,14 @@ TClass* TBufferSQL2::ReadClass(const TClass*, UInt_t*)
 ////////////////////////////////////////////////////////////////////////////////
 /// Suppressed function of TBuffer
 
-void TBufferSQL2::WriteClass(const TClass*)
+void TBufferSQL2::WriteClass(const TClass *)
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Suppressed function of TBuffer
 
-Int_t TBufferSQL2::CheckByteCount(UInt_t /*r_s */, UInt_t /*r_c*/, const TClass* /*cl*/)
+Int_t TBufferSQL2::CheckByteCount(UInt_t /*r_s */, UInt_t /*r_c*/, const TClass * /*cl*/)
 {
    return 0;
 }
@@ -911,7 +897,7 @@ Int_t TBufferSQL2::CheckByteCount(UInt_t /*r_s */, UInt_t /*r_c*/, const TClass*
 ////////////////////////////////////////////////////////////////////////////////
 /// Suppressed function of TBuffer
 
-Int_t  TBufferSQL2::CheckByteCount(UInt_t, UInt_t, const char*)
+Int_t TBufferSQL2::CheckByteCount(UInt_t, UInt_t, const char *)
 {
    return 0;
 }
@@ -928,7 +914,7 @@ void TBufferSQL2::SetByteCount(UInt_t, Bool_t)
 
 void TBufferSQL2::SkipVersion(const TClass *cl)
 {
-   ReadVersion(0,0,cl);
+   ReadVersion(0, 0, cl);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -940,21 +926,22 @@ Version_t TBufferSQL2::ReadVersion(UInt_t *start, UInt_t *bcnt, const TClass *)
 {
    Version_t res = 0;
 
-   if (start) *start = 0;
-   if (bcnt) *bcnt = 0;
+   if (start)
+      *start = 0;
+   if (bcnt)
+      *bcnt = 0;
 
-   if (fReadVersionBuffer>=0) {
+   if (fReadVersionBuffer >= 0) {
       res = fReadVersionBuffer;
       fReadVersionBuffer = -1;
-      if (gDebug>3)
+      if (gDebug > 3)
          std::cout << "TBufferSQL2::ReadVersion from buffer = " << res << std::endl;
-   } else
-   if ((fCurrentData!=0) && fCurrentData->IsBlobData() &&
-       fCurrentData->VerifyDataType(sqlio::Version)) {
+   } else if ((fCurrentData != 0) && fCurrentData->IsBlobData() && fCurrentData->VerifyDataType(sqlio::Version)) {
       TString value = fCurrentData->GetValue();
       res = value.Atoi();
-      if (gDebug>3)
-         std::cout << "TBufferSQL2::ReadVersion from blob " << fCurrentData->GetBlobPrefixName() << " = " << res << std::endl;
+      if (gDebug > 3)
+         std::cout << "TBufferSQL2::ReadVersion from blob " << fCurrentData->GetBlobPrefixName() << " = " << res
+                   << std::endl;
       fCurrentData->ShiftToNextValue();
    } else {
       Error("ReadVersion", "No correspondent tags to read version");
@@ -971,8 +958,9 @@ Version_t TBufferSQL2::ReadVersion(UInt_t *start, UInt_t *bcnt, const TClass *)
 
 UInt_t TBufferSQL2::WriteVersion(const TClass *cl, Bool_t /* useBcnt */)
 {
-   if (gDebug>2)
-      std::cout << "TBufferSQL2::WriteVersion " << (cl ? cl->GetName() : "null") << "   ver = " << (cl ? cl->GetClassVersion() : 0) << std::endl;
+   if (gDebug > 2)
+      std::cout << "TBufferSQL2::WriteVersion " << (cl ? cl->GetName() : "null")
+                << "   ver = " << (cl ? cl->GetClassVersion() : 0) << std::endl;
 
    if (cl)
       Stack()->AddVersion(cl);
@@ -983,7 +971,7 @@ UInt_t TBufferSQL2::WriteVersion(const TClass *cl, Bool_t /* useBcnt */)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read object from buffer. Only used from TBuffer.
 
-void* TBufferSQL2::ReadObjectAny(const TClass*)
+void *TBufferSQL2::ReadObjectAny(const TClass *)
 {
    return SqlReadObject(0);
 }
@@ -1002,67 +990,71 @@ void TBufferSQL2::SkipObjectAny()
 
 void TBufferSQL2::WriteObjectClass(const void *actualObjStart, const TClass *actualClass)
 {
-   if (gDebug>2)
-      std::cout << "TBufferSQL2::WriteObject of class " << (actualClass ? actualClass->GetName() : " null") << std::endl;
+   if (gDebug > 2)
+      std::cout << "TBufferSQL2::WriteObject of class " << (actualClass ? actualClass->GetName() : " null")
+                << std::endl;
    SqlWriteObject(actualObjStart, actualClass);
 }
 
-#define SQLReadArrayUncompress(vname, arrsize)  \
-   {                                            \
-      while(indx<arrsize)                       \
-         SqlReadBasic(vname[indx++]);           \
+#define SQLReadArrayUncompress(vname, arrsize) \
+   {                                           \
+      while (indx < arrsize)                   \
+         SqlReadBasic(vname[indx++]);          \
    }
 
-
-#define SQLReadArrayCompress(vname, arrsize)                            \
-   {                                                                    \
-      while(indx<arrsize) {                                             \
-         const char* name = fCurrentData->GetBlobPrefixName();          \
-         Int_t first, last, res;                                        \
-         if (strstr(name,sqlio::IndexSepar)==0) {                       \
-            res = sscanf(name,"[%d", &first); last = first;             \
-         } else res = sscanf(name,"[%d..%d", &first, &last);            \
-         if (gDebug>5) std::cout << name << " first = " << first << " last = " << last << " res = " << res << std::endl; \
-         if ((first!=indx) || (last<first) || (last>=arrsize)) {        \
-            Error("SQLReadArrayCompress","Error reading array content %s", name); \
-            fErrorFlag = 1;                                             \
-            break;                                                      \
-         }                                                              \
-         SqlReadBasic(vname[indx]); indx++;                             \
-         while(indx<=last)                                              \
-            vname[indx++] = vname[first];                               \
-      }                                                                 \
+#define SQLReadArrayCompress(vname, arrsize)                                                                  \
+   {                                                                                                          \
+      while (indx < arrsize) {                                                                                \
+         const char *name = fCurrentData->GetBlobPrefixName();                                                \
+         Int_t first, last, res;                                                                              \
+         if (strstr(name, sqlio::IndexSepar) == 0) {                                                          \
+            res = sscanf(name, "[%d", &first);                                                                \
+            last = first;                                                                                     \
+         } else                                                                                               \
+            res = sscanf(name, "[%d..%d", &first, &last);                                                     \
+         if (gDebug > 5)                                                                                      \
+            std::cout << name << " first = " << first << " last = " << last << " res = " << res << std::endl; \
+         if ((first != indx) || (last < first) || (last >= arrsize)) {                                        \
+            Error("SQLReadArrayCompress", "Error reading array content %s", name);                            \
+            fErrorFlag = 1;                                                                                   \
+            break;                                                                                            \
+         }                                                                                                    \
+         SqlReadBasic(vname[indx]);                                                                           \
+         indx++;                                                                                              \
+         while (indx <= last)                                                                                 \
+            vname[indx++] = vname[first];                                                                     \
+      }                                                                                                       \
    }
-
 
 // macro to read content of array with compression
-#define SQLReadArrayContent(vname, arrsize, withsize)                   \
-   {                                                                    \
-      if (gDebug>3) std::cout << "SQLReadArrayContent  " << (arrsize) << std::endl; \
-      PushStack()->SetArray(withsize ? arrsize : -1);                   \
-      Int_t indx = 0;                                                   \
-      if (fCurrentData->IsBlobData())                                   \
-         SQLReadArrayCompress(vname, arrsize)                           \
-         else                                                           \
-            SQLReadArrayUncompress(vname, arrsize)                      \
-               PopStack();                                              \
-      if (gDebug>3) std::cout << "SQLReadArrayContent done " << std::endl;        \
+#define SQLReadArrayContent(vname, arrsize, withsize)                                                 \
+   {                                                                                                  \
+      if (gDebug > 3)                                                                                 \
+         std::cout << "SQLReadArrayContent  " << (arrsize) << std::endl;                              \
+      PushStack()->SetArray(withsize ? arrsize : -1);                                                 \
+      Int_t indx = 0;                                                                                 \
+      if (fCurrentData->IsBlobData())                                                                 \
+         SQLReadArrayCompress(vname, arrsize) else SQLReadArrayUncompress(vname, arrsize) PopStack(); \
+      if (gDebug > 3)                                                                                 \
+         std::cout << "SQLReadArrayContent done " << std::endl;                                       \
    }
 
 // macro to read array, which include size attribute
-#define TBufferSQL2_ReadArray(tname, vname)     \
-   {                                            \
-      Int_t n = SqlReadArraySize();             \
-      if (n<=0) return 0;                       \
-      if (!vname) vname = new tname[n];         \
-      SQLReadArrayContent(vname, n, kTRUE);     \
-      return n;                                 \
+#define TBufferSQL2_ReadArray(tname, vname) \
+   {                                        \
+      Int_t n = SqlReadArraySize();         \
+      if (n <= 0)                           \
+         return 0;                          \
+      if (!vname)                           \
+         vname = new tname[n];              \
+      SQLReadArrayContent(vname, n, kTRUE); \
+      return n;                             \
    }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read Float16 value
 
-void TBufferSQL2::ReadFloat16 (Float_t *f, TStreamerElement * /*ele*/)
+void TBufferSQL2::ReadFloat16(Float_t *f, TStreamerElement * /*ele*/)
 {
    SqlReadBasic(*f);
 }
@@ -1070,7 +1062,7 @@ void TBufferSQL2::ReadFloat16 (Float_t *f, TStreamerElement * /*ele*/)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read Double32 value
 
-void TBufferSQL2::ReadDouble32 (Double_t *d, TStreamerElement * /*ele*/)
+void TBufferSQL2::ReadDouble32(Double_t *d, TStreamerElement * /*ele*/)
 {
    SqlReadBasic(*d);
 }
@@ -1118,7 +1110,7 @@ void TBufferSQL2::ReadWithNbits(Double_t *ptr, Int_t /* nbits */)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write Float16 value
 
-void TBufferSQL2::WriteFloat16 (Float_t *f, TStreamerElement * /*ele*/)
+void TBufferSQL2::WriteFloat16(Float_t *f, TStreamerElement * /*ele*/)
 {
    SqlWriteBasic(*f);
 }
@@ -1126,7 +1118,7 @@ void TBufferSQL2::WriteFloat16 (Float_t *f, TStreamerElement * /*ele*/)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write Double32 value
 
-void TBufferSQL2::WriteDouble32 (Double_t *d, TStreamerElement * /*ele*/)
+void TBufferSQL2::WriteDouble32(Double_t *d, TStreamerElement * /*ele*/)
 {
    SqlWriteBasic(*d);
 }
@@ -1134,81 +1126,81 @@ void TBufferSQL2::WriteDouble32 (Double_t *d, TStreamerElement * /*ele*/)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Bool_t from buffer
 
-Int_t TBufferSQL2::ReadArray(Bool_t    *&b)
+Int_t TBufferSQL2::ReadArray(Bool_t *&b)
 {
-   TBufferSQL2_ReadArray(Bool_t,b);
+   TBufferSQL2_ReadArray(Bool_t, b);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Char_t from buffer
 
-Int_t TBufferSQL2::ReadArray(Char_t    *&c)
+Int_t TBufferSQL2::ReadArray(Char_t *&c)
 {
-   TBufferSQL2_ReadArray(Char_t,c);
+   TBufferSQL2_ReadArray(Char_t, c);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of UChar_t from buffer
 
-Int_t TBufferSQL2::ReadArray(UChar_t   *&c)
+Int_t TBufferSQL2::ReadArray(UChar_t *&c)
 {
-   TBufferSQL2_ReadArray(UChar_t,c);
+   TBufferSQL2_ReadArray(UChar_t, c);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Short_t from buffer
 
-Int_t TBufferSQL2::ReadArray(Short_t   *&h)
+Int_t TBufferSQL2::ReadArray(Short_t *&h)
 {
-   TBufferSQL2_ReadArray(Short_t,h);
+   TBufferSQL2_ReadArray(Short_t, h);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of UShort_t from buffer
 
-Int_t TBufferSQL2::ReadArray(UShort_t  *&h)
+Int_t TBufferSQL2::ReadArray(UShort_t *&h)
 {
-   TBufferSQL2_ReadArray(UShort_t,h);
+   TBufferSQL2_ReadArray(UShort_t, h);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Int_t from buffer
 
-Int_t TBufferSQL2::ReadArray(Int_t     *&i)
+Int_t TBufferSQL2::ReadArray(Int_t *&i)
 {
-   TBufferSQL2_ReadArray(Int_t,i);
+   TBufferSQL2_ReadArray(Int_t, i);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of UInt_t from buffer
 
-Int_t TBufferSQL2::ReadArray(UInt_t    *&i)
+Int_t TBufferSQL2::ReadArray(UInt_t *&i)
 {
-   TBufferSQL2_ReadArray(UInt_t,i);
+   TBufferSQL2_ReadArray(UInt_t, i);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Long_t from buffer
 
-Int_t TBufferSQL2::ReadArray(Long_t    *&l)
+Int_t TBufferSQL2::ReadArray(Long_t *&l)
 {
-   TBufferSQL2_ReadArray(Long_t,l);
+   TBufferSQL2_ReadArray(Long_t, l);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of ULong_t from buffer
 
-Int_t TBufferSQL2::ReadArray(ULong_t   *&l)
+Int_t TBufferSQL2::ReadArray(ULong_t *&l)
 {
-   TBufferSQL2_ReadArray(ULong_t,l);
+   TBufferSQL2_ReadArray(ULong_t, l);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Long64_t from buffer
 
-Int_t TBufferSQL2::ReadArray(Long64_t  *&l)
+Int_t TBufferSQL2::ReadArray(Long64_t *&l)
 {
-   TBufferSQL2_ReadArray(Long64_t,l);
+   TBufferSQL2_ReadArray(Long64_t, l);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1216,55 +1208,57 @@ Int_t TBufferSQL2::ReadArray(Long64_t  *&l)
 
 Int_t TBufferSQL2::ReadArray(ULong64_t *&l)
 {
-   TBufferSQL2_ReadArray(ULong64_t,l);
+   TBufferSQL2_ReadArray(ULong64_t, l);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Float_t from buffer
 
-Int_t TBufferSQL2::ReadArray(Float_t   *&f)
+Int_t TBufferSQL2::ReadArray(Float_t *&f)
 {
-   TBufferSQL2_ReadArray(Float_t,f);
+   TBufferSQL2_ReadArray(Float_t, f);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Double_t from buffer
 
-Int_t TBufferSQL2::ReadArray(Double_t  *&d)
+Int_t TBufferSQL2::ReadArray(Double_t *&d)
 {
-   TBufferSQL2_ReadArray(Double_t,d);
+   TBufferSQL2_ReadArray(Double_t, d);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Float16_t from buffer
 
-Int_t TBufferSQL2::ReadArrayFloat16(Float_t  *&f, TStreamerElement * /*ele*/)
+Int_t TBufferSQL2::ReadArrayFloat16(Float_t *&f, TStreamerElement * /*ele*/)
 {
-   TBufferSQL2_ReadArray(Float_t,f);
+   TBufferSQL2_ReadArray(Float_t, f);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Double32_t from buffer
 
-Int_t TBufferSQL2::ReadArrayDouble32(Double_t  *&d, TStreamerElement * /*ele*/)
+Int_t TBufferSQL2::ReadArrayDouble32(Double_t *&d, TStreamerElement * /*ele*/)
 {
-   TBufferSQL2_ReadArray(Double_t,d);
+   TBufferSQL2_ReadArray(Double_t, d);
 }
 
 // macro to read static array, which include size attribute
-#define TBufferSQL2_ReadStaticArray(vname)      \
-   {                                            \
-      Int_t n = SqlReadArraySize();             \
-      if (n<=0) return 0;                       \
-      if (!vname) return 0;                     \
-      SQLReadArrayContent(vname, n, kTRUE);     \
-      return n;                                 \
+#define TBufferSQL2_ReadStaticArray(vname)  \
+   {                                        \
+      Int_t n = SqlReadArraySize();         \
+      if (n <= 0)                           \
+         return 0;                          \
+      if (!vname)                           \
+         return 0;                          \
+      SQLReadArrayContent(vname, n, kTRUE); \
+      return n;                             \
    }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Bool_t from buffer
 
-Int_t TBufferSQL2::ReadStaticArray(Bool_t    *b)
+Int_t TBufferSQL2::ReadStaticArray(Bool_t *b)
 {
    TBufferSQL2_ReadStaticArray(b);
 }
@@ -1272,7 +1266,7 @@ Int_t TBufferSQL2::ReadStaticArray(Bool_t    *b)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Char_t from buffer
 
-Int_t TBufferSQL2::ReadStaticArray(Char_t    *c)
+Int_t TBufferSQL2::ReadStaticArray(Char_t *c)
 {
    TBufferSQL2_ReadStaticArray(c);
 }
@@ -1280,7 +1274,7 @@ Int_t TBufferSQL2::ReadStaticArray(Char_t    *c)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of UChar_t from buffer
 
-Int_t TBufferSQL2::ReadStaticArray(UChar_t   *c)
+Int_t TBufferSQL2::ReadStaticArray(UChar_t *c)
 {
    TBufferSQL2_ReadStaticArray(c);
 }
@@ -1288,7 +1282,7 @@ Int_t TBufferSQL2::ReadStaticArray(UChar_t   *c)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Short_t from buffer
 
-Int_t TBufferSQL2::ReadStaticArray(Short_t   *h)
+Int_t TBufferSQL2::ReadStaticArray(Short_t *h)
 {
    TBufferSQL2_ReadStaticArray(h);
 }
@@ -1296,7 +1290,7 @@ Int_t TBufferSQL2::ReadStaticArray(Short_t   *h)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of UShort_t from buffer
 
-Int_t TBufferSQL2::ReadStaticArray(UShort_t  *h)
+Int_t TBufferSQL2::ReadStaticArray(UShort_t *h)
 {
    TBufferSQL2_ReadStaticArray(h);
 }
@@ -1304,7 +1298,7 @@ Int_t TBufferSQL2::ReadStaticArray(UShort_t  *h)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Int_t from buffer
 
-Int_t TBufferSQL2::ReadStaticArray(Int_t     *i)
+Int_t TBufferSQL2::ReadStaticArray(Int_t *i)
 {
    TBufferSQL2_ReadStaticArray(i);
 }
@@ -1312,7 +1306,7 @@ Int_t TBufferSQL2::ReadStaticArray(Int_t     *i)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of UInt_t from buffer
 
-Int_t TBufferSQL2::ReadStaticArray(UInt_t    *i)
+Int_t TBufferSQL2::ReadStaticArray(UInt_t *i)
 {
    TBufferSQL2_ReadStaticArray(i);
 }
@@ -1320,7 +1314,7 @@ Int_t TBufferSQL2::ReadStaticArray(UInt_t    *i)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Long_t from buffer
 
-Int_t TBufferSQL2::ReadStaticArray(Long_t    *l)
+Int_t TBufferSQL2::ReadStaticArray(Long_t *l)
 {
    TBufferSQL2_ReadStaticArray(l);
 }
@@ -1328,7 +1322,7 @@ Int_t TBufferSQL2::ReadStaticArray(Long_t    *l)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of ULong_t from buffer
 
-Int_t TBufferSQL2::ReadStaticArray(ULong_t   *l)
+Int_t TBufferSQL2::ReadStaticArray(ULong_t *l)
 {
    TBufferSQL2_ReadStaticArray(l);
 }
@@ -1336,7 +1330,7 @@ Int_t TBufferSQL2::ReadStaticArray(ULong_t   *l)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Long64_t from buffer
 
-Int_t TBufferSQL2::ReadStaticArray(Long64_t  *l)
+Int_t TBufferSQL2::ReadStaticArray(Long64_t *l)
 {
    TBufferSQL2_ReadStaticArray(l);
 }
@@ -1352,7 +1346,7 @@ Int_t TBufferSQL2::ReadStaticArray(ULong64_t *l)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Float_t from buffer
 
-Int_t TBufferSQL2::ReadStaticArray(Float_t   *f)
+Int_t TBufferSQL2::ReadStaticArray(Float_t *f)
 {
    TBufferSQL2_ReadStaticArray(f);
 }
@@ -1360,7 +1354,7 @@ Int_t TBufferSQL2::ReadStaticArray(Float_t   *f)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Double_t from buffer
 
-Int_t TBufferSQL2::ReadStaticArray(Double_t  *d)
+Int_t TBufferSQL2::ReadStaticArray(Double_t *d)
 {
    TBufferSQL2_ReadStaticArray(d);
 }
@@ -1368,7 +1362,7 @@ Int_t TBufferSQL2::ReadStaticArray(Double_t  *d)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Float16_t from buffer
 
-Int_t TBufferSQL2::ReadStaticArrayFloat16(Float_t  *f, TStreamerElement * /*ele*/)
+Int_t TBufferSQL2::ReadStaticArrayFloat16(Float_t *f, TStreamerElement * /*ele*/)
 {
    TBufferSQL2_ReadStaticArray(f);
 }
@@ -1376,45 +1370,49 @@ Int_t TBufferSQL2::ReadStaticArrayFloat16(Float_t  *f, TStreamerElement * /*ele*
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Double32_t from buffer
 
-Int_t TBufferSQL2::ReadStaticArrayDouble32(Double_t  *d, TStreamerElement * /*ele*/)
+Int_t TBufferSQL2::ReadStaticArrayDouble32(Double_t *d, TStreamerElement * /*ele*/)
 {
    TBufferSQL2_ReadStaticArray(d);
 }
 
 // macro to read content of array, which not include size of array
 // macro also treat situation, when instead of one single array chain of several elements should be produced
-#define TBufferSQL2_ReadFastArray(vname)                                \
-   {                                                                    \
-      if (n<=0) return;                                                 \
-      TStreamerElement* elem = Stack(0)->GetElement();                  \
-      if ((elem!=0) && (elem->GetType()>TStreamerInfo::kOffsetL) &&     \
-          (elem->GetType()<TStreamerInfo::kOffsetP) &&                  \
-          (elem->GetArrayLength()!=n)) fExpectedChain = kTRUE;          \
-      if (fExpectedChain) {                                             \
-         fExpectedChain = kFALSE;                                       \
-         Int_t startnumber = Stack(0)->GetElementNumber();              \
-         TStreamerInfo* info = Stack(1)->GetStreamerInfo();             \
-         Int_t index = 0;                                               \
-         while (index<n) {                                              \
-            elem = (TStreamerElement*)info->GetElements()->At(startnumber++); \
-            if (index>1) { PopStack(); WorkWithElement(elem, elem->GetType()); } \
-            if (elem->GetType()<TStreamerInfo::kOffsetL) {              \
-               SqlReadBasic(vname[index]);                              \
-               index++;                                                 \
-            } else {                                                    \
-               Int_t elemlen = elem->GetArrayLength();                  \
-               SQLReadArrayContent((vname+index), elemlen, kFALSE);     \
-               index+=elemlen;                                          \
-            }                                                           \
-         }                                                              \
-      } else {                                                          \
-         SQLReadArrayContent(vname, n, kFALSE);                         \
-      }                                                                 \
+#define TBufferSQL2_ReadFastArray(vname)                                                                               \
+   {                                                                                                                   \
+      if (n <= 0)                                                                                                      \
+         return;                                                                                                       \
+      TStreamerElement *elem = Stack(0)->GetElement();                                                                 \
+      if ((elem != 0) && (elem->GetType() > TStreamerInfo::kOffsetL) && (elem->GetType() < TStreamerInfo::kOffsetP) && \
+          (elem->GetArrayLength() != n))                                                                               \
+         fExpectedChain = kTRUE;                                                                                       \
+      if (fExpectedChain) {                                                                                            \
+         fExpectedChain = kFALSE;                                                                                      \
+         Int_t startnumber = Stack(0)->GetElementNumber();                                                             \
+         TStreamerInfo *info = Stack(1)->GetStreamerInfo();                                                            \
+         Int_t index = 0;                                                                                              \
+         while (index < n) {                                                                                           \
+            elem = (TStreamerElement *)info->GetElements()->At(startnumber++);                                         \
+            if (index > 1) {                                                                                           \
+               PopStack();                                                                                             \
+               WorkWithElement(elem, elem->GetType());                                                                 \
+            }                                                                                                          \
+            if (elem->GetType() < TStreamerInfo::kOffsetL) {                                                           \
+               SqlReadBasic(vname[index]);                                                                             \
+               index++;                                                                                                \
+            } else {                                                                                                   \
+               Int_t elemlen = elem->GetArrayLength();                                                                 \
+               SQLReadArrayContent((vname + index), elemlen, kFALSE);                                                  \
+               index += elemlen;                                                                                       \
+            }                                                                                                          \
+         }                                                                                                             \
+      } else {                                                                                                         \
+         SQLReadArrayContent(vname, n, kFALSE);                                                                        \
+      }                                                                                                                \
    }
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Bool_t from buffer
 
-void TBufferSQL2::ReadFastArray(Bool_t    *b, Int_t n)
+void TBufferSQL2::ReadFastArray(Bool_t *b, Int_t n)
 {
    TBufferSQL2_ReadFastArray(b);
 }
@@ -1423,14 +1421,15 @@ void TBufferSQL2::ReadFastArray(Bool_t    *b, Int_t n)
 /// Read array of Char_t from buffer
 /// if nodename==CharStar, read all array as string
 
-void TBufferSQL2::ReadFastArray(Char_t    *c, Int_t n)
+void TBufferSQL2::ReadFastArray(Char_t *c, Int_t n)
 {
-   if ((n>0) && fCurrentData->IsBlobData() &&
-       fCurrentData->VerifyDataType(sqlio::CharStar, kFALSE)) {
-      const char* buf = SqlReadCharStarValue();
-      if ((buf==0) || (n<=0)) return;
+   if ((n > 0) && fCurrentData->IsBlobData() && fCurrentData->VerifyDataType(sqlio::CharStar, kFALSE)) {
+      const char *buf = SqlReadCharStarValue();
+      if ((buf == 0) || (n <= 0))
+         return;
       Int_t size = strlen(buf);
-      if (size<n) size = n;
+      if (size < n)
+         size = n;
       memcpy(c, buf, size);
    } else {
       //     std::cout << "call standard macro TBufferSQL2_ReadFastArray" << std::endl;
@@ -1441,7 +1440,7 @@ void TBufferSQL2::ReadFastArray(Char_t    *c, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of UChar_t from buffer
 
-void TBufferSQL2::ReadFastArray(UChar_t   *c, Int_t n)
+void TBufferSQL2::ReadFastArray(UChar_t *c, Int_t n)
 {
    TBufferSQL2_ReadFastArray(c);
 }
@@ -1449,7 +1448,7 @@ void TBufferSQL2::ReadFastArray(UChar_t   *c, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Short_t from buffer
 
-void TBufferSQL2::ReadFastArray(Short_t   *h, Int_t n)
+void TBufferSQL2::ReadFastArray(Short_t *h, Int_t n)
 {
    TBufferSQL2_ReadFastArray(h);
 }
@@ -1457,7 +1456,7 @@ void TBufferSQL2::ReadFastArray(Short_t   *h, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of UShort_t from buffer
 
-void TBufferSQL2::ReadFastArray(UShort_t  *h, Int_t n)
+void TBufferSQL2::ReadFastArray(UShort_t *h, Int_t n)
 {
    TBufferSQL2_ReadFastArray(h);
 }
@@ -1465,7 +1464,7 @@ void TBufferSQL2::ReadFastArray(UShort_t  *h, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Int_t from buffer
 
-void TBufferSQL2::ReadFastArray(Int_t     *i, Int_t n)
+void TBufferSQL2::ReadFastArray(Int_t *i, Int_t n)
 {
    TBufferSQL2_ReadFastArray(i);
 }
@@ -1473,7 +1472,7 @@ void TBufferSQL2::ReadFastArray(Int_t     *i, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of UInt_t from buffer
 
-void TBufferSQL2::ReadFastArray(UInt_t    *i, Int_t n)
+void TBufferSQL2::ReadFastArray(UInt_t *i, Int_t n)
 {
    TBufferSQL2_ReadFastArray(i);
 }
@@ -1481,7 +1480,7 @@ void TBufferSQL2::ReadFastArray(UInt_t    *i, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Long_t from buffer
 
-void TBufferSQL2::ReadFastArray(Long_t    *l, Int_t n)
+void TBufferSQL2::ReadFastArray(Long_t *l, Int_t n)
 {
    TBufferSQL2_ReadFastArray(l);
 }
@@ -1489,7 +1488,7 @@ void TBufferSQL2::ReadFastArray(Long_t    *l, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of ULong_t from buffer
 
-void TBufferSQL2::ReadFastArray(ULong_t   *l, Int_t n)
+void TBufferSQL2::ReadFastArray(ULong_t *l, Int_t n)
 {
    TBufferSQL2_ReadFastArray(l);
 }
@@ -1497,7 +1496,7 @@ void TBufferSQL2::ReadFastArray(ULong_t   *l, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Long64_t from buffer
 
-void TBufferSQL2::ReadFastArray(Long64_t  *l, Int_t n)
+void TBufferSQL2::ReadFastArray(Long64_t *l, Int_t n)
 {
    TBufferSQL2_ReadFastArray(l);
 }
@@ -1513,7 +1512,7 @@ void TBufferSQL2::ReadFastArray(ULong64_t *l, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Float_t from buffer
 
-void TBufferSQL2::ReadFastArray(Float_t   *f, Int_t n)
+void TBufferSQL2::ReadFastArray(Float_t *f, Int_t n)
 {
    TBufferSQL2_ReadFastArray(f);
 }
@@ -1521,7 +1520,7 @@ void TBufferSQL2::ReadFastArray(Float_t   *f, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Double_t from buffer
 
-void TBufferSQL2::ReadFastArray(Double_t  *d, Int_t n)
+void TBufferSQL2::ReadFastArray(Double_t *d, Int_t n)
 {
    TBufferSQL2_ReadFastArray(d);
 }
@@ -1529,7 +1528,7 @@ void TBufferSQL2::ReadFastArray(Double_t  *d, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Float16_t from buffer
 
-void TBufferSQL2::ReadFastArrayFloat16(Float_t  *f, Int_t n, TStreamerElement * /*ele*/)
+void TBufferSQL2::ReadFastArrayFloat16(Float_t *f, Int_t n, TStreamerElement * /*ele*/)
 {
    TBufferSQL2_ReadFastArray(f);
 }
@@ -1537,7 +1536,7 @@ void TBufferSQL2::ReadFastArrayFloat16(Float_t  *f, Int_t n, TStreamerElement * 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Float16_t from buffer
 
-void TBufferSQL2::ReadFastArrayWithFactor(Float_t  *f, Int_t n, Double_t /* factor */, Double_t /* minvalue */)
+void TBufferSQL2::ReadFastArrayWithFactor(Float_t *f, Int_t n, Double_t /* factor */, Double_t /* minvalue */)
 {
    TBufferSQL2_ReadFastArray(f);
 }
@@ -1545,7 +1544,7 @@ void TBufferSQL2::ReadFastArrayWithFactor(Float_t  *f, Int_t n, Double_t /* fact
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Float16_t from buffer
 
-void TBufferSQL2::ReadFastArrayWithNbits(Float_t  *f, Int_t n, Int_t /*nbits*/)
+void TBufferSQL2::ReadFastArrayWithNbits(Float_t *f, Int_t n, Int_t /*nbits*/)
 {
    TBufferSQL2_ReadFastArray(f);
 }
@@ -1553,7 +1552,7 @@ void TBufferSQL2::ReadFastArrayWithNbits(Float_t  *f, Int_t n, Int_t /*nbits*/)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Double32_t from buffer
 
-void TBufferSQL2::ReadFastArrayDouble32(Double_t  *d, Int_t n, TStreamerElement * /*ele*/)
+void TBufferSQL2::ReadFastArrayDouble32(Double_t *d, Int_t n, TStreamerElement * /*ele*/)
 {
    TBufferSQL2_ReadFastArray(d);
 }
@@ -1561,14 +1560,14 @@ void TBufferSQL2::ReadFastArrayDouble32(Double_t  *d, Int_t n, TStreamerElement 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Double32_t from buffer
 
-void TBufferSQL2::ReadFastArrayWithFactor(Double_t  *d, Int_t n, Double_t /* factor */, Double_t /* minvalue */)
+void TBufferSQL2::ReadFastArrayWithFactor(Double_t *d, Int_t n, Double_t /* factor */, Double_t /* minvalue */)
 {
    TBufferSQL2_ReadFastArray(d);
 }
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Double32_t from buffer
 
-void TBufferSQL2::ReadFastArrayWithNbits(Double_t  *d, Int_t n, Int_t /*nbits*/)
+void TBufferSQL2::ReadFastArrayWithNbits(Double_t *d, Int_t n, Int_t /*nbits*/)
 {
    TBufferSQL2_ReadFastArray(d);
 }
@@ -1579,22 +1578,23 @@ void TBufferSQL2::ReadFastArrayWithNbits(Double_t  *d, Int_t n, Int_t /*nbits*/)
 /// buf.StreamObject(obj, cl). In that case it is easy to understand where
 /// object data is started and finished
 
-void TBufferSQL2::ReadFastArray(void  *start, const TClass *cl, Int_t n, TMemberStreamer *streamer, const TClass* onFileClass )
+void TBufferSQL2::ReadFastArray(void *start, const TClass *cl, Int_t n, TMemberStreamer *streamer,
+                                const TClass *onFileClass)
 {
-   if (gDebug>2)
-      Info("ReadFastArray","(void *");
+   if (gDebug > 2)
+      Info("ReadFastArray", "(void *");
 
    if (streamer) {
       StreamObject(start, streamer, cl, 0, onFileClass);
-//      (*streamer)(*this,start,0);
+      //      (*streamer)(*this,start,0);
       return;
    }
 
    int objectSize = cl->Size();
-   char *obj = (char*)start;
-   char *end = obj + n*objectSize;
+   char *obj = (char *)start;
+   char *end = obj + n * objectSize;
 
-   for(; obj<end; obj+=objectSize) {
+   for (; obj < end; obj += objectSize) {
       StreamObject(obj, cl, onFileClass);
    }
    //   TBuffer::ReadFastArray(start, cl, n, s);
@@ -1606,40 +1606,44 @@ void TBufferSQL2::ReadFastArray(void  *start, const TClass *cl, Int_t n, TMember
 /// buf.StreamObject(obj, cl). In that case it is easy to understand where
 /// object data is started and finished
 
-void TBufferSQL2::ReadFastArray(void **start, const TClass *cl, Int_t n, Bool_t isPreAlloc, TMemberStreamer *streamer, const TClass* onFileClass )
+void TBufferSQL2::ReadFastArray(void **start, const TClass *cl, Int_t n, Bool_t isPreAlloc, TMemberStreamer *streamer,
+                                const TClass *onFileClass)
 {
-   if (gDebug>2)
-      Info("ReadFastArray","(void **  pre = %d  n = %d", isPreAlloc, n);
+   if (gDebug > 2)
+      Info("ReadFastArray", "(void **  pre = %d  n = %d", isPreAlloc, n);
 
    if (streamer) {
       if (isPreAlloc) {
-         for (Int_t j=0;j<n;j++) {
-            if (!start[j]) start[j] = ((TClass*)cl)->New();
+         for (Int_t j = 0; j < n; j++) {
+            if (!start[j])
+               start[j] = ((TClass *)cl)->New();
          }
       }
-      StreamObject((void*)start, streamer, cl, 0, onFileClass);
-//      (*streamer)(*this,(void*)start,0);
+      StreamObject((void *)start, streamer, cl, 0, onFileClass);
+      //      (*streamer)(*this,(void*)start,0);
       return;
    }
 
    if (!isPreAlloc) {
 
-      for (Int_t j=0; j<n; j++){
-         //delete the object or collection
-         if (start[j] && TStreamerInfo::CanDelete()) ((TClass*)cl)->Destructor(start[j],kFALSE); // call delete and desctructor
+      for (Int_t j = 0; j < n; j++) {
+         // delete the object or collection
+         if (start[j] && TStreamerInfo::CanDelete())
+            ((TClass *)cl)->Destructor(start[j], kFALSE); // call delete and desctructor
          start[j] = ReadObjectAny(cl);
       }
 
-   } else {   //case //-> in comment
+   } else { // case //-> in comment
 
-      for (Int_t j=0; j<n; j++) {
-         if (!start[j]) start[j] = ((TClass*)cl)->New();
+      for (Int_t j = 0; j < n; j++) {
+         if (!start[j])
+            start[j] = ((TClass *)cl)->New();
          StreamObject(start[j], cl, onFileClass);
       }
    }
 
-   if (gDebug>2)
-      Info("ReadFastArray","(void ** Done" );
+   if (gDebug > 2)
+      Info("ReadFastArray", "(void ** Done");
 
    //   TBuffer::ReadFastArray(startp, cl, n, isPreAlloc, s);
 }
@@ -1650,54 +1654,57 @@ void TBufferSQL2::ReadFastArray(void **start, const TClass *cl, Int_t n, Bool_t 
 
 Int_t TBufferSQL2::SqlReadArraySize()
 {
-   const char* value = SqlReadValue(sqlio::Array);
-   if ((value==0) || (strlen(value)==0)) return 0;
+   const char *value = SqlReadValue(sqlio::Array);
+   if ((value == 0) || (strlen(value) == 0))
+      return 0;
    Int_t sz = atoi(value);
    return sz;
 }
 
 // macro to write content of noncompressed array, not used
-#define SQLWriteArrayNoncompress(vname, arrsize)        \
-   {                                                    \
-      for(Int_t indx=0;indx<arrsize;indx++) {           \
-         SqlWriteBasic(vname[indx]);                    \
-         Stack()->ChildArrayIndex(indx, 1);             \
-      }                                                 \
+#define SQLWriteArrayNoncompress(vname, arrsize)     \
+   {                                                 \
+      for (Int_t indx = 0; indx < arrsize; indx++) { \
+         SqlWriteBasic(vname[indx]);                 \
+         Stack()->ChildArrayIndex(indx, 1);          \
+      }                                              \
    }
 
 // macro to write content of compressed array
-#define SQLWriteArrayCompress(vname, arrsize)                           \
-   {                                                                    \
-      Int_t indx = 0;                                                   \
-      while(indx<arrsize) {                                             \
-         Int_t curr = indx; indx++;                                     \
-         while ((indx<arrsize) && (vname[indx]==vname[curr])) indx++;   \
-         SqlWriteBasic(vname[curr]);                                    \
-         Stack()->ChildArrayIndex(curr, indx-curr);                     \
-      }                                                                 \
+#define SQLWriteArrayCompress(vname, arrsize)                     \
+   {                                                              \
+      Int_t indx = 0;                                             \
+      while (indx < arrsize) {                                    \
+         Int_t curr = indx;                                       \
+         indx++;                                                  \
+         while ((indx < arrsize) && (vname[indx] == vname[curr])) \
+            indx++;                                               \
+         SqlWriteBasic(vname[curr]);                              \
+         Stack()->ChildArrayIndex(curr, indx - curr);             \
+      }                                                           \
    }
 
-#define SQLWriteArrayContent(vname, arrsize, withsize)  \
-   {                                                    \
-      PushStack()->SetArray(withsize ? arrsize : -1);   \
-      if (fCompressLevel>0) {                           \
-         SQLWriteArrayCompress(vname, arrsize)          \
-            } else {                                    \
-         SQLWriteArrayNoncompress(vname, arrsize)       \
-            }                                           \
-      PopStack();                                       \
+#define SQLWriteArrayContent(vname, arrsize, withsize) \
+   {                                                   \
+      PushStack()->SetArray(withsize ? arrsize : -1);  \
+      if (fCompressLevel > 0) {                        \
+         SQLWriteArrayCompress(vname, arrsize)         \
+      } else {                                         \
+         SQLWriteArrayNoncompress(vname, arrsize)      \
+      }                                                \
+      PopStack();                                      \
    }
 
 // macro to write array, which include size
-#define TBufferSQL2_WriteArray(vname)           \
-   {                                            \
-      SQLWriteArrayContent(vname, n, kTRUE);    \
+#define TBufferSQL2_WriteArray(vname)        \
+   {                                         \
+      SQLWriteArrayContent(vname, n, kTRUE); \
    }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Bool_t to buffer
 
-void TBufferSQL2::WriteArray(const Bool_t    *b, Int_t n)
+void TBufferSQL2::WriteArray(const Bool_t *b, Int_t n)
 {
    TBufferSQL2_WriteArray(b);
 }
@@ -1705,7 +1712,7 @@ void TBufferSQL2::WriteArray(const Bool_t    *b, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Char_t to buffer
 
-void TBufferSQL2::WriteArray(const Char_t    *c, Int_t n)
+void TBufferSQL2::WriteArray(const Char_t *c, Int_t n)
 {
    TBufferSQL2_WriteArray(c);
 }
@@ -1713,7 +1720,7 @@ void TBufferSQL2::WriteArray(const Char_t    *c, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of UChar_t to buffer
 
-void TBufferSQL2::WriteArray(const UChar_t   *c, Int_t n)
+void TBufferSQL2::WriteArray(const UChar_t *c, Int_t n)
 {
    TBufferSQL2_WriteArray(c);
 }
@@ -1721,7 +1728,7 @@ void TBufferSQL2::WriteArray(const UChar_t   *c, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Short_t to buffer
 
-void TBufferSQL2::WriteArray(const Short_t   *h, Int_t n)
+void TBufferSQL2::WriteArray(const Short_t *h, Int_t n)
 {
    TBufferSQL2_WriteArray(h);
 }
@@ -1729,7 +1736,7 @@ void TBufferSQL2::WriteArray(const Short_t   *h, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of UShort_t to buffer
 
-void TBufferSQL2::WriteArray(const UShort_t  *h, Int_t n)
+void TBufferSQL2::WriteArray(const UShort_t *h, Int_t n)
 {
    TBufferSQL2_WriteArray(h);
 }
@@ -1737,7 +1744,7 @@ void TBufferSQL2::WriteArray(const UShort_t  *h, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Int_ to buffer
 
-void TBufferSQL2::WriteArray(const Int_t     *i, Int_t n)
+void TBufferSQL2::WriteArray(const Int_t *i, Int_t n)
 {
    TBufferSQL2_WriteArray(i);
 }
@@ -1745,7 +1752,7 @@ void TBufferSQL2::WriteArray(const Int_t     *i, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of UInt_t to buffer
 
-void TBufferSQL2::WriteArray(const UInt_t    *i, Int_t n)
+void TBufferSQL2::WriteArray(const UInt_t *i, Int_t n)
 {
    TBufferSQL2_WriteArray(i);
 }
@@ -1753,7 +1760,7 @@ void TBufferSQL2::WriteArray(const UInt_t    *i, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Long_t to buffer
 
-void TBufferSQL2::WriteArray(const Long_t    *l, Int_t n)
+void TBufferSQL2::WriteArray(const Long_t *l, Int_t n)
 {
    TBufferSQL2_WriteArray(l);
 }
@@ -1761,7 +1768,7 @@ void TBufferSQL2::WriteArray(const Long_t    *l, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of ULong_t to buffer
 
-void TBufferSQL2::WriteArray(const ULong_t   *l, Int_t n)
+void TBufferSQL2::WriteArray(const ULong_t *l, Int_t n)
 {
    TBufferSQL2_WriteArray(l);
 }
@@ -1769,7 +1776,7 @@ void TBufferSQL2::WriteArray(const ULong_t   *l, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Long64_t to buffer
 
-void TBufferSQL2::WriteArray(const Long64_t  *l, Int_t n)
+void TBufferSQL2::WriteArray(const Long64_t *l, Int_t n)
 {
    TBufferSQL2_WriteArray(l);
 }
@@ -1785,7 +1792,7 @@ void TBufferSQL2::WriteArray(const ULong64_t *l, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Float_t to buffer
 
-void TBufferSQL2::WriteArray(const Float_t   *f, Int_t n)
+void TBufferSQL2::WriteArray(const Float_t *f, Int_t n)
 {
    TBufferSQL2_WriteArray(f);
 }
@@ -1793,7 +1800,7 @@ void TBufferSQL2::WriteArray(const Float_t   *f, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Double_t to buffer
 
-void TBufferSQL2::WriteArray(const Double_t  *d, Int_t n)
+void TBufferSQL2::WriteArray(const Double_t *d, Int_t n)
 {
    TBufferSQL2_WriteArray(d);
 }
@@ -1801,7 +1808,7 @@ void TBufferSQL2::WriteArray(const Double_t  *d, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Float16_t to buffer
 
-void TBufferSQL2::WriteArrayFloat16(const Float_t  *f, Int_t n, TStreamerElement * /*ele*/)
+void TBufferSQL2::WriteArrayFloat16(const Float_t *f, Int_t n, TStreamerElement * /*ele*/)
 {
    TBufferSQL2_WriteArray(f);
 }
@@ -1809,46 +1816,50 @@ void TBufferSQL2::WriteArrayFloat16(const Float_t  *f, Int_t n, TStreamerElement
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Double32_t to buffer
 
-void TBufferSQL2::WriteArrayDouble32(const Double_t  *d, Int_t n, TStreamerElement * /*ele*/)
+void TBufferSQL2::WriteArrayDouble32(const Double_t *d, Int_t n, TStreamerElement * /*ele*/)
 {
    TBufferSQL2_WriteArray(d);
 }
 
 // write array without size attribute
 // macro also treat situation, when instead of one single array chain of several elements should be produced
-#define TBufferSQL2_WriteFastArray(vname)                               \
-   {                                                                    \
-      if (n<=0) return;                                                 \
-      TStreamerElement* elem = Stack(0)->GetElement();                  \
-      if ((elem!=0) && (elem->GetType()>TStreamerInfo::kOffsetL) &&     \
-          (elem->GetType()<TStreamerInfo::kOffsetP) &&                  \
-          (elem->GetArrayLength()!=n)) fExpectedChain = kTRUE;          \
-      if (fExpectedChain) {                                             \
-         TStreamerInfo* info = Stack(1)->GetStreamerInfo();             \
-         Int_t startnumber = Stack(0)->GetElementNumber();              \
-         Int_t index = 0;                                               \
-         while (index<n) {                                              \
-            elem = (TStreamerElement*)info->GetElements()->At(startnumber++); \
-            if (index>0) { PopStack(); WorkWithElement(elem, elem->GetType()); } \
-            if (elem->GetType()<TStreamerInfo::kOffsetL) {              \
-               SqlWriteBasic(vname[index]);                             \
-               index++;                                                 \
-            } else {                                                    \
-               Int_t elemlen = elem->GetArrayLength();                  \
-               SQLWriteArrayContent((vname+index), elemlen, kFALSE);    \
-               index+=elemlen;                                          \
-            }                                                           \
-            fExpectedChain = kFALSE;                                    \
-         }                                                              \
-      } else {                                                          \
-         SQLWriteArrayContent(vname, n, kFALSE);                        \
-      }                                                                 \
+#define TBufferSQL2_WriteFastArray(vname)                                                                              \
+   {                                                                                                                   \
+      if (n <= 0)                                                                                                      \
+         return;                                                                                                       \
+      TStreamerElement *elem = Stack(0)->GetElement();                                                                 \
+      if ((elem != 0) && (elem->GetType() > TStreamerInfo::kOffsetL) && (elem->GetType() < TStreamerInfo::kOffsetP) && \
+          (elem->GetArrayLength() != n))                                                                               \
+         fExpectedChain = kTRUE;                                                                                       \
+      if (fExpectedChain) {                                                                                            \
+         TStreamerInfo *info = Stack(1)->GetStreamerInfo();                                                            \
+         Int_t startnumber = Stack(0)->GetElementNumber();                                                             \
+         Int_t index = 0;                                                                                              \
+         while (index < n) {                                                                                           \
+            elem = (TStreamerElement *)info->GetElements()->At(startnumber++);                                         \
+            if (index > 0) {                                                                                           \
+               PopStack();                                                                                             \
+               WorkWithElement(elem, elem->GetType());                                                                 \
+            }                                                                                                          \
+            if (elem->GetType() < TStreamerInfo::kOffsetL) {                                                           \
+               SqlWriteBasic(vname[index]);                                                                            \
+               index++;                                                                                                \
+            } else {                                                                                                   \
+               Int_t elemlen = elem->GetArrayLength();                                                                 \
+               SQLWriteArrayContent((vname + index), elemlen, kFALSE);                                                 \
+               index += elemlen;                                                                                       \
+            }                                                                                                          \
+            fExpectedChain = kFALSE;                                                                                   \
+         }                                                                                                             \
+      } else {                                                                                                         \
+         SQLWriteArrayContent(vname, n, kFALSE);                                                                       \
+      }                                                                                                                \
    }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Bool_t to buffer
 
-void TBufferSQL2::WriteFastArray(const Bool_t    *b, Int_t n)
+void TBufferSQL2::WriteFastArray(const Bool_t *b, Int_t n)
 {
    TBufferSQL2_WriteFastArray(b);
 }
@@ -1857,20 +1868,23 @@ void TBufferSQL2::WriteFastArray(const Bool_t    *b, Int_t n)
 /// Write array of Char_t to buffer
 /// it will be reproduced as CharStar node with string as attribute
 
-void TBufferSQL2::WriteFastArray(const Char_t    *c, Int_t n)
+void TBufferSQL2::WriteFastArray(const Char_t *c, Int_t n)
 {
-   Bool_t usedefault = (n==0) || fExpectedChain;
+   Bool_t usedefault = (n == 0) || fExpectedChain;
 
-   const Char_t* ccc = c;
+   const Char_t *ccc = c;
    // check if no zeros in the array
    if (!usedefault)
-      for (int i=0;i<n;i++)
-         if (*ccc++==0) { usedefault = kTRUE; break; }
+      for (int i = 0; i < n; i++)
+         if (*ccc++ == 0) {
+            usedefault = kTRUE;
+            break;
+         }
 
    if (usedefault) {
       TBufferSQL2_WriteFastArray(c);
    } else {
-      Char_t* buf = new Char_t[n+1];
+      Char_t *buf = new Char_t[n + 1];
       memcpy(buf, c, n);
       buf[n] = 0;
       SqlWriteValue(buf, sqlio::CharStar);
@@ -1881,7 +1895,7 @@ void TBufferSQL2::WriteFastArray(const Char_t    *c, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of UChar_t to buffer
 
-void TBufferSQL2::WriteFastArray(const UChar_t   *c, Int_t n)
+void TBufferSQL2::WriteFastArray(const UChar_t *c, Int_t n)
 {
    TBufferSQL2_WriteFastArray(c);
 }
@@ -1889,7 +1903,7 @@ void TBufferSQL2::WriteFastArray(const UChar_t   *c, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Short_t to buffer
 
-void TBufferSQL2::WriteFastArray(const Short_t   *h, Int_t n)
+void TBufferSQL2::WriteFastArray(const Short_t *h, Int_t n)
 {
    TBufferSQL2_WriteFastArray(h);
 }
@@ -1897,7 +1911,7 @@ void TBufferSQL2::WriteFastArray(const Short_t   *h, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of UShort_t to buffer
 
-void TBufferSQL2::WriteFastArray(const UShort_t  *h, Int_t n)
+void TBufferSQL2::WriteFastArray(const UShort_t *h, Int_t n)
 {
    TBufferSQL2_WriteFastArray(h);
 }
@@ -1905,7 +1919,7 @@ void TBufferSQL2::WriteFastArray(const UShort_t  *h, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Int_t to buffer
 
-void TBufferSQL2::WriteFastArray(const Int_t     *i, Int_t n)
+void TBufferSQL2::WriteFastArray(const Int_t *i, Int_t n)
 {
    TBufferSQL2_WriteFastArray(i);
 }
@@ -1913,7 +1927,7 @@ void TBufferSQL2::WriteFastArray(const Int_t     *i, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of UInt_t to buffer
 
-void TBufferSQL2::WriteFastArray(const UInt_t    *i, Int_t n)
+void TBufferSQL2::WriteFastArray(const UInt_t *i, Int_t n)
 {
    TBufferSQL2_WriteFastArray(i);
 }
@@ -1921,7 +1935,7 @@ void TBufferSQL2::WriteFastArray(const UInt_t    *i, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Long_t to buffer
 
-void TBufferSQL2::WriteFastArray(const Long_t    *l, Int_t n)
+void TBufferSQL2::WriteFastArray(const Long_t *l, Int_t n)
 {
    TBufferSQL2_WriteFastArray(l);
 }
@@ -1929,7 +1943,7 @@ void TBufferSQL2::WriteFastArray(const Long_t    *l, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of ULong_t to buffer
 
-void TBufferSQL2::WriteFastArray(const ULong_t   *l, Int_t n)
+void TBufferSQL2::WriteFastArray(const ULong_t *l, Int_t n)
 {
    TBufferSQL2_WriteFastArray(l);
 }
@@ -1937,7 +1951,7 @@ void TBufferSQL2::WriteFastArray(const ULong_t   *l, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Long64_t to buffer
 
-void TBufferSQL2::WriteFastArray(const Long64_t  *l, Int_t n)
+void TBufferSQL2::WriteFastArray(const Long64_t *l, Int_t n)
 {
    TBufferSQL2_WriteFastArray(l);
 }
@@ -1953,7 +1967,7 @@ void TBufferSQL2::WriteFastArray(const ULong64_t *l, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Float_t to buffer
 
-void TBufferSQL2::WriteFastArray(const Float_t   *f, Int_t n)
+void TBufferSQL2::WriteFastArray(const Float_t *f, Int_t n)
 {
    TBufferSQL2_WriteFastArray(f);
 }
@@ -1961,7 +1975,7 @@ void TBufferSQL2::WriteFastArray(const Float_t   *f, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Double_t to buffer
 
-void TBufferSQL2::WriteFastArray(const Double_t  *d, Int_t n)
+void TBufferSQL2::WriteFastArray(const Double_t *d, Int_t n)
 {
    TBufferSQL2_WriteFastArray(d);
 }
@@ -1969,7 +1983,7 @@ void TBufferSQL2::WriteFastArray(const Double_t  *d, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Float16_t to buffer
 
-void TBufferSQL2::WriteFastArrayFloat16(const Float_t  *f, Int_t n, TStreamerElement * /*ele*/)
+void TBufferSQL2::WriteFastArrayFloat16(const Float_t *f, Int_t n, TStreamerElement * /*ele*/)
 {
    TBufferSQL2_WriteFastArray(f);
 }
@@ -1977,7 +1991,7 @@ void TBufferSQL2::WriteFastArrayFloat16(const Float_t  *f, Int_t n, TStreamerEle
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Double32_t to buffer
 
-void TBufferSQL2::WriteFastArrayDouble32(const Double_t  *d, Int_t n, TStreamerElement * /*ele*/)
+void TBufferSQL2::WriteFastArrayDouble32(const Double_t *d, Int_t n, TStreamerElement * /*ele*/)
 {
    TBufferSQL2_WriteFastArray(d);
 }
@@ -1988,19 +2002,20 @@ void TBufferSQL2::WriteFastArrayDouble32(const Double_t  *d, Int_t n, TStreamerE
 /// buf.StreamObject(obj, cl). In that case it is easy to understand where
 /// object data is started and finished
 
-void  TBufferSQL2::WriteFastArray(void  *start,  const TClass *cl, Int_t n, TMemberStreamer *streamer)
+void TBufferSQL2::WriteFastArray(void *start, const TClass *cl, Int_t n, TMemberStreamer *streamer)
 {
    if (streamer) {
       StreamObject(start, streamer, cl, 0);
-//      (*streamer)(*this, start, 0);
+      //      (*streamer)(*this, start, 0);
       return;
    }
 
-   char *obj = (char*)start;
-   if (!n) n=1;
+   char *obj = (char *)start;
+   if (!n)
+      n = 1;
    int size = cl->Size();
 
-   for(Int_t j=0; j<n; j++,obj+=size)
+   for (Int_t j = 0; j < n; j++, obj += size)
       StreamObject(obj, cl);
 
    //   TBuffer::WriteFastArray(start, cl, n, s);
@@ -2015,8 +2030,8 @@ void  TBufferSQL2::WriteFastArray(void  *start,  const TClass *cl, Int_t n, TMem
 Int_t TBufferSQL2::WriteFastArray(void **start, const TClass *cl, Int_t n, Bool_t isPreAlloc, TMemberStreamer *streamer)
 {
    if (streamer) {
-      StreamObject((void*) start, streamer, cl, 0);
-//      (*streamer)(*this,(void*)start,0);
+      StreamObject((void *)start, streamer, cl, 0);
+      //      (*streamer)(*this,(void*)start,0);
       return 0;
    }
 
@@ -2026,25 +2041,26 @@ Int_t TBufferSQL2::WriteFastArray(void **start, const TClass *cl, Int_t n, Bool_
 
    if (!isPreAlloc) {
 
-      for (Int_t j=0;j<n;j++) {
-         //must write StreamerInfo if pointer is null
-         if (!strInfo && !start[j] ) ForceWriteInfo(((TClass*)cl)->GetStreamerInfo(),kFALSE);
+      for (Int_t j = 0; j < n; j++) {
+         // must write StreamerInfo if pointer is null
+         if (!strInfo && !start[j])
+            ForceWriteInfo(((TClass *)cl)->GetStreamerInfo(), kFALSE);
          strInfo = 2003;
-         res |= WriteObjectAny(start[j],cl);
+         res |= WriteObjectAny(start[j], cl);
       }
 
    } else {
-      //case //-> in comment
+      // case //-> in comment
 
-      for (Int_t j=0;j<n;j++) {
-         if (!start[j]) start[j] = ((TClass*)cl)->New();
+      for (Int_t j = 0; j < n; j++) {
+         if (!start[j])
+            start[j] = ((TClass *)cl)->New();
          StreamObject(start[j], cl);
       }
-
    }
    return res;
 
-//   return TBuffer::WriteFastArray(startp, cl, n, isPreAlloc, s);
+   //   return TBuffer::WriteFastArray(startp, cl, n, isPreAlloc, s);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2068,7 +2084,7 @@ void TBufferSQL2::StreamObject(void *obj, const char *className, const TClass *o
 
 void TBufferSQL2::StreamObject(void *obj, const TClass *cl, const TClass *onFileClass)
 {
-   if (gDebug>1)
+   if (gDebug > 1)
       std::cout << " TBufferSQL2::StreamObject class = " << (cl ? cl->GetName() : "none") << std::endl;
    if (IsReading())
       SqlReadObject(obj, 0, 0, 0, onFileClass);
@@ -2087,13 +2103,15 @@ void TBufferSQL2::StreamObject(TObject *obj)
 ////////////////////////////////////////////////////////////////////////////////
 /// Stream object to/from buffer
 
-void TBufferSQL2::StreamObject(void *obj, TMemberStreamer *streamer, const TClass *cl, Int_t n, const TClass *onFileClass)
+void TBufferSQL2::StreamObject(void *obj, TMemberStreamer *streamer, const TClass *cl, Int_t n,
+                               const TClass *onFileClass)
 {
-   if (streamer==0) return;
+   if (streamer == 0)
+      return;
 
-   if (gDebug>1)
+   if (gDebug > 1)
       std::cout << "Stream object of class = " << cl->GetName() << std::endl;
-//   (*streamer)(*this, obj, n);
+   //   (*streamer)(*this, obj, n);
 
    if (IsReading())
       SqlReadObject(obj, 0, streamer, n, onFileClass);
@@ -2102,15 +2120,15 @@ void TBufferSQL2::StreamObject(void *obj, TMemberStreamer *streamer, const TClas
 }
 
 // macro for right shift operator for basic type
-#define TBufferSQL2_operatorin(vname)           \
-   {                                            \
-      SqlReadBasic(vname);                      \
+#define TBufferSQL2_operatorin(vname) \
+   {                                  \
+      SqlReadBasic(vname);            \
    }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads Bool_t value from buffer
 
-void TBufferSQL2::ReadBool(Bool_t    &b)
+void TBufferSQL2::ReadBool(Bool_t &b)
 {
    TBufferSQL2_operatorin(b);
 }
@@ -2118,7 +2136,7 @@ void TBufferSQL2::ReadBool(Bool_t    &b)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads Char_t value from buffer
 
-void TBufferSQL2::ReadChar(Char_t    &c)
+void TBufferSQL2::ReadChar(Char_t &c)
 {
    TBufferSQL2_operatorin(c);
 }
@@ -2126,7 +2144,7 @@ void TBufferSQL2::ReadChar(Char_t    &c)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads UChar_t value from buffer
 
-void TBufferSQL2::ReadUChar(UChar_t   &c)
+void TBufferSQL2::ReadUChar(UChar_t &c)
 {
    TBufferSQL2_operatorin(c);
 }
@@ -2134,7 +2152,7 @@ void TBufferSQL2::ReadUChar(UChar_t   &c)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads Short_t value from buffer
 
-void TBufferSQL2::ReadShort(Short_t   &h)
+void TBufferSQL2::ReadShort(Short_t &h)
 {
    TBufferSQL2_operatorin(h);
 }
@@ -2142,7 +2160,7 @@ void TBufferSQL2::ReadShort(Short_t   &h)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads UShort_t value from buffer
 
-void TBufferSQL2::ReadUShort(UShort_t  &h)
+void TBufferSQL2::ReadUShort(UShort_t &h)
 {
    TBufferSQL2_operatorin(h);
 }
@@ -2150,7 +2168,7 @@ void TBufferSQL2::ReadUShort(UShort_t  &h)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads Int_t value from buffer
 
-void TBufferSQL2::ReadInt(Int_t     &i)
+void TBufferSQL2::ReadInt(Int_t &i)
 {
    TBufferSQL2_operatorin(i);
 }
@@ -2158,7 +2176,7 @@ void TBufferSQL2::ReadInt(Int_t     &i)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads UInt_t value from buffer
 
-void TBufferSQL2::ReadUInt(UInt_t    &i)
+void TBufferSQL2::ReadUInt(UInt_t &i)
 {
    TBufferSQL2_operatorin(i);
 }
@@ -2166,7 +2184,7 @@ void TBufferSQL2::ReadUInt(UInt_t    &i)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads Long_t value from buffer
 
-void TBufferSQL2::ReadLong(Long_t    &l)
+void TBufferSQL2::ReadLong(Long_t &l)
 {
    TBufferSQL2_operatorin(l);
 }
@@ -2174,7 +2192,7 @@ void TBufferSQL2::ReadLong(Long_t    &l)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads ULong_t value from buffer
 
-void TBufferSQL2::ReadULong(ULong_t   &l)
+void TBufferSQL2::ReadULong(ULong_t &l)
 {
    TBufferSQL2_operatorin(l);
 }
@@ -2182,7 +2200,7 @@ void TBufferSQL2::ReadULong(ULong_t   &l)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads Long64_t value from buffer
 
-void TBufferSQL2::ReadLong64(Long64_t  &l)
+void TBufferSQL2::ReadLong64(Long64_t &l)
 {
    TBufferSQL2_operatorin(l);
 }
@@ -2198,7 +2216,7 @@ void TBufferSQL2::ReadULong64(ULong64_t &l)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads Float_t value from buffer
 
-void TBufferSQL2::ReadFloat(Float_t   &f)
+void TBufferSQL2::ReadFloat(Float_t &f)
 {
    TBufferSQL2_operatorin(f);
 }
@@ -2206,7 +2224,7 @@ void TBufferSQL2::ReadFloat(Float_t   &f)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads Double_t value from buffer
 
-void TBufferSQL2::ReadDouble(Double_t  &d)
+void TBufferSQL2::ReadDouble(Double_t &d)
 {
    TBufferSQL2_operatorin(d);
 }
@@ -2214,16 +2232,17 @@ void TBufferSQL2::ReadDouble(Double_t  &d)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads array of characters from buffer
 
-void TBufferSQL2::ReadCharP(Char_t    *c)
+void TBufferSQL2::ReadCharP(Char_t *c)
 {
-   const char* buf = SqlReadCharStarValue();
-   if (buf) strcpy(c, buf);
+   const char *buf = SqlReadCharStarValue();
+   if (buf)
+      strcpy(c, buf);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read a TString
 
-void TBufferSQL2::ReadTString(TString   &s)
+void TBufferSQL2::ReadTString(TString &s)
 {
    TBufferFile::ReadTString(s);
 }
@@ -2231,7 +2250,7 @@ void TBufferSQL2::ReadTString(TString   &s)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write a TString
 
-void TBufferSQL2::WriteTString(const TString  &s)
+void TBufferSQL2::WriteTString(const TString &s)
 {
    TBufferFile::WriteTString(s);
 }
@@ -2255,7 +2274,7 @@ void TBufferSQL2::WriteStdString(const std::string *s)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read a char* string
 
-void TBufferSQL2::ReadCharStar(char* &s)
+void TBufferSQL2::ReadCharStar(char *&s)
 {
    TBufferFile::ReadCharStar(s);
 }
@@ -2268,17 +2287,16 @@ void TBufferSQL2::WriteCharStar(char *s)
    TBufferFile::WriteCharStar(s);
 }
 
-
 // macro for right shift operator for basic types
-#define TBufferSQL2_operatorout(vname)          \
-   {                                            \
-      SqlWriteBasic(vname);                     \
+#define TBufferSQL2_operatorout(vname) \
+   {                                   \
+      SqlWriteBasic(vname);            \
    }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Writes Bool_t value to buffer
 
-void TBufferSQL2::WriteBool(Bool_t    b)
+void TBufferSQL2::WriteBool(Bool_t b)
 {
    TBufferSQL2_operatorout(b);
 }
@@ -2286,7 +2304,7 @@ void TBufferSQL2::WriteBool(Bool_t    b)
 ////////////////////////////////////////////////////////////////////////////////
 /// Writes Char_t value to buffer
 
-void TBufferSQL2::WriteChar(Char_t    c)
+void TBufferSQL2::WriteChar(Char_t c)
 {
    TBufferSQL2_operatorout(c);
 }
@@ -2294,7 +2312,7 @@ void TBufferSQL2::WriteChar(Char_t    c)
 ////////////////////////////////////////////////////////////////////////////////
 /// Writes UChar_t value to buffer
 
-void TBufferSQL2::WriteUChar(UChar_t   c)
+void TBufferSQL2::WriteUChar(UChar_t c)
 {
    TBufferSQL2_operatorout(c);
 }
@@ -2302,7 +2320,7 @@ void TBufferSQL2::WriteUChar(UChar_t   c)
 ////////////////////////////////////////////////////////////////////////////////
 /// Writes Short_t value to buffer
 
-void TBufferSQL2::WriteShort(Short_t   h)
+void TBufferSQL2::WriteShort(Short_t h)
 {
    TBufferSQL2_operatorout(h);
 }
@@ -2310,7 +2328,7 @@ void TBufferSQL2::WriteShort(Short_t   h)
 ////////////////////////////////////////////////////////////////////////////////
 /// Writes UShort_t value to buffer
 
-void TBufferSQL2::WriteUShort(UShort_t  h)
+void TBufferSQL2::WriteUShort(UShort_t h)
 {
    TBufferSQL2_operatorout(h);
 }
@@ -2318,7 +2336,7 @@ void TBufferSQL2::WriteUShort(UShort_t  h)
 ////////////////////////////////////////////////////////////////////////////////
 /// Writes Int_t value to buffer
 
-void TBufferSQL2::WriteInt(Int_t     i)
+void TBufferSQL2::WriteInt(Int_t i)
 {
    TBufferSQL2_operatorout(i);
 }
@@ -2326,7 +2344,7 @@ void TBufferSQL2::WriteInt(Int_t     i)
 ////////////////////////////////////////////////////////////////////////////////
 /// Writes UInt_t value to buffer
 
-void TBufferSQL2::WriteUInt(UInt_t    i)
+void TBufferSQL2::WriteUInt(UInt_t i)
 {
    TBufferSQL2_operatorout(i);
 }
@@ -2334,7 +2352,7 @@ void TBufferSQL2::WriteUInt(UInt_t    i)
 ////////////////////////////////////////////////////////////////////////////////
 /// Writes Long_t value to buffer
 
-void TBufferSQL2::WriteLong(Long_t    l)
+void TBufferSQL2::WriteLong(Long_t l)
 {
    TBufferSQL2_operatorout(l);
 }
@@ -2342,7 +2360,7 @@ void TBufferSQL2::WriteLong(Long_t    l)
 ////////////////////////////////////////////////////////////////////////////////
 /// Writes ULong_t value to buffer
 
-void TBufferSQL2::WriteULong(ULong_t   l)
+void TBufferSQL2::WriteULong(ULong_t l)
 {
    TBufferSQL2_operatorout(l);
 }
@@ -2350,7 +2368,7 @@ void TBufferSQL2::WriteULong(ULong_t   l)
 ////////////////////////////////////////////////////////////////////////////////
 /// Writes Long64_t value to buffer
 
-void TBufferSQL2::WriteLong64(Long64_t  l)
+void TBufferSQL2::WriteLong64(Long64_t l)
 {
    TBufferSQL2_operatorout(l);
 }
@@ -2366,7 +2384,7 @@ void TBufferSQL2::WriteULong64(ULong64_t l)
 ////////////////////////////////////////////////////////////////////////////////
 /// Writes Float_t value to buffer
 
-void TBufferSQL2::WriteFloat(Float_t   f)
+void TBufferSQL2::WriteFloat(Float_t f)
 {
    TBufferSQL2_operatorout(f);
 }
@@ -2374,7 +2392,7 @@ void TBufferSQL2::WriteFloat(Float_t   f)
 ////////////////////////////////////////////////////////////////////////////////
 /// Writes Double_t value to buffer
 
-void TBufferSQL2::WriteDouble(Double_t  d)
+void TBufferSQL2::WriteDouble(Double_t d)
 {
    TBufferSQL2_operatorout(d);
 }
@@ -2400,7 +2418,7 @@ Bool_t TBufferSQL2::SqlWriteBasic(Char_t value)
 ////////////////////////////////////////////////////////////////////////////////
 /// converts Short_t to string and creates correspondent sql structure
 
-Bool_t  TBufferSQL2::SqlWriteBasic(Short_t value)
+Bool_t TBufferSQL2::SqlWriteBasic(Short_t value)
 {
    char buf[50];
    snprintf(buf, sizeof(buf), "%hd", value);
@@ -2440,7 +2458,7 @@ Bool_t TBufferSQL2::SqlWriteBasic(Long64_t value)
 ////////////////////////////////////////////////////////////////////////////////
 /// converts Float_t to string and creates correspondent sql structure
 
-Bool_t  TBufferSQL2::SqlWriteBasic(Float_t value)
+Bool_t TBufferSQL2::SqlWriteBasic(Float_t value)
 {
    char buf[200];
    snprintf(buf, sizeof(buf), TSQLServer::GetFloatFormat(), value);
@@ -2517,7 +2535,7 @@ Bool_t TBufferSQL2::SqlWriteBasic(ULong64_t value)
 
 //______________________________________________________________________________
 
-Bool_t TBufferSQL2::SqlWriteValue(const char* value, const char* tname)
+Bool_t TBufferSQL2::SqlWriteValue(const char *value, const char *tname)
 {
    // create structure in stack, which holds specified value
 
@@ -2529,12 +2547,12 @@ Bool_t TBufferSQL2::SqlWriteValue(const char* value, const char* tname)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read current value from table and convert it to Char_t value
 
-void TBufferSQL2::SqlReadBasic(Char_t& value)
+void TBufferSQL2::SqlReadBasic(Char_t &value)
 {
-   const char* res = SqlReadValue(sqlio::Char);
+   const char *res = SqlReadValue(sqlio::Char);
    if (res) {
       int n;
-      sscanf(res,"%d", &n);
+      sscanf(res, "%d", &n);
       value = n;
    } else
       value = 0;
@@ -2543,11 +2561,11 @@ void TBufferSQL2::SqlReadBasic(Char_t& value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read current value from table and convert it to Short_t value
 
-void TBufferSQL2::SqlReadBasic(Short_t& value)
+void TBufferSQL2::SqlReadBasic(Short_t &value)
 {
-   const char* res = SqlReadValue(sqlio::Short);
+   const char *res = SqlReadValue(sqlio::Short);
    if (res)
-      sscanf(res,"%hd", &value);
+      sscanf(res, "%hd", &value);
    else
       value = 0;
 }
@@ -2555,11 +2573,11 @@ void TBufferSQL2::SqlReadBasic(Short_t& value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read current value from table and convert it to Int_t value
 
-void TBufferSQL2::SqlReadBasic(Int_t& value)
+void TBufferSQL2::SqlReadBasic(Int_t &value)
 {
-   const char* res = SqlReadValue(sqlio::Int);
+   const char *res = SqlReadValue(sqlio::Int);
    if (res)
-      sscanf(res,"%d", &value);
+      sscanf(res, "%d", &value);
    else
       value = 0;
 }
@@ -2567,11 +2585,11 @@ void TBufferSQL2::SqlReadBasic(Int_t& value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read current value from table and convert it to Long_t value
 
-void TBufferSQL2::SqlReadBasic(Long_t& value)
+void TBufferSQL2::SqlReadBasic(Long_t &value)
 {
-   const char* res = SqlReadValue(sqlio::Long);
+   const char *res = SqlReadValue(sqlio::Long);
    if (res)
-      sscanf(res,"%ld", &value);
+      sscanf(res, "%ld", &value);
    else
       value = 0;
 }
@@ -2579,9 +2597,9 @@ void TBufferSQL2::SqlReadBasic(Long_t& value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read current value from table and convert it to Long64_t value
 
-void TBufferSQL2::SqlReadBasic(Long64_t& value)
+void TBufferSQL2::SqlReadBasic(Long64_t &value)
 {
-   const char* res = SqlReadValue(sqlio::Long64);
+   const char *res = SqlReadValue(sqlio::Long64);
    if (res)
       sscanf(res, FLong64, &value);
    else
@@ -2591,9 +2609,9 @@ void TBufferSQL2::SqlReadBasic(Long64_t& value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read current value from table and convert it to Float_t value
 
-void TBufferSQL2::SqlReadBasic(Float_t& value)
+void TBufferSQL2::SqlReadBasic(Float_t &value)
 {
-   const char* res = SqlReadValue(sqlio::Float);
+   const char *res = SqlReadValue(sqlio::Float);
    if (res)
       sscanf(res, "%f", &value);
    else
@@ -2603,9 +2621,9 @@ void TBufferSQL2::SqlReadBasic(Float_t& value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read current value from table and convert it to Double_t value
 
-void TBufferSQL2::SqlReadBasic(Double_t& value)
+void TBufferSQL2::SqlReadBasic(Double_t &value)
 {
-   const char* res = SqlReadValue(sqlio::Double);
+   const char *res = SqlReadValue(sqlio::Double);
    if (res)
       sscanf(res, "%lf", &value);
    else
@@ -2615,11 +2633,11 @@ void TBufferSQL2::SqlReadBasic(Double_t& value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read current value from table and convert it to Bool_t value
 
-void TBufferSQL2::SqlReadBasic(Bool_t& value)
+void TBufferSQL2::SqlReadBasic(Bool_t &value)
 {
-   const char* res = SqlReadValue(sqlio::Bool);
+   const char *res = SqlReadValue(sqlio::Bool);
    if (res)
-      value = (strcmp(res, sqlio::True)==0);
+      value = (strcmp(res, sqlio::True) == 0);
    else
       value = kFALSE;
 }
@@ -2627,12 +2645,12 @@ void TBufferSQL2::SqlReadBasic(Bool_t& value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read current value from table and convert it to UChar_t value
 
-void TBufferSQL2::SqlReadBasic(UChar_t& value)
+void TBufferSQL2::SqlReadBasic(UChar_t &value)
 {
-   const char* res = SqlReadValue(sqlio::UChar);
+   const char *res = SqlReadValue(sqlio::UChar);
    if (res) {
       unsigned int n;
-      sscanf(res,"%ud", &n);
+      sscanf(res, "%ud", &n);
       value = n;
    } else
       value = 0;
@@ -2641,11 +2659,11 @@ void TBufferSQL2::SqlReadBasic(UChar_t& value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read current value from table and convert it to UShort_t value
 
-void TBufferSQL2::SqlReadBasic(UShort_t& value)
+void TBufferSQL2::SqlReadBasic(UShort_t &value)
 {
-   const char* res = SqlReadValue(sqlio::UShort);
+   const char *res = SqlReadValue(sqlio::UShort);
    if (res)
-      sscanf(res,"%hud", &value);
+      sscanf(res, "%hud", &value);
    else
       value = 0;
 }
@@ -2653,11 +2671,11 @@ void TBufferSQL2::SqlReadBasic(UShort_t& value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read current value from table and convert it to UInt_t value
 
-void TBufferSQL2::SqlReadBasic(UInt_t& value)
+void TBufferSQL2::SqlReadBasic(UInt_t &value)
 {
-   const char* res = SqlReadValue(sqlio::UInt);
+   const char *res = SqlReadValue(sqlio::UInt);
    if (res)
-      sscanf(res,"%u", &value);
+      sscanf(res, "%u", &value);
    else
       value = 0;
 }
@@ -2665,11 +2683,11 @@ void TBufferSQL2::SqlReadBasic(UInt_t& value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read current value from table and convert it to ULong_t value
 
-void TBufferSQL2::SqlReadBasic(ULong_t& value)
+void TBufferSQL2::SqlReadBasic(ULong_t &value)
 {
-   const char* res = SqlReadValue(sqlio::ULong);
+   const char *res = SqlReadValue(sqlio::ULong);
    if (res)
-      sscanf(res,"%lu", &value);
+      sscanf(res, "%lu", &value);
    else
       value = 0;
 }
@@ -2677,9 +2695,9 @@ void TBufferSQL2::SqlReadBasic(ULong_t& value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read current value from table and convert it to ULong64_t value
 
-void TBufferSQL2::SqlReadBasic(ULong64_t& value)
+void TBufferSQL2::SqlReadBasic(ULong64_t &value)
 {
-   const char* res = SqlReadValue(sqlio::ULong64);
+   const char *res = SqlReadValue(sqlio::ULong64);
    if (res)
       sscanf(res, FULong64, &value);
    else
@@ -2689,12 +2707,13 @@ void TBufferSQL2::SqlReadBasic(ULong64_t& value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read string value from current stack node
 
-const char* TBufferSQL2::SqlReadValue(const char* tname)
+const char *TBufferSQL2::SqlReadValue(const char *tname)
 {
-   if (fErrorFlag>0) return 0;
+   if (fErrorFlag > 0)
+      return 0;
 
-   if (fCurrentData==0) {
-      Error("SqlReadValue","No object data to read from");
+   if (fCurrentData == 0) {
+      Error("SqlReadValue", "No object data to read from");
       fErrorFlag = 1;
       return 0;
    }
@@ -2709,7 +2728,7 @@ const char* TBufferSQL2::SqlReadValue(const char* tname)
 
    fCurrentData->ShiftToNextValue();
 
-   if (gDebug>4)
+   if (gDebug > 4)
       std::cout << "   SqlReadValue " << tname << " = " << fReadBuffer << std::endl;
 
    return fReadBuffer.Data();
@@ -2718,44 +2737,46 @@ const char* TBufferSQL2::SqlReadValue(const char* tname)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read CharStar value, if it has special code, request it from large table
 
-const char* TBufferSQL2::SqlReadCharStarValue()
+const char *TBufferSQL2::SqlReadCharStarValue()
 {
-   const char* res = SqlReadValue(sqlio::CharStar);
-   if ((res==0) || (fSQL==0)) return 0;
+   const char *res = SqlReadValue(sqlio::CharStar);
+   if ((res == 0) || (fSQL == 0))
+      return 0;
 
    Long64_t objid = Stack()->DefineObjectId(kTRUE);
 
    Int_t strid = fSQL->IsLongStringCode(objid, res);
-   if (strid<=0) return res;
+   if (strid <= 0)
+      return res;
 
    fSQL->GetLongString(objid, strid, fReadBuffer);
 
    return fReadBuffer.Data();
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Push stack with structurual information about streamed object
 
-TSQLStructure* TBufferSQL2::PushStack()
+TSQLStructure *TBufferSQL2::PushStack()
 {
-   TSQLStructure* res = new TSQLStructure;
-   if (fStk==0) {
+   TSQLStructure *res = new TSQLStructure;
+   if (fStk == 0) {
       fStructure = res;
    } else {
       fStk->Add(res);
    }
 
-   fStk = res;   // add in the stack
+   fStk = res; // add in the stack
    return fStk;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Pop stack
 
-TSQLStructure* TBufferSQL2::PopStack()
+TSQLStructure *TBufferSQL2::PopStack()
 {
-   if (fStk==0) return 0;
+   if (fStk == 0)
+      return 0;
    fStk = fStk->GetParent();
    return fStk;
 }
@@ -2763,19 +2784,19 @@ TSQLStructure* TBufferSQL2::PopStack()
 ////////////////////////////////////////////////////////////////////////////////
 /// returns head of stack
 
-TSQLStructure* TBufferSQL2::Stack(Int_t depth)
+TSQLStructure *TBufferSQL2::Stack(Int_t depth)
 {
-   TSQLStructure* curr = fStk;
-   while ((depth-->0) && (curr!=0)) curr = curr->GetParent();
+   TSQLStructure *curr = fStk;
+   while ((depth-- > 0) && (curr != 0))
+      curr = curr->GetParent();
    return curr;
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// set printf format for float/double members, default "%e"
 /// changes global TSQLServer variable
 
-void TBufferSQL2::SetFloatFormat(const char* fmt)
+void TBufferSQL2::SetFloatFormat(const char *fmt)
 {
    TSQLServer::SetFloatFormat(fmt);
 }
@@ -2784,7 +2805,7 @@ void TBufferSQL2::SetFloatFormat(const char* fmt)
 /// return current printf format for float/double members, default "%e"
 /// return format, hold by TSQLServer
 
-const char* TBufferSQL2::GetFloatFormat()
+const char *TBufferSQL2::GetFloatFormat()
 {
    return TSQLServer::GetFloatFormat();
 }
@@ -2799,26 +2820,24 @@ Int_t TBufferSQL2::ApplySequence(const TStreamerInfoActions::TActionSequence &se
    IncrementLevel(info);
 
    if (gDebug) {
-      //loop on all active members
+      // loop on all active members
       TStreamerInfoActions::ActionContainer_t::const_iterator end = sequence.fActions.end();
-      for(TStreamerInfoActions::ActionContainer_t::const_iterator iter = sequence.fActions.begin();
-          iter != end;
-          ++iter) {
+      for (TStreamerInfoActions::ActionContainer_t::const_iterator iter = sequence.fActions.begin(); iter != end;
+           ++iter) {
          // Idea: Try to remove this function call as it is really needed only for XML streaming.
-         SetStreamerElementNumber((*iter).fConfiguration->fCompInfo->fElem,(*iter).fConfiguration->fCompInfo->fType);
-         (*iter).PrintDebug(*this,obj);
-         (*iter)(*this,obj);
+         SetStreamerElementNumber((*iter).fConfiguration->fCompInfo->fElem, (*iter).fConfiguration->fCompInfo->fType);
+         (*iter).PrintDebug(*this, obj);
+         (*iter)(*this, obj);
       }
 
    } else {
-      //loop on all active members
+      // loop on all active members
       TStreamerInfoActions::ActionContainer_t::const_iterator end = sequence.fActions.end();
-      for(TStreamerInfoActions::ActionContainer_t::const_iterator iter = sequence.fActions.begin();
-          iter != end;
-          ++iter) {
+      for (TStreamerInfoActions::ActionContainer_t::const_iterator iter = sequence.fActions.begin(); iter != end;
+           ++iter) {
          // Idea: Try to remove this function call as it is really needed only for XML streaming.
-         SetStreamerElementNumber((*iter).fConfiguration->fCompInfo->fElem,(*iter).fConfiguration->fCompInfo->fType);
-         (*iter)(*this,obj);
+         SetStreamerElementNumber((*iter).fConfiguration->fCompInfo->fElem, (*iter).fConfiguration->fCompInfo->fType);
+         (*iter)(*this, obj);
       }
    }
 
@@ -2830,32 +2849,32 @@ Int_t TBufferSQL2::ApplySequence(const TStreamerInfoActions::TActionSequence &se
 /// Read one collection of objects from the buffer using the StreamerInfoLoopAction.
 /// The collection needs to be a split TClonesArray or a split vector of pointers.
 
-Int_t TBufferSQL2::ApplySequenceVecPtr(const TStreamerInfoActions::TActionSequence &sequence, void *start_collection, void *end_collection)
+Int_t TBufferSQL2::ApplySequenceVecPtr(const TStreamerInfoActions::TActionSequence &sequence, void *start_collection,
+                                       void *end_collection)
 {
    TVirtualStreamerInfo *info = sequence.fStreamerInfo;
    IncrementLevel(info);
 
    if (gDebug) {
-      //loop on all active members
+      // loop on all active members
       TStreamerInfoActions::ActionContainer_t::const_iterator end = sequence.fActions.end();
-      for(TStreamerInfoActions::ActionContainer_t::const_iterator iter = sequence.fActions.begin();
-          iter != end;
-          ++iter) {
+      for (TStreamerInfoActions::ActionContainer_t::const_iterator iter = sequence.fActions.begin(); iter != end;
+           ++iter) {
          // Idea: Try to remove this function call as it is really needed only for XML streaming.
-         SetStreamerElementNumber((*iter).fConfiguration->fCompInfo->fElem,(*iter).fConfiguration->fCompInfo->fType);
-         (*iter).PrintDebug(*this,*(char**)start_collection);  // Warning: This limits us to TClonesArray and vector of pointers.
-         (*iter)(*this,start_collection,end_collection);
+         SetStreamerElementNumber((*iter).fConfiguration->fCompInfo->fElem, (*iter).fConfiguration->fCompInfo->fType);
+         (*iter).PrintDebug(
+            *this, *(char **)start_collection); // Warning: This limits us to TClonesArray and vector of pointers.
+         (*iter)(*this, start_collection, end_collection);
       }
 
    } else {
-      //loop on all active members
+      // loop on all active members
       TStreamerInfoActions::ActionContainer_t::const_iterator end = sequence.fActions.end();
-      for(TStreamerInfoActions::ActionContainer_t::const_iterator iter = sequence.fActions.begin();
-          iter != end;
-          ++iter) {
+      for (TStreamerInfoActions::ActionContainer_t::const_iterator iter = sequence.fActions.begin(); iter != end;
+           ++iter) {
          // Idea: Try to remove this function call as it is really needed only for XML streaming.
-         SetStreamerElementNumber((*iter).fConfiguration->fCompInfo->fElem,(*iter).fConfiguration->fCompInfo->fType);
-         (*iter)(*this,start_collection,end_collection);
+         SetStreamerElementNumber((*iter).fConfiguration->fCompInfo->fElem, (*iter).fConfiguration->fCompInfo->fType);
+         (*iter)(*this, start_collection, end_collection);
       }
    }
 
@@ -2866,7 +2885,8 @@ Int_t TBufferSQL2::ApplySequenceVecPtr(const TStreamerInfoActions::TActionSequen
 ////////////////////////////////////////////////////////////////////////////////
 /// Read one collection of objects from the buffer using the StreamerInfoLoopAction.
 
-Int_t TBufferSQL2::ApplySequence(const TStreamerInfoActions::TActionSequence &sequence, void *start_collection, void *end_collection)
+Int_t TBufferSQL2::ApplySequence(const TStreamerInfoActions::TActionSequence &sequence, void *start_collection,
+                                 void *end_collection)
 {
    TVirtualStreamerInfo *info = sequence.fStreamerInfo;
    IncrementLevel(info);
@@ -2877,31 +2897,28 @@ Int_t TBufferSQL2::ApplySequence(const TStreamerInfoActions::TActionSequence &se
       // Get the address of the first item for the PrintDebug.
       // (Performance is not essential here since we are going to print to
       // the screen anyway).
-      void *arr0 = loopconfig->GetFirstAddress(start_collection,end_collection);
+      void *arr0 = loopconfig->GetFirstAddress(start_collection, end_collection);
       // loop on all active members
       TStreamerInfoActions::ActionContainer_t::const_iterator end = sequence.fActions.end();
-      for(TStreamerInfoActions::ActionContainer_t::const_iterator iter = sequence.fActions.begin();
-          iter != end;
-          ++iter) {
+      for (TStreamerInfoActions::ActionContainer_t::const_iterator iter = sequence.fActions.begin(); iter != end;
+           ++iter) {
          // Idea: Try to remove this function call as it is really needed only for XML streaming.
-         SetStreamerElementNumber((*iter).fConfiguration->fCompInfo->fElem,(*iter).fConfiguration->fCompInfo->fType);
-         (*iter).PrintDebug(*this,arr0);
-         (*iter)(*this,start_collection,end_collection,loopconfig);
+         SetStreamerElementNumber((*iter).fConfiguration->fCompInfo->fElem, (*iter).fConfiguration->fCompInfo->fType);
+         (*iter).PrintDebug(*this, arr0);
+         (*iter)(*this, start_collection, end_collection, loopconfig);
       }
 
    } else {
-      //loop on all active members
+      // loop on all active members
       TStreamerInfoActions::ActionContainer_t::const_iterator end = sequence.fActions.end();
-      for(TStreamerInfoActions::ActionContainer_t::const_iterator iter = sequence.fActions.begin();
-          iter != end;
-          ++iter) {
+      for (TStreamerInfoActions::ActionContainer_t::const_iterator iter = sequence.fActions.begin(); iter != end;
+           ++iter) {
          // Idea: Try to remove this function call as it is really needed only for XML streaming.
-         SetStreamerElementNumber((*iter).fConfiguration->fCompInfo->fElem,(*iter).fConfiguration->fCompInfo->fType);
-         (*iter)(*this,start_collection,end_collection,loopconfig);
+         SetStreamerElementNumber((*iter).fConfiguration->fCompInfo->fElem, (*iter).fConfiguration->fCompInfo->fType);
+         (*iter)(*this, start_collection, end_collection, loopconfig);
       }
    }
 
    DecrementLevel(info);
    return 0;
 }
-

--- a/io/sql/src/TKeySQL.cxx
+++ b/io/sql/src/TKeySQL.cxx
@@ -13,11 +13,10 @@
 \class TKeySQL
 \ingroup IO
 
-TKeySQL represents metainforamtion about object, which was written to
+TKeySQL represents meta-inforamtion about object, which was written to
 SQL database. It keeps object id, which used to locate object data
 from database tables.
 */
-
 
 #include "TKeySQL.h"
 
@@ -37,58 +36,57 @@ ClassImp(TKeySQL);
 ////////////////////////////////////////////////////////////////////////////////
 /// default constructor
 
-TKeySQL::TKeySQL() :
-   TKey(),
-   fKeyId(-1),
-   fObjId(-1)
+TKeySQL::TKeySQL() : TKey(), fKeyId(-1), fObjId(-1)
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates TKeySQL and convert obj data to TSQLStructure via TBufferSQL2
 
-TKeySQL::TKeySQL(TDirectory* mother, const TObject* obj, const char* name, const char* title) :
-    TKey(mother),
-    fKeyId(-1),
-    fObjId(-1)
+TKeySQL::TKeySQL(TDirectory *mother, const TObject *obj, const char *name, const char *title)
+   : TKey(mother), fKeyId(-1), fObjId(-1)
 {
-   if (name) SetName(name); else
-      if (obj!=0) {SetName(obj->GetName());  fClassName=obj->ClassName();}
-      else SetName("Noname");
+   if (name)
+      SetName(name);
+   else if (obj != 0) {
+      SetName(obj->GetName());
+      fClassName = obj->ClassName();
+   } else
+      SetName("Noname");
 
-   if (title) SetTitle(title);
+   if (title)
+      SetTitle(title);
 
-   StoreKeyObject((void*)obj, obj ? obj->IsA() : 0);
+   StoreKeyObject((void *)obj, obj ? obj->IsA() : 0);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates TKeySQL and convert obj data to TSQLStructure via TBufferSQL2
 
-TKeySQL::TKeySQL(TDirectory* mother, const void* obj, const TClass* cl, const char* name, const char* title) :
-    TKey(mother),
-    fKeyId(-1),
-    fObjId(-1)
+TKeySQL::TKeySQL(TDirectory *mother, const void *obj, const TClass *cl, const char *name, const char *title)
+   : TKey(mother), fKeyId(-1), fObjId(-1)
 {
-   if (name && *name) SetName(name);
-   else SetName(cl ? cl->GetName() : "Noname");
+   if (name && *name)
+      SetName(name);
+   else
+      SetName(cl ? cl->GetName() : "Noname");
 
-   if (title) SetTitle(title);
+   if (title)
+      SetTitle(title);
 
    StoreKeyObject(obj, cl);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Create TKeySQL object, which correponds to single entry in keys table
+/// Create TKeySQL object, which corresponds to single entry in keys table
 
-TKeySQL::TKeySQL(TDirectory* mother, Long64_t keyid, Long64_t objid,
-                 const char* name, const char* title,
-                 const char* keydatetime, Int_t cycle, const char* classname) :
-    TKey(mother),
-    fKeyId(keyid),
-    fObjId(objid)
+TKeySQL::TKeySQL(TDirectory *mother, Long64_t keyid, Long64_t objid, const char *name, const char *title,
+                 const char *keydatetime, Int_t cycle, const char *classname)
+   : TKey(mother), fKeyId(keyid), fObjId(objid)
 {
    SetName(name);
-   if (title) SetTitle(title);
+   if (title)
+      SetTitle(title);
    TDatime dt(keydatetime);
    fDatime = dt;
    fCycle = cycle;
@@ -107,30 +105,40 @@ TKeySQL::~TKeySQL()
 /// Used in TFile::StreamKeysForDirectory() method to verify data for that keys
 /// should be updated
 
-Bool_t TKeySQL::IsKeyModified(const char* keyname, const char* keytitle, const char* keydatime, Int_t cycle, const char* classname)
+Bool_t TKeySQL::IsKeyModified(const char *keyname, const char *keytitle, const char *keydatime, Int_t cycle,
+                              const char *classname)
 {
-   Int_t len1 = (GetName()==0) ? 0 : strlen(GetName());
-   Int_t len2 = (keyname==0) ? 0 : strlen(keyname);
-   if (len1!=len2) return kTRUE;
-   if ((len1>0) && (strcmp(GetName(), keyname)!=0)) return kTRUE;
+   Int_t len1 = (GetName() == 0) ? 0 : strlen(GetName());
+   Int_t len2 = (keyname == 0) ? 0 : strlen(keyname);
+   if (len1 != len2)
+      return kTRUE;
+   if ((len1 > 0) && (strcmp(GetName(), keyname) != 0))
+      return kTRUE;
 
-   len1 = (GetTitle()==0) ? 0 : strlen(GetTitle());
-   len2 = (keytitle==0) ? 0 : strlen(keytitle);
-   if (len1!=len2) return kTRUE;
-   if ((len1>0) && (strcmp(GetTitle(), keytitle)!=0)) return kTRUE;
+   len1 = (GetTitle() == 0) ? 0 : strlen(GetTitle());
+   len2 = (keytitle == 0) ? 0 : strlen(keytitle);
+   if (len1 != len2)
+      return kTRUE;
+   if ((len1 > 0) && (strcmp(GetTitle(), keytitle) != 0))
+      return kTRUE;
 
-   const char* tm = GetDatime().AsSQLString();
-   len1 = (tm==0) ? 0 : strlen(tm);
-   len2 = (keydatime==0) ? 0 : strlen(keydatime);
-   if (len1!=len2) return kTRUE;
-   if ((len1>0) && (strcmp(tm, keydatime)!=0)) return kTRUE;
+   const char *tm = GetDatime().AsSQLString();
+   len1 = (tm == 0) ? 0 : strlen(tm);
+   len2 = (keydatime == 0) ? 0 : strlen(keydatime);
+   if (len1 != len2)
+      return kTRUE;
+   if ((len1 > 0) && (strcmp(tm, keydatime) != 0))
+      return kTRUE;
 
-   if (cycle!=GetCycle()) return kTRUE;
+   if (cycle != GetCycle())
+      return kTRUE;
 
-   len1 = (GetClassName()==0) ? 0 : strlen(GetClassName());
-   len2 = (classname==0) ? 0 : strlen(classname);
-   if (len1!=len2) return kTRUE;
-   if ((len1>0) && (strcmp(GetClassName(), classname)!=0)) return kTRUE;
+   len1 = (GetClassName() == 0) ? 0 : strlen(GetClassName());
+   len2 = (classname == 0) ? 0 : strlen(classname);
+   if (len1 != len2)
+      return kTRUE;
+   if ((len1 > 0) && (strcmp(GetClassName(), classname) != 0))
+      return kTRUE;
 
    return kFALSE;
 }
@@ -141,9 +149,9 @@ Bool_t TKeySQL::IsKeyModified(const char* keyname, const char* keytitle, const c
 
 void TKeySQL::Delete(Option_t * /*option*/)
 {
-   TSQLFile* f = (TSQLFile*) GetFile();
+   TSQLFile *f = (TSQLFile *)GetFile();
 
-   if (f!=0)
+   if (f != 0)
       f->DeleteKeyFromDB(GetDBKeyId());
 
    fMotherDir->GetListOfKeys()->Remove(this);
@@ -160,9 +168,9 @@ Long64_t TKeySQL::GetDBDirId() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Stores object, associated with key, into data tables
 
-void TKeySQL::StoreKeyObject(const void* obj, const TClass* cl)
+void TKeySQL::StoreKeyObject(const void *obj, const TClass *cl)
 {
-   TSQLFile* f = (TSQLFile*) GetFile();
+   TSQLFile *f = (TSQLFile *)GetFile();
 
    fCycle = GetMotherDir()->AppendKey(this);
 
@@ -170,20 +178,21 @@ void TKeySQL::StoreKeyObject(const void* obj, const TClass* cl)
 
    fObjId = f->StoreObjectInTables(fKeyId, obj, cl);
 
-   if (cl) fClassName = cl->GetName();
+   if (cl)
+      fClassName = cl->GetName();
 
-   if (GetDBObjId()>=0) {
+   if (GetDBObjId() >= 0) {
       fDatime.Set();
       if (!f->WriteKeyData(this)) {
          // cannot add entry to keys table
-         Error("StoreKeyObject","Cannot write data to key tables");
+         Error("StoreKeyObject", "Cannot write data to key tables");
          // delete everything relevant for that key
          f->DeleteKeyFromDB(GetDBKeyId());
          fObjId = -1;
       }
    }
 
-   if (GetDBObjId()<0)
+   if (GetDBObjId() < 0)
       GetMotherDir()->GetListOfKeys()->Remove(this);
    // fix me !!! One should delete object by other means
    // delete this;
@@ -195,27 +204,29 @@ void TKeySQL::StoreKeyObject(const void* obj, const TClass* cl)
 /// Before invoking this function, obj has been created via the
 /// default constructor.
 
-Int_t TKeySQL::Read(TObject* tobj)
+Int_t TKeySQL::Read(TObject *tobj)
 {
-   if (tobj==0) return 0;
+   if (tobj == 0)
+      return 0;
 
-   void* res = ReadKeyObject(tobj, 0);
+   void *res = ReadKeyObject(tobj, 0);
 
-   return res==0 ? 0 : 1;
+   return res == 0 ? 0 : 1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read object derived from TObject class
 /// If it is not TObject or in case of error, return 0
 
-TObject* TKeySQL::ReadObj()
+TObject *TKeySQL::ReadObj()
 {
-   TObject* tobj = (TObject*) ReadKeyObject(0, TObject::Class());
+   TObject *tobj = (TObject *)ReadKeyObject(0, TObject::Class());
 
-   if (tobj!=0) {
-      if (gROOT->GetForceStyle()) tobj->UseCurrentStyle();
+   if (tobj != 0) {
+      if (gROOT->GetForceStyle())
+         tobj->UseCurrentStyle();
       if (tobj->IsA() == TDirectoryFile::Class()) {
-         TDirectoryFile *dir = (TDirectoryFile*) tobj;
+         TDirectoryFile *dir = (TDirectoryFile *)tobj;
          dir->SetName(GetName());
          dir->SetTitle(GetTitle());
          dir->SetSeekDir(GetDBKeyId());
@@ -232,14 +243,15 @@ TObject* TKeySQL::ReadObj()
 /// Read object derived from TObject class
 /// If it is not TObject or in case of error, return 0
 
-TObject* TKeySQL::ReadObjWithBuffer(char * /*bufferRead*/)
+TObject *TKeySQL::ReadObjWithBuffer(char * /*bufferRead*/)
 {
-   TObject* tobj = (TObject*) ReadKeyObject(0, TObject::Class());
+   TObject *tobj = (TObject *)ReadKeyObject(0, TObject::Class());
 
-   if (tobj!=0) {
-      if (gROOT->GetForceStyle()) tobj->UseCurrentStyle();
+   if (tobj != 0) {
+      if (gROOT->GetForceStyle())
+         tobj->UseCurrentStyle();
       if (tobj->IsA() == TDirectoryFile::Class()) {
-         TDirectoryFile *dir = (TDirectoryFile*) tobj;
+         TDirectoryFile *dir = (TDirectoryFile *)tobj;
          dir->SetName(GetName());
          dir->SetTitle(GetTitle());
          dir->SetSeekDir(GetDBKeyId());
@@ -255,12 +267,12 @@ TObject* TKeySQL::ReadObjWithBuffer(char * /*bufferRead*/)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read object of any type from SQL database
 
-void* TKeySQL::ReadObjectAny(const TClass* expectedClass)
+void *TKeySQL::ReadObjectAny(const TClass *expectedClass)
 {
    void *res = ReadKeyObject(0, expectedClass);
 
    if (res && (expectedClass == TDirectoryFile::Class())) {
-      TDirectoryFile *dir = (TDirectoryFile *) res;
+      TDirectoryFile *dir = (TDirectoryFile *)res;
       dir->SetName(GetName());
       dir->SetTitle(GetTitle());
       dir->SetSeekDir(GetDBKeyId());
@@ -275,35 +287,37 @@ void* TKeySQL::ReadObjectAny(const TClass* expectedClass)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read object, associated with key, from database
 
-void* TKeySQL::ReadKeyObject(void* obj, const TClass* expectedClass)
+void *TKeySQL::ReadKeyObject(void *obj, const TClass *expectedClass)
 {
-   TSQLFile* f = (TSQLFile*) GetFile();
+   TSQLFile *f = (TSQLFile *)GetFile();
 
-   if ((GetDBKeyId()<=0) || (f==0)) return obj;
+   if ((GetDBKeyId() <= 0) || (f == 0))
+      return obj;
 
    TBufferSQL2 buffer(TBuffer::kRead, f);
 
-   TClass* cl = 0;
+   TClass *cl = 0;
 
-   void* res = buffer.SqlReadAny(GetDBKeyId(), GetDBObjId(), &cl, obj);
+   void *res = buffer.SqlReadAny(GetDBKeyId(), GetDBObjId(), &cl, obj);
 
-   if ((cl==0) || (res==0)) return 0;
+   if ((cl == 0) || (res == 0))
+      return 0;
 
    Int_t delta = 0;
 
-   if (expectedClass!=0) {
+   if (expectedClass != 0) {
       delta = cl->GetBaseClassOffset(expectedClass);
-      if (delta<0) {
-         if (obj==0) cl->Destructor(res);
+      if (delta < 0) {
+         if (obj == 0)
+            cl->Destructor(res);
          return 0;
       }
       if (cl->GetState() > TClass::kEmulated && expectedClass->GetState() <= TClass::kEmulated) {
-         //we cannot mix a compiled class with an emulated class in the inheritance
-         Warning("XmlReadAny",
-                 "Trying to read an emulated class (%s) to store in a compiled pointer (%s)",
-                 cl->GetName(),expectedClass->GetName());
+         // we cannot mix a compiled class with an emulated class in the inheritance
+         Warning("XmlReadAny", "Trying to read an emulated class (%s) to store in a compiled pointer (%s)",
+                 cl->GetName(), expectedClass->GetName());
       }
    }
 
-   return ((char*)res) + delta;
+   return ((char *)res) + delta;
 }

--- a/io/sql/src/TKeySQL.cxx
+++ b/io/sql/src/TKeySQL.cxx
@@ -257,7 +257,19 @@ TObject* TKeySQL::ReadObjWithBuffer(char * /*bufferRead*/)
 
 void* TKeySQL::ReadObjectAny(const TClass* expectedClass)
 {
-   return ReadKeyObject(0, expectedClass);
+   void *res = ReadKeyObject(0, expectedClass);
+
+   if (res && (expectedClass == TDirectoryFile::Class())) {
+      TDirectoryFile *dir = (TDirectoryFile *) res;
+      dir->SetName(GetName());
+      dir->SetTitle(GetTitle());
+      dir->SetSeekDir(GetDBKeyId());
+      dir->SetMother(fMotherDir);
+      dir->ReadKeys();
+      fMotherDir->Append(dir);
+   }
+
+   return res;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/io/sql/src/TSQLClassInfo.cxx
+++ b/io/sql/src/TSQLClassInfo.cxx
@@ -24,30 +24,20 @@ List of this objects are kept by TSQLFile class.
 
 #include "TObjArray.h"
 
-
 ClassImp(TSQLClassColumnInfo);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// default constructor
 
-TSQLClassColumnInfo::TSQLClassColumnInfo() :
-   TObject(),
-   fName(),
-   fSQLName(),
-   fSQLType()
+TSQLClassColumnInfo::TSQLClassColumnInfo() : TObject(), fName(), fSQLName(), fSQLType()
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// normal constructor
 
-TSQLClassColumnInfo::TSQLClassColumnInfo(const char* name,
-                                         const char* sqlname,
-                                         const char* sqltype) :
-   TObject(),
-   fName(name),
-   fSQLName(sqlname),
-   fSQLType(sqltype)
+TSQLClassColumnInfo::TSQLClassColumnInfo(const char *name, const char *sqlname, const char *sqltype)
+   : TObject(), fName(name), fSQLName(sqlname), fSQLType(sqltype)
 {
 }
 
@@ -58,21 +48,14 @@ TSQLClassColumnInfo::~TSQLClassColumnInfo()
 {
 }
 
-
 ClassImp(TSQLClassInfo);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// default constructor
 
-TSQLClassInfo::TSQLClassInfo() :
-   TObject(),
-   fClassName(),
-   fClassVersion(0),
-   fClassId(0),
-   fClassTable(),
-   fRawTable(),
-   fColumns(0),
-   fRawtableExist(kFALSE)
+TSQLClassInfo::TSQLClassInfo()
+   : TObject(), fClassName(), fClassVersion(0), fClassId(0), fClassTable(), fRawTable(), fColumns(0),
+     fRawtableExist(kFALSE)
 {
 }
 
@@ -80,17 +63,9 @@ TSQLClassInfo::TSQLClassInfo() :
 /// normal constructor of TSQLClassInfo class
 /// Sets names of tables, which are used for that version of class
 
-TSQLClassInfo::TSQLClassInfo(Long64_t classid,
-                             const char* classname,
-                             Int_t version) :
-   TObject(),
-   fClassName(classname),
-   fClassVersion(version),
-   fClassId(classid),
-   fClassTable(),
-   fRawTable(),
-   fColumns(0),
-   fRawtableExist(kFALSE)
+TSQLClassInfo::TSQLClassInfo(Long64_t classid, const char *classname, Int_t version)
+   : TObject(), fClassName(classname), fClassVersion(version), fClassId(classid), fClassTable(), fRawTable(),
+     fColumns(0), fRawtableExist(kFALSE)
 {
    fClassTable.Form("%s_ver%d", classname, version);
    fRawTable.Form("%s_raw%d", classname, version);
@@ -101,7 +76,7 @@ TSQLClassInfo::TSQLClassInfo(Long64_t classid,
 
 TSQLClassInfo::~TSQLClassInfo()
 {
-   if (fColumns!=0) {
+   if (fColumns != 0) {
       fColumns->Delete();
       delete fColumns;
    }
@@ -110,9 +85,9 @@ TSQLClassInfo::~TSQLClassInfo()
 ////////////////////////////////////////////////////////////////////////////////
 /// assigns new list of columns
 
-void TSQLClassInfo::SetColumns(TObjArray* columns)
+void TSQLClassInfo::SetColumns(TObjArray *columns)
 {
-   if (fColumns!=0) {
+   if (fColumns != 0) {
       fColumns->Delete();
       delete fColumns;
    }
@@ -122,7 +97,7 @@ void TSQLClassInfo::SetColumns(TObjArray* columns)
 ////////////////////////////////////////////////////////////////////////////////
 /// set current status of class tables
 
-void TSQLClassInfo::SetTableStatus(TObjArray* columns, Bool_t israwtable)
+void TSQLClassInfo::SetTableStatus(TObjArray *columns, Bool_t israwtable)
 {
    SetColumns(columns);
    fRawtableExist = israwtable;
@@ -135,19 +110,21 @@ void TSQLClassInfo::SetTableStatus(TObjArray* columns, Bool_t israwtable)
 /// or for name, used as column name (sqlname = kTRUE)
 /// Return index of column in list (-1 if not found)
 
-Int_t TSQLClassInfo::FindColumn(const char* name, Bool_t sqlname)
+Int_t TSQLClassInfo::FindColumn(const char *name, Bool_t sqlname)
 {
-   if ((name==0) || (fColumns==0)) return -1;
+   if ((name == 0) || (fColumns == 0))
+      return -1;
 
    TIter next(fColumns);
 
-   TSQLClassColumnInfo* col = 0;
+   TSQLClassColumnInfo *col = 0;
 
    Int_t indx = 0;
 
-   while ((col = (TSQLClassColumnInfo*) next()) != 0) {
-      const char* colname = sqlname ? col->GetSQLName() : col->GetName();
-      if (strcmp(colname, name)==0) return indx;
+   while ((col = (TSQLClassColumnInfo *)next()) != 0) {
+      const char *colname = sqlname ? col->GetSQLName() : col->GetName();
+      if (strcmp(colname, name) == 0)
+         return indx;
       indx++;
    }
 

--- a/io/sql/src/TSQLObjectData.cxx
+++ b/io/sql/src/TSQLObjectData.cxx
@@ -14,7 +14,7 @@
 \ingroup IO
 
 TSQLObjectData is used in TBufferSQL2 class in reading procedure.
-It contains data, request from database table for one specifc
+It contains data, request from database table for one specific
 object for one specific class. For instance, when data for
 class TH1 required, requests will be done to
 TH1_ver4 and TH1_raw4 tables and result of these requests
@@ -42,21 +42,14 @@ ClassImp(TSQLObjectInfo);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TSQLObjectInfo::TSQLObjectInfo() :
-   TObject(),
-   fObjId(0),
-   fClassName(),
-   fVersion(0)
+TSQLObjectInfo::TSQLObjectInfo() : TObject(), fObjId(0), fClassName(), fVersion(0)
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TSQLObjectInfo::TSQLObjectInfo(Long64_t objid, const char* classname, Version_t version) :
-   TObject(),
-   fObjId(objid),
-   fClassName(classname),
-   fVersion(version)
+TSQLObjectInfo::TSQLObjectInfo(Long64_t objid, const char *classname, Version_t version)
+   : TObject(), fObjId(objid), fClassName(classname), fVersion(version)
 {
 }
 
@@ -77,54 +70,24 @@ ClassImp(TSQLObjectData);
 ////////////////////////////////////////////////////////////////////////////////
 /// default contrsuctor
 
-TSQLObjectData::TSQLObjectData() :
-      TObject(),
-      fInfo(0),
-      fObjId(0),
-      fOwner(kFALSE),
-      fClassData(0),
-      fBlobData(0),
-      fBlobStmt(0),
-      fLocatedColumn(-1),
-      fClassRow(0),
-      fBlobRow(0),
-      fLocatedField(0),
-      fLocatedValue(0),
-      fCurrentBlob(kFALSE),
-      fBlobPrefixName(0),
-      fBlobTypeName(0),
-      fUnpack(0)
+TSQLObjectData::TSQLObjectData()
+   : TObject(), fInfo(0), fObjId(0), fOwner(kFALSE), fClassData(0), fBlobData(0), fBlobStmt(0), fLocatedColumn(-1),
+     fClassRow(0), fBlobRow(0), fLocatedField(0), fLocatedValue(0), fCurrentBlob(kFALSE), fBlobPrefixName(0),
+     fBlobTypeName(0), fUnpack(0)
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// normal contrsuctor,
 
-TSQLObjectData::TSQLObjectData(TSQLClassInfo* sqlinfo,
-                               Long64_t       objid,
-                               TSQLResult*    classdata,
-                               TSQLRow*       classrow,
-                               TSQLResult*    blobdata,
-                               TSQLStatement* blobstmt) :
-   TObject(),
-   fInfo(sqlinfo),
-   fObjId(objid),
-   fOwner(kFALSE),
-   fClassData(classdata),
-   fBlobData(blobdata),
-   fBlobStmt(blobstmt),
-   fLocatedColumn(-1),
-   fClassRow(classrow),
-   fBlobRow(0),
-   fLocatedField(0),
-   fLocatedValue(0),
-   fCurrentBlob(kFALSE),
-   fBlobPrefixName(0),
-   fBlobTypeName(0),
-   fUnpack(0)
+TSQLObjectData::TSQLObjectData(TSQLClassInfo *sqlinfo, Long64_t objid, TSQLResult *classdata, TSQLRow *classrow,
+                               TSQLResult *blobdata, TSQLStatement *blobstmt)
+   : TObject(), fInfo(sqlinfo), fObjId(objid), fOwner(kFALSE), fClassData(classdata), fBlobData(blobdata),
+     fBlobStmt(blobstmt), fLocatedColumn(-1), fClassRow(classrow), fBlobRow(0), fLocatedField(0), fLocatedValue(0),
+     fCurrentBlob(kFALSE), fBlobPrefixName(0), fBlobTypeName(0), fUnpack(0)
 {
    // take ownership if no special row from data pool is provided
-   if ((fClassData!=0) && (fClassRow==0)) {
+   if ((fClassData != 0) && (fClassRow == 0)) {
       fOwner = kTRUE;
       fClassRow = fClassData->Next();
    }
@@ -137,12 +100,20 @@ TSQLObjectData::TSQLObjectData(TSQLClassInfo* sqlinfo,
 
 TSQLObjectData::~TSQLObjectData()
 {
-   if ((fClassData!=0) && fOwner) delete fClassData;
-   if (fClassRow!=0) delete fClassRow;
-   if (fBlobRow!=0) delete fBlobRow;
-   if (fBlobData!=0) delete fBlobData;
-   if (fUnpack!=0) { fUnpack->Delete(); delete fUnpack; }
-   if (fBlobStmt!=0) delete fBlobStmt;
+   if ((fClassData != 0) && fOwner)
+      delete fClassData;
+   if (fClassRow != 0)
+      delete fClassRow;
+   if (fBlobRow != 0)
+      delete fBlobRow;
+   if (fBlobData != 0)
+      delete fBlobData;
+   if (fUnpack != 0) {
+      fUnpack->Delete();
+      delete fUnpack;
+   }
+   if (fBlobStmt != 0)
+      delete fBlobStmt;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -150,25 +121,27 @@ TSQLObjectData::~TSQLObjectData()
 
 Int_t TSQLObjectData::GetNumClassFields()
 {
-   if (fClassData!=0) return fClassData->GetFieldCount();
+   if (fClassData != 0)
+      return fClassData->GetFieldCount();
    return 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// get name of class table column
 
-const char* TSQLObjectData::GetClassFieldName(Int_t n)
+const char *TSQLObjectData::GetClassFieldName(Int_t n)
 {
-   if (fClassData!=0) return fClassData->GetFieldName(n);
+   if (fClassData != 0)
+      return fClassData->GetFieldName(n);
    return 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// locate column of that name in results
 
-Bool_t TSQLObjectData::LocateColumn(const char* colname, Bool_t isblob)
+Bool_t TSQLObjectData::LocateColumn(const char *colname, Bool_t isblob)
 {
-   if (fUnpack!=0) {
+   if (fUnpack != 0) {
       fUnpack->Delete();
       delete fUnpack;
       fUnpack = 0;
@@ -178,34 +151,37 @@ Bool_t TSQLObjectData::LocateColumn(const char* colname, Bool_t isblob)
    fLocatedValue = 0;
    fCurrentBlob = kFALSE;
 
-   if ((fClassData==0) || (fClassRow==0)) return kFALSE;
+   if ((fClassData == 0) || (fClassRow == 0))
+      return kFALSE;
 
-//   Int_t numfields = GetNumClassFields();
+   //   Int_t numfields = GetNumClassFields();
 
    Int_t ncol = fInfo->FindColumn(colname, kFALSE);
-   if (ncol>0) {
+   if (ncol > 0) {
       fLocatedColumn = ncol;
       fLocatedField = GetClassFieldName(ncol);
       fLocatedValue = fClassRow->GetField(ncol);
    }
 
-
-/*   for (Int_t ncol=1;ncol<numfields;ncol++) {
-      const char* fieldname = GetClassFieldName(ncol);
-      if (strcmp(colname, fieldname)==0) {
-         fLocatedColumn = ncol;
-         fLocatedField = fieldname;
-         fLocatedValue = fClassRow->GetField(ncol);
-         break;
+   /*   for (Int_t ncol=1;ncol<numfields;ncol++) {
+         const char* fieldname = GetClassFieldName(ncol);
+         if (strcmp(colname, fieldname)==0) {
+            fLocatedColumn = ncol;
+            fLocatedField = fieldname;
+            fLocatedValue = fClassRow->GetField(ncol);
+            break;
+         }
       }
-   }
-*/
+   */
 
-   if (fLocatedField==0) return kFALSE;
+   if (fLocatedField == 0)
+      return kFALSE;
 
-   if (!isblob) return kTRUE;
+   if (!isblob)
+      return kTRUE;
 
-   if ((fBlobRow==0) && (fBlobStmt==0)) return kFALSE;
+   if ((fBlobRow == 0) && (fBlobStmt == 0))
+      return kFALSE;
 
    fCurrentBlob = kTRUE;
 
@@ -219,15 +195,18 @@ Bool_t TSQLObjectData::LocateColumn(const char* colname, Bool_t isblob)
 
 Bool_t TSQLObjectData::ShiftBlobRow()
 {
-   if (fBlobStmt!=0) {
+   if (fBlobStmt != 0) {
       Bool_t res = fBlobStmt->NextResultRow();
-      if (!res) { delete fBlobStmt; fBlobStmt = 0; }
+      if (!res) {
+         delete fBlobStmt;
+         fBlobStmt = 0;
+      }
       return res;
    }
 
    delete fBlobRow;
    fBlobRow = fBlobData ? fBlobData->Next() : 0;
-   return fBlobRow!=0;
+   return fBlobRow != 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -235,44 +214,44 @@ Bool_t TSQLObjectData::ShiftBlobRow()
 
 Bool_t TSQLObjectData::ExtractBlobValues()
 {
-   const char* name = 0;
+   const char *name = 0;
 
    Bool_t hasdata = kFALSE;
 
-   if (fBlobStmt!=0) {
+   if (fBlobStmt != 0) {
       name = fBlobStmt->GetString(0);
       fLocatedValue = fBlobStmt->GetString(1);
       hasdata = kTRUE;
    }
 
    if (!hasdata) {
-      if (fBlobRow!=0) {
+      if (fBlobRow != 0) {
          fLocatedValue = fBlobRow->GetField(1);
          name = fBlobRow->GetField(0);
       }
    }
 
-   if (name==0) {
+   if (name == 0) {
       fBlobPrefixName = 0;
       fBlobTypeName = 0;
       return kFALSE;
    }
 
-   const char* separ = strstr(name, ":"); //SQLNameSeparator()
+   const char *separ = strstr(name, ":"); // SQLNameSeparator()
 
-   if (separ==0) {
+   if (separ == 0) {
       fBlobPrefixName = 0;
       fBlobTypeName = name;
    } else {
       fBlobPrefixName = name;
-      separ+=strlen(":"); //SQLNameSeparator()
+      separ += strlen(":"); // SQLNameSeparator()
       fBlobTypeName = separ;
    }
 
-//   if (gDebug>4)
-//      Info("ExtractBlobValues","Prefix:%s Type:%s",
-//            (fBlobPrefixName ? fBlobPrefixName : "null"),
-//            (fBlobTypeName ? fBlobTypeName : "null"));
+   //   if (gDebug>4)
+   //      Info("ExtractBlobValues","Prefix:%s Type:%s",
+   //            (fBlobPrefixName ? fBlobPrefixName : "null"),
+   //            (fBlobTypeName ? fBlobTypeName : "null"));
 
    return kTRUE;
 }
@@ -281,10 +260,10 @@ Bool_t TSQLObjectData::ExtractBlobValues()
 /// add emulated data
 /// this used to place version or TObject raw data, read from normal tables
 
-void TSQLObjectData::AddUnpack(const char* tname, const char* value)
+void TSQLObjectData::AddUnpack(const char *tname, const char *value)
 {
-   TNamed* str = new TNamed(tname, value);
-   if (fUnpack==0) {
+   TNamed *str = new TNamed(tname, value);
+   if (fUnpack == 0) {
       fUnpack = new TObjArray();
       fBlobPrefixName = 0;
       fBlobTypeName = str->GetName();
@@ -297,7 +276,7 @@ void TSQLObjectData::AddUnpack(const char* tname, const char* value)
 ////////////////////////////////////////////////////////////////////////////////
 /// emulate integer value in raw data
 
-void TSQLObjectData::AddUnpackInt(const char* tname, Int_t value)
+void TSQLObjectData::AddUnpackInt(const char *tname, Int_t value)
 {
    TString sbuf;
    sbuf.Form("%d", value);
@@ -311,13 +290,13 @@ void TSQLObjectData::ShiftToNextValue()
 {
    Bool_t doshift = kTRUE;
 
-   if (fUnpack!=0) {
-      TObject* prev = fUnpack->First();
+   if (fUnpack != 0) {
+      TObject *prev = fUnpack->First();
       fUnpack->Remove(prev);
       delete prev;
       fUnpack->Compress();
-      if (fUnpack->GetLast()>=0) {
-         TNamed* curr = (TNamed*) fUnpack->First();
+      if (fUnpack->GetLast() >= 0) {
+         TNamed *curr = (TNamed *)fUnpack->First();
          fBlobPrefixName = 0;
          fBlobTypeName = curr->GetName();
          fLocatedValue = curr->GetTitle();
@@ -329,49 +308,50 @@ void TSQLObjectData::ShiftToNextValue()
    }
 
    if (fCurrentBlob) {
-      if (doshift) ShiftBlobRow();
+      if (doshift)
+         ShiftBlobRow();
       ExtractBlobValues();
-   } else
-      if (fClassData!=0) {
-         if (doshift) fLocatedColumn++;
-         if (fLocatedColumn<GetNumClassFields()) {
-            fLocatedField = GetClassFieldName(fLocatedColumn);
-            fLocatedValue = fClassRow->GetField(fLocatedColumn);
-         } else {
-            fLocatedField = 0;
-            fLocatedValue = 0;
-         }
+   } else if (fClassData != 0) {
+      if (doshift)
+         fLocatedColumn++;
+      if (fLocatedColumn < GetNumClassFields()) {
+         fLocatedField = GetClassFieldName(fLocatedColumn);
+         fLocatedValue = fClassRow->GetField(fLocatedColumn);
+      } else {
+         fLocatedField = 0;
+         fLocatedValue = 0;
       }
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// checks if data type corresponds to that stored in raw table
 
-Bool_t TSQLObjectData::VerifyDataType(const char* tname, Bool_t errormsg)
+Bool_t TSQLObjectData::VerifyDataType(const char *tname, Bool_t errormsg)
 {
-   if (tname==0) {
+   if (tname == 0) {
       if (errormsg)
-         Error("VerifyDataType","Data type not specified");
+         Error("VerifyDataType", "Data type not specified");
       return kFALSE;
    }
 
    // here maybe type of column can be checked
-   if (!IsBlobData()) return kTRUE;
+   if (!IsBlobData())
+      return kTRUE;
 
-   if (gDebug>4)
-      if ((fBlobTypeName==0) && errormsg) {
-         Error("VerifyDataType","fBlobTypeName is null");
+   if (gDebug > 4)
+      if ((fBlobTypeName == 0) && errormsg) {
+         Error("VerifyDataType", "fBlobTypeName is null");
          return kFALSE;
       }
-
 
    TString v1(fBlobTypeName);
    TString v2(tname);
 
-//   if (strcmp(fBlobTypeName,tname)!=0) {
-   if (v1!=v2) {
+   //   if (strcmp(fBlobTypeName,tname)!=0) {
+   if (v1 != v2) {
       if (errormsg)
-         Error("VerifyDataType","Data type missmatch %s - %s", fBlobTypeName, tname);
+         Error("VerifyDataType", "Data type missmatch %s - %s", fBlobTypeName, tname);
       return kFALSE;
    }
 
@@ -383,7 +363,8 @@ Bool_t TSQLObjectData::VerifyDataType(const char* tname, Bool_t errormsg)
 
 Bool_t TSQLObjectData::PrepareForRawData()
 {
-   if (!ExtractBlobValues()) return kFALSE;
+   if (!ExtractBlobValues())
+      return kFALSE;
 
    fCurrentBlob = kTRUE;
 
@@ -402,28 +383,18 @@ Bool_t TSQLObjectData::PrepareForRawData()
 //
 //________________________________________________________________________
 
-
 ClassImp(TSQLObjectDataPool);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TSQLObjectDataPool::TSQLObjectDataPool() :
-   TObject(),
-   fInfo(0),
-   fClassData(0),
-   fIsMoreRows(kTRUE),
-   fRowsPool(0)
+TSQLObjectDataPool::TSQLObjectDataPool() : TObject(), fInfo(0), fClassData(0), fIsMoreRows(kTRUE), fRowsPool(0)
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TSQLObjectDataPool::TSQLObjectDataPool(TSQLClassInfo* info, TSQLResult* data) :
-   TObject(),
-   fInfo(info),
-   fClassData(data),
-   fIsMoreRows(kTRUE),
-   fRowsPool(0)
+TSQLObjectDataPool::TSQLObjectDataPool(TSQLClassInfo *info, TSQLResult *data)
+   : TObject(), fInfo(info), fClassData(data), fIsMoreRows(kTRUE), fRowsPool(0)
 {
 }
 
@@ -433,8 +404,9 @@ TSQLObjectDataPool::TSQLObjectDataPool(TSQLClassInfo* info, TSQLResult* data) :
 
 TSQLObjectDataPool::~TSQLObjectDataPool()
 {
-   if (fClassData!=0) delete fClassData;
-   if (fRowsPool!=0) {
+   if (fClassData != 0)
+      delete fClassData;
+   if (fRowsPool != 0) {
       fRowsPool->Delete();
       delete fRowsPool;
    }
@@ -443,18 +415,19 @@ TSQLObjectDataPool::~TSQLObjectDataPool()
 ////////////////////////////////////////////////////////////////////////////////
 /// Returns single sql row with object data for that class
 
-TSQLRow* TSQLObjectDataPool::GetObjectRow(Long64_t objid)
+TSQLRow *TSQLObjectDataPool::GetObjectRow(Long64_t objid)
 {
-   if (fClassData==0) return 0;
+   if (fClassData == 0)
+      return 0;
 
    Long64_t rowid;
 
-   if (fRowsPool!=0) {
-      TObjLink* link = fRowsPool->FirstLink();
-      while (link!=0) {
-         TSQLRow* row = (TSQLRow*) link->GetObject();
+   if (fRowsPool != 0) {
+      TObjLink *link = fRowsPool->FirstLink();
+      while (link != 0) {
+         TSQLRow *row = (TSQLRow *)link->GetObject();
          rowid = sqlio::atol64(row->GetField(0));
-         if (rowid==objid) {
+         if (rowid == objid) {
             fRowsPool->Remove(link);
             return row;
          }
@@ -464,17 +437,18 @@ TSQLRow* TSQLObjectDataPool::GetObjectRow(Long64_t objid)
    }
 
    while (fIsMoreRows) {
-      TSQLRow* row = fClassData->Next();
-      if (row==0)
+      TSQLRow *row = fClassData->Next();
+      if (row == 0)
          fIsMoreRows = kFALSE;
       else {
          rowid = sqlio::atol64(row->GetField(0));
-         if (rowid==objid) return row;
-         if (fRowsPool==0) fRowsPool = new TList();
+         if (rowid == objid)
+            return row;
+         if (fRowsPool == 0)
+            fRowsPool = new TList();
          fRowsPool->Add(row);
       }
    }
 
    return 0;
 }
-

--- a/io/sql/src/TSQLStructure.cxx
+++ b/io/sql/src/TSQLStructure.cxx
@@ -12,10 +12,10 @@
 /**
 \class TSQLStructure
 \ingroup IO
-This is hierarhical structure, which is created when data is written
-by TBufferSQL2. It contains data all structurual information such:
-version of written class, data memeber types of that class, value for
-each data memeber and so on.
+This is hierarchical structure, which is created when data is written
+by TBufferSQL2. It contains data all structural information such:
+version of written class, data member types of that class, value for
+each data member and so on.
 Such structure in some sense similar to XML node and subnodes structure
 Once it created, it converted to SQL statements, which are submitted
 to database server.
@@ -41,116 +41,117 @@ to database server.
 #include "TDataType.h"
 
 namespace sqlio {
-   const Int_t Ids_NullPtr       = 0; // used to identify NULL pointer in tables
-   const Int_t Ids_RootDir       = 0; // dir:id, used for keys stored in root directory.
-   const Int_t Ids_TSQLFile      = 0; // keyid for TSQLFile entry in keys list
-   const Int_t Ids_StreamerInfos = 1; // keyid used to store StreamerInfos in ROOT directory
-   const Int_t Ids_FirstKey      =10; // first key id, which is used in KeysTable (beside streamer info or something else)
-   const Int_t Ids_FirstObject   = 1; // first object id, allowed in object tables
+const Int_t Ids_NullPtr = 0;       // used to identify NULL pointer in tables
+const Int_t Ids_RootDir = 0;       // dir:id, used for keys stored in root directory.
+const Int_t Ids_TSQLFile = 0;      // keyid for TSQLFile entry in keys list
+const Int_t Ids_StreamerInfos = 1; // keyid used to store StreamerInfos in ROOT directory
+const Int_t Ids_FirstKey = 10;     // first key id, which is used in KeysTable (beside streamer info or something else)
+const Int_t Ids_FirstObject = 1;   // first object id, allowed in object tables
 
-   const char* ObjectRef     = "ObjectRef";
-   const char* ObjectRef_Arr = "ObjectRefArr";
-   const char* ObjectPtr     = "ObjectPtr";
-   const char* ObjectInst    = "ObjectInst";
-   const char* Version       = "Version";
-   const char* TObjectUniqueId = "UniqueId";
-   const char* TObjectBits = "Bits";
-   const char* TObjectProcessId = "ProcessId";
-   const char* TStringValue= "StringValue";
-   const char* IndexSepar  = "..";
-   const char* RawSuffix = ":rawdata";
-   const char* ParentSuffix = ":parent";
-   const char* ObjectSuffix = ":object";
-   const char* PointerSuffix = ":pointer";
-   const char* StrSuffix     = ":str";
-   const char* LongStrPrefix = "#~#";
+const char *ObjectRef = "ObjectRef";
+const char *ObjectRef_Arr = "ObjectRefArr";
+const char *ObjectPtr = "ObjectPtr";
+const char *ObjectInst = "ObjectInst";
+const char *Version = "Version";
+const char *TObjectUniqueId = "UniqueId";
+const char *TObjectBits = "Bits";
+const char *TObjectProcessId = "ProcessId";
+const char *TStringValue = "StringValue";
+const char *IndexSepar = "..";
+const char *RawSuffix = ":rawdata";
+const char *ParentSuffix = ":parent";
+const char *ObjectSuffix = ":object";
+const char *PointerSuffix = ":pointer";
+const char *StrSuffix = ":str";
+const char *LongStrPrefix = "#~#";
 
-   const char* Array       = "Array";
-   const char* Bool        = "Bool_t";
-   const char* Char        = "Char_t";
-   const char* Short       = "Short_t";
-   const char* Int         = "Int_t";
-   const char* Long        = "Long_t";
-   const char* Long64      = "Long64_t";
-   const char* Float       = "Float_t";
-   const char* Double      = "Double_t";
-   const char* UChar       = "UChar_t";
-   const char* UShort      = "UShort_t";
-   const char* UInt        = "UInt_t";
-   const char* ULong       = "ULong_t";
-   const char* ULong64     = "ULong64_t";
-   const char* CharStar    = "CharStar";
-   const char* True        = "1";
-   const char* False       = "0";
+const char *Array = "Array";
+const char *Bool = "Bool_t";
+const char *Char = "Char_t";
+const char *Short = "Short_t";
+const char *Int = "Int_t";
+const char *Long = "Long_t";
+const char *Long64 = "Long64_t";
+const char *Float = "Float_t";
+const char *Double = "Double_t";
+const char *UChar = "UChar_t";
+const char *UShort = "UShort_t";
+const char *UInt = "UInt_t";
+const char *ULong = "ULong_t";
+const char *ULong64 = "ULong64_t";
+const char *CharStar = "CharStar";
+const char *True = "1";
+const char *False = "0";
 
-   // standard tables names
-   const char* KeysTable      = "KeysTable";
-   const char* KeysTableIndex = "KeysTableIndex";
-   const char* ObjectsTable   = "ObjectsTable";
-   const char* ObjectsTableIndex = "ObjectsTableIndex";
-   const char* IdsTable = "IdsTable";
-   const char* IdsTableIndex = "IdsTableIndex";
-   const char* StringsTable   = "StringsTable";
-   const char* ConfigTable    = "Configurations";
+// standard tables names
+const char *KeysTable = "KeysTable";
+const char *KeysTableIndex = "KeysTableIndex";
+const char *ObjectsTable = "ObjectsTable";
+const char *ObjectsTableIndex = "ObjectsTableIndex";
+const char *IdsTable = "IdsTable";
+const char *IdsTableIndex = "IdsTableIndex";
+const char *StringsTable = "StringsTable";
+const char *ConfigTable = "Configurations";
 
-   // colummns in Keys table
-   const char* KT_Name      = "Name";
-   const char* KT_Title     = "Title";
-   const char* KT_Datetime  = "Datime";
-   const char* KT_Cycle     = "Cycle";
-   const char* KT_Class     = "Class";
+// columns in Keys table
+const char *KT_Name = "Name";
+const char *KT_Title = "Title";
+const char *KT_Datetime = "Datime";
+const char *KT_Cycle = "Cycle";
+const char *KT_Class = "Class";
 
-   const char* DT_Create    = "CreateDatime";
-   const char* DT_Modified  = "ModifiedDatime";
-   const char* DT_UUID      = "UUID";
+const char *DT_Create = "CreateDatime";
+const char *DT_Modified = "ModifiedDatime";
+const char *DT_UUID = "UUID";
 
-   // colummns in Objects table
-   const char* OT_Class     = "Class";
-   const char* OT_Version   = "Version";
+// columns in Objects table
+const char *OT_Class = "Class";
+const char *OT_Version = "Version";
 
-   // columns in Identifiers Table
-   const char* IT_TableID   = "TableId";
-   const char* IT_SubID     = "SubId";
-   const char* IT_Type      = "Type";
-   const char* IT_FullName  = "FullName";
-   const char* IT_SQLName   = "SQLName";
-   const char* IT_Info      = "Info";
+// columns in Identifiers Table
+const char *IT_TableID = "TableId";
+const char *IT_SubID = "SubId";
+const char *IT_Type = "Type";
+const char *IT_FullName = "FullName";
+const char *IT_SQLName = "SQLName";
+const char *IT_Info = "Info";
 
-   // colummns in _streamer_ tables
-   const char* BT_Field     = "Field";
-   const char* BT_Value     = "Value";
+// colummns in _streamer_ tables
+const char *BT_Field = "Field";
+const char *BT_Value = "Value";
 
-   // colummns in string table
-   const char* ST_Value     = "LongStringValue";
+// colummns in string table
+const char *ST_Value = "LongStringValue";
 
-   // columns in config table
-   const char* CT_Field     = "Field";
-   const char* CT_Value     = "Value";
+// columns in config table
+const char *CT_Field = "Field";
+const char *CT_Value = "Value";
 
-   // values in config table
-   const char* cfg_Version  = "SQL_IO_version";
-   const char* cfg_UseSufixes = "UseNameSuffix";
-   const char* cfg_ArrayLimit = "ArraySizeLimit";
-   const char* cfg_TablesType = "TablesType";
-   const char* cfg_UseTransactions = "UseTransactions";
-   const char* cfg_UseIndexes = "UseIndexes";
-   const char* cfg_LockingMode = "LockingMode";
-   const char* cfg_ModifyCounter = "ModifyCounter";
+// values in config table
+const char *cfg_Version = "SQL_IO_version";
+const char *cfg_UseSufixes = "UseNameSuffix";
+const char *cfg_ArrayLimit = "ArraySizeLimit";
+const char *cfg_TablesType = "TablesType";
+const char *cfg_UseTransactions = "UseTransactions";
+const char *cfg_UseIndexes = "UseIndexes";
+const char *cfg_LockingMode = "LockingMode";
+const char *cfg_ModifyCounter = "ModifyCounter";
 };
 
 //________________________________________________________________________
 
 #ifdef R__VISUAL_CPLUSPLUS
-#define FLong64    "%I64d"
-#define FULong64   "%I64u"
+#define FLong64 "%I64d"
+#define FULong64 "%I64u"
 #else
-#define FLong64    "%lld"
-#define FULong64   "%llu"
+#define FLong64 "%lld"
+#define FULong64 "%llu"
 #endif
 
-Long64_t sqlio::atol64(const char* value)
+Long64_t sqlio::atol64(const char *value)
 {
-   if ((value==0) || (*value==0)) return 0;
+   if ((value == 0) || (*value == 0))
+      return 0;
    Long64_t res = 0;
    sscanf(value, FLong64, &res);
    return res;
@@ -166,12 +167,7 @@ ClassImp(TSQLColumnData);
 ////////////////////////////////////////////////////////////////////////////////
 /// default constructor
 
-   TSQLColumnData::TSQLColumnData() :
-      TObject(),
-      fName(),
-      fType(),
-      fValue(),
-      fNumeric(kFALSE)
+TSQLColumnData::TSQLColumnData() : TObject(), fName(), fType(), fValue(), fNumeric(kFALSE)
 {
 }
 
@@ -179,29 +175,18 @@ ClassImp(TSQLColumnData);
 /// normal constructor of TSQLColumnData class
 /// specifies name, type and value for one column
 
-TSQLColumnData::TSQLColumnData(const char* name,
-                               const char* sqltype,
-                               const char* value,
-                               Bool_t numeric) :
-   TObject(),
-   fName(name),
-   fType(sqltype),
-   fValue(value),
-   fNumeric(numeric)
+TSQLColumnData::TSQLColumnData(const char *name, const char *sqltype, const char *value, Bool_t numeric)
+   : TObject(), fName(name), fType(sqltype), fValue(value), fNumeric(numeric)
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// constructs TSQLColumnData object for integer column
 
-TSQLColumnData::TSQLColumnData(const char* name, Long64_t value) :
-   TObject(),
-   fName(name),
-   fType("INT"),
-   fValue(),
-   fNumeric(kTRUE)
+TSQLColumnData::TSQLColumnData(const char *name, Long64_t value)
+   : TObject(), fName(name), fType("INT"), fValue(), fNumeric(kTRUE)
 {
-   fValue.Form("%lld",value);
+   fValue.Form("%lld", value);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -211,18 +196,13 @@ TSQLColumnData::~TSQLColumnData()
 {
 }
 
-
 ClassImp(TSQLTableData);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// normal constructor
 
-TSQLTableData::TSQLTableData(TSQLFile* f, TSQLClassInfo* info) :
-   TObject(),
-   fFile(f),
-   fInfo(info),
-   fColumns(),
-   fColInfos(0)
+TSQLTableData::TSQLTableData(TSQLFile *f, TSQLClassInfo *info)
+   : TObject(), fFile(f), fInfo(info), fColumns(), fColInfos(0)
 {
    if (info && !info->IsClassTableExist())
       fColInfos = new TObjArray;
@@ -234,7 +214,7 @@ TSQLTableData::TSQLTableData(TSQLFile* f, TSQLClassInfo* info) :
 TSQLTableData::~TSQLTableData()
 {
    fColumns.Delete();
-   if (fColInfos!=0) {
+   if (fColInfos != 0) {
       fColInfos->Delete();
       delete fColInfos;
    }
@@ -243,71 +223,71 @@ TSQLTableData::~TSQLTableData()
 ////////////////////////////////////////////////////////////////////////////////
 /// Add INT column to list of columns
 
-void TSQLTableData::AddColumn(const char* name, Long64_t value)
+void TSQLTableData::AddColumn(const char *name, Long64_t value)
 {
-   TObjString* v = new TObjString(Form("%lld",value));
+   TObjString *v = new TObjString(Form("%lld", value));
    v->SetBit(BIT(20), kTRUE);
    fColumns.Add(v);
 
-//   TSQLColumnData* col = new TSQLColumnData(name, value);
-//   fColumns.Add(col);
+   //   TSQLColumnData* col = new TSQLColumnData(name, value);
+   //   fColumns.Add(col);
 
-   if (fColInfos!=0)
-     fColInfos->Add(new TSQLClassColumnInfo(name, DefineSQLName(name), "INT"));
+   if (fColInfos != 0)
+      fColInfos->Add(new TSQLClassColumnInfo(name, DefineSQLName(name), "INT"));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Add nomral column to list of columns
+/// Add normal column to list of columns
 
-void TSQLTableData::AddColumn(const char* name,
-                              const char* sqltype,
-                              const char* value,
-                              Bool_t numeric)
+void TSQLTableData::AddColumn(const char *name, const char *sqltype, const char *value, Bool_t numeric)
 {
-   TObjString* v = new TObjString(value);
+   TObjString *v = new TObjString(value);
    v->SetBit(BIT(20), numeric);
    fColumns.Add(v);
 
-//   TSQLColumnData* col = new TSQLColumnData(name, sqltype, value, numeric);
-//   fColumns.Add(col);
+   //   TSQLColumnData* col = new TSQLColumnData(name, sqltype, value, numeric);
+   //   fColumns.Add(col);
 
-   if (fColInfos!=0)
-     fColInfos->Add(new TSQLClassColumnInfo(name, DefineSQLName(name), sqltype));
+   if (fColInfos != 0)
+      fColInfos->Add(new TSQLClassColumnInfo(name, DefineSQLName(name), sqltype));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// produce suitable name for column, taking into account length limitation
 
-TString TSQLTableData::DefineSQLName(const char* fullname)
+TString TSQLTableData::DefineSQLName(const char *fullname)
 {
    Int_t maxlen = fFile->SQLMaxIdentifierLength();
 
    Int_t len = strlen(fullname);
 
-   if ((len<=maxlen) && !HasSQLName(fullname)) return TString(fullname);
+   if ((len <= maxlen) && !HasSQLName(fullname))
+      return TString(fullname);
 
    Int_t cnt = -1;
    TString res, scnt;
 
    do {
 
-      scnt.Form("%d",cnt);
-      Int_t numlen = cnt<0 ? 0 : scnt.Length();
+      scnt.Form("%d", cnt);
+      Int_t numlen = cnt < 0 ? 0 : scnt.Length();
 
       res = fullname;
 
       if (len + numlen > maxlen)
          res.Resize(maxlen - numlen);
 
-      if (cnt>=0) res+=scnt;
+      if (cnt >= 0)
+         res += scnt;
 
-      if (!HasSQLName(res.Data())) return res;
+      if (!HasSQLName(res.Data()))
+         return res;
 
       cnt++;
 
-   } while (cnt<10000);
+   } while (cnt < 10000);
 
-   Error("DefineSQLName","Cannot find reasonable column name for field %s",fullname);
+   Error("DefineSQLName", "Cannot find reasonable column name for field %s", fullname);
 
    return TString(fullname);
 }
@@ -315,19 +295,19 @@ TString TSQLTableData::DefineSQLName(const char* fullname)
 ////////////////////////////////////////////////////////////////////////////////
 /// checks if columns list already has that sql name
 
-Bool_t TSQLTableData::HasSQLName(const char* sqlname)
+Bool_t TSQLTableData::HasSQLName(const char *sqlname)
 {
    TIter next(fColInfos);
 
-   TSQLClassColumnInfo* col = 0;
+   TSQLClassColumnInfo *col = 0;
 
-   while ((col = (TSQLClassColumnInfo*) next()) != 0) {
-      const char* colname = col->GetSQLName();
-      if (strcmp(colname, sqlname)==0) return kTRUE;
+   while ((col = (TSQLClassColumnInfo *)next()) != 0) {
+      const char *colname = col->GetSQLName();
+      if (strcmp(colname, sqlname) == 0)
+         return kTRUE;
    }
 
    return kFALSE;
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -335,13 +315,13 @@ Bool_t TSQLTableData::HasSQLName(const char* sqlname)
 
 Int_t TSQLTableData::GetNumColumns()
 {
-   return fColumns.GetLast() +1;
+   return fColumns.GetLast() + 1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// returm column value
+/// return column value
 
-const char* TSQLTableData::GetColumn(Int_t n)
+const char *TSQLTableData::GetColumn(Int_t n)
 {
    return fColumns[n]->GetName();
 }
@@ -357,9 +337,9 @@ Bool_t TSQLTableData::IsNumeric(Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// take ownership over colinfos
 
-TObjArray* TSQLTableData::TakeColInfos()
+TObjArray *TSQLTableData::TakeColInfos()
 {
-   TObjArray* res = fColInfos;
+   TObjArray *res = fColInfos;
    fColInfos = 0;
    return res;
 }
@@ -368,15 +348,8 @@ TObjArray* TSQLTableData::TakeColInfos()
 
 ClassImp(TSQLStructure);
 
-TSQLStructure::TSQLStructure() :
-   TObject(),
-   fParent(0),
-   fType(0),
-   fPointer(0),
-   fValue(),
-   fArrayIndex(-1),
-   fRepeatCnt(0),
-   fChilds()
+TSQLStructure::TSQLStructure()
+   : TObject(), fParent(0), fType(0), fPointer(0), fValue(), fArrayIndex(-1), fRepeatCnt(0), fChilds()
 {
    // default constructor
 }
@@ -387,12 +360,11 @@ TSQLStructure::TSQLStructure() :
 TSQLStructure::~TSQLStructure()
 {
    fChilds.Delete();
-   if (GetType()==kSqlObjectData) {
-      TSQLObjectData* objdata = (TSQLObjectData*) fPointer;
+   if (GetType() == kSqlObjectData) {
+      TSQLObjectData *objdata = (TSQLObjectData *)fPointer;
       delete objdata;
-   } else
-   if (GetType()==kSqlCustomElement) {
-      TStreamerElement* elem = (TStreamerElement*) fPointer;
+   } else if (GetType() == kSqlCustomElement) {
+      TStreamerElement *elem = (TStreamerElement *)fPointer;
       delete elem;
    }
 }
@@ -402,24 +374,24 @@ TSQLStructure::~TSQLStructure()
 
 Int_t TSQLStructure::NumChilds() const
 {
-   return fChilds.GetLast()+1;
+   return fChilds.GetLast() + 1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// return child structure of index n
 
-TSQLStructure* TSQLStructure::GetChild(Int_t n) const
+TSQLStructure *TSQLStructure::GetChild(Int_t n) const
 {
-   return (n<0) || (n>fChilds.GetLast()) ? 0 : (TSQLStructure*) fChilds[n];
+   return (n < 0) || (n > fChilds.GetLast()) ? 0 : (TSQLStructure *)fChilds[n];
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// set structure type as kSqlObject
 
-void TSQLStructure::SetObjectRef(Long64_t refid, const TClass* cl)
+void TSQLStructure::SetObjectRef(Long64_t refid, const TClass *cl)
 {
    fType = kSqlObject;
-   fValue.Form("%lld",refid);
+   fValue.Form("%lld", refid);
    fPointer = cl;
 }
 
@@ -429,24 +401,25 @@ void TSQLStructure::SetObjectRef(Long64_t refid, const TClass* cl)
 void TSQLStructure::SetObjectPointer(Long64_t ptrid)
 {
    fType = kSqlPointer;
-   fValue.Form("%lld",ptrid);
+   fValue.Form("%lld", ptrid);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// set structure type as kSqlVersion
 
-void TSQLStructure::SetVersion(const TClass* cl, Int_t version)
+void TSQLStructure::SetVersion(const TClass *cl, Int_t version)
 {
    fType = kSqlVersion;
    fPointer = cl;
-   if (version<0) version = cl->GetClassVersion();
-   fValue.Form("%d",version);
+   if (version < 0)
+      version = cl->GetClassVersion();
+   fValue.Form("%d", version);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// set structure type as kSqlClassStreamer
 
-void TSQLStructure::SetClassStreamer(const TClass* cl)
+void TSQLStructure::SetClassStreamer(const TClass *cl)
 {
    fType = kSqlClassStreamer;
    fPointer = cl;
@@ -455,7 +428,7 @@ void TSQLStructure::SetClassStreamer(const TClass* cl)
 ////////////////////////////////////////////////////////////////////////////////
 /// set structure type as kSqlStreamerInfo
 
-void TSQLStructure::SetStreamerInfo(const TStreamerInfo* info)
+void TSQLStructure::SetStreamerInfo(const TStreamerInfo *info)
 {
    fType = kSqlStreamerInfo;
    fPointer = info;
@@ -464,7 +437,7 @@ void TSQLStructure::SetStreamerInfo(const TStreamerInfo* info)
 ////////////////////////////////////////////////////////////////////////////////
 /// set structure type as kSqlElement
 
-void TSQLStructure::SetStreamerElement(const TStreamerElement* elem, Int_t number)
+void TSQLStructure::SetStreamerElement(const TStreamerElement *elem, Int_t number)
 {
    fType = kSqlElement;
    fPointer = elem;
@@ -474,17 +447,17 @@ void TSQLStructure::SetStreamerElement(const TStreamerElement* elem, Int_t numbe
 ////////////////////////////////////////////////////////////////////////////////
 /// set structure type as kSqlCustomClass
 
-void TSQLStructure::SetCustomClass(const TClass* cl, Version_t version)
+void TSQLStructure::SetCustomClass(const TClass *cl, Version_t version)
 {
    fType = kSqlCustomClass;
-   fPointer = (void*) cl;
+   fPointer = (void *)cl;
    fArrayIndex = version;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// set structure type as kSqlCustomElement
 
-void TSQLStructure::SetCustomElement(TStreamerElement* elem)
+void TSQLStructure::SetCustomElement(TStreamerElement *elem)
 {
    fType = kSqlCustomElement;
    fPointer = elem;
@@ -493,7 +466,7 @@ void TSQLStructure::SetCustomElement(TStreamerElement* elem)
 ////////////////////////////////////////////////////////////////////////////////
 /// set structure type as kSqlValue
 
-void TSQLStructure::SetValue(const char* value, const char* tname)
+void TSQLStructure::SetValue(const char *value, const char *tname)
 {
    fType = kSqlValue;
    fValue = value;
@@ -504,7 +477,7 @@ void TSQLStructure::SetValue(const char* value, const char* tname)
 /// change value of this structure
 /// used as "workaround" to keep object id in kSqlElement node
 
-void TSQLStructure::ChangeValueOnly(const char* value)
+void TSQLStructure::ChangeValueOnly(const char *value)
 {
    fValue = value;
 }
@@ -524,8 +497,8 @@ void TSQLStructure::SetArrayIndex(Int_t indx, Int_t cnt)
 
 void TSQLStructure::ChildArrayIndex(Int_t index, Int_t cnt)
 {
-   TSQLStructure* last = (TSQLStructure*) fChilds.Last();
-   if ((last!=0) && (last->GetType()==kSqlValue))
+   TSQLStructure *last = (TSQLStructure *)fChilds.Last();
+   if ((last != 0) && (last->GetType() == kSqlValue))
       last->SetArrayIndex(index, cnt);
 }
 
@@ -535,39 +508,40 @@ void TSQLStructure::ChildArrayIndex(Int_t index, Int_t cnt)
 void TSQLStructure::SetArray(Int_t sz)
 {
    fType = kSqlArray;
-   if (sz>=0) fValue.Form("%d",sz);
+   if (sz >= 0)
+      fValue.Form("%d", sz);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// return object class if type kSqlObject
 
-TClass* TSQLStructure::GetObjectClass() const
+TClass *TSQLStructure::GetObjectClass() const
 {
-   return (fType==kSqlObject) ? (TClass*) fPointer : 0;
+   return (fType == kSqlObject) ? (TClass *)fPointer : 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// return class for version tag if type is kSqlVersion
 
-TClass* TSQLStructure::GetVersionClass() const
+TClass *TSQLStructure::GetVersionClass() const
 {
-   return (fType==kSqlVersion) ? (TClass*) fPointer : 0;
+   return (fType == kSqlVersion) ? (TClass *)fPointer : 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// return TStreamerInfo* if type is kSqlStreamerInfo
 
-TStreamerInfo*  TSQLStructure::GetStreamerInfo() const
+TStreamerInfo *TSQLStructure::GetStreamerInfo() const
 {
-   return (fType==kSqlStreamerInfo) ? (TStreamerInfo*) fPointer : 0;
+   return (fType == kSqlStreamerInfo) ? (TStreamerInfo *)fPointer : 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// return TStremerElement* if type is kSqlElement
 
-TStreamerElement* TSQLStructure::GetElement() const
+TStreamerElement *TSQLStructure::GetElement() const
 {
-   return (fType==kSqlElement) || (fType==kSqlCustomElement) ? (TStreamerElement*) fPointer : 0;
+   return (fType == kSqlElement) || (fType == kSqlCustomElement) ? (TStreamerElement *)fPointer : 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -575,23 +549,23 @@ TStreamerElement* TSQLStructure::GetElement() const
 
 Int_t TSQLStructure::GetElementNumber() const
 {
-   return (fType==kSqlElement) ? fArrayIndex : 0;
+   return (fType == kSqlElement) ? fArrayIndex : 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// return value type if structure is kSqlValue
 
-const char* TSQLStructure::GetValueType() const
+const char *TSQLStructure::GetValueType() const
 {
-   return (fType==kSqlValue) ? (const char*) fPointer : 0;
+   return (fType == kSqlValue) ? (const char *)fPointer : 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// return element custom class if strutures is kSqlCustomClass
 
-TClass* TSQLStructure::GetCustomClass() const
+TClass *TSQLStructure::GetCustomClass() const
 {
-   return (fType==kSqlCustomClass) ? (TClass*) fPointer : 0;
+   return (fType == kSqlCustomClass) ? (TClass *)fPointer : 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -599,21 +573,21 @@ TClass* TSQLStructure::GetCustomClass() const
 
 Version_t TSQLStructure::GetCustomClassVersion() const
 {
-   return (fType==kSqlCustomClass) ? fArrayIndex : 0;
+   return (fType == kSqlCustomClass) ? fArrayIndex : 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// provides class info if structure kSqlStreamerInfo or kSqlCustomClass
 
-Bool_t TSQLStructure::GetClassInfo(TClass* &cl, Version_t &version)
+Bool_t TSQLStructure::GetClassInfo(TClass *&cl, Version_t &version)
 {
-   if (GetType()==kSqlStreamerInfo) {
-      TStreamerInfo* info = GetStreamerInfo();
-      if (info==0) return kFALSE;
+   if (GetType() == kSqlStreamerInfo) {
+      TStreamerInfo *info = GetStreamerInfo();
+      if (info == 0)
+         return kFALSE;
       cl = info->GetClass();
       version = info->GetClassVersion();
-   } else
-   if (GetType()==kSqlCustomClass) {
+   } else if (GetType() == kSqlCustomClass) {
       cl = GetCustomClass();
       version = GetCustomClassVersion();
    } else
@@ -626,17 +600,17 @@ Bool_t TSQLStructure::GetClassInfo(TClass* &cl, Version_t &version)
 /// for different structure kinds has different sense
 /// For kSqlVersion it version, for kSqlReference it is object id and so on
 
-const char* TSQLStructure::GetValue() const
+const char *TSQLStructure::GetValue() const
 {
    return fValue.Data();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Add child strucure
+/// Add child structure
 
-void TSQLStructure::Add(TSQLStructure* child)
+void TSQLStructure::Add(TSQLStructure *child)
 {
-   if (child!=0) {
+   if (child != 0) {
       child->SetParent(this);
       fChilds.Add(child);
    }
@@ -645,9 +619,9 @@ void TSQLStructure::Add(TSQLStructure* child)
 ////////////////////////////////////////////////////////////////////////////////
 /// add child as version
 
-void TSQLStructure::AddVersion(const TClass* cl, Int_t version)
+void TSQLStructure::AddVersion(const TClass *cl, Int_t version)
 {
-   TSQLStructure* ver = new TSQLStructure;
+   TSQLStructure *ver = new TSQLStructure;
    ver->SetVersion(cl, version);
    Add(ver);
 }
@@ -655,9 +629,9 @@ void TSQLStructure::AddVersion(const TClass* cl, Int_t version)
 ////////////////////////////////////////////////////////////////////////////////
 /// Add child structure as value
 
-void TSQLStructure::AddValue(const char* value, const char* tname)
+void TSQLStructure::AddValue(const char *value, const char *tname)
 {
-   TSQLStructure* child = new TSQLStructure;
+   TSQLStructure *child = new TSQLStructure;
    child->SetValue(value, tname);
    Add(child);
 }
@@ -669,17 +643,14 @@ void TSQLStructure::AddValue(const char* value, const char* tname)
 
 Long64_t TSQLStructure::DefineObjectId(Bool_t recursive)
 {
-   TSQLStructure* curr = this;
-   while (curr!=0) {
-      if ((curr->GetType()==kSqlObject) ||
-          (curr->GetType()==kSqlPointer) ||
-         // workaround to store object id in element structure
-          (curr->GetType()==kSqlElement) ||
-          (curr->GetType()==kSqlCustomElement) ||
-          (curr->GetType()==kSqlCustomClass) ||
-          (curr->GetType()==kSqlStreamerInfo)) {
-         const char* value = curr->GetValue();
-         if ((value!=0) && (strlen(value)>0))
+   TSQLStructure *curr = this;
+   while (curr != 0) {
+      if ((curr->GetType() == kSqlObject) || (curr->GetType() == kSqlPointer) ||
+          // workaround to store object id in element structure
+          (curr->GetType() == kSqlElement) || (curr->GetType() == kSqlCustomElement) ||
+          (curr->GetType() == kSqlCustomClass) || (curr->GetType() == kSqlStreamerInfo)) {
+         const char *value = curr->GetValue();
+         if ((value != 0) && (strlen(value) > 0))
             return sqlio::atol64(value);
       }
 
@@ -691,7 +662,7 @@ Long64_t TSQLStructure::DefineObjectId(Bool_t recursive)
 ////////////////////////////////////////////////////////////////////////////////
 /// set element to be used for object data
 
-void TSQLStructure::SetObjectData(TSQLObjectData* objdata)
+void TSQLStructure::SetObjectData(TSQLObjectData *objdata)
 {
    fType = kSqlObjectData;
    fPointer = objdata;
@@ -700,22 +671,22 @@ void TSQLStructure::SetObjectData(TSQLObjectData* objdata)
 ////////////////////////////////////////////////////////////////////////////////
 /// add element with pointer to object data
 
-void TSQLStructure::AddObjectData(TSQLObjectData* objdata)
+void TSQLStructure::AddObjectData(TSQLObjectData *objdata)
 {
-   TSQLStructure* child = new TSQLStructure;
+   TSQLStructure *child = new TSQLStructure;
    child->SetObjectData(objdata);
    Add(child);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// searchs for objects data
+/// searches for objects data
 
-TSQLObjectData* TSQLStructure::GetObjectData(Bool_t search)
+TSQLObjectData *TSQLStructure::GetObjectData(Bool_t search)
 {
-   TSQLStructure* child = GetChild(0);
-   if ((child!=0) && (child->GetType()==kSqlObjectData))
-      return (TSQLObjectData*) child->fPointer;
-   if (search && (GetParent()!=0))
+   TSQLStructure *child = GetChild(0);
+   if ((child != 0) && (child->GetType() == kSqlObjectData))
+      return (TSQLObjectData *)child->fPointer;
+   if (search && (GetParent() != 0))
       return GetParent()->GetObjectData(search);
    return 0;
 }
@@ -723,7 +694,7 @@ TSQLObjectData* TSQLStructure::GetObjectData(Bool_t search)
 ////////////////////////////////////////////////////////////////////////////////
 /// print content of complete structure
 
-void TSQLStructure::Print(Option_t*) const
+void TSQLStructure::Print(Option_t *) const
 {
    PrintLevel(0);
 }
@@ -733,50 +704,53 @@ void TSQLStructure::Print(Option_t*) const
 
 void TSQLStructure::PrintLevel(Int_t level) const
 {
-   for(Int_t n=0;n<level;n++) std::cout << " ";
+   for (Int_t n = 0; n < level; n++)
+      std::cout << " ";
    switch (fType) {
    case 0: std::cout << "Undefined type"; break;
    case kSqlObject: std::cout << "Object ref = " << fValue; break;
    case kSqlPointer: std::cout << "Pointer ptr = " << fValue; break;
    case kSqlVersion: {
-      const TClass* cl = (const TClass*) fPointer;
+      const TClass *cl = (const TClass *)fPointer;
       std::cout << "Version cl = " << cl->GetName() << " ver = " << cl->GetClassVersion();
       break;
    }
    case kSqlStreamerInfo: {
-      const TStreamerInfo* info = (const TStreamerInfo*) fPointer;
+      const TStreamerInfo *info = (const TStreamerInfo *)fPointer;
       std::cout << "Class: " << info->GetName();
       break;
    }
    case kSqlCustomElement:
    case kSqlElement: {
-      const TStreamerElement* elem = (const TStreamerElement*) fPointer;
+      const TStreamerElement *elem = (const TStreamerElement *)fPointer;
       std::cout << "Member: " << elem->GetName();
       break;
    }
    case kSqlValue: {
       std::cout << "Value: " << fValue;
-      if (fRepeatCnt>1) std::cout << "  cnt:" << fRepeatCnt;
-      if (fPointer!=0) std::cout << "  type = " << (const char*)fPointer;
+      if (fRepeatCnt > 1)
+         std::cout << "  cnt:" << fRepeatCnt;
+      if (fPointer != 0)
+         std::cout << "  type = " << (const char *)fPointer;
       break;
    }
    case kSqlArray: {
       std::cout << "Array ";
-      if (fValue.Length()>0) std::cout << "  sz = " << fValue;
+      if (fValue.Length() > 0)
+         std::cout << "  sz = " << fValue;
       break;
    }
    case kSqlCustomClass: {
-      TClass* cl = (TClass*) fPointer;
+      TClass *cl = (TClass *)fPointer;
       std::cout << "CustomClass: " << cl->GetName() << "  ver = " << fValue;
       break;
    }
-   default:
-      std::cout << "Unknown type";
+   default: std::cout << "Unknown type";
    }
    std::cout << std::endl;
 
-   for(Int_t n=0;n<NumChilds();n++)
-      GetChild(n)->PrintLevel(level+2);
+   for (Int_t n = 0; n < NumChilds(); n++)
+      GetChild(n)->PrintLevel(level + 2);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -784,23 +758,23 @@ void TSQLStructure::PrintLevel(Int_t level) const
 
 Bool_t TSQLStructure::IsNumericType(Int_t typ)
 {
-   switch(typ) {
-   case TStreamerInfo::kShort   : return kTRUE;
-   case TStreamerInfo::kInt     : return kTRUE;
-   case TStreamerInfo::kLong    : return kTRUE;
-   case TStreamerInfo::kFloat   : return kTRUE;
-   case TStreamerInfo::kFloat16 : return kTRUE;
-   case TStreamerInfo::kCounter : return kTRUE;
-   case TStreamerInfo::kDouble  : return kTRUE;
+   switch (typ) {
+   case TStreamerInfo::kShort: return kTRUE;
+   case TStreamerInfo::kInt: return kTRUE;
+   case TStreamerInfo::kLong: return kTRUE;
+   case TStreamerInfo::kFloat: return kTRUE;
+   case TStreamerInfo::kFloat16: return kTRUE;
+   case TStreamerInfo::kCounter: return kTRUE;
+   case TStreamerInfo::kDouble: return kTRUE;
    case TStreamerInfo::kDouble32: return kTRUE;
-   case TStreamerInfo::kUChar   : return kTRUE;
-   case TStreamerInfo::kUShort  : return kTRUE;
-   case TStreamerInfo::kUInt    : return kTRUE;
-   case TStreamerInfo::kULong   : return kTRUE;
-   case TStreamerInfo::kBits    : return kTRUE;
-   case TStreamerInfo::kLong64  : return kTRUE;
-   case TStreamerInfo::kULong64 : return kTRUE;
-   case TStreamerInfo::kBool    : return kTRUE;
+   case TStreamerInfo::kUChar: return kTRUE;
+   case TStreamerInfo::kUShort: return kTRUE;
+   case TStreamerInfo::kUInt: return kTRUE;
+   case TStreamerInfo::kULong: return kTRUE;
+   case TStreamerInfo::kBits: return kTRUE;
+   case TStreamerInfo::kLong64: return kTRUE;
+   case TStreamerInfo::kULong64: return kTRUE;
+   case TStreamerInfo::kBool: return kTRUE;
    }
    return kFALSE;
 }
@@ -809,26 +783,26 @@ Bool_t TSQLStructure::IsNumericType(Int_t typ)
 /// provides name for basic types
 /// used as suffix for column name or field suffix in raw table
 
-const char* TSQLStructure::GetSimpleTypeName(Int_t typ)
+const char *TSQLStructure::GetSimpleTypeName(Int_t typ)
 {
-   switch(typ) {
-   case TStreamerInfo::kChar    : return sqlio::Char;
-   case TStreamerInfo::kShort   : return sqlio::Short;
-   case TStreamerInfo::kInt     : return sqlio::Int;
-   case TStreamerInfo::kLong    : return sqlio::Long;
-   case TStreamerInfo::kFloat   : return sqlio::Float;
-   case TStreamerInfo::kFloat16 : return sqlio::Float;
-   case TStreamerInfo::kCounter : return sqlio::Int;
-   case TStreamerInfo::kDouble  : return sqlio::Double;
+   switch (typ) {
+   case TStreamerInfo::kChar: return sqlio::Char;
+   case TStreamerInfo::kShort: return sqlio::Short;
+   case TStreamerInfo::kInt: return sqlio::Int;
+   case TStreamerInfo::kLong: return sqlio::Long;
+   case TStreamerInfo::kFloat: return sqlio::Float;
+   case TStreamerInfo::kFloat16: return sqlio::Float;
+   case TStreamerInfo::kCounter: return sqlio::Int;
+   case TStreamerInfo::kDouble: return sqlio::Double;
    case TStreamerInfo::kDouble32: return sqlio::Double;
-   case TStreamerInfo::kUChar   : return sqlio::UChar;
-   case TStreamerInfo::kUShort  : return sqlio::UShort;
-   case TStreamerInfo::kUInt    : return sqlio::UInt;
-   case TStreamerInfo::kULong   : return sqlio::ULong;
-   case TStreamerInfo::kBits    : return sqlio::UInt;
-   case TStreamerInfo::kLong64  : return sqlio::Long64;
-   case TStreamerInfo::kULong64 : return sqlio::ULong64;
-   case TStreamerInfo::kBool    : return sqlio::Bool;
+   case TStreamerInfo::kUChar: return sqlio::UChar;
+   case TStreamerInfo::kUShort: return sqlio::UShort;
+   case TStreamerInfo::kUInt: return sqlio::UInt;
+   case TStreamerInfo::kULong: return sqlio::ULong;
+   case TStreamerInfo::kBits: return sqlio::UInt;
+   case TStreamerInfo::kLong64: return sqlio::Long64;
+   case TStreamerInfo::kULong64: return sqlio::ULong64;
+   case TStreamerInfo::kBool: return sqlio::Bool;
    }
 
    return 0;
@@ -843,14 +817,7 @@ const char* TSQLStructure::GetSimpleTypeName(Int_t typ)
 class TSqlCmdsBuffer : public TObject {
 
 public:
-   TSqlCmdsBuffer(TSQLFile* f, TSQLClassInfo* info) :
-      TObject(),
-      fFile(f),
-      fInfo(info),
-      fBlobStmt(0),
-      fNormStmt(0)
-   {
-   }
+   TSqlCmdsBuffer(TSQLFile *f, TSQLClassInfo *info) : TObject(), fFile(f), fInfo(info), fBlobStmt(0), fNormStmt(0) {}
 
    virtual ~TSqlCmdsBuffer()
    {
@@ -860,19 +827,21 @@ public:
       fFile->SQLDeleteStatement(fNormStmt);
    }
 
-   void AddValues(Bool_t isnorm, const char* values)
+   void AddValues(Bool_t isnorm, const char *values)
    {
-      TObjString* str = new TObjString(values);
-      if (isnorm) fNormCmds.Add(str);
-      else fBlobCmds.Add(str);
+      TObjString *str = new TObjString(values);
+      if (isnorm)
+         fNormCmds.Add(str);
+      else
+         fBlobCmds.Add(str);
    }
 
-   TSQLFile* fFile;
-   TSQLClassInfo* fInfo;
+   TSQLFile *fFile;
+   TSQLClassInfo *fInfo;
    TObjArray fNormCmds;
    TObjArray fBlobCmds;
-   TSQLStatement* fBlobStmt;
-   TSQLStatement* fNormStmt;
+   TSQLStatement *fBlobStmt;
+   TSQLStatement *fNormStmt;
 };
 
 //________________________________________________________________________
@@ -882,40 +851,28 @@ public:
 class TSqlRegistry : public TObject {
 
 public:
-   TSqlRegistry() :
-      TObject(),
-      fFile(0),
-      fKeyId(0),
-      fLastObjId(-1),
-      fCmds(0),
-      fFirstObjId(0),
-      fCurrentObjId(0),
-      fCurrentObjClass(0),
-      fLastLongStrId(0),
-      fPool(),
-      fLongStrValues(),
-      fRegValues(),
-      fRegStmt(0)
+   TSqlRegistry()
+      : TObject(), fFile(0), fKeyId(0), fLastObjId(-1), fCmds(0), fFirstObjId(0), fCurrentObjId(0), fCurrentObjClass(0),
+        fLastLongStrId(0), fPool(), fLongStrValues(), fRegValues(), fRegStmt(0)
    {
    }
 
-   TSQLFile*  fFile;
-   Long64_t   fKeyId;
-   Long64_t   fLastObjId;
-   TObjArray* fCmds;
-   Long64_t   fFirstObjId;
+   TSQLFile *fFile;
+   Long64_t fKeyId;
+   Long64_t fLastObjId;
+   TObjArray *fCmds;
+   Long64_t fFirstObjId;
 
-   Long64_t   fCurrentObjId;
-   TClass*    fCurrentObjClass;
+   Long64_t fCurrentObjId;
+   TClass *fCurrentObjClass;
 
-   Int_t      fLastLongStrId;
+   Int_t fLastLongStrId;
 
-   TMap       fPool;
-   TObjArray  fLongStrValues;
-   TObjArray  fRegValues;
+   TMap fPool;
+   TObjArray fLongStrValues;
+   TObjArray fRegValues;
 
-   TSQLStatement* fRegStmt;
-
+   TSQLStatement *fRegStmt;
 
    virtual ~TSqlRegistry()
    {
@@ -927,71 +884,76 @@ public:
 
    Long64_t GetNextObjId() { return ++fLastObjId; }
 
-   void AddSqlCmd(const char* query)
+   void AddSqlCmd(const char *query)
    {
       // add SQL command to the list
-      if (fCmds==0) fCmds = new TObjArray;
+      if (fCmds == 0)
+         fCmds = new TObjArray;
       fCmds->Add(new TObjString(query));
    }
 
-   TSqlCmdsBuffer* GetCmdsBuffer(TSQLClassInfo* sqlinfo)
+   TSqlCmdsBuffer *GetCmdsBuffer(TSQLClassInfo *sqlinfo)
    {
-      if (sqlinfo==0) return 0;
-      TSqlCmdsBuffer* buf = (TSqlCmdsBuffer*) fPool.GetValue(sqlinfo);
-      if (buf==0) {
+      if (sqlinfo == 0)
+         return 0;
+      TSqlCmdsBuffer *buf = (TSqlCmdsBuffer *)fPool.GetValue(sqlinfo);
+      if (buf == 0) {
          buf = new TSqlCmdsBuffer(fFile, sqlinfo);
          fPool.Add(sqlinfo, buf);
       }
       return buf;
    }
 
-   void ConvertSqlValues(TObjArray& values, const char* tablename)
+   void ConvertSqlValues(TObjArray &values, const char *tablename)
    {
-   // this function transforms array of values for one table
-   // to SQL command. For MySQL one INSERT querie can
-   // contain data for more than one row
+      // this function transforms array of values for one table
+      // to SQL command. For MySQL one INSERT query can
+      // contain data for more than one row
 
-      if ((values.GetLast()<0) || (tablename==0)) return;
+      if ((values.GetLast() < 0) || (tablename == 0))
+         return;
 
       Bool_t canbelong = fFile->IsMySQL();
 
       Int_t maxsize = 50000;
       TString sqlcmd(maxsize), value, onecmd, cmdmask;
 
-      const char* quote = fFile->SQLIdentifierQuote();
+      const char *quote = fFile->SQLIdentifierQuote();
 
       TIter iter(&values);
-      TObject* cmd = 0;
-      while ((cmd = iter())!=0) {
+      TObject *cmd = 0;
+      while ((cmd = iter()) != 0) {
 
-         if (sqlcmd.Length()==0)
-            sqlcmd.Form("INSERT INTO %s%s%s VALUES (%s)",
-                        quote, tablename, quote, cmd->GetName());
+         if (sqlcmd.Length() == 0)
+            sqlcmd.Form("INSERT INTO %s%s%s VALUES (%s)", quote, tablename, quote, cmd->GetName());
          else {
-            sqlcmd+=", (";
+            sqlcmd += ", (";
             sqlcmd += cmd->GetName();
-            sqlcmd+=")";
+            sqlcmd += ")";
          }
 
-         if (!canbelong || (sqlcmd.Length()>maxsize*0.9)) {
+         if (!canbelong || (sqlcmd.Length() > maxsize * 0.9)) {
             AddSqlCmd(sqlcmd.Data());
             sqlcmd = "";
          }
       }
 
-      if (sqlcmd.Length()>0) AddSqlCmd(sqlcmd.Data());
+      if (sqlcmd.Length() > 0)
+         AddSqlCmd(sqlcmd.Data());
    }
 
    void ConvertPoolValues()
    {
-      TSQLClassInfo* sqlinfo = 0;
+      TSQLClassInfo *sqlinfo = 0;
       TIter iter(&fPool);
-      while ((sqlinfo = (TSQLClassInfo*) iter())!=0) {
-         TSqlCmdsBuffer* buf = (TSqlCmdsBuffer*) fPool.GetValue(sqlinfo);
-         if (buf==0) continue;
+      while ((sqlinfo = (TSQLClassInfo *)iter()) != 0) {
+         TSqlCmdsBuffer *buf = (TSqlCmdsBuffer *)fPool.GetValue(sqlinfo);
+         if (buf == 0)
+            continue;
          ConvertSqlValues(buf->fNormCmds, sqlinfo->GetClassTableName());
          // ensure that raw table will be created
-         if (buf->fBlobCmds.GetLast()>=0) fFile->CreateRawTable(sqlinfo);
+         if (buf->fBlobCmds.GetLast() >= 0)
+            fFile->CreateRawTable(sqlinfo);
          ConvertSqlValues(buf->fBlobCmds, sqlinfo->GetRawTableName());
          if (buf->fBlobStmt)
             buf->fBlobStmt->Process();
@@ -1001,30 +963,29 @@ public:
 
       ConvertSqlValues(fLongStrValues, sqlio::StringsTable);
       ConvertSqlValues(fRegValues, sqlio::ObjectsTable);
-      if (fRegStmt) fRegStmt->Process();
+      if (fRegStmt)
+         fRegStmt->Process();
    }
 
-
-   void AddRegCmd(Long64_t objid, TClass* cl)
+   void AddRegCmd(Long64_t objid, TClass *cl)
    {
-      Long64_t indx = objid-fFirstObjId;
-      if (indx<0) {
-         Error("AddRegCmd","Something wrong with objid = %lld", objid);
+      Long64_t indx = objid - fFirstObjId;
+      if (indx < 0) {
+         Error("AddRegCmd", "Something wrong with objid = %lld", objid);
          return;
       }
 
       if (fFile->IsOracle() || fFile->IsODBC()) {
-         if ((fRegStmt==0) && fFile->SQLCanStatement()) {
-            const char* quote = fFile->SQLIdentifierQuote();
+         if ((fRegStmt == 0) && fFile->SQLCanStatement()) {
+            const char *quote = fFile->SQLIdentifierQuote();
 
             TString sqlcmd;
-            const char* pars = fFile->IsOracle() ? ":1, :2, :3, :4" : "?, ?, ?, ?";
-            sqlcmd.Form("INSERT INTO %s%s%s VALUES (%s)",
-                     quote, sqlio::ObjectsTable, quote, pars);
+            const char *pars = fFile->IsOracle() ? ":1, :2, :3, :4" : "?, ?, ?, ?";
+            sqlcmd.Form("INSERT INTO %s%s%s VALUES (%s)", quote, sqlio::ObjectsTable, quote, pars);
             fRegStmt = fFile->SQLStatement(sqlcmd.Data(), 1000);
          }
 
-         if (fRegStmt!=0) {
+         if (fRegStmt != 0) {
             fRegStmt->NextIteration();
             fRegStmt->SetLong64(0, fKeyId);
             fRegStmt->SetLong64(1, objid);
@@ -1034,24 +995,22 @@ public:
          }
       }
 
-      const char* valuequote = fFile->SQLValueQuote();
+      const char *valuequote = fFile->SQLValueQuote();
       TString cmd;
-      cmd.Form("%lld, %lld, %s%s%s, %d",
-                fKeyId, objid,
-                valuequote, cl->GetName(), valuequote,
-                cl->GetClassVersion());
+      cmd.Form("%lld, %lld, %s%s%s, %d", fKeyId, objid, valuequote, cl->GetName(), valuequote, cl->GetClassVersion());
       fRegValues.AddAtAndExpand(new TObjString(cmd), indx);
    }
 
-   Int_t AddLongString(const char* strvalue)
+   Int_t AddLongString(const char *strvalue)
    {
       // add value to special string table,
       // where large (more than 255 bytes) strings are stored
 
-      if (fLastLongStrId==0) fFile->VerifyLongStringTable();
+      if (fLastLongStrId == 0)
+         fFile->VerifyLongStringTable();
       Int_t strid = ++fLastLongStrId;
       TString value = strvalue;
-      const char* valuequote = fFile->SQLValueQuote();
+      const char *valuequote = fFile->SQLValueQuote();
       TSQLStructure::AddStrBrackets(value, valuequote);
 
       TString cmd;
@@ -1062,32 +1021,35 @@ public:
       return strid;
    }
 
-   Bool_t InsertToNormalTableOracle(TSQLTableData* columns, TSQLClassInfo* sqlinfo)
+   Bool_t InsertToNormalTableOracle(TSQLTableData *columns, TSQLClassInfo *sqlinfo)
    {
-      TSqlCmdsBuffer* buf = GetCmdsBuffer(sqlinfo);
-      if (buf==0) return kFALSE;
+      TSqlCmdsBuffer *buf = GetCmdsBuffer(sqlinfo);
+      if (buf == 0)
+         return kFALSE;
 
-      TSQLStatement* stmt = buf->fNormStmt;
-      if (stmt==0) {
+      TSQLStatement *stmt = buf->fNormStmt;
+      if (stmt == 0) {
          // if one cannot create statement, do it normal way
-         if (!fFile->SQLCanStatement()) return kFALSE;
+         if (!fFile->SQLCanStatement())
+            return kFALSE;
 
-         const char* quote = fFile->SQLIdentifierQuote();
+         const char *quote = fFile->SQLIdentifierQuote();
          TString sqlcmd;
-         sqlcmd.Form("INSERT INTO %s%s%s VALUES (",
-                     quote, sqlinfo->GetClassTableName(), quote);
-         for (int n=0;n<columns->GetNumColumns();n++) {
-            if (n>0) sqlcmd +=", ";
+         sqlcmd.Form("INSERT INTO %s%s%s VALUES (", quote, sqlinfo->GetClassTableName(), quote);
+         for (int n = 0; n < columns->GetNumColumns(); n++) {
+            if (n > 0)
+               sqlcmd += ", ";
             if (fFile->IsOracle()) {
                sqlcmd += ":";
-               sqlcmd += (n+1);
+               sqlcmd += (n + 1);
             } else
                sqlcmd += "?";
          }
          sqlcmd += ")";
 
          stmt = fFile->SQLStatement(sqlcmd.Data(), 1000);
-         if (stmt==0) return kFALSE;
+         if (stmt == 0)
+            return kFALSE;
          buf->fNormStmt = stmt;
       }
 
@@ -1095,32 +1057,34 @@ public:
 
       Int_t sizelimit = fFile->SQLSmallTextTypeLimit();
 
-      for (Int_t ncol=0;ncol<columns->GetNumColumns();ncol++) {
-         const char* value = columns->GetColumn(ncol);
-         if (value==0) value = "";
+      for (Int_t ncol = 0; ncol < columns->GetNumColumns(); ncol++) {
+         const char *value = columns->GetColumn(ncol);
+         if (value == 0)
+            value = "";
          stmt->SetString(ncol, value, sizelimit);
       }
 
       return kTRUE;
    }
 
-   void InsertToNormalTable(TSQLTableData* columns, TSQLClassInfo* sqlinfo)
+   void InsertToNormalTable(TSQLTableData *columns, TSQLClassInfo *sqlinfo)
    {
       // produce SQL query to insert object data into normal table
 
       if (fFile->IsOracle() || fFile->IsODBC())
          if (InsertToNormalTableOracle(columns, sqlinfo))
-           return;
+            return;
 
-      const char* valuequote = fFile->SQLValueQuote();
+      const char *valuequote = fFile->SQLValueQuote();
 
       TString values;
 
-      for (Int_t n=0;n<columns->GetNumColumns();n++) {
-         if (n>0) values+=", ";
+      for (Int_t n = 0; n < columns->GetNumColumns(); n++) {
+         if (n > 0)
+            values += ", ";
 
          if (columns->IsNumeric(n))
-            values+=columns->GetColumn(n);
+            values += columns->GetColumn(n);
          else {
             TString value = columns->GetColumn(n);
             TSQLStructure::AddStrBrackets(value, valuequote);
@@ -1128,32 +1092,23 @@ public:
          }
       }
 
-      TSqlCmdsBuffer* buf = GetCmdsBuffer(sqlinfo);
-      if (buf!=0) buf->AddValues(kTRUE, values.Data());
+      TSqlCmdsBuffer *buf = GetCmdsBuffer(sqlinfo);
+      if (buf != 0)
+         buf->AddValues(kTRUE, values.Data());
    }
 };
-
 
 //_____________________________________________________________________________
 
 // TSqlRawBuffer is used to convert raw data, which corresponds to one
-// object and belong to single SQL tables. Supoorts both statements
+// object and belong to single SQL tables. Supports both statements
 // and query mode
 
 class TSqlRawBuffer : public TObject {
 
 public:
-
-   TSqlRawBuffer(TSqlRegistry* reg, TSQLClassInfo* sqlinfo) :
-      TObject(),
-      fFile(0),
-      fInfo(0),
-      fCmdBuf(0),
-      fObjId(0),
-      fRawId(0),
-      fValueMask(),
-      fValueQuote(0),
-      fMaxStrSize(255)
+   TSqlRawBuffer(TSqlRegistry *reg, TSQLClassInfo *sqlinfo)
+      : TObject(), fFile(0), fInfo(0), fCmdBuf(0), fObjId(0), fRawId(0), fValueMask(), fValueQuote(0), fMaxStrSize(255)
    {
       fFile = reg->fFile;
       fInfo = sqlinfo;
@@ -1167,57 +1122,57 @@ public:
    virtual ~TSqlRawBuffer()
    {
       // close blob statement for Oracle
-      TSQLStatement* stmt = fCmdBuf->fBlobStmt;
-      if ((stmt!=0) && fFile->IsOracle()) {
+      TSQLStatement *stmt = fCmdBuf->fBlobStmt;
+      if ((stmt != 0) && fFile->IsOracle()) {
          stmt->Process();
          delete stmt;
          fCmdBuf->fBlobStmt = 0;
       }
    }
 
-   Bool_t IsAnyData() const { return fRawId>0; }
+   Bool_t IsAnyData() const { return fRawId > 0; }
 
-   void AddLine(const char* name, const char* value, const char* topname = 0, const char* ns = 0)
+   void AddLine(const char *name, const char *value, const char *topname = 0, const char *ns = 0)
    {
-      if (fCmdBuf==0) return;
+      if (fCmdBuf == 0)
+         return;
 
       // when first line is created, check all problems
-      if (fRawId==0) {
+      if (fRawId == 0) {
          Bool_t maketmt = kFALSE;
          if (fFile->IsOracle() || fFile->IsODBC())
-            maketmt = (fCmdBuf->fBlobStmt==0) && fFile->SQLCanStatement();
+            maketmt = (fCmdBuf->fBlobStmt == 0) && fFile->SQLCanStatement();
 
          if (maketmt) {
             // ensure that raw table is exists
             fFile->CreateRawTable(fInfo);
 
-            const char* quote = fFile->SQLIdentifierQuote();
+            const char *quote = fFile->SQLIdentifierQuote();
             TString sqlcmd;
-            const char* params = fFile->IsOracle() ? ":1, :2, :3, :4" : "?, ?, ?, ?";
-            sqlcmd.Form("INSERT INTO %s%s%s VALUES (%s)",
-                        quote, fInfo->GetRawTableName(), quote, params);
-            TSQLStatement* stmt = fFile->SQLStatement(sqlcmd.Data(), 2000);
+            const char *params = fFile->IsOracle() ? ":1, :2, :3, :4" : "?, ?, ?, ?";
+            sqlcmd.Form("INSERT INTO %s%s%s VALUES (%s)", quote, fInfo->GetRawTableName(), quote, params);
+            TSQLStatement *stmt = fFile->SQLStatement(sqlcmd.Data(), 2000);
             fCmdBuf->fBlobStmt = stmt;
          }
       }
 
       TString buf;
-      const char* fullname = name;
-      if ((topname!=0) && (ns!=0)) {
-         buf+=topname;
-         buf+=ns;
-         buf+=name;
+      const char *fullname = name;
+      if ((topname != 0) && (ns != 0)) {
+         buf += topname;
+         buf += ns;
+         buf += name;
          fullname = buf.Data();
       }
 
-      TSQLStatement* stmt = fCmdBuf->fBlobStmt;
+      TSQLStatement *stmt = fCmdBuf->fBlobStmt;
 
-      if (stmt!=0) {
+      if (stmt != 0) {
          stmt->NextIteration();
          stmt->SetLong64(0, fObjId);
          stmt->SetInt(1, fRawId++);
          stmt->SetString(2, fullname, fMaxStrSize);
-//         Info("AddLine","name = %s value = %s",fullname, value);
+         //         Info("AddLine","name = %s value = %s",fullname, value);
          stmt->SetString(3, value, fMaxStrSize);
       } else {
          TString valuebuf(value);
@@ -1228,13 +1183,13 @@ public:
       }
    }
 
-   TSQLFile*  fFile;
-   TSQLClassInfo* fInfo;
-   TSqlCmdsBuffer* fCmdBuf;
+   TSQLFile *fFile;
+   TSQLClassInfo *fInfo;
+   TSqlCmdsBuffer *fCmdBuf;
    Long64_t fObjId;
    Int_t fRawId;
    TString fValueMask;
-   const char* fValueQuote;
+   const char *fValueQuote;
    Int_t fMaxStrSize;
 };
 
@@ -1245,9 +1200,10 @@ Long64_t TSQLStructure::FindMaxObjectId()
 {
    Long64_t max = DefineObjectId(kFALSE);
 
-   for (Int_t n=0;n<NumChilds();n++) {
+   for (Int_t n = 0; n < NumChilds(); n++) {
       Long64_t zn = GetChild(n)->FindMaxObjectId();
-      if (zn>max) max = zn;
+      if (zn > max)
+         max = zn;
    }
 
    return max;
@@ -1259,9 +1215,10 @@ Long64_t TSQLStructure::FindMaxObjectId()
 /// this structure with object data
 /// Should be only called for toplevel structure
 
-Bool_t TSQLStructure::ConvertToTables(TSQLFile* file, Long64_t keyid, TObjArray* cmds)
+Bool_t TSQLStructure::ConvertToTables(TSQLFile *file, Long64_t keyid, TObjArray *cmds)
 {
-   if ((file==0) || (cmds==0)) return kFALSE;
+   if ((file == 0) || (cmds == 0))
+      return kFALSE;
 
    TSqlRegistry reg;
 
@@ -1286,15 +1243,16 @@ Bool_t TSQLStructure::ConvertToTables(TSQLFile* file, Long64_t keyid, TObjArray*
 /// first tries convert it to normal form
 /// if fails, produces data for raw table
 
-void TSQLStructure::PerformConversion(TSqlRegistry* reg, TSqlRawBuffer* blobs, const char* topname, Bool_t useblob)
+void TSQLStructure::PerformConversion(TSqlRegistry *reg, TSqlRawBuffer *blobs, const char *topname, Bool_t useblob)
 {
    TString sbuf;
-   const char* ns = reg->fFile->SQLNameSeparator();
+   const char *ns = reg->fFile->SQLNameSeparator();
 
    switch (fType) {
    case kSqlObject: {
 
-      if (!StoreObject(reg, DefineObjectId(kFALSE), GetObjectClass())) break;
+      if (!StoreObject(reg, DefineObjectId(kFALSE), GetObjectClass()))
+         break;
 
       blobs->AddLine(sqlio::ObjectRef, GetValue(), topname, ns);
 
@@ -1302,34 +1260,36 @@ void TSQLStructure::PerformConversion(TSqlRegistry* reg, TSqlRawBuffer* blobs, c
    }
 
    case kSqlPointer: {
-      blobs->AddLine(sqlio::ObjectPtr, fValue.Data(), topname,ns);
+      blobs->AddLine(sqlio::ObjectPtr, fValue.Data(), topname, ns);
       break;
    }
 
    case kSqlVersion: {
-      if (fPointer!=0)
-         topname = ((TClass*) fPointer)->GetName();
+      if (fPointer != 0)
+         topname = ((TClass *)fPointer)->GetName();
       else
-         Error("PerformConversion","version without class");
+         Error("PerformConversion", "version without class");
       blobs->AddLine(sqlio::Version, fValue.Data(), topname, ns);
       break;
    }
 
    case kSqlStreamerInfo: {
 
-      TStreamerInfo* info = GetStreamerInfo();
-      if (info==0) return;
+      TStreamerInfo *info = GetStreamerInfo();
+      if (info == 0)
+         return;
 
       if (useblob) {
-         for(Int_t n=0;n<=fChilds.GetLast();n++) {
-            TSQLStructure* child = (TSQLStructure*) fChilds.At(n);
+         for (Int_t n = 0; n <= fChilds.GetLast(); n++) {
+            TSQLStructure *child = (TSQLStructure *)fChilds.At(n);
             child->PerformConversion(reg, blobs, info->GetName(), useblob);
          }
       } else {
          Long64_t objid = reg->GetNextObjId();
          TString sobjid;
-         sobjid.Form("%lld",objid);
-         if (!StoreObject(reg, objid, info->GetClass(), kTRUE)) return;
+         sobjid.Form("%lld", objid);
+         if (!StoreObject(reg, objid, info->GetClass(), kTRUE))
+            return;
          blobs->AddLine(sqlio::ObjectInst, sobjid.Data(), topname, ns);
       }
       break;
@@ -1337,32 +1297,35 @@ void TSQLStructure::PerformConversion(TSqlRegistry* reg, TSqlRawBuffer* blobs, c
 
    case kSqlCustomElement:
    case kSqlElement: {
-      const TStreamerElement* elem = (const TStreamerElement*) fPointer;
+      const TStreamerElement *elem = (const TStreamerElement *)fPointer;
 
       Int_t indx = 0;
-      while (indx<NumChilds()) {
-         TSQLStructure* child = GetChild(indx++);
+      while (indx < NumChilds()) {
+         TSQLStructure *child = GetChild(indx++);
          child->PerformConversion(reg, blobs, elem->GetName(), useblob);
       }
       break;
    }
 
    case kSqlValue: {
-      const char* tname = (const char*) fPointer;
-      if (fArrayIndex>=0) {
-         if (fRepeatCnt>1)
-            sbuf.Form("%s%d%s%d%s%s%s", "[", fArrayIndex, sqlio::IndexSepar, fArrayIndex+fRepeatCnt-1, "]", ns, tname);
+      const char *tname = (const char *)fPointer;
+      if (fArrayIndex >= 0) {
+         if (fRepeatCnt > 1)
+            sbuf.Form("%s%d%s%d%s%s%s", "[", fArrayIndex, sqlio::IndexSepar, fArrayIndex + fRepeatCnt - 1, "]", ns,
+                      tname);
          else
             sbuf.Form("%s%d%s%s%s", "[", fArrayIndex, "]", ns, tname);
       } else {
-         if (tname!=0) sbuf = tname;
-         else sbuf = "Value";
+         if (tname != 0)
+            sbuf = tname;
+         else
+            sbuf = "Value";
       }
 
       TString buf;
-      const char* value = fValue.Data();
+      const char *value = fValue.Data();
 
-      if ((tname==sqlio::CharStar) && (value!=0)) {
+      if ((tname == sqlio::CharStar) && (value != 0)) {
          Int_t size = strlen(value);
          if (size > reg->fFile->SQLSmallTextTypeLimit()) {
             Int_t strid = reg->AddLongString(value);
@@ -1371,16 +1334,16 @@ void TSQLStructure::PerformConversion(TSqlRegistry* reg, TSqlRawBuffer* blobs, c
          }
       }
 
-      blobs->AddLine(sbuf.Data(), value, (fArrayIndex>=0) ? 0 : topname, ns);
+      blobs->AddLine(sbuf.Data(), value, (fArrayIndex >= 0) ? 0 : topname, ns);
 
       break;
    }
 
    case kSqlArray: {
-      if (fValue.Length()>0)
+      if (fValue.Length() > 0)
          blobs->AddLine(sqlio::Array, fValue.Data(), topname, ns);
-      for(Int_t n=0;n<=fChilds.GetLast();n++) {
-         TSQLStructure* child = (TSQLStructure*) fChilds.At(n);
+      for (Int_t n = 0; n <= fChilds.GetLast(); n++) {
+         TSQLStructure *child = (TSQLStructure *)fChilds.At(n);
          child->PerformConversion(reg, blobs, topname, useblob);
       }
       break;
@@ -1390,21 +1353,24 @@ void TSQLStructure::PerformConversion(TSqlRegistry* reg, TSqlRawBuffer* blobs, c
 
 ////////////////////////////////////////////////////////////////////////////////
 /// convert object data to sql statements
-/// if normal (columnwise) representation is not possible,
+/// if normal (column-wise) representation is not possible,
 /// complete object will be converted to raw format
 
-Bool_t TSQLStructure::StoreObject(TSqlRegistry* reg, Long64_t objid, TClass* cl, Bool_t registerobj)
+Bool_t TSQLStructure::StoreObject(TSqlRegistry *reg, Long64_t objid, TClass *cl, Bool_t registerobj)
 {
-   if ((cl==0) || (objid<0)) return kFALSE;
+   if ((cl == 0) || (objid < 0))
+      return kFALSE;
 
-   if (gDebug>1) {
-      std::cout << "Store object " << objid <<" cl = " << cl->GetName() << std::endl;
-      if (GetStreamerInfo()) std::cout << "Info = " << GetStreamerInfo()->GetName() << std::endl; else
-         if (GetElement()) std::cout << "Element = " << GetElement()->GetName() << std::endl;
+   if (gDebug > 1) {
+      std::cout << "Store object " << objid << " cl = " << cl->GetName() << std::endl;
+      if (GetStreamerInfo())
+         std::cout << "Info = " << GetStreamerInfo()->GetName() << std::endl;
+      else if (GetElement())
+         std::cout << "Element = " << GetElement()->GetName() << std::endl;
    }
 
    Long64_t oldid = reg->fCurrentObjId;
-   TClass* oldcl = reg->fCurrentObjClass;
+   TClass *oldcl = reg->fCurrentObjClass;
 
    reg->fCurrentObjId = objid;
    reg->fCurrentObjClass = cl;
@@ -1413,32 +1379,31 @@ Bool_t TSQLStructure::StoreObject(TSqlRegistry* reg, Long64_t objid, TClass* cl,
 
    Bool_t res = kTRUE;
 
-   if (cl==TObject::Class())
+   if (cl == TObject::Class())
       normstore = StoreTObject(reg);
-   else
-   if (cl==TString::Class())
+   else if (cl == TString::Class())
       normstore = StoreTString(reg);
+   else if (GetType() == kSqlStreamerInfo)
+      // this is a case when array of objects are stored in blob and each object
+      // has normal streamer. Then it will be stored in normal form and only one tag
+      // will be kept to remind about
+      normstore = StoreClassInNormalForm(reg);
    else
-      if (GetType()==kSqlStreamerInfo)
-         // this is a case when array of objects are stored in blob and each object
-         // has normal streamer. Then it will be stored in normal form and only one tag
-         // will be kept to remind about
-         normstore = StoreClassInNormalForm(reg);
-      else
-         normstore = StoreObjectInNormalForm(reg);
+      normstore = StoreObjectInNormalForm(reg);
 
-   if (gDebug>2)
-      std::cout << "Store object " << objid << " of class " << cl->GetName() << "  normal = " << normstore << " sqltype = " << GetType() << std::endl;
+   if (gDebug > 2)
+      std::cout << "Store object " << objid << " of class " << cl->GetName() << "  normal = " << normstore
+                << " sqltype = " << GetType() << std::endl;
 
    if (!normstore) {
 
       // This is a case, when only raw table is exists
 
-      TSQLClassInfo* sqlinfo = reg->fFile->RequestSQLClassInfo(cl);
+      TSQLClassInfo *sqlinfo = reg->fFile->RequestSQLClassInfo(cl);
       TSqlRawBuffer rawdata(reg, sqlinfo);
 
-      for(Int_t n=0;n<NumChilds();n++) {
-         TSQLStructure* child = GetChild(n);
+      for (Int_t n = 0; n < NumChilds(); n++) {
+         TSQLStructure *child = GetChild(n);
          child->PerformConversion(reg, &rawdata, 0 /*cl->GetName()*/);
       }
 
@@ -1458,15 +1423,17 @@ Bool_t TSQLStructure::StoreObject(TSqlRegistry* reg, Long64_t objid, TClass* cl,
 /// this function verify object child elements and
 /// calls transformation to class table
 
-Bool_t TSQLStructure::StoreObjectInNormalForm(TSqlRegistry* reg)
+Bool_t TSQLStructure::StoreObjectInNormalForm(TSqlRegistry *reg)
 {
-   if (fChilds.GetLast()!=1) return kFALSE;
+   if (fChilds.GetLast() != 1)
+      return kFALSE;
 
-   TSQLStructure* s_ver = GetChild(0);
+   TSQLStructure *s_ver = GetChild(0);
 
-   TSQLStructure* s_info = GetChild(1);
+   TSQLStructure *s_info = GetChild(1);
 
-   if (!CheckNormalClassPair(s_ver, s_info)) return kFALSE;
+   if (!CheckNormalClassPair(s_ver, s_info))
+      return kFALSE;
 
    return s_info->StoreClassInNormalForm(reg);
 }
@@ -1475,63 +1442,66 @@ Bool_t TSQLStructure::StoreObjectInNormalForm(TSqlRegistry* reg)
 /// produces data for complete class table
 /// where not possible, raw data for some elements are created
 
-Bool_t TSQLStructure::StoreClassInNormalForm(TSqlRegistry* reg)
+Bool_t TSQLStructure::StoreClassInNormalForm(TSqlRegistry *reg)
 {
-   TClass* cl = 0;
+   TClass *cl = 0;
    Version_t version = 0;
-   if (!GetClassInfo(cl, version)) return kFALSE;
-   if (cl==0) return kFALSE;
+   if (!GetClassInfo(cl, version))
+      return kFALSE;
+   if (cl == 0)
+      return kFALSE;
 
-   TSQLClassInfo* sqlinfo = reg->fFile->RequestSQLClassInfo(cl->GetName(), version);
+   TSQLClassInfo *sqlinfo = reg->fFile->RequestSQLClassInfo(cl->GetName(), version);
 
    TSQLTableData columns(reg->fFile, sqlinfo);
    // Bool_t needblob = kFALSE;
 
    TSqlRawBuffer rawdata(reg, sqlinfo);
 
-//   Int_t currrawid = 0;
+   //   Int_t currrawid = 0;
 
    // add first column with object id
    columns.AddColumn(reg->fFile->SQLObjectIdColumn(), reg->fCurrentObjId);
 
-   for(Int_t n=0;n<=fChilds.GetLast();n++) {
-      TSQLStructure* child = (TSQLStructure*) fChilds.At(n);
-      TStreamerElement* elem = child->GetElement();
+   for (Int_t n = 0; n <= fChilds.GetLast(); n++) {
+      TSQLStructure *child = (TSQLStructure *)fChilds.At(n);
+      TStreamerElement *elem = child->GetElement();
 
-      if (elem==0) {
+      if (elem == 0) {
          Error("StoreClassInNormalForm", "CAN NOT BE");
          continue;
       }
 
-      if (child->StoreElementInNormalForm(reg, &columns)) continue;
+      if (child->StoreElementInNormalForm(reg, &columns))
+         continue;
 
       Int_t columntyp = DefineElementColumnType(elem, reg->fFile);
-      if ((columntyp!=kColRawData) && (columntyp!=kColObjectArray)) {
-         Error("StoreClassInNormalForm","Element %s typ=%d has problem with normal store ", elem->GetName(), columntyp);
+      if ((columntyp != kColRawData) && (columntyp != kColObjectArray)) {
+         Error("StoreClassInNormalForm", "Element %s typ=%d has problem with normal store ", elem->GetName(),
+               columntyp);
          continue;
       }
-
 
       Bool_t doblobs = kTRUE;
 
       Int_t blobid = rawdata.fRawId; // keep id of first raw, used in class table
 
-      if (columntyp==kColObjectArray)
+      if (columntyp == kColObjectArray)
          if (child->TryConvertObjectArray(reg, &rawdata))
             doblobs = kFALSE;
 
       if (doblobs)
          child->PerformConversion(reg, &rawdata, elem->GetName(), kFALSE);
 
-      if (blobid==rawdata.fRawId)
+      if (blobid == rawdata.fRawId)
          blobid = -1; // no data for blob was created
       else {
-         //reg->fFile->CreateRawTable(sqlinfo);
-         //blobid = currrawid; // column will contain first raw id
-         //reg->ConvertBlobs(&blobs, sqlinfo, currrawid);
-         //needblob = kTRUE;
+         // reg->fFile->CreateRawTable(sqlinfo);
+         // blobid = currrawid; // column will contain first raw id
+         // reg->ConvertBlobs(&blobs, sqlinfo, currrawid);
+         // needblob = kTRUE;
       }
-      //blobs.Delete();
+      // blobs.Delete();
 
       TString blobname = elem->GetName();
       if (reg->fFile->GetUseSuffixes())
@@ -1550,16 +1520,17 @@ Bool_t TSQLStructure::StoreClassInNormalForm(TSqlRegistry* reg)
 ////////////////////////////////////////////////////////////////////////////////
 /// produce string with complete index like [1][2][0]
 
-TString TSQLStructure::MakeArrayIndex(TStreamerElement* elem, Int_t index)
+TString TSQLStructure::MakeArrayIndex(TStreamerElement *elem, Int_t index)
 {
    TString res;
-   if ((elem==0) || (elem->GetArrayLength()==0)) return res;
+   if ((elem == 0) || (elem->GetArrayLength() == 0))
+      return res;
 
-   for(Int_t ndim=elem->GetArrayDim()-1;ndim>=0;ndim--) {
+   for (Int_t ndim = elem->GetArrayDim() - 1; ndim >= 0; ndim--) {
       Int_t ix = index % elem->GetMaxIndex(ndim);
       index = index / elem->GetMaxIndex(ndim);
       TString buf;
-      buf.Form("%s%d%s","[",ix,"]");
+      buf.Form("%s%d%s", "[", ix, "]");
       res = buf + res;
    }
    return res;
@@ -1568,33 +1539,33 @@ TString TSQLStructure::MakeArrayIndex(TStreamerElement* elem, Int_t index)
 ////////////////////////////////////////////////////////////////////////////////
 /// tries to store element data in column
 
-Bool_t TSQLStructure::StoreElementInNormalForm(TSqlRegistry* reg, TSQLTableData* columns)
+Bool_t TSQLStructure::StoreElementInNormalForm(TSqlRegistry *reg, TSQLTableData *columns)
 {
-   TStreamerElement* elem = GetElement();
-   if (elem==0) return kFALSE;
+   TStreamerElement *elem = GetElement();
+   if (elem == 0)
+      return kFALSE;
 
    Int_t typ = elem->GetType();
 
    Int_t columntyp = DefineElementColumnType(elem, reg->fFile);
 
-   if (gDebug>4)
-      std::cout << "Element " << elem->GetName()
-           << "   type = " << typ
-           << "  column = " << columntyp << std::endl;
+   if (gDebug > 4)
+      std::cout << "Element " << elem->GetName() << "   type = " << typ << "  column = " << columntyp << std::endl;
 
    TString colname = DefineElementColumnName(elem, reg->fFile);
 
-   if (columntyp==kColTString) {
-      const char* value;
-      if (!RecognizeTString(value)) return kFALSE;
+   if (columntyp == kColTString) {
+      const char *value;
+      if (!RecognizeTString(value))
+         return kFALSE;
 
       Int_t len = value ? strlen(value) : 0;
 
       Int_t sizelimit = reg->fFile->SQLSmallTextTypeLimit();
 
-      const char* stype = reg->fFile->SQLSmallTextType();
+      const char *stype = reg->fFile->SQLSmallTextType();
 
-      if (len<=sizelimit)
+      if (len <= sizelimit)
          columns->AddColumn(colname.Data(), stype, value, kFALSE);
       else {
          Int_t strid = reg->AddLongString(value);
@@ -1605,9 +1576,9 @@ Bool_t TSQLStructure::StoreElementInNormalForm(TSqlRegistry* reg, TSQLTableData*
       return kTRUE;
    }
 
-   if (columntyp==kColParent) {
+   if (columntyp == kColParent) {
       Long64_t objid = reg->fCurrentObjId;
-      TClass* basecl = elem->GetClassPointer();
+      TClass *basecl = elem->GetClassPointer();
       Int_t resversion = basecl->GetClassVersion();
       if (!StoreObject(reg, objid, basecl, kFALSE))
          resversion = -1;
@@ -1615,50 +1586,52 @@ Bool_t TSQLStructure::StoreElementInNormalForm(TSqlRegistry* reg, TSQLTableData*
       return kTRUE;
    }
 
-   if (columntyp==kColObject) {
+   if (columntyp == kColObject) {
 
       Long64_t objid = -1;
 
-      if (NumChilds()==1) {
-         TSQLStructure* child = GetChild(0);
+      if (NumChilds() == 1) {
+         TSQLStructure *child = GetChild(0);
 
-         if (child->GetType()==kSqlObject) {
+         if (child->GetType() == kSqlObject) {
             objid = child->DefineObjectId(kFALSE);
-            if (!child->StoreObject(reg, objid, child->GetObjectClass())) return kFALSE;
-         } else
-         if (child->GetType()==kSqlPointer) {
+            if (!child->StoreObject(reg, objid, child->GetObjectClass()))
+               return kFALSE;
+         } else if (child->GetType() == kSqlPointer) {
             TString sobjid = child->GetValue();
-            if (sobjid.Length()>0)
+            if (sobjid.Length() > 0)
                objid = sqlio::atol64(sobjid.Data());
          }
       }
 
-      if (objid<0) {
-         //std::cout << "!!!! Not standard " << elem->GetName() << " class = " << elem->GetClassPointer()->GetName() << std::endl;
+      if (objid < 0) {
+         // std::cout << "!!!! Not standard " << elem->GetName() << " class = " << elem->GetClassPointer()->GetName() <<
+         // std::endl;
          objid = reg->GetNextObjId();
          if (!StoreObject(reg, objid, elem->GetClassPointer()))
-            objid = -1;  // this is a case, when no data was stored for this object
+            objid = -1; // this is a case, when no data was stored for this object
       }
 
       columns->AddColumn(colname.Data(), objid);
       return kTRUE;
    }
 
-   if (columntyp==kColNormObject) {
+   if (columntyp == kColNormObject) {
 
-      if (NumChilds()!=1) {
-         Error("kColNormObject","NumChilds()=%d", NumChilds());
+      if (NumChilds() != 1) {
+         Error("kColNormObject", "NumChilds()=%d", NumChilds());
          PrintLevel(20);
          return kFALSE;
       }
-      TSQLStructure* child = GetChild(0);
-      if ((child->GetType()!=kSqlPointer) && (child->GetType()!=kSqlObject)) return kFALSE;
+      TSQLStructure *child = GetChild(0);
+      if ((child->GetType() != kSqlPointer) && (child->GetType() != kSqlObject))
+         return kFALSE;
 
       Bool_t normal = kTRUE;
 
       Long64_t objid = -1;
 
-      if (child->GetType()==kSqlObject) {
+      if (child->GetType() == kSqlObject) {
          objid = child->DefineObjectId(kFALSE);
          normal = child->StoreObject(reg, objid, child->GetObjectClass());
       } else {
@@ -1666,7 +1639,7 @@ Bool_t TSQLStructure::StoreElementInNormalForm(TSqlRegistry* reg, TSQLTableData*
       }
 
       if (!normal) {
-         Error("kColNormObject","child->StoreObject fails");
+         Error("kColNormObject", "child->StoreObject fails");
          return kFALSE;
       }
 
@@ -1674,22 +1647,24 @@ Bool_t TSQLStructure::StoreElementInNormalForm(TSqlRegistry* reg, TSQLTableData*
       return kTRUE;
    }
 
-   if (columntyp==kColNormObjectArray) {
+   if (columntyp == kColNormObjectArray) {
 
-      if (elem->GetArrayLength()!=NumChilds()) return kFALSE;
+      if (elem->GetArrayLength() != NumChilds())
+         return kFALSE;
 
-      for (Int_t index=0;index<NumChilds();index++) {
-         TSQLStructure* child = GetChild(index);
-         if ((child->GetType()!=kSqlPointer) &&
-             (child->GetType()!=kSqlObject)) return kFALSE;
+      for (Int_t index = 0; index < NumChilds(); index++) {
+         TSQLStructure *child = GetChild(index);
+         if ((child->GetType() != kSqlPointer) && (child->GetType() != kSqlObject))
+            return kFALSE;
          Bool_t normal = kTRUE;
 
          Long64_t objid = child->DefineObjectId(kFALSE);
 
-         if (child->GetType()==kSqlObject)
+         if (child->GetType() == kSqlObject)
             normal = child->StoreObject(reg, objid, child->GetObjectClass());
 
-         if (!normal) return kFALSE;
+         if (!normal)
+            return kFALSE;
 
          colname = DefineElementColumnName(elem, reg->fFile, index);
 
@@ -1698,68 +1673,75 @@ Bool_t TSQLStructure::StoreElementInNormalForm(TSqlRegistry* reg, TSQLTableData*
       return kTRUE;
    }
 
-   if (columntyp==kColObjectPtr) {
-      if (NumChilds()!=1) return kFALSE;
-      TSQLStructure* child = GetChild(0);
-      if ((child->GetType()!=kSqlPointer) && (child->GetType()!=kSqlObject)) return kFALSE;
+   if (columntyp == kColObjectPtr) {
+      if (NumChilds() != 1)
+         return kFALSE;
+      TSQLStructure *child = GetChild(0);
+      if ((child->GetType() != kSqlPointer) && (child->GetType() != kSqlObject))
+         return kFALSE;
 
       Bool_t normal = kTRUE;
       Long64_t objid = -1;
 
-      if (child->GetType()==kSqlObject) {
+      if (child->GetType() == kSqlObject) {
          objid = child->DefineObjectId(kFALSE);
          normal = child->StoreObject(reg, objid, child->GetObjectClass());
       }
 
-      if (!normal) return kFALSE;
+      if (!normal)
+         return kFALSE;
 
       columns->AddColumn(colname.Data(), objid);
       return kTRUE;
    }
 
-   if (columntyp==kColSimple) {
+   if (columntyp == kColSimple) {
 
       // only child shoud existing for element
-      if (NumChilds()!=1) {
-         Error("StoreElementInNormalForm","Enexpected number %d for simple element %s", NumChilds(), elem->GetName());
+      if (NumChilds() != 1) {
+         Error("StoreElementInNormalForm", "Enexpected number %d for simple element %s", NumChilds(), elem->GetName());
          return kFALSE;
       }
 
-      TSQLStructure* child = GetChild(0);
-      if (child->GetType()!=kSqlValue) return kFALSE;
+      TSQLStructure *child = GetChild(0);
+      if (child->GetType() != kSqlValue)
+         return kFALSE;
 
-      const char* value = child->GetValue();
-      if (value==0) return kFALSE;
+      const char *value = child->GetValue();
+      if (value == 0)
+         return kFALSE;
 
-      const char* sqltype = reg->fFile->SQLCompatibleType(typ);
+      const char *sqltype = reg->fFile->SQLCompatibleType(typ);
 
       columns->AddColumn(colname.Data(), sqltype, value, IsNumericType(typ));
 
       return kTRUE;
    }
 
-   if (columntyp==kColSimpleArray) {
+   if (columntyp == kColSimpleArray) {
       // number of items should be exactly equal to number of children
 
-      if (NumChilds()!=1) {
-         Error("StoreElementInNormalForm","In fixed array %s only array node should be", elem->GetName());
+      if (NumChilds() != 1) {
+         Error("StoreElementInNormalForm", "In fixed array %s only array node should be", elem->GetName());
          return kFALSE;
       }
-      TSQLStructure* arr = GetChild(0);
+      TSQLStructure *arr = GetChild(0);
 
-      const char* sqltype = reg->fFile->SQLCompatibleType(typ % 20);
+      const char *sqltype = reg->fFile->SQLCompatibleType(typ % 20);
 
-      for(Int_t n=0;n<arr->NumChilds();n++) {
-         TSQLStructure* child = arr->GetChild(n);
-         if (child->GetType()!=kSqlValue) return kFALSE;
+      for (Int_t n = 0; n < arr->NumChilds(); n++) {
+         TSQLStructure *child = arr->GetChild(n);
+         if (child->GetType() != kSqlValue)
+            return kFALSE;
 
-         const char* value = child->GetValue();
-         if (value==0) return kFALSE;
+         const char *value = child->GetValue();
+         if (value == 0)
+            return kFALSE;
 
          Int_t index = child->GetArrayIndex();
          Int_t last = index + child->GetRepeatCounter();
 
-         while (index<last) {
+         while (index < last) {
             colname = DefineElementColumnName(elem, reg->fFile, index);
             columns->AddColumn(colname.Data(), sqltype, value, kTRUE);
             index++;
@@ -1772,38 +1754,42 @@ Bool_t TSQLStructure::StoreElementInNormalForm(TSqlRegistry* reg, TSQLTableData*
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// tries to write array of objects as lis of object refereneces
+/// tries to write array of objects as list of object references
 /// in _streamer_ table, while objects itself will be stored in
-/// other tables. If not successfull, object data will be stored
+/// other tables. If not successful, object data will be stored
 /// in _streamer_ table
 
-Bool_t TSQLStructure::TryConvertObjectArray(TSqlRegistry* reg, TSqlRawBuffer* blobs)
+Bool_t TSQLStructure::TryConvertObjectArray(TSqlRegistry *reg, TSqlRawBuffer *blobs)
 {
-   TStreamerElement* elem = GetElement();
-   if (elem==0) return kFALSE;
+   TStreamerElement *elem = GetElement();
+   if (elem == 0)
+      return kFALSE;
 
-   if (NumChilds() % 2 !=0) return kFALSE;
+   if (NumChilds() % 2 != 0)
+      return kFALSE;
 
    Int_t indx = 0;
 
-   while (indx<NumChilds()) {
-      TSQLStructure* s_ver = GetChild(indx++);
-      TSQLStructure* s_info = GetChild(indx++);
-      if (!CheckNormalClassPair(s_ver, s_info)) return kFALSE;
+   while (indx < NumChilds()) {
+      TSQLStructure *s_ver = GetChild(indx++);
+      TSQLStructure *s_info = GetChild(indx++);
+      if (!CheckNormalClassPair(s_ver, s_info))
+         return kFALSE;
    }
 
    indx = 0;
-   const char* ns = reg->fFile->SQLNameSeparator();
+   const char *ns = reg->fFile->SQLNameSeparator();
 
-   while (indx<NumChilds()-1) {
-      indx++; //TSQLStructure* s_ver = GetChild(indx++);
-      TSQLStructure* s_info = GetChild(indx++);
-      TClass* cl = 0;
+   while (indx < NumChilds() - 1) {
+      indx++; // TSQLStructure* s_ver = GetChild(indx++);
+      TSQLStructure *s_info = GetChild(indx++);
+      TClass *cl = 0;
       Version_t version = 0;
-      if (!s_info->GetClassInfo(cl, version)) return kFALSE;
+      if (!s_info->GetClassInfo(cl, version))
+         return kFALSE;
       Long64_t objid = reg->GetNextObjId();
       if (!s_info->StoreObject(reg, objid, cl))
-         objid = -1;  // this is a case, when no data was stored for this object
+         objid = -1; // this is a case, when no data was stored for this object
 
       TString sobjid;
       sobjid.Form("%lld", objid);
@@ -1818,18 +1804,20 @@ Bool_t TSQLStructure::TryConvertObjectArray(TSqlRegistry* reg, TSqlRawBuffer* bl
 /// check if pair of two element corresponds
 /// to start of object, stored in normal form
 
-Bool_t TSQLStructure::CheckNormalClassPair(TSQLStructure* s_ver, TSQLStructure* s_info)
+Bool_t TSQLStructure::CheckNormalClassPair(TSQLStructure *s_ver, TSQLStructure *s_info)
 {
-   if ((s_ver==0) || (s_info==0) || (s_ver->GetType()!=kSqlVersion)) return kFALSE;
+   if ((s_ver == 0) || (s_info == 0) || (s_ver->GetType() != kSqlVersion))
+      return kFALSE;
 
-   TClass* ver_cl = s_ver->GetVersionClass();
+   TClass *ver_cl = s_ver->GetVersionClass();
 
-   TClass* info_cl = 0;
+   TClass *info_cl = 0;
    Version_t info_ver = 0;
-   if (!s_info->GetClassInfo(info_cl, info_ver)) return kFALSE;
+   if (!s_info->GetClassInfo(info_cl, info_ver))
+      return kFALSE;
 
-   if ((ver_cl==0) || (info_cl==0) || (ver_cl!=info_cl) ||
-       (ver_cl->GetClassVersion()!=info_ver)) return kFALSE;
+   if ((ver_cl == 0) || (info_cl == 0) || (ver_cl != info_cl) || (ver_cl->GetClassVersion() != info_ver))
+      return kFALSE;
 
    return kTRUE;
 }
@@ -1838,32 +1826,35 @@ Bool_t TSQLStructure::CheckNormalClassPair(TSQLStructure* s_ver, TSQLStructure* 
 /// store data of TObject in special table
 /// workaround custom TObject streamer
 
-Bool_t TSQLStructure::StoreTObject(TSqlRegistry* reg)
+Bool_t TSQLStructure::StoreTObject(TSqlRegistry *reg)
 {
    // check if it is really Looks like TObject data
-   if ((NumChilds()<3) || (NumChilds()>4)) return kFALSE;
+   if ((NumChilds() < 3) || (NumChilds() > 4))
+      return kFALSE;
 
-   TSQLStructure* str_ver  = GetChild(0);
-   TSQLStructure* str_id   = GetChild(1);
-   TSQLStructure* str_bits = GetChild(2);
-   TSQLStructure* str_prid = GetChild(3);
+   TSQLStructure *str_ver = GetChild(0);
+   TSQLStructure *str_id = GetChild(1);
+   TSQLStructure *str_bits = GetChild(2);
+   TSQLStructure *str_prid = GetChild(3);
 
-   if (str_ver->GetType()!=kSqlVersion) return kFALSE;
-   if ((str_id->GetType()!=kSqlValue) ||
-       (str_id->GetValueType()!=sqlio::UInt)) return kFALSE;
-   if ((str_bits->GetType()!=kSqlValue) ||
-       (str_bits->GetValueType()!=sqlio::UInt)) return kFALSE;
-   if (str_prid!=0)
-      if ((str_prid->GetType()!=kSqlValue) ||
-          (str_prid->GetValueType()!=sqlio::UShort)) return kFALSE;
+   if (str_ver->GetType() != kSqlVersion)
+      return kFALSE;
+   if ((str_id->GetType() != kSqlValue) || (str_id->GetValueType() != sqlio::UInt))
+      return kFALSE;
+   if ((str_bits->GetType() != kSqlValue) || (str_bits->GetValueType() != sqlio::UInt))
+      return kFALSE;
+   if (str_prid != 0)
+      if ((str_prid->GetType() != kSqlValue) || (str_prid->GetValueType() != sqlio::UShort))
+         return kFALSE;
 
-   TSQLClassInfo* sqlinfo = reg->fFile->RequestSQLClassInfo(TObject::Class());
+   TSQLClassInfo *sqlinfo = reg->fFile->RequestSQLClassInfo(TObject::Class());
 
-   if (sqlinfo==0) return kFALSE;
+   if (sqlinfo == 0)
+      return kFALSE;
 
    TSQLTableData columns(reg->fFile, sqlinfo);
 
-   const char* uinttype = reg->fFile->SQLCompatibleType(TStreamerInfo::kUInt);
+   const char *uinttype = reg->fFile->SQLCompatibleType(TStreamerInfo::kUInt);
 
    columns.AddColumn(reg->fFile->SQLObjectIdColumn(), reg->fCurrentObjId);
 
@@ -1882,13 +1873,15 @@ Bool_t TSQLStructure::StoreTObject(TSqlRegistry* reg)
 /// store data of TString in special table
 /// it is required when TString stored as pointer and reference to it possible
 
-Bool_t TSQLStructure::StoreTString(TSqlRegistry* reg)
+Bool_t TSQLStructure::StoreTString(TSqlRegistry *reg)
 {
-   const char* value = 0;
-   if (!RecognizeTString(value)) return kFALSE;
+   const char *value = 0;
+   if (!RecognizeTString(value))
+      return kFALSE;
 
-   TSQLClassInfo* sqlinfo = reg->fFile->RequestSQLClassInfo(TString::Class());
-   if (sqlinfo==0) return kFALSE;
+   TSQLClassInfo *sqlinfo = reg->fFile->RequestSQLClassInfo(TString::Class());
+   if (sqlinfo == 0)
+      return kFALSE;
 
    TSQLTableData columns(reg->fFile, sqlinfo);
 
@@ -1902,33 +1895,45 @@ Bool_t TSQLStructure::StoreTString(TSqlRegistry* reg)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// prove that structure containes TString data
+/// prove that structure contains TString data
 
-Bool_t TSQLStructure::RecognizeTString(const char* &value)
+Bool_t TSQLStructure::RecognizeTString(const char *&value)
 {
    value = 0;
 
-   if ((NumChilds()==0) || (NumChilds()>3)) return kFALSE;
+   if ((NumChilds() == 0) || (NumChilds() > 3))
+      return kFALSE;
 
-   TSQLStructure *len=0, *lenbig=0, *chars=0;
-   for (Int_t n=0;n<NumChilds();n++) {
-      TSQLStructure* curr = GetChild(n);
-      if (curr->fType!=kSqlValue) return kFALSE;
-      if (curr->fPointer==sqlio::UChar) {
-         if (len==0) len=curr; else return kFALSE;
+   TSQLStructure *len = 0, *lenbig = 0, *chars = 0;
+   for (Int_t n = 0; n < NumChilds(); n++) {
+      TSQLStructure *curr = GetChild(n);
+      if (curr->fType != kSqlValue)
+         return kFALSE;
+      if (curr->fPointer == sqlio::UChar) {
+         if (len == 0)
+            len = curr;
+         else
+            return kFALSE;
+      } else if (curr->fPointer == sqlio::Int) {
+         if (lenbig == 0)
+            lenbig = curr;
+         else
+            return kFALSE;
+      } else if (curr->fPointer == sqlio::CharStar) {
+         if (chars == 0)
+            chars = curr;
+         else
+            return kFALSE;
       } else
-         if (curr->fPointer==sqlio::Int) {
-            if (lenbig==0) lenbig=curr; else return kFALSE;
-         } else
-            if (curr->fPointer==sqlio::CharStar) {
-               if (chars==0) chars=curr; else return kFALSE;
-            } else return kFALSE;
+         return kFALSE;
    }
 
-   if (len==0) return kFALSE;
-   if ((lenbig!=0) && ((chars==0) || (len==0))) return kFALSE;
+   if (len == 0)
+      return kFALSE;
+   if ((lenbig != 0) && ((chars == 0) || (len == 0)))
+      return kFALSE;
 
-   if (chars!=0)
+   if (chars != 0)
       value = chars->GetValue();
 
    return kTRUE;
@@ -1938,103 +1943,93 @@ Bool_t TSQLStructure::RecognizeTString(const char* &value)
 /// defines which kind of column can be assigned for this element
 /// Possible cases
 ///    kColSimple       -  basic data type
-///    kColSimpleArray  -  fixed arary of basic types
+///    kColSimpleArray  -  fixed array of basic types
 ///    kColParent       -  parent class
-///    kColObject       -  object as data memeber
+///    kColObject       -  object as data member
 ///    kColObjectPtr    -  object as pointer
 ///    kColTString      -  TString
 ///    kColRawData      -  anything else as raw data
 
-Int_t TSQLStructure::DefineElementColumnType(TStreamerElement* elem, TSQLFile* f)
+Int_t TSQLStructure::DefineElementColumnType(TStreamerElement *elem, TSQLFile *f)
 {
-   if (elem==0) return kColUnknown;
+   if (elem == 0)
+      return kColUnknown;
 
    Int_t typ = elem->GetType();
 
-   if (typ == TStreamerInfo::kMissing) return kColRawData;
+   if (typ == TStreamerInfo::kMissing)
+      return kColRawData;
 
-   if ((typ>0) && (typ<20) &&
-       (typ!=TStreamerInfo::kCharStar)) return kColSimple;
+   if ((typ > 0) && (typ < 20) && (typ != TStreamerInfo::kCharStar))
+      return kColSimple;
 
-   if ((typ>TStreamerInfo::kOffsetL) &&
-       (typ<TStreamerInfo::kOffsetP))
-      if ((f->GetArrayLimit()<0) ||
-          (elem->GetArrayLength()<=f->GetArrayLimit()))
+   if ((typ > TStreamerInfo::kOffsetL) && (typ < TStreamerInfo::kOffsetP))
+      if ((f->GetArrayLimit() < 0) || (elem->GetArrayLength() <= f->GetArrayLimit()))
          return kColSimpleArray;
 
-   if (typ==TStreamerInfo::kTObject) {
+   if (typ == TStreamerInfo::kTObject) {
       if (elem->InheritsFrom(TStreamerBase::Class()))
          return kColParent;
       else
          return kColObject;
    }
 
-   if (typ==TStreamerInfo::kTNamed) {
+   if (typ == TStreamerInfo::kTNamed) {
       if (elem->InheritsFrom(TStreamerBase::Class()))
          return kColParent;
       else
          return kColObject;
    }
 
-   if (typ==TStreamerInfo::kTString) return kColTString;
+   if (typ == TStreamerInfo::kTString)
+      return kColTString;
 
-   if (typ==TStreamerInfo::kBase) return kColParent;
+   if (typ == TStreamerInfo::kBase)
+      return kColParent;
 
-   if (typ==TStreamerInfo::kSTL)
+   if (typ == TStreamerInfo::kSTL)
       if (elem->InheritsFrom(TStreamerBase::Class()))
          return kColParent;
 
    // this is workaround
    // these two tags stored with WriteFastArray, but read with cl->Streamer()
-   if ((typ==TStreamerInfo::kObject)  ||
-       (typ==TStreamerInfo::kAny)) {
-      if (elem->GetArrayLength()==0)
+   if ((typ == TStreamerInfo::kObject) || (typ == TStreamerInfo::kAny)) {
+      if (elem->GetArrayLength() == 0)
          return kColObject;
-      else
-         if (elem->GetStreamer()==0)
-            return kColObjectArray;
+      else if (elem->GetStreamer() == 0)
+         return kColObjectArray;
    }
 
-   if ((typ==TStreamerInfo::kObject)  ||
-       (typ==TStreamerInfo::kAny) ||
-       (typ==TStreamerInfo::kAnyp) ||
-       (typ==TStreamerInfo::kObjectp) ||
-       (typ==TStreamerInfo::kAnyP) ||
-       (typ==TStreamerInfo::kObjectP)) {
-      if ((elem->GetArrayLength()==0) ||
-         (elem->GetStreamer()!=0))
+   if ((typ == TStreamerInfo::kObject) || (typ == TStreamerInfo::kAny) || (typ == TStreamerInfo::kAnyp) ||
+       (typ == TStreamerInfo::kObjectp) || (typ == TStreamerInfo::kAnyP) || (typ == TStreamerInfo::kObjectP)) {
+      if ((elem->GetArrayLength() == 0) || (elem->GetStreamer() != 0))
          return kColNormObject;
       else
          return kColNormObjectArray;
    }
 
-   if ((typ==TStreamerInfo::kObject + TStreamerInfo::kOffsetL) ||
-       (typ==TStreamerInfo::kAny + TStreamerInfo::kOffsetL) ||
-       (typ==TStreamerInfo::kAnyp + TStreamerInfo::kOffsetL) ||
-       (typ==TStreamerInfo::kObjectp + TStreamerInfo::kOffsetL) ||
-       (typ==TStreamerInfo::kAnyP + TStreamerInfo::kOffsetL) ||
-       (typ==TStreamerInfo::kObjectP + TStreamerInfo::kOffsetL)) {
-      if (elem->GetStreamer()!=0)
+   if ((typ == TStreamerInfo::kObject + TStreamerInfo::kOffsetL) ||
+       (typ == TStreamerInfo::kAny + TStreamerInfo::kOffsetL) ||
+       (typ == TStreamerInfo::kAnyp + TStreamerInfo::kOffsetL) ||
+       (typ == TStreamerInfo::kObjectp + TStreamerInfo::kOffsetL) ||
+       (typ == TStreamerInfo::kAnyP + TStreamerInfo::kOffsetL) ||
+       (typ == TStreamerInfo::kObjectP + TStreamerInfo::kOffsetL)) {
+      if (elem->GetStreamer() != 0)
          return kColNormObject;
       else
          return kColNormObjectArray;
    }
 
-   if ((typ==TStreamerInfo::kObject) ||
-       (typ==TStreamerInfo::kAny) ||
-       (typ==TStreamerInfo::kAnyp) ||
-       (typ==TStreamerInfo::kObjectp) ||
-       (typ==TStreamerInfo::kSTL)) {
-      if (elem->GetArrayLength()==0)
+   if ((typ == TStreamerInfo::kObject) || (typ == TStreamerInfo::kAny) || (typ == TStreamerInfo::kAnyp) ||
+       (typ == TStreamerInfo::kObjectp) || (typ == TStreamerInfo::kSTL)) {
+      if (elem->GetArrayLength() == 0)
          return kColObject;
-      else
-         if (elem->GetStreamer()==0)
-            return kColObjectArray;
+      else if (elem->GetStreamer() == 0)
+         return kColObjectArray;
    }
 
-   if (((typ==TStreamerInfo::kAnyP) ||
-        (typ==TStreamerInfo::kObjectP)) &&
-       (elem->GetArrayDim()==0)) return kColObjectPtr;
+   if (((typ == TStreamerInfo::kAnyP) || (typ == TStreamerInfo::kObjectP)) && (elem->GetArrayDim() == 0))
+      return kColObjectPtr;
 
    //   if ((typ==TStreamerInfo::kSTLp) &&
    //       (elem->GetArrayDim()==0)) {
@@ -2049,35 +2044,36 @@ Int_t TSQLStructure::DefineElementColumnType(TStreamerElement* elem, TSQLFile* f
 ////////////////////////////////////////////////////////////////////////////////
 /// returns name of the column in class table for that element
 
-TString TSQLStructure::DefineElementColumnName(TStreamerElement* elem, TSQLFile* f, Int_t indx)
+TString TSQLStructure::DefineElementColumnName(TStreamerElement *elem, TSQLFile *f, Int_t indx)
 {
    TString colname = "";
 
    Int_t coltype = DefineElementColumnType(elem, f);
-   if (coltype==kColUnknown) return colname;
+   if (coltype == kColUnknown)
+      return colname;
 
-   const char* elemname = elem->GetName();
+   const char *elemname = elem->GetName();
 
    switch (coltype) {
    case kColSimple: {
       colname = elemname;
       if (f->GetUseSuffixes()) {
-         colname+=f->SQLNameSeparator();
-         colname+=GetSimpleTypeName(elem->GetType());
+         colname += f->SQLNameSeparator();
+         colname += GetSimpleTypeName(elem->GetType());
       }
       break;
    }
 
    case kColSimpleArray: {
       colname = elemname;
-      colname+=MakeArrayIndex(elem, indx);
+      colname += MakeArrayIndex(elem, indx);
       break;
    }
 
    case kColParent: {
       colname = elemname;
       if (f->GetUseSuffixes())
-         colname+=sqlio::ParentSuffix;
+         colname += sqlio::ParentSuffix;
       break;
    }
 
@@ -2090,7 +2086,7 @@ TString TSQLStructure::DefineElementColumnName(TStreamerElement* elem, TSQLFile*
 
    case kColNormObjectArray: {
       colname = elemname;
-      colname+=MakeArrayIndex(elem, indx);
+      colname += MakeArrayIndex(elem, indx);
       if (f->GetUseSuffixes())
          colname += sqlio::ObjectSuffix;
       break;
@@ -2113,7 +2109,7 @@ TString TSQLStructure::DefineElementColumnName(TStreamerElement* elem, TSQLFile*
    case kColTString: {
       colname = elem->GetName();
       if (f->GetUseSuffixes())
-         colname+=sqlio::StrSuffix;
+         colname += sqlio::StrSuffix;
       break;
    }
 
@@ -2138,27 +2134,28 @@ TString TSQLStructure::DefineElementColumnName(TStreamerElement* elem, TSQLFile*
 ////////////////////////////////////////////////////////////////////////////////
 /// find column in TSQLObjectData object, which correspond to current element
 
-Int_t TSQLStructure::LocateElementColumn(TSQLFile* f, TBufferSQL2* buf, TSQLObjectData* data)
+Int_t TSQLStructure::LocateElementColumn(TSQLFile *f, TBufferSQL2 *buf, TSQLObjectData *data)
 {
-   TStreamerElement* elem = GetElement();
-   if ((elem==0) || (data==0)) return kColUnknown;
+   TStreamerElement *elem = GetElement();
+   if ((elem == 0) || (data == 0))
+      return kColUnknown;
 
    Int_t coltype = DefineElementColumnType(elem, f);
 
-   if (gDebug>4)
-      std::cout <<"TSQLStructure::LocateElementColumn " << elem->GetName() <<
-         " coltyp = " << coltype << " : " << elem->GetType() << " len = " << elem->GetArrayLength() << std::endl;
+   if (gDebug > 4)
+      std::cout << "TSQLStructure::LocateElementColumn " << elem->GetName() << " coltyp = " << coltype << " : "
+                << elem->GetType() << " len = " << elem->GetArrayLength() << std::endl;
 
-   if (coltype==kColUnknown) return kColUnknown;
+   if (coltype == kColUnknown)
+      return kColUnknown;
 
-   const char* elemname = elem->GetName();
+   const char *elemname = elem->GetName();
    Bool_t located = kFALSE;
 
    TString colname = DefineElementColumnName(elem, f);
 
-   if (gDebug>4)
-      std::cout << "         colname = " << colname << " in " <<
-            data->GetInfo()->GetClassTableName() << std::endl;
+   if (gDebug > 4)
+      std::cout << "         colname = " << colname << " in " << data->GetInfo()->GetClassTableName() << std::endl;
 
    switch (coltype) {
    case kColSimple: {
@@ -2173,74 +2170,84 @@ Int_t TSQLStructure::LocateElementColumn(TSQLFile* f, TBufferSQL2* buf, TSQLObje
 
    case kColParent: {
       located = data->LocateColumn(colname.Data());
-      if (located==kColUnknown) return kColUnknown;
+      if (located == kColUnknown)
+         return kColUnknown;
 
       Long64_t objid = DefineObjectId(kTRUE);
-      const char* clname = elemname;
+      const char *clname = elemname;
       Version_t version = atoi(data->GetValue());
 
       // this is a case, when parent store nothing in the database
-      if (version<0) break;
+      if (version < 0)
+         break;
 
       // special treatment for TObject
-      if (strcmp(clname,TObject::Class()->GetName())==0) {
+      if (strcmp(clname, TObject::Class()->GetName()) == 0) {
          UnpackTObject(f, buf, data, objid, version);
          break;
       }
 
-      TSQLClassInfo* sqlinfo = f->FindSQLClassInfo(clname, version);
-      if (sqlinfo==0) return kColUnknown;
+      TSQLClassInfo *sqlinfo = f->FindSQLClassInfo(clname, version);
+      if (sqlinfo == 0)
+         return kColUnknown;
 
       // this will indicate that streamer is completely custom
       if (sqlinfo->IsClassTableExist()) {
          data->AddUnpackInt(sqlio::Version, version);
       } else {
-         TSQLObjectData* objdata = buf->SqlObjectData(objid, sqlinfo);
-         if ((objdata==0) || !objdata->PrepareForRawData()) return kColUnknown;
+         TSQLObjectData *objdata = buf->SqlObjectData(objid, sqlinfo);
+         if ((objdata == 0) || !objdata->PrepareForRawData())
+            return kColUnknown;
          AddObjectData(objdata);
       }
 
       break;
    }
 
-      // This is a case when streamer of object will be called directly.
-      // Typically it happens when object is data memeber of the class.
-      // Here we need to define class of object and if it was written by
-      // normal streamer (via TStreamerInfo methods) or directly as blob.
-      // When blob was used, blob data should be readed.
-      // In normal case only version is required. Other object data will be
-      // read by TBufferSQL2::IncrementLevel method
+   // This is a case when streamer of object will be called directly.
+   // Typically it happens when object is data member of the class.
+   // Here we need to define class of object and if it was written by
+   // normal streamer (via TStreamerInfo methods) or directly as blob.
+   // When blob was used, blob data should be read.
+   // In normal case only version is required. Other object data will be
+   // read by TBufferSQL2::IncrementLevel method
    case kColObject: {
       located = data->LocateColumn(colname.Data());
-      if (located==kColUnknown) return located;
+      if (located == kColUnknown)
+         return located;
 
-      const char* strobjid = data->GetValue();
-      if (strobjid==0) return kColUnknown;
+      const char *strobjid = data->GetValue();
+      if (strobjid == 0)
+         return kColUnknown;
 
       Long64_t objid = sqlio::atol64(strobjid);
 
       // when nothing was stored, nothing need to be read. skip
-      if (objid<0) break;
+      if (objid < 0)
+         break;
 
       TString clname;
       Version_t version;
 
-      if (!buf->SqlObjectInfo(objid, clname, version)) return kColUnknown;
+      if (!buf->SqlObjectInfo(objid, clname, version))
+         return kColUnknown;
 
       // special treatment for TObject
-      if (clname==TObject::Class()->GetName()) {
+      if (clname == TObject::Class()->GetName()) {
          UnpackTObject(f, buf, data, objid, version);
          break;
       }
 
-      TSQLClassInfo* sqlinfo = f->FindSQLClassInfo(clname.Data(), version);
-      if (sqlinfo==0) return kColUnknown;
+      TSQLClassInfo *sqlinfo = f->FindSQLClassInfo(clname.Data(), version);
+      if (sqlinfo == 0)
+         return kColUnknown;
 
       if (sqlinfo->IsClassTableExist()) {
          data->AddUnpackInt(sqlio::Version, version);
       } else {
-         TSQLObjectData* objdata = buf->SqlObjectData(objid, sqlinfo);
-         if ((objdata==0) || !objdata->PrepareForRawData()) return kColUnknown;
+         TSQLObjectData *objdata = buf->SqlObjectData(objid, sqlinfo);
+         if ((objdata == 0) || !objdata->PrepareForRawData())
+            return kColUnknown;
          AddObjectData(objdata);
       }
 
@@ -2250,10 +2257,10 @@ Int_t TSQLStructure::LocateElementColumn(TSQLFile* f, TBufferSQL2* buf, TSQLObje
       break;
    }
 
-      // this is case of pointer on any object
-      // field contains objectid.
-      // Object id, class of object and so on will be checked
-      // when TBuffer::ReadObject method will be called
+   // this is case of pointer on any object
+   // field contains objectid.
+   // Object id, class of object and so on will be checked
+   // when TBuffer::ReadObject method will be called
    case kColObjectPtr: {
       located = data->LocateColumn(colname.Data());
       break;
@@ -2275,8 +2282,9 @@ Int_t TSQLStructure::LocateElementColumn(TSQLFile* f, TBufferSQL2* buf, TSQLObje
 
    case kColTString: {
       located = data->LocateColumn(colname);
-      if (located==kColUnknown) return located;
-      const char* value = data->GetValue();
+      if (located == kColUnknown)
+         return located;
+      const char *value = data->GetValue();
 
       Long64_t objid = DefineObjectId(kTRUE);
       Int_t strid = f->IsLongStringCode(objid, value);
@@ -2284,18 +2292,18 @@ Int_t TSQLStructure::LocateElementColumn(TSQLFile* f, TBufferSQL2* buf, TSQLObje
       TString buf2;
 
       // if special prefix found, than try get such string
-      if (strid>0)
+      if (strid > 0)
          if (f->GetLongString(objid, strid, buf2))
             value = buf2.Data();
 
-      Int_t len = (value==0) ? 0 : strlen(value);
-      if (len<255) {
+      Int_t len = (value == 0) ? 0 : strlen(value);
+      if (len < 255) {
          data->AddUnpackInt(sqlio::UChar, len);
       } else {
          data->AddUnpackInt(sqlio::UChar, 255);
          data->AddUnpackInt(sqlio::Int, len);
       }
-      if (len>0)
+      if (len > 0)
          data->AddUnpack(sqlio::CharStar, value);
       break;
    }
@@ -2311,21 +2319,25 @@ Int_t TSQLStructure::LocateElementColumn(TSQLFile* f, TBufferSQL2* buf, TSQLObje
    }
    }
 
-   if (!located) coltype = kColUnknown;
+   if (!located)
+      coltype = kColUnknown;
 
    return coltype;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Unpack TObject data in form, understodable by custom TObject streamer
+/// Unpack TObject data in form, accepted by custom TObject streamer
 
-Bool_t TSQLStructure::UnpackTObject(TSQLFile* f, TBufferSQL2* buf, TSQLObjectData* data, Long64_t objid, Int_t clversion)
+Bool_t
+TSQLStructure::UnpackTObject(TSQLFile *f, TBufferSQL2 *buf, TSQLObjectData *data, Long64_t objid, Int_t clversion)
 {
-   TSQLClassInfo* sqlinfo = f->FindSQLClassInfo(TObject::Class()->GetName(), clversion);
-   if (sqlinfo==0) return kFALSE;
+   TSQLClassInfo *sqlinfo = f->FindSQLClassInfo(TObject::Class()->GetName(), clversion);
+   if (sqlinfo == 0)
+      return kFALSE;
 
-   TSQLObjectData* tobjdata = buf->SqlObjectData(objid, sqlinfo);
-   if (tobjdata==0) return kFALSE;
+   TSQLObjectData *tobjdata = buf->SqlObjectData(objid, sqlinfo);
+   if (tobjdata == 0)
+      return kFALSE;
 
    data->AddUnpackInt(sqlio::Version, clversion);
 
@@ -2338,8 +2350,8 @@ Bool_t TSQLStructure::UnpackTObject(TSQLFile* f, TBufferSQL2* buf, TSQLObjectDat
    tobjdata->ShiftToNextValue();
 
    tobjdata->LocateColumn(sqlio::TObjectProcessId);
-   const char* value = tobjdata->GetValue();
-   if ((value!=0) && (strlen(value)>0))
+   const char *value = tobjdata->GetValue();
+   if ((value != 0) && (strlen(value) > 0))
       data->AddUnpack(sqlio::UShort, value);
 
    delete tobjdata;
@@ -2348,28 +2360,31 @@ Bool_t TSQLStructure::UnpackTObject(TSQLFile* f, TBufferSQL2* buf, TSQLObjectDat
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Unpack TString data in form, understodable by custom TString streamer
+/// Unpack TString data in form, accepted by custom TString streamer
 
-Bool_t TSQLStructure::UnpackTString(TSQLFile* f, TBufferSQL2* buf, TSQLObjectData* data, Long64_t objid, Int_t clversion)
+Bool_t
+TSQLStructure::UnpackTString(TSQLFile *f, TBufferSQL2 *buf, TSQLObjectData *data, Long64_t objid, Int_t clversion)
 {
-   TSQLClassInfo* sqlinfo = f->FindSQLClassInfo(TString::Class()->GetName(), clversion);
-   if (sqlinfo==0) return kFALSE;
+   TSQLClassInfo *sqlinfo = f->FindSQLClassInfo(TString::Class()->GetName(), clversion);
+   if (sqlinfo == 0)
+      return kFALSE;
 
-   TSQLObjectData* tstringdata = buf->SqlObjectData(objid, sqlinfo);
-   if (tstringdata==0) return kFALSE;
+   TSQLObjectData *tstringdata = buf->SqlObjectData(objid, sqlinfo);
+   if (tstringdata == 0)
+      return kFALSE;
 
    tstringdata->LocateColumn(sqlio::TStringValue);
 
-   const char* value = tstringdata->GetValue();
+   const char *value = tstringdata->GetValue();
 
-   Int_t len = (value==0) ? 0 : strlen(value);
-   if (len<255) {
+   Int_t len = (value == 0) ? 0 : strlen(value);
+   if (len < 255) {
       data->AddUnpackInt(sqlio::UChar, len);
    } else {
       data->AddUnpackInt(sqlio::UChar, 255);
       data->AddUnpackInt(sqlio::Int, len);
    }
-   if (len>0)
+   if (len > 0)
       data->AddUnpack(sqlio::CharStar, value);
 
    delete tstringdata;
@@ -2378,12 +2393,14 @@ Bool_t TSQLStructure::UnpackTString(TSQLFile* f, TBufferSQL2* buf, TSQLObjectDat
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// adds quotes arround string value and replaces some special symbols
+/// adds quotes around string value and replaces some special symbols
 
-void TSQLStructure::AddStrBrackets(TString &s, const char* quote)
+void TSQLStructure::AddStrBrackets(TString &s, const char *quote)
 {
-   if (strcmp(quote,"\"")==0) s.ReplaceAll("\"","\\\"");
-                        else  s.ReplaceAll("'","''");
+   if (strcmp(quote, "\"") == 0)
+      s.ReplaceAll("\"", "\\\"");
+   else
+      s.ReplaceAll("'", "''");
    s.Prepend(quote);
    s.Append(quote);
 }

--- a/io/xml/inc/TBufferXML.h
+++ b/io/xml/inc/TBufferXML.h
@@ -20,7 +20,6 @@
 
 #include <string>
 
-
 class TExMap;
 class TVirtualStreamerInfo;
 class TStreamerInfo;
@@ -30,257 +29,261 @@ class TMemberStreamer;
 class TXMLFile;
 class TXMLStackObj;
 
-
 class TBufferXML : public TBufferFile, public TXMLSetup {
 
-friend class TKeyXML;
+   friend class TKeyXML;
 
 public:
-
    TBufferXML(TBuffer::EMode mode);
-   TBufferXML(TBuffer::EMode mode, TXMLFile* file);
+   TBufferXML(TBuffer::EMode mode, TXMLFile *file);
    virtual ~TBufferXML();
 
-   static TString   ConvertToXML(const TObject* obj, Bool_t GenericLayout = kFALSE, Bool_t UseNamespaces = kFALSE);
-   static TString   ConvertToXML(const void* obj, const TClass* cl, Bool_t GenericLayout = kFALSE, Bool_t UseNamespaces = kFALSE);
+   static TString ConvertToXML(const TObject *obj, Bool_t GenericLayout = kFALSE, Bool_t UseNamespaces = kFALSE);
+   static TString
+   ConvertToXML(const void *obj, const TClass *cl, Bool_t GenericLayout = kFALSE, Bool_t UseNamespaces = kFALSE);
 
-   static TObject*  ConvertFromXML(const char* str, Bool_t GenericLayout = kFALSE, Bool_t UseNamespaces = kFALSE);
-   static void*     ConvertFromXMLAny(const char* str, TClass** cl = 0, Bool_t GenericLayout = kFALSE, Bool_t UseNamespaces = kFALSE);
+   static TObject *ConvertFromXML(const char *str, Bool_t GenericLayout = kFALSE, Bool_t UseNamespaces = kFALSE);
+   static void *
+   ConvertFromXMLAny(const char *str, TClass **cl = 0, Bool_t GenericLayout = kFALSE, Bool_t UseNamespaces = kFALSE);
 
-   Int_t             GetIOVersion() const { return fIOVersion; }
-   void              SetIOVersion(Int_t v) { fIOVersion = v; }
+   Int_t GetIOVersion() const { return fIOVersion; }
+   void SetIOVersion(Int_t v) { fIOVersion = v; }
 
    // suppress class writing/reading
 
-   virtual TClass*  ReadClass(const TClass* cl = 0, UInt_t* objTag = 0);
-   virtual void     WriteClass(const TClass* cl);
+   virtual TClass *ReadClass(const TClass *cl = 0, UInt_t *objTag = 0);
+   virtual void WriteClass(const TClass *cl);
 
    // redefined virtual functions of TBuffer
 
-   virtual Int_t    CheckByteCount(UInt_t startpos, UInt_t bcnt, const TClass *clss); // SL
-   virtual Int_t    CheckByteCount(UInt_t startpos, UInt_t bcnt, const char *classname); // SL
-   virtual void     SetByteCount(UInt_t cntpos, Bool_t packInVersion = kFALSE);  // SL
+   virtual Int_t CheckByteCount(UInt_t startpos, UInt_t bcnt, const TClass *clss);    // SL
+   virtual Int_t CheckByteCount(UInt_t startpos, UInt_t bcnt, const char *classname); // SL
+   virtual void SetByteCount(UInt_t cntpos, Bool_t packInVersion = kFALSE);           // SL
 
-   virtual void      SkipVersion(const TClass *cl = 0);
-   virtual Version_t ReadVersion(UInt_t *start = 0, UInt_t *bcnt = 0, const TClass *cl = 0);  // SL
-   virtual UInt_t    WriteVersion(const TClass *cl, Bool_t useBcnt = kFALSE);  // SL
+   virtual void SkipVersion(const TClass *cl = 0);
+   virtual Version_t ReadVersion(UInt_t *start = 0, UInt_t *bcnt = 0, const TClass *cl = 0); // SL
+   virtual UInt_t WriteVersion(const TClass *cl, Bool_t useBcnt = kFALSE);                   // SL
 
-   virtual void*    ReadObjectAny(const TClass* clCast);
-   virtual void     SkipObjectAny();
+   virtual void *ReadObjectAny(const TClass *clCast);
+   virtual void SkipObjectAny();
 
-   virtual void     IncrementLevel(TVirtualStreamerInfo*);
-   virtual void     SetStreamerElementNumber(TStreamerElement *elem, Int_t comp_type);
-   virtual void     DecrementLevel(TVirtualStreamerInfo*);
+   virtual void IncrementLevel(TVirtualStreamerInfo *);
+   virtual void SetStreamerElementNumber(TStreamerElement *elem, Int_t comp_type);
+   virtual void DecrementLevel(TVirtualStreamerInfo *);
 
-   virtual void     ClassBegin(const TClass*, Version_t = -1);
-   virtual void     ClassEnd(const TClass*);
-   virtual void     ClassMember(const char* name, const char* typeName = 0, Int_t arrsize1 = -1, Int_t arrsize2 = -1);
+   virtual void ClassBegin(const TClass *, Version_t = -1);
+   virtual void ClassEnd(const TClass *);
+   virtual void ClassMember(const char *name, const char *typeName = 0, Int_t arrsize1 = -1, Int_t arrsize2 = -1);
 
-   virtual void     WriteObject(const TObject *obj);
+   virtual void WriteObject(const TObject *obj);
 
-   virtual void     ReadFloat16 (Float_t *f, TStreamerElement *ele=0);
-   virtual void     WriteFloat16(Float_t *f, TStreamerElement *ele=0);
-   virtual void     ReadDouble32 (Double_t *d, TStreamerElement *ele=0);
-   virtual void     WriteDouble32(Double_t *d, TStreamerElement *ele=0);
-   virtual void     ReadWithFactor(Float_t *ptr, Double_t factor, Double_t minvalue);
-   virtual void     ReadWithNbits(Float_t *ptr, Int_t nbits);
-   virtual void     ReadWithFactor(Double_t *ptr, Double_t factor, Double_t minvalue);
-   virtual void     ReadWithNbits(Double_t *ptr, Int_t nbits);
+   virtual void ReadFloat16(Float_t *f, TStreamerElement *ele = 0);
+   virtual void WriteFloat16(Float_t *f, TStreamerElement *ele = 0);
+   virtual void ReadDouble32(Double_t *d, TStreamerElement *ele = 0);
+   virtual void WriteDouble32(Double_t *d, TStreamerElement *ele = 0);
+   virtual void ReadWithFactor(Float_t *ptr, Double_t factor, Double_t minvalue);
+   virtual void ReadWithNbits(Float_t *ptr, Int_t nbits);
+   virtual void ReadWithFactor(Double_t *ptr, Double_t factor, Double_t minvalue);
+   virtual void ReadWithNbits(Double_t *ptr, Int_t nbits);
 
-   virtual Int_t    ReadArray(Bool_t    *&b);
-   virtual Int_t    ReadArray(Char_t    *&c);
-   virtual Int_t    ReadArray(UChar_t   *&c);
-   virtual Int_t    ReadArray(Short_t   *&h);
-   virtual Int_t    ReadArray(UShort_t  *&h);
-   virtual Int_t    ReadArray(Int_t     *&i);
-   virtual Int_t    ReadArray(UInt_t    *&i);
-   virtual Int_t    ReadArray(Long_t    *&l);
-   virtual Int_t    ReadArray(ULong_t   *&l);
-   virtual Int_t    ReadArray(Long64_t  *&l);
-   virtual Int_t    ReadArray(ULong64_t *&l);
-   virtual Int_t    ReadArray(Float_t   *&f);
-   virtual Int_t    ReadArray(Double_t  *&d);
-   virtual Int_t    ReadArrayFloat16(Float_t  *&f, TStreamerElement *ele=0);
-   virtual Int_t    ReadArrayDouble32(Double_t  *&d, TStreamerElement *ele=0);
+   virtual Int_t ReadArray(Bool_t *&b);
+   virtual Int_t ReadArray(Char_t *&c);
+   virtual Int_t ReadArray(UChar_t *&c);
+   virtual Int_t ReadArray(Short_t *&h);
+   virtual Int_t ReadArray(UShort_t *&h);
+   virtual Int_t ReadArray(Int_t *&i);
+   virtual Int_t ReadArray(UInt_t *&i);
+   virtual Int_t ReadArray(Long_t *&l);
+   virtual Int_t ReadArray(ULong_t *&l);
+   virtual Int_t ReadArray(Long64_t *&l);
+   virtual Int_t ReadArray(ULong64_t *&l);
+   virtual Int_t ReadArray(Float_t *&f);
+   virtual Int_t ReadArray(Double_t *&d);
+   virtual Int_t ReadArrayFloat16(Float_t *&f, TStreamerElement *ele = 0);
+   virtual Int_t ReadArrayDouble32(Double_t *&d, TStreamerElement *ele = 0);
 
-   virtual Int_t    ReadStaticArray(Bool_t    *b);
-   virtual Int_t    ReadStaticArray(Char_t    *c);
-   virtual Int_t    ReadStaticArray(UChar_t   *c);
-   virtual Int_t    ReadStaticArray(Short_t   *h);
-   virtual Int_t    ReadStaticArray(UShort_t  *h);
-   virtual Int_t    ReadStaticArray(Int_t     *i);
-   virtual Int_t    ReadStaticArray(UInt_t    *i);
-   virtual Int_t    ReadStaticArray(Long_t    *l);
-   virtual Int_t    ReadStaticArray(ULong_t   *l);
-   virtual Int_t    ReadStaticArray(Long64_t  *l);
-   virtual Int_t    ReadStaticArray(ULong64_t *l);
-   virtual Int_t    ReadStaticArray(Float_t   *f);
-   virtual Int_t    ReadStaticArray(Double_t  *d);
-   virtual Int_t    ReadStaticArrayFloat16(Float_t  *f, TStreamerElement *ele=0);
-   virtual Int_t    ReadStaticArrayDouble32(Double_t  *d, TStreamerElement *ele=0);
+   virtual Int_t ReadStaticArray(Bool_t *b);
+   virtual Int_t ReadStaticArray(Char_t *c);
+   virtual Int_t ReadStaticArray(UChar_t *c);
+   virtual Int_t ReadStaticArray(Short_t *h);
+   virtual Int_t ReadStaticArray(UShort_t *h);
+   virtual Int_t ReadStaticArray(Int_t *i);
+   virtual Int_t ReadStaticArray(UInt_t *i);
+   virtual Int_t ReadStaticArray(Long_t *l);
+   virtual Int_t ReadStaticArray(ULong_t *l);
+   virtual Int_t ReadStaticArray(Long64_t *l);
+   virtual Int_t ReadStaticArray(ULong64_t *l);
+   virtual Int_t ReadStaticArray(Float_t *f);
+   virtual Int_t ReadStaticArray(Double_t *d);
+   virtual Int_t ReadStaticArrayFloat16(Float_t *f, TStreamerElement *ele = 0);
+   virtual Int_t ReadStaticArrayDouble32(Double_t *d, TStreamerElement *ele = 0);
 
-   virtual void     ReadFastArray(Bool_t    *b, Int_t n);
-   virtual void     ReadFastArray(Char_t    *c, Int_t n);
-   virtual void     ReadFastArray(UChar_t   *c, Int_t n);
-   virtual void     ReadFastArray(Short_t   *h, Int_t n);
-   virtual void     ReadFastArray(UShort_t  *h, Int_t n);
-   virtual void     ReadFastArray(Int_t     *i, Int_t n);
-   virtual void     ReadFastArray(UInt_t    *i, Int_t n);
-   virtual void     ReadFastArray(Long_t    *l, Int_t n);
-   virtual void     ReadFastArray(ULong_t   *l, Int_t n);
-   virtual void     ReadFastArray(Long64_t  *l, Int_t n);
-   virtual void     ReadFastArray(ULong64_t *l, Int_t n);
-   virtual void     ReadFastArray(Float_t   *f, Int_t n);
-   virtual void     ReadFastArray(Double_t  *d, Int_t n);
-   virtual void     ReadFastArrayFloat16(Float_t  *f, Int_t n, TStreamerElement *ele=0);
-   virtual void     ReadFastArrayDouble32(Double_t  *d, Int_t n, TStreamerElement *ele=0);
-   virtual void     ReadFastArrayWithFactor(Float_t *ptr, Int_t n, Double_t factor, Double_t minvalue) ;
-   virtual void     ReadFastArrayWithNbits(Float_t *ptr, Int_t n, Int_t nbits);
-   virtual void     ReadFastArrayWithFactor(Double_t *ptr, Int_t n, Double_t factor, Double_t minvalue);
-   virtual void     ReadFastArrayWithNbits(Double_t *ptr, Int_t n, Int_t nbits) ;
+   virtual void ReadFastArray(Bool_t *b, Int_t n);
+   virtual void ReadFastArray(Char_t *c, Int_t n);
+   virtual void ReadFastArray(UChar_t *c, Int_t n);
+   virtual void ReadFastArray(Short_t *h, Int_t n);
+   virtual void ReadFastArray(UShort_t *h, Int_t n);
+   virtual void ReadFastArray(Int_t *i, Int_t n);
+   virtual void ReadFastArray(UInt_t *i, Int_t n);
+   virtual void ReadFastArray(Long_t *l, Int_t n);
+   virtual void ReadFastArray(ULong_t *l, Int_t n);
+   virtual void ReadFastArray(Long64_t *l, Int_t n);
+   virtual void ReadFastArray(ULong64_t *l, Int_t n);
+   virtual void ReadFastArray(Float_t *f, Int_t n);
+   virtual void ReadFastArray(Double_t *d, Int_t n);
+   virtual void ReadFastArrayFloat16(Float_t *f, Int_t n, TStreamerElement *ele = 0);
+   virtual void ReadFastArrayDouble32(Double_t *d, Int_t n, TStreamerElement *ele = 0);
+   virtual void ReadFastArrayWithFactor(Float_t *ptr, Int_t n, Double_t factor, Double_t minvalue);
+   virtual void ReadFastArrayWithNbits(Float_t *ptr, Int_t n, Int_t nbits);
+   virtual void ReadFastArrayWithFactor(Double_t *ptr, Int_t n, Double_t factor, Double_t minvalue);
+   virtual void ReadFastArrayWithNbits(Double_t *ptr, Int_t n, Int_t nbits);
 
-   virtual void     WriteArray(const Bool_t    *b, Int_t n);
-   virtual void     WriteArray(const Char_t    *c, Int_t n);
-   virtual void     WriteArray(const UChar_t   *c, Int_t n);
-   virtual void     WriteArray(const Short_t   *h, Int_t n);
-   virtual void     WriteArray(const UShort_t  *h, Int_t n);
-   virtual void     WriteArray(const Int_t     *i, Int_t n);
-   virtual void     WriteArray(const UInt_t    *i, Int_t n);
-   virtual void     WriteArray(const Long_t    *l, Int_t n);
-   virtual void     WriteArray(const ULong_t   *l, Int_t n);
-   virtual void     WriteArray(const Long64_t  *l, Int_t n);
-   virtual void     WriteArray(const ULong64_t *l, Int_t n);
-   virtual void     WriteArray(const Float_t   *f, Int_t n);
-   virtual void     WriteArray(const Double_t  *d, Int_t n);
-   virtual void     WriteArrayFloat16(const Float_t  *f, Int_t n, TStreamerElement *ele=0);
-   virtual void     WriteArrayDouble32(const Double_t  *d, Int_t n, TStreamerElement *ele=0);
-   virtual void     ReadFastArray(void  *start , const TClass *cl, Int_t n=1, TMemberStreamer *s=0, const TClass* onFileClass = 0);
-   virtual void     ReadFastArray(void **startp, const TClass *cl, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s=0, const TClass* onFileClass = 0);
+   virtual void WriteArray(const Bool_t *b, Int_t n);
+   virtual void WriteArray(const Char_t *c, Int_t n);
+   virtual void WriteArray(const UChar_t *c, Int_t n);
+   virtual void WriteArray(const Short_t *h, Int_t n);
+   virtual void WriteArray(const UShort_t *h, Int_t n);
+   virtual void WriteArray(const Int_t *i, Int_t n);
+   virtual void WriteArray(const UInt_t *i, Int_t n);
+   virtual void WriteArray(const Long_t *l, Int_t n);
+   virtual void WriteArray(const ULong_t *l, Int_t n);
+   virtual void WriteArray(const Long64_t *l, Int_t n);
+   virtual void WriteArray(const ULong64_t *l, Int_t n);
+   virtual void WriteArray(const Float_t *f, Int_t n);
+   virtual void WriteArray(const Double_t *d, Int_t n);
+   virtual void WriteArrayFloat16(const Float_t *f, Int_t n, TStreamerElement *ele = 0);
+   virtual void WriteArrayDouble32(const Double_t *d, Int_t n, TStreamerElement *ele = 0);
+   virtual void
+   ReadFastArray(void *start, const TClass *cl, Int_t n = 1, TMemberStreamer *s = 0, const TClass *onFileClass = 0);
+   virtual void ReadFastArray(void **startp, const TClass *cl, Int_t n = 1, Bool_t isPreAlloc = kFALSE,
+                              TMemberStreamer *s = 0, const TClass *onFileClass = 0);
 
-   virtual void     WriteFastArray(const Bool_t    *b, Int_t n);
-   virtual void     WriteFastArray(const Char_t    *c, Int_t n);
-   virtual void     WriteFastArray(const UChar_t   *c, Int_t n);
-   virtual void     WriteFastArray(const Short_t   *h, Int_t n);
-   virtual void     WriteFastArray(const UShort_t  *h, Int_t n);
-   virtual void     WriteFastArray(const Int_t     *i, Int_t n);
-   virtual void     WriteFastArray(const UInt_t    *i, Int_t n);
-   virtual void     WriteFastArray(const Long_t    *l, Int_t n);
-   virtual void     WriteFastArray(const ULong_t   *l, Int_t n);
-   virtual void     WriteFastArray(const Long64_t  *l, Int_t n);
-   virtual void     WriteFastArray(const ULong64_t *l, Int_t n);
-   virtual void     WriteFastArray(const Float_t   *f, Int_t n);
-   virtual void     WriteFastArray(const Double_t  *d, Int_t n);
-   virtual void     WriteFastArrayFloat16(const Float_t  *d, Int_t n, TStreamerElement *ele=0);
-   virtual void     WriteFastArrayDouble32(const Double_t  *d, Int_t n, TStreamerElement *ele=0);
-   virtual void     WriteFastArray(void  *start,  const TClass *cl, Int_t n=1, TMemberStreamer *s=0);
-   virtual Int_t    WriteFastArray(void **startp, const TClass *cl, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s=0);
+   virtual void WriteFastArray(const Bool_t *b, Int_t n);
+   virtual void WriteFastArray(const Char_t *c, Int_t n);
+   virtual void WriteFastArray(const UChar_t *c, Int_t n);
+   virtual void WriteFastArray(const Short_t *h, Int_t n);
+   virtual void WriteFastArray(const UShort_t *h, Int_t n);
+   virtual void WriteFastArray(const Int_t *i, Int_t n);
+   virtual void WriteFastArray(const UInt_t *i, Int_t n);
+   virtual void WriteFastArray(const Long_t *l, Int_t n);
+   virtual void WriteFastArray(const ULong_t *l, Int_t n);
+   virtual void WriteFastArray(const Long64_t *l, Int_t n);
+   virtual void WriteFastArray(const ULong64_t *l, Int_t n);
+   virtual void WriteFastArray(const Float_t *f, Int_t n);
+   virtual void WriteFastArray(const Double_t *d, Int_t n);
+   virtual void WriteFastArrayFloat16(const Float_t *d, Int_t n, TStreamerElement *ele = 0);
+   virtual void WriteFastArrayDouble32(const Double_t *d, Int_t n, TStreamerElement *ele = 0);
+   virtual void WriteFastArray(void *start, const TClass *cl, Int_t n = 1, TMemberStreamer *s = 0);
+   virtual Int_t
+   WriteFastArray(void **startp, const TClass *cl, Int_t n = 1, Bool_t isPreAlloc = kFALSE, TMemberStreamer *s = 0);
 
-   virtual void     StreamObject(void *obj, const std::type_info &typeinfo, const TClass* onFileClass = 0);
-   virtual void     StreamObject(void *obj, const char *className, const TClass* onFileClass = 0 );
-   virtual void     StreamObject(void *obj, const TClass *cl, const TClass* onFileClass = 0 );
-   virtual void     StreamObject(TObject *obj);
+   virtual void StreamObject(void *obj, const std::type_info &typeinfo, const TClass *onFileClass = 0);
+   virtual void StreamObject(void *obj, const char *className, const TClass *onFileClass = 0);
+   virtual void StreamObject(void *obj, const TClass *cl, const TClass *onFileClass = 0);
+   virtual void StreamObject(TObject *obj);
 
-   virtual   void     ReadBool(Bool_t       &b);
-   virtual   void     ReadChar(Char_t       &c);
-   virtual   void     ReadUChar(UChar_t     &c);
-   virtual   void     ReadShort(Short_t     &s);
-   virtual   void     ReadUShort(UShort_t   &s);
-   virtual   void     ReadInt(Int_t         &i);
-   virtual   void     ReadUInt(UInt_t       &i);
-   virtual   void     ReadLong(Long_t       &l);
-   virtual   void     ReadULong(ULong_t     &l);
-   virtual   void     ReadLong64(Long64_t   &l);
-   virtual   void     ReadULong64(ULong64_t &l);
-   virtual   void     ReadFloat(Float_t     &f);
-   virtual   void     ReadDouble(Double_t   &d);
-   virtual   void     ReadCharP(Char_t      *c);
-   virtual   void     ReadTString(TString   &s);
-   virtual   void     ReadStdString(std::string *s);
-   using              TBuffer::ReadStdString;
-   virtual   void     ReadCharStar(char* &s);
+   virtual void ReadBool(Bool_t &b);
+   virtual void ReadChar(Char_t &c);
+   virtual void ReadUChar(UChar_t &c);
+   virtual void ReadShort(Short_t &s);
+   virtual void ReadUShort(UShort_t &s);
+   virtual void ReadInt(Int_t &i);
+   virtual void ReadUInt(UInt_t &i);
+   virtual void ReadLong(Long_t &l);
+   virtual void ReadULong(ULong_t &l);
+   virtual void ReadLong64(Long64_t &l);
+   virtual void ReadULong64(ULong64_t &l);
+   virtual void ReadFloat(Float_t &f);
+   virtual void ReadDouble(Double_t &d);
+   virtual void ReadCharP(Char_t *c);
+   virtual void ReadTString(TString &s);
+   virtual void ReadStdString(std::string *s);
+   using TBuffer::ReadStdString;
+   virtual void ReadCharStar(char *&s);
 
-   virtual   void     WriteBool(Bool_t       b);
-   virtual   void     WriteChar(Char_t       c);
-   virtual   void     WriteUChar(UChar_t     c);
-   virtual   void     WriteShort(Short_t     s);
-   virtual   void     WriteUShort(UShort_t   s);
-   virtual   void     WriteInt(Int_t         i);
-   virtual   void     WriteUInt(UInt_t       i);
-   virtual   void     WriteLong(Long_t       l);
-   virtual   void     WriteULong(ULong_t     l);
-   virtual   void     WriteLong64(Long64_t   l);
-   virtual   void     WriteULong64(ULong64_t l);
-   virtual   void     WriteFloat(Float_t     f);
-   virtual   void     WriteDouble(Double_t   d);
-   virtual   void     WriteCharP(const Char_t *c);
-   virtual   void     WriteTString(const TString  &s);
-   virtual   void     WriteStdString(const std::string *s);
-   using              TBuffer::WriteStdString;
-   virtual   void     WriteCharStar(char *s);
+   virtual void WriteBool(Bool_t b);
+   virtual void WriteChar(Char_t c);
+   virtual void WriteUChar(UChar_t c);
+   virtual void WriteShort(Short_t s);
+   virtual void WriteUShort(UShort_t s);
+   virtual void WriteInt(Int_t i);
+   virtual void WriteUInt(UInt_t i);
+   virtual void WriteLong(Long_t l);
+   virtual void WriteULong(ULong_t l);
+   virtual void WriteLong64(Long64_t l);
+   virtual void WriteULong64(ULong64_t l);
+   virtual void WriteFloat(Float_t f);
+   virtual void WriteDouble(Double_t d);
+   virtual void WriteCharP(const Char_t *c);
+   virtual void WriteTString(const TString &s);
+   virtual void WriteStdString(const std::string *s);
+   using TBuffer::WriteStdString;
+   virtual void WriteCharStar(char *s);
 
    virtual Int_t ApplySequence(const TStreamerInfoActions::TActionSequence &sequence, void *object);
-   virtual Int_t ApplySequenceVecPtr(const TStreamerInfoActions::TActionSequence &sequence, void *start_collection, void *end_collection);
-   virtual Int_t ApplySequence(const TStreamerInfoActions::TActionSequence &sequence, void *start_collection, void *end_collection);
+   virtual Int_t ApplySequenceVecPtr(const TStreamerInfoActions::TActionSequence &sequence, void *start_collection,
+                                     void *end_collection);
+   virtual Int_t
+   ApplySequence(const TStreamerInfoActions::TActionSequence &sequence, void *start_collection, void *end_collection);
 
    // end of redefined virtual functions
 
-   static    void     SetFloatFormat(const char* fmt = "%e");
-   static const char* GetFloatFormat();
-
+   static void SetFloatFormat(const char *fmt = "%e");
+   static const char *GetFloatFormat();
 
 protected:
    TBufferXML();
 
    // redefined protected virtual functions
 
-   virtual void     WriteObjectClass(const void *actualObjStart, const TClass *actualClass);
+   virtual void WriteObjectClass(const void *actualObjStart, const TClass *actualClass);
 
    // end redefined protected virtual functions
 
-   TXMLFile*        XmlFile();
+   TXMLFile *XmlFile();
 
-   Int_t            GetCompressionAlgorithm() const;
-   Int_t            GetCompressionLevel() const;
-   Int_t            GetCompressionSettings() const;
-   void             SetCompressionAlgorithm(Int_t algorithm=0);
-   void             SetCompressionLevel(Int_t level=1);
-   void             SetCompressionSettings(Int_t settings=1);
-   void             SetXML(TXMLEngine* xml) { fXML = xml; }
+   Int_t GetCompressionAlgorithm() const;
+   Int_t GetCompressionLevel() const;
+   Int_t GetCompressionSettings() const;
+   void SetCompressionAlgorithm(Int_t algorithm = 0);
+   void SetCompressionLevel(Int_t level = 1);
+   void SetCompressionSettings(Int_t settings = 1);
+   void SetXML(TXMLEngine *xml) { fXML = xml; }
 
-   void             XmlWriteBlock(XMLNodePointer_t node);
-   XMLNodePointer_t XmlWriteAny(const void* obj, const TClass* cl);
+   void XmlWriteBlock(XMLNodePointer_t node);
+   XMLNodePointer_t XmlWriteAny(const void *obj, const TClass *cl);
 
-   void             XmlReadBlock(XMLNodePointer_t node);
-   void*            XmlReadAny(XMLNodePointer_t node, void* obj, TClass** cl);
+   void XmlReadBlock(XMLNodePointer_t node);
+   void *XmlReadAny(XMLNodePointer_t node, void *obj, TClass **cl);
 
-   TXMLStackObj*    PushStack(XMLNodePointer_t current, Bool_t simple = kFALSE);
-   TXMLStackObj*    PopStack();
-   void             ShiftStack(const char* info = 0);
+   TXMLStackObj *PushStack(XMLNodePointer_t current, Bool_t simple = kFALSE);
+   TXMLStackObj *PopStack();
+   void ShiftStack(const char *info = 0);
 
    XMLNodePointer_t StackNode();
-   TXMLStackObj*    Stack(Int_t depth = 0);
+   TXMLStackObj *Stack(Int_t depth = 0);
 
-   void             WorkWithClass(TStreamerInfo* info, const TClass* cl = 0);
-   void             WorkWithElement(TStreamerElement* elem, Int_t comp_type);
-   Bool_t           VerifyNode(XMLNodePointer_t node, const char* name, const char* errinfo = 0);
-   Bool_t           VerifyStackNode(const char* name, const char* errinfo = 0);
+   void WorkWithClass(TStreamerInfo *info, const TClass *cl = 0);
+   void WorkWithElement(TStreamerElement *elem, Int_t comp_type);
+   Bool_t VerifyNode(XMLNodePointer_t node, const char *name, const char *errinfo = 0);
+   Bool_t VerifyStackNode(const char *name, const char *errinfo = 0);
 
-   Bool_t           VerifyAttr(XMLNodePointer_t node, const char* name, const char* value, const char* errinfo = 0);
-   Bool_t           VerifyStackAttr(const char* name, const char* value, const char* errinfo = 0);
+   Bool_t VerifyAttr(XMLNodePointer_t node, const char *name, const char *value, const char *errinfo = 0);
+   Bool_t VerifyStackAttr(const char *name, const char *value, const char *errinfo = 0);
 
-   Bool_t           ProcessPointer(const void* ptr, XMLNodePointer_t node);
-   void             RegisterPointer(const void* ptr, XMLNodePointer_t node);
-   Bool_t           ExtractPointer(XMLNodePointer_t node, void* &ptr, TClass* &cl);
-   void             ExtractReference(XMLNodePointer_t node, const void* ptr, const TClass* cl);
+   Bool_t ProcessPointer(const void *ptr, XMLNodePointer_t node);
+   void RegisterPointer(const void *ptr, XMLNodePointer_t node);
+   Bool_t ExtractPointer(XMLNodePointer_t node, void *&ptr, TClass *&cl);
+   void ExtractReference(XMLNodePointer_t node, const void *ptr, const TClass *cl);
 
-   XMLNodePointer_t CreateItemNode(const char* name);
-   Bool_t           VerifyItemNode(const char* name, const char* errinfo = 0);
+   XMLNodePointer_t CreateItemNode(const char *name);
+   Bool_t VerifyItemNode(const char *name, const char *errinfo = 0);
 
-   void             CreateElemNode(const TStreamerElement* elem);
-   Bool_t           VerifyElemNode(const TStreamerElement* elem);
+   void CreateElemNode(const TStreamerElement *elem);
+   Bool_t VerifyElemNode(const TStreamerElement *elem);
 
-   void             PerformPreProcessing(const TStreamerElement* elem, XMLNodePointer_t elemnode);
-   void             PerformPostProcessing();
+   void PerformPreProcessing(const TStreamerElement *elem, XMLNodePointer_t elemnode);
+   void PerformPostProcessing();
 
    XMLNodePointer_t XmlWriteBasic(Char_t value);
    XMLNodePointer_t XmlWriteBasic(Short_t value);
@@ -295,51 +298,52 @@ protected:
    XMLNodePointer_t XmlWriteBasic(UInt_t value);
    XMLNodePointer_t XmlWriteBasic(ULong_t value);
    XMLNodePointer_t XmlWriteBasic(ULong64_t value);
-   XMLNodePointer_t XmlWriteValue(const char* value, const char* name);
+   XMLNodePointer_t XmlWriteValue(const char *value, const char *name);
 
-   void             XmlReadBasic(Char_t& value);
-   void             XmlReadBasic(Short_t& value);
-   void             XmlReadBasic(Int_t& value);
-   void             XmlReadBasic(Long_t& value);
-   void             XmlReadBasic(Long64_t& value);
-   void             XmlReadBasic(Float_t& value);
-   void             XmlReadBasic(Double_t& value);
-   void             XmlReadBasic(Bool_t& value);
-   void             XmlReadBasic(UChar_t& value);
-   void             XmlReadBasic(UShort_t& value);
-   void             XmlReadBasic(UInt_t& value);
-   void             XmlReadBasic(ULong_t& value);
-   void             XmlReadBasic(ULong64_t& value);
-   const char*      XmlReadValue(const char* name);
+   void XmlReadBasic(Char_t &value);
+   void XmlReadBasic(Short_t &value);
+   void XmlReadBasic(Int_t &value);
+   void XmlReadBasic(Long_t &value);
+   void XmlReadBasic(Long64_t &value);
+   void XmlReadBasic(Float_t &value);
+   void XmlReadBasic(Double_t &value);
+   void XmlReadBasic(Bool_t &value);
+   void XmlReadBasic(UChar_t &value);
+   void XmlReadBasic(UShort_t &value);
+   void XmlReadBasic(UInt_t &value);
+   void XmlReadBasic(ULong_t &value);
+   void XmlReadBasic(ULong64_t &value);
+   const char *XmlReadValue(const char *name);
 
-   XMLNodePointer_t XmlWriteObject(const void* obj, const TClass* objClass);
-   void*            XmlReadObject(void* obj, TClass** cl = 0);
+   XMLNodePointer_t XmlWriteObject(const void *obj, const TClass *objClass);
+   void *XmlReadObject(void *obj, TClass **cl = 0);
 
-   void             BeforeIOoperation();
-   void             CheckVersionBuf();
+   void BeforeIOoperation();
+   void CheckVersionBuf();
 
-   TXMLEngine*      fXML;                 //!
+   TXMLEngine *fXML; //!
 
-   TObjArray        fStack;                //!
+   TObjArray fStack; //!
 
-   Version_t        fVersionBuf;           //!
+   Version_t fVersionBuf; //!
 
-   TExMap*          fObjMap;               //!
-   TObjArray*       fIdArray;              //!
+   TExMap *fObjMap;     //!
+   TObjArray *fIdArray; //!
 
-   TString          fValueBuf;             //!
+   TString fValueBuf; //!
 
-   Int_t            fErrorFlag;            //!
+   Int_t fErrorFlag; //!
 
-   Bool_t           fCanUseCompact;        ///<!   Flag indicate that basic type (like Int_t) can be placed in the same tag
-   Bool_t           fExpectedChain;        ///<!   Flag to resolve situation when several elements of same basic type stored as FastArray
-   TClass*          fExpectedBaseClass;    ///<!   Pointer to class, which should be stored as parent of current
-   Int_t            fCompressLevel;        ///<!   Compression level and algorithm
-   Int_t            fIOVersion;            ///<!   Indicates format of ROOT xml file
+   Bool_t fCanUseCompact; ///<!   Flag indicate that basic type (like Int_t) can be placed in the same tag
+   Bool_t fExpectedChain; ///<!   Flag to resolve situation when several elements of same basic type stored as FastArray
+   TClass *fExpectedBaseClass; ///<!   Pointer to class, which should be stored as parent of current
+   Int_t fCompressLevel;       ///<!   Compression level and algorithm
+   Int_t fIOVersion;           ///<!   Indicates format of ROOT xml file
 
-   static std::string fgFloatFmt;          ///<!   Printf argument for floats and doubles, either "%f" or "%e" or "%10f" and so on
+   static std::string
+      fgFloatFmt; ///<!   Printf argument for floats and doubles, either "%f" or "%e" or "%10f" and so on
 
-   ClassDef(TBufferXML, 0); //a specialized TBuffer to read/write to XML files
+   ClassDef(TBufferXML, 0); // a specialized TBuffer to read/write to XML files
 };
 
 //______________________________________________________________________________
@@ -361,5 +365,3 @@ inline Int_t TBufferXML::GetCompressionSettings() const
 }
 
 #endif
-
-

--- a/io/xml/inc/TKeyXML.h
+++ b/io/xml/inc/TKeyXML.h
@@ -20,62 +20,63 @@ class TXMLFile;
 class TKeyXML : public TKey {
 
 private:
-   TKeyXML(const TKeyXML&);            // TKeyXML objects are not copiable.
-   TKeyXML& operator=(const TKeyXML&); // TKeyXML objects are not copiable.
+   TKeyXML(const TKeyXML &);            // TKeyXML objects are not copiable.
+   TKeyXML &operator=(const TKeyXML &); // TKeyXML objects are not copiable.
 
 protected:
    TKeyXML();
 
 public:
-   TKeyXML(TDirectory* mother, Long64_t keyid, const TObject* obj, const char* name = 0, const char* title = 0);
-   TKeyXML(TDirectory* mother, Long64_t keyid, const void* obj, const TClass* cl, const char* name, const char* title = 0);
-   TKeyXML(TDirectory* mother, Long64_t keyid, XMLNodePointer_t keynode);
+   TKeyXML(TDirectory *mother, Long64_t keyid, const TObject *obj, const char *name = 0, const char *title = 0);
+   TKeyXML(TDirectory *mother, Long64_t keyid, const void *obj, const TClass *cl, const char *name,
+           const char *title = 0);
+   TKeyXML(TDirectory *mother, Long64_t keyid, XMLNodePointer_t keynode);
    virtual ~TKeyXML();
 
    // redefined TKey Methods
-   virtual void      Delete(Option_t *option="");
-   virtual void      DeleteBuffer() {}
-   virtual void      FillBuffer(char *&) {}
-   virtual char     *GetBuffer() const { return 0; }
-   virtual Long64_t  GetSeekKey() const  { return fKeyNode ? 1024 : 0;}
-   virtual Long64_t  GetSeekPdir() const { return fKeyNode ? 1024 : 0;}
-   //virtual ULong_t   Hash() const { return 0; }
-   virtual void      Keep() {}
-   //virtual void      ls(Option_t* ="") const;
-   //virtual void      Print(Option_t* ="") const {}
+   virtual void Delete(Option_t *option = "");
+   virtual void DeleteBuffer() {}
+   virtual void FillBuffer(char *&) {}
+   virtual char *GetBuffer() const { return 0; }
+   virtual Long64_t GetSeekKey() const { return fKeyNode ? 1024 : 0; }
+   virtual Long64_t GetSeekPdir() const { return fKeyNode ? 1024 : 0; }
+   // virtual ULong_t   Hash() const { return 0; }
+   virtual void Keep() {}
+   // virtual void      ls(Option_t* ="") const;
+   // virtual void      Print(Option_t* ="") const {}
 
-   virtual Int_t     Read(TObject* tobj);
-   virtual TObject  *ReadObj();
-   virtual TObject  *ReadObjWithBuffer(char *bufferRead);
-   virtual void     *ReadObjectAny(const TClass *expectedClass);
+   virtual Int_t Read(TObject *tobj);
+   virtual TObject *ReadObj();
+   virtual TObject *ReadObjWithBuffer(char *bufferRead);
+   virtual void *ReadObjectAny(const TClass *expectedClass);
 
-   virtual void      ReadBuffer(char *&) {}
-   virtual Bool_t    ReadFile() { return kTRUE; }
-   virtual void      SetBuffer() { fBuffer = 0; }
-   virtual Int_t     WriteFile(Int_t =1, TFile* = 0) { return 0; }
+   virtual void ReadBuffer(char *&) {}
+   virtual Bool_t ReadFile() { return kTRUE; }
+   virtual void SetBuffer() { fBuffer = 0; }
+   virtual Int_t WriteFile(Int_t = 1, TFile * = 0) { return 0; }
 
    // TKeyXML specific methods
 
-   XMLNodePointer_t  KeyNode() const { return fKeyNode; }
-   Long64_t          GetKeyId() const { return fKeyId; }
-   Bool_t            IsSubdir() const { return fSubdir; }
-   void              SetSubir() { fSubdir = kTRUE; }
-   void              UpdateObject(TObject* obj);
-   void              UpdateAttributes();
+   XMLNodePointer_t KeyNode() const { return fKeyNode; }
+   Long64_t GetKeyId() const { return fKeyId; }
+   Bool_t IsSubdir() const { return fSubdir; }
+   void SetSubir() { fSubdir = kTRUE; }
+   void UpdateObject(TObject *obj);
+   void UpdateAttributes();
 
 protected:
-   virtual Int_t     Read(const char *name) { return TKey::Read(name); }
-   void              StoreObject(const void* obj, const TClass* cl, Bool_t check_tobj = kFALSE);
-   void              StoreKeyAttributes();
-   TXMLEngine*       XMLEngine();
+   virtual Int_t Read(const char *name) { return TKey::Read(name); }
+   void StoreObject(const void *obj, const TClass *cl, Bool_t check_tobj = kFALSE);
+   void StoreKeyAttributes();
+   TXMLEngine *XMLEngine();
 
-   void*             XmlReadAny(void* obj, const TClass* expectedClass);
+   void *XmlReadAny(void *obj, const TClass *expectedClass);
 
-   XMLNodePointer_t  fKeyNode;  //! node with stored object
-   Long64_t          fKeyId;    //! unique identifier of key for search methods
-   Bool_t            fSubdir;   //! indicates that key contains subdirectory
+   XMLNodePointer_t fKeyNode; //! node with stored object
+   Long64_t fKeyId;           //! unique identifier of key for search methods
+   Bool_t fSubdir;            //! indicates that key contains subdirectory
 
-   ClassDef(TKeyXML,1) // a special TKey for XML files
+   ClassDef(TKeyXML, 1) // a special TKey for XML files
 };
 
 #endif

--- a/io/xml/inc/TXMLEngine.h
+++ b/io/xml/inc/TXMLEngine.h
@@ -14,10 +14,10 @@
 
 #include "TObject.h"
 
-typedef void* XMLNodePointer_t;
-typedef void* XMLNsPointer_t;
-typedef void* XMLAttrPointer_t;
-typedef void* XMLDocPointer_t;
+typedef void *XMLNodePointer_t;
+typedef void *XMLNsPointer_t;
+typedef void *XMLAttrPointer_t;
+typedef void *XMLDocPointer_t;
 
 class TXMLInputStream;
 class TXMLOutputStream;
@@ -26,97 +26,85 @@ class TString;
 class TXMLEngine : public TObject {
 
 protected:
-   char*             Makestr(const char* str);
-   char*             Makenstr(const char* start, int len);
-   XMLNodePointer_t  AllocateNode(int namelen, XMLNodePointer_t parent);
-   XMLAttrPointer_t  AllocateAttr(int namelen, int valuelen, XMLNodePointer_t xmlnode);
-   XMLNsPointer_t    FindNs(XMLNodePointer_t xmlnode, const char* nsname);
-   void              TruncateNsExtension(XMLNodePointer_t xmlnode);
-   void              UnpackSpecialCharacters(char* target, const char* source, int srclen);
-   void              OutputValue(char* value, TXMLOutputStream* out);
-   void              SaveNode(XMLNodePointer_t xmlnode, TXMLOutputStream* out, Int_t layout, Int_t level);
-   XMLNodePointer_t  ReadNode(XMLNodePointer_t xmlparent, TXMLInputStream* inp, Int_t& resvalue);
-   void              DisplayError(Int_t error, Int_t linenumber);
-   XMLDocPointer_t   ParseStream(TXMLInputStream* input);
+   char *Makestr(const char *str);
+   char *Makenstr(const char *start, int len);
+   XMLNodePointer_t AllocateNode(int namelen, XMLNodePointer_t parent);
+   XMLAttrPointer_t AllocateAttr(int namelen, int valuelen, XMLNodePointer_t xmlnode);
+   XMLNsPointer_t FindNs(XMLNodePointer_t xmlnode, const char *nsname);
+   void TruncateNsExtension(XMLNodePointer_t xmlnode);
+   void UnpackSpecialCharacters(char *target, const char *source, int srclen);
+   void OutputValue(char *value, TXMLOutputStream *out);
+   void SaveNode(XMLNodePointer_t xmlnode, TXMLOutputStream *out, Int_t layout, Int_t level);
+   XMLNodePointer_t ReadNode(XMLNodePointer_t xmlparent, TXMLInputStream *inp, Int_t &resvalue);
+   void DisplayError(Int_t error, Int_t linenumber);
+   XMLDocPointer_t ParseStream(TXMLInputStream *input);
 
-   Bool_t            fSkipComments;    //! if true, do not create comments nodes in document during parsing
+   Bool_t fSkipComments; //! if true, do not create comments nodes in document during parsing
 
 public:
    TXMLEngine();
    virtual ~TXMLEngine();
 
-   void              SetSkipComments(Bool_t on = kTRUE) { fSkipComments = on; }
-   Bool_t            GetSkipComments() const { return fSkipComments; }
+   void SetSkipComments(Bool_t on = kTRUE) { fSkipComments = on; }
+   Bool_t GetSkipComments() const { return fSkipComments; }
 
-   Bool_t            HasAttr(XMLNodePointer_t xmlnode, const char* name);
-   const char*       GetAttr(XMLNodePointer_t xmlnode, const char* name);
-   Int_t             GetIntAttr(XMLNodePointer_t node, const char* name);
-   XMLAttrPointer_t  NewAttr(XMLNodePointer_t xmlnode, XMLNsPointer_t,
-                             const char* name, const char* value);
-   XMLAttrPointer_t  NewIntAttr(XMLNodePointer_t xmlnode, const char* name, Int_t value);
-   void              FreeAttr(XMLNodePointer_t xmlnode, const char* name);
-   void              FreeAllAttr(XMLNodePointer_t xmlnode);
-   XMLAttrPointer_t  GetFirstAttr(XMLNodePointer_t xmlnode);
-   XMLAttrPointer_t  GetNextAttr(XMLAttrPointer_t xmlattr);
-   const char*       GetAttrName(XMLAttrPointer_t xmlattr);
-   const char*       GetAttrValue(XMLAttrPointer_t xmlattr);
-   XMLNodePointer_t  NewChild(XMLNodePointer_t parent, XMLNsPointer_t ns,
-                              const char* name, const char* content = 0);
-   XMLNsPointer_t    NewNS(XMLNodePointer_t xmlnode, const char* reference, const char* name = 0);
-   XMLNsPointer_t    GetNS(XMLNodePointer_t xmlnode);
-   const char*       GetNSName(XMLNsPointer_t ns);
-   const char*       GetNSReference(XMLNsPointer_t ns);
-   void              AddChild(XMLNodePointer_t parent, XMLNodePointer_t child);
-   void              AddChildFirst(XMLNodePointer_t parent, XMLNodePointer_t child);
-   Bool_t            AddComment(XMLNodePointer_t parent, const char* comment);
-   Bool_t            AddDocComment(XMLDocPointer_t xmldoc, const char* comment);
-   Bool_t            AddRawLine(XMLNodePointer_t parent, const char* line);
-   Bool_t            AddDocRawLine(XMLDocPointer_t xmldoc, const char* line);
-   Bool_t            AddStyleSheet(XMLNodePointer_t parent,
-                                   const char* href,
-                                   const char* type = "text/css",
-                                   const char* title = 0,
-                                   int alternate = -1,
-                                   const char* media = 0,
-                                   const char* charset = 0);
-   Bool_t            AddDocStyleSheet(XMLDocPointer_t xmldoc,
-                                      const char* href,
-                                      const char* type = "text/css",
-                                      const char* title = 0,
-                                      int alternate = -1,
-                                      const char* media = 0,
-                                      const char* charset = 0);
-   void              UnlinkNode(XMLNodePointer_t node);
-   void              FreeNode(XMLNodePointer_t xmlnode);
-   void              UnlinkFreeNode(XMLNodePointer_t xmlnode);
-   const char*       GetNodeName(XMLNodePointer_t xmlnode);
-   const char*       GetNodeContent(XMLNodePointer_t xmlnode);
-   void              SetNodeContent(XMLNodePointer_t xmlnode, const char* content, Int_t len = 0);
-   void              AddNodeContent(XMLNodePointer_t xmlnode, const char* content, Int_t len = 0);
-   XMLNodePointer_t  GetChild(XMLNodePointer_t xmlnode, Bool_t realnode = kTRUE);
-   XMLNodePointer_t  GetParent(XMLNodePointer_t xmlnode);
-   XMLNodePointer_t  GetNext(XMLNodePointer_t xmlnode, Bool_t realnode = kTRUE);
-   void              ShiftToNext(XMLNodePointer_t &xmlnode, Bool_t realnode = kTRUE);
-   Bool_t            IsXmlNode(XMLNodePointer_t xmlnode);
-   Bool_t            IsEmptyNode(XMLNodePointer_t xmlnode);
-   Bool_t            IsContentNode(XMLNodePointer_t xmlnode);
-   Bool_t            IsCommentNode(XMLNodePointer_t xmlnode);
-   void              SkipEmpty(XMLNodePointer_t &xmlnode);
-   void              CleanNode(XMLNodePointer_t xmlnode);
-   XMLDocPointer_t   NewDoc(const char* version = "1.0");
-   void              AssignDtd(XMLDocPointer_t xmldoc, const char* dtdname, const char* rootname);
-   void              FreeDoc(XMLDocPointer_t xmldoc);
-   void              SaveDoc(XMLDocPointer_t xmldoc, const char* filename, Int_t layout = 1);
-   void              DocSetRootElement(XMLDocPointer_t xmldoc, XMLNodePointer_t xmlnode);
-   XMLNodePointer_t  DocGetRootElement(XMLDocPointer_t xmldoc);
-   XMLDocPointer_t   ParseFile(const char* filename, Int_t maxbuf = 100000);
-   XMLDocPointer_t   ParseString(const char* xmlstring);
-   Bool_t            ValidateVersion(XMLDocPointer_t doc, const char* version = 0);
-   Bool_t            ValidateDocument(XMLDocPointer_t, Bool_t = kFALSE) { return kFALSE; } // obsolete
-   void              SaveSingleNode(XMLNodePointer_t xmlnode, TString* res, Int_t layout = 1);
-   XMLNodePointer_t  ReadSingleNode(const char* src);
+   Bool_t HasAttr(XMLNodePointer_t xmlnode, const char *name);
+   const char *GetAttr(XMLNodePointer_t xmlnode, const char *name);
+   Int_t GetIntAttr(XMLNodePointer_t node, const char *name);
+   XMLAttrPointer_t NewAttr(XMLNodePointer_t xmlnode, XMLNsPointer_t, const char *name, const char *value);
+   XMLAttrPointer_t NewIntAttr(XMLNodePointer_t xmlnode, const char *name, Int_t value);
+   void FreeAttr(XMLNodePointer_t xmlnode, const char *name);
+   void FreeAllAttr(XMLNodePointer_t xmlnode);
+   XMLAttrPointer_t GetFirstAttr(XMLNodePointer_t xmlnode);
+   XMLAttrPointer_t GetNextAttr(XMLAttrPointer_t xmlattr);
+   const char *GetAttrName(XMLAttrPointer_t xmlattr);
+   const char *GetAttrValue(XMLAttrPointer_t xmlattr);
+   XMLNodePointer_t NewChild(XMLNodePointer_t parent, XMLNsPointer_t ns, const char *name, const char *content = 0);
+   XMLNsPointer_t NewNS(XMLNodePointer_t xmlnode, const char *reference, const char *name = 0);
+   XMLNsPointer_t GetNS(XMLNodePointer_t xmlnode);
+   const char *GetNSName(XMLNsPointer_t ns);
+   const char *GetNSReference(XMLNsPointer_t ns);
+   void AddChild(XMLNodePointer_t parent, XMLNodePointer_t child);
+   void AddChildFirst(XMLNodePointer_t parent, XMLNodePointer_t child);
+   Bool_t AddComment(XMLNodePointer_t parent, const char *comment);
+   Bool_t AddDocComment(XMLDocPointer_t xmldoc, const char *comment);
+   Bool_t AddRawLine(XMLNodePointer_t parent, const char *line);
+   Bool_t AddDocRawLine(XMLDocPointer_t xmldoc, const char *line);
+   Bool_t AddStyleSheet(XMLNodePointer_t parent, const char *href, const char *type = "text/css", const char *title = 0,
+                        int alternate = -1, const char *media = 0, const char *charset = 0);
+   Bool_t AddDocStyleSheet(XMLDocPointer_t xmldoc, const char *href, const char *type = "text/css",
+                           const char *title = 0, int alternate = -1, const char *media = 0, const char *charset = 0);
+   void UnlinkNode(XMLNodePointer_t node);
+   void FreeNode(XMLNodePointer_t xmlnode);
+   void UnlinkFreeNode(XMLNodePointer_t xmlnode);
+   const char *GetNodeName(XMLNodePointer_t xmlnode);
+   const char *GetNodeContent(XMLNodePointer_t xmlnode);
+   void SetNodeContent(XMLNodePointer_t xmlnode, const char *content, Int_t len = 0);
+   void AddNodeContent(XMLNodePointer_t xmlnode, const char *content, Int_t len = 0);
+   XMLNodePointer_t GetChild(XMLNodePointer_t xmlnode, Bool_t realnode = kTRUE);
+   XMLNodePointer_t GetParent(XMLNodePointer_t xmlnode);
+   XMLNodePointer_t GetNext(XMLNodePointer_t xmlnode, Bool_t realnode = kTRUE);
+   void ShiftToNext(XMLNodePointer_t &xmlnode, Bool_t realnode = kTRUE);
+   Bool_t IsXmlNode(XMLNodePointer_t xmlnode);
+   Bool_t IsEmptyNode(XMLNodePointer_t xmlnode);
+   Bool_t IsContentNode(XMLNodePointer_t xmlnode);
+   Bool_t IsCommentNode(XMLNodePointer_t xmlnode);
+   void SkipEmpty(XMLNodePointer_t &xmlnode);
+   void CleanNode(XMLNodePointer_t xmlnode);
+   XMLDocPointer_t NewDoc(const char *version = "1.0");
+   void AssignDtd(XMLDocPointer_t xmldoc, const char *dtdname, const char *rootname);
+   void FreeDoc(XMLDocPointer_t xmldoc);
+   void SaveDoc(XMLDocPointer_t xmldoc, const char *filename, Int_t layout = 1);
+   void DocSetRootElement(XMLDocPointer_t xmldoc, XMLNodePointer_t xmlnode);
+   XMLNodePointer_t DocGetRootElement(XMLDocPointer_t xmldoc);
+   XMLDocPointer_t ParseFile(const char *filename, Int_t maxbuf = 100000);
+   XMLDocPointer_t ParseString(const char *xmlstring);
+   Bool_t ValidateVersion(XMLDocPointer_t doc, const char *version = 0);
+   Bool_t ValidateDocument(XMLDocPointer_t, Bool_t = kFALSE) { return kFALSE; } // obsolete
+   void SaveSingleNode(XMLNodePointer_t xmlnode, TString *res, Int_t layout = 1);
+   XMLNodePointer_t ReadSingleNode(const char *src);
 
-   ClassDef(TXMLEngine,1);   // ROOT XML I/O parser, user by TXMLFile to read/write xml files
+   ClassDef(TXMLEngine, 1); // ROOT XML I/O parser, user by TXMLFile to read/write xml files
 };
 
 #endif

--- a/io/xml/inc/TXMLFile.h
+++ b/io/xml/inc/TXMLFile.h
@@ -16,136 +16,126 @@
 #include "TFile.h"
 #include "TXMLSetup.h"
 
-
 class TKeyXML;
 class TList;
 class TStreamerElement;
 class TStreamerInfo;
 
-
 class TXMLFile : public TFile, public TXMLSetup {
 
 protected:
-
-   void             InitXmlFile(Bool_t create);
+   void InitXmlFile(Bool_t create);
    // Interface to basic system I/O routines
-   virtual Int_t    SysOpen(const char*, Int_t, UInt_t) { return 0; }
-   virtual Int_t    SysClose(Int_t) { return 0; }
-   virtual Int_t    SysRead(Int_t, void*, Int_t) { return 0; }
-   virtual Int_t    SysWrite(Int_t, const void*, Int_t) { return 0; }
+   virtual Int_t SysOpen(const char *, Int_t, UInt_t) { return 0; }
+   virtual Int_t SysClose(Int_t) { return 0; }
+   virtual Int_t SysRead(Int_t, void *, Int_t) { return 0; }
+   virtual Int_t SysWrite(Int_t, const void *, Int_t) { return 0; }
    virtual Long64_t SysSeek(Int_t, Long64_t, Int_t) { return 0; }
-   virtual Int_t    SysStat(Int_t, Long_t*, Long64_t*, Long_t*, Long_t*) { return 0; }
-   virtual Int_t    SysSync(Int_t) { return 0; }
+   virtual Int_t SysStat(Int_t, Long_t *, Long64_t *, Long_t *, Long_t *) { return 0; }
+   virtual Int_t SysSync(Int_t) { return 0; }
 
    // Overwrite methods for directory I/O
-   virtual Long64_t DirCreateEntry(TDirectory*);
-   virtual Int_t    DirReadKeys(TDirectory*);
-   virtual void     DirWriteKeys(TDirectory*);
-   virtual void     DirWriteHeader(TDirectory*);
+   virtual Long64_t DirCreateEntry(TDirectory *);
+   virtual Int_t DirReadKeys(TDirectory *);
+   virtual void DirWriteKeys(TDirectory *);
+   virtual void DirWriteHeader(TDirectory *);
 
 private:
-   //let the compiler do the job. gcc complains when the following line is activated
-   //TXMLFile(const TXMLFile &) {}            //Files cannot be copied
+   // let the compiler do the job. gcc complains when the following line is activated
+   // TXMLFile(const TXMLFile &) {}            //Files cannot be copied
    void operator=(const TXMLFile &);
 
 public:
    TXMLFile();
-   TXMLFile(const char* filename, Option_t* option = "read", const char* title = "title", Int_t compression = 1);
+   TXMLFile(const char *filename, Option_t *option = "read", const char *title = "title", Int_t compression = 1);
    virtual ~TXMLFile();
 
-   virtual void      Close(Option_t *option=""); // *MENU*
-   virtual TKey*     CreateKey(TDirectory* mother, const TObject* obj, const char* name, Int_t bufsize);
-   virtual TKey*     CreateKey(TDirectory* mother, const void* obj, const TClass* cl, const char* name, Int_t bufsize);
-   virtual void      DrawMap(const char* ="*",Option_t* ="") {}
-   virtual void      FillBuffer(char* &) {}
-   virtual void      Flush() {}
+   virtual void Close(Option_t *option = ""); // *MENU*
+   virtual TKey *CreateKey(TDirectory *mother, const TObject *obj, const char *name, Int_t bufsize);
+   virtual TKey *CreateKey(TDirectory *mother, const void *obj, const TClass *cl, const char *name, Int_t bufsize);
+   virtual void DrawMap(const char * = "*", Option_t * = "") {}
+   virtual void FillBuffer(char *&) {}
+   virtual void Flush() {}
 
-   virtual Long64_t  GetEND() const { return 0; }
-   virtual Int_t     GetErrno() const { return 0; }
-   virtual void      ResetErrno() const {}
+   virtual Long64_t GetEND() const { return 0; }
+   virtual Int_t GetErrno() const { return 0; }
+   virtual void ResetErrno() const {}
 
-   virtual Int_t     GetNfree() const { return 0; }
-   virtual Int_t     GetNbytesInfo() const {return 0; }
-   virtual Int_t     GetNbytesFree() const {return 0; }
-   virtual Long64_t  GetSeekFree() const {return 0; }
-   virtual Long64_t  GetSeekInfo() const {return 0; }
-   virtual Long64_t  GetSize() const { return 0; }
-   virtual TList*    GetStreamerInfoList();
-   Int_t             GetIOVersion() const { return fIOVersion; }
+   virtual Int_t GetNfree() const { return 0; }
+   virtual Int_t GetNbytesInfo() const { return 0; }
+   virtual Int_t GetNbytesFree() const { return 0; }
+   virtual Long64_t GetSeekFree() const { return 0; }
+   virtual Long64_t GetSeekInfo() const { return 0; }
+   virtual Long64_t GetSize() const { return 0; }
+   virtual TList *GetStreamerInfoList();
+   Int_t GetIOVersion() const { return fIOVersion; }
 
-   virtual Bool_t    IsOpen() const;
+   virtual Bool_t IsOpen() const;
 
-   virtual void      MakeFree(Long64_t, Long64_t) {}
-   virtual void      MakeProject(const char *, const char* ="*", Option_t* ="new") {} // *MENU*
-   virtual void      Map(Option_t *) {} //
-   virtual void      Map() {} //
-   virtual void      Paint(Option_t* ="") {}
-   virtual void      Print(Option_t* ="") const {}
-   virtual Bool_t    ReadBuffer(char*, Int_t) { return kFALSE; }
-   virtual Bool_t    ReadBuffer(char*, Long64_t, Int_t) { return kFALSE; }
-   virtual void      ReadFree() {}
-   virtual Int_t     Recover() { return 0; }
-   virtual Int_t     ReOpen(Option_t *mode);
-   virtual void      Seek(Long64_t, ERelativeTo=kBeg) {}
+   virtual void MakeFree(Long64_t, Long64_t) {}
+   virtual void MakeProject(const char *, const char * = "*", Option_t * = "new") {} // *MENU*
+   virtual void Map(Option_t *) {}                                                   //
+   virtual void Map() {}                                                             //
+   virtual void Paint(Option_t * = "") {}
+   virtual void Print(Option_t * = "") const {}
+   virtual Bool_t ReadBuffer(char *, Int_t) { return kFALSE; }
+   virtual Bool_t ReadBuffer(char *, Long64_t, Int_t) { return kFALSE; }
+   virtual void ReadFree() {}
+   virtual Int_t Recover() { return 0; }
+   virtual Int_t ReOpen(Option_t *mode);
+   virtual void Seek(Long64_t, ERelativeTo = kBeg) {}
 
-   virtual void      SetEND(Long64_t) {}
-   virtual Int_t     Sizeof() const { return 0; }
+   virtual void SetEND(Long64_t) {}
+   virtual Int_t Sizeof() const { return 0; }
 
-   virtual Bool_t    WriteBuffer(const char*, Int_t) { return kFALSE; }
-   virtual Int_t     Write(const char* =0, Int_t=0, Int_t=0) { return 0; }
-   virtual Int_t     Write(const char* =0, Int_t=0, Int_t=0) const { return 0; }
-   virtual void      WriteFree() {}
-   virtual void      WriteHeader() {}
-   virtual void      WriteStreamerInfo();
+   virtual Bool_t WriteBuffer(const char *, Int_t) { return kFALSE; }
+   virtual Int_t Write(const char * = 0, Int_t = 0, Int_t = 0) { return 0; }
+   virtual Int_t Write(const char * = 0, Int_t = 0, Int_t = 0) const { return 0; }
+   virtual void WriteFree() {}
+   virtual void WriteHeader() {}
+   virtual void WriteStreamerInfo();
 
    // XML specific functions
 
-   virtual void      SetXmlLayout(EXMLLayout layout);
-   virtual void      SetStoreStreamerInfos(Bool_t iConvert = kTRUE);
-   virtual void      SetUsedDtd(Bool_t use = kTRUE);
-   virtual void      SetUseNamespaces(Bool_t iUseNamespaces = kTRUE);
+   virtual void SetXmlLayout(EXMLLayout layout);
+   virtual void SetStoreStreamerInfos(Bool_t iConvert = kTRUE);
+   virtual void SetUsedDtd(Bool_t use = kTRUE);
+   virtual void SetUseNamespaces(Bool_t iUseNamespaces = kTRUE);
 
-   Bool_t            AddXmlComment(const char* comment);
-   Bool_t            AddXmlStyleSheet(const char* href,
-                                      const char* type = "text/css",
-                                      const char* title = 0,
-                                      int alternate = -1,
-                                      const char* media = 0,
-                                      const char* charset = 0);
-   Bool_t            AddXmlLine(const char* line);
+   Bool_t AddXmlComment(const char *comment);
+   Bool_t AddXmlStyleSheet(const char *href, const char *type = "text/css", const char *title = 0, int alternate = -1,
+                           const char *media = 0, const char *charset = 0);
+   Bool_t AddXmlLine(const char *line);
 
-   TXMLEngine*       XML() { return fXML; }
+   TXMLEngine *XML() { return fXML; }
 
 protected:
    // functions to store streamer infos
 
-   void              StoreStreamerElement(XMLNodePointer_t node, TStreamerElement* elem);
-   void              ReadStreamerElement(XMLNodePointer_t node, TStreamerInfo* info);
+   void StoreStreamerElement(XMLNodePointer_t node, TStreamerElement *elem);
+   void ReadStreamerElement(XMLNodePointer_t node, TStreamerInfo *info);
 
-   Bool_t            ReadFromFile();
-   Int_t             ReadKeysList(TDirectory* dir, XMLNodePointer_t topnode);
-   TKeyXML*          FindDirKey(TDirectory* dir);
-   TDirectory*       FindKeyDir(TDirectory* mother, Long64_t keyid);
-   void              CombineNodesTree(TDirectory* dir, XMLNodePointer_t topnode, Bool_t dolink);
+   Bool_t ReadFromFile();
+   Int_t ReadKeysList(TDirectory *dir, XMLNodePointer_t topnode);
+   TKeyXML *FindDirKey(TDirectory *dir);
+   TDirectory *FindKeyDir(TDirectory *mother, Long64_t keyid);
+   void CombineNodesTree(TDirectory *dir, XMLNodePointer_t topnode, Bool_t dolink);
 
-   void              SaveToFile();
+   void SaveToFile();
 
-   static void       ProduceFileNames(const char* filename, TString& fname, TString& dtdname);
+   static void ProduceFileNames(const char *filename, TString &fname, TString &dtdname);
 
-   XMLDocPointer_t   fDoc;                  //!
+   XMLDocPointer_t fDoc; //!
 
-   XMLNodePointer_t  fStreamerInfoNode;     //!  pointer of node with streamer info data
+   XMLNodePointer_t fStreamerInfoNode; //!  pointer of node with streamer info data
 
-   TXMLEngine*       fXML;                  //! object for interface with xml library
+   TXMLEngine *fXML; //! object for interface with xml library
 
-   Int_t             fIOVersion;            //! indicates format of ROOT xml file
+   Int_t fIOVersion; //! indicates format of ROOT xml file
 
-   Long64_t          fKeyCounter;           //! counter of created keys, used for keys id
+   Long64_t fKeyCounter; //! counter of created keys, used for keys id
 
-ClassDef(TXMLFile, 3)  //ROOT file in XML format
+   ClassDef(TXMLFile, 3) // ROOT file in XML format
 };
 
-
-
 #endif
-

--- a/io/xml/inc/TXMLPlayer.h
+++ b/io/xml/inc/TXMLPlayer.h
@@ -24,33 +24,33 @@ class TStreamerSTL;
 class TDataMember;
 
 class TXMLPlayer : public TObject {
-   public:
-      TXMLPlayer();
-      virtual ~TXMLPlayer();
+public:
+   TXMLPlayer();
+   virtual ~TXMLPlayer();
 
-      Bool_t ProduceCode(TList* cllist, const char* filename);
+   Bool_t ProduceCode(TList *cllist, const char *filename);
 
-   protected:
+protected:
+   TString GetStreamerName(TClass *cl);
 
-      TString GetStreamerName(TClass* cl);
+   const char *ElementGetter(TClass *cl, const char *membername, int specials = 0);
+   const char *ElementSetter(TClass *cl, const char *membername, char *endch);
 
-      const char* ElementGetter(TClass* cl, const char* membername, int specials = 0);
-      const char* ElementSetter(TClass* cl, const char* membername, char* endch);
+   TString GetMemberTypeName(TDataMember *member);
+   TString GetBasicTypeName(TStreamerElement *el);
+   TString GetBasicTypeReaderMethodName(Int_t type, const char *realname);
+   void ProduceStreamerSource(std::ostream &fs, TClass *cl, TList *cllist);
 
-      TString GetMemberTypeName(TDataMember* member);
-      TString GetBasicTypeName(TStreamerElement* el);
-      TString GetBasicTypeReaderMethodName(Int_t type, const char* realname);
-      void ProduceStreamerSource(std::ostream& fs, TClass* cl, TList* cllist);
+   void ReadSTLarg(std::ostream &fs, TString &argname, int argtyp, Bool_t isargptr, TClass *argcl, TString &tname,
+                   TString &ifcond);
+   void WriteSTLarg(std::ostream &fs, const char *accname, int argtyp, Bool_t isargptr, TClass *argcl);
+   Bool_t ProduceSTLstreamer(std::ostream &fs, TClass *cl, TStreamerSTL *el, Bool_t isWriting);
 
-      void ReadSTLarg(std::ostream& fs, TString& argname, int argtyp, Bool_t isargptr, TClass* argcl, TString& tname, TString& ifcond);
-      void WriteSTLarg(std::ostream& fs, const char* accname, int argtyp, Bool_t isargptr, TClass* argcl);
-      Bool_t ProduceSTLstreamer(std::ostream& fs, TClass* cl, TStreamerSTL* el, Bool_t isWriting);
+   TString fGetterName; //!  buffer for name of getter method
+   TString fSetterName; //!  buffer for name of setter method
+   TXMLSetup fXmlSetup; //!  buffer for xml names conversion
 
-      TString fGetterName;                   //!  buffer for name of getter method
-      TString fSetterName;                   //!  buffer for name of setter method
-      TXMLSetup fXmlSetup;                   //!  buffer for xml names conversion
-
-   ClassDef(TXMLPlayer,1) // Generation of external xml streamers
+   ClassDef(TXMLPlayer, 1) // Generation of external xml streamers
 };
 
 #endif

--- a/io/xml/inc/TXMLPlayer.h
+++ b/io/xml/inc/TXMLPlayer.h
@@ -48,7 +48,7 @@ class TXMLPlayer : public TObject {
 
       TString fGetterName;                   //!  buffer for name of getter method
       TString fSetterName;                   //!  buffer for name of setter method
-      TXMLSetup fXmlSetup;                   //!  buffer for xml names convertion
+      TXMLSetup fXmlSetup;                   //!  buffer for xml names conversion
 
    ClassDef(TXMLPlayer,1) // Generation of external xml streamers
 };

--- a/io/xml/inc/TXMLSetup.h
+++ b/io/xml/inc/TXMLSetup.h
@@ -25,116 +25,113 @@
 #undef False
 #endif
 
-
 namespace xmlio {
-   extern const char* Root;
-   extern const char* Setup;
-   extern const char* ClassVersion;
-   extern const char* IOVersion;
-   extern const char* OnlyVersion;
-   extern const char* Ptr;
-   extern const char* Ref;
-   extern const char* Null;
-   extern const char* IdBase;
-   extern const char* Size;
-   extern const char* Xmlobject;
-   extern const char* Xmlkey;
-   extern const char* Cycle;
-   extern const char* XmlBlock;
-   extern const char* Zip;
-   extern const char* Object;
-   extern const char* ObjClass;
-   extern const char* Class;
-   extern const char* Member;
-   extern const char* Item;
-   extern const char* Name;
-   extern const char* Title;
-   extern const char* CreateTm;
-   extern const char* ModifyTm;
-   extern const char* ObjectUUID;
-   extern const char* Type;
-   extern const char* Value;
-   extern const char* v;
-   extern const char* cnt;
-   extern const char* True;
-   extern const char* False;
-   extern const char* SInfos;
+extern const char *Root;
+extern const char *Setup;
+extern const char *ClassVersion;
+extern const char *IOVersion;
+extern const char *OnlyVersion;
+extern const char *Ptr;
+extern const char *Ref;
+extern const char *Null;
+extern const char *IdBase;
+extern const char *Size;
+extern const char *Xmlobject;
+extern const char *Xmlkey;
+extern const char *Cycle;
+extern const char *XmlBlock;
+extern const char *Zip;
+extern const char *Object;
+extern const char *ObjClass;
+extern const char *Class;
+extern const char *Member;
+extern const char *Item;
+extern const char *Name;
+extern const char *Title;
+extern const char *CreateTm;
+extern const char *ModifyTm;
+extern const char *ObjectUUID;
+extern const char *Type;
+extern const char *Value;
+extern const char *v;
+extern const char *cnt;
+extern const char *True;
+extern const char *False;
+extern const char *SInfos;
 
-   extern const char* Array;
-   extern const char* Bool;
-   extern const char* Char;
-   extern const char* Short;
-   extern const char* Int;
-   extern const char* Long;
-   extern const char* Long64;
-   extern const char* Float;
-   extern const char* Double;
-   extern const char* UChar;
-   extern const char* UShort;
-   extern const char* UInt;
-   extern const char* ULong;
-   extern const char* ULong64;
-   extern const char* String;
-   extern const char* CharStar;
+extern const char *Array;
+extern const char *Bool;
+extern const char *Char;
+extern const char *Short;
+extern const char *Int;
+extern const char *Long;
+extern const char *Long64;
+extern const char *Float;
+extern const char *Double;
+extern const char *UChar;
+extern const char *UShort;
+extern const char *UInt;
+extern const char *ULong;
+extern const char *ULong64;
+extern const char *String;
+extern const char *CharStar;
 }
 
 class TStreamerElement;
 
 class TXMLSetup {
-   public:
-      enum EXMLLayout { kSpecialized = 2,
-                        kGeneralized = 3 };
+public:
+   enum EXMLLayout { kSpecialized = 2, kGeneralized = 3 };
 
-      TXMLSetup();
-      TXMLSetup(const char* opt);
-      TXMLSetup(const TXMLSetup& src);
-      virtual ~TXMLSetup();
+   TXMLSetup();
+   TXMLSetup(const char *opt);
+   TXMLSetup(const TXMLSetup &src);
+   virtual ~TXMLSetup();
 
-      TString        GetSetupAsString();
+   TString GetSetupAsString();
 
-      void           PrintSetup();
+   void PrintSetup();
 
-      EXMLLayout     GetXmlLayout() const { return fXmlLayout; }
-      Bool_t         IsStoreStreamerInfos() const { return fStoreStreamerInfos; }
-      Bool_t         IsUseDtd() const { return fUseDtd; }
-      Bool_t         IsUseNamespaces() const { return fUseNamespaces; }
+   EXMLLayout GetXmlLayout() const { return fXmlLayout; }
+   Bool_t IsStoreStreamerInfos() const { return fStoreStreamerInfos; }
+   Bool_t IsUseDtd() const { return fUseDtd; }
+   Bool_t IsUseNamespaces() const { return fUseNamespaces; }
 
-      virtual void   SetXmlLayout(EXMLLayout layout) { fXmlLayout = layout; }
-      virtual void   SetStoreStreamerInfos(Bool_t iConvert = kTRUE) { fStoreStreamerInfos = iConvert; }
-      virtual void   SetUsedDtd(Bool_t use = kTRUE) { fUseDtd = use; }
-      virtual void   SetUseNamespaces(Bool_t iUseNamespaces = kTRUE) { fUseNamespaces = iUseNamespaces; }
+   virtual void SetXmlLayout(EXMLLayout layout) { fXmlLayout = layout; }
+   virtual void SetStoreStreamerInfos(Bool_t iConvert = kTRUE) { fStoreStreamerInfos = iConvert; }
+   virtual void SetUsedDtd(Bool_t use = kTRUE) { fUseDtd = use; }
+   virtual void SetUseNamespaces(Bool_t iUseNamespaces = kTRUE) { fUseNamespaces = iUseNamespaces; }
 
-      const char*    XmlConvertClassName(const char* name);
-      const char*    XmlClassNameSpaceRef(const TClass* cl);
-      const char*    XmlGetElementName(const TStreamerElement* el);
+   const char *XmlConvertClassName(const char *name);
+   const char *XmlClassNameSpaceRef(const TClass *cl);
+   const char *XmlGetElementName(const TStreamerElement *el);
 
-      Int_t          GetNextRefCounter() { return fRefCounter++; }
+   Int_t GetNextRefCounter() { return fRefCounter++; }
 
-      static TString DefaultXmlSetup();
-      static void    SetNameSpaceBase(const char* namespacebase);
+   static TString DefaultXmlSetup();
+   static void SetNameSpaceBase(const char *namespacebase);
 
-   protected:
+protected:
+   TClass *XmlDefineClass(const char *xmlClassName);
+   const char *GetElItemName(TStreamerElement *el);
 
-      TClass*        XmlDefineClass(const char* xmlClassName);
-      const char*    GetElItemName(TStreamerElement* el);
+   Bool_t IsValidXmlSetup(const char *setupstr);
+   Bool_t ReadSetupFromStr(const char *setupstr);
 
-      Bool_t         IsValidXmlSetup(const char* setupstr);
-      Bool_t         ReadSetupFromStr(const char* setupstr);
+   Int_t AtoI(const char *sbuf, Int_t def = 0, const char *errinfo = 0);
 
-      Int_t          AtoI(const char* sbuf, Int_t def = 0, const char* errinfo = 0);
+   EXMLLayout fXmlLayout;
+   Bool_t fStoreStreamerInfos;
+   Bool_t fUseDtd;
+   Bool_t fUseNamespaces;
 
-      EXMLLayout     fXmlLayout;
-      Bool_t         fStoreStreamerInfos;
-      Bool_t         fUseDtd;
-      Bool_t         fUseNamespaces;
+   Int_t fRefCounter; //!  counter , used to build id of xml references
 
-      Int_t          fRefCounter;      //!  counter , used to build id of xml references
+   TString fStrBuf; //!  buffer, used in XmlDefineClass() function
 
-      TString        fStrBuf;          //!  buffer, used in XmlDefineClass() function
+   static TString fgNameSpaceBase;
 
-      static TString fgNameSpaceBase;
-
-   ClassDef(TXMLSetup,1) //settings to be stored in XML files
+   ClassDef(TXMLSetup, 1) // settings to be stored in XML files
 };
 
 #endif

--- a/io/xml/src/TBufferXML.cxx
+++ b/io/xml/src/TBufferXML.cxx
@@ -79,7 +79,7 @@ TBufferXML::TBufferXML() :
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Creates buffer object to serailize/deserialize data to/from xml.
+/// Creates buffer object to serialize/deserialize data to/from xml.
 /// Mode should be either TBuffer::kRead or TBuffer::kWrite.
 
 TBufferXML::TBufferXML(TBuffer::EMode mode) :
@@ -105,7 +105,7 @@ TBufferXML::TBufferXML(TBuffer::EMode mode) :
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Creates buffer object to serailize/deserialize data to/from xml.
+/// Creates buffer object to serialize/deserialize data to/from xml.
 /// This constructor should be used, if data from buffer supposed to be stored in file.
 /// Mode should be either TBuffer::kRead or TBuffer::kWrite.
 
@@ -303,7 +303,7 @@ void TBufferXML::WriteObject(const TObject *obj)
 }
 
 // TXMLStackObj is used to keep stack of object hierarchy,
-// stored in TBuffer. For instnace, data for parent class(es)
+// stored in TBuffer. For example, data for parent class(es)
 // stored in subnodes, but initial object node will be kept.
 
 class TXMLStackObj : public TObject {
@@ -656,7 +656,7 @@ Bool_t TBufferXML::ExtractPointer(XMLNodePointer_t node, void* &ptr, TClass* &cl
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Analyse, if node has "ref" attribute and register it to object map
+/// Analyze if node has "ref" attribute and register it to object map
 
 void TBufferXML::ExtractReference(XMLNodePointer_t node, const void* ptr, const TClass* cl)
 {
@@ -682,7 +682,7 @@ void TBufferXML::ExtractReference(XMLNodePointer_t node, const void* ptr, const 
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Check, if node has specified name
+/// Check if node has specified name
 
 Bool_t TBufferXML::VerifyNode(XMLNodePointer_t node, const char* name, const char* errinfo)
 {
@@ -790,7 +790,7 @@ void TBufferXML::CreateElemNode(const TStreamerElement* elem)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Checks, if stack node correspond to TStreamerElement object
+/// Checks if stack node correspond to TStreamerElement object
 
 Bool_t TBufferXML::VerifyElemNode(const TStreamerElement* elem)
 {
@@ -897,7 +897,7 @@ void* TBufferXML::XmlReadObject(void* obj, TClass** cl)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Function is called from TStreamerInfo WriteBuffer and Readbuffer functions
+/// Function is called from TStreamerInfo WriteBuffer and ReadBuffer functions
 /// and indent new level in xml structure.
 /// This call indicates, that TStreamerInfo functions starts streaming
 /// object data of correspondent class
@@ -968,7 +968,7 @@ void  TBufferXML::WorkWithClass(TStreamerInfo* sinfo, const TClass* cl)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Function is called from TStreamerInfo WriteBuffer and Readbuffer functions
+/// Function is called from TStreamerInfo WriteBuffer and ReadBuffer functions
 /// and decrease level in xml structure.
 
 void TBufferXML::DecrementLevel(TVirtualStreamerInfo* info)
@@ -999,7 +999,7 @@ void TBufferXML::DecrementLevel(TVirtualStreamerInfo* info)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Function is called from TStreamerInfo WriteBuffer and Readbuffer functions
+/// Function is called from TStreamerInfo WriteBuffer and ReadBuffer functions
 /// and add/verify next element of xml structure
 /// This calls allows separate data, correspondent to one class member, from another
 
@@ -1010,9 +1010,9 @@ void TBufferXML::SetStreamerElementNumber(TStreamerElement *elem, Int_t comptype
 
 ////////////////////////////////////////////////////////////////////////////////
 /// This function is a part of SetStreamerElementNumber method.
-/// It is introduced for reading of data for specified data memeber of class.
+/// It is introduced for reading of data for specified data member of class.
 /// Used also in ReadFastArray methods to resolve problem of compressed data,
-/// when several data memebers of the same basic type streamed with single ...FastArray call
+/// when several data members of the same basic type streamed with single ...FastArray call
 
 void TBufferXML::WorkWithElement(TStreamerElement* elem, Int_t comp_type)
 {
@@ -1682,7 +1682,7 @@ void TBufferXML::ReadWithNbits(Float_t *ptr, Int_t /* nbits */)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Read a Double32_t from the buffer when the factor and minimun value have been specified
+/// Read a Double32_t from the buffer when the factor and minimum value have been specified
 /// see comments about Double32_t encoding at TBufferFile::WriteDouble32().
 /// Currently TBufferXML does not optimize space in this case.
 

--- a/io/xml/src/TBufferXML.cxx
+++ b/io/xml/src/TBufferXML.cxx
@@ -24,7 +24,6 @@ therefore most of ROOT and user classes can be stored to xml. There are
 limitations for complex objects like TTree, which can not be yet converted to xml.
 */
 
-
 #include "TBufferXML.h"
 #include "Compression.h"
 #include "TXMLFile.h"
@@ -46,35 +45,23 @@ limitations for complex objects like TTree, which can not be yet converted to xm
 #include "RZip.h"
 
 #ifdef R__VISUAL_CPLUSPLUS
-#define FLong64    "%I64d"
-#define FULong64   "%I64u"
+#define FLong64 "%I64d"
+#define FULong64 "%I64u"
 #else
-#define FLong64    "%lld"
-#define FULong64   "%llu"
+#define FLong64 "%lld"
+#define FULong64 "%llu"
 #endif
 
 ClassImp(TBufferXML);
-
 
 std::string TBufferXML::fgFloatFmt = "%e";
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor
 
-TBufferXML::TBufferXML() :
-   TBufferFile(),
-   TXMLSetup(),
-   fXML(0),
-   fStack(),
-   fVersionBuf(-111),
-   fObjMap(0),
-   fIdArray(0),
-   fErrorFlag(0),
-   fCanUseCompact(kFALSE),
-   fExpectedChain(kFALSE),
-   fExpectedBaseClass(0),
-   fCompressLevel(0),
-   fIOVersion(3)
+TBufferXML::TBufferXML()
+   : TBufferFile(), TXMLSetup(), fXML(0), fStack(), fVersionBuf(-111), fObjMap(0), fIdArray(0), fErrorFlag(0),
+     fCanUseCompact(kFALSE), fExpectedChain(kFALSE), fExpectedBaseClass(0), fCompressLevel(0), fIOVersion(3)
 {
 }
 
@@ -82,20 +69,9 @@ TBufferXML::TBufferXML() :
 /// Creates buffer object to serialize/deserialize data to/from xml.
 /// Mode should be either TBuffer::kRead or TBuffer::kWrite.
 
-TBufferXML::TBufferXML(TBuffer::EMode mode) :
-   TBufferFile(mode),
-   TXMLSetup(),
-   fXML(0),
-   fStack(),
-   fVersionBuf(-111),
-   fObjMap(0),
-   fIdArray(0),
-   fErrorFlag(0),
-   fCanUseCompact(kFALSE),
-   fExpectedChain(kFALSE),
-   fExpectedBaseClass(0),
-   fCompressLevel(0),
-   fIOVersion(3)
+TBufferXML::TBufferXML(TBuffer::EMode mode)
+   : TBufferFile(mode), TXMLSetup(), fXML(0), fStack(), fVersionBuf(-111), fObjMap(0), fIdArray(0), fErrorFlag(0),
+     fCanUseCompact(kFALSE), fExpectedChain(kFALSE), fExpectedBaseClass(0), fCompressLevel(0), fIOVersion(3)
 {
    fBufSize = 1000000000;
 
@@ -109,20 +85,9 @@ TBufferXML::TBufferXML(TBuffer::EMode mode) :
 /// This constructor should be used, if data from buffer supposed to be stored in file.
 /// Mode should be either TBuffer::kRead or TBuffer::kWrite.
 
-TBufferXML::TBufferXML(TBuffer::EMode mode, TXMLFile* file) :
-   TBufferFile(mode),
-   TXMLSetup(*file),
-   fXML(0),
-   fStack(),
-   fVersionBuf(-111),
-   fObjMap(0),
-   fIdArray(0),
-   fErrorFlag(0),
-   fCanUseCompact(kFALSE),
-   fExpectedChain(kFALSE),
-   fExpectedBaseClass(0),
-   fCompressLevel(0),
-   fIOVersion(3)
+TBufferXML::TBufferXML(TBuffer::EMode mode, TXMLFile *file)
+   : TBufferFile(mode), TXMLSetup(*file), fXML(0), fStack(), fVersionBuf(-111), fObjMap(0), fIdArray(0), fErrorFlag(0),
+     fCanUseCompact(kFALSE), fExpectedChain(kFALSE), fExpectedBaseClass(0), fCompressLevel(0), fIOVersion(3)
 {
    // this is for the case when StreamerInfo reads elements from
    // buffer as ReadFastArray. When it checks if size of buffer is
@@ -145,8 +110,10 @@ TBufferXML::TBufferXML(TBuffer::EMode mode, TXMLFile* file) :
 
 TBufferXML::~TBufferXML()
 {
-   if (fObjMap) delete fObjMap;
-   if (fIdArray) delete fIdArray;
+   if (fObjMap)
+      delete fObjMap;
+   if (fIdArray)
+      delete fIdArray;
    fStack.Delete();
 }
 
@@ -154,9 +121,9 @@ TBufferXML::~TBufferXML()
 /// Returns pointer to TXMLFile object.
 /// Access to file is necessary to produce unique identifier for object references.
 
-TXMLFile* TBufferXML::XmlFile()
+TXMLFile *TBufferXML::XmlFile()
 {
-   return dynamic_cast<TXMLFile*>(GetParent());
+   return dynamic_cast<TXMLFile *>(GetParent());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -165,16 +132,17 @@ TXMLFile* TBufferXML::XmlFile()
 /// UseNamespaces allow XML namespaces.
 /// See TXMLSetup class for details
 
-TString TBufferXML::ConvertToXML(const TObject* obj, Bool_t GenericLayout, Bool_t UseNamespaces)
+TString TBufferXML::ConvertToXML(const TObject *obj, Bool_t GenericLayout, Bool_t UseNamespaces)
 {
    TClass *clActual = 0;
-   void *ptr = (void *) obj;
+   void *ptr = (void *)obj;
 
-   if (obj!=0) {
+   if (obj != 0) {
       clActual = TObject::Class()->GetActualClass(obj);
-      if (!clActual) clActual = TObject::Class(); else
-      if (clActual != TObject::Class())
-         ptr = (void *) ((Long_t) obj - clActual->GetBaseClassOffset(TObject::Class()));
+      if (!clActual)
+         clActual = TObject::Class();
+      else if (clActual != TObject::Class())
+         ptr = (void *)((Long_t)obj - clActual->GetBaseClassOffset(TObject::Class()));
    }
 
    return ConvertToXML(ptr, clActual, GenericLayout, UseNamespaces);
@@ -186,7 +154,7 @@ TString TBufferXML::ConvertToXML(const TObject* obj, Bool_t GenericLayout, Bool_
 /// UseNamespaces allow XML namespaces.
 /// See TXMLSetup class for details
 
-TString TBufferXML::ConvertToXML(const void* obj, const TClass* cl, Bool_t GenericLayout, Bool_t UseNamespaces)
+TString TBufferXML::ConvertToXML(const void *obj, const TClass *cl, Bool_t GenericLayout, Bool_t UseNamespaces)
 {
    TXMLEngine xml;
 
@@ -212,21 +180,22 @@ TString TBufferXML::ConvertToXML(const void* obj, const TClass* cl, Bool_t Gener
 /// If object does not inherit from TObject class, return 0.
 /// GenericLayout and UseNamespaces should be the same as in ConvertToXML()
 
-TObject* TBufferXML::ConvertFromXML(const char* str, Bool_t GenericLayout, Bool_t UseNamespaces)
+TObject *TBufferXML::ConvertFromXML(const char *str, Bool_t GenericLayout, Bool_t UseNamespaces)
 {
-   TClass* cl = 0;
-   void* obj = ConvertFromXMLAny(str, &cl, GenericLayout, UseNamespaces);
+   TClass *cl = 0;
+   void *obj = ConvertFromXMLAny(str, &cl, GenericLayout, UseNamespaces);
 
-   if ((cl==0) || (obj==0)) return 0;
+   if ((cl == 0) || (obj == 0))
+      return 0;
 
    Int_t delta = cl->GetBaseClassOffset(TObject::Class());
 
-   if (delta<0) {
+   if (delta < 0) {
       cl->Destructor(obj);
       return 0;
    }
 
-   return (TObject*) ( ( (char*)obj ) + delta );
+   return (TObject *)(((char *)obj) + delta);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -234,7 +203,7 @@ TObject* TBufferXML::ConvertFromXML(const char* str, Bool_t GenericLayout, Bool_
 /// If cl!=0, return actual class of object.
 /// GenericLayout and UseNamespaces should be the same as in ConvertToXML()
 
-void* TBufferXML::ConvertFromXMLAny(const char* str, TClass** cl, Bool_t GenericLayout, Bool_t UseNamespaces)
+void *TBufferXML::ConvertFromXMLAny(const char *str, TClass **cl, Bool_t GenericLayout, Bool_t UseNamespaces)
 {
    TXMLEngine xml;
    TBufferXML buf(TBuffer::kRead);
@@ -246,7 +215,7 @@ void* TBufferXML::ConvertFromXMLAny(const char* str, TClass** cl, Bool_t Generic
 
    XMLNodePointer_t xmlnode = xml.ReadSingleNode(str);
 
-   void* obj = buf.XmlReadAny(xmlnode, 0, cl);
+   void *obj = buf.XmlReadAny(xmlnode, 0, cl);
 
    xml.FreeNode(xmlnode);
 
@@ -257,11 +226,12 @@ void* TBufferXML::ConvertFromXMLAny(const char* str, TClass** cl, Bool_t Generic
 /// Convert object of any class to xml structures
 /// Return pointer on top xml element
 
-XMLNodePointer_t TBufferXML::XmlWriteAny(const void* obj, const TClass* cl)
+XMLNodePointer_t TBufferXML::XmlWriteAny(const void *obj, const TClass *cl)
 {
    fErrorFlag = 0;
 
-   if (fXML==0) return 0;
+   if (fXML == 0)
+      return 0;
 
    XMLNodePointer_t res = XmlWriteObject(obj, cl);
 
@@ -273,18 +243,21 @@ XMLNodePointer_t TBufferXML::XmlWriteAny(const void* obj, const TClass* cl)
 /// Return pointer to read object.
 /// if (cl!=0) returns pointer to class of object
 
-void* TBufferXML::XmlReadAny(XMLNodePointer_t node, void* obj, TClass** cl)
+void *TBufferXML::XmlReadAny(XMLNodePointer_t node, void *obj, TClass **cl)
 {
-   if (node==0) return 0;
-   if (cl) *cl = 0;
+   if (node == 0)
+      return 0;
+   if (cl)
+      *cl = 0;
 
    fErrorFlag = 0;
 
-   if (fXML==0) return 0;
+   if (fXML == 0)
+      return 0;
 
    PushStack(node, kTRUE);
 
-   void* res = XmlReadObject(obj, cl);
+   void *res = XmlReadObject(obj, cl);
 
    PopStack();
 
@@ -307,47 +280,42 @@ void TBufferXML::WriteObject(const TObject *obj)
 // stored in subnodes, but initial object node will be kept.
 
 class TXMLStackObj : public TObject {
-   public:
-      TXMLStackObj(XMLNodePointer_t node) :
-         TObject(),
-         fNode(node),
-         fInfo(0),
-         fElem(0),
-         fElemNumber(0),
-         fCompressedClassNode(kFALSE),
-         fClassNs(0),
-         fIsStreamerInfo(kFALSE),
-         fIsElemOwner(kFALSE)
-          {}
+public:
+   TXMLStackObj(XMLNodePointer_t node)
+      : TObject(), fNode(node), fInfo(0), fElem(0), fElemNumber(0), fCompressedClassNode(kFALSE), fClassNs(0),
+        fIsStreamerInfo(kFALSE), fIsElemOwner(kFALSE)
+   {
+   }
 
-      virtual ~TXMLStackObj()
-      {
-         if (fIsElemOwner) delete fElem;
-      }
+   virtual ~TXMLStackObj()
+   {
+      if (fIsElemOwner)
+         delete fElem;
+   }
 
-      Bool_t IsStreamerInfo() const { return fIsStreamerInfo; }
+   Bool_t IsStreamerInfo() const { return fIsStreamerInfo; }
 
-      XMLNodePointer_t  fNode;
-      TStreamerInfo*    fInfo;
-      TStreamerElement* fElem;
-      Int_t             fElemNumber;
-      Bool_t            fCompressedClassNode;
-      XMLNsPointer_t    fClassNs;
-      Bool_t            fIsStreamerInfo;
-      Bool_t            fIsElemOwner;
+   XMLNodePointer_t fNode;
+   TStreamerInfo *fInfo;
+   TStreamerElement *fElem;
+   Int_t fElemNumber;
+   Bool_t fCompressedClassNode;
+   XMLNsPointer_t fClassNs;
+   Bool_t fIsStreamerInfo;
+   Bool_t fIsElemOwner;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Add new level to xml stack.
 
-TXMLStackObj* TBufferXML::PushStack(XMLNodePointer_t current, Bool_t simple)
+TXMLStackObj *TBufferXML::PushStack(XMLNodePointer_t current, Bool_t simple)
 {
    if (IsReading() && !simple) {
       current = fXML->GetChild(current);
       fXML->SkipEmpty(current);
    }
 
-   TXMLStackObj* stack = new TXMLStackObj(current);
+   TXMLStackObj *stack = new TXMLStackObj(current);
    fStack.Add(stack);
    return stack;
 }
@@ -355,25 +323,25 @@ TXMLStackObj* TBufferXML::PushStack(XMLNodePointer_t current, Bool_t simple)
 ////////////////////////////////////////////////////////////////////////////////
 /// Remove one level from xml stack.
 
-TXMLStackObj* TBufferXML::PopStack()
+TXMLStackObj *TBufferXML::PopStack()
 {
-   TObject* last = fStack.Last();
-   if (last!=0) {
+   TObject *last = fStack.Last();
+   if (last != 0) {
       fStack.Remove(last);
       delete last;
       fStack.Compress();
    }
-   return dynamic_cast<TXMLStackObj*> (fStack.Last());
+   return dynamic_cast<TXMLStackObj *>(fStack.Last());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return xml stack object of specified depth.
 
-TXMLStackObj* TBufferXML::Stack(Int_t depth)
+TXMLStackObj *TBufferXML::Stack(Int_t depth)
 {
-   TXMLStackObj* stack = 0;
-   if (depth<=fStack.GetLast())
-      stack = dynamic_cast<TXMLStackObj*> (fStack.At(fStack.GetLast()-depth));
+   TXMLStackObj *stack = 0;
+   if (depth <= fStack.GetLast())
+      stack = dynamic_cast<TXMLStackObj *>(fStack.At(fStack.GetLast() - depth));
    return stack;
 }
 
@@ -382,19 +350,20 @@ TXMLStackObj* TBufferXML::Stack(Int_t depth)
 
 XMLNodePointer_t TBufferXML::StackNode()
 {
-   TXMLStackObj* stack = dynamic_cast<TXMLStackObj*> (fStack.Last());
-   return (stack==0) ? 0 : stack->fNode;
+   TXMLStackObj *stack = dynamic_cast<TXMLStackObj *>(fStack.Last());
+   return (stack == 0) ? 0 : stack->fNode;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Shift stack node to next.
 
-void TBufferXML::ShiftStack(const char* errinfo)
+void TBufferXML::ShiftStack(const char *errinfo)
 {
-   TXMLStackObj* stack = dynamic_cast<TXMLStackObj*> (fStack.Last());
+   TXMLStackObj *stack = dynamic_cast<TXMLStackObj *>(fStack.Last());
    if (stack) {
       fXML->ShiftToNext(stack->fNode);
-      if (gDebug>4) Info("ShiftStack","%s to node %s", errinfo, fXML->GetNodeName(stack->fNode));
+      if (gDebug > 4)
+         Info("ShiftStack", "%s to node %s", errinfo, fXML->GetNodeName(stack->fNode));
    }
 }
 
@@ -403,7 +372,8 @@ void TBufferXML::ShiftStack(const char* errinfo)
 
 void TBufferXML::SetCompressionAlgorithm(Int_t algorithm)
 {
-   if (algorithm < 0 || algorithm >= ROOT::kUndefinedCompressionAlgorithm) algorithm = 0;
+   if (algorithm < 0 || algorithm >= ROOT::kUndefinedCompressionAlgorithm)
+      algorithm = 0;
    if (fCompressLevel < 0) {
       // if the level is not defined yet use 1 as a default
       fCompressLevel = 100 * algorithm + 1;
@@ -418,14 +388,17 @@ void TBufferXML::SetCompressionAlgorithm(Int_t algorithm)
 
 void TBufferXML::SetCompressionLevel(Int_t level)
 {
-   if (level < 0) level = 0;
-   if (level > 99) level = 99;
+   if (level < 0)
+      level = 0;
+   if (level > 99)
+      level = 99;
    if (fCompressLevel < 0) {
       // if the algorithm is not defined yet use 0 as a default
       fCompressLevel = level;
    } else {
       int algorithm = fCompressLevel / 100;
-      if (algorithm >= ROOT::kUndefinedCompressionAlgorithm) algorithm = 0;
+      if (algorithm >= ROOT::kUndefinedCompressionAlgorithm)
+         algorithm = 0;
       fCompressLevel = 100 * algorithm + level;
    }
 }
@@ -446,50 +419,52 @@ void TBufferXML::SetCompressionSettings(Int_t settings)
 
 void TBufferXML::XmlWriteBlock(XMLNodePointer_t node)
 {
-   if ((node==0) || (Length()==0)) return;
+   if ((node == 0) || (Length() == 0))
+      return;
 
-   const char* src = Buffer();
+   const char *src = Buffer();
    int srcSize = Length();
 
-   char* fZipBuffer = 0;
+   char *fZipBuffer = 0;
 
    Int_t compressionLevel = GetCompressionLevel();
-   ROOT::ECompressionAlgorithm compressionAlgorithm = static_cast<ROOT::ECompressionAlgorithm>(GetCompressionAlgorithm());
+   ROOT::ECompressionAlgorithm compressionAlgorithm =
+      static_cast<ROOT::ECompressionAlgorithm>(GetCompressionAlgorithm());
 
    if ((Length() > 512) && (compressionLevel > 0)) {
       int zipBufferSize = Length();
       fZipBuffer = new char[zipBufferSize + 9];
       int dataSize = Length();
       int compressedSize = 0;
-      R__zipMultipleAlgorithm(compressionLevel, &dataSize, Buffer(), &zipBufferSize,
-                              fZipBuffer, &compressedSize,
+      R__zipMultipleAlgorithm(compressionLevel, &dataSize, Buffer(), &zipBufferSize, fZipBuffer, &compressedSize,
                               compressionAlgorithm);
       if (compressedSize > 0) {
-        src = fZipBuffer;
-        srcSize = compressedSize;
+         src = fZipBuffer;
+         srcSize = compressedSize;
       } else {
-        delete[] fZipBuffer;
-        fZipBuffer = 0;
+         delete[] fZipBuffer;
+         fZipBuffer = 0;
       }
    }
 
    TString res;
    char sbuf[500];
    int block = 0;
-   char* tgt = sbuf;
+   char *tgt = sbuf;
    int srcCnt = 0;
 
-   while (srcCnt++<srcSize) {
-      tgt+=sprintf(tgt, " %02x", (unsigned char) *src);
+   while (srcCnt++ < srcSize) {
+      tgt += sprintf(tgt, " %02x", (unsigned char)*src);
       src++;
-      if (block++==100) {
+      if (block++ == 100) {
          res += sbuf;
          block = 0;
          tgt = sbuf;
       }
    }
 
-   if (block>0) res += sbuf;
+   if (block > 0)
+      res += sbuf;
 
    XMLNodePointer_t blocknode = fXML->NewChild(node, 0, xmlio::XmlBlock, res);
    fXML->NewIntAttr(blocknode, xmlio::Size, Length());
@@ -505,19 +480,20 @@ void TBufferXML::XmlWriteBlock(XMLNodePointer_t node)
 
 void TBufferXML::XmlReadBlock(XMLNodePointer_t blocknode)
 {
-   if (blocknode==0) return;
+   if (blocknode == 0)
+      return;
 
    Int_t blockSize = fXML->GetIntAttr(blocknode, xmlio::Size);
    Bool_t blockCompressed = fXML->HasAttr(blocknode, xmlio::Zip);
-   char* fUnzipBuffer = 0;
+   char *fUnzipBuffer = 0;
 
-   if (gDebug>2)
-      Info("XmlReadBlock","Block size = %d, Length = %d, Compressed = %d",
-                           blockSize, Length(), blockCompressed);
+   if (gDebug > 2)
+      Info("XmlReadBlock", "Block size = %d, Length = %d, Compressed = %d", blockSize, Length(), blockCompressed);
 
-   if (blockSize>BufferSize()) Expand(blockSize);
+   if (blockSize > BufferSize())
+      Expand(blockSize);
 
-   char* tgt = Buffer();
+   char *tgt = Buffer();
    Int_t readSize = blockSize;
 
    TString content = fXML->GetNodeContent(blocknode);
@@ -530,40 +506,41 @@ void TBufferXML::XmlReadBlock(XMLNodePointer_t blocknode)
       readSize = zipSize;
    }
 
-   char* ptr = (char*) content.Data();
+   char *ptr = (char *)content.Data();
 
-   if (gDebug>3)
-      Info("XmlReadBlock","Content %s", ptr);
+   if (gDebug > 3)
+      Info("XmlReadBlock", "Content %s", ptr);
 
-   for (int i=0;i<readSize;i++) {
-      while ((*ptr<48) || ((*ptr>57) && (*ptr<97)) || (*ptr>102)) ptr++;
+   for (int i = 0; i < readSize; i++) {
+      while ((*ptr < 48) || ((*ptr > 57) && (*ptr < 97)) || (*ptr > 102))
+         ptr++;
 
-      int b_hi = (*ptr>57) ? *ptr-87 : *ptr-48;
+      int b_hi = (*ptr > 57) ? *ptr - 87 : *ptr - 48;
       ptr++;
-      int b_lo = (*ptr>57) ? *ptr-87 : *ptr-48;
+      int b_lo = (*ptr > 57) ? *ptr - 87 : *ptr - 48;
       ptr++;
 
-      *tgt=b_hi*16+b_lo;
+      *tgt = b_hi * 16 + b_lo;
       tgt++;
 
-      if (gDebug>4) Info("XmlReadBlock","    Buf[%d] = %d", i, b_hi*16+b_lo);
+      if (gDebug > 4)
+         Info("XmlReadBlock", "    Buf[%d] = %d", i, b_hi * 16 + b_lo);
    }
 
    if (fUnzipBuffer) {
 
       int srcsize;
       int tgtsize;
-      int status = R__unzip_header(&srcsize, (UChar_t*) fUnzipBuffer, &tgtsize);
+      int status = R__unzip_header(&srcsize, (UChar_t *)fUnzipBuffer, &tgtsize);
 
       int unzipRes = 0;
       if (status == 0) {
-        R__unzip(&readSize, (unsigned char*) fUnzipBuffer, &blockSize,
-                            (unsigned char*) Buffer(), &unzipRes);
+         R__unzip(&readSize, (unsigned char *)fUnzipBuffer, &blockSize, (unsigned char *)Buffer(), &unzipRes);
       }
-      if (status != 0 || unzipRes!=blockSize)
+      if (status != 0 || unzipRes != blockSize)
          Error("XmlReadBlock", "Decompression error %d", unzipRes);
-      else
-         if (gDebug>2) Info("XmlReadBlock","Unzip ok");
+      else if (gDebug > 2)
+         Info("XmlReadBlock", "Unzip ok");
       delete[] fUnzipBuffer;
    }
 }
@@ -573,21 +550,24 @@ void TBufferXML::XmlReadBlock(XMLNodePointer_t blocknode)
 /// if ptr is pointer on object, which is already saved in buffer
 /// Automatically add "ref" attribute to node, where referenced object is stored
 
-Bool_t TBufferXML::ProcessPointer(const void* ptr, XMLNodePointer_t node)
+Bool_t TBufferXML::ProcessPointer(const void *ptr, XMLNodePointer_t node)
 {
-   if (node==0) return kFALSE;
+   if (node == 0)
+      return kFALSE;
 
    TString refvalue;
 
-   if (ptr==0)
-      refvalue = xmlio::Null;   //null
+   if (ptr == 0)
+      refvalue = xmlio::Null; // null
    else {
-      if (fObjMap==0) return kFALSE;
+      if (fObjMap == 0)
+         return kFALSE;
 
-      ULong_t hash = TString::Hash(&ptr, sizeof(void*));
+      ULong_t hash = TString::Hash(&ptr, sizeof(void *));
 
-      XMLNodePointer_t refnode = (XMLNodePointer_t) (Long_t)fObjMap->GetValue(hash, (Long_t) ptr);
-      if (refnode==0) return kFALSE;
+      XMLNodePointer_t refnode = (XMLNodePointer_t)(Long_t)fObjMap->GetValue(hash, (Long_t)ptr);
+      if (refnode == 0)
+         return kFALSE;
 
       if (fXML->HasAttr(refnode, xmlio::Ref))
          refvalue = fXML->GetAttr(refnode, xmlio::Ref);
@@ -600,7 +580,7 @@ Bool_t TBufferXML::ProcessPointer(const void* ptr, XMLNodePointer_t node)
          fXML->NewAttr(refnode, 0, xmlio::Ref, refvalue.Data());
       }
    }
-   if (refvalue.Length()>0) {
+   if (refvalue.Length() > 0) {
       fXML->NewAttr(node, 0, xmlio::Ptr, refvalue.Data());
       return kTRUE;
    }
@@ -612,43 +592,48 @@ Bool_t TBufferXML::ProcessPointer(const void* ptr, XMLNodePointer_t node)
 /// Register pair of object pointer and node, where this object is saved,
 /// in object map
 
-void TBufferXML::RegisterPointer(const void* ptr, XMLNodePointer_t node)
+void TBufferXML::RegisterPointer(const void *ptr, XMLNodePointer_t node)
 {
-   if ((node==0) || (ptr==0)) return;
+   if ((node == 0) || (ptr == 0))
+      return;
 
-   ULong_t hash = TString::Hash(&ptr, sizeof(void*));
+   ULong_t hash = TString::Hash(&ptr, sizeof(void *));
 
-   if (fObjMap==0) fObjMap = new TExMap();
+   if (fObjMap == 0)
+      fObjMap = new TExMap();
 
-   if (fObjMap->GetValue(hash, (Long_t) ptr)==0)
-      fObjMap->Add(hash, (Long_t) ptr, (Long_t) node);
+   if (fObjMap->GetValue(hash, (Long_t)ptr) == 0)
+      fObjMap->Add(hash, (Long_t)ptr, (Long_t)node);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Searches for "ptr" attribute and returns pointer to object and class,
 /// if "ptr" attribute reference to read object
 
-Bool_t TBufferXML::ExtractPointer(XMLNodePointer_t node, void* &ptr, TClass* &cl)
+Bool_t TBufferXML::ExtractPointer(XMLNodePointer_t node, void *&ptr, TClass *&cl)
 {
    cl = 0;
 
-   if (!fXML->HasAttr(node,xmlio::Ptr)) return kFALSE;
+   if (!fXML->HasAttr(node, xmlio::Ptr))
+      return kFALSE;
 
-   const char* ptrid = fXML->GetAttr(node, xmlio::Ptr);
+   const char *ptrid = fXML->GetAttr(node, xmlio::Ptr);
 
-   if (ptrid==0) return kFALSE;
+   if (ptrid == 0)
+      return kFALSE;
 
    // null
-   if (strcmp(ptrid, xmlio::Null)==0) {
+   if (strcmp(ptrid, xmlio::Null) == 0) {
       ptr = 0;
       return kTRUE;
    }
 
-   if ((fIdArray==0) || (fObjMap==0)) return kFALSE;
+   if ((fIdArray == 0) || (fObjMap == 0))
+      return kFALSE;
 
-   TNamed* obj = (TNamed*) fIdArray->FindObject(ptrid);
+   TNamed *obj = (TNamed *)fIdArray->FindObject(ptrid);
    if (obj) {
-      ptr = (void*) (Long_t)fObjMap->GetValue((Long_t) fIdArray->IndexOf(obj));
+      ptr = (void *)(Long_t)fObjMap->GetValue((Long_t)fIdArray->IndexOf(obj));
       cl = TClass::GetClass(obj->GetTitle());
       return kTRUE;
    }
@@ -658,40 +643,43 @@ Bool_t TBufferXML::ExtractPointer(XMLNodePointer_t node, void* &ptr, TClass* &cl
 ////////////////////////////////////////////////////////////////////////////////
 /// Analyze if node has "ref" attribute and register it to object map
 
-void TBufferXML::ExtractReference(XMLNodePointer_t node, const void* ptr, const TClass* cl)
+void TBufferXML::ExtractReference(XMLNodePointer_t node, const void *ptr, const TClass *cl)
 {
-   if ((node==0) || (ptr==0)) return;
+   if ((node == 0) || (ptr == 0))
+      return;
 
-   const char* refid = fXML->GetAttr(node, xmlio::Ref);
+   const char *refid = fXML->GetAttr(node, xmlio::Ref);
 
-   if (refid==0) return;
+   if (refid == 0)
+      return;
 
-   if (fIdArray==0) {
+   if (fIdArray == 0) {
       fIdArray = new TObjArray;
       fIdArray->SetOwner(kTRUE);
    }
-   TNamed* nid = new TNamed(refid, cl->GetName());
+   TNamed *nid = new TNamed(refid, cl->GetName());
    fIdArray->Add(nid);
 
-   if (fObjMap==0) fObjMap = new TExMap();
+   if (fObjMap == 0)
+      fObjMap = new TExMap();
 
-   fObjMap->Add((Long_t) fIdArray->IndexOf(nid), (Long_t) ptr);
+   fObjMap->Add((Long_t)fIdArray->IndexOf(nid), (Long_t)ptr);
 
-   if (gDebug>2)
-      Info("ExtractReference","Find reference %s for object %p", refid, ptr);
+   if (gDebug > 2)
+      Info("ExtractReference", "Find reference %s for object %p", refid, ptr);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Check if node has specified name
 
-Bool_t TBufferXML::VerifyNode(XMLNodePointer_t node, const char* name, const char* errinfo)
+Bool_t TBufferXML::VerifyNode(XMLNodePointer_t node, const char *name, const char *errinfo)
 {
-   if ((name==0) || (node==0)) return kFALSE;
+   if ((name == 0) || (node == 0))
+      return kFALSE;
 
-   if (strcmp(fXML->GetNodeName(node), name)!=0) {
+   if (strcmp(fXML->GetNodeName(node), name) != 0) {
       if (errinfo) {
-         Error("VerifyNode","Reading XML file (%s). Get: %s, expects: %s",
-                errinfo, fXML->GetNodeName(node), name);
+         Error("VerifyNode", "Reading XML file (%s). Get: %s, expects: %s", errinfo, fXML->GetNodeName(node), name);
          fErrorFlag = 1;
       }
       return kFALSE;
@@ -702,22 +690,22 @@ Bool_t TBufferXML::VerifyNode(XMLNodePointer_t node, const char* name, const cha
 ////////////////////////////////////////////////////////////////////////////////
 /// Check, if stack node has specified name
 
-Bool_t TBufferXML::VerifyStackNode(const char* name, const char* errinfo)
+Bool_t TBufferXML::VerifyStackNode(const char *name, const char *errinfo)
 {
    return VerifyNode(StackNode(), name, errinfo);
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Checks, that attribute of specified name exists and has specified value
 
-Bool_t TBufferXML::VerifyAttr(XMLNodePointer_t node, const char* name, const char* value, const char* errinfo)
+Bool_t TBufferXML::VerifyAttr(XMLNodePointer_t node, const char *name, const char *value, const char *errinfo)
 {
-   if ((node==0) || (name==0) || (value==0)) return kFALSE;
-   const char* cont = fXML->GetAttr(node, name);
-   if (((cont==0) || (strcmp(cont, value)!=0))) {
-      if  (errinfo) {
-         Error("VerifyAttr","%s : attr %s = %s, expected: %s", errinfo, name, cont, value);
+   if ((node == 0) || (name == 0) || (value == 0))
+      return kFALSE;
+   const char *cont = fXML->GetAttr(node, name);
+   if (((cont == 0) || (strcmp(cont, value) != 0))) {
+      if (errinfo) {
+         Error("VerifyAttr", "%s : attr %s = %s, expected: %s", errinfo, name, cont, value);
          fErrorFlag = 1;
       }
       return kFALSE;
@@ -728,7 +716,7 @@ Bool_t TBufferXML::VerifyAttr(XMLNodePointer_t node, const char* name, const cha
 ////////////////////////////////////////////////////////////////////////////////
 /// Checks stack attribute
 
-Bool_t TBufferXML::VerifyStackAttr(const char* name, const char* value, const char* errinfo)
+Bool_t TBufferXML::VerifyStackAttr(const char *name, const char *value, const char *errinfo)
 {
    return VerifyAttr(StackNode(), name, value, errinfo);
 }
@@ -736,10 +724,10 @@ Bool_t TBufferXML::VerifyStackAttr(const char* name, const char* value, const ch
 ////////////////////////////////////////////////////////////////////////////////
 /// Create item node of specified name
 
-XMLNodePointer_t TBufferXML::CreateItemNode(const char* name)
+XMLNodePointer_t TBufferXML::CreateItemNode(const char *name)
 {
    XMLNodePointer_t node = 0;
-   if (GetXmlLayout()==kGeneralized) {
+   if (GetXmlLayout() == kGeneralized) {
       node = fXML->NewChild(StackNode(), 0, xmlio::Item, 0);
       fXML->NewAttr(node, 0, xmlio::Name, name);
    } else
@@ -750,12 +738,11 @@ XMLNodePointer_t TBufferXML::CreateItemNode(const char* name)
 ////////////////////////////////////////////////////////////////////////////////
 /// Checks, if stack node is item and has specified name
 
-Bool_t TBufferXML::VerifyItemNode(const char* name, const char* errinfo)
+Bool_t TBufferXML::VerifyItemNode(const char *name, const char *errinfo)
 {
    Bool_t res = kTRUE;
-   if (GetXmlLayout()==kGeneralized)
-      res = VerifyStackNode(xmlio::Item, errinfo) &&
-            VerifyStackAttr(xmlio::Name, name, errinfo);
+   if (GetXmlLayout() == kGeneralized)
+      res = VerifyStackNode(xmlio::Item, errinfo) && VerifyStackAttr(xmlio::Name, name, errinfo);
    else
       res = VerifyStackNode(name, errinfo);
    return res;
@@ -764,49 +751,52 @@ Bool_t TBufferXML::VerifyItemNode(const char* name, const char* errinfo)
 ////////////////////////////////////////////////////////////////////////////////
 /// Create xml node correspondent to TStreamerElement object
 
-void TBufferXML::CreateElemNode(const TStreamerElement* elem)
+void TBufferXML::CreateElemNode(const TStreamerElement *elem)
 {
    XMLNodePointer_t elemnode = 0;
 
-   const char* elemxmlname = XmlGetElementName(elem);
+   const char *elemxmlname = XmlGetElementName(elem);
 
-   if (GetXmlLayout()==kGeneralized) {
+   if (GetXmlLayout() == kGeneralized) {
       elemnode = fXML->NewChild(StackNode(), 0, xmlio::Member, 0);
       fXML->NewAttr(elemnode, 0, xmlio::Name, elemxmlname);
    } else {
       // take namesapce for element only if it is not a base class or class name
       XMLNsPointer_t ns = Stack()->fClassNs;
-      if ((elem->GetType()==TStreamerInfo::kBase)
-           || ((elem->GetType()==TStreamerInfo::kTNamed) && !strcmp(elem->GetName(), TNamed::Class()->GetName()))
-           || ((elem->GetType()==TStreamerInfo::kTObject) && !strcmp(elem->GetName(), TObject::Class()->GetName()))
-           || ((elem->GetType()==TStreamerInfo::kTString) && !strcmp(elem->GetName(), TString::Class()->GetName())))
+      if ((elem->GetType() == TStreamerInfo::kBase) ||
+          ((elem->GetType() == TStreamerInfo::kTNamed) && !strcmp(elem->GetName(), TNamed::Class()->GetName())) ||
+          ((elem->GetType() == TStreamerInfo::kTObject) && !strcmp(elem->GetName(), TObject::Class()->GetName())) ||
+          ((elem->GetType() == TStreamerInfo::kTString) && !strcmp(elem->GetName(), TString::Class()->GetName())))
          ns = 0;
 
       elemnode = fXML->NewChild(StackNode(), ns, elemxmlname, 0);
    }
 
-   TXMLStackObj* curr = PushStack(elemnode);
-   curr->fElem = (TStreamerElement*)elem;
+   TXMLStackObj *curr = PushStack(elemnode);
+   curr->fElem = (TStreamerElement *)elem;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Checks if stack node correspond to TStreamerElement object
 
-Bool_t TBufferXML::VerifyElemNode(const TStreamerElement* elem)
+Bool_t TBufferXML::VerifyElemNode(const TStreamerElement *elem)
 {
-   const char* elemxmlname = XmlGetElementName(elem);
+   const char *elemxmlname = XmlGetElementName(elem);
 
-   if (GetXmlLayout()==kGeneralized) {
-      if (!VerifyStackNode(xmlio::Member)) return kFALSE;
-      if (!VerifyStackAttr(xmlio::Name, elemxmlname)) return kFALSE;
+   if (GetXmlLayout() == kGeneralized) {
+      if (!VerifyStackNode(xmlio::Member))
+         return kFALSE;
+      if (!VerifyStackAttr(xmlio::Name, elemxmlname))
+         return kFALSE;
    } else {
-      if (!VerifyStackNode(elemxmlname)) return kFALSE;
+      if (!VerifyStackNode(elemxmlname))
+         return kFALSE;
    }
 
    PerformPreProcessing(elem, StackNode());
 
-   TXMLStackObj* curr = PushStack(StackNode()); // set pointer to first data inside element
-   curr->fElem = (TStreamerElement*)elem;
+   TXMLStackObj *curr = PushStack(StackNode()); // set pointer to first data inside element
+   curr->fElem = (TStreamerElement *)elem;
    return kTRUE;
 }
 
@@ -815,12 +805,14 @@ Bool_t TBufferXML::VerifyElemNode(const TStreamerElement* elem)
 /// If object was written before, only pointer will be stored
 /// Return pointer to top xml node, representing object
 
-XMLNodePointer_t TBufferXML::XmlWriteObject(const void* obj, const TClass* cl)
+XMLNodePointer_t TBufferXML::XmlWriteObject(const void *obj, const TClass *cl)
 {
    XMLNodePointer_t objnode = fXML->NewChild(StackNode(), 0, xmlio::Object, 0);
 
-   if (!cl) obj = 0;
-   if (ProcessPointer(obj, objnode)) return objnode;
+   if (!cl)
+      obj = 0;
+   if (ProcessPointer(obj, objnode))
+      return objnode;
 
    TString clname = XmlConvertClassName(cl->GetName());
 
@@ -830,12 +822,12 @@ XMLNodePointer_t TBufferXML::XmlWriteObject(const void* obj, const TClass* cl)
 
    PushStack(objnode);
 
-   ((TClass*)cl)->Streamer((void*)obj, *this);
+   ((TClass *)cl)->Streamer((void *)obj, *this);
 
    PopStack();
 
-   if (gDebug>1)
-      Info("XmlWriteObject","Done write for class: %s", cl ? cl->GetName() : "null");
+   if (gDebug > 1)
+      Info("XmlWriteObject", "Done write for class: %s", cl ? cl->GetName() : "null");
 
    return objnode;
 }
@@ -843,55 +835,63 @@ XMLNodePointer_t TBufferXML::XmlWriteObject(const void* obj, const TClass* cl)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read object from the buffer
 
-void* TBufferXML::XmlReadObject(void* obj, TClass** cl)
+void *TBufferXML::XmlReadObject(void *obj, TClass **cl)
 {
-   if (cl) *cl = 0;
+   if (cl)
+      *cl = 0;
 
    XMLNodePointer_t objnode = StackNode();
 
-   if (fErrorFlag>0) return obj;
+   if (fErrorFlag > 0)
+      return obj;
 
-   if (objnode==0) return obj;
+   if (objnode == 0)
+      return obj;
 
-   if (!VerifyNode(objnode, xmlio::Object, "XmlReadObjectNew")) return obj;
+   if (!VerifyNode(objnode, xmlio::Object, "XmlReadObjectNew"))
+      return obj;
 
-   TClass* objClass = 0;
+   TClass *objClass = 0;
 
    if (ExtractPointer(objnode, obj, objClass)) {
       ShiftStack("readobjptr");
-      if (cl) *cl = objClass;
+      if (cl)
+         *cl = objClass;
       return obj;
    }
 
    TString clname = fXML->GetAttr(objnode, xmlio::ObjClass);
    objClass = XmlDefineClass(clname);
-   if (objClass == TDirectory::Class()) objClass = TDirectoryFile::Class();
+   if (objClass == TDirectory::Class())
+      objClass = TDirectoryFile::Class();
 
-   if (objClass==0) {
+   if (objClass == 0) {
       Error("XmlReadObject", "Cannot find class %s", clname.Data());
       ShiftStack("readobjerr");
       return obj;
    }
 
-   if (gDebug>1)
+   if (gDebug > 1)
       Info("XmlReadObject", "Reading object of class %s", clname.Data());
 
-   if (obj==0) obj = objClass->New();
+   if (obj == 0)
+      obj = objClass->New();
 
    ExtractReference(objnode, obj, objClass);
 
    PushStack(objnode);
 
-   objClass->Streamer((void*)obj, *this);
+   objClass->Streamer((void *)obj, *this);
 
    PopStack();
 
    ShiftStack("readobj");
 
-   if (gDebug>1)
+   if (gDebug > 1)
       Info("XmlReadObject", "Reading object of class %s done", clname.Data());
 
-   if (cl) *cl = objClass;
+   if (cl)
+      *cl = objClass;
 
    return obj;
 }
@@ -902,31 +902,34 @@ void* TBufferXML::XmlReadObject(void* obj, TClass** cl)
 /// This call indicates, that TStreamerInfo functions starts streaming
 /// object data of correspondent class
 
-void TBufferXML::IncrementLevel(TVirtualStreamerInfo* info)
+void TBufferXML::IncrementLevel(TVirtualStreamerInfo *info)
 {
-   WorkWithClass((TStreamerInfo*)info);
+   WorkWithClass((TStreamerInfo *)info);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Prepares buffer to stream data of specified class.
 
-void  TBufferXML::WorkWithClass(TStreamerInfo* sinfo, const TClass* cl)
+void TBufferXML::WorkWithClass(TStreamerInfo *sinfo, const TClass *cl)
 {
    fCanUseCompact = kFALSE;
    fExpectedChain = kFALSE;
 
-   if (sinfo!=0) cl = sinfo->GetClass();
+   if (sinfo != 0)
+      cl = sinfo->GetClass();
 
-   if (cl==0) return;
+   if (cl == 0)
+      return;
 
    TString clname = XmlConvertClassName(cl->GetName());
 
-   if (gDebug>2) Info("IncrementLevel","Class: %s", clname.Data());
+   if (gDebug > 2)
+      Info("IncrementLevel", "Class: %s", clname.Data());
 
-   Bool_t compressClassNode = fExpectedBaseClass==cl;
+   Bool_t compressClassNode = fExpectedBaseClass == cl;
    fExpectedBaseClass = 0;
 
-   TXMLStackObj* stack = Stack();
+   TXMLStackObj *stack = Stack();
 
    if (IsWriting()) {
 
@@ -934,7 +937,7 @@ void  TBufferXML::WorkWithClass(TStreamerInfo* sinfo, const TClass* cl)
       if (compressClassNode) {
          classnode = StackNode();
       } else {
-         if (GetXmlLayout()==kGeneralized) {
+         if (GetXmlLayout() == kGeneralized) {
             classnode = fXML->NewChild(StackNode(), 0, xmlio::Class, 0);
             fXML->NewAttr(classnode, 0, "name", clname);
          } else
@@ -942,22 +945,25 @@ void  TBufferXML::WorkWithClass(TStreamerInfo* sinfo, const TClass* cl)
          stack = PushStack(classnode);
       }
 
-      if (fVersionBuf>=-1) {
-         if (fVersionBuf == -1) fVersionBuf = 1;
+      if (fVersionBuf >= -1) {
+         if (fVersionBuf == -1)
+            fVersionBuf = 1;
          fXML->NewIntAttr(classnode, xmlio::ClassVersion, fVersionBuf);
          fVersionBuf = -111;
       }
 
-      if (IsUseNamespaces() && (GetXmlLayout()!=kGeneralized))
+      if (IsUseNamespaces() && (GetXmlLayout() != kGeneralized))
          stack->fClassNs = fXML->NewNS(classnode, XmlClassNameSpaceRef(cl), clname);
 
    } else {
       if (!compressClassNode) {
-         if (GetXmlLayout()==kGeneralized) {
-            if (!VerifyStackNode(xmlio::Class, "StartInfo")) return;
-            if (!VerifyStackAttr("name", clname, "StartInfo")) return;
-         } else
-            if (!VerifyStackNode(clname, "StartInfo")) return;
+         if (GetXmlLayout() == kGeneralized) {
+            if (!VerifyStackNode(xmlio::Class, "StartInfo"))
+               return;
+            if (!VerifyStackAttr("name", clname, "StartInfo"))
+               return;
+         } else if (!VerifyStackNode(clname, "StartInfo"))
+            return;
          stack = PushStack(StackNode());
       }
    }
@@ -971,21 +977,21 @@ void  TBufferXML::WorkWithClass(TStreamerInfo* sinfo, const TClass* cl)
 /// Function is called from TStreamerInfo WriteBuffer and ReadBuffer functions
 /// and decrease level in xml structure.
 
-void TBufferXML::DecrementLevel(TVirtualStreamerInfo* info)
+void TBufferXML::DecrementLevel(TVirtualStreamerInfo *info)
 {
    CheckVersionBuf();
 
    fCanUseCompact = kFALSE;
    fExpectedChain = kFALSE;
 
-   if (gDebug>2)
-      Info("DecrementLevel","Class: %s", (info ? info->GetClass()->GetName() : "custom"));
+   if (gDebug > 2)
+      Info("DecrementLevel", "Class: %s", (info ? info->GetClass()->GetName() : "custom"));
 
-   TXMLStackObj* stack = Stack();
+   TXMLStackObj *stack = Stack();
 
    if (!stack->IsStreamerInfo()) {
       PerformPostProcessing();
-      stack = PopStack();  // remove stack of last element
+      stack = PopStack(); // remove stack of last element
    }
 
    if (stack->fCompressedClassNode) {
@@ -993,8 +999,9 @@ void TBufferXML::DecrementLevel(TVirtualStreamerInfo* info)
       stack->fIsStreamerInfo = kFALSE;
       stack->fCompressedClassNode = kFALSE;
    } else {
-      PopStack();                       // back from data of stack info
-      if (IsReading()) ShiftStack("declevel"); // shift to next element after streamer info
+      PopStack(); // back from data of stack info
+      if (IsReading())
+         ShiftStack("declevel"); // shift to next element after streamer info
    }
 }
 
@@ -1014,7 +1021,7 @@ void TBufferXML::SetStreamerElementNumber(TStreamerElement *elem, Int_t comptype
 /// Used also in ReadFastArray methods to resolve problem of compressed data,
 /// when several data members of the same basic type streamed with single ...FastArray call
 
-void TBufferXML::WorkWithElement(TStreamerElement* elem, Int_t comp_type)
+void TBufferXML::WorkWithElement(TStreamerElement *elem, Int_t comp_type)
 {
    CheckVersionBuf();
 
@@ -1022,20 +1029,21 @@ void TBufferXML::WorkWithElement(TStreamerElement* elem, Int_t comp_type)
    fCanUseCompact = kFALSE;
    fExpectedBaseClass = 0;
 
-   TXMLStackObj* stack = Stack();
-   if (stack==0) {
+   TXMLStackObj *stack = Stack();
+   if (stack == 0) {
       Error("SetStreamerElementNumber", "stack is empty");
       return;
    }
 
-   if (!stack->IsStreamerInfo()) {  // this is not a first element
+   if (!stack->IsStreamerInfo()) { // this is not a first element
       PerformPostProcessing();
-      PopStack();           // go level back
-      if (IsReading()) ShiftStack("startelem");   // shift to next element, only for reading
-      stack = dynamic_cast<TXMLStackObj*> (fStack.Last());
+      PopStack(); // go level back
+      if (IsReading())
+         ShiftStack("startelem"); // shift to next element, only for reading
+      stack = dynamic_cast<TXMLStackObj *>(fStack.Last());
    }
 
-   if (stack==0) {
+   if (stack == 0) {
       Error("SetStreamerElementNumber", "Lost of stack");
       return;
    }
@@ -1045,7 +1053,7 @@ void TBufferXML::WorkWithElement(TStreamerElement* elem, Int_t comp_type)
       return;
    }
 
-   TStreamerInfo* info = stack->fInfo;
+   TStreamerInfo *info = stack->fInfo;
 
    if (!stack->IsStreamerInfo()) {
       Error("SetStreamerElementNumber", "Problem in Inc/Dec level");
@@ -1053,40 +1061,39 @@ void TBufferXML::WorkWithElement(TStreamerElement* elem, Int_t comp_type)
    }
    Int_t number = info ? info->GetElements()->IndexOf(elem) : -1;
 
-   if (gDebug>4) Info("SetStreamerElementNumber", "    Next element %s", elem->GetName());
+   if (gDebug > 4)
+      Info("SetStreamerElementNumber", "    Next element %s", elem->GetName());
 
-   Bool_t isBasicType = (elem->GetType()>0) && (elem->GetType()<20);
+   Bool_t isBasicType = (elem->GetType() > 0) && (elem->GetType() < 20);
 
    fExpectedChain = isBasicType && (comp_type - elem->GetType() == TStreamerInfo::kOffsetL);
 
-   if (fExpectedChain && (gDebug>3)) {
-      Info("SetStreamerElementNumber",
-           "    Expects chain for elem %s number %d",
-            elem->GetName(), number);
+   if (fExpectedChain && (gDebug > 3)) {
+      Info("SetStreamerElementNumber", "    Expects chain for elem %s number %d", elem->GetName(), number);
    }
 
-   fCanUseCompact = isBasicType && ((elem->GetType()==comp_type) ||
-                                    (elem->GetType()==comp_type-TStreamerInfo::kConv) ||
-                                    (elem->GetType()==comp_type-TStreamerInfo::kSkip));
+   fCanUseCompact =
+      isBasicType && ((elem->GetType() == comp_type) || (elem->GetType() == comp_type - TStreamerInfo::kConv) ||
+                      (elem->GetType() == comp_type - TStreamerInfo::kSkip));
 
-   if ((elem->GetType()==TStreamerInfo::kBase) ||
-       ((elem->GetType()==TStreamerInfo::kTNamed) && !strcmp(elem->GetName(), TNamed::Class()->GetName())))
+   if ((elem->GetType() == TStreamerInfo::kBase) ||
+       ((elem->GetType() == TStreamerInfo::kTNamed) && !strcmp(elem->GetName(), TNamed::Class()->GetName())))
       fExpectedBaseClass = elem->GetClassPointer();
 
-   if (fExpectedBaseClass && (gDebug>3))
-      Info("SetStreamerElementNumber",
-           "   Expects base class %s with standard streamer",
-               fExpectedBaseClass->GetName());
+   if (fExpectedBaseClass && (gDebug > 3))
+      Info("SetStreamerElementNumber", "   Expects base class %s with standard streamer",
+           fExpectedBaseClass->GetName());
 
    if (IsWriting()) {
       CreateElemNode(elem);
    } else {
-      if (!VerifyElemNode(elem)) return;
+      if (!VerifyElemNode(elem))
+         return;
    }
 
    stack = Stack();
    stack->fElemNumber = number;
-   stack->fIsElemOwner = (number<0);
+   stack->fIsElemOwner = (number < 0);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1099,7 +1106,7 @@ void TBufferXML::WorkWithElement(TStreamerElement* elem, Int_t comp_type)
 /// convert class data to XML. Without that functions calls
 /// classes with custom streamers cannot be used with TBufferXML
 
-void TBufferXML::ClassBegin(const TClass* cl, Version_t)
+void TBufferXML::ClassBegin(const TClass *cl, Version_t)
 {
    WorkWithClass(0, cl);
 }
@@ -1108,7 +1115,7 @@ void TBufferXML::ClassBegin(const TClass* cl, Version_t)
 /// Should be called at the end of custom streamer
 /// See TBufferXML::ClassBegin for more details
 
-void TBufferXML::ClassEnd(const TClass*)
+void TBufferXML::ClassEnd(const TClass *)
 {
    DecrementLevel(0);
 }
@@ -1151,12 +1158,13 @@ void TBufferXML::ClassEnd(const TClass*)
 /// second dimension of array. Can be used for array of basic types.
 /// See ClassBegin() method for more details.
 
-void TBufferXML::ClassMember(const char* name, const char* typeName, Int_t arrsize1, Int_t arrsize2)
+void TBufferXML::ClassMember(const char *name, const char *typeName, Int_t arrsize1, Int_t arrsize2)
 {
-   if (typeName==0) typeName = name;
+   if (typeName == 0)
+      typeName = name;
 
-   if ((name==0) || (strlen(name)==0)) {
-      Error("ClassMember","Invalid member name");
+   if ((name == 0) || (strlen(name) == 0)) {
+      Error("ClassMember", "Invalid member name");
       fErrorFlag = 1;
       return;
    }
@@ -1165,31 +1173,32 @@ void TBufferXML::ClassMember(const char* name, const char* typeName, Int_t arrsi
 
    Int_t typ_id(-1), comp_type(-1);
 
-   if (strcmp(typeName,"raw:data")==0)
+   if (strcmp(typeName, "raw:data") == 0)
       typ_id = TStreamerInfo::kMissing;
 
-   if (typ_id<0) {
+   if (typ_id < 0) {
       TDataType *dt = gROOT->GetType(typeName);
-      if (dt!=0)
-         if ((dt->GetType()>0) && (dt->GetType()<20))
+      if (dt != 0)
+         if ((dt->GetType() > 0) && (dt->GetType() < 20))
             typ_id = dt->GetType();
    }
 
-   if (typ_id<0)
-      if (strcmp(name, typeName)==0) {
-         TClass* cl = TClass::GetClass(tname.Data());
-         if (cl!=0) typ_id = TStreamerInfo::kBase;
+   if (typ_id < 0)
+      if (strcmp(name, typeName) == 0) {
+         TClass *cl = TClass::GetClass(tname.Data());
+         if (cl != 0)
+            typ_id = TStreamerInfo::kBase;
       }
 
-   if (typ_id<0) {
+   if (typ_id < 0) {
       Bool_t isptr = kFALSE;
-      if (tname[tname.Length()-1]=='*') {
-         tname.Resize(tname.Length()-1);
+      if (tname[tname.Length() - 1] == '*') {
+         tname.Resize(tname.Length() - 1);
          isptr = kTRUE;
       }
-      TClass* cl = TClass::GetClass(tname.Data());
-      if (cl==0) {
-         Error("ClassMember","Invalid class specifier %s", typeName);
+      TClass *cl = TClass::GetClass(tname.Data());
+      if (cl == 0) {
+         Error("ClassMember", "Invalid class specifier %s", typeName);
          fErrorFlag = 1;
          return;
       }
@@ -1199,62 +1208,61 @@ void TBufferXML::ClassMember(const char* name, const char* typeName, Int_t arrsi
       else
          typ_id = isptr ? TStreamerInfo::kAnyp : TStreamerInfo::kAny;
 
-      if ((cl==TString::Class()) && !isptr)
+      if ((cl == TString::Class()) && !isptr)
          typ_id = TStreamerInfo::kTString;
    }
 
-   TStreamerElement* elem = 0;
+   TStreamerElement *elem = 0;
 
    if (typ_id == TStreamerInfo::kMissing) {
-      elem = new TStreamerElement(name,"title",0, typ_id, "raw:data");
+      elem = new TStreamerElement(name, "title", 0, typ_id, "raw:data");
    } else
 
-   if (typ_id==TStreamerInfo::kBase) {
-      TClass* cl = TClass::GetClass(tname.Data());
-      if (cl!=0) {
-         TStreamerBase* b = new TStreamerBase(tname.Data(), "title", 0);
+      if (typ_id == TStreamerInfo::kBase) {
+      TClass *cl = TClass::GetClass(tname.Data());
+      if (cl != 0) {
+         TStreamerBase *b = new TStreamerBase(tname.Data(), "title", 0);
          b->SetBaseVersion(cl->GetClassVersion());
          elem = b;
       }
    } else
 
-   if ((typ_id>0) && (typ_id<20)) {
+      if ((typ_id > 0) && (typ_id < 20)) {
       elem = new TStreamerBasicType(name, "title", 0, typ_id, typeName);
       comp_type = typ_id;
    } else
 
-   if ((typ_id==TStreamerInfo::kObject) ||
-       (typ_id==TStreamerInfo::kTObject) ||
-       (typ_id==TStreamerInfo::kTNamed)) {
+      if ((typ_id == TStreamerInfo::kObject) || (typ_id == TStreamerInfo::kTObject) ||
+          (typ_id == TStreamerInfo::kTNamed)) {
       elem = new TStreamerObject(name, "title", 0, tname.Data());
    } else
 
-   if (typ_id==TStreamerInfo::kObjectp) {
+      if (typ_id == TStreamerInfo::kObjectp) {
       elem = new TStreamerObjectPointer(name, "title", 0, tname.Data());
    } else
 
-   if (typ_id==TStreamerInfo::kAny) {
+      if (typ_id == TStreamerInfo::kAny) {
       elem = new TStreamerObjectAny(name, "title", 0, tname.Data());
    } else
 
-   if (typ_id==TStreamerInfo::kAnyp) {
+      if (typ_id == TStreamerInfo::kAnyp) {
       elem = new TStreamerObjectAnyPointer(name, "title", 0, tname.Data());
    } else
 
-   if (typ_id==TStreamerInfo::kTString) {
+      if (typ_id == TStreamerInfo::kTString) {
       elem = new TStreamerString(name, "title", 0);
    }
 
-   if (elem==0) {
-      Error("ClassMember","Invalid combination name = %s type = %s", name, typeName);
+   if (elem == 0) {
+      Error("ClassMember", "Invalid combination name = %s type = %s", name, typeName);
       fErrorFlag = 1;
       return;
    }
 
-   if (arrsize1>0) {
-      elem->SetArrayDim(arrsize2>0 ? 2 : 1);
+   if (arrsize1 > 0) {
+      elem->SetArrayDim(arrsize2 > 0 ? 2 : 1);
       elem->SetMaxIndex(0, arrsize1);
-      if (arrsize2>0)
+      if (arrsize2 > 0)
          elem->SetMaxIndex(1, arrsize2);
    }
 
@@ -1267,59 +1275,63 @@ void TBufferXML::ClassMember(const char* name, const char* typeName, Int_t arrsi
 
 void TBufferXML::PerformPostProcessing()
 {
-   if (GetXmlLayout()==kGeneralized) return;
+   if (GetXmlLayout() == kGeneralized)
+      return;
 
-   const TStreamerElement* elem = Stack()->fElem;
+   const TStreamerElement *elem = Stack()->fElem;
    XMLNodePointer_t elemnode = IsWriting() ? Stack()->fNode : Stack(1)->fNode;
 
-   if ((elem==0) || (elemnode==0)) return;
+   if ((elem == 0) || (elemnode == 0))
+      return;
 
-   if (elem->GetType()==TStreamerInfo::kTString)  {
+   if (elem->GetType() == TStreamerInfo::kTString) {
 
       XMLNodePointer_t node = fXML->GetChild(elemnode);
       fXML->SkipEmpty(node);
 
       XMLNodePointer_t nodecharstar(0), nodeuchar(0), nodeint(0), nodestring(0);
 
-      while (node!=0) {
-         const char* name = fXML->GetNodeName(node);
-         if (strcmp(name, xmlio::String)==0) {
-            if (nodestring) return;
+      while (node != 0) {
+         const char *name = fXML->GetNodeName(node);
+         if (strcmp(name, xmlio::String) == 0) {
+            if (nodestring)
+               return;
             nodestring = node;
-         } else
-         if (strcmp(name, xmlio::UChar)==0) {
-            if (nodeuchar) return;
+         } else if (strcmp(name, xmlio::UChar) == 0) {
+            if (nodeuchar)
+               return;
             nodeuchar = node;
-         } else
-         if (strcmp(name, xmlio::Int)==0) {
-            if (nodeint) return;
+         } else if (strcmp(name, xmlio::Int) == 0) {
+            if (nodeint)
+               return;
             nodeint = node;
-         } else
-         if (strcmp(name, xmlio::CharStar)==0) {
-            if (nodecharstar!=0) return;
+         } else if (strcmp(name, xmlio::CharStar) == 0) {
+            if (nodecharstar != 0)
+               return;
             nodecharstar = node;
-         } else return; // can not be something else
+         } else
+            return; // can not be something else
          fXML->ShiftToNext(node);
       }
 
       TString str;
 
-      if (GetIOVersion()<3) {
-         if (nodeuchar==0) return;
-         if (nodecharstar!=0)
+      if (GetIOVersion() < 3) {
+         if (nodeuchar == 0)
+            return;
+         if (nodecharstar != 0)
             str = fXML->GetAttr(nodecharstar, xmlio::v);
          fXML->UnlinkFreeNode(nodeuchar);
          fXML->UnlinkFreeNode(nodeint);
          fXML->UnlinkFreeNode(nodecharstar);
       } else {
-         if (nodestring!=0)
+         if (nodestring != 0)
             str = fXML->GetAttr(nodestring, xmlio::v);
          fXML->UnlinkFreeNode(nodestring);
       }
 
       fXML->NewAttr(elemnode, 0, "str", str);
-   } else
-   if (elem->GetType()==TStreamerInfo::kTObject) {
+   } else if (elem->GetType() == TStreamerInfo::kTObject) {
       XMLNodePointer_t node = fXML->GetChild(elemnode);
       fXML->SkipEmpty(node);
 
@@ -1327,39 +1339,45 @@ void TBufferXML::PerformPostProcessing()
       XMLNodePointer_t idnode = 0;
       XMLNodePointer_t bitsnode = 0;
       XMLNodePointer_t prnode = 0;
-      while (node!=0) {
-         const char* name = fXML->GetNodeName(node);
+      while (node != 0) {
+         const char *name = fXML->GetNodeName(node);
 
-         if (strcmp(name, xmlio::OnlyVersion)==0) {
-            if (vnode) return;
+         if (strcmp(name, xmlio::OnlyVersion) == 0) {
+            if (vnode)
+               return;
             vnode = node;
-         } else
-         if (strcmp(name, xmlio::UInt)==0) {
-            if (idnode==0) idnode = node; else
-            if (bitsnode==0) bitsnode = node; else return;
-         } else
-         if (strcmp(name, xmlio::UShort)==0) {
-            if (prnode) return;
+         } else if (strcmp(name, xmlio::UInt) == 0) {
+            if (idnode == 0)
+               idnode = node;
+            else if (bitsnode == 0)
+               bitsnode = node;
+            else
+               return;
+         } else if (strcmp(name, xmlio::UShort) == 0) {
+            if (prnode)
+               return;
             prnode = node;
-         } else return;
+         } else
+            return;
          fXML->ShiftToNext(node);
       }
 
-      if ((vnode==0) || (idnode==0) || (bitsnode==0)) return;
+      if ((vnode == 0) || (idnode == 0) || (bitsnode == 0))
+         return;
 
-      TString str = fXML->GetAttr(idnode,xmlio::v);
+      TString str = fXML->GetAttr(idnode, xmlio::v);
       fXML->NewAttr(elemnode, 0, "fUniqueID", str);
 
       str = fXML->GetAttr(bitsnode, xmlio::v);
       UInt_t bits;
-      sscanf(str.Data(),"%u", &bits);
+      sscanf(str.Data(), "%u", &bits);
 
       char sbuf[20];
-      snprintf(sbuf, sizeof(sbuf), "%x",bits);
+      snprintf(sbuf, sizeof(sbuf), "%x", bits);
       fXML->NewAttr(elemnode, 0, "fBits", sbuf);
 
-      if (prnode!=0) {
-         str = fXML->GetAttr(prnode,xmlio::v);
+      if (prnode != 0) {
+         str = fXML->GetAttr(prnode, xmlio::v);
          fXML->NewAttr(elemnode, 0, "fProcessID", str);
       }
 
@@ -1374,30 +1392,33 @@ void TBufferXML::PerformPostProcessing()
 /// Function is unpack TObject and TString structures to be able read
 /// them from custom streamers of this objects
 
-void TBufferXML::PerformPreProcessing(const TStreamerElement* elem, XMLNodePointer_t elemnode)
+void TBufferXML::PerformPreProcessing(const TStreamerElement *elem, XMLNodePointer_t elemnode)
 {
-   if (GetXmlLayout()==kGeneralized) return;
-   if ((elem==0) || (elemnode==0)) return;
+   if (GetXmlLayout() == kGeneralized)
+      return;
+   if ((elem == 0) || (elemnode == 0))
+      return;
 
-   if (elem->GetType()==TStreamerInfo::kTString) {
+   if (elem->GetType() == TStreamerInfo::kTString) {
 
-      if (!fXML->HasAttr(elemnode,"str")) return;
+      if (!fXML->HasAttr(elemnode, "str"))
+         return;
       TString str = fXML->GetAttr(elemnode, "str");
       fXML->FreeAttr(elemnode, "str");
 
-      if (GetIOVersion()<3) {
+      if (GetIOVersion() < 3) {
          Int_t len = str.Length();
-         XMLNodePointer_t ucharnode = fXML->NewChild(elemnode, 0, xmlio::UChar,0);
+         XMLNodePointer_t ucharnode = fXML->NewChild(elemnode, 0, xmlio::UChar, 0);
          char sbuf[20];
          snprintf(sbuf, sizeof(sbuf), "%d", len);
-         if (len<255) {
-            fXML->NewAttr(ucharnode,0,xmlio::v,sbuf);
+         if (len < 255) {
+            fXML->NewAttr(ucharnode, 0, xmlio::v, sbuf);
          } else {
-            fXML->NewAttr(ucharnode,0,xmlio::v,"255");
+            fXML->NewAttr(ucharnode, 0, xmlio::v, "255");
             XMLNodePointer_t intnode = fXML->NewChild(elemnode, 0, xmlio::Int, 0);
             fXML->NewAttr(intnode, 0, xmlio::v, sbuf);
          }
-         if (len>0) {
+         if (len > 0) {
             XMLNodePointer_t node = fXML->NewChild(elemnode, 0, xmlio::CharStar, 0);
             fXML->NewAttr(node, 0, xmlio::v, str);
          }
@@ -1405,10 +1426,11 @@ void TBufferXML::PerformPreProcessing(const TStreamerElement* elem, XMLNodePoint
          XMLNodePointer_t node = fXML->NewChild(elemnode, 0, xmlio::String, 0);
          fXML->NewAttr(node, 0, xmlio::v, str);
       }
-   } else
-   if (elem->GetType()==TStreamerInfo::kTObject) {
-      if (!fXML->HasAttr(elemnode, "fUniqueID")) return;
-      if (!fXML->HasAttr(elemnode, "fBits")) return;
+   } else if (elem->GetType() == TStreamerInfo::kTObject) {
+      if (!fXML->HasAttr(elemnode, "fUniqueID"))
+         return;
+      if (!fXML->HasAttr(elemnode, "fBits"))
+         return;
 
       TString idstr = fXML->GetAttr(elemnode, "fUniqueID");
       TString bitsstr = fXML->GetAttr(elemnode, "fBits");
@@ -1425,14 +1447,14 @@ void TBufferXML::PerformPreProcessing(const TStreamerElement* elem, XMLNodePoint
       fXML->NewAttr(node, 0, xmlio::v, idstr);
 
       UInt_t bits;
-      sscanf(bitsstr.Data(),"%x", &bits);
+      sscanf(bitsstr.Data(), "%x", &bits);
       char sbuf[20];
       snprintf(sbuf, sizeof(sbuf), "%u", bits);
 
       node = fXML->NewChild(elemnode, 0, xmlio::UInt, 0);
       fXML->NewAttr(node, 0, xmlio::v, sbuf);
 
-      if (prstr.Length()>0) {
+      if (prstr.Length() > 0) {
          node = fXML->NewChild(elemnode, 0, xmlio::UShort, 0);
          fXML->NewAttr(node, 0, xmlio::v, prstr.Data());
       }
@@ -1451,15 +1473,16 @@ void TBufferXML::BeforeIOoperation()
 ////////////////////////////////////////////////////////////////////////////////
 /// Function to read class from buffer, used in old-style streamers
 
-TClass* TBufferXML::ReadClass(const TClass*, UInt_t*)
+TClass *TBufferXML::ReadClass(const TClass *, UInt_t *)
 {
-   const char* clname = 0;
+   const char *clname = 0;
 
    if (VerifyItemNode(xmlio::Class)) {
       clname = XmlReadValue(xmlio::Class);
    }
 
-   if (gDebug>2) Info("ReadClass", "Try to read class %s", clname ? clname : "---");
+   if (gDebug > 2)
+      Info("ReadClass", "Try to read class %s", clname ? clname : "---");
 
    return clname ? gROOT->GetClass(clname) : 0;
 }
@@ -1467,9 +1490,10 @@ TClass* TBufferXML::ReadClass(const TClass*, UInt_t*)
 ////////////////////////////////////////////////////////////////////////////////
 /// Function to write class into buffer, used in old-style streamers
 
-void TBufferXML::WriteClass(const TClass* cl)
+void TBufferXML::WriteClass(const TClass *cl)
 {
-   if (gDebug>2) Info("WriteClass", "Try to write class %s", cl->GetName());
+   if (gDebug > 2)
+      Info("WriteClass", "Try to write class %s", cl->GetName());
 
    XmlWriteValue(cl->GetName(), xmlio::Class);
 }
@@ -1477,7 +1501,7 @@ void TBufferXML::WriteClass(const TClass* cl)
 ////////////////////////////////////////////////////////////////////////////////
 /// Suppressed function of TBuffer
 
-Int_t TBufferXML::CheckByteCount(UInt_t /*r_s */, UInt_t /*r_c*/, const TClass* /*cl*/)
+Int_t TBufferXML::CheckByteCount(UInt_t /*r_s */, UInt_t /*r_c*/, const TClass * /*cl*/)
 {
    return 0;
 }
@@ -1485,7 +1509,7 @@ Int_t TBufferXML::CheckByteCount(UInt_t /*r_s */, UInt_t /*r_c*/, const TClass* 
 ////////////////////////////////////////////////////////////////////////////////
 /// Suppressed function of TBuffer
 
-Int_t  TBufferXML::CheckByteCount(UInt_t, UInt_t, const char*)
+Int_t TBufferXML::CheckByteCount(UInt_t, UInt_t, const char *)
 {
    return 0;
 }
@@ -1502,7 +1526,7 @@ void TBufferXML::SetByteCount(UInt_t, Bool_t)
 
 void TBufferXML::SkipVersion(const TClass *cl)
 {
-   ReadVersion(0,0,cl);
+   ReadVersion(0, 0, cl);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1514,23 +1538,25 @@ Version_t TBufferXML::ReadVersion(UInt_t *start, UInt_t *bcnt, const TClass * /*
 
    Version_t res = 0;
 
-   if (start) *start = 0;
-   if (bcnt) *bcnt = 0;
+   if (start)
+      *start = 0;
+   if (bcnt)
+      *bcnt = 0;
 
    if (VerifyItemNode(xmlio::OnlyVersion)) {
       res = AtoI(XmlReadValue(xmlio::OnlyVersion));
-   } else
-   if ((fExpectedBaseClass!=0) && (fXML->HasAttr(Stack(1)->fNode, xmlio::ClassVersion))) {
+   } else if ((fExpectedBaseClass != 0) && (fXML->HasAttr(Stack(1)->fNode, xmlio::ClassVersion))) {
       res = fXML->GetIntAttr(Stack(1)->fNode, xmlio::ClassVersion);
-   } else
-   if (fXML->HasAttr(StackNode(), xmlio::ClassVersion)) {
+   } else if (fXML->HasAttr(StackNode(), xmlio::ClassVersion)) {
       res = fXML->GetIntAttr(StackNode(), xmlio::ClassVersion);
    } else {
-      Error("ReadVersion", "No correspondent tags to read version");;
+      Error("ReadVersion", "No correspondent tags to read version");
+      ;
       fErrorFlag = 1;
    }
 
-   if (gDebug>2) Info("ReadVersion","Version = %d", res);
+   if (gDebug > 2)
+      Info("ReadVersion", "Version = %d", res);
 
    return res;
 }
@@ -1541,7 +1567,7 @@ Version_t TBufferXML::ReadVersion(UInt_t *start, UInt_t *bcnt, const TClass * /*
 
 void TBufferXML::CheckVersionBuf()
 {
-   if (IsWriting() && (fVersionBuf>=-100)) {
+   if (IsWriting() && (fVersionBuf >= -100)) {
       char sbuf[20];
       snprintf(sbuf, sizeof(sbuf), "%d", fVersionBuf);
       XmlWriteValue(sbuf, xmlio::OnlyVersion);
@@ -1558,14 +1584,13 @@ UInt_t TBufferXML::WriteVersion(const TClass *cl, Bool_t /* useBcnt */)
 {
    BeforeIOoperation();
 
-   if (fExpectedBaseClass!=cl)
+   if (fExpectedBaseClass != cl)
       fExpectedBaseClass = 0;
 
    fVersionBuf = cl->GetClassVersion();
 
-   if (gDebug>2)
-      Info("WriteVersion", "Class: %s, version = %d",
-           cl->GetName(), fVersionBuf);
+   if (gDebug > 2)
+      Info("WriteVersion", "Class: %s, version = %d", cl->GetName(), fVersionBuf);
 
    return 0;
 }
@@ -1573,12 +1598,12 @@ UInt_t TBufferXML::WriteVersion(const TClass *cl, Bool_t /* useBcnt */)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read object from buffer. Only used from TBuffer
 
-void* TBufferXML::ReadObjectAny(const TClass*)
+void *TBufferXML::ReadObjectAny(const TClass *)
 {
    BeforeIOoperation();
-   if (gDebug>2)
-      Info("ReadObjectAny","From node %s", fXML->GetNodeName(StackNode()));
-   void* res = XmlReadObject(0);
+   if (gDebug > 2)
+      Info("ReadObjectAny", "From node %s", fXML->GetNodeName(StackNode()));
+   void *res = XmlReadObject(0);
    return res;
 }
 
@@ -1588,7 +1613,7 @@ void* TBufferXML::ReadObjectAny(const TClass*)
 
 void TBufferXML::SkipObjectAny()
 {
-   ShiftStack("skipobjectany");                                          \
+   ShiftStack("skipobjectany");
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1597,54 +1622,59 @@ void TBufferXML::SkipObjectAny()
 void TBufferXML::WriteObjectClass(const void *actualObjStart, const TClass *actualClass)
 {
    BeforeIOoperation();
-   if (gDebug>2)
-      Info("WriteObject","Class %s", (actualClass ? actualClass->GetName() : " null"));
+   if (gDebug > 2)
+      Info("WriteObject", "Class %s", (actualClass ? actualClass->GetName() : " null"));
    XmlWriteObject(actualObjStart, actualClass);
 }
 
 // Macro to read content of uncompressed array
-#define TXMLReadArrayNoncompress(vname) \
-{                                       \
-   for(Int_t indx=0;indx<n;indx++)      \
-     XmlReadBasic(vname[indx]);         \
-}
+#define TXMLReadArrayNoncompress(vname)      \
+   {                                         \
+      for (Int_t indx = 0; indx < n; indx++) \
+         XmlReadBasic(vname[indx]);          \
+   }
 
 // macro to read content of array with compression
-#define TXMLReadArrayContent(vname, arrsize)               \
-{                                                          \
-   Int_t indx = 0;                                         \
-   while(indx<arrsize) {                                   \
-     Int_t cnt = 1;                                        \
-     if (fXML->HasAttr(StackNode(), xmlio::cnt))         \
-        cnt = fXML->GetIntAttr(StackNode(), xmlio::cnt); \
-     XmlReadBasic(vname[indx]);                            \
-     Int_t curr = indx; indx++;                            \
-     while(cnt>1) {                                        \
-       vname[indx] = vname[curr];                          \
-       cnt--; indx++;                                      \
-     }                                                     \
-   }                                                       \
-}
+#define TXMLReadArrayContent(vname, arrsize)                 \
+   {                                                         \
+      Int_t indx = 0;                                        \
+      while (indx < arrsize) {                               \
+         Int_t cnt = 1;                                      \
+         if (fXML->HasAttr(StackNode(), xmlio::cnt))         \
+            cnt = fXML->GetIntAttr(StackNode(), xmlio::cnt); \
+         XmlReadBasic(vname[indx]);                          \
+         Int_t curr = indx;                                  \
+         indx++;                                             \
+         while (cnt > 1) {                                   \
+            vname[indx] = vname[curr];                       \
+            cnt--;                                           \
+            indx++;                                          \
+         }                                                   \
+      }                                                      \
+   }
 
 // macro to read array, which include size attribute
-#define TBufferXML_ReadArray(tname, vname)                    \
-{                                                             \
-   BeforeIOoperation();                                       \
-   if (!VerifyItemNode(xmlio::Array,"ReadArray")) return 0; \
-   Int_t n = fXML->GetIntAttr(StackNode(), xmlio::Size);    \
-   if (n<=0) return 0;                                        \
-   if (!vname) vname = new tname[n];                          \
-   PushStack(StackNode());                                    \
-   TXMLReadArrayContent(vname, n);                            \
-   PopStack();                                                \
-   ShiftStack("readarr");                                     \
-   return n;                                                  \
-}
+#define TBufferXML_ReadArray(tname, vname)                  \
+   {                                                        \
+      BeforeIOoperation();                                  \
+      if (!VerifyItemNode(xmlio::Array, "ReadArray"))       \
+         return 0;                                          \
+      Int_t n = fXML->GetIntAttr(StackNode(), xmlio::Size); \
+      if (n <= 0)                                           \
+         return 0;                                          \
+      if (!vname)                                           \
+         vname = new tname[n];                              \
+      PushStack(StackNode());                               \
+      TXMLReadArrayContent(vname, n);                       \
+      PopStack();                                           \
+      ShiftStack("readarr");                                \
+      return n;                                             \
+   }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read a Float16_t from the buffer
 
-void TBufferXML::ReadFloat16 (Float_t *f, TStreamerElement * /*ele*/)
+void TBufferXML::ReadFloat16(Float_t *f, TStreamerElement * /*ele*/)
 {
    BeforeIOoperation();
    XmlReadBasic(*f);
@@ -1653,7 +1683,7 @@ void TBufferXML::ReadFloat16 (Float_t *f, TStreamerElement * /*ele*/)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read a Double32_t from the buffer
 
-void TBufferXML::ReadDouble32 (Double_t *d, TStreamerElement * /*ele*/)
+void TBufferXML::ReadDouble32(Double_t *d, TStreamerElement * /*ele*/)
 {
    BeforeIOoperation();
    XmlReadBasic(*d);
@@ -1706,7 +1736,7 @@ void TBufferXML::ReadWithNbits(Double_t *ptr, Int_t /* nbits */)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write a Float16_t to the buffer
 
-void TBufferXML::WriteFloat16 (Float_t *f, TStreamerElement * /*ele*/)
+void TBufferXML::WriteFloat16(Float_t *f, TStreamerElement * /*ele*/)
 {
    BeforeIOoperation();
    XmlWriteBasic(*f);
@@ -1715,7 +1745,7 @@ void TBufferXML::WriteFloat16 (Float_t *f, TStreamerElement * /*ele*/)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write a Double32_t to the buffer
 
-void TBufferXML::WriteDouble32 (Double_t *d, TStreamerElement * /*ele*/)
+void TBufferXML::WriteDouble32(Double_t *d, TStreamerElement * /*ele*/)
 {
    BeforeIOoperation();
    XmlWriteBasic(*d);
@@ -1724,81 +1754,81 @@ void TBufferXML::WriteDouble32 (Double_t *d, TStreamerElement * /*ele*/)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Bool_t from buffer
 
-Int_t TBufferXML::ReadArray(Bool_t    *&b)
+Int_t TBufferXML::ReadArray(Bool_t *&b)
 {
-   TBufferXML_ReadArray(Bool_t,b);
+   TBufferXML_ReadArray(Bool_t, b);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Char_t from buffer
 
-Int_t TBufferXML::ReadArray(Char_t    *&c)
+Int_t TBufferXML::ReadArray(Char_t *&c)
 {
-   TBufferXML_ReadArray(Char_t,c);
+   TBufferXML_ReadArray(Char_t, c);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of UChar_t from buffer
 
-Int_t TBufferXML::ReadArray(UChar_t   *&c)
+Int_t TBufferXML::ReadArray(UChar_t *&c)
 {
-   TBufferXML_ReadArray(UChar_t,c);
+   TBufferXML_ReadArray(UChar_t, c);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Short_t from buffer
 
-Int_t TBufferXML::ReadArray(Short_t   *&h)
+Int_t TBufferXML::ReadArray(Short_t *&h)
 {
-   TBufferXML_ReadArray(Short_t,h);
+   TBufferXML_ReadArray(Short_t, h);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of UShort_t from buffer
 
-Int_t TBufferXML::ReadArray(UShort_t  *&h)
+Int_t TBufferXML::ReadArray(UShort_t *&h)
 {
-   TBufferXML_ReadArray(UShort_t,h);
+   TBufferXML_ReadArray(UShort_t, h);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Int_t from buffer
 
-Int_t TBufferXML::ReadArray(Int_t     *&i)
+Int_t TBufferXML::ReadArray(Int_t *&i)
 {
-   TBufferXML_ReadArray(Int_t,i);
+   TBufferXML_ReadArray(Int_t, i);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of UInt_t from buffer
 
-Int_t TBufferXML::ReadArray(UInt_t    *&i)
+Int_t TBufferXML::ReadArray(UInt_t *&i)
 {
-   TBufferXML_ReadArray(UInt_t,i);
+   TBufferXML_ReadArray(UInt_t, i);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Long_t from buffer
 
-Int_t TBufferXML::ReadArray(Long_t    *&l)
+Int_t TBufferXML::ReadArray(Long_t *&l)
 {
-   TBufferXML_ReadArray(Long_t,l);
+   TBufferXML_ReadArray(Long_t, l);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of ULong_t from buffer
 
-Int_t TBufferXML::ReadArray(ULong_t   *&l)
+Int_t TBufferXML::ReadArray(ULong_t *&l)
 {
-   TBufferXML_ReadArray(ULong_t,l);
+   TBufferXML_ReadArray(ULong_t, l);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Long64_t from buffer
 
-Int_t TBufferXML::ReadArray(Long64_t  *&l)
+Int_t TBufferXML::ReadArray(Long64_t *&l)
 {
-   TBufferXML_ReadArray(Long64_t,l);
+   TBufferXML_ReadArray(Long64_t, l);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1806,60 +1836,63 @@ Int_t TBufferXML::ReadArray(Long64_t  *&l)
 
 Int_t TBufferXML::ReadArray(ULong64_t *&l)
 {
-   TBufferXML_ReadArray(ULong64_t,l);
+   TBufferXML_ReadArray(ULong64_t, l);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Float_t from buffer
 
-Int_t TBufferXML::ReadArray(Float_t   *&f)
+Int_t TBufferXML::ReadArray(Float_t *&f)
 {
-   TBufferXML_ReadArray(Float_t,f);
+   TBufferXML_ReadArray(Float_t, f);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Double_t from buffer
 
-Int_t TBufferXML::ReadArray(Double_t  *&d)
+Int_t TBufferXML::ReadArray(Double_t *&d)
 {
-   TBufferXML_ReadArray(Double_t,d);
+   TBufferXML_ReadArray(Double_t, d);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Float16_t from buffer
 
-Int_t TBufferXML::ReadArrayFloat16(Float_t  *&f, TStreamerElement * /*ele*/)
+Int_t TBufferXML::ReadArrayFloat16(Float_t *&f, TStreamerElement * /*ele*/)
 {
-   TBufferXML_ReadArray(Float_t,f);
+   TBufferXML_ReadArray(Float_t, f);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Double32_t from buffer
 
-Int_t TBufferXML::ReadArrayDouble32(Double_t  *&d, TStreamerElement * /*ele*/)
+Int_t TBufferXML::ReadArrayDouble32(Double_t *&d, TStreamerElement * /*ele*/)
 {
-   TBufferXML_ReadArray(Double_t,d);
+   TBufferXML_ReadArray(Double_t, d);
 }
 
 // macro to read array from xml buffer
-#define TBufferXML_ReadStaticArray(vname)                           \
-{                                                                   \
-   BeforeIOoperation();                                             \
-   if (!VerifyItemNode(xmlio::Array,"ReadStaticArray")) return 0; \
-   Int_t n = fXML->GetIntAttr(StackNode(), xmlio::Size);          \
-   if (n<=0) return 0;                                              \
-   if (!vname) return 0;                                            \
-   PushStack(StackNode());                                          \
-   TXMLReadArrayContent(vname, n);                                  \
-   PopStack();                                                      \
-   ShiftStack("readstatarr");                                       \
-   return n;                                                        \
-}
+#define TBufferXML_ReadStaticArray(vname)                   \
+   {                                                        \
+      BeforeIOoperation();                                  \
+      if (!VerifyItemNode(xmlio::Array, "ReadStaticArray")) \
+         return 0;                                          \
+      Int_t n = fXML->GetIntAttr(StackNode(), xmlio::Size); \
+      if (n <= 0)                                           \
+         return 0;                                          \
+      if (!vname)                                           \
+         return 0;                                          \
+      PushStack(StackNode());                               \
+      TXMLReadArrayContent(vname, n);                       \
+      PopStack();                                           \
+      ShiftStack("readstatarr");                            \
+      return n;                                             \
+   }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Bool_t from buffer
 
-Int_t TBufferXML::ReadStaticArray(Bool_t    *b)
+Int_t TBufferXML::ReadStaticArray(Bool_t *b)
 {
    TBufferXML_ReadStaticArray(b);
 }
@@ -1867,7 +1900,7 @@ Int_t TBufferXML::ReadStaticArray(Bool_t    *b)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Char_t from buffer
 
-Int_t TBufferXML::ReadStaticArray(Char_t    *c)
+Int_t TBufferXML::ReadStaticArray(Char_t *c)
 {
    TBufferXML_ReadStaticArray(c);
 }
@@ -1875,7 +1908,7 @@ Int_t TBufferXML::ReadStaticArray(Char_t    *c)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of UChar_t from buffer
 
-Int_t TBufferXML::ReadStaticArray(UChar_t   *c)
+Int_t TBufferXML::ReadStaticArray(UChar_t *c)
 {
    TBufferXML_ReadStaticArray(c);
 }
@@ -1883,7 +1916,7 @@ Int_t TBufferXML::ReadStaticArray(UChar_t   *c)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Short_t from buffer
 
-Int_t TBufferXML::ReadStaticArray(Short_t   *h)
+Int_t TBufferXML::ReadStaticArray(Short_t *h)
 {
    TBufferXML_ReadStaticArray(h);
 }
@@ -1891,7 +1924,7 @@ Int_t TBufferXML::ReadStaticArray(Short_t   *h)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of UShort_t from buffer
 
-Int_t TBufferXML::ReadStaticArray(UShort_t  *h)
+Int_t TBufferXML::ReadStaticArray(UShort_t *h)
 {
    TBufferXML_ReadStaticArray(h);
 }
@@ -1899,7 +1932,7 @@ Int_t TBufferXML::ReadStaticArray(UShort_t  *h)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Int_t from buffer
 
-Int_t TBufferXML::ReadStaticArray(Int_t     *i)
+Int_t TBufferXML::ReadStaticArray(Int_t *i)
 {
    TBufferXML_ReadStaticArray(i);
 }
@@ -1907,7 +1940,7 @@ Int_t TBufferXML::ReadStaticArray(Int_t     *i)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of UInt_t from buffer
 
-Int_t TBufferXML::ReadStaticArray(UInt_t    *i)
+Int_t TBufferXML::ReadStaticArray(UInt_t *i)
 {
    TBufferXML_ReadStaticArray(i);
 }
@@ -1915,7 +1948,7 @@ Int_t TBufferXML::ReadStaticArray(UInt_t    *i)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Long_t from buffer
 
-Int_t TBufferXML::ReadStaticArray(Long_t    *l)
+Int_t TBufferXML::ReadStaticArray(Long_t *l)
 {
    TBufferXML_ReadStaticArray(l);
 }
@@ -1923,7 +1956,7 @@ Int_t TBufferXML::ReadStaticArray(Long_t    *l)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of ULong_t from buffer
 
-Int_t TBufferXML::ReadStaticArray(ULong_t   *l)
+Int_t TBufferXML::ReadStaticArray(ULong_t *l)
 {
    TBufferXML_ReadStaticArray(l);
 }
@@ -1931,7 +1964,7 @@ Int_t TBufferXML::ReadStaticArray(ULong_t   *l)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Long64_t from buffer
 
-Int_t TBufferXML::ReadStaticArray(Long64_t  *l)
+Int_t TBufferXML::ReadStaticArray(Long64_t *l)
 {
    TBufferXML_ReadStaticArray(l);
 }
@@ -1947,7 +1980,7 @@ Int_t TBufferXML::ReadStaticArray(ULong64_t *l)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Float_t from buffer
 
-Int_t TBufferXML::ReadStaticArray(Float_t   *f)
+Int_t TBufferXML::ReadStaticArray(Float_t *f)
 {
    TBufferXML_ReadStaticArray(f);
 }
@@ -1955,7 +1988,7 @@ Int_t TBufferXML::ReadStaticArray(Float_t   *f)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Double_t from buffer
 
-Int_t TBufferXML::ReadStaticArray(Double_t  *d)
+Int_t TBufferXML::ReadStaticArray(Double_t *d)
 {
    TBufferXML_ReadStaticArray(d);
 }
@@ -1963,7 +1996,7 @@ Int_t TBufferXML::ReadStaticArray(Double_t  *d)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Float16_t from buffer
 
-Int_t TBufferXML::ReadStaticArrayFloat16(Float_t  *f, TStreamerElement * /*ele*/)
+Int_t TBufferXML::ReadStaticArrayFloat16(Float_t *f, TStreamerElement * /*ele*/)
 {
    TBufferXML_ReadStaticArray(f);
 }
@@ -1971,7 +2004,7 @@ Int_t TBufferXML::ReadStaticArrayFloat16(Float_t  *f, TStreamerElement * /*ele*/
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Double32_t from buffer
 
-Int_t TBufferXML::ReadStaticArrayDouble32(Double_t  *d, TStreamerElement * /*ele*/)
+Int_t TBufferXML::ReadStaticArrayDouble32(Double_t *d, TStreamerElement * /*ele*/)
 {
    TBufferXML_ReadStaticArray(d);
 }
@@ -1979,49 +2012,56 @@ Int_t TBufferXML::ReadStaticArrayDouble32(Double_t  *d, TStreamerElement * /*ele
 // macro to read content of array, which not include size of array
 // macro also treat situation, when instead of one single array chain
 // of several elements should be produced
-#define TBufferXML_ReadFastArray(vname)                                   \
-{                                                                         \
-   BeforeIOoperation();                                                   \
-   if (n<=0) return;                                                      \
-   TStreamerElement* elem = Stack(0)->fElem;                              \
-   if ((elem!=0) && (elem->GetType()>TStreamerInfo::kOffsetL) &&          \
-       (elem->GetType()<TStreamerInfo::kOffsetP) &&                       \
-       (elem->GetArrayLength()!=n)) fExpectedChain = kTRUE;               \
-   if (fExpectedChain) {                                                  \
-      fExpectedChain = kFALSE;                                            \
-      Int_t startnumber = Stack(0)->fElemNumber;                          \
-      TStreamerInfo* info = Stack(1)->fInfo;                              \
-      Int_t index = 0;                                                    \
-      while (index<n) {                                                   \
-        elem = (TStreamerElement*)info->GetElements()->At(startnumber++); \
-        if (elem->GetType()<TStreamerInfo::kOffsetL) {                    \
-           if (index>0) { PopStack(); ShiftStack("chainreader"); VerifyElemNode(elem); }  \
-           fCanUseCompact = kTRUE;                                        \
-           XmlReadBasic(vname[index]);                                    \
-           index++;                                                       \
-        } else {                                                          \
-           if (!VerifyItemNode(xmlio::Array,"ReadFastArray")) return;     \
-           PushStack(StackNode());                                        \
-           Int_t elemlen = elem->GetArrayLength();                        \
-           TXMLReadArrayContent((vname+index), elemlen);                  \
-           PopStack();                                                    \
-           ShiftStack("readfastarr");                                     \
-           index+=elemlen;                                                \
-        }                                                                 \
-      }                                                                   \
-   } else {                                                               \
-      if (!VerifyItemNode(xmlio::Array,"ReadFastArray")) return;          \
-      PushStack(StackNode());                                             \
-      TXMLReadArrayContent(vname, n);                                     \
-      PopStack();                                                         \
-      ShiftStack("readfastarr");                                          \
-   }                                                                      \
-}
+#define TBufferXML_ReadFastArray(vname)                                                                                \
+   {                                                                                                                   \
+      BeforeIOoperation();                                                                                             \
+      if (n <= 0)                                                                                                      \
+         return;                                                                                                       \
+      TStreamerElement *elem = Stack(0)->fElem;                                                                        \
+      if ((elem != 0) && (elem->GetType() > TStreamerInfo::kOffsetL) && (elem->GetType() < TStreamerInfo::kOffsetP) && \
+          (elem->GetArrayLength() != n))                                                                               \
+         fExpectedChain = kTRUE;                                                                                       \
+      if (fExpectedChain) {                                                                                            \
+         fExpectedChain = kFALSE;                                                                                      \
+         Int_t startnumber = Stack(0)->fElemNumber;                                                                    \
+         TStreamerInfo *info = Stack(1)->fInfo;                                                                        \
+         Int_t index = 0;                                                                                              \
+         while (index < n) {                                                                                           \
+            elem = (TStreamerElement *)info->GetElements()->At(startnumber++);                                         \
+            if (elem->GetType() < TStreamerInfo::kOffsetL) {                                                           \
+               if (index > 0) {                                                                                        \
+                  PopStack();                                                                                          \
+                  ShiftStack("chainreader");                                                                           \
+                  VerifyElemNode(elem);                                                                                \
+               }                                                                                                       \
+               fCanUseCompact = kTRUE;                                                                                 \
+               XmlReadBasic(vname[index]);                                                                             \
+               index++;                                                                                                \
+            } else {                                                                                                   \
+               if (!VerifyItemNode(xmlio::Array, "ReadFastArray"))                                                     \
+                  return;                                                                                              \
+               PushStack(StackNode());                                                                                 \
+               Int_t elemlen = elem->GetArrayLength();                                                                 \
+               TXMLReadArrayContent((vname + index), elemlen);                                                         \
+               PopStack();                                                                                             \
+               ShiftStack("readfastarr");                                                                              \
+               index += elemlen;                                                                                       \
+            }                                                                                                          \
+         }                                                                                                             \
+      } else {                                                                                                         \
+         if (!VerifyItemNode(xmlio::Array, "ReadFastArray"))                                                           \
+            return;                                                                                                    \
+         PushStack(StackNode());                                                                                       \
+         TXMLReadArrayContent(vname, n);                                                                               \
+         PopStack();                                                                                                   \
+         ShiftStack("readfastarr");                                                                                    \
+      }                                                                                                                \
+   }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Bool_t from buffer
 
-void TBufferXML::ReadFastArray(Bool_t    *b, Int_t n)
+void TBufferXML::ReadFastArray(Bool_t *b, Int_t n)
 {
    TBufferXML_ReadFastArray(b);
 }
@@ -2030,13 +2070,14 @@ void TBufferXML::ReadFastArray(Bool_t    *b, Int_t n)
 /// Read array of Char_t from buffer
 /// if nodename==CharStar, read all array as string
 
-void TBufferXML::ReadFastArray(Char_t    *c, Int_t n)
+void TBufferXML::ReadFastArray(Char_t *c, Int_t n)
 {
-   if ((n>0) && VerifyItemNode(xmlio::CharStar)) {
-      const char* buf;
+   if ((n > 0) && VerifyItemNode(xmlio::CharStar)) {
+      const char *buf;
       if ((buf = XmlReadValue(xmlio::CharStar))) {
          Int_t size = strlen(buf);
-         if (size<n) size = n;
+         if (size < n)
+            size = n;
          memcpy(c, buf, size);
       }
    } else
@@ -2046,7 +2087,7 @@ void TBufferXML::ReadFastArray(Char_t    *c, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of UChar_t from buffer
 
-void TBufferXML::ReadFastArray(UChar_t   *c, Int_t n)
+void TBufferXML::ReadFastArray(UChar_t *c, Int_t n)
 {
    TBufferXML_ReadFastArray(c);
 }
@@ -2054,7 +2095,7 @@ void TBufferXML::ReadFastArray(UChar_t   *c, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Short_t from buffer
 
-void TBufferXML::ReadFastArray(Short_t   *h, Int_t n)
+void TBufferXML::ReadFastArray(Short_t *h, Int_t n)
 {
    TBufferXML_ReadFastArray(h);
 }
@@ -2062,7 +2103,7 @@ void TBufferXML::ReadFastArray(Short_t   *h, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of UShort_t from buffer
 
-void TBufferXML::ReadFastArray(UShort_t  *h, Int_t n)
+void TBufferXML::ReadFastArray(UShort_t *h, Int_t n)
 {
    TBufferXML_ReadFastArray(h);
 }
@@ -2070,7 +2111,7 @@ void TBufferXML::ReadFastArray(UShort_t  *h, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Int_t from buffer
 
-void TBufferXML::ReadFastArray(Int_t     *i, Int_t n)
+void TBufferXML::ReadFastArray(Int_t *i, Int_t n)
 {
    TBufferXML_ReadFastArray(i);
 }
@@ -2078,7 +2119,7 @@ void TBufferXML::ReadFastArray(Int_t     *i, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of UInt_t from buffer
 
-void TBufferXML::ReadFastArray(UInt_t    *i, Int_t n)
+void TBufferXML::ReadFastArray(UInt_t *i, Int_t n)
 {
    TBufferXML_ReadFastArray(i);
 }
@@ -2086,7 +2127,7 @@ void TBufferXML::ReadFastArray(UInt_t    *i, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Long_t from buffer
 
-void TBufferXML::ReadFastArray(Long_t    *l, Int_t n)
+void TBufferXML::ReadFastArray(Long_t *l, Int_t n)
 {
    TBufferXML_ReadFastArray(l);
 }
@@ -2094,7 +2135,7 @@ void TBufferXML::ReadFastArray(Long_t    *l, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of ULong_t from buffer
 
-void TBufferXML::ReadFastArray(ULong_t   *l, Int_t n)
+void TBufferXML::ReadFastArray(ULong_t *l, Int_t n)
 {
    TBufferXML_ReadFastArray(l);
 }
@@ -2102,7 +2143,7 @@ void TBufferXML::ReadFastArray(ULong_t   *l, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Long64_t from buffer
 
-void TBufferXML::ReadFastArray(Long64_t  *l, Int_t n)
+void TBufferXML::ReadFastArray(Long64_t *l, Int_t n)
 {
    TBufferXML_ReadFastArray(l);
 }
@@ -2118,7 +2159,7 @@ void TBufferXML::ReadFastArray(ULong64_t *l, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Float_t from buffer
 
-void TBufferXML::ReadFastArray(Float_t   *f, Int_t n)
+void TBufferXML::ReadFastArray(Float_t *f, Int_t n)
 {
    TBufferXML_ReadFastArray(f);
 }
@@ -2126,7 +2167,7 @@ void TBufferXML::ReadFastArray(Float_t   *f, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Double_t from buffer
 
-void TBufferXML::ReadFastArray(Double_t  *d, Int_t n)
+void TBufferXML::ReadFastArray(Double_t *d, Int_t n)
 {
    TBufferXML_ReadFastArray(d);
 }
@@ -2134,7 +2175,7 @@ void TBufferXML::ReadFastArray(Double_t  *d, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Float16_t from buffer
 
-void TBufferXML::ReadFastArrayFloat16(Float_t  *f, Int_t n, TStreamerElement * /*ele*/)
+void TBufferXML::ReadFastArrayFloat16(Float_t *f, Int_t n, TStreamerElement * /*ele*/)
 {
    TBufferXML_ReadFastArray(f);
 }
@@ -2142,7 +2183,7 @@ void TBufferXML::ReadFastArrayFloat16(Float_t  *f, Int_t n, TStreamerElement * /
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Float16_t from buffer
 
-void TBufferXML::ReadFastArrayWithFactor(Float_t  *f, Int_t n, Double_t /* factor */, Double_t /* minvalue */)
+void TBufferXML::ReadFastArrayWithFactor(Float_t *f, Int_t n, Double_t /* factor */, Double_t /* minvalue */)
 {
    TBufferXML_ReadFastArray(f);
 }
@@ -2150,7 +2191,7 @@ void TBufferXML::ReadFastArrayWithFactor(Float_t  *f, Int_t n, Double_t /* facto
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Float16_t from buffer
 
-void TBufferXML::ReadFastArrayWithNbits(Float_t  *f, Int_t n, Int_t /*nbits*/)
+void TBufferXML::ReadFastArrayWithNbits(Float_t *f, Int_t n, Int_t /*nbits*/)
 {
    TBufferXML_ReadFastArray(f);
 }
@@ -2158,7 +2199,7 @@ void TBufferXML::ReadFastArrayWithNbits(Float_t  *f, Int_t n, Int_t /*nbits*/)
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Double32_t from buffer
 
-void TBufferXML::ReadFastArrayDouble32(Double_t  *d, Int_t n, TStreamerElement * /*ele*/)
+void TBufferXML::ReadFastArrayDouble32(Double_t *d, Int_t n, TStreamerElement * /*ele*/)
 {
    TBufferXML_ReadFastArray(d);
 }
@@ -2166,7 +2207,7 @@ void TBufferXML::ReadFastArrayDouble32(Double_t  *d, Int_t n, TStreamerElement *
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Double32_t from buffer
 
-void TBufferXML::ReadFastArrayWithFactor(Double_t  *d, Int_t n, Double_t /* factor */, Double_t /* minvalue */)
+void TBufferXML::ReadFastArrayWithFactor(Double_t *d, Int_t n, Double_t /* factor */, Double_t /* minvalue */)
 {
    TBufferXML_ReadFastArray(d);
 }
@@ -2174,7 +2215,7 @@ void TBufferXML::ReadFastArrayWithFactor(Double_t  *d, Int_t n, Double_t /* fact
 ////////////////////////////////////////////////////////////////////////////////
 /// Read array of Double32_t from buffer
 
-void TBufferXML::ReadFastArrayWithNbits(Double_t  *d, Int_t n, Int_t /*nbits*/)
+void TBufferXML::ReadFastArrayWithNbits(Double_t *d, Int_t n, Int_t /*nbits*/)
 {
    TBufferXML_ReadFastArray(d);
 }
@@ -2182,7 +2223,7 @@ void TBufferXML::ReadFastArrayWithNbits(Double_t  *d, Int_t n, Int_t /*nbits*/)
 ////////////////////////////////////////////////////////////////////////////////
 /// redefined here to avoid warning message from gcc
 
-void TBufferXML::ReadFastArray(void  *start, const TClass *cl, Int_t n, TMemberStreamer *s, const TClass *onFileClass)
+void TBufferXML::ReadFastArray(void *start, const TClass *cl, Int_t n, TMemberStreamer *s, const TClass *onFileClass)
 {
    TBufferFile::ReadFastArray(start, cl, n, s, onFileClass);
 }
@@ -2190,55 +2231,58 @@ void TBufferXML::ReadFastArray(void  *start, const TClass *cl, Int_t n, TMemberS
 ////////////////////////////////////////////////////////////////////////////////
 /// redefined here to avoid warning message from gcc
 
-void TBufferXML::ReadFastArray(void **startp, const TClass *cl, Int_t n, Bool_t isPreAlloc, TMemberStreamer *s, const TClass *onFileClass)
+void TBufferXML::ReadFastArray(void **startp, const TClass *cl, Int_t n, Bool_t isPreAlloc, TMemberStreamer *s,
+                               const TClass *onFileClass)
 {
    TBufferFile::ReadFastArray(startp, cl, n, isPreAlloc, s, onFileClass);
 }
 
 // macro to write content of noncompressed array
-#define TXMLWriteArrayNoncompress(vname, arrsize) \
-{                                                 \
-   for(Int_t indx=0;indx<arrsize;indx++)          \
-     XmlWriteBasic(vname[indx]);                  \
-}
+#define TXMLWriteArrayNoncompress(vname, arrsize)  \
+   {                                               \
+      for (Int_t indx = 0; indx < arrsize; indx++) \
+         XmlWriteBasic(vname[indx]);               \
+   }
 
 // macro to write content of compressed array
-#define TXMLWriteArrayCompress(vname, arrsize)                     \
-{                                                                  \
-   Int_t indx = 0;                                                 \
-   while(indx<arrsize) {                                           \
-      XMLNodePointer_t elemnode = XmlWriteBasic(vname[indx]);      \
-      Int_t curr = indx; indx++;                                   \
-      while ((indx<arrsize) && (vname[indx]==vname[curr])) indx++; \
-      if (indx-curr > 1)                                           \
-         fXML->NewIntAttr(elemnode, xmlio::cnt, indx-curr);      \
-   }                                                               \
-}
+#define TXMLWriteArrayCompress(vname, arrsize)                    \
+   {                                                              \
+      Int_t indx = 0;                                             \
+      while (indx < arrsize) {                                    \
+         XMLNodePointer_t elemnode = XmlWriteBasic(vname[indx]);  \
+         Int_t curr = indx;                                       \
+         indx++;                                                  \
+         while ((indx < arrsize) && (vname[indx] == vname[curr])) \
+            indx++;                                               \
+         if (indx - curr > 1)                                     \
+            fXML->NewIntAttr(elemnode, xmlio::cnt, indx - curr);  \
+      }                                                           \
+   }
 
-#define TXMLWriteArrayContent(vname, arrsize)   \
-{                                               \
-   if (fCompressLevel>0) {                      \
-     TXMLWriteArrayCompress(vname, arrsize)     \
-   } else {                                     \
-     TXMLWriteArrayNoncompress(vname, arrsize)  \
-   }                                            \
-}
+#define TXMLWriteArrayContent(vname, arrsize)      \
+   {                                               \
+      if (fCompressLevel > 0) {                    \
+         TXMLWriteArrayCompress(vname, arrsize)    \
+      } else {                                     \
+         TXMLWriteArrayNoncompress(vname, arrsize) \
+      }                                            \
+   }
 
 // macro to write array, which include size
-#define TBufferXML_WriteArray(vname)                          \
-{                                                             \
-   BeforeIOoperation();                                       \
-   XMLNodePointer_t arrnode = CreateItemNode(xmlio::Array); \
-   fXML->NewIntAttr(arrnode, xmlio::Size, n);               \
-   PushStack(arrnode);                                        \
-   TXMLWriteArrayContent(vname, n);                           \
-   PopStack();                                                \
-}
+#define TBufferXML_WriteArray(vname)                           \
+   {                                                           \
+      BeforeIOoperation();                                     \
+      XMLNodePointer_t arrnode = CreateItemNode(xmlio::Array); \
+      fXML->NewIntAttr(arrnode, xmlio::Size, n);               \
+      PushStack(arrnode);                                      \
+      TXMLWriteArrayContent(vname, n);                         \
+      PopStack();                                              \
+   }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Bool_t to buffer
 
-void TBufferXML::WriteArray(const Bool_t    *b, Int_t n)
+void TBufferXML::WriteArray(const Bool_t *b, Int_t n)
 {
    TBufferXML_WriteArray(b);
 }
@@ -2246,7 +2290,7 @@ void TBufferXML::WriteArray(const Bool_t    *b, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Char_t to buffer
 
-void TBufferXML::WriteArray(const Char_t    *c, Int_t n)
+void TBufferXML::WriteArray(const Char_t *c, Int_t n)
 {
    TBufferXML_WriteArray(c);
 }
@@ -2254,7 +2298,7 @@ void TBufferXML::WriteArray(const Char_t    *c, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of UChar_t to buffer
 
-void TBufferXML::WriteArray(const UChar_t   *c, Int_t n)
+void TBufferXML::WriteArray(const UChar_t *c, Int_t n)
 {
    TBufferXML_WriteArray(c);
 }
@@ -2262,7 +2306,7 @@ void TBufferXML::WriteArray(const UChar_t   *c, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Short_t to buffer
 
-void TBufferXML::WriteArray(const Short_t   *h, Int_t n)
+void TBufferXML::WriteArray(const Short_t *h, Int_t n)
 {
    TBufferXML_WriteArray(h);
 }
@@ -2270,7 +2314,7 @@ void TBufferXML::WriteArray(const Short_t   *h, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of UShort_t to buffer
 
-void TBufferXML::WriteArray(const UShort_t  *h, Int_t n)
+void TBufferXML::WriteArray(const UShort_t *h, Int_t n)
 {
    TBufferXML_WriteArray(h);
 }
@@ -2278,7 +2322,7 @@ void TBufferXML::WriteArray(const UShort_t  *h, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Int_ to buffer
 
-void TBufferXML::WriteArray(const Int_t     *i, Int_t n)
+void TBufferXML::WriteArray(const Int_t *i, Int_t n)
 {
    TBufferXML_WriteArray(i);
 }
@@ -2286,7 +2330,7 @@ void TBufferXML::WriteArray(const Int_t     *i, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of UInt_t to buffer
 
-void TBufferXML::WriteArray(const UInt_t    *i, Int_t n)
+void TBufferXML::WriteArray(const UInt_t *i, Int_t n)
 {
    TBufferXML_WriteArray(i);
 }
@@ -2294,7 +2338,7 @@ void TBufferXML::WriteArray(const UInt_t    *i, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Long_t to buffer
 
-void TBufferXML::WriteArray(const Long_t    *l, Int_t n)
+void TBufferXML::WriteArray(const Long_t *l, Int_t n)
 {
    TBufferXML_WriteArray(l);
 }
@@ -2302,7 +2346,7 @@ void TBufferXML::WriteArray(const Long_t    *l, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of ULong_t to buffer
 
-void TBufferXML::WriteArray(const ULong_t   *l, Int_t n)
+void TBufferXML::WriteArray(const ULong_t *l, Int_t n)
 {
    TBufferXML_WriteArray(l);
 }
@@ -2310,7 +2354,7 @@ void TBufferXML::WriteArray(const ULong_t   *l, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Long64_t to buffer
 
-void TBufferXML::WriteArray(const Long64_t  *l, Int_t n)
+void TBufferXML::WriteArray(const Long64_t *l, Int_t n)
 {
    TBufferXML_WriteArray(l);
 }
@@ -2326,7 +2370,7 @@ void TBufferXML::WriteArray(const ULong64_t *l, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Float_t to buffer
 
-void TBufferXML::WriteArray(const Float_t   *f, Int_t n)
+void TBufferXML::WriteArray(const Float_t *f, Int_t n)
 {
    TBufferXML_WriteArray(f);
 }
@@ -2334,7 +2378,7 @@ void TBufferXML::WriteArray(const Float_t   *f, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Double_t to buffer
 
-void TBufferXML::WriteArray(const Double_t  *d, Int_t n)
+void TBufferXML::WriteArray(const Double_t *d, Int_t n)
 {
    TBufferXML_WriteArray(d);
 }
@@ -2342,7 +2386,7 @@ void TBufferXML::WriteArray(const Double_t  *d, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Float16_t to buffer
 
-void TBufferXML::WriteArrayFloat16(const Float_t  *f, Int_t n, TStreamerElement * /*ele*/)
+void TBufferXML::WriteArrayFloat16(const Float_t *f, Int_t n, TStreamerElement * /*ele*/)
 {
    TBufferXML_WriteArray(f);
 }
@@ -2350,7 +2394,7 @@ void TBufferXML::WriteArrayFloat16(const Float_t  *f, Int_t n, TStreamerElement 
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Double32_t to buffer
 
-void TBufferXML::WriteArrayDouble32(const Double_t  *d, Int_t n, TStreamerElement * /*ele*/)
+void TBufferXML::WriteArrayDouble32(const Double_t *d, Int_t n, TStreamerElement * /*ele*/)
 {
    TBufferXML_WriteArray(d);
 }
@@ -2358,47 +2402,51 @@ void TBufferXML::WriteArrayDouble32(const Double_t  *d, Int_t n, TStreamerElemen
 // write array without size attribute
 // macro also treat situation, when instead of one single array
 // chain of several elements should be produced
-#define TBufferXML_WriteFastArray(vname)                                  \
-{                                                                         \
-   BeforeIOoperation();                                                   \
-   if (n<=0) return;                                                      \
-   TStreamerElement* elem = Stack(0)->fElem;                              \
-   if ((elem!=0) && (elem->GetType()>TStreamerInfo::kOffsetL) &&          \
-       (elem->GetType()<TStreamerInfo::kOffsetP) &&                       \
-       (elem->GetArrayLength()!=n)) fExpectedChain = kTRUE;               \
-   if (fExpectedChain) {                                                  \
-      TStreamerInfo* info = Stack(1)->fInfo;                              \
-      Int_t startnumber = Stack(0)->fElemNumber;                          \
-      fExpectedChain = kFALSE;                                            \
-      Int_t index = 0;                                                    \
-      while (index<n) {                                                   \
-        elem =(TStreamerElement*)info->GetElements()->At(startnumber++);  \
-        if (elem->GetType()<TStreamerInfo::kOffsetL) {                    \
-          if(index>0) { PopStack(); CreateElemNode(elem); }               \
-          fCanUseCompact = kTRUE;                                         \
-          XmlWriteBasic(vname[index]);                                    \
-          index++;                                                        \
-        } else {                                                          \
-          XMLNodePointer_t arrnode = CreateItemNode(xmlio::Array);        \
-          Int_t elemlen = elem->GetArrayLength();                         \
-          PushStack(arrnode);                                             \
-          TXMLWriteArrayContent((vname+index), elemlen);                  \
-          index+=elemlen;                                                 \
-          PopStack();                                                     \
-        }                                                                 \
-      }                                                                   \
-   } else {                                                               \
-      XMLNodePointer_t arrnode = CreateItemNode(xmlio::Array);            \
-      PushStack(arrnode);                                                 \
-      TXMLWriteArrayContent(vname, n);                                    \
-      PopStack();                                                         \
-   }                                                                      \
-}
+#define TBufferXML_WriteFastArray(vname)                                                                               \
+   {                                                                                                                   \
+      BeforeIOoperation();                                                                                             \
+      if (n <= 0)                                                                                                      \
+         return;                                                                                                       \
+      TStreamerElement *elem = Stack(0)->fElem;                                                                        \
+      if ((elem != 0) && (elem->GetType() > TStreamerInfo::kOffsetL) && (elem->GetType() < TStreamerInfo::kOffsetP) && \
+          (elem->GetArrayLength() != n))                                                                               \
+         fExpectedChain = kTRUE;                                                                                       \
+      if (fExpectedChain) {                                                                                            \
+         TStreamerInfo *info = Stack(1)->fInfo;                                                                        \
+         Int_t startnumber = Stack(0)->fElemNumber;                                                                    \
+         fExpectedChain = kFALSE;                                                                                      \
+         Int_t index = 0;                                                                                              \
+         while (index < n) {                                                                                           \
+            elem = (TStreamerElement *)info->GetElements()->At(startnumber++);                                         \
+            if (elem->GetType() < TStreamerInfo::kOffsetL) {                                                           \
+               if (index > 0) {                                                                                        \
+                  PopStack();                                                                                          \
+                  CreateElemNode(elem);                                                                                \
+               }                                                                                                       \
+               fCanUseCompact = kTRUE;                                                                                 \
+               XmlWriteBasic(vname[index]);                                                                            \
+               index++;                                                                                                \
+            } else {                                                                                                   \
+               XMLNodePointer_t arrnode = CreateItemNode(xmlio::Array);                                                \
+               Int_t elemlen = elem->GetArrayLength();                                                                 \
+               PushStack(arrnode);                                                                                     \
+               TXMLWriteArrayContent((vname + index), elemlen);                                                        \
+               index += elemlen;                                                                                       \
+               PopStack();                                                                                             \
+            }                                                                                                          \
+         }                                                                                                             \
+      } else {                                                                                                         \
+         XMLNodePointer_t arrnode = CreateItemNode(xmlio::Array);                                                      \
+         PushStack(arrnode);                                                                                           \
+         TXMLWriteArrayContent(vname, n);                                                                              \
+         PopStack();                                                                                                   \
+      }                                                                                                                \
+   }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Bool_t to buffer
 
-void TBufferXML::WriteFastArray(const Bool_t    *b, Int_t n)
+void TBufferXML::WriteFastArray(const Bool_t *b, Int_t n)
 {
    TBufferXML_WriteFastArray(b);
 }
@@ -2408,19 +2456,22 @@ void TBufferXML::WriteFastArray(const Bool_t    *b, Int_t n)
 /// If array does not include any special characters,
 /// it will be reproduced as CharStar node with string as attribute
 
-void TBufferXML::WriteFastArray(const Char_t    *c, Int_t n)
+void TBufferXML::WriteFastArray(const Char_t *c, Int_t n)
 {
-   Bool_t usedefault = (n==0) || fExpectedChain;
-   const Char_t* buf = c;
+   Bool_t usedefault = (n == 0) || fExpectedChain;
+   const Char_t *buf = c;
    if (!usedefault)
-      for (int i=0;i<n;i++) {
-         if (*buf < 27) { usedefault = kTRUE; break; }
+      for (int i = 0; i < n; i++) {
+         if (*buf < 27) {
+            usedefault = kTRUE;
+            break;
+         }
          buf++;
       }
    if (usedefault) {
       TBufferXML_WriteFastArray(c);
    } else {
-      Char_t* buf2 = new Char_t[n+1];
+      Char_t *buf2 = new Char_t[n + 1];
       memcpy(buf2, c, n);
       buf2[n] = 0;
       XmlWriteValue(buf2, xmlio::CharStar);
@@ -2431,7 +2482,7 @@ void TBufferXML::WriteFastArray(const Char_t    *c, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of UChar_t to buffer
 
-void TBufferXML::WriteFastArray(const UChar_t   *c, Int_t n)
+void TBufferXML::WriteFastArray(const UChar_t *c, Int_t n)
 {
    TBufferXML_WriteFastArray(c);
 }
@@ -2439,7 +2490,7 @@ void TBufferXML::WriteFastArray(const UChar_t   *c, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Short_t to buffer
 
-void TBufferXML::WriteFastArray(const Short_t   *h, Int_t n)
+void TBufferXML::WriteFastArray(const Short_t *h, Int_t n)
 {
    TBufferXML_WriteFastArray(h);
 }
@@ -2447,7 +2498,7 @@ void TBufferXML::WriteFastArray(const Short_t   *h, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of UShort_t to buffer
 
-void TBufferXML::WriteFastArray(const UShort_t  *h, Int_t n)
+void TBufferXML::WriteFastArray(const UShort_t *h, Int_t n)
 {
    TBufferXML_WriteFastArray(h);
 }
@@ -2455,7 +2506,7 @@ void TBufferXML::WriteFastArray(const UShort_t  *h, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Int_t to buffer
 
-void TBufferXML::WriteFastArray(const Int_t     *i, Int_t n)
+void TBufferXML::WriteFastArray(const Int_t *i, Int_t n)
 {
    TBufferXML_WriteFastArray(i);
 }
@@ -2463,7 +2514,7 @@ void TBufferXML::WriteFastArray(const Int_t     *i, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of UInt_t to buffer
 
-void TBufferXML::WriteFastArray(const UInt_t    *i, Int_t n)
+void TBufferXML::WriteFastArray(const UInt_t *i, Int_t n)
 {
    TBufferXML_WriteFastArray(i);
 }
@@ -2471,7 +2522,7 @@ void TBufferXML::WriteFastArray(const UInt_t    *i, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Long_t to buffer
 
-void TBufferXML::WriteFastArray(const Long_t    *l, Int_t n)
+void TBufferXML::WriteFastArray(const Long_t *l, Int_t n)
 {
    TBufferXML_WriteFastArray(l);
 }
@@ -2479,7 +2530,7 @@ void TBufferXML::WriteFastArray(const Long_t    *l, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of ULong_t to buffer
 
-void TBufferXML::WriteFastArray(const ULong_t   *l, Int_t n)
+void TBufferXML::WriteFastArray(const ULong_t *l, Int_t n)
 {
    TBufferXML_WriteFastArray(l);
 }
@@ -2487,7 +2538,7 @@ void TBufferXML::WriteFastArray(const ULong_t   *l, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Long64_t to buffer
 
-void TBufferXML::WriteFastArray(const Long64_t  *l, Int_t n)
+void TBufferXML::WriteFastArray(const Long64_t *l, Int_t n)
 {
    TBufferXML_WriteFastArray(l);
 }
@@ -2503,7 +2554,7 @@ void TBufferXML::WriteFastArray(const ULong64_t *l, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Float_t to buffer
 
-void TBufferXML::WriteFastArray(const Float_t   *f, Int_t n)
+void TBufferXML::WriteFastArray(const Float_t *f, Int_t n)
 {
    TBufferXML_WriteFastArray(f);
 }
@@ -2511,7 +2562,7 @@ void TBufferXML::WriteFastArray(const Float_t   *f, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Double_t to buffer
 
-void TBufferXML::WriteFastArray(const Double_t  *d, Int_t n)
+void TBufferXML::WriteFastArray(const Double_t *d, Int_t n)
 {
    TBufferXML_WriteFastArray(d);
 }
@@ -2519,7 +2570,7 @@ void TBufferXML::WriteFastArray(const Double_t  *d, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Float16_t to buffer
 
-void TBufferXML::WriteFastArrayFloat16(const Float_t  *f, Int_t n, TStreamerElement * /*ele*/)
+void TBufferXML::WriteFastArrayFloat16(const Float_t *f, Int_t n, TStreamerElement * /*ele*/)
 {
    TBufferXML_WriteFastArray(f);
 }
@@ -2527,7 +2578,7 @@ void TBufferXML::WriteFastArrayFloat16(const Float_t  *f, Int_t n, TStreamerElem
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Double32_t to buffer
 
-void TBufferXML::WriteFastArrayDouble32(const Double_t  *d, Int_t n, TStreamerElement * /*ele*/)
+void TBufferXML::WriteFastArrayDouble32(const Double_t *d, Int_t n, TStreamerElement * /*ele*/)
 {
    TBufferXML_WriteFastArray(d);
 }
@@ -2535,7 +2586,7 @@ void TBufferXML::WriteFastArrayDouble32(const Double_t  *d, Int_t n, TStreamerEl
 ////////////////////////////////////////////////////////////////////////////////
 /// Recall TBuffer function to avoid gcc warning message
 
-void  TBufferXML::WriteFastArray(void  *start,  const TClass *cl, Int_t n, TMemberStreamer *s)
+void TBufferXML::WriteFastArray(void *start, const TClass *cl, Int_t n, TMemberStreamer *s)
 {
    TBufferFile::WriteFastArray(start, cl, n, s);
 }
@@ -2551,7 +2602,7 @@ Int_t TBufferXML::WriteFastArray(void **startp, const TClass *cl, Int_t n, Bool_
 ////////////////////////////////////////////////////////////////////////////////
 /// steram object to/from buffer
 
-void TBufferXML::StreamObject(void *obj, const std::type_info &typeinfo, const TClass* /* onFileClass */ )
+void TBufferXML::StreamObject(void *obj, const std::type_info &typeinfo, const TClass * /* onFileClass */)
 {
    StreamObject(obj, TClass::GetClass(typeinfo));
 }
@@ -2559,7 +2610,7 @@ void TBufferXML::StreamObject(void *obj, const std::type_info &typeinfo, const T
 ////////////////////////////////////////////////////////////////////////////////
 /// steram object to/from buffer
 
-void TBufferXML::StreamObject(void *obj, const char *className, const TClass* /* onFileClass */ )
+void TBufferXML::StreamObject(void *obj, const char *className, const TClass * /* onFileClass */)
 {
    StreamObject(obj, TClass::GetClass(className));
 }
@@ -2574,11 +2625,11 @@ void TBufferXML::StreamObject(TObject *obj)
 ////////////////////////////////////////////////////////////////////////////////
 /// Steram object to/from buffer
 
-void TBufferXML::StreamObject(void *obj, const TClass *cl, const TClass* /* onfileClass */ )
+void TBufferXML::StreamObject(void *obj, const TClass *cl, const TClass * /* onfileClass */)
 {
    BeforeIOoperation();
-   if (gDebug>1)
-      Info("StreamObject","Class: %s", (cl ? cl->GetName() : "none"));
+   if (gDebug > 1)
+      Info("StreamObject", "Class: %s", (cl ? cl->GetName() : "none"));
    if (IsReading())
       XmlReadObject(obj);
    else
@@ -2587,15 +2638,15 @@ void TBufferXML::StreamObject(void *obj, const TClass *cl, const TClass* /* onfi
 
 // macro for right shift operator for basic type
 #define TBufferXML_operatorin(vname) \
-{                                    \
-  BeforeIOoperation();               \
-  XmlReadBasic(vname);               \
-}
+   {                                 \
+      BeforeIOoperation();           \
+      XmlReadBasic(vname);           \
+   }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads Bool_t value from buffer
 
-void TBufferXML::ReadBool(Bool_t    &b)
+void TBufferXML::ReadBool(Bool_t &b)
 {
    TBufferXML_operatorin(b);
 }
@@ -2603,7 +2654,7 @@ void TBufferXML::ReadBool(Bool_t    &b)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads Char_t value from buffer
 
-void TBufferXML::ReadChar(Char_t    &c)
+void TBufferXML::ReadChar(Char_t &c)
 {
    TBufferXML_operatorin(c);
 }
@@ -2611,7 +2662,7 @@ void TBufferXML::ReadChar(Char_t    &c)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads UChar_t value from buffer
 
-void TBufferXML::ReadUChar(UChar_t   &c)
+void TBufferXML::ReadUChar(UChar_t &c)
 {
    TBufferXML_operatorin(c);
 }
@@ -2619,7 +2670,7 @@ void TBufferXML::ReadUChar(UChar_t   &c)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads Short_t value from buffer
 
-void TBufferXML::ReadShort(Short_t   &h)
+void TBufferXML::ReadShort(Short_t &h)
 {
    TBufferXML_operatorin(h);
 }
@@ -2627,7 +2678,7 @@ void TBufferXML::ReadShort(Short_t   &h)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads UShort_t value from buffer
 
-void TBufferXML::ReadUShort(UShort_t  &h)
+void TBufferXML::ReadUShort(UShort_t &h)
 {
    TBufferXML_operatorin(h);
 }
@@ -2635,7 +2686,7 @@ void TBufferXML::ReadUShort(UShort_t  &h)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads Int_t value from buffer
 
-void TBufferXML::ReadInt(Int_t     &i)
+void TBufferXML::ReadInt(Int_t &i)
 {
    TBufferXML_operatorin(i);
 }
@@ -2643,7 +2694,7 @@ void TBufferXML::ReadInt(Int_t     &i)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads UInt_t value from buffer
 
-void TBufferXML::ReadUInt(UInt_t    &i)
+void TBufferXML::ReadUInt(UInt_t &i)
 {
    TBufferXML_operatorin(i);
 }
@@ -2651,7 +2702,7 @@ void TBufferXML::ReadUInt(UInt_t    &i)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads Long_t value from buffer
 
-void TBufferXML::ReadLong(Long_t    &l)
+void TBufferXML::ReadLong(Long_t &l)
 {
    TBufferXML_operatorin(l);
 }
@@ -2659,7 +2710,7 @@ void TBufferXML::ReadLong(Long_t    &l)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads ULong_t value from buffer
 
-void TBufferXML::ReadULong(ULong_t   &l)
+void TBufferXML::ReadULong(ULong_t &l)
 {
    TBufferXML_operatorin(l);
 }
@@ -2667,7 +2718,7 @@ void TBufferXML::ReadULong(ULong_t   &l)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads Long64_t value from buffer
 
-void TBufferXML::ReadLong64(Long64_t  &l)
+void TBufferXML::ReadLong64(Long64_t &l)
 {
    TBufferXML_operatorin(l);
 }
@@ -2683,7 +2734,7 @@ void TBufferXML::ReadULong64(ULong64_t &l)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads Float_t value from buffer
 
-void TBufferXML::ReadFloat(Float_t   &f)
+void TBufferXML::ReadFloat(Float_t &f)
 {
    TBufferXML_operatorin(f);
 }
@@ -2691,7 +2742,7 @@ void TBufferXML::ReadFloat(Float_t   &f)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads Double_t value from buffer
 
-void TBufferXML::ReadDouble(Double_t  &d)
+void TBufferXML::ReadDouble(Double_t &d)
 {
    TBufferXML_operatorin(d);
 }
@@ -2699,10 +2750,10 @@ void TBufferXML::ReadDouble(Double_t  &d)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads array of characters from buffer
 
-void TBufferXML::ReadCharP(Char_t    *c)
+void TBufferXML::ReadCharP(Char_t *c)
 {
    BeforeIOoperation();
-   const char* buf;
+   const char *buf;
    if ((buf = XmlReadValue(xmlio::CharStar)))
       strcpy(c, buf);
 }
@@ -2712,11 +2763,11 @@ void TBufferXML::ReadCharP(Char_t    *c)
 
 void TBufferXML::ReadTString(TString &s)
 {
-   if (GetIOVersion()<3) {
+   if (GetIOVersion() < 3) {
       TBufferFile::ReadTString(s);
    } else {
       BeforeIOoperation();
-      const char* buf;
+      const char *buf;
       if ((buf = XmlReadValue(xmlio::String)))
          s = buf;
    }
@@ -2727,36 +2778,36 @@ void TBufferXML::ReadTString(TString &s)
 
 void TBufferXML::ReadStdString(std::string *s)
 {
-   if (GetIOVersion()<3) {
+   if (GetIOVersion() < 3) {
       TBufferFile::ReadStdString(s);
    } else {
       BeforeIOoperation();
-      const char* buf;
+      const char *buf;
       if ((buf = XmlReadValue(xmlio::String)))
-         if (s) *s = buf;
+         if (s)
+            *s = buf;
    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read a char* string
 
-void TBufferXML::ReadCharStar(char* &s)
+void TBufferXML::ReadCharStar(char *&s)
 {
    TBufferFile::ReadCharStar(s);
 }
 
-
 // macro for left shift operator for basic types
 #define TBufferXML_operatorout(vname) \
-{                                     \
-  BeforeIOoperation();                \
-  XmlWriteBasic(vname);               \
-}
+   {                                  \
+      BeforeIOoperation();            \
+      XmlWriteBasic(vname);           \
+   }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Writes Bool_t value to buffer
 
-void TBufferXML::WriteBool(Bool_t    b)
+void TBufferXML::WriteBool(Bool_t b)
 {
    TBufferXML_operatorout(b);
 }
@@ -2764,7 +2815,7 @@ void TBufferXML::WriteBool(Bool_t    b)
 ////////////////////////////////////////////////////////////////////////////////
 /// Writes Char_t value to buffer
 
-void TBufferXML::WriteChar(Char_t    c)
+void TBufferXML::WriteChar(Char_t c)
 {
    TBufferXML_operatorout(c);
 }
@@ -2772,7 +2823,7 @@ void TBufferXML::WriteChar(Char_t    c)
 ////////////////////////////////////////////////////////////////////////////////
 /// Writes UChar_t value to buffer
 
-void TBufferXML::WriteUChar(UChar_t   c)
+void TBufferXML::WriteUChar(UChar_t c)
 {
    TBufferXML_operatorout(c);
 }
@@ -2780,7 +2831,7 @@ void TBufferXML::WriteUChar(UChar_t   c)
 ////////////////////////////////////////////////////////////////////////////////
 /// Writes Short_t value to buffer
 
-void TBufferXML::WriteShort(Short_t   h)
+void TBufferXML::WriteShort(Short_t h)
 {
    TBufferXML_operatorout(h);
 }
@@ -2788,7 +2839,7 @@ void TBufferXML::WriteShort(Short_t   h)
 ////////////////////////////////////////////////////////////////////////////////
 /// Writes UShort_t value to buffer
 
-void TBufferXML::WriteUShort(UShort_t  h)
+void TBufferXML::WriteUShort(UShort_t h)
 {
    TBufferXML_operatorout(h);
 }
@@ -2796,7 +2847,7 @@ void TBufferXML::WriteUShort(UShort_t  h)
 ////////////////////////////////////////////////////////////////////////////////
 /// Writes Int_t value to buffer
 
-void TBufferXML::WriteInt(Int_t     i)
+void TBufferXML::WriteInt(Int_t i)
 {
    TBufferXML_operatorout(i);
 }
@@ -2804,7 +2855,7 @@ void TBufferXML::WriteInt(Int_t     i)
 ////////////////////////////////////////////////////////////////////////////////
 /// Writes UInt_t value to buffer
 
-void TBufferXML::WriteUInt(UInt_t    i)
+void TBufferXML::WriteUInt(UInt_t i)
 {
    TBufferXML_operatorout(i);
 }
@@ -2812,7 +2863,7 @@ void TBufferXML::WriteUInt(UInt_t    i)
 ////////////////////////////////////////////////////////////////////////////////
 /// Writes Long_t value to buffer
 
-void TBufferXML::WriteLong(Long_t    l)
+void TBufferXML::WriteLong(Long_t l)
 {
    TBufferXML_operatorout(l);
 }
@@ -2820,7 +2871,7 @@ void TBufferXML::WriteLong(Long_t    l)
 ////////////////////////////////////////////////////////////////////////////////
 /// Writes ULong_t value to buffer
 
-void TBufferXML::WriteULong(ULong_t   l)
+void TBufferXML::WriteULong(ULong_t l)
 {
    TBufferXML_operatorout(l);
 }
@@ -2828,7 +2879,7 @@ void TBufferXML::WriteULong(ULong_t   l)
 ////////////////////////////////////////////////////////////////////////////////
 /// Writes Long64_t value to buffer
 
-void TBufferXML::WriteLong64(Long64_t  l)
+void TBufferXML::WriteLong64(Long64_t l)
 {
    TBufferXML_operatorout(l);
 }
@@ -2844,7 +2895,7 @@ void TBufferXML::WriteULong64(ULong64_t l)
 ////////////////////////////////////////////////////////////////////////////////
 /// Writes Float_t value to buffer
 
-void TBufferXML::WriteFloat(Float_t   f)
+void TBufferXML::WriteFloat(Float_t f)
 {
    TBufferXML_operatorout(f);
 }
@@ -2852,7 +2903,7 @@ void TBufferXML::WriteFloat(Float_t   f)
 ////////////////////////////////////////////////////////////////////////////////
 /// Writes Double_t value to buffer
 
-void TBufferXML::WriteDouble(Double_t  d)
+void TBufferXML::WriteDouble(Double_t d)
 {
    TBufferXML_operatorout(d);
 }
@@ -2871,7 +2922,7 @@ void TBufferXML::WriteCharP(const Char_t *c)
 
 void TBufferXML::WriteTString(const TString &s)
 {
-   if (GetIOVersion()<3) {
+   if (GetIOVersion() < 3) {
       TBufferFile::WriteTString(s);
    } else {
       BeforeIOoperation();
@@ -2884,12 +2935,14 @@ void TBufferXML::WriteTString(const TString &s)
 
 void TBufferXML::WriteStdString(const std::string *s)
 {
-   if (GetIOVersion()<3) {
+   if (GetIOVersion() < 3) {
       TBufferFile::WriteStdString(s);
    } else {
       BeforeIOoperation();
-      if (s) XmlWriteValue(s->c_str(), xmlio::String);
-      else XmlWriteValue("", xmlio::String);
+      if (s)
+         XmlWriteValue(s->c_str(), xmlio::String);
+      else
+         XmlWriteValue("", xmlio::String);
    }
 }
 
@@ -2901,21 +2954,20 @@ void TBufferXML::WriteCharStar(char *s)
    TBufferFile::WriteCharStar(s);
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Converts Char_t to string and add xml node to buffer
 
 XMLNodePointer_t TBufferXML::XmlWriteBasic(Char_t value)
 {
    char buf[50];
-   snprintf(buf, sizeof(buf), "%d",value);
+   snprintf(buf, sizeof(buf), "%d", value);
    return XmlWriteValue(buf, xmlio::Char);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Converts Short_t to string and add xml node to buffer
 
-XMLNodePointer_t  TBufferXML::XmlWriteBasic(Short_t value)
+XMLNodePointer_t TBufferXML::XmlWriteBasic(Short_t value)
 {
    char buf[50];
    snprintf(buf, sizeof(buf), "%hd", value);
@@ -2955,7 +3007,7 @@ XMLNodePointer_t TBufferXML::XmlWriteBasic(Long64_t value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Converts Float_t to string and add xml node to buffer
 
-XMLNodePointer_t  TBufferXML::XmlWriteBasic(Float_t value)
+XMLNodePointer_t TBufferXML::XmlWriteBasic(Float_t value)
 {
    char buf[200];
    snprintf(buf, sizeof(buf), fgFloatFmt.c_str(), value);
@@ -3033,7 +3085,7 @@ XMLNodePointer_t TBufferXML::XmlWriteBasic(ULong64_t value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Create xml node with specified name and adds it to stack node
 
-XMLNodePointer_t TBufferXML::XmlWriteValue(const char* value, const char* name)
+XMLNodePointer_t TBufferXML::XmlWriteValue(const char *value, const char *name)
 {
    XMLNodePointer_t node = 0;
 
@@ -3052,12 +3104,12 @@ XMLNodePointer_t TBufferXML::XmlWriteValue(const char* value, const char* name)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads string from current xml node and convert it to Char_t value
 
-void TBufferXML::XmlReadBasic(Char_t& value)
+void TBufferXML::XmlReadBasic(Char_t &value)
 {
-   const char* res = XmlReadValue(xmlio::Char);
+   const char *res = XmlReadValue(xmlio::Char);
    if (res) {
       int n;
-      sscanf(res,"%d", &n);
+      sscanf(res, "%d", &n);
       value = n;
    } else
       value = 0;
@@ -3066,11 +3118,11 @@ void TBufferXML::XmlReadBasic(Char_t& value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads string from current xml node and convert it to Short_t value
 
-void TBufferXML::XmlReadBasic(Short_t& value)
+void TBufferXML::XmlReadBasic(Short_t &value)
 {
-   const char* res = XmlReadValue(xmlio::Short);
+   const char *res = XmlReadValue(xmlio::Short);
    if (res)
-      sscanf(res,"%hd", &value);
+      sscanf(res, "%hd", &value);
    else
       value = 0;
 }
@@ -3078,11 +3130,11 @@ void TBufferXML::XmlReadBasic(Short_t& value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads string from current xml node and convert it to Int_t value
 
-void TBufferXML::XmlReadBasic(Int_t& value)
+void TBufferXML::XmlReadBasic(Int_t &value)
 {
-   const char* res = XmlReadValue(xmlio::Int);
+   const char *res = XmlReadValue(xmlio::Int);
    if (res)
-      sscanf(res,"%d", &value);
+      sscanf(res, "%d", &value);
    else
       value = 0;
 }
@@ -3090,11 +3142,11 @@ void TBufferXML::XmlReadBasic(Int_t& value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads string from current xml node and convert it to Long_t value
 
-void TBufferXML::XmlReadBasic(Long_t& value)
+void TBufferXML::XmlReadBasic(Long_t &value)
 {
-   const char* res = XmlReadValue(xmlio::Long);
+   const char *res = XmlReadValue(xmlio::Long);
    if (res)
-      sscanf(res,"%ld", &value);
+      sscanf(res, "%ld", &value);
    else
       value = 0;
 }
@@ -3102,9 +3154,9 @@ void TBufferXML::XmlReadBasic(Long_t& value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads string from current xml node and convert it to Long64_t value
 
-void TBufferXML::XmlReadBasic(Long64_t& value)
+void TBufferXML::XmlReadBasic(Long64_t &value)
 {
-   const char* res = XmlReadValue(xmlio::Long64);
+   const char *res = XmlReadValue(xmlio::Long64);
    if (res)
       sscanf(res, FLong64, &value);
    else
@@ -3114,9 +3166,9 @@ void TBufferXML::XmlReadBasic(Long64_t& value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads string from current xml node and convert it to Float_t value
 
-void TBufferXML::XmlReadBasic(Float_t& value)
+void TBufferXML::XmlReadBasic(Float_t &value)
 {
-   const char* res = XmlReadValue(xmlio::Float);
+   const char *res = XmlReadValue(xmlio::Float);
    if (res)
       sscanf(res, "%f", &value);
    else
@@ -3126,9 +3178,9 @@ void TBufferXML::XmlReadBasic(Float_t& value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads string from current xml node and convert it to Double_t value
 
-void TBufferXML::XmlReadBasic(Double_t& value)
+void TBufferXML::XmlReadBasic(Double_t &value)
 {
-   const char* res = XmlReadValue(xmlio::Double);
+   const char *res = XmlReadValue(xmlio::Double);
    if (res)
       sscanf(res, "%lf", &value);
    else
@@ -3138,11 +3190,11 @@ void TBufferXML::XmlReadBasic(Double_t& value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads string from current xml node and convert it to Bool_t value
 
-void TBufferXML::XmlReadBasic(Bool_t& value)
+void TBufferXML::XmlReadBasic(Bool_t &value)
 {
-   const char* res = XmlReadValue(xmlio::Bool);
+   const char *res = XmlReadValue(xmlio::Bool);
    if (res)
-      value = (strcmp(res, xmlio::True)==0);
+      value = (strcmp(res, xmlio::True) == 0);
    else
       value = kFALSE;
 }
@@ -3150,12 +3202,12 @@ void TBufferXML::XmlReadBasic(Bool_t& value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads string from current xml node and convert it to UChar_t value
 
-void TBufferXML::XmlReadBasic(UChar_t& value)
+void TBufferXML::XmlReadBasic(UChar_t &value)
 {
-   const char* res = XmlReadValue(xmlio::UChar);
+   const char *res = XmlReadValue(xmlio::UChar);
    if (res) {
       unsigned int n;
-      sscanf(res,"%ud", &n);
+      sscanf(res, "%ud", &n);
       value = n;
    } else
       value = 0;
@@ -3164,11 +3216,11 @@ void TBufferXML::XmlReadBasic(UChar_t& value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads string from current xml node and convert it to UShort_t value
 
-void TBufferXML::XmlReadBasic(UShort_t& value)
+void TBufferXML::XmlReadBasic(UShort_t &value)
 {
-   const char* res = XmlReadValue(xmlio::UShort);
+   const char *res = XmlReadValue(xmlio::UShort);
    if (res)
-      sscanf(res,"%hud", &value);
+      sscanf(res, "%hud", &value);
    else
       value = 0;
 }
@@ -3176,11 +3228,11 @@ void TBufferXML::XmlReadBasic(UShort_t& value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads string from current xml node and convert it to UInt_t value
 
-void TBufferXML::XmlReadBasic(UInt_t& value)
+void TBufferXML::XmlReadBasic(UInt_t &value)
 {
-   const char* res = XmlReadValue(xmlio::UInt);
+   const char *res = XmlReadValue(xmlio::UInt);
    if (res)
-      sscanf(res,"%u", &value);
+      sscanf(res, "%u", &value);
    else
       value = 0;
 }
@@ -3188,11 +3240,11 @@ void TBufferXML::XmlReadBasic(UInt_t& value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads string from current xml node and convert it to ULong_t value
 
-void TBufferXML::XmlReadBasic(ULong_t& value)
+void TBufferXML::XmlReadBasic(ULong_t &value)
 {
-   const char* res = XmlReadValue(xmlio::ULong);
+   const char *res = XmlReadValue(xmlio::ULong);
    if (res)
-      sscanf(res,"%lu", &value);
+      sscanf(res, "%lu", &value);
    else
       value = 0;
 }
@@ -3200,9 +3252,9 @@ void TBufferXML::XmlReadBasic(ULong_t& value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads string from current xml node and convert it to ULong64_t value
 
-void TBufferXML::XmlReadBasic(ULong64_t& value)
+void TBufferXML::XmlReadBasic(ULong64_t &value)
 {
-   const char* res = XmlReadValue(xmlio::ULong64);
+   const char *res = XmlReadValue(xmlio::ULong64);
    if (res)
       sscanf(res, FULong64, &value);
    else
@@ -3212,27 +3264,29 @@ void TBufferXML::XmlReadBasic(ULong64_t& value)
 ////////////////////////////////////////////////////////////////////////////////
 /// read string value from current stack node
 
-const char* TBufferXML::XmlReadValue(const char* name)
+const char *TBufferXML::XmlReadValue(const char *name)
 {
-   if (fErrorFlag>0) return 0;
+   if (fErrorFlag > 0)
+      return 0;
 
    Bool_t trysimple = fCanUseCompact;
    fCanUseCompact = kFALSE;
 
    if (trysimple) {
-      if (fXML->HasAttr(Stack(1)->fNode,xmlio::v))
+      if (fXML->HasAttr(Stack(1)->fNode, xmlio::v))
          fValueBuf = fXML->GetAttr(Stack(1)->fNode, xmlio::v);
       else
          trysimple = kFALSE;
    }
 
    if (!trysimple) {
-      if (!VerifyItemNode(name, "XmlReadValue")) return 0;
+      if (!VerifyItemNode(name, "XmlReadValue"))
+         return 0;
       fValueBuf = fXML->GetAttr(StackNode(), xmlio::v);
    }
 
-   if (gDebug>4)
-      Info("XmlReadValue","     Name = %s value = %s", name, fValueBuf.Data());
+   if (gDebug > 4)
+      Info("XmlReadValue", "     Name = %s value = %s", name, fValueBuf.Data());
 
    if (!trysimple)
       ShiftStack("readvalue");
@@ -3240,16 +3294,17 @@ const char* TBufferXML::XmlReadValue(const char* name)
    return fValueBuf.Data();
 }
 
-void TBufferXML::SetFloatFormat(const char* fmt)
+void TBufferXML::SetFloatFormat(const char *fmt)
 {
    // Set printf format for float/double members, default "%e"
    // This method is not thread-safe as it changes a global state.
 
-   if (!fmt) fgFloatFmt = "%e";
+   if (!fmt)
+      fgFloatFmt = "%e";
    fgFloatFmt = fmt;
 }
 
-const char* TBufferXML::GetFloatFormat()
+const char *TBufferXML::GetFloatFormat()
 {
    // return current printf format for float/double members, default "%e"
 
@@ -3266,26 +3321,24 @@ Int_t TBufferXML::ApplySequence(const TStreamerInfoActions::TActionSequence &seq
    IncrementLevel(info);
 
    if (gDebug) {
-      //loop on all active members
+      // loop on all active members
       TStreamerInfoActions::ActionContainer_t::const_iterator end = sequence.fActions.end();
-      for(TStreamerInfoActions::ActionContainer_t::const_iterator iter = sequence.fActions.begin();
-          iter != end;
-          ++iter) {
+      for (TStreamerInfoActions::ActionContainer_t::const_iterator iter = sequence.fActions.begin(); iter != end;
+           ++iter) {
          // Idea: Try to remove this function call as it is really needed only for XML streaming.
-         SetStreamerElementNumber((*iter).fConfiguration->fCompInfo->fElem,(*iter).fConfiguration->fCompInfo->fType);
-         (*iter).PrintDebug(*this,obj);
-         (*iter)(*this,obj);
+         SetStreamerElementNumber((*iter).fConfiguration->fCompInfo->fElem, (*iter).fConfiguration->fCompInfo->fType);
+         (*iter).PrintDebug(*this, obj);
+         (*iter)(*this, obj);
       }
 
    } else {
-      //loop on all active members
+      // loop on all active members
       TStreamerInfoActions::ActionContainer_t::const_iterator end = sequence.fActions.end();
-      for(TStreamerInfoActions::ActionContainer_t::const_iterator iter = sequence.fActions.begin();
-          iter != end;
-          ++iter) {
+      for (TStreamerInfoActions::ActionContainer_t::const_iterator iter = sequence.fActions.begin(); iter != end;
+           ++iter) {
          // Idea: Try to remove this function call as it is really needed only for XML streaming.
-         SetStreamerElementNumber((*iter).fConfiguration->fCompInfo->fElem,(*iter).fConfiguration->fCompInfo->fType);
-         (*iter)(*this,obj);
+         SetStreamerElementNumber((*iter).fConfiguration->fCompInfo->fElem, (*iter).fConfiguration->fCompInfo->fType);
+         (*iter)(*this, obj);
       }
    }
 
@@ -3297,32 +3350,32 @@ Int_t TBufferXML::ApplySequence(const TStreamerInfoActions::TActionSequence &seq
 /// Read one collection of objects from the buffer using the StreamerInfoLoopAction.
 /// The collection needs to be a split TClonesArray or a split vector of pointers.
 
-Int_t TBufferXML::ApplySequenceVecPtr(const TStreamerInfoActions::TActionSequence &sequence, void *start_collection, void *end_collection)
+Int_t TBufferXML::ApplySequenceVecPtr(const TStreamerInfoActions::TActionSequence &sequence, void *start_collection,
+                                      void *end_collection)
 {
    TVirtualStreamerInfo *info = sequence.fStreamerInfo;
    IncrementLevel(info);
 
    if (gDebug) {
-      //loop on all active members
+      // loop on all active members
       TStreamerInfoActions::ActionContainer_t::const_iterator end = sequence.fActions.end();
-      for(TStreamerInfoActions::ActionContainer_t::const_iterator iter = sequence.fActions.begin();
-          iter != end;
-          ++iter) {
+      for (TStreamerInfoActions::ActionContainer_t::const_iterator iter = sequence.fActions.begin(); iter != end;
+           ++iter) {
          // Idea: Try to remove this function call as it is really needed only for XML streaming.
-         SetStreamerElementNumber((*iter).fConfiguration->fCompInfo->fElem,(*iter).fConfiguration->fCompInfo->fType);
-         (*iter).PrintDebug(*this,*(char**)start_collection);  // Warning: This limits us to TClonesArray and vector of pointers.
-         (*iter)(*this,start_collection,end_collection);
+         SetStreamerElementNumber((*iter).fConfiguration->fCompInfo->fElem, (*iter).fConfiguration->fCompInfo->fType);
+         (*iter).PrintDebug(
+            *this, *(char **)start_collection); // Warning: This limits us to TClonesArray and vector of pointers.
+         (*iter)(*this, start_collection, end_collection);
       }
 
    } else {
-      //loop on all active members
+      // loop on all active members
       TStreamerInfoActions::ActionContainer_t::const_iterator end = sequence.fActions.end();
-      for(TStreamerInfoActions::ActionContainer_t::const_iterator iter = sequence.fActions.begin();
-          iter != end;
-          ++iter) {
+      for (TStreamerInfoActions::ActionContainer_t::const_iterator iter = sequence.fActions.begin(); iter != end;
+           ++iter) {
          // Idea: Try to remove this function call as it is really needed only for XML streaming.
-         SetStreamerElementNumber((*iter).fConfiguration->fCompInfo->fElem,(*iter).fConfiguration->fCompInfo->fType);
-         (*iter)(*this,start_collection,end_collection);
+         SetStreamerElementNumber((*iter).fConfiguration->fCompInfo->fElem, (*iter).fConfiguration->fCompInfo->fType);
+         (*iter)(*this, start_collection, end_collection);
       }
    }
 
@@ -3333,7 +3386,8 @@ Int_t TBufferXML::ApplySequenceVecPtr(const TStreamerInfoActions::TActionSequenc
 ////////////////////////////////////////////////////////////////////////////////
 /// Read one collection of objects from the buffer using the StreamerInfoLoopAction.
 
-Int_t TBufferXML::ApplySequence(const TStreamerInfoActions::TActionSequence &sequence, void *start_collection, void *end_collection)
+Int_t TBufferXML::ApplySequence(const TStreamerInfoActions::TActionSequence &sequence, void *start_collection,
+                                void *end_collection)
 {
    TVirtualStreamerInfo *info = sequence.fStreamerInfo;
    IncrementLevel(info);
@@ -3344,27 +3398,25 @@ Int_t TBufferXML::ApplySequence(const TStreamerInfoActions::TActionSequence &seq
       // Get the address of the first item for the PrintDebug.
       // (Performance is not essential here since we are going to print to
       // the screen anyway).
-      void *arr0 = loopconfig->GetFirstAddress(start_collection,end_collection);
+      void *arr0 = loopconfig->GetFirstAddress(start_collection, end_collection);
       // loop on all active members
       TStreamerInfoActions::ActionContainer_t::const_iterator end = sequence.fActions.end();
-      for(TStreamerInfoActions::ActionContainer_t::const_iterator iter = sequence.fActions.begin();
-          iter != end;
-          ++iter) {
+      for (TStreamerInfoActions::ActionContainer_t::const_iterator iter = sequence.fActions.begin(); iter != end;
+           ++iter) {
          // Idea: Try to remove this function call as it is really needed only for XML streaming.
-         SetStreamerElementNumber((*iter).fConfiguration->fCompInfo->fElem,(*iter).fConfiguration->fCompInfo->fType);
-         (*iter).PrintDebug(*this,arr0);
-         (*iter)(*this,start_collection,end_collection,loopconfig);
+         SetStreamerElementNumber((*iter).fConfiguration->fCompInfo->fElem, (*iter).fConfiguration->fCompInfo->fType);
+         (*iter).PrintDebug(*this, arr0);
+         (*iter)(*this, start_collection, end_collection, loopconfig);
       }
 
    } else {
-      //loop on all active members
+      // loop on all active members
       TStreamerInfoActions::ActionContainer_t::const_iterator end = sequence.fActions.end();
-      for(TStreamerInfoActions::ActionContainer_t::const_iterator iter = sequence.fActions.begin();
-          iter != end;
-          ++iter) {
+      for (TStreamerInfoActions::ActionContainer_t::const_iterator iter = sequence.fActions.begin(); iter != end;
+           ++iter) {
          // Idea: Try to remove this function call as it is really needed only for XML streaming.
-         SetStreamerElementNumber((*iter).fConfiguration->fCompInfo->fElem,(*iter).fConfiguration->fCompInfo->fType);
-         (*iter)(*this,start_collection,end_collection,loopconfig);
+         SetStreamerElementNumber((*iter).fConfiguration->fCompInfo->fElem, (*iter).fConfiguration->fCompInfo->fType);
+         (*iter)(*this, start_collection, end_collection, loopconfig);
       }
    }
 

--- a/io/xml/src/TKeyXML.cxx
+++ b/io/xml/src/TKeyXML.cxx
@@ -39,7 +39,7 @@ TKeyXML::TKeyXML() :
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Creates TKeyXML and convert obj data to xml structures
+/// Creates TKeyXML and convert object data to xml structures
 
 TKeyXML::TKeyXML(TDirectory* mother, Long64_t keyid, const TObject* obj, const char* name, const char* title) :
     TKey(mother),
@@ -70,7 +70,7 @@ TKeyXML::TKeyXML(TDirectory* mother, Long64_t keyid, const TObject* obj, const c
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Creates TKeyXML and convert obj data to xml structures
+/// Creates TKeyXML and convert object data to xml structures
 
 TKeyXML::TKeyXML(TDirectory* mother, Long64_t keyid, const void* obj, const TClass* cl, const char* name, const char* title) :
    TKey(mother),

--- a/io/xml/src/TKeyXML.cxx
+++ b/io/xml/src/TKeyXML.cxx
@@ -16,7 +16,6 @@
 // TObjArray and so on.
 //________________________________________________________________________
 
-
 #include "TKeyXML.h"
 
 #include "TBufferXML.h"
@@ -30,38 +29,31 @@ ClassImp(TKeyXML);
 ////////////////////////////////////////////////////////////////////////////////
 /// default constructor
 
-TKeyXML::TKeyXML() :
-   TKey(),
-   fKeyNode(0),
-   fKeyId(0),
-   fSubdir(kFALSE)
+TKeyXML::TKeyXML() : TKey(), fKeyNode(0), fKeyId(0), fSubdir(kFALSE)
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates TKeyXML and convert object data to xml structures
 
-TKeyXML::TKeyXML(TDirectory* mother, Long64_t keyid, const TObject* obj, const char* name, const char* title) :
-    TKey(mother),
-    fKeyNode(0),
-    fKeyId(keyid),
-    fSubdir(kFALSE)
+TKeyXML::TKeyXML(TDirectory *mother, Long64_t keyid, const TObject *obj, const char *name, const char *title)
+   : TKey(mother), fKeyNode(0), fKeyId(keyid), fSubdir(kFALSE)
 {
    if (name)
       SetName(name);
-   else
-      if (obj!=0) {
-         SetName(obj->GetName());
-         fClassName=obj->ClassName();
-      } else
-         SetName("Noname");
+   else if (obj != 0) {
+      SetName(obj->GetName());
+      fClassName = obj->ClassName();
+   } else
+      SetName("Noname");
 
-   if (title) SetTitle(title);
+   if (title)
+      SetTitle(title);
 
-   fCycle  = GetMotherDir()->AppendKey(this);
+   fCycle = GetMotherDir()->AppendKey(this);
 
-   TXMLEngine* xml = XMLEngine();
-   if (xml!=0)
+   TXMLEngine *xml = XMLEngine();
+   if (xml != 0)
       fKeyNode = xml->NewChild(0, 0, xmlio::Xmlkey, 0);
 
    fDatime.Set();
@@ -72,21 +64,22 @@ TKeyXML::TKeyXML(TDirectory* mother, Long64_t keyid, const TObject* obj, const c
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates TKeyXML and convert object data to xml structures
 
-TKeyXML::TKeyXML(TDirectory* mother, Long64_t keyid, const void* obj, const TClass* cl, const char* name, const char* title) :
-   TKey(mother),
-   fKeyNode(0),
-   fKeyId(keyid),
-   fSubdir(kFALSE)
+TKeyXML::TKeyXML(TDirectory *mother, Long64_t keyid, const void *obj, const TClass *cl, const char *name,
+                 const char *title)
+   : TKey(mother), fKeyNode(0), fKeyId(keyid), fSubdir(kFALSE)
 {
-   if (name && *name) SetName(name);
-   else SetName(cl ? cl->GetName() : "Noname");
+   if (name && *name)
+      SetName(name);
+   else
+      SetName(cl ? cl->GetName() : "Noname");
 
-   if (title) SetTitle(title);
+   if (title)
+      SetTitle(title);
 
-   fCycle  = GetMotherDir()->AppendKey(this);
+   fCycle = GetMotherDir()->AppendKey(this);
 
-   TXMLEngine* xml = XMLEngine();
-   if (xml!=0)
+   TXMLEngine *xml = XMLEngine();
+   if (xml != 0)
       fKeyNode = xml->NewChild(0, 0, xmlio::Xmlkey, 0);
 
    fDatime.Set();
@@ -97,13 +90,10 @@ TKeyXML::TKeyXML(TDirectory* mother, Long64_t keyid, const void* obj, const TCla
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates TKeyXML and takes ownership over xml node, from which object can be restored
 
-TKeyXML::TKeyXML(TDirectory* mother, Long64_t keyid, XMLNodePointer_t keynode) :
-   TKey(mother),
-   fKeyNode(keynode),
-   fKeyId(keyid),
-   fSubdir(kFALSE)
+TKeyXML::TKeyXML(TDirectory *mother, Long64_t keyid, XMLNodePointer_t keynode)
+   : TKey(mother), fKeyNode(keynode), fKeyId(keyid), fSubdir(kFALSE)
 {
-   TXMLEngine* xml = XMLEngine();
+   TXMLEngine *xml = XMLEngine();
 
    SetName(xml->GetAttr(keynode, xmlio::Name));
 
@@ -129,7 +119,7 @@ TKeyXML::TKeyXML(TDirectory* mother, Long64_t keyid, XMLNodePointer_t keynode) :
 TKeyXML::~TKeyXML()
 {
    if (fKeyNode) {
-      TXMLEngine* xml = XMLEngine();
+      TXMLEngine *xml = XMLEngine();
       if (xml) {
          xml->FreeNode(fKeyNode);
       } else {
@@ -145,7 +135,7 @@ TKeyXML::~TKeyXML()
 
 void TKeyXML::Delete(Option_t * /*option*/)
 {
-   TXMLEngine* xml = XMLEngine();
+   TXMLEngine *xml = XMLEngine();
    if (fKeyNode && xml) {
       xml->FreeNode(fKeyNode);
       fKeyNode = 0;
@@ -159,16 +149,17 @@ void TKeyXML::Delete(Option_t * /*option*/)
 
 void TKeyXML::StoreKeyAttributes()
 {
-   TXMLEngine* xml = XMLEngine();
-   TXMLFile* f = (TXMLFile*) GetFile();
-   if ((f==0) || (xml==0) || (fKeyNode==0)) return;
+   TXMLEngine *xml = XMLEngine();
+   TXMLFile *f = (TXMLFile *)GetFile();
+   if ((f == 0) || (xml == 0) || (fKeyNode == 0))
+      return;
 
    xml->NewAttr(fKeyNode, 0, xmlio::Name, GetName());
 
    xml->NewIntAttr(fKeyNode, xmlio::Cycle, fCycle);
 
-   if (f->GetIOVersion()>1) {
-      if (strlen(GetTitle())>0)
+   if (f->GetIOVersion() > 1) {
+      if (strlen(GetTitle()) > 0)
          xml->NewAttr(fKeyNode, 0, xmlio::Title, GetTitle());
       xml->NewAttr(fKeyNode, 0, xmlio::CreateTm, fDatime.AsSQLString());
    }
@@ -177,34 +168,37 @@ void TKeyXML::StoreKeyAttributes()
 ////////////////////////////////////////////////////////////////////////////////
 ///  convert object to xml structure and keep this structure in key
 
-void TKeyXML::StoreObject(const void* obj, const TClass* cl, Bool_t check_tobj)
+void TKeyXML::StoreObject(const void *obj, const TClass *cl, Bool_t check_tobj)
 {
-   TXMLFile* f = (TXMLFile*) GetFile();
-   TXMLEngine* xml = XMLEngine();
-   if ((f==0) || (xml==0) || (fKeyNode==0)) return;
+   TXMLFile *f = (TXMLFile *)GetFile();
+   TXMLEngine *xml = XMLEngine();
+   if ((f == 0) || (xml == 0) || (fKeyNode == 0))
+      return;
 
    if (obj && check_tobj) {
-      TClass* actual = TObject::Class()->GetActualClass((TObject*) obj);
-      if (!actual) actual = TObject::Class(); else
-      if (actual != TObject::Class())
-         obj = (void *) ((Long_t) obj - actual->GetBaseClassOffset(TObject::Class()));
+      TClass *actual = TObject::Class()->GetActualClass((TObject *)obj);
+      if (!actual)
+         actual = TObject::Class();
+      else if (actual != TObject::Class())
+         obj = (void *)((Long_t)obj - actual->GetBaseClassOffset(TObject::Class()));
       cl = actual;
    }
 
    StoreKeyAttributes();
 
    TBufferXML buffer(TBuffer::kWrite, f);
-   if (f->GetIOVersion()==1)
+   if (f->GetIOVersion() == 1)
       buffer.SetBit(TBuffer::kCannotHandleMemberWiseStreaming, kFALSE);
 
    XMLNodePointer_t node = buffer.XmlWriteAny(obj, cl);
 
-   if (node!=0)
+   if (node != 0)
       xml->AddChildFirst(fKeyNode, node);
 
    buffer.XmlWriteBlock(fKeyNode);
 
-   if (cl) fClassName = cl->GetName();
+   if (cl)
+      fClassName = cl->GetName();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -212,8 +206,9 @@ void TKeyXML::StoreObject(const void* obj, const TClass* cl, Bool_t check_tobj)
 
 void TKeyXML::UpdateAttributes()
 {
-   TXMLEngine* xml = XMLEngine();
-   if ((xml==0) || (fKeyNode==0)) return;
+   TXMLEngine *xml = XMLEngine();
+   if ((xml == 0) || (fKeyNode == 0))
+      return;
 
    xml->FreeAllAttr(fKeyNode);
 
@@ -224,16 +219,18 @@ void TKeyXML::UpdateAttributes()
 /// updates object, stored in the node
 /// Used for TDirectory data update
 
-void TKeyXML::UpdateObject(TObject* obj)
+void TKeyXML::UpdateObject(TObject *obj)
 {
-   TXMLFile* f = (TXMLFile*) GetFile();
-   TXMLEngine* xml = XMLEngine();
-   if ((f==0) || (xml==0) || (obj==0) || (fKeyNode==0)) return;
+   TXMLFile *f = (TXMLFile *)GetFile();
+   TXMLEngine *xml = XMLEngine();
+   if ((f == 0) || (xml == 0) || (obj == 0) || (fKeyNode == 0))
+      return;
 
    XMLNodePointer_t objnode = xml->GetChild(fKeyNode);
    xml->SkipEmpty(objnode);
 
-   if (objnode==0) return;
+   if (objnode == 0)
+      return;
 
    xml->UnlinkNode(objnode);
    xml->FreeNode(objnode);
@@ -249,27 +246,29 @@ void TKeyXML::UpdateObject(TObject* obj)
 /// Before invoking this function, obj has been created via the
 /// default constructor.
 
-Int_t TKeyXML::Read(TObject* tobj)
+Int_t TKeyXML::Read(TObject *tobj)
 {
-   if (tobj==0) return 0;
+   if (tobj == 0)
+      return 0;
 
-   void* res = XmlReadAny(tobj, 0);
+   void *res = XmlReadAny(tobj, 0);
 
-   return res==0 ? 0 : 1;
+   return res == 0 ? 0 : 1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// read object derived from TObject class, from key
 /// if it is not TObject or in case of error, return 0
 
-TObject* TKeyXML::ReadObj()
+TObject *TKeyXML::ReadObj()
 {
-   TObject* tobj = (TObject*) XmlReadAny(0, TObject::Class());
+   TObject *tobj = (TObject *)XmlReadAny(0, TObject::Class());
 
-   if (tobj!=0) {
-      if (gROOT->GetForceStyle()) tobj->UseCurrentStyle();
+   if (tobj != 0) {
+      if (gROOT->GetForceStyle())
+         tobj->UseCurrentStyle();
       if (tobj->IsA() == TDirectoryFile::Class()) {
-         TDirectoryFile *dir = (TDirectoryFile*) tobj;
+         TDirectoryFile *dir = (TDirectoryFile *)tobj;
          dir->SetName(GetName());
          dir->SetTitle(GetTitle());
          dir->SetSeekDir(GetKeyId());
@@ -288,14 +287,15 @@ TObject* TKeyXML::ReadObj()
 /// read object derived from TObject class, from key
 /// if it is not TObject or in case of error, return 0
 
-TObject* TKeyXML::ReadObjWithBuffer(char * /*bufferRead*/)
+TObject *TKeyXML::ReadObjWithBuffer(char * /*bufferRead*/)
 {
-   TObject* tobj = (TObject*) XmlReadAny(0, TObject::Class());
+   TObject *tobj = (TObject *)XmlReadAny(0, TObject::Class());
 
-   if (tobj!=0) {
-      if (gROOT->GetForceStyle()) tobj->UseCurrentStyle();
+   if (tobj != 0) {
+      if (gROOT->GetForceStyle())
+         tobj->UseCurrentStyle();
       if (tobj->IsA() == TDirectoryFile::Class()) {
-         TDirectoryFile *dir = (TDirectoryFile*) tobj;
+         TDirectoryFile *dir = (TDirectoryFile *)tobj;
          dir->SetName(GetName());
          dir->SetTitle(GetTitle());
          dir->SetSeekDir(GetKeyId());
@@ -313,12 +313,12 @@ TObject* TKeyXML::ReadObjWithBuffer(char * /*bufferRead*/)
 ////////////////////////////////////////////////////////////////////////////////
 /// read object of any type
 
-void* TKeyXML::ReadObjectAny(const TClass *expectedClass)
+void *TKeyXML::ReadObjectAny(const TClass *expectedClass)
 {
    void *res = XmlReadAny(0, expectedClass);
 
    if (res && (expectedClass == TDirectoryFile::Class())) {
-      TDirectoryFile *dir = (TDirectoryFile *) res;
+      TDirectoryFile *dir = (TDirectoryFile *)res;
       dir->SetName(GetName());
       dir->SetTitle(GetTitle());
       dir->SetSeekDir(GetKeyId());
@@ -335,22 +335,25 @@ void* TKeyXML::ReadObjectAny(const TClass *expectedClass)
 ////////////////////////////////////////////////////////////////////////////////
 /// read object from key and cast to expected class
 
-void* TKeyXML::XmlReadAny(void* obj, const TClass* expectedClass)
+void *TKeyXML::XmlReadAny(void *obj, const TClass *expectedClass)
 {
-   if (fKeyNode==0) return obj;
+   if (fKeyNode == 0)
+      return obj;
 
-   TXMLFile* f = (TXMLFile*) GetFile();
-   TXMLEngine* xml = XMLEngine();
-   if ((f==0) || (xml==0)) return obj;
+   TXMLFile *f = (TXMLFile *)GetFile();
+   TXMLEngine *xml = XMLEngine();
+   if ((f == 0) || (xml == 0))
+      return obj;
 
    TBufferXML buffer(TBuffer::kRead, f);
-   if (f->GetIOVersion()==1)
+   if (f->GetIOVersion() == 1)
       buffer.SetBit(TBuffer::kCannotHandleMemberWiseStreaming, kFALSE);
 
    XMLNodePointer_t blocknode = xml->GetChild(fKeyNode);
    xml->SkipEmpty(blocknode);
-   while (blocknode!=0) {
-      if (strcmp(xml->GetNodeName(blocknode), xmlio::XmlBlock)==0) break;
+   while (blocknode != 0) {
+      if (strcmp(xml->GetNodeName(blocknode), xmlio::XmlBlock) == 0)
+         break;
       xml->ShiftToNext(blocknode);
    }
    buffer.XmlReadBlock(blocknode);
@@ -358,35 +361,36 @@ void* TKeyXML::XmlReadAny(void* obj, const TClass* expectedClass)
    XMLNodePointer_t objnode = xml->GetChild(fKeyNode);
    xml->SkipEmpty(objnode);
 
-   TClass* cl = 0;
-   void* res = buffer.XmlReadAny(objnode, obj, &cl);
+   TClass *cl = 0;
+   void *res = buffer.XmlReadAny(objnode, obj, &cl);
 
-   if ((cl==0) || (res==0)) return obj;
+   if ((cl == 0) || (res == 0))
+      return obj;
 
    Int_t delta = 0;
 
-   if (expectedClass!=0) {
+   if (expectedClass != 0) {
       delta = cl->GetBaseClassOffset(expectedClass);
-      if (delta<0) {
-         if (obj==0) cl->Destructor(res);
+      if (delta < 0) {
+         if (obj == 0)
+            cl->Destructor(res);
          return 0;
       }
       if (cl->GetState() > TClass::kEmulated && expectedClass->GetState() <= TClass::kEmulated) {
-         //we cannot mix a compiled class with an emulated class in the inheritance
-         Warning("XmlReadAny",
-                 "Trying to read an emulated class (%s) to store in a compiled pointer (%s)",
-                 cl->GetName(),expectedClass->GetName());
+         // we cannot mix a compiled class with an emulated class in the inheritance
+         Warning("XmlReadAny", "Trying to read an emulated class (%s) to store in a compiled pointer (%s)",
+                 cl->GetName(), expectedClass->GetName());
       }
    }
 
-   return ((char*)res) + delta;
+   return ((char *)res) + delta;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// return pointer on TXMLEngine object, used for xml conversion
 
-TXMLEngine* TKeyXML::XMLEngine()
+TXMLEngine *TKeyXML::XMLEngine()
 {
-   TXMLFile* f = (TXMLFile*) GetFile();
-   return f==0 ? 0 : f->XML();
+   TXMLFile *f = (TXMLFile *)GetFile();
+   return f == 0 ? 0 : f->XML();
 }

--- a/io/xml/src/TKeyXML.cxx
+++ b/io/xml/src/TKeyXML.cxx
@@ -315,7 +315,21 @@ TObject* TKeyXML::ReadObjWithBuffer(char * /*bufferRead*/)
 
 void* TKeyXML::ReadObjectAny(const TClass *expectedClass)
 {
-   return XmlReadAny(0, expectedClass);
+   void *res = XmlReadAny(0, expectedClass);
+
+   if (res && (expectedClass == TDirectoryFile::Class())) {
+      TDirectoryFile *dir = (TDirectoryFile *) res;
+      dir->SetName(GetName());
+      dir->SetTitle(GetTitle());
+      dir->SetSeekDir(GetKeyId());
+      // set mother before reading keys
+      dir->SetMother(fMotherDir);
+      dir->ReadKeys();
+      fMotherDir->Append(dir);
+      fSubdir = kTRUE;
+   }
+
+   return res;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/io/xml/src/TXMLEngine.cxx
+++ b/io/xml/src/TXMLEngine.cxx
@@ -563,7 +563,7 @@ void TXMLEngine::FreeAllAttr(XMLNodePointer_t xmlnode)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// return first attribute in the list, namespace (if exists) will be skiped
+/// return first attribute in the list, namespace (if exists) will be skipped
 
 XMLAttrPointer_t TXMLEngine::GetFirstAttr(XMLNodePointer_t xmlnode)
 {
@@ -690,7 +690,6 @@ const char* TXMLEngine::GetNSReference(XMLNsPointer_t ns)
    return GetAttrValue((XMLAttrPointer_t)ns);
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// add child element to xmlnode
 
@@ -801,7 +800,7 @@ Bool_t TXMLEngine::AddDocRawLine(XMLDocPointer_t xmldoc, const char* line)
 /// Creates <?xml-stylesheet alternate="yes" title="compact" href="small-base.css" type="text/css"?>
 /// Attributes href and type must be supplied,
 ///  other attributes: title, alternate, media, charset are optional
-/// if alternate==0, attribyte alternate="no" will be created,
+/// if alternate==0, attribute alternate="no" will be created,
 /// if alternate>0, attribute alternate="yes"
 /// if alternate<0, attribute will not be created
 
@@ -862,7 +861,7 @@ Bool_t TXMLEngine::AddDocStyleSheet(XMLDocPointer_t xmldoc,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// unlink (dettach) xml node from parent
+/// unlink (detach) xml node from parent
 
 void TXMLEngine::UnlinkNode(XMLNodePointer_t xmlnode)
 {
@@ -887,8 +886,8 @@ void TXMLEngine::UnlinkNode(XMLNodePointer_t xmlnode)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// release all memory, allocated fro this node and
-/// destroyes node itself
+/// release all memory, allocated from this node and
+/// destroys node itself
 
 void TXMLEngine::FreeNode(XMLNodePointer_t xmlnode)
 {
@@ -1113,7 +1112,7 @@ XMLDocPointer_t TXMLEngine::NewDoc(const char* version)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// assignes dtd filename to document
+/// assigns dtd filename to document
 
 void TXMLEngine::AssignDtd(XMLDocPointer_t xmldoc, const char* dtdname, const char* rootname)
 {
@@ -1141,7 +1140,7 @@ void TXMLEngine::FreeDoc(XMLDocPointer_t xmldoc)
 ////////////////////////////////////////////////////////////////////////////////
 /// store document content to file
 /// if layout<=0, no any spaces or newlines will be placed between
-/// xmlnodes. Xml file will have minimum size, but nonreadable structure
+/// xmlnodes. Xml file will have minimum size, but non-readable structure
 /// if (layout>0) each node will be started from new line,
 /// and number of spaces will correspond to structure depth.
 
@@ -1270,7 +1269,7 @@ Bool_t TXMLEngine::ValidateVersion(XMLDocPointer_t xmldoc, const char* version)
 ////////////////////////////////////////////////////////////////////////////////
 /// convert single xml node (and its child node) to string
 /// if layout<=0, no any spaces or newlines will be placed between
-/// xmlnodes. Xml file will have minimum size, but nonreadable structure
+/// xmlnodes. Xml file will have minimum size, but non-readable structure
 /// if (layout>0) each node will be started from new line,
 /// and number of spaces will correspond to structure depth.
 
@@ -1331,7 +1330,7 @@ char* TXMLEngine::Makenstr(const char* str, int len)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Allocates new xml node with specified namelength
+/// Allocates new xml node with specified name length
 
 XMLNodePointer_t TXMLEngine::AllocateNode(int namelen, XMLNodePointer_t parent)
 {
@@ -1783,8 +1782,6 @@ XMLNodePointer_t TXMLEngine::ReadNode(XMLNodePointer_t xmlparent, TXMLInputStrea
       return node;
    }
 
-
-
    EXmlNodeType nodetype = kXML_NODE;
    Bool_t canhaschildren = true;
    char endsymbol = '/';
@@ -1909,5 +1906,4 @@ void TXMLEngine::DisplayError(Int_t error, Int_t linenumber)
       case -1: Error("ParseFile", "Unexpected end of xml file"); break;
       default: Error("ParseFile", "XML syntax error at line %d", linenumber); break;
    }
-
 }

--- a/io/xml/src/TXMLEngine.cxx
+++ b/io/xml/src/TXMLEngine.cxx
@@ -31,58 +31,57 @@
 ClassImp(TXMLEngine);
 
 struct SXmlAttr_t {
-   SXmlAttr_t  *fNext;
+   SXmlAttr_t *fNext;
    // after structure itself memory for attribute name is preserved
    // if first byte is 0, this is special attribute
-   static inline char* Name(void* arg) { return (char*)arg + sizeof(SXmlAttr_t); }
+   static inline char *Name(void *arg) { return (char *)arg + sizeof(SXmlAttr_t); }
 };
 
 enum EXmlNodeType {
-  kXML_NODE    = 1,    // normal node with children
-  kXML_COMMENT = 2,    // comment (stored as value of node fName)
-  kXML_PI_NODE = 3,    // processing instructions node (like <?name  attr="" ?>
-  kXML_RAWLINE = 4,    // just one line of xml code
-  kXML_CONTENT = 5     // node content, can appear many times in between of normal nodes
+   kXML_NODE = 1,    // normal node with children
+   kXML_COMMENT = 2, // comment (stored as value of node fName)
+   kXML_PI_NODE = 3, // processing instructions node (like <?name  attr="" ?>
+   kXML_RAWLINE = 4, // just one line of xml code
+   kXML_CONTENT = 5  // node content, can appear many times in between of normal nodes
 };
 
 struct SXmlNode_t {
-   EXmlNodeType fType;    //  this is node type - node, comment, processing instruction and so on
-   SXmlAttr_t  *fAttr;    // first attribute
-   SXmlAttr_t  *fNs;      // name space definition (if any)
-   SXmlNode_t  *fNext;    // next node on the same level of hierarchy
-   SXmlNode_t  *fChild;   // first child node
-   SXmlNode_t  *fLastChild; // last child node
-   SXmlNode_t  *fParent;   // parent node
+   EXmlNodeType fType;     //  this is node type - node, comment, processing instruction and so on
+   SXmlAttr_t *fAttr;      // first attribute
+   SXmlAttr_t *fNs;        // name space definition (if any)
+   SXmlNode_t *fNext;      // next node on the same level of hierarchy
+   SXmlNode_t *fChild;     // first child node
+   SXmlNode_t *fLastChild; // last child node
+   SXmlNode_t *fParent;    // parent node
    // consequent bytes after structure are node name
    // if first byte is 0, next is node content
-   static inline char* Name(void* arg) { return (char*)arg + sizeof(SXmlNode_t); }
+   static inline char *Name(void *arg) { return (char *)arg + sizeof(SXmlNode_t); }
 };
 
 struct SXmlDoc_t {
-   SXmlNode_t  *fRootNode;
-   char        *fDtdName;
-   char        *fDtdRoot;
+   SXmlNode_t *fRootNode;
+   char *fDtdName;
+   char *fDtdRoot;
 };
 
 class TXMLOutputStream {
 protected:
-
-   std::ostream  *fOut;
-   TString       *fOutStr;
-   char          *fBuf;
-   char          *fCurrent;
-   char          *fMaxAddr;
-   char          *fLimitAddr;
+   std::ostream *fOut;
+   TString *fOutStr;
+   char *fBuf;
+   char *fCurrent;
+   char *fMaxAddr;
+   char *fLimitAddr;
 
 public:
-   TXMLOutputStream(const char* filename, Int_t bufsize = 20000)
+   TXMLOutputStream(const char *filename, Int_t bufsize = 20000)
    {
       fOut = new std::ofstream(filename);
       fOutStr = 0;
       Init(bufsize);
    }
 
-   TXMLOutputStream(TString* outstr, Int_t bufsize = 20000)
+   TXMLOutputStream(TString *outstr, Int_t bufsize = 20000)
    {
       fOut = 0;
       fOutStr = outstr;
@@ -91,109 +90,100 @@ public:
 
    void Init(Int_t bufsize)
    {
-      fBuf = (char*) malloc(bufsize);
+      fBuf = (char *)malloc(bufsize);
       fCurrent = fBuf;
       fMaxAddr = fBuf + bufsize;
-      fLimitAddr = fBuf + int(bufsize*0.75);
+      fLimitAddr = fBuf + int(bufsize * 0.75);
    }
 
    virtual ~TXMLOutputStream()
    {
-      if (fCurrent!=fBuf) OutputCurrent();
+      if (fCurrent != fBuf)
+         OutputCurrent();
       delete fOut;
       free(fBuf);
    }
 
    void OutputCurrent()
    {
-      if (fCurrent!=fBuf) {
-         if (fOut!=0)
-            fOut->write(fBuf, fCurrent-fBuf);
-         else if (fOutStr!=0)
-            fOutStr->Append(fBuf, fCurrent-fBuf);
+      if (fCurrent != fBuf) {
+         if (fOut != 0)
+            fOut->write(fBuf, fCurrent - fBuf);
+         else if (fOutStr != 0)
+            fOutStr->Append(fBuf, fCurrent - fBuf);
       }
       fCurrent = fBuf;
    }
 
    void OutputChar(char symb)
    {
-      if (fOut!=0) fOut->put(symb); else
-      if (fOutStr!=0) fOutStr->Append(symb);
+      if (fOut != 0)
+         fOut->put(symb);
+      else if (fOutStr != 0)
+         fOutStr->Append(symb);
    }
 
-   void Write(const char* str)
+   void Write(const char *str)
    {
       int len = strlen(str);
-      if (fCurrent+len>=fMaxAddr) {
+      if (fCurrent + len >= fMaxAddr) {
          OutputCurrent();
-         fOut->write(str,len);
+         fOut->write(str, len);
       } else {
          while (*str)
-           *fCurrent++ = *str++;
-         if (fCurrent>fLimitAddr)
+            *fCurrent++ = *str++;
+         if (fCurrent > fLimitAddr)
             OutputCurrent();
       }
    }
 
-   void Put(char symb, Int_t cnt=1)
+   void Put(char symb, Int_t cnt = 1)
    {
-      if (fCurrent+cnt>=fMaxAddr)
+      if (fCurrent + cnt >= fMaxAddr)
          OutputCurrent();
-      if (fCurrent+cnt>=fMaxAddr)
-         for(int n=0;n<cnt;n++)
+      if (fCurrent + cnt >= fMaxAddr)
+         for (int n = 0; n < cnt; n++)
             OutputChar(symb);
       else {
-         for(int n=0;n<cnt;n++)
+         for (int n = 0; n < cnt; n++)
             *fCurrent++ = symb;
-         if (fCurrent>fLimitAddr)
+         if (fCurrent > fLimitAddr)
             OutputCurrent();
       }
    }
 };
 
 class TXMLEntity : public TNamed {
-   Bool_t      fSystem;   //!  is system (file)
+   Bool_t fSystem; //!  is system (file)
 public:
    TXMLEntity() : TNamed(), fSystem(kFALSE) {}
-   TXMLEntity(const TString& name, const TString& value, Bool_t sys) : TNamed(name, value), fSystem(sys) {}
+   TXMLEntity(const TString &name, const TString &value, Bool_t sys) : TNamed(name, value), fSystem(sys) {}
    Bool_t IsSystem() const { return fSystem; }
 };
 
-
 class TXMLInputStream {
 protected:
+   std::istream *fInp;
+   const char *fInpStr;
+   Int_t fInpStrLen;
 
-   std::istream  *fInp;
-   const char    *fInpStr;
-   Int_t          fInpStrLen;
+   char *fBuf;
+   Int_t fBufSize;
 
-   char          *fBuf;
-   Int_t          fBufSize;
+   char *fMaxAddr;
+   char *fLimitAddr;
 
-   char          *fMaxAddr;
-   char          *fLimitAddr;
+   Int_t fTotalPos;
+   Int_t fCurrentLine;
 
-   Int_t          fTotalPos;
-   Int_t          fCurrentLine;
-
-   TObjArray      fEntities;   //! array of TXMLEntity
+   TObjArray fEntities; //! array of TXMLEntity
 
 public:
+   char *fCurrent;
 
-   char           *fCurrent;
-
-   TXMLInputStream(Bool_t isfilename, const char* filename, Int_t ibufsize) :
-      fInp(0),
-      fInpStr(0),
-      fInpStrLen(0),
-      fBuf(0),
-      fBufSize(0),
-      fMaxAddr(0),
-      fLimitAddr(0),
-      fTotalPos(0),
-      fCurrentLine(0),
-      fEntities(),
-      fCurrent(0)
+   TXMLInputStream(Bool_t isfilename, const char *filename, Int_t ibufsize)
+      : fInp(0), fInpStr(0), fInpStrLen(0), fBuf(0), fBufSize(0), fMaxAddr(0), fLimitAddr(0), fTotalPos(0),
+        fCurrentLine(0), fEntities(), fCurrent(0)
    {
       if (isfilename) {
          fInp = new std::ifstream(filename);
@@ -202,19 +192,19 @@ public:
       } else {
          fInp = 0;
          fInpStr = filename;
-         fInpStrLen = filename==0 ? 0 : strlen(filename);
+         fInpStrLen = filename == 0 ? 0 : strlen(filename);
       }
 
       fBufSize = ibufsize;
-      fBuf = (char*) malloc(fBufSize);
+      fBuf = (char *)malloc(fBufSize);
 
       fCurrent = 0;
       fMaxAddr = 0;
 
       int len = DoRead(fBuf, fBufSize);
       fCurrent = fBuf;
-      fMaxAddr = fBuf+len;
-      fLimitAddr = fBuf + int(len*0.75);
+      fMaxAddr = fBuf + len;
+      fLimitAddr = fBuf + int(len * 0.75);
 
       fTotalPos = 0;
       fCurrentLine = 1;
@@ -224,202 +214,236 @@ public:
 
    virtual ~TXMLInputStream()
    {
-      delete fInp; fInp = 0;
-      free(fBuf); fBuf = 0;
+      delete fInp;
+      fInp = 0;
+      free(fBuf);
+      fBuf = 0;
    }
 
-   inline Bool_t EndOfFile() { return (fInp!=0) ? fInp->eof() : (fInpStrLen<=0); }
+   inline Bool_t EndOfFile() { return (fInp != 0) ? fInp->eof() : (fInpStrLen <= 0); }
 
-   inline Bool_t EndOfStream() { return EndOfFile() && (fCurrent>=fMaxAddr); }
+   inline Bool_t EndOfStream() { return EndOfFile() && (fCurrent >= fMaxAddr); }
 
-   void AddEntity(TXMLEntity* ent) { fEntities.Add(ent); }
+   void AddEntity(TXMLEntity *ent) { fEntities.Add(ent); }
 
    Int_t NumEntities() const { return fEntities.GetLast() + 1; }
 
-   TXMLEntity* FindEntity(const char* beg, Int_t len)
+   TXMLEntity *FindEntity(const char *beg, Int_t len)
    {
-      if (len<=0) return 0;
-      for (Int_t n=0; n<=fEntities.GetLast(); n++) {
-         TXMLEntity* entity = (TXMLEntity*) fEntities[n];
-         if ((Int_t) strlen(entity->GetName()) != len) continue;
-         if (strncmp(beg, entity->GetName(), len)==0) return entity;
+      if (len <= 0)
+         return 0;
+      for (Int_t n = 0; n <= fEntities.GetLast(); n++) {
+         TXMLEntity *entity = (TXMLEntity *)fEntities[n];
+         if ((Int_t)strlen(entity->GetName()) != len)
+            continue;
+         if (strncmp(beg, entity->GetName(), len) == 0)
+            return entity;
       }
       return 0;
    }
 
-
-   int DoRead(char* buf, int maxsize)
+   int DoRead(char *buf, int maxsize)
    {
-      if (EndOfFile()) return 0;
-      if (fInp!=0) {
+      if (EndOfFile())
+         return 0;
+      if (fInp != 0) {
          fInp->get(buf, maxsize, 0);
          maxsize = strlen(buf);
       } else {
-         if (maxsize>fInpStrLen) maxsize = fInpStrLen;
+         if (maxsize > fInpStrLen)
+            maxsize = fInpStrLen;
          strncpy(buf, fInpStr, maxsize);
-         fInpStr+=maxsize;
-         fInpStrLen-=maxsize;
+         fInpStr += maxsize;
+         fInpStrLen -= maxsize;
       }
       return maxsize;
    }
 
    Bool_t ExpandStream()
    {
-      if (EndOfFile()) return kFALSE;
-      fBufSize*=2;
+      if (EndOfFile())
+         return kFALSE;
+      fBufSize *= 2;
       int curlength = fMaxAddr - fBuf;
-      char* newbuf = (char*) realloc(fBuf, fBufSize);
-      if (newbuf==0) return kFALSE;
+      char *newbuf = (char *)realloc(fBuf, fBufSize);
+      if (newbuf == 0)
+         return kFALSE;
 
       fMaxAddr = newbuf + (fMaxAddr - fBuf);
       fCurrent = newbuf + (fCurrent - fBuf);
       fLimitAddr = newbuf + (fLimitAddr - fBuf);
       fBuf = newbuf;
 
-      int len = DoRead(fMaxAddr, fBufSize-curlength);
-      if (len==0) return kFALSE;
+      int len = DoRead(fMaxAddr, fBufSize - curlength);
+      if (len == 0)
+         return kFALSE;
       fMaxAddr += len;
-      fLimitAddr += int(len*0.75);
+      fLimitAddr += int(len * 0.75);
       return kTRUE;
    }
 
    Bool_t ShiftStream()
    {
-      if (fCurrent<fLimitAddr) return kTRUE; // everything ok, can continue
-      if (EndOfFile()) return kTRUE;
+      if (fCurrent < fLimitAddr)
+         return kTRUE; // everything ok, can continue
+      if (EndOfFile())
+         return kTRUE;
       int rest_len = fMaxAddr - fCurrent;
       memmove(fBuf, fCurrent, rest_len);
       int read_len = DoRead(fBuf + rest_len, fBufSize - rest_len);
 
       fCurrent = fBuf;
       fMaxAddr = fBuf + rest_len + read_len;
-      fLimitAddr = fBuf + int((rest_len + read_len)*0.75);
+      fLimitAddr = fBuf + int((rest_len + read_len) * 0.75);
       return kTRUE;
    }
 
-   Int_t  TotalPos() { return fTotalPos; }
+   Int_t TotalPos() { return fTotalPos; }
 
    Int_t CurrentLine() { return fCurrentLine; }
 
    Bool_t ShiftCurrent(Int_t sz = 1)
    {
-      for(int n=0;n<sz;n++) {
-         if (*fCurrent==10) fCurrentLine++;
-         if (fCurrent>=fLimitAddr) {
+      for (int n = 0; n < sz; n++) {
+         if (*fCurrent == 10)
+            fCurrentLine++;
+         if (fCurrent >= fLimitAddr) {
             ShiftStream();
-            if (fCurrent>=fMaxAddr) return kFALSE;
+            if (fCurrent >= fMaxAddr)
+               return kFALSE;
          }
          fCurrent++;
       }
-      fTotalPos+=sz;
+      fTotalPos += sz;
       return kTRUE;
    }
 
    Bool_t SkipSpaces(Bool_t tillendl = kFALSE)
    {
-      while (fCurrent<fMaxAddr) {
+      while (fCurrent < fMaxAddr) {
          char symb = *fCurrent;
-         if ((symb>26) && (symb!=' ')) return kTRUE;
+         if ((symb > 26) && (symb != ' '))
+            return kTRUE;
 
-         if (!ShiftCurrent()) return kFALSE;
+         if (!ShiftCurrent())
+            return kFALSE;
 
-         if (tillendl && (symb==10)) return kTRUE;
+         if (tillendl && (symb == 10))
+            return kTRUE;
       }
       return kFALSE;
    }
 
-   Bool_t CheckFor(const char* str)
+   Bool_t CheckFor(const char *str)
    {
       // Check if in current position we see specified string
       int len = strlen(str);
-      while (fCurrent+len>fMaxAddr)
-         if (!ExpandStream()) return kFALSE;
-      char* curr = fCurrent;
+      while (fCurrent + len > fMaxAddr)
+         if (!ExpandStream())
+            return kFALSE;
+      char *curr = fCurrent;
       while (*str != 0)
-         if (*str++ != *curr++) return kFALSE;
+         if (*str++ != *curr++)
+            return kFALSE;
       return ShiftCurrent(len);
    }
 
-   Int_t SearchFor(const char* str)
+   Int_t SearchFor(const char *str)
    {
       // Serach for specified string in the stream
       // return number of symbols before string was found, -1 if error
       int len = strlen(str);
 
-      char* curr = fCurrent;
+      char *curr = fCurrent;
 
       do {
          curr++;
-         while (curr+len>fMaxAddr)
-            if (!ExpandStream()) return -1;
-         char* chk0 = curr;
-         const char* chk = str;
+         while (curr + len > fMaxAddr)
+            if (!ExpandStream())
+               return -1;
+         char *chk0 = curr;
+         const char *chk = str;
          Bool_t find = kTRUE;
          while (*chk != 0)
-            if (*chk++ != *chk0++) { find = kFALSE; break; }
+            if (*chk++ != *chk0++) {
+               find = kFALSE;
+               break;
+            }
          // if string found, shift to the next symbol after string
-         if (find) return curr - fCurrent;
-      } while (curr<fMaxAddr);
+         if (find)
+            return curr - fCurrent;
+      } while (curr < fMaxAddr);
       return -1;
    }
 
-#define GoodStartSymbol(symb) \
-   (((symb>='a') && (symb<='z')) || ((symb>='A') && (symb<='Z')) || (symb=='_') || \
-    ((symb>=0xc0) && (symb<=0xd6)) || ((symb>=0xd8) && (symb<=0xf6)) || (symb>0xf8))
+#define GoodStartSymbol(symb)                                                                \
+   (((symb >= 'a') && (symb <= 'z')) || ((symb >= 'A') && (symb <= 'Z')) || (symb == '_') || \
+    ((symb >= 0xc0) && (symb <= 0xd6)) || ((symb >= 0xd8) && (symb <= 0xf6)) || (symb > 0xf8))
 
    Int_t LocateIdentifier()
    {
-      unsigned char symb = (unsigned char) *fCurrent;
+      unsigned char symb = (unsigned char)*fCurrent;
 
       Bool_t ok = GoodStartSymbol(symb);
-      if (!ok) return 0;
+      if (!ok)
+         return 0;
 
-      char* curr = fCurrent;
+      char *curr = fCurrent;
 
       do {
          curr++;
-         if (curr>=fMaxAddr)
-            if (!ExpandStream()) return 0;
-         symb = (unsigned char) *curr;
-         ok = GoodStartSymbol(symb) ||
-              ((symb>='0') && (symb<='9')) || (symb==':')  || (symb=='-') || (symb=='.') || (symb==0xb7);
-         if (!ok) return curr-fCurrent;
-      } while (curr<fMaxAddr);
+         if (curr >= fMaxAddr)
+            if (!ExpandStream())
+               return 0;
+         symb = (unsigned char)*curr;
+         ok = GoodStartSymbol(symb) || ((symb >= '0') && (symb <= '9')) || (symb == ':') || (symb == '-') ||
+              (symb == '.') || (symb == 0xb7);
+         if (!ok)
+            return curr - fCurrent;
+      } while (curr < fMaxAddr);
       return 0;
    }
 
    Int_t LocateContent()
    {
-      char* curr = fCurrent;
-      while (curr<fMaxAddr) {
+      char *curr = fCurrent;
+      while (curr < fMaxAddr) {
          char symb = *curr;
-         if (symb=='<') return curr - fCurrent;
+         if (symb == '<')
+            return curr - fCurrent;
          curr++;
-         if (curr>=fMaxAddr)
-            if (!ExpandStream()) return -1;
+         if (curr >= fMaxAddr)
+            if (!ExpandStream())
+               return -1;
       }
       return -1;
    }
 
-   Int_t LocateValue(char* start, bool withequalsign = true)
+   Int_t LocateValue(char *start, bool withequalsign = true)
    {
-      char* curr = start;
-      if (curr>=fMaxAddr)
-         if (!ExpandStream()) return 0;
+      char *curr = start;
+      if (curr >= fMaxAddr)
+         if (!ExpandStream())
+            return 0;
       if (withequalsign) {
-         if (*curr!='=') return 0;
+         if (*curr != '=')
+            return 0;
          curr++;
-         if (curr>=fMaxAddr)
-            if (!ExpandStream()) return 0;
+         if (curr >= fMaxAddr)
+            if (!ExpandStream())
+               return 0;
       }
-      if ((*curr!='\"') && (*curr!='\'')) return 0;
+      if ((*curr != '\"') && (*curr != '\''))
+         return 0;
       char quote = *curr;
       do {
          curr++;
-         if (curr>=fMaxAddr)
-            if (!ExpandStream()) return 0;
-         if (*curr==quote) return curr-start+1;
-      } while (curr<fMaxAddr);
+         if (curr >= fMaxAddr)
+            if (!ExpandStream())
+               return 0;
+         if (*curr == quote)
+            return curr - start + 1;
+      } while (curr < fMaxAddr);
       return 0;
    }
 };
@@ -432,7 +456,6 @@ TXMLEngine::TXMLEngine()
    fSkipComments = kFALSE;
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// destructor for TXMLEngine object
 
@@ -443,12 +466,14 @@ TXMLEngine::~TXMLEngine()
 ////////////////////////////////////////////////////////////////////////////////
 /// checks if node has attribute of specified name
 
-Bool_t TXMLEngine::HasAttr(XMLNodePointer_t xmlnode, const char* name)
+Bool_t TXMLEngine::HasAttr(XMLNodePointer_t xmlnode, const char *name)
 {
-   if ((xmlnode==0) || (name==0)) return kFALSE;
-   SXmlAttr_t* attr = ((SXmlNode_t*)xmlnode)->fAttr;
-   while (attr!=0) {
-      if (strcmp(SXmlAttr_t::Name(attr),name)==0) return kTRUE;
+   if ((xmlnode == 0) || (name == 0))
+      return kFALSE;
+   SXmlAttr_t *attr = ((SXmlNode_t *)xmlnode)->fAttr;
+   while (attr != 0) {
+      if (strcmp(SXmlAttr_t::Name(attr), name) == 0)
+         return kTRUE;
       attr = attr->fNext;
    }
    return kFALSE;
@@ -457,12 +482,13 @@ Bool_t TXMLEngine::HasAttr(XMLNodePointer_t xmlnode, const char* name)
 ////////////////////////////////////////////////////////////////////////////////
 /// returns value of attribute for xmlnode
 
-const char* TXMLEngine::GetAttr(XMLNodePointer_t xmlnode, const char* name)
+const char *TXMLEngine::GetAttr(XMLNodePointer_t xmlnode, const char *name)
 {
-   if (xmlnode==0) return 0;
-   SXmlAttr_t* attr = ((SXmlNode_t*)xmlnode)->fAttr;
-   while (attr!=0) {
-      if (strcmp(SXmlAttr_t::Name(attr),name)==0)
+   if (xmlnode == 0)
+      return 0;
+   SXmlAttr_t *attr = ((SXmlNode_t *)xmlnode)->fAttr;
+   while (attr != 0) {
+      if (strcmp(SXmlAttr_t::Name(attr), name) == 0)
          return SXmlAttr_t::Name(attr) + strlen(name) + 1;
       attr = attr->fNext;
    }
@@ -472,12 +498,14 @@ const char* TXMLEngine::GetAttr(XMLNodePointer_t xmlnode, const char* name)
 ////////////////////////////////////////////////////////////////////////////////
 /// returns value of attribute as integer
 
-Int_t TXMLEngine::GetIntAttr(XMLNodePointer_t xmlnode, const char* name)
+Int_t TXMLEngine::GetIntAttr(XMLNodePointer_t xmlnode, const char *name)
 {
-   if (xmlnode==0) return 0;
+   if (xmlnode == 0)
+      return 0;
    Int_t res = 0;
-   const char* attr = GetAttr(xmlnode, name);
-   if (attr) sscanf(attr, "%d", &res);
+   const char *attr = GetAttr(xmlnode, name);
+   if (attr)
+      sscanf(attr, "%d", &res);
    return res;
 }
 
@@ -485,56 +513,55 @@ Int_t TXMLEngine::GetIntAttr(XMLNodePointer_t xmlnode, const char* name)
 /// creates new attribute for xmlnode,
 /// namespaces are not supported for attributes
 
-XMLAttrPointer_t TXMLEngine::NewAttr(XMLNodePointer_t xmlnode, XMLNsPointer_t,
-                                     const char* name, const char* value)
+XMLAttrPointer_t TXMLEngine::NewAttr(XMLNodePointer_t xmlnode, XMLNsPointer_t, const char *name, const char *value)
 {
-   if (xmlnode==0) return 0;
+   if (xmlnode == 0)
+      return 0;
 
    int namelen(name != 0 ? strlen(name) : 0);
    int valuelen(value != 0 ? strlen(value) : 0);
-   SXmlAttr_t* attr = (SXmlAttr_t*) AllocateAttr(namelen, valuelen, xmlnode);
+   SXmlAttr_t *attr = (SXmlAttr_t *)AllocateAttr(namelen, valuelen, xmlnode);
 
-   char* attrname = SXmlAttr_t::Name(attr);
-   if (namelen>0)
-      strncpy(attrname, name, namelen+1);
+   char *attrname = SXmlAttr_t::Name(attr);
+   if (namelen > 0)
+      strncpy(attrname, name, namelen + 1);
    else
       *attrname = 0;
    attrname += (namelen + 1);
-   if (valuelen>0)
-      strncpy(attrname, value, valuelen+1);
+   if (valuelen > 0)
+      strncpy(attrname, value, valuelen + 1);
    else
       *attrname = 0;
 
-   return (XMLAttrPointer_t) attr;
+   return (XMLAttrPointer_t)attr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// create node attribute with integer value
 
-XMLAttrPointer_t TXMLEngine::NewIntAttr(XMLNodePointer_t xmlnode,
-                                      const char* name,
-                                      Int_t value)
+XMLAttrPointer_t TXMLEngine::NewIntAttr(XMLNodePointer_t xmlnode, const char *name, Int_t value)
 {
    char sbuf[30];
-   sprintf(sbuf,"%d",value);
+   sprintf(sbuf, "%d", value);
    return NewAttr(xmlnode, 0, name, sbuf);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// remove attribute from xmlnode
 
-void TXMLEngine::FreeAttr(XMLNodePointer_t xmlnode, const char* name)
+void TXMLEngine::FreeAttr(XMLNodePointer_t xmlnode, const char *name)
 {
-   if (xmlnode==0) return;
-   SXmlAttr_t* attr = ((SXmlNode_t*) xmlnode)->fAttr;
-   SXmlAttr_t* prev = 0;
-   while (attr!=0) {
-      if (strcmp(SXmlAttr_t::Name(attr),name)==0) {
-         if (prev!=0)
+   if (xmlnode == 0)
+      return;
+   SXmlAttr_t *attr = ((SXmlNode_t *)xmlnode)->fAttr;
+   SXmlAttr_t *prev = 0;
+   while (attr != 0) {
+      if (strcmp(SXmlAttr_t::Name(attr), name) == 0) {
+         if (prev != 0)
             prev->fNext = attr->fNext;
          else
-            ((SXmlNode_t*) xmlnode)->fAttr = attr->fNext;
-         //fNumNodes--;
+            ((SXmlNode_t *)xmlnode)->fAttr = attr->fNext;
+         // fNumNodes--;
          free(attr);
          return;
       }
@@ -549,31 +576,33 @@ void TXMLEngine::FreeAttr(XMLNodePointer_t xmlnode, const char* name)
 
 void TXMLEngine::FreeAllAttr(XMLNodePointer_t xmlnode)
 {
-   if (xmlnode==0) return;
+   if (xmlnode == 0)
+      return;
 
-   SXmlNode_t* node = (SXmlNode_t*) xmlnode;
-   SXmlAttr_t* attr = node->fAttr;
-   while (attr!=0) {
-      SXmlAttr_t* next = attr->fNext;
+   SXmlNode_t *node = (SXmlNode_t *)xmlnode;
+   SXmlAttr_t *attr = node->fAttr;
+   while (attr != 0) {
+      SXmlAttr_t *next = attr->fNext;
       free(attr);
       attr = next;
    }
    node->fAttr = 0;
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// return first attribute in the list, namespace (if exists) will be skipped
 
 XMLAttrPointer_t TXMLEngine::GetFirstAttr(XMLNodePointer_t xmlnode)
 {
-   if (xmlnode==0) return 0;
-   SXmlNode_t* node = (SXmlNode_t*) xmlnode;
+   if (xmlnode == 0)
+      return 0;
+   SXmlNode_t *node = (SXmlNode_t *)xmlnode;
 
-   SXmlAttr_t* attr = node->fAttr;
-   if ((attr!=0) && (node->fNs==attr)) attr = attr->fNext;
+   SXmlAttr_t *attr = node->fAttr;
+   if ((attr != 0) && (node->fNs == attr))
+      attr = attr->fNext;
 
-   return (XMLAttrPointer_t) attr;
+   return (XMLAttrPointer_t)attr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -581,82 +610,84 @@ XMLAttrPointer_t TXMLEngine::GetFirstAttr(XMLNodePointer_t xmlnode)
 
 XMLAttrPointer_t TXMLEngine::GetNextAttr(XMLAttrPointer_t xmlattr)
 {
-   if (xmlattr==0) return 0;
+   if (xmlattr == 0)
+      return 0;
 
-   return (XMLAttrPointer_t) ((SXmlAttr_t*) xmlattr)->fNext;
+   return (XMLAttrPointer_t)((SXmlAttr_t *)xmlattr)->fNext;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// return name of the attribute
 
-const char* TXMLEngine::GetAttrName(XMLAttrPointer_t xmlattr)
+const char *TXMLEngine::GetAttrName(XMLAttrPointer_t xmlattr)
 {
-   if (xmlattr==0) return 0;
+   if (xmlattr == 0)
+      return 0;
 
    return SXmlAttr_t::Name(xmlattr);
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// return value of attribute
 
-const char* TXMLEngine::GetAttrValue(XMLAttrPointer_t xmlattr)
+const char *TXMLEngine::GetAttrValue(XMLAttrPointer_t xmlattr)
 {
-   if (xmlattr==0) return 0;
+   if (xmlattr == 0)
+      return 0;
 
-   const char* attrname = SXmlAttr_t::Name(xmlattr);
+   const char *attrname = SXmlAttr_t::Name(xmlattr);
    return attrname + strlen(attrname) + 1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// create new child element for parent node
 
-XMLNodePointer_t TXMLEngine::NewChild(XMLNodePointer_t parent, XMLNsPointer_t ns,
-                                      const char* name, const char* content)
+XMLNodePointer_t TXMLEngine::NewChild(XMLNodePointer_t parent, XMLNsPointer_t ns, const char *name, const char *content)
 {
-   int namelen(name!=0 ? strlen(name) : 0);
+   int namelen(name != 0 ? strlen(name) : 0);
 
-   SXmlNode_t* node = (SXmlNode_t*) AllocateNode(namelen, parent);
+   SXmlNode_t *node = (SXmlNode_t *)AllocateNode(namelen, parent);
 
-   if (namelen>0)
-      strncpy(SXmlNode_t::Name(node), name, namelen+1);
+   if (namelen > 0)
+      strncpy(SXmlNode_t::Name(node), name, namelen + 1);
    else
       *SXmlNode_t::Name(node) = 0;
 
-   node->fNs = (SXmlAttr_t*) ns;
-   int contlen = (content!=0) ? strlen(content) : 0;
-   if (contlen>0) {
-      SXmlNode_t* contnode = (SXmlNode_t*) AllocateNode(contlen, node);
+   node->fNs = (SXmlAttr_t *)ns;
+   int contlen = (content != 0) ? strlen(content) : 0;
+   if (contlen > 0) {
+      SXmlNode_t *contnode = (SXmlNode_t *)AllocateNode(contlen, node);
       contnode->fType = kXML_CONTENT; // indicate that we creating content node
-      strncpy(SXmlNode_t::Name(contnode), content, contlen+1);
+      strncpy(SXmlNode_t::Name(contnode), content, contlen + 1);
    }
 
-   return (XMLNodePointer_t) node;
+   return (XMLNodePointer_t)node;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// create namespace attribute for xmlnode.
 /// namespace attribute will be always the first in list of node attributes
 
-XMLNsPointer_t TXMLEngine::NewNS(XMLNodePointer_t xmlnode, const char* reference, const char* name)
+XMLNsPointer_t TXMLEngine::NewNS(XMLNodePointer_t xmlnode, const char *reference, const char *name)
 {
-   SXmlNode_t* node = (SXmlNode_t*) xmlnode;
-   if (name==0) name = SXmlNode_t::Name(node);
+   SXmlNode_t *node = (SXmlNode_t *)xmlnode;
+   if (name == 0)
+      name = SXmlNode_t::Name(node);
    int namelen = strlen(name);
-   char* nsname = new char[namelen+7];
-   snprintf(nsname, namelen+7, "xmlns:%s", name);
+   char *nsname = new char[namelen + 7];
+   snprintf(nsname, namelen + 7, "xmlns:%s", name);
 
-   SXmlAttr_t* first = node->fAttr;
+   SXmlAttr_t *first = node->fAttr;
    node->fAttr = 0;
 
-   SXmlAttr_t* nsattr = (SXmlAttr_t*) NewAttr(xmlnode, 0, nsname, reference);
+   SXmlAttr_t *nsattr = (SXmlAttr_t *)NewAttr(xmlnode, 0, nsname, reference);
 
    node->fAttr = nsattr;
    nsattr->fNext = first;
 
    node->fNs = nsattr;
    delete[] nsname;
-   return (XMLNsPointer_t) nsattr;
+   return (XMLNsPointer_t)nsattr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -664,20 +695,22 @@ XMLNsPointer_t TXMLEngine::NewNS(XMLNodePointer_t xmlnode, const char* reference
 
 XMLNsPointer_t TXMLEngine::GetNS(XMLNodePointer_t xmlnode)
 {
-   if (xmlnode==0) return 0;
-   SXmlNode_t* node = (SXmlNode_t*) xmlnode;
+   if (xmlnode == 0)
+      return 0;
+   SXmlNode_t *node = (SXmlNode_t *)xmlnode;
 
-   return (XMLNsPointer_t) node->fNs;
+   return (XMLNsPointer_t)node->fNs;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// return name id of namespace
 
-const char* TXMLEngine::GetNSName(XMLNsPointer_t ns)
+const char *TXMLEngine::GetNSName(XMLNsPointer_t ns)
 {
-   const char* nsname = GetAttrName((XMLAttrPointer_t)ns);
+   const char *nsname = GetAttrName((XMLAttrPointer_t)ns);
 
-   if ((nsname!=0) && (strncmp(nsname,"xmlns:",6)==0)) nsname+=6;
+   if ((nsname != 0) && (strncmp(nsname, "xmlns:", 6) == 0))
+      nsname += 6;
 
    return nsname;
 }
@@ -685,7 +718,7 @@ const char* TXMLEngine::GetNSName(XMLNsPointer_t ns)
 ////////////////////////////////////////////////////////////////////////////////
 /// return reference id of namespace
 
-const char* TXMLEngine::GetNSReference(XMLNsPointer_t ns)
+const char *TXMLEngine::GetNSReference(XMLNsPointer_t ns)
 {
    return GetAttrValue((XMLAttrPointer_t)ns);
 }
@@ -695,16 +728,17 @@ const char* TXMLEngine::GetNSReference(XMLNsPointer_t ns)
 
 void TXMLEngine::AddChild(XMLNodePointer_t parent, XMLNodePointer_t child)
 {
-   if ((parent==0) || (child==0)) return;
-   SXmlNode_t* pnode = (SXmlNode_t*) parent;
-   SXmlNode_t* cnode = (SXmlNode_t*) child;
+   if ((parent == 0) || (child == 0))
+      return;
+   SXmlNode_t *pnode = (SXmlNode_t *)parent;
+   SXmlNode_t *cnode = (SXmlNode_t *)child;
    cnode->fParent = pnode;
-   if (pnode->fLastChild==0) {
+   if (pnode->fLastChild == 0) {
       pnode->fChild = cnode;
       pnode->fLastChild = cnode;
    } else {
-      //SXmlNode_t* ch = pnode->fChild;
-      //while (ch->fNext!=0) ch=ch->fNext;
+      // SXmlNode_t* ch = pnode->fChild;
+      // while (ch->fNext!=0) ch=ch->fNext;
       pnode->fLastChild->fNext = cnode;
       pnode->fLastChild = cnode;
    }
@@ -715,30 +749,32 @@ void TXMLEngine::AddChild(XMLNodePointer_t parent, XMLNodePointer_t child)
 
 void TXMLEngine::AddChildFirst(XMLNodePointer_t parent, XMLNodePointer_t child)
 {
-   if ((parent==0) || (child==0)) return;
-   SXmlNode_t* pnode = (SXmlNode_t*) parent;
-   SXmlNode_t* cnode = (SXmlNode_t*) child;
+   if ((parent == 0) || (child == 0))
+      return;
+   SXmlNode_t *pnode = (SXmlNode_t *)parent;
+   SXmlNode_t *cnode = (SXmlNode_t *)child;
    cnode->fParent = pnode;
 
    cnode->fNext = pnode->fChild;
    pnode->fChild = cnode;
 
-   if (pnode->fLastChild==0) pnode->fLastChild = cnode;
+   if (pnode->fLastChild == 0)
+      pnode->fLastChild = cnode;
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Adds comment line to the node
 
-Bool_t TXMLEngine::AddComment(XMLNodePointer_t xmlnode, const char* comment)
+Bool_t TXMLEngine::AddComment(XMLNodePointer_t xmlnode, const char *comment)
 {
-   if ((xmlnode==0) || (comment==0)) return kFALSE;
+   if ((xmlnode == 0) || (comment == 0))
+      return kFALSE;
 
    int commentlen = strlen(comment);
 
-   SXmlNode_t* node = (SXmlNode_t*) AllocateNode(commentlen, xmlnode);
+   SXmlNode_t *node = (SXmlNode_t *)AllocateNode(commentlen, xmlnode);
    node->fType = kXML_COMMENT;
-   strncpy(SXmlNode_t::Name(node), comment, commentlen+1);
+   strncpy(SXmlNode_t::Name(node), comment, commentlen + 1);
 
    return kTRUE;
 }
@@ -746,16 +782,17 @@ Bool_t TXMLEngine::AddComment(XMLNodePointer_t xmlnode, const char* comment)
 ////////////////////////////////////////////////////////////////////////////////
 /// add comment line to the top of the document
 
-Bool_t TXMLEngine::AddDocComment(XMLDocPointer_t xmldoc, const char* comment)
+Bool_t TXMLEngine::AddDocComment(XMLDocPointer_t xmldoc, const char *comment)
 {
-   if (xmldoc==0) return kFALSE;
+   if (xmldoc == 0)
+      return kFALSE;
 
    XMLNodePointer_t rootnode = DocGetRootElement(xmldoc);
    UnlinkNode(rootnode);
 
-   Bool_t res = AddComment(((SXmlDoc_t*)xmldoc)->fRootNode, comment);
+   Bool_t res = AddComment(((SXmlDoc_t *)xmldoc)->fRootNode, comment);
 
-   AddChild((XMLNodePointer_t) ((SXmlDoc_t*)xmldoc)->fRootNode, rootnode);
+   AddChild((XMLNodePointer_t)((SXmlDoc_t *)xmldoc)->fRootNode, rootnode);
 
    return res;
 }
@@ -765,14 +802,15 @@ Bool_t TXMLEngine::AddDocComment(XMLDocPointer_t xmldoc, const char* comment)
 /// Line should has correct xml syntax that later it can be decoded by xml parser
 /// For instance, it can be comment or processing instructions
 
-Bool_t TXMLEngine::AddRawLine(XMLNodePointer_t xmlnode, const char* line)
+Bool_t TXMLEngine::AddRawLine(XMLNodePointer_t xmlnode, const char *line)
 {
-   if ((xmlnode==0) || (line==0)) return kFALSE;
+   if ((xmlnode == 0) || (line == 0))
+      return kFALSE;
 
    int linelen = strlen(line);
-   SXmlNode_t* node = (SXmlNode_t*) AllocateNode(linelen, xmlnode);
+   SXmlNode_t *node = (SXmlNode_t *)AllocateNode(linelen, xmlnode);
    node->fType = kXML_RAWLINE;
-   strncpy(SXmlNode_t::Name(node), line, linelen+1);
+   strncpy(SXmlNode_t::Name(node), line, linelen + 1);
 
    return kTRUE;
 }
@@ -781,19 +819,17 @@ Bool_t TXMLEngine::AddRawLine(XMLNodePointer_t xmlnode, const char* line)
 /// Add just line on the top of xml document
 /// Line should has correct xml syntax that later it can be decoded by xml parser
 
-Bool_t TXMLEngine::AddDocRawLine(XMLDocPointer_t xmldoc, const char* line)
+Bool_t TXMLEngine::AddDocRawLine(XMLDocPointer_t xmldoc, const char *line)
 {
    XMLNodePointer_t rootnode = DocGetRootElement(xmldoc);
    UnlinkNode(rootnode);
 
-   Bool_t res = AddRawLine(((SXmlDoc_t*)xmldoc)->fRootNode, line);
+   Bool_t res = AddRawLine(((SXmlDoc_t *)xmldoc)->fRootNode, line);
 
-   AddChild((XMLNodePointer_t) ((SXmlDoc_t*)xmldoc)->fRootNode, rootnode);
+   AddChild((XMLNodePointer_t)((SXmlDoc_t *)xmldoc)->fRootNode, rootnode);
 
    return res;
-
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Adds style sheet definition to the specified node
@@ -804,58 +840,51 @@ Bool_t TXMLEngine::AddDocRawLine(XMLDocPointer_t xmldoc, const char* line)
 /// if alternate>0, attribute alternate="yes"
 /// if alternate<0, attribute will not be created
 
-Bool_t TXMLEngine::AddStyleSheet(XMLNodePointer_t xmlnode,
-                                 const char* href,
-                                 const char* type,
-                                 const char* title,
-                                 int alternate,
-                                 const char* media,
-                                 const char* charset)
+Bool_t TXMLEngine::AddStyleSheet(XMLNodePointer_t xmlnode, const char *href, const char *type, const char *title,
+                                 int alternate, const char *media, const char *charset)
 {
-   if ((xmlnode==0) || (href==0) || (type==0)) return kFALSE;
+   if ((xmlnode == 0) || (href == 0) || (type == 0))
+      return kFALSE;
 
-   const char* nodename = "xml-stylesheet";
+   const char *nodename = "xml-stylesheet";
    int nodenamelen = strlen(nodename);
 
-   SXmlNode_t* node = (SXmlNode_t*) AllocateNode(nodenamelen, xmlnode);
+   SXmlNode_t *node = (SXmlNode_t *)AllocateNode(nodenamelen, xmlnode);
    node->fType = kXML_PI_NODE;
-   strncpy(SXmlNode_t::Name(node), nodename, nodenamelen+1);
+   strncpy(SXmlNode_t::Name(node), nodename, nodenamelen + 1);
 
-   if (alternate>=0)
-     NewAttr(node, 0, "alternate", (alternate>0) ? "yes" : "no");
+   if (alternate >= 0)
+      NewAttr(node, 0, "alternate", (alternate > 0) ? "yes" : "no");
 
-   if (title!=0) NewAttr(node, 0, "title", title);
+   if (title != 0)
+      NewAttr(node, 0, "title", title);
 
    NewAttr(node, 0, "href", href);
    NewAttr(node, 0, "type", type);
 
-   if (media!=0) NewAttr(node, 0, "media", media);
-   if (charset!=0) NewAttr(node, 0, "charset", charset);
+   if (media != 0)
+      NewAttr(node, 0, "media", media);
+   if (charset != 0)
+      NewAttr(node, 0, "charset", charset);
 
    return kTRUE;
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Add style sheet definition on the top of document
 
-Bool_t TXMLEngine::AddDocStyleSheet(XMLDocPointer_t xmldoc,
-                                    const char* href,
-                                    const char* type,
-                                    const char* title,
-                                    int alternate,
-                                    const char* media,
-                                    const char* charset)
+Bool_t TXMLEngine::AddDocStyleSheet(XMLDocPointer_t xmldoc, const char *href, const char *type, const char *title,
+                                    int alternate, const char *media, const char *charset)
 {
-   if (xmldoc==0) return kFALSE;
+   if (xmldoc == 0)
+      return kFALSE;
 
    XMLNodePointer_t rootnode = DocGetRootElement(xmldoc);
    UnlinkNode(rootnode);
 
-   Bool_t res = AddStyleSheet(((SXmlDoc_t*)xmldoc)->fRootNode,
-                            href,type,title,alternate,media,charset);
+   Bool_t res = AddStyleSheet(((SXmlDoc_t *)xmldoc)->fRootNode, href, type, title, alternate, media, charset);
 
-   AddChild((XMLNodePointer_t) ((SXmlDoc_t*)xmldoc)->fRootNode, rootnode);
+   AddChild((XMLNodePointer_t)((SXmlDoc_t *)xmldoc)->fRootNode, rootnode);
 
    return res;
 }
@@ -865,20 +894,23 @@ Bool_t TXMLEngine::AddDocStyleSheet(XMLDocPointer_t xmldoc,
 
 void TXMLEngine::UnlinkNode(XMLNodePointer_t xmlnode)
 {
-   if (xmlnode==0) return;
-   SXmlNode_t* node = (SXmlNode_t*) xmlnode;
+   if (xmlnode == 0)
+      return;
+   SXmlNode_t *node = (SXmlNode_t *)xmlnode;
 
-   SXmlNode_t* parent = node->fParent;
+   SXmlNode_t *parent = node->fParent;
 
-   if (parent==0) return;
+   if (parent == 0)
+      return;
 
-   if (parent->fChild==node) {
+   if (parent->fChild == node) {
       parent->fChild = node->fNext;
-      if (parent->fLastChild==node)
+      if (parent->fLastChild == node)
          parent->fLastChild = node->fNext;
    } else {
-      SXmlNode_t* ch = parent->fChild;
-      while (ch->fNext!=node) ch = ch->fNext;
+      SXmlNode_t *ch = parent->fChild;
+      while (ch->fNext != node)
+         ch = ch->fNext;
       ch->fNext = node->fNext;
       if (parent->fLastChild == node)
          parent->fLastChild = ch;
@@ -891,27 +923,28 @@ void TXMLEngine::UnlinkNode(XMLNodePointer_t xmlnode)
 
 void TXMLEngine::FreeNode(XMLNodePointer_t xmlnode)
 {
-   if (xmlnode==0) return;
-   SXmlNode_t* node = (SXmlNode_t*) xmlnode;
+   if (xmlnode == 0)
+      return;
+   SXmlNode_t *node = (SXmlNode_t *)xmlnode;
 
-   SXmlNode_t* child = node->fChild;
-   while (child!=0) {
-      SXmlNode_t* next = child->fNext;
+   SXmlNode_t *child = node->fChild;
+   while (child != 0) {
+      SXmlNode_t *next = child->fNext;
       FreeNode((XMLNodePointer_t)child);
       child = next;
    }
 
-   SXmlAttr_t* attr = node->fAttr;
-   while (attr!=0) {
-      SXmlAttr_t* next = attr->fNext;
-      //fNumNodes--;
+   SXmlAttr_t *attr = node->fAttr;
+   while (attr != 0) {
+      SXmlAttr_t *next = attr->fNext;
+      // fNumNodes--;
       free(attr);
       attr = next;
    }
 
    free(node);
 
-   //fNumNodes--;
+   // fNumNodes--;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -926,21 +959,24 @@ void TXMLEngine::UnlinkFreeNode(XMLNodePointer_t xmlnode)
 ////////////////////////////////////////////////////////////////////////////////
 /// returns name of xmlnode
 
-const char* TXMLEngine::GetNodeName(XMLNodePointer_t xmlnode)
+const char *TXMLEngine::GetNodeName(XMLNodePointer_t xmlnode)
 {
-   return xmlnode==0 ? 0 : SXmlNode_t::Name(xmlnode);
+   return xmlnode == 0 ? 0 : SXmlNode_t::Name(xmlnode);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// get contents (if any) of xml node
 
-const char* TXMLEngine::GetNodeContent(XMLNodePointer_t xmlnode)
+const char *TXMLEngine::GetNodeContent(XMLNodePointer_t xmlnode)
 {
-   if (xmlnode==0) return 0;
-   SXmlNode_t* node = (SXmlNode_t*) xmlnode;
-   if (node->fChild == 0) return 0;
+   if (xmlnode == 0)
+      return 0;
+   SXmlNode_t *node = (SXmlNode_t *)xmlnode;
+   if (node->fChild == 0)
+      return 0;
 
-   if (node->fChild->fType != kXML_CONTENT) return 0;
+   if (node->fChild->fType != kXML_CONTENT)
+      return 0;
 
    return SXmlNode_t::Name(node->fChild);
 }
@@ -949,21 +985,24 @@ const char* TXMLEngine::GetNodeContent(XMLNodePointer_t xmlnode)
 /// set content of the xml node
 /// if old node content was exists, it will be replaced
 
-void TXMLEngine::SetNodeContent(XMLNodePointer_t xmlnode, const char* content, Int_t len)
+void TXMLEngine::SetNodeContent(XMLNodePointer_t xmlnode, const char *content, Int_t len)
 {
-   if (xmlnode==0) return;
-   SXmlNode_t* node = (SXmlNode_t*) xmlnode;
+   if (xmlnode == 0)
+      return;
+   SXmlNode_t *node = (SXmlNode_t *)xmlnode;
    if ((node->fChild != 0) && (node->fChild->fType == kXML_CONTENT))
-      UnlinkFreeNode((XMLNodePointer_t) node->fChild);
+      UnlinkFreeNode((XMLNodePointer_t)node->fChild);
 
-   if (content==0) return;
-   if (len<=0) len = strlen(content);
+   if (content == 0)
+      return;
+   if (len <= 0)
+      len = strlen(content);
 
-   SXmlNode_t* contnode = (SXmlNode_t*) AllocateNode(len, 0);
-   char* nameptr = SXmlNode_t::Name(contnode);
+   SXmlNode_t *contnode = (SXmlNode_t *)AllocateNode(len, 0);
+   char *nameptr = SXmlNode_t::Name(contnode);
    contnode->fType = kXML_CONTENT;
    strncpy(nameptr, content, len);
-   nameptr+=len;
+   nameptr += len;
    *nameptr = 0; // here we add padding 0 to get normal string
 
    AddChildFirst(xmlnode, (XMLNodePointer_t)contnode);
@@ -973,16 +1012,18 @@ void TXMLEngine::SetNodeContent(XMLNodePointer_t xmlnode, const char* content, I
 /// add new content of the xml node
 /// old content will be preserved, one could mix content with child nodes
 
-void TXMLEngine::AddNodeContent(XMLNodePointer_t xmlnode, const char* content, Int_t len)
+void TXMLEngine::AddNodeContent(XMLNodePointer_t xmlnode, const char *content, Int_t len)
 {
-   if ((xmlnode==0) || (content==0)) return;
-   if (len<=0) len = strlen(content);
+   if ((xmlnode == 0) || (content == 0))
+      return;
+   if (len <= 0)
+      len = strlen(content);
 
-   SXmlNode_t* contnode = (SXmlNode_t*) AllocateNode(len, xmlnode);
-   char* nameptr = SXmlNode_t::Name(contnode);
+   SXmlNode_t *contnode = (SXmlNode_t *)AllocateNode(len, xmlnode);
+   char *nameptr = SXmlNode_t::Name(contnode);
    contnode->fType = kXML_CONTENT;
    strncpy(nameptr, content, len);
-   nameptr+=len;
+   nameptr += len;
    *nameptr = 0; // here we add padding 0 to get normal string
 }
 
@@ -991,9 +1032,10 @@ void TXMLEngine::AddNodeContent(XMLNodePointer_t xmlnode, const char* content, I
 
 XMLNodePointer_t TXMLEngine::GetChild(XMLNodePointer_t xmlnode, Bool_t realnode)
 {
-   XMLNodePointer_t res = xmlnode==0 ? 0 :((SXmlNode_t*) xmlnode)->fChild;
+   XMLNodePointer_t res = xmlnode == 0 ? 0 : ((SXmlNode_t *)xmlnode)->fChild;
    // skip content(s) node, if specified
-   if (realnode && (res!=0) && (((SXmlNode_t*)res)->fType != kXML_NODE)) ShiftToNext(res, kTRUE);
+   if (realnode && (res != 0) && (((SXmlNode_t *)res)->fType != kXML_NODE))
+      ShiftToNext(res, kTRUE);
    return res;
 }
 
@@ -1002,7 +1044,7 @@ XMLNodePointer_t TXMLEngine::GetChild(XMLNodePointer_t xmlnode, Bool_t realnode)
 
 XMLNodePointer_t TXMLEngine::GetParent(XMLNodePointer_t xmlnode)
 {
-   return xmlnode==0 ? 0 : (XMLNodePointer_t) ((SXmlNode_t*) xmlnode)->fParent;
+   return xmlnode == 0 ? 0 : (XMLNodePointer_t)((SXmlNode_t *)xmlnode)->fParent;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1012,9 +1054,10 @@ XMLNodePointer_t TXMLEngine::GetParent(XMLNodePointer_t xmlnode)
 XMLNodePointer_t TXMLEngine::GetNext(XMLNodePointer_t xmlnode, Bool_t realnode)
 {
    do {
-      xmlnode = xmlnode==0 ? 0 : (XMLNodePointer_t) ((SXmlNode_t*) xmlnode)->fNext;
-      if ((xmlnode==0) || !realnode) return xmlnode;
-   } while (((SXmlNode_t*) xmlnode)->fType != kXML_NODE);
+      xmlnode = xmlnode == 0 ? 0 : (XMLNodePointer_t)((SXmlNode_t *)xmlnode)->fNext;
+      if ((xmlnode == 0) || !realnode)
+         return xmlnode;
+   } while (((SXmlNode_t *)xmlnode)->fType != kXML_NODE);
 
    return xmlnode;
 }
@@ -1026,9 +1069,10 @@ XMLNodePointer_t TXMLEngine::GetNext(XMLNodePointer_t xmlnode, Bool_t realnode)
 void TXMLEngine::ShiftToNext(XMLNodePointer_t &xmlnode, Bool_t realnode)
 {
    do {
-      xmlnode = xmlnode==0 ? 0 : (XMLNodePointer_t) ((SXmlNode_t*) xmlnode)->fNext;
-      if ((xmlnode==0) || !realnode) return;
-   } while (((SXmlNode_t*) xmlnode)->fType != kXML_NODE);
+      xmlnode = xmlnode == 0 ? 0 : (XMLNodePointer_t)((SXmlNode_t *)xmlnode)->fNext;
+      if ((xmlnode == 0) || !realnode)
+         return;
+   } while (((SXmlNode_t *)xmlnode)->fType != kXML_NODE);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1036,7 +1080,7 @@ void TXMLEngine::ShiftToNext(XMLNodePointer_t &xmlnode, Bool_t realnode)
 
 Bool_t TXMLEngine::IsXmlNode(XMLNodePointer_t xmlnode)
 {
-   return xmlnode==0 ? kFALSE : (((SXmlNode_t*) xmlnode)->fType == kXML_NODE);
+   return xmlnode == 0 ? kFALSE : (((SXmlNode_t *)xmlnode)->fType == kXML_NODE);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1044,7 +1088,7 @@ Bool_t TXMLEngine::IsXmlNode(XMLNodePointer_t xmlnode)
 
 Bool_t TXMLEngine::IsEmptyNode(XMLNodePointer_t xmlnode)
 {
-   return xmlnode==0 ? kTRUE : (((SXmlNode_t*) xmlnode)->fType != kXML_NODE);
+   return xmlnode == 0 ? kTRUE : (((SXmlNode_t *)xmlnode)->fType != kXML_NODE);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1052,7 +1096,7 @@ Bool_t TXMLEngine::IsEmptyNode(XMLNodePointer_t xmlnode)
 
 Bool_t TXMLEngine::IsContentNode(XMLNodePointer_t xmlnode)
 {
-   return xmlnode==0 ? kFALSE : (((SXmlNode_t*) xmlnode)->fType == kXML_CONTENT);
+   return xmlnode == 0 ? kFALSE : (((SXmlNode_t *)xmlnode)->fType == kXML_CONTENT);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1060,30 +1104,30 @@ Bool_t TXMLEngine::IsContentNode(XMLNodePointer_t xmlnode)
 
 Bool_t TXMLEngine::IsCommentNode(XMLNodePointer_t xmlnode)
 {
-   return xmlnode==0 ? kFALSE : (((SXmlNode_t*) xmlnode)->fType == kXML_COMMENT);
+   return xmlnode == 0 ? kFALSE : (((SXmlNode_t *)xmlnode)->fType == kXML_COMMENT);
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Skip all current empty nodes and locate on first "true" node
 
 void TXMLEngine::SkipEmpty(XMLNodePointer_t &xmlnode)
 {
-   if (IsEmptyNode(xmlnode)) ShiftToNext(xmlnode);
+   if (IsEmptyNode(xmlnode))
+      ShiftToNext(xmlnode);
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// remove all children node from xmlnode
 
 void TXMLEngine::CleanNode(XMLNodePointer_t xmlnode)
 {
-   if (xmlnode==0) return;
-   SXmlNode_t* node = (SXmlNode_t*) xmlnode;
+   if (xmlnode == 0)
+      return;
+   SXmlNode_t *node = (SXmlNode_t *)xmlnode;
 
-   SXmlNode_t* child = node->fChild;
-   while (child!=0) {
-      SXmlNode_t* next = child->fNext;
+   SXmlNode_t *child = node->fChild;
+   while (child != 0) {
+      SXmlNode_t *next = child->fNext;
       FreeNode((XMLNodePointer_t)child);
       child = next;
    }
@@ -1095,29 +1139,30 @@ void TXMLEngine::CleanNode(XMLNodePointer_t xmlnode)
 ////////////////////////////////////////////////////////////////////////////////
 /// creates new xml document with provided version
 
-XMLDocPointer_t TXMLEngine::NewDoc(const char* version)
+XMLDocPointer_t TXMLEngine::NewDoc(const char *version)
 {
-   SXmlDoc_t* doc = new SXmlDoc_t;
-   doc->fRootNode = (SXmlNode_t*) NewChild(0, 0, "??DummyTopNode??", 0);
+   SXmlDoc_t *doc = new SXmlDoc_t;
+   doc->fRootNode = (SXmlNode_t *)NewChild(0, 0, "??DummyTopNode??", 0);
 
-   if (version!=0) {
-      XMLNodePointer_t vernode = NewChild( (XMLNodePointer_t) doc->fRootNode, 0, "xml");
-      ((SXmlNode_t*) vernode)->fType = kXML_PI_NODE;
+   if (version != 0) {
+      XMLNodePointer_t vernode = NewChild((XMLNodePointer_t)doc->fRootNode, 0, "xml");
+      ((SXmlNode_t *)vernode)->fType = kXML_PI_NODE;
       NewAttr(vernode, 0, "version", version);
    }
 
    doc->fDtdName = 0;
    doc->fDtdRoot = 0;
-   return (XMLDocPointer_t) doc;
+   return (XMLDocPointer_t)doc;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// assigns dtd filename to document
 
-void TXMLEngine::AssignDtd(XMLDocPointer_t xmldoc, const char* dtdname, const char* rootname)
+void TXMLEngine::AssignDtd(XMLDocPointer_t xmldoc, const char *dtdname, const char *rootname)
 {
-   if (xmldoc==0) return;
-   SXmlDoc_t* doc = (SXmlDoc_t*) xmldoc;
+   if (xmldoc == 0)
+      return;
+   SXmlDoc_t *doc = (SXmlDoc_t *)xmldoc;
    delete[] doc->fDtdName;
    doc->fDtdName = Makestr(dtdname);
    delete[] doc->fDtdRoot;
@@ -1129,9 +1174,10 @@ void TXMLEngine::AssignDtd(XMLDocPointer_t xmldoc, const char* dtdname, const ch
 
 void TXMLEngine::FreeDoc(XMLDocPointer_t xmldoc)
 {
-   if (xmldoc==0) return;
-   SXmlDoc_t* doc = (SXmlDoc_t*) xmldoc;
-   FreeNode((XMLNodePointer_t) doc->fRootNode);
+   if (xmldoc == 0)
+      return;
+   SXmlDoc_t *doc = (SXmlDoc_t *)xmldoc;
+   FreeNode((XMLNodePointer_t)doc->fRootNode);
    delete[] doc->fDtdName;
    delete[] doc->fDtdRoot;
    delete doc;
@@ -1144,21 +1190,21 @@ void TXMLEngine::FreeDoc(XMLDocPointer_t xmldoc)
 /// if (layout>0) each node will be started from new line,
 /// and number of spaces will correspond to structure depth.
 
-void TXMLEngine::SaveDoc(XMLDocPointer_t xmldoc, const char* filename, Int_t layout)
+void TXMLEngine::SaveDoc(XMLDocPointer_t xmldoc, const char *filename, Int_t layout)
 {
-   if (xmldoc==0) return;
+   if (xmldoc == 0)
+      return;
 
-   SXmlDoc_t* doc = (SXmlDoc_t*) xmldoc;
+   SXmlDoc_t *doc = (SXmlDoc_t *)xmldoc;
 
    TXMLOutputStream out(filename, 100000);
 
-   XMLNodePointer_t child = GetChild((XMLNodePointer_t) doc->fRootNode, kFALSE);
+   XMLNodePointer_t child = GetChild((XMLNodePointer_t)doc->fRootNode, kFALSE);
 
    do {
       SaveNode(child, &out, layout, 0);
       ShiftToNext(child, kFALSE);
-   } while (child!=0);
-
+   } while (child != 0);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1166,11 +1212,12 @@ void TXMLEngine::SaveDoc(XMLDocPointer_t xmldoc, const char* filename, Int_t lay
 
 void TXMLEngine::DocSetRootElement(XMLDocPointer_t xmldoc, XMLNodePointer_t xmlnode)
 {
-   if (xmldoc==0) return;
+   if (xmldoc == 0)
+      return;
 
    FreeNode(DocGetRootElement(xmldoc));
 
-   AddChild((XMLNodePointer_t) ((SXmlDoc_t*)xmldoc)->fRootNode, xmlnode);
+   AddChild((XMLNodePointer_t)((SXmlDoc_t *)xmldoc)->fRootNode, xmlnode);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1178,9 +1225,10 @@ void TXMLEngine::DocSetRootElement(XMLDocPointer_t xmldoc, XMLNodePointer_t xmln
 
 XMLNodePointer_t TXMLEngine::DocGetRootElement(XMLDocPointer_t xmldoc)
 {
-   if (xmldoc==0) return 0;
+   if (xmldoc == 0)
+      return 0;
 
-   XMLNodePointer_t xmlnode = (XMLNodePointer_t) ((SXmlDoc_t*)xmldoc)->fRootNode;
+   XMLNodePointer_t xmlnode = (XMLNodePointer_t)((SXmlDoc_t *)xmldoc)->fRootNode;
 
    // typically first child of XML document is version
    // therefore just skip it when returning root node of document
@@ -1192,10 +1240,12 @@ XMLNodePointer_t TXMLEngine::DocGetRootElement(XMLDocPointer_t xmldoc)
 /// The maxbuf argument specifies the max size of the XML file to be
 /// parsed. The default value is 100000.
 
-XMLDocPointer_t TXMLEngine::ParseFile(const char* filename, Int_t maxbuf)
+XMLDocPointer_t TXMLEngine::ParseFile(const char *filename, Int_t maxbuf)
 {
-   if ((filename==0) || (strlen(filename)==0)) return 0;
-   if (maxbuf < 100000) maxbuf = 100000;
+   if ((filename == 0) || (strlen(filename) == 0))
+      return 0;
+   if (maxbuf < 100000)
+      maxbuf = 100000;
    TXMLInputStream inp(true, filename, maxbuf);
    return ParseStream(&inp);
 }
@@ -1203,19 +1253,21 @@ XMLDocPointer_t TXMLEngine::ParseFile(const char* filename, Int_t maxbuf)
 ////////////////////////////////////////////////////////////////////////////////
 /// parses content of string and tries to produce xml structures
 
-XMLDocPointer_t TXMLEngine::ParseString(const char* xmlstring)
+XMLDocPointer_t TXMLEngine::ParseString(const char *xmlstring)
 {
-   if ((xmlstring==0) || (strlen(xmlstring)==0)) return 0;
-   TXMLInputStream inp(false, xmlstring, 2*strlen(xmlstring) );
+   if ((xmlstring == 0) || (strlen(xmlstring) == 0))
+      return 0;
+   TXMLInputStream inp(false, xmlstring, 2 * strlen(xmlstring));
    return ParseStream(&inp);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// parses content of the stream and tries to produce xml structures
 
-XMLDocPointer_t TXMLEngine::ParseStream(TXMLInputStream* inp)
+XMLDocPointer_t TXMLEngine::ParseStream(TXMLInputStream *inp)
 {
-   if (inp == 0) return 0;
+   if (inp == 0)
+      return 0;
 
    XMLDocPointer_t xmldoc = NewDoc(0);
 
@@ -1224,12 +1276,15 @@ XMLDocPointer_t TXMLEngine::ParseStream(TXMLInputStream* inp)
    Int_t resvalue = 0;
 
    do {
-      ReadNode(((SXmlDoc_t*) xmldoc)->fRootNode, inp, resvalue);
+      ReadNode(((SXmlDoc_t *)xmldoc)->fRootNode, inp, resvalue);
 
-      if (resvalue!=2) break;
+      if (resvalue != 2)
+         break;
 
-      // coverity[unchecked_value] at this place result of SkipSpaces() doesn't matter - either file is finished (false) or there is some more nodes to analyse (true)
-      if (!inp->EndOfStream()) inp->SkipSpaces();
+      // coverity[unchecked_value] at this place result of SkipSpaces() doesn't matter - either file is finished (false)
+      // or there is some more nodes to analyse (true)
+      if (!inp->EndOfStream())
+         inp->SkipSpaces();
 
       if (inp->EndOfStream()) {
          success = true;
@@ -1249,21 +1304,27 @@ XMLDocPointer_t TXMLEngine::ParseStream(TXMLInputStream* inp)
 ////////////////////////////////////////////////////////////////////////////////
 /// check that first node is xml processing instruction with correct xml version number
 
-Bool_t TXMLEngine::ValidateVersion(XMLDocPointer_t xmldoc, const char* version)
+Bool_t TXMLEngine::ValidateVersion(XMLDocPointer_t xmldoc, const char *version)
 {
-   if (xmldoc==0) return kFALSE;
+   if (xmldoc == 0)
+      return kFALSE;
 
-   XMLNodePointer_t vernode = GetChild((XMLNodePointer_t) ((SXmlDoc_t*) xmldoc)->fRootNode, kFALSE);
-   if (vernode==0) return kFALSE;
+   XMLNodePointer_t vernode = GetChild((XMLNodePointer_t)((SXmlDoc_t *)xmldoc)->fRootNode, kFALSE);
+   if (vernode == 0)
+      return kFALSE;
 
-   if (((SXmlNode_t*) vernode)->fType!=kXML_PI_NODE) return kFALSE;
-   if (strcmp(GetNodeName(vernode), "xml")!=0) return kFALSE;
+   if (((SXmlNode_t *)vernode)->fType != kXML_PI_NODE)
+      return kFALSE;
+   if (strcmp(GetNodeName(vernode), "xml") != 0)
+      return kFALSE;
 
-   const char* value = GetAttr(vernode,"version");
-   if (value==0) return kFALSE;
-   if (version==0) version = "1.0";
+   const char *value = GetAttr(vernode, "version");
+   if (value == 0)
+      return kFALSE;
+   if (version == 0)
+      version = "1.0";
 
-   return strcmp(version,value)==0;
+   return strcmp(version, value) == 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1273,9 +1334,10 @@ Bool_t TXMLEngine::ValidateVersion(XMLDocPointer_t xmldoc, const char* version)
 /// if (layout>0) each node will be started from new line,
 /// and number of spaces will correspond to structure depth.
 
-void TXMLEngine::SaveSingleNode(XMLNodePointer_t xmlnode, TString* res, Int_t layout)
+void TXMLEngine::SaveSingleNode(XMLNodePointer_t xmlnode, TString *res, Int_t layout)
 {
-   if ((res==0) || (xmlnode==0)) return;
+   if ((res == 0) || (xmlnode == 0))
+      return;
 
    TXMLOutputStream out(res, 10000);
 
@@ -1285,9 +1347,10 @@ void TXMLEngine::SaveSingleNode(XMLNodePointer_t xmlnode, TString* res, Int_t la
 ////////////////////////////////////////////////////////////////////////////////
 /// read single xml node from provided string
 
-XMLNodePointer_t TXMLEngine::ReadSingleNode(const char* src)
+XMLNodePointer_t TXMLEngine::ReadSingleNode(const char *src)
 {
-   if (src==0) return 0;
+   if (src == 0)
+      return 0;
 
    TXMLInputStream inp(false, src, 10000);
 
@@ -1295,7 +1358,7 @@ XMLNodePointer_t TXMLEngine::ReadSingleNode(const char* src)
 
    XMLNodePointer_t xmlnode = ReadNode(0, &inp, resvalue);
 
-   if (resvalue<=0) {
+   if (resvalue <= 0) {
       DisplayError(resvalue, inp.CurrentLine());
       FreeNode(xmlnode);
       return 0;
@@ -1307,25 +1370,28 @@ XMLNodePointer_t TXMLEngine::ReadSingleNode(const char* src)
 ////////////////////////////////////////////////////////////////////////////////
 /// creates char* variable with copy of provided string
 
-char* TXMLEngine::Makestr(const char* str)
+char *TXMLEngine::Makestr(const char *str)
 {
-   if (str==0) return 0;
+   if (str == 0)
+      return 0;
    int len = strlen(str);
-   if (len==0) return 0;
-   char* res = new char[len+1];
-   strncpy(res, str, len+1);
+   if (len == 0)
+      return 0;
+   char *res = new char[len + 1];
+   strncpy(res, str, len + 1);
    return res;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// creates char* variable with copy of len symbols from provided string
 
-char* TXMLEngine::Makenstr(const char* str, int len)
+char *TXMLEngine::Makenstr(const char *str, int len)
 {
-   if ((str==0) || (len==0)) return 0;
-   char* res = new char[len+1];
+   if ((str == 0) || (len == 0))
+      return 0;
+   char *res = new char[len + 1];
    strncpy(res, str, len);
-   *(res+len) = 0;
+   *(res + len) = 0;
    return res;
 }
 
@@ -1334,9 +1400,9 @@ char* TXMLEngine::Makenstr(const char* str, int len)
 
 XMLNodePointer_t TXMLEngine::AllocateNode(int namelen, XMLNodePointer_t parent)
 {
-   //fNumNodes++;
+   // fNumNodes++;
 
-   SXmlNode_t* node = (SXmlNode_t*) malloc(sizeof(SXmlNode_t) + namelen + 1);
+   SXmlNode_t *node = (SXmlNode_t *)malloc(sizeof(SXmlNode_t) + namelen + 1);
 
    node->fType = kXML_NODE;
    node->fParent = 0;
@@ -1346,10 +1412,10 @@ XMLNodePointer_t TXMLEngine::AllocateNode(int namelen, XMLNodePointer_t parent)
    node->fLastChild = 0;
    node->fNext = 0;
 
-   if (parent!=0)
-      AddChild(parent, (XMLNodePointer_t) node);
+   if (parent != 0)
+      AddChild(parent, (XMLNodePointer_t)node);
 
-   return (XMLNodePointer_t) node;
+   return (XMLNodePointer_t)node;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1357,35 +1423,37 @@ XMLNodePointer_t TXMLEngine::AllocateNode(int namelen, XMLNodePointer_t parent)
 
 XMLAttrPointer_t TXMLEngine::AllocateAttr(int namelen, int valuelen, XMLNodePointer_t xmlnode)
 {
-   //fNumNodes++;
+   // fNumNodes++;
 
-   SXmlAttr_t* attr = (SXmlAttr_t*) malloc(sizeof(SXmlAttr_t) + namelen + 1 + valuelen + 1);
+   SXmlAttr_t *attr = (SXmlAttr_t *)malloc(sizeof(SXmlAttr_t) + namelen + 1 + valuelen + 1);
 
-   SXmlNode_t* node = (SXmlNode_t*) xmlnode;
+   SXmlNode_t *node = (SXmlNode_t *)xmlnode;
 
    attr->fNext = 0;
 
-   if (node->fAttr==0)
+   if (node->fAttr == 0)
       node->fAttr = attr;
    else {
-      SXmlAttr_t* d = node->fAttr;
-      while (d->fNext!=0) d = d->fNext;
+      SXmlAttr_t *d = node->fAttr;
+      while (d->fNext != 0)
+         d = d->fNext;
       d->fNext = attr;
    }
 
-   return (XMLAttrPointer_t) attr;
+   return (XMLAttrPointer_t)attr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// define if namespace of that name exists for xmlnode
 
-XMLNsPointer_t TXMLEngine::FindNs(XMLNodePointer_t xmlnode, const char* name)
+XMLNsPointer_t TXMLEngine::FindNs(XMLNodePointer_t xmlnode, const char *name)
 {
-   SXmlNode_t* node = (SXmlNode_t*) xmlnode;
-   while (node!=0) {
-      if (node->fNs!=0) {
-         const char* nsname = SXmlAttr_t::Name(node->fNs) + 6;
-         if (strcmp(nsname, name)==0) return node->fNs;
+   SXmlNode_t *node = (SXmlNode_t *)xmlnode;
+   while (node != 0) {
+      if (node->fNs != 0) {
+         const char *nsname = SXmlAttr_t::Name(node->fNs) + 6;
+         if (strcmp(nsname, name) == 0)
+            return node->fNs;
       }
       node = node->fParent;
    }
@@ -1397,41 +1465,53 @@ XMLNsPointer_t TXMLEngine::FindNs(XMLNodePointer_t xmlnode, const char* name)
 
 void TXMLEngine::TruncateNsExtension(XMLNodePointer_t xmlnode)
 {
-   SXmlNode_t* node = (SXmlNode_t*) xmlnode;
-   if (node==0) return;
-   char* colon = strchr(SXmlNode_t::Name(node),':');
-   if (colon==0) return;
+   SXmlNode_t *node = (SXmlNode_t *)xmlnode;
+   if (node == 0)
+      return;
+   char *colon = strchr(SXmlNode_t::Name(node), ':');
+   if (colon == 0)
+      return;
 
-   char* copyname = SXmlNode_t::Name(node);
+   char *copyname = SXmlNode_t::Name(node);
 
-   while (*colon!=0)
-     *(copyname++) = *(++colon);
+   while (*colon != 0)
+      *(copyname++) = *(++colon);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// unpack special symbols, used in xml syntax to code characters
 /// these symbols: '<' - &lt, '>' - &gt, '&' - &amp, '"' - &quot, ''' - &apos
 
-void TXMLEngine::UnpackSpecialCharacters(char* target, const char* source, int srclen)
+void TXMLEngine::UnpackSpecialCharacters(char *target, const char *source, int srclen)
 {
-   while (srclen>0) {
-      if (*source=='&') {
-         if ((srclen>3) && (*(source+1)=='l') && (*(source+2)=='t') && (*(source+3)==';')) {
-            *target++ = '<'; source+=4; srclen-=4;
-         } else
-         if ((srclen>3) && (*(source+1)=='g') && (*(source+2)=='t') && (*(source+3)==';')) {
-            *target++ = '>'; source+=4; srclen-=4;
-         } else
-         if ((srclen>4) && (*(source+1)=='a') && (*(source+2)=='m') && (*(source+3)=='p') && (*(source+4)==';')) {
-            *target++ = '&'; source+=5; srclen-=5;
-         } else
-         if ((srclen>5) && (*(source+1)=='q') && (*(source+2)=='u') && (*(source+3)=='o') && (*(source+4)=='t') && (*(source+5)==';')) {
-            *target++ = '\"'; source+=6; srclen-=6;
-         } else
-         if ((srclen>5) && (*(source+1)=='a') && (*(source+2)=='p') && (*(source+3)=='o') && (*(source+4)=='s') && (*(source+5)==';')) {
-            *target++ = '\''; source+=6; srclen-=6;
+   while (srclen > 0) {
+      if (*source == '&') {
+         if ((srclen > 3) && (*(source + 1) == 'l') && (*(source + 2) == 't') && (*(source + 3) == ';')) {
+            *target++ = '<';
+            source += 4;
+            srclen -= 4;
+         } else if ((srclen > 3) && (*(source + 1) == 'g') && (*(source + 2) == 't') && (*(source + 3) == ';')) {
+            *target++ = '>';
+            source += 4;
+            srclen -= 4;
+         } else if ((srclen > 4) && (*(source + 1) == 'a') && (*(source + 2) == 'm') && (*(source + 3) == 'p') &&
+                    (*(source + 4) == ';')) {
+            *target++ = '&';
+            source += 5;
+            srclen -= 5;
+         } else if ((srclen > 5) && (*(source + 1) == 'q') && (*(source + 2) == 'u') && (*(source + 3) == 'o') &&
+                    (*(source + 4) == 't') && (*(source + 5) == ';')) {
+            *target++ = '\"';
+            source += 6;
+            srclen -= 6;
+         } else if ((srclen > 5) && (*(source + 1) == 'a') && (*(source + 2) == 'p') && (*(source + 3) == 'o') &&
+                    (*(source + 4) == 's') && (*(source + 5) == ';')) {
+            *target++ = '\'';
+            source += 6;
+            srclen -= 6;
          } else {
-            *target++ = *source++; srclen--;
+            *target++ = *source++;
+            srclen--;
          }
       } else {
          *target++ = *source++;
@@ -1446,72 +1526,82 @@ void TXMLEngine::UnpackSpecialCharacters(char* target, const char* source, int s
 /// if symbols '<' '&' '>' '"' ''' appears in the string, they
 /// will be encoded to appropriate xml symbols: &lt, &amp, &gt, &quot, &apos
 
-void TXMLEngine::OutputValue(char* value, TXMLOutputStream* out)
+void TXMLEngine::OutputValue(char *value, TXMLOutputStream *out)
 {
-   if (value==0) return;
+   if (value == 0)
+      return;
 
-   char* last = value;
-   char* find = 0;
-   while ((find=strpbrk(last,"<&>\"")) !=0 ) {
+   char *last = value;
+   char *find = 0;
+   while ((find = strpbrk(last, "<&>\"")) != 0) {
       char symb = *find;
       *find = 0;
       out->Write(last);
       *find = symb;
-      last = find+1;
-      if (symb=='<')       out->Write("&lt;");
-      else if (symb=='>')  out->Write("&gt;");
-      else if (symb=='&')  out->Write("&amp;");
-      else if (symb=='\'') out->Write("&apos;");
-      else                 out->Write("&quot;");
+      last = find + 1;
+      if (symb == '<')
+         out->Write("&lt;");
+      else if (symb == '>')
+         out->Write("&gt;");
+      else if (symb == '&')
+         out->Write("&amp;");
+      else if (symb == '\'')
+         out->Write("&apos;");
+      else
+         out->Write("&quot;");
    }
-   if (*last!=0)
+   if (*last != 0)
       out->Write(last);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// stream data of xmlnode to output
 
-void TXMLEngine::SaveNode(XMLNodePointer_t xmlnode, TXMLOutputStream* out, Int_t layout, Int_t level)
+void TXMLEngine::SaveNode(XMLNodePointer_t xmlnode, TXMLOutputStream *out, Int_t layout, Int_t level)
 {
-   if (xmlnode==0) return;
-   SXmlNode_t* node = (SXmlNode_t*) xmlnode;
+   if (xmlnode == 0)
+      return;
+   SXmlNode_t *node = (SXmlNode_t *)xmlnode;
 
-   Bool_t issingleline = (node->fChild==0);
+   Bool_t issingleline = (node->fChild == 0);
 
-   if (layout>0) out->Put(' ', level);
+   if (layout > 0)
+      out->Put(' ', level);
 
    if (node->fType == kXML_COMMENT) {
       out->Write("<!--");
       out->Write(SXmlNode_t::Name(node));
       out->Write("-->");
-      if (layout>0) out->Put('\n');
+      if (layout > 0)
+         out->Put('\n');
       return;
-   } else
-   if (node->fType == kXML_RAWLINE) {
+   } else if (node->fType == kXML_RAWLINE) {
       out->Write(SXmlNode_t::Name(node));
-      if (layout>0) out->Put('\n');
+      if (layout > 0)
+         out->Put('\n');
       return;
-   } else
-   if (node->fType == kXML_CONTENT) {
+   } else if (node->fType == kXML_CONTENT) {
       out->Write(SXmlNode_t::Name(node));
-      if (layout>0) out->Put('\n');
+      if (layout > 0)
+         out->Put('\n');
       return;
    }
 
    out->Put('<');
-   if (node->fType==kXML_PI_NODE) out->Put('?');
+   if (node->fType == kXML_PI_NODE)
+      out->Put('?');
 
    // we suppose that ns is always first attribute
-   if ((node->fNs!=0) && (node->fNs!=node->fAttr)) {
-      out->Write(SXmlAttr_t::Name(node->fNs)+6);
+   if ((node->fNs != 0) && (node->fNs != node->fAttr)) {
+      out->Write(SXmlAttr_t::Name(node->fNs) + 6);
       out->Put(':');
    }
    out->Write(SXmlNode_t::Name(node));
 
-   SXmlAttr_t* attr = node->fAttr;
-   while (attr!=0) {
+   SXmlAttr_t *attr = node->fAttr;
+   while (attr != 0) {
       out->Put(' ');
-      char* attrname = SXmlAttr_t::Name(attr);
+      char *attrname = SXmlAttr_t::Name(attr);
       out->Write(attrname);
       out->Write("=\"");
       attrname += strlen(attrname) + 1;
@@ -1522,38 +1612,44 @@ void TXMLEngine::SaveNode(XMLNodePointer_t xmlnode, TXMLOutputStream* out, Int_t
 
    // if single line, close node with "/>" and return
    if (issingleline) {
-      if (node->fType==kXML_PI_NODE) out->Write("?>");
-                              else out->Write("/>");
-      if (layout>0) out->Put('\n');
+      if (node->fType == kXML_PI_NODE)
+         out->Write("?>");
+      else
+         out->Write("/>");
+      if (layout > 0)
+         out->Put('\n');
       return;
    }
 
    out->Put('>');
 
-   SXmlNode_t* child = node->fChild;
+   SXmlNode_t *child = node->fChild;
 
-   if ((child!=0) && (child->fType == kXML_CONTENT) && (child->fNext == 0)) {
+   if ((child != 0) && (child->fType == kXML_CONTENT) && (child->fNext == 0)) {
       // special case when single content node is exists
       out->Write(SXmlNode_t::Name(child));
    } else {
-      if (layout>0) out->Put('\n');
-      while (child!=0) {
-         SaveNode((XMLNodePointer_t) child, out, layout, level+2);
+      if (layout > 0)
+         out->Put('\n');
+      while (child != 0) {
+         SaveNode((XMLNodePointer_t)child, out, layout, level + 2);
          child = child->fNext;
       }
       // add starting spaces before closing node
-      if (layout>0) out->Put(' ',level);
+      if (layout > 0)
+         out->Put(' ', level);
    }
 
    out->Write("</");
    // we suppose that ns is always first attribute
-   if ((node->fNs!=0) && (node->fNs!=node->fAttr)) {
-      out->Write(SXmlAttr_t::Name(node->fNs)+6);
+   if ((node->fNs != 0) && (node->fNs != node->fAttr)) {
+      out->Write(SXmlAttr_t::Name(node->fNs) + 6);
       out->Put(':');
    }
    out->Write(SXmlNode_t::Name(node));
    out->Put('>');
-   if (layout>0) out->Put('\n');
+   if (layout > 0)
+      out->Put('\n');
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1563,49 +1659,67 @@ void TXMLEngine::SaveNode(XMLNodePointer_t xmlnode, TXMLOutputStream* out, Int_t
 /// resvalue == 1 if this is endnode of parent
 /// resvalue == 2 if this is child
 
-XMLNodePointer_t TXMLEngine::ReadNode(XMLNodePointer_t xmlparent, TXMLInputStream* inp, Int_t& resvalue)
+XMLNodePointer_t TXMLEngine::ReadNode(XMLNodePointer_t xmlparent, TXMLInputStream *inp, Int_t &resvalue)
 {
    resvalue = 0;
 
-   if (inp==0) return 0;
-   if (!inp->SkipSpaces()) { resvalue = -1; return 0; }
-   SXmlNode_t* parent = (SXmlNode_t*) xmlparent;
+   if (inp == 0)
+      return 0;
+   if (!inp->SkipSpaces()) {
+      resvalue = -1;
+      return 0;
+   }
+   SXmlNode_t *parent = (SXmlNode_t *)xmlparent;
 
-   SXmlNode_t* node = 0;
+   SXmlNode_t *node = 0;
 
    // process comments before we start to analyse any node symbols
    while (inp->CheckFor("<!--")) {
       Int_t commentlen = inp->SearchFor("-->");
-      if (commentlen<=0) { resvalue = -10; return 0; }
+      if (commentlen <= 0) {
+         resvalue = -10;
+         return 0;
+      }
 
       if (!fSkipComments) {
-         node = (SXmlNode_t*) AllocateNode(commentlen, xmlparent);
-         char* nameptr = SXmlNode_t::Name(node);
+         node = (SXmlNode_t *)AllocateNode(commentlen, xmlparent);
+         char *nameptr = SXmlNode_t::Name(node);
          node->fType = kXML_COMMENT;
          strncpy(nameptr, inp->fCurrent, commentlen); // here copy only content, there is no padding 0 at the end
-         nameptr+=commentlen;
+         nameptr += commentlen;
          *nameptr = 0; // here we add padding 0 to get normal string
       }
 
-      if (!inp->ShiftCurrent(commentlen+3)) { resvalue = -1; return node; }
-      if (!inp->SkipSpaces()) { resvalue = -1; return node; }
+      if (!inp->ShiftCurrent(commentlen + 3)) {
+         resvalue = -1;
+         return node;
+      }
+      if (!inp->SkipSpaces()) {
+         resvalue = -1;
+         return node;
+      }
 
       resvalue = 2;
       return node;
    }
 
-   if (*inp->fCurrent!='<') {
+   if (*inp->fCurrent != '<') {
       // here should be reading of element content
       // now one can have content at any place of the node, also after childs
-      if (parent==0) { resvalue = -2; return 0; }
+      if (parent == 0) {
+         resvalue = -2;
+         return 0;
+      }
       int contlen = inp->LocateContent();
-      if (contlen<0) return 0;
+      if (contlen < 0)
+         return 0;
 
-      SXmlNode_t* contnode = (SXmlNode_t*) AllocateNode(contlen, xmlparent);
+      SXmlNode_t *contnode = (SXmlNode_t *)AllocateNode(contlen, xmlparent);
       contnode->fType = kXML_CONTENT;
-      char* contptr = SXmlNode_t::Name(contnode);
+      char *contptr = SXmlNode_t::Name(contnode);
       UnpackSpecialCharacters(contptr, inp->fCurrent, contlen);
-      if (!inp->ShiftCurrent(contlen)) return 0;
+      if (!inp->ShiftCurrent(contlen))
+         return 0;
 
       if (inp->NumEntities() <= 0) {
          resvalue = 2;
@@ -1614,22 +1728,26 @@ XMLNodePointer_t TXMLEngine::ReadNode(XMLNodePointer_t xmlparent, TXMLInputStrea
 
       // analyze content on possible includes only when ENTITY was specified for document
 
-      const char* beg(0), *lastentity(0), *curr(contptr);
+      const char *beg(0), *lastentity(0), *curr(contptr);
 
       while (*curr != 0) {
-         if ((beg==0) && (*curr=='&')) beg = curr;
-         if ((beg==0) || (*curr!=';')) { curr++; continue; }
+         if ((beg == 0) && (*curr == '&'))
+            beg = curr;
+         if ((beg == 0) || (*curr != ';')) {
+            curr++;
+            continue;
+         }
 
-         TXMLEntity* entity = inp->FindEntity(beg+1, curr - beg - 1);
+         TXMLEntity *entity = inp->FindEntity(beg + 1, curr - beg - 1);
 
-         if (entity!=0) {
+         if (entity != 0) {
 
-            if (lastentity==0) {
+            if (lastentity == 0) {
                lastentity = contptr;
                UnlinkNode(contnode);
             }
 
-            if (lastentity!=beg)
+            if (lastentity != beg)
                AddNodeContent(xmlparent, lastentity, beg - lastentity);
 
             // printf("Find entity %s in content\n", entity->GetName());
@@ -1642,7 +1760,7 @@ XMLNodePointer_t TXMLEngine::ReadNode(XMLNodePointer_t xmlparent, TXMLInputStrea
 
                XMLNodePointer_t topnode = DocGetRootElement(entitydoc);
 
-               while (topnode!=0) {
+               while (topnode != 0) {
                   XMLNodePointer_t currnode = topnode;
                   ShiftToNext(topnode, false);
                   UnlinkNode(currnode);
@@ -1659,9 +1777,10 @@ XMLNodePointer_t TXMLEngine::ReadNode(XMLNodePointer_t xmlparent, TXMLInputStrea
          lastentity = curr;
       }
 
-      if (lastentity!=0) {
+      if (lastentity != 0) {
          // add rest part of the content
-         if (strlen(lastentity)>0) AddNodeContent(xmlparent,lastentity);
+         if (strlen(lastentity) > 0)
+            AddNodeContent(xmlparent, lastentity);
          // do not forget to cleanup content node
          FreeNode(contnode);
          contnode = 0;
@@ -1671,30 +1790,43 @@ XMLNodePointer_t TXMLEngine::ReadNode(XMLNodePointer_t xmlparent, TXMLInputStrea
       return contnode;
    } else {
       // skip "<" symbol
-      if (!inp->ShiftCurrent()) return 0;
+      if (!inp->ShiftCurrent())
+         return 0;
    }
 
-   if (*inp->fCurrent=='/') {
+   if (*inp->fCurrent == '/') {
       // this is a starting of closing node
-      if (!inp->ShiftCurrent()) return 0;
-      if (!inp->SkipSpaces()) return 0;
+      if (!inp->ShiftCurrent())
+         return 0;
+      if (!inp->SkipSpaces())
+         return 0;
       Int_t len = inp->LocateIdentifier();
-      if (len<=0) { resvalue = -3; return 0; }
+      if (len <= 0) {
+         resvalue = -3;
+         return 0;
+      }
 
-      if (parent==0) { resvalue = -4; return 0; }
+      if (parent == 0) {
+         resvalue = -4;
+         return 0;
+      }
 
-      if (strncmp(SXmlNode_t::Name(parent), inp->fCurrent, len)!=0) {
+      if (strncmp(SXmlNode_t::Name(parent), inp->fCurrent, len) != 0) {
          resvalue = -5;
          return 0;
       }
 
-      if (!inp->ShiftCurrent(len)) return 0;
+      if (!inp->ShiftCurrent(len))
+         return 0;
 
-      if (!inp->SkipSpaces())   return 0;
-      if (*inp->fCurrent!='>')  return 0;
-      if (!inp->ShiftCurrent()) return 0;
+      if (!inp->SkipSpaces())
+         return 0;
+      if (*inp->fCurrent != '>')
+         return 0;
+      if (!inp->ShiftCurrent())
+         return 0;
 
-      if (parent->fNs!=0)
+      if (parent->fNs != 0)
          TruncateNsExtension((XMLNodePointer_t)parent);
 
       inp->SkipSpaces(kTRUE); // locate start of next string
@@ -1702,69 +1834,138 @@ XMLNodePointer_t TXMLEngine::ReadNode(XMLNodePointer_t xmlparent, TXMLInputStrea
       return 0;
    }
 
-   if (*inp->fCurrent=='!') {
+   if (*inp->fCurrent == '!') {
       // this is start of DTD reading, only limited number of features are supported
-      if (!inp->ShiftCurrent()) return 0;
-      if (!inp->CheckFor("DOCTYPE")) { resvalue = -12; return 0; }
-      if (!inp->SkipSpaces()) { resvalue = -13; return 0; }
+      if (!inp->ShiftCurrent())
+         return 0;
+      if (!inp->CheckFor("DOCTYPE")) {
+         resvalue = -12;
+         return 0;
+      }
+      if (!inp->SkipSpaces()) {
+         resvalue = -13;
+         return 0;
+      }
 
       // now skip name of the root element - it is not verified at all
       Int_t len = inp->LocateIdentifier();
-      if (len<=0) { resvalue = -13; return 0; }
-      if (!inp->ShiftCurrent(len)) { resvalue = -13; return 0; }
-      if (!inp->SkipSpaces()) { resvalue = -13; return 0; }
+      if (len <= 0) {
+         resvalue = -13;
+         return 0;
+      }
+      if (!inp->ShiftCurrent(len)) {
+         resvalue = -13;
+         return 0;
+      }
+      if (!inp->SkipSpaces()) {
+         resvalue = -13;
+         return 0;
+      }
 
       // this is start of reading ENTITIES
       if (inp->CheckFor("[")) {
-         if (!inp->SkipSpaces()) return 0;
+         if (!inp->SkipSpaces())
+            return 0;
          while (true) {
             if (inp->CheckFor("<!ENTITY")) {
                // process ENTITY from DTD
-               if (!inp->SkipSpaces()) { resvalue = -13; return 0; }
+               if (!inp->SkipSpaces()) {
+                  resvalue = -13;
+                  return 0;
+               }
                Int_t namelen = inp->LocateIdentifier();
-               if (namelen<=0) { resvalue = -13; return 0; }
+               if (namelen <= 0) {
+                  resvalue = -13;
+                  return 0;
+               }
                TString entity_name(inp->fCurrent, namelen);
-               if (!inp->ShiftCurrent(namelen)) { resvalue = -13; return 0; }
-               if (!inp->SkipSpaces()) { resvalue = -13; return 0; }
+               if (!inp->ShiftCurrent(namelen)) {
+                  resvalue = -13;
+                  return 0;
+               }
+               if (!inp->SkipSpaces()) {
+                  resvalue = -13;
+                  return 0;
+               }
                Bool_t is_system = kFALSE;
                if (inp->CheckFor("SYSTEM")) {
-                  if (!inp->SkipSpaces()) { resvalue = -13; return 0; }
+                  if (!inp->SkipSpaces()) {
+                     resvalue = -13;
+                     return 0;
+                  }
                   is_system = kTRUE;
                }
 
-               char* valuestart = inp->fCurrent;
+               char *valuestart = inp->fCurrent;
                Int_t valuelen = inp->LocateValue(valuestart, false);
-               if (valuelen < 2) { resvalue = -13; return 0; }
+               if (valuelen < 2) {
+                  resvalue = -13;
+                  return 0;
+               }
 
-               TString entity_value(valuestart+1, valuelen-2);
+               TString entity_value(valuestart + 1, valuelen - 2);
 
-               if (!inp->ShiftCurrent(valuelen)) { resvalue = -13; return 0; }
+               if (!inp->ShiftCurrent(valuelen)) {
+                  resvalue = -13;
+                  return 0;
+               }
                inp->SkipSpaces();
-               if (*inp->fCurrent!='>') { resvalue = -13; return 0; }
-               if (!inp->ShiftCurrent()) { resvalue = -13; return 0; }
+               if (*inp->fCurrent != '>') {
+                  resvalue = -13;
+                  return 0;
+               }
+               if (!inp->ShiftCurrent()) {
+                  resvalue = -13;
+                  return 0;
+               }
                inp->SkipSpaces();
 
                inp->AddEntity(new TXMLEntity(entity_name, entity_value, is_system));
                continue;
 
-               // printf("Entity:%s system:%s value:%s\n", entity_name.Data(), is_system ? "true" : "false", entity_value.Data());
+               // printf("Entity:%s system:%s value:%s\n", entity_name.Data(), is_system ? "true" : "false",
+               // entity_value.Data());
             }
 
             if (inp->CheckFor("<!ELEMENT")) {
                // process ELEMENT from DTD - dummy at the moment
-               if (!inp->SkipSpaces()) { resvalue = -13; return 0; }
+               if (!inp->SkipSpaces()) {
+                  resvalue = -13;
+                  return 0;
+               }
                Int_t namelen = inp->LocateIdentifier();
-               if (namelen<=0) { resvalue = -13; return 0; }
+               if (namelen <= 0) {
+                  resvalue = -13;
+                  return 0;
+               }
 
-               if (!inp->ShiftCurrent(namelen)) { resvalue = -13; return 0; }
-               if (!inp->SkipSpaces()) { resvalue = -13; return 0; }
+               if (!inp->ShiftCurrent(namelen)) {
+                  resvalue = -13;
+                  return 0;
+               }
+               if (!inp->SkipSpaces()) {
+                  resvalue = -13;
+                  return 0;
+               }
 
-               if (!inp->CheckFor("(")) { resvalue = -13; return 0; }
-               if (inp->SearchFor(")")<=0) { resvalue = -13; return 0; }
+               if (!inp->CheckFor("(")) {
+                  resvalue = -13;
+                  return 0;
+               }
+               if (inp->SearchFor(")") <= 0) {
+                  resvalue = -13;
+                  return 0;
+               }
 
                inp->SkipSpaces();
-               if (*inp->fCurrent!='>') { resvalue = -13; return 0; }
-               if (!inp->ShiftCurrent()) { resvalue = -13; return 0; }
+               if (*inp->fCurrent != '>') {
+                  resvalue = -13;
+                  return 0;
+               }
+               if (!inp->ShiftCurrent()) {
+                  resvalue = -13;
+                  return 0;
+               }
                inp->SkipSpaces();
 
                continue;
@@ -1773,10 +1974,16 @@ XMLNodePointer_t TXMLEngine::ReadNode(XMLNodePointer_t xmlparent, TXMLInputStrea
             break;
          }
 
-         if (!inp->CheckFor("]")) { resvalue = -13; return 0; }
+         if (!inp->CheckFor("]")) {
+            resvalue = -13;
+            return 0;
+         }
       }
       inp->SkipSpaces();
-      if (!inp->CheckFor(">")) { resvalue = -13; return 0; }
+      if (!inp->CheckFor(">")) {
+         resvalue = -13;
+         return 0;
+      }
 
       resvalue = 2;
       return node;
@@ -1787,94 +1994,113 @@ XMLNodePointer_t TXMLEngine::ReadNode(XMLNodePointer_t xmlparent, TXMLInputStrea
    char endsymbol = '/';
 
    // this is case of processing instructions node
-   if (*inp->fCurrent=='?') {
-      if (!inp->ShiftCurrent()) return 0;
+   if (*inp->fCurrent == '?') {
+      if (!inp->ShiftCurrent())
+         return 0;
       nodetype = kXML_PI_NODE;
       canhaschildren = false;
       endsymbol = '?';
    }
 
-   if (!inp->SkipSpaces()) return 0;
+   if (!inp->SkipSpaces())
+      return 0;
    Int_t len = inp->LocateIdentifier();
-   if (len<=0) return 0;
-   node = (SXmlNode_t*) AllocateNode(len, xmlparent);
-   char* nameptr = SXmlNode_t::Name(node);
+   if (len <= 0)
+      return 0;
+   node = (SXmlNode_t *)AllocateNode(len, xmlparent);
+   char *nameptr = SXmlNode_t::Name(node);
    node->fType = nodetype;
 
    strncpy(nameptr, inp->fCurrent, len); // here copied content without padding 0
-   nameptr+=len;
+   nameptr += len;
    *nameptr = 0; // add 0 to the end
 
-   char* colon = strchr(SXmlNode_t::Name(node),':');
-   if ((colon!=0) && (parent!=0)) {
+   char *colon = strchr(SXmlNode_t::Name(node), ':');
+   if ((colon != 0) && (parent != 0)) {
       *colon = 0;
-      node->fNs = (SXmlAttr_t*) FindNs(xmlparent, SXmlNode_t::Name(node));
-      *colon =':';
+      node->fNs = (SXmlAttr_t *)FindNs(xmlparent, SXmlNode_t::Name(node));
+      *colon = ':';
    }
 
-   if (!inp->ShiftCurrent(len)) return 0;
+   if (!inp->ShiftCurrent(len))
+      return 0;
 
    do {
-      if (!inp->SkipSpaces()) return 0;
+      if (!inp->SkipSpaces())
+         return 0;
 
       char nextsymb = *inp->fCurrent;
 
-      if (nextsymb==endsymbol) {  // this is end of short node like <node ... />
-         if (!inp->ShiftCurrent()) return 0;
-         if (*inp->fCurrent=='>') {
-            if (!inp->ShiftCurrent()) return 0;
+      if (nextsymb == endsymbol) { // this is end of short node like <node ... />
+         if (!inp->ShiftCurrent())
+            return 0;
+         if (*inp->fCurrent == '>') {
+            if (!inp->ShiftCurrent())
+               return 0;
 
-            if (node->fNs!=0)
-               TruncateNsExtension((XMLNodePointer_t) node);
+            if (node->fNs != 0)
+               TruncateNsExtension((XMLNodePointer_t)node);
 
             inp->SkipSpaces(kTRUE); // locate start of next string
             resvalue = 2;
             return node;
-         } else return 0;
-      } else
-      if (nextsymb=='>') { // this is end of parent node, lets find all children
-         if (!canhaschildren) { resvalue = -11; return 0; }
+         } else
+            return 0;
+      } else if (nextsymb == '>') { // this is end of parent node, lets find all children
+         if (!canhaschildren) {
+            resvalue = -11;
+            return 0;
+         }
 
-         if (!inp->ShiftCurrent()) return 0;
+         if (!inp->ShiftCurrent())
+            return 0;
 
          do {
             ReadNode(node, inp, resvalue);
-         } while (resvalue==2);
+         } while (resvalue == 2);
 
-         if (resvalue==1) {
+         if (resvalue == 1) {
             resvalue = 2;
             return node;
-         } else return 0;
+         } else
+            return 0;
       } else {
          Int_t attrlen = inp->LocateIdentifier();
-         if (attrlen<=0) { resvalue = -6; return 0; }
+         if (attrlen <= 0) {
+            resvalue = -6;
+            return 0;
+         }
 
-         char* valuestart = inp->fCurrent+attrlen;
+         char *valuestart = inp->fCurrent + attrlen;
 
          int valuelen = inp->LocateValue(valuestart, true);
-         if (valuelen<3) { resvalue = -7; return 0; }
+         if (valuelen < 3) {
+            resvalue = -7;
+            return 0;
+         }
 
-         SXmlAttr_t* attr = (SXmlAttr_t*) AllocateAttr(attrlen, valuelen-3, (XMLNodePointer_t) node);
+         SXmlAttr_t *attr = (SXmlAttr_t *)AllocateAttr(attrlen, valuelen - 3, (XMLNodePointer_t)node);
 
-         char* attrname = SXmlAttr_t::Name(attr);
+         char *attrname = SXmlAttr_t::Name(attr);
          strncpy(attrname, inp->fCurrent, attrlen);
-         attrname+=attrlen;
+         attrname += attrlen;
          *attrname = 0;
          attrname++;
-         UnpackSpecialCharacters(attrname, valuestart+2, valuelen-3);
+         UnpackSpecialCharacters(attrname, valuestart + 2, valuelen - 3);
 
-         if (!inp->ShiftCurrent(attrlen+valuelen)) return 0;
+         if (!inp->ShiftCurrent(attrlen + valuelen))
+            return 0;
 
          attrname = SXmlAttr_t::Name(attr);
 
-         if ((strlen(attrname)>6) && (strstr(attrname,"xmlns:")==attrname)) {
-            if (strcmp(SXmlNode_t::Name(node), attrname + 6)!=0) {
+         if ((strlen(attrname) > 6) && (strstr(attrname, "xmlns:") == attrname)) {
+            if (strcmp(SXmlNode_t::Name(node), attrname + 6) != 0) {
                resvalue = -8;
-               //return 0;
+               // return 0;
             }
-            if (node->fNs!=0) {
+            if (node->fNs != 0) {
                resvalue = -9;
-               //return 0;
+               // return 0;
             }
             node->fNs = attr;
          }
@@ -1889,21 +2115,25 @@ XMLNodePointer_t TXMLEngine::ReadNode(XMLNodePointer_t xmlparent, TXMLInputStrea
 
 void TXMLEngine::DisplayError(Int_t error, Int_t linenumber)
 {
-   switch(error) {
-      case -14: Error("ParseFile", "Error include external XML file at line %d", linenumber); break;
-      case -13: Error("ParseFile", "Error processing DTD part of XML file at line %d", linenumber); break;
-      case -12: Error("ParseFile", "DOCTYPE missing after <! at line %d", linenumber); break;
-      case -11: Error("ParseFile", "Node cannot be closed with > symbol at line %d, for instance <?xml ... ?> node", linenumber); break;
-      case -10: Error("ParseFile", "Error in xml comments definition at line %d, must be <!-- comments -->", linenumber); break;
-      case -9: Error("ParseFile", "Multiple name space definitions not allowed, line %d", linenumber); break;
-      case -8: Error("ParseFile", "Invalid namespace specification, line %d", linenumber); break;
-      case -7: Error("ParseFile", "Invalid attribute value, line %d", linenumber); break;
-      case -6: Error("ParseFile", "Invalid identifier for node attribute, line %d", linenumber); break;
-      case -5: Error("ParseFile", "Mismatch between open and close nodes, line %d", linenumber); break;
-      case -4: Error("ParseFile", "Unexpected close node, line %d", linenumber); break;
-      case -3: Error("ParseFile", "Valid identifier for close node is missing, line %d", linenumber); break;
-      case -2: Error("ParseFile", "No multiple content entries allowed, line %d", linenumber); break;
-      case -1: Error("ParseFile", "Unexpected end of xml file"); break;
-      default: Error("ParseFile", "XML syntax error at line %d", linenumber); break;
+   switch (error) {
+   case -14: Error("ParseFile", "Error include external XML file at line %d", linenumber); break;
+   case -13: Error("ParseFile", "Error processing DTD part of XML file at line %d", linenumber); break;
+   case -12: Error("ParseFile", "DOCTYPE missing after <! at line %d", linenumber); break;
+   case -11:
+      Error("ParseFile", "Node cannot be closed with > symbol at line %d, for instance <?xml ... ?> node", linenumber);
+      break;
+   case -10:
+      Error("ParseFile", "Error in xml comments definition at line %d, must be <!-- comments -->", linenumber);
+      break;
+   case -9: Error("ParseFile", "Multiple name space definitions not allowed, line %d", linenumber); break;
+   case -8: Error("ParseFile", "Invalid namespace specification, line %d", linenumber); break;
+   case -7: Error("ParseFile", "Invalid attribute value, line %d", linenumber); break;
+   case -6: Error("ParseFile", "Invalid identifier for node attribute, line %d", linenumber); break;
+   case -5: Error("ParseFile", "Mismatch between open and close nodes, line %d", linenumber); break;
+   case -4: Error("ParseFile", "Unexpected close node, line %d", linenumber); break;
+   case -3: Error("ParseFile", "Valid identifier for close node is missing, line %d", linenumber); break;
+   case -2: Error("ParseFile", "No multiple content entries allowed, line %d", linenumber); break;
+   case -1: Error("ParseFile", "Unexpected end of xml file"); break;
+   default: Error("ParseFile", "XML syntax error at line %d", linenumber); break;
    }
 }

--- a/io/xml/src/TXMLFile.cxx
+++ b/io/xml/src/TXMLFile.cxx
@@ -94,18 +94,11 @@ ClassImp(TXMLFile);
 ////////////////////////////////////////////////////////////////////////////////
 /// default TXMLFile constructor
 
-TXMLFile::TXMLFile() :
-   TFile(),
-   TXMLSetup(),
-   fDoc(0),
-   fStreamerInfoNode(0),
-   fXML(0),
-   fKeyCounter(0)
+TXMLFile::TXMLFile() : TFile(), TXMLSetup(), fDoc(0), fStreamerInfoNode(0), fXML(0), fKeyCounter(0)
 {
    SetBit(kBinaryFile, kFALSE);
-   fIOVersion  = TXMLFile::Class_Version();
+   fIOVersion = TXMLFile::Class_Version();
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Open or creates local XML file with name filename.
@@ -129,13 +122,8 @@ TXMLFile::TXMLFile() :
 ///
 /// For a moment TXMLFile does not support TTree objects and subdirectories
 
-TXMLFile::TXMLFile(const char* filename, Option_t* option, const char* title, Int_t compression) :
-   TFile(),
-   TXMLSetup(),
-   fDoc(0),
-   fStreamerInfoNode(0),
-   fXML(0),
-   fKeyCounter(0)
+TXMLFile::TXMLFile(const char *filename, Option_t *option, const char *title, Int_t compression)
+   : TFile(), TXMLSetup(), fDoc(0), fStreamerInfoNode(0), fXML(0), fKeyCounter(0)
 {
    fXML = new TXMLEngine();
 
@@ -150,40 +138,42 @@ TXMLFile::TXMLFile(const char* filename, Option_t* option, const char* title, In
    SetTitle(title);
    TDirectoryFile::Build(this, 0);
 
-   fD          = -1;
-   fFile       = this;
-   fFree       = 0;
-   fVersion    = gROOT->GetVersionInt();  //ROOT version in integer format
-   fUnits      = 4;
-   fOption     = option;
+   fD = -1;
+   fFile = this;
+   fFree = 0;
+   fVersion = gROOT->GetVersionInt(); // ROOT version in integer format
+   fUnits = 4;
+   fOption = option;
    SetCompressionSettings(compression);
-   fWritten    = 0;
-   fSumBuffer  = 0;
+   fWritten = 0;
+   fSumBuffer = 0;
    fSum2Buffer = 0;
-   fBytesRead  = 0;
+   fBytesRead = 0;
    fBytesWrite = 0;
    fClassIndex = 0;
-   fSeekInfo   = 0;
+   fSeekInfo = 0;
    fNbytesInfo = 0;
    fProcessIDs = 0;
-   fNProcessIDs= 0;
-   fIOVersion  = TXMLFile::Class_Version();
+   fNProcessIDs = 0;
+   fIOVersion = TXMLFile::Class_Version();
    SetBit(kBinaryFile, kFALSE);
 
    fOption = option;
    fOption.ToUpper();
 
-   if (fOption == "NEW") fOption = "CREATE";
+   if (fOption == "NEW")
+      fOption = "CREATE";
 
-   Bool_t create   = (fOption == "CREATE") ? kTRUE : kFALSE;
+   Bool_t create = (fOption == "CREATE") ? kTRUE : kFALSE;
    Bool_t recreate = (fOption == "RECREATE") ? kTRUE : kFALSE;
-   Bool_t update   = (fOption == "UPDATE") ? kTRUE : kFALSE;
-   Bool_t read     = (fOption == "READ") ? kTRUE : kFALSE;
+   Bool_t update = (fOption == "UPDATE") ? kTRUE : kFALSE;
+   Bool_t read = (fOption == "READ") ? kTRUE : kFALSE;
    Bool_t xmlsetup = IsValidXmlSetup(option);
-   if (xmlsetup) recreate = kTRUE;
+   if (xmlsetup)
+      recreate = kTRUE;
 
    if (!create && !recreate && !update && !read) {
-      read    = kTRUE;
+      read = kTRUE;
       fOption = "READ";
    }
 
@@ -196,14 +186,13 @@ TXMLFile::TXMLFile(const char* filename, Option_t* option, const char* title, In
    }
 
    // support dumping to /dev/null on UNIX
-   if (!strcmp(filename, "/dev/null") &&
-       !gSystem->AccessPathName(filename, kWritePermission)) {
-      devnull  = kTRUE;
-      create   = kTRUE;
+   if (!strcmp(filename, "/dev/null") && !gSystem->AccessPathName(filename, kWritePermission)) {
+      devnull = kTRUE;
+      create = kTRUE;
       recreate = kFALSE;
-      update   = kFALSE;
-      read     = kFALSE;
-      fOption  = "CREATE";
+      update = kFALSE;
+      read = kFALSE;
+      fOption = "CREATE";
       SetBit(TFile::kDevNull);
    }
 
@@ -212,7 +201,7 @@ TXMLFile::TXMLFile(const char* filename, Option_t* option, const char* title, In
    fname = gSystem->ExpandPathName(filename);
    if (fname) {
       SetName(fname);
-      delete [] (char*)fname;
+      delete[](char *) fname;
       fname = GetName();
    } else {
       Error("TXMLFile", "error expanding path %s", filename);
@@ -223,8 +212,8 @@ TXMLFile::TXMLFile(const char* filename, Option_t* option, const char* title, In
       if (!gSystem->AccessPathName(fname, kFileExists))
          gSystem->Unlink(fname);
       recreate = kFALSE;
-      create   = kTRUE;
-      fOption  = "CREATE";
+      create = kTRUE;
+      fOption = "CREATE";
    }
 
    if (create && !devnull && !gSystem->AccessPathName(fname, kFileExists)) {
@@ -283,8 +272,9 @@ zombie:
 
 void TXMLFile::InitXmlFile(Bool_t create)
 {
-   Int_t len = gROOT->GetListOfStreamerInfo()->GetSize()+1;
-   if (len<5000) len = 5000;
+   Int_t len = gROOT->GetListOfStreamerInfo()->GetSize() + 1;
+   if (len < 5000)
+      len = 5000;
    fClassIndex = new TArrayC(len);
    fClassIndex->Reset(0);
 
@@ -303,13 +293,14 @@ void TXMLFile::InitXmlFile(Bool_t create)
    cd();
 
    fNProcessIDs = 0;
-   TKey* key = 0;
+   TKey *key = 0;
    TIter iter(fKeys);
-   while ((key = (TKey*)iter())!=0) {
-      if (!strcmp(key->GetClassName(),"TProcessID")) fNProcessIDs++;
+   while ((key = (TKey *)iter()) != 0) {
+      if (!strcmp(key->GetClassName(), "TProcessID"))
+         fNProcessIDs++;
    }
 
-   fProcessIDs = new TObjArray(fNProcessIDs+1);
+   fProcessIDs = new TObjArray(fNProcessIDs + 1);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -318,13 +309,15 @@ void TXMLFile::InitXmlFile(Bool_t create)
 
 void TXMLFile::Close(Option_t *option)
 {
-   if (!IsOpen()) return;
+   if (!IsOpen())
+      return;
 
    TString opt = option;
-   if (opt.Length()>0)
+   if (opt.Length() > 0)
       opt.ToLower();
 
-   if (IsWritable()) SaveToFile();
+   if (IsWritable())
+      SaveToFile();
 
    fWritable = kFALSE;
 
@@ -349,14 +342,15 @@ void TXMLFile::Close(Option_t *option)
       TDirectoryFile::Close();
    }
 
-   //delete the TProcessIDs
+   // delete the TProcessIDs
    TList pidDeleted;
    TIter next(fProcessIDs);
    TProcessID *pid;
-   while ((pid = (TProcessID*)next())) {
+   while ((pid = (TProcessID *)next())) {
       if (!pid->DecrementCount()) {
-         if (pid != TProcessID::GetSessionProcessID()) pidDeleted.Add(pid);
-      } else if(opt.Contains("r")) {
+         if (pid != TProcessID::GetSessionProcessID())
+            pidDeleted.Add(pid);
+      } else if (opt.Contains("r")) {
          pid->Clear();
       }
    }
@@ -373,7 +367,7 @@ TXMLFile::~TXMLFile()
 {
    Close();
 
-   if (fXML!=0) {
+   if (fXML != 0) {
       delete fXML;
       fXML = 0;
    }
@@ -398,7 +392,7 @@ Bool_t TXMLFile::IsOpen() const
 /// Reopen a file with a different access mode, like from READ to
 /// See TFile::Open() for details
 
-Int_t TXMLFile::ReOpen(Option_t* mode)
+Int_t TXMLFile::ReOpen(Option_t *mode)
 {
    cd();
 
@@ -434,7 +428,7 @@ Int_t TXMLFile::ReOpen(Option_t* mode)
 ////////////////////////////////////////////////////////////////////////////////
 /// create XML key, which will store object in xml structures
 
-TKey* TXMLFile::CreateKey(TDirectory* mother, const TObject* obj, const char* name, Int_t)
+TKey *TXMLFile::CreateKey(TDirectory *mother, const TObject *obj, const char *name, Int_t)
 {
    return new TKeyXML(mother, ++fKeyCounter, obj, name);
 }
@@ -442,7 +436,7 @@ TKey* TXMLFile::CreateKey(TDirectory* mother, const TObject* obj, const char* na
 ////////////////////////////////////////////////////////////////////////////////
 /// create XML key, which will store object in xml structures
 
-TKey* TXMLFile::CreateKey(TDirectory* mother, const void* obj, const TClass* cl, const char* name, Int_t)
+TKey *TXMLFile::CreateKey(TDirectory *mother, const void *obj, const TClass *cl, const char *name, Int_t)
 {
    return new TKeyXML(mother, ++fKeyCounter, obj, cl, name);
 }
@@ -450,24 +444,24 @@ TKey* TXMLFile::CreateKey(TDirectory* mother, const void* obj, const TClass* cl,
 ////////////////////////////////////////////////////////////////////////////////
 /// function produces pair of xml and dtd file names
 
-void TXMLFile::ProduceFileNames(const char* filename, TString& fname, TString& dtdname)
+void TXMLFile::ProduceFileNames(const char *filename, TString &fname, TString &dtdname)
 {
    fname = filename;
    dtdname = filename;
 
    Bool_t hasxmlext = kFALSE;
 
-   if (fname.Length()>4) {
-      TString last = fname(fname.Length()-4,4);
+   if (fname.Length() > 4) {
+      TString last = fname(fname.Length() - 4, 4);
       last.ToLower();
-      hasxmlext = (last==".xml");
+      hasxmlext = (last == ".xml");
    }
 
    if (hasxmlext) {
-      dtdname.Replace(dtdname.Length()-4,4,".dtd");
+      dtdname.Replace(dtdname.Length() - 4, 4, ".dtd");
    } else {
-      fname+=".xml";
-      dtdname+=".dtd";
+      fname += ".xml";
+      dtdname += ".dtd";
    }
 }
 
@@ -482,10 +476,11 @@ void TXMLFile::ProduceFileNames(const char* filename, TString& fname, TString& d
 
 void TXMLFile::SaveToFile()
 {
-   if (fDoc==0) return;
+   if (fDoc == 0)
+      return;
 
-   if (gDebug>1)
-      Info("SaveToFile","File: %s",fRealName.Data());
+   if (gDebug > 1)
+      Info("SaveToFile", "File: %s", fRealName.Data());
 
    XMLNodePointer_t fRootNode = fXML->DocGetRootElement(fDoc);
 
@@ -495,7 +490,7 @@ void TXMLFile::SaveToFile()
    fXML->FreeAttr(fRootNode, xmlio::Ref);
    fXML->NewAttr(fRootNode, 0, xmlio::Ref, xmlio::Null);
 
-   if (GetIOVersion()>1) {
+   if (GetIOVersion() > 1) {
 
       fXML->FreeAttr(fRootNode, xmlio::CreateTm);
       fXML->NewAttr(fRootNode, 0, xmlio::CreateTm, fDatimeC.AsSQLString());
@@ -507,7 +502,7 @@ void TXMLFile::SaveToFile()
       fXML->NewAttr(fRootNode, 0, xmlio::ObjectUUID, fUUID.AsString());
 
       fXML->FreeAttr(fRootNode, xmlio::Title);
-      if (strlen(GetTitle())>0)
+      if (strlen(GetTitle()) > 0)
          fXML->NewAttr(fRootNode, 0, xmlio::Title, GetTitle());
 
       fXML->FreeAttr(fRootNode, xmlio::IOVersion);
@@ -520,12 +515,12 @@ void TXMLFile::SaveToFile()
    TString fname, dtdname;
    ProduceFileNames(fRealName, fname, dtdname);
 
-/*
-   TIter iter(GetListOfKeys());
-   TKeyXML* key = 0;
-   while ((key=(TKeyXML*)iter()) !=0)
-      fXML->AddChild(fRootNode, key->KeyNode());
-*/
+   /*
+      TIter iter(GetListOfKeys());
+      TKeyXML* key = 0;
+      while ((key=(TKeyXML*)iter()) !=0)
+         fXML->AddChild(fRootNode, key->KeyNode());
+   */
 
    CombineNodesTree(this, fRootNode, kTRUE);
 
@@ -534,14 +529,14 @@ void TXMLFile::SaveToFile()
    if (fStreamerInfoNode)
       fXML->AddChild(fRootNode, fStreamerInfoNode);
 
-   Int_t layout = GetCompressionLevel()>5 ? 0 : 1;
+   Int_t layout = GetCompressionLevel() > 5 ? 0 : 1;
 
    fXML->SaveDoc(fDoc, fname, layout);
 
-/*   iter.Reset();
-   while ((key=(TKeyXML*)iter()) !=0)
-      fXML->UnlinkNode(key->KeyNode());
-*/
+   /*   iter.Reset();
+      while ((key=(TKeyXML*)iter()) !=0)
+         fXML->UnlinkNode(key->KeyNode());
+   */
    CombineNodesTree(this, fRootNode, kFALSE);
 
    if (fStreamerInfoNode)
@@ -551,14 +546,15 @@ void TXMLFile::SaveToFile()
 ////////////////////////////////////////////////////////////////////////////////
 /// Connect/disconnect all file nodes to single tree before/after saving
 
-void TXMLFile::CombineNodesTree(TDirectory* dir, XMLNodePointer_t topnode, Bool_t dolink)
+void TXMLFile::CombineNodesTree(TDirectory *dir, XMLNodePointer_t topnode, Bool_t dolink)
 {
-   if (dir==0) return;
+   if (dir == 0)
+      return;
 
    TIter iter(dir->GetListOfKeys());
-   TKeyXML* key = 0;
+   TKeyXML *key = 0;
 
-   while ((key=(TKeyXML*)iter()) !=0) {
+   while ((key = (TKeyXML *)iter()) != 0) {
       if (dolink)
          fXML->AddChild(topnode, key->KeyNode());
       else
@@ -567,7 +563,6 @@ void TXMLFile::CombineNodesTree(TDirectory* dir, XMLNodePointer_t topnode, Bool_
          CombineNodesTree(FindKeyDir(dir, key->GetKeyId()), key->KeyNode(), dolink);
    }
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// read document from file
@@ -578,13 +573,14 @@ void TXMLFile::CombineNodesTree(TDirectory* dir, XMLNodePointer_t topnode, Bool_
 Bool_t TXMLFile::ReadFromFile()
 {
    fDoc = fXML->ParseFile(fRealName);
-   if (fDoc==0) return kFALSE;
+   if (fDoc == 0)
+      return kFALSE;
 
    XMLNodePointer_t fRootNode = fXML->DocGetRootElement(fDoc);
 
-   if ((fRootNode==0) || !fXML->ValidateVersion(fDoc)) {
+   if ((fRootNode == 0) || !fXML->ValidateVersion(fDoc)) {
       fXML->FreeDoc(fDoc);
-      fDoc=0;
+      fDoc = 0;
       return kFALSE;
    }
 
@@ -618,19 +614,20 @@ Bool_t TXMLFile::ReadFromFile()
 
    fStreamerInfoNode = fXML->GetChild(fRootNode);
    fXML->SkipEmpty(fStreamerInfoNode);
-   while (fStreamerInfoNode!=0) {
-      if (strcmp(xmlio::SInfos, fXML->GetNodeName(fStreamerInfoNode))==0) break;
+   while (fStreamerInfoNode != 0) {
+      if (strcmp(xmlio::SInfos, fXML->GetNodeName(fStreamerInfoNode)) == 0)
+         break;
       fXML->ShiftToNext(fStreamerInfoNode);
    }
    fXML->UnlinkNode(fStreamerInfoNode);
 
-   if (fStreamerInfoNode!=0)
+   if (fStreamerInfoNode != 0)
       ReadStreamerInfo();
 
    if (IsUseDtd())
-      if (!fXML->ValidateDocument(fDoc, gDebug>0)) {
+      if (!fXML->ValidateDocument(fDoc, gDebug > 0)) {
          fXML->FreeDoc(fDoc);
-         fDoc=0;
+         fDoc = 0;
          return kFALSE;
       }
 
@@ -644,25 +641,26 @@ Bool_t TXMLFile::ReadFromFile()
 ////////////////////////////////////////////////////////////////////////////////
 /// Read list of keys for directory
 
-Int_t TXMLFile::ReadKeysList(TDirectory* dir, XMLNodePointer_t topnode)
+Int_t TXMLFile::ReadKeysList(TDirectory *dir, XMLNodePointer_t topnode)
 {
-   if ((dir==0) || (topnode==0)) return 0;
+   if ((dir == 0) || (topnode == 0))
+      return 0;
 
    Int_t nkeys = 0;
 
    XMLNodePointer_t keynode = fXML->GetChild(topnode);
    fXML->SkipEmpty(keynode);
-   while (keynode!=0) {
+   while (keynode != 0) {
       XMLNodePointer_t next = fXML->GetNext(keynode);
 
-      if (strcmp(xmlio::Xmlkey, fXML->GetNodeName(keynode))==0) {
+      if (strcmp(xmlio::Xmlkey, fXML->GetNodeName(keynode)) == 0) {
          fXML->UnlinkNode(keynode);
 
-         TKeyXML* key = new TKeyXML(dir, ++fKeyCounter, keynode);
+         TKeyXML *key = new TKeyXML(dir, ++fKeyCounter, keynode);
          dir->AppendKey(key);
 
-         if (gDebug>2)
-            Info("ReadKeysList","Add key %s from node %s",key->GetName(), fXML->GetNodeName(keynode));
+         if (gDebug > 2)
+            Info("ReadKeysList", "Add key %s from node %s", key->GetName(), fXML->GetNodeName(keynode));
 
          nkeys++;
       }
@@ -684,25 +682,27 @@ void TXMLFile::WriteStreamerInfo()
       fStreamerInfoNode = 0;
    }
 
-   if (!IsStoreStreamerInfos()) return;
+   if (!IsStoreStreamerInfos())
+      return;
 
    TObjArray list;
 
    TIter iter(gROOT->GetListOfStreamerInfo());
 
-   TStreamerInfo* info = 0;
+   TStreamerInfo *info = 0;
 
-   while ((info = (TStreamerInfo*) iter()) !=0 ) {
+   while ((info = (TStreamerInfo *)iter()) != 0) {
       Int_t uid = info->GetNumber();
       if (fClassIndex->fArray[uid])
          list.Add(info);
    }
 
-   if (list.GetSize()==0) return;
+   if (list.GetSize() == 0)
+      return;
 
    fStreamerInfoNode = fXML->NewChild(0, 0, xmlio::SInfos);
-   for (int n=0;n<=list.GetLast();n++) {
-      info  = (TStreamerInfo*) list.At(n);
+   for (int n = 0; n <= list.GetLast(); n++) {
+      info = (TStreamerInfo *)list.At(n);
 
       XMLNodePointer_t infonode = fXML->NewChild(fStreamerInfoNode, 0, "TStreamerInfo");
 
@@ -711,12 +711,13 @@ void TXMLFile::WriteStreamerInfo()
 
       fXML->NewIntAttr(infonode, "v", info->IsA()->GetClassVersion());
       fXML->NewIntAttr(infonode, "classversion", info->GetClassVersion());
-      fXML->NewAttr(infonode, 0, "canoptimize", (info->TestBit(TStreamerInfo::kCannotOptimize) ? xmlio::False : xmlio::True));
+      fXML->NewAttr(infonode, 0, "canoptimize",
+                    (info->TestBit(TStreamerInfo::kCannotOptimize) ? xmlio::False : xmlio::True));
       fXML->NewIntAttr(infonode, "checksum", info->GetCheckSum());
 
       TIter iter2(info->GetElements());
-      TStreamerElement* elem=0;
-      while ((elem= (TStreamerElement*) iter2()) != 0) {
+      TStreamerElement *elem = 0;
+      while ((elem = (TStreamerElement *)iter2()) != 0) {
          StoreStreamerElement(infonode, elem);
       }
    }
@@ -726,40 +727,41 @@ void TXMLFile::WriteStreamerInfo()
 /// Read streamerinfo structures from xml format and provide them in the list
 /// It is user responsibility to destroy this list
 
-TList* TXMLFile::GetStreamerInfoList()
+TList *TXMLFile::GetStreamerInfoList()
 {
-   if (fStreamerInfoNode==0) return 0;
+   if (fStreamerInfoNode == 0)
+      return 0;
 
-   TList* list = new TList();
+   TList *list = new TList();
 
    XMLNodePointer_t sinfonode = fXML->GetChild(fStreamerInfoNode);
    fXML->SkipEmpty(sinfonode);
 
-   while (sinfonode!=0) {
-      if (strcmp("TStreamerInfo",fXML->GetNodeName(sinfonode))==0) {
-         TString fname = fXML->GetAttr(sinfonode,"name");
-         TString ftitle = fXML->GetAttr(sinfonode,"title");
+   while (sinfonode != 0) {
+      if (strcmp("TStreamerInfo", fXML->GetNodeName(sinfonode)) == 0) {
+         TString fname = fXML->GetAttr(sinfonode, "name");
+         TString ftitle = fXML->GetAttr(sinfonode, "title");
 
-         TStreamerInfo* info = new TStreamerInfo(TClass::GetClass(fname));
+         TStreamerInfo *info = new TStreamerInfo(TClass::GetClass(fname));
          info->SetTitle(ftitle);
 
          list->Add(info);
 
-         Int_t clversion = AtoI(fXML->GetAttr(sinfonode,"classversion"));
+         Int_t clversion = AtoI(fXML->GetAttr(sinfonode, "classversion"));
          info->SetClassVersion(clversion);
          info->SetOnFileClassVersion(clversion);
-         Int_t checksum = AtoI(fXML->GetAttr(sinfonode,"checksum"));
+         Int_t checksum = AtoI(fXML->GetAttr(sinfonode, "checksum"));
          info->SetCheckSum(checksum);
 
-         const char* canoptimize = fXML->GetAttr(sinfonode,"canoptimize");
-         if ((canoptimize==0) || (strcmp(canoptimize,xmlio::False)==0))
+         const char *canoptimize = fXML->GetAttr(sinfonode, "canoptimize");
+         if ((canoptimize == 0) || (strcmp(canoptimize, xmlio::False) == 0))
             info->SetBit(TStreamerInfo::kCannotOptimize);
          else
             info->ResetBit(TStreamerInfo::kCannotOptimize);
 
          XMLNodePointer_t node = fXML->GetChild(sinfonode);
          fXML->SkipEmpty(node);
-         while (node!=0) {
+         while (node != 0) {
             ReadStreamerElement(node, info);
             fXML->ShiftToNext(node);
          }
@@ -775,57 +777,54 @@ TList* TXMLFile::GetStreamerInfoList()
 ////////////////////////////////////////////////////////////////////////////////
 /// store data of single TStreamerElement in streamer node
 
-void TXMLFile::StoreStreamerElement(XMLNodePointer_t infonode, TStreamerElement* elem)
+void TXMLFile::StoreStreamerElement(XMLNodePointer_t infonode, TStreamerElement *elem)
 {
-   TClass* cl = elem->IsA();
+   TClass *cl = elem->IsA();
 
    XMLNodePointer_t node = fXML->NewChild(infonode, 0, cl->GetName());
 
    char sbuf[100], namebuf[100];
 
-   fXML->NewAttr(node,0,"name",elem->GetName());
-   if (strlen(elem->GetTitle())>0)
-      fXML->NewAttr(node,0,"title",elem->GetTitle());
+   fXML->NewAttr(node, 0, "name", elem->GetName());
+   if (strlen(elem->GetTitle()) > 0)
+      fXML->NewAttr(node, 0, "title", elem->GetTitle());
 
    fXML->NewIntAttr(node, "v", cl->GetClassVersion());
 
    fXML->NewIntAttr(node, "type", elem->GetType());
 
-   if (strlen(elem->GetTypeName())>0)
-      fXML->NewAttr(node,0,"typename", elem->GetTypeName());
+   if (strlen(elem->GetTypeName()) > 0)
+      fXML->NewAttr(node, 0, "typename", elem->GetTypeName());
 
    fXML->NewIntAttr(node, "size", elem->GetSize());
 
-   if (elem->GetArrayDim()>0) {
+   if (elem->GetArrayDim() > 0) {
       fXML->NewIntAttr(node, "numdim", elem->GetArrayDim());
 
-      for (int ndim=0;ndim<elem->GetArrayDim();ndim++) {
+      for (int ndim = 0; ndim < elem->GetArrayDim(); ndim++) {
          sprintf(namebuf, "dim%d", ndim);
          fXML->NewIntAttr(node, namebuf, elem->GetMaxIndex(ndim));
       }
    }
 
    if (cl == TStreamerBase::Class()) {
-      TStreamerBase* base = (TStreamerBase*) elem;
+      TStreamerBase *base = (TStreamerBase *)elem;
       sprintf(sbuf, "%d", base->GetBaseVersion());
-      fXML->NewAttr(node,0, "baseversion", sbuf);
+      fXML->NewAttr(node, 0, "baseversion", sbuf);
       sprintf(sbuf, "%d", base->GetBaseCheckSum());
-      fXML->NewAttr(node,0, "basechecksum", sbuf);
-   } else
-   if (cl == TStreamerBasicPointer::Class()) {
-      TStreamerBasicPointer* bptr = (TStreamerBasicPointer*) elem;
+      fXML->NewAttr(node, 0, "basechecksum", sbuf);
+   } else if (cl == TStreamerBasicPointer::Class()) {
+      TStreamerBasicPointer *bptr = (TStreamerBasicPointer *)elem;
       fXML->NewIntAttr(node, "countversion", bptr->GetCountVersion());
       fXML->NewAttr(node, 0, "countname", bptr->GetCountName());
       fXML->NewAttr(node, 0, "countclass", bptr->GetCountClass());
-   } else
-   if (cl == TStreamerLoop::Class()) {
-      TStreamerLoop* loop = (TStreamerLoop*) elem;
+   } else if (cl == TStreamerLoop::Class()) {
+      TStreamerLoop *loop = (TStreamerLoop *)elem;
       fXML->NewIntAttr(node, "countversion", loop->GetCountVersion());
       fXML->NewAttr(node, 0, "countname", loop->GetCountName());
       fXML->NewAttr(node, 0, "countclass", loop->GetCountClass());
-   } else
-   if ((cl == TStreamerSTL::Class()) || (cl == TStreamerSTLstring::Class())) {
-      TStreamerSTL* stl = (TStreamerSTL*) elem;
+   } else if ((cl == TStreamerSTL::Class()) || (cl == TStreamerSTLstring::Class())) {
+      TStreamerSTL *stl = (TStreamerSTL *)elem;
       fXML->NewIntAttr(node, "STLtype", stl->GetSTLtype());
       fXML->NewIntAttr(node, "Ctype", stl->GetCtype());
    }
@@ -834,58 +833,55 @@ void TXMLFile::StoreStreamerElement(XMLNodePointer_t infonode, TStreamerElement*
 ////////////////////////////////////////////////////////////////////////////////
 /// read and reconstruct single TStreamerElement from xml node
 
-void TXMLFile::ReadStreamerElement(XMLNodePointer_t node, TStreamerInfo* info)
+void TXMLFile::ReadStreamerElement(XMLNodePointer_t node, TStreamerInfo *info)
 {
-   TClass* cl = TClass::GetClass(fXML->GetNodeName(node));
-   if ((cl==0) || !cl->InheritsFrom(TStreamerElement::Class())) return;
+   TClass *cl = TClass::GetClass(fXML->GetNodeName(node));
+   if ((cl == 0) || !cl->InheritsFrom(TStreamerElement::Class()))
+      return;
 
-   TStreamerElement* elem = (TStreamerElement*) cl->New();
+   TStreamerElement *elem = (TStreamerElement *)cl->New();
 
-   int elem_type = fXML->GetIntAttr(node,"type");
+   int elem_type = fXML->GetIntAttr(node, "type");
 
-   elem->SetName(fXML->GetAttr(node,"name"));
-   elem->SetTitle(fXML->GetAttr(node,"title"));
+   elem->SetName(fXML->GetAttr(node, "name"));
+   elem->SetTitle(fXML->GetAttr(node, "title"));
    elem->SetType(elem_type);
-   elem->SetTypeName(fXML->GetAttr(node,"typename"));
-   elem->SetSize(fXML->GetIntAttr(node,"size"));
-
+   elem->SetTypeName(fXML->GetAttr(node, "typename"));
+   elem->SetSize(fXML->GetIntAttr(node, "size"));
 
    if (cl == TStreamerBase::Class()) {
-      int basever = fXML->GetIntAttr(node,"baseversion");
-      ((TStreamerBase*) elem)->SetBaseVersion(basever);
-      Int_t baseCheckSum = fXML->GetIntAttr(node,"basechecksum");
-      ((TStreamerBase*) elem)->SetBaseCheckSum(baseCheckSum);
-   } else
-   if (cl == TStreamerBasicPointer::Class()) {
-      TString countname = fXML->GetAttr(node,"countname");
-      TString countclass = fXML->GetAttr(node,"countclass");
+      int basever = fXML->GetIntAttr(node, "baseversion");
+      ((TStreamerBase *)elem)->SetBaseVersion(basever);
+      Int_t baseCheckSum = fXML->GetIntAttr(node, "basechecksum");
+      ((TStreamerBase *)elem)->SetBaseCheckSum(baseCheckSum);
+   } else if (cl == TStreamerBasicPointer::Class()) {
+      TString countname = fXML->GetAttr(node, "countname");
+      TString countclass = fXML->GetAttr(node, "countclass");
       Int_t countversion = fXML->GetIntAttr(node, "countversion");
 
-      ((TStreamerBasicPointer*)elem)->SetCountVersion(countversion);
-      ((TStreamerBasicPointer*)elem)->SetCountName(countname);
-      ((TStreamerBasicPointer*)elem)->SetCountClass(countclass);
-   } else
-   if (cl == TStreamerLoop::Class()) {
-      TString countname = fXML->GetAttr(node,"countname");
-      TString countclass = fXML->GetAttr(node,"countclass");
-      Int_t countversion = fXML->GetIntAttr(node,"countversion");
-      ((TStreamerLoop*)elem)->SetCountVersion(countversion);
-      ((TStreamerLoop*)elem)->SetCountName(countname);
-      ((TStreamerLoop*)elem)->SetCountClass(countclass);
-   } else
-   if ((cl == TStreamerSTL::Class()) || (cl == TStreamerSTLstring::Class()))  {
-      int fSTLtype = fXML->GetIntAttr(node,"STLtype");
-      int fCtype = fXML->GetIntAttr(node,"Ctype");
-      ((TStreamerSTL*)elem)->SetSTLtype(fSTLtype);
-      ((TStreamerSTL*)elem)->SetCtype(fCtype);
+      ((TStreamerBasicPointer *)elem)->SetCountVersion(countversion);
+      ((TStreamerBasicPointer *)elem)->SetCountName(countname);
+      ((TStreamerBasicPointer *)elem)->SetCountClass(countclass);
+   } else if (cl == TStreamerLoop::Class()) {
+      TString countname = fXML->GetAttr(node, "countname");
+      TString countclass = fXML->GetAttr(node, "countclass");
+      Int_t countversion = fXML->GetIntAttr(node, "countversion");
+      ((TStreamerLoop *)elem)->SetCountVersion(countversion);
+      ((TStreamerLoop *)elem)->SetCountName(countname);
+      ((TStreamerLoop *)elem)->SetCountClass(countclass);
+   } else if ((cl == TStreamerSTL::Class()) || (cl == TStreamerSTLstring::Class())) {
+      int fSTLtype = fXML->GetIntAttr(node, "STLtype");
+      int fCtype = fXML->GetIntAttr(node, "Ctype");
+      ((TStreamerSTL *)elem)->SetSTLtype(fSTLtype);
+      ((TStreamerSTL *)elem)->SetCtype(fCtype);
    }
 
    char namebuf[100];
 
    if (fXML->HasAttr(node, "numdim")) {
-      int numdim = fXML->GetIntAttr(node,"numdim");
+      int numdim = fXML->GetIntAttr(node, "numdim");
       elem->SetArrayDim(numdim);
-      for (int ndim=0;ndim<numdim;ndim++) {
+      for (int ndim = 0; ndim < numdim; ndim++) {
          sprintf(namebuf, "dim%d", ndim);
          int maxi = fXML->GetIntAttr(node, namebuf);
          elem->SetMaxIndex(ndim, maxi);
@@ -925,7 +921,7 @@ void TXMLFile::ReadStreamerElement(XMLNodePointer_t node, TStreamerInfo* info)
 
 void TXMLFile::SetXmlLayout(EXMLLayout layout)
 {
-   if (IsWritable() && (GetListOfKeys()->GetSize()==0))
+   if (IsWritable() && (GetListOfKeys()->GetSize() == 0))
       TXMLSetup::SetXmlLayout(layout);
 }
 
@@ -937,7 +933,7 @@ void TXMLFile::SetXmlLayout(EXMLLayout layout)
 
 void TXMLFile::SetStoreStreamerInfos(Bool_t iConvert)
 {
-   if (IsWritable() &&  (GetListOfKeys()->GetSize()==0))
+   if (IsWritable() && (GetListOfKeys()->GetSize() == 0))
       TXMLSetup::SetStoreStreamerInfos(iConvert);
 }
 
@@ -948,7 +944,7 @@ void TXMLFile::SetStoreStreamerInfos(Bool_t iConvert)
 
 void TXMLFile::SetUsedDtd(Bool_t use)
 {
-   if (IsWritable() &&  (GetListOfKeys()->GetSize()==0))
+   if (IsWritable() && (GetListOfKeys()->GetSize() == 0))
       TXMLSetup::SetUsedDtd(use);
 }
 
@@ -968,7 +964,7 @@ void TXMLFile::SetUsedDtd(Bool_t use)
 
 void TXMLFile::SetUseNamespaces(Bool_t iUseNamespaces)
 {
-   if (IsWritable() && (GetListOfKeys()->GetSize()==0))
+   if (IsWritable() && (GetListOfKeys()->GetSize() == 0))
       TXMLSetup::SetUseNamespaces(iUseNamespaces);
 }
 
@@ -977,9 +973,10 @@ void TXMLFile::SetUseNamespaces(Bool_t iUseNamespaces)
 /// This line can only be seen in xml editor and cannot be accessed later
 /// with TXMLFile methods
 
-Bool_t TXMLFile::AddXmlComment(const char* comment)
+Bool_t TXMLFile::AddXmlComment(const char *comment)
 {
-   if (!IsWritable() || (fXML==0)) return kFALSE;
+   if (!IsWritable() || (fXML == 0))
+      return kFALSE;
 
    return fXML->AddDocComment(fDoc, comment);
 }
@@ -994,16 +991,13 @@ Bool_t TXMLFile::AddXmlComment(const char* comment)
 /// if alternate<0, attribute will not be created
 /// This style sheet definition cannot be later access with TXMLFile methods.
 
-Bool_t TXMLFile::AddXmlStyleSheet(const char* href,
-                                  const char* type,
-                                  const char* title,
-                                  int alternate,
-                                  const char* media,
-                                  const char* charset)
+Bool_t TXMLFile::AddXmlStyleSheet(const char *href, const char *type, const char *title, int alternate,
+                                  const char *media, const char *charset)
 {
-   if (!IsWritable() || (fXML==0)) return kFALSE;
+   if (!IsWritable() || (fXML == 0))
+      return kFALSE;
 
-   return fXML->AddDocStyleSheet(fDoc, href,type,title,alternate,media,charset);
+   return fXML->AddDocStyleSheet(fDoc, href, type, title, alternate, media, charset);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1013,9 +1007,10 @@ Bool_t TXMLFile::AddXmlStyleSheet(const char* href,
 /// To be parsed later by TXMLFile again, this line should contain either
 /// xml comments or xml processing instruction
 
-Bool_t TXMLFile::AddXmlLine(const char* line)
+Bool_t TXMLFile::AddXmlLine(const char *line)
 {
-   if (!IsWritable() || (fXML==0)) return kFALSE;
+   if (!IsWritable() || (fXML == 0))
+      return kFALSE;
 
    return fXML->AddDocRawLine(fDoc, line);
 }
@@ -1023,12 +1018,13 @@ Bool_t TXMLFile::AddXmlLine(const char* line)
 ////////////////////////////////////////////////////////////////////////////////
 /// Create key for directory entry in the key
 
-Long64_t TXMLFile::DirCreateEntry(TDirectory* dir)
+Long64_t TXMLFile::DirCreateEntry(TDirectory *dir)
 {
-   TDirectory* mother = dir->GetMotherDir();
-   if (mother==0) mother = this;
+   TDirectory *mother = dir->GetMotherDir();
+   if (mother == 0)
+      mother = this;
 
-   TKeyXML* key = new TKeyXML(mother, ++fKeyCounter, dir, dir->GetName(), dir->GetTitle());
+   TKeyXML *key = new TKeyXML(mother, ++fKeyCounter, dir, dir->GetName(), dir->GetTitle());
 
    key->SetSubir();
 
@@ -1038,53 +1034,56 @@ Long64_t TXMLFile::DirCreateEntry(TDirectory* dir)
 ////////////////////////////////////////////////////////////////////////////////
 /// Search for key which correspond to directory dir
 
-TKeyXML* TXMLFile::FindDirKey(TDirectory* dir)
+TKeyXML *TXMLFile::FindDirKey(TDirectory *dir)
 {
-   TDirectory* motherdir = dir->GetMotherDir();
-   if (motherdir==0) motherdir = this;
+   TDirectory *motherdir = dir->GetMotherDir();
+   if (motherdir == 0)
+      motherdir = this;
 
    TIter next(motherdir->GetListOfKeys());
-   TObject* obj = 0;
+   TObject *obj = 0;
 
-   while ((obj = next())!=0) {
-      TKeyXML* key = dynamic_cast<TKeyXML*> (obj);
+   while ((obj = next()) != 0) {
+      TKeyXML *key = dynamic_cast<TKeyXML *>(obj);
 
-      if (key!=0)
-         if (key->GetKeyId()==dir->GetSeekDir()) return key;
+      if (key != 0)
+         if (key->GetKeyId() == dir->GetSeekDir())
+            return key;
    }
 
    return 0;
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
-///Find a directory in motherdir with a seek equal to keyid
+/// Find a directory in motherdir with a seek equal to keyid
 
-TDirectory* TXMLFile::FindKeyDir(TDirectory* motherdir, Long64_t keyid)
+TDirectory *TXMLFile::FindKeyDir(TDirectory *motherdir, Long64_t keyid)
 {
-   if (motherdir==0) motherdir = this;
+   if (motherdir == 0)
+      motherdir = this;
 
    TIter next(motherdir->GetList());
-   TObject* obj = 0;
+   TObject *obj = 0;
 
-   while ((obj = next())!=0) {
-      TDirectory* dir = dynamic_cast<TDirectory*> (obj);
-      if (dir!=0)
-         if (dir->GetSeekDir()==keyid) return dir;
+   while ((obj = next()) != 0) {
+      TDirectory *dir = dynamic_cast<TDirectory *>(obj);
+      if (dir != 0)
+         if (dir->GetSeekDir() == keyid)
+            return dir;
    }
 
    return 0;
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read keys for directory
 /// Make sense only once, while next time no new subnodes will be created
 
-Int_t TXMLFile::DirReadKeys(TDirectory* dir)
+Int_t TXMLFile::DirReadKeys(TDirectory *dir)
 {
-   TKeyXML* key = FindDirKey(dir);
-   if (key==0) return 0;
+   TKeyXML *key = FindDirKey(dir);
+   if (key == 0)
+      return 0;
 
    return ReadKeysList(dir, key->KeyNode());
 }
@@ -1092,23 +1091,24 @@ Int_t TXMLFile::DirReadKeys(TDirectory* dir)
 ////////////////////////////////////////////////////////////////////////////////
 /// Update key attributes
 
-void TXMLFile::DirWriteKeys(TDirectory*)
+void TXMLFile::DirWriteKeys(TDirectory *)
 {
    TIter next(GetListOfKeys());
-   TObject* obj = 0;
+   TObject *obj = 0;
 
-   while ((obj = next())!=0) {
-      TKeyXML* key = dynamic_cast<TKeyXML*> (obj);
-      if (key!=0) key->UpdateAttributes();
+   while ((obj = next()) != 0) {
+      TKeyXML *key = dynamic_cast<TKeyXML *>(obj);
+      if (key != 0)
+         key->UpdateAttributes();
    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-///Write the directory header
+/// Write the directory header
 
-void TXMLFile::DirWriteHeader(TDirectory* dir)
+void TXMLFile::DirWriteHeader(TDirectory *dir)
 {
-   TKeyXML* key = FindDirKey(dir);
-   if (key!=0)
+   TKeyXML *key = FindDirKey(dir);
+   if (key != 0)
       key->UpdateObject(dir);
 }

--- a/io/xml/src/TXMLFile.cxx
+++ b/io/xml/src/TXMLFile.cxx
@@ -472,13 +472,13 @@ void TXMLFile::ProduceFileNames(const char* filename, TString& fname, TString& d
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Saves xml structures to file
+/// Saves xml structures to the file
 /// xml elements are kept in list of TKeyXML objects
 /// When saving, all this elements are linked to root xml node
-/// In the end StreamerInfo structures are added
+/// At the end StreamerInfo structures are added
 /// After xml document is saved, all nodes will be unlinked from root node
 /// and kept in memory.
-/// Only Close() or destructor relase memory, used by xml structures
+/// Only Close() or destructor release memory, used by xml structures
 
 void TXMLFile::SaveToFile()
 {
@@ -571,9 +571,9 @@ void TXMLFile::CombineNodesTree(TDirectory* dir, XMLNodePointer_t topnode, Bool_
 
 ////////////////////////////////////////////////////////////////////////////////
 /// read document from file
-/// Now full content of docuument reads into the memory
+/// Now full content of document reads into the memory
 /// Then document decomposed to separate keys and streamer info structures
-/// All inrelevant data will be cleaned
+/// All irrelevant data will be cleaned
 
 Bool_t TXMLFile::ReadFromFile()
 {
@@ -931,8 +931,8 @@ void TXMLFile::SetXmlLayout(EXMLLayout layout)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// If true, all correspondent to file TStreamerInfo objects will be stored in file
-/// this allows to apply schema avolution later for this file
-/// may be usefull, when file used outside ROOT and TStreamerInfo objects does not required
+/// this allows to apply schema evolution later for this file
+/// may be useful, when file used outside ROOT and TStreamerInfo objects does not required
 /// Can be changed only for newly created file.
 
 void TXMLFile::SetStoreStreamerInfos(Bool_t iConvert)
@@ -953,7 +953,7 @@ void TXMLFile::SetUsedDtd(Bool_t use)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Specifiy usage of namespaces in xml file
+/// Specify usage of namespaces in xml file
 /// In current implementation every instrumented class in file gets its unique namespace,
 /// which is equal to name of class and refer to root documentation page like
 /// <TAttPad xmlns:TAttPad="http://root.cern.ch/root/htmldoc/TAttPad.html" version="3">
@@ -984,13 +984,12 @@ Bool_t TXMLFile::AddXmlComment(const char* comment)
    return fXML->AddDocComment(fDoc, comment);
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Adds style sheet definition on the top of xml document
 /// Creates <?xml-stylesheet alternate="yes" title="compact" href="small-base.css" type="text/css"?>
 /// Attributes href and type must be supplied,
 ///  other attributes: title, alternate, media, charset are optional
-/// if alternate==0, attribyte alternate="no" will be created,
+/// if alternate==0, attribute alternate="no" will be created,
 /// if alternate>0, attribute alternate="yes"
 /// if alternate<0, attribute will not be created
 /// This style sheet definition cannot be later access with TXMLFile methods.
@@ -1037,7 +1036,7 @@ Long64_t TXMLFile::DirCreateEntry(TDirectory* dir)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Serach for key which correspond to direcory dir
+/// Search for key which correspond to directory dir
 
 TKeyXML* TXMLFile::FindDirKey(TDirectory* dir)
 {
@@ -1080,7 +1079,7 @@ TDirectory* TXMLFile::FindKeyDir(TDirectory* motherdir, Long64_t keyid)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read keys for directory
-/// Make sence only once, while next time no new subnodes will be created
+/// Make sense only once, while next time no new subnodes will be created
 
 Int_t TXMLFile::DirReadKeys(TDirectory* dir)
 {

--- a/io/xml/src/TXMLPlayer.cxx
+++ b/io/xml/src/TXMLPlayer.cxx
@@ -120,12 +120,12 @@
 #include <string>
 #include <vector>
 
-const char* tab1 = "   ";
-const char* tab2 = "      ";
-const char* tab3 = "         ";
-const char* tab4 = "            ";
+const char *tab1 = "   ";
+const char *tab2 = "      ";
+const char *tab3 = "         ";
+const char *tab4 = "            ";
 
-const char* names_xmlfileclass = "TXmlFile";
+const char *names_xmlfileclass = "TXmlFile";
 
 ClassImp(TXMLPlayer);
 
@@ -146,9 +146,10 @@ TXMLPlayer::~TXMLPlayer()
 ////////////////////////////////////////////////////////////////////////////////
 /// returns streamer function name for given class
 
-TString TXMLPlayer::GetStreamerName(TClass* cl)
+TString TXMLPlayer::GetStreamerName(TClass *cl)
 {
-   if (cl==0) return "";
+   if (cl == 0)
+      return "";
    TString res = cl->GetName();
    res += "_streamer";
    return res;
@@ -162,12 +163,13 @@ TString TXMLPlayer::GetStreamerName(TClass* cl)
 /// For instance, if filename is "streamers", files "streamers.h" and "streamers.cxx"
 /// will be created.
 
-Bool_t TXMLPlayer::ProduceCode(TList* cllist, const char* filename)
+Bool_t TXMLPlayer::ProduceCode(TList *cllist, const char *filename)
 {
-   if ((cllist==0) || (filename==0)) return kFALSE;
+   if ((cllist == 0) || (filename == 0))
+      return kFALSE;
 
-   std::ofstream fh(TString(filename)+".h");
-   std::ofstream fs(TString(filename)+".cxx");
+   std::ofstream fh(TString(filename) + ".h");
+   std::ofstream fs(TString(filename) + ".cxx");
 
    fh << "// generated header file" << std::endl << std::endl;
    fh << "#ifndef " << filename << "_h" << std::endl;
@@ -182,11 +184,11 @@ Bool_t TXMLPlayer::ProduceCode(TList* cllist, const char* filename)
 
    TObjArray inclfiles;
    TIter iter(cllist);
-   TClass* cl = 0;
-   while ((cl = (TClass*) iter()) != 0) {
-      if (inclfiles.FindObject(cl->GetDeclFileName())==0) {
+   TClass *cl = 0;
+   while ((cl = (TClass *)iter()) != 0) {
+      if (inclfiles.FindObject(cl->GetDeclFileName()) == 0) {
          fs << "#include \"" << cl->GetDeclFileName() << "\"" << std::endl;
-         inclfiles.Add(new TNamed(cl->GetDeclFileName(),""));
+         inclfiles.Add(new TNamed(cl->GetDeclFileName(), ""));
       }
    }
    inclfiles.Delete();
@@ -198,10 +200,11 @@ Bool_t TXMLPlayer::ProduceCode(TList* cllist, const char* filename)
 
    iter.Reset();
 
-   while ((cl = (TClass*) iter()) != 0) {
+   while ((cl = (TClass *)iter()) != 0) {
 
-      fh << "extern void* " << GetStreamerName(cl) << "("
-         << names_xmlfileclass << " &buf, void* ptr = 0, bool checktypes = true);" << std::endl << std::endl;
+      fh << "extern void* " << GetStreamerName(cl) << "(" << names_xmlfileclass
+         << " &buf, void* ptr = 0, bool checktypes = true);" << std::endl
+         << std::endl;
 
       ProduceStreamerSource(fs, cl, cllist);
    }
@@ -215,34 +218,37 @@ Bool_t TXMLPlayer::ProduceCode(TList* cllist, const char* filename)
 ////////////////////////////////////////////////////////////////////////////////
 /// returns name of simple data type for given data member
 
-TString TXMLPlayer::GetMemberTypeName(TDataMember* member)
+TString TXMLPlayer::GetMemberTypeName(TDataMember *member)
 {
-   if (member==0) return "int";
+   if (member == 0)
+      return "int";
 
    if (member->IsBasic())
-   switch (member->GetDataType()->GetType()) {
-      case kChar_t:     return "char";
-      case kShort_t:    return "short";
-      case kInt_t:      return "int";
-      case kLong_t:     return "long";
-      case kLong64_t:   return "long long";
+      switch (member->GetDataType()->GetType()) {
+      case kChar_t: return "char";
+      case kShort_t: return "short";
+      case kInt_t: return "int";
+      case kLong_t: return "long";
+      case kLong64_t: return "long long";
       case kFloat16_t:
-      case kFloat_t:    return "float";
+      case kFloat_t: return "float";
       case kDouble32_t:
-      case kDouble_t:   return "double";
-      case kUChar_t:    {
+      case kDouble_t: return "double";
+      case kUChar_t: {
          char first = member->GetDataType()->GetTypeName()[0];
-         if ((first=='B') || (first=='b')) return "bool";
+         if ((first == 'B') || (first == 'b'))
+            return "bool";
          return "unsigned char";
       }
-      case kBool_t:     return "bool";
-      case kUShort_t:   return "unsigned short";
-      case kUInt_t:     return "unsigned int";
-      case kULong_t:    return "unsigned long";
-      case kULong64_t:  return "unsigned long long";
-   }
+      case kBool_t: return "bool";
+      case kUShort_t: return "unsigned short";
+      case kUInt_t: return "unsigned int";
+      case kULong_t: return "unsigned long";
+      case kULong64_t: return "unsigned long long";
+      }
 
-   if (member->IsEnum()) return "int";
+   if (member->IsEnum())
+      return "int";
 
    return member->GetTypeName();
 }
@@ -250,30 +256,32 @@ TString TXMLPlayer::GetMemberTypeName(TDataMember* member)
 ////////////////////////////////////////////////////////////////////////////////
 /// return simple data types for given TStreamerElement object
 
-TString TXMLPlayer::GetBasicTypeName(TStreamerElement* el)
+TString TXMLPlayer::GetBasicTypeName(TStreamerElement *el)
 {
-   if (el->GetType() == TVirtualStreamerInfo::kCounter) return "int";
+   if (el->GetType() == TVirtualStreamerInfo::kCounter)
+      return "int";
 
    switch (el->GetType() % 20) {
-      case TVirtualStreamerInfo::kChar:     return "char";
-      case TVirtualStreamerInfo::kShort:    return "short";
-      case TVirtualStreamerInfo::kInt:      return "int";
-      case TVirtualStreamerInfo::kLong:     return "long";
-      case TVirtualStreamerInfo::kLong64:   return "long long";
-      case TVirtualStreamerInfo::kFloat16:
-      case TVirtualStreamerInfo::kFloat:    return "float";
-      case TVirtualStreamerInfo::kDouble32:
-      case TVirtualStreamerInfo::kDouble:   return "double";
-      case TVirtualStreamerInfo::kUChar: {
-         char first = el->GetTypeNameBasic()[0];
-         if ((first=='B') || (first=='b')) return "bool";
-         return "unsigned char";
-      }
-      case TVirtualStreamerInfo::kBool:     return "bool";
-      case TVirtualStreamerInfo::kUShort:   return "unsigned short";
-      case TVirtualStreamerInfo::kUInt:     return "unsigned int";
-      case TVirtualStreamerInfo::kULong:    return "unsigned long";
-      case TVirtualStreamerInfo::kULong64:  return "unsigned long long";
+   case TVirtualStreamerInfo::kChar: return "char";
+   case TVirtualStreamerInfo::kShort: return "short";
+   case TVirtualStreamerInfo::kInt: return "int";
+   case TVirtualStreamerInfo::kLong: return "long";
+   case TVirtualStreamerInfo::kLong64: return "long long";
+   case TVirtualStreamerInfo::kFloat16:
+   case TVirtualStreamerInfo::kFloat: return "float";
+   case TVirtualStreamerInfo::kDouble32:
+   case TVirtualStreamerInfo::kDouble: return "double";
+   case TVirtualStreamerInfo::kUChar: {
+      char first = el->GetTypeNameBasic()[0];
+      if ((first == 'B') || (first == 'b'))
+         return "bool";
+      return "unsigned char";
+   }
+   case TVirtualStreamerInfo::kBool: return "bool";
+   case TVirtualStreamerInfo::kUShort: return "unsigned short";
+   case TVirtualStreamerInfo::kUInt: return "unsigned int";
+   case TVirtualStreamerInfo::kULong: return "unsigned long";
+   case TVirtualStreamerInfo::kULong64: return "unsigned long long";
    }
    return "int";
 }
@@ -281,32 +289,34 @@ TString TXMLPlayer::GetBasicTypeName(TStreamerElement* el)
 ////////////////////////////////////////////////////////////////////////////////
 /// return functions name to read simple data type from xml file
 
-TString TXMLPlayer::GetBasicTypeReaderMethodName(Int_t type, const char* realname)
+TString TXMLPlayer::GetBasicTypeReaderMethodName(Int_t type, const char *realname)
 {
-   if (type == TVirtualStreamerInfo::kCounter) return "ReadInt";
+   if (type == TVirtualStreamerInfo::kCounter)
+      return "ReadInt";
 
    switch (type % 20) {
-      case TVirtualStreamerInfo::kChar:     return "ReadChar";
-      case TVirtualStreamerInfo::kShort:    return "ReadShort";
-      case TVirtualStreamerInfo::kInt:      return "ReadInt";
-      case TVirtualStreamerInfo::kLong:     return "ReadLong";
-      case TVirtualStreamerInfo::kLong64:   return "ReadLong64";
-      case TVirtualStreamerInfo::kFloat16:
-      case TVirtualStreamerInfo::kFloat:    return "ReadFloat";
-      case TVirtualStreamerInfo::kDouble32:
-      case TVirtualStreamerInfo::kDouble:   return "ReadDouble";
-      case TVirtualStreamerInfo::kUChar: {
-         Bool_t isbool = false;
-         if (realname!=0)
-            isbool = (TString(realname).Index("bool",0, TString::kIgnoreCase)>=0);
-         if (isbool) return "ReadBool";
-         return "ReadUChar";
-      }
-      case TVirtualStreamerInfo::kBool:     return "ReadBool";
-      case TVirtualStreamerInfo::kUShort:   return "ReadUShort";
-      case TVirtualStreamerInfo::kUInt:     return "ReadUInt";
-      case TVirtualStreamerInfo::kULong:    return "ReadULong";
-      case TVirtualStreamerInfo::kULong64:  return "ReadULong64";
+   case TVirtualStreamerInfo::kChar: return "ReadChar";
+   case TVirtualStreamerInfo::kShort: return "ReadShort";
+   case TVirtualStreamerInfo::kInt: return "ReadInt";
+   case TVirtualStreamerInfo::kLong: return "ReadLong";
+   case TVirtualStreamerInfo::kLong64: return "ReadLong64";
+   case TVirtualStreamerInfo::kFloat16:
+   case TVirtualStreamerInfo::kFloat: return "ReadFloat";
+   case TVirtualStreamerInfo::kDouble32:
+   case TVirtualStreamerInfo::kDouble: return "ReadDouble";
+   case TVirtualStreamerInfo::kUChar: {
+      Bool_t isbool = false;
+      if (realname != 0)
+         isbool = (TString(realname).Index("bool", 0, TString::kIgnoreCase) >= 0);
+      if (isbool)
+         return "ReadBool";
+      return "ReadUChar";
+   }
+   case TVirtualStreamerInfo::kBool: return "ReadBool";
+   case TVirtualStreamerInfo::kUShort: return "ReadUShort";
+   case TVirtualStreamerInfo::kUInt: return "ReadUInt";
+   case TVirtualStreamerInfo::kULong: return "ReadULong";
+   case TVirtualStreamerInfo::kULong64: return "ReadULong64";
    }
    return "ReadValue";
 }
@@ -319,48 +329,52 @@ TString TXMLPlayer::GetBasicTypeReaderMethodName(Int_t type, const char* realnam
 ///    2 - produce pointer on given member
 ///    3 - skip casting when produce pointer by buf.P() function
 
-const char* TXMLPlayer::ElementGetter(TClass* cl, const char* membername, int specials)
+const char *TXMLPlayer::ElementGetter(TClass *cl, const char *membername, int specials)
 {
-   TClass* membercl = cl ? cl->GetBaseDataMember(membername) : 0;
-   TDataMember* member = membercl ? membercl->GetDataMember(membername) : 0;
-   TMethodCall* mgetter = member ? member->GetterMethod(0) : 0;
+   TClass *membercl = cl ? cl->GetBaseDataMember(membername) : 0;
+   TDataMember *member = membercl ? membercl->GetDataMember(membername) : 0;
+   TMethodCall *mgetter = member ? member->GetterMethod(0) : 0;
 
-   if ((mgetter!=0) && (mgetter->GetMethod()->Property() & kIsPublic)) {
+   if ((mgetter != 0) && (mgetter->GetMethod()->Property() & kIsPublic)) {
       fGetterName = "obj->";
       fGetterName += mgetter->GetMethodName();
       fGetterName += "()";
-   } else
-   if ((member==0) || ((member->Property() & kIsPublic) != 0)) {
+   } else if ((member == 0) || ((member->Property() & kIsPublic) != 0)) {
       fGetterName = "obj->";
       fGetterName += membername;
    } else {
       fGetterName = "";
-      Bool_t deref = (member->GetArrayDim()==0) && (specials!=2);
-      if (deref) fGetterName += "*(";
-      if (specials!=3) {
+      Bool_t deref = (member->GetArrayDim() == 0) && (specials != 2);
+      if (deref)
+         fGetterName += "*(";
+      if (specials != 3) {
          fGetterName += "(";
-         if (member->Property() & kIsConstant) fGetterName += "const ";
+         if (member->Property() & kIsConstant)
+            fGetterName += "const ";
          fGetterName += GetMemberTypeName(member);
-         if (member->IsaPointer()) fGetterName+="*";
+         if (member->IsaPointer())
+            fGetterName += "*";
          fGetterName += "*) ";
       }
       fGetterName += "buf.P(obj,";
       fGetterName += member->GetOffset();
       fGetterName += ")";
-      if (deref) fGetterName += ")";
+      if (deref)
+         fGetterName += ")";
       specials = 0;
    }
 
-   if ((specials==1) && (member!=0)) {
+   if ((specials == 1) && (member != 0)) {
       TString cast = "(";
       cast += GetMemberTypeName(member);
-      if (member->IsaPointer() || (member->GetArrayDim()>0)) cast += "*";
+      if (member->IsaPointer() || (member->GetArrayDim() > 0))
+         cast += "*";
       cast += ") ";
       cast += fGetterName;
       fGetterName = cast;
    }
 
-   if ((specials==2) && (member!=0)) {
+   if ((specials == 2) && (member != 0)) {
       TString buf = "&(";
       buf += fGetterName;
       buf += ")";
@@ -374,31 +388,33 @@ const char* TXMLPlayer::ElementGetter(TClass* cl, const char* membername, int sp
 /// Produce code to set value to given data member.
 /// endch should be output after value is specified.
 
-const char* TXMLPlayer::ElementSetter(TClass* cl, const char* membername, char* endch)
+const char *TXMLPlayer::ElementSetter(TClass *cl, const char *membername, char *endch)
 {
-   strcpy(endch,"");
+   strcpy(endch, "");
 
-   TClass* membercl = cl ? cl->GetBaseDataMember(membername) : 0;
-   TDataMember* member = membercl ? membercl->GetDataMember(membername) : 0;
-   TMethodCall* msetter = member ? member->SetterMethod(cl) : 0;
+   TClass *membercl = cl ? cl->GetBaseDataMember(membername) : 0;
+   TDataMember *member = membercl ? membercl->GetDataMember(membername) : 0;
+   TMethodCall *msetter = member ? member->SetterMethod(cl) : 0;
 
-   if ((msetter!=0) && (msetter->GetMethod()->Property() & kIsPublic)) {
+   if ((msetter != 0) && (msetter->GetMethod()->Property() & kIsPublic)) {
       fSetterName = "obj->";
       fSetterName += msetter->GetMethodName();
       fSetterName += "(";
-      strcpy(endch,")");
-   } else
-   if ((member==0) || (member->Property() & kIsPublic) != 0) {
+      strcpy(endch, ")");
+   } else if ((member == 0) || (member->Property() & kIsPublic) != 0) {
       fSetterName = "obj->";
       fSetterName += membername;
       fSetterName += " = ";
    } else {
       fSetterName = "";
-      if (member->GetArrayDim()==0) fSetterName += "*";
+      if (member->GetArrayDim() == 0)
+         fSetterName += "*";
       fSetterName += "((";
-      if (member->Property() & kIsConstant) fSetterName += "const ";
+      if (member->Property() & kIsConstant)
+         fSetterName += "const ";
       fSetterName += GetMemberTypeName(member);
-      if (member->IsaPointer()) fSetterName += "*";
+      if (member->IsaPointer())
+         fSetterName += "*";
       fSetterName += "*) buf.P(obj,";
       fSetterName += member->GetOffset();
       fSetterName += ")) = ";
@@ -409,222 +425,216 @@ const char* TXMLPlayer::ElementSetter(TClass* cl, const char* membername, char* 
 ////////////////////////////////////////////////////////////////////////////////
 /// Produce source code of streamer function for specified class
 
-void TXMLPlayer::ProduceStreamerSource(std::ostream& fs, TClass* cl, TList* cllist)
+void TXMLPlayer::ProduceStreamerSource(std::ostream &fs, TClass *cl, TList *cllist)
 {
-   if (cl==0) return;
-   TVirtualStreamerInfo* info = cl->GetStreamerInfo();
-   TObjArray* elements = info->GetElements();
-   if (elements==0) return;
+   if (cl == 0)
+      return;
+   TVirtualStreamerInfo *info = cl->GetStreamerInfo();
+   TObjArray *elements = info->GetElements();
+   if (elements == 0)
+      return;
 
    fs << "//__________________________________________________________________________" << std::endl;
-   fs << "void* " << GetStreamerName(cl) << "("
-         << names_xmlfileclass << " &buf, void* ptr, bool checktypes)" << std::endl;
+   fs << "void* " << GetStreamerName(cl) << "(" << names_xmlfileclass << " &buf, void* ptr, bool checktypes)"
+      << std::endl;
    fs << "{" << std::endl;
    fs << tab1 << cl->GetName() << " *obj = (" << cl->GetName() << "*) ptr;" << std::endl;
 
    fs << tab1 << "if (buf.IsReading()) { " << std::endl;
 
    TIter iter(cllist);
-   TClass* c1 = 0;
+   TClass *c1 = 0;
    Bool_t firstchild = true;
 
-   while ((c1 = (TClass*) iter()) != 0) {
-      if (c1==cl) continue;
-      if (c1->GetListOfBases()->FindObject(cl->GetName())==0) continue;
+   while ((c1 = (TClass *)iter()) != 0) {
+      if (c1 == cl)
+         continue;
+      if (c1->GetListOfBases()->FindObject(cl->GetName()) == 0)
+         continue;
       if (firstchild) {
          fs << tab2 << "if (checktypes) {" << std::endl;
          fs << tab3 << "void* ";
          firstchild = false;
       } else
          fs << tab3;
-      fs << "res = " << GetStreamerName(c1)
-         << "(buf, dynamic_cast<" << c1->GetName() << "*>(obj));" << std::endl;
-      fs << tab3 << "if (res) return dynamic_cast<" << cl->GetName()
-         << "*>(("<< c1->GetName() << " *) res);" << std::endl;
+      fs << "res = " << GetStreamerName(c1) << "(buf, dynamic_cast<" << c1->GetName() << "*>(obj));" << std::endl;
+      fs << tab3 << "if (res) return dynamic_cast<" << cl->GetName() << "*>((" << c1->GetName() << " *) res);"
+         << std::endl;
    }
-   if (!firstchild) fs << tab2 << "}" << std::endl;
+   if (!firstchild)
+      fs << tab2 << "}" << std::endl;
 
-   fs << tab2 << "if (!buf.CheckClassNode(\"" << cl->GetName() << "\", "
-              << info->GetClassVersion() << ")) return 0;" << std::endl;
+   fs << tab2 << "if (!buf.CheckClassNode(\"" << cl->GetName() << "\", " << info->GetClassVersion() << ")) return 0;"
+      << std::endl;
 
    fs << tab2 << "if (obj==0) obj = new " << cl->GetName() << ";" << std::endl;
 
    int n;
-   for (n=0;n<=elements->GetLast();n++) {
+   for (n = 0; n <= elements->GetLast(); n++) {
 
-      TStreamerElement* el = dynamic_cast<TStreamerElement*> (elements->At(n));
-      if (el==0) continue;
+      TStreamerElement *el = dynamic_cast<TStreamerElement *>(elements->At(n));
+      if (el == 0)
+         continue;
 
       Int_t typ = el->GetType();
 
       switch (typ) {
-         // basic types
-         case TVirtualStreamerInfo::kBool:
-         case TVirtualStreamerInfo::kChar:
-         case TVirtualStreamerInfo::kShort:
-         case TVirtualStreamerInfo::kInt:
-         case TVirtualStreamerInfo::kLong:
-         case TVirtualStreamerInfo::kLong64:
-         case TVirtualStreamerInfo::kFloat:
-         case TVirtualStreamerInfo::kFloat16:
-         case TVirtualStreamerInfo::kDouble:
-         case TVirtualStreamerInfo::kUChar:
-         case TVirtualStreamerInfo::kUShort:
-         case TVirtualStreamerInfo::kUInt:
-         case TVirtualStreamerInfo::kULong:
-         case TVirtualStreamerInfo::kULong64:
-         case TVirtualStreamerInfo::kDouble32:
-         case TVirtualStreamerInfo::kCounter: {
-            char endch[5];
-            fs << tab2 << ElementSetter(cl, el->GetName(), endch);
-            fs << "buf." << GetBasicTypeReaderMethodName(el->GetType(), 0)
-               << "(\"" << el->GetName() << "\")" << endch << ";" << std::endl;
-            continue;
-         }
-
-         // array of basic types like bool[10]
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kBool:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kChar:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kShort:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kInt:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kLong:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kLong64:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kFloat:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kFloat16:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kDouble:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kUChar:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kUShort:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kUInt:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kULong:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kULong64:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kDouble32: {
-            fs << tab2 << "buf.ReadArray("
-                       << ElementGetter(cl, el->GetName(), (el->GetArrayDim()>1) ? 1 : 0);
-            fs         << ", " << el->GetArrayLength()
-                       << ", \"" << el->GetName() << "\");" << std::endl;
-            continue;
-         }
-
-         // array of basic types like bool[n]
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kBool:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kChar:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kShort:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kInt:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kLong:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kLong64:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kFloat:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kFloat16:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kDouble:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kUChar:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kUShort:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kUInt:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kULong:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kULong64:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kDouble32: {
-            TStreamerBasicPointer* elp = dynamic_cast<TStreamerBasicPointer*> (el);
-            if (elp==0) {
-               std::cout << "fatal error with TStreamerBasicPointer" << std::endl;
-               continue;
-            }
-            char endch[5];
-
-            fs << tab2 << ElementSetter(cl, el->GetName(), endch);
-            fs         << "buf.ReadArray(" << ElementGetter(cl, el->GetName());
-            fs         << ", " << ElementGetter(cl, elp->GetCountName());
-            fs         << ", \"" << el->GetName() << "\", true)" << endch << ";" << std::endl;
-            continue;
-         }
-
-         case TVirtualStreamerInfo::kCharStar: {
-            char endch[5];
-            fs << tab2 << ElementSetter(cl, el->GetName(), endch);
-            fs         << "buf.ReadCharStar(" << ElementGetter(cl, el->GetName());
-            fs         << ", \"" << el->GetName() << "\")" << endch << ";" << std::endl;
-            continue;
-         }
-
-         case TVirtualStreamerInfo::kBase: {
-            fs << tab2 << GetStreamerName(el->GetClassPointer())
-               << "(buf, dynamic_cast<" << el->GetClassPointer()->GetName()
-               << "*>(obj), false);" << std::endl;
-            continue;
-         }
-
-         // Class*   Class not derived from TObject and with comment field //->
-         case TVirtualStreamerInfo::kAnyp:
-         case TVirtualStreamerInfo::kAnyp    + TVirtualStreamerInfo::kOffsetL: {
-            if (el->GetArrayLength()>0) {
-               fs << tab2 << "buf.ReadObjectArr(" << ElementGetter(cl, el->GetName());
-               fs         << ", " << el->GetArrayLength() << ", -1"
-                          << ", \"" << el->GetName() << "\", "
-                          << GetStreamerName(el->GetClassPointer()) << ");" << std::endl;
-            } else {
-               fs << tab2 << "buf.ReadObject(" << ElementGetter(cl, el->GetName());
-               fs         << ", \"" << el->GetName() << "\", "
-                          << GetStreamerName(el->GetClassPointer()) << ");" << std::endl;
-            }
-            continue;
-         }
-
-         // Class*   Class not derived from TObject and no comment
-         case TVirtualStreamerInfo::kAnyP:
-         case TVirtualStreamerInfo::kAnyP + TVirtualStreamerInfo::kOffsetL: {
-            if (el->GetArrayLength()>0) {
-               fs << tab2 << "for (int n=0;n<" << el->GetArrayLength() << ";n++) "
-                          << "delete (" << ElementGetter(cl, el->GetName()) << ")[n];" << std::endl;
-               fs << tab2 << "buf.ReadObjectPtrArr((void**) " << ElementGetter(cl, el->GetName(), 3);
-               fs         << ", " << el->GetArrayLength()
-                          << ", \"" << el->GetName() << "\", "
-                          << GetStreamerName(el->GetClassPointer()) << ");" << std::endl;
-            } else {
-               char endch[5];
-
-               fs << tab2 << "delete " << ElementGetter(cl, el->GetName()) << ";" << std::endl;
-               fs << tab2 << ElementSetter(cl, el->GetName(), endch);
-               fs         << "(" << el->GetClassPointer()->GetName()
-                          << "*) buf.ReadObjectPtr(\"" << el->GetName() << "\", "
-                          << GetStreamerName(el->GetClassPointer())
-                          << ")" <<endch << ";" << std::endl;
-            }
-            continue;
-         }
-
-         // Class  NOT derived from TObject
-         case TVirtualStreamerInfo::kAny: {
-            fs << tab2 << "buf.ReadObject(" << ElementGetter(cl, el->GetName(), 2);
-            fs         << ", \"" << el->GetName() << "\", "
-                       << GetStreamerName(el->GetClassPointer()) << ");" << std::endl;
-            continue;
-         }
-
-         // Class  NOT derived from TObject, array
-         case TVirtualStreamerInfo::kAny + TVirtualStreamerInfo::kOffsetL: {
-            fs << tab2 << "buf.ReadObjectArr(" << ElementGetter(cl, el->GetName());
-            fs         << ", " << el->GetArrayLength()
-                       << ", sizeof(" << el->GetClassPointer()->GetName()
-                       << "), \"" << el->GetName() << "\", "
-                       << GetStreamerName(el->GetClassPointer()) << ");" << std::endl;
-            continue;
-         }
-
-         // container with no virtual table (stl) and no comment
-         case TVirtualStreamerInfo::kSTLp:
-         case TVirtualStreamerInfo::kSTL:
-         case TVirtualStreamerInfo::kSTLp + TVirtualStreamerInfo::kOffsetL:
-         case TVirtualStreamerInfo::kSTL + TVirtualStreamerInfo::kOffsetL: {
-            TStreamerSTL* elstl = dynamic_cast<TStreamerSTL*> (el);
-            if (elstl==0) break; // to make skip
-
-            if (ProduceSTLstreamer(fs, cl, elstl, false)) continue;
-
-            fs << tab2 << "// STL type = " << elstl->GetSTLtype() << std::endl;
-            break;
-         }
+      // basic types
+      case TVirtualStreamerInfo::kBool:
+      case TVirtualStreamerInfo::kChar:
+      case TVirtualStreamerInfo::kShort:
+      case TVirtualStreamerInfo::kInt:
+      case TVirtualStreamerInfo::kLong:
+      case TVirtualStreamerInfo::kLong64:
+      case TVirtualStreamerInfo::kFloat:
+      case TVirtualStreamerInfo::kFloat16:
+      case TVirtualStreamerInfo::kDouble:
+      case TVirtualStreamerInfo::kUChar:
+      case TVirtualStreamerInfo::kUShort:
+      case TVirtualStreamerInfo::kUInt:
+      case TVirtualStreamerInfo::kULong:
+      case TVirtualStreamerInfo::kULong64:
+      case TVirtualStreamerInfo::kDouble32:
+      case TVirtualStreamerInfo::kCounter: {
+         char endch[5];
+         fs << tab2 << ElementSetter(cl, el->GetName(), endch);
+         fs << "buf." << GetBasicTypeReaderMethodName(el->GetType(), 0) << "(\"" << el->GetName() << "\")" << endch
+            << ";" << std::endl;
+         continue;
       }
-      fs << tab2 << "buf.SkipMember(\"" << el->GetName()
-         << "\");   // sinfo type " << el->GetType()
-         << " of class " << el->GetClassPointer()->GetName()
-         << " not supported" << std::endl;
+
+      // array of basic types like bool[10]
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kBool:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kChar:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kShort:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kInt:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kLong:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kLong64:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kFloat:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kFloat16:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kDouble:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kUChar:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kUShort:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kUInt:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kULong:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kULong64:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kDouble32: {
+         fs << tab2 << "buf.ReadArray(" << ElementGetter(cl, el->GetName(), (el->GetArrayDim() > 1) ? 1 : 0);
+         fs << ", " << el->GetArrayLength() << ", \"" << el->GetName() << "\");" << std::endl;
+         continue;
+      }
+
+      // array of basic types like bool[n]
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kBool:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kChar:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kShort:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kInt:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kLong:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kLong64:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kFloat:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kFloat16:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kDouble:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kUChar:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kUShort:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kUInt:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kULong:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kULong64:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kDouble32: {
+         TStreamerBasicPointer *elp = dynamic_cast<TStreamerBasicPointer *>(el);
+         if (elp == 0) {
+            std::cout << "fatal error with TStreamerBasicPointer" << std::endl;
+            continue;
+         }
+         char endch[5];
+
+         fs << tab2 << ElementSetter(cl, el->GetName(), endch);
+         fs << "buf.ReadArray(" << ElementGetter(cl, el->GetName());
+         fs << ", " << ElementGetter(cl, elp->GetCountName());
+         fs << ", \"" << el->GetName() << "\", true)" << endch << ";" << std::endl;
+         continue;
+      }
+
+      case TVirtualStreamerInfo::kCharStar: {
+         char endch[5];
+         fs << tab2 << ElementSetter(cl, el->GetName(), endch);
+         fs << "buf.ReadCharStar(" << ElementGetter(cl, el->GetName());
+         fs << ", \"" << el->GetName() << "\")" << endch << ";" << std::endl;
+         continue;
+      }
+
+      case TVirtualStreamerInfo::kBase: {
+         fs << tab2 << GetStreamerName(el->GetClassPointer()) << "(buf, dynamic_cast<"
+            << el->GetClassPointer()->GetName() << "*>(obj), false);" << std::endl;
+         continue;
+      }
+
+      // Class*   Class not derived from TObject and with comment field //->
+      case TVirtualStreamerInfo::kAnyp:
+      case TVirtualStreamerInfo::kAnyp + TVirtualStreamerInfo::kOffsetL: {
+         if (el->GetArrayLength() > 0) {
+            fs << tab2 << "buf.ReadObjectArr(" << ElementGetter(cl, el->GetName());
+            fs << ", " << el->GetArrayLength() << ", -1"
+               << ", \"" << el->GetName() << "\", " << GetStreamerName(el->GetClassPointer()) << ");" << std::endl;
+         } else {
+            fs << tab2 << "buf.ReadObject(" << ElementGetter(cl, el->GetName());
+            fs << ", \"" << el->GetName() << "\", " << GetStreamerName(el->GetClassPointer()) << ");" << std::endl;
+         }
+         continue;
+      }
+
+      // Class*   Class not derived from TObject and no comment
+      case TVirtualStreamerInfo::kAnyP:
+      case TVirtualStreamerInfo::kAnyP + TVirtualStreamerInfo::kOffsetL: {
+         if (el->GetArrayLength() > 0) {
+            fs << tab2 << "for (int n=0;n<" << el->GetArrayLength() << ";n++) "
+               << "delete (" << ElementGetter(cl, el->GetName()) << ")[n];" << std::endl;
+            fs << tab2 << "buf.ReadObjectPtrArr((void**) " << ElementGetter(cl, el->GetName(), 3);
+            fs << ", " << el->GetArrayLength() << ", \"" << el->GetName() << "\", "
+               << GetStreamerName(el->GetClassPointer()) << ");" << std::endl;
+         } else {
+            char endch[5];
+
+            fs << tab2 << "delete " << ElementGetter(cl, el->GetName()) << ";" << std::endl;
+            fs << tab2 << ElementSetter(cl, el->GetName(), endch);
+            fs << "(" << el->GetClassPointer()->GetName() << "*) buf.ReadObjectPtr(\"" << el->GetName() << "\", "
+               << GetStreamerName(el->GetClassPointer()) << ")" << endch << ";" << std::endl;
+         }
+         continue;
+      }
+
+      // Class  NOT derived from TObject
+      case TVirtualStreamerInfo::kAny: {
+         fs << tab2 << "buf.ReadObject(" << ElementGetter(cl, el->GetName(), 2);
+         fs << ", \"" << el->GetName() << "\", " << GetStreamerName(el->GetClassPointer()) << ");" << std::endl;
+         continue;
+      }
+
+      // Class  NOT derived from TObject, array
+      case TVirtualStreamerInfo::kAny + TVirtualStreamerInfo::kOffsetL: {
+         fs << tab2 << "buf.ReadObjectArr(" << ElementGetter(cl, el->GetName());
+         fs << ", " << el->GetArrayLength() << ", sizeof(" << el->GetClassPointer()->GetName() << "), \""
+            << el->GetName() << "\", " << GetStreamerName(el->GetClassPointer()) << ");" << std::endl;
+         continue;
+      }
+
+      // container with no virtual table (stl) and no comment
+      case TVirtualStreamerInfo::kSTLp:
+      case TVirtualStreamerInfo::kSTL:
+      case TVirtualStreamerInfo::kSTLp + TVirtualStreamerInfo::kOffsetL:
+      case TVirtualStreamerInfo::kSTL + TVirtualStreamerInfo::kOffsetL: {
+         TStreamerSTL *elstl = dynamic_cast<TStreamerSTL *>(el);
+         if (elstl == 0)
+            break; // to make skip
+
+         if (ProduceSTLstreamer(fs, cl, elstl, false))
+            continue;
+
+         fs << tab2 << "// STL type = " << elstl->GetSTLtype() << std::endl;
+         break;
+      }
+      }
+      fs << tab2 << "buf.SkipMember(\"" << el->GetName() << "\");   // sinfo type " << el->GetType() << " of class "
+         << el->GetClassPointer()->GetName() << " not supported" << std::endl;
    }
 
    fs << tab2 << "buf.EndClassNode();" << std::endl;
@@ -637,183 +647,175 @@ void TXMLPlayer::ProduceStreamerSource(std::ostream& fs, TClass* cl, TList* clli
 
    firstchild = true;
    iter.Reset();
-   while ((c1 = (TClass*) iter()) != 0) {
-      if (c1==cl) continue;
-      if (c1->GetListOfBases()->FindObject(cl->GetName())==0) continue;
+   while ((c1 = (TClass *)iter()) != 0) {
+      if (c1 == cl)
+         continue;
+      if (c1->GetListOfBases()->FindObject(cl->GetName()) == 0)
+         continue;
       if (firstchild) {
          firstchild = false;
          fs << tab2 << "if (checktypes) {" << std::endl;
       }
       fs << tab3 << "if (dynamic_cast<" << c1->GetName() << "*>(obj))" << std::endl;
-      fs << tab4 << "return " << GetStreamerName(c1) << "(buf, dynamic_cast<" << c1->GetName() << "*>(obj));" << std::endl;
+      fs << tab4 << "return " << GetStreamerName(c1) << "(buf, dynamic_cast<" << c1->GetName() << "*>(obj));"
+         << std::endl;
    }
-   if (!firstchild) fs << tab2 << "}" << std::endl;
+   if (!firstchild)
+      fs << tab2 << "}" << std::endl;
 
-   fs << tab2 << "buf.StartClassNode(\"" << cl->GetName() << "\", "
-              << info->GetClassVersion() << ");" << std::endl;
+   fs << tab2 << "buf.StartClassNode(\"" << cl->GetName() << "\", " << info->GetClassVersion() << ");" << std::endl;
 
-   for (n=0;n<=elements->GetLast();n++) {
+   for (n = 0; n <= elements->GetLast(); n++) {
 
-      TStreamerElement* el = dynamic_cast<TStreamerElement*> (elements->At(n));
-      if (el==0) continue;
+      TStreamerElement *el = dynamic_cast<TStreamerElement *>(elements->At(n));
+      if (el == 0)
+         continue;
 
       Int_t typ = el->GetType();
 
       switch (typ) {
-         // write basic types
-         case TVirtualStreamerInfo::kBool:
-         case TVirtualStreamerInfo::kChar:
-         case TVirtualStreamerInfo::kShort:
-         case TVirtualStreamerInfo::kInt:
-         case TVirtualStreamerInfo::kLong:
-         case TVirtualStreamerInfo::kLong64:
-         case TVirtualStreamerInfo::kFloat:
-         case TVirtualStreamerInfo::kFloat16:
-         case TVirtualStreamerInfo::kDouble:
-         case TVirtualStreamerInfo::kUChar:
-         case TVirtualStreamerInfo::kUShort:
-         case TVirtualStreamerInfo::kUInt:
-         case TVirtualStreamerInfo::kULong:
-         case TVirtualStreamerInfo::kULong64:
-         case TVirtualStreamerInfo::kDouble32:
-         case TVirtualStreamerInfo::kCounter: {
-            fs << tab2 << "buf.WriteValue(";
-            if (typ==TVirtualStreamerInfo::kUChar)
-               fs <<"(unsigned char) " << ElementGetter(cl, el->GetName());
-            else
-               fs << ElementGetter(cl, el->GetName());
-            fs << ", \"" << el->GetName() << "\");" << std::endl;
-            continue;
-         }
-
-         // array of basic types
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kBool:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kChar:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kShort:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kInt:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kLong:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kLong64:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kFloat:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kFloat16:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kDouble:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kUChar:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kUShort:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kUInt:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kULong:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kULong64:
-         case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kDouble32: {
-            fs << tab2 << "buf.WriteArray("
-                       << ElementGetter(cl, el->GetName(), (el->GetArrayDim()>1) ? 1 : 0);
-            fs         << ", " << el->GetArrayLength()
-                       << ", \"" << el->GetName() << "\");" << std::endl;
-            continue;
-         }
-
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kBool:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kChar:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kShort:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kInt:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kLong:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kLong64:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kFloat:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kFloat16:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kDouble:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kUChar:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kUShort:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kUInt:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kULong:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kULong64:
-         case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kDouble32: {
-            TStreamerBasicPointer* elp = dynamic_cast<TStreamerBasicPointer*> (el);
-            if (elp==0) {
-               std::cout << "fatal error with TStreamerBasicPointer" << std::endl;
-               continue;
-            }
-            fs << tab2 << "buf.WriteArray(" << ElementGetter(cl, el->GetName());
-            fs         << ", " << ElementGetter(cl, elp->GetCountName())
-                       << ", \"" << el->GetName() << "\", true);" << std::endl;
-            continue;
-         }
-
-         case TVirtualStreamerInfo::kCharStar: {
-            fs << tab2 << "buf.WriteCharStar(" << ElementGetter(cl, el->GetName())
-                       << ", \"" << el->GetName() << "\");" << std::endl;
-            continue;
-         }
-
-         case TVirtualStreamerInfo::kBase: {
-            fs << tab2 << GetStreamerName(el->GetClassPointer())
-               << "(buf, dynamic_cast<" << el->GetClassPointer()->GetName()
-               << "*>(obj), false);" << std::endl;
-            continue;
-         }
-
-         // Class*   Class not derived from TObject and with comment field //->
-         case TVirtualStreamerInfo::kAnyp:
-         case TVirtualStreamerInfo::kAnyp    + TVirtualStreamerInfo::kOffsetL: {
-            if (el->GetArrayLength()>0) {
-               fs << tab2 << "buf.WriteObjectArr(" << ElementGetter(cl, el->GetName());
-               fs         << ", " << el->GetArrayLength() << ", -1"
-                          << ", \"" << el->GetName() << "\", "
-                          << GetStreamerName(el->GetClassPointer()) << ");" << std::endl;
-            } else {
-               fs << tab2 << "buf.WriteObject(" << ElementGetter(cl, el->GetName());
-               fs         << ", \"" << el->GetName() << "\", "
-                          << GetStreamerName(el->GetClassPointer()) << ");" << std::endl;
-            }
-            continue;
-         }
-
-         // Class*   Class not derived from TObject and no comment
-         case TVirtualStreamerInfo::kAnyP:
-         case TVirtualStreamerInfo::kAnyP + TVirtualStreamerInfo::kOffsetL: {
-            if (el->GetArrayLength()>0) {
-               fs << tab2 << "buf.WriteObjectPtrArr((void**) " << ElementGetter(cl, el->GetName(), 3);
-               fs         << ", " << el->GetArrayLength()
-                          << ", \"" << el->GetName() << "\", "
-                          << GetStreamerName(el->GetClassPointer()) << ");" << std::endl;
-            } else {
-               fs << tab2 << "buf.WriteObjectPtr(" << ElementGetter(cl, el->GetName());
-               fs         << ", \"" << el->GetName() << "\", "
-                          << GetStreamerName(el->GetClassPointer()) << ");" << std::endl;
-            }
-            continue;
-         }
-
-         case TVirtualStreamerInfo::kAny: {    // Class  NOT derived from TObject
-            fs << tab2 << "buf.WriteObject(" << ElementGetter(cl, el->GetName(), 2);
-            fs         << ", \"" << el->GetName() << "\", "
-                       << GetStreamerName(el->GetClassPointer()) << ");" << std::endl;
-            continue;
-         }
-
-         case TVirtualStreamerInfo::kAny    + TVirtualStreamerInfo::kOffsetL: {
-            fs << tab2 << "buf.WriteObjectArr(" << ElementGetter(cl, el->GetName());
-            fs         << ", " << el->GetArrayLength()
-                       << ", sizeof(" << el->GetClassPointer()->GetName()
-                       << "), \"" << el->GetName() << "\", "
-                       << GetStreamerName(el->GetClassPointer()) << ");" << std::endl;
-            continue;
-         }
-
-         // container with no virtual table (stl) and no comment
-         case TVirtualStreamerInfo::kSTLp + TVirtualStreamerInfo::kOffsetL:
-         case TVirtualStreamerInfo::kSTL + TVirtualStreamerInfo::kOffsetL:
-         case TVirtualStreamerInfo::kSTLp:
-         case TVirtualStreamerInfo::kSTL: {
-            TStreamerSTL* elstl = dynamic_cast<TStreamerSTL*> (el);
-            if (elstl==0) break; // to make skip
-
-            if (ProduceSTLstreamer(fs, cl, elstl, true)) continue;
-            fs << tab2 << "// STL type = " << elstl->GetSTLtype() << std::endl;
-            break;
-         }
-
+      // write basic types
+      case TVirtualStreamerInfo::kBool:
+      case TVirtualStreamerInfo::kChar:
+      case TVirtualStreamerInfo::kShort:
+      case TVirtualStreamerInfo::kInt:
+      case TVirtualStreamerInfo::kLong:
+      case TVirtualStreamerInfo::kLong64:
+      case TVirtualStreamerInfo::kFloat:
+      case TVirtualStreamerInfo::kFloat16:
+      case TVirtualStreamerInfo::kDouble:
+      case TVirtualStreamerInfo::kUChar:
+      case TVirtualStreamerInfo::kUShort:
+      case TVirtualStreamerInfo::kUInt:
+      case TVirtualStreamerInfo::kULong:
+      case TVirtualStreamerInfo::kULong64:
+      case TVirtualStreamerInfo::kDouble32:
+      case TVirtualStreamerInfo::kCounter: {
+         fs << tab2 << "buf.WriteValue(";
+         if (typ == TVirtualStreamerInfo::kUChar)
+            fs << "(unsigned char) " << ElementGetter(cl, el->GetName());
+         else
+            fs << ElementGetter(cl, el->GetName());
+         fs << ", \"" << el->GetName() << "\");" << std::endl;
+         continue;
       }
-      fs << tab2 << "buf.MakeEmptyMember(\"" << el->GetName()
-                 << "\");   // sinfo type " << el->GetType()
-                 << " of class " << el->GetClassPointer()->GetName()
-                 << " not supported" << std::endl;
+
+      // array of basic types
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kBool:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kChar:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kShort:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kInt:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kLong:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kLong64:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kFloat:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kFloat16:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kDouble:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kUChar:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kUShort:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kUInt:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kULong:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kULong64:
+      case TVirtualStreamerInfo::kOffsetL + TVirtualStreamerInfo::kDouble32: {
+         fs << tab2 << "buf.WriteArray(" << ElementGetter(cl, el->GetName(), (el->GetArrayDim() > 1) ? 1 : 0);
+         fs << ", " << el->GetArrayLength() << ", \"" << el->GetName() << "\");" << std::endl;
+         continue;
+      }
+
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kBool:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kChar:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kShort:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kInt:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kLong:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kLong64:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kFloat:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kFloat16:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kDouble:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kUChar:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kUShort:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kUInt:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kULong:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kULong64:
+      case TVirtualStreamerInfo::kOffsetP + TVirtualStreamerInfo::kDouble32: {
+         TStreamerBasicPointer *elp = dynamic_cast<TStreamerBasicPointer *>(el);
+         if (elp == 0) {
+            std::cout << "fatal error with TStreamerBasicPointer" << std::endl;
+            continue;
+         }
+         fs << tab2 << "buf.WriteArray(" << ElementGetter(cl, el->GetName());
+         fs << ", " << ElementGetter(cl, elp->GetCountName()) << ", \"" << el->GetName() << "\", true);" << std::endl;
+         continue;
+      }
+
+      case TVirtualStreamerInfo::kCharStar: {
+         fs << tab2 << "buf.WriteCharStar(" << ElementGetter(cl, el->GetName()) << ", \"" << el->GetName() << "\");"
+            << std::endl;
+         continue;
+      }
+
+      case TVirtualStreamerInfo::kBase: {
+         fs << tab2 << GetStreamerName(el->GetClassPointer()) << "(buf, dynamic_cast<"
+            << el->GetClassPointer()->GetName() << "*>(obj), false);" << std::endl;
+         continue;
+      }
+
+      // Class*   Class not derived from TObject and with comment field //->
+      case TVirtualStreamerInfo::kAnyp:
+      case TVirtualStreamerInfo::kAnyp + TVirtualStreamerInfo::kOffsetL: {
+         if (el->GetArrayLength() > 0) {
+            fs << tab2 << "buf.WriteObjectArr(" << ElementGetter(cl, el->GetName());
+            fs << ", " << el->GetArrayLength() << ", -1"
+               << ", \"" << el->GetName() << "\", " << GetStreamerName(el->GetClassPointer()) << ");" << std::endl;
+         } else {
+            fs << tab2 << "buf.WriteObject(" << ElementGetter(cl, el->GetName());
+            fs << ", \"" << el->GetName() << "\", " << GetStreamerName(el->GetClassPointer()) << ");" << std::endl;
+         }
+         continue;
+      }
+
+      // Class*   Class not derived from TObject and no comment
+      case TVirtualStreamerInfo::kAnyP:
+      case TVirtualStreamerInfo::kAnyP + TVirtualStreamerInfo::kOffsetL: {
+         if (el->GetArrayLength() > 0) {
+            fs << tab2 << "buf.WriteObjectPtrArr((void**) " << ElementGetter(cl, el->GetName(), 3);
+            fs << ", " << el->GetArrayLength() << ", \"" << el->GetName() << "\", "
+               << GetStreamerName(el->GetClassPointer()) << ");" << std::endl;
+         } else {
+            fs << tab2 << "buf.WriteObjectPtr(" << ElementGetter(cl, el->GetName());
+            fs << ", \"" << el->GetName() << "\", " << GetStreamerName(el->GetClassPointer()) << ");" << std::endl;
+         }
+         continue;
+      }
+
+      case TVirtualStreamerInfo::kAny: { // Class  NOT derived from TObject
+         fs << tab2 << "buf.WriteObject(" << ElementGetter(cl, el->GetName(), 2);
+         fs << ", \"" << el->GetName() << "\", " << GetStreamerName(el->GetClassPointer()) << ");" << std::endl;
+         continue;
+      }
+
+      case TVirtualStreamerInfo::kAny + TVirtualStreamerInfo::kOffsetL: {
+         fs << tab2 << "buf.WriteObjectArr(" << ElementGetter(cl, el->GetName());
+         fs << ", " << el->GetArrayLength() << ", sizeof(" << el->GetClassPointer()->GetName() << "), \""
+            << el->GetName() << "\", " << GetStreamerName(el->GetClassPointer()) << ");" << std::endl;
+         continue;
+      }
+
+      // container with no virtual table (stl) and no comment
+      case TVirtualStreamerInfo::kSTLp + TVirtualStreamerInfo::kOffsetL:
+      case TVirtualStreamerInfo::kSTL + TVirtualStreamerInfo::kOffsetL:
+      case TVirtualStreamerInfo::kSTLp:
+      case TVirtualStreamerInfo::kSTL: {
+         TStreamerSTL *elstl = dynamic_cast<TStreamerSTL *>(el);
+         if (elstl == 0)
+            break; // to make skip
+
+         if (ProduceSTLstreamer(fs, cl, elstl, true))
+            continue;
+         fs << tab2 << "// STL type = " << elstl->GetSTLtype() << std::endl;
+         break;
+      }
+      }
+      fs << tab2 << "buf.MakeEmptyMember(\"" << el->GetName() << "\");   // sinfo type " << el->GetType()
+         << " of class " << el->GetClassPointer()->GetName() << " not supported" << std::endl;
    }
 
    fs << tab2 << "buf.EndClassNode();" << std::endl;
@@ -826,224 +828,234 @@ void TXMLPlayer::ProduceStreamerSource(std::ostream& fs, TClass* cl, TList* clli
 ////////////////////////////////////////////////////////////////////////////////
 /// Produce code to read argument of stl container from xml file
 
-void TXMLPlayer::ReadSTLarg(std::ostream& fs,
-                            TString& argname,
-                            int argtyp,
-                            Bool_t isargptr,
-                            TClass* argcl,
-                            TString& tname,
-                            TString& ifcond)
+void TXMLPlayer::ReadSTLarg(std::ostream &fs, TString &argname, int argtyp, Bool_t isargptr, TClass *argcl,
+                            TString &tname, TString &ifcond)
 {
-   switch(argtyp) {
-      case TVirtualStreamerInfo::kBool:
-      case TVirtualStreamerInfo::kChar:
-      case TVirtualStreamerInfo::kShort:
-      case TVirtualStreamerInfo::kInt:
-      case TVirtualStreamerInfo::kLong:
-      case TVirtualStreamerInfo::kLong64:
-      case TVirtualStreamerInfo::kFloat:
-      case TVirtualStreamerInfo::kFloat16:
-      case TVirtualStreamerInfo::kDouble:
-      case TVirtualStreamerInfo::kUChar:
-      case TVirtualStreamerInfo::kUShort:
-      case TVirtualStreamerInfo::kUInt:
-      case TVirtualStreamerInfo::kULong:
-      case TVirtualStreamerInfo::kULong64:
-      case TVirtualStreamerInfo::kDouble32:
-      case TVirtualStreamerInfo::kCounter: {
-         fs << tname << " " << argname << " = buf."
-            << GetBasicTypeReaderMethodName(argtyp, tname.Data()) << "(0);" << std::endl;
-         break;
-      }
+   switch (argtyp) {
+   case TVirtualStreamerInfo::kBool:
+   case TVirtualStreamerInfo::kChar:
+   case TVirtualStreamerInfo::kShort:
+   case TVirtualStreamerInfo::kInt:
+   case TVirtualStreamerInfo::kLong:
+   case TVirtualStreamerInfo::kLong64:
+   case TVirtualStreamerInfo::kFloat:
+   case TVirtualStreamerInfo::kFloat16:
+   case TVirtualStreamerInfo::kDouble:
+   case TVirtualStreamerInfo::kUChar:
+   case TVirtualStreamerInfo::kUShort:
+   case TVirtualStreamerInfo::kUInt:
+   case TVirtualStreamerInfo::kULong:
+   case TVirtualStreamerInfo::kULong64:
+   case TVirtualStreamerInfo::kDouble32:
+   case TVirtualStreamerInfo::kCounter: {
+      fs << tname << " " << argname << " = buf." << GetBasicTypeReaderMethodName(argtyp, tname.Data()) << "(0);"
+         << std::endl;
+      break;
+   }
 
-      case TVirtualStreamerInfo::kObject: {
-         fs << tname << (isargptr ? " ": " *") << argname << " = "
-            << "(" << argcl->GetName() << "*)"
-            << "buf.ReadObjectPtr(0, "
-            << GetStreamerName(argcl) << ");" << std::endl;
-         if (!isargptr) {
-            if (ifcond.Length()>0) ifcond+=" && ";
-            ifcond += argname;
-            TString buf = "*";
-            buf += argname;
-            argname = buf;
-         }
-         break;
+   case TVirtualStreamerInfo::kObject: {
+      fs << tname << (isargptr ? " " : " *") << argname << " = "
+         << "(" << argcl->GetName() << "*)"
+         << "buf.ReadObjectPtr(0, " << GetStreamerName(argcl) << ");" << std::endl;
+      if (!isargptr) {
+         if (ifcond.Length() > 0)
+            ifcond += " && ";
+         ifcond += argname;
+         TString buf = "*";
+         buf += argname;
+         argname = buf;
       }
+      break;
+   }
 
-      case TVirtualStreamerInfo::kSTLstring: {
-         fs << "string *" << argname << " = "
-            << "buf.ReadSTLstring();" << std::endl;
-         if (!isargptr) {
-            if (ifcond.Length()>0) ifcond+=" && ";
-            ifcond += argname;
-            TString buf = "*";
-            buf += argname;
-            argname = buf;
-         }
-         break;
+   case TVirtualStreamerInfo::kSTLstring: {
+      fs << "string *" << argname << " = "
+         << "buf.ReadSTLstring();" << std::endl;
+      if (!isargptr) {
+         if (ifcond.Length() > 0)
+            ifcond += " && ";
+         ifcond += argname;
+         TString buf = "*";
+         buf += argname;
+         argname = buf;
       }
+      break;
+   }
 
-      default:
-         fs << "/* argument " << argname << " not supported */";
+   default: fs << "/* argument " << argname << " not supported */";
    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Produce code to write argument of stl container to xml file
 
-void TXMLPlayer::WriteSTLarg(std::ostream& fs, const char* accname, int argtyp, Bool_t isargptr, TClass* argcl)
+void TXMLPlayer::WriteSTLarg(std::ostream &fs, const char *accname, int argtyp, Bool_t isargptr, TClass *argcl)
 {
-   switch(argtyp) {
-      case TVirtualStreamerInfo::kBool:
-      case TVirtualStreamerInfo::kChar:
-      case TVirtualStreamerInfo::kShort:
-      case TVirtualStreamerInfo::kInt:
-      case TVirtualStreamerInfo::kLong:
-      case TVirtualStreamerInfo::kLong64:
-      case TVirtualStreamerInfo::kFloat:
-      case TVirtualStreamerInfo::kFloat16:
-      case TVirtualStreamerInfo::kDouble:
-      case TVirtualStreamerInfo::kUChar:
-      case TVirtualStreamerInfo::kUShort:
-      case TVirtualStreamerInfo::kUInt:
-      case TVirtualStreamerInfo::kULong:
-      case TVirtualStreamerInfo::kULong64:
-      case TVirtualStreamerInfo::kDouble32:
-      case TVirtualStreamerInfo::kCounter: {
-         fs << "buf.WriteValue(" << accname << ", 0);" << std::endl;
-         break;
-      }
+   switch (argtyp) {
+   case TVirtualStreamerInfo::kBool:
+   case TVirtualStreamerInfo::kChar:
+   case TVirtualStreamerInfo::kShort:
+   case TVirtualStreamerInfo::kInt:
+   case TVirtualStreamerInfo::kLong:
+   case TVirtualStreamerInfo::kLong64:
+   case TVirtualStreamerInfo::kFloat:
+   case TVirtualStreamerInfo::kFloat16:
+   case TVirtualStreamerInfo::kDouble:
+   case TVirtualStreamerInfo::kUChar:
+   case TVirtualStreamerInfo::kUShort:
+   case TVirtualStreamerInfo::kUInt:
+   case TVirtualStreamerInfo::kULong:
+   case TVirtualStreamerInfo::kULong64:
+   case TVirtualStreamerInfo::kDouble32:
+   case TVirtualStreamerInfo::kCounter: {
+      fs << "buf.WriteValue(" << accname << ", 0);" << std::endl;
+      break;
+   }
 
-      case TVirtualStreamerInfo::kObject: {
-         fs << "buf.WriteObjectPtr(";
-         if (isargptr)
-            fs << accname;
-         else
-            fs << "&(" << accname << ")";
-         fs << ", 0, " <<  GetStreamerName(argcl) << ");" << std::endl;
-         break;
-      }
+   case TVirtualStreamerInfo::kObject: {
+      fs << "buf.WriteObjectPtr(";
+      if (isargptr)
+         fs << accname;
+      else
+         fs << "&(" << accname << ")";
+      fs << ", 0, " << GetStreamerName(argcl) << ");" << std::endl;
+      break;
+   }
 
-      case TVirtualStreamerInfo::kSTLstring: {
-         fs << "buf.WriteSTLstring(";
-         if (isargptr)
-            fs << accname;
-         else
-            fs << "&(" << accname << ")";
-         fs << ");" << std::endl;
-         break;
-      }
+   case TVirtualStreamerInfo::kSTLstring: {
+      fs << "buf.WriteSTLstring(";
+      if (isargptr)
+         fs << accname;
+      else
+         fs << "&(" << accname << ")";
+      fs << ");" << std::endl;
+      break;
+   }
 
-      default:
-         fs << "/* argument not supported */" << std::endl;
+   default: fs << "/* argument not supported */" << std::endl;
    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Produce code of xml streamer for data member of stl type
 
-Bool_t TXMLPlayer::ProduceSTLstreamer(std::ostream& fs, TClass* cl, TStreamerSTL* el, Bool_t isWriting)
+Bool_t TXMLPlayer::ProduceSTLstreamer(std::ostream &fs, TClass *cl, TStreamerSTL *el, Bool_t isWriting)
 {
-   if ((cl==0) || (el==0)) return false;
+   if ((cl == 0) || (el == 0))
+      return false;
 
-   TClass* contcl = el->GetClassPointer();
+   TClass *contcl = el->GetClassPointer();
 
    Bool_t isstr = (el->GetSTLtype() == ROOT::kSTLstring);
    Bool_t isptr = el->IsaPointer();
-   Bool_t isarr = (el->GetArrayLength()>0);
-   Bool_t isparent = (strcmp(el->GetName(), contcl->GetName())==0);
+   Bool_t isarr = (el->GetArrayLength() > 0);
+   Bool_t isparent = (strcmp(el->GetName(), contcl->GetName()) == 0);
 
    int stltyp = -1;
    int narg = 0;
    int argtype[2];
    Bool_t isargptr[2];
-   TClass* argcl[2];
+   TClass *argcl[2];
    TString argtname[2];
 
    if (!isstr && contcl->GetCollectionType() != ROOT::kNotSTL) {
-         int nestedLoc = 0;
-         std::vector<std::string> splitName;
-         TClassEdit::GetSplit(contcl->GetName(), splitName, nestedLoc);
+      int nestedLoc = 0;
+      std::vector<std::string> splitName;
+      TClassEdit::GetSplit(contcl->GetName(), splitName, nestedLoc);
 
-         stltyp = contcl->GetCollectionType();
-         switch (stltyp) {
-            case ROOT::kSTLvector            : narg = 1; break;
-            case ROOT::kSTLlist              : narg = 1; break;
-            case ROOT::kSTLforwardlist       : narg = 1; break;
-            case ROOT::kSTLdeque             : narg = 1; break;
-            case ROOT::kSTLmap               : narg = 2; break;
-            case ROOT::kSTLmultimap          : narg = 2; break;
-            case ROOT::kSTLset               : narg = 1; break;
-            case ROOT::kSTLmultiset          : narg = 1; break;
-            case ROOT::kSTLunorderedset      : narg = 1; break;
-            case ROOT::kSTLunorderedmultiset : narg = 1; break;
-            case ROOT::kSTLunorderedmap      : narg = 2; break;
-            case ROOT::kSTLunorderedmultimap : narg = 2; break;
+      stltyp = contcl->GetCollectionType();
+      switch (stltyp) {
+      case ROOT::kSTLvector: narg = 1; break;
+      case ROOT::kSTLlist: narg = 1; break;
+      case ROOT::kSTLforwardlist: narg = 1; break;
+      case ROOT::kSTLdeque: narg = 1; break;
+      case ROOT::kSTLmap: narg = 2; break;
+      case ROOT::kSTLmultimap: narg = 2; break;
+      case ROOT::kSTLset: narg = 1; break;
+      case ROOT::kSTLmultiset: narg = 1; break;
+      case ROOT::kSTLunorderedset: narg = 1; break;
+      case ROOT::kSTLunorderedmultiset: narg = 1; break;
+      case ROOT::kSTLunorderedmap: narg = 2; break;
+      case ROOT::kSTLunorderedmultimap: narg = 2; break;
 
-            default: return false;
+      default: return false;
+      }
+
+      for (int n = 0; n < narg; n++) {
+         argtype[n] = -1;
+         isargptr[n] = false;
+         argcl[n] = 0;
+         argtname[n] = "";
+
+         TString buf = splitName[n + 1];
+
+         argtname[n] = buf;
+
+         // nested STL containers not yet supported
+         if (TClassEdit::IsSTLCont(buf.Data()))
+            return false;
+
+         int pstar = buf.Index("*");
+
+         if (pstar > 0) {
+            isargptr[n] = true;
+            pstar--;
+            while ((pstar > 0) && (buf[pstar] == ' '))
+               pstar--;
+            buf.Remove(pstar + 1);
+         } else
+            isargptr[n] = false;
+
+         if (buf.Index("const ") == 0) {
+            buf.Remove(0, 6);
+            while ((buf.Length() > 0) && (buf[0] == ' '))
+               buf.Remove(0, 1);
          }
 
-         for(int n=0;n<narg;n++) {
-            argtype[n] = -1;
-            isargptr[n] = false;
-            argcl[n] = 0;
-            argtname[n] = "";
+         TDataType *dt = (TDataType *)gROOT->GetListOfTypes()->FindObject(buf);
+         if (dt)
+            argtype[n] = dt->GetType();
+         else if (buf == "string")
+            argtype[n] = TVirtualStreamerInfo::kSTLstring;
+         else {
+            argcl[n] = TClass::GetClass(buf);
+            if (argcl[n] != 0)
+               argtype[n] = TVirtualStreamerInfo::kObject;
+         }
+         if (argtype[n] < 0)
+            stltyp = -1;
+      } // for narg
 
-            TString buf = splitName[n+1];
-
-            argtname[n] = buf;
-
-            // nested STL containers not yet supported
-            if (TClassEdit::IsSTLCont(buf.Data())) return false;
-
-            int pstar = buf.Index("*");
-
-            if (pstar>0) {
-               isargptr[n] = true;
-               pstar--;
-               while ((pstar>0) && (buf[pstar]==' ')) pstar--;
-               buf.Remove(pstar+1);
-            } else
-               isargptr[n] = false;
-
-            if (buf.Index("const ")==0) {
-               buf.Remove(0,6);
-               while ((buf.Length()>0) && (buf[0]==' ')) buf.Remove(0,1);
-            }
-
-            TDataType *dt = (TDataType*)gROOT->GetListOfTypes()->FindObject(buf);
-            if (dt) argtype[n] = dt->GetType(); else
-            if (buf=="string")
-               argtype[n] = TVirtualStreamerInfo::kSTLstring;
-            else {
-               argcl[n] = TClass::GetClass(buf);
-               if (argcl[n]!=0) argtype[n]=TVirtualStreamerInfo::kObject;
-            }
-            if (argtype[n]<0) stltyp = -1;
-         } // for narg
-
-      if (stltyp<0) return false;
+      if (stltyp < 0)
+         return false;
    }
 
-   Bool_t akaarrayaccess = (narg==1) && (argtype[0]<20);
+   Bool_t akaarrayaccess = (narg == 1) && (argtype[0] < 20);
 
    char tabs[30], tabs2[30];
 
    if (isWriting) {
 
-      fs << tab2 << "if (buf.StartSTLnode(\""
-                 << fXmlSetup.XmlGetElementName(el) << "\")) {" << std::endl;
+      fs << tab2 << "if (buf.StartSTLnode(\"" << fXmlSetup.XmlGetElementName(el) << "\")) {" << std::endl;
 
       fs << tab3 << contcl->GetName() << " ";
 
       TString accname;
       if (isptr) {
-         if (isarr) { fs << "**cont"; accname = "(*cont)->"; }
-            else { fs << "*cont"; accname = "cont->"; }
-      } else
-      if (isarr) { fs << "*cont"; accname = "cont->"; }
-         else { fs << "&cont"; accname = "cont."; }
+         if (isarr) {
+            fs << "**cont";
+            accname = "(*cont)->";
+         } else {
+            fs << "*cont";
+            accname = "cont->";
+         }
+      } else if (isarr) {
+         fs << "*cont";
+         accname = "cont->";
+      } else {
+         fs << "&cont";
+         accname = "cont.";
+      }
 
       fs << " = ";
 
@@ -1067,31 +1079,26 @@ Bool_t TXMLPlayer::ProduceSTLstreamer(std::ostream& fs, TClass* cl, TStreamerSTL
          fs << tabs << "} else {" << std::endl;
       }
 
-      fs << tabs2 << "buf.WriteSTLsize(" << accname
-                  << (isstr ? "length(), true);" : "size());") << std::endl;
+      fs << tabs2 << "buf.WriteSTLsize(" << accname << (isstr ? "length(), true);" : "size());") << std::endl;
 
       if (isstr) {
          fs << tabs2 << "buf.WriteSTLstringData(" << accname << "c_str());" << std::endl;
       } else {
          if (akaarrayaccess) {
-            fs << tabs2 << argtname[0] << "* arr = new " << argtname[0]
-                                       << "[" << accname << "size()];" << std::endl;
+            fs << tabs2 << argtname[0] << "* arr = new " << argtname[0] << "[" << accname << "size()];" << std::endl;
             fs << tabs2 << "int k = 0;" << std::endl;
          }
 
          fs << tabs2 << contcl->GetName() << "::const_iterator iter;" << std::endl;
-         fs << tabs2 << "for (iter = " << accname << "begin(); iter != "
-                    << accname << "end(); iter++)";
+         fs << tabs2 << "for (iter = " << accname << "begin(); iter != " << accname << "end(); iter++)";
          if (akaarrayaccess) {
             fs << std::endl << tabs2 << tab1 << "arr[k++] = *iter;" << std::endl;
             fs << tabs2 << "buf.WriteArray(arr, " << accname << "size(), 0, false);" << std::endl;
             fs << tabs2 << "delete[] arr;" << std::endl;
-         } else
-         if (narg==1) {
+         } else if (narg == 1) {
             fs << std::endl << tabs2 << tab1;
             WriteSTLarg(fs, "*iter", argtype[0], isargptr[0], argcl[0]);
-         } else
-         if (narg==2) {
+         } else if (narg == 2) {
             fs << " {" << std::endl;
             fs << tabs2 << tab1;
             WriteSTLarg(fs, "iter->first", argtype[0], isargptr[0], argcl[0]);
@@ -1101,7 +1108,8 @@ Bool_t TXMLPlayer::ProduceSTLstreamer(std::ostream& fs, TClass* cl, TStreamerSTL
          }
       } // if (isstr)
 
-      if (isptr) fs << tabs << "}" << std::endl;
+      if (isptr)
+         fs << tabs << "}" << std::endl;
 
       if (isarr && el->GetArrayLength()) {
          if (isptr)
@@ -1116,18 +1124,27 @@ Bool_t TXMLPlayer::ProduceSTLstreamer(std::ostream& fs, TClass* cl, TStreamerSTL
 
    } else {
 
-
-      fs << tab2 << "if (buf.VerifySTLnode(\""
-                 << fXmlSetup.XmlGetElementName(el) << "\")) {" << std::endl;
+      fs << tab2 << "if (buf.VerifySTLnode(\"" << fXmlSetup.XmlGetElementName(el) << "\")) {" << std::endl;
 
       fs << tab3 << contcl->GetName() << " ";
       TString accname, accptr;
       if (isptr) {
-         if (isarr) { fs << "**cont"; accname = "(*cont)->"; accptr = "*cont"; }
-            else { fs << "*cont"; accname = "cont->"; accptr = "cont"; }
-      } else
-      if (isarr) { fs << "*cont"; accname = "cont->"; }
-         else { fs << "&cont"; accname = "cont."; }
+         if (isarr) {
+            fs << "**cont";
+            accname = "(*cont)->";
+            accptr = "*cont";
+         } else {
+            fs << "*cont";
+            accname = "cont->";
+            accptr = "cont";
+         }
+      } else if (isarr) {
+         fs << "*cont";
+         accname = "cont->";
+      } else {
+         fs << "&cont";
+         accname = "cont.";
+      }
 
       fs << " = ";
 
@@ -1151,7 +1168,7 @@ Bool_t TXMLPlayer::ProduceSTLstreamer(std::ostream& fs, TClass* cl, TStreamerSTL
          if (!isarr) {
             char endch[5];
             fs << tabs << ElementSetter(cl, el->GetName(), endch);
-            fs         << "cont" << endch << ";" << std::endl;
+            fs << "cont" << endch << ";" << std::endl;
          }
       } else {
          fs << tabs << accname << (isstr ? "erase();" : "clear();") << std::endl;
@@ -1169,42 +1186,45 @@ Bool_t TXMLPlayer::ProduceSTLstreamer(std::ostream& fs, TClass* cl, TStreamerSTL
 
          if (akaarrayaccess) {
             fs << std::endl << tabs << tab1 << accname;
-            if ((stltyp==ROOT::kSTLset) || (stltyp==ROOT::kSTLmultiset))
-               fs << "insert"; else fs << "push_back";
+            if ((stltyp == ROOT::kSTLset) || (stltyp == ROOT::kSTLmultiset))
+               fs << "insert";
+            else
+               fs << "push_back";
             fs << "(arr[k]);" << std::endl;
             fs << tabs << "delete[] arr;" << std::endl;
-         } else
-         if (narg==1) {
+         } else if (narg == 1) {
             TString arg1("arg"), ifcond;
             fs << " {" << std::endl << tabs << tab1;
             ReadSTLarg(fs, arg1, argtype[0], isargptr[0], argcl[0], argtname[0], ifcond);
             fs << tabs << tab1;
-            if (ifcond.Length()>0) fs << "if (" << ifcond << ") ";
+            if (ifcond.Length() > 0)
+               fs << "if (" << ifcond << ") ";
             fs << accname;
-            if ((stltyp==ROOT::kSTLset) || (stltyp==ROOT::kSTLmultiset))
+            if ((stltyp == ROOT::kSTLset) || (stltyp == ROOT::kSTLmultiset))
                fs << "insert";
             else
                fs << "push_back";
             fs << "(" << arg1 << ");" << std::endl;
             fs << tabs << "}" << std::endl;
-         } else
-         if (narg==2) {
+         } else if (narg == 2) {
             TString arg1("arg1"), arg2("arg2"), ifcond;
             fs << " {" << std::endl << tabs << tab1;
             ReadSTLarg(fs, arg1, argtype[0], isargptr[0], argcl[0], argtname[0], ifcond);
             fs << tabs << tab1;
             ReadSTLarg(fs, arg2, argtype[1], isargptr[1], argcl[1], argtname[1], ifcond);
             fs << tabs << tab1;
-            if (ifcond.Length()>0) fs << "if (" << ifcond << ") ";
-            fs << accname << "insert(make_pair("
-               << arg1 << ", " << arg2 << "));" << std::endl;
+            if (ifcond.Length() > 0)
+               fs << "if (" << ifcond << ") ";
+            fs << accname << "insert(make_pair(" << arg1 << ", " << arg2 << "));" << std::endl;
             fs << tabs << "}" << std::endl;
          }
       }
 
       if (isarr && el->GetArrayLength()) {
-         if (isptr) fs << tabs << "cont++;" << std::endl;
-         else fs << tabs << "(void*) cont = (char*) cont + sizeof(" << contcl->GetName() << ");" << std::endl;
+         if (isptr)
+            fs << tabs << "cont++;" << std::endl;
+         else
+            fs << tabs << "(void*) cont = (char*) cont + sizeof(" << contcl->GetName() << ");" << std::endl;
          fs << tab3 << "}" << std::endl;
       }
 

--- a/io/xml/src/TXMLSetup.cxx
+++ b/io/xml/src/TXMLSetup.cxx
@@ -30,7 +30,6 @@
 
 //________________________________________________________________________
 
-
 #include "TXMLSetup.h"
 
 #include "TROOT.h"
@@ -44,55 +43,55 @@ ClassImp(TXMLSetup);
 
 namespace xmlio {
 
-   const char* Root        = "root";
-   const char* Setup       = "setup";
-   const char* ClassVersion= "version";
-   const char* IOVersion   = "version";
-   const char* OnlyVersion = "Version";
-   const char* Ptr         = "ptr";
-   const char* Ref         = "ref";
-   const char* Null        = "null";
-   const char* IdBase      = "id";
-   const char* Size        = "size";
-   const char* Xmlobject   = "XmlObject";
-   const char* Xmlkey      = "XmlKey";
-   const char* Cycle       = "cycle";
-   const char* XmlBlock    = "XmlBlock";
-   const char* Zip         = "zip";
-   const char* Object      = "Object";
-   const char* ObjClass    = "class";
-   const char* Class       = "Class";
-   const char* Member      = "Member";
-   const char* Item        = "Item";
-   const char* Name        = "name";
-   const char* Title       = "title";
-   const char* CreateTm    = "created";
-   const char* ModifyTm    = "modified";
-   const char* ObjectUUID  = "uuid";
-   const char* Type        = "type";
-   const char* Value       = "value";
-   const char* v           = "v";
-   const char* cnt         = "cnt";
-   const char* True        = "true";
-   const char* False       = "false";
-   const char* SInfos      = "StreamerInfos";
+const char *Root = "root";
+const char *Setup = "setup";
+const char *ClassVersion = "version";
+const char *IOVersion = "version";
+const char *OnlyVersion = "Version";
+const char *Ptr = "ptr";
+const char *Ref = "ref";
+const char *Null = "null";
+const char *IdBase = "id";
+const char *Size = "size";
+const char *Xmlobject = "XmlObject";
+const char *Xmlkey = "XmlKey";
+const char *Cycle = "cycle";
+const char *XmlBlock = "XmlBlock";
+const char *Zip = "zip";
+const char *Object = "Object";
+const char *ObjClass = "class";
+const char *Class = "Class";
+const char *Member = "Member";
+const char *Item = "Item";
+const char *Name = "name";
+const char *Title = "title";
+const char *CreateTm = "created";
+const char *ModifyTm = "modified";
+const char *ObjectUUID = "uuid";
+const char *Type = "type";
+const char *Value = "value";
+const char *v = "v";
+const char *cnt = "cnt";
+const char *True = "true";
+const char *False = "false";
+const char *SInfos = "StreamerInfos";
 
-   const char* Array       = "Array";
-   const char* Bool        = "Bool_t";
-   const char* Char        = "Char_t";
-   const char* Short       = "Short_t";
-   const char* Int         = "Int_t";
-   const char* Long        = "Long_t";
-   const char* Long64      = "Long64_t";
-   const char* Float       = "Float_t";
-   const char* Double      = "Double_t";
-   const char* UChar       = "UChar_t";
-   const char* UShort      = "UShort_t";
-   const char* UInt        = "UInt_t";
-   const char* ULong       = "ULong_t";
-   const char* ULong64     = "ULong64_t";
-   const char* String      = "string";
-   const char* CharStar    = "CharStar";
+const char *Array = "Array";
+const char *Bool = "Bool_t";
+const char *Char = "Char_t";
+const char *Short = "Short_t";
+const char *Int = "Int_t";
+const char *Long = "Long_t";
+const char *Long64 = "Long64_t";
+const char *Float = "Float_t";
+const char *Double = "Double_t";
+const char *UChar = "UChar_t";
+const char *UShort = "UShort_t";
+const char *UInt = "UInt_t";
+const char *ULong = "ULong_t";
+const char *ULong64 = "ULong64_t";
+const char *String = "string";
+const char *CharStar = "CharStar";
 };
 
 TString TXMLSetup::fgNameSpaceBase = "http://root.cern.ch/root/htmldoc/";
@@ -108,7 +107,7 @@ TString TXMLSetup::DefaultXmlSetup()
 ////////////////////////////////////////////////////////////////////////////////
 /// set namespace base
 
-void TXMLSetup::SetNameSpaceBase(const char* namespacebase)
+void TXMLSetup::SetNameSpaceBase(const char *namespacebase)
 {
    fgNameSpaceBase = namespacebase;
 }
@@ -116,24 +115,16 @@ void TXMLSetup::SetNameSpaceBase(const char* namespacebase)
 ////////////////////////////////////////////////////////////////////////////////
 /// default constructor of TXMLSetup class
 
-TXMLSetup::TXMLSetup() :
-   fXmlLayout(kSpecialized),
-   fStoreStreamerInfos(kTRUE),
-   fUseDtd(kFALSE),
-   fUseNamespaces(kFALSE),
-   fRefCounter(0)
+TXMLSetup::TXMLSetup()
+   : fXmlLayout(kSpecialized), fStoreStreamerInfos(kTRUE), fUseDtd(kFALSE), fUseNamespaces(kFALSE), fRefCounter(0)
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// creates TXMLSetup object getting values from string
 
-TXMLSetup::TXMLSetup(const char* opt) :
-   fXmlLayout(kSpecialized),
-   fStoreStreamerInfos(kTRUE),
-   fUseDtd(kFALSE),
-   fUseNamespaces(kFALSE),
-   fRefCounter(0)
+TXMLSetup::TXMLSetup(const char *opt)
+   : fXmlLayout(kSpecialized), fStoreStreamerInfos(kTRUE), fUseDtd(kFALSE), fUseNamespaces(kFALSE), fRefCounter(0)
 {
    ReadSetupFromStr(opt);
 }
@@ -141,12 +132,9 @@ TXMLSetup::TXMLSetup(const char* opt) :
 ////////////////////////////////////////////////////////////////////////////////
 /// copy constructor of TXMLSetup class
 
-TXMLSetup::TXMLSetup(const TXMLSetup& src) :
-   fXmlLayout(src.fXmlLayout),
-   fStoreStreamerInfos(src.fStoreStreamerInfos),
-   fUseDtd(src.fUseDtd),
-   fUseNamespaces(src.fUseNamespaces),
-   fRefCounter(0)
+TXMLSetup::TXMLSetup(const TXMLSetup &src)
+   : fXmlLayout(src.fXmlLayout), fStoreStreamerInfos(src.fStoreStreamerInfos), fUseDtd(src.fUseDtd),
+     fUseNamespaces(src.fUseNamespaces), fRefCounter(0)
 {
 }
 
@@ -164,7 +152,7 @@ TString TXMLSetup::GetSetupAsString()
 {
    char setupstr[10] = "2xxx";
 
-   setupstr[0] = char(48+fXmlLayout);
+   setupstr[0] = char(48 + fXmlLayout);
    setupstr[1] = fStoreStreamerInfos ? 'x' : 'o';
    setupstr[2] = fUseDtd ? 'x' : 'o';
    setupstr[3] = fUseNamespaces ? 'x' : 'o';
@@ -175,30 +163,36 @@ TString TXMLSetup::GetSetupAsString()
 ////////////////////////////////////////////////////////////////////////////////
 /// checks if string is valid setup
 
-Bool_t TXMLSetup::IsValidXmlSetup(const char* setupstr)
+Bool_t TXMLSetup::IsValidXmlSetup(const char *setupstr)
 {
-   if ((setupstr==0) || (strlen(setupstr)!=4)) return kFALSE;
+   if ((setupstr == 0) || (strlen(setupstr) != 4))
+      return kFALSE;
    TString str = setupstr;
    str.ToLower();
-   if ((str[0]<48) || (str[0]>53)) return kFALSE;
-   for (int n=1;n<4;n++)
-      if ((str[n]!='o') && (str[n]!='x')) return kFALSE;
+   if ((str[0] < 48) || (str[0] > 53))
+      return kFALSE;
+   for (int n = 1; n < 4; n++)
+      if ((str[n] != 'o') && (str[n] != 'x'))
+         return kFALSE;
    return kTRUE;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// get values from string
 
-Bool_t TXMLSetup::ReadSetupFromStr(const char* setupstr)
+Bool_t TXMLSetup::ReadSetupFromStr(const char *setupstr)
 {
-   if ((setupstr==0) || (strlen(setupstr)<4)) return kFALSE;
-   Int_t lay          = EXMLLayout(setupstr[0] - 48);
-   if (lay==kGeneralized) fXmlLayout = kGeneralized;
-                     else fXmlLayout = kSpecialized;
+   if ((setupstr == 0) || (strlen(setupstr) < 4))
+      return kFALSE;
+   Int_t lay = EXMLLayout(setupstr[0] - 48);
+   if (lay == kGeneralized)
+      fXmlLayout = kGeneralized;
+   else
+      fXmlLayout = kSpecialized;
 
-   fStoreStreamerInfos = setupstr[1]=='x';
-   fUseDtd            = kFALSE;
-   fUseNamespaces     = setupstr[3]=='x';
+   fStoreStreamerInfos = setupstr[1] == 'x';
+   fUseDtd = kFALSE;
+   fUseNamespaces = setupstr[3] == 'x';
    return kTRUE;
 }
 
@@ -217,49 +211,53 @@ void TXMLSetup::PrintSetup()
 ////////////////////////////////////////////////////////////////////////////////
 /// convert class name to exclude any special symbols like ':', '<' '>' ',' and spaces
 
-const char* TXMLSetup::XmlConvertClassName(const char* clname)
+const char *TXMLSetup::XmlConvertClassName(const char *clname)
 {
    fStrBuf = clname;
-   fStrBuf.ReplaceAll("<","_");
-   fStrBuf.ReplaceAll(">","_");
-   fStrBuf.ReplaceAll(",","_");
-   fStrBuf.ReplaceAll(" ","_");
-   fStrBuf.ReplaceAll(":","_");
+   fStrBuf.ReplaceAll("<", "_");
+   fStrBuf.ReplaceAll(">", "_");
+   fStrBuf.ReplaceAll(",", "_");
+   fStrBuf.ReplaceAll(" ", "_");
+   fStrBuf.ReplaceAll(":", "_");
    return fStrBuf.Data();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// produce string which used as reference in class namespace definition
 
-const char* TXMLSetup::XmlClassNameSpaceRef(const TClass* cl)
+const char *TXMLSetup::XmlClassNameSpaceRef(const TClass *cl)
 {
    TString clname = XmlConvertClassName(cl->GetName());
    fStrBuf = fgNameSpaceBase;
    fStrBuf += clname;
    if (fgNameSpaceBase == "http://root.cern.ch/root/htmldoc/")
-     fStrBuf += ".html";
+      fStrBuf += ".html";
    return fStrBuf.Data();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 ///  return converted name for TStreamerElement
 
-const char* TXMLSetup::XmlGetElementName(const TStreamerElement* el)
+const char *TXMLSetup::XmlGetElementName(const TStreamerElement *el)
 {
-   if (el==0) return 0;
-   if (!el->InheritsFrom(TStreamerSTL::Class())) return el->GetName();
-   if (strcmp(el->GetName(), el->GetClassPointer()->GetName())!=0) return el->GetName();
+   if (el == 0)
+      return 0;
+   if (!el->InheritsFrom(TStreamerSTL::Class()))
+      return el->GetName();
+   if (strcmp(el->GetName(), el->GetClassPointer()->GetName()) != 0)
+      return el->GetName();
    return XmlConvertClassName(el->GetName());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// get item name for given element
 
-const char* TXMLSetup::GetElItemName(TStreamerElement* el)
+const char *TXMLSetup::GetElItemName(TStreamerElement *el)
 {
-   if (el==0) return 0;
+   if (el == 0)
+      return 0;
    fStrBuf = el->GetName();
-   fStrBuf+="_item";
+   fStrBuf += "_item";
    return fStrBuf.Data();
 }
 
@@ -267,15 +265,17 @@ const char* TXMLSetup::GetElItemName(TStreamerElement* el)
 /// define class for the converted class name, where
 /// special symbols were replaced by '_'
 
-TClass* TXMLSetup::XmlDefineClass(const char* xmlClassName)
+TClass *TXMLSetup::XmlDefineClass(const char *xmlClassName)
 {
-   if (strchr(xmlClassName,'_')==0) return TClass::GetClass(xmlClassName);
+   if (strchr(xmlClassName, '_') == 0)
+      return TClass::GetClass(xmlClassName);
 
    TIter iter(gROOT->GetListOfClasses());
-   TClass* cl = 0;
-   while ((cl = (TClass*) iter()) != 0) {
-      const char* name = XmlConvertClassName(cl->GetName());
-      if (strcmp(xmlClassName,name)==0) return cl;
+   TClass *cl = 0;
+   while ((cl = (TClass *)iter()) != 0) {
+      const char *name = XmlConvertClassName(cl->GetName());
+      if (strcmp(xmlClassName, name) == 0)
+         return cl;
    }
    return 0;
 }
@@ -284,9 +284,10 @@ TClass* TXMLSetup::XmlDefineClass(const char* xmlClassName)
 /// converts string to integer.
 /// if error, returns default value
 
-Int_t TXMLSetup::AtoI(const char* sbuf, Int_t def, const char* errinfo)
+Int_t TXMLSetup::AtoI(const char *sbuf, Int_t def, const char *errinfo)
 {
-   if (sbuf) return atoi(sbuf);
+   if (sbuf)
+      return atoi(sbuf);
    if (errinfo)
       std::cerr << "<Error in TXMLSetup::AtoI>" << errinfo << " not valid integer: sbuf <NULL>" << std::endl;
    return def;

--- a/io/xml/src/TXMLSetup.cxx
+++ b/io/xml/src/TXMLSetup.cxx
@@ -13,7 +13,7 @@
 //
 // Class TXMLSetup is used as storage of xml file settings
 // This class is used in TXMLFile and in TXmlBuffer classes.
-// Xml settings can be codded via a string in following format
+// Xml settings can be coded via a string in following format
 //
 //   "2xoo"
 //    ||| \ .
@@ -114,7 +114,7 @@ void TXMLSetup::SetNameSpaceBase(const char* namespacebase)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// defaule constructor of TXMLSetup class
+/// default constructor of TXMLSetup class
 
 TXMLSetup::TXMLSetup() :
    fXmlLayout(kSpecialized),
@@ -126,7 +126,7 @@ TXMLSetup::TXMLSetup() :
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// contsruct TXMLSetup object getting values from string
+/// creates TXMLSetup object getting values from string
 
 TXMLSetup::TXMLSetup(const char* opt) :
    fXmlLayout(kSpecialized),
@@ -139,7 +139,7 @@ TXMLSetup::TXMLSetup(const char* opt) :
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// copy sonstructor of TXMLSetup class
+/// copy constructor of TXMLSetup class
 
 TXMLSetup::TXMLSetup(const TXMLSetup& src) :
    fXmlLayout(src.fXmlLayout),


### PR DESCRIPTION
Through continuous changes in TFile/TDirectoryFile functionality,
sub-directory support in TXMLFile was lost. Now reintroduced again.

Make similar changes for TSQLFile (only for historical reasons, seems to be nobody using it)

Reformat source code with clang format