### PR TITLE
Improve StreamerInfo's Streamer

### DIFF
--- a/core/base/inc/RConfig.h
+++ b/core/base/inc/RConfig.h
@@ -364,6 +364,7 @@
 #      define R__OLDHPACC
 #      define R__TEMPLATE_OVERLOAD_BUG
 #      define R__GLOBALSTL       /* STL in global name space */
+#      error "ROOT requires proper support for C++11 or higher"
 #   else
 #      define R__PLACEMENTDELETE /* supports overloading placement delete */
 #      define R__TMPLTSTREAM     /* std::iostream implemented with templates */

--- a/core/base/inc/TBuffer.h
+++ b/core/base/inc/TBuffer.h
@@ -149,11 +149,11 @@ public:
    virtual void       WriteClass(const TClass *cl) = 0;
 
    virtual TObject   *ReadObject(const TClass *cl) = 0;
-   virtual void       WriteObject(const TObject *obj) = 0;
+   virtual void       WriteObject(const TObject *obj, Bool_t cacheReuse) = 0;
 
-   template <class T> Int_t WriteObject(const T *objptr);
+   template <class T> Int_t WriteObject(const T *objptr, Bool_t cacheReuse = kTRUE);
 
-   virtual Int_t      WriteObjectAny(const void *obj, const TClass *ptrClass) = 0;
+   virtual Int_t      WriteObjectAny(const void *obj, const TClass *ptrClass, Bool_t cacheReuse = kTRUE) = 0;
 
    virtual UShort_t   GetPidOffset() const  = 0;
    virtual void       SetPidOffset(UShort_t offset) = 0;
@@ -409,10 +409,10 @@ inline TBuffer &operator<<(TBuffer &buf, const TObject *obj)
    { buf.WriteObjectAny(obj, TObject::Class()); return buf; }
 
 template <class T>
-inline Int_t TBuffer::WriteObject(const T *objptr)
+inline Int_t TBuffer::WriteObject(const T *objptr, Bool_t cacheReuse)
 {
    TClass *cl = (objptr) ? TBuffer::GetClass(typeid(T)) : 0;
-   return WriteObjectAny(objptr, cl);
+   return WriteObjectAny(objptr, cl, cacheReuse);
 }
 
 #endif // ROOT_TBuffer

--- a/core/base/inc/TBuffer.h
+++ b/core/base/inc/TBuffer.h
@@ -151,6 +151,8 @@ public:
    virtual TObject   *ReadObject(const TClass *cl) = 0;
    virtual void       WriteObject(const TObject *obj) = 0;
 
+   template <class T> Int_t WriteObject(const T *objptr);
+
    virtual Int_t      WriteObjectAny(const void *obj, const TClass *ptrClass) = 0;
 
    virtual UShort_t   GetPidOffset() const  = 0;
@@ -406,4 +408,11 @@ template <>
 inline TBuffer &operator<<(TBuffer &buf, const TObject *obj)
    { buf.WriteObjectAny(obj, TObject::Class()); return buf; }
 
-#endif
+template <class T>
+inline Int_t TBuffer::WriteObject(const T *objptr)
+{
+   TClass *cl = (objptr) ? TBuffer::GetClass(typeid(T)) : 0;
+   return WriteObjectAny(objptr, cl);
+}
+
+#endif // ROOT_TBuffer

--- a/core/base/inc/TString.h
+++ b/core/base/inc/TString.h
@@ -32,10 +32,6 @@
 #include <stdio.h>
 #include <string>
 
-#ifdef R__GLOBALSTL
-namespace std { using ::string; }
-#endif
-
 class TRegexp;
 class TPRegexp;
 class TString;

--- a/core/cont/src/TClassTable.cxx
+++ b/core/cont/src/TClassTable.cxx
@@ -100,11 +100,7 @@ namespace ROOT {
      // This wrapper class allow to avoid putting #include <map> in the
      // TROOT.h header file.
    public:
-#ifdef R__GLOBALSTL
-      typedef std::map<string, TClassRec*>           IdMap_t;
-#else
       typedef std::map<std::string, TClassRec*> IdMap_t;
-#endif
       typedef IdMap_t::key_type                 key_type;
       typedef IdMap_t::const_iterator           const_iterator;
       typedef IdMap_t::size_type                size_type;

--- a/core/meta/inc/TBaseClass.h
+++ b/core/meta/inc/TBaseClass.h
@@ -25,22 +25,33 @@
 #include "TDictionary.h"
 #include "TClassRef.h"
 
+#include <atomic>
+
 class TBrowser;
 class TClass;
 
 class TBaseClass : public TDictionary {
+#ifndef __CLING__
+   using AtomicInt_t = std::atomic<Int_t>;
+   static_assert(sizeof(std::atomic<Int_t>) == sizeof(Int_t),
+                 "We requiqre atomic<int> and <int> to have the same size but they are not");
+#else
+   // std::atomic is not yet supported in the I/O, so
+   // we hide them from Cling
+   using AtomicInt_t = Int_t;
+#endif
 
 private:
    TBaseClass(const TBaseClass &);          // Not implemented
    TBaseClass&operator=(const TBaseClass&); // Not implemented
 
 private:
-   BaseClassInfo_t   *fInfo;      //!pointer to CINT base class info
-   TClassRef          fClassPtr;  // pointer to the base class TClass
-   TClass            *fClass;     //!pointer to parent class
-   Int_t              fDelta;     // BaseClassInfo_t offset (INT_MAX if unset)
-   mutable Int_t      fProperty;  // BaseClassInfo_t's properties
-   Int_t              fSTLType;   // cache of IsSTLContainer()
+   BaseClassInfo_t    *fInfo;      //!pointer to CINT base class info
+   TClassRef           fClassPtr;  // pointer to the base class TClass
+   TClass             *fClass;     //!pointer to parent class
+   AtomicInt_t         fDelta;     // BaseClassInfo_t offset (INT_MAX if unset)
+   mutable AtomicInt_t fProperty;  // BaseClassInfo_t's properties
+   Int_t               fSTLType;   // cache of IsSTLContainer()
 
 public:
    TBaseClass(BaseClassInfo_t *info = 0, TClass *cl = 0);

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -317,11 +317,7 @@ namespace ROOT {
      // This wrapper class allow to avoid putting #include <map> in the
      // TROOT.h header file.
    public:
-#ifdef R__GLOBALSTL
-      typedef map<string,TClass*>                 IdMap_t;
-#else
       typedef std::map<std::string,TClass*>       IdMap_t;
-#endif
       typedef IdMap_t::key_type                   key_type;
       typedef IdMap_t::const_iterator             const_iterator;
       typedef IdMap_t::size_type                  size_type;

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -3095,10 +3095,11 @@ TClass *TClass::GetClass(const char *name, Bool_t load, Bool_t silent)
 
 TClass *TClass::GetClass(const std::type_info& typeinfo, Bool_t load, Bool_t /* silent */)
 {
-   //protect access to TROOT::GetListOfClasses
-   R__LOCKGUARD(gInterpreterMutex);
+   if (!gROOT->GetListOfClasses())
+      return 0;
 
-   if (!gROOT->GetListOfClasses())    return 0;
+   //protect access to TROOT::GetIdMap
+   R__READ_LOCKGUARD(ROOT::gCoreMutex);
 
    TClass* cl = GetIdMap()->Find(typeinfo.name());
 
@@ -3120,6 +3121,8 @@ TClass *TClass::GetClass(const std::type_info& typeinfo, Bool_t load, Bool_t /* 
    }
 
    if (!load) return 0;
+
+   R__WRITE_LOCKGUARD(ROOT::gCoreMutex);
 
    DictFuncPtr_t dict = TClassTable::GetDict(typeinfo);
    if (dict) {

--- a/io/io/inc/TBufferFile.h
+++ b/io/io/inc/TBufferFile.h
@@ -73,7 +73,7 @@ protected:
    void   CheckCount(UInt_t offset);
    UInt_t CheckObject(UInt_t offset, const TClass *cl, Bool_t readClass = kFALSE);
 
-   virtual  void  WriteObjectClass(const void *actualObjStart, const TClass *actualClass);
+   virtual  void  WriteObjectClass(const void *actualObjStart, const TClass *actualClass, Bool_t cacheReuse);
 
 public:
    enum { kMapSize = 503 };
@@ -139,11 +139,11 @@ public:
    virtual void       WriteClass(const TClass *cl);
 
    virtual TObject   *ReadObject(const TClass *cl);
-   virtual void       WriteObject(const TObject *obj);
+   virtual void       WriteObject(const TObject *obj, Bool_t cacheReuse = kTRUE);
 
    using TBuffer::WriteObject;
 
-   virtual Int_t      WriteObjectAny(const void *obj, const TClass *ptrClass);
+   virtual Int_t      WriteObjectAny(const void *obj, const TClass *ptrClass, Bool_t cacheReuse = kTRUE);
 
    UShort_t GetPidOffset() const {
       // See comment in TBuffer::SetPidOffset

--- a/io/io/inc/TBufferFile.h
+++ b/io/io/inc/TBufferFile.h
@@ -141,6 +141,8 @@ public:
    virtual TObject   *ReadObject(const TClass *cl);
    virtual void       WriteObject(const TObject *obj);
 
+   using TBuffer::WriteObject;
+
    virtual Int_t      WriteObjectAny(const void *obj, const TClass *ptrClass);
 
    UShort_t GetPidOffset() const {

--- a/io/io/inc/TBufferJSON.h
+++ b/io/io/inc/TBufferJSON.h
@@ -74,7 +74,7 @@ public:
    virtual void     ClassEnd(const TClass *);
    virtual void     ClassMember(const char *name, const char *typeName = 0, Int_t arrsize1 = -1, Int_t arrsize2 = -1);
 
-   virtual void     WriteObject(const TObject *obj);
+   virtual void     WriteObject(const TObject *obj, Bool_t cacheReuse = kTRUE);
 
    using TBuffer::WriteObject;
 
@@ -222,7 +222,7 @@ public:
 
    virtual   Int_t    WriteClones(TClonesArray *a, Int_t nobjects);
 
-   virtual   Int_t    WriteObjectAny(const void *obj, const TClass *ptrClass);
+   virtual   Int_t    WriteObjectAny(const void *obj, const TClass *ptrClass, Bool_t cacheReuse = kTRUE);
    virtual   Int_t    WriteClassBuffer(const TClass *cl, void *pointer);
 
    virtual Int_t      ApplySequence(const TStreamerInfoActions::TActionSequence &sequence, void *object);
@@ -412,7 +412,7 @@ public:
 protected:
    // redefined protected virtual functions
 
-   virtual void     WriteObjectClass(const void *actualObjStart, const TClass *actualClass);
+   virtual void     WriteObjectClass(const void *actualObjStart, const TClass *actualClass, Bool_t cacheReuse);
 
    // end redefined protected virtual functions
 

--- a/io/io/inc/TBufferJSON.h
+++ b/io/io/inc/TBufferJSON.h
@@ -76,6 +76,8 @@ public:
 
    virtual void     WriteObject(const TObject *obj);
 
+   using TBuffer::WriteObject;
+
    virtual void     ReadFloat16(Float_t *f, TStreamerElement *ele = 0);
    virtual void     WriteFloat16(Float_t *f, TStreamerElement *ele = 0);
    virtual void     ReadDouble32(Double_t *d, TStreamerElement *ele = 0);

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -805,20 +805,6 @@ Bool_t TBufferJSON::CheckObject(const void *ptr, const TClass * /*cl*/)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Convert object into json structures.
-/// !!! Should be used only by TBufferJSON itself.
-/// Use ConvertToJSON() methods to convert object to json
-/// Redefined here to avoid gcc 3.x warning
-
-void TBufferJSON::WriteObject(const TObject *obj)
-{
-   if (gDebug > 1)
-      Info("WriteObject", "Object %p", obj);
-
-   WriteObjectAny(obj, TObject::Class());
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// add new level to the structures stack
 
 TJSONStackObj *TBufferJSON::PushStack(Int_t inclevel)

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -5138,28 +5138,21 @@ void TStreamerInfo::Streamer(TBuffer &R__b)
       //////////////////////////////////////////////////////////////////////////
 
       R__b.ClassMember("fElements","TObjArray*");
-#if NOTYET
-      if (has_no_artificial_member) {
-         R__b << fElements;
-      } else
-#endif
       {
-         R__LOCKGUARD(gInterpreterMutex);
-         Int_t nobjects = fElements->GetEntriesFast();
-         TObjArray store( *fElements );
+         TObjArray elements(fElements->GetEntriesFast());
          TStreamerElement *el;
+         Int_t nobjects = fElements->GetEntriesFast();
          for (Int_t i = 0; i < nobjects; i++) {
-            el = (TStreamerElement*)fElements->UncheckedAt(i);
-            if( el != 0 && (el->IsA() == TStreamerArtificial::Class() || el->TestBit(TStreamerElement::kRepeat))) {
-               fElements->RemoveAt( i );
-            } else if( el !=0 && (el->TestBit(TStreamerElement::kCache) && !el->TestBit(TStreamerElement::kWrite)) ) {
-               fElements->RemoveAt( i );
+            el = (TStreamerElement *)fElements->UncheckedAt(i);
+            if (el != 0 && (el->IsA() == TStreamerArtificial::Class() || el->TestBit(TStreamerElement::kRepeat))) {
+               // skip
+            } else if (el != 0 && (el->TestBit(TStreamerElement::kCache) && !el->TestBit(TStreamerElement::kWrite))) {
+               // skip
+            } else if (el != 0) {
+               elements.AddLast(el);
             }
          }
-         fElements->Compress();
-         R__b << fElements;
-         R__ASSERT(!fElements->IsOwner());
-         *fElements = store;
+         R__b.WriteObjectAny(&elements, TObjArray::Class(), kFALSE);
       }
       R__b.ClassEnd(TStreamerInfo::Class());
       R__b.SetByteCount(R__c, kTRUE);

--- a/io/sql/inc/TBufferSQL2.h
+++ b/io/sql/inc/TBufferSQL2.h
@@ -152,8 +152,6 @@ public:
    virtual void ClassEnd(const TClass *);
    virtual void ClassMember(const char *name, const char *typeName = 0, Int_t arrsize1 = -1, Int_t arrsize2 = -1);
 
-   virtual void WriteObject(const TObject *obj);
-
    virtual void ReadFloat16(Float_t *f, TStreamerElement *ele = 0);
    virtual void WriteFloat16(Float_t *f, TStreamerElement *ele = 0);
    virtual void ReadDouble32(Double_t *d, TStreamerElement *ele = 0);

--- a/io/sql/inc/TBufferSQL2.h
+++ b/io/sql/inc/TBufferSQL2.h
@@ -56,7 +56,7 @@ protected:
 
    // redefined protected virtual functions
 
-   virtual void WriteObjectClass(const void *actualObjStart, const TClass *actualClass);
+   virtual void WriteObjectClass(const void *actualObjStart, const TClass *actualClass, Bool_t cacheReuse);
 
    // end redefined protected virtual functions
 
@@ -103,11 +103,12 @@ protected:
    const char *SqlReadCharStarValue();
 
    Int_t
-   SqlWriteObject(const void *obj, const TClass *objClass, TMemberStreamer *streamer = 0, Int_t streamer_index = 0);
+   SqlWriteObject(const void *obj, const TClass *objClass, Bool_t cacheReuse, TMemberStreamer *streamer = 0, Int_t streamer_index = 0);
    void *SqlReadObject(void *obj, TClass **cl = 0, TMemberStreamer *streamer = 0, Int_t streamer_index = 0,
                        const TClass *onFileClass = 0);
    void *SqlReadObjectDirect(void *obj, TClass **cl, Long64_t objid, TMemberStreamer *streamer = 0,
                              Int_t streamer_index = 0, const TClass *onFileClass = 0);
+
 
 public:
    TBufferSQL2(TBuffer::EMode mode);

--- a/io/sql/src/TBufferSQL2.cxx
+++ b/io/sql/src/TBufferSQL2.cxx
@@ -295,17 +295,6 @@ TSQLObjectData *TBufferSQL2::SqlObjectData(Long64_t objid, TSQLClassInfo *sqlinf
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Convert object into sql structures.
-/// <b>It should be used only by TBufferSQL2 itself</b>
-/// Use SqlWrite() functions to convert your object to sql
-/// Redefined here to avoid gcc 3.x warning
-
-void TBufferSQL2::WriteObject(const TObject *obj)
-{
-   TBufferFile::WriteObject(obj);
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Write object to buffer.
 /// If object was written before, only pointer will be stored
 /// Return id of saved object

--- a/io/xml/inc/TBufferXML.h
+++ b/io/xml/inc/TBufferXML.h
@@ -75,8 +75,6 @@ public:
    virtual void ClassEnd(const TClass *);
    virtual void ClassMember(const char *name, const char *typeName = 0, Int_t arrsize1 = -1, Int_t arrsize2 = -1);
 
-   virtual void WriteObject(const TObject *obj);
-
    virtual void ReadFloat16(Float_t *f, TStreamerElement *ele = 0);
    virtual void WriteFloat16(Float_t *f, TStreamerElement *ele = 0);
    virtual void ReadDouble32(Double_t *d, TStreamerElement *ele = 0);

--- a/io/xml/inc/TBufferXML.h
+++ b/io/xml/inc/TBufferXML.h
@@ -234,7 +234,7 @@ protected:
 
    // redefined protected virtual functions
 
-   virtual void WriteObjectClass(const void *actualObjStart, const TClass *actualClass);
+   virtual void WriteObjectClass(const void *actualObjStart, const TClass *actualClass, Bool_t cacheReuse);
 
    // end redefined protected virtual functions
 
@@ -313,7 +313,7 @@ protected:
    void XmlReadBasic(ULong64_t &value);
    const char *XmlReadValue(const char *name);
 
-   XMLNodePointer_t XmlWriteObject(const void *obj, const TClass *objClass);
+   XMLNodePointer_t XmlWriteObject(const void *obj, const TClass *objClass, Bool_t cacheReuse);
    void *XmlReadObject(void *obj, TClass **cl = 0);
 
    void BeforeIOoperation();

--- a/io/xml/src/TBufferXML.cxx
+++ b/io/xml/src/TBufferXML.cxx
@@ -264,17 +264,6 @@ void *TBufferXML::XmlReadAny(XMLNodePointer_t node, void *obj, TClass **cl)
    return res;
 }
 
-////////////////////////////////////////////////////////////////////////////////
-/// Convert object into xml structures.
-/// !!! Should be used only by TBufferXML itself.
-/// Use ConvertToXML() methods to convert your object to xml
-/// Redefined here to avoid gcc 3.x warning
-
-void TBufferXML::WriteObject(const TObject *obj)
-{
-   TBufferFile::WriteObject(obj);
-}
-
 // TXMLStackObj is used to keep stack of object hierarchy,
 // stored in TBuffer. For example, data for parent class(es)
 // stored in subnodes, but initial object node will be kept.

--- a/io/xml/src/TBufferXML.cxx
+++ b/io/xml/src/TBufferXML.cxx
@@ -233,7 +233,7 @@ XMLNodePointer_t TBufferXML::XmlWriteAny(const void *obj, const TClass *cl)
    if (fXML == 0)
       return 0;
 
-   XMLNodePointer_t res = XmlWriteObject(obj, cl);
+   XMLNodePointer_t res = XmlWriteObject(obj, cl, kTRUE);
 
    return res;
 }
@@ -794,7 +794,7 @@ Bool_t TBufferXML::VerifyElemNode(const TStreamerElement *elem)
 /// If object was written before, only pointer will be stored
 /// Return pointer to top xml node, representing object
 
-XMLNodePointer_t TBufferXML::XmlWriteObject(const void *obj, const TClass *cl)
+XMLNodePointer_t TBufferXML::XmlWriteObject(const void *obj, const TClass *cl, Bool_t cacheReuse)
 {
    XMLNodePointer_t objnode = fXML->NewChild(StackNode(), 0, xmlio::Object, 0);
 
@@ -807,7 +807,7 @@ XMLNodePointer_t TBufferXML::XmlWriteObject(const void *obj, const TClass *cl)
 
    fXML->NewAttr(objnode, 0, xmlio::ObjClass, clname);
 
-   RegisterPointer(obj, objnode);
+   if (cacheReuse) RegisterPointer(obj, objnode);
 
    PushStack(objnode);
 
@@ -1608,12 +1608,12 @@ void TBufferXML::SkipObjectAny()
 ////////////////////////////////////////////////////////////////////////////////
 /// Write object to buffer. Only used from TBuffer
 
-void TBufferXML::WriteObjectClass(const void *actualObjStart, const TClass *actualClass)
+void TBufferXML::WriteObjectClass(const void *actualObjStart, const TClass *actualClass, Bool_t cacheReuse)
 {
    BeforeIOoperation();
    if (gDebug > 2)
       Info("WriteObject", "Class %s", (actualClass ? actualClass->GetName() : " null"));
-   XmlWriteObject(actualObjStart, actualClass);
+   XmlWriteObject(actualObjStart, actualClass, cacheReuse);
 }
 
 // Macro to read content of uncompressed array
@@ -2622,7 +2622,7 @@ void TBufferXML::StreamObject(void *obj, const TClass *cl, const TClass * /* onf
    if (IsReading())
       XmlReadObject(obj);
    else
-      XmlWriteObject(obj, cl);
+      XmlWriteObject(obj, cl, kTRUE);
 }
 
 // macro for right shift operator for basic type

--- a/main/src/ssh2rpd.cxx
+++ b/main/src/ssh2rpd.cxx
@@ -33,9 +33,6 @@
 #include "Varargs.h"
 #include "Rtypes.h"
 #include <string.h>
-#ifdef R__GLOBALSTL
-namespace std { using ::string; }
-#endif
 
 int gDebug;
 

--- a/net/net/inc/TMessage.h
+++ b/net/net/inc/TMessage.h
@@ -87,7 +87,6 @@ public:
    Int_t    Uncompress();
    char    *CompBuffer() const { return fBufComp; }
    Int_t    CompLength() const { return (Int_t)(fBufCompCur - fBufComp); }
-   void     WriteObject(const TObject *obj);
    UShort_t WriteProcessID(TProcessID *pid);
 
    static void   EnableSchemaEvolutionForAll(Bool_t enable = kTRUE);

--- a/net/net/src/TMessage.cxx
+++ b/net/net/src/TMessage.cxx
@@ -156,7 +156,14 @@ void TMessage::Forward()
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Remember that the StreamerInfo is being used in writing.
-
+///
+/// When support for schema evolution is enabled the list of TStreamerInfo
+/// used to stream this object is kept in fInfos. This information is used
+/// by TSocket::Send that sends this list through the socket. This list is in
+/// turn used by TSocket::Recv to store the TStreamerInfo objects in the
+/// relevant TClass in case the TClass does not know yet about a particular
+/// class version. This feature is implemented to support clients and servers
+/// with either different ROOT versions or different user classes versions.
 void TMessage::TagStreamerInfo(TVirtualStreamerInfo *info)
 {
    if (fgEvolution || fEvolution) {
@@ -179,6 +186,12 @@ void TMessage::Reset()
       fBufCompCur = 0;
       fCompPos    = 0;
    }
+
+   if (fgEvolution || fEvolution) {
+      if (fInfos)
+         fInfos->Clear();
+   }
+   fBitsPIDs.ResetAllBits();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -404,29 +417,6 @@ Int_t TMessage::Uncompress()
    fCompress = 1;
 
    return 0;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Write object to message buffer.
-/// When support for schema evolution is enabled the list of TStreamerInfo
-/// used to stream this object is kept in fInfos. This information is used
-/// by TSocket::Send that sends this list through the socket. This list is in
-/// turn used by TSocket::Recv to store the TStreamerInfo objects in the
-/// relevant TClass in case the TClass does not know yet about a particular
-/// class version. This feature is implemented to support clients and servers
-/// with either different ROOT versions or different user classes versions.
-
-void TMessage::WriteObject(const TObject *obj)
-{
-   if (fgEvolution || fEvolution) {
-      if (fInfos)
-         fInfos->Clear();
-      else
-         fInfos = new TList();
-   }
-
-   fBitsPIDs.ResetAllBits();
-   WriteObjectAny(obj, TObject::Class());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/net/rpdutils/res/rpdp.h
+++ b/net/rpdutils/res/rpdp.h
@@ -26,9 +26,6 @@
 #include "MessageTypes.h"
 #include "rpderr.h"
 #include <string>
-#ifdef R__GLOBALSTL
-namespace std { using ::string; }
-#endif
 
 /////////////////////////////////////////////////////////////////////
 //                                                                 //

--- a/proof/proof/inc/TProof.h
+++ b/proof/proof/inc/TProof.h
@@ -41,10 +41,6 @@
 #include <map>
 #include <mutex>
 
-#ifdef R__GLOBALSTL
-namespace std { using ::map; }
-#endif
-
 #define CANNOTUSE(x) Info(x,"Not manager: cannot use this method")
 
 class TChain;

--- a/proof/proofd/src/proofexecv.cxx
+++ b/proof/proofd/src/proofexecv.cxx
@@ -40,10 +40,6 @@
 #include "rpdconn.h"
 #include "rpdpriv.h"
 
-#ifdef R__GLOBALSTL
-namespace std { using ::string; }
-#endif
-
 static int gType = 0;
 static int gDebug = 0;
 static FILE *gLogger = 0;

--- a/proof/proofplayer/inc/TStatus.h
+++ b/proof/proofplayer/inc/TStatus.h
@@ -28,9 +28,6 @@
 
 #include <set>
 #include <string>
-#ifdef R__GLOBALSTL
-namespace std { using ::set; using ::string; }
-#endif
 
 class TStatus : public TNamed {
 

--- a/test/TBench.h
+++ b/test/TBench.h
@@ -9,7 +9,6 @@ namespace stdext {}
 #include <set>
 #include <map>
 
-#ifndef R__GLOBALSTL
 #ifndef WIN32
 using std::vector;
 using std::list;
@@ -21,23 +20,6 @@ using std::multimap;
 #else
 using namespace std;
 using namespace stdext;
-#endif
-#endif
-#ifdef R__HPUX
-namespace std {
-  using ::make_pair;
-  using ::pair;
-}
-#endif
-
-#ifdef __CINT__
-template<class a,class b,class c> class hash_map : public map<a,b,c> {};
-template<class a,class b> class hash_set : public set<a,b> {};
-template<class a,class b,class c> class hash_multimap : public multimap<a,b,c> {};
-template<class a,class b> class hash_multiset : public multiset<a,b> {};
-#else
-//#include <hash_map>
-//#include <hash_set>
 #endif
 
 //-------------------------------------------------------------


### PR DESCRIPTION
Avoid modification of StreamerInfo during their streaming and thus remove the need for lock acquisition there.