### PR TITLE
[cxxmodules] Also preload TMVA/TreePlayer/Graf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,7 +347,7 @@ if(runtime_cxxmodules)
   # we will always load them to workaround the fact that we can't
   # load the decls in them via rootmap files (as they are inside
   # namespaces which isn't supported).
-  add_custom_target(onepcm DEPENDS Net Math TreeViewer RooStats Hist Gpad TreePlayer RooFit EG RGL TMVA TMVAGui Graf GenVector)
+  add_custom_target(onepcm DEPENDS Net MathCore TreeViewer RooStats Hist Gpad TreePlayer RooFit EG RGL TMVA TMVAGui Graf GenVector)
 else()
   add_custom_command(OUTPUT etc/allDict.cxx.pch
                     COMMAND ${CMAKE_COMMAND} -E env ROOTIGNOREPREFIX=1 ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/etc/dictpch/makepch.py etc/allDict.cxx.pch ${__allIncludes} -I${CMAKE_BINARY_DIR}/include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,7 +347,7 @@ if(runtime_cxxmodules)
   # we will always load them to workaround the fact that we can't
   # load the decls in them via rootmap files (as they are inside
   # namespaces which isn't supported).
-  add_custom_target(onepcm DEPENDS TreePlayer TMVA Graf)
+  add_custom_target(onepcm DEPENDS RooStats Gpad TreePlayer TMVA Graf)
 else()
   add_custom_command(OUTPUT etc/allDict.cxx.pch
                     COMMAND ${CMAKE_COMMAND} -E env ROOTIGNOREPREFIX=1 ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/etc/dictpch/makepch.py etc/allDict.cxx.pch ${__allIncludes} -I${CMAKE_BINARY_DIR}/include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,7 +347,7 @@ if(runtime_cxxmodules)
   # we will always load them to workaround the fact that we can't
   # load the decls in them via rootmap files (as they are inside
   # namespaces which isn't supported).
-  add_custom_target(onepcm DEPENDS Net TreeViewer RooStats Hist Gpad TreePlayer TMVA Graf GenVector)
+  add_custom_target(onepcm DEPENDS Net Math TreeViewer RooStats Hist Gpad TreePlayer TMVA Graf GenVector)
 else()
   add_custom_command(OUTPUT etc/allDict.cxx.pch
                     COMMAND ${CMAKE_COMMAND} -E env ROOTIGNOREPREFIX=1 ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/etc/dictpch/makepch.py etc/allDict.cxx.pch ${__allIncludes} -I${CMAKE_BINARY_DIR}/include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,7 +347,7 @@ if(runtime_cxxmodules)
   # we will always load them to workaround the fact that we can't
   # load the decls in them via rootmap files (as they are inside
   # namespaces which isn't supported).
-  add_custom_target(onepcm DEPENDS Net Math TreeViewer RooStats Hist Gpad TreePlayer RooFit TMVA TMVAGui Graf GenVector)
+  add_custom_target(onepcm DEPENDS Net Math TreeViewer RooStats Hist Gpad TreePlayer RooFit RGL TMVA TMVAGui Graf GenVector)
 else()
   add_custom_command(OUTPUT etc/allDict.cxx.pch
                     COMMAND ${CMAKE_COMMAND} -E env ROOTIGNOREPREFIX=1 ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/etc/dictpch/makepch.py etc/allDict.cxx.pch ${__allIncludes} -I${CMAKE_BINARY_DIR}/include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,7 +347,7 @@ if(runtime_cxxmodules)
   # we will always load them to workaround the fact that we can't
   # load the decls in them via rootmap files (as they are inside
   # namespaces which isn't supported).
-  add_custom_target(onepcm DEPENDS Net RooStats Hist Gpad TreePlayer TMVA Graf GenVector)
+  add_custom_target(onepcm DEPENDS Net TreeViewer RooStats Hist Gpad TreePlayer TMVA Graf GenVector)
 else()
   add_custom_command(OUTPUT etc/allDict.cxx.pch
                     COMMAND ${CMAKE_COMMAND} -E env ROOTIGNOREPREFIX=1 ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/etc/dictpch/makepch.py etc/allDict.cxx.pch ${__allIncludes} -I${CMAKE_BINARY_DIR}/include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,7 +347,7 @@ if(runtime_cxxmodules)
   # we will always load them to workaround the fact that we can't
   # load the decls in them via rootmap files (as they are inside
   # namespaces which isn't supported).
-  add_custom_target(onepcm DEPENDS RooStats Hist Gpad TreePlayer TMVA Graf GenVector)
+  add_custom_target(onepcm DEPENDS Net RooStats Hist Gpad TreePlayer TMVA Graf GenVector)
 else()
   add_custom_command(OUTPUT etc/allDict.cxx.pch
                     COMMAND ${CMAKE_COMMAND} -E env ROOTIGNOREPREFIX=1 ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/etc/dictpch/makepch.py etc/allDict.cxx.pch ${__allIncludes} -I${CMAKE_BINARY_DIR}/include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,7 +347,7 @@ if(runtime_cxxmodules)
   # we will always load them to workaround the fact that we can't
   # load the decls in them via rootmap files (as they are inside
   # namespaces which isn't supported).
-  add_custom_target(onepcm DEPENDS RooStats Gpad TreePlayer TMVA Graf GenVector)
+  add_custom_target(onepcm DEPENDS RooStats Hist Gpad TreePlayer TMVA Graf GenVector)
 else()
   add_custom_command(OUTPUT etc/allDict.cxx.pch
                     COMMAND ${CMAKE_COMMAND} -E env ROOTIGNOREPREFIX=1 ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/etc/dictpch/makepch.py etc/allDict.cxx.pch ${__allIncludes} -I${CMAKE_BINARY_DIR}/include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,7 +347,7 @@ if(runtime_cxxmodules)
   # we will always load them to workaround the fact that we can't
   # load the decls in them via rootmap files (as they are inside
   # namespaces which isn't supported).
-  add_custom_target(onepcm DEPENDS Net Math TreeViewer RooStats Hist Gpad TreePlayer RooFit RGL TMVA TMVAGui Graf GenVector)
+  add_custom_target(onepcm DEPENDS Net Math TreeViewer RooStats Hist Gpad TreePlayer RooFit EG RGL TMVA TMVAGui Graf GenVector)
 else()
   add_custom_command(OUTPUT etc/allDict.cxx.pch
                     COMMAND ${CMAKE_COMMAND} -E env ROOTIGNOREPREFIX=1 ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/etc/dictpch/makepch.py etc/allDict.cxx.pch ${__allIncludes} -I${CMAKE_BINARY_DIR}/include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,7 +347,7 @@ if(runtime_cxxmodules)
   # we will always load them to workaround the fact that we can't
   # load the decls in them via rootmap files (as they are inside
   # namespaces which isn't supported).
-  add_custom_target(onepcm DEPENDS Net Math TreeViewer RooStats Hist Gpad TreePlayer TMVA TMVAGui Graf GenVector)
+  add_custom_target(onepcm DEPENDS Net Math TreeViewer RooStats Hist Gpad TreePlayer RooFit TMVA TMVAGui Graf GenVector)
 else()
   add_custom_command(OUTPUT etc/allDict.cxx.pch
                     COMMAND ${CMAKE_COMMAND} -E env ROOTIGNOREPREFIX=1 ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/etc/dictpch/makepch.py etc/allDict.cxx.pch ${__allIncludes} -I${CMAKE_BINARY_DIR}/include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,7 +347,7 @@ if(runtime_cxxmodules)
   # we will always load them to workaround the fact that we can't
   # load the decls in them via rootmap files (as they are inside
   # namespaces which isn't supported).
-  add_custom_target(onepcm DEPENDS RooStats Gpad TreePlayer TMVA Graf)
+  add_custom_target(onepcm DEPENDS RooStats Gpad TreePlayer TMVA Graf GenVector)
 else()
   add_custom_command(OUTPUT etc/allDict.cxx.pch
                     COMMAND ${CMAKE_COMMAND} -E env ROOTIGNOREPREFIX=1 ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/etc/dictpch/makepch.py etc/allDict.cxx.pch ${__allIncludes} -I${CMAKE_BINARY_DIR}/include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,7 +343,11 @@ endif()
 
 if(runtime_cxxmodules)
   # Dummy target that does nothing, we don't need a PCH for modules.
-  add_custom_target(onepcm)
+  # However, we require that TMVA/Graf/Treeplayer are built here as
+  # we will always load them to workaround the fact that we can't
+  # load the decls in them via rootmap files (as they are inside
+  # namespaces which isn't supported).
+  add_custom_target(onepcm DEPENDS TreePlayer TMVA Graf)
 else()
   add_custom_command(OUTPUT etc/allDict.cxx.pch
                     COMMAND ${CMAKE_COMMAND} -E env ROOTIGNOREPREFIX=1 ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/etc/dictpch/makepch.py etc/allDict.cxx.pch ${__allIncludes} -I${CMAKE_BINARY_DIR}/include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,7 +347,7 @@ if(runtime_cxxmodules)
   # we will always load them to workaround the fact that we can't
   # load the decls in them via rootmap files (as they are inside
   # namespaces which isn't supported).
-  add_custom_target(onepcm DEPENDS Net Math TreeViewer RooStats Hist Gpad TreePlayer TMVA Graf GenVector)
+  add_custom_target(onepcm DEPENDS Net Math TreeViewer RooStats Hist Gpad TreePlayer TMVA TMVAGui Graf GenVector)
 else()
   add_custom_command(OUTPUT etc/allDict.cxx.pch
                     COMMAND ${CMAKE_COMMAND} -E env ROOTIGNOREPREFIX=1 ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/etc/dictpch/makepch.py etc/allDict.cxx.pch ${__allIncludes} -I${CMAKE_BINARY_DIR}/include

--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -366,7 +366,8 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
     endforeach()
   endif()
 
-  if(runtime_cxxmodules AND ARG_MODULE)
+  set(runtime_cxxmodules_env)
+  if(runtime_cxxmodules AND ARG_MODULE AND NOT ARG_MULTIDICT)
     # FIXME: Once modules work better, we should use some other value like "1"
     # to disable the module-build remarks from clang.
     set(runtime_cxxmodules_env "ROOT_MODULES=DEBUG")

--- a/core/base/inc/TROOT.h
+++ b/core/base/inc/TROOT.h
@@ -309,7 +309,8 @@ public:
                                     const char* fwdDeclCode,
                                     void (*triggerFunc)(),
                                     const FwdDeclArgsToKeepCollection_t& fwdDeclsArgToSkip,
-                                    const char** classesHeaders);
+                                    const char** classesHeaders,
+                                    bool hasCxxModule = false);
    TObject          *Remove(TObject*);
    void              RemoveClass(TClass *);
    void              Reset(Option_t *option="");

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -258,7 +258,8 @@ namespace {
                          const char* fwdDeclCode,
                          void (*triggerFunc)(),
                          const TROOT::FwdDeclArgsToKeepCollection_t& fwdDeclsArgToSkip,
-                         const char** classesHeaders):
+                         const char **classesHeaders,
+                         bool hasCxxModule):
                            fModuleName(moduleName),
                            fHeaders(headers),
                            fPayloadCode(payloadCode),
@@ -266,7 +267,8 @@ namespace {
                            fIncludePaths(includePaths),
                            fTriggerFunc(triggerFunc),
                            fClassesHeaders(classesHeaders),
-                           fFwdNargsToKeepColl(fwdDeclsArgToSkip){}
+                           fFwdNargsToKeepColl(fwdDeclsArgToSkip),
+                           fHasCxxModule(hasCxxModule) {}
 
       const char* fModuleName; // module name
       const char** fHeaders; // 0-terminated array of header files
@@ -277,6 +279,7 @@ namespace {
       const char** fClassesHeaders; // 0-terminated list of classes and related header files
       const TROOT::FwdDeclArgsToKeepCollection_t fFwdNargsToKeepColl; // Collection of
                                                                       // pairs of template fwd decls and number of
+      bool fHasCxxModule; // Whether this module has a C++ module alongside it.
    };
 
    std::vector<ModuleHeaderInfo_t>& GetModuleHeaderInfoBuffer() {
@@ -2068,7 +2071,8 @@ void TROOT::InitInterpreter()
                                    li->fTriggerFunc,
                                    li->fFwdNargsToKeepColl,
                                    li->fClassesHeaders,
-                                   kTRUE /*lateRegistration*/);
+                                   kTRUE /*lateRegistration*/,
+                                   li->fHasCxxModule);
    }
    GetModuleHeaderInfoBuffer().clear();
 
@@ -2477,7 +2481,8 @@ void TROOT::RegisterModule(const char* modulename,
                            const char* fwdDeclCode,
                            void (*triggerFunc)(),
                            const TInterpreter::FwdDeclArgsToKeepCollection_t& fwdDeclsArgToSkip,
-                           const char** classesHeaders)
+                           const char** classesHeaders,
+                           bool hasCxxModule)
 {
 
    // First a side track to insure proper end of process behavior.
@@ -2539,12 +2544,12 @@ void TROOT::RegisterModule(const char* modulename,
 
    // Now register with TCling.
    if (gCling) {
-      gCling->RegisterModule(modulename, headers, includePaths, payloadCode, fwdDeclCode,
-                             triggerFunc, fwdDeclsArgToSkip, classesHeaders);
+      gCling->RegisterModule(modulename, headers, includePaths, payloadCode, fwdDeclCode, triggerFunc,
+                             fwdDeclsArgToSkip, classesHeaders, false, hasCxxModule);
    } else {
-      GetModuleHeaderInfoBuffer()
-         .push_back(ModuleHeaderInfo_t (modulename, headers, includePaths, payloadCode, fwdDeclCode,
-                                        triggerFunc, fwdDeclsArgToSkip,classesHeaders));
+      GetModuleHeaderInfoBuffer().push_back(ModuleHeaderInfo_t(modulename, headers, includePaths, payloadCode,
+                                                               fwdDeclCode, triggerFunc, fwdDeclsArgToSkip,
+                                                               classesHeaders, hasCxxModule));
    }
 }
 

--- a/core/dictgen/src/TModuleGenerator.cxx
+++ b/core/dictgen/src/TModuleGenerator.cxx
@@ -462,7 +462,7 @@ void TModuleGenerator::WriteRegistrationSource(std::ostream &out,
                               "    if (!isInitialized) {\n"
                               "      TROOT::RegisterModule(\"" << GetDemangledDictionaryName() << "\",\n"
                               "        headers, includePaths, payloadCode, fwdDeclCode,\n"
-                              "        TriggerDictionaryInitialization_" << GetDictionaryName() << "_Impl, " << fwdDeclnArgsToKeepString << ", classesHeaders);\n"
+                              "        TriggerDictionaryInitialization_" << GetDictionaryName() << "_Impl, " << fwdDeclnArgsToKeepString << ", classesHeaders, " << (fCI->getLangOpts().Modules ? "/*has C++ module*/true" : "/*has no C++ module*/false") << ");\n"
                               "      isInitialized = true;\n"
                               "    }\n"
                               "  }\n"

--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -154,7 +154,8 @@ public:
                                    void (* /*triggerFunc*/)(),
                                    const FwdDeclArgsToKeepCollection_t& fwdDeclArgsToKeep,
                                    const char** classesHeaders,
-                                   Bool_t lateRegistration = false) = 0;
+                                   Bool_t lateRegistration = false,
+                                   Bool_t hasCxxModule = false) = 0;
    virtual void     RegisterTClassUpdate(TClass *oldcl,DictFuncPtr_t dict) = 0;
    virtual void     UnRegisterTClassUpdate(const TClass *oldcl) = 0;
    virtual Int_t    SetClassSharedLibs(const char *cls, const char *libs) = 0;

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1379,7 +1379,7 @@ void TCling::Initialize()
    if (fInterpreter->getCI()->getLangOpts().Modules && !IsFromRootCling()) {
       // Load modules that we can't automatically load via rootmap files as they
       // contain decls in namespaces which aren't supported.
-      LoadModules({"TMVA", "Gpad", "RooStats", "GenVector", "Hist", "Net", "TreePlayer", "Graf"}, *fInterpreter);
+      LoadModules({"TMVA", "Gpad", "RooStats", "GenVector", "Hist", "Net", "TreePlayer", "TreeViewer", "Graf"}, *fInterpreter);
    }
 }
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1269,6 +1269,7 @@ TCling::TCling(const char *name, const char *title)
       HeaderSearch& hdrSearch = fInterpreter->getCI()->getPreprocessor().getHeaderSearchInfo();
       hdrSearch.loadTopLevelSystemModules();
       loadModulePath(hdrSearch, gSystem->GetDynamicPath());
+      fInterpreter->getCI()->getHeaderSearchOpts().AddPrebuiltModulePath(".");
 
       // Setup core C++ modules if we have any to setup.
       LoadModules({"libc", "stl", "ROOT_Types", "Core", "RIO"}, *fInterpreter);

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1152,8 +1152,6 @@ TCling::TCling(const char *name, const char *title)
 #ifdef R__USE_CXXMODULES
    useCxxModules = true;
 #endif
-   if (useCxxModules)
-     fHeaderParsingOnDemand = false;
 
    llvm::install_fatal_error_handler(&exceptionErrorHandler);
 
@@ -1789,7 +1787,22 @@ void TCling::RegisterModule(const char* modulename,
       } // if (dyLibName)
    } // if (!lateRegistration)
 
-   if (hasHeaderParsingOnDemand && fwdDeclsCode){
+   clang::Sema &TheSema = fInterpreter->getSema();
+   bool ModuleWasSuccessfullyLoaded = false;
+   if (hasCxxModule) {
+      std::string ModuleName = llvm::StringRef(modulename).substr(3).str();
+      ModuleWasSuccessfullyLoaded = LoadModule(ModuleName, *fInterpreter);
+      if (!ModuleWasSuccessfullyLoaded) {
+         // Only report if we found the module in the modulemap.
+         clang::Preprocessor &PP = TheSema.getPreprocessor();
+         clang::HeaderSearch &headerSearch = PP.getHeaderSearchInfo();
+         clang::ModuleMap &moduleMap = headerSearch.getModuleMap();
+         if (moduleMap.findModule(ModuleName))
+            Info("TCling::RegisterModule", "Module %s in modulemap failed to load.", ModuleName.c_str());
+      }
+   }
+
+   if (!ModuleWasSuccessfullyLoaded && hasHeaderParsingOnDemand && fwdDeclsCode){
       // We now parse the forward declarations. All the classes are then modified
       // in order for them to have an external lexical storage.
       std::string fwdDeclsCodeLessEnums;
@@ -1926,21 +1939,7 @@ void TCling::RegisterModule(const char* modulename,
    if (fClingCallbacks)
      oldValue = SetClassAutoloading(false);
 
-   clang::Sema &TheSema = fInterpreter->getSema();
 
-   bool ModuleWasSuccessfullyLoaded = false;
-   if (hasCxxModule) {
-      std::string ModuleName = llvm::StringRef(modulename).substr(3).str();
-      ModuleWasSuccessfullyLoaded = LoadModule(ModuleName, *fInterpreter);
-      if (!ModuleWasSuccessfullyLoaded) {
-         // Only report if we found the module in the modulemap.
-         clang::Preprocessor &PP = TheSema.getPreprocessor();
-         clang::HeaderSearch &headerSearch = PP.getHeaderSearchInfo();
-         clang::ModuleMap &moduleMap = headerSearch.getModuleMap();
-         if (moduleMap.findModule(ModuleName))
-            Info("TCling::RegisterModule", "Module %s in modulemap failed to load.", ModuleName.c_str());
-      }
-   }
 
    { // scope within which diagnostics are de-activated
    // For now we disable diagnostics because we saw them already at

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1380,7 +1380,7 @@ void TCling::Initialize()
    if (fInterpreter->getCI()->getLangOpts().Modules && !IsFromRootCling()) {
       // Load modules that we can't automatically load via rootmap files as they
       // contain decls in namespaces which aren't supported.
-      LoadModules({"TMVA", "Gpad", "RooStats", "GenVector", "Hist", "TreePlayer", "Graf"}, *fInterpreter);
+      LoadModules({"TMVA", "Gpad", "RooStats", "GenVector", "Hist", "Net", "TreePlayer", "Graf"}, *fInterpreter);
    }
 }
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1356,6 +1356,11 @@ TCling::~TCling()
 void TCling::Initialize()
 {
    fClingCallbacks->Initialize();
+   if (fInterpreter->getCI()->getLangOpts().Modules && !IsFromRootCling()) {
+      // Load modules that we can't automatically load via rootmap files as they
+      // contain decls in namespaces which aren't supported.
+      LoadModules({"TMVA", "TreePlayer", "Graf"}, *fInterpreter);
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1065,8 +1065,10 @@ inline bool TCling::TUniqueString::Append(const std::string& str)
    return notPresent;
 }
 
+////////////////////////////////////////////////////////////////////////////////
 ///\returns true if the module was loaded.
-static bool LoadModule(const std::string &ModuleName, cling::Interpreter &interp) {
+static bool LoadModule(const std::string &ModuleName, cling::Interpreter &interp, bool Complain = true)
+{
    clang::CompilerInstance &CI = *interp.getCI();
 
    assert(CI.getLangOpts().Modules && "Function only relevant when C++ modules are turned on!");
@@ -1080,57 +1082,30 @@ static bool LoadModule(const std::string &ModuleName, cling::Interpreter &interp
       clang::IdentifierInfo *II = PP.getIdentifierInfo(M->Name);
       SourceLocation ValidLoc = M->DefinitionLoc;
       bool success = !CI.getSema().ActOnModuleImport(ValidLoc, ValidLoc, std::make_pair(II, ValidLoc)).isInvalid();
-      // Also make the module visible in the preprocessor to export its macros.
-      PP.makeModuleVisible(M, ValidLoc);
-      return success;
+      if (success) {
+         // Also make the module visible in the preprocessor to export its macros.
+         PP.makeModuleVisible(M, ValidLoc);
+         return success;
+      }
+      if (Complain) {
+         if (M->IsSystem)
+            Error("TCling::LoadModule", "Module %s failed to load", M->Name.c_str());
+         else
+            Info("TCling::LoadModule", "Module %s failed to load", M->Name.c_str());
+      }
    }
+   if (Complain)
+      Error("TCling::LoadModule", "Module %s not found!", ModuleName.c_str());
    return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Loads the basic C++ modules that we require to run any ROOT program.
-/// This is just supposed to make the declarations in their headers available
-/// to the interpreter.
-static void LoadCoreModules(cling::Interpreter &interp)
+/// Loads the C++ modules that we require to run any ROOT program. This is just
+/// supposed to make a C++ module from a modulemap available to the interpreter.
+static void LoadModules(const std::vector<std::string> &modules, cling::Interpreter &interp)
 {
-   clang::CompilerInstance &CI = *interp.getCI();
-   // Without modules, this function is just a no-op.
-   if (!CI.getLangOpts().Modules)
-      return;
-
-   clang::HeaderSearch &headerSearch = CI.getPreprocessor().getHeaderSearchInfo();
-   clang::ModuleMap &moduleMap = headerSearch.getModuleMap();
-   // List of core modules we can load, but it's ok if they are missing because
-   // the system doesn't have these modules.
-   if (clang::Module *LIBCM = moduleMap.findModule("libc"))
-      if (!LoadModule(LIBCM->Name, interp))
-         Error("TCling::LoadCoreModules", "Cannot load module %s", LIBCM->Name.c_str());
-
-   if (clang::Module *STLM = moduleMap.findModule("stl"))
-      if (!LoadModule(STLM->Name, interp))
-         Error("TCling::LoadCoreModules", "Cannot load module %s", STLM->Name.c_str());
-
-   // ROOT_Types is a module outside core because we need C and -no-rtti compatibility.
-   // Preload it as it is an integral part of module Core.
-   if (!LoadModule(moduleMap.findModule("ROOT_Types")->Name, interp))
-      Error("TCling::LoadCoreModules", "Cannot load module ROOT_Types");
-
-   if (!LoadModule(moduleMap.findModule("Core")->Name, interp))
-      Error("TCling::LoadCoreModules", "Cannot load module Core");
-
-   if (!LoadModule(moduleMap.findModule("RIO")->Name, interp))
-      Error("TCling::LoadCoreModules", "Cannot load module RIO");
-
-   // Check that the gROOT macro was exported by any core module.
-   assert(interp.getMacro("gROOT") && "Couldn't load gROOT macro?");
-
-   // C99 decided that it's a very good idea to name a macro `I` (the letter I).
-   // This seems to screw up nearly all the template code out there as `I` is
-   // common template parameter name and iterator variable name.
-   // Let's follow the GCC recommendation and undefine `I` in case any of the
-   // core modules have defined it:
-   // https://www.gnu.org/software/libc/manual/html_node/Complex-Numbers.html
-   interp.declare("#ifdef I\n #undef I\n #endif\n");
+   for (const auto &modName : modules)
+      LoadModule(modName, interp);
 }
 
 static bool FileExists(const char *file)
@@ -1274,6 +1249,22 @@ TCling::TCling(const char *name, const char *title)
    static llvm::raw_fd_ostream fMPOuts (STDOUT_FILENO, /*ShouldClose*/false);
    fMetaProcessor = new cling::MetaProcessor(*fInterpreter, fMPOuts);
 
+   if (fInterpreter->getCI()->getLangOpts().Modules) {
+      // Setup core C++ modules if we have any to setup.
+      LoadModules({"libc", "stl", "ROOT_Types", "Core", "RIO"}, *fInterpreter);
+
+      // Check that the gROOT macro was exported by any core module.
+      assert(fInterpreter->getMacro("gROOT") && "Couldn't load gROOT macro?");
+
+      // C99 decided that it's a very good idea to name a macro `I` (the letter I).
+      // This seems to screw up nearly all the template code out there as `I` is
+      // common template parameter name and iterator variable name.
+      // Let's follow the GCC recommendation and undefine `I` in case any of the
+      // core modules have defined it:
+      // https://www.gnu.org/software/libc/manual/html_node/Complex-Numbers.html
+      fInterpreter->declare("#ifdef I\n #undef I\n #endif\n");
+   }
+
    // For the list to also include string, we have to include it now.
    // rootcling does parts already if needed, e.g. genreflex does not want using
    // namespace std.
@@ -1292,9 +1283,6 @@ TCling::TCling(const char *name, const char *title)
                             "using namespace std;\n"
                             "#include <cassert>\n");
    }
-
-   // Setup core C++ modules if we have any to setup.
-   LoadCoreModules(*fInterpreter);
 
    // We are now ready (enough is loaded) to init the list of opaque typedefs.
    fNormalizedCtxt = new ROOT::TMetaUtils::TNormalizedCtxt(fInterpreter->getLookupHelper());

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1380,7 +1380,7 @@ void TCling::Initialize()
    if (fInterpreter->getCI()->getLangOpts().Modules && !IsFromRootCling()) {
       // Load modules that we can't automatically load via rootmap files as they
       // contain decls in namespaces which aren't supported.
-      LoadModules({"TMVA", "Gpad", "RooStats", "GenVector", "Hist", "Math", "Net", "TreePlayer", "TreeViewer", "Graf"}, *fInterpreter);
+      LoadModules({"TMVA", "TMVAGui", "Gpad", "RooStats", "GenVector", "Hist", "Math", "Net", "TreePlayer", "TreeViewer", "Graf"}, *fInterpreter);
    }
 }
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1380,7 +1380,7 @@ void TCling::Initialize()
    if (fInterpreter->getCI()->getLangOpts().Modules && !IsFromRootCling()) {
       // Load modules that we can't automatically load via rootmap files as they
       // contain decls in namespaces which aren't supported.
-      LoadModules({"TMVA", "RGL", "RooFit", "TMVAGui", "Gpad", "RooStats", "GenVector", "Hist", "Math", "Net", "TreePlayer", "TreeViewer", "Graf"}, *fInterpreter);
+      LoadModules({"TMVA", "EG", "RGL", "RooFit", "TMVAGui", "Gpad", "RooStats", "GenVector", "Hist", "Math", "Net", "TreePlayer", "TreeViewer", "Graf"}, *fInterpreter);
    }
 }
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1380,7 +1380,7 @@ void TCling::Initialize()
    if (fInterpreter->getCI()->getLangOpts().Modules && !IsFromRootCling()) {
       // Load modules that we can't automatically load via rootmap files as they
       // contain decls in namespaces which aren't supported.
-      LoadModules({"TMVA", "RooFit", "TMVAGui", "Gpad", "RooStats", "GenVector", "Hist", "Math", "Net", "TreePlayer", "TreeViewer", "Graf"}, *fInterpreter);
+      LoadModules({"TMVA", "RGL", "RooFit", "TMVAGui", "Gpad", "RooStats", "GenVector", "Hist", "Math", "Net", "TreePlayer", "TreeViewer", "Graf"}, *fInterpreter);
    }
 }
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1380,7 +1380,7 @@ void TCling::Initialize()
    if (fInterpreter->getCI()->getLangOpts().Modules && !IsFromRootCling()) {
       // Load modules that we can't automatically load via rootmap files as they
       // contain decls in namespaces which aren't supported.
-      LoadModules({"TMVA", "Gpad", "RooStats", "TreePlayer", "Graf"}, *fInterpreter);
+      LoadModules({"TMVA", "Gpad", "RooStats", "GenVector", "TreePlayer", "Graf"}, *fInterpreter);
    }
 }
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1380,7 +1380,7 @@ void TCling::Initialize()
    if (fInterpreter->getCI()->getLangOpts().Modules && !IsFromRootCling()) {
       // Load modules that we can't automatically load via rootmap files as they
       // contain decls in namespaces which aren't supported.
-      LoadModules({"TMVA", "Gpad", "RooStats", "GenVector", "Hist", "Net", "TreePlayer", "TreeViewer", "Graf"}, *fInterpreter);
+      LoadModules({"TMVA", "Gpad", "RooStats", "GenVector", "Hist", "Math", "Net", "TreePlayer", "TreeViewer", "Graf"}, *fInterpreter);
    }
 }
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1179,6 +1179,7 @@ TCling::TCling(const char *name, const char *title)
       clingArgsStorage.push_back("-Wno-undefined-inline");
       clingArgsStorage.push_back("-fsigned-char");
    }
+   clingArgsStorage.push_back("-DVc_NO_VERSION_CHECK");
 
    std::vector<const char*> interpArgs;
    for (std::vector<std::string>::const_iterator iArg = clingArgsStorage.begin(),

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1380,7 +1380,7 @@ void TCling::Initialize()
    if (fInterpreter->getCI()->getLangOpts().Modules && !IsFromRootCling()) {
       // Load modules that we can't automatically load via rootmap files as they
       // contain decls in namespaces which aren't supported.
-      LoadModules({"TMVA", "Gpad", "RooStats", "GenVector", "TreePlayer", "Graf"}, *fInterpreter);
+      LoadModules({"TMVA", "Gpad", "RooStats", "GenVector", "Hist", "TreePlayer", "Graf"}, *fInterpreter);
    }
 }
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1380,7 +1380,7 @@ void TCling::Initialize()
    if (fInterpreter->getCI()->getLangOpts().Modules && !IsFromRootCling()) {
       // Load modules that we can't automatically load via rootmap files as they
       // contain decls in namespaces which aren't supported.
-      LoadModules({"TMVA", "TreePlayer", "Graf"}, *fInterpreter);
+      LoadModules({"TMVA", "Gpad", "RooStats", "TreePlayer", "Graf"}, *fInterpreter);
    }
 }
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1380,7 +1380,7 @@ void TCling::Initialize()
    if (fInterpreter->getCI()->getLangOpts().Modules && !IsFromRootCling()) {
       // Load modules that we can't automatically load via rootmap files as they
       // contain decls in namespaces which aren't supported.
-      LoadModules({"TMVA", "TMVAGui", "Gpad", "RooStats", "GenVector", "Hist", "Math", "Net", "TreePlayer", "TreeViewer", "Graf"}, *fInterpreter);
+      LoadModules({"TMVA", "RooFit", "TMVAGui", "Gpad", "RooStats", "GenVector", "Hist", "Math", "Net", "TreePlayer", "TreeViewer", "Graf"}, *fInterpreter);
    }
 }
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1661,7 +1661,8 @@ void TCling::RegisterModule(const char* modulename,
                             void (*triggerFunc)(),
                             const FwdDeclArgsToKeepCollection_t& fwdDeclsArgToSkip,
                             const char** classesHeaders,
-                            Bool_t lateRegistration /*=false*/)
+                            Bool_t lateRegistration /*=false*/,
+                            Bool_t hasCxxModule /*=false*/)
 {
    const bool fromRootCling = IsFromRootCling();
    // We need the dictionary initialization but we don't want to inject the
@@ -1901,7 +1902,7 @@ void TCling::RegisterModule(const char* modulename,
    clang::Sema &TheSema = fInterpreter->getSema();
 
    bool ModuleWasSuccessfullyLoaded = false;
-   if (TheSema.getLangOpts().Modules) {
+   if (hasCxxModule) {
       std::string ModuleName = llvm::StringRef(modulename).substr(3).str();
       ModuleWasSuccessfullyLoaded = LoadModule(ModuleName, *fInterpreter);
       if (!ModuleWasSuccessfullyLoaded) {

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1380,7 +1380,7 @@ void TCling::Initialize()
    if (fInterpreter->getCI()->getLangOpts().Modules && !IsFromRootCling()) {
       // Load modules that we can't automatically load via rootmap files as they
       // contain decls in namespaces which aren't supported.
-      LoadModules({"TMVA", "EG", "RGL", "RooFit", "TMVAGui", "Gpad", "RooStats", "GenVector", "Hist", "Math", "Net", "TreePlayer", "TreeViewer", "Graf"}, *fInterpreter);
+      LoadModules({"TMVA", "EG", "RGL", "RooFit", "TMVAGui", "Gpad", "RooStats", "GenVector", "Hist", "MathCore", "Net", "TreePlayer", "TreeViewer", "Graf"}, *fInterpreter);
    }
 }
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1120,18 +1120,18 @@ static bool IsFromRootCling() {
   return foundSymbol;
 }
 
-static void loadModulePath(HeaderSearch& hdrSearch, const char* environmentVariable) {
-  const char* LD_LIBRARY_PATH = getenv(environmentVariable);
-  if (LD_LIBRARY_PATH) {
-     StringRef path = LD_LIBRARY_PATH;
+static void loadModulePath(HeaderSearch& hdrSearch, const char* inputPath) {
+  if (inputPath) {
+     StringRef path = inputPath;
      SmallVector<StringRef, 32> paths;
      path.split(paths, ":");
+
      for (StringRef path : paths) {
         SmallString<128> ModuleMapFilePath = path;
-        llvm::sys::path::append(ModuleMapFilePath, "module.modulemap");
 
-        if (auto file = hdrSearch.getFileMgr().getFile(ModuleMapFilePath))
+        if (auto file = hdrSearch.getFileMgr().getFile(ModuleMapFilePath)) {
            hdrSearch.loadModuleMapFile(file, false, FileID());
+        }
     }
   }
 }
@@ -1269,7 +1269,7 @@ TCling::TCling(const char *name, const char *title)
    if (fInterpreter->getCI()->getLangOpts().Modules) {
       HeaderSearch& hdrSearch = fInterpreter->getCI()->getPreprocessor().getHeaderSearchInfo();
       hdrSearch.loadTopLevelSystemModules();
-      loadModulePath(hdrSearch, "LD_LIBRARY_PATH");
+      loadModulePath(hdrSearch, gSystem->GetDynamicPath());
 
       // Setup core C++ modules if we have any to setup.
       LoadModules({"libc", "stl", "ROOT_Types", "Core", "RIO"}, *fInterpreter);

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1120,6 +1120,22 @@ static bool IsFromRootCling() {
   return foundSymbol;
 }
 
+static void loadModulePath(HeaderSearch& hdrSearch, const char* environmentVariable) {
+  const char* LD_LIBRARY_PATH = getenv(environmentVariable);
+  if (LD_LIBRARY_PATH) {
+     StringRef path = LD_LIBRARY_PATH;
+     SmallVector<StringRef, 32> paths;
+     path.split(paths, ":");
+     for (StringRef path : paths) {
+        SmallString<128> ModuleMapFilePath = path;
+        llvm::sys::path::append(ModuleMapFilePath, "module.modulemap");
+
+        if (auto file = hdrSearch.getFileMgr().getFile(ModuleMapFilePath))
+           hdrSearch.loadModuleMapFile(file, false, FileID());
+    }
+  }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Initialize the cling interpreter interface.
 
@@ -1251,6 +1267,10 @@ TCling::TCling(const char *name, const char *title)
    fMetaProcessor = new cling::MetaProcessor(*fInterpreter, fMPOuts);
 
    if (fInterpreter->getCI()->getLangOpts().Modules) {
+      HeaderSearch& hdrSearch = fInterpreter->getCI()->getPreprocessor().getHeaderSearchInfo();
+      hdrSearch.loadTopLevelSystemModules();
+      loadModulePath(hdrSearch, "LD_LIBRARY_PATH");
+
       // Setup core C++ modules if we have any to setup.
       LoadModules({"libc", "stl", "ROOT_Types", "Core", "RIO"}, *fInterpreter);
 

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -205,7 +205,8 @@ public: // Public Interface
                           void (*triggerFunc)(),
                           const FwdDeclArgsToKeepCollection_t& fwdDeclsArgToSkip,
                           const char** classesHeaders,
-                          Bool_t lateRegistration = false);
+                          Bool_t lateRegistration = false,
+                          Bool_t hasCxxModule = false);
    void    RegisterTClassUpdate(TClass *oldcl,DictFuncPtr_t dict);
    void    UnRegisterTClassUpdate(const TClass *oldcl);
 


### PR DESCRIPTION
ROOT can't autoparse classes inside namespaces with the rootmap
system (as the loading callbacks don't correctly land where
they are supposed to land with our injected namespaces). As this
turns out to be a feature of some kind, let's preload
TMVA/TreePlayer/Graf to fix all failing tests that are related
to this feature/bug with modules enabled.

This commit can be dropped if we solve on of those problems:

1. figure out how to fix this bug in the rootmap-based loading
without regressin in performance.

2. replace the rootmap system with something else like attaching
all C++ modules on startup.

Note that we already do something like this in normal ROOT by
including these packages into the PCH which also makes those
decls available in the normal clang lookup.

This PR depends on #1394