### PR TITLE
Add library prefix and suffixes for Windows

### DIFF
--- a/cmake/scripts/ROOTConfig.cmake.in
+++ b/cmake/scripts/ROOTConfig.cmake.in
@@ -78,6 +78,10 @@ endforeach()
 #----------------------------------------------------------------------------
 # Now set them to ROOT_LIBRARIES
 set(ROOT_LIBRARIES)
+if(MSVC)
+  set(CMAKE_FIND_LIBRARY_PREFIXES "lib")
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ".lib" ".dll")
+endif()
 foreach(_cpt Core Imt RIO Net Hist Graf Graf3d Gpad Tree TreePlayer Rint Postscript Matrix Physics MathCore Thread MultiProc ${ROOT_FIND_COMPONENTS})
   find_library(ROOT_${_cpt}_LIBRARY ${_cpt} HINTS ${ROOT_LIBRARY_DIR})
   if(ROOT_${_cpt}_LIBRARY)


### PR DESCRIPTION
This allows to properly find required components on Windows (e.g. roottest couldn't find RIO)