### PR TITLE
Protect against out-of-bounds access

### DIFF
--- a/graf2d/gpad/src/TRatioPlot.cxx
+++ b/graf2d/gpad/src/TRatioPlot.cxx
@@ -1074,9 +1074,9 @@ Int_t TRatioPlot::BuildLowerPlot()
             ((TGraphAsymmErrors*)fRatioGraph)->SetPointError(ipoint,  fH1->GetBinWidth(i)/2., fH1->GetBinWidth(i)/2., 0.5, 0.5);
 
             fConfidenceInterval1->SetPoint(ipoint, x, 0);
-            fConfidenceInterval1->SetPointError(ipoint, x, ci1[i] / error);
+            fConfidenceInterval1->SetPointError(ipoint, x, i < ci1.size() ? ci1[i] / error : 0);
             fConfidenceInterval2->SetPoint(ipoint, x, 0);
-            fConfidenceInterval2->SetPointError(ipoint, x, ci2[i] / error);
+            fConfidenceInterval2->SetPointError(ipoint, x, i < ci2.size() ? ci2[i] / error : 0);
 
             ++ipoint;
 


### PR DESCRIPTION
I chose to put this issue in a separate PR since there might be a better fix than the one proposed here.

The loops that fills the ci1 and c12 vectors are defined as:

for (Int_t i=1; i<=fH1->GetNbinsX();++i) {

while the loop that reads the values back is defined as:

for (Int_t i=0; i<=fH1->GetNbinsX();++i) {

i.e. it has one more iteration (since it starts at 0 instead of 1).

So on the last iteration it accesses the vector beyond its last element.

This PR just adds a protection and makes sure the out-of-bounds element is not read and replaces it with a zero. While this makes the tests not crash, I am not sure there isn't some other bug here, and that the proper fix is something else. That the code tries to read one more value from the vector than it writes is suspicious.
