### PR TITLE
Resolve ROOT-9283

### DIFF
--- a/tree/tree/inc/TChain.h
+++ b/tree/tree/inc/TChain.h
@@ -130,7 +130,7 @@ public:
    virtual Long64_t  Process(const char *filename, Option_t *option="", Long64_t nentries=kMaxEntries, Long64_t firstentry=0); // *MENU*
    virtual Long64_t  Process(TSelector* selector, Option_t* option = "", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0);
    virtual void      RecursiveRemove(TObject *obj);
-   virtual void      RemoveFriend(TTree*);
+   virtual void      RemoveFriend(TTree *tree,Bool_t parent = kFALSE);
    virtual void      Reset(Option_t *option="");
    virtual void      ResetAfterMerge(TFileMergeInfo *);
    virtual void      ResetBranchAddress(TBranch *);

--- a/tree/tree/inc/TFriendElement.h
+++ b/tree/tree/inc/TFriendElement.h
@@ -58,6 +58,7 @@ public:
    virtual TTree      *GetTree();
    virtual const char *GetTreeName() const {return fTreeName.Data();}
    virtual void        ls(Option_t *option="") const;
+   virtual void        RecursiveRemove(TObject *obj);
 
    ClassDef(TFriendElement,2)  //A friend element of another TTree
 };

--- a/tree/tree/inc/TFriendElement.h
+++ b/tree/tree/inc/TFriendElement.h
@@ -39,8 +39,8 @@ protected:
    TString       fTreeName;    ///<  name of the friend TTree
    Bool_t        fOwnFile;     ///<  true if file is managed by this class
 
-   TFriendElement(const TFriendElement&);
-   TFriendElement& operator=(const TFriendElement&);
+   TFriendElement(const TFriendElement&) = delete;
+   TFriendElement& operator=(const TFriendElement&) = delete;
 
    friend void TFriendElement__SetTree(TTree *tree, TList *frlist);
 

--- a/tree/tree/inc/TFriendElement.h
+++ b/tree/tree/inc/TFriendElement.h
@@ -28,6 +28,7 @@
 
 class TFile;
 class TTree;
+class TChain;
 class TClass;
 
 class TFriendElement : public TNamed {
@@ -43,6 +44,7 @@ protected:
    TFriendElement& operator=(const TFriendElement&) = delete;
 
    friend void TFriendElement__SetTree(TTree *tree, TList *frlist);
+   friend class TChain;
 
 public:
    enum EStatusBits { kFromChain = BIT(11) };

--- a/tree/tree/inc/TFriendElement.h
+++ b/tree/tree/inc/TFriendElement.h
@@ -55,9 +55,9 @@ public:
    virtual ~TFriendElement();
    virtual TTree      *Connect();
    virtual TTree      *DisConnect();
-   virtual TFile      *GetFile();
+   virtual TFile      *GetFile(Bool_t load = kTRUE);
    virtual TTree      *GetParentTree() const {return fParentTree;}
-   virtual TTree      *GetTree();
+   virtual TTree      *GetTree(Bool_t load = kTRUE);
    virtual const char *GetTreeName() const {return fTreeName.Data();}
    virtual void        ls(Option_t *option="") const;
    virtual void        RecursiveRemove(TObject *obj);

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -491,7 +491,7 @@ public:
    virtual Long64_t        ReadStream(std::istream& inputStream, const char* branchDescriptor = "", char delimiter = ' ');
    virtual void            Refresh();
    virtual void            RecursiveRemove(TObject *obj);
-   virtual void            RemoveFriend(TTree*);
+   virtual void            RemoveFriend(TTree *, Bool_t parent = kFALSE);
    virtual void            Reset(Option_t* option = "");
    virtual void            ResetAfterMerge(TFileMergeInfo *);
    virtual void            ResetBranchAddress(TBranch *);

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -2210,6 +2210,7 @@ void TChain::RecursiveRemove(TObject *obj)
    if (fTree == obj) {
       fTree = 0;
    }
+   TTree::RecursiveRemove(obj);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -2225,16 +2225,16 @@ void TChain::RecursiveRemove(TObject *obj)
 ////////////////////////////////////////////////////////////////////////////////
 /// Remove a friend from the list of friends.
 
-void TChain::RemoveFriend(TTree* oldFriend)
+void TChain::RemoveFriend(TTree* oldFriend, Bool_t parent /* = kFALSE */)
 {
    // We already have been visited while recursively looking
    // through the friends tree, let return
 
-   if (!fFriends) {
+   if (!fFriends || fFriends->GetSize() == 0) {
       return;
    }
 
-   TTree::RemoveFriend(oldFriend);
+   TTree::RemoveFriend(oldFriend, parent);
 
    if (fProofChain)
       // This updates the proxy chain when we will really use PROOF

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -1338,8 +1338,15 @@ Long64_t TChain::LoadTree(Long64_t entry)
                   // they could be reused. So we compare the tree
                   // number instead.
                   needUpdate = kTRUE;
-                  fTree->RemoveFriend(oldintree);
-                  fTree->AddFriend(at->GetTree(), fe->GetName())->SetBit(TFriendElement::kFromChain);
+                  if (fetree) {
+                     fTree->GetListOfFriends()->Remove(fetree);
+                     delete fetree;
+                  } else {
+                     fTree->RemoveFriend(at);
+                  }
+                  TFriendElement *at_fe = fTree->AddFriend(at->GetTree(), fe->GetName());
+                  at_fe->SetBit(TFriendElement::kFromChain);
+                  at_fe->fParentTree = at;
                }
             } else {
                // else we assume it is a simple tree If the tree is a
@@ -1609,7 +1616,9 @@ Long64_t TChain::LoadTree(Long64_t entry)
          t->LoadTreeFriend(entry, this);
          TTree* friend_t = t->GetTree();
          if (friend_t) {
-            fTree->AddFriend(friend_t, fe->GetName())->SetBit(TFriendElement::kFromChain);
+            TFriendElement *at_fe = fTree->AddFriend(friend_t, fe->GetName());
+            at_fe->SetBit(TFriendElement::kFromChain);
+            at_fe->fParentTree = t;
          }
       }
    }

--- a/tree/tree/src/TFriendElement.cxx
+++ b/tree/tree/src/TFriendElement.cxx
@@ -144,34 +144,6 @@ TFriendElement::TFriendElement(TTree *tree, TTree* friendtree, const char *alias
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Copy constructor
-
-TFriendElement::TFriendElement(const TFriendElement& tfe) :
-   TNamed(tfe),
-   fParentTree(tfe.fParentTree),
-   fTree(tfe.fTree),
-   fFile(tfe.fFile),
-   fTreeName(tfe.fTreeName),
-   fOwnFile(tfe.fOwnFile)
-{
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Equal operator
-
-TFriendElement& TFriendElement::operator=(const TFriendElement& tfe)
-{
-   if(this!=&tfe) {
-      TNamed::operator=(tfe);
-      fParentTree=tfe.fParentTree;
-      fTree=tfe.fTree;
-      fFile=tfe.fFile;
-      fTreeName=tfe.fTreeName;
-      fOwnFile=tfe.fOwnFile;
-   } return *this;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Destructor.  Disconnect from the owning tree if needed.
 
 TFriendElement::~TFriendElement()

--- a/tree/tree/src/TFriendElement.cxx
+++ b/tree/tree/src/TFriendElement.cxx
@@ -224,3 +224,18 @@ void TFriendElement::ls(Option_t *) const
 {
    printf(" Friend Tree: %s in file: %s\n",GetName(),GetTitle());
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Update the tree and file pointer in case of RecursiveRemove.
+
+void TFriendElement::RecursiveRemove(TObject *obj)
+{
+    if (obj == fFile) {
+       fFile = nullptr;
+       fTree = nullptr;
+    } else if (obj == fTree) {
+       fTree = nullptr;
+    } else if (obj == fParentTree) {
+       fParentTree = nullptr;
+    }
+}

--- a/tree/tree/src/TFriendElement.cxx
+++ b/tree/tree/src/TFriendElement.cxx
@@ -175,10 +175,12 @@ TTree *TFriendElement::DisConnect()
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return pointer to TFile containing this friend TTree.
+/// If 'load' is true, attempts to loa the TTree from the file
+/// otherwise return the current value of fTree.
 
-TFile *TFriendElement::GetFile()
+TFile *TFriendElement::GetFile(Bool_t load /* = kTRUE */)
 {
-   if (fFile || IsZombie()) return fFile;
+   if (fFile || IsZombie() || !load) return fFile;
 
    if (strlen(GetTitle())) {
       TDirectory::TContext ctxt;
@@ -201,10 +203,12 @@ TFile *TFriendElement::GetFile()
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return pointer to friend TTree.
+/// If 'load' is true, attempts to loa the TTree from the file
+/// otherwise return the current value of fTree.
 
-TTree *TFriendElement::GetTree()
+TTree *TFriendElement::GetTree(Bool_t load /* = kTRUE */)
 {
-   if (fTree) return fTree;
+   if (fTree || !load) return fTree;
 
    if (GetFile()) {
       fFile->GetObject(GetTreeName(),fTree);
@@ -231,10 +235,11 @@ void TFriendElement::ls(Option_t *) const
 void TFriendElement::RecursiveRemove(TObject *obj)
 {
     if (obj == fFile) {
-       fFile = nullptr;
-       fTree = nullptr;
+       fFile = (TFile*) nullptr;
+       fTree = (TTree*) nullptr;
+       fOwnFile = kFALSE;
     } else if (obj == fTree) {
-       fTree = nullptr;
+       fTree = (TTree*) nullptr;
     } else if (obj == fParentTree) {
        fParentTree = nullptr;
     }

--- a/tree/tree/src/TFriendElement.cxx
+++ b/tree/tree/src/TFriendElement.cxx
@@ -85,8 +85,8 @@ TFriendElement::TFriendElement(TTree *tree, const char *treename, TFile *file)
    fOwnFile    = kFALSE;
    fParentTree = tree;
    fTreeName   = treename;
-   if (fParentTree && fParentTree->GetDirectory()
-       && fParentTree->GetDirectory()->GetFile() == fFile) {
+   if (fParentTree && fParentTree->GetTree() && fParentTree->GetTree()->GetDirectory()
+       && fParentTree->GetTree()->GetDirectory()->GetFile() == fFile) {
       // The friend and the TTree are in the same file, let's not record
       // the filename.
       SetTitle("");
@@ -125,8 +125,8 @@ TFriendElement::TFriendElement(TTree *tree, TTree* friendtree, const char *alias
    if (fTree) {
       fTreeName   = fTree->GetName();
       if (fTree->GetDirectory()) fFile = fTree->GetDirectory()->GetFile();
-      if (fParentTree && fParentTree->GetDirectory()
-          && fParentTree->GetDirectory()->GetFile() == fFile) {
+      if (fParentTree && fParentTree->GetTree() && fParentTree->GetTree()->GetDirectory()
+          && fParentTree->GetTree()->GetDirectory()->GetFile() == fFile) {
          // The friend and the TTree are in the same file, let's not record
          // the filename.
          SetTitle("");
@@ -185,7 +185,7 @@ TFile *TFriendElement::GetFile()
       fFile = TFile::Open(GetTitle());
       fOwnFile = kTRUE;
    } else {
-      TDirectory *dir = fParentTree->GetDirectory();
+      TDirectory *dir = (fParentTree && fParentTree->GetTree()) ? fParentTree->GetTree()->GetDirectory() : nullptr;
       if (dir) {
          fFile = dir->GetFile();
          fOwnFile = kFALSE;

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -7580,6 +7580,15 @@ void TTree::RecursiveRemove(TObject *obj)
    if (fFriends) {
       fFriends->RecursiveRemove(obj);
    }
+   // Note that if obj is equal to fDirectory, some 'wrong' is going on
+   // as the directory would have deleted the TTree it owns before
+   // calling RecursiveRemove.
+   if (fDirectory == obj) {
+      Warning("RecursiveRemove",
+              "The directory of the TTree %s is unexpectedly RecursiveRemoved before the TTree",
+              GetName());
+      fDirectory = 0;
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -7635,23 +7635,25 @@ void TTree::Refresh()
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Remove a friend from the list of friends.
+/// If 'parent' is false, search a TFriendElement that points to the 'tree' argument.
+/// If 'parent' is true, search a TFriendElement whose 'parent tree' is the 'tree' argument.
 
-void TTree::RemoveFriend(TTree* parent)
+void TTree::RemoveFriend(TTree* tree, bool parent /* = kFALSE */)
 {
    // We already have been visited while recursively looking
    // through the friends tree, let return
    if (kRemoveFriend & fFriendLockStatus) {
       return;
    }
-   if (!fFriends) {
+   if (!fFriends || fFriends->GetEntries() == 0) {
       return;
    }
    TFriendLock lock(this, kRemoveFriend);
    TIter nextf(fFriends);
    TFriendElement* fe = 0;
    while ((fe = (TFriendElement*) nextf())) {
-      TTree* friend_t = fe->GetParentTree();
-      if (friend_t == parent) {
+      TTree* friend_t = parent ? fe->GetParentTree() : friend_t = fe->GetTree(kFALSE);
+      if (friend_t == tree) {
          fFriends->Remove(fe);
          delete fe;
          fe = 0;

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -7636,7 +7636,7 @@ void TTree::Refresh()
 ////////////////////////////////////////////////////////////////////////////////
 /// Remove a friend from the list of friends.
 
-void TTree::RemoveFriend(TTree* oldFriend)
+void TTree::RemoveFriend(TTree* parent)
 {
    // We already have been visited while recursively looking
    // through the friends tree, let return
@@ -7650,8 +7650,8 @@ void TTree::RemoveFriend(TTree* oldFriend)
    TIter nextf(fFriends);
    TFriendElement* fe = 0;
    while ((fe = (TFriendElement*) nextf())) {
-      TTree* friend_t = fe->GetTree();
-      if (friend_t == oldFriend) {
+      TTree* friend_t = fe->GetParentTree();
+      if (friend_t == parent) {
          fFriends->Remove(fe);
          delete fe;
          fe = 0;


### PR DESCRIPTION
TChain::RecursiveRemove was not looking at the list of friends.

TTree::RecursiveRemove was looking at the list of friends but we needed a TFriendElement::RecursiveRemove for it to be effective.