### PR TITLE
Autoload canonical namespaces

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -5036,37 +5036,11 @@ namespace {
          // because it may shadow the lookup of other names contained
          // in that namespace
 
-         #ifdef R__USE_CXXMODULES
-         // When we want to autoload contents from namespaces we end up in Sema::LookupQualifiedName; then we issue a
-         // callback to FindExternallyVisibleName which forwards to LookupObject. Lookup object takes a DeclContext as
-         // an argument. This argument is always the primary lookup context (which for a NamespaceDecl is the original
-         // namespace.
-         //
-         // Regular autoloading does not consider this (or has chosen not to) because this reduces the amount of
-         // autoloads. Such autoloads can happen when resolving template instantiations when computing a decl's linkage
-         // by clang's CodeGen. This in turn loads unexpected libraries such as RooFit when trying to resolve all
-         // template specializations of __to_raw_pointer (located in <memory>), including the one taking a
-         // HistFactory::Data*.
-         //
-         // That way we end up needlessly loading RooFit and showing it's weird banner, potentially breaking a lot of
-         // tests.
-         //
-         // This behavior can be considered as broken because we hide information about possible redeclarations which
-         // can affect the linkage computation or other checks in codegen. If we fix the bug we will probably explode
-         // ROOT's memory footprint and make the gap between standard ROOT and ROOT with modules even bigger.
-         //
-         // Since it is not clear how much work and issue resolving is required for standard ROOT, we can probably
-         // only live with the workaround of the missing concept: moving entities in namespaces whose autoloading
-         // requires declarations to be in the PCH. For instance, ROOT::Experimental::TDataFrame.
-         //
-         // FIXME: We might want to consider enabling this for regular autoloading once we have a good understanding
-         // of the performance implications.
          NamespaceDecl* nsOrigDecl = nsDecl->getOriginalNamespace();
          if (nsDecl != nsOrigDecl) {
             nsOrigDecl->setHasExternalVisibleStorage();
             fNSSet.insert(nsOrigDecl);
          }
-         #endif
          nsDecl->setHasExternalVisibleStorage();
          fNSSet.insert(nsDecl);
          return true;


### PR DESCRIPTION
ROOT injects forward declarations of entities as trampolines to resolve the full definitions and load the corresponding library. This allows the ROOT users to 'just' type a name and the interpreter will resolve its definition and dlopen the library describing it.

There is a well-known (not well understood until now) limitation with this system: we cannot load entities in namespaces. Namely, if we type `ROOT::TDF::TDataFrame;` the system won't be able to resolve it. This is because we enable the system to load only the contents of namespaces from the forward declarations. For example,
```cpp
// rootmap file
namespace ROOT{ namespace Experimental { class TDataFrame; } } // #1

// real code
namespace ROOT{ namespace Experimental { class TDataFrame {}; } } // #2

[root] ROOT::Experimental::TDataFrame d; // #3
```
`#1` is piped at root/interpreter start up; we find the DeclContext and flag it. `#3` triggers a lookup and `#includes #2`. The problem is that we do not issue a lookup in `#2`. The effect is that we practically cannot autoload entities from namespaces.

Turning it 'just' on breaks performance and starts loading irrelevant libraries. This is because clang eagerly deserializes template specialization declarations for the decl context in question when computing linkage information in CodeGen.

All heavy lifting is done in [D41416](https://reviews.llvm.org/D41416) and landed in e51a2b9de4. It enables finer-grained template specialization deserialization removing the effect of loading irrelevant libraries. The performance impact will be seen shortly after we land this PR.
