### PR TITLE
Fix ROOT-9030

### DIFF
--- a/tutorials/hist/candledecay.C
+++ b/tutorials/hist/candledecay.C
@@ -12,13 +12,13 @@ void candledecay()
 {
    TCanvas *c1 = new TCanvas("c1","Candle Decay",800,600);
    c1->Divide(2,1);
-   TRandom *rand = new TRandom();
+   TRandom *r0 = new TRandom();
    TH2I *h1 = new TH2I("h1","Decay",1000,0,1000,20,0,20);
 
    float myRand;
    for (int i = 0; i < 19; i++) {
       for (int j = 0; j < 1000000; j++) {
-         myRand = rand->Gaus(350+i*8,20+2*i);
+         myRand = r0->Gaus(350+i*8,20+2*i);
          h1->Fill(myRand,i);
       }
    }

--- a/tutorials/hist/candlehisto.C
+++ b/tutorials/hist/candlehisto.C
@@ -13,14 +13,14 @@ void candlehisto()
    TCanvas *c1 = new TCanvas("c1", "Candle Presets", 800, 600);
    c1->Divide(3, 2);
 
-   TRandom *rand = new TRandom();
+   TRandom *r0 = new TRandom();
    TH2I *h1 = new TH2I("h1", "Sin", 18, 0, 360, 100, -1.5, 1.5);
    h1->GetXaxis()->SetTitle("Deg");
 
    float myRand;
    for (int i = 0; i < 360; i+= 10) {
       for (int j = 0; j < 100; j++) {
-         myRand = rand->Gaus(sin(i * 3.14 / 180), 0.2);
+         myRand = r0->Gaus(sin(i * 3.14 / 180), 0.2);
          h1->Fill(i, myRand);
       }
    }

--- a/tutorials/hist/candleplot.C
+++ b/tutorials/hist/candleplot.C
@@ -11,7 +11,7 @@
 void candleplot() {
 
    gStyle->SetTimeOffset(0);
-   TRandom *rand = new TRandom();
+   TRandom *r0 = new TRandom();
    TDatime *dateBegin = new TDatime(2010,1,1,0,0,0);
    TDatime *dateEnd = new TDatime(2011,1,1,0,0,0);
 
@@ -25,8 +25,8 @@ void candleplot() {
    float Rand;
    for (int i = dateBegin->Convert(); i < dateEnd->Convert(); i+=86400*30) {
       for (int j = 0; j < 1000; j++) {
-         Rand = rand->Gaus(500+sin(i/10000000.)*100,50); h1->Fill(i,Rand);
-         Rand = rand->Gaus(500+sin(i/11000000.)*100,70); h2->Fill(i,Rand);
+         Rand = r0->Gaus(500+sin(i/10000000.)*100,50); h1->Fill(i,Rand);
+         Rand = r0->Gaus(500+sin(i/11000000.)*100,70); h2->Fill(i,Rand);
       }
    }
 
@@ -45,5 +45,5 @@ void candleplot() {
    h1->Draw("candle2");
    h2->Draw("candle3 same");
 
-   gPad->BuildLegend(0.78,0.695,0.980,0.935,"","f");
+   gPad->BuildLegend(0.78,0.695,0.980,0.935,"");
 }

--- a/tutorials/hist/histpalettecolor.C
+++ b/tutorials/hist/histpalettecolor.C
@@ -30,10 +30,10 @@ void histpalettecolor()
    TH1F *h4 = new TH1F ("h4","Histogram drawn with full triangles down",100,-4,4);
    TH1F *h5 = new TH1F ("h5","Histogram drawn with empty circles",100,-4,4);
 
-   TRandom3 random;
+   TRandom3 r3;
    Double_t px,py;
    for (Int_t i = 0; i < 25000; i++) {
-      random.Rannor(px,py);
+      r3.Rannor(px,py);
       h1->Fill(px,10.);
       h2->Fill(px, 8.);
       h3->Fill(px, 6.);


### PR DESCRIPTION
Tutorial scripts uses 'rand' and 'random' keywords as a name for variables which causes many online notebooks to fail. Fixes ROOT-9030.

Details:
* https://root-forum.cern.ch/t/declaration-of-trandom-object-as-rand-causes-redefinition-error-when-running-interactively/26363
* https://root.cern/doc/v610/group__tutorial__hist.html
* https://sft.its.cern.ch/jira/browse/ROOT-9030