### PR TITLE
Fix ROOT-9116

### DIFF
--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -61,6 +61,7 @@ TTreeProcessorMT::TTreeProcessorMT(TTree &tree, TEntryList &entries) : treeView(
 /// Divide input data in clusters, i.e. the workloads to distribute to tasks
 std::vector<ROOT::Internal::TreeViewCluster> TTreeProcessorMT::MakeClusters()
 {
+   TDirectory::TContext c;
    std::vector<ROOT::Internal::TreeViewCluster> clusters;
    const auto &fileNames = treeView->GetFileNames();
    const auto nFileNames = fileNames.size();


### PR DESCRIPTION
"TDF: bad interaction between multi-thread execution and separate output TFile"

See [jira ticket](https://sft.its.cern.ch/jira/browse/ROOT-9116?filter=-1) for more details.