### PR TITLE
change the TBufferMerger callback to wrap the merge operation

### DIFF
--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -74,12 +74,13 @@ public:
    /** Returns the number of buffers currently in the queue. */
    size_t GetQueueSize() const;
 
-   /** Register a user callback function to be called after a buffer has been
-    *  removed from the merging queue and finished being processed. This
-    *  function can be useful to allow asynchronous launching of new tasks to
-    *  push more data into the queue once its size satisfies user requirements.
+   /** Register a user callback function to wrap the merge operation, to be
+    *  called to merge the queue.  This function can be useful to allow
+    *  asynchronous launching of new tasks to push more data into the queue
+    *  once its size satisfies user requirements, or to control the threading
+    *  context where the merge is performed.
     */
-   void RegisterCallback(const std::function<void(void)> &f);
+   void RegisterCallback(const std::function<void(std::function<void()>)> &f);
 
    /** Returns the current value of the auto save setting in bytes (default = 0). */
    size_t GetAutoSave() const;
@@ -118,7 +119,7 @@ private:
    std::queue<TBufferFile *> fQueue;                             //< Queue to which data is pushed and merged
    std::unique_ptr<std::thread> fMergingThread;                  //< Worker thread that writes to disk
    std::vector<std::weak_ptr<TBufferMergerFile>> fAttachedFiles; //< Attached files
-   std::function<void(void)> fCallback;                          //< Callback for when data is removed from queue
+   std::function<void(std::function<void()>)> fCallback;         //< Callback wrapper around the merge operation
 
    ClassDef(TBufferMerger, 0);
 };

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -70,7 +70,7 @@ size_t TBufferMerger::GetQueueSize() const
 void TBufferMerger::RegisterCallback(const std::function<void(std::function<void()>)> &f)
 {
   if (nullptr == f) { 
-     fCallback = [](const std::function<void()> &f){ f(); };
+     fCallback = [](const std::function<void()> &fn){ fn(); };
   } else {
      fCallback = f;
   }

--- a/io/io/test/TBufferMerger.cxx
+++ b/io/io/test/TBufferMerger.cxx
@@ -343,7 +343,8 @@ TEST(TBufferMerger, RegisterCallbackTasks)
       TTaskGroup tg;
 
       /* callback: launches new tasks when called */
-      merger.RegisterCallback([&]() {
+      merger.RegisterCallback([&](const std::function<void()> &f) {
+         f();
          int i = 0;
          while (launched < tasks && ++i <= 2) {
             tg.Run(task);

--- a/io/io/test/TBufferMerger.cxx
+++ b/io/io/test/TBufferMerger.cxx
@@ -254,7 +254,8 @@ TEST(TBufferMerger, RegisterCallbackThreads)
       std::vector<std::thread> workers;
 
       /* callback: launches new tasks when called */
-      merger.RegisterCallback([&]() {
+      merger.RegisterCallback([&](const std::function<void()> &f) {
+         f();
          int i = 0;
          while (launched < tasks && ++i <= 2) {
             workers.emplace_back(task);


### PR DESCRIPTION
This PR modifies the TBufferMerger callback (that CMS requested) so that it wraps the merge operation--the callback is passed the function to perform the merge and is responsible for calling it.  The motivation for this change is that the merge operation is taking enough CPU time that we need it to be executed in the CMSSW framework's TBB task arena so that we don't overrun our CPU commitment.  With this change, we can use a callback like

```
      mergeExec_ = [this](const std::function<void()> &f){
        std::promise<void> barrier;
        auto fwrap = [&]() { 
          auto set_value = [](decltype(barrier)* b) { b->set_value(); };
          std::unique_ptr<decltype(barrier), decltype(set_value)> release(&barrier, set_value);
          f();
        };
        taskArena_->enqueue(fwrap);
        barrier.get_future().wait();
      };
```

to queue the merge operation to our task arena and wait for it to complete.  This also ensures that any IMT operations invoked by the merge operation are also executed in our task arena.

Since the callback can still perform any operations it wants after executing the merge operation, this is a superset of the previous callback functionality.