### PR TITLE
Set the SourceManager flag to enable -fmodules-embed-all-files.

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -1043,6 +1043,9 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
                                           /*UserFilesAreVolatile*/ true);
     CI->setSourceManager(SM); // CI now owns SM
 
+    if (Invocation.getFrontendOpts().ModulesEmbedAllFiles)
+       CI->getSourceManager().setAllFilesAreTransient(true);
+
     // As main file we want
     // * a virtual file that is claiming to be huge
     // * with an empty memory buffer attached (to bring the content)


### PR DESCRIPTION
This marks all files in the PCH/PCM transient. This allows clang to
stream them back within the zip in the PCH rather than requiring the
files to be physically present on disk.

This should resolve an introduced regression which materializes if
the files are moved/deleted after the generation of the PCH.