### PR TITLE
webgui: improve TDisplayItem classes

### DIFF
--- a/etc/http/scripts/JSRootCore.js
+++ b/etc/http/scripts/JSRootCore.js
@@ -99,7 +99,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 19/02/2018";
+   JSROOT.version = "dev 20/02/2018";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;
@@ -2087,6 +2087,7 @@
       if (JSROOT.GetUrlOption('io', src)!=null) prereq += "io;";
       if (JSROOT.GetUrlOption('tree', src)!=null) prereq += "tree;";
       if (JSROOT.GetUrlOption('2d', src)!=null) prereq += "2d;";
+      if (JSROOT.GetUrlOption('v7', src)!=null) prereq += "v7;";
       if (JSROOT.GetUrlOption('hist', src)!=null) prereq += "2d;hist;";
       if (JSROOT.GetUrlOption('hierarchy', src)!=null) prereq += "2d;hierarchy;";
       if (JSROOT.GetUrlOption('jq2d', src)!=null) prereq += "2d;hierarchy;jq2d;";

--- a/etc/http/scripts/JSRootPainter.js
+++ b/etc/http/scripts/JSRootPainter.js
@@ -2788,7 +2788,8 @@
 
       // create TFrame element if not exists
       if (this.svg_frame().select(".main_layer").empty() && ((is_main == 1) || (is_main == 3) || (is_main == 4))) {
-         JSROOT.Painter.drawFrame(divid, null, (is_main == 4) ? "3d" : "");
+         if (typeof JSROOT.Painter.drawFrame == 'function')
+            JSROOT.Painter.drawFrame(divid, null, (is_main == 4) ? "3d" : "");
          if ((is_main != 4) && this.svg_frame().empty()) return alert("Fail to draw dummy TFrame");
       }
 
@@ -3533,7 +3534,7 @@
       var painter = this.pad_painter();
       if ((painter === null) || (painter.pad === null)) return null;
 
-      if (painter.pad.fPrimitives !== null)
+      if (painter.pad.fPrimitives)
          for (var n=0;n<painter.pad.fPrimitives.arr.length;++n) {
             var prim = painter.pad.fPrimitives.arr[n];
             if (('fName' in prim) && (prim.fName === objname)) return prim;

--- a/etc/http/scripts/JSRootPainter.v6.js
+++ b/etc/http/scripts/JSRootPainter.v6.js
@@ -821,9 +821,9 @@
    // ===============================================
 
    function TFramePainter(tframe) {
+      if (tframe && tframe.$dummy) tframe = null;
       JSROOT.TooltipHandler.call(this, tframe);
       this.zoom_kind = 0;
-
       this.mode3d = false;
       this.shrink_frame_left = 0.;
       this.x_kind = 'normal'; // 'normal', 'log', 'time', 'labels'
@@ -1387,7 +1387,7 @@
           tframe = this.GetObject();
 
       if ((this.fX1NDC === undefined) || (force && !this.modified_NDC)) {
-         if (!pad) {
+         if (!pad || (pad.fLeftMargin===undefined)) {
             JSROOT.extend(this, JSROOT.gStyle.FrameNDC);
          } else {
             JSROOT.extend(this, {
@@ -1410,8 +1410,10 @@
             this.fillatt.SetSolidColor('white');
       }
 
-      if (pad) this.createAttLine({ color: pad.fFrameLineColor, width: pad.fFrameLineWidth, style: pad.fFrameLineStyle });
-      else this.createAttLine({ attr: tframe, color: 'black' });
+      if (pad && pad.fFrameLineColor!==undefined)
+         this.createAttLine({ color: pad.fFrameLineColor, width: pad.fFrameLineWidth, style: pad.fFrameLineStyle });
+      else
+         this.createAttLine({ attr: tframe, color: 'black' });
    }
 
    TFramePainter.prototype.SizeChanged = function() {

--- a/graf2d/gpadv7/inc/LinkDef.h
+++ b/graf2d/gpadv7/inc/LinkDef.h
@@ -14,6 +14,8 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
+#pragma link C++ class std::vector<std::unique_ptr<ROOT::Experimental::TDisplayItem>>+;
+#pragma link C++ class ROOT::Experimental::TPadDisplayItem+;
 #pragma link C++ class ROOT::Experimental::Detail::TMenuItem+;
 #pragma link C++ class std::vector<ROOT::Experimental::Detail::TMenuItem*>+;
 #pragma link C++ class ROOT::Experimental::Detail::TCheckedMenuItem+;

--- a/graf2d/gpadv7/inc/LinkDef.h
+++ b/graf2d/gpadv7/inc/LinkDef.h
@@ -21,6 +21,7 @@
 #pragma link C++ class std::vector<ROOT::Experimental::Detail::TMenuArgument>+;
 #pragma link C++ class ROOT::Experimental::Detail::TArgsMenuItem+;
 #pragma link C++ class ROOT::Experimental::TMenuItems+;
+#pragma link C++ class ROOT::Experimental::TObjectDrawingOpts+;
 #pragma link C++ class ROOT::Experimental::TObjectDrawable+;
 #pragma link C++ class ROOT::Experimental::Detail::TPadUserAxisBase+;
 #pragma link C++ class ROOT::Experimental::TPadCartesianUserAxis+;

--- a/graf2d/gpadv7/inc/LinkDef.h
+++ b/graf2d/gpadv7/inc/LinkDef.h
@@ -23,6 +23,7 @@
 #pragma link C++ class ROOT::Experimental::TMenuItems+;
 #pragma link C++ class ROOT::Experimental::TObjectDrawingOpts+;
 #pragma link C++ class ROOT::Experimental::TObjectDrawable+;
+#pragma link C++ class ROOT::Experimental::TObjectDisplayItem+;
 #pragma link C++ class ROOT::Experimental::Detail::TPadUserAxisBase+;
 #pragma link C++ class ROOT::Experimental::TPadCartesianUserAxis+;
 #pragma link C++ struct ROOT::Experimental::Internal::TPadHorizVert+;

--- a/graf2d/gpadv7/v7/inc/ROOT/TObjectDrawable.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/TObjectDrawable.hxx
@@ -23,6 +23,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 class TObject;
 

--- a/graf2d/gpadv7/v7/inc/ROOT/TObjectDrawable.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/TObjectDrawable.hxx
@@ -19,6 +19,8 @@
 #include <ROOT/TDrawable.hxx>
 #include <ROOT/TDrawingOptsBase.hxx>
 #include "ROOT/RStringView.hxx"
+#include "ROOT/TDisplayItem.hxx"
+
 #include <memory>
 #include <string>
 
@@ -63,6 +65,15 @@ public:
    /// Executes menu item
    void Execute(const std::string &) final;
 };
+
+class TObjectDisplayItem : public TDisplayItem {
+protected:
+   const TObject *fObject; ///< object to draw
+   std::string fOption;    ///< v6 draw options
+public:
+   TObjectDisplayItem(TObject *obj, const std::string &opt) : fObject(obj), fOption(opt) {}
+};
+
 } // namespace Experimental
 } // namespace ROOT
 
@@ -73,5 +84,6 @@ GetDrawable(const std::shared_ptr<TObject> &obj, const std::string &opt = "")
 {
    return std::make_unique<ROOT::Experimental::TObjectDrawable>(obj, opt);
 }
+
 
 #endif

--- a/graf2d/gpadv7/v7/inc/ROOT/TObjectDrawable.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/TObjectDrawable.hxx
@@ -32,8 +32,8 @@ namespace Experimental {
 class TPadBase;
 
 /// \class ROOT::Experimental::Internal::TObjectDrawingOpts Drawing options for TObject.
-class TObjectDrawingOpts: public TDrawingOptsBase {
-   std::string fOpts;                   ///< The drawing options
+class TObjectDrawingOpts : public TDrawingOptsBase {
+   std::string fOpts; ///< The drawing options
 
 public:
    TObjectDrawingOpts(const std::string &opts = "") : fOpts(opts) {}
@@ -43,13 +43,14 @@ public:
 
 /// \class ROOT::Experimental::Internal::TObjectDrawable
 /// Provides v7 drawing facilities for TObject types (TGraph etc).
-class TObjectDrawable: public TDrawableBase<TObjectDrawable> {
+class TObjectDrawable : public TDrawableBase<TObjectDrawable> {
    const std::shared_ptr<TObject> fObj; ///< The object to be painted
    TObjectDrawingOpts fOpts;
+
 public:
    TObjectDrawable() = default;
 
-   TObjectDrawable(const std::shared_ptr<TObject> &obj, const std::string &opt): fObj(obj), fOpts(opt) {}
+   TObjectDrawable(const std::shared_ptr<TObject> &obj, const std::string &opt) : fObj(obj), fOpts(opt) {}
 
    /// Paint the histogram
    void Paint(Internal::TVirtualCanvasPainter &canv) final;
@@ -84,6 +85,5 @@ GetDrawable(const std::shared_ptr<TObject> &obj, const std::string &opt = "")
 {
    return std::make_unique<ROOT::Experimental::TObjectDrawable>(obj, opt);
 }
-
 
 #endif

--- a/graf2d/gpadv7/v7/inc/ROOT/TPadDisplayItem.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/TPadDisplayItem.hxx
@@ -1,0 +1,47 @@
+/// \file ROOT/TDisplayItem.h
+/// \ingroup Base ROOT7
+/// \author Sergey Linev
+/// \date 2017-05-31
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_TPadDisplayItem
+#define ROOT7_TPadDisplayItem
+
+#include <ROOT/TDisplayItem.hxx>
+
+#include <ROOT/TFrame.hxx>
+
+namespace ROOT {
+namespace Experimental {
+
+// list of snapshot for primitives in pad
+
+using TDisplayItemsVector = std::vector<std::unique_ptr<TDisplayItem>>;
+
+class TPadDisplayItem : public TDisplayItem {
+protected:
+   const TFrame *fFrame{nullptr};   ///< temporary pointer on frame object
+   TDisplayItemsVector fPrimitives; ///< display items for all primitives in the pad
+public:
+   TPadDisplayItem() = default;
+   virtual ~TPadDisplayItem() {}
+   void SetFrame(const TFrame *f) { fFrame = f; }
+   TDisplayItemsVector &GetPrimitives() { return fPrimitives; }
+   void Add(std::unique_ptr<TDisplayItem> &&item) { fPrimitives.push_back(std::move(item)); }
+   TDisplayItem *Last() const { return fPrimitives.back().get(); }
+   void Clear() { fPrimitives.clear(); }
+};
+
+} // Experimental
+} // ROOT
+
+#endif

--- a/graf2d/gpadv7/v7/inc/ROOT/TPadDisplayItem.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/TPadDisplayItem.hxx
@@ -27,6 +27,10 @@ namespace Experimental {
 
 using TDisplayItemsVector = std::vector<std::unique_ptr<TDisplayItem>>;
 
+/// Display item for the pad
+/// Includes different graphical properties of the pad itself plus
+/// list of created items for all primitives
+
 class TPadDisplayItem : public TDisplayItem {
 protected:
    const TFrame *fFrame{nullptr};   ///< temporary pointer on frame object
@@ -37,8 +41,11 @@ public:
    void SetFrame(const TFrame *f) { fFrame = f; }
    TDisplayItemsVector &GetPrimitives() { return fPrimitives; }
    void Add(std::unique_ptr<TDisplayItem> &&item) { fPrimitives.push_back(std::move(item)); }
-   TDisplayItem *Last() const { return fPrimitives.back().get(); }
-   void Clear() { fPrimitives.clear(); }
+   void Clear()
+   {
+      fPrimitives.clear();
+      fFrame = nullptr;
+   }
 };
 
 } // Experimental

--- a/graf2d/gpadv7/v7/inc/ROOT/TVirtualCanvasPainter.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/TVirtualCanvasPainter.hxx
@@ -56,7 +56,7 @@ public:
    virtual bool IsBatchMode() const { return true; }
 
    /// add display item to the canvas
-   virtual void AddDisplayItem(TDisplayItem *item) = 0;
+   virtual void AddDisplayItem(std::unique_ptr<TDisplayItem> &&item) = 0;
 
    /// indicate that canvas changed, provides current version of the canvas
    virtual void CanvasUpdated(uint64_t, bool, CanvasCallback_t) = 0;

--- a/graf2d/gpadv7/v7/src/TObjectDrawable.cxx
+++ b/graf2d/gpadv7/v7/src/TObjectDrawable.cxx
@@ -27,7 +27,7 @@
 
 void ROOT::Experimental::TObjectDrawable::Paint(Internal::TVirtualCanvasPainter &canv)
 {
-   canv.AddDisplayItem(new TObjectDisplayItem(fObj.get(), fOpts.GetOptionString()));
+   canv.AddDisplayItem(std::make_unique<TObjectDisplayItem>(fObj.get(), fOpts.GetOptionString()));
 }
 
 void ROOT::Experimental::TObjectDrawable::PopulateMenu(TMenuItems &items)

--- a/graf2d/gpadv7/v7/src/TObjectDrawable.cxx
+++ b/graf2d/gpadv7/v7/src/TObjectDrawable.cxx
@@ -27,10 +27,7 @@
 
 void ROOT::Experimental::TObjectDrawable::Paint(Internal::TVirtualCanvasPainter &canv)
 {
-   ROOT::Experimental::TDisplayItem *res = new TOrdinaryDisplayItem<TObject>(fObj.get());
-   res->SetOption(fOpts.GetOptionString());
-
-   canv.AddDisplayItem(res);
+   canv.AddDisplayItem(new TObjectDisplayItem(fObj.get(), fOpts.GetOptionString()));
 }
 
 void ROOT::Experimental::TObjectDrawable::PopulateMenu(TMenuItems &items)

--- a/graf2d/gpadv7/v7/src/TObjectDrawable.cxx
+++ b/graf2d/gpadv7/v7/src/TObjectDrawable.cxx
@@ -28,7 +28,7 @@
 void ROOT::Experimental::TObjectDrawable::Paint(Internal::TVirtualCanvasPainter &canv)
 {
    ROOT::Experimental::TDisplayItem *res = new TOrdinaryDisplayItem<TObject>(fObj.get());
-   res->SetOption(fOpts.GetOptionString().c_str());
+   res->SetOption(fOpts.GetOptionString());
 
    canv.AddDisplayItem(res);
 }

--- a/graf2d/primitives/inc/LinkDef.h
+++ b/graf2d/primitives/inc/LinkDef.h
@@ -15,7 +15,6 @@
 #pragma link off all functions;
 
 #pragma link C++ class ROOT::Experimental::TDisplayItem+;
-#pragma link C++ class ROOT::Experimental::TPadDisplayItem+;
 #pragma link C++ class ROOT::Experimental::TPalette+;
 #pragma link C++ class ROOT::Experimental::TColor+;
 #pragma link C++ class ROOT::Experimental::TStringEnumAttr+;

--- a/graf2d/primitives/v7/inc/ROOT/TDisplayItem.hxx
+++ b/graf2d/primitives/v7/inc/ROOT/TDisplayItem.hxx
@@ -32,19 +32,15 @@ class TFrame;
 class TDisplayItem {
 protected:
    std::string fObjectID;   ///< unique object identifier
-   std::string fOption;     ///< draw options, probably need to remove from here
 
 public:
-   TDisplayItem();
+   TDisplayItem() = default;
    TDisplayItem(const TDisplayItem &rhs);
    virtual ~TDisplayItem();
 
    void SetObjectIDAsPtr(void *ptr);
    void SetObjectID(const std::string &id) { fObjectID = id; }
    std::string GetObjectID() const { return fObjectID; }
-
-   void SetOption(const std::string &opt) { fOption = opt; }
-   std::string GetOption() const { return fOption; }
 
    static std::string MakeIDFromPtr(void *ptr);
 };
@@ -56,7 +52,7 @@ protected:
    const TFrame *fFrame{nullptr};               ///< temporary pointer on frame object
    std::vector<TDisplayItem *> fPrimitives;
 public:
-   TPadDisplayItem() : TDisplayItem(), fPrimitives() { }
+   TPadDisplayItem() = default;
    virtual ~TPadDisplayItem();
    void SetFrame(const TFrame *f) { fFrame = f; }
    void Add(TDisplayItem *snap) { fPrimitives.push_back(snap); }
@@ -69,14 +65,14 @@ public:
 template <class T>
 class TOrdinaryDisplayItem : public TDisplayItem {
 protected:
-   const T *fSnapshot;
+   const T *fObject;
 
 public:
-   TOrdinaryDisplayItem(const T *addr) : TDisplayItem(), fSnapshot(addr) {}
-   TOrdinaryDisplayItem(const TOrdinaryDisplayItem<T> &&rhs) : TDisplayItem(rhs), fSnapshot(rhs.fSnapshot) {}
-   virtual ~TOrdinaryDisplayItem() { fSnapshot = 0; }
+   TOrdinaryDisplayItem(const T *addr) : TDisplayItem(), fObject(addr) {}
+   TOrdinaryDisplayItem(const TOrdinaryDisplayItem<T> &&rhs) : TDisplayItem(rhs), fObject(rhs.fObject) {}
+   virtual ~TOrdinaryDisplayItem() {}
 
-   const T *GetSnapshot() const { return fSnapshot; }
+   const T *GetObject() const { return fObject; }
 };
 
 // unique pointer of specified class with ownership
@@ -84,14 +80,14 @@ public:
 template <class T>
 class TUniqueDisplayItem : public TDisplayItem {
 protected:
-   std::unique_ptr<T> fSnapshot;
+   std::unique_ptr<T> fObject;
 
 public:
-   TUniqueDisplayItem(T *addr) : TDisplayItem(), fSnapshot(addr) {}
-   TUniqueDisplayItem(const TUniqueDisplayItem<T> &&rhs) : TDisplayItem(rhs), fSnapshot(std::move(rhs.fSnapshot)) {}
+   TUniqueDisplayItem(T *addr) : TDisplayItem(), fObject(addr) {}
+   TUniqueDisplayItem(const TUniqueDisplayItem<T> &&rhs) : TDisplayItem(rhs), fObject(std::move(rhs.fObject)) {}
    virtual ~TUniqueDisplayItem() {}
 
-   T *GetSnapshot() const { return fSnapshot.get(); }
+   T *GetObject() const { return fObject.get(); }
 };
 
 } // namespace Experimental

--- a/graf2d/primitives/v7/inc/ROOT/TDisplayItem.hxx
+++ b/graf2d/primitives/v7/inc/ROOT/TDisplayItem.hxx
@@ -31,12 +31,11 @@ class TFrame;
 
 class TDisplayItem {
 protected:
-   std::string fObjectID;   ///< unique object identifier
+   std::string fObjectID; ///< unique object identifier
 
 public:
    TDisplayItem() = default;
-   TDisplayItem(const TDisplayItem &rhs);
-   virtual ~TDisplayItem();
+   virtual ~TDisplayItem() {}
 
    void SetObjectIDAsPtr(void *ptr);
    void SetObjectID(const std::string &id) { fObjectID = id; }
@@ -49,8 +48,8 @@ public:
 
 class TPadDisplayItem : public TDisplayItem {
 protected:
-   const TFrame *fFrame{nullptr};               ///< temporary pointer on frame object
-   std::vector<TDisplayItem *> fPrimitives;
+   const TFrame *fFrame{nullptr};           ///< temporary pointer on frame object
+   std::vector<TDisplayItem *> fPrimitives; ///< display items for all primitives in the pad
 public:
    TPadDisplayItem() = default;
    virtual ~TPadDisplayItem();
@@ -65,12 +64,10 @@ public:
 template <class T>
 class TOrdinaryDisplayItem : public TDisplayItem {
 protected:
-   const T *fObject;
+   const T *fObject{nullptr};
 
 public:
    TOrdinaryDisplayItem(const T *addr) : TDisplayItem(), fObject(addr) {}
-   TOrdinaryDisplayItem(const TOrdinaryDisplayItem<T> &&rhs) : TDisplayItem(rhs), fObject(rhs.fObject) {}
-   virtual ~TOrdinaryDisplayItem() {}
 
    const T *GetObject() const { return fObject; }
 };
@@ -84,8 +81,6 @@ protected:
 
 public:
    TUniqueDisplayItem(T *addr) : TDisplayItem(), fObject(addr) {}
-   TUniqueDisplayItem(const TUniqueDisplayItem<T> &&rhs) : TDisplayItem(rhs), fObject(std::move(rhs.fObject)) {}
-   virtual ~TUniqueDisplayItem() {}
 
    T *GetObject() const { return fObject.get(); }
 };

--- a/graf2d/primitives/v7/inc/ROOT/TDisplayItem.hxx
+++ b/graf2d/primitives/v7/inc/ROOT/TDisplayItem.hxx
@@ -44,27 +44,12 @@ public:
    static std::string MakeIDFromPtr(void *ptr);
 };
 
-// list of snapshot for primitives in pad
-
-class TPadDisplayItem : public TDisplayItem {
-protected:
-   const TFrame *fFrame{nullptr};           ///< temporary pointer on frame object
-   std::vector<TDisplayItem *> fPrimitives; ///< display items for all primitives in the pad
-public:
-   TPadDisplayItem() = default;
-   virtual ~TPadDisplayItem();
-   void SetFrame(const TFrame *f) { fFrame = f; }
-   void Add(TDisplayItem *snap) { fPrimitives.push_back(snap); }
-   TDisplayItem *Last() const { return fPrimitives[fPrimitives.size() - 1]; }
-   void Clear();
-};
-
 // direct pointer to some object without ownership
 
 template <class T>
 class TOrdinaryDisplayItem : public TDisplayItem {
 protected:
-   const T *fObject{nullptr};
+   const T *fObject{nullptr}; ///<  direct pointer without ownership
 
 public:
    TOrdinaryDisplayItem(const T *addr) : TDisplayItem(), fObject(addr) {}

--- a/graf2d/primitives/v7/inc/ROOT/TDisplayItem.hxx
+++ b/graf2d/primitives/v7/inc/ROOT/TDisplayItem.hxx
@@ -31,9 +31,8 @@ class TFrame;
 
 class TDisplayItem {
 protected:
-   std::string fObjectID;
-   std::string fOption;
-   int fKind;
+   std::string fObjectID;   ///< unique object identifier
+   std::string fOption;     ///< draw options, probably need to remove from here
 
 public:
    TDisplayItem();
@@ -47,9 +46,6 @@ public:
    void SetOption(const std::string &opt) { fOption = opt; }
    std::string GetOption() const { return fOption; }
 
-   void SetKind(int kind) { fKind = kind; }
-   int GetKind() const { return fKind; }
-
    static std::string MakeIDFromPtr(void *ptr);
 };
 
@@ -57,10 +53,10 @@ public:
 
 class TPadDisplayItem : public TDisplayItem {
 protected:
-   const TFrame *fFrame{nullptr};         ///! temporary pointer on frame object
+   const TFrame *fFrame{nullptr};               ///< temporary pointer on frame object
    std::vector<TDisplayItem *> fPrimitives;
 public:
-   TPadDisplayItem() : TDisplayItem(), fPrimitives() { SetKind(3); }
+   TPadDisplayItem() : TDisplayItem(), fPrimitives() { }
    virtual ~TPadDisplayItem();
    void SetFrame(const TFrame *f) { fFrame = f; }
    void Add(TDisplayItem *snap) { fPrimitives.push_back(snap); }
@@ -76,7 +72,7 @@ protected:
    const T *fSnapshot;
 
 public:
-   TOrdinaryDisplayItem(const T *addr) : TDisplayItem(), fSnapshot(addr) { SetKind(1); }
+   TOrdinaryDisplayItem(const T *addr) : TDisplayItem(), fSnapshot(addr) {}
    TOrdinaryDisplayItem(const TOrdinaryDisplayItem<T> &&rhs) : TDisplayItem(rhs), fSnapshot(rhs.fSnapshot) {}
    virtual ~TOrdinaryDisplayItem() { fSnapshot = 0; }
 
@@ -91,7 +87,7 @@ protected:
    std::unique_ptr<T> fSnapshot;
 
 public:
-   TUniqueDisplayItem(T *addr) : TDisplayItem(), fSnapshot(addr) { SetKind(1); }
+   TUniqueDisplayItem(T *addr) : TDisplayItem(), fSnapshot(addr) {}
    TUniqueDisplayItem(const TUniqueDisplayItem<T> &&rhs) : TDisplayItem(rhs), fSnapshot(std::move(rhs.fSnapshot)) {}
    virtual ~TUniqueDisplayItem() {}
 

--- a/graf2d/primitives/v7/inc/ROOT/TDisplayItem.hxx
+++ b/graf2d/primitives/v7/inc/ROOT/TDisplayItem.hxx
@@ -41,11 +41,11 @@ public:
    virtual ~TDisplayItem();
 
    void SetObjectIDAsPtr(void *ptr);
-   void SetObjectID(const char *id) { fObjectID = id; }
-   const char *GetObjectID() const { return fObjectID.c_str(); }
+   void SetObjectID(const std::string &id) { fObjectID = id; }
+   std::string GetObjectID() const { return fObjectID; }
 
-   void SetOption(const char *opt) { fOption = opt; }
-   const char *GetOption() { return fOption.c_str(); }
+   void SetOption(const std::string &opt) { fOption = opt; }
+   std::string GetOption() const { return fOption; }
 
    void SetKind(int kind) { fKind = kind; }
    int GetKind() const { return fKind; }

--- a/graf2d/primitives/v7/inc/ROOT/TText.hxx
+++ b/graf2d/primitives/v7/inc/ROOT/TText.hxx
@@ -63,9 +63,9 @@ public:
    double GetY() const { return fY; }
 };
 
-class TextDrawingOpts: public TDrawingOptsBase {
-   TDrawingAttr<int> fLineWidth{*this, "Text.Line.Width", 3}; ///< The line width.
-   TDrawingAttr<TColor> fLineColor{*this, "Text.Line.Color", TColor::kBlack}; ///< The line color.
+class TextDrawingOpts : public TDrawingOptsBase {
+   TDrawingAttr<int> fLineWidth{*this, "Text.Line.Width", 3};                     ///< The line width.
+   TDrawingAttr<TColor> fLineColor{*this, "Text.Line.Color", TColor::kBlack};     ///< The line color.
    TDrawingAttr<TColor> fFillColor{*this, "Text.Fill.Color", TColor::kInvisible}; ///< The fill color.
 
 public:
@@ -96,17 +96,15 @@ private:
 public:
    TTextDrawable() = default;
 
-   TTextDrawable(const std::shared_ptr<ROOT::Experimental::TText> &txt)
-      : fText(txt)
-   {
-   }
+   TTextDrawable(const std::shared_ptr<ROOT::Experimental::TText> &txt) : fText(txt) {}
 
    TextDrawingOpts &GetOptions() { return fOpts; }
    const TextDrawingOpts &GetOptions() const { return fOpts; }
 
    void Paint(Internal::TVirtualCanvasPainter &canv) final
    {
-      canv.AddDisplayItem(new ROOT::Experimental::TOrdinaryDisplayItem<ROOT::Experimental::TTextDrawable>(this));
+      canv.AddDisplayItem(
+         std::make_unique<ROOT::Experimental::TOrdinaryDisplayItem<ROOT::Experimental::TTextDrawable>>(this));
    }
 };
 

--- a/graf2d/primitives/v7/src/TDisplayItem.cxx
+++ b/graf2d/primitives/v7/src/TDisplayItem.cxx
@@ -17,12 +17,8 @@
 
 #include "TString.h"
 
-ROOT::Experimental::TDisplayItem::TDisplayItem() : fObjectID(), fOption()
-{
-}
-
 ROOT::Experimental::TDisplayItem::TDisplayItem(const TDisplayItem &rhs)
-   : fObjectID(rhs.fObjectID), fOption(rhs.fOption)
+   : fObjectID(rhs.fObjectID)
 {
 }
 
@@ -34,8 +30,7 @@ ROOT::Experimental::TDisplayItem::~TDisplayItem()
 std::string ROOT::Experimental::TDisplayItem::MakeIDFromPtr(void *ptr)
 {
    UInt_t hash = TString::Hash(&ptr, sizeof(ptr));
-   TString res = TString::UItoa(hash, 10);
-   return std::string(res.Data());
+   return std::to_string(hash);
 }
 
 void ROOT::Experimental::TDisplayItem::SetObjectIDAsPtr(void *ptr)

--- a/graf2d/primitives/v7/src/TDisplayItem.cxx
+++ b/graf2d/primitives/v7/src/TDisplayItem.cxx
@@ -41,7 +41,7 @@ std::string ROOT::Experimental::TDisplayItem::MakeIDFromPtr(void *ptr)
 void ROOT::Experimental::TDisplayItem::SetObjectIDAsPtr(void *ptr)
 {
    std::string id = MakeIDFromPtr(ptr);
-   SetObjectID(id.c_str());
+   SetObjectID(id);
 }
 
 // =================

--- a/graf2d/primitives/v7/src/TDisplayItem.cxx
+++ b/graf2d/primitives/v7/src/TDisplayItem.cxx
@@ -17,12 +17,12 @@
 
 #include "TString.h"
 
-ROOT::Experimental::TDisplayItem::TDisplayItem() : fObjectID(), fOption(), fKind(0)
+ROOT::Experimental::TDisplayItem::TDisplayItem() : fObjectID(), fOption()
 {
 }
 
 ROOT::Experimental::TDisplayItem::TDisplayItem(const TDisplayItem &rhs)
-   : fObjectID(rhs.fObjectID), fOption(rhs.fOption), fKind(rhs.fKind)
+   : fObjectID(rhs.fObjectID), fOption(rhs.fOption)
 {
 }
 

--- a/graf2d/primitives/v7/src/TDisplayItem.cxx
+++ b/graf2d/primitives/v7/src/TDisplayItem.cxx
@@ -28,18 +28,3 @@ void ROOT::Experimental::TDisplayItem::SetObjectIDAsPtr(void *ptr)
    std::string id = MakeIDFromPtr(ptr);
    SetObjectID(id);
 }
-
-// =================
-
-ROOT::Experimental::TPadDisplayItem::~TPadDisplayItem()
-{
-   Clear();
-}
-
-void ROOT::Experimental::TPadDisplayItem::Clear()
-{
-   fFrame = nullptr;
-   for (unsigned n = 0; n < fPrimitives.size(); ++n)
-      delete fPrimitives[n];
-   fPrimitives.clear();
-}

--- a/graf2d/primitives/v7/src/TDisplayItem.cxx
+++ b/graf2d/primitives/v7/src/TDisplayItem.cxx
@@ -17,16 +17,6 @@
 
 #include "TString.h"
 
-ROOT::Experimental::TDisplayItem::TDisplayItem(const TDisplayItem &rhs)
-   : fObjectID(rhs.fObjectID)
-{
-}
-
-// pin vtable
-ROOT::Experimental::TDisplayItem::~TDisplayItem()
-{
-}
-
 std::string ROOT::Experimental::TDisplayItem::MakeIDFromPtr(void *ptr)
 {
    UInt_t hash = TString::Hash(&ptr, sizeof(ptr));
@@ -49,6 +39,7 @@ ROOT::Experimental::TPadDisplayItem::~TPadDisplayItem()
 void ROOT::Experimental::TPadDisplayItem::Clear()
 {
    fFrame = nullptr;
-   for (unsigned n = 0; n < fPrimitives.size(); ++n) delete fPrimitives[n];
+   for (unsigned n = 0; n < fPrimitives.size(); ++n)
+      delete fPrimitives[n];
    fPrimitives.clear();
 }

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -203,12 +203,13 @@ private:
 
    std::shared_ptr<TWebWindow> fWindow; ///!< configured display
 
-   WebConnList fWebConn;         ///<! connections list
-   bool fHadWebConn;             ///<! true if any connection were existing
-   TPadDisplayItem fDisplayList; ///!< full list of items to display
-   WebCommandsList fCmds;        ///!< list of submitted commands
-   uint64_t fCmdsCnt;            ///!< commands counter
-   std::string fWaitingCmdId;    ///!< command id waited for completion
+   WebConnList fWebConn;           ///<! connections list
+   bool fHadWebConn;               ///<! true if any connection were existing
+   TPadDisplayItem fDisplayList;   ///!< full list of items to display
+   std::string fCurrentDrawableId; ///!< id of drawable, which paint method is called
+   WebCommandsList fCmds;          ///!< list of submitted commands
+   uint64_t fCmdsCnt;              ///!< commands counter
+   std::string fWaitingCmdId;      ///!< command id waited for completion
 
    uint64_t fSnapshotVersion;   ///!< version of snapshot
    std::string fSnapshot;       ///!< last produced snapshot
@@ -255,7 +256,11 @@ public:
    /// returns true is canvas used in batch mode
    virtual bool IsBatchMode() const override { return fBatchMode; }
 
-   virtual void AddDisplayItem(std::unique_ptr<TDisplayItem> &&item) override { fDisplayList.Add(std::move(item)); }
+   virtual void AddDisplayItem(std::unique_ptr<TDisplayItem> &&item) override
+   {
+      item->SetObjectID(fCurrentDrawableId);
+      fDisplayList.Add(std::move(item));
+   }
 
    virtual void CanvasUpdated(uint64_t ver, bool async, ROOT::Experimental::CanvasCallback_t callback) override;
 
@@ -690,9 +695,11 @@ std::string ROOT::Experimental::TCanvasPainter::CreateSnapshot(const ROOT::Exper
 
    for (auto &&drawable : can.GetPrimitives()) {
 
+      fCurrentDrawableId = TDisplayItem::MakeIDFromPtr(drawable.get());
+
       drawable->Paint(*this);
 
-      fDisplayList.Last()->SetObjectIDAsPtr(&(*drawable));
+      // fDisplayList.Last()->SetObjectIDAsPtr(&(*drawable));
 
       // ROOT::Experimental::TDisplayItem *sub = drawable->CreateSnapshot(can);
       // if (!sub) continue;

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -17,6 +17,7 @@
 #include "ROOT/TCanvas.hxx"
 #include <ROOT/TLogger.hxx>
 #include <ROOT/TDisplayItem.hxx>
+#include <ROOT/TPadDisplayItem.hxx>
 #include <ROOT/TMenuItem.hxx>
 
 #include <ROOT/TWebWindow.hxx>
@@ -254,7 +255,7 @@ public:
    /// returns true is canvas used in batch mode
    virtual bool IsBatchMode() const override { return fBatchMode; }
 
-   virtual void AddDisplayItem(TDisplayItem *item) override { fDisplayList.Add(item); }
+   virtual void AddDisplayItem(std::unique_ptr<TDisplayItem> &&item) override { fDisplayList.Add(std::move(item)); }
 
    virtual void CanvasUpdated(uint64_t ver, bool async, ROOT::Experimental::CanvasCallback_t callback) override;
 
@@ -699,7 +700,7 @@ std::string ROOT::Experimental::TCanvasPainter::CreateSnapshot(const ROOT::Exper
       // lst.Add(sub);
    }
 
-   TString res = TBufferJSON::ToJSON(&fDisplayList  /*, 23 */);
+   TString res = TBufferJSON::ToJSON(&fDisplayList /*, 23 */);
 
    // TBufferJSON::ExportToFile("canv.json", &fDisplayList, gROOT->GetClass("ROOT::Experimental::TPadDisplayItem"));
 

--- a/hist/histpainter/v7/src/THistPainter.cxx
+++ b/hist/histpainter/v7/src/THistPainter.cxx
@@ -26,7 +26,7 @@ using namespace ROOT::Experimental;
 using namespace ROOT::Experimental::Internal;
 
 namespace {
-class THistPainter1D: public THistPainterBase<1> {
+class THistPainter1D : public THistPainterBase<1> {
 public:
    void Paint(TDrawable &drw, const THistDrawingOpts<1> & /*opts*/, TVirtualCanvasPainter &canv) final
    {
@@ -36,15 +36,13 @@ public:
       assert(dynamic_cast<THistDrawable<1> *>(&drw) && "Wrong drawable type");
       THistDrawable<1> &hd = static_cast<THistDrawable<1> &>(drw);
 
-      ROOT::Experimental::TDisplayItem *res = new ROOT::Experimental::TOrdinaryDisplayItem<ROOT::Experimental::THistDrawable<1>>(&hd);
-      // res->SetOption("col");
-
-      canv.AddDisplayItem(res);
+      canv.AddDisplayItem(
+         std::make_unique<ROOT::Experimental::TOrdinaryDisplayItem<ROOT::Experimental::THistDrawable<1>>>(&hd));
    }
    virtual ~THistPainter1D() final {}
 };
 
-class THistPainter2D: public THistPainterBase<2> {
+class THistPainter2D : public THistPainterBase<2> {
 public:
    void Paint(TDrawable &drw, const THistDrawingOpts<2> & /*opts*/, TVirtualCanvasPainter &canv) final
    {
@@ -52,17 +50,13 @@ public:
       assert(dynamic_cast<THistDrawable<2> *>(&drw) && "Wrong drawable type");
       THistDrawable<2> &hd = static_cast<THistDrawable<2> &>(drw);
 
-      ROOT::Experimental::TDisplayItem *res = new ROOT::Experimental::TOrdinaryDisplayItem<ROOT::Experimental::THistDrawable<2>>(&hd);
-      // res->SetOption("col");
-
-      canv.AddDisplayItem(res);
-
-      // hd.GetOldHist()->Paint("BOX");
+      canv.AddDisplayItem(
+         std::make_unique<ROOT::Experimental::TOrdinaryDisplayItem<ROOT::Experimental::THistDrawable<2>>>(&hd));
    }
    virtual ~THistPainter2D() final {}
 };
 
-class THistPainter3D: public THistPainterBase<3> {
+class THistPainter3D : public THistPainterBase<3> {
 public:
    void Paint(TDrawable &hist, const THistDrawingOpts<3> & /*opts*/, TVirtualCanvasPainter & /*canv*/) final
    {


### PR DESCRIPTION
These classes reflect information, which used in clients for display.

Base class only includes displayed object id.
It set by canvas itself and used later to identify object in interactive actions.
Any additional info (like drawing options) provided in appropriate derived classes.

Main change in ``TPadDisplayItem``, which belongs to gpadv7 and uses ``std::vector<std::unique_ptr<TDisplayItem>>`` to claim ownership of temporary-created items for each primitive.

Adjust JSROOT code to correctly display ROOT6 objects in ROOT7 canvas