### PR TITLE
Fixing requirement that all ROOT be available for Minuit2

### DIFF
--- a/math/mathcore/inc/Math/IFunctionfwd.h
+++ b/math/mathcore/inc/Math/IFunctionfwd.h
@@ -13,8 +13,6 @@
 #ifndef ROOT_Math_IFunctionfwd
 #define ROOT_Math_IFunctionfwd
 
-#include "Types.h"
-
 namespace ROOT {
 
    namespace Math {

--- a/math/mathcore/inc/Math/Util.h
+++ b/math/mathcore/inc/Math/Util.h
@@ -18,7 +18,14 @@
 
 #include <cmath>
 #include <limits>
+
+
+// This can be protected against by defining ROOT_Math_VecTypes
+// This is only used for the R__HAS_VECCORE define
+// and a single VecCore function in EvalLog
+#ifndef ROOT_Math_VecTypes
 #include "Types.h"
+#endif
 
 
 // for defining unused variables in the interfaces
@@ -55,10 +62,10 @@ namespace ROOT {
    template<class T>
    inline T EvalLog(T x) {
       static const T epsilon = T(2.0 * std::numeric_limits<double>::min());
-#if !defined(R__HAS_VECCORE)
-      T logval = x <= epsilon ? x / epsilon + std::log(epsilon) - T(1.0) : std::log(x);
-#else
+#ifdef R__HAS_VECCORE
       T logval = vecCore::Blend<T>(x <= epsilon, x / epsilon + std::log(epsilon) - T(1.0), std::log(x));
+#else
+      T logval = x <= epsilon ? x / epsilon + std::log(epsilon) - T(1.0) : std::log(x);
 #endif
       return logval;
    }


### PR DESCRIPTION
This is a very conservative proposed solution to [ROOT-9274](https://sft.its.cern.ch/jira/projects/ROOT/issues/ROOT-9274), where one unneeded `Types.h` usage is removed and one more is wrapped in a protector. This allows a build system to turn off the including of `Types.h` if required.

A slightly less conservative one would be to include `RConfigure.h` instead of `Types.h`, then `VecCore/VecCore` if the vec core define is on. It is possible that a user might want the side effects of `Types.h`, and Types does include `vc/vc` before VecCore, and I'm not sure if that's needed on first import, so I left this conservative.