### PR TITLE
webgui: use --web arguments to configure web window output

### DIFF
--- a/core/base/inc/TROOT.h
+++ b/core/base/inc/TROOT.h
@@ -18,7 +18,7 @@
 // TROOT                                                                //
 //                                                                      //
 // The TROOT object is the entry point to the system.                   //
-// The single instance of TROOT is accessable via the global gROOT.     //
+// The single instance of TROOT is accessible via the global gROOT.     //
 // Using the gROOT pointer one has access to basically every object     //
 // created in a ROOT based program. The TROOT object is essentially a   //
 // "dispatcher" with several lists pointing to the ROOT main objects.   //
@@ -168,7 +168,7 @@ protected:
    TCollection     *fClassGenerators;     //List of user defined class generators;
    TSeqCollection  *fSecContexts;         //List of security contexts (TSecContext)
    TSeqCollection  *fProofs;              //List of proof sessions
-   TSeqCollection  *fClipboard;           //List of clipbard objects
+   TSeqCollection  *fClipboard;           //List of clipboard objects
    TSeqCollection  *fDataSets;            //List of data sets (TDSet or TChain)
    AListOfEnums_t   fEnums;               //List of enum types
    TProcessUUID    *fUUIDs;               //Pointer to TProcessID managing TUUIDs

--- a/core/base/inc/TROOT.h
+++ b/core/base/inc/TROOT.h
@@ -281,7 +281,7 @@ public:
    Int_t             GetNtypes() const { return fTypes->GetSize(); }
    TFolder          *GetRootFolder() const { return fRootFolder; }
    TProcessUUID     *GetUUIDs() const { return fUUIDs; }
-   TString           GetWebDisplay() const { return fWebDisplay; }
+   const TString    &GetWebDisplay() const { return fWebDisplay; }
    void              Idle(UInt_t idleTimeInSec, const char *command = 0);
    Int_t             IgnoreInclude(const char *fname, const char *expandedfname);
    Bool_t            IsBatch() const { return fBatch; }

--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -427,7 +427,7 @@ void TApplication::GetOptions(Int_t *argc, char **argv)
             else                  gROOT->SetWebDisplay("");
          } else {
             argv[i] = null;
-            if (gROOT->IsBatch()) opt.Append("batch");
+            if (gROOT->IsBatch()) opt.Prepend("batch");
             gROOT->SetWebDisplay(opt.Data());
          }
       } else if (!strcmp(argv[i], "-e")) {

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -2748,9 +2748,9 @@ void TROOT::SetMacroPath(const char *newpath)
 ///
 ///  - "off": turns off the web display and come back to normal graphics in
 ///    interactive mode.
-///  - "batch":  turns the web display in batch mode. It can be combined with an
+///  - "batch":  turns the web display in batch mode. It can be prepend with an
 ///    other string which will be considered as the new current web display
-///  - "nobatch": turns the web display in interactive mode. It can be combined with an
+///  - "nobatch": turns the web display in interactive mode. It can be prepend with an
 ///    other string which will be considered as the new current web display
 ///
 /// If the option "off" is not set, this method turns the normal graphics to
@@ -2758,28 +2758,27 @@ void TROOT::SetMacroPath(const char *newpath)
 
 void TROOT::SetWebDisplay(const char *webdisplay)
 {
-   TString wd = webdisplay;
-   wd.ToLower();
-   wd.ReplaceAll(" ","");
+   const char *wd = webdisplay;
+   if (!wd)
+      wd = "";
 
-   if (wd.Contains("off")) {
+   if (!strcmp(wd, "off")) {
       fIsWebDisplay = kFALSE;
       fIsWebDisplayBatch = kFALSE;
       fWebDisplay = "";
       gROOT->SetBatch(kFALSE);
    } else {
       fIsWebDisplay = kTRUE;
-      if (wd.Contains("nobatch")) {
-         wd.ReplaceAll("nobatch","");
-         fIsWebDisplayBatch = kFALSE;
-         if (wd.Length() >0) fWebDisplay = wd;
-      } else if (wd.Contains("batch")) {
-         wd.ReplaceAll("batch","");
+      if (!strncmp(wd, "batch", 5)) {
          fIsWebDisplayBatch = kTRUE;
-         if (wd.Length() >0) fWebDisplay = wd;
+         wd += 5;
+      } else if (!strncmp(wd, "nobatch", 7)) {
+         fIsWebDisplayBatch = kFALSE;
+         wd += 7;
       } else {
-         fWebDisplay = wd;
+         fIsWebDisplayBatch = kFALSE;
       }
+      fWebDisplay = wd;
       gROOT->SetBatch(kTRUE);
    }
 }

--- a/etc/http/files/canvas.htm
+++ b/etc/http/files/canvas.htm
@@ -67,7 +67,7 @@
       }
       
       JSROOT.ConnectWebWindow({
-         prereq: "2d;v7;",
+         prereq: "2d;v6;v7;",
          prereq_logdiv: "CanvasDiv",
          callback: InitV7Canvas
       });

--- a/graf2d/gpadv7/v7/inc/ROOT/TVirtualCanvasPainter.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/TVirtualCanvasPainter.hxx
@@ -40,7 +40,7 @@ protected:
    class Generator {
    public:
       /// Abstract interface to create a TVirtualCanvasPainter implementation.
-      virtual std::unique_ptr<TVirtualCanvasPainter> Create(const TCanvas &canv, bool batch_mode) const = 0;
+      virtual std::unique_ptr<TVirtualCanvasPainter> Create(const TCanvas &canv) const = 0;
       /// Default destructor.
       virtual ~Generator();
    };
@@ -51,9 +51,6 @@ protected:
 public:
    /// Default destructor.
    virtual ~TVirtualCanvasPainter();
-
-   /// returns true is canvas used in batch mode
-   virtual bool IsBatchMode() const { return true; }
 
    /// add display item to the canvas
    virtual void AddDisplayItem(std::unique_ptr<TDisplayItem> &&item) = 0;
@@ -72,7 +69,7 @@ public:
    virtual bool AddPanel(std::shared_ptr<TWebWindow>) { return false; }
 
    /// Loads the plugin that implements this class.
-   static std::unique_ptr<TVirtualCanvasPainter> Create(const TCanvas &canv, bool batch_mode = false);
+   static std::unique_ptr<TVirtualCanvasPainter> Create(const TCanvas &canv);
 };
 } // namespace Internal
 } // namespace Experimental

--- a/graf2d/gpadv7/v7/src/TCanvas.cxx
+++ b/graf2d/gpadv7/v7/src/TCanvas.cxx
@@ -90,11 +90,10 @@ void ROOT::Experimental::TCanvas::Show(const std::string &where)
       return;
    }
 
-   bool batch_mode = gROOT->IsBatch();
    if (!fModified)
       fModified = 1; // 0 is special value, means no changes and no drawings
 
-   fPainter = Internal::TVirtualCanvasPainter::Create(*this, batch_mode);
+   fPainter = Internal::TVirtualCanvasPainter::Create(*this);
    if (fPainter) {
       fPainter->NewDisplay(where);
       fPainter->CanvasUpdated(fModified, true, nullptr); // trigger async display
@@ -113,7 +112,7 @@ void ROOT::Experimental::TCanvas::Hide()
 void ROOT::Experimental::TCanvas::SaveAs(const std::string &filename, bool async, CanvasCallback_t callback)
 {
    if (!fPainter)
-      fPainter = Internal::TVirtualCanvasPainter::Create(*this, true);
+      fPainter = Internal::TVirtualCanvasPainter::Create(*this);
    if (filename.find(".svg") != std::string::npos)
       fPainter->DoWhenReady("SVG", filename, async, callback);
    else if (filename.find(".png") != std::string::npos)

--- a/graf2d/gpadv7/v7/src/TCanvas.cxx
+++ b/graf2d/gpadv7/v7/src/TCanvas.cxx
@@ -111,8 +111,10 @@ void ROOT::Experimental::TCanvas::Hide()
 
 void ROOT::Experimental::TCanvas::SaveAs(const std::string &filename, bool async, CanvasCallback_t callback)
 {
-   if (!fPainter)
-      fPainter = Internal::TVirtualCanvasPainter::Create(*this);
+   if (!fPainter) {
+      // TODO: probably, one should remove such canvas display after short timeout
+      Show("batch_canvas");
+   }
    if (filename.find(".svg") != std::string::npos)
       fPainter->DoWhenReady("SVG", filename, async, callback);
    else if (filename.find(".png") != std::string::npos)

--- a/graf2d/gpadv7/v7/src/TVirtualCanvasPainter.cxx
+++ b/graf2d/gpadv7/v7/src/TVirtualCanvasPainter.cxx
@@ -40,7 +40,7 @@ std::unique_ptr<ROOT::Experimental::Internal::TVirtualCanvasPainter::Generator>
 }
 
 std::unique_ptr<ROOT::Experimental::Internal::TVirtualCanvasPainter> ROOT::Experimental::Internal::
-   TVirtualCanvasPainter::Create(const TCanvas &canv, bool batch_mode)
+   TVirtualCanvasPainter::Create(const TCanvas &canv)
 {
    if (!GetGenerator()) {
       LoadCanvasPainterLibrary();
@@ -49,7 +49,7 @@ std::unique_ptr<ROOT::Experimental::Internal::TVirtualCanvasPainter> ROOT::Exper
          throw std::runtime_error("TVirtualCanvasPainter::Generator failed to initialize");
       }
    }
-   return GetGenerator()->Create(canv, batch_mode);
+   return GetGenerator()->Create(canv);
 }
 
 /// The implementation is here to pin the vtable.

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -623,8 +623,16 @@ void ROOT::Experimental::TCanvasPainter::ProcessData(unsigned connid, const std:
 
 void ROOT::Experimental::TCanvasPainter::NewDisplay(const std::string &where)
 {
+   std::string showarg = where;
+   bool batch_mode = false;
+   if (showarg == "batch_canvas") {
+      batch_mode = true;
+      showarg.clear();
+   }
+
    if (!fWindow) {
-      fWindow = TWebWindowsManager::Instance()->CreateWindow(gROOT->IsWebDisplayBatch());
+
+      fWindow = TWebWindowsManager::Instance()->CreateWindow(batch_mode);
 
       fWindow->SetConnLimit(0); // allow any number of connections
 
@@ -635,7 +643,7 @@ void ROOT::Experimental::TCanvasPainter::NewDisplay(const std::string &where)
       // fWindow->SetGeometry(500,300);
    }
 
-   fWindow->Show(where);
+   fWindow->Show(showarg);
 }
 
 /// append window and panel inside canvas window

--- a/gui/fitpanel/v7/src/TFitPanel.cxx
+++ b/gui/fitpanel/v7/src/TFitPanel.cxx
@@ -35,7 +35,7 @@ web-based FitPanel prototype.
 std::shared_ptr<ROOT::Experimental::TWebWindow> ROOT::Experimental::TFitPanel::GetWindow()
 {
    if (!fWindow) {
-      fWindow = TWebWindowsManager::Instance()->CreateWindow(gROOT->IsWebDisplayBatch());
+      fWindow = TWebWindowsManager::Instance()->CreateWindow();
 
       fWindow->SetPanelName("FitPanel");
 
@@ -88,7 +88,7 @@ void ROOT::Experimental::TFitPanel::ProcessData(unsigned connid, const std::stri
       model.fModelNames.push_back(ComboBoxItem("3", "RootModel3"));
       model.fSelectModelId = "3";
 
-      TString json = TBufferJSON::ConvertToJSON(&model, gROOT->GetClass("ROOT::Experimental::TFitPanelModel"));
+      TString json = TBufferJSON::ToJSON(&model);
 
       fWindow->Send(std::string("MODEL:") + json.Data(), fConnId);
 

--- a/gui/fitpanel/v7/src/TFitPanel.cxx
+++ b/gui/fitpanel/v7/src/TFitPanel.cxx
@@ -35,7 +35,7 @@ web-based FitPanel prototype.
 std::shared_ptr<ROOT::Experimental::TWebWindow> ROOT::Experimental::TFitPanel::GetWindow()
 {
    if (!fWindow) {
-      fWindow = TWebWindowsManager::Instance()->CreateWindow(gROOT->IsBatch());
+      fWindow = TWebWindowsManager::Instance()->CreateWindow(gROOT->IsWebDisplayBatch());
 
       fWindow->SetPanelName("FitPanel");
 

--- a/gui/webdisplay/src/TWebWindow.cxx
+++ b/gui/webdisplay/src/TWebWindow.cxx
@@ -13,9 +13,6 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#pragma GCC diagnostic ignored "-Wall"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-
 #include "ROOT/TWebWindow.hxx"
 
 #include "ROOT/TWebWindowsManager.hxx"
@@ -65,7 +62,7 @@ In second case no any graphical elements will be created. For the normal window 
 (width and height), which are applied when window shown.
 
 Each window can be shown several times (if allowed) in different places - either as the
-CEF (chromium embdedded) window or in the standard web browser. When started, window will open and show
+CEF (chromium embedded) window or in the standard web browser. When started, window will open and show
 HTML page, configured with TWebWindow::SetDefaultPage() method.
 
 Typically (but not necessarily) clients open web socket connection to the window and one can exchange data,

--- a/gui/webdisplay/src/TWebWindowsManager.cxx
+++ b/gui/webdisplay/src/TWebWindowsManager.cxx
@@ -13,9 +13,6 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#pragma GCC diagnostic ignored "-Wall"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-
 #include "ROOT/TWebWindowsManager.hxx"
 
 #include <ROOT/TLogger.hxx>
@@ -33,6 +30,7 @@
 #include "TApplication.h"
 #include "TTimer.h"
 #include "RConfigure.h"
+#include "TROOT.h"
 
 /** \class ROOT::Experimental::TWebWindowManager
 \ingroup webdisplay
@@ -224,11 +222,8 @@ bool ROOT::Experimental::TWebWindowsManager::Show(ROOT::Experimental::TWebWindow
    addr.Form("/web7gui/%s/%s", handler->GetName(), (batch_mode ? "?batch_mode" : ""));
 
    std::string where = _where;
-   if (where.empty()) {
-      const char *cwhere = gSystem->Getenv("WEBGUI_WHERE");
-      if (cwhere)
-         where = cwhere;
-   }
+   if (where.empty())
+      where = gROOT->GetWebDisplay().Data();
 
    bool is_native = where.empty() || (where == "native"), is_qt5 = (where == "qt5"), is_cef = (where == "cef"),
         is_chrome = (where == "chrome") || (where == "chromium");

--- a/gui/webdisplay/src/TWebWindowsManager.cxx
+++ b/gui/webdisplay/src/TWebWindowsManager.cxx
@@ -124,7 +124,7 @@ std::shared_ptr<ROOT::Experimental::TWebWindow> ROOT::Experimental::TWebWindowsM
       return nullptr;
    }
 
-   win->SetBatchMode(batch_mode);
+   win->SetBatchMode(batch_mode || gROOT->IsWebDisplayBatch());
 
    win->SetId(++fIdCnt); // set unique ID
 


### PR DESCRIPTION
Now one can run root in different web modes:

    root --web cef tutorials/v7/draw.cxx
    root --web qt5 tutorials/v7/draw.cxx
    root --web chromium tutorials/v7/draw.cxx

If in draw.cxx one replaces `canv->Show()` with `canvas->SaveAs("draw.png");`, one can test 
batch mode like:

    root -b --web cef tutorials/v7/draw.cxx
    root -b --web chromium tutorials/v7/draw.cxx

Now one can check Qt5 on Mac, using normal ROOT macros from tutorials/v7

