### PR TITLE
 Fix compile error in GenVector

### DIFF
--- a/math/genvector/inc/Math/GenVector/Cartesian3D.h
+++ b/math/genvector/inc/Math/GenVector/Cartesian3D.h
@@ -111,11 +111,8 @@ public :
    Scalar Perp2() const { return fX*fX + fY*fY ;}
    Scalar Rho() const { return sqrt(Perp2()); }
    Scalar R() const { return sqrt(Mag2()); }
-   Scalar Theta() const
-   {
-      return (fX == Scalar(0) && fY == Scalar(0) && fZ == Scalar(0)) ? Scalar(0) : atan2(Rho(), Z());
-   }
-   Scalar Phi() const { return (fX == Scalar(0) && fY == Scalar(0)) ? Scalar(0) : atan2(fY, fX); }
+   Scalar Theta() const { return atan2(Rho(), Z()); }
+   Scalar Phi() const { return atan2(fY, fX); }
 
    // pseudorapidity
    Scalar Eta() const {
@@ -237,9 +234,9 @@ public :
 
 private:
 
-   T fX;  // x coordinate
-   T fY;  // y coordinate
-   T fZ;  // z coordinate
+   Scalar fX;  // x coordinate
+   Scalar fY;  // y coordinate
+   Scalar fZ;  // z coordinate
 };
 
 


### PR DESCRIPTION
When you try to use GenVector you get errors like this:
```
/home/yuka/root-build/include/Math/GenVector/Cartesian3D.h:116:50: error: could not convert ‘Vc_1::operator==<double, Vc_1::VectorAbi::Avx, Vc_1::Vector<double, Vc_1::VectorAbi::Avx> >(((const ROOT::Math::Cartesian3D<Vc_1::Vector<double, Vc_1::VectorAbi::Avx> >*)this)->ROOT::Math::Cartesian3D<Vc_1::Vector<double, Vc_1::VectorAbi::Avx> >::fX, Vc_1::Vector<double, Vc_1::VectorAbi::Avx>(0, 0)).Vc_1::Mask<double, Vc_1::VectorAbi::Avx>::operator&&(Vc_1::operator==<double, Vc_1::VectorAbi::Avx, Vc_1::Vector<double, Vc_1::VectorAbi::Avx> >(((const ROOT::Math::Cartesian3D<Vc_1::Vector<double, Vc_1::VectorAbi::Avx> >*)this)->ROOT::Math::Cartesian3D<Vc_1::Vector<double, Vc_1::VectorAbi::Avx> >::fY, Vc_1::Vector<double, Vc_1::VectorAbi::Avx>(0, 0))).Vc_1::Mask<double, Vc_1::VectorAbi::Avx>::operator&&(Vc_1::operator==<double, Vc_1::VectorAbi::Avx, Vc_1::Vector<double, Vc_1::VectorAbi::Avx> >(((const ROOT::Math::Cartesian3D<Vc_1::Vector<double, Vc_1::VectorAbi::Avx> >*)this)->ROOT::Math::Cartesian3D<Vc_1::Vector<double, Vc_1::VectorAbi::Avx> >::fZ, Vc_1::Vector<double, Vc_1::VectorAbi::Avx>(0, 0)))’ from ‘Vc_1::Mask<double, Vc_1::VectorAbi::Avx>’ to ‘bool’
       return (fX == Scalar(0) && fY == Scalar(0) && fZ == Scalar(0)) ? Scalar(0) : atan2(Rho(), Z());
```

When arguments of atan2 is both 0, it's supporsed to emit error rather
than just returning Scalar(0). Thus it's better just returning atan2
without checking its arguments.