### PR TITLE
fix -Woverride warnings in TMVA MLP codegen

### DIFF
--- a/tmva/tmva/src/MethodANNBase.cxx
+++ b/tmva/tmva/src/MethodANNBase.cxx
@@ -1149,9 +1149,9 @@ void TMVA::MethodANNBase::MakeClassSpecific( std::ostream& fout, const TString& 
    fncName = className+"::OutputActivationFnc";   //zjh
    fOutput->MakeFunction(fout, fncName);//zjh
 
-   fout << "   " << std::endl;
+   fout << std::endl;
    fout << "// Clean up" << std::endl;
-   fout << "inline void " << className << "::Clear() " << std::endl;
+   fout << "inline void " << className << "::Clear()" << std::endl;
    fout << "{" << std::endl;
    fout << "}" << std::endl;
 }

--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -3015,12 +3015,12 @@ void TMVA::MethodBase::MakeClass( const TString& theClassFileName ) const
    fout << " public:" << std::endl;
    fout << std::endl;
    fout << "   // constructor" << std::endl;
-   fout << "   " << className << "( std::vector<std::string>& theInputVars ) " << std::endl;
+   fout << "   " << className << "( std::vector<std::string>& theInputVars )" << std::endl;
    fout << "      : IClassifierReader()," << std::endl;
    fout << "        fClassName( \"" << className << "\" )," << std::endl;
    fout << "        fNvars( " << GetNvar() << " )," << std::endl;
    fout << "        fIsNormalised( " << (IsNormalised() ? "true" : "false") << " )" << std::endl;
-   fout << "   {      " << std::endl;
+   fout << "   {" << std::endl;
    fout << "      // the training input variables" << std::endl;
    fout << "      const char* inputVars[] = { ";
    for (UInt_t ivar=0; ivar<GetNvar(); ivar++) {
@@ -3076,9 +3076,9 @@ void TMVA::MethodBase::MakeClass( const TString& theClassFileName ) const
    fout << "   }" << std::endl;
    fout << std::endl;
    fout << "   // the classifier response" << std::endl;
-   fout << "   // \"inputValues\" is a vector of input values in the same order as the " << std::endl;
+   fout << "   // \"inputValues\" is a vector of input values in the same order as the" << std::endl;
    fout << "   // variables given to the constructor" << std::endl;
-   fout << "   double GetMvaValue( const std::vector<double>& inputValues ) const;" << std::endl;
+   fout << "   double GetMvaValue( const std::vector<double>& inputValues ) const override;" << std::endl;
    fout << std::endl;
    fout << " private:" << std::endl;
    fout << std::endl;

--- a/tmva/tmva/src/VariableTransformBase.cxx
+++ b/tmva/tmva/src/VariableTransformBase.cxx
@@ -824,7 +824,7 @@ void TMVA::VariableTransformBase::MakeFunction( std::ostream& fout, const TStrin
       fout << "   // define the indices of the variables which are transformed by this transformation" << std::endl;
       fout << "   static std::vector<int> indicesGet;" << std::endl;
       fout << "   static std::vector<int> indicesPut;" << std::endl << std::endl;
-      fout << "   if ( indicesGet.empty() ) { " << std::endl;
+      fout << "   if ( indicesGet.empty() ) {" << std::endl;
       fout << "      indicesGet.reserve(fNvars);" << std::endl;
 
       for( ItVarTypeIdxConst itEntry = fGet.begin(), itEntryEnd = fGet.end(); itEntry != itEntryEnd; ++itEntry ) {
@@ -845,8 +845,8 @@ void TMVA::VariableTransformBase::MakeFunction( std::ostream& fout, const TStrin
             Log() << kFATAL << "VariableTransformBase/GetInput : unknown type '" << type << "'." << Endl;
          }
       }
-      fout << "   } " <<  std::endl;
-      fout << "   if ( indicesPut.empty() ) { " << std::endl;
+      fout << "   }" <<  std::endl;
+      fout << "   if ( indicesPut.empty() ) {" << std::endl;
       fout << "      indicesPut.reserve(fNvars);" << std::endl;
 
       for( ItVarTypeIdxConst itEntry = fPut.begin(), itEntryEnd = fPut.end(); itEntry != itEntryEnd; ++itEntry ) {
@@ -868,7 +868,7 @@ void TMVA::VariableTransformBase::MakeFunction( std::ostream& fout, const TStrin
          }
       }
 
-      fout << "   } " <<  std::endl;
+      fout << "   }" <<  std::endl;
       fout << std::endl;
 
    }else if( part == 1){


### PR DESCRIPTION
this is a backport of
https://gitlab.cern.ch/lhcb/Rec/commit/6103563cc0fc537d8920a2918117b27a48823772#5c0090c3eee645cadb8dd97f9faf43e9664403ce_191_190

There are actually two changes:
 - add an override in MethodBase generated code
 - remove trailing whitespaces in the code of a MLP w/ normalise variable transformation.

discussion points:
 - one could also remove trailing whitespaces in other files (`grep -- ' " << std::endl;'`)
 - the whitespaces are a bit on the boarder of history noise vs. useful
 - the override will make the generated code for all code generated methods (not only MLP) depend on c++11 (which to my knowledge is the case for MLP already, but not for the other methods).