### PR TITLE
ROOT-9237: Prevent different output in absence of OpenGL

### DIFF
--- a/bindings/pyroot/JupyROOT/cppcompleter.py
+++ b/bindings/pyroot/JupyROOT/cppcompleter.py
@@ -54,18 +54,13 @@ class CppCompleter(object):
     TH1I
     TH1K
     TH1S
-    >>> for suggestion in comp._completeImpl("TH2"):
+    >>> for suggestion in comp._completeImpl("TProfile"):
     ...     print(suggestion)
-    TH2
-    TH2C
-    TH2D
-    TH2Editor
-    TH2F
-    TH2GL
-    TH2I
-    TH2Poly
-    TH2PolyBin
-    TH2S
+    TProfile
+    TProfile2D
+    TProfile2Poly
+    TProfile2PolyBin
+    TProfile3D
     >>> garbage = ROOT.gInterpreter.ProcessLine("TH1F* h")
     >>> for suggestion in comp._completeImpl("h->GetA"):
     ...     print(suggestion)


### PR DESCRIPTION
Prevent roottest_python_JupyROOT_cppcompleter_doctest from failing when OpenGL is disabled. 

Suggestions for TProfile should be constant in all builds and they will serve the same purpose: test the tab completion mechanism.