### PR TITLE
Delete unnecessary includes from RooFactoryWSTool

### DIFF
--- a/roofit/roofitcore/src/RooFactoryWSTool.cxx
+++ b/roofit/roofitcore/src/RooFactoryWSTool.cxx
@@ -37,9 +37,7 @@ instantiate objects.
 #include "RooMsgService.h"
 #include "RooWorkspace.h"
 #include "TInterpreter.h"
-#include "TClass.h"
 #include "TEnum.h"
-#include "TClassTable.h"
 #include "RooAbsPdf.h"
 #include "RooGaussian.h"
 #include <fstream>


### PR DESCRIPTION
TClassTable.h and TClass.h were included but not used in this file.