### PR TITLE
Minuit2 fixes

### DIFF
--- a/math/minuit2/inc/Minuit2/CombinedMinimumBuilder.h
+++ b/math/minuit2/inc/Minuit2/CombinedMinimumBuilder.h
@@ -31,7 +31,7 @@ public:
    virtual FunctionMinimum Minimum(const MnFcn&, const GradientCalculator&, const MinimumSeed&, const MnStrategy&, unsigned int, double) const;
 
    //re-implement setter of base class. Need also to store in the base class for consistency
-   virtual void SetPrintLevel(int level) {
+   virtual void SetPrintLevel(int level) const {
       MinimumBuilder::SetPrintLevel(level);
       fVMMinimizer.Builder().SetPrintLevel(level);
       fSimplexMinimizer.Builder().SetPrintLevel(level);

--- a/math/minuit2/inc/Minuit2/MinimumBuilder.h
+++ b/math/minuit2/inc/Minuit2/MinimumBuilder.h
@@ -40,7 +40,7 @@ public:
    bool TraceIter() const { return (fTracer); }
    MnTraceObject * TraceObject() const { return (fTracer); }
 
-   virtual void SetPrintLevel(int level) { fPrintLevel = level;}
+   virtual void SetPrintLevel(int level) const { fPrintLevel = level;}
    virtual void SetStorageLevel(int level) { fStorageLevel = level;}
 
    // set trace object (user manages it)
@@ -54,7 +54,7 @@ public:
 
 private:
 
-   int fPrintLevel;
+   mutable int fPrintLevel;
    int fStorageLevel;
 
    MnTraceObject * fTracer; //! tracer object (it is managed by user)

--- a/math/minuit2/src/MinimumBuilder.cxx
+++ b/math/minuit2/src/MinimumBuilder.cxx
@@ -8,10 +8,7 @@
  **********************************************************************/
 
 #include "Minuit2/MinimumBuilder.h"
-
-#if defined(DEBUG) || defined(WARNINGMSG)
 #include "Minuit2/MnPrint.h"
-#endif
 
 
 namespace ROOT {


### PR DESCRIPTION
Hi, I am one of the iminuit developers (https://github.com/iminuit/iminuit).

We are glad that Minuit2 is still usable as a package separate from ROOT and thank the ROOT developers for that. It makes our life much easier.

The iminuit package is build by copying the Minuit2 code in ROOT and building a Cython wrapper around it. Because we compile and use the Minuit2 code outside of the ROOT build environment, we found and fixed some bugs, which we would like to merge upstream in ROOT as well. Each of the two commits in this PR fixes one issue.

The first is rather trivial, `MnPrint` is used unconditionally, even though the corresponding header `MnPrint.h` is only included if certain compiler flags are set.

The second one is a change in the interface of the `MinimumBuilder` base class. We run Minuit using the `MnMigrad` class. Without this change, there is no way to change the print level in a particular instance of MnMigrad. The change does not violate the logical constness of MinimumBuilder.