### PR TITLE
[TDF] Fix/rephrase documentation for the parameters of the Range action

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -749,24 +749,24 @@ public:
    }
 
    ////////////////////////////////////////////////////////////////////////////
-   /// \brief Creates a node that filters entries based on range: [start, stop)
+   /// \brief Creates a node that filters entries based on range: [begin, end)
    /// \param[in] begin Initial entry number considered for this range.
    /// \param[in] end Final entry number (excluded) considered for this range. 0 means that the range goes until the end of the dataset.
    /// \param[in] stride Process one entry of the [begin, end) range every `stride` entries. Must be strictly greater than 0.
    ///
    /// Note that in case of previous Ranges and Filters the selected range refers to the transformed dataset.
    /// Ranges are only available if EnableImplicitMT has _not_ been called. Multi-thread ranges are not supported.
-   TInterface<TDFDetail::TRange<Proxied>> Range(unsigned int start, unsigned int stop, unsigned int stride = 1)
+   TInterface<TDFDetail::TRange<Proxied>> Range(unsigned int begin, unsigned int end, unsigned int stride = 1)
    {
       // check invariants
-      if (stride == 0 || (stop != 0 && stop < start))
-         throw std::runtime_error("Range: stride must be strictly greater than 0 and stop must be greater than start.");
+      if (stride == 0 || (end != 0 && end < begin))
+         throw std::runtime_error("Range: stride must be strictly greater than 0 and end must be greater than begin.");
       if (ROOT::IsImplicitMTEnabled())
          throw std::runtime_error("Range was called with ImplicitMT enabled. Multi-thread ranges are not supported.");
 
       auto df = GetDataFrameChecked();
       using Range_t = TDFDetail::TRange<Proxied>;
-      auto RangePtr = std::make_shared<Range_t>(start, stop, stride, *fProxiedPtr);
+      auto RangePtr = std::make_shared<Range_t>(begin, end, stride, *fProxiedPtr);
       df->Book(RangePtr);
       TInterface<TDFDetail::TRange<Proxied>> tdf_r(RangePtr, fImplWeakPtr, fValidCustomColumns, fDataSource);
       return tdf_r;
@@ -774,10 +774,10 @@ public:
 
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Creates a node that filters entries based on range
-   /// \param[in] stop Total number of entries that will be processed before stopping. 0 means "never stop".
+   /// \param[in] end Final entry number (excluded) considered for this range. 0 means that the range goes until the end of the dataset.
    ///
    /// See the other Range overload for a detailed description.
-   TInterface<TDFDetail::TRange<Proxied>> Range(unsigned int stop) { return Range(0, stop, 1); }
+   TInterface<TDFDetail::TRange<Proxied>> Range(unsigned int end) { return Range(0, end, 1); }
 
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Execute a user-defined function on each entry (*instant action*)

--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -749,11 +749,12 @@ public:
    }
 
    ////////////////////////////////////////////////////////////////////////////
-   /// \brief Creates a node that filters entries based on range
-   /// \param[in] start How many entries to discard before resuming processing.
-   /// \param[in] stop Total number of entries that will be processed before stopping. 0 means "never stop".
-   /// \param[in] stride Process one entry every `stride` entries. Must be strictly greater than 0.
+   /// \brief Creates a node that filters entries based on range: [start, stop)
+   /// \param[in] begin Initial entry number considered for this range.
+   /// \param[in] end Final entry number (excluded) considered for this range. 0 means that the range goes until the end of the dataset.
+   /// \param[in] stride Process one entry of the [begin, end) range every `stride` entries. Must be strictly greater than 0.
    ///
+   /// Note that in case of previous Ranges and Filters the selected range refers to the transformed dataset.
    /// Ranges are only available if EnableImplicitMT has _not_ been called. Multi-thread ranges are not supported.
    TInterface<TDFDetail::TRange<Proxied>> Range(unsigned int start, unsigned int stop, unsigned int stride = 1)
    {

--- a/tree/treeplayer/src/TDataFrame.cxx
+++ b/tree/treeplayer/src/TDataFrame.cxx
@@ -536,21 +536,21 @@ once, a run is triggered.
 ### <a name="ranges"></a>Ranges
 When `TDataFrame` is not being used in a multi-thread environment (i.e. no call to `EnableImplicitMT` was made),
 `Range` transformations are available. These act very much like filters but instead of basing their decision on
-a filter expression, they rely on `start`,`stop` and `stride` parameters.
+a filter expression, they rely on `begin`,`end` and `stride` parameters.
 
-- `start`: number of entries that will be skipped before starting processing again
-- `stop`: maximum number of entries that will be processed
-- `stride`: only process one entry every `stride` entries
+- `begin`: initial entry number considered for this range.
+- `end`: final entry number (excluded) considered for this range. 0 means that the range goes until the end of the dataset.
+- `stride`: process one entry of the [begin, end) range every `stride` entries. Must be strictly greater than 0.
 
-The actual number of entries processed downstream of a `Range` node will be `(stop - start)/stride` (or less if less
+The actual number of entries processed downstream of a `Range` node will be `(end - begin)/stride` (or less if less
 entries than that are available).
 
 Note that ranges act "locally", not based on the global entry count: `Range(10,50)` means "skip the first 10 entries
 *that reach this node*, let the next 40 entries pass, then stop processing". If a range node hangs from a filter node,
-and the range has a `start` parameter of 10, that means the range will skip the first 10 entries *that pass the
+and the range has a `begin` parameter of 10, that means the range will skip the first 10 entries *that pass the
 preceding filter*.
 
-Ranges allow "early quitting": if all branches of execution of a functional graph reached their `stop` value of
+Ranges allow "early quitting": if all branches of execution of a functional graph reached their `end` value of
 processed entries, the event-loop is immediately interrupted. This is useful for debugging and quick data explorations.
 
 ### <a name="custom-columns"></a> Custom columns


### PR DESCRIPTION
This PR proposes a rephrasing of the documentation for the parameters of the Range action.

The current documentation for the `stop` parameter of the `Range` action in TDataFrame says: "Total number of entries that will be processed before stopping". Nevertheless, the behaviour of TDataFrame when setting a Range seems to indicate that the `stop` parameter is actually the first entry index that will not be processed.

Indeed, if we consider the following code:
```python
import ROOT
fileName = "https://root.cern/files/teaching/CMS_Open_Dataset.root"
tdf_orig = ROOT.ROOT.Experimental.TDataFrame("data", fileName)
tdf = tdf_orig.Range(10, 12)

pt1_h = tdf.Histo1D("pt1")

print("Histo 1: " + str(pt1_h.GetEntries()))
```
The result is:
```
Histo 1: 2.0
```
and not 12 as one could interpret from the current documentation.