### PR TITLE
[NFC] Make it more obvious that we don't concat C-strings

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1286,7 +1286,7 @@ TCling::TCling(const char *name, const char *title)
       fInterpreter->declare("#include \"Rtypes.h\"\n"
                             + gClassDefInterpMacro + "\n"
                             + gInterpreterClassDef + "\n"
-                            + "#undef ClassImp\n"
+                            "#undef ClassImp\n"
                             "#define ClassImp(X);\n"
                             "#include <string>\n"
                             "using namespace std;\n"


### PR DESCRIPTION
The code is fine, but it looks suspicious to the reader and it's
free to fix this small detail and let the code not look as if we
want to concat C-string via +.