### PR TITLE
[TDF] Fix for ROOT-9207

### DIFF
--- a/tree/treeplayer/src/TDFUtils.cxx
+++ b/tree/treeplayer/src/TDFUtils.cxx
@@ -157,7 +157,9 @@ unsigned int GetNSlots()
    return nSlots;
 }
 
-void GetBranchNamesImpl(TTree &t, std::set<std::string> &bNames, std::set<TTree *> &analysedTrees)
+// The set here is used as a registry, the real list, which keeps the order, is
+// the one in the vector
+void GetBranchNamesImpl(TTree &t, std::set<std::string> &bNamesReg, ColumnNames_t &bNames, std::set<TTree *> &analysedTrees)
 {
 
    if (!analysedTrees.insert(&t).second) {
@@ -167,7 +169,10 @@ void GetBranchNamesImpl(TTree &t, std::set<std::string> &bNames, std::set<TTree 
    auto branches = t.GetListOfBranches();
    if (branches) {
       for (auto branchObj : *branches) {
-         bNames.insert(branchObj->GetName());
+         auto name = branchObj->GetName();
+         if(bNamesReg.insert(name).second) {
+            bNames.emplace_back(name);
+         }
       }
    }
 
@@ -178,7 +183,7 @@ void GetBranchNamesImpl(TTree &t, std::set<std::string> &bNames, std::set<TTree 
 
    for (auto friendTreeObj : *friendTrees) {
       auto friendTree = ((TFriendElement *)friendTreeObj)->GetTree();
-      GetBranchNamesImpl(*friendTree, bNames, analysedTrees);
+      GetBranchNamesImpl(*friendTree, bNamesReg, bNames, analysedTrees);
    }
 }
 
@@ -187,11 +192,9 @@ void GetBranchNamesImpl(TTree &t, std::set<std::string> &bNames, std::set<TTree 
 ColumnNames_t GetBranchNames(TTree &t)
 {
    std::set<std::string> bNamesSet;
-   std::set<TTree *> analysedTrees;
-   GetBranchNamesImpl(t, bNamesSet, analysedTrees);
    ColumnNames_t bNames;
-   for (auto &bName : bNamesSet)
-      bNames.emplace_back(bName);
+   std::set<TTree *> analysedTrees;
+   GetBranchNamesImpl(t, bNamesSet, bNames, analysedTrees);
    return bNames;
 }
 

--- a/tree/treeplayer/test/dataframe/dataframe_interface.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_interface.cxx
@@ -138,6 +138,19 @@ TEST(TDataFrameInterface, GetColumnNamesFromTree)
    EXPECT_EQ(2U, names.size());
 }
 
+TEST(TDataFrameInterface, GetColumnNamesFromOrdering)
+{
+   TTree t("t", "t");
+   int a, b;
+   t.Branch("zzz", &a);
+   t.Branch("aaa", &b);
+   TDataFrame tdf(t);
+   auto names = tdf.GetColumnNames();
+   EXPECT_STREQ("zzz", names[0].c_str());
+   EXPECT_STREQ("aaa", names[1].c_str());
+   EXPECT_EQ(2U, names.size());
+}
+
 TEST(TDataFrameInterface, GetColumnNamesFromSource)
 {
    std::unique_ptr<TDataSource> tds(new TTrivialDS(1));


### PR DESCRIPTION
do not sort alphabetically the branches of the tree(s) associated to the
tdf. This can lead to trouble in presence of variable size arrays and
snapshot: the leafcount must always be present when crating a variable
size array branch referring to it.