### PR TITLE
TTree: flush baskets in parallel if IMT is on and the tree accepts parallelism

### DIFF
--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -4453,8 +4453,9 @@ Int_t TTree::Fill()
       fBranchRef->Clear();
 
 #ifdef R__USE_IMT
+   const auto useIMT = ROOT::IsImplicitMTEnabled() && fIMTEnabled;
    ROOT::Internal::TBranchIMTHelper imtHelper;
-   if (fIMTEnabled) {
+   if (useIMT) {
       fIMTFlush = true;
       fIMTZipBytes.store(0);
       fIMTTotBytes.store(0);
@@ -4471,7 +4472,7 @@ Int_t TTree::Fill()
 #ifndef R__USE_IMT
       nwrite = branch->FillImpl(nullptr);
 #else
-      nwrite = branch->FillImpl(fIMTEnabled ? &imtHelper : nullptr);
+      nwrite = branch->FillImpl(useIMT ? &imtHelper : nullptr);
 #endif
       if (nwrite < 0) {
          if (nerror < 2) {
@@ -4952,7 +4953,8 @@ Int_t TTree::FlushBaskets() const
    Int_t nb = lb->GetEntriesFast();
 
 #ifdef R__USE_IMT
-   if (fIMTEnabled) {
+   const auto useIMT = ROOT::IsImplicitMTEnabled() && fIMTEnabled;
+   if (useIMT) {
       if (fSortedBranches.empty()) { const_cast<TTree*>(this)->InitializeBranchLists(false); }
 
       BoolRAIIToggle sentry(fIMTFlush);


### PR DESCRIPTION
instead of checking only if the tree accepts parallelism.