### PR TITLE
Remove unnecessary includes

### DIFF
--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -67,10 +67,7 @@ setting/clearing/testing named attributes.
 #include "RooTreeDataStore.h"
 
 #include <string.h>
-#include <iomanip>
-#include <fstream>
 #include <algorithm>
-#include <sstream>
 
 using namespace std ;
 

--- a/roofit/roofitcore/src/RooAbsCategoryLValue.cxx
+++ b/roofit/roofitcore/src/RooAbsCategoryLValue.cxx
@@ -32,7 +32,6 @@ to other RooAbsArgs must be invertible
 #include "Riostream.h"
 #include "Riostream.h"
 #include <stdlib.h>
-#include <string.h>
 #include "TTree.h"
 #include "TString.h"
 #include "TH1.h"

--- a/roofit/roofitcore/src/RooAbsCollection.cxx
+++ b/roofit/roofitcore/src/RooAbsCollection.cxx
@@ -29,11 +29,6 @@ collections.
 **/
 
 #include <iomanip>
-#include <fstream>
-#include <vector>
-#include <string>
-#include <sstream>
-#include <algorithm>
 
 #include "Riostream.h"
 #include "TClass.h"

--- a/roofit/roofitcore/src/RooAbsMoment.cxx
+++ b/roofit/roofitcore/src/RooAbsMoment.cxx
@@ -30,7 +30,6 @@ derivator class.
 #include "Riostream.h"
 #include "Riostream.h"
 #include <math.h>
-#include <string>
 
 #include "RooAbsMoment.h"
 #include "RooAbsReal.h"

--- a/roofit/roofitcore/src/RooAbsRealLValue.cxx
+++ b/roofit/roofitcore/src/RooAbsRealLValue.cxx
@@ -35,9 +35,6 @@ interpreted as a parameter.
 #include "RooFit.h"
 
 #include <math.h>
-#include <stdlib.h>
-#include <string.h>
-#include <ctype.h>
 #include "Riostream.h"
 #include "TObjString.h"
 #include "TTree.h"

--- a/roofit/roofitcore/src/RooAdaptiveIntegratorND.cxx
+++ b/roofit/roofitcore/src/RooAdaptiveIntegratorND.cxx
@@ -38,7 +38,6 @@ numerical integration algorithm.
 #include "Math/AdaptiveIntegratorMultiDim.h"
 
 #include <assert.h>
-#include <iomanip>
 
 
 

--- a/roofit/roofitcore/src/RooAddition.cxx
+++ b/roofit/roofitcore/src/RooAddition.cxx
@@ -30,9 +30,6 @@ i.e. all integrals of the product are handled numerically
 
 #include "Riostream.h"
 #include <math.h>
-#include <memory>
-#include <list>
-#include <algorithm>
 using namespace std ;
 
 #include "RooAddition.h"

--- a/roofit/roofitcore/src/RooArgList.cxx
+++ b/roofit/roofitcore/src/RooArgList.cxx
@@ -40,7 +40,6 @@
 
 #include "Riostream.h"
 #include <iomanip>
-#include <fstream>
 #include "TClass.h"
 #include "RooArgList.h"
 #include "RooErrorHandler.h"

--- a/roofit/roofitcore/src/RooArgSet.cxx
+++ b/roofit/roofitcore/src/RooArgSet.cxx
@@ -41,8 +41,6 @@
 
 #include "Riostream.h"
 #include <iomanip>
-#include <fstream>
-#include <list>
 #include "TClass.h"
 #include "RooErrorHandler.h"
 #include "RooArgSet.h"

--- a/roofit/roofitcore/src/RooBinning.cxx
+++ b/roofit/roofitcore/src/RooBinning.cxx
@@ -27,7 +27,6 @@ uniformly spaced boundaries.
 **/
 
 #include <cmath>
-#include <algorithm>
 #include "RooFit.h"
 
 #include "Riostream.h"

--- a/roofit/roofitcore/src/RooBinningCategory.cxx
+++ b/roofit/roofitcore/src/RooBinningCategory.cxx
@@ -29,7 +29,6 @@ by a series of thresholds.
 #include "Riostream.h"
 #include "Riostream.h"
 #include <stdlib.h>
-#include <stdio.h>
 #include "TString.h"
 #include "RooBinningCategory.h"
 #include "RooStreamParser.h"

--- a/roofit/roofitcore/src/RooCatType.cxx
+++ b/roofit/roofitcore/src/RooCatType.cxx
@@ -27,7 +27,6 @@ index value which define the state
 #include "RooFit.h"
 
 #include <stdlib.h>
-#include <stdlib.h>
 #include "TClass.h"
 #include "RooCatType.h"
 

--- a/roofit/roofitcore/src/RooCategory.cxx
+++ b/roofit/roofitcore/src/RooCategory.cxx
@@ -29,7 +29,6 @@ has a public interface to define the possible value states.
 #include "Riostream.h"
 #include "Riostream.h"
 #include <stdlib.h>
-#include <string.h>
 #include "TTree.h"
 #include "TString.h"
 #include "TH1.h"

--- a/roofit/roofitcore/src/RooClassFactory.cxx
+++ b/roofit/roofitcore/src/RooClassFactory.cxx
@@ -39,8 +39,6 @@ instantiate objects.
 #include "RooGlobalFunc.h"
 #include "RooAbsPdf.h"
 #include <fstream>
-#include <vector>
-#include <string>
 
 using namespace std ;
 

--- a/roofit/roofitcore/src/RooCurve.cxx
+++ b/roofit/roofitcore/src/RooCurve.cxx
@@ -50,11 +50,7 @@ a function y(x) is actually evaluated to approximate a smooth curve, use:
 #include "TMatrixD.h"
 #include "TVectorD.h"
 #include <iomanip>
-#include <math.h>
-#include <assert.h>
 #include <deque>
-#include <algorithm>
-#include <limits>
 
 using namespace std ;
 

--- a/roofit/roofitcore/src/RooDerivative.cxx
+++ b/roofit/roofitcore/src/RooDerivative.cxx
@@ -30,7 +30,6 @@ derivator class.
 #include "Riostream.h"
 #include "Riostream.h"
 #include <math.h>
-#include <string>
 
 #include "RooDerivative.h"
 #include "RooAbsReal.h"

--- a/roofit/roofitcore/src/RooEllipse.cxx
+++ b/roofit/roofitcore/src/RooEllipse.cxx
@@ -34,7 +34,6 @@ an error contour.
 #include "Riostream.h"
 #include "TClass.h"
 #include <math.h>
-#include <assert.h>
 
 using namespace std;
 

--- a/roofit/roofitcore/src/RooExpensiveObjectCache.cxx
+++ b/roofit/roofitcore/src/RooExpensiveObjectCache.cxx
@@ -35,7 +35,6 @@ retrieve these precalculated objects
 #include "RooArgSet.h"
 #include "RooMsgService.h"
 #include <iostream>
-#include <math.h>
 using namespace std ;
 
 #include "RooExpensiveObjectCache.h"

--- a/roofit/roofitcore/src/RooFactoryWSTool.cxx
+++ b/roofit/roofitcore/src/RooFactoryWSTool.cxx
@@ -41,8 +41,6 @@ instantiate objects.
 #include "RooAbsPdf.h"
 #include "RooGaussian.h"
 #include <fstream>
-#include <vector>
-#include <string>
 #include "RooGlobalFunc.h"
 #include "RooDataSet.h"
 #include "RooDataHist.h"

--- a/roofit/roofitcore/src/RooFirstMoment.cxx
+++ b/roofit/roofitcore/src/RooFirstMoment.cxx
@@ -30,7 +30,6 @@ derivator class.
 #include "Riostream.h"
 #include "Riostream.h"
 #include <math.h>
-#include <string>
 
 #include "RooFirstMoment.h"
 #include "RooAbsReal.h"

--- a/roofit/roofitcore/src/RooGaussKronrodIntegrator1D.cxx
+++ b/roofit/roofitcore/src/RooGaussKronrodIntegrator1D.cxx
@@ -46,7 +46,6 @@ reached
 #include <assert.h>
 #include <math.h>
 #include <float.h>
-#include <stdlib.h>
 #include "Riostream.h"
 #include "TMath.h"
 #include "RooGaussKronrodIntegrator1D.h"

--- a/roofit/roofitcore/src/RooHist.cxx
+++ b/roofit/roofitcore/src/RooHist.cxx
@@ -37,7 +37,6 @@ a RooPlot.
 #include "TClass.h"
 #include "Riostream.h"
 #include <iomanip>
-#include <math.h>
 
 using namespace std;
 

--- a/roofit/roofitcore/src/RooLinearVar.cxx
+++ b/roofit/roofitcore/src/RooLinearVar.cxx
@@ -41,9 +41,6 @@
 #include "Riostream.h"
 
 #include <math.h>
-#include <stdlib.h>
-#include <string.h>
-#include <ctype.h>
 #include "TClass.h"
 #include "TObjString.h"
 #include "TTree.h"

--- a/roofit/roofitcore/src/RooMCIntegrator.cxx
+++ b/roofit/roofitcore/src/RooMCIntegrator.cxx
@@ -40,7 +40,6 @@ based on a C version from the 0.9 beta release of the GNU scientific library.
 #include "RooMsgService.h"
 
 #include <math.h>
-#include <assert.h>
 
 
 

--- a/roofit/roofitcore/src/RooMappedCategory.cxx
+++ b/roofit/roofitcore/src/RooMappedCategory.cxx
@@ -23,8 +23,6 @@
 // output state label.
 
 #include <cstdio>
-#include <memory>
-#include <cstdlib>
 
 #include "RooMappedCategory.h"
 

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -44,7 +44,6 @@ automatic PDF optimization.
 #include "TClass.h"
 
 #include <fstream>
-#include <iomanip>
 
 #include "TH1.h"
 #include "TH2.h"

--- a/roofit/roofitcore/src/RooMoment.cxx
+++ b/roofit/roofitcore/src/RooMoment.cxx
@@ -30,7 +30,6 @@ derivator class.
 #include "Riostream.h"
 #include "Riostream.h"
 #include <math.h>
-#include <string>
 
 #include "RooMoment.h"
 #include "RooAbsReal.h"

--- a/roofit/roofitcore/src/RooMsgService.cxx
+++ b/roofit/roofitcore/src/RooMsgService.cxx
@@ -56,7 +56,6 @@ The singleton instance is accessible through RooMsgService::instance() ;
 #include "TSystem.h"
 #include "Riostream.h"
 #include <iomanip>
-#include <fstream>
 using namespace std ;
 using namespace RooFit ;
 

--- a/roofit/roofitcore/src/RooMultiCategory.cxx
+++ b/roofit/roofitcore/src/RooMultiCategory.cxx
@@ -31,7 +31,6 @@ category modifies its list of states
 #include "Riostream.h"
 #include "Riostream.h"
 #include <stdlib.h>
-#include <stdio.h>
 #include "TString.h"
 #include "RooMultiCategory.h"
 #include "RooStreamParser.h"

--- a/roofit/roofitcore/src/RooNameSet.cxx
+++ b/roofit/roofitcore/src/RooNameSet.cxx
@@ -27,8 +27,6 @@ by offering it a list of new RooAbsArg objects.
 **/
 
 #include <cstring>
-#include <algorithm>
-#include <cassert>
 
 #include "RooFit.h"
 #include "Riostream.h"

--- a/roofit/roofitcore/src/RooPlot.cxx
+++ b/roofit/roofitcore/src/RooPlot.cxx
@@ -67,7 +67,6 @@ object onto a one-dimensional plot.
 
 #include "Riostream.h"
 #include <string.h>
-#include <assert.h>
 
 using namespace std;
 

--- a/roofit/roofitcore/src/RooProduct.cxx
+++ b/roofit/roofitcore/src/RooProduct.cxx
@@ -27,10 +27,7 @@ of a given set of other RooAbsReal objects
 
 
 #include <cmath>
-#include <vector>
-#include <utility>
 #include <memory>
-#include <algorithm>
 
 #include "RooProduct.h"
 #include "RooNameReg.h"

--- a/roofit/roofitcore/src/RooRealSumFunc.cxx
+++ b/roofit/roofitcore/src/RooRealSumFunc.cxx
@@ -44,7 +44,6 @@
 #include "RooNameReg.h"
 #include "RooTrace.h"
 #include <memory>
-#include <algorithm>
 
 using namespace std;
 

--- a/roofit/roofitcore/src/RooRealSumPdf.cxx
+++ b/roofit/roofitcore/src/RooRealSumPdf.cxx
@@ -49,7 +49,6 @@ In the present version \f$coef_i\f$ may not depend on x, but this limitation may
 #include "RooMsgService.h"
 #include "RooNameReg.h"
 #include <memory>
-#include <algorithm>
 
 #include "TError.h"
 

--- a/roofit/roofitcore/src/RooRealVar.cxx
+++ b/roofit/roofitcore/src/RooRealVar.cxx
@@ -31,10 +31,6 @@ a optionally series of alternate named ranges.
 #include "RooTrace.h"
 
 #include <math.h>
-#include <stdlib.h>
-#include <string.h>
-#include <ctype.h>
-#include <iomanip>
 #include "TObjString.h"
 #include "TTree.h"
 #include "RooRealVar.h"

--- a/roofit/roofitcore/src/RooSecondMoment.cxx
+++ b/roofit/roofitcore/src/RooSecondMoment.cxx
@@ -30,7 +30,6 @@ derivator class.
 #include "Riostream.h"
 #include "Riostream.h"
 #include <math.h>
-#include <string>
 
 #include "RooSecondMoment.h"
 #include "RooAbsReal.h"

--- a/roofit/roofitcore/src/RooSimPdfBuilder.cxx
+++ b/roofit/roofitcore/src/RooSimPdfBuilder.cxx
@@ -418,7 +418,6 @@
 #include "RooFit.h"
 
 #include <string.h>
-#include <string.h>
 
 #ifndef _WIN32
 #include <strings.h>

--- a/roofit/roofitcore/src/RooStreamParser.cxx
+++ b/roofit/roofitcore/src/RooStreamParser.cxx
@@ -39,7 +39,6 @@
 #include "Riostream.h"
 #include "Riostream.h"
 #include <stdlib.h>
-#include <ctype.h>
 
 #ifndef _WIN32
 #include <strings.h>

--- a/roofit/roofitcore/src/RooStringVar.cxx
+++ b/roofit/roofitcore/src/RooStringVar.cxx
@@ -26,9 +26,6 @@ RooStringVar implements a string values RooAbsArg
 #include "Riostream.h"
 
 #include <math.h>
-#include <stdlib.h>
-#include <string.h>
-#include <ctype.h>
 #include "TObjString.h"
 #include "TTree.h"
 #include "RooStringVar.h"

--- a/roofit/roofitcore/src/RooSuperCategory.cxx
+++ b/roofit/roofitcore/src/RooSuperCategory.cxx
@@ -35,7 +35,6 @@ category modifies its list of states
 #include "Riostream.h"
 #include "Riostream.h"
 #include <stdlib.h>
-#include <stdio.h>
 #include "TString.h"
 #include "TClass.h"
 #include "RooSuperCategory.h"

--- a/roofit/roofitcore/src/RooThresholdCategory.cxx
+++ b/roofit/roofitcore/src/RooThresholdCategory.cxx
@@ -29,7 +29,6 @@ by a series of thresholds.
 #include "Riostream.h"
 #include "Riostream.h"
 #include <stdlib.h>
-#include <stdio.h>
 #include "TString.h"
 #include "RooThresholdCategory.h"
 #include "RooStreamParser.h"

--- a/roofit/roofitcore/src/RooVectorDataStore.cxx
+++ b/roofit/roofitcore/src/RooVectorDataStore.cxx
@@ -41,8 +41,6 @@ use a TTree as internal storage mechanism
 #include "RooTrace.h"
 
 #include <iomanip>
-#include <algorithm>
-#include <memory>
 using namespace std ;
 
 ClassImp(RooVectorDataStore);

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -59,9 +59,6 @@ importClassCode() method.
 #include "TFile.h"
 #include "TH1.h"
 #include <map>
-#include <string>
-#include <list>
-#include <set>
 
 using namespace std ;
 
@@ -74,7 +71,6 @@ using namespace std ;
 #include "TClass.h"
 #include "Riostream.h"
 #include <string.h>
-#include <assert.h>
 
 ClassImp(RooWorkspace);
 ;


### PR DESCRIPTION
Thanks to @dpiparo suggestion, I wrote a script automatically removing unnecessary includes under a directory. In
this patch I removed unnecessary includes in roofit/roofitcore/src/ for test, but
you can use this script to any directories.

Script:
https://gist.github.com/yamaguchi1024/d95843a5e549fcc6ba0e6e23da5c132a

How to use:
python3 iwyu.py /path/to/directory/you/want/

Limitations:
include-what-you-use is not complete, it sometimes remove *necessary*
includes. So you must compile and modify diff or checkout files if necessary include was
removed. I reccomend to use this script in a directory where you're
familiar with, because you anyway have to check the diff.