### PR TITLE
[TMVA] Template RandomGenerator

### DIFF
--- a/tmva/tmva/CMakeLists.txt
+++ b/tmva/tmva/CMakeLists.txt
@@ -95,12 +95,4 @@ if(NOT gnuinstall)
                  PATTERN "data" EXCLUDE)
 endif()
 
-ROOT_ADD_TEST_SUBDIRECTORY(test/crossvalidation)
-ROOT_ADD_TEST_SUBDIRECTORY(test/DNN)
-ROOT_ADD_TEST_SUBDIRECTORY(test/Method)
-ROOT_ADD_TEST_SUBDIRECTORY(test/ROC)
-ROOT_ADD_TEST_SUBDIRECTORY(test/envelope)
-
-
-
-
+ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/tmva/tmva/inc/TMVA/DataSetFactory.h
+++ b/tmva/tmva/inc/TMVA/DataSetFactory.h
@@ -64,21 +64,6 @@ namespace TMVA {
 
    // =============== functors =======================
 
-   class RandomGenerator {
-   public:
-      using result_type = UInt_t;
-
-      RandomGenerator(UInt_t seed) { fRandom.SetSeed(seed); }
-
-      UInt_t operator()(UInt_t n = kMaxUInt) { return fRandom.Integer(n); }
-
-      static constexpr UInt_t min() { return 0; }
-      static constexpr UInt_t max() { return kMaxUInt; }
-
-   private:
-      TRandom3 fRandom; // random generator
-   };
-
    // delete-functor (to be used in e.g. for_each algorithm)
    template<class T>
       struct DeleteFunctor_t

--- a/tmva/tmva/inc/TMVA/Tools.h
+++ b/tmva/tmva/inc/TMVA/Tools.h
@@ -282,6 +282,51 @@ namespace TMVA {
 
    Tools& gTools(); // global accessor
 
+   //
+   // Adapts a TRandom random number generator to the interface of the ones in the
+   // standard library (STL) so that TRandom derived generators can be used with
+   // STL algorithms such as `std::shuffle`.
+   //
+   // Example:
+   // ```
+   // std::vector<double> v {0, 1, 2, 3, 4, 5};
+   // TRandom3StdEngine rng(seed);
+   // std::shuffle(v.begin(), v.end(), rng);
+   // ```
+   //
+   // Or at a lower level:
+   // ```
+   // std::vector<double> v {0, 1, 2, 3, 4, 5};
+   // RandomGenerator<TRandom3> rng(seed);
+   // std::shuffle(v.begin(), v.end(), rng);
+   // ```
+   //
+   template <typename TRandomLike, typename UIntType = UInt_t, UIntType max_val = kMaxUInt>
+   class RandomGenerator {
+   public:
+      using result_type = UIntType;
+
+      RandomGenerator(UIntType seed = 0) { fRandom.SetSeed(seed); }
+
+      static constexpr UIntType min() { return 0; }
+      static constexpr UIntType max() { return max_val; }
+
+      void seed(UIntType val = 0) { fRandom.SetSeed(val); }
+
+      UIntType operator()() { return fRandom.Integer(max()); }
+
+      void discard(unsigned long long z)
+      {
+         for (unsigned long long i = 0; i < z; ++i) {
+            volatile result_type r;
+            r = fRandom.Integer(max());
+         }
+      }
+
+   private:
+      TRandomLike fRandom; // random generator
+   };
+
 } // namespace TMVA
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/src/CvSplit.cxx
+++ b/tmva/tmva/src/CvSplit.cxx
@@ -16,6 +16,7 @@
 #include "TMVA/DataSetInfo.h"
 #include "TMVA/Event.h"
 #include "TMVA/MsgLogger.h"
+#include "TMVA/Tools.h"
 
 #include <TString.h>
 #include <TFormula.h>
@@ -293,7 +294,7 @@ std::vector<UInt_t> TMVA::CvSplitKFolds::GetEventIndexToFoldMapping(UInt_t nEntr
    }
 
    // Shuffle assignment
-   TMVA::RandomGenerator rng(seed);
+   TMVA::RandomGenerator<TRandom3> rng(seed);
    std::shuffle(fOrigToFoldMapping.begin(), fOrigToFoldMapping.end(), rng);
 
    return fOrigToFoldMapping;

--- a/tmva/tmva/src/DataSetFactory.cxx
+++ b/tmva/tmva/src/DataSetFactory.cxx
@@ -68,6 +68,7 @@ Class that contains all the data information
 #include "TMVA/DataInputHandler.h"
 #include "TMVA/Event.h"
 
+#include "TMVA/Tools.h"
 #include "TMVA/Types.h"
 #include "TMVA/VariableInfo.h"
 
@@ -985,7 +986,7 @@ TMVA::DataSetFactory::MixEvents( DataSetInfo& dsi,
                                  const TString& normMode,
                                  UInt_t splitSeed)
 {
-   TMVA::RandomGenerator rndm(splitSeed);
+   TMVA::RandomGenerator<TRandom3> rndm(splitSeed);
 
    // ==== splitting of undefined events to kTraining and kTesting
 

--- a/tmva/tmva/test/CMakeLists.txt
+++ b/tmva/tmva/test/CMakeLists.txt
@@ -6,12 +6,10 @@
 set(Libraries TMVA)
 include_directories(${ROOT_INCLUDE_DIRS})
 
-# Tests
-ROOT_EXECUTABLE(TestRandomGenerator
-                TestRandomGenerator.cxx
-                LIBRARIES ${Libraries})
-ROOT_ADD_TEST(TMVA-RandomGenerator
-              COMMAND TestRandomGenerator)
+# Tests using google test
+ROOT_ADD_GTEST(TestRandomGenerator
+               TestRandomGenerator.cxx
+               LIBRARIES ${Libraries})
 
 # Subdirectories
 ROOT_ADD_TEST_SUBDIRECTORY(test/crossvalidation)

--- a/tmva/tmva/test/CMakeLists.txt
+++ b/tmva/tmva/test/CMakeLists.txt
@@ -3,9 +3,6 @@
 # @author Kim Albertsson
 ############################################################################
 
-project(tmva-tests)
-find_package(ROOT REQUIRED)
-
 set(Libraries TMVA)
 include_directories(${ROOT_INCLUDE_DIRS})
 

--- a/tmva/tmva/test/CMakeLists.txt
+++ b/tmva/tmva/test/CMakeLists.txt
@@ -1,0 +1,24 @@
+############################################################################
+# CMakeLists.txt file for building ROOT TMVA tests.
+# @author Kim Albertsson
+############################################################################
+
+project(tmva-tests)
+find_package(ROOT REQUIRED)
+
+set(Libraries TMVA)
+include_directories(${ROOT_INCLUDE_DIRS})
+
+# Tests
+ROOT_EXECUTABLE(TestRandomGenerator
+                TestRandomGenerator.cxx
+                LIBRARIES ${Libraries})
+ROOT_ADD_TEST(TMVA-RandomGenerator
+              COMMAND TestRandomGenerator)
+
+# Subdirectories
+ROOT_ADD_TEST_SUBDIRECTORY(test/crossvalidation)
+ROOT_ADD_TEST_SUBDIRECTORY(test/DNN)
+ROOT_ADD_TEST_SUBDIRECTORY(test/Method)
+ROOT_ADD_TEST_SUBDIRECTORY(test/ROC)
+ROOT_ADD_TEST_SUBDIRECTORY(test/envelope)

--- a/tmva/tmva/test/DNN/CMakeLists.txt
+++ b/tmva/tmva/test/DNN/CMakeLists.txt
@@ -3,9 +3,6 @@
 # @author Simon Pfreundschuh
 ############################################################################
 
-project(tmva-tests)
-find_package(ROOT REQUIRED)
-
 set(Libraries Core MathCore Matrix TMVA)
 include_directories(${ROOT_INCLUDE_DIRS})
 

--- a/tmva/tmva/test/TestRandomGenerator.cxx
+++ b/tmva/tmva/test/TestRandomGenerator.cxx
@@ -12,6 +12,9 @@
 // Stdlib
 #include <iostream>
 
+// External
+#include "gtest/gtest.h"
+
 using TRandom1StdGen = TMVA::RandomGenerator<TRandom1, UInt_t, kMaxUInt << 2>;
 using TRandom2StdGen = TMVA::RandomGenerator<TRandom2, UInt_t, kMaxUInt << 2>;
 using TRandom3StdGen = TMVA::RandomGenerator<TRandom3>;
@@ -90,12 +93,17 @@ void test_example()
    std::cout << std::endl;
 }
 
-int main()
+TEST(RandomGenerator, print)
 {
-
    test_print(10);
-   test_discard(10);
-   test_example();
+}
 
-   return 0;
+TEST(RandomGenerator, discard)
+{
+   test_discard(10);
+}
+
+TEST(RandomGenerator, example)
+{
+   test_example();
 }

--- a/tmva/tmva/test/TestRandomGenerator.cxx
+++ b/tmva/tmva/test/TestRandomGenerator.cxx
@@ -1,0 +1,101 @@
+
+// ROOT
+#include "TRandom.h"
+#include "TRandom1.h"
+#include "TRandom2.h"
+#include "TRandom3.h"
+#include "TRandomGen.h"
+
+// TMVA
+#include "TMVA/Tools.h"
+
+// Stdlib
+#include <iostream>
+
+using TRandom1StdGen = TMVA::RandomGenerator<TRandom1, UInt_t, kMaxUInt << 2>;
+using TRandom2StdGen = TMVA::RandomGenerator<TRandom2, UInt_t, kMaxUInt << 2>;
+using TRandom3StdGen = TMVA::RandomGenerator<TRandom3>;
+using TRandomMixMaxStdGen = TMVA::RandomGenerator<TRandomMixMax>;
+using TRandomMixMax17StdGen = TMVA::RandomGenerator<TRandomMixMax17>;
+using TRandomMixMax256StdGen = TMVA::RandomGenerator<TRandomMixMax256>;
+
+template <typename URNG>
+void print_urng(URNG urng, int n = 10)
+{
+   std::uniform_int_distribution<UInt_t> dist{2, 5};
+
+   for (int i = 0; i < n; ++i) {
+      std::cout << dist(urng) << ", ";
+   }
+   std::cout << std::endl;
+}
+
+// Test that generation compiles
+void test_print(int n)
+{
+
+   std::cout << "Generating numbers from TRandom1StdGen: ";
+   print_urng(TRandom1StdGen{1}, n);
+   std::cout << "Generating numbers from TRandom2StdGen: ";
+   print_urng(TRandom2StdGen{1}, n);
+   std::cout << "Generating numbers from TRandom3StdGen: ";
+   print_urng(TRandom3StdGen{1}, n);
+
+   std::cout << "Generating numbers from TRandomMixMaxStdGen: ";
+   print_urng(TRandomMixMaxStdGen{1}, n);
+   std::cout << "Generating numbers from TRandomMixMax17StdGen: ";
+   print_urng(TRandomMixMax17StdGen{1}, n);
+   std::cout << "Generating numbers from TRandomMixMax256StdGen: ";
+   print_urng(TRandomMixMax256StdGen{1}, n);
+
+   std::cout << std::endl;
+}
+
+// Make sure that discard skips N steps
+void test_discard(int n)
+{
+   TRandom3StdGen rng1{100};
+   TRandom3StdGen rng2{100};
+
+   std::uniform_int_distribution<UInt_t> dist{2, 5};
+
+   for (int i = 0; i < n; ++i) {
+      rng1();
+   }
+   rng2.discard(n);
+
+   for (int i = 0; i < 10; ++i) {
+      if (not(dist(rng1) == dist(rng2))) {
+         throw std::runtime_error("");
+      }
+   }
+
+   std::cout << "Discard test success!" << std::endl;
+}
+
+// Make sure the example code in the documentation compiles
+void test_example()
+{
+   std::cout << std::endl;
+   std::cout << "Shuffling vector {0, 1, 2, 3, 4, 5}" << std::endl;
+
+   int seed = 0;
+   std::vector<double> v{0, 1, 2, 3, 4, 5};
+   TMVA::RandomGenerator<TRandom3> rng(seed);
+   std::shuffle(v.begin(), v.end(), rng);
+
+   for (auto e : v) {
+      std::cout << e << ", ";
+   }
+   std::cout << std::endl;
+}
+
+int main()
+{
+
+   test_print(10);
+   test_discard(10);
+   test_example();
+
+   return 0;
+}

--- a/tmva/tmva/test/crossvalidation/CMakeLists.txt
+++ b/tmva/tmva/test/crossvalidation/CMakeLists.txt
@@ -3,9 +3,6 @@
 # @author Kim Albertsson
 ############################################################################
 
-project(tmva-tests)
-find_package(ROOT REQUIRED)
-
 set(Libraries TMVA)
 include_directories(${ROOT_INCLUDE_DIRS})
 


### PR DESCRIPTION
This PR:
- Generalises the DataSetFactory::RandomGenerator class and moves it to TMVA::Tools.
- Replaces use of the old class with the new one.
- Adds test cases for the new class.

This could be taken a step further and be put in a separate header in ROOT proper alongside its friends `ROOT::Math::TRandomEngine<Engine>`, `TRandom : public ROOT::Math::TRandomEngine`, `ROOT::Math::StdEngine<Engine>`, and `TRandomGen<Engine> : public TRandom`.
These classes define the TRandom interface and adapts foreign interfaced to that of TRandom.

This PR provides an interface for going in the other direction. One could then imagine renaming this class to `TRandomAsStdEngine` and move it outside of TMVA for all to benefit.