### PR TITLE
Fixing some bugs in RMVA

### DIFF
--- a/tmva/rmva/inc/TMVA/MethodRXGB.h
+++ b/tmva/rmva/inc/TMVA/MethodRXGB.h
@@ -79,7 +79,6 @@ namespace TMVA {
       DataSetManager    *fDataSetManager;     // DSMTEST
       friend class Factory;                   // DSMTEST
       friend class Reader;                    // DSMTEST
-
    protected:
 
       
@@ -88,9 +87,6 @@ namespace TMVA {
       UInt_t fNRounds;
       Double_t fEta;
       UInt_t fMaxDepth;
-      TString fObjectiveS;
-      TString fObjective;
-      Int_t fClassNum;
       static Bool_t IsModuleLoaded;
 
       std::vector<UInt_t>  fFactorNumeric;   //factors creations

--- a/tmva/rmva/inc/TMVA/MethodRXGB.h
+++ b/tmva/rmva/inc/TMVA/MethodRXGB.h
@@ -79,6 +79,7 @@ namespace TMVA {
       DataSetManager    *fDataSetManager;     // DSMTEST
       friend class Factory;                   // DSMTEST
       friend class Reader;                    // DSMTEST
+
    protected:
 
       
@@ -87,6 +88,9 @@ namespace TMVA {
       UInt_t fNRounds;
       Double_t fEta;
       UInt_t fMaxDepth;
+      TString fObjectiveS;
+      TString fObjective;
+      Int_t fClassNum;
       static Bool_t IsModuleLoaded;
 
       std::vector<UInt_t>  fFactorNumeric;   //factors creations

--- a/tmva/rmva/src/MethodC50.cxx
+++ b/tmva/rmva/src/MethodC50.cxx
@@ -143,7 +143,7 @@ void MethodC50::Train()
    fModel = new ROOT::R::TRObject(Model);
    if (IsModelPersistence())  
    {
-        TString path = GetWeightFileDir() + "/C50Model.RData";
+        TString path = GetWeightFileDir() +  "/" + GetName() + ".RData";
         Log() << Endl;
         Log() << gTools().Color("bold") << "--- Saving State File In:" << gTools().Color("reset") << path << Endl;
         Log() << Endl;
@@ -324,7 +324,7 @@ void MethodC50::GetHelpMessage() const
 void TMVA::MethodC50::ReadModelFromFile()
 {
    ROOT::R::TRInterface::Instance().Require("C50");
-   TString path = GetWeightFileDir() + "/C50Model.RData";
+   TString path = GetWeightFileDir() +  "/" + GetName() + ".RData";
    Log() << Endl;
    Log() << gTools().Color("bold") << "--- Loading State File From:" << gTools().Color("reset") << path << Endl;
    Log() << Endl;

--- a/tmva/rmva/src/MethodRSNNS.cxx
+++ b/tmva/rmva/src/MethodRSNNS.cxx
@@ -188,7 +188,7 @@ void MethodRSNNS::Train()
       //if model persistence is enabled saving it is R serialziation.
       if (IsModelPersistence())  
       {
-            TString path = GetWeightFileDir() + "/RMLPModel.RData";
+            TString path = GetWeightFileDir() +  "/" + GetName() + ".RData";
             Log() << Endl;
             Log() << gTools().Color("bold") << "--- Saving State File In:" << gTools().Color("reset") << path << Endl;
             Log() << Endl;
@@ -332,7 +332,7 @@ std::vector<Double_t> MethodRSNNS::GetMvaValues(Long64_t firstEvt, Long64_t last
 void TMVA::MethodRSNNS::ReadModelFromFile()
 {
    ROOT::R::TRInterface::Instance().Require("RSNNS");
-   TString path = GetWeightFileDir() + "/RMLPModel.RData";
+   TString path = GetWeightFileDir() +  "/" + GetName() + ".RData";
    Log() << Endl;
    Log() << gTools().Color("bold") << "--- Loading State File From:" << gTools().Color("reset") << path << Endl;
    Log() << Endl;

--- a/tmva/rmva/src/MethodRSVM.cxx
+++ b/tmva/rmva/src/MethodRSVM.cxx
@@ -213,7 +213,7 @@ void MethodRSVM::DeclareOptions()
    DeclareOptionRef(fEpsilon, "Epsilon", "epsilon in the insensitive-loss function (default: 0.1)");
    DeclareOptionRef(fShrinking, "Shrinking", "option whether to use the shrinking-heuristics (default:‘TRUE’)");
    DeclareOptionRef(fCross, "Cross", "if a integer value k>0 is specified, a k-fold cross validation on the training data is performed to assess the quality of the model: the accuracy rate for classification and the Mean Squared Error for regression");
-   DeclareOptionRef(fCross, "Probability", "logical indicating whether the model should allow for probability predictions");
+   DeclareOptionRef(fProbability, "Probability", "logical indicating whether the model should allow for probability predictions");
    DeclareOptionRef(fFitted, "Fitted", "logical indicating whether the fitted values should be computed and included in the model or not (default: ‘TRUE’)");
 
 }

--- a/tmva/rmva/src/MethodRSVM.cxx
+++ b/tmva/rmva/src/MethodRSVM.cxx
@@ -169,7 +169,7 @@ void MethodRSVM::Train()
    fModel = new ROOT::R::TRObject(Model);
    if (IsModelPersistence())
    {
-        TString path = GetWeightFileDir() + "/RSVMModel.RData";
+        TString path = GetWeightFileDir() +  "/" + GetName() + ".RData";
         Log() << Endl;
         Log() << gTools().Color("bold") << "--- Saving State File In:" << gTools().Color("reset") << path << Endl;
         Log() << Endl;
@@ -212,8 +212,8 @@ void MethodRSVM::DeclareOptions()
    DeclareOptionRef(fTolerance, "Tolerance", "tolerance of termination criterion (default: 0.001)");
    DeclareOptionRef(fEpsilon, "Epsilon", "epsilon in the insensitive-loss function (default: 0.1)");
    DeclareOptionRef(fShrinking, "Shrinking", "option whether to use the shrinking-heuristics (default:‘TRUE’)");
-   DeclareOptionRef(fCross, "Cross", "if a integer value k>0 is specified, a k-fold cross validation on the training data is performed to assess the\
-                                       quality of the model: the accuracy rate for classification and the Mean Squared Error for regression");
+   DeclareOptionRef(fCross, "Cross", "if a integer value k>0 is specified, a k-fold cross validation on the training data is performed to assess the quality of the model: the accuracy rate for classification and the Mean Squared Error for regression");
+   DeclareOptionRef(fCross, "Probability", "logical indicating whether the model should allow for probability predictions");
    DeclareOptionRef(fFitted, "Fitted", "logical indicating whether the fitted values should be computed and included in the model or not (default: ‘TRUE’)");
 
 }
@@ -356,7 +356,7 @@ std::vector<Double_t> MethodRSVM::GetMvaValues(Long64_t firstEvt, Long64_t lastE
 void TMVA::MethodRSVM::ReadModelFromFile()
 {
    ROOT::R::TRInterface::Instance().Require("e1071");
-   TString path = GetWeightFileDir() + "/RSVMModel.RData";
+   TString path = GetWeightFileDir() +  "/" + GetName() + ".RData";
    Log() << Endl;
    Log() << gTools().Color("bold") << "--- Loading State File From:" << gTools().Color("reset") << path << Endl;
    Log() << Endl;

--- a/tmva/rmva/src/MethodRXGB.cxx
+++ b/tmva/rmva/src/MethodRXGB.cxx
@@ -54,8 +54,6 @@ MethodRXGB::MethodRXGB(const TString &jobName,
    fNRounds(10),
    fEta(0.3),
    fMaxDepth(6),
-   fObjective("multi:softprob"),
-   fClassNum(2),
    predict("predict", "xgboost"),
    xgbtrain("xgboost"),
    xgbdmatrix("xgb.DMatrix"),
@@ -75,8 +73,6 @@ MethodRXGB::MethodRXGB(DataSetInfo &theData, const TString &theWeightFile)
      fNRounds(10),
      fEta(0.3),
      fMaxDepth(6),
-     fObjective("multi:softprob"),
-     fClassNum(2),
      predict("predict", "xgboost"),
      xgbtrain("xgboost"),
      xgbdmatrix("xgb.DMatrix"),
@@ -90,13 +86,11 @@ MethodRXGB::MethodRXGB(DataSetInfo &theData, const TString &theWeightFile)
 }
 
 
-
 //_______________________________________________________________________
 MethodRXGB::~MethodRXGB(void)
 {
    if (fModel) delete fModel;
 }
-
 
 //_______________________________________________________________________
 Bool_t MethodRXGB::HasAnalysisType(Types::EAnalysisType type, UInt_t numberClasses, UInt_t /*numberTargets*/)
@@ -137,8 +131,6 @@ void MethodRXGB::Train()
    ROOT::R::TRDataFrame params;
    params["eta"] = fEta;
    params["max.depth"] = fMaxDepth;
-   params["objective"] = fObjective;
-   params["num_class"] = fClassNum;
 
    SEXP Model = xgbtrain(ROOT::R::Label["data"] = dmatrix,
                          ROOT::R::Label["label"] = fFactorNumeric,
@@ -163,15 +155,11 @@ void MethodRXGB::DeclareOptions()
    DeclareOptionRef(fNRounds, "NRounds", "The max number of iterations");
    DeclareOptionRef(fEta, "Eta", "Step size shrinkage used in update to prevents overfitting. After each boosting step, we can directly get the weights of new features. and eta actually shrinks the feature weights to make the boosting process more conservative.");
    DeclareOptionRef(fMaxDepth, "MaxDepth", "Maximum depth of the tree");
-   DeclareOptionRef(fObjectiveS, "objective", "The learning task and the corresponding learning objective");
-   DeclareOptionRef(fClassNum, "num_class", "Number of classes to be used for multiclass classification if using with multi:softmax and multi:softprob objectives ");;;;;;
 }
 
 //_______________________________________________________________________
 void MethodRXGB::ProcessOptions()
 {
-   fObjectiveS.ToLower();
-   if      (fObjectiveS == "multi_softprob") fObjective = "multi:softprob";
 }
 
 //_______________________________________________________________________
@@ -246,10 +234,6 @@ std::vector<Double_t> MethodRXGB::GetMvaValues(Long64_t firstEvt, Long64_t lastE
    std::vector<Double_t> mvaValues(nEvents); 
    ROOT::R::TRObject pred = predict(*fModel, xgbdmatrix(ROOT::R::Label["data"] = asmatrix(evtData)));
    mvaValues = pred.As<std::vector<Double_t>>();
-   /*for (int i = 0; i < mvaValues.size(); ++i)
-    {
-      std::cout << i <<  mvaValues[i] << std::endl;
-    } */
 
    if (logProgress) {
       Log() << kINFO <<Form("Dataset[%s] : ",DataInfo().GetName())<< "Elapsed time for evaluation of " << nEvents <<  " events: "


### PR DESCRIPTION
Models trained with RMVA are saved in .Rdata files.
For all of the models in 
MethodC50.cxx 
MethodRSNNS.cxx 
MethodRSVM.cxx 
MethodRXGB.cxx 

name of the file is hardcoded e.g:

TString path = GetWeightFileDir() + "/RXGBModel.RData";

so when one books multiple variations of the same model with

factory->BookMethod(dataloader, TMVA::Types::kRXGB, "kRXGB", "!V:NRounds=80:MaxDepth=2:Eta=1");

TMVA keeps overwriting the same file and at the end reports the same results for all variants (for example, on all plots there is only one curve for different model versions)

An easy fix which I tested to be working is to replace the lines like

TString path = GetWeightFileDir() + "/RXGBModel.RData

with

TString path = GetWeightFileDir() + "/" + GetName() + ".RData";

everywhere in *.cxx files above. This will use a file name based on the method title the same way it is done for the default TMVA methods as long as a user uses unique titles when booking using the line above

Another fix are changes to the example code in /test since the current example uses outdated code which fails to run. Also, that code failed to run because "Probability" option for RSVM model was not declared with DeclareOptionRef method inside the source file.
