### PR TITLE
Fix for JIT compilation of Formula when reading from a file

### DIFF
--- a/hist/hist/inc/TFormula.h
+++ b/hist/hist/inc/TFormula.h
@@ -92,6 +92,7 @@ private:
    Bool_t            fReadyToExecute;       //! trasient to force initialization
    Bool_t            fClingInitialized;  //!  transient to force re-initialization
    Bool_t            fAllParametersSetted;    // flag to control if all parameters are setted
+   Bool_t            fLazyInitialization = kFALSE;  //! transient flag to control lazy initialization (needed for reading from files)
    TMethodCall *fMethod;                      //! pointer to methodcall
    TString           fClingName;     //! unique name passed to Cling to define the function ( double clingName(double*x, double*p) )
 
@@ -111,7 +112,8 @@ private:
    static Bool_t   IsDefaultVariableName(const TString &name);
    void ReplaceAllNames(TString &formula, std::map<TString, TString> &substitutions);
    void FillParametrizedFunctions(std::map<std::pair<TString, Int_t>, std::pair<TString, TString>> &functions);
-   void FillVecFunctionsShurtCuts(); 
+   void FillVecFunctionsShurtCuts();
+   void ReInitializeEvalMethod(); 
 
 protected:
 
@@ -120,12 +122,12 @@ protected:
    std::map<TString,Int_t,TFormulaParamOrder>   fParams;   //  list of  parameter names
    std::map<TString,Double_t>          fConsts;   //!
    std::map<TString,TString>           fFunctionsShortcuts;  //!
-   TString                        fFormula;
-   Int_t                          fNdim;  //!
-   Int_t                          fNpar;  //!
-   Int_t                          fNumber;  //!
-   std::vector<TObject*>          fLinearParts;  // vector of linear functions
-   Bool_t                         fVectorized = false;      // whether we should use vectorized or regular variables
+   TString                             fFormula;  // string representing the formula expression
+   Int_t                               fNdim;  //   Dimension - needed for lambda expressions  
+   Int_t                               fNpar;  //!  Number of parameter (transient since we save the vector)
+   Int_t                               fNumber;  //!
+   std::vector<TObject*>               fLinearParts;  // vector of linear functions
+   Bool_t                              fVectorized = false;      // whether we should use vectorized or regular variables
    // (we default to false since a lot of functions still cannot be expressed in vectorized form)
 
    static Bool_t IsOperator(const char c);
@@ -219,6 +221,6 @@ public:
    void           SetVariables(const std::pair<TString,Double_t> *vars, const Int_t size);
    void SetVectorized(Bool_t vectorized);
 
-   ClassDef(TFormula,11)
+   ClassDef(TFormula,12)
 };
 #endif

--- a/test/TFormulaParsingTests.h
+++ b/test/TFormulaParsingTests.h
@@ -872,7 +872,7 @@ bool test45()
 
    TF1 * func2 = (TF1*) func->Clone("func2");
 
-   bool ok = fpEqual( func2->Eval(1), func->Eval(1), true);
+   bool ok = fpEqual( func2->Eval(2), func->Eval(2), true);
    return ok;
 }
 


### PR DESCRIPTION
Flag when CLING fails to compile the formula. In this case  try again when evaluating 
the formula. 
This should fix the recursive jitting and reading of formula from files. Like: 

TFile *_file0 = TFile::Open("formula.root")
formula->Eval(1.)

where formula.root contains a formula with name "formula" 

It should fix ROOT-7512