### PR TITLE
Enchancement in TBufferXML

### DIFF
--- a/README/ReleaseNotes/v614/index.md
+++ b/README/ReleaseNotes/v614/index.md
@@ -40,6 +40,9 @@ The following people have contributed to this new version:
 ## Core Libraries
 
 ## I/O Libraries
+   - Implement reading of objects data from JSON
+   - Provide TBufferJSON::ToJSON() and TBufferJSON::FromJSON() methods
+   - Provide TBufferXML::ToXML() and TBufferXML::FromXML() methods
 
 ## TTree Libraries
 

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -86,58 +86,7 @@ persistent storage for object data - only for live applications.
 #define FULong64 "%llu"
 #endif
 
-// #if defined(__GNUC__)
-// #if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) < 40900
-// #define DUMMY_JSON_PARSER
-// #endif
-// #endif
-
-#ifdef DUMMY_JSON_PARSER
-
-// this is just to avoid tons of #ifdefs in the code
-// provide dummy declaration of json parser, which does not compiled with gcc 4.8
-
-namespace nlohmann {
-class json {
-public:
-   json() {}
-
-   bool is_array() const { return false; }
-   bool is_object() const { return false; }
-   bool is_string() const { return false; }
-   bool is_null() const { return true; }
-
-   std::string dump() const { return ""; }
-
-   unsigned count(const std::string &) const { return 0; }
-
-   operator std::string() { return std::string(); }
-
-   unsigned size() const { return 0; }
-   json &at(const std::string &) { return *this; }
-   json &at(int) { return *this; }
-
-   json &operator[](const std::string &) { return *this; }
-   json &operator[](int) { return *this; }
-
-   int find(const std::string &) { return 0; }
-   int end() { return 0; }
-
-   template <class T>
-   T get()
-   {
-      return T();
-   }
-
-   static json parse(std::string) { return json(); }
-};
-}
-
-#else
-
 #include "json.hpp"
-
-#endif
 
 ClassImp(TBufferJSON);
 

--- a/io/xml/inc/TBufferXML.h
+++ b/io/xml/inc/TBufferXML.h
@@ -56,7 +56,7 @@ public:
    static Bool_t FromXML(T *&obj, const char *xml, Bool_t GenericLayout = kFALSE, Bool_t UseNamespaces = kFALSE)
    {
       if (obj)
-        return kFALSE;
+         return kFALSE;
       obj = (T *)ConvertFromXMLChecked(xml, TBuffer::GetClass(typeid(T)), GenericLayout, UseNamespaces);
       return obj != nullptr;
    }

--- a/io/xml/inc/TBufferXML.h
+++ b/io/xml/inc/TBufferXML.h
@@ -317,7 +317,7 @@ protected:
    R__ALWAYS_INLINE void XmlReadArrayContent(T *arr, Int_t arrsize);
 
    template <typename T>
-   R__ALWAYS_INLINE Int_t XmlReadArray(T *&arr);
+   R__ALWAYS_INLINE Int_t XmlReadArray(T *&arr, bool is_static = false);
 
    XMLNodePointer_t XmlWriteObject(const void *obj, const TClass *objClass, Bool_t cacheReuse);
    void *XmlReadObject(void *obj, TClass **cl = 0);

--- a/io/xml/inc/TBufferXML.h
+++ b/io/xml/inc/TBufferXML.h
@@ -313,6 +313,12 @@ protected:
    void XmlReadBasic(ULong64_t &value);
    const char *XmlReadValue(const char *name);
 
+   template <typename T>
+   R__ALWAYS_INLINE void XmlReadArrayContent(T *arr, Int_t arrsize);
+
+   template <typename T>
+   R__ALWAYS_INLINE Int_t XmlReadArray(T *&arr);
+
    XMLNodePointer_t XmlWriteObject(const void *obj, const TClass *objClass, Bool_t cacheReuse);
    void *XmlReadObject(void *obj, TClass **cl = 0);
 

--- a/io/xml/inc/TBufferXML.h
+++ b/io/xml/inc/TBufferXML.h
@@ -319,6 +319,9 @@ protected:
    template <typename T>
    R__ALWAYS_INLINE Int_t XmlReadArray(T *&arr, bool is_static = false);
 
+   template <typename T>
+   R__ALWAYS_INLINE void XmlReadFastArray(T *arr, Int_t n);
+
    XMLNodePointer_t XmlWriteObject(const void *obj, const TClass *objClass, Bool_t cacheReuse);
    void *XmlReadObject(void *obj, TClass **cl = 0);
 

--- a/io/xml/inc/TBufferXML.h
+++ b/io/xml/inc/TBufferXML.h
@@ -323,10 +323,13 @@ protected:
    R__ALWAYS_INLINE void XmlReadFastArray(T *arr, Int_t n);
 
    template <typename T>
-   R__ALWAYS_INLINE void XmlWriteArrayContent(T *arr, Int_t arrsize);
+   R__ALWAYS_INLINE void XmlWriteArrayContent(const T *arr, Int_t arrsize);
 
    template <typename T>
-   R__ALWAYS_INLINE void XmlWriteArray(T *arr, Int_t arrsize);
+   R__ALWAYS_INLINE void XmlWriteArray(const T *arr, Int_t arrsize);
+
+   template <typename T>
+   R__ALWAYS_INLINE void XmlWriteFastArray(const T *arr, Int_t n);
 
    XMLNodePointer_t XmlWriteObject(const void *obj, const TClass *objClass, Bool_t cacheReuse);
    void *XmlReadObject(void *obj, TClass **cl = 0);

--- a/io/xml/inc/TBufferXML.h
+++ b/io/xml/inc/TBufferXML.h
@@ -42,9 +42,24 @@ public:
    static TString
    ConvertToXML(const void *obj, const TClass *cl, Bool_t GenericLayout = kFALSE, Bool_t UseNamespaces = kFALSE);
 
+   template <class T>
+   static TString ToXML(const T *obj, Bool_t GenericLayout = kFALSE, Bool_t UseNamespaces = kFALSE)
+   {
+      return ConvertToXML(obj, TBuffer::GetClass(typeid(T)), GenericLayout, UseNamespaces);
+   }
+
    static TObject *ConvertFromXML(const char *str, Bool_t GenericLayout = kFALSE, Bool_t UseNamespaces = kFALSE);
    static void *
    ConvertFromXMLAny(const char *str, TClass **cl = 0, Bool_t GenericLayout = kFALSE, Bool_t UseNamespaces = kFALSE);
+
+   template <class T>
+   static Bool_t FromXML(T *&obj, const char *xml, Bool_t GenericLayout = kFALSE, Bool_t UseNamespaces = kFALSE)
+   {
+      if (obj)
+        return kFALSE;
+      obj = (T *)ConvertFromXMLChecked(xml, TBuffer::GetClass(typeid(T)), GenericLayout, UseNamespaces);
+      return obj != nullptr;
+   }
 
    Int_t GetIOVersion() const { return fIOVersion; }
    void SetIOVersion(Int_t v) { fIOVersion = v; }
@@ -237,6 +252,9 @@ protected:
    virtual void WriteObjectClass(const void *actualObjStart, const TClass *actualClass, Bool_t cacheReuse);
 
    // end redefined protected virtual functions
+
+   static void *ConvertFromXMLChecked(const char *xml, const TClass *expectedClass, Bool_t GenericLayout = kFALSE,
+                                      Bool_t UseNamespaces = kFALSE);
 
    TXMLFile *XmlFile();
 

--- a/io/xml/inc/TBufferXML.h
+++ b/io/xml/inc/TBufferXML.h
@@ -322,6 +322,12 @@ protected:
    template <typename T>
    R__ALWAYS_INLINE void XmlReadFastArray(T *arr, Int_t n);
 
+   template <typename T>
+   R__ALWAYS_INLINE void XmlWriteArrayContent(T *arr, Int_t arrsize);
+
+   template <typename T>
+   R__ALWAYS_INLINE void XmlWriteArray(T *arr, Int_t arrsize);
+
    XMLNodePointer_t XmlWriteObject(const void *obj, const TClass *objClass, Bool_t cacheReuse);
    void *XmlReadObject(void *obj, TClass **cl = 0);
 

--- a/io/xml/src/TBufferXML.cxx
+++ b/io/xml/src/TBufferXML.cxx
@@ -2591,19 +2591,13 @@ void TBufferXML::StreamObject(void *obj, const TClass *cl, const TClass * /* onf
       XmlWriteObject(obj, cl, kTRUE);
 }
 
-// macro for right shift operator for basic type
-#define TBufferXML_operatorin(vname) \
-   {                                 \
-      BeforeIOoperation();           \
-      XmlReadBasic(vname);           \
-   }
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Reads Bool_t value from buffer
 
 void TBufferXML::ReadBool(Bool_t &b)
 {
-   TBufferXML_operatorin(b);
+   BeforeIOoperation();
+   XmlReadBasic(b);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2611,7 +2605,8 @@ void TBufferXML::ReadBool(Bool_t &b)
 
 void TBufferXML::ReadChar(Char_t &c)
 {
-   TBufferXML_operatorin(c);
+   BeforeIOoperation();
+   XmlReadBasic(c);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2619,7 +2614,8 @@ void TBufferXML::ReadChar(Char_t &c)
 
 void TBufferXML::ReadUChar(UChar_t &c)
 {
-   TBufferXML_operatorin(c);
+   BeforeIOoperation();
+   XmlReadBasic(c);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2627,7 +2623,8 @@ void TBufferXML::ReadUChar(UChar_t &c)
 
 void TBufferXML::ReadShort(Short_t &h)
 {
-   TBufferXML_operatorin(h);
+   BeforeIOoperation();
+   XmlReadBasic(h);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2635,7 +2632,8 @@ void TBufferXML::ReadShort(Short_t &h)
 
 void TBufferXML::ReadUShort(UShort_t &h)
 {
-   TBufferXML_operatorin(h);
+   BeforeIOoperation();
+   XmlReadBasic(h);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2643,7 +2641,8 @@ void TBufferXML::ReadUShort(UShort_t &h)
 
 void TBufferXML::ReadInt(Int_t &i)
 {
-   TBufferXML_operatorin(i);
+   BeforeIOoperation();
+   XmlReadBasic(i);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2651,7 +2650,8 @@ void TBufferXML::ReadInt(Int_t &i)
 
 void TBufferXML::ReadUInt(UInt_t &i)
 {
-   TBufferXML_operatorin(i);
+   BeforeIOoperation();
+   XmlReadBasic(i);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2659,7 +2659,8 @@ void TBufferXML::ReadUInt(UInt_t &i)
 
 void TBufferXML::ReadLong(Long_t &l)
 {
-   TBufferXML_operatorin(l);
+   BeforeIOoperation();
+   XmlReadBasic(l);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2667,7 +2668,8 @@ void TBufferXML::ReadLong(Long_t &l)
 
 void TBufferXML::ReadULong(ULong_t &l)
 {
-   TBufferXML_operatorin(l);
+   BeforeIOoperation();
+   XmlReadBasic(l);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2675,7 +2677,8 @@ void TBufferXML::ReadULong(ULong_t &l)
 
 void TBufferXML::ReadLong64(Long64_t &l)
 {
-   TBufferXML_operatorin(l);
+   BeforeIOoperation();
+   XmlReadBasic(l);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2683,7 +2686,8 @@ void TBufferXML::ReadLong64(Long64_t &l)
 
 void TBufferXML::ReadULong64(ULong64_t &l)
 {
-   TBufferXML_operatorin(l);
+   BeforeIOoperation();
+   XmlReadBasic(l);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2691,7 +2695,8 @@ void TBufferXML::ReadULong64(ULong64_t &l)
 
 void TBufferXML::ReadFloat(Float_t &f)
 {
-   TBufferXML_operatorin(f);
+   BeforeIOoperation();
+   XmlReadBasic(f);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2699,7 +2704,8 @@ void TBufferXML::ReadFloat(Float_t &f)
 
 void TBufferXML::ReadDouble(Double_t &d)
 {
-   TBufferXML_operatorin(d);
+   BeforeIOoperation();
+   XmlReadBasic(d);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2752,19 +2758,13 @@ void TBufferXML::ReadCharStar(char *&s)
    TBufferFile::ReadCharStar(s);
 }
 
-// macro for left shift operator for basic types
-#define TBufferXML_operatorout(vname) \
-   {                                  \
-      BeforeIOoperation();            \
-      XmlWriteBasic(vname);           \
-   }
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Writes Bool_t value to buffer
 
 void TBufferXML::WriteBool(Bool_t b)
 {
-   TBufferXML_operatorout(b);
+   BeforeIOoperation();
+   XmlWriteBasic(b);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2772,7 +2772,8 @@ void TBufferXML::WriteBool(Bool_t b)
 
 void TBufferXML::WriteChar(Char_t c)
 {
-   TBufferXML_operatorout(c);
+   BeforeIOoperation();
+   XmlWriteBasic(c);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2780,7 +2781,8 @@ void TBufferXML::WriteChar(Char_t c)
 
 void TBufferXML::WriteUChar(UChar_t c)
 {
-   TBufferXML_operatorout(c);
+   BeforeIOoperation();
+   XmlWriteBasic(c);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2788,7 +2790,8 @@ void TBufferXML::WriteUChar(UChar_t c)
 
 void TBufferXML::WriteShort(Short_t h)
 {
-   TBufferXML_operatorout(h);
+   BeforeIOoperation();
+   XmlWriteBasic(h);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2796,7 +2799,8 @@ void TBufferXML::WriteShort(Short_t h)
 
 void TBufferXML::WriteUShort(UShort_t h)
 {
-   TBufferXML_operatorout(h);
+   BeforeIOoperation();
+   XmlWriteBasic(h);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2804,7 +2808,8 @@ void TBufferXML::WriteUShort(UShort_t h)
 
 void TBufferXML::WriteInt(Int_t i)
 {
-   TBufferXML_operatorout(i);
+   BeforeIOoperation();
+   XmlWriteBasic(i);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2812,7 +2817,8 @@ void TBufferXML::WriteInt(Int_t i)
 
 void TBufferXML::WriteUInt(UInt_t i)
 {
-   TBufferXML_operatorout(i);
+   BeforeIOoperation();
+   XmlWriteBasic(i);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2820,7 +2826,8 @@ void TBufferXML::WriteUInt(UInt_t i)
 
 void TBufferXML::WriteLong(Long_t l)
 {
-   TBufferXML_operatorout(l);
+   BeforeIOoperation();
+   XmlWriteBasic(l);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2828,7 +2835,8 @@ void TBufferXML::WriteLong(Long_t l)
 
 void TBufferXML::WriteULong(ULong_t l)
 {
-   TBufferXML_operatorout(l);
+   BeforeIOoperation();
+   XmlWriteBasic(l);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2836,7 +2844,8 @@ void TBufferXML::WriteULong(ULong_t l)
 
 void TBufferXML::WriteLong64(Long64_t l)
 {
-   TBufferXML_operatorout(l);
+   BeforeIOoperation();
+   XmlWriteBasic(l);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2844,7 +2853,8 @@ void TBufferXML::WriteLong64(Long64_t l)
 
 void TBufferXML::WriteULong64(ULong64_t l)
 {
-   TBufferXML_operatorout(l);
+   BeforeIOoperation();
+   XmlWriteBasic(l);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2852,7 +2862,8 @@ void TBufferXML::WriteULong64(ULong64_t l)
 
 void TBufferXML::WriteFloat(Float_t f)
 {
-   TBufferXML_operatorout(f);
+   BeforeIOoperation();
+   XmlWriteBasic(f);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2860,7 +2871,8 @@ void TBufferXML::WriteFloat(Float_t f)
 
 void TBufferXML::WriteDouble(Double_t d)
 {
-   TBufferXML_operatorout(d);
+   BeforeIOoperation();
+   XmlWriteBasic(d);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/io/xml/src/TBufferXML.cxx
+++ b/io/xml/src/TBufferXML.cxx
@@ -835,7 +835,8 @@ XMLNodePointer_t TBufferXML::XmlWriteObject(const void *obj, const TClass *cl, B
 
    fXML->NewAttr(objnode, 0, xmlio::ObjClass, clname);
 
-   if (cacheReuse) RegisterPointer(obj, objnode);
+   if (cacheReuse)
+      RegisterPointer(obj, objnode);
 
    PushStack(objnode);
 
@@ -1653,22 +1654,22 @@ R__ALWAYS_INLINE void TBufferXML::XmlReadArrayContent(T *arr, Int_t arrsize)
 template <typename T>
 R__ALWAYS_INLINE Int_t TBufferXML::XmlReadArray(T *&arr, bool is_static)
 {
-    BeforeIOoperation();
-    if (!VerifyItemNode(xmlio::Array, is_static ? "ReadStaticArray" : "ReadArray"))
-       return 0;
-    Int_t n = fXML->GetIntAttr(StackNode(), xmlio::Size);
-    if (n <= 0)
-       return 0;
-    if (!arr) {
-       if (is_static)
-          return 0;
-       arr = new T[n];
-    }
-    PushStack(StackNode());
-    XmlReadArrayContent(arr, n);
-    PopStack();
-    ShiftStack(is_static ? "readstatarr" : "readarr");
-    return n;
+   BeforeIOoperation();
+   if (!VerifyItemNode(xmlio::Array, is_static ? "ReadStaticArray" : "ReadArray"))
+      return 0;
+   Int_t n = fXML->GetIntAttr(StackNode(), xmlio::Size);
+   if (n <= 0)
+      return 0;
+   if (!arr) {
+      if (is_static)
+         return 0;
+      arr = new T[n];
+   }
+   PushStack(StackNode());
+   XmlReadArrayContent(arr, n);
+   PopStack();
+   ShiftStack(is_static ? "readstatarr" : "readarr");
+   return n;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1991,7 +1992,6 @@ Int_t TBufferXML::ReadStaticArrayDouble32(Double_t *d, TStreamerElement * /*ele*
    return XmlReadArray(d, true);
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Template method to read content of array, which not include size of array
 /// Also treated situation, when instead of one single array chain
@@ -2242,7 +2242,6 @@ R__ALWAYS_INLINE void TBufferXML::XmlWriteArrayContent(const T *arr, Int_t arrsi
          XmlWriteBasic(arr[indx]);
    }
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array, including it size

--- a/io/xml/src/TBufferXML.cxx
+++ b/io/xml/src/TBufferXML.cxx
@@ -1607,6 +1607,7 @@ void TBufferXML::WriteObjectClass(const void *actualObjStart, const TClass *actu
          XmlReadBasic(vname[indx]);          \
    }
 
+
 // macro to read content of array with compression
 #define TXMLReadArrayContent(vname, arrsize)                 \
    {                                                         \
@@ -1626,23 +1627,45 @@ void TBufferXML::WriteObjectClass(const void *actualObjStart, const TClass *actu
       }                                                      \
    }
 
-// macro to read array, which include size attribute
-#define TBufferXML_ReadArray(tname, vname)                  \
-   {                                                        \
-      BeforeIOoperation();                                  \
-      if (!VerifyItemNode(xmlio::Array, "ReadArray"))       \
-         return 0;                                          \
-      Int_t n = fXML->GetIntAttr(StackNode(), xmlio::Size); \
-      if (n <= 0)                                           \
-         return 0;                                          \
-      if (!vname)                                           \
-         vname = new tname[n];                              \
-      PushStack(StackNode());                               \
-      TXMLReadArrayContent(vname, n);                       \
-      PopStack();                                           \
-      ShiftStack("readarr");                                \
-      return n;                                             \
+////////////////////////////////////////////////////////////////////////////////
+/// Template method to read array content
+
+template <typename T>
+R__ALWAYS_INLINE void TBufferXML::XmlReadArrayContent(T *arr, Int_t arrsize)
+{
+   Int_t indx = 0, cnt, curr;
+   while (indx < arrsize) {
+      cnt = 1;
+      if (fXML->HasAttr(StackNode(), xmlio::cnt))
+         cnt = fXML->GetIntAttr(StackNode(), xmlio::cnt);
+      XmlReadBasic(arr[indx]);
+      curr = indx++;
+      while (cnt-- > 1)
+         arr[indx++] = arr[curr];
    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Template method to read array with size attribute
+/// If necessary, array is created
+
+template <typename T>
+R__ALWAYS_INLINE Int_t TBufferXML::XmlReadArray(T *&arr)
+{
+    BeforeIOoperation();
+    if (!VerifyItemNode(xmlio::Array, "ReadArray"))
+       return 0;
+    Int_t n = fXML->GetIntAttr(StackNode(), xmlio::Size);
+    if (n <= 0)
+       return 0;
+    if (!arr)
+       arr = new T[n];
+    PushStack(StackNode());
+    XmlReadArrayContent(arr, n);
+    PopStack();
+    ShiftStack("readarr");
+    return n;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read a Float16_t from the buffer
@@ -1729,7 +1752,7 @@ void TBufferXML::WriteDouble32(Double_t *d, TStreamerElement * /*ele*/)
 
 Int_t TBufferXML::ReadArray(Bool_t *&b)
 {
-   TBufferXML_ReadArray(Bool_t, b);
+   return XmlReadArray(b);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1737,7 +1760,7 @@ Int_t TBufferXML::ReadArray(Bool_t *&b)
 
 Int_t TBufferXML::ReadArray(Char_t *&c)
 {
-   TBufferXML_ReadArray(Char_t, c);
+   return XmlReadArray(c);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1745,7 +1768,7 @@ Int_t TBufferXML::ReadArray(Char_t *&c)
 
 Int_t TBufferXML::ReadArray(UChar_t *&c)
 {
-   TBufferXML_ReadArray(UChar_t, c);
+   return XmlReadArray(c);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1753,7 +1776,7 @@ Int_t TBufferXML::ReadArray(UChar_t *&c)
 
 Int_t TBufferXML::ReadArray(Short_t *&h)
 {
-   TBufferXML_ReadArray(Short_t, h);
+   return XmlReadArray(h);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1761,7 +1784,7 @@ Int_t TBufferXML::ReadArray(Short_t *&h)
 
 Int_t TBufferXML::ReadArray(UShort_t *&h)
 {
-   TBufferXML_ReadArray(UShort_t, h);
+   return XmlReadArray(h);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1769,7 +1792,7 @@ Int_t TBufferXML::ReadArray(UShort_t *&h)
 
 Int_t TBufferXML::ReadArray(Int_t *&i)
 {
-   TBufferXML_ReadArray(Int_t, i);
+   return XmlReadArray(i);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1777,7 +1800,7 @@ Int_t TBufferXML::ReadArray(Int_t *&i)
 
 Int_t TBufferXML::ReadArray(UInt_t *&i)
 {
-   TBufferXML_ReadArray(UInt_t, i);
+   return XmlReadArray(i);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1785,7 +1808,7 @@ Int_t TBufferXML::ReadArray(UInt_t *&i)
 
 Int_t TBufferXML::ReadArray(Long_t *&l)
 {
-   TBufferXML_ReadArray(Long_t, l);
+   return XmlReadArray(l);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1793,7 +1816,7 @@ Int_t TBufferXML::ReadArray(Long_t *&l)
 
 Int_t TBufferXML::ReadArray(ULong_t *&l)
 {
-   TBufferXML_ReadArray(ULong_t, l);
+   return XmlReadArray(l);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1801,7 +1824,7 @@ Int_t TBufferXML::ReadArray(ULong_t *&l)
 
 Int_t TBufferXML::ReadArray(Long64_t *&l)
 {
-   TBufferXML_ReadArray(Long64_t, l);
+   return XmlReadArray(l);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1809,7 +1832,7 @@ Int_t TBufferXML::ReadArray(Long64_t *&l)
 
 Int_t TBufferXML::ReadArray(ULong64_t *&l)
 {
-   TBufferXML_ReadArray(ULong64_t, l);
+   return XmlReadArray(l);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1817,7 +1840,7 @@ Int_t TBufferXML::ReadArray(ULong64_t *&l)
 
 Int_t TBufferXML::ReadArray(Float_t *&f)
 {
-   TBufferXML_ReadArray(Float_t, f);
+   return XmlReadArray(f);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1825,7 +1848,7 @@ Int_t TBufferXML::ReadArray(Float_t *&f)
 
 Int_t TBufferXML::ReadArray(Double_t *&d)
 {
-   TBufferXML_ReadArray(Double_t, d);
+   return XmlReadArray(d);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1833,7 +1856,7 @@ Int_t TBufferXML::ReadArray(Double_t *&d)
 
 Int_t TBufferXML::ReadArrayFloat16(Float_t *&f, TStreamerElement * /*ele*/)
 {
-   TBufferXML_ReadArray(Float_t, f);
+   return XmlReadArray(f);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1841,7 +1864,7 @@ Int_t TBufferXML::ReadArrayFloat16(Float_t *&f, TStreamerElement * /*ele*/)
 
 Int_t TBufferXML::ReadArrayDouble32(Double_t *&d, TStreamerElement * /*ele*/)
 {
-   TBufferXML_ReadArray(Double_t, d);
+   return XmlReadArray(d);
 }
 
 // macro to read array from xml buffer


### PR DESCRIPTION
- replace all C++ macros with template parameters
- introduce ToXML/FromXML template methods to ease objects conversion
- clang-format TBufferXML code

Now TBufferXML and TBufferJSON has similar code structure.
As next step, one should try to derive TBufferXML from TBuffer.
If it works, one could provide common basic class for XML and JSON. 