### PR TITLE
[cxxmodules] Also traverse 'used' C++ modules for the header check.

### DIFF
--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -485,6 +485,16 @@ function (ROOT_CXXMODULES_APPEND_TO_MODULEMAP library library_headers)
   set (excluded_headers "${excluded_headers}")
 
   set(modulemap_entry "module \"${library}\" {")
+
+  # Add a `use` directive to Core/Thread to signal that they use some
+  # split out submodules and we pass the rootcling integrity check.
+  if ("${library}" STREQUAL Core)
+    set (modulemap_entry "${modulemap_entry}\n  use ROOT_Types\n")
+    set (modulemap_entry "${modulemap_entry}\n  use ROOT_Core_Config_C\n")
+  elseif ("${library}" STREQUAL Thread)
+    set (modulemap_entry "${modulemap_entry}\n  use ThreadLocalStorage\n")
+  endif()
+
   # For modules GCocoa and GQuartz we need objc context.
   if (${library} MATCHES "(GCocoa|GQuartz)")
     set (modulemap_entry "${modulemap_entry}\n  requires objc\n")

--- a/core/clingutils/res/TClingUtils.h
+++ b/core/clingutils/res/TClingUtils.h
@@ -460,7 +460,8 @@ ROOT::ESTLType IsSTLContainer(const clang::FieldDecl &m);
 int IsSTLContainer(const clang::CXXBaseSpecifier &base);
 
 void foreachHeaderInModule(const clang::Module &module,
-                           const std::function<void(const clang::Module::Header &)> &closure);
+                           const std::function<void(const clang::Module::Header &)> &closure,
+                           bool includeDirectlyUsedModules = true);
 
 //______________________________________________________________________________
 const char *ShortTypeName(const char *typeDesc);

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -2268,21 +2268,10 @@ static bool IncludeHeaders(const std::vector<std::string> &headers, cling::Inter
 static bool ModuleContainsHeaders(TModuleGenerator &modGen, clang::Module *module,
                                   std::vector<std::string> &missingHeaders)
 {
-   // Make a list of modules and submodules that we can check for headers.
-   // We use a SetVector to prevent an infinite loop in unlikely case the
-   // modules somehow are messed up and don't form a tree...
-   llvm::SetVector<clang::Module *> modules;
-   modules.insert(module);
-   for (size_t i = 0; i < modules.size(); ++i) {
-      clang::Module *M = modules[i];
-      for (clang::Module *subModule : M->submodules()) modules.insert(subModule);
-   }
    // Now we collect all header files from the previously collected modules.
    std::set<std::string> moduleHeaders;
-   for (clang::Module *module : modules) {
-      ROOT::TMetaUtils::foreachHeaderInModule(
-         *module, [&moduleHeaders](const clang::Module::Header &h) { moduleHeaders.insert(h.NameAsWritten); });
-   }
+   ROOT::TMetaUtils::foreachHeaderInModule(
+      *module, [&moduleHeaders](const clang::Module::Header &h) { moduleHeaders.insert(h.NameAsWritten); });
 
    // Go through the list of headers that are required by the ModuleGenerator
    // and check for each header if it's in one of the modules we loaded.


### PR DESCRIPTION
rootcling performs an integrity check on the headers that are passed
via the command line and the ones we have in the modulemap. As this
check currently fails because we had to split up the Core and Thread,
we signal with a `use` directive that these other modules belong to
the current module.

The `use` directive is usually only for signalling that we intend
to use this other module from our module, but as we anyway don't
use `-fmodules-decluse` in ROOT we can just reuse this for telling
rootcling that it should also check the split out submodules when
doing the integrity check for the headers.

To give a concrete example: `ThreadLocalStorage` had to split
out of `Thread` to fix a cycle between `Core` and `Thread`.
However, rootcling now doesn't see the ThreadLocalStorage headers
in the `Thread` module but we pass them to the rootcling invocation
for `Thread`. This adds a `use ThreadLocalStorage` to Thread and
lets rootcling also iterate all `use`'d other modules when doing
this check, so we again have the full set of modules here.