### PR TITLE
Fix rootls with python3 (Fixes ROOT-9299).

### DIFF
--- a/main/python/cmdLineUtils.py
+++ b/main/python/cmdLineUtils.py
@@ -1081,7 +1081,7 @@ def _rootLsPrintSimpleLs(keyList,indent,oneColumn):
     if max_element_width >= term_width: ncol,col_widths = 1,[1]
     else:
         # Start with max possible number of columns and reduce until it fits
-        ncol = 1 if oneColumn else min( len(keyList), term_width / min_element_width  )
+        ncol = 1 if oneColumn else min( len(keyList), term_width // min_element_width  )
         while True:
             col_widths = \
                 [ max( len(key.GetName()) + min_chars_between \


### PR DESCRIPTION
In python 3 'term_width / min_element_width' is a float and can't be passed to
range a few lines below.