### PR TITLE
Drop deprecated register storage class from libAfterImage

### DIFF
--- a/graf2d/asimage/src/libAfterImage/afterbase.c
+++ b/graf2d/asimage/src/libAfterImage/afterbase.c
@@ -87,7 +87,7 @@ asim_set_application_name (char *argv0)
 	char *temp = &(argv0[0]);
 	do
 	{	/* Save our program name - for error messages */
-		register int i = 1 ;                   /* we don't use standard strrchr since there
+		int i = 1 ;                   /* we don't use standard strrchr since there
 												* seems to be some weirdness in
 												* CYGWIN implementation of it. */
 		asim_ApplicationName =  temp ;
@@ -214,7 +214,7 @@ asim_put_file_home (const char *path_with_home)
 	static char   default_home[3] = "./";
 	static int    home_len = 0;
 	char         *str = NULL, *ptr;
-	register int  i;
+	int  i;
 	if (path_with_home == NULL)
 		return NULL;
 	/* home dir ? */
@@ -304,10 +304,10 @@ char         *
 asim_find_file (const char *file, const char *pathlist, int type)
 {
 	char 		  *path;
-	register int   len;
+	int   len;
 	int            max_path = 0;
-	register char *ptr;
-	register int   i;
+	char *ptr;
+	int   i;
 	Bool local = False ;
 
 	if (file == NULL)
@@ -364,7 +364,7 @@ asim_find_file (const char *file, const char *pathlist, int type)
 			i-- ;
 		if( i > 0 )
 		{
-			register char *try_path = path+max_path-i;
+			char *try_path = path+max_path-i;
 			strncpy( try_path, ptr, i );
 			if (access(try_path, type) == 0)
 			{
@@ -383,7 +383,7 @@ static char         *
 find_envvar (char *var_start, int *end_pos)
 {
 	char          backup, *name_start = var_start;
-	register int  i;
+	int  i;
 	char         *var = NULL;
 
 	if (var_start[0] == '{')
@@ -511,7 +511,7 @@ int
 asim_mystrcasecmp (const char *s1, const char *s2)
 {
 	int          c1, c2;
-	register int i = 0 ;
+	int i = 0 ;
 
 	if (s1 == NULL || s2 == NULL)
 		return (s1 == s2) ? 0 : ((s1==NULL)?1:-1);
@@ -536,8 +536,8 @@ asim_mystrcasecmp (const char *s1, const char *s2)
 int
 asim_mystrncasecmp (const char *s1, const char *s2, size_t n)
 {
-	register int  c1, c2;
-	register int i = 0 ;
+	int  c1, c2;
+	int i = 0 ;
 
 	if (s1 == NULL || s2 == NULL)
 		return (s1 == s2) ? 0 : ((s1==NULL)?1:-1);
@@ -588,7 +588,7 @@ const char *asim_parse_argb_color( const char *color, CARD32 *pargb )
 		{
 			CARD32 argb = 0 ;
 			int len = 0 ;
-			register const char *ptr = color+1 ;
+			const char *ptr = color+1 ;
 			while( isxdigit((int)ptr[len]) ) len++;
 			if( len >= 3)
 			{
@@ -634,7 +634,7 @@ const char *asim_parse_argb_color( const char *color, CARD32 *pargb )
 			/* does not really matter here what screen to use : */
 			Display *dpy = get_default_asvisual()->dpy;
 #ifdef X_DISPLAY_MISSING
-			register const char *ptr = &(color[0]);
+			const char *ptr = &(color[0]);
             if(!FindColor(color, pargb))
                 return color;
     		while( !isspace((int)*ptr) && *ptr != '\0' ) ptr++;
@@ -644,7 +644,7 @@ const char *asim_parse_argb_color( const char *color, CARD32 *pargb )
 				return color ;
 			else
 			{
-				register const char *ptr = &(color[0]);
+				const char *ptr = &(color[0]);
 #ifndef X_DISPLAY_MISSING
 				XColor xcol, xcol_scr ;
 /* XXX Not sure if Scr.asv->colormap is always defined here.  If not,
@@ -801,7 +801,7 @@ asim_create_ashash (ASHashKey size,
 static void
 destroy_ashash_bucket (ASHashBucket * bucket, void (*item_destroy_func) (ASHashableValue, void *))
 {
-	register ASHashItem *item, *next;
+	ASHashItem *item, *next;
 
 	for (item = *bucket; item != NULL; item = next)
 	{
@@ -819,7 +819,7 @@ asim_destroy_ashash (ASHashTable ** hash)
 LOCAL_DEBUG_CALLER_OUT( " hash = %p, *hash = %p", hash, *hash  );
 	if (*hash)
 	{
-		register int  i;
+		int  i;
 
 		for (i = (*hash)->size - 1; i >= 0; i--)
 			if ((*hash)->buckets[i])
@@ -839,7 +839,7 @@ add_item_to_bucket (ASHashBucket * bucket, ASHashItem * item, long (*compare_fun
 	/* first check if we already have this item */
 	for (tmp = bucket; *tmp != NULL; tmp = &((*tmp)->next))
 	{
-		register long res = compare_func ((*tmp)->value, item->value);
+		long res = compare_func ((*tmp)->value, item->value);
 
 		if (res == 0)
 			return ((*tmp)->data == item->data) ? ASH_ItemExistsSame : ASH_ItemExistsDiffer;
@@ -895,8 +895,8 @@ static ASHashItem **
 find_item_in_bucket (ASHashBucket * bucket,
 					 ASHashableValue value, long (*compare_func) (ASHashableValue, ASHashableValue))
 {
-	register ASHashItem **tmp;
-	register long res;
+	ASHashItem **tmp;
+	long res;
 
 	/* first check if we already have this item */
 	for (tmp = bucket; *tmp != NULL; tmp = &((*tmp)->next))
@@ -993,7 +993,7 @@ ASHashKey asim_pointer_hash_value (ASHashableValue value, ASHashKey hash_size)
         void *ptr;
         ASHashKey key[2];
     } mix;
-    register  ASHashKey key;
+     ASHashKey key;
 
     mix.ptr = (void*)value;
     key = mix.key[0]^mix.key[1] ;
@@ -1007,9 +1007,9 @@ ASHashKey
 asim_string_hash_value (ASHashableValue value, ASHashKey hash_size)
 {
 	ASHashKey     hash_key = 0;
-	register int  i = 0;
+	int  i = 0;
 	char         *string = (char*)value;
-	register char c;
+	char c;
 
 	do
 	{
@@ -1025,9 +1025,9 @@ asim_string_hash_value (ASHashableValue value, ASHashKey hash_size)
 long
 asim_string_compare (ASHashableValue value1, ASHashableValue value2)
 {
-	register char *str1 = (char*)value1;
-	register char *str2 = (char*)value2;
-	register int   i = 0 ;
+	char *str1 = (char*)value1;
+	char *str2 = (char*)value2;
+	int   i = 0 ;
 
 	if (str1 == str2)
 		return 0;
@@ -1056,9 +1056,9 @@ ASHashKey
 asim_casestring_hash_value (ASHashableValue value, ASHashKey hash_size)
 {
 	ASHashKey     hash_key = 0;
-	register int  i = 0;
+	int  i = 0;
 	char         *string = (char*)value;
-	register int c;
+	int c;
 
 	do
 	{
@@ -1077,9 +1077,9 @@ asim_casestring_hash_value (ASHashableValue value, ASHashKey hash_size)
 long
 asim_casestring_compare (ASHashableValue value1, ASHashableValue value2)
 {
-	register char *str1 = (char*)value1;
-	register char *str2 = (char*)value2;
-	register int   i = 0;
+	char *str1 = (char*)value1;
+	char *str2 = (char*)value2;
+	int   i = 0;
 
 	if (str1 == str2)
 		return 0;
@@ -1196,7 +1196,7 @@ asim_start_ticker (unsigned int size)
 	_as_ticker_last_tick = times (&t);		   /* in system ticks */
 	if (_as_ticker_tick_time == 0)
 	{
-		register clock_t delta = _as_ticker_last_tick;
+		clock_t delta = _as_ticker_last_tick;
 		/* calibrating clock - how many ms per cpu tick ? */
 		sleep_a_little (100);
 		_as_ticker_last_tick = times (&t);
@@ -1219,9 +1219,9 @@ asim_wait_tick ()
 {
 #ifndef _WIN32
 	struct tms    t;
-	register clock_t curr = (times (&t) - _as_ticker_last_tick) * _as_ticker_tick_time;
+	clock_t curr = (times (&t) - _as_ticker_last_tick) * _as_ticker_tick_time;
 #else
-	register int curr = (time(NULL) - _as_ticker_last_tick) * _as_ticker_tick_time;
+	int curr = (time(NULL) - _as_ticker_last_tick) * _as_ticker_tick_time;
 #endif
 
 	if (curr < _as_ticker_tick_size)
@@ -1671,7 +1671,7 @@ int asim_xml_parse(const char* str, xml_elem_t* current, ASHashTable *vocabulary
 
 char *asim_interpret_ctrl_codes( char *text )
 {
-	register char *ptr = text ;
+	char *ptr = text ;
 	int len, curr = 0 ;
 	if( ptr == NULL )  return NULL ;	
 
@@ -1694,7 +1694,7 @@ char *asim_interpret_ctrl_codes( char *text )
 			}	 
 			if( subst ) 
 			{
-				register int i = curr ; 
+				int i = curr ; 
 				ptr[i] = subst ;
 				while( ++i < len ) 
 					ptr[i] = ptr[i+1] ; 
@@ -1821,7 +1821,7 @@ add_xml_buffer_close_tag( ASXmlBuffer *xb, xml_elem_t *tag )
 int 
 asim_spool_xml_tag( ASXmlBuffer *xb, char *tmp, int len )
 {
-	register int i = 0 ; 
+	int i = 0 ; 
 	
 	if( !xb->verbatim && !xb->quoted && 
 		(xb->state != ASXML_Start || xb->level == 0 )) 

--- a/graf2d/asimage/src/libAfterImage/ascmap.c
+++ b/graf2d/asimage/src/libAfterImage/ascmap.c
@@ -67,7 +67,7 @@
 /***********************************************************************************/
 static inline ASMappedColor *new_mapped_color( CARD32 red, CARD32 green, CARD32 blue, CARD32 indexed )
 {
-	register ASMappedColor *pnew = malloc( sizeof( ASMappedColor ));
+	ASMappedColor *pnew = malloc( sizeof( ASMappedColor ));
 	if( pnew != NULL )
 	{
 		pnew->red   = INDEX_UNSHIFT_RED  (red) ;
@@ -104,14 +104,14 @@ add_index_color( ASSortedColorHash *index, CARD32 indexed, unsigned int slot, CA
 	}
 	while( *pnext )
 	{
-		register ASMappedColor *pelem = *pnext ;/* to avoid double redirection */
+		ASMappedColor *pelem = *pnext ;/* to avoid double redirection */
 		if( pelem->indexed == indexed )
 		{
 			++(pelem->count);
 			return ;
 		}else if( pelem->indexed > indexed )
 		{
-			register ASMappedColor *pnew = new_mapped_color( red, green, blue, indexed );
+			ASMappedColor *pnew = new_mapped_color( red, green, blue, indexed );
 			if( pnew )
 			{
 				++(index->count_unique);
@@ -159,7 +159,7 @@ check_colorindex_counts( ASSortedColorHash *index )
 
 	for( i = 0 ; i < index->buckets_num ; i++ )
 	{
-		register ASMappedColor *pelem = index->buckets[i].head ;
+		ASMappedColor *pelem = index->buckets[i].head ;
 		int row_count = 0 ;
 		while( pelem != NULL )
 		{
@@ -186,8 +186,8 @@ fix_colorindex_shortcuts( ASSortedColorHash *index )
 
 	for( i = 0 ; i < index->buckets_num ; i++ )
 	{
-		register ASMappedColor **pelem = &(index->buckets[i].head) ;
-		register ASMappedColor **tail = &(index->buckets[i].tail) ;
+		ASMappedColor **pelem = &(index->buckets[i].head) ;
+		ASMappedColor **tail = &(index->buckets[i].tail) ;
 		while( *pelem != NULL )
 		{
 			if( (*pelem)->cmap_idx < 0 )
@@ -229,7 +229,7 @@ fix_colorindex_shortcuts( ASSortedColorHash *index )
 
 
 static inline void
-add_colormap_item( register ASColormapEntry *pentry, ASMappedColor *pelem, int cmap_idx )
+add_colormap_item( ASColormapEntry *pentry, ASMappedColor *pelem, int cmap_idx )
 {
 	pentry->red   = pelem->red ;
 	pentry->green = pelem->green ;
@@ -247,7 +247,7 @@ add_colormap_items( ASSortedColorHash *index, unsigned int start, unsigned int s
 	{
 		for( i = start ; i < stop ; i++ )
 		{
-			register ASMappedColor *pelem = index->buckets[i].head ;
+			ASMappedColor *pelem = index->buckets[i].head ;
 			while ( pelem != NULL )
 			{
 				add_colormap_item( &(entries[cmap_idx]), pelem, base++ );
@@ -267,7 +267,7 @@ add_colormap_items( ASSortedColorHash *index, unsigned int start, unsigned int s
 
 		for( i = start ; i <= stop ; i++ )
 		{
-			register ASMappedColor *pelem = index->buckets[i].head ;
+			ASMappedColor *pelem = index->buckets[i].head ;
 			while ( pelem != NULL /*&& cmap_idx < quota*/ )
 			{
 				if( pelem->cmap_idx < 0 )
@@ -414,7 +414,7 @@ colormap_asimage( ASImage *im, ASColormap *cmap, unsigned int max_colors, unsign
 
 	int *dst ;
 	unsigned int y ;
-	register int x ;
+	int x ;
 
 	if( im == NULL || cmap == NULL || im->width == 0 )
 		return NULL;

--- a/graf2d/asimage/src/libAfterImage/asfont.c
+++ b/graf2d/asimage/src/libAfterImage/asfont.c
@@ -170,7 +170,7 @@ open_freetype_font_int( ASFontManager *fontman, const char *font_string, int fac
 		if( (realfilename = find_file( font_string, fontman->font_path, R_OK )) == NULL )
 		{/* we might have face index specifier at the end of the filename */
 			char *tmp = mystrdup( font_string );
-			register int i = 0;
+			int i = 0;
 			while(tmp[i] != '\0' ) ++i ;
 			while( --i >= 0 )
 				if( !isdigit( tmp[i] ) )
@@ -368,7 +368,7 @@ release_font( ASFont *font )
 }
 
 static inline void
-free_glyph_data( register ASGlyph *asg )
+free_glyph_data( ASGlyph *asg )
 {
     if( asg->pixmap )
         free( asg->pixmap );
@@ -390,7 +390,7 @@ destroy_glyph_range( ASGlyphRange **pgr )
         if( gr->glyphs )
 		{
             int max_i = ((int)gr->max_char-(int)gr->min_char)+1 ;
-            register int i = -1 ;
+            int i = -1 ;
 /*fprintf( stderr, " max_char = %d, min_char = %d, i = %d", gr->max_char, gr->min_char, max_i);*/
             while( ++i < max_i )
             {
@@ -464,8 +464,8 @@ compress_glyph_pixmap( unsigned char *src, unsigned char *buffer,
 					   int src_step )
 {
 	unsigned char *pixmap ;
-	register unsigned char *dst = buffer ;
-	register int k = 0, i = 0 ;
+	unsigned char *dst = buffer ;
+	int k = 0, i = 0 ;
 	int count = -1;
 	unsigned char last = src[0];
 /* new way: if its FF we encode it as 01rrrrrr where rrrrrr is repitition count
@@ -520,8 +520,8 @@ void
 antialias_glyph( unsigned char *buffer, unsigned int width, unsigned int height )
 {
 	unsigned char *row1, *row2 ;
-	register unsigned char *row ;
-	register int x;
+	unsigned char *row ;
+	int x;
 	int y;
 
 	row1 = &(buffer[0]);
@@ -651,7 +651,7 @@ scale_down_glyph_width( unsigned char *buffer, int from_width, int to_width, int
 {
     int smaller = to_width;
     int bigger  = from_width;
-	register int i = 0, k = 0, l;
+	int i = 0, k = 0, l;
 	/*fprintf( stderr, "scaling glyph down from %d to %d\n", from_width, to_width );*/
     /* LOCAL_DEBUG_OUT( "smaller %d, bigger %d, eps %d", smaller, bigger, eps ); */
     /* now using Bresengham algoritm to fiill the scales :
@@ -755,7 +755,7 @@ load_X11_glyph_range( Display *dpy, ASFont *font, XFontStruct *xfs, size_t char_
 		XCharStruct *chars = &(xfs->per_char[char_offset+r->min_char-min_char]);
         int len = ((int)r->max_char-(int)r->min_char)+1;
 		unsigned char char_base = r->min_char&0x00FF;
-		register int i ;
+		int i ;
 		Pixmap p;
 		XImage *xim;
 		unsigned int total_width = 0 ;
@@ -803,7 +803,7 @@ LOCAL_DEBUG_OUT( "loading glyph range of %lu-%lu", r->min_char, r->max_char );
 		pen_x = 0 ;
 		for( i = 0 ; i < len ; i++ )
 		{
-			register int x, y ;
+			int x, y ;
 			int width = r->glyphs[i].width;
 			unsigned char *row = &(buffer[0]);
 
@@ -1006,7 +1006,7 @@ load_X11_glyphs( Display *dpy, ASFont *font, XFontStruct *xfs )
 static void
 load_glyph_freetype( ASFont *font, ASGlyph *asg, int glyph, UNICODE_CHAR uc )
 {
-	register FT_Face face ;
+	FT_Face face ;
 	static CARD8 *glyph_compress_buf = NULL, *glyph_scaling_buf = NULL ;
 	static int glyph_compress_buf_size = 0, glyph_scaling_buf_size = 0;
 
@@ -1037,7 +1037,7 @@ load_glyph_freetype( ASFont *font, ASGlyph *asg, int glyph, UNICODE_CHAR uc )
 	if( face->glyph->bitmap.buffer )
 	{
 		FT_Bitmap 	*bmap = &(face->glyph->bitmap) ;
-		register CARD8 *src = bmap->buffer ;
+		CARD8 *src = bmap->buffer ;
 		int src_step ;
 /* 		int hpad = (face->glyph->bitmap_left<0)? -face->glyph->bitmap_left: face->glyph->bitmap_left ;
 */
@@ -1088,7 +1088,7 @@ load_glyph_freetype( ASFont *font, ASGlyph *asg, int glyph, UNICODE_CHAR uc )
 			}	
 			if( (int)asg->width + asg->lead > (int)font->space_size )
 			{	
-				register CARD8 *buf ;
+				CARD8 *buf ;
 				int i ;
 				asg->width = (int)font->space_size - asg->lead ;
 				if( glyph_scaling_buf_size  < bmap->width*bmap->rows*2 )
@@ -1143,7 +1143,7 @@ split_freetype_glyph_range( unsigned long min_char, unsigned long max_char, FT_F
 LOCAL_DEBUG_CALLER_OUT( "min_char = %lu, max_char = %lu, face = %p", min_char, max_char, face );
 	while( min_char <= max_char )
 	{
-		register unsigned long i = min_char;
+		unsigned long i = min_char;
 		while( i <= max_char && FT_Get_Char_Index( face, CHAR2UNICODE(i)) == 0 ) i++ ;
 		if( i <= max_char )
 		{
@@ -1191,7 +1191,7 @@ load_freetype_locale_glyph( ASFont *font, UNICODE_CHAR uc )
 static void
 load_freetype_locale_glyphs( unsigned long min_char, unsigned long max_char, ASFont *font )
 {
-	register unsigned long i = min_char ;
+	unsigned long i = min_char ;
 LOCAL_DEBUG_CALLER_OUT( "min_char = %lu, max_char = %lu, font = %p", min_char, max_char, font );
 	if( font->locale_glyphs == NULL )
 		font->locale_glyphs = create_ashash( 0, NULL, NULL, asglyph_destroy );
@@ -1270,7 +1270,7 @@ load_freetype_glyphs( ASFont *font )
 
 static inline ASGlyph *get_unicode_glyph( const UNICODE_CHAR uc, ASFont *font )
 {
-	register ASGlyphRange *r;
+	ASGlyphRange *r;
 	ASGlyph *asg = NULL ;
 	ASHashData hdata = {0} ;
 	for( r = font->codemap ; r != NULL ; r = r->above )
@@ -1529,18 +1529,18 @@ free_glyph_map( ASGlyphMap *map, Bool reusable )
 static int
 get_text_length (ASCharType char_type, const char *text)
 {
-	register int count = 0;
+	int count = 0;
 	if( char_type == ASCT_Char )
 	{
-		register char *ptr = (char*)text ;
+		char *ptr = (char*)text ;
 		while( ptr[count] != 0 )++count;
 	}else if( char_type == ASCT_UTF8 )
 	{
-		register char *ptr = (char*)text ;
+		char *ptr = (char*)text ;
 		while( *ptr != 0 ){	++count; ptr += UTF8_CHAR_SIZE(*ptr); }
 	}else if( char_type == ASCT_Unicode )
 	{
-		register UNICODE_CHAR *uc_ptr = (UNICODE_CHAR*)text ;
+		UNICODE_CHAR *uc_ptr = (UNICODE_CHAR*)text ;
 		while( uc_ptr[count] != 0 )	++count;
 	}
 	return count;
@@ -1561,12 +1561,12 @@ get_text_glyph_list (const char *text, ASFont *font, ASCharType char_type, int l
 	glyphs = safecalloc( length+1, sizeof(ASGlyph*));
 	if (char_type == ASCT_Char)
 	{
-		register char *ptr = (char*)text;
+		char *ptr = (char*)text;
 		for (i = 0 ; i < length ; ++i)
 			glyphs[i] = get_character_glyph (ptr[i], font);
 	}else if (char_type == ASCT_UTF8)
 	{
-		register char *ptr = (char*)text;
+		char *ptr = (char*)text;
 		for (i = 0 ; i < length ; ++i)
 		{
 			glyphs[i] = get_utf8_glyph (ptr, font);
@@ -1574,7 +1574,7 @@ get_text_glyph_list (const char *text, ASFont *font, ASCharType char_type, int l
 		}		
 	}else if( char_type == ASCT_Unicode )
 	{
-		register UNICODE_CHAR *uc_ptr = (UNICODE_CHAR*)text ;
+		UNICODE_CHAR *uc_ptr = (UNICODE_CHAR*)text ;
 		for (i = 0 ; i < length ; ++i)
 			glyphs[i] = get_unicode_glyph (uc_ptr[i], font);
 	}
@@ -1780,11 +1780,11 @@ render_asglyph( CARD8 **scanlines, CARD8 *row,
 {
 	int count = -1 ;
 	int max_y = y + height ;
-	register CARD32 data = 0;
+	CARD32 data = 0;
 	while( y < max_y )
 	{
-		register CARD8 *dst = scanlines[y]+start_x;
-		register int x = -1;
+		CARD8 *dst = scanlines[y]+start_x;
+		int x = -1;
 		while( ++x < width )
 		{
 /*fprintf( stderr, "data = %X, count = %d, x = %d, y = %d\n", data, count, x, y );*/
@@ -1820,11 +1820,11 @@ render_asglyph_over( CARD8 **scanlines, CARD8 *row,
 	int count = -1 ;
 	int max_y = y + height ;
 	CARD32 anti_data = 0;
-	register CARD32 data = 0;
+	CARD32 data = 0;
 	while( y < max_y )
 	{
-		register CARD8 *dst = scanlines[y]+start_x;
-		register int x = -1;
+		CARD8 *dst = scanlines[y]+start_x;
+		int x = -1;
 		while( ++x < width )
 		{
 /*fprintf( stderr, "data = %X, count = %d, x = %d, y = %d\n", data, count, x, y );*/

--- a/graf2d/asimage/src/libAfterImage/asimage.c
+++ b/graf2d/asimage/src/libAfterImage/asimage.c
@@ -126,7 +126,7 @@ asimage_init (ASImage * im, Bool free_resources)
 	{
 		if (free_resources)
 		{
-			register int i ;
+			int i ;
 			for( i = im->height*4-1 ; i>= 0 ; --i )
 				if( im->red[i] != 0 )
 					forget_data( NULL, im->red[i] );
@@ -723,7 +723,7 @@ flip_gradient( ASGradient *orig, int flip )
 	grad->type = type ;
 	if( inverse_points )
     {
-        register int i = 0, k = npoints;
+        int i = 0, k = npoints;
         while( --k >= 0 )
         {
             grad->color[i] = orig->color[k] ;
@@ -732,7 +732,7 @@ flip_gradient( ASGradient *orig, int flip )
         }
     }else
 	{
-        register int i = npoints ;
+        int i = npoints ;
         while( --i >= 0 )
         {
             grad->color[i] = orig->color[i] ;
@@ -745,7 +745,7 @@ flip_gradient( ASGradient *orig, int flip )
 /* ******************** ASImageLayer ****************************/
 
 void
-init_image_layers( register ASImageLayer *l, int count )
+init_image_layers( ASImageLayer *l, int count )
 {
 	memset( l, 0x00, sizeof(ASImageLayer)*count );
 	while( --count >= 0 )
@@ -769,11 +769,11 @@ create_image_layers( int count )
 }
 
 void
-destroy_image_layers( register ASImageLayer *l, int count, Bool reusable )
+destroy_image_layers( ASImageLayer *l, int count, Bool reusable )
 {
 	if( l )
 	{
-		register int i = count;
+		int i = count;
 		while( --i >= 0 )
 		{
 			if( l[i].im )
@@ -814,7 +814,7 @@ asimage_add_line_mono (ASImage * im, ColorPart color, CARD8 value, unsigned int 
 }
 
 size_t
-asimage_add_line (ASImage * im, ColorPart color, register CARD32 * data, unsigned int y)
+asimage_add_line (ASImage * im, ColorPart color, CARD32 * data, unsigned int y)
 {
    int colint = (int) color;
 	if (AS_ASSERT(im) || colint <0 || color >= IC_NUM_CHANNELS )
@@ -828,7 +828,7 @@ asimage_add_line (ASImage * im, ColorPart color, register CARD32 * data, unsigne
 }
 
 size_t
-asimage_add_line_bgra (ASImage * im, register CARD32 * data, unsigned int y)
+asimage_add_line_bgra (ASImage * im, CARD32 * data, unsigned int y)
 {
 	if (AS_ASSERT(im) )
 		return 0;
@@ -873,7 +873,7 @@ void print_asimage( ASImage *im, int flags, char * func, int line )
 {
 	if( im )
 	{
-		register unsigned int k ;
+		unsigned int k ;
 		int total_mem = 0 ;
 		fprintf( stderr, "%s:%d> printing ASImage %p.\n", func, line, im);
 		for( k = 0 ; k < im->height ; k++ )
@@ -889,13 +889,13 @@ void print_asimage( ASImage *im, int flags, char * func, int line )
 		fprintf( stderr, "%s:%d> Attempted to print NULL ASImage.\n", func, line);
 }
 
-void print_component( register CARD32 *data, int nonsense, int len );
+void print_component( CARD32 *data, int nonsense, int len );
 
 int
 asimage_decode_line (ASImage * im, ColorPart color, CARD32 * to_buf, unsigned int y, unsigned int skip, unsigned int out_width)
 {
 	ASStorageID id = im->channels[color][y];
-	register int i = 0;
+	int i = 0;
 	/* that thing below is supposedly highly optimized : */
 LOCAL_DEBUG_CALLER_OUT( "im->width = %d, color = %d, y = %d, skip = %d, out_width = %d", im->width, color, y, skip, out_width );
 
@@ -923,9 +923,9 @@ move_asimage_channel( ASImage *dst, int channel_dst, ASImage *src, int channel_s
 	if( !AS_ASSERT(dst) && !AS_ASSERT(src) && channel_src >= 0 && channel_src < IC_NUM_CHANNELS &&
 		channel_dst >= 0 && channel_dst < IC_NUM_CHANNELS )
 	{
-		register int i = MIN(dst->height, src->height);
-		register ASStorageID *dst_rows = dst->channels[channel_dst] ;
-		register ASStorageID *src_rows = src->channels[channel_src] ;
+		int i = MIN(dst->height, src->height);
+		ASStorageID *dst_rows = dst->channels[channel_dst] ;
+		ASStorageID *src_rows = src->channels[channel_src] ;
 		while( --i >= 0 )
 		{
 			if( dst_rows[i] )
@@ -943,9 +943,9 @@ copy_asimage_channel( ASImage *dst, int channel_dst, ASImage *src, int channel_s
 	if( !AS_ASSERT(dst) && !AS_ASSERT(src) && channel_src >= 0 && channel_src < IC_NUM_CHANNELS &&
 		channel_dst >= 0 && channel_dst < IC_NUM_CHANNELS )
 	{
-		register int i = MIN(dst->height, src->height);
-		register ASStorageID *dst_rows = dst->channels[channel_dst] ;
-		register ASStorageID *src_rows = src->channels[channel_src] ;
+		int i = MIN(dst->height, src->height);
+		ASStorageID *dst_rows = dst->channels[channel_dst] ;
+		ASStorageID *src_rows = src->channels[channel_src] ;
 		LOCAL_DEBUG_OUT( "src = %p, dst = %p, dst->width = %d, src->width = %d", src, dst, dst->width, src->width );
 		while( --i >= 0 )
 		{
@@ -974,9 +974,9 @@ copy_asimage_lines( ASImage *dst, unsigned int offset_dst,
 		for( chan = 0 ; chan < IC_NUM_CHANNELS ; ++chan )
 			if( get_flags( filter, 0x01<<chan ) )
 			{
-				register int i = -1;
-				register ASStorageID *dst_rows = &(dst->channels[chan][offset_dst]) ;
-				register ASStorageID *src_rows = &(src->channels[chan][offset_src]) ;
+				int i = -1;
+				ASStorageID *dst_rows = &(dst->channels[chan][offset_dst]) ;
+				ASStorageID *src_rows = &(src->channels[chan][offset_src]) ;
 LOCAL_DEBUG_OUT( "copying %d lines of channel %d...", nlines, chan );
 				while( ++i < (int)nlines )
 				{
@@ -998,7 +998,7 @@ LOCAL_DEBUG_OUT( "copying %d lines of channel %d...", nlines, chan );
 Bool
 asimage_compare_line (ASImage *im, ColorPart color, CARD32 *to_buf, CARD32 *tmp, unsigned int y, Bool verbose)
 {
-	register unsigned int i;
+	unsigned int i;
 	asimage_decode_line( im, color, tmp, y, 0, im->width );
 	for( i = 0 ; i < im->width ; i++ )
 		if( tmp[i] != to_buf[i] )
@@ -1019,8 +1019,8 @@ get_asimage_chanmask( ASImage *im)
 	if( !AS_ASSERT(im) )
 		for( color = 0; color < IC_NUM_CHANNELS ; color++ )
 		{
-			register ASStorageID *chan = im->channels[color];
-			register int y, height = im->height ;
+			ASStorageID *chan = im->channels[color];
+			int y, height = im->height ;
 			for( y = 0 ; y < height ; y++ )
 				if( chan[y] )
 				{
@@ -1085,7 +1085,7 @@ check_asimage_alpha (ASVisual *asv, ASImage *im )
 /* Vector -> ASImage functions :                                                  */
 /* ********************************************************************************/
 Bool
-set_asimage_vector( ASImage *im, register double *vector )
+set_asimage_vector( ASImage *im, double *vector )
 {
 	if( vector == NULL || im == NULL )
 		return False;
@@ -1094,8 +1094,8 @@ set_asimage_vector( ASImage *im, register double *vector )
 		im->alt.vector = safemalloc( im->width*im->height*sizeof(double));
 
 	{
-		register double *dst = im->alt.vector ;
-		register int i = im->width*im->height;
+		double *dst = im->alt.vector ;
+		int i = im->width*im->height;
 		while( --i >= 0 )
 			dst[i] = vector[i] ;
 	}
@@ -1187,9 +1187,9 @@ clone_asimage( ASImage *src, ASFlagType filter )
 		for( chan = 0 ; chan < IC_NUM_CHANNELS;  chan++ )
 			if( get_flags( filter, 0x01<<chan) )
 			{
-				register int i = dst->height;
-				register ASStorageID *dst_rows = dst->channels[chan] ;
-				register ASStorageID *src_rows = src->channels[chan] ;
+				int i = dst->height;
+				ASStorageID *dst_rows = dst->channels[chan] ;
+				ASStorageID *src_rows = src->channels[chan] ;
 				while( --i >= 0 )
 					dst_rows[i] = dup_data( NULL, src_rows[i] );
 			}
@@ -1451,9 +1451,9 @@ get_asimage_channel_rects( ASImage *src, int channel, unsigned int threshold, un
 
 /***********************************************************************************/
 void
-raw2scanline( register CARD8 *row, ASScanline *buf, CARD8 *gamma_table, unsigned int width, Bool grayscale, Bool do_alpha )
+raw2scanline( CARD8 *row, ASScanline *buf, CARD8 *gamma_table, unsigned int width, Bool grayscale, Bool do_alpha )
 {
-	register int x = width;
+	int x = width;
 
 	if( grayscale )
 		row += do_alpha? width<<1 : width ;

--- a/graf2d/asimage/src/libAfterImage/asimage.h
+++ b/graf2d/asimage/src/libAfterImage/asimage.h
@@ -565,7 +565,7 @@ Bool asimage_replace (ASImage *im, ASImage *from);
  * set_asimage_vector() This function replaces contents of the vector 
  * member of ASImage structure with new double precision data.
  * SYNOPSIS
- * set_asimage_vector( ASImage *im, register double *vector );
+ * set_asimage_vector( ASImage *im, double *vector );
  * INPUTS
  * im				- pointer to valid ASImage structure.
  * vector           - scientific data to attach to the image.
@@ -573,7 +573,7 @@ Bool asimage_replace (ASImage *im, ASImage *from);
  * Data must have size of width*height ahere width and height are size of 
  * the ASImage.
  *********/
-Bool set_asimage_vector( ASImage *im, register double *vector );
+Bool set_asimage_vector( ASImage *im, double *vector );
 /****f* libAfterImage/asimage/vectorize_asimage()
  * NAME
  * vectorize_asimage() This function replaces contents of the vector 
@@ -792,7 +792,7 @@ ASGradient *flip_gradient( ASGradient *orig, int flip );
  * NAME 
  * init_image_layers()    - initialize set of ASImageLayer structures.
  * SYNOPSIS
- * void init_image_layers( register ASImageLayer *l, int count );
+ * void init_image_layers( ASImageLayer *l, int count );
  * INPUTS
  * l              - pointer to valid ASImageLayer structure.
  * count          - number of elements to initialize.
@@ -800,7 +800,7 @@ ASGradient *flip_gradient( ASGradient *orig, int flip );
  * Initializes array on ASImageLayer structures to sensible defaults.
  * Basically - all zeros and merge_scanlines == alphablend_scanlines.
  *********/
-void init_image_layers( register ASImageLayer *l, int count );
+void init_image_layers( ASImageLayer *l, int count );
 /****f* libAfterImage/asimage/create_image_layers()
  * NAME 
  * create_image_layers()  - allocate and initialize set of ASImageLayer's.
@@ -822,7 +822,7 @@ ASImageLayer *create_image_layers( int count );
  * NAME 
  * destroy_image_layers() - destroy set of ASImageLayer structures.
  * SYNOPSIS
- * void destroy_image_layers( register ASImageLayer *l,
+ * void destroy_image_layers( ASImageLayer *l,
  *                            int count,
  *                            Bool reusable );
  * INPUTS
@@ -836,7 +836,7 @@ ASImageLayer *create_image_layers( int count );
  * If there was ASImage and/or ASImageBevel attached to it - it will be
  * deallocated as well.
  *********/
-void destroy_image_layers( register ASImageLayer *l, int count, Bool reusable );
+void destroy_image_layers( ASImageLayer *l, int count, Bool reusable );
 
 /****f* libAfterImage/asimage/asimage_add_line()
  * NAME
@@ -945,7 +945,7 @@ void destroy_image_layers( register ASImageLayer *l, int count, Bool reusable );
  *********/
 size_t asimage_add_line (ASImage * im, ColorPart color, CARD32 * data, unsigned int y);
 size_t asimage_add_line_mono (ASImage * im, ColorPart color, CARD8 value, unsigned int y);
-size_t asimage_add_line_bgra (ASImage * im, register CARD32 * data, unsigned int y);
+size_t asimage_add_line_bgra (ASImage * im, CARD32 * data, unsigned int y);
 
 ASFlagType get_asimage_chanmask( ASImage *im);
 int check_asimage_alpha (ASVisual *asv, ASImage *im );
@@ -1076,7 +1076,7 @@ do{	f((c1).red,(c2).red,(c3).red,(c4).red,(o1).red,(o2).red,(p),(len+(len&0x01))
 #define QUANT_ERR_BITS  	8
 #define QUANT_ERR_MASK  	0x000000FF
 
-void copy_component( register CARD32 *src, register CARD32 *dst, int *unused, int len );
+void copy_component( CARD32 *src, CARD32 *dst, int *unused, int len );
 
 #ifdef X_DISPLAY_MISSING
 typedef struct XRectangle
@@ -1110,7 +1110,7 @@ XRectangle*
 get_asimage_channel_rects( ASImage *src, int channel, unsigned int threshold, unsigned int *rects_count_ret );
 
 void
-raw2scanline( register CARD8 *row, struct ASScanline *buf, CARD8 *gamma_table, unsigned int width, Bool grayscale, Bool do_alpha );
+raw2scanline( CARD8 *row, struct ASScanline *buf, CARD8 *gamma_table, unsigned int width, Bool grayscale, Bool do_alpha );
 
 #ifdef __cplusplus
 }

--- a/graf2d/asimage/src/libAfterImage/asimagexml.c
+++ b/graf2d/asimage/src/libAfterImage/asimagexml.c
@@ -231,7 +231,7 @@ compose_asimage_xml_from_doc(ASVisual *asv, ASImageManager *imman, ASFontManager
 
 		if( !local_dir_included )
 		{
-			register int i = 0;
+			int i = 0;
 			char **paths = my_imman->search_path ;
 			while( i < MAX_SEARCH_PATHS && paths[i] != NULL ) ++i;
 			if( i < MAX_SEARCH_PATHS ) 
@@ -2138,7 +2138,7 @@ handle_asxml_tag_tile( ASImageXMLState *state, xml_elem_t* doc, xml_elem_t* parm
 	}
 	if( complement_str )
 	{
-		register char *ptr = complement_str ;
+		char *ptr = complement_str ;
 		CARD32 a = ARGB32_ALPHA8(tint),
 				r = ARGB32_RED8(tint),
 				g = ARGB32_GREEN8(tint),

--- a/graf2d/asimage/src/libAfterImage/asstorage.c
+++ b/graf2d/asimage/src/libAfterImage/asstorage.c
@@ -131,9 +131,9 @@ rlediff_compress_bitmap32( CARD8 *buffer,  CARD8* data, int size, CARD32 bitmap_
 
 
 static void
-compute_diff8( register ASStorageDiff *diff, register CARD8 *data, int size ) 
+compute_diff8( ASStorageDiff *diff, CARD8 *data, int size ) 
 {
-	register int i = 0;	
+	int i = 0;	
 	diff[0] = data[0] ;
 /*	fprintf( stderr, "%d(%4.4X) ", diff[0], diff[0] ); */
 	while( ++i < size ) 
@@ -145,10 +145,10 @@ compute_diff8( register ASStorageDiff *diff, register CARD8 *data, int size )
 }	   
 
 static void
-compute_diff32( register ASStorageDiff *diff, CARD8 *data, int size ) 
+compute_diff32( ASStorageDiff *diff, CARD8 *data, int size ) 
 {
-	register int i = 0;	
-	register CARD32 *data32 = (CARD32*)data ;
+	int i = 0;	
+	CARD32 *data32 = (CARD32*)data ;
 	diff[0] = data32[0] ;
 /*	fprintf( stderr, "\n0:%d(%4.4X) ", diff[0], diff[0] ); */
 	while( ++i < size ) 
@@ -160,90 +160,90 @@ compute_diff32( register ASStorageDiff *diff, CARD8 *data, int size )
 }	   
 
 static void
-compute_diff32_8bitshift( register ASStorageDiff *diff, CARD8 *data, int size ) 
+compute_diff32_8bitshift( ASStorageDiff *diff, CARD8 *data, int size ) 
 {
-	register int i = 0;	
-	register CARD32 *data32 = (CARD32*)data ;
-	register ASStorageDiff dp = data32[0]>>8;
+	int i = 0;	
+	CARD32 *data32 = (CARD32*)data ;
+	ASStorageDiff dp = data32[0]>>8;
 	diff[0] = dp ;
 	while( ++i < size ) 
 	{
-		register ASStorageDiff d = data32[i]>>8;
+		ASStorageDiff d = data32[i]>>8;
 		diff[i] = d - dp ;
 		dp = d;
 	}
 }	   
 
 static void
-compute_diff32_16bitshift( register ASStorageDiff *diff, CARD8 *data, int size ) 
+compute_diff32_16bitshift( ASStorageDiff *diff, CARD8 *data, int size ) 
 {
-	register int i = 0;	
-	register CARD32 *data32 = (CARD32*)data ;
-	register ASStorageDiff dp = data32[0]>>16;
+	int i = 0;	
+	CARD32 *data32 = (CARD32*)data ;
+	ASStorageDiff dp = data32[0]>>16;
 	diff[0] = dp ;
 	while( ++i < size ) 
 	{
-		register ASStorageDiff d = data32[i]>>16;
+		ASStorageDiff d = data32[i]>>16;
 		diff[i] = d - dp ;
 		dp = d;
 	}
 }	   
 
 static void
-compute_diff32_masked( register ASStorageDiff *diff, CARD8 *data, int size ) 
+compute_diff32_masked( ASStorageDiff *diff, CARD8 *data, int size ) 
 {
-	register int i = 0;	
-	register CARD32 *data32 = (CARD32*)data ;
-	register ASStorageDiff dp = data32[0]&0x0ff;
+	int i = 0;	
+	CARD32 *data32 = (CARD32*)data ;
+	ASStorageDiff dp = data32[0]&0x0ff;
 	diff[0] = dp ;
 	while( ++i < size ) 
 	{
-		register ASStorageDiff d = data32[i]&0x0ff;
+		ASStorageDiff d = data32[i]&0x0ff;
 		diff[i] = d - dp ;
 		dp = d;
 	}
 }	   
 
 static void
-compute_diff32_8bitshift_masked( register ASStorageDiff *diff, CARD8 *data, int size ) 
+compute_diff32_8bitshift_masked( ASStorageDiff *diff, CARD8 *data, int size ) 
 {
-	register int i = 0;	
-	register CARD32 *data32 = (CARD32*)data ;
-	register ASStorageDiff dp = (data32[0]>>8)&0x0ff;
+	int i = 0;	
+	CARD32 *data32 = (CARD32*)data ;
+	ASStorageDiff dp = (data32[0]>>8)&0x0ff;
 	diff[0] = dp ;
 	while( ++i < size ) 
 	{
-		register ASStorageDiff d = (data32[i]>>8)&0x0ff;
+		ASStorageDiff d = (data32[i]>>8)&0x0ff;
 		diff[i] = d - dp ;
 		dp = d;
 	}
 }	   
 
 static void
-compute_diff32_16bitshift_masked( register ASStorageDiff *diff, CARD8 *data, int size ) 
+compute_diff32_16bitshift_masked( ASStorageDiff *diff, CARD8 *data, int size ) 
 {
-	register int i = 0;	
-	register CARD32 *data32 = (CARD32*)data ;
-	register ASStorageDiff dp = (data32[0]>>16)&0x0ff;
+	int i = 0;	
+	CARD32 *data32 = (CARD32*)data ;
+	ASStorageDiff dp = (data32[0]>>16)&0x0ff;
 	diff[0] = dp ;
 	while( ++i < size ) 
 	{
-		register ASStorageDiff d = (data32[i]>>16)&0x0ff;
+		ASStorageDiff d = (data32[i]>>16)&0x0ff;
 		diff[i] = d - dp ;
 		dp = d;
 	}
 }	   
 
 static void
-compute_diff32_24bitshift_masked( register ASStorageDiff *diff, CARD8 *data, int size ) 
+compute_diff32_24bitshift_masked( ASStorageDiff *diff, CARD8 *data, int size ) 
 {
-	register int i = 0;	
-	register CARD32 *data32 = (CARD32*)data ;
-	register ASStorageDiff dp = (data32[0]>>24)&0x0ff;
+	int i = 0;	
+	CARD32 *data32 = (CARD32*)data ;
+	ASStorageDiff dp = (data32[0]>>24)&0x0ff;
 	diff[0] = dp ;
 	while( ++i < size ) 
 	{
-		register ASStorageDiff d = (data32[i]>>24)&0x0ff;
+		ASStorageDiff d = (data32[i]>>24)&0x0ff;
 		diff[i] = d - dp ;
 		dp = d;
 	}
@@ -1145,8 +1145,8 @@ defragment_storage_block( ASStorageBlock *block )
 		if( used != brk	)
 		{/* can't use memcpy as regions may overlap */
 			int size = (ASStorageSlot_FULL_SIZE(used))/4;
-			register CARD32 *from = (CARD32*)used ;
-			register CARD32 *to = (CARD32*)brk ;
+			CARD32 *from = (CARD32*)used ;
+			CARD32 *to = (CARD32*)brk ;
 			for( i = 0 ; i < size ; ++i ) 
 				to[i] = from[i];
 		}	
@@ -1296,8 +1296,8 @@ split_storage_slot( ASStorageBlock *block, ASStorageSlot *slot, int to_size )
 		new_slot->index = ++(block->last_used) ;
 	}else
 	{
-		register int i, max_i = block->slots_count ;
-		register ASStorageSlot **slots = block->slots ;
+		int i, max_i = block->slots_count ;
+		ASStorageSlot **slots = block->slots ;
 		LOCAL_DEBUG_OUT( "max_i = %d", max_i );
 		
 		for( i = 0 ; i < max_i ; ++i ) 
@@ -1587,7 +1587,7 @@ typedef void (*data_cpy_func_type)(ASStorageDstBuffer *, void *, size_t);
 
 static void card8_card8_cpy( ASStorageDstBuffer *dst, void *src, size_t size)
 {
-	register CARD8 *dst8 = (CARD8*)dst->buffer ;
+	CARD8 *dst8 = (CARD8*)dst->buffer ;
 	dst8 += dst->offset ;
 	memcpy( dst8, src, size );
 }	 
@@ -1595,9 +1595,9 @@ static void card8_card8_cpy( ASStorageDstBuffer *dst, void *src, size_t size)
 
 static void card8_card32_cpy( ASStorageDstBuffer *dst, void *src, size_t size)
 {
-	register CARD32 *dst32 = (CARD32*)dst->buffer + dst->offset ;
-	register CARD8  *src8  = (CARD8*)src ;
-	register int i;
+	CARD32 *dst32 = (CARD32*)dst->buffer + dst->offset ;
+	CARD8  *src8  = (CARD8*)src ;
+	int i;
 	for( i = 0 ;  i < (int)size ; ++i ) 
 		dst32[i] = src8[i] ;
 }	 
@@ -2229,7 +2229,7 @@ make_storage_test_data( ASStorageTest *test, int min_size, int max_size, ASFlagT
 int 
 test_data_integrity( CARD8 *a, CARD8* b, int size, ASFlagType flags ) 
 {
-	register int i ;
+	int i ;
 	CARD32 *b32 = (CARD32*)b;
 	CARD32 threshold32 = AS_STORAGE_DEFAULT_BMAP_THRESHOLD ;
 	CARD32 threshold8 = AS_STORAGE_DEFAULT_BMAP_THRESHOLD ;

--- a/graf2d/asimage/src/libAfterImage/asvisual.c
+++ b/graf2d/asimage/src/libAfterImage/asvisual.c
@@ -96,8 +96,8 @@ debug_AllocColor( const char *file, int line, ASVisual *asv, Colormap cmap, XCol
 long
 ARGB32_manhattan_distance (long a, long b)
 {
-	register int d = (int)ARGB32_RED8(a)   - (int)ARGB32_RED8(b);
-	register int t = (d < 0 )? -d : d ;
+	int d = (int)ARGB32_RED8(a)   - (int)ARGB32_RED8(b);
+	int t = (d < 0 )? -d : d ;
 
 	d = (int)ARGB32_GREEN8(a) - (int)ARGB32_GREEN8(b);
 	t += (d < 0)? -d : d ;
@@ -115,8 +115,8 @@ int get_bits_per_pixel(Display *dpy, int depth)
 {
 #if 0
 #ifndef X_DISPLAY_MISSING
- 	register ScreenFormat *fmt = dpy->pixmap_format;
- 	register int i;
+ 	ScreenFormat *fmt = dpy->pixmap_format;
+ 	int i;
 
  	for (i = dpy->nformats + 1; --i; ++fmt)
  		if (fmt->depth == depth)
@@ -295,7 +295,7 @@ query_screen_visual_id( ASVisual *asv, Display *dpy, int screen, Window root, in
 
 	if( asv->visual_info.visual == NULL )
 	{  /* we ain't found any decent Visuals - that's some crappy screen you have! */
-		register int vclass = 6 ;
+		int vclass = 6 ;
 		while( --vclass >= 0 )
 			if( XMatchVisualInfo( dpy, screen, default_depth, vclass, &(asv->visual_info) ) )
 				break;
@@ -458,7 +458,7 @@ visual2visual_prop( ASVisual *asv, size_t *size_ret,
 	prop[4] = asv->as_colormap_type ;
 	if( cmap_size > 0 )
 	{
-		register int i;
+		int i;
 		for( i = 0 ; i < cmap_size ; i++ )
 			prop[i+5] = asv->as_colormap[i] ;
 	}
@@ -519,7 +519,7 @@ visual_prop2visual( ASVisual *asv, Display *dpy, int screen,
 
 	if( cmap_size > 0 )
 	{
-		register int i ;
+		int i ;
 		if( asv->as_colormap )
 			free( asv->as_colormap );
 		asv->as_colormap = safemalloc( cmap_size );
@@ -625,7 +625,7 @@ make_reverse_colormap( unsigned long *cmap, size_t size, int depth, unsigned sho
 {
 	unsigned int max_pixel = 0x01<<depth ;
 	ARGB32 *rcmap = safecalloc( max_pixel, sizeof( ARGB32 ) );
-	register int i ;
+	int i ;
 
 	for( i = 0 ; i < (int)size ; i++ )
 		if( cmap[i] < max_pixel )
@@ -637,7 +637,7 @@ ASHashTable *
 make_reverse_colorhash( unsigned long *cmap, size_t size, int depth, unsigned short mask, unsigned short shift )
 {
 	ASHashTable *hash = create_ashash( 0, NULL, NULL, NULL );
-	register unsigned int i ;
+	unsigned int i ;
 
 	if( hash )
 	{
@@ -1535,7 +1535,7 @@ XImage*
 create_visual_ximage( ASVisual *asv, unsigned int width, unsigned int height, unsigned int depth )
 {
 #ifndef X_DISPLAY_MISSING
-	register XImage *ximage = NULL;
+	XImage *ximage = NULL;
 	unsigned long dsize;
 	char         *data;
 	int unit ;
@@ -1618,7 +1618,7 @@ XImage*
 create_visual_scratch_ximage( ASVisual *asv, unsigned int width, unsigned int height, unsigned int depth )
 {
 #ifndef X_DISPLAY_MISSING
-	register XImage *ximage = NULL;
+	XImage *ximage = NULL;
 	char         *data;
 	int unit ;
 
@@ -1680,7 +1680,7 @@ create_visual_scratch_ximage( ASVisual *asv, unsigned int width, unsigned int he
 static int
 get_shifts (unsigned long mask)
 {
-	register int  i = 1;
+	int  i = 1;
 
 	while (mask >> i)
 		i++;
@@ -1691,7 +1691,7 @@ get_shifts (unsigned long mask)
 static int
 get_bits (unsigned long mask)
 {
-	register int  i;
+	int  i;
 
 	for (i = 0; mask; mask >>= 1)
 		if (mask & 1)
@@ -1751,46 +1751,46 @@ CARD32 color2pixel24rgb(ASVisual *asv, CARD32 encoded_color, unsigned long *pixe
 }
 CARD32 color2pixel16bgr(ASVisual *asv, CARD32 encoded_color, unsigned long *pixel)
 {
-	register CARD32 c = encoded_color ;
+	CARD32 c = encoded_color ;
     *pixel = ((c&0x000000F8)<<8)|((c&0x0000FC00)>>5)|((c&0x00F80000)>>19);
 	return (c>>1)&0x00030103;
 }
 CARD32 color2pixel16rgb(ASVisual *asv, CARD32 encoded_color, unsigned long *pixel)
 {
-	register CARD32 c = encoded_color ;
+	CARD32 c = encoded_color ;
     *pixel = ((c&0x00F80000)>>8)|((c&0x0000FC00)>>5)|((c&0x000000F8)>>3);
 	return (c>>1)&0x00030103;
 }
 CARD32 color2pixel15bgr(ASVisual *asv, CARD32 encoded_color, unsigned long *pixel)
 {
-	register CARD32 c = encoded_color ;
+	CARD32 c = encoded_color ;
     *pixel = ((c&0x000000F8)<<7)|((c&0x0000F800)>>6)|((c&0x00F80000)>>19);
 	return (c>>1)&0x00030303;
 }
 CARD32 color2pixel15rgb(ASVisual *asv, CARD32 encoded_color, unsigned long *pixel)
 {
-	register CARD32 c = encoded_color ;
+	CARD32 c = encoded_color ;
     *pixel = ((c&0x00F80000)>>9)|((c&0x0000F800)>>6)|((c&0x000000F8)>>3);
 	return (c>>1)&0x00030303;
 }
 
 CARD32 color2pixel_pseudo3bpp( ASVisual *asv, CARD32 encoded_color, unsigned long *pixel )
 {
-	register CARD32 c = encoded_color ;
+	CARD32 c = encoded_color ;
 	*pixel = asv->as_colormap[((c>>25)&0x0008)|((c>>16)&0x0002)|((c>>7)&0x0001)];
 	return (c>>1)&0x003F3F3F;
 }
 
 CARD32 color2pixel_pseudo6bpp( ASVisual *asv, CARD32 encoded_color, unsigned long *pixel )
 {
-	register CARD32 c = encoded_color ;
+	CARD32 c = encoded_color ;
 	*pixel = asv->as_colormap[((c>>22)&0x0030)|((c>>14)&0x000C)|((c>>6)&0x0003)];
 	return (c>>1)&0x001F1F1F;
 }
 
 CARD32 color2pixel_pseudo12bpp( ASVisual *asv, CARD32 encoded_color, unsigned long *pixel )
 {
-	register CARD32 c = encoded_color ;
+	CARD32 c = encoded_color ;
 	*pixel = asv->as_colormap[((c>>16)&0x0F00)|((c>>10)&0x00F0)|((c>>4)&0x000F)];
 	return (c>>1)&0x00070707;
 }
@@ -1812,12 +1812,12 @@ void pixel2color15rgb(ASVisual *asv, unsigned long pixel, CARD32 *red, CARD32 *g
 void pixel2color15bgr(ASVisual *asv, unsigned long pixel, CARD32 *red, CARD32 *green, CARD32 *blue)
 {}
 
-void ximage2scanline32(ASVisual *asv, XImage *xim, ASScanline *sl, int y,  register unsigned char *xim_data )
+void ximage2scanline32(ASVisual *asv, XImage *xim, ASScanline *sl, int y,  unsigned char *xim_data )
 {
-	register CARD32 *r = sl->xc1+sl->offset_x, *g = sl->xc2+sl->offset_x, *b = sl->xc3+sl->offset_x;
-	register CARD32 *a = sl->alpha+sl->offset_x;
+	CARD32 *r = sl->xc1+sl->offset_x, *g = sl->xc2+sl->offset_x, *b = sl->xc3+sl->offset_x;
+	CARD32 *a = sl->alpha+sl->offset_x;
 	int i = MIN((unsigned int)(xim->width),sl->width-sl->offset_x);
-	register CARD32 *src = (CARD32*)xim_data ;
+	CARD32 *src = (CARD32*)xim_data ;
 /*	src += sl->offset_x; */
 /*fprintf( stderr, "%d: ", y);*/
 
@@ -1848,11 +1848,11 @@ void ximage2scanline32(ASVisual *asv, XImage *xim, ASScanline *sl, int y,  regis
 /*fprintf( stderr, "\n");*/
 }
 
-void ximage2scanline16( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  register unsigned char *xim_data )
+void ximage2scanline16( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  unsigned char *xim_data )
 {
-	register int i = MIN((unsigned int)(xim->width),sl->width-sl->offset_x)-1;
-	register CARD16 *src = (CARD16*)xim_data ;
-    register CARD32 *r = sl->xc1+sl->offset_x, *g = sl->xc2+sl->offset_x, *b = sl->xc3+sl->offset_x;
+	int i = MIN((unsigned int)(xim->width),sl->width-sl->offset_x)-1;
+	CARD16 *src = (CARD16*)xim_data ;
+    CARD32 *r = sl->xc1+sl->offset_x, *g = sl->xc2+sl->offset_x, *b = sl->xc3+sl->offset_x;
 #ifdef WORDS_BIGENDIAN
 	if( !asv->msb_first )
 #else
@@ -1875,11 +1875,11 @@ void ximage2scanline16( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  regi
 		}while( --i >= 0);
 
 }
-void ximage2scanline15( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  register unsigned char *xim_data )
+void ximage2scanline15( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  unsigned char *xim_data )
 {
-	register int i = MIN((unsigned int)(xim->width),sl->width-sl->offset_x)-1;
-	register CARD16 *src = (CARD16*)xim_data ;
-    register CARD32 *r = sl->xc1+sl->offset_x, *g = sl->xc2+sl->offset_x, *b = sl->xc3+sl->offset_x;
+	int i = MIN((unsigned int)(xim->width),sl->width-sl->offset_x)-1;
+	CARD16 *src = (CARD16*)xim_data ;
+    CARD32 *r = sl->xc1+sl->offset_x, *g = sl->xc2+sl->offset_x, *b = sl->xc3+sl->offset_x;
 #ifdef WORDS_BIGENDIAN
 	if( !asv->msb_first )
 #else
@@ -1905,10 +1905,10 @@ void ximage2scanline15( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  regi
 #ifndef X_DISPLAY_MISSING
 
 void
-ximage2scanline_pseudo3bpp( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  register unsigned char *xim_data )
+ximage2scanline_pseudo3bpp( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  unsigned char *xim_data )
 {
-	register int i = MIN((unsigned int)(xim->width),sl->width-sl->offset_x)-1;
-    register CARD32 *r = sl->xc1+sl->offset_x, *g = sl->xc2+sl->offset_x, *b = sl->xc3+sl->offset_x;
+	int i = MIN((unsigned int)(xim->width),sl->width-sl->offset_x)-1;
+    CARD32 *r = sl->xc1+sl->offset_x, *g = sl->xc2+sl->offset_x, *b = sl->xc3+sl->offset_x;
 
 	do
 	{
@@ -1927,14 +1927,14 @@ ximage2scanline_pseudo3bpp( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  
 }
 
 void
-ximage2scanline_pseudo6bpp( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  register unsigned char *xim_data )
+ximage2scanline_pseudo6bpp( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  unsigned char *xim_data )
 {
-	register int i = MIN((unsigned int)(xim->width),sl->width-sl->offset_x)-1;
-    register CARD32 *r = sl->xc1+sl->offset_x, *g = sl->xc2+sl->offset_x, *b = sl->xc3+sl->offset_x;
+	int i = MIN((unsigned int)(xim->width),sl->width-sl->offset_x)-1;
+    CARD32 *r = sl->xc1+sl->offset_x, *g = sl->xc2+sl->offset_x, *b = sl->xc3+sl->offset_x;
 
 	if( xim->bits_per_pixel == 8 )
 	{
-		register CARD8 *src = (CARD8*)xim_data ;
+		CARD8 *src = (CARD8*)xim_data ;
 		do
 		{
 			ARGB32 c = asv->as_colormap_reverse.xref[src[i]] ;
@@ -1965,14 +1965,14 @@ ximage2scanline_pseudo6bpp( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  
 }
 
 void
-ximage2scanline_pseudo12bpp( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  register unsigned char *xim_data )
+ximage2scanline_pseudo12bpp( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  unsigned char *xim_data )
 {
-	register int i = MIN((unsigned int)(xim->width),sl->width-sl->offset_x)-1;
-    register CARD32 *r = sl->xc1+sl->offset_x, *g = sl->xc2+sl->offset_x, *b = sl->xc3+sl->offset_x;
+	int i = MIN((unsigned int)(xim->width),sl->width-sl->offset_x)-1;
+    CARD32 *r = sl->xc1+sl->offset_x, *g = sl->xc2+sl->offset_x, *b = sl->xc3+sl->offset_x;
 
 	if( xim->bits_per_pixel == 16 )
 	{
-		register CARD16 *src = (CARD16*)xim_data ;
+		CARD16 *src = (CARD16*)xim_data ;
 		do
 		{
             ASHashData hdata ;
@@ -2007,12 +2007,12 @@ ximage2scanline_pseudo12bpp( ASVisual *asv, XImage *xim, ASScanline *sl, int y, 
 }
 #endif
 
-void scanline2ximage32( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  register unsigned char *xim_data )
+void scanline2ximage32( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  unsigned char *xim_data )
 {
-	register CARD32 *r = sl->xc1+sl->offset_x, *g = sl->xc2+sl->offset_x, *b = sl->xc3+sl->offset_x;
-	register CARD32 *a = sl->alpha+sl->offset_x;
-	register int i = MIN((unsigned int)(xim->width),sl->width-sl->offset_x);
-	register CARD32 *src = (CARD32*)xim_data;
+	CARD32 *r = sl->xc1+sl->offset_x, *g = sl->xc2+sl->offset_x, *b = sl->xc3+sl->offset_x;
+	CARD32 *a = sl->alpha+sl->offset_x;
+	int i = MIN((unsigned int)(xim->width),sl->width-sl->offset_x);
+	CARD32 *src = (CARD32*)xim_data;
 /*	src += sl->offset_x ; */
 /*fprintf( stderr, "%d: ", y);*/
 #ifdef WORDS_BIGENDIAN
@@ -2038,12 +2038,12 @@ void scanline2ximage32( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  regi
 #endif
 }
 
-void scanline2ximage16( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  register unsigned char *xim_data )
+void scanline2ximage16( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  unsigned char *xim_data )
 {
-	register int i = MIN((unsigned int)(xim->width),sl->width-sl->offset_x)-1;
-	register CARD16 *src = (CARD16*)xim_data ;
-    register CARD32 *r = sl->xc1+sl->offset_x, *g = sl->xc2+sl->offset_x, *b = sl->xc3+sl->offset_x;
-	register CARD32 c = (r[i]<<20) | (g[i]<<10) | (b[i]);
+	int i = MIN((unsigned int)(xim->width),sl->width-sl->offset_x)-1;
+	CARD16 *src = (CARD16*)xim_data ;
+    CARD32 *r = sl->xc1+sl->offset_x, *g = sl->xc2+sl->offset_x, *b = sl->xc3+sl->offset_x;
+	CARD32 c = (r[i]<<20) | (g[i]<<10) | (b[i]);
 #ifdef WORDS_BIGENDIAN
 	if( !asv->msb_first )
 #else
@@ -2057,7 +2057,7 @@ void scanline2ximage16( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  regi
 			/* carry over quantization error allow for error diffusion:*/
 			c = ((c>>1)&0x00300403)+((r[i]<<20) | (g[i]<<10) | (b[i]));
 			{
-				register CARD32 d = c&0x300C0300 ;
+				CARD32 d = c&0x300C0300 ;
 				if( d )
 				{
 					if( c&0x30000000 )
@@ -2080,7 +2080,7 @@ void scanline2ximage16( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  regi
 			/* carry over quantization error allow for error diffusion:*/
 			c = ((c>>1)&0x00300403)+((r[i]<<20) | (g[i]<<10) | (b[i]));
 			{
-				register CARD32 d = c&0x300C0300 ;
+				CARD32 d = c&0x300C0300 ;
 				if( d )
 				{
 					if( c&0x30000000 )
@@ -2096,12 +2096,12 @@ void scanline2ximage16( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  regi
 		}while(1);
 }
 
-void scanline2ximage15( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  register unsigned char *xim_data )
+void scanline2ximage15( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  unsigned char *xim_data )
 {
-	register int i = MIN((unsigned int)(xim->width),sl->width-sl->offset_x)-1;
-	register CARD16 *src = (CARD16*)xim_data ;
-    register CARD32 *r = sl->xc1+sl->offset_x, *g = sl->xc2+sl->offset_x, *b = sl->xc3+sl->offset_x;
-	register CARD32 c = (r[i]<<20) | (g[i]<<10) | (b[i]);
+	int i = MIN((unsigned int)(xim->width),sl->width-sl->offset_x)-1;
+	CARD16 *src = (CARD16*)xim_data ;
+    CARD32 *r = sl->xc1+sl->offset_x, *g = sl->xc2+sl->offset_x, *b = sl->xc3+sl->offset_x;
+	CARD32 c = (r[i]<<20) | (g[i]<<10) | (b[i]);
 #ifdef WORDS_BIGENDIAN
 	if( !asv->msb_first )
 #else
@@ -2116,7 +2116,7 @@ void scanline2ximage15( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  regi
 			c = ((c>>1)&0x00300C03)+((r[i]<<20) | (g[i]<<10) | (b[i]));
 /*fprintf( stderr, "%s:%d src[%d] = 0x%4.4X, c = 0x%X, color[%d] = #%2.2X%2.2X%2.2X\n", __FUNCTION__, __LINE__, i+1, src[i+1], c, i, r[i], g[i], b[i]);*/
 			{
-				register CARD32 d = c&0x300C0300 ;
+				CARD32 d = c&0x300C0300 ;
 				if( d )
 				{
 					if( c&0x30000000 )
@@ -2140,7 +2140,7 @@ void scanline2ximage15( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  regi
 			/* carry over quantization error allow for error diffusion:*/
 			c = ((c>>1)&0x00300C03)+((r[i]<<20) | (g[i]<<10) | (b[i]));
 			{
-				register CARD32 d = c&0x300C0300 ;
+				CARD32 d = c&0x300C0300 ;
 				if( d )
 				{
 					if( c&0x30000000 )
@@ -2158,11 +2158,11 @@ void scanline2ximage15( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  regi
 
 #ifndef X_DISPLAY_MISSING
 void
-scanline2ximage_pseudo3bpp( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  register unsigned char *xim_data )
+scanline2ximage_pseudo3bpp( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  unsigned char *xim_data )
 {
-	register CARD32 *r = sl->xc1+sl->offset_x, *g = sl->xc2+sl->offset_x, *b = sl->xc3+sl->offset_x;
-	register int i = MIN((unsigned int)(xim->width),sl->width-sl->offset_x)-1;
-	register CARD32 c = (r[i]<<20) | (g[i]<<10) | (b[i]);
+	CARD32 *r = sl->xc1+sl->offset_x, *g = sl->xc2+sl->offset_x, *b = sl->xc3+sl->offset_x;
+	int i = MIN((unsigned int)(xim->width),sl->width-sl->offset_x)-1;
+	CARD32 c = (r[i]<<20) | (g[i]<<10) | (b[i]);
 
 	do
 	{
@@ -2171,7 +2171,7 @@ scanline2ximage_pseudo3bpp( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  
 			break;
 		c = ((c>>1)&0x03F0FC3F)+((r[i]<<20) | (g[i]<<10) | (b[i]));
 		{/* handling possible overflow : */
-			register CARD32 d = c&0x300C0300 ;
+			CARD32 d = c&0x300C0300 ;
 			if( d )
 			{
 				if( c&0x30000000 )
@@ -2187,15 +2187,15 @@ scanline2ximage_pseudo3bpp( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  
 }
 
 void
-scanline2ximage_pseudo6bpp( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  register unsigned char *xim_data )
+scanline2ximage_pseudo6bpp( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  unsigned char *xim_data )
 {
-	register CARD32 *r = sl->xc1+sl->offset_x, *g = sl->xc2+sl->offset_x, *b = sl->xc3+sl->offset_x;
-	register int i = MIN((unsigned int)(xim->width),sl->width-sl->offset_x)-1;
-	register CARD32 c = (r[i]<<20) | (g[i]<<10) | (b[i]);
+	CARD32 *r = sl->xc1+sl->offset_x, *g = sl->xc2+sl->offset_x, *b = sl->xc3+sl->offset_x;
+	int i = MIN((unsigned int)(xim->width),sl->width-sl->offset_x)-1;
+	CARD32 c = (r[i]<<20) | (g[i]<<10) | (b[i]);
 
 	if( xim->bits_per_pixel == 8 )
 	{
-		register CARD8 *dst = (CARD8*)xim_data ;
+		CARD8 *dst = (CARD8*)xim_data ;
 		do
 		{
 			dst[i] = asv->as_colormap[((c>>22)&0x0030)|((c>>14)&0x000C)|((c>>6)&0x0003)];
@@ -2203,7 +2203,7 @@ scanline2ximage_pseudo6bpp( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  
 				break;
 			c = ((c>>1)&0x01F07C1F)+((r[i]<<20) | (g[i]<<10) | (b[i]));
 			{/* handling possible overflow : */
-				register CARD32 d = c&0x300C0300 ;
+				CARD32 d = c&0x300C0300 ;
 				if( d )
 				{
 					if( c&0x30000000 )
@@ -2225,7 +2225,7 @@ scanline2ximage_pseudo6bpp( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  
 				break;
 			c = ((c>>1)&0x01F07C1F)+((r[i]<<20) | (g[i]<<10) | (b[i]));
 			{/* handling possible overflow : */
-				register CARD32 d = c&0x300C0300 ;
+				CARD32 d = c&0x300C0300 ;
 				if( d )
 				{
 					if( c&0x30000000 )
@@ -2242,15 +2242,15 @@ scanline2ximage_pseudo6bpp( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  
 }
 
 void
-scanline2ximage_pseudo12bpp( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  register unsigned char *xim_data )
+scanline2ximage_pseudo12bpp( ASVisual *asv, XImage *xim, ASScanline *sl, int y,  unsigned char *xim_data )
 {
-	register CARD32 *r = sl->xc1+sl->offset_x, *g = sl->xc2+sl->offset_x, *b = sl->xc3+sl->offset_x;
-	register int i = MIN((unsigned int)(xim->width),sl->width-sl->offset_x)-1;
-	register CARD32 c = (r[i]<<20) | (g[i]<<10) | (b[i]);
+	CARD32 *r = sl->xc1+sl->offset_x, *g = sl->xc2+sl->offset_x, *b = sl->xc3+sl->offset_x;
+	int i = MIN((unsigned int)(xim->width),sl->width-sl->offset_x)-1;
+	CARD32 c = (r[i]<<20) | (g[i]<<10) | (b[i]);
 
 	if( xim->bits_per_pixel == 16 )
 	{
-		register CARD16 *dst = (CARD16*)xim_data ;
+		CARD16 *dst = (CARD16*)xim_data ;
 		do
 		{
 			dst[i] = asv->as_colormap[((c>>16)&0x0F00)|((c>>10)&0x00F0)|((c>>4)&0x000F)];
@@ -2258,7 +2258,7 @@ scanline2ximage_pseudo12bpp( ASVisual *asv, XImage *xim, ASScanline *sl, int y, 
 				break;
 			c = ((c>>1)&0x00701C07)+((r[i]<<20) | (g[i]<<10) | (b[i]));
 			{/* handling possible overflow : */
-				register CARD32 d = c&0x300C0300 ;
+				CARD32 d = c&0x300C0300 ;
 				if( d )
 				{
 					if( c&0x30000000 )
@@ -2280,7 +2280,7 @@ scanline2ximage_pseudo12bpp( ASVisual *asv, XImage *xim, ASScanline *sl, int y, 
 				break;
 			c = ((c>>1)&0x00701C07)+((r[i]<<20) | (g[i]<<10) | (b[i]));
 			{/* handling possible overflow : */
-				register CARD32 d = c&0x300C0300 ;
+				CARD32 d = c&0x300C0300 ;
 				if( d )
 				{
 					if( c&0x30000000 )

--- a/graf2d/asimage/src/libAfterImage/asvisual.h
+++ b/graf2d/asimage/src/libAfterImage/asvisual.h
@@ -309,19 +309,19 @@ void pixel2color16bgr(ASVisual *asv, unsigned long pixel, CARD32 *red, CARD32 *g
 void pixel2color15rgb(ASVisual *asv, unsigned long pixel, CARD32 *red, CARD32 *green, CARD32 *blue);
 void pixel2color15bgr(ASVisual *asv, unsigned long pixel, CARD32 *red, CARD32 *green, CARD32 *blue);
 
-void ximage2scanline32( ASVisual *asv, XImage *xim, struct ASScanline *sl, int y,  register unsigned char *xim_data );
-void ximage2scanline16( ASVisual *asv, XImage *xim, struct ASScanline *sl, int y,  register unsigned char *xim_data );
-void ximage2scanline15( ASVisual *asv, XImage *xim, struct ASScanline *sl, int y,  register unsigned char *xim_data );
-void ximage2scanline_pseudo3bpp( ASVisual *asv, XImage *xim, struct ASScanline *sl, int y,  register unsigned char *xim_data );
-void ximage2scanline_pseudo6bpp( ASVisual *asv, XImage *xim, struct ASScanline *sl, int y,  register unsigned char *xim_data );
-void ximage2scanline_pseudo12bpp( ASVisual *asv, XImage *xim, struct ASScanline *sl, int y,  register unsigned char *xim_data );
+void ximage2scanline32( ASVisual *asv, XImage *xim, struct ASScanline *sl, int y,  unsigned char *xim_data );
+void ximage2scanline16( ASVisual *asv, XImage *xim, struct ASScanline *sl, int y,  unsigned char *xim_data );
+void ximage2scanline15( ASVisual *asv, XImage *xim, struct ASScanline *sl, int y,  unsigned char *xim_data );
+void ximage2scanline_pseudo3bpp( ASVisual *asv, XImage *xim, struct ASScanline *sl, int y,  unsigned char *xim_data );
+void ximage2scanline_pseudo6bpp( ASVisual *asv, XImage *xim, struct ASScanline *sl, int y,  unsigned char *xim_data );
+void ximage2scanline_pseudo12bpp( ASVisual *asv, XImage *xim, struct ASScanline *sl, int y,  unsigned char *xim_data );
 
-void scanline2ximage32( ASVisual *asv, XImage *xim, struct ASScanline *sl, int y,  register unsigned char *xim_data );
-void scanline2ximage16( ASVisual *asv, XImage *xim, struct ASScanline *sl, int y,  register unsigned char *xim_data );
-void scanline2ximage15( ASVisual *asv, XImage *xim, struct ASScanline *sl, int y,  register unsigned char *xim_data );
-void scanline2ximage_pseudo3bpp( ASVisual *asv, XImage *xim, struct ASScanline *sl, int y,  register unsigned char *xim_data );
-void scanline2ximage_pseudo6bpp( ASVisual *asv, XImage *xim, struct ASScanline *sl, int y,  register unsigned char *xim_data );
-void scanline2ximage_pseudo12bpp( ASVisual *asv, XImage *xim, struct ASScanline *sl, int y,  register unsigned char *xim_data );
+void scanline2ximage32( ASVisual *asv, XImage *xim, struct ASScanline *sl, int y,  unsigned char *xim_data );
+void scanline2ximage16( ASVisual *asv, XImage *xim, struct ASScanline *sl, int y,  unsigned char *xim_data );
+void scanline2ximage15( ASVisual *asv, XImage *xim, struct ASScanline *sl, int y,  unsigned char *xim_data );
+void scanline2ximage_pseudo3bpp( ASVisual *asv, XImage *xim, struct ASScanline *sl, int y,  unsigned char *xim_data );
+void scanline2ximage_pseudo6bpp( ASVisual *asv, XImage *xim, struct ASScanline *sl, int y,  unsigned char *xim_data );
+void scanline2ximage_pseudo12bpp( ASVisual *asv, XImage *xim, struct ASScanline *sl, int y,  unsigned char *xim_data );
 
 /****f* libAfterImage/query_screen_visual()
  * NAME

--- a/graf2d/asimage/src/libAfterImage/blender.c
+++ b/graf2d/asimage/src/libAfterImage/blender.c
@@ -54,7 +54,7 @@ rgb2value( CARD32 red, CARD32 green, CARD32 blue )
 CARD32
 rgb2saturation( CARD32 red, CARD32 green, CARD32 blue )
 {
-	register int max_val, min_val ;
+	int max_val, min_val ;
 	if( red > green )
 	{
 		max_val = MAX(red,blue);
@@ -331,7 +331,7 @@ merge_scanlines_func_desc std_merge_scanlines_func_list[] =
 merge_scanlines_func
 blend_scanlines_name2func( const char *name )
 {
-	register int i = 0;
+	int i = 0;
 
 	if( name == NULL )
 		return NULL ;
@@ -362,9 +362,9 @@ list_scanline_merging(FILE* stream, const char *format)
 }
 
 #define BLEND_SCANLINES_HEADER \
-	register int i = -1, max_i = bottom->width ; \
-	register CARD32 *ta = top->alpha, *tr = top->red, *tg = top->green, *tb = top->blue; \
-	register CARD32 *ba = bottom->alpha, *br = bottom->red, *bg = bottom->green, *bb = bottom->blue; \
+	int i = -1, max_i = bottom->width ; \
+	CARD32 *ta = top->alpha, *tr = top->red, *tg = top->green, *tb = top->blue; \
+	CARD32 *ba = bottom->alpha, *br = bottom->red, *bg = bottom->green, *bb = bottom->blue; \
 	if( offset < 0 ){ \
 		offset = -offset ; \
 		ta += offset ;	tr += offset ;	tg += offset ;	tb += offset ; \

--- a/graf2d/asimage/src/libAfterImage/bmp.c
+++ b/graf2d/asimage/src/libAfterImage/bmp.c
@@ -155,7 +155,7 @@ LOCAL_DEBUG_CALLER_OUT( "src = %p, offset_x = %d, offset_y = %d, to_width = %d, 
 
 	for( y = 0 ; y < max_y ; y++  )
 	{
-		register int x = to_width;
+		int x = to_width;
 		imdec->decode_image_scanline( imdec );
 		/* convert to DIB bits : */
 		curr -= pad ;

--- a/graf2d/asimage/src/libAfterImage/char2uni.c
+++ b/graf2d/asimage/src/libAfterImage/char2uni.c
@@ -960,7 +960,7 @@ parse_charset_name( const char *name )
 	while( set < SUPPORTED_CHARSETS_NUM )
 	{
 		char **aliases =&(_as_charset_names[set][0]) ;
-		register int i = 0 ;
+		int i = 0 ;
 		char c;
 		while( (c = aliases[i][0]) != '\0' )
 		{

--- a/graf2d/asimage/src/libAfterImage/draw.c
+++ b/graf2d/asimage/src/libAfterImage/draw.c
@@ -148,7 +148,7 @@ apply_tool_2D( ASDrawContext *ctx, int curr_x, int curr_y, CARD32 ratio )
 					if( dst[x] < src[x] ) 
 						dst[x] = src[x] ;
 					/*
-					register CARD32 t = (CARD32)dst[x] + (CARD32)src[x] ;
+					CARD32 t = (CARD32)dst[x] + (CARD32)src[x] ;
 					dst[x] = t > 255? 255 : t ;
 			 		*/
 				}
@@ -1059,8 +1059,8 @@ apply_asdraw_context( ASImage *im, ASDrawContext *ctx, ASFlagType filter )
 		if( get_flags( filter, 0x01<<chan) )
 		{
 			int y;
-			register ASStorageID *rows = im->channels[chan] ;
-			register CARD32 *canvas_row = ctx->canvas ; 
+			ASStorageID *rows = im->channels[chan] ;
+			CARD32 *canvas_row = ctx->canvas ; 
 			for( y = 0 ; y < height ; ++y )
 			{	
 #if defined(LOCAL_DEBUG) && !defined(NO_DEBUG_OUTPUT)

--- a/graf2d/asimage/src/libAfterImage/export.c
+++ b/graf2d/asimage/src/libAfterImage/export.c
@@ -197,9 +197,9 @@ open_writable_image_file( const char *path )
 }
 
 void
-scanline2raw( register CARD8 *row, ASScanline *buf, CARD8 *gamma_table, unsigned int width, Bool grayscale, Bool do_alpha )
+scanline2raw( CARD8 *row, ASScanline *buf, CARD8 *gamma_table, unsigned int width, Bool grayscale, Bool do_alpha )
 {
-	register int x = width;
+	int x = width;
 
 	if( grayscale )
 		row += do_alpha? width<<1 : width ;
@@ -280,7 +280,7 @@ ASImage2xpm ( ASImage *im, const char *path, ASImageExportParams *params )
 	START_TIME(started);
 	static const ASXpmExportParams defaultsXPM = { ASIT_Xpm, EXPORT_ALPHA, 4, 127, 512 };
 	ASImageExportParams defaults;
-	register char *ptr ;
+	char *ptr ;
 
 	LOCAL_DEBUG_CALLER_OUT ("(\"%s\")", path);
 
@@ -322,8 +322,8 @@ LOCAL_DEBUG_OUT("writing file%s","");
 		fputc( '"', outfile );
 		for( x = 0; x < im->width ; x++ )
 		{
-			register int idx = (row_pointer[x] >= 0)? row_pointer[x] : transp_idx ;
-			register char *ptr = &(xpm_cmap.char_code[idx*(xpm_cmap.cpp+1)]) ;
+			int idx = (row_pointer[x] >= 0)? row_pointer[x] : transp_idx ;
+			char *ptr = &(xpm_cmap.char_code[idx*(xpm_cmap.cpp+1)]) ;
 LOCAL_DEBUG_OUT( "(%d,%d)->%d (row_pointer %d )", x, y, idx, row_pointer[x] );
             if( idx > (int)cmap.count )
                 show_error("bad XPM color index :(%d,%d) -> %d, %d: %s", x, y, idx, row_pointer[x], ptr );
@@ -362,7 +362,7 @@ ASImage2xpmRawBuff ( ASImage *im, CARD8 **buffer, int *size, ASImageExportParams
 	START_TIME(started);
 	static const ASXpmExportParams defaultsXPM = { ASIT_Xpm, EXPORT_ALPHA, 4, 127, 512 };
         ASImageExportParams defaults;
-	register char *ptr ;
+	char *ptr ;
    char *curr;
 
    if( params == NULL ) {
@@ -430,8 +430,8 @@ LOCAL_DEBUG_OUT("building charmap%s","");
 
 		for( x = 0; x < im->width ; x++ )
 		{
-			register int idx = (row_pointer[x] >= 0)? row_pointer[x] : transp_idx ;
-			register char *ptr = &(xpm_cmap.char_code[idx*(xpm_cmap.cpp+1)]) ;
+			int idx = (row_pointer[x] >= 0)? row_pointer[x] : transp_idx ;
+			char *ptr = &(xpm_cmap.char_code[idx*(xpm_cmap.cpp+1)]) ;
          int len = strlen(ptr);
 
             if( idx > (int)cmap.count )
@@ -478,7 +478,7 @@ ASImage2xpm ( ASImage *im, const char *path,  ASImageExportParams *params )
 /***********************************************************************************/
 #ifdef HAVE_PNG		/* PNG PNG PNG PNG PNG PNG PNG PNG PNG PNG PNG PNG PNG PNG PNG PNG */
 static Bool
-ASImage2png_int ( ASImage *im, void *data, png_rw_ptr write_fn, png_flush_ptr flush_fn, register ASImageExportParams *params )
+ASImage2png_int ( ASImage *im, void *data, png_rw_ptr write_fn, png_flush_ptr flush_fn, ASImageExportParams *params )
 {
 	png_structp png_ptr  = NULL;
 	png_infop   info_ptr = NULL;
@@ -579,7 +579,7 @@ ASImage2png_int ( ASImage *im, void *data, png_rw_ptr write_fn, png_flush_ptr fl
 		row_pointer = safemalloc( im->width*(has_alpha?2:1));
 		for ( y = 0 ; y < (int)im->height ; y++ )
 		{
-			register int i = im->width;
+			int i = im->width;
 			CARD8   *ptr = (CARD8*)row_pointer;
 
 			imdec->decode_image_scanline( imdec );
@@ -601,7 +601,7 @@ ASImage2png_int ( ASImage *im, void *data, png_rw_ptr write_fn, png_flush_ptr fl
 		row_pointer = safecalloc( im->width * (has_alpha?4:3), 1 );
 		for (y = 0; y < (int)im->height; y++)
 		{
-			register int i = im->width;
+			int i = im->width;
 			CARD8   *ptr = (CARD8*)(row_pointer+(i-1)*(has_alpha?4:3)) ;
 			imdec->decode_image_scanline( imdec );
 			if( has_alpha )
@@ -640,7 +640,7 @@ ASImage2png_int ( ASImage *im, void *data, png_rw_ptr write_fn, png_flush_ptr fl
 }
 
 Bool
-ASImage2png ( ASImage *im, const char *path, register ASImageExportParams *params )
+ASImage2png ( ASImage *im, const char *path, ASImageExportParams *params )
 {
 	FILE *outfile;
 	Bool res ;
@@ -832,7 +832,7 @@ ASImage2jpeg( ASImage *im, const char *path,  ASImageExportParams *params )
 		row_pointer[0] = safemalloc( im->width );
 		for (y = 0; y < (int)im->height; y++)
 		{
-			register int i = im->width;
+			int i = im->width;
 			CARD8   *ptr = (CARD8*)row_pointer[0];
 			imdec->decode_image_scanline( imdec );
 			while( --i >= 0 ) /* normalized graylevel computing :  */
@@ -844,7 +844,7 @@ ASImage2jpeg( ASImage *im, const char *path,  ASImageExportParams *params )
 		row_pointer[0] = safemalloc( im->width * 3 );
 		for (y = 0; y < (int)im->height; y++)
 		{
-			register int i = (int)im->width;
+			int i = (int)im->width;
 			CARD8   *ptr = (CARD8*)(row_pointer[0]+(i-1)*3) ;
 LOCAL_DEBUG_OUT( "decoding  row %d", y );
 			imdec->decode_image_scanline( imdec );
@@ -1180,8 +1180,8 @@ Bool ASImage2gif( ASImage *im, const char *path,  ASImageExportParams *params )
 		/* it appears to be much faster to write image out in line by line fashion */
 		for( y = 0 ; y < (int)im->height ; y++ )
 		{
-			register int x = im->width ;
-			register int *src = mapped_im + x*y;
+			int x = im->width ;
+			int *src = mapped_im + x*y;
 	  	    while( --x >= 0 )
 	  			row_pointer[x] = src[x] ;
 #if (GIFLIB_MAJOR>=5)
@@ -1325,7 +1325,7 @@ ASImage2tiff( ASImage *im, const char *path, ASImageExportParams *params)
 
 	for (row = 0; row < im->height; ++row)
 	{
-		register int i = im->width, k = (im->width-1)*nsamples ;
+		int i = im->width, k = (im->width-1)*nsamples ;
 		imdec->decode_image_scanline( imdec );
 
 		if( has_alpha )

--- a/graf2d/asimage/src/libAfterImage/imencdec.c
+++ b/graf2d/asimage/src/libAfterImage/imencdec.c
@@ -201,7 +201,7 @@ asimage_erase_line( ASImage * im, ColorPart color, unsigned int y )
 
 /* for consistency sake : */
 void
-copy_component( register CARD32 *src, register CARD32 *dst, int *unused, int len )
+copy_component( CARD32 *src, CARD32 *dst, int *unused, int len )
 {
 #if 1
 #ifdef CARD64
@@ -211,7 +211,7 @@ copy_component( register CARD32 *src, register CARD32 *dst, int *unused, int len
 	double *dsrc = (double*)src;
 	double *ddst = (double*)dst;
 #endif
-	register int i = 0;
+	int i = 0;
 
 	len += len&0x01;
 	len = len>>1 ;
@@ -220,7 +220,7 @@ copy_component( register CARD32 *src, register CARD32 *dst, int *unused, int len
 		ddst[i] = dsrc[i];
 	}while(++i < len );
 #else
-	register int i = 0;
+	int i = 0;
 
 	len += len&0x01;
 	do
@@ -231,9 +231,9 @@ copy_component( register CARD32 *src, register CARD32 *dst, int *unused, int len
 }
 
 static inline int
-set_component( register CARD32 *src, register CARD32 value, int offset, int len )
+set_component( CARD32 *src, CARD32 value, int offset, int len )
 {
-	register int i ;
+	int i ;
 	for( i = offset ; i < len ; ++i )
 		src[i] = value;
 	return len-offset;
@@ -242,9 +242,9 @@ set_component( register CARD32 *src, register CARD32 value, int offset, int len 
 
 
 static inline void
-divide_component( register CARD32 *src, register CARD32 *dst, CARD16 ratio, int len )
+divide_component( CARD32 *src, CARD32 *dst, CARD16 ratio, int len )
 {
-	register int i = 0;
+	int i = 0;
 	len += len&0x00000001;                     /* we are 8byte aligned/padded anyways */
 	if( ratio == 2 )
 	{
@@ -284,8 +284,8 @@ divide_component( register CARD32 *src, register CARD32 *dst, CARD16 ratio, int 
 	}else
 	{
 		do{
-			register int c1 = src[i];
-			register int c2 = src[i+1];
+			int c1 = src[i];
+			int c2 = src[i+1];
 			dst[i] = c1/ratio;
 			dst[i+1] = c2/ratio;
 			i+=2;
@@ -503,7 +503,7 @@ ASImageOutput *
 start_image_output( ASVisual *asv, ASImage *im, ASAltImFormats format,
                     int shift, int quality )
 {
-	register ASImageOutput *imout= NULL;
+	ASImageOutput *imout= NULL;
    int formati = (int) format;
 
 	if( im != NULL )
@@ -603,7 +603,7 @@ stop_image_output( ASImageOutput **pimout )
 {
 	if( pimout )
 	{
-		register ASImageOutput *imout = *pimout;
+		ASImageOutput *imout = *pimout;
 		if( imout )
 		{
 			if( imout->used )
@@ -618,12 +618,12 @@ stop_image_output( ASImageOutput **pimout )
 
 /* diffusingly combine src onto self and dst, and rightbitshift src by quantization shift */
 static inline void
-best_output_filter( register CARD32 *line1, register CARD32 *line2, int unused, int len )
+best_output_filter( CARD32 *line1, CARD32 *line2, int unused, int len )
 {/* we carry half of the quantization error onto the surrounding pixels : */
  /*        X    7/16 */
  /* 3/16  5/16  1/16 */
-	register int i ;
-	register CARD32 errp = 0, err = 0, c;
+	int i ;
+	CARD32 errp = 0, err = 0, c;
 	c = line1[0];
 	if( (c&0xFFFF0000)!= 0 )
 		c = ( c&0x7F000000 )?0:0x0000FFFF;
@@ -646,12 +646,12 @@ best_output_filter( register CARD32 *line1, register CARD32 *line2, int unused, 
 }
 
 static inline void
-fine_output_filter( register CARD32 *src, register CARD32 *dst, short ratio, int len )
+fine_output_filter( CARD32 *src, CARD32 *dst, short ratio, int len )
 {/* we carry half of the quantization error onto the following pixel and store it in dst: */
-	register int i = 0;
+	int i = 0;
 	if( ratio <= 1 )
 	{
-		register int c = src[0];
+		int c = src[0];
   	    do
 		{
 			if( (c&0xFFFF0000)!= 0 )
@@ -663,7 +663,7 @@ fine_output_filter( register CARD32 *src, register CARD32 *dst, short ratio, int
 		}while(1);
 	}else if( ratio == 2 )
 	{
-		register CARD32 c = src[0];
+		CARD32 c = src[0];
   	    do
 		{
 			c = c>>1 ;
@@ -676,7 +676,7 @@ fine_output_filter( register CARD32 *src, register CARD32 *dst, short ratio, int
 		}while( 1 );
 	}else
 	{
-		register CARD32 c = src[0];
+		CARD32 c = src[0];
   	    do
 		{
 			c = c/ratio ;
@@ -691,14 +691,14 @@ fine_output_filter( register CARD32 *src, register CARD32 *dst, short ratio, int
 }
 
 static inline void
-fast_output_filter( register CARD32 *src, register CARD32 *dst, short ratio, int len )
+fast_output_filter( CARD32 *src, CARD32 *dst, short ratio, int len )
 {/*  no error diffusion whatsoever: */
-	register int i = 0;
+	int i = 0;
 	if( ratio <= 1 )
 	{
 		for( ; i < len ; ++i )
 		{
-			register CARD32 c = src[i];
+			CARD32 c = src[i];
 			if( (c&0xFFFF0000) != 0 )
 				dst[i] = ( c&0x7F000000 )?0:0x000000FF;
 			else
@@ -708,7 +708,7 @@ fast_output_filter( register CARD32 *src, register CARD32 *dst, short ratio, int
 	{
 		for( ; i < len ; ++i )
 		{
-			register CARD32 c = src[i]>>1;
+			CARD32 c = src[i]>>1;
 			if( (c&0xFFFF0000) != 0 )
 				dst[i] = ( c&0x7F000000 )?0:0x000000FF;
 			else
@@ -718,7 +718,7 @@ fast_output_filter( register CARD32 *src, register CARD32 *dst, short ratio, int
 	{
 		for( ; i < len ; ++i )
 		{
-			register CARD32 c = src[i]/ratio;
+			CARD32 c = src[i]/ratio;
 			if( (c&0xFFFF0000) != 0 )
 				dst[i] = ( c&0x7F000000 )?0:0x000000FF;
 			else
@@ -728,10 +728,10 @@ fast_output_filter( register CARD32 *src, register CARD32 *dst, short ratio, int
 }
 
 static inline void
-fine_output_filter_mod( register CARD32 *data, int unused, int len )
+fine_output_filter_mod( CARD32 *data, int unused, int len )
 {/* we carry half of the quantization error onto the following pixel : */
-	register int i ;
-	register CARD32 err = 0, c;
+	int i ;
+	CARD32 err = 0, c;
 	for( i = 0 ; i < len ; ++i )
 	{
 		c = data[i];
@@ -755,14 +755,14 @@ decode_asscanline_native( ASImageDecoder *imdec, unsigned int skip, int y )
 	for( i = 0 ; i < IC_NUM_CHANNELS ; i++ )
 		if( get_flags(imdec->filter, 0x01<<i) )
 		{
-			register CARD32 *chan = scl->channels[i]+skip;
+			CARD32 *chan = scl->channels[i]+skip;
 			if( imdec->im )
 				count = fetch_data32( NULL, imdec->im->channels[i][y], chan, imdec->offset_x, width, 0, NULL);
 			else
 				count = 0 ;
 			if( scl->shift )
 			{
-				register int k  = 0;
+				int k  = 0;
 				for(; k < count ; k++ )
 					chan[k] = chan[k]<<8;
 			}
@@ -850,7 +850,7 @@ decode_asscanline_ximage( ASImageDecoder *imdec, unsigned int skip, int y )
 		{
 #ifndef X_DISPLAY_MISSING
 			CARD32 *dst = xim_scl->alpha ;
-			register int x = MIN((int)xim_scl->width,xim->width);
+			int x = MIN((int)xim_scl->width,xim->width);
 			if( xim->depth == 8 )
 			{
 				CARD8  *src = (CARD8*)xim->data+xim->bytes_per_line*y ;
@@ -864,9 +864,9 @@ decode_asscanline_ximage( ASImageDecoder *imdec, unsigned int skip, int y )
 		for( i = 0 ; i < IC_NUM_CHANNELS ; i++ )
 			if( get_flags(filter, 0x01<<i) )
 			{
-				register CARD32 *src = xim_scl->channels[i]+offset_x ;
-				register CARD32 *dst = scl->channels[i]+skip;
-				register int k  = 0;
+				CARD32 *src = xim_scl->channels[i]+offset_x ;
+				CARD32 *dst = scl->channels[i]+skip;
+				int k  = 0;
 				count = xim_width-offset_x ;
 				if( count > width )
 					count = width ;
@@ -902,7 +902,7 @@ decode_asscanline_ximage( ASImageDecoder *imdec, unsigned int skip, int y )
 		{
 #ifndef X_DISPLAY_MISSING
 			CARD32 *dst = scl->alpha+skip ;
-			register int x = MIN(width,xim_width);
+			int x = MIN(width,xim_width);
 			if( xim->depth == 8 )
 			{
 				CARD8  *src = (CARD8*)xim->data+xim->bytes_per_line*y ;
@@ -918,10 +918,10 @@ decode_asscanline_ximage( ASImageDecoder *imdec, unsigned int skip, int y )
 		for( i = 0 ; i < IC_NUM_CHANNELS ; i++ )
 			if( get_flags(filter, 0x01<<i) )
 			{
-				register CARD32 *chan = scl->channels[i]+skip;
+				CARD32 *chan = scl->channels[i]+skip;
 				if( scl->shift )
 				{
-					register int k  = 0;
+					int k  = 0;
 					for(; k < count ; k++ )
 						chan[k] = chan[k]<<8;
 				}
@@ -953,7 +953,7 @@ decode_image_scanline_normal( ASImageDecoder *imdec )
 }
 
 static inline void
-draw_solid_bevel_line( register ASScanline *scl, int alt_left, int hi_end, int lo_start, int alt_right,
+draw_solid_bevel_line( ASScanline *scl, int alt_left, int hi_end, int lo_start, int alt_right,
 					   ARGB32 bevel_color, ARGB32 shade_color, ARGB32 hi_corner, ARGB32 lo_corner )
 {
 	int channel ;
@@ -985,7 +985,7 @@ draw_fading_bevel_sides( ASImageDecoder *imdec,
 					     int left_margin, int left_delta,
 					     int right_delta, int right_margin )
 {
-	register ASScanline *scl = &(imdec->buffer);
+	ASScanline *scl = &(imdec->buffer);
 	ASImageBevel *bevel = imdec->bevel ;
 	CARD32 ha_bevel = ARGB32_ALPHA8(bevel->hi_color);
 	CARD32 ha_shade = ARGB32_ALPHA8(bevel->lo_color);
@@ -997,8 +997,8 @@ draw_fading_bevel_sides( ASImageDecoder *imdec,
 		if( get_flags(scl->flags, (0x01<<channel)) )
 		{
 			CARD32 chan_col = ARGB32_CHAN8(bevel->hi_color,channel)<<scl->shift ;
-			register CARD32 ca = hda_bevel*(left_delta+1) ;
-			register int i = MIN((int)scl->width, imdec->bevel_left+(int)bevel->left_inline-left_delta);
+			CARD32 ca = hda_bevel*(left_delta+1) ;
+			int i = MIN((int)scl->width, imdec->bevel_left+(int)bevel->left_inline-left_delta);
 			CARD32 *chan_img_start = scl->channels[channel] ;
 
 			while( --i >= left_margin )
@@ -1022,7 +1022,7 @@ draw_transp_bevel_sides( ASImageDecoder *imdec,
 					     int left_margin, int left_delta,
 					     int right_delta, int right_margin )
 {
-	register ASScanline *scl = &(imdec->buffer);
+	ASScanline *scl = &(imdec->buffer);
 	ASImageBevel *bevel = imdec->bevel ;
 	CARD32 ha_bevel = ARGB32_ALPHA8(bevel->hi_color)>>1;
 	CARD32 ha_shade = ARGB32_ALPHA8(bevel->lo_color)>>1;
@@ -1032,8 +1032,8 @@ draw_transp_bevel_sides( ASImageDecoder *imdec,
 		if( get_flags(scl->flags, (0x01<<channel)) )
 		{
 			CARD32 chan_col = (ARGB32_CHAN8(bevel->hi_color,channel)<<scl->shift)*ha_bevel ;
-			register CARD32 ca = 255-ha_bevel ;
-			register int i = imdec->bevel_left+(int)bevel->left_inline-left_delta;
+			CARD32 ca = 255-ha_bevel ;
+			int i = imdec->bevel_left+(int)bevel->left_inline-left_delta;
 			CARD32 *chan_img_start = scl->channels[channel] ;
 
 			while( --i >= left_margin )
@@ -1054,7 +1054,7 @@ draw_transp_bevel_line ( ASImageDecoder *imdec,
 						 CARD32 ca,
 						 ARGB32 left_color, ARGB32 color, ARGB32 right_color )
 {
-	register ASScanline *scl = &(imdec->buffer);
+	ASScanline *scl = &(imdec->buffer);
 	ASImageBevel *bevel = imdec->bevel ;
 	int start_point = imdec->bevel_left+(int)bevel->left_inline-left_delta;
 	int end_point   = imdec->bevel_right + right_delta - (int)bevel->right_inline;
@@ -1067,7 +1067,7 @@ draw_transp_bevel_line ( ASImageDecoder *imdec,
 			{
 				CARD32 chan_col = (ARGB32_CHAN8(color,channel)<<scl->shift)*(ca>>8) ;
 				CARD32 *chan_img_start = scl->channels[channel] ;
-				register int i ;
+				int i ;
 				int end_i;
 
 				if( start_point < 0 )
@@ -1095,9 +1095,9 @@ draw_transp_bevel_line ( ASImageDecoder *imdec,
 void
 decode_image_scanline_beveled( ASImageDecoder *imdec )
 {
-	register ASScanline *scl = &(imdec->buffer);
+	ASScanline *scl = &(imdec->buffer);
 	int 	 			 y_out = imdec->next_line- (int)imdec->offset_y;
-	register ASImageBevel *bevel = imdec->bevel ;
+	ASImageBevel *bevel = imdec->bevel ;
 	ARGB32 bevel_color = bevel->hi_color, shade_color = bevel->lo_color;
 	int offset_shade = 0;
 
@@ -1114,7 +1114,7 @@ decode_image_scanline_beveled( ASImageDecoder *imdec )
 	{
 		if( bevel->top_outline > 0 )
 		{
-			register int line = y_out - (imdec->bevel_top - (int)bevel->top_outline);
+			int line = y_out - (imdec->bevel_top - (int)bevel->top_outline);
 			int alt_left  = (line*bevel->left_outline/bevel->top_outline)+1 ;
 			int alt_right = (line*bevel->right_outline/bevel->top_outline)+1 ;
 
@@ -1135,7 +1135,7 @@ decode_image_scanline_beveled( ASImageDecoder *imdec )
 	{
 		if( bevel->bottom_outline > 0 )
 		{
-			register int line = bevel->bottom_outline - (y_out - imdec->bevel_bottom);
+			int line = bevel->bottom_outline - (y_out - imdec->bevel_bottom);
 			int alt_left  = (line*bevel->left_outline/bevel->bottom_outline)+1 ;
 			int alt_right = (line*bevel->right_outline/bevel->bottom_outline)+1 ;
 
@@ -1173,7 +1173,7 @@ decode_image_scanline_beveled( ASImageDecoder *imdec )
 			{
 				if( y_out < imdec->bevel_top+(int)bevel->top_inline)
 				{
-					register int line = y_out - imdec->bevel_top;
+					int line = y_out - imdec->bevel_top;
 					int left_delta  = bevel->left_inline-((line*bevel->left_inline/bevel->top_inline)) ;
 					int right_delta = bevel->right_inline-((line*bevel->right_inline/bevel->top_inline)-1) ;
 
@@ -1185,7 +1185,7 @@ decode_image_scanline_beveled( ASImageDecoder *imdec )
 
 				}else if( y_out >= imdec->bevel_bottom - bevel->bottom_inline)
 				{
-					register int line = y_out - (imdec->bevel_bottom - bevel->bottom_inline);
+					int line = y_out - (imdec->bevel_bottom - bevel->bottom_inline);
 					int left_delta  = (line*bevel->left_inline/bevel->bottom_inline)+1 ;
 					int right_delta = (line*bevel->right_inline/bevel->bottom_inline)-1 ;
 
@@ -1209,7 +1209,7 @@ decode_image_scanline_beveled( ASImageDecoder *imdec )
  
 				if( y_out < imdec->bevel_top+bevel->top_inline)
 				{
-					register int line = y_out - imdec->bevel_top;
+					int line = y_out - imdec->bevel_top;
 					int left_delta  = bevel->left_inline-((line*bevel->left_inline/bevel->top_inline)) ;
 					int right_delta = bevel->right_inline-((line*bevel->right_inline/bevel->top_inline)-1) ;
 	    			CARD32 hda_bevel = (ARGB32_ALPHA8(bevel_color)<<8)/(bevel->left_inline+1) ;
@@ -1226,7 +1226,7 @@ decode_image_scanline_beveled( ASImageDecoder *imdec )
 
 				}else if( y_out >= imdec->bevel_bottom - bevel->bottom_inline)
 				{
-					register int line = y_out - (imdec->bevel_bottom - bevel->bottom_inline);
+					int line = y_out - (imdec->bevel_bottom - bevel->bottom_inline);
 					int left_delta  = (line*bevel->left_inline/bevel->bottom_inline)+1 ;
 					int right_delta = (line*bevel->right_inline/bevel->bottom_inline)-1 ;
 	    			CARD32 hda_shade = (ARGB32_ALPHA8(shade_color)<<8)/(bevel->right_inline+1) ;
@@ -1252,7 +1252,7 @@ decode_image_scanline_beveled( ASImageDecoder *imdec )
 inline static void
 tile_ximage_line( XImage *xim, unsigned int line, int step, int range )
 {
-	register int i ;
+	int i ;
 	int xim_step = step*xim->bytes_per_line ;
 	char *src_line = xim->data+xim->bytes_per_line*line ;
 	char *dst_line = src_line+xim_step ;
@@ -1269,13 +1269,13 @@ encode_image_scanline_mask_xim( ASImageOutput *imout, ASScanline *to_store )
 {
 #ifndef X_DISPLAY_MISSING
 	ASImage *im = imout->im ;
-	register XImage *xim = im->alt.mask_ximage ;
+	XImage *xim = im->alt.mask_ximage ;
 	if( imout->next_line < xim->height && imout->next_line >= 0 )
 	{
 		if( get_flags(to_store->flags, SCL_DO_ALPHA) )
 		{
 			CARD32 *a = to_store->alpha ;
-			register int x = MIN((unsigned int)(xim->width), to_store->width);
+			int x = MIN((unsigned int)(xim->width), to_store->width);
 			if( xim->depth == 8 )
 			{
 				CARD8 *dst = (CARD8*)xim->data+xim->bytes_per_line*imout->next_line ;
@@ -1301,7 +1301,7 @@ void
 encode_image_scanline_xim( ASImageOutput *imout, ASScanline *to_store )
 {
 #ifndef X_DISPLAY_MISSING
-	register XImage *xim = imout->im->alt.ximage ;
+	XImage *xim = imout->im->alt.ximage ;
 	if( imout->next_line < xim->height && imout->next_line >= 0 )
 	{
 		unsigned char *dst = (unsigned char*)xim->data+imout->next_line*xim->bytes_per_line ;
@@ -1369,7 +1369,7 @@ LOCAL_DEBUG_CALLER_OUT( "imout->next_line = %d, imout->im->height = %d", imout->
 		if( imout->tiling_step > 0 )
 		{
 			int bytes_count ;
-			register int i, color ;
+			int i, color ;
 			int line = imout->next_line ;
 			int range = (imout->tiling_range ? imout->tiling_range:imout->im->height);
 			int max_i = MIN((int)imout->im->height,line+range), min_i = MAX(0,line-range) ;
@@ -1396,7 +1396,7 @@ LOCAL_DEBUG_CALLER_OUT( "imout->next_line = %d, imout->im->height = %d", imout->
 			}
 		}else
 		{
-			register int color ;
+			int color ;
 			for( color = 0 ; color < IC_NUM_CHANNELS ; color++ )
 			{
 				if( get_flags(to_store->flags,0x01<<color))
@@ -1421,7 +1421,7 @@ LOCAL_DEBUG_CALLER_OUT( "imout->next_line = %d, imout->im->height = %d", imout->
 inline static void
 tile_argb32_line( ARGB32 *data, unsigned int line, int step, unsigned int width, unsigned int height, int range )
 {
-	register int i ;
+	int i ;
 	ARGB32 *src_line = data+line*width ;
 	ARGB32 *dst_line = src_line+step*width ;
 	int max_i = MIN((int)height,(int)line+range), min_i = MAX(0,(int)line-range) ;
@@ -1436,14 +1436,14 @@ tile_argb32_line( ARGB32 *data, unsigned int line, int step, unsigned int width,
 void
 encode_image_scanline_argb32( ASImageOutput *imout, ASScanline *to_store )
 {
-	register ARGB32 *data = imout->im->alt.argb32 ;
+	ARGB32 *data = imout->im->alt.argb32 ;
 	if( imout->next_line < (int)imout->im->height && imout->next_line >= 0 )
 	{
-		register int x = imout->im->width;
-		register CARD32 *alpha = to_store->alpha ;
-		register CARD32 *red = to_store->red ;
-		register CARD32 *green = to_store->green ;
-		register CARD32 *blue = to_store->blue ;
+		int x = imout->im->width;
+		CARD32 *alpha = to_store->alpha ;
+		CARD32 *red = to_store->red ;
+		CARD32 *green = to_store->green ;
+		CARD32 *blue = to_store->blue ;
 		if( !get_flags(to_store->flags, SCL_DO_RED) )
 			set_component( red, ARGB32_RED8(to_store->back_color), 0, to_store->width );
 		if( !get_flags(to_store->flags, SCL_DO_GREEN) )

--- a/graf2d/asimage/src/libAfterImage/import.c
+++ b/graf2d/asimage/src/libAfterImage/import.c
@@ -187,7 +187,7 @@ char *locate_image_file_in_path( const char *file, ASImageImportParams *iparams 
 {
 	int 		  filename_len ;
 	char 		 *realfilename = NULL, *tmp = NULL ;
-	register int i;
+	int i;
 	ASImageImportParams dummy_iparams = {0};
 
 	if( iparams == NULL )
@@ -875,7 +875,7 @@ load_asimage_list_entry_data( ASImageListEntry *entry, size_t max_bytes )
 	if( entry->type == ASIT_Unknown ) 
 	{
 		int i = entry->buffer->size ; 
-		register char *ptr = entry->buffer->data ;
+		char *ptr = entry->buffer->data ;
 		while ( --i >= 0 )	
 			if( !isprint(ptr[i]) && ptr[i] != '\n'&& ptr[i] != '\r'&& ptr[i] != '\t' )	
 				break;
@@ -913,7 +913,7 @@ locate_image_file( const char *file, char **paths )
 			realfilename = NULL ;
 			if( paths != NULL )
 			{	/* now lets try and find the file in any of the optional paths :*/
-				register int i = 0;
+				int i = 0;
 				do
 				{
 					if( i > 0 ) 
@@ -1203,11 +1203,11 @@ xpm2ASImage( const char * path, ASImageImportParams *params )
 /***********************************************************************************/
 
 static inline void
-apply_gamma( register CARD8* raw, register CARD8 *gamma_table, unsigned int width )
+apply_gamma( CARD8* raw, CARD8 *gamma_table, unsigned int width )
 {
 	if( gamma_table )
 	{	
-		register unsigned int i ;
+		unsigned int i ;
 		for( i = 0 ; i < width ; ++i )
 			raw[i] = gamma_table[raw[i]] ;
 	}
@@ -1411,7 +1411,7 @@ png2ASImage_int( void *data, png_rw_ptr read_fn, ASImageImportParams *params )
 					if( do_alpha )
 					{
 						int has_zero = False, has_nozero = False ;
-						register unsigned int i;
+						unsigned int i;
 						for ( i = 0 ; i < buf.width ; ++i)
 						{
 							if( buf.alpha[i] != 0x00FF )
@@ -1557,7 +1557,7 @@ jpeg2ASImage( const char * path, ASImageImportParams *params )
 	ASScanline    buf;
 	int y;
 	START_TIME(started);
- /*	register int i ;*/
+ /*	int i ;*/
 
 	/* we want to open the input file before doing anything else,
 	 * so that the setjmp() error recovery below can assume the file is open.
@@ -1822,7 +1822,7 @@ ppm2ASImage( const char * path, ASImageImportParams *params )
 			{
 				if( buffer[0] != '#' )
 				{
-					register int i = 0;
+					int i = 0;
 					if( width > 0 )
 					{
 						colors = atoi(&(buffer[i]));
@@ -2275,7 +2275,7 @@ LOCAL_DEBUG_OUT( "strip size = %d, bytes_in = %d, bytes_per_row = %d", bc[strip_
 				TIFFReadRGBAStrip(tif, first_row, (void*)data);
 				do
 				{
-					register CARD32 *row = data ;
+					CARD32 *row = data ;
 					int y = first_row + rows_per_strip ;
 					if( y > height ) 
 						y = height ;
@@ -2425,7 +2425,7 @@ svg2ASImage( const char * path, ASImageImportParams *params )
 		gdk_pixbuf_get_bits_per_sample(pixbuf) == 8 ) 
 	{
 	   	int width, height;
-		register CARD8 *row = gdk_pixbuf_get_pixels(pixbuf);
+		CARD8 *row = gdk_pixbuf_get_pixels(pixbuf);
 		int y;
 		CARD8 		 *r = NULL, *g = NULL, *b = NULL, *a = NULL ;
 		int old_storage_block_size;

--- a/graf2d/asimage/src/libAfterImage/libjpeg/jcarith.c
+++ b/graf2d/asimage/src/libAfterImage/libjpeg/jcarith.c
@@ -218,10 +218,10 @@ finish_pass (j_compress_ptr cinfo)
 LOCAL(void)
 arith_encode (j_compress_ptr cinfo, unsigned char *st, int val) 
 {
-  register arith_entropy_ptr e = (arith_entropy_ptr) cinfo->entropy;
-  register unsigned char nl, nm;
-  register INT32 qe, temp;
-  register int sv;
+  arith_entropy_ptr e = (arith_entropy_ptr) cinfo->entropy;
+  unsigned char nl, nm;
+  INT32 qe, temp;
+  int sv;
 
   /* Fetch values from our compact representation of Table D.2:
    * Qe values and probability estimation state machine
@@ -277,7 +277,7 @@ arith_encode (j_compress_ptr cinfo, unsigned char *st, int val)
 	}
 	e->zc += e->sc;  /* carry-over converts stacked 0xFF bytes to 0x00 */
 	e->sc = 0;
-	/* Note: The 3 spacer bits in the C register guarantee
+	/* Note: The 3 spacer bits in the C guarantee
 	 * that the new buffer byte can't be 0xFF here
 	 * (see page 160 in the P&M JPEG book). */
 	e->buffer = temp & 0xFF;  /* new output byte, might overflow later */

--- a/graf2d/asimage/src/libAfterImage/libjpeg/jccolor.c
+++ b/graf2d/asimage/src/libAfterImage/libjpeg/jccolor.c
@@ -62,7 +62,7 @@ typedef my_color_converter * my_cconvert_ptr;
 
 /* We allocate one big table and divide it up into eight parts, instead of
  * doing eight alloc_small requests.  This lets us use a single table base
- * address, which can be held in a register in the inner loops on many
+ * address, which can be held in a in the inner loops on many
  * machines (more than can hold all eight addresses, anyway).
  */
 
@@ -132,11 +132,11 @@ rgb_ycc_convert (j_compress_ptr cinfo,
 		 JDIMENSION output_row, int num_rows)
 {
   my_cconvert_ptr cconvert = (my_cconvert_ptr) cinfo->cconvert;
-  register int r, g, b;
-  register INT32 * ctab = cconvert->rgb_ycc_tab;
-  register JSAMPROW inptr;
-  register JSAMPROW outptr0, outptr1, outptr2;
-  register JDIMENSION col;
+  int r, g, b;
+  INT32 * ctab = cconvert->rgb_ycc_tab;
+  JSAMPROW inptr;
+  JSAMPROW outptr0, outptr1, outptr2;
+  JDIMENSION col;
   JDIMENSION num_cols = cinfo->image_width;
 
   while (--num_rows >= 0) {
@@ -188,11 +188,11 @@ rgb_gray_convert (j_compress_ptr cinfo,
 		  JDIMENSION output_row, int num_rows)
 {
   my_cconvert_ptr cconvert = (my_cconvert_ptr) cinfo->cconvert;
-  register int r, g, b;
-  register INT32 * ctab = cconvert->rgb_ycc_tab;
-  register JSAMPROW inptr;
-  register JSAMPROW outptr;
-  register JDIMENSION col;
+  int r, g, b;
+  INT32 * ctab = cconvert->rgb_ycc_tab;
+  JSAMPROW inptr;
+  JSAMPROW outptr;
+  JDIMENSION col;
   JDIMENSION num_cols = cinfo->image_width;
 
   while (--num_rows >= 0) {
@@ -227,11 +227,11 @@ cmyk_ycck_convert (j_compress_ptr cinfo,
 		   JDIMENSION output_row, int num_rows)
 {
   my_cconvert_ptr cconvert = (my_cconvert_ptr) cinfo->cconvert;
-  register int r, g, b;
-  register INT32 * ctab = cconvert->rgb_ycc_tab;
-  register JSAMPROW inptr;
-  register JSAMPROW outptr0, outptr1, outptr2, outptr3;
-  register JDIMENSION col;
+  int r, g, b;
+  INT32 * ctab = cconvert->rgb_ycc_tab;
+  JSAMPROW inptr;
+  JSAMPROW outptr0, outptr1, outptr2, outptr3;
+  JDIMENSION col;
   JDIMENSION num_cols = cinfo->image_width;
 
   while (--num_rows >= 0) {
@@ -281,9 +281,9 @@ grayscale_convert (j_compress_ptr cinfo,
 		   JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
 		   JDIMENSION output_row, int num_rows)
 {
-  register JSAMPROW inptr;
-  register JSAMPROW outptr;
-  register JDIMENSION col;
+  JSAMPROW inptr;
+  JSAMPROW outptr;
+  JDIMENSION col;
   JDIMENSION num_cols = cinfo->image_width;
   int instride = cinfo->input_components;
 
@@ -310,10 +310,10 @@ null_convert (j_compress_ptr cinfo,
 	      JSAMPARRAY input_buf, JSAMPIMAGE output_buf,
 	      JDIMENSION output_row, int num_rows)
 {
-  register JSAMPROW inptr;
-  register JSAMPROW outptr;
-  register JDIMENSION col;
-  register int ci;
+  JSAMPROW inptr;
+  JSAMPROW outptr;
+  JDIMENSION col;
+  int ci;
   int nc = cinfo->num_components;
   JDIMENSION num_cols = cinfo->image_width;
 

--- a/graf2d/asimage/src/libAfterImage/libjpeg/jcdctmgr.c
+++ b/graf2d/asimage/src/libAfterImage/libjpeg/jcdctmgr.c
@@ -82,9 +82,9 @@ forward_DCT (j_compress_ptr cinfo, jpeg_component_info * compptr,
     (*do_dct) (workspace, sample_data, start_col);
 
     /* Quantize/descale the coefficients, and store into coef_blocks[] */
-    { register DCTELEM temp, qval;
-      register int i;
-      register JCOEFPTR output_ptr = coef_blocks[bi];
+    { DCTELEM temp, qval;
+      int i;
+      JCOEFPTR output_ptr = coef_blocks[bi];
 
       for (i = 0; i < DCTSIZE2; i++) {
 	qval = divisors[i];
@@ -145,9 +145,9 @@ forward_DCT_float (j_compress_ptr cinfo, jpeg_component_info * compptr,
     (*do_dct) (workspace, sample_data, start_col);
 
     /* Quantize/descale the coefficients, and store into coef_blocks[] */
-    { register FAST_FLOAT temp;
-      register int i;
-      register JCOEFPTR output_ptr = coef_blocks[bi];
+    { FAST_FLOAT temp;
+      int i;
+      JCOEFPTR output_ptr = coef_blocks[bi];
 
       for (i = 0; i < DCTSIZE2; i++) {
 	/* Apply the quantization and scaling factor */

--- a/graf2d/asimage/src/libAfterImage/libjpeg/jchuff.c
+++ b/graf2d/asimage/src/libAfterImage/libjpeg/jchuff.c
@@ -308,8 +308,8 @@ emit_bits_s (working_state * state, unsigned int code, int size)
 /* Emit some bits; return TRUE if successful, FALSE if must suspend */
 {
   /* This routine is heavily used, so it's worth coding tightly. */
-  register INT32 put_buffer = (INT32) code;
-  register int put_bits = state->cur.put_bits;
+  INT32 put_buffer = (INT32) code;
+  int put_bits = state->cur.put_bits;
 
   /* if size is 0, caller used an invalid Huffman table entry */
   if (size == 0)
@@ -347,8 +347,8 @@ emit_bits_e (huff_entropy_ptr entropy, unsigned int code, int size)
 /* Emit some bits, unless we are in gather mode */
 {
   /* This routine is heavily used, so it's worth coding tightly. */
-  register INT32 put_buffer = (INT32) code;
-  register int put_bits = entropy->saved.put_bits;
+  INT32 put_buffer = (INT32) code;
+  int put_bits = entropy->saved.put_bits;
 
   /* if size is 0, caller used an invalid Huffman table entry */
   if (size == 0)
@@ -458,7 +458,7 @@ emit_buffered_bits (huff_entropy_ptr entropy, char * bufstart,
 LOCAL(void)
 emit_eobrun (huff_entropy_ptr entropy)
 {
-  register int temp, nbits;
+  int temp, nbits;
 
   if (entropy->EOBRUN > 0) {	/* if there is any pending EOBRUN */
     temp = entropy->EOBRUN;
@@ -541,8 +541,8 @@ METHODDEF(boolean)
 encode_mcu_DC_first (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
-  register int temp, temp2;
-  register int nbits;
+  int temp, temp2;
+  int nbits;
   int blkn, ci;
   int Al = cinfo->Al;
   JBLOCKROW block;
@@ -628,9 +628,9 @@ METHODDEF(boolean)
 encode_mcu_AC_first (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
-  register int temp, temp2;
-  register int nbits;
-  register int r, k;
+  int temp, temp2;
+  int nbits;
+  int r, k;
   int Se, Al;
   const int * natural_order;
   JBLOCKROW block;
@@ -739,7 +739,7 @@ METHODDEF(boolean)
 encode_mcu_DC_refine (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
-  register int temp;
+  int temp;
   int blkn;
   int Al = cinfo->Al;
   JBLOCKROW block;
@@ -786,8 +786,8 @@ METHODDEF(boolean)
 encode_mcu_AC_refine (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
-  register int temp;
-  register int r, k;
+  int temp;
+  int r, k;
   int EOB;
   char *BR_buffer;
   unsigned int BR;
@@ -916,9 +916,9 @@ LOCAL(boolean)
 encode_one_block (working_state * state, JCOEFPTR block, int last_dc_val,
 		  c_derived_tbl *dctbl, c_derived_tbl *actbl)
 {
-  register int temp, temp2;
-  register int nbits;
-  register int k, r, i;
+  int temp, temp2;
+  int nbits;
+  int k, r, i;
   int Se = state->cinfo->lim_Se;
   const int * natural_order = state->cinfo->natural_order;
 
@@ -1122,9 +1122,9 @@ LOCAL(void)
 htest_one_block (j_compress_ptr cinfo, JCOEFPTR block, int last_dc_val,
 		 long dc_counts[], long ac_counts[])
 {
-  register int temp;
-  register int nbits;
-  register int k, r;
+  int temp;
+  int nbits;
+  int k, r;
   int Se = cinfo->lim_Se;
   const int * natural_order = cinfo->natural_order;
   

--- a/graf2d/asimage/src/libAfterImage/libjpeg/jcphuff.c
+++ b/graf2d/asimage/src/libAfterImage/libjpeg/jcphuff.c
@@ -229,8 +229,8 @@ emit_bits (phuff_entropy_ptr entropy, unsigned int code, int size)
 /* Emit some bits, unless we are in gather mode */
 {
   /* This routine is heavily used, so it's worth coding tightly. */
-  register INT32 put_buffer = (INT32) code;
-  register int put_bits = entropy->put_bits;
+  INT32 put_buffer = (INT32) code;
+  int put_bits = entropy->put_bits;
 
   /* if size is 0, caller used an invalid Huffman table entry */
   if (size == 0)
@@ -315,7 +315,7 @@ emit_buffered_bits (phuff_entropy_ptr entropy, char * bufstart,
 LOCAL(void)
 emit_eobrun (phuff_entropy_ptr entropy)
 {
-  register int temp, nbits;
+  int temp, nbits;
 
   if (entropy->EOBRUN > 0) {	/* if there is any pending EOBRUN */
     temp = entropy->EOBRUN;
@@ -377,8 +377,8 @@ METHODDEF(boolean)
 encode_mcu_DC_first (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
 {
   phuff_entropy_ptr entropy = (phuff_entropy_ptr) cinfo->entropy;
-  register int temp, temp2;
-  register int nbits;
+  int temp, temp2;
+  int nbits;
   int blkn, ci;
   int Al = cinfo->Al;
   JBLOCKROW block;
@@ -464,9 +464,9 @@ METHODDEF(boolean)
 encode_mcu_AC_first (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
 {
   phuff_entropy_ptr entropy = (phuff_entropy_ptr) cinfo->entropy;
-  register int temp, temp2;
-  register int nbits;
-  register int r, k;
+  int temp, temp2;
+  int nbits;
+  int r, k;
   int Se = cinfo->Se;
   int Al = cinfo->Al;
   JBLOCKROW block;
@@ -571,7 +571,7 @@ METHODDEF(boolean)
 encode_mcu_DC_refine (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
 {
   phuff_entropy_ptr entropy = (phuff_entropy_ptr) cinfo->entropy;
-  register int temp;
+  int temp;
   int blkn;
   int Al = cinfo->Al;
   JBLOCKROW block;
@@ -618,8 +618,8 @@ METHODDEF(boolean)
 encode_mcu_AC_refine (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
 {
   phuff_entropy_ptr entropy = (phuff_entropy_ptr) cinfo->entropy;
-  register int temp;
-  register int r, k;
+  int temp;
+  int r, k;
   int EOB;
   char *BR_buffer;
   unsigned int BR;

--- a/graf2d/asimage/src/libAfterImage/libjpeg/jcprepct.c
+++ b/graf2d/asimage/src/libAfterImage/libjpeg/jcprepct.c
@@ -106,7 +106,7 @@ LOCAL(void)
 expand_bottom_edge (JSAMPARRAY image_data, JDIMENSION num_cols,
 		    int input_rows, int output_rows)
 {
-  register int row;
+  int row;
 
   for (row = input_rows; row < output_rows; row++) {
     jcopy_sample_rows(image_data, input_rows-1, image_data, row,

--- a/graf2d/asimage/src/libAfterImage/libjpeg/jcsample.c
+++ b/graf2d/asimage/src/libAfterImage/libjpeg/jcsample.c
@@ -96,9 +96,9 @@ LOCAL(void)
 expand_right_edge (JSAMPARRAY image_data, int num_rows,
 		   JDIMENSION input_cols, JDIMENSION output_cols)
 {
-  register JSAMPROW ptr;
-  register JSAMPLE pixval;
-  register int count;
+  JSAMPROW ptr;
+  JSAMPLE pixval;
+  int count;
   int row;
   int numcols = (int) (output_cols - input_cols);
 
@@ -227,8 +227,8 @@ h2v1_downsample (j_compress_ptr cinfo, jpeg_component_info * compptr,
   int inrow;
   JDIMENSION outcol;
   JDIMENSION output_cols = compptr->width_in_blocks * compptr->DCT_h_scaled_size;
-  register JSAMPROW inptr, outptr;
-  register int bias;
+  JSAMPROW inptr, outptr;
+  int bias;
 
   /* Expand input data enough to let all the output samples be generated
    * by the standard loop.  Special-casing padded output would be more
@@ -264,8 +264,8 @@ h2v2_downsample (j_compress_ptr cinfo, jpeg_component_info * compptr,
   int inrow, outrow;
   JDIMENSION outcol;
   JDIMENSION output_cols = compptr->width_in_blocks * compptr->DCT_h_scaled_size;
-  register JSAMPROW inptr0, inptr1, outptr;
-  register int bias;
+  JSAMPROW inptr0, inptr1, outptr;
+  int bias;
 
   /* Expand input data enough to let all the output samples be generated
    * by the standard loop.  Special-casing padded output would be more
@@ -308,7 +308,7 @@ h2v2_smooth_downsample (j_compress_ptr cinfo, jpeg_component_info * compptr,
   int inrow, outrow;
   JDIMENSION colctr;
   JDIMENSION output_cols = compptr->width_in_blocks * compptr->DCT_h_scaled_size;
-  register JSAMPROW inptr0, inptr1, above_ptr, below_ptr, outptr;
+  JSAMPROW inptr0, inptr1, above_ptr, below_ptr, outptr;
   INT32 membersum, neighsum, memberscale, neighscale;
 
   /* Expand input data enough to let all the output samples be generated
@@ -409,7 +409,7 @@ fullsize_smooth_downsample (j_compress_ptr cinfo, jpeg_component_info *compptr,
   int inrow;
   JDIMENSION colctr;
   JDIMENSION output_cols = compptr->width_in_blocks * compptr->DCT_h_scaled_size;
-  register JSAMPROW inptr, above_ptr, below_ptr, outptr;
+  JSAMPROW inptr, above_ptr, below_ptr, outptr;
   INT32 membersum, neighsum, memberscale, neighscale;
   int colsum, lastcolsum, nextcolsum;
 

--- a/graf2d/asimage/src/libAfterImage/libjpeg/jdarith.c
+++ b/graf2d/asimage/src/libAfterImage/libjpeg/jdarith.c
@@ -86,7 +86,7 @@ get_byte (j_decompress_ptr cinfo)
  * Return value is 0 or 1 (binary decision).
  *
  * Note: I've changed the handling of the code base & bit
- * buffer register C compared to other implementations
+ * buffer C compared to other implementations
  * based on the standards layout & procedures.
  * While it also contains both the actual base of the
  * coding interval (16 bits) and the next-bits buffer,
@@ -105,10 +105,10 @@ get_byte (j_decompress_ptr cinfo)
 LOCAL(int)
 arith_decode (j_decompress_ptr cinfo, unsigned char *st)
 {
-  register arith_entropy_ptr e = (arith_entropy_ptr) cinfo->entropy;
-  register unsigned char nl, nm;
-  register INT32 qe, temp;
-  register int sv, data;
+  arith_entropy_ptr e = (arith_entropy_ptr) cinfo->entropy;
+  unsigned char nl, nm;
+  INT32 qe, temp;
+  int sv, data;
 
   /* Renormalization & data input per section D.2.6 */
   while (e->a < 0x8000L) {
@@ -135,7 +135,7 @@ arith_decode (j_decompress_ptr cinfo, unsigned char *st)
 	  }
 	}
       }
-      e->c = (e->c << 8) | data; /* insert data into C register */
+      e->c = (e->c << 8) | data; /* insert data into C */
       if ((e->ct += 8) < 0)	 /* update bit shift counter */
 	/* Need more initial bytes */
 	if (++e->ct == 0)

--- a/graf2d/asimage/src/libAfterImage/libjpeg/jdcoefct.c
+++ b/graf2d/asimage/src/libAfterImage/libjpeg/jdcoefct.c
@@ -550,7 +550,7 @@ decompress_smooth_data (j_decompress_ptr cinfo, JSAMPIMAGE output_buf)
 	next_block_row = buffer_ptr;
       else
 	next_block_row = buffer[block_row+1];
-      /* We fetch the surrounding DC values using a sliding-register approach.
+      /* We fetch the surrounding DC values using a sliding-approach.
        * Initialize all nine here so as to do the right thing on narrow pics.
        */
       DC1 = DC2 = DC3 = (int) prev_block_row[0][0];

--- a/graf2d/asimage/src/libAfterImage/libjpeg/jdcolor.c
+++ b/graf2d/asimage/src/libAfterImage/libjpeg/jdcolor.c
@@ -122,17 +122,17 @@ ycc_rgb_convert (j_decompress_ptr cinfo,
 		 JSAMPARRAY output_buf, int num_rows)
 {
   my_cconvert_ptr cconvert = (my_cconvert_ptr) cinfo->cconvert;
-  register int y, cb, cr;
-  register JSAMPROW outptr;
-  register JSAMPROW inptr0, inptr1, inptr2;
-  register JDIMENSION col;
+  int y, cb, cr;
+  JSAMPROW outptr;
+  JSAMPROW inptr0, inptr1, inptr2;
+  JDIMENSION col;
   JDIMENSION num_cols = cinfo->output_width;
   /* copy these pointers into registers if possible */
-  register JSAMPLE * range_limit = cinfo->sample_range_limit;
-  register int * Crrtab = cconvert->Cr_r_tab;
-  register int * Cbbtab = cconvert->Cb_b_tab;
-  register INT32 * Crgtab = cconvert->Cr_g_tab;
-  register INT32 * Cbgtab = cconvert->Cb_g_tab;
+  JSAMPLE * range_limit = cinfo->sample_range_limit;
+  int * Crrtab = cconvert->Cr_r_tab;
+  int * Cbbtab = cconvert->Cb_b_tab;
+  INT32 * Crgtab = cconvert->Cr_g_tab;
+  INT32 * Cbgtab = cconvert->Cb_g_tab;
   SHIFT_TEMPS
 
   while (--num_rows >= 0) {
@@ -170,9 +170,9 @@ null_convert (j_decompress_ptr cinfo,
 	      JSAMPIMAGE input_buf, JDIMENSION input_row,
 	      JSAMPARRAY output_buf, int num_rows)
 {
-  register JSAMPROW inptr, outptr;
-  register JDIMENSION count;
-  register int num_components = cinfo->num_components;
+  JSAMPROW inptr, outptr;
+  JDIMENSION count;
+  int num_components = cinfo->num_components;
   JDIMENSION num_cols = cinfo->output_width;
   int ci;
 
@@ -218,8 +218,8 @@ gray_rgb_convert (j_decompress_ptr cinfo,
 		  JSAMPIMAGE input_buf, JDIMENSION input_row,
 		  JSAMPARRAY output_buf, int num_rows)
 {
-  register JSAMPROW inptr, outptr;
-  register JDIMENSION col;
+  JSAMPROW inptr, outptr;
+  JDIMENSION col;
   JDIMENSION num_cols = cinfo->output_width;
 
   while (--num_rows >= 0) {
@@ -247,17 +247,17 @@ ycck_cmyk_convert (j_decompress_ptr cinfo,
 		   JSAMPARRAY output_buf, int num_rows)
 {
   my_cconvert_ptr cconvert = (my_cconvert_ptr) cinfo->cconvert;
-  register int y, cb, cr;
-  register JSAMPROW outptr;
-  register JSAMPROW inptr0, inptr1, inptr2, inptr3;
-  register JDIMENSION col;
+  int y, cb, cr;
+  JSAMPROW outptr;
+  JSAMPROW inptr0, inptr1, inptr2, inptr3;
+  JDIMENSION col;
   JDIMENSION num_cols = cinfo->output_width;
   /* copy these pointers into registers if possible */
-  register JSAMPLE * range_limit = cinfo->sample_range_limit;
-  register int * Crrtab = cconvert->Cr_r_tab;
-  register int * Cbbtab = cconvert->Cb_b_tab;
-  register INT32 * Crgtab = cconvert->Cr_g_tab;
-  register INT32 * Cbgtab = cconvert->Cb_g_tab;
+  JSAMPLE * range_limit = cinfo->sample_range_limit;
+  int * Crrtab = cconvert->Cr_r_tab;
+  int * Cbbtab = cconvert->Cb_b_tab;
+  INT32 * Crgtab = cconvert->Cr_g_tab;
+  INT32 * Cbgtab = cconvert->Cb_g_tab;
   SHIFT_TEMPS
 
   while (--num_rows >= 0) {

--- a/graf2d/asimage/src/libAfterImage/libjpeg/jdhuff.c
+++ b/graf2d/asimage/src/libAfterImage/libjpeg/jdhuff.c
@@ -86,7 +86,7 @@ typedef struct {		/* Bitreading working state within an MCU */
   /* We need a copy, rather than munging the original, in case of suspension */
   const JOCTET * next_input_byte; /* => next byte to read from source */
   size_t bytes_in_buffer;	/* # of bytes remaining in source buffer */
-  /* Bit input buffer --- note these values are kept in register variables,
+  /* Bit input buffer --- note these values are kept in variables,
    * not in this struct, inside the inner loops.
    */
   bit_buf_type get_buffer;	/* current bit-extraction buffer */
@@ -97,8 +97,8 @@ typedef struct {		/* Bitreading working state within an MCU */
 
 /* Macros to declare and load/save bitread local variables. */
 #define BITREAD_STATE_VARS  \
-	register bit_buf_type get_buffer;  \
-	register int bits_left;  \
+	bit_buf_type get_buffer;  \
+	int bits_left;  \
 	bitread_working_state br_state
 
 #define BITREAD_LOAD_STATE(cinfop,permstate)  \
@@ -166,7 +166,7 @@ typedef struct {		/* Bitreading working state within an MCU */
  */
 
 #define HUFF_DECODE(result,state,htbl,failaction,slowlabel) \
-{ register int nb, look; \
+{ int nb, look; \
   if (bits_left < HUFF_LOOKAHEAD) { \
     if (! jpeg_fill_bit_buffer(&state,get_buffer,bits_left, 0)) {failaction;} \
     get_buffer = state.get_buffer; bits_left = state.bits_left; \
@@ -463,13 +463,13 @@ jpeg_make_d_derived_tbl (j_decompress_ptr cinfo, boolean isDC, int tblno,
 
 LOCAL(boolean)
 jpeg_fill_bit_buffer (bitread_working_state * state,
-		      register bit_buf_type get_buffer, register int bits_left,
+		      bit_buf_type get_buffer, int bits_left,
 		      int nbits)
 /* Load up the bit buffer to a depth of at least nbits */
 {
   /* Copy heavily used state fields into locals (hopefully registers) */
-  register const JOCTET * next_input_byte = state->next_input_byte;
-  register size_t bytes_in_buffer = state->bytes_in_buffer;
+  const JOCTET * next_input_byte = state->next_input_byte;
+  size_t bytes_in_buffer = state->bytes_in_buffer;
   j_decompress_ptr cinfo = state->cinfo;
 
   /* Attempt to load at least MIN_GET_BITS bits into get_buffer. */
@@ -478,7 +478,7 @@ jpeg_fill_bit_buffer (bitread_working_state * state,
 
   if (cinfo->unread_marker == 0) {	/* cannot advance past a marker */
     while (bits_left < MIN_GET_BITS) {
-      register int c;
+      int c;
 
       /* Attempt to read a byte */
       if (bytes_in_buffer == 0) {
@@ -590,11 +590,11 @@ static const int bmask[16] =	/* bmask[n] is mask for n rightmost bits */
 
 LOCAL(int)
 jpeg_huff_decode (bitread_working_state * state,
-		  register bit_buf_type get_buffer, register int bits_left,
+		  bit_buf_type get_buffer, int bits_left,
 		  d_derived_tbl * htbl, int min_bits)
 {
-  register int l = min_bits;
-  register INT32 code;
+  int l = min_bits;
+  INT32 code;
 
   /* HUFF_DECODE has determined that the code is at least min_bits */
   /* bits long, so fetch that many bits in one swoop. */
@@ -696,7 +696,7 @@ decode_mcu_DC_first (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
 {   
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
   int Al = cinfo->Al;
-  register int s, r;
+  int s, r;
   int blkn, ci;
   JBLOCKROW block;
   BITREAD_STATE_VARS;
@@ -766,7 +766,7 @@ METHODDEF(boolean)
 decode_mcu_AC_first (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
 {   
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
-  register int s, k, r;
+  int s, k, r;
   unsigned int EOBRUN;
   int Se, Al;
   const int * natural_order;
@@ -904,7 +904,7 @@ METHODDEF(boolean)
 decode_mcu_AC_refine (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
 {   
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
-  register int s, k, r;
+  int s, k, r;
   unsigned int EOBRUN;
   int Se, p1, m1;
   const int * natural_order;
@@ -1088,7 +1088,7 @@ decode_mcu_sub (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
     for (blkn = 0; blkn < cinfo->blocks_in_MCU; blkn++) {
       JBLOCKROW block = MCU_data[blkn];
       d_derived_tbl * htbl;
-      register int s, k, r;
+      int s, k, r;
       int coef_limit, ci;
 
       /* Decode a single block's worth of coefficients */
@@ -1212,7 +1212,7 @@ decode_mcu (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
     for (blkn = 0; blkn < cinfo->blocks_in_MCU; blkn++) {
       JBLOCKROW block = MCU_data[blkn];
       d_derived_tbl * htbl;
-      register int s, k, r;
+      int s, k, r;
       int coef_limit, ci;
 
       /* Decode a single block's worth of coefficients */

--- a/graf2d/asimage/src/libAfterImage/libjpeg/jdhuff.h
+++ b/graf2d/asimage/src/libAfterImage/libjpeg/jdhuff.h
@@ -89,7 +89,7 @@ typedef struct {		/* Bitreading working state within an MCU */
   /* We need a copy, rather than munging the original, in case of suspension */
   const JOCTET * next_input_byte; /* => next byte to read from source */
   size_t bytes_in_buffer;	/* # of bytes remaining in source buffer */
-  /* Bit input buffer --- note these values are kept in register variables,
+  /* Bit input buffer --- note these values are kept in variables,
    * not in this struct, inside the inner loops.
    */
   bit_buf_type get_buffer;	/* current bit-extraction buffer */
@@ -100,8 +100,8 @@ typedef struct {		/* Bitreading working state within an MCU */
 
 /* Macros to declare and load/save bitread local variables. */
 #define BITREAD_STATE_VARS  \
-	register bit_buf_type get_buffer;  \
-	register int bits_left;  \
+	bit_buf_type get_buffer;  \
+	int bits_left;  \
 	bitread_working_state br_state
 
 #define BITREAD_LOAD_STATE(cinfop,permstate)  \
@@ -152,8 +152,8 @@ typedef struct {		/* Bitreading working state within an MCU */
 
 /* Load up the bit buffer to a depth of at least nbits */
 EXTERN(boolean) jpeg_fill_bit_buffer
-	JPP((bitread_working_state * state, register bit_buf_type get_buffer,
-	     register int bits_left, int nbits));
+	JPP((bitread_working_state * state, bit_buf_type get_buffer,
+	     int bits_left, int nbits));
 
 
 /*
@@ -174,7 +174,7 @@ EXTERN(boolean) jpeg_fill_bit_buffer
  */
 
 #define HUFF_DECODE(result,state,htbl,failaction,slowlabel) \
-{ register int nb, look; \
+{ int nb, look; \
   if (bits_left < HUFF_LOOKAHEAD) { \
     if (! jpeg_fill_bit_buffer(&state,get_buffer,bits_left, 0)) {failaction;} \
     get_buffer = state.get_buffer; bits_left = state.bits_left; \
@@ -197,5 +197,5 @@ slowlabel: \
 
 /* Out-of-line case for Huffman code fetching */
 EXTERN(int) jpeg_huff_decode
-	JPP((bitread_working_state * state, register bit_buf_type get_buffer,
-	     register int bits_left, d_derived_tbl * htbl, int min_bits));
+	JPP((bitread_working_state * state, bit_buf_type get_buffer,
+	     int bits_left, d_derived_tbl * htbl, int min_bits));

--- a/graf2d/asimage/src/libAfterImage/libjpeg/jdmerge.c
+++ b/graf2d/asimage/src/libAfterImage/libjpeg/jdmerge.c
@@ -228,13 +228,13 @@ h2v1_merged_upsample (j_decompress_ptr cinfo,
 		      JSAMPARRAY output_buf)
 {
   my_upsample_ptr upsample = (my_upsample_ptr) cinfo->upsample;
-  register int y, cred, cgreen, cblue;
+  int y, cred, cgreen, cblue;
   int cb, cr;
-  register JSAMPROW outptr;
+  JSAMPROW outptr;
   JSAMPROW inptr0, inptr1, inptr2;
   JDIMENSION col;
   /* copy these pointers into registers if possible */
-  register JSAMPLE * range_limit = cinfo->sample_range_limit;
+  JSAMPLE * range_limit = cinfo->sample_range_limit;
   int * Crrtab = upsample->Cr_r_tab;
   int * Cbbtab = upsample->Cb_b_tab;
   INT32 * Crgtab = upsample->Cr_g_tab;
@@ -290,13 +290,13 @@ h2v2_merged_upsample (j_decompress_ptr cinfo,
 		      JSAMPARRAY output_buf)
 {
   my_upsample_ptr upsample = (my_upsample_ptr) cinfo->upsample;
-  register int y, cred, cgreen, cblue;
+  int y, cred, cgreen, cblue;
   int cb, cr;
-  register JSAMPROW outptr0, outptr1;
+  JSAMPROW outptr0, outptr1;
   JSAMPROW inptr00, inptr01, inptr1, inptr2;
   JDIMENSION col;
   /* copy these pointers into registers if possible */
-  register JSAMPLE * range_limit = cinfo->sample_range_limit;
+  JSAMPLE * range_limit = cinfo->sample_range_limit;
   int * Crrtab = upsample->Cr_r_tab;
   int * Cbbtab = upsample->Cb_b_tab;
   INT32 * Crgtab = upsample->Cr_g_tab;

--- a/graf2d/asimage/src/libAfterImage/libjpeg/jdsample.c
+++ b/graf2d/asimage/src/libAfterImage/libjpeg/jdsample.c
@@ -192,9 +192,9 @@ int_upsample (j_decompress_ptr cinfo, jpeg_component_info * compptr,
 {
   my_upsample_ptr upsample = (my_upsample_ptr) cinfo->upsample;
   JSAMPARRAY output_data = *output_data_ptr;
-  register JSAMPROW inptr, outptr;
-  register JSAMPLE invalue;
-  register int h;
+  JSAMPROW inptr, outptr;
+  JSAMPLE invalue;
+  int h;
   JSAMPROW outend;
   int h_expand, v_expand;
   int inrow, outrow;
@@ -235,8 +235,8 @@ h2v1_upsample (j_decompress_ptr cinfo, jpeg_component_info * compptr,
 	       JSAMPARRAY input_data, JSAMPARRAY * output_data_ptr)
 {
   JSAMPARRAY output_data = *output_data_ptr;
-  register JSAMPROW inptr, outptr;
-  register JSAMPLE invalue;
+  JSAMPROW inptr, outptr;
+  JSAMPLE invalue;
   JSAMPROW outend;
   int outrow;
 
@@ -263,8 +263,8 @@ h2v2_upsample (j_decompress_ptr cinfo, jpeg_component_info * compptr,
 	       JSAMPARRAY input_data, JSAMPARRAY * output_data_ptr)
 {
   JSAMPARRAY output_data = *output_data_ptr;
-  register JSAMPROW inptr, outptr;
-  register JSAMPLE invalue;
+  JSAMPROW inptr, outptr;
+  JSAMPLE invalue;
   JSAMPROW outend;
   int inrow, outrow;
 

--- a/graf2d/asimage/src/libAfterImage/libjpeg/jquant1.c
+++ b/graf2d/asimage/src/libAfterImage/libjpeg/jquant1.c
@@ -462,12 +462,12 @@ color_quantize (j_decompress_ptr cinfo, JSAMPARRAY input_buf,
 {
   my_cquantize_ptr cquantize = (my_cquantize_ptr) cinfo->cquantize;
   JSAMPARRAY colorindex = cquantize->colorindex;
-  register int pixcode, ci;
-  register JSAMPROW ptrin, ptrout;
+  int pixcode, ci;
+  JSAMPROW ptrin, ptrout;
   int row;
   JDIMENSION col;
   JDIMENSION width = cinfo->output_width;
-  register int nc = cinfo->out_color_components;
+  int nc = cinfo->out_color_components;
 
   for (row = 0; row < num_rows; row++) {
     ptrin = input_buf[row];
@@ -489,8 +489,8 @@ color_quantize3 (j_decompress_ptr cinfo, JSAMPARRAY input_buf,
 /* Fast path for out_color_components==3, no dithering */
 {
   my_cquantize_ptr cquantize = (my_cquantize_ptr) cinfo->cquantize;
-  register int pixcode;
-  register JSAMPROW ptrin, ptrout;
+  int pixcode;
+  JSAMPROW ptrin, ptrout;
   JSAMPROW colorindex0 = cquantize->colorindex[0];
   JSAMPROW colorindex1 = cquantize->colorindex[1];
   JSAMPROW colorindex2 = cquantize->colorindex[2];
@@ -517,8 +517,8 @@ quantize_ord_dither (j_decompress_ptr cinfo, JSAMPARRAY input_buf,
 /* General case, with ordered dithering */
 {
   my_cquantize_ptr cquantize = (my_cquantize_ptr) cinfo->cquantize;
-  register JSAMPROW input_ptr;
-  register JSAMPROW output_ptr;
+  JSAMPROW input_ptr;
+  JSAMPROW output_ptr;
   JSAMPROW colorindex_ci;
   int * dither;			/* points to active row of dither matrix */
   int row_index, col_index;	/* current indexes into dither matrix */
@@ -567,9 +567,9 @@ quantize3_ord_dither (j_decompress_ptr cinfo, JSAMPARRAY input_buf,
 /* Fast path for out_color_components==3, with ordered dithering */
 {
   my_cquantize_ptr cquantize = (my_cquantize_ptr) cinfo->cquantize;
-  register int pixcode;
-  register JSAMPROW input_ptr;
-  register JSAMPROW output_ptr;
+  int pixcode;
+  JSAMPROW input_ptr;
+  JSAMPROW output_ptr;
   JSAMPROW colorindex0 = cquantize->colorindex[0];
   JSAMPROW colorindex1 = cquantize->colorindex[1];
   JSAMPROW colorindex2 = cquantize->colorindex[2];
@@ -612,14 +612,14 @@ quantize_fs_dither (j_decompress_ptr cinfo, JSAMPARRAY input_buf,
 /* General case, with Floyd-Steinberg dithering */
 {
   my_cquantize_ptr cquantize = (my_cquantize_ptr) cinfo->cquantize;
-  register LOCFSERROR cur;	/* current error or pixel value */
+  LOCFSERROR cur;	/* current error or pixel value */
   LOCFSERROR belowerr;		/* error for pixel below cur */
   LOCFSERROR bpreverr;		/* error for below/prev col */
   LOCFSERROR bnexterr;		/* error for below/next col */
   LOCFSERROR delta;
-  register FSERRPTR errorptr;	/* => fserrors[] at column before current */
-  register JSAMPROW input_ptr;
-  register JSAMPROW output_ptr;
+  FSERRPTR errorptr;	/* => fserrors[] at column before current */
+  JSAMPROW input_ptr;
+  JSAMPROW output_ptr;
   JSAMPROW colorindex_ci;
   JSAMPROW colormap_ci;
   int pixcode;

--- a/graf2d/asimage/src/libAfterImage/libjpeg/jquant2.c
+++ b/graf2d/asimage/src/libAfterImage/libjpeg/jquant2.c
@@ -225,9 +225,9 @@ prescan_quantize (j_decompress_ptr cinfo, JSAMPARRAY input_buf,
 		  JSAMPARRAY output_buf, int num_rows)
 {
   my_cquantize_ptr cquantize = (my_cquantize_ptr) cinfo->cquantize;
-  register JSAMPROW ptr;
-  register histptr histp;
-  register hist3d histogram = cquantize->histogram;
+  JSAMPROW ptr;
+  histptr histp;
+  hist3d histogram = cquantize->histogram;
   int row;
   JDIMENSION col;
   JDIMENSION width = cinfo->output_width;
@@ -274,9 +274,9 @@ find_biggest_color_pop (boxptr boxlist, int numboxes)
 /* Find the splittable box with the largest color population */
 /* Returns NULL if no splittable boxes remain */
 {
-  register boxptr boxp;
-  register int i;
-  register long maxc = 0;
+  boxptr boxp;
+  int i;
+  long maxc = 0;
   boxptr which = NULL;
   
   for (i = 0, boxp = boxlist; i < numboxes; i++, boxp++) {
@@ -294,9 +294,9 @@ find_biggest_volume (boxptr boxlist, int numboxes)
 /* Find the splittable box with the largest (scaled) volume */
 /* Returns NULL if no splittable boxes remain */
 {
-  register boxptr boxp;
-  register int i;
-  register INT32 maxv = 0;
+  boxptr boxp;
+  int i;
+  INT32 maxv = 0;
   boxptr which = NULL;
   
   for (i = 0, boxp = boxlist; i < numboxes; i++, boxp++) {
@@ -427,7 +427,7 @@ median_cut (j_decompress_ptr cinfo, boxptr boxlist, int numboxes,
 {
   int n,lb;
   int c0,c1,c2,cmax;
-  register boxptr b1,b2;
+  boxptr b1,b2;
 
   while (numboxes < desired_colors) {
     /* Select box to split.
@@ -783,12 +783,12 @@ find_best_colors (j_decompress_ptr cinfo, int minc0, int minc1, int minc2,
 {
   int ic0, ic1, ic2;
   int i, icolor;
-  register INT32 * bptr;	/* pointer into bestdist[] array */
+  INT32 * bptr;	/* pointer into bestdist[] array */
   JSAMPLE * cptr;		/* pointer into bestcolor[] array */
   INT32 dist0, dist1;		/* initial distance values */
-  register INT32 dist2;		/* current distance in inner loop */
+  INT32 dist2;		/* current distance in inner loop */
   INT32 xx0, xx1;		/* distance increments */
-  register INT32 xx2;
+  INT32 xx2;
   INT32 inc0, inc1, inc2;	/* initial values for increments */
   /* This array holds the distance to the nearest-so-far color for each cell */
   INT32 bestdist[BOX_C0_ELEMS * BOX_C1_ELEMS * BOX_C2_ELEMS];
@@ -861,8 +861,8 @@ fill_inverse_cmap (j_decompress_ptr cinfo, int c0, int c1, int c2)
   hist3d histogram = cquantize->histogram;
   int minc0, minc1, minc2;	/* lower left corner of update box */
   int ic0, ic1, ic2;
-  register JSAMPLE * cptr;	/* pointer into bestcolor[] array */
-  register histptr cachep;	/* pointer into main cache array */
+  JSAMPLE * cptr;	/* pointer into bestcolor[] array */
+  histptr cachep;	/* pointer into main cache array */
   /* This array lists the candidate colormap indexes. */
   JSAMPLE colorlist[MAXNUMCOLORS];
   int numcolors;		/* number of candidate colors */
@@ -918,9 +918,9 @@ pass2_no_dither (j_decompress_ptr cinfo,
 {
   my_cquantize_ptr cquantize = (my_cquantize_ptr) cinfo->cquantize;
   hist3d histogram = cquantize->histogram;
-  register JSAMPROW inptr, outptr;
-  register histptr cachep;
-  register int c0, c1, c2;
+  JSAMPROW inptr, outptr;
+  histptr cachep;
+  int c0, c1, c2;
   int row;
   JDIMENSION col;
   JDIMENSION width = cinfo->output_width;
@@ -952,10 +952,10 @@ pass2_fs_dither (j_decompress_ptr cinfo,
 {
   my_cquantize_ptr cquantize = (my_cquantize_ptr) cinfo->cquantize;
   hist3d histogram = cquantize->histogram;
-  register LOCFSERROR cur0, cur1, cur2;	/* current error or pixel value */
+  LOCFSERROR cur0, cur1, cur2;	/* current error or pixel value */
   LOCFSERROR belowerr0, belowerr1, belowerr2; /* error for pixel below cur */
   LOCFSERROR bpreverr0, bpreverr1, bpreverr2; /* error for below/prev col */
-  register FSERRPTR errorptr;	/* => fserrors[] at column before current */
+  FSERRPTR errorptr;	/* => fserrors[] at column before current */
   JSAMPROW inptr;		/* => current input pixel */
   JSAMPROW outptr;		/* => current output pixel */
   histptr cachep;
@@ -1030,7 +1030,7 @@ pass2_fs_dither (j_decompress_ptr cinfo,
       if (*cachep == 0)
 	fill_inverse_cmap(cinfo, cur0>>C0_SHIFT,cur1>>C1_SHIFT,cur2>>C2_SHIFT);
       /* Now emit the colormap index for this cell */
-      { register int pixcode = *cachep - 1;
+      { int pixcode = *cachep - 1;
 	*outptr = (JSAMPLE) pixcode;
 	/* Compute representation error for this pixel */
 	cur0 -= GETJSAMPLE(colormap0[pixcode]);
@@ -1041,7 +1041,7 @@ pass2_fs_dither (j_decompress_ptr cinfo,
        * Add these into the running sums, and simultaneously shift the
        * next-line error sums left by 1 column.
        */
-      { register LOCFSERROR bnexterr, delta;
+      { LOCFSERROR bnexterr, delta;
 
 	bnexterr = cur0;	/* Process component 0 */
 	delta = cur0 * 2;

--- a/graf2d/asimage/src/libAfterImage/libjpeg/jutils.c
+++ b/graf2d/asimage/src/libAfterImage/libjpeg/jutils.c
@@ -169,13 +169,13 @@ jcopy_sample_rows (JSAMPARRAY input_array, int source_row,
  * The source and destination arrays must be at least as wide as num_cols.
  */
 {
-  register JSAMPROW inptr, outptr;
+  JSAMPROW inptr, outptr;
 #ifdef FMEMCOPY
-  register size_t count = (size_t) (num_cols * SIZEOF(JSAMPLE));
+  size_t count = (size_t) (num_cols * SIZEOF(JSAMPLE));
 #else
-  register JDIMENSION count;
+  JDIMENSION count;
 #endif
-  register int row;
+  int row;
 
   input_array += source_row;
   output_array += dest_row;
@@ -201,8 +201,8 @@ jcopy_block_row (JBLOCKROW input_row, JBLOCKROW output_row,
 #ifdef FMEMCOPY
   FMEMCOPY(output_row, input_row, num_blocks * (DCTSIZE2 * SIZEOF(JCOEF)));
 #else
-  register JCOEFPTR inptr, outptr;
-  register long count;
+  JCOEFPTR inptr, outptr;
+  long count;
 
   inptr = (JCOEFPTR) input_row;
   outptr = (JCOEFPTR) output_row;
@@ -221,8 +221,8 @@ jzero_far (void FAR * target, size_t bytestozero)
 #ifdef FMEMZERO
   FMEMZERO(target, bytestozero);
 #else
-  register char FAR * ptr = (char FAR *) target;
-  register size_t count;
+  char FAR * ptr = (char FAR *) target;
+  size_t count;
 
   for (count = bytestozero; count > 0; count--) {
     *ptr++ = 0;

--- a/graf2d/asimage/src/libAfterImage/libungif/gifalloc.c
+++ b/graf2d/asimage/src/libAfterImage/libungif/gifalloc.c
@@ -28,7 +28,7 @@
 int BitSize(int n)
 /* return smallest bitfield size n will fit in */
 {
-    register  int i;
+     int i;
 
     for (i = 1; i <= 8; i++)
 	if ((1 << i) >= n)
@@ -172,7 +172,7 @@ ColorMapObject *UnionColorMap(
 
     if (RoundUpTo != ColorUnion->ColorCount)
     {
-	register GifColorType	*Map = ColorUnion->Colors;
+	GifColorType	*Map = ColorUnion->Colors;
 
 	/*
 	 * Zero out slots up to next power of 2.
@@ -199,8 +199,8 @@ void ApplyTranslation(SavedImage *Image, GifPixelType Translation[])
  * Apply a given color translation to the raster bits of an image
  */
 {
-    register int i;
-    register int RasterSize = Image->ImageDesc.Height * Image->ImageDesc.Width;
+    int i;
+    int RasterSize = Image->ImageDesc.Height * Image->ImageDesc.Width;
 
     for (i = 0; i < RasterSize; i++)
 	Image->RasterBits[i] = Translation[(int)(Image->RasterBits[i])];

--- a/graf2d/asimage/src/libAfterImage/scanline.c
+++ b/graf2d/asimage/src/libAfterImage/scanline.c
@@ -46,7 +46,7 @@
 ASScanline*
 prepare_scanline( unsigned int width, unsigned int shift, ASScanline *reusable_memory, Bool BGR_mode  )
 {
-	register ASScanline *sl = reusable_memory ;
+	ASScanline *sl = reusable_memory ;
 	size_t aligned_width;
 	void *ptr;
 

--- a/graf2d/asimage/src/libAfterImage/transform.c
+++ b/graf2d/asimage/src/libAfterImage/transform.c
@@ -111,10 +111,10 @@ ASVisual __transform_fake_asv = {0};
 #define AVERAGE_COLORN(T,N)					(((T)<<QUANT_ERR_BITS)/N)
 
 static inline void
-enlarge_component12( register CARD32 *src, register CARD32 *dst, int *scales, int len )
+enlarge_component12( CARD32 *src, CARD32 *dst, int *scales, int len )
 {/* expected len >= 2  */
-	register int i = 0, k = 0;
-	register int c1 = src[0], c4;
+	int i = 0, k = 0;
+	int c1 = src[0], c4;
 	--len; --len ;
 	while( i < len )
 	{
@@ -123,7 +123,7 @@ enlarge_component12( register CARD32 *src, register CARD32 *dst, int *scales, in
 		dst[k] = INTERPOLATE_COLOR1(src[i]) ;
 		if( scales[i] == 2 )
 		{
-			register int c2 = src[i], c3 = src[i+1] ;
+			int c2 = src[i], c3 = src[i+1] ;
 			c3 = INTERPOLATE_COLOR2(c1,c2,c3,c4);
 			dst[++k] = (c3&0xFF000000 )?0:c3;
 		}
@@ -137,7 +137,7 @@ enlarge_component12( register CARD32 *src, register CARD32 *dst, int *scales, in
 		dst[k] = INTERPOLATE_COLOR1(src[i]);
 	else
 	{
-		register int c2 = src[i], c3 = src[i+1] ;
+		int c2 = src[i], c3 = src[i+1] ;
 		c2 = INTERPOLATE_COLOR2(c1,c2,c3,c3);
 		dst[k] = (c2&0xFF000000 )?0:c2;
 	}
@@ -145,10 +145,10 @@ enlarge_component12( register CARD32 *src, register CARD32 *dst, int *scales, in
 }
 
 static inline void
-enlarge_component23( register CARD32 *src, register CARD32 *dst, int *scales, int len )
+enlarge_component23( CARD32 *src, CARD32 *dst, int *scales, int len )
 {/* expected len >= 2  */
-	register int i = 0, k = 0;
-	register int c1 = src[0], c4 = src[1];
+	int i = 0, k = 0;
+	int c1 = src[0], c4 = src[1];
 	if( scales[0] == 1 )
 	{/* special processing for first element - it can be 1 - others can only be 2 or 3 */
 		dst[k] = INTERPOLATE_COLOR1(src[0]) ;
@@ -158,7 +158,7 @@ enlarge_component23( register CARD32 *src, register CARD32 *dst, int *scales, in
 	--len; --len ;
 	while( i < len )
 	{
-		register int c2 = src[i], c3 = src[i+1] ;
+		int c2 = src[i], c3 = src[i+1] ;
 		c4 = src[i+2];
 		dst[k] = INTERPOLATE_COLOR1(c2) ;
 		if( scales[i] == 2 )
@@ -179,7 +179,7 @@ enlarge_component23( register CARD32 *src, register CARD32 *dst, int *scales, in
 	}
 	/* to avoid one more if() in loop we moved tail part out of the loop : */
 	{
-		register int c2 = src[i], c3 = src[i+1] ;
+		int c2 = src[i], c3 = src[i+1] ;
 		dst[k] = INTERPOLATE_COLOR1(c2) ;
 		if( scales[i] == 2 )
 		{
@@ -206,12 +206,12 @@ enlarge_component23( register CARD32 *src, register CARD32 *dst, int *scales, in
  * visible artifacts on smooth gradient-like images
  */
 static inline void
-enlarge_component( register CARD32 *src, register CARD32 *dst, int *scales, int len )
+enlarge_component( CARD32 *src, CARD32 *dst, int *scales, int len )
 {/* we skip all checks as it is static function and we want to optimize it
   * as much as possible */
 	int i = 0;
 	int c1 = src[0];
-	register int T ;
+	int T ;
 	--len ;
 	if( len < 1 )
 	{
@@ -222,8 +222,8 @@ enlarge_component( register CARD32 *src, register CARD32 *dst, int *scales, int 
 	}
 	do
 	{
-		register short S = scales[i];
-		register int step = INTERPOLATION_TOTAL_STEP(src[i],src[i+1]);
+		short S = scales[i];
+		int step = INTERPOLATION_TOTAL_STEP(src[i],src[i+1]);
 
 		if( i+1 == len )
 			T = INTERPOLATION_TOTAL_START(c1,src[i],src[i+1],src[i+1],S);
@@ -233,7 +233,7 @@ enlarge_component( register CARD32 *src, register CARD32 *dst, int *scales, int 
 /*		LOCAL_DEBUG_OUT( "pixel %d, S = %d, step = %d", i, S, step );*/
 		if( step )
 		{
-			register int n = 0 ;
+			int n = 0 ;
 			do
 			{
 				dst[n] = (T&0x7F000000)?0:INTERPOLATE_N_COLOR(T,S);
@@ -243,7 +243,7 @@ enlarge_component( register CARD32 *src, register CARD32 *dst, int *scales, int 
 			dst += n ;
 		}else
 		{
-			register CARD32 c = (T&0x7F000000)?0:INTERPOLATE_N_COLOR(T,S);
+			CARD32 c = (T&0x7F000000)?0:INTERPOLATE_N_COLOR(T,S);
 			while(--S >= 0){	dst[S] = c;	}
 			dst += scales[i] ;
 		}
@@ -254,13 +254,13 @@ enlarge_component( register CARD32 *src, register CARD32 *dst, int *scales, int 
 }
 
 static inline void
-enlarge_component_dumb( register CARD32 *src, register CARD32 *dst, int *scales, int len )
+enlarge_component_dumb( CARD32 *src, CARD32 *dst, int *scales, int len )
 {/* we skip all checks as it is static function and we want to optimize it
   * as much as possible */
 	int i = 0, k = 0;
 	do
 	{
-		register CARD32 c = INTERPOLATE_COLOR1(src[i]);
+		CARD32 c = INTERPOLATE_COLOR1(src[i]);
 		int max_k = k+scales[i];
 		do
 		{
@@ -271,14 +271,14 @@ enlarge_component_dumb( register CARD32 *src, register CARD32 *dst, int *scales,
 
 /* this will shrink array based on count of items in src per one dst item with averaging */
 static inline void
-shrink_component( register CARD32 *src, register CARD32 *dst, int *scales, int len )
+shrink_component( CARD32 *src, CARD32 *dst, int *scales, int len )
 {/* we skip all checks as it is static function and we want to optimize it
   * as much as possible */
-	register int i = -1, k = -1;
+	int i = -1, k = -1;
 	while( ++k < len )
 	{
-		register int reps = scales[k] ;
-		register int c1 = src[++i];
+		int reps = scales[k] ;
+		int c1 = src[++i];
 /*LOCAL_DEBUG_OUT( "pixel = %d, scale[k] = %d", k, reps );*/
 		if( reps == 1 )
 			dst[k] = AVERAGE_COLOR1(c1);
@@ -295,25 +295,25 @@ shrink_component( register CARD32 *src, register CARD32 *dst, int *scales, int l
 				c1 += src[i];
 			}
 			{
-				register short S = scales[k];
+				short S = scales[k];
 				dst[k] = AVERAGE_COLORN(c1,S);
 			}
 		}
 	}
 }
 static inline void
-shrink_component11( register CARD32 *src, register CARD32 *dst, int *scales, int len )
+shrink_component11( CARD32 *src, CARD32 *dst, int *scales, int len )
 {
-	register int i ;
+	int i ;
 	for( i = 0 ; i < len ; ++i )
 		dst[i] = AVERAGE_COLOR1(src[i]);
 }
 
 
 static inline void
-reverse_component( register CARD32 *src, register CARD32 *dst, int *unused, int len )
+reverse_component( CARD32 *src, CARD32 *dst, int *unused, int len )
 {
-	register int i = 0;
+	int i = 0;
 	src += len-1 ;
 	do
 	{
@@ -358,7 +358,7 @@ add_component( CARD32 *src, CARD32 *incr, int *scales, int len )
 #endif
 #endif
 	{
-		register int c1, c2;
+		int c1, c2;
 		int i = 0;
 		do{
 			c1 = (int)src[i] + (int)incr[i] ;
@@ -372,30 +372,30 @@ add_component( CARD32 *src, CARD32 *incr, int *scales, int len )
 
 #ifdef NEED_RBITSHIFT_FUNCS
 static inline void
-rbitshift_component( register CARD32 *src, register CARD32 *dst, int shift, int len )
+rbitshift_component( CARD32 *src, CARD32 *dst, int shift, int len )
 {
-	register int i ;
+	int i ;
 	for( i = 0 ; i < len ; ++i )
 		dst[i] = src[i]>>shift;
 }
 #endif
 
 static inline void
-start_component_interpolation( CARD32 *c1, CARD32 *c2, CARD32 *c3, CARD32 *c4, register CARD32 *T, register CARD32 *step, int S, int len)
+start_component_interpolation( CARD32 *c1, CARD32 *c2, CARD32 *c3, CARD32 *c4, CARD32 *T, CARD32 *step, int S, int len)
 {
-	register int i;
+	int i;
 	for( i = 0 ; i < len ; i++ )
 	{
-		register int rc2 = c2[i], rc3 = c3[i] ;
+		int rc2 = c2[i], rc3 = c3[i] ;
 		T[i] = INTERPOLATION_TOTAL_START(c1[i],rc2,rc3,c4[i],S)/(S<<1);
 		step[i] = INTERPOLATION_TOTAL_STEP(rc2,rc3)/(S<<1);
 	}
 }
 
 static inline void
-component_interpolation_hardcoded( CARD32 *c1, CARD32 *c2, CARD32 *c3, CARD32 *c4, register CARD32 *T, CARD32 *unused, CARD16 kind, int len)
+component_interpolation_hardcoded( CARD32 *c1, CARD32 *c2, CARD32 *c3, CARD32 *c4, CARD32 *T, CARD32 *unused, CARD16 kind, int len)
 {
-	register int i;
+	int i;
 	if( kind == 1 )
 	{
 		for( i = 0 ; i < len ; i++ )
@@ -405,8 +405,8 @@ component_interpolation_hardcoded( CARD32 *c1, CARD32 *c2, CARD32 *c3, CARD32 *c
 			   and even better then more complicated one : */
 			T[i] = (c2[i]+c3[i])>>1 ;
 #else
-    		register int minus = c1[i]+c4[i] ;
-			register int plus  = (c2[i]<<1)+c2[i]+(c3[i]<<1)+c3[i];
+    		int minus = c1[i]+c4[i] ;
+			int plus  = (c2[i]<<1)+c2[i]+(c3[i]<<1)+c3[i];
 
 			T[i] = ( (plus>>1) < minus )?(c2[i]+c3[i])>>1 :
 								   		 (plus-minus)>>2;
@@ -416,47 +416,47 @@ component_interpolation_hardcoded( CARD32 *c1, CARD32 *c2, CARD32 *c3, CARD32 *c
 	{
 		for( i = 0 ; i < len ; i++ )
 		{
-    		register int rc1 = c1[i], rc2 = c2[i], rc3 = c3[i] ;
+    		int rc1 = c1[i], rc2 = c2[i], rc3 = c3[i] ;
 			T[i] = INTERPOLATE_A_COLOR3_V(rc1,rc2,rc3,c4[i]);
 		}
 	}else
 		for( i = 0 ; i < len ; i++ )
 		{
-    		register int rc1 = c1[i], rc2 = c2[i], rc3 = c3[i] ;
+    		int rc1 = c1[i], rc2 = c2[i], rc3 = c3[i] ;
 			T[i] = INTERPOLATE_B_COLOR3_V(rc1,rc2,rc3,c4[i]);
 		}
 }
 
 #ifdef NEED_RBITSHIFT_FUNCS
 static inline void
-divide_component_mod( register CARD32 *data, CARD16 ratio, int len )
+divide_component_mod( CARD32 *data, CARD16 ratio, int len )
 {
-	register int i ;
+	int i ;
 	for( i = 0 ; i < len ; ++i )
 		data[i] /= ratio;
 }
 
 static inline void
-rbitshift_component_mod( register CARD32 *data, int bits, int len )
+rbitshift_component_mod( CARD32 *data, int bits, int len )
 {
-	register int i ;
+	int i ;
 	for( i = 0 ; i < len ; ++i )
 		data[i] = data[i]>>bits;
 }
 #endif
 void
-print_component( register CARD32 *data, int nonsense, int len )
+print_component( CARD32 *data, int nonsense, int len )
 {
-	register int i ;
+	int i ;
 	for( i = 0 ; i < len ; ++i )
 		fprintf( stderr, " %8.8lX", (long)data[i] );
 	fprintf( stderr, "\n");
 }
 
 static inline void
-tint_component_mod( register CARD32 *data, CARD16 ratio, int len )
+tint_component_mod( CARD32 *data, CARD16 ratio, int len )
 {
-	register int i ;
+	int i ;
 	if( ratio == 255 )
 		for( i = 0 ; i < len ; ++i )
 			data[i] = data[i]<<8;
@@ -472,9 +472,9 @@ tint_component_mod( register CARD32 *data, CARD16 ratio, int len )
 }
 
 static inline void
-make_component_gradient16( register CARD32 *data, CARD16 from, CARD16 to, CARD8 seed, int len )
+make_component_gradient16( CARD32 *data, CARD16 from, CARD16 to, CARD8 seed, int len )
 {
-	register int i ;
+	int i ;
 	long incr = (((long)to<<8)-((long)from<<8))/len ;
 
 	if( incr == 0 )
@@ -497,7 +497,7 @@ make_component_gradient16( register CARD32 *data, CARD16 from, CARD16 to, CARD8 
 static inline void
 copytintpad_scanline( ASScanline *src, ASScanline *dst, int offset, ARGB32 tint )
 {
-	register int i ;
+	int i ;
 	CARD32 chan_tint[4], chan_fill[4] ;
 	int color ;
 	int copy_width = src->width, dst_offset = 0, src_offset = 0;
@@ -521,13 +521,13 @@ copytintpad_scanline( ASScanline *src, ASScanline *dst, int offset, ARGB32 tint 
 	dst->flags = src->flags ;
 	for( color = 0 ; color < IC_NUM_CHANNELS ; ++color )
 	{
-		register CARD32 *psrc = src->channels[color]+src_offset;
-		register CARD32 *pdst = dst->channels[color];
+		CARD32 *psrc = src->channels[color]+src_offset;
+		CARD32 *pdst = dst->channels[color];
 		int ratio = chan_tint[color];
 /*	fprintf( stderr, "channel %d, tint is %d(%X), src_width = %d, src_offset = %d, dst_width = %d, dst_offset = %d psrc = %p, pdst = %p\n", color, ratio, ratio, src->width, src_offset, dst->width, dst_offset, psrc, pdst );
 */
 		{
-/*			register CARD32 fill = chan_fill[color]; */
+/*			CARD32 fill = chan_fill[color]; */
 			for( i = 0 ; i < dst_offset ; ++i )
 				pdst[i] = 0;
 			pdst += dst_offset ;
@@ -555,7 +555,7 @@ copytintpad_scanline( ASScanline *src, ASScanline *dst, int offset, ARGB32 tint 
 			set_flags( dst->flags, (0x01<<color));
 		}
 		{
-/*			register CARD32 fill = chan_fill[color]; */
+/*			CARD32 fill = chan_fill[color]; */
 			for( ; i < (int)dst->width-dst_offset ; ++i )
 				pdst[i] = 0;
 /*				print_component(pdst, 0, dst->width ); */
@@ -588,7 +588,7 @@ make_gradient_scanline( ASScanline *scl, ASGradient *grad, ASFlagType filter, AR
 
 		for( i = 0  ; i <= max_i ; i++ )
 		{
-			register int k ;
+			int k ;
 			int new_idx = -1 ;
 			/* now lets find the next point  : */
 			for( k = 0 ; k <= max_i ; ++k )
@@ -601,8 +601,8 @@ make_gradient_scanline( ASScanline *scl, ASGradient *grad, ASFlagType filter, AR
 						new_idx = k ;
 					else
 					{
-						register int d1 = new_idx-last_idx ;
-						register int d2 = k - last_idx ;
+						int d1 = new_idx-last_idx ;
+						int d2 = k - last_idx ;
 						if( d1*d1 > d2*d2 )
 							new_idx = k ;
 					}
@@ -666,7 +666,7 @@ make_scales( int from_size, int to_size, int tail )
 	int *scales ;
     int smaller = MIN(from_size,to_size);
     int bigger  = MAX(from_size,to_size);
-	register int i = 0, k = 0;
+	int i = 0, k = 0;
 	int eps;
     LOCAL_DEBUG_OUT( "from %d to %d tail %d", from_size, to_size, tail );
 	scales = safecalloc( smaller+tail, sizeof(int));
@@ -922,7 +922,7 @@ scale_asimage( ASVisual *asv, ASImage *src, int to_width, int to_height,
 	scales_v = make_scales( src->height, to_height, ( quality == ASIMAGE_QUALITY_POOR  || src->height <= 3)?0:1 );
 #if defined(LOCAL_DEBUG) && !defined(NO_DEBUG_OUTPUT)
 	{
-	  register int i ;
+	  int i ;
 	  for( i = 0 ; i < MIN(src->width, to_width) ; i++ )
 		fprintf( stderr, " %d", scales_h[i] );
 	  fprintf( stderr, "\n" );
@@ -1002,7 +1002,7 @@ scale_asimage2( ASVisual *asv, ASImage *src,
 	scales_v = make_scales( clip_height, to_height, ( quality == ASIMAGE_QUALITY_POOR  || clip_height <= 3)?0:1 );
 #if defined(LOCAL_DEBUG) && !defined(NO_DEBUG_OUTPUT)
 	{
-	  register int i ;
+	  int i ;
 	  for( i = 0 ; i < MIN(clip_width, to_width) ; i++ )
 		fprintf( stderr, " %d", scales_h[i] );
 	  fprintf( stderr, "\n" );
@@ -1216,7 +1216,7 @@ LOCAL_DEBUG_OUT( "min_y = %d, max_y = %d", min_y, max_y );
 				if( imdecs[i] && pcurr->dst_y <= y &&
 					pcurr->dst_y+(int)pcurr->clip_height+(int)imdecs[i]->bevel_v_addon > y )
 				{
-					register ASScanline *b = &(imdecs[i]->buffer);
+					ASScanline *b = &(imdecs[i]->buffer);
 					CARD32 tint = pcurr->tint ;
 					imdecs[i]->decode_image_scanline( imdecs[i] );
 					if( tint != 0 )
@@ -1307,11 +1307,11 @@ LOCAL_DEBUG_CALLER_OUT( "width = %d, height = %d, filetr = 0x%lX, dither_count =
 					LOCAL_DEBUG_OUT( "back_color = %8.8lX", result.back_color);
 				}else
 				{
-					register CARD32  *dst = result.channels[color] ;
+					CARD32  *dst = result.channels[color] ;
 					for( line = 0 ; line  < dither_lines_num ; line++ )
 					{
-						register int x ;
-						register CARD32 d = chan_data[line] ;
+						int x ;
+						CARD32 d = chan_data[line] ;
 						for( x = line ; x < width ; x+=dither_lines_num )
 						{
 							dst[x] = d ;
@@ -1332,7 +1332,7 @@ make_gradient_diag_width( ASImageOutput *imout, ASScanline *dither_lines, int di
 	/* using bresengham algorithm again to trigger horizontal shift : */
 	short smaller = imout->im->height;
 	short bigger  = imout->im->width;
-	register int i = 0;
+	int i = 0;
 	int eps;
 LOCAL_DEBUG_CALLER_OUT( "width = %d, height = %d, filetr = 0x%lX, dither_count = %d, dither width = %d\n", bigger, smaller, filter, dither_lines_num, dither_lines[0].width );
 
@@ -1362,7 +1362,7 @@ make_gradient_diag_height( ASImageOutput *imout, ASScanline *dither_lines, int d
 	/* using bresengham algorithm again to trigger horizontal shift : */
 	unsigned short smaller = width;
 	unsigned short bigger  = height;
-	register int i = 0, k =0;
+	int i = 0, k =0;
 	int eps;
 	ASScanline result;
 	int *offsets ;
@@ -1442,7 +1442,7 @@ get_best_grad_back_color( ASGradient *grad )
 	{
 		CARD8 best = 0;
 		unsigned int best_size = 0;
-		register int i = grad->npoints;
+		int i = grad->npoints;
 		while( --i > 0 )
 		{ /* very crude algorithm, detecting biggest spans of the same color :*/
 			CARD8 c = ARGB32_CHAN8(grad->color[i], chan );
@@ -1809,10 +1809,10 @@ LOCAL_DEBUG_OUT( "copiing %d lines", clip_height );
 				result.flags = imdec->buffer.flags ;
 				for( chan = 0 ; chan < IC_NUM_CHANNELS ; ++chan )
 				{
-	   				register CARD32 *chan_data = result.channels[chan] ;
-	   				register CARD32 *src_chan_data = imdec->buffer.channels[chan]+((dst_x<0)? -dst_x : 0) ;
+	   				CARD32 *chan_data = result.channels[chan] ;
+	   				CARD32 *src_chan_data = imdec->buffer.channels[chan]+((dst_x<0)? -dst_x : 0) ;
 					CARD32 chan_val = ARGB32_CHAN8(color, chan);
-					register int k = -1;
+					int k = -1;
 					for( k = 0 ; k < start_x ; ++k )
 						chan_data[k] = chan_val ;
 					chan_data += k ;
@@ -1893,7 +1893,7 @@ Bool fill_asimage( ASVisual *asv, ASImage *im,
 			CARD32 	*b = imdec->buffer.blue + x  ;
 			for( i = 0 ; i < height ; i++ )
 			{
-				register int k ;
+				int k ;
 				imdec->decode_image_scanline( imdec );
 				for( k = 0 ; k < width ; ++k )
 				{
@@ -1924,7 +1924,7 @@ colorize_asimage_vector( ASVisual *asv, ASImage *im,
 	ASImageOutput  *imout = NULL ;
 	ASScanline buf ;
 	int x, y, curr_point, last_point ;
-    register double *vector ;
+    double *vector ;
 	double *points ;
 	double *multipliers[IC_NUM_CHANNELS] ;
 	START_TIME(started);
@@ -1975,7 +1975,7 @@ colorize_asimage_vector( ASVisual *asv, ASImage *im,
 	{
 		for( x = 0 ; x < (int)im->width ;)
 		{
-			register int i = IC_NUM_CHANNELS ;
+			int i = IC_NUM_CHANNELS ;
 			double d ;
 
 			if( points[curr_point] > vector[x] )
@@ -2070,7 +2070,7 @@ gauss_component(CARD32 *src, CARD32 *dst, int radius, double* gauss, int len)
 {
 	int x, j, r = radius - 1;
 	for (x = 0 ; x < len ; x++) {
-		register double v = 0.0;
+		double v = 0.0;
 		for (j = x - r ; j <= 0 ; j++) v += src[0] * gauss[x - j];
 		for ( ; j < x ; j++) v += src[j] * gauss[x - j];
 		v += src[x] * gauss[0];
@@ -2205,10 +2205,10 @@ gauss_component_int2(CARD32 *s1, CARD32 *d1, CARD32 *s2, CARD32 *d2, int radius,
 	GAUSS_COEFF_TYPE g0 = gauss[0];
 	for( x = 0 ; x < radius ; ++x )
 	{
-		register CARD32 *xs1 = &s1[x];
-		register CARD32 *xs2 = &s2[x];
-		register CARD32 v1 = s1[x]*g0;
-		register CARD32 v2 = s2[x]*g0;
+		CARD32 *xs1 = &s1[x];
+		CARD32 *xs2 = &s2[x];
+		CARD32 v1 = s1[x]*g0;
+		CARD32 v2 = s2[x]*g0;
 		for( j = 1 ; j <= x ; ++j )
 			MIDDLE_STRETCH_GAUSS;
 		for( ; j < radius ; ++j ) 
@@ -2229,10 +2229,10 @@ gauss_component_int2(CARD32 *s1, CARD32 *d1, CARD32 *s2, CARD32 *d2, int radius,
 	}	
 	while( x <= len-radius )
 	{
-		register CARD32 *xs1 = &s1[x];
-		register CARD32 *xs2 = &s2[x];
-		register CARD32 v1 = s1[x]*g0;
-		register CARD32 v2 = s2[x]*g0;
+		CARD32 *xs1 = &s1[x];
+		CARD32 *xs2 = &s2[x];
+		CARD32 v1 = s1[x]*g0;
+		CARD32 v2 = s2[x]*g0;
 		for( j = 1 ; j < radius ; ++j ) 
 			MIDDLE_STRETCH_GAUSS;
 		d1[x] = v1 ;
@@ -2241,10 +2241,10 @@ gauss_component_int2(CARD32 *s1, CARD32 *d1, CARD32 *s2, CARD32 *d2, int radius,
 	}
 	while( --tail > 0 )/*x < len*/
 	{
-		register CARD32 *xs1 = &s1[x];
-		register CARD32 *xs2 = &s2[x];
-		register CARD32 v1 = xs1[0]*g0;
-		register CARD32 v2 = xs2[0]*g0;
+		CARD32 *xs1 = &s1[x];
+		CARD32 *xs2 = &s2[x];
+		CARD32 v1 = xs1[0]*g0;
+		CARD32 v2 = xs2[0]*g0;
 		for( j = 1 ; j < tail ; ++j ) 
 			MIDDLE_STRETCH_GAUSS;
 		for( ; j <radius ; ++j )
@@ -2456,7 +2456,7 @@ ASImage* blur_asimage_gauss(ASVisual* asv, ASImage* src, double dhorz, double dv
 		        		copy_component( lines[y]->channels[chan], res_chan, 0, width);
 					else
 					{	
-						register ASScanline **ysrc = &lines[y];
+						ASScanline **ysrc = &lines[y];
 						int j = 0;
 						GAUSS_COEFF_TYPE g = vert_gauss[0];
 						CARD32 *src_chan1 = ysrc[0]->channels[chan];
@@ -2498,7 +2498,7 @@ ASImage* blur_asimage_gauss(ASVisual* asv, ASImage* src, double dhorz, double dv
 		        		copy_component( lines[y]->channels[chan], res_chan, 0, result.width);
 					else
 					{	
-						register ASScanline **ysrc = &lines[y];
+						ASScanline **ysrc = &lines[y];
 /* surprisingly, having x loops inside y loop yields 30% to 80% better performance */
 						int j = 0;
 						CARD32 *src_chan1 = ysrc[0]->channels[chan];
@@ -2572,7 +2572,7 @@ ASImage* blur_asimage_gauss(ASVisual* asv, ASImage* src, double dhorz, double dv
 		        		copy_component( lines[y]->channels[chan], res_chan, 0, result.width);
 					else
 					{	
-						register ASScanline **ysrc = &lines[y];
+						ASScanline **ysrc = &lines[y];
 						int j = 0;
 						GAUSS_COEFF_TYPE g ;
 						CARD32 *src_chan1 = ysrc[0]->channels[chan];
@@ -2854,7 +2854,7 @@ LOCAL_DEBUG_OUT("adjusting actually...%s", "");
 		}
 		for( y = 0 ; y < max_y ; y++  )
 		{
-			register int x = imdec->buffer.width;
+			int x = imdec->buffer.width;
 			CARD32 *r = imdec->buffer.red;
 			CARD32 *g = imdec->buffer.green;
 			CARD32 *b = imdec->buffer.blue ;

--- a/graf2d/asimage/src/libAfterImage/ungif.c
+++ b/graf2d/asimage/src/libAfterImage/ungif.c
@@ -266,7 +266,7 @@ write_gif_saved_images( GifFileType *gif, SavedImage *images, unsigned int count
 
 	for( i = 0 ; i < count && status == GIF_OK; ++i )
 	{
-		register SavedImage	*sp = &images[i];
+		SavedImage	*sp = &images[i];
 		int		SavedHeight = sp->ImageDesc.Height;
 		int		SavedWidth = sp->ImageDesc.Width;
 		ExtensionBlock	*ep;

--- a/graf2d/asimage/src/libAfterImage/xcf.c
+++ b/graf2d/asimage/src/libAfterImage/xcf.c
@@ -146,7 +146,7 @@ read_xcf_image( FILE *fp )
 		{
 			if( prop->id == XCF_PROP_COLORMAP )
 			{
-				register int i ;
+				int i ;
 				CARD32 n = *((CARD32*)(prop->data)) ;
 				n = as_ntohl(n);
 				xcf_im->num_cols = n ;
@@ -182,7 +182,7 @@ read_xcf_image( FILE *fp )
 void
 print_xcf_properties( char* prompt, XcfProperty *prop )
 {
-	register int i = 0 ;
+	int i = 0 ;
 	while( prop )
 	{
 		fprintf( stderr, "%s.properties[%d] = %p\n", prompt, i, prop );
@@ -190,7 +190,7 @@ print_xcf_properties( char* prompt, XcfProperty *prop )
 		fprintf( stderr, "%s.properties[%d].size = %ld\n", prompt, i, (long)prop->len );
 		if( prop->len > 0 )
 		{
-			register unsigned int k ;
+			unsigned int k ;
 			fprintf( stderr, "%s.properties[%d].data = ", prompt, i );
 			for( k = 0 ; k < prop->len ; k++ )
 				fprintf( stderr, "%2.2X ", prop->data[k] );
@@ -235,7 +235,7 @@ print_xcf_hierarchy( char* prompt, XcfHierarchy *h )
 void
 print_xcf_channels( char* prompt, XcfChannel *head, Bool mask )
 {
-	register int i = 0 ;
+	int i = 0 ;
 	char p[256] ;
 	while( head )
 	{
@@ -263,7 +263,7 @@ print_xcf_channels( char* prompt, XcfChannel *head, Bool mask )
 void
 print_xcf_layers( char* prompt, XcfLayer *head )
 {
-	register int i = 0 ;
+	int i = 0 ;
 	char p[256] ;
 	while( head )
 	{
@@ -328,7 +328,7 @@ free_xcf_hierarchy( XcfHierarchy *hierarchy )
 {
 	if( hierarchy )
 	{
-		register XcfLevel *level = hierarchy->levels;
+		XcfLevel *level = hierarchy->levels;
 		while( level )
 		{
 			XcfLevel *next = level->next ;
@@ -723,7 +723,7 @@ read_xcf_tiles_rle( XcfImage *xcf_im, FILE *fp, XcfTile *head )
 static inline void
 store_colors( CARD8 *data, ASScanline *curr_buf, int bpp, int comp, int offset_x, int width )
 {
-	register int i ;
+	int i ;
 	CARD32   *out = NULL;
 	if( comp+1 < bpp || bpp == 3 )
 	{
@@ -780,7 +780,7 @@ decode_xcf_tile_rle( FILE *fp, XcfTile *tile, int bpp,
 		while ( y < height )
 		{
 			int len = *tile_buf ;
-			register int i ;
+			int i ;
 			++tile_buf;
 			--bytes_in;
 			if( len >= 128 )
@@ -845,7 +845,7 @@ Bool
 fix_xcf_image_line( ASScanline *buf, int bpp, unsigned int width, CARD8 *cmap,
 					CARD8 opacity, ARGB32 color )
 {
-	register unsigned int i ;
+	unsigned int i ;
 	Bool do_alpha = False ;
 	if( bpp == 1 )
 	{

--- a/graf2d/asimage/src/libAfterImage/ximage.c
+++ b/graf2d/asimage/src/libAfterImage/ximage.c
@@ -135,7 +135,7 @@ PRINT_BACKGROUND_OP_TIME;
 #endif
 			}else if( xim->depth == 8 )
 			{
-			    register int x = width;
+			    int x = width;
 			    while(--x >= 0 )
 	    		        xim_buf.blue[x] = (CARD32)(xim_line[x]);
 	    		    asimage_add_line (im, IC_RED,   xim_buf.red, i);
@@ -143,7 +143,7 @@ PRINT_BACKGROUND_OP_TIME;
 			    asimage_add_line (im, IC_BLUE,  xim_buf.red, i);
 			}else if( xim->depth == 1 )
 			{
-			    register int x = width;
+			    int x = width;
 			    while(--x >= 0 )
 			    {
 #ifndef X_DISPLAY_MISSING
@@ -169,7 +169,7 @@ PRINT_BACKGROUND_OP_TIME;
 
 		for (i = 0; i < height; i++)
 		{
-			register int x = width;
+			int x = width;
 			if( alpha_xim->depth == 8 )
 			{
 				while(--x >= 0 ) dst[x] = (CARD32)(xim_line[x]);
@@ -203,9 +203,9 @@ ximage2asimage (ASVisual *asv, XImage * xim, unsigned int compression)
 }
 
 static inline int
-xim_set_component( register CARD32 *src, register CARD32 value, int offset, int len )
+xim_set_component( CARD32 *src, CARD32 value, int offset, int len )
 {
-	register int i ;
+	int i ;
 	for( i = offset ; i < len ; ++i )
 		src[i] = value;
 	return len-offset;

--- a/graf2d/asimage/src/libAfterImage/xpm.c
+++ b/graf2d/asimage/src/libAfterImage/xpm.c
@@ -340,9 +340,9 @@ get_xpm_char( ASXpmFile *xpm_file )
 	{
 		if( xpm_file->bytes_in > AS_XPM_BUFFER_UNDO )
 		{
-			register char* src = &(xpm_file->buffer[xpm_file->bytes_in-AS_XPM_BUFFER_UNDO]);
-			register char* dst = &(xpm_file->buffer[0]);
-			register int i;
+			char* src = &(xpm_file->buffer[xpm_file->bytes_in-AS_XPM_BUFFER_UNDO]);
+			char* dst = &(xpm_file->buffer[0]);
+			int i;
 			for( i = 0 ; i < AS_XPM_BUFFER_UNDO ; i++ )
 				dst[i] = src[i];
 /*			xpm_file->bytes_in = AS_XPM_BUFFER_UNDO+fread( &(xpm_file->buffer[AS_XPM_BUFFER_UNDO]), 1, AS_XPM_BUFFER_SIZE, xpm_file->fp );*/
@@ -400,7 +400,7 @@ seek_next_xpm_string( ASXpmFile *xpm_file )
 {
 	while( xpm_file->parse_state == XPM_InImage )
 	{
-		register char c;
+		char c;
 		c = get_xpm_char(xpm_file);
 		if( c == '/')
 			skip_xpm_comments( xpm_file );
@@ -415,7 +415,7 @@ seek_next_xpm_image( ASXpmFile *xpm_file )
 {
 	while( xpm_file->parse_state == XPM_InFile )
 	{
-		register char c;
+		char c;
 		c = get_xpm_char(xpm_file);
 		if( c == '/')
 			skip_xpm_comments( xpm_file );
@@ -455,7 +455,7 @@ read_next_xpm_string( ASXpmFile *xpm_file )
 static Bool
 parse_xpm_cmap_entry( ASXpmFile *xpm_file, char **colornames )
 {
-	register char *ptr ;
+	char *ptr ;
 	int key ;
 	Bool success = False ;
 
@@ -522,7 +522,7 @@ close_xpm_file( ASXpmFile **xpm_file )
 				free( (*xpm_file)->cmap );
 			if( (*xpm_file)->cmap2 )
 			{
-				register int i ;
+				int i ;
 				for( i = 0 ; i < 256 ; i++ )
 					if( (*xpm_file)->cmap2[i] )
 						free( (*xpm_file)->cmap2[i] );
@@ -697,7 +697,7 @@ get_xpm_string( ASXpmFile *xpm_file )
 Bool
 parse_xpm_header( ASXpmFile *xpm_file )
 {
-	register char *ptr ;
+	char *ptr ;
 	if( xpm_file == NULL || xpm_file->str_buf == NULL )
 		return False;
 
@@ -739,7 +739,7 @@ static ARGB32
 lookup_xpm_color( char **colornames, ASHashTable *xpm_color_names )
 {
     ARGB32 color = 0;
-	register int key = 5 ;
+	int key = 5 ;
 	do
 	{
 		if( colornames[key] )
@@ -878,7 +878,7 @@ convert_xpm_scanline( ASXpmFile *xpm_file, unsigned int line )
 {
 	CARD32 *r = xpm_file->scl.red, *g = xpm_file->scl.green,
 		   *b = xpm_file->scl.blue,*a = (xpm_file->do_alpha)?xpm_file->scl.alpha:NULL ;
-	register int k = xpm_file->width ;
+	int k = xpm_file->width ;
 	ARGB32 *cmap = xpm_file->cmap ;
 #ifdef HAVE_LIBXPM
 	unsigned int *data = xpm_file->xpmImage.data+k*line ;
@@ -893,7 +893,7 @@ convert_xpm_scanline( ASXpmFile *xpm_file, unsigned int line )
 		while( --k >= 0 )
 			if( data[k] < xpm_file->cmap_size )
 			{
-				register CARD32 c = cmap[data[k]] ;
+				CARD32 c = cmap[data[k]] ;
 				r[k] = ARGB32_RED8(c);
 				g[k] = ARGB32_GREEN8(c);
 				b[k] = ARGB32_BLUE8(c);
@@ -908,7 +908,7 @@ convert_xpm_scanline( ASXpmFile *xpm_file, unsigned int line )
 			ARGB32 *slot = cmap2[data[k<<1]] ;
 			if( slot != NULL )
 			{
-				register CARD32 c = slot[data[(k<<1)+1]] ;
+				CARD32 c = slot[data[(k<<1)+1]] ;
 				r[k] = ARGB32_RED8(c);
 				g[k] = ARGB32_GREEN8(c);
 				b[k] = ARGB32_BLUE8(c);
@@ -924,7 +924,7 @@ convert_xpm_scanline( ASXpmFile *xpm_file, unsigned int line )
 		data += (k-1)*xpm_file->bpp ;
 		while( --k >= 0 )
 		{
-			register int i = xpm_file->bpp;
+			int i = xpm_file->bpp;
             ASHashData hdata = {0} ;
             CARD32 c = 0;
 			while( --i >= 0 )
@@ -964,7 +964,7 @@ build_xpm_charmap( ASColormap *cmap, Bool has_alpha, ASXpmCharmap *reusable_memo
 	ptr = xpm_cmap->char_code = safemalloc(xpm_cmap->count*(xpm_cmap->cpp+1)) ;
 	for( i = 0 ; i < (int)xpm_cmap->count ; i++ )
 	{
-		register int k = xpm_cmap->cpp ;
+		int k = xpm_cmap->cpp ;
 		rem = i ;
 		ptr[k] = '\0' ;
 		while( --k >= 0 )

--- a/graf2d/asimage/src/libAfterImage/zlib/crc32.c
+++ b/graf2d/asimage/src/libAfterImage/zlib/crc32.c
@@ -4,7 +4,7 @@
  *
  * Thanks to Rodney Brown <rbrown64@csc.com.au> for his contribution of faster
  * CRC methods: exclusive-oring 32 bits of data at a time, and pre-computing
- * tables for updating the shift register in one step with three exclusive-ors
+ * tables for updating the shift in one step with three exclusive-ors
  * instead of four steps with four exclusive-ors.  This results in about a
  * factor of two increase in speed on a Power PC G4 (PPC7455) using gcc -O3.
  */
@@ -89,17 +89,17 @@ local void make_crc_table OF((void));
   byte 0xb1 is the polynomial x^7+x^3+x+1), then the CRC is (q*x^32) mod p,
   where a mod b means the remainder after dividing a by b.
 
-  This calculation is done using the shift-register method of multiplying and
-  taking the remainder.  The register is initialized to zero, and for each
-  incoming bit, x^32 is added mod p to the register if the bit is a one (where
-  x^32 mod p is p+x^32 = x^26+...+1), and the register is multiplied mod p by
+  This calculation is done using the shift-method of multiplying and
+  taking the remainder.  The is initialized to zero, and for each
+  incoming bit, x^32 is added mod p to the if the bit is a one (where
+  x^32 mod p is p+x^32 = x^26+...+1), and the is multiplied mod p by
   x (which is shifting right by one and adding x^32 mod p if the bit shifted
   out is a one).  We start with the highest power (least significant bit) of
   q and repeat for all eight bits of q.
 
   The first table is simply the CRC of all possible eight bit values.  This is
   all the information needed to generate CRCs on data a byte at a time for all
-  combinations of CRC register values and incoming bytes.  The remaining tables
+  combinations of CRC values and incoming bytes.  The remaining tables
   allow for word-at-a-time CRC calculation for both big-endian and little-
   endian machines, where a word is four bytes.
 */
@@ -264,8 +264,8 @@ local unsigned long crc32_little(crc, buf, len)
     const unsigned char FAR *buf;
     unsigned len;
 {
-    register u4 c;
-    register const u4 FAR *buf4;
+    u4 c;
+    const u4 FAR *buf4;
 
     c = (u4)crc;
     c = ~c;
@@ -304,8 +304,8 @@ local unsigned long crc32_big(crc, buf, len)
     const unsigned char FAR *buf;
     unsigned len;
 {
-    register u4 c;
-    register const u4 FAR *buf4;
+    u4 c;
+    const u4 FAR *buf4;
 
     c = REV((u4)crc);
     c = ~c;

--- a/graf2d/asimage/src/libAfterImage/zlib/deflate.c
+++ b/graf2d/asimage/src/libAfterImage/zlib/deflate.c
@@ -1029,9 +1029,9 @@ local uInt longest_match(s, cur_match)
     IPos cur_match;                             /* current match */
 {
     unsigned chain_length = s->max_chain_length;/* max hash chain length */
-    register Bytef *scan = s->window + s->strstart; /* current string */
-    register Bytef *match;                       /* matched string */
-    register int len;                           /* length of current match */
+    Bytef *scan = s->window + s->strstart; /* current string */
+    Bytef *match;                       /* matched string */
+    int len;                           /* length of current match */
     int best_len = s->prev_length;              /* best match length so far */
     int nice_match = s->nice_match;             /* stop if match long enough */
     IPos limit = s->strstart > (IPos)MAX_DIST(s) ?
@@ -1046,13 +1046,13 @@ local uInt longest_match(s, cur_match)
     /* Compare two bytes at a time. Note: this is not always beneficial.
      * Try with and without -DUNALIGNED_OK to check.
      */
-    register Bytef *strend = s->window + s->strstart + MAX_MATCH - 1;
-    register ush scan_start = *(ushf*)scan;
-    register ush scan_end   = *(ushf*)(scan+best_len-1);
+    Bytef *strend = s->window + s->strstart + MAX_MATCH - 1;
+    ush scan_start = *(ushf*)scan;
+    ush scan_end   = *(ushf*)(scan+best_len-1);
 #else
-    register Bytef *strend = s->window + s->strstart + MAX_MATCH;
-    register Byte scan_end1  = scan[best_len-1];
-    register Byte scan_end   = scan[best_len];
+    Bytef *strend = s->window + s->strstart + MAX_MATCH;
+    Byte scan_end1  = scan[best_len-1];
+    Byte scan_end   = scan[best_len];
 #endif
 
     /* The code is optimized for HASH_BITS >= 8 and MAX_MATCH-2 multiple of 16.
@@ -1176,10 +1176,10 @@ local uInt longest_match_fast(s, cur_match)
     deflate_state *s;
     IPos cur_match;                             /* current match */
 {
-    register Bytef *scan = s->window + s->strstart; /* current string */
-    register Bytef *match;                       /* matched string */
-    register int len;                           /* length of current match */
-    register Bytef *strend = s->window + s->strstart + MAX_MATCH;
+    Bytef *scan = s->window + s->strstart; /* current string */
+    Bytef *match;                       /* matched string */
+    int len;                           /* length of current match */
+    Bytef *strend = s->window + s->strstart + MAX_MATCH;
 
     /* The code is optimized for HASH_BITS >= 8 and MAX_MATCH-2 multiple of 16.
      * It is easy to get rid of this optimization if necessary.
@@ -1266,8 +1266,8 @@ local void check_match(s, start, match, length)
 local void fill_window(s)
     deflate_state *s;
 {
-    register unsigned n, m;
-    register Posf *p;
+    unsigned n, m;
+    Posf *p;
     unsigned more;    /* Amount of free space at the end of the window. */
     uInt wsize = s->w_size;
 

--- a/graf2d/asimage/src/libAfterImage/zlib/trees.c
+++ b/graf2d/asimage/src/libAfterImage/zlib/trees.c
@@ -1147,7 +1147,7 @@ local unsigned bi_reverse(code, len)
     unsigned code; /* the value to invert */
     int len;       /* its bit length */
 {
-    register unsigned res = 0;
+    unsigned res = 0;
     do {
         res |= code & 1;
         code >>= 1, res <<= 1;


### PR DESCRIPTION
Fix for these warnings: http://cdash.cern.ch/viewBuildError.php?type=1&buildid=454389. No functional change otherwise.

I still need to test that with external libAfterImage this is not a problem, so please let me merge this myself.