### PR TITLE
Fix failing test with GCC 7.3.0 and C++17

### DIFF
--- a/roofit/histfactory/CMakeLists.txt
+++ b/roofit/histfactory/CMakeLists.txt
@@ -14,11 +14,10 @@ ROOT_STANDARD_LIBRARY_PACKAGE(HistFactory
                               DEPENDENCIES RooFit RooFitCore Tree RIO Hist Matrix MathCore
                                            Minuit Foam Graf Gpad RooStats XMLParser)
 
-                                           ROOT_EXECUTABLE(hist2workspace MakeModelAndMeasurements.cxx hist2workspace.cxx
-			       LIBRARIES HistFactory RooFit RooFitCore Tree RIO Matrix Hist ${ROOT_MATHMORE_LIBRARY} ${GSL_LIBRARIES} MathCore 
-                                         Graf Gpad Minuit Foam RooStats XMLParser
-                               BUILTINS GSL)
-
+ROOT_EXECUTABLE(hist2workspace MakeModelAndMeasurements.cxx hist2workspace.cxx
+                LIBRARIES HistFactory RooFit RooFitCore Tree RIO Matrix Hist
+                ${ROOT_MATHMORE_LIBRARY} ${GSL_LIBRARIES} MathCore Graf Gpad
+                Minuit Foam RooStats XMLParser BUILTINS GSL)
 
 file(COPY config/prepareHistFactory DESTINATION  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 install(FILES ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/prepareHistFactory

--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -611,7 +611,8 @@ namespace HistFactory{
     for(unsigned int i = 0; i < systList.size(); ++i) {
 
       OverallSys& sys = systList.at(i);
-      const char * name = sys.GetName().c_str();
+      std::string strname = sys.GetName();
+      const char * name = strname.c_str();
 
       // case of no systematic (is it possible)
       if (meas.GetNoSyst().count(sys.GetName()) > 0 ) {


### PR DESCRIPTION
Test `tutorial-roostats-CreateExampleFile` fails for me with GCC 7.3.0 and C++17=ON.