### PR TITLE
[rootcp] Write out keys only if cycle number increases

### DIFF
--- a/main/python/cmdLineUtils.py
+++ b/main/python/cmdLineUtils.py
@@ -598,8 +598,19 @@ def copyRootObjectRecursive(sourceFile,sourcePathSplit,destFile,destPathSplit,re
     """
     retcode = 0
     replaceOption = replace
+    seen = {}
     for key in getKeyList(sourceFile,sourcePathSplit):
         objectName = key.GetName()
+
+        # write keys only if the cycle is higher than before
+        if objectName not in seen.keys():
+            seen[objectName] = key
+        else:
+            if seen[objectName].GetCycle() < key.GetCycle():
+                seen[objectName] = key
+            else:
+                continue
+
         if isDirectoryKey(key):
             if not isExisting(destFile,destPathSplit+[objectName]):
                 createDirectory(destFile,destPathSplit+[objectName])

--- a/main/python/rootcp.py
+++ b/main/python/rootcp.py
@@ -13,18 +13,24 @@ import sys
 # Help strings
 COMMAND_HELP = "Copy objects from ROOT files into an other"
 
-EPILOG = """Examples:
+EPILOG = """
+Note: If an object has been written to a file multiple times, rootcp will copy only the latest version of that object.
+
+Examples:
+- rootcp source.root dest.root
+  Copy the latest version of each object in 'source.root' to 'dest.root'.
+
 - rootcp source.root:hist* dest.root
-  Copy all histograms whose named starts with 'hist' from 'source.root' to 'dest.root'.
+  Copy all histograms whose names start with 'hist' from 'source.root' to 'dest.root'.
 
 - rootcp source1.root:hist1 source2.root:hist2 dest.root
   Copy histograms 'hist1' from 'source1.root' and 'hist2' from 'source2.root' to 'dest.root'.
 
 - rootcp --recreate source.root:hist dest.root
-  Recreate the destination file 'dest.root' and copy the histogram named 'hist' from 'source.root' into it.
+  Recreate 'dest.root' and copy the histogram named 'hist' from 'source.root' into it.
 
 - rootcp -c 1 source.root:hist dest.root
-  Change the compression factor of the destination file 'dest.root' if not existing and copy the histogram named 'hist' from 'source.root' into it.
+  Change compression factor of 'dest.root' if not existing and copy the histogram named 'hist' from 'source.root' into it.
 """
 
 def execute():


### PR DESCRIPTION
Fixes https://sft.its.cern.ch/jira/browse/ROOT-8528.

*Note:* keys appear in the list of keys in decreasing cycle order. Therefore, if an object has been written more than once, we should skip the old versions, and that's what this commit does.