### PR TITLE
Work around 'bug' in clang 5 C++17 overload resolution.

### DIFF
--- a/core/base/inc/TString.h
+++ b/core/base/inc/TString.h
@@ -275,7 +275,9 @@ public:
 
    // Type conversion
    operator const char*() const { return GetPointer(); }
-#if __cplusplus >= 201700L
+#if (__cplusplus >= 201700L) && (!defined(__clang_major__) || __clang_major__ > 5)
+   // Clang 5.0 support for explicit conversion is still inadequate even in c++17 mode.
+   // (It leads to extraneous ambiguous overload errors)
    explicit operator std::string() const { return std::string(GetPointer(),Length()); }
    explicit operator ROOT::Internal::TStringView() const { return ROOT::Internal::TStringView(GetPointer(),Length()); }
    operator std::string_view() const { return std::string_view(GetPointer(),Length()); }


### PR DESCRIPTION
Clang 5.0, and hence current Cling, support for explicit conversion is still inadequate even in c++17 mode.