### PR TITLE
[TDF] Remove ambiguous Reduce overload

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -892,20 +892,6 @@ public:
    }
 
    ////////////////////////////////////////////////////////////////////////////
-   /// \brief Execute a user-defined reduce operation on the values of the first default column.
-   /// \tparam F The type of the reduce callable. Automatically deduced.
-   /// \tparam T The type of the column to apply the reduction to. Automatically deduced.
-   /// \param[in] f A callable with signature `T(T,T)`
-   /// \param[in] redIdentity The reduced object of each thread is initialised to this value.
-   ///
-   /// See the description of the first Reduce overload for more information.
-   template <typename F, typename T = typename TTraits::CallableTraits<F>::ret_type>
-   TResultProxy<T> Reduce(F f, const T &redIdentity)
-   {
-      return Reduce(std::move(f), "", redIdentity);
-   }
-
-   ////////////////////////////////////////////////////////////////////////////
    /// \brief Return the number of entries processed (*lazy action*)
    ///
    /// Useful e.g. for counting the number of entries passing a certain filter (see also `Report`).

--- a/tree/treeplayer/test/dataframe/dataframe_simple_tests.hxx
+++ b/tree/treeplayer/test/dataframe/dataframe_simple_tests.hxx
@@ -410,3 +410,20 @@ TEST(TEST_CATEGORY, TakeCarrays)
 
    gSystem->Unlink(fileName);
 }
+
+TEST(TEST_CATEGORY, Reduce)
+{
+   auto d = TDataFrame(5).DefineSlotEntry("x", [](unsigned int, ULong64_t e) { return static_cast<int>(e) + 1; });
+   auto r1 = d.Reduce([](int x, int y) { return x + y; }, "x");
+   auto r2 = d.Reduce([](int x, int y) { return x * y; }, "x", 1);
+   EXPECT_EQ(*r1, 15);
+   EXPECT_EQ(*r2, 120);
+
+   ROOT::EnableImplicitMT(2);
+   auto d2 = TDataFrame(5).DefineSlotEntry("x", [](unsigned int, ULong64_t e) { return static_cast<int>(e) + 1; });
+   auto r3 = d2.Reduce([](int x, int y) { return x + y; }, "x");
+   auto r4 = d2.Reduce([](int x, int y) { return x * y; }, "x", 1);
+   EXPECT_EQ(*r3, 15);
+   EXPECT_EQ(*r4, 120);
+   ROOT::DisableImplicitMT();
+}


### PR DESCRIPTION
`Reduce(F f, const T &redIdentity)`
and
`Reduce(F f, std::string_view column)`
can clash. The first `Reduce` overload has been removed.

A separate PR to roottest fixes `test_reduce` by adapting to this change.