### PR TITLE
Fix doxygen ~ alignment

### DIFF
--- a/core/meta/src/TStatusBitsChecker.cxx
+++ b/core/meta/src/TStatusBitsChecker.cxx
@@ -42,7 +42,7 @@
       // used in TStreamerElement
       kHasRange = TStreamerElement::kHasRange
    };
-  ~~~ {.cpp}
+   ~~~ {.cpp}
 
   Without the EStatusBitsDupExceptions enum you would see
 

--- a/tree/treeplayer/src/TTreeReader.cxx
+++ b/tree/treeplayer/src/TTreeReader.cxx
@@ -235,7 +235,7 @@ void TTreeReader::Initialize()
 /// If end <= begin, `end` is ignored (set to `-1`) and only `begin` is used.
 /// Example:
 ///
-///  ~~~ {.cpp}
+/// ~~~ {.cpp}
 /// reader.SetEntriesRange(3, 5);
 /// while (reader.Next()) {
 ///   // Will load entries 3 and 4.


### PR DESCRIPTION
The ~~~ at the start and the end of a code block must align to the same position on the line. Otherwise you get warnings:

warning: reached end of file while inside a ~~~ block!
The command that should end the block seems to be missing!
