### PR TITLE
Support r-value reference parameters in TClingCallFunc

### DIFF
--- a/core/metacling/src/TClingCallFunc.cxx
+++ b/core/metacling/src/TClingCallFunc.cxx
@@ -320,7 +320,7 @@ void TClingCallFunc::collect_type_info(QualType &QT, ostringstream &typedefbuf, 
       QT = cast<clang::PointerType>(QT)->getPointeeType();
    } else if (QT->isReferenceType()) {
       if (QT->isRValueReferenceType()) refType = kRValueReference;
-      else refType = kReference;
+      else refType = kLValueReference;
       QT = cast<ReferenceType>(QT)->getPointeeType();
    }
    // Fall through for the array type to deal with reference/pointer ro array type.
@@ -376,7 +376,7 @@ void TClingCallFunc::make_narg_ctor(const unsigned N, ostringstream &typedefbuf,
       }
       if (refType != kNotReference) {
          callbuf << "(" << type_name.c_str() <<
-                 (refType == kReference ? "&" : "&&") << ")*(" << type_name.c_str() << "*)args["
+                 (refType == kLValueReference ? "&" : "&&") << ")*(" << type_name.c_str() << "*)args["
                  << i << "]";
       } else if (isPointer) {
          callbuf << "*(" << type_name.c_str() << "**)args["
@@ -490,7 +490,7 @@ void TClingCallFunc::make_narg_call(const std::string &return_type, const unsign
 
       if (refType != kNotReference) {
          callbuf << "(" << type_name.c_str() <<
-                 (refType == kReference ? "&" : "&&") << ")*(" << type_name.c_str() << "*)args["
+                 (refType == kLValueReference ? "&" : "&&") << ")*(" << type_name.c_str() << "*)args["
                  << i << "]";
       } else if (isPointer) {
          callbuf << "*(" << type_name.c_str() << "**)args["

--- a/core/metacling/src/TClingCallFunc.h
+++ b/core/metacling/src/TClingCallFunc.h
@@ -79,7 +79,7 @@ private:
 private:
    enum EReferenceType {
       kNotReference,
-      kReference,
+      kLValueReference,
       kRValueReference
    };
 

--- a/core/metacling/src/TClingCallFunc.h
+++ b/core/metacling/src/TClingCallFunc.h
@@ -77,6 +77,12 @@ private:
    bool fReturnIsRecordType : 1;
 
 private:
+   enum EReferenceType {
+      kNotReference,
+      kReference,
+      kRValueReference
+   };
+
    using ExecWithRetFunc_t =  std::function<void(void* address, cling::Value &ret)>;
 
    void* compile_wrapper(const std::string& wrapper_name,
@@ -85,7 +91,7 @@ private:
 
    void collect_type_info(clang::QualType& QT, std::ostringstream& typedefbuf,
                           std::ostringstream& callbuf, std::string& type_name,
-                          bool& isReference, bool& isPointer, int indent_level,
+                          EReferenceType& refType, bool& isPointer, int indent_level,
                           bool forArgument);
 
    void make_narg_call(const std::string &return_type, const unsigned N, std::ostringstream &typedefbuf,

--- a/core/metacling/test/TClingCallFuncTests.cxx
+++ b/core/metacling/test/TClingCallFuncTests.cxx
@@ -106,6 +106,26 @@ TEST(TClingCallFunc, FunctionWrapperVoid)
    gInterpreter->ClassInfo_Delete(GlobalNamespace);
 }
 
+TEST(TClingCallFunc, FunctionWrapperRValueRefArg)
+{
+   gInterpreter->Declare(R"cpp(
+                           void FunctionWrapperFuncRValueRefArg(int&& j) {}
+                           )cpp");
+
+   ClassInfo_t *GlobalNamespace = gInterpreter->ClassInfo_Factory("");
+   CallFunc_t *mc = gInterpreter->CallFunc_Factory();
+   long offset = 0;
+
+   gInterpreter->CallFunc_SetFuncProto(mc, GlobalNamespace, "FunctionWrapperFuncRValueRefArg", "int&&", &offset);
+   std::string wrapper = gInterpreter->CallFunc_GetWrapperCode(mc);
+
+   ASSERT_TRUE(gInterpreter->Declare(wrapper.c_str()));
+
+   // Cleanup
+   gInterpreter->CallFunc_Delete(mc);
+   gInterpreter->ClassInfo_Delete(GlobalNamespace);
+}
+
 TEST(TClingCallFunc, FunctionWrapperVariadic)
 {
    gInterpreter->Declare(R"cpp(


### PR DESCRIPTION
This PR adds some functionality to TClingCallFunc in order to handle moves in function parameters. The changes were implemented by Wim Lavrijsen in Cppyy's Cling and requested for ROOT's here:

https://sft.its.cern.ch/jira/browse/ROOT-9075

This PR also incorporates @pcanal's suggestion of using an enum to describe the reference type.