### PR TITLE
[modular.] Don't autoload MathCore

### DIFF
--- a/core/rint/src/TRint.cxx
+++ b/core/rint/src/TRint.cxx
@@ -156,12 +156,6 @@ TRint::TRint(const char *appClassName, Int_t *argc, char **argv, void *options,
       PrintLogo(lite);
    }
 
-   // Explicitly load libMathCore as CINT will not auto load it when using one
-   // of its globals. Once moved to Cling, which should work correctly, we
-   // can remove this statement.
-   if (!gClassTable->GetDict("TRandom"))
-      gSystem->Load("libMathCore");
-
    // Load some frequently used includes
    Int_t includes = gEnv->GetValue("Rint.Includes", 1);
    // When the interactive ROOT starts, it can automatically load some frequently


### PR DESCRIPTION
We move to cling, this should now work without explicitly loading
it. This also unblocks the modularization project which doesn't
include MathCore in the minimal base image.