### PR TITLE
The fit parameters were painted too early. 

### DIFF
--- a/hist/histpainter/src/TGraphPainter.cxx
+++ b/hist/histpainter/src/TGraphPainter.cxx
@@ -1023,6 +1023,26 @@ void TGraphPainter::PaintHelper(TGraph *theGraph, Option_t *option)
       } else {
          PaintGraphSimple(theGraph,chopt);
       }
+
+      // Paint the fit parameters if needed.
+      TF1 *fit = 0;
+      TList *functions = theGraph->GetListOfFunctions();
+      TObject *f;
+      if (functions) {
+         f = (TF1*)functions->First();
+         if (f) {
+            if (f->InheritsFrom(TF1::Class())) fit = (TF1*)f;
+         }
+         TIter   next(functions);
+         while ((f = (TObject*) next())) {
+            if (f->InheritsFrom(TF1::Class())) {
+               fit = (TF1*)f;
+               break;
+            }
+         }
+      }
+      if (fit) PaintStats(theGraph, fit);
+
    }
 }
 
@@ -1171,24 +1191,6 @@ void TGraphPainter::PaintGraph(TGraph *theGraph, Int_t npoints, const Double_t *
 
    // Set Clipping option
    gPad->SetBit(TGraph::kClipFrame, theGraph->TestBit(TGraph::kClipFrame));
-
-   TF1 *fit = 0;
-   TList *functions = theGraph->GetListOfFunctions();
-   TObject *f;
-   if (functions) {
-      f = (TF1*)functions->First();
-      if (f) {
-         if (f->InheritsFrom(TF1::Class())) fit = (TF1*)f;
-      }
-      TIter   next(functions);
-      while ((f = (TObject*) next())) {
-         if (f->InheritsFrom(TF1::Class())) {
-            fit = (TF1*)f;
-            break;
-         }
-      }
-   }
-   if (fit) PaintStats(theGraph, fit);
 
    rwxmin   = gPad->GetUxmin();
    rwxmax   = gPad->GetUxmax();


### PR DESCRIPTION
With the following macro the error bars overlapped the stat box:

{
   vector < float > X, Xerr;
   vector < float > Y, Yerr;
   for(int i=0 ; i<10 ; ++i) {
      X.push_back(i*0.1); Xerr.push_back(1.);
      Y.push_back(i*2.2); Yerr.push_back(1.);
   }
   auto g = new TGraphErrors(X.size(), &(X[0]), &(Y[0]), &(Xerr[0]), &(Yerr[0]));

   auto f = new TF1("f","pol1",0.,1.); g->Fit("f","QR");
   gStyle->SetOptFit(true);

   g->Draw();
}