### PR TITLE
[cxxmodules] Preload more modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,7 +355,7 @@ if(runtime_cxxmodules)
   # we will always load them to workaround the fact that we can't
   # load the decls in them via rootmap files (as they are inside
   # namespaces which isn't supported).
-  add_custom_target(onepcm DEPENDS TreePlayer TMVA Graf)
+  add_custom_target(onepcm DEPENDS Net TreeViewer RooStats Hist Gpad TreePlayer TMVA Graf GenVector)
 else()
   add_custom_command(OUTPUT etc/allDict.cxx.pch
                     COMMAND ${CMAKE_COMMAND} -E env ROOTIGNOREPREFIX=1 ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/etc/dictpch/makepch.py etc/allDict.cxx.pch ${__allIncludes} -I${CMAKE_BINARY_DIR}/include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,7 +351,11 @@ endif()
 
 if(runtime_cxxmodules)
   # Dummy target that does nothing, we don't need a PCH for modules.
-  add_custom_target(onepcm)
+  # However, we require that TMVA/Graf/Treeplayer are built here as
+  # we will always load them to workaround the fact that we can't
+  # load the decls in them via rootmap files (as they are inside
+  # namespaces which isn't supported).
+  add_custom_target(onepcm DEPENDS TreePlayer TMVA Graf)
 else()
   add_custom_command(OUTPUT etc/allDict.cxx.pch
                     COMMAND ${CMAKE_COMMAND} -E env ROOTIGNOREPREFIX=1 ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/etc/dictpch/makepch.py etc/allDict.cxx.pch ${__allIncludes} -I${CMAKE_BINARY_DIR}/include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,7 +355,7 @@ if(runtime_cxxmodules)
   # we will always load them to workaround the fact that we can't
   # load the decls in them via rootmap files (as they are inside
   # namespaces which isn't supported).
-  add_custom_target(onepcm DEPENDS Net TreeViewer RooStats Hist Gpad TreePlayer TMVA Graf GenVector)
+  add_custom_target(onepcm DEPENDS Net MathCore TreeViewer RooStats Hist Gpad TreePlayer RooFit EG RGL TMVA TMVAGui Graf GenVector)
 else()
   add_custom_command(OUTPUT etc/allDict.cxx.pch
                     COMMAND ${CMAKE_COMMAND} -E env ROOTIGNOREPREFIX=1 ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/etc/dictpch/makepch.py etc/allDict.cxx.pch ${__allIncludes} -I${CMAKE_BINARY_DIR}/include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,7 +355,7 @@ if(runtime_cxxmodules)
   # we will always load them to workaround the fact that we can't
   # load the decls in them via rootmap files (as they are inside
   # namespaces which isn't supported).
-  add_custom_target(onepcm DEPENDS Net MathCore TreeViewer RooStats Hist Gpad TreePlayer RooFit EG RGL TMVA TMVAGui Graf GenVector)
+  add_custom_target(onepcm DEPENDS Net MathCore TreeViewer Hist Gpad TreePlayer EG RGL TMVA TMVAGui Graf GenVector)
 else()
   add_custom_command(OUTPUT etc/allDict.cxx.pch
                     COMMAND ${CMAKE_COMMAND} -E env ROOTIGNOREPREFIX=1 ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/etc/dictpch/makepch.py etc/allDict.cxx.pch ${__allIncludes} -I${CMAKE_BINARY_DIR}/include

--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -366,8 +366,11 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
     endforeach()
   endif()
 
-  if(runtime_cxxmodules AND ARG_MODULE)
-    set(newargs -cxxmodule ${newargs})
+  set(runtime_cxxmodules_env)
+  if(runtime_cxxmodules AND ARG_MODULE AND NOT ARG_MULTIDICT)
+    # FIXME: Once modules work better, we should use some other value like "1"
+    # to disable the module-build remarks from clang.
+    set(runtime_cxxmodules_env "ROOT_MODULES=DEBUG")
   endif()
 
   #---what rootcling command to use--------------------------

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1114,18 +1114,18 @@ static bool IsFromRootCling() {
   return foundSymbol;
 }
 
-static void loadModulePath(HeaderSearch& hdrSearch, const char* environmentVariable) {
-  const char* LD_LIBRARY_PATH = getenv(environmentVariable);
-  if (LD_LIBRARY_PATH) {
-     StringRef path = LD_LIBRARY_PATH;
+static void loadModulePath(HeaderSearch& hdrSearch, const char* inputPath) {
+  if (inputPath) {
+     StringRef path = inputPath;
      SmallVector<StringRef, 32> paths;
      path.split(paths, ":");
+
      for (StringRef path : paths) {
         SmallString<128> ModuleMapFilePath = path;
-        llvm::sys::path::append(ModuleMapFilePath, "module.modulemap");
 
-        if (auto file = hdrSearch.getFileMgr().getFile(ModuleMapFilePath))
+        if (auto file = hdrSearch.getFileMgr().getFile(ModuleMapFilePath)) {
            hdrSearch.loadModuleMapFile(file, false, FileID());
+        }
     }
   }
 }
@@ -1271,7 +1271,7 @@ TCling::TCling(const char *name, const char *title)
    if (fInterpreter->getCI()->getLangOpts().Modules) {
       HeaderSearch& hdrSearch = fInterpreter->getCI()->getPreprocessor().getHeaderSearchInfo();
       hdrSearch.loadTopLevelSystemModules();
-      loadModulePath(hdrSearch, "LD_LIBRARY_PATH");
+      loadModulePath(hdrSearch, gSystem->GetDynamicPath());
 
       // Setup core C++ modules if we have any to setup.
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1386,7 +1386,7 @@ void TCling::Initialize()
    if (fInterpreter->getCI()->getLangOpts().Modules && !IsFromRootCling()) {
       // Load modules that we can't automatically load via rootmap files as they
       // contain decls in namespaces which aren't supported.
-      LoadModules({"TMVA", "Gpad", "RooStats", "GenVector", "Hist", "Net", "TreePlayer", "TreeViewer", "Graf"}, *fInterpreter);
+      LoadModules({"TMVA", "EG", "RGL", "RooFit", "TMVAGui", "Gpad", "RooStats", "GenVector", "Hist", "MathCore", "Net", "TreePlayer", "TreeViewer", "Graf"}, *fInterpreter);
    }
 }
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1271,6 +1271,7 @@ TCling::TCling(const char *name, const char *title)
       HeaderSearch& hdrSearch = fInterpreter->getCI()->getPreprocessor().getHeaderSearchInfo();
       hdrSearch.loadTopLevelSystemModules();
       loadModulePath(hdrSearch, gSystem->GetDynamicPath());
+      fInterpreter->getCI()->getHeaderSearchOpts().AddPrebuiltModulePath(".");
 
       // Setup core C++ modules if we have any to setup.
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1114,6 +1114,22 @@ static bool IsFromRootCling() {
   return foundSymbol;
 }
 
+static void loadModulePath(HeaderSearch& hdrSearch, const char* environmentVariable) {
+  const char* LD_LIBRARY_PATH = getenv(environmentVariable);
+  if (LD_LIBRARY_PATH) {
+     StringRef path = LD_LIBRARY_PATH;
+     SmallVector<StringRef, 32> paths;
+     path.split(paths, ":");
+     for (StringRef path : paths) {
+        SmallString<128> ModuleMapFilePath = path;
+        llvm::sys::path::append(ModuleMapFilePath, "module.modulemap");
+
+        if (auto file = hdrSearch.getFileMgr().getFile(ModuleMapFilePath))
+           hdrSearch.loadModuleMapFile(file, false, FileID());
+    }
+  }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Initialize the cling interpreter interface.
 
@@ -1253,6 +1269,10 @@ TCling::TCling(const char *name, const char *title)
    fMetaProcessor = new cling::MetaProcessor(*fInterpreter, fMPOuts);
 
    if (fInterpreter->getCI()->getLangOpts().Modules) {
+      HeaderSearch& hdrSearch = fInterpreter->getCI()->getPreprocessor().getHeaderSearchInfo();
+      hdrSearch.loadTopLevelSystemModules();
+      loadModulePath(hdrSearch, "LD_LIBRARY_PATH");
+
       // Setup core C++ modules if we have any to setup.
 
       // Load libc and stl first.

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1121,11 +1121,12 @@ static void loadModulePath(HeaderSearch& hdrSearch, const char* inputPath) {
      path.split(paths, ":");
 
      for (StringRef path : paths) {
-        SmallString<128> ModuleMapFilePath = path;
+      SmallString<128> ModuleMapFilePath = path;
+      llvm::sys::path::append(ModuleMapFilePath, "module.modulemap");
 
-        if (auto file = hdrSearch.getFileMgr().getFile(ModuleMapFilePath)) {
-           hdrSearch.loadModuleMapFile(file, false, FileID());
-        }
+      if (auto file = hdrSearch.getFileMgr().getFile(ModuleMapFilePath)) {
+         hdrSearch.loadModuleMapFile(file, false, FileID());
+      }
     }
   }
 }
@@ -5149,6 +5150,20 @@ Int_t TCling::LoadLibraryMap(const char* rootmapfile)
          }
          if (!skip) {
             void* dirp = gSystem->OpenDirectory(d);
+
+            // Load the modulemap from the dir and add it to the prebuilt module
+            // path.
+            // FIXME: This is ROOT quality code, refactor me.
+            fInterpreter->getCI()->getHeaderSearchOpts().AddPrebuiltModulePath(d.Data());
+            auto& hdrSearch = fInterpreter->getCI()->getPreprocessor().getHeaderSearchInfo();
+            SmallString<128> ModuleMapFilePath = StringRef(d.Data());
+            llvm::sys::path::append(ModuleMapFilePath, "module.modulemap");
+
+            if (auto file = hdrSearch.getFileMgr().getFile(ModuleMapFilePath)) {
+               hdrSearch.loadModuleMapFile(file, false, FileID());
+            }
+
+
             if (dirp) {
                if (gDebug > 3) {
                   Info("LoadLibraryMap", "%s", d.Data());

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1386,7 +1386,7 @@ void TCling::Initialize()
    if (fInterpreter->getCI()->getLangOpts().Modules && !IsFromRootCling()) {
       // Load modules that we can't automatically load via rootmap files as they
       // contain decls in namespaces which aren't supported.
-      LoadModules({"TMVA", "TreePlayer", "Graf"}, *fInterpreter);
+      LoadModules({"TMVA", "Gpad", "RooStats", "GenVector", "Hist", "Net", "TreePlayer", "TreeViewer", "Graf"}, *fInterpreter);
    }
 }
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1363,6 +1363,11 @@ TCling::~TCling()
 void TCling::Initialize()
 {
    fClingCallbacks->Initialize();
+   if (fInterpreter->getCI()->getLangOpts().Modules && !IsFromRootCling()) {
+      // Load modules that we can't automatically load via rootmap files as they
+      // contain decls in namespaces which aren't supported.
+      LoadModules({"TMVA", "TreePlayer", "Graf"}, *fInterpreter);
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1395,7 +1395,7 @@ void TCling::Initialize()
    if (fInterpreter->getCI()->getLangOpts().Modules && !IsFromRootCling()) {
       // Load modules that we can't automatically load via rootmap files as they
       // contain decls in namespaces which aren't supported.
-      LoadModules({"TMVA", "EG", "RGL", "RooFit", "TMVAGui", "Gpad", "RooStats", "GenVector", "Hist", "MathCore", "Net", "TreePlayer", "TreeViewer", "Graf"}, *fInterpreter);
+      LoadModules({"TMVA", "EG", "RGL", "TMVAGui", "Gpad", "GenVector", "Hist", "MathCore", "Net", "TreePlayer", "TreeViewer", "Graf"}, *fInterpreter);
    }
 }
 


### PR DESCRIPTION
Rebase PR #1396.

Original PR comment:
"ROOT can't autoparse classes inside namespaces with the rootmap
system (as the loading callbacks don't correctly land where
they are supposed to land with our injected namespaces). As this
turns out to be a feature of some kind, let's preload
TMVA/TreePlayer/Graf to fix all failing tests that are related
to this feature/bug with modules enabled.

This commit can be dropped if we solve on of those problems:

    figure out how to fix this bug in the rootmap-based loading
    without regressin in performance.

    replace the rootmap system with something else like attaching
    all C++ modules on startup.

Note that we already do something like this in normal ROOT by
including these packages into the PCH which also makes those
decls available in the normal clang lookup."