### PR TITLE
Integrate clad

### DIFF
--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -9,6 +9,22 @@ set(LLVM_BUILD_TOOLS OFF CACHE BOOL "")
 set(LLVM_TOOL_LLVM_AR_BUILD OFF CACHE BOOL "")
 set(CLANG_TOOL_CLANG_OFFLOAD_BUNDLER_BUILD OFF CACHE BOOL "")
 set(LLVM_FORCE_USE_OLD_TOOLCHAIN ON CACHE BOOL "")
+
+# FIXME: We cannot use etcdir or prefix from RootConfiguration.cmake because it
+# is included very late.
+if(gnuinstall)
+  set(prefix ${CMAKE_INSTALL_PREFIX})
+else()
+  set(prefix ${ROOTSYS})
+endif()
+if(IS_ABSOLUTE ${CMAKE_INSTALL_SYSCONFDIR})
+  set(etcdir ${CMAKE_INSTALL_SYSCONFDIR})
+else()
+  set(etcdir ${prefix}/${CMAKE_INSTALL_SYSCONFDIR})
+endif()
+set(CLING_PLUGIN_INSTALL_PREFIX "${etcdir}/cling/plugins/" CACHE STRING "" FORCE)
+set(LLVM_DIR "${CMAKE_BINARY_DIR}/interpreter/llvm/src")
+set(CLING_BUILD_PLUGINS ON)
 set(LLVM_EXTERNAL_CLING_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cling" CACHE STRING "")
 set(LLVM_EXTERNAL_PROJECTS "cling" CACHE STRING "")
 # We only use llvm/clang through TCling which is (with the help of core/meta) already taking a lock

--- a/interpreter/cling/include/cling/Interpreter/ClingOptions.inc
+++ b/interpreter/cling/include/cling/Interpreter/ClingOptions.inc
@@ -20,11 +20,11 @@ OPTION(prefix_0, "<input>", INPUT, Input, INVALID, INVALID, 0, 0, 0, 0, 0, 0)
 OPTION(prefix_0, "<unknown>", UNKNOWN, Unknown, INVALID, INVALID, 0, 0, 0, 0, 0, 0)
 OPTION(prefix_2, "errorout", _errorout, Flag, INVALID, INVALID, 0, 0, 0,
        "Do not recover from input errors", 0, 0)
+// Re-implement to forward to our help
 OPTION(prefix_3, "help", help, Flag, INVALID, INVALID, 0, 0, 0,
        "Print this help text", 0, 0)
 OPTION(prefix_1, "L", L, JoinedOrSeparate, INVALID, INVALID, 0, 0, 0,
        "Add directory to library search path", "<directory>", 0)
-// Re-implement to forward to our help
 OPTION(prefix_1, "l", l, JoinedOrSeparate, INVALID, INVALID, 0, 0, 0,
        "Load a library before prompt", "<library>", 0)
 OPTION(prefix_2, "metastr=", _metastr_EQ, Joined, INVALID, INVALID, 0, 0, 0,

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -657,8 +657,17 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
       P.resize(ExeIncl.size());
       // Get foo/include
       llvm::sys::path::append(P, "include");
-      if (llvm::sys::fs::is_directory(P.str()))
+      if (llvm::sys::fs::is_directory(P.str())) {
         utils::AddIncludePaths(P.str(), HOpts, nullptr);
+        llvm::sys::path::append(P, "clang");
+        if (!llvm::sys::fs::is_directory(P.str())) {
+          // LLVM is not installed. Try resolving clang from its usual location.
+          P = llvm::sys::path::parent_path(P);
+          llvm::sys::path::append(P, "..", "tools", "clang", "include");
+          if (llvm::sys::fs::is_directory(P.str()))
+            utils::AddIncludePaths(P.str(), HOpts, nullptr);
+        }
+      }
     }
   }
 

--- a/interpreter/cling/tools/CMakeLists.txt
+++ b/interpreter/cling/tools/CMakeLists.txt
@@ -6,11 +6,14 @@
 # LICENSE.TXT for details.
 #------------------------------------------------------------------------------
 
-
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../lib/UserInterface/textinput
    OR CLING_INCLUDE_TESTS)
   add_subdirectory(driver)
   add_subdirectory(Jupyter)
   add_subdirectory(libcling)
   add_subdirectory(demo)
+endif()
+
+if(CLING_BUILD_PLUGINS)
+  add_subdirectory(plugins)
 endif()

--- a/interpreter/cling/tools/plugins/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/CMakeLists.txt
@@ -1,0 +1,45 @@
+#------------------------------------------------------------------------------
+# CLING - the C++ LLVM-based InterpreterG :)
+#
+# This file is dual-licensed: you can choose to license it under the University
+# of Illinois Open Source License or the GNU Lesser General Public License. See
+# LICENSE.TXT for details.
+#------------------------------------------------------------------------------
+
+## If we drop a compatible cmake project in this folder we should automatically
+## pick it up and build it.
+#function(LISTSUBDIRS result curdir)
+#  file(GLOB children RELATIVE ${curdir} ${curdir}/*)
+#  set(dirlist "")
+#  foreach(child ${children})
+#    if(IS_DIRECTORY ${curdir}/${child})
+#      if(APPEND dirlist ${child})
+#    endif()
+#  endforeach()
+#  set(${result} ${dirlist} PARENT_SCOPE)
+#endfunction()
+#
+#LISTSUBDIRS(subdirs ${CMAKE_CURRENT_SOURCE_DIR}/plugins/)
+#foreach(subdir ${SUBDIRS})
+#  add_subdirectory(${subdir})
+#endforeach()
+
+ExternalProject_Add(
+  clad
+  GIT_REPOSITORY https://github.com/vgvassilev/clad.git
+  GIT_TAG master
+  UPDATE_COMMAND ""
+  CMAKE_ARGS -G ${CMAKE_GENERATOR}
+             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+             -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+             -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
+             -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+             -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+             -DCMAKE_INSTALL_PREFIX=${CLING_PLUGIN_INSTALL_PREFIX}
+             -DCLAD_PATH_TO_LLVM_BUILD=${LLVM_DIR}
+  #BUILD_BYPRODUCTS ${_gtest_byproducts}
+  # Wrap download, configure and build steps in a script to log output
+  LOG_DOWNLOAD ON
+  LOG_CONFIGURE ON
+  LOG_BUILD ON
+  )


### PR DESCRIPTION
clad is a C++ plugin for clang that implements automatic differentiation of user-defined functions by employing the chain rule in forward mode, coupled with source code transformation and AST constant fold.