### PR TITLE
Use GetListOfClasses instead of iterating over AST

### DIFF
--- a/core/rint/src/TTabCom.cxx
+++ b/core/rint/src/TTabCom.cxx
@@ -426,45 +426,7 @@ void TTabCom::RehashAll()
 
 const TSeqCollection *TTabCom::GetListOfClasses()
 {
-   if (!fpClasses) {
-      fpClasses = new THashList;
-      // Iterate over the table from the map file.
-      THashList* entries = gInterpreter->GetMapfile()->GetTable();
-      TIter next(entries);
-      while (const auto key = next()) {
-         // This is not needed with the new rootmap format
-         const char* className = key->GetName();
-         if (!strncmp(className, "Library.", 8))
-            className += 8;
-
-         if (!strstr(className, ".h"))
-            fpClasses->Add(new TObjString(className));
-      }
-
-      // We might have autoload entries that don't have a rootmap entry
-      // (libCore) and no interpreter info (not yet loaded).
-      TClassTable::Init(); // reset counter
-      while (const char* className = TClassTable::Next()) {
-         if (!fpClasses->FindObject(className)) {
-            fpClasses->Add(new TObjString(className));
-         }
-      }
-   }
-
-   if (fPrevInterpMarker != gInterpreter->GetInterpreterStateMarker()) {
-      ClassInfo_t* ci = gInterpreter->ClassInfo_Factory(kFALSE /*all*/);
-      while (gInterpreter->ClassInfo_Next(ci)) {
-         const char* className = gInterpreter->ClassInfo_FullName(ci);
-         if (strstr(className, "(anonymous)"))
-            continue;
-         if (!fpClasses->FindObject(className)) {
-            fpClasses->Add(new TObjString(className));
-         }
-      }
-      gInterpreter->ClassInfo_Delete(ci);
-   }
-
-   return fpClasses;
+   return (TSeqCollection*) gROOT->GetListOfClasses();
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
GetListOfClasses is returning fClasses, which is a collection of classes
in TCollection type.

If I'm understanding collectly, fClasses in TROOT is initialized at the entry
point so it's already on the memory.