### PR TITLE
Improve diagnostics when interface called with wrong arguments.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -4082,9 +4082,10 @@ TClass *TCling::GenerateTClass(ClassInfo_t *classinfo, Bool_t silent /* = kFALSE
 ///    gInterpreter->GenerateDictionary("myclass","myclass.h;myhelper.h");
 /// ~~~
 
-Int_t TCling::GenerateDictionary(const char* classes, const char* includes /* = 0 */, const char* /* options  = 0 */)
+Int_t TCling::GenerateDictionary(const char* classes, const char* includes /* = "" */, const char* /* options  = 0 */)
 {
    if (classes == 0 || classes[0] == 0) {
+      Error("TCling::GenerateDictionary", "Cannot generate dictionary without passing classes.");
       return 0;
    }
    // Split the input list
@@ -4104,6 +4105,8 @@ Int_t TCling::GenerateDictionary(const char* classes, const char* includes /* = 
       }
    }
    std::vector<std::string> listIncludes;
+   if (!includes)
+      includes = "";
    for (
       const char* current = includes, *prev = includes;
       *current != 0;

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -4122,7 +4122,7 @@ Int_t TCling::GenerateDictionary(const char* classes, const char* includes /* = 
       }
    }
    // Generate the temporary dictionary file
-   return TCling_GenerateDictionary(listClasses, listIncludes,
+   return !TCling_GenerateDictionary(listClasses, listIncludes,
       std::vector<std::string>(), std::vector<std::string>());
 }
 

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -188,7 +188,7 @@ public: // Public Interface
    Int_t   GetMore() const { return fMore; }
    TClass *GenerateTClass(const char *classname, Bool_t emulation, Bool_t silent = kFALSE);
    TClass *GenerateTClass(ClassInfo_t *classinfo, Bool_t silent = kFALSE);
-   Int_t   GenerateDictionary(const char* classes, const char* includes = 0, const char* options = 0);
+   Int_t   GenerateDictionary(const char* classes, const char* includes = "", const char* options = 0);
    char*   GetPrompt() { return fPrompt; }
    const char* GetSharedLibs();
    const char* GetClassSharedLibs(const char* cls);

--- a/core/metacling/test/TClingTests.cxx
+++ b/core/metacling/test/TClingTests.cxx
@@ -1,0 +1,106 @@
+#include "TClass.h"
+#include "TInterpreter.h"
+#include "TSystem.h"
+
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+// Copied from TFileMergerTests.cxx.
+// FIXME: Factor out in a new testing library in ROOT.
+namespace {
+using testing::internal::GetCapturedStderr;
+using testing::internal::CaptureStderr;
+using testing::internal::RE;
+class ExpectedErrorRAII {
+   std::string ExpectedRegex;
+   void pop()
+   {
+      std::string Seen = GetCapturedStderr();
+      bool match = RE::FullMatch(Seen, RE(ExpectedRegex));
+      EXPECT_TRUE(match);
+      if (!match) {
+         std::string msg = "Match failed!\nSeen: '" + Seen + "'\nRegex: '" + ExpectedRegex + "'\n";
+         GTEST_NONFATAL_FAILURE_(msg.c_str());
+      }
+   }
+
+public:
+   ExpectedErrorRAII(std::string E) : ExpectedRegex(E) { CaptureStderr(); }
+   ~ExpectedErrorRAII() { pop(); }
+};
+}
+
+#define EXPECT_ROOT_ERROR(expression, expected_error) \
+   {                                                  \
+      ExpectedErrorRAII EE(expected_error);           \
+      expression;                                     \
+   }
+
+// FIXME: We should probably have such a facility in TCling.
+static void cleanup()
+{
+   // Remove AutoDict
+   void* dir = gSystem->OpenDirectory(gSystem->pwd());
+   const char* name = 0;
+   while ((name = gSystem->GetDirEntry(dir)))
+      if (!strncmp(name, "AutoDict_", 9))
+         gSystem->Unlink(name);
+
+   gSystem->FreeDirectory(dir);
+}
+
+class TClingTests : public ::testing::Test {
+protected:
+   // virtual void SetUp() { }
+
+   // FIXME: We cannot rely on TearDown because it is executed at the end of
+   // every test. This triggers another bug in the dictionary generation phase,
+   // possibly due to concurrent file system operations.
+   //virtual void TearDown() {
+      // If there are failures we want to keep the created files.
+      //if (!::testing::Test::HasFatalFailure())
+      //   cleanup();
+   //}
+
+};
+
+// FIXME: Merge with TearDown.
+struct CleanupRAII {
+   CleanupRAII() {
+      if (!::testing::Test::HasFatalFailure())
+         cleanup();
+   }
+} Cleanup;
+
+TEST_F(TClingTests, GenerateDictionaryErrorHandling)
+{
+   // Check error reporting and handling.
+   EXPECT_ROOT_ERROR(ASSERT_FALSE(gInterpreter->GenerateDictionary("", "")),
+                     "Error in .* Cannot generate dictionary without passing classes.\n");
+   EXPECT_ROOT_ERROR(ASSERT_FALSE(gInterpreter->GenerateDictionary(nullptr, nullptr)),
+                     "Error in .* Cannot generate dictionary without passing classes.\n");
+}
+
+TEST_F(TClingTests, GenerateDictionaryRegression)
+{
+   // Make sure we do not crash or go in an infinite loop.
+   ASSERT_TRUE(gInterpreter->GenerateDictionary("std::set<int>"));
+   ASSERT_TRUE(gInterpreter->GenerateDictionary("std::set<int>", ""));
+   ASSERT_TRUE(gInterpreter->GenerateDictionary("std::set<int>", "set"));
+
+   // FIXME: This makes the linkdef parser go in an infinite loop.
+   //ASSERT_TRUE(gInterpreter->GenerateDictionary("std::vector<std::array<int, 5>>", ""));
+}
+
+TEST_F(TClingTests, GenerateDictionary)
+{
+   auto cl = TClass::GetClass("vector<TNamed*>");
+   ASSERT_FALSE(cl && cl->IsLoaded());
+
+   ASSERT_TRUE(gInterpreter->GenerateDictionary("std::vector<TNamed*>"));
+   cl = TClass::GetClass("vector<TNamed*>");
+   ASSERT_TRUE(cl != nullptr);
+   ASSERT_TRUE(cl->IsLoaded());
+}
+


### PR DESCRIPTION
If we call `gInterpreter->GenerateDictionary("std::vector<int>")` with
missing second parameter (which expects to pass the corresponding include)
we crash.

This patch enables error reporting and removes the default argument to
tell the user that nullptr is not expected.