### PR TITLE
Adding an include directory for all exported shared libraries, master branch (2017.12.14.)

### DIFF
--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -640,6 +640,7 @@ function(ROOT_LINKER_LIBRARY library)
   set_property(GLOBAL APPEND PROPERTY ROOT_EXPORTED_TARGETS ${library})
   set_target_properties(${library} PROPERTIES OUTPUT_NAME ${library_name})
   set_target_properties(${library} PROPERTIES INTERFACE_LINK_LIBRARIES "${ARG_DEPENDENCIES}")
+  target_include_directories(${library} PUBLIC $<INSTALL_INTERFACE:include>)
   # Do not add -Dname_EXPORTS to the command-line when building files in this
   # target. Doing so is actively harmful for the modules build because it
   # creates extra module variants, and not useful because we don't use these


### PR DESCRIPTION
Hi,

This has been bugging me for a while now. 😛

ROOT has been exporting a CMake configuration for downstream projects (using ROOT) for a while now. But the exported/imported library targets at the moment can't be used with code like:

```cmake
find_package( ROOT 6.10 REQUIRED )
add_executable( MyExecutable test.cxx )
target_link_libraries( MyExecutable ROOT::Core )
```

In this case the build would complain that it can't find the ROOT headers that `test.cxx` may want to use. Even though the expectation against imported targets **is** that they would carry all information with them to compile any client code correctly.

While the latter sentiment can take us quite far, as one could even argue that imported libraries should carry whatever compiler definitions/options the client may need with themselves, unfortunately this is not super easy to do with CMake at the moment. (For instance I don't know of a good way in which the imported library could impose the same C++ standard on the client project that ROOT was built with. While allowing the client project to use an even newer standard if needed.)

So for now I'll just be satisfied making sure that at least the include directory needed by the ROOT libraries would be automatically propagated to clients wanting to link against them. This update takes care of that.

Cheers,
        Attila