### PR TITLE
Switch object format from ELF to COFF and fix symbol lookup

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -5866,6 +5866,9 @@ void* TCling::LazyFunctionCreatorAutoload(const std::string& mangled_name) {
    //  function name.
    //
 
+   if (!strncmp(name.c_str(), "public: __thiscall ", sizeof("public: __thiscall ")-1)) {
+      name.erase(0, sizeof("public: __thiscall ")-1);
+   }
    if (!strncmp(name.c_str(), "typeinfo for ", sizeof("typeinfo for ")-1)) {
       name.erase(0, sizeof("typeinfo for ")-1);
    } else if (!strncmp(name.c_str(), "vtable for ", sizeof("vtable for ")-1)) {

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -894,7 +894,7 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
     llvm::Triple TheTriple(llvm::sys::getProcessTriple());
 #ifdef LLVM_ON_WIN32
     // COFF format currently needs a few changes in LLVM to function properly.
-    TheTriple.setObjectFormat(llvm::Triple::ELF);
+    TheTriple.setObjectFormat(llvm::Triple::COFF);
 #endif
     clang::driver::Driver Drvr(argv[0], TheTriple.getTriple(), *Diags);
     //Drvr.setWarnMissingInput(false);

--- a/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
@@ -16,8 +16,8 @@
 #include "llvm/ExecutionEngine/SectionMemoryManager.h"
 #include "llvm/Support/DynamicLibrary.h"
 
-#ifdef __APPLE__
-// Apple adds an extra '_'
+#if defined(__APPLE__) || defined (_MSC_VER)
+// Apple and Windows add an extra '_'
 # define MANGLE_PREFIX "_"
 #endif
 


### PR DESCRIPTION
- Switch object format from ELF (Linux) to COFF (Windows)
- Fix mangled symbols lookup on Windows: remove leading '_' and use malloc to simulate __imp_ variables (that are indirection pointers)