### PR TITLE
Add initial support for an Apache Arrow based TDataFrame

### DIFF
--- a/cmake/modules/FindArrow.cmake
+++ b/cmake/modules/FindArrow.cmake
@@ -1,0 +1,156 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# - Find ARROW (arrow/api.h, libarrow.a, libarrow.so)
+# This module defines
+#  ARROW_INCLUDE_DIR, directory containing headers
+#  ARROW_LIBS, directory containing arrow libraries
+#  ARROW_STATIC_LIB, path to libarrow.a
+#  ARROW_SHARED_LIB, path to libarrow's shared library
+#  ARROW_SHARED_IMP_LIB, path to libarrow's import library (MSVC only)
+#  ARROW_FOUND, whether arrow has been found
+
+include(FindPkgConfig)
+include(GNUInstallDirs)
+
+if ("$ENV{ARROW_HOME}" STREQUAL "")
+  pkg_check_modules(ARROW arrow)
+  if (ARROW_FOUND)
+    pkg_get_variable(ARROW_ABI_VERSION arrow abi_version)
+    message(STATUS "Arrow ABI version: ${ARROW_ABI_VERSION}")
+    pkg_get_variable(ARROW_SO_VERSION arrow so_version)
+    message(STATUS "Arrow SO version: ${ARROW_SO_VERSION}")
+    if ("${ARROW_INCLUDE_DIRS}" STREQUAL "")
+      set(ARROW_INCLUDE_DIRS "/usr/${CMAKE_INSTALL_INCLUDEDIR}")
+    endif()
+    if ("${ARROW_LIBRARY_DIRS}" STREQUAL "")
+      set(ARROW_LIBRARY_DIRS "/usr/${CMAKE_INSTALL_LIBDIR}")
+      if (EXISTS "/etc/debian_version" AND CMAKE_LIBRARY_ARCHITECTURE)
+        set(ARROW_LIBRARY_DIRS
+          "${ARROW_LIBRARY_DIRS}/${CMAKE_LIBRARY_ARCHITECTURE}")
+      endif()
+    endif()
+    set(ARROW_INCLUDE_DIR ${ARROW_INCLUDE_DIRS})
+    set(ARROW_LIBS ${ARROW_LIBRARY_DIRS})
+    set(ARROW_SEARCH_LIB_PATH ${ARROW_LIBRARY_DIRS})
+  endif()
+else()
+  set(ARROW_HOME "$ENV{ARROW_HOME}")
+
+  set(ARROW_SEARCH_HEADER_PATHS
+    ${ARROW_HOME}/include
+    )
+
+  set(ARROW_SEARCH_LIB_PATH
+    ${ARROW_HOME}/lib
+    )
+
+  find_path(ARROW_INCLUDE_DIR arrow/array.h PATHS
+    ${ARROW_SEARCH_HEADER_PATHS}
+    # make sure we don't accidentally pick up a different version
+    NO_DEFAULT_PATH
+    )
+endif()
+
+find_library(ARROW_LIB_PATH NAMES arrow
+  PATHS
+  ${ARROW_SEARCH_LIB_PATH}
+  NO_DEFAULT_PATH)
+get_filename_component(ARROW_LIBS ${ARROW_LIB_PATH} DIRECTORY)
+
+find_library(ARROW_PYTHON_LIB_PATH NAMES arrow_python
+  PATHS
+  ${ARROW_SEARCH_LIB_PATH}
+  NO_DEFAULT_PATH)
+get_filename_component(ARROW_PYTHON_LIBS ${ARROW_PYTHON_LIB_PATH} DIRECTORY)
+
+if (MSVC)
+  SET(CMAKE_FIND_LIBRARY_SUFFIXES ".lib" ".dll")
+
+  if (MSVC AND NOT DEFINED ARROW_MSVC_STATIC_LIB_SUFFIX)
+    set(ARROW_MSVC_STATIC_LIB_SUFFIX "_static")
+  endif()
+
+  find_library(ARROW_SHARED_LIBRARIES NAMES arrow
+    PATHS ${ARROW_HOME} NO_DEFAULT_PATH
+    PATH_SUFFIXES "bin" )
+
+  find_library(ARROW_PYTHON_SHARED_LIBRARIES NAMES arrow_python
+    PATHS ${ARROW_HOME} NO_DEFAULT_PATH
+    PATH_SUFFIXES "bin" )
+  get_filename_component(ARROW_SHARED_LIBS ${ARROW_SHARED_LIBRARIES} PATH )
+  get_filename_component(ARROW_PYTHON_SHARED_LIBS ${ARROW_PYTHON_SHARED_LIBRARIES} PATH )
+endif ()
+
+if (ARROW_INCLUDE_DIR AND ARROW_LIBS)
+  set(ARROW_FOUND TRUE)
+  set(ARROW_LIB_NAME arrow)
+  set(ARROW_PYTHON_LIB_NAME arrow_python)
+  if (MSVC)
+    set(ARROW_STATIC_LIB ${ARROW_LIBS}/${ARROW_LIB_NAME}${ARROW_MSVC_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX})
+    set(ARROW_PYTHON_STATIC_LIB ${ARROW_PYTHON_LIBS}/${ARROW_PYTHON_LIB_NAME}${ARROW_MSVC_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX})
+    set(ARROW_SHARED_LIB ${ARROW_SHARED_LIBS}/${ARROW_LIB_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX})
+    set(ARROW_PYTHON_SHARED_LIB ${ARROW_PYTHON_SHARED_LIBS}/${ARROW_PYTHON_LIB_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX})
+    set(ARROW_SHARED_IMP_LIB ${ARROW_LIBS}/${ARROW_LIB_NAME}.lib)
+    set(ARROW_PYTHON_SHARED_IMP_LIB ${ARROW_PYTHON_LIBS}/${ARROW_PYTHON_LIB_NAME}.lib)
+  else()
+    set(ARROW_STATIC_LIB ${ARROW_LIBS}/lib${ARROW_LIB_NAME}.a)
+    set(ARROW_PYTHON_STATIC_LIB ${ARROW_LIBS}/lib${ARROW_PYTHON_LIB_NAME}.a)
+
+    set(ARROW_SHARED_LIB ${ARROW_LIBS}/lib${ARROW_LIB_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX})
+    set(ARROW_PYTHON_SHARED_LIB ${ARROW_LIBS}/lib${ARROW_PYTHON_LIB_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX})
+  endif()
+endif()
+
+if (ARROW_FOUND)
+  if (NOT Arrow_FIND_QUIETLY)
+    message(STATUS "Found the Arrow core library: ${ARROW_LIB_PATH}")
+    message(STATUS "Found the Arrow Python library: ${ARROW_PYTHON_LIB_PATH}")
+  endif ()
+else ()
+  if (NOT Arrow_FIND_QUIETLY)
+    set(ARROW_ERR_MSG "Could not find the Arrow library. Looked for headers")
+    set(ARROW_ERR_MSG "${ARROW_ERR_MSG} in ${ARROW_SEARCH_HEADER_PATHS}, and for libs")
+    set(ARROW_ERR_MSG "${ARROW_ERR_MSG} in ${ARROW_SEARCH_LIB_PATH}")
+    if (Arrow_FIND_REQUIRED)
+      message(FATAL_ERROR "${ARROW_ERR_MSG}")
+    else (Arrow_FIND_REQUIRED)
+      message(STATUS "${ARROW_ERR_MSG}")
+    endif (Arrow_FIND_REQUIRED)
+  endif ()
+  set(ARROW_FOUND FALSE)
+endif ()
+
+if (MSVC)
+  mark_as_advanced(
+    ARROW_INCLUDE_DIR
+    ARROW_STATIC_LIB
+    ARROW_SHARED_LIB
+    ARROW_SHARED_IMP_LIB
+    ARROW_PYTHON_STATIC_LIB
+    ARROW_PYTHON_SHARED_LIB
+    ARROW_PYTHON_SHARED_IMP_LIB
+  )
+else()
+  mark_as_advanced(
+    ARROW_INCLUDE_DIR
+    ARROW_STATIC_LIB
+    ARROW_SHARED_LIB
+    ARROW_PYTHON_STATIC_LIB
+    ARROW_PYTHON_SHARED_LIB
+  )
+endif()

--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -64,6 +64,7 @@ ROOT_BUILD_OPTION(afdsmgrd OFF "Dataset manager for PROOF-based analysis facilit
 ROOT_BUILD_OPTION(afs OFF "AFS support, requires AFS libs and objects")
 ROOT_BUILD_OPTION(alien OFF "AliEn support, requires libgapiUI from ALICE")
 ROOT_BUILD_OPTION(asimage ON "Image processing support, requires libAfterImage")
+ROOT_BUILD_OPTION(arrow OFF "Apache Arrow in memory columnar storage support")
 ROOT_BUILD_OPTION(astiff ON "Include tiff support in image processing")
 ROOT_BUILD_OPTION(bonjour OFF "Bonjour support, requires libdns_sd and/or Avahi")
 ROOT_BUILD_OPTION(builtin_afterimage ON "Build included libAfterImage, or use system libAfterImage")

--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -282,6 +282,11 @@ set(alienlibdir ${ALIEN_LIBRARY_DIR})
 set(alienlib ${ALIEN_LIBRARY})
 set(alienincdir ${ALIEN_INCLUDE_DIR})
 
+set(buildarrow ${value${arrow}})
+set(arrowlibdir ${ARROW_LIBRARY_DIR})
+set(arrowlib ${ARROW_LIBRARY})
+set(arrowincdir ${ARROW_INCLUDE_DIR})
+
 set(buildasimage ${value${asimage}})
 set(builtinafterimage ${builtin_afterimage})
 set(asextralib ${ASEXTRA_LIBRARIES})

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -917,7 +917,24 @@ if(alien)
   endif()
 endif()
 
-#---Check for cling -------- --------------------------------------------------------
+#---Check for Apache Arrow
+if(arrow)
+  find_package(Arrow)
+  if(NOT ARROW_FOUND)
+    if(fail-on-missing)
+      message(FATAL_ERROR "Apache Arrow not found. Please set ARROW_HOME to point to you Arrow installation,"
+                          "or include the installation of Arrrow the CMAKE_PREFIX_PATH. ")
+    else()
+      message(STATUS "Apache Arrow API not found. Set variable ARROW_HOME to point to your Arrow installation,"
+                     "or include the installation of Arrow in the CMAKE_PREFIX_PATH.")
+      message(STATUS "For the time being switching OFF 'arrow' option")
+      set(arrow OFF CACHE BOOL "" FORCE)
+    endif()
+  endif()
+
+endif()
+
+#---Check for cling and llvm --------------------------------------------------------
 if(cling)
   set(CLING_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/interpreter/cling/include)
   if(MSVC)

--- a/tree/treeplayer/CMakeLists.txt
+++ b/tree/treeplayer/CMakeLists.txt
@@ -3,6 +3,10 @@
 # @author Pere Mato, CERN
 ############################################################################
 
+if (ARROW_FOUND)
+  include_directories(${ARROW_INCLUDE_DIR})
+endif()
+
 # TBranchProxyTemplate.h is only used by selectors, to verify that the selector
 # source matches the ROOT interface. It should not end up in the dictionary nor
 # in the PCH.
@@ -27,11 +31,16 @@ if(NOT imt)
   list(REMOVE_ITEM sources ${CMAKE_CURRENT_SOURCE_DIR}/src/TTreeProcessorMT.cxx)
 endif()
 
+if(NOT ARROW_FOUND)
+  list(REMOVE_ITEM dictHeaders ${CMAKE_CURRENT_SOURCE_DIR}/inc/ROOT/TArrowDS.hxx)
+  list(REMOVE_ITEM sources ${CMAKE_CURRENT_SOURCE_DIR}/src/TArrowDS.cxx)
+endif()
+
 ROOT_STANDARD_LIBRARY_PACKAGE(TreePlayer
                               HEADERS ${dictHeaders}
                               SOURCES ${sources}
                               DICTIONARY_OPTIONS "-writeEmptyRootPCM"
-                              LIBRARIES ${TBB_LIBRARIES}
+                              LIBRARIES ${TBB_LIBRARIES} ${ARROW_SHARED_LIB}
                               DEPENDENCIES Tree Graf3d Graf Hist Gpad RIO MathCore
                               ${TREEPLAYER_DEPENDENCIES})
 

--- a/tree/treeplayer/inc/ROOT/TArrowDS.hxx
+++ b/tree/treeplayer/inc/ROOT/TArrowDS.hxx
@@ -1,0 +1,209 @@
+#ifndef ROOT_TARROWTDS
+#define ROOT_TARROWTDS
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+#endif
+#include <arrow/table.h>
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+#include <memory>
+
+#include "ROOT/TDataFrame.hxx"
+#include "ROOT/TDataSource.hxx"
+
+namespace ROOT {
+namespace Experimental {
+namespace TDF {
+
+class TArrowDS final : public TDataSource {
+private:
+   // Per slot visitor of an Array.
+   class ArrayPtrVisitor : public ::arrow::ArrayVisitor {
+   private:
+      /// The pointer to update.
+      void **fResult;
+      bool fCachedBool;          // Booleans need to be unpacked, so we use a cached entry.
+      std::string fCachedString; //
+      /// The entry in the array which should be looked up.
+      ULong64_t fCurrentEntry;
+
+   public:
+      ArrayPtrVisitor(void **result) : fResult{result}, fCurrentEntry{0} {}
+
+      void SetEntry(ULong64_t entry) { fCurrentEntry = entry; }
+
+      /// Check if we are asking the same entry as before.
+      virtual arrow::Status Visit(arrow::Int32Array const &array) final
+      {
+         *fResult = (void *)(array.raw_values() + fCurrentEntry);
+         return arrow::Status::OK();
+      }
+
+      virtual arrow::Status Visit(arrow::Int64Array const &array) final
+      {
+         *fResult = (void *)(array.raw_values() + fCurrentEntry);
+         return arrow::Status::OK();
+      }
+
+      /// Check if we are asking the same entry as before.
+      virtual arrow::Status Visit(arrow::UInt32Array const &array) final
+      {
+         *fResult = (void *)(array.raw_values() + fCurrentEntry);
+         return arrow::Status::OK();
+      }
+
+      virtual arrow::Status Visit(arrow::UInt64Array const &array) final
+      {
+         *fResult = (void *)(array.raw_values() + fCurrentEntry);
+         return arrow::Status::OK();
+      }
+
+      virtual arrow::Status Visit(arrow::FloatArray const &array) final
+      {
+         *fResult = (void *)(array.raw_values() + fCurrentEntry);
+         return arrow::Status::OK();
+      }
+
+      virtual arrow::Status Visit(arrow::DoubleArray const &array) final
+      {
+         *fResult = (void *)(array.raw_values() + fCurrentEntry);
+         return arrow::Status::OK();
+      }
+
+      virtual arrow::Status Visit(arrow::BooleanArray const &array) final
+      {
+         fCachedBool = array.Value(fCurrentEntry);
+         *fResult = reinterpret_cast<void *>(&fCachedBool);
+         return arrow::Status::OK();
+      }
+
+      virtual arrow::Status Visit(arrow::StringArray const &array) final
+      {
+         fCachedString = array.GetString(fCurrentEntry);
+         *fResult = reinterpret_cast<void *>(&fCachedString);
+         return arrow::Status::OK();
+      }
+
+      using ::arrow::ArrayVisitor::Visit;
+   };
+
+   /// Helper class which keeps track for each slot where to get the entry.
+   class ValueGetter {
+   private:
+      std::vector<void *> fValuesPtrPerSlot;
+      std::vector<ULong64_t> fLastEntryPerSlot;
+      std::vector<ULong64_t> fLastChunkPerSlot;
+      std::vector<ULong64_t> fFirstEntryPerChunk;
+      std::vector<ArrayPtrVisitor> fArrayVisitorPerSlot;
+      /// Since data can be chunked in different arrays we need to construct an
+      /// index which contains the first element of each chunk, so that we can
+      /// quickly move to the correct chunk.
+      std::vector<ULong64_t> fChunkIndex;
+      arrow::ArrayVector fChunks;
+
+   public:
+      ValueGetter(size_t slots, arrow::ArrayVector chunks)
+         : fValuesPtrPerSlot(slots, nullptr), fLastEntryPerSlot(slots, 0), fLastChunkPerSlot(slots, 0), fChunks{chunks}
+      {
+         fChunkIndex.reserve(fChunks.size());
+         size_t next = 0;
+         for (auto &chunk : chunks) {
+            fFirstEntryPerChunk.push_back(next);
+            next += chunk->length();
+            fChunkIndex.push_back(next);
+         }
+         for (size_t si = 0, se = fValuesPtrPerSlot.size(); si != se; ++si) {
+            fArrayVisitorPerSlot.push_back(ArrayPtrVisitor{fValuesPtrPerSlot.data() + si});
+         }
+      }
+
+      /// This returns the ptr to the ptr to actual data.
+      std::vector<void *> slotPtrs()
+      {
+         std::vector<void *> result;
+         for (size_t i = 0; i < fValuesPtrPerSlot.size(); ++i) {
+            result.push_back(fValuesPtrPerSlot.data() + i);
+         }
+         return result;
+      }
+
+      // Convenience method to avoid code duplication between
+      // SetEntry and InitSlot
+      void UncachedSlotLookup(unsigned int slot, ULong64_t entry)
+      {
+         // If entry is greater than the previous one,
+         // we can skip all the chunks before the last one we
+         // queried.
+         size_t ci = 0;
+         assert(slot < fLastChunkPerSlot.size());
+         if (fLastEntryPerSlot[slot] < entry) {
+            ci = fLastChunkPerSlot.at(slot);
+         }
+
+         for (size_t ce = fChunkIndex.size(); ci != ce; ++ci) {
+            if (entry < fChunkIndex[ci]) {
+               assert(slot < fLastChunkPerSlot.size());
+               fLastChunkPerSlot[slot] = ci;
+               break;
+            }
+         }
+
+         // Update the pointer to the requested entry.
+         // Notice that we need to find the entry
+         auto chunk = fChunks.at(fLastChunkPerSlot[slot]);
+         assert(slot < fArrayVisitorPerSlot.size());
+         fArrayVisitorPerSlot[slot].SetEntry(entry - fFirstEntryPerChunk[fLastChunkPerSlot[slot]]);
+         auto status = chunk->Accept(fArrayVisitorPerSlot.data() + slot);
+         if (!status.ok()) {
+            std::string msg = "Could not get pointer for slot ";
+            msg += std::to_string(slot) + " looking at entry " + std::to_string(entry);
+            throw std::runtime_error(msg);
+         }
+      }
+
+      /// Set the current entry to be retrieved
+      void SetEntry(unsigned int slot, ULong64_t entry)
+      {
+         // Same entry as before
+         if (fLastEntryPerSlot[slot] == entry) {
+            return;
+         }
+         UncachedSlotLookup(slot, entry);
+      }
+   };
+
+   std::shared_ptr<arrow::Table> fTable;
+   std::vector<std::pair<ULong64_t, ULong64_t>> fEntryRanges;
+   std::vector<std::string> fColumnNames;
+   size_t fNSlots;
+
+   std::vector<std::pair<size_t, size_t>> fGetterIndex; // (columnId, visitorId)
+   std::vector<ValueGetter> fValueGetters;              // Visitors to be used to track and get entries. One per column.
+   std::vector<void *> GetColumnReadersImpl(std::string_view name, const std::type_info &type) override;
+
+public:
+   TArrowDS(std::shared_ptr<arrow::Table> table, std::vector<std::string> const &columns);
+   ~TArrowDS();
+   const std::vector<std::string> &GetColumnNames() const override;
+   std::vector<std::pair<ULong64_t, ULong64_t>> GetEntryRanges() override;
+   std::string GetTypeName(std::string_view colName) const override;
+   bool HasColumn(std::string_view colName) const override;
+   void SetEntry(unsigned int slot, ULong64_t entry) override;
+   void InitSlot(unsigned int slot, ULong64_t firstEntry) override;
+   void SetNSlots(unsigned int nSlots) override;
+   void Initialise() override;
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////
+/// \brief Factory method to create a Apache Arrow TDataFrame.
+/// \param[in] table an apache::arrow table to use as a source.
+TDataFrame MakeArrowDataFrame(std::shared_ptr<arrow::Table> table, std::vector<std::string> const &columns);
+
+} // namespace TDF
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/tree/treeplayer/src/TArrowDS.cxx
+++ b/tree/treeplayer/src/TArrowDS.cxx
@@ -1,0 +1,342 @@
+// Author: Giulio Eulisse CERN  2/2018
+
+/*************************************************************************
+ * Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+// clang-format off
+/** \class ROOT::Experimental::TDF::TArrowDS
+    \ingroup dataframe
+    \brief TDataFrame data source class to interface with Apache Arrow.
+
+The TArrowDS implements a proxy TDataSource to be able to use Apache Arrow
+tables with TDataFrame.
+
+A TDataFrame that adapts an arrow::Table class can be constructed using the factory method
+ROOT::Experimental::TDF::MakeArrowDataFrame, which accepts one parameter:
+1. An arrow::Table smart pointer.
+
+The types of the columns are derived from the types in the associated
+arrow::Schema. 
+
+*/
+// clang-format on
+
+#include <ROOT/TDFUtils.hxx>
+#include <ROOT/TSeq.hxx>
+#include <ROOT/TArrowDS.hxx>
+#include <ROOT/RMakeUnique.hxx>
+
+#include <algorithm>
+#include <sstream>
+#include <string>
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+#endif
+#include <arrow/table.h>
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+
+namespace ROOT {
+namespace Experimental {
+namespace TDF {
+
+/// Helper to get the contents of a given column
+
+/// Helper to get the human readable name of type
+class TDFTypeNameGetter : public ::arrow::TypeVisitor {
+private:
+   std::string fTypeName;
+
+public:
+   arrow::Status Visit(const arrow::Int64Type &) override
+   {
+      fTypeName = "Long64_t";
+      return arrow::Status::OK();
+   }
+   arrow::Status Visit(const arrow::Int32Type &) override
+   {
+      fTypeName = "Long32_t";
+      return arrow::Status::OK();
+   }
+   arrow::Status Visit(const arrow::UInt64Type &) override
+   {
+      fTypeName = "ULong64_t";
+      return arrow::Status::OK();
+   }
+   arrow::Status Visit(const arrow::UInt32Type &) override
+   {
+      fTypeName = "ULong32_t";
+      return arrow::Status::OK();
+   }
+   arrow::Status Visit(const arrow::FloatType &) override
+   {
+      fTypeName = "float";
+      return arrow::Status::OK();
+   }
+   arrow::Status Visit(const arrow::DoubleType &) override
+   {
+      fTypeName = "double";
+      return arrow::Status::OK();
+   }
+   arrow::Status Visit(const arrow::StringType &) override
+   {
+      fTypeName = "string";
+      return arrow::Status::OK();
+   }
+   arrow::Status Visit(const arrow::BooleanType &) override
+   {
+      fTypeName = "bool";
+      return arrow::Status::OK();
+   }
+   std::string result() { return fTypeName; }
+
+   using ::arrow::TypeVisitor::Visit;
+};
+
+/// Helper to determine if a given Column is a supported type.
+class VerifyValidColumnType : public ::arrow::TypeVisitor {
+private:
+public:
+   virtual arrow::Status Visit(const arrow::Int64Type &) override { return arrow::Status::OK(); }
+   virtual arrow::Status Visit(const arrow::Int32Type &) override { return arrow::Status::OK(); }
+   virtual arrow::Status Visit(const arrow::FloatType &) override { return arrow::Status::OK(); }
+   virtual arrow::Status Visit(const arrow::DoubleType &) override { return arrow::Status::OK(); }
+   virtual arrow::Status Visit(const arrow::StringType &) override { return arrow::Status::OK(); }
+   virtual arrow::Status Visit(const arrow::BooleanType &) override { return arrow::Status::OK(); }
+
+   using ::arrow::TypeVisitor::Visit;
+};
+
+////////////////////////////////////////////////////////////////////////
+/// Constructor to create an Arrow TDataSource for TDataFrame.
+/// \param[in] table the arrow Table to observe.
+/// \param[in] columns the name of the columns to use
+/// In case columns is empty, we use all the columns found in the table
+TArrowDS::TArrowDS(std::shared_ptr<arrow::Table> inTable, std::vector<std::string> const &inColumns)
+   : fTable{inTable}, fColumnNames{inColumns}, fNSlots(1)
+{
+   auto &columnNames = fColumnNames;
+   auto &table = fTable;
+   auto &index = fGetterIndex;
+   // We want to allow people to specify which columns they
+   // need so that we can think of upfront IO optimizations.
+   auto filterWantedColumns = [&columnNames, &table]()
+   {
+      if (columnNames.empty()) {
+         for (auto &field : table->schema()->fields()) {
+            columnNames.push_back(field->name());
+         }
+      }
+   };
+
+   auto getRecordsFirstColumn = [&columnNames, &table]()
+   {
+      if (columnNames.empty()) {
+         throw std::runtime_error("At least one column required");
+      }
+      auto name = columnNames.front();
+      auto index = table->schema()->GetFieldIndex(name);
+      return table->column(index)->length();
+   };
+
+   // All columns are supposed to have the same number of entries.
+   auto verifyColumnSize = [&table](std::shared_ptr<arrow::Column> column, int nRecords)
+   {
+      if (column->length() != nRecords) {
+         std::string msg = "Column ";
+         msg += column->name() + " has a different number of entries.";
+         throw std::runtime_error(msg);
+      }
+   };
+
+   /// For the moment we support only a few native types.
+   auto verifyColumnType = [](std::shared_ptr<arrow::Column> column) {
+      auto verifyType = std::make_unique<VerifyValidColumnType>();
+      auto result = column->type()->Accept(verifyType.get());
+      if (result.ok() == false) {
+         std::string msg = "Column ";
+         msg += column->name() + " contains an unsupported type.";
+         throw std::runtime_error(msg);
+      }
+   };
+
+   /// This is used to create an index between the columnId
+   /// and the associated getter.
+   auto addColumnToGetterIndex = [&index](int columnId)
+   {
+      index.push_back(std::make_pair(columnId, index.size()));
+   };
+
+   /// Assuming we can get called more than once, we need to
+   /// reset the getter index each time.
+   auto resetGetterIndex = [&index]() { index.clear(); };
+
+   /// This is what initialization actually does
+   filterWantedColumns();
+   resetGetterIndex();
+   auto nRecords = getRecordsFirstColumn();
+   for (auto &columnName : fColumnNames) {
+      auto columnIdx = fTable->schema()->GetFieldIndex(columnName);
+      addColumnToGetterIndex(columnIdx);
+
+      auto column = fTable->column(columnIdx);
+      verifyColumnSize(column, nRecords);
+      verifyColumnType(column);
+   }
+   SetNSlots(fNSlots);
+}
+
+////////////////////////////////////////////////////////////////////////
+/// Destructor.
+TArrowDS::~TArrowDS()
+{
+}
+
+const std::vector<std::string> &TArrowDS::GetColumnNames() const
+{
+   return fColumnNames;
+}
+
+std::vector<std::pair<ULong64_t, ULong64_t>> TArrowDS::GetEntryRanges()
+{
+   auto entryRanges(std::move(fEntryRanges)); // empty fEntryRanges
+   return entryRanges;
+}
+
+std::string TArrowDS::GetTypeName(std::string_view colName) const
+{
+   auto field = fTable->schema()->GetFieldByName(std::string(colName));
+   if (!field) {
+      std::string msg = "The dataset does not have column ";
+      msg += colName;
+      throw std::runtime_error(msg);
+   }
+   TDFTypeNameGetter typeGetter;
+   auto status = field->type()->Accept(&typeGetter);
+   if (status.ok() == false) {
+      std::string msg = "TArrowDS does not support a column of type ";
+      msg += field->type()->name();
+      throw std::runtime_error(msg);
+   }
+   return typeGetter.result();
+}
+
+bool TArrowDS::HasColumn(std::string_view colName) const
+{
+   auto field = fTable->schema()->GetFieldByName(std::string(colName));
+   if (!field) {
+      return false;
+   }
+   return true;
+}
+
+void TArrowDS::SetEntry(unsigned int slot, ULong64_t entry)
+{
+   for (auto link : fGetterIndex) {
+      auto column = fTable->column(link.first);
+      auto &getter = fValueGetters[link.second];
+      getter.SetEntry(slot, entry);
+   }
+}
+
+void TArrowDS::InitSlot(unsigned int slot, ULong64_t entry)
+{
+   for (auto link : fGetterIndex) {
+      auto column = fTable->column(link.first);
+      auto &getter = fValueGetters[link.second];
+      getter.UncachedSlotLookup(slot, entry);
+   }
+}
+
+void TArrowDS::SetNSlots(unsigned int nSlots)
+{
+   // We dump all the previous getters structures and we rebuild it.
+   auto nColumns = fGetterIndex.size();
+   auto &outNSlots = fNSlots;
+   auto &ranges = fEntryRanges;
+   auto &table = fTable;
+   auto &columnNames = fColumnNames;
+
+   fValueGetters.clear();
+   fValueGetters.reserve(nColumns);
+   for (size_t ci = 0; ci != nColumns; ++ci) {
+      auto chunkedArray = fTable->column(fGetterIndex[ci].first)->data();
+      fValueGetters.push_back(ValueGetter{nSlots, chunkedArray->chunks()});
+   }
+
+   // We use the same logic as the ROOTDS.
+   auto splitInEqualRanges = [&outNSlots, &ranges](int nRecords, unsigned int newNSlots)
+   {
+      ranges.clear();
+      outNSlots = newNSlots;
+      const auto chunkSize = nRecords / outNSlots;
+      const auto remainder = 1U == outNSlots ? 0 : nRecords % outNSlots;
+      auto start = 0UL;
+      auto end = 0UL;
+      for (auto i : ROOT::TSeqU(outNSlots)) {
+         start = end;
+         end += chunkSize;
+         ranges.emplace_back(start, end);
+         (void)i;
+      }
+      ranges.back().second += remainder;
+   };
+
+   auto getNRecords = [&table, &columnNames]()->int
+   {
+      auto index = table->schema()->GetFieldIndex(columnNames.front());
+      return table->column(index)->length();
+   };
+
+   auto nRecords = getNRecords();
+   splitInEqualRanges(nRecords, nSlots);
+}
+
+/// This needs to return a pointer to the pointer each value getter
+/// will point to.
+std::vector<void *> TArrowDS::GetColumnReadersImpl(std::string_view colName, const std::type_info &)
+{
+   auto &index = fGetterIndex;
+   auto findGetterIndex = [&index](unsigned int column)
+   {
+      for (auto &entry : index) {
+         if (entry.first == column) {
+            return entry.second;
+         }
+      }
+      throw std::runtime_error("No column found at index " + std::to_string(column));
+   };
+
+   const int columnIdx = fTable->schema()->GetFieldIndex(std::string(colName));
+   const int getterIdx = findGetterIndex(columnIdx);
+   assert(getterIdx != -1);
+   assert(getterIdx < fValueGetters.size());
+   return fValueGetters[getterIdx].slotPtrs();
+}
+
+void TArrowDS::Initialise()
+{
+}
+
+/// Creates a TDataFrame using an arrow::Table as input.
+/// \param[in] table the arrow Table to observe.
+/// \param[in] columnNames the name of the columns to use
+/// In case columnNames is empty, we use all the columns found in the table
+TDataFrame MakeArrowDataFrame(std::shared_ptr<arrow::Table> table, std::vector<std::string> const &columnNames)
+{
+   ROOT::Experimental::TDataFrame tdf(std::make_unique<TArrowDS>(table, columnNames));
+   return tdf;
+}
+
+} // namespace TDF
+} // namespace Experimental
+} // namespace ROOT

--- a/tree/treeplayer/test/CMakeLists.txt
+++ b/tree/treeplayer/test/CMakeLists.txt
@@ -24,6 +24,10 @@ ROOT_ADD_GTEST(datasource_root dataframe/datasource_root.cxx LIBRARIES TreePlaye
 ROOT_ADD_GTEST(datasource_trivial dataframe/datasource_trivial.cxx LIBRARIES TreePlayer)
 configure_file(dataframe/TCsvDS_test_headers.csv . COPYONLY)
 configure_file(dataframe/TCsvDS_test_noheaders.csv . COPYONLY)
+if(ARROW_FOUND)
+ROOT_ADD_GTEST(datasource_arrow dataframe/datasource_arrow.cxx LIBRARIES TreePlayer ${ARROW_SHARED_LIB})
+target_include_directories(datasource_arrow BEFORE PRIVATE ${ARROW_INCLUDE_DIR})
+endif()
 ROOT_ADD_GTEST(datasource_csv dataframe/datasource_csv.cxx LIBRARIES TreePlayer)
 ROOT_ADD_GTEST(datasource_lazy dataframe/datasource_lazy.cxx LIBRARIES TreePlayer)
 

--- a/tree/treeplayer/test/dataframe/datasource_arrow.cxx
+++ b/tree/treeplayer/test/dataframe/datasource_arrow.cxx
@@ -1,0 +1,229 @@
+#include <ROOT/TDataFrame.hxx>
+#include <ROOT/TArrowDS.hxx>
+#include <ROOT/TSeq.hxx>
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+#endif
+#include <arrow/record_batch.h>
+#include <arrow/memory_pool.h>
+#include <arrow/builder.h>
+#include <arrow/test-util.h>
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+#include <gtest/gtest.h>
+
+#include <iostream>
+
+using namespace ROOT::Experimental;
+using namespace ROOT::Experimental::TDF;
+using namespace arrow;
+
+std::shared_ptr<Schema> exampleSchema()
+{
+   return schema({field("Name", arrow::utf8()), field("Age", arrow::int64()), field("Height", arrow::float64()),
+                  field("Married", arrow::boolean())});
+}
+
+std::shared_ptr<Table> createTestTable()
+{
+   auto schema_ = exampleSchema();
+
+   std::vector<bool> is_valid(6, true);
+   std::vector<std::string> names = {"Harry", "Bob,Bob", "\"Joe\"", "Tom", " John  ", " Mary Ann "};
+   std::vector<int64_t> ages = {64, 50, 40, 30, 2, 0};
+   std::vector<double> heights = {180.0, 200.5, 1.7, 1.9, 1.0, 0.8};
+   std::vector<bool> marriageStatus = {true, true, false, true, false, false};
+
+   std::shared_ptr<Array> arrays_[4];
+
+   arrow::ArrayFromVector<StringType, std::string>(names, &arrays_[0]);
+   arrow::ArrayFromVector<Int64Type, int64_t>(ages, &arrays_[1]);
+   arrow::ArrayFromVector<DoubleType, double>(heights, &arrays_[2]);
+   arrow::ArrayFromVector<BooleanType, bool>(marriageStatus, &arrays_[3]);
+
+   std::vector<std::shared_ptr<Column>> columns_ = {
+      std::make_shared<Column>(schema_->field(0), arrays_[0]), std::make_shared<Column>(schema_->field(1), arrays_[1]),
+      std::make_shared<Column>(schema_->field(2), arrays_[2]), std::make_shared<Column>(schema_->field(3), arrays_[3])};
+
+   auto table_ = Table::Make(schema_, columns_);
+   return table_;
+}
+
+TEST(TArrowDS, ColTypeNames)
+{
+   TArrowDS tds(createTestTable(), {"Name", "Age", "Height", "Married"});
+   tds.SetNSlots(1);
+
+   auto colNames = tds.GetColumnNames();
+
+   EXPECT_TRUE(tds.HasColumn("Name"));
+   EXPECT_TRUE(tds.HasColumn("Age"));
+   EXPECT_FALSE(tds.HasColumn("Address"));
+
+   ASSERT_EQ(colNames.size(), 4U);
+   EXPECT_STREQ("Height", colNames[2].c_str());
+   EXPECT_STREQ("Married", colNames[3].c_str());
+
+   EXPECT_STREQ("string", tds.GetTypeName("Name").c_str());
+   EXPECT_STREQ("Long64_t", tds.GetTypeName("Age").c_str());
+   EXPECT_STREQ("double", tds.GetTypeName("Height").c_str());
+   EXPECT_STREQ("bool", tds.GetTypeName("Married").c_str());
+}
+
+TEST(TArrowDS, EntryRanges)
+{
+   TArrowDS tds(createTestTable(), {});
+   tds.SetNSlots(3U);
+   tds.Initialise();
+
+   // Still dividing in equal parts...
+   auto ranges = tds.GetEntryRanges();
+
+   ASSERT_EQ(3U, ranges.size());
+   EXPECT_EQ(0U, ranges[0].first);
+   EXPECT_EQ(2U, ranges[0].second);
+   EXPECT_EQ(2U, ranges[1].first);
+   EXPECT_EQ(4U, ranges[1].second);
+   EXPECT_EQ(4U, ranges[2].first);
+   EXPECT_EQ(6U, ranges[2].second);
+}
+
+TEST(TArrowDS, ColumnReaders)
+{
+   TArrowDS tds(createTestTable(), {});
+
+   const auto nSlots = 3U;
+   tds.SetNSlots(nSlots);
+   auto vals = tds.GetColumnReaders<Long64_t>("Age");
+   tds.Initialise();
+   auto ranges = tds.GetEntryRanges();
+   auto slot = 0U;
+   std::vector<Long64_t> ages = {64, 50, 40, 30, 2, 0};
+   for (auto &&range : ranges) {
+      tds.InitSlot(slot, range.first);
+      ASSERT_LT(slot, vals.size());
+      for (auto i : ROOT::TSeq<int>(range.first, range.second)) {
+         tds.SetEntry(slot, i);
+         auto val = **vals[slot];
+         EXPECT_EQ(ages[i], val);
+      }
+      slot++;
+   }
+}
+
+TEST(TArrowDS, ColumnReadersString)
+{
+   TArrowDS tds(createTestTable(), {});
+
+   const auto nSlots = 3U;
+   tds.SetNSlots(nSlots);
+   auto vals = tds.GetColumnReaders<std::string>("Name");
+   tds.Initialise();
+   auto ranges = tds.GetEntryRanges();
+   auto slot = 0U;
+   std::vector<std::string> names = {"Harry", "Bob,Bob", "\"Joe\"", "Tom", " John  ", " Mary Ann "};
+   for (auto &&range : ranges) {
+      tds.InitSlot(slot, range.first);
+      ASSERT_LT(slot, vals.size());
+      for (auto i : ROOT::TSeq<int>(range.first, range.second)) {
+         tds.SetEntry(slot, i);
+         auto val = *((std::string *)*vals[slot]);
+         ASSERT_LT(i, names.size());
+         EXPECT_EQ(names[i], val);
+      }
+      slot++;
+   }
+}
+
+#ifndef NDEBUG
+
+TEST(TArrowDS, SetNSlotsTwice)
+{
+   auto theTest = []() {
+      TArrowDS tds(createTestTable(), {});
+      tds.SetNSlots(1);
+      tds.SetNSlots(1);
+   };
+   ASSERT_DEATH(theTest(), "Setting the number of slots even if the number of slots is different from zero.");
+}
+#endif
+
+#ifdef R__B64
+
+TEST(TArrowDS, FromATDF)
+{
+   std::unique_ptr<TDataSource> tds(new TArrowDS(createTestTable(), {}));
+   TDataFrame tdf(std::move(tds));
+   auto max = tdf.Max<double>("Height");
+   auto min = tdf.Min<double>("Height");
+   auto c = tdf.Count();
+
+   EXPECT_EQ(6U, *c);
+   EXPECT_DOUBLE_EQ(200.5, *max);
+   EXPECT_DOUBLE_EQ(0.8, *min);
+}
+
+TEST(TArrowDS, FromATDFWithJitting)
+{
+   std::unique_ptr<TDataSource> tds(new TArrowDS(createTestTable(), {}));
+   TDataFrame tdf(std::move(tds));
+   auto max = tdf.Filter("Age<40").Max("Age");
+   auto min = tdf.Define("Age2", "Age").Filter("Age2>30").Min("Age2");
+
+   EXPECT_EQ(30, *max);
+   EXPECT_EQ(40, *min);
+}
+
+// NOW MT!-------------
+#ifdef R__USE_IMT
+
+TEST(TArrowDS, DefineSlotCheckMT)
+{
+   const auto nSlots = 4U;
+   ROOT::EnableImplicitMT(nSlots);
+
+   std::vector<unsigned int> ids(nSlots, 0u);
+   std::unique_ptr<TDataSource> tds(new TArrowDS(createTestTable(), {}));
+   TDataFrame d(std::move(tds));
+   auto m = d.DefineSlot("x", [&](unsigned int slot) {
+                ids[slot] = 1u;
+                return 1;
+             }).Max("x");
+   EXPECT_EQ(1, *m); // just in case
+
+   const auto nUsedSlots = std::accumulate(ids.begin(), ids.end(), 0u);
+   EXPECT_GT(nUsedSlots, 0u);
+   EXPECT_LE(nUsedSlots, nSlots);
+}
+
+TEST(TArrowDS, FromATDFMT)
+{
+   std::unique_ptr<TDataSource> tds(new TArrowDS(createTestTable(), {}));
+   TDataFrame tdf(std::move(tds));
+   auto max = tdf.Max<double>("Height");
+   auto min = tdf.Min<double>("Height");
+   auto c = tdf.Count();
+
+   EXPECT_EQ(6U, *c);
+   EXPECT_DOUBLE_EQ(200.5, *max);
+   EXPECT_DOUBLE_EQ(.8, *min);
+}
+
+TEST(TArrowDS, FromATDFWithJittingMT)
+{
+   std::unique_ptr<TDataSource> tds(new TArrowDS(createTestTable(), {}));
+   TDataFrame tdf(std::move(tds));
+   auto max = tdf.Filter("Age<40").Max("Age");
+   auto min = tdf.Define("Age2", "Age").Filter("Age2>30").Min("Age2");
+
+   EXPECT_EQ(30, *max);
+   EXPECT_EQ(40, *min);
+}
+
+#endif // R__USE_IMT
+
+#endif // R__B64


### PR DESCRIPTION
Apache Arrow is a cross-language development platform for in-memory data
which is backed by a number of opensource projects including Calcite,
Cassandra, Drill, Hadoop, HBase, Ibis, Impala, Kudu, Pandas, Parquet,
Phoenix, Spark, and Storm. This implements a TDataSource which allows
using columns in a `arrow::Table` as an input to a TDataFrame.