### PR TITLE
don't mix fUsed state between threads if fgUseStaticMinuit is false

### DIFF
--- a/math/minuit/src/TMinuitMinimizer.cxx
+++ b/math/minuit/src/TMinuitMinimizer.cxx
@@ -270,7 +270,7 @@ bool TMinuitMinimizer::SetVariable(unsigned int ivar, const std::string & name, 
    // set a free variable.
    if (!CheckMinuitInstance()) return false;
 
-   fUsed = fgUsed;
+   if (fgUseStaticMinuit) fUsed = fgUsed;
 
    // clear after minimization when setting params
    if (fUsed) DoClear();
@@ -286,7 +286,7 @@ bool TMinuitMinimizer::SetLimitedVariable(unsigned int ivar, const std::string &
    // set a limited variable.
    if (!CheckMinuitInstance()) return false;
 
-   fUsed = fgUsed;
+   if (fgUseStaticMinuit) fUsed = fgUsed;
 
    // clear after minimization when setting params
    if (fUsed) DoClear();
@@ -337,7 +337,7 @@ bool TMinuitMinimizer::SetFixedVariable(unsigned int ivar, const std::string & n
    if (!CheckMinuitInstance()) return false;
 
    // clear after minimization when setting params
-   fUsed = fgUsed;
+   if (fgUseStaticMinuit) fUsed = fgUsed;
 
    // clear after minimization when setting params
    if (fUsed) DoClear();


### PR DESCRIPTION
in TMinuitMinimizer, if fgUseStaticMinuit is set to false, assignments from fgUsed (static) to fUsed (local) can mix the state between different instances.  This bug was introduced 7 years ago when the USE_STATIC_TMINUIT ifdefs were removed, without conditioning all the cases on the value of fgUseStaticMinuit.  This is believed to be at least partially responsible for crashes CMS is seeing at https://github.com/cms-sw/cmssw/issues/21769