### PR TITLE
Add cwd to prebuilt module path.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1253,7 +1253,7 @@ TCling::TCling(const char *name, const char *title)
    fMetaProcessor = new cling::MetaProcessor(*fInterpreter, fMPOuts);
 
    if (fInterpreter->getCI()->getLangOpts().Modules) {
-      fInterpreter->getCI()->getHeaderSearchOpts().AddPrebuiltModulePath(".");
+      //fInterpreter->getCI()->getHeaderSearchOpts().AddPrebuiltModulePath(".");
 
       // Setup core C++ modules if we have any to setup.
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1253,6 +1253,8 @@ TCling::TCling(const char *name, const char *title)
    fMetaProcessor = new cling::MetaProcessor(*fInterpreter, fMPOuts);
 
    if (fInterpreter->getCI()->getLangOpts().Modules) {
+      fInterpreter->getCI()->getHeaderSearchOpts().AddPrebuiltModulePath(".");
+
       // Setup core C++ modules if we have any to setup.
 
       // Load libc and stl first.


### PR DESCRIPTION
This will be able to find modules generated by rootcling outside of
the standard ROOT build.

This is often the case when we have custom dictionaries.