### PR TITLE
[cxxmodules] Also include explicitly assert

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1282,7 +1282,8 @@ TCling::TCling(const char *name, const char *title)
    if (fromRootCling) {
       fInterpreter->declare("#include \"RtypesCore.h\"\n"
                             "#include <string>\n"
-                            "using std::string;");
+                            "using std::string;\n"
+                            "#include <cassert>\n");
    } else {
       fInterpreter->declare("#include \"Rtypes.h\"\n"
                             + gClassDefInterpMacro + "\n"
@@ -1290,7 +1291,8 @@ TCling::TCling(const char *name, const char *title)
                             + "#undef ClassImp\n"
                             "#define ClassImp(X);\n"
                             "#include <string>\n"
-                            "using namespace std;");
+                            "using namespace std;\n"
+                            "#include <cassert>\n");
    }
 
    // Setup core C++ modules if we have any to setup.


### PR DESCRIPTION
Assert isn't included from the STL/libc module as it's a textual
header which needs to be textually parsed. Let's add it to the
TCling `declare` call to cheaply get assert with modules into
the lookup.