### PR TITLE
[cmake] Generation of RGitCommit.h depends on nothing.

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -59,13 +59,6 @@ set(objectlibs $<TARGET_OBJECTS:Base>
                ${winnt_objects})
 
 #---Generation of RGitCommit.h-----------------------------------------------------------
-foreach(exp ${objectlibs})
-  string(REGEX REPLACE "^[$]<TARGET_OBJECTS:(.+)>" "\\1" lib ${exp})
-  get_target_property(objs ${lib} OBJECTS)
-  list(APPEND dep_objects ${objs})
-  list(APPEND dep_targets ${lib})
-endforeach()
-
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/include/RGitCommit.h
                    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_BINARY_DIR}/RGitCommit.h.tmp ${CMAKE_BINARY_DIR}/include/RGitCommit.h
                    COMMENT ""
@@ -76,19 +69,18 @@ if(WIN32)
                      COMMAND ${CMAKE_SOURCE_DIR}/build/win/gitinfo.bat ${CMAKE_SOURCE_DIR}
                      COMMAND ${CMAKE_SOURCE_DIR}/build/win/githeader.bat RGitCommit.h.tmp
                      COMMENT "Recording the git revision now"
-                     DEPENDS ${dep_objects} move_artifacts
+                     DEPENDS move_artifacts
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 else()
   add_custom_command(OUTPUT  ${CMAKE_BINARY_DIR}/RGitCommit.h.tmp
                      COMMAND ${CMAKE_SOURCE_DIR}/build/unix/gitinfo.sh ${CMAKE_SOURCE_DIR}
                      COMMAND ${CMAKE_SOURCE_DIR}/build/unix/githeader.sh RGitCommit.h.tmp
                      COMMENT "Recording the git revision now"
-                     DEPENDS ${dep_objects} move_artifacts
+                     DEPENDS move_artifacts
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 endif()
 add_custom_target(gitcommit ALL DEPENDS ${CMAKE_BINARY_DIR}/RGitCommit.h.tmp)
 set_source_files_properties(${CMAKE_BINARY_DIR}/RGitCommit.h.tmp PROPERTIES GENERATED TRUE)
-add_dependencies(gitcommit ${dep_targets})
 
 set_source_files_properties(${CMAKE_BINARY_DIR}/include/RGitCommit.h
                             PROPERTIES GENERATED TRUE HEADER_FILE_ONLY TRUE)


### PR DESCRIPTION
Remove the redundant dependencies from the target. This fixes a cxxmodules
nightly builds.