### PR TITLE
Fix stringstream formatting on Windows

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -634,8 +634,10 @@ public:
                                                                                       fValidCustomColumns, fDataSource);
       // build a string equivalent to
       // "(TInterface<nodetype*>*)(this)->Snapshot<Ts...>(treename,filename,*(ColumnNames_t*)(&columnList), options)"
+      // on Windows, to prefix the hexadecimal value of a pointer with '0x',
+      // one need to write: std::hex << std::showbase << (size_t)pointer
       snapCall << "reinterpret_cast<ROOT::Experimental::TDF::TInterface<" << upcastInterface.GetNodeTypeName() << ">*>("
-               << &upcastInterface << ")->Snapshot<";
+               << std::hex << std::showbase << (size_t)&upcastInterface << ")->Snapshot<";
       bool first = true;
       for (auto &b : columnList) {
          if (!first)
@@ -645,8 +647,9 @@ public:
       };
       snapCall << ">(\"" << treename << "\", \"" << filename << "\", "
                << "*reinterpret_cast<std::vector<std::string>*>(" // vector<string> should be ColumnNames_t
-               << &columnList << "),"
-               << "*reinterpret_cast<ROOT::Experimental::TDF::TSnapshotOptions*>(" << &options << "));";
+               << std::hex << std::showbase << (size_t)&columnList << "),"
+               << "*reinterpret_cast<ROOT::Experimental::TDF::TSnapshotOptions*>("
+               << std::hex << std::showbase << (size_t)&options << "));";
       // jit snapCall, return result
       TInterpreter::EErrorCode errorCode;
       auto newTDFPtr = gInterpreter->Calc(snapCall.str().c_str(), &errorCode);
@@ -715,8 +718,10 @@ public:
                                                                                       fValidCustomColumns, fDataSource);
       // build a string equivalent to
       // "(TInterface<nodetype*>*)(this)->Cache<Ts...>(*(ColumnNames_t*)(&columnList))"
+      // on Windows, to prefix the hexadecimal value of a pointer with '0x',
+      // one need to write: std::hex << std::showbase << (size_t)pointer
       snapCall << "reinterpret_cast<ROOT::Experimental::TDF::TInterface<" << upcastInterface.GetNodeTypeName() << ">*>("
-               << &upcastInterface << ")->Cache<";
+               << std::hex << std::showbase << (size_t)&upcastInterface << ")->Cache<";
       bool first = true;
       for (auto &b : columnList) {
          if (!first)
@@ -725,7 +730,7 @@ public:
          first = false;
       };
       snapCall << ">(*reinterpret_cast<std::vector<std::string>*>(" // vector<string> should be ColumnNames_t
-               << &columnList << "));";
+               << std::hex << std::showbase << (size_t)&columnList << "));";
       // jit snapCall, return result
       TInterpreter::EErrorCode errorCode;
       auto newTDFPtr = gInterpreter->Calc(snapCall.str().c_str(), &errorCode);

--- a/tree/treeplayer/src/TDFInterface.cxx
+++ b/tree/treeplayer/src/TDFInterface.cxx
@@ -175,7 +175,9 @@ Long_t JitTransformation(void *thisPtr, std::string_view methodName, std::string
 
    // Here we have two cases: filter and column
    ss.str("");
-   ss << targetTypeName << "(((" << interfaceTypeName << "*)" << thisPtr << ")->" << methodName << "(";
+   // on Windows, to prefix the hexadecimal value of a pointer with '0x',
+   // one need to write: std::hex << std::showbase << (size_t)pointer
+   ss << targetTypeName << "(((" << interfaceTypeName << "*)" << std::hex << std::showbase << (size_t)thisPtr << ")->" << methodName << "(";
    if (methodName == "Define") {
       ss << "\"" << name << "\", ";
    }
@@ -264,15 +266,18 @@ std::string JitBuildAndBook(const ColumnNames_t &bl, const std::string &prevNode
                     << "<" << actionTypeName;
    for (auto &colType : columnTypeNames)
       createAction_str << ", " << colType;
-   createAction_str << ">(*reinterpret_cast<" << prevNodeTypename << "*>(" << prevNode << "), {";
+   // on Windows, to prefix the hexadecimal value of a pointer with '0x',
+   // one need to write: std::hex << std::showbase << (size_t)pointer
+   createAction_str << ">(*reinterpret_cast<" << prevNodeTypename << "*>(" << std::hex << std::showbase << (size_t)prevNode << "), {";
    for (auto i = 0u; i < bl.size(); ++i) {
       if (i != 0u)
          createAction_str << ", ";
       createAction_str << '"' << bl[i] << '"';
    }
-   createAction_str << "}, " << nSlots << ", reinterpret_cast<" << actionResultTypeName << "*>(" << rOnHeap << ")"
-                    << ", reinterpret_cast<const std::shared_ptr<ROOT::Internal::TDF::TActionBase*>*>(" << actionPtrPtr
-                    << "));";
+   createAction_str << "}, " << std::dec << std::noshowbase << nSlots << ", reinterpret_cast<" << actionResultTypeName << "*>("
+                    << std::hex << std::showbase << (size_t)rOnHeap << ")"
+                    << ", reinterpret_cast<const std::shared_ptr<ROOT::Internal::TDF::TActionBase*>*>("
+                    << std::hex << std::showbase << (size_t)actionPtrPtr << "));";
    return createAction_str.str();
 }
 


### PR DESCRIPTION
When streaming a hexadecimal value of a pointer in a stringstream on Windows, to prefix its hexadecimal value with '0x', one need to use this syntax:
std::hex << std::showbase << (size_t)pointer