### PR TITLE
Fix another potential crash on Windows

### DIFF
--- a/core/foundation/src/TClassEdit.cxx
+++ b/core/foundation/src/TClassEdit.cxx
@@ -1900,7 +1900,7 @@ public:
       auto argsEnd = v.end();
       auto argsBeginPlusOne = ++v.begin();
       auto argPos = std::find_if(argsBeginPlusOne, argsEnd,
-                              [](std::string& arg){return arg.front() == ':';});
+           [](std::string& arg){return (!arg.empty() && arg.front() == ':');});
       if (argPos != argsEnd) {
          const int lenght = clName.size();
          int wedgeBalance = 0;


### PR DESCRIPTION
On Windows, (as the standard says) calling front() on an empty std::vector causes an undefined behaviour. One must check that the container contains something using empty() before calling front()