### PR TITLE
Add sub-pads support in v7 TCanvas

### DIFF
--- a/core/base/v7/inc/ROOT/TDrawable.hxx
+++ b/core/base/v7/inc/ROOT/TDrawable.hxx
@@ -27,7 +27,7 @@ class TDrawingOptsBase;
 class TMenuItems;
 
 namespace Internal {
-class TVirtualCanvasPainter;
+class TPadPainter;
 }
 
 /** \class TDrawable
@@ -38,7 +38,7 @@ class TDrawable {
 public:
    virtual ~TDrawable();
 
-   virtual void Paint(Internal::TVirtualCanvasPainter &onCanv) = 0;
+   virtual void Paint(Internal::TPadPainter &onPad) = 0;
 
    /** Method can be used to provide menu items for the drawn object */
    virtual void PopulateMenu(TMenuItems &){};

--- a/core/base/v7/inc/ROOT/TDrawable.hxx
+++ b/core/base/v7/inc/ROOT/TDrawable.hxx
@@ -22,9 +22,9 @@
 namespace ROOT {
 namespace Experimental {
 
-class TCanvas;
 class TDrawingOptsBase;
 class TMenuItems;
+class TPadBase;
 
 namespace Internal {
 class TPadPainter;
@@ -35,6 +35,10 @@ class TPadPainter;
  */
 
 class TDrawable {
+friend class TPadBase;
+private:
+   std::string  fId; ///< object identifier, unique inside TCanvas
+
 public:
    virtual ~TDrawable();
 
@@ -48,6 +52,8 @@ public:
    /// Get the reference to the drawing options as TDrawingOptsBase. Used e.g. to identify the TDrawable in
    /// the list of primitives.
    virtual TDrawingOptsBase& GetOptionsBase() = 0;
+
+   std::string GetId() const { return fId; }
 
 };
 

--- a/etc/http/changes.md
+++ b/etc/http/changes.md
@@ -1,5 +1,10 @@
 # JSROOT changelog
 
+## Changes in dev
+1. Introduce JSROOT.StoreJSON() function. It creates JSON code for the 
+   TCanvas with all drawn objects inside. Allows to store current canvas state
+
+
 ## Changes in 5.4.0
 1. New supported classes:
    - TDiamond

--- a/etc/http/scripts/JSRootCore.js
+++ b/etc/http/scripts/JSRootCore.js
@@ -96,7 +96,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 6/03/2018";
+   JSROOT.version = "dev 13/03/2018";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;

--- a/etc/http/scripts/JSRootPainter.js
+++ b/etc/http/scripts/JSRootPainter.js
@@ -5504,6 +5504,20 @@
       return JSROOT.draw(divid, obj, opt, callback);
    }
 
+   /** Save object, drawn in specified element, as JSON.
+    *
+    * Normally it is TCanvas object with list of primitives
+    */
+
+   JSROOT.StoreJSON = function(divid) {
+      var p = new TObjectPainter;
+      p.SetDivId(divid,-1);
+
+      var canp = p.canv_painter();
+      return canp ? canp.ProduceJSON() : "";
+   }
+
+
    /** Create SVG image for provided object.
     *
     * Function especially useful in Node.js environment to generate images for

--- a/etc/http/scripts/JSRootPainter.v6.js
+++ b/etc/http/scripts/JSRootPainter.v6.js
@@ -4473,6 +4473,30 @@
       return bits;
    }
 
+   /// produce JSON for TCanvas, which can be used to display canvas once again
+   TCanvasPainter.prototype.ProduceJSON = function() {
+
+      var canv = this.GetObject();
+
+      if (!this.normal_canvas) {
+
+         // fill list of primitives from painters
+         this.ForEachPainterInPad(function(p) {
+            if (p.$secondary) return; // ignore all secoandry painters
+
+            var subobj = p.GetObject();
+            if (subobj && subobj._typename)
+               canv.fPrimitives.Add(subobj, p.OptionsAsString());
+         }, "objects");
+      }
+
+      var res = JSROOT.toJSON(canv);
+
+      if (!this.normal_canvas)
+         canv.fPrimitives.Clear();
+
+      return res;
+   }
 
    function drawCanvas(divid, can, opt) {
       var nocanvas = (can===null);

--- a/etc/http/scripts/JSRootPainter.v7hist.js
+++ b/etc/http/scripts/JSRootPainter.v7hist.js
@@ -49,7 +49,7 @@
       if (!this.frame_painter())
          JSROOT.v7.drawFrame(divid, null);
 
-      this.SetDivId(divid);
+      this.SetDivId(divid, 1);
    }
 
    THistPainter.prototype.GetHisto = function() {
@@ -97,8 +97,6 @@
 
    THistPainter.prototype.DecodeOptions = function(opt) {
       if (!this.options) this.options = { Hist : 1 };
-
-
    }
 
    THistPainter.prototype.Clear3DScene = function() {
@@ -268,11 +266,19 @@
       this.zmax = axis.max;
    }
 
+   THistPainter.prototype.AddInteractive = function() {
+      // only first painter in list allowed to add interactive functionality to the frame
+
+      if (this.is_main_painter()) {
+         var fp = this.frame_painter();
+         if (fp) fp.AddInteractive();
+      }
+   }
+
 
    THistPainter.prototype.DrawBins = function() {
       alert("HistPainter.DrawBins not implemented");
    }
-
 
    THistPainter.prototype.ToggleTitle = function(arg) {
       return false;
@@ -1721,7 +1727,7 @@
          this.DrawBins();
       // this.DrawTitle();
       // this.UpdateStatWebCanvas();
-      // this.AddInteractive();
+      this.AddInteractive();
       JSROOT.CallBack(call_back);
    }
 
@@ -3515,7 +3521,7 @@
 
       // this.UpdateStatWebCanvas();
 
-      // this.AddInteractive();
+      this.AddInteractive();
 
       JSROOT.CallBack(call_back);
    }

--- a/etc/http/scripts/JSRootPainter.v7more.js
+++ b/etc/http/scripts/JSRootPainter.v7more.js
@@ -59,9 +59,13 @@
       this.FinishTextDrawing();
    }
 
+   function drawLine() {
+   }
+
    // ================================================================================
 
    JSROOT.v7.drawText = drawText;
+   JSROOT.v7.drawLine = drawLine;
 
    return JSROOT;
 

--- a/graf2d/gpadv7/inc/LinkDef.h
+++ b/graf2d/gpadv7/inc/LinkDef.h
@@ -31,6 +31,7 @@
 #pragma link C++ struct ROOT::Experimental::Internal::TPadHorizVert+;
 #pragma link C++ struct ROOT::Experimental::TPadExtent+;
 #pragma link C++ struct ROOT::Experimental::TPadPos+;
+#pragma link C++ class ROOT::Experimental::TDrawingAttr<ROOT::Experimental::TPadPos>+;
 #pragma link C++ class std::vector<std::unique_ptr<ROOT::Experimental::TDrawable>>+;
 #pragma link C++ class ROOT::Experimental::TPadBase+;
 #pragma link C++ class ROOT::Experimental::TPadDrawingOpts+;

--- a/graf2d/gpadv7/v7/inc/ROOT/TCanvas.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/TCanvas.hxx
@@ -31,6 +31,7 @@ namespace Experimental {
   */
 
 class TCanvas: public TPadBase {
+friend class TPadBase;  /// use for ID generation
 private:
    /// Title of the canvas.
    std::string fTitle;
@@ -40,6 +41,8 @@ private:
 
    /// Modify counter, incremented every time canvas is changed
    uint64_t fModified; ///<!
+
+   uint64_t fIdCounter{2};   ///< counter for objects, id==1 is canvas itself
 
    /// The painter of this canvas, bootstrapping the graphics connection.
    /// Unmapped canvases (those that never had `Draw()` invoked) might not have
@@ -51,6 +54,8 @@ private:
 
    /// Disable assignment for now.
    TCanvas &operator=(const TCanvas &) = delete;
+
+   std::string GenerateUniqueId();
 
 public:
    static std::shared_ptr<TCanvas> Create(const std::string &title);

--- a/graf2d/gpadv7/v7/inc/ROOT/TObjectDrawable.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/TObjectDrawable.hxx
@@ -53,8 +53,8 @@ public:
 
    TObjectDrawable(const std::shared_ptr<TObject> &obj, const std::string &opt) : fObj(obj), fOpts(opt) {}
 
-   /// Paint the histogram
-   void Paint(Internal::TVirtualCanvasPainter &canv) final;
+   /// Paint the object
+   void Paint(Internal::TPadPainter &canv) final;
 
    /// Fill menu items for the object
    void PopulateMenu(TMenuItems &) final;

--- a/graf2d/gpadv7/v7/inc/ROOT/TPad.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/TPad.hxx
@@ -164,7 +164,7 @@ private:
    TPadBase *fParent = nullptr; /// The parent pad, if this pad has one.
 
    /// Size of the pad in the parent's (!) coordinate system.
-   TPadExtent fSize = {640_px, 400_px};
+   TPadExtent fSize = {1._normal, 1._normal}; // {640_px, 400_px};
 
 public:
    friend std::unique_ptr<TPadDrawable> GetDrawable(std::unique_ptr<TPad> &&pad);

--- a/graf2d/gpadv7/v7/inc/ROOT/TPad.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/TPad.hxx
@@ -32,10 +32,6 @@ namespace Experimental {
 
 class TPad;
 
-namespace Internal {
-class TVirtualCanvasPainter;
-}
-
 /** \class ROOT::Experimental::TPadBase
   Base class for graphic containers for `TDrawable`-s.
   */
@@ -250,17 +246,15 @@ public:
    /// Move a sub-pad into this (i.e. parent's) list of drawables.
    TPadDrawable(std::unique_ptr<TPad> &&pPad, const TPadDrawingOpts& opts = {});
 
-   /// Paint the pad.
-   void Paint(Internal::TVirtualCanvasPainter & /*canv*/) final
-   {
-      // FIXME: and then what? Something with fPad.GetListOfPrimitives()?
-   }
+   /// Paint primitives from the pad.
+   void Paint(Internal::TPadPainter &) final;
 
    TPad *Get() const { return fPad.get(); }
 
    /// Drawing options.
    TPadDrawingOpts &GetOptions() { return fOpts; }
 };
+
 template <class... ARGS>
 inline std::shared_ptr<TPadDrawable> GetDrawable(std::unique_ptr<TPad> &&pad, ARGS... args)
 {

--- a/graf2d/gpadv7/v7/inc/ROOT/TPad.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/TPad.hxx
@@ -123,6 +123,8 @@ public:
       return true;
    }
 
+   std::shared_ptr<TDrawable> FindDrawable(const std::string &id) const;
+
    /// Wipe the pad by clearing the list of primitives.
    void Wipe()
    {

--- a/graf2d/gpadv7/v7/inc/ROOT/TPad.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/TPad.hxx
@@ -131,6 +131,8 @@ public:
       fPrimitives.clear();
    }
 
+   void CreateFrame();
+
    const TFrame *GetFrame() const { return fFrame.get(); }
 
    /// Get the elements contained in the canvas.

--- a/graf2d/gpadv7/v7/inc/ROOT/TPad.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/TPad.hxx
@@ -31,6 +31,7 @@ namespace ROOT {
 namespace Experimental {
 
 class TPad;
+class TCanvas;
 
 /** \class ROOT::Experimental::TPadBase
   Base class for graphic containers for `TDrawable`-s.
@@ -53,11 +54,15 @@ private:
    /// Disable assignment.
    TPadBase &operator=(const TPadBase &) = delete;
 
+   void AssignUniqueID(std::shared_ptr<TDrawable> &ptr);
+
    /// Adds a `DRAWABLE` to `fPrimitives`, returning a `shared_ptr` to `DRAWABLE::GetOptions()`.
    template <class DRAWABLE>
    auto AddDrawable(std::shared_ptr<DRAWABLE> &&uPtr)
    {
       fPrimitives.emplace_back(std::move(uPtr));
+
+      AssignUniqueID(fPrimitives.back());
 
       using Options_t = typename std::remove_reference<decltype(uPtr->GetOptions())>::type;
       auto spDrawable = std::static_pointer_cast<DRAWABLE>(fPrimitives.back());

--- a/graf2d/gpadv7/v7/inc/ROOT/TPadDisplayItem.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/TPadDisplayItem.hxx
@@ -37,12 +37,14 @@ class TPadDisplayItem : public TDisplayItem {
 protected:
    const TFrame *fFrame{nullptr};   ///< temporary pointer on frame object
    const TPadDrawingOpts *fDrawOpts{nullptr}; ///< temporary pointer on pad drawing options
+   const TPadExtent *fSize{nullptr};  ///< temporary pointer on pad size attributes
    TDisplayItemsVector fPrimitives; ///< display items for all primitives in the pad
 public:
    TPadDisplayItem() = default;
    virtual ~TPadDisplayItem() {}
    void SetFrame(const TFrame *f) { fFrame = f; }
    void SetDrawOpts(const TPadDrawingOpts *opts) { fDrawOpts = opts; }
+   void SetSize(const TPadExtent *sz) { fSize = sz; }
    TDisplayItemsVector &GetPrimitives() { return fPrimitives; }
    void Add(std::unique_ptr<TDisplayItem> &&item) { fPrimitives.push_back(std::move(item)); }
    void Clear()
@@ -50,6 +52,7 @@ public:
       fPrimitives.clear();
       fFrame = nullptr;
       fDrawOpts = nullptr;
+      fSize = nullptr;
    }
 };
 

--- a/graf2d/gpadv7/v7/inc/ROOT/TPadDisplayItem.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/TPadDisplayItem.hxx
@@ -20,6 +20,8 @@
 
 #include <ROOT/TFrame.hxx>
 
+#include <ROOT/TPad.hxx>
+
 namespace ROOT {
 namespace Experimental {
 
@@ -34,17 +36,20 @@ using TDisplayItemsVector = std::vector<std::unique_ptr<TDisplayItem>>;
 class TPadDisplayItem : public TDisplayItem {
 protected:
    const TFrame *fFrame{nullptr};   ///< temporary pointer on frame object
+   const TPadDrawingOpts *fDrawOpts{nullptr}; ///< temporary pointer on pad drawing options
    TDisplayItemsVector fPrimitives; ///< display items for all primitives in the pad
 public:
    TPadDisplayItem() = default;
    virtual ~TPadDisplayItem() {}
    void SetFrame(const TFrame *f) { fFrame = f; }
+   void SetDrawOpts(const TPadDrawingOpts *opts) { fDrawOpts = opts; }
    TDisplayItemsVector &GetPrimitives() { return fPrimitives; }
    void Add(std::unique_ptr<TDisplayItem> &&item) { fPrimitives.push_back(std::move(item)); }
    void Clear()
    {
       fPrimitives.clear();
       fFrame = nullptr;
+      fDrawOpts = nullptr;
    }
 };
 

--- a/graf2d/gpadv7/v7/inc/ROOT/TPadPainter.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/TPadPainter.hxx
@@ -1,0 +1,64 @@
+/// \file ROOT/TPadPainter.hxx
+/// \ingroup Gpad ROOT7
+/// \author Sergey Linev
+/// \date 2018-03-12
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_TPadPainter
+#define ROOT7_TPadPainter
+
+#include "ROOT/TDisplayItem.hxx"
+
+#include <memory>
+#include <string>
+
+namespace ROOT {
+namespace Experimental {
+
+class TPadDisplayItem;
+class TPadDrawable;
+class TPadBase;
+
+namespace Internal {
+
+/** \class ROOT::Experimental::Internal::TPadPainter
+  Abstract interface for object painting on the pad/canvas.
+  */
+
+class TPadPainter {
+
+friend class ROOT::Experimental::TPadDrawable;
+
+protected:
+
+    std::unique_ptr<TPadDisplayItem> fPadDisplayItem; ///<! display items for all drawables in the pad
+    std::string   fCurrentDrawableId; ///<! current drawable id
+
+    void PaintDrawables(const TPadBase &pad);
+
+public:
+
+   /// Default constructor
+   TPadPainter() = default;
+
+   /// Default destructor.
+   virtual ~TPadPainter();
+
+   /// add display item to the canvas
+   virtual void AddDisplayItem(std::unique_ptr<TDisplayItem> &&item);
+};
+
+} // namespace Internal
+} // namespace Experimental
+} // namespace ROOT
+
+#endif // ROOT7_TPadPainter

--- a/graf2d/gpadv7/v7/inc/ROOT/TPadPos.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/TPadPos.hxx
@@ -79,7 +79,7 @@ struct TPadPos: Internal::TPadHorizVert {
       double fVert;  ///< Vertical scale factor
    };
 
-   /// Scale a `TPadHorizVert` horizonally and vertically.
+   /// Scale a `TPadHorizVert` horizontally and vertically.
    /// \param scale - the scale factor,
    TPadPos &operator*=(const ScaleFactor &scale)
    {

--- a/graf2d/gpadv7/v7/inc/ROOT/TVirtualCanvasPainter.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/TVirtualCanvasPainter.hxx
@@ -16,7 +16,7 @@
 #ifndef ROOT7_TVirtualCanvasPainter
 #define ROOT7_TVirtualCanvasPainter
 
-#include "ROOT/TDisplayItem.hxx"
+#include "ROOT/TPadPainter.hxx"
 
 #include <memory>
 #include <functional>
@@ -35,7 +35,7 @@ namespace Internal {
   Abstract interface for painting a canvas.
   */
 
-class TVirtualCanvasPainter {
+class TVirtualCanvasPainter : public TPadPainter {
 protected:
    class Generator {
    public:
@@ -51,9 +51,6 @@ protected:
 public:
    /// Default destructor.
    virtual ~TVirtualCanvasPainter();
-
-   /// add display item to the canvas
-   virtual void AddDisplayItem(std::unique_ptr<TDisplayItem> &&item) = 0;
 
    /// indicate that canvas changed, provides current version of the canvas
    virtual void CanvasUpdated(uint64_t, bool, CanvasCallback_t) = 0;

--- a/graf2d/gpadv7/v7/src/TCanvas.cxx
+++ b/graf2d/gpadv7/v7/src/TCanvas.cxx
@@ -43,6 +43,17 @@ const std::vector<std::shared_ptr<ROOT::Experimental::TCanvas>> &ROOT::Experimen
 //  }
 // }
 
+///////////////////////////////////////////////////////////////////////////////////////
+/// Generates unique ID inside the canvas
+
+std::string ROOT::Experimental::TCanvas::GenerateUniqueId()
+{
+   return std::to_string(fIdCounter++);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////
+/// Returns true is canvas was modified since last painting
+
 bool ROOT::Experimental::TCanvas::IsModified() const
 {
    return fPainter ? fPainter->IsCanvasModified(fModified) : fModified;

--- a/graf2d/gpadv7/v7/src/TObjectDrawable.cxx
+++ b/graf2d/gpadv7/v7/src/TObjectDrawable.cxx
@@ -18,16 +18,16 @@
 #include <ROOT/TDisplayItem.hxx>
 #include <ROOT/TLogger.hxx>
 #include <ROOT/TMenuItem.hxx>
-#include <ROOT/TVirtualCanvasPainter.hxx>
+#include <ROOT/TPadPainter.hxx>
 
 #include "TClass.h"
 #include "TROOT.h"
 
 #include <exception>
 
-void ROOT::Experimental::TObjectDrawable::Paint(Internal::TVirtualCanvasPainter &canv)
+void ROOT::Experimental::TObjectDrawable::Paint(Internal::TPadPainter &pad)
 {
-   canv.AddDisplayItem(std::make_unique<TObjectDisplayItem>(fObj.get(), fOpts.GetOptionString()));
+   pad.AddDisplayItem(std::make_unique<TObjectDisplayItem>(fObj.get(), fOpts.GetOptionString()));
 }
 
 void ROOT::Experimental::TObjectDrawable::PopulateMenu(TMenuItems &items)

--- a/graf2d/gpadv7/v7/src/TPad.cxx
+++ b/graf2d/gpadv7/v7/src/TPad.cxx
@@ -108,5 +108,6 @@ void ROOT::Experimental::TPadDrawable::Paint(Internal::TPadPainter &toppad)
    Internal::TPadPainter painter;
 
    painter.PaintDrawables(*fPad.get());
+
    toppad.AddDisplayItem(std::move(painter.fPadDisplayItem));
 }

--- a/graf2d/gpadv7/v7/src/TPad.cxx
+++ b/graf2d/gpadv7/v7/src/TPad.cxx
@@ -97,6 +97,18 @@ ROOT::Experimental::TPadBase::Divide(int nHoriz, int nVert, const TPadExtent &pa
    return ret;
 }
 
+
+void ROOT::Experimental::TPadBase::CreateFrame()
+{
+   if (!fFrame) {
+      ROOT::Experimental::TFrame::DrawingOpts opts;
+      fFrame = std::make_unique<ROOT::Experimental::TFrame>(opts);
+   }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+
 ROOT::Experimental::TPad::~TPad() = default;
 
 /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/gpadv7/v7/src/TPad.cxx
+++ b/graf2d/gpadv7/v7/src/TPad.cxx
@@ -109,5 +109,7 @@ void ROOT::Experimental::TPadDrawable::Paint(Internal::TPadPainter &toppad)
 
    painter.PaintDrawables(*fPad.get());
 
+   painter.fPadDisplayItem->SetDrawOpts(&GetOptions());
+
    toppad.AddDisplayItem(std::move(painter.fPadDisplayItem));
 }

--- a/graf2d/gpadv7/v7/src/TPad.cxx
+++ b/graf2d/gpadv7/v7/src/TPad.cxx
@@ -79,15 +79,19 @@ ROOT::Experimental::TPadBase::Divide(int nHoriz, int nVert, const TPadExtent &pa
    offset *= {1. / nHoriz, 1. / nVert};
    const TPadExtent size = offset - padding;
 
+   printf("SIZES %5.2f %5.2f\n", size.fHoriz.fNormal.fVal, size.fVert.fNormal.fVal);
+
    ret.resize(nHoriz);
    for (int iHoriz = 0; iHoriz < nHoriz; ++iHoriz) {
       ret[iHoriz].resize(nVert);
       for (int iVert = 0; iVert < nVert; ++iVert) {
          TPadPos subPos = offset;
-         subPos *= {1. * nHoriz, 1. * nVert};
+         subPos *= {1. * iHoriz, 1. * iVert};
          auto uniqPad = std::make_unique<TPad>(*this, size);
          ret[iHoriz][iVert] = uniqPad.get();
          Draw(std::move(uniqPad), subPos);
+
+         printf("Create subpad pos %5.2f %5.2f\n", subPos.fHoriz.fNormal.fVal, subPos.fVert.fNormal.fVal);
       }
    }
    return ret;
@@ -110,6 +114,8 @@ void ROOT::Experimental::TPadDrawable::Paint(Internal::TPadPainter &toppad)
    painter.PaintDrawables(*fPad.get());
 
    painter.fPadDisplayItem->SetDrawOpts(&GetOptions());
+
+   painter.fPadDisplayItem->SetSize(&fPad->GetSize());
 
    toppad.AddDisplayItem(std::move(painter.fPadDisplayItem));
 }

--- a/graf2d/gpadv7/v7/src/TPad.cxx
+++ b/graf2d/gpadv7/v7/src/TPad.cxx
@@ -27,10 +27,10 @@
 
 ROOT::Experimental::TPadBase::~TPadBase() = default;
 
-
 void ROOT::Experimental::TPadBase::AssignUniqueID(std::shared_ptr<TDrawable> &ptr)
 {
-   if (!ptr) return;
+   if (!ptr)
+      return;
 
    TCanvas *canv = GetCanvas();
    if (!canv) {
@@ -41,6 +41,25 @@ void ROOT::Experimental::TPadBase::AssignUniqueID(std::shared_ptr<TDrawable> &pt
    ptr->fId = canv->GenerateUniqueId();
 }
 
+std::shared_ptr<ROOT::Experimental::TDrawable> ROOT::Experimental::TPadBase::FindDrawable(const std::string &id) const
+{
+   for (auto &&drawable : GetPrimitives()) {
+
+      if (drawable->GetId() == id)
+         return drawable;
+
+      TPadDrawable *pad_draw = dynamic_cast<TPadDrawable *> (drawable.get());
+      if (!pad_draw || !pad_draw->Get()) continue;
+
+      auto subelem = pad_draw->Get()->FindDrawable(id);
+
+      if (!subelem) continue;
+
+      return subelem;
+   }
+
+   return nullptr;
+}
 
 std::vector<std::vector<ROOT::Experimental::TPad *>>
 ROOT::Experimental::TPadBase::Divide(int nHoriz, int nVert, const TPadExtent &padding /*= {}*/)
@@ -76,16 +95,12 @@ ROOT::Experimental::TPadBase::Divide(int nHoriz, int nVert, const TPadExtent &pa
 
 ROOT::Experimental::TPad::~TPad() = default;
 
-
-
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-
-ROOT::Experimental::TPadDrawable::TPadDrawable(std::unique_ptr<TPad> &&pPad, const TPadDrawingOpts& opts /*= {}*/)
+ROOT::Experimental::TPadDrawable::TPadDrawable(std::unique_ptr<TPad> &&pPad, const TPadDrawingOpts &opts /*= {}*/)
    : fPad(std::move(pPad)), fOpts(opts)
 {
 }
-
 
 /// Paint the pad.
 void ROOT::Experimental::TPadDrawable::Paint(Internal::TPadPainter &toppad)
@@ -95,4 +110,3 @@ void ROOT::Experimental::TPadDrawable::Paint(Internal::TPadPainter &toppad)
    painter.PaintDrawables(*fPad.get());
    toppad.AddDisplayItem(std::move(painter.fPadDisplayItem));
 }
-

--- a/graf2d/gpadv7/v7/src/TPad.cxx
+++ b/graf2d/gpadv7/v7/src/TPad.cxx
@@ -18,6 +18,8 @@
 #include "ROOT/TLogger.hxx"
 #include "ROOT/TPadExtent.hxx"
 #include "ROOT/TPadPos.hxx"
+#include <ROOT/TPadDisplayItem.hxx>
+#include <ROOT/TPadPainter.hxx>
 
 #include <cassert>
 #include <limits>
@@ -58,7 +60,23 @@ ROOT::Experimental::TPadBase::Divide(int nHoriz, int nVert, const TPadExtent &pa
 
 ROOT::Experimental::TPad::~TPad() = default;
 
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+
 ROOT::Experimental::TPadDrawable::TPadDrawable(std::unique_ptr<TPad> &&pPad, const TPadDrawingOpts& opts /*= {}*/)
    : fPad(std::move(pPad)), fOpts(opts)
 {
 }
+
+
+/// Paint the pad.
+void ROOT::Experimental::TPadDrawable::Paint(Internal::TPadPainter &toppad)
+{
+   Internal::TPadPainter painter;
+
+   painter.PaintDrawables(*fPad.get());
+   toppad.AddDisplayItem(std::move(painter.fPadDisplayItem));
+}
+

--- a/graf2d/gpadv7/v7/src/TPad.cxx
+++ b/graf2d/gpadv7/v7/src/TPad.cxx
@@ -20,11 +20,27 @@
 #include "ROOT/TPadPos.hxx"
 #include <ROOT/TPadDisplayItem.hxx>
 #include <ROOT/TPadPainter.hxx>
+#include <ROOT/TCanvas.hxx>
 
 #include <cassert>
 #include <limits>
 
 ROOT::Experimental::TPadBase::~TPadBase() = default;
+
+
+void ROOT::Experimental::TPadBase::AssignUniqueID(std::shared_ptr<TDrawable> &ptr)
+{
+   if (!ptr) return;
+
+   TCanvas *canv = GetCanvas();
+   if (!canv) {
+      R__ERROR_HERE("Gpad") << "Cannot access canvas when unique object id should be assigned";
+      return;
+   }
+
+   ptr->fId = canv->GenerateUniqueId();
+}
+
 
 std::vector<std::vector<ROOT::Experimental::TPad *>>
 ROOT::Experimental::TPadBase::Divide(int nHoriz, int nVert, const TPadExtent &padding /*= {}*/)

--- a/graf2d/gpadv7/v7/src/TPadPainter.cxx
+++ b/graf2d/gpadv7/v7/src/TPadPainter.cxx
@@ -1,0 +1,42 @@
+/// \file TPadPainter.cxx
+/// \ingroup Gpad ROOT7
+/// \author Sergey Linev
+/// \date 2018-03-12
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+#include <ROOT/TPadPainter.hxx>
+
+#include <ROOT/TPadDisplayItem.hxx>
+#include <ROOT/TPad.hxx>
+
+
+/// destructor
+ROOT::Experimental::Internal::TPadPainter::~TPadPainter()
+{
+   // defined here, while TPadDisplayItem only included here
+}
+
+
+void ROOT::Experimental::Internal::TPadPainter::AddDisplayItem(std::unique_ptr<TDisplayItem> &&item)
+{
+   item->SetObjectID(fCurrentDrawableId);
+   fPadDisplayItem->Add(std::move(item));
+}
+
+void ROOT::Experimental::Internal::TPadPainter::PaintDrawables(const TPadBase &pad)
+{
+   fPadDisplayItem = std::make_unique<TPadDisplayItem>();
+
+   fPadDisplayItem->SetObjectIDAsPtr((void *) (&pad));
+
+   fPadDisplayItem->SetFrame(pad.GetFrame());
+
+   for (auto &&drawable : pad.GetPrimitives()) {
+
+      fCurrentDrawableId = TDisplayItem::MakeIDFromPtr(drawable.get());
+
+      drawable->Paint(*this);
+   }
+
+}

--- a/graf2d/gpadv7/v7/src/TPadPainter.cxx
+++ b/graf2d/gpadv7/v7/src/TPadPainter.cxx
@@ -28,13 +28,11 @@ void ROOT::Experimental::Internal::TPadPainter::PaintDrawables(const TPadBase &p
 {
    fPadDisplayItem = std::make_unique<TPadDisplayItem>();
 
-   fPadDisplayItem->SetObjectIDAsPtr((void *) (&pad));
-
    fPadDisplayItem->SetFrame(pad.GetFrame());
 
    for (auto &&drawable : pad.GetPrimitives()) {
 
-      fCurrentDrawableId = TDisplayItem::MakeIDFromPtr(drawable.get());
+      fCurrentDrawableId = drawable->GetId();
 
       drawable->Paint(*this);
    }

--- a/graf2d/primitives/v7/inc/ROOT/TDisplayItem.hxx
+++ b/graf2d/primitives/v7/inc/ROOT/TDisplayItem.hxx
@@ -37,11 +37,8 @@ public:
    TDisplayItem() = default;
    virtual ~TDisplayItem() {}
 
-   void SetObjectIDAsPtr(void *ptr);
    void SetObjectID(const std::string &id) { fObjectID = id; }
    std::string GetObjectID() const { return fObjectID; }
-
-   static std::string MakeIDFromPtr(void *ptr);
 };
 
 // direct pointer to some object without ownership

--- a/graf2d/primitives/v7/inc/ROOT/TLine.hxx
+++ b/graf2d/primitives/v7/inc/ROOT/TLine.hxx
@@ -20,7 +20,7 @@
 #include <ROOT/TDrawingAttr.hxx>
 #include <ROOT/TDrawingOptsBase.hxx>
 #include <ROOT/TPad.hxx>
-#include <ROOT/TVirtualCanvasPainter.hxx>
+#include <ROOT/TPadPainter.hxx>
 
 #include <initializer_list>
 #include <memory>
@@ -82,9 +82,9 @@ public:
    DrawingOpts &GetOptions() { return fOpts; }
    const DrawingOpts &GetOptions() const { return fOpts; }
 
-   void Paint(Internal::TVirtualCanvasPainter &canv) final
+   void Paint(Internal::TPadPainter &topPad) final
    {
-      canv.AddDisplayItem(
+      topPad.AddDisplayItem(
          std::make_unique<ROOT::Experimental::TOrdinaryDisplayItem<ROOT::Experimental::TLine>>(this));
    }
 };

--- a/graf2d/primitives/v7/inc/ROOT/TText.hxx
+++ b/graf2d/primitives/v7/inc/ROOT/TText.hxx
@@ -20,7 +20,7 @@
 #include <ROOT/TDrawingAttr.hxx>
 #include <ROOT/TDrawingOptsBase.hxx>
 #include <ROOT/TPad.hxx>
-#include <ROOT/TVirtualCanvasPainter.hxx>
+#include <ROOT/TPadPainter.hxx>
 
 #include <initializer_list>
 #include <memory>
@@ -99,9 +99,9 @@ public:
    DrawingOpts &GetOptions() { return fOpts; }
    const DrawingOpts &GetOptions() const { return fOpts; }
 
-   void Paint(Internal::TVirtualCanvasPainter &canv) final
+   void Paint(Internal::TPadPainter &pad) final
    {
-      canv.AddDisplayItem(
+      pad.AddDisplayItem(
          std::make_unique<ROOT::Experimental::TOrdinaryDisplayItem<ROOT::Experimental::TText>>(this));
    }
 };

--- a/graf2d/primitives/v7/src/TDisplayItem.cxx
+++ b/graf2d/primitives/v7/src/TDisplayItem.cxx
@@ -14,17 +14,3 @@
  *************************************************************************/
 
 #include "ROOT/TDisplayItem.hxx"
-
-#include "TString.h"
-
-std::string ROOT::Experimental::TDisplayItem::MakeIDFromPtr(void *ptr)
-{
-   UInt_t hash = TString::Hash(&ptr, sizeof(ptr));
-   return std::to_string(hash);
-}
-
-void ROOT::Experimental::TDisplayItem::SetObjectIDAsPtr(void *ptr)
-{
-   std::string id = MakeIDFromPtr(ptr);
-   SetObjectID(id);
-}

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -709,15 +709,13 @@ std::string ROOT::Experimental::TCanvasPainter::CreateSnapshot(const ROOT::Exper
 
    fPadDisplayItem->SetObjectID("canvas"); // for canvas itself use special id
 
-   TString res = TBufferJSON::ToJSON(fPadDisplayItem.get() /*, 23 */);
+   TString res = TBufferJSON::ToJSON(fPadDisplayItem.get(), 23);
 
-   TBufferJSON::ExportToFile("canv.json", fPadDisplayItem.get(), gROOT->GetClass("ROOT::Experimental::TPadDisplayItem"));
+   // TBufferJSON::ExportToFile("canv.json", fPadDisplayItem.get(), gROOT->GetClass("ROOT::Experimental::TPadDisplayItem"));
 
    fPadDisplayItem.reset(); // no need to keep memory any longer
 
    // fDisplayList.Clear();
-
-
 
    //   std::ofstream ofs("snap.json");
    //   ofs << res.Data() << std::endl;

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -203,16 +203,16 @@ private:
 
    WebConnList fWebConn;           ///<! connections list
    bool fHadWebConn{false};        ///<! true if any connection were existing
-   TPadDisplayItem fDisplayList;   ///!< full list of items to display
-   std::string fCurrentDrawableId; ///!< id of drawable, which paint method is called
-   WebCommandsList fCmds;          ///!< list of submitted commands
-   uint64_t fCmdsCnt{0};           ///!< commands counter
-   std::string fWaitingCmdId;      ///!< command id waited for completion
+   //TPadDisplayItem fDisplayList;   ///<! full list of items to display
+   //std::string fCurrentDrawableId; ///<! id of drawable, which paint method is called
+   WebCommandsList fCmds;          ///<! list of submitted commands
+   uint64_t fCmdsCnt{0};           ///<! commands counter
+   std::string fWaitingCmdId;      ///<! command id waited for completion
 
-   uint64_t fSnapshotVersion{0};   ///!< version of snapshot
-   std::string fSnapshot;          ///!< last produced snapshot
-   uint64_t fSnapshotDelivered{0}; ///!< minimal version delivered to all connections
-   WebUpdatesList fUpdatesLst;     ///!< list of callbacks for canvas update
+   uint64_t fSnapshotVersion{0};   ///<! version of snapshot
+   std::string fSnapshot;          ///<! last produced snapshot
+   uint64_t fSnapshotDelivered{0}; ///<! minimal version delivered to all connections
+   WebUpdatesList fUpdatesLst;     ///<! list of callbacks for canvas update
 
    /// Disable copy construction.
    TCanvasPainter(const TCanvasPainter &) = delete;
@@ -247,11 +247,11 @@ public:
 
    virtual ~TCanvasPainter();
 
-   virtual void AddDisplayItem(std::unique_ptr<TDisplayItem> &&item) override
-   {
-      item->SetObjectID(fCurrentDrawableId);
-      fDisplayList.Add(std::move(item));
-   }
+//   virtual void AddDisplayItem(std::unique_ptr<TDisplayItem> &&item) override
+//   {
+//      item->SetObjectID(fCurrentDrawableId);
+//      fDisplayList.Add(std::move(item));
+//   }
 
    virtual void CanvasUpdated(uint64_t ver, bool async, ROOT::Experimental::CanvasCallback_t callback) override;
 
@@ -704,7 +704,8 @@ bool ROOT::Experimental::TCanvasPainter::AddPanel(std::shared_ptr<TWebWindow> wi
 
 std::string ROOT::Experimental::TCanvasPainter::CreateSnapshot(const ROOT::Experimental::TCanvas &can)
 {
-   fDisplayList.Clear();
+
+/*   fDisplayList.Clear();
 
    fDisplayList.SetObjectIDAsPtr((void *)&can);
 
@@ -716,12 +717,19 @@ std::string ROOT::Experimental::TCanvasPainter::CreateSnapshot(const ROOT::Exper
 
       drawable->Paint(*this);
    }
+*/
 
-   TString res = TBufferJSON::ToJSON(&fDisplayList /*, 23 */);
+   PaintDrawables(can);
 
-   // TBufferJSON::ExportToFile("canv.json", &fDisplayList, gROOT->GetClass("ROOT::Experimental::TPadDisplayItem"));
+   TString res = TBufferJSON::ToJSON(fPadDisplayItem.get() /*, 23 */);
 
-   fDisplayList.Clear();
+   TBufferJSON::ExportToFile("canv.json", fPadDisplayItem.get(), gROOT->GetClass("ROOT::Experimental::TPadDisplayItem"));
+
+   fPadDisplayItem.reset(); // no need to keep memory any longer
+
+   // fDisplayList.Clear();
+
+
 
    //   std::ofstream ofs("snap.json");
    //   ofs << res.Data() << std::endl;

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -705,23 +705,9 @@ bool ROOT::Experimental::TCanvasPainter::AddPanel(std::shared_ptr<TWebWindow> wi
 std::string ROOT::Experimental::TCanvasPainter::CreateSnapshot(const ROOT::Experimental::TCanvas &can)
 {
 
-/*   fDisplayList.Clear();
-
-   fDisplayList.SetObjectIDAsPtr((void *)&can);
-
-   fDisplayList.SetFrame(can.GetFrame());
-
-   for (auto &&drawable : can.GetPrimitives()) {
-
-      fCurrentDrawableId = TDisplayItem::MakeIDFromPtr(drawable.get());
-
-      drawable->Paint(*this);
-   }
-*/
-
    PaintDrawables(can);
 
-   // fPadDisplayItem.SetObjectID("canvas"); // for canvas itself use special id
+   fPadDisplayItem->SetObjectID("canvas"); // for canvas itself use special id
 
    TString res = TBufferJSON::ToJSON(fPadDisplayItem.get() /*, 23 */);
 

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -455,14 +455,14 @@ void ROOT::Experimental::TCanvasPainter::CanvasUpdated(uint64_t ver, bool async,
       return;
    }
 
+   fSnapshotVersion = ver;
+   fSnapshot = CreateSnapshot(fCanvas);
+
    if (!fWindow || !fWindow->IsShown()) {
       if (callback)
          callback(false);
       return;
    }
-
-   fSnapshotVersion = ver;
-   fSnapshot = CreateSnapshot(fCanvas);
 
    CheckDataToSend();
 

--- a/gui/webdisplay/src/TWebWindow.cxx
+++ b/gui/webdisplay/src/TWebWindow.cxx
@@ -206,7 +206,7 @@ bool ROOT::Experimental::TWebWindow::ProcessWS(THttpCallArg &arg)
    const char *buf = (const char *)arg.GetPostData();
    char *str_end = nullptr;
 
-   printf("Get portion of data %d %.30s\n", (int)arg.GetPostDataLength(), buf);
+   // printf("Get portion of data %d %.30s\n", (int)arg.GetPostDataLength(), buf);
 
    unsigned long ackn_oper = std::strtoul(buf, &str_end, 10);
    assert(str_end && *str_end == ':' && "missing number of acknowledged operations");

--- a/hist/histdraw/v7/inc/ROOT/THistDrawable.hxx
+++ b/hist/histdraw/v7/inc/ROOT/THistDrawable.hxx
@@ -51,7 +51,7 @@ public:
    static THistPainterBase<DIMENSION> *GetPainter();
 
    /// Paint a THist. All we need is access to its GetBinContent()
-   virtual void Paint(TDrawable &obj, const THistDrawingOpts<DIMENSION> &opts, TVirtualCanvasPainter &canv) = 0;
+   virtual void Paint(TDrawable &obj, const THistDrawingOpts<DIMENSION> &opts, TPadPainter &pad) = 0;
 };
 
 extern template class THistPainterBase<1>;
@@ -96,7 +96,7 @@ public:
    {}
 
    /// Paint the histogram
-   void Paint(Internal::TVirtualCanvasPainter &canv) final;
+   void Paint(Internal::TPadPainter &pad) final;
 
    THistDrawingOpts<DIMENSIONS> &GetOptions() { return fOpts; }
    const THistDrawingOpts<DIMENSIONS> &GetOptions() const { return fOpts; }

--- a/hist/histdraw/v7/src/THistDrawable.cxx
+++ b/hist/histdraw/v7/src/THistDrawable.cxx
@@ -72,9 +72,9 @@ THistDrawable<DIMENSIONS>::THistDrawable() = default;
 
 /// Paint the histogram
 template <int DIMENSIONS>
-void THistDrawable<DIMENSIONS>::Paint(Internal::TVirtualCanvasPainter &canv)
+void THistDrawable<DIMENSIONS>::Paint(Internal::TPadPainter &pad)
 {
-   Internal::THistPainterBase<DIMENSIONS>::GetPainter()->Paint(*this, fOpts, canv);
+   Internal::THistPainterBase<DIMENSIONS>::GetPainter()->Paint(*this, fOpts, pad);
 }
 
 namespace ROOT {

--- a/hist/histpainter/v7/src/THistPainter.cxx
+++ b/hist/histpainter/v7/src/THistPainter.cxx
@@ -16,7 +16,7 @@
 //#include "ROOT/THistPainter.hxx" see ROOT/THistDrawable.h
 
 #include "ROOT/THistDrawable.hxx"
-#include "ROOT/TVirtualCanvasPainter.hxx"
+#include "ROOT/TPadPainter.hxx"
 #include "ROOT/TDisplayItem.hxx"
 
 #include <iostream>
@@ -28,7 +28,7 @@ using namespace ROOT::Experimental::Internal;
 namespace {
 class THistPainter1D : public THistPainterBase<1> {
 public:
-   void Paint(TDrawable &drw, const THistDrawingOpts<1> & /*opts*/, TVirtualCanvasPainter &canv) final
+   void Paint(TDrawable &drw, const THistDrawingOpts<1> & /*opts*/, TPadPainter &pad) final
    {
       // TODO: paint!
       std::cout << "Painting 1D histogram @" << &drw << '\n';
@@ -36,7 +36,7 @@ public:
       assert(dynamic_cast<THistDrawable<1> *>(&drw) && "Wrong drawable type");
       THistDrawable<1> &hd = static_cast<THistDrawable<1> &>(drw);
 
-      canv.AddDisplayItem(
+      pad.AddDisplayItem(
          std::make_unique<ROOT::Experimental::TOrdinaryDisplayItem<ROOT::Experimental::THistDrawable<1>>>(&hd));
    }
    virtual ~THistPainter1D() final {}
@@ -44,13 +44,13 @@ public:
 
 class THistPainter2D : public THistPainterBase<2> {
 public:
-   void Paint(TDrawable &drw, const THistDrawingOpts<2> & /*opts*/, TVirtualCanvasPainter &canv) final
+   void Paint(TDrawable &drw, const THistDrawingOpts<2> & /*opts*/, TPadPainter &pad) final
    {
       std::cout << "Painting 2D histogram @" << &drw << '\n';
       assert(dynamic_cast<THistDrawable<2> *>(&drw) && "Wrong drawable type");
       THistDrawable<2> &hd = static_cast<THistDrawable<2> &>(drw);
 
-      canv.AddDisplayItem(
+      pad.AddDisplayItem(
          std::make_unique<ROOT::Experimental::TOrdinaryDisplayItem<ROOT::Experimental::THistDrawable<2>>>(&hd));
    }
    virtual ~THistPainter2D() final {}
@@ -58,7 +58,7 @@ public:
 
 class THistPainter3D : public THistPainterBase<3> {
 public:
-   void Paint(TDrawable &hist, const THistDrawingOpts<3> & /*opts*/, TVirtualCanvasPainter & /*canv*/) final
+   void Paint(TDrawable &hist, const THistDrawingOpts<3> & /*opts*/, TPadPainter & /*canv*/) final
    {
       // TODO: paint!
       std::cout << "Painting 3D histogram (to be done) @" << &hist << '\n';

--- a/tutorials/v7/draw_subpads.cxx
+++ b/tutorials/v7/draw_subpads.cxx
@@ -1,0 +1,66 @@
+/// \file
+/// \ingroup tutorial_v7
+///
+/// \macro_code
+///
+/// \date 2018-03-13
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+/// \author Sergey Linev
+
+/*************************************************************************
+ * Copyright (C) 1995-2015, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/THist.hxx"
+#include "ROOT/TCanvas.hxx"
+#include "ROOT/TPad.hxx"
+
+void draw_subpads() {
+  using namespace ROOT;
+
+  // Create the histogram.
+  Experimental::TAxisConfig xaxis(10, 0., 10.);
+  auto pHist1 = std::make_shared<Experimental::TH1D>(xaxis);
+  auto pHist2 = std::make_shared<Experimental::TH1D>(xaxis);
+  auto pHist3 = std::make_shared<Experimental::TH1D>(xaxis);
+
+  // Fill a few points.
+  pHist1->Fill(1);
+  pHist1->Fill(2);
+  pHist1->Fill(2);
+  pHist1->Fill(3);
+
+  pHist2->Fill(5);
+  pHist2->Fill(6);
+  pHist2->Fill(6);
+  pHist2->Fill(7);
+
+  pHist3->Fill(4);
+  pHist3->Fill(5);
+  pHist3->Fill(5);
+  pHist3->Fill(6);
+
+  // Create a canvas to be displayed.
+  auto canvas = Experimental::TCanvas::Create("Canvas Title");
+
+  // Divide canvas on sub-pads
+
+  auto subpads = canvas->Divide(2,2);
+
+  subpads[0][0]->Draw(pHist1)->SetLineColor(Experimental::TColor::kRed);
+  subpads[1][0]->Draw(pHist2)->SetLineColor(Experimental::TColor::kBlue);
+  subpads[0][1]->Draw(pHist3)->SetLineColor(Experimental::TColor::kGreen);
+
+  // Divide pad on sub-sub-pads
+  auto subsubpads = subpads[1][1]->Divide(2,2);
+
+  subsubpads[0][0]->Draw(pHist1)->SetLineColor(Experimental::TColor::kBlue);
+  subsubpads[1][0]->Draw(pHist2)->SetLineColor(Experimental::TColor::kGreen);
+  subsubpads[0][1]->Draw(pHist3)->SetLineColor(Experimental::TColor::kRed);
+
+  canvas->Show();
+}


### PR DESCRIPTION
Now one can use TCanvas::Divide() and TPad::Divide() methods.

Created subpads will be displayed by the client - including objects in the pads.

Introduce unique object identifier inside the canvas - it is just 64-bit counter. All drawables add to canvas or sub-pads get unique identifier, generated by canvas

TPadPainter is class for painting drawables in canvas/sub-pads. TVirtualCanvasPainter derived from TPadPainter and add more methods for canvas display.

Provide draw_subpads.cxx tutorial.