### PR TITLE
Several fixes for Windows

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -262,6 +262,8 @@ namespace {
       sArguments.addArgument("-Wno-microsoft-unqualified-friend");
       sArguments.addArgument("-Wno-deprecated-declarations");
 
+      sArguments.addArgument("-fno-threadsafe-statics");
+
       //sArguments.addArgument("-Wno-dllimport-static-field-def");
       //sArguments.addArgument("-Wno-microsoft-template");
 

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -262,7 +262,7 @@ namespace {
       sArguments.addArgument("-Wno-microsoft-unqualified-friend");
       sArguments.addArgument("-Wno-deprecated-declarations");
 
-      sArguments.addArgument("-fno-threadsafe-statics");
+      //sArguments.addArgument("-fno-threadsafe-statics");
 
       //sArguments.addArgument("-Wno-dllimport-static-field-def");
       //sArguments.addArgument("-Wno-microsoft-template");

--- a/interpreter/cling/lib/MetaProcessor/MetaProcessor.cpp
+++ b/interpreter/cling/lib/MetaProcessor/MetaProcessor.cpp
@@ -395,11 +395,7 @@ namespace cling {
       }
     }
 
-#ifdef LLVM_ON_WIN32
     std::ifstream in(filename.str().c_str(), std::ifstream::binary);
-#else
-    std::ifstream in(filename.str().c_str());
-#endif
     if (in.fail())
       return reportIOErr(filename, "open");
 

--- a/interpreter/cling/lib/MetaProcessor/MetaProcessor.cpp
+++ b/interpreter/cling/lib/MetaProcessor/MetaProcessor.cpp
@@ -395,7 +395,11 @@ namespace cling {
       }
     }
 
+#ifdef LLVM_ON_WIN32
+    std::ifstream in(filename.str().c_str(), std::ifstream::binary);
+#else
     std::ifstream in(filename.str().c_str());
+#endif
     if (in.fail())
       return reportIOErr(filename, "open");
 
@@ -473,7 +477,15 @@ namespace cling {
     if (topmost)
       m_TopExecutingFile = m_CurrentlyExecutingFile;
 
-    content.insert(0, "#line 2 \"" + filename.str() + "\" \n");
+    std::string path(filename.str());
+#ifdef LLVM_ON_WIN32
+    std::size_t p = 0;
+    while ((p = path.find('\\', p)) != std::string::npos) {
+      path.insert(p, "\\");
+      p += 2;
+    }
+#endif
+    content.insert(0, "#line 2 \"" + path + "\" \n");
     // We don't want to value print the results of a unnamed macro.
     if (content.back() != ';')
       content.append(";");

--- a/interpreter/cling/lib/MetaProcessor/MetaProcessor.cpp
+++ b/interpreter/cling/lib/MetaProcessor/MetaProcessor.cpp
@@ -395,6 +395,8 @@ namespace cling {
       }
     }
 
+    // Windows requires std::ifstream::binary to properly handle
+    // CRLF and LF line endings
     std::ifstream in(filename.str().c_str(), std::ifstream::binary);
     if (in.fail())
       return reportIOErr(filename, "open");


### PR DESCRIPTION
in CIFactory:
- Add -fno-threadsafe-statics flag (for Windows only), to prevent potential unresolved symbols at run-time

in MetaProcessor::readInputFromFile:
- add required std::ifstream::binary flag when opening the std::ifstream
- add missing backslashes

in PlatformWin:
- properly format error messages
- in IsDLL(): check and return false if the file size is 0
- fix _CxxThrowException symbol name (not fully understood - to be reviewed)
- filter out a couple of system dlls when looking for symbols