### PR TITLE
extended output of rms-validation in tmva/TransformationHandler

### DIFF
--- a/tmva/tmva/src/TransformationHandler.cxx
+++ b/tmva/tmva/src/TransformationHandler.cxx
@@ -115,10 +115,11 @@ TMVA::VariableTransformBase* TMVA::TransformationHandler::AddTransformation( Var
 
 void TMVA::TransformationHandler::AddStats( Int_t k, UInt_t ivar, Double_t mean, Double_t rms, Double_t min, Double_t max )
 {
-   if (rms <= 0) {
+   if (rms <= 0 || TMath::IsNaN(rms)) {
       Log() << kWARNING << "Variable \"" << Variable(ivar).GetExpression()
-            << "\" has zero or negative RMS^2 "
-            << "==> set to zero. Please check the variable content" << Endl;
+            << "\" has zero, negative, or NaN RMS^2: "
+            << rms
+            << " ==> set to zero. Please check the variable content" << Endl;
       rms = 0;
    }
 


### PR DESCRIPTION
 - add check if rms is NaN
 - output value of rms (zero, negative, or NaN)
 - set rms to zero if it is NaN (before only done for zero or negative values)

→ I suspect the training will have problems in that situation anyway but **I think** it makes the message easier to digest:

before:
```
…
<WARNING> <WARNING>                : Dataset[Default] : <GetCorrelationMatrix> Zero variances for variables (0, 2) = -2.14875e-05
…
<HEADER> TFHandler_Factory        :            Variable                   Mean                   RMS           [        Min                   Max ]
                         : ------------------------------------------------------------------------------------------------------------------
                         :            LifeTime:            0.0011344                 -nan   [           8.5046e-05             0.024133 ]

…
                         : Some more output
                         : -nan -nan -nan -nan -nan -nan
<FATAL>                          : <GetSeparation> signal and background histograms have different or invalid dimensions:
***> abort program execution
terminate called after throwing an instance of 'std::runtime_error'
  what():  FATAL error

```
after
```
…
<WARNING> <WARNING>                : Dataset[Default] : <GetCorrelationMatrix> Zero variances for variables (0, 2) = -2.14875e-05
…
<WARNING> <WARNING>                : Variable "LifeTime" has zero, negative, or NaN RMS^2: -nan ==> set to zero. Please check the variable content

```
I.e. the nan does not appear in the table anymore (where I didn't spot it first) but the abnormal value gets pulled out into a WARNING message. (Where it also comes with variable name, as opposed to the long list of correlation matrix warning, which makes it non-trivial to understand which variables are problematic, if many, and comes w/o human readable names)

tbh: I have not yet understood why NaN arrives there (… well a few lines before the √ of a negative number is computed … but I don't yet know why that arrived there. Still investigating, will follow up once I know more).