### PR TITLE
Make TBufferMerger agnostic about user's model for parallelism

### DIFF
--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -106,6 +106,7 @@ private:
 
    void Init(TFile*);
 
+   void Merge();
    void Push(TBufferFile *buffer);
    void WriteOutputFile();
 

--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -106,7 +106,7 @@ private:
    /** TBufferMerger has no copy operator */
    TBufferMerger &operator=(const TBufferMerger &);
 
-   void Init(std::unique_ptr<TFile>);
+   void Init(TFile*);
 
    void Push(TBufferFile *buffer);
    void WriteOutputFile();

--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -110,6 +110,7 @@ private:
    void WriteOutputFile();
 
    size_t fAutoSave;                                             // AutoSave only every fAutoSave bytes
+   size_t fBuffered;                                             // Number of bytes currently buffered
    TFileMerger fMerger;                                          // TFileMerger used to merge all buffers
    std::mutex fQueueMutex;                                       // Mutex used to lock fQueue
    std::condition_variable fDataAvailable;                       // Condition variable used to wait for data

--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -15,12 +15,10 @@
 #include "TFileMerger.h"
 #include "TMemFile.h"
 
-#include <condition_variable>
 #include <functional>
 #include <memory>
 #include <mutex>
 #include <queue>
-#include <thread>
 
 namespace ROOT {
 namespace Experimental {
@@ -108,15 +106,13 @@ private:
 
    void Merge();
    void Push(TBufferFile *buffer);
-   void WriteOutputFile();
 
    size_t fAutoSave{0};                                          // AutoSave only every fAutoSave bytes
    size_t fBuffered{0};                                          // Number of bytes currently buffered
    TFileMerger fMerger{false, false};                            // TFileMerger used to merge all buffers
+   std::mutex fMergeMutex;                                       // Mutex used to lock fMerger
    std::mutex fQueueMutex;                                       // Mutex used to lock fQueue
-   std::condition_variable fDataAvailable;                       // Condition variable used to wait for data
    std::queue<TBufferFile *> fQueue;                             // Queue to which data is pushed and merged
-   std::unique_ptr<std::thread> fMergingThread;                  // Worker thread that writes to disk
    std::vector<std::weak_ptr<TBufferMergerFile>> fAttachedFiles; // Attached files
    std::function<void(void)> fCallback;                          // Callback for when data is removed from queue
 };

--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -109,16 +109,14 @@ private:
    void Push(TBufferFile *buffer);
    void WriteOutputFile();
 
-   size_t fAutoSave;                                             //< AutoSave only every fAutoSave bytes
-   TFileMerger fMerger;                                          //< TFileMerger used to merge all buffers
-   std::mutex fQueueMutex;                                       //< Mutex used to lock fQueue
-   std::condition_variable fDataAvailable;                       //< Condition variable used to wait for data
-   std::queue<TBufferFile *> fQueue;                             //< Queue to which data is pushed and merged
-   std::unique_ptr<std::thread> fMergingThread;                  //< Worker thread that writes to disk
-   std::vector<std::weak_ptr<TBufferMergerFile>> fAttachedFiles; //< Attached files
-   std::function<void(void)> fCallback;                          //< Callback for when data is removed from queue
-
-   ClassDef(TBufferMerger, 0);
+   size_t fAutoSave;                                             // AutoSave only every fAutoSave bytes
+   TFileMerger fMerger;                                          // TFileMerger used to merge all buffers
+   std::mutex fQueueMutex;                                       // Mutex used to lock fQueue
+   std::condition_variable fDataAvailable;                       // Condition variable used to wait for data
+   std::queue<TBufferFile *> fQueue;                             // Queue to which data is pushed and merged
+   std::unique_ptr<std::thread> fMergingThread;                  // Worker thread that writes to disk
+   std::vector<std::weak_ptr<TBufferMergerFile>> fAttachedFiles; // Attached files
+   std::function<void(void)> fCallback;                          // Callback for when data is removed from queue
 };
 
 /**

--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -12,6 +12,7 @@
 #ifndef ROOT_TBufferMerger
 #define ROOT_TBufferMerger
 
+#include "TFileMerger.h"
 #include "TMemFile.h"
 
 #include <condition_variable>
@@ -108,8 +109,8 @@ private:
    void Push(TBufferFile *buffer);
    void WriteOutputFile();
 
-   TFile* fFile;                                                 //< Output file.
    size_t fAutoSave;                                             //< AutoSave only every fAutoSave bytes
+   TFileMerger fMerger;                                          //< TFileMerger used to merge all buffers
    std::mutex fQueueMutex;                                       //< Mutex used to lock fQueue
    std::condition_variable fDataAvailable;                       //< Condition variable used to wait for data
    std::queue<TBufferFile *> fQueue;                             //< Queue to which data is pushed and merged

--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -110,9 +110,9 @@ private:
    void Push(TBufferFile *buffer);
    void WriteOutputFile();
 
-   size_t fAutoSave;                                             // AutoSave only every fAutoSave bytes
-   size_t fBuffered;                                             // Number of bytes currently buffered
-   TFileMerger fMerger;                                          // TFileMerger used to merge all buffers
+   size_t fAutoSave{0};                                          // AutoSave only every fAutoSave bytes
+   size_t fBuffered{0};                                          // Number of bytes currently buffered
+   TFileMerger fMerger{false, false};                            // TFileMerger used to merge all buffers
    std::mutex fQueueMutex;                                       // Mutex used to lock fQueue
    std::condition_variable fDataAvailable;                       // Condition variable used to wait for data
    std::queue<TBufferFile *> fQueue;                             // Queue to which data is pushed and merged

--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -21,9 +21,6 @@
 #include <queue>
 #include <thread>
 
-class TBufferFile;
-class TFile;
-
 namespace ROOT {
 namespace Experimental {
 

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -26,19 +26,19 @@ TBufferMerger::TBufferMerger(const char *name, Option_t *option, Int_t compress)
    // instantiating a TBufferMerger should not alter gDirectory's state.
    TDirectory::TContext ctxt;
    if (TFile *output = TFile::Open(name, option, /*title*/ name, compress))
-      Init(std::unique_ptr<TFile>(output));
+      Init(output);
    else
       Error("OutputFile", "cannot open the MERGER output file %s", name);
 }
 
 TBufferMerger::TBufferMerger(std::unique_ptr<TFile> output)
 {
-   Init(std::move(output));
+   Init(output.release());
 }
 
-void TBufferMerger::Init(std::unique_ptr<TFile> output)
+void TBufferMerger::Init(TFile *output)
 {
-   fFile = output.release();
+   fFile = output;
    fAutoSave = 0;
    fMergingThread.reset(new std::thread([&]() { this->WriteOutputFile(); }));
 }

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -90,6 +90,16 @@ void TBufferMerger::SetAutoSave(size_t size)
    fAutoSave = size;
 }
 
+void TBufferMerger::Merge()
+{
+   fBuffered = 0;
+   fMerger.PartialMerge();
+   fMerger.Reset();
+
+   if (fCallback)
+      fCallback();
+}
+
 void TBufferMerger::WriteOutputFile()
 {
    std::unique_ptr<TBufferFile> buffer;
@@ -116,19 +126,11 @@ void TBufferMerger::WriteOutputFile()
          new TMemFile(fMerger.GetOutputFileName(), buffer->Buffer() + buffer->Length(), length, "read"));
       fMerger.AddFile(memfiles.back().get(), false);
 
-      if (fBuffered > fAutoSave) {
-         fBuffered = 0;
-         fMerger.PartialMerge();
-         fMerger.Reset();
-         memfiles.clear();
-      }
-
-      if (fCallback)
-         fCallback();
+      if (fBuffered > fAutoSave)
+         Merge();
    }
 
-   fMerger.PartialMerge();
-   fMerger.Reset();
+   Merge();
 }
 
 } // namespace Experimental

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -113,16 +113,8 @@ void TBufferMerger::WriteOutputFile()
       if (!buffer)
          break;
 
-      Long64_t length;
-      buffer->SetReadMode();
-      buffer->SetBufferOffset();
-      buffer->ReadLong64(length);
-      fBuffered += length;
-
-      TMemFile *memfile =
-         new TMemFile(fMerger.GetOutputFileName(), buffer->Buffer() + buffer->Length(), length, "read");
-
-      fMerger.AddAdoptFile(memfile);
+      fBuffered += buffer->BufferSize();
+      fMerger.AddAdoptFile(new TMemFile(fMerger.GetOutputFileName(), buffer->Buffer(), buffer->BufferSize(), "read"));
 
       if (fBuffered > fAutoSave)
          Merge();

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -22,8 +22,8 @@ namespace Experimental {
 
 TBufferMerger::TBufferMerger(const char *name, Option_t *option, Int_t compress)
 {
-   // NOTE: We cannot use ctor chaining or in-place initialization because we want this operation to have no effect on
-   // ROOT's gDirectory.
+   // We cannot chain constructors or use in-place initialization here because
+   // instantiating a TBufferMerger should not alter gDirectory's state.
    TDirectory::TContext ctxt;
    if (TFile *output = TFile::Open(name, option, /*title*/ name, compress))
       Init(std::unique_ptr<TFile>(output));

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -38,7 +38,6 @@ void TBufferMerger::Init(TFile *output)
       Error("TBufferMerger", "cannot write to output file");
 
    fMerger.OutputFile(std::unique_ptr<TFile>(output));
-   fMergingThread.reset(new std::thread([&]() { this->WriteOutputFile(); }));
 }
 
 TBufferMerger::~TBufferMerger()
@@ -46,8 +45,8 @@ TBufferMerger::~TBufferMerger()
    for (auto f : fAttachedFiles)
       if (!f.expired()) Fatal("TBufferMerger", " TBufferMergerFiles must be destroyed before the server");
 
-   this->Push(nullptr);
-   fMergingThread->join();
+   if (!fQueue.empty())
+      Merge();
 }
 
 std::shared_ptr<TBufferMergerFile> TBufferMerger::GetFile()
@@ -73,9 +72,12 @@ void TBufferMerger::Push(TBufferFile *buffer)
 {
    {
       std::lock_guard<std::mutex> lock(fQueueMutex);
+      fBuffered += buffer->BufferSize();
       fQueue.push(buffer);
    }
-   fDataAvailable.notify_one();
+
+   if (fBuffered > fAutoSave)
+      Merge();
 }
 
 size_t TBufferMerger::GetAutoSave() const
@@ -90,37 +92,25 @@ void TBufferMerger::SetAutoSave(size_t size)
 
 void TBufferMerger::Merge()
 {
-   fBuffered = 0;
+   std::lock_guard<std::mutex> m(fMergeMutex);
+   {
+      std::lock_guard<std::mutex> q(fQueueMutex);
+
+      while (!fQueue.empty()) {
+         std::unique_ptr<TBufferFile> buffer{fQueue.front()};
+         fMerger.AddAdoptFile(
+            new TMemFile(fMerger.GetOutputFileName(), buffer->Buffer(), buffer->BufferSize(), "READ"));
+         fQueue.pop();
+      }
+
+      fBuffered = 0;
+   }
+
    fMerger.PartialMerge();
    fMerger.Reset();
 
    if (fCallback)
       fCallback();
-}
-
-void TBufferMerger::WriteOutputFile()
-{
-   std::unique_ptr<TBufferFile> buffer;
-
-   while (true) {
-      std::unique_lock<std::mutex> lock(fQueueMutex);
-      fDataAvailable.wait(lock, [this]() { return !this->fQueue.empty(); });
-
-      buffer.reset(fQueue.front());
-      fQueue.pop();
-      lock.unlock();
-
-      if (!buffer)
-         break;
-
-      fBuffered += buffer->BufferSize();
-      fMerger.AddAdoptFile(new TMemFile(fMerger.GetOutputFileName(), buffer->Buffer(), buffer->BufferSize(), "read"));
-
-      if (fBuffered > fAutoSave)
-         Merge();
-   }
-
-   Merge();
 }
 
 } // namespace Experimental

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -103,7 +103,6 @@ void TBufferMerger::Merge()
 void TBufferMerger::WriteOutputFile()
 {
    std::unique_ptr<TBufferFile> buffer;
-   std::vector<std::unique_ptr<TMemFile>> memfiles;
 
    while (true) {
       std::unique_lock<std::mutex> lock(fQueueMutex);
@@ -122,9 +121,10 @@ void TBufferMerger::WriteOutputFile()
       buffer->ReadLong64(length);
       fBuffered += length;
 
-      memfiles.emplace_back(
-         new TMemFile(fMerger.GetOutputFileName(), buffer->Buffer() + buffer->Length(), length, "read"));
-      fMerger.AddFile(memfiles.back().get(), false);
+      TMemFile *memfile =
+         new TMemFile(fMerger.GetOutputFileName(), buffer->Buffer() + buffer->Length(), length, "read");
+
+      fMerger.AddAdoptFile(memfile);
 
       if (fBuffered > fAutoSave)
          Merge();

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -37,8 +37,6 @@ void TBufferMerger::Init(TFile *output)
    if (!output || !output->IsWritable() || output->IsZombie())
       Error("TBufferMerger", "cannot write to output file");
 
-   fAutoSave = 0;
-   fBuffered = 0;
    fMerger.OutputFile(std::unique_ptr<TFile>(output));
    fMergingThread.reset(new std::thread([&]() { this->WriteOutputFile(); }));
 }

--- a/io/io/src/TBufferMergerFile.cxx
+++ b/io/io/src/TBufferMergerFile.cxx
@@ -11,14 +11,15 @@
 
 #include "ROOT/TBufferMerger.hxx"
 
-#include "TArrayC.h"
 #include "TBufferFile.h"
 
 namespace ROOT {
 namespace Experimental {
 
 TBufferMergerFile::TBufferMergerFile(TBufferMerger &m)
-   : TMemFile(m.fFile->GetName(), "recreate", "", m.fFile->GetCompressionSettings()), fMerger(m)
+   : TMemFile(m.fMerger.GetOutputFile()->GetName(), "RECREATE", "",
+              m.fMerger.GetOutputFile()->GetCompressionSettings()),
+     fMerger(m)
 {
 }
 

--- a/io/io/src/TBufferMergerFile.cxx
+++ b/io/io/src/TBufferMergerFile.cxx
@@ -32,12 +32,10 @@ Int_t TBufferMergerFile::Write(const char *name, Int_t opt, Int_t bufsize)
    Int_t nbytes = TMemFile::Write(name, opt, bufsize);
 
    if (nbytes) {
-      TBufferFile *fBuffer = new TBufferFile(TBuffer::kWrite);
-
-      fBuffer->WriteLong64(GetEND());
-      CopyTo(*fBuffer);
-
-      fMerger.Push(fBuffer);
+      TBufferFile *buffer = new TBufferFile(TBuffer::kWrite);
+      CopyTo(*buffer);
+      buffer->SetReadMode();
+      fMerger.Push(buffer);
       ResetAfterMerge(0);
    }
    return nbytes;

--- a/io/io/test/CMakeLists.txt
+++ b/io/io/test/CMakeLists.txt
@@ -1,1 +1,2 @@
-ROOT_ADD_GTEST(IOTests TBufferMerger.cxx TFileMergerTests.cxx  LIBRARIES RIO Tree)
+ROOT_ADD_GTEST(TBufferMerger TBufferMerger.cxx LIBRARIES RIO Tree)
+ROOT_ADD_GTEST(TFileMerger TFileMergerTests.cxx LIBRARIES RIO Tree)


### PR DESCRIPTION
After ROOT's cleanup has become more thread-safe, we can just let the user decide if they want to use threads or tasks with TBufferMerger. We no longer use a separate thread for merging, which means we do not oversubscribe the machine anymore either.