### PR TITLE
[cling] Value print memory address of C++ object with oveloaded &

### DIFF
--- a/interpreter/cling/CMakeLists.txt
+++ b/interpreter/cling/CMakeLists.txt
@@ -434,11 +434,14 @@ else()
 endif()
 
 if( CLING_INCLUDE_TESTS )
-  set(cling_include_deflt "${CMAKE_INSTALL_PREFIX}/include${cling_path_delim}\
-${CMAKE_CURRENT_SOURCE_DIR}/include${cling_path_delim}\
-${CLANG_INCLUDE_DIRS}${cling_path_delim}\
-${LLVM_INCLUDE_DIRS}"
-    )
+  set(cling_include_deflt ${CMAKE_INSTALL_PREFIX}/include
+                          ${CMAKE_CURRENT_SOURCE_DIR}/include
+                          ${CLANG_INCLUDE_DIRS}
+                          ${LLVM_INCLUDE_DIRS}
+  )
+
+  # CLANG_INCLUDE_DIRS and LLVM_INCLUDE_DIRS can be a semicolon separated lists.
+  string(REPLACE ";" ${cling_path_delim} cling_include_deflt "${cling_include_deflt}")
 endif()
 
 if(NOT CLING_INCLUDE_PATHS)

--- a/interpreter/cling/lib/Interpreter/ValueExtractionSynthesizer.h
+++ b/interpreter/cling/lib/Interpreter/ValueExtractionSynthesizer.h
@@ -45,6 +45,10 @@ namespace cling {
     ///
     clang::Expr* m_UnresolvedCopyArray;
 
+    ///\brief std::addressof cache.
+    ///
+    clang::Expr* m_UnresolvedStdAddressOf;
+
     bool m_isChildInterpreter;
 
 public:

--- a/interpreter/cling/test/Autoloading/AutoForwarding.C
+++ b/interpreter/cling/test/Autoloading/AutoForwarding.C
@@ -7,10 +7,6 @@
 //------------------------------------------------------------------------------
 
 // RUN: cat %s | %cling -I%S -Xclang -verify
-//
-//   XFAIL: *
-//   until enum autoloading is fixed.
-//
 // Test FwdPrinterTest
 
 // Test similar to ROOT-7037

--- a/interpreter/cling/test/Prompt/ValuePrinter/Regression.C
+++ b/interpreter/cling/test/Prompt/ValuePrinter/Regression.C
@@ -107,3 +107,11 @@ void f(std::string) {}
 f // CHECK: (void (*)(std::string)) Function @0x{{[0-9a-f]+}}
 // CHECK: at input_line_{{[0-9].*}}:1:
 // CHECK: void f(std::string) {}
+
+class notapointer {};
+struct OverloadedAddrOf {
+  notapointer operator&() {
+    return notapointer();
+  }
+};
+OverloadedAddrOf overloadedAddrOf


### PR DESCRIPTION
The patch teaches cling to print the proper address of C++ objects with overloaded address-of operator.