### PR TITLE
[cmake] Prevent constantly rebuilding LLVM

### DIFF
--- a/interpreter/llvm/src/include/llvm/Support/CMakeLists.txt
+++ b/interpreter/llvm/src/include/llvm/Support/CMakeLists.txt
@@ -40,21 +40,31 @@ set(version_inc "${CMAKE_CURRENT_BINARY_DIR}/VCSRevision.h")
 
 set(get_svn_script "${LLVM_CMAKE_PATH}/GenerateVersionFromCVS.cmake")
 
-if(DEFINED llvm_vc)
-  # Create custom target to generate the VC revision include.
-  add_custom_command(OUTPUT "${version_inc}"
-    DEPENDS "${llvm_vc}" "${get_svn_script}"
-    COMMAND
-    ${CMAKE_COMMAND} "-DSOURCE_DIR=${LLVM_MAIN_SRC_DIR}"
-                     "-DNAME=LLVM_REVISION"
-                     "-DHEADER_FILE=${version_inc}"
-                     -P "${get_svn_script}")
+# Disable this version check as it will cause constant rebuilds because
+# this code doesn't correctly handle out embedded LLVM.
+# This can just be dropped when we upgrade to LLVM 6.0 where this check will
+# be disabled by the LLVM_APPEND_VC_REV=OFF we set in interpreter/CMakeLists.txt
+#if(DEFINED llvm_vc)
+#  # Create custom target to generate the VC revision include.
+#  add_custom_command(OUTPUT "${version_inc}"
+#    DEPENDS "${llvm_vc}" "${get_svn_script}"
+#    COMMAND
+#    ${CMAKE_COMMAND} "-DSOURCE_DIR=${LLVM_MAIN_SRC_DIR}"
+#                     "-DNAME=LLVM_REVISION"
+#                     "-DHEADER_FILE=${version_inc}"
+#                     -P "${get_svn_script}")
+#
+#  # Mark the generated header as being generated.
+#  set_source_files_properties("${version_inc}"
+#    PROPERTIES GENERATED TRUE
+#               HEADER_FILE_ONLY TRUE)
+#else()
+#  file(WRITE "${version_inc}" "")
+#endif()
 
-  # Mark the generated header as being generated.
-  set_source_files_properties("${version_inc}"
-    PROPERTIES GENERATED TRUE
-               HEADER_FILE_ONLY TRUE)
-else()
+# Instead of the code above, just write a dummy file if none exists yet. If
+# one already exists, we shouldn't touch it to prevent rebuilding.
+if (NOT EXISTS "${version_inc}")
   file(WRITE "${version_inc}" "")
 endif()
 


### PR DESCRIPTION
This was already fixed 4940aea49fa30eb8fdc0e169640158fc8ec5b768
and is fixed in LLVM upstream, however the fix only landed after
the 5.0 branch and we therefore need to reland our hack.