### PR TITLE
Don't install intermediate static lib minicern

### DIFF
--- a/misc/minicern/CMakeLists.txt
+++ b/misc/minicern/CMakeLists.txt
@@ -3,7 +3,7 @@
 ############################################################################
 
 set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fPIC")
-ROOT_LINKER_LIBRARY(minicern *.c *.f TYPE STATIC)
+ROOT_LINKER_LIBRARY(minicern *.c *.f TYPE STATIC NOINSTALL)
 target_link_libraries(minicern ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES})
 
 # Disable optimization since it some cases was causing crashes.


### PR DESCRIPTION
This change was split off from #1643 since it suggested that it needed to be postponed until 6.14.