### PR TITLE
[PyROOT] Backport memory leak fix (ROOT-9025)

### DIFF
--- a/bindings/pyroot/src/TPyBufferFactory.cxx
+++ b/bindings/pyroot/src/TPyBufferFactory.cxx
@@ -112,6 +112,8 @@ namespace {
       Py_buffer bufinfo;
       (*(PyBuffer_Type.tp_as_buffer->bf_getbuffer))( self, &bufinfo, PyBUF_SIMPLE );
       buf = (char*)bufinfo.buf;
+      (*(PyBuffer_Type.tp_as_buffer->bf_releasebuffer))(self, &bufinfo);
+      Py_DECREF(bufinfo.obj);
 #endif
 
       if ( ! buf )


### PR DESCRIPTION
Once tested with the previous push to master, this backports the fix for ROOT-9025: a memory leak when accessing a branch of a TTree in Python, that branch being of type array.