### PR TITLE
Move C headers in extern C context.

### DIFF
--- a/graf2d/asimage/src/TASImage.cxx
+++ b/graf2d/asimage/src/TASImage.cxx
@@ -104,9 +104,9 @@ ROOT tutorials: `$ROOTSYS/tutorials/image/`
 #   include <win32/afterbase.h>
 #   define X_DISPLAY_MISSING 1
 #endif
+extern "C" {
 #   include <afterimage.h>
 #   include <bmp.h>
-extern "C" {
 #   include <draw.h>
 }
 

--- a/graf2d/asimage/src/TASPaletteEditor.cxx
+++ b/graf2d/asimage/src/TASPaletteEditor.cxx
@@ -46,8 +46,8 @@ It is called by a pull down menu item of TASImage.
 #   include <win32/config.h>
 #   include <win32/afterbase.h>
 #endif
-#   include <afterimage.h>
 extern "C" {
+#   include <afterimage.h>
 #   include <bmp.h>
 }
 

--- a/tmva/pymva/src/MethodPyAdaBoost.cxx
+++ b/tmva/pymva/src/MethodPyAdaBoost.cxx
@@ -17,7 +17,9 @@
  *                                                                                *
  **********************************************************************************/
 
-#include <Python.h> // Needs to be included first to avoid redefinition of _POSIX_C_SOURCE
+extern "C" {
+   #include <Python.h> // Needs to be included first to avoid redefinition of _POSIX_C_SOURCE
+}
 #include "TMVA/MethodPyAdaBoost.h"
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION

--- a/tmva/pymva/src/MethodPyGTB.cxx
+++ b/tmva/pymva/src/MethodPyGTB.cxx
@@ -17,7 +17,9 @@
  *                                                                                *
  **********************************************************************************/
 
-#include <Python.h>    // Needs to be included first to avoid redefinition of _POSIX_C_SOURCE
+extern "C" {
+   #include <Python.h>    // Needs to be included first to avoid redefinition of _POSIX_C_SOURCE
+}
 #include "TMVA/MethodPyGTB.h"
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION

--- a/tmva/pymva/src/MethodPyKeras.cxx
+++ b/tmva/pymva/src/MethodPyKeras.cxx
@@ -1,7 +1,9 @@
 // @(#)root/tmva/pymva $Id$
 // Author: Stefan Wunsch, 2016
 
-#include <Python.h>
+extern "C" {
+   #include <Python.h>
+}
 #include "TMVA/MethodPyKeras.h"
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION

--- a/tmva/pymva/src/MethodPyRandomForest.cxx
+++ b/tmva/pymva/src/MethodPyRandomForest.cxx
@@ -16,7 +16,9 @@
  * (http://tmva.sourceforge.net/LICENSE)                                          *
  *                                                                                *
  **********************************************************************************/
-#include <Python.h>    // Needs to be included first to avoid redefinition of _POSIX_C_SOURCE
+extern "C" {
+   #include <Python.h>    // Needs to be included first to avoid redefinition of _POSIX_C_SOURCE
+}
 #include "TMVA/MethodPyRandomForest.h"
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION

--- a/tmva/pymva/src/PyMethodBase.cxx
+++ b/tmva/pymva/src/PyMethodBase.cxx
@@ -11,7 +11,9 @@
  *                                                                                *
  **********************************************************************************/
 
-#include <Python.h> // Needs to be included first to avoid redefinition of _POSIX_C_SOURCE
+extern "C" {
+   #include <Python.h> // Needs to be included first to avoid redefinition of _POSIX_C_SOURCE
+}
 #include <TMVA/PyMethodBase.h>
 
 #include "TMVA/DataSet.h"


### PR DESCRIPTION
This fixes a few 'deprecated register' warnings.