### PR TITLE
Delete loop from RooCintUtils::isValidEnumValue

### DIFF
--- a/roofit/roofitcore/src/RooCintUtils.cxx
+++ b/roofit/roofitcore/src/RooCintUtils.cxx
@@ -110,6 +110,7 @@ namespace RooCintUtils
   {
     // Returns true if given type is an enum
      
+    // FIXME: We don't have any guarantee that typeName is less than 256 bytes
     // Chop type name into class name and enum name
     char buf[256] ;
     strlcpy(buf,typeName,256) ;
@@ -122,21 +123,15 @@ namespace RooCintUtils
 
     ClassInfo_t* cls = gInterpreter->ClassInfo_Factory(className);
     DataMemberInfo_t* dm = gInterpreter->DataMemberInfo_Factory(cls);
-    while (gInterpreter->DataMemberInfo_Next(dm)) {
-      // Check if this data member represents an enum value
-      // there is no "const" with CLING 
-      //if (string(Form("const %s",typeName))==gInterpreter->DataMemberInfo_TypeName(dm)) {  // this for 5.34
-      if (string(Form("%s",typeName))==gInterpreter->DataMemberInfo_TypeName(dm)) {
-	if (string(value)==gInterpreter->DataMemberInfo_Name(dm)) {
-          gInterpreter->DataMemberInfo_Delete(dm);
-          gInterpreter->ClassInfo_Delete(cls);
-	  return kTRUE ;
-	}
-      }
-    }
-    gInterpreter->DataMemberInfo_Delete(dm);
-    gInterpreter->ClassInfo_Delete(cls);
-    return kFALSE ;
+
+    Bool_t res;
+
+    if (string(value)==gInterpreter->DataMemberInfo_Name(dm))
+      res = kTRUE;
+    else
+      res = kFALSE;
+
+    return res;
   }
 }
 

--- a/roofit/roofitcore/src/RooCintUtils.cxx
+++ b/roofit/roofitcore/src/RooCintUtils.cxx
@@ -25,6 +25,7 @@
 
 #include "RooMsgService.h"
 #include "TInterpreter.h"
+#include "TEnum.h"
 
 #include <string.h>
 #include <string>
@@ -116,25 +117,7 @@ namespace RooCintUtils
     strlcpy(buf,typeName,256) ;
     char* className = strtok(buf,":") ;
 
-    // Chop any class name prefix from value
-    if (strrchr(value,':')) {
-      value = strrchr(value,':')+1 ;
-    }
-
-    ClassInfo_t* cls = gInterpreter->ClassInfo_Factory(className);
-    DataMemberInfo_t* dm = gInterpreter->DataMemberInfo_Factory(cls);
-
-    Bool_t res;
-
-    if (string(value)==gInterpreter->DataMemberInfo_Name(dm))
-      res = kTRUE;
-    else
-      res = kFALSE;
-
-    gInterpreter->DataMemberInfo_Delete(dm);
-    gInterpreter->ClassInfo_Delete(cls);
-
-    return res;
+    return (strcmp(TEnum::GetEnum(className)->GetName(), value) == 0);
   }
 }
 

--- a/roofit/roofitcore/src/RooCintUtils.cxx
+++ b/roofit/roofitcore/src/RooCintUtils.cxx
@@ -131,6 +131,9 @@ namespace RooCintUtils
     else
       res = kFALSE;
 
+    gInterpreter->DataMemberInfo_Delete(dm);
+    gInterpreter->ClassInfo_Delete(cls);
+
     return res;
   }
 }


### PR DESCRIPTION
We want to compare the first token of typeName separated by ":" and
value, and we only have to see it once.