### PR TITLE
[Math] Do not use type alias for GenVector class members

### DIFF
--- a/math/genvector/inc/Math/GenVector/Cartesian3D.h
+++ b/math/genvector/inc/Math/GenVector/Cartesian3D.h
@@ -234,9 +234,9 @@ public :
 
 private:
 
-   Scalar fX;  // x coordinate
-   Scalar fY;  // y coordinate
-   Scalar fZ;  // z coordinate
+   T fX;  // x coordinate
+   T fY;  // y coordinate
+   T fZ;  // z coordinate
 };
 
 


### PR DESCRIPTION
Using Scalar instead of T directly breaks things for `Double32_t`.