### PR TITLE
Use HTTPS for lcgpackages

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -2,7 +2,7 @@
 include(ExternalProject)
 include(FindPackageHandleStandardArgs)
 
-set(lcgpackages http://lcgpackages.web.cern.ch/lcgpackages/tarFiles/sources)
+set(lcgpackages https://lcgpackages.web.cern.ch/lcgpackages/tarFiles/sources)
 
 #---On MacOSX, try to find frameworks after standard libraries or headers------------
 set(CMAKE_FIND_FRAMEWORK LAST)


### PR DESCRIPTION
HTTPS seems to be supported just fine for this domain, but there's no 301/302 redirect from HTTP, so as-is this is simply enforcing plaintext on everyone who uses CMake to build, which is... not ideal.

The use of SHA256 checksums is a 👍, but doesn't nullify every benefit of using HTTPS where available.