### PR TITLE
Add cividis colormap

### DIFF
--- a/core/base/inc/TColor.h
+++ b/core/base/inc/TColor.h
@@ -123,6 +123,6 @@ public:
                        kStarryNight=102,     kSunset=103,      kTemperatureMap=104,
                        kThermometer=105,     kValentine=106,   kVisibleSpectrum=107,
                        kWaterMelon=108,      kCool=109,        kCopper=110,
-                       kGistEarth=111,       kViridis=112};
+                       kGistEarth=111,       kViridis=112,     kCividis=113};
 #endif
 

--- a/core/base/src/TColor.cxx
+++ b/core/base/src/TColor.cxx
@@ -316,7 +316,7 @@ kSienna=99,           kSolar=100,       kSouthWest=101,
 kStarryNight=102,     kSunset=103,      kTemperatureMap=104,
 kThermometer=105,     kValentine=106,   kVisibleSpectrum=107,
 kWaterMelon=108,      kCool=109,        kCopper=110,
-kGistEarth=111,       kViridis=112
+kGistEarth=111,       kViridis=112,     kCividis=113
 ~~~
 
 <table border=0>
@@ -896,6 +896,15 @@ Begin_Macro("width=300")
    TF2 *f2 = new TF2("f2","0.1+(1-(x-2)*(x-2))*(1-(y-2)*(y-2))",0.999,3.002,0.999,3.002);
    f2->SetContour(99); gStyle->SetPalette(kViridis);
    f2->Draw("surf2Z"); f2->SetTitle("kViridis");
+}
+End_Macro
+</td><td>
+Begin_Macro("width=300")
+{
+   c  = new TCanvas("c","c",0,0,600,600);
+   TF2 *f2 = new TF2("f2","0.1+(1-(x-2)*(x-2))*(1-(y-2)*(y-2))",0.999,3.002,0.999,3.002);
+   f2->SetContour(99); gStyle->SetPalette(kCividis);
+   f2->Draw("surf2Z"); f2->SetTitle("kCividis");
 }
 End_Macro
 </td></tr>
@@ -2345,6 +2354,7 @@ Int_t TColor::CreateGradientColorTable(UInt_t Number, Double_t* Stops,
 /// if ncolors = 110 and colors=0, a Copper palette is used.
 /// if ncolors = 111 and colors=0, a Gist Earth palette is used.
 /// if ncolors = 112 and colors=0, a Viridis palette is used.
+/// if ncolors = 112 and colors=0, a Cividis palette is used.
 /// ~~~
 /// These palettes can also be accessed by names:
 /// ~~~ {.cpp}
@@ -2368,7 +2378,7 @@ Int_t TColor::CreateGradientColorTable(UInt_t Number, Double_t* Stops,
 /// kStarryNight=102,     kSunset=103,      kTemperatureMap=104,
 /// kThermometer=105,     kValentine=106,   kVisibleSpectrum=107,
 /// kWaterMelon=108,      kCool=109,        kCopper=110,
-/// kGistEarth=111        kViridis=112
+/// kGistEarth=111        kViridis=112,     kCividis=113
 /// ~~~
 /// For example:
 /// ~~~ {.cpp}
@@ -3064,6 +3074,16 @@ void TColor::SetPalette(Int_t ncolors, Int_t *colors, Float_t alpha)
             Double_t green[9] = {  9./255., 24./255.,  55./255.,  87./255., 118./255., 150./255., 180./255., 200./255., 222./255.};
             Double_t blue[9]  = { 30./255., 96./255., 112./255., 114./255., 112./255., 101./255.,  72./255.,  35./255.,   0./255.};
             Idx = TColor::CreateGradientColorTable(9, stops, red, green, blue, 255, alpha);
+         }
+         break;
+
+      // Cividis
+      case 113:
+         {
+            Double_t red[9]   = {  0./255.,   5./255.,  65./255.,  97./255., 124./255., 156./255., 189./255., 224./255., 255./255.};
+            Double_t green[9] = { 32./255.,  54./255.,  77./255., 100./255., 123./255., 148./255., 175./255., 203./255., 234./255.};
+            Double_t blue[9]  = { 77./255., 110./255., 107./255., 111./255., 120./255., 119./255., 111./255.,  94./255.,  70./255.};
+            Idx = TColor::CreateGradientColorTable(18, stops, red, green, blue, 255, alpha);
          }
          break;
 

--- a/core/base/src/TColor.cxx
+++ b/core/base/src/TColor.cxx
@@ -2354,7 +2354,7 @@ Int_t TColor::CreateGradientColorTable(UInt_t Number, Double_t* Stops,
 /// if ncolors = 110 and colors=0, a Copper palette is used.
 /// if ncolors = 111 and colors=0, a Gist Earth palette is used.
 /// if ncolors = 112 and colors=0, a Viridis palette is used.
-/// if ncolors = 112 and colors=0, a Cividis palette is used.
+/// if ncolors = 113 and colors=0, a Cividis palette is used.
 /// ~~~
 /// These palettes can also be accessed by names:
 /// ~~~ {.cpp}

--- a/tutorials/graphics/palettes.C
+++ b/tutorials/graphics/palettes.C
@@ -104,5 +104,6 @@ void palettes() {
    draw_palette(kCopper, "Copper");
    draw_palette(kGistEarth, "Gist Earth");
    draw_palette(kViridis, "Viridis");
+   draw_palette(kCividis, "Cividis");
 }
 


### PR DESCRIPTION
This adds **cividis** as 113th colormap to TColor, as well as the palettes tutorial.

This colormap aims to solve problems that people with **color vision deficiency** have with the common colormaps. For more details see:

Nuñez J, Anderton C, and Renslow R. _Optimizing colormaps with consideration for color vision deficiency to enable accurate interpretation of scientific data._

https://arxiv.org/abs/1712.01662


The colormap stops have been interpolated from the (256 stops) Fiji/ImageJ version [1] and cut down to the 9 stops that ROOT uses (using the scipy Akima interpolator). Alternatively, the official* (18 stop) version committed to plotly.py [2] could be used, which would mean a slight deviation from the other palettes (see code below). In the plot produced by the palette tutorial the difference between the 9 and 18 stops seems negligible, hence sticking to the ROOT default values seems appropriate.

    Double_t cstps[18] = {0.0, 0.0588235294118, 0.117647058824, 0.176470588235, 0.235294117647, 0.294117647059, 0.352941176471, 0.411764705882, 0.470588235294, 0.529411764706, 0.588235294118, 0.647058823529, 0.705882352941, 0.764705882353, 0.823529411765, 0.882352941176, 0.941176470588, 1.0};
    Double_t red[18]   = {  0./255.,   0./255.,   0./255., 39./255.,  60./255.,  76./255.,  91./255., 104./255., 117./255., 131./255., 146./255., 161./255., 176./255., 192./255., 209./255., 225./255., 243./255., 255./255.};
    Double_t green[18] = { 32./255.,  42./255.,  52./255., 63./255.,  74./255.,  85./255.,  95./255., 106./255., 117./255., 129./255., 140./255., 152./255., 165./255., 177./255., 191./255., 204./255., 219./255., 233./255.};
    Double_t blue[18]  = { 76./255., 102./255., 110./255., 108./255., 107./255., 107./255., 109./255., 112./255., 117./255., 120./255., 120./255., 118./255., 114./255., 109./255., 102./255., 92./255.,  79./255.,  69./255.};
    Idx = TColor::CreateGradientColorTable(18, cstps, red, green, blue, 255, alpha); 

*Meaning committed by the original author.

[1] https://github.com/fiji/fiji/blob/master/luts/cividis.txt
[2] https://github.com/plotly/plotly.py/pull/883