### PR TITLE
[backport] Backport r323051.

### DIFF
--- a/interpreter/llvm/src/tools/clang/cmake/modules/CMakeLists.txt
+++ b/interpreter/llvm/src/tools/clang/cmake/modules/CMakeLists.txt
@@ -2,7 +2,7 @@
 # link against them. LLVM calls its version of this file LLVMExports.cmake, but
 # the usual CMake convention seems to be ${Project}Targets.cmake.
 set(CLANG_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/clang)
-set(clang_cmake_builddir "${CMAKE_BINARY_DIR}/${CLANG_INSTALL_PACKAGE_DIR}")
+set(clang_cmake_builddir "${CLANG_BINARY_DIR}/${CLANG_INSTALL_PACKAGE_DIR}")
 
 # Keep this in sync with llvm/cmake/CMakeLists.txt!
 set(LLVM_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm)


### PR DESCRIPTION
Original message:
"[cmake] Use CLANG_BINARY_DIR to determine the build directory.

The patch puts the ClangConfig.cmake in the expected location  when clang is
embedded into a framework."