### PR TITLE
[cxxmodules] Remove TVersionCheck.h from Core C++ module blacklist

### DIFF
--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -470,7 +470,7 @@ function (ROOT_CXXMODULES_APPEND_TO_MODULEMAP library library_headers)
     endif()
   endif(APPLE)
 
-  set(excluded_headers RConfig.h RVersion.h RtypesImp.h TVersionCheck.h
+  set(excluded_headers RConfig.h RVersion.h RtypesImp.h
                         Rtypes.h RtypesCore.h TClassEdit.h
                         TIsAProxy.h TVirtualIsAProxy.h
                         DllImport.h TGenericClassInfo.h


### PR DESCRIPTION
This header is directly included by TObject.h and directly including
it from some other header doesn't seem to be supported. As C++ modules
with submodule visibility simulate directl including each module header,
we seem to get some errors according to the comments in this header.

This patch removes it from the argument list of the
ROOT_GENERATE_DICTIONARY call which prevents it from getting directly
included in the `Core` C++ module. We can also remove it from the header
blacklist after this change.

The normal dictionary won't be affected by this. This header is anyway
not supposed to contain TVersionCheck.h but only TObject.h which will
still provide it in the right way.