### PR TITLE
[cxxmodules] Allow rootcling to load system modules using the overlays.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1230,9 +1230,10 @@ TCling::TCling(const char *name, const char *title)
 
    // Activate C++ modules support. If we are running within rootcling, it's up
    // to rootcling to set this flag depending on whether it wants to produce
-   // C++ modules.
+   // C++ modules. Unless we are running in stage 2 where rootcling will require
+   // TCling's interpreter information.
    TString vfsArg;
-   if (useCxxModules && !fromRootCling) {
+   if (useCxxModules && getenv("ROOT_MODULES")) {
       // We only set this flag, rest is done by the CIFactory.
       interpArgs.push_back("-fmodules");
       // We should never build modules during runtime, so let's enable the


### PR DESCRIPTION
Rootcling's stage2 mode calls gDriverConfig->fTCling__GetInterpreter() to
get the TCling's instance of the cling interpreter. This in turn might
need to initialize TCling.

Our modules setup preloads a modulemap but not the overlays preventing
system modules such as libc and stl to be loaded. This criples rootcling
and whenever it #includes a header file we get an error that we included
a module from ROOT which depends on modules stl but it is not accessible
through the module map.