### PR TITLE
Fix Error Descriptor

### DIFF
--- a/tree/treeplayer/inc/TTreeReaderValue.h
+++ b/tree/treeplayer/inc/TTreeReaderValue.h
@@ -134,7 +134,7 @@ public:
 
    T* Get() {
       if (!fProxy){
-         Error("Get()", "Value reader not properly initialized, did you remember to call TTreeReader.Set(Next)Entry()?");
+         Error("TTreeReaderValue::Get()", "Value reader not properly initialized, did you remember to call TTreeReader.Set(Next)Entry()?");
          return 0;
       }
       void *address = GetAddress(); // Needed to figure out if it's a pointer


### PR DESCRIPTION
Fix Error Descriptor in `TTreeReaderValue::Get()` Function