### PR TITLE
Derive TBufferXML from TBuffer

### DIFF
--- a/io/io/inc/TBufferJSON.h
+++ b/io/io/inc/TBufferJSON.h
@@ -249,9 +249,9 @@ public:
 
    virtual void TagStreamerInfo(TVirtualStreamerInfo * /*info*/) {}
 
-   virtual Bool_t CheckObject(const TObject * /*obj*/);
+   virtual Bool_t CheckObject(const TObject *obj);
 
-   virtual Bool_t CheckObject(const void * /*ptr*/, const TClass * /*cl*/);
+   virtual Bool_t CheckObject(const void *ptr, const TClass *cl);
 
    // abstract virtual methods from TBuffer, which should be redefined
 

--- a/io/io/inc/TBufferJSON.h
+++ b/io/io/inc/TBufferJSON.h
@@ -61,7 +61,7 @@ public:
 
    // suppress class writing/reading
 
-   virtual TClass *ReadClass(const TClass *cl = 0, UInt_t *objTag = 0);
+   virtual TClass *ReadClass(const TClass *cl = nullptr, UInt_t *objTag = nullptr);
    virtual void WriteClass(const TClass *cl);
 
    // redefined virtual functions of TBuffer
@@ -70,8 +70,8 @@ public:
    virtual Int_t CheckByteCount(UInt_t startpos, UInt_t bcnt, const char *classname); // SL
    virtual void SetByteCount(UInt_t cntpos, Bool_t packInVersion = kFALSE);           // SL
 
-   virtual void SkipVersion(const TClass *cl = 0);
-   virtual Version_t ReadVersion(UInt_t *start = 0, UInt_t *bcnt = 0, const TClass *cl = 0); // SL
+   virtual void SkipVersion(const TClass *cl = nullptr);
+   virtual Version_t ReadVersion(UInt_t *start = nullptr, UInt_t *bcnt = nullptr, const TClass *cl = nullptr); // SL
    virtual Version_t ReadVersionNoCheckSum(UInt_t *, UInt_t *) { return 0; }
    virtual UInt_t WriteVersion(const TClass *cl, Bool_t useBcnt = kFALSE); // SL
 
@@ -85,16 +85,16 @@ public:
 
    virtual void ClassBegin(const TClass *, Version_t = -1);
    virtual void ClassEnd(const TClass *);
-   virtual void ClassMember(const char *name, const char *typeName = 0, Int_t arrsize1 = -1, Int_t arrsize2 = -1);
+   virtual void ClassMember(const char *name, const char *typeName = nullptr, Int_t arrsize1 = -1, Int_t arrsize2 = -1);
 
    virtual void WriteObject(const TObject *obj, Bool_t cacheReuse = kTRUE);
 
    using TBuffer::WriteObject;
 
-   virtual void ReadFloat16(Float_t *f, TStreamerElement *ele = 0);
-   virtual void WriteFloat16(Float_t *f, TStreamerElement *ele = 0);
-   virtual void ReadDouble32(Double_t *d, TStreamerElement *ele = 0);
-   virtual void WriteDouble32(Double_t *d, TStreamerElement *ele = 0);
+   virtual void ReadFloat16(Float_t *f, TStreamerElement *ele = nullptr);
+   virtual void WriteFloat16(Float_t *f, TStreamerElement *ele = nullptr);
+   virtual void ReadDouble32(Double_t *d, TStreamerElement *ele = nullptr);
+   virtual void WriteDouble32(Double_t *d, TStreamerElement *ele = nullptr);
    virtual void ReadWithFactor(Float_t *ptr, Double_t factor, Double_t minvalue);
    virtual void ReadWithNbits(Float_t *ptr, Int_t nbits);
    virtual void ReadWithFactor(Double_t *ptr, Double_t factor, Double_t minvalue);
@@ -113,8 +113,8 @@ public:
    virtual Int_t ReadArray(ULong64_t *&l);
    virtual Int_t ReadArray(Float_t *&f);
    virtual Int_t ReadArray(Double_t *&d);
-   virtual Int_t ReadArrayFloat16(Float_t *&f, TStreamerElement *ele = 0);
-   virtual Int_t ReadArrayDouble32(Double_t *&d, TStreamerElement *ele = 0);
+   virtual Int_t ReadArrayFloat16(Float_t *&f, TStreamerElement *ele = nullptr);
+   virtual Int_t ReadArrayDouble32(Double_t *&d, TStreamerElement *ele = nullptr);
 
    virtual Int_t ReadStaticArray(Bool_t *b);
    virtual Int_t ReadStaticArray(Char_t *c);
@@ -129,8 +129,8 @@ public:
    virtual Int_t ReadStaticArray(ULong64_t *l);
    virtual Int_t ReadStaticArray(Float_t *f);
    virtual Int_t ReadStaticArray(Double_t *d);
-   virtual Int_t ReadStaticArrayFloat16(Float_t *f, TStreamerElement *ele = 0);
-   virtual Int_t ReadStaticArrayDouble32(Double_t *d, TStreamerElement *ele = 0);
+   virtual Int_t ReadStaticArrayFloat16(Float_t *f, TStreamerElement *ele = nullptr);
+   virtual Int_t ReadStaticArrayDouble32(Double_t *d, TStreamerElement *ele = nullptr);
 
    virtual void ReadFastArray(Bool_t *b, Int_t n);
    virtual void ReadFastArray(Char_t *c, Int_t n);
@@ -146,8 +146,8 @@ public:
    virtual void ReadFastArray(ULong64_t *l, Int_t n);
    virtual void ReadFastArray(Float_t *f, Int_t n);
    virtual void ReadFastArray(Double_t *d, Int_t n);
-   virtual void ReadFastArrayFloat16(Float_t *f, Int_t n, TStreamerElement *ele = 0);
-   virtual void ReadFastArrayDouble32(Double_t *d, Int_t n, TStreamerElement *ele = 0);
+   virtual void ReadFastArrayFloat16(Float_t *f, Int_t n, TStreamerElement *ele = nullptr);
+   virtual void ReadFastArrayDouble32(Double_t *d, Int_t n, TStreamerElement *ele = nullptr);
    virtual void ReadFastArrayWithFactor(Float_t *ptr, Int_t n, Double_t factor, Double_t minvalue);
    virtual void ReadFastArrayWithNbits(Float_t *ptr, Int_t n, Int_t nbits);
    virtual void ReadFastArrayWithFactor(Double_t *ptr, Int_t n, Double_t factor, Double_t minvalue);
@@ -166,12 +166,12 @@ public:
    virtual void WriteArray(const ULong64_t *l, Int_t n);
    virtual void WriteArray(const Float_t *f, Int_t n);
    virtual void WriteArray(const Double_t *d, Int_t n);
-   virtual void WriteArrayFloat16(const Float_t *f, Int_t n, TStreamerElement *ele = 0);
-   virtual void WriteArrayDouble32(const Double_t *d, Int_t n, TStreamerElement *ele = 0);
-   virtual void
-   ReadFastArray(void *start, const TClass *cl, Int_t n = 1, TMemberStreamer *s = 0, const TClass *onFileClass = 0);
+   virtual void WriteArrayFloat16(const Float_t *f, Int_t n, TStreamerElement *ele = nullptr);
+   virtual void WriteArrayDouble32(const Double_t *d, Int_t n, TStreamerElement *ele = nullptr);
+   virtual void ReadFastArray(void *start, const TClass *cl, Int_t n = 1, TMemberStreamer *s = nullptr,
+                              const TClass *onFileClass = nullptr);
    virtual void ReadFastArray(void **startp, const TClass *cl, Int_t n = 1, Bool_t isPreAlloc = kFALSE,
-                              TMemberStreamer *s = 0, const TClass *onFileClass = 0);
+                              TMemberStreamer *s = nullptr, const TClass *onFileClass = nullptr);
 
    virtual void WriteFastArray(const Bool_t *b, Int_t n);
    virtual void WriteFastArray(const Char_t *c, Int_t n);
@@ -187,15 +187,15 @@ public:
    virtual void WriteFastArray(const ULong64_t *l, Int_t n);
    virtual void WriteFastArray(const Float_t *f, Int_t n);
    virtual void WriteFastArray(const Double_t *d, Int_t n);
-   virtual void WriteFastArrayFloat16(const Float_t *d, Int_t n, TStreamerElement *ele = 0);
-   virtual void WriteFastArrayDouble32(const Double_t *d, Int_t n, TStreamerElement *ele = 0);
-   virtual void WriteFastArray(void *start, const TClass *cl, Int_t n = 1, TMemberStreamer *s = 0);
-   virtual Int_t
-   WriteFastArray(void **startp, const TClass *cl, Int_t n = 1, Bool_t isPreAlloc = kFALSE, TMemberStreamer *s = 0);
+   virtual void WriteFastArrayFloat16(const Float_t *d, Int_t n, TStreamerElement *ele = nullptr);
+   virtual void WriteFastArrayDouble32(const Double_t *d, Int_t n, TStreamerElement *ele = nullptr);
+   virtual void WriteFastArray(void *start, const TClass *cl, Int_t n = 1, TMemberStreamer *s = nullptr);
+   virtual Int_t WriteFastArray(void **startp, const TClass *cl, Int_t n = 1, Bool_t isPreAlloc = kFALSE,
+                                TMemberStreamer *s = nullptr);
 
-   virtual void StreamObject(void *obj, const std::type_info &typeinfo, const TClass *onFileClass = 0);
-   virtual void StreamObject(void *obj, const char *className, const TClass *onFileClass = 0);
-   virtual void StreamObject(void *obj, const TClass *cl, const TClass *onFileClass = 0);
+   virtual void StreamObject(void *obj, const std::type_info &typeinfo, const TClass *onFileClass = nullptr);
+   virtual void StreamObject(void *obj, const char *className, const TClass *onFileClass = nullptr);
+   virtual void StreamObject(void *obj, const TClass *cl, const TClass *onFileClass = nullptr);
    virtual void StreamObject(TObject *obj);
 
    virtual void ReadBool(Bool_t &b);
@@ -361,14 +361,14 @@ public:
    }
 
    // Utilities for TClass
-   virtual Int_t ReadClassEmulated(const TClass * /*cl*/, void * /*object*/, const TClass * /*onfile_class*/ = 0)
+   virtual Int_t ReadClassEmulated(const TClass * /*cl*/, void * /*object*/, const TClass * /*onfile_class*/ = nullptr)
    {
       Error("ReadClassEmulated", "useless");
       return 0;
    }
-   virtual Int_t ReadClassBuffer(const TClass * /*cl*/, void * /*pointer*/, const TClass * /*onfile_class*/ = 0);
+   virtual Int_t ReadClassBuffer(const TClass * /*cl*/, void * /*pointer*/, const TClass * /*onfile_class*/ = nullptr);
    virtual Int_t ReadClassBuffer(const TClass * /*cl*/, void * /*pointer*/, Int_t /*version*/, UInt_t /*start*/,
-                                 UInt_t /*count*/, const TClass * /*onfile_class*/ = 0);
+                                 UInt_t /*count*/, const TClass * /*onfile_class*/ = nullptr);
 
    // end of redefined virtual functions
 

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -932,25 +932,33 @@ TString TBufferJSON::JsonWriteMember(const void *ptr, TDataMember *member, TClas
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Check that object already stored in the buffer
+/// Check if the specified object of the specified class is already in
+/// the buffer. Returns kTRUE if object already in the buffer,
+/// kFALSE otherwise (also if obj is 0 ).
 
 Bool_t TBufferJSON::CheckObject(const TObject *obj)
 {
-   if (!obj)
-      return kTRUE;
-
-   return fJsonrMap.find(obj) != fJsonrMap.end();
+   return CheckObject(obj, TObject::Class());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Check that object already stored in the buffer
+/// Check if the specified object of the specified class is already in
+/// the buffer. Returns kTRUE if object already in the buffer,
+/// kFALSE otherwise (also if obj is 0 ).
 
-Bool_t TBufferJSON::CheckObject(const void *ptr, const TClass * /*cl*/)
+Bool_t TBufferJSON::CheckObject(const void *obj, const TClass *ptrClass)
 {
-   if (!ptr)
-      return kTRUE;
+   if (!obj || !ptrClass || (fJsonrMap.size() == 0))
+      return kFALSE;
 
-   return fJsonrMap.find(ptr) != fJsonrMap.end();
+   TClass *clActual = ptrClass->GetActualClass(obj);
+
+   const char *temp = (const char *)obj;
+
+   if (clActual && (ptrClass != clActual))
+      temp -= clActual->GetBaseClassOffset(ptrClass);
+
+   return fJsonrMap.find(temp) != fJsonrMap.end();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -303,7 +303,7 @@ public:
 
    Bool_t IsStreamerInfo() const { return fIsStreamerInfo; }
 
-   Bool_t IsStreamerElement() const { return !fIsStreamerInfo && (fElem != nullptr); }
+   Bool_t IsStreamerElement() const { return !fIsStreamerInfo && fElem; }
 
    void PushValue(TString &v)
    {
@@ -398,7 +398,7 @@ TBufferJSON::TBufferJSON(TBuffer::EMode mode)
    // in this case locale will be changed and restored at the end of object conversion
 
    char *loc = setlocale(LC_NUMERIC, 0);
-   if ((loc != 0) && (strcmp(loc, "C") != 0)) {
+   if (loc && (strcmp(loc, "C") != 0)) {
       fNumericLocale = loc;
       setlocale(LC_NUMERIC, "C");
    }
@@ -599,7 +599,7 @@ Int_t TBufferJSON::ExportToFile(const char *filename, const TObject *obj, const 
          buflen = 512;
 
       char *buffer = (char *)malloc(buflen);
-      if (buffer == 0)
+      if (!buffer)
          return 0; // failure
 
       char *bufcur = buffer;
@@ -679,7 +679,7 @@ Int_t TBufferJSON::ExportToFile(const char *filename, const void *obj, const TCl
          buflen = 512;
 
       char *buffer = (char *)malloc(buflen);
-      if (buffer == 0)
+      if (!buffer)
          return 0; // failure
 
       char *bufcur = buffer;
@@ -1462,9 +1462,9 @@ void TBufferJSON::JsonReadCollection(TCollection *col, const TClass *)
       if (clones)
          continue;
 
-      if (!subobj || !readClass)
+      if (!subobj || !readClass) {
          subobj = nullptr;
-      else if (readClass->GetBaseClassOffset(TObject::Class()) != 0) {
+      } else if (readClass->GetBaseClassOffset(TObject::Class()) != 0) {
          Error("JsonReadCollection", "Try to add object %s not derived from TObject", readClass->GetName());
          subobj = nullptr;
       }
@@ -1479,9 +1479,9 @@ void TBufferJSON::JsonReadCollection(TCollection *col, const TClass *)
 
          PopStack();
 
-         if (!subobj2 || !readClass)
+         if (!subobj2 || !readClass) {
             subobj2 = nullptr;
-         else if (readClass->GetBaseClassOffset(TObject::Class()) != 0) {
+         } else if (readClass->GetBaseClassOffset(TObject::Class()) != 0) {
             Error("JsonReadCollection", "Try to add object %s not derived from TObject", readClass->GetName());
             subobj2 = nullptr;
          }

--- a/io/xml/inc/TBufferXML.h
+++ b/io/xml/inc/TBufferXML.h
@@ -312,12 +312,8 @@ public:
       return 0;
    }
 
-   virtual UShort_t GetPidOffset() const
-   {
-      Error("GetPidOffset", "useless");
-      return 0;
-   }
-   virtual void SetPidOffset(UShort_t /*offset*/) { Error("SetPidOffset", "useless"); }
+   virtual UShort_t GetPidOffset() const { return fPidOffset; }
+   virtual void SetPidOffset(UShort_t offset) { fPidOffset = offset; }
    virtual Int_t GetBufferDisplacement() const
    {
       Error("GetBufferDisplacement", "useless");
@@ -331,21 +327,9 @@ public:
       Error("GetLastProcessID", "useless");
       return 0;
    }
-   virtual UInt_t GetTRefExecId()
-   {
-      Error("GetTRefExecId", "useless");
-      return 0;
-   }
-   virtual TProcessID *ReadProcessID(UShort_t /*pidf*/)
-   {
-      Error("ReadProcessID", "useless");
-      return 0;
-   }
-   virtual UShort_t WriteProcessID(TProcessID * /*pid*/)
-   {
-      // Error("WriteProcessID", "useless");
-      return 0;
-   }
+   virtual UInt_t GetTRefExecId();
+   virtual TProcessID *ReadProcessID(UShort_t pidf);
+   virtual UShort_t WriteProcessID(TProcessID *pid);
 
    // Utilities for TStreamerInfo
    virtual void ForceWriteInfo(TVirtualStreamerInfo *info, Bool_t force);
@@ -507,6 +491,8 @@ protected:
    TClass *fExpectedBaseClass; ///<!   Pointer to class, which should be stored as parent of current
    Int_t fCompressLevel;       ///<!   Compression level and algorithm
    Int_t fIOVersion;           ///<!   Indicates format of ROOT xml file
+
+   UShort_t fPidOffset; ///<! PID offset
 
    static std::string
       fgFloatFmt; ///<!   Printf argument for floats and doubles, either "%f" or "%e" or "%10f" and so on

--- a/io/xml/inc/TBufferXML.h
+++ b/io/xml/inc/TBufferXML.h
@@ -12,11 +12,13 @@
 #ifndef ROOT_TBufferXML
 #define ROOT_TBufferXML
 
-#include "TBufferFile.h"
+#include "TBuffer.h"
 #include "TXMLSetup.h"
 #include "TXMLEngine.h"
 #include "TString.h"
 #include "TObjArray.h"
+#include "TArrayC.h"
+#include "TClonesArray.h"
 
 #include <string>
 
@@ -29,7 +31,7 @@ class TMemberStreamer;
 class TXMLFile;
 class TXMLStackObj;
 
-class TBufferXML : public TBufferFile, public TXMLSetup {
+class TBufferXML : public TBuffer, public TXMLSetup {
 
    friend class TKeyXML;
 
@@ -77,7 +79,8 @@ public:
 
    virtual void SkipVersion(const TClass *cl = nullptr);
    virtual Version_t ReadVersion(UInt_t *start = nullptr, UInt_t *bcnt = nullptr, const TClass *cl = nullptr); // SL
-   virtual UInt_t WriteVersion(const TClass *cl, Bool_t useBcnt = kFALSE);                                     // SL
+   virtual Version_t ReadVersionNoCheckSum(UInt_t *, UInt_t *);
+   virtual UInt_t WriteVersion(const TClass *cl, Bool_t useBcnt = kFALSE); // SL
 
    virtual void *ReadObjectAny(const TClass *clCast);
    virtual void SkipObjectAny();
@@ -144,6 +147,7 @@ public:
    virtual void ReadFastArray(ULong64_t *l, Int_t n);
    virtual void ReadFastArray(Float_t *f, Int_t n);
    virtual void ReadFastArray(Double_t *d, Int_t n);
+   virtual void ReadFastArrayString(Char_t *c, Int_t n);
    virtual void ReadFastArrayFloat16(Float_t *f, Int_t n, TStreamerElement *ele = nullptr);
    virtual void ReadFastArrayDouble32(Double_t *d, Int_t n, TStreamerElement *ele = nullptr);
    virtual void ReadFastArrayWithFactor(Float_t *ptr, Int_t n, Double_t factor, Double_t minvalue);
@@ -184,6 +188,7 @@ public:
    virtual void WriteFastArray(const ULong64_t *l, Int_t n);
    virtual void WriteFastArray(const Float_t *f, Int_t n);
    virtual void WriteFastArray(const Double_t *d, Int_t n);
+   virtual void WriteFastArrayString(const Char_t *c, Int_t n);
    virtual void WriteFastArrayFloat16(const Float_t *d, Int_t n, TStreamerElement *ele = nullptr);
    virtual void WriteFastArrayDouble32(const Double_t *d, Int_t n, TStreamerElement *ele = nullptr);
    virtual void WriteFastArray(void *start, const TClass *cl, Int_t n = 1, TMemberStreamer *s = nullptr);
@@ -240,6 +245,135 @@ public:
    ApplySequence(const TStreamerInfoActions::TActionSequence &sequence, void *start_collection, void *end_collection);
 
    // end of redefined virtual functions
+
+   // abstract TBuffer methods, probably dedicated for TBufferText
+
+   virtual Bool_t CheckObject(const TObject *obj);
+
+   virtual Bool_t CheckObject(const void *ptr, const TClass *cl);
+
+   virtual Int_t ReadBuf(void * /*buf*/, Int_t /*max*/)
+   {
+      Error("ReadBuf", "useless");
+      return 0;
+   }
+
+   virtual void WriteBuf(const void * /*buf*/, Int_t /*max*/) { Error("WriteBuf", "useless"); }
+
+   virtual char *ReadString(char * /*s*/, Int_t /*max*/)
+   {
+      Error("ReadString", "useless");
+      return 0;
+   }
+
+   virtual void WriteString(const char * /*s*/) { Error("WriteString", "useless"); }
+
+   virtual Int_t GetVersionOwner() const
+   {
+      Error("GetVersionOwner", "useless");
+      return 0;
+   }
+   virtual Int_t GetMapCount() const
+   {
+      Error("GetMapCount", "useless");
+      return 0;
+   }
+   virtual void GetMappedObject(UInt_t /*tag*/, void *& /*ptr*/, TClass *& /*ClassPtr*/) const
+   {
+      Error("GetMappedObject", "useless");
+   }
+   virtual void MapObject(const TObject * /*obj*/, UInt_t /*offset*/ = 1) { Error("MapObject", "useless"); }
+   virtual void MapObject(const void * /*obj*/, const TClass * /*cl*/, UInt_t /*offset*/ = 1)
+   {
+      Error("MapObject", "useless");
+   }
+   virtual void Reset() { Error("Reset", "useless"); }
+   virtual void InitMap() { Error("InitMap", "useless"); }
+   virtual void ResetMap() { Error("ResetMap", "useless"); }
+   virtual void SetReadParam(Int_t /*mapsize*/) { Error("SetReadParam", "useless"); }
+   virtual void SetWriteParam(Int_t /*mapsize*/) { Error("SetWriteParam", "useless"); }
+
+   virtual Version_t ReadVersionForMemberWise(const TClass * /*cl*/ = nullptr)
+   {
+      Error("ReadVersionForMemberWise", "useless");
+      return 0;
+   }
+   virtual UInt_t WriteVersionMemberWise(const TClass * /*cl*/, Bool_t /*useBcnt*/ = kFALSE)
+   {
+      Error("WriteVersionMemberWise", "useless");
+      return 0;
+   }
+
+   virtual TVirtualStreamerInfo *GetInfo();
+
+   virtual TObject *ReadObject(const TClass * /*cl*/)
+   {
+      Error("ReadObject", "useless");
+      return 0;
+   }
+
+   virtual UShort_t GetPidOffset() const
+   {
+      Error("GetPidOffset", "useless");
+      return 0;
+   }
+   virtual void SetPidOffset(UShort_t /*offset*/) { Error("SetPidOffset", "useless"); }
+   virtual Int_t GetBufferDisplacement() const
+   {
+      Error("GetBufferDisplacement", "useless");
+      return 0;
+   }
+   virtual void SetBufferDisplacement() { Error("SetBufferDisplacement", "useless"); }
+   virtual void SetBufferDisplacement(Int_t /*skipped*/) { Error("SetBufferDisplacement", "useless"); }
+
+   virtual TProcessID *GetLastProcessID(TRefTable * /*reftable*/) const
+   {
+      Error("GetLastProcessID", "useless");
+      return 0;
+   }
+   virtual UInt_t GetTRefExecId()
+   {
+      Error("GetTRefExecId", "useless");
+      return 0;
+   }
+   virtual TProcessID *ReadProcessID(UShort_t /*pidf*/)
+   {
+      Error("ReadProcessID", "useless");
+      return 0;
+   }
+   virtual UShort_t WriteProcessID(TProcessID * /*pid*/)
+   {
+      // Error("WriteProcessID", "useless");
+      return 0;
+   }
+
+   // Utilities for TStreamerInfo
+   virtual void ForceWriteInfo(TVirtualStreamerInfo *info, Bool_t force);
+   virtual void ForceWriteInfoClones(TClonesArray *a);
+   virtual Int_t ReadClones(TClonesArray *a, Int_t nobjects, Version_t objvers);
+   virtual Int_t WriteClones(TClonesArray *a, Int_t nobjects);
+
+   // Utilities for TClass
+   virtual Int_t ReadClassEmulated(const TClass * /*cl*/, void * /*object*/, const TClass * /*onfile_class*/ = nullptr)
+   {
+      Error("ReadClassEmulated", "useless");
+      return 0;
+   }
+
+   virtual Int_t ReadClassBuffer(const TClass * /*cl*/, void * /*pointer*/, const TClass * /*onfile_class*/ = nullptr);
+   virtual Int_t ReadClassBuffer(const TClass * /*cl*/, void * /*pointer*/, Int_t /*version*/, UInt_t /*start*/,
+                                 UInt_t /*count*/, const TClass * /*onfile_class*/ = nullptr);
+
+   virtual Int_t WriteClassBuffer(const TClass *cl, void *pointer);
+
+   virtual void TagStreamerInfo(TVirtualStreamerInfo * /*info*/);
+
+   virtual void WriteObject(const TObject *obj, Bool_t cacheReuse = kTRUE);
+   virtual Int_t WriteObjectAny(const void *obj, const TClass *ptrClass, Bool_t cacheReuse = kTRUE);
+
+   using TBuffer::WriteObject;
+
+   // end of abstract TBuffer methods, probably dedicated for TBufferText
 
    static void SetFloatFormat(const char *fmt = "%e");
    static const char *GetFloatFormat();

--- a/io/xml/inc/TBufferXML.h
+++ b/io/xml/inc/TBufferXML.h
@@ -49,8 +49,8 @@ public:
    }
 
    static TObject *ConvertFromXML(const char *str, Bool_t GenericLayout = kFALSE, Bool_t UseNamespaces = kFALSE);
-   static void *
-   ConvertFromXMLAny(const char *str, TClass **cl = 0, Bool_t GenericLayout = kFALSE, Bool_t UseNamespaces = kFALSE);
+   static void *ConvertFromXMLAny(const char *str, TClass **cl = nullptr, Bool_t GenericLayout = kFALSE,
+                                  Bool_t UseNamespaces = kFALSE);
 
    template <class T>
    static Bool_t FromXML(T *&obj, const char *xml, Bool_t GenericLayout = kFALSE, Bool_t UseNamespaces = kFALSE)
@@ -66,7 +66,7 @@ public:
 
    // suppress class writing/reading
 
-   virtual TClass *ReadClass(const TClass *cl = 0, UInt_t *objTag = 0);
+   virtual TClass *ReadClass(const TClass *cl = nullptr, UInt_t *objTag = nullptr);
    virtual void WriteClass(const TClass *cl);
 
    // redefined virtual functions of TBuffer
@@ -75,9 +75,9 @@ public:
    virtual Int_t CheckByteCount(UInt_t startpos, UInt_t bcnt, const char *classname); // SL
    virtual void SetByteCount(UInt_t cntpos, Bool_t packInVersion = kFALSE);           // SL
 
-   virtual void SkipVersion(const TClass *cl = 0);
-   virtual Version_t ReadVersion(UInt_t *start = 0, UInt_t *bcnt = 0, const TClass *cl = 0); // SL
-   virtual UInt_t WriteVersion(const TClass *cl, Bool_t useBcnt = kFALSE);                   // SL
+   virtual void SkipVersion(const TClass *cl = nullptr);
+   virtual Version_t ReadVersion(UInt_t *start = nullptr, UInt_t *bcnt = nullptr, const TClass *cl = nullptr); // SL
+   virtual UInt_t WriteVersion(const TClass *cl, Bool_t useBcnt = kFALSE);                                     // SL
 
    virtual void *ReadObjectAny(const TClass *clCast);
    virtual void SkipObjectAny();
@@ -88,12 +88,12 @@ public:
 
    virtual void ClassBegin(const TClass *, Version_t = -1);
    virtual void ClassEnd(const TClass *);
-   virtual void ClassMember(const char *name, const char *typeName = 0, Int_t arrsize1 = -1, Int_t arrsize2 = -1);
+   virtual void ClassMember(const char *name, const char *typeName = nullptr, Int_t arrsize1 = -1, Int_t arrsize2 = -1);
 
-   virtual void ReadFloat16(Float_t *f, TStreamerElement *ele = 0);
-   virtual void WriteFloat16(Float_t *f, TStreamerElement *ele = 0);
-   virtual void ReadDouble32(Double_t *d, TStreamerElement *ele = 0);
-   virtual void WriteDouble32(Double_t *d, TStreamerElement *ele = 0);
+   virtual void ReadFloat16(Float_t *f, TStreamerElement *ele = nullptr);
+   virtual void WriteFloat16(Float_t *f, TStreamerElement *ele = nullptr);
+   virtual void ReadDouble32(Double_t *d, TStreamerElement *ele = nullptr);
+   virtual void WriteDouble32(Double_t *d, TStreamerElement *ele = nullptr);
    virtual void ReadWithFactor(Float_t *ptr, Double_t factor, Double_t minvalue);
    virtual void ReadWithNbits(Float_t *ptr, Int_t nbits);
    virtual void ReadWithFactor(Double_t *ptr, Double_t factor, Double_t minvalue);
@@ -112,8 +112,8 @@ public:
    virtual Int_t ReadArray(ULong64_t *&l);
    virtual Int_t ReadArray(Float_t *&f);
    virtual Int_t ReadArray(Double_t *&d);
-   virtual Int_t ReadArrayFloat16(Float_t *&f, TStreamerElement *ele = 0);
-   virtual Int_t ReadArrayDouble32(Double_t *&d, TStreamerElement *ele = 0);
+   virtual Int_t ReadArrayFloat16(Float_t *&f, TStreamerElement *ele = nullptr);
+   virtual Int_t ReadArrayDouble32(Double_t *&d, TStreamerElement *ele = nullptr);
 
    virtual Int_t ReadStaticArray(Bool_t *b);
    virtual Int_t ReadStaticArray(Char_t *c);
@@ -128,8 +128,8 @@ public:
    virtual Int_t ReadStaticArray(ULong64_t *l);
    virtual Int_t ReadStaticArray(Float_t *f);
    virtual Int_t ReadStaticArray(Double_t *d);
-   virtual Int_t ReadStaticArrayFloat16(Float_t *f, TStreamerElement *ele = 0);
-   virtual Int_t ReadStaticArrayDouble32(Double_t *d, TStreamerElement *ele = 0);
+   virtual Int_t ReadStaticArrayFloat16(Float_t *f, TStreamerElement *ele = nullptr);
+   virtual Int_t ReadStaticArrayDouble32(Double_t *d, TStreamerElement *ele = nullptr);
 
    virtual void ReadFastArray(Bool_t *b, Int_t n);
    virtual void ReadFastArray(Char_t *c, Int_t n);
@@ -144,8 +144,8 @@ public:
    virtual void ReadFastArray(ULong64_t *l, Int_t n);
    virtual void ReadFastArray(Float_t *f, Int_t n);
    virtual void ReadFastArray(Double_t *d, Int_t n);
-   virtual void ReadFastArrayFloat16(Float_t *f, Int_t n, TStreamerElement *ele = 0);
-   virtual void ReadFastArrayDouble32(Double_t *d, Int_t n, TStreamerElement *ele = 0);
+   virtual void ReadFastArrayFloat16(Float_t *f, Int_t n, TStreamerElement *ele = nullptr);
+   virtual void ReadFastArrayDouble32(Double_t *d, Int_t n, TStreamerElement *ele = nullptr);
    virtual void ReadFastArrayWithFactor(Float_t *ptr, Int_t n, Double_t factor, Double_t minvalue);
    virtual void ReadFastArrayWithNbits(Float_t *ptr, Int_t n, Int_t nbits);
    virtual void ReadFastArrayWithFactor(Double_t *ptr, Int_t n, Double_t factor, Double_t minvalue);
@@ -164,12 +164,12 @@ public:
    virtual void WriteArray(const ULong64_t *l, Int_t n);
    virtual void WriteArray(const Float_t *f, Int_t n);
    virtual void WriteArray(const Double_t *d, Int_t n);
-   virtual void WriteArrayFloat16(const Float_t *f, Int_t n, TStreamerElement *ele = 0);
-   virtual void WriteArrayDouble32(const Double_t *d, Int_t n, TStreamerElement *ele = 0);
-   virtual void
-   ReadFastArray(void *start, const TClass *cl, Int_t n = 1, TMemberStreamer *s = 0, const TClass *onFileClass = 0);
+   virtual void WriteArrayFloat16(const Float_t *f, Int_t n, TStreamerElement *ele = nullptr);
+   virtual void WriteArrayDouble32(const Double_t *d, Int_t n, TStreamerElement *ele = nullptr);
+   virtual void ReadFastArray(void *start, const TClass *cl, Int_t n = 1, TMemberStreamer *s = nullptr,
+                              const TClass *onFileClass = nullptr);
    virtual void ReadFastArray(void **startp, const TClass *cl, Int_t n = 1, Bool_t isPreAlloc = kFALSE,
-                              TMemberStreamer *s = 0, const TClass *onFileClass = 0);
+                              TMemberStreamer *s = nullptr, const TClass *onFileClass = nullptr);
 
    virtual void WriteFastArray(const Bool_t *b, Int_t n);
    virtual void WriteFastArray(const Char_t *c, Int_t n);
@@ -184,15 +184,15 @@ public:
    virtual void WriteFastArray(const ULong64_t *l, Int_t n);
    virtual void WriteFastArray(const Float_t *f, Int_t n);
    virtual void WriteFastArray(const Double_t *d, Int_t n);
-   virtual void WriteFastArrayFloat16(const Float_t *d, Int_t n, TStreamerElement *ele = 0);
-   virtual void WriteFastArrayDouble32(const Double_t *d, Int_t n, TStreamerElement *ele = 0);
-   virtual void WriteFastArray(void *start, const TClass *cl, Int_t n = 1, TMemberStreamer *s = 0);
-   virtual Int_t
-   WriteFastArray(void **startp, const TClass *cl, Int_t n = 1, Bool_t isPreAlloc = kFALSE, TMemberStreamer *s = 0);
+   virtual void WriteFastArrayFloat16(const Float_t *d, Int_t n, TStreamerElement *ele = nullptr);
+   virtual void WriteFastArrayDouble32(const Double_t *d, Int_t n, TStreamerElement *ele = nullptr);
+   virtual void WriteFastArray(void *start, const TClass *cl, Int_t n = 1, TMemberStreamer *s = nullptr);
+   virtual Int_t WriteFastArray(void **startp, const TClass *cl, Int_t n = 1, Bool_t isPreAlloc = kFALSE,
+                                TMemberStreamer *s = nullptr);
 
-   virtual void StreamObject(void *obj, const std::type_info &typeinfo, const TClass *onFileClass = 0);
-   virtual void StreamObject(void *obj, const char *className, const TClass *onFileClass = 0);
-   virtual void StreamObject(void *obj, const TClass *cl, const TClass *onFileClass = 0);
+   virtual void StreamObject(void *obj, const std::type_info &typeinfo, const TClass *onFileClass = nullptr);
+   virtual void StreamObject(void *obj, const char *className, const TClass *onFileClass = nullptr);
+   virtual void StreamObject(void *obj, const TClass *cl, const TClass *onFileClass = nullptr);
    virtual void StreamObject(TObject *obj);
 
    virtual void ReadBool(Bool_t &b);
@@ -274,18 +274,18 @@ protected:
 
    TXMLStackObj *PushStack(XMLNodePointer_t current, Bool_t simple = kFALSE);
    TXMLStackObj *PopStack();
-   void ShiftStack(const char *info = 0);
+   void ShiftStack(const char *info = nullptr);
 
    XMLNodePointer_t StackNode();
    TXMLStackObj *Stack(Int_t depth = 0);
 
-   void WorkWithClass(TStreamerInfo *info, const TClass *cl = 0);
+   void WorkWithClass(TStreamerInfo *info, const TClass *cl = nullptr);
    void WorkWithElement(TStreamerElement *elem, Int_t comp_type);
-   Bool_t VerifyNode(XMLNodePointer_t node, const char *name, const char *errinfo = 0);
-   Bool_t VerifyStackNode(const char *name, const char *errinfo = 0);
+   Bool_t VerifyNode(XMLNodePointer_t node, const char *name, const char *errinfo = nullptr);
+   Bool_t VerifyStackNode(const char *name, const char *errinfo = nullptr);
 
-   Bool_t VerifyAttr(XMLNodePointer_t node, const char *name, const char *value, const char *errinfo = 0);
-   Bool_t VerifyStackAttr(const char *name, const char *value, const char *errinfo = 0);
+   Bool_t VerifyAttr(XMLNodePointer_t node, const char *name, const char *value, const char *errinfo = nullptr);
+   Bool_t VerifyStackAttr(const char *name, const char *value, const char *errinfo = nullptr);
 
    Bool_t ProcessPointer(const void *ptr, XMLNodePointer_t node);
    void RegisterPointer(const void *ptr, XMLNodePointer_t node);
@@ -293,7 +293,7 @@ protected:
    void ExtractReference(XMLNodePointer_t node, const void *ptr, const TClass *cl);
 
    XMLNodePointer_t CreateItemNode(const char *name);
-   Bool_t VerifyItemNode(const char *name, const char *errinfo = 0);
+   Bool_t VerifyItemNode(const char *name, const char *errinfo = nullptr);
 
    void CreateElemNode(const TStreamerElement *elem);
    Bool_t VerifyElemNode(const TStreamerElement *elem);
@@ -350,7 +350,7 @@ protected:
    R__ALWAYS_INLINE void XmlWriteFastArray(const T *arr, Int_t n);
 
    XMLNodePointer_t XmlWriteObject(const void *obj, const TClass *objClass, Bool_t cacheReuse);
-   void *XmlReadObject(void *obj, TClass **cl = 0);
+   void *XmlReadObject(void *obj, TClass **cl = nullptr);
 
    void BeforeIOoperation();
    void CheckVersionBuf();

--- a/io/xml/src/TBufferXML.cxx
+++ b/io/xml/src/TBufferXML.cxx
@@ -4120,3 +4120,49 @@ Int_t TBufferXML::WriteClones(TClonesArray *a, Int_t nobjects)
    // No need to tell call ForceWriteInfo as it by ForceWriteInfoClones.
    return ApplySequenceVecPtr(*(info->GetWriteMemberWiseActions(kTRUE)), arr, end);
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// The TProcessID with number pidf is read from file.
+/// If the object is not already entered in the gROOT list, it is added.
+
+TProcessID *TBufferXML::ReadProcessID(UShort_t pidf)
+{
+   TFile *file = (TFile *)GetParent();
+   if (!file) {
+      if (!pidf)
+         return TProcessID::GetPID(); // may happen when cloning an object
+      return 0;
+   }
+
+   TProcessID *pid = nullptr;
+   {
+      R__LOCKGUARD_IMT(gInterpreterMutex); // Lock for parallel TTree I/O
+      pid = file->ReadProcessID(pidf);
+   }
+
+   return pid;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Check if the ProcessID pid is already in the file.
+/// If not, add it and return the index number in the local file list.
+
+UShort_t TBufferXML::WriteProcessID(TProcessID *pid)
+{
+   TFile *file = (TFile *)GetParent();
+   if (!file)
+      return 0;
+   return file->WriteProcessID(pid);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Return the exec id stored in the current TStreamerInfo element.
+/// The execid has been saved in the unique id of the TStreamerElement
+/// being read by TStreamerElement::Streamer.
+/// The current element (fgElement) is set as a static global
+/// by TStreamerInfo::ReadBuffer (Clones) when reading this TRef.
+
+UInt_t TBufferXML::GetTRefExecId()
+{
+   return TStreamerInfo::GetCurrentElement()->GetUniqueID();
+}

--- a/io/xml/src/TBufferXML.cxx
+++ b/io/xml/src/TBufferXML.cxx
@@ -62,7 +62,7 @@ std::string TBufferXML::fgFloatFmt = "%e";
 
 TBufferXML::TBufferXML()
    : TBuffer(), TXMLSetup(), fXML(nullptr), fStack(), fVersionBuf(-111), fObjMap(nullptr), fIdArray(nullptr),
-     fErrorFlag(0), fCanUseCompact(kFALSE), fExpectedChain(kFALSE), fExpectedBaseClass(0), fCompressLevel(0),
+     fErrorFlag(0), fCanUseCompact(kFALSE), fExpectedChain(kFALSE), fExpectedBaseClass(nullptr), fCompressLevel(0),
      fIOVersion(3)
 {
 }
@@ -73,7 +73,7 @@ TBufferXML::TBufferXML()
 
 TBufferXML::TBufferXML(TBuffer::EMode mode)
    : TBuffer(mode), TXMLSetup(), fXML(nullptr), fStack(), fVersionBuf(-111), fObjMap(nullptr), fIdArray(nullptr),
-     fErrorFlag(0), fCanUseCompact(kFALSE), fExpectedChain(kFALSE), fExpectedBaseClass(0), fCompressLevel(0),
+     fErrorFlag(0), fCanUseCompact(kFALSE), fExpectedChain(kFALSE), fExpectedBaseClass(nullptr), fCompressLevel(0),
      fIOVersion(3)
 {
    fBufSize = 1000000000;
@@ -90,7 +90,7 @@ TBufferXML::TBufferXML(TBuffer::EMode mode)
 
 TBufferXML::TBufferXML(TBuffer::EMode mode, TXMLFile *file)
    : TBuffer(mode), TXMLSetup(*file), fXML(nullptr), fStack(), fVersionBuf(-111), fObjMap(nullptr), fIdArray(nullptr),
-     fErrorFlag(0), fCanUseCompact(kFALSE), fExpectedChain(kFALSE), fExpectedBaseClass(0), fCompressLevel(0),
+     fErrorFlag(0), fCanUseCompact(kFALSE), fExpectedChain(kFALSE), fExpectedBaseClass(nullptr), fCompressLevel(0),
      fIOVersion(3)
 {
    // this is for the case when StreamerInfo reads elements from
@@ -219,7 +219,7 @@ void *TBufferXML::ConvertFromXMLAny(const char *str, TClass **cl, Bool_t Generic
 
    XMLNodePointer_t xmlnode = xml.ReadSingleNode(str);
 
-   void *obj = buf.XmlReadAny(xmlnode, 0, cl);
+   void *obj = buf.XmlReadAny(xmlnode, nullptr, cl);
 
    xml.FreeNode(xmlnode);
 
@@ -303,7 +303,7 @@ void *TBufferXML::XmlReadAny(XMLNodePointer_t node, void *obj, TClass **cl)
 class TXMLStackObj : public TObject {
 public:
    TXMLStackObj(XMLNodePointer_t node)
-      : TObject(), fNode(node), fInfo(0), fElem(0), fElemNumber(0), fCompressedClassNode(kFALSE), fClassNs(0),
+      : TObject(), fNode(node), fInfo(nullptr), fElem(nullptr), fElemNumber(0), fCompressedClassNode(kFALSE), fClassNs(nullptr),
         fIsStreamerInfo(kFALSE), fIsElemOwner(kFALSE)
    {
    }
@@ -461,7 +461,7 @@ void TBufferXML::XmlWriteBlock(XMLNodePointer_t node)
          srcSize = compressedSize;
       } else {
          delete[] fZipBuffer;
-         fZipBuffer = 0;
+         fZipBuffer = nullptr;
       }
    }
 
@@ -484,7 +484,7 @@ void TBufferXML::XmlWriteBlock(XMLNodePointer_t node)
    if (block > 0)
       res += sbuf;
 
-   XMLNodePointer_t blocknode = fXML->NewChild(node, 0, xmlio::XmlBlock, res);
+   XMLNodePointer_t blocknode = fXML->NewChild(node, nullptr, xmlio::XmlBlock, res);
    fXML->NewIntAttr(blocknode, xmlio::Size, Length());
 
    if (fZipBuffer) {
@@ -503,7 +503,7 @@ void TBufferXML::XmlReadBlock(XMLNodePointer_t blocknode)
 
    Int_t blockSize = fXML->GetIntAttr(blocknode, xmlio::Size);
    Bool_t blockCompressed = fXML->HasAttr(blocknode, xmlio::Zip);
-   char *fUnzipBuffer = 0;
+   char *fUnzipBuffer = nullptr;
 
    if (gDebug > 2)
       Info("XmlReadBlock", "Block size = %d, Length = %d, Compressed = %d", blockSize, Length(), blockCompressed);
@@ -594,11 +594,11 @@ Bool_t TBufferXML::ProcessPointer(const void *ptr, XMLNodePointer_t node)
             refvalue += XmlFile()->GetNextRefCounter();
          else
             refvalue += GetNextRefCounter();
-         fXML->NewAttr(refnode, 0, xmlio::Ref, refvalue.Data());
+         fXML->NewAttr(refnode, nullptr, xmlio::Ref, refvalue.Data());
       }
    }
    if (refvalue.Length() > 0) {
-      fXML->NewAttr(node, 0, xmlio::Ptr, refvalue.Data());
+      fXML->NewAttr(node, nullptr, xmlio::Ptr, refvalue.Data());
       return kTRUE;
    }
 
@@ -744,12 +744,12 @@ Bool_t TBufferXML::VerifyStackAttr(const char *name, const char *value, const ch
 
 XMLNodePointer_t TBufferXML::CreateItemNode(const char *name)
 {
-   XMLNodePointer_t node = 0;
+   XMLNodePointer_t node = nullptr;
    if (GetXmlLayout() == kGeneralized) {
-      node = fXML->NewChild(StackNode(), 0, xmlio::Item, 0);
-      fXML->NewAttr(node, 0, xmlio::Name, name);
+      node = fXML->NewChild(StackNode(), nullptr, xmlio::Item, nullptr);
+      fXML->NewAttr(node, nullptr, xmlio::Name, name);
    } else
-      node = fXML->NewChild(StackNode(), 0, name, 0);
+      node = fXML->NewChild(StackNode(), nullptr, name, nullptr);
    return node;
 }
 
@@ -771,13 +771,13 @@ Bool_t TBufferXML::VerifyItemNode(const char *name, const char *errinfo)
 
 void TBufferXML::CreateElemNode(const TStreamerElement *elem)
 {
-   XMLNodePointer_t elemnode = 0;
+   XMLNodePointer_t elemnode = nullptr;
 
    const char *elemxmlname = XmlGetElementName(elem);
 
    if (GetXmlLayout() == kGeneralized) {
-      elemnode = fXML->NewChild(StackNode(), 0, xmlio::Member, 0);
-      fXML->NewAttr(elemnode, 0, xmlio::Name, elemxmlname);
+      elemnode = fXML->NewChild(StackNode(), nullptr, xmlio::Member, nullptr);
+      fXML->NewAttr(elemnode, nullptr, xmlio::Name, elemxmlname);
    } else {
       // take namesapce for element only if it is not a base class or class name
       XMLNsPointer_t ns = Stack()->fClassNs;
@@ -785,9 +785,9 @@ void TBufferXML::CreateElemNode(const TStreamerElement *elem)
           ((elem->GetType() == TStreamerInfo::kTNamed) && !strcmp(elem->GetName(), TNamed::Class()->GetName())) ||
           ((elem->GetType() == TStreamerInfo::kTObject) && !strcmp(elem->GetName(), TObject::Class()->GetName())) ||
           ((elem->GetType() == TStreamerInfo::kTString) && !strcmp(elem->GetName(), TString::Class()->GetName())))
-         ns = 0;
+         ns = nullptr;
 
-      elemnode = fXML->NewChild(StackNode(), ns, elemxmlname, 0);
+      elemnode = fXML->NewChild(StackNode(), ns, elemxmlname, nullptr);
    }
 
    TXMLStackObj *curr = PushStack(elemnode);
@@ -825,16 +825,16 @@ Bool_t TBufferXML::VerifyElemNode(const TStreamerElement *elem)
 
 XMLNodePointer_t TBufferXML::XmlWriteObject(const void *obj, const TClass *cl, Bool_t cacheReuse)
 {
-   XMLNodePointer_t objnode = fXML->NewChild(StackNode(), 0, xmlio::Object, 0);
+   XMLNodePointer_t objnode = fXML->NewChild(StackNode(), nullptr, xmlio::Object, nullptr);
 
    if (!cl)
-      obj = 0;
+      obj = nullptr;
    if (ProcessPointer(obj, objnode))
       return objnode;
 
    TString clname = XmlConvertClassName(cl->GetName());
 
-   fXML->NewAttr(objnode, 0, xmlio::ObjClass, clname);
+   fXML->NewAttr(objnode, nullptr, xmlio::ObjClass, clname);
 
    if (cacheReuse)
       RegisterPointer(obj, objnode);
@@ -957,10 +957,10 @@ void TBufferXML::WorkWithClass(TStreamerInfo *sinfo, const TClass *cl)
          classnode = StackNode();
       } else {
          if (GetXmlLayout() == kGeneralized) {
-            classnode = fXML->NewChild(StackNode(), 0, xmlio::Class, 0);
-            fXML->NewAttr(classnode, 0, "name", clname);
+            classnode = fXML->NewChild(StackNode(), nullptr, xmlio::Class, nullptr);
+            fXML->NewAttr(classnode, nullptr, "name", clname);
          } else
-            classnode = fXML->NewChild(StackNode(), 0, clname, 0);
+            classnode = fXML->NewChild(StackNode(), nullptr, clname, nullptr);
          stack = PushStack(classnode);
       }
 
@@ -1014,7 +1014,7 @@ void TBufferXML::DecrementLevel(TVirtualStreamerInfo *info)
    }
 
    if (stack->fCompressedClassNode) {
-      stack->fInfo = 0;
+      stack->fInfo = nullptr;
       stack->fIsStreamerInfo = kFALSE;
       stack->fCompressedClassNode = kFALSE;
    } else {
@@ -1335,7 +1335,7 @@ void TBufferXML::PerformPostProcessing()
          fXML->UnlinkFreeNode(nodestring);
       }
 
-      fXML->NewAttr(elemnode, 0, "str", str);
+      fXML->NewAttr(elemnode, nullptr, "str", str);
    } else if (elem->GetType() == TStreamerInfo::kTObject) {
       XMLNodePointer_t node = fXML->GetChild(elemnode);
       fXML->SkipEmpty(node);
@@ -1369,7 +1369,7 @@ void TBufferXML::PerformPostProcessing()
          return;
 
       TString str = fXML->GetAttr(idnode, xmlio::v);
-      fXML->NewAttr(elemnode, 0, "fUniqueID", str);
+      fXML->NewAttr(elemnode, nullptr, "fUniqueID", str);
 
       str = fXML->GetAttr(bitsnode, xmlio::v);
       UInt_t bits;
@@ -1377,11 +1377,11 @@ void TBufferXML::PerformPostProcessing()
 
       char sbuf[20];
       snprintf(sbuf, sizeof(sbuf), "%x", bits);
-      fXML->NewAttr(elemnode, 0, "fBits", sbuf);
+      fXML->NewAttr(elemnode, nullptr, "fBits", sbuf);
 
       if (prnode) {
          str = fXML->GetAttr(prnode, xmlio::v);
-         fXML->NewAttr(elemnode, 0, "fProcessID", str);
+         fXML->NewAttr(elemnode, nullptr, "fProcessID", str);
       }
 
       fXML->UnlinkFreeNode(vnode);
@@ -1411,23 +1411,23 @@ void TBufferXML::PerformPreProcessing(const TStreamerElement *elem, XMLNodePoint
 
       if (GetIOVersion() < 3) {
          Int_t len = str.Length();
-         XMLNodePointer_t ucharnode = fXML->NewChild(elemnode, 0, xmlio::UChar, 0);
+         XMLNodePointer_t ucharnode = fXML->NewChild(elemnode, nullptr, xmlio::UChar, nullptr);
          char sbuf[20];
          snprintf(sbuf, sizeof(sbuf), "%d", len);
          if (len < 255) {
-            fXML->NewAttr(ucharnode, 0, xmlio::v, sbuf);
+            fXML->NewAttr(ucharnode, nullptr, xmlio::v, sbuf);
          } else {
-            fXML->NewAttr(ucharnode, 0, xmlio::v, "255");
-            XMLNodePointer_t intnode = fXML->NewChild(elemnode, 0, xmlio::Int, 0);
-            fXML->NewAttr(intnode, 0, xmlio::v, sbuf);
+            fXML->NewAttr(ucharnode, nullptr, xmlio::v, "255");
+            XMLNodePointer_t intnode = fXML->NewChild(elemnode, nullptr, xmlio::Int, nullptr);
+            fXML->NewAttr(intnode, nullptr, xmlio::v, sbuf);
          }
          if (len > 0) {
-            XMLNodePointer_t node = fXML->NewChild(elemnode, 0, xmlio::CharStar, 0);
-            fXML->NewAttr(node, 0, xmlio::v, str);
+            XMLNodePointer_t node = fXML->NewChild(elemnode, nullptr, xmlio::CharStar, nullptr);
+            fXML->NewAttr(node, nullptr, xmlio::v, str);
          }
       } else {
-         XMLNodePointer_t node = fXML->NewChild(elemnode, 0, xmlio::String, 0);
-         fXML->NewAttr(node, 0, xmlio::v, str);
+         XMLNodePointer_t node = fXML->NewChild(elemnode, nullptr, xmlio::String, nullptr);
+         fXML->NewAttr(node, nullptr, xmlio::v, str);
       }
    } else if (elem->GetType() == TStreamerInfo::kTObject) {
       if (!fXML->HasAttr(elemnode, "fUniqueID"))
@@ -1443,23 +1443,23 @@ void TBufferXML::PerformPreProcessing(const TStreamerElement *elem, XMLNodePoint
       fXML->FreeAttr(elemnode, "fBits");
       fXML->FreeAttr(elemnode, "fProcessID");
 
-      XMLNodePointer_t node = fXML->NewChild(elemnode, 0, xmlio::OnlyVersion, 0);
-      fXML->NewAttr(node, 0, xmlio::v, "1");
+      XMLNodePointer_t node = fXML->NewChild(elemnode, nullptr, xmlio::OnlyVersion, nullptr);
+      fXML->NewAttr(node, nullptr, xmlio::v, "1");
 
-      node = fXML->NewChild(elemnode, 0, xmlio::UInt, 0);
-      fXML->NewAttr(node, 0, xmlio::v, idstr);
+      node = fXML->NewChild(elemnode, nullptr, xmlio::UInt, nullptr);
+      fXML->NewAttr(node, nullptr, xmlio::v, idstr);
 
       UInt_t bits;
       sscanf(bitsstr.Data(), "%x", &bits);
       char sbuf[20];
       snprintf(sbuf, sizeof(sbuf), "%u", bits);
 
-      node = fXML->NewChild(elemnode, 0, xmlio::UInt, 0);
-      fXML->NewAttr(node, 0, xmlio::v, sbuf);
+      node = fXML->NewChild(elemnode, nullptr, xmlio::UInt, nullptr);
+      fXML->NewAttr(node, nullptr, xmlio::v, sbuf);
 
       if (prstr.Length() > 0) {
-         node = fXML->NewChild(elemnode, 0, xmlio::UShort, 0);
-         fXML->NewAttr(node, 0, xmlio::v, prstr.Data());
+         node = fXML->NewChild(elemnode, nullptr, xmlio::UShort, nullptr);
+         fXML->NewAttr(node, nullptr, xmlio::v, prstr.Data());
       }
    }
 }
@@ -1480,14 +1480,13 @@ TClass *TBufferXML::ReadClass(const TClass *, UInt_t *)
 {
    const char *clname = nullptr;
 
-   if (VerifyItemNode(xmlio::Class)) {
+   if (VerifyItemNode(xmlio::Class))
       clname = XmlReadValue(xmlio::Class);
-   }
 
    if (gDebug > 2)
       Info("ReadClass", "Try to read class %s", clname ? clname : "---");
 
-   return clname ? gROOT->GetClass(clname) : 0;
+   return clname ? gROOT->GetClass(clname) : nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1529,7 +1528,7 @@ void TBufferXML::SetByteCount(UInt_t, Bool_t)
 
 void TBufferXML::SkipVersion(const TClass *cl)
 {
-   ReadVersion(0, 0, cl);
+   ReadVersion(nullptr, nullptr, cl);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1598,7 +1597,7 @@ UInt_t TBufferXML::WriteVersion(const TClass *cl, Bool_t /* useBcnt */)
    BeforeIOoperation();
 
    if (fExpectedBaseClass != cl)
-      fExpectedBaseClass = 0;
+      fExpectedBaseClass = nullptr;
 
    fVersionBuf = cl->GetClassVersion();
 
@@ -3310,14 +3309,14 @@ XMLNodePointer_t TBufferXML::XmlWriteBasic(ULong64_t value)
 
 XMLNodePointer_t TBufferXML::XmlWriteValue(const char *value, const char *name)
 {
-   XMLNodePointer_t node = 0;
+   XMLNodePointer_t node = nullptr;
 
    if (fCanUseCompact)
       node = StackNode();
    else
       node = CreateItemNode(name);
 
-   fXML->NewAttr(node, 0, xmlio::v, value);
+   fXML->NewAttr(node, nullptr, xmlio::v, value);
 
    fCanUseCompact = kFALSE;
 
@@ -3735,7 +3734,7 @@ Int_t TBufferXML::ReadClassBuffer(const TClass *cl, void *pointer, Int_t version
          return 0;
       }
       sinfo = (TStreamerInfo *)infos->At(version);
-      if (sinfo == 0) {
+      if (!sinfo) {
          // Unless the data is coming via a socket connection from with schema evolution
          // (tracking) was not enabled.  So let's create the StreamerInfo if it is the
          // one for the current version, otherwise let's complain ...
@@ -3811,7 +3810,7 @@ Int_t TBufferXML::ReadClassBuffer(const TClass *cl, void *pointer, const TClass 
    // The ondisk class has been specified so get foreign streamer info
    /////////////////////////////////////////////////////////////////////////////
 
-   TStreamerInfo *sinfo = 0;
+   TStreamerInfo *sinfo = nullptr;
    if (onFileClass) {
       sinfo = (TStreamerInfo *)cl->GetConversionStreamerInfo(onFileClass, version);
       if (!sinfo) {
@@ -3863,7 +3862,7 @@ Int_t TBufferXML::ReadClassBuffer(const TClass *cl, void *pointer, const TClass 
             }
          }
 
-         if (sinfo == 0) {
+         if (!sinfo) {
             // Unless the data is coming via a socket connection from with schema evolution
             // (tracking) was not enabled.  So let's create the StreamerInfo if it is the
             // one for the current version, otherwise let's complain ...
@@ -3937,11 +3936,11 @@ Int_t TBufferXML::WriteClassBuffer(const TClass *cl, void *pointer)
 {
    // build the StreamerInfo if first time for the class
    TStreamerInfo *sinfo = (TStreamerInfo *)const_cast<TClass *>(cl)->GetCurrentStreamerInfo();
-   if (sinfo == 0) {
+   if (!sinfo) {
       // Have to be sure between the check and the taking of the lock if the current streamer has changed
       R__LOCKGUARD(gInterpreterMutex);
       sinfo = (TStreamerInfo *)const_cast<TClass *>(cl)->GetCurrentStreamerInfo();
-      if (sinfo == 0) {
+      if (!sinfo) {
          const_cast<TClass *>(cl)->BuildRealData(pointer);
          sinfo = new TStreamerInfo(const_cast<TClass *>(cl));
          const_cast<TClass *>(cl)->SetCurrentStreamerInfo(sinfo);
@@ -4035,7 +4034,7 @@ struct DynamicType {
 Int_t TBufferXML::WriteObjectAny(const void *obj, const TClass *ptrClass, Bool_t cacheReuse /* = kTRUE */)
 {
    if (!obj) {
-      WriteObjectClass(0, 0, kTRUE);
+      WriteObjectClass(nullptr, nullptr, kTRUE);
       return 1;
    }
 

--- a/io/xml/src/TBufferXML.cxx
+++ b/io/xml/src/TBufferXML.cxx
@@ -15,13 +15,20 @@
 
 Class for serializing/deserializing object to/from xml.
 
-It redefines most of TBuffer class function to convert simple types,
-array of simple types and objects to/from xml.
-Instead of writing a binary data it creates a set of xml structures as
-nodes and attributes
+The simple way to create XML representation is:
+~~~{.cpp}
+   TNamed *obj = new TNamed("name", "title");
+   TString xml = TBufferXML::ToXML(obj);
+~~~
+Produced xml can be decoded into new object:
+~~~{.cpp}
+   TNamed *obj2 = nullptr;
+   TBufferXML::FromXML(obj2, xml);
+~~~
+
 TBufferXML class uses streaming mechanism, provided by ROOT system,
-therefore most of ROOT and user classes can be stored to xml. There are
-limitations for complex objects like TTree, which can not be yet converted to xml.
+therefore most of ROOT and user classes can be stored to xml.
+There are limitations for complex objects like TTree, which can not be converted to xml.
 */
 
 #include "TBufferXML.h"
@@ -303,8 +310,8 @@ void *TBufferXML::XmlReadAny(XMLNodePointer_t node, void *obj, TClass **cl)
 class TXMLStackObj : public TObject {
 public:
    TXMLStackObj(XMLNodePointer_t node)
-      : TObject(), fNode(node), fInfo(nullptr), fElem(nullptr), fElemNumber(0), fCompressedClassNode(kFALSE), fClassNs(nullptr),
-        fIsStreamerInfo(kFALSE), fIsElemOwner(kFALSE)
+      : TObject(), fNode(node), fInfo(nullptr), fElem(nullptr), fElemNumber(0), fCompressedClassNode(kFALSE),
+        fClassNs(nullptr), fIsStreamerInfo(kFALSE), fIsElemOwner(kFALSE)
    {
    }
 

--- a/io/xml/src/TBufferXML.cxx
+++ b/io/xml/src/TBufferXML.cxx
@@ -746,10 +746,10 @@ XMLNodePointer_t TBufferXML::CreateItemNode(const char *name)
 {
    XMLNodePointer_t node = nullptr;
    if (GetXmlLayout() == kGeneralized) {
-      node = fXML->NewChild(StackNode(), nullptr, xmlio::Item, nullptr);
+      node = fXML->NewChild(StackNode(), nullptr, xmlio::Item);
       fXML->NewAttr(node, nullptr, xmlio::Name, name);
    } else
-      node = fXML->NewChild(StackNode(), nullptr, name, nullptr);
+      node = fXML->NewChild(StackNode(), nullptr, name);
    return node;
 }
 
@@ -776,7 +776,7 @@ void TBufferXML::CreateElemNode(const TStreamerElement *elem)
    const char *elemxmlname = XmlGetElementName(elem);
 
    if (GetXmlLayout() == kGeneralized) {
-      elemnode = fXML->NewChild(StackNode(), nullptr, xmlio::Member, nullptr);
+      elemnode = fXML->NewChild(StackNode(), nullptr, xmlio::Member);
       fXML->NewAttr(elemnode, nullptr, xmlio::Name, elemxmlname);
    } else {
       // take namesapce for element only if it is not a base class or class name
@@ -787,7 +787,7 @@ void TBufferXML::CreateElemNode(const TStreamerElement *elem)
           ((elem->GetType() == TStreamerInfo::kTString) && !strcmp(elem->GetName(), TString::Class()->GetName())))
          ns = nullptr;
 
-      elemnode = fXML->NewChild(StackNode(), ns, elemxmlname, nullptr);
+      elemnode = fXML->NewChild(StackNode(), ns, elemxmlname);
    }
 
    TXMLStackObj *curr = PushStack(elemnode);
@@ -825,7 +825,7 @@ Bool_t TBufferXML::VerifyElemNode(const TStreamerElement *elem)
 
 XMLNodePointer_t TBufferXML::XmlWriteObject(const void *obj, const TClass *cl, Bool_t cacheReuse)
 {
-   XMLNodePointer_t objnode = fXML->NewChild(StackNode(), nullptr, xmlio::Object, nullptr);
+   XMLNodePointer_t objnode = fXML->NewChild(StackNode(), nullptr, xmlio::Object);
 
    if (!cl)
       obj = nullptr;
@@ -957,10 +957,10 @@ void TBufferXML::WorkWithClass(TStreamerInfo *sinfo, const TClass *cl)
          classnode = StackNode();
       } else {
          if (GetXmlLayout() == kGeneralized) {
-            classnode = fXML->NewChild(StackNode(), nullptr, xmlio::Class, nullptr);
+            classnode = fXML->NewChild(StackNode(), nullptr, xmlio::Class);
             fXML->NewAttr(classnode, nullptr, "name", clname);
          } else
-            classnode = fXML->NewChild(StackNode(), nullptr, clname, nullptr);
+            classnode = fXML->NewChild(StackNode(), nullptr, clname);
          stack = PushStack(classnode);
       }
 
@@ -1411,22 +1411,22 @@ void TBufferXML::PerformPreProcessing(const TStreamerElement *elem, XMLNodePoint
 
       if (GetIOVersion() < 3) {
          Int_t len = str.Length();
-         XMLNodePointer_t ucharnode = fXML->NewChild(elemnode, nullptr, xmlio::UChar, nullptr);
+         XMLNodePointer_t ucharnode = fXML->NewChild(elemnode, nullptr, xmlio::UChar);
          char sbuf[20];
          snprintf(sbuf, sizeof(sbuf), "%d", len);
          if (len < 255) {
             fXML->NewAttr(ucharnode, nullptr, xmlio::v, sbuf);
          } else {
             fXML->NewAttr(ucharnode, nullptr, xmlio::v, "255");
-            XMLNodePointer_t intnode = fXML->NewChild(elemnode, nullptr, xmlio::Int, nullptr);
+            XMLNodePointer_t intnode = fXML->NewChild(elemnode, nullptr, xmlio::Int);
             fXML->NewAttr(intnode, nullptr, xmlio::v, sbuf);
          }
          if (len > 0) {
-            XMLNodePointer_t node = fXML->NewChild(elemnode, nullptr, xmlio::CharStar, nullptr);
+            XMLNodePointer_t node = fXML->NewChild(elemnode, nullptr, xmlio::CharStar);
             fXML->NewAttr(node, nullptr, xmlio::v, str);
          }
       } else {
-         XMLNodePointer_t node = fXML->NewChild(elemnode, nullptr, xmlio::String, nullptr);
+         XMLNodePointer_t node = fXML->NewChild(elemnode, nullptr, xmlio::String);
          fXML->NewAttr(node, nullptr, xmlio::v, str);
       }
    } else if (elem->GetType() == TStreamerInfo::kTObject) {
@@ -1443,10 +1443,10 @@ void TBufferXML::PerformPreProcessing(const TStreamerElement *elem, XMLNodePoint
       fXML->FreeAttr(elemnode, "fBits");
       fXML->FreeAttr(elemnode, "fProcessID");
 
-      XMLNodePointer_t node = fXML->NewChild(elemnode, nullptr, xmlio::OnlyVersion, nullptr);
+      XMLNodePointer_t node = fXML->NewChild(elemnode, nullptr, xmlio::OnlyVersion);
       fXML->NewAttr(node, nullptr, xmlio::v, "1");
 
-      node = fXML->NewChild(elemnode, nullptr, xmlio::UInt, nullptr);
+      node = fXML->NewChild(elemnode, nullptr, xmlio::UInt);
       fXML->NewAttr(node, nullptr, xmlio::v, idstr);
 
       UInt_t bits;
@@ -1454,11 +1454,11 @@ void TBufferXML::PerformPreProcessing(const TStreamerElement *elem, XMLNodePoint
       char sbuf[20];
       snprintf(sbuf, sizeof(sbuf), "%u", bits);
 
-      node = fXML->NewChild(elemnode, nullptr, xmlio::UInt, nullptr);
+      node = fXML->NewChild(elemnode, nullptr, xmlio::UInt);
       fXML->NewAttr(node, nullptr, xmlio::v, sbuf);
 
       if (prstr.Length() > 0) {
-         node = fXML->NewChild(elemnode, nullptr, xmlio::UShort, nullptr);
+         node = fXML->NewChild(elemnode, nullptr, xmlio::UShort);
          fXML->NewAttr(node, nullptr, xmlio::v, prstr.Data());
       }
    }

--- a/io/xml/src/TKeyXML.cxx
+++ b/io/xml/src/TKeyXML.cxx
@@ -54,7 +54,7 @@ TKeyXML::TKeyXML(TDirectory *mother, Long64_t keyid, const TObject *obj, const c
 
    TXMLEngine *xml = XMLEngine();
    if (xml)
-      fKeyNode = xml->NewChild(nullptr, nullptr, xmlio::Xmlkey, nullptr);
+      fKeyNode = xml->NewChild(nullptr, nullptr, xmlio::Xmlkey);
 
    fDatime.Set();
 
@@ -80,7 +80,7 @@ TKeyXML::TKeyXML(TDirectory *mother, Long64_t keyid, const void *obj, const TCla
 
    TXMLEngine *xml = XMLEngine();
    if (xml)
-      fKeyNode = xml->NewChild(nullptr, nullptr, xmlio::Xmlkey, nullptr);
+      fKeyNode = xml->NewChild(nullptr, nullptr, xmlio::Xmlkey);
 
    fDatime.Set();
 

--- a/io/xml/src/TKeyXML.cxx
+++ b/io/xml/src/TKeyXML.cxx
@@ -29,7 +29,7 @@ ClassImp(TKeyXML);
 ////////////////////////////////////////////////////////////////////////////////
 /// default constructor
 
-TKeyXML::TKeyXML() : TKey(), fKeyNode(0), fKeyId(0), fSubdir(kFALSE)
+TKeyXML::TKeyXML() : TKey(), fKeyNode(nullptr), fKeyId(0), fSubdir(kFALSE)
 {
 }
 
@@ -37,11 +37,11 @@ TKeyXML::TKeyXML() : TKey(), fKeyNode(0), fKeyId(0), fSubdir(kFALSE)
 /// Creates TKeyXML and convert object data to xml structures
 
 TKeyXML::TKeyXML(TDirectory *mother, Long64_t keyid, const TObject *obj, const char *name, const char *title)
-   : TKey(mother), fKeyNode(0), fKeyId(keyid), fSubdir(kFALSE)
+   : TKey(mother), fKeyNode(nullptr), fKeyId(keyid), fSubdir(kFALSE)
 {
-   if (name)
+   if (name) {
       SetName(name);
-   else if (obj != 0) {
+   } else if (obj) {
       SetName(obj->GetName());
       fClassName = obj->ClassName();
    } else
@@ -53,12 +53,12 @@ TKeyXML::TKeyXML(TDirectory *mother, Long64_t keyid, const TObject *obj, const c
    fCycle = GetMotherDir()->AppendKey(this);
 
    TXMLEngine *xml = XMLEngine();
-   if (xml != 0)
-      fKeyNode = xml->NewChild(0, 0, xmlio::Xmlkey, 0);
+   if (xml)
+      fKeyNode = xml->NewChild(nullptr, nullptr, xmlio::Xmlkey, nullptr);
 
    fDatime.Set();
 
-   StoreObject(obj, 0, kTRUE);
+   StoreObject(obj, nullptr, kTRUE);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -66,7 +66,7 @@ TKeyXML::TKeyXML(TDirectory *mother, Long64_t keyid, const TObject *obj, const c
 
 TKeyXML::TKeyXML(TDirectory *mother, Long64_t keyid, const void *obj, const TClass *cl, const char *name,
                  const char *title)
-   : TKey(mother), fKeyNode(0), fKeyId(keyid), fSubdir(kFALSE)
+   : TKey(mother), fKeyNode(nullptr), fKeyId(keyid), fSubdir(kFALSE)
 {
    if (name && *name)
       SetName(name);
@@ -79,8 +79,8 @@ TKeyXML::TKeyXML(TDirectory *mother, Long64_t keyid, const void *obj, const TCla
    fCycle = GetMotherDir()->AppendKey(this);
 
    TXMLEngine *xml = XMLEngine();
-   if (xml != 0)
-      fKeyNode = xml->NewChild(0, 0, xmlio::Xmlkey, 0);
+   if (xml)
+      fKeyNode = xml->NewChild(nullptr, nullptr, xmlio::Xmlkey, nullptr);
 
    fDatime.Set();
 
@@ -138,7 +138,7 @@ void TKeyXML::Delete(Option_t * /*option*/)
    TXMLEngine *xml = XMLEngine();
    if (fKeyNode && xml) {
       xml->FreeNode(fKeyNode);
-      fKeyNode = 0;
+      fKeyNode = nullptr;
    }
 
    fMotherDir->GetListOfKeys()->Remove(this);
@@ -151,17 +151,17 @@ void TKeyXML::StoreKeyAttributes()
 {
    TXMLEngine *xml = XMLEngine();
    TXMLFile *f = (TXMLFile *)GetFile();
-   if ((f == 0) || (xml == 0) || (fKeyNode == 0))
+   if (!f || !xml || !fKeyNode)
       return;
 
-   xml->NewAttr(fKeyNode, 0, xmlio::Name, GetName());
+   xml->NewAttr(fKeyNode, nullptr, xmlio::Name, GetName());
 
    xml->NewIntAttr(fKeyNode, xmlio::Cycle, fCycle);
 
    if (f->GetIOVersion() > 1) {
       if (strlen(GetTitle()) > 0)
-         xml->NewAttr(fKeyNode, 0, xmlio::Title, GetTitle());
-      xml->NewAttr(fKeyNode, 0, xmlio::CreateTm, fDatime.AsSQLString());
+         xml->NewAttr(fKeyNode, nullptr, xmlio::Title, GetTitle());
+      xml->NewAttr(fKeyNode, nullptr, xmlio::CreateTm, fDatime.AsSQLString());
    }
 }
 
@@ -172,14 +172,14 @@ void TKeyXML::StoreObject(const void *obj, const TClass *cl, Bool_t check_tobj)
 {
    TXMLFile *f = (TXMLFile *)GetFile();
    TXMLEngine *xml = XMLEngine();
-   if ((f == 0) || (xml == 0) || (fKeyNode == 0))
+   if (!f || !xml || !fKeyNode)
       return;
 
    if (obj && check_tobj) {
       TClass *actual = TObject::Class()->GetActualClass((TObject *)obj);
-      if (!actual)
+      if (!actual) {
          actual = TObject::Class();
-      else if (actual != TObject::Class())
+      } else if (actual != TObject::Class())
          obj = (void *)((Long_t)obj - actual->GetBaseClassOffset(TObject::Class()));
       cl = actual;
    }
@@ -192,7 +192,7 @@ void TKeyXML::StoreObject(const void *obj, const TClass *cl, Bool_t check_tobj)
 
    XMLNodePointer_t node = buffer.XmlWriteAny(obj, cl);
 
-   if (node != 0)
+   if (node)
       xml->AddChildFirst(fKeyNode, node);
 
    buffer.XmlWriteBlock(fKeyNode);
@@ -207,7 +207,7 @@ void TKeyXML::StoreObject(const void *obj, const TClass *cl, Bool_t check_tobj)
 void TKeyXML::UpdateAttributes()
 {
    TXMLEngine *xml = XMLEngine();
-   if ((xml == 0) || (fKeyNode == 0))
+   if (!xml || !fKeyNode)
       return;
 
    xml->FreeAllAttr(fKeyNode);
@@ -223,13 +223,13 @@ void TKeyXML::UpdateObject(TObject *obj)
 {
    TXMLFile *f = (TXMLFile *)GetFile();
    TXMLEngine *xml = XMLEngine();
-   if ((f == 0) || (xml == 0) || (obj == 0) || (fKeyNode == 0))
+   if (!f || !xml || !obj || !fKeyNode)
       return;
 
    XMLNodePointer_t objnode = xml->GetChild(fKeyNode);
    xml->SkipEmpty(objnode);
 
-   if (objnode == 0)
+   if (!objnode)
       return;
 
    xml->UnlinkNode(objnode);
@@ -237,7 +237,7 @@ void TKeyXML::UpdateObject(TObject *obj)
 
    xml->FreeAllAttr(fKeyNode);
 
-   StoreObject(obj, 0, kTRUE);
+   StoreObject(obj, nullptr, kTRUE);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -248,23 +248,23 @@ void TKeyXML::UpdateObject(TObject *obj)
 
 Int_t TKeyXML::Read(TObject *tobj)
 {
-   if (tobj == 0)
+   if (!tobj)
       return 0;
 
-   void *res = XmlReadAny(tobj, 0);
+   void *res = XmlReadAny(tobj, nullptr);
 
-   return res == 0 ? 0 : 1;
+   return !res ? 0 : 1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// read object derived from TObject class, from key
-/// if it is not TObject or in case of error, return 0
+/// if it is not TObject or in case of error, return nullptr
 
 TObject *TKeyXML::ReadObj()
 {
-   TObject *tobj = (TObject *)XmlReadAny(0, TObject::Class());
+   TObject *tobj = (TObject *)XmlReadAny(nullptr, TObject::Class());
 
-   if (tobj != 0) {
+   if (tobj) {
       if (gROOT->GetForceStyle())
          tobj->UseCurrentStyle();
       if (tobj->IsA() == TDirectoryFile::Class()) {
@@ -285,13 +285,13 @@ TObject *TKeyXML::ReadObj()
 
 ////////////////////////////////////////////////////////////////////////////////
 /// read object derived from TObject class, from key
-/// if it is not TObject or in case of error, return 0
+/// if it is not TObject or in case of error, return nullptr
 
 TObject *TKeyXML::ReadObjWithBuffer(char * /*bufferRead*/)
 {
-   TObject *tobj = (TObject *)XmlReadAny(0, TObject::Class());
+   TObject *tobj = (TObject *)XmlReadAny(nullptr, TObject::Class());
 
-   if (tobj != 0) {
+   if (tobj) {
       if (gROOT->GetForceStyle())
          tobj->UseCurrentStyle();
       if (tobj->IsA() == TDirectoryFile::Class()) {
@@ -315,7 +315,7 @@ TObject *TKeyXML::ReadObjWithBuffer(char * /*bufferRead*/)
 
 void *TKeyXML::ReadObjectAny(const TClass *expectedClass)
 {
-   void *res = XmlReadAny(0, expectedClass);
+   void *res = XmlReadAny(nullptr, expectedClass);
 
    if (res && (expectedClass == TDirectoryFile::Class())) {
       TDirectoryFile *dir = (TDirectoryFile *)res;
@@ -337,12 +337,12 @@ void *TKeyXML::ReadObjectAny(const TClass *expectedClass)
 
 void *TKeyXML::XmlReadAny(void *obj, const TClass *expectedClass)
 {
-   if (fKeyNode == 0)
+   if (!fKeyNode)
       return obj;
 
    TXMLFile *f = (TXMLFile *)GetFile();
    TXMLEngine *xml = XMLEngine();
-   if ((f == 0) || (xml == 0))
+   if (!f || !xml)
       return obj;
 
    TBufferXML buffer(TBuffer::kRead, f);
@@ -351,7 +351,7 @@ void *TKeyXML::XmlReadAny(void *obj, const TClass *expectedClass)
 
    XMLNodePointer_t blocknode = xml->GetChild(fKeyNode);
    xml->SkipEmpty(blocknode);
-   while (blocknode != 0) {
+   while (blocknode) {
       if (strcmp(xml->GetNodeName(blocknode), xmlio::XmlBlock) == 0)
          break;
       xml->ShiftToNext(blocknode);
@@ -361,20 +361,20 @@ void *TKeyXML::XmlReadAny(void *obj, const TClass *expectedClass)
    XMLNodePointer_t objnode = xml->GetChild(fKeyNode);
    xml->SkipEmpty(objnode);
 
-   TClass *cl = 0;
+   TClass *cl = nullptr;
    void *res = buffer.XmlReadAny(objnode, obj, &cl);
 
-   if ((cl == 0) || (res == 0))
+   if (!cl || !res)
       return obj;
 
    Int_t delta = 0;
 
-   if (expectedClass != 0) {
+   if (expectedClass) {
       delta = cl->GetBaseClassOffset(expectedClass);
       if (delta < 0) {
-         if (obj == 0)
+         if (!obj)
             cl->Destructor(res);
-         return 0;
+         return nullptr;
       }
       if (cl->GetState() > TClass::kEmulated && expectedClass->GetState() <= TClass::kEmulated) {
          // we cannot mix a compiled class with an emulated class in the inheritance
@@ -392,5 +392,5 @@ void *TKeyXML::XmlReadAny(void *obj, const TClass *expectedClass)
 TXMLEngine *TKeyXML::XMLEngine()
 {
    TXMLFile *f = (TXMLFile *)GetFile();
-   return f == 0 ? 0 : f->XML();
+   return f ? f->XML() : nullptr;
 }

--- a/io/xml/src/TXMLFile.cxx
+++ b/io/xml/src/TXMLFile.cxx
@@ -94,7 +94,7 @@ ClassImp(TXMLFile);
 ////////////////////////////////////////////////////////////////////////////////
 /// default TXMLFile constructor
 
-TXMLFile::TXMLFile() : TFile(), TXMLSetup(), fDoc(0), fStreamerInfoNode(0), fXML(0), fKeyCounter(0)
+TXMLFile::TXMLFile() : TFile(), TXMLSetup(), fDoc(nullptr), fStreamerInfoNode(nullptr), fXML(nullptr), fKeyCounter(0)
 {
    SetBit(kBinaryFile, kFALSE);
    fIOVersion = TXMLFile::Class_Version();
@@ -120,10 +120,10 @@ TXMLFile::TXMLFile() : TFile(), TXMLSetup(), fDoc(0), fStreamerInfoNode(0), fXML
 ///
 /// For more details see comments for TFile::TFile() constructor
 ///
-/// For a moment TXMLFile does not support TTree objects and subdirectories
+/// TXMLFile does not support TTree objects
 
 TXMLFile::TXMLFile(const char *filename, Option_t *option, const char *title, Int_t compression)
-   : TFile(), TXMLSetup(), fDoc(0), fStreamerInfoNode(0), fXML(0), fKeyCounter(0)
+   : TFile(), TXMLSetup(), fDoc(nullptr), fStreamerInfoNode(nullptr), fXML(nullptr), fKeyCounter(0)
 {
    fXML = new TXMLEngine();
 
@@ -133,7 +133,7 @@ TXMLFile::TXMLFile(const char *filename, Option_t *option, const char *title, In
    if (filename && !strncmp(filename, "xml:", 4))
       filename += 4;
 
-   gDirectory = 0;
+   gDirectory = nullptr;
    SetName(filename);
    SetTitle(title);
    TDirectoryFile::Build(this, 0);
@@ -178,7 +178,7 @@ TXMLFile::TXMLFile(const char *filename, Option_t *option, const char *title, In
    }
 
    Bool_t devnull = kFALSE;
-   const char *fname = 0;
+   const char *fname = nullptr;
 
    if (!filename || !filename[0]) {
       Error("TXMLFile", "file name is not specified");
@@ -280,7 +280,7 @@ void TXMLFile::InitXmlFile(Bool_t create)
 
    if (create) {
       fDoc = fXML->NewDoc();
-      XMLNodePointer_t fRootNode = fXML->NewChild(0, 0, xmlio::Root, 0);
+      XMLNodePointer_t fRootNode = fXML->NewChild(nullptr, nullptr, xmlio::Root);
       fXML->DocSetRootElement(fDoc, fRootNode);
    } else {
       ReadFromFile();
@@ -293,9 +293,9 @@ void TXMLFile::InitXmlFile(Bool_t create)
    cd();
 
    fNProcessIDs = 0;
-   TKey *key = 0;
+   TKey *key = nullptr;
    TIter iter(fKeys);
-   while ((key = (TKey *)iter()) != 0) {
+   while ((key = (TKey *)iter()) != nullptr) {
       if (!strcmp(key->GetClassName(), "TProcessID"))
          fNProcessIDs++;
    }
@@ -476,7 +476,7 @@ void TXMLFile::ProduceFileNames(const char *filename, TString &fname, TString &d
 
 void TXMLFile::SaveToFile()
 {
-   if (fDoc == 0)
+   if (!fDoc)
       return;
 
    if (gDebug > 1)
@@ -485,25 +485,25 @@ void TXMLFile::SaveToFile()
    XMLNodePointer_t fRootNode = fXML->DocGetRootElement(fDoc);
 
    fXML->FreeAttr(fRootNode, xmlio::Setup);
-   fXML->NewAttr(fRootNode, 0, xmlio::Setup, GetSetupAsString());
+   fXML->NewAttr(fRootNode, nullptr, xmlio::Setup, GetSetupAsString());
 
    fXML->FreeAttr(fRootNode, xmlio::Ref);
-   fXML->NewAttr(fRootNode, 0, xmlio::Ref, xmlio::Null);
+   fXML->NewAttr(fRootNode, nullptr, xmlio::Ref, xmlio::Null);
 
    if (GetIOVersion() > 1) {
 
       fXML->FreeAttr(fRootNode, xmlio::CreateTm);
-      fXML->NewAttr(fRootNode, 0, xmlio::CreateTm, fDatimeC.AsSQLString());
+      fXML->NewAttr(fRootNode, nullptr, xmlio::CreateTm, fDatimeC.AsSQLString());
 
       fXML->FreeAttr(fRootNode, xmlio::ModifyTm);
-      fXML->NewAttr(fRootNode, 0, xmlio::ModifyTm, fDatimeM.AsSQLString());
+      fXML->NewAttr(fRootNode, nullptr, xmlio::ModifyTm, fDatimeM.AsSQLString());
 
       fXML->FreeAttr(fRootNode, xmlio::ObjectUUID);
-      fXML->NewAttr(fRootNode, 0, xmlio::ObjectUUID, fUUID.AsString());
+      fXML->NewAttr(fRootNode, nullptr, xmlio::ObjectUUID, fUUID.AsString());
 
       fXML->FreeAttr(fRootNode, xmlio::Title);
       if (strlen(GetTitle()) > 0)
-         fXML->NewAttr(fRootNode, 0, xmlio::Title, GetTitle());
+         fXML->NewAttr(fRootNode, nullptr, xmlio::Title, GetTitle());
 
       fXML->FreeAttr(fRootNode, xmlio::IOVersion);
       fXML->NewIntAttr(fRootNode, xmlio::IOVersion, GetIOVersion());
@@ -517,8 +517,8 @@ void TXMLFile::SaveToFile()
 
    /*
       TIter iter(GetListOfKeys());
-      TKeyXML* key = 0;
-      while ((key=(TKeyXML*)iter()) !=0)
+      TKeyXML* key = nullptr;
+      while ((key=(TKeyXML*)iter()) != nullptr)
          fXML->AddChild(fRootNode, key->KeyNode());
    */
 
@@ -534,7 +534,7 @@ void TXMLFile::SaveToFile()
    fXML->SaveDoc(fDoc, fname, layout);
 
    /*   iter.Reset();
-      while ((key=(TKeyXML*)iter()) !=0)
+      while ((key=(TKeyXML*)iter()) != nullptr)
          fXML->UnlinkNode(key->KeyNode());
    */
    CombineNodesTree(this, fRootNode, kFALSE);
@@ -548,13 +548,13 @@ void TXMLFile::SaveToFile()
 
 void TXMLFile::CombineNodesTree(TDirectory *dir, XMLNodePointer_t topnode, Bool_t dolink)
 {
-   if (dir == 0)
+   if (!dir)
       return;
 
    TIter iter(dir->GetListOfKeys());
-   TKeyXML *key = 0;
+   TKeyXML *key = nullptr;
 
-   while ((key = (TKeyXML *)iter()) != 0) {
+   while ((key = (TKeyXML *)iter()) != nullptr) {
       if (dolink)
          fXML->AddChild(topnode, key->KeyNode());
       else
@@ -573,14 +573,14 @@ void TXMLFile::CombineNodesTree(TDirectory *dir, XMLNodePointer_t topnode, Bool_
 Bool_t TXMLFile::ReadFromFile()
 {
    fDoc = fXML->ParseFile(fRealName);
-   if (fDoc == 0)
+   if (!fDoc)
       return kFALSE;
 
    XMLNodePointer_t fRootNode = fXML->DocGetRootElement(fDoc);
 
-   if ((fRootNode == 0) || !fXML->ValidateVersion(fDoc)) {
+   if (!fRootNode || !fXML->ValidateVersion(fDoc)) {
       fXML->FreeDoc(fDoc);
-      fDoc = 0;
+      fDoc = nullptr;
       return kFALSE;
    }
 
@@ -614,20 +614,20 @@ Bool_t TXMLFile::ReadFromFile()
 
    fStreamerInfoNode = fXML->GetChild(fRootNode);
    fXML->SkipEmpty(fStreamerInfoNode);
-   while (fStreamerInfoNode != 0) {
+   while (fStreamerInfoNode) {
       if (strcmp(xmlio::SInfos, fXML->GetNodeName(fStreamerInfoNode)) == 0)
          break;
       fXML->ShiftToNext(fStreamerInfoNode);
    }
    fXML->UnlinkNode(fStreamerInfoNode);
 
-   if (fStreamerInfoNode != 0)
+   if (fStreamerInfoNode)
       ReadStreamerInfo();
 
    if (IsUseDtd())
       if (!fXML->ValidateDocument(fDoc, gDebug > 0)) {
          fXML->FreeDoc(fDoc);
-         fDoc = 0;
+         fDoc = nullptr;
          return kFALSE;
       }
 
@@ -643,14 +643,14 @@ Bool_t TXMLFile::ReadFromFile()
 
 Int_t TXMLFile::ReadKeysList(TDirectory *dir, XMLNodePointer_t topnode)
 {
-   if ((dir == 0) || (topnode == 0))
+   if (!dir || !topnode)
       return 0;
 
    Int_t nkeys = 0;
 
    XMLNodePointer_t keynode = fXML->GetChild(topnode);
    fXML->SkipEmpty(keynode);
-   while (keynode != 0) {
+   while (keynode) {
       XMLNodePointer_t next = fXML->GetNext(keynode);
 
       if (strcmp(xmlio::Xmlkey, fXML->GetNodeName(keynode)) == 0) {
@@ -679,7 +679,7 @@ void TXMLFile::WriteStreamerInfo()
 {
    if (fStreamerInfoNode) {
       fXML->FreeNode(fStreamerInfoNode);
-      fStreamerInfoNode = 0;
+      fStreamerInfoNode = nullptr;
    }
 
    if (!IsStoreStreamerInfos())
@@ -689,9 +689,9 @@ void TXMLFile::WriteStreamerInfo()
 
    TIter iter(gROOT->GetListOfStreamerInfo());
 
-   TStreamerInfo *info = 0;
+   TStreamerInfo *info = nullptr;
 
-   while ((info = (TStreamerInfo *)iter()) != 0) {
+   while ((info = (TStreamerInfo *)iter()) != nullptr) {
       Int_t uid = info->GetNumber();
       if (fClassIndex->fArray[uid])
          list.Add(info);
@@ -700,26 +700,25 @@ void TXMLFile::WriteStreamerInfo()
    if (list.GetSize() == 0)
       return;
 
-   fStreamerInfoNode = fXML->NewChild(0, 0, xmlio::SInfos);
+   fStreamerInfoNode = fXML->NewChild(nullptr, nullptr, xmlio::SInfos);
    for (int n = 0; n <= list.GetLast(); n++) {
       info = (TStreamerInfo *)list.At(n);
 
-      XMLNodePointer_t infonode = fXML->NewChild(fStreamerInfoNode, 0, "TStreamerInfo");
+      XMLNodePointer_t infonode = fXML->NewChild(fStreamerInfoNode, nullptr, "TStreamerInfo");
 
-      fXML->NewAttr(infonode, 0, "name", info->GetName());
-      fXML->NewAttr(infonode, 0, "title", info->GetTitle());
+      fXML->NewAttr(infonode, nullptr, "name", info->GetName());
+      fXML->NewAttr(infonode, nullptr, "title", info->GetTitle());
 
       fXML->NewIntAttr(infonode, "v", info->IsA()->GetClassVersion());
       fXML->NewIntAttr(infonode, "classversion", info->GetClassVersion());
-      fXML->NewAttr(infonode, 0, "canoptimize",
+      fXML->NewAttr(infonode, nullptr, "canoptimize",
                     (info->TestBit(TStreamerInfo::kCannotOptimize) ? xmlio::False : xmlio::True));
       fXML->NewIntAttr(infonode, "checksum", info->GetCheckSum());
 
       TIter iter2(info->GetElements());
-      TStreamerElement *elem = 0;
-      while ((elem = (TStreamerElement *)iter2()) != 0) {
+      TStreamerElement *elem = nullptr;
+      while ((elem = (TStreamerElement *)iter2()) != nullptr)
          StoreStreamerElement(infonode, elem);
-      }
    }
 }
 
@@ -729,15 +728,15 @@ void TXMLFile::WriteStreamerInfo()
 
 TList *TXMLFile::GetStreamerInfoList()
 {
-   if (fStreamerInfoNode == 0)
-      return 0;
+   if (!fStreamerInfoNode)
+      return nullptr;
 
    TList *list = new TList();
 
    XMLNodePointer_t sinfonode = fXML->GetChild(fStreamerInfoNode);
    fXML->SkipEmpty(sinfonode);
 
-   while (sinfonode != 0) {
+   while (sinfonode) {
       if (strcmp("TStreamerInfo", fXML->GetNodeName(sinfonode)) == 0) {
          TString fname = fXML->GetAttr(sinfonode, "name");
          TString ftitle = fXML->GetAttr(sinfonode, "title");
@@ -754,14 +753,14 @@ TList *TXMLFile::GetStreamerInfoList()
          info->SetCheckSum(checksum);
 
          const char *canoptimize = fXML->GetAttr(sinfonode, "canoptimize");
-         if ((canoptimize == 0) || (strcmp(canoptimize, xmlio::False) == 0))
+         if (!canoptimize || (strcmp(canoptimize, xmlio::False) == 0))
             info->SetBit(TStreamerInfo::kCannotOptimize);
          else
             info->ResetBit(TStreamerInfo::kCannotOptimize);
 
          XMLNodePointer_t node = fXML->GetChild(sinfonode);
          fXML->SkipEmpty(node);
-         while (node != 0) {
+         while (node) {
             ReadStreamerElement(node, info);
             fXML->ShiftToNext(node);
          }
@@ -781,20 +780,20 @@ void TXMLFile::StoreStreamerElement(XMLNodePointer_t infonode, TStreamerElement 
 {
    TClass *cl = elem->IsA();
 
-   XMLNodePointer_t node = fXML->NewChild(infonode, 0, cl->GetName());
+   XMLNodePointer_t node = fXML->NewChild(infonode, nullptr, cl->GetName());
 
    char sbuf[100], namebuf[100];
 
-   fXML->NewAttr(node, 0, "name", elem->GetName());
+   fXML->NewAttr(node, nullptr, "name", elem->GetName());
    if (strlen(elem->GetTitle()) > 0)
-      fXML->NewAttr(node, 0, "title", elem->GetTitle());
+      fXML->NewAttr(node, nullptr, "title", elem->GetTitle());
 
    fXML->NewIntAttr(node, "v", cl->GetClassVersion());
 
    fXML->NewIntAttr(node, "type", elem->GetType());
 
    if (strlen(elem->GetTypeName()) > 0)
-      fXML->NewAttr(node, 0, "typename", elem->GetTypeName());
+      fXML->NewAttr(node, nullptr, "typename", elem->GetTypeName());
 
    fXML->NewIntAttr(node, "size", elem->GetSize());
 
@@ -810,19 +809,19 @@ void TXMLFile::StoreStreamerElement(XMLNodePointer_t infonode, TStreamerElement 
    if (cl == TStreamerBase::Class()) {
       TStreamerBase *base = (TStreamerBase *)elem;
       sprintf(sbuf, "%d", base->GetBaseVersion());
-      fXML->NewAttr(node, 0, "baseversion", sbuf);
+      fXML->NewAttr(node, nullptr, "baseversion", sbuf);
       sprintf(sbuf, "%d", base->GetBaseCheckSum());
-      fXML->NewAttr(node, 0, "basechecksum", sbuf);
+      fXML->NewAttr(node, nullptr, "basechecksum", sbuf);
    } else if (cl == TStreamerBasicPointer::Class()) {
       TStreamerBasicPointer *bptr = (TStreamerBasicPointer *)elem;
       fXML->NewIntAttr(node, "countversion", bptr->GetCountVersion());
-      fXML->NewAttr(node, 0, "countname", bptr->GetCountName());
-      fXML->NewAttr(node, 0, "countclass", bptr->GetCountClass());
+      fXML->NewAttr(node, nullptr, "countname", bptr->GetCountName());
+      fXML->NewAttr(node, nullptr, "countclass", bptr->GetCountClass());
    } else if (cl == TStreamerLoop::Class()) {
       TStreamerLoop *loop = (TStreamerLoop *)elem;
       fXML->NewIntAttr(node, "countversion", loop->GetCountVersion());
-      fXML->NewAttr(node, 0, "countname", loop->GetCountName());
-      fXML->NewAttr(node, 0, "countclass", loop->GetCountClass());
+      fXML->NewAttr(node, nullptr, "countname", loop->GetCountName());
+      fXML->NewAttr(node, nullptr, "countclass", loop->GetCountClass());
    } else if ((cl == TStreamerSTL::Class()) || (cl == TStreamerSTLstring::Class())) {
       TStreamerSTL *stl = (TStreamerSTL *)elem;
       fXML->NewIntAttr(node, "STLtype", stl->GetSTLtype());
@@ -836,7 +835,7 @@ void TXMLFile::StoreStreamerElement(XMLNodePointer_t infonode, TStreamerElement 
 void TXMLFile::ReadStreamerElement(XMLNodePointer_t node, TStreamerInfo *info)
 {
    TClass *cl = TClass::GetClass(fXML->GetNodeName(node));
-   if ((cl == 0) || !cl->InheritsFrom(TStreamerElement::Class()))
+   if (!cl || !cl->InheritsFrom(TStreamerElement::Class()))
       return;
 
    TStreamerElement *elem = (TStreamerElement *)cl->New();
@@ -975,7 +974,7 @@ void TXMLFile::SetUseNamespaces(Bool_t iUseNamespaces)
 
 Bool_t TXMLFile::AddXmlComment(const char *comment)
 {
-   if (!IsWritable() || (fXML == 0))
+   if (!IsWritable() || !fXML)
       return kFALSE;
 
    return fXML->AddDocComment(fDoc, comment);
@@ -994,7 +993,7 @@ Bool_t TXMLFile::AddXmlComment(const char *comment)
 Bool_t TXMLFile::AddXmlStyleSheet(const char *href, const char *type, const char *title, int alternate,
                                   const char *media, const char *charset)
 {
-   if (!IsWritable() || (fXML == 0))
+   if (!IsWritable() || !fXML)
       return kFALSE;
 
    return fXML->AddDocStyleSheet(fDoc, href, type, title, alternate, media, charset);
@@ -1009,7 +1008,7 @@ Bool_t TXMLFile::AddXmlStyleSheet(const char *href, const char *type, const char
 
 Bool_t TXMLFile::AddXmlLine(const char *line)
 {
-   if (!IsWritable() || (fXML == 0))
+   if (!IsWritable() || !fXML)
       return kFALSE;
 
    return fXML->AddDocRawLine(fDoc, line);
@@ -1021,7 +1020,7 @@ Bool_t TXMLFile::AddXmlLine(const char *line)
 Long64_t TXMLFile::DirCreateEntry(TDirectory *dir)
 {
    TDirectory *mother = dir->GetMotherDir();
-   if (mother == 0)
+   if (!mother)
       mother = this;
 
    TKeyXML *key = new TKeyXML(mother, ++fKeyCounter, dir, dir->GetName(), dir->GetTitle());
@@ -1037,21 +1036,21 @@ Long64_t TXMLFile::DirCreateEntry(TDirectory *dir)
 TKeyXML *TXMLFile::FindDirKey(TDirectory *dir)
 {
    TDirectory *motherdir = dir->GetMotherDir();
-   if (motherdir == 0)
+   if (!motherdir)
       motherdir = this;
 
    TIter next(motherdir->GetListOfKeys());
-   TObject *obj = 0;
+   TObject *obj = nullptr;
 
-   while ((obj = next()) != 0) {
+   while ((obj = next()) != nullptr) {
       TKeyXML *key = dynamic_cast<TKeyXML *>(obj);
 
-      if (key != 0)
+      if (key)
          if (key->GetKeyId() == dir->GetSeekDir())
             return key;
    }
 
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1059,20 +1058,20 @@ TKeyXML *TXMLFile::FindDirKey(TDirectory *dir)
 
 TDirectory *TXMLFile::FindKeyDir(TDirectory *motherdir, Long64_t keyid)
 {
-   if (motherdir == 0)
+   if (!motherdir)
       motherdir = this;
 
    TIter next(motherdir->GetList());
-   TObject *obj = 0;
+   TObject *obj = nullptr;
 
-   while ((obj = next()) != 0) {
+   while ((obj = next()) != nullptr) {
       TDirectory *dir = dynamic_cast<TDirectory *>(obj);
-      if (dir != 0)
+      if (dir)
          if (dir->GetSeekDir() == keyid)
             return dir;
    }
 
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1082,7 +1081,7 @@ TDirectory *TXMLFile::FindKeyDir(TDirectory *motherdir, Long64_t keyid)
 Int_t TXMLFile::DirReadKeys(TDirectory *dir)
 {
    TKeyXML *key = FindDirKey(dir);
-   if (key == 0)
+   if (!key)
       return 0;
 
    return ReadKeysList(dir, key->KeyNode());
@@ -1094,11 +1093,11 @@ Int_t TXMLFile::DirReadKeys(TDirectory *dir)
 void TXMLFile::DirWriteKeys(TDirectory *)
 {
    TIter next(GetListOfKeys());
-   TObject *obj = 0;
+   TObject *obj = nullptr;
 
-   while ((obj = next()) != 0) {
+   while ((obj = next()) != nullptr) {
       TKeyXML *key = dynamic_cast<TKeyXML *>(obj);
-      if (key != 0)
+      if (key)
          key->UpdateAttributes();
    }
 }
@@ -1109,6 +1108,6 @@ void TXMLFile::DirWriteKeys(TDirectory *)
 void TXMLFile::DirWriteHeader(TDirectory *dir)
 {
    TKeyXML *key = FindDirKey(dir);
-   if (key != 0)
+   if (key)
       key->UpdateObject(dir);
 }

--- a/io/xml/src/TXMLPlayer.cxx
+++ b/io/xml/src/TXMLPlayer.cxx
@@ -12,7 +12,7 @@
 //________________________________________________________________________
 //
 // Class for xml code generation
-// It should be used for generation of xml steramers, which could be used outside root
+// It should be used for generation of xml streamers, which could be used outside root
 // environment. This means, that with help of such streamers user can read and write
 // objects from/to xml file, which later can be accepted by ROOT.
 //
@@ -23,7 +23,7 @@
 //
 // 1. ROOT library with required classes should be created.
 //    In general, without such library non of user objects can be stored and
-//    retrived from any ROOT file
+//    retrieved from any ROOT file
 //
 // 2. Generate xml streamers by root script like:
 //
@@ -41,7 +41,7 @@
 //
 //  3. Copy "streamers.h", "streamers.cxx", "TXmlFile.h", "TXmlFile.cxx" files
 //     to user project and compile them. TXmlFile class implementation can be taken
-//     from http://www-linux.gsi.de/~linev/xmlfile.tar.gz
+//     from http://web-docs.gsi.de/~linev/xmlfile.tar.gz
 //
 // TXMLPlayer class generates one function per class, which called class streamer.
 // Name of such function for class TExample will be TExample_streamer.
@@ -63,13 +63,13 @@
 // If data member of class is private or protected, it can not be accessed via
 // member name. Two alternative way is supported. First, if for class member fValue
 // exists function GetValue(), it will be used to get value from the class, and if
-// exists SetValue(), it will be used to set apropriate data member. Names of setter
+// exists SetValue(), it will be used to set appropriate data member. Names of setter
 // and getter methods can be specified in comments filed like:
 //
 //     int  fValue;   // *OPTION={GetMethod="GetV";SetMethod="SetV"}
 //
 // If getter or setter methods does not available, address to data member will be
-// calculated as predefined offeset to object start address. In that case generated code
+// calculated as predefined offset to object start address. In that case generated code
 // should be used only on the same platform (OS + compiler), where it was generated.
 //
 // Generated streamers resolve inheritance tree for given class. This allows to have
@@ -93,7 +93,7 @@
 //        outfile.Close();
 //
 // Complete example for generating and using of external xml streamers can be taken from
-// http://www-linux.gsi.de/~linev/xmlreader.tar.gz
+// http://www-docs.gsi.de/~linev/xmlreader.tar.gz
 //
 // Any bug reports and requests for additional functionality are welcome.
 //


### PR DESCRIPTION
Remove dependency from TBufferFile.
Now simply duplicate some code from TBufferFile in TBufferXML.
This is last version, which is fully compatible with previous XML I/O.

Next steps - introduce TBufferText class, which will be base for JSON and XML classes.
Several methods will be shared between these two classes.
And both XML and JSON will use text actions for objects streaming, 
which may lead into incompatible changes in XML format. 
