### PR TITLE
Use a helper class (TStringView) to resolve string/string_view ambiguity. [v6-08]

### DIFF
--- a/core/base/inc/ROOT/StringConv.hxx
+++ b/core/base/inc/ROOT/StringConv.hxx
@@ -156,6 +156,12 @@ EFromHumanReadableSize FromHumanReadableSize(std::string_view str, T &value)
 
 }
 
+template <typename T>
+EFromHumanReadableSize FromHumanReadableSize(ROOT::Internal::TStringView str, T &value)
+{
+   return FromHumanReadableSize(std::string_view(str),value);
+}
+
 } // namespace ROOT.
 
 #endif // ROOT_StringConv

--- a/core/base/inc/TString.h
+++ b/core/base/inc/TString.h
@@ -287,7 +287,13 @@ public:
 
    // Type conversion
    operator const char*() const { return GetPointer(); }
+#if __cplusplus >= 201700L
+   explicit operator std::string() const { return std::string(GetPointer(),Length()); }
+   explicit operator ROOT::Internal::TStringView() const { return ROOT::Internal::TStringView(GetPointer(),Length()); }
    operator std::string_view() const { return std::string_view(GetPointer(),Length()); }
+#else
+   operator ROOT::Internal::TStringView() const { return ROOT::Internal::TStringView(GetPointer(),Length()); }
+#endif
 
    // Assignment
    TString    &operator=(char s);                // Replace string
@@ -421,6 +427,7 @@ public:
    void         ToUpper();                              // Change self to upper-case
    TObjArray   *Tokenize(const TString &delim) const;
    Bool_t       Tokenize(TString &tok, Ssiz_t &from, const char *delim = " ") const;
+   std::string_view View() const { return std::string_view(GetPointer(),Length()); }
 
    // Static member functions
    static UInt_t  Hash(const void *txt, Int_t ntxt);    // Calculates hash index from any char string.

--- a/core/base/inc/TString.h
+++ b/core/base/inc/TString.h
@@ -453,6 +453,12 @@ template <>
 TBuffer  &operator>>(TBuffer &buf,       TString *&sp);
 TBuffer  &operator<<(TBuffer &buf, const TString * sp);
 
+// Conversion operator (per se).
+inline std::string& operator+=(std::string &left, const TString &right)
+{
+   return left.append(right.Data());
+}
+
 TString ToLower(const TString &s);    // Return lower-case version of argument
 TString ToUpper(const TString &s);    // Return upper-case version of argument
 

--- a/core/metautils/inc/RStringView.h
+++ b/core/metautils/inc/RStringView.h
@@ -55,4 +55,17 @@ namespace std {
 
 #endif // ifdef else R__HAS_STD_STRING_VIEW
 
+namespace ROOT {
+namespace Internal {
+    class TStringView {
+       const char *fData{nullptr};
+       size_t      fLength{0};
+
+    public:
+       explicit TStringView(const char *cstr, size_t len) : fData(cstr), fLength(len) {}
+
+       operator std::string_view() const { return std::string_view(fData,fLength); }
+    };
+} // namespace Internal
+} // namespace ROOT
 #endif // RStringView_H

--- a/core/metautils/inc/RStringView.h
+++ b/core/metautils/inc/RStringView.h
@@ -47,7 +47,7 @@ namespace std {
 #ifndef R__HAS_STOD_STRING_VIEW
    inline double stod(std::string_view str, size_t *pos)
    {
-      return std::stod(str.to_string(),pos);
+      return std::stod(std::string(str.data(), str.size()),pos);
    }
 #endif
 

--- a/core/metautils/inc/TClassEdit.h
+++ b/core/metautils/inc/TClassEdit.h
@@ -163,6 +163,7 @@ namespace TClassEdit {
    bool        IsSTLBitset(const char *type);
    ROOT::ESTLType UnderlyingIsSTLCont(std::string_view type);
    ROOT::ESTLType IsSTLCont (std::string_view type);
+   inline ROOT::ESTLType IsSTLCont (ROOT::Internal::TStringView type) { return IsSTLCont(std::string_view(type)); }
    int         IsSTLCont (const char *type,int testAlloc);
    bool        IsStdClass(const char *type);
    bool        IsVectorBool(const char *name);

--- a/core/metautils/src/TClassEdit.cxx
+++ b/core/metautils/src/TClassEdit.cxx
@@ -1280,7 +1280,7 @@ ROOT::ESTLType TClassEdit::IsSTLCont(std::string_view type)
       return ROOT::kNotSTL;
    }
 
-   return STLKind({type.data(),pos});
+   return STLKind(type.substr(0,pos));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/io/io/inc/TFile.h
+++ b/io/io/inc/TFile.h
@@ -297,7 +297,10 @@ public:
    static Long64_t     GetFileCounter();
    static void         IncrementFileCounter();
 
-   static Bool_t       SetCacheFileDir(const char *cacheDir, Bool_t operateDisconnected = kTRUE,
+   static Bool_t       SetCacheFileDir(ROOT::Internal::TStringView cacheDir, Bool_t operateDisconnected = kTRUE,
+                                       Bool_t forceCacheread = kFALSE)
+     { return SetCacheFileDir(std::string_view(cacheDir), operateDisconnected, forceCacheread); }
+   static Bool_t       SetCacheFileDir(std::string_view cacheDir, Bool_t operateDisconnected = kTRUE,
                                        Bool_t forceCacheread = kFALSE);
    static const char  *GetCacheFileDir();
    static Bool_t       ShrinkCacheFileDir(Long64_t shrinkSize, Long_t cleanupInteval = 0);

--- a/io/io/inc/TFileMerger.h
+++ b/io/io/inc/TFileMerger.h
@@ -85,6 +85,7 @@ public:
    const char *GetMsgPrefix() const { return fMsgPrefix; }
    void        SetMsgPrefix(const char *prefix);
    const char *GetMergeOptions() { return fMergeOptions; }
+   void        SetMergeOptions(const TString &options) { fMergeOptions = options; }
    void        SetMergeOptions(const std::string_view &options) { fMergeOptions = options; }
    void        AddObjectNames(const char *name) {fObjectNames += name; fObjectNames += " ";}
    const char *GetObjectNames() const {return fObjectNames.Data();}

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -4423,7 +4423,7 @@ void TFile::IncrementFileCounter() { fgFileCounter++; }
 /// Sets the directory where to locally stage/cache remote files.
 /// If the directory is not writable by us return kFALSE.
 
-Bool_t TFile::SetCacheFileDir(const char *cachedir, Bool_t operatedisconnected,
+Bool_t TFile::SetCacheFileDir(std::string_view cachedir, Bool_t operatedisconnected,
                               Bool_t forcecacheread )
 {
    TString cached = cachedir;
@@ -4434,7 +4434,7 @@ Bool_t TFile::SetCacheFileDir(const char *cachedir, Bool_t operatedisconnected,
       // try to create it
       gSystem->mkdir(cached, kTRUE);
       if (gSystem->AccessPathName(cached, kFileExists)) {
-         ::Error("TFile::SetCacheFileDir", "no sufficient permissions on cache directory %s or cannot create it", cachedir);
+         ::Error("TFile::SetCacheFileDir", "no sufficient permissions on cache directory %s or cannot create it", TString(cachedir).Data());
          fgCacheFileDir = "";
          return kFALSE;
       }


### PR DESCRIPTION
This solves the ambiguity of conversion from TString to std::string_view while preserving the conversion from
TString to std::string at the cost of requiring overload of function taking a std::string_view.  This is necessary
as C++11 and C++14 does not have the proper semantic for properly resolving the conversions eventhough we have
an explicit conversion (from TString to std::string).  Note that this problem is resovled in C++17