### PR TITLE
TMVA TestCrossValidationSerialise memory handling

### DIFF
--- a/tmva/tmva/src/CrossValidation.cxx
+++ b/tmva/tmva/src/CrossValidation.cxx
@@ -409,8 +409,6 @@ void TMVA::CrossValidation::ProcessFold(UInt_t iFold, UInt_t iMethod)
    // Clean-up for this fold
    {
       smethod->Data()->DeleteResults(foldTitle, Types::kTraining, smethod->GetAnalysisType());
-   }
-   if (fFoldFileOutput) {
       smethod->Data()->DeleteResults(foldTitle, Types::kTesting, smethod->GetAnalysisType());
    }
    fFoldFactory->DeleteAllMethods();


### PR DESCRIPTION
The newly integrated cross validation has suffered two seemingly random failures. Reported [here](https://epsft-jenkins.cern.ch/job/root-pullrequests-build/15871/testReport/projectroot.tmva.tmva.test/crossvalidation/TMVA_CrossValidation_Serialise/) and [here](https://epsft-jenkins.cern.ch/job/root-incremental-master-noimt/BUILDTYPE=Debug,COMPILER=gcc49,LABEL=centos7/1803/testReport/projectroot.tmva.tmva.test/crossvalidation/TMVA_CrossValidation_Serialise/).

The root cause is still not properly understood, but this patch addresses two issues discovered by valgrind and which may be related.