### PR TITLE
Changing file's source code encoding to UTF-8

### DIFF
--- a/graf3d/eve/src/TEveTrans.cxx
+++ b/graf3d/eve/src/TEveTrans.cxx
@@ -212,7 +212,7 @@ void TEveTrans::SetupRotation(Int_t i, Int_t j, Double_t f)
 /// Input : from[3], to[3] which both must be *normalized* non-zero vectors
 /// Output: mtx[3][3] -- a 3x3 matrix in column-major form
 ///
-/// Authors: Tomas Möller, John Hughes
+/// Authors: Tomas MÃ¶ller, John Hughes
 ///          "Efficiently Building a Matrix to Rotate One Vector to Another"
 ///          Journal of Graphics Tools, 4(4):1-4, 1999
 


### PR DESCRIPTION
```
oksana@oksana-ThinkPad-E470:~/CERN_sources/root$ file graf3d/eve/src/TEveTrans.cxx 
graf3d/eve/src/TEveTrans.cxx: C source, ISO-8859 text
```

Tiny fix for sending coverage data to coveralls.io (Error: "source sequence is illegal/malformed utf-8"): https://github.com/okkez/coveralls-lcov/issues/12

