### PR TITLE
Final update to use LZ4 as a default for ROOT

### DIFF
--- a/io/io/inc/TFile.h
+++ b/io/io/inc/TFile.h
@@ -174,7 +174,7 @@ public:
    enum EFileType { kDefault = 0, kLocal = 1, kNet = 2, kWeb = 3, kFile = 4, kMerge = 5};
 
    TFile();
-   TFile(const char *fname, Option_t *option="", const char *ftitle="", Int_t compress=1);
+   TFile(const char *fname, Option_t *option="", const char *ftitle="", Int_t compress=4);
    virtual ~TFile();
    virtual void        Close(Option_t *option=""); // *MENU*
    virtual void        Copy(TObject &) const { MayNotUse("Copy(TObject &)"); }
@@ -253,8 +253,8 @@ public:
    virtual void        SetCacheRead(TFileCacheRead *cache, TObject* tree = 0, ECacheAction action = kDisconnect);
    virtual void        SetCacheWrite(TFileCacheWrite *cache);
    virtual void        SetCompressionAlgorithm(Int_t algorithm=0);
-   virtual void        SetCompressionLevel(Int_t level=1);
-   virtual void        SetCompressionSettings(Int_t settings=1);
+   virtual void        SetCompressionLevel(Int_t level=4);
+   virtual void        SetCompressionSettings(Int_t settings=4);
    virtual void        SetEND(Long64_t last) { fEND = last; }
    virtual void        SetOffset(Long64_t offset, ERelativeTo pos = kBeg);
    virtual void        SetOption(Option_t *option=">") { fOption = option; }

--- a/io/io/inc/TMemFile.h
+++ b/io/io/inc/TMemFile.h
@@ -59,8 +59,8 @@ private:
    TMemFile &operator=(const TMemFile&); // Not implemented.
 
 public:
-   TMemFile(const char *name, Option_t *option="", const char *ftitle="", Int_t compress=1);
-   TMemFile(const char *name, char *buffer, Long64_t size, Option_t *option="", const char *ftitle="", Int_t compress=1);
+   TMemFile(const char *name, Option_t *option="", const char *ftitle="", Int_t compress=4);
+   TMemFile(const char *name, char *buffer, Long64_t size, Option_t *option="", const char *ftitle="", Int_t compress=4);
    TMemFile(const TMemFile &orig);
    virtual ~TMemFile();
 

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -2181,8 +2181,8 @@ void TFile::SetCompressionAlgorithm(Int_t algorithm)
 {
    if (algorithm < 0 || algorithm >= ROOT::kUndefinedCompressionAlgorithm) algorithm = 0;
    if (fCompress < 0) {
-      // if the level is not defined yet use 1 as a default
-      fCompress = 100 * algorithm + 1;
+      // if the level is not defined yet use 4 as a default (was 1 for ZLIB)
+      fCompress = 100 * algorithm + 4;
    } else {
       int level = fCompress % 100;
       fCompress = 100 * algorithm + level;

--- a/io/rfio/inc/TRFIOFile.h
+++ b/io/rfio/inc/TRFIOFile.h
@@ -33,7 +33,7 @@ private:
 
 public:
    TRFIOFile(const char *url, Option_t *option="",
-             const char *ftitle="", Int_t compress=1);
+             const char *ftitle="", Int_t compress=4);
    ~TRFIOFile();
 
    Int_t   GetErrno() const;

--- a/io/xml/inc/TBufferXML.h
+++ b/io/xml/inc/TBufferXML.h
@@ -228,8 +228,8 @@ protected:
    Int_t GetCompressionLevel() const;
    Int_t GetCompressionSettings() const;
    void SetCompressionAlgorithm(Int_t algorithm = 0);
-   void SetCompressionLevel(Int_t level = 1);
-   void SetCompressionSettings(Int_t settings = 1);
+   void SetCompressionLevel(Int_t level = 4);
+   void SetCompressionSettings(Int_t settings = 4);
    void SetXML(TXMLEngine *xml) { fXML = xml; }
 
    void XmlWriteBlock(XMLNodePointer_t node);

--- a/io/xml/src/TBufferXML.cxx
+++ b/io/xml/src/TBufferXML.cxx
@@ -366,7 +366,7 @@ void TBufferXML::SetCompressionAlgorithm(Int_t algorithm)
       algorithm = 0;
    if (fCompressLevel < 0) {
       // if the level is not defined yet use 1 as a default
-      fCompressLevel = 100 * algorithm + 1;
+      fCompressLevel = 100 * algorithm + 4;
    } else {
       int level = fCompressLevel % 100;
       fCompressLevel = 100 * algorithm + level;

--- a/main/src/hadd.cxx
+++ b/main/src/hadd.cxx
@@ -12,7 +12,7 @@
          (targetfile is overwritten if it exists)
 
   When the -f option is specified, one can also specify the compression
-  level of the target file. By default the compression level is 1, but
+  level of the target file. By default the compression level is 4, but
   if "-f0" is specified, the target file will not be compressed.
   if "-f6" is specified, the compression level 6 will be used.
 
@@ -421,9 +421,9 @@ int main( int argc, char **argv )
          if (firstInput && !firstInput->IsZombie())
             newcomp = firstInput->GetCompressionSettings();
          else
-            newcomp = 1;
+            newcomp = 4;
          delete firstInput;
-      } else newcomp = 1; // default compression level.
+      } else newcomp = 4; // default compression level.
    }
    if (verbosity > 1) {
       if (keepCompressionAsIs && !reoptimize)

--- a/net/davix/inc/TDavixFile.h
+++ b/net/davix/inc/TDavixFile.h
@@ -93,7 +93,7 @@ public:
     ///
     /// Several parameters can be used if separated with whitespace
 
-   TDavixFile(const char* url, Option_t *option="", const char *ftitle="", Int_t compress=1);
+   TDavixFile(const char* url, Option_t *option="", const char *ftitle="", Int_t compress=4);
 
    ~TDavixFile();
 

--- a/net/net/inc/TMessage.h
+++ b/net/net/inc/TMessage.h
@@ -81,8 +81,8 @@ public:
    Int_t    GetCompressionLevel() const;
    Int_t    GetCompressionSettings() const;
    void     SetCompressionAlgorithm(Int_t algorithm=0);
-   void     SetCompressionLevel(Int_t level=1);
-   void     SetCompressionSettings(Int_t settings=1);
+   void     SetCompressionLevel(Int_t level=4);
+   void     SetCompressionSettings(Int_t settings=4);
    Int_t    Compress();
    Int_t    Uncompress();
    char    *CompBuffer() const { return fBufComp; }

--- a/net/net/inc/TSocket.h
+++ b/net/net/inc/TSocket.h
@@ -164,8 +164,8 @@ public:
    virtual Int_t         SendRaw(const void *buffer, Int_t length,
                                  ESendRecvOptions opt = kDefault);
    void                  SetCompressionAlgorithm(Int_t algorithm=0);
-   void                  SetCompressionLevel(Int_t level=1);
-   void                  SetCompressionSettings(Int_t settings=1);
+   void                  SetCompressionLevel(Int_t level=4);
+   void                  SetCompressionSettings(Int_t settings=4);
    virtual Int_t         SetOption(ESockOptions opt, Int_t val);
    void                  SetRemoteProtocol(Int_t rproto) { fRemoteProtocol = rproto; }
    void                  SetSecContext(TSecContext *ctx) { fSecContext = ctx; }

--- a/net/net/inc/TUDPSocket.h
+++ b/net/net/inc/TUDPSocket.h
@@ -132,8 +132,8 @@ public:
    virtual Int_t         SendRaw(const void *buffer, Int_t length,
                                  ESendRecvOptions opt = kDefault);
    void                  SetCompressionAlgorithm(Int_t algorithm=0);
-   void                  SetCompressionLevel(Int_t level=1);
-   void                  SetCompressionSettings(Int_t settings=1);
+   void                  SetCompressionLevel(Int_t level=4);
+   void                  SetCompressionSettings(Int_t settings=4);
    virtual Int_t         SetOption(ESockOptions opt, Int_t val);
    void                  SetRemoteProtocol(Int_t rproto) { fRemoteProtocol = rproto; }
    void                  SetSecContext(TSecContext *ctx) { fSecContext = ctx; }

--- a/net/net/src/TMessage.cxx
+++ b/net/net/src/TMessage.cxx
@@ -239,7 +239,7 @@ void TMessage::SetCompressionAlgorithm(Int_t algorithm)
    if (algorithm < 0 || algorithm >= ROOT::kUndefinedCompressionAlgorithm) algorithm = 0;
    Int_t newCompress;
    if (fCompress < 0) {
-      newCompress = 100 * algorithm + 1;
+      newCompress = 100 * algorithm + 4;
    } else {
       int level = fCompress % 100;
       newCompress = 100 * algorithm + level;

--- a/net/net/src/TSocket.cxx
+++ b/net/net/src/TSocket.cxx
@@ -1051,8 +1051,8 @@ void TSocket::SetCompressionAlgorithm(Int_t algorithm)
 {
    if (algorithm < 0 || algorithm >= ROOT::kUndefinedCompressionAlgorithm) algorithm = 0;
    if (fCompress < 0) {
-      // if the level is not defined yet use 1 as a default
-      fCompress = 100 * algorithm + 1;
+      // if the level is not defined yet use 4 as a default (with ZLIB was 1)
+      fCompress = 100 * algorithm + 4;
    } else {
       int level = fCompress % 100;
       fCompress = 100 * algorithm + level;

--- a/net/net/src/TUDPSocket.cxx
+++ b/net/net/src/TUDPSocket.cxx
@@ -1022,8 +1022,8 @@ void TUDPSocket::SetCompressionAlgorithm(Int_t algorithm)
 {
    if (algorithm < 0 || algorithm >= ROOT::kUndefinedCompressionAlgorithm) algorithm = 0;
    if (fCompress < 0) {
-      // if the level is not defined yet use 1 as a default
-      fCompress = 100 * algorithm + 1;
+      // if the level is not defined yet use 4 as a default (with ZLIB was 1)
+      fCompress = 100 * algorithm + 4;
    } else {
       int level = fCompress % 100;
       fCompress = 100 * algorithm + level;

--- a/roofit/roofitcore/src/RooAbsCategory.cxx
+++ b/roofit/roofitcore/src/RooAbsCategory.cxx
@@ -505,7 +505,7 @@ void RooAbsCategory::attachToTree(TTree& t, Int_t bufSize)
 
     if (branch->GetCompressionLevel()<0) {
       cxcoutD(DataHandling) << "RooAbsCategory::attachToTree(" << GetName() << ") Fixing compression level of branch " << GetName() << endl ;
-      branch->SetCompressionLevel(1) ;
+      branch->SetCompressionLevel(4) ;
     }
   }
 
@@ -521,7 +521,7 @@ void RooAbsCategory::attachToTree(TTree& t, Int_t bufSize)
     t.SetBranchAddress(idxName,&((Int_t&)_value._value)) ;
     if (branch->GetCompressionLevel()<0) {
       cxcoutD(Contents) << "RooAbsCategory::attachToTree(" << GetName() << ") Fixing compression level of branch " << idxName << endl ;
-      branch->SetCompressionLevel(1) ;
+      branch->SetCompressionLevel(4) ;
     }
     
   } else {    
@@ -529,7 +529,7 @@ void RooAbsCategory::attachToTree(TTree& t, Int_t bufSize)
     format.Append("/I");
     void* ptr = &(_value._value) ;
     branch = t.Branch(idxName, ptr, (const Text_t*)format, bufSize);
-    branch->SetCompressionLevel(1) ;
+    branch->SetCompressionLevel(4) ;
   }
   
   // First determine if branch is taken
@@ -538,7 +538,7 @@ void RooAbsCategory::attachToTree(TTree& t, Int_t bufSize)
     t.SetBranchAddress(lblName,_value._label) ;
     if (branch->GetCompressionLevel()<0) {
       cxcoutD(DataHandling) << "RooAbsCategory::attachToTree(" << GetName() << ") Fixing compression level of branch " << lblName << endl ;
-      branch->SetCompressionLevel(1) ;
+      branch->SetCompressionLevel(4) ;
     }
 
   } else {    
@@ -546,7 +546,7 @@ void RooAbsCategory::attachToTree(TTree& t, Int_t bufSize)
     format.Append("/C");
     void* ptr = _value._label ;
     branch = t.Branch(lblName, ptr, (const Text_t*)format, bufSize);
-    branch->SetCompressionLevel(1) ;
+    branch->SetCompressionLevel(4) ;
   }
 
 }

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -3244,7 +3244,7 @@ void RooAbsReal::attachToTree(TTree& t, Int_t bufSize)
 
     if (branch->GetCompressionLevel()<0) {
       // cout << "RooAbsReal::attachToTree(" << GetName() << ") Fixing compression level of branch " << cleanName << endl ;
-      branch->SetCompressionLevel(1) ;
+      branch->SetCompressionLevel(4) ;
     }
 
 //      cout << "RooAbsReal::attachToTree(" << cleanName << "): branch already exists in tree " << (void*)&t << ", changing address" << endl ;
@@ -3254,7 +3254,7 @@ void RooAbsReal::attachToTree(TTree& t, Int_t bufSize)
     TString format(cleanName);
     format.Append("/D");
     branch = t.Branch(cleanName, &_value, (const Text_t*)format, bufSize);
-    branch->SetCompressionLevel(1) ;
+    branch->SetCompressionLevel(4) ;
     //      cout << "RooAbsReal::attachToTree(" << cleanName << "): creating new branch in tree " << (void*)&t << endl ;
   }
 

--- a/roofit/roofitcore/src/RooAbsString.cxx
+++ b/roofit/roofitcore/src/RooAbsString.cxx
@@ -257,13 +257,13 @@ void RooAbsString::attachToTree(TTree& t, Int_t bufSize)
     t.SetBranchAddress(GetName(),_value) ;
     if (branch->GetCompressionLevel()<0) {
       cxcoutD(DataHandling) << "RooAbsString::attachToTree(" << GetName() << ") Fixing compression level of branch " << GetName() << endl ;
-      branch->SetCompressionLevel(1) ;
+      branch->SetCompressionLevel(4) ;
     }
   } else {
     TString format(GetName());
     format.Append("/C");
     branch = t.Branch(GetName(), _value, (const Text_t*)format, bufSize);
-    branch->SetCompressionLevel(1) ;
+    branch->SetCompressionLevel(4) ;
   }
 }
  

--- a/roofit/roostats/inc/RooStats/SamplingDistPlot.h
+++ b/roofit/roostats/inc/RooStats/SamplingDistPlot.h
@@ -96,7 +96,7 @@ namespace RooStats {
     void SetYRange( double mi, double ma ) { fYMin = mi; fYMax = ma; }
 
     /// write to Root file
-    void DumpToFile(const char* RootFileName, Option_t *option="", const char *ftitle="", Int_t compress=1);
+    void DumpToFile(const char* RootFileName, Option_t *option="", const char *ftitle="", Int_t compress=4);
 
   private:
     std::vector<Double_t> fSamplingDistr;

--- a/tree/tree/inc/TBranch.h
+++ b/tree/tree/inc/TBranch.h
@@ -219,8 +219,8 @@ public:
    virtual void      SetBasketSize(Int_t buffsize);
    virtual void      SetBufferAddress(TBuffer *entryBuffer);
    void              SetCompressionAlgorithm(Int_t algorithm=0);
-   void              SetCompressionLevel(Int_t level=1);
-   void              SetCompressionSettings(Int_t settings=1);
+   void              SetCompressionLevel(Int_t level=4);
+   void              SetCompressionSettings(Int_t settings=4);
    virtual void      SetEntries(Long64_t entries);
    virtual void      SetEntryOffsetLen(Int_t len, Bool_t updateSubBranches = kFALSE);
    virtual void      SetFirstEntry( Long64_t entry );

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -2252,7 +2252,7 @@ void TBranch::SetCompressionAlgorithm(Int_t algorithm)
 {
    if (algorithm < 0 || algorithm >= ROOT::kUndefinedCompressionAlgorithm) algorithm = 0;
    if (fCompress < 0) {
-      fCompress = 100 * algorithm + 1;
+      fCompress = 100 * algorithm + 4;
    } else {
       int level = fCompress % 100;
       fCompress = 100 * algorithm + level;

--- a/tree/tree/src/TBranchRef.cxx
+++ b/tree/tree/src/TBranchRef.cxx
@@ -60,7 +60,7 @@ TBranchRef::TBranchRef(TTree *tree)
    SetTitle("List of branch numbers with referenced objects");
    fRefTable = new TRefTable(this,100);
 
-   fCompress       = 1;
+   fCompress       = 4;
    fBasketSize     = 32000;
    fAddress        = 0;
    fBasketBytes    = new Int_t[fMaxBaskets];

--- a/tree/treeplayer/inc/ROOT/TSnapshotOptions.hxx
+++ b/tree/treeplayer/inc/ROOT/TSnapshotOptions.hxx
@@ -30,8 +30,8 @@ struct TSnapshotOptions {
    {
    }
    std::string fMode = "RECREATE";             //< Mode of creation of output file
-   ECAlgo fCompressionAlgorithm = ROOT::kZLIB; //< Compression algorithm of output file
-   int fCompressionLevel = 1;                  //< Compression level of output file
+   ECAlgo fCompressionAlgorithm = ROOT::kLZ4; //< Compression algorithm of output file
+   int fCompressionLevel = 4;                  //< Compression level of output file
    int fAutoFlush = 0;                         //< AutoFlush value for output tree
    int fSplitLevel = 99;                       //< Split level of output tree
 };

--- a/tutorials/net/hclient.C
+++ b/tutorials/net/hclient.C
@@ -37,7 +37,7 @@ void hclient(Bool_t evol=kFALSE)
    Float_t messlen  = 0;
    Float_t cmesslen = 0;
    if (idx == 1)
-      sock->SetCompressionLevel(1);
+      sock->SetCompressionLevel(4);
 
    TH1 *hpx;
    if (idx == 0) {

--- a/tutorials/net/hclientbonj.C
+++ b/tutorials/net/hclientbonj.C
@@ -62,7 +62,7 @@ void ConnectToServer(const TInetAddress *hostb, Int_t port)
    Float_t messlen  = 0;
    Float_t cmesslen = 0;
    if (idx == 1)
-      sock->SetCompressionLevel(1);
+      sock->SetCompressionLevel(4);
 
    TH1 *hpx;
    if (idx == 0) {

--- a/tutorials/tree/tcl.C
+++ b/tutorials/tree/tcl.C
@@ -35,7 +35,7 @@ void tclwrite(Int_t split)
 // Generate a Tree with a TClonesArray
 // The array can be split or not
    TFile f("tcl.root","recreate");
-   f.SetCompressionLevel(1); //try level 2 also
+   f.SetCompressionLevel(4); //try level 2 also
    TTree T("T","test tcl");
    TClonesArray *arr = new TClonesArray("TLine");
    TClonesArray &ar = *arr;


### PR DESCRIPTION
These changes are providing final transition to LZ4
```
oksana@oksana-ThinkPad-E470:~/CERN_sources/root/builds$ root tutorials/hsimple.root 
   --------------------------------------------------------------------
  | Welcome to ROOT 6.13/01                        http://root.cern.ch |
  |                                       (c) 1995-2017, The ROOT Team |
  | Built for linuxx8664gcc                                            |
  | From heads/master@v6-11-02-2061-gbdde402239, Mar 13 2018, 21:27:32 |
  | Try '.help', '.demo', '.license', '.credits', '.quit'/'.q'         |
   --------------------------------------------------------------------

root [0] 
Attaching file tutorials/hsimple.root as _file0...
(TFile *) 0x55cd127ea830
root [1] _file0->GetCompressionAlgorithm()
(int) 0
root [2] _file0->GetCompressionSettings()
(int) 4
root [3] _file0->GetCompressionLevel()
(int) 4
root [4]
```