### PR TITLE
Fix ROOT-9199: "TDF: improper handling of branches with leaflists"

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFUtils.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFUtils.hxx
@@ -148,6 +148,8 @@ using TVBVec_t = std::vector<TVBPtr_t>;
 std::string
 ColumnName2ColumnTypeName(const std::string &colName, TTree *, TCustomColumnBase *, TDataSource * = nullptr);
 
+char TypeName2ROOTTypeName(const std::string &b);
+
 const char *ToConstCharPtr(const char *s);
 const char *ToConstCharPtr(const std::string &s);
 unsigned int GetNSlots();

--- a/tree/treeplayer/src/TDFUtils.cxx
+++ b/tree/treeplayer/src/TDFUtils.cxx
@@ -124,6 +124,35 @@ ColumnName2ColumnTypeName(const std::string &colName, TTree *tree, TCustomColumn
    }
 }
 
+/// Convert type name (e.g. "Float_t") to ROOT type code (e.g. 'F') -- see TBranch documentation.
+/// Return a space ' ' in case no match was found.
+char TypeName2ROOTTypeName(const std::string &b)
+{
+   if (b == "Char_t")
+      return 'B';
+   if (b == "UChar_t")
+      return 'b';
+   if (b == "Short_t")
+      return 'S';
+   if (b == "UShort_t")
+      return 's';
+   if (b == "Int_t")
+      return 'I';
+   if (b == "UInt_t")
+      return 'i';
+   if (b == "Float_t")
+      return 'F';
+   if (b == "Double_t")
+      return 'D';
+   if (b == "Long64_t")
+      return 'L';
+   if (b == "ULong64_t")
+      return 'l';
+   if (b == "Bool_t")
+      return 'O';
+   return ' ';
+}
+
 const char *ToConstCharPtr(const char *s)
 {
    return s;

--- a/tree/treeplayer/test/dataframe/dataframe_utils.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_utils.cxx
@@ -120,6 +120,33 @@ TEST(TDataFrameUtils, DeduceAllPODsFromColumns)
    }
 }
 
+TEST(TDataFrameUtils, DeduceTypeOfBranchesWithCustomTitle)
+{
+   int i;
+   float f;
+   int a[2];
+
+   TTree t("t", "t");
+   auto b = t.Branch("float", &f);
+   b->SetTitle("custom title");
+   b = t.Branch("i", &i);
+   b->SetTitle("custom title");
+   b = t.Branch("arrint", &a, "a[2]/I");
+   b->SetTitle("custom title");
+   b = t.Branch("vararrint", &a, "a[i]/I");
+   b->SetTitle("custom title");
+
+   std::map<const char *, const char *> nameTypes = {{"float", "Float_t"},
+                                                     {"i", "Int_t"},
+                                                     {"arrint", "ROOT::Experimental::TDF::TArrayBranch<Int_t>"},
+                                                     {"vararrint", "ROOT::Experimental::TDF::TArrayBranch<Int_t>"}};
+
+   for (auto &nameType : nameTypes) {
+      auto typeName = ROOT::Internal::TDF::ColumnName2ColumnTypeName(nameType.first, &t, nullptr);
+      EXPECT_STREQ(nameType.second, typeName.c_str());
+   }
+}
+
 TEST(TDataFrameUtils, ToConstCharPtr)
 {
    const char *s_content("mystring");

--- a/tree/treeplayer/test/dataframe/dataframe_utils.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_utils.cxx
@@ -100,19 +100,19 @@ TEST(TDataFrameUtils, DeduceAllPODsFromColumns)
    t.Branch("arrint", &a, "a[2]/I");
    t.Branch("vararrint", &a, "a[i]/I");
 
-   std::map<const char *, const char *> nameTypes = {{"char", "char"},
-                                                     {"uchar", "unsigned char"},
-                                                     {"i", "int"},
-                                                     {"uint", "unsigned int"},
-                                                     {"short", "short"},
-                                                     {"ushort", "unsigned short"},
-                                                     {"double", "double"},
-                                                     {"float", "float"},
+   std::map<const char *, const char *> nameTypes = {{"char", "Char_t"},
+                                                     {"uchar", "UChar_t"},
+                                                     {"i", "Int_t"},
+                                                     {"uint", "UInt_t"},
+                                                     {"short", "Short_t"},
+                                                     {"ushort", "UShort_t"},
+                                                     {"double", "Double_t"},
+                                                     {"float", "Float_t"},
                                                      {"Long64_t", "Long64_t"},
                                                      {"ULong64_t", "ULong64_t"},
-                                                     {"bool", "bool"},
-                                                     {"arrint", "ROOT::Experimental::TDF::TArrayBranch<int>"},
-                                                     {"vararrint", "ROOT::Experimental::TDF::TArrayBranch<int>"}};
+                                                     {"bool", "Bool_t"},
+                                                     {"arrint", "ROOT::Experimental::TDF::TArrayBranch<Int_t>"},
+                                                     {"vararrint", "ROOT::Experimental::TDF::TArrayBranch<Int_t>"}};
 
    for (auto &nameType : nameTypes) {
       auto typeName = ROOT::Internal::TDF::ColumnName2ColumnTypeName(nameType.first, &t, nullptr);

--- a/tree/treeplayer/test/dataframe/datasource_root.cxx
+++ b/tree/treeplayer/test/dataframe/datasource_root.cxx
@@ -47,7 +47,7 @@ TEST(TRootDS, ColTypeNames)
    EXPECT_STREQ("i", colNames[0].c_str());
    EXPECT_STREQ("g", colNames[1].c_str());
 
-   EXPECT_STREQ("int", tds.GetTypeName("i").c_str());
+   EXPECT_STREQ("Int_t", tds.GetTypeName("i").c_str());
    EXPECT_STREQ("TGraph", tds.GetTypeName("g").c_str());
 }
 


### PR DESCRIPTION
This fixes some wrongly handled cases in TDF's runtime type deduction logic.

This PR renders #1529 obsolete.