### PR TITLE
[roofit] Add a non-const overload.

### DIFF
--- a/roofit/roofitcore/inc/RooMCStudy.h
+++ b/roofit/roofitcore/inc/RooMCStudy.h
@@ -58,6 +58,9 @@ public:
   const RooArgSet* fitParams(Int_t sampleNum) const ;
   const RooFitResult* fitResult(Int_t sampleNum) const ;
   const RooAbsData* genData(Int_t sampleNum) const ;
+  RooAbsData* genData(Int_t sampleNum) {
+    return const_cast<RooAbsData*>(const_cast<const RooMCStudy *>(this)->genData(sampleNum));
+  }
   const RooDataSet& fitParDataSet() ;
   const RooDataSet* genParDataSet() const { 
     // Return dataset with generator parameters for each toy. When constraints are used these


### PR DESCRIPTION
This allows uses such as:
RooMCStudy* mcstudy = new RooMCStudy;
auto var = RooStats::ProfileLikelihoodCalculator(mcstudy->genData(),...);
to compile and work without the users to have to use const_casts.