### PR TITLE
[cxxmodules] Don't generate C++ modules for clingutil STL dicts.

### DIFF
--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -881,10 +881,11 @@ endfunction()
 #                                 LINKDEF LinkDef.h LinkDef2.h : linkdef files, default value is "LinkDef.h"
 #                                 DICTIONARY_OPTIONS option    : options passed to rootcling
 #                                 INSTALL_OPTIONS option       : options passed to install headers
+#                                 NO_MODULE                    : don't generate a C++ module for this package
 #                                )
 #---------------------------------------------------------------------------------------------------
 function(ROOT_STANDARD_LIBRARY_PACKAGE libname)
-  set(options NO_INSTALL_HEADERS STAGE1 NO_HEADERS NO_SOURCES OBJECT_LIBRARY)
+  set(options NO_INSTALL_HEADERS STAGE1 NO_HEADERS NO_SOURCES OBJECT_LIBRARY NO_MODULE)
   set(oneValueArgs)
   set(multiValueArgs DEPENDENCIES HEADERS SOURCES BUILTINS LIBRARIES DICTIONARY_OPTIONS LINKDEF INSTALL_OPTIONS)
   CMAKE_PARSE_ARGUMENTS(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -917,8 +918,15 @@ function(ROOT_STANDARD_LIBRARY_PACKAGE libname)
     set(STAGE1_FLAG "STAGE1")
   endif()
 
+  # Don't pass the MODULE arg to ROOT_GENERATE_DICTIONARY when
+  # NO_MODULE is set.
+  set(MODULE_GEN_ARG MODULE ${libname})
+  if(ARG_NO_MODULE)
+    set(MODULE_GEN_ARG)
+  endif()
+
   ROOT_GENERATE_DICTIONARY(G__${libname} ${ARG_HEADERS}
-                          MODULE ${libname}
+                          ${MODULE_GEN_ARG}
                           ${STAGE1_FLAG}
                           LINKDEF ${ARG_LINKDEF}
                           OPTIONS ${ARG_DICTIONARY_OPTIONS}

--- a/core/clingutils/CMakeLists.txt
+++ b/core/clingutils/CMakeLists.txt
@@ -46,7 +46,7 @@ foreach(dict ${stldicts})
   string(REPLACE "complex" "root_std_complex.h" header ${header})
   string(REPLACE "multi" "" header ${header})
   ROOT_STANDARD_LIBRARY_PACKAGE(${dict}Dict
-                                NO_SOURCES NO_INSTALL_HEADERS
+                                NO_SOURCES NO_INSTALL_HEADERS NO_MODULE
                                 STAGE1
                                 HEADERS ${header}
                                 LINKDEF src/${dict}Linkdef.h


### PR DESCRIPTION
These C++ modules serve no purpose as we
1. already have an STL dict.
2. they contain just interpreter clutter therefore.
3. care only about the generated IO information.

Let's disable them to get rid of all the build warning
when rootcling can't find the specific STL header that doesn't
exist inside ROOT:

```
Warning in <GenerateModule>: warning: Couldn't find the following specified headers in the module listDict:
  list
Warning in <GenerateModule>: warning: Couldn't find the following specified headers in the module multisetDict:
  set
```