### PR TITLE
Remove TClingClassInfo iteration

### DIFF
--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -142,6 +142,14 @@ TClingClassInfo::TClingClassInfo(cling::Interpreter *interp,
    Init(tag);
 }
 
+TClingClassInfo::TClingClassInfo(cling::Interpreter *interp,
+                                 const Decl *D)
+   : fInterp(interp), fFirstTime(true), fDescend(false), fIterAll(kTRUE),
+     fIsIter(false), fDecl(0), fType(0), fTitle(""), fOffsetCache(0)
+{
+   Init(D);
+}
+
 void TClingClassInfo::AddBaseOffsetValue(const clang::Decl* decl, ptrdiff_t offset)
 {
    // Add the offset value from this class to the non-virtual base class

--- a/core/metacling/src/TClingClassInfo.h
+++ b/core/metacling/src/TClingClassInfo.h
@@ -81,6 +81,7 @@ public:
    explicit TClingClassInfo(cling::Interpreter *, Bool_t all = kTRUE);
    explicit TClingClassInfo(cling::Interpreter *, const char *);
    explicit TClingClassInfo(cling::Interpreter *, const clang::Type &);
+   explicit TClingClassInfo(cling::Interpreter *, const clang::Decl *);
    void                 AddBaseOffsetFunction(const clang::Decl* decl, OffsetPtrFunc_t func) { fOffsetCache[decl] = std::make_pair(0L, func); }
    void                 AddBaseOffsetValue(const clang::Decl* decl, ptrdiff_t offset);
    long                 ClassProperty() const;

--- a/core/metacling/src/TClingDataMemberInfo.cxx
+++ b/core/metacling/src/TClingDataMemberInfo.cxx
@@ -78,7 +78,7 @@ TClingDataMemberInfo::TClingDataMemberInfo(cling::Interpreter *interp,
 TClingDataMemberInfo::TClingDataMemberInfo(cling::Interpreter *interp,
                                            const clang::ValueDecl *ValD,
                                            TClingClassInfo *ci)
-: fInterp(interp), fClassInfo(ci ? new TClingClassInfo(*ci) : new TClingClassInfo(interp)), fFirstTime(true),
+: fInterp(interp), fClassInfo(ci ? new TClingClassInfo(*ci) : new TClingClassInfo(interp, ValD)), fFirstTime(true),
     fTitle(""), fSingleDecl(ValD), fContextIdx(0U), fIoType(""), fIoName(""){
 
    using namespace llvm;


### PR DESCRIPTION
Do not set up the iterator in the ctor.
    
Many interfaces in ROOT namely TCling do not need to iterate over decls to find what they look for. They use the regular lookup facilities which are provided by cling or clang.
    
In a few cases we still use the pattern:
`TClingClassInfo(fInterpreter) ci; ci.GetDataMember(..);`
where we are supposed to look for a ROOT's definition of a data member on the global scope. In turn, this pattern does not walk the decls but performs a 'regular' lookup.
    
This patch removes the expensive setup of the iterators (triggering humongous amount of deserializations). We lazily set up the iterators only when we are about to start iterating (most notably coming from the legacy PyROOT interfaces).
