### PR TITLE
Use real path to source dir when checking for roottest and rootbench (ROOT-8741)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,19 +432,24 @@ if(testing)
     #---Is the roottest source directory around?
     if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/roottest)
       set(roottestdir ${CMAKE_CURRENT_SOURCE_DIR}/roottest)
-    elseif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../roottest)
-      get_filename_component(roottestdir ${CMAKE_CURRENT_SOURCE_DIR}/../roottest ABSOLUTE)
+    else()
+      # Need to break into two steps in case the source dir is a symlink
+      get_filename_component(_source_dir ${CMAKE_CURRENT_SOURCE_DIR} REALPATH)
+      set(roottestdir ${_source_dir}/../roottest)
     endif()
-    if(roottestdir)
+
+    if(IS_DIRECTORY ${roottestdir})
       file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/roottest)
       add_subdirectory(${roottestdir} roottest)
     else()
       message("-- Could not find roottest directory! Cloning from the repository...")
-      execute_process(COMMAND ${GIT_EXECUTABLE} clone -b ${GIT_BRANCH} http://root.cern.ch/git/roottest.git
+      execute_process(COMMAND ${GIT_EXECUTABLE} clone -b ${GIT_BRANCH}
+                      http://github.com/root-project/roottest.git
                       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
       add_subdirectory(roottest)
     endif()
   endif()
+
   if(rootbench)
     find_package(Git REQUIRED)
     execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
@@ -453,15 +458,19 @@ if(testing)
     #---Is the rootbench source directory around?
     if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/rootbench)
       set(rootbenchdir ${CMAKE_CURRENT_SOURCE_DIR}/rootbench)
-    elseif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../rootbench)
-      get_filename_component(rootbenchdir ${CMAKE_CURRENT_SOURCE_DIR}/../rootbench ABSOLUTE)
+    else()
+      # Need to break into two steps in case the source dir is a symlink
+      get_filename_component(_source_dir ${CMAKE_CURRENT_SOURCE_DIR} REALPATH)
+      set(rootbenchdir ${_source_dir}/../rootbench)
     endif()
-    if(rootbenchdir)
+
+    if(IS_DIRECTORY ${rootbenchdir})
       file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/rootbench)
       add_subdirectory(${rootbenchdir} rootbench)
     else()
       message("-- Could not find rootbench directory! Cloning from the repository...")
-      execute_process(COMMAND ${GIT_EXECUTABLE} clone -b ${GIT_BRANCH} https://github.com/root-project/rootbench.git
+      execute_process(COMMAND ${GIT_EXECUTABLE} clone -b ${GIT_BRANCH}
+                      https://github.com/root-project/rootbench.git
                       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
       add_subdirectory(rootbench)
     endif()


### PR DESCRIPTION
Fixes [ROOT-8741](https://sft.its.cern.ch/jira/browse/ROOT-8741). The error happens when the source directory is a symlink.