### PR TITLE
extend and update man pages

### DIFF
--- a/man/man1/hadd.1
+++ b/man/man1/hadd.1
@@ -27,13 +27,13 @@ For extensive documentation on the \fBROOT\fR system, see
 .UE
 .PP
 A \fBUsers Guide\fR is available from
-.UR http://root.cern.ch/root/UsersGuide.html
+.UR https://root.cern.ch/root/htmldoc/guides/users-guide/ROOTUsersGuide.html
 here.
 .UE
 .PP
 The classes of ROOT are all documented by the automatic documentation
 system, and is available
-.UR http://root.cern.ch/root/html/ClassIndex.html
+.UR https://root.cern/doc/master/annotated.html
 online.
 .UE
 .SH "ORIGINAL AUTHORS"

--- a/man/man1/root-config.1
+++ b/man/man1/root-config.1
@@ -10,20 +10,22 @@ root-config \- ROOT utility for your Makefiles
 .B root-config
 .I "[options]"
 .SH "DESCRIPTION"
-Put lines like 
+\fIroot-config\fP is a tool that is used to configure to determine
+the compiler and linker flags that should be used to compile
+and link programs that use \fIROOT\fP.
 .RS 
 .nf 
 
-CFLAGS = $(shell root-config \-\-cflags)
-LIBS   = $(shell root-config \-\-libs)
-GLIBS  = $(shell root-config \-\-glibs)
+CPPFLAGS  += $(shell root-config \-\-cflags)
+LDLIBS    += $(shell root-config \-\-libs)
+LDFLAGS   += $(shell root-config \-\-ldflags)
 
 %Cint.cxx:Include.h LinkDef.h
         rootcint \-f $@ \-c $^ 
 
 .fi
 .RE
-in you Makefile.
+in you Makefile to use the built-in rules of gnu make. For GUIs, replace \fI\-\-libs\fR by \fI\-\-glibs\fR.
 .PP
 You may also find the \fIautomake\fR(1), \fIautoconf\fR(1), and
 \fIlibtool\fR(1) macro file \fI/usr/share/aclocal/root.m4\fR
@@ -174,11 +176,14 @@ Output a line suitable for linking a program agains the \fBROOT\fR
 libraries. No graphics libraries are output. 
 .TP
 .B \-\-glibs
-As above, but also output for the graphics libraries. 
+As above, but also output for the graphics (GUI) libraries. 
+.TP
+.B \-\-evelibs
+As above, but also output for the graphics libraries and Eve libraries.
 .TP
 .B \-\-cflags
-Output a line suitable for compiling a source file againd the
-\fBROOT\fR header (class declararion) files. 
+Output a line suitable for compiling a source file against the
+\fBROOT\fR header (class declararion) files.
 .TP
 .B \-\-new 
 Put the \fBlibNew.so\fR library in the library lists.  This option
@@ -201,8 +206,53 @@ Do not print auxiliary compiler flags in the output of
 \fB\-\-cflags\fR.
 .TP
 .B \-\-noldflags
-Do not print library path link option in output of \fB\-\-libs\fR and
+Do not print library path link option in output of \fB\-\-libs\fR, \fB\-\-evelibs\fR and
 \fB\-\-glibs\fR. 
+.TP
+.B \-\-ldflags
+Print additional linker flags (eg. \fB\-m64\fR)
+.TP
+.B \-\-arch
+Print the architecture (compiler/OS)
+.TP
+.B \-\-platform
+Print the platform (OS)
+.TP
+.B \-\-bindir
+Print the binary directory of the root installation (location of the root executable)
+.TP
+.B \-\-etcdir
+Print the configuration directory (place of system.rootrc, mime type, valgrind suppression files and .desktop files)
+.TP
+.B \-\-config
+Print arguments used for ./configure as used when building root. These cannot be used for ./configure if root was built with CMake.
+.TP
+.B \-\-git-revision
+Print the ROOT git revision number from which root was built.
+.TP
+.B \-\-has-<feature>
+Test if <feature> has been enabled in the build process.
+.TP
+.B \-\-features
+Print list of all supported features
+.TP
+.B \-\-ncpu
+Print number of available (hyperthreaded) cores
+.TP
+.B \-\-python-version
+Print the Python version used by ROOT
+.TP
+.B \-\-cc
+Print alternative C compiler specified when ROOT was built
+.TP
+.B \-\-cxx
+Print alternative C++ compiler specified when ROOT was built
+.TP
+.B \-\-f77
+Print alternative Fortran compiler specified when ROOT was built
+.TP
+.B \-\-ld
+Print alternative Linker specified when ROOT was built
 .SH "SEE ALSO"
 \fIroot\fR(1), \fIroot-cint\fR(1)
 .PP

--- a/man/man1/root.1
+++ b/man/man1/root.1
@@ -7,8 +7,26 @@
 .SH NAME
 root \- Interpretor of C++ for the ROOT framework
 .SH SYNOPSIS
-.B root
-.I "[options] files ..."
+.SY root
+.OP options
+.OP -e 'expression'
+.RI [ datafile\~ .\|.\|.]
+.RI [ macrofile\~ .\|.\|.]
+.SY root
+.RI macrofile.C
+.SY root
+.RI macrofile.C(arguments\~.\|.\|.)
+.SY root
+.RI macrofile.C(\\\(dqstring\~arguments\\\(dq)
+.SY root
+.RI macrofile.C+
+.SY root
+.RI macrofile.C++
+.SY root
+.RI macrofile.C+g
+.SY root
+.RI macrofile.C+O
+.YS
 .SH "DESCRIPTION"
 \fBR\fROOTs \fBO\fRbject-\fBO\fRriented \fBT\fRechnologies.
 .PP
@@ -18,12 +36,12 @@ is a interactive interpretor of C++ code. It uses the
 framework. For more information on
 .BR ROOT ,
 please refer to
-.UR   http://root.cern.ch
-\fIhttp://root.cern.ch\fR.
+.UR http://root.cern.ch
+.UE .
 .PP
-An extensive \fIUsers Guide\fR is available from that site.
+An extensive \fIUsers Guide\fR is available from that site (see below).
 .SH OPTIONS
-.B \-?
+.B \-?, -h, --help
 Show summary of options.
 .TP
 .B -b
@@ -36,11 +54,26 @@ Execute the command passed between single quotes
 Do not execute logon and logoff macros as specified in
 .B .rootrc
 .TP
+.B --notebook
+execute ROOT notebook
+.TP
+.B -t
+enable thread-safety and implicit multi-threading (IMT)
+.TP
 .B -q
 Exit after processing command line macro files
 .TP
 .B -l
 Do not show splash screen
+.PP
+\fIData files\fR are opened and accessible in root as \fI_file0\fR, \fI_file1\fR ...
+.PP
+\fIMacro files\fR are either intrepreted (filename provided alone) or compiled (with + added to the filename).
+Afterwards the function with the same name as the filename (without extension) in the macro file is executed (eg. \fIvoid macro()\fR in a file \fImacro.C\fR).
+.PP
+Compilation is done on-demand if the macro is newer than a previously generated shared library. Two plus signs (macro.C++) force a recompilation. Adding \fIO\fR after a plus results in an optimised build, adding \fIg\fR adds debug symbols (eg. \fImacro.C+Og\fR).
+.PP
+Macro files, data files and \fI-e\fR expressions are processed in the order in which they are provided. If a macro relies on the presence of \fI_file0\fR, then root should be called with \fIroot data.root macro.C\fR.
 .SH "SEE ALSO"
 .SB
 \fIrootcling\fR(1), \fIcling\fR(1), \fIroot-config\fR(1),
@@ -48,34 +81,44 @@ Do not show splash screen
 .PP
 For extensive documentation on the \fBROOT\fR system, see
 .UR http://root.cern.ch
-\fIhttp://root.cern.ch\fR
-.UE
+.UE .
 .PP
-A \fBUsers Guide\fR is available
-.UR http://root.cern.ch/root/UsersGuide.html
-online.
-.UE
+A \fBUsers Guide\fR is available at
+.UR http://root.cern.ch/root/htmldoc/guides/users-guide/ROOTUsersGuide.html
+.UE .
 .PP
 The classes of ROOT are all documented by the automatic documentation
-system, and is available
-.UR http://root.cern.ch/root/html/ClassIndex.html
-online.
+system, and is available at
+.UR https://root.cern/doc/master/annotated.html
+.UE .
+.PP
+Questions and support are provided in
+.UR https://root-forum.cern.ch/
+the root forum
+.UE ,
+bugs can be reported
+.UR https://sft.its.cern.ch/jira/projects/ROOT/issues
+on jira
 .UE
+and pull requests can be submitted
+.UR https://github.com/root-project/root
+on github
+.UE .
 .SH FILES
 .TP
 <\fIetcdir\fR>/\fBsystem.rootrc\fR
-System-wide configuration file. <\fIetcdir\fR> either ROOTSYS, or
+System-wide configuration file. <\fIetcdir\fR> either $ROOTSYS, or
 something like \fB/etc/root\fR
 .TP
 <\fIlibdir\fR>/*\fR
 .B ROOT
-C++ class libraries. <\fIlibdir\fR> is either ROOTSYS/lib or something
+C++ class libraries. <\fIlibdir\fR> is either $ROOTSYS/lib or something
 like \fB/usr/lib/root\fR.
 .TP
 <\fIincdir\fR>/*\fR
 The header files for the
 .B ROOT
-C++ class libraries. <\fIincdir\fR> is either ROOTSYS/include or
+C++ class libraries. <\fIincdir\fR> is either $ROOTSYS/include or
 something like \fB/usr/include/root\fR.
 .TP
 \fB~/.rootrc\fR, \fB./.rootrc\fR

--- a/man/man1/roota.1
+++ b/man/man1/roota.1
@@ -50,13 +50,13 @@ For extensive documentation on the \fBROOT\fR system, see
 .UE
 .IP *
 A \fBUsers Guide\fR is available from
-.UR http://root.cern.ch/root/UsersGuide.html
+.UR https://root.cern.ch/root/htmldoc/guides/users-guide/ROOTUsersGuide.html
 \fIthe ROOT website\fR
 .UE
 .IP *
 The classes of ROOT are all documented by the automatic documentation
 system and is available
-.UR http://root.cern.ch/root/html/ClassIndex.html
+.UR https://root.cern/doc/master/annotated.html
 \fIonline\fR.
 .UE
 .SH FILES


### PR DESCRIPTION
 * replace ROOTSYS by $ROOTSYS
 * import new options for `root` and `root-config` from the current help messages
 * extended the explanation of `root` for macro compilation (`+`, `+O`, ...), combinations of macro and data files, combinations of macros with expressions
 * updated a few URLs
 * updated root-config explanation for Makefiles (adapting to built-in rules)

Please check, especially the third point is based my on my regular usage of root and not on the official documentation.