### PR TITLE
Allow compilation of ROOT on Linux with clang-5.0 + libc++ and C++17 enabled

### DIFF
--- a/core/textinput/src/textinput/TextInput.cpp
+++ b/core/textinput/src/textinput/TextInput.cpp
@@ -63,7 +63,7 @@ namespace textinput {
 
     // Signal displays that the input got taken.
     std::for_each(fContext->GetDisplays().begin(), fContext->GetDisplays().end(),
-             std::mem_fun(&Display::NotifyResetInput));
+             [](Display *D) { return D->NotifyResetInput(); });
 
     ReleaseInputOutput();
 
@@ -157,7 +157,7 @@ namespace textinput {
                && Cmd.GetCommandID() == Editor::kCmdWindowResize) {
       std::for_each(fContext->GetDisplays().begin(),
                     fContext->GetDisplays().end(),
-                    std::mem_fun(&Display::NotifyWindowChange));
+                    [](Display *D) { return D->NotifyWindowChange(); });
     } else {
       if (!in.IsRaw() && in.GetExtendedInput() == InputData::kEIEOF) {
         fLastReadResult = kRREOF;
@@ -168,7 +168,7 @@ namespace textinput {
           // Signal displays that an error has occurred.
           std::for_each(fContext->GetDisplays().begin(),
                         fContext->GetDisplays().end(),
-                        std::mem_fun(&Display::NotifyError));
+                        [](Display *D) { return D->NotifyError(); });
         } else if (Cmd.GetKind() == Editor::kCKCommand
                    && (Cmd.GetCommandID() == Editor::kCmdEnter ||
                        Cmd.GetCommandID() == Editor::kCmdHistReplay)) {
@@ -192,7 +192,7 @@ namespace textinput {
 
     if (oldCursorPos != fContext->GetCursor()) {
       std::for_each(fContext->GetDisplays().begin(), fContext->GetDisplays().end(),
-                    std::mem_fun(&Display::NotifyCursorChange));
+                    [](Display *D) { return D->NotifyCursorChange(); });
     }
 
     oldCursorPos = fContext->GetCursor();
@@ -223,7 +223,7 @@ namespace textinput {
     if (!ColModR.fDisplay.IsEmpty()
         || ColModR.fDisplay.fPromptUpdate != Range::kNoPromptUpdate) {
       std::for_each(fContext->GetDisplays().begin(), fContext->GetDisplays().end(),
-                    std::bind2nd(std::mem_fun(&Display::NotifyTextChange), ColModR.fDisplay));
+                    [ColModR](Display *D) { return D->NotifyTextChange(ColModR.fDisplay); });
     }
   }
 
@@ -244,8 +244,7 @@ namespace textinput {
     fNeedPromptRedraw = false;
     // Immediate refresh.
     std::for_each(fContext->GetDisplays().begin(), fContext->GetDisplays().end(),
-                  std::bind2nd(std::mem_fun(&Display::NotifyTextChange),
-                               R.fDisplay));
+                  [R](Display *D) { return D->NotifyTextChange(R.fDisplay); });
     // Empty range.
     R.fDisplay = Range::Empty();
 
@@ -264,8 +263,7 @@ namespace textinput {
     fNeedPromptRedraw = false;
     std::for_each(fContext->GetDisplays().begin(),
                   fContext->GetDisplays().end(),
-                  std::bind2nd(std::mem_fun(&Display::NotifyTextChange),
-                               Range::AllWithPrompt()));
+                  [](Display *D) { return D->NotifyTextChange(Range::AllWithPrompt()); });
   }
 
   void
@@ -288,10 +286,10 @@ namespace textinput {
     if (fActive) return;
     // Signal readers that we are about to read.
     std::for_each(fContext->GetReaders().begin(), fContext->GetReaders().end(),
-                  std::mem_fun(&Reader::GrabInputFocus));
+                  [](Reader *R) { return R->GrabInputFocus(); });
     // Signal displays that we are about to display.
     std::for_each(fContext->GetDisplays().begin(), fContext->GetDisplays().end(),
-                  std::mem_fun(&Display::Attach));
+                  [](Display *D) { return D->Attach(); });
     fActive = true;
   }
 
@@ -300,11 +298,11 @@ namespace textinput {
     // Signal readers that we are done reading.
     if (!fActive) return;
     std::for_each(fContext->GetReaders().begin(), fContext->GetReaders().end(),
-                  std::mem_fun(&Reader::ReleaseInputFocus));
+                  [](Reader *R) { return R->ReleaseInputFocus(); });
 
     // Signal displays that we are done displaying.
     std::for_each(fContext->GetDisplays().begin(), fContext->GetDisplays().end(),
-                  std::mem_fun(&Display::Detach));
+                  [](Display *D) { return D->Detach(); });
 
     fActive = false;
   }
@@ -326,7 +324,7 @@ namespace textinput {
   TextInput::HandleResize() {
     // Resize signal was emitted, tell the displays.
     std::for_each(fContext->GetDisplays().begin(), fContext->GetDisplays().end(),
-             std::mem_fun(&Display::NotifyWindowChange));
+                  [](Display *D) { return D->NotifyWindowChange(); });
   }
 
   void

--- a/hist/hist/src/TKDE.cxx
+++ b/hist/hist/src/TKDE.cxx
@@ -720,7 +720,8 @@ void TKDE::TKernel::ComputeAdaptiveWeights() {
    }
    Double_t kAPPROX_GEO_MEAN = 0.241970724519143365; // 1 / TMath::Power(2 * TMath::Pi(), .5) * TMath::Exp(-.5). Approximated geometric mean over pointwise data (the KDE function is substituted by the "real Gaussian" pdf) and proportional to sigma. Used directly when the mirroring is enabled, otherwise computed from the data
    fKDE->fAdaptiveBandwidthFactor = fKDE->fUseMirroring ? kAPPROX_GEO_MEAN / fKDE->fSigmaRob : std::sqrt(std::exp(fKDE->fAdaptiveBandwidthFactor / fKDE->fData.size()));
-   transform(weights.begin(), weights.end(), fWeights.begin(), std::bind2nd(std::multiplies<Double_t>(), fKDE->fAdaptiveBandwidthFactor));
+   transform(weights.begin(), weights.end(), fWeights.begin(),
+             std::bind(std::multiplies<Double_t>(), std::placeholders::_1, fKDE->fAdaptiveBandwidthFactor));
    //printf("adaptive bandwidth factor % f weight 0 %f , %f \n",fKDE->fAdaptiveBandwidthFactor, weights[0],fWeights[0] );
 }
 

--- a/hist/hist/src/TKDE.cxx
+++ b/hist/hist/src/TKDE.cxx
@@ -503,11 +503,13 @@ void TKDE::SetMirroredEvents() {
    std::vector<Double_t> originalWeights = fEventWeights;
   if (fMirrorLeft) {
       fEvents.resize(2 * fNEvents, 0.0);
-      transform(fEvents.begin(), fEvents.begin() + fNEvents, fEvents.begin() + fNEvents, std::bind1st(std::minus<Double_t>(), 2 * fXMin));
+      transform(fEvents.begin(), fEvents.begin() + fNEvents, fEvents.begin() + fNEvents,
+                std::bind(std::minus<Double_t>(), 2 * fXMin, std::placeholders::_1));
    }
    if (fMirrorRight) {
       fEvents.resize((fMirrorLeft + 2) * fNEvents, 0.0);
-      transform(fEvents.begin(), fEvents.begin() + fNEvents, fEvents.begin() + (fMirrorLeft + 1) * fNEvents, std::bind1st(std::minus<Double_t>(), 2 * fXMax));
+      transform(fEvents.begin(), fEvents.begin() + fNEvents, fEvents.begin() + (fMirrorLeft + 1) * fNEvents,
+                std::bind(std::minus<Double_t>(), 2 * fXMax, std::placeholders::_1));
    }
    if (!fEventWeights.empty() && (fMirrorLeft || fMirrorRight)) {
       // copy weights too

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -290,7 +290,7 @@ namespace cling {
         if (auto M = T->getModule()) {
           for (const llvm::StringRef& Sym : Syms) {
             const llvm::GlobalValue* GV = M->getNamedValue(Sym);
-  #if defined(__GLIBCXX__) && !defined(__APPLE__)
+  #if defined(__linux__)
             // libstdc++ mangles at_quick_exit on Linux when g++ < 5
             if (!GV && Sym.equals("at_quick_exit"))
               GV = M->getNamedValue("_Z13at_quick_exitPFvvE");
@@ -404,13 +404,17 @@ namespace cling {
 
     // Intercept all atexit calls, as the Interpreter and functions will be long
     // gone when the -native- versions invoke them.
-#if defined(__GLIBCXX__) && !defined(__APPLE__)
+#if defined(__linux__)
     const char* LinkageCxx = "extern \"C++\"";
     const char* Attr = LangOpts.CPlusPlus ? " throw () " : "";
-    const char* cxa_atexit_is_noexcept = LangOpts.CPlusPlus ? " noexcept" : "";
 #else
     const char* LinkageCxx = Linkage;
     const char* Attr = "";
+#endif
+
+#if defined(__GLIBCXX__)
+    const char* cxa_atexit_is_noexcept = LangOpts.CPlusPlus ? " noexcept" : "";
+#else
     const char* cxa_atexit_is_noexcept = "";
 #endif
 

--- a/interpreter/llvm/src/include/llvm/IR/Instructions.h
+++ b/interpreter/llvm/src/include/llvm/IR/Instructions.h
@@ -4195,11 +4195,10 @@ private:
   }
 
 public:
-  using DerefFnTy = std::pointer_to_unary_function<Value *, BasicBlock *>;
+  using DerefFnTy = BasicBlock *(*)(Value *);
   using handler_iterator = mapped_iterator<op_iterator, DerefFnTy>;
   using handler_range = iterator_range<handler_iterator>;
-  using ConstDerefFnTy =
-      std::pointer_to_unary_function<const Value *, const BasicBlock *>;
+  using ConstDerefFnTy = const BasicBlock *(*)(const Value *);
   using const_handler_iterator =
       mapped_iterator<const_op_iterator, ConstDerefFnTy>;
   using const_handler_range = iterator_range<const_handler_iterator>;

--- a/math/mathcore/src/GoFTest.cxx
+++ b/math/mathcore/src/GoFTest.cxx
@@ -300,7 +300,8 @@ namespace Math {
    }
 
    void GoFTest::LogSample() {
-      transform(fSamples[0].begin(), fSamples[0].end(), fSamples[0].begin(), std::ptr_fun<Double_t, Double_t>(TMath::Log));
+      transform(fSamples[0].begin(), fSamples[0].end(), fSamples[0].begin(),
+                std::function<Double_t(Double_t)>(TMath::Log));
       SetParameters();
    }
 

--- a/math/mathcore/src/GoFTest.cxx
+++ b/math/mathcore/src/GoFTest.cxx
@@ -670,7 +670,8 @@ void GoFTest::AndersonDarling2SamplesTest(Double_t& pvalue, Double_t& testStat) 
       for (std::vector<Double_t>::iterator data = z.begin(); data != endUnique; ++data) {
          UInt_t n = std::count(fCombinedSamples.begin(), fCombinedSamples.end(), *data);
          h.push_back(n);
-         H.push_back(std::count_if(fCombinedSamples.begin(), fCombinedSamples.end(), bind2nd(std::less<Double_t>(), *data)) + n / 2.);
+         H.push_back(std::count_if(fCombinedSamples.begin(), fCombinedSamples.end(),
+                     std::bind(std::less<Double_t>(), std::placeholders::_1, *data)) + n / 2.);
       }
       std::cout << "time for H";
       w.Print();
@@ -679,7 +680,8 @@ void GoFTest::AndersonDarling2SamplesTest(Double_t& pvalue, Double_t& testStat) 
       for (UInt_t i = 0; i < nSamples; ++i) {
          for (std::vector<Double_t>::iterator data = z.begin(); data != endUnique; ++data) {
             UInt_t n = std::count(fSamples[i].begin(), fSamples[i].end(), *data);
-            F[i].push_back(std::count_if(fSamples[i].begin(), fSamples[i].end(), bind2nd(std::less<Double_t>(), *data)) + n / 2.);
+            F[i].push_back(std::count_if(fSamples[i].begin(), fSamples[i].end(),
+                           std::bind(std::less<Double_t>(), std::placeholders::_1, *data)) + n / 2.);
          }
       }
       std::cout << "time for F";

--- a/math/mathcore/test/testSampleQuantiles.cxx
+++ b/math/mathcore/test/testSampleQuantiles.cxx
@@ -7,6 +7,8 @@
 
 #include <iostream>
 #include <algorithm>
+#include <random>
+
 using std::cout;
 using std::endl;
 
@@ -37,7 +39,7 @@ bool testQuantiles(int type = 0, bool sorted = true) {
 
    if (!sorted) {
       // shuffle the data
-      std::random_shuffle(x, x+10);
+      std::shuffle(x, x+10, std::default_random_engine{});
       if (debug) {
          std::cout << "shuffle data " << std::endl;
          std::cout << " data = { ";

--- a/math/mathmore/test/CMakeLists.txt
+++ b/math/mathmore/test/CMakeLists.txt
@@ -39,12 +39,9 @@ if(ROOT_minuit2_FOUND)
   list(APPEND Libraries Minuit2)
 endif()
 
-
 #some tests requires directly gsl
 include_directories(${GSL_INCLUDE_DIR} ${CMAKE_SOURCE_DIR})
 add_definitions(-DUSE_ROOT_ERROR -DHAVE_ROOTLIBS)
-
-ROOT_ADD_CXX_FLAG(CMAKE_CXX_FLAGS -Wno-deprecated-declarations) # bind1st
 
 #---Build and add all the defined test in the list---------------
 foreach(file ${TestMathMoreSource})

--- a/math/mathmore/test/testFunctor.cxx
+++ b/math/mathmore/test/testFunctor.cxx
@@ -338,52 +338,32 @@ void testMore() {
    ROOT::Math::ParamFunctor fp1(&freeRootFunc2D);
    TestTimePF(fp1);
 
-//    ROOT::Math::ParamFunctor1D fp2(&freeParamFunc1D);
-//    TestTimePF(fp2);
-
-
    DerivFunction fdf;
    TestTime(fdf);
-
 
    //1D
 
    DerivFunction1D f13;
    TestTime(f13);
 
-
-
-
-   //TestTimeGF(f3);
    ROOT::Math::WrappedFunction<> f5(freeFunction1D);
    TestTime(f5);
 
    ROOT::Math::WrappedMultiFunction<> f5b(freeFunction,2);
    TestTime(f5b);
 
-
-
    F1D fobj;
-   //std::cout << typeid(&F1D::Eval).name() << std::endl;
-   ROOT::Math::Functor1D f6(std::bind1st(std::mem_fun(&F1D::Eval), &fobj) );
+   ROOT::Math::Functor1D f6([&fobj](double x) { return fobj.Eval(x); });
    TestTime(f6);
 
-   ROOT::Math::WrappedFunction<std::binder1st<std::mem_fun1_t<double, F1D, double> > >  f6a((std::bind1st(std::mem_fun(&F1D::Eval), &fobj)));
+   ROOT::Math::WrappedFunction<std::function<double(double)>> f6a([&fobj](double x) { return fobj.Eval(x); });
    TestTime(f6a);
 
-   //typedef double( * FreeFunc ) (double );
-   //ROOT::Math::WrappedMemFunction<F1D,FreeFunc>  f6b(&fobj, &F1D::Eval, );
-
-//    typedef double (F1D::*MemFun)(double);
-//    double (F1D::*p1 )(double) = &F1D::Eval;
-//    std::cout << typeid(p1).name() << std::endl;
-   ROOT::Math::WrappedMemFunction<F1D, double (F1D::*)(double) >  f6b(fobj, &F1D::Eval );
+   ROOT::Math::WrappedMemFunction<F1D, double (F1D::*)(double)> f6b(fobj, &F1D::Eval);
    TestTime(f6b);
 
-   ROOT::Math::Functor1D f6c(&fobj, &F1D::Eval );
+   ROOT::Math::Functor1D f6c(&fobj, &F1D::Eval);
    TestTime(f6c);
-
-
 
 #ifdef LATER
    FunctorNV<GradFunc, MyFunction> f5(myf);
@@ -395,11 +375,7 @@ void testMore() {
 #endif
 
    TF1 tf1("tf1",freeRootFunc2D,0,1,0);
-   //TF2 tf1("tf1","x+y",0,1,0,1);
    TestTimeTF1(tf1);
-
-//    ROOT::Fit::WrappedTF1 f7(&tf1);
-//    TestTime(f7);
 
    ROOT::Math::WrappedMultiTF1 f7b(tf1);
    TestTime(f7b);
@@ -413,17 +389,11 @@ void testMore() {
    ROOT::Math::WrappedParamFunction<TF1*> wf7b(&tf1,2,0,0);
    TestTimePF(wf7b);
 
-
-
    TF1 tf2("tf2",freeRootFunc1D,0,1,0);
    TestTimeTF1(tf2);
 
    ROOT::Math::WrappedTF1 f7c(tf2);
    TestTime(f7c);
-
-
-//    double xx[1] = {2};
-//    f7(xx);
 
    ROOT::Math::Functor f8(f7b,f7b.NDim());
    TestTime(f8);
@@ -437,8 +407,6 @@ void testMore() {
 //    ROOT::Math::Functor f10(&tf1,&TF1::EvalPar,tf1.GetNdim());
 //    TestTime(f10);
 // #endif
-
-
 
    // test with rootit
 #ifdef HAVE_ROOFIT

--- a/misc/memstat/inc/TMemStatHelpers.h
+++ b/misc/memstat/inc/TMemStatHelpers.h
@@ -48,7 +48,7 @@ namespace Memstat {
 
       iterator_t iter(&_Container);
       iterator_t found(
-         std::find_if(iter.Begin(), iterator_t::End(), bind2nd(SFind_t(), _ToFind))
+         std::find_if(iter.Begin(), iterator_t::End(), std::bind(SFind_t(), std::placeholders::_1, _ToFind))
       );
       return ((!(*found)) ? -1 : std::distance(iter.Begin(), found));
    }

--- a/net/glite/src/TGLite.cxx
+++ b/net/glite/src/TGLite.cxx
@@ -202,7 +202,7 @@ struct SAddMapElementFunc: public binary_function<SLFCFileInfo_t, TGLiteResult*,
       // Add replication info
       for_each(_lfc_info.m_LFCRepInfoVector.begin(),
                _lfc_info.m_LFCRepInfoVector.end(),
-               bind2nd(SAddRepInfo(), map));
+               std::bind(SAddRepInfo(), std::placeholders::_1, map));
 
       _Result->Add(map);
       return true;
@@ -321,7 +321,7 @@ TGridResult* TGLite::Query(const char *_path, const char *_pattern /*= NULL*/, c
 
    // Creating ROOT containers to store the resultset
    TGLiteResult *result = new TGLiteResult();
-   for_each(container.begin(), container.end(), bind2nd(SAddMapElementFunc(), result));
+   for_each(container.begin(), container.end(), std::bind(SAddMapElementFunc(), std::placeholders::_1, result));
 
    return result;
 }
@@ -369,7 +369,7 @@ TGridResult* TGLite::Ls(const char *_ldn, Option_t* /*options*/, Bool_t /*verbos
 
    // Creating a ROOT container to store the resultset
    TGLiteResult *result = new TGLiteResult();
-   for_each(container.begin(), container.end(), bind2nd(SAddMapElementFunc(), result));
+   for_each(container.begin(), container.end(), std::bind(SAddMapElementFunc(), std::placeholders::_1, result));
 
    return result;
 }

--- a/test/stressIterators.h
+++ b/test/stressIterators.h
@@ -57,7 +57,7 @@ struct SEnumFunctor<TMap> {
 
 //______________________________________________________________________________
 template<class T>
-struct SFind : std::binary_function<TObject*, TString, bool> {
+struct SFind : std::function<TObject*(TString, bool)> {
    bool operator()(TObject *_Obj, const TString &_ToFind) const {
       TObjString *str(dynamic_cast<TObjString*>(_Obj));
       if (!str)
@@ -68,7 +68,7 @@ struct SFind : std::binary_function<TObject*, TString, bool> {
 
 //______________________________________________________________________________
 template<>
-struct SFind<TMap> : std::binary_function<TObject*, TString, bool> {
+struct SFind<TMap> : std::function<TObject*(TString, bool)> {
    bool operator()(TObject *_Obj, const TString &_ToFind) const {
       TPair *pair(dynamic_cast<TPair*>(_Obj));
       if (!pair)
@@ -124,7 +124,7 @@ void TestContainer_find_if(const T &container, const TString &aToFind)
 
    iterator_t iter(&container);
    iterator_t found(
-      std::find_if(iter.Begin(), iterator_t::End(), bind2nd(SFind<T>(), aToFind))
+      std::find_if(iter.Begin(), iterator_t::End(), std::bind(SFind<T>(), std::placeholders::_1, aToFind))
    );
    if (!(*found))
       throw std::runtime_error("Test case <TestContainer_find_if> has failed. Can't find object.");
@@ -158,7 +158,7 @@ void TestContainer_count_if(const T &container, const TString &aToFind, Int_t Co
 
    iterator_t iter(&container);
    typename iterator_t::difference_type cnt(
-      std::count_if(iter.Begin(), iterator_t::End(), bind2nd(SFind<T>(), aToFind))
+      std::count_if(iter.Begin(), iterator_t::End(), std::bind(SFind<T>(), std::placeholders::_1, aToFind))
    );
 
    if (Count != cnt)

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Reference/DataLoader.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Reference/DataLoader.h
@@ -21,6 +21,8 @@
 
 #include "TMVA/DNN/DataLoader.h"
 
+#include <random>
+
 namespace TMVA {
 namespace DNN {
 
@@ -112,7 +114,7 @@ TBatch<TReference<AReal>> TDataLoader<AData, TReference<AReal>>::GetBatch()
 template <typename AData, typename AReal>
 void TDataLoader<AData, TReference<AReal>>::Shuffle()
 {
-   std::random_shuffle(fSampleIndices.begin(), fSampleIndices.end());
+   std::shuffle(fSampleIndices.begin(), fSampleIndices.end(), std::default_random_engine{});
 }
 
 } // namespace DNN

--- a/tmva/tmva/inc/TMVA/DNN/DataLoader.h
+++ b/tmva/tmva/inc/TMVA/DNN/DataLoader.h
@@ -19,11 +19,12 @@
 #define TMVA_DNN_DATALOADER
 
 #include "TMatrix.h"
-#include <vector>
-#include <iostream>
-#include <algorithm>
-
 #include "TMVA/Event.h"
+
+#include <algorithm>
+#include <iostream>
+#include <random>
+#include <vector>
 
 namespace TMVA {
 
@@ -267,7 +268,7 @@ TBatch<AArchitecture> TDataLoader<Data_t, AArchitecture>::GetBatch()
 template<typename Data_t, typename AArchitecture>
 void TDataLoader<Data_t, AArchitecture>::Shuffle()
 {
-   std::random_shuffle(fSampleIndices.begin(), fSampleIndices.end());
+   std::shuffle(fSampleIndices.begin(), fSampleIndices.end(), std::default_random_engine{});
 }
 
 } // namespace DNN

--- a/tmva/tmva/inc/TMVA/NeuralNet.icc
+++ b/tmva/tmva/inc/TMVA/NeuralNet.icc
@@ -7,13 +7,14 @@
 #pragma once
 #pragma GCC diagnostic ignored "-Wunused-variable"
 
-#include <tuple>
-#include <future>
-
 #include "Math/Util.h"
 
 #include "TMVA/Pattern.h"
 #include "TMVA/MethodBase.h"
+
+#include <tuple>
+#include <future>
+#include <random>
 
 namespace TMVA
 {
@@ -944,7 +945,7 @@ template <typename LAYERDATA>
             size_t numBatches = numPattern/settings.batchSize ();
             size_t numBatches_stored = numBatches;
 
-            std::random_shuffle (itPatternBegin, itPatternEnd);
+            std::shuffle(itPatternBegin, itPatternEnd, std::default_random_engine{});
             Iterator itPatternBatchBegin = itPatternBegin;
             Iterator itPatternBatchEnd = itPatternBatchBegin;
 

--- a/tmva/tmva/inc/TMVA/RuleFit.h
+++ b/tmva/tmva/inc/TMVA/RuleFit.h
@@ -27,12 +27,13 @@
 #ifndef ROOT_TMVA_RuleFit
 #define ROOT_TMVA_RuleFit
 
-#include <algorithm>
-
 #include "TMVA/DecisionTree.h"
 #include "TMVA/RuleEnsemble.h"
 #include "TMVA/RuleFitParams.h"
 #include "TMVA/Event.h"
+
+#include <algorithm>
+#include <random>
 
 namespace TMVA {
 
@@ -61,7 +62,10 @@ namespace TMVA {
 
       void SetTrainingEvents( const std::vector<const TMVA::Event *> & el );
 
-      void ReshuffleEvents() { std::random_shuffle(fTrainingEventsRndm.begin(),fTrainingEventsRndm.end()); }
+      void ReshuffleEvents()
+      {
+         std::shuffle(fTrainingEventsRndm.begin(), fTrainingEventsRndm.end(), fRNGEngine);
+      }
 
       void SetMethodBase( const MethodBase *rfbase );
 
@@ -169,6 +173,7 @@ namespace TMVA {
       MsgLogger& Log() const { return *fLogger; }    
 
       static const Int_t randSEED = 0; // set to 1 for debugging purposes or to zero for random seeds
+      std::default_random_engine fRNGEngine;
 
       ClassDef(RuleFit,0);  // Calculations for Friedman's RuleFit method
    };

--- a/tmva/tmva/src/DNN/Architectures/Cpu/DataLoader.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Cpu/DataLoader.cxx
@@ -17,6 +17,7 @@
 #include "TMVA/DNN/Architectures/Cpu/DataLoader.h"
 #include "TMVA/Event.h"
 #include <iostream>
+#include <random>
 
 namespace TMVA
 {
@@ -128,7 +129,7 @@ template<typename Data_t, typename Real_t>
 auto TCpuDataLoader<Data_t, Real_t>::begin()
     -> BatchIterator_t
 {
-   random_shuffle(fSampleIndices.begin(), fSampleIndices.end());
+   std::shuffle(fSampleIndices.begin(), fSampleIndices.end(), std::default_random_engine{});
    return BatchIterator_t(*this, 0);
 }
 

--- a/tmva/tmva/src/DataSetFactory.cxx
+++ b/tmva/tmva/src/DataSetFactory.cxx
@@ -1348,30 +1348,12 @@ TMVA::DataSetFactory::MixEvents( DataSetInfo& dsi,
             }
          }
       }
-
-      // debugging output: classnumbers of all events in training and testing vectors
-      //       std::cout << std::endl;
-      //       std::cout << "TRAINING VECTOR" << std::endl;
-      //       std::transform( trainingEventVector->begin(), trainingEventVector->end(), ostream_iterator<Int_t>(std::cout, "|"), std::mem_fun(&TMVA::Event::GetClass) );
-
-      //       std::cout << std::endl;
-      //       std::cout << "TESTING VECTOR" << std::endl;
-      //       std::transform( testingEventVector->begin(), testingEventVector->end(), ostream_iterator<Int_t>(std::cout, "|"), std::mem_fun(&TMVA::Event::GetClass) );
-      //       std::cout << std::endl;
-
    }else{
       for( UInt_t cls = 0; cls < dsi.GetNClasses(); ++cls ){
          trainingEventVector->insert( trainingEventVector->end(), tmpEventVector[Types::kTraining].at(cls).begin(), tmpEventVector[Types::kTraining].at(cls).end() );
          testingEventVector->insert ( testingEventVector->end(),  tmpEventVector[Types::kTesting].at(cls).begin(),  tmpEventVector[Types::kTesting].at(cls).end()  );
       }
    }
-
-   //    std::cout << "trainingEventVector " << trainingEventVector->size() << std::endl;
-   //    std::cout << "testingEventVector  " << testingEventVector->size() << std::endl;
-
-   //    std::transform( trainingEventVector->begin(), trainingEventVector->end(), ostream_iterator<Int_t>(std::cout, "> \n"), std::mem_fun(&TMVA::Event::GetNVariables) );
-   //    std::transform( testingEventVector->begin(), testingEventVector->end(), ostream_iterator<Int_t>(std::cout, "> \n"), std::mem_fun(&TMVA::Event::GetNVariables) );
-
    // delete the tmpEventVector (but not the events therein)
    tmpEventVector[Types::kTraining].clear();
    tmpEventVector[Types::kTesting].clear();
@@ -1462,22 +1444,17 @@ TMVA::DataSetFactory::RenormEvents( TMVA::DataSetInfo& dsi,
       //     compose_binary creates a BinaryFunction of ...
       //         std::plus<Double_t>() knows how to sum up two doubles
       //         null<Double_t>() leaves the first argument (the running sum) unchanged and returns it
-      //         std::mem_fun knows how to call a member function (type and member-function given as argument) and return the result
       //
       // all together sums up all the event-weights of the events in the vector and returns it
-      trainingSumWeightsPerClass.at(cls) = std::accumulate( tmpEventVector[Types::kTraining].at(cls).begin(),
-                                                            tmpEventVector[Types::kTraining].at(cls).end(),
-                                                            Double_t(0),
-                                                            compose_binary( std::plus<Double_t>(),
-                                                                            null<Double_t>(),
-                                                                            std::mem_fun(&TMVA::Event::GetOriginalWeight) ) );
+      trainingSumWeightsPerClass.at(cls) =
+         std::accumulate(tmpEventVector[Types::kTraining].at(cls).begin(),
+                         tmpEventVector[Types::kTraining].at(cls).end(),
+                         Double_t(0), [](Double_t w, const TMVA::Event *E) { return w + E->GetOriginalWeight(); });
 
-      testingSumWeightsPerClass.at(cls)  = std::accumulate( tmpEventVector[Types::kTesting].at(cls).begin(),
-                                                            tmpEventVector[Types::kTesting].at(cls).end(),
-                                                            Double_t(0),
-                                                            compose_binary( std::plus<Double_t>(),
-                                                                            null<Double_t>(),
-                                                                            std::mem_fun(&TMVA::Event::GetOriginalWeight) ) );
+      testingSumWeightsPerClass.at(cls) =
+         std::accumulate(tmpEventVector[Types::kTesting].at(cls).begin(),
+                         tmpEventVector[Types::kTesting].at(cls).end(),
+                         Double_t(0), [](Double_t w, const TMVA::Event *E) { return w + E->GetOriginalWeight(); });
 
       if ( cls == dsi.GetSignalClassIndex()){
          trainingSumSignalWeights += trainingSumWeightsPerClass.at(cls);
@@ -1588,21 +1565,15 @@ TMVA::DataSetFactory::RenormEvents( TMVA::DataSetInfo& dsi,
    testingSumBackgrWeights  = 0; // Backgr. includes all classes that are not signal
 
    for( UInt_t cls = 0, clsEnd = dsi.GetNClasses(); cls < clsEnd; ++cls ){
+      trainingSumWeightsPerClass.at(cls) =
+         std::accumulate(tmpEventVector[Types::kTraining].at(cls).begin(),
+                         tmpEventVector[Types::kTraining].at(cls).end(),
+                         Double_t(0), [](Double_t w, const TMVA::Event *E) { return w + E->GetOriginalWeight(); });
 
-      trainingSumWeightsPerClass.at(cls) = (std::accumulate( tmpEventVector[Types::kTraining].at(cls).begin(),  // accumulate --> start at begin
-                                                             tmpEventVector[Types::kTraining].at(cls).end(),    //    until end()
-                                                             Double_t(0),                                       // values are of type double
-                                                             compose_binary( std::plus<Double_t>(),             // define addition for doubles
-                                                                             null<Double_t>(),                  // take the argument, don't do anything and return it
-                                                                             std::mem_fun(&TMVA::Event::GetOriginalWeight) ) )); // take the value from GetOriginalWeight
-
-      testingSumWeightsPerClass.at(cls)  = std::accumulate( tmpEventVector[Types::kTesting].at(cls).begin(),
-                                                            tmpEventVector[Types::kTesting].at(cls).end(),
-                                                            Double_t(0),
-                                                            compose_binary( std::plus<Double_t>(),
-                                                                            null<Double_t>(),
-                                                                            std::mem_fun(&TMVA::Event::GetOriginalWeight) ) );
-
+      testingSumWeightsPerClass.at(cls) =
+         std::accumulate(tmpEventVector[Types::kTesting].at(cls).begin(),
+                         tmpEventVector[Types::kTesting].at(cls).end(),
+                         Double_t(0), [](Double_t w, const TMVA::Event *E) { return w + E->GetOriginalWeight(); });
 
       if ( cls == dsi.GetSignalClassIndex()){
          trainingSumSignalWeights += trainingSumWeightsPerClass.at(cls);

--- a/tmva/tmva/src/DataSetFactory.cxx
+++ b/tmva/tmva/src/DataSetFactory.cxx
@@ -43,6 +43,7 @@ Class that contains all the data information
 #include <algorithm>
 #include <functional>
 #include <numeric>
+#include <random>
 
 #include "TMVA/DataSetFactory.h"
 
@@ -984,7 +985,7 @@ TMVA::DataSetFactory::MixEvents( DataSetInfo& dsi,
                                  const TString& normMode,
                                  UInt_t splitSeed)
 {
-   TMVA::RandomGenerator rndm( splitSeed );
+   std::default_random_engine rndm(splitSeed);
 
    // ==== splitting of undefined events to kTraining and kTesting
 
@@ -998,9 +999,7 @@ TMVA::DataSetFactory::MixEvents( DataSetInfo& dsi,
                   << unspecifiedEvents.size()
                   << " events of class " << cls
                   << " which are not yet associated to testing or training" << Endl;
-            std::random_shuffle( unspecifiedEvents.begin(),
-                                 unspecifiedEvents.end(),
-                                 rndm );
+            std::shuffle(unspecifiedEvents.begin(), unspecifiedEvents.end(), rndm);
          }
       }
    }
@@ -1225,7 +1224,7 @@ TMVA::DataSetFactory::MixEvents( DataSetInfo& dsi,
             // make indices
             std::generate( indicesTraining.begin(), indicesTraining.end(), TMVA::Increment<UInt_t>(0) );
             // shuffle indices
-            std::random_shuffle( indicesTraining.begin(), indicesTraining.end(), rndm );
+            std::shuffle(indicesTraining.begin(), indicesTraining.end(), rndm);
             // erase indices of not needed events
             indicesTraining.erase( indicesTraining.begin()+sizeTraining-UInt_t(requestedTraining), indicesTraining.end() );
             // delete all events with the given indices
@@ -1243,7 +1242,7 @@ TMVA::DataSetFactory::MixEvents( DataSetInfo& dsi,
             // make indices
             std::generate( indicesTesting.begin(), indicesTesting.end(), TMVA::Increment<UInt_t>(0) );
             // shuffle indices
-            std::random_shuffle( indicesTesting.begin(), indicesTesting.end(), rndm );
+            std::shuffle(indicesTesting.begin(), indicesTesting.end(), rndm);
             // erase indices of not needed events
             indicesTesting.erase( indicesTesting.begin()+sizeTesting-UInt_t(requestedTesting), indicesTesting.end() );
             // delete all events with the given indices
@@ -1363,8 +1362,8 @@ TMVA::DataSetFactory::MixEvents( DataSetInfo& dsi,
    if (mixMode == "RANDOM") {
       Log() << kDEBUG << Form("Dataset[%s] : ",dsi.GetName())<< "shuffling events"<<Endl;
 
-      std::random_shuffle( trainingEventVector->begin(), trainingEventVector->end(), rndm );
-      std::random_shuffle( testingEventVector->begin(),  testingEventVector->end(),  rndm  );
+      std::shuffle(trainingEventVector->begin(), trainingEventVector->end(), rndm);
+      std::shuffle(testingEventVector->begin(),  testingEventVector->end(),  rndm);
    }
 
    Log() << kDEBUG << Form("Dataset[%s] : ",dsi.GetName())<< "trainingEventVector " << trainingEventVector->size() << Endl;

--- a/tmva/tmva/src/MethodFDA.cxx
+++ b/tmva/tmva/src/MethodFDA.cxx
@@ -596,9 +596,6 @@ void TMVA::MethodFDA::CalculateMulticlassValues( const TMVA::Event*& evt, std::v
       values.push_back( value );
       sum += value;
    }
-
-   //    // normalize to sum of value (commented out, .. have to think of how to treat negative classifier values)
-   //    std::transform( fMulticlassReturnVal.begin(), fMulticlassReturnVal.end(), fMulticlassReturnVal.begin(), bind2nd( std::divides<float>(), sum) );
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/src/MethodRuleFit.cxx
+++ b/tmva/tmva/src/MethodRuleFit.cxx
@@ -57,6 +57,7 @@ J Friedman's RuleFit method
 
 #include <algorithm>
 #include <list>
+#include <random>
 
 using std::min;
 
@@ -433,7 +434,7 @@ void TMVA::MethodRuleFit::InitEventSample( void )
    }
    if (fTreeEveFrac>1.0) fTreeEveFrac=1.0;
    //
-   std::random_shuffle(fEventSample.begin(), fEventSample.end());
+   std::shuffle(fEventSample.begin(), fEventSample.end(), std::default_random_engine{});
    //
    Log() << kDEBUG << "Set sub-sample fraction to " << fTreeEveFrac << Endl;
 }

--- a/tmva/tmva/src/NeuralNet.cxx
+++ b/tmva/tmva/src/NeuralNet.cxx
@@ -556,18 +556,13 @@ namespace TMVA
             size_t numDrops = dropFraction * _numNodes;
             if (numDrops >= _numNodes) // maintain at least one node
                 numDrops = _numNodes - 1;
-            dropContainer.insert (end (dropContainer), _numNodes-numDrops, true); // add the markers for the nodes which are enabled
-            dropContainer.insert (end (dropContainer), numDrops, false); // add the markers for the disabled nodes
-            // shuffle 
-            std::random_shuffle (end (dropContainer)-_numNodes, end (dropContainer)); // shuffle enabled and disabled markers
+            // add the markers for the nodes which are enabled
+            dropContainer.insert (end (dropContainer), _numNodes-numDrops, true);
+            // add the markers for the disabled nodes
+            dropContainer.insert (end (dropContainer), numDrops, false);
+            // shuffle enabled and disabled markers
+            std::shuffle(end(dropContainer)-_numNodes, end(dropContainer), std::default_random_engine{});
         }
-
-
-
-
-
-
-
  
     }; // namespace DNN
 }; // namespace TMVA

--- a/tmva/tmva/src/RuleFit.cxx
+++ b/tmva/tmva/src/RuleFit.cxx
@@ -55,18 +55,19 @@ A class implementing various fits of rule ensembles
 #include "TROOT.h" // for gROOT
 
 #include <algorithm>
+#include <random>
 
 ClassImp(TMVA::RuleFit);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// constructor
 
-TMVA::RuleFit::RuleFit( const MethodBase *rfbase )
-: fVisHistsUseImp( kTRUE ),
-   fLogger( new MsgLogger("RuleFit") )
+TMVA::RuleFit::RuleFit(const MethodBase *rfbase)
+   : fVisHistsUseImp( kTRUE )
+   , fLogger(new MsgLogger("RuleFit"))
 {
-   Initialize( rfbase );
-   std::srand( randSEED );  // initialize random number generator used by std::random_shuffle
+   Initialize(rfbase);
+   fRNGEngine.seed(randSEED);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -77,10 +78,10 @@ TMVA::RuleFit::RuleFit()
    , fNEveEffTrain(0)
    , fMethodRuleFit(0)
    , fMethodBase(0)
-   , fVisHistsUseImp( kTRUE )
-   , fLogger( new MsgLogger("RuleFit") )
+   , fVisHistsUseImp(kTRUE)
+   , fLogger(new MsgLogger("RuleFit"))
 {
-   std::srand( randSEED ); // initialize random number generator used by std::random_shuffle
+   fRNGEngine.seed(randSEED);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -451,7 +452,7 @@ void TMVA::RuleFit::SetTrainingEvents( const std::vector<const Event *>& el )
    }
 
    // Re-shuffle the vector, ie, recreate it in a random order
-   std::random_shuffle( fTrainingEventsRndm.begin(), fTrainingEventsRndm.end() );
+   std::shuffle(fTrainingEventsRndm.begin(), fTrainingEventsRndm.end(), fRNGEngine);
 
    // fraction events per tree
    fNTreeSample = static_cast<UInt_t>(neve*fMethodRuleFit->GetTreeEveFrac());

--- a/tmva/tmva/src/RuleFitParams.cxx
+++ b/tmva/tmva/src/RuleFitParams.cxx
@@ -1079,11 +1079,13 @@ Double_t TMVA::RuleFitParams::ErrorRateRocRaw( std::vector<Double_t> & sFsig,
    //
    for (Int_t i=0; i<np; i++) {
       fcut = minf + df*Double_t(i);
-      indit = std::find_if( sFsig.begin(), sFsig.end(), std::bind2nd(std::greater_equal<Double_t>(), fcut));
+      indit = std::find_if(sFsig.begin(), sFsig.end(),
+                           std::bind(std::greater_equal<Double_t>(), std::placeholders::_1, fcut));
       nesig = sFsig.end()-indit; // number of sig accepted with F>cut
       if (TMath::Abs(pnesig-nesig)>0) {
          npok++;
-         indit = std::find_if( sFbkg.begin(), sFbkg.end(), std::bind2nd(std::greater_equal<Double_t>(), fcut));
+         indit = std::find_if(sFbkg.begin(), sFbkg.end(),
+                              std::bind(std::greater_equal<Double_t>(), std::placeholders::_1, fcut));
          nrbkg = indit-sFbkg.begin(); // number of bkg rejected with F>cut
          rejb = Double_t(nrbkg)/Double_t(nbkg);
          effs = Double_t(nesig)/Double_t(nsig);


### PR DESCRIPTION
This gets rid of some deprecated things that are actually removed in libc++, such as `std::pointer_to_unary_function` and `std::mem_fun`. However, it is not yet enough to compile all of ROOT with C++17 enabled with libc++, after linking `rootcling_stage1`, there is a confusion between standard library headers in `rootcling` that will need to be addressed by further changes.