### PR TITLE
[TDF] Fix ROOT-9122: if the regex does not match any column, throw

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -1683,6 +1683,15 @@ private:
          }
       }
 
+      if (selectedColumns.empty()) {
+         std::string text;
+         if (columnNameRegexp.empty()) {
+            text = "There is no column available to match.";
+         } else {
+            text = "Regex \"" + columnNameRegexp + "\" did not match any column.";
+         }
+         throw std::runtime_error(text);
+      }
       return selectedColumns;
    }
 

--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -671,7 +671,7 @@ public:
                                      std::string_view columnNameRegexp = "",
                                      const TSnapshotOptions &options = TSnapshotOptions())
    {
-      auto selectedColumns = ConvertRegexToColumns(columnNameRegexp);
+      auto selectedColumns = ConvertRegexToColumns(columnNameRegexp, "Snapshot");
       return Snapshot(treename, filename, selectedColumns, options);
    }
    // clang-format on
@@ -744,7 +744,7 @@ public:
    /// is empty, all columns are selected.
    TInterface<TLoopManager> Cache(std::string_view columnNameRegexp = "")
    {
-      auto selectedColumns = ConvertRegexToColumns(columnNameRegexp);
+      auto selectedColumns = ConvertRegexToColumns(columnNameRegexp, "Cache");
       return Cache(selectedColumns);
    }
 
@@ -1555,7 +1555,7 @@ public:
    ///
    /// An aggregator callable takes two values, an aggregator variable and a column value. The aggregator variable is
    /// initialized to aggIdentity or default-constructed if aggIdentity is omitted.
-   /// This action calls the aggregator callable for each processed entry, passing in the aggregator variable and 
+   /// This action calls the aggregator callable for each processed entry, passing in the aggregator variable and
    /// the value of the column columnName.
    /// If the signature is `U(U,T)` the aggregator variable is then copy-assigned the result of the execution of the callable.
    /// Otherwise the signature of aggregator must be `void(U&,T)`.
@@ -1637,7 +1637,7 @@ private:
       fValidCustomColumns.emplace_back(slotColName);
    }
 
-   ColumnNames_t ConvertRegexToColumns(std::string_view columnNameRegexp)
+   ColumnNames_t ConvertRegexToColumns(std::string_view columnNameRegexp, std::string_view callerName)
    {
       const auto theRegexSize = columnNameRegexp.size();
       std::string theRegex(columnNameRegexp);
@@ -1684,11 +1684,11 @@ private:
       }
 
       if (selectedColumns.empty()) {
-         std::string text;
+         std::string text(callerName);
          if (columnNameRegexp.empty()) {
-            text = "There is no column available to match.";
+            text = ": there is no column available to match.";
          } else {
-            text = "Regex \"" + columnNameRegexp + "\" did not match any column.";
+            text = ": regex \"" + columnNameRegexp + "\" did not match any column.";
          }
          throw std::runtime_error(text);
       }

--- a/tree/treeplayer/test/dataframe/dataframe_cache.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_cache.cxx
@@ -112,8 +112,8 @@ TEST(Cache, InternalColumnsSnapshot)
    TDataFrame tdf(2);
    auto f = 0.f;
    auto colName = "tdfMySecretcol_";
-   auto orig = tdf.Define(colName, [&f]() { return f++; });
-   auto cached = orig.Cache<float>({colName});
+   auto orig = tdf.Define(colName, [&f]() { return f++; }).Define("dummy", []() { return 0.f; });
+   auto cached = orig.Cache<float, float>({colName, "dummy"});
    auto snapshot = cached.Snapshot("t", "InternalColumnsSnapshot.root", "", {"RECREATE", ROOT::kZLIB, 0, 0, 99});
    int ret(1);
    try {

--- a/tree/treeplayer/test/dataframe/dataframe_snapshot.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_snapshot.cxx
@@ -100,6 +100,21 @@ protected:
 const std::vector<std::string> TDFSnapshotArrays::kFileNames = {"test_snapshotarray1.root", "test_snapshotarray2.root"};
 
 /********* SINGLE THREAD TESTS ***********/
+
+// Test for ROOT-9122
+TEST_F(TDFSnapshot, Snapshot_nocolumnmatch)
+{
+   TDataFrame d(1);
+   int ret(1);
+   try {
+      testing::internal::CaptureStderr();
+      d.Snapshot("t", "f.root", "x");
+   } catch (const std::runtime_error &e) {
+      ret = 0;
+   }
+   EXPECT_EQ(0, ret);
+}
+
 void test_snapshot_update(TInterface<TLoopManager> &tdf)
 {
    // test snapshotting two trees to the same file with two snapshots and the "UPDATE" option


### PR DESCRIPTION
in addition, adapt tests accordingly.