### PR TITLE
etc/ file installation fix, master branch (2018.02.13.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,16 +410,16 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_INSTALL_PREFIX)
     install(DIRECTORY README DESTINATION ${CMAKE_INSTALL_DOCDIR})
   endif()
   install(DIRECTORY etc/ DESTINATION ${CMAKE_INSTALL_SYSCONFDIR} USE_SOURCE_PERMISSIONS
-                         REGEX "/system.rootrc$" EXCLUDE
-                         REGEX "/system.rootauthrc$" EXCLUDE
-                         REGEX "/system.rootdaemonrc$" EXCLUDE
-                         REGEX "/rootd.rc.d$" EXCLUDE
-                         REGEX "/proofd.rc.d$" EXCLUDE
-                         REGEX "/rootd.xinetd$" EXCLUDE
-                         REGEX "/proofd.xinetd$" EXCLUDE
-                         REGEX "/root.mimes$" EXCLUDE
-                         REGEX "/cmake$" EXCLUDE
-                         REGEX "/http$" EXCLUDE )
+                         PATTERN "system.rootrc" EXCLUDE
+                         PATTERN "system.rootauthrc" EXCLUDE
+                         PATTERN "system.rootdaemonrc" EXCLUDE
+                         PATTERN "rootd.rc.d" EXCLUDE
+                         PATTERN "proofd.rc.d" EXCLUDE
+                         PATTERN "rootd.xinetd" EXCLUDE
+                         PATTERN "proofd.xinetd" EXCLUDE
+                         PATTERN "root.mimes" EXCLUDE
+                         PATTERN "cmake" EXCLUDE
+                         PATTERN "http" EXCLUDE )
   install(DIRECTORY fonts/  DESTINATION ${CMAKE_INSTALL_FONTDIR})
   install(DIRECTORY icons/  DESTINATION ${CMAKE_INSTALL_ICONDIR})
   install(DIRECTORY macros/ DESTINATION ${CMAKE_INSTALL_MACRODIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -418,7 +418,7 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_INSTALL_PREFIX)
                          REGEX rootd.xinetd EXCLUDE
                          REGEX proofd.xinetd EXCLUDE
                          REGEX root.mimes EXCLUDE
-                         REGEX cmake EXCLUDE
+                         REGEX "/cmake$" EXCLUDE
                          REGEX /http EXCLUDE )
   install(DIRECTORY fonts/  DESTINATION ${CMAKE_INSTALL_FONTDIR})
   install(DIRECTORY icons/  DESTINATION ${CMAKE_INSTALL_ICONDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,16 +410,16 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_INSTALL_PREFIX)
     install(DIRECTORY README DESTINATION ${CMAKE_INSTALL_DOCDIR})
   endif()
   install(DIRECTORY etc/ DESTINATION ${CMAKE_INSTALL_SYSCONFDIR} USE_SOURCE_PERMISSIONS
-                         REGEX system.rootrc EXCLUDE
-                         REGEX system.rootauthrc EXCLUDE
-                         REGEX system.rootdaemonrc EXCLUDE
-                         REGEX rootd.rc.d EXCLUDE
-                         REGEX proofd.rc.d EXCLUDE
-                         REGEX rootd.xinetd EXCLUDE
-                         REGEX proofd.xinetd EXCLUDE
-                         REGEX root.mimes EXCLUDE
+                         REGEX "/system.rootrc$" EXCLUDE
+                         REGEX "/system.rootauthrc$" EXCLUDE
+                         REGEX "/system.rootdaemonrc$" EXCLUDE
+                         REGEX "/rootd.rc.d$" EXCLUDE
+                         REGEX "/proofd.rc.d$" EXCLUDE
+                         REGEX "/rootd.xinetd$" EXCLUDE
+                         REGEX "/proofd.xinetd$" EXCLUDE
+                         REGEX "/root.mimes$" EXCLUDE
                          REGEX "/cmake$" EXCLUDE
-                         REGEX /http EXCLUDE )
+                         REGEX "/http$" EXCLUDE )
   install(DIRECTORY fonts/  DESTINATION ${CMAKE_INSTALL_FONTDIR})
   install(DIRECTORY icons/  DESTINATION ${CMAKE_INSTALL_ICONDIR})
   install(DIRECTORY macros/ DESTINATION ${CMAKE_INSTALL_MACRODIR})


### PR DESCRIPTION
This almost broke me...

I've been trying to find for days why ROOT would not build correctly in one particular (fairly complicated) setup for me. I just couldn't figure out why I wouldn't get the files meant for the `etc/` directory in my installation.

Turns out that it was because in this weird setup I put the ROOT source code into a directory inside of another CMake project, into a directory that had `/CMakeFiles/` as part of its path. And would you know, macOS still comes with a case insensitive file system, so this exclusion rule was triggering for the full contents of the `etc/` directory in this setup.

After realising this, I modified my project's setup to put the ROOT source code into a safer location. But this update should still help people avoid a similar situation later on...

P.S. I checked in a simple standalone example that this formalism should do the right thing. (Took me some tries to find "just the right" incantation.)