### PR TITLE
Random improvements found (mainly) by clang-tidy

### DIFF
--- a/core/base/inc/TApplication.h
+++ b/core/base/inc/TApplication.h
@@ -84,7 +84,7 @@ protected:
 
    TApplication();
 
-   virtual Long_t     ProcessRemote(const char *line, Int_t *error = 0);
+   virtual Long_t     ProcessRemote(const char *line, Int_t *error = nullptr);
    virtual void       Help(const char *line);
    virtual void       LoadGraphicsLibs();
    virtual void       MakeBatch();
@@ -98,7 +98,7 @@ protected:
 
 public:
    TApplication(const char *appClassName, Int_t *argc, char **argv,
-                void *options = 0, Int_t numOptions = 0);
+                void *options = nullptr, Int_t numOptions = 0);
    virtual ~TApplication();
 
    void            InitializeGraphics();
@@ -110,8 +110,8 @@ public:
    virtual void    HandleIdleTimer();   //*SIGNAL*
    virtual Bool_t  HandleTermInput() { return kFALSE; }
    virtual void    Init() { fAppImp->Init(); }
-   virtual Long_t  ProcessLine(const char *line, Bool_t sync = kFALSE, Int_t *error = 0);
-   virtual Long_t  ProcessFile(const char *file, Int_t *error = 0, Bool_t keep = kFALSE);
+   virtual Long_t  ProcessLine(const char *line, Bool_t sync = kFALSE, Int_t *error = nullptr);
+   virtual Long_t  ProcessFile(const char *file, Int_t *error = nullptr, Bool_t keep = kFALSE);
    virtual void    Run(Bool_t retrn = kFALSE);
    virtual void    SetIdleTimer(UInt_t idleTimeInSec, const char *command);
    virtual void    RemoveIdleTimer();
@@ -154,7 +154,7 @@ public:
    virtual void    ReturnPressed(char *text );        //*SIGNAL*
    virtual Int_t   TabCompletionHook(char *buf, int *pLoc, std::ostream& out);
 
-   static Long_t   ExecuteFile(const char *file, Int_t *error = 0, Bool_t keep = kFALSE);
+   static Long_t   ExecuteFile(const char *file, Int_t *error = nullptr, Bool_t keep = kFALSE);
    static TList   *GetApplications();
    static void     CreateApplication();
    static void     NeedGraphicsLibs();

--- a/core/base/inc/TBuffer.h
+++ b/core/base/inc/TBuffer.h
@@ -53,8 +53,8 @@ protected:
    CacheList_t      fCacheStack;    //Stack of pointers to the cache where to temporarily store the value of 'missing' data members
 
    // Default ctor
-   TBuffer() : TObject(), fMode(0), fVersion(0), fBufSize(0), fBuffer(0),
-     fBufCur(0), fBufMax(0), fParent(0), fReAllocFunc(0), fCacheStack(0,(TVirtualArray*)0) {}
+   TBuffer() : TObject(), fMode(0), fVersion(0), fBufSize(0), fBuffer(nullptr),
+     fBufCur(nullptr), fBufMax(nullptr), fParent(nullptr), fReAllocFunc(nullptr), fCacheStack(0,(TVirtualArray*)nullptr) {}
 
    // TBuffer objects cannot be copied or assigned
    TBuffer(const TBuffer &);           // not implemented
@@ -76,7 +76,7 @@ public:
 
    TBuffer(EMode mode);
    TBuffer(EMode mode, Int_t bufsiz);
-   TBuffer(EMode mode, Int_t bufsiz, void *buf, Bool_t adopt = kTRUE, ReAllocCharFun_t reallocfunc = 0);
+   TBuffer(EMode mode, Int_t bufsiz, void *buf, Bool_t adopt = kTRUE, ReAllocCharFun_t reallocfunc = nullptr);
    virtual ~TBuffer();
 
    Int_t    GetBufferVersion() const { return fVersion; }
@@ -84,15 +84,15 @@ public:
    Bool_t   IsWriting() const { return (fMode & kWrite) != 0; }
    void     SetReadMode();
    void     SetWriteMode();
-   void     SetBuffer(void *buf, UInt_t bufsiz = 0, Bool_t adopt = kTRUE, ReAllocCharFun_t reallocfunc = 0);
+   void     SetBuffer(void *buf, UInt_t bufsiz = 0, Bool_t adopt = kTRUE, ReAllocCharFun_t reallocfunc = nullptr);
    ReAllocCharFun_t GetReAllocFunc() const;
-   void     SetReAllocFunc(ReAllocCharFun_t reallocfunc = 0);
+   void     SetReAllocFunc(ReAllocCharFun_t reallocfunc = nullptr);
    void     SetBufferOffset(Int_t offset = 0) { fBufCur = fBuffer+offset; }
    void     SetParent(TObject *parent);
    TObject *GetParent()  const;
    char    *Buffer()     const { return fBuffer; }
    Int_t    BufferSize() const { return fBufSize; }
-   void     DetachBuffer() { fBuffer = 0; }
+   void     DetachBuffer() { fBuffer = nullptr; }
    Int_t    Length()     const { return (Int_t)(fBufCur - fBuffer); }
    void     Expand(Int_t newsize, Bool_t copy = kTRUE);  // expand buffer to newsize
    void     AutoExpand(Int_t size_needed);  // expand buffer to newsize
@@ -121,10 +121,10 @@ public:
    virtual Int_t      CheckByteCount(UInt_t startpos, UInt_t bcnt, const char *classname) = 0;
    virtual void       SetByteCount(UInt_t cntpos, Bool_t packInVersion = kFALSE)= 0;
 
-   virtual void       SkipVersion(const TClass *cl = 0) = 0;
-   virtual Version_t  ReadVersion(UInt_t *start = 0, UInt_t *bcnt = 0, const TClass *cl = 0) = 0;
-   virtual Version_t  ReadVersionNoCheckSum(UInt_t *start = 0, UInt_t *bcnt = 0) = 0;
-   virtual Version_t  ReadVersionForMemberWise(const TClass *cl = 0) = 0;
+   virtual void       SkipVersion(const TClass *cl = nullptr) = 0;
+   virtual Version_t  ReadVersion(UInt_t *start = nullptr, UInt_t *bcnt = nullptr, const TClass *cl = nullptr) = 0;
+   virtual Version_t  ReadVersionNoCheckSum(UInt_t *start = nullptr, UInt_t *bcnt = nullptr) = 0;
+   virtual Version_t  ReadVersionForMemberWise(const TClass *cl = nullptr) = 0;
    virtual UInt_t     WriteVersion(const TClass *cl, Bool_t useBcnt = kFALSE) = 0;
    virtual UInt_t     WriteVersionMemberWise(const TClass *cl, Bool_t useBcnt = kFALSE) = 0;
 
@@ -138,14 +138,14 @@ public:
 
    virtual void       ClassBegin(const TClass*, Version_t = -1) = 0;
    virtual void       ClassEnd(const TClass*) = 0;
-   virtual void       ClassMember(const char*, const char* = 0, Int_t = -1, Int_t = -1) = 0;
+   virtual void       ClassMember(const char*, const char* = nullptr, Int_t = -1, Int_t = -1) = 0;
    virtual TVirtualStreamerInfo *GetInfo() = 0;
 
    virtual TVirtualArray *PeekDataCache() const;
    virtual TVirtualArray *PopDataCache();
    virtual void           PushDataCache(TVirtualArray *);
 
-   virtual TClass    *ReadClass(const TClass *cl = 0, UInt_t *objTag = 0) = 0;
+   virtual TClass    *ReadClass(const TClass *cl = nullptr, UInt_t *objTag = nullptr) = 0;
    virtual void       WriteClass(const TClass *cl) = 0;
 
    virtual TObject   *ReadObject(const TClass *cl) = 0;
@@ -162,10 +162,10 @@ public:
    virtual void       SetBufferDisplacement(Int_t skipped) = 0;
 
    // basic types and arrays of basic types
-   virtual   void     ReadFloat16 (Float_t *f, TStreamerElement *ele=0) = 0;
-   virtual   void     WriteFloat16(Float_t *f, TStreamerElement *ele=0) = 0;
-   virtual   void     ReadDouble32 (Double_t *d, TStreamerElement *ele=0) = 0;
-   virtual   void     WriteDouble32(Double_t *d, TStreamerElement *ele=0) = 0;
+   virtual   void     ReadFloat16 (Float_t *f, TStreamerElement *ele=nullptr) = 0;
+   virtual   void     WriteFloat16(Float_t *f, TStreamerElement *ele=nullptr) = 0;
+   virtual   void     ReadDouble32 (Double_t *d, TStreamerElement *ele=nullptr) = 0;
+   virtual   void     WriteDouble32(Double_t *d, TStreamerElement *ele=nullptr) = 0;
    virtual   void     ReadWithFactor(Float_t *ptr, Double_t factor, Double_t minvalue) = 0;
    virtual   void     ReadWithNbits(Float_t *ptr, Int_t nbits) = 0;
    virtual   void     ReadWithFactor(Double_t *ptr, Double_t factor, Double_t minvalue) = 0;
@@ -184,8 +184,8 @@ public:
    virtual   Int_t    ReadArray(ULong64_t *&l) = 0;
    virtual   Int_t    ReadArray(Float_t   *&f) = 0;
    virtual   Int_t    ReadArray(Double_t  *&d) = 0;
-   virtual   Int_t    ReadArrayFloat16(Float_t *&f, TStreamerElement *ele=0) = 0;
-   virtual   Int_t    ReadArrayDouble32(Double_t *&d, TStreamerElement *ele=0) = 0;
+   virtual   Int_t    ReadArrayFloat16(Float_t *&f, TStreamerElement *ele=nullptr) = 0;
+   virtual   Int_t    ReadArrayDouble32(Double_t *&d, TStreamerElement *ele=nullptr) = 0;
 
    virtual   Int_t    ReadStaticArray(Bool_t    *b) = 0;
    virtual   Int_t    ReadStaticArray(Char_t    *c) = 0;
@@ -200,8 +200,8 @@ public:
    virtual   Int_t    ReadStaticArray(ULong64_t *l) = 0;
    virtual   Int_t    ReadStaticArray(Float_t   *f) = 0;
    virtual   Int_t    ReadStaticArray(Double_t  *d) = 0;
-   virtual   Int_t    ReadStaticArrayFloat16(Float_t  *f, TStreamerElement *ele=0) = 0;
-   virtual   Int_t    ReadStaticArrayDouble32(Double_t  *d, TStreamerElement *ele=0) = 0;
+   virtual   Int_t    ReadStaticArrayFloat16(Float_t  *f, TStreamerElement *ele=nullptr) = 0;
+   virtual   Int_t    ReadStaticArrayDouble32(Double_t  *d, TStreamerElement *ele=nullptr) = 0;
 
    virtual   void     ReadFastArray(Bool_t    *b, Int_t n) = 0;
    virtual   void     ReadFastArray(Char_t    *c, Int_t n) = 0;
@@ -217,14 +217,14 @@ public:
    virtual   void     ReadFastArray(ULong64_t *l, Int_t n) = 0;
    virtual   void     ReadFastArray(Float_t   *f, Int_t n) = 0;
    virtual   void     ReadFastArray(Double_t  *d, Int_t n) = 0;
-   virtual   void     ReadFastArrayFloat16(Float_t  *f, Int_t n, TStreamerElement *ele=0) = 0;
-   virtual   void     ReadFastArrayDouble32(Double_t  *d, Int_t n, TStreamerElement *ele=0) = 0;
+   virtual   void     ReadFastArrayFloat16(Float_t  *f, Int_t n, TStreamerElement *ele=nullptr) = 0;
+   virtual   void     ReadFastArrayDouble32(Double_t  *d, Int_t n, TStreamerElement *ele=nullptr) = 0;
    virtual   void     ReadFastArrayWithFactor(Float_t *ptr, Int_t n, Double_t factor, Double_t minvalue) = 0;
    virtual   void     ReadFastArrayWithNbits(Float_t *ptr, Int_t n, Int_t nbits) = 0;
    virtual   void     ReadFastArrayWithFactor(Double_t *ptr, Int_t n, Double_t factor, Double_t minvalue) = 0;
    virtual   void     ReadFastArrayWithNbits(Double_t *ptr, Int_t n, Int_t nbits) = 0;
-   virtual   void     ReadFastArray(void  *start , const TClass *cl, Int_t n=1, TMemberStreamer *s=0, const TClass *onFileClass=0) = 0;
-   virtual   void     ReadFastArray(void **startp, const TClass *cl, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s=0, const TClass *onFileClass=0) = 0;
+   virtual   void     ReadFastArray(void  *start , const TClass *cl, Int_t n=1, TMemberStreamer *s=nullptr, const TClass *onFileClass=nullptr) = 0;
+   virtual   void     ReadFastArray(void **startp, const TClass *cl, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s=nullptr, const TClass *onFileClass=nullptr) = 0;
 
    virtual   void     WriteArray(const Bool_t    *b, Int_t n) = 0;
    virtual   void     WriteArray(const Char_t    *c, Int_t n) = 0;
@@ -239,8 +239,8 @@ public:
    virtual   void     WriteArray(const ULong64_t *l, Int_t n) = 0;
    virtual   void     WriteArray(const Float_t   *f, Int_t n) = 0;
    virtual   void     WriteArray(const Double_t  *d, Int_t n) = 0;
-   virtual   void     WriteArrayFloat16(const Float_t  *f, Int_t n, TStreamerElement *ele=0) = 0;
-   virtual   void     WriteArrayDouble32(const Double_t  *d, Int_t n, TStreamerElement *ele=0) = 0;
+   virtual   void     WriteArrayFloat16(const Float_t  *f, Int_t n, TStreamerElement *ele=nullptr) = 0;
+   virtual   void     WriteArrayDouble32(const Double_t  *d, Int_t n, TStreamerElement *ele=nullptr) = 0;
 
    virtual   void     WriteFastArray(const Bool_t    *b, Int_t n) = 0;
    virtual   void     WriteFastArray(const Char_t    *c, Int_t n) = 0;
@@ -256,14 +256,14 @@ public:
    virtual   void     WriteFastArray(const ULong64_t *l, Int_t n) = 0;
    virtual   void     WriteFastArray(const Float_t   *f, Int_t n) = 0;
    virtual   void     WriteFastArray(const Double_t  *d, Int_t n) = 0;
-   virtual   void     WriteFastArrayFloat16(const Float_t  *f, Int_t n, TStreamerElement *ele=0) = 0;
-   virtual   void     WriteFastArrayDouble32(const Double_t  *d, Int_t n, TStreamerElement *ele=0) = 0;
-   virtual   void     WriteFastArray(void  *start,  const TClass *cl, Int_t n=1, TMemberStreamer *s=0) = 0;
-   virtual   Int_t    WriteFastArray(void **startp, const TClass *cl, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s=0) = 0;
+   virtual   void     WriteFastArrayFloat16(const Float_t  *f, Int_t n, TStreamerElement *ele=nullptr) = 0;
+   virtual   void     WriteFastArrayDouble32(const Double_t  *d, Int_t n, TStreamerElement *ele=nullptr) = 0;
+   virtual   void     WriteFastArray(void  *start,  const TClass *cl, Int_t n=1, TMemberStreamer *s=nullptr) = 0;
+   virtual   Int_t    WriteFastArray(void **startp, const TClass *cl, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s=nullptr) = 0;
 
-   virtual   void     StreamObject(void *obj, const std::type_info &typeinfo, const TClass* onFileClass = 0 ) = 0;
-   virtual   void     StreamObject(void *obj, const char *className, const TClass* onFileClass = 0 ) = 0;
-   virtual   void     StreamObject(void *obj, const TClass *cl, const TClass* onFileClass = 0 ) = 0;
+   virtual   void     StreamObject(void *obj, const std::type_info &typeinfo, const TClass* onFileClass = nullptr ) = 0;
+   virtual   void     StreamObject(void *obj, const char *className, const TClass* onFileClass = nullptr ) = 0;
+   virtual   void     StreamObject(void *obj, const TClass *cl, const TClass* onFileClass = nullptr ) = 0;
    virtual   void     StreamObject(TObject *obj) = 0;
 
    virtual   void     ReadBool(Bool_t       &b) = 0;
@@ -319,9 +319,9 @@ public:
    virtual   Int_t    WriteClones(TClonesArray *a, Int_t nobjects) = 0;
 
    // Utilities for TClass
-   virtual   Int_t    ReadClassEmulated(const TClass *cl, void *object, const TClass *onfile_class = 0) = 0;
-   virtual   Int_t    ReadClassBuffer(const TClass *cl, void *pointer, const TClass *onfile_class = 0) = 0;
-   virtual   Int_t    ReadClassBuffer(const TClass *cl, void *pointer, Int_t version, UInt_t start, UInt_t count, const TClass *onfile_class = 0) = 0;
+   virtual   Int_t    ReadClassEmulated(const TClass *cl, void *object, const TClass *onfile_class = nullptr) = 0;
+   virtual   Int_t    ReadClassBuffer(const TClass *cl, void *pointer, const TClass *onfile_class = nullptr) = 0;
+   virtual   Int_t    ReadClassBuffer(const TClass *cl, void *pointer, Int_t version, UInt_t start, UInt_t count, const TClass *onfile_class = nullptr) = 0;
    virtual   Int_t    WriteClassBuffer(const TClass *cl, void *pointer) = 0;
 
    // Utilites to streamer using sequences.
@@ -393,7 +393,7 @@ template <class Tmpl> TBuffer &operator>>(TBuffer &buf, Tmpl *&obj)
 
 template <class Tmpl> TBuffer &operator<<(TBuffer &buf, const Tmpl *obj)
 {
-   TClass *cl = (obj) ? TBuffer::GetClass(typeid(*obj)) : 0;
+   TClass *cl = (obj) ? TBuffer::GetClass(typeid(*obj)) : nullptr;
    buf.WriteObjectAny(obj, cl);
    return buf;
 }
@@ -411,7 +411,7 @@ inline TBuffer &operator<<(TBuffer &buf, const TObject *obj)
 template <class T>
 inline Int_t TBuffer::WriteObject(const T *objptr, Bool_t cacheReuse)
 {
-   TClass *cl = (objptr) ? TBuffer::GetClass(typeid(T)) : 0;
+   TClass *cl = (objptr) ? TBuffer::GetClass(typeid(T)) : nullptr;
    return WriteObjectAny(objptr, cl, cacheReuse);
 }
 

--- a/core/base/inc/TCanvasImp.h
+++ b/core/base/inc/TCanvasImp.h
@@ -43,10 +43,10 @@ protected:
    virtual Bool_t IsLocked() { return kFALSE; }
 
    virtual Bool_t PerformUpdate() { return kFALSE; }
-   virtual TVirtualPadPainter *CreatePadPainter() { return 0; }
+   virtual TVirtualPadPainter *CreatePadPainter() { return nullptr; }
 
 public:
-   TCanvasImp(TCanvas *c=0) : fCanvas(c) { }
+   TCanvasImp(TCanvas *c=nullptr) : fCanvas(c) { }
    TCanvasImp(TCanvas *c, const char *name, UInt_t width, UInt_t height);
    TCanvasImp(TCanvas *c, const char *name, Int_t x, Int_t y, UInt_t width, UInt_t height);
    virtual ~TCanvasImp() { }
@@ -57,7 +57,7 @@ public:
    virtual UInt_t GetWindowGeometry(Int_t &x, Int_t &y, UInt_t &w, UInt_t &h);
    virtual void   Iconify() { }
    virtual Int_t  InitWindow() { return 0; }
-   virtual void   SetStatusText(const char *text = 0, Int_t partidx = 0);
+   virtual void   SetStatusText(const char *text = nullptr, Int_t partidx = 0);
    virtual void   SetWindowPosition(Int_t x, Int_t y);
    virtual void   SetWindowSize(UInt_t w, UInt_t h);
    virtual void   SetWindowTitle(const char *newTitle);

--- a/core/base/inc/TDirectory.h
+++ b/core/base/inc/TDirectory.h
@@ -52,7 +52,7 @@ public:
       friend class TDirectory;
    public:
       TContext(TDirectory *previous, TDirectory *newCurrent)
-         : fDirectory(previous), fActiveDestructor(false), fDirectoryWait(false), fPrevious(0), fNext(0)
+         : fDirectory(previous), fActiveDestructor(false), fDirectoryWait(false), fPrevious(nullptr), fNext(nullptr)
       {
          // Store the current directory so we can restore it
          // later and cd to the new directory.
@@ -61,16 +61,16 @@ public:
          else CdNull();
       }
       TContext()
-         : fDirectory(TDirectory::CurrentDirectory()), fActiveDestructor(false), fDirectoryWait(false), fPrevious(0),
-           fNext(0)
+         : fDirectory(TDirectory::CurrentDirectory()), fActiveDestructor(false), fDirectoryWait(false), fPrevious(nullptr),
+           fNext(nullptr)
       {
          // Store the current directory so we can restore it
          // later and cd to the new directory.
          if ( fDirectory ) (*fDirectory).RegisterContext(this);
       }
       TContext(TDirectory *newCurrent)
-         : fDirectory(TDirectory::CurrentDirectory()), fActiveDestructor(false), fDirectoryWait(false), fPrevious(0),
-           fNext(0)
+         : fDirectory(TDirectory::CurrentDirectory()), fActiveDestructor(false), fDirectoryWait(false), fPrevious(nullptr),
+           fNext(nullptr)
       {
          // Store the current directory so we can restore it
          // later and cd to the new directory.
@@ -110,7 +110,7 @@ protected:
 public:
 
    TDirectory();
-   TDirectory(const char *name, const char *title, Option_t *option="", TDirectory* motherDir = 0);
+   TDirectory(const char *name, const char *title, Option_t *option="", TDirectory* motherDir = nullptr);
    virtual ~TDirectory();
    static  void        AddDirectory(Bool_t add=kTRUE);
    static  Bool_t      AddDirectoryStatus();
@@ -118,22 +118,22 @@ public:
    virtual void        Add(TObject *obj, Bool_t replace = kFALSE) { Append(obj,replace); }
    virtual Int_t       AppendKey(TKey *) {return 0;}
    virtual void        Browse(TBrowser *b);
-   virtual void        Build(TFile* motherFile = 0, TDirectory* motherDir = 0);
+   virtual void        Build(TFile* motherFile = nullptr, TDirectory* motherDir = nullptr);
    virtual void        Clear(Option_t *option="");
    virtual TObject    *CloneObject(const TObject *obj, Bool_t autoadd = kTRUE);
    virtual void        Close(Option_t *option="");
    static TDirectory *&CurrentDirectory();  // Return the current directory for this thread.
    virtual void        Copy(TObject &) const { MayNotUse("Copy(TObject &)"); }
-   virtual Bool_t      cd(const char *path = 0);
+   virtual Bool_t      cd(const char *path = nullptr);
    virtual void        DeleteAll(Option_t *option="");
    virtual void        Delete(const char *namecycle="");
    virtual void        Draw(Option_t *option="");
-   virtual TKey       *FindKey(const char * /*keyname*/) const {return 0;}
-   virtual TKey       *FindKeyAny(const char * /*keyname*/) const {return 0;}
+   virtual TKey       *FindKey(const char * /*keyname*/) const {return nullptr;}
+   virtual TKey       *FindKeyAny(const char * /*keyname*/) const {return nullptr;}
    virtual TObject    *FindObject(const char *name) const;
    virtual TObject    *FindObject(const TObject *obj) const;
    virtual TObject    *FindObjectAny(const char *name) const;
-   virtual TObject    *FindObjectAnyFile(const char * /*name*/) const {return 0;}
+   virtual TObject    *FindObjectAnyFile(const char * /*name*/) const {return nullptr;}
    virtual TObject    *Get(const char *namecycle);
    virtual TDirectory *GetDirectory(const char *namecycle, Bool_t printError = false, const char *funcname = "GetDirectory");
    template <class T> inline void GetObject(const char* namecycle, T*& ptr) // See TDirectory::Get for information
@@ -144,12 +144,12 @@ public:
    virtual void       *GetObjectChecked(const char *namecycle, const TClass* cl);
    virtual void       *GetObjectUnchecked(const char *namecycle);
    virtual Int_t       GetBufferSize() const {return 0;}
-   virtual TFile      *GetFile() const { return 0; }
-   virtual TKey       *GetKey(const char * /*name */, Short_t /* cycle */=9999) const {return 0;}
+   virtual TFile      *GetFile() const { return nullptr; }
+   virtual TKey       *GetKey(const char * /*name */, Short_t /* cycle */=9999) const {return nullptr;}
    virtual TList      *GetList() const { return fList; }
-   virtual TList      *GetListOfKeys() const { return 0; }
+   virtual TList      *GetListOfKeys() const { return nullptr; }
    virtual TObject    *GetMother() const { return fMother; }
-   virtual TDirectory *GetMotherDir() const { return fMother==0 ? 0 : dynamic_cast<TDirectory*>(fMother); }
+   virtual TDirectory *GetMotherDir() const { return fMother==nullptr ? nullptr : dynamic_cast<TDirectory*>(fMother); }
    virtual Int_t       GetNbytesKeys() const { return 0; }
    virtual Int_t       GetNkeys() const { return 0; }
    virtual Long64_t    GetSeekDir() const { return 0; }
@@ -165,7 +165,7 @@ public:
    virtual TDirectory *mkdir(const char *name, const char *title="");
    virtual TFile      *OpenFile(const char * /*name*/, Option_t * /*option*/ = "",
                             const char * /*ftitle*/ = "", Int_t /*compress*/ = 1,
-                            Int_t /*netopt*/ = 0) {return 0;}
+                            Int_t /*netopt*/ = 0) {return nullptr;}
    virtual void        Paint(Option_t *option="");
    virtual void        Print(Option_t *option="") const;
    virtual void        Purge(Short_t /*nkeep*/=1) {}
@@ -187,9 +187,9 @@ public:
    virtual void        SetSeekDir(Long64_t) {}
    virtual void        SetWritable(Bool_t) {}
    virtual Int_t       Sizeof() const {return 0;}
-   virtual Int_t       Write(const char * /*name*/=0, Int_t /*opt*/=0, Int_t /*bufsize*/=0){return 0;}
-   virtual Int_t       Write(const char * /*name*/=0, Int_t /*opt*/=0, Int_t /*bufsize*/=0) const {return 0;}
-   virtual Int_t       WriteTObject(const TObject *obj, const char *name =0, Option_t * /*option*/="", Int_t /*bufsize*/ =0);
+   virtual Int_t       Write(const char * /*name*/=nullptr, Int_t /*opt*/=0, Int_t /*bufsize*/=0){return 0;}
+   virtual Int_t       Write(const char * /*name*/=nullptr, Int_t /*opt*/=0, Int_t /*bufsize*/=0) const {return 0;}
+   virtual Int_t       WriteTObject(const TObject *obj, const char *name =nullptr, Option_t * /*option*/="", Int_t /*bufsize*/ =0);
 private:
            Int_t       WriteObject(void *obj, const char* name, Option_t *option="", Int_t bufsize=0); // Intentionaly not implemented.
 public:

--- a/core/base/inc/TFileCollection.h
+++ b/core/base/inc/TFileCollection.h
@@ -59,8 +59,8 @@ public:
    enum EStatusBits {
       kRemoteCollection = BIT(15)   // the collection is not staged
    };
-   TFileCollection(const char *name = 0, const char *title = 0,
-                   const char *file = 0, Int_t nfiles = -1, Int_t firstfile = 1);
+   TFileCollection(const char *name = nullptr, const char *title = nullptr,
+                   const char *file = nullptr, Int_t nfiles = -1, Int_t firstfile = 1);
    virtual ~TFileCollection();
 
    Int_t           Add(TFileInfo *info);
@@ -70,7 +70,7 @@ public:
    THashList      *GetList() { return fList; }
    void            SetList(THashList* list) { fList = list; }
 
-   TObjString     *ExportInfo(const char *name = 0, Int_t popt = 0);
+   TObjString     *ExportInfo(const char *name = nullptr, Int_t popt = 0);
 
    Long64_t        Merge(TCollection* list);
    Int_t           RemoveDuplicates();
@@ -95,15 +95,15 @@ public:
    void            SetDefaultTreeName(const char* treeName) { fDefaultTree = treeName; }
    Long64_t        GetTotalEntries(const char *tree) const;
 
-   TFileInfoMeta  *GetMetaData(const char *meta = 0) const;
+   TFileInfoMeta  *GetMetaData(const char *meta = nullptr) const;
    void            SetDefaultMetaData(const char *meta);
    Bool_t          AddMetaData(TObject *meta);
-   void            RemoveMetaData(const char *meta = 0);
+   void            RemoveMetaData(const char *meta = nullptr);
 
    TFileCollection *GetStagedSubset();
 
    TFileCollection *GetFilesOnServer(const char *server);
-   TMap            *GetFilesPerServer(const char *exclude = 0, Bool_t curronly =  kFALSE);
+   TMap            *GetFilesPerServer(const char *exclude = nullptr, Bool_t curronly =  kFALSE);
 
    ClassDef(TFileCollection, 3)  // Collection of TFileInfo objects
 };

--- a/core/base/inc/TFileInfo.h
+++ b/core/base/inc/TFileInfo.h
@@ -59,8 +59,8 @@ public:
       kSortWithIndex  = BIT(17)     // Use index when sorting (in Compare)
    };
 
-   TFileInfo(const char *url = 0, Long64_t size = -1, const char *uuid = 0,
-             const char *md5 = 0, TObject *meta = 0);
+   TFileInfo(const char *url = nullptr, Long64_t size = -1, const char *uuid = nullptr,
+             const char *md5 = nullptr, TObject *meta = nullptr);
    TFileInfo(const TFileInfo &);
 
    virtual ~TFileInfo();
@@ -80,7 +80,7 @@ public:
    TUUID          *GetUUID() const         { return fUUID; }
    TMD5           *GetMD5() const          { return fMD5; }
    TList          *GetMetaDataList() const { return fMetaDataList; }
-   TFileInfoMeta  *GetMetaData(const char *meta = 0) const;
+   TFileInfoMeta  *GetMetaData(const char *meta = nullptr) const;
 
    void            SetSize(Long64_t size)  { fSize = size; }
    void            SetUUID(const char *uuid);
@@ -90,7 +90,7 @@ public:
    Bool_t          AddUrl(const char *url, Bool_t infront = kFALSE);
    Bool_t          RemoveUrl(const char *url);
    Bool_t          AddMetaData(TObject *meta);
-   Bool_t          RemoveMetaData(const char *meta = 0);
+   Bool_t          RemoveMetaData(const char *meta = nullptr);
 
    Bool_t          IsSortable() const { return kTRUE; }
    Int_t           Compare(const TObject *obj) const;

--- a/core/base/inc/TObject.h
+++ b/core/base/inc/TObject.h
@@ -108,8 +108,8 @@ public:
    virtual void        DrawClass() const; // *MENU*
    virtual TObject    *DrawClone(Option_t *option="") const; // *MENU*
    virtual void        Dump() const; // *MENU*
-   virtual void        Execute(const char *method,  const char *params, Int_t *error=0);
-   virtual void        Execute(TMethod *method, TObjArray *params, Int_t *error=0);
+   virtual void        Execute(const char *method,  const char *params, Int_t *error=nullptr);
+   virtual void        Execute(TMethod *method, TObjArray *params, Int_t *error=nullptr);
    virtual void        ExecuteEvent(Int_t event, Int_t px, Int_t py);
    virtual TObject    *FindObject(const char *name) const;
    virtual TObject    *FindObject(const TObject *obj) const;
@@ -145,8 +145,8 @@ public:
    virtual void        SetDrawOption(Option_t *option="");  // *MENU*
    virtual void        SetUniqueID(UInt_t uid);
    virtual void        UseCurrentStyle();
-   virtual Int_t       Write(const char *name=0, Int_t option=0, Int_t bufsize=0);
-   virtual Int_t       Write(const char *name=0, Int_t option=0, Int_t bufsize=0) const;
+   virtual Int_t       Write(const char *name=nullptr, Int_t option=0, Int_t bufsize=0);
+   virtual Int_t       Write(const char *name=nullptr, Int_t option=0, Int_t bufsize=0) const;
 
    //----- operators
    void    *operator new(size_t sz) { return TStorage::ObjectAlloc(sz); }

--- a/core/base/inc/TPluginManager.h
+++ b/core/base/inc/TPluginManager.h
@@ -121,7 +121,7 @@ private:
 
    TPluginHandler() :
       fBase(), fRegexp(), fClass(), fPlugin(), fCtor(), fOrigin(),
-      fCallEnv(0), fMethod(0), fCanCall(0), fIsMacro(kTRUE), fIsGlobal(kTRUE) { }
+      fCallEnv(nullptr), fMethod(nullptr), fCanCall(0), fIsMacro(kTRUE), fIsGlobal(kTRUE) { }
    TPluginHandler(const char *base, const char *regexp,
                   const char *className, const char *pluginName,
                   const char *ctor, const char *origin);
@@ -192,21 +192,21 @@ private:
    void   LoadHandlerMacros(const char *path);
 
 public:
-   TPluginManager() : fHandlers(0), fBasesLoaded(0), fReadingDirs(kFALSE) { }
+   TPluginManager() : fHandlers(nullptr), fBasesLoaded(nullptr), fReadingDirs(kFALSE) { }
    ~TPluginManager();
 
    void   LoadHandlersFromEnv(TEnv *env);
-   void   LoadHandlersFromPluginDirs(const char *base = 0);
+   void   LoadHandlersFromPluginDirs(const char *base = nullptr);
    void   AddHandler(const char *base, const char *regexp,
                      const char *className, const char *pluginName,
-                     const char *ctor = 0, const char *origin = 0);
-   void   RemoveHandler(const char *base, const char *regexp = 0);
+                     const char *ctor = nullptr, const char *origin = nullptr);
+   void   RemoveHandler(const char *base, const char *regexp = nullptr);
 
-   TPluginHandler *FindHandler(const char *base, const char *uri = 0);
+   TPluginHandler *FindHandler(const char *base, const char *uri = nullptr);
 
    void   Print(Option_t *opt = "") const;
-   Int_t  WritePluginMacros(const char *dir, const char *plugin = 0) const;
-   Int_t  WritePluginRecords(const char *envFile, const char *plugin = 0) const;
+   Int_t  WritePluginMacros(const char *dir, const char *plugin = nullptr) const;
+   Int_t  WritePluginRecords(const char *envFile, const char *plugin = nullptr) const;
 
    ClassDef(TPluginManager,1)  // Manager for plugin handlers
 };

--- a/core/base/inc/TQObject.h
+++ b/core/base/inc/TQObject.h
@@ -114,7 +114,7 @@ public:
 
       TString signal = CompressName(signal_name);
 
-      TVirtualQConnection *connection = 0;
+      TVirtualQConnection *connection = nullptr;
 
       // execute class signals
       TList *sigList;
@@ -178,15 +178,15 @@ public:
                   void *receiver,
                   const char *slot);
 
-   Bool_t Disconnect(const char *signal = 0,
-                     void *receiver = 0,
-                     const char *slot = 0);
+   Bool_t Disconnect(const char *signal = nullptr,
+                     void *receiver = nullptr,
+                     const char *slot = nullptr);
 
    virtual void   HighPriority(const char *signal_name,
-                               const char *slot_name = 0);
+                               const char *slot_name = nullptr);
 
    virtual void   LowPriority(const char *signal_name,
-                              const char *slot_name = 0);
+                              const char *slot_name = nullptr);
 
    virtual Bool_t HasConnection(const char *signal_name) const;
    virtual Int_t  NumberOfSignals() const;
@@ -214,14 +214,14 @@ public:
                           const char *slot);
 
    static Bool_t  Disconnect(TQObject *sender,
-                             const char *signal = 0,
-                             void *receiver = 0,
-                             const char *slot = 0);
+                             const char *signal = nullptr,
+                             void *receiver = nullptr,
+                             const char *slot = nullptr);
 
    static Bool_t  Disconnect(const char *class_name,
                              const char *signal,
-                             void *receiver = 0,
-                             const char *slot = 0);
+                             void *receiver = nullptr,
+                             const char *slot = nullptr);
 
    static Bool_t  AreAllSignalsBlocked();
    static Bool_t  BlockAllSignals(Bool_t b);
@@ -244,7 +244,7 @@ private:
    TQObjSender& operator=(const TQObjSender&); // not implemented
 
 public:
-   TQObjSender() : TQObject(), fSender(0), fSenderClass() { }
+   TQObjSender() : TQObject(), fSender(nullptr), fSenderClass() { }
    virtual ~TQObjSender() { Disconnect(); }
 
    virtual void SetSender(void *sender) { fSender = sender; }

--- a/core/base/inc/TROOT.h
+++ b/core/base/inc/TROOT.h
@@ -191,7 +191,7 @@ public:
 
    typedef std::vector<std::pair<std::string, int> > FwdDeclArgsToKeepCollection_t;
 
-                     TROOT(const char *name, const char *title, VoidFuncPtr_t *initfunc = 0);
+                     TROOT(const char *name, const char *title, VoidFuncPtr_t *initfunc = nullptr);
    virtual           ~TROOT();
    void              AddClass(TClass *cl);
    void              AddClassGenerator(TClassGenerator *gen);
@@ -262,15 +262,15 @@ public:
    TCollection      *GetListOfFunctionTemplates();
    TList            *GetListOfBrowsables() const { return fBrowsables; }
    TDataType        *GetType(const char *name, Bool_t load = kFALSE) const;
-   TFile            *GetFile() const { if (gDirectory != this) return gDirectory->GetFile(); else return 0;}
+   TFile            *GetFile() const { if (gDirectory != this) return gDirectory->GetFile(); else return nullptr;}
    TFile            *GetFile(const char *name) const;
    TFunctionTemplate*GetFunctionTemplate(const char *name);
    TStyle           *GetStyle(const char *name) const;
    TObject          *GetFunction(const char *name) const;
    TGlobal          *GetGlobal(const char *name, Bool_t load = kFALSE) const;
    TGlobal          *GetGlobal(const TObject *obj, Bool_t load = kFALSE) const;
-   TFunction        *GetGlobalFunction(const char *name, const char *params = 0, Bool_t load = kFALSE);
-   TFunction        *GetGlobalFunctionWithPrototype(const char *name, const char *proto = 0, Bool_t load = kFALSE);
+   TFunction        *GetGlobalFunction(const char *name, const char *params = nullptr, Bool_t load = kFALSE);
+   TFunction        *GetGlobalFunctionWithPrototype(const char *name, const char *proto = nullptr, Bool_t load = kFALSE);
    TObject          *GetGeometry(const char *name) const;
    const TObject    *GetSelectedPrimitive() const { return fPrimitive; }
    TVirtualPad      *GetSelectedPad() const { return fSelectPad; }
@@ -278,7 +278,7 @@ public:
    Int_t             GetNtypes() const { return fTypes->GetSize(); }
    TFolder          *GetRootFolder() const { return fRootFolder; }
    TProcessUUID     *GetUUIDs() const { return fUUIDs; }
-   void              Idle(UInt_t idleTimeInSec, const char *command = 0);
+   void              Idle(UInt_t idleTimeInSec, const char *command = nullptr);
    Int_t             IgnoreInclude(const char *fname, const char *expandedfname);
    Bool_t            IsBatch() const { return fBatch; }
    Bool_t            IsExecutingMacro() const { return fExecutingMacro; }
@@ -291,14 +291,14 @@ public:
    void              ls(Option_t *option = "") const;
    Int_t             LoadClass(const char *classname, const char *libname, Bool_t check = kFALSE);
    TClass           *LoadClass(const char *name, Bool_t silent = kFALSE) const;
-   Int_t             LoadMacro(const char *filename, Int_t *error = 0, Bool_t check = kFALSE);
-   Long_t            Macro(const char *filename, Int_t *error = 0, Bool_t padUpdate = kTRUE);
+   Int_t             LoadMacro(const char *filename, Int_t *error = nullptr, Bool_t check = kFALSE);
+   Long_t            Macro(const char *filename, Int_t *error = nullptr, Bool_t padUpdate = kTRUE);
    TCanvas          *MakeDefCanvas() const;
    void              Message(Int_t id, const TObject *obj);
    Bool_t            MustClean() const { return fMustClean; }
-   Long_t            ProcessLine(const char *line, Int_t *error = 0);
-   Long_t            ProcessLineSync(const char *line, Int_t *error = 0);
-   Long_t            ProcessLineFast(const char *line, Int_t *error = 0);
+   Long_t            ProcessLine(const char *line, Int_t *error = nullptr);
+   Long_t            ProcessLineSync(const char *line, Int_t *error = nullptr);
+   Long_t            ProcessLineFast(const char *line, Int_t *error = nullptr);
    Bool_t            ReadingObject() const;
    void              RecursiveRemove(TObject *obj);
    void              RefreshBrowsers();

--- a/core/base/inc/TRef.h
+++ b/core/base/inc/TRef.h
@@ -39,7 +39,7 @@ protected:
 
 public:
 
-   TRef(): fPID(0) { }
+   TRef(): fPID(nullptr) { }
    TRef(TObject *obj);
    TRef(const TRef &ref);
    void  operator=(TObject *obj);

--- a/core/base/inc/TString.h
+++ b/core/base/inc/TString.h
@@ -248,7 +248,7 @@ public:
    TString();                           // Null string
    explicit TString(Ssiz_t ic);         // Suggested capacity
    TString(const TString &s);           // Copy constructor
-   TString(TString &&s);                // Move constructor
+   TString(TString &&s) noexcept;       // Move constructor
    TString(const char *s);              // Copy to embedded null
    TString(const char *s, Ssiz_t n);    // Copy past any embedded nulls
    TString(const std::string &s);
@@ -287,6 +287,7 @@ public:
    TString    &operator=(char s);                // Replace string
    TString    &operator=(const char *s);
    TString    &operator=(const TString &s);
+   TString    &operator=(TString &&s) noexcept;
    TString    &operator=(const std::string &s);
    TString    &operator=(const std::string_view &s);
    TString    &operator=(const TSubString &s);

--- a/core/base/inc/TString.h
+++ b/core/base/inc/TString.h
@@ -229,11 +229,7 @@ private:
    static Ssiz_t  MaxSize() { return (kMaxInt >> 1) - 1; }
 #endif
    void           UnLink() const { if (IsLong()) delete [] fRep.fLong.fData; }
-   void           Zero() {
-      Ssiz_t (&a)[kNwords] = fRep.fRaw.fWords;
-      for (UInt_t i = 0; i < kNwords; ++i)
-         a[i] = 0;
-   }
+   void           Zero() { for (auto &word : fRep.fRaw.fWords) word = 0; }
    char          *Init(Ssiz_t capacity, Ssiz_t nchar);
    void           Clone(Ssiz_t nc); // Make self a distinct copy w. capacity nc
    void           FormImp(const char *fmt, va_list ap);

--- a/core/base/inc/TString.h
+++ b/core/base/inc/TString.h
@@ -616,10 +616,10 @@ inline TString &TString::Prepend(const TString &s, Ssiz_t n)
 { return Replace(0, 0, s.Data(), TMath::Min(n, s.Length())); }
 
 inline TString &TString::Remove(Ssiz_t pos)
-{ return Replace(pos, TMath::Max(0, Length()-pos), 0, 0); }
+{ return Replace(pos, TMath::Max(0, Length()-pos), nullptr, 0); }
 
 inline TString &TString::Remove(Ssiz_t pos, Ssiz_t n)
-{ return Replace(pos, n, 0, 0); }
+{ return Replace(pos, n, nullptr, 0); }
 
 inline TString &TString::Chop()
 { return Remove(TMath::Max(0, Length()-1)); }

--- a/core/base/inc/TStyle.h
+++ b/core/base/inc/TStyle.h
@@ -391,9 +391,9 @@ public:
    void             ToggleEditor() { fShowEditor = fShowEditor ? 0 : 1; }
    void             ToggleToolBar() { fShowToolBar = fShowToolBar ? 0 : 1; }
    void             SetIsReading(Bool_t reading=kTRUE);
-   void             SetPalette(Int_t ncolors=kBird, Int_t *colors=0, Float_t alpha=1.);
+   void             SetPalette(Int_t ncolors=kBird, Int_t *colors=nullptr, Float_t alpha=1.);
    void             SavePrimitive(std::ostream &out, Option_t * = "");
-   void             SaveSource(const char *filename, Option_t *option=0);
+   void             SaveSource(const char *filename, Option_t *option=nullptr);
 
    ClassDef(TStyle, 17);  //A collection of all graphics attributes
 };

--- a/core/base/inc/TSystem.h
+++ b/core/base/inc/TSystem.h
@@ -208,7 +208,7 @@ struct RedirectHandle_t {
    Int_t     fStdOutDup;   // Duplicated descriptor for stdout
    Int_t     fStdErrDup;   // Duplicated descriptor for stderr
    Int_t     fReadOffSet;  // Offset where to start reading the file (used by ShowOutput(...))
-   RedirectHandle_t(const char *n = 0) : fFile(n), fStdOutTty(), fStdErrTty(), fStdOutDup(-1),
+   RedirectHandle_t(const char *n = nullptr) : fFile(n), fStdOutTty(), fStdErrTty(), fStdOutDup(-1),
                                          fStdErrDup(-1), fReadOffSet(-1) { }
    void Reset() { fFile = ""; fStdOutTty = ""; fStdErrTty = "";
                   fStdOutDup = -1; fStdErrDup = -1; fReadOffSet = -1; }
@@ -304,8 +304,8 @@ protected:
    TString &GetLastErrorString();             //Last system error message (thread local).
    const TString &GetLastErrorString() const; //Last system error message (thread local).
 
-   TSystem               *FindHelper(const char *path, void *dirptr = 0);
-   virtual Bool_t         ConsistentWith(const char *path, void *dirptr = 0);
+   TSystem               *FindHelper(const char *path, void *dirptr = nullptr);
+   virtual Bool_t         ConsistentWith(const char *path, void *dirptr = nullptr);
    virtual const char    *ExpandFileName(const char *fname);
    virtual Bool_t         ExpandFileName(TString &fname);
    virtual void           SigAlarmInterruptsSyscalls(Bool_t) { }
@@ -394,24 +394,24 @@ public:
    virtual void           *OpenDirectory(const char *name);
    virtual void            FreeDirectory(void *dirp);
    virtual const char     *GetDirEntry(void *dirp);
-   virtual void           *GetDirPtr() const { return 0; }
+   virtual void           *GetDirPtr() const { return nullptr; }
    virtual Bool_t          ChangeDirectory(const char *path);
    virtual const char     *WorkingDirectory();
    virtual std::string     GetWorkingDirectory() const;
-   virtual const char     *HomeDirectory(const char *userName = 0);
-   virtual std::string     GetHomeDirectory(const char *userName = 0) const;
+   virtual const char     *HomeDirectory(const char *userName = nullptr);
+   virtual std::string     GetHomeDirectory(const char *userName = nullptr) const;
    virtual int             mkdir(const char *name, Bool_t recursive = kFALSE);
    Bool_t                  cd(const char *path) { return ChangeDirectory(path); }
    const char             *pwd() { return WorkingDirectory(); }
    virtual const char     *TempDirectory() const;
-   virtual FILE           *TempFileName(TString &base, const char *dir = 0);
+   virtual FILE           *TempFileName(TString &base, const char *dir = nullptr);
 
    //---- Paths & Files
    virtual const char     *BaseName(const char *pathname);
    virtual const char     *DirName(const char *pathname);
    virtual char           *ConcatFileName(const char *dir, const char *name);
    virtual Bool_t          IsAbsoluteFileName(const char *dir);
-   virtual Bool_t          IsFileInIncludePath(const char *name, char **fullpath = 0);
+   virtual Bool_t          IsFileInIncludePath(const char *name, char **fullpath = nullptr);
    virtual const char     *PrependPathName(const char *dir, TString& name);
    virtual Bool_t          ExpandPathName(TString &path);
    virtual char           *ExpandPathName(const char *path);
@@ -432,17 +432,17 @@ public:
    virtual const char     *UnixPathName(const char *unixpathname);
    virtual const char     *FindFile(const char *search, TString& file, EAccessMode mode = kFileExists);
    virtual char           *Which(const char *search, const char *file, EAccessMode mode = kFileExists);
-   virtual TList          *GetVolumes(Option_t *) const { return 0; }
+   virtual TList          *GetVolumes(Option_t *) const { return nullptr; }
 
    //---- Users & Groups
-   virtual Int_t           GetUid(const char *user = 0);
-   virtual Int_t           GetGid(const char *group = 0);
+   virtual Int_t           GetUid(const char *user = nullptr);
+   virtual Int_t           GetGid(const char *group = nullptr);
    virtual Int_t           GetEffectiveUid();
    virtual Int_t           GetEffectiveGid();
    virtual UserGroup_t    *GetUserInfo(Int_t uid);
-   virtual UserGroup_t    *GetUserInfo(const char *user = 0);
+   virtual UserGroup_t    *GetUserInfo(const char *user = nullptr);
    virtual UserGroup_t    *GetGroupInfo(Int_t gid);
-   virtual UserGroup_t    *GetGroupInfo(const char *group = 0);
+   virtual UserGroup_t    *GetGroupInfo(const char *group = nullptr);
 
    //---- Environment Manipulation
    virtual void            Setenv(const char *name, const char *value);
@@ -455,7 +455,7 @@ public:
    virtual void            Closelog();
 
    //---- Standard Output redirection
-   virtual Int_t           RedirectOutput(const char *name, const char *mode = "a", RedirectHandle_t *h = 0);
+   virtual Int_t           RedirectOutput(const char *name, const char *mode = "a", RedirectHandle_t *h = nullptr);
    virtual void            ShowOutput(RedirectHandle_t *h);
 
    //---- Dynamic Loading

--- a/core/base/inc/TTimeStamp.h
+++ b/core/base/inc/TTimeStamp.h
@@ -148,11 +148,11 @@ public:
 
    void         Copy(TTimeStamp &ts) const;
    UInt_t       GetDate(Bool_t inUTC = kTRUE, Int_t secOffset = 0,
-                        UInt_t *year = 0, UInt_t *month = 0,
-                        UInt_t *day = 0) const;
+                        UInt_t *year = nullptr, UInt_t *month = nullptr,
+                        UInt_t *day = nullptr) const;
    UInt_t       GetTime(Bool_t inUTC = kTRUE, Int_t secOffset = 0,
-                        UInt_t *hour = 0, UInt_t *min = 0,
-                        UInt_t *sec = 0) const;
+                        UInt_t *hour = nullptr, UInt_t *min = nullptr,
+                        UInt_t *sec = nullptr) const;
    Int_t        GetDayOfYear(Bool_t inUTC = kTRUE, Int_t secOffset = 0) const;
    Int_t        GetDayOfWeek(Bool_t inUTC = kTRUE, Int_t secOffset = 0) const;
    Int_t        GetMonth(Bool_t inUTC = kTRUE, Int_t secOffset = 0) const;

--- a/core/base/inc/TUrl.h
+++ b/core/base/inc/TUrl.h
@@ -57,7 +57,7 @@ private:
 
 public:
    TUrl() : fUrl(), fProtocol(), fUser(), fPasswd(), fHost(), fFile(),
-            fAnchor(), fOptions(), fFileOA(), fHostFQ(), fPort(-1), fOptionsMap(0) { }
+            fAnchor(), fOptions(), fFileOA(), fHostFQ(), fPort(-1), fOptionsMap(nullptr) { }
    TUrl(const char *url, Bool_t defaultIsFile = kFALSE);
    TUrl(const TUrl &url);
    TUrl &operator=(const TUrl &rhs);

--- a/core/base/inc/TVirtualMutex.h
+++ b/core/base/inc/TVirtualMutex.h
@@ -80,7 +80,7 @@ public:
    Int_t UnLock() {
       if (!fMutex) return 0;
       auto tmp = fMutex;
-      fMutex = 0;
+      fMutex = nullptr;
       return tmp->UnLock();
    }
    ~TLockGuard() { if (fMutex) fMutex->UnLock(); }

--- a/core/base/inc/TVirtualPad.h
+++ b/core/base/inc/TVirtualPad.h
@@ -181,7 +181,7 @@ public:
    virtual void     RangeAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t ymax) = 0;
    virtual void     RecursiveRemove(TObject *obj) = 0;
    virtual void     RedrawAxis(Option_t *option="") = 0;
-   virtual void     ResetView3D(TObject *view=0) = 0;
+   virtual void     ResetView3D(TObject *view=nullptr) = 0;
    virtual void     ResizePad(Option_t *option="") = 0;
    virtual void     SaveAs(const char *filename="",Option_t *option="") const = 0;
    virtual void     SetBatch(Bool_t batch=kTRUE) = 0;
@@ -219,7 +219,7 @@ public:
    virtual void     SetPhi(Double_t phi=30) = 0;
    virtual void     SetToolTipText(const char *text, Long_t delayms = 1000) = 0;
    virtual void     SetVertical(Bool_t vert=kTRUE) = 0;
-   virtual void     SetView(TView *view=0) = 0;
+   virtual void     SetView(TView *view=nullptr) = 0;
    virtual void     SetViewer3D(TVirtualViewer3D * /*viewer3d*/) {}
    virtual void     ShowGuidelines(TObject *object, const Int_t event, const char mode = 'i', const bool cling = true) = 0;
    virtual TObject *WaitPrimitive(const char *pname="", const char *emode="") = 0;

--- a/core/base/inc/TVirtualX.h
+++ b/core/base/inc/TVirtualX.h
@@ -71,7 +71,7 @@ public:
    TVirtualX(const char *name, const char *title);
    virtual ~TVirtualX() { }
 
-   virtual Bool_t    Init(void *display=0);
+   virtual Bool_t    Init(void *display=nullptr);
    virtual void      ClearWindow();
    virtual void      ClosePixmap();
    virtual void      CloseWindow();
@@ -103,7 +103,7 @@ public:
    EDrawMode         GetDrawMode() { return fDrawMode; }
    virtual Int_t     GetDoubleBuffer(Int_t wid);
    virtual void      GetGeometry(Int_t wid, Int_t &x, Int_t &y, UInt_t &w, UInt_t &h);
-   virtual const char *DisplayName(const char * = 0);
+   virtual const char *DisplayName(const char * = nullptr);
    virtual Handle_t  GetNativeEvent() const;
    virtual ULong_t   GetPixel(Color_t cindex);
    virtual void      GetPlanes(Int_t &nplanes);

--- a/core/base/src/TString.cxx
+++ b/core/base/src/TString.cxx
@@ -173,7 +173,7 @@ TString::TString(const TString &s)
 ////////////////////////////////////////////////////////////////////////////////
 /// Move constructor.
 
-TString::TString(TString &&s)
+TString::TString(TString &&s) noexcept
 {
    // Short or long, all data is in fRaw.
    fRep.fRaw = s.fRep.fRaw;
@@ -317,6 +317,17 @@ TString& TString::operator=(const TString &rhs)
          memcpy(data, rhs.GetLongPointer(), n);
       }
    }
+   return *this;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Move-Assignment operator.
+
+TString& TString::operator=(TString &&rhs) noexcept
+{
+   UnLink();
+   fRep.fRaw = rhs.fRep.fRaw;
+   rhs.Zero();
    return *this;
 }
 

--- a/core/cont/inc/TCollection.h
+++ b/core/cont/inc/TCollection.h
@@ -166,8 +166,8 @@ public:
    virtual void       Clear(Option_t *option="") = 0;
    virtual TObject   *Clone(const char *newname="") const;
    Int_t              Compare(const TObject *obj) const;
-   Bool_t             Contains(const char *name) const { return FindObject(name) != 0; }
-   Bool_t             Contains(const TObject *obj) const { return FindObject(obj) != 0; }
+   Bool_t             Contains(const char *name) const { return FindObject(name) != nullptr; }
+   Bool_t             Contains(const TObject *obj) const { return FindObject(obj) != nullptr; }
    virtual void       Delete(Option_t *option="") = 0;
    virtual void       Draw(Option_t *option="");
    virtual void       Dump() const ;
@@ -204,8 +204,8 @@ public:
    void               SetName(const char *name) { fName = name; }
    virtual void       SetOwner(Bool_t enable = kTRUE);
    virtual bool       UseRWLock();
-   virtual Int_t      Write(const char *name=0, Int_t option=0, Int_t bufsize=0);
-   virtual Int_t      Write(const char *name=0, Int_t option=0, Int_t bufsize=0) const;
+   virtual Int_t      Write(const char *name=nullptr, Int_t option=0, Int_t bufsize=0);
+   virtual Int_t      Write(const char *name=nullptr, Int_t option=0, Int_t bufsize=0) const;
 
    R__ALWAYS_INLINE Bool_t IsUsingRWLock() const { return TestBit(TCollection::kUseRWLock); }
 
@@ -240,7 +240,7 @@ protected:
 
 public:
    TIter(const TCollection *col, Bool_t dir = kIterForward)
-         : fIterator(col ? col->MakeIterator(dir) : 0) { }
+         : fIterator(col ? col->MakeIterator(dir) : nullptr) { }
    TIter(TIterator *it) : fIterator(it) { }
    TIter(const TIter &iter);
    TIter &operator=(const TIter &rhs);

--- a/core/cont/inc/THashTable.h
+++ b/core/cont/inc/THashTable.h
@@ -118,7 +118,7 @@ private:
    TListIter        *fListCursor;  //current position in collision list
    Bool_t            fDirection;   //iteration direction
 
-   THashTableIter() : fTable(0), fCursor(0), fListCursor(0), fDirection(kIterForward) { }
+   THashTableIter() : fTable(nullptr), fCursor(0), fListCursor(nullptr), fDirection(kIterForward) { }
    Int_t             NextSlot();
 
 public:

--- a/core/cont/inc/TMap.h
+++ b/core/cont/inc/TMap.h
@@ -84,8 +84,8 @@ public:
    TPair            *RemoveEntry(TObject *key);
    virtual void      SetOwnerValue(Bool_t enable = kTRUE);
    virtual void      SetOwnerKeyValue(Bool_t ownkeys = kTRUE, Bool_t ownvals = kTRUE);
-   virtual Int_t     Write(const char *name=0, Int_t option=0, Int_t bufsize=0);
-   virtual Int_t     Write(const char *name=0, Int_t option=0, Int_t bufsize=0) const;
+   virtual Int_t     Write(const char *name=nullptr, Int_t option=0, Int_t bufsize=0);
+   virtual Int_t     Write(const char *name=nullptr, Int_t option=0, Int_t bufsize=0) const;
 
    ClassDef(TMap,3)  //A (key,value) map
 };
@@ -151,7 +151,7 @@ private:
    THashTableIter   *fCursor;      //current position in map
    Bool_t            fDirection;   //iteration direction
 
-   TMapIter() : fMap(0), fCursor(0), fDirection(kIterForward) { }
+   TMapIter() : fMap(nullptr), fCursor(nullptr), fDirection(kIterForward) { }
 
 public:
    TMapIter(const TMap *map, Bool_t dir = kIterForward);

--- a/core/cont/src/TList.cxx
+++ b/core/cont/src/TList.cxx
@@ -767,7 +767,7 @@ void TList::RecursiveRemove(TObject *obj)
    // the node being cleared and/or deleted.
    {
       auto cached = fCache.lock();
-      if (cached && cached->fNext.get() == nullptr && cached->fPrev.lock().get() == nullptr) {
+      if (cached && cached->fNext == nullptr && cached->fPrev.lock() == nullptr) {
          TObject *ob = cached->GetObject();
          if (ob && ob->TestBit(kNotDeleted)) {
             ob->RecursiveRemove(obj);
@@ -949,7 +949,7 @@ void TList::Sort(Bool_t order)
    // correct back links
    std::shared_ptr<TObjLink> ol, lnk = fFirst;
 
-   if (lnk.get()) lnk->fPrev.reset();
+   if (lnk) lnk->fPrev.reset();
    while ((ol = lnk)) {
       lnk = lnk->fNext;
       if (lnk)

--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -339,10 +339,10 @@ public:
    TClass(const char *name, Version_t cversion, Bool_t silent = kFALSE);
    TClass(const char *name, Version_t cversion, EState theState, Bool_t silent = kFALSE);
    TClass(ClassInfo_t *info, Version_t cversion,
-          const char *dfil, const char *ifil = 0,
+          const char *dfil, const char *ifil = nullptr,
           Int_t dl = 0, Int_t il = 0, Bool_t silent = kFALSE);
    TClass(const char *name, Version_t cversion,
-          const char *dfil, const char *ifil = 0,
+          const char *dfil, const char *ifil = nullptr,
           Int_t dl = 0, Int_t il = 0, Bool_t silent = kFALSE);
    TClass(const char *name, Version_t cversion,
           const std::type_info &info, TVirtualIsAProxy *isa,
@@ -357,7 +357,7 @@ public:
    static Int_t       ReadRules();
    void               AdoptSchemaRules( ROOT::Detail::TSchemaRuleSet *rules );
    virtual void       Browse(TBrowser *b);
-   void               BuildRealData(void *pointer=0, Bool_t isTransient = kFALSE);
+   void               BuildRealData(void *pointer=nullptr, Bool_t isTransient = kFALSE);
    void               BuildEmulatedRealData(const char *name, Long_t offset, TClass *cl);
    void               CalculateStreamerOffset() const;
    Bool_t             CallShowMembers(const void* obj, TMemberInspector &insp, Bool_t isTransient = kFALSE) const;
@@ -377,7 +377,7 @@ public:
    TVirtualStreamerInfo     *FindConversionStreamerInfo( const TClass* onfile_cl, UInt_t checksum ) const;
    Bool_t             HasDataMemberInfo() const { return fHasRootPcmInfo || HasInterpreterInfo(); }
    Bool_t             HasDefaultConstructor() const;
-   Bool_t             HasInterpreterInfoInMemory() const { return 0 != fClassInfo; }
+   Bool_t             HasInterpreterInfoInMemory() const { return nullptr != fClassInfo; }
    Bool_t             HasInterpreterInfo() const { return fCanLoadClassInfo || fClassInfo; }
    UInt_t             GetCheckSum(ECheckSum code = kCurrentCheckSum) const;
    UInt_t             GetCheckSum(Bool_t &isvalid) const;
@@ -423,7 +423,7 @@ public:
    TClass            *GetActualClass(const void *object) const;
    TClass            *GetBaseClass(const char *classname);
    TClass            *GetBaseClass(const TClass *base);
-   Int_t              GetBaseClassOffset(const TClass *toBase, void *address = 0, bool isDerivedObject = true);
+   Int_t              GetBaseClassOffset(const TClass *toBase, void *address = nullptr, bool isDerivedObject = true);
    TClass            *GetBaseDataMember(const char *datamember);
    ROOT::ESTLType     GetCollectionType() const;
    ROOT::DirAutoAdd_t GetDirectoryAutoAdd() const;
@@ -558,7 +558,7 @@ public:
    const void        *DynamicCast(const TClass *base, const void *obj, Bool_t up = kTRUE);
    Bool_t             IsFolder(void *obj) const;
 
-   inline void        Streamer(void *obj, TBuffer &b, const TClass *onfile_class = 0) const
+   inline void        Streamer(void *obj, TBuffer &b, const TClass *onfile_class = nullptr) const
    {
       // Inline for performance, skipping one function call.
 #ifdef R__NO_ATOMIC_FUNCTION_POINTER

--- a/core/meta/inc/TDataType.h
+++ b/core/meta/inc/TDataType.h
@@ -61,7 +61,7 @@ protected:
    TDataType& operator=(const TDataType&);
 
 public:
-   TDataType(TypedefInfo_t *info = 0);
+   TDataType(TypedefInfo_t *info = nullptr);
    TDataType(const char *typenam);
    virtual       ~TDataType();
    Int_t          Size() const;

--- a/core/meta/inc/TDictionary.h
+++ b/core/meta/inc/TDictionary.h
@@ -165,8 +165,8 @@ protected:
    Bool_t              UpdateInterpreterStateMarker();
 
 public:
-   TDictionary(): fAttributeMap(0), fUpdatingTransactionCount(0) { }
-   TDictionary(const char* name): TNamed(name, ""), fAttributeMap(0), fUpdatingTransactionCount(0) { }
+   TDictionary(): fAttributeMap(nullptr), fUpdatingTransactionCount(0) { }
+   TDictionary(const char* name): TNamed(name, ""), fAttributeMap(nullptr), fUpdatingTransactionCount(0) { }
    TDictionary(const TDictionary& dict);
    virtual ~TDictionary();
 

--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -60,7 +60,7 @@ struct InterpreterMutexRegistrationRAII {
 class TInterpreter : public TNamed {
 
 protected:
-   virtual void Execute(TMethod *method, TObjArray *params, int *error = 0) = 0;
+   virtual void Execute(TMethod *method, TObjArray *params, int *error = nullptr) = 0;
    virtual Bool_t SetSuspendAutoParsing(Bool_t value) = 0;
 
    friend class SuspendAutoParsing;
@@ -92,7 +92,7 @@ public:
       typedef void (*Dtor_t)(void*, unsigned long, int);
 
       CallFuncIFacePtr_t():
-         fKind(kUninitialized), fGeneric(0) {}
+         fKind(kUninitialized), fGeneric(nullptr) {}
       CallFuncIFacePtr_t(Generic_t func):
          fKind(kGeneric), fGeneric(func) {}
       CallFuncIFacePtr_t(Ctor_t func):
@@ -125,8 +125,8 @@ public:
    virtual ~TInterpreter() { }
 
    virtual void     AddIncludePath(const char *path) = 0;
-   virtual void    *SetAutoLoadCallBack(void* /*cb*/) { return 0; }
-   virtual void    *GetAutoLoadCallBack() const { return 0; }
+   virtual void    *SetAutoLoadCallBack(void* /*cb*/) { return nullptr; }
+   virtual void    *GetAutoLoadCallBack() const { return nullptr; }
    virtual Int_t    AutoLoad(const char *classname, Bool_t knowDictNotLoaded = kFALSE) = 0;
    virtual Int_t    AutoLoad(const std::type_info& typeinfo, Bool_t knowDictNotLoaded = kFALSE) = 0;
    virtual Int_t    AutoParse(const char* cls) = 0;
@@ -137,11 +137,11 @@ public:
    virtual void     EndOfLineAction() = 0;
    virtual TClass  *GetClass(const std::type_info& typeinfo, Bool_t load) const = 0;
    virtual Int_t    GetExitCode() const = 0;
-   virtual TEnv    *GetMapfile() const { return 0; }
+   virtual TEnv    *GetMapfile() const { return nullptr; }
    virtual Int_t    GetMore() const = 0;
    virtual TClass  *GenerateTClass(const char *classname, Bool_t emulation, Bool_t silent = kFALSE) = 0;
    virtual TClass  *GenerateTClass(ClassInfo_t *classinfo, Bool_t silent = kFALSE) = 0;
-   virtual Int_t    GenerateDictionary(const char *classes, const char *includes = 0, const char *options = 0) = 0;
+   virtual Int_t    GenerateDictionary(const char *classes, const char *includes = nullptr, const char *options = nullptr) = 0;
    virtual char    *GetPrompt() = 0;
    virtual const char *GetSharedLibs() = 0;
    virtual const char *GetClassSharedLibs(const char *cls) = 0;
@@ -153,14 +153,14 @@ public:
    virtual void     InspectMembers(TMemberInspector&, const void* obj, const TClass* cl, Bool_t isTransient) = 0;
    virtual Bool_t   IsLoaded(const char *filename) const = 0;
    virtual Int_t    Load(const char *filenam, Bool_t system = kFALSE) = 0;
-   virtual void     LoadMacro(const char *filename, EErrorCode *error = 0) = 0;
-   virtual Int_t    LoadLibraryMap(const char *rootmapfile = 0) = 0;
+   virtual void     LoadMacro(const char *filename, EErrorCode *error = nullptr) = 0;
+   virtual Int_t    LoadLibraryMap(const char *rootmapfile = nullptr) = 0;
    virtual Int_t    RescanLibraryMap() = 0;
    virtual Int_t    ReloadAllSharedLibraryMaps() = 0;
    virtual Int_t    UnloadAllSharedLibraryMaps() = 0;
    virtual Int_t    UnloadLibraryMap(const char *library) = 0;
-   virtual Long_t   ProcessLine(const char *line, EErrorCode *error = 0) = 0;
-   virtual Long_t   ProcessLineSynch(const char *line, EErrorCode *error = 0) = 0;
+   virtual Long_t   ProcessLine(const char *line, EErrorCode *error = nullptr) = 0;
+   virtual Long_t   ProcessLineSynch(const char *line, EErrorCode *error = nullptr) = 0;
    virtual void     PrintIntro() = 0;
    virtual void     RegisterModule(const char* /*modulename*/,
                                    const char** /*headers*/,
@@ -199,7 +199,7 @@ public:
    virtual ECheckClassInfo CheckClassInfo(const char *name, Bool_t autoload, Bool_t isClassOrNamespaceOnly = kFALSE) = 0;
 
    virtual Bool_t   CheckClassTemplate(const char *name) = 0;
-   virtual Long_t   Calc(const char *line, EErrorCode* error = 0) = 0;
+   virtual Long_t   Calc(const char *line, EErrorCode* error = nullptr) = 0;
    virtual void     CreateListOfBaseClasses(TClass *cl) const = 0;
    virtual void     CreateListOfDataMembers(TClass *cl) const = 0;
    virtual void     CreateListOfMethods(TClass *cl) const = 0;
@@ -210,11 +210,11 @@ public:
    virtual void     GetInterpreterTypeName(const char *name, std::string &output, Bool_t full = kFALSE) = 0;
    virtual void    *GetInterfaceMethod(TClass *cl, const char *method, const char *params, Bool_t objectIsConst = kFALSE) = 0;
    virtual void    *GetInterfaceMethodWithPrototype(TClass *cl, const char *method, const char *proto, Bool_t objectIsConst = kFALSE, ROOT::EFunctionMatchMode /* mode */ = ROOT::kConversionMatch) = 0;
-   virtual void     Execute(const char *function, const char *params, int *error = 0) = 0;
-   virtual void     Execute(TObject *obj, TClass *cl, const char *method, const char *params, int *error = 0) = 0;
-   virtual void     Execute(TObject *obj, TClass *cl, TMethod *method, TObjArray *params, int *error = 0) = 0;
-   virtual void     ExecuteWithArgsAndReturn(TMethod *method, void* address, const void* args[] = 0, int /*nargs*/ = 0, void* ret= 0) const = 0;
-   virtual Long_t   ExecuteMacro(const char *filename, EErrorCode *error = 0) = 0;
+   virtual void     Execute(const char *function, const char *params, int *error = nullptr) = 0;
+   virtual void     Execute(TObject *obj, TClass *cl, const char *method, const char *params, int *error = nullptr) = 0;
+   virtual void     Execute(TObject *obj, TClass *cl, TMethod *method, TObjArray *params, int *error = nullptr) = 0;
+   virtual void     ExecuteWithArgsAndReturn(TMethod *method, void* address, const void* args[] = nullptr, int /*nargs*/ = 0, void* ret= nullptr) const = 0;
+   virtual Long_t   ExecuteMacro(const char *filename, EErrorCode *error = nullptr) = 0;
    virtual Bool_t   IsErrorMessagesEnabled() const = 0;
    virtual Bool_t   SetErrorMessages(Bool_t enable = kTRUE) = 0;
    virtual Bool_t   IsProcessLineLocked() const = 0;
@@ -231,15 +231,15 @@ public:
    // Misc
    virtual int    DisplayClass(FILE * /* fout */,const char * /* name */,int /* base */,int /* start */) const {return 0;}
    virtual int    DisplayIncludePath(FILE * /* fout */) const {return 0;}
-   virtual void  *FindSym(const char * /* entry */) const {return 0;}
+   virtual void  *FindSym(const char * /* entry */) const {return nullptr;}
    virtual void   GenericError(const char * /* error */) const {;}
    virtual Long_t GetExecByteCode() const {return 0;}
-   virtual const char *GetTopLevelMacroName() const {return 0;};
-   virtual const char *GetCurrentMacroName()  const {return 0;};
+   virtual const char *GetTopLevelMacroName() const {return nullptr;};
+   virtual const char *GetCurrentMacroName()  const {return nullptr;};
    virtual int    GetSecurityError() const{return 0;}
    virtual int    LoadFile(const char * /* path */) const {return 0;}
    virtual Bool_t LoadText(const char * /* text */) const {return kFALSE;}
-   virtual const char *MapCppName(const char*) const {return 0;}
+   virtual const char *MapCppName(const char*) const {return nullptr;}
    virtual void   SetAlloclockfunc(void (*)()) const {;}
    virtual void   SetAllocunlockfunc(void (*)()) const {;}
    virtual int    SetClassAutoloading(int) const {return 0;}
@@ -247,7 +247,7 @@ public:
    virtual void   SetErrmsgcallback(void * /* p */) const {;}
    virtual void   SetTempLevel(int /* val */) const {;}
    virtual int    UnloadFile(const char * /* path */) const {return 0;}
-   virtual TInterpreterValue *CreateTemporary() { return 0; }
+   virtual TInterpreterValue *CreateTemporary() { return nullptr; }
    virtual void   CodeComplete(const std::string&, size_t&,
                                std::vector<std::string>&) {;}
    virtual int Evaluate(const char*, TInterpreterValue&) {return 0;}
@@ -286,13 +286,13 @@ public:
    virtual void   CallFunc_Exec(CallFunc_t * /* func */, void * /* address */) const {;}
    virtual void   CallFunc_Exec(CallFunc_t * /* func */, void * /* address */, TInterpreterValue& /* val */) const {;}
    virtual void   CallFunc_ExecWithReturn(CallFunc_t * /* func */, void * /* address */, void * /* ret */) const {;}
-   virtual void   CallFunc_ExecWithArgsAndReturn(CallFunc_t * /* func */, void * /* address */, const void* /* args */ [] = 0, int /*nargs*/ = 0, void * /* ret */ = 0) const {}
+   virtual void   CallFunc_ExecWithArgsAndReturn(CallFunc_t * /* func */, void * /* address */, const void* /* args */ [] = nullptr, int /*nargs*/ = 0, void * /* ret */ = nullptr) const {}
    virtual Long_t    CallFunc_ExecInt(CallFunc_t * /* func */, void * /* address */) const {return 0;}
    virtual Long64_t  CallFunc_ExecInt64(CallFunc_t * /* func */, void * /* address */) const {return 0;}
    virtual Double_t  CallFunc_ExecDouble(CallFunc_t * /* func */, void * /* address */) const {return 0;}
-   virtual CallFunc_t   *CallFunc_Factory() const {return 0;}
-   virtual CallFunc_t   *CallFunc_FactoryCopy(CallFunc_t * /* func */) const {return 0;}
-   virtual MethodInfo_t *CallFunc_FactoryMethod(CallFunc_t * /* func */) const {return 0;}
+   virtual CallFunc_t   *CallFunc_Factory() const {return nullptr;}
+   virtual CallFunc_t   *CallFunc_FactoryCopy(CallFunc_t * /* func */) const {return nullptr;}
+   virtual MethodInfo_t *CallFunc_FactoryMethod(CallFunc_t * /* func */) const {return nullptr;}
    virtual void   CallFunc_IgnoreExtraArgs(CallFunc_t * /*func */, bool /*ignore*/) const {;}
    virtual void   CallFunc_Init(CallFunc_t * /* func */) const {;}
    virtual Bool_t CallFunc_IsValid(CallFunc_t * /* func */) const {return 0;}
@@ -377,7 +377,7 @@ public:
    virtual ClassInfo_t  *ClassInfo_Factory(ClassInfo_t * /* cl */) const = 0;
    virtual ClassInfo_t  *ClassInfo_Factory(const char * /* name */) const = 0;
    virtual Long_t   ClassInfo_GetBaseOffset(ClassInfo_t* /* fromDerived */,
-                                            ClassInfo_t* /* toBase */, void* /* address */ = 0, bool /*isderived*/ = true) const {return 0;}
+                                            ClassInfo_t* /* toBase */, void* /* address */ = nullptr, bool /*isderived*/ = true) const {return 0;}
    virtual int    ClassInfo_GetMethodNArg(ClassInfo_t * /* info */, const char * /* method */,const char * /* proto */, Bool_t /* objectIsConst */ = false, ROOT::EFunctionMatchMode /* mode */ = ROOT::kConversionMatch) const {return 0;}
    virtual Bool_t ClassInfo_HasDefaultConstructor(ClassInfo_t * /* info */) const {return 0;}
    virtual Bool_t ClassInfo_HasMethod(ClassInfo_t * /* info */, const char * /* name */) const {return 0;}
@@ -390,41 +390,41 @@ public:
    virtual Bool_t ClassInfo_IsValidMethod(ClassInfo_t * /* info */, const char * /* method */,const char * /* proto */, Long_t * /* offset */, ROOT::EFunctionMatchMode /* mode */ = ROOT::kConversionMatch) const {return 0;}
    virtual Bool_t ClassInfo_IsValidMethod(ClassInfo_t * /* info */, const char * /* method */,const char * /* proto */, Bool_t /* objectIsConst */, Long_t * /* offset */, ROOT::EFunctionMatchMode /* mode */ = ROOT::kConversionMatch) const {return 0;}
    virtual int    ClassInfo_Next(ClassInfo_t * /* info */) const {return 0;}
-   virtual void  *ClassInfo_New(ClassInfo_t * /* info */) const {return 0;}
-   virtual void  *ClassInfo_New(ClassInfo_t * /* info */, int /* n */) const {return 0;}
-   virtual void  *ClassInfo_New(ClassInfo_t * /* info */, int /* n */, void * /* arena */) const {return 0;}
-   virtual void  *ClassInfo_New(ClassInfo_t * /* info */, void * /* arena */) const {return 0;}
+   virtual void  *ClassInfo_New(ClassInfo_t * /* info */) const {return nullptr;}
+   virtual void  *ClassInfo_New(ClassInfo_t * /* info */, int /* n */) const {return nullptr;}
+   virtual void  *ClassInfo_New(ClassInfo_t * /* info */, int /* n */, void * /* arena */) const {return nullptr;}
+   virtual void  *ClassInfo_New(ClassInfo_t * /* info */, void * /* arena */) const {return nullptr;}
    virtual Long_t ClassInfo_Property(ClassInfo_t * /* info */) const {return 0;}
    virtual int    ClassInfo_Size(ClassInfo_t * /* info */) const {return 0;}
    virtual Long_t ClassInfo_Tagnum(ClassInfo_t * /* info */) const {return 0;}
-   virtual const char *ClassInfo_FileName(ClassInfo_t * /* info */) const {return 0;}
-   virtual const char *ClassInfo_FullName(ClassInfo_t * /* info */) const {return 0;}
-   virtual const char *ClassInfo_Name(ClassInfo_t * /* info */) const {return 0;}
-   virtual const char *ClassInfo_Title(ClassInfo_t * /* info */) const {return 0;}
-   virtual const char *ClassInfo_TmpltName(ClassInfo_t * /* info */) const {return 0;}
+   virtual const char *ClassInfo_FileName(ClassInfo_t * /* info */) const {return nullptr;}
+   virtual const char *ClassInfo_FullName(ClassInfo_t * /* info */) const {return nullptr;}
+   virtual const char *ClassInfo_Name(ClassInfo_t * /* info */) const {return nullptr;}
+   virtual const char *ClassInfo_Title(ClassInfo_t * /* info */) const {return nullptr;}
+   virtual const char *ClassInfo_TmpltName(ClassInfo_t * /* info */) const {return nullptr;}
 
 
    // BaseClassInfo interface
    virtual void   BaseClassInfo_Delete(BaseClassInfo_t * /* bcinfo */) const {;}
-   virtual BaseClassInfo_t  *BaseClassInfo_Factory(ClassInfo_t * /* info */) const {return 0;}
+   virtual BaseClassInfo_t  *BaseClassInfo_Factory(ClassInfo_t * /* info */) const {return nullptr;}
    virtual BaseClassInfo_t  *BaseClassInfo_Factory(ClassInfo_t* /* derived */,
-                                                   ClassInfo_t* /* base */) const {return 0;}
+                                                   ClassInfo_t* /* base */) const {return nullptr;}
    virtual int    BaseClassInfo_Next(BaseClassInfo_t * /* bcinfo */) const {return 0;}
    virtual int    BaseClassInfo_Next(BaseClassInfo_t * /* bcinfo */, int  /* onlyDirect */) const {return 0;}
-   virtual Long_t BaseClassInfo_Offset(BaseClassInfo_t * /* toBaseClassInfo */, void* /* address */ = 0 /*default for non-virtual*/, bool /*isderived*/ = true /*default for non-virtual*/) const {return 0;}
+   virtual Long_t BaseClassInfo_Offset(BaseClassInfo_t * /* toBaseClassInfo */, void* /* address */ = nullptr /*default for non-virtual*/, bool /*isderived*/ = true /*default for non-virtual*/) const {return 0;}
    virtual Long_t BaseClassInfo_Property(BaseClassInfo_t * /* bcinfo */) const {return 0;}
    virtual Long_t BaseClassInfo_Tagnum(BaseClassInfo_t * /* bcinfo */) const {return 0;}
    virtual ClassInfo_t*BaseClassInfo_ClassInfo(BaseClassInfo_t * /* bcinfo */) const = 0;
-   virtual const char *BaseClassInfo_FullName(BaseClassInfo_t * /* bcinfo */) const {return 0;}
-   virtual const char *BaseClassInfo_Name(BaseClassInfo_t * /* bcinfo */) const {return 0;}
-   virtual const char *BaseClassInfo_TmpltName(BaseClassInfo_t * /* bcinfo */) const {return 0;}
+   virtual const char *BaseClassInfo_FullName(BaseClassInfo_t * /* bcinfo */) const {return nullptr;}
+   virtual const char *BaseClassInfo_Name(BaseClassInfo_t * /* bcinfo */) const {return nullptr;}
+   virtual const char *BaseClassInfo_TmpltName(BaseClassInfo_t * /* bcinfo */) const {return nullptr;}
 
    // DataMemberInfo interface
    virtual int    DataMemberInfo_ArrayDim(DataMemberInfo_t * /* dminfo */) const {return 0;}
    virtual void   DataMemberInfo_Delete(DataMemberInfo_t * /* dminfo */) const {;}
-   virtual DataMemberInfo_t  *DataMemberInfo_Factory(ClassInfo_t * /* clinfo */ = 0) const {return 0;}
+   virtual DataMemberInfo_t  *DataMemberInfo_Factory(ClassInfo_t * /* clinfo */ = nullptr) const {return nullptr;}
    virtual DataMemberInfo_t  *DataMemberInfo_Factory(DeclId_t declid, ClassInfo_t* clinfo) const = 0;
-   virtual DataMemberInfo_t  *DataMemberInfo_FactoryCopy(DataMemberInfo_t * /* dminfo */) const {return 0;}
+   virtual DataMemberInfo_t  *DataMemberInfo_FactoryCopy(DataMemberInfo_t * /* dminfo */) const {return nullptr;}
    virtual Bool_t DataMemberInfo_IsValid(DataMemberInfo_t * /* dminfo */) const {return 0;}
    virtual int    DataMemberInfo_MaxIndex(DataMemberInfo_t * /* dminfo */, Int_t  /* dim */) const {return 0;}
    virtual int    DataMemberInfo_Next(DataMemberInfo_t * /* dminfo */) const {return 0;}
@@ -432,11 +432,11 @@ public:
    virtual Long_t DataMemberInfo_Property(DataMemberInfo_t * /* dminfo */) const {return 0;}
    virtual Long_t DataMemberInfo_TypeProperty(DataMemberInfo_t * /* dminfo */) const {return 0;}
    virtual int    DataMemberInfo_TypeSize(DataMemberInfo_t * /* dminfo */) const {return 0;}
-   virtual const char *DataMemberInfo_TypeName(DataMemberInfo_t * /* dminfo */) const {return 0;}
-   virtual const char *DataMemberInfo_TypeTrueName(DataMemberInfo_t * /* dminfo */) const {return 0;}
-   virtual const char *DataMemberInfo_Name(DataMemberInfo_t * /* dminfo */) const {return 0;}
-   virtual const char *DataMemberInfo_Title(DataMemberInfo_t * /* dminfo */) const {return 0;}
-   virtual const char *DataMemberInfo_ValidArrayIndex(DataMemberInfo_t * /* dminfo */) const {return 0;}
+   virtual const char *DataMemberInfo_TypeName(DataMemberInfo_t * /* dminfo */) const {return nullptr;}
+   virtual const char *DataMemberInfo_TypeTrueName(DataMemberInfo_t * /* dminfo */) const {return nullptr;}
+   virtual const char *DataMemberInfo_Name(DataMemberInfo_t * /* dminfo */) const {return nullptr;}
+   virtual const char *DataMemberInfo_Title(DataMemberInfo_t * /* dminfo */) const {return nullptr;}
+   virtual const char *DataMemberInfo_ValidArrayIndex(DataMemberInfo_t * /* dminfo */) const {return nullptr;}
 
    // Function Template interface
    virtual void   FuncTempInfo_Delete(FuncTempInfo_t * /* ft_info */) const = 0;
@@ -452,67 +452,67 @@ public:
    // MethodInfo interface
    virtual void   MethodInfo_CreateSignature(MethodInfo_t * /* minfo */, TString & /* signature */) const {;}
    virtual void   MethodInfo_Delete(MethodInfo_t * /* minfo */) const {;}
-   virtual MethodInfo_t  *MethodInfo_Factory() const {return 0;}
-   virtual MethodInfo_t  *MethodInfo_Factory(ClassInfo_t * /*clinfo*/) const {return 0;}
+   virtual MethodInfo_t  *MethodInfo_Factory() const {return nullptr;}
+   virtual MethodInfo_t  *MethodInfo_Factory(ClassInfo_t * /*clinfo*/) const {return nullptr;}
    virtual MethodInfo_t  *MethodInfo_Factory(DeclId_t declid) const = 0;
-   virtual MethodInfo_t  *MethodInfo_FactoryCopy(MethodInfo_t * /* minfo */) const {return 0;}
-   virtual void  *MethodInfo_InterfaceMethod(MethodInfo_t * /* minfo */) const {return 0;}
+   virtual MethodInfo_t  *MethodInfo_FactoryCopy(MethodInfo_t * /* minfo */) const {return nullptr;}
+   virtual void  *MethodInfo_InterfaceMethod(MethodInfo_t * /* minfo */) const {return nullptr;}
    virtual Bool_t MethodInfo_IsValid(MethodInfo_t * /* minfo */) const {return 0;}
    virtual int    MethodInfo_NArg(MethodInfo_t * /* minfo */) const {return 0;}
    virtual int    MethodInfo_NDefaultArg(MethodInfo_t * /* minfo */) const {return 0;}
    virtual int    MethodInfo_Next(MethodInfo_t * /* minfo */) const {return 0;}
    virtual Long_t MethodInfo_Property(MethodInfo_t * /* minfo */) const = 0;
    virtual Long_t MethodInfo_ExtraProperty(MethodInfo_t * /* minfo */) const = 0;
-   virtual TypeInfo_t  *MethodInfo_Type(MethodInfo_t * /* minfo */) const {return 0;}
+   virtual TypeInfo_t  *MethodInfo_Type(MethodInfo_t * /* minfo */) const {return nullptr;}
    virtual EReturnType MethodInfo_MethodCallReturnType(MethodInfo_t* minfo) const = 0;
-   virtual const char *MethodInfo_GetMangledName(MethodInfo_t * /* minfo */) const {return 0;}
-   virtual const char *MethodInfo_GetPrototype(MethodInfo_t * /* minfo */) const {return 0;}
-   virtual const char *MethodInfo_Name(MethodInfo_t * /* minfo */) const {return 0;}
-   virtual const char *MethodInfo_TypeName(MethodInfo_t * /* minfo */) const {return 0;}
+   virtual const char *MethodInfo_GetMangledName(MethodInfo_t * /* minfo */) const {return nullptr;}
+   virtual const char *MethodInfo_GetPrototype(MethodInfo_t * /* minfo */) const {return nullptr;}
+   virtual const char *MethodInfo_Name(MethodInfo_t * /* minfo */) const {return nullptr;}
+   virtual const char *MethodInfo_TypeName(MethodInfo_t * /* minfo */) const {return nullptr;}
    virtual std::string MethodInfo_TypeNormalizedName(MethodInfo_t * /* minfo */) const {return "";}
-   virtual const char *MethodInfo_Title(MethodInfo_t * /* minfo */) const {return 0;}
+   virtual const char *MethodInfo_Title(MethodInfo_t * /* minfo */) const {return nullptr;}
 
    // MethodArgInfo interface
    virtual void   MethodArgInfo_Delete(MethodArgInfo_t * /* marginfo */) const {;}
-   virtual MethodArgInfo_t  *MethodArgInfo_Factory() const {return 0;}
-   virtual MethodArgInfo_t  *MethodArgInfo_Factory(MethodInfo_t * /*minfo*/) const {return 0;}
-   virtual MethodArgInfo_t  *MethodArgInfo_FactoryCopy(MethodArgInfo_t * /* marginfo */) const {return 0;}
+   virtual MethodArgInfo_t  *MethodArgInfo_Factory() const {return nullptr;}
+   virtual MethodArgInfo_t  *MethodArgInfo_Factory(MethodInfo_t * /*minfo*/) const {return nullptr;}
+   virtual MethodArgInfo_t  *MethodArgInfo_FactoryCopy(MethodArgInfo_t * /* marginfo */) const {return nullptr;}
    virtual Bool_t MethodArgInfo_IsValid(MethodArgInfo_t * /* marginfo */) const {return 0;}
    virtual int    MethodArgInfo_Next(MethodArgInfo_t * /* marginfo */) const {return 0;}
    virtual Long_t MethodArgInfo_Property(MethodArgInfo_t * /* marginfo */) const {return 0;}
-   virtual const char *MethodArgInfo_DefaultValue(MethodArgInfo_t * /* marginfo */) const {return 0;}
-   virtual const char *MethodArgInfo_Name(MethodArgInfo_t * /* marginfo */) const {return 0;}
-   virtual const char *MethodArgInfo_TypeName(MethodArgInfo_t * /* marginfo */) const {return 0;}
+   virtual const char *MethodArgInfo_DefaultValue(MethodArgInfo_t * /* marginfo */) const {return nullptr;}
+   virtual const char *MethodArgInfo_Name(MethodArgInfo_t * /* marginfo */) const {return nullptr;}
+   virtual const char *MethodArgInfo_TypeName(MethodArgInfo_t * /* marginfo */) const {return nullptr;}
    virtual std::string MethodArgInfo_TypeNormalizedName(MethodArgInfo_t * /* marginfo */) const = 0;
 
 
    // TypeInfo interface
    virtual void    TypeInfo_Delete(TypeInfo_t * /* tinfo */) const {;}
-   virtual TypeInfo_t *TypeInfo_Factory() const {return 0;}
-   virtual TypeInfo_t *TypeInfo_Factory(const char* /* name */) const {return 0;}
-   virtual TypeInfo_t *TypeInfo_FactoryCopy(TypeInfo_t * /* tinfo */) const {return 0;}
+   virtual TypeInfo_t *TypeInfo_Factory() const {return nullptr;}
+   virtual TypeInfo_t *TypeInfo_Factory(const char* /* name */) const {return nullptr;}
+   virtual TypeInfo_t *TypeInfo_FactoryCopy(TypeInfo_t * /* tinfo */) const {return nullptr;}
    virtual void   TypeInfo_Init(TypeInfo_t * /* tinfo */, const char * /* funcname */) const {;}
    virtual Bool_t TypeInfo_IsValid(TypeInfo_t * /* tinfo */) const {return 0;}
-   virtual const char *TypeInfo_Name(TypeInfo_t * /* info */) const {return 0;}
+   virtual const char *TypeInfo_Name(TypeInfo_t * /* info */) const {return nullptr;}
    virtual Long_t TypeInfo_Property(TypeInfo_t * /* tinfo */) const {return 0;}
    virtual int    TypeInfo_RefType(TypeInfo_t * /* tinfo */) const {return 0;}
    virtual int    TypeInfo_Size(TypeInfo_t * /* tinfo */) const {return 0;}
-   virtual const char *TypeInfo_TrueName(TypeInfo_t * /* tinfo */) const {return 0;}
+   virtual const char *TypeInfo_TrueName(TypeInfo_t * /* tinfo */) const {return nullptr;}
 
 
    // TypedefInfo interface
    virtual void   TypedefInfo_Delete(TypedefInfo_t * /* tinfo */) const {;}
-   virtual TypedefInfo_t  *TypedefInfo_Factory() const {return 0;}
-   virtual TypedefInfo_t  *TypedefInfo_Factory(const char *) const {return 0;}
-   virtual TypedefInfo_t  *TypedefInfo_FactoryCopy(TypedefInfo_t * /* tinfo */) const {return 0;}
+   virtual TypedefInfo_t  *TypedefInfo_Factory() const {return nullptr;}
+   virtual TypedefInfo_t  *TypedefInfo_Factory(const char *) const {return nullptr;}
+   virtual TypedefInfo_t  *TypedefInfo_FactoryCopy(TypedefInfo_t * /* tinfo */) const {return nullptr;}
    virtual void   TypedefInfo_Init(TypedefInfo_t * /* tinfo */, const char * /* funcname */) const {;}
    virtual Bool_t TypedefInfo_IsValid(TypedefInfo_t * /* tinfo */) const {return 0;}
    virtual int    TypedefInfo_Next(TypedefInfo_t* /*tinfo*/) const {return 0;}
    virtual Long_t TypedefInfo_Property(TypedefInfo_t * /* tinfo */) const {return 0;}
    virtual int    TypedefInfo_Size(TypedefInfo_t * /* tinfo */) const {return 0;}
-   virtual const char *TypedefInfo_TrueName(TypedefInfo_t * /* tinfo */) const {return 0;}
-   virtual const char *TypedefInfo_Name(TypedefInfo_t * /* tinfo */) const {return 0;}
-   virtual const char *TypedefInfo_Title(TypedefInfo_t * /* tinfo */) const {return 0;}
+   virtual const char *TypedefInfo_TrueName(TypedefInfo_t * /* tinfo */) const {return nullptr;}
+   virtual const char *TypedefInfo_Name(TypedefInfo_t * /* tinfo */) const {return nullptr;}
+   virtual const char *TypedefInfo_Title(TypedefInfo_t * /* tinfo */) const {return nullptr;}
 
    static TInterpreter *Instance();
 

--- a/core/meta/inc/TIsAProxy.h
+++ b/core/meta/inc/TIsAProxy.h
@@ -80,7 +80,7 @@ public:
    virtual void SetClass(TClass *cl)                   { fClass = cl; }
    // IsA callback
    virtual TClass* operator()(const void *obj) {
-      return obj==0 ? fClass : ((const T*)obj)->IsA();
+      return obj==nullptr ? fClass : ((const T*)obj)->IsA();
    }
 };
 

--- a/core/meta/inc/TMethodCall.h
+++ b/core/meta/inc/TMethodCall.h
@@ -61,8 +61,8 @@ private:
    Bool_t         fDtorOnly;  //call only dtor and not delete when calling ~xxx
    EReturnType    fRetType;   //method return type
 
-   void Execute(const char *,  const char *, int * /*error*/ = 0) { }    // versions of TObject
-   void Execute(TMethod *, TObjArray *, int * /*error*/ = 0) { }
+   void Execute(const char *,  const char *, int * /*error*/ = nullptr) { }    // versions of TObject
+   void Execute(TMethod *, TObjArray *, int * /*error*/ = nullptr) { }
 
    void InitImplementation(const char *methodname, const char *params, const char *proto, Bool_t objectIsConst, TClass *cl, const ClassInfo_t *cinfo, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch);
 
@@ -123,22 +123,22 @@ public:
    void     Execute(Double_t &retDouble);
    void     Execute(const char *params, Double_t &retDouble);
 
-   void     Execute(void *objAddress, const void* args[], int nargs, void *ret = 0);
+   void     Execute(void *objAddress, const void* args[], int nargs, void *ret = nullptr);
 
    ClassDef(TMethodCall,0)  //Method calling interface
 };
 
 inline void TMethodCall::Execute()
-   { Execute((void *)0); }
+   { Execute((void *)nullptr); }
 inline void TMethodCall::Execute(const char *params)
-   { Execute((void *)0, params); }
+   { Execute((void *)nullptr, params); }
 inline void TMethodCall::Execute(Long_t &retLong)
-   { Execute((void *)0, retLong); }
+   { Execute((void *)nullptr, retLong); }
 inline void TMethodCall::Execute(const char *params, Long_t &retLong)
-   { Execute((void *)0, params, retLong); }
+   { Execute((void *)nullptr, params, retLong); }
 inline void TMethodCall::Execute(Double_t &retDouble)
-   { Execute((void *)0, retDouble); }
+   { Execute((void *)nullptr, retDouble); }
 inline void TMethodCall::Execute(const char *params, Double_t &retDouble)
-   { Execute((void *)0, params, retDouble); }
+   { Execute((void *)nullptr, params, retDouble); }
 
 #endif

--- a/core/meta/inc/TSchemaHelper.h
+++ b/core/meta/inc/TSchemaHelper.h
@@ -22,7 +22,7 @@ namespace Internal {
    {
       TSchemaHelper(): fTarget(), fSourceClass(),
        fSource(), fCode(), fVersion(), fChecksum(),
-       fInclude(), fEmbed(true), fFunctionPtr( 0 ),
+       fInclude(), fEmbed(true), fFunctionPtr( nullptr ),
        fAttributes() {}
       std::string fTarget;
       std::string fSourceClass;

--- a/core/meta/src/TProtoClass.cxx
+++ b/core/meta/src/TProtoClass.cxx
@@ -99,8 +99,8 @@ TProtoClass::TProtoClass(TClass* cl):
          fPRealData.push_back(protoRealData);
       }
 
-      if (gDebug > 2) {
-         for (auto data : fPRealData) {
+      // if (gDebug > 2) {
+         // for (const auto &data : fPRealData) {
             // const auto classType = dataPtr->IsA();
             // const auto dataName = data.fName;
             // const auto dataClass = data.fClass;
@@ -112,8 +112,8 @@ TProtoClass::TProtoClass(TClass* cl):
             //    Info("TProtoClass","Data is a objectstring: %s", dataPtrName);
             // if (dataPtr->TestBit(TRealData::kTransient))
             //    Info("TProtoClass","And is transient");
-         }
-      }
+         // }
+      // }
    }
 
    // this crashes

--- a/geom/geom/src/TGeoArb8.cxx
+++ b/geom/geom/src/TGeoArb8.cxx
@@ -369,8 +369,8 @@ void TGeoArb8::ComputeTwist()
    illegal_cross = TGeoShape::IsSegCrossing(fXY[0][0],fXY[0][1],fXY[1][0],fXY[1][1],
                                             fXY[2][0],fXY[2][1],fXY[3][0],fXY[3][1]);
    if (!illegal_cross)
-   illegal_cross = TGeoShape::IsSegCrossing(fXY[4][0],fXY[4][1],fXY[5][0],fXY[5][1],
-                                            fXY[6][0],fXY[6][1],fXY[7][0],fXY[7][1]);
+      illegal_cross = TGeoShape::IsSegCrossing(fXY[4][0],fXY[4][1],fXY[5][0],fXY[5][1],
+                                               fXY[6][0],fXY[6][1],fXY[7][0],fXY[7][1]);
    if (illegal_cross) {
       Error("ComputeTwist", "Shape %s type Arb8: Malformed polygon with crossing opposite segments", GetName());
       InspectShape();

--- a/geom/geom/src/TGeoPhysicalNode.cxx
+++ b/geom/geom/src/TGeoPhysicalNode.cxx
@@ -570,7 +570,6 @@ TGeoPNEntry::TGeoPNEntry(const char *name, const char *path)
       TString errmsg("Cannot define a physical node link without a closed geometry and a valid path !");
       Error("ctor", "%s", errmsg.Data());
       throw errmsg;
-      return;
    }
    gGeoManager->PushPath();
    gGeoManager->cd(path);

--- a/geom/geom/src/TGeoVolume.cxx
+++ b/geom/geom/src/TGeoVolume.cxx
@@ -1082,7 +1082,7 @@ void TGeoVolume::AddNodeOverlap(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat,
    node->SetNumber(copy_no);
    node->SetOverlapping();
    if (vol->GetMedium() == fMedium)
-   node->SetVirtual();
+      node->SetVirtual();
    vol->Grab();
 }
 

--- a/graf2d/gpad/inc/TCanvas.h
+++ b/graf2d/gpad/inc/TCanvas.h
@@ -143,7 +143,7 @@ public:
    Int_t             GetEventY() const { return fEventY; }
    Color_t           GetHighLightColor() const { return fHighLightColor; }
    TVirtualPad      *GetPadSave() const { return fPadSave; }
-   void              ClearPadSave() { fPadSave = 0; }
+   void              ClearPadSave() { fPadSave = nullptr; }
    TObject          *GetSelected() const {return fSelected;}
    TObject          *GetClickSelected() const {return fClickSelected;}
    Int_t             GetSelectedX() const {return fSelectedX;}

--- a/graf2d/gpad/inc/TPad.h
+++ b/graf2d/gpad/inc/TPad.h
@@ -310,7 +310,7 @@ public:
    virtual void      RangeAxisChanged() { Emit("RangeAxisChanged()"); } // *SIGNAL*
    virtual void      RecursiveRemove(TObject *obj);
    virtual void      RedrawAxis(Option_t *option="");
-   virtual void      ResetView3D(TObject *view=0){fPadView3D=view;}
+   virtual void      ResetView3D(TObject *view=nullptr){fPadView3D=view;}
    virtual void      ResizePad(Option_t *option="");
    virtual void      Resized() { Emit("Resized()"); } // *SIGNAL*
    virtual void      SaveAs(const char *filename="",Option_t *option="") const; // *MENU*
@@ -352,7 +352,7 @@ public:
    virtual void      SetPhi(Double_t phi=30) {fPhi = phi; Modified();}
    virtual void      SetToolTipText(const char *text, Long_t delayms = 1000);
    virtual void      SetVertical(Bool_t vert=kTRUE);
-   virtual void      SetView(TView *view = 0);
+   virtual void      SetView(TView *view = nullptr);
    virtual void      SetViewer3D(TVirtualViewer3D *viewer3d) {fViewer3D = viewer3d;}
 
    virtual void      SetGLDevice(Int_t dev) {fGLDevice = dev;}

--- a/graf2d/gpad/src/TPadPainter.cxx
+++ b/graf2d/gpad/src/TPadPainter.cxx
@@ -572,9 +572,9 @@ void TPadPainter::SaveImage(TVirtualPad *pad, const char *fileName, Int_t type) 
       const std::unique_ptr<unsigned char[]>
                pixelData(gVirtualX->GetColorBits(canvas->GetCanvasID(), 0, 0, w, h));
 
-      if (pixelData.get()) {
+      if (pixelData) {
          const std::unique_ptr<TImage> image(TImage::Create());
-         if (image.get()) {
+         if (image) {
             image->DrawRectangle(0, 0, w, h);
             if (unsigned char *argb = (unsigned char *)image->GetArgbArray()) {
                //Ohhh.
@@ -609,7 +609,7 @@ void TPadPainter::SaveImage(TVirtualPad *pad, const char *fileName, Int_t type) 
       gVirtualX->WriteGIF((char*)fileName);
    } else {
       const std::unique_ptr<TImage> img(TImage::Create());
-      if (img.get()) {
+      if (img) {
          img->FromPad(pad);
          img->WriteImage(fileName, (TImage::EImageFileTypes)type);
       }

--- a/graf2d/gpad/v7/src/TCanvas.cxx
+++ b/graf2d/gpad/v7/src/TCanvas.cxx
@@ -106,8 +106,7 @@ void ROOT::Experimental::TCanvas::Show(const std::string &where)
 
 void ROOT::Experimental::TCanvas::Hide()
 {
-   if (fPainter)
-      delete fPainter.release();
+   fPainter = nullptr;
 }
 
 void ROOT::Experimental::TCanvas::SaveAs(const std::string &filename, bool async, CanvasCallback_t callback)

--- a/graf2d/graf/inc/TAttImage.h
+++ b/graf2d/graf/inc/TAttImage.h
@@ -100,7 +100,7 @@ public:
                      { fImageQuality = lquality;} // *SUBMENU*
    virtual void     SetPalette(const TImagePalette *palette);
    virtual void     StartPaletteEditor(); // *MENU*
-   virtual void     EditorClosed() { fPaletteEditor = 0; }
+   virtual void     EditorClosed() { fPaletteEditor = nullptr; }
    Bool_t           IsPaletteEnabled() const { return fPaletteEnabled; }
 
    ClassDef(TAttImage,1)  //Image attributes

--- a/graf2d/graf/inc/TImage.h
+++ b/graf2d/graf/inc/TImage.h
@@ -108,14 +108,14 @@ public:
    virtual ~TImage() { }
 
    // Cloning
-   virtual TObject *Clone(const char *) const { return 0; }
+   virtual TObject *Clone(const char *) const { return nullptr; }
 
    // Input / output
    virtual void ReadImage(const char * /*file*/, EImageFileTypes /*type*/ = TImage::kUnknown) {}
    virtual void WriteImage(const char * /*file*/, EImageFileTypes /*type*/ = TImage::kUnknown)  {}
-   virtual void SetImage(const Double_t * /*imageData*/, UInt_t /*width*/, UInt_t /*height*/, TImagePalette * /*palette*/ = 0) {}
-   virtual void SetImage(const TArrayD & /*imageData*/, UInt_t /*width*/, TImagePalette * /*palette*/ = 0) {}
-   virtual void SetImage(const TVectorD & /*imageData*/, UInt_t /*width*/, TImagePalette * /*palette*/ = 0) {}
+   virtual void SetImage(const Double_t * /*imageData*/, UInt_t /*width*/, UInt_t /*height*/, TImagePalette * /*palette*/ = nullptr) {}
+   virtual void SetImage(const TArrayD & /*imageData*/, UInt_t /*width*/, TImagePalette * /*palette*/ = nullptr) {}
+   virtual void SetImage(const TVectorD & /*imageData*/, UInt_t /*width*/, TImagePalette * /*palette*/ = nullptr) {}
    virtual void SetImage(Pixmap_t /*pxm*/, Pixmap_t /*mask*/ = 0) {}
 
    // Create an image from the given pad. (See TASImage::FromPad)
@@ -158,14 +158,14 @@ public:
    virtual void Blur(Double_t /*horizontal*/ = 3, Double_t /*vertical*/ = 3) { }
 
    // Reduces colordepth of an image. (See TASImage::Vectorize)
-   virtual Double_t *Vectorize(UInt_t /*max_colors*/ = 256, UInt_t /*dither*/ = 4, Int_t /*opaque_threshold*/ = 0) { return 0; }
+   virtual Double_t *Vectorize(UInt_t /*max_colors*/ = 256, UInt_t /*dither*/ = 4, Int_t /*opaque_threshold*/ = 0) { return nullptr; }
 
    // (See TASImage::HSV)
    virtual void HSV(UInt_t /*hue*/ = 0, UInt_t /*radius*/ = 360, Int_t /*H*/ = 0, Int_t /*S*/ = 0, Int_t /*V*/ = 0,
                     Int_t /*x*/ = 0, Int_t /*y*/ = 0, UInt_t /*width*/ = 0, UInt_t /*height*/ = 0) {}
 
    // Render multipoint gradient inside a rectangle. (See TASImage::Gradient)
-   virtual void Gradient(UInt_t /*angle*/ = 0, const char * /*colors*/ = "#FFFFFF #000000", const char * /*offsets*/ = 0,
+   virtual void Gradient(UInt_t /*angle*/ = 0, const char * /*colors*/ = "#FFFFFF #000000", const char * /*offsets*/ = nullptr,
                          Int_t /*x*/ = 0, Int_t /*y*/ = 0, UInt_t /*width*/ = 0, UInt_t /*height*/ = 0) {}
 
    // Merge two images. (See TASImage::Merge)
@@ -189,7 +189,7 @@ public:
                          const char * /*col*/ = "#000000", UInt_t /*thick*/ = 1, Int_t /*mode*/ = 0) {}
    virtual void DrawRectangle(UInt_t /*x*/, UInt_t /*y*/, UInt_t /*w*/, UInt_t /*h*/,
                               const char * /*col*/ = "#000000", UInt_t /*thick*/ = 1) {}
-   virtual void FillRectangle(const char * /*col*/ = 0, Int_t /*x*/ = 0, Int_t /*y*/ = 0,
+   virtual void FillRectangle(const char * /*col*/ = nullptr, Int_t /*x*/ = 0, Int_t /*y*/ = 0,
                               UInt_t /*width*/ = 0, UInt_t /*height*/ = 0) {}
    virtual void DrawPolyLine(UInt_t /*nn*/, TPoint * /*xy*/, const char * /*col*/ = "#000000",
                              UInt_t /*thick*/ = 1, TImage::ECoordMode /*mode*/ = kCoordModeOrigin) {}
@@ -198,24 +198,24 @@ public:
                           TImage::ECoordMode /*mode*/ = kCoordModeOrigin) {}
    virtual void DrawSegments(UInt_t /*nseg*/, Segment_t * /*seg*/, const char * /*col*/ = "#000000", UInt_t /*thick*/ = 1) {}
    virtual void DrawText(Int_t /*x*/ = 0, Int_t /*y*/ = 0, const char * /*text*/ = "", Int_t /*size*/ = 12,
-                         const char * /*color*/ = 0, const char * /*font*/ = "fixed",
-                         EText3DType /*type*/ = TImage::kPlain, const char * /*fore_file*/ = 0, Float_t /*angle*/ = 0) { }
+                         const char * /*color*/ = nullptr, const char * /*font*/ = "fixed",
+                         EText3DType /*type*/ = TImage::kPlain, const char * /*fore_file*/ = nullptr, Float_t /*angle*/ = 0) { }
    virtual void DrawText(TText * /*text*/, Int_t /*x*/ = 0, Int_t /*y*/ = 0) { }
    virtual void FillPolygon(UInt_t /*npt*/, TPoint * /*ppt*/, const char * /*col*/ = "#000000",
-                           const char * /*stipple*/ = 0, UInt_t /*w*/ = 16, UInt_t /*h*/ = 16) {}
+                           const char * /*stipple*/ = nullptr, UInt_t /*w*/ = 16, UInt_t /*h*/ = 16) {}
    virtual void FillPolygon(UInt_t /*npt*/, TPoint * /*ppt*/, TImage * /*tile*/) {}
    virtual void CropPolygon(UInt_t /*npt*/, TPoint * /*ppt*/) {}
    virtual void DrawFillArea(UInt_t /*npt*/, TPoint * /*ppt*/, const char * /*col*/ = "#000000",
-                           const char * /*stipple*/ = 0, UInt_t /*w*/ = 16, UInt_t /*h*/ = 16) {}
+                           const char * /*stipple*/ = nullptr, UInt_t /*w*/ = 16, UInt_t /*h*/ = 16) {}
    virtual void DrawFillArea(UInt_t /*npt*/, TPoint * /*ppt*/, TImage * /*tile*/) {}
    virtual void FillSpans(UInt_t /*npt*/, TPoint * /*ppt*/, UInt_t * /*widths*/,  const char * /*col*/ = "#000000",
-                         const char * /*stipple*/ = 0, UInt_t /*w*/ = 16, UInt_t /*h*/ = 16) {}
+                         const char * /*stipple*/ = nullptr, UInt_t /*w*/ = 16, UInt_t /*h*/ = 16) {}
    virtual void FillSpans(UInt_t /*npt*/, TPoint * /*ppt*/, UInt_t * /*widths*/, TImage * /*tile*/) {}
    virtual void CropSpans(UInt_t /*npt*/, TPoint * /*ppt*/, UInt_t * /*widths*/) {}
    virtual void CopyArea(TImage * /*dst*/, Int_t /*xsrc*/, Int_t /*ysrc*/, UInt_t /*w*/, UInt_t /*h*/,
                          Int_t /*xdst*/ = 0, Int_t /*ydst*/ = 0, Int_t /*gfunc*/ = 3, EColorChan /*chan*/ = kAllChan) {}
    virtual void DrawCellArray(Int_t /*x1*/, Int_t /*y1*/, Int_t /*x2*/, Int_t /*y2*/, Int_t /*nx*/, Int_t /*ny*/, UInt_t * /*ic*/) {}
-   virtual void FloodFill(Int_t /*x*/, Int_t /*y*/, const char * /*col*/, const char * /*min_col*/, const char * /*max_col*/ = 0) {}
+   virtual void FloodFill(Int_t /*x*/, Int_t /*y*/, const char * /*col*/, const char * /*min_col*/, const char * /*max_col*/ = nullptr) {}
    virtual void DrawCubeBezier(Int_t /*x1*/, Int_t /*y1*/, Int_t /*x2*/, Int_t /*y2*/, Int_t /*x3*/, Int_t /*y3*/, const char * /*col*/ = "#000000", UInt_t /*thick*/ = 1) {}
    virtual void DrawStraightEllips(Int_t /*x*/, Int_t /*y*/, Int_t /*rx*/, Int_t /*ry*/, const char * /*col*/ = "#000000", Int_t /*thick*/ = 1) {}
    virtual void DrawCircle(Int_t /*x*/, Int_t /*y*/, Int_t /*r*/, const char * /*col*/ = "#000000", Int_t /*thick*/ = 1) {}
@@ -228,16 +228,16 @@ public:
    virtual UInt_t GetWidth() const { return 0; }
    virtual UInt_t GetHeight() const { return 0; }
    virtual Bool_t IsValid() const { return kTRUE; }
-   virtual TImage *GetScaledImage() const { return 0; }
+   virtual TImage *GetScaledImage() const { return nullptr; }
 
-   virtual TArrayL  *GetPixels(Int_t /*x*/= 0, Int_t /*y*/= 0, UInt_t /*w*/ = 0, UInt_t /*h*/ = 0) { return 0; }
-   virtual TArrayD  *GetArray(UInt_t /*w*/ = 0, UInt_t /*h*/ = 0, TImagePalette * = gWebImagePalette) { return 0; }
+   virtual TArrayL  *GetPixels(Int_t /*x*/= 0, Int_t /*y*/= 0, UInt_t /*w*/ = 0, UInt_t /*h*/ = 0) { return nullptr; }
+   virtual TArrayD  *GetArray(UInt_t /*w*/ = 0, UInt_t /*h*/ = 0, TImagePalette * = gWebImagePalette) { return nullptr; }
    virtual Pixmap_t  GetPixmap() { return 0; }
    virtual Pixmap_t  GetMask() { return 0; }
-   virtual UInt_t   *GetArgbArray() { return 0; }
-   virtual UInt_t   *GetRgbaArray() { return 0; }
-   virtual Double_t *GetVecArray() { return 0; }
-   virtual UInt_t   *GetScanline(UInt_t /*y*/) { return 0; }
+   virtual UInt_t   *GetArgbArray() { return nullptr; }
+   virtual UInt_t   *GetRgbaArray() { return nullptr; }
+   virtual Double_t *GetVecArray() { return nullptr; }
+   virtual UInt_t   *GetScanline(UInt_t /*y*/) { return nullptr; }
    virtual void      GetImageBuffer(char ** /*buffer*/, int* /*size*/, EImageFileTypes /*type*/ = TImage::kPng) {}
    virtual Bool_t    SetImageBuffer(char ** /*buffer*/, EImageFileTypes /*type*/ = TImage::kPng) { return kFALSE; }
    virtual void      PaintImage(Drawable_t /*wid*/, Int_t /*x*/, Int_t /*y*/, Int_t /*xsrc*/ = 0, Int_t /*ysrc*/ = 0, UInt_t /*wsrc*/ = 0, UInt_t /*hsrc*/ = 0, Option_t * /*opt*/ = "") { }
@@ -249,8 +249,8 @@ public:
    static TImage *Open(const char *file, EImageFileTypes type = kUnknown);
    static TImage *Open(char **data);
    static TImage *Open(const char *name, const Double_t *imageData, UInt_t width, UInt_t height, TImagePalette *palette);
-   static TImage *Open(const char *name, const TArrayD &imageData, UInt_t width, TImagePalette *palette = 0);
-   static TImage *Open(const char *name, const TVectorD &imageData, UInt_t width, TImagePalette *palette = 0);
+   static TImage *Open(const char *name, const TArrayD &imageData, UInt_t width, TImagePalette *palette = nullptr);
+   static TImage *Open(const char *name, const TVectorD &imageData, UInt_t width, TImagePalette *palette = nullptr);
 
    TImage    &operator+=(const TImage &i) { Append(&i, "+"); return *this; }
    TImage    &operator/=(const TImage &i) { Append(&i, "/"); return *this; }

--- a/graf2d/graf/inc/TText.h
+++ b/graf2d/graf/inc/TText.h
@@ -55,7 +55,7 @@ public:
    virtual void     GetTextExtent(UInt_t &w, UInt_t &h, const char *text) const;
    virtual void     GetTextExtent(UInt_t &w, UInt_t &h, const wchar_t *text) const;
    virtual void     GetTextAdvance(UInt_t &a, const char *text, const Bool_t kern=kTRUE) const;
-   const void *     GetWcsTitle(void) const;
+   const void *     GetWcsTitle() const;
    Double_t         GetY() const  { return fY; }
 
    virtual void     ls(Option_t *option="") const;

--- a/graf3d/eve/src/TEveElement.cxx
+++ b/graf3d/eve/src/TEveElement.cxx
@@ -1721,7 +1721,7 @@ void TEveElement::DestroyOrWarn()
    {
       Destroy();
    }
-   catch (TEveException& exc)
+   catch (const TEveException& exc)
    {
       Warning(eh, "%s", exc.Data());
    }
@@ -1742,7 +1742,7 @@ void TEveElement::DestroyElements()
          try {
             c->Destroy();
          }
-         catch (TEveException exc) {
+         catch (const TEveException &exc) {
             Warning(eh, "element destruction failed: '%s'.", exc.Data());
             RemoveElement(c);
          }

--- a/graf3d/gl/src/TGLHistPainter.cxx
+++ b/graf3d/gl/src/TGLHistPainter.cxx
@@ -259,7 +259,7 @@ Int_t TGLHistPainter::DistancetoPrimitive(Int_t px, Int_t py)
    //tp]
 
    if (fPlotType == kGLDefaultPlot)
-      return fDefaultPainter.get() ? fDefaultPainter->DistancetoPrimitive(px, py) : 9999;
+      return fDefaultPainter ? fDefaultPainter->DistancetoPrimitive(px, py) : 9999;
    else {
       //Adjust px and py - canvas can have several pads inside, so we need to convert
       //the from canvas' system into pad's.
@@ -296,7 +296,7 @@ Int_t TGLHistPainter::DistancetoPrimitive(Int_t px, Int_t py)
 
 void TGLHistPainter::DrawPanel()
 {
-   if (fDefaultPainter.get())
+   if (fDefaultPainter)
       fDefaultPainter->DrawPanel();
 }
 
@@ -314,7 +314,7 @@ void TGLHistPainter::DrawPanel()
 void TGLHistPainter::ExecuteEvent(Int_t event, Int_t px, Int_t py)
 {
    if (fPlotType == kGLDefaultPlot) {
-      if(fDefaultPainter.get()) {
+      if(fDefaultPainter) {
          fDefaultPainter->ExecuteEvent(event, px, py);
       }
    } else {
@@ -439,7 +439,7 @@ void TGLHistPainter::ExecuteEvent(Int_t event, Int_t px, Int_t py)
 
 TList *TGLHistPainter::GetContourList(Double_t contour)const
 {
-   return fDefaultPainter.get() ? fDefaultPainter->GetContourList(contour) : 0;
+   return fDefaultPainter ? fDefaultPainter->GetContourList(contour) : 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -454,8 +454,8 @@ char *TGLHistPainter::GetObjectInfo(Int_t px, Int_t py)const
 {
    static char errMsg[] = { "TGLHistPainter::GetObjectInfo: Error in a hist painter\n" };
    if (fPlotType == kGLDefaultPlot)
-      return fDefaultPainter.get() ? fDefaultPainter->GetObjectInfo(px, py)
-                                   : errMsg;
+      return fDefaultPainter ? fDefaultPainter->GetObjectInfo(px, py)
+                             : errMsg;
    else {
       TGLUtil::InitializeIfNeeded();
       const Float_t scale = TGLUtil::GetScreenScalingFactor();
@@ -483,7 +483,7 @@ TList *TGLHistPainter::GetStack()const
 Bool_t TGLHistPainter::IsInside(Int_t x, Int_t y)
 {
    if (fPlotType == kGLDefaultPlot)
-      return fDefaultPainter.get() ? fDefaultPainter->IsInside(x, y) : kFALSE;
+      return fDefaultPainter ? fDefaultPainter->IsInside(x, y) : kFALSE;
 
    return kFALSE;
 }
@@ -495,7 +495,7 @@ Bool_t TGLHistPainter::IsInside(Int_t x, Int_t y)
 Bool_t TGLHistPainter::IsInside(Double_t x, Double_t y)
 {
    if (fPlotType == kGLDefaultPlot)
-      return fDefaultPainter.get() ? fDefaultPainter->IsInside(x, y) : kFALSE;
+      return fDefaultPainter ? fDefaultPainter->IsInside(x, y) : kFALSE;
 
    return kFALSE;
 }
@@ -506,7 +506,7 @@ Bool_t TGLHistPainter::IsInside(Double_t x, Double_t y)
 
 void TGLHistPainter::PaintStat(Int_t dostat, TF1 *fit)
 {
-   if (fDefaultPainter.get())
+   if (fDefaultPainter)
       fDefaultPainter->PaintStat(dostat, fit);
 }
 
@@ -518,7 +518,7 @@ void TGLHistPainter::ProcessMessage(const char *m, const TObject *o)
    if (!std::strcmp(m, "SetF3"))
       fF3 = (TF3 *)o;
 
-   if (fDefaultPainter.get())
+   if (fDefaultPainter)
       fDefaultPainter->ProcessMessage(m, o);
 }
 
@@ -529,7 +529,7 @@ void TGLHistPainter::SetHistogram(TH1 *h)
 {
    fHist = h;
 
-   if (fDefaultPainter.get())
+   if (fDefaultPainter)
       fDefaultPainter->SetHistogram(h);
 }
 
@@ -540,7 +540,7 @@ void TGLHistPainter::SetStack(TList *s)
 {
    fStack = s;
 
-   if (fDefaultPainter.get())
+   if (fDefaultPainter)
       fDefaultPainter->SetStack(s);
 }
 
@@ -579,7 +579,7 @@ void TGLHistPainter::Paint(Option_t *o)
       option.Remove(glPos, 2);
    else if (fPlotType != kGLParametricPlot && fPlotType != kGL5D && fPlotType != kGLTH3Composition) {
       gPad->SetCopyGLDevice(kFALSE);
-      if (fDefaultPainter.get())
+      if (fDefaultPainter)
          fDefaultPainter->Paint(o);//option.Data());
       return;
    }
@@ -595,7 +595,7 @@ void TGLHistPainter::Paint(Option_t *o)
       //gPad->SetCopyGLDevice(kFALSE);
       //tp]
 
-      if (fDefaultPainter.get())
+      if (fDefaultPainter)
          fDefaultPainter->Paint(option.Data());
    } else {
       Int_t glContext = gPad->GetGLDevice();
@@ -697,30 +697,30 @@ void TGLHistPainter::CreatePainter(const PlotOption_t &option, const TString &ad
    }
 
    if (option.fPlotType == kGLLegoPlot) {
-      if (!fGLPainter.get()) {
+      if (!fGLPainter) {
          if (dynamic_cast<TH2Poly*>(fHist))
             fGLPainter.reset(new TGLH2PolyPainter(fHist, &fCamera, &fCoord));
          else
             fGLPainter.reset(new TGLLegoPainter(fHist, &fCamera, &fCoord));
       }
    } else if (option.fPlotType == kGLSurfacePlot) {
-      if (!fGLPainter.get())
+      if (!fGLPainter)
          fGLPainter.reset(new TGLSurfacePainter(fHist, &fCamera, &fCoord));
    } else if (option.fPlotType == kGLBoxPlot) {
-      if (!fGLPainter.get())
+      if (!fGLPainter)
          fGLPainter.reset(new TGLBoxPainter(fHist, &fCamera, &fCoord));
    } else if (option.fPlotType == kGLTF3Plot) {
-      if (!fGLPainter.get())
+      if (!fGLPainter)
          fGLPainter.reset(new TGLTF3Painter(fF3, fHist, &fCamera, &fCoord));
    } else if (option.fPlotType == kGLIsoPlot) {
-      if (!fGLPainter.get())
+      if (!fGLPainter)
          fGLPainter.reset(new TGLIsoPainter(fHist, &fCamera, &fCoord));
    } else if (option.fPlotType == kGLVoxel) {
-      if (!fGLPainter.get())
+      if (!fGLPainter)
          fGLPainter.reset(new TGLVoxelPainter(fHist, &fCamera, &fCoord));
    }
 
-   if (fGLPainter.get()) {
+   if (fGLPainter) {
       fPlotType = option.fPlotType;
       fCoord.SetXLog(gPad->GetLogx());
       fCoord.SetYLog(gPad->GetLogy());
@@ -740,7 +740,7 @@ void TGLHistPainter::CreatePainter(const PlotOption_t &option, const TString &ad
 
 void TGLHistPainter::SetShowProjection(const char *option, Int_t nbins)
 {
-   if (fDefaultPainter.get()) fDefaultPainter->SetShowProjection(option, nbins);
+   if (fDefaultPainter) fDefaultPainter->SetShowProjection(option, nbins);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/fitpanel/src/TFitEditor.cxx
+++ b/gui/fitpanel/src/TFitEditor.cxx
@@ -3142,7 +3142,7 @@ void TFitEditor::DoLibrary(Bool_t on)
                if ( fLibGSL->GetState() != kButtonDisabled )
                   fLibGSL->SetState(kButtonUp);
                if ( fLibGenetics->GetState() != kButtonDisabled )
-               fLibGenetics->SetState(kButtonUp);
+                  fLibGenetics->SetState(kButtonUp);
                fStatusBar->SetText("LIB Minuit", 1);
             }
 

--- a/hist/hist/inc/TAxis.h
+++ b/hist/hist/inc/TAxis.h
@@ -97,7 +97,7 @@ public:
    virtual void       Copy(TObject &axis) const;
    virtual void       Delete(Option_t * /*option*/ ="") { }
    virtual Int_t      DistancetoPrimitive(Int_t px, Int_t py);
-   virtual TObject   *DrawClone(Option_t * /*option*/ ="") const {return 0;}
+   virtual TObject   *DrawClone(Option_t * /*option*/ ="") const {return nullptr;}
    virtual void       ExecuteEvent(Int_t event, Int_t px, Int_t py);
    virtual Int_t      FindBin(Double_t x);
    virtual Int_t      FindBin(Double_t x) const { return FindFixBin(x); }

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -403,9 +403,9 @@ public:
    static  Bool_t   DefaultAddToGlobalList(Bool_t on = kTRUE);
    virtual void     Browse(TBrowser *b);
    virtual void     Copy(TObject &f1) const;
-   virtual Double_t Derivative(Double_t x, Double_t *params = 0, Double_t epsilon = 0.001) const;
-   virtual Double_t Derivative2(Double_t x, Double_t *params = 0, Double_t epsilon = 0.001) const;
-   virtual Double_t Derivative3(Double_t x, Double_t *params = 0, Double_t epsilon = 0.001) const;
+   virtual Double_t Derivative(Double_t x, Double_t *params = nullptr, Double_t epsilon = 0.001) const;
+   virtual Double_t Derivative2(Double_t x, Double_t *params = nullptr, Double_t epsilon = 0.001) const;
+   virtual Double_t Derivative3(Double_t x, Double_t *params = nullptr, Double_t epsilon = 0.001) const;
    static  Double_t DerivativeError();
    virtual Int_t    DistancetoPrimitive(Int_t px, Int_t py);
    virtual void     Draw(Option_t *option = "");
@@ -415,8 +415,8 @@ public:
    virtual void     DrawF1(Double_t xmin, Double_t xmax, Option_t *option = "");
    virtual Double_t Eval(Double_t x, Double_t y = 0, Double_t z = 0, Double_t t = 0) const;
    //template <class T> T Eval(T x, T y = 0, T z = 0, T t = 0) const; 
-   virtual Double_t EvalPar(const Double_t *x, const Double_t *params = 0);
-   template <class T> T EvalPar(const T *x, const Double_t *params = 0);
+   virtual Double_t EvalPar(const Double_t *x, const Double_t *params = nullptr);
+   template <class T> T EvalPar(const T *x, const Double_t *params = nullptr);
    virtual Double_t operator()(Double_t x, Double_t y = 0, Double_t z = 0, Double_t t = 0) const;
    template <class T> T operator()(const T *x, const Double_t *params = nullptr);
    virtual void     ExecuteEvent(Int_t event, Int_t px, Int_t py);
@@ -564,10 +564,10 @@ public:
    static  void     InitStandardFunctions();
    virtual Double_t Integral(Double_t a, Double_t b, Double_t epsrel = 1.e-12);
    virtual Double_t IntegralOneDim(Double_t a, Double_t b, Double_t epsrel, Double_t epsabs, Double_t &err);
-   virtual Double_t IntegralError(Double_t a, Double_t b, const Double_t *params = 0, const Double_t *covmat = 0, Double_t epsilon = 1.E-2);
-   virtual Double_t IntegralError(Int_t n, const Double_t *a, const Double_t *b, const Double_t *params = 0, const Double_t *covmat = 0, Double_t epsilon = 1.E-2);
+   virtual Double_t IntegralError(Double_t a, Double_t b, const Double_t *params = nullptr, const Double_t *covmat = nullptr, Double_t epsilon = 1.E-2);
+   virtual Double_t IntegralError(Int_t n, const Double_t *a, const Double_t *b, const Double_t *params = nullptr, const Double_t *covmat = nullptr, Double_t epsilon = 1.E-2);
    // virtual Double_t IntegralFast(const TGraph *g, Double_t a, Double_t b, Double_t *params=0);
-   virtual Double_t IntegralFast(Int_t num, Double_t *x, Double_t *w, Double_t a, Double_t b, Double_t *params = 0, Double_t epsilon = 1e-12);
+   virtual Double_t IntegralFast(Int_t num, Double_t *x, Double_t *w, Double_t a, Double_t b, Double_t *params = nullptr, Double_t epsilon = 1e-12);
    virtual Double_t IntegralMultiple(Int_t n, const Double_t *a, const Double_t *b, Int_t maxpts, Double_t epsrel, Double_t epsabs , Double_t &relerr, Int_t &nfnevl, Int_t &ifail);
    virtual Double_t IntegralMultiple(Int_t n, const Double_t *a, const Double_t *b, Int_t /*minpts*/, Int_t maxpts, Double_t epsrel, Double_t &relerr, Int_t &nfnevl, Int_t &ifail)
    {
@@ -597,7 +597,7 @@ public:
    {
       fChisquare = chi2;
    }
-   virtual void     SetFitResult(const ROOT::Fit::FitResult &result, const Int_t *indpar = 0);
+   virtual void     SetFitResult(const ROOT::Fit::FitResult &result, const Int_t *indpar = nullptr);
    template <class PtrObj, typename MemFn>
    void SetFunction(PtrObj &p, MemFn memFn);
    template <typename Func>
@@ -646,7 +646,7 @@ public:
    virtual void     SetParError(Int_t ipar, Double_t error);
    virtual void     SetParErrors(const Double_t *errors);
    virtual void     SetParLimits(Int_t ipar, Double_t parmin, Double_t parmax);
-   virtual void     SetParent(TObject *p = 0)
+   virtual void     SetParent(TObject *p = nullptr)
    {
       fParent = p;
    }
@@ -671,13 +671,13 @@ public:
    static  void     SetCurrent(TF1 *f1);
 
    //Moments
-   virtual Double_t Moment(Double_t n, Double_t a, Double_t b, const Double_t *params = 0, Double_t epsilon = 0.000001);
-   virtual Double_t CentralMoment(Double_t n, Double_t a, Double_t b, const Double_t *params = 0, Double_t epsilon = 0.000001);
-   virtual Double_t Mean(Double_t a, Double_t b, const Double_t *params = 0, Double_t epsilon = 0.000001)
+   virtual Double_t Moment(Double_t n, Double_t a, Double_t b, const Double_t *params = nullptr, Double_t epsilon = 0.000001);
+   virtual Double_t CentralMoment(Double_t n, Double_t a, Double_t b, const Double_t *params = nullptr, Double_t epsilon = 0.000001);
+   virtual Double_t Mean(Double_t a, Double_t b, const Double_t *params = nullptr, Double_t epsilon = 0.000001)
    {
       return Moment(1, a, b, params, epsilon);
    }
-   virtual Double_t Variance(Double_t a, Double_t b, const Double_t *params = 0, Double_t epsilon = 0.000001)
+   virtual Double_t Variance(Double_t a, Double_t b, const Double_t *params = nullptr, Double_t epsilon = 0.000001)
    {
       return CentralMoment(2, a, b, params, epsilon);
    }
@@ -689,7 +689,7 @@ public:
 
 private:
    template <class T>
-   T EvalParTempl(const T *data, const Double_t *params = 0);
+   T EvalParTempl(const T *data, const Double_t *params = nullptr);
 
 #ifdef R__HAS_VECCORE
    inline double EvalParVec(const Double_t *data, const Double_t *params);

--- a/hist/hist/inc/TFitResultPtr.h
+++ b/hist/hist/inc/TFitResultPtr.h
@@ -31,7 +31,7 @@ class TFitResult;
 class TFitResultPtr {
 public:
 
-   TFitResultPtr(int status = -1): fStatus(status), fPointer(0) {};
+   TFitResultPtr(int status = -1): fStatus(status), fPointer(nullptr) {};
 
    TFitResultPtr(const std::shared_ptr<TFitResult> & p);
 

--- a/hist/hist/inc/TFormula.h
+++ b/hist/hist/inc/TFormula.h
@@ -174,11 +174,11 @@ public:
    Double_t       Eval(Double_t x, Double_t y) const;
    Double_t       Eval(Double_t x, Double_t y , Double_t z) const;
    Double_t       Eval(Double_t x, Double_t y , Double_t z , Double_t t ) const;
-   Double_t       EvalPar(const Double_t *x, const Double_t *params=0) const;
+   Double_t       EvalPar(const Double_t *x, const Double_t *params=nullptr) const;
    // template <class T>
    // T Eval(T x, T y = 0, T z = 0, T t = 0) const;
    template <class T>
-   T EvalPar(const T *x, const Double_t *params = 0) const {
+   T EvalPar(const T *x, const Double_t *params = nullptr) const {
       return  EvalParVec(x, params);
    }
 #ifdef R__HAS_VECCORE

--- a/hist/hist/inc/TGraph.h
+++ b/hist/hist/inc/TGraph.h
@@ -99,9 +99,9 @@ public:
    virtual void          Draw(Option_t *chopt="");
    virtual void          DrawGraph(Int_t n, const Int_t *x, const Int_t *y, Option_t *option="");
    virtual void          DrawGraph(Int_t n, const Float_t *x, const Float_t *y, Option_t *option="");
-   virtual void          DrawGraph(Int_t n, const Double_t *x=0, const Double_t *y=0, Option_t *option="");
+   virtual void          DrawGraph(Int_t n, const Double_t *x=nullptr, const Double_t *y=nullptr, Option_t *option="");
    virtual void          DrawPanel(); // *MENU*
-   virtual Double_t      Eval(Double_t x, TSpline *spline=0, Option_t *option="") const;
+   virtual Double_t      Eval(Double_t x, TSpline *spline=nullptr, Option_t *option="") const;
    virtual void          ExecuteEvent(Int_t event, Int_t px, Int_t py);
    virtual void          Expand(Int_t newsize);
    virtual void          Expand(Int_t newsize, Int_t step);
@@ -128,16 +128,16 @@ public:
    virtual Double_t      GetErrorYlow(Int_t bin)  const;
    Double_t             *GetX()  const {return fX;}
    Double_t             *GetY()  const {return fY;}
-   virtual Double_t     *GetEX() const {return 0;}
-   virtual Double_t     *GetEY() const {return 0;}
-   virtual Double_t     *GetEXhigh() const {return 0;}
-   virtual Double_t     *GetEXlow()  const {return 0;}
-   virtual Double_t     *GetEYhigh() const {return 0;}
-   virtual Double_t     *GetEYlow()  const {return 0;}
-   virtual Double_t     *GetEXlowd()  const {return 0;}
-   virtual Double_t     *GetEXhighd() const {return 0;}
-   virtual Double_t     *GetEYlowd()  const {return 0;}
-   virtual Double_t     *GetEYhighd() const {return 0;}
+   virtual Double_t     *GetEX() const {return nullptr;}
+   virtual Double_t     *GetEY() const {return nullptr;}
+   virtual Double_t     *GetEXhigh() const {return nullptr;}
+   virtual Double_t     *GetEXlow()  const {return nullptr;}
+   virtual Double_t     *GetEYhigh() const {return nullptr;}
+   virtual Double_t     *GetEYlow()  const {return nullptr;}
+   virtual Double_t     *GetEXlowd()  const {return nullptr;}
+   virtual Double_t     *GetEXhighd() const {return nullptr;}
+   virtual Double_t     *GetEYlowd()  const {return nullptr;}
+   virtual Double_t     *GetEYhighd() const {return nullptr;}
    Double_t              GetMaximum()  const {return fMaximum;}
    Double_t              GetMinimum()  const {return fMinimum;}
    TAxis                *GetXaxis() const ;

--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -190,12 +190,12 @@ public:
    static  Bool_t   AddDirectoryStatus();
    virtual void     Browse(TBrowser *b);
    virtual Bool_t   CanExtendAllAxes() const;
-   virtual Double_t Chi2Test(const TH1* h2, Option_t *option = "UU", Double_t *res = 0) const;
-   virtual Double_t Chi2TestX(const TH1* h2, Double_t &chi2, Int_t &ndf, Int_t &igood,Option_t *option = "UU",  Double_t *res = 0) const;
+   virtual Double_t Chi2Test(const TH1* h2, Option_t *option = "UU", Double_t *res = nullptr) const;
+   virtual Double_t Chi2TestX(const TH1* h2, Double_t &chi2, Int_t &ndf, Int_t &igood,Option_t *option = "UU",  Double_t *res = nullptr) const;
    virtual Double_t Chisquare(TF1 * f1, Option_t *option = "") const;
    virtual void     ClearUnderflowAndOverflow();
    virtual Double_t ComputeIntegral(Bool_t onlyPositive = false);
-   TObject*         Clone(const char* newname=0) const;
+   TObject*         Clone(const char* newname=nullptr) const;
    virtual void     Copy(TObject &hnew) const;
    virtual void     DirectoryAutoAdd(TDirectory *);
    virtual Int_t    DistancetoPrimitive(Int_t px, Int_t py);
@@ -249,7 +249,7 @@ public:
    virtual Float_t  GetTickLength(Option_t *axis="X") const;
    virtual Float_t  GetBarOffset() const {return Float_t(0.001*Float_t(fBarOffset));}
    virtual Float_t  GetBarWidth() const  {return Float_t(0.001*Float_t(fBarWidth));}
-   virtual Int_t    GetContour(Double_t *levels=0);
+   virtual Int_t    GetContour(Double_t *levels=nullptr);
    virtual Double_t GetContourLevel(Int_t level) const;
    virtual Double_t GetContourLevelPad(Int_t level) const;
 
@@ -298,7 +298,7 @@ public:
 
    TVirtualHistPainter *GetPainter(Option_t *option="");
 
-   virtual Int_t    GetQuantiles(Int_t nprobSum, Double_t *q, const Double_t *probSum=0);
+   virtual Int_t    GetQuantiles(Int_t nprobSum, Double_t *q, const Double_t *probSum=nullptr);
    virtual Double_t GetRandom() const;
    virtual void     GetStats(Double_t *stats) const;
    virtual Double_t GetStdDev(Int_t axis=1) const;
@@ -339,8 +339,8 @@ public:
    virtual void     Paint(Option_t *option="");
    virtual void     Print(Option_t *option="") const;
    virtual void     PutStats(Double_t *stats);
-   virtual TH1     *Rebin(Int_t ngroup=2, const char*newname="", const Double_t *xbins=0);  // *MENU*
-   virtual TH1     *RebinX(Int_t ngroup=2, const char*newname="") { return Rebin(ngroup,newname, (Double_t*) 0); }
+   virtual TH1     *Rebin(Int_t ngroup=2, const char*newname="", const Double_t *xbins=nullptr);  // *MENU*
+   virtual TH1     *RebinX(Int_t ngroup=2, const char*newname="") { return Rebin(ngroup,newname, (Double_t*) nullptr); }
    virtual void     Rebuild(Option_t *option="");
    virtual void     RecursiveRemove(TObject *obj);
    virtual void     Reset(Option_t *option="");
@@ -370,7 +370,7 @@ public:
    virtual void     SetBuffer(Int_t buffersize, Option_t *option="");
    virtual UInt_t   SetCanExtend(UInt_t extendBitMask);
    virtual void     SetContent(const Double_t *content);
-   virtual void     SetContour(Int_t nlevels, const Double_t *levels=0);
+   virtual void     SetContour(Int_t nlevels, const Double_t *levels=nullptr);
    virtual void     SetContourLevel(Int_t level, Double_t value);
    static  void     SetDefaultBufferSize(Int_t buffersize=1000);
    static  void     SetDefaultSumw2(Bool_t sumw2=kTRUE);

--- a/hist/hist/inc/TH2.h
+++ b/hist/hist/inc/TH2.h
@@ -77,8 +77,8 @@ public:
    virtual void     FillRandom(TH1 *h, Int_t ntimes=5000);
    virtual Int_t    FindFirstBinAbove(Double_t threshold=0, Int_t axis=1) const;
    virtual Int_t    FindLastBinAbove (Double_t threshold=0, Int_t axis=1) const;
-   virtual void     FitSlicesX(TF1 *f1=0,Int_t firstybin=0, Int_t lastybin=-1, Int_t cut=0, Option_t *option="QNR", TObjArray* arr = 0);
-   virtual void     FitSlicesY(TF1 *f1=0,Int_t firstxbin=0, Int_t lastxbin=-1, Int_t cut=0, Option_t *option="QNR", TObjArray* arr = 0);
+   virtual void     FitSlicesX(TF1 *f1=nullptr,Int_t firstybin=0, Int_t lastybin=-1, Int_t cut=0, Option_t *option="QNR", TObjArray* arr = nullptr);
+   virtual void     FitSlicesY(TF1 *f1=nullptr,Int_t firstxbin=0, Int_t lastxbin=-1, Int_t cut=0, Option_t *option="QNR", TObjArray* arr = nullptr);
    virtual Int_t    GetBin(Int_t binx, Int_t biny, Int_t binz = 0) const;
    virtual Double_t GetBinWithContent2(Double_t c, Int_t &binx, Int_t &biny, Int_t firstxbin=1, Int_t lastxbin=-1,Int_t firstybin=1, Int_t lastybin=-1, Double_t maxdiff=0) const;
    virtual Double_t GetBinContent(Int_t bin) const { return TH1::GetBinContent(bin); }
@@ -105,7 +105,7 @@ public:
    virtual Double_t KolmogorovTest(const TH1 *h2, Option_t *option="") const;
    virtual TH2     *RebinX(Int_t ngroup=2, const char *newname=""); // *MENU*
    virtual TH2     *RebinY(Int_t ngroup=2, const char *newname=""); // *MENU*
-   virtual TH2     *Rebin(Int_t ngroup=2, const char*newname="", const Double_t *xbins=0);  // re-implementation of the TH1 function using RebinX
+   virtual TH2     *Rebin(Int_t ngroup=2, const char*newname="", const Double_t *xbins=nullptr);  // re-implementation of the TH1 function using RebinX
    virtual TH2     *Rebin2D(Int_t nxgroup=2, Int_t nygroup=2, const char *newname=""); // *MENU*
       TProfile     *ProfileX(const char *name="_pfx", Int_t firstybin=1, Int_t lastybin=-1, Option_t *option="") const;   // *MENU*
       TProfile     *ProfileY(const char *name="_pfy", Int_t firstxbin=1, Int_t lastxbin=-1, Option_t *option="") const;   // *MENU*

--- a/hist/hist/inc/TProfile.h
+++ b/hist/hist/inc/TProfile.h
@@ -61,7 +61,7 @@ private:
    Int_t Fill(Double_t) { MayNotUse("Fill(Double_t)"); return -1;}
    void FillN(Int_t, const Double_t *, const Double_t *, Int_t) { MayNotUse("FillN(Int_t, Double_t*, Double_t*, Int_t)"); }
    Double_t *GetB()  {return &fBinEntries.fArray[0];}
-   Double_t *GetB2() {return (fBinSumw2.fN ? &fBinSumw2.fArray[0] : 0 ); }
+   Double_t *GetB2() {return (fBinSumw2.fN ? &fBinSumw2.fArray[0] : nullptr ); }
    Double_t *GetW()  {return &fArray[0];}
    Double_t *GetW2() {return &fSumw2.fArray[0];}
    void SetBins(Int_t, Double_t, Double_t, Int_t, Double_t, Double_t)
@@ -121,7 +121,7 @@ public:
    virtual Bool_t   Multiply(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1, Option_t *option=""); // *MENU*
            TH1D    *ProjectionX(const char *name="_px", Option_t *option="e") const;
    virtual void     PutStats(Double_t *stats);
-           TH1     *Rebin(Int_t ngroup=2, const char*newname="", const Double_t *xbins=0);
+           TH1     *Rebin(Int_t ngroup=2, const char*newname="", const Double_t *xbins=nullptr);
    virtual void     Reset(Option_t *option="");
    virtual void     SavePrimitive(std::ostream &out, Option_t *option = "");
    virtual void     Scale(Double_t c1=1, Option_t *option="");

--- a/hist/hist/inc/TSpline.h
+++ b/hist/hist/inc/TSpline.h
@@ -36,13 +36,13 @@ protected:
 
 public:
    TSpline() : fDelta(-1), fXmin(0), fXmax(0),
-      fNp(0), fKstep(kFALSE), fHistogram(0), fGraph(0), fNpx(100) {}
+      fNp(0), fKstep(kFALSE), fHistogram(nullptr), fGraph(nullptr), fNpx(100) {}
    TSpline(const char *title, Double_t delta, Double_t xmin,
       Double_t xmax, Int_t np, Bool_t step) :
       TNamed("Spline",title), TAttFill(0,1),
       fDelta(delta), fXmin(xmin),
       fXmax(xmax), fNp(np), fKstep(step),
-      fHistogram(0), fGraph(0), fNpx(100) {}
+      fHistogram(nullptr), fGraph(nullptr), fNpx(100) {}
    virtual ~TSpline();
 
    virtual void     GetKnot(Int_t i, Double_t &x, Double_t &y) const =0;
@@ -201,26 +201,26 @@ protected:
    void   SetCond(const char *opt);
 
 public:
-   TSpline3() : TSpline() , fPoly(0), fValBeg(0), fValEnd(0),
+   TSpline3() : TSpline() , fPoly(nullptr), fValBeg(0), fValEnd(0),
       fBegCond(-1), fEndCond(-1) {}
    TSpline3(const char *title,
-            Double_t x[], Double_t y[], Int_t n, const char *opt=0,
+            Double_t x[], Double_t y[], Int_t n, const char *opt=nullptr,
             Double_t valbeg=0, Double_t valend=0);
    TSpline3(const char *title,
             Double_t xmin, Double_t xmax,
-            Double_t y[], Int_t n, const char *opt=0,
+            Double_t y[], Int_t n, const char *opt=nullptr,
             Double_t valbeg=0, Double_t valend=0);
    TSpline3(const char *title,
-            Double_t x[], const TF1 *func, Int_t n, const char *opt=0,
+            Double_t x[], const TF1 *func, Int_t n, const char *opt=nullptr,
             Double_t valbeg=0, Double_t valend=0);
    TSpline3(const char *title,
             Double_t xmin, Double_t xmax,
-            const TF1 *func, Int_t n, const char *opt=0,
+            const TF1 *func, Int_t n, const char *opt=nullptr,
             Double_t valbeg=0, Double_t valend=0);
    TSpline3(const char *title,
-            const TGraph *g, const char *opt=0,
+            const TGraph *g, const char *opt=nullptr,
             Double_t valbeg=0, Double_t valend=0);
-   TSpline3(const TH1 *h, const char *opt=0,
+   TSpline3(const TH1 *h, const char *opt=nullptr,
             Double_t valbeg=0, Double_t valend=0);
    TSpline3(const TSpline3&);
    TSpline3& operator=(const TSpline3&);
@@ -257,31 +257,31 @@ protected:
                       const char *cb1, const char *ce1, const char *cb2,
                       const char *ce2);
 public:
-   TSpline5() : TSpline() , fPoly(0) {}
+   TSpline5() : TSpline() , fPoly(nullptr) {}
    TSpline5(const char *title,
             Double_t x[], Double_t y[], Int_t n,
-            const char *opt=0, Double_t b1=0, Double_t e1=0,
+            const char *opt=nullptr, Double_t b1=0, Double_t e1=0,
             Double_t b2=0, Double_t e2=0);
    TSpline5(const char *title,
             Double_t xmin, Double_t xmax,
             Double_t y[], Int_t n,
-            const char *opt=0, Double_t b1=0, Double_t e1=0,
+            const char *opt=nullptr, Double_t b1=0, Double_t e1=0,
             Double_t b2=0, Double_t e2=0);
    TSpline5(const char *title,
             Double_t x[], const TF1 *func, Int_t n,
-            const char *opt=0, Double_t b1=0, Double_t e1=0,
+            const char *opt=nullptr, Double_t b1=0, Double_t e1=0,
             Double_t b2=0, Double_t e2=0);
    TSpline5(const char *title,
             Double_t xmin, Double_t xmax,
             const TF1 *func, Int_t n,
-            const char *opt=0, Double_t b1=0, Double_t e1=0,
+            const char *opt=nullptr, Double_t b1=0, Double_t e1=0,
             Double_t b2=0, Double_t e2=0);
    TSpline5(const char *title,
             const TGraph *g,
-            const char *opt=0, Double_t b1=0, Double_t e1=0,
+            const char *opt=nullptr, Double_t b1=0, Double_t e1=0,
             Double_t b2=0, Double_t e2=0);
    TSpline5(const TH1 *h,
-            const char *opt=0, Double_t b1=0, Double_t e1=0,
+            const char *opt=nullptr, Double_t b1=0, Double_t e1=0,
             Double_t b2=0, Double_t e2=0);
    TSpline5(const TSpline5&);
    TSpline5& operator=(const TSpline5&);

--- a/hist/hist/src/TF1Convolution.cxx
+++ b/hist/hist/src/TF1Convolution.cxx
@@ -78,7 +78,7 @@ void TF1Convolution::InitializeDataMembers(TF1* function1, TF1* function2, Bool_
       function2->Copy(*fnew2);
       fFunction2 = std::unique_ptr<TF1>(fnew2);
    }
-   if (fFunction1.get() == nullptr|| fFunction2.get() == nullptr)
+   if (!fFunction1 || !fFunction2)
       Fatal("InitializeDataMembers","Invalid functions - Abort");
 
    // Set kNotGlobal bit

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -849,7 +849,7 @@ void TFormula::FillDefaults()
    for (int i = 0; i < 9; ++i)
       defvars2[i] = TString::Format("x[%d]",i);
 
-   for (auto var : defvars) {
+   for (const auto &var : defvars) {
       int pos = fVars.size();
       fVars[var] = TFormulaVariable(var, 0, pos);
       fClingVariables.push_back(0);

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -2774,7 +2774,7 @@ const char * TFormula::GetParName(Int_t ipar) const
    }
    Error("GetParName","Parameter with index %d not found !!",ipar);
    //return TString::Format("p%d",ipar);
-   return TString();
+   return "";
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/v7/inc/ROOT/TAxis.hxx
+++ b/hist/hist/v7/inc/ROOT/TAxis.hxx
@@ -247,7 +247,7 @@ public:
 private:
    unsigned int fNBins;         ///< Number of bins including under- and overflow.
    std::string fTitle;          ///< Title of this axis, used for graphics / text.
-   const bool fCanGrow = false; ///< Whether this axis can grow (and thus has no overflow bins).
+   bool fCanGrow = false;       ///< Whether this axis can grow (and thus has no overflow bins).
 };
 
 ///\name TAxisBase::const_iterator comparison operators

--- a/hist/unfold/src/TUnfoldBinning.cxx
+++ b/hist/unfold/src/TUnfoldBinning.cxx
@@ -1415,7 +1415,7 @@ TH1 *TUnfoldBinning::ExtractHistogram
          }
       }
    }
-   delete binMap;
+   delete[] binMap;
    return r;
 }
 

--- a/html/src/TClassDocOutput.cxx
+++ b/html/src/TClassDocOutput.cxx
@@ -419,9 +419,8 @@ Bool_t TClassDocOutput::ClassDotCharts(std::ostream& out)
    gSystem->PrependPathName("inh", filenameInh);
    gSystem->PrependPathName(fHtml->GetOutputDir(), filenameInh);
    filenameInh += "_Inh";
-   if (!CreateDotClassChartInh(filenameInh + ".dot") ||
-      !RunDot(filenameInh, &out))
-   return kFALSE;
+   if (!CreateDotClassChartInh(filenameInh + ".dot") || !RunDot(filenameInh, &out))
+      return kFALSE;
 
    TString filenameInhMem(title);
    gSystem->PrependPathName("inhmem", filenameInhMem);

--- a/interpreter/cling/lib/Interpreter/ForwardDeclPrinter.cpp
+++ b/interpreter/cling/lib/Interpreter/ForwardDeclPrinter.cpp
@@ -104,7 +104,7 @@ namespace cling {
       }
     }
     if (printMacros) {
-      for (auto m : macrodefs) {
+      for (const auto &m : macrodefs) {
         Out() << "#undef " << m << "\n";
       }
     }

--- a/io/io/inc/TBufferFile.h
+++ b/io/io/inc/TBufferFile.h
@@ -62,8 +62,8 @@ protected:
 
    // Default ctor
    TBufferFile() : TBuffer(), fMapCount(0), fMapSize(0),
-               fDisplacement(0),fPidOffset(0), fMap(0), fClassMap(0),
-     fInfo(0), fInfoStack() {}
+               fDisplacement(0),fPidOffset(0), fMap(nullptr), fClassMap(nullptr),
+     fInfo(nullptr), fInfoStack() {}
 
    // TBuffer objects cannot be copied or assigned
    TBufferFile(const TBufferFile &);       ///<  not implemented
@@ -89,7 +89,7 @@ public:
 
    TBufferFile(TBuffer::EMode mode);
    TBufferFile(TBuffer::EMode mode, Int_t bufsiz);
-   TBufferFile(TBuffer::EMode mode, Int_t bufsiz, void *buf, Bool_t adopt = kTRUE, ReAllocCharFun_t reallocfunc = 0);
+   TBufferFile(TBuffer::EMode mode, Int_t bufsiz, void *buf, Bool_t adopt = kTRUE, ReAllocCharFun_t reallocfunc = nullptr);
    virtual ~TBufferFile();
 
    Int_t    GetMapCount() const { return fMapCount; }
@@ -110,10 +110,10 @@ public:
    virtual Int_t      CheckByteCount(UInt_t startpos, UInt_t bcnt, const char *classname);
    virtual void       SetByteCount(UInt_t cntpos, Bool_t packInVersion = kFALSE);
 
-   virtual void       SkipVersion(const TClass *cl = 0);
-   virtual Version_t  ReadVersion(UInt_t *start = 0, UInt_t *bcnt = 0, const TClass *cl = 0);
-   virtual Version_t  ReadVersionNoCheckSum(UInt_t *start = 0, UInt_t *bcnt = 0);
-   virtual Version_t  ReadVersionForMemberWise(const TClass *cl = 0);
+   virtual void       SkipVersion(const TClass *cl = nullptr);
+   virtual Version_t  ReadVersion(UInt_t *start = nullptr, UInt_t *bcnt = nullptr, const TClass *cl = nullptr);
+   virtual Version_t  ReadVersionNoCheckSum(UInt_t *start = nullptr, UInt_t *bcnt = nullptr);
+   virtual Version_t  ReadVersionForMemberWise(const TClass *cl = nullptr);
    virtual UInt_t     WriteVersion(const TClass *cl, Bool_t useBcnt = kFALSE);
    virtual UInt_t     WriteVersionMemberWise(const TClass *cl, Bool_t useBcnt = kFALSE);
 
@@ -127,7 +127,7 @@ public:
    TVirtualStreamerInfo  *GetInfo() {return (TVirtualStreamerInfo*)fInfo;}
    virtual void       ClassBegin(const TClass*, Version_t = -1) {}
    virtual void       ClassEnd(const TClass*) {}
-   virtual void       ClassMember(const char*, const char* = 0, Int_t = -1, Int_t = -1) {}
+   virtual void       ClassMember(const char*, const char* = nullptr, Int_t = -1, Int_t = -1) {}
 
    virtual Int_t      ReadBuf(void *buf, Int_t max);
    virtual void       WriteBuf(const void *buf, Int_t max);
@@ -135,7 +135,7 @@ public:
    virtual char      *ReadString(char *s, Int_t max);
    virtual void       WriteString(const char *s);
 
-   virtual TClass    *ReadClass(const TClass *cl = 0, UInt_t *objTag = 0);
+   virtual TClass    *ReadClass(const TClass *cl = nullptr, UInt_t *objTag = nullptr);
    virtual void       WriteClass(const TClass *cl);
 
    virtual TObject   *ReadObject(const TClass *cl);
@@ -156,10 +156,10 @@ public:
             { fDisplacement =  (Int_t)(Length() - skipped); }
 
    // basic types and arrays of basic types
-   virtual   void     ReadFloat16 (Float_t *f, TStreamerElement *ele=0);
-   virtual   void     WriteFloat16(Float_t *f, TStreamerElement *ele=0);
-   virtual   void     ReadDouble32 (Double_t *d, TStreamerElement *ele=0);
-   virtual   void     WriteDouble32(Double_t *d, TStreamerElement *ele=0);
+   virtual   void     ReadFloat16 (Float_t *f, TStreamerElement *ele=nullptr);
+   virtual   void     WriteFloat16(Float_t *f, TStreamerElement *ele=nullptr);
+   virtual   void     ReadDouble32 (Double_t *d, TStreamerElement *ele=nullptr);
+   virtual   void     WriteDouble32(Double_t *d, TStreamerElement *ele=nullptr);
    virtual   void     ReadWithFactor(Float_t *ptr, Double_t factor, Double_t minvalue);
    virtual   void     ReadWithNbits(Float_t *ptr, Int_t nbits);
    virtual   void     ReadWithFactor(Double_t *ptr, Double_t factor, Double_t minvalue);
@@ -178,8 +178,8 @@ public:
    virtual   Int_t    ReadArray(ULong64_t *&l);
    virtual   Int_t    ReadArray(Float_t   *&f);
    virtual   Int_t    ReadArray(Double_t  *&d);
-   virtual   Int_t    ReadArrayFloat16(Float_t  *&f, TStreamerElement *ele=0);
-   virtual   Int_t    ReadArrayDouble32(Double_t  *&d, TStreamerElement *ele=0);
+   virtual   Int_t    ReadArrayFloat16(Float_t  *&f, TStreamerElement *ele=nullptr);
+   virtual   Int_t    ReadArrayDouble32(Double_t  *&d, TStreamerElement *ele=nullptr);
 
    virtual   Int_t    ReadStaticArray(Bool_t    *b);
    virtual   Int_t    ReadStaticArray(Char_t    *c);
@@ -194,8 +194,8 @@ public:
    virtual   Int_t    ReadStaticArray(ULong64_t *l);
    virtual   Int_t    ReadStaticArray(Float_t   *f);
    virtual   Int_t    ReadStaticArray(Double_t  *d);
-   virtual   Int_t    ReadStaticArrayFloat16(Float_t  *f, TStreamerElement *ele=0);
-   virtual   Int_t    ReadStaticArrayDouble32(Double_t  *d, TStreamerElement *ele=0);
+   virtual   Int_t    ReadStaticArrayFloat16(Float_t  *f, TStreamerElement *ele=nullptr);
+   virtual   Int_t    ReadStaticArrayDouble32(Double_t  *d, TStreamerElement *ele=nullptr);
 
    virtual   void     ReadFastArray(Bool_t    *b, Int_t n);
    virtual   void     ReadFastArray(Char_t    *c, Int_t n);
@@ -211,14 +211,14 @@ public:
    virtual   void     ReadFastArray(ULong64_t *l, Int_t n);
    virtual   void     ReadFastArray(Float_t   *f, Int_t n);
    virtual   void     ReadFastArray(Double_t  *d, Int_t n);
-   virtual   void     ReadFastArrayFloat16(Float_t  *f, Int_t n, TStreamerElement *ele=0);
-   virtual   void     ReadFastArrayDouble32(Double_t  *d, Int_t n, TStreamerElement *ele=0);
+   virtual   void     ReadFastArrayFloat16(Float_t  *f, Int_t n, TStreamerElement *ele=nullptr);
+   virtual   void     ReadFastArrayDouble32(Double_t  *d, Int_t n, TStreamerElement *ele=nullptr);
    virtual   void     ReadFastArrayWithFactor(Float_t *ptr, Int_t n, Double_t factor, Double_t minvalue) ;
    virtual   void     ReadFastArrayWithNbits(Float_t *ptr, Int_t n, Int_t nbits);
    virtual   void     ReadFastArrayWithFactor(Double_t *ptr, Int_t n, Double_t factor, Double_t minvalue);
    virtual   void     ReadFastArrayWithNbits(Double_t *ptr, Int_t n, Int_t nbits) ;
-   virtual   void     ReadFastArray(void  *start , const TClass *cl, Int_t n=1, TMemberStreamer *s=0, const TClass* onFileClass=0 );
-   virtual   void     ReadFastArray(void **startp, const TClass *cl, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s=0, const TClass* onFileClass=0);
+   virtual   void     ReadFastArray(void  *start , const TClass *cl, Int_t n=1, TMemberStreamer *s=nullptr, const TClass* onFileClass=nullptr );
+   virtual   void     ReadFastArray(void **startp, const TClass *cl, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s=nullptr, const TClass* onFileClass=nullptr);
 
    virtual   void     WriteArray(const Bool_t    *b, Int_t n);
    virtual   void     WriteArray(const Char_t    *c, Int_t n);
@@ -233,8 +233,8 @@ public:
    virtual   void     WriteArray(const ULong64_t *l, Int_t n);
    virtual   void     WriteArray(const Float_t   *f, Int_t n);
    virtual   void     WriteArray(const Double_t  *d, Int_t n);
-   virtual   void     WriteArrayFloat16(const Float_t  *f, Int_t n, TStreamerElement *ele=0);
-   virtual   void     WriteArrayDouble32(const Double_t  *d, Int_t n, TStreamerElement *ele=0);
+   virtual   void     WriteArrayFloat16(const Float_t  *f, Int_t n, TStreamerElement *ele=nullptr);
+   virtual   void     WriteArrayDouble32(const Double_t  *d, Int_t n, TStreamerElement *ele=nullptr);
 
    virtual   void     WriteFastArray(const Bool_t    *b, Int_t n);
    virtual   void     WriteFastArray(const Char_t    *c, Int_t n);
@@ -250,14 +250,14 @@ public:
    virtual   void     WriteFastArray(const ULong64_t *l, Int_t n);
    virtual   void     WriteFastArray(const Float_t   *f, Int_t n);
    virtual   void     WriteFastArray(const Double_t  *d, Int_t n);
-   virtual   void     WriteFastArrayFloat16(const Float_t  *f, Int_t n, TStreamerElement *ele=0);
-   virtual   void     WriteFastArrayDouble32(const Double_t  *d, Int_t n, TStreamerElement *ele=0);
-   virtual   void     WriteFastArray(void  *start,  const TClass *cl, Int_t n=1, TMemberStreamer *s=0);
-   virtual   Int_t    WriteFastArray(void **startp, const TClass *cl, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s=0);
+   virtual   void     WriteFastArrayFloat16(const Float_t  *f, Int_t n, TStreamerElement *ele=nullptr);
+   virtual   void     WriteFastArrayDouble32(const Double_t  *d, Int_t n, TStreamerElement *ele=nullptr);
+   virtual   void     WriteFastArray(void  *start,  const TClass *cl, Int_t n=1, TMemberStreamer *s=nullptr);
+   virtual   Int_t    WriteFastArray(void **startp, const TClass *cl, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s=nullptr);
 
-   virtual   void     StreamObject(void *obj, const std::type_info &typeinfo, const TClass* onFileClass = 0 );
-   virtual   void     StreamObject(void *obj, const char *className, const TClass* onFileClass = 0 );
-   virtual   void     StreamObject(void *obj, const TClass *cl, const TClass* onFileClass = 0 );
+   virtual   void     StreamObject(void *obj, const std::type_info &typeinfo, const TClass* onFileClass = nullptr );
+   virtual   void     StreamObject(void *obj, const char *className, const TClass* onFileClass = nullptr );
+   virtual   void     StreamObject(void *obj, const TClass *cl, const TClass* onFileClass = nullptr );
    virtual   void     StreamObject(TObject *obj);
 
    virtual   void     ReadBool(Bool_t       &b);

--- a/io/io/inc/TDirectoryFile.h
+++ b/io/io/inc/TDirectoryFile.h
@@ -45,7 +45,7 @@ protected:
    TList      *fKeys;            ///< Pointer to keys list in memory
 
    virtual void         CleanTargets();
-   void Init(TClass *cl = 0);
+   void Init(TClass *cl = nullptr);
 
 private:
    TDirectoryFile(const TDirectoryFile &directory);  //Directories cannot be copied
@@ -56,17 +56,17 @@ public:
    enum { kCloseDirectory = BIT(7) };
 
    TDirectoryFile();
-   TDirectoryFile(const char *name, const char *title, Option_t *option="", TDirectory* motherDir = 0);
+   TDirectoryFile(const char *name, const char *title, Option_t *option="", TDirectory* motherDir = nullptr);
    virtual ~TDirectoryFile();
    virtual void        Append(TObject *obj, Bool_t replace = kFALSE);
            void        Add(TObject *obj, Bool_t replace = kFALSE) { Append(obj,replace); }
            Int_t       AppendKey(TKey *key);
    virtual void        Browse(TBrowser *b);
-           void        Build(TFile* motherFile = 0, TDirectory* motherDir = 0);
+           void        Build(TFile* motherFile = nullptr, TDirectory* motherDir = nullptr);
    virtual TObject    *CloneObject(const TObject *obj, Bool_t autoadd = kTRUE);
    virtual void        Close(Option_t *option="");
    virtual void        Copy(TObject &) const { MayNotUse("Copy(TObject &)"); }
-   virtual Bool_t      cd(const char *path = 0);
+   virtual Bool_t      cd(const char *path = nullptr);
    virtual void        Delete(const char *namecycle="");
    virtual void        FillBuffer(char *&buffer);
    virtual TKey       *FindKey(const char *keyname) const;
@@ -115,9 +115,9 @@ public:
    virtual void        SetTRefAction(TObject *ref, TObject *parent);
    void                SetWritable(Bool_t writable=kTRUE);
    virtual Int_t       Sizeof() const;
-   virtual Int_t       Write(const char *name=0, Int_t opt=0, Int_t bufsize=0);
-   virtual Int_t       Write(const char *name=0, Int_t opt=0, Int_t bufsize=0) const ;
-   virtual Int_t       WriteTObject(const TObject *obj, const char *name=0, Option_t *option="", Int_t bufsize=0);
+   virtual Int_t       Write(const char *name=nullptr, Int_t opt=0, Int_t bufsize=0);
+   virtual Int_t       Write(const char *name=nullptr, Int_t opt=0, Int_t bufsize=0) const ;
+   virtual Int_t       WriteTObject(const TObject *obj, const char *name=nullptr, Option_t *option="", Int_t bufsize=0);
    virtual Int_t       WriteObjectAny(const void *obj, const char *classname, const char *name, Option_t *option="", Int_t bufsize=0);
    virtual Int_t       WriteObjectAny(const void *obj, const TClass *cl, const char *name, Option_t *option="", Int_t bufsize=0);
    virtual void        WriteDirHeader();

--- a/io/io/inc/TFile.h
+++ b/io/io/inc/TFile.h
@@ -192,7 +192,7 @@ public:
    Long64_t            GetArchiveOffset() const { return fArchiveOffset; }
    Int_t               GetBestBuffer() const;
    virtual Int_t       GetBytesToPrefetch() const;
-   TFileCacheRead     *GetCacheRead(TObject* tree = 0) const;
+   TFileCacheRead     *GetCacheRead(TObject* tree = nullptr) const;
    TFileCacheWrite    *GetCacheWrite() const;
    TArrayC            *GetClassIndex() const { return fClassIndex; }
    Int_t               GetCompressionAlgorithm() const;
@@ -250,7 +250,7 @@ public:
    virtual Int_t       Recover();
    virtual Int_t       ReOpen(Option_t *mode);
    virtual void        Seek(Long64_t offset, ERelativeTo pos = kBeg);
-   virtual void        SetCacheRead(TFileCacheRead *cache, TObject* tree = 0, ECacheAction action = kDisconnect);
+   virtual void        SetCacheRead(TFileCacheRead *cache, TObject* tree = nullptr, ECacheAction action = kDisconnect);
    virtual void        SetCacheWrite(TFileCacheWrite *cache);
    virtual void        SetCompressionAlgorithm(Int_t algorithm=0);
    virtual void        SetCompressionLevel(Int_t level=1);
@@ -263,8 +263,8 @@ public:
    virtual Int_t       Sizeof() const;
    void                SumBuffer(Int_t bufsize);
    virtual Bool_t      WriteBuffer(const char *buf, Int_t len);
-   virtual Int_t       Write(const char *name=0, Int_t opt=0, Int_t bufsiz=0);
-   virtual Int_t       Write(const char *name=0, Int_t opt=0, Int_t bufsiz=0) const;
+   virtual Int_t       Write(const char *name=nullptr, Int_t opt=0, Int_t bufsiz=0);
+   virtual Int_t       Write(const char *name=nullptr, Int_t opt=0, Int_t bufsiz=0) const;
    virtual void        WriteFree();
    virtual void        WriteHeader();
    virtual UShort_t    WriteProcessID(TProcessID *pid);
@@ -279,7 +279,7 @@ public:
                             Int_t netopt = 0);
    static TFile       *Open(TFileOpenHandle *handle);
 
-   static EFileType    GetType(const char *name, Option_t *option = "", TString *prefix = 0);
+   static EFileType    GetType(const char *name, Option_t *option = "", TString *prefix = nullptr);
 
    static EAsyncOpenStatus GetAsyncOpenStatus(const char *name);
    static EAsyncOpenStatus GetAsyncOpenStatus(TFileOpenHandle *handle);
@@ -346,7 +346,7 @@ private:
                                fNetOpt(0), fFile(f) { }
    TFileOpenHandle(const char *n, const char *o, const char *t, Int_t cmp,
                    Int_t no) : TNamed(n,t), fOpt(o), fCompress(cmp),
-                               fNetOpt(no), fFile(0) { }
+                               fNetOpt(no), fFile(nullptr) { }
    TFileOpenHandle(const TFileOpenHandle&);
    TFileOpenHandle& operator=(const TFileOpenHandle&);
 

--- a/io/io/inc/TKey.h
+++ b/io/io/inc/TKey.h
@@ -47,10 +47,10 @@ protected:
    TDirectory *fMotherDir;   ///<!pointer to mother directory
 
    virtual Int_t    Read(const char *name) { return TObject::Read(name); }
-   virtual void     Create(Int_t nbytes, TFile* f = 0);
+   virtual void     Create(Int_t nbytes, TFile* f = nullptr);
            void     Build(TDirectory* motherDir, const char* classname, Long64_t filepos);
    virtual void     Reset(); // Currently only for the use of TBasket.
-   virtual Int_t    WriteFileKeepBuffer(TFile *f = 0);
+   virtual Int_t    WriteFileKeepBuffer(TFile *f = nullptr);
 
 
  public:
@@ -61,7 +61,7 @@ protected:
    TKey(const TString &name, const TString &title, const TClass *cl, Int_t nbytes, TDirectory* motherDir);
    TKey(const TObject *obj, const char *name, Int_t bufsize, TDirectory* motherDir);
    TKey(const void *obj, const TClass *cl, const char *name, Int_t bufsize, TDirectory* motherDir);
-   TKey(Long64_t pointer, Int_t nbytes, TDirectory* motherDir = 0);
+   TKey(Long64_t pointer, Int_t nbytes, TDirectory* motherDir = nullptr);
    virtual ~TKey();
 
    virtual void        Browse(TBrowser *b);
@@ -106,7 +106,7 @@ protected:
    virtual void        SetParent(const TObject *parent);
            void        SetMotherDir(TDirectory* dir) { fMotherDir = dir; }
    virtual Int_t       Sizeof() const;
-   virtual Int_t       WriteFile(Int_t cycle=1, TFile* f = 0);
+   virtual Int_t       WriteFile(Int_t cycle=1, TFile* f = nullptr);
 
    ClassDef(TKey,4); //Header description of a logical record on file.
 };

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -45,7 +45,7 @@ void TBufferMerger::Init(std::unique_ptr<TFile> output)
 
 TBufferMerger::~TBufferMerger()
 {
-   for (auto f : fAttachedFiles)
+   for (const auto &f : fAttachedFiles)
       if (!f.expired()) Fatal("TBufferMerger", " TBufferMergerFiles must be destroyed before the server");
 
    this->Push(nullptr);

--- a/io/xml/inc/TXMLEngine.h
+++ b/io/xml/inc/TXMLEngine.h
@@ -59,8 +59,8 @@ public:
    XMLAttrPointer_t GetNextAttr(XMLAttrPointer_t xmlattr);
    const char *GetAttrName(XMLAttrPointer_t xmlattr);
    const char *GetAttrValue(XMLAttrPointer_t xmlattr);
-   XMLNodePointer_t NewChild(XMLNodePointer_t parent, XMLNsPointer_t ns, const char *name, const char *content = 0);
-   XMLNsPointer_t NewNS(XMLNodePointer_t xmlnode, const char *reference, const char *name = 0);
+   XMLNodePointer_t NewChild(XMLNodePointer_t parent, XMLNsPointer_t ns, const char *name, const char *content = nullptr);
+   XMLNsPointer_t NewNS(XMLNodePointer_t xmlnode, const char *reference, const char *name = nullptr);
    XMLNsPointer_t GetNS(XMLNodePointer_t xmlnode);
    const char *GetNSName(XMLNsPointer_t ns);
    const char *GetNSReference(XMLNsPointer_t ns);
@@ -71,10 +71,10 @@ public:
    Bool_t AddDocComment(XMLDocPointer_t xmldoc, const char *comment);
    Bool_t AddRawLine(XMLNodePointer_t parent, const char *line);
    Bool_t AddDocRawLine(XMLDocPointer_t xmldoc, const char *line);
-   Bool_t AddStyleSheet(XMLNodePointer_t parent, const char *href, const char *type = "text/css", const char *title = 0,
-                        int alternate = -1, const char *media = 0, const char *charset = 0);
+   Bool_t AddStyleSheet(XMLNodePointer_t parent, const char *href, const char *type = "text/css", const char *title = nullptr,
+                        int alternate = -1, const char *media = nullptr, const char *charset = nullptr);
    Bool_t AddDocStyleSheet(XMLDocPointer_t xmldoc, const char *href, const char *type = "text/css",
-                           const char *title = 0, int alternate = -1, const char *media = 0, const char *charset = 0);
+                           const char *title = nullptr, int alternate = -1, const char *media = nullptr, const char *charset = nullptr);
    void UnlinkNode(XMLNodePointer_t node);
    void FreeNode(XMLNodePointer_t xmlnode);
    void UnlinkFreeNode(XMLNodePointer_t xmlnode);
@@ -100,7 +100,7 @@ public:
    XMLNodePointer_t DocGetRootElement(XMLDocPointer_t xmldoc);
    XMLDocPointer_t ParseFile(const char *filename, Int_t maxbuf = 100000);
    XMLDocPointer_t ParseString(const char *xmlstring);
-   Bool_t ValidateVersion(XMLDocPointer_t doc, const char *version = 0);
+   Bool_t ValidateVersion(XMLDocPointer_t doc, const char *version = nullptr);
    Bool_t ValidateDocument(XMLDocPointer_t, Bool_t = kFALSE) { return kFALSE; } // obsolete
    void SaveSingleNode(XMLNodePointer_t xmlnode, TString *res, Int_t layout = 1);
    XMLNodePointer_t ReadSingleNode(const char *src);

--- a/main/src/hadd.cxx
+++ b/main/src/hadd.cxx
@@ -525,7 +525,7 @@ int main( int argc, char **argv )
    };
 
    auto reductionFunc = [&]() {
-      for (auto pf : partialFiles) {
+      for (const auto &pf : partialFiles) {
          fileMerger.AddFile(pf.c_str());
       }
       return mergeFiles(fileMerger);
@@ -544,7 +544,7 @@ int main( int argc, char **argv )
          std::cout << "hadd failed at the parallel stage" << std::endl;
       }
       if (!debug) {
-         for (auto pf : partialFiles) {
+         for (const auto &pf : partialFiles) {
             gSystem->Unlink(pf.c_str());
          }
       }

--- a/math/genvector/src/GenVector_exception.cxx
+++ b/math/genvector/src/GenVector_exception.cxx
@@ -23,8 +23,7 @@ void Throw(GenVector_exception & e) { if (GenVector_exception::fgOn) throw e; }
 
 void GenVector::Throw(const char * s) {
    if (!GenVector_exception::fgOn) return;
-   GenVector_exception e(s);
-   throw e;
+   throw GenVector_exception(s);
 }
 
 

--- a/math/mathcore/inc/TMath.h
+++ b/math/mathcore/inc/TMath.h
@@ -457,7 +457,7 @@ struct Limits {
 
    //Sample quantiles
    void      Quantiles(Int_t n, Int_t nprob, Double_t *x, Double_t *quantiles, Double_t *prob,
-                       Bool_t isSorted=kTRUE, Int_t *index = 0, Int_t type=7);
+                       Bool_t isSorted=kTRUE, Int_t *index = nullptr, Int_t type=7);
 
    // IsInside
    template <typename T> Bool_t IsInside(T xp, T yp, Int_t np, T *x, T *y);
@@ -513,22 +513,22 @@ struct Limits {
 
    //Mean, Geometric Mean, Median, RMS(sigma)
 
-   template <typename T> Double_t Mean(Long64_t n, const T *a, const Double_t *w=0);
+   template <typename T> Double_t Mean(Long64_t n, const T *a, const Double_t *w=nullptr);
    template <typename Iterator> Double_t Mean(Iterator first, Iterator last);
    template <typename Iterator, typename WeightIterator> Double_t Mean(Iterator first, Iterator last, WeightIterator wfirst);
 
    template <typename T> Double_t GeomMean(Long64_t n, const T *a);
    template <typename Iterator> Double_t GeomMean(Iterator first, Iterator last);
 
-   template <typename T> Double_t RMS(Long64_t n, const T *a, const Double_t *w=0);
+   template <typename T> Double_t RMS(Long64_t n, const T *a, const Double_t *w=nullptr);
    template <typename Iterator> Double_t RMS(Iterator first, Iterator last);
    template <typename Iterator, typename WeightIterator> Double_t RMS(Iterator first, Iterator last, WeightIterator wfirst);
 
-   template <typename T> Double_t StdDev(Long64_t n, const T *a, const Double_t * w = 0) { return RMS<T>(n,a,w); }
+   template <typename T> Double_t StdDev(Long64_t n, const T *a, const Double_t * w = nullptr) { return RMS<T>(n,a,w); }
    template <typename Iterator> Double_t StdDev(Iterator first, Iterator last) { return RMS<Iterator>(first,last); }
    template <typename Iterator, typename WeightIterator> Double_t StdDev(Iterator first, Iterator last, WeightIterator wfirst) { return RMS<Iterator,WeightIterator>(first,last,wfirst); }
 
-   template <typename T> Double_t Median(Long64_t n, const T *a,  const Double_t *w=0, Long64_t *work=0);
+   template <typename T> Double_t Median(Long64_t n, const T *a,  const Double_t *w=nullptr, Long64_t *work=nullptr);
 
    //k-th order statistic
    template <class Element, typename Size> Element KOrdStat(Size n, const Element *a, Size k, Size *work = 0);

--- a/math/mathcore/src/Fitter.cxx
+++ b/math/mathcore/src/Fitter.cxx
@@ -620,7 +620,7 @@ bool Fitter::DoLinearFit( ) {
 bool Fitter::CalculateHessErrors() {
    // compute the Hesse errors according to configuration
    // set in the parameters and append value in fit result
-   if (fObjFunction.get() == 0) {
+   if (!fObjFunction) {
       MATH_ERROR_MSG("Fitter::CalculateHessErrors","Objective function has not been set");
       return false;
    }
@@ -700,12 +700,12 @@ bool Fitter::CalculateMinosErrors() {
    // (in DoMinimization) when creating the FItResult if the
    //  FitConfig::MinosErrors() flag is set
 
-   if (!fMinimizer.get() ) {
+   if (!fMinimizer) {
        MATH_ERROR_MSG("Fitter::CalculateMinosErrors","Minimizer does not exist - cannot calculate Minos errors");
        return false;
    }
 
-   if (!fResult.get() || fResult->IsEmpty() ) {
+   if (!fResult || fResult->IsEmpty() ) {
        MATH_ERROR_MSG("Fitter::CalculateMinosErrors","Invalid Fit Result - cannot calculate Minos errors");
        return false;
    }
@@ -773,7 +773,7 @@ bool Fitter::DoInitMinimizer() {
    // create first Minimizer
    // using an auto_Ptr will delete the previous existing one
    fMinimizer = std::shared_ptr<ROOT::Math::Minimizer> ( fConfig.CreateMinimizer() );
-   if (fMinimizer.get() == 0) {
+   if (!fMinimizer) {
       MATH_ERROR_MSG("Fitter::FitFCN","Minimizer cannot be created");
       return false;
    }
@@ -882,7 +882,7 @@ bool Fitter::ApplyWeightCorrection(const ROOT::Math::IMultiGenFunction & loglw2,
    // - the objective function is a likelihood function and Likelihood::UseSumOfWeightSquare()
    //    has been called before
 
-   if (fMinimizer.get() == 0) {
+   if (!fMinimizer) {
       MATH_ERROR_MSG("Fitter::ApplyWeightCorrection","Must perform first a fit before applying the correction");
       return false;
    }

--- a/math/mathcore/src/Fitter.cxx
+++ b/math/mathcore/src/Fitter.cxx
@@ -318,7 +318,7 @@ bool Fitter::EvalFCN() {
       return false;
    }
    // create a Fit result from the fit configuration
-   fResult = std::shared_ptr<ROOT::Fit::FitResult>(new ROOT::Fit::FitResult(fConfig) );
+   fResult = std::make_shared<ROOT::Fit::FitResult>(fConfig);
    // evaluate one time the FCN
    double fcnval = (*fObjFunction)(fResult->GetParams() );
    // update fit result
@@ -811,7 +811,7 @@ bool Fitter::DoMinimization(const ROOT::Math::IMultiGenFunction * chi2func) {
    // unsigned int ncalls =  ObjFuncTrait<ObjFunc>::NCalls(*fcn);
    // int fitType =  ObjFuncTrait<ObjFunc>::Type(objFunc);
 
-   if (!fResult) fResult =  std::shared_ptr<FitResult> ( new FitResult() );
+   if (!fResult) fResult = std::make_shared<FitResult>();
    fResult->FillResult(fMinimizer,fConfig, fFunc, ret, fDataSize, fBinFit, chi2func );
 
    // when possible get ncalls from FCN and set in fit result

--- a/math/mathcore/src/GoFTest.cxx
+++ b/math/mathcore/src/GoFTest.cxx
@@ -178,7 +178,7 @@ namespace Math {
    GoFTest::~GoFTest() {}
 
    void GoFTest::SetSamples(std::vector<const Double_t*> samples, const std::vector<UInt_t> samplesSizes) {
-      fCombinedSamples.assign(std::accumulate(samplesSizes.begin(), samplesSizes.end(), 0), 0.0);
+      fCombinedSamples.assign(std::accumulate(samplesSizes.begin(), samplesSizes.end(), 0u), 0.0);
       UInt_t combinedSamplesSize = 0;
       for (UInt_t i = 0; i < samples.size(); ++i) {
          fSamples[i].assign(samples[i], samples[i] + samplesSizes[i]);

--- a/math/matrix/inc/TMatrixT.h
+++ b/math/matrix/inc/TMatrixT.h
@@ -58,7 +58,7 @@ public:
    enum EMatrixCreatorsOp1 { kZero,kUnit,kTransposed,kInverted,kAtA };
    enum EMatrixCreatorsOp2 { kMult,kTransposeMult,kInvMult,kMultTranspose,kPlus,kMinus };
 
-   TMatrixT(): fDataStack(), fElements(0) { }
+   TMatrixT(): fDataStack(), fElements(nullptr) { }
    TMatrixT(Int_t nrows,Int_t ncols);
    TMatrixT(Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb);
    TMatrixT(Int_t nrows,Int_t ncols,const Element *data,Option_t *option="");
@@ -66,7 +66,7 @@ public:
    TMatrixT(const TMatrixT      <Element> &another);
    TMatrixT(const TMatrixTSym   <Element> &another);
    TMatrixT(const TMatrixTSparse<Element> &another);
-   template <class Element2> TMatrixT(const TMatrixT<Element2> &another): fElements(0)
+   template <class Element2> TMatrixT(const TMatrixT<Element2> &another): fElements(nullptr)
    {
       R__ASSERT(another.IsValid());
       Allocate(another.GetNrows(),another.GetNcols(),another.GetRowLwb(),another.GetColLwb());
@@ -109,16 +109,16 @@ public:
 
    virtual const Element *GetMatrixArray  () const;
    virtual       Element *GetMatrixArray  ();
-   virtual const Int_t   *GetRowIndexArray() const { return 0; }
-   virtual       Int_t   *GetRowIndexArray()       { return 0; }
-   virtual const Int_t   *GetColIndexArray() const { return 0; }
-   virtual       Int_t   *GetColIndexArray()       { return 0; }
+   virtual const Int_t   *GetRowIndexArray() const { return nullptr; }
+   virtual       Int_t   *GetRowIndexArray()       { return nullptr; }
+   virtual const Int_t   *GetColIndexArray() const { return nullptr; }
+   virtual       Int_t   *GetColIndexArray()       { return nullptr; }
 
    virtual       TMatrixTBase<Element> &SetRowIndexArray(Int_t * /*data*/) { MayNotUse("SetRowIndexArray(Int_t *)"); return *this; }
    virtual       TMatrixTBase<Element> &SetColIndexArray(Int_t * /*data*/) { MayNotUse("SetColIndexArray(Int_t *)"); return *this; }
 
    virtual void Clear(Option_t * /*option*/ ="") { if (this->fIsOwner) Delete_m(this->fNelems,fElements);
-                                                   else fElements = 0;
+                                                   else fElements = nullptr;
                                                    this->fNelems = 0; }
 
            TMatrixT    <Element> &Use     (Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb,Element *data);
@@ -144,8 +144,8 @@ public:
    virtual Double_t Determinant  () const;
    virtual void     Determinant  (Double_t &d1,Double_t &d2) const;
 
-           TMatrixT<Element> &Invert      (Double_t *det=0);
-           TMatrixT<Element> &InvertFast  (Double_t *det=0);
+           TMatrixT<Element> &Invert      (Double_t *det=nullptr);
+           TMatrixT<Element> &InvertFast  (Double_t *det=nullptr);
            TMatrixT<Element> &Transpose   (const TMatrixT<Element> &source);
    inline  TMatrixT<Element> &T           () { return this->Transpose(*this); }
            TMatrixT<Element> &Rank1Update (const TVectorT<Element> &v,Element alpha=1.0);

--- a/math/matrix/inc/TMatrixTSym.h
+++ b/math/matrix/inc/TMatrixTSym.h
@@ -81,16 +81,16 @@ public:
 
    virtual const Element *GetMatrixArray  () const;
    virtual       Element *GetMatrixArray  ();
-   virtual const Int_t   *GetRowIndexArray() const { return 0; }
-   virtual       Int_t   *GetRowIndexArray()       { return 0; }
-   virtual const Int_t   *GetColIndexArray() const { return 0; }
-   virtual       Int_t   *GetColIndexArray()       { return 0; }
+   virtual const Int_t   *GetRowIndexArray() const { return nullptr; }
+   virtual       Int_t   *GetRowIndexArray()       { return nullptr; }
+   virtual const Int_t   *GetColIndexArray() const { return nullptr; }
+   virtual       Int_t   *GetColIndexArray()       { return nullptr; }
 
    virtual       TMatrixTBase<Element> &SetRowIndexArray(Int_t * /*data*/) { MayNotUse("SetRowIndexArray(Int_t *)"); return *this; }
    virtual       TMatrixTBase<Element> &SetColIndexArray(Int_t * /*data*/) { MayNotUse("SetColIndexArray(Int_t *)"); return *this; }
 
    virtual void   Clear      (Option_t * /*option*/ ="") { if (this->fIsOwner) Delete_m(this->fNelems,fElements);
-                                                           else fElements = 0;
+                                                           else fElements = nullptr;
                                                            this->fNelems = 0; }
    virtual Bool_t IsSymmetric() const { return kTRUE; }
 
@@ -121,8 +121,8 @@ public:
    virtual Double_t      Determinant   () const;
    virtual void          Determinant   (Double_t &d1,Double_t &d2) const;
 
-           TMatrixTSym<Element>  &Invert        (Double_t *det=0);
-           TMatrixTSym<Element>  &InvertFast    (Double_t *det=0);
+           TMatrixTSym<Element>  &Invert        (Double_t *det=nullptr);
+           TMatrixTSym<Element>  &InvertFast    (Double_t *det=nullptr);
            TMatrixTSym<Element>  &Transpose     (const TMatrixTSym<Element> &source);
    inline  TMatrixTSym<Element>  &T             () { return this->Transpose(*this); }
            TMatrixTSym<Element>  &Rank1Update   (const TVectorT   <Element> &v,Element alpha=1.0);

--- a/math/matrix/inc/TVectorT.h
+++ b/math/matrix/inc/TVectorT.h
@@ -50,7 +50,7 @@ protected:
 
 public:
 
-   TVectorT() : fNrows(0), fRowLwb(0), fElements(0), fDataStack (), fIsOwner(kTRUE) { }
+   TVectorT() : fNrows(0), fRowLwb(0), fElements(nullptr), fDataStack (), fIsOwner(kTRUE) { }
    explicit TVectorT(Int_t n);
    TVectorT(Int_t lwb,Int_t upb);
    TVectorT(Int_t n,const Element *elements);
@@ -172,7 +172,7 @@ public:
    void Add(const TVectorT<Element> &v);
    void Add(const TVectorT<Element> &v1, const TVectorT<Element> &v2);
    void Clear(Option_t * /*option*/ ="") { if (fIsOwner) Delete_m(fNrows,fElements);
-                                           else fElements = 0;
+                                           else fElements = nullptr;
                                            fNrows = 0; }
    void Draw (Option_t *option=""); // *MENU*
    void Print(Option_t *option="") const;  // *MENU*

--- a/math/mlp/inc/TMultiLayerPerceptron.h
+++ b/math/mlp/inc/TMultiLayerPerceptron.h
@@ -53,13 +53,13 @@ class TMultiLayerPerceptron : public TObject {
                           kRibierePolak, kFletcherReeves, kBFGS };
    enum EDataSet { kTraining, kTest };
    TMultiLayerPerceptron();
-   TMultiLayerPerceptron(const char* layout, TTree* data = 0,
+   TMultiLayerPerceptron(const char* layout, TTree* data = nullptr,
                          const char* training = "Entry$%2==0",
                          const char* test = "",
                          TNeuron::ENeuronType type = TNeuron::kSigmoid,
                          const char* extF = "", const char* extD  = "");
    TMultiLayerPerceptron(const char* layout,
-                         const char* weight, TTree* data = 0,
+                         const char* weight, TTree* data = nullptr,
                          const char* training = "Entry$%2==0",
                          const char* test = "",
                          TNeuron::ENeuronType type = TNeuron::kSigmoid,

--- a/net/net/inc/TSecContext.h
+++ b/net/net/inc/TSecContext.h
@@ -60,10 +60,10 @@ public:
 
    TSecContext(const char *url, Int_t meth, Int_t offset,
                const char *id, const char *token,
-               TDatime expdate = kROOTTZERO, void *ctx = 0);
+               TDatime expdate = kROOTTZERO, void *ctx = nullptr);
    TSecContext(const char *user, const char *host, Int_t meth, Int_t offset,
                const char *id, const char *token,
-               TDatime expdate = kROOTTZERO, void *ctx = 0);
+               TDatime expdate = kROOTTZERO, void *ctx = nullptr);
    virtual    ~TSecContext();
 
    void        AddForCleanup(Int_t port, Int_t proto, Int_t type);

--- a/net/net/inc/TSocket.h
+++ b/net/net/inc/TSocket.h
@@ -100,9 +100,9 @@ protected:
    static Int_t  fgClientProtocol; // client "protocol" version
 
    TSocket() : fAddress(), fBytesRecv(0), fBytesSent(0), fCompress(0),
-               fLocalAddress(), fRemoteProtocol(), fSecContext(0), fService(),
+               fLocalAddress(), fRemoteProtocol(), fSecContext(nullptr), fService(),
                fServType(kSOCKD), fSocket(-1), fTcpWindowSize(0), fUrl(),
-               fBitsInfo(), fUUIDs(0), fLastUsageMtx(0), fLastUsage() { }
+               fBitsInfo(), fUUIDs(nullptr), fLastUsageMtx(nullptr), fLastUsage() { }
 
    Bool_t       Authenticate(const char *user);
    void         SetDescriptor(Int_t desc) { fSocket = desc; }
@@ -182,9 +182,9 @@ public:
 
    static TSocket       *CreateAuthSocket(const char *user, const char *host,
                                           Int_t port, Int_t size = 0,
-                                          Int_t tcpwindowsize = -1, TSocket *s = 0, Int_t *err = 0);
+                                          Int_t tcpwindowsize = -1, TSocket *s = nullptr, Int_t *err = nullptr);
    static TSocket       *CreateAuthSocket(const char *url, Int_t size = 0,
-                                          Int_t tcpwindowsize = -1, TSocket *s = 0, Int_t *err = 0);
+                                          Int_t tcpwindowsize = -1, TSocket *s = nullptr, Int_t *err = nullptr);
    static void           NetError(const char *where, Int_t error);
 
    ClassDef(TSocket,0)  //This class implements client sockets

--- a/proof/proof/src/TProof.cxx
+++ b/proof/proof/src/TProof.cxx
@@ -3861,7 +3861,7 @@ Int_t TProof::HandleInputMessage(TSlave *sl, TMessage *mess, Bool_t deactonfail)
                            ourwi->SetSysInfo(slinfo->GetSysInfo());
                            ourwi->fHostName = slinfo->GetName();
                            if (slinfo->GetDataDir() && (strlen(slinfo->GetDataDir()) > 0))
-                           ourwi->fDataDir = slinfo->GetDataDir();
+                              ourwi->fDataDir = slinfo->GetDataDir();
                            break;
                         }
                      }
@@ -10402,10 +10402,10 @@ void TProof::ShowLog(Int_t qry)
    UInt_t tolog = (UInt_t)(endlog - startlog);
 
    // Perhaps nothing
-   if (tolog <= 0)
-
-   // Set starting point
-   lseek(fileno(fLogFileR), startlog, SEEK_SET);
+   if (tolog <= 0) {
+      // Set starting point
+      lseek(fileno(fLogFileR), startlog, SEEK_SET);
+   }
 
    // Now we go
    Int_t np = 0;

--- a/roofit/histfactory/src/hist2workspace.cxx
+++ b/roofit/histfactory/src/hist2workspace.cxx
@@ -73,7 +73,7 @@ int main(int argc, char** argv) {
     try {
       RooStats::HistFactory::fastDriver(input);
     }
-    catch(std::string str) {
+    catch (const std::string& str) {
       std::cerr << "hist2workspace - Caught exception: " << str << std::endl ;
       exit(1);
     }
@@ -94,7 +94,7 @@ int main(int argc, char** argv) {
       try {
 	RooStats::HistFactory::fastDriver(input);
       }
-      catch(std::string str) {
+      catch (const std::string& str) {
 	std::cerr << "hist2workspace - Caught exception: " << str << std::endl ;
 	exit(1);
       }

--- a/roofit/roofit/inc/RooMomentMorphFuncND.h
+++ b/roofit/roofit/inc/RooMomentMorphFuncND.h
@@ -21,10 +21,7 @@
 #include "TMap.h"
 
 #include <vector>
-#include <string>
 #include <map>
-
-using namespace std;
 
 class RooChangeTracker;
 
@@ -47,7 +44,7 @@ public:
          _grid.push_back(binning_y.clone());
          _grid.push_back(binning_z.clone());
       };
-      Grid2(const vector<RooAbsBinning *> binnings)
+      Grid2(const std::vector<RooAbsBinning *> binnings)
       {
          for (unsigned int i = 0; i < binnings.size(); i++) {
             _grid.push_back(binnings[i]->clone());
@@ -59,15 +56,15 @@ public:
       void addPdf(const RooAbsReal &func, int bin_x);
       void addPdf(const RooAbsReal &func, int bin_x, int bin_y);
       void addPdf(const RooAbsReal &func, int bin_x, int bin_y, int bin_z);
-      void addPdf(const RooAbsReal &func, vector<int> bins);
+      void addPdf(const RooAbsReal &func, std::vector<int> bins);
       void addBinning(const RooAbsBinning &binning) { _grid.push_back(binning.clone()); };
 
-      mutable vector<RooAbsBinning *> _grid;
+      mutable std::vector<RooAbsBinning *> _grid;
       mutable RooArgList _pdfList;
-      mutable map<vector<int>, int> _pdfMap;
+      mutable std::map<std::vector<int>, int> _pdfMap;
 
-      mutable vector<vector<double>> _nref;
-      mutable vector<int> _nnuis;
+      mutable std::vector<std::vector<double>> _nref;
+      mutable std::vector<int> _nnuis;
 
       ClassDef(RooMomentMorphFuncND::Grid2, 1)
    };
@@ -124,16 +121,16 @@ protected:
 
    template <typename T>
    struct Digits {
-      typename vector<T>::const_iterator begin;
-      typename vector<T>::const_iterator end;
-      typename vector<T>::const_iterator me;
+      typename std::vector<T>::const_iterator begin;
+      typename std::vector<T>::const_iterator end;
+      typename std::vector<T>::const_iterator me;
    };
 
    template <typename T>
-   static void cartesian_product(vector<vector<T>> &out, vector<vector<T>> &in);
+   static void cartesian_product(std::vector<std::vector<T>> &out, std::vector<std::vector<T>> &in);
    template <typename Iterator>
    static bool next_combination(const Iterator first, Iterator k, const Iterator last);
-   void findShape(const vector<double> &x) const;
+   void findShape(const std::vector<double> &x) const;
 
    friend class CacheElem;
    friend class Grid2;
@@ -151,8 +148,8 @@ protected:
 
    mutable TMatrixD *_M;
    mutable TMatrixD *_MSqr;
-   mutable vector<vector<double>> _squareVec;
-   mutable vector<int> _squareIdx;
+   mutable std::vector<std::vector<double>> _squareVec;
+   mutable std::vector<int> _squareIdx;
 
    Setting _setting;
    Bool_t _useHorizMorph;

--- a/roofit/roofit/inc/RooMomentMorphND.h
+++ b/roofit/roofit/inc/RooMomentMorphND.h
@@ -21,10 +21,7 @@
 #include "TMap.h"
 
 #include <vector>
-#include <string>
 #include <map>
-
-using namespace std;
 
 class RooChangeTracker;
 
@@ -47,7 +44,7 @@ public:
          _grid.push_back(binning_y.clone());
          _grid.push_back(binning_z.clone());
       };
-      Grid(const vector<RooAbsBinning *> binnings)
+      Grid(const std::vector<RooAbsBinning *> binnings)
       {
          for (unsigned int i = 0; i < binnings.size(); i++) {
             _grid.push_back(binnings[i]->clone());
@@ -59,15 +56,15 @@ public:
       void addPdf(const RooAbsPdf &pdf, int bin_x);
       void addPdf(const RooAbsPdf &pdf, int bin_x, int bin_y);
       void addPdf(const RooAbsPdf &pdf, int bin_x, int bin_y, int bin_z);
-      void addPdf(const RooAbsPdf &pdf, vector<int> bins);
+      void addPdf(const RooAbsPdf &pdf, std::vector<int> bins);
       void addBinning(const RooAbsBinning &binning) { _grid.push_back(binning.clone()); };
 
-      mutable vector<RooAbsBinning *> _grid;
+      mutable std::vector<RooAbsBinning *> _grid;
       mutable RooArgList _pdfList;
-      mutable map<vector<int>, int> _pdfMap;
+      mutable std::map<std::vector<int>, int> _pdfMap;
 
-      mutable vector<vector<double>> _nref;
-      mutable vector<int> _nnuis;
+      mutable std::vector<std::vector<double>> _nref;
+      mutable std::vector<int> _nnuis;
    };
 
 protected:
@@ -120,7 +117,7 @@ protected:
    RooAbsPdf *sumPdf(const RooArgSet *nset);
    CacheElem *getCache(const RooArgSet *nset) const;
 
-   void findShape(const vector<double> &x) const;
+   void findShape(const std::vector<double> &x) const;
 
    friend class CacheElem;
    friend class Grid;
@@ -138,8 +135,8 @@ protected:
 
    mutable TMatrixD *_M;
    mutable TMatrixD *_MSqr;
-   mutable vector<vector<double>> _squareVec;
-   mutable vector<int> _squareIdx;
+   mutable std::vector<std::vector<double>> _squareVec;
+   mutable std::vector<int> _squareIdx;
 
    Setting _setting;
    Bool_t _useHorizMorph;

--- a/roofit/roofitcore/src/RooClassFactory.cxx
+++ b/roofit/roofitcore/src/RooClassFactory.cxx
@@ -783,7 +783,7 @@ std::string RooClassFactory::ClassFacIFace::create(RooFactoryWSTool& ft, const c
 	  varList.add(ft.asARG(args[i].c_str())) ;
 	}
       }
-    } catch (string err) {
+    } catch (const string &err) {
       throw string(Form("RooClassFactory::ClassFacIFace::create() ERROR: %s",err.c_str())) ;
     }
 

--- a/roofit/roofitcore/src/RooFactoryWSTool.cxx
+++ b/roofit/roofitcore/src/RooFactoryWSTool.cxx
@@ -410,7 +410,7 @@ RooAbsArg* RooFactoryWSTool::createArg(const char* className, const char* objNam
       }
     }
     cintExpr += ") ;" ;
-  } catch (string err) {
+  } catch (const string &err) {
     coutE(ObjectHandling) << "RooFactoryWSTool::createArg() ERROR constructing " << className << "::" << objName << ": " << err << endl ;
     logError() ;
     return 0 ;
@@ -481,7 +481,7 @@ RooAddPdf* RooFactoryWSTool::add(const char *objName, const char* specList, Bool
     }
     pdfList.add(pdfList2) ;
 
-  } catch (string err) {
+  } catch (const string &err) {
     coutE(ObjectHandling) << "RooFactoryWSTool::add(" << objName << ") ERROR creating RooAddPdf: " << err << endl ;    
     logError() ;
     return 0 ;
@@ -523,7 +523,7 @@ RooRealSumPdf* RooFactoryWSTool::amplAdd(const char *objName, const char* specLi
     }
     amplList.add(amplList2) ;
 
-  } catch (string err) {
+  } catch (const string &err) {
     coutE(ObjectHandling) << "RooFactoryWSTool::add(" << objName << ") ERROR creating RooRealSumPdf: " << err << endl ;    
     logError() ;
     return 0 ;
@@ -565,7 +565,7 @@ RooProdPdf* RooFactoryWSTool::prod(const char *objName, const char* pdfList)
       
       try {
  	cmdList.Add(Conditional(asSET(tok),asSET(sep),!invCond).Clone()) ;
-      } catch (string err) {
+      } catch (const string &err) {
 	coutE(ObjectHandling) << "RooFactoryWSTool::prod(" << objName << ") ERROR creating RooProdPdf Conditional argument: " << err << endl ;
 	logError() ;
 	return 0 ;
@@ -585,7 +585,7 @@ RooProdPdf* RooFactoryWSTool::prod(const char *objName, const char* pdfList)
   RooProdPdf* pdf = 0 ;
   try {
     pdf = new RooProdPdf(objName,objName,asSET(regPdfList.c_str()),cmdList) ;
-  } catch (string err) {
+  } catch (const string &err) {
     coutE(ObjectHandling) << "RooFactoryWSTool::prod(" << objName << ") ERROR creating RooProdPdf input set of regular p.d.f.s: " << err << endl ;
     logError() ;
     pdf = 0 ;
@@ -626,7 +626,7 @@ RooSimultaneous* RooFactoryWSTool::simul(const char* objName, const char* indexC
 
       try {
 	theMap[tok] = &asPDF(eq+1) ;
-      } catch ( string err ) {
+      } catch (const string &err) {
 	coutE(ObjectHandling) << "RooFactoryWSTool::simul(" << objName << ") ERROR creating RooSimultaneous: " << err << endl ;
 	logError() ;
       }
@@ -639,7 +639,7 @@ RooSimultaneous* RooFactoryWSTool::simul(const char* objName, const char* indexC
   RooSimultaneous* pdf(0) ;
   try {
     pdf = new RooSimultaneous(objName,objName,theMap,asCATLV(indexCat)) ;
-  } catch (string err) {
+  } catch (const string &err) {
     coutE(ObjectHandling) << "RooFactoryWSTool::simul(" << objName << ") ERROR creating RooSimultaneous::" << objName << " " << err << endl ;
     logError() ;
   }
@@ -678,7 +678,7 @@ RooAddition* RooFactoryWSTool::addfunc(const char *objName, const char* specList
       tok = strtok_r(0,",",&save) ;
     }
 
-  } catch (string err) {
+  } catch (const string &err) {
     coutE(ObjectHandling) << "RooFactoryWSTool::addfunc(" << objName << ") ERROR creating RooAddition: " << err << endl ;
     logError() ;
     return 0 ;
@@ -856,7 +856,7 @@ RooAbsArg* RooFactoryWSTool::process(const char* expr)
   string out ;
   try {
     out = processExpression(buf) ;
-  } catch (string error) {
+  } catch (const string &error) {
     coutE(ObjectHandling) << "RooFactoryWSTool::processExpression() ERROR in parsing: " << error << endl ;
     logError() ;
   }

--- a/roofit/roostats/src/AsymptoticCalculator.cxx
+++ b/roofit/roostats/src/AsymptoticCalculator.cxx
@@ -1368,7 +1368,7 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(const ModelConfig & model, con
 
       // part 1: create the nuisance pdf
       std::unique_ptr<RooAbsPdf> nuispdf(RooStats::MakeNuisancePdf(model,"TempNuisPdf") );
-      if (nuispdf.get() == 0) {
+      if (nuispdf == nullptr) {
          oocoutF((TObject*)0,Generation) << "AsymptoticCalculator::MakeAsimovData: model has nuisance parameters and global obs but no nuisance pdf "
                                          << std::endl;
       }
@@ -1380,7 +1380,7 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(const ModelConfig & model, con
       }
       else
          // nothing to unfold - just use the pdf
-         pdfList.add(*nuispdf.get());
+         pdfList.add(*nuispdf);
 
       RooLinkedListIter iter(pdfList.iterator());
       for (RooAbsArg *a = (RooAbsArg *) iter.Next(); a != 0; a = (RooAbsArg *) iter.Next()) {

--- a/roofit/roostats/src/BayesianCalculator.cxx
+++ b/roofit/roostats/src/BayesianCalculator.cxx
@@ -168,7 +168,7 @@ public:
 
    PosteriorCdfFunction(RooAbsReal & nll,  RooArgList & bindParams, RooAbsReal * prior = 0, const char * integType = 0, double nllMinimum = 0) :
       fFunctor(nll, bindParams, RooArgList() ),              // functor
-      fPriorFunc(std::shared_ptr<RooFunctor>((RooFunctor*)0)),
+      fPriorFunc(nullptr),
       fLikelihood(fFunctor, 0, nllMinimum),         // integral of exp(-nll) function
       fIntegrator(ROOT::Math::IntegratorMultiDim::GetType(integType) ),  // integrator
       fXmin(bindParams.getSize() ),               // vector of parameters (min values)
@@ -178,7 +178,7 @@ public:
    {
 
       if (prior) {
-         fPriorFunc = std::shared_ptr<RooFunctor>(new RooFunctor(*prior, bindParams, RooArgList() ));
+         fPriorFunc = std::make_shared<RooFunctor>(*prior, bindParams, RooArgList());
          fLikelihood.SetPrior(fPriorFunc.get() );
       }
 
@@ -354,7 +354,7 @@ public:
    PosteriorFunction(RooAbsReal & nll, RooRealVar & poi, RooArgList & nuisParams, RooAbsReal * prior = 0, const char * integType = 0, double
                      norm = 1.0,  double nllOffset = 0, int niter = 0) :
       fFunctor(nll, nuisParams, RooArgList() ),
-      fPriorFunc(std::shared_ptr<RooFunctor>((RooFunctor*)0)),
+      fPriorFunc(nullptr),
       fLikelihood(fFunctor, 0, nllOffset),
       fPoi(&poi),
       fXmin(nuisParams.getSize() ),
@@ -364,7 +364,7 @@ public:
    {
 
       if (prior) {
-         fPriorFunc = std::shared_ptr<RooFunctor>(new RooFunctor(*prior, nuisParams, RooArgList() ));
+         fPriorFunc = std::make_shared<RooFunctor>(*prior, nuisParams, RooArgList());
          fLikelihood.SetPrior(fPriorFunc.get() );
       }
 
@@ -470,7 +470,7 @@ public:
    PosteriorFunctionFromToyMC(RooAbsReal & nll, RooAbsPdf & pdf, RooRealVar & poi, RooArgList & nuisParams, RooAbsReal * prior = 0, double
                               nllOffset = 0, int niter = 0, bool redoToys = true ) :
       fFunctor(nll, nuisParams, RooArgList() ),
-      fPriorFunc(std::shared_ptr<RooFunctor>((RooFunctor*)0)),
+      fPriorFunc(nullptr),
       fLikelihood(fFunctor, 0, nllOffset),
       fPdf(&pdf),
       fPoi(&poi),
@@ -483,7 +483,7 @@ public:
       if (niter == 0) fNumIterations = 100; // default value
 
       if (prior) {
-         fPriorFunc = std::shared_ptr<RooFunctor>(new RooFunctor(*prior, nuisParams, RooArgList() ));
+         fPriorFunc = std::make_shared<RooFunctor>(*prior, nuisParams, RooArgList());
          fLikelihood.SetPrior(fPriorFunc.get() );
       }
 

--- a/roofit/roostats/src/LikelihoodInterval.cxx
+++ b/roofit/roostats/src/LikelihoodInterval.cxx
@@ -258,7 +258,7 @@ bool LikelihoodInterval::CreateMinimizer() {
       ccoutI(InputArguments) << "LikelihoodInterval: using nll offset - set all RooAbsReal to hide the offset  " << std::endl;
       RooAbsReal::setHideOffset(kFALSE); // need to keep this false
    }
-   fFunctor = std::shared_ptr<RooFunctor>(new RooFunctor(nll, RooArgSet(), params ));
+   fFunctor = std::make_shared<RooFunctor>(nll, RooArgSet(), params);
 
    std::string minimType =  ROOT::Math::MinimizerOptions::DefaultMinimizerType();
    std::transform(minimType.begin(), minimType.end(), minimType.begin(), (int(*)(int)) tolower );
@@ -275,7 +275,7 @@ bool LikelihoodInterval::CreateMinimizer() {
 
    if (!fMinimizer.get()) return false;
 
-   fMinFunc = std::shared_ptr<ROOT::Math::IMultiGenFunction>( new ROOT::Math::WrappedMultiFunction<RooFunctor &> (*fFunctor, fFunctor->nPar() ) );
+   fMinFunc = std::make_shared<ROOT::Math::WrappedMultiFunction<RooFunctor &>>(*fFunctor, fFunctor->nPar());
    fMinimizer->SetFunction(*fMinFunc);
 
    // set minimizer parameters

--- a/tmva/tmva/inc/TMVA/BinarySearchTree.h
+++ b/tmva/tmva/inc/TMVA/BinarySearchTree.h
@@ -65,13 +65,13 @@ namespace TMVA {
    public:
       
       // constructor
-      BinarySearchTree( void );
+      BinarySearchTree();
     
       // copy constructor
       BinarySearchTree (const BinarySearchTree &b);
 
       // destructor
-      virtual ~BinarySearchTree( void );
+      virtual ~BinarySearchTree();
     
       virtual Node * CreateNode( UInt_t ) const { return new BinarySearchTreeNode(); }
       virtual BinaryTree* CreateTree() const { return new BinarySearchTree(); }
@@ -86,7 +86,7 @@ namespace TMVA {
       void Insert( const Event * );
     
       // get sum of weights of the nodes;
-      Double_t GetSumOfWeights( void ) const;
+      Double_t GetSumOfWeights() const;
 
       //get sum of weights of the nodes of given type;
       Double_t GetSumOfWeights( Int_t theType ) const;
@@ -95,7 +95,7 @@ namespace TMVA {
       void SetPeriode( Int_t p )      { fPeriod = p; }
 
       // return periode (number of variables)
-      UInt_t  GetPeriode( void ) const { return fPeriod; }
+      UInt_t  GetPeriode() const { return fPeriod; }
 
       // counts events (weights) within a given volume 
       Double_t SearchVolume( Volume*, std::vector<const TMVA::BinarySearchTreeNode*>* events = 0 );

--- a/tmva/tmva/inc/TMVA/DataLoader.h
+++ b/tmva/tmva/inc/TMVA/DataLoader.h
@@ -54,7 +54,6 @@ namespace TMVA {
    class IMethod;   
    class VariableTransformBase;
    class VarTransformHandler;
-   class Classification;
 
    class DataLoader : public Configurable {
       friend class Factory;

--- a/tmva/tmva/inc/TMVA/DecisionTreeNode.h
+++ b/tmva/tmva/inc/TMVA/DecisionTreeNode.h
@@ -283,9 +283,9 @@ namespace TMVA {
       inline virtual DecisionTreeNode* GetParent( ) const { return static_cast<DecisionTreeNode*>(fParent); }
 
       // set pointer to the left/right daughter and parent node
-      inline virtual void SetLeft  (Node* l) { fLeft   = static_cast<DecisionTreeNode*>(l);} 
-      inline virtual void SetRight (Node* r) { fRight  = static_cast<DecisionTreeNode*>(r);} 
-      inline virtual void SetParent(Node* p) { fParent = static_cast<DecisionTreeNode*>(p);} 
+      inline virtual void SetLeft  (Node* l) { fLeft   = l;}
+      inline virtual void SetRight (Node* r) { fRight  = r;}
+      inline virtual void SetParent(Node* p) { fParent = p;}
 
 
 

--- a/tmva/tmva/inc/TMVA/DecisionTreeNode.h
+++ b/tmva/tmva/inc/TMVA/DecisionTreeNode.h
@@ -151,34 +151,34 @@ namespace TMVA {
       // set the cut value applied at this node
       void  SetCutValue ( Float_t c ) { fCutValue  = c; }
       // return the cut value applied at this node
-      Float_t GetCutValue ( void ) const { return fCutValue;  }
+      Float_t GetCutValue () const { return fCutValue;  }
 
       // set true: if event variable > cutValue ==> signal , false otherwise
       void SetCutType( Bool_t t   ) { fCutType = t; }
       // return kTRUE: Cuts select signal, kFALSE: Cuts select bkg
-      Bool_t GetCutType( void ) const { return fCutType; }
+      Bool_t GetCutType() const { return fCutType; }
 
       // set node type: 1 signal node, -1 bkg leave, 0 intermediate Node
       void  SetNodeType( Int_t t ) { fNodeType = t;}
       // return node type: 1 signal node, -1 bkg leave, 0 intermediate Node
-      Int_t GetNodeType( void ) const { return fNodeType; }
+      Int_t GetNodeType() const { return fNodeType; }
 
       //return  S/(S+B) (purity) at this node (from  training)
-      Float_t GetPurity( void ) const { return fPurity;}
+      Float_t GetPurity() const { return fPurity;}
       //calculate S/(S+B) (purity) at this node (from  training)
-      void SetPurity( void );
+      void SetPurity();
 
       //set the response of the node (for regression)
       void SetResponse( Float_t r ) { fResponse = r;}
 
       //return the response of the node (for regression)
-      Float_t GetResponse( void ) const { return fResponse;}
+      Float_t GetResponse() const { return fResponse;}
 
       //set the RMS of the response of the node (for regression)
       void SetRMS( Float_t r ) { fRMS = r;}
 
       //return the RMS of the response of the node (for regression)
-      Float_t GetRMS( void ) const { return fRMS;}
+      Float_t GetRMS() const { return fRMS;}
 
       // set the sum of the signal weights in the node
       void SetNSigEvents( Float_t s ) { fTrainInfo->fNSigEvents = s; }
@@ -226,42 +226,42 @@ namespace TMVA {
       void IncrementNEvents_unweighted( ){ fTrainInfo->fNEvents_unweighted +=1 ; }
 
       // return the sum of the signal weights in the node
-      Float_t GetNSigEvents( void ) const  { return fTrainInfo->fNSigEvents; }
+      Float_t GetNSigEvents() const  { return fTrainInfo->fNSigEvents; }
 
       // return the sum of the backgr weights in the node
-      Float_t GetNBkgEvents( void ) const  { return fTrainInfo->fNBkgEvents; }
+      Float_t GetNBkgEvents() const  { return fTrainInfo->fNBkgEvents; }
 
       // return  the number of events that entered the node (during training)
-      Float_t GetNEvents( void ) const  { return fTrainInfo->fNEvents; }
+      Float_t GetNEvents() const  { return fTrainInfo->fNEvents; }
 
       // return the sum of unweighted signal weights in the node
-      Float_t GetNSigEvents_unweighted( void ) const  { return fTrainInfo->fNSigEvents_unweighted; }
+      Float_t GetNSigEvents_unweighted() const  { return fTrainInfo->fNSigEvents_unweighted; }
 
       // return the sum of unweighted backgr weights in the node
-      Float_t GetNBkgEvents_unweighted( void ) const  { return fTrainInfo->fNBkgEvents_unweighted; }
+      Float_t GetNBkgEvents_unweighted() const  { return fTrainInfo->fNBkgEvents_unweighted; }
 
       // return  the number of unweighted events that entered the node (during training)
-      Float_t GetNEvents_unweighted( void ) const  { return fTrainInfo->fNEvents_unweighted; }
+      Float_t GetNEvents_unweighted() const  { return fTrainInfo->fNEvents_unweighted; }
 
       // return the sum of unboosted signal weights in the node
-      Float_t GetNSigEvents_unboosted( void ) const  { return fTrainInfo->fNSigEvents_unboosted; }
+      Float_t GetNSigEvents_unboosted() const  { return fTrainInfo->fNSigEvents_unboosted; }
 
       // return the sum of unboosted backgr weights in the node
-      Float_t GetNBkgEvents_unboosted( void ) const  { return fTrainInfo->fNBkgEvents_unboosted; }
+      Float_t GetNBkgEvents_unboosted() const  { return fTrainInfo->fNBkgEvents_unboosted; }
 
       // return  the number of unboosted events that entered the node (during training)
-      Float_t GetNEvents_unboosted( void ) const  { return fTrainInfo->fNEvents_unboosted; }
+      Float_t GetNEvents_unboosted() const  { return fTrainInfo->fNEvents_unboosted; }
 
 
       // set the choosen index, measure of "purity" (separation between S and B) AT this node
       void SetSeparationIndex( Float_t sep ){ fTrainInfo->fSeparationIndex =sep ; }
       // return the separation index AT this node
-      Float_t GetSeparationIndex( void ) const  { return fTrainInfo->fSeparationIndex; }
+      Float_t GetSeparationIndex() const  { return fTrainInfo->fSeparationIndex; }
 
       // set the separation, or information gained BY this nodes selection
       void SetSeparationGain( Float_t sep ){ fTrainInfo->fSeparationGain =sep ; }
       // return the gain in separation obtained by this nodes selection
-      Float_t GetSeparationGain( void ) const  { return fTrainInfo->fSeparationGain; }
+      Float_t GetSeparationGain() const  { return fTrainInfo->fSeparationGain; }
 
       // printout of the node
       virtual void Print( std::ostream& os ) const;

--- a/tmva/tmva/inc/TMVA/Factory.h
+++ b/tmva/tmva/inc/TMVA/Factory.h
@@ -112,26 +112,26 @@ namespace TMVA {
 
       // training for all booked methods
       void TrainAllMethods                 ();
-      void TrainAllMethodsForClassification( void ) { TrainAllMethods(); }
-      void TrainAllMethodsForRegression    ( void ) { TrainAllMethods(); }
+      void TrainAllMethodsForClassification() { TrainAllMethods(); }
+      void TrainAllMethodsForRegression    () { TrainAllMethods(); }
 
       // testing
       void TestAllMethods();
 
       // performance evaluation
-      void EvaluateAllMethods( void );
+      void EvaluateAllMethods();
       void EvaluateAllVariables(DataLoader *loader, TString options = "" ); 
   
       TH1F* EvaluateImportance( DataLoader *loader,VIType vitype, Types::EMVA theMethod,  TString methodTitle, const char *theOption = "" );
 
       // delete all methods and reset the method vector
-      void DeleteAllMethods( void );
+      void DeleteAllMethods();
 
       // accessors
       IMethod* GetMethod( const TString& datasetname, const TString& title ) const;
       Bool_t   HasMethod( const TString& datasetname, const TString& title ) const;
 
-      Bool_t Verbose( void ) const { return fVerbose; }
+      Bool_t Verbose() const { return fVerbose; }
       void SetVerbose( Bool_t v=kTRUE );
 
       // make ROOT-independent C++ class for classifier response 

--- a/tmva/tmva/inc/TMVA/LossFunction.h
+++ b/tmva/tmva/inc/TMVA/LossFunction.h
@@ -33,7 +33,7 @@
 
 //#include <iosfwd>
 #include <vector>
-#include <map>
+#include <unordered_map>
 #include "TMVA/Event.h"
 #include "TMVA/Types.h"
 
@@ -128,8 +128,8 @@ namespace TMVA {
       virtual ~LossFunctionBDT(){};
 
       // abstract methods that need to be implemented
-      virtual void Init(std::map<const TMVA::Event*, LossFunctionEventInfo>& evinfomap, std::vector<double>& boostWeights) = 0;
-      virtual void SetTargets(std::vector<const TMVA::Event*>& evs, std::map< const TMVA::Event*, LossFunctionEventInfo >& evinfomap) = 0;
+      virtual void Init(std::unordered_map<const TMVA::Event*, LossFunctionEventInfo>& evinfomap, std::vector<double>& boostWeights) = 0;
+      virtual void SetTargets(std::vector<const TMVA::Event*>& evs, std::unordered_map< const TMVA::Event*, LossFunctionEventInfo >& evinfomap) = 0;
       virtual Double_t Target(LossFunctionEventInfo& e) = 0;
       virtual Double_t Fit(std::vector<LossFunctionEventInfo>& evs) = 0;
    };
@@ -181,8 +181,8 @@ namespace TMVA {
       ~HuberLossFunctionBDT(){};
 
       // The LossFunctionBDT methods
-      void Init(std::map<const TMVA::Event*, LossFunctionEventInfo>& evinfomap, std::vector<double>& boostWeights);
-      void SetTargets(std::vector<const TMVA::Event*>& evs, std::map< const TMVA::Event*, LossFunctionEventInfo >& evinfomap);
+      void Init(std::unordered_map<const TMVA::Event*, LossFunctionEventInfo>& evinfomap, std::vector<double>& boostWeights);
+      void SetTargets(std::vector<const TMVA::Event*>& evs, std::unordered_map< const TMVA::Event*, LossFunctionEventInfo >& evinfomap);
       Double_t Target(LossFunctionEventInfo& e);
       Double_t Fit(std::vector<LossFunctionEventInfo>& evs);
 
@@ -223,8 +223,8 @@ namespace TMVA {
       ~LeastSquaresLossFunctionBDT(){};
 
       // The LossFunctionBDT methods
-      void Init(std::map<const TMVA::Event*, LossFunctionEventInfo>& evinfomap, std::vector<double>& boostWeights);
-      void SetTargets(std::vector<const TMVA::Event*>& evs, std::map< const TMVA::Event*, LossFunctionEventInfo >& evinfomap);
+      void Init(std::unordered_map<const TMVA::Event*, LossFunctionEventInfo>& evinfomap, std::vector<double>& boostWeights);
+      void SetTargets(std::vector<const TMVA::Event*>& evs, std::unordered_map< const TMVA::Event*, LossFunctionEventInfo >& evinfomap);
       Double_t Target(LossFunctionEventInfo& e);
       Double_t Fit(std::vector<LossFunctionEventInfo>& evs);
    };
@@ -262,8 +262,8 @@ namespace TMVA {
       ~AbsoluteDeviationLossFunctionBDT(){};
 
       // The LossFunctionBDT methods
-      void Init(std::map<const TMVA::Event*, LossFunctionEventInfo>& evinfomap, std::vector<double>& boostWeights);
-      void SetTargets(std::vector<const TMVA::Event*>& evs, std::map< const TMVA::Event*, LossFunctionEventInfo >& evinfomap);
+      void Init(std::unordered_map<const TMVA::Event*, LossFunctionEventInfo>& evinfomap, std::vector<double>& boostWeights);
+      void SetTargets(std::vector<const TMVA::Event*>& evs, std::unordered_map< const TMVA::Event*, LossFunctionEventInfo >& evinfomap);
       Double_t Target(LossFunctionEventInfo& e);
       Double_t Fit(std::vector<LossFunctionEventInfo>& evs);
    };

--- a/tmva/tmva/inc/TMVA/MethodBDT.h
+++ b/tmva/tmva/inc/TMVA/MethodBDT.h
@@ -210,9 +210,9 @@ namespace TMVA {
       Bool_t                          fBaggedGradBoost; // turn bagging in combination with grad boost on/off
       //Double_t                        fSumOfWeights;    // sum of all event weights
       //std::map< const TMVA::Event*, std::pair<Double_t, Double_t> >       fWeightedResiduals;  // weighted regression residuals
-      std::map< const TMVA::Event*, LossFunctionEventInfo>                fLossFunctionEventInfo;  // map event to true value, predicted value, and weight
+      std::unordered_map< const TMVA::Event*, LossFunctionEventInfo>                fLossFunctionEventInfo;  // map event to true value, predicted value, and weight
                                                                                                    // used by different loss functions for BDT regression
-      std::map< const TMVA::Event*,std::vector<double> > fResiduals; // individual event residuals for gradient boost
+      std::unordered_map< const TMVA::Event*,std::vector<double> > fResiduals; // individual event residuals for gradient boost
 
       //options for the decision Tree
       SeparationBase                 *fSepType;         // the separation used in node splitting

--- a/tmva/tmva/inc/TMVA/MethodBDT.h
+++ b/tmva/tmva/inc/TMVA/MethodBDT.h
@@ -64,7 +64,7 @@ namespace TMVA {
       MethodBDT( DataSetInfo& theData,
                  const TString& theWeightFile);
 
-      virtual ~MethodBDT( void );
+      virtual ~MethodBDT();
 
       virtual Bool_t HasAnalysisType( Types::EAnalysisType type, UInt_t numberClasses, UInt_t numberTargets );
 
@@ -78,10 +78,10 @@ namespace TMVA {
       virtual void SetTuneParameters(std::map<TString,Double_t> tuneParameters);
 
       // training method
-      void Train( void );
+      void Train();
 
       // revoke training
-      void Reset( void );
+      void Reset();
 
       using MethodBase::ReadWeightsFromStream;
 
@@ -93,7 +93,7 @@ namespace TMVA {
       void ReadWeightsFromXML(void* parent);
 
       // write method specific histos to target file
-      void WriteMonitoringHistosToFile( void ) const;
+      void WriteMonitoringHistosToFile() const;
 
       // calculate the MVA value
       Double_t GetMvaValue( Double_t* err = 0, Double_t* errUpper = 0);
@@ -162,7 +162,7 @@ namespace TMVA {
 
    private:
       // Init used in the various constructors
-      void Init( void );
+      void Init();
 
       void PreProcessNegativeEventWeights();
 

--- a/tmva/tmva/inc/TMVA/MethodBayesClassifier.h
+++ b/tmva/tmva/inc/TMVA/MethodBayesClassifier.h
@@ -53,12 +53,12 @@ namespace TMVA {
       MethodBayesClassifier( DataSetInfo& theData, 
                              const TString& theWeightFile);
       
-      virtual ~MethodBayesClassifier( void );
+      virtual ~MethodBayesClassifier();
     
       virtual Bool_t HasAnalysisType( Types::EAnalysisType type, UInt_t numberClasses, UInt_t numberTargets );
 
       // training method
-      void Train( void );
+      void Train();
 
       using MethodBase::ReadWeightsFromStream;
 
@@ -72,7 +72,7 @@ namespace TMVA {
       // calculate the MVA value
       Double_t GetMvaValue( Double_t* err = 0, Double_t* errUpper = 0 );
 
-      void Init( void );
+      void Init();
 
       // ranking of input variables
       const Ranking* CreateRanking() { return 0; }

--- a/tmva/tmva/inc/TMVA/MethodBoost.h
+++ b/tmva/tmva/inc/TMVA/MethodBoost.h
@@ -71,12 +71,12 @@ namespace TMVA {
       MethodBoost( DataSetInfo& dsi,
                    const TString& theWeightFile );
 
-      virtual ~MethodBoost( void );
+      virtual ~MethodBoost();
 
       virtual Bool_t HasAnalysisType( Types::EAnalysisType type, UInt_t numberClasses, UInt_t /*numberTargets*/ );
 
       // training and boosting all the classifiers
-      void Train( void );
+      void Train();
 
       // ranking of input variables
       const Ranking* CreateRanking();
@@ -129,7 +129,7 @@ namespace TMVA {
       Double_t GetBoostROCIntegral(Bool_t, Types::ETreeType, Bool_t CalcOverlapIntergral=kFALSE);
 
       // writing the monitoring histograms and tree to a file
-      void WriteMonitoringHistosToFile( void ) const;
+      void WriteMonitoringHistosToFile() const;
 
       // write evaluation histograms into target file
       virtual void WriteEvaluationHistosToFile(Types::ETreeType treetype);

--- a/tmva/tmva/inc/TMVA/MethodCFMlpANN.h
+++ b/tmva/tmva/inc/TMVA/MethodCFMlpANN.h
@@ -103,12 +103,12 @@ namespace TMVA {
       MethodCFMlpANN( DataSetInfo& theData,
                       const TString& theWeightFile);
 
-      virtual ~MethodCFMlpANN( void );
+      virtual ~MethodCFMlpANN();
 
       virtual Bool_t HasAnalysisType( Types::EAnalysisType type, UInt_t numberClasses, UInt_t /*numberTargets*/ );
 
       // training method
-      void Train( void );
+      void Train();
 
       using MethodBase::ReadWeightsFromStream;
 
@@ -170,7 +170,7 @@ namespace TMVA {
       Double_t NN_fonc( Int_t, Double_t ) const;
 
       // default initialisation
-      void Init( void );
+      void Init();
 
       ClassDef(MethodCFMlpANN,0); // Interface for Clermond-Ferrand artificial neural network
    };

--- a/tmva/tmva/inc/TMVA/MethodCFMlpANN_Utils.h
+++ b/tmva/tmva/inc/TMVA/MethodCFMlpANN_Utils.h
@@ -72,7 +72,7 @@ namespace TMVA {
                                    Double_t*, Int_t*, Int_t* ) = 0;
   
       Double_t Fdecroi(Int_t *i__);
-      Double_t Sen3a(void);
+      Double_t Sen3a();
 
       void  Wini      ();
       void  En_avant  (Int_t *ievent);
@@ -150,7 +150,7 @@ namespace TMVA {
                return fxx[0][0];
             }
          }
-         void Delete( void ) {
+         void Delete() {
             if (0 != fxx) for (Int_t i=0; i<fNevt; i++) if (0 != fxx[i]) delete [] fxx[i];
             delete[] fxx;
             fxx=0;

--- a/tmva/tmva/inc/TMVA/MethodCategory.h
+++ b/tmva/tmva/inc/TMVA/MethodCategory.h
@@ -69,11 +69,11 @@ namespace TMVA {
       MethodCategory( DataSetInfo& dsi,
                       const TString& theWeightFile );
 
-      virtual ~MethodCategory( void );
+      virtual ~MethodCategory();
 
       virtual Bool_t HasAnalysisType( Types::EAnalysisType type, UInt_t numberClasses, UInt_t /*numberTargets*/ );
       // training and boosting all the classifiers
-      void Train( void );
+      void Train();
 
       // ranking of input variables
       const Ranking* CreateRanking();

--- a/tmva/tmva/inc/TMVA/MethodCompositeBase.h
+++ b/tmva/tmva/inc/TMVA/MethodCompositeBase.h
@@ -81,7 +81,7 @@ namespace TMVA {
       // create ranking
       virtual const Ranking* CreateRanking() = 0;
 
-      virtual ~MethodCompositeBase( void );
+      virtual ~MethodCompositeBase();
 
    protected:
 

--- a/tmva/tmva/inc/TMVA/MethodCrossValidation.h
+++ b/tmva/tmva/inc/TMVA/MethodCrossValidation.h
@@ -42,17 +42,17 @@ public:
    // constructor for calculating BDT-MVA using previously generatad decision trees
    MethodCrossValidation(DataSetInfo &theData, const TString &theWeightFile);
 
-   virtual ~MethodCrossValidation(void);
+   virtual ~MethodCrossValidation();
 
    // optimize tuning parameters
    // virtual std::map<TString,Double_t> OptimizeTuningParameters(TString fomType="ROCIntegral", TString
    // fitType="FitGA"); virtual void SetTuneParameters(std::map<TString,Double_t> tuneParameters);
 
    // training method
-   void Train(void);
+   void Train();
 
    // revoke training
-   void Reset(void);
+   void Reset();
 
    using MethodBase::ReadWeightsFromStream;
 
@@ -64,7 +64,7 @@ public:
    void ReadWeightsFromXML(void *parent);
 
    // write method specific histos to target file
-   void WriteMonitoringHistosToFile(void) const;
+   void WriteMonitoringHistosToFile() const;
 
    // calculate the MVA value
    Double_t GetMvaValue(Double_t *err = 0, Double_t *errUpper = 0);
@@ -85,7 +85,7 @@ public:
    Bool_t HasAnalysisType(Types::EAnalysisType type, UInt_t numberClasses, UInt_t numberTargets);
 
 protected:
-   void Init(void);
+   void Init();
    void DeclareCompatibilityOptions();
 
 private:

--- a/tmva/tmva/inc/TMVA/MethodCuts.h
+++ b/tmva/tmva/inc/TMVA/MethodCuts.h
@@ -73,12 +73,12 @@ namespace TMVA {
       // this is a workaround which is necessary since CINT is not capable of handling dynamic casts
       static MethodCuts* DynamicCast( IMethod* method ) { return dynamic_cast<MethodCuts*>(method); }
 
-      virtual ~MethodCuts( void );
+      virtual ~MethodCuts();
 
       virtual Bool_t HasAnalysisType( Types::EAnalysisType type, UInt_t numberClasses, UInt_t numberTargets );
 
       // training method
-      void Train( void );
+      void Train();
 
       using MethodBase::ReadWeightsFromStream;
 
@@ -91,7 +91,7 @@ namespace TMVA {
       Double_t GetMvaValue( Double_t* err = 0, Double_t* errUpper = 0 );
 
       // write method specific histos to target file
-      void WriteMonitoringHistosToFile( void ) const;
+      void WriteMonitoringHistosToFile() const;
 
       // test the method
       void TestClassification();
@@ -99,7 +99,7 @@ namespace TMVA {
       // also overwrite --> not computed for cuts
       Double_t GetSeparation  ( TH1*, TH1* ) const { return -1; }
       Double_t GetSeparation  ( PDF* = 0, PDF* = 0 ) const { return -1; }
-      Double_t GetSignificance( void )       const { return -1; }
+      Double_t GetSignificance()       const { return -1; }
       Double_t GetmuTransform ( TTree *)           { return -1; }
       Double_t GetEfficiency  ( const TString&, Types::ETreeType, Double_t& );
       Double_t GetTrainingEfficiency(const TString& );
@@ -223,7 +223,7 @@ namespace TMVA {
 
       // creates PDFs in case these are used to compute efficiencies 
       // (corresponds to: EffMethod == kUsePDFs)
-      void     CreateVariablePDFs( void );
+      void     CreateVariablePDFs();
 
       // returns signal and background efficiencies for given cuts - using event counting
       void     GetEffsfromSelection( Double_t* cutMin, Double_t* cutMax,
@@ -233,7 +233,7 @@ namespace TMVA {
                                 Double_t& effS, Double_t& effB );
 
       // default initialisation method called by all constructors
-      void     Init( void );
+      void     Init();
 
       ClassDef(MethodCuts,0);  // Multivariate optimisation of signal efficiency
    };

--- a/tmva/tmva/inc/TMVA/MethodDT.h
+++ b/tmva/tmva/inc/TMVA/MethodDT.h
@@ -56,11 +56,11 @@ namespace TMVA {
       MethodDT( DataSetInfo& dsi,
                 const TString& theWeightFile);
 
-      virtual ~MethodDT( void );
+      virtual ~MethodDT();
 
       virtual Bool_t HasAnalysisType( Types::EAnalysisType type, UInt_t numberClasses, UInt_t numberTargets );
 
-      void Train( void );
+      void Train();
 
       using MethodBase::ReadWeightsFromStream;
 
@@ -98,7 +98,7 @@ namespace TMVA {
 
    private:
       // Init used in the various constructors
-      void Init( void );
+      void Init();
 
    private:
 

--- a/tmva/tmva/inc/TMVA/MethodFDA.h
+++ b/tmva/tmva/inc/TMVA/MethodFDA.h
@@ -69,12 +69,12 @@ namespace TMVA {
       MethodFDA( DataSetInfo& theData,
                  const TString& theWeightFile);
 
-      virtual ~MethodFDA( void );
+      virtual ~MethodFDA();
 
       Bool_t HasAnalysisType( Types::EAnalysisType type, UInt_t numberClasses, UInt_t numberTargets );
 
       // training method
-      void Train( void );
+      void Train();
 
       using MethodBase::ReadWeightsFromStream;
 
@@ -89,7 +89,7 @@ namespace TMVA {
       virtual const std::vector<Float_t>& GetRegressionValues();
       virtual const std::vector<Float_t>& GetMulticlassValues();
 
-      void Init( void );
+      void Init();
 
       // ranking of input variables
       const Ranking* CreateRanking() { return 0; }

--- a/tmva/tmva/inc/TMVA/MethodFisher.h
+++ b/tmva/tmva/inc/TMVA/MethodFisher.h
@@ -63,13 +63,13 @@ namespace TMVA {
       MethodFisher( DataSetInfo& dsi,
                     const TString& theWeightFile);
 
-      virtual ~MethodFisher( void );
+      virtual ~MethodFisher();
 
       virtual Bool_t HasAnalysisType( Types::EAnalysisType type, UInt_t numberClasses, UInt_t numberTargets );
 
 
       // training method
-      void Train( void );
+      void Train();
 
       using MethodBase::ReadWeightsFromStream;
 
@@ -84,13 +84,13 @@ namespace TMVA {
       Double_t GetMvaValue( Double_t* err = 0, Double_t* errUpper = 0 );
 
       enum EFisherMethod { kFisher, kMahalanobis };
-      EFisherMethod GetFisherMethod( void ) { return fFisherMethod; }
+      EFisherMethod GetFisherMethod() { return fFisherMethod; }
 
       // ranking of input variables
       const Ranking* CreateRanking();
 
       // nice output
-      void PrintCoefficients( void );
+      void PrintCoefficients();
 
 
    protected:
@@ -108,25 +108,25 @@ namespace TMVA {
       void ProcessOptions();
 
       // Initialization and allocation of matrices
-      void InitMatrices( void );
+      void InitMatrices();
 
       // get mean value of variables
-      void GetMean( void );
+      void GetMean();
 
       // get matrix of covariance within class
-      void GetCov_WithinClass( void );
+      void GetCov_WithinClass();
 
       // get matrix of covariance between class
-      void GetCov_BetweenClass( void );
+      void GetCov_BetweenClass();
 
       // and the full covariance matrix
-      void GetCov_Full( void );
+      void GetCov_Full();
 
       // get discriminating power
-      void GetDiscrimPower( void );
+      void GetDiscrimPower();
 
       // get Fisher coefficients
-      void GetFisherCoeff( void );
+      void GetFisherCoeff();
 
       // matrix of variables means: S, B, S+B vs. variables
       TMatrixD *fMeanMatx;
@@ -149,7 +149,7 @@ namespace TMVA {
       Double_t fF0;                   // offset
 
       // default initialisation called by all constructors
-      void Init( void );
+      void Init();
 
       ClassDef(MethodFisher,0); // Analysis of Fisher discriminant (Fisher or Mahalanobis approach) 
    };

--- a/tmva/tmva/inc/TMVA/MethodLD.h
+++ b/tmva/tmva/inc/TMVA/MethodLD.h
@@ -62,12 +62,12 @@ namespace TMVA {
                 const TString& theWeightFile);
 
       // destructor
-      virtual ~MethodLD( void );
+      virtual ~MethodLD();
 
       Bool_t HasAnalysisType( Types::EAnalysisType type, UInt_t numberClasses, UInt_t numberTargets );
     
       // training method
-      void Train( void );
+      void Train();
 
       // calculate the MVA value
       Double_t GetMvaValue( Double_t* err = 0, Double_t* errUpper = 0 );
@@ -101,22 +101,22 @@ namespace TMVA {
       std::vector< std::vector<Double_t>* > *fLDCoeff; // LD coefficients
 
       // default initialisation called by all constructors
-      void Init( void );
+      void Init();
 
       // Initialization and allocation of matrices
-      void InitMatrices( void );
+      void InitMatrices();
 
       // Compute fSumMatx
-      void GetSum( void );
+      void GetSum();
 
       // Compute fSumValMatx
-      void GetSumVal( void );
+      void GetSumVal();
 
       // get LD coefficients
-      void GetLDCoeff( void );
+      void GetLDCoeff();
       
       // nice output
-      void PrintCoefficients( void );
+      void PrintCoefficients();
 
       ClassDef(MethodLD,0); //Linear discriminant analysis
    };

--- a/tmva/tmva/inc/TMVA/MethodPDEFoam.h
+++ b/tmva/tmva/inc/TMVA/MethodPDEFoam.h
@@ -79,16 +79,16 @@ namespace TMVA {
       MethodPDEFoam( DataSetInfo& dsi,
                      const TString& theWeightFile);
 
-      virtual ~MethodPDEFoam( void );
+      virtual ~MethodPDEFoam();
 
       virtual Bool_t HasAnalysisType( Types::EAnalysisType type, UInt_t numberClasses, UInt_t numberTargets );
 
       // training methods
-      void Train( void );
-      void TrainMonoTargetRegression( void );    // Regression output: one value
-      void TrainMultiTargetRegression( void );   // Regression output: any number of values
-      void TrainSeparatedClassification( void ); // Classification: one foam for Sig, one for Bg
-      void TrainUnifiedClassification( void );   // Classification: one foam for Signal and Bg
+      void Train();
+      void TrainMonoTargetRegression();    // Regression output: one value
+      void TrainMultiTargetRegression();   // Regression output: any number of values
+      void TrainSeparatedClassification(); // Classification: one foam for Sig, one for Bg
+      void TrainUnifiedClassification();   // Classification: one foam for Signal and Bg
       void TrainMultiClassification();           // Classification: one foam for every class
 
       using MethodBase::ReadWeightsFromStream;
@@ -124,7 +124,7 @@ namespace TMVA {
       void GetNCuts(PDEFoamCell *cell, std::vector<UInt_t> &nCuts);
 
       // helper functions to convert enum types to UInt_t and back
-      EKernel GetKernel( void ) { return fKernel; }
+      EKernel GetKernel() { return fKernel; }
       UInt_t KernelToUInt(EKernel ker) const { return UInt_t(ker); }
       EKernel UIntToKernel(UInt_t iker);
       UInt_t TargetSelectionToUInt(ETargetSelection ts) const { return UInt_t(ts); }
@@ -167,7 +167,7 @@ namespace TMVA {
       void ProcessOptions();
 
       // nice output
-      void PrintCoefficients( void );
+      void PrintCoefficients();
 
       // Square function (fastest implementation)
       template<typename T> T Sqr(T x) const { return x*x; }
@@ -205,7 +205,7 @@ namespace TMVA {
       std::vector<PDEFoam*> fFoam;    // grown PDEFoams
 
       // default initialisation called by all constructors
-      void Init( void );
+      void Init();
 
       ClassDef(MethodPDEFoam,0); // Multi-dimensional probability density estimator using TFoam (PDE-Foam)
    };

--- a/tmva/tmva/inc/TMVA/MethodPDERS.h
+++ b/tmva/tmva/inc/TMVA/MethodPDERS.h
@@ -68,13 +68,13 @@ namespace TMVA {
       MethodPDERS( DataSetInfo& theData,
                    const TString& theWeightFile);
 
-      virtual ~MethodPDERS( void );
+      virtual ~MethodPDERS();
 
       virtual Bool_t HasAnalysisType( Types::EAnalysisType type, UInt_t numberClasses, UInt_t numberTargets );
 
 
       // training method
-      void Train( void );
+      void Train();
 
       // write weights to file
       void WriteWeightsToStream( TFile& rf ) const;
@@ -97,7 +97,7 @@ namespace TMVA {
       Double_t         GetVolumeContentForRoot( Double_t );
 
       // static pointer to this object
-      static MethodPDERS* ThisPDERS( void );
+      static MethodPDERS* ThisPDERS();
 
    protected:
 
@@ -111,7 +111,7 @@ namespace TMVA {
       Int_t        fFcnCall;    // number of external function calls (RootFinder)
 
       // accessors
-      BinarySearchTree* GetBinaryTree( void ) const { return fBinaryTree; }
+      BinarySearchTree* GetBinaryTree() const { return fBinaryTree; }
 
       Double_t             CKernelEstimate( const Event&, std::vector<const BinarySearchTreeNode*>&, Volume& );
       void                 RKernelEstimate( const Event&, std::vector<const BinarySearchTreeNode*>&, Volume&, std::vector<Float_t> *pdfSum );
@@ -201,7 +201,7 @@ namespace TMVA {
       Bool_t             fPrinted;       // print
       Bool_t             fNormTree;      // binary-search tree is normalised
 
-      void    SetVolumeElement ( void );
+      void    SetVolumeElement ();
 
       Double_t              CRScalc           ( const Event& );
       void                  RRScalc           ( const Event&, std::vector<Float_t>* count );
@@ -214,7 +214,7 @@ namespace TMVA {
       static MethodPDERS*& GetMethodPDERSThreadLocal() {TTHREAD_TLS(MethodPDERS*) fgThisPDERS(nullptr); return fgThisPDERS;};
       void UpdateThis();
 
-      void Init( void );
+      void Init();
 
       ClassDef(MethodPDERS,0); // Multi-dimensional probability density estimator range search (PDERS) method
    };

--- a/tmva/tmva/inc/TMVA/MethodRuleFit.h
+++ b/tmva/tmva/inc/TMVA/MethodRuleFit.h
@@ -56,12 +56,12 @@ namespace TMVA {
       MethodRuleFit( DataSetInfo& theData,
                      const TString& theWeightFile);
 
-      virtual ~MethodRuleFit( void );
+      virtual ~MethodRuleFit();
 
       virtual Bool_t HasAnalysisType( Types::EAnalysisType type, UInt_t numberClasses, UInt_t /*numberTargets*/ );
 
       // training method
-      void Train( void );
+      void Train();
 
       using MethodBase::ReadWeightsFromStream;
 
@@ -76,7 +76,7 @@ namespace TMVA {
       Double_t GetMvaValue( Double_t* err = 0, Double_t* errUpper = 0 );
 
       // write method specific histos to target file
-      void WriteMonitoringHistosToFile( void ) const;
+      void WriteMonitoringHistosToFile() const;
 
       // ranking of input variables
       const Ranking* CreateRanking();
@@ -124,10 +124,10 @@ namespace TMVA {
       void GetHelpMessage() const;
 
       // initialize rulefit
-      void Init( void );
+      void Init();
 
       // copy all training events into a stl::vector
-      void InitEventSample( void );
+      void InitEventSample();
 
       // initialize monitor ntuple
       void InitMonitorNtuple();

--- a/tmva/tmva/inc/TMVA/MethodSVM.h
+++ b/tmva/tmva/inc/TMVA/MethodSVM.h
@@ -63,7 +63,7 @@ namespace TMVA
       
       MethodSVM( DataSetInfo& theData, const TString& theWeightFile);
 
-      virtual ~MethodSVM( void );
+      virtual ~MethodSVM();
     
       virtual Bool_t HasAnalysisType( Types::EAnalysisType type, UInt_t numberClasses, UInt_t numberTargets );
 
@@ -74,10 +74,10 @@ namespace TMVA
       std::map< TString,std::vector<Double_t> > GetTuningOptions();
 
       // training method
-      void Train( void );
+      void Train();
 
       // revoke training (required for optimise tuning parameters)                    
-      void Reset( void );
+      void Reset();
 
       using MethodBase::ReadWeightsFromStream;
 
@@ -94,7 +94,7 @@ namespace TMVA
       Double_t GetMvaValue( Double_t* err = 0, Double_t* errUpper = 0 );
       const std::vector<Float_t>& GetRegressionValues();
       
-      void Init( void );
+      void Init();
 
       // ranking of input variables
       const Ranking* CreateRanking() { return 0; } 

--- a/tmva/tmva/inc/TMVA/MethodTMlpANN.h
+++ b/tmva/tmva/inc/TMVA/MethodTMlpANN.h
@@ -58,12 +58,12 @@ namespace TMVA {
       MethodTMlpANN( DataSetInfo& theData,
                      const TString& theWeightFile);
 
-      virtual ~MethodTMlpANN( void );
+      virtual ~MethodTMlpANN();
 
       virtual Bool_t HasAnalysisType( Types::EAnalysisType type, UInt_t numberClasses, UInt_t numberTargets );
 
       // training method
-      void Train( void );
+      void Train();
 
       using MethodBase::ReadWeightsFromStream;
 
@@ -118,7 +118,7 @@ namespace TMVA {
       TString  fLearningMethod;     // the learning method (given via option string)
 
       // default initialisation called by all constructors
-      void Init( void );
+      void Init();
 
       ClassDef(MethodTMlpANN,0); // Implementation of interface for TMultiLayerPerceptron
    };

--- a/tmva/tmva/inc/TMVA/NeuralNet.icc
+++ b/tmva/tmva/inc/TMVA/NeuralNet.icc
@@ -800,6 +800,7 @@ template <typename LAYERDATA>
                             batches.push_back (Batch (itPat, testPattern.end ()));
 
                         std::vector<std::future<std::tuple<double,std::vector<double>>>> futures;
+                        futures.reserve(batches.size());
                         for (auto& batch : batches)
                         {
                             // -------------------- execute each of the batch ranges on a different thread -------------------------------
@@ -987,6 +988,7 @@ template <typename LAYERDATA>
         
                 // -------------------- loop  over batches -------------------------------------------
                 std::vector<std::future<double>> futures;
+                futures.reserve(batchVec.size());
                 for (auto& batchRange : batchVec)
                 {
                     // -------------------- execute each of the batch ranges on a different thread -------------------------------

--- a/tmva/tmva/inc/TMVA/PDF.h
+++ b/tmva/tmva/inc/TMVA/PDF.h
@@ -203,7 +203,7 @@ namespace TMVA {
       // This is a workaround for OSx where static thread_local data members are
       // not supported. The C++ solution would indeed be the following:
       static PDF*& GetThisPdfThreadLocal() { TTHREAD_TLS(PDF*) fgThisPDF(nullptr); return fgThisPDF; };
-      static PDF*              ThisPDF( void ); 
+      static PDF*              ThisPDF(); 
 
       // external auxiliary functions 
       static Double_t          IGetVal( Double_t*, Double_t* );

--- a/tmva/tmva/inc/TMVA/ROCCalc.h
+++ b/tmva/tmva/inc/TMVA/ROCCalc.h
@@ -16,7 +16,6 @@ class TH1D;
 class TH2;
 class TH2F;
 class TSpline;
-class TSpline1;
 
 namespace TMVA {
 

--- a/tmva/tmva/inc/TMVA/Reader.h
+++ b/tmva/tmva/inc/TMVA/Reader.h
@@ -75,7 +75,7 @@ namespace TMVA {
       Reader( std::vector<TString>& varNames, const TString& theOption = "", Bool_t verbose = 0 );
       Reader( const TString& varNames, const TString& theOption, Bool_t verbose = 0 );  // format: "var1:var2:..."
 
-      virtual ~Reader( void );
+      virtual ~Reader();
 
       // book MVA method via weight file
       IMethod* BookMVA( const TString& methodTag, const TString& weightfile );
@@ -114,7 +114,7 @@ namespace TMVA {
 
       // accessors
       virtual const char* GetName() const { return "Reader"; }
-      Bool_t   Verbose( void ) const  { return fVerbose; }
+      Bool_t   Verbose() const  { return fVerbose; }
       void     SetVerbose( Bool_t v ) { fVerbose = v; }
 
       const DataSetInfo& DataInfo() const { return fDataSetInfo; }
@@ -141,7 +141,7 @@ namespace TMVA {
       DataInputHandler fDataInputHandler;
 
       // Init Reader class
-      void Init( void );
+      void Init();
 
       // Decode Constructor string (or TString) and fill variable name std::vector
       void DecodeVarNames( const std::string& varNames );

--- a/tmva/tmva/inc/TMVA/RootFinder.h
+++ b/tmva/tmva/inc/TMVA/RootFinder.h
@@ -53,7 +53,7 @@ namespace TMVA {
                   Double_t rootMin, Double_t rootMax,
                   Int_t    maxIterations = 100, 
                   Double_t absTolerance  = 0.0 );
-      virtual ~RootFinder( void );
+      virtual ~RootFinder();
       
       // returns the root of the function
       Double_t Root( Double_t refValue );

--- a/tmva/tmva/inc/TMVA/TSpline1.h
+++ b/tmva/tmva/inc/TMVA/TSpline1.h
@@ -45,12 +45,12 @@ namespace TMVA {
    public:
   
       TSpline1( const TString& title, TGraph* theGraph );
-      virtual ~TSpline1( void );
+      virtual ~TSpline1();
 
       virtual  Double_t Eval( Double_t x ) const;
 
       // dummy implementations
-      virtual void BuildCoeff( void );
+      virtual void BuildCoeff();
       virtual void GetKnot( Int_t i, Double_t& x, Double_t& y ) const;
 
       const TGraph* GetGraph() const { return fGraph; }

--- a/tmva/tmva/inc/TMVA/TSpline2.h
+++ b/tmva/tmva/inc/TMVA/TSpline2.h
@@ -45,12 +45,12 @@ namespace TMVA {
    public:
   
       TSpline2( const TString& title, TGraph* theGraph );
-      virtual ~TSpline2( void );
+      virtual ~TSpline2();
 
       virtual  Double_t Eval( Double_t x ) const;
 
       // dummy implementations
-      virtual void BuildCoeff( void );
+      virtual void BuildCoeff();
       virtual void GetKnot( Int_t i, Double_t& x, Double_t& y ) const;
 
    private:

--- a/tmva/tmva/inc/TMVA/Timer.h
+++ b/tmva/tmva/inc/TMVA/Timer.h
@@ -61,19 +61,19 @@ namespace TMVA {
 
       Timer( const char* prefix = "", Bool_t colourfulOutput = kTRUE );
       Timer( Int_t ncounts, const char* prefix = "", Bool_t colourfulOutput = kTRUE );
-      virtual ~Timer( void );
+      virtual ~Timer();
 
       void Init ( Int_t ncounts );
-      void Reset( void );
+      void Reset();
 
       // when the "Scientific" flag set, time is returned with sub-decimals
       // for algorithm timing measurement
       TString   GetElapsedTime ( Bool_t Scientific = kTRUE  );
-      Double_t  ElapsedSeconds ( void );
-      TString   GetLeftTime     ( Int_t icounts );
+      Double_t  ElapsedSeconds ();
+      TString   GetLeftTime    ( Int_t icounts );
       void      DrawProgressBar( Int_t, const TString& comment = "" );
       void      DrawProgressBar( TString );
-      void      DrawProgressBar( void );
+      void      DrawProgressBar();
 
    private:
 

--- a/tmva/tmva/inc/TMVA/VariableGaussTransform.h
+++ b/tmva/tmva/inc/TMVA/VariableGaussTransform.h
@@ -74,7 +74,7 @@ namespace TMVA {
    public:
 
       VariableGaussTransform( DataSetInfo& dsi, TString strcor=""  );
-      virtual ~VariableGaussTransform( void );
+      virtual ~VariableGaussTransform();
 
       void   Initialize();
       Bool_t PrepareTransformation (const std::vector<Event*>&);

--- a/tmva/tmva/inc/TMVA/Volume.h
+++ b/tmva/tmva/inc/TMVA/Volume.h
@@ -59,15 +59,15 @@ namespace TMVA {
       Volume( Double_t l , Double_t u );
 
       // destructor
-      virtual ~Volume( void );
+      virtual ~Volume();
 
       // destruct the volue 
-      void Delete       ( void );
+      void Delete       ();
       // "scale" the volume by multiplying each upper and lower boundary by "f" 
       void Scale        ( Double_t f );
       // "scale" the volume by symmetrically blowing up the interval in each dimension
       void ScaleInterval( Double_t f );
-      void Print        ( void ) const;
+      void Print        () const;
 
       // allow direct access for better speed
       std::vector<Double_t> *fLower;    // vector with lower volume dimensions

--- a/tmva/tmva/src/BinarySearchTree.cxx
+++ b/tmva/tmva/src/BinarySearchTree.cxx
@@ -100,9 +100,8 @@ TMVA::BinarySearchTree::BinarySearchTree( const BinarySearchTree &b)
 
 TMVA::BinarySearchTree::~BinarySearchTree( void )
 {
-   for(std::vector< std::pair<Double_t, const TMVA::Event*> >::iterator pIt = fNormalizeTreeTable.begin();
-       pIt != fNormalizeTreeTable.end(); ++pIt) {
-      delete pIt->second;
+   for(auto & pIt : fNormalizeTreeTable) {
+      delete pIt.second;
    }
 }
 

--- a/tmva/tmva/src/BinarySearchTree.cxx
+++ b/tmva/tmva/src/BinarySearchTree.cxx
@@ -69,7 +69,7 @@ ClassImp(TMVA::BinarySearchTree);
 ////////////////////////////////////////////////////////////////////////////////
 /// default constructor
 
-TMVA::BinarySearchTree::BinarySearchTree( void ) :
+TMVA::BinarySearchTree::BinarySearchTree() :
 BinaryTree(),
    fPeriod      ( 1 ),
    fCurrentDepth( 0 ),
@@ -98,7 +98,7 @@ TMVA::BinarySearchTree::BinarySearchTree( const BinarySearchTree &b)
 ////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
-TMVA::BinarySearchTree::~BinarySearchTree( void )
+TMVA::BinarySearchTree::~BinarySearchTree()
 {
    for(auto & pIt : fNormalizeTreeTable) {
       delete pIt.second;
@@ -223,7 +223,7 @@ TMVA::BinarySearchTreeNode* TMVA::BinarySearchTree::Search(Event* event, Node* n
 ////////////////////////////////////////////////////////////////////////////////
 /// return the sum of event (node) weights
 
-Double_t TMVA::BinarySearchTree::GetSumOfWeights( void ) const
+Double_t TMVA::BinarySearchTree::GetSumOfWeights() const
 {
    if (fSumOfWeights <= 0) {
       Log() << kWARNING << "you asked for the SumOfWeights, which is not filled yet"

--- a/tmva/tmva/src/BinarySearchTree.cxx
+++ b/tmva/tmva/src/BinarySearchTree.cxx
@@ -125,7 +125,7 @@ void TMVA::BinarySearchTree::Insert( const Event* event )
    fCurrentDepth=0;
    fStatisticsIsValid = kFALSE;
 
-   if (this->GetRoot() == NULL) {           // If the list is empty...
+   if (this->GetRoot() == nullptr) {           // If the list is empty...
       this->SetRoot( new BinarySearchTreeNode(event)); //Make the new node the root.
       // have to use "s" for start as "r" for "root" would be the same as "r" for "right"
       this->GetRoot()->SetPos('s');
@@ -160,7 +160,7 @@ void TMVA::BinarySearchTree::Insert( const Event *event,
    fStatisticsIsValid = kFALSE;
 
    if (node->GoesLeft(*event)){    // If the adding item is less than the current node's data...
-      if (node->GetLeft() != NULL){            // If there is a left node...
+      if (node->GetLeft() != nullptr){            // If there is a left node...
          // Add the new event to the left node
          this->Insert(event, node->GetLeft());
       }
@@ -177,7 +177,7 @@ void TMVA::BinarySearchTree::Insert( const Event *event,
       }
    }
    else if (node->GoesRight(*event)) { // If the adding item is less than or equal to the current node's data...
-      if (node->GetRight() != NULL) {              // If there is a right node...
+      if (node->GetRight() != nullptr) {              // If there is a right node...
          // Add the new node to it.
          this->Insert(event, node->GetRight());
       }
@@ -209,7 +209,7 @@ TMVA::BinarySearchTreeNode* TMVA::BinarySearchTree::Search( Event* event ) const
 
 TMVA::BinarySearchTreeNode* TMVA::BinarySearchTree::Search(Event* event, Node* node) const
 {
-   if (node != NULL) {               // If the node is not NULL...
+   if (node != nullptr) {               // If the node is not NULL...
       // If we have found the node...
       if (((BinarySearchTreeNode*)(node))->EqualsMe(*event))
          return (BinarySearchTreeNode*)node;                  // Return it
@@ -218,7 +218,7 @@ TMVA::BinarySearchTreeNode* TMVA::BinarySearchTree::Search(Event* event, Node* n
       else                          //If the node's data is less than the search item...
          return this->Search(event, node->GetRight()); //Search the right node.
    }
-   else return NULL; //If the node is NULL, return NULL.
+   else return nullptr; //If the node is NULL, return NULL.
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -285,7 +285,7 @@ Double_t TMVA::BinarySearchTree::Fill( const std::vector<Event*>& events, Int_t 
          fSumOfWeights += events[ievt]->GetWeight();
       }
    } // end of event loop
-   CalcStatistics(0);
+   CalcStatistics(nullptr);
 
    return fSumOfWeights;
 }
@@ -354,8 +354,8 @@ void TMVA::BinarySearchTree::NormalizeTree ( std::vector< std::pair<Double_t, co
 void TMVA::BinarySearchTree::NormalizeTree()
 {
    SetNormalize( kFALSE );
-   Clear( NULL );
-   this->SetRoot(NULL);
+   Clear( nullptr );
+   this->SetRoot(nullptr);
    NormalizeTree( fNormalizeTreeTable.begin(), fNormalizeTreeTable.end(), 0 );
 }
 
@@ -364,12 +364,12 @@ void TMVA::BinarySearchTree::NormalizeTree()
 
 void TMVA::BinarySearchTree::Clear( Node* n )
 {
-   BinarySearchTreeNode* currentNode = (BinarySearchTreeNode*)(n == NULL ? this->GetRoot() : n);
+   BinarySearchTreeNode* currentNode = (BinarySearchTreeNode*)(n == nullptr ? this->GetRoot() : n);
 
-   if (currentNode->GetLeft()  != 0) Clear( currentNode->GetLeft()  );
-   if (currentNode->GetRight() != 0) Clear( currentNode->GetRight() );
+   if (currentNode->GetLeft()  != nullptr) Clear( currentNode->GetLeft()  );
+   if (currentNode->GetRight() != nullptr) Clear( currentNode->GetRight() );
 
-   if (n != NULL) delete n;
+   if (n != nullptr) delete n;
 
    return;
 }
@@ -391,16 +391,16 @@ Double_t TMVA::BinarySearchTree::SearchVolume( Volume* volume,
 Double_t TMVA::BinarySearchTree::SearchVolume( Node* t, Volume* volume, Int_t depth,
                                                std::vector<const BinarySearchTreeNode*>* events )
 {
-   if (t==NULL) return 0;  // Are we at an outer leave?
+   if (t==nullptr) return 0;  // Are we at an outer leave?
 
    BinarySearchTreeNode* st = (BinarySearchTreeNode*)t;
 
    Double_t count = 0.0;
    if (InVolume( st->GetEventV(), volume )) {
       count += st->GetWeight();
-      if (NULL != events) events->push_back( st );
+      if (nullptr != events) events->push_back( st );
    }
-   if (st->GetLeft()==NULL && st->GetRight()==NULL) {
+   if (st->GetLeft()==nullptr && st->GetRight()==nullptr) {
 
       return count;  // Are we at an outer leave?
    }
@@ -445,7 +445,7 @@ void TMVA::BinarySearchTree::CalcStatistics( Node* n )
    BinarySearchTreeNode * currentNode = (BinarySearchTreeNode*)n;
 
    // default, start at the tree top, then descend recursively
-   if (n == NULL) {
+   if (n == nullptr) {
       fSumOfWeights = 0;
       for (Int_t sb=0; sb<2; sb++) {
          fNEventsW[sb]  = 0;
@@ -462,7 +462,7 @@ void TMVA::BinarySearchTree::CalcStatistics( Node* n )
          }
       }
       currentNode = (BinarySearchTreeNode*) this->GetRoot();
-      if (currentNode == NULL) return; // no root-node
+      if (currentNode == nullptr) return; // no root-node
    }
 
    const std::vector<Float_t> & evtVec = currentNode->GetEventV();
@@ -482,10 +482,10 @@ void TMVA::BinarySearchTree::CalcStatistics( Node* n )
       if (val > fMax[type][j]) fMax[type][j] = val;
    }
 
-   if ( (currentNode->GetLeft()  != NULL) ) CalcStatistics( currentNode->GetLeft() );
-   if ( (currentNode->GetRight() != NULL) ) CalcStatistics( currentNode->GetRight() );
+   if ( (currentNode->GetLeft()  != nullptr) ) CalcStatistics( currentNode->GetLeft() );
+   if ( (currentNode->GetRight() != nullptr) ) CalcStatistics( currentNode->GetRight() );
 
-   if (n == NULL) { // i.e. the root node
+   if (n == nullptr) { // i.e. the root node
       for (Int_t sb=0; sb<2; sb++) {
          for (UInt_t j=0; j<fPeriod; j++) {
             if (fNEventsW[sb] == 0) { fMeans[sb][j] = fRMS[sb][j] = 0; continue; }
@@ -506,7 +506,7 @@ void TMVA::BinarySearchTree::CalcStatistics( Node* n )
 Int_t TMVA::BinarySearchTree::SearchVolumeWithMaxLimit( Volume *volume, std::vector<const BinarySearchTreeNode*>* events,
                                                         Int_t max_points )
 {
-   if (this->GetRoot() == NULL) return 0;  // Are we at an outer leave?
+   if (this->GetRoot() == nullptr) return 0;  // Are we at an outer leave?
 
    std::queue< std::pair< const BinarySearchTreeNode*, Int_t > > queue;
    std::pair< const BinarySearchTreeNode*, Int_t > st = std::make_pair( (const BinarySearchTreeNode*)this->GetRoot(), 0 );
@@ -522,7 +522,7 @@ Int_t TMVA::BinarySearchTree::SearchVolumeWithMaxLimit( Volume *volume, std::vec
 
       if (InVolume( st.first->GetEventV(), volume )) {
          count++;
-         if (NULL != events) events->push_back( st.first );
+         if (nullptr != events) events->push_back( st.first );
       }
 
       Bool_t tl, tr;
@@ -534,8 +534,8 @@ Int_t TMVA::BinarySearchTree::SearchVolumeWithMaxLimit( Volume *volume, std::vec
                << d << " != " << "node "<< st.first->GetSelector() << Endl;
       }
 
-      tl = (*(volume->fLower))[d] <  st.first->GetEventV()[d] && st.first->GetLeft()  != NULL;  // Should we descend left?
-      tr = (*(volume->fUpper))[d] >= st.first->GetEventV()[d] && st.first->GetRight() != NULL;  // Should we descend right?
+      tl = (*(volume->fLower))[d] <  st.first->GetEventV()[d] && st.first->GetLeft()  != nullptr;  // Should we descend left?
+      tr = (*(volume->fUpper))[d] >= st.first->GetEventV()[d] && st.first->GetRight() != nullptr;  // Should we descend right?
 
       if (tl) queue.push( std::make_pair( (const BinarySearchTreeNode*)st.first->GetLeft(), d+1 ) );
       if (tr) queue.push( std::make_pair( (const BinarySearchTreeNode*)st.first->GetRight(), d+1 ) );

--- a/tmva/tmva/src/BinarySearchTreeNode.cxx
+++ b/tmva/tmva/src/BinarySearchTreeNode.cxx
@@ -60,11 +60,11 @@ TMVA::BinarySearchTreeNode::BinarySearchTreeNode( const Event* e, UInt_t /* sign
 : TMVA::Node(),
    fEventV  ( std::vector<Float_t>() ),
    fTargets ( std::vector<Float_t>() ),
-   fWeight  ( e==0?0:e->GetWeight()  ),
-   fClass   ( e==0?0:e->GetClass() ), // see BinarySearchTree.h, line Mean() RMS() Min() and Max()
+   fWeight  ( e==nullptr?0:e->GetWeight()  ),
+   fClass   ( e==nullptr?0:e->GetClass() ), // see BinarySearchTree.h, line Mean() RMS() Min() and Max()
    fSelector( -1 )
 {
-   if (e!=0) {
+   if (e!=nullptr) {
       for (UInt_t ivar=0; ivar<e->GetNVariables(); ivar++) fEventV.push_back(e->GetValue(ivar));
       for (std::vector<Float_t>::const_iterator it = e->GetTargets().begin(); it < e->GetTargets().end(); ++it ) {
          fTargets.push_back( (*it) );
@@ -99,10 +99,10 @@ TMVA::BinarySearchTreeNode::BinarySearchTreeNode ( const BinarySearchTreeNode &n
    fSelector( n.fSelector )
 {
    this->SetParent( parent );
-   if (n.GetLeft() == 0 ) this->SetLeft(NULL);
+   if (n.GetLeft() == nullptr ) this->SetLeft(nullptr);
    else this->SetLeft( new BinarySearchTreeNode( *((BinarySearchTreeNode*)(n.GetLeft())),this));
 
-   if (n.GetRight() == 0 ) this->SetRight(NULL);
+   if (n.GetRight() == nullptr ) this->SetRight(nullptr);
    else this->SetRight( new BinarySearchTreeNode( *((BinarySearchTreeNode*)(n.GetRight())),this));
 
 }
@@ -159,9 +159,9 @@ void TMVA::BinarySearchTreeNode::Print( std::ostream& os ) const
 
    os << "Selector: " <<  this->GetSelector() <<std::endl;
    os << "My address is " << long(this) << ", ";
-   if (this->GetParent() != NULL) os << " parent at addr: " << long(this->GetParent()) ;
-   if (this->GetLeft() != NULL) os << " left daughter at addr: " << long(this->GetLeft());
-   if (this->GetRight() != NULL) os << " right daughter at addr: " << long(this->GetRight()) ;
+   if (this->GetParent() != nullptr) os << " parent at addr: " << long(this->GetParent()) ;
+   if (this->GetLeft() != nullptr) os << " left daughter at addr: " << long(this->GetLeft());
+   if (this->GetRight() != nullptr) os << " right daughter at addr: " << long(this->GetRight()) ;
 
    os << " **** > "<< std::endl;
 }
@@ -179,8 +179,8 @@ void TMVA::BinarySearchTreeNode::PrintRec( std::ostream& os ) const
    os << "  EvtWeight " << std::setw(10) << fWeight;
    os << std::setw(10) << "Class: " << GetClass() << std::endl;
 
-   if (this->GetLeft() != NULL)this->GetLeft()->PrintRec(os) ;
-   if (this->GetRight() != NULL)this->GetRight()->PrintRec(os);
+   if (this->GetLeft() != nullptr)this->GetLeft()->PrintRec(os) ;
+   if (this->GetRight() != nullptr)this->GetRight()->PrintRec(os);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/src/BinarySearchTreeNode.cxx
+++ b/tmva/tmva/src/BinarySearchTreeNode.cxx
@@ -258,8 +258,8 @@ void TMVA::BinarySearchTreeNode::AddContentToNode( std::stringstream& s ) const
 {
    std::ios_base::fmtflags ff = s.flags();
    s.precision( 16 );
-   for (UInt_t i=0; i<fEventV.size();  i++) s << std::scientific << " " << fEventV[i];
-   for (UInt_t i=0; i<fTargets.size(); i++) s << std::scientific << " " << fTargets[i];
+   for (float i : fEventV) s << std::scientific << " " << i;
+   for (float fTarget : fTargets) s << std::scientific << " " << fTarget;
    s.flags(ff);
 }
 ////////////////////////////////////////////////////////////////////////////////
@@ -268,9 +268,9 @@ void TMVA::BinarySearchTreeNode::AddContentToNode( std::stringstream& s ) const
 void TMVA::BinarySearchTreeNode::ReadContent( std::stringstream& s )
 {
    Float_t temp=0;
-   for (UInt_t i=0; i<fEventV.size(); i++){
+   for (float & i : fEventV){
       s >> temp;
-      fEventV[i]=temp;
+      i=temp;
    }
    while (s >> temp) fTargets.push_back(temp);
 }

--- a/tmva/tmva/src/BinaryTree.cxx
+++ b/tmva/tmva/src/BinaryTree.cxx
@@ -52,7 +52,7 @@ ClassImp(TMVA::BinaryTree);
 ////////////////////////////////////////////////////////////////////////////////
 /// constructor for a yet "empty" tree. Needs to be filled afterwards
 
-TMVA::BinaryTree::BinaryTree( void )
+TMVA::BinaryTree::BinaryTree()
 : fRoot  ( nullptr ),
    fNNodes( 0 ),
    fDepth ( 0 )
@@ -62,7 +62,7 @@ TMVA::BinaryTree::BinaryTree( void )
 ////////////////////////////////////////////////////////////////////////////////
 ///destructor (deletes the nodes and "events" if owned by the tree
 
-TMVA::BinaryTree::~BinaryTree( void )
+TMVA::BinaryTree::~BinaryTree()
 {
    this->DeleteNode( fRoot );
    fRoot=nullptr;

--- a/tmva/tmva/src/BinaryTree.cxx
+++ b/tmva/tmva/src/BinaryTree.cxx
@@ -53,7 +53,7 @@ ClassImp(TMVA::BinaryTree);
 /// constructor for a yet "empty" tree. Needs to be filled afterwards
 
 TMVA::BinaryTree::BinaryTree( void )
-: fRoot  ( NULL ),
+: fRoot  ( nullptr ),
    fNNodes( 0 ),
    fDepth ( 0 )
 {
@@ -65,7 +65,7 @@ TMVA::BinaryTree::BinaryTree( void )
 TMVA::BinaryTree::~BinaryTree( void )
 {
    this->DeleteNode( fRoot );
-   fRoot=0;
+   fRoot=nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -73,7 +73,7 @@ TMVA::BinaryTree::~BinaryTree( void )
 
 void TMVA::BinaryTree::DeleteNode( TMVA::Node* node )
 {
-   if (node != NULL) { //If the node is not NULL...
+   if (node != nullptr) { //If the node is not NULL...
       this->DeleteNode(node->GetLeft());  //Delete its left node.
       this->DeleteNode(node->GetRight()); //Delete its right node.
 
@@ -102,17 +102,17 @@ TMVA::Node* TMVA::BinaryTree::GetRightDaughter( Node *n)
 
 UInt_t TMVA::BinaryTree::CountNodes(TMVA::Node *n)
 {
-   if (n == NULL){ //default, start at the tree top, then descend recursively
+   if (n == nullptr){ //default, start at the tree top, then descend recursively
       n = (Node*)this->GetRoot();
-      if (n == NULL) return 0 ;
+      if (n == nullptr) return 0 ;
    }
 
    UInt_t countNodes=1;
 
-   if (this->GetLeftDaughter(n) != NULL){
+   if (this->GetLeftDaughter(n) != nullptr){
       countNodes += this->CountNodes( this->GetLeftDaughter(n) );
    }
-   if (this->GetRightDaughter(n) != NULL) {
+   if (this->GetRightDaughter(n) != nullptr) {
       countNodes += this->CountNodes( this->GetRightDaughter(n) );
    }
 
@@ -169,9 +169,9 @@ std::ostream& TMVA::operator<< (std::ostream& os, const TMVA::BinaryTree& tree)
 void TMVA::BinaryTree::Read(std::istream & istr, UInt_t tmva_Version_Code )
 {
    Node * currentNode = GetRoot();
-   Node* parent = 0;
+   Node* parent = nullptr;
 
-   if(currentNode==0) {
+   if(currentNode==nullptr) {
       currentNode=CreateNode();
       SetRoot(currentNode);
    }
@@ -184,9 +184,9 @@ void TMVA::BinaryTree::Read(std::istream & istr, UInt_t tmva_Version_Code )
       }
 
       // find parent node
-      while( parent!=0 && parent->GetDepth() != currentNode->GetDepth()-1) parent=parent->GetParent();
+      while( parent!=nullptr && parent->GetDepth() != currentNode->GetDepth()-1) parent=parent->GetParent();
 
-      if (parent!=0) { // link new node to parent
+      if (parent!=nullptr) { // link new node to parent
          currentNode->SetParent(parent);
          if (currentNode->GetPos()=='l') parent->SetLeft(currentNode);
          if (currentNode->GetPos()=='r') parent->SetRight(currentNode);
@@ -212,17 +212,17 @@ std::istream& TMVA::operator>> (std::istream& istr, TMVA::BinaryTree& tree)
 
 void TMVA::BinaryTree::SetTotalTreeDepth( Node *n)
 {
-   if (n == NULL){ //default, start at the tree top, then descend recursively
+   if (n == nullptr){ //default, start at the tree top, then descend recursively
       n = (Node*) this->GetRoot();
-      if (n == NULL) {
+      if (n == nullptr) {
          Log() << kFATAL << "SetTotalTreeDepth: started with undefined ROOT node" <<Endl;
          return ;
       }
    }
-   if (this->GetLeftDaughter(n) != NULL){
+   if (this->GetLeftDaughter(n) != nullptr){
       this->SetTotalTreeDepth( this->GetLeftDaughter(n) );
    }
-   if (this->GetRightDaughter(n) != NULL) {
+   if (this->GetRightDaughter(n) != nullptr) {
       this->SetTotalTreeDepth( this->GetRightDaughter(n) );
    }
    if (n->GetDepth() > this->GetTotalTreeDepth()) this->SetTotalTreeDepth(n->GetDepth());

--- a/tmva/tmva/src/CCPruner.cxx
+++ b/tmva/tmva/src/CCPruner.cxx
@@ -70,12 +70,12 @@ CCPruner::CCPruner( DecisionTree* t_max, const EventList* validationSample,
                     SeparationBase* qualityIndex ) :
    fAlpha(-1.0),
    fValidationSample(validationSample),
-   fValidationDataSet(NULL),
+   fValidationDataSet(nullptr),
    fOptimalK(-1)
 {
    fTree = t_max;
 
-   if(qualityIndex == NULL) {
+   if(qualityIndex == nullptr) {
       fOwnQIndex = true;
       fQualityIndex = new MisClassificationError();
    }
@@ -92,13 +92,13 @@ CCPruner::CCPruner( DecisionTree* t_max, const EventList* validationSample,
 CCPruner::CCPruner( DecisionTree* t_max, const DataSet* validationSample,
                     SeparationBase* qualityIndex ) :
    fAlpha(-1.0),
-   fValidationSample(NULL),
+   fValidationSample(nullptr),
    fValidationDataSet(validationSample),
    fOptimalK(-1)
 {
    fTree = t_max;
 
-   if(qualityIndex == NULL) {
+   if(qualityIndex == nullptr) {
       fOwnQIndex = true;
       fQualityIndex = new MisClassificationError();
    }
@@ -134,7 +134,7 @@ void CCPruner::Optimize( )
 
    std::ofstream outfile;
    if (fDebug) outfile.open("costcomplexity.log");
-   if(!HaveStopCondition && (fValidationSample == NULL && fValidationDataSet == NULL) ) {
+   if(!HaveStopCondition && (fValidationSample == nullptr && fValidationDataSet == nullptr) ) {
       if (fDebug) outfile << "ERROR: no validation sample, so cannot optimize pruning!" << std::endl;
       delete dTWrapper;
       if (fDebug) outfile.close();
@@ -189,7 +189,7 @@ void CCPruner::Optimize( )
       k += 1;
       if(!HaveStopCondition) {
          Double_t q;
-         if (fValidationDataSet != NULL) q = dTWrapper->TestTreeQuality(fValidationDataSet);
+         if (fValidationDataSet != nullptr) q = dTWrapper->TestTreeQuality(fValidationDataSet);
          else q = dTWrapper->TestTreeQuality(fValidationSample);
          fQualityIndexList.push_back(q);
       }

--- a/tmva/tmva/src/CCTreeWrapper.cxx
+++ b/tmva/tmva/src/CCTreeWrapper.cxx
@@ -45,7 +45,7 @@ TMVA::CCTreeWrapper::CCTreeNode::CCTreeNode( DecisionTreeNode* n ) :
    fMinAlphaC(-1.0),
    fDTNode(n)
 {
-   if ( n != NULL && n->GetRight() != NULL && n->GetLeft() != NULL ) {
+   if ( n != nullptr && n->GetRight() != nullptr && n->GetLeft() != nullptr ) {
       SetRight( new CCTreeNode( ((DecisionTreeNode*) n->GetRight()) ) );
       GetRight()->SetParent(this);
       SetLeft( new CCTreeNode( ((DecisionTreeNode*) n->GetLeft()) ) );
@@ -57,8 +57,8 @@ TMVA::CCTreeWrapper::CCTreeNode::CCTreeNode( DecisionTreeNode* n ) :
 /// destructor of a CCTreeNode
 
 TMVA::CCTreeWrapper::CCTreeNode::~CCTreeNode() {
-   if(GetLeft() != NULL) delete GetLeftDaughter();
-   if(GetRight() != NULL) delete GetRightDaughter();
+   if(GetLeft() != nullptr) delete GetLeftDaughter();
+   if(GetRight() != nullptr) delete GetRightDaughter();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -92,7 +92,7 @@ void TMVA::CCTreeWrapper::CCTreeNode::Print( std::ostream& os ) const {
 
 void TMVA::CCTreeWrapper::CCTreeNode::PrintRec( std::ostream& os ) const {
    this->Print(os);
-   if(this->GetLeft() != NULL && this->GetRight() != NULL) {
+   if(this->GetLeft() != nullptr && this->GetRight() != nullptr) {
       this->GetLeft()->PrintRec(os);
       this->GetRight()->PrintRec(os);
    }
@@ -102,7 +102,7 @@ void TMVA::CCTreeWrapper::CCTreeNode::PrintRec( std::ostream& os ) const {
 /// constructor
 
 TMVA::CCTreeWrapper::CCTreeWrapper( DecisionTree* T, SeparationBase* qualityIndex ) :
-   fRoot(NULL)
+   fRoot(nullptr)
 {
    fDTParent = T;
    fRoot = new CCTreeNode( dynamic_cast<DecisionTreeNode*>(T->GetRoot()) );
@@ -129,7 +129,7 @@ void TMVA::CCTreeWrapper::InitTree( CCTreeNode* t )
    // set R(t) = Gini(t) or MisclassificationError(t), etc.
    t->SetNodeResubstitutionEstimate((s+b)*fQualityIndex->GetSeparationIndex(s,b));
 
-   if(t->GetLeft() != NULL && t->GetRight() != NULL) { // n is an interior (non-leaf) node
+   if(t->GetLeft() != nullptr && t->GetRight() != nullptr) { // n is an interior (non-leaf) node
       // traverse the tree
       InitTree(t->GetLeftDaughter());
       InitTree(t->GetRightDaughter());
@@ -159,8 +159,8 @@ void TMVA::CCTreeWrapper::InitTree( CCTreeNode* t )
 
 void TMVA::CCTreeWrapper::PruneNode( CCTreeNode* t )
 {
-   if( t->GetLeft() != NULL &&
-       t->GetRight() != NULL ) {
+   if( t->GetLeft() != nullptr &&
+       t->GetRight() != nullptr ) {
       CCTreeNode* l = t->GetLeftDaughter();
       CCTreeNode* r = t->GetRightDaughter();
       t->SetNLeafDaughters( 1 );
@@ -169,8 +169,8 @@ void TMVA::CCTreeWrapper::PruneNode( CCTreeNode* t )
       t->SetMinAlphaC( std::numeric_limits<double>::infinity( ) );
       delete l;
       delete r;
-      t->SetLeft(NULL);
-      t->SetRight(NULL);
+      t->SetLeft(nullptr);
+      t->SetRight(nullptr);
    }else{
       std::cout << " ERROR in CCTreeWrapper::PruneNode: you try to prune a leaf node.. that does not make sense " << std::endl;
    }
@@ -229,8 +229,8 @@ Double_t TMVA::CCTreeWrapper::CheckEvent( const TMVA::Event & e, Bool_t useYesNo
    CCTreeNode* t = fRoot;
 
    while(//current->GetNodeType() == 0 &&
-         t->GetLeft() != NULL &&
-         t->GetRight() != NULL){ // at an interior (non-leaf) node
+         t->GetLeft() != nullptr &&
+         t->GetRight() != nullptr){ // at an interior (non-leaf) node
       if (current->GoesRight(e)) {
          //current = (DecisionTreeNode*)current->GetRight();
          t = t->GetRightDaughter();

--- a/tmva/tmva/src/CCTreeWrapper.cxx
+++ b/tmva/tmva/src/CCTreeWrapper.cxx
@@ -183,14 +183,14 @@ void TMVA::CCTreeWrapper::PruneNode( CCTreeNode* t )
 Double_t TMVA::CCTreeWrapper::TestTreeQuality( const EventList* validationSample )
 {
    Double_t ncorrect=0, nfalse=0;
-   for (UInt_t ievt=0; ievt < validationSample->size(); ievt++) {
-      Bool_t isSignalType = (CheckEvent(*(*validationSample)[ievt]) > fDTParent->GetNodePurityLimit() ) ? 1 : 0;
+   for (auto ievt : *validationSample) {
+      Bool_t isSignalType = (CheckEvent(*ievt) > fDTParent->GetNodePurityLimit() ) ? 1 : 0;
 
-      if (isSignalType == ((*validationSample)[ievt]->GetClass() == 0)) {
-         ncorrect += (*validationSample)[ievt]->GetWeight();
+      if (isSignalType == (ievt->GetClass() == 0)) {
+         ncorrect += ievt->GetWeight();
       }
       else{
-         nfalse += (*validationSample)[ievt]->GetWeight();
+         nfalse += ievt->GetWeight();
       }
    }
    return  ncorrect / (ncorrect + nfalse);

--- a/tmva/tmva/src/ClassInfo.cxx
+++ b/tmva/tmva/src/ClassInfo.cxx
@@ -50,7 +50,7 @@ TMVA::ClassInfo::ClassInfo( const TString& name )
      fWeight( "" ),
      fCut( "" ),
      fNumber( 0 ),
-     fCorrMatrix( 0 ),
+     fCorrMatrix( nullptr ),
      fLogger( new MsgLogger("ClassInfo", kINFO) )
 {
 }

--- a/tmva/tmva/src/Classification.cxx
+++ b/tmva/tmva/src/Classification.cxx
@@ -1183,9 +1183,9 @@ void TMVA::Experimental::Classification::MergeFiles()
    TestTree->Write();
    ifile->Close();
    // cleaning
-   for (UInt_t i = 0; i < fMethods.size(); i++) {
-      auto methodname = fMethods[i].GetValue<TString>("MethodName");
-      auto methodtitle = fMethods[i].GetValue<TString>("MethodTitle");
+   for (auto & fMethod : fMethods) {
+      auto methodname = fMethod.GetValue<TString>("MethodName");
+      auto methodtitle = fMethod.GetValue<TString>("MethodTitle");
       auto fname = Form(".%s%s%s.root", fDataLoader->GetName(), methodname.Data(), methodtitle.Data());
       gSystem->Unlink(fname);
    }

--- a/tmva/tmva/src/Classification.cxx
+++ b/tmva/tmva/src/Classification.cxx
@@ -200,7 +200,7 @@ TMVA::Experimental::Classification::Classification(DataLoader *dataloader, TFile
  * \param options string extra options.
  */
 TMVA::Experimental::Classification::Classification(DataLoader *dataloader, TString options)
-   : TMVA::Envelope("Classification", dataloader, NULL, options), fAnalysisType(Types::kClassification),
+   : TMVA::Envelope("Classification", dataloader, nullptr, options), fAnalysisType(Types::kClassification),
      fCorrelations(kFALSE), fROC(kTRUE)
 {
 
@@ -221,7 +221,7 @@ TMVA::Experimental::Classification::Classification(DataLoader *dataloader, TStri
 TMVA::Experimental::Classification::~Classification()
 {
    for (auto m : fIMethods) {
-      if (m != NULL)
+      if (m != nullptr)
          delete m;
    }
 }
@@ -386,7 +386,7 @@ TMVA::MethodBase *TMVA::Experimental::Classification::GetMethod(TString methodna
    if (!HasMethod(methodname, methodtitle)) {
       std::cout << methodname << " " << methodtitle << std::endl;
       Log() << kERROR << "Trying to get method not booked." << Endl;
-      return 0;
+      return nullptr;
    }
    Int_t index = -1;
    if (HasMethodObject(methodname, methodtitle, index)) {
@@ -440,8 +440,8 @@ TMVA::MethodBase *TMVA::Experimental::Classification::GetMethod(TString methodna
    }
 
    MethodBase *method = dynamic_cast<MethodBase *>(im);
-   if (method == 0)
-      return 0; // could not create method
+   if (method == nullptr)
+      return nullptr; // could not create method
 
    // set fDataSetManager if MethodCategory (to enable Category to create datasetinfo objects)
    if (method->GetMethodType() == Types::kCategory) {
@@ -461,7 +461,7 @@ TMVA::MethodBase *TMVA::Experimental::Classification::GetMethod(TString methodna
                                 GetDataLoaderDataSetInfo().GetNTargets())) {
       Log() << kWARNING << "Method " << method->GetMethodTypeName() << " is not capable of handling ";
       Log() << "classification with " << GetDataLoaderDataSetInfo().GetNClasses() << " classes." << Endl;
-      return 0;
+      return nullptr;
    }
 
    if (fModelPersistence)
@@ -556,7 +556,7 @@ void TMVA::Experimental::Classification::TestMethod(TString methodname, TString 
    method->SetFile(fFile.get());
    method->SetSilentFile(IsSilentFile());
 
-   MethodBase *methodNoCuts = NULL;
+   MethodBase *methodNoCuts = nullptr;
    if (!IsCutsMethod(method))
       methodNoCuts = method;
 
@@ -634,7 +634,7 @@ void TMVA::Experimental::Classification::TestMethod(TString methodname, TString 
    // --> count overlaps
    // -----------------------------------------------------------------------
    if (fCorrelations) {
-      const Int_t nmeth = methodNoCuts == NULL ? 0 : 1;
+      const Int_t nmeth = methodNoCuts == nullptr ? 0 : 1;
       const Int_t nvar = method->fDataSetInfo.GetNVariables();
       if (nmeth > 0) {
 
@@ -668,7 +668,7 @@ void TMVA::Experimental::Classification::TestMethod(TString methodname, TString 
             const Event *ev = defDs->GetEvent(ievt);
 
             //                 for correlations
-            TMatrixD *theMat = 0;
+            TMatrixD *theMat = nullptr;
             for (Int_t im = 0; im < nmeth; im++) {
                //                    check for NaN value
                Double_t retval = (Double_t)(*mvaRes[im])[ievt][0];
@@ -715,7 +715,7 @@ void TMVA::Experimental::Classification::TestMethod(TString methodname, TString 
          const TMatrixD *corrMatB = gTools().GetCorrelationMatrix(covMatB);
 
          //              print correlation matrices
-         if (corrMatS != 0 && corrMatB != 0) {
+         if (corrMatS != nullptr && corrMatB != nullptr) {
 
             //                 extract MVA matrix
             TMatrixD mvaMatS(nmeth, nmeth);
@@ -1128,15 +1128,15 @@ void TMVA::Experimental::Classification::MergeFiles()
 {
 
    auto dsdir = fFile->mkdir(fDataLoader->GetName()); // dataset dir
-   TTree *TrainTree = 0;
-   TTree *TestTree = 0;
-   TFile *ifile = 0;
-   TFile *ofile = 0;
+   TTree *TrainTree = nullptr;
+   TTree *TestTree = nullptr;
+   TFile *ifile = nullptr;
+   TFile *ofile = nullptr;
    for (UInt_t i = 0; i < fMethods.size(); i++) {
       auto methodname = fMethods[i].GetValue<TString>("MethodName");
       auto methodtitle = fMethods[i].GetValue<TString>("MethodTitle");
       auto fname = Form(".%s%s%s.root", fDataLoader->GetName(), methodname.Data(), methodtitle.Data());
-      TDirectoryFile *ds = 0;
+      TDirectoryFile *ds = nullptr;
       if (i == 0) {
          ifile = new TFile(fname);
          ds = (TDirectoryFile *)ifile->Get(fDataLoader->GetName());

--- a/tmva/tmva/src/ClassifierFactory.cxx
+++ b/tmva/tmva/src/ClassifierFactory.cxx
@@ -39,7 +39,7 @@ class TString;
 ///
 /// Initialize static singleton pointer
 ///
-TMVA::ClassifierFactory* TMVA::ClassifierFactory::fgInstance = 0;
+TMVA::ClassifierFactory* TMVA::ClassifierFactory::fgInstance = nullptr;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// access to the ClassifierFactory singleton
@@ -57,7 +57,7 @@ TMVA::ClassifierFactory& TMVA::ClassifierFactory::Instance()
 
 void TMVA::ClassifierFactory::DestroyInstance()
 {
-   if (fgInstance!=0) delete fgInstance;
+   if (fgInstance!=nullptr) delete fgInstance;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/src/Config.cxx
+++ b/tmva/tmva/src/Config.cxx
@@ -42,7 +42,7 @@ Singleton class for global configuration settings used by TMVA.
 ClassImp(TMVA::Config);
 
 #if __cplusplus > 199711L
-std::atomic<TMVA::Config*> TMVA::Config::fgConfigPtr{ 0 };
+std::atomic<TMVA::Config*> TMVA::Config::fgConfigPtr{ nullptr };
 #else
 TMVA::Config* TMVA::Config::fgConfigPtr = 0;
 #endif
@@ -89,7 +89,7 @@ TMVA::Config::~Config()
 void TMVA::Config::DestroyInstance()
 {
 #if __cplusplus > 199711L
-   delete fgConfigPtr.exchange(0);
+   delete fgConfigPtr.exchange(nullptr);
 #else
    if (fgConfigPtr != 0) { delete fgConfigPtr; fgConfigPtr = 0;}
 #endif
@@ -103,7 +103,7 @@ TMVA::Config& TMVA::Config::Instance()
 #if __cplusplus > 199711L
    if(!fgConfigPtr) {
       TMVA::Config* tmp = new Config();
-      TMVA::Config* expected = 0;
+      TMVA::Config* expected = nullptr;
       if(! fgConfigPtr.compare_exchange_strong(expected,tmp) ) {
          //another thread beat us to the switch
          delete tmp;

--- a/tmva/tmva/src/Configurable.cxx
+++ b/tmva/tmva/src/Configurable.cxx
@@ -71,7 +71,7 @@ TMVA::Configurable::Configurable( const TString& theOption)
 : TNamed("Configurable","Configurable"),
    fOptions                    ( theOption ),
    fLooseOptionCheckingEnabled ( kTRUE ),
-   fLastDeclaredOption         ( 0 ),
+   fLastDeclaredOption         ( nullptr ),
    fConfigDescription          ( "No description" ),
    fReferenceFile              ( "None" ),
    fLogger                     ( new MsgLogger(this) )
@@ -170,7 +170,7 @@ void TMVA::Configurable::ParseOptions()
          // the optname. Sometimes the [] is part of the optname and
          // does not describe an array
          OptionBase* decOpt = (OptionBase *)fListOfOptions.FindObject(optname);
-         if (decOpt==0 && optname.Contains('[')) {
+         if (decOpt==nullptr && optname.Contains('[')) {
             // now we see if there is an [] and if the optname exists
             // after removing the [idx]
             TString st = optname(optname.First('[')+1,100);
@@ -182,7 +182,7 @@ void TMVA::Configurable::ParseOptions()
          }
 
          TListIter optIt(&fListOfOptions);
-         if (decOpt!=0) {
+         if (decOpt!=nullptr) {
             if (decOpt->IsSet())
                Log() << kWARNING << "Value for option " << decOpt->GetName()
                      << " was previously set to " << decOpt->GetValue() << Endl;
@@ -220,19 +220,19 @@ void TMVA::Configurable::ParseOptions()
          Bool_t hasNotSign = kFALSE;
          if (s.BeginsWith("!")) { s.Remove(0,1); preserveNotSign = hasNotSign = kTRUE; }
          TString optname(s); optname.ToLower();
-         OptionBase* decOpt = 0;
+         OptionBase* decOpt = nullptr;
          Bool_t optionExists = kFALSE;
          TListIter optIt(&fListOfOptions);
-         while ((decOpt = (OptionBase*)optIt()) !=0) {
+         while ((decOpt = (OptionBase*)optIt()) !=nullptr) {
             TString predOptName(decOpt->GetName());
             predOptName.ToLower();
             if (predOptName == optname) optionExists = kTRUE;
-            if (dynamic_cast<Option<bool>*>(decOpt)==0) continue; // not a boolean option
+            if (dynamic_cast<Option<bool>*>(decOpt)==nullptr) continue; // not a boolean option
             if (predOptName == optname) break;
          }
 
 
-         if (decOpt != 0) {
+         if (decOpt != nullptr) {
             decOpt->SetValue( hasNotSign ? "0" : "1" );
             paramParsed = kTRUE;
          }
@@ -356,7 +356,7 @@ void TMVA::Configurable::AddOptionsXMLTo( void* parent ) const
    void* opts = gTools().AddChild(parent, "Options");
    TListIter optIt( &fListOfOptions );
    while (OptionBase * opt = (OptionBase *) optIt()) {
-      void* optnode = 0;
+      void* optnode = nullptr;
       if (opt->IsArrayOpt()) {
          std::stringstream s("");
          s.precision( 16 );
@@ -384,7 +384,7 @@ void TMVA::Configurable::ReadOptionsFromXML( void* node )
    void* opt = gTools().GetChild(node);
    TString optName, optValue;
    fOptions="";
-   while (opt != 0) {
+   while (opt != nullptr) {
       if (fOptions.Length()!=0) fOptions += ":";
       gTools().ReadAttr(opt, "name", optName);
       optValue = TString( gTools().GetContent(opt) );

--- a/tmva/tmva/src/CostComplexityPruneTool.cxx
+++ b/tmva/tmva/src/CostComplexityPruneTool.cxx
@@ -128,7 +128,7 @@ CostComplexityPruneTool::CalculatePruningInfo( DecisionTree* dt,
    try {
       InitTreePruningMetaData((DecisionTreeNode*)dt->GetRoot());
    }
-   catch(std::string error) {
+   catch(const std::string &error) {
       Log() << kERROR << "Couldn't initialize the tree meta data because of error ("
             << error << ")" << Endl;
       return nullptr;
@@ -139,7 +139,7 @@ CostComplexityPruneTool::CalculatePruningInfo( DecisionTree* dt,
    try {
       Optimize( dt, W );  // run the cost complexity pruning algorithm
    }
-   catch(std::string error) {
+   catch(const std::string &error) {
       Log() << kERROR << "Error optimizing pruning sequence ("
             << error << ")" << Endl;
       return nullptr;

--- a/tmva/tmva/src/CostComplexityPruneTool.cxx
+++ b/tmva/tmva/src/CostComplexityPruneTool.cxx
@@ -88,7 +88,7 @@ CostComplexityPruneTool::CostComplexityPruneTool( SeparationBase* qualityIndex )
 /// the destructor for the cost complexity pruning
 
 CostComplexityPruneTool::~CostComplexityPruneTool( ) {
-   if(fQualityIndexTool != NULL) delete fQualityIndexTool;
+   if(fQualityIndexTool != nullptr) delete fQualityIndexTool;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -102,11 +102,11 @@ CostComplexityPruneTool::CalculatePruningInfo( DecisionTree* dt,
 {
    if( isAutomatic ) SetAutomatic();
 
-   if( dt == NULL || (IsAutomatic() && validationSample == NULL) ) {
+   if( dt == nullptr || (IsAutomatic() && validationSample == nullptr) ) {
       // must have a valid decision tree to prune, and if the prune strength
       // is to be chosen automatically, must have a test sample from
       // which to calculate the quality of the pruned tree(s)
-      return NULL;
+      return nullptr;
    }
 
    Double_t Q = -1.0;
@@ -131,7 +131,7 @@ CostComplexityPruneTool::CalculatePruningInfo( DecisionTree* dt,
    catch(std::string error) {
       Log() << kERROR << "Couldn't initialize the tree meta data because of error ("
             << error << ")" << Endl;
-      return NULL;
+      return nullptr;
    }
 
    Log() << kDEBUG << "Automatic cost complexity pruning is " << (IsAutomatic()?"on":"off") << "." << Endl;
@@ -142,7 +142,7 @@ CostComplexityPruneTool::CalculatePruningInfo( DecisionTree* dt,
    catch(std::string error) {
       Log() << kERROR << "Error optimizing pruning sequence ("
             << error << ")" << Endl;
-      return NULL;
+      return nullptr;
    }
 
    Log() << kDEBUG << "Index of pruning sequence to stop at: " << fOptimalK << Endl;
@@ -180,7 +180,7 @@ CostComplexityPruneTool::CalculatePruningInfo( DecisionTree* dt,
 /// critical alpha, the minimal alpha down the tree, etc...  for each node!!
 
 void CostComplexityPruneTool::InitTreePruningMetaData( DecisionTreeNode* n ) {
-   if( n == NULL ) return;
+   if( n == nullptr ) return;
 
    Double_t s = n->GetNSigEvents();
    Double_t b = n->GetNBkgEvents();
@@ -188,7 +188,7 @@ void CostComplexityPruneTool::InitTreePruningMetaData( DecisionTreeNode* n ) {
    if (fQualityIndexTool) n->SetNodeR( (s+b)*fQualityIndexTool->GetSeparationIndex(s,b));
    else n->SetNodeR( (s+b)*n->GetSeparationIndex() );
 
-   if(n->GetLeft() != NULL && n->GetRight() != NULL) { // n is an interior (non-leaf) node
+   if(n->GetLeft() != nullptr && n->GetRight() != nullptr) { // n is an interior (non-leaf) node
       n->SetTerminal(kFALSE);
       // traverse the tree
       InitTreePruningMetaData(n->GetLeft());

--- a/tmva/tmva/src/CrossValidation.cxx
+++ b/tmva/tmva/src/CrossValidation.cxx
@@ -318,7 +318,7 @@ void TMVA::CrossValidation::SetNumFolds(UInt_t i)
    if (i != fNumFolds) {
       fNumFolds = i;
       fSplit = std::unique_ptr<CvSplitCrossValidation>(new CvSplitCrossValidation(fNumFolds, fSplitExprString));
-      fDataLoader->MakeKFoldDataSet(*fSplit.get());
+      fDataLoader->MakeKFoldDataSet(*fSplit);
       fFoldStatus = kTRUE;
    }
 }
@@ -331,7 +331,7 @@ void TMVA::CrossValidation::SetSplitExpr(TString splitExpr)
    if (splitExpr != fSplitExprString) {
       fSplitExprString = splitExpr;
       fSplit = std::unique_ptr<CvSplitCrossValidation>(new CvSplitCrossValidation(fNumFolds, fSplitExprString));
-      fDataLoader->MakeKFoldDataSet(*fSplit.get());
+      fDataLoader->MakeKFoldDataSet(*fSplit);
       fFoldStatus = kTRUE;
    }
 }
@@ -369,7 +369,7 @@ void TMVA::CrossValidation::ProcessFold(UInt_t iFold, UInt_t iMethod)
       fFoldFactory = std::unique_ptr<TMVA::Factory>(new TMVA::Factory(fJobName, foldOutputFile, fCvFactoryOptions));
    }
 
-   fDataLoader->PrepareFoldDataSet(*fSplit.get(), iFold, TMVA::Types::kTraining);
+   fDataLoader->PrepareFoldDataSet(*fSplit, iFold, TMVA::Types::kTraining);
    MethodBase *smethod = fFoldFactory->BookMethod(fDataLoader.get(), methodName, foldTitle, methodOptions);
 
    // Train method (train method and eval train set)
@@ -436,7 +436,7 @@ void TMVA::CrossValidation::Evaluate()
 
       // Generate K folds on given dataset
       if (!fFoldStatus) {
-         fDataLoader->MakeKFoldDataSet(*fSplit.get());
+         fDataLoader->MakeKFoldDataSet(*fSplit);
          fFoldStatus = kTRUE;
       }
 
@@ -456,7 +456,7 @@ void TMVA::CrossValidation::Evaluate()
       fFactory->BookMethod(fDataLoader.get(), Types::kCrossValidation, methodTitle, options);
 
       // Evaluation
-      fDataLoader->RecombineKFoldDataSet(*fSplit.get());
+      fDataLoader->RecombineKFoldDataSet(*fSplit);
 
       fFactory->TrainAllMethods();
       fFactory->TestAllMethods();

--- a/tmva/tmva/src/CvSplit.cxx
+++ b/tmva/tmva/src/CvSplit.cxx
@@ -73,25 +73,25 @@ void TMVA::CvSplitBootstrappedStratified::MakeKFoldDataSet(DataSetInfo &dsi)
    std::vector<TMVA::Event *> TestBkgData;
 
    // Split the testing and training sets into signal and background classes.
-   for (UInt_t i = 0; i < TrainingData.size(); ++i) {
-      if (strncmp(dsi.GetClassInfo(TrainingData.at(i)->GetClass())->GetName(), "Signal", 6) == 0) {
-         TrainSigData.push_back(TrainingData.at(i));
-      } else if (strncmp(dsi.GetClassInfo(TrainingData.at(i)->GetClass())->GetName(), "Background", 10) == 0) {
-         TrainBkgData.push_back(TrainingData.at(i));
+   for (auto i : TrainingData) {
+      if (strncmp(dsi.GetClassInfo(i->GetClass())->GetName(), "Signal", 6) == 0) {
+         TrainSigData.push_back(i);
+      } else if (strncmp(dsi.GetClassInfo(i->GetClass())->GetName(), "Background", 10) == 0) {
+         TrainBkgData.push_back(i);
       } else {
          Log() << kFATAL << "DataSets should only contain Signal and Background classes for classification, "
-               << dsi.GetClassInfo(TrainingData.at(i)->GetClass())->GetName() << " is not a recognised class" << Endl;
+               << dsi.GetClassInfo(i->GetClass())->GetName() << " is not a recognised class" << Endl;
       }
    }
 
-   for (UInt_t i = 0; i < TestingData.size(); ++i) {
-      if (strncmp(dsi.GetClassInfo(TestingData.at(i)->GetClass())->GetName(), "Signal", 6) == 0) {
-         TestSigData.push_back(TestingData.at(i));
-      } else if (strncmp(dsi.GetClassInfo(TestingData.at(i)->GetClass())->GetName(), "Background", 10) == 0) {
-         TestBkgData.push_back(TestingData.at(i));
+   for (auto i : TestingData) {
+      if (strncmp(dsi.GetClassInfo(i->GetClass())->GetName(), "Signal", 6) == 0) {
+         TestSigData.push_back(i);
+      } else if (strncmp(dsi.GetClassInfo(i->GetClass())->GetName(), "Background", 10) == 0) {
+         TestBkgData.push_back(i);
       } else {
          Log() << kFATAL << "DataSets should only contain Signal and Background classes for classification, "
-               << dsi.GetClassInfo(TestingData.at(i)->GetClass())->GetName() << " is not a recognised class" << Endl;
+               << dsi.GetClassInfo(i->GetClass())->GetName() << " is not a recognised class" << Endl;
       }
    }
 

--- a/tmva/tmva/src/DataInputHandler.cxx
+++ b/tmva/tmva/src/DataInputHandler.cxx
@@ -195,8 +195,8 @@ void TMVA::DataInputHandler::ClearTreeList( const TString& className )
 std::vector< TString >* TMVA::DataInputHandler::GetClassList() const
 {
    std::vector< TString >* ret = new std::vector< TString >();
-   for ( std::map< TString, std::vector<TreeInfo> >::iterator it = fInputTrees.begin(); it != fInputTrees.end(); ++it ){
-      ret->push_back( it->first );
+   for (auto & fInputTree : fInputTrees){
+      ret->push_back( fInputTree.first );
    }
    return ret;
 }
@@ -218,8 +218,8 @@ UInt_t TMVA::DataInputHandler::GetEntries(const std::vector<TreeInfo>& tiV) cons
 UInt_t TMVA::DataInputHandler::GetEntries() const
 {
    UInt_t number = 0;
-   for (std::map< TString, std::vector<TreeInfo> >::iterator it = fInputTrees.begin(); it != fInputTrees.end(); ++it) {
-      number += GetEntries( it->second );
+   for (auto & fInputTree : fInputTrees) {
+      number += GetEntries( fInputTree.second );
    }
    return number;
 }

--- a/tmva/tmva/src/DataInputHandler.cxx
+++ b/tmva/tmva/src/DataInputHandler.cxx
@@ -155,7 +155,7 @@ TTree* TMVA::DataInputHandler::ReadInputTree( const TString& dataFile )
 {
    TTree* tr = new TTree( "tmp", dataFile );
    std::ifstream in(dataFile);
-   tr->SetDirectory(0); Log() << kWARNING << "Watch out, I (Helge) made the Tree not associated to the current directory .. Hopefully that does not have unwanted consequences" << Endl;
+   tr->SetDirectory(nullptr); Log() << kWARNING << "Watch out, I (Helge) made the Tree not associated to the current directory .. Hopefully that does not have unwanted consequences" << Endl;
    if (!in.good()) Log() << kFATAL << "Could not open file: " << dataFile << Endl;
    in.close();
 

--- a/tmva/tmva/src/DataLoader.cxx
+++ b/tmva/tmva/src/DataLoader.cxx
@@ -537,8 +537,7 @@ TMVA::DataSetInfo& TMVA::DataLoader::DefaultDataSetInfo()
 
 void TMVA::DataLoader::SetInputVariables( std::vector<TString>* theVariables )
 {
-   for (std::vector<TString>::iterator it=theVariables->begin();
-        it!=theVariables->end(); ++it) AddVariable(*it);
+   for (auto & theVariable : *theVariables) AddVariable(theVariable);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/src/DataLoader.cxx
+++ b/tmva/tmva/src/DataLoader.cxx
@@ -86,7 +86,7 @@ ClassImp(TMVA::DataLoader);
 
 TMVA::DataLoader::DataLoader( TString thedlName)
 : Configurable( ),
-   fDataSetManager       ( NULL ), //DSMTEST
+   fDataSetManager       ( nullptr ), //DSMTEST
    fDataInputHandler     ( new DataInputHandler ),
    fTransformations      ( "I" ),
    fVerbose              ( kFALSE ),
@@ -134,7 +134,7 @@ TMVA::DataSetInfo& TMVA::DataLoader::AddDataSet( const TString& dsiName )
 {
    DataSetInfo* dsi = fDataSetManager->GetDataSetInfo(dsiName); // DSMTEST
 
-   if (dsi!=0) return *dsi;
+   if (dsi!=nullptr) return *dsi;
 
    return fDataSetManager->AddDataSetInfo(*(new DataSetInfo(dsiName))); // DSMTEST
 }
@@ -201,7 +201,7 @@ TMVA::DataLoader* TMVA::DataLoader::VarTransform(TString trafoDefinition)
 TTree* TMVA::DataLoader::CreateEventAssignTrees( const TString& name )
 {
    TTree * assignTree = new TTree( name, name );
-   assignTree->SetDirectory(0);
+   assignTree->SetDirectory(nullptr);
    assignTree->Branch( "type",   &fATreeType,   "ATreeType/I" );
    assignTree->Branch( "weight", &fATreeWeight, "ATreeWeight/F" );
 
@@ -293,11 +293,11 @@ void TMVA::DataLoader::AddEvent( const TString& className, Types::ETreeType tt,
 
 
    if (clIndex>=fTrainAssignTree.size()) {
-      fTrainAssignTree.resize(clIndex+1, 0);
-      fTestAssignTree.resize(clIndex+1, 0);
+      fTrainAssignTree.resize(clIndex+1, nullptr);
+      fTestAssignTree.resize(clIndex+1, nullptr);
    }
 
-   if (fTrainAssignTree[clIndex]==0) { // does not exist yet
+   if (fTrainAssignTree[clIndex]==nullptr) { // does not exist yet
       fTrainAssignTree[clIndex] = CreateEventAssignTrees( Form("TrainAssignTree_%s", className.Data()) );
       fTestAssignTree[clIndex]  = CreateEventAssignTrees( Form("TestAssignTree_%s",  className.Data()) );
    }
@@ -316,7 +316,7 @@ void TMVA::DataLoader::AddEvent( const TString& className, Types::ETreeType tt,
 
 Bool_t TMVA::DataLoader::UserAssignEvents(UInt_t clIndex)
 {
-   return fTrainAssignTree[clIndex]!=0;
+   return fTrainAssignTree[clIndex]!=nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/src/DataLoader.cxx
+++ b/tmva/tmva/src/DataLoader.cxx
@@ -100,7 +100,7 @@ TMVA::DataLoader::DataLoader( TString thedlName)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TMVA::DataLoader::~DataLoader( void )
+TMVA::DataLoader::~DataLoader()
 {
    // destructor
 

--- a/tmva/tmva/src/DataSet.cxx
+++ b/tmva/tmva/src/DataSet.cxx
@@ -129,8 +129,8 @@ TMVA::DataSet::~DataSet()
 
    fBlockBelongToTraining.clear();
    // delete results
-   for (std::vector< std::map< TString, Results* > >::iterator it = fResults.begin(); it != fResults.end(); ++it) {
-      for (std::map< TString, Results* >::iterator itMap = (*it).begin(); itMap != (*it).end(); ++itMap) {
+   for (auto & fResult : fResults) {
+      for (std::map< TString, Results* >::iterator itMap = fResult.begin(); itMap != fResult.end(); ++itMap) {
          delete itMap->second;
       }
    }
@@ -192,7 +192,7 @@ void TMVA::DataSet::DestroyCollection(Types::ETreeType type, Bool_t deleteEvents
    if (i>=fEventCollection.size() || fEventCollection[i].size()==0) return;
    if (deleteEvents) {
 
-      for (UInt_t j=0; j<fEventCollection[i].size(); j++) delete fEventCollection[i][j];
+      for (auto & j : fEventCollection[i]) delete j;
    }
    fEventCollection[i].clear();
 }
@@ -620,27 +620,24 @@ TTree* TMVA::DataSet::GetTree( Types::ETreeType type )
 
    // create all branches for the variables
    Int_t n = 0;
-   for (std::vector<VariableInfo>::const_iterator itVars = fdsi->GetVariableInfos().begin();
-        itVars != fdsi->GetVariableInfos().end(); ++itVars) {
+   for (const auto & itVars : fdsi->GetVariableInfos()) {
 
       // has to be changed to take care of types different than float: TODO
-      tree->Branch( (*itVars).GetInternalName(), &varVals[n], (*itVars).GetInternalName()+TString("/F") );
+      tree->Branch( itVars.GetInternalName(), &varVals[n], itVars.GetInternalName()+TString("/F") );
       n++;
    }
    // create the branches for the targets
    n = 0;
-   for (std::vector<VariableInfo>::const_iterator itTgts = fdsi->GetTargetInfos().begin();
-        itTgts != fdsi->GetTargetInfos().end(); ++itTgts) {
+   for (const auto & itTgts : fdsi->GetTargetInfos()) {
       // has to be changed to take care of types different than float: TODO
-      tree->Branch( (*itTgts).GetInternalName(), &tgtVals[n], (*itTgts).GetInternalName()+TString("/F") );
+      tree->Branch( itTgts.GetInternalName(), &tgtVals[n], itTgts.GetInternalName()+TString("/F") );
       n++;
    }
    // create the branches for the spectator variables
    n = 0;
-   for (std::vector<VariableInfo>::const_iterator itVis = fdsi->GetSpectatorInfos().begin();
-        itVis != fdsi->GetSpectatorInfos().end(); ++itVis) {
+   for (const auto & itVis : fdsi->GetSpectatorInfos()) {
       // has to be changed to take care of types different than float: TODO
-      tree->Branch( (*itVis).GetInternalName(), &visVals[n], (*itVis).GetInternalName()+TString("/F") );
+      tree->Branch( itVis.GetInternalName(), &visVals[n], itVis.GetInternalName()+TString("/F") );
       n++;
    }
 
@@ -648,18 +645,17 @@ TTree* TMVA::DataSet::GetTree( Types::ETreeType type )
 
    // create all the branches for the results
    n = 0;
-   for (std::map< TString, Results* >::iterator itMethod = fResults.at(t).begin();
-        itMethod != fResults.at(t).end(); ++itMethod) {
+   for (auto & itMethod : fResults.at(t)) {
 
 
-      Log() << kDEBUG << Form("Dataset[%s] : ",fdsi->GetName()) << "analysis type: " << (itMethod->second->GetAnalysisType()==Types::kRegression ? "Regression" :
-                                                                                        (itMethod->second->GetAnalysisType()==Types::kMulticlass ? "Multiclass" : "Classification" )) << Endl;
+      Log() << kDEBUG << Form("Dataset[%s] : ",fdsi->GetName()) << "analysis type: " << (itMethod.second->GetAnalysisType()==Types::kRegression ? "Regression" :
+                                                                                        (itMethod.second->GetAnalysisType()==Types::kMulticlass ? "Multiclass" : "Classification" )) << Endl;
 
-      if (itMethod->second->GetAnalysisType() == Types::kClassification) {
+      if (itMethod.second->GetAnalysisType() == Types::kClassification) {
          // classification
-         tree->Branch( itMethod->first, &(metVals[n][0]), itMethod->first + "/F" );
+         tree->Branch( itMethod.first, &(metVals[n][0]), itMethod.first + "/F" );
       }
-      else if (itMethod->second->GetAnalysisType() == Types::kMulticlass) {
+      else if (itMethod.second->GetAnalysisType() == Types::kMulticlass) {
          // multiclass classification
          TString leafList("");
          for (UInt_t iCls = 0; iCls < fdsi->GetNClasses(); iCls++) {
@@ -667,11 +663,11 @@ TTree* TMVA::DataSet::GetTree( Types::ETreeType type )
             leafList.Append( fdsi->GetClassInfo( iCls )->GetName() );
             leafList.Append( "/F" );
          }
-         Log() << kDEBUG << Form("Dataset[%s] : ",fdsi->GetName()) << "itMethod->first " << itMethod->first <<  "    LEAFLIST: "
-               << leafList << "    itMethod->second " << itMethod->second <<  Endl;
-         tree->Branch( itMethod->first, (metVals[n]), leafList );
+         Log() << kDEBUG << Form("Dataset[%s] : ",fdsi->GetName()) << "itMethod->first " << itMethod.first <<  "    LEAFLIST: "
+               << leafList << "    itMethod->second " << itMethod.second <<  Endl;
+         tree->Branch( itMethod.first, (metVals[n]), leafList );
       }
-      else if (itMethod->second->GetAnalysisType() == Types::kRegression) {
+      else if (itMethod.second->GetAnalysisType() == Types::kRegression) {
          // regression
          TString leafList("");
          for (UInt_t iTgt = 0; iTgt < fdsi->GetNTargets(); iTgt++) {
@@ -680,9 +676,9 @@ TTree* TMVA::DataSet::GetTree( Types::ETreeType type )
             //            leafList.Append( fdsi->GetTargetInfo( iTgt ).GetLabel() );
             leafList.Append( "/F" );
          }
-         Log() << kDEBUG << Form("Dataset[%s] : ",fdsi->GetName()) << "itMethod->first " << itMethod->first <<  "    LEAFLIST: "
-               << leafList << "    itMethod->second " << itMethod->second <<  Endl;
-         tree->Branch( itMethod->first, (metVals[n]), leafList );
+         Log() << kDEBUG << Form("Dataset[%s] : ",fdsi->GetName()) << "itMethod->first " << itMethod.first <<  "    LEAFLIST: "
+               << leafList << "    itMethod->second " << itMethod.second <<  Endl;
+         tree->Branch( itMethod.first, (metVals[n]), leafList );
       }
       else {
          Log() << kWARNING << Form("Dataset[%s] : ",fdsi->GetName()) << "Unknown analysis type for result found when writing TestTree." << Endl;
@@ -708,24 +704,23 @@ TTree* TMVA::DataSet::GetTree( Types::ETreeType type )
 
       // loop through all the results and write the branches
       n=0;
-      for (std::map<TString, Results*>::iterator itMethod = fResults.at(t).begin();
-           itMethod != fResults.at(t).end(); ++itMethod) {
-         Results* results = itMethod->second;
+      for (auto & itMethod : fResults.at(t)) {
+         Results* results = itMethod.second;
 
          const std::vector< Float_t >& vals = results->operator[](iEvt);
 
-         if (itMethod->second->GetAnalysisType() == Types::kClassification) {
+         if (itMethod.second->GetAnalysisType() == Types::kClassification) {
             // classification
             metVals[n][0] = vals[0];
          }
-         else if (itMethod->second->GetAnalysisType() == Types::kMulticlass) {
+         else if (itMethod.second->GetAnalysisType() == Types::kMulticlass) {
             // multiclass classification
             for (UInt_t nCls = 0, nClsEnd=fdsi->GetNClasses(); nCls < nClsEnd; nCls++) {
                Float_t val = vals.at(nCls);
                metVals[n][nCls] = val;
             }
          }
-         else if (itMethod->second->GetAnalysisType() == Types::kRegression) {
+         else if (itMethod.second->GetAnalysisType() == Types::kRegression) {
             // regression
             for (UInt_t nTgts = 0; nTgts < fdsi->GetNTargets(); nTgts++) {
                Float_t val = vals.at(nTgts);

--- a/tmva/tmva/src/DataSet.cxx
+++ b/tmva/tmva/src/DataSet.cxx
@@ -71,7 +71,7 @@ TMVA::DataSet::DataSet(const DataSetInfo& dsi)
    fBlockBelongToTraining.push_back(kTRUE);
 
    // sampling
-   fSamplingRandom = 0;
+   fSamplingRandom = nullptr;
 
    Int_t treeNum = 2;
    fSampling.resize( treeNum );
@@ -103,7 +103,7 @@ TMVA::DataSet::DataSet()
     fBlockBelongToTraining.push_back(kTRUE);
 
     // sampling
-    fSamplingRandom = 0;
+    fSamplingRandom = nullptr;
 
     Int_t treeNum = 2;
     fSampling.resize( treeNum );
@@ -136,7 +136,7 @@ TMVA::DataSet::~DataSet()
    }
 
    // delete sampling
-   if (fSamplingRandom != 0 ) delete fSamplingRandom;
+   if (fSamplingRandom != nullptr ) delete fSamplingRandom;
 
 
    // need also to delete fEventCollections[2] and [3], not sure if they are used
@@ -173,7 +173,7 @@ Long64_t TMVA::DataSet::GetNClassEvents( Int_t type, UInt_t classNumber )
    catch (std::out_of_range excpt) {
       ClassInfo* ci = fdsi->GetClassInfo( classNumber );
       Log() << kFATAL << Form("Dataset[%s] : ",fdsi->GetName()) << "No " << (type==0?"training":(type==1?"testing":"_unknown_type_"))
-            << " events for class " << (ci==NULL?"_no_name_known_":ci->GetName()) << " (index # "<<classNumber<<")"
+            << " events for class " << (ci==nullptr?"_no_name_known_":ci->GetName()) << " (index # "<<classNumber<<")"
             << " available. Check if all class names are spelled correctly and if events are"
             << " passing the selection cuts." << Endl;
    }
@@ -281,7 +281,7 @@ TMVA::Results* TMVA::DataSet::GetResults( const TString & resultsName,
 
    // nothing found
 
-   Results * newresults = 0;
+   Results * newresults = nullptr;
    switch(analysistype) {
    case Types::kClassification:
       newresults = new ResultsClassification(fdsi,resultsName);
@@ -297,7 +297,7 @@ TMVA::Results* TMVA::DataSet::GetResults( const TString & resultsName,
       break;
    case Types::kMaxAnalysisType:
       //Log() << kINFO << " GetResults("<<info<<") can't create new one." << Endl;
-      return 0;
+      return nullptr;
       break;
    }
 
@@ -430,7 +430,7 @@ Long64_t TMVA::DataSet::GetNEvtBkgdTrain()
 void TMVA::DataSet::InitSampling( Float_t fraction, Float_t weight, UInt_t seed  )
 {
    // add a random generator if not yet present
-   if (fSamplingRandom == 0 ) fSamplingRandom = new TRandom3( seed );
+   if (fSamplingRandom == nullptr ) fSamplingRandom = new TRandom3( seed );
 
    // first, clear the lists
    std::vector< std::pair< Float_t, Long64_t >* > evtList;
@@ -482,7 +482,7 @@ void TMVA::DataSet::CreateSampling() const
 
    if (!fSampling.at(treeIdx) ) return;
 
-   if (fSamplingRandom == 0 )
+   if (fSamplingRandom == nullptr )
       Log() << kFATAL<< Form("Dataset[%s] : ",fdsi->GetName())
             << "no random generator present for creating a random/importance sampling (initialized?)" << Endl;
 
@@ -583,7 +583,7 @@ TTree* TMVA::DataSet::GetTree( Types::ETreeType type )
 
    // the dataset does not hold the tree, this function returns a new tree every time it is called
 
-   if (type!=Types::kTraining && type!=Types::kTesting) return 0;
+   if (type!=Types::kTraining && type!=Types::kTesting) return nullptr;
 
    Types::ETreeType savedType = GetCurrentType();
 

--- a/tmva/tmva/src/DataSet.cxx
+++ b/tmva/tmva/src/DataSet.cxx
@@ -170,7 +170,7 @@ Long64_t TMVA::DataSet::GetNClassEvents( Int_t type, UInt_t classNumber )
    try {
       return fClassEvents.at(type).at(classNumber);
    }
-   catch (std::out_of_range excpt) {
+   catch (const std::out_of_range &excpt) {
       ClassInfo* ci = fdsi->GetClassInfo( classNumber );
       Log() << kFATAL << Form("Dataset[%s] : ",fdsi->GetName()) << "No " << (type==0?"training":(type==1?"testing":"_unknown_type_"))
             << " events for class " << (ci==nullptr?"_no_name_known_":ci->GetName()) << " (index # "<<classNumber<<")"

--- a/tmva/tmva/src/DataSetFactory.cxx
+++ b/tmva/tmva/src/DataSetFactory.cxx
@@ -95,7 +95,7 @@ TMVA::DataSetFactory::DataSetFactory() :
    fVerbose(kFALSE),
    fVerboseLevel(TString("Info")),
    fScaleWithPreselEff(0),
-   fCurrentTree(0),
+   fCurrentTree(nullptr),
    fCurrentEvtIdx(0),
    fInputFormulas(0),
    fLogger( new MsgLogger("DataSetFactory", kINFO) )
@@ -169,7 +169,7 @@ TMVA::DataSet* TMVA::DataSetFactory::BuildDynamicDataSet( TMVA::DataSetInfo& dsi
    std::vector<VariableInfo>::iterator it = varinfos.begin(), itEnd=varinfos.end();
    for (;it!=itEnd;++it) {
       Float_t* external=(Float_t*)(*it).GetExternalLink();
-      if (external==0)
+      if (external==nullptr)
          Log() << kDEBUG << Form("Dataset[%s] : ",dsi.GetName()) << "The link to the external variable is NULL while I am trying to build a dynamic data set. In this case fTmpEvent from MethodBase HAS TO BE USED in the method to get useful values in variables." << Endl;
       else evdyn->push_back (external);
    }
@@ -300,7 +300,7 @@ void TMVA::DataSetFactory::ChangeToNewTree( TreeInfo& tinfo, const DataSetInfo &
    std::vector<TTreeFormula*>::const_iterator formIt, formItEnd;
    for (formIt = fInputFormulas.begin(), formItEnd=fInputFormulas.end(); formIt!=formItEnd; ++formIt) if (*formIt) delete *formIt;
    fInputFormulas.clear();
-   TTreeFormula* ttf = 0;
+   TTreeFormula* ttf = nullptr;
 
    for (UInt_t i=0; i<dsi.GetNVariables(); i++) {
       ttf = new TTreeFormula( Form( "Formula%s", dsi.GetVariableInfo(i).GetInternalName().Data() ),
@@ -344,7 +344,7 @@ void TMVA::DataSetFactory::ChangeToNewTree( TreeInfo& tinfo, const DataSetInfo &
    for (UInt_t clIdx=0; clIdx<dsi.GetNClasses(); clIdx++) {
       const TCut& tmpCut = dsi.GetClassInfo(clIdx)->GetCut();
       const TString tmpCutExp(tmpCut.GetTitle());
-      ttf = 0;
+      ttf = nullptr;
       if (tmpCutExp!="") {
          ttf = new TTreeFormula( Form("CutClass%i",clIdx), tmpCutExp, tr );
          Bool_t worked = CheckTTreeFormula( ttf, tmpCutExp, hasDollar );
@@ -366,11 +366,11 @@ void TMVA::DataSetFactory::ChangeToNewTree( TreeInfo& tinfo, const DataSetInfo &
       const TString tmpWeight = dsi.GetClassInfo(clIdx)->GetWeight();
 
       if (dsi.GetClassInfo(clIdx)->GetName() != tinfo.GetClassName() ) { // if the tree is of another class
-         fWeightFormula.push_back( 0 );
+         fWeightFormula.push_back( nullptr );
          continue;
       }
 
-      ttf = 0;
+      ttf = nullptr;
       if (tmpWeight!="") {
          ttf = new TTreeFormula( "FormulaWeight", tmpWeight, tr );
          Bool_t worked = CheckTTreeFormula( ttf, tmpWeight, hasDollar );
@@ -380,7 +380,7 @@ void TMVA::DataSetFactory::ChangeToNewTree( TreeInfo& tinfo, const DataSetInfo &
          }
       }
       else {
-         ttf = 0;
+         ttf = nullptr;
       }
       fWeightFormula.push_back( ttf );
    }
@@ -807,7 +807,7 @@ TMVA::DataSetFactory::BuildEventVector( TMVA::DataSetInfo& dsi,
                   }
                };
 
-               TTreeFormula* formula = 0;
+               TTreeFormula* formula = nullptr;
 
                // the cut expression
                Double_t cutVal = 1.;
@@ -857,7 +857,7 @@ TMVA::DataSetFactory::BuildEventVector( TMVA::DataSetInfo& dsi,
                // the weight
                Float_t weight = currentInfo.GetWeight(); // multiply by tree weight
                formula = fWeightFormula[cl];
-               if (formula!=0) {
+               if (formula!=nullptr) {
                   Int_t ndata = formula->GetNdata();
                   weight *= (ndata == 1 ?
                              formula->EvalInstance() :
@@ -1230,10 +1230,10 @@ TMVA::DataSetFactory::MixEvents( DataSetInfo& dsi,
             // delete all events with the given indices
             for( std::vector<UInt_t>::iterator it = indicesTraining.begin(), itEnd = indicesTraining.end(); it != itEnd; ++it ){
                delete eventVectorTraining.at( (*it) ); // delete event
-               eventVectorTraining.at( (*it) ) = NULL; // set pointer to NULL
+               eventVectorTraining.at( (*it) ) = nullptr; // set pointer to NULL
             }
             // now remove and erase all events with pointer==NULL
-            eventVectorTraining.erase( std::remove( eventVectorTraining.begin(), eventVectorTraining.end(), (void*)NULL ), eventVectorTraining.end() );
+            eventVectorTraining.erase( std::remove( eventVectorTraining.begin(), eventVectorTraining.end(), (void*)nullptr ), eventVectorTraining.end() );
          }
 
          UInt_t sizeTesting   = eventVectorTesting.size();
@@ -1248,10 +1248,10 @@ TMVA::DataSetFactory::MixEvents( DataSetInfo& dsi,
             // delete all events with the given indices
             for( std::vector<UInt_t>::iterator it = indicesTesting.begin(), itEnd = indicesTesting.end(); it != itEnd; ++it ){
                delete eventVectorTesting.at( (*it) ); // delete event
-               eventVectorTesting.at( (*it) ) = NULL; // set pointer to NULL
+               eventVectorTesting.at( (*it) ) = nullptr; // set pointer to NULL
             }
             // now remove and erase all events with pointer==NULL
-            eventVectorTesting.erase( std::remove( eventVectorTesting.begin(), eventVectorTesting.end(), (void*)NULL ), eventVectorTesting.end() );
+            eventVectorTesting.erase( std::remove( eventVectorTesting.begin(), eventVectorTesting.end(), (void*)nullptr ), eventVectorTesting.end() );
          }
       }
       else { // erase at end

--- a/tmva/tmva/src/DataSetFactory.cxx
+++ b/tmva/tmva/src/DataSetFactory.cxx
@@ -1228,9 +1228,9 @@ TMVA::DataSetFactory::MixEvents( DataSetInfo& dsi,
             // erase indices of not needed events
             indicesTraining.erase( indicesTraining.begin()+sizeTraining-UInt_t(requestedTraining), indicesTraining.end() );
             // delete all events with the given indices
-            for( std::vector<UInt_t>::iterator it = indicesTraining.begin(), itEnd = indicesTraining.end(); it != itEnd; ++it ){
-               delete eventVectorTraining.at( (*it) ); // delete event
-               eventVectorTraining.at( (*it) ) = nullptr; // set pointer to NULL
+            for(unsigned int & it : indicesTraining){
+               delete eventVectorTraining.at( it ); // delete event
+               eventVectorTraining.at( it ) = nullptr; // set pointer to NULL
             }
             // now remove and erase all events with pointer==NULL
             eventVectorTraining.erase( std::remove( eventVectorTraining.begin(), eventVectorTraining.end(), (void*)nullptr ), eventVectorTraining.end() );
@@ -1246,9 +1246,9 @@ TMVA::DataSetFactory::MixEvents( DataSetInfo& dsi,
             // erase indices of not needed events
             indicesTesting.erase( indicesTesting.begin()+sizeTesting-UInt_t(requestedTesting), indicesTesting.end() );
             // delete all events with the given indices
-            for( std::vector<UInt_t>::iterator it = indicesTesting.begin(), itEnd = indicesTesting.end(); it != itEnd; ++it ){
-               delete eventVectorTesting.at( (*it) ); // delete event
-               eventVectorTesting.at( (*it) ) = nullptr; // set pointer to NULL
+            for(unsigned int & it : indicesTesting){
+               delete eventVectorTesting.at( it ); // delete event
+               eventVectorTesting.at( it ) = nullptr; // set pointer to NULL
             }
             // now remove and erase all events with pointer==NULL
             eventVectorTesting.erase( std::remove( eventVectorTesting.begin(), eventVectorTesting.end(), (void*)nullptr ), eventVectorTesting.end() );

--- a/tmva/tmva/src/DataSetInfo.cxx
+++ b/tmva/tmva/src/DataSetInfo.cxx
@@ -60,9 +60,9 @@ Class that contains all the data information.
 
 TMVA::DataSetInfo::DataSetInfo(const TString& name)
    : TObject(),
-     fDataSetManager(NULL),
+     fDataSetManager(nullptr),
      fName(name),
-     fDataSet( 0 ),
+     fDataSet( nullptr ),
      fNeedsRebuilding( kTRUE ),
      fVariables(),
      fTargets(),
@@ -74,10 +74,10 @@ TMVA::DataSetInfo::DataSetInfo(const TString& name)
      fTrainingSumBackgrWeights(-1),
      fTestingSumSignalWeights (-1),
      fTestingSumBackgrWeights (-1),
-     fOwnRootDir(0),
+     fOwnRootDir(nullptr),
      fVerbose( kFALSE ),
      fSignalClass(0),
-     fTargetsForMulticlass(0),
+     fTargetsForMulticlass(nullptr),
      fLogger( new MsgLogger("DataSetInfo", kINFO) )
 {
 }
@@ -102,7 +102,7 @@ TMVA::DataSetInfo::~DataSetInfo()
 
 void TMVA::DataSetInfo::ClearDataSet() const
 {
-   if(fDataSet!=0) { delete fDataSet; fDataSet=0; }
+   if(fDataSet!=nullptr) { delete fDataSet; fDataSet=nullptr; }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -143,7 +143,7 @@ TMVA::ClassInfo* TMVA::DataSetInfo::GetClassInfo( const TString& name ) const
    for (std::vector<ClassInfo*>::iterator it = fClasses.begin(); it < fClasses.end(); ++it) {
       if ((*it)->GetName() == name) return (*it);
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -154,7 +154,7 @@ TMVA::ClassInfo* TMVA::DataSetInfo::GetClassInfo( Int_t cls ) const
       return fClasses.at(cls);
    }
    catch(...) {
-      return 0;
+      return nullptr;
    }
 }
 
@@ -202,7 +202,7 @@ Bool_t TMVA::DataSetInfo::HasCuts() const
 const TMatrixD* TMVA::DataSetInfo::CorrelationMatrix( const TString& className ) const
 {
    ClassInfo* ptr = GetClassInfo(className);
-   return ptr?ptr->GetCorrelationMatrix():0;
+   return ptr?ptr->GetCorrelationMatrix():nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -399,7 +399,7 @@ TH2* TMVA::DataSetInfo::CreateCorrelationMatrixHist( const TMatrixD* m,
                                                      const TString&  hName,
                                                      const TString&  hTitle ) const
 {
-   if (m==0) return 0;
+   if (m==nullptr) return nullptr;
 
    const UInt_t nvar = GetNVariables();
 
@@ -461,8 +461,8 @@ TH2* TMVA::DataSetInfo::CreateCorrelationMatrixHist( const TMatrixD* m,
 
 TMVA::DataSet* TMVA::DataSetInfo::GetDataSet() const
 {
-   if (fDataSet==0 || fNeedsRebuilding) {
-      if(fDataSet!=0) ClearDataSet();
+   if (fDataSet==nullptr || fNeedsRebuilding) {
+      if(fDataSet!=nullptr) ClearDataSet();
       //      fDataSet = DataSetManager::Instance().CreateDataSet(GetName()); //DSMTEST replaced by following lines
       if( !fDataSetManager )
          Log() << kFATAL << Form("Dataset[%s] : ",fName.Data()) << "DataSetManager has not been set in DataSetInfo (GetDataSet() )." << Endl;

--- a/tmva/tmva/src/DataSetInfo.cxx
+++ b/tmva/tmva/src/DataSetInfo.cxx
@@ -89,8 +89,8 @@ TMVA::DataSetInfo::~DataSetInfo()
 {
    ClearDataSet();
 
-   for(UInt_t i=0, iEnd = fClasses.size(); i<iEnd; ++i) {
-      delete fClasses[i];
+   for(auto & fClasse : fClasses) {
+      delete fClasse;
    }
 
    delete fTargetsForMulticlass;
@@ -480,8 +480,8 @@ UInt_t TMVA::DataSetInfo::GetNSpectators(bool all) const
    if(all)
       return fSpectators.size();
    UInt_t nsp(0);
-   for(std::vector<VariableInfo>::const_iterator spit=fSpectators.begin(); spit!=fSpectators.end(); ++spit) {
-      if(spit->GetVarType()!='C') nsp++;
+   for(const auto & fSpectator : fSpectators) {
+      if(fSpectator.GetVarType()!='C') nsp++;
    }
    return nsp;
 }

--- a/tmva/tmva/src/DataSetManager.cxx
+++ b/tmva/tmva/src/DataSetManager.cxx
@@ -47,7 +47,7 @@ using std::endl;
 /// constructor
 
 TMVA::DataSetManager::DataSetManager( DataInputHandler& dataInput )
-   : fDatasetFactory(0),
+   : fDatasetFactory(nullptr),
      fDataInput(&dataInput),
      fDataSetInfoCollection(),
      fLogger( new MsgLogger("DataSetManager", kINFO) )
@@ -58,8 +58,8 @@ TMVA::DataSetManager::DataSetManager( DataInputHandler& dataInput )
 /// constructor
 
 TMVA::DataSetManager::DataSetManager( )
-: fDatasetFactory(0),
-fDataInput(0),
+: fDatasetFactory(nullptr),
+fDataInput(nullptr),
 fDataSetInfoCollection(),
 fLogger( new MsgLogger("DataSetManager", kINFO) )
 {
@@ -107,7 +107,7 @@ TMVA::DataSetInfo& TMVA::DataSetManager::AddDataSetInfo(DataSetInfo& dsi)
    dsi.SetDataSetManager( this ); // DSMTEST
 
    DataSetInfo * dsiInList = GetDataSetInfo(dsi.GetName());
-   if (dsiInList!=0) return *dsiInList;
+   if (dsiInList!=nullptr) return *dsiInList;
    fDataSetInfoCollection.Add( const_cast<DataSetInfo*>(&dsi) );
    return dsi;
 }

--- a/tmva/tmva/src/DecisionTree.cxx
+++ b/tmva/tmva/src/DecisionTree.cxx
@@ -529,8 +529,8 @@ UInt_t TMVA::DecisionTree::BuildTree( const std::vector<const TMVA::Event*> & ev
 
 void TMVA::DecisionTree::FillTree( const std::vector<TMVA::Event*> & eventSample )
 {
-   for (UInt_t i=0; i<eventSample.size(); i++) {
-      this->FillEvent(*(eventSample[i]),nullptr);
+   for (auto i : eventSample) {
+      this->FillEvent(*i,nullptr);
    }
 }
 
@@ -655,9 +655,9 @@ Double_t TMVA::DecisionTree::PruneTree( const EventConstList* validationSample )
       //           << " has quality index " << info->QualityIndex << Endl;
 
 
-      for (UInt_t i = 0; i < info->PruneSequence.size(); ++i) {
+      for (auto & i : info->PruneSequence) {
 
-         PruneNode(info->PruneSequence[i]);
+         PruneNode(i);
       }
       // update the number of nodes after the pruning
       this->CountNodes();
@@ -679,8 +679,8 @@ Double_t TMVA::DecisionTree::PruneTree( const EventConstList* validationSample )
 void TMVA::DecisionTree::ApplyValidationSample( const EventConstList* validationSample ) const
 {
    GetRoot()->ResetValidationData();
-   for (UInt_t ievt=0; ievt < validationSample->size(); ievt++) {
-      CheckEventWithPrunedTree((*validationSample)[ievt]);
+   for (auto ievt : *validationSample) {
+      CheckEventWithPrunedTree(ievt);
    }
 }
 
@@ -768,9 +768,8 @@ void TMVA::DecisionTree::CheckEventWithPrunedTree( const Event* e ) const
 Double_t TMVA::DecisionTree::GetSumWeights( const EventConstList* validationSample ) const
 {
    Double_t sumWeights = 0.0;
-   for( EventConstList::const_iterator it = validationSample->begin();
-        it != validationSample->end(); ++it ) {
-      sumWeights += (*it)->GetWeight();
+   for(auto it : *validationSample) {
+      sumWeights += it->GetWeight();
    }
    return sumWeights;
 }
@@ -1564,16 +1563,16 @@ Double_t TMVA::DecisionTree::TrainNodeFull( const EventConstList & eventSample,
 
    // Initialize (un)weighted counters for signal & background
    // Construct a list of event wrappers that point to the original data
-   for( std::vector<const TMVA::Event*>::const_iterator it = eventSample.begin(); it != eventSample.end(); ++it ) {
-      if((*it)->GetClass() == fSigClass) { // signal or background event
-         nTotS += (*it)->GetWeight();
+   for(auto it : eventSample) {
+      if(it->GetClass() == fSigClass) { // signal or background event
+         nTotS += it->GetWeight();
          ++nTotS_unWeighted;
       }
       else {
-         nTotB += (*it)->GetWeight();
+         nTotB += it->GetWeight();
          ++nTotB_unWeighted;
       }
-      bdtEventSample.push_back(TMVA::BDTEventWrapper(*it));
+      bdtEventSample.push_back(TMVA::BDTEventWrapper(it));
    }
 
    std::vector<Char_t> useVariable(fNvars); // <----- bool is stored (for performance reasons, no std::vector<bool>  has been taken)
@@ -1731,10 +1730,10 @@ Double_t TMVA::DecisionTree::CheckEvent( const TMVA::Event * e, Bool_t UseYesNoL
 Double_t  TMVA::DecisionTree::SamplePurity( std::vector<TMVA::Event*> eventSample )
 {
    Double_t sumsig=0, sumbkg=0, sumtot=0;
-   for (UInt_t ievt=0; ievt<eventSample.size(); ievt++) {
-      if (eventSample[ievt]->GetClass() != fSigClass) sumbkg+=eventSample[ievt]->GetWeight();
-      else sumsig+=eventSample[ievt]->GetWeight();
-      sumtot+=eventSample[ievt]->GetWeight();
+   for (auto & ievt : eventSample) {
+      if (ievt->GetClass() != fSigClass) sumbkg+=ievt->GetWeight();
+      else sumsig+=ievt->GetWeight();
+      sumtot+=ievt->GetWeight();
    }
    // sanity check
    if (sumtot!= (sumsig+sumbkg)){

--- a/tmva/tmva/src/DecisionTree.cxx
+++ b/tmva/tmva/src/DecisionTree.cxx
@@ -120,8 +120,8 @@ TMVA::DecisionTree::DecisionTree():
    fUseFisherCuts  (kFALSE),
    fMinLinCorrForFisher (1),
    fUseExclusiveVars (kTRUE),
-   fSepType        (NULL),
-   fRegType        (NULL),
+   fSepType        (nullptr),
+   fRegType        (nullptr),
    fMinSize        (0),
    fMinNodeSize    (1),
    fMinSepGain (0),
@@ -133,12 +133,12 @@ TMVA::DecisionTree::DecisionTree():
    fRandomisedTree (kFALSE),
    fUseNvars       (0),
    fUsePoissonNvars(kFALSE),
-   fMyTrandom (NULL),
+   fMyTrandom (nullptr),
    fMaxDepth       (999999),
    fSigClass       (0),
    fTreeID         (0),
    fAnalysisType   (Types::kClassification),
-   fDataSetInfo    (NULL)
+   fDataSetInfo    (nullptr)
 {
 }
 
@@ -158,7 +158,7 @@ TMVA::DecisionTree::DecisionTree( TMVA::SeparationBase *sepType, Float_t minSize
    fMinLinCorrForFisher (1),
    fUseExclusiveVars (kTRUE),
    fSepType        (sepType),
-   fRegType        (NULL),
+   fRegType        (nullptr),
    fMinSize        (0),
    fMinNodeSize    (minSize),
    fMinSepGain     (0),
@@ -177,7 +177,7 @@ TMVA::DecisionTree::DecisionTree( TMVA::SeparationBase *sepType, Float_t minSize
    fAnalysisType   (Types::kClassification),
    fDataSetInfo    (dataInfo)
 {
-   if (sepType == NULL) { // it is interpreted as a regression tree, where
+   if (sepType == nullptr) { // it is interpreted as a regression tree, where
                           // currently the separation type (simple least square)
                           // cannot be chosen freely)
       fAnalysisType = Types::kRegression;
@@ -247,26 +247,26 @@ TMVA::DecisionTree::~DecisionTree()
 
 void TMVA::DecisionTree::SetParentTreeInNodes( Node *n )
 {
-   if (n == NULL) { //default, start at the tree top, then descend recursively
+   if (n == nullptr) { //default, start at the tree top, then descend recursively
       n = this->GetRoot();
-      if (n == NULL) {
+      if (n == nullptr) {
          Log() << kFATAL << "SetParentTreeNodes: started with undefined ROOT node" <<Endl;
          return ;
       }
    }
 
-   if ((this->GetLeftDaughter(n) == NULL) && (this->GetRightDaughter(n) != NULL) ) {
+   if ((this->GetLeftDaughter(n) == nullptr) && (this->GetRightDaughter(n) != nullptr) ) {
       Log() << kFATAL << " Node with only one daughter?? Something went wrong" << Endl;
       return;
-   }  else if ((this->GetLeftDaughter(n) != NULL) && (this->GetRightDaughter(n) == NULL) ) {
+   }  else if ((this->GetLeftDaughter(n) != nullptr) && (this->GetRightDaughter(n) == nullptr) ) {
       Log() << kFATAL << " Node with only one daughter?? Something went wrong" << Endl;
       return;
    }
    else {
-      if (this->GetLeftDaughter(n) != NULL) {
+      if (this->GetLeftDaughter(n) != nullptr) {
          this->SetParentTreeInNodes( this->GetLeftDaughter(n) );
       }
-      if (this->GetRightDaughter(n) != NULL) {
+      if (this->GetRightDaughter(n) != nullptr) {
          this->SetParentTreeInNodes( this->GetRightDaughter(n) );
       }
    }
@@ -294,7 +294,7 @@ TMVA::DecisionTree* TMVA::DecisionTree::CreateFromXML(void* node, UInt_t tmva_Ve
 UInt_t TMVA::DecisionTree::BuildTree( const std::vector<const TMVA::Event*> & eventSample,
                                       TMVA::DecisionTreeNode *node)
 {
-   if (node==NULL) {
+   if (node==nullptr) {
       //start with the root node
       node = new TMVA::DecisionTreeNode();
       fNNodes = 1;
@@ -530,7 +530,7 @@ UInt_t TMVA::DecisionTree::BuildTree( const std::vector<const TMVA::Event*> & ev
 void TMVA::DecisionTree::FillTree( const std::vector<TMVA::Event*> & eventSample )
 {
    for (UInt_t i=0; i<eventSample.size(); i++) {
-      this->FillEvent(*(eventSample[i]),NULL);
+      this->FillEvent(*(eventSample[i]),nullptr);
    }
 }
 
@@ -541,7 +541,7 @@ void TMVA::DecisionTree::FillTree( const std::vector<TMVA::Event*> & eventSample
 void TMVA::DecisionTree::FillEvent( const TMVA::Event & event,
                                     TMVA::DecisionTreeNode *node )
 {
-   if (node == NULL) { // that's the start, take the Root node
+   if (node == nullptr) { // that's the start, take the Root node
       node = this->GetRoot();
    }
 
@@ -572,7 +572,7 @@ void TMVA::DecisionTree::FillEvent( const TMVA::Event & event,
 
 void TMVA::DecisionTree::ClearTree()
 {
-   if (this->GetRoot()!=NULL) this->GetRoot()->ClearNodeAndAllDaughters();
+   if (this->GetRoot()!=nullptr) this->GetRoot()->ClearNodeAndAllDaughters();
 
 }
 
@@ -586,7 +586,7 @@ void TMVA::DecisionTree::ClearTree()
 
 UInt_t TMVA::DecisionTree::CleanTree( DecisionTreeNode *node )
 {
-   if (node==NULL) {
+   if (node==nullptr) {
       node = this->GetRoot();
    }
 
@@ -613,8 +613,8 @@ UInt_t TMVA::DecisionTree::CleanTree( DecisionTreeNode *node )
 
 Double_t TMVA::DecisionTree::PruneTree( const EventConstList* validationSample )
 {
-   IPruneTool* tool(NULL);
-   PruningInfo* info(NULL);
+   IPruneTool* tool(nullptr);
+   PruningInfo* info(nullptr);
 
    if( fPruneMethod == kNoPruning ) return 0.0;
 
@@ -634,7 +634,7 @@ Double_t TMVA::DecisionTree::PruneTree( const EventConstList* validationSample )
 
    tool->SetPruneStrength(GetPruneStrength());
    if(tool->IsAutomatic()) {
-      if(validationSample == NULL){
+      if(validationSample == nullptr){
          Log() << kFATAL << "Cannot automate the pruning algorithm without an "
                << "independent validation sample!" << Endl;
       }else if(validationSample->size() == 0) {
@@ -692,15 +692,15 @@ void TMVA::DecisionTree::ApplyValidationSample( const EventConstList* validation
 
 Double_t TMVA::DecisionTree::TestPrunedTreeQuality( const DecisionTreeNode* n, Int_t mode ) const
 {
-   if (n == NULL) { // default, start at the tree top, then descend recursively
+   if (n == nullptr) { // default, start at the tree top, then descend recursively
       n = this->GetRoot();
-      if (n == NULL) {
+      if (n == nullptr) {
          Log() << kFATAL << "TestPrunedTreeQuality: started with undefined ROOT node" <<Endl;
          return 0;
       }
    }
 
-   if( n->GetLeft() != NULL && n->GetRight() != NULL && !n->IsTerminal() ) {
+   if( n->GetLeft() != nullptr && n->GetRight() != nullptr && !n->IsTerminal() ) {
       return (TestPrunedTreeQuality( n->GetLeft(), mode ) +
               TestPrunedTreeQuality( n->GetRight(), mode ));
    }
@@ -735,11 +735,11 @@ Double_t TMVA::DecisionTree::TestPrunedTreeQuality( const DecisionTreeNode* n, I
 void TMVA::DecisionTree::CheckEventWithPrunedTree( const Event* e ) const
 {
    DecisionTreeNode* current =  this->GetRoot();
-   if (current == NULL) {
+   if (current == nullptr) {
       Log() << kFATAL << "CheckEventWithPrunedTree: started with undefined ROOT node" <<Endl;
    }
 
-   while(current != NULL) {
+   while(current != nullptr) {
       if(e->GetClass() == fSigClass)
          current->SetNSValidation(current->GetNSValidation() + e->GetWeight());
       else
@@ -750,8 +750,8 @@ void TMVA::DecisionTree::CheckEventWithPrunedTree( const Event* e ) const
          current->AddToSumTarget2(e->GetWeight()*e->GetTarget(0)*e->GetTarget(0));
       }
 
-      if (current->GetRight() == NULL || current->GetLeft() == NULL) {
-         current = NULL;
+      if (current->GetRight() == nullptr || current->GetLeft() == nullptr) {
+         current = nullptr;
       }
       else {
          if (current->GoesRight(*e))
@@ -780,9 +780,9 @@ Double_t TMVA::DecisionTree::GetSumWeights( const EventConstList* validationSamp
 
 UInt_t TMVA::DecisionTree::CountLeafNodes( TMVA::Node *n )
 {
-   if (n == NULL) { // default, start at the tree top, then descend recursively
+   if (n == nullptr) { // default, start at the tree top, then descend recursively
       n =  this->GetRoot();
-      if (n == NULL) {
+      if (n == nullptr) {
          Log() << kFATAL << "CountLeafNodes: started with undefined ROOT node" <<Endl;
          return 0;
       }
@@ -790,14 +790,14 @@ UInt_t TMVA::DecisionTree::CountLeafNodes( TMVA::Node *n )
 
    UInt_t countLeafs=0;
 
-   if ((this->GetLeftDaughter(n) == NULL) && (this->GetRightDaughter(n) == NULL) ) {
+   if ((this->GetLeftDaughter(n) == nullptr) && (this->GetRightDaughter(n) == nullptr) ) {
       countLeafs += 1;
    }
    else {
-      if (this->GetLeftDaughter(n) != NULL) {
+      if (this->GetLeftDaughter(n) != nullptr) {
          countLeafs += this->CountLeafNodes( this->GetLeftDaughter(n) );
       }
-      if (this->GetRightDaughter(n) != NULL) {
+      if (this->GetRightDaughter(n) != nullptr) {
          countLeafs += this->CountLeafNodes( this->GetRightDaughter(n) );
       }
    }
@@ -809,30 +809,30 @@ UInt_t TMVA::DecisionTree::CountLeafNodes( TMVA::Node *n )
 
 void TMVA::DecisionTree::DescendTree( Node* n )
 {
-   if (n == NULL) { // default, start at the tree top, then descend recursively
+   if (n == nullptr) { // default, start at the tree top, then descend recursively
       n =  this->GetRoot();
-      if (n == NULL) {
+      if (n == nullptr) {
          Log() << kFATAL << "DescendTree: started with undefined ROOT node" <<Endl;
          return ;
       }
    }
 
-   if ((this->GetLeftDaughter(n) == NULL) && (this->GetRightDaughter(n) == NULL) ) {
+   if ((this->GetLeftDaughter(n) == nullptr) && (this->GetRightDaughter(n) == nullptr) ) {
       // do nothing
    }
-   else if ((this->GetLeftDaughter(n) == NULL) && (this->GetRightDaughter(n) != NULL) ) {
+   else if ((this->GetLeftDaughter(n) == nullptr) && (this->GetRightDaughter(n) != nullptr) ) {
       Log() << kFATAL << " Node with only one daughter?? Something went wrong" << Endl;
       return;
    }
-   else if ((this->GetLeftDaughter(n) != NULL) && (this->GetRightDaughter(n) == NULL) ) {
+   else if ((this->GetLeftDaughter(n) != nullptr) && (this->GetRightDaughter(n) == nullptr) ) {
       Log() << kFATAL << " Node with only one daughter?? Something went wrong" << Endl;
       return;
    }
    else {
-      if (this->GetLeftDaughter(n) != NULL) {
+      if (this->GetLeftDaughter(n) != nullptr) {
          this->DescendTree( this->GetLeftDaughter(n) );
       }
-      if (this->GetRightDaughter(n) != NULL) {
+      if (this->GetRightDaughter(n) != nullptr) {
          this->DescendTree( this->GetRightDaughter(n) );
       }
    }
@@ -846,8 +846,8 @@ void TMVA::DecisionTree::PruneNode( DecisionTreeNode* node )
    DecisionTreeNode *l = node->GetLeft();
    DecisionTreeNode *r = node->GetRight();
 
-   node->SetRight(NULL);
-   node->SetLeft(NULL);
+   node->SetRight(nullptr);
+   node->SetLeft(nullptr);
    node->SetSelector(-1);
    node->SetSeparationGain(-1);
    if (node->GetPurity() > fNodePurityLimit) node->SetNodeType(1);
@@ -865,7 +865,7 @@ void TMVA::DecisionTree::PruneNode( DecisionTreeNode* node )
 /// pruning stages without "touching" the tree.
 
 void TMVA::DecisionTree::PruneNodeInPlace( DecisionTreeNode* node ) {
-   if(node == NULL) return;
+   if(node == nullptr) return;
    node->SetNTerminal(1);
    node->SetSubTreeR( node->GetNodeR() );
    node->SetAlpha( std::numeric_limits<double>::infinity( ) );
@@ -1623,7 +1623,7 @@ Double_t TMVA::DecisionTree::TrainNodeFull( const EventConstList & eventSample,
       // Locate the optimal cut for this (ivar-th) variable
       for( it = bdtEventSample.begin(); it != it_end; ++it ) {
          if( index == 0 ) { ++index; continue; }
-         if( *(*it) == NULL ) {
+         if( *(*it) == nullptr ) {
             Log() << kFATAL << "In TrainNodeFull(): have a null event! Where index="
                   << index << ", and parent node=" << node->GetParent() << Endl;
             break;

--- a/tmva/tmva/src/DecisionTree.cxx
+++ b/tmva/tmva/src/DecisionTree.cxx
@@ -561,9 +561,9 @@ void TMVA::DecisionTree::FillEvent( const TMVA::Event & event,
 
    if (node->GetNodeType() == 0) { //intermediate node --> go down
       if (node->GoesRight(event))
-         this->FillEvent(event,static_cast<TMVA::DecisionTreeNode*>(node->GetRight())) ;
+         this->FillEvent(event, node->GetRight());
       else
-         this->FillEvent(event,static_cast<TMVA::DecisionTreeNode*>(node->GetLeft())) ;
+         this->FillEvent(event, node->GetLeft());
    }
 }
 

--- a/tmva/tmva/src/DecisionTreeNode.cxx
+++ b/tmva/tmva/src/DecisionTreeNode.cxx
@@ -81,7 +81,7 @@ TMVA::DecisionTreeNode::DecisionTreeNode()
    }
    else {
       //std::cout << "**Node constructor WITHOUT TrainingINFO"<<std::endl;
-      fTrainInfo = 0;
+      fTrainInfo = nullptr;
    }
 }
 
@@ -105,7 +105,7 @@ TMVA::DecisionTreeNode::DecisionTreeNode(TMVA::Node* p, char pos)
    }
    else {
       //std::cout << "**Node constructor WITHOUT TrainingINFO"<<std::endl;
-      fTrainInfo = 0;
+      fTrainInfo = nullptr;
    }
 }
 
@@ -126,10 +126,10 @@ TMVA::DecisionTreeNode::DecisionTreeNode(const TMVA::DecisionTreeNode &n,
      fIsTerminalNode( n.fIsTerminalNode )
 {
    this->SetParent( parent );
-   if (n.GetLeft() == 0 ) this->SetLeft(NULL);
+   if (n.GetLeft() == nullptr ) this->SetLeft(nullptr);
    else this->SetLeft( new DecisionTreeNode( *((DecisionTreeNode*)(n.GetLeft())),this));
 
-   if (n.GetRight() == 0 ) this->SetRight(NULL);
+   if (n.GetRight() == nullptr ) this->SetRight(nullptr);
    else this->SetRight( new DecisionTreeNode( *((DecisionTreeNode*)(n.GetRight())),this));
 
    if (DecisionTreeNode::fgIsTraining){
@@ -138,7 +138,7 @@ TMVA::DecisionTreeNode::DecisionTreeNode(const TMVA::DecisionTreeNode &n,
    }
    else {
       //std::cout << "**Node constructor WITHOUT TrainingINFO"<<std::endl;
-      fTrainInfo = 0;
+      fTrainInfo = nullptr;
    }
 }
 
@@ -228,9 +228,9 @@ void TMVA::DecisionTreeNode::Print(std::ostream& os) const
       << std::endl;
 
    os << "My address is " << long(this) << ", ";
-   if (this->GetParent() != NULL) os << " parent at addr: "         << long(this->GetParent()) ;
-   if (this->GetLeft()   != NULL) os << " left daughter at addr: "  << long(this->GetLeft());
-   if (this->GetRight()  != NULL) os << " right daughter at addr: " << long(this->GetRight()) ;
+   if (this->GetParent() != nullptr) os << " parent at addr: "         << long(this->GetParent()) ;
+   if (this->GetLeft()   != nullptr) os << " left daughter at addr: "  << long(this->GetLeft());
+   if (this->GetRight()  != nullptr) os << " right daughter at addr: " << long(this->GetRight()) ;
 
    os << " **** > " << std::endl;
 }
@@ -262,8 +262,8 @@ void TMVA::DecisionTreeNode::PrintRec(std::ostream& os) const
    if (this->GetCC() > 10000000000000.) os << " CC: " << 100000. << std::endl;
    else os << " CC: "  << this->GetCC() << std::endl;
 
-   if (this->GetLeft()  != NULL) this->GetLeft() ->PrintRec(os);
-   if (this->GetRight() != NULL) this->GetRight()->PrintRec(os);
+   if (this->GetLeft()  != nullptr) this->GetLeft() ->PrintRec(os);
+   if (this->GetRight() != nullptr) this->GetRight()->PrintRec(os);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -355,8 +355,8 @@ void TMVA::DecisionTreeNode::ClearNodeAndAllDaughters()
    SetSeparationGain(-1);
    SetPurity();
 
-   if (this->GetLeft()  != NULL) ((DecisionTreeNode*)(this->GetLeft()))->ClearNodeAndAllDaughters();
-   if (this->GetRight() != NULL) ((DecisionTreeNode*)(this->GetRight()))->ClearNodeAndAllDaughters();
+   if (this->GetLeft()  != nullptr) ((DecisionTreeNode*)(this->GetLeft()))->ClearNodeAndAllDaughters();
+   if (this->GetRight() != nullptr) ((DecisionTreeNode*)(this->GetRight()))->ClearNodeAndAllDaughters();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -369,7 +369,7 @@ void TMVA::DecisionTreeNode::ResetValidationData( ) {
    SetSumTarget( 0 );
    SetSumTarget2( 0 );
 
-   if(GetLeft() != NULL && GetRight() != NULL) {
+   if(GetLeft() != nullptr && GetRight() != nullptr) {
       GetLeft()->ResetValidationData();
       GetRight()->ResetValidationData();
    }
@@ -392,7 +392,7 @@ void TMVA::DecisionTreeNode::PrintPrune( std::ostream& os ) const {
 
 void TMVA::DecisionTreeNode::PrintRecPrune( std::ostream& os ) const {
    this->PrintPrune(os);
-   if(this->GetLeft() != NULL && this->GetRight() != NULL) {
+   if(this->GetLeft() != nullptr && this->GetRight() != nullptr) {
       ((DecisionTreeNode*)this->GetLeft())->PrintRecPrune(os);
       ((DecisionTreeNode*)this->GetRight())->PrintRecPrune(os);
    }

--- a/tmva/tmva/src/DecisionTreeNode.cxx
+++ b/tmva/tmva/src/DecisionTreeNode.cxx
@@ -188,7 +188,7 @@ Bool_t TMVA::DecisionTreeNode::GoesLeft(const TMVA::Event & e) const
 /// REM: even if nodes with purity 0.01 are very PURE background nodes, they still
 ///      get a small value of the purity.
 
-void TMVA::DecisionTreeNode::SetPurity( void )
+void TMVA::DecisionTreeNode::SetPurity()
 {
    if ( ( this->GetNSigEvents() + this->GetNBkgEvents() ) > 0 ) {
       fPurity = this->GetNSigEvents() / ( this->GetNSigEvents() + this->GetNBkgEvents());

--- a/tmva/tmva/src/Envelope.cxx
+++ b/tmva/tmva/src/Envelope.cxx
@@ -250,8 +250,8 @@ void TMVA::Envelope::WriteDataInformation(TMVA::DataSetInfo &fDataSetInfo, TMVA:
    fDataSetInfo.GetDataSet(); // builds dataset (including calculation of correlation matrix)
 
    // correlation matrix of the default DS
-   const TMatrixD *m(0);
-   const TH2 *h(0);
+   const TMatrixD *m(nullptr);
+   const TH2 *h(nullptr);
 
    if (fAnalysisType == Types::kMulticlass) {
       for (UInt_t cls = 0; cls < fDataSetInfo.GetNClasses(); cls++) {
@@ -259,7 +259,7 @@ void TMVA::Envelope::WriteDataInformation(TMVA::DataSetInfo &fDataSetInfo, TMVA:
          h = fDataSetInfo.CreateCorrelationMatrixHist(
             m, TString("CorrelationMatrix") + fDataSetInfo.GetClassInfo(cls)->GetName(),
             TString("Correlation Matrix (") + fDataSetInfo.GetClassInfo(cls)->GetName() + TString(")"));
-         if (h != 0) {
+         if (h != nullptr) {
             h->Write();
             delete h;
          }
@@ -267,21 +267,21 @@ void TMVA::Envelope::WriteDataInformation(TMVA::DataSetInfo &fDataSetInfo, TMVA:
    } else {
       m = fDataSetInfo.CorrelationMatrix("Signal");
       h = fDataSetInfo.CreateCorrelationMatrixHist(m, "CorrelationMatrixS", "Correlation Matrix (signal)");
-      if (h != 0) {
+      if (h != nullptr) {
          h->Write();
          delete h;
       }
 
       m = fDataSetInfo.CorrelationMatrix("Background");
       h = fDataSetInfo.CreateCorrelationMatrixHist(m, "CorrelationMatrixB", "Correlation Matrix (background)");
-      if (h != 0) {
+      if (h != nullptr) {
          h->Write();
          delete h;
       }
 
       m = fDataSetInfo.CorrelationMatrix("Regression");
       h = fDataSetInfo.CreateCorrelationMatrixHist(m, "CorrelationMatrix", "Correlation Matrix");
-      if (h != 0) {
+      if (h != nullptr) {
          h->Write();
          delete h;
       }
@@ -296,7 +296,7 @@ void TMVA::Envelope::WriteDataInformation(TMVA::DataSetInfo &fDataSetInfo, TMVA:
 
    // remove any trace of identity transform - if given (avoid to apply it twice)
    std::vector<TMVA::TransformationHandler *> trfs;
-   TransformationHandler *identityTrHandler = 0;
+   TransformationHandler *identityTrHandler = nullptr;
 
    std::vector<TString> trfsDef = gTools().SplitString(processTrfs, ';');
    std::vector<TString>::iterator trfsDefIt = trfsDef.begin();

--- a/tmva/tmva/src/Event.cxx
+++ b/tmva/tmva/src/Event.cxx
@@ -48,7 +48,7 @@ Bool_t TMVA::Event::fgIgnoreNegWeightsInTraining = kFALSE;
 
 TMVA::Event::Event()
    : fValues(),
-     fValuesDynamic(0),
+     fValuesDynamic(nullptr),
      fTargets(),
      fSpectators(),
      fVariableArrangement(0),
@@ -69,7 +69,7 @@ TMVA::Event::Event( const std::vector<Float_t>& ev,
                     Double_t weight,
                     Double_t boostweight )
    : fValues(ev),
-     fValuesDynamic(0),
+     fValuesDynamic(nullptr),
      fTargets(tg),
      fSpectators(0),
      fVariableArrangement(0),
@@ -91,7 +91,7 @@ TMVA::Event::Event( const std::vector<Float_t>& ev,
                     Double_t weight,
                     Double_t boostweight )
    : fValues(ev),
-     fValuesDynamic(0),
+     fValuesDynamic(nullptr),
      fTargets(tg),
      fSpectators(vi),
      fVariableArrangement(0),
@@ -111,7 +111,7 @@ TMVA::Event::Event( const std::vector<Float_t>& ev,
                     Double_t weight,
                     Double_t boostweight )
    : fValues(ev),
-     fValuesDynamic(0),
+     fValuesDynamic(nullptr),
      fTargets(0),
      fSpectators(0),
      fVariableArrangement(0),
@@ -128,7 +128,7 @@ TMVA::Event::Event( const std::vector<Float_t>& ev,
 
 TMVA::Event::Event( const std::vector<Float_t*>*& evdyn, UInt_t nvar )
    : fValues(nvar),
-     fValuesDynamic(0),
+     fValuesDynamic(nullptr),
      fTargets(0),
      fSpectators(evdyn->size()-nvar),
      fVariableArrangement(0),
@@ -175,7 +175,7 @@ TMVA::Event::Event( const Event& event )
       }
 
       fDynamic=kFALSE;
-      fValuesDynamic=NULL;
+      fValuesDynamic=nullptr;
 }
 }
 
@@ -224,7 +224,7 @@ void TMVA::Event::CopyVarValues( const Event& other )
       }
    }
    fDynamic     = kFALSE;
-   fValuesDynamic = NULL;
+   fValuesDynamic = nullptr;
 
    fClass       = other.fClass;
    fWeight      = other.fWeight;

--- a/tmva/tmva/src/Event.cxx
+++ b/tmva/tmva/src/Event.cxx
@@ -284,8 +284,8 @@ const std::vector<Float_t>& TMVA::Event::GetValues() const
       UInt_t mapIdx;
       if (fDynamic) {
          fValues.clear();
-         for (UInt_t i=0; i< fVariableArrangement.size(); i++){
-            mapIdx = fVariableArrangement[i];
+         for (unsigned int i : fVariableArrangement){
+            mapIdx = i;
             fValues.push_back(*((fValuesDynamic)->at(mapIdx)));
          }
       } else {
@@ -293,8 +293,8 @@ const std::vector<Float_t>& TMVA::Event::GetValues() const
          // (change them permanently) ... guess the only way is to add a 'fValuesRearranged' array,
          // and living with the fact that it 'doubles' the Event size :(
          fValuesRearranged.clear();
-         for (UInt_t i=0; i< fVariableArrangement.size(); i++){
-            mapIdx = fVariableArrangement[i];
+         for (unsigned int i : fVariableArrangement){
+            mapIdx = i;
             fValuesRearranged.push_back(fValues.at(mapIdx));
          }
          return fValuesRearranged;

--- a/tmva/tmva/src/ExpectedErrorPruneTool.cxx
+++ b/tmva/tmva/src/ExpectedErrorPruneTool.cxx
@@ -82,11 +82,11 @@ TMVA::ExpectedErrorPruneTool::CalculatePruningInfo( DecisionTree* dt,
       isAutomatic = kFALSE;
       Log() << kWARNING << "Sorry automatic pruning strength determination is not implemented yet" << Endl;
    }
-   if( dt == NULL || (IsAutomatic() && validationSample == NULL) ) {
+   if( dt == nullptr || (IsAutomatic() && validationSample == nullptr) ) {
       // must have a valid decision tree to prune, and if the prune strength
       // is to be chosen automatically, must have a test sample from
       // which to calculate the quality of the pruned tree(s)
-      return NULL;
+      return nullptr;
    }
    fNodePurityLimit = dt->GetNodePurityLimit();
 
@@ -158,7 +158,7 @@ TMVA::ExpectedErrorPruneTool::CalculatePruningInfo( DecisionTree* dt,
 
         return new PruningInfo(it->first, it->second, fPruneSequence);
       */
-      return NULL;
+      return nullptr;
    }
    else { // no automatic pruning - just use the provided prune strength parameter
       FindListOfNodes( (DecisionTreeNode*)dt->GetRoot() );

--- a/tmva/tmva/src/Factory.cxx
+++ b/tmva/tmva/src/Factory.cxx
@@ -211,7 +211,7 @@ TMVA::Factory::Factory( TString jobName, TString theOption )
    fAnalysisType         ( Types::kClassification ),
    fModelPersistence     (kTRUE)
 {
-   fgTargetFile = 0;
+   fgTargetFile = nullptr;
    fLogger->SetSource(GetName());
 
 
@@ -363,8 +363,8 @@ TMVA::MethodBase* TMVA::Factory::BookMethod( TMVA::DataLoader *loader, TString t
 
    if( fAnalysisType == Types::kNoAnalysisType ){
       if( loader->DefaultDataSetInfo().GetNClasses()==2
-          && loader->DefaultDataSetInfo().GetClassInfo("Signal") != NULL
-          && loader->DefaultDataSetInfo().GetClassInfo("Background") != NULL
+          && loader->DefaultDataSetInfo().GetClassInfo("Signal") != nullptr
+          && loader->DefaultDataSetInfo().GetClassInfo("Background") != nullptr
           ){
          fAnalysisType = Types::kClassification; // default is classification
       } else if( loader->DefaultDataSetInfo().GetNClasses() >= 2 ){
@@ -379,7 +379,7 @@ TMVA::MethodBase* TMVA::Factory::BookMethod( TMVA::DataLoader *loader, TString t
 
   if(fMethodsMap.find(datasetname)!=fMethodsMap.end())
    {
-      if (GetMethod( datasetname,methodTitle ) != 0) {
+      if (GetMethod( datasetname,methodTitle ) != nullptr) {
        Log() << kFATAL << "Booking failed since method with title <"
         << methodTitle <<"> already exists "<< "in with DataSet Name <"<< loader->GetName()<<">  "
         << Endl;
@@ -428,7 +428,7 @@ TMVA::MethodBase* TMVA::Factory::BookMethod( TMVA::DataLoader *loader, TString t
    }
 
    MethodBase *method = dynamic_cast<MethodBase*>(im);
-   if (method==0) return 0; // could not create method
+   if (method==nullptr) return nullptr; // could not create method
 
    // set fDataSetManager if MethodCategory (to enable Category to create datasetinfo objects) // DSMTEST
    if (method->GetMethodType() == Types::kCategory) { // DSMTEST
@@ -457,7 +457,7 @@ TMVA::MethodBase* TMVA::Factory::BookMethod( TMVA::DataLoader *loader, TString t
       else {
          Log() << "classification with " << loader->DefaultDataSetInfo().GetNClasses() << " classes." << Endl;
       }
-      return 0;
+      return nullptr;
    }
 
    if(fModelPersistence) method->SetWeightFileDir(fFileDir);
@@ -560,7 +560,7 @@ TMVA::MethodBase* TMVA::Factory::BookMethodWeightfile(DataLoader *loader, TMVA::
 
 TMVA::IMethod* TMVA::Factory::GetMethod(const TString& datasetname,  const TString &methodTitle ) const
 {
-   if(fMethodsMap.find(datasetname)==fMethodsMap.end()) return 0;
+   if(fMethodsMap.find(datasetname)==fMethodsMap.end()) return nullptr;
 
    MVector *methods=fMethodsMap.find(datasetname)->second;
 
@@ -570,7 +570,7 @@ TMVA::IMethod* TMVA::Factory::GetMethod(const TString& datasetname,  const TStri
       MethodBase* mva = dynamic_cast<MethodBase*>(*itrMethod);
       if ( (mva->GetMethodName())==methodTitle ) return mva;
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -605,15 +605,15 @@ void TMVA::Factory::WriteDataInformation(DataSetInfo&     fDataSetInfo)
 
 
    // correlation matrix of the default DS
-   const TMatrixD* m(0);
-   const TH2* h(0);
+   const TMatrixD* m(nullptr);
+   const TH2* h(nullptr);
 
    if(fAnalysisType == Types::kMulticlass){
       for (UInt_t cls = 0; cls < fDataSetInfo.GetNClasses() ; cls++) {
          m = fDataSetInfo.CorrelationMatrix(fDataSetInfo.GetClassInfo(cls)->GetName());
          h = fDataSetInfo.CreateCorrelationMatrixHist(m, TString("CorrelationMatrix")+fDataSetInfo.GetClassInfo(cls)->GetName(),
                                                               TString("Correlation Matrix (")+ fDataSetInfo.GetClassInfo(cls)->GetName() +TString(")"));
-         if (h!=0) {
+         if (h!=nullptr) {
             h->Write();
             delete h;
          }
@@ -622,21 +622,21 @@ void TMVA::Factory::WriteDataInformation(DataSetInfo&     fDataSetInfo)
    else{
       m = fDataSetInfo.CorrelationMatrix( "Signal" );
       h = fDataSetInfo.CreateCorrelationMatrixHist(m, "CorrelationMatrixS", "Correlation Matrix (signal)");
-      if (h!=0) {
+      if (h!=nullptr) {
          h->Write();
          delete h;
       }
 
       m = fDataSetInfo.CorrelationMatrix( "Background" );
       h = fDataSetInfo.CreateCorrelationMatrixHist(m, "CorrelationMatrixB", "Correlation Matrix (background)");
-      if (h!=0) {
+      if (h!=nullptr) {
          h->Write();
          delete h;
       }
 
       m = fDataSetInfo.CorrelationMatrix( "Regression" );
       h = fDataSetInfo.CreateCorrelationMatrixHist(m, "CorrelationMatrix", "Correlation Matrix");
-      if (h!=0) {
+      if (h!=nullptr) {
          h->Write();
          delete h;
       }
@@ -651,7 +651,7 @@ void TMVA::Factory::WriteDataInformation(DataSetInfo&     fDataSetInfo)
 
    // remove any trace of identity transform - if given (avoid to apply it twice)
    std::vector<TMVA::TransformationHandler*> trfs;
-   TransformationHandler* identityTrHandler = 0;
+   TransformationHandler* identityTrHandler = nullptr;
 
    std::vector<TString> trfsDef = gTools().SplitString(processTrfs,';');
    std::vector<TString>::iterator trfsDefIt = trfsDef.begin();
@@ -1057,7 +1057,7 @@ TCanvas * TMVA::Factory::GetROCCurve(TString datasetname, UInt_t iClass)
 {
    if (fMethodsMap.find(datasetname) == fMethodsMap.end()) {
       Log() << kERROR << Form("DataSet = %s not found in methods map.", datasetname.Data()) << Endl;
-      return 0;
+      return nullptr;
    }
 
    TString name = Form("ROCCurve %s class %i", datasetname.Data(), iClass);
@@ -1120,7 +1120,7 @@ void TMVA::Factory::TrainAllMethods()
      Event::SetIsTraining(kTRUE);
      MethodBase* mva = dynamic_cast<MethodBase*>(*itrMethod);
 
-     if(mva==0) continue;
+     if(mva==nullptr) continue;
 
      if(mva->DataInfo().GetDataSetManager()->DataInput().GetEntries() <=1) { // 0 entries --> 0 events, 1 entry --> dynamical dataset (or one entry)
          Log() << kFATAL << "No input data for the training provided!" << Endl;
@@ -1162,7 +1162,7 @@ void TMVA::Factory::TrainAllMethods()
 
       // create and print ranking
       const Ranking* ranking = (*itrMethod)->CreateRanking();
-      if (ranking != 0) ranking->Print();
+      if (ranking != nullptr) ranking->Print();
       else Log() << kINFO << "No variable ranking supplied by classifier: "
            << dynamic_cast<MethodBase*>(*itrMethod)->GetMethodName() << Endl;
        }
@@ -1183,7 +1183,7 @@ void TMVA::Factory::TrainAllMethods()
      for (UInt_t i=0; i<methods->size(); i++) {
 
        MethodBase* m = dynamic_cast<MethodBase*>((*methods)[i]);
-       if(m==0) continue;
+       if(m==nullptr) continue;
 
        TMVA::Types::EMVA methodType = m->GetMethodType();
        TString           weightfile = m->GetWeightFileName();
@@ -1248,7 +1248,7 @@ void TMVA::Factory::TestAllMethods()
       for( itrMethod = methods->begin(); itrMethod != methods->end(); ++itrMethod ) {
      Event::SetIsTraining(kFALSE);
      MethodBase* mva = dynamic_cast<MethodBase*>(*itrMethod);
-     if(mva==0) continue;
+     if(mva==nullptr) continue;
      Types::EAnalysisType analysisType = mva->GetAnalysisType();
      Log() << kHEADER << "Test method: " << mva->GetMethodName() << " for "
       << (analysisType == Types::kRegression ? "Regression" :
@@ -1277,7 +1277,7 @@ void TMVA::Factory::MakeClass(const TString& datasetname , const TString& method
       MVector::const_iterator itrMethod;
       for (itrMethod    = methods->begin(); itrMethod != methods->end(); ++itrMethod) {
          MethodBase* method = dynamic_cast<MethodBase*>(*itrMethod);
-         if(method==0) continue;
+         if(method==nullptr) continue;
          Log() << kINFO << "Make response class for classifier: " << method->GetMethodName() << Endl;
          method->MakeClass();
       }
@@ -1305,7 +1305,7 @@ void TMVA::Factory::PrintHelpMessage(const TString& datasetname , const TString&
       MVector::const_iterator itrMethod ;
       for (itrMethod    = methods->begin(); itrMethod != methods->end(); ++itrMethod) {
          MethodBase* method = dynamic_cast<MethodBase*>(*itrMethod);
-         if(method==0) continue;
+         if(method==nullptr) continue;
          Log() << kINFO << "Print help message for classifier: " << method->GetMethodName() << Endl;
          method->PrintHelpMessage();
       }
@@ -1405,7 +1405,7 @@ void TMVA::Factory::EvaluateAllMethods( void )
       for (MVector::iterator itrMethod =methods->begin(); itrMethod != methods->end(); ++itrMethod) {
      Event::SetIsTraining(kFALSE);
      MethodBase* theMethod = dynamic_cast<MethodBase*>(*itrMethod);
-     if(theMethod==0) continue;
+     if(theMethod==nullptr) continue;
      theMethod->SetFile(fgTargetFile);
      theMethod->SetSilentFile(IsSilentFile());
      if (theMethod->GetMethodType() != Types::kCuts) methodsNoCuts.push_back( *itrMethod );
@@ -1631,7 +1631,7 @@ void TMVA::Factory::EvaluateAllMethods( void )
       std::vector<ResultsClassification*> mvaRes;
       for (MVector::iterator itrMethod = methodsNoCuts.begin(); itrMethod != methodsNoCuts.end(); ++itrMethod, ++ivar) {
           MethodBase* m = dynamic_cast<MethodBase*>(*itrMethod);
-          if(m==0) continue;
+          if(m==nullptr) continue;
           theVars->push_back( m->GetTestvarName() );
           rvec.push_back( m->GetSignalReferenceCut() );
           theVars->back().ReplaceAll( "MVA_", "" );
@@ -1653,7 +1653,7 @@ void TMVA::Factory::EvaluateAllMethods( void )
           const Event* ev = defDs->GetEvent(ievt);
 
     //                 for correlations
-          TMatrixD* theMat = 0;
+          TMatrixD* theMat = nullptr;
           for (Int_t im=0; im<nmeth; im++) {
     //                    check for NaN value
             Double_t retval = (Double_t)(*mvaRes[im])[ievt][0];
@@ -1693,7 +1693,7 @@ void TMVA::Factory::EvaluateAllMethods( void )
       const TMatrixD* corrMatB = gTools().GetCorrelationMatrix( covMatB );
 
     //              print correlation matrices
-      if (corrMatS != 0 && corrMatB != 0) {
+      if (corrMatS != nullptr && corrMatB != nullptr) {
 
     //                 extract MVA matrix
           TMatrixD mvaMatS(nmeth,nmeth);
@@ -1791,7 +1791,7 @@ void TMVA::Factory::EvaluateAllMethods( void )
 
      for (Int_t i=0; i<nmeth_used[0]; i++) {
        MethodBase* theMethod = dynamic_cast<MethodBase*>((*methods)[i]);
-       if(theMethod==0) continue;
+       if(theMethod==nullptr) continue;
 
        Log() << kINFO << Form("%-20s %-15s:%#9.3g%#9.3g%#9.3g%#9.3g  |  %#5.3f  %#5.3f",
                     theMethod->fDataSetInfo.GetName(),
@@ -1811,7 +1811,7 @@ void TMVA::Factory::EvaluateAllMethods( void )
 
      for (Int_t i=0; i<nmeth_used[0]; i++) {
        MethodBase* theMethod = dynamic_cast<MethodBase*>((*methods)[i]);
-       if(theMethod==0) continue;
+       if(theMethod==nullptr) continue;
        Log() << kINFO << Form("%-20s %-15s:%#9.3g%#9.3g%#9.3g%#9.3g  |  %#5.3f  %#5.3f",
                     theMethod->fDataSetInfo.GetName(),
                     (const char*)mname[0][i],
@@ -1893,7 +1893,7 @@ void TMVA::Factory::EvaluateAllMethods( void )
                const TString mvaName = mname[k][i];
 
                MethodBase *theMethod = dynamic_cast<MethodBase *>(GetMethod(datasetName, mvaName));
-               if (theMethod == 0) {
+               if (theMethod == nullptr) {
                   continue;
                }
 
@@ -2045,7 +2045,7 @@ void TMVA::Factory::EvaluateAllMethods( void )
                   }
 
                   MethodBase *theMethod = dynamic_cast<MethodBase *>(GetMethod(datasetName, methodName));
-                  if (theMethod == 0) {
+                  if (theMethod == nullptr) {
                      continue;
                   }
 
@@ -2105,7 +2105,7 @@ void TMVA::Factory::EvaluateAllMethods( void )
                for (Int_t i = 0; i < nmeth_used[k]; i++) {
                   if (k == 1) mname[k][i].ReplaceAll("Variable_", "");
                   MethodBase *theMethod = dynamic_cast<MethodBase *>((*methods)[i]);
-                  if (theMethod == 0) continue;
+                  if (theMethod == nullptr) continue;
 
                   Log() << kINFO << Form("%-20s %-15s: %#1.3f (%#1.3f)       %#1.3f (%#1.3f)      %#1.3f (%#1.3f)",
                                          theMethod->fDataSetInfo.GetName(), (const char *)mname[k][i], eff01[k][i],
@@ -2125,7 +2125,7 @@ void TMVA::Factory::EvaluateAllMethods( void )
          for (Int_t k=0; k<2; k++) {
       for (Int_t i=0; i<nmeth_used[k]; i++) {
           MethodBase* theMethod = dynamic_cast<MethodBase*>((*methods)[i]);
-          if(theMethod==0) continue;
+          if(theMethod==nullptr) continue;
           // write test/training trees
           RootBaseDir()->cd(theMethod->fDataSetInfo.GetName());
           if(std::find(datasets.begin(), datasets.end(), theMethod->fDataSetInfo.GetName()) == datasets.end())
@@ -2522,7 +2522,7 @@ TH1F* TMVA::Factory::GetImportance(const int nbits,std::vector<Double_t> importa
   vih1->GetYaxis()->SetTitleOffset(1.24);
 
   vih1->GetYaxis()->SetRangeUser(-7, 50);
-  vih1->SetDirectory(0);
+  vih1->SetDirectory(nullptr);
 
 //   vih1->Draw("B");
   return vih1;

--- a/tmva/tmva/src/Factory.cxx
+++ b/tmva/tmva/src/Factory.cxx
@@ -309,7 +309,7 @@ Bool_t TMVA::Factory::IsModelPersistence()
 ////////////////////////////////////////////////////////////////////////////////
 /// Destructor.
 
-TMVA::Factory::~Factory( void )
+TMVA::Factory::~Factory()
 {
    std::vector<TMVA::VariableTransformBase*>::iterator trfIt = fDefaultTrfs.begin();
    for (;trfIt != fDefaultTrfs.end(); ++trfIt) delete (*trfIt);
@@ -327,7 +327,7 @@ TMVA::Factory::~Factory( void )
 ////////////////////////////////////////////////////////////////////////////////
 /// Delete methods.
 
-void TMVA::Factory::DeleteAllMethods( void )
+void TMVA::Factory::DeleteAllMethods()
 {
    std::map<TString,MVector*>::iterator itrMap;
 
@@ -1330,7 +1330,7 @@ void TMVA::Factory::EvaluateAllVariables(DataLoader *loader, TString options )
 ////////////////////////////////////////////////////////////////////////////////
 /// Iterates over all MVAs that have been booked, and calls their evaluation methods.
 
-void TMVA::Factory::EvaluateAllMethods( void )
+void TMVA::Factory::EvaluateAllMethods()
 {
    Log() << kHEADER << gTools().Color("bold") << "Evaluate all methods" << gTools().Color("reset") << Endl;
 

--- a/tmva/tmva/src/Factory.cxx
+++ b/tmva/tmva/src/Factory.cxx
@@ -1418,6 +1418,7 @@ void TMVA::Factory::EvaluateAllMethods( void )
        Double_t biasT, devT, rmsT, mInfT;
        Double_t rho;
 
+       Log() << kINFO << "TestRegression (testing)" << Endl;
        theMethod->TestRegression( bias, biasT, dev, devT, rms, rmsT, mInf, mInfT, rho, TMVA::Types::kTesting  );
        biastest[0]  .push_back( bias );
        devtest[0]   .push_back( dev );
@@ -1429,6 +1430,7 @@ void TMVA::Factory::EvaluateAllMethods( void )
        rmstestT[0]  .push_back( rmsT );
        minftestT[0] .push_back( mInfT );
 
+       Log() << kINFO << "TestRegression (training)" << Endl;
        theMethod->TestRegression( bias, biasT, dev, devT, rms, rmsT, mInf, mInfT, rho, TMVA::Types::kTraining  );
        biastrain[0] .push_back( bias );
        devtrain[0]  .push_back( dev );

--- a/tmva/tmva/src/Factory.cxx
+++ b/tmva/tmva/src/Factory.cxx
@@ -1180,9 +1180,9 @@ void TMVA::Factory::TrainAllMethods()
       if(!IsSilentFile())RootBaseDir()->cd();
 
      // iterate through all booked methods
-     for (UInt_t i=0; i<methods->size(); i++) {
+     for (auto & method : *methods) {
 
-       MethodBase* m = dynamic_cast<MethodBase*>((*methods)[i]);
+       MethodBase* m = dynamic_cast<MethodBase*>(method);
        if(m==nullptr) continue;
 
        TMVA::Types::EMVA methodType = m->GetMethodType();
@@ -1217,7 +1217,7 @@ void TMVA::Factory::TrainAllMethods()
        m->SetTestvarName(testvarName);
 
        // replace trained method by newly created one (from weight file) in methods vector
-       (*methods)[i] = m;
+       method = m;
      }
        }
    }
@@ -1402,13 +1402,13 @@ void TMVA::Factory::EvaluateAllMethods( void )
       Bool_t doMulticlass = kFALSE;
 
       // iterate over methods and evaluate
-      for (MVector::iterator itrMethod =methods->begin(); itrMethod != methods->end(); ++itrMethod) {
+      for (auto & method : *methods) {
      Event::SetIsTraining(kFALSE);
-     MethodBase* theMethod = dynamic_cast<MethodBase*>(*itrMethod);
+     MethodBase* theMethod = dynamic_cast<MethodBase*>(method);
      if(theMethod==nullptr) continue;
      theMethod->SetFile(fgTargetFile);
      theMethod->SetSilentFile(IsSilentFile());
-     if (theMethod->GetMethodType() != Types::kCuts) methodsNoCuts.push_back( *itrMethod );
+     if (theMethod->GetMethodType() != Types::kCuts) methodsNoCuts.push_back( method );
 
      if (theMethod->DoRegression()) {
        doRegression = kTRUE;
@@ -2122,8 +2122,8 @@ void TMVA::Factory::EvaluateAllMethods( void )
      if(!IsSilentFile())
      {
          std::list<TString> datasets;
-         for (Int_t k=0; k<2; k++) {
-      for (Int_t i=0; i<nmeth_used[k]; i++) {
+         for (int k : nmeth_used) {
+      for (Int_t i=0; i<k; i++) {
           MethodBase* theMethod = dynamic_cast<MethodBase*>((*methods)[i]);
           if(theMethod==nullptr) continue;
           // write test/training trees

--- a/tmva/tmva/src/FitterBase.cxx
+++ b/tmva/tmva/src/FitterBase.cxx
@@ -74,8 +74,8 @@ TMVA::FitterBase::FitterBase( IFitterTarget& target,
 Double_t TMVA::FitterBase::Run()
 {
    std::vector<Double_t> pars;
-   for (std::vector<Interval*>::const_iterator parIt = fRanges.begin(); parIt != fRanges.end(); ++parIt) {
-      pars.push_back( (*parIt)->GetMean() );
+   for (auto fRange : fRanges) {
+      pars.push_back( fRange->GetMean() );
    }
 
    //   delete fLogger;

--- a/tmva/tmva/src/GeneticPopulation.cxx
+++ b/tmva/tmva/src/GeneticPopulation.cxx
@@ -205,16 +205,16 @@ TMVA::GeneticGenes* TMVA::GeneticPopulation::GetGenes( Int_t index )
 
 void TMVA::GeneticPopulation::Print( Int_t untilIndex )
 {
-   for ( unsigned int it = 0; it < fGenePool.size(); ++it )
+   for (auto & it : fGenePool)
       {
          Int_t n=0;
          if (untilIndex >= -1 ) {
             if (untilIndex == -1 ) return;
             untilIndex--;
          }
-         Log() << "fitness: " << fGenePool[it].GetFitness() << "    ";
-         for (vector< Double_t >::iterator vec = fGenePool[it].GetFactors().begin();
-              vec < fGenePool[it].GetFactors().end(); ++vec ) {
+         Log() << "fitness: " << it.GetFitness() << "    ";
+         for (vector< Double_t >::iterator vec = it.GetFactors().begin();
+              vec < it.GetFactors().end(); ++vec ) {
             Log() << "f_" << n++ << ": " << (*vec) << "     ";
          }
          Log() << Endl;
@@ -227,15 +227,15 @@ void TMVA::GeneticPopulation::Print( Int_t untilIndex )
 
 void TMVA::GeneticPopulation::Print( ostream & out, Int_t untilIndex )
 {
-   for ( unsigned int it = 0; it < fGenePool.size(); ++it ) {
+   for (auto & it : fGenePool) {
       Int_t n=0;
       if (untilIndex >= -1 ) {
          if (untilIndex == -1 ) return;
          untilIndex--;
       }
-      out << "fitness: " << fGenePool[it].GetFitness() << "    ";
-      for (vector< Double_t >::iterator vec = fGenePool[it].GetFactors().begin();
-           vec < fGenePool[it].GetFactors().end(); ++vec ) {
+      out << "fitness: " << it.GetFitness() << "    ";
+      for (vector< Double_t >::iterator vec = it.GetFactors().begin();
+           vec < it.GetFactors().end(); ++vec ) {
          out << "f_" << n++ << ": " << (*vec) << "     ";
       }
       out << std::endl;
@@ -282,9 +282,8 @@ vector<Double_t> TMVA::GeneticPopulation::VariableDistribution( Int_t /*varNumbe
 
 void TMVA::GeneticPopulation::AddPopulation( GeneticPopulation *strangers )
 {
-   for (std::vector<TMVA::GeneticGenes>::iterator it = strangers->fGenePool.begin();
-        it != strangers->fGenePool.end(); ++it ) {
-      GiveHint( it->GetFactors(), it->GetFitness() );
+   for (auto & it : strangers->fGenePool) {
+      GiveHint( it.GetFactors(), it.GetFitness() );
    }
 }
 

--- a/tmva/tmva/src/GeneticPopulation.cxx
+++ b/tmva/tmva/src/GeneticPopulation.cxx
@@ -80,7 +80,7 @@ TMVA::GeneticPopulation::GeneticPopulation(const std::vector<Interval*>& ranges,
 
 TMVA::GeneticPopulation::~GeneticPopulation()
 {
-   if (fRandomGenerator != NULL) delete fRandomGenerator;
+   if (fRandomGenerator != nullptr) delete fRandomGenerator;
 
    std::vector<GeneticRange*>::iterator it = fRanges.begin();
    for (;it!=fRanges.end(); ++it) delete *it;

--- a/tmva/tmva/src/KDEKernel.cxx
+++ b/tmva/tmva/src/KDEKernel.cxx
@@ -61,11 +61,11 @@ TMVA::KDEKernel::KDEKernel( EKernelIter kiter, const TH1 *hist, Float_t lower_ed
    fLowerEdge (lower_edge ),
    fUpperEdge (upper_edge),
    fFineFactor ( FineFactor ),
-   fKernel_integ ( 0 ),
+   fKernel_integ ( nullptr ),
    fKDEborder ( kborder ),
    fLogger( new MsgLogger("KDEKernel") )
 {
-   if (hist == NULL) {
+   if (hist == nullptr) {
       Log() << kFATAL << "Called without valid histogram pointer (hist)!" << Endl;
    }
 
@@ -83,10 +83,10 @@ TMVA::KDEKernel::KDEKernel( EKernelIter kiter, const TH1 *hist, Float_t lower_ed
 
 TMVA::KDEKernel::~KDEKernel()
 {
-   if (fHist           != NULL) delete fHist;
-   if (fFirstIterHist  != NULL) delete fFirstIterHist;
-   if (fSigmaHist      != NULL) delete fSigmaHist;
-   if (fKernel_integ   != NULL) delete fKernel_integ;
+   if (fHist           != nullptr) delete fHist;
+   if (fFirstIterHist  != nullptr) delete fFirstIterHist;
+   if (fSigmaHist      != nullptr) delete fSigmaHist;
+   if (fKernel_integ   != nullptr) delete fKernel_integ;
    delete fLogger;
 }
 
@@ -214,7 +214,7 @@ void TMVA::KDEKernel::SetKernelType( EKernelType ktype )
       }
    }
 
-   if (fKernel_integ ==0 ) {
+   if (fKernel_integ ==nullptr ) {
       Log() << kFATAL << "KDE kernel not correctly initialized!" << Endl;
    }
 }

--- a/tmva/tmva/src/LDA.cxx
+++ b/tmva/tmva/src/LDA.cxx
@@ -47,8 +47,8 @@
 TMVA::LDA::LDA( Float_t tolerence, Bool_t debug )
    : fTolerence(tolerence),
      fNumParams(0),
-     fSigma(0),
-     fSigmaInverse(0),
+     fSigma(nullptr),
+     fSigmaInverse(nullptr),
      fDebug(debug),
      fLogger( new MsgLogger("LDA", (debug?kINFO:kDEBUG)) )
 {
@@ -108,7 +108,7 @@ void TMVA::LDA::Initialize(const LDAEvents& inputSignalEvents, const LDAEvents& 
    // the signal, background, and total matrix
    TMatrixF sigmaSignal(fNumParams, fNumParams);
    TMatrixF sigmaBack(fNumParams, fNumParams);
-   if (fSigma!=0) delete fSigma;
+   if (fSigma!=nullptr) delete fSigma;
    fSigma = new TMatrixF(fNumParams, fNumParams);
    for (UInt_t row=0; row < fNumParams; ++row) {
       for (UInt_t col=0; col < fNumParams; ++col) {

--- a/tmva/tmva/src/LossFunction.cxx
+++ b/tmva/tmva/src/LossFunction.cxx
@@ -85,8 +85,8 @@ Double_t TMVA::HuberLossFunction::CalculateSumOfWeights(std::vector<LossFunction
 
    // Calculate the sum of the weights
    Double_t sumOfWeights = 0;
-   for(UInt_t i = 0; i<evs.size(); i++)
-      sumOfWeights+=evs[i].weight;
+   for(auto & ev : evs)
+      sumOfWeights+=ev.weight;
 
    return sumOfWeights;
 }
@@ -131,8 +131,8 @@ void TMVA::HuberLossFunction::SetTransitionPoint(std::vector<LossFunctionEventIn
    // the quantile was chosen too low. Let's use the first nonzero residual as the transition point instead.
    if(fTransitionPoint == 0){
       // evs should already be sorted according to the magnitude of the residuals, since CalculateQuantile does this
-      for(UInt_t i=0; i<evs.size(); i++){
-         Double_t residual = TMath::Abs(evs[i].trueValue - evs[i].predictedValue);
+      for(auto & ev : evs){
+         Double_t residual = TMath::Abs(ev.trueValue - ev.predictedValue);
          if(residual != 0){
             fTransitionPoint = residual;
             break;
@@ -189,8 +189,8 @@ Double_t TMVA::HuberLossFunction::CalculateNetLoss(std::vector<LossFunctionEvent
    SetTransitionPoint(evs);
 
    Double_t netloss = 0;
-   for(UInt_t i=0; i<evs.size(); i++)
-       netloss+=CalculateLoss(evs[i]);
+   for(auto & ev : evs)
+       netloss+=CalculateLoss(ev);
    return netloss;
    // should get a function to return the average loss as well
    // return netloss/fSumOfWeights
@@ -207,8 +207,8 @@ Double_t TMVA::HuberLossFunction::CalculateMeanLoss(std::vector<LossFunctionEven
    SetTransitionPoint(evs);
 
    Double_t netloss = 0;
-   for(UInt_t i=0; i<evs.size(); i++)
-       netloss+=CalculateLoss(evs[i]);
+   for(auto & ev : evs)
+       netloss+=CalculateLoss(ev);
    return netloss/fSumOfWeights;
 }
 
@@ -326,8 +326,8 @@ Double_t TMVA::LeastSquaresLossFunction::CalculateLoss(LossFunctionEventInfo& e)
 
 Double_t TMVA::LeastSquaresLossFunction::CalculateNetLoss(std::vector<LossFunctionEventInfo>& evs){
    Double_t netloss = 0;
-   for(UInt_t i=0; i<evs.size(); i++)
-       netloss+=CalculateLoss(evs[i]);
+   for(auto & ev : evs)
+       netloss+=CalculateLoss(ev);
    return netloss;
    // should get a function to return the average loss as well
    // return netloss/fSumOfWeights
@@ -339,9 +339,9 @@ Double_t TMVA::LeastSquaresLossFunction::CalculateNetLoss(std::vector<LossFuncti
 Double_t TMVA::LeastSquaresLossFunction::CalculateMeanLoss(std::vector<LossFunctionEventInfo>& evs){
    Double_t netloss = 0;
    Double_t sumOfWeights = 0;
-   for(UInt_t i=0; i<evs.size(); i++){
-       sumOfWeights+=evs[i].weight;
-       netloss+=CalculateLoss(evs[i]);
+   for(auto & ev : evs){
+       sumOfWeights+=ev.weight;
+       netloss+=CalculateLoss(ev);
    }
    // return the weighted mean
    return netloss/sumOfWeights;
@@ -412,10 +412,10 @@ Double_t TMVA::LeastSquaresLossFunctionBDT::Fit(std::vector<LossFunctionEventInf
 // The fit in the terminal node for least squares is the weighted average of the residuals.
    Double_t sumOfWeights = 0;
    Double_t weightedResidualSum = 0;
-   for(UInt_t j=0;j<evs.size();j++){
-      sumOfWeights += evs[j].weight;
-      Double_t residual = evs[j].trueValue - evs[j].predictedValue;
-      weightedResidualSum += evs[j].weight*residual;
+   for(auto & ev : evs){
+      sumOfWeights += ev.weight;
+      Double_t residual = ev.trueValue - ev.predictedValue;
+      weightedResidualSum += ev.weight*residual;
    }
    Double_t weightedMean = weightedResidualSum/sumOfWeights;
 
@@ -446,8 +446,8 @@ Double_t TMVA::AbsoluteDeviationLossFunction::CalculateLoss(LossFunctionEventInf
 Double_t TMVA::AbsoluteDeviationLossFunction::CalculateNetLoss(std::vector<LossFunctionEventInfo>& evs){
 
    Double_t netloss = 0;
-   for(UInt_t i=0; i<evs.size(); i++)
-       netloss+=CalculateLoss(evs[i]);
+   for(auto & ev : evs)
+       netloss+=CalculateLoss(ev);
    return netloss;
 }
 
@@ -457,9 +457,9 @@ Double_t TMVA::AbsoluteDeviationLossFunction::CalculateNetLoss(std::vector<LossF
 Double_t TMVA::AbsoluteDeviationLossFunction::CalculateMeanLoss(std::vector<LossFunctionEventInfo>& evs){
    Double_t sumOfWeights = 0;
    Double_t netloss = 0;
-   for(UInt_t i=0; i<evs.size(); i++){
-       sumOfWeights+=evs[i].weight;
-       netloss+=CalculateLoss(evs[i]);
+   for(auto & ev : evs){
+       sumOfWeights+=ev.weight;
+       netloss+=CalculateLoss(ev);
    }
    return netloss/sumOfWeights;
 }
@@ -531,8 +531,8 @@ Double_t TMVA::AbsoluteDeviationLossFunctionBDT::Fit(std::vector<LossFunctionEve
 
    // calculate the sum of weights, used in the weighted median calculation
    Double_t sumOfWeights = 0;
-   for(UInt_t j=0; j<evs.size(); j++)
-      sumOfWeights+=evs[j].weight;
+   for(auto & ev : evs)
+      sumOfWeights+=ev.weight;
 
    // get the index of the weighted median
    UInt_t i = 0;

--- a/tmva/tmva/src/LossFunction.cxx
+++ b/tmva/tmva/src/LossFunction.cxx
@@ -225,7 +225,7 @@ TMVA::HuberLossFunctionBDT::HuberLossFunctionBDT(){
 ////////////////////////////////////////////////////////////////////////////////
 /// huber BDT, initialize the targets and prepare for the regression
 
-void TMVA::HuberLossFunctionBDT::Init(std::map<const TMVA::Event*, LossFunctionEventInfo>& evinfomap, std::vector<double>& boostWeights){
+void TMVA::HuberLossFunctionBDT::Init(std::unordered_map<const TMVA::Event*, LossFunctionEventInfo>& evinfomap, std::vector<double>& boostWeights){
 // Run this once before building the forest. Set initial prediction to weightedMedian.
 
    std::vector<LossFunctionEventInfo> evinfovec;
@@ -248,7 +248,7 @@ void TMVA::HuberLossFunctionBDT::Init(std::map<const TMVA::Event*, LossFunctionE
 ////////////////////////////////////////////////////////////////////////////////
 /// huber BDT, set the targets for a collection of events
 
-void TMVA::HuberLossFunctionBDT::SetTargets(std::vector<const TMVA::Event*>& evs, std::map< const TMVA::Event*, LossFunctionEventInfo >& evinfomap){
+void TMVA::HuberLossFunctionBDT::SetTargets(std::vector<const TMVA::Event*>& evs, std::unordered_map< const TMVA::Event*, LossFunctionEventInfo >& evinfomap){
 
    std::vector<LossFunctionEventInfo> eventvec;
    for (std::vector<const TMVA::Event*>::const_iterator e=evs.begin(); e!=evs.end();++e){
@@ -359,7 +359,7 @@ Least Squares BDT Loss Function.
 ////////////////////////////////////////////////////////////////////////////////
 /// least squares BDT, initialize the targets and prepare for the regression
 
-void TMVA::LeastSquaresLossFunctionBDT::Init(std::map<const TMVA::Event*, LossFunctionEventInfo>& evinfomap, std::vector<double>& boostWeights){
+void TMVA::LeastSquaresLossFunctionBDT::Init(std::unordered_map<const TMVA::Event*, LossFunctionEventInfo>& evinfomap, std::vector<double>& boostWeights){
 // Run this once before building the forest. Set initial prediction to the weightedMean
 
    std::vector<LossFunctionEventInfo> evinfovec;
@@ -381,9 +381,10 @@ void TMVA::LeastSquaresLossFunctionBDT::Init(std::map<const TMVA::Event*, LossFu
 ////////////////////////////////////////////////////////////////////////////////
 /// least squares BDT, set the targets for a collection of events
 
-void TMVA::LeastSquaresLossFunctionBDT::SetTargets(std::vector<const TMVA::Event*>& evs, std::map< const TMVA::Event*, LossFunctionEventInfo >& evinfomap){
+void TMVA::LeastSquaresLossFunctionBDT::SetTargets(std::vector<const TMVA::Event*>& evs, std::unordered_map< const TMVA::Event*, LossFunctionEventInfo >& evinfomap){
 
    std::vector<LossFunctionEventInfo> eventvec;
+   eventvec.reserve(evs.size());
    for (std::vector<const TMVA::Event*>::const_iterator e=evs.begin(); e!=evs.end();++e){
       eventvec.push_back(LossFunctionEventInfo(evinfomap[*e].trueValue, evinfomap[*e].predictedValue, (*e)->GetWeight()));
    }
@@ -473,7 +474,7 @@ Absolute Deviation BDT Loss Function.
 ////////////////////////////////////////////////////////////////////////////////
 /// absolute deviation BDT, initialize the targets and prepare for the regression
 
-void TMVA::AbsoluteDeviationLossFunctionBDT::Init(std::map<const TMVA::Event*, LossFunctionEventInfo>& evinfomap, std::vector<double>& boostWeights){
+void TMVA::AbsoluteDeviationLossFunctionBDT::Init(std::unordered_map<const TMVA::Event*, LossFunctionEventInfo>& evinfomap, std::vector<double>& boostWeights){
 // Run this once before building the forest. Set initial prediction to weightedMedian.
 
    std::vector<LossFunctionEventInfo> evinfovec;
@@ -494,7 +495,7 @@ void TMVA::AbsoluteDeviationLossFunctionBDT::Init(std::map<const TMVA::Event*, L
 ////////////////////////////////////////////////////////////////////////////////
 /// absolute deviation BDT, set the targets for a collection of events
 
-void TMVA::AbsoluteDeviationLossFunctionBDT::SetTargets(std::vector<const TMVA::Event*>& evs, std::map< const TMVA::Event*, LossFunctionEventInfo >& evinfomap){
+void TMVA::AbsoluteDeviationLossFunctionBDT::SetTargets(std::vector<const TMVA::Event*>& evs, std::unordered_map< const TMVA::Event*, LossFunctionEventInfo >& evinfomap){
 
    std::vector<LossFunctionEventInfo> eventvec;
    for (std::vector<const TMVA::Event*>::const_iterator e=evs.begin(); e!=evs.end();++e){

--- a/tmva/tmva/src/LossFunction.cxx
+++ b/tmva/tmva/src/LossFunction.cxx
@@ -229,6 +229,7 @@ void TMVA::HuberLossFunctionBDT::Init(std::unordered_map<const TMVA::Event*, Los
 // Run this once before building the forest. Set initial prediction to weightedMedian.
 
    std::vector<LossFunctionEventInfo> evinfovec;
+   evinfovec.reserve(evinfomap.size());
    for (auto &e: evinfomap){
       evinfovec.push_back(LossFunctionEventInfo(e.second.trueValue, e.second.predictedValue, e.first->GetWeight()));
    }
@@ -251,8 +252,9 @@ void TMVA::HuberLossFunctionBDT::Init(std::unordered_map<const TMVA::Event*, Los
 void TMVA::HuberLossFunctionBDT::SetTargets(std::vector<const TMVA::Event*>& evs, std::unordered_map< const TMVA::Event*, LossFunctionEventInfo >& evinfomap){
 
    std::vector<LossFunctionEventInfo> eventvec;
-   for (std::vector<const TMVA::Event*>::const_iterator e=evs.begin(); e!=evs.end();++e){
-      eventvec.push_back(LossFunctionEventInfo(evinfomap[*e].trueValue, evinfomap[*e].predictedValue, (*e)->GetWeight()));
+   eventvec.reserve(evs.size());
+   for (const auto &e : evs) {
+      eventvec.push_back(LossFunctionEventInfo(evinfomap[e].trueValue, evinfomap[e].predictedValue, e->GetWeight()));
    }
 
    // Recalculate the residual that separates the "core" of the data and the "tails"
@@ -261,8 +263,8 @@ void TMVA::HuberLossFunctionBDT::SetTargets(std::vector<const TMVA::Event*>& evs
    SetSumOfWeights(eventvec); // This was already set in init, but may change if there is subsampling for each tree
    SetTransitionPoint(eventvec);
 
-   for (std::vector<const TMVA::Event*>::const_iterator e=evs.begin(); e!=evs.end();++e) {
-         const_cast<TMVA::Event*>(*e)->SetTarget(0,Target(evinfomap[*e]));
+   for (auto &e : evs) {
+         const_cast<TMVA::Event*>(e)->SetTarget(0,Target(evinfomap[e]));
    }
 }
 
@@ -289,13 +291,13 @@ Double_t TMVA::HuberLossFunctionBDT::Fit(std::vector<LossFunctionEventInfo>& evs
    Double_t sumOfWeights = CalculateSumOfWeights(evs);
    Double_t shift=0,diff= 0;
    Double_t residualMedian = CalculateQuantile(evs,0.5,sumOfWeights, false);
-   for(UInt_t j=0;j<evs.size();j++){
-      Double_t residual = evs[j].trueValue - evs[j].predictedValue;
+   for (const auto &lfei : evs) {
+      Double_t residual = lfei.trueValue - lfei.predictedValue;
       diff = residual-residualMedian;
       // if we are using weights then I'm not sure why this isn't weighted
       shift+=1.0/evs.size()*((diff<0)?-1.0:1.0)*TMath::Min(fTransitionPoint,fabs(diff));
       // I think this should be
-      // shift+=evs[j].weight/sumOfWeights*((diff<0)?-1.0:1.0)*TMath::Min(fTransitionPoint,fabs(diff));
+      // shift+=lfei.weight/sumOfWeights*((diff<0)?-1.0:1.0)*TMath::Min(fTransitionPoint,fabs(diff));
       // not sure why it was originally coded like this
    }
    return (residualMedian + shift);
@@ -363,6 +365,7 @@ void TMVA::LeastSquaresLossFunctionBDT::Init(std::unordered_map<const TMVA::Even
 // Run this once before building the forest. Set initial prediction to the weightedMean
 
    std::vector<LossFunctionEventInfo> evinfovec;
+   evinfovec.reserve(evinfomap.size());
    for (auto &e: evinfomap){
       evinfovec.push_back(LossFunctionEventInfo(e.second.trueValue, e.second.predictedValue, e.first->GetWeight()));
    }
@@ -385,12 +388,12 @@ void TMVA::LeastSquaresLossFunctionBDT::SetTargets(std::vector<const TMVA::Event
 
    std::vector<LossFunctionEventInfo> eventvec;
    eventvec.reserve(evs.size());
-   for (std::vector<const TMVA::Event*>::const_iterator e=evs.begin(); e!=evs.end();++e){
-      eventvec.push_back(LossFunctionEventInfo(evinfomap[*e].trueValue, evinfomap[*e].predictedValue, (*e)->GetWeight()));
+   for (const auto &e : evs) {
+      eventvec.push_back(LossFunctionEventInfo(evinfomap[e].trueValue, evinfomap[e].predictedValue, e->GetWeight()));
    }
 
-   for (std::vector<const TMVA::Event*>::const_iterator e=evs.begin(); e!=evs.end();++e) {
-         const_cast<TMVA::Event*>(*e)->SetTarget(0,Target(evinfomap[*e]));
+   for (auto &e : evs) {
+         const_cast<TMVA::Event*>(e)->SetTarget(0,Target(evinfomap[e]));
    }
 }
 
@@ -478,6 +481,7 @@ void TMVA::AbsoluteDeviationLossFunctionBDT::Init(std::unordered_map<const TMVA:
 // Run this once before building the forest. Set initial prediction to weightedMedian.
 
    std::vector<LossFunctionEventInfo> evinfovec;
+   evinfovec.reserve(evinfomap.size());
    for (auto &e: evinfomap){
       evinfovec.push_back(LossFunctionEventInfo(e.second.trueValue, e.second.predictedValue, e.first->GetWeight()));
    }
@@ -498,12 +502,13 @@ void TMVA::AbsoluteDeviationLossFunctionBDT::Init(std::unordered_map<const TMVA:
 void TMVA::AbsoluteDeviationLossFunctionBDT::SetTargets(std::vector<const TMVA::Event*>& evs, std::unordered_map< const TMVA::Event*, LossFunctionEventInfo >& evinfomap){
 
    std::vector<LossFunctionEventInfo> eventvec;
-   for (std::vector<const TMVA::Event*>::const_iterator e=evs.begin(); e!=evs.end();++e){
-      eventvec.push_back(LossFunctionEventInfo(evinfomap[*e].trueValue, evinfomap[*e].predictedValue, (*e)->GetWeight()));
+   for (const auto &e : evs) {
+      auto &lfei = evinfomap[e];
+      eventvec.push_back(LossFunctionEventInfo(lfei.trueValue, lfei.predictedValue, e->GetWeight()));
    }
 
-   for (std::vector<const TMVA::Event*>::const_iterator e=evs.begin(); e!=evs.end();++e) {
-         const_cast<TMVA::Event*>(*e)->SetTarget(0,Target(evinfomap[*e]));
+   for (auto &e : evs) {
+         const_cast<TMVA::Event*>(e)->SetTarget(0,Target(evinfomap[e]));
    }
 }
 
@@ -526,7 +531,7 @@ Double_t TMVA::AbsoluteDeviationLossFunctionBDT::Fit(std::vector<LossFunctionEve
 
    // use a lambda function to tell the vector how to sort the LossFunctionEventInfo data structures
    // sort in ascending order of residual value
-   std::sort(evs.begin(), evs.end(), [](LossFunctionEventInfo a, LossFunctionEventInfo b){
+   std::sort(evs.begin(), evs.end(), [](const LossFunctionEventInfo &a, const LossFunctionEventInfo &b){
                                         return (a.trueValue-a.predictedValue) < (b.trueValue-b.predictedValue); });
 
    // calculate the sum of weights, used in the weighted median calculation

--- a/tmva/tmva/src/MethodANNBase.cxx
+++ b/tmva/tmva/src/MethodANNBase.cxx
@@ -1022,17 +1022,17 @@ void TMVA::MethodANNBase::WriteMonitoringHistosToFile() const
       epochdir = BaseDir()->mkdir( Form("EpochMonitoring_%4d",epochVal) );
 
    epochdir->cd();
-   for (std::vector<TH1*>::const_iterator it = fEpochMonHistS.begin(); it != fEpochMonHistS.end(); ++it) {
-      (*it)->Write();
-      delete (*it);
+   for (auto it : fEpochMonHistS) {
+      it->Write();
+      delete it;
    }
-   for (std::vector<TH1*>::const_iterator it = fEpochMonHistB.begin(); it != fEpochMonHistB.end(); ++it) {
-      (*it)->Write();
-      delete (*it);
+   for (auto it : fEpochMonHistB) {
+      it->Write();
+      delete it;
    }
-   for (std::vector<TH1*>::const_iterator it = fEpochMonHistW.begin(); it != fEpochMonHistW.end(); ++it) {
-      (*it)->Write();
-      delete (*it);
+   for (auto it : fEpochMonHistW) {
+      it->Write();
+      delete it;
    }
    BaseDir()->cd();
 }

--- a/tmva/tmva/src/MethodANNBase.cxx
+++ b/tmva/tmva/src/MethodANNBase.cxx
@@ -211,15 +211,15 @@ std::vector<Int_t>* TMVA::MethodANNBase::ParseLayoutString(TString layerSpec)
 
 void TMVA::MethodANNBase::InitANNBase()
 {
-   fNetwork         = NULL;
-   frgen            = NULL;
-   fActivation      = NULL;
-   fOutput          = NULL; //zjh
-   fIdentity        = NULL;
-   fInputCalculator = NULL;
-   fSynapses        = NULL;
-   fEstimatorHistTrain = NULL;
-   fEstimatorHistTest  = NULL;
+   fNetwork         = nullptr;
+   frgen            = nullptr;
+   fActivation      = nullptr;
+   fOutput          = nullptr; //zjh
+   fIdentity        = nullptr;
+   fInputCalculator = nullptr;
+   fSynapses        = nullptr;
+   fEstimatorHistTrain = nullptr;
+   fEstimatorHistTest  = nullptr;
 
    // reset monitoring histogram vectors
    fEpochMonHistS.clear();
@@ -227,7 +227,7 @@ void TMVA::MethodANNBase::InitANNBase()
    fEpochMonHistW.clear();
 
    // these will be set in BuildNetwork()
-   fInputLayer = NULL;
+   fInputLayer = nullptr;
    fOutputNeurons.clear();
 
    frgen = new TRandom3(fRandomSeed);
@@ -248,7 +248,7 @@ TMVA::MethodANNBase::~MethodANNBase()
 
 void TMVA::MethodANNBase::DeleteNetwork()
 {
-   if (fNetwork != NULL) {
+   if (fNetwork != nullptr) {
       TObjArray *layer;
       Int_t numLayers = fNetwork->GetEntriesFast();
       for (Int_t i = 0; i < numLayers; i++) {
@@ -258,20 +258,20 @@ void TMVA::MethodANNBase::DeleteNetwork()
       delete fNetwork;
    }
 
-   if (frgen != NULL)            delete frgen;
-   if (fActivation != NULL)      delete fActivation;
-   if (fOutput != NULL)          delete fOutput;  //zjh
-   if (fIdentity != NULL)        delete fIdentity;
-   if (fInputCalculator != NULL) delete fInputCalculator;
-   if (fSynapses != NULL)        delete fSynapses;
+   if (frgen != nullptr)            delete frgen;
+   if (fActivation != nullptr)      delete fActivation;
+   if (fOutput != nullptr)          delete fOutput;  //zjh
+   if (fIdentity != nullptr)        delete fIdentity;
+   if (fInputCalculator != nullptr) delete fInputCalculator;
+   if (fSynapses != nullptr)        delete fSynapses;
 
-   fNetwork         = NULL;
-   frgen            = NULL;
-   fActivation      = NULL;
-   fOutput          = NULL; //zjh
-   fIdentity        = NULL;
-   fInputCalculator = NULL;
-   fSynapses        = NULL;
+   fNetwork         = nullptr;
+   frgen            = nullptr;
+   fActivation      = nullptr;
+   fOutput          = nullptr; //zjh
+   fIdentity        = nullptr;
+   fInputCalculator = nullptr;
+   fSynapses        = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -328,7 +328,7 @@ void TMVA::MethodANNBase::BuildNetwork( std::vector<Int_t>* layout, std::vector<
       fOutputNeurons.push_back( (TNeuron*)outputLayer->At(i) );
    }
 
-   if (weights == NULL) InitWeights();
+   if (weights == nullptr) InitWeights();
    else                 ForceWeights(weights);
 }
 
@@ -338,7 +338,7 @@ void TMVA::MethodANNBase::BuildNetwork( std::vector<Int_t>* layout, std::vector<
 void TMVA::MethodANNBase::BuildLayers( std::vector<Int_t>* layout, Bool_t fromFile )
 {
    TObjArray* curLayer;
-   TObjArray* prevLayer = NULL;
+   TObjArray* prevLayer = nullptr;
 
    Int_t numLayers = layout->size();
 
@@ -639,7 +639,7 @@ const std::vector<Float_t> &TMVA::MethodANNBase::GetRegressionValues()
    // check the output of the network
    TObjArray* outputLayer = (TObjArray*)fNetwork->At( fNetwork->GetEntriesFast()-1 );
 
-   if (fRegressionReturnVal == NULL) fRegressionReturnVal = new std::vector<Float_t>();
+   if (fRegressionReturnVal == nullptr) fRegressionReturnVal = new std::vector<Float_t>();
    fRegressionReturnVal->clear();
 
    Event * evT = new Event(*ev);
@@ -677,7 +677,7 @@ const std::vector<Float_t> &TMVA::MethodANNBase::GetMulticlassValues()
 
    // check the output of the network
 
-   if (fMulticlassReturnVal == NULL) fMulticlassReturnVal = new std::vector<Float_t>();
+   if (fMulticlassReturnVal == nullptr) fMulticlassReturnVal = new std::vector<Float_t>();
    fMulticlassReturnVal->clear();
    std::vector<Float_t> temp;
 
@@ -707,16 +707,16 @@ const std::vector<Float_t> &TMVA::MethodANNBase::GetMulticlassValues()
 void TMVA::MethodANNBase::AddWeightsXMLTo( void* parent ) const
 {
    Int_t numLayers = fNetwork->GetEntriesFast();
-   void* wght = gTools().xmlengine().NewChild(parent, 0, "Weights");
-   void* xmlLayout = gTools().xmlengine().NewChild(wght, 0, "Layout");
-   gTools().xmlengine().NewAttr(xmlLayout, 0, "NLayers", gTools().StringFromInt(fNetwork->GetEntriesFast()) );
+   void* wght = gTools().xmlengine().NewChild(parent, nullptr, "Weights");
+   void* xmlLayout = gTools().xmlengine().NewChild(wght, nullptr, "Layout");
+   gTools().xmlengine().NewAttr(xmlLayout, nullptr, "NLayers", gTools().StringFromInt(fNetwork->GetEntriesFast()) );
    TString weights = "";
    for (Int_t i = 0; i < numLayers; i++) {
       TObjArray* layer = (TObjArray*)fNetwork->At(i);
       Int_t numNeurons = layer->GetEntriesFast();
-      void* layerxml = gTools().xmlengine().NewChild(xmlLayout, 0, "Layer");
-      gTools().xmlengine().NewAttr(layerxml, 0, "Index",    gTools().StringFromInt(i) );
-      gTools().xmlengine().NewAttr(layerxml, 0, "NNeurons", gTools().StringFromInt(numNeurons) );
+      void* layerxml = gTools().xmlengine().NewChild(xmlLayout, nullptr, "Layer");
+      gTools().xmlengine().NewAttr(layerxml, nullptr, "Index",    gTools().StringFromInt(i) );
+      gTools().xmlengine().NewAttr(layerxml, nullptr, "NNeurons", gTools().StringFromInt(numNeurons) );
       for (Int_t j = 0; j < numNeurons; j++) {
          TNeuron* neuron = (TNeuron*)layer->At(j);
          Int_t numSynapses = neuron->NumPostLinks();
@@ -735,15 +735,15 @@ void TMVA::MethodANNBase::AddWeightsXMLTo( void* parent ) const
 
    // if inverse hessian exists, write inverse hessian to weight file
    if( fInvHessian.GetNcols()>0 ){
-      void* xmlInvHessian = gTools().xmlengine().NewChild(wght, 0, "InverseHessian");
+      void* xmlInvHessian = gTools().xmlengine().NewChild(wght, nullptr, "InverseHessian");
 
       // get the matrix dimensions
       Int_t nElements = fInvHessian.GetNoElements();
       Int_t nRows     = fInvHessian.GetNrows();
       Int_t nCols     = fInvHessian.GetNcols();
-      gTools().xmlengine().NewAttr(xmlInvHessian, 0, "NElements", gTools().StringFromInt(nElements) );
-      gTools().xmlengine().NewAttr(xmlInvHessian, 0, "NRows", gTools().StringFromInt(nRows) );
-      gTools().xmlengine().NewAttr(xmlInvHessian, 0, "NCols", gTools().StringFromInt(nCols) );
+      gTools().xmlengine().NewAttr(xmlInvHessian, nullptr, "NElements", gTools().StringFromInt(nElements) );
+      gTools().xmlengine().NewAttr(xmlInvHessian, nullptr, "NRows", gTools().StringFromInt(nRows) );
+      gTools().xmlengine().NewAttr(xmlInvHessian, nullptr, "NCols", gTools().StringFromInt(nCols) );
 
       // read in the matrix elements
       Double_t* elements = new Double_t[nElements+10];
@@ -752,8 +752,8 @@ void TMVA::MethodANNBase::AddWeightsXMLTo( void* parent ) const
       // store the matrix elements row-wise
       Int_t index = 0;
       for( Int_t row = 0; row < nRows; ++row ){
-         void* xmlRow = gTools().xmlengine().NewChild(xmlInvHessian, 0, "Row");
-         gTools().xmlengine().NewAttr(xmlRow, 0, "Index", gTools().StringFromInt(row) );
+         void* xmlRow = gTools().xmlengine().NewChild(xmlInvHessian, nullptr, "Row");
+         gTools().xmlengine().NewAttr(xmlRow, nullptr, "Index", gTools().StringFromInt(row) );
 
          // create the rows
          std::stringstream s("");
@@ -778,7 +778,7 @@ void TMVA::MethodANNBase::ReadWeightsFromXML( void* wghtnode )
    Bool_t fromFile = kTRUE;
    std::vector<Int_t>* layout = new std::vector<Int_t>();
 
-   void* xmlLayout = NULL;
+   void* xmlLayout = nullptr;
    xmlLayout = gTools().GetChild(wghtnode, "Layout");
    if( !xmlLayout )
       xmlLayout = wghtnode;
@@ -797,7 +797,7 @@ void TMVA::MethodANNBase::ReadWeightsFromXML( void* wghtnode )
       ch = gTools().GetNextChild(ch);
    }
 
-   BuildNetwork( layout, NULL, fromFile );
+   BuildNetwork( layout, nullptr, fromFile );
    // use 'slow' (exact) TanH if processing old weigh file to ensure 100% compatible results
    // otherwise use the new default, the 'tast tanh' approximation
    if (GetTrainingTMVAVersionCode() < TMVA_VERSION(4,2,1) && fActivation->GetExpression().Contains("tanh")){
@@ -840,7 +840,7 @@ void TMVA::MethodANNBase::ReadWeightsFromXML( void* wghtnode )
 
    delete layout;
 
-   void* xmlInvHessian = NULL;
+   void* xmlInvHessian = nullptr;
    xmlInvHessian = gTools().GetChild(wghtnode, "InverseHessian");
    if( !xmlInvHessian )
       // no inverse hessian available
@@ -1015,7 +1015,7 @@ void TMVA::MethodANNBase::WriteMonitoringHistosToFile() const
    static int epochMonitoringDirectoryNumber = 0;
 #endif
    int epochVal = epochMonitoringDirectoryNumber++;
-   TDirectory* epochdir = NULL;
+   TDirectory* epochdir = nullptr;
    if( epochVal == 0 )
       epochdir = BaseDir()->mkdir( "EpochMonitoring" );
    else

--- a/tmva/tmva/src/MethodBDT.cxx
+++ b/tmva/tmva/src/MethodBDT.cxx
@@ -727,7 +727,7 @@ void TMVA::MethodBDT::Reset( void )
    // disappear and just use the DataSet samples ..
 
    // remove all the trees
-   for (UInt_t i=0; i<fForest.size();           i++) delete fForest[i];
+   for (auto & i : fForest) delete i;
    fForest.clear();
 
    fBoostWeights.clear();
@@ -751,7 +751,7 @@ void TMVA::MethodBDT::Reset( void )
 
 TMVA::MethodBDT::~MethodBDT( void )
 {
-   for (UInt_t i=0; i<fForest.size();           i++) delete fForest[i];
+   for (auto & i : fForest) delete i;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -763,7 +763,7 @@ void TMVA::MethodBDT::InitEventSample( void )
 
    if (fEventSample.size() > 0) { // do not re-initialise the event sample, just set all boostweights to 1. as if it were untouched
       // reset all previously stored/accumulated BOOST weights in the event sample
-      for (UInt_t iev=0; iev<fEventSample.size(); iev++) fEventSample[iev]->SetBoostWeight(1.);
+      for (auto & iev : fEventSample) iev->SetBoostWeight(1.);
    } else {
       Data()->SetCurrentType(Types::kTraining);
       UInt_t nevents = Data()->GetNTrainingEvents();
@@ -778,7 +778,7 @@ void TMVA::MethodBDT::InitEventSample( void )
       if (!DoRegression()) DeterminePreselectionCuts(tmpEventSample);
       else fDoPreselection = kFALSE; // just to make sure...
 
-      for (UInt_t i=0; i<tmpEventSample.size(); i++) delete tmpEventSample[i];
+      for (auto & i : tmpEventSample) delete i;
 
 
       Bool_t firstNegWeight=kTRUE;
@@ -875,12 +875,12 @@ void TMVA::MethodBDT::InitEventSample( void )
       Double_t nevents = fEventSample.size();
       Double_t sumSigW=0, sumBkgW=0;
       Int_t    sumSig=0, sumBkg=0;
-      for (UInt_t ievt=0; ievt<fEventSample.size(); ievt++) {
-         if ((DataInfo().IsSignal(fEventSample[ievt])) ) {
-            sumSigW += fEventSample[ievt]->GetWeight();
+      for (auto & ievt : fEventSample) {
+         if ((DataInfo().IsSignal(ievt)) ) {
+            sumSigW += ievt->GetWeight();
             sumSig++;
          } else {
-            sumBkgW += fEventSample[ievt]->GetWeight();
+            sumBkgW += ievt->GetWeight();
             sumBkg++;
          }
       }
@@ -933,14 +933,14 @@ void TMVA::MethodBDT::PreProcessNegativeEventWeights(){
    Double_t totalPosWeights = 0;
    Double_t totalWeights    = 0;
    std::vector<const Event*> negEvents;
-   for (UInt_t iev = 0; iev < fEventSample.size(); iev++){
-      if (fEventSample[iev]->GetWeight() < 0) {
-         totalNegWeights += fEventSample[iev]->GetWeight();
-         negEvents.push_back(fEventSample[iev]);
+   for (auto & iev : fEventSample){
+      if (iev->GetWeight() < 0) {
+         totalNegWeights += iev->GetWeight();
+         negEvents.push_back(iev);
       } else {
-         totalPosWeights += fEventSample[iev]->GetWeight();
+         totalPosWeights += iev->GetWeight();
       }
-      totalWeights += fEventSample[iev]->GetWeight();
+      totalWeights += iev->GetWeight();
    }
    if (totalNegWeights == 0 ) {
       Log() << kINFO << "no negative event weights found .. no preprocessing necessary" << Endl;
@@ -1030,28 +1030,28 @@ void TMVA::MethodBDT::PreProcessNegativeEventWeights(){
 
    std::vector<const Event*> newEventSample;
 
-   for (UInt_t iev = 0; iev < fEventSample.size(); iev++){
-      if (fEventSample[iev]->GetWeight() < 0) {
-         totalNegWeights += fEventSample[iev]->GetWeight();
-         totalWeights    += fEventSample[iev]->GetWeight();
+   for (auto & iev : fEventSample){
+      if (iev->GetWeight() < 0) {
+         totalNegWeights += iev->GetWeight();
+         totalWeights    += iev->GetWeight();
       } else {
-         totalPosWeights += fEventSample[iev]->GetWeight();
-         totalWeights    += fEventSample[iev]->GetWeight();
+         totalPosWeights += iev->GetWeight();
+         totalWeights    += iev->GetWeight();
       }
-      if (fEventSample[iev]->GetWeight() > 0) {
-         newEventSample.push_back(new Event(*fEventSample[iev]));
-         if (fEventSample[iev]->GetClass() == fSignalClass){
-            sigWeight += fEventSample[iev]->GetWeight();
+      if (iev->GetWeight() > 0) {
+         newEventSample.push_back(new Event(*iev));
+         if (iev->GetClass() == fSignalClass){
+            sigWeight += iev->GetWeight();
             nSig+=1;
          }else{
-            bkgWeight += fEventSample[iev]->GetWeight();
+            bkgWeight += iev->GetWeight();
             nBkg+=1;
          }
       }
    }
    if (totalNegWeights < 0) Log() << kFATAL << " compensation of negative event weights with positive ones did not work " << totalNegWeights << Endl;
 
-   for (UInt_t i=0; i<fEventSample.size();      i++) delete fEventSample[i];
+   for (auto & i : fEventSample) delete i;
    fEventSample = newEventSample;
 
    Log() << kINFO  << " after PreProcessing, the Event sample is left with " << fEventSample.size() << " events (unweighted), all with positive weights, adding up to " << totalWeights << Endl;
@@ -1404,8 +1404,8 @@ void TMVA::MethodBDT::Train()
    // reset all previously stored/accumulated BOOST weights in the event sample
    //   for (UInt_t iev=0; iev<fEventSample.size(); iev++) fEventSample[iev]->SetBoostWeight(1.);
    Log() << kDEBUG << "Now I delete the privat data sample"<< Endl;
-   for (UInt_t i=0; i<fEventSample.size();      i++) delete fEventSample[i];
-   for (UInt_t i=0; i<fValidationSample.size(); i++) delete fValidationSample[i];
+   for (auto & i : fEventSample) delete i;
+   for (auto & i : fValidationSample) delete i;
    fEventSample.clear();
    fValidationSample.clear();
 
@@ -1533,10 +1533,9 @@ Double_t TMVA::MethodBDT::GradBoostRegression(std::vector<const TMVA::Event*>& e
 
    // calculate the constant fit for each terminal node based upon the events in the node
    // node (iLeave->first), vector of event information (iLeave->second)
-   for (std::map<TMVA::DecisionTreeNode*,vector< TMVA::LossFunctionEventInfo > >::iterator iLeave=leaves.begin();
-        iLeave!=leaves.end();++iLeave){
-      Double_t fit = fRegressionLossFunctionBDTG->Fit(iLeave->second);
-      (iLeave->first)->SetResponse(fShrinkage*fit);
+   for (auto & leave : leaves){
+      Double_t fit = fRegressionLossFunctionBDTG->Fit(leave.second);
+      (leave.first)->SetResponse(fShrinkage*fit);
    }
 
    UpdateTargetsRegression(*fTrainSample);
@@ -1587,14 +1586,14 @@ void TMVA::MethodBDT::InitGradBoost( std::vector<const TMVA::Event*>& eventSampl
 Double_t TMVA::MethodBDT::TestTreeQuality( DecisionTree *dt )
 {
    Double_t ncorrect=0, nfalse=0;
-   for (UInt_t ievt=0; ievt<fValidationSample.size(); ievt++) {
-      Bool_t isSignalType= (dt->CheckEvent(fValidationSample[ievt]) > fNodePurityLimit ) ? 1 : 0;
+   for (auto & ievt : fValidationSample) {
+      Bool_t isSignalType= (dt->CheckEvent(ievt) > fNodePurityLimit ) ? 1 : 0;
 
-      if (isSignalType == (DataInfo().IsSignal(fValidationSample[ievt])) ) {
-         ncorrect += fValidationSample[ievt]->GetWeight();
+      if (isSignalType == (DataInfo().IsSignal(ievt)) ) {
+         ncorrect += ievt->GetWeight();
       }
       else{
-         nfalse += fValidationSample[ievt]->GetWeight();
+         nfalse += ievt->GetWeight();
       }
    }
 
@@ -1678,8 +1677,8 @@ void TMVA::MethodBDT::BoostMonitor(Int_t iTree)
    }
 
 
-   for (UInt_t iev=0; iev < fEventSample.size(); iev++){
-      if (fEventSample[iev]->GetBoostWeight() > max) max = 1.01*fEventSample[iev]->GetBoostWeight();
+   for (auto & iev : fEventSample){
+      if (iev->GetBoostWeight() > max) max = 1.01*iev->GetBoostWeight();
    }
    TH1F *tmpBoostWeightsS = new TH1F(Form("BoostWeightsInTreeS%d",iTree),Form("BoostWeightsInTreeS%d",iTree),100,0.,max);
    TH1F *tmpBoostWeightsB = new TH1F(Form("BoostWeightsInTreeB%d",iTree),Form("BoostWeightsInTreeB%d",iTree),100,0.,max);
@@ -1689,17 +1688,17 @@ void TMVA::MethodBDT::BoostMonitor(Int_t iTree)
    TH1F *tmpBoostWeights;
    std::vector<TH1F*> *h;
 
-   for (UInt_t iev=0; iev < fEventSample.size(); iev++){
-      if (fEventSample[iev]->GetClass() == signalClassNr) {
+   for (auto & iev : fEventSample){
+      if (iev->GetClass() == signalClassNr) {
          tmpBoostWeights=tmpBoostWeightsS;
          h=&hS;
       }else{
          tmpBoostWeights=tmpBoostWeightsB;
          h=&hB;
       }
-      tmpBoostWeights->Fill(fEventSample[iev]->GetBoostWeight());
+      tmpBoostWeights->Fill(iev->GetBoostWeight());
       for (UInt_t ivar=0; ivar<GetNvar(); ivar++){
-         (*h)[ivar]->Fill(fEventSample[iev]->GetValue(ivar),fEventSample[iev]->GetWeight());
+         (*h)[ivar]->Fill(iev->GetValue(ivar),iev->GetWeight());
       }
    }
 
@@ -2305,7 +2304,7 @@ void  TMVA::MethodBDT::ReadWeightsFromStream( std::istream& istr )
    istr >> dummy >> fNTrees;
    Log() << kINFO << "Read " << fNTrees << " Decision trees" << Endl;
 
-   for (UInt_t i=0;i<fForest.size();i++) delete fForest[i];
+   for (auto & i : fForest) delete i;
    fForest.clear();
    fBoostWeights.clear();
    Int_t iTree;
@@ -2473,8 +2472,8 @@ const std::vector<Float_t> & TMVA::MethodBDT::GetRegressionValues()
       evT->SetTarget(0, rVal/Double_t(count) );
    }
    else if(fBoostType=="Grad"){
-      for (UInt_t itree=0; itree<fForest.size(); itree++) {
-         myMVA += fForest[itree]->CheckEvent(ev,kFALSE);
+      for (auto & itree : fForest) {
+         myMVA += itree->CheckEvent(ev,kFALSE);
       }
       //      fRegressionReturnVal->push_back( myMVA+fBoostWeights[0]);
       evT->SetTarget(0, myMVA+fBoostWeights[0] );
@@ -2533,11 +2532,11 @@ vector< Double_t > TMVA::MethodBDT::GetVariableImportance()
       }
    }
 
-   for (UInt_t ivar=0; ivar< fVariableImportance.size(); ivar++){
-      fVariableImportance[ivar] = TMath::Sqrt(fVariableImportance[ivar]);
-      sum += fVariableImportance[ivar];
+   for (double & ivar : fVariableImportance){
+      ivar = TMath::Sqrt(ivar);
+      sum += ivar;
    }
-   for (UInt_t ivar=0; ivar< fVariableImportance.size(); ivar++) fVariableImportance[ivar] /= sum;
+   for (double & ivar : fVariableImportance) ivar /= sum;
 
    return fVariableImportance;
 }
@@ -2885,16 +2884,16 @@ void TMVA::MethodBDT::DeterminePreselectionCuts(const std::vector<const TMVA::Ev
 
    // Initialize (un)weighted counters for signal & background
    // Construct a list of event wrappers that point to the original data
-   for( std::vector<const TMVA::Event*>::const_iterator it = eventSample.begin(); it != eventSample.end(); ++it ) {
-      if (DataInfo().IsSignal(*it)){
-         nTotS += (*it)->GetWeight();
+   for(auto it : eventSample) {
+      if (DataInfo().IsSignal(it)){
+         nTotS += it->GetWeight();
          ++nTotS_unWeighted;
       }
       else {
-         nTotB += (*it)->GetWeight();
+         nTotB += it->GetWeight();
          ++nTotB_unWeighted;
       }
-      bdtEventSample.push_back(TMVA::BDTEventWrapper(*it));
+      bdtEventSample.push_back(TMVA::BDTEventWrapper(it));
    }
 
    for( UInt_t ivar = 0; ivar < GetNvar(); ivar++ ) { // loop over all discriminating variables

--- a/tmva/tmva/src/MethodBDT.cxx
+++ b/tmva/tmva/src/MethodBDT.cxx
@@ -683,7 +683,7 @@ void TMVA::MethodBDT::SetMinNodeSize(TString sizeInPercent){
 ////////////////////////////////////////////////////////////////////////////////
 /// Common initialisation with defaults for the BDT-Method.
 
-void TMVA::MethodBDT::Init( void )
+void TMVA::MethodBDT::Init()
 {
    fNTrees         = 800;
    if (fAnalysisType == Types::kClassification || fAnalysisType == Types::kMulticlass ) {
@@ -721,7 +721,7 @@ void TMVA::MethodBDT::Init( void )
 ////////////////////////////////////////////////////////////////////////////////
 /// Reset the method, as if it had just been instantiated (forget all training etc.).
 
-void TMVA::MethodBDT::Reset( void )
+void TMVA::MethodBDT::Reset()
 {
    // I keep the BDT EventSample and its Validation sample (eventually they should all
    // disappear and just use the DataSet samples ..
@@ -749,7 +749,7 @@ void TMVA::MethodBDT::Reset( void )
 ///  - Note: fEventSample and ValidationSample are already deleted at the end of TRAIN
 ///         When they are not used anymore
 
-TMVA::MethodBDT::~MethodBDT( void )
+TMVA::MethodBDT::~MethodBDT()
 {
    for (auto & i : fForest) delete i;
 }
@@ -757,7 +757,7 @@ TMVA::MethodBDT::~MethodBDT( void )
 ////////////////////////////////////////////////////////////////////////////////
 /// Initialize the event sample (i.e. reset the boost-weights... etc).
 
-void TMVA::MethodBDT::InitEventSample( void )
+void TMVA::MethodBDT::InitEventSample()
 {
    if (!HasTrainingTree()) Log() << kFATAL << "<Init> Data().TrainingTree() is zero pointer" << Endl;
 
@@ -2503,7 +2503,7 @@ const std::vector<Float_t> & TMVA::MethodBDT::GetRegressionValues()
 /// Here we could write some histograms created during the processing
 /// to the output file.
 
-void  TMVA::MethodBDT::WriteMonitoringHistosToFile( void ) const
+void  TMVA::MethodBDT::WriteMonitoringHistosToFile() const
 {
    Log() << kDEBUG << "\tWrite monitoring histograms to file: " << BaseDir()->GetPath() << Endl;
 

--- a/tmva/tmva/src/MethodBDT.cxx
+++ b/tmva/tmva/src/MethodBDT.cxx
@@ -166,7 +166,7 @@ TMVA::MethodBDT::MethodBDT( const TString& jobName,
                             DataSetInfo& theData,
                             const TString& theOption ) :
    TMVA::MethodBase( jobName, Types::kBDT, methodTitle, theData, theOption)
-   , fTrainSample(0)
+   , fTrainSample(nullptr)
    , fNTrees(0)
    , fSigToBkgFraction(0)
    , fAdaBoostBeta(0)
@@ -211,8 +211,8 @@ TMVA::MethodBDT::MethodBDT( const TString& jobName,
    , fSkipNormalization(kFALSE)
    , fHistoricBool(kFALSE)
 {
-   fMonitorNtuple = NULL;
-   fSepType = NULL;
+   fMonitorNtuple = nullptr;
+   fSepType = nullptr;
    fRegressionLossFunctionBDTG = nullptr;
 }
 
@@ -221,7 +221,7 @@ TMVA::MethodBDT::MethodBDT( const TString& jobName,
 TMVA::MethodBDT::MethodBDT( DataSetInfo& theData,
                             const TString& theWeightFile)
    : TMVA::MethodBase( Types::kBDT, theData, theWeightFile)
-   , fTrainSample(0)
+   , fTrainSample(nullptr)
    , fNTrees(0)
    , fSigToBkgFraction(0)
    , fAdaBoostBeta(0)
@@ -266,8 +266,8 @@ TMVA::MethodBDT::MethodBDT( DataSetInfo& theData,
    , fSkipNormalization(kFALSE)
    , fHistoricBool(kFALSE)
 {
-   fMonitorNtuple = NULL;
-   fSepType = NULL;
+   fMonitorNtuple = nullptr;
+   fSepType = nullptr;
    fRegressionLossFunctionBDTG = nullptr;
    // constructor for calculating BDT-MVA using previously generated decision trees
    // the result of the previous training (the decision trees) are read in via the
@@ -476,7 +476,7 @@ void TMVA::MethodBDT::ProcessOptions()
    else if (fSepTypeS == "giniindexwithlaplace")   fSepType = new GiniIndexWithLaplace();
    else if (fSepTypeS == "crossentropy")           fSepType = new CrossEntropy();
    else if (fSepTypeS == "sdivsqrtsplusb")         fSepType = new SdivSqrtSplusB();
-   else if (fSepTypeS == "regressionvariance")     fSepType = NULL;
+   else if (fSepTypeS == "regressionvariance")     fSepType = nullptr;
    else {
       Log() << kINFO << GetOptions() << Endl;
       Log() << kFATAL << "<ProcessOptions> unknown Separation Index option " << fSepTypeS << " called" << Endl;
@@ -576,9 +576,9 @@ void TMVA::MethodBDT::ProcessOptions()
          fUseYesNoLeaf = kFALSE;
       }
 
-      if (fSepType != NULL){
+      if (fSepType != nullptr){
          Log() << kWARNING << "Regression Trees do not work with Separation type other than <RegressionVariance> --> I will use it instead" << Endl;
-         fSepType = NULL;
+         fSepType = nullptr;
       }
       if (fUseFisherCuts){
          Log() << kWARNING << "Sorry, UseFisherCuts is not available for regression analysis, I will ignore it!" << Endl;
@@ -731,7 +731,7 @@ void TMVA::MethodBDT::Reset( void )
    fForest.clear();
 
    fBoostWeights.clear();
-   if (fMonitorNtuple) { fMonitorNtuple->Delete(); fMonitorNtuple=NULL; }
+   if (fMonitorNtuple) { fMonitorNtuple->Delete(); fMonitorNtuple=nullptr; }
    fVariableImportance.clear();
    fResiduals.clear();
    fLossFunctionEventInfo.clear();
@@ -1338,7 +1338,7 @@ void TMVA::MethodBDT::Train()
          fForest.back()->SetPruneMethod(fPruneMethod); // set the pruning method for the tree
          fForest.back()->SetPruneStrength(fPruneStrength); // set the strength parameter
 
-         std::vector<const Event*> * validationSample = NULL;
+         std::vector<const Event*> * validationSample = nullptr;
          if(fAutomatic) validationSample = &fValidationSample;
 
          Double_t bw = this->Boost(*fTrainSample, fForest.back());
@@ -1551,7 +1551,7 @@ void TMVA::MethodBDT::InitGradBoost( std::vector<const TMVA::Event*>& eventSampl
    // Should get rid of this line. It's just for debugging.
    //std::sort(eventSample.begin(), eventSample.end(), [](const TMVA::Event* a, const TMVA::Event* b){
    //                                     return (a->GetTarget(0) < b->GetTarget(0)); });
-   fSepType=NULL; //set fSepType to NULL (regression trees are used for both classification an regression)
+   fSepType=nullptr; //set fSepType to NULL (regression trees are used for both classification an regression)
    if(DoRegression()){
       for (std::vector<const TMVA::Event*>::const_iterator e=eventSample.begin(); e!=eventSample.end();++e) {
          fLossFunctionEventInfo[*e]= TMVA::LossFunctionEventInfo((*e)->GetTarget(0), 0, (*e)->GetWeight());
@@ -2385,7 +2385,7 @@ Double_t TMVA::MethodBDT::PrivateGetMvaValue(const TMVA::Event* ev, Double_t* er
 const std::vector<Float_t>& TMVA::MethodBDT::GetMulticlassValues()
 {
    const TMVA::Event *e = GetEvent();
-   if (fMulticlassReturnVal == NULL) fMulticlassReturnVal = new std::vector<Float_t>();
+   if (fMulticlassReturnVal == nullptr) fMulticlassReturnVal = new std::vector<Float_t>();
    fMulticlassReturnVal->clear();
 
    UInt_t nClasses = DataInfo().GetNClasses();
@@ -2421,7 +2421,7 @@ const std::vector<Float_t>& TMVA::MethodBDT::GetMulticlassValues()
 const std::vector<Float_t> & TMVA::MethodBDT::GetRegressionValues()
 {
 
-   if (fRegressionReturnVal == NULL) fRegressionReturnVal = new std::vector<Float_t>();
+   if (fRegressionReturnVal == nullptr) fRegressionReturnVal = new std::vector<Float_t>();
    fRegressionReturnVal->clear();
 
    const Event * ev = GetEvent();
@@ -2822,19 +2822,19 @@ void TMVA::MethodBDT::MakeClassSpecificHeader(  std::ostream& fout, const TStrin
 
 void TMVA::MethodBDT::MakeClassInstantiateNode( DecisionTreeNode *n, std::ostream& fout, const TString& className ) const
 {
-   if (n == NULL) {
+   if (n == nullptr) {
       Log() << kFATAL << "MakeClassInstantiateNode: started with undefined node" <<Endl;
       return ;
    }
    fout << "NN("<<std::endl;
-   if (n->GetLeft() != NULL){
+   if (n->GetLeft() != nullptr){
       this->MakeClassInstantiateNode( (DecisionTreeNode*)n->GetLeft() , fout, className);
    }
    else {
       fout << "0";
    }
    fout << ", " <<std::endl;
-   if (n->GetRight() != NULL){
+   if (n->GetRight() != nullptr){
       this->MakeClassInstantiateNode( (DecisionTreeNode*)n->GetRight(), fout, className );
    }
    else {

--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -366,7 +366,7 @@ TMVA::MethodBase::MethodBase( Types::EMVA methodType,
 ////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
-TMVA::MethodBase::~MethodBase( void )
+TMVA::MethodBase::~MethodBase()
 {
    // destructor
    if (!fSetupCompleted) Log() << kFATAL <<Form("Dataset[%s] : ",DataInfo().GetName())<< "Calling destructor of method which got never setup" << Endl;
@@ -2085,7 +2085,7 @@ void TMVA::MethodBase::WriteEvaluationHistosToFile(Types::ETreeType treetype)
 /// write special monitoring histograms to file
 /// dummy implementation here -----------------
 
-void  TMVA::MethodBase::WriteMonitoringHistosToFile( void ) const
+void  TMVA::MethodBase::WriteMonitoringHistosToFile() const
 {
 }
 
@@ -2728,7 +2728,7 @@ TMatrixD TMVA::MethodBase::GetMulticlassConfusionMatrix(Double_t effB, Types::ET
 /// significance = \frac{|<S> - <B>|}{\sqrt{RMS_{S2} + RMS_{B2}}}
 /// \f]
 
-Double_t TMVA::MethodBase::GetSignificance( void ) const
+Double_t TMVA::MethodBase::GetSignificance() const
 {
    Double_t rms = sqrt( fRmsS*fRmsS + fRmsB*fRmsB );
 

--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -899,9 +899,10 @@ std::vector<Double_t> TMVA::MethodBase::GetMvaValues(Long64_t firstEvt, Long64_t
    Timer timer( nEvents, GetName(), kTRUE );
 
    if (logProgress)
-   Log() << kHEADER<<Form("[%s] : ",DataInfo().GetName())<< "Evaluation of " << GetMethodName() << " on "
-        << (Data()->GetCurrentType()==Types::kTraining?"training":"testing") << " sample (" << nEvents << " events)" << Endl;
-
+      Log() << kHEADER << Form("[%s] : ",DataInfo().GetName())
+            << "Evaluation of " << GetMethodName() << " on "
+            << (Data()->GetCurrentType() == Types::kTraining ? "training" : "testing")
+            << " sample (" << nEvents << " events)" << Endl;
 
    for (Int_t ievt=firstEvt; ievt<lastEvt; ievt++) {
       Data()->SetCurrentEvent(ievt);

--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -985,6 +985,8 @@ void TMVA::MethodBase::TestRegression( Double_t& bias, Double_t& biasT,
    Float_t* tV = new Float_t[nevt];
    Float_t* wV = new Float_t[nevt];
    Float_t  xmin = 1e30, xmax = -1e30;
+   Log() << kINFO << "Calculate regression for all events" << Endl;
+   Timer timer( nevt, GetName(), kTRUE );
    for (Long64_t ievt=0; ievt<nevt; ievt++) {
 
       const Event* ev = Data()->GetEvent(ievt); // NOTE: need untransformed event here !
@@ -1012,7 +1014,11 @@ void TMVA::MethodBase::TestRegression( Double_t& bias, Double_t& biasT,
       m1  += t*w; s1 += t*t*w;
       m2  += r*w; s2 += r*r*w;
       s12 += t*r;
+      if ((ievt & 0xFF) == 0) timer.DrawProgressBar(ievt);
    }
+   timer.DrawProgressBar(nevt - 1);
+   Log() << kINFO << "Elapsed time for evaluation of " << nevt <<  " events: "
+         << timer.GetElapsedTime() << "       " << Endl;
 
    // standard quantities
    bias /= sumw;

--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -392,9 +392,8 @@ TMVA::MethodBase::~MethodBase( void )
 
    for (Int_t i = 0; i < 2; i++ ) {
       if (fEventCollections.at(i)) {
-         for (std::vector<Event*>::const_iterator it = fEventCollections.at(i)->begin();
-              it != fEventCollections.at(i)->end(); ++it) {
-            delete (*it);
+         for (auto it : *fEventCollections.at(i)) {
+            delete it;
          }
          delete fEventCollections.at(i);
          fEventCollections.at(i) = nullptr;
@@ -1764,9 +1763,7 @@ void TMVA::MethodBase::AddSpectatorsXMLTo( void* parent ) const
    void* specs = gTools().AddChild(parent, "Spectators");
 
    UInt_t writeIdx=0;
-   for (UInt_t idx=0; idx<DataInfo().GetSpectatorInfos().size(); idx++) {
-
-      VariableInfo& vi = DataInfo().GetSpectatorInfos()[idx];
+   for (auto & vi : DataInfo().GetSpectatorInfos()) {
 
       // we do not want to write spectators that are category-cuts,
       // except if the method is the category method and the spectators belong to it

--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -246,12 +246,12 @@ TMVA::MethodBase::MethodBase( const TString& jobName,
                               const TString& theOption) :
    IMethod(),
    Configurable               ( theOption ),
-   fTmpEvent                  ( 0 ),
-   fRanking                   ( 0 ),
-   fInputVars                 ( 0 ),
+   fTmpEvent                  ( nullptr ),
+   fRanking                   ( nullptr ),
+   fInputVars                 ( nullptr ),
    fAnalysisType              ( Types::kNoAnalysisType ),
-   fRegressionReturnVal       ( 0 ),
-   fMulticlassReturnVal       ( 0 ),
+   fRegressionReturnVal       ( nullptr ),
+   fMulticlassReturnVal       ( nullptr ),
    fDataSetInfo               ( dsi ),
    fSignalReferenceCut        ( 0.5 ),
    fSignalReferenceCutOrientation( 1. ),
@@ -263,24 +263,24 @@ TMVA::MethodBase::MethodBase( const TString& jobName,
    fTMVATrainingVersion       ( TMVA_VERSION_CODE ),
    fROOTTrainingVersion       ( ROOT_VERSION_CODE ),
    fConstructedFromWeightFile ( kFALSE ),
-   fBaseDir                   ( 0 ),
-   fMethodBaseDir             ( 0 ),
-   fFile                      ( 0 ),
+   fBaseDir                   ( nullptr ),
+   fMethodBaseDir             ( nullptr ),
+   fFile                      ( nullptr ),
    fSilentFile                (kFALSE),
    fModelPersistence          (kTRUE),
    fWeightFile                ( "" ),
-   fEffS                      ( 0 ),
-   fDefaultPDF                ( 0 ),
-   fMVAPdfS                   ( 0 ),
-   fMVAPdfB                   ( 0 ),
-   fSplS                      ( 0 ),
-   fSplB                      ( 0 ),
-   fSpleffBvsS                ( 0 ),
-   fSplTrainS                 ( 0 ),
-   fSplTrainB                 ( 0 ),
-   fSplTrainEffBvsS           ( 0 ),
+   fEffS                      ( nullptr ),
+   fDefaultPDF                ( nullptr ),
+   fMVAPdfS                   ( nullptr ),
+   fMVAPdfB                   ( nullptr ),
+   fSplS                      ( nullptr ),
+   fSplB                      ( nullptr ),
+   fSpleffBvsS                ( nullptr ),
+   fSplTrainS                 ( nullptr ),
+   fSplTrainB                 ( nullptr ),
+   fSplTrainEffBvsS           ( nullptr ),
    fVarTransformString        ( "None" ),
-   fTransformationPointer     ( 0 ),
+   fTransformationPointer     ( nullptr ),
    fTransformation            ( dsi, methodTitle ),
    fVerbose                   ( kFALSE ),
    fVerbosityLevelString      ( "Default" ),
@@ -289,10 +289,10 @@ TMVA::MethodBase::MethodBase( const TString& jobName,
    fIgnoreNegWeightsInTraining( kFALSE ),
    fSignalClass               ( 0 ),
    fBackgroundClass           ( 0 ),
-   fSplRefS                   ( 0 ),
-   fSplRefB                   ( 0 ),
-   fSplTrainRefS              ( 0 ),
-   fSplTrainRefB              ( 0 ),
+   fSplRefS                   ( nullptr ),
+   fSplRefB                   ( nullptr ),
+   fSplTrainRefS              ( nullptr ),
+   fSplTrainRefB              ( nullptr ),
    fSetupCompleted            (kFALSE)
 {
    SetTestvarName();
@@ -310,12 +310,12 @@ TMVA::MethodBase::MethodBase( Types::EMVA methodType,
                               const TString& weightFile ) :
    IMethod(),
    Configurable(""),
-   fTmpEvent                  ( 0 ),
-   fRanking                   ( 0 ),
-   fInputVars                 ( 0 ),
+   fTmpEvent                  ( nullptr ),
+   fRanking                   ( nullptr ),
+   fInputVars                 ( nullptr ),
    fAnalysisType              ( Types::kNoAnalysisType ),
-   fRegressionReturnVal       ( 0 ),
-   fMulticlassReturnVal       ( 0 ),
+   fRegressionReturnVal       ( nullptr ),
+   fMulticlassReturnVal       ( nullptr ),
    fDataSetInfo               ( dsi ),
    fSignalReferenceCut        ( 0.5 ),
    fVariableTransformType     ( Types::kSignal ),
@@ -326,24 +326,24 @@ TMVA::MethodBase::MethodBase( Types::EMVA methodType,
    fTMVATrainingVersion       ( 0 ),
    fROOTTrainingVersion       ( 0 ),
    fConstructedFromWeightFile ( kTRUE ),
-   fBaseDir                   ( 0 ),
-   fMethodBaseDir             ( 0 ),
-   fFile                      ( 0 ),
+   fBaseDir                   ( nullptr ),
+   fMethodBaseDir             ( nullptr ),
+   fFile                      ( nullptr ),
    fSilentFile                (kFALSE),
    fModelPersistence          (kTRUE),
    fWeightFile                ( weightFile ),
-   fEffS                      ( 0 ),
-   fDefaultPDF                ( 0 ),
-   fMVAPdfS                   ( 0 ),
-   fMVAPdfB                   ( 0 ),
-   fSplS                      ( 0 ),
-   fSplB                      ( 0 ),
-   fSpleffBvsS                ( 0 ),
-   fSplTrainS                 ( 0 ),
-   fSplTrainB                 ( 0 ),
-   fSplTrainEffBvsS           ( 0 ),
+   fEffS                      ( nullptr ),
+   fDefaultPDF                ( nullptr ),
+   fMVAPdfS                   ( nullptr ),
+   fMVAPdfB                   ( nullptr ),
+   fSplS                      ( nullptr ),
+   fSplB                      ( nullptr ),
+   fSpleffBvsS                ( nullptr ),
+   fSplTrainS                 ( nullptr ),
+   fSplTrainB                 ( nullptr ),
+   fSplTrainEffBvsS           ( nullptr ),
    fVarTransformString        ( "None" ),
-   fTransformationPointer     ( 0 ),
+   fTransformationPointer     ( nullptr ),
    fTransformation            ( dsi, "" ),
    fVerbose                   ( kFALSE ),
    fVerbosityLevelString      ( "Default" ),
@@ -352,10 +352,10 @@ TMVA::MethodBase::MethodBase( Types::EMVA methodType,
    fIgnoreNegWeightsInTraining( kFALSE ),
    fSignalClass               ( 0 ),
    fBackgroundClass           ( 0 ),
-   fSplRefS                   ( 0 ),
-   fSplRefB                   ( 0 ),
-   fSplTrainRefS              ( 0 ),
-   fSplTrainRefB              ( 0 ),
+   fSplRefS                   ( nullptr ),
+   fSplRefB                   ( nullptr ),
+   fSplTrainRefS              ( nullptr ),
+   fSplTrainRefB              ( nullptr ),
    fSetupCompleted            (kFALSE)
 {
    fLogger->SetSource(GetName());
@@ -372,23 +372,23 @@ TMVA::MethodBase::~MethodBase( void )
    if (!fSetupCompleted) Log() << kFATAL <<Form("Dataset[%s] : ",DataInfo().GetName())<< "Calling destructor of method which got never setup" << Endl;
 
    // destructor
-   if (fInputVars != 0)  { fInputVars->clear(); delete fInputVars; }
-   if (fRanking   != 0)  delete fRanking;
+   if (fInputVars != nullptr)  { fInputVars->clear(); delete fInputVars; }
+   if (fRanking   != nullptr)  delete fRanking;
 
    // PDFs
-   if (fDefaultPDF!= 0)  { delete fDefaultPDF; fDefaultPDF = 0; }
-   if (fMVAPdfS   != 0)  { delete fMVAPdfS; fMVAPdfS = 0; }
-   if (fMVAPdfB   != 0)  { delete fMVAPdfB; fMVAPdfB = 0; }
+   if (fDefaultPDF!= nullptr)  { delete fDefaultPDF; fDefaultPDF = nullptr; }
+   if (fMVAPdfS   != nullptr)  { delete fMVAPdfS; fMVAPdfS = nullptr; }
+   if (fMVAPdfB   != nullptr)  { delete fMVAPdfB; fMVAPdfB = nullptr; }
 
    // Splines
-   if (fSplS)            { delete fSplS; fSplS = 0; }
-   if (fSplB)            { delete fSplB; fSplB = 0; }
-   if (fSpleffBvsS)      { delete fSpleffBvsS; fSpleffBvsS = 0; }
-   if (fSplRefS)         { delete fSplRefS; fSplRefS = 0; }
-   if (fSplRefB)         { delete fSplRefB; fSplRefB = 0; }
-   if (fSplTrainRefS)    { delete fSplTrainRefS; fSplTrainRefS = 0; }
-   if (fSplTrainRefB)    { delete fSplTrainRefB; fSplTrainRefB = 0; }
-   if (fSplTrainEffBvsS) { delete fSplTrainEffBvsS; fSplTrainEffBvsS = 0; }
+   if (fSplS)            { delete fSplS; fSplS = nullptr; }
+   if (fSplB)            { delete fSplB; fSplB = nullptr; }
+   if (fSpleffBvsS)      { delete fSpleffBvsS; fSpleffBvsS = nullptr; }
+   if (fSplRefS)         { delete fSplRefS; fSplRefS = nullptr; }
+   if (fSplRefB)         { delete fSplRefB; fSplRefB = nullptr; }
+   if (fSplTrainRefS)    { delete fSplTrainRefS; fSplTrainRefS = nullptr; }
+   if (fSplTrainRefB)    { delete fSplTrainRefB; fSplTrainRefB = nullptr; }
+   if (fSplTrainEffBvsS) { delete fSplTrainEffBvsS; fSplTrainEffBvsS = nullptr; }
 
    for (Int_t i = 0; i < 2; i++ ) {
       if (fEventCollections.at(i)) {
@@ -397,7 +397,7 @@ TMVA::MethodBase::~MethodBase( void )
             delete (*it);
          }
          delete fEventCollections.at(i);
-         fEventCollections.at(i) = 0;
+         fEventCollections.at(i) = nullptr;
       }
    }
 
@@ -451,9 +451,9 @@ void TMVA::MethodBase::InitBase()
    fNbinsMVAoutput     = gConfig().fVariablePlotting.fNbinsMVAoutput;
    fNbinsH             = NBIN_HIST_HIGH;
 
-   fSplTrainS          = 0;
-   fSplTrainB          = 0;
-   fSplTrainEffBvsS    = 0;
+   fSplTrainS          = nullptr;
+   fSplTrainB          = nullptr;
+   fSplTrainEffBvsS    = nullptr;
    fMeanS              = -1;
    fMeanB              = -1;
    fRmsS               = -1;
@@ -461,31 +461,31 @@ void TMVA::MethodBase::InitBase()
    fXmin               = DBL_MAX;
    fXmax               = -DBL_MAX;
    fTxtWeightsOnly     = kTRUE;
-   fSplRefS            = 0;
-   fSplRefB            = 0;
+   fSplRefS            = nullptr;
+   fSplRefB            = nullptr;
 
    fTrainTime          = -1.;
    fTestTime           = -1.;
 
-   fRanking            = 0;
+   fRanking            = nullptr;
 
    // temporary until the move to DataSet is complete
    fInputVars = new std::vector<TString>;
    for (UInt_t ivar=0; ivar<GetNvar(); ivar++) {
       fInputVars->push_back(DataInfo().GetVariableInfo(ivar).GetLabel());
    }
-   fRegressionReturnVal = 0;
-   fMulticlassReturnVal = 0;
+   fRegressionReturnVal = nullptr;
+   fMulticlassReturnVal = nullptr;
 
    fEventCollections.resize( 2 );
-   fEventCollections.at(0) = 0;
-   fEventCollections.at(1) = 0;
+   fEventCollections.at(0) = nullptr;
+   fEventCollections.at(1) = nullptr;
 
    // retrieve signal and background class index
-   if (DataInfo().GetClassInfo("Signal") != 0) {
+   if (DataInfo().GetClassInfo("Signal") != nullptr) {
       fSignalClass = DataInfo().GetClassInfo("Signal")->GetNumber();
    }
-   if (DataInfo().GetClassInfo("Background") != 0) {
+   if (DataInfo().GetClassInfo("Background") != nullptr) {
       fBackgroundClass = DataInfo().GetClassInfo("Background")->GetNumber();
    }
 
@@ -571,9 +571,9 @@ void TMVA::MethodBase::ProcessBaseOptions()
                                                Log() );
 
    if (!HasMVAPdfs()) {
-      if (fDefaultPDF!= 0) { delete fDefaultPDF; fDefaultPDF = 0; }
-      if (fMVAPdfS   != 0) { delete fMVAPdfS; fMVAPdfS = 0; }
-      if (fMVAPdfB   != 0) { delete fMVAPdfB; fMVAPdfB = 0; }
+      if (fDefaultPDF!= nullptr) { delete fDefaultPDF; fDefaultPDF = nullptr; }
+      if (fMVAPdfS   != nullptr) { delete fMVAPdfS; fMVAPdfS = nullptr; }
+      if (fMVAPdfB   != nullptr) { delete fMVAPdfB; fMVAPdfB = nullptr; }
    }
 
    if (fVerbose) { // overwrites other settings
@@ -837,7 +837,7 @@ void TMVA::MethodBase::NoErrorCalc(Double_t* const err, Double_t* const errUpper
 Double_t TMVA::MethodBase::GetMvaValue( const Event* const ev, Double_t* err, Double_t* errUpper ) {
    fTmpEvent = ev;
    Double_t val = GetMvaValue(err, errUpper);
-   fTmpEvent = 0;
+   fTmpEvent = nullptr;
    return val;
 }
 
@@ -1110,7 +1110,7 @@ void TMVA::MethodBase::TestClassification()
       ( Data()->GetResults(GetMethodName(),Types::kTesting, Types::kClassification) );
 
    // sanity checks: tree must exist, and theVar must be in tree
-   if (0==mvaRes && !(GetMethodTypeName().Contains("Cuts"))) {
+   if (nullptr==mvaRes && !(GetMethodTypeName().Contains("Cuts"))) {
       Log()<<Form("Dataset[%s] : ",DataInfo().GetName()) << "mvaRes " << mvaRes << " GetMethodTypeName " << GetMethodTypeName()
            << " contains " << !(GetMethodTypeName().Contains("Cuts")) << Endl;
       Log() << kFATAL<<Form("Dataset[%s] : ",DataInfo().GetName()) << "<TestInit> Test variable " << GetTestvarName()
@@ -1151,10 +1151,10 @@ void TMVA::MethodBase::TestClassification()
    mva_s->Sumw2();
    mva_b->Sumw2();
 
-   TH1* proba_s = 0;
-   TH1* proba_b = 0;
-   TH1* rarity_s = 0;
-   TH1* rarity_b = 0;
+   TH1* proba_s = nullptr;
+   TH1* proba_b = nullptr;
+   TH1* rarity_s = nullptr;
+   TH1* rarity_b = nullptr;
    if (HasMVAPdfs()) {
       // P(MVA) plots used for graphics representation
       proba_s = new TH1D( TestvarName + "_Proba_S", TestvarName + "_Proba_S", fNbinsMVAoutput, 0.0, 1.0 );
@@ -1234,8 +1234,8 @@ void TMVA::MethodBase::TestClassification()
    gTools().NormHist( mva_eff_b  );
 
    // create PDFs from histograms, using default splines, and no additional smoothing
-   if (fSplS) { delete fSplS; fSplS = 0; }
-   if (fSplB) { delete fSplB; fSplB = 0; }
+   if (fSplS) { delete fSplS; fSplS = nullptr; }
+   if (fSplB) { delete fSplB; fSplB = nullptr; }
    fSplS = new PDF( TString(GetName()) + " PDF Sig", mva_s, PDF::kSpline2 );
    fSplB = new PDF( TString(GetName()) + " PDF Bkg", mva_b, PDF::kSpline2 );
 }
@@ -1392,7 +1392,7 @@ void TMVA::MethodBase::WriteStateToFile() const
     << "Creating xml weight file: "
          << gTools().Color("lightblue") << xmlfname << gTools().Color("reset") << Endl;
    void* doc      = gTools().xmlengine().NewDoc();
-   void* rootnode = gTools().AddChild(0,"MethodSetup", "", true);
+   void* rootnode = gTools().AddChild(nullptr,"MethodSetup", "", true);
    gTools().xmlengine().DocSetRootElement(doc,rootnode);
    gTools().AddAttr(rootnode,"Method", GetMethodTypeName() + "::" + GetMethodName());
    WriteStateToXML(rootnode);
@@ -1479,7 +1479,7 @@ void TMVA::MethodBase::ReadStateFromXML( void* methodNode )
 
    TString nodeName("");
    void* ch = gTools().GetChild(methodNode);
-   while (ch!=0) {
+   while (ch!=nullptr) {
       nodeName = TString( gTools().GetName(ch) );
 
       if (nodeName=="GeneralInfo") {
@@ -1541,8 +1541,8 @@ void TMVA::MethodBase::ReadStateFromXML( void* methodNode )
       }
       else if (nodeName=="MVAPdfs") {
          TString pdfname;
-         if (fMVAPdfS) { delete fMVAPdfS; fMVAPdfS=0; }
-         if (fMVAPdfB) { delete fMVAPdfB; fMVAPdfB=0; }
+         if (fMVAPdfS) { delete fMVAPdfS; fMVAPdfS=nullptr; }
+         if (fMVAPdfB) { delete fMVAPdfB; fMVAPdfB=nullptr; }
          void* pdfnode = gTools().GetChild(ch);
          if (pdfnode) {
             gTools().ReadAttr(pdfnode, "Name", pdfname);
@@ -1627,7 +1627,7 @@ void TMVA::MethodBase::ReadStateFromStream( std::istream& fin )
          GetTransformationHandler().AddTransformation( new VariableNormalizeTransform(DataInfo()), -1 );
       norm->BuildTransformationFromVarInfo( DataInfo().GetVariableInfos() );
    }
-   VariableTransformBase *varTrafo(0), *varTrafo2(0);
+   VariableTransformBase *varTrafo(nullptr), *varTrafo2(nullptr);
    if ( fVarTransformString == "None") {
       if (fUseDecorr)
          varTrafo = GetTransformationHandler().AddTransformation( new VariableDecorrTransform(DataInfo()), -1 );
@@ -1665,8 +1665,8 @@ void TMVA::MethodBase::ReadStateFromStream( std::istream& fin )
       // Now read the MVA PDFs
       fin.getline(buf,512);
       while (!TString(buf).BeginsWith("#MVAPDFS")) fin.getline(buf,512);
-      if (fMVAPdfS != 0) { delete fMVAPdfS; fMVAPdfS = 0; }
-      if (fMVAPdfB != 0) { delete fMVAPdfB; fMVAPdfB = 0; }
+      if (fMVAPdfS != nullptr) { delete fMVAPdfS; fMVAPdfS = nullptr; }
+      if (fMVAPdfB != nullptr) { delete fMVAPdfB; fMVAPdfB = nullptr; }
       fMVAPdfS = new PDF(TString(GetName()) + " MVA PDF Sig");
       fMVAPdfB = new PDF(TString(GetName()) + " MVA PDF Bkg");
       fMVAPdfS->SetReadingVersion( GetTrainingTMVAVersionCode() );
@@ -1925,12 +1925,12 @@ void TMVA::MethodBase::ReadClassesFromXML( void* clsnode )
    }
 
    // retrieve signal and background class index
-   if (DataInfo().GetClassInfo("Signal") != 0) {
+   if (DataInfo().GetClassInfo("Signal") != nullptr) {
       fSignalClass = DataInfo().GetClassInfo("Signal")->GetNumber();
    }
    else
       fSignalClass=0;
-   if (DataInfo().GetClassInfo("Background") != 0) {
+   if (DataInfo().GetClassInfo("Background") != nullptr) {
       fBackgroundClass = DataInfo().GetClassInfo("Background")->GetNumber();
    }
    else
@@ -1963,11 +1963,11 @@ void TMVA::MethodBase::ReadTargetsFromXML( void* tarnode )
 
 TDirectory* TMVA::MethodBase::BaseDir() const
 {
-   if (fBaseDir != 0) return fBaseDir;
+   if (fBaseDir != nullptr) return fBaseDir;
    Log()<<kDEBUG<<Form("Dataset[%s] : ",DataInfo().GetName())<<" Base Directory for " << GetMethodName() << " not set yet --> check if already there.." <<Endl;
 
    TDirectory* methodDir = MethodBaseDir();
-   if (methodDir==0)
+   if (methodDir==nullptr)
       Log() << kFATAL <<Form("Dataset[%s] : ",DataInfo().GetName())<< "MethodBase::BaseDir() - MethodBaseDir() return a NULL pointer!" << Endl;
 
    TString defaultDir = GetMethodName();
@@ -1994,7 +1994,7 @@ TDirectory* TMVA::MethodBase::BaseDir() const
 
  TDirectory* TMVA::MethodBase::MethodBaseDir() const
  {
-    if (fMethodBaseDir != 0) return fMethodBaseDir;
+    if (fMethodBaseDir != nullptr) return fMethodBaseDir;
 
     Log()<<kDEBUG<<Form("Dataset[%s] : ",DataInfo().GetName())<<" Base Directory for " << GetMethodTypeName() << " not set yet --> check if already there.." <<Endl;
 
@@ -2061,12 +2061,12 @@ void TMVA::MethodBase::WriteEvaluationHistosToFile(Types::ETreeType treetype)
 
 
    // write MVA PDFs to file - if exist
-   if (0 != fMVAPdfS) {
+   if (nullptr != fMVAPdfS) {
       fMVAPdfS->GetOriginalHist()->Write();
       fMVAPdfS->GetSmoothedHist()->Write();
       fMVAPdfS->GetPDFHist()->Write();
    }
-   if (0 != fMVAPdfB) {
+   if (nullptr != fMVAPdfB) {
       fMVAPdfB->GetOriginalHist()->Write();
       fMVAPdfB->GetSmoothedHist()->Write();
       fMVAPdfB->GetPDFHist()->Write();
@@ -2149,7 +2149,7 @@ void TMVA::MethodBase::CreateMVAPdfs()
    ResultsClassification * mvaRes = dynamic_cast<ResultsClassification*>
       ( Data()->GetResults(GetMethodName(), Types::kTraining, Types::kClassification) );
 
-   if (mvaRes==0 || mvaRes->GetSize()==0) {
+   if (mvaRes==nullptr || mvaRes->GetSize()==0) {
       Log() << kERROR<<Form("Dataset[%s] : ",DataInfo().GetName())<< "<CreateMVAPdfs> No result of classifier testing available" << Endl;
    }
 
@@ -2420,11 +2420,11 @@ Double_t TMVA::MethodBase::GetEfficiency( const TString& theString, Types::ETree
       // find cut that corresponds to signal efficiency and update signal-like criterion
       Double_t cut = rootFinder.Root( 0.5*(effS + effS_) );
       SetSignalReferenceCut( cut );
-      fEffS = 0;
+      fEffS = nullptr;
    }
 
    // must exist...
-   if (0 == fSpleffBvsS) {
+   if (nullptr == fSpleffBvsS) {
       delete list;
       return 0.0;
    }
@@ -2629,14 +2629,14 @@ Double_t TMVA::MethodBase::GetTrainingEfficiency(const TString& theString)
          eff_bvss->SetBinContent( bini, effB     );
          rej_bvss->SetBinContent( bini, 1.0-effB );
       }
-      fEffS = 0;
+      fEffS = nullptr;
 
       // create splines for histogram
       fSplTrainEffBvsS = new TSpline1( "effBvsS", new TGraph( eff_bvss ) );
    }
 
    // must exist...
-   if (0 == fSplTrainEffBvsS) return 0.0;
+   if (nullptr == fSplTrainEffBvsS) return 0.0;
 
    // now find signal efficiency that corresponds to required background efficiency
    Double_t effS = 0., effB, effS_ = 0., effB_ = 0.;
@@ -2784,7 +2784,7 @@ Double_t TMVA::MethodBase::GetROCIntegral(TH1D *histS, TH1D *histB) const
    if ((!histS && histB) || (histS && !histB))
       Log() << kFATAL <<Form("Dataset[%s] : ",DataInfo().GetName())<< "<GetROCIntegral(TH1D*, TH1D*)> Mismatch in hists" << Endl;
 
-   if (histS==0 || histB==0) return 0.;
+   if (histS==nullptr || histB==nullptr) return 0.;
 
    TMVA::PDF *pdfS = new TMVA::PDF( " PDF Sig", histS, TMVA::PDF::kSpline3 );
    TMVA::PDF *pdfB = new TMVA::PDF( " PDF Bkg", histB, TMVA::PDF::kSpline3 );
@@ -2820,7 +2820,7 @@ Double_t TMVA::MethodBase::GetROCIntegral(PDF *pdfS, PDF *pdfB) const
    if (!pdfS) pdfS = fSplS;
    if (!pdfB) pdfB = fSplB;
 
-   if (pdfS==0 || pdfB==0) return 0.;
+   if (pdfS==nullptr || pdfB==nullptr) return 0.;
 
    Double_t xmin = TMath::Min(pdfS->GetXmin(), pdfB->GetXmin());
    Double_t xmax = TMath::Max(pdfS->GetXmax(), pdfB->GetXmax());
@@ -2863,7 +2863,7 @@ Double_t TMVA::MethodBase::GetMaximumSignificance( Double_t SignalEvents,
    TH1* eff_s = results->GetHist("MVA_EFF_S");
    TH1* eff_b = results->GetHist("MVA_EFF_B");
 
-   if ( (eff_s==0) || (eff_b==0) ) {
+   if ( (eff_s==nullptr) || (eff_b==nullptr) ) {
       Log() << kWARNING <<Form("Dataset[%s] : ",DataInfo().GetName())<< "Efficiency histograms empty !" << Endl;
       Log() << kWARNING <<Form("Dataset[%s] : ",DataInfo().GetName())<< "no maximum cut found, return 0" << Endl;
       return 0;
@@ -3207,7 +3207,7 @@ void TMVA::MethodBase::PrintHelpMessage() const
 {
    // if options are written to reference file, also append help info
    std::streambuf* cout_sbuf = std::cout.rdbuf(); // save original sbuf
-   std::ofstream* o = 0;
+   std::ofstream* o = nullptr;
    if (gConfig().WriteOptionsReference()) {
       Log() << kINFO << "Print Help message for class " << GetName() << " into file: " << GetReferenceFile() << Endl;
       o = new std::ofstream( GetReferenceFile(), std::ios::app );
@@ -3298,7 +3298,7 @@ const std::vector<TMVA::Event*>& TMVA::MethodBase::GetEventCollection( Types::ET
    // transformed events. If the pointer is already != 0, i.e. the whole thing has been
    // done before, I don't need to do it again, but just "hand over" the pointer to those events.
    Int_t idx = Data()->TreeIndex(type);  //index indicating Training,Testing,...  events/datasets
-   if (fEventCollections.at(idx) == 0) {
+   if (fEventCollections.at(idx) == nullptr) {
       fEventCollections.at(idx) = &(Data()->GetEventCollection(type));
       fEventCollections.at(idx) = GetTransformationHandler().CalcTransformations(*(fEventCollections.at(idx)),kTRUE);
    }
@@ -3335,7 +3335,7 @@ Double_t TMVA::MethodBase::GetKSTrainingVsTest(Char_t SorB, TString opt){
    ResultsClassification* mvaRes = dynamic_cast<ResultsClassification*>
       ( Data()->GetResults(GetMethodName(),Types::kTesting, Types::kClassification) );
 
-   if (mvaRes != NULL) {
+   if (mvaRes != nullptr) {
       TH1D *mva_s = dynamic_cast<TH1D*> (mvaRes->GetHist("MVA_S"));
       TH1D *mva_b = dynamic_cast<TH1D*> (mvaRes->GetHist("MVA_B"));
       TH1D *mva_s_tr = dynamic_cast<TH1D*> (mvaRes->GetHist("MVA_TRAIN_S"));

--- a/tmva/tmva/src/MethodBayesClassifier.cxx
+++ b/tmva/tmva/src/MethodBayesClassifier.cxx
@@ -81,7 +81,7 @@ Bool_t TMVA::MethodBayesClassifier::HasAnalysisType( Types::EAnalysisType type, 
 ////////////////////////////////////////////////////////////////////////////////
 /// default initialisation
 
-void TMVA::MethodBayesClassifier::Init( void )
+void TMVA::MethodBayesClassifier::Init()
 {
 }
 
@@ -102,14 +102,14 @@ void TMVA::MethodBayesClassifier::ProcessOptions()
 ////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
-TMVA::MethodBayesClassifier::~MethodBayesClassifier( void )
+TMVA::MethodBayesClassifier::~MethodBayesClassifier()
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// some training
 
-void TMVA::MethodBayesClassifier::Train( void )
+void TMVA::MethodBayesClassifier::Train()
 {
 }
 

--- a/tmva/tmva/src/MethodBoost.cxx
+++ b/tmva/tmva/src/MethodBoost.cxx
@@ -144,7 +144,7 @@ TMVA::MethodBoost::MethodBoost( DataSetInfo& dsi,
 ////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
-TMVA::MethodBoost::~MethodBoost( void )
+TMVA::MethodBoost::~MethodBoost()
 {
    fMethodWeight.clear();
 
@@ -580,7 +580,7 @@ void TMVA::MethodBoost::ResetBoostWeights()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TMVA::MethodBoost::WriteMonitoringHistosToFile( void ) const
+void TMVA::MethodBoost::WriteMonitoringHistosToFile() const
 {
    TDirectory* dir=nullptr;
    if (fMonitorBoostedMethod) {

--- a/tmva/tmva/src/MethodBoost.cxx
+++ b/tmva/tmva/src/MethodBoost.cxx
@@ -104,15 +104,15 @@ ClassImp(TMVA::MethodBoost);
    , fBoostedMethodTitle(methodTitle)
    , fBoostedMethodOptions(theOption)
    , fMonitorBoostedMethod(kFALSE)
-   , fMonitorTree(0)
+   , fMonitorTree(nullptr)
    , fBoostWeight(0)
    , fMethodError(0)
    , fROC_training(0.0)
    , fOverlap_integral(0.0)
-   , fMVAvalues(0)
+   , fMVAvalues(nullptr)
 {
    fMVAvalues = new std::vector<Float_t>;
-   fDataSetManager = NULL;
+   fDataSetManager = nullptr;
    fHistoricBoolOption = kFALSE;
 }
 
@@ -129,15 +129,15 @@ TMVA::MethodBoost::MethodBoost( DataSetInfo& dsi,
    , fBoostedMethodTitle("")
    , fBoostedMethodOptions("")
    , fMonitorBoostedMethod(kFALSE)
-   , fMonitorTree(0)
+   , fMonitorTree(nullptr)
    , fBoostWeight(0)
    , fMethodError(0)
    , fROC_training(0.0)
    , fOverlap_integral(0.0)
-   , fMVAvalues(0)
+   , fMVAvalues(nullptr)
 {
    fMVAvalues = new std::vector<Float_t>;
-   fDataSetManager = NULL;
+   fDataSetManager = nullptr;
    fHistoricBoolOption = kFALSE;
 }
 
@@ -159,7 +159,7 @@ TMVA::MethodBoost::~MethodBoost( void )
 
    if (fMVAvalues) {
       delete fMVAvalues;
-      fMVAvalues = 0;
+      fMVAvalues = nullptr;
    }
 }
 
@@ -354,7 +354,7 @@ void TMVA::MethodBoost::CheckSetup()
 
 void TMVA::MethodBoost::Train()
 {
-   TDirectory* methodDir( 0 );
+   TDirectory* methodDir( nullptr );
    TString     dirName,dirTitle;
    Int_t       StopCounter=0;
    Results* results = Data()->GetResults(GetMethodName(), Types::kTraining, GetAnalysisType());
@@ -401,7 +401,7 @@ void TMVA::MethodBoost::Train()
       // suppressing the rest of the classifier output the right way
       fCurrentMethod  = (dynamic_cast<MethodBase*>(method));
 
-      if (fCurrentMethod==0) {
+      if (fCurrentMethod==nullptr) {
          Log() << kFATAL << "uups.. guess the booking of the " << fCurrentMethodIdx << "-th classifier somehow failed" << Endl;
          return; // hope that makes coverity happy (as if fears I might use the pointer later on, not knowing that FATAL exits
       }
@@ -432,7 +432,7 @@ void TMVA::MethodBoost::Train()
       {
         if (fMonitorBoostedMethod) {
             methodDir=GetFile()->GetDirectory(dirName=Form("%s_B%04i",fBoostedMethodName.Data(),fCurrentMethodIdx));
-            if (methodDir==0) {
+            if (methodDir==nullptr) {
                 methodDir=BaseDir()->mkdir(dirName,dirTitle=Form("Directory Boosted %s #%04i", fBoostedMethodName.Data(),fCurrentMethodIdx));
             }
             fCurrentMethod->SetMethodDir(methodDir);
@@ -546,7 +546,7 @@ void TMVA::MethodBoost::CreateMVAHistorgrams()
    // nrms = number of rms around the average to use for outline (of the 0 classifier)
    Double_t meanS, meanB, rmsS, rmsB, xmin, xmax, nrms = 10;
    Int_t signalClass = 0;
-   if (DataInfo().GetClassInfo("Signal") != 0) {
+   if (DataInfo().GetClassInfo("Signal") != nullptr) {
       signalClass = DataInfo().GetClassInfo("Signal")->GetNumber();
    }
    gTools().ComputeStat( GetEventCollection( Types::kMaxTreeType ), fMVAvalues,
@@ -582,7 +582,7 @@ void TMVA::MethodBoost::ResetBoostWeights()
 
 void TMVA::MethodBoost::WriteMonitoringHistosToFile( void ) const
 {
-   TDirectory* dir=0;
+   TDirectory* dir=nullptr;
    if (fMonitorBoostedMethod) {
       for (UInt_t imtd=0;imtd<fBoostNum;imtd++) {
 
@@ -645,13 +645,13 @@ void TMVA::MethodBoost::WriteEvaluationHistosToFile(Types::ETreeType treetype)
    UInt_t nloop = fTestSigMVAHist.size();
    if (fMethods.size()<nloop) nloop = fMethods.size();
    if (fMonitorBoostedMethod) {
-      TDirectory* dir=0;
+      TDirectory* dir=nullptr;
       for (UInt_t imtd=0;imtd<nloop;imtd++) {
          //writing the histograms in the specific classifier's directory
          MethodBase* mva = dynamic_cast<MethodBase*>(fMethods[imtd]);
          if (!mva) continue;
          dir = mva->BaseDir();
-         if (dir==0) continue;
+         if (dir==nullptr) continue;
          dir->cd();
          fTestSigMVAHist[imtd]->SetDirectory(dir);
          fTestSigMVAHist[imtd]->Write();
@@ -881,7 +881,7 @@ Double_t TMVA::MethodBoost::AdaBoost(MethodBase* method, Bool_t discreteAdaBoost
    Float_t w,v; Bool_t sig=kTRUE;
    Double_t sumAll=0, sumWrong=0;
    Bool_t* WrongDetection=new Bool_t[GetNEvents()];
-   QuickMVAProbEstimator *MVAProb=NULL;
+   QuickMVAProbEstimator *MVAProb=nullptr;
 
    if (discreteAdaBoost) {
       FindMVACut(method);
@@ -1093,7 +1093,7 @@ void TMVA::MethodBoost::GetHelpMessage() const
 
 const TMVA::Ranking* TMVA::MethodBoost::CreateRanking()
 {
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1107,7 +1107,7 @@ Double_t TMVA::MethodBoost::GetMvaValue( Double_t* err, Double_t* errUpper )
    //Double_t fact    = TMath::Exp(-1.)+TMath::Exp(1.);
    for (UInt_t i=0;i< fMethods.size(); i++){
       MethodBase* m = dynamic_cast<MethodBase*>(fMethods[i]);
-      if (m==0) continue;
+      if (m==nullptr) continue;
       Double_t val = fTmpEvent ? m->GetMvaValue(fTmpEvent) : m->GetMvaValue();
       Double_t sigcut = m->GetSignalReferenceCut();
 
@@ -1165,7 +1165,7 @@ Double_t TMVA::MethodBoost::GetBoostROCIntegral(Bool_t singleMethod, Types::ETre
    // set data sample training / testing
    Data()->SetCurrentType(eTT);
 
-   MethodBase* method = singleMethod ? dynamic_cast<MethodBase*>(fMethods.back()) : 0; // ToDo CoVerity flags this line as there is no protection against a zero-pointer delivered by dynamic_cast
+   MethodBase* method = singleMethod ? dynamic_cast<MethodBase*>(fMethods.back()) : nullptr; // ToDo CoVerity flags this line as there is no protection against a zero-pointer delivered by dynamic_cast
    // to make CoVerity happy (although, OF COURSE, the last method in the committee
    // has to be also of type MethodBase as ANY method is... hence the dynamic_cast
    // will never by "zero" ...
@@ -1213,7 +1213,7 @@ Double_t TMVA::MethodBoost::GetBoostROCIntegral(Bool_t singleMethod, Types::ETre
 
    // now create histograms for calculation of the ROC integral
    Int_t signalClass = 0;
-   if (DataInfo().GetClassInfo("Signal") != 0) {
+   if (DataInfo().GetClassInfo("Signal") != nullptr) {
       signalClass = DataInfo().GetClassInfo("Signal")->GetNumber();
    }
    gTools().ComputeStat( GetEventCollection(eTT), mvaRes,
@@ -1226,7 +1226,7 @@ Double_t TMVA::MethodBoost::GetBoostROCIntegral(Bool_t singleMethod, Types::ETre
    // calculate ROC integral
    TH1* mva_s = new TH1F( "MVA_S", "MVA_S", fNbins, xmin, xmax );
    TH1* mva_b = new TH1F( "MVA_B", "MVA_B", fNbins, xmin, xmax );
-   TH1 *mva_s_overlap=0, *mva_b_overlap=0;
+   TH1 *mva_s_overlap=nullptr, *mva_b_overlap=nullptr;
    if (CalcOverlapIntergral) {
       mva_s_overlap = new TH1F( "MVA_S_OVERLAP", "MVA_S_OVERLAP", fNbins, xmin, xmax );
       mva_b_overlap = new TH1F( "MVA_B_OVERLAP", "MVA_B_OVERLAP", fNbins, xmin, xmax );

--- a/tmva/tmva/src/MethodCFMlpANN.cxx
+++ b/tmva/tmva/src/MethodCFMlpANN.cxx
@@ -134,12 +134,12 @@ TMVA::MethodCFMlpANN::MethodCFMlpANN( const TString& jobName,
                                       DataSetInfo& theData,
                                       const TString& theOption  ) :
    TMVA::MethodBase( jobName, Types::kCFMlpANN, methodTitle, theData, theOption),
-   fData(0),
-   fClass(0),
+   fData(nullptr),
+   fClass(nullptr),
    fNlayers(0),
    fNcycles(0),
-   fNodes(0),
-   fYNN(0),
+   fNodes(nullptr),
+   fYNN(nullptr),
    MethodCFMlpANN_nsel(0)
 {
    MethodCFMlpANN_Utils::SetLogger(&Log());
@@ -151,12 +151,12 @@ TMVA::MethodCFMlpANN::MethodCFMlpANN( const TString& jobName,
 TMVA::MethodCFMlpANN::MethodCFMlpANN( DataSetInfo& theData,
                                       const TString& theWeightFile):
    TMVA::MethodBase( Types::kCFMlpANN, theData, theWeightFile),
-   fData(0),
-   fClass(0),
+   fData(nullptr),
+   fClass(nullptr),
    fNlayers(0),
    fNcycles(0),
-   fNodes(0),
-   fYNN(0),
+   fNodes(nullptr),
+   fYNN(nullptr),
    MethodCFMlpANN_nsel(0)
 {
 }
@@ -274,10 +274,10 @@ TMVA::MethodCFMlpANN::~MethodCFMlpANN( void )
    delete fClass;
    delete[] fNodes;
 
-   if (fYNN!=0) {
+   if (fYNN!=nullptr) {
       for (Int_t i=0; i<fNlayers; i++) delete[] fYNN[i];
       delete[] fYNN;
-      fYNN=0;
+      fYNN=nullptr;
    }
 }
 
@@ -296,10 +296,10 @@ void TMVA::MethodCFMlpANN::Train( void )
 
    for (Int_t i=0; i<nlayers; i++) nodes[i] = fNodes[i]; // full copy of class member
 
-   if (fYNN != 0) {
+   if (fYNN != nullptr) {
       for (Int_t i=0; i<fNlayers; i++) delete[] fYNN[i];
       delete[] fYNN;
-      fYNN = 0;
+      fYNN = nullptr;
    }
    fYNN = new Double_t*[nlayers];
    for (Int_t layer=0; layer<nlayers; layer++)
@@ -439,10 +439,10 @@ void TMVA::MethodCFMlpANN::ReadWeightsFromStream( std::istream & istr )
    // read number of layers (sum of: input + output + hidden)
    istr >> fParam_1.layerm;
 
-   if (fYNN != 0) {
+   if (fYNN != nullptr) {
       for (Int_t i=0; i<fNlayers; i++) delete[] fYNN[i];
       delete[] fYNN;
-      fYNN = 0;
+      fYNN = nullptr;
    }
    fYNN = new Double_t*[fParam_1.layerm];
    for (Int_t layer=0; layer<fParam_1.layerm; layer++) {
@@ -515,7 +515,7 @@ Int_t TMVA::MethodCFMlpANN::DataInterface( Double_t* /*tout2*/, Double_t*  /*tin
 
 
    // sanity checks
-   if (0 == xpg) {
+   if (nullptr == xpg) {
       Log() << kFATAL << "ERROR in MethodCFMlpANN_DataInterface zero pointer xpg" << Endl;
    }
    if (*nvar != (Int_t)this->GetNvar()) {
@@ -557,7 +557,7 @@ void TMVA::MethodCFMlpANN::AddWeightsXMLTo( void* parent ) const
    for (Int_t layer=1; layer<fParam_1.layerm; layer++) {
       void* layernode = gTools().AddChild(wght, "Layer"+gTools().StringFromInt(layer));
       gTools().AddAttr(layernode,"NNeurons",fNeur_1.neuron[layer]);
-      void* neuronnode=NULL;
+      void* neuronnode=nullptr;
       for (Int_t neuron=0; neuron<fNeur_1.neuron[layer]; neuron++) {
          neuronnode = gTools().AddChild(layernode,"Neuron"+gTools().StringFromInt(neuron));
          stringstream weights;
@@ -588,10 +588,10 @@ void TMVA::MethodCFMlpANN::ReadWeightsFromXML( void* wghtnode )
    stringstream content(minmaxcontent);
    for (UInt_t ivar=0; ivar<GetNvar(); ivar++)
       content >> fVarn_1.xmin[ivar] >> fVarn_1.xmax[ivar];
-   if (fYNN != 0) {
+   if (fYNN != nullptr) {
       for (Int_t i=0; i<fNlayers; i++) delete[] fYNN[i];
       delete[] fYNN;
-      fYNN = 0;
+      fYNN = nullptr;
    }
    fYNN = new Double_t*[fParam_1.layerm];
    void *layernode=gTools().GetNextChild(minmaxnode);
@@ -605,7 +605,7 @@ void TMVA::MethodCFMlpANN::ReadWeightsFromXML( void* wghtnode )
    }
    for (Int_t layer=1; layer<fParam_1.layerm; layer++) {
       layernode=gTools().GetNextChild(layernode);
-      void* neuronnode=NULL;
+      void* neuronnode=nullptr;
       neuronnode = gTools().GetChild(layernode);
       for (Int_t neuron=0; neuron<fNeur_1.neuron[layer]; neuron++) {
          const char* neuronweights = gTools().GetContent(neuronnode);

--- a/tmva/tmva/src/MethodCFMlpANN.cxx
+++ b/tmva/tmva/src/MethodCFMlpANN.cxx
@@ -256,7 +256,7 @@ void TMVA::MethodCFMlpANN::ProcessOptions()
 ////////////////////////////////////////////////////////////////////////////////
 /// default initialisation called by all constructors
 
-void TMVA::MethodCFMlpANN::Init( void )
+void TMVA::MethodCFMlpANN::Init()
 {
    // CFMlpANN prefers normalised input variables
    SetNormalised( kTRUE );
@@ -268,7 +268,7 @@ void TMVA::MethodCFMlpANN::Init( void )
 ////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
-TMVA::MethodCFMlpANN::~MethodCFMlpANN( void )
+TMVA::MethodCFMlpANN::~MethodCFMlpANN()
 {
    delete fData;
    delete fClass;
@@ -284,7 +284,7 @@ TMVA::MethodCFMlpANN::~MethodCFMlpANN( void )
 ////////////////////////////////////////////////////////////////////////////////
 /// training of the Clement-Ferrand NN classifier
 
-void TMVA::MethodCFMlpANN::Train( void )
+void TMVA::MethodCFMlpANN::Train()
 {
    Double_t dumDat(0);
    Int_t ntrain(Data()->GetNTrainingEvents());

--- a/tmva/tmva/src/MethodCFMlpANN_Utils.cxx
+++ b/tmva/tmva/src/MethodCFMlpANN_Utils.cxx
@@ -904,7 +904,7 @@ void TMVA::MethodCFMlpANN_Utils::GraphNN( Int_t *ilearn, Double_t * /*xxx*/,
 ////////////////////////////////////////////////////////////////////////////////
 /// [smart comments to be added]
 
-Double_t TMVA::MethodCFMlpANN_Utils::Sen3a( void )
+Double_t TMVA::MethodCFMlpANN_Utils::Sen3a()
 {
    // Initialized data
    Int_t    m12 = 4096;

--- a/tmva/tmva/src/MethodCFMlpANN_Utils.cxx
+++ b/tmva/tmva/src/MethodCFMlpANN_Utils.cxx
@@ -136,7 +136,7 @@ fg_999(999)
    for(i=0; i<max_Events_;++i) fVarn_1.nclass[i] = 0;
    for(i=0; i<max_nVar_;++i) fVarn_1.xmax[i] = 0;
 
-   fLogger = 0;
+   fLogger = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/src/MethodCategory.cxx
+++ b/tmva/tmva/src/MethodCategory.cxx
@@ -88,8 +88,8 @@ ClassImp(TMVA::MethodCategory);
                                          DataSetInfo& theData,
                                          const TString& theOption )
    : TMVA::MethodCompositeBase( jobName, Types::kCategory, methodTitle, theData, theOption),
-   fCatTree(0),
-   fDataSetManager(NULL)
+   fCatTree(nullptr),
+   fDataSetManager(nullptr)
 {
 }
 
@@ -99,8 +99,8 @@ ClassImp(TMVA::MethodCategory);
 TMVA::MethodCategory::MethodCategory( DataSetInfo& dsi,
                                       const TString& theWeightFile)
    : TMVA::MethodCompositeBase( Types::kCategory, dsi, theWeightFile),
-     fCatTree(0),
-     fDataSetManager(NULL)
+     fCatTree(nullptr),
+     fDataSetManager(nullptr)
 {
 }
 
@@ -156,7 +156,7 @@ TMVA::IMethod* TMVA::MethodCategory::AddMethod( const TCut& theCut,
    IMethod* addedMethod = ClassifierFactory::Instance().Create(addedMethodName,GetJobName(),theTitle,dsi,theOptions);
 
    MethodBase *method = (dynamic_cast<MethodBase*>(addedMethod));
-   if(method==0) return 0;
+   if(method==nullptr) return nullptr;
 
    if(fModelPersistence) method->SetWeightFileDir(fFileDir);
    method->SetModelPersistence(fModelPersistence);
@@ -171,7 +171,7 @@ TMVA::IMethod* TMVA::MethodCategory::AddMethod( const TCut& theCut,
    // set or create correct method base dir for added method
    const TString dirName(Form("Method_%s",method->GetMethodTypeName().Data()));
    TDirectory * dir = BaseDir()->GetDirectory(dirName);
-   if (dir != 0) method->SetMethodBaseDir( dir );
+   if (dir != nullptr) method->SetMethodBaseDir( dir );
    else method->SetMethodBaseDir( BaseDir()->mkdir(dirName,Form("Directory for all %s methods", method->GetMethodTypeName().Data())) );
 
    // method->SetBaseDir(eigenes base dir, gucken ob Fisher dir existiert, sonst erzeugen )
@@ -325,12 +325,12 @@ void TMVA::MethodCategory::InitCircularTree(const DataSetInfo& dsi)
 
    Bool_t hasAllExternalLinks = kTRUE;
    for (viIt = vars.begin(); viIt != vars.end(); ++viIt)
-      if( viIt->GetExternalLink() == 0 ) {
+      if( viIt->GetExternalLink() == nullptr ) {
          hasAllExternalLinks = kFALSE;
          break;
       }
    for (viIt = specs.begin(); viIt != specs.end(); ++viIt)
-      if( viIt->GetExternalLink() == 0 ) {
+      if( viIt->GetExternalLink() == nullptr ) {
          hasAllExternalLinks = kFALSE;
          break;
       }
@@ -429,7 +429,7 @@ void TMVA::MethodCategory::Train()
          MethodBase* mva = dynamic_cast<MethodBase*>(*itrMethod);
          if (mva && mva->Data()->GetNTrainingEvents() >= MinNoTrainingEvents) {
             const Ranking* ranking = (*itrMethod)->CreateRanking();
-            if (ranking != 0)
+            if (ranking != nullptr)
                ranking->Print();
             else
                Log() << kINFO << "No variable ranking supplied by classifier: "
@@ -446,7 +446,7 @@ void TMVA::MethodCategory::AddWeightsXMLTo( void* parent ) const
 {
    void* wght = gTools().AddChild(parent, "Weights");
    gTools().AddAttr( wght, "NSubMethods", fMethods.size() );
-   void* submethod(0);
+   void* submethod(nullptr);
 
    // iterate over methods and write them to XML file
    for (UInt_t i=0; i<fMethods.size(); i++) {
@@ -497,7 +497,7 @@ void TMVA::MethodCategory::ReadWeightsFromXML( void* wghtnode )
       // recreate sub-method from weights and add to fMethods
       MethodBase* method = dynamic_cast<MethodBase*>( ClassifierFactory::Instance().Create( methodType.Data(),
                                                                                             dsi, "none" ) );
-      if(method==0)
+      if(method==nullptr)
          Log() << kFATAL << "Could not create sub-method " << method << " from XML." << Endl;
 
       method->SetupMethod();
@@ -562,7 +562,7 @@ void TMVA::MethodCategory::GetHelpMessage() const
 
 const TMVA::Ranking* TMVA::MethodCategory::CreateRanking()
 {
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -628,7 +628,7 @@ Double_t TMVA::MethodCategory::GetMvaValue( Double_t* err, Double_t* errUpper )
    // get mva value from the suitable sub-classifier
    ev->SetVariableArrangement(&fVarMaps[methodToUse]);
    Double_t mvaValue = dynamic_cast<MethodBase*>(fMethods[methodToUse])->GetMvaValue(ev,err,errUpper);
-   ev->SetVariableArrangement(0);
+   ev->SetVariableArrangement(nullptr);
 
    return mvaValue;
 }

--- a/tmva/tmva/src/MethodCategory.cxx
+++ b/tmva/tmva/src/MethodCategory.cxx
@@ -107,7 +107,7 @@ TMVA::MethodCategory::MethodCategory( DataSetInfo& dsi,
 ////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
-TMVA::MethodCategory::~MethodCategory( void )
+TMVA::MethodCategory::~MethodCategory()
 {
    std::vector<TTreeFormula*>::iterator formIt = fCatFormulas.begin();
    std::vector<TTreeFormula*>::iterator lastF = fCatFormulas.end();

--- a/tmva/tmva/src/MethodCompositeBase.cxx
+++ b/tmva/tmva/src/MethodCompositeBase.cxx
@@ -74,7 +74,7 @@ TMVA::MethodCompositeBase::MethodCompositeBase( const TString& jobName,
                                                 DataSetInfo& theData,
                                                 const TString& theOption )
 : TMVA::MethodBase( jobName, methodType, methodTitle, theData, theOption),
-   fCurrentMethodIdx(0), fCurrentMethod(0)
+   fCurrentMethodIdx(0), fCurrentMethod(nullptr)
 {}
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -83,7 +83,7 @@ TMVA::MethodCompositeBase::MethodCompositeBase( Types::EMVA methodType,
                                                 DataSetInfo& dsi,
                                                 const TString& weightFile)
    : TMVA::MethodBase( methodType, dsi, weightFile),
-     fCurrentMethodIdx(0), fCurrentMethod(0)
+     fCurrentMethodIdx(0), fCurrentMethod(nullptr)
 {}
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -98,7 +98,7 @@ TMVA::IMethod* TMVA::MethodCompositeBase::GetMethod( const TString &methodTitle 
       MethodBase* mva = dynamic_cast<MethodBase*>(*itrMethod);
       if ( (mva->GetMethodName())==methodTitle ) return mva;
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -108,7 +108,7 @@ TMVA::IMethod* TMVA::MethodCompositeBase::GetMethod( const Int_t index ) const
 {
    std::vector<IMethod*>::const_iterator itrMethod = fMethods.begin()+index;
    if (itrMethod<fMethods.end()) return *itrMethod;
-   else                          return 0;
+   else                          return nullptr;
 }
 
 
@@ -199,7 +199,7 @@ void TMVA::MethodCompositeBase::ReadWeightsFromXML( void* wghtnode )
       fMethodWeight.push_back(methodWeight);
       MethodBase* meth = dynamic_cast<MethodBase*>(fMethods.back());
 
-      if(meth==0)
+      if(meth==nullptr)
          Log() << kFATAL << "Could not read method from XML" << Endl;
 
       void* methXML = gTools().GetChild(ch);

--- a/tmva/tmva/src/MethodCompositeBase.cxx
+++ b/tmva/tmva/src/MethodCompositeBase.cxx
@@ -159,7 +159,7 @@ void TMVA::MethodCompositeBase::ReadWeightsFromXML( void* wghtnode )
    UInt_t nMethods;
    TString methodName, methodTypeName, jobName, optionString;
 
-   for (UInt_t i=0;i<fMethods.size();i++) delete fMethods[i];
+   for (auto & fMethod : fMethods) delete fMethod;
    fMethods.clear();
    fMethodWeight.clear();
    gTools().ReadAttr( wghtnode, "NMethods",  nMethods );
@@ -238,7 +238,7 @@ void  TMVA::MethodCompositeBase::ReadWeightsFromStream( std::istream& istr )
    // coverity[tainted_data_argument]
    istr >> dummy >> methodNum;
    Log() << kINFO << "Read " << methodNum << " Classifiers" << Endl;
-   for (UInt_t i=0;i<fMethods.size();i++) delete fMethods[i];
+   for (auto & fMethod : fMethods) delete fMethod;
    fMethods.clear();
    fMethodWeight.clear();
    for (UInt_t i=0; i<methodNum; i++) {

--- a/tmva/tmva/src/MethodCompositeBase.cxx
+++ b/tmva/tmva/src/MethodCompositeBase.cxx
@@ -141,7 +141,7 @@ void TMVA::MethodCompositeBase::AddWeightsXMLTo( void* parent ) const
 ////////////////////////////////////////////////////////////////////////////////
 /// delete methods
 
-TMVA::MethodCompositeBase::~MethodCompositeBase( void )
+TMVA::MethodCompositeBase::~MethodCompositeBase()
 {
    std::vector<IMethod*>::iterator itrMethod = fMethods.begin();
    for (; itrMethod != fMethods.end(); ++itrMethod) {

--- a/tmva/tmva/src/MethodCrossValidation.cxx
+++ b/tmva/tmva/src/MethodCrossValidation.cxx
@@ -47,7 +47,7 @@ TMVA::MethodCrossValidation::MethodCrossValidation(DataSetInfo &theData, const T
 /// Destructor.
 ///
 
-TMVA::MethodCrossValidation::~MethodCrossValidation(void) {}
+TMVA::MethodCrossValidation::~MethodCrossValidation() {}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -95,7 +95,7 @@ void TMVA::MethodCrossValidation::ProcessOptions()
 ////////////////////////////////////////////////////////////////////////////////
 /// Common initialisation with defaults for the Method.
 
-void TMVA::MethodCrossValidation::Init(void)
+void TMVA::MethodCrossValidation::Init()
 {
    fMulticlassValues = std::vector<Float_t>(DataInfo().GetNClasses());
 }
@@ -103,7 +103,7 @@ void TMVA::MethodCrossValidation::Init(void)
 ////////////////////////////////////////////////////////////////////////////////
 /// Reset the method, as if it had just been instantiated (forget all training etc.).
 
-void TMVA::MethodCrossValidation::Reset(void) {}
+void TMVA::MethodCrossValidation::Reset() {}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// \brief Returns filename of weight file for a given fold.
@@ -302,7 +302,7 @@ const std::vector<Float_t> &TMVA::MethodCrossValidation::GetRegressionValues()
 ////////////////////////////////////////////////////////////////////////////////
 ///
 
-void TMVA::MethodCrossValidation::WriteMonitoringHistosToFile(void) const
+void TMVA::MethodCrossValidation::WriteMonitoringHistosToFile() const
 {
    // // Used for evaluation, which is outside the life time of MethodCrossEval.
    // Log() << kFATAL << "Method CrossValidation should not be created manually,"

--- a/tmva/tmva/src/MethodCuts.cxx
+++ b/tmva/tmva/src/MethodCuts.cxx
@@ -692,7 +692,7 @@ void  TMVA::MethodCuts::Train( void )
       fitter->Run();
 
       // clean up
-      for (UInt_t ivar=0; ivar<ranges.size(); ivar++) delete ranges[ivar];
+      for (auto & range : ranges) delete range;
       delete fitter;
 
    }

--- a/tmva/tmva/src/MethodCuts.cxx
+++ b/tmva/tmva/src/MethodCuts.cxx
@@ -217,7 +217,7 @@ Bool_t TMVA::MethodCuts::HasAnalysisType( Types::EAnalysisType type, UInt_t numb
 ////////////////////////////////////////////////////////////////////////////////
 /// default initialisation called by all constructors
 
-void TMVA::MethodCuts::Init( void )
+void TMVA::MethodCuts::Init()
 {
    fVarHistS          = fVarHistB = nullptr;
    fVarHistS_smooth   = fVarHistB_smooth = nullptr;
@@ -267,7 +267,7 @@ void TMVA::MethodCuts::Init( void )
 ////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
-TMVA::MethodCuts::~MethodCuts( void )
+TMVA::MethodCuts::~MethodCuts()
 {
    delete fRangeSign;
    delete fMeanS;
@@ -575,7 +575,7 @@ Double_t TMVA::MethodCuts::GetCuts( Double_t effS,
 ////////////////////////////////////////////////////////////////////////////////
 /// training method: here the cuts are optimised for the training sample
 
-void  TMVA::MethodCuts::Train( void )
+void  TMVA::MethodCuts::Train()
 {
    if (fEffMethod == kUsePDFs) CreateVariablePDFs(); // create PDFs for variables
 
@@ -1103,7 +1103,7 @@ void TMVA::MethodCuts::GetEffsfromSelection( Double_t* cutMin, Double_t* cutMax,
 ////////////////////////////////////////////////////////////////////////////////
 /// for PDF method: create efficiency reference histograms and PDFs
 
-void TMVA::MethodCuts::CreateVariablePDFs( void )
+void TMVA::MethodCuts::CreateVariablePDFs()
 {
    // create list of histograms and PDFs
    fVarHistS        = new std::vector<TH1*>( GetNvar() );
@@ -1408,7 +1408,7 @@ void TMVA::MethodCuts::ReadWeightsFromXML( void* wghtnode )
 ////////////////////////////////////////////////////////////////////////////////
 /// write histograms and PDFs to file for monitoring purposes
 
-void TMVA::MethodCuts::WriteMonitoringHistosToFile( void ) const
+void TMVA::MethodCuts::WriteMonitoringHistosToFile() const
 {
    Log() << kINFO << "Write monitoring histograms to file: " << BaseDir()->GetPath() << Endl;
 

--- a/tmva/tmva/src/MethodCuts.cxx
+++ b/tmva/tmva/src/MethodCuts.cxx
@@ -133,34 +133,34 @@ TMVA::MethodCuts::MethodCuts( const TString& jobName,
    MethodBase( jobName, Types::kCuts, methodTitle, theData, theOption),
    fFitMethod  ( kUseGeneticAlgorithm ),
    fEffMethod  ( kUseEventSelection ),
-   fFitParams (0),
+   fFitParams (nullptr),
    fTestSignalEff(0.7),
    fEffSMin    ( 0 ),
    fEffSMax    ( 0 ),
-   fCutRangeMin( 0 ),
-   fCutRangeMax( 0 ),
-   fBinaryTreeS( 0 ),
-   fBinaryTreeB( 0 ),
-   fCutMin     ( 0 ),
-   fCutMax     ( 0 ),
-   fTmpCutMin  ( 0 ),
-   fTmpCutMax  ( 0 ),
-   fAllVarsI   ( 0 ),
+   fCutRangeMin( nullptr ),
+   fCutRangeMax( nullptr ),
+   fBinaryTreeS( nullptr ),
+   fBinaryTreeB( nullptr ),
+   fCutMin     ( nullptr ),
+   fCutMax     ( nullptr ),
+   fTmpCutMin  ( nullptr ),
+   fTmpCutMax  ( nullptr ),
+   fAllVarsI   ( nullptr ),
    fNpar       ( 0 ),
    fEffRef     ( 0 ),
-   fRangeSign  ( 0 ),
-   fRandom     ( 0 ),
-   fMeanS      ( 0 ),
-   fMeanB      ( 0 ),
-   fRmsS       ( 0 ),
-   fRmsB       ( 0 ),
-   fEffBvsSLocal( 0 ),
-   fVarHistS   ( 0 ),
-   fVarHistB   ( 0 ),
-   fVarHistS_smooth( 0 ),
-   fVarHistB_smooth( 0 ),
-   fVarPdfS    ( 0 ),
-   fVarPdfB    ( 0 ),
+   fRangeSign  ( nullptr ),
+   fRandom     ( nullptr ),
+   fMeanS      ( nullptr ),
+   fMeanB      ( nullptr ),
+   fRmsS       ( nullptr ),
+   fRmsB       ( nullptr ),
+   fEffBvsSLocal( nullptr ),
+   fVarHistS   ( nullptr ),
+   fVarHistB   ( nullptr ),
+   fVarHistS_smooth( nullptr ),
+   fVarHistB_smooth( nullptr ),
+   fVarPdfS    ( nullptr ),
+   fVarPdfB    ( nullptr ),
    fNegEffWarning( kFALSE )
 {
 }
@@ -173,34 +173,34 @@ TMVA::MethodCuts::MethodCuts( DataSetInfo& theData,
    MethodBase( Types::kCuts, theData, theWeightFile),
    fFitMethod  ( kUseGeneticAlgorithm ),
    fEffMethod  ( kUseEventSelection ),
-   fFitParams (0),
+   fFitParams (nullptr),
    fTestSignalEff(0.7),
    fEffSMin    ( 0 ),
    fEffSMax    ( 0 ),
-   fCutRangeMin( 0 ),
-   fCutRangeMax( 0 ),
-   fBinaryTreeS( 0 ),
-   fBinaryTreeB( 0 ),
-   fCutMin     ( 0 ),
-   fCutMax     ( 0 ),
-   fTmpCutMin  ( 0 ),
-   fTmpCutMax  ( 0 ),
-   fAllVarsI   ( 0 ),
+   fCutRangeMin( nullptr ),
+   fCutRangeMax( nullptr ),
+   fBinaryTreeS( nullptr ),
+   fBinaryTreeB( nullptr ),
+   fCutMin     ( nullptr ),
+   fCutMax     ( nullptr ),
+   fTmpCutMin  ( nullptr ),
+   fTmpCutMax  ( nullptr ),
+   fAllVarsI   ( nullptr ),
    fNpar       ( 0 ),
    fEffRef     ( 0 ),
-   fRangeSign  ( 0 ),
-   fRandom     ( 0 ),
-   fMeanS      ( 0 ),
-   fMeanB      ( 0 ),
-   fRmsS       ( 0 ),
-   fRmsB       ( 0 ),
-   fEffBvsSLocal( 0 ),
-   fVarHistS   ( 0 ),
-   fVarHistB   ( 0 ),
-   fVarHistS_smooth( 0 ),
-   fVarHistB_smooth( 0 ),
-   fVarPdfS    ( 0 ),
-   fVarPdfB    ( 0 ),
+   fRangeSign  ( nullptr ),
+   fRandom     ( nullptr ),
+   fMeanS      ( nullptr ),
+   fMeanB      ( nullptr ),
+   fRmsS       ( nullptr ),
+   fRmsB       ( nullptr ),
+   fEffBvsSLocal( nullptr ),
+   fVarHistS   ( nullptr ),
+   fVarHistB   ( nullptr ),
+   fVarHistS_smooth( nullptr ),
+   fVarHistB_smooth( nullptr ),
+   fVarPdfS    ( nullptr ),
+   fVarPdfB    ( nullptr ),
    fNegEffWarning( kFALSE )
 {
 }
@@ -219,11 +219,11 @@ Bool_t TMVA::MethodCuts::HasAnalysisType( Types::EAnalysisType type, UInt_t numb
 
 void TMVA::MethodCuts::Init( void )
 {
-   fVarHistS          = fVarHistB = 0;
-   fVarHistS_smooth   = fVarHistB_smooth = 0;
-   fVarPdfS           = fVarPdfB = 0;
-   fFitParams         = 0;
-   fBinaryTreeS       = fBinaryTreeB = 0;
+   fVarHistS          = fVarHistB = nullptr;
+   fVarHistS_smooth   = fVarHistB_smooth = nullptr;
+   fVarPdfS           = fVarPdfB = nullptr;
+   fFitParams         = nullptr;
+   fBinaryTreeS       = fBinaryTreeB = nullptr;
    fEffSMin           = 0;
    fEffSMax           = 0;
 
@@ -277,24 +277,24 @@ TMVA::MethodCuts::~MethodCuts( void )
    delete fFitParams;
    delete fEffBvsSLocal;
 
-   if (NULL != fCutRangeMin) delete [] fCutRangeMin;
-   if (NULL != fCutRangeMax) delete [] fCutRangeMax;
-   if (NULL != fAllVarsI)    delete [] fAllVarsI;
+   if (nullptr != fCutRangeMin) delete [] fCutRangeMin;
+   if (nullptr != fCutRangeMax) delete [] fCutRangeMax;
+   if (nullptr != fAllVarsI)    delete [] fAllVarsI;
 
    for (UInt_t i=0;i<GetNvar();i++) {
-      if (NULL != fCutMin[i]  ) delete [] fCutMin[i];
-      if (NULL != fCutMax[i]  ) delete [] fCutMax[i];
-      if (NULL != fCutRange[i]) delete fCutRange[i];
+      if (nullptr != fCutMin[i]  ) delete [] fCutMin[i];
+      if (nullptr != fCutMax[i]  ) delete [] fCutMax[i];
+      if (nullptr != fCutRange[i]) delete fCutRange[i];
    }
 
-   if (NULL != fCutMin) delete [] fCutMin;
-   if (NULL != fCutMax) delete [] fCutMax;
+   if (nullptr != fCutMin) delete [] fCutMin;
+   if (nullptr != fCutMax) delete [] fCutMax;
 
-   if (NULL != fTmpCutMin) delete [] fTmpCutMin;
-   if (NULL != fTmpCutMax) delete [] fTmpCutMax;
+   if (nullptr != fTmpCutMin) delete [] fTmpCutMin;
+   if (nullptr != fTmpCutMax) delete [] fTmpCutMax;
 
-   if (NULL != fBinaryTreeS) delete fBinaryTreeS;
-   if (NULL != fBinaryTreeB) delete fBinaryTreeB;
+   if (nullptr != fBinaryTreeS) delete fBinaryTreeS;
+   if (nullptr != fBinaryTreeB) delete fBinaryTreeB;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -336,7 +336,7 @@ void TMVA::MethodCuts::DeclareOptions()
    fCutRangeMin = new Double_t[GetNvar()];
    fCutRangeMax = new Double_t[GetNvar()];
    for (UInt_t ivar=0; ivar<GetNvar(); ivar++) {
-      fCutRange[ivar] = 0;
+      fCutRange[ivar] = nullptr;
       fCutRangeMin[ivar] = fCutRangeMax[ivar] = -1;
    }
 
@@ -435,7 +435,7 @@ Double_t TMVA::MethodCuts::GetMvaValue( Double_t* err, Double_t* errUpper )
    NoErrorCalc(err, errUpper);
 
    // sanity check
-   if (fCutMin == NULL || fCutMax == NULL || fNbins == 0) {
+   if (fCutMin == nullptr || fCutMax == nullptr || fNbins == 0) {
       Log() << kFATAL << "<Eval_Cuts> fCutMin/Max have zero pointer. "
             << "Did you book Cuts ?" << Endl;
    }
@@ -471,7 +471,7 @@ void TMVA::MethodCuts::PrintCuts( Double_t effS ) const
    Double_t trueEffS = GetCuts( effS, cutsMin, cutsMax );
 
    // retrieve variable expressions (could be transformations)
-   std::vector<TString>* varVec = 0;
+   std::vector<TString>* varVec = nullptr;
    if (GetTransformationHandler().GetNumOfTransformations() == 0) {
       // no transformation applied, replace by current variables
       varVec = new std::vector<TString>;
@@ -580,8 +580,8 @@ void  TMVA::MethodCuts::Train( void )
    if (fEffMethod == kUsePDFs) CreateVariablePDFs(); // create PDFs for variables
 
    // create binary trees (global member variables) for signal and background
-   if (fBinaryTreeS != 0) { delete fBinaryTreeS; fBinaryTreeS = 0; }
-   if (fBinaryTreeB != 0) { delete fBinaryTreeB; fBinaryTreeB = 0; }
+   if (fBinaryTreeS != nullptr) { delete fBinaryTreeS; fBinaryTreeS = nullptr; }
+   if (fBinaryTreeB != nullptr) { delete fBinaryTreeB; fBinaryTreeB = nullptr; }
 
    // the variables may be transformed by a transformation method: to coherently
    // treat signal and background one must decide which transformation type shall
@@ -623,7 +623,7 @@ void  TMVA::MethodCuts::Train( void )
    delete fEffBvsSLocal;
    fEffBvsSLocal = new TH1F( GetTestvarName() + "_effBvsSLocal",
                              TString(GetName()) + " efficiency of B vs S", fNbins, 0.0, 1.0 );
-   fEffBvsSLocal->SetDirectory(0); // it's local
+   fEffBvsSLocal->SetDirectory(nullptr); // it's local
 
    // init
    for (Int_t ibin=1; ibin<=fNbins; ibin++) fEffBvsSLocal->SetBinContent( ibin, -0.1 );
@@ -665,7 +665,7 @@ void  TMVA::MethodCuts::Train( void )
       }
 
       // create the fitter
-      FitterBase* fitter = NULL;
+      FitterBase* fitter = nullptr;
 
       switch (fFitMethod) {
       case kUseGeneticAlgorithm:
@@ -795,8 +795,8 @@ void  TMVA::MethodCuts::Train( void )
    // --------------------------------------------------------------------------
    else Log() << kFATAL << "Unknown minimisation method: " << fFitMethod << Endl;
 
-   if (fBinaryTreeS != 0) { delete fBinaryTreeS; fBinaryTreeS = 0; }
-   if (fBinaryTreeB != 0) { delete fBinaryTreeB; fBinaryTreeB = 0; }
+   if (fBinaryTreeS != nullptr) { delete fBinaryTreeS; fBinaryTreeS = nullptr; }
+   if (fBinaryTreeB != nullptr) { delete fBinaryTreeB; fBinaryTreeB = nullptr; }
 
    // force cut ranges within limits
    for (UInt_t ivar=0; ivar<GetNvar(); ivar++) {
@@ -1262,10 +1262,10 @@ void  TMVA::MethodCuts::ReadWeightsFromStream( std::istream& istr )
 
    Int_t   tmpbin;
    Float_t tmpeffS, tmpeffB;
-   if (fEffBvsSLocal != 0) delete fEffBvsSLocal;
+   if (fEffBvsSLocal != nullptr) delete fEffBvsSLocal;
    fEffBvsSLocal = new TH1F( GetTestvarName() + "_effBvsSLocal",
                              TString(GetName()) + " efficiency of B vs S", fNbins, 0.0, 1.0 );
-   fEffBvsSLocal->SetDirectory(0); // it's local
+   fEffBvsSLocal->SetDirectory(nullptr); // it's local
 
    for (Int_t ibin=0; ibin<fNbins; ibin++) {
       istr >> tmpbin >> tmpeffS >> tmpeffB;
@@ -1328,11 +1328,11 @@ void TMVA::MethodCuts::ReadWeightsFromXML( void* wghtnode )
 {
    // delete old min and max
    for (UInt_t i=0; i<GetNvar(); i++) {
-      if (fCutMin[i] != 0) delete [] fCutMin[i];
-      if (fCutMax[i] != 0) delete [] fCutMax[i];
+      if (fCutMin[i] != nullptr) delete [] fCutMin[i];
+      if (fCutMax[i] != nullptr) delete [] fCutMax[i];
    }
-   if (fCutMin != 0) delete [] fCutMin;
-   if (fCutMax != 0) delete [] fCutMax;
+   if (fCutMin != nullptr) delete [] fCutMin;
+   if (fCutMax != nullptr) delete [] fCutMax;
 
    Int_t tmpEffMethod, tmpFitMethod;
    gTools().ReadAttr( wghtnode, "OptimisationMethod", tmpEffMethod );
@@ -1366,7 +1366,7 @@ void TMVA::MethodCuts::ReadWeightsFromXML( void* wghtnode )
    delete fEffBvsSLocal;
    fEffBvsSLocal = new TH1F( GetTestvarName() + "_effBvsSLocal",
                              TString(GetName()) + " efficiency of B vs S", fNbins, 0.0, 1.0 );
-   fEffBvsSLocal->SetDirectory(0); // it's local
+   fEffBvsSLocal->SetDirectory(nullptr); // it's local
    for (Int_t ibin=1; ibin<=fNbins; ibin++) fEffBvsSLocal->SetBinContent( ibin, -0.1 ); // Init
 
    fCutMin = new Double_t*[GetNvar()];
@@ -1460,10 +1460,10 @@ Double_t TMVA::MethodCuts::GetTrainingEfficiency(const TString& theString)
    delete list;
 
    // first round ? --> create histograms
-   if (results->GetHist("EFF_BVSS_TR")==0) {
+   if (results->GetHist("EFF_BVSS_TR")==nullptr) {
 
-      if (fBinaryTreeS != 0) { delete fBinaryTreeS; fBinaryTreeS = 0; }
-      if (fBinaryTreeB != 0) { delete fBinaryTreeB; fBinaryTreeB = 0; }
+      if (fBinaryTreeS != nullptr) { delete fBinaryTreeS; fBinaryTreeS = nullptr; }
+      if (fBinaryTreeB != nullptr) { delete fBinaryTreeB; fBinaryTreeB = nullptr; }
 
       fBinaryTreeS = new BinarySearchTree();
       fBinaryTreeS->Fill( GetEventCollection(Types::kTraining), fSignalClass );
@@ -1519,7 +1519,7 @@ Double_t TMVA::MethodCuts::GetTrainingEfficiency(const TString& theString)
    }
 
    // must exist...
-   if (NULL == fSplTrainEffBvsS) return 0.0;
+   if (nullptr == fSplTrainEffBvsS) return 0.0;
 
    // now find signal efficiency that corresponds to required background efficiency
    Double_t effS = 0., effB, effS_ = 0., effB_ = 0.;
@@ -1580,10 +1580,10 @@ Double_t TMVA::MethodCuts::GetEfficiency( const TString& theString, Types::ETree
 
 
    // first round ? --> create histograms
-   if (results->GetHist("MVA_EFF_BvsS")==0) {
+   if (results->GetHist("MVA_EFF_BvsS")==nullptr) {
 
-      if (fBinaryTreeS!=0) { delete fBinaryTreeS; fBinaryTreeS = 0; }
-      if (fBinaryTreeB!=0) { delete fBinaryTreeB; fBinaryTreeB = 0; }
+      if (fBinaryTreeS!=nullptr) { delete fBinaryTreeS; fBinaryTreeS = nullptr; }
+      if (fBinaryTreeB!=nullptr) { delete fBinaryTreeB; fBinaryTreeB = nullptr; }
 
       // the variables may be transformed by a transformation method: to coherently
       // treat signal and background one must decide which transformation type shall
@@ -1654,7 +1654,7 @@ Double_t TMVA::MethodCuts::GetEfficiency( const TString& theString, Types::ETree
    }
 
    // must exist...
-   if (NULL == fSpleffBvsS) return 0.0;
+   if (nullptr == fSpleffBvsS) return 0.0;
 
    // now find signal efficiency that corresponds to required background efficiency
    Double_t effS = 0, effB = 0, effS_ = 0, effB_ = 0;

--- a/tmva/tmva/src/MethodDNN.cxx
+++ b/tmva/tmva/src/MethodDNN.cxx
@@ -397,7 +397,7 @@ std::vector<double> fetchValue(const std::map<TString, TString> & keyValueMap,
    TObjArray* tokenStrings = parseString.Tokenize (tokenDelim);
    TIter nextToken (tokenStrings);
    TObjString* tokenString = (TObjString*)nextToken ();
-   for (; tokenString != NULL; tokenString = (TObjString*)nextToken ()) {
+   for (; tokenString != nullptr; tokenString = (TObjString*)nextToken ()) {
       std::stringstream sstr;
       double currentValue;
       sstr << tokenString->GetString ().Data ();
@@ -810,7 +810,7 @@ void TMVA::MethodDNN::Train()
                                          MinimizerType::fSteepest, s.learningRate,
                                          s.momentum, 1, s.multithreading);
       std::shared_ptr<Settings> ptrSettings(settings);
-      ptrSettings->setMonitoring (0);
+      ptrSettings->setMonitoring (nullptr);
       Log() << kINFO
             << "Training with learning rate = " << ptrSettings->learningRate ()
             << ", momentum = " << ptrSettings->momentum ()
@@ -1285,7 +1285,7 @@ const std::vector<Float_t> & TMVA::MethodDNN::GetRegressionValues()
    for (size_t i = 0; i < nTargets; i++)
        output[i] = YHat(0, i);
 
-   if (fRegressionReturnVal == NULL) {
+   if (fRegressionReturnVal == nullptr) {
        fRegressionReturnVal = new std::vector<Float_t>();
    }
    fRegressionReturnVal->clear();
@@ -1308,7 +1308,7 @@ const std::vector<Float_t> & TMVA::MethodDNN::GetMulticlassValues()
    size_t nVariables = GetEvent()->GetNVariables();
    Matrix_t X(1, nVariables);
    Matrix_t YHat(1, DataInfo().GetNClasses());
-   if (fMulticlassReturnVal == NULL) {
+   if (fMulticlassReturnVal == nullptr) {
       fMulticlassReturnVal = new std::vector<Float_t>(DataInfo().GetNClasses());
    }
 
@@ -1328,22 +1328,22 @@ const std::vector<Float_t> & TMVA::MethodDNN::GetMulticlassValues()
 
 void TMVA::MethodDNN::AddWeightsXMLTo( void* parent ) const
 {
-   void* nn = gTools().xmlengine().NewChild(parent, 0, "Weights");
+   void* nn = gTools().xmlengine().NewChild(parent, nullptr, "Weights");
    Int_t inputWidth = fNet.GetInputWidth();
    Int_t depth      = fNet.GetDepth();
    char  lossFunction = static_cast<char>(fNet.GetLossFunction());
-   gTools().xmlengine().NewAttr(nn, 0, "InputWidth",
+   gTools().xmlengine().NewAttr(nn, nullptr, "InputWidth",
                                 gTools().StringFromInt(inputWidth));
-   gTools().xmlengine().NewAttr(nn, 0, "Depth", gTools().StringFromInt(depth));
-   gTools().xmlengine().NewAttr(nn, 0, "LossFunction", TString(lossFunction));
-   gTools().xmlengine().NewAttr(nn, 0, "OutputFunction",
+   gTools().xmlengine().NewAttr(nn, nullptr, "Depth", gTools().StringFromInt(depth));
+   gTools().xmlengine().NewAttr(nn, nullptr, "LossFunction", TString(lossFunction));
+   gTools().xmlengine().NewAttr(nn, nullptr, "OutputFunction",
                                 TString(static_cast<char>(fOutputFunction)));
 
    for (Int_t i = 0; i < depth; i++) {
       const auto& layer = fNet.GetLayer(i);
-      auto layerxml = gTools().xmlengine().NewChild(nn, 0, "Layer");
+      auto layerxml = gTools().xmlengine().NewChild(nn, nullptr, "Layer");
       int activationFunction = static_cast<int>(layer.GetActivationFunction());
-      gTools().xmlengine().NewAttr(layerxml, 0, "ActivationFunction",
+      gTools().xmlengine().NewAttr(layerxml, nullptr, "ActivationFunction",
                                    TString::Itoa(activationFunction, 10));
       WriteMatrixXML(layerxml, "Weights", layer.GetWeights());
       WriteMatrixXML(layerxml, "Biases",  layer.GetBiases());

--- a/tmva/tmva/src/MethodDT.cxx
+++ b/tmva/tmva/src/MethodDT.cxx
@@ -415,8 +415,8 @@ Double_t TMVA::MethodDT::PruneTree( )
       pruneTool->Optimize();
       std::vector<DecisionTreeNode*> nodes = pruneTool->GetOptimalPruneSequence();
       fPruneStrength = pruneTool->GetOptimalPruneStrength();
-      for(UInt_t i = 0; i < nodes.size(); i++)
-         fTree->PruneNode(nodes[i]);
+      for(auto & node : nodes)
+         fTree->PruneNode(node);
       delete pruneTool;
    }
    else if (fAutomatic &&  fPruneMethod != DecisionTree::kCostComplexityPruning){

--- a/tmva/tmva/src/MethodDT.cxx
+++ b/tmva/tmva/src/MethodDT.cxx
@@ -131,8 +131,8 @@ ClassImp(TMVA::MethodDT);
                              DataSetInfo& theData,
                              const TString& theOption) :
    TMVA::MethodBase( jobName, Types::kDT, methodTitle, theData, theOption)
-   , fTree(0)
-   , fSepType(0)
+   , fTree(nullptr)
+   , fSepType(nullptr)
    , fMinNodeEvents(0)
    , fMinNodeSize(0)
    , fNCuts(0)
@@ -157,8 +157,8 @@ ClassImp(TMVA::MethodDT);
 TMVA::MethodDT::MethodDT( DataSetInfo& dsi,
                           const TString& theWeightFile) :
    TMVA::MethodBase( Types::kDT, dsi, theWeightFile)
-   , fTree(0)
-   , fSepType(0)
+   , fTree(nullptr)
+   , fSepType(nullptr)
    , fMinNodeEvents(0)
    , fMinNodeSize(0)
    , fNCuts(0)
@@ -567,5 +567,5 @@ void TMVA::MethodDT::GetHelpMessage() const
 
 const TMVA::Ranking* TMVA::MethodDT::CreateRanking()
 {
-   return 0;
+   return nullptr;
 }

--- a/tmva/tmva/src/MethodDT.cxx
+++ b/tmva/tmva/src/MethodDT.cxx
@@ -342,7 +342,7 @@ void TMVA::MethodDT::SetMinNodeSize(TString sizeInPercent){
 ////////////////////////////////////////////////////////////////////////////////
 /// common initialisation with defaults for the DT-Method
 
-void TMVA::MethodDT::Init( void )
+void TMVA::MethodDT::Init()
 {
    fMinNodeEvents  = -1;
    fMinNodeSize    = 5;
@@ -367,14 +367,14 @@ void TMVA::MethodDT::Init( void )
 ////////////////////////////////////////////////////////////////////////////////
 ///destructor
 
-TMVA::MethodDT::~MethodDT( void )
+TMVA::MethodDT::~MethodDT()
 {
    delete fTree;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TMVA::MethodDT::Train( void )
+void TMVA::MethodDT::Train()
 {
    TMVA::DecisionTreeNode::fgIsTraining=true;
    fTree = new DecisionTree( fSepType, fMinNodeSize, fNCuts, &(DataInfo()), 0,

--- a/tmva/tmva/src/MethodFDA.cxx
+++ b/tmva/tmva/src/MethodFDA.cxx
@@ -89,10 +89,10 @@ ClassImp(TMVA::MethodFDA);
                                const TString& theOption)
    : MethodBase( jobName, Types::kFDA, methodTitle, theData, theOption),
    IFitterTarget   (),
-   fFormula        ( 0 ),
+   fFormula        ( nullptr ),
    fNPars          ( 0 ),
-   fFitter         ( 0 ),
-   fConvergerFitter( 0 ),
+   fFitter         ( nullptr ),
+   fConvergerFitter( nullptr ),
    fSumOfWeightsSig( 0 ),
    fSumOfWeightsBkg( 0 ),
    fSumOfWeights   ( 0 ),
@@ -107,10 +107,10 @@ TMVA::MethodFDA::MethodFDA( DataSetInfo& theData,
                             const TString& theWeightFile)
    : MethodBase( Types::kFDA, theData, theWeightFile),
      IFitterTarget   (),
-     fFormula        ( 0 ),
+     fFormula        ( nullptr ),
      fNPars          ( 0 ),
-     fFitter         ( 0 ),
-     fConvergerFitter( 0 ),
+     fFitter         ( nullptr ),
+     fConvergerFitter( nullptr ),
      fSumOfWeightsSig( 0 ),
      fSumOfWeightsBkg( 0 ),
      fSumOfWeights   ( 0 ),
@@ -140,7 +140,7 @@ void TMVA::MethodFDA::Init( void )
    fConverger       = "";
 
    if( DoMulticlass() )
-      if (fMulticlassReturnVal == NULL) fMulticlassReturnVal = new std::vector<Float_t>();
+      if (fMulticlassReturnVal == nullptr) fMulticlassReturnVal = new std::vector<Float_t>();
 
 }
 
@@ -258,7 +258,7 @@ void TMVA::MethodFDA::ProcessOptions()
    }
 
    fParRange.resize( fNPars );
-   for (UInt_t ipar=0; ipar<fNPars; ipar++) fParRange[ipar] = 0;
+   for (UInt_t ipar=0; ipar<fNPars; ipar++) fParRange[ipar] = nullptr;
 
    for (UInt_t ipar=0; ipar<fNPars; ipar++) {
       // parse (a,b)
@@ -349,11 +349,11 @@ void TMVA::MethodFDA::ClearAll( void )
    // hence, ... erase the copied pointers to assure, that they are deleted only once.
    //   fParRange.erase( fParRange.begin()+(fNPars), fParRange.end() );
    for (UInt_t ipar=0; ipar<fParRange.size() && ipar<fNPars; ipar++) {
-      if (fParRange[ipar] != 0) { delete fParRange[ipar]; fParRange[ipar] = 0; }
+      if (fParRange[ipar] != nullptr) { delete fParRange[ipar]; fParRange[ipar] = nullptr; }
    }
    fParRange.clear();
 
-   if (fFormula  != 0) { delete fFormula; fFormula = 0; }
+   if (fFormula  != nullptr) { delete fFormula; fFormula = nullptr; }
    fBestPars.clear();
 }
 
@@ -406,10 +406,10 @@ void TMVA::MethodFDA::Train( void )
    // print results
    PrintResults( fFitMethod, fBestPars, estimator );
 
-   delete fFitter; fFitter = 0;
-   if (fConvergerFitter!=0 && fConvergerFitter!=(IFitterTarget*)this) {
+   delete fFitter; fFitter = nullptr;
+   if (fConvergerFitter!=nullptr && fConvergerFitter!=(IFitterTarget*)this) {
       delete fConvergerFitter;
-      fConvergerFitter = 0;
+      fConvergerFitter = nullptr;
    }
    ExitFromTraining();
 }
@@ -529,7 +529,7 @@ Double_t TMVA::MethodFDA::GetMvaValue( Double_t* err, Double_t* errUpper )
 
 const std::vector<Float_t>& TMVA::MethodFDA::GetRegressionValues()
 {
-   if (fRegressionReturnVal == NULL) fRegressionReturnVal = new std::vector<Float_t>();
+   if (fRegressionReturnVal == nullptr) fRegressionReturnVal = new std::vector<Float_t>();
    fRegressionReturnVal->clear();
 
    const Event* ev = GetEvent();
@@ -552,7 +552,7 @@ const std::vector<Float_t>& TMVA::MethodFDA::GetRegressionValues()
 
 const std::vector<Float_t>& TMVA::MethodFDA::GetMulticlassValues()
 {
-   if (fMulticlassReturnVal == NULL) fMulticlassReturnVal = new std::vector<Float_t>();
+   if (fMulticlassReturnVal == nullptr) fMulticlassReturnVal = new std::vector<Float_t>();
    fMulticlassReturnVal->clear();
    std::vector<Float_t> temp;
 

--- a/tmva/tmva/src/MethodFDA.cxx
+++ b/tmva/tmva/src/MethodFDA.cxx
@@ -121,7 +121,7 @@ TMVA::MethodFDA::MethodFDA( DataSetInfo& theData,
 ////////////////////////////////////////////////////////////////////////////////
 /// default initialisation
 
-void TMVA::MethodFDA::Init( void )
+void TMVA::MethodFDA::Init()
 {
    fNPars    = 0;
 
@@ -323,7 +323,7 @@ void TMVA::MethodFDA::ProcessOptions()
 ////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
-TMVA::MethodFDA::~MethodFDA( void )
+TMVA::MethodFDA::~MethodFDA()
 {
    ClearAll();
 }
@@ -343,7 +343,7 @@ Bool_t TMVA::MethodFDA::HasAnalysisType( Types::EAnalysisType type, UInt_t numbe
 ////////////////////////////////////////////////////////////////////////////////
 /// delete and clear all class members
 
-void TMVA::MethodFDA::ClearAll( void )
+void TMVA::MethodFDA::ClearAll()
 {
    // if there is more than one output dimension, the paramater ranges are the same again (object has been copied).
    // hence, ... erase the copied pointers to assure, that they are deleted only once.
@@ -360,7 +360,7 @@ void TMVA::MethodFDA::ClearAll( void )
 ////////////////////////////////////////////////////////////////////////////////
 /// FDA training
 
-void TMVA::MethodFDA::Train( void )
+void TMVA::MethodFDA::Train()
 {
    // cache training events
    fSumOfWeights    = 0;

--- a/tmva/tmva/src/MethodFisher.cxx
+++ b/tmva/tmva/src/MethodFisher.cxx
@@ -174,7 +174,7 @@ TMVA::MethodFisher::MethodFisher( DataSetInfo& dsi,
 ////////////////////////////////////////////////////////////////////////////////
 /// default initialization called by all constructors
 
-void TMVA::MethodFisher::Init( void )
+void TMVA::MethodFisher::Init()
 {
    // allocate Fisher coefficients
    fFisherCoeff = new std::vector<Double_t>( GetNvar() );
@@ -213,7 +213,7 @@ void TMVA::MethodFisher::ProcessOptions()
 ////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
-TMVA::MethodFisher::~MethodFisher( void )
+TMVA::MethodFisher::~MethodFisher()
 {
    if (fBetw       ) { delete fBetw; fBetw = nullptr; }
    if (fWith       ) { delete fWith; fWith = nullptr; }
@@ -234,7 +234,7 @@ Bool_t TMVA::MethodFisher::HasAnalysisType( Types::EAnalysisType type, UInt_t nu
 ////////////////////////////////////////////////////////////////////////////////
 /// computation of Fisher coefficients by series of matrix operations
 
-void TMVA::MethodFisher::Train( void )
+void TMVA::MethodFisher::Train()
 {
    // get mean value of each variables for signal, backgd and signal+backgd
    GetMean();
@@ -282,7 +282,7 @@ Double_t TMVA::MethodFisher::GetMvaValue( Double_t* err, Double_t* errUpper )
 ////////////////////////////////////////////////////////////////////////////////
 /// initialization method; creates global matrices and vectors
 
-void TMVA::MethodFisher::InitMatrices( void )
+void TMVA::MethodFisher::InitMatrices()
 {
    // average value of each variables for S, B, S+B
    fMeanMatx = new TMatrixD( GetNvar(), 3 );
@@ -299,7 +299,7 @@ void TMVA::MethodFisher::InitMatrices( void )
 ////////////////////////////////////////////////////////////////////////////////
 /// compute mean values of variables in each sample, and the overall means
 
-void TMVA::MethodFisher::GetMean( void )
+void TMVA::MethodFisher::GetMean()
 {
    // initialize internal sum-of-weights variables
    fSumOfWeightsS = 0;
@@ -348,7 +348,7 @@ void TMVA::MethodFisher::GetMean( void )
 /// the matrix of covariance 'within class' reflects the dispersion of the
 /// events relative to the center of gravity of their own class
 
-void TMVA::MethodFisher::GetCov_WithinClass( void )
+void TMVA::MethodFisher::GetCov_WithinClass()
 {
    // assert required
    assert( fSumOfWeightsS > 0 && fSumOfWeightsB > 0 );
@@ -414,7 +414,7 @@ void TMVA::MethodFisher::GetCov_WithinClass( void )
 /// events of a class relative to the global center of gravity of all the class
 /// hence the separation between classes
 
-void TMVA::MethodFisher::GetCov_BetweenClass( void )
+void TMVA::MethodFisher::GetCov_BetweenClass()
 {
    // assert required
    assert( fSumOfWeightsS > 0 && fSumOfWeightsB > 0);
@@ -437,7 +437,7 @@ void TMVA::MethodFisher::GetCov_BetweenClass( void )
 ////////////////////////////////////////////////////////////////////////////////
 /// compute full covariance matrix from sum of within and between matrices
 
-void TMVA::MethodFisher::GetCov_Full( void )
+void TMVA::MethodFisher::GetCov_Full()
 {
    for (UInt_t x=0; x<GetNvar(); x++)
       for (UInt_t y=0; y<GetNvar(); y++)
@@ -454,7 +454,7 @@ void TMVA::MethodFisher::GetCov_Full( void )
 /// then the array of Fisher coefficients is
 /// [coeff] =sqrt(fNsig*fNbgd)/fNevt*transpose{Xs-Xb}*InvWith
 
-void TMVA::MethodFisher::GetFisherCoeff( void )
+void TMVA::MethodFisher::GetFisherCoeff()
 {
    // assert required
    assert( fSumOfWeightsS > 0 && fSumOfWeightsB > 0);
@@ -525,7 +525,7 @@ void TMVA::MethodFisher::GetFisherCoeff( void )
 /// we want signal & backgd classes as compact and separated as possible
 /// the discriminating power is then defined as the ration "fBetw/fWith"
 
-void TMVA::MethodFisher::GetDiscrimPower( void )
+void TMVA::MethodFisher::GetDiscrimPower()
 {
    for (UInt_t ivar=0; ivar<GetNvar(); ivar++) {
       if ((*fCov)(ivar, ivar) != 0)
@@ -554,7 +554,7 @@ const TMVA::Ranking* TMVA::MethodFisher::CreateRanking()
 /// display Fisher coefficients and discriminating power for each variable
 /// check maximum length of variable name
 
-void TMVA::MethodFisher::PrintCoefficients( void )
+void TMVA::MethodFisher::PrintCoefficients()
 {
    Log() << kHEADER << "Results for Fisher coefficients:" << Endl;
 

--- a/tmva/tmva/src/MethodFisher.cxx
+++ b/tmva/tmva/src/MethodFisher.cxx
@@ -137,16 +137,16 @@ TMVA::MethodFisher::MethodFisher( const TString& jobName,
                                   DataSetInfo& dsi,
                                   const TString& theOption ) :
    MethodBase( jobName, Types::kFisher, methodTitle, dsi, theOption),
-   fMeanMatx     ( 0 ),
+   fMeanMatx     ( nullptr ),
    fTheMethod    ( "Fisher" ),
    fFisherMethod ( kFisher ),
-   fBetw         ( 0 ),
-   fWith         ( 0 ),
-   fCov          ( 0 ),
+   fBetw         ( nullptr ),
+   fWith         ( nullptr ),
+   fCov          ( nullptr ),
    fSumOfWeightsS( 0 ),
    fSumOfWeightsB( 0 ),
-   fDiscrimPow   ( 0 ),
-   fFisherCoeff  ( 0 ),
+   fDiscrimPow   ( nullptr ),
+   fFisherCoeff  ( nullptr ),
    fF0           ( 0 )
 {
 }
@@ -157,16 +157,16 @@ TMVA::MethodFisher::MethodFisher( const TString& jobName,
 TMVA::MethodFisher::MethodFisher( DataSetInfo& dsi,
                                   const TString& theWeightFile) :
    MethodBase( Types::kFisher, dsi, theWeightFile),
-   fMeanMatx     ( 0 ),
+   fMeanMatx     ( nullptr ),
    fTheMethod    ( "Fisher" ),
    fFisherMethod ( kFisher ),
-   fBetw         ( 0 ),
-   fWith         ( 0 ),
-   fCov          ( 0 ),
+   fBetw         ( nullptr ),
+   fWith         ( nullptr ),
+   fCov          ( nullptr ),
    fSumOfWeightsS( 0 ),
    fSumOfWeightsB( 0 ),
-   fDiscrimPow   ( 0 ),
-   fFisherCoeff  ( 0 ),
+   fDiscrimPow   ( nullptr ),
+   fFisherCoeff  ( nullptr ),
    fF0           ( 0 )
 {
 }
@@ -215,11 +215,11 @@ void TMVA::MethodFisher::ProcessOptions()
 
 TMVA::MethodFisher::~MethodFisher( void )
 {
-   if (fBetw       ) { delete fBetw; fBetw = 0; }
-   if (fWith       ) { delete fWith; fWith = 0; }
-   if (fCov        ) { delete fCov;  fCov = 0; }
-   if (fDiscrimPow ) { delete fDiscrimPow; fDiscrimPow = 0; }
-   if (fFisherCoeff) { delete fFisherCoeff; fFisherCoeff = 0; }
+   if (fBetw       ) { delete fBetw; fBetw = nullptr; }
+   if (fWith       ) { delete fWith; fWith = nullptr; }
+   if (fCov        ) { delete fCov;  fCov = nullptr; }
+   if (fDiscrimPow ) { delete fDiscrimPow; fDiscrimPow = nullptr; }
+   if (fFisherCoeff) { delete fFisherCoeff; fFisherCoeff = nullptr; }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -460,7 +460,7 @@ void TMVA::MethodFisher::GetFisherCoeff( void )
    assert( fSumOfWeightsS > 0 && fSumOfWeightsB > 0);
 
    // invert covariance matrix
-   TMatrixD* theMat = 0;
+   TMatrixD* theMat = nullptr;
    switch (GetFisherMethod()) {
    case kFisher:
       theMat = fWith;

--- a/tmva/tmva/src/MethodHMatrix.cxx
+++ b/tmva/tmva/src/MethodHMatrix.cxx
@@ -108,7 +108,7 @@ TMVA::MethodHMatrix::MethodHMatrix( DataSetInfo& theData,
 ////////////////////////////////////////////////////////////////////////////////
 /// default initialization called by all constructors
 
-void TMVA::MethodHMatrix::Init( void )
+void TMVA::MethodHMatrix::Init()
 {
    //SetNormalised( kFALSE ); obsolete!
 
@@ -124,7 +124,7 @@ void TMVA::MethodHMatrix::Init( void )
 ////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
-TMVA::MethodHMatrix::~MethodHMatrix( void )
+TMVA::MethodHMatrix::~MethodHMatrix()
 {
    if (nullptr != fInvHMatrixS) delete fInvHMatrixS;
    if (nullptr != fInvHMatrixB) delete fInvHMatrixB;
@@ -159,7 +159,7 @@ void TMVA::MethodHMatrix::ProcessOptions()
 ////////////////////////////////////////////////////////////////////////////////
 /// computes H-matrices for signal and background samples
 
-void TMVA::MethodHMatrix::Train( void )
+void TMVA::MethodHMatrix::Train()
 {
    // covariance matrices for signal and background
    ComputeCovariance( kTRUE,  fInvHMatrixS );

--- a/tmva/tmva/src/MethodHMatrix.cxx
+++ b/tmva/tmva/src/MethodHMatrix.cxx
@@ -85,10 +85,10 @@ ClassImp(TMVA::MethodHMatrix);
                                        DataSetInfo& theData,
                                        const TString& theOption )
    : TMVA::MethodBase( jobName, Types::kHMatrix, methodTitle, theData, theOption)
-   ,fInvHMatrixS(0)
-   ,fInvHMatrixB(0)
-   ,fVecMeanS(0)
-   ,fVecMeanB(0)
+   ,fInvHMatrixS(nullptr)
+   ,fInvHMatrixB(nullptr)
+   ,fVecMeanS(nullptr)
+   ,fVecMeanB(nullptr)
 {
 }
 
@@ -98,10 +98,10 @@ ClassImp(TMVA::MethodHMatrix);
 TMVA::MethodHMatrix::MethodHMatrix( DataSetInfo& theData,
                                     const TString& theWeightFile)
    : TMVA::MethodBase( Types::kHMatrix, theData, theWeightFile)
-   ,fInvHMatrixS(0)
-   ,fInvHMatrixB(0)
-   ,fVecMeanS(0)
-   ,fVecMeanB(0)
+   ,fInvHMatrixS(nullptr)
+   ,fInvHMatrixB(nullptr)
+   ,fVecMeanS(nullptr)
+   ,fVecMeanB(nullptr)
 {
 }
 
@@ -126,10 +126,10 @@ void TMVA::MethodHMatrix::Init( void )
 
 TMVA::MethodHMatrix::~MethodHMatrix( void )
 {
-   if (NULL != fInvHMatrixS) delete fInvHMatrixS;
-   if (NULL != fInvHMatrixB) delete fInvHMatrixB;
-   if (NULL != fVecMeanS   ) delete fVecMeanS;
-   if (NULL != fVecMeanB   ) delete fVecMeanB;
+   if (nullptr != fInvHMatrixS) delete fInvHMatrixS;
+   if (nullptr != fInvHMatrixB) delete fInvHMatrixB;
+   if (nullptr != fVecMeanS   ) delete fVecMeanS;
+   if (nullptr != fVecMeanB   ) delete fVecMeanB;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/src/MethodKNN.cxx
+++ b/tmva/tmva/src/MethodKNN.cxx
@@ -66,7 +66,7 @@ ClassImp(TMVA::MethodKNN);
    : TMVA::MethodBase(jobName, Types::kKNN, methodTitle, theData, theOption)
    , fSumOfWeightsS(0)
    , fSumOfWeightsB(0)
-   , fModule(0)
+   , fModule(nullptr)
    , fnkNN(0)
    , fBalanceDepth(0)
    , fScaleFrac(0)
@@ -87,7 +87,7 @@ TMVA::MethodKNN::MethodKNN( DataSetInfo& theData,
    : TMVA::MethodBase( Types::kKNN, theData, theWeightFile)
    , fSumOfWeightsS(0)
    , fSumOfWeightsB(0)
-   , fModule(0)
+   , fModule(nullptr)
    , fnkNN(0)
    , fBalanceDepth(0)
    , fScaleFrac(0)
@@ -434,7 +434,7 @@ Double_t TMVA::MethodKNN::GetMvaValue( Double_t* err, Double_t* errUpper )
 
 const std::vector< Float_t >& TMVA::MethodKNN::GetRegressionValues()
 {
-   if( fRegressionReturnVal == 0 )
+   if( fRegressionReturnVal == nullptr )
       fRegressionReturnVal = new std::vector<Float_t>;
    else
       fRegressionReturnVal->clear();
@@ -517,7 +517,7 @@ const std::vector< Float_t >& TMVA::MethodKNN::GetRegressionValues()
 
 const TMVA::Ranking* TMVA::MethodKNN::CreateRanking()
 {
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -688,7 +688,7 @@ void TMVA::MethodKNN::WriteWeightsToStream(TFile &rf) const
 
    kNN::Event *event = new kNN::Event();
    TTree *tree = new TTree("knn", "event tree");
-   tree->SetDirectory(0);
+   tree->SetDirectory(nullptr);
    tree->Branch("event", "TMVA::kNN::Event", &event);
 
    Double_t size = 0.0;

--- a/tmva/tmva/src/MethodKNN.cxx
+++ b/tmva/tmva/src/MethodKNN.cxx
@@ -366,24 +366,24 @@ Double_t TMVA::MethodKNN::GetMvaValue( Double_t* err, Double_t* errUpper )
    UInt_t count_all = 0;
    Double_t weight_all = 0, weight_sig = 0, weight_bac = 0;
 
-   for (kNN::List::const_iterator lit = rlist.begin(); lit != rlist.end(); ++lit) {
+   for (const auto & lit : rlist) {
 
       // get reference to current node to make code more readable
-      const kNN::Node<kNN::Event> &node = *(lit->first);
+      const kNN::Node<kNN::Event> &node = *(lit.first);
 
       // Warn about Monte-Carlo event with zero distance
       // this happens when this query event is also in learning sample
-      if (lit->second < 0.0) {
+      if (lit.second < 0.0) {
          Log() << kFATAL << "A neighbor has negative distance to query event" << Endl;
       }
-      else if (!(lit->second > 0.0)) {
+      else if (!(lit.second > 0.0)) {
          Log() << kVERBOSE << "A neighbor has zero distance to query event" << Endl;
       }
 
       // get event weight and scale weight by kernel function
       Double_t evweight = node.GetWeight();
       if      (use_gaus) evweight *= MethodKNN::GausKernel(event_knn, node.GetEvent(), rms_vec);
-      else if (use_poln) evweight *= MethodKNN::PolnKernel(TMath::Sqrt(lit->second)*kradius);
+      else if (use_poln) evweight *= MethodKNN::PolnKernel(TMath::Sqrt(lit.second)*kradius);
 
       if (fUseWeight) weight_all += evweight;
       else          ++weight_all;
@@ -469,10 +469,10 @@ const std::vector< Float_t >& TMVA::MethodKNN::GetRegressionValues()
    Double_t weight_all = 0;
    UInt_t count_all = 0;
 
-   for (kNN::List::const_iterator lit = rlist.begin(); lit != rlist.end(); ++lit) {
+   for (const auto & lit : rlist) {
 
       // get reference to current node to make code more readable
-      const kNN::Node<kNN::Event> &node = *(lit->first);
+      const kNN::Node<kNN::Event> &node = *(lit.first);
       const kNN::VarVec &tvec = node.GetEvent().GetTargets();
       const Double_t weight = node.GetEvent().GetWeight();
 
@@ -502,8 +502,8 @@ const std::vector< Float_t >& TMVA::MethodKNN::GetRegressionValues()
       return *fRegressionReturnVal;
    }
 
-   for (UInt_t ivar = 0; ivar < reg_vec.size(); ++ivar) {
-      reg_vec[ivar] /= weight_all;
+   for (float & ivar : reg_vec) {
+      ivar /= weight_all;
    }
 
    // copy result
@@ -529,22 +529,22 @@ void TMVA::MethodKNN::AddWeightsXMLTo( void* parent ) const {
    if (fEvent.size()>0) gTools().AddAttr(wght,"NVar",fEvent.begin()->GetNVar());
    if (fEvent.size()>0) gTools().AddAttr(wght,"NTgt",fEvent.begin()->GetNTgt());
 
-   for (kNN::EventVec::const_iterator event = fEvent.begin(); event != fEvent.end(); ++event) {
+   for (const auto & event : fEvent) {
 
       std::stringstream s("");
       s.precision( 16 );
-      for (UInt_t ivar = 0; ivar < event->GetNVar(); ++ivar) {
+      for (UInt_t ivar = 0; ivar < event.GetNVar(); ++ivar) {
          if (ivar>0) s << " ";
-         s << std::scientific << event->GetVar(ivar);
+         s << std::scientific << event.GetVar(ivar);
       }
 
-      for (UInt_t itgt = 0; itgt < event->GetNTgt(); ++itgt) {
-         s << " " << std::scientific << event->GetTgt(itgt);
+      for (UInt_t itgt = 0; itgt < event.GetNTgt(); ++itgt) {
+         s << " " << std::scientific << event.GetTgt(itgt);
       }
 
       void* evt = gTools().AddChild(wght, "Event", s.str().c_str());
-      gTools().AddAttr(evt,"Type", event->GetType());
-      gTools().AddAttr(evt,"Weight", event->GetWeight());
+      gTools().AddAttr(evt,"Type", event.GetType());
+      gTools().AddAttr(evt,"Weight", event.GetWeight());
    }
 }
 
@@ -692,8 +692,8 @@ void TMVA::MethodKNN::WriteWeightsToStream(TFile &rf) const
    tree->Branch("event", "TMVA::kNN::Event", &event);
 
    Double_t size = 0.0;
-   for (kNN::EventVec::const_iterator it = fEvent.begin(); it != fEvent.end(); ++it) {
-      (*event) = (*it);
+   for (const auto & it : fEvent) {
+      (*event) = it;
       size += tree->Fill();
    }
 
@@ -872,11 +872,11 @@ Double_t TMVA::MethodKNN::getKernelRadius(const kNN::List &rlist) const
    UInt_t kcount = 0;
    const UInt_t knn = static_cast<UInt_t>(fnkNN);
 
-   for (kNN::List::const_iterator lit = rlist.begin(); lit != rlist.end(); ++lit)
+   for (const auto & lit : rlist)
       {
-         if (!(lit->second > 0.0)) continue;
+         if (!(lit.second > 0.0)) continue;
 
-         if (kradius < lit->second || kradius < 0.0) kradius = lit->second;
+         if (kradius < lit.second || kradius < 0.0) kradius = lit.second;
 
          ++kcount;
          if (kcount >= knn) break;
@@ -896,12 +896,12 @@ const std::vector<Double_t> TMVA::MethodKNN::getRMS(const kNN::List &rlist, cons
    UInt_t kcount = 0;
    const UInt_t knn = static_cast<UInt_t>(fnkNN);
 
-   for (kNN::List::const_iterator lit = rlist.begin(); lit != rlist.end(); ++lit)
+   for (const auto & lit : rlist)
       {
-         if (!(lit->second > 0.0)) continue;
+         if (!(lit.second > 0.0)) continue;
 
-         const kNN::Node<kNN::Event> *node_ = lit -> first;
-         const kNN::Event &event_ = node_-> GetEvent();
+         const kNN::Node<kNN::Event> *node_ = lit.first;
+         const kNN::Event &event_ = node_->GetEvent();
 
          if (rvec.empty()) {
             rvec.insert(rvec.end(), event_.GetNVar(), 0.0);
@@ -946,10 +946,10 @@ Double_t TMVA::MethodKNN::getLDAValue(const kNN::List &rlist, const kNN::Event &
 {
    LDAEvents sig_vec, bac_vec;
 
-   for (kNN::List::const_iterator lit = rlist.begin(); lit != rlist.end(); ++lit) {
+   for (const auto & lit : rlist) {
 
       // get reference to current node to make code more readable
-      const kNN::Node<kNN::Event> &node = *(lit->first);
+      const kNN::Node<kNN::Event> &node = *(lit.first);
       const kNN::VarVec &tvec = node.GetEvent().GetVars();
 
       if (node.GetEvent().GetType() == 1) { // signal type = 1

--- a/tmva/tmva/src/MethodLD.cxx
+++ b/tmva/tmva/src/MethodLD.cxx
@@ -120,8 +120,8 @@ TMVA::MethodLD::~MethodLD( void )
    if (fSumValMatx) { delete fSumValMatx; fSumValMatx = nullptr; }
    if (fCoeffMatx)  { delete fCoeffMatx;  fCoeffMatx  = nullptr; }
    if (fLDCoeff) {
-      for (vector< vector< Double_t >* >::iterator vi=fLDCoeff->begin(); vi!=fLDCoeff->end(); ++vi){
-         if (*vi) { delete *vi; *vi = 0; }
+      for (auto & vi : *fLDCoeff){
+         if (vi) { delete vi; vi = 0; }
       }
       delete fLDCoeff; fLDCoeff = nullptr;
    }
@@ -174,8 +174,8 @@ Double_t TMVA::MethodLD::GetMvaValue( Double_t* err, Double_t* errUpper )
       (*fRegressionReturnVal)[iout] = (*(*fLDCoeff)[iout])[0] ;
 
       int icoeff=0;
-      for (std::vector<Float_t>::const_iterator it = ev->GetValues().begin();it!=ev->GetValues().end();++it){
-         (*fRegressionReturnVal)[iout] += (*(*fLDCoeff)[iout])[++icoeff] * (*it);
+      for (float it : ev->GetValues()){
+         (*fRegressionReturnVal)[iout] += (*(*fLDCoeff)[iout])[++icoeff] * it;
       }
    }
 
@@ -199,8 +199,8 @@ const std::vector< Float_t >& TMVA::MethodLD::GetRegressionValues()
       (*fRegressionReturnVal)[iout] = (*(*fLDCoeff)[iout])[0] ;
 
       int icoeff = 0;
-      for (std::vector<Float_t>::const_iterator it = ev->GetValues().begin();it!=ev->GetValues().end();++it){
-         (*fRegressionReturnVal)[iout] += (*(*fLDCoeff)[iout])[++icoeff] * (*it);
+      for (float it : ev->GetValues()){
+         (*fRegressionReturnVal)[iout] += (*(*fLDCoeff)[iout])[++icoeff] * it;
       }
    }
 
@@ -389,8 +389,8 @@ void TMVA::MethodLD::ReadWeightsFromXML( void* wghtnode )
 
    // create vector with coefficients (double vector due to arbitrary output dimension)
    if (fLDCoeff) {
-      for (vector< vector< Double_t >* >::iterator vi=fLDCoeff->begin(); vi!=fLDCoeff->end(); ++vi){
-         if (*vi) { delete *vi; *vi = 0; }
+      for (auto & vi : *fLDCoeff){
+         if (vi) { delete vi; vi = 0; }
       }
       delete fLDCoeff; fLDCoeff = nullptr;
    }

--- a/tmva/tmva/src/MethodLD.cxx
+++ b/tmva/tmva/src/MethodLD.cxx
@@ -74,10 +74,10 @@ ClassImp(TMVA::MethodLD);
                              const TString& theOption ) :
    MethodBase( jobName, Types::kLD, methodTitle, dsi, theOption),
    fNRegOut   ( 0 ),
-   fSumMatx   ( 0 ),
-   fSumValMatx( 0 ),
-   fCoeffMatx ( 0 ),
-   fLDCoeff   ( 0 )
+   fSumMatx   ( nullptr ),
+   fSumValMatx( nullptr ),
+   fCoeffMatx ( nullptr ),
+   fLDCoeff   ( nullptr )
 {
 }
 
@@ -87,10 +87,10 @@ ClassImp(TMVA::MethodLD);
 TMVA::MethodLD::MethodLD( DataSetInfo& theData, const TString& theWeightFile)
    : MethodBase( Types::kLD, theData, theWeightFile),
      fNRegOut   ( 0 ),
-     fSumMatx   ( 0 ),
-     fSumValMatx( 0 ),
-     fCoeffMatx ( 0 ),
-     fLDCoeff   ( 0 )
+     fSumMatx   ( nullptr ),
+     fSumValMatx( nullptr ),
+     fCoeffMatx ( nullptr ),
+     fLDCoeff   ( nullptr )
 {
 }
 
@@ -116,14 +116,14 @@ void TMVA::MethodLD::Init( void )
 
 TMVA::MethodLD::~MethodLD( void )
 {
-   if (fSumMatx)    { delete fSumMatx;    fSumMatx    = 0; }
-   if (fSumValMatx) { delete fSumValMatx; fSumValMatx = 0; }
-   if (fCoeffMatx)  { delete fCoeffMatx;  fCoeffMatx  = 0; }
+   if (fSumMatx)    { delete fSumMatx;    fSumMatx    = nullptr; }
+   if (fSumValMatx) { delete fSumValMatx; fSumValMatx = nullptr; }
+   if (fCoeffMatx)  { delete fCoeffMatx;  fCoeffMatx  = nullptr; }
    if (fLDCoeff) {
       for (vector< vector< Double_t >* >::iterator vi=fLDCoeff->begin(); vi!=fLDCoeff->end(); ++vi){
          if (*vi) { delete *vi; *vi = 0; }
       }
-      delete fLDCoeff; fLDCoeff = 0;
+      delete fLDCoeff; fLDCoeff = nullptr;
    }
 }
 
@@ -167,7 +167,7 @@ Double_t TMVA::MethodLD::GetMvaValue( Double_t* err, Double_t* errUpper )
 {
    const Event* ev = GetEvent();
 
-   if (fRegressionReturnVal == NULL) fRegressionReturnVal = new vector< Float_t >();
+   if (fRegressionReturnVal == nullptr) fRegressionReturnVal = new vector< Float_t >();
    fRegressionReturnVal->resize( fNRegOut );
 
    for (Int_t iout = 0; iout<fNRegOut; iout++) {
@@ -192,7 +192,7 @@ const std::vector< Float_t >& TMVA::MethodLD::GetRegressionValues()
 {
    const Event* ev = GetEvent();
 
-   if (fRegressionReturnVal == NULL) fRegressionReturnVal = new vector< Float_t >();
+   if (fRegressionReturnVal == nullptr) fRegressionReturnVal = new vector< Float_t >();
    fRegressionReturnVal->resize( fNRegOut );
 
    for (Int_t iout = 0; iout<fNRegOut; iout++) {
@@ -392,7 +392,7 @@ void TMVA::MethodLD::ReadWeightsFromXML( void* wghtnode )
       for (vector< vector< Double_t >* >::iterator vi=fLDCoeff->begin(); vi!=fLDCoeff->end(); ++vi){
          if (*vi) { delete *vi; *vi = 0; }
       }
-      delete fLDCoeff; fLDCoeff = 0;
+      delete fLDCoeff; fLDCoeff = nullptr;
    }
    fLDCoeff = new vector< vector< Double_t >* >(fNRegOut);
    for (Int_t ivar = 0; ivar<fNRegOut; ivar++) (*fLDCoeff)[ivar] = new std::vector<Double_t>( ncoeff );

--- a/tmva/tmva/src/MethodLD.cxx
+++ b/tmva/tmva/src/MethodLD.cxx
@@ -97,7 +97,7 @@ TMVA::MethodLD::MethodLD( DataSetInfo& theData, const TString& theWeightFile)
 ////////////////////////////////////////////////////////////////////////////////
 /// default initialization called by all constructors
 
-void TMVA::MethodLD::Init( void )
+void TMVA::MethodLD::Init()
 {
    if(DataInfo().GetNTargets()!=0) fNRegOut = DataInfo().GetNTargets();
    else                fNRegOut = 1;
@@ -114,7 +114,7 @@ void TMVA::MethodLD::Init( void )
 ////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
-TMVA::MethodLD::~MethodLD( void )
+TMVA::MethodLD::~MethodLD()
 {
    if (fSumMatx)    { delete fSumMatx;    fSumMatx    = nullptr; }
    if (fSumValMatx) { delete fSumValMatx; fSumValMatx = nullptr; }
@@ -144,7 +144,7 @@ Bool_t TMVA::MethodLD::HasAnalysisType( Types::EAnalysisType type, UInt_t number
 ////////////////////////////////////////////////////////////////////////////////
 /// compute fSumMatx
 
-void TMVA::MethodLD::Train( void )
+void TMVA::MethodLD::Train()
 {
    GetSum();
 
@@ -219,7 +219,7 @@ const std::vector< Float_t >& TMVA::MethodLD::GetRegressionValues()
 ////////////////////////////////////////////////////////////////////////////////
 /// Initialization method; creates global matrices and vectors
 
-void TMVA::MethodLD::InitMatrices( void )
+void TMVA::MethodLD::InitMatrices()
 {
    fSumMatx    = new TMatrixD( GetNvar()+1, GetNvar()+1 );
    fSumValMatx = new TMatrixD( GetNvar()+1, fNRegOut );
@@ -231,7 +231,7 @@ void TMVA::MethodLD::InitMatrices( void )
 /// Calculates the matrix transposed(X)*W*X with W being the diagonal weight matrix
 /// and X the coordinates values
 
-void TMVA::MethodLD::GetSum( void )
+void TMVA::MethodLD::GetSum()
 {
    const UInt_t nvar = DataInfo().GetNVariables();
 
@@ -268,7 +268,7 @@ void TMVA::MethodLD::GetSum( void )
 ////////////////////////////////////////////////////////////////////////////////
 /// Calculates the vector transposed(X)*W*Y with Y being the target vector
 
-void TMVA::MethodLD::GetSumVal( void )
+void TMVA::MethodLD::GetSumVal()
 {
    const UInt_t nvar = DataInfo().GetNVariables();
 
@@ -308,7 +308,7 @@ void TMVA::MethodLD::GetSumVal( void )
 ////////////////////////////////////////////////////////////////////////////////
 /// Calculates the coefficients used for classification/regression
 
-void TMVA::MethodLD::GetLDCoeff( void )
+void TMVA::MethodLD::GetLDCoeff()
 {
    const UInt_t nvar = DataInfo().GetNVariables();
 
@@ -487,7 +487,7 @@ void TMVA::MethodLD::ProcessOptions()
 ////////////////////////////////////////////////////////////////////////////////
 /// Display the classification/regression coefficients for each variable
 
-void TMVA::MethodLD::PrintCoefficients( void )
+void TMVA::MethodLD::PrintCoefficients()
 {
    Log() << kHEADER << "Results for LD coefficients:" << Endl;
 

--- a/tmva/tmva/src/MethodLikelihood.cxx
+++ b/tmva/tmva/src/MethodLikelihood.cxx
@@ -765,10 +765,10 @@ void  TMVA::MethodLikelihood::WriteMonitoringHistosToFile( void ) const
 
       // ---------- create cloned low-binned histogram for comparison in macros (mainly necessary for KDE)
       TH1* h[2] = { (*fHistSig)[ivar], (*fHistBgd)[ivar] };
-      for (UInt_t i=0; i<2; i++) {
-         TH1* hclone = (TH1F*)h[i]->Clone( TString(h[i]->GetName()) + "_nice" );
-         hclone->SetName ( TString(h[i]->GetName()) + "_nice" );
-         hclone->SetTitle( TString(h[i]->GetTitle()) + "" );
+      for (auto & i : h) {
+         TH1* hclone = (TH1F*)i->Clone( TString(i->GetName()) + "_nice" );
+         hclone->SetName ( TString(i->GetName()) + "_nice" );
+         hclone->SetTitle( TString(i->GetTitle()) + "" );
          if (hclone->GetNbinsX() > 100) {
             Int_t resFactor = 5;
             hclone->Rebin( resFactor );

--- a/tmva/tmva/src/MethodLikelihood.cxx
+++ b/tmva/tmva/src/MethodLikelihood.cxx
@@ -151,21 +151,21 @@ ClassImp(TMVA::MethodLikelihood);
    fEpsilon       ( 1.e3 * DBL_MIN ),
    fTransformLikelihoodOutput( kFALSE ),
    fDropVariable  ( 0 ),
-   fHistSig       ( 0 ),
-   fHistBgd       ( 0 ),
-   fHistSig_smooth( 0 ),
-   fHistBgd_smooth( 0 ),
-   fDefaultPDFLik ( 0 ),
-   fPDFSig        ( 0 ),
-   fPDFBgd        ( 0 ),
+   fHistSig       ( nullptr ),
+   fHistBgd       ( nullptr ),
+   fHistSig_smooth( nullptr ),
+   fHistBgd_smooth( nullptr ),
+   fDefaultPDFLik ( nullptr ),
+   fPDFSig        ( nullptr ),
+   fPDFBgd        ( nullptr ),
    fNsmooth       ( 2 ),
-   fNsmoothVarS   ( 0 ),
-   fNsmoothVarB   ( 0 ),
+   fNsmoothVarS   ( nullptr ),
+   fNsmoothVarB   ( nullptr ),
    fAverageEvtPerBin( 0 ),
-   fAverageEvtPerBinVarS (0),
-   fAverageEvtPerBinVarB (0),
+   fAverageEvtPerBinVarS (nullptr),
+   fAverageEvtPerBinVarB (nullptr),
    fKDEfineFactor ( 0 ),
-   fInterpolateString(0)
+   fInterpolateString(nullptr)
 {
 }
 
@@ -178,21 +178,21 @@ TMVA::MethodLikelihood::MethodLikelihood( DataSetInfo& theData,
    fEpsilon       ( 1.e3 * DBL_MIN ),
    fTransformLikelihoodOutput( kFALSE ),
    fDropVariable  ( 0 ),
-   fHistSig       ( 0 ),
-   fHistBgd       ( 0 ),
-   fHistSig_smooth( 0 ),
-   fHistBgd_smooth( 0 ),
-   fDefaultPDFLik ( 0 ),
-   fPDFSig        ( 0 ),
-   fPDFBgd        ( 0 ),
+   fHistSig       ( nullptr ),
+   fHistBgd       ( nullptr ),
+   fHistSig_smooth( nullptr ),
+   fHistBgd_smooth( nullptr ),
+   fDefaultPDFLik ( nullptr ),
+   fPDFSig        ( nullptr ),
+   fPDFBgd        ( nullptr ),
    fNsmooth       ( 2 ),
-   fNsmoothVarS   ( 0 ),
-   fNsmoothVarB   ( 0 ),
+   fNsmoothVarS   ( nullptr ),
+   fNsmoothVarB   ( nullptr ),
    fAverageEvtPerBin( 0 ),
-   fAverageEvtPerBinVarS (0),
-   fAverageEvtPerBinVarB (0),
+   fAverageEvtPerBinVarS (nullptr),
+   fAverageEvtPerBinVarB (nullptr),
    fKDEfineFactor ( 0 ),
-   fInterpolateString(0)
+   fInterpolateString(nullptr)
 {
 }
 
@@ -201,17 +201,17 @@ TMVA::MethodLikelihood::MethodLikelihood( DataSetInfo& theData,
 
 TMVA::MethodLikelihood::~MethodLikelihood( void )
 {
-   if (NULL != fDefaultPDFLik)  delete fDefaultPDFLik;
-   if (NULL != fHistSig)        delete fHistSig;
-   if (NULL != fHistBgd)        delete fHistBgd;
-   if (NULL != fHistSig_smooth) delete fHistSig_smooth;
-   if (NULL != fHistBgd_smooth) delete fHistBgd_smooth;
+   if (nullptr != fDefaultPDFLik)  delete fDefaultPDFLik;
+   if (nullptr != fHistSig)        delete fHistSig;
+   if (nullptr != fHistBgd)        delete fHistBgd;
+   if (nullptr != fHistSig_smooth) delete fHistSig_smooth;
+   if (nullptr != fHistBgd_smooth) delete fHistBgd_smooth;
    for (UInt_t ivar=0; ivar<GetNvar(); ivar++) {
-      if ((*fPDFSig)[ivar] !=0) delete (*fPDFSig)[ivar];
-      if ((*fPDFBgd)[ivar] !=0) delete (*fPDFBgd)[ivar];
+      if ((*fPDFSig)[ivar] !=nullptr) delete (*fPDFSig)[ivar];
+      if ((*fPDFBgd)[ivar] !=nullptr) delete (*fPDFBgd)[ivar];
    }
-   if (NULL != fPDFSig)         delete fPDFSig;
-   if (NULL != fPDFBgd)         delete fPDFBgd;
+   if (nullptr != fPDFSig)         delete fPDFSig;
+   if (nullptr != fPDFBgd)         delete fPDFBgd;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -231,12 +231,12 @@ void TMVA::MethodLikelihood::Init( void )
 {
    // no ranking test
    fDropVariable   = -1;
-   fHistSig        = new std::vector<TH1*>      ( GetNvar(), (TH1*)0 );
-   fHistBgd        = new std::vector<TH1*>      ( GetNvar(), (TH1*)0 );
-   fHistSig_smooth = new std::vector<TH1*>      ( GetNvar(), (TH1*)0 );
-   fHistBgd_smooth = new std::vector<TH1*>      ( GetNvar(), (TH1*)0 );
-   fPDFSig         = new std::vector<TMVA::PDF*>( GetNvar(), (TMVA::PDF*)0 );
-   fPDFBgd         = new std::vector<TMVA::PDF*>( GetNvar(), (TMVA::PDF*)0 );
+   fHistSig        = new std::vector<TH1*>      ( GetNvar(), (TH1*)nullptr );
+   fHistBgd        = new std::vector<TH1*>      ( GetNvar(), (TH1*)nullptr );
+   fHistSig_smooth = new std::vector<TH1*>      ( GetNvar(), (TH1*)nullptr );
+   fHistBgd_smooth = new std::vector<TH1*>      ( GetNvar(), (TH1*)nullptr );
+   fPDFSig         = new std::vector<TMVA::PDF*>( GetNvar(), (TMVA::PDF*)nullptr );
+   fPDFBgd         = new std::vector<TMVA::PDF*>( GetNvar(), (TMVA::PDF*)nullptr );
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -442,8 +442,8 @@ void TMVA::MethodLikelihood::Train( void )
       (*fPDFBgd)[ivar]->ValidatePDF( (*fHistBgd)[ivar] );
 
       // saving the smoothed histograms
-      if ((*fPDFSig)[ivar]->GetSmoothedHist() != 0) (*fHistSig_smooth)[ivar] = (*fPDFSig)[ivar]->GetSmoothedHist();
-      if ((*fPDFBgd)[ivar]->GetSmoothedHist() != 0) (*fHistBgd_smooth)[ivar] = (*fPDFBgd)[ivar]->GetSmoothedHist();
+      if ((*fPDFSig)[ivar]->GetSmoothedHist() != nullptr) (*fHistSig_smooth)[ivar] = (*fPDFSig)[ivar]->GetSmoothedHist();
+      if ((*fPDFBgd)[ivar]->GetSmoothedHist() != nullptr) (*fHistBgd_smooth)[ivar] = (*fPDFBgd)[ivar]->GetSmoothedHist();
    }
    ExitFromTraining();
 }
@@ -495,7 +495,7 @@ Double_t TMVA::MethodLikelihood::GetMvaValue( Double_t* err, Double_t* errUpper 
 
          // find corresponding histogram from cached indices
          PDF* pdf = (itype == 0) ? (*fPDFSig)[ivar] : (*fPDFBgd)[ivar];
-         if (pdf == 0) Log() << kFATAL << "<GetMvaValue> Reference histograms don't exist" << Endl;
+         if (pdf == nullptr) Log() << kFATAL << "<GetMvaValue> Reference histograms don't exist" << Endl;
          TH1* hist = pdf->GetPDFHist();
 
          // interpolate linearly between adjacent bins
@@ -563,16 +563,16 @@ void TMVA::MethodLikelihood::WriteOptionsToStream( std::ostream& o, const TStrin
    Configurable::WriteOptionsToStream( o, prefix);
 
    // writing the options defined for the different pdfs
-   if (fDefaultPDFLik != 0) {
+   if (fDefaultPDFLik != nullptr) {
       o << prefix << std::endl << prefix << "#Default Likelihood PDF Options:" << std::endl << prefix << std::endl;
       fDefaultPDFLik->WriteOptionsToStream( o, prefix );
    }
    for (UInt_t ivar = 0; ivar < fPDFSig->size(); ivar++) {
-      if ((*fPDFSig)[ivar] != 0) {
+      if ((*fPDFSig)[ivar] != nullptr) {
          o << prefix << std::endl << prefix << Form("#Signal[%d] Likelihood PDF Options:",ivar) << std::endl << prefix << std::endl;
          (*fPDFSig)[ivar]->WriteOptionsToStream( o, prefix );
       }
-      if ((*fPDFBgd)[ivar] != 0) {
+      if ((*fPDFBgd)[ivar] != nullptr) {
          o << prefix << std::endl << prefix << "#Background[%d] Likelihood PDF Options:" << std::endl << prefix << std::endl;
          (*fPDFBgd)[ivar]->WriteOptionsToStream( o, prefix );
       }
@@ -589,7 +589,7 @@ void TMVA::MethodLikelihood::AddWeightsXMLTo( void* parent ) const
    gTools().AddAttr(wght, "NClasses", 2);
    void* pdfwrap;
    for (UInt_t ivar=0; ivar<GetNvar(); ivar++) {
-      if ( (*fPDFSig)[ivar]==0 || (*fPDFBgd)[ivar]==0 )
+      if ( (*fPDFSig)[ivar]==nullptr || (*fPDFBgd)[ivar]==nullptr )
          Log() << kFATAL << "Reference histograms for variable " << ivar
                << " don't exist, can't write it to weight file" << Endl;
       pdfwrap = gTools().AddChild(wght, "PDFDescriptor");
@@ -679,8 +679,8 @@ void  TMVA::MethodLikelihood::ReadWeightsFromXML(void* wghtnode)
    for (UInt_t ivar=0; ivar<nvars; ivar++){
       void* pdfnode = gTools().GetChild(descnode);
       Log() << kDEBUG << "Reading signal and background PDF for variable: " << GetInputVar( ivar ) << Endl;
-      if ((*fPDFSig)[ivar] !=0) delete (*fPDFSig)[ivar];
-      if ((*fPDFBgd)[ivar] !=0) delete (*fPDFBgd)[ivar];
+      if ((*fPDFSig)[ivar] !=nullptr) delete (*fPDFSig)[ivar];
+      if ((*fPDFBgd)[ivar] !=nullptr) delete (*fPDFBgd)[ivar];
       (*fPDFSig)[ivar] = new PDF( GetInputVar( ivar ) + " PDF Sig" );
       (*fPDFBgd)[ivar] = new PDF( GetInputVar( ivar ) + " PDF Bkg" );
       (*fPDFSig)[ivar]->SetReadingVersion( GetTrainingTMVAVersionCode() );
@@ -705,8 +705,8 @@ void  TMVA::MethodLikelihood::ReadWeightsFromStream( std::istream & istr )
    TH1::AddDirectory(0); // this avoids the binding of the hists in TMVA::PDF to the current ROOT file
    for (UInt_t ivar=0; ivar<GetNvar(); ivar++){
       Log() << kDEBUG << "Reading signal and background PDF for variable: " << GetInputVar( ivar ) << Endl;
-      if ((*fPDFSig)[ivar] !=0) delete (*fPDFSig)[ivar];
-      if ((*fPDFBgd)[ivar] !=0) delete (*fPDFBgd)[ivar];
+      if ((*fPDFSig)[ivar] !=nullptr) delete (*fPDFSig)[ivar];
+      if ((*fPDFBgd)[ivar] !=nullptr) delete (*fPDFBgd)[ivar];
       (*fPDFSig)[ivar] = new PDF(GetInputVar( ivar ) + " PDF Sig" );
       (*fPDFBgd)[ivar] = new PDF(GetInputVar( ivar ) + " PDF Bkg");
       (*fPDFSig)[ivar]->SetReadingVersion( GetTrainingTMVAVersionCode() );
@@ -743,13 +743,13 @@ void  TMVA::MethodLikelihood::WriteMonitoringHistosToFile( void ) const
    for (UInt_t ivar=0; ivar<GetNvar(); ivar++) {
       (*fHistSig)[ivar]->Write();
       (*fHistBgd)[ivar]->Write();
-      if ((*fHistSig_smooth)[ivar] != 0) (*fHistSig_smooth)[ivar]->Write();
-      if ((*fHistBgd_smooth)[ivar] != 0) (*fHistBgd_smooth)[ivar]->Write();
+      if ((*fHistSig_smooth)[ivar] != nullptr) (*fHistSig_smooth)[ivar]->Write();
+      if ((*fHistBgd_smooth)[ivar] != nullptr) (*fHistBgd_smooth)[ivar]->Write();
       (*fPDFSig)[ivar]->GetPDFHist()->Write();
       (*fPDFBgd)[ivar]->GetPDFHist()->Write();
 
-      if ((*fPDFSig)[ivar]->GetNSmoothHist() != 0) (*fPDFSig)[ivar]->GetNSmoothHist()->Write();
-      if ((*fPDFBgd)[ivar]->GetNSmoothHist() != 0) (*fPDFBgd)[ivar]->GetNSmoothHist()->Write();
+      if ((*fPDFSig)[ivar]->GetNSmoothHist() != nullptr) (*fPDFSig)[ivar]->GetNSmoothHist()->Write();
+      if ((*fPDFBgd)[ivar]->GetNSmoothHist() != nullptr) (*fPDFBgd)[ivar]->GetNSmoothHist()->Write();
 
       // add special plots to check the smoothing in the GetVal method
       Float_t xmin=((*fPDFSig)[ivar]->GetPDFHist()->GetXaxis())->GetXmin();

--- a/tmva/tmva/src/MethodLikelihood.cxx
+++ b/tmva/tmva/src/MethodLikelihood.cxx
@@ -199,7 +199,7 @@ TMVA::MethodLikelihood::MethodLikelihood( DataSetInfo& theData,
 ////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
-TMVA::MethodLikelihood::~MethodLikelihood( void )
+TMVA::MethodLikelihood::~MethodLikelihood()
 {
    if (nullptr != fDefaultPDFLik)  delete fDefaultPDFLik;
    if (nullptr != fHistSig)        delete fHistSig;
@@ -227,7 +227,7 @@ Bool_t TMVA::MethodLikelihood::HasAnalysisType( Types::EAnalysisType type,
 ////////////////////////////////////////////////////////////////////////////////
 /// default initialisation called by all constructors
 
-void TMVA::MethodLikelihood::Init( void )
+void TMVA::MethodLikelihood::Init()
 {
    // no ranking test
    fDropVariable   = -1;
@@ -336,7 +336,7 @@ void TMVA::MethodLikelihood::ProcessOptions()
 /// the transformations are applied using both classes, also the corresponding boundaries
 /// need to take this into account
 
-void TMVA::MethodLikelihood::Train( void )
+void TMVA::MethodLikelihood::Train()
 {
    UInt_t nvar=GetNvar();
    std::vector<Double_t> xmin(nvar), xmax(nvar);
@@ -735,7 +735,7 @@ void  TMVA::MethodLikelihood::ReadWeightsFromStream( TFile& rf )
 ////////////////////////////////////////////////////////////////////////////////
 /// write histograms and PDFs to file for monitoring purposes
 
-void  TMVA::MethodLikelihood::WriteMonitoringHistosToFile( void ) const
+void  TMVA::MethodLikelihood::WriteMonitoringHistosToFile() const
 {
    Log() << kINFO << "Write monitoring histograms to file: " << BaseDir()->GetPath() << Endl;
    BaseDir()->cd();

--- a/tmva/tmva/src/MethodMLP.cxx
+++ b/tmva/tmva/src/MethodMLP.cxx
@@ -399,9 +399,9 @@ Double_t TMVA::MethodMLP::CalculateEstimator( Types::ETreeType treeType, Int_t i
 
       Float_t weightRangeCut = fWeightRange*sumOfWeights;
       Float_t weightSum      = 0.f;
-      for(std::vector<std::pair<Float_t,Float_t> >::iterator itDev = fDeviationsFromTargets->begin(), itDevEnd = fDeviationsFromTargets->end(); itDev != itDevEnd; ++itDev ){
-         float deviation = (*itDev).first;
-         float devWeight = (*itDev).second;
+      for(auto & fDeviationsFromTarget : *fDeviationsFromTargets){
+         float deviation = fDeviationsFromTarget.first;
+         float devWeight = fDeviationsFromTarget.second;
          weightSum += devWeight; // add the weight of this event
          if( weightSum <= weightRangeCut ) { // if within the region defined by fWeightRange
             estimator += devWeight*deviation;

--- a/tmva/tmva/src/MethodMLP.cxx
+++ b/tmva/tmva/src/MethodMLP.cxx
@@ -105,7 +105,7 @@ TMVA::MethodMLP::MethodMLP( const TString& jobName,
      fBatchSize(0), fTestRate(0), fEpochMon(false),
      fGA_nsteps(0), fGA_preCalc(0), fGA_SC_steps(0),
      fGA_SC_rate(0), fGA_SC_factor(0.0),
-     fDeviationsFromTargets(0),
+     fDeviationsFromTargets(nullptr),
      fWeightRange     (1.0)
 {
 
@@ -128,7 +128,7 @@ TMVA::MethodMLP::MethodMLP( DataSetInfo& theData,
      fBatchSize(0), fTestRate(0), fEpochMon(false),
      fGA_nsteps(0), fGA_preCalc(0), fGA_SC_steps(0),
      fGA_SC_rate(0), fGA_SC_factor(0.0),
-     fDeviationsFromTargets(0),
+     fDeviationsFromTargets(nullptr),
      fWeightRange     (1.0)
 {
 }
@@ -308,8 +308,8 @@ Double_t TMVA::MethodMLP::CalculateEstimator( Types::ETreeType treeType, Int_t i
    TString nameS = name + "_S";
    Int_t   nbin  = 100;
    Float_t limit = 2;
-   TH1*    histS = 0;
-   TH1*    histB = 0;
+   TH1*    histS = nullptr;
+   TH1*    histB = nullptr;
    if (fEpochMon && iEpoch >= 0 && !DoRegression()) {
       histS = new TH1F( nameS, nameS, nbin, -limit, limit );
       histB = new TH1F( nameB, nameB, nbin, -limit, limit );
@@ -386,8 +386,8 @@ Double_t TMVA::MethodMLP::CalculateEstimator( Types::ETreeType treeType, Int_t i
 
 
       // fill monitoring histograms
-      if (DataInfo().IsSignal(ev) && histS != 0) histS->Fill( float(v), float(w) );
-      else if              (histB != 0) histB->Fill( float(v), float(w) );
+      if (DataInfo().IsSignal(ev) && histS != nullptr) histS->Fill( float(v), float(w) );
+      else if              (histB != nullptr) histB->Fill( float(v), float(w) );
    }
 
 
@@ -412,8 +412,8 @@ Double_t TMVA::MethodMLP::CalculateEstimator( Types::ETreeType treeType, Int_t i
       delete fDeviationsFromTargets;
    }
 
-   if (histS != 0) fEpochMonHistS.push_back( histS );
-   if (histB != 0) fEpochMonHistB.push_back( histB );
+   if (histS != nullptr) fEpochMonHistS.push_back( histS );
+   if (histB != nullptr) fEpochMonHistB.push_back( histB );
 
    //if      (DoRegression()) estimator = TMath::Sqrt(estimator/Float_t(nEvents));
    //else if (DoMulticlass()) estimator = TMath::Sqrt(estimator/Float_t(nEvents));
@@ -439,7 +439,7 @@ Double_t TMVA::MethodMLP::CalculateEstimator( Types::ETreeType treeType, Int_t i
 
 void TMVA::MethodMLP::Train(Int_t nEpochs)
 {
-   if (fNetwork == 0) {
+   if (fNetwork == nullptr) {
       //Log() << kERROR <<"ANN Network is not initialized, doing it now!"<< Endl;
       Log() << kFATAL <<"ANN Network is not initialized, doing it now!"<< Endl;
       SetAnalysisType(GetAnalysisType());
@@ -1555,7 +1555,7 @@ Double_t TMVA::MethodMLP::GetMvaValue( Double_t* errLower, Double_t* errUpper )
    Double_t MvaValue = MethodANNBase::GetMvaValue();// contains back propagation
 
    // no hessian (old training file) or no error requested
-   if (!fCalculateErrors || errLower==0 || errUpper==0)
+   if (!fCalculateErrors || errLower==nullptr || errUpper==nullptr)
       return MvaValue;
 
    Double_t MvaUpper,MvaLower,median,variance;

--- a/tmva/tmva/src/MethodPDEFoam.cxx
+++ b/tmva/tmva/src/MethodPDEFoam.cxx
@@ -168,7 +168,7 @@ Bool_t TMVA::MethodPDEFoam::HasAnalysisType( Types::EAnalysisType type, UInt_t n
 ////////////////////////////////////////////////////////////////////////////////
 /// default initialization called by all constructors
 
-void TMVA::MethodPDEFoam::Init( void )
+void TMVA::MethodPDEFoam::Init()
 {
    // init PDEFoam options
    fSigBgSeparated = kFALSE;   // default: unified foam
@@ -307,7 +307,7 @@ void TMVA::MethodPDEFoam::ProcessOptions()
 ////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
-TMVA::MethodPDEFoam::~MethodPDEFoam( void )
+TMVA::MethodPDEFoam::~MethodPDEFoam()
 {
    DeleteFoams();
 
@@ -427,7 +427,7 @@ void TMVA::MethodPDEFoam::CalcXminXmax()
 ////////////////////////////////////////////////////////////////////////////////
 /// Train PDE-Foam depending on the set options
 
-void TMVA::MethodPDEFoam::Train( void )
+void TMVA::MethodPDEFoam::Train()
 {
    Log() << kVERBOSE << "Calculate Xmin and Xmax for every dimension" << Endl;
    CalcXminXmax();
@@ -1143,7 +1143,7 @@ void TMVA::MethodPDEFoam::Reset()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TMVA::MethodPDEFoam::PrintCoefficients( void )
+void TMVA::MethodPDEFoam::PrintCoefficients()
 {}
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/src/MethodPDEFoam.cxx
+++ b/tmva/tmva/src/MethodPDEFoam.cxx
@@ -465,9 +465,9 @@ void TMVA::MethodPDEFoam::Train( void )
    }
 
    // delete the binary search tree in order to save memory
-   for(UInt_t i=0; i<fFoam.size(); i++) {
-      if(fFoam.at(i))
-         fFoam.at(i)->DeleteBinarySearchTree();
+   for(auto & i : fFoam) {
+      if(i)
+         i->DeleteBinarySearchTree();
    }
    ExitFromTraining();
 }
@@ -827,10 +827,10 @@ const TMVA::Ranking* TMVA::MethodPDEFoam::CreateRanking()
    std::vector<Float_t> importance(GetNvar(), 0);
 
    // determine variable importances
-   for (UInt_t ifoam = 0; ifoam < fFoam.size(); ++ifoam) {
+   for (auto & ifoam : fFoam) {
       // get the number of cuts made in every dimension of foam
-      PDEFoamCell *root_cell = fFoam.at(ifoam)->GetRootCell();
-      std::vector<UInt_t> nCuts(fFoam.at(ifoam)->GetTotDim(), 0);
+      PDEFoamCell *root_cell = ifoam->GetRootCell();
+      std::vector<UInt_t> nCuts(ifoam->GetTotDim(), 0);
       GetNCuts(root_cell, nCuts);
 
       // fill the importance vector (ignoring the target dimensions in
@@ -1072,8 +1072,8 @@ const std::vector<Float_t>& TMVA::MethodPDEFoam::GetRegressionValues()
       if (targets.size() != Data()->GetNTargets())
          Log() << kFATAL << "Something wrong with multi-target regression foam: "
                << "number of targets does not match the DataSet()" << Endl;
-      for(UInt_t i=0; i<targets.size(); i++)
-         fRegressionReturnVal->push_back(targets.at(i));
+      for(float target : targets)
+         fRegressionReturnVal->push_back(target);
    }
    else {
       fRegressionReturnVal->push_back(fFoam.at(0)->GetCellValue(vals, kValue, fKernelEstimator));
@@ -1120,8 +1120,8 @@ TMVA::PDEFoamKernelBase* TMVA::MethodPDEFoam::CreatePDEFoamKernel()
 
 void TMVA::MethodPDEFoam::DeleteFoams()
 {
-   for (UInt_t i=0; i<fFoam.size(); i++)
-      if (fFoam.at(i)) delete fFoam.at(i);
+   for (auto & i : fFoam)
+      if (i) delete i;
    fFoam.clear();
 }
 
@@ -1210,10 +1210,10 @@ void TMVA::MethodPDEFoam::WriteFoamsToFile() const
    else           rootFile = new TFile(rfname, "RECREATE");
 
    // write the foams
-   for (UInt_t i=0; i<fFoam.size(); ++i) {
-      Log() << "writing foam " << fFoam.at(i)->GetFoamName().Data()
+   for (auto i : fFoam) {
+      Log() << "writing foam " << i->GetFoamName().Data()
             << " to file" << Endl;
-      fFoam.at(i)->Write(fFoam.at(i)->GetFoamName().Data());
+      i->Write(i->GetFoamName().Data());
    }
 
    rootFile->Close();
@@ -1483,12 +1483,12 @@ TMVA::ETargetSelection TMVA::MethodPDEFoam::UIntToTargetSelection(UInt_t its)
 
 void TMVA::MethodPDEFoam::FillVariableNamesToFoam() const
 {
-   for (UInt_t ifoam=0; ifoam<fFoam.size(); ifoam++) {
-      for (Int_t idim=0; idim<fFoam.at(ifoam)->GetTotDim(); idim++) {
+   for (auto ifoam : fFoam) {
+      for (Int_t idim=0; idim<ifoam->GetTotDim(); idim++) {
          if(fMultiTargetRegression && (UInt_t)idim>=DataInfo().GetNVariables())
-            fFoam.at(ifoam)->AddVariableName(DataInfo().GetTargetInfo(idim-DataInfo().GetNVariables()).GetExpression().Data());
+            ifoam->AddVariableName(DataInfo().GetTargetInfo(idim-DataInfo().GetNVariables()).GetExpression().Data());
          else
-            fFoam.at(ifoam)->AddVariableName(DataInfo().GetVariableInfo(idim).GetExpression().Data());
+            ifoam->AddVariableName(DataInfo().GetVariableInfo(idim).GetExpression().Data());
       }
    }
 }

--- a/tmva/tmva/src/MethodPDEFoam.cxx
+++ b/tmva/tmva/src/MethodPDEFoam.cxx
@@ -103,7 +103,7 @@ ClassImp(TMVA::MethodPDEFoam);
    , fMaxDepth(0)
    , fKernelStr("None")
    , fKernel(kNone)
-   , fKernelEstimator(NULL)
+   , fKernelEstimator(nullptr)
    , fTargetSelectionStr("Mean")
    , fTargetSelection(kMean)
    , fFillFoamWithOrigWeights(kFALSE)
@@ -139,7 +139,7 @@ TMVA::MethodPDEFoam::MethodPDEFoam( DataSetInfo& dsi,
    , fMaxDepth(0)
    , fKernelStr("None")
    , fKernel(kNone)
-   , fKernelEstimator(NULL)
+   , fKernelEstimator(nullptr)
    , fTargetSelectionStr("Mean")
    , fTargetSelection(kMean)
    , fFillFoamWithOrigWeights(kFALSE)
@@ -188,7 +188,7 @@ void TMVA::MethodPDEFoam::Init( void )
    fDTSeparation   = kFoam;    // separation type
 
    fKernel         = kNone; // default: use no kernel
-   fKernelEstimator= NULL;  // kernel estimator used during evaluation
+   fKernelEstimator= nullptr;  // kernel estimator used during evaluation
    fTargetSelection= kMean; // default: use mean for target selection (only multi target regression!)
 
    fCompress              = kTRUE;  // compress ROOT output file
@@ -311,7 +311,7 @@ TMVA::MethodPDEFoam::~MethodPDEFoam( void )
 {
    DeleteFoams();
 
-   if (fKernelEstimator != NULL)
+   if (fKernelEstimator != nullptr)
       delete fKernelEstimator;
 }
 
@@ -733,8 +733,8 @@ Double_t TMVA::MethodPDEFoam::GetMvaValue( Double_t* err, Double_t* errUpper )
    // calculate the error
    if (err || errUpper) {
       const Double_t discr_error = CalculateMVAError();
-      if (err != 0) *err = discr_error;
-      if (errUpper != 0) *errUpper = discr_error;
+      if (err != nullptr) *err = discr_error;
+      if (errUpper != nullptr) *errUpper = discr_error;
    }
 
    if (fUseYesNoCell)
@@ -791,7 +791,7 @@ const std::vector<Float_t>& TMVA::MethodPDEFoam::GetMulticlassValues()
    const TMVA::Event *ev = GetEvent();
    std::vector<Float_t> xvec = ev->GetValues();
 
-   if (fMulticlassReturnVal == NULL)
+   if (fMulticlassReturnVal == nullptr)
       fMulticlassReturnVal = new std::vector<Float_t>();
    fMulticlassReturnVal->clear();
    fMulticlassReturnVal->reserve(DataInfo().GetNClasses());
@@ -875,14 +875,14 @@ const TMVA::Ranking* TMVA::MethodPDEFoam::CreateRanking()
 
 void TMVA::MethodPDEFoam::GetNCuts(PDEFoamCell *cell, std::vector<UInt_t> &nCuts)
 {
-   if (cell == NULL || cell->GetStat() == 1) // cell is active
+   if (cell == nullptr || cell->GetStat() == 1) // cell is active
       return;
 
    nCuts.at(cell->GetBest())++;
 
-   if (cell->GetDau0() != NULL)
+   if (cell->GetDau0() != nullptr)
       GetNCuts(cell->GetDau0(), nCuts);
-   if (cell->GetDau1() != NULL)
+   if (cell->GetDau1() != nullptr)
       GetNCuts(cell->GetDau1(), nCuts);
 }
 
@@ -948,8 +948,8 @@ TMVA::PDEFoam* TMVA::MethodPDEFoam::InitFoam(TString foamcaption, EFoamType ft, 
    }
 
    // create PDEFoam and PDEFoamDensityBase
-   PDEFoam *pdefoam = NULL;
-   PDEFoamDensityBase *density = NULL;
+   PDEFoam *pdefoam = nullptr;
+   PDEFoamDensityBase *density = nullptr;
    if (fDTSeparation == kFoam) {
       // use PDEFoam algorithm
       switch (ft) {
@@ -979,7 +979,7 @@ TMVA::PDEFoam* TMVA::MethodPDEFoam::InitFoam(TString foamcaption, EFoamType ft, 
 
       // create separation type class, which is owned by
       // PDEFoamDecisionTree (i.e. PDEFoamDecisionTree will delete it)
-      SeparationBase *sepType = NULL;
+      SeparationBase *sepType = nullptr;
       switch (fDTSeparation) {
       case kGiniIndex:
          sepType = new GiniIndex();
@@ -1049,7 +1049,7 @@ TMVA::PDEFoam* TMVA::MethodPDEFoam::InitFoam(TString foamcaption, EFoamType ft, 
 
 const std::vector<Float_t>& TMVA::MethodPDEFoam::GetRegressionValues()
 {
-   if (fRegressionReturnVal == 0) fRegressionReturnVal = new std::vector<Float_t>();
+   if (fRegressionReturnVal == nullptr) fRegressionReturnVal = new std::vector<Float_t>();
    fRegressionReturnVal->clear();
    fRegressionReturnVal->reserve(Data()->GetNTargets());
 
@@ -1110,9 +1110,9 @@ TMVA::PDEFoamKernelBase* TMVA::MethodPDEFoam::CreatePDEFoamKernel()
       return new PDEFoamKernelGauss(fVolFrac/2.0);
    default:
       Log() << kFATAL << "Kernel: " << fKernel << " not supported!" << Endl;
-      return NULL;
+      return nullptr;
    }
-   return NULL;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1135,9 +1135,9 @@ void TMVA::MethodPDEFoam::Reset()
 {
    DeleteFoams();
 
-   if (fKernelEstimator != NULL) {
+   if (fKernelEstimator != nullptr) {
       delete fKernelEstimator;
-      fKernelEstimator = NULL;
+      fKernelEstimator = nullptr;
    }
 }
 
@@ -1205,7 +1205,7 @@ void TMVA::MethodPDEFoam::WriteFoamsToFile() const
    // add foam indicator to distinguish from main weight file
    rfname.ReplaceAll( ".xml", "_foams.root" );
 
-   TFile *rootFile = 0;
+   TFile *rootFile = nullptr;
    if (fCompress) rootFile = new TFile(rfname, "RECREATE", "foamfile", 9);
    else           rootFile = new TFile(rfname, "RECREATE");
 
@@ -1348,7 +1348,7 @@ void TMVA::MethodPDEFoam::ReadWeightsFromXML( void* wghtnode )
    ReadFoamsFromFile();
 
    // recreate the pdefoam kernel estimator
-   if (fKernelEstimator != NULL)
+   if (fKernelEstimator != nullptr)
       delete fKernelEstimator;
    fKernelEstimator = CreatePDEFoamKernel();
 }
@@ -1373,22 +1373,22 @@ void TMVA::MethodPDEFoam::ReadWeightsFromXML( void* wghtnode )
 
 TMVA::PDEFoam* TMVA::MethodPDEFoam::ReadClonedFoamFromFile(TFile* file, const TString& foamname)
 {
-   if (file == NULL) {
+   if (file == nullptr) {
       Log() << kWARNING << "<ReadClonedFoamFromFile>: NULL pointer given" << Endl;
-      return NULL;
+      return nullptr;
    }
 
    // try to load the foam from the file
    PDEFoam *foam = (PDEFoam*) file->Get(foamname);
-   if (foam == NULL) {
-      return NULL;
+   if (foam == nullptr) {
+      return nullptr;
    }
    // try to clone the foam
    foam = (PDEFoam*) foam->Clone();
-   if (foam == NULL) {
+   if (foam == nullptr) {
       Log() << kWARNING << "<ReadClonedFoamFromFile>: " << foamname
             << " could not be cloned!" << Endl;
-      return NULL;
+      return nullptr;
    }
 
    return foam;
@@ -1425,7 +1425,7 @@ void TMVA::MethodPDEFoam::ReadFoamsFromFile()
       } else {
          // try to load discriminator foam
          PDEFoam *foam = ReadClonedFoamFromFile(rootFile, "DiscrFoam");
-         if (foam != NULL)
+         if (foam != nullptr)
             fFoam.push_back(foam);
          else {
             // load multiclass foams

--- a/tmva/tmva/src/MethodPDERS.cxx
+++ b/tmva/tmva/src/MethodPDERS.cxx
@@ -411,8 +411,8 @@ const std::vector< Float_t >& TMVA::MethodPDERS::GetRegressionValues()
 
    Event * evT = new Event(*ev);
    UInt_t ivar = 0;
-   for (std::vector<Float_t>::iterator it = fRegressionReturnVal->begin(); it != fRegressionReturnVal->end(); ++it ) {
-      evT->SetTarget(ivar,(*it));
+   for (float & it : *fRegressionReturnVal) {
+      evT->SetTarget(ivar,it);
       ivar++;
    }
 
@@ -755,11 +755,11 @@ void TMVA::MethodPDERS::GetSample( const Event& e,
 
          //getting all elements that are closer than fkNNMin-th element
          //signals
-         for (Int_t j=0;j<Int_t(events.size());j++) {
-            Double_t dist = GetNormalizedDistance( e, *events[j], dim_normalization );
+         for (auto & event : events) {
+            Double_t dist = GetNormalizedDistance( e, *event, dim_normalization );
 
             if (dist <= (*distances)[fkNNMin-1])
-               tempVector.push_back( events[j] );
+               tempVector.push_back( event );
          }
          fMax_distance = (*distances)[fkNNMin-1];
          delete distances;
@@ -844,19 +844,19 @@ Double_t TMVA::MethodPDERS::CKernelEstimate( const Event & event,
    Double_t pdfSumB = 0;
 
    // Iteration over sample points
-   for (std::vector<const BinarySearchTreeNode*>::iterator iev = events.begin(); iev != events.end(); ++iev) {
+   for (auto & iev : events) {
 
       // First switch to the one dimensional distance
-      Double_t normalized_distance = GetNormalizedDistance (event, *(*iev), dim_normalization);
+      Double_t normalized_distance = GetNormalizedDistance (event, *iev, dim_normalization);
 
       // always working within the hyperelipsoid, except for when we don't
       // note that rejection ratio goes to 1 as nvar goes to infinity
       if (normalized_distance > 1 && fKernelEstimator != kBox) continue;
 
-      if ( (*iev)->GetClass()==fSignalClass )
-         pdfSumS += ApplyKernelFunction (normalized_distance) * (*iev)->GetWeight();
+      if ( iev->GetClass()==fSignalClass )
+         pdfSumS += ApplyKernelFunction (normalized_distance) * iev->GetWeight();
       else
-         pdfSumB += ApplyKernelFunction (normalized_distance) * (*iev)->GetWeight();
+         pdfSumB += ApplyKernelFunction (normalized_distance) * iev->GetWeight();
    }
    pdfSumS = KernelNormalization( pdfSumS < 0. ? 0. : pdfSumS );
    pdfSumB = KernelNormalization( pdfSumB < 0. ? 0. : pdfSumB );
@@ -891,18 +891,18 @@ void TMVA::MethodPDERS::RKernelEstimate( const Event & event,
       pdfSum->push_back( 0 );
 
    // Iteration over sample points
-   for (std::vector<const BinarySearchTreeNode*>::iterator iev = events.begin(); iev != events.end(); ++iev) {
+   for (auto & iev : events) {
 
       // First switch to the one dimensional distance
-      Double_t normalized_distance = GetNormalizedDistance (event, *(*iev), dim_normalization);
+      Double_t normalized_distance = GetNormalizedDistance (event, *iev, dim_normalization);
 
       // always working within the hyperelipsoid, except for when we don't
       // note that rejection ratio goes to 1 as nvar goes to infinity
       if (normalized_distance > 1 && fKernelEstimator != kBox) continue;
 
       for (Int_t ivar = 0; ivar < fNRegOut ; ivar++) {
-         pdfSum->at(ivar) += ApplyKernelFunction (normalized_distance) * (*iev)->GetWeight() * (*iev)->GetTargets()[ivar];
-         pdfDiv           += ApplyKernelFunction (normalized_distance) * (*iev)->GetWeight();
+         pdfSum->at(ivar) += ApplyKernelFunction (normalized_distance) * iev->GetWeight() * iev->GetTargets()[ivar];
+         pdfDiv           += ApplyKernelFunction (normalized_distance) * iev->GetWeight();
       }
    }
 

--- a/tmva/tmva/src/MethodPDERS.cxx
+++ b/tmva/tmva/src/MethodPDERS.cxx
@@ -175,7 +175,7 @@ Bool_t TMVA::MethodPDERS::HasAnalysisType( Types::EAnalysisType type, UInt_t num
 ////////////////////////////////////////////////////////////////////////////////
 /// default initialisation routine called by all constructors
 
-void TMVA::MethodPDERS::Init( void )
+void TMVA::MethodPDERS::Init()
 {
    fBinaryTree = nullptr;
 
@@ -207,7 +207,7 @@ void TMVA::MethodPDERS::Init( void )
 ////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
-TMVA::MethodPDERS::~MethodPDERS( void )
+TMVA::MethodPDERS::~MethodPDERS()
 {
    if (fDelta) delete fDelta;
    if (fShift) delete fShift;
@@ -349,7 +349,7 @@ void TMVA::MethodPDERS::ProcessOptions()
 /// trainingTree in the weight file, and to rebuild the binary tree in the
 /// test phase from scratch
 
-void TMVA::MethodPDERS::Train( void )
+void TMVA::MethodPDERS::Train()
 {
    if (IsNormalised()) Log() << kFATAL << "\"Normalise\" option cannot be used with PDERS; "
                              << "please remove the option from the configuration string, or "
@@ -480,7 +480,7 @@ void TMVA::MethodPDERS::CreateBinarySearchTree( Types::ETreeType type )
 ////////////////////////////////////////////////////////////////////////////////
 /// defines volume dimensions
 
-void TMVA::MethodPDERS::SetVolumeElement( void ) {
+void TMVA::MethodPDERS::SetVolumeElement() {
    if (GetNvar()==0) {
       Log() << kFATAL << "GetNvar() == 0" << Endl;
       return;
@@ -1181,14 +1181,14 @@ void TMVA::MethodPDERS::ReadWeightsFromStream( TFile& /*rf*/ )
 ////////////////////////////////////////////////////////////////////////////////
 /// static pointer to this object
 
-TMVA::MethodPDERS* TMVA::MethodPDERS::ThisPDERS( void )
+TMVA::MethodPDERS* TMVA::MethodPDERS::ThisPDERS()
 {
    return GetMethodPDERSThreadLocal();
 }
 ////////////////////////////////////////////////////////////////////////////////
 /// update static this pointer
 
-void TMVA::MethodPDERS::UpdateThis( void )
+void TMVA::MethodPDERS::UpdateThis()
 {
    GetMethodPDERSThreadLocal() = this;
 }

--- a/tmva/tmva/src/MethodPDERS.cxx
+++ b/tmva/tmva/src/MethodPDERS.cxx
@@ -107,8 +107,8 @@ ClassImp(TMVA::MethodPDERS);
    fFcnCall(0),
    fVRangeMode(kAdaptive),
    fKernelEstimator(kBox),
-   fDelta(0),
-   fShift(0),
+   fDelta(nullptr),
+   fShift(nullptr),
    fScaleS(0),
    fScaleB(0),
    fDeltaFrac(0),
@@ -126,8 +126,8 @@ ClassImp(TMVA::MethodPDERS);
    fPrinted(0),
    fNormTree(0)
 {
-      fHelpVolume = NULL;
-      fBinaryTree = NULL;
+      fHelpVolume = nullptr;
+      fBinaryTree = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -139,8 +139,8 @@ TMVA::MethodPDERS::MethodPDERS( DataSetInfo& theData,
    fFcnCall(0),
    fVRangeMode(kAdaptive),
    fKernelEstimator(kBox),
-   fDelta(0),
-   fShift(0),
+   fDelta(nullptr),
+   fShift(nullptr),
    fScaleS(0),
    fScaleB(0),
    fDeltaFrac(0),
@@ -158,8 +158,8 @@ TMVA::MethodPDERS::MethodPDERS( DataSetInfo& theData,
    fPrinted(0),
    fNormTree(0)
 {
-      fHelpVolume = NULL;
-      fBinaryTree = NULL;
+      fHelpVolume = nullptr;
+      fBinaryTree = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -177,7 +177,7 @@ Bool_t TMVA::MethodPDERS::HasAnalysisType( Types::EAnalysisType type, UInt_t num
 
 void TMVA::MethodPDERS::Init( void )
 {
-   fBinaryTree = NULL;
+   fBinaryTree = nullptr;
 
    UpdateThis();
 
@@ -212,7 +212,7 @@ TMVA::MethodPDERS::~MethodPDERS( void )
    if (fDelta) delete fDelta;
    if (fShift) delete fShift;
 
-   if (NULL != fBinaryTree) delete fBinaryTree;
+   if (nullptr != fBinaryTree) delete fBinaryTree;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -391,7 +391,7 @@ Double_t TMVA::MethodPDERS::GetMvaValue( Double_t* err, Double_t* errUpper )
 
 const std::vector< Float_t >& TMVA::MethodPDERS::GetRegressionValues()
 {
-   if (fRegressionReturnVal == 0) fRegressionReturnVal = new std::vector<Float_t>;
+   if (fRegressionReturnVal == nullptr) fRegressionReturnVal = new std::vector<Float_t>;
    fRegressionReturnVal->clear();
    // init the size of a volume element using a defined fraction of the
    // volume containing the entire events
@@ -456,7 +456,7 @@ void TMVA::MethodPDERS::CalcAverages()
 
 void TMVA::MethodPDERS::CreateBinarySearchTree( Types::ETreeType type )
 {
-   if (NULL != fBinaryTree) delete fBinaryTree;
+   if (nullptr != fBinaryTree) delete fBinaryTree;
    fBinaryTree = new BinarySearchTree();
    if (fNormTree) {
       fBinaryTree->SetNormalize( kTRUE );
@@ -619,7 +619,7 @@ void TMVA::MethodPDERS::GetSample( const Event& e,
 
          fBinaryTree->SearchVolume( volume, &events );
 
-         fHelpVolume = NULL;
+         fHelpVolume = nullptr;
       }
       // -----------------------------------------------------------------------
       else {
@@ -1112,7 +1112,7 @@ void TMVA::MethodPDERS::AddWeightsXMLTo( void* parent ) const
 
 void TMVA::MethodPDERS::ReadWeightsFromXML( void* wghtnode)
 {
-   if (NULL != fBinaryTree) delete fBinaryTree;
+   if (nullptr != fBinaryTree) delete fBinaryTree;
    void* treenode = gTools().GetChild(wghtnode);
    fBinaryTree = TMVA::BinarySearchTree::CreateFromXML(treenode);
    if(!fBinaryTree)
@@ -1139,7 +1139,7 @@ void TMVA::MethodPDERS::ReadWeightsFromXML( void* wghtnode)
 
 void TMVA::MethodPDERS::ReadWeightsFromStream( std::istream& istr)
 {
-   if (NULL != fBinaryTree) delete fBinaryTree;
+   if (nullptr != fBinaryTree) delete fBinaryTree;
 
    fBinaryTree = new BinarySearchTree();
 

--- a/tmva/tmva/src/MethodPlugins.cxx
+++ b/tmva/tmva/src/MethodPlugins.cxx
@@ -63,8 +63,8 @@ namespace
    TMVA::IMethod* CreateMethodPlugins(const TString& jobName, const TString& methodTitle, TMVA::DataSetInfo& theData, const TString& theOption)
    {
       //std::cout << "CreateMethodPlugins is called with options : '" << jobName << "', '" << methodTitle<< "', " << theOption<< "'" << std::endl;
-      TPluginManager *pluginManager(0);
-      TPluginHandler *pluginHandler(0);
+      TPluginManager *pluginManager(nullptr);
+      TPluginHandler *pluginHandler(nullptr);
       pluginManager = gROOT->GetPluginManager();
       //An empty methodTitle is a Problem for the PluginHandler, so we need to fiddle it out of the weightsfilename
       TString myMethodTitle;
@@ -80,7 +80,7 @@ namespace
       if(!pluginHandler)
          {
             std::cerr <<  "Couldn't find plugin handler for TMVA@@MethodBase and " << methodTitle << std::endl;
-            return 0;
+            return nullptr;
          }
       //std::cout << "pluginHandler found myMethodTitle=" << myMethodTitle<<std::endl;
       if (pluginHandler->LoadPlugin() == 0) {
@@ -94,7 +94,7 @@ namespace
          }
       }
       //std::cout << "plugin done" << std::endl;
-      return 0; // end of function should never be reached. This is here to silence the compiler
+      return nullptr; // end of function should never be reached. This is here to silence the compiler
    }
 
    struct registration {

--- a/tmva/tmva/src/MethodRuleFit.cxx
+++ b/tmva/tmva/src/MethodRuleFit.cxx
@@ -166,7 +166,7 @@ TMVA::MethodRuleFit::MethodRuleFit( DataSetInfo& theData,
 ////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
-TMVA::MethodRuleFit::~MethodRuleFit( void )
+TMVA::MethodRuleFit::~MethodRuleFit()
 {
    for (auto & i : fEventSample) delete i;
    for (auto & i : fForest)      delete i;
@@ -419,7 +419,7 @@ void TMVA::MethodRuleFit::Init()
 /// This method should never be called without existing trainingTree, as it
 /// the vector of events from the ROOT training tree
 
-void TMVA::MethodRuleFit::InitEventSample( void )
+void TMVA::MethodRuleFit::InitEventSample()
 {
    if (Data()->GetNEvents()==0) Log() << kFATAL << "<Init> Data().TrainingTree() is zero pointer" << Endl;
 
@@ -441,7 +441,7 @@ void TMVA::MethodRuleFit::InitEventSample( void )
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TMVA::MethodRuleFit::Train( void )
+void TMVA::MethodRuleFit::Train()
 {
    TMVA::DecisionTreeNode::fgIsTraining=true;
    // training of rules
@@ -465,7 +465,7 @@ void TMVA::MethodRuleFit::Train( void )
 ////////////////////////////////////////////////////////////////////////////////
 /// training of rules using TMVA implementation
 
-void TMVA::MethodRuleFit::TrainTMVARuleFit( void )
+void TMVA::MethodRuleFit::TrainTMVARuleFit()
 {
    if (IsNormalised()) Log() << kFATAL << "\"Normalise\" option cannot be used with RuleFit; "
                              << "please remove the option from the configuration string, or "
@@ -533,7 +533,7 @@ void TMVA::MethodRuleFit::TrainTMVARuleFit( void )
 ////////////////////////////////////////////////////////////////////////////////
 /// training of rules using Jerome Friedmans implementation
 
-void TMVA::MethodRuleFit::TrainJFRuleFit( void )
+void TMVA::MethodRuleFit::TrainJFRuleFit()
 {
    fRuleFit.InitPtrs( this );
    Data()->SetCurrentType(Types::kTraining);
@@ -626,7 +626,7 @@ Double_t TMVA::MethodRuleFit::GetMvaValue( Double_t* err, Double_t* errUpper )
 ////////////////////////////////////////////////////////////////////////////////
 /// write special monitoring histograms to file (here ntuple)
 
-void  TMVA::MethodRuleFit::WriteMonitoringHistosToFile( void ) const
+void  TMVA::MethodRuleFit::WriteMonitoringHistosToFile() const
 {
    BaseDir()->cd();
    Log() << kINFO << "Write monitoring ntuple to file: " << BaseDir()->GetPath() << Endl;

--- a/tmva/tmva/src/MethodRuleFit.cxx
+++ b/tmva/tmva/src/MethodRuleFit.cxx
@@ -168,8 +168,8 @@ TMVA::MethodRuleFit::MethodRuleFit( DataSetInfo& theData,
 
 TMVA::MethodRuleFit::~MethodRuleFit( void )
 {
-   for (UInt_t i=0; i<fEventSample.size(); i++) delete fEventSample[i];
-   for (UInt_t i=0; i<fForest.size(); i++)      delete fForest[i];
+   for (auto & i : fEventSample) delete i;
+   for (auto & i : fForest)      delete i;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/src/MethodRuleFit.cxx
+++ b/tmva/tmva/src/MethodRuleFit.cxx
@@ -91,7 +91,7 @@ ClassImp(TMVA::MethodRuleFit);
    , fRFNendnodes(0)
    , fNTrees(0)
    , fTreeEveFrac(0)
-   , fSepType(0)
+   , fSepType(nullptr)
    , fMinFracNEve(0)
    , fMaxFracNEve(0)
    , fNCuts(0)
@@ -112,7 +112,7 @@ ClassImp(TMVA::MethodRuleFit);
    , fRuleMinDist(0)
    , fLinQuantile(0)
 {
-      fMonitorNtuple = NULL;
+      fMonitorNtuple = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -139,7 +139,7 @@ TMVA::MethodRuleFit::MethodRuleFit( DataSetInfo& theData,
    , fRFNendnodes(0)
    , fNTrees(0)
    , fTreeEveFrac(0)
-   , fSepType(0)
+   , fSepType(nullptr)
    , fMinFracNEve(0)
    , fMaxFracNEve(0)
    , fNCuts(0)
@@ -160,7 +160,7 @@ TMVA::MethodRuleFit::MethodRuleFit( DataSetInfo& theData,
    , fRuleMinDist(0)
    , fLinQuantile(0)
 {
-      fMonitorNtuple = NULL;
+      fMonitorNtuple = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/src/MethodSVM.cxx
+++ b/tmva/tmva/src/MethodSVM.cxx
@@ -171,7 +171,7 @@ TMVA::MethodSVM::~MethodSVM()
 ////////////////////////////////////////////////////////////////////////////////
 // reset the method, as if it had just been instantiated (forget all training etc.)
 
-void TMVA::MethodSVM::Reset( void )
+void TMVA::MethodSVM::Reset()
 {
    // reset the method, as if it had just been instantiated (forget all training etc.)
    fSupportVectors->clear();

--- a/tmva/tmva/src/MethodSVM.cxx
+++ b/tmva/tmva/src/MethodSVM.cxx
@@ -96,12 +96,12 @@ ClassImp(TMVA::MethodSVM);
    , fNSubSets(0)
    , fBparm(0)
    , fGamma(0)
-   , fWgSet(0)
-   , fInputData(0)
-   , fSupportVectors(0)
-   , fSVKernelFunction(0)
-   , fMinVars(0)
-   , fMaxVars(0)
+   , fWgSet(nullptr)
+   , fInputData(nullptr)
+   , fSupportVectors(nullptr)
+   , fSVKernelFunction(nullptr)
+   , fMinVars(nullptr)
+   , fMaxVars(nullptr)
    , fDoubleSigmaSquared(0)
    , fOrder(0)
    , fTheta(0)
@@ -131,12 +131,12 @@ TMVA::MethodSVM::MethodSVM( DataSetInfo& theData, const TString& theWeightFile)
    , fNSubSets(0)
    , fBparm(0)
    , fGamma(0)
-   , fWgSet(0)
-   , fInputData(0)
-   , fSupportVectors(0)
-   , fSVKernelFunction(0)
-   , fMinVars(0)
-   , fMaxVars(0)
+   , fWgSet(nullptr)
+   , fInputData(nullptr)
+   , fSupportVectors(nullptr)
+   , fSVKernelFunction(nullptr)
+   , fMinVars(nullptr)
+   , fMaxVars(nullptr)
    , fDoubleSigmaSquared(0)
    , fOrder(0)
    , fTheta(0)
@@ -164,8 +164,8 @@ TMVA::MethodSVM::~MethodSVM()
    for (UInt_t i=0; i<fInputData->size(); i++) {
       delete fInputData->at(i);
    }
-   if (fWgSet !=0)           { delete fWgSet; fWgSet=0; }
-   if (fSVKernelFunction !=0 ) { delete fSVKernelFunction; fSVKernelFunction = 0; }
+   if (fWgSet !=nullptr)           { delete fWgSet; fWgSet=nullptr; }
+   if (fSVKernelFunction !=nullptr ) { delete fSVKernelFunction; fSVKernelFunction = nullptr; }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -177,11 +177,11 @@ void TMVA::MethodSVM::Reset( void )
    fSupportVectors->clear();
    for (UInt_t i=0; i<fInputData->size(); i++){
       delete fInputData->at(i);
-      fInputData->at(i)=0;
+      fInputData->at(i)=nullptr;
    }
    fInputData->clear();
-   if (fWgSet !=0)           { fWgSet=0; }
-   if (fSVKernelFunction !=0 ) { fSVKernelFunction = 0; }
+   if (fWgSet !=nullptr)           { fWgSet=nullptr; }
+   if (fSVKernelFunction !=nullptr ) { fSVKernelFunction = nullptr; }
    if (Data()){
       Data()->DeleteResults(GetMethodName(), Types::kTraining, GetAnalysisType());
    }
@@ -386,7 +386,7 @@ void TMVA::MethodSVM::Train()
    fBparm          = fWgSet->GetBpar();
    fSupportVectors = fWgSet->GetSupportVectors();
    delete fWgSet;
-   fWgSet=0;
+   fWgSet=nullptr;
 
     if (!fExitFromTraining) fIPyMaxIter = fIPyCurrentIter;
     ExitFromTraining();
@@ -444,11 +444,11 @@ void TMVA::MethodSVM::ReadWeightsFromXML( void* wghtnode )
    // UInt_t ns = 0;
    std::vector<Float_t>* svector = new std::vector<Float_t>(GetNvar());
 
-   if (fMaxVars!=0) delete fMaxVars;
+   if (fMaxVars!=nullptr) delete fMaxVars;
    fMaxVars = new TVectorD( GetNvar() );
-   if (fMinVars!=0) delete fMinVars;
+   if (fMinVars!=nullptr) delete fMinVars;
    fMinVars = new TVectorD( GetNvar() );
-   if (fSupportVectors!=0) {
+   if (fSupportVectors!=nullptr) {
       for (vector< SVEvent* >::iterator it = fSupportVectors->begin(); it!=fSupportVectors->end(); ++it)
          delete *it;
       delete fSupportVectors;
@@ -474,7 +474,7 @@ void TMVA::MethodSVM::ReadWeightsFromXML( void* wghtnode )
    maxminnode = gTools().GetNextChild(maxminnode);
    for (UInt_t ivar = 0; ivar < GetNvar(); ivar++)
       gTools().ReadAttr( maxminnode,"Var"+gTools().StringFromInt(ivar),(*fMinVars)[ivar]);
-   if (fSVKernelFunction!=0) delete fSVKernelFunction;
+   if (fSVKernelFunction!=nullptr) delete fSVKernelFunction;
    if( fTheKernel == "RBF" ){
       fSVKernelFunction = new SVKernelFunction(SVKernelFunction::kRBF, fGamma);
    }
@@ -512,7 +512,7 @@ void TMVA::MethodSVM::WriteWeightsToStream( TFile& ) const
 
 void  TMVA::MethodSVM::ReadWeightsFromStream( std::istream& istr )
 {
-   if (fSupportVectors !=0) { delete fSupportVectors; fSupportVectors = 0;}
+   if (fSupportVectors !=nullptr) { delete fSupportVectors; fSupportVectors = nullptr;}
    fSupportVectors = new std::vector<TMVA::SVEvent*>(0);
 
    // read configuration from input stream
@@ -601,7 +601,7 @@ Double_t TMVA::MethodSVM::GetMvaValue( Double_t* err, Double_t* errUpper )
 
 const std::vector<Float_t>& TMVA::MethodSVM::GetRegressionValues()
 {
-   if( fRegressionReturnVal == NULL )
+   if( fRegressionReturnVal == nullptr )
       fRegressionReturnVal = new std::vector<Float_t>();
    fRegressionReturnVal->clear();
 

--- a/tmva/tmva/src/MethodTMlpANN.cxx
+++ b/tmva/tmva/src/MethodTMlpANN.cxx
@@ -93,8 +93,8 @@ ClassImp(TMVA::MethodTMlpANN);
                                        DataSetInfo& theData,
                                        const TString& theOption) :
    TMVA::MethodBase( jobName, Types::kTMlpANN, methodTitle, theData, theOption),
-   fMLP(0),
-   fLocalTrainingTree(0),
+   fMLP(nullptr),
+   fLocalTrainingTree(nullptr),
    fNcycles(100),
    fValidationFraction(0.5),
    fLearningMethod( "" )
@@ -107,8 +107,8 @@ ClassImp(TMVA::MethodTMlpANN);
 TMVA::MethodTMlpANN::MethodTMlpANN( DataSetInfo& theData,
                                     const TString& theWeightFile) :
    TMVA::MethodBase( Types::kTMlpANN, theData, theWeightFile),
-   fMLP(0),
-   fLocalTrainingTree(0),
+   fMLP(nullptr),
+   fLocalTrainingTree(nullptr),
    fNcycles(100),
    fValidationFraction(0.5),
    fLearningMethod( "" )
@@ -312,7 +312,7 @@ void TMVA::MethodTMlpANN::Train( void )
    // localTrainingTree->Print();
 
    // create NN
-   if (fMLP != 0) { delete fMLP; fMLP = 0; }
+   if (fMLP != nullptr) { delete fMLP; fMLP = nullptr; }
    fMLP = new TMultiLayerPerceptron( fMLPBuildOptions.Data(),
                                      localTrainingTree,
                                      trainList,
@@ -363,12 +363,12 @@ void TMVA::MethodTMlpANN::AddWeightsXMLTo( void* parent ) const
    std::ifstream inf( tmpfile.Data() );
    char temp[256];
    TString data("");
-   void *ch=NULL;
+   void *ch=nullptr;
    while (inf.getline(temp,256)) {
       TString dummy(temp);
       //std::cout << dummy << std::endl; // remove annoying debug printout with std::cout
       if (dummy.BeginsWith('#')) {
-         if (ch!=0) gTools().AddRawLine( ch, data.Data() );
+         if (ch!=nullptr) gTools().AddRawLine( ch, data.Data() );
          dummy = dummy.Strip(TString::kLeading, '#');
          dummy = dummy(0,dummy.First(' '));
          ch = gTools().AddChild(wght, dummy);
@@ -377,7 +377,7 @@ void TMVA::MethodTMlpANN::AddWeightsXMLTo( void* parent ) const
       }
       data += (dummy + " ");
    }
-   if (ch != 0) gTools().AddRawLine( ch, data.Data() );
+   if (ch != nullptr) gTools().AddRawLine( ch, data.Data() );
 
    inf.close();
 }
@@ -439,7 +439,7 @@ void  TMVA::MethodTMlpANN::ReadWeightsFromXML( void* wghtnode )
    }
    dummyTree->Branch("type", &type, "type/I");
 
-   if (fMLP != 0) { delete fMLP; fMLP = 0; }
+   if (fMLP != nullptr) { delete fMLP; fMLP = nullptr; }
    fMLP = new TMultiLayerPerceptron( fMLPBuildOptions.Data(), dummyTree );
    fMLP->LoadWeights( fname );
 }
@@ -468,7 +468,7 @@ void  TMVA::MethodTMlpANN::ReadWeightsFromStream( std::istream& istr )
    }
    dummyTree->Branch("type", &type, "type/I");
 
-   if (fMLP != 0) { delete fMLP; fMLP = 0; }
+   if (fMLP != nullptr) { delete fMLP; fMLP = nullptr; }
    fMLP = new TMultiLayerPerceptron( fMLPBuildOptions.Data(), dummyTree );
 
    fMLP->LoadWeights( "./TMlp.nn.weights.temp" );

--- a/tmva/tmva/src/MethodTMlpANN.cxx
+++ b/tmva/tmva/src/MethodTMlpANN.cxx
@@ -129,14 +129,14 @@ Bool_t TMVA::MethodTMlpANN::HasAnalysisType( Types::EAnalysisType type, UInt_t n
 ////////////////////////////////////////////////////////////////////////////////
 /// default initialisations
 
-void TMVA::MethodTMlpANN::Init( void )
+void TMVA::MethodTMlpANN::Init()
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
-TMVA::MethodTMlpANN::~MethodTMlpANN( void )
+TMVA::MethodTMlpANN::~MethodTMlpANN()
 {
    if (fMLP) delete fMLP;
 }
@@ -264,7 +264,7 @@ Double_t TMVA::MethodTMlpANN::GetMvaValue( Double_t* err, Double_t* errUpper )
 /// TMultiLayerPerceptron wants test and training tree at once
 /// so merge the training and testing trees from the MVA factory first:
 
-void TMVA::MethodTMlpANN::Train( void )
+void TMVA::MethodTMlpANN::Train()
 {
    Int_t type;
    Float_t weight;

--- a/tmva/tmva/src/MinuitFitter.cxx
+++ b/tmva/tmva/src/MinuitFitter.cxx
@@ -140,7 +140,7 @@ Double_t TMVA::MinuitFitter::Run( std::vector<Double_t>& pars )
             << GetNpars() << " != " << pars.size() << Endl;
 
    // timing of MC
-   Timer* timer = 0;
+   Timer* timer = nullptr;
    if (!fBatch) timer = new Timer();
 
    // define fit parameters

--- a/tmva/tmva/src/MinuitWrapper.cxx
+++ b/tmva/tmva/src/MinuitWrapper.cxx
@@ -133,5 +133,5 @@ TObject *TMVA::MinuitWrapper::Clone(char const* newname) const
 {
    MinuitWrapper *named = (MinuitWrapper*)TNamed::Clone(newname);
    named->fFitterTarget = fFitterTarget;
-   return 0;
+   return nullptr;
 }

--- a/tmva/tmva/src/ModulekNN.cxx
+++ b/tmva/tmva/src/ModulekNN.cxx
@@ -172,7 +172,7 @@ std::ostream& TMVA::kNN::operator<<(std::ostream& os, const TMVA::kNN::Event& ev
 
 TMVA::kNN::ModulekNN::ModulekNN()
    :fDimn(0),
-    fTree(0),
+    fTree(nullptr),
     fLogger( new MsgLogger("ModulekNN") )
 {
 }
@@ -183,7 +183,7 @@ TMVA::kNN::ModulekNN::ModulekNN()
 TMVA::kNN::ModulekNN::~ModulekNN()
 {
    if (fTree) {
-      delete fTree; fTree = 0;
+      delete fTree; fTree = nullptr;
    }
    delete fLogger;
 }
@@ -197,7 +197,7 @@ void TMVA::kNN::ModulekNN::Clear()
 
    if (fTree) {
       delete fTree;
-      fTree = 0;
+      fTree = nullptr;
    }
 
    fVarScale.clear();
@@ -450,26 +450,26 @@ TMVA::kNN::Node<TMVA::kNN::Event>* TMVA::kNN::ModulekNN::Optimize(const UInt_t o
 {
    if (fVar.empty() || fDimn != fVar.size()) {
       Log() << kWARNING << "<Optimize> Cannot build a tree" << Endl;
-      return 0;
+      return nullptr;
    }
 
    const UInt_t size = (fVar.begin()->second).size();
    if (size < 1) {
       Log() << kWARNING << "<Optimize> Cannot build a tree without events" << Endl;
-      return 0;
+      return nullptr;
    }
 
    VarMap::const_iterator it = fVar.begin();
    for (; it != fVar.end(); ++it) {
       if ((it->second).size() != size) {
          Log() << kWARNING << "<Optimize> # of variables doesn't match between dimensions" << Endl;
-         return 0;
+         return nullptr;
       }
    }
 
    if (double(fDimn*size) < TMath::Power(2.0, double(odepth))) {
       Log() << kWARNING << "<Optimize> Optimization depth exceeds number of events" << Endl;
-      return 0;
+      return nullptr;
    }
 
    Log() << kHEADER << "Optimizing tree for " << fDimn << " variables with " << size << " values" << Endl;
@@ -479,12 +479,12 @@ TMVA::kNN::Node<TMVA::kNN::Event>* TMVA::kNN::ModulekNN::Optimize(const UInt_t o
    it = fVar.find(0);
    if (it == fVar.end() || (it->second).size() < 2) {
       Log() << kWARNING << "<Optimize> Missing 0 variable" << Endl;
-      return 0;
+      return nullptr;
    }
 
    const Event pevent(VarVec(fDimn, (it->second)[size/2]), -1.0, -1);
 
-   Node<Event> *tree = new Node<Event>(0, pevent, 0);
+   Node<Event> *tree = new Node<Event>(nullptr, pevent, 0);
 
    pvec.push_back(tree);
 
@@ -494,13 +494,13 @@ TMVA::kNN::Node<TMVA::kNN::Event>* TMVA::kNN::ModulekNN::Optimize(const UInt_t o
       VarMap::const_iterator vit = fVar.find(mod);
       if (vit == fVar.end()) {
          Log() << kFATAL << "Missing " << mod << " variable" << Endl;
-         return 0;
+         return nullptr;
       }
       const std::vector<Double_t> &dvec = vit->second;
 
       if (dvec.size() < 2) {
          Log() << kFATAL << "Missing " << mod << " variable" << Endl;
-         return 0;
+         return nullptr;
       }
 
       UInt_t ichild = 1;

--- a/tmva/tmva/src/ModulekNN.cxx
+++ b/tmva/tmva/src/ModulekNN.cxx
@@ -294,8 +294,8 @@ Bool_t TMVA::kNN::ModulekNN::Fill(const UShort_t odepth, const UInt_t ifrac, con
    fCount.clear();
 
    // sort each variable for all events - needs this before Optimize() and ComputeMetric()
-   for (VarMap::iterator it = fVar.begin(); it != fVar.end(); ++it) {
-      std::sort((it->second).begin(), (it->second).end());
+   for (auto & it : fVar) {
+      std::sort((it.second).begin(), (it.second).end());
    }
 
    if (option.find("metric") != std::string::npos && ifrac > 0) {
@@ -303,8 +303,8 @@ Bool_t TMVA::kNN::ModulekNN::Fill(const UShort_t odepth, const UInt_t ifrac, con
 
       // sort again each variable for all events - needs this before Optimize()
       // rescaling has changed variable values
-      for (VarMap::iterator it = fVar.begin(); it != fVar.end(); ++it) {
-         std::sort((it->second).begin(), (it->second).end());
+      for (auto & it : fVar) {
+         std::sort((it.second).begin(), (it.second).end());
       }
    }
 
@@ -612,11 +612,11 @@ void TMVA::kNN::ModulekNN::ComputeMetric(const UInt_t ifrac)
 
    fVar.clear();
 
-   for (UInt_t ievent = 0; ievent < fEvent.size(); ++ievent) {
-      fEvent[ievent] = Scale(fEvent[ievent]);
+   for (auto & ievent : fEvent) {
+      ievent = Scale(ievent);
 
       for (UInt_t ivar = 0; ivar < fDimn; ++ivar) {
-         fVar[ivar].push_back(fEvent[ievent].GetVar(ivar));
+         fVar[ivar].push_back(ievent.GetVar(ivar));
       }
    }
 }

--- a/tmva/tmva/src/MsgLogger.cxx
+++ b/tmva/tmva/src/MsgLogger.cxx
@@ -60,8 +60,8 @@ const std::string                      TMVA::MsgLogger::fgPrefix = "";
 const std::string                      TMVA::MsgLogger::fgSuffix = ": ";
 #if __cplusplus > 199711L
 std::atomic<Bool_t>                                       TMVA::MsgLogger::fgInhibitOutput{kFALSE};
-std::atomic<const std::map<TMVA::EMsgType, std::string>*> TMVA::MsgLogger::fgTypeMap{0};
-std::atomic<const std::map<TMVA::EMsgType, std::string>*> TMVA::MsgLogger::fgColorMap{0};
+std::atomic<const std::map<TMVA::EMsgType, std::string>*> TMVA::MsgLogger::fgTypeMap{nullptr};
+std::atomic<const std::map<TMVA::EMsgType, std::string>*> TMVA::MsgLogger::fgColorMap{nullptr};
 #else
 Bool_t                                       TMVA::MsgLogger::fgInhibitOutput = kFALSE;
 const std::map<TMVA::EMsgType, std::string>* TMVA::MsgLogger::fgTypeMap  = 0;
@@ -89,7 +89,7 @@ TMVA::MsgLogger::MsgLogger( const TObject* source, EMsgType minType )
 /// constructor
 
 TMVA::MsgLogger::MsgLogger( const std::string& source, EMsgType minType )
-   : fObjSource ( 0 ),
+   : fObjSource ( nullptr ),
      fStrSource ( source ),
      fActiveType( kINFO ),
      fMinType   ( minType )
@@ -101,7 +101,7 @@ TMVA::MsgLogger::MsgLogger( const std::string& source, EMsgType minType )
 /// constructor
 
 TMVA::MsgLogger::MsgLogger( EMsgType minType )
-   : fObjSource ( 0 ),
+   : fObjSource ( nullptr ),
      fStrSource ( "Unknown" ),
      fActiveType( kINFO ),
      fMinType   ( minType )
@@ -116,7 +116,7 @@ TMVA::MsgLogger::MsgLogger( const MsgLogger& parent )
    : std::basic_ios<MsgLogger::char_type, MsgLogger::traits_type>(),
      std::ostringstream(),
      TObject(),
-     fObjSource(0)
+     fObjSource(nullptr)
 {
    InitMaps();
    *this = parent;
@@ -279,7 +279,7 @@ void TMVA::MsgLogger::InitMaps()
       (*tmp)[kFATAL]    = std::string("FATAL");
       (*tmp)[kSILENT]   = std::string("SILENT");
       (*tmp)[kHEADER]   = std::string("HEADER");
-      const std::map<TMVA::EMsgType, std::string>* expected=0;
+      const std::map<TMVA::EMsgType, std::string>* expected=nullptr;
       if(fgTypeMap.compare_exchange_strong(expected,tmp)) {
          //Have the global own this
          gOwnTypeMap.reset(tmp);
@@ -300,7 +300,7 @@ void TMVA::MsgLogger::InitMaps()
       (*tmp)[kFATAL]   = std::string("\033[37;41;1m");
       (*tmp)[kSILENT]  = std::string("\033[30m");
 
-      const std::map<TMVA::EMsgType, std::string>* expected=0;
+      const std::map<TMVA::EMsgType, std::string>* expected=nullptr;
       if(fgColorMap.compare_exchange_strong(expected,tmp)) {
          //Have the global own this
          gOwnColorMap.reset(tmp);

--- a/tmva/tmva/src/NeuralNet.cxx
+++ b/tmva/tmva/src/NeuralNet.cxx
@@ -233,7 +233,7 @@ namespace TMVA
             , m_maxConvergenceCount (0)
             , m_minError (1e10)
             , m_useMultithreading (_useMultithreading)
-            , fMonitoring (NULL)
+            , fMonitoring (nullptr)
         {
         }
     

--- a/tmva/tmva/src/Node.cxx
+++ b/tmva/tmva/src/Node.cxx
@@ -49,12 +49,12 @@ ClassImp(TMVA::Node);
 Int_t TMVA::Node::fgCount = 0;
 
 TMVA::Node::Node()
-   : fParent( NULL ),
-     fLeft  ( NULL),
-     fRight ( NULL ),
+   : fParent( nullptr ),
+     fLeft  ( nullptr),
+     fRight ( nullptr ),
      fPos   ( 'u' ),
      fDepth ( 0 ),
-     fParentTree( NULL )
+     fParentTree( nullptr )
 {
    // default constructor
    fgCount++;
@@ -65,8 +65,8 @@ TMVA::Node::Node()
 
 TMVA::Node::Node( Node* p, char pos )
    : fParent ( p ),
-     fLeft ( NULL ),
-     fRight( NULL ),
+     fLeft ( nullptr ),
+     fRight( nullptr ),
      fPos  ( pos ),
      fDepth( p->GetDepth() + 1),
      fParentTree(p->GetParentTree())
@@ -82,12 +82,12 @@ TMVA::Node::Node( Node* p, char pos )
 /// constructors of the derived classes
 
 TMVA::Node::Node ( const Node &n )
-   : fParent( NULL ),
-     fLeft  ( NULL),
-     fRight ( NULL ),
+   : fParent( nullptr ),
+     fLeft  ( nullptr),
+     fRight ( nullptr ),
      fPos   ( n.fPos ),
      fDepth ( n.fDepth ),
-     fParentTree( NULL )
+     fParentTree( nullptr )
 {
    fgCount++;
 }
@@ -114,9 +114,9 @@ int TMVA::Node::GetCount()
 Int_t TMVA::Node::CountMeAndAllDaughters() const
 {
    Int_t n=1;
-   if (this->GetLeft() != NULL)
+   if (this->GetLeft() != nullptr)
       n+= this->GetLeft()->CountMeAndAllDaughters();
-   if (this->GetRight() != NULL)
+   if (this->GetRight() != nullptr)
       n+= this->GetRight()->CountMeAndAllDaughters();
 
    return n;
@@ -137,7 +137,7 @@ std::ostream& TMVA::operator<<( std::ostream& os, const TMVA::Node& node )
 
 std::ostream& TMVA::operator<<( std::ostream& os, const TMVA::Node* node )
 {
-   if (node!=NULL) node->Print(os);
+   if (node!=nullptr) node->Print(os);
    return os;                // Return the output stream.
 }
 

--- a/tmva/tmva/src/OptimizeConfigParameters.cxx
+++ b/tmva/tmva/src/OptimizeConfigParameters.cxx
@@ -63,10 +63,10 @@ TMVA::OptimizeConfigParameters::OptimizeConfigParameters(MethodBase * const meth
    fTuneParameters(tuneParameters),
    fFOMType(fomType),
    fOptimizationFitType(optimizationFitType),
-   fMvaSig(NULL),
-   fMvaBkg(NULL),
-   fMvaSigFineBin(NULL),
-   fMvaBkgFineBin(NULL),
+   fMvaSig(nullptr),
+   fMvaBkg(nullptr),
+   fMvaSigFineBin(nullptr),
+   fMvaBkgFineBin(nullptr),
    fNotDoneYet(kFALSE)
 {
    std::string name = "OptimizeConfigParameters_";
@@ -259,7 +259,7 @@ void TMVA::OptimizeConfigParameters::optimizeFit()
 
    // create the fitter
 
-   FitterBase* fitter = NULL;
+   FitterBase* fitter = nullptr;
 
    if ( fOptimizationFitType == "Minuit"  ) {
       TString opt="FitStrategy=0:UseImprove=False:UseMinos=False:Tolerance=100";

--- a/tmva/tmva/src/OptimizeConfigParameters.cxx
+++ b/tmva/tmva/src/OptimizeConfigParameters.cxx
@@ -149,9 +149,9 @@ std::map<TString,Double_t> TMVA::OptimizeConfigParameters::optimize()
 
 std::vector< int > TMVA::OptimizeConfigParameters::GetScanIndices( int val, std::vector<int> base){
    std::vector < int > indices;
-   for (UInt_t i=0; i< base.size(); i++){
-      indices.push_back(val % base[i] );
-      val = int( floor( float(val) / float(base[i]) ) );
+   for (int i : base){
+      indices.push_back(val % i );
+      val = int( floor( float(val) / float(i) ) );
    }
    return indices;
 }
@@ -194,9 +194,9 @@ void TMVA::OptimizeConfigParameters::optimizeScan()
    }
    Int_t Ntot = 1;
    std::vector< int > Nindividual;
-   for (UInt_t i=0; i<v.size(); i++) {
-      Ntot *= v[i].size();
-      Nindividual.push_back(v[i].size());
+   for (auto & i : v) {
+      Ntot *= i.size();
+      Nindividual.push_back(i.size());
    }
    //loop on the total number of different combinations
 
@@ -208,9 +208,8 @@ void TMVA::OptimizeConfigParameters::optimizeScan()
       }
       Log() << kINFO << "--------------------------" << Endl;
       Log() << kINFO <<"Settings being evaluated:" << Endl;
-      for (std::map<TString,Double_t>::iterator it_print=currentParameters.begin();
-           it_print!=currentParameters.end(); ++it_print){
-         Log() << kINFO << "  " << it_print->first  << " = " << it_print->second << Endl;
+      for (auto & currentParameter : currentParameters){
+         Log() << kINFO << "  " << currentParameter.first  << " = " << currentParameter.second << Endl;
       }
 
       GetMethod()->Reset();
@@ -227,9 +226,8 @@ void TMVA::OptimizeConfigParameters::optimizeScan()
 
       if (currentFOM > bestFOM) {
          bestFOM = currentFOM;
-         for (std::map<TString,Double_t>::iterator iter=currentParameters.begin();
-              iter != currentParameters.end(); ++iter){
-            fTunedParameters[iter->first]=iter->second;
+         for (auto & currentParameter : currentParameters){
+            fTunedParameters[currentParameter.first]=currentParameter.second;
          }
       }
    }
@@ -288,7 +286,7 @@ void TMVA::OptimizeConfigParameters::optimizeFit()
    fitter->Run(pars);
 
    // clean up
-   for (UInt_t ipar=0; ipar<ranges.size(); ipar++) delete ranges[ipar];
+   for (auto & range : ranges) delete range;
 
    GetMethod()->Reset();
 
@@ -401,16 +399,16 @@ void TMVA::OptimizeConfigParameters::GetMVADists()
 
    //   fMethod->GetTransformationHandler().CalcTransformations(fMethod->Data()->GetEventCollection(Types::kTesting));
 
-   for (UInt_t iev=0; iev < events.size() ; iev++){
+   for (auto event : events){
       //      std::cout << " GetMVADists event " << iev << std::endl;
       //      std::cout << " Class  = " << events[iev]->GetClass() << std::endl;
       //         std::cout << " MVA Value = " << fMethod->GetMvaValue(events[iev]) << std::endl;
-      if (events[iev]->GetClass() == signalClassNr) {
-         fMvaSig->Fill(fMethod->GetMvaValue(events[iev]),events[iev]->GetWeight());
-         fMvaSigFineBin->Fill(fMethod->GetMvaValue(events[iev]),events[iev]->GetWeight());
+      if (event->GetClass() == signalClassNr) {
+         fMvaSig->Fill(fMethod->GetMvaValue(event),event->GetWeight());
+         fMvaSigFineBin->Fill(fMethod->GetMvaValue(event),event->GetWeight());
       } else {
-         fMvaBkg->Fill(fMethod->GetMvaValue(events[iev]),events[iev]->GetWeight());
-         fMvaBkgFineBin->Fill(fMethod->GetMvaValue(events[iev]),events[iev]->GetWeight());
+         fMvaBkg->Fill(fMethod->GetMvaValue(event),event->GetWeight());
+         fMvaBkgFineBin->Fill(fMethod->GetMvaValue(event),event->GetWeight());
       }
    }
 }

--- a/tmva/tmva/src/PDEFoam.cxx
+++ b/tmva/tmva/src/PDEFoam.cxx
@@ -1045,8 +1045,8 @@ std::vector<Float_t> TMVA::PDEFoam::GetCellValue( const std::map<Int_t,Float_t>&
 {
    // transformed event
    std::map<Int_t,Float_t> txvec;
-   for (std::map<Int_t,Float_t>::const_iterator it=xvec.begin(); it!=xvec.end(); ++it)
-      txvec.insert(std::pair<Int_t, Float_t>(it->first, VarTransform(it->first, it->second)));
+   for (const auto & it : xvec)
+      txvec.insert(std::pair<Int_t, Float_t>(it.first, VarTransform(it.first, it.second)));
 
    // find all cells, which correspond to the transformed event
    std::vector<PDEFoamCell*> cells = FindCells(txvec);

--- a/tmva/tmva/src/PDEFoam.cxx
+++ b/tmva/tmva/src/PDEFoam.cxx
@@ -108,18 +108,18 @@ TMVA::PDEFoam::PDEFoam() :
    fNBin(5),
    fNSampl(2000),
    fEvPerBin(0),
-   fMaskDiv(0),
-   fInhiDiv(0),
+   fMaskDiv(nullptr),
+   fInhiDiv(nullptr),
    fNoAct(1),
    fLastCe(-1),
-   fCells(0),
-   fHistEdg(0),
-   fRvec(0),
+   fCells(nullptr),
+   fHistEdg(nullptr),
+   fRvec(nullptr),
    fPseRan(new TRandom3(4356)),
-   fAlpha(0),
+   fAlpha(nullptr),
    fFoamType(kSeparate),
-   fXmin(0),
-   fXmax(0),
+   fXmin(nullptr),
+   fXmax(nullptr),
    fNElements(0),
    fNmin(100),
    fMaxDepth(0),
@@ -127,7 +127,7 @@ TMVA::PDEFoam::PDEFoam() :
    fFillFoamWithOrigWeights(kFALSE),
    fDTSeparation(kFoam),
    fPeekMax(kTRUE),
-   fDistr(NULL),
+   fDistr(nullptr),
    fTimer(new Timer(0, "PDEFoam", kTRUE)),
    fVariableNames(new TObjArray()),
    fLogger(new MsgLogger("PDEFoam"))
@@ -147,18 +147,18 @@ TMVA::PDEFoam::PDEFoam(const TString& name) :
    fNBin(5),
    fNSampl(2000),
    fEvPerBin(0),
-   fMaskDiv(0),
-   fInhiDiv(0),
+   fMaskDiv(nullptr),
+   fInhiDiv(nullptr),
    fNoAct(1),
    fLastCe(-1),
-   fCells(0),
-   fHistEdg(0),
-   fRvec(0),
+   fCells(nullptr),
+   fHistEdg(nullptr),
+   fRvec(nullptr),
    fPseRan(new TRandom3(4356)),
-   fAlpha(0),
+   fAlpha(nullptr),
    fFoamType(kSeparate),
-   fXmin(0),
-   fXmax(0),
+   fXmin(nullptr),
+   fXmax(nullptr),
    fNElements(0),
    fNmin(100),
    fMaxDepth(0),
@@ -166,7 +166,7 @@ TMVA::PDEFoam::PDEFoam(const TString& name) :
    fFillFoamWithOrigWeights(kFALSE),
    fDTSeparation(kFoam),
    fPeekMax(kTRUE),
-   fDistr(NULL),
+   fDistr(nullptr),
    fTimer(new Timer(1, "PDEFoam", kTRUE)),
    fVariableNames(new TObjArray()),
    fLogger(new MsgLogger("PDEFoam"))
@@ -188,11 +188,11 @@ TMVA::PDEFoam::~PDEFoam()
    delete fTimer;
    if (fDistr)  delete fDistr;
    if (fPseRan) delete fPseRan;
-   if (fXmin) { delete [] fXmin;  fXmin=0; }
-   if (fXmax) { delete [] fXmax;  fXmax=0; }
+   if (fXmin) { delete [] fXmin;  fXmin=nullptr; }
+   if (fXmax) { delete [] fXmax;  fXmax=nullptr; }
 
    ResetCellElements();
-   if(fCells!= 0) {
+   if(fCells!= nullptr) {
       for(Int_t i=0; i<fNCells; i++) delete fCells[i]; // PDEFoamCell*[]
       delete [] fCells;
    }
@@ -214,18 +214,18 @@ TMVA::PDEFoam::PDEFoam(const PDEFoam &from) :
    , fNBin(0)
    , fNSampl(0)
    , fEvPerBin(0)
-   , fMaskDiv(0)
-   , fInhiDiv(0)
+   , fMaskDiv(nullptr)
+   , fInhiDiv(nullptr)
    , fNoAct(0)
    , fLastCe(0)
-   , fCells(0)
-   , fHistEdg(0)
-   , fRvec(0)
-   , fPseRan(0)
-   , fAlpha(0)
+   , fCells(nullptr)
+   , fHistEdg(nullptr)
+   , fRvec(nullptr)
+   , fPseRan(nullptr)
+   , fAlpha(nullptr)
    , fFoamType(kSeparate)
-   , fXmin(0)
-   , fXmax(0)
+   , fXmin(nullptr)
+   , fXmax(nullptr)
    , fNElements(0)
    , fNmin(0)
    , fMaxDepth(0)
@@ -233,9 +233,9 @@ TMVA::PDEFoam::PDEFoam(const PDEFoam &from) :
    , fFillFoamWithOrigWeights(kFALSE)
    , fDTSeparation(kFoam)
    , fPeekMax(kTRUE)
-   , fDistr(0)
-   , fTimer(0)
-   , fVariableNames(0)
+   , fDistr(nullptr)
+   , fTimer(nullptr)
+   , fVariableNames(nullptr)
    , fLogger(new MsgLogger(*from.fLogger))
 {
    Log() << kFATAL << "COPY CONSTRUCTOR NOT IMPLEMENTED" << Endl;
@@ -295,8 +295,8 @@ void TMVA::PDEFoam::Create()
    Bool_t addStatus = TH1::AddDirectoryStatus();
    TH1::AddDirectory(kFALSE);
 
-   if(fPseRan==0) Log() << kFATAL << "Random number generator not set" << Endl;
-   if(fDistr==0)  Log() << kFATAL << "Distribution function not set" << Endl;
+   if(fPseRan==nullptr) Log() << kFATAL << "Random number generator not set" << Endl;
+   if(fDistr==nullptr)  Log() << kFATAL << "Distribution function not set" << Endl;
    if(fDim==0)    Log() << kFATAL << "Zero dimension not allowed" << Endl;
 
    /////////////////////////////////////////////////////////////////////////
@@ -304,20 +304,20 @@ void TMVA::PDEFoam::Create()
    //  it is done globally, not for each cell, to save on allocation time //
    /////////////////////////////////////////////////////////////////////////
    fRvec = new Double_t[fDim];   // Vector of random numbers
-   if(fRvec==0)  Log() << kFATAL << "Cannot initialize buffer fRvec" << Endl;
+   if(fRvec==nullptr)  Log() << kFATAL << "Cannot initialize buffer fRvec" << Endl;
 
    if(fDim>0){
       fAlpha = new Double_t[fDim];    // sum<1 for internal parametrization of the simplex
-      if(fAlpha==0)  Log() << kFATAL << "Cannot initialize buffer fAlpha" << Endl;
+      if(fAlpha==nullptr)  Log() << kFATAL << "Cannot initialize buffer fAlpha" << Endl;
    }
 
    //====== List of directions inhibited for division
-   if(fInhiDiv == 0){
+   if(fInhiDiv == nullptr){
       fInhiDiv = new Int_t[fDim];
       for(Int_t i=0; i<fDim; i++) fInhiDiv[i]=0;
    }
    //====== Dynamic mask used in Explore for edge determination
-   if(fMaskDiv == 0){
+   if(fMaskDiv == nullptr){
       fMaskDiv = new Int_t[fDim];
       for(Int_t i=0; i<fDim; i++) fMaskDiv[i]=1;
    }
@@ -357,7 +357,7 @@ void TMVA::PDEFoam::Create()
 void TMVA::PDEFoam::InitCells()
 {
    fLastCe =-1;                             // Index of the last cell
-   if(fCells!= 0) {
+   if(fCells!= nullptr) {
       for(Int_t i=0; i<fNCells; i++) delete fCells[i];
       delete [] fCells;
    }
@@ -375,7 +375,7 @@ void TMVA::PDEFoam::InitCells()
    /////////////////////////////////////////////////////////////////////////////
    //              Single Root Hypercube                                      //
    /////////////////////////////////////////////////////////////////////////////
-   CellFill(1,   0);  //  0-th cell ACTIVE
+   CellFill(1,   nullptr);  //  0-th cell ACTIVE
 
    // Exploration of the root cell(s)
    for(Long_t iCell=0; iCell<=fLastCe; iCell++){
@@ -397,12 +397,12 @@ Int_t TMVA::PDEFoam::CellFill(Int_t status, PDEFoamCell *parent)
 
    cell = fCells[fLastCe];
 
-   cell->Fill(status, parent, 0, 0);
+   cell->Fill(status, parent, nullptr, nullptr);
 
    cell->SetBest( -1);         // pointer for planning division of the cell
    cell->SetXdiv(0.5);         // factor for division
    Double_t xInt2,xDri2;
-   if(parent!=0){
+   if(parent!=nullptr){
       xInt2  = 0.5*parent->GetIntg();
       xDri2  = 0.5*parent->GetDriv();
       cell->SetIntg(xInt2);
@@ -456,7 +456,7 @@ void TMVA::PDEFoam::Explore(PDEFoamCell *cell)
 
    Double_t *xRand = new Double_t[fDim];
 
-   Double_t *volPart=0;
+   Double_t *volPart=nullptr;
 
    // calculate volume scale
    Double_t vol_scale = 1.0;
@@ -551,7 +551,7 @@ void TMVA::PDEFoam::Explore(PDEFoamCell *cell)
 
    // correct/update integrals in all parent cells to the top of the tree
    Double_t  parIntg, parDriv;
-   for (parent = cell->GetPare(); parent!=0; parent = parent->GetPare()){
+   for (parent = cell->GetPare(); parent!=nullptr; parent = parent->GetPare()){
       parIntg = parent->GetIntg();
       parDriv = parent->GetDriv();
       parent->SetIntg( parIntg   +intTrue -intOld );
@@ -803,7 +803,7 @@ void TMVA::PDEFoam::Grow()
 void  TMVA::PDEFoam::SetInhiDiv(Int_t iDim, Int_t inhiDiv)
 {
    if(fDim==0) Log() << kFATAL << "SetInhiDiv: fDim=0" << Endl;
-   if(fInhiDiv == 0) {
+   if(fInhiDiv == nullptr) {
       fInhiDiv = new Int_t[ fDim ];
       for(Int_t i=0; i<fDim; i++) fInhiDiv[i]=0;
    }
@@ -831,16 +831,16 @@ void TMVA::PDEFoam::CheckAll(Int_t level)
    for(iCell=1; iCell<=fLastCe; iCell++) {
       cell = fCells[iCell];
       //  checking general rules
-      if( ((cell->GetDau0()==0) && (cell->GetDau1()!=0) ) ||
-          ((cell->GetDau1()==0) && (cell->GetDau0()!=0) ) ) {
+      if( ((cell->GetDau0()==nullptr) && (cell->GetDau1()!=nullptr) ) ||
+          ((cell->GetDau1()==nullptr) && (cell->GetDau0()!=nullptr) ) ) {
          errors++;
          if (level==1) Log() << kFATAL << "ERROR: Cell's no %d has only one daughter " << iCell << Endl;
       }
-      if( (cell->GetDau0()==0) && (cell->GetDau1()==0) && (cell->GetStat()==0) ) {
+      if( (cell->GetDau0()==nullptr) && (cell->GetDau1()==nullptr) && (cell->GetStat()==0) ) {
          errors++;
          if (level==1) Log() << kFATAL << "ERROR: Cell's no %d  has no daughter and is inactive " << iCell << Endl;
       }
-      if( (cell->GetDau0()!=0) && (cell->GetDau1()!=0) && (cell->GetStat()==1) ) {
+      if( (cell->GetDau0()!=nullptr) && (cell->GetDau1()!=nullptr) && (cell->GetStat()==1) ) {
          errors++;
          if (level==1) Log() << kFATAL << "ERROR: Cell's no %d has two daughters and is active " << iCell << Endl;
       }
@@ -854,13 +854,13 @@ void TMVA::PDEFoam::CheckAll(Int_t level)
       }
 
       // checking daughters
-      if(cell->GetDau0()!=0) {
+      if(cell->GetDau0()!=nullptr) {
          if(cell != (cell->GetDau0())->GetPare()) {
             errors++;
             if (level==1)  Log() << kFATAL << "ERROR: Cell's no %d daughter 0 not pointing to this cell " << iCell << Endl;
          }
       }
-      if(cell->GetDau1()!=0) {
+      if(cell->GetDau1()!=nullptr) {
          if(cell != (cell->GetDau1())->GetPare()) {
             errors++;
             if (level==1) Log() << kFATAL << "ERROR: Cell's no %d daughter 1 not pointing to this cell " << iCell << Endl;
@@ -926,7 +926,7 @@ void TMVA::PDEFoam::PrintCell(Long_t iCell)
    // print the cell elements
    Log() << "Elements: [";
    TVectorD *vec = (TVectorD*)fCells[iCell]->GetElement();
-   if (vec != NULL){
+   if (vec != nullptr){
       for (Int_t i=0; i<vec->GetNrows(); i++){
          if (i>0) Log() << ", ";
          Log() << GetCellElement(fCells[iCell], i);
@@ -978,7 +978,7 @@ void TMVA::PDEFoam::ResetCellElements()
       TObject* elements = fCells[iCell]->GetElement();
       if (elements) {
          delete elements;
-         fCells[iCell]->SetElement(NULL);
+         fCells[iCell]->SetElement(nullptr);
       }
    }
 }
@@ -1017,7 +1017,7 @@ Bool_t TMVA::PDEFoam::CellValueIsUndefined( PDEFoamCell* /* cell */ )
 Float_t TMVA::PDEFoam::GetCellValue(const std::vector<Float_t> &xvec, ECellValue cv, PDEFoamKernelBase *kernel)
 {
    std::vector<Float_t> txvec(VarTransform(xvec));
-   if (kernel == NULL)
+   if (kernel == nullptr)
       return GetCellValue(FindCell(txvec), cv);
    else
       return kernel->Estimate(this, txvec, cv);
@@ -1236,7 +1236,7 @@ TH1D* TMVA::PDEFoam::Draw1Dim( ECellValue cell_value, Int_t nbin, PDEFoamKernelB
       std::vector<Float_t> txvec;
       txvec.push_back( VarTransform(0, h1->GetBinCenter(ibinx)) );
       Float_t val = 0;
-      if (kernel != NULL) {
+      if (kernel != nullptr) {
          // get cell value using the kernel
          val = kernel->Estimate(this, txvec, cell_value);
       } else {
@@ -1331,7 +1331,7 @@ TH2D* TMVA::PDEFoam::Project2( Int_t idim1, Int_t idim2, ECellValue cell_value, 
                else
                   tvec.push_back(txvec[i]);
             }
-            if (kernel != NULL) {
+            if (kernel != nullptr) {
                // get the cell value using the kernel
                sum_cv += kernel->Estimate(this, tvec, cell_value);
             } else {
@@ -1432,11 +1432,11 @@ Double_t TMVA::PDEFoam::GetCellElement( const PDEFoamCell *cell, UInt_t i ) cons
 
 void TMVA::PDEFoam::SetCellElement( PDEFoamCell *cell, UInt_t i, Double_t value )
 {
-   TVectorD *vec = NULL;
+   TVectorD *vec = nullptr;
 
    // if no cell elements are set, create TVectorD with i+1 entries,
    // ranging from [0,i]
-   if (cell->GetElement() == NULL) {
+   if (cell->GetElement() == nullptr) {
       vec = new TVectorD(i+1);
       vec->Zero();       // set all values to zero
       (*vec)(i) = value; // set element i to value
@@ -1565,7 +1565,7 @@ void TMVA::PDEFoam::RootPlot2dim( const TString& filename, TString opt,
    }
 
    if (fillcells)
-      (colors ? gStyle->SetPalette(1, 0) : gStyle->SetPalette(0) );
+      (colors ? gStyle->SetPalette(1, nullptr) : gStyle->SetPalette(0) );
 
    Float_t zmin = 1E8;  // minimal value (for color calculation)
    Float_t zmax = -1E8; // maximal value (for color calculation)
@@ -1667,5 +1667,5 @@ void TMVA::PDEFoam::FillBinarySearchTree( const Event* ev )
 void TMVA::PDEFoam::DeleteBinarySearchTree()
 {
    if(fDistr) delete fDistr;
-   fDistr = NULL;
+   fDistr = nullptr;
 }

--- a/tmva/tmva/src/PDEFoam.cxx
+++ b/tmva/tmva/src/PDEFoam.cxx
@@ -940,7 +940,7 @@ void TMVA::PDEFoam::PrintCell(Long_t iCell)
 ////////////////////////////////////////////////////////////////////////////////
 /// Prints geometry of ALL cells of the FOAM
 
-void TMVA::PDEFoam::PrintCells(void)
+void TMVA::PDEFoam::PrintCells()
 {
    for(Long_t iCell=0; iCell<=fLastCe; iCell++)
       PrintCell(iCell);

--- a/tmva/tmva/src/PDEFoamCell.cxx
+++ b/tmva/tmva/src/PDEFoamCell.cxx
@@ -191,7 +191,7 @@ void    TMVA::PDEFoamCell::GetHSize( PDEFoamVect &cellSize)  const
 ////////////////////////////////////////////////////////////////////////////////
 /// Calculates volume of the cell using size params which are calculated
 
-void TMVA::PDEFoamCell::CalcVolume(void)
+void TMVA::PDEFoamCell::CalcVolume()
 {
    Int_t k;
    Double_t volu=1.0;

--- a/tmva/tmva/src/PDEFoamCell.cxx
+++ b/tmva/tmva/src/PDEFoamCell.cxx
@@ -55,15 +55,15 @@ TMVA::PDEFoamCell::PDEFoamCell()
    fDim(0),
    fSerial(0),
    fStatus(1),
-   fParent(0),
-   fDaught0(0),
-   fDaught1(0),
+   fParent(nullptr),
+   fDaught0(nullptr),
+   fDaught1(nullptr),
    fXdiv(0.0),
    fBest(0),
    fVolume(0.0),
    fIntegral(0.0),
    fDrive(0.0),
-   fElement(0)
+   fElement(nullptr)
 {
 }
 
@@ -75,15 +75,15 @@ TMVA::PDEFoamCell::PDEFoamCell(Int_t kDim)
      fDim(kDim),
      fSerial(0),
      fStatus(1),
-     fParent(0),
-     fDaught0(0),
-     fDaught1(0),
+     fParent(nullptr),
+     fDaught0(nullptr),
+     fDaught1(nullptr),
      fXdiv(0.0),
      fBest(0),
      fVolume(0.0),
      fIntegral(0.0),
      fDrive(0.0),
-     fElement(0)
+     fElement(nullptr)
 {
    if ( kDim <= 0 )
       Error( "PDEFoamCell", "Dimension has to be >0" );
@@ -143,9 +143,9 @@ void    TMVA::PDEFoamCell::GetHcub( PDEFoamVect &cellPosi, PDEFoamVect &cellSize
    const PDEFoamCell *pCell,*dCell;
    cellPosi = 0.0; cellSize=1.0; // load all components
    dCell = this;
-   while(dCell != 0) {
+   while(dCell != nullptr) {
       pCell = dCell->GetPare();
-      if( pCell== 0) break;
+      if( pCell== nullptr) break;
       Int_t    kDiv = pCell->fBest;
       Double_t xDivi = pCell->fXdiv;
       if(dCell == pCell->GetDau0()  ) {
@@ -172,9 +172,9 @@ void    TMVA::PDEFoamCell::GetHSize( PDEFoamVect &cellSize)  const
    const PDEFoamCell *pCell,*dCell;
    cellSize=1.0; // load all components
    dCell = this;
-   while(dCell != 0) {
+   while(dCell != nullptr) {
       pCell = dCell->GetPare();
-      if( pCell== 0) break;
+      if( pCell== nullptr) break;
       Int_t    kDiv = pCell->fBest;
       Double_t xDivi = pCell->fXdiv;
       if(dCell == pCell->GetDau0() ) {
@@ -210,12 +210,12 @@ void TMVA::PDEFoamCell::CalcVolume(void)
 UInt_t TMVA::PDEFoamCell::GetDepth()
 {
    // check whether we are in the root cell
-   if (fParent == 0)
+   if (fParent == nullptr)
       return 1;
 
    UInt_t depth = 1;
    PDEFoamCell *cell = this;
-   while ((cell=cell->GetPare()) != 0){
+   while ((cell=cell->GetPare()) != nullptr){
       ++depth;
    }
    return depth;
@@ -230,9 +230,9 @@ UInt_t TMVA::PDEFoamCell::GetTreeDepth(UInt_t depth)
       return depth + 1;
 
    UInt_t depth0 = 0, depth1 = 0;
-   if (GetDau0() != NULL)
+   if (GetDau0() != nullptr)
       depth0 = GetDau0()->GetTreeDepth(depth+1);
-   if (GetDau1() != NULL)
+   if (GetDau1() != nullptr)
       depth1 = GetDau1()->GetTreeDepth(depth+1);
 
    return (depth0 > depth1 ? depth0 : depth1);

--- a/tmva/tmva/src/PDEFoamDecisionTree.cxx
+++ b/tmva/tmva/src/PDEFoamDecisionTree.cxx
@@ -231,8 +231,8 @@ void TMVA::PDEFoamDecisionTree::Explore(PDEFoamCell *cell)
       SetCellElement(cell, 0, nTotS + nTotB);
 
    // clean up
-   for (UInt_t ih = 0; ih < hsig.size(); ih++)  delete hsig.at(ih);
-   for (UInt_t ih = 0; ih < hbkg.size(); ih++)  delete hbkg.at(ih);
-   for (UInt_t ih = 0; ih < hsig_unw.size(); ih++)  delete hsig_unw.at(ih);
-   for (UInt_t ih = 0; ih < hbkg_unw.size(); ih++)  delete hbkg_unw.at(ih);
+   for (auto & ih : hsig)  delete ih;
+   for (auto & ih : hbkg)  delete ih;
+   for (auto & ih : hsig_unw)  delete ih;
+   for (auto & ih : hbkg_unw)  delete ih;
 }

--- a/tmva/tmva/src/PDEFoamDecisionTree.cxx
+++ b/tmva/tmva/src/PDEFoamDecisionTree.cxx
@@ -68,7 +68,7 @@ ClassImp(TMVA::PDEFoamDecisionTree);
 
 TMVA::PDEFoamDecisionTree::PDEFoamDecisionTree()
 : PDEFoamDiscriminant()
-   , fSepType(NULL)
+   , fSepType(nullptr)
 {
 }
 
@@ -158,7 +158,7 @@ void TMVA::PDEFoamDecisionTree::Explore(PDEFoamCell *cell)
 
    // fDistr must be of type PDEFoamDecisionTreeDensity*
    PDEFoamDecisionTreeDensity *distr = dynamic_cast<PDEFoamDecisionTreeDensity*>(fDistr);
-   if (distr == NULL)
+   if (distr == nullptr)
       Log() << kFATAL << "<PDEFoamDecisionTree::Explore>: cast failed: "
             << "PDEFoamDensityBase* --> PDEFoamDecisionTreeDensity*" << Endl;
 

--- a/tmva/tmva/src/PDEFoamDensityBase.cxx
+++ b/tmva/tmva/src/PDEFoamDensityBase.cxx
@@ -143,7 +143,7 @@ TMVA::PDEFoamDensityBase::PDEFoamDensityBase(const PDEFoamDensityBase &distr)
 
 void TMVA::PDEFoamDensityBase::FillBinarySearchTree(const Event* ev)
 {
-   if (fBst == NULL)
+   if (fBst == nullptr)
       Log() << kFATAL << "<PDEFoamDensityBase::FillBinarySearchTree> "
             << "Binary tree is not set!" << Endl;
 

--- a/tmva/tmva/src/PDEFoamDiscriminant.cxx
+++ b/tmva/tmva/src/PDEFoamDiscriminant.cxx
@@ -236,7 +236,7 @@ TH2D* TMVA::PDEFoamDiscriminant::Project2(Int_t idim1, Int_t idim2, ECellValue c
             }
             // get the cell value using the kernel
             Float_t cv = 0;
-            if (kernel != NULL) {
+            if (kernel != nullptr) {
                cv = kernel->Estimate(this, tvec, cell_value);
             } else {
                cv = GetCellValue(FindCell(tvec), cell_value);

--- a/tmva/tmva/src/PDEFoamKernelBase.cxx
+++ b/tmva/tmva/src/PDEFoamKernelBase.cxx
@@ -68,6 +68,6 @@ TMVA::PDEFoamKernelBase::PDEFoamKernelBase(const PDEFoamKernelBase &other)
 
 TMVA::PDEFoamKernelBase::~PDEFoamKernelBase()
 {
-   if (fLogger != NULL)
+   if (fLogger != nullptr)
       delete fLogger;
 }

--- a/tmva/tmva/src/PDEFoamKernelGauss.cxx
+++ b/tmva/tmva/src/PDEFoamKernelGauss.cxx
@@ -78,7 +78,7 @@ TMVA::PDEFoamKernelGauss::PDEFoamKernelGauss(const PDEFoamKernelGauss &other)
 
 Float_t TMVA::PDEFoamKernelGauss::Estimate(PDEFoam *foam, std::vector<Float_t> &txvec, ECellValue cv)
 {
-   if (foam == NULL)
+   if (foam == nullptr)
       Log() << kFATAL << "<PDEFoamKernelGauss::Estimate>: PDEFoam not set!" << Endl;
 
    Float_t result = 0, norm = 0;
@@ -132,8 +132,8 @@ Float_t TMVA::PDEFoamKernelGauss::GetAverageNeighborsValue(PDEFoam *foam,
    // loop over all dimensions and find neighbor cells
    for (Int_t dim = 0; dim < foam->GetTotDim(); dim++) {
       std::vector<Float_t> ntxvec(txvec);
-      PDEFoamCell* left_cell  = 0; // left cell
-      PDEFoamCell* right_cell = 0; // right cell
+      PDEFoamCell* left_cell  = nullptr; // left cell
+      PDEFoamCell* right_cell = nullptr; // right cell
 
       // get left cell
       ntxvec[dim] = cellPosi[dim] - xoffset;

--- a/tmva/tmva/src/PDEFoamKernelLinN.cxx
+++ b/tmva/tmva/src/PDEFoamKernelLinN.cxx
@@ -76,7 +76,7 @@ TMVA::PDEFoamKernelLinN::PDEFoamKernelLinN(const PDEFoamKernelLinN &other)
 
 Float_t TMVA::PDEFoamKernelLinN::Estimate(PDEFoam *foam, std::vector<Float_t> &txvec, ECellValue cv)
 {
-   if (foam == NULL)
+   if (foam == nullptr)
       Log() << kFATAL << "<PDEFoamKernelLinN::Estimate>: PDEFoam not set!" << Endl;
 
    return WeightLinNeighbors(foam, txvec, cv, kTRUE);
@@ -131,7 +131,7 @@ Float_t TMVA::PDEFoamKernelLinN::WeightLinNeighbors(PDEFoam *foam, std::vector<F
    for (Int_t dim = 0; dim < foam->GetTotDim(); dim++) {
       std::vector<Float_t> ntxvec(txvec);
       Float_t mindist;
-      PDEFoamCell *mindistcell = 0; // cell with minimal distance to txvec
+      PDEFoamCell *mindistcell = nullptr; // cell with minimal distance to txvec
       // calc minimal distance to neighbor cell
       mindist = (txvec[dim] - cellPosi[dim]) / cellSize[dim];
       if (mindist < 0.5) { // left neighbour
@@ -183,8 +183,8 @@ Float_t TMVA::PDEFoamKernelLinN::GetAverageNeighborsValue(PDEFoam *foam,
    // loop over all dimensions and find neighbor cells
    for (Int_t dim = 0; dim < foam->GetTotDim(); dim++) {
       std::vector<Float_t> ntxvec(txvec);
-      PDEFoamCell* left_cell  = 0; // left cell
-      PDEFoamCell* right_cell = 0; // right cell
+      PDEFoamCell* left_cell  = nullptr; // left cell
+      PDEFoamCell* right_cell = nullptr; // right cell
 
       // get left cell
       ntxvec[dim] = cellPosi[dim] - xoffset;

--- a/tmva/tmva/src/PDEFoamKernelTrivial.cxx
+++ b/tmva/tmva/src/PDEFoamKernelTrivial.cxx
@@ -74,7 +74,7 @@ TMVA::PDEFoamKernelTrivial::PDEFoamKernelTrivial(const PDEFoamKernelTrivial &oth
 
 Float_t TMVA::PDEFoamKernelTrivial::Estimate(PDEFoam *foam, std::vector<Float_t> &txvec, ECellValue cv)
 {
-   if (foam == NULL)
+   if (foam == nullptr)
       Log() << kFATAL << "<PDEFoamKernelTrivial::Estimate>: PDEFoam not set!" << Endl;
 
    return foam->GetCellValue(foam->FindCell(txvec), cv);

--- a/tmva/tmva/src/PDEFoamMultiTarget.cxx
+++ b/tmva/tmva/src/PDEFoamMultiTarget.cxx
@@ -129,10 +129,9 @@ std::vector<Float_t> TMVA::PDEFoamMultiTarget::GetCellValue(const std::map<Int_t
 {
    // transform event vector
    std::map<Int_t, Float_t> txvec; // transformed event vector
-   for (std::map<Int_t, Float_t>::const_iterator it = xvec.begin();
-        it != xvec.end(); ++it) {
-      Float_t coordinate = it->second; // event coordinate
-      Int_t dim = it->first;           // dimension
+   for (const auto & it : xvec) {
+      Float_t coordinate = it.second; // event coordinate
+      Int_t dim = it.first;           // dimension
       // checkt whether coordinate is within foam borders. if not,
       // push event coordinate into foam
       if (coordinate <= fXmin[dim])
@@ -204,26 +203,24 @@ void TMVA::PDEFoamMultiTarget::CalculateMpv(std::map<Int_t, Float_t>& target, co
    Double_t max_dens = 0.0;            // maximum cell density
 
    // loop over all cells and find cell with maximum event density
-   for (std::vector<PDEFoamCell*>::const_iterator cell_it = cells.begin();
-        cell_it != cells.end(); ++cell_it) {
+   for (auto cell : cells) {
 
       // get event density of cell
-      const Double_t cell_density = GetCellValue(*cell_it, kValueDensity);
+      const Double_t cell_density = GetCellValue(cell, kValueDensity);
 
       // has this cell a larger event density?
       if (cell_density > max_dens) {
          // get cell position and size
          PDEFoamVect  cellPosi(GetTotDim()), cellSize(GetTotDim());
-         (*cell_it)->GetHcub(cellPosi, cellSize);
+         cell->GetHcub(cellPosi, cellSize);
 
          // save new maximum density
          max_dens = cell_density;
 
          // calculate new target values
-         for (std::map<Int_t, Float_t>::iterator target_it = target.begin();
-              target_it != target.end(); ++target_it) {
-            const Int_t dim = target_it->first; // target dimension
-            target_it->second =
+         for (auto & target_it : target) {
+            const Int_t dim = target_it.first; // target dimension
+            target_it.second =
                VarTransformInvers(dim, cellPosi[dim] + 0.5 * cellSize[dim]);
          }
       }
@@ -251,21 +248,19 @@ void TMVA::PDEFoamMultiTarget::CalculateMean(std::map<Int_t, Float_t>& target, c
    std::map<Int_t, Float_t> norm;
 
    // loop over all cells and find cell with maximum event density
-   for (std::vector<PDEFoamCell*>::const_iterator cell_it = cells.begin();
-        cell_it != cells.end(); ++cell_it) {
+   for (auto cell : cells) {
 
       // get event density of cell
-      const Double_t cell_density = GetCellValue(*cell_it, kValueDensity);
+      const Double_t cell_density = GetCellValue(cell, kValueDensity);
 
       // get cell position and size
       PDEFoamVect  cellPosi(GetTotDim()), cellSize(GetTotDim());
-      (*cell_it)->GetHcub(cellPosi, cellSize);
+      cell->GetHcub(cellPosi, cellSize);
 
       // accumulate weighted target values
-      for (std::map<Int_t, Float_t>::iterator target_it = target.begin();
-           target_it != target.end(); ++target_it) {
-         const Int_t dim = target_it->first; // target dimension
-         target_it->second += cell_density *
+      for (auto & target_it : target) {
+         const Int_t dim = target_it.first; // target dimension
+         target_it.second += cell_density *
             VarTransformInvers(dim, cellPosi[dim] + 0.5 * cellSize[dim]);
          norm[dim] += cell_density;
       }

--- a/tmva/tmva/src/PDEFoamTarget.cxx
+++ b/tmva/tmva/src/PDEFoamTarget.cxx
@@ -154,7 +154,7 @@ Float_t TMVA::PDEFoamTarget::GetCellValue(const std::vector<Float_t> &xvec, ECel
 
    if (!CellValueIsUndefined(cell)) {
       // cell is not empty
-      if (kernel == NULL)
+      if (kernel == nullptr)
          return GetCellValue(cell, cv);
       else
          return kernel->Estimate(this, txvec, cv);
@@ -187,8 +187,8 @@ Float_t TMVA::PDEFoamTarget::GetAverageNeighborsValue(std::vector<Float_t> &txve
    // loop over all dimensions and find neighbor cells
    for (Int_t dim = 0; dim < GetTotDim(); dim++) {
       std::vector<Float_t> ntxvec(txvec);
-      PDEFoamCell* left_cell  = 0; // left cell
-      PDEFoamCell* right_cell = 0; // right cell
+      PDEFoamCell* left_cell  = nullptr; // left cell
+      PDEFoamCell* right_cell = nullptr; // right cell
 
       // get left cell
       ntxvec[dim] = cellPosi[dim] - xoffset;

--- a/tmva/tmva/src/PDEFoamVect.cxx
+++ b/tmva/tmva/src/PDEFoamVect.cxx
@@ -50,7 +50,7 @@ ClassImp(TMVA::PDEFoamVect);
 TMVA::PDEFoamVect::PDEFoamVect()
 : TObject(),
    fDim(0),
-   fCoords(0)
+   fCoords(nullptr)
 {
 }
 
@@ -61,7 +61,7 @@ TMVA::PDEFoamVect::PDEFoamVect()
 TMVA::PDEFoamVect::PDEFoamVect(Int_t n)
    : TObject(),
      fDim(n),
-     fCoords(0)
+     fCoords(nullptr)
 {
    if (n>0) {
       fCoords = new Double_t[fDim];
@@ -86,7 +86,7 @@ TMVA::PDEFoamVect::PDEFoamVect(const PDEFoamVect &vect)
 TMVA::PDEFoamVect::~PDEFoamVect()
 {
    delete [] fCoords; //  free(fCoords)
-   fCoords=0;
+   fCoords=nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -200,7 +200,7 @@ TMVA::PDEFoamVect& TMVA::PDEFoamVect::operator =(Double_t Vect[])
 
 TMVA::PDEFoamVect& TMVA::PDEFoamVect::operator =(Double_t x)
 {
-   if(fCoords != 0) {
+   if(fCoords != nullptr) {
       for(Int_t i=0; i<fDim; i++)
          fCoords[i] = x;
    }

--- a/tmva/tmva/src/PDF.cxx
+++ b/tmva/tmva/src/PDF.cxx
@@ -72,14 +72,14 @@ TMVA::PDF::PDF( const TString& name, Bool_t norm )
    fNsmooth       ( 0 ),
    fMinNsmooth    (-1 ),
    fMaxNsmooth    (-1 ),
-   fNSmoothHist   ( 0 ),
+   fNSmoothHist   ( nullptr ),
    fInterpolMethod( PDF::kSpline2 ),
-   fSpline        ( 0 ),
-   fPDFHist       ( 0 ),
-   fHist          ( 0 ),
-   fHistOriginal  ( 0 ),
-   fGraph         ( 0 ),
-   fIGetVal       ( 0 ),
+   fSpline        ( nullptr ),
+   fPDFHist       ( nullptr ),
+   fHist          ( nullptr ),
+   fHistOriginal  ( nullptr ),
+   fGraph         ( nullptr ),
+   fIGetVal       ( nullptr ),
    fHistAvgEvtPerBin  ( 0 ),
    fHistDefinedNBins  ( 0 ),
    fKDEtypeString     ( 0 ),
@@ -94,7 +94,7 @@ TMVA::PDF::PDF( const TString& name, Bool_t norm )
    fCheckHist     ( kFALSE ),
    fNormalize     ( norm ),
    fSuffix        ( "" ),
-   fLogger        ( 0 )
+   fLogger        ( nullptr )
 {
    fLogger   = new MsgLogger(this);
    GetThisPdfThreadLocal() = this;
@@ -115,14 +115,14 @@ TMVA::PDF::PDF( const TString& name,
    fPDFName       ( name ),
    fMinNsmooth    ( minnsmooth ),
    fMaxNsmooth    ( maxnsmooth ),
-   fNSmoothHist   ( 0 ),
+   fNSmoothHist   ( nullptr ),
    fInterpolMethod( method ),
-   fSpline        ( 0 ),
-   fPDFHist       ( 0 ),
-   fHist          ( 0 ),
-   fHistOriginal  ( 0 ),
-   fGraph         ( 0 ),
-   fIGetVal       ( 0 ),
+   fSpline        ( nullptr ),
+   fPDFHist       ( nullptr ),
+   fHist          ( nullptr ),
+   fHistOriginal  ( nullptr ),
+   fGraph         ( nullptr ),
+   fIGetVal       ( nullptr ),
    fHistAvgEvtPerBin  ( 0 ),
    fHistDefinedNBins  ( 0 ),
    fKDEtypeString     ( 0 ),
@@ -137,7 +137,7 @@ TMVA::PDF::PDF( const TString& name,
    fCheckHist     ( checkHist ),
    fNormalize     ( norm ),
    fSuffix        ( "" ),
-   fLogger        ( 0 )
+   fLogger        ( nullptr )
 {
    fLogger   = new MsgLogger(this);
    BuildPDF( hist );
@@ -159,14 +159,14 @@ TMVA::PDF::PDF( const TString& name,
    fNsmooth       ( 0 ),
    fMinNsmooth    (-1 ),
    fMaxNsmooth    (-1 ),
-   fNSmoothHist   ( 0 ),
+   fNSmoothHist   ( nullptr ),
    fInterpolMethod( PDF::kKDE ),
-   fSpline        ( 0 ),
-   fPDFHist       ( 0 ),
-   fHist          ( 0 ),
-   fHistOriginal  ( 0 ),
-   fGraph         ( 0 ),
-   fIGetVal       ( 0 ),
+   fSpline        ( nullptr ),
+   fPDFHist       ( nullptr ),
+   fHist          ( nullptr ),
+   fHistOriginal  ( nullptr ),
+   fGraph         ( nullptr ),
+   fIGetVal       ( nullptr ),
    fHistAvgEvtPerBin  ( 0 ),
    fHistDefinedNBins  ( 0 ),
    fKDEtypeString     ( 0 ),
@@ -181,7 +181,7 @@ TMVA::PDF::PDF( const TString& name,
    fCheckHist     ( kFALSE ),
    fNormalize     ( norm ),
    fSuffix        ( "" ),
-   fLogger        ( 0 )
+   fLogger        ( nullptr )
 {
    fLogger   = new MsgLogger(this);
    BuildPDF( hist );
@@ -200,14 +200,14 @@ TMVA::PDF::PDF( const TString& name,
    fNsmooth       ( 0 ),
    fMinNsmooth    ( -1 ),
    fMaxNsmooth    ( -1 ),
-   fNSmoothHist   ( 0 ),
+   fNSmoothHist   ( nullptr ),
    fInterpolMethod( PDF::kSpline0 ),
-   fSpline        ( 0 ),
-   fPDFHist       ( 0 ),
-   fHist          ( 0 ),
-   fHistOriginal  ( 0 ),
-   fGraph         ( 0 ),
-   fIGetVal       ( 0 ),
+   fSpline        ( nullptr ),
+   fPDFHist       ( nullptr ),
+   fHist          ( nullptr ),
+   fHistOriginal  ( nullptr ),
+   fGraph         ( nullptr ),
+   fIGetVal       ( nullptr ),
    fHistAvgEvtPerBin  ( 50 ),
    fHistDefinedNBins  ( 0 ),
    fKDEtypeString     ( "Gauss" ),
@@ -222,10 +222,10 @@ TMVA::PDF::PDF( const TString& name,
    fCheckHist     ( kFALSE ),
    fNormalize     ( norm ),
    fSuffix        ( suffix ),
-   fLogger        ( 0 )
+   fLogger        ( nullptr )
 {
    fLogger   = new MsgLogger(this);
-   if (defaultPDF != 0) {
+   if (defaultPDF != nullptr) {
       fNsmooth            = defaultPDF->fNsmooth;
       fMinNsmooth         = defaultPDF->fMinNsmooth;
       fMaxNsmooth         = defaultPDF->fMaxNsmooth;
@@ -245,12 +245,12 @@ TMVA::PDF::PDF( const TString& name,
 TMVA::PDF::~PDF()
 {
    // destructor
-   if (fSpline       != NULL) delete fSpline;
-   if (fHist         != NULL) delete fHist;
-   if (fPDFHist      != NULL) delete fPDFHist;
-   if (fHistOriginal != NULL) delete fHistOriginal;
-   if (fIGetVal      != NULL) delete fIGetVal;
-   if (fGraph        != NULL) delete fGraph;
+   if (fSpline       != nullptr) delete fSpline;
+   if (fHist         != nullptr) delete fHist;
+   if (fPDFHist      != nullptr) delete fPDFHist;
+   if (fHistOriginal != nullptr) delete fHistOriginal;
+   if (fIGetVal      != nullptr) delete fIGetVal;
+   if (fGraph        != nullptr) delete fGraph;
    delete fLogger;
 }
 
@@ -260,7 +260,7 @@ void TMVA::PDF::BuildPDF( const TH1* hist )
 {
    GetThisPdfThreadLocal() = this;
    // sanity check
-   if (hist == NULL) Log() << kFATAL << "Called without valid histogram pointer!" << Endl;
+   if (hist == nullptr) Log() << kFATAL << "Called without valid histogram pointer!" << Endl;
 
    // histogram should be non empty
    if (hist->GetEntries() <= 0)
@@ -290,8 +290,8 @@ void TMVA::PDF::BuildPDF( const TH1* hist )
    fHist        ->SetTitle( fHist->GetName() );
 
    // do not store in current target file
-   fHistOriginal->SetDirectory(0);
-   fHist        ->SetDirectory(0);
+   fHistOriginal->SetDirectory(nullptr);
+   fHist        ->SetDirectory(nullptr);
    fUseHistogram = kFALSE;
 
    if (fInterpolMethod == PDF::kKDE) BuildKDEPDF();
@@ -322,7 +322,7 @@ void TMVA::PDF::BuildSplinePDF()
    // (not useful for discrete distributions, or if no splines are requested)
    if (fInterpolMethod != PDF::kSpline0 && fCheckHist) CheckHist();
    // use ROOT TH1 smooth method
-   fNSmoothHist = 0;
+   fNSmoothHist = nullptr;
    if (fMaxNsmooth > 0 && fMinNsmooth >=0 ) SmoothHistogram();
 
    // fill histogramm to graph
@@ -376,7 +376,7 @@ void TMVA::PDF::BuildSplinePDF()
    if (fNormalize)
       if (integral>0) fPDFHist->Scale( 1.0/integral );
 
-   fPDFHist->SetDirectory(0);
+   fPDFHist->SetDirectory(nullptr);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -446,7 +446,7 @@ void TMVA::PDF::BuildKDEPDF()
    // normalize
    if (fNormalize)
       if (integral>0) fPDFHist->Scale( 1.0/integral );
-   fPDFHist->SetDirectory(0);
+   fPDFHist->SetDirectory(nullptr);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -547,7 +547,7 @@ void TMVA::PDF::FillSplineToHist()
          fPDFHist->SetBinContent( bin, TMath::Max(y, fgEpsilon) );
       }
    }
-   fPDFHist->SetDirectory(0);
+   fPDFHist->SetDirectory(nullptr);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -555,7 +555,7 @@ void TMVA::PDF::FillSplineToHist()
 
 void TMVA::PDF::CheckHist() const
 {
-   if (fHist == NULL) {
+   if (fHist == nullptr) {
       Log() << kFATAL << "<CheckHist> Called without valid histogram pointer!" << Endl;
    }
 
@@ -691,7 +691,7 @@ Double_t TMVA::PDF::GetIntegral( Double_t xmin, Double_t xmax )
    else {
 
       // compute via Gaussian quadrature (C++ version of CERNLIB function DGAUSS)
-      if (fIGetVal == 0) fIGetVal = new TF1( "IGetVal", PDF::IGetVal, GetXmin(), GetXmax(), 0 );
+      if (fIGetVal == nullptr) fIGetVal = new TF1( "IGetVal", PDF::IGetVal, GetXmin(), GetXmax(), 0 );
       integral = fIGetVal->Integral( xmin, xmax );
    }
 
@@ -986,10 +986,10 @@ void TMVA::PDF::ReadXML( void* pdfnode )
    gTools().ReadAttr( histch, "HasEquidistantBins", hasEquidistantBinning );
 
    // recreate the original hist
-   TH1* newhist = 0;
+   TH1* newhist = nullptr;
    if (hasEquidistantBinning) {
       newhist = new TH1F( hname, hname, nbins, xmin, xmax );
-      newhist->SetDirectory(0);
+      newhist->SetDirectory(nullptr);
       const char* content = gTools().GetContent(histch);
       std::stringstream s(content);
       Double_t val;
@@ -1013,7 +1013,7 @@ void TMVA::PDF::ReadXML( void* pdfnode )
       std::stringstream sb(binString);
       for (UInt_t i=0; i<=nbins; i++) sb >> binns[i];
       newhist =  new TH1F( hname, hname, nbins, binns.GetMatrixArray() );
-      newhist->SetDirectory(0);
+      newhist->SetDirectory(nullptr);
       for (UInt_t i=0; i<nbins; i++) {
          s >> val;
          newhist->SetBinContent(i+1,val);
@@ -1023,11 +1023,11 @@ void TMVA::PDF::ReadXML( void* pdfnode )
    TString hnameSmooth = hname;
    hnameSmooth.ReplaceAll( "_original", "_smoothed" );
 
-   if (fHistOriginal != 0) delete fHistOriginal;
+   if (fHistOriginal != nullptr) delete fHistOriginal;
    fHistOriginal = newhist;
    fHist = (TH1F*)fHistOriginal->Clone( hnameSmooth );
    fHist->SetTitle( hnameSmooth );
-   fHist->SetDirectory(0);
+   fHist->SetDirectory(nullptr);
 
    if (fInterpolMethod == PDF::kKDE) BuildKDEPDF();
    else                              BuildSplinePDF();
@@ -1114,18 +1114,18 @@ std::istream& TMVA::operator>> ( std::istream& istr, PDF& pdf )
       std::exit(1);
    }
    TH1* newhist = new TH1F( hname,hname, nbins, xmin, xmax );
-   newhist->SetDirectory(0);
+   newhist->SetDirectory(nullptr);
    Float_t val;
    for (Int_t i=0; i<nbins; i++) {
       istr >> val;
       newhist->SetBinContent(i+1,val);
    }
 
-   if (pdf.fHistOriginal != 0) delete pdf.fHistOriginal;
+   if (pdf.fHistOriginal != nullptr) delete pdf.fHistOriginal;
    pdf.fHistOriginal = newhist;
    pdf.fHist = (TH1F*)pdf.fHistOriginal->Clone( hnameSmooth );
    pdf.fHist->SetTitle( hnameSmooth );
-   pdf.fHist->SetDirectory(0);
+   pdf.fHist->SetDirectory(nullptr);
 
    if (pdf.fMinNsmooth>=0) pdf.BuildSplinePDF();
    else {

--- a/tmva/tmva/src/PDF.cxx
+++ b/tmva/tmva/src/PDF.cxx
@@ -1136,7 +1136,7 @@ std::istream& TMVA::operator>> ( std::istream& istr, PDF& pdf )
    return istr;
 }
 
-TMVA::PDF*  TMVA::PDF::ThisPDF( void )
+TMVA::PDF*  TMVA::PDF::ThisPDF()
 {
    // return global "this" pointer of PDF
    return GetThisPdfThreadLocal();

--- a/tmva/tmva/src/ROCCalc.cxx
+++ b/tmva/tmva/src/ROCCalc.cxx
@@ -49,22 +49,22 @@ TMVA::ROCCalc::ROCCalc(TH1* mvaS, TH1* mvaB) :
    fMaxIter(100),
    fAbsTol(0.0),
    fStatus(kTRUE),
-   fmvaS(0),
-   fmvaB(0),
-   fmvaSpdf(0),
-   fmvaBpdf(0),
-   fSplS(0),
-   fSplB(0),
-   fSplmvaCumS(0),
-   fSplmvaCumB(0),
-   fSpleffBvsS(0),
+   fmvaS(nullptr),
+   fmvaB(nullptr),
+   fmvaSpdf(nullptr),
+   fmvaBpdf(nullptr),
+   fSplS(nullptr),
+   fSplB(nullptr),
+   fSplmvaCumS(nullptr),
+   fSplmvaCumB(nullptr),
+   fSpleffBvsS(nullptr),
    fnStot(0),
    fnBtot(0),
-   fSignificance(0),
-   fPurity(0),
-   effBvsS(0),
-   rejBvsS(0),
-   inveffBvsS(0),
+   fSignificance(nullptr),
+   fPurity(nullptr),
+   effBvsS(nullptr),
+   rejBvsS(nullptr),
+   inveffBvsS(nullptr),
    fLogger ( new TMVA::MsgLogger("ROCCalc") )
 {
    fUseSplines = kTRUE;
@@ -93,7 +93,7 @@ TMVA::ROCCalc::ROCCalc(TH1* mvaS, TH1* mvaB) :
    //the I will divide it by 10 anyway doing some tests ROC integral is the same
    fmvaSpdf = mvaS->RebinX(mvaS->GetNbinsX()/10,"MVA Signal PDF");
    fmvaBpdf = mvaB->RebinX(mvaB->GetNbinsX()/10,"MVA Backgr PDF");
-   if(fmvaSpdf==0||fmvaBpdf==0)
+   if(fmvaSpdf==nullptr||fmvaBpdf==nullptr)
       {
          Log() << kERROR << "Cannot Rebin Histograms mvaS and mvaB, ROC values will be calculated without Rebin histograms."<<Endl;
          fStatus=kFALSE;
@@ -138,21 +138,21 @@ void TMVA::ROCCalc::ApplySignalAndBackgroundStyle( TH1* sig, TH1* bkg, TH1* any 
    Int_t LineColor__B = c_BackgroundLine;
    Int_t LineWidth__B = 2;
 
-   if (sig != NULL) {
+   if (sig != nullptr) {
       sig->SetLineColor( LineColor__S );
       sig->SetLineWidth( LineWidth__S );
       sig->SetFillStyle( FillStyle__S );
       sig->SetFillColor( FillColor__S );
    }
 
-   if (bkg != NULL) {
+   if (bkg != nullptr) {
       bkg->SetLineColor( LineColor__B );
       bkg->SetLineWidth( LineWidth__B );
       bkg->SetFillStyle( FillStyle__B );
       bkg->SetFillColor( FillColor__B );
    }
 
-   if (any != NULL) {
+   if (any != nullptr) {
       any->SetLineColor( LineColor__S );
       any->SetLineWidth( LineWidth__S );
       any->SetFillStyle( FillStyle__S );
@@ -165,11 +165,11 @@ void TMVA::ROCCalc::ApplySignalAndBackgroundStyle( TH1* sig, TH1* bkg, TH1* any 
 
 TMVA::ROCCalc::~ROCCalc() {
    // delete Splines and all histograms that were created only for internal use
-   if (fSplS)            { delete fSplS; fSplS = 0; }
-   if (fSplB)            { delete fSplB; fSplB = 0; }
-   if (fSpleffBvsS)      { delete fSpleffBvsS; fSpleffBvsS = 0; }
-   if (fSplmvaCumS)      { delete fSplmvaCumS; fSplmvaCumS = 0; }
-   if (fSplmvaCumB)      { delete fSplmvaCumB; fSplmvaCumB = 0; }
+   if (fSplS)            { delete fSplS; fSplS = nullptr; }
+   if (fSplB)            { delete fSplB; fSplB = nullptr; }
+   if (fSpleffBvsS)      { delete fSpleffBvsS; fSpleffBvsS = nullptr; }
+   if (fSplmvaCumS)      { delete fSplmvaCumS; fSplmvaCumS = nullptr; }
+   if (fSplmvaCumB)      { delete fSplmvaCumB; fSplmvaCumB = nullptr; }
    if (fmvaScumul)       { delete fmvaScumul; }
    if (fmvaBcumul)       { delete fmvaBcumul; }
    if (effBvsS)          { delete effBvsS; }
@@ -200,17 +200,17 @@ TH1D* TMVA::ROCCalc::GetROC(){
    //   fmvaBcumul->Draw("histsame");
 
    // background efficiency versus signal efficiency
-   if(effBvsS==0) effBvsS = new TH1D("effBvsS", "ROC-Curve", fNbins, 0, 1 );
+   if(effBvsS==nullptr) effBvsS = new TH1D("effBvsS", "ROC-Curve", fNbins, 0, 1 );
    effBvsS->SetXTitle( "Signal eff" );
    effBvsS->SetYTitle( "Backgr eff" );
 
    // background rejection (=1-eff.) versus signal efficiency
-   if(rejBvsS==0) rejBvsS = new TH1D( "rejBvsS", "ROC-Curve", fNbins, 0, 1 );
+   if(rejBvsS==nullptr) rejBvsS = new TH1D( "rejBvsS", "ROC-Curve", fNbins, 0, 1 );
    rejBvsS->SetXTitle( "Signal eff" );
    rejBvsS->SetYTitle( "Backgr rejection (1-eff)" );
 
    // inverse background eff (1/eff.) versus signal efficiency
-   if(inveffBvsS ==0) inveffBvsS = new TH1D("invBeffvsSeff", "ROC-Curve" , fNbins, 0, 1 );
+   if(inveffBvsS ==nullptr) inveffBvsS = new TH1D("invBeffvsSeff", "ROC-Curve" , fNbins, 0, 1 );
    inveffBvsS->SetXTitle( "Signal eff" );
    inveffBvsS->SetYTitle( "Inverse backgr. eff (1/eff)" );
 
@@ -274,7 +274,7 @@ TH1D* TMVA::ROCCalc::GetROC(){
 Double_t TMVA::ROCCalc::GetROCIntegral(){
    Double_t effS = 0, effB = 0;
    Int_t    nbins = 1000;
-   if (fSpleffBvsS == 0) this->GetROC(); // that will make the ROC calculation if not done yet
+   if (fSpleffBvsS == nullptr) this->GetROC(); // that will make the ROC calculation if not done yet
 
    // compute area of rej-vs-eff plot
    Double_t integral = 0;
@@ -299,7 +299,7 @@ Double_t TMVA::ROCCalc::GetEffSForEffBof(Double_t effBref, Double_t &effSerr){
    // find precise efficiency value
    Double_t effS=0., effB, effSOld=1., effBOld=0.;
    Int_t    nbins = 1000;
-   if (fSpleffBvsS == 0) this->GetROC(); // that will make the ROC calculation if not done yet
+   if (fSpleffBvsS == nullptr) this->GetROC(); // that will make the ROC calculation if not done yet
 
    Float_t step=1./nbins;  // stepsize in efficiency binning
    for (Int_t bini=1; bini<=nbins; bini++) {

--- a/tmva/tmva/src/ROCCurve.cxx
+++ b/tmva/tmva/src/ROCCurve.cxx
@@ -46,7 +46,7 @@ auto tupleSort = [](std::tuple<Float_t, Float_t, Bool_t> _a, std::tuple<Float_t,
 
 //_______________________________________________________________________
 TMVA::ROCCurve::ROCCurve(const std::vector<std::tuple<Float_t, Float_t, Bool_t>> &mvas)
-   : fLogger(new TMVA::MsgLogger("ROCCurve")), fGraph(NULL), fMva(mvas)
+   : fLogger(new TMVA::MsgLogger("ROCCurve")), fGraph(nullptr), fMva(mvas)
 {
 }
 
@@ -55,7 +55,7 @@ TMVA::ROCCurve::ROCCurve(const std::vector<std::tuple<Float_t, Float_t, Bool_t>>
 
 TMVA::ROCCurve::ROCCurve(const std::vector<Float_t> &mvaValues, const std::vector<Bool_t> &mvaTargets,
                          const std::vector<Float_t> &mvaWeights)
-   : fLogger(new TMVA::MsgLogger("ROCCurve")), fGraph(NULL)
+   : fLogger(new TMVA::MsgLogger("ROCCurve")), fGraph(nullptr)
 {
    assert(mvaValues.size() == mvaTargets.size());
    assert(mvaValues.size() == mvaWeights.size());
@@ -71,7 +71,7 @@ TMVA::ROCCurve::ROCCurve(const std::vector<Float_t> &mvaValues, const std::vecto
 ///
 
 TMVA::ROCCurve::ROCCurve(const std::vector<Float_t> &mvaValues, const std::vector<Bool_t> &mvaTargets)
-   : fLogger(new TMVA::MsgLogger("ROCCurve")), fGraph(NULL)
+   : fLogger(new TMVA::MsgLogger("ROCCurve")), fGraph(nullptr)
 {
    assert(mvaValues.size() == mvaTargets.size());
 
@@ -86,7 +86,7 @@ TMVA::ROCCurve::ROCCurve(const std::vector<Float_t> &mvaValues, const std::vecto
 ///
 
 TMVA::ROCCurve::ROCCurve(const std::vector<Float_t> &mvaSignal, const std::vector<Float_t> &mvaBackground)
-   : fLogger(new TMVA::MsgLogger("ROCCurve")), fGraph(NULL)
+   : fLogger(new TMVA::MsgLogger("ROCCurve")), fGraph(nullptr)
 {
    for (UInt_t i = 0; i < mvaSignal.size(); i++) {
       fMva.emplace_back(mvaSignal[i], 1, kTRUE);
@@ -104,7 +104,7 @@ TMVA::ROCCurve::ROCCurve(const std::vector<Float_t> &mvaSignal, const std::vecto
 
 TMVA::ROCCurve::ROCCurve(const std::vector<Float_t> &mvaSignal, const std::vector<Float_t> &mvaBackground,
                          const std::vector<Float_t> &mvaSignalWeights, const std::vector<Float_t> &mvaBackgroundWeights)
-   : fLogger(new TMVA::MsgLogger("ROCCurve")), fGraph(NULL)
+   : fLogger(new TMVA::MsgLogger("ROCCurve")), fGraph(nullptr)
 {
    assert(mvaSignal.size() == mvaSignalWeights.size());
    assert(mvaBackground.size() == mvaBackgroundWeights.size());

--- a/tmva/tmva/src/ROCCurve.cxx
+++ b/tmva/tmva/src/ROCCurve.cxx
@@ -88,12 +88,12 @@ TMVA::ROCCurve::ROCCurve(const std::vector<Float_t> &mvaValues, const std::vecto
 TMVA::ROCCurve::ROCCurve(const std::vector<Float_t> &mvaSignal, const std::vector<Float_t> &mvaBackground)
    : fLogger(new TMVA::MsgLogger("ROCCurve")), fGraph(nullptr)
 {
-   for (UInt_t i = 0; i < mvaSignal.size(); i++) {
-      fMva.emplace_back(mvaSignal[i], 1, kTRUE);
+   for (float i : mvaSignal) {
+      fMva.emplace_back(i, 1, kTRUE);
    }
 
-   for (UInt_t i = 0; i < mvaBackground.size(); i++) {
-      fMva.emplace_back(mvaBackground[i], 1, kFALSE);
+   for (float i : mvaBackground) {
+      fMva.emplace_back(i, 1, kFALSE);
    }
 
    std::sort(fMva.begin(), fMva.end(), tupleSort);

--- a/tmva/tmva/src/Ranking.cxx
+++ b/tmva/tmva/src/Ranking.cxx
@@ -111,8 +111,8 @@ void TMVA::Ranking::AddRank( const Rank& rank )
 void TMVA::Ranking::Print() const
 {
    Int_t maxL = 0;
-   for (std::vector<Rank>::const_iterator ir = fRanking.begin(); ir != fRanking.end(); ++ir )
-      if ((*ir).GetVariable().Length() > maxL) maxL = (*ir).GetVariable().Length();
+   for (const auto & ir : fRanking)
+      if (ir.GetVariable().Length() > maxL) maxL = ir.GetVariable().Length();
 
    TString hline = "";
    for (Int_t i=0; i<maxL+15+fRankingDiscriminatorName.Length(); i++) hline += "-";
@@ -124,11 +124,11 @@ void TMVA::Ranking::Print() const
          << std::resetiosflags(std::ios::right)
          << " : " << fRankingDiscriminatorName << Endl;
    Log() << kINFO << hline << Endl;
-   for (std::vector<Rank>::const_iterator ir = fRanking.begin(); ir != fRanking.end(); ++ir ) {
+   for (const auto & ir : fRanking) {
       Log() << kINFO
-            << Form( "%4i : ",(*ir).GetRank() )
-            << std::setw(TMath::Max(maxL+0,9)) << (*ir).GetVariable().Data()
-            << Form( " : %3.3e", (*ir).GetRankValue() ) << Endl;
+            << Form( "%4i : ",ir.GetRank() )
+            << std::setw(TMath::Max(maxL+0,9)) << ir.GetVariable().Data()
+            << Form( " : %3.3e", ir.GetRankValue() ) << Endl;
    }
    Log() << kINFO << hline << Endl;
 }

--- a/tmva/tmva/src/Reader.cxx
+++ b/tmva/tmva/src/Reader.cxx
@@ -633,7 +633,7 @@ Float_t TMVA::Reader::EvaluateRegression( UInt_t tgtNumber, const TString& metho
    try {
       return EvaluateRegression(methodTag, aux).at(tgtNumber);
    }
-   catch (std::out_of_range e) {
+   catch (const std::out_of_range &e) {
       Log() << kWARNING << "Regression could not be evaluated for target-number " << tgtNumber << Endl;
       return 0;
    }
@@ -699,7 +699,7 @@ Float_t TMVA::Reader::EvaluateMulticlass( UInt_t clsNumber, const TString& metho
    try {
       return EvaluateMulticlass(methodTag, aux).at(clsNumber);
    }
-   catch (std::out_of_range e) {
+   catch (const std::out_of_range &e) {
       Log() << kWARNING << "Multiclass could not be evaluated for class-number " << clsNumber << Endl;
       return 0;
    }

--- a/tmva/tmva/src/Reader.cxx
+++ b/tmva/tmva/src/Reader.cxx
@@ -171,8 +171,8 @@ TMVA::Reader::Reader( std::vector<TString>& inputVars, const TString& theOption,
 
    // arguments: names of input variables (vector)
    //            verbose flag
-   for (std::vector<TString>::iterator ivar = inputVars.begin(); ivar != inputVars.end(); ++ivar)
-      DataInfo().AddVariable( *ivar );
+   for (auto & inputVar : inputVars)
+      DataInfo().AddVariable( inputVar );
 
    Init();
 }
@@ -201,8 +201,8 @@ TMVA::Reader::Reader( std::vector<std::string>& inputVars, const TString& theOpt
 
    // arguments: names of input variables (vector)
    //            verbose flag
-   for (std::vector<std::string>::iterator ivar = inputVars.begin(); ivar != inputVars.end(); ++ivar)
-      DataInfo().AddVariable( ivar->c_str() );
+   for (auto & inputVar : inputVars)
+      DataInfo().AddVariable( inputVar.c_str() );
 
    Init();
 }
@@ -285,8 +285,8 @@ TMVA::Reader::~Reader( void )
 
    delete fLogger;
 
-   for (auto it=fMethodMap.begin(); it!=fMethodMap.end(); it++){
-      MethodBase * kl = dynamic_cast<TMVA::MethodBase*>(it->second);
+   for (auto & it : fMethodMap){
+      MethodBase * kl = dynamic_cast<TMVA::MethodBase*>(it.second);
       delete kl;
    }
 }

--- a/tmva/tmva/src/Reader.cxx
+++ b/tmva/tmva/src/Reader.cxx
@@ -279,7 +279,7 @@ void TMVA::Reader::DeclareOptions()
 ////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
-TMVA::Reader::~Reader( void )
+TMVA::Reader::~Reader()
 {
    delete fDataSetManager; // DSMTEST
 
@@ -294,7 +294,7 @@ TMVA::Reader::~Reader( void )
 ////////////////////////////////////////////////////////////////////////////////
 /// default initialisation (no member variables)
 
-void TMVA::Reader::Init( void )
+void TMVA::Reader::Init()
 {
    if (Verbose()) fLogger->SetMinType( kVERBOSE );
 

--- a/tmva/tmva/src/Reader.cxx
+++ b/tmva/tmva/src/Reader.cxx
@@ -127,7 +127,7 @@
 
 TMVA::Reader::Reader( const TString& theOption, Bool_t verbose )
 : Configurable( theOption ),
-   fDataSetManager( NULL ), // DSMTEST
+   fDataSetManager( nullptr ), // DSMTEST
    fDataSetInfo(),
    fVerbose( verbose ),
    fSilent ( kFALSE ),
@@ -135,7 +135,7 @@ TMVA::Reader::Reader( const TString& theOption, Bool_t verbose )
    fCalculateError(kFALSE),
    fMvaEventError( 0 ),
    fMvaEventErrorUpper( 0 ),
-   fLogger ( 0 )
+   fLogger ( nullptr )
 {
    fDataSetManager = new DataSetManager( fDataInputHandler );
    fDataSetManager->AddDataSetInfo(fDataSetInfo);
@@ -152,7 +152,7 @@ TMVA::Reader::Reader( const TString& theOption, Bool_t verbose )
 
 TMVA::Reader::Reader( std::vector<TString>& inputVars, const TString& theOption, Bool_t verbose )
    : Configurable( theOption ),
-     fDataSetManager( NULL ), // DSMTEST
+     fDataSetManager( nullptr ), // DSMTEST
      fDataSetInfo(),
      fVerbose( verbose ),
      fSilent ( kFALSE ),
@@ -160,7 +160,7 @@ TMVA::Reader::Reader( std::vector<TString>& inputVars, const TString& theOption,
      fCalculateError(kFALSE),
      fMvaEventError( 0 ),
      fMvaEventErrorUpper( 0 ),   //zjh
-     fLogger ( 0 )
+     fLogger ( nullptr )
 {
    fDataSetManager = new DataSetManager( fDataInputHandler );
    fDataSetManager->AddDataSetInfo(fDataSetInfo);
@@ -182,7 +182,7 @@ TMVA::Reader::Reader( std::vector<TString>& inputVars, const TString& theOption,
 
 TMVA::Reader::Reader( std::vector<std::string>& inputVars, const TString& theOption, Bool_t verbose )
    : Configurable( theOption ),
-     fDataSetManager( NULL ), // DSMTEST
+     fDataSetManager( nullptr ), // DSMTEST
      fDataSetInfo(),
      fVerbose( verbose ),
      fSilent ( kFALSE ),
@@ -190,7 +190,7 @@ TMVA::Reader::Reader( std::vector<std::string>& inputVars, const TString& theOpt
      fCalculateError(kFALSE),
      fMvaEventError( 0 ),
      fMvaEventErrorUpper( 0 ),
-     fLogger ( 0 )
+     fLogger ( nullptr )
 {
    fDataSetManager = new DataSetManager( fDataInputHandler );
    fDataSetManager->AddDataSetInfo(fDataSetInfo);
@@ -212,7 +212,7 @@ TMVA::Reader::Reader( std::vector<std::string>& inputVars, const TString& theOpt
 
 TMVA::Reader::Reader( const std::string& varNames, const TString& theOption, Bool_t verbose )
    : Configurable( theOption ),
-     fDataSetManager( NULL ), // DSMTEST
+     fDataSetManager( nullptr ), // DSMTEST
      fDataSetInfo(),
      fVerbose( verbose ),
      fSilent ( kFALSE ),
@@ -220,7 +220,7 @@ TMVA::Reader::Reader( const std::string& varNames, const TString& theOption, Boo
      fCalculateError(kFALSE),
      fMvaEventError( 0 ),
      fMvaEventErrorUpper( 0 ),
-     fLogger ( 0 )
+     fLogger ( nullptr )
 {
    fDataSetManager = new DataSetManager( fDataInputHandler );
    fDataSetManager->AddDataSetInfo(fDataSetInfo);
@@ -240,7 +240,7 @@ TMVA::Reader::Reader( const std::string& varNames, const TString& theOption, Boo
 
 TMVA::Reader::Reader( const TString& varNames, const TString& theOption, Bool_t verbose )
    : Configurable( theOption ),
-     fDataSetManager( NULL ), // DSMTEST
+     fDataSetManager( nullptr ), // DSMTEST
      fDataSetInfo(),
      fVerbose( verbose ),
      fSilent ( kFALSE ),
@@ -248,7 +248,7 @@ TMVA::Reader::Reader( const TString& varNames, const TString& theOption, Bool_t 
      fCalculateError(kFALSE),
      fMvaEventError( 0 ),
      fMvaEventErrorUpper( 0 ),
-     fLogger ( 0 )
+     fLogger ( nullptr )
 {
    fDataSetManager = new DataSetManager( fDataInputHandler );
    fDataSetManager->AddDataSetInfo(fDataSetInfo);
@@ -406,7 +406,7 @@ TMVA::IMethod* TMVA::Reader::BookMVA( TMVA::Types::EMVA methodType, const TStrin
 
    MethodBase *method = (dynamic_cast<MethodBase*>(im));
 
-   if (method==0) return im;
+   if (method==nullptr) return im;
 
    if( method->GetMethodType() == Types::kCategory ){
       MethodCategory *methCat = (dynamic_cast<MethodCategory*>(method));
@@ -445,7 +445,7 @@ TMVA::IMethod* TMVA::Reader::BookMVA( TMVA::Types::EMVA methodType, const char* 
 
    MethodBase *method = (dynamic_cast<MethodBase*>(im));
 
-   if(!method) return 0;
+   if(!method) return nullptr;
 
    if( method->GetMethodType() == Types::kCategory ){
       MethodCategory *methCat = (dynamic_cast<MethodCategory*>(method));
@@ -487,7 +487,7 @@ Double_t TMVA::Reader::EvaluateMVA( const std::vector<Float_t>& inputVec, const 
    // create a temporary event from the vector.
    IMethod* imeth = FindMVA( methodTag );
    MethodBase* meth = dynamic_cast<TMVA::MethodBase*>(imeth);
-   if(meth==0) return 0;
+   if(meth==nullptr) return 0;
 
    //   Event* tmpEvent=new Event(inputVec, 2); // ToDo resolve magic 2 issue
    Event* tmpEvent=new Event(inputVec, DataInfo().GetNVariables()); // is this the solution?
@@ -504,7 +504,7 @@ Double_t TMVA::Reader::EvaluateMVA( const std::vector<Float_t>& inputVec, const 
       if(mc)
          mc->SetTestSignalEfficiency( aux );
    }
-   Double_t val = meth->GetMvaValue( tmpEvent, (fCalculateError?&fMvaEventError:0));
+   Double_t val = meth->GetMvaValue( tmpEvent, (fCalculateError?&fMvaEventError:nullptr));
    delete tmpEvent;
    return val;
 }
@@ -530,7 +530,7 @@ Double_t TMVA::Reader::EvaluateMVA( const std::vector<Double_t>& inputVec, const
 
 Double_t TMVA::Reader::EvaluateMVA( const TString& methodTag, Double_t aux )
 {
-   IMethod* method = 0;
+   IMethod* method = nullptr;
 
    std::map<TString, IMethod*>::iterator it = fMethodMap.find( methodTag );
    if (it == fMethodMap.end()) {
@@ -544,7 +544,7 @@ Double_t TMVA::Reader::EvaluateMVA( const TString& methodTag, Double_t aux )
 
    MethodBase * kl = dynamic_cast<TMVA::MethodBase*>(method);
 
-   if(kl==0)
+   if(kl==nullptr)
       Log() << kFATAL << methodTag << " is not a method" << Endl;
 
    // check for NaN in event data:  (note: in the factory, this check was done already at the creation of the datasets, hence
@@ -572,8 +572,8 @@ Double_t TMVA::Reader::EvaluateMVA( MethodBase* method, Double_t aux )
          mc->SetTestSignalEfficiency( aux );
    }
 
-   return method->GetMvaValue( (fCalculateError?&fMvaEventError:0),
-                               (fCalculateError?&fMvaEventErrorUpper:0) );
+   return method->GetMvaValue( (fCalculateError?&fMvaEventError:nullptr),
+                               (fCalculateError?&fMvaEventErrorUpper:nullptr) );
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -581,7 +581,7 @@ Double_t TMVA::Reader::EvaluateMVA( MethodBase* method, Double_t aux )
 
 const std::vector< Float_t >& TMVA::Reader::EvaluateRegression( const TString& methodTag, Double_t aux )
 {
-   IMethod* method = 0;
+   IMethod* method = nullptr;
 
    std::map<TString, IMethod*>::iterator it = fMethodMap.find( methodTag );
    if (it == fMethodMap.end()) {
@@ -594,7 +594,7 @@ const std::vector< Float_t >& TMVA::Reader::EvaluateRegression( const TString& m
 
    MethodBase * kl = dynamic_cast<TMVA::MethodBase*>(method);
 
-   if(kl==0)
+   if(kl==nullptr)
       Log() << kFATAL << methodTag << " is not a method" << Endl;
    // check for NaN in event data:  (note: in the factory, this check was done already at the creation of the datasets, hence
    // it is not again checked in each of these subsequent calls..
@@ -646,7 +646,7 @@ Float_t TMVA::Reader::EvaluateRegression( UInt_t tgtNumber, const TString& metho
 
 const std::vector< Float_t >& TMVA::Reader::EvaluateMulticlass( const TString& methodTag, Double_t aux )
 {
-   IMethod* method = 0;
+   IMethod* method = nullptr;
 
    std::map<TString, IMethod*>::iterator it = fMethodMap.find( methodTag );
    if (it == fMethodMap.end()) {
@@ -659,7 +659,7 @@ const std::vector< Float_t >& TMVA::Reader::EvaluateMulticlass( const TString& m
 
    MethodBase * kl = dynamic_cast<TMVA::MethodBase*>(method);
 
-   if(kl==0)
+   if(kl==nullptr)
       Log() << kFATAL << methodTag << " is not a method" << Endl;
    // check for NaN in event data:  (note: in the factory, this check was done already at the creation of the datasets, hence
    // it is not again checked in each of these subsequent calls..
@@ -714,7 +714,7 @@ TMVA::IMethod* TMVA::Reader::FindMVA( const TString& methodTag )
    std::map<TString, IMethod*>::iterator it = fMethodMap.find( methodTag );
    if (it != fMethodMap.end()) return it->second;
    Log() << kERROR << "Method " << methodTag << " not found!" << Endl;
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -731,7 +731,7 @@ TMVA::MethodCuts* TMVA::Reader::FindCutsMVA( const TString& methodTag )
 
 Double_t TMVA::Reader::GetProba( const TString& methodTag,  Double_t ap_sig, Double_t mvaVal )
 {
-   IMethod* method = 0;
+   IMethod* method = nullptr;
    std::map<TString, IMethod*>::iterator it = fMethodMap.find( methodTag );
    if (it == fMethodMap.end()) {
       for (it = fMethodMap.begin(); it!=fMethodMap.end(); ++it) Log() << "M" << it->first << Endl;
@@ -741,7 +741,7 @@ Double_t TMVA::Reader::GetProba( const TString& methodTag,  Double_t ap_sig, Dou
    else method = it->second;
 
    MethodBase* kl = dynamic_cast<MethodBase*>(method);
-   if(kl==0) return -1;
+   if(kl==nullptr) return -1;
    // check for NaN in event data:  (note: in the factory, this check was done already at the creation of the datasets, hence
    // it is not again checked in each of these subsequent calls..
    const Event* ev = kl->GetEvent();
@@ -762,7 +762,7 @@ Double_t TMVA::Reader::GetProba( const TString& methodTag,  Double_t ap_sig, Dou
 
 Double_t TMVA::Reader::GetRarity( const TString& methodTag, Double_t mvaVal )
 {
-   IMethod* method = 0;
+   IMethod* method = nullptr;
    std::map<TString, IMethod*>::iterator it = fMethodMap.find( methodTag );
    if (it == fMethodMap.end()) {
       for (it = fMethodMap.begin(); it!=fMethodMap.end(); ++it) Log() << "M" << it->first << Endl;
@@ -772,7 +772,7 @@ Double_t TMVA::Reader::GetRarity( const TString& methodTag, Double_t mvaVal )
    else method = it->second;
 
    MethodBase* kl = dynamic_cast<MethodBase*>(method);
-   if(kl==0) return -1;
+   if(kl==nullptr) return -1;
    // check for NaN in event data:  (note: in the factory, this check was done already at the creation of the datasets, hence
    // it is not again checked in each of these subsequent calls..
    const Event* ev = kl->GetEvent();

--- a/tmva/tmva/src/Results.cxx
+++ b/tmva/tmva/src/Results.cxx
@@ -61,7 +61,7 @@ TMVA::Results::Results( const DataSetInfo* dsi, TString resultsName )
 
 TMVA::Results::Results( )
 : fTreeType(Types::kTraining),
-fDsi(0),
+fDsi(nullptr),
 fStorage( new TList() ),
 fHistAlias( new std::map<TString, TObject*> ),
 fLogger( new MsgLogger("Results", kINFO))
@@ -93,13 +93,13 @@ void TMVA::Results::Store( TObject* obj, const char* alias )
    }
 
    TString as(obj->GetName());
-   if (alias!=0) as=TString(alias);
+   if (alias!=nullptr) as=TString(alias);
    if (fHistAlias->find(as) != fHistAlias->end()) {
       // alias exists
       *fLogger << kFATAL << "Alias " << as << " already exists in results storage" << Endl;
    }
    if( obj->InheritsFrom(TH1::Class()) ) {
-      ((TH1*)obj)->SetDirectory(0);
+      ((TH1*)obj)->SetDirectory(nullptr);
    }
    fStorage->Add( obj );
    fHistAlias->insert(std::pair<TString, TObject*>(as,obj));

--- a/tmva/tmva/src/ResultsRegression.cxx
+++ b/tmva/tmva/src/ResultsRegression.cxx
@@ -95,7 +95,7 @@ TH1F*  TMVA::ResultsRegression::QuadraticDeviation( UInt_t tgtNum , Bool_t trunc
    xmax *= 1.1;
    Int_t nbins = 500;
    TH1F* h = new TH1F( name, name, nbins, xmin, xmax);
-   h->SetDirectory(0);
+   h->SetDirectory(nullptr);
    h->GetXaxis()->SetTitle("Quadratic Deviation");
    h->GetYaxis()->SetTitle("Weighted Entries");
 
@@ -178,7 +178,7 @@ TH2F*  TMVA::ResultsRegression::DeviationAsAFunctionOf( UInt_t varNum, UInt_t tg
 
 
    TH2F* h = new TH2F( name, name, nxbins, xmin, xmax, nybins, ymin, ymax );
-   h->SetDirectory(0);
+   h->SetDirectory(nullptr);
 
    h->GetXaxis()->SetTitle( (takeTargets ? dsi->GetTargetInfo(varNum).GetTitle() : dsi->GetVariableInfo(varNum).GetTitle() ) );
    TString varName( dsi->GetTargetInfo(tgtNum).GetTitle() );

--- a/tmva/tmva/src/RootFinder.cxx
+++ b/tmva/tmva/src/RootFinder.cxx
@@ -61,7 +61,7 @@ TMVA::RootFinder::RootFinder(TMVA::MethodBase *method ,
 ////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
-TMVA::RootFinder::~RootFinder( void )
+TMVA::RootFinder::~RootFinder()
 {
    delete fLogger;
 }

--- a/tmva/tmva/src/Rule.cxx
+++ b/tmva/tmva/src/Rule.cxx
@@ -63,7 +63,7 @@ intelligent fitting. See the RuleEnsemble class for more info.
 
 TMVA::Rule::Rule( RuleEnsemble *re,
                   const std::vector< const Node * >& nodes )
-   : fCut           ( 0 )
+   : fCut           ( nullptr )
    , fNorm          ( 1.0 )
    , fSupport       ( 0.0 )
    , fSigma         ( 0.0 )
@@ -90,7 +90,7 @@ TMVA::Rule::Rule( RuleEnsemble *re,
 /// the simple constructor
 
 TMVA::Rule::Rule( RuleEnsemble *re )
-   : fCut           ( 0 )
+   : fCut           ( nullptr )
    , fNorm          ( 1.0 )
    , fSupport       ( 0.0 )
    , fSigma         ( 0.0 )
@@ -108,14 +108,14 @@ TMVA::Rule::Rule( RuleEnsemble *re )
 /// the simple constructor
 
 TMVA::Rule::Rule()
-   : fCut           ( 0 )
+   : fCut           ( nullptr )
    , fNorm          ( 1.0 )
    , fSupport       ( 0.0 )
    , fSigma         ( 0.0 )
    , fCoefficient   ( 0.0 )
    , fImportance    ( 0.0 )
    , fImportanceRef ( 1.0 )
-   , fRuleEnsemble  ( 0 )
+   , fRuleEnsemble  ( nullptr )
    , fSSB           ( 0 )
    , fSSBNeve       ( 0 )
    , fLogger( new MsgLogger("RuleFit") )

--- a/tmva/tmva/src/RuleEnsemble.cxx
+++ b/tmva/tmva/src/RuleEnsemble.cxx
@@ -65,12 +65,12 @@ TMVA::RuleEnsemble::RuleEnsemble( RuleFit *rf )
    , fRuleNCsig       ( 0 )
    , fRuleMinDist     ( 1e-3 ) // closest allowed 'distance' between two rules
    , fNRulesGenerated ( 0 )
-   , fEvent           ( 0 )
+   , fEvent           ( nullptr )
    , fEventCacheOK    ( true )
    , fRuleMapOK       ( true )
    , fRuleMapInd0     ( 0 )
    , fRuleMapInd1     ( 0 )
-   , fRuleMapEvents   ( 0 )
+   , fRuleMapEvents   ( nullptr )
    , fLogger( new MsgLogger("RuleFit") )
 {
    Initialize( rf );
@@ -81,9 +81,9 @@ TMVA::RuleEnsemble::RuleEnsemble( RuleFit *rf )
 
 TMVA::RuleEnsemble::RuleEnsemble( const RuleEnsemble& other )
    : fAverageSupport   ( 1 )
-   , fEvent(0)
-   , fRuleMapEvents(0)
-   , fRuleFit(0)
+   , fEvent(nullptr)
+   , fRuleMapEvents(nullptr)
+   , fRuleFit(nullptr)
    , fLogger( new MsgLogger("RuleFit") )
 {
    Copy( other );
@@ -105,13 +105,13 @@ TMVA::RuleEnsemble::RuleEnsemble()
    , fRuleNCsig       ( 0 )
    , fRuleMinDist     ( 1e-3 ) // closest allowed 'distance' between two rules
    , fNRulesGenerated ( 0 )
-   , fEvent           ( 0 )
+   , fEvent           ( nullptr )
    , fEventCacheOK    ( true )
    , fRuleMapOK       ( true )
    , fRuleMapInd0     ( 0 )
    , fRuleMapInd1     ( 0 )
-   , fRuleMapEvents   ( 0 )
-   , fRuleFit         ( 0 )
+   , fRuleMapEvents   ( nullptr )
+   , fRuleFit         ( nullptr )
    , fLogger( new MsgLogger("RuleFit") )
 {
 }
@@ -141,8 +141,8 @@ void TMVA::RuleEnsemble::Initialize( const RuleFit *rf )
    fLinPDFS.clear();
    //
    fVarImportance.resize( nvars,0.0 );
-   fLinPDFB.resize( nvars,0 );
-   fLinPDFS.resize( nvars,0 );
+   fLinPDFB.resize( nvars,nullptr );
+   fLinPDFS.resize( nvars,nullptr );
    fImportanceRef = 1.0;
    for (UInt_t i=0; i<nvars; i++) { // a priori all linear terms are equally valid
       fLinTermOK.push_back(kTRUE);
@@ -161,7 +161,7 @@ void TMVA::RuleEnsemble::SetMsgType( EMsgType t ) {
 
 const TMVA::MethodRuleFit*  TMVA::RuleEnsemble::GetMethodRuleFit() const
 {
-   return ( fRuleFit==0 ? 0:fRuleFit->GetMethodRuleFit());
+   return ( fRuleFit==nullptr ? nullptr:fRuleFit->GetMethodRuleFit());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -170,7 +170,7 @@ const TMVA::MethodRuleFit*  TMVA::RuleEnsemble::GetMethodRuleFit() const
 
 const TMVA::MethodBase*  TMVA::RuleEnsemble::GetMethodBase() const
 {
-   return ( fRuleFit==0 ? 0:fRuleFit->GetMethodBase());
+   return ( fRuleFit==nullptr ? nullptr:fRuleFit->GetMethodBase());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -497,7 +497,7 @@ void TMVA::RuleEnsemble::CalcVarImportance()
    Log() << kVERBOSE << "Compute variable importance" << Endl;
    Double_t rimp;
    UInt_t nrules = fRules.size();
-   if (GetMethodBase()==0) Log() << kFATAL << "RuleEnsemble::CalcVarImportance() - should not be here!" << Endl;
+   if (GetMethodBase()==nullptr) Log() << kFATAL << "RuleEnsemble::CalcVarImportance() - should not be here!" << Endl;
    UInt_t nvars  = GetMethodBase()->GetNvar();
    UInt_t nvarsUsed;
    Double_t rimpN;
@@ -1268,7 +1268,7 @@ void TMVA::RuleEnsemble::Copy( const RuleEnsemble & other )
 
 Int_t TMVA::RuleEnsemble::CalcNRules( const DecisionTree *dtree )
 {
-   if (dtree==0) return 0;
+   if (dtree==nullptr) return 0;
    Node *node = dtree->GetRoot();
    Int_t nendnodes = 0;
    FindNEndNodes( node, nendnodes );
@@ -1280,8 +1280,8 @@ Int_t TMVA::RuleEnsemble::CalcNRules( const DecisionTree *dtree )
 
 void TMVA::RuleEnsemble::FindNEndNodes( const Node *node, Int_t & nendnodes )
 {
-   if (node==0) return;
-   if ((node->GetRight()==0) && (node->GetLeft()==0)) {
+   if (node==nullptr) return;
+   if ((node->GetRight()==nullptr) && (node->GetLeft()==nullptr)) {
       ++nendnodes;
       return;
    }
@@ -1305,8 +1305,8 @@ void TMVA::RuleEnsemble::MakeRulesFromTree( const DecisionTree *dtree )
 
 void TMVA::RuleEnsemble::AddRule( const Node *node )
 {
-   if (node==0) return;
-   if (node->GetParent()==0) { // it's a root node, don't make a rule
+   if (node==nullptr) return;
+   if (node->GetParent()==nullptr) { // it's a root node, don't make a rule
       AddRule( node->GetRight() );
       AddRule( node->GetLeft() );
    }
@@ -1331,13 +1331,13 @@ void TMVA::RuleEnsemble::AddRule( const Node *node )
 
 TMVA::Rule *TMVA::RuleEnsemble::MakeTheRule( const Node *node )
 {
-   if (node==0) {
+   if (node==nullptr) {
       Log() << kFATAL << "<MakeTheRule> Input node is NULL. Should not happen. BUG!" << Endl;
-      return 0;
+      return nullptr;
    }
 
-   if (node->GetParent()==0) { // a root node - ignore
-      return 0;
+   if (node->GetParent()==nullptr) { // a root node - ignore
+      return nullptr;
    }
    //
    std::vector< const Node * > nodeVec;
@@ -1347,7 +1347,7 @@ TMVA::Rule *TMVA::RuleEnsemble::MakeTheRule( const Node *node )
    // <root node> <node1> <node2> ... <node given as argument>
    //
    nodeVec.push_back( node );
-   while (parent!=0) {
+   while (parent!=nullptr) {
       parent = parent->GetParent();
       if (!parent) continue;
       const DecisionTreeNode* dtn = dynamic_cast<const DecisionTreeNode*>(parent);
@@ -1357,7 +1357,7 @@ TMVA::Rule *TMVA::RuleEnsemble::MakeTheRule( const Node *node )
    }
    if (nodeVec.size()<2) {
       Log() << kFATAL << "<MakeTheRule> BUG! Inconsistent Rule!" << Endl;
-      return 0;
+      return nullptr;
    }
    Rule *rule = new Rule( this, nodeVec );
    rule->SetMsgType( Log().GetMinType() );
@@ -1371,7 +1371,7 @@ void TMVA::RuleEnsemble::MakeRuleMap(const std::vector<const Event *> *events, U
 {
    Log() << kVERBOSE << "Making Rule map for all events" << Endl;
    // make rule response map
-   if (events==0) events = GetTrainingEvents();
+   if (events==nullptr) events = GetTrainingEvents();
    if ((ifirst==0) || (ilast==0) || (ifirst>ilast)) {
       ifirst = 0;
       ilast  = events->size()-1;

--- a/tmva/tmva/src/RuleEnsemble.cxx
+++ b/tmva/tmva/src/RuleEnsemble.cxx
@@ -121,8 +121,8 @@ TMVA::RuleEnsemble::RuleEnsemble()
 
 TMVA::RuleEnsemble::~RuleEnsemble()
 {
-   for ( std::vector<Rule *>::iterator itrRule = fRules.begin(); itrRule != fRules.end(); ++itrRule ) {
-      delete *itrRule;
+   for (auto & fRule : fRules) {
+      delete fRule;
    }
    // NOTE: Should not delete the histos fLinPDFB/S since they are delete elsewhere
    delete fLogger;
@@ -389,15 +389,15 @@ void TMVA::RuleEnsemble::CalcRuleSupport()
    Double_t ew;
    //
    if ((nrules>0) && (events->size()>0)) {
-      for ( std::vector< Rule * >::iterator itrRule=fRules.begin(); itrRule!=fRules.end(); ++itrRule ) {
+      for (auto & fRule : fRules) {
          s=0.0;
          ssig=0.0;
          sbkg=0.0;
-         for ( std::vector<const Event * >::const_iterator itrEvent=events->begin(); itrEvent!=events->end(); ++itrEvent ) {
-            if ((*itrRule)->EvalEvent( *(*itrEvent) )) {
-               ew = (*itrEvent)->GetWeight();
+         for (auto event : *events) {
+            if (fRule->EvalEvent( *event )) {
+               ew = event->GetWeight();
                s += ew;
-               if (GetMethodRuleFit()->DataInfo().IsSignal(*itrEvent)) ssig += ew;
+               if (GetMethodRuleFit()->DataInfo().IsSignal(event)) ssig += ew;
                else                         sbkg += ew;
             }
          }
@@ -409,10 +409,10 @@ void TMVA::RuleEnsemble::CalcRuleSupport()
          ttot += t;
          ssum = ssig+sbkg;
          ssb = (ssum>0 ? Double_t(ssig)/Double_t(ssig+sbkg) : 0.0 );
-         (*itrRule)->SetSupport(s);
-         (*itrRule)->SetNorm(t);
-         (*itrRule)->SetSSB( ssb );
-         (*itrRule)->SetSSBNeve(Double_t(ssig+sbkg));
+         fRule->SetSupport(s);
+         fRule->SetNorm(t);
+         fRule->SetSSB( ssb );
+         fRule->SetSSBNeve(Double_t(ssig+sbkg));
          indrule++;
       }
       fAverageSupport   = stot/nrules;
@@ -438,8 +438,8 @@ void TMVA::RuleEnsemble::CalcImportance()
 
 void TMVA::RuleEnsemble::SetImportanceRef(Double_t impref)
 {
-   for ( UInt_t i=0; i<fRules.size(); i++ ) {
-      fRules[i]->SetImportanceRef(impref);
+   for (auto & fRule : fRules) {
+      fRule->SetImportanceRef(impref);
    }
    fImportanceRef = impref;
 }

--- a/tmva/tmva/src/RuleFit.cxx
+++ b/tmva/tmva/src/RuleFit.cxx
@@ -76,8 +76,8 @@ TMVA::RuleFit::RuleFit(const MethodBase *rfbase)
 TMVA::RuleFit::RuleFit()
    : fNTreeSample(0)
    , fNEveEffTrain(0)
-   , fMethodRuleFit(0)
-   , fMethodBase(0)
+   , fMethodRuleFit(nullptr)
+   , fMethodBase(nullptr)
    , fVisHistsUseImp(kTRUE)
    , fLogger(new MsgLogger("RuleFit"))
 {
@@ -175,7 +175,7 @@ void TMVA::RuleFit::Copy( const RuleFit& other )
 
 Double_t TMVA::RuleFit::CalcWeightSum( const std::vector<const Event *> *events, UInt_t neve )
 {
-   if (events==0) return 0.0;
+   if (events==nullptr) return 0.0;
    if (neve==0) neve=events->size();
    //
    Double_t sumw=0;
@@ -200,8 +200,8 @@ void TMVA::RuleFit::SetMsgType( EMsgType t )
 
 void TMVA::RuleFit::BuildTree( DecisionTree *dt )
 {
-   if (dt==0) return;
-   if (fMethodRuleFit==0) {
+   if (dt==nullptr) return;
+   if (fMethodRuleFit==nullptr) {
       Log() << kFATAL << "RuleFit::BuildTree() - Attempting to build a tree NOT from a MethodRuleFit" << Endl;
    }
    std::vector<const Event *> evevec;
@@ -221,7 +221,7 @@ void TMVA::RuleFit::BuildTree( DecisionTree *dt )
 
 void TMVA::RuleFit::MakeForest()
 {
-   if (fMethodRuleFit==0) {
+   if (fMethodRuleFit==nullptr) {
       Log() << kFATAL << "RuleFit::BuildTree() - Attempting to build a tree NOT from a MethodRuleFit" << Endl;
    }
    Log() << kDEBUG << "Creating a forest with " << fMethodRuleFit->GetNTrees() << " decision trees" << Endl;
@@ -269,10 +269,10 @@ void TMVA::RuleFit::MakeForest()
          BuildTree(dt); // reads fNTreeSample events from fTrainingEventsRndm
          if (dt->GetNNodes()<3) {
             delete dt;
-            dt=0;
+            dt=nullptr;
          }
          ntries++;
-         tryAgain = ((dt==0) && (ntries<ntriesMax));
+         tryAgain = ((dt==nullptr) && (ntries<ntriesMax));
       }
       if (dt) {
          fForest.push_back(dt);
@@ -439,7 +439,7 @@ Double_t TMVA::RuleFit::EvalEvent( const Event& e )
 
 void TMVA::RuleFit::SetTrainingEvents( const std::vector<const Event *>& el )
 {
-   if (fMethodRuleFit==0) Log() << kFATAL << "RuleFit::SetTrainingEvents - MethodRuleFit not initialized" << Endl;
+   if (fMethodRuleFit==nullptr) Log() << kFATAL << "RuleFit::SetTrainingEvents - MethodRuleFit not initialized" << Endl;
    UInt_t neve = el.size();
    if (neve==0) Log() << kWARNING << "An empty sample of training events was given" << Endl;
 
@@ -532,8 +532,8 @@ void TMVA::RuleFit::NormVisHists(std::vector<TH2F *> & hlist)
 
 void TMVA::RuleFit::FillCut(TH2F* h2, const Rule *rule, Int_t vind)
 {
-   if (rule==0) return;
-   if (h2==0) return;
+   if (rule==nullptr) return;
+   if (h2==nullptr) return;
    //
    Double_t rmin,  rmax;
    Bool_t   dormin,dormax;
@@ -583,7 +583,7 @@ void TMVA::RuleFit::FillCut(TH2F* h2, const Rule *rule, Int_t vind)
 
 void TMVA::RuleFit::FillLin(TH2F* h2,Int_t vind)
 {
-   if (h2==0) return;
+   if (h2==nullptr) return;
    if (!fRuleEnsemble.DoLinear()) return;
    //
    Int_t firstbin = 1;
@@ -607,8 +607,8 @@ void TMVA::RuleFit::FillLin(TH2F* h2,Int_t vind)
 
 void TMVA::RuleFit::FillCorr(TH2F* h2,const Rule *rule,Int_t vx, Int_t vy)
 {
-   if (rule==0) return;
-   if (h2==0) return;
+   if (rule==nullptr) return;
+   if (h2==nullptr) return;
    Double_t val;
    if (fVisHistsUseImp) {
       val = rule->GetImportance();
@@ -714,7 +714,7 @@ void TMVA::RuleFit::FillVisHistCut(const Rule* rule, std::vector<TH2F *> & hlist
 
 void TMVA::RuleFit::FillVisHistCorr(const Rule * rule, std::vector<TH2F *> & hlist)
 {
-   if (rule==0) return;
+   if (rule==nullptr) return;
    Double_t ruleimp  = rule->GetImportance();
    if (!(ruleimp>0)) return;
    if (ruleimp<fRuleEnsemble.GetImportanceCut()) return;
@@ -785,13 +785,13 @@ void TMVA::RuleFit::MakeVisHists()
    const TString corrDirName = "CorrelationPlots";
 
    TDirectory* rootDir   = fMethodBase->GetFile();
-   TDirectory* varDir    = 0;
-   TDirectory* corrDir   = 0;
+   TDirectory* varDir    = nullptr;
+   TDirectory* corrDir   = nullptr;
 
    TDirectory* methodDir = fMethodBase->BaseDir();
    TString varDirName;
    //
-   Bool_t done=(rootDir==0);
+   Bool_t done=(rootDir==nullptr);
    Int_t type=0;
    if (done) {
       Log() << kWARNING << "No basedir - BUG??" << Endl;
@@ -800,19 +800,19 @@ void TMVA::RuleFit::MakeVisHists()
    while (!done) {
       varDir = (TDirectory*)rootDir->Get( directories[type] );
       type++;
-      done = ((varDir!=0) || (type>4));
+      done = ((varDir!=nullptr) || (type>4));
    }
-   if (varDir==0) {
+   if (varDir==nullptr) {
       Log() << kWARNING << "No input variable directory found - BUG?" << Endl;
       return;
    }
    corrDir = (TDirectory*)varDir->Get( corrDirName );
-   if (corrDir==0) {
+   if (corrDir==nullptr) {
       Log() << kWARNING << "No correlation directory found" << Endl;
       Log() << kWARNING << "Check for other warnings related to correlation histograms" << Endl;
       return;
    }
-   if (methodDir==0) {
+   if (methodDir==nullptr) {
       Log() << kWARNING << "No rulefit method directory found - BUG?" << Endl;
       return;
    }
@@ -822,7 +822,7 @@ void TMVA::RuleFit::MakeVisHists()
    //
    // get correlation plot directory
    corrDir = (TDirectory *)varDir->Get(corrDirName);
-   if (corrDir==0) {
+   if (corrDir==nullptr) {
       Log() << kWARNING << "No correlation directory found : " << corrDirName << Endl;
       return;
    }
@@ -913,7 +913,7 @@ void TMVA::RuleFit::MakeVisHists()
       FillVisHistCut(rule, h1Vector);
    }
    // fill linear terms and normalise hists
-   FillVisHistCut(0, h1Vector);
+   FillVisHistCut(nullptr, h1Vector);
    NormVisHists(h1Vector);
 
    //
@@ -937,7 +937,7 @@ void TMVA::RuleFit::MakeVisHists()
 void TMVA::RuleFit::MakeDebugHists()
 {
    TDirectory* methodDir = fMethodBase->BaseDir();
-   if (methodDir==0) {
+   if (methodDir==nullptr) {
       Log() << kWARNING << "<MakeDebugHists> No rulefit method directory found - bug?" << Endl;
       return;
    }

--- a/tmva/tmva/src/RuleFit.cxx
+++ b/tmva/tmva/src/RuleFit.cxx
@@ -309,8 +309,8 @@ void TMVA::RuleFit::MakeForest()
 void TMVA::RuleFit::SaveEventWeights()
 {
    fEventWeights.clear();
-   for (std::vector<const Event*>::iterator e=fTrainingEvents.begin(); e!=fTrainingEvents.end(); ++e) {
-      Double_t w = (*e)->GetBoostWeight();
+   for (auto & fTrainingEvent : fTrainingEvents) {
+      Double_t w = fTrainingEvent->GetBoostWeight();
       fEventWeights.push_back(w);
    }
 }
@@ -325,8 +325,8 @@ void TMVA::RuleFit::RestoreEventWeights()
       Log() << kERROR << "RuleFit::RestoreEventWeights() called without having called SaveEventWeights() before!" << Endl;
       return;
    }
-   for (std::vector<const Event*>::iterator e=fTrainingEvents.begin(); e!=fTrainingEvents.end(); ++e) {
-      (*e)->SetBoostWeight(fEventWeights[ie]);
+   for (auto & fTrainingEvent : fTrainingEvents) {
+      fTrainingEvent->SetBoostWeight(fEventWeights[ie]);
       ie++;
    }
 }
@@ -343,12 +343,12 @@ void TMVA::RuleFit::Boost( DecisionTree *dt )
    //
    std::vector<Char_t> correctSelected; // <--- boolean stored
    //
-   for (std::vector<const Event*>::iterator e=fTrainingEvents.begin(); e!=fTrainingEvents.end(); ++e) {
-      Bool_t isSignalType = (dt->CheckEvent(*e,kTRUE) > 0.5 );
-      Double_t w = (*e)->GetWeight();
+   for (auto & fTrainingEvent : fTrainingEvents) {
+      Bool_t isSignalType = (dt->CheckEvent(fTrainingEvent,kTRUE) > 0.5 );
+      Double_t w = fTrainingEvent->GetWeight();
       sumw += w;
       //
-      if (isSignalType == fMethodBase->DataInfo().IsSignal(*e)) { // correctly classified
+      if (isSignalType == fMethodBase->DataInfo().IsSignal(fTrainingEvent)) { // correctly classified
          correctSelected.push_back(kTRUE);
       }
       else {                                // misclassified
@@ -365,16 +365,16 @@ void TMVA::RuleFit::Boost( DecisionTree *dt )
    Double_t newSumw=0.0;
    UInt_t ie=0;
    // set new weight to misclassified events
-   for (std::vector<const Event*>::iterator e=fTrainingEvents.begin(); e!=fTrainingEvents.end(); ++e) {
+   for (auto & fTrainingEvent : fTrainingEvents) {
       if (!correctSelected[ie])
-         (*e)->SetBoostWeight( (*e)->GetBoostWeight() * boostWeight);
-      newSumw+=(*e)->GetWeight();
+         fTrainingEvent->SetBoostWeight( fTrainingEvent->GetBoostWeight() * boostWeight);
+      newSumw+=fTrainingEvent->GetWeight();
       ie++;
    }
    // reweight all events
    Double_t scale = sumw/newSumw;
-   for (std::vector<const Event*>::iterator e=fTrainingEvents.begin(); e!=fTrainingEvents.end(); ++e) {
-      (*e)->SetBoostWeight( (*e)->GetBoostWeight() * scale);
+   for (auto & fTrainingEvent : fTrainingEvents) {
+      fTrainingEvent->SetBoostWeight( fTrainingEvent->GetBoostWeight() * scale);
    }
    Log() << kDEBUG << "boostWeight = " << boostWeight << "    scale = " << scale << Endl;
 }
@@ -519,8 +519,7 @@ void TMVA::RuleFit::NormVisHists(std::vector<TH2F *> & hlist)
    }
 
    //
-   for (UInt_t i=0; i<hlist.size(); i++) {
-      TH2F *hs = hlist[i];
+   for (auto hs : hlist) {
       hs->Scale(scale);
       hs->SetMinimum(usemin);
       hs->SetMaximum(usemax);
@@ -927,8 +926,8 @@ void TMVA::RuleFit::MakeVisHists()
 
    // write histograms to file
    methodDir->cd();
-   for (UInt_t i=0; i<h1Vector.size();     i++) h1Vector[i]->Write();
-   for (UInt_t i=0; i<h2CorrVector.size(); i++) h2CorrVector[i]->Write();
+   for (auto & i : h1Vector) i->Write();
+   for (auto & i : h2CorrVector) i->Write();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/src/RuleFitAPI.cxx
+++ b/tmva/tmva/src/RuleFitAPI.cxx
@@ -175,7 +175,7 @@ void TMVA::RuleFitAPI::CheckRFWorkDir()
    }
    // check rf_go.exe
    FILE *f = fopen("rf_go.exe","r");
-   if (f==0) {
+   if (f==nullptr) {
       fLogger << kWARNING << "No rf_go.exe file in directory : " << fRFWorkDir << Endl;
       HowtoSetupRF();
       fLogger << kFATAL << "Setup failed - aborting!" << Endl;

--- a/tmva/tmva/src/RuleFitParams.cxx
+++ b/tmva/tmva/src/RuleFitParams.cxx
@@ -613,8 +613,8 @@ void TMVA::RuleFitParams::MakeGDPath()
    fRuleEnsemble->SetOffset(offsetMin);
    fRuleEnsemble->ClearCoefficients(0);
    fRuleEnsemble->ClearLinCoefficients(0);
-   for (UInt_t i=0; i<fGDOfsTst.size(); i++) {
-      fGDOfsTst[i] = offsetMin;
+   for (double & i : fGDOfsTst) {
+      i = offsetMin;
    }
    Log() << kVERBOSE << "Obtained initial offset = " << offsetMin << Endl;
 

--- a/tmva/tmva/src/RuleFitParams.cxx
+++ b/tmva/tmva/src/RuleFitParams.cxx
@@ -63,8 +63,8 @@ Double_t gGDLinLoop=0;
 /// constructor
 
 TMVA::RuleFitParams::RuleFitParams()
-   : fRuleFit ( 0 )
-   , fRuleEnsemble ( 0 )
+   : fRuleFit ( nullptr )
+   , fRuleEnsemble ( nullptr )
    , fNRules ( 0 )
    , fNLinear ( 0 )
    , fPathIdx1 ( 0 )
@@ -83,14 +83,14 @@ TMVA::RuleFitParams::RuleFitParams()
    , fGDErrScale ( 1.1 )
    , fAverageTruth( 0 )
    , fFstarMedian ( 0 )
-   , fGDNtuple    ( 0 )
+   , fGDNtuple    ( nullptr )
    , fNTRisk      ( 0 )
    , fNTErrorRate ( 0 )
    , fNTNuval     ( 0 )
    , fNTCoefRad   ( 0 )
    , fNTOffset ( 0 )
-   , fNTCoeff ( 0 )
-   , fNTLinCoeff ( 0 )
+   , fNTCoeff ( nullptr )
+   , fNTLinCoeff ( nullptr )
    , fsigave( 0 )
    , fsigrms( 0 )
    , fbkgave( 0 )
@@ -104,8 +104,8 @@ TMVA::RuleFitParams::RuleFitParams()
 
 TMVA::RuleFitParams::~RuleFitParams()
 {
-   if (fNTCoeff)     { delete fNTCoeff; fNTCoeff = 0; }
-   if (fNTLinCoeff)  { delete fNTLinCoeff;fNTLinCoeff = 0; }
+   if (fNTCoeff)     { delete fNTCoeff; fNTCoeff = nullptr; }
+   if (fNTLinCoeff)  { delete fNTLinCoeff;fNTLinCoeff = nullptr; }
    delete fLogger;
 }
 
@@ -114,8 +114,8 @@ TMVA::RuleFitParams::~RuleFitParams()
 
 void TMVA::RuleFitParams::Init()
 {
-   if (fRuleFit==0) return;
-   if (fRuleFit->GetMethodRuleFit()==0) {
+   if (fRuleFit==nullptr) return;
+   if (fRuleFit->GetMethodRuleFit()==nullptr) {
       Log() << kFATAL << "RuleFitParams::Init() - MethodRuleFit ptr is null" << Endl;
    }
    UInt_t neve = fRuleFit->GetTrainingEvents().size();
@@ -192,8 +192,8 @@ void TMVA::RuleFitParams::InitNtuple()
    fGDNtuple->Branch("coefrad", &fNTCoefRad,  "coefrad/D");
    fGDNtuple->Branch("offset",  &fNTOffset,   "offset/D");
    //
-   fNTCoeff    = (fNRules >0 ? new Double_t[fNRules]  : 0);
-   fNTLinCoeff = (fNLinear>0 ? new Double_t[fNLinear] : 0);
+   fNTCoeff    = (fNRules >0 ? new Double_t[fNRules]  : nullptr);
+   fNTLinCoeff = (fNLinear>0 ? new Double_t[fNLinear] : nullptr);
 
    for (UInt_t i=0; i<fNRules; i++) {
       fGDNtuple->Branch(Form("a%d",i+1),&fNTCoeff[i],Form("a%d/D",i+1));
@@ -220,7 +220,7 @@ void TMVA::RuleFitParams::EvaluateAverage( UInt_t ind1, UInt_t ind2,
    //
    if (fNLinear>0) avsel.resize(fNLinear,0);
    if (fNRules>0)  avrul.resize(fNRules,0);
-   const std::vector<UInt_t> *eventRuleMap=0;
+   const std::vector<UInt_t> *eventRuleMap=nullptr;
    Double_t ew;
    Double_t sumew=0;
    //
@@ -1289,7 +1289,7 @@ void TMVA::RuleFitParams::MakeTstGradientVector()
    Double_t sF;   // score function value
    Double_t r;   // eq 35, ref 1
    Double_t y;   // true score (+1 or -1)
-   const std::vector<UInt_t> *eventRuleMap=0;
+   const std::vector<UInt_t> *eventRuleMap=nullptr;
    UInt_t rind;
    //
    // Loop over all events
@@ -1407,7 +1407,7 @@ void TMVA::RuleFitParams::MakeGradientVector()
    Double_t sF;   // score function value
    Double_t r;   // eq 35, ref 1
    Double_t y;   // true score (+1 or -1)
-   const std::vector<UInt_t> *eventRuleMap=0;
+   const std::vector<UInt_t> *eventRuleMap=nullptr;
    UInt_t rind;
    //
    gGDInit += Double_t(clock()-t0)/CLOCKS_PER_SEC;

--- a/tmva/tmva/src/SVEvent.cxx
+++ b/tmva/tmva/src/SVEvent.cxx
@@ -51,7 +51,7 @@ TMVA::SVEvent::SVEvent()
    fIdx(0),
    fNs(0),
    fIsShrinked(0),
-   fLine(0),
+   fLine(nullptr),
    fTarget(0)
 {
 }
@@ -70,7 +70,7 @@ TMVA::SVEvent::SVEvent( const Event* event, Float_t C_par, Bool_t isSignal )
      fIdx     ( isSignal ? -1 : 1 ),
      fNs(0),
      fIsShrinked(0),
-     fLine(0),
+     fLine(nullptr),
      fTarget((event->GetNTargets() > 0 ? event->GetTarget(0) : 0))
 {
 }
@@ -89,7 +89,7 @@ TMVA::SVEvent::SVEvent( const std::vector<Float_t>* svector, Float_t alpha, Int_
      fIdx(-1),
      fNs(ns),
      fIsShrinked(0),
-     fLine(0),
+     fLine(nullptr),
      fTarget(0)
 {
 }
@@ -108,7 +108,7 @@ TMVA::SVEvent::SVEvent( const std::vector<Float_t>* svector, Float_t alpha, Floa
      fIdx(-1),
      fNs(0),
      fIsShrinked(0),
-     fLine(0),
+     fLine(nullptr),
      fTarget(0)
 {
 }
@@ -118,9 +118,9 @@ TMVA::SVEvent::SVEvent( const std::vector<Float_t>* svector, Float_t alpha, Floa
 
 TMVA::SVEvent::~SVEvent()
 {
-   if (fLine != 0) {
+   if (fLine != nullptr) {
       delete [] fLine;
-      fLine = 0;
+      fLine = nullptr;
    }
 }
 

--- a/tmva/tmva/src/SVEvent.cxx
+++ b/tmva/tmva/src/SVEvent.cxx
@@ -130,7 +130,7 @@ TMVA::SVEvent::~SVEvent()
 void TMVA::SVEvent::Print( std::ostream& os ) const
 {
    os << "type::" << fTypeFlag <<" target::"<< fTarget << " alpha::" << fAlpha <<" alpha_p::"<< fAlpha_p<< " values::" ;
-   for (UInt_t j =0; j < fDataVector.size();j++) os<<fDataVector.at(j)<<" ";
+   for (float j : fDataVector) os<<j<<" ";
    os << std::endl;
 }
 

--- a/tmva/tmva/src/SVKernelFunction.cxx
+++ b/tmva/tmva/src/SVKernelFunction.cxx
@@ -208,8 +208,8 @@ Float_t TMVA::SVKernelFunction::Evaluate( SVEvent* ev1, SVEvent* ev2 )
          // Methods" by Cristianini and Shawe-Taylor, Section 3.3.2
          Float_t kernelVal;
          kernelVal = 1;
-         for(UInt_t i = 0; i<fKernelsList.size(); i++){
-            fKernel = fKernelsList.at(i);
+         for(auto & i : fKernelsList){
+            fKernel = i;
             Float_t a = Evaluate(ev1,ev2);
             kernelVal *= a;
          }
@@ -223,8 +223,8 @@ Float_t TMVA::SVKernelFunction::Evaluate( SVEvent* ev1, SVEvent* ev2 )
          // kSum before returning so it can be used again. Described in "An Introduction to          // Support Vector Machines and Other Kernel-based Learning
          // Methods" by Cristianini and Shawe-Taylor, Section 3.3.2
          Float_t kernelVal = 0;
-         for(UInt_t i = 0; i<fKernelsList.size(); i++){
-            fKernel = fKernelsList.at(i);
+         for(auto & i : fKernelsList){
+            fKernel = i;
             Float_t a = Evaluate(ev1,ev2);
             kernelVal += a;
          }

--- a/tmva/tmva/src/SVKernelMatrix.cxx
+++ b/tmva/tmva/src/SVKernelMatrix.cxx
@@ -53,8 +53,8 @@ Kernel matrix for Support Vector Machine
 
 TMVA::SVKernelMatrix::SVKernelMatrix()
    : fSize(0),
-     fKernelFunction(0),
-     fSVKernelMatrix(0),
+     fKernelFunction(nullptr),
+     fSVKernelMatrix(nullptr),
      fLogger( new MsgLogger("ResultsRegression", kINFO) )
 {
 }
@@ -89,10 +89,10 @@ TMVA::SVKernelMatrix::~SVKernelMatrix()
 {
    for (UInt_t i = fSize -1; i > 0; i--) {
       delete[] fSVKernelMatrix[i];
-      fSVKernelMatrix[i] = 0;
+      fSVKernelMatrix[i] = nullptr;
    }
    delete[] fSVKernelMatrix;
-   fSVKernelMatrix = 0;
+   fSVKernelMatrix = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -100,9 +100,9 @@ TMVA::SVKernelMatrix::~SVKernelMatrix()
 
 Float_t* TMVA::SVKernelMatrix::GetLine( UInt_t line )
 {
-   Float_t* fLine = NULL;
+   Float_t* fLine = nullptr;
    if (line >= fSize) {
-      return NULL;
+      return nullptr;
    }
    else {
       fLine = new Float_t[fSize];

--- a/tmva/tmva/src/SVWorkingSet.cxx
+++ b/tmva/tmva/src/SVWorkingSet.cxx
@@ -50,12 +50,12 @@ Working class for Support Vector Machine
 
 TMVA::SVWorkingSet::SVWorkingSet()
    : fdoRegression(kFALSE),
-     fInputData(0),
-     fSupVec(0),
-     fKFunction(0),
-     fKMatrix(0),
-     fTEventUp(0),
-     fTEventLow(0),
+     fInputData(nullptr),
+     fSupVec(nullptr),
+     fKFunction(nullptr),
+     fKMatrix(nullptr),
+     fTEventUp(nullptr),
+     fTEventLow(nullptr),
      fB_low(1.),
      fB_up(-1.),
      fTolerance(0.01),
@@ -70,10 +70,10 @@ TMVA::SVWorkingSet::SVWorkingSet(std::vector<TMVA::SVEvent*>*inputVectors, SVKer
                                  Float_t tol, Bool_t doreg)
    : fdoRegression(doreg),
      fInputData(inputVectors),
-     fSupVec(0),
+     fSupVec(nullptr),
      fKFunction(kernelFunction),
-     fTEventUp(0),
-     fTEventLow(0),
+     fTEventUp(nullptr),
+     fTEventLow(nullptr),
      fB_low(1.),
      fB_up(-1.),
      fTolerance(tol),
@@ -120,7 +120,7 @@ TMVA::SVWorkingSet::SVWorkingSet(std::vector<TMVA::SVEvent*>*inputVectors, SVKer
 
 TMVA::SVWorkingSet::~SVWorkingSet()
 {
-   if (fKMatrix   != 0) {delete fKMatrix; fKMatrix = 0;}
+   if (fKMatrix   != nullptr) {delete fKMatrix; fKMatrix = nullptr;}
    delete fLogger;
 }
 
@@ -128,7 +128,7 @@ TMVA::SVWorkingSet::~SVWorkingSet()
 
 Bool_t TMVA::SVWorkingSet::ExamineExample( TMVA::SVEvent* jevt )
 {
-   SVEvent* ievt=0;
+   SVEvent* ievt=nullptr;
    Float_t fErrorC_J = 0.;
    if( jevt->GetIdx()==0) fErrorC_J = jevt->GetErrorCache();
    else{
@@ -470,7 +470,7 @@ void TMVA::SVWorkingSet::PrintStat()
 std::vector<TMVA::SVEvent*>* TMVA::SVWorkingSet::GetSupportVectors()
 {
    std::vector<TMVA::SVEvent*>::iterator idIter;
-   if( fSupVec != 0) {delete fSupVec; fSupVec = 0; }
+   if( fSupVec != nullptr) {delete fSupVec; fSupVec = nullptr; }
    fSupVec = new std::vector<TMVA::SVEvent*>(0);
 
    for( idIter = fInputData->begin(); idIter != fInputData->end(); ++idIter){
@@ -680,7 +680,7 @@ Bool_t TMVA::SVWorkingSet::TakeStepReg(TMVA::SVEvent* ievt,TMVA::SVEvent* jevt )
 Bool_t TMVA::SVWorkingSet::ExamineExampleReg(TMVA::SVEvent* jevt)
 {
    Float_t feps = 1e-7;// TODO check which value is the best
-   SVEvent* ievt=0;
+   SVEvent* ievt=nullptr;
    Float_t fErrorC_J = 0.;
    if( jevt->IsInI0()) {
       fErrorC_J = jevt->GetErrorCache();

--- a/tmva/tmva/src/TActivationChooser.cxx
+++ b/tmva/tmva/src/TActivationChooser.cxx
@@ -77,9 +77,9 @@ TMVA::TActivationChooser::CreateActivation(EActivationType type) const
    case kRadial:  return new TActivationRadial();
    default:
       Log() << kFATAL << "no Activation function of type " << type << " found" << Endl;
-      return 0;
+      return nullptr;
    }
-   return NULL;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -96,7 +96,7 @@ TMVA::TActivationChooser::CreateActivation(const TString& type) const
    else if (type == fRADIAL)  return CreateActivation(kRadial);
    else {
       Log() << kFATAL << "no Activation function of type " << type << " found" << Endl;
-      return 0;
+      return nullptr;
    }
 }
 

--- a/tmva/tmva/src/TActivationRadial.cxx
+++ b/tmva/tmva/src/TActivationRadial.cxx
@@ -56,8 +56,8 @@ TMVA::TActivationRadial::TActivationRadial()
 
 TMVA::TActivationRadial::~TActivationRadial()
 {
-   if (fEqn != NULL) delete fEqn;
-   if (fEqnDerivative != NULL) delete fEqnDerivative;
+   if (fEqn != nullptr) delete fEqn;
+   if (fEqnDerivative != nullptr) delete fEqnDerivative;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -65,7 +65,7 @@ TMVA::TActivationRadial::~TActivationRadial()
 
 Double_t TMVA::TActivationRadial::Eval(Double_t arg)
 {
-   if (fEqn == NULL) return UNINITIALIZED;
+   if (fEqn == nullptr) return UNINITIALIZED;
    return fEqn->Eval(arg);
 }
 
@@ -74,7 +74,7 @@ Double_t TMVA::TActivationRadial::Eval(Double_t arg)
 
 Double_t TMVA::TActivationRadial::EvalDerivative(Double_t arg)
 {
-   if (fEqnDerivative == NULL) return UNINITIALIZED;
+   if (fEqnDerivative == nullptr) return UNINITIALIZED;
    return fEqnDerivative->Eval(arg);
 }
 
@@ -85,12 +85,12 @@ TString TMVA::TActivationRadial::GetExpression()
 {
    TString expr = "";
 
-   if (fEqn == NULL) expr += "<null>";
+   if (fEqn == nullptr) expr += "<null>";
    else              expr += fEqn->GetExpFormula();
 
    expr += "\t\t";
 
-   if (fEqnDerivative == NULL) expr += "<null>";
+   if (fEqnDerivative == nullptr) expr += "<null>";
    else                        expr += fEqnDerivative->GetExpFormula();
 
    return expr;

--- a/tmva/tmva/src/TActivationSigmoid.cxx
+++ b/tmva/tmva/src/TActivationSigmoid.cxx
@@ -57,8 +57,8 @@ TMVA::TActivationSigmoid::TActivationSigmoid()
 
 TMVA::TActivationSigmoid::~TActivationSigmoid()
 {
-   if (fEqn != NULL) delete fEqn;
-   if (fEqnDerivative != NULL) delete fEqnDerivative;
+   if (fEqn != nullptr) delete fEqn;
+   if (fEqnDerivative != nullptr) delete fEqnDerivative;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -66,7 +66,7 @@ TMVA::TActivationSigmoid::~TActivationSigmoid()
 
 Double_t TMVA::TActivationSigmoid::Eval(Double_t arg)
 {
-   if (fEqn == NULL) return UNINITIALIZED;
+   if (fEqn == nullptr) return UNINITIALIZED;
    return fEqn->Eval(arg);
 
    //return EvalFast(arg);
@@ -77,7 +77,7 @@ Double_t TMVA::TActivationSigmoid::Eval(Double_t arg)
 
 Double_t TMVA::TActivationSigmoid::EvalDerivative(Double_t arg)
 {
-   if (fEqnDerivative == NULL) return UNINITIALIZED;
+   if (fEqnDerivative == nullptr) return UNINITIALIZED;
    return fEqnDerivative->Eval(arg);
 
    //return EvalDerivativeFast(arg);
@@ -90,12 +90,12 @@ TString TMVA::TActivationSigmoid::GetExpression()
 {
    TString expr = "";
 
-   if (fEqn == NULL) expr += "<null>";
+   if (fEqn == nullptr) expr += "<null>";
    else              expr += fEqn->GetExpFormula();
 
    expr += "\t\t";
 
-   if (fEqnDerivative == NULL) expr += "<null>";
+   if (fEqnDerivative == nullptr) expr += "<null>";
    else                        expr += fEqnDerivative->GetExpFormula();
 
    return expr;

--- a/tmva/tmva/src/TNeuron.cxx
+++ b/tmva/tmva/src/TNeuron.cxx
@@ -57,8 +57,8 @@ TMVA::TNeuron::TNeuron()
 
 TMVA::TNeuron::~TNeuron()
 {
-   if (fLinksIn != NULL)  delete fLinksIn;
-   if (fLinksOut != NULL) delete fLinksOut;
+   if (fLinksIn != nullptr)  delete fLinksIn;
+   if (fLinksOut != nullptr) delete fLinksOut;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -73,9 +73,9 @@ void TMVA::TNeuron::InitNeuron()
    fDelta = UNINITIALIZED;
    fDEDw = UNINITIALIZED;
    fError = UNINITIALIZED;
-   fActivation = NULL;
+   fActivation = nullptr;
    fForcedValue = kFALSE;
-   fInputCalculator = NULL;
+   fInputCalculator = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -101,7 +101,7 @@ void TMVA::TNeuron::CalculateValue()
 
 void TMVA::TNeuron::CalculateActivationValue()
 {
-   if (fActivation == NULL) {
+   if (fActivation == nullptr) {
       PrintMessage( kWARNING ,"No activation equation specified." );
       fActivationValue = UNINITIALIZED;
       return;
@@ -128,7 +128,7 @@ void TMVA::TNeuron::CalculateDelta()
    // need to calculate error for any other neuron
    else {
       error = 0.0;
-      TSynapse* synapse = NULL;
+      TSynapse* synapse = nullptr;
       // Replaced TObjArrayIter pointer by object, as creating it on the stack
       // is much faster (5-10% improvement seen) than re-allocating the new
       // memory for the pointer each time. Thanks to Peter Elmer who pointed this out
@@ -136,7 +136,7 @@ void TMVA::TNeuron::CalculateDelta()
       TObjArrayIter iter(fLinksOut);
       while (true) {
          synapse = (TSynapse*) iter.Next();
-         if (synapse == NULL) break;
+         if (synapse == nullptr) break;
          error += synapse->GetWeightedDelta();
       }
 
@@ -150,7 +150,7 @@ void TMVA::TNeuron::CalculateDelta()
 
 void TMVA::TNeuron::SetInputCalculator(TNeuronInput* calculator)
 {
-   if (fInputCalculator != NULL) delete fInputCalculator;
+   if (fInputCalculator != nullptr) delete fInputCalculator;
    fInputCalculator = calculator;
 }
 
@@ -159,7 +159,7 @@ void TMVA::TNeuron::SetInputCalculator(TNeuronInput* calculator)
 
 void TMVA::TNeuron::SetActivationEqn(TActivation* activation)
 {
-   if (fActivation != NULL) delete fActivation;
+   if (fActivation != nullptr) delete fActivation;
    fActivation = activation;
 }
 
@@ -194,16 +194,16 @@ void TMVA::TNeuron::DeletePreLinks()
 
 void TMVA::TNeuron::DeleteLinksArray(TObjArray*& links)
 {
-   if (links == NULL) return;
+   if (links == nullptr) return;
 
-   TSynapse* synapse = NULL;
+   TSynapse* synapse = nullptr;
    Int_t numLinks = links->GetEntriesFast();
    for (Int_t i=0; i<numLinks; i++) {
       synapse = (TSynapse*)links->At(i);
-      if (synapse != NULL) delete synapse;
+      if (synapse != nullptr) delete synapse;
    }
    delete links;
-   links = NULL;
+   links = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -225,11 +225,11 @@ void TMVA::TNeuron::UpdateSynapsesBatch()
 {
    if (IsInputNeuron()) return;
 
-   TSynapse* synapse = NULL;
+   TSynapse* synapse = nullptr;
    TObjArrayIter iter(fLinksIn);
    while (true) {
       synapse = (TSynapse*) iter.Next();
-      if (synapse == NULL) break;
+      if (synapse == nullptr) break;
       synapse->CalculateDelta();
    }
 
@@ -243,12 +243,12 @@ void TMVA::TNeuron::UpdateSynapsesSequential()
 {
    if (IsInputNeuron()) return;
 
-   TSynapse* synapse = NULL;
+   TSynapse* synapse = nullptr;
    TObjArrayIter iter(fLinksIn);
 
    while (true) {
       synapse = (TSynapse*) iter.Next();
-      if (synapse == NULL) break;
+      if (synapse == nullptr) break;
       synapse->InitDelta();
       synapse->CalculateDelta();
       synapse->AdjustWeight();
@@ -264,13 +264,13 @@ void TMVA::TNeuron::AdjustSynapseWeights()
 {
    if (IsInputNeuron()) return;
 
-   TSynapse* synapse = NULL;
+   TSynapse* synapse = nullptr;
    TObjArrayIter iter(fLinksIn);
 
 
    while (true) {
       synapse = (TSynapse*) iter.Next();
-      if (synapse == NULL) break;
+      if (synapse == nullptr) break;
       synapse->AdjustWeight();
    }
 
@@ -285,13 +285,13 @@ void TMVA::TNeuron::InitSynapseDeltas()
    // an input neuron has no pre-weights to adjust
    if (IsInputNeuron()) return;
 
-   TSynapse* synapse = NULL;
+   TSynapse* synapse = nullptr;
    TObjArrayIter iter(fLinksIn);
 
    while (true) {
       synapse = (TSynapse*) iter.Next();
 
-      if (synapse == NULL) break;
+      if (synapse == nullptr) break;
       synapse->InitDelta();
    }
 
@@ -302,7 +302,7 @@ void TMVA::TNeuron::InitSynapseDeltas()
 
 void TMVA::TNeuron::PrintLinks(TObjArray* links) const
 {
-   if (links == NULL) {
+   if (links == nullptr) {
       Log() << kDEBUG << "\t\t\t<none>" << Endl;
       return;
    }
@@ -326,7 +326,7 @@ void TMVA::TNeuron::PrintLinks(TObjArray* links) const
 
 void TMVA::TNeuron::PrintActivationEqn()
 {
-   if (fActivation != NULL) Log() << kDEBUG << fActivation->GetExpression() << Endl;
+   if (fActivation != nullptr) Log() << kDEBUG << fActivation->GetExpression() << Endl;
    else                     Log() << kDEBUG << "<none>" << Endl;
 }
 

--- a/tmva/tmva/src/TSpline1.cxx
+++ b/tmva/tmva/src/TSpline1.cxx
@@ -50,7 +50,7 @@ TMVA::TSpline1::TSpline1( const TString& title, TGraph* theGraph )
 ////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
-TMVA::TSpline1::~TSpline1( void )
+TMVA::TSpline1::~TSpline1()
 {
    if (fGraph) delete fGraph; // ROOT's spline classes also own the TGraph
 }
@@ -84,7 +84,7 @@ Double_t TMVA::TSpline1::Eval( Double_t x ) const
 ////////////////////////////////////////////////////////////////////////////////
 /// no coefficients to precompute
 
-void TMVA::TSpline1::BuildCoeff( void )
+void TMVA::TSpline1::BuildCoeff()
 {
 }
 

--- a/tmva/tmva/src/TSpline2.cxx
+++ b/tmva/tmva/src/TSpline2.cxx
@@ -51,7 +51,7 @@ TMVA::TSpline2::TSpline2( const TString& title, TGraph* theGraph )
 ////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
-TMVA::TSpline2::~TSpline2( void )
+TMVA::TSpline2::~TSpline2()
 {
    if (fGraph) delete fGraph; // ROOT's spline classes also own the TGraph
 }
@@ -119,7 +119,7 @@ Double_t TMVA::TSpline2::Eval( const Double_t x ) const
 ////////////////////////////////////////////////////////////////////////////////
 /// no coefficients to precompute
 
-void TMVA::TSpline2::BuildCoeff( void )
+void TMVA::TSpline2::BuildCoeff()
 {
 }
 

--- a/tmva/tmva/src/TSynapse.cxx
+++ b/tmva/tmva/src/TSynapse.cxx
@@ -50,8 +50,8 @@ TMVA::TSynapse::TSynapse()
      fDelta( 0 ),
      fDEDw( 0 ),
      fCount( 0 ),
-     fPreNeuron( NULL ),
-     fPostNeuron( NULL )
+     fPreNeuron( nullptr ),
+     fPostNeuron( nullptr )
 {
    fWeight     = fgUNINITIALIZED;
 }
@@ -76,7 +76,7 @@ void TMVA::TSynapse::SetWeight(Double_t weight)
 
 Double_t TMVA::TSynapse::GetWeightedValue()
 {
-   if (fPreNeuron == NULL)
+   if (fPreNeuron == nullptr)
       Log() << kFATAL << "<GetWeightedValue> synapse not connected to neuron" << Endl;
 
    return (fWeight * fPreNeuron->GetActivationValue());
@@ -87,7 +87,7 @@ Double_t TMVA::TSynapse::GetWeightedValue()
 
 Double_t TMVA::TSynapse::GetWeightedDelta()
 {
-   if (fPostNeuron == NULL)
+   if (fPostNeuron == nullptr)
       Log() << kFATAL << "<GetWeightedDelta> synapse not connected to neuron" << Endl;
 
    return fWeight * fPostNeuron->GetDelta();

--- a/tmva/tmva/src/Timer.cxx
+++ b/tmva/tmva/src/Timer.cxx
@@ -97,7 +97,7 @@ TMVA::Timer::Timer( Int_t ncounts, const char* prefix, Bool_t colourfulOutput  )
 ////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
-TMVA::Timer::~Timer( void )
+TMVA::Timer::~Timer()
 {
    delete fLogger;
 }
@@ -112,7 +112,7 @@ void TMVA::Timer::Init( Int_t ncounts )
 ////////////////////////////////////////////////////////////////////////////////
 /// resets timer
 
-void TMVA::Timer::Reset( void )
+void TMVA::Timer::Reset()
 {
    TStopwatch::Start( kTRUE );
    fPreviousProgress = -1;
@@ -122,7 +122,7 @@ void TMVA::Timer::Reset( void )
 ////////////////////////////////////////////////////////////////////////////////
 /// computes elapsed tim in seconds
 
-Double_t TMVA::Timer::ElapsedSeconds( void )
+Double_t TMVA::Timer::ElapsedSeconds()
 {
    Double_t rt = TStopwatch::RealTime(); TStopwatch::Start( kFALSE );
    return rt;

--- a/tmva/tmva/src/Tools.cxx
+++ b/tmva/tmva/src/Tools.cxx
@@ -66,7 +66,7 @@ Global auxiliary applications and data treatment routines.
 using namespace std;
 
 #if __cplusplus > 199711L
-std::atomic<TMVA::Tools*> TMVA::Tools::fgTools{0};
+std::atomic<TMVA::Tools*> TMVA::Tools::fgTools{nullptr};
 #else
 TMVA::Tools* TMVA::Tools::fgTools = 0;
 #endif
@@ -76,7 +76,7 @@ TMVA::Tools& TMVA::Tools::Instance()        {
 #if __cplusplus > 199711L
    if(!fgTools) {
       Tools* tmp = new Tools();
-      Tools* expected = 0;
+      Tools* expected = nullptr;
       if(! fgTools.compare_exchange_strong(expected,tmp)) {
          //another thread beat us
          delete tmp;
@@ -91,7 +91,7 @@ void         TMVA::Tools::DestroyInstance() {
    //NOTE: there is no thread safe way to do this so
    // one must only call this method ones in an executable
 #if __cplusplus > 199711L
-   if (fgTools != 0) { delete fgTools.load(); fgTools=0; }
+   if (fgTools != nullptr) { delete fgTools.load(); fgTools=nullptr; }
 #else
    if (fgTools != 0) { delete fgTools; fgTools=0; }
 #endif
@@ -217,7 +217,7 @@ void TMVA::Tools::ComputeStat( const std::vector<TMVA::Event*>& events, std::vec
                                Double_t& xmin,  Double_t& xmax,
                                Int_t signalClass, Bool_t  norm )
 {
-   if (0 == valVec)
+   if (nullptr == valVec)
       Log() << kFATAL << "<Tools::ComputeStat> value vector is zero pointer" << Endl;
 
    if ( events.size() != valVec->size() )
@@ -336,7 +336,7 @@ TMatrixD* TMVA::Tools::GetSQRootMatrix( TMatrixDSym* symMat )
 const TMatrixD* TMVA::Tools::GetCorrelationMatrix( const TMatrixD* covMat )
 {
 
-   if (covMat == 0) return 0;
+   if (covMat == nullptr) return nullptr;
    // sanity check
    Int_t nvar = covMat->GetNrows();
    if (nvar != covMat->GetNcols())
@@ -1126,8 +1126,8 @@ void TMVA::Tools::ReadAttr( void* node, const char* attrname, TString& value )
 
 void TMVA::Tools::AddAttr( void* node, const char* attrname, const char* value )
 {
-   if( node == 0 ) return;
-   gTools().xmlengine().NewAttr(node, 0, attrname, value );
+   if( node == nullptr ) return;
+   gTools().xmlengine().NewAttr(node, nullptr, attrname, value );
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1135,14 +1135,14 @@ void TMVA::Tools::AddAttr( void* node, const char* attrname, const char* value )
 
 void* TMVA::Tools::AddChild( void* parent, const char* childname, const char* content, bool isRootNode )
 {
-   if( !isRootNode && parent == 0 ) return 0;
-   return gTools().xmlengine().NewChild(parent, 0, childname, content);
+   if( !isRootNode && parent == nullptr ) return nullptr;
+   return gTools().xmlengine().NewChild(parent, nullptr, childname, content);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 Bool_t TMVA::Tools::AddComment( void* node, const char* comment ) {
-   if( node == 0 ) return kFALSE;
+   if( node == nullptr ) return kFALSE;
    return gTools().xmlengine().AddComment(node, comment);
 }
 
@@ -1162,8 +1162,8 @@ void* TMVA::Tools::GetParent( void* child)
 void* TMVA::Tools::GetChild( void* parent, const char* childname )
 {
    void* ch = xmlengine().GetChild(parent);
-   if (childname != 0) {
-      while (ch!=0 && strcmp(xmlengine().GetNodeName(ch),childname) != 0) ch = xmlengine().GetNext(ch);
+   if (childname != nullptr) {
+      while (ch!=nullptr && strcmp(xmlengine().GetNodeName(ch),childname) != 0) ch = xmlengine().GetNext(ch);
    }
    return ch;
 }
@@ -1174,8 +1174,8 @@ void* TMVA::Tools::GetChild( void* parent, const char* childname )
 void* TMVA::Tools::GetNextChild( void* prevchild, const char* childname )
 {
    void* ch = xmlengine().GetNext(prevchild);
-   if (childname != 0) {
-      while (ch!=0 && strcmp(xmlengine().GetNodeName(ch),childname)!=0) ch = xmlengine().GetNext(ch);
+   if (childname != nullptr) {
+      while (ch!=nullptr && strcmp(xmlengine().GetNodeName(ch),childname)!=0) ch = xmlengine().GetNext(ch);
    }
    return ch;
 }
@@ -1254,9 +1254,9 @@ TString TMVA::Tools::StringFromDouble( Double_t d )
 
 void TMVA::Tools::WriteTMatrixDToXML( void* node, const char* name, TMatrixD* mat )
 {
-   void* matnode = xmlengine().NewChild(node, 0, name);
-   xmlengine().NewAttr(matnode,0,"Rows", StringFromInt(mat->GetNrows()) );
-   xmlengine().NewAttr(matnode,0,"Columns", StringFromInt(mat->GetNcols()) );
+   void* matnode = xmlengine().NewChild(node, nullptr, name);
+   xmlengine().NewAttr(matnode,nullptr,"Rows", StringFromInt(mat->GetNrows()) );
+   xmlengine().NewAttr(matnode,nullptr,"Columns", StringFromInt(mat->GetNcols()) );
    std::stringstream s;
    for (Int_t row = 0; row<mat->GetNrows(); row++) {
       for (Int_t col = 0; col<mat->GetNcols(); col++) {
@@ -1527,7 +1527,7 @@ TMVA::Tools::CalcCovarianceMatrices( const std::vector<Event*>& events, Int_t ma
 {
    if (events.empty()) {
       Log() << kWARNING << " Asked to calculate a covariance matrix for an empty event vectors.. sorry cannot do that -> return NULL"<<Endl;
-      return 0;
+      return nullptr;
    }
 
    UInt_t nvars=0, ntgts=0, nspcts=0;

--- a/tmva/tmva/src/Tools.cxx
+++ b/tmva/tmva/src/Tools.cxx
@@ -348,9 +348,10 @@ const TMatrixD* TMVA::Tools::GetCorrelationMatrix( const TMatrixD* covMat )
       for (Int_t jvar=0; jvar<nvar; jvar++) {
          if (ivar != jvar) {
             Double_t d = (*covMat)(ivar, ivar)*(*covMat)(jvar, jvar);
-            if (d > 1E-20) (*corrMat)(ivar, jvar) = (*covMat)(ivar, jvar)/TMath::Sqrt(d);
-    else {
-      Log() <<  "<GetCorrelationMatrix> zero variances for variables "
+            if (d > 1E-20) {
+               (*corrMat)(ivar, jvar) = (*covMat)(ivar, jvar)/TMath::Sqrt(d);
+            } else {
+               Log() <<  "<GetCorrelationMatrix> zero variances for variables "
                      << "(" << ivar << ", " << jvar << ")" << Endl;
                (*corrMat)(ivar, jvar) = 0;
             }

--- a/tmva/tmva/src/Tools.cxx
+++ b/tmva/tmva/src/Tools.cxx
@@ -530,7 +530,7 @@ std::vector<Double_t> TMVA::Tools::MVADiff( std::vector<Double_t>& a, std::vecto
 
 void TMVA::Tools::Scale( std::vector<Double_t>& v, Double_t f )
 {
-   for (UInt_t i=0; i<v.size();i++) v[i]*=f;
+   for (double & i : v) i*=f;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -538,7 +538,7 @@ void TMVA::Tools::Scale( std::vector<Double_t>& v, Double_t f )
 
 void TMVA::Tools::Scale( std::vector<Float_t>& v, Float_t f )
 {
-   for (UInt_t i=0; i<v.size();i++) v[i]*=f;
+   for (float & i : v) i*=f;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -725,8 +725,8 @@ Bool_t TMVA::Tools::CheckForVerboseOption( const TString& cs ) const
    s.ToLower();
    s.ReplaceAll(" ","");
    std::vector<TString> v = SplitString( s, ':' );
-   for (std::vector<TString>::iterator it = v.begin(); it != v.end(); ++it) {
-      if ((*it == "v" || *it == "verbose") && !it->Contains("!")) isVerbose = kTRUE;
+   for (auto & it : v) {
+      if ((it == "v" || it == "verbose") && !it.Contains("!")) isVerbose = kTRUE;
    }
 
    return isVerbose;
@@ -1507,9 +1507,9 @@ std::vector<TMatrixDSym*>*
 TMVA::Tools::CalcCovarianceMatrices( const std::vector<const Event*>& events, Int_t maxCls, VariableTransformBase* transformBase )
 {
    std::vector<Event*> eventVector;
-   for (std::vector<const Event*>::const_iterator it = events.begin(), itEnd = events.end(); it != itEnd; ++it)
+   for (auto event : events)
       {
-         eventVector.push_back (new Event(*(*it)));
+         eventVector.push_back (new Event(*event));
       }
    std::vector<TMatrixDSym*>* returnValue = CalcCovarianceMatrices (eventVector, maxCls, transformBase);
    for (std::vector<Event*>::const_iterator it = eventVector.begin(), itEnd = eventVector.end(); it != itEnd; ++it)
@@ -1568,10 +1568,9 @@ TMVA::Tools::CalcCovarianceMatrices( const std::vector<Event*>& events, Int_t ma
    }
 
    // perform event loop
-   for (UInt_t i=0; i<events.size(); i++) {
+   for (auto ev : events) {
 
       // fill the event
-      const Event * ev = events[i];
       cls = ev->GetClass();
       Double_t weight = ev->GetWeight();
 

--- a/tmva/tmva/src/TransformationHandler.cxx
+++ b/tmva/tmva/src/TransformationHandler.cxx
@@ -132,8 +132,8 @@ void TMVA::TransformationHandler::AddStats( Int_t k, UInt_t ivar, Double_t mean,
 
 void TMVA::TransformationHandler::SetTransformationReferenceClass( Int_t cls )
 {
-   for (UInt_t i = 0; i < fTransformationsReferenceClasses.size(); i++) {
-      fTransformationsReferenceClasses.at( i ) = cls;
+   for (int & fTransformationsReferenceClasse : fTransformationsReferenceClasses) {
+      fTransformationsReferenceClasse = cls;
    }
 }
 
@@ -217,8 +217,8 @@ const std::vector<TMVA::Event*>* TMVA::TransformationHandler::CalcTransformation
    std::vector< Int_t >::iterator rClsIt = fTransformationsReferenceClasses.begin();
    while (VariableTransformBase *trf = (VariableTransformBase*) trIt()) {
       if (trf->PrepareTransformation(*transformedEvents)) {
-         for (UInt_t ievt = 0; ievt<transformedEvents->size(); ievt++) {  // loop through all events
-            *(*transformedEvents)[ievt] = *trf->Transform((*transformedEvents)[ievt],(*rClsIt));
+         for (auto & transformedEvent : *transformedEvents) {  // loop through all events
+            *transformedEvent = *trf->Transform(transformedEvent,(*rClsIt));
          }
          ++rClsIt;
       }
@@ -232,8 +232,8 @@ const std::vector<TMVA::Event*>* TMVA::TransformationHandler::CalcTransformation
    //sometimes, the actual transformed event vector is not used for anything but the previous
    //CalcStat and PlotVariables calles, in that case, we delete it again (and return NULL)
    if (!createNewVector) {  // if we don't want that newly created event vector to persist, then delete it
-      for ( UInt_t ievt = 0; ievt<transformedEvents->size(); ievt++)
-         delete (*transformedEvents)[ievt];
+      for (auto & transformedEvent : *transformedEvents)
+         delete transformedEvent;
       delete transformedEvents;
       transformedEvents=nullptr;
    }

--- a/tmva/tmva/src/TransformationHandler.cxx
+++ b/tmva/tmva/src/TransformationHandler.cxx
@@ -68,7 +68,7 @@ Class that contains all the data information.
 
 TMVA::TransformationHandler::TransformationHandler( DataSetInfo& dsi, const TString& callerName )
    : fDataSetInfo(dsi),
-     fRootBaseDir(0),
+     fRootBaseDir(nullptr),
      fCallerName (callerName),
      fLogger     ( new MsgLogger(TString("TFHandler_" + callerName).Data(), kINFO) )
 {
@@ -235,7 +235,7 @@ const std::vector<TMVA::Event*>* TMVA::TransformationHandler::CalcTransformation
       for ( UInt_t ievt = 0; ievt<transformedEvents->size(); ievt++)
          delete (*transformedEvents)[ievt];
       delete transformedEvents;
-      transformedEvents=NULL;
+      transformedEvents=nullptr;
    }
 
    return transformedEvents; // give back the newly created event collection (containing the transformed events)
@@ -449,15 +449,15 @@ TString TMVA::TransformationHandler::GetVariableAxisTitle( const VariableInfo& i
 
 void TMVA::TransformationHandler::PlotVariables (const std::vector<Event*>& events, TDirectory* theDirectory )
 {
-   if (fRootBaseDir==0 && theDirectory == 0) return;
+   if (fRootBaseDir==nullptr && theDirectory == nullptr) return;
 
    Log() << kDEBUG << "Plot event variables for ";
-   if (theDirectory !=0) Log()<< TString(theDirectory->GetName()) << Endl;
+   if (theDirectory !=nullptr) Log()<< TString(theDirectory->GetName()) << Endl;
    else Log() << GetName() << Endl;
 
    // extension for transformation type
    TString transfType = "";
-   if (theDirectory == 0) {
+   if (theDirectory == nullptr) {
       transfType += "_";
       transfType += GetName();
    }else{ // you plot for the individual classifiers. Note, here the "statistics" still need to be calculated as you are in the testing phase
@@ -476,14 +476,14 @@ void TMVA::TransformationHandler::PlotVariables (const std::vector<Event*>& even
 
    for (Int_t cls = 0; cls < ncls; cls++) {
       hVars.at(cls).resize ( nvar+ntgt );
-      hVars.at(cls).assign ( nvar+ntgt, 0 ); // fill with zeros
+      hVars.at(cls).assign ( nvar+ntgt, nullptr ); // fill with zeros
       mycorr.at(cls).resize( nvar+ntgt );
       myprof.at(cls).resize( nvar+ntgt );
       for (UInt_t ivar=0; ivar < nvar+ntgt; ivar++) {
          mycorr.at(cls).at(ivar).resize( nvar+ntgt );
          myprof.at(cls).at(ivar).resize( nvar+ntgt );
-         mycorr.at(cls).at(ivar).assign( nvar+ntgt, 0 ); // fill with zeros
-         myprof.at(cls).at(ivar).assign( nvar+ntgt, 0 ); // fill with zeros
+         mycorr.at(cls).at(ivar).assign( nvar+ntgt, nullptr ); // fill with zeros
+         myprof.at(cls).at(ivar).assign( nvar+ntgt, nullptr ); // fill with zeros
       }
    }
 
@@ -534,7 +534,7 @@ void TMVA::TransformationHandler::PlotVariables (const std::vector<Event*>& even
             className += (ntgt == 1 && var_tgt == 1 ? "_target" : "");
 
             // choose reasonable histogram ranges, by removing outliers
-            TH1* h = 0;
+            TH1* h = nullptr;
             if (info.GetVarType() == 'I') {
                // special treatment for integer variables
                Int_t xmin = TMath::Nint( GetMin( ( var_tgt*nvar )+ivar) );
@@ -713,8 +713,8 @@ void TMVA::TransformationHandler::PlotVariables (const std::vector<Event*>& even
    // computes ranking of input variables
    // separation for 2-class classification
    else if (fDataSetInfo.GetNClasses() == 2
-            && fDataSetInfo.GetClassInfo("Signal") != NULL
-            && fDataSetInfo.GetClassInfo("Background") != NULL
+            && fDataSetInfo.GetClassInfo("Signal") != nullptr
+            && fDataSetInfo.GetClassInfo("Background") != nullptr
             ) { // TODO: ugly hack.. adapt to new framework
       fRanking.push_back( new Ranking( GetName() + "Transformation", "Separation" ) );
       for (UInt_t i=0; i<nvar; i++) {
@@ -730,7 +730,7 @@ void TMVA::TransformationHandler::PlotVariables (const std::vector<Event*>& even
    // write histograms
 
    TDirectory* localDir = theDirectory;
-   if (theDirectory == 0) {
+   if (theDirectory == nullptr) {
       // create directory in root dir
       fRootBaseDir->cd();
       TString outputDir = TString("InputVariables");
@@ -740,8 +740,8 @@ void TMVA::TransformationHandler::PlotVariables (const std::vector<Event*>& even
 
       TString uniqueOutputDir = outputDir;
       Int_t counter = 0;
-      TObject* o = NULL;
-      while( (o = fRootBaseDir->FindObject(uniqueOutputDir)) != 0 ){
+      TObject* o = nullptr;
+      while( (o = fRootBaseDir->FindObject(uniqueOutputDir)) != nullptr ){
          uniqueOutputDir = outputDir+Form("_%d",counter);
          Log() << kINFO << "A " << o->ClassName() << " with name " << o->GetName() << " already exists in "
                << fRootBaseDir->GetPath() << ", I will try with "<<uniqueOutputDir<<"." << Endl;
@@ -764,9 +764,9 @@ void TMVA::TransformationHandler::PlotVariables (const std::vector<Event*>& even
 
    for (UInt_t i=0; i<nvar+ntgt; i++) {
       for (Int_t cls = 0; cls < ncls; cls++) {
-         if (hVars.at(cls).at(i) != 0) {
+         if (hVars.at(cls).at(i) != nullptr) {
             hVars.at(cls).at(i)->Write();
-            hVars.at(cls).at(i)->SetDirectory(0);
+            hVars.at(cls).at(i)->SetDirectory(nullptr);
             delete hVars.at(cls).at(i);
          }
       }
@@ -784,21 +784,21 @@ void TMVA::TransformationHandler::PlotVariables (const std::vector<Event*>& even
       for (UInt_t i=0; i<nvar+ntgt; i++) {
          for (UInt_t j=i+1; j<nvar+ntgt; j++) {
             for (Int_t cls = 0; cls < ncls; cls++) {
-               if (mycorr.at(cls).at(i).at(j) != 0 ) {
+               if (mycorr.at(cls).at(i).at(j) != nullptr ) {
                   mycorr.at(cls).at(i).at(j)->Write();
-                  mycorr.at(cls).at(i).at(j)->SetDirectory(0);
+                  mycorr.at(cls).at(i).at(j)->SetDirectory(nullptr);
                   delete mycorr.at(cls).at(i).at(j);
                }
-               if (myprof.at(cls).at(i).at(j) != 0) {
+               if (myprof.at(cls).at(i).at(j) != nullptr) {
                   myprof.at(cls).at(i).at(j)->Write();
-                  myprof.at(cls).at(i).at(j)->SetDirectory(0);
+                  myprof.at(cls).at(i).at(j)->SetDirectory(nullptr);
                   delete myprof.at(cls).at(i).at(j);
                }
             }
          }
       }
    }
-   if (theDirectory != 0 ) theDirectory->cd();
+   if (theDirectory != nullptr ) theDirectory->cd();
    else                    fRootBaseDir->cd();
 }
 
@@ -808,7 +808,7 @@ void TMVA::TransformationHandler::PlotVariables (const std::vector<Event*>& even
 std::vector<TString>* TMVA::TransformationHandler::GetTransformationStringsOfLastTransform() const
 {
    VariableTransformBase* trf = ((VariableTransformBase*)GetTransformationList().Last());
-   if (!trf) return 0;
+   if (!trf) return nullptr;
    else      return trf->GetTransformationStrings( fTransformationsReferenceClasses.back() );
 }
 
@@ -818,7 +818,7 @@ std::vector<TString>* TMVA::TransformationHandler::GetTransformationStringsOfLas
 const char* TMVA::TransformationHandler::GetNameOfLastTransform() const
 {
    VariableTransformBase* trf = ((VariableTransformBase*)GetTransformationList().Last());
-   if (!trf) return 0;
+   if (!trf) return nullptr;
    else      return trf->GetName();
 }
 
@@ -839,7 +839,7 @@ void TMVA::TransformationHandler::WriteToStream( std::ostream& o ) const
       trf->WriteTransformationToStream(o);
       ci = fDataSetInfo.GetClassInfo( (*rClsIt) );
       TString clsName;
-      if (ci == 0 ) clsName = "AllClasses";
+      if (ci == nullptr ) clsName = "AllClasses";
       else clsName = ci->GetName();
       o << "ReferenceClass " << clsName << std::endl;
       ++rClsIt;
@@ -877,7 +877,7 @@ void TMVA::TransformationHandler::ReadFromXML( void* trfsnode )
       TString trfname;
       gTools().ReadAttr(ch, "Name", trfname);
 
-      VariableTransformBase* newtrf = 0;
+      VariableTransformBase* newtrf = nullptr;
 
       if (trfname == "Decorrelation" ) {
          newtrf = new VariableDecorrTransform(fDataSetInfo);

--- a/tmva/tmva/src/Types.cxx
+++ b/tmva/tmva/src/Types.cxx
@@ -44,7 +44,7 @@ Singleton class for Global types used by TMVA
 #endif
 
 #if __cplusplus > 199711L
-std::atomic<TMVA::Types*> TMVA::Types::fgTypesPtr{0};
+std::atomic<TMVA::Types*> TMVA::Types::fgTypesPtr{nullptr};
 static std::mutex gTypesMutex;
 #else
 TMVA::Types* TMVA::Types::fgTypesPtr = 0;
@@ -72,7 +72,7 @@ TMVA::Types& TMVA::Types::Instance()
 #if __cplusplus > 199711L
    if(!fgTypesPtr) {
       Types* tmp = new Types();
-      Types* expected = 0;
+      Types* expected = nullptr;
       if(!fgTypesPtr.compare_exchange_strong(expected,tmp)) {
          //Another thread already did it
          delete tmp;
@@ -90,7 +90,7 @@ TMVA::Types& TMVA::Types::Instance()
 void   TMVA::Types::DestroyInstance()
 {
 #if __cplusplus > 199711L
-   if (fgTypesPtr != 0) { delete fgTypesPtr.load(); fgTypesPtr = 0; }
+   if (fgTypesPtr != nullptr) { delete fgTypesPtr.load(); fgTypesPtr = nullptr; }
 #else
    if (fgTypesPtr != 0) { delete fgTypesPtr; fgTypesPtr = 0; }
 #endif

--- a/tmva/tmva/src/VariableDecorrTransform.cxx
+++ b/tmva/tmva/src/VariableDecorrTransform.cxx
@@ -64,8 +64,8 @@ TMVA::VariableDecorrTransform::VariableDecorrTransform( DataSetInfo& dsi )
 
 TMVA::VariableDecorrTransform::~VariableDecorrTransform()
 {
-   for (std::vector<TMatrixD*>::iterator it = fDecorrMatrices.begin(); it != fDecorrMatrices.end(); ++it) {
-      if ((*it) != 0) delete (*it);
+   for (auto & fDecorrMatrice : fDecorrMatrices) {
+      if (fDecorrMatrice != 0) delete fDecorrMatrice;
    }
 }
 
@@ -244,9 +244,8 @@ const TMVA::Event* TMVA::VariableDecorrTransform::InverseTransform( const TMVA::
 void TMVA::VariableDecorrTransform::CalcSQRMats( const std::vector< Event*>& events, Int_t maxCls )
 {
    // delete old matrices if any
-   for (std::vector<TMatrixD*>::iterator it = fDecorrMatrices.begin();
-        it != fDecorrMatrices.end(); ++it)
-      if (0 != (*it) ) { delete (*it); *it=0; }
+   for (auto & fDecorrMatrice : fDecorrMatrices)
+      if (0 != fDecorrMatrice ) { delete fDecorrMatrice; fDecorrMatrice=0; }
 
 
    // if more than one classes, then produce one matrix for all events as well (beside the matrices for each class)
@@ -273,9 +272,8 @@ void TMVA::VariableDecorrTransform::WriteTransformationToStream( std::ostream& o
 {
    Int_t cls = 0;
    Int_t dp = o.precision();
-   for (std::vector<TMatrixD*>::const_iterator itm = fDecorrMatrices.begin(); itm != fDecorrMatrices.end(); ++itm) {
+   for (auto mat : fDecorrMatrices) {
       o << "# correlation matrix " << std::endl;
-      TMatrixD* mat = (*itm);
       o << cls << " " << mat->GetNrows() << " x " << mat->GetNcols() << std::endl;
       for (Int_t row = 0; row<mat->GetNrows(); row++) {
          for (Int_t col = 0; col<mat->GetNcols(); col++) {
@@ -322,8 +320,8 @@ void TMVA::VariableDecorrTransform::AttachXMLTo(void* parent)
 void TMVA::VariableDecorrTransform::ReadFromXML( void* trfnode )
 {
    // first delete the old matrices
-   for( std::vector<TMatrixD*>::iterator it = fDecorrMatrices.begin(); it != fDecorrMatrices.end(); ++it )
-      if( (*it) != 0 ) delete (*it);
+   for(auto & fDecorrMatrice : fDecorrMatrices)
+      if( fDecorrMatrice != 0 ) delete fDecorrMatrice;
    fDecorrMatrices.clear();
 
    Bool_t newFormat = kFALSE;
@@ -413,9 +411,9 @@ void TMVA::VariableDecorrTransform::ReadTransformationFromStream( std::istream& 
 void TMVA::VariableDecorrTransform::PrintTransformation( std::ostream& )
 {
    Int_t cls = 0;
-   for (std::vector<TMatrixD*>::iterator itm = fDecorrMatrices.begin(); itm != fDecorrMatrices.end(); ++itm) {
+   for (auto & fDecorrMatrice : fDecorrMatrices) {
       Log() << kINFO << "Transformation matrix "<< cls <<":" << Endl;
-      (*itm)->Print();
+      fDecorrMatrice->Print();
    }
 }
 

--- a/tmva/tmva/src/VariableDecorrTransform.cxx
+++ b/tmva/tmva/src/VariableDecorrTransform.cxx
@@ -120,7 +120,7 @@ std::vector<TString>* TMVA::VariableDecorrTransform::GetTransformationStrings( I
    if (cls < 0 || cls > GetNClasses()) whichMatrix = GetNClasses();
 
    TMatrixD* m = fDecorrMatrices.at(whichMatrix);
-   if (m == 0) {
+   if (m == nullptr) {
       if (whichMatrix == GetNClasses() )
          Log() << kFATAL << "Transformation matrix all classes is not defined"
                << Endl;
@@ -181,7 +181,7 @@ const TMVA::Event* TMVA::VariableDecorrTransform::Transform( const TMVA::Event* 
    //}
 
    TMatrixD* m = fDecorrMatrices.at(whichMatrix);
-   if (m == 0) {
+   if (m == nullptr) {
       if (whichMatrix == GetNClasses() )
          Log() << kFATAL << "Transformation matrix all classes is not defined"
                << Endl;
@@ -190,8 +190,8 @@ const TMVA::Event* TMVA::VariableDecorrTransform::Transform( const TMVA::Event* 
                << Endl;
    }
 
-   if (fTransformedEvent==0 || fTransformedEvent->GetNVariables()!=ev->GetNVariables()) {
-      if (fTransformedEvent!=0) { delete fTransformedEvent; fTransformedEvent = 0; }
+   if (fTransformedEvent==nullptr || fTransformedEvent->GetNVariables()!=ev->GetNVariables()) {
+      if (fTransformedEvent!=nullptr) { delete fTransformedEvent; fTransformedEvent = nullptr; }
       fTransformedEvent = new Event();
    }
 
@@ -251,14 +251,14 @@ void TMVA::VariableDecorrTransform::CalcSQRMats( const std::vector< Event*>& eve
 
    // if more than one classes, then produce one matrix for all events as well (beside the matrices for each class)
    const UInt_t matNum = (maxCls<=1)?maxCls:maxCls+1;
-   fDecorrMatrices.resize( matNum, (TMatrixD*) 0 );
+   fDecorrMatrices.resize( matNum, (TMatrixD*) nullptr );
 
    std::vector<TMatrixDSym*>* covMat = gTools().CalcCovarianceMatrices( events, maxCls, this );
 
 
    for (UInt_t cls=0; cls<matNum; cls++) {
       TMatrixD* sqrMat = gTools().GetSQRootMatrix( covMat->at(cls) );
-      if ( sqrMat==0 )
+      if ( sqrMat==nullptr )
          Log() << kFATAL << "<GetSQRMats> Zero pointer returned for SQR matrix" << Endl;
       fDecorrMatrices[cls] = sqrMat;
       delete (*covMat)[cls];
@@ -328,13 +328,13 @@ void TMVA::VariableDecorrTransform::ReadFromXML( void* trfnode )
 
    Bool_t newFormat = kFALSE;
 
-   void* inpnode = NULL;
+   void* inpnode = nullptr;
 
    inpnode = gTools().GetChild(trfnode, "Selection"); // new xml format
-   if( inpnode!=NULL )
+   if( inpnode!=nullptr )
       newFormat = kTRUE; // new xml format
 
-   void* ch = NULL;
+   void* ch = nullptr;
    if( newFormat ){
       // ------------- new format --------------------
       // read input
@@ -345,7 +345,7 @@ void TMVA::VariableDecorrTransform::ReadFromXML( void* trfnode )
       ch = gTools().GetChild(trfnode);
 
    // Read the transformation matrices from the xml node
-   while(ch!=0) {
+   while(ch!=nullptr) {
       Int_t nrows, ncols;
       gTools().ReadAttr(ch, "Rows", nrows);
       gTools().ReadAttr(ch, "Columns", ncols);
@@ -390,7 +390,7 @@ void TMVA::VariableDecorrTransform::ReadTransformationFromStream( std::istream& 
          // coverity[tainted_data_argument]
          sstr >> nrows >> dummy >> ncols;
          if (fDecorrMatrices.size() <= cls ) fDecorrMatrices.resize(cls+1);
-         if (fDecorrMatrices.at(cls) != 0) delete fDecorrMatrices.at(cls);
+         if (fDecorrMatrices.at(cls) != nullptr) delete fDecorrMatrices.at(cls);
          TMatrixD* mat = fDecorrMatrices.at(cls) = new TMatrixD(nrows,ncols);
          // now read all matrix parameters
          for (Int_t row = 0; row<mat->GetNrows(); row++) {

--- a/tmva/tmva/src/VariableGaussTransform.cxx
+++ b/tmva/tmva/src/VariableGaussTransform.cxx
@@ -155,7 +155,7 @@ const TMVA::Event* TMVA::VariableGaussTransform::Transform(const Event* const ev
          continue;
       }
 
-      if (0 != fCumulativePDF[ivar][cls]) {
+      if (nullptr != fCumulativePDF[ivar][cls]) {
          // first make it flat
          if(fTMVAVersion>TMVA_VERSION(3,9,7))
             cumulant = (fCumulativePDF[ivar][cls])->GetVal(input.at(ivar));
@@ -178,8 +178,8 @@ const TMVA::Event* TMVA::VariableGaussTransform::Transform(const Event* const ev
       }
    }
 
-   if (fTransformedEvent==0 || fTransformedEvent->GetNVariables()!=ev->GetNVariables()) {
-      if (fTransformedEvent!=0) { delete fTransformedEvent; fTransformedEvent = 0; }
+   if (fTransformedEvent==nullptr || fTransformedEvent->GetNVariables()!=ev->GetNVariables()) {
+      if (fTransformedEvent!=nullptr) { delete fTransformedEvent; fTransformedEvent = nullptr; }
       fTransformedEvent = new Event();
    }
 
@@ -224,7 +224,7 @@ const TMVA::Event* TMVA::VariableGaussTransform::InverseTransform(const  Event* 
          continue;
       }
 
-      if (0 != fCumulativePDF[ivar][cls]) {
+      if (nullptr != fCumulativePDF[ivar][cls]) {
          invCumulant = input.at(ivar);
 
          // first de-gauss ist if gaussianized
@@ -241,7 +241,7 @@ const TMVA::Event* TMVA::VariableGaussTransform::InverseTransform(const  Event* 
       }
    }
 
-   if (fBackTransformedEvent==0) fBackTransformedEvent = new Event( *ev );
+   if (fBackTransformedEvent==nullptr) fBackTransformedEvent = new Event( *ev );
 
    SetOutput( fBackTransformedEvent, output, mask, ev, kTRUE );
 
@@ -367,14 +367,14 @@ void TMVA::VariableGaussTransform::GetCumulativeDist( const std::vector< Event*>
             binnings[k] = vsForBinning[icls][ivar][k];
          }
          fCumulativeDist[ivar].resize(numDist);
-         if (0 != fCumulativeDist[ivar][icls] ) {
+         if (nullptr != fCumulativeDist[ivar][icls] ) {
             delete fCumulativeDist[ivar][icls];
          }
          fCumulativeDist[ivar][icls] = new TH1F(Form("Cumulative_Var%d_cls%d",ivar,icls),
                                                 Form("Cumulative_Var%d_cls%d",ivar,icls),
                                                 nbins[icls][ivar] -1, // class icls
                                                 binnings);
-         fCumulativeDist[ivar][icls]->SetDirectory(0);
+         fCumulativeDist[ivar][icls]->SetDirectory(nullptr);
          delete [] binnings;
       }
    }
@@ -450,7 +450,7 @@ void TMVA::VariableGaussTransform::CleanUpCumulativeArrays(TString opt) {
    if (opt == "ALL" || opt == "PDF"){
       for (UInt_t ivar=0; ivar<fCumulativePDF.size(); ivar++) {
          for (UInt_t icls=0; icls<fCumulativePDF[ivar].size(); icls++) {
-            if (0 != fCumulativePDF[ivar][icls]) delete fCumulativePDF[ivar][icls];
+            if (nullptr != fCumulativePDF[ivar][icls]) delete fCumulativePDF[ivar][icls];
          }
       }
       fCumulativePDF.clear();
@@ -458,7 +458,7 @@ void TMVA::VariableGaussTransform::CleanUpCumulativeArrays(TString opt) {
    if (opt == "ALL" || opt == "Dist"){
       for (UInt_t ivar=0; ivar<fCumulativeDist.size(); ivar++) {
          for (UInt_t icls=0; icls<fCumulativeDist[ivar].size(); icls++) {
-            if (0 != fCumulativeDist[ivar][icls]) delete fCumulativeDist[ivar][icls];
+            if (nullptr != fCumulativeDist[ivar][icls]) delete fCumulativeDist[ivar][icls];
          }
       }
       fCumulativeDist.clear();
@@ -480,8 +480,8 @@ void TMVA::VariableGaussTransform::AttachXMLTo(void* parent) {
       //      gTools().AddAttr( varxml, "Name",     Variables()[ivar].GetLabel() );
       gTools().AddAttr( varxml, "VarIndex", ivar );
 
-      if ( fCumulativePDF[ivar][0]==0 ||
-           (fCumulativePDF[ivar].size()>1 && fCumulativePDF[ivar][1]==0 ))
+      if ( fCumulativePDF[ivar][0]==nullptr ||
+           (fCumulativePDF[ivar].size()>1 && fCumulativePDF[ivar][1]==nullptr ))
          Log() << kFATAL << "Cumulative histograms for variable " << ivar << " don't exist, can't write it to weight file" << Endl;
 
       for (UInt_t icls=0; icls<fCumulativePDF[ivar].size(); icls++){
@@ -506,13 +506,13 @@ void TMVA::VariableGaussTransform::ReadFromXML( void* trfnode ) {
 
    Bool_t newFormat = kFALSE;
 
-   void* inpnode = NULL;
+   void* inpnode = nullptr;
 
    inpnode = gTools().GetChild(trfnode, "Selection"); // new xml format
-   if( inpnode!=NULL )
+   if( inpnode!=nullptr )
       newFormat = kTRUE; // new xml format
 
-   void* varnode = NULL;
+   void* varnode = nullptr;
    if( newFormat ){
       // ------------- new format --------------------
       // read input
@@ -590,10 +590,10 @@ void TMVA::VariableGaussTransform::ReadTransformationFromStream( std::istream& i
          if(type>=fCumulativeDist[ivar].size()) fCumulativeDist[ivar].resize(type+1);
 
          TH1F * histToRead = fCumulativeDist[ivar][type];
-         if ( histToRead !=0 ) delete histToRead;
+         if ( histToRead !=nullptr ) delete histToRead;
          // recreate the cumulative histogram to be filled with the values read
          histToRead = new TH1F( hname, hname, nbins, Binnings );
-         histToRead->SetDirectory(0);
+         histToRead->SetDirectory(nullptr);
          fCumulativeDist[ivar][type]=histToRead;
 
          istr >> devnullS; // read the line "BinContent" ..

--- a/tmva/tmva/src/VariableGaussTransform.cxx
+++ b/tmva/tmva/src/VariableGaussTransform.cxx
@@ -746,7 +746,7 @@ void TMVA::VariableGaussTransform::MakeFunction( std::ostream& fout, const TStri
                if( type != 'v' ){
                   Log() << kWARNING << "MakeClass for the Gauss transformation works only for the transformation of variables. The transformation of targets/spectators is not implemented." << Endl;
                }
-            }catch( std::out_of_range except ){
+            } catch (const std::out_of_range &except) {
                Log() << kWARNING << "MakeClass for the Gauss transformation searched for a non existing variable index (" << ivar << ")" << Endl;
             }
 

--- a/tmva/tmva/src/VariableGaussTransform.cxx
+++ b/tmva/tmva/src/VariableGaussTransform.cxx
@@ -77,7 +77,7 @@ TMVA::VariableGaussTransform::VariableGaussTransform( DataSetInfo& dsi, TString 
 ////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
-TMVA::VariableGaussTransform::~VariableGaussTransform( void )
+TMVA::VariableGaussTransform::~VariableGaussTransform()
 {
    CleanUpCumulativeArrays();
 }

--- a/tmva/tmva/src/VariableGaussTransform.cxx
+++ b/tmva/tmva/src/VariableGaussTransform.cxx
@@ -306,8 +306,7 @@ void TMVA::VariableGaussTransform::GetCumulativeDist( const std::vector< Event*>
 
 
       Int_t ivar = 0;
-      for( std::vector<Float_t>::iterator itInput = input.begin(), itInputEnd = input.end(); itInput != itInputEnd; ++itInput ) {
-         Float_t value = (*itInput);
+      for(float value : input) {
          listsForBinning[cls][ivar].push_back(TMVA::TMVAGaussPair(value,eventWeight));
          if (numDist>1)listsForBinning[numDist-1][ivar].push_back(TMVA::TMVAGaussPair(value,eventWeight));
          ++ivar;
@@ -400,8 +399,7 @@ void TMVA::VariableGaussTransform::GetCumulativeDist( const std::vector< Event*>
       GetInput( ev, input, mask );
 
       Int_t ivar = 0;
-      for( std::vector<Float_t>::iterator itInput = input.begin(), itInputEnd = input.end(); itInput != itInputEnd; ++itInput ) {
-         Float_t value = (*itInput);
+      for(float value : input) {
          fCumulativeDist[ivar][cls]->Fill(value,eventWeight);
          if (numDist>1) fCumulativeDist[ivar][numDist-1]->Fill(value,eventWeight);
 
@@ -448,17 +446,17 @@ void TMVA::VariableGaussTransform::WriteTransformationToStream( std::ostream& ) 
 
 void TMVA::VariableGaussTransform::CleanUpCumulativeArrays(TString opt) {
    if (opt == "ALL" || opt == "PDF"){
-      for (UInt_t ivar=0; ivar<fCumulativePDF.size(); ivar++) {
-         for (UInt_t icls=0; icls<fCumulativePDF[ivar].size(); icls++) {
-            if (nullptr != fCumulativePDF[ivar][icls]) delete fCumulativePDF[ivar][icls];
+      for (auto & ivar : fCumulativePDF) {
+         for (UInt_t icls=0; icls<ivar.size(); icls++) {
+            if (nullptr != ivar[icls]) delete ivar[icls];
          }
       }
       fCumulativePDF.clear();
    }
    if (opt == "ALL" || opt == "Dist"){
-      for (UInt_t ivar=0; ivar<fCumulativeDist.size(); ivar++) {
-         for (UInt_t icls=0; icls<fCumulativeDist[ivar].size(); icls++) {
-            if (nullptr != fCumulativeDist[ivar][icls]) delete fCumulativeDist[ivar][icls];
+      for (auto & ivar : fCumulativeDist) {
+         for (UInt_t icls=0; icls<ivar.size(); icls++) {
+            if (nullptr != ivar[icls]) delete ivar[icls];
          }
       }
       fCumulativeDist.clear();

--- a/tmva/tmva/src/VariableImportance.cxx
+++ b/tmva/tmva/src/VariableImportance.cxx
@@ -176,7 +176,7 @@ TH1F* TMVA::VariableImportance::GetImportance(const UInt_t nbits,std::vector<Flo
     vihist->GetYaxis()->SetTitleOffset(1.24);
 
     vihist->GetYaxis()->SetRangeUser(-7, 50);
-    vihist->SetDirectory(0);
+    vihist->SetDirectory(nullptr);
 
     return vihist;
 }

--- a/tmva/tmva/src/VariableInfo.cxx
+++ b/tmva/tmva/src/VariableInfo.cxx
@@ -91,7 +91,7 @@ TMVA::VariableInfo::VariableInfo()
      fXrmsNorm     ( 0 ),
      fXvarianceNorm( 0 ),
      fNormalized   ( kFALSE ),
-     fExternalData ( 0 ),
+     fExternalData ( nullptr ),
      fVarCounter   ( 0 )
 {
    fXminNorm     =  1e30;

--- a/tmva/tmva/src/VariableNormalizeTransform.cxx
+++ b/tmva/tmva/src/VariableNormalizeTransform.cxx
@@ -133,15 +133,13 @@ const TMVA::Event* TMVA::VariableNormalizeTransform::Transform( const TMVA::Even
 
    UInt_t iidx = 0;
    std::vector<Char_t>::iterator itMask = mask.begin();
-   for ( std::vector<Float_t>::iterator itInp = input.begin(), itInpEnd = input.end(); itInp != itInpEnd; ++itInp) { // loop over input variables
+   for (float val : input) { // loop over input variables
       if( (*itMask) ){
          ++iidx;
          ++itMask;
          // don't put any value into output if the value is masked
          continue;
       }
-
-      Float_t val = (*itInp);
 
       min = minVector.at(iidx);
       max = maxVector.at(iidx);
@@ -185,9 +183,7 @@ const TMVA::Event* TMVA::VariableNormalizeTransform::InverseTransform(const TMVA
    const FloatVector& maxVector = fMax.at(cls);
 
    UInt_t iidx = 0;
-   for ( std::vector<Float_t>::iterator itInp = input.begin(), itInpEnd = input.end(); itInp != itInpEnd; ++itInp) { // loop over input variables
-      Float_t val = (*itInp);
-
+   for (float val : input) { // loop over input variables
       min = minVector.at(iidx);
       max = maxVector.at(iidx);
       Float_t offset = min;
@@ -246,9 +242,7 @@ void TMVA::VariableNormalizeTransform::CalcNormalizationParams( const std::vecto
 
       GetInput(event,input,mask);    // select the input variables for the transformation and get them from the event
       UInt_t iidx = 0;
-      for ( std::vector<Float_t>::iterator itInp = input.begin(), itInpEnd = input.end(); itInp != itInpEnd; ++itInp) { // loop over input variables
-         Float_t val = (*itInp);
-
+      for (float val : input) { // loop over input variables
          if( minVector.at(iidx) > val ) minVector.at(iidx) = val;
          if( maxVector.at(iidx) < val ) maxVector.at(iidx) = val;
 
@@ -278,12 +272,12 @@ std::vector<TString>* TMVA::VariableNormalizeTransform::GetTransformationStrings
    std::vector<TString>* strVec = new std::vector<TString>(size);
 
    UInt_t iinp = 0;
-   for( ItVarTypeIdxConst itGet = fGet.begin(), itGetEnd = fGet.end(); itGet != itGetEnd; ++itGet ) {
+   for(const auto & itGet : fGet) {
       min = fMin.at(cls).at(iinp);
       max = fMax.at(cls).at(iinp);
 
-      Char_t type = (*itGet).first;
-      UInt_t idx  = (*itGet).second;
+      Char_t type = itGet.first;
+      UInt_t idx  = itGet.second;
       Float_t offset = min;
       Float_t scale  = 1.0/(max-min);
       TString str("");

--- a/tmva/tmva/src/VariableNormalizeTransform.cxx
+++ b/tmva/tmva/src/VariableNormalizeTransform.cxx
@@ -125,7 +125,7 @@ const TMVA::Event* TMVA::VariableNormalizeTransform::Transform( const TMVA::Even
    std::vector<Char_t> mask; // entries with kTRUE must not be transformed
    GetInput( ev, input, mask );
 
-   if (fTransformedEvent==0) fTransformedEvent = new Event();
+   if (fTransformedEvent==nullptr) fTransformedEvent = new Event();
 
    Float_t min,max;
    const FloatVector& minVector = fMin.at(cls);
@@ -178,7 +178,7 @@ const TMVA::Event* TMVA::VariableNormalizeTransform::InverseTransform(const TMVA
    std::vector<Char_t> mask;
    GetInput( ev, input, mask, kTRUE );
 
-   if (fBackTransformedEvent==0) fBackTransformedEvent = new Event( *ev );
+   if (fBackTransformedEvent==nullptr) fBackTransformedEvent = new Event( *ev );
 
    Float_t min,max;
    const FloatVector& minVector = fMin.at(cls);
@@ -357,10 +357,10 @@ void TMVA::VariableNormalizeTransform::ReadFromXML( void* trfnode )
 {
    Bool_t newFormat = kFALSE;
 
-   void* inpnode = NULL;
+   void* inpnode = nullptr;
 
    inpnode = gTools().GetChild(trfnode, "Selection"); // new xml format
-   if( inpnode != NULL )
+   if( inpnode != nullptr )
       newFormat = kTRUE;
 
    if( newFormat ){

--- a/tmva/tmva/src/VariablePCATransform.cxx
+++ b/tmva/tmva/src/VariablePCATransform.cxx
@@ -242,9 +242,8 @@ void TMVA::VariablePCATransform::CalculatePrincipalComponents( const std::vector
       }
 
       UInt_t iinp = 0;
-      for( std::vector<Float_t>::iterator itInp = input.begin(), itInpEnd = input.end(); itInp != itInpEnd; ++itInp )
+      for(float value : input)
          {
-            Float_t value = (*itInp);
             dvec[iinp] = (Double_t)value;
             ++iinp;
          }
@@ -254,8 +253,8 @@ void TMVA::VariablePCATransform::CalculatePrincipalComponents( const std::vector
    }
 
    // delete possible leftovers
-   for (UInt_t i=0; i<fMeanValues.size(); i++)   if (fMeanValues[i]   != nullptr) delete fMeanValues[i];
-   for (UInt_t i=0; i<fEigenVectors.size(); i++) if (fEigenVectors[i] != nullptr) delete fEigenVectors[i];
+   for (auto & fMeanValue : fMeanValues)   if (fMeanValue   != nullptr) delete fMeanValue;
+   for (auto & fEigenVector : fEigenVectors) if (fEigenVector != nullptr) delete fEigenVector;
    fMeanValues.resize(maxPCA,nullptr);
    fEigenVectors.resize(maxPCA,nullptr);
 

--- a/tmva/tmva/src/VariablePCATransform.cxx
+++ b/tmva/tmva/src/VariablePCATransform.cxx
@@ -67,8 +67,8 @@ TMVA::VariablePCATransform::VariablePCATransform( DataSetInfo& dsi )
 TMVA::VariablePCATransform::~VariablePCATransform()
 {
    for (UInt_t i=0; i<fMeanValues.size(); i++) {
-      if (fMeanValues.at(i)   != 0) delete fMeanValues.at(i);
-      if (fEigenVectors.at(i) != 0) delete fEigenVectors.at(i);
+      if (fMeanValues.at(i)   != nullptr) delete fMeanValues.at(i);
+      if (fEigenVectors.at(i) != nullptr) delete fEigenVectors.at(i);
    }
 }
 
@@ -126,7 +126,7 @@ Bool_t TMVA::VariablePCATransform::PrepareTransformation (const std::vector<Even
 
 const TMVA::Event* TMVA::VariablePCATransform::Transform( const Event* const ev, Int_t cls ) const
 {
-   if (!IsCreated()) return 0;
+   if (!IsCreated()) return nullptr;
 
    //   const Int_t inputSize = fGet.size();
    //   const UInt_t nCls = GetNClasses();
@@ -142,7 +142,7 @@ const TMVA::Event* TMVA::VariablePCATransform::Transform( const Event* const ev,
 
    // Perform PCA and put it into PCAed events tree
 
-   if (fTransformedEvent==0 ) {
+   if (fTransformedEvent==nullptr ) {
       fTransformedEvent = new Event();
    }
 
@@ -175,7 +175,7 @@ const TMVA::Event* TMVA::VariablePCATransform::Transform( const Event* const ev,
 
 const TMVA::Event* TMVA::VariablePCATransform::InverseTransform( const Event* const ev, Int_t cls ) const
 {
-   if (!IsCreated()) return 0;
+   if (!IsCreated()) return nullptr;
    //   const Int_t inputSize = fGet.size();
    const UInt_t nCls = GetNClasses();
    //UInt_t evCls = ev->GetClass();
@@ -186,7 +186,7 @@ const TMVA::Event* TMVA::VariablePCATransform::InverseTransform( const Event* co
    if (cls < 0 || UInt_t(cls) > nCls) cls = (fMeanValues.size()==1?0:2);//( GetNClasses() == 1 ? 0 : 1 );  ;
    // Perform PCA and put it into PCAed events tree
 
-   if (fBackTransformedEvent==0 ) fBackTransformedEvent = new Event();
+   if (fBackTransformedEvent==nullptr ) fBackTransformedEvent = new Event();
 
    std::vector<Float_t> principalComponents;
    std::vector<Char_t>  mask;
@@ -254,10 +254,10 @@ void TMVA::VariablePCATransform::CalculatePrincipalComponents( const std::vector
    }
 
    // delete possible leftovers
-   for (UInt_t i=0; i<fMeanValues.size(); i++)   if (fMeanValues[i]   != 0) delete fMeanValues[i];
-   for (UInt_t i=0; i<fEigenVectors.size(); i++) if (fEigenVectors[i] != 0) delete fEigenVectors[i];
-   fMeanValues.resize(maxPCA,0);
-   fEigenVectors.resize(maxPCA,0);
+   for (UInt_t i=0; i<fMeanValues.size(); i++)   if (fMeanValues[i]   != nullptr) delete fMeanValues[i];
+   for (UInt_t i=0; i<fEigenVectors.size(); i++) if (fEigenVectors[i] != nullptr) delete fEigenVectors[i];
+   fMeanValues.resize(maxPCA,nullptr);
+   fEigenVectors.resize(maxPCA,nullptr);
 
    for (UInt_t i=0; i<maxPCA; i++ ) {
       pca.at(i)->MakePrincipals();
@@ -390,10 +390,10 @@ void TMVA::VariablePCATransform::ReadFromXML( void* trfnode )
 
    Bool_t newFormat = kFALSE;
 
-   void* inpnode = NULL;
+   void* inpnode = nullptr;
 
    inpnode = gTools().GetChild(trfnode, "Selection"); // new xml format
-   if( inpnode!=NULL )
+   if( inpnode!=nullptr )
       newFormat = kTRUE; // new xml format
 
    if( newFormat ){
@@ -413,8 +413,8 @@ void TMVA::VariablePCATransform::ReadFromXML( void* trfnode )
          gTools().ReadAttr(ch, "NRows",      nrows);
 
          // set the correct size
-         if (fMeanValues.size()<=clsIdx) fMeanValues.resize(clsIdx+1,0);
-         if (fMeanValues[clsIdx]==0) fMeanValues[clsIdx] = new TVectorD( nrows );
+         if (fMeanValues.size()<=clsIdx) fMeanValues.resize(clsIdx+1,nullptr);
+         if (fMeanValues[clsIdx]==nullptr) fMeanValues[clsIdx] = new TVectorD( nrows );
          fMeanValues[clsIdx]->ResizeTo( nrows );
 
          // now read vector entries
@@ -428,8 +428,8 @@ void TMVA::VariablePCATransform::ReadFromXML( void* trfnode )
          gTools().ReadAttr(ch, "NRows",      nrows);
          gTools().ReadAttr(ch, "NCols",      ncols);
 
-         if (fEigenVectors.size()<=clsIdx) fEigenVectors.resize(clsIdx+1,0);
-         if (fEigenVectors[clsIdx]==0) fEigenVectors[clsIdx] = new TMatrixD( nrows, ncols );
+         if (fEigenVectors.size()<=clsIdx) fEigenVectors.resize(clsIdx+1,nullptr);
+         if (fEigenVectors[clsIdx]==nullptr) fEigenVectors[clsIdx] = new TMatrixD( nrows, ncols );
          fEigenVectors[clsIdx]->ResizeTo( nrows, ncols );
 
          // now read matrix entries
@@ -456,8 +456,8 @@ void TMVA::VariablePCATransform::ReadTransformationFromStream( std::istream& ist
    UInt_t classIdx=(classname=="signal"?0:1);
 
    for (UInt_t i=0; i<fMeanValues.size(); i++) {
-      if (fMeanValues.at(i)   != 0) delete fMeanValues.at(i);
-      if (fEigenVectors.at(i) != 0) delete fEigenVectors.at(i);
+      if (fMeanValues.at(i)   != nullptr) delete fMeanValues.at(i);
+      if (fEigenVectors.at(i) != nullptr) delete fEigenVectors.at(i);
    }
    fMeanValues.resize(3);
    fEigenVectors.resize(3);
@@ -478,7 +478,7 @@ void TMVA::VariablePCATransform::ReadTransformationFromStream( std::istream& ist
          sstr >> nrows;
          Int_t sbType = (strvar=="signal" ? 0 : 1);
 
-         if (fMeanValues[sbType] == 0) fMeanValues[sbType] = new TVectorD( nrows );
+         if (fMeanValues[sbType] == nullptr) fMeanValues[sbType] = new TVectorD( nrows );
          else                          fMeanValues[sbType]->ResizeTo( nrows );
 
          // now read vector entries
@@ -506,7 +506,7 @@ void TMVA::VariablePCATransform::ReadTransformationFromStream( std::istream& ist
          sstr >> nrows >> dummy >> ncols;
          Int_t sbType = (strvar=="signal" ? 0 : 1);
 
-         if (fEigenVectors[sbType] == 0) fEigenVectors[sbType] = new TMatrixD( nrows, ncols );
+         if (fEigenVectors[sbType] == nullptr) fEigenVectors[sbType] = new TMatrixD( nrows, ncols );
          else                            fEigenVectors[sbType]->ResizeTo( nrows, ncols );
 
          // now read matrix entries

--- a/tmva/tmva/src/VariableRearrangeTransform.cxx
+++ b/tmva/tmva/src/VariableRearrangeTransform.cxx
@@ -86,7 +86,7 @@ const TMVA::Event* TMVA::VariableRearrangeTransform::Transform( const TMVA::Even
    // apply the normalization transformation
    if (!IsCreated()) Log() << kFATAL << "Transformation not yet created" << Endl;
 
-   if (fTransformedEvent==0) fTransformedEvent = new Event();
+   if (fTransformedEvent==nullptr) fTransformedEvent = new Event();
 
    FloatVector input; // will be filled with the selected variables, (targets)
    std::vector<Char_t> mask; // masked variables
@@ -105,7 +105,7 @@ const TMVA::Event* TMVA::VariableRearrangeTransform::InverseTransform( const TMV
    // apply the inverse transformation
    if (!IsCreated()) Log() << kFATAL << "Transformation not yet created" << Endl;
 
-   if (fBackTransformedEvent==0) fBackTransformedEvent = new Event( *ev );
+   if (fBackTransformedEvent==nullptr) fBackTransformedEvent = new Event( *ev );
 
    FloatVector input;  // will be filled with the selected variables, targets, (spectators)
    std::vector<Char_t> mask; // masked variables
@@ -144,10 +144,10 @@ void TMVA::VariableRearrangeTransform::AttachXMLTo(void* parent)
 void TMVA::VariableRearrangeTransform::ReadFromXML( void* trfnode )
 {
 
-   void* inpnode = NULL;
+   void* inpnode = nullptr;
 
    inpnode = gTools().GetChild(trfnode, "Selection"); // new xml format
-   if(inpnode == NULL)
+   if(inpnode == nullptr)
       Log() << kFATAL << "Unknown weight file format for transformations. (tried to read in 'rearrange' transform)" << Endl;
 
    VariableTransformBase::ReadFromXML( inpnode );

--- a/tmva/tmva/src/VariableTransform.cxx
+++ b/tmva/tmva/src/VariableTransform.cxx
@@ -64,120 +64,130 @@
 /// create variable transformations
 
 namespace TMVA {
-void CreateVariableTransforms( const TString& trafoDefinitionIn,
-                               TMVA::DataSetInfo& dataInfo,
-                               TMVA::TransformationHandler& transformationHandler,
-                               TMVA::MsgLogger& log )
+void CreateVariableTransforms(const TString& trafoDefinitionIn,
+                              TMVA::DataSetInfo& dataInfo,
+                              TMVA::TransformationHandler& transformationHandler,
+                              TMVA::MsgLogger& log)
 {
-    TString trafoDefinition(trafoDefinitionIn);
-    if (trafoDefinition == "None") return; // no transformations
+   TString trafoDefinition(trafoDefinitionIn);
+   if (trafoDefinition == "None") return; // no transformations
 
-    // workaround for transformations to complicated to be handled by makeclass
-    // count number of transformations with incomplete set of variables
-    TString trafoDefinitionCheck(trafoDefinitionIn);
-    int npartial = 0, ntrafo=0;
-    for (Int_t pos = 0, siz = trafoDefinition.Sizeof(); pos < siz; ++pos) {
-        TString ch = trafoDefinition(pos,1);
-        if ( ch == "(" ) npartial++;
-        if ( ch == "+" || ch == ",") ntrafo++;
-    }
-    if (npartial>1) {
-        log << kWARNING << "The use of multiple partial variable transformations during the application phase can be properly invoked via the \"Reader\", but it is not yet implemented in \"MakeClass\", the creation mechanism for standalone C++ application classes. The standalone C++ class produced by this training job is thus INCOMPLETE AND MUST NOT BE USED! The transformation in question is: " << trafoDefinitionIn << Endl; // ToDo make info and do not write the standalone class
-        //
-        // this does not work since this function is static
-        // fDisableWriting=true; // disable creation of stand-alone class
-        // ToDo we need to tell the transformation that it cannot write itself
-    }
-    // workaround end
+   // workaround for transformations to complicated to be handled by makeclass
+   // count number of transformations with incomplete set of variables
+   TString trafoDefinitionCheck(trafoDefinitionIn);
+   int npartial = 0, ntrafo = 0;
+   for (Int_t pos = 0, siz = trafoDefinition.Sizeof(); pos < siz; ++pos) {
+      TString ch = trafoDefinition(pos,1);
+      if ( ch == "(" ) npartial++;
+      if ( ch == "+" || ch == ",") ntrafo++;
+   }
+   if (npartial>1) {
+      log << kWARNING
+          << "The use of multiple partial variable transformations during the "
+             "application phase can be properly invoked via the \"Reader\", but "
+             "it is not yet implemented in \"MakeClass\", the creation mechanism "
+             "for standalone C++ application classes. The standalone C++ class "
+             "produced by this training job is thus INCOMPLETE AND MUST NOT BE USED! "
+             "The transformation in question is: " << trafoDefinitionIn << Endl;
+      // ToDo make info and do not write the standalone class
+      //
+      // this does not work since this function is static
+      // fDisableWriting=true; // disable creation of stand-alone class
+      // ToDo we need to tell the transformation that it cannot write itself
+   }
+   // workaround end
 
-    Int_t parenthesisCount = 0;
-    for (Int_t position = 0, size = trafoDefinition.Sizeof(); position < size; ++position) {
-        TString ch = trafoDefinition(position,1);
-        if      (ch == "(")                          ++parenthesisCount;
-        else if (ch == ")")                          --parenthesisCount;
-        else if (ch == "," && parenthesisCount == 0) trafoDefinition.Replace(position,1,'+');
-    }
+   Int_t parenthesisCount = 0;
+   for (Int_t position = 0, size = trafoDefinition.Sizeof(); position < size; ++position) {
+      TString ch = trafoDefinition(position,1);
+      if      (ch == "(") ++parenthesisCount;
+      else if (ch == ")") --parenthesisCount;
+      else if (ch == "," && parenthesisCount == 0) trafoDefinition.Replace(position,1,'+');
+   }
 
-    TList* trList = gTools().ParseFormatLine( trafoDefinition, "+" );
-    TListIter trIt(trList);
-    while (TObjString* os = (TObjString*)trIt()) {
-        TString tdef = os->GetString();
-        Int_t idxCls = -1;
+   TList* trList = gTools().ParseFormatLine( trafoDefinition, "+" );
+   TListIter trIt(trList);
+   while (TObjString* os = (TObjString*)trIt()) {
+      TString tdef = os->GetString();
+      Int_t idxCls = -1;
 
-        TString variables = "";
-        if (tdef.Contains("(")) { // contains selection of variables
-            Ssiz_t parStart = tdef.Index( "(" );
-            Ssiz_t parLen   = tdef.Index( ")", parStart )-parStart+1;
+      TString variables = "";
+      if (tdef.Contains("(")) { // contains selection of variables
+         Ssiz_t parStart = tdef.Index( "(" );
+         Ssiz_t parLen   = tdef.Index( ")", parStart )-parStart+1;
 
-            variables = tdef(parStart,parLen);
-            tdef.Remove(parStart,parLen);
-            variables.Remove(parLen-1,1);
-            variables.Remove(0,1);
-        }
+         variables = tdef(parStart,parLen);
+         tdef.Remove(parStart,parLen);
+         variables.Remove(parLen-1,1);
+         variables.Remove(0,1);
+      }
 
-        TList* trClsList = gTools().ParseFormatLine( tdef, "_" ); // split entry to get trf-name and class-name
-        TListIter trClsIt(trClsList);
-        if (trClsList->GetSize() < 1) log << kFATAL <<Form("Dataset[%s] : ",dataInfo.GetName())<< "Incorrect transformation string provided." << Endl;
-        const TString& trName = ((TObjString*)trClsList->At(0))->GetString();
+      TList* trClsList = gTools().ParseFormatLine( tdef, "_" ); // split entry to get trf-name and class-name
+      TListIter trClsIt(trClsList);
+      if (trClsList->GetSize() < 1)
+          log << kFATAL <<Form("Dataset[%s] : ",dataInfo.GetName())<< "Incorrect transformation string provided." << Endl;
+      const TString& trName = ((TObjString*)trClsList->At(0))->GetString();
 
-        if (trClsList->GetEntries() > 1) {
-            TString trCls = "AllClasses";
-            ClassInfo *ci = NULL;
-            trCls  = ((TObjString*)trClsList->At(1))->GetString();
-            if (trCls != "AllClasses") {
-                ci = dataInfo.GetClassInfo( trCls );
-                if (ci == NULL)
-                    log << kFATAL <<Form("Dataset[%s] : ",dataInfo.GetName())<< "Class " << trCls << " not known for variable transformation "
-                        << trName << ", please check." << Endl;
-                else
-                    idxCls = ci->GetNumber();
-            }
-        }
+      if (trClsList->GetEntries() > 1) {
+         TString trCls = "AllClasses";
+         ClassInfo *ci = NULL;
+         trCls  = ((TObjString*)trClsList->At(1))->GetString();
+         if (trCls != "AllClasses") {
+            ci = dataInfo.GetClassInfo( trCls );
+            if (ci == NULL)
+               log << kFATAL <<Form("Dataset[%s] : ",dataInfo.GetName())<< "Class " << trCls << " not known for variable transformation "
+                   << trName << ", please check." << Endl;
+            else
+               idxCls = ci->GetNumber();
+         }
+      }
 
-        VariableTransformBase* transformation = NULL;
-        if      (trName == "I" || trName == "Ident" || trName == "Identity") {
-            if (variables.Length() == 0) variables = "_V_";
-            transformation = new VariableIdentityTransform( dataInfo);
-        }
-        else if (trName == "D" || trName == "Deco" || trName == "Decorrelate") {
-            if (variables.Length() == 0) variables = "_V_";
-            transformation = new VariableDecorrTransform( dataInfo);
-        }
-        else if (trName == "P" || trName == "PCA") {
-            if (variables.Length() == 0) variables = "_V_";
-            transformation = new VariablePCATransform   ( dataInfo);
-        }
-        else if (trName == "U" || trName == "Uniform") {
-            if (variables.Length() == 0) variables = "_V_,_T_";
-            transformation = new VariableGaussTransform ( dataInfo, "Uniform" );
-        }
-        else if (trName == "G" || trName == "Gauss") {
-            if (variables.Length() == 0) variables = "_V_";
-            transformation = new VariableGaussTransform ( dataInfo);
-        }
-        else if (trName == "N" || trName == "Norm" || trName == "Normalise" || trName == "Normalize") {
-            if (variables.Length() == 0) variables = "_V_,_T_";
-            transformation = new VariableNormalizeTransform( dataInfo);
-        }
-        else log << kFATAL <<Form("Dataset[%s] : ",dataInfo.GetName())<< "<ProcessOptions> Variable transform '"
-                     << trName << "' unknown." << Endl;
+      VariableTransformBase* transformation = NULL;
+      if (trName == "I" || trName == "Ident" || trName == "Identity") {
+         if (variables.Length() == 0) variables = "_V_";
+         transformation = new VariableIdentityTransform(dataInfo);
+      }
+      else if (trName == "D" || trName == "Deco" || trName == "Decorrelate") {
+         if (variables.Length() == 0) variables = "_V_";
+         transformation = new VariableDecorrTransform(dataInfo);
+      }
+      else if (trName == "P" || trName == "PCA") {
+         if (variables.Length() == 0) variables = "_V_";
+         transformation = new VariablePCATransform(dataInfo);
+      }
+      else if (trName == "U" || trName == "Uniform") {
+         if (variables.Length() == 0) variables = "_V_,_T_";
+         transformation = new VariableGaussTransform(dataInfo, "Uniform" );
+      }
+      else if (trName == "G" || trName == "Gauss") {
+         if (variables.Length() == 0) variables = "_V_";
+         transformation = new VariableGaussTransform(dataInfo);
+      }
+      else if (trName == "N" || trName == "Norm" || trName == "Normalise" || trName == "Normalize") {
+         if (variables.Length() == 0) variables = "_V_,_T_";
+         transformation = new VariableNormalizeTransform(dataInfo);
+      }
+      else
+         log << kFATAL << Form("Dataset[%s] : ",dataInfo.GetName())
+             << "<ProcessOptions> Variable transform '"
+             << trName << "' unknown." << Endl;
 
 
-        if (transformation) {
-            ClassInfo* clsInfo = dataInfo.GetClassInfo(idxCls);
-             if (clsInfo )
-        log << kHEADER <<Form("[%s] : ",dataInfo.GetName())
-    << "Create Transformation \"" << trName << "\" with reference class "
-                    << clsInfo->GetName() << "=("<< idxCls <<")"<<Endl << Endl;
-else
-        log << kHEADER <<Form("[%s] : ",dataInfo.GetName())
-    << "Create Transformation \"" << trName << "\" with events from all classes." << Endl << Endl;
+      if (transformation) {
+         ClassInfo* clsInfo = dataInfo.GetClassInfo(idxCls);
+         if (clsInfo)
+            log << kHEADER << Form("[%s] : ",dataInfo.GetName())
+                << "Create Transformation \"" << trName << "\" with reference class "
+                << clsInfo->GetName() << "=("<< idxCls <<")" << Endl << Endl;
+         else
+            log << kHEADER << Form("[%s] : ",dataInfo.GetName())
+                << "Create Transformation \"" << trName << "\" with events from all classes."
+                << Endl << Endl;
 
-            transformation->SelectInput( variables );
-            transformationHandler.AddTransformation(transformation, idxCls);
-        }
-    }
-    return;
+         transformation->SelectInput(variables);
+         transformationHandler.AddTransformation(transformation, idxCls);
+      }
+   }
 }
 
 }

--- a/tmva/tmva/src/VariableTransform.cxx
+++ b/tmva/tmva/src/VariableTransform.cxx
@@ -130,11 +130,11 @@ void CreateVariableTransforms(const TString& trafoDefinitionIn,
 
       if (trClsList->GetEntries() > 1) {
          TString trCls = "AllClasses";
-         ClassInfo *ci = NULL;
+         ClassInfo *ci = nullptr;
          trCls  = ((TObjString*)trClsList->At(1))->GetString();
          if (trCls != "AllClasses") {
             ci = dataInfo.GetClassInfo( trCls );
-            if (ci == NULL)
+            if (ci == nullptr)
                log << kFATAL <<Form("Dataset[%s] : ",dataInfo.GetName())<< "Class " << trCls << " not known for variable transformation "
                    << trName << ", please check." << Endl;
             else
@@ -142,7 +142,7 @@ void CreateVariableTransforms(const TString& trafoDefinitionIn,
          }
       }
 
-      VariableTransformBase* transformation = NULL;
+      VariableTransformBase* transformation = nullptr;
       if (trName == "I" || trName == "Ident" || trName == "Identity") {
          if (variables.Length() == 0) variables = "_V_";
          transformation = new VariableIdentityTransform(dataInfo);

--- a/tmva/tmva/src/VariableTransformBase.cxx
+++ b/tmva/tmva/src/VariableTransformBase.cxx
@@ -235,16 +235,13 @@ void TMVA::VariableTransformBase::SelectInput( const TString& _inputVariables, B
          ++idx;
       }
    }else {
-      for( SelectedIndices::iterator it = varIndices.begin(), itEnd = varIndices.end(); it != itEnd; ++it ) {
-         Int_t idx = (*it);
+      for(int idx : varIndices) {
          fPut.push_back( std::pair<Char_t,UInt_t>('v',idx) );
       }
-      for( SelectedIndices::iterator it = tgtIndices.begin(), itEnd = tgtIndices.end(); it != itEnd; ++it ) {
-         Int_t idx = (*it);
+      for(int idx : tgtIndices) {
          fPut.push_back( std::pair<Char_t,UInt_t>('t',idx) );
       }
-      for( SelectedIndices::iterator it = spctIndices.begin(), itEnd = spctIndices.end(); it != itEnd; ++it ) {
-         Int_t idx = (*it);
+      for(int idx : spctIndices) {
          fPut.push_back( std::pair<Char_t,UInt_t>('s',idx) );
       }
 
@@ -439,8 +436,8 @@ void TMVA::VariableTransformBase::CountVariableTypes( UInt_t& nvars, UInt_t& ntg
 
    nvars = ntgts = nspcts = 0;
 
-   for( ItVarTypeIdxConst itEntry = fGet.begin(), itEntryEnd = fGet.end(); itEntry != itEntryEnd; ++itEntry ) {
-      Char_t type = (*itEntry).first;
+   for(const auto & itEntry : fGet) {
+      Char_t type = itEntry.first;
 
       switch( type ) {
       case 'v':
@@ -629,9 +626,9 @@ void TMVA::VariableTransformBase::AttachXMLTo(void* parent)
    // choose the new dsi for output if present, if not, take the common one
    const DataSetInfo* outputDsiPtr = (fDsiOutput? fDsiOutput : &fDsi );
 
-   for( ItVarTypeIdx itGet = fGet.begin(), itGetEnd = fGet.end(); itGet != itGetEnd; ++itGet ) {
-      UInt_t idx  = (*itGet).second;
-      Char_t type = (*itGet).first;
+   for(auto & itGet : fGet) {
+      UInt_t idx  = itGet.second;
+      Char_t type = itGet.first;
 
       TString label      = "";
       TString expression = "";
@@ -667,9 +664,9 @@ void TMVA::VariableTransformBase::AttachXMLTo(void* parent)
    void* outxml = gTools().AddChild(selxml, "Output");
    gTools().AddAttr(outxml, "NOutputs", fPut.size() );
 
-   for( ItVarTypeIdx itPut = fPut.begin(), itPutEnd = fPut.end(); itPut != itPutEnd; ++itPut ) {
-      UInt_t idx  = (*itPut).second;
-      Char_t type = (*itPut).first;
+   for(auto & itPut : fPut) {
+      UInt_t idx  = itPut.second;
+      Char_t type = itPut.first;
 
       TString label = "";
       TString expression = "";

--- a/tmva/tmva/src/VariableTransformBase.cxx
+++ b/tmva/tmva/src/VariableTransformBase.cxx
@@ -68,9 +68,9 @@ TMVA::VariableTransformBase::VariableTransformBase( DataSetInfo& dsi,
                                                     const TString& trfName )
 : TObject(),
    fDsi(dsi),
-   fDsiOutput(NULL),
-   fTransformedEvent(0),
-   fBackTransformedEvent(0),
+   fDsiOutput(nullptr),
+   fTransformedEvent(nullptr),
+   fBackTransformedEvent(nullptr),
    fVariableTransform(tf),
    fEnabled( kTRUE ),
    fCreated( kFALSE ),
@@ -82,7 +82,7 @@ TMVA::VariableTransformBase::VariableTransformBase( DataSetInfo& dsi,
    fNSpectators(0),
    fSortGet(kTRUE),
    fTMVAVersion(TMVA_VERSION_CODE),
-   fLogger( 0 )
+   fLogger( nullptr )
 {
    fLogger = new MsgLogger(this, kINFO);
    for (UInt_t ivar = 0; ivar < fDsi.GetNVariables(); ivar++) {
@@ -100,8 +100,8 @@ TMVA::VariableTransformBase::VariableTransformBase( DataSetInfo& dsi,
 
 TMVA::VariableTransformBase::~VariableTransformBase()
 {
-   if (fTransformedEvent!=0)     delete fTransformedEvent;
-   if (fBackTransformedEvent!=0) delete fBackTransformedEvent;
+   if (fTransformedEvent!=nullptr)     delete fTransformedEvent;
+   if (fBackTransformedEvent!=nullptr) delete fBackTransformedEvent;
    // destructor
    delete fLogger;
 }

--- a/tmva/tmva/src/Volume.cxx
+++ b/tmva/tmva/src/Volume.cxx
@@ -132,7 +132,7 @@ TMVA::Volume::Volume( Volume& V )
 ////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
-TMVA::Volume::~Volume( void )
+TMVA::Volume::~Volume()
 {
    // delete volume boundaries only if owned by the volume
    if (fOwnerShip) this->Delete();
@@ -141,7 +141,7 @@ TMVA::Volume::~Volume( void )
 ////////////////////////////////////////////////////////////////////////////////
 /// delete array of volume bondaries
 
-void TMVA::Volume::Delete( void )
+void TMVA::Volume::Delete()
 {
    if (nullptr != fLower) { delete fLower; fLower = nullptr; }
    if (nullptr != fUpper) { delete fUpper; fUpper = nullptr; }
@@ -172,7 +172,7 @@ void TMVA::Volume::ScaleInterval( Double_t f )
 ////////////////////////////////////////////////////////////////////////////////
 /// printout of the volume boundaries
 
-void TMVA::Volume::Print( void ) const
+void TMVA::Volume::Print() const
 {
    MsgLogger fLogger( "Volume" );
    for (UInt_t ivar=0; ivar<fLower->size(); ivar++) {

--- a/tmva/tmva/src/Volume.cxx
+++ b/tmva/tmva/src/Volume.cxx
@@ -143,8 +143,8 @@ TMVA::Volume::~Volume( void )
 
 void TMVA::Volume::Delete( void )
 {
-   if (NULL != fLower) { delete fLower; fLower = NULL; }
-   if (NULL != fUpper) { delete fUpper; fUpper = NULL; }
+   if (nullptr != fLower) { delete fLower; fLower = nullptr; }
+   if (nullptr != fUpper) { delete fUpper; fUpper = nullptr; }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmvagui/inc/TMVA/mvaeffs.h
+++ b/tmva/tmvagui/inc/TMVA/mvaeffs.h
@@ -1,36 +1,17 @@
 #ifndef mvaeffs__HH
 #define mvaeffs__HH
-#include <iostream>
-#include <iomanip>
-using std::cout;
-using std::endl;
-
-#include "tmvaglob.h"
 
 #include "RQ_OBJECT.h"
-
-#include "TH1.h"
-#include "TROOT.h"
-#include "TList.h"
-#include "TIterator.h"
-#include "TStyle.h"
-#include "TPad.h"
 #include "TCanvas.h"
-#include "TLatex.h"
-#include "TLegend.h"
-#include "TLine.h"
-#include "TH2.h"
-#include "TFormula.h"
 #include "TFile.h"
-#include "TApplication.h"
-#include "TKey.h"
-#include "TClass.h"
-#include "TGaxis.h"
-
-#include "TGWindow.h"
-#include "TGButton.h"
 #include "TGLabel.h"
 #include "TGNumberEntry.h"
+#include "TGWindow.h"
+#include "TGaxis.h"
+#include "TH1.h"
+#include "TIterator.h"
+#include "TLatex.h"
+#include "TList.h"
 
 namespace TMVA{
 

--- a/tmva/tmvagui/inc/TMVA/probas.h
+++ b/tmva/tmvagui/inc/TMVA/probas.h
@@ -1,36 +1,8 @@
 #ifndef probas__HH
 #define probas__HH
-#include <iostream>
-#include <iomanip>
-using std::cout;
-using std::endl;
 
-#include "tmvaglob.h"
+#include "TString.h"
 
-#include "RQ_OBJECT.h"
-
-#include "TH1.h"
-#include "TROOT.h"
-#include "TList.h"
-#include "TIterator.h"
-#include "TStyle.h"
-#include "TPad.h"
-#include "TCanvas.h"
-#include "TLatex.h"
-#include "TLegend.h"
-#include "TLine.h"
-#include "TH2.h"
-#include "TFormula.h"
-#include "TFile.h"
-#include "TApplication.h"
-#include "TKey.h"
-#include "TClass.h"
-#include "TGaxis.h"
-
-#include "TGWindow.h"
-#include "TGButton.h"
-#include "TGLabel.h"
-#include "TGNumberEntry.h"
 namespace TMVA{
 
    // this macro plots the MVA probability distributions (Signal and

--- a/tmva/tmvagui/src/BoostControlPlots.cxx
+++ b/tmva/tmvagui/src/BoostControlPlots.cxx
@@ -56,9 +56,9 @@ void TMVA::boostcontrolplots(TString dataset, TDirectory *boostdir ) {
    //   Note: the ROCIntegral plots are only filled for option "Boost_DetailedMonitoring=ture" currently not filled...
    //   TString hname[nPlots]={"BoostWeight","MethodWeight","ErrFraction","ROCIntegral_test"};
 
-   for (Int_t i=0; i<nPlots; i++){
+   for (const auto & i : hname){
       Int_t color = 4; 
-      TH1 *h = (TH1*) boostdir->Get(hname[i]);
+      TH1 *h = (TH1*) boostdir->Get(i);
       TString plotname = h->GetName();
       h->SetMaximum(h->GetMaximum()*1.3);
       h->SetMinimum( 0 );

--- a/tmva/tmvagui/src/TMVAGui.cxx
+++ b/tmva/tmvagui/src/TMVAGui.cxx
@@ -311,7 +311,7 @@ void TMVA::TMVAGui( const char* fName  , TString dataset)
    cbar->Show();
 
    // indicate inactive buttons
-   for (UInt_t i=0; i<TMVAGui_inactiveButtons.size(); i++) cbar->SetButtonState(TMVAGui_inactiveButtons[i], 3 );
+   for (auto & TMVAGui_inactiveButton : TMVAGui_inactiveButtons) cbar->SetButtonState(TMVAGui_inactiveButton, 3 );
    if (TMVAGui_inactiveButtons.size() > 0) {
       cout << "=== Note: inactive buttons indicate classifiers that were not trained, ===" << endl;
       cout << "===       or functionalities that were not invoked during the training ===" << endl;

--- a/tmva/tmvagui/src/TMVAMultiClassGui.cxx
+++ b/tmva/tmvagui/src/TMVAMultiClassGui.cxx
@@ -327,7 +327,7 @@ void TMVA::TMVAMultiClassGui(const char* fName ,TString dataset)
    cbar->Show();
 
    // indicate inactive buttons
-   for (UInt_t i=0; i<TMVAMultiClassGui_inactiveButtons.size(); i++) cbar->SetButtonState( TMVAMultiClassGui_inactiveButtons[i], 3 );
+   for (auto & TMVAMultiClassGui_inactiveButton : TMVAMultiClassGui_inactiveButtons) cbar->SetButtonState( TMVAMultiClassGui_inactiveButton, 3 );
    if (TMVAMultiClassGui_inactiveButtons.size() > 0) {
       std::cout << "=== Note: inactive buttons indicate that the corresponding classifiers were not trained ===" << std::endl;
    }

--- a/tmva/tmvagui/src/TMVARegGui.cxx
+++ b/tmva/tmvagui/src/TMVARegGui.cxx
@@ -241,7 +241,7 @@ void TMVA::TMVARegGui( const char* fName ,TString dataset)
    cbar->Show();
 
    // indicate inactive buttons
-   for (UInt_t i=0; i<TMVARegGui_inactiveButtons.size(); i++) cbar->SetButtonState( TMVARegGui_inactiveButtons[i], 3 );
+   for (auto & TMVARegGui_inactiveButton : TMVARegGui_inactiveButtons) cbar->SetButtonState( TMVARegGui_inactiveButton, 3 );
    if (TMVARegGui_inactiveButtons.size() > 0) {
       cout << "=== Note: inactive buttons indicate that the corresponding methods were not trained ===" << endl;
    }

--- a/tmva/tmvagui/src/likelihoodrefs.cxx
+++ b/tmva/tmvagui/src/likelihoodrefs.cxx
@@ -34,8 +34,8 @@ void TMVA::likelihoodrefs(TString dataset, TDirectory *lhdir ) {
 
       // avoid duplicated plotting
       Bool_t found = kFALSE;
-      for (UInt_t j = 0; j < hasBeenUsed.size(); j++) {
-         if (hasBeenUsed[j] == hname.Data()) found = kTRUE;
+      for (const auto & j : hasBeenUsed) {
+         if (j == hname.Data()) found = kTRUE;
       }
       if (!found) {
 

--- a/tmva/tmvagui/src/mvaeffs.cxx
+++ b/tmva/tmvagui/src/mvaeffs.cxx
@@ -1,37 +1,34 @@
+#include "TApplication.h"
+#include "TCanvas.h"
+#include "TClass.h"
+#include "TFile.h"
+#include "TFormula.h"
+#include "TGButton.h"
+#include "TGLabel.h"
+#include "TGNumberEntry.h"
+#include "TGWindow.h"
+#include "TGaxis.h"
+#include "TH1.h"
+#include "TH2.h"
+#include "TIterator.h"
+#include "TKey.h"
+#include "TLatex.h"
+#include "TLegend.h"
+#include "TLine.h"
+#include "TList.h"
 #include "TMVA/mvaeffs.h"
-#include <iostream>
+#include "TMVA/tmvaglob.h"
+#include "TPad.h"
+#include "TROOT.h"
+#include "TStyle.h"
+
 #include <iomanip>
+#include <iostream>
+
 using std::cout;
 using std::endl;
 using std::setfill;
 using std::setw;
-
-
-
-#include "RQ_OBJECT.h"
-
-#include "TH1.h"
-#include "TROOT.h"
-#include "TList.h"
-#include "TIterator.h"
-#include "TStyle.h"
-#include "TPad.h"
-#include "TCanvas.h"
-#include "TLatex.h"
-#include "TLegend.h"
-#include "TLine.h"
-#include "TH2.h"
-#include "TFormula.h"
-#include "TFile.h"
-#include "TApplication.h"
-#include "TKey.h"
-#include "TClass.h"
-#include "TGaxis.h"
-
-#include "TGWindow.h"
-#include "TGButton.h"
-#include "TGLabel.h"
-#include "TGNumberEntry.h"
 
 // this macro plots the signal and background efficiencies
 // as a function of the MVA cut.

--- a/tmva/tmvagui/src/network.cxx
+++ b/tmva/tmvagui/src/network.cxx
@@ -236,8 +236,8 @@ TString* TMVA::get_var_names(TString dataset, Int_t nVars )
                                     "InputVariables_Deco"};
    
    TDirectory* dir = 0;
-   for (Int_t i=0; i<6; i++) {
-      dir = (TDirectory*)Network_GFile->GetDirectory(dataset.Data())->Get( directories[i] );
+   for (const auto & directorie : directories) {
+      dir = (TDirectory*)Network_GFile->GetDirectory(dataset.Data())->Get( directorie );
       if (dir != 0) break;
    }
    if (dir==0) {

--- a/tmva/tmvagui/src/paracoor.cxx
+++ b/tmva/tmvagui/src/paracoor.cxx
@@ -60,7 +60,7 @@ void TMVA::paracoor(TString dataset, TString fin , Bool_t useTMVAStyle )
 
          // create draw option
          TString varstr = mvas[imva] + ":";
-         for (UInt_t ivar=0; ivar<vars.size(); ivar++) varstr += vars[ivar] + ":";
+         for (const auto & var : vars) varstr += var + ":";
          varstr.Resize( varstr.Last( ':' ) );
 
          // create canvas

--- a/tmva/tmvagui/src/probas.cxx
+++ b/tmva/tmvagui/src/probas.cxx
@@ -1,35 +1,18 @@
+#include "TCanvas.h"
+#include "TFile.h"
+#include "TH2F.h"
+#include "TIterator.h"
+#include "TKey.h"
+#include "TLegend.h"
+#include "TList.h"
 #include "TMVA/probas.h"
+#include "TMVA/tmvaglob.h"
+#include "TString.h"
+
 #include <iostream>
-#include <iomanip>
+
 using std::cout;
 using std::endl;
-
-
-
-#include "RQ_OBJECT.h"
-
-#include "TH1.h"
-#include "TROOT.h"
-#include "TList.h"
-#include "TIterator.h"
-#include "TStyle.h"
-#include "TPad.h"
-#include "TCanvas.h"
-#include "TLatex.h"
-#include "TLegend.h"
-#include "TLine.h"
-#include "TH2.h"
-#include "TFormula.h"
-#include "TFile.h"
-#include "TApplication.h"
-#include "TKey.h"
-#include "TClass.h"
-#include "TGaxis.h"
-
-#include "TGWindow.h"
-#include "TGButton.h"
-#include "TGLabel.h"
-#include "TGNumberEntry.h"
 
 // this macro plots the MVA probability distributions (Signal and
 // Background overlayed) of different MVA methods run in TMVA

--- a/tree/tree/inc/TBasket.h
+++ b/tree/tree/inc/TBasket.h
@@ -123,7 +123,7 @@ public:
            Int_t   ReadBasketBytes(Long64_t pos, TFile *file);
    virtual void    Reset();
 
-           Int_t   LoadBasketBuffers(Long64_t pos, Int_t len, TFile *file, TTree *tree = 0);
+           Int_t   LoadBasketBuffers(Long64_t pos, Int_t len, TFile *file, TTree *tree = nullptr);
    Long64_t        CopyTo(TFile *to);
 
            void    SetBranch(TBranch *branch) { fBranch = branch; }

--- a/tree/tree/inc/TBranch.h
+++ b/tree/tree/inc/TBranch.h
@@ -224,7 +224,7 @@ public:
    virtual void      SetEntries(Long64_t entries);
    virtual void      SetEntryOffsetLen(Int_t len, Bool_t updateSubBranches = kFALSE);
    virtual void      SetFirstEntry( Long64_t entry );
-   virtual void      SetFile(TFile *file=0);
+   virtual void      SetFile(TFile *file=nullptr);
    virtual void      SetFile(const char *filename);
    void              SetIOFeatures(TIOFeatures &features) {fIOFeatures = features;}
    virtual Bool_t    SetMakeClass(Bool_t decomposeObj = kTRUE);

--- a/tree/tree/inc/TChain.h
+++ b/tree/tree/inc/TChain.h
@@ -137,21 +137,21 @@ public:
    virtual void      ResetBranchAddresses();
    virtual Long64_t  Scan(const char *varexp="", const char *selection="", Option_t *option="", Long64_t nentries=kMaxEntries, Long64_t firstentry=0); // *MENU*
    virtual void      SetAutoDelete(Bool_t autodel=kTRUE);
-   virtual Int_t     SetBranchAddress(const char *bname,void *add, TBranch **ptr = 0);
+   virtual Int_t     SetBranchAddress(const char *bname,void *add, TBranch **ptr = nullptr);
    virtual Int_t     SetBranchAddress(const char *bname,void *add, TBranch **ptr, TClass *realClass, EDataType datatype, Bool_t isptr);
    virtual Int_t     SetBranchAddress(const char *bname,void *add, TClass *realClass, EDataType datatype, Bool_t isptr);
-   template <class T> Int_t SetBranchAddress(const char *bname, T **add, TBranch **ptr = 0) {
+   template <class T> Int_t SetBranchAddress(const char *bname, T **add, TBranch **ptr = nullptr) {
      return TTree::SetBranchAddress<T>(bname, add, ptr);
    }
 #ifndef R__NO_CLASS_TEMPLATE_SPECIALIZATION
    // This can only be used when the template overload resolution can distringuish between
    // T* and T**
-   template <class T> Int_t SetBranchAddress(const char *bname, T *add, TBranch **ptr = 0) {
+   template <class T> Int_t SetBranchAddress(const char *bname, T *add, TBranch **ptr = nullptr) {
      return TTree::SetBranchAddress<T>(bname, add, ptr);
    }
 #endif
 
-   virtual void      SetBranchStatus(const char *bname, Bool_t status=1, UInt_t *found=0);
+   virtual void      SetBranchStatus(const char *bname, Bool_t status=1, UInt_t *found=nullptr);
    virtual Int_t     SetCacheSize(Long64_t cacheSize = -1);
    virtual void      SetDirectory(TDirectory *dir);
    virtual void      SetEntryList(TEntryList *elist, Option_t *opt="");

--- a/tree/tree/inc/TLeaf.h
+++ b/tree/tree/inc/TLeaf.h
@@ -85,7 +85,7 @@ public:
    virtual Int_t    GetMinimum() const { return 0; }
    virtual Int_t    GetNdata() const { return fNdata; }
    virtual Int_t    GetOffset() const { return fOffset; }
-   virtual void    *GetValuePointer() const { return 0; }
+   virtual void    *GetValuePointer() const { return nullptr; }
    virtual const char *GetTypeName() const { return ""; }
 
    virtual Double_t GetValue(Int_t i = 0) const;
@@ -104,7 +104,7 @@ public:
       Error("ReadValue", "Not implemented!");
    }
            Int_t    ResetAddress(void *add, Bool_t destructor = kFALSE);
-   virtual void     SetAddress(void *add = 0);
+   virtual void     SetAddress(void *add = nullptr);
    virtual void     SetBranch(TBranch *branch) { fBranch = branch; }
    virtual void     SetLeafCount(TLeaf *leaf);
    virtual void     SetLen(Int_t len = 1) { fLen = len; }

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -342,7 +342,7 @@ public:
    virtual TBranch        *BranchRef();
    virtual void            Browse(TBrowser*);
    virtual Int_t           BuildIndex(const char* majorname, const char* minorname = "0");
-   TStreamerInfo          *BuildStreamerInfo(TClass* cl, void* pointer = 0, Bool_t canOptimize = kTRUE);
+   TStreamerInfo          *BuildStreamerInfo(TClass* cl, void* pointer = nullptr, Bool_t canOptimize = kTRUE);
    virtual TFile          *ChangeFile(TFile* file);
    virtual TTree          *CloneTree(Long64_t nentries = -1, Option_t* option = "");
    virtual void            CopyAddresses(TTree*,Bool_t undo = kFALSE);
@@ -464,10 +464,10 @@ public:
    virtual Int_t           LoadBaskets(Long64_t maxmemory = 2000000000);
    virtual Long64_t        LoadTree(Long64_t entry);
    virtual Long64_t        LoadTreeFriend(Long64_t entry, TTree* T);
-   virtual Int_t           MakeClass(const char* classname = 0, Option_t* option = "");
-   virtual Int_t           MakeCode(const char* filename = 0);
-   virtual Int_t           MakeProxy(const char* classname, const char* macrofilename = 0, const char* cutfilename = 0, const char* option = 0, Int_t maxUnrolling = 3);
-   virtual Int_t           MakeSelector(const char* selector = 0, Option_t* option = "");
+   virtual Int_t           MakeClass(const char* classname = nullptr, Option_t* option = "");
+   virtual Int_t           MakeCode(const char* filename = nullptr);
+   virtual Int_t           MakeProxy(const char* classname, const char* macrofilename = nullptr, const char* cutfilename = nullptr, const char* option = nullptr, Int_t maxUnrolling = 3);
+   virtual Int_t           MakeSelector(const char* selector = nullptr, Option_t* option = "");
    Bool_t                  MemoryFull(Int_t nbytes);
    virtual Long64_t        Merge(TCollection* list, Option_t* option = "");
    virtual Long64_t        Merge(TCollection* list, TFileMergeInfo *info);
@@ -502,27 +502,27 @@ public:
    virtual void            SetAutoFlush(Long64_t autof = -30000000);
    virtual void            SetBasketSize(const char* bname, Int_t buffsize = 16000);
 #if !defined(__CINT__)
-   virtual Int_t           SetBranchAddress(const char *bname,void *add, TBranch **ptr = 0);
+   virtual Int_t           SetBranchAddress(const char *bname,void *add, TBranch **ptr = nullptr);
 #endif
    virtual Int_t           SetBranchAddress(const char *bname,void *add, TClass *realClass, EDataType datatype, Bool_t isptr);
    virtual Int_t           SetBranchAddress(const char *bname,void *add, TBranch **ptr, TClass *realClass, EDataType datatype, Bool_t isptr);
-   template <class T> Int_t SetBranchAddress(const char *bname, T **add, TBranch **ptr = 0) {
+   template <class T> Int_t SetBranchAddress(const char *bname, T **add, TBranch **ptr = nullptr) {
       TClass *cl = TClass::GetClass(typeid(T));
       EDataType type = kOther_t;
-      if (cl==0) type = TDataType::GetType(typeid(T));
+      if (cl==nullptr) type = TDataType::GetType(typeid(T));
       return SetBranchAddress(bname,add,ptr,cl,type,true);
    }
 #ifndef R__NO_CLASS_TEMPLATE_SPECIALIZATION
    // This can only be used when the template overload resolution can distinguish between
    // T* and T**
-   template <class T> Int_t SetBranchAddress(const char *bname, T *add, TBranch **ptr = 0) {
+   template <class T> Int_t SetBranchAddress(const char *bname, T *add, TBranch **ptr = nullptr) {
       TClass *cl = TClass::GetClass(typeid(T));
       EDataType type = kOther_t;
-      if (cl==0) type = TDataType::GetType(typeid(T));
+      if (cl==nullptr) type = TDataType::GetType(typeid(T));
       return SetBranchAddress(bname,add,ptr,cl,type,false);
    }
 #endif
-   virtual void            SetBranchStatus(const char* bname, Bool_t status = 1, UInt_t* found = 0);
+   virtual void            SetBranchStatus(const char* bname, Bool_t status = 1, UInt_t* found = nullptr);
    static  void            SetBranchStyle(Int_t style = 1);  //style=0 for old branch, =1 for new branch style
    virtual Int_t           SetCacheSize(Long64_t cachesize = -1);
    virtual Int_t           SetCacheEntryRange(Long64_t first, Long64_t last);
@@ -571,8 +571,8 @@ public:
    virtual Int_t           StopCacheLearningPhase();
    virtual Int_t           UnbinnedFit(const char* funcname, const char* varexp, const char* selection = "", Option_t* option = "", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0);
    void                    UseCurrentStyle();
-   virtual Int_t           Write(const char *name=0, Int_t option=0, Int_t bufsize=0);
-   virtual Int_t           Write(const char *name=0, Int_t option=0, Int_t bufsize=0) const;
+   virtual Int_t           Write(const char *name=nullptr, Int_t option=0, Int_t bufsize=0);
+   virtual Int_t           Write(const char *name=nullptr, Int_t option=0, Int_t bufsize=0) const;
 
    ClassDef(TTree, 20) // Tree descriptor (the main ROOT I/O class)
 };
@@ -593,7 +593,7 @@ protected:
    TIterator         *fTreeIter;     ///< current tree sub-iterator.
    Bool_t             fDirection;    ///< iteration direction
 
-   TTreeFriendLeafIter() : fTree(0), fLeafIter(0), fTreeIter(0),
+   TTreeFriendLeafIter() : fTree(nullptr), fLeafIter(nullptr), fTreeIter(nullptr),
        fDirection(0) { }
 
 public:
@@ -603,7 +603,7 @@ public:
    TIterator &operator=(const TIterator &rhs);
    TTreeFriendLeafIter &operator=(const TTreeFriendLeafIter &rhs);
 
-   const TCollection *GetCollection() const { return 0; }
+   const TCollection *GetCollection() const { return nullptr; }
    Option_t          *GetOption() const;
    TObject           *Next();
    void               Reset() { SafeDelete(fLeafIter); SafeDelete(fTreeIter); }

--- a/tree/tree/inc/TVirtualTreePlayer.h
+++ b/tree/tree/inc/TVirtualTreePlayer.h
@@ -76,8 +76,8 @@ public:
    virtual Int_t          MakeClass(const char *classname, const char *option) = 0;
    virtual Int_t          MakeCode(const char *filename) = 0;
    virtual Int_t          MakeProxy(const char *classname,
-                                    const char *macrofilename = 0, const char *cutfilename = 0,
-                                    const char *option = 0, Int_t maxUnrolling = 3) = 0;
+                                    const char *macrofilename = nullptr, const char *cutfilename = nullptr,
+                                    const char *option = nullptr, Int_t maxUnrolling = 3) = 0;
    virtual Int_t          MakeReader(const char *classname, Option_t *option) = 0;
    virtual TPrincipal    *Principal(const char *varexp="", const char *selection="", Option_t *option="np"
                                     ,Long64_t nentries=kMaxEntries, Long64_t firstentry=0) = 0;

--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -1376,7 +1376,7 @@ public:
    template <typename FirstColumn, typename... OtherColumns, typename T> // need FirstColumn to disambiguate overloads
    TResultProxy<T> Fill(T &&model, const ColumnNames_t &columnList)
    {
-      auto h = std::make_shared<T>(std::move(model));
+      auto h = std::make_shared<T>(std::forward(model));
       if (!TDFInternal::HistoUtils<T>::HasAxisLimits(*h)) {
          throw std::runtime_error("The absence of axes limits is not supported yet.");
       }
@@ -1397,7 +1397,7 @@ public:
    template <typename T>
    TResultProxy<T> Fill(T &&model, const ColumnNames_t &bl)
    {
-      auto h = std::make_shared<T>(std::move(model));
+      auto h = std::make_shared<T>(std::forward(model));
       if (!TDFInternal::HistoUtils<T>::HasAxisLimits(*h)) {
          throw std::runtime_error("The absence of axes limits is not supported yet.");
       }
@@ -1792,7 +1792,7 @@ private:
 
       // Here we check if the return type is a pointer. In this case, we assume it points to valid memory
       // and we treat the column as if it came from a data source, i.e. it points to valid memory.
-      loopManager->Book(std::make_shared<NewCol_t>(name, std::move(expression), validColumnNames, loopManager.get()));
+      loopManager->Book(std::make_shared<NewCol_t>(name, std::forward(expression), validColumnNames, loopManager.get()));
       TInterface<Proxied> newInterface(fProxiedPtr, fImplWeakPtr, fValidCustomColumns, fDataSource);
       newInterface.fValidCustomColumns.emplace_back(name);
       return newInterface;

--- a/tree/treeplayer/inc/TTreeFormula.h
+++ b/tree/treeplayer/inc/TTreeFormula.h
@@ -139,7 +139,7 @@ protected:
    Int_t       FindLeafForExpression(const char* expression, TLeaf *&leaf, TString &leftover, Bool_t &final, UInt_t &paran_level, TObjArray &castqueue, std::vector<std::string>& aliasUsed, Bool_t &useLeafCollectionObject, const char *fullExpression);
    TLeaf*      GetLeafWithDatamember(const char* topchoice, const char* nextchice, Long64_t readentry) const;
    Int_t       ParseWithLeaf(TLeaf *leaf, const char *expression, Bool_t final, UInt_t paran_level, TObjArray &castqueue, Bool_t useLeafCollectionObject, const char *fullExpression);
-   Int_t       RegisterDimensions(Int_t code, Int_t size, TFormLeafInfoMultiVarDim * multidim = 0);
+   Int_t       RegisterDimensions(Int_t code, Int_t size, TFormLeafInfoMultiVarDim * multidim = nullptr);
    Int_t       RegisterDimensions(Int_t code, TBranchElement *branch);
    Int_t       RegisterDimensions(Int_t code, TFormLeafInfo *info, TFormLeafInfo *maininfo, Bool_t useCollectionObject);
    Int_t       RegisterDimensions(Int_t code, TLeaf *leaf);
@@ -177,10 +177,10 @@ public:
    virtual Int_t       DefinedVariable(TString &variable, Int_t &action);
    virtual TClass*     EvalClass() const;
 
-   template<typename T> T EvalInstance(Int_t i=0, const char *stringStack[]=0);
-   virtual Double_t       EvalInstance(Int_t i=0, const char *stringStack[]=0) {return EvalInstance<Double_t>(i, stringStack); }
-   virtual Long64_t       EvalInstance64(Int_t i=0, const char *stringStack[]=0) {return EvalInstance<Long64_t>(i, stringStack); }
-   virtual LongDouble_t   EvalInstanceLD(Int_t i=0, const char *stringStack[]=0) {return EvalInstance<LongDouble_t>(i, stringStack); }
+   template<typename T> T EvalInstance(Int_t i=0, const char *stringStack[]=nullptr);
+   virtual Double_t       EvalInstance(Int_t i=0, const char *stringStack[]=nullptr) {return EvalInstance<Double_t>(i, stringStack); }
+   virtual Long64_t       EvalInstance64(Int_t i=0, const char *stringStack[]=nullptr) {return EvalInstance<Long64_t>(i, stringStack); }
+   virtual LongDouble_t   EvalInstanceLD(Int_t i=0, const char *stringStack[]=nullptr) {return EvalInstance<LongDouble_t>(i, stringStack); }
 
    virtual const char *EvalStringInstance(Int_t i=0);
    virtual void*       EvalObject(Int_t i=0);
@@ -203,7 +203,7 @@ public:
    virtual Bool_t      Notify() { UpdateFormulaLeaves(); return kTRUE; }
    virtual char       *PrintValue(Int_t mode=0) const;
    virtual char       *PrintValue(Int_t mode, Int_t instance, const char *decform = "9.9") const;
-   virtual void        SetAxis(TAxis *axis=0);
+   virtual void        SetAxis(TAxis *axis=nullptr);
            void        SetQuickLoad(Bool_t quick) { fQuickLoad = quick; }
    virtual void        SetTree(TTree *tree) {fTree = tree;}
    virtual void        ResetLoading();

--- a/tree/treeplayer/src/TDFNodes.cxx
+++ b/tree/treeplayer/src/TDFNodes.cxx
@@ -327,8 +327,8 @@ void TLoopManager::CleanUpNodes()
 
    // forget TActions and detach TResultProxies
    fBookedActions.clear();
-   for (auto readiness : fResProxyReadiness) {
-      *readiness.get() = true;
+   for (const auto &readiness : fResProxyReadiness) {
+      *readiness = true;
    }
    fResProxyReadiness.clear();
 


### PR DESCRIPTION
I already told Axel I was "playing" with clang-tidy. Here are some first results, basically low-hanging fruits only. I also included some of my own TMVA patches (more progress bars / unordered_map) and code modernization for TMVA.

Biggest improvement is probably the missing TString move assignment operator, that makes sorting a vector<TString> much much faster if the strings are too long for short string optimization.

Most of these patches can be applied in any order, they do not depend on each other.

We can discuss the large modernize-loops commit. I didn't have enough time to go through the loop variable names. The autogenerated names are not always the best (especially if the name "i" is generated). Nevertheless I wanted to push all these changes before SB52 :-)