### PR TITLE
[PyROOT] ROOT-9025: Fix memory leak when accessing an array branch

### DIFF
--- a/bindings/pyroot/src/TPyBufferFactory.cxx
+++ b/bindings/pyroot/src/TPyBufferFactory.cxx
@@ -112,6 +112,8 @@ namespace {
       Py_buffer bufinfo;
       (*(PyBuffer_Type.tp_as_buffer->bf_getbuffer))( self, &bufinfo, PyBUF_SIMPLE );
       buf = (char*)bufinfo.buf;
+      (*(PyBuffer_Type.tp_as_buffer->bf_releasebuffer))(self, &bufinfo);
+      Py_DECREF(bufinfo.obj);
 #endif
 
       if ( ! buf )


### PR DESCRIPTION
As reported in ROOT-9025, there was a memory leak when accessing a branch of a TTree in Python, that branch being of type array.

The leak was actually not in the branch access itself via __getattr__, but when accessing one element of the array.

This commit fixes the leak that happened when trying to retrieve a pointer to the buffer with the array content as a linear char array. It does so by adding a missing reference decrement for the array.