### PR TITLE
[cmake] Drop setting the default build type.

### DIFF
--- a/cmake/modules/CheckCompiler.cmake
+++ b/cmake/modules/CheckCompiler.cmake
@@ -80,21 +80,6 @@ else()
   set(GCC_MINOR 0)
 endif()
 
-#---Set a default build type for single-configuration CMake generators if no build type is set------
-if(WIN32)
-  set(CMAKE_CONFIGURATION_TYPES Release MinSizeRel Debug RelWithDebInfo)
-else()
-  set(CMAKE_CONFIGURATION_TYPES Release MinSizeRel Debug RelWithDebInfo Optimized)
-endif()
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Choose the type of build, options are: Release, MinSizeRel, Debug, RelWithDebInfo, Optimized." FORCE)
-endif()
-string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)
-string(TOUPPER "${CMAKE_CONFIGURATION_TYPES}" uppercase_CMAKE_CONFIGURATION_TYPES)
-if(NOT "${uppercase_CMAKE_CONFIGURATION_TYPES}" MATCHES "${uppercase_CMAKE_BUILD_TYPE}")
-  message(FATAL_ERROR "CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} needs to be one of known build types: ${CMAKE_CONFIGURATION_TYPES}")
-endif()
-
 include(CheckCXXCompilerFlag)
 include(CheckCCompilerFlag)
 


### PR DESCRIPTION
Messing up with cmake system variables such as CMAKE_CONFIGURATION_TYPES
is considered a bad practice. It becomes overly complicated for multi-
stage cmake generators such as XCode and VisualStudio.

This code prevents us to build against vanilla llvm and as per D33444
we were advised to revisit this code.

This PR blocks #1632.