### PR TITLE
[cxxmodules] Move away from environment variable

### DIFF
--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -367,23 +367,22 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
   endif()
 
   if(runtime_cxxmodules AND ARG_MODULE)
-    # FIXME: Once modules work better, we should use some other value like "1"
-    # to disable the module-build remarks from clang.
-    set(runtime_cxxmodules_env "ROOT_MODULES=DEBUG")
+    set(newargs -cxxmodule ${newargs})
   endif()
+
   #---what rootcling command to use--------------------------
   if(ARG_STAGE1)
-    set(command ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}" "${runtime_cxxmodules_env}" $<TARGET_FILE:rootcling_stage1>)
+    set(command ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}" $<TARGET_FILE:rootcling_stage1>)
     set(pcm_name)
   else()
     if(CMAKE_PROJECT_NAME STREQUAL ROOT)
       set(command ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}"
-                  "ROOTIGNOREPREFIX=1" "${runtime_cxxmodules_env}" $<TARGET_FILE:rootcling> -rootbuild)
+                  "ROOTIGNOREPREFIX=1" $<TARGET_FILE:rootcling> -rootbuild)
       set(ROOTCINTDEP rootcling)
     elseif(TARGET ROOT::rootcling)
-      set(command ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${ROOT_LIBRARY_DIR}:$ENV{LD_LIBRARY_PATH}" "${runtime_cxxmodules_env}" $<TARGET_FILE:ROOT::rootcling>)
+      set(command ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${ROOT_LIBRARY_DIR}:$ENV{LD_LIBRARY_PATH}" $<TARGET_FILE:ROOT::rootcling>)
     else()
-      set(command ${CMAKE_COMMAND} -E env "${runtime_cxxmodules_env}" rootcling)
+      set(command ${CMAKE_COMMAND} -E rootcling)
     endif()
   endif()
 

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -4069,6 +4069,7 @@ int RootClingMain(int argc,
    bool writeEmptyRootPCM = false;
    bool selSyntaxOnly = false;
    bool noIncludePaths = false;
+   bool cxxmodule = getenv("ROOT_MODULES") != nullptr;
 
    // Collect the diagnostic pragmas linked to the usage of -W
    // Workaround for ROOT-5656
@@ -4089,6 +4090,12 @@ int RootClingMain(int argc,
             // name for the rootmap file
             rootmapFileName = argv[ic + 1];
             ic += 2;
+            continue;
+         }
+
+         if (strcmp("-cxxmodule", argv[ic]) == 0) {
+            cxxmodule = true;
+            ic += 1;
             continue;
          }
 
@@ -4269,7 +4276,7 @@ int RootClingMain(int argc,
       sharedLibraryPathName = dictpathname;
    }
 
-   if (!isPCH && getenv("ROOT_MODULES")) {
+   if (!isPCH && cxxmodule) {
       // We just pass -fmodules, the CIFactory will do the rest and configure
       // clang correctly once it sees this flag.
       clingArgsInterpreter.push_back("-fmodules");
@@ -4945,7 +4952,7 @@ int RootClingMain(int argc,
          // Write the module/PCH depending on what mode we are on
          if (modGen.IsPCH()) {
             if (!GenerateAllDict(modGen, CI, currentDirectory)) return 1;
-         } else if (getenv("ROOT_MODULES")) {
+         } else if (cxxmodule) {
             if (!GenerateModule(modGen, resourceDir, interp, linkdefFilename, moduleName.str()))
                return 1;
          }


### PR DESCRIPTION
Beside the general aversion against using an environment variable
for this setting, it also turns out that we can't easily set an
environment variable for a rootcling invocation in roottest.

This patch adds the -cxxmodule flag to rootcling to allow activating
this feature without the old environment variable. For backwards
compability, we keep the ROOT_MODULES support around (for now).