### PR TITLE
Use /bin/env instead of /usr/bin/env in shell scripts

### DIFF
--- a/bindings/pyroot/JupyROOT/kernel/rootkernel.py
+++ b/bindings/pyroot/JupyROOT/kernel/rootkernel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/bin/env python
 # -*- coding:utf-8 -*-
 #-----------------------------------------------------------------------------
 #  Copyright (c) 2015, ROOT Team.

--- a/bindings/ruby/test/test_rr.rb
+++ b/bindings/ruby/test/test_rr.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/bin/env ruby
 
 require 'libRuby'
 require 'test/unit'

--- a/build/unix/compiledata.sh
+++ b/build/unix/compiledata.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/env bash
 
 # Script to generate the file include/compiledata.h.
 # Called by main Makefile.

--- a/build/unix/githeader.sh
+++ b/build/unix/githeader.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/env bash
 
 # Generate the header file from the Store info about in which git branch, what SHA1 and at what date/time
 # we executed make.

--- a/build/unix/gitinfo.sh
+++ b/build/unix/gitinfo.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/env bash
 
 # Store info about in which git branch, what SHA1 and at what date/time
 # we executed make.

--- a/build/unix/gitinfollvm.sh
+++ b/build/unix/gitinfollvm.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/env bash
 
 # Check version of interpreter/llvm directory and if it is changed force
 # a make in the LLVM tree. It creates the file

--- a/config/root-config.in
+++ b/config/root-config.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/env bash
 # -*- sh-indentation: 3 -*-
 # This script returns the machine dependent compile options needed
 # to compile and link applications using the ROOT libraries.

--- a/documentation/doxygen/converttonotebook.py
+++ b/documentation/doxygen/converttonotebook.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/bin/env python
 # Author: Pau Miquel i Mir <pau.miquel.mir@cern.ch> <pmm1g15@soton.ac.uk>>
 # Date: July, 2016
 #

--- a/main/python/cmdLineUtils.py
+++ b/main/python/cmdLineUtils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env @python@
+#!/bin/env @python@
 
 # ROOT command line tools module: cmdLineUtils
 # Author: Julien Ripoche

--- a/main/python/rootbrowse.py
+++ b/main/python/rootbrowse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env @python@
+#!/bin/env @python@
 
 # ROOT command line tools: rootbrowse
 # Author: Julien Ripoche

--- a/main/python/rootcp.py
+++ b/main/python/rootcp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env @python@
+#!/bin/env @python@
 
 # ROOT command line tools: rootcp
 # Author: Julien Ripoche

--- a/main/python/rootdrawtree.py
+++ b/main/python/rootdrawtree.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env @python@
+#!/bin/env @python@
 
 # ROOT command line tools: rootdrawtree
 # Author: Luca Giommi

--- a/main/python/rooteventselector.py
+++ b/main/python/rooteventselector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env @python@
+#!/bin/env @python@
 
 # ROOT command line tools: rooteventselector
 # Author: Julien Ripoche

--- a/main/python/rootls.py
+++ b/main/python/rootls.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env @python@
+#!/bin/env @python@
 
 # ROOT command line tools: rootls
 # Author: Julien Ripoche

--- a/main/python/rootmkdir.py
+++ b/main/python/rootmkdir.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env @python@
+#!/bin/env @python@
 
 # ROOT command line tools: rootmkdir
 # Author: Julien Ripoche

--- a/main/python/rootmv.py
+++ b/main/python/rootmv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env @python@
+#!/bin/env @python@
 
 # ROOT command line tools: rootmv
 # Author: Julien Ripoche

--- a/main/python/rootprint.py
+++ b/main/python/rootprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env @python@
+#!/bin/env @python@
 
 # ROOT command line tools: rootprint
 # Author: Julien Ripoche

--- a/main/python/rootrm.py
+++ b/main/python/rootrm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env @python@
+#!/bin/env @python@
 
 # ROOT command line tools: rootrm
 # Author: Julien Ripoche

--- a/main/python/rootslimtree.py
+++ b/main/python/rootslimtree.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env @python@
+#!/bin/env @python@
 
 # ROOT command line tools: rootslimtree
 # Author: Lawrence Lee via Julien Ripoche's rooteventselector

--- a/tutorials/histfactory/example.py
+++ b/tutorials/histfactory/example.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/bin/env python
 
 #
 # A pyROOT script demonstrating

--- a/tutorials/histfactory/makeQuickModel.py
+++ b/tutorials/histfactory/makeQuickModel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/bin/env python
 
 #
 # A pyROOT script that allows one to

--- a/tutorials/tmva/keras/ApplicationClassificationKeras.py
+++ b/tutorials/tmva/keras/ApplicationClassificationKeras.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/bin/env python
 
 from ROOT import TMVA, TFile, TString
 from array import array

--- a/tutorials/tmva/keras/ApplicationRegressionKeras.py
+++ b/tutorials/tmva/keras/ApplicationRegressionKeras.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/bin/env python
 
 from ROOT import TMVA, TFile, TString
 from array import array

--- a/tutorials/tmva/keras/ClassificationKeras.py
+++ b/tutorials/tmva/keras/ClassificationKeras.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/bin/env python
 
 from ROOT import TMVA, TFile, TTree, TCut
 from subprocess import call

--- a/tutorials/tmva/keras/GenerateModel.py
+++ b/tutorials/tmva/keras/GenerateModel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/bin/env python
 
 from keras.models import Sequential
 from keras.layers.core import Dense, Activation

--- a/tutorials/tmva/keras/MulticlassKeras.py
+++ b/tutorials/tmva/keras/MulticlassKeras.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/bin/env python
 
 from ROOT import TMVA, TFile, TTree, TCut, gROOT
 from os.path import isfile

--- a/tutorials/tmva/keras/RegressionKeras.py
+++ b/tutorials/tmva/keras/RegressionKeras.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/bin/env python
 
 from ROOT import TMVA, TFile, TTree, TCut
 from subprocess import call


### PR DESCRIPTION
This improves portability since /usr/bin/env is not always guaranteed
to be there. This is true for some container images, and some old unix
variants.

I found this out trying to build ROOT inside a container myself...