### PR TITLE
Fix missing include for Windows

### DIFF
--- a/math/mathcore/src/GenAlgoOptions.cxx
+++ b/math/mathcore/src/GenAlgoOptions.cxx
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <functional>
 #include <ctype.h>   // need to use c version of tolower defined here
+#include <string>
 
 namespace ROOT {
 namespace Math {


### PR DESCRIPTION
This missing include breaks Minuit2 standalone on MSVC. Can be tested as part of #1680.