### PR TITLE
TBufferMerger without separate thread, second take

### DIFF
--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -107,14 +107,14 @@ private:
    void Merge();
    void Push(TBufferFile *buffer);
 
-   size_t fAutoSave{0};                                          // AutoSave only every fAutoSave bytes
-   size_t fBuffered{0};                                          // Number of bytes currently buffered
-   TFileMerger fMerger{false, false};                            // TFileMerger used to merge all buffers
-   std::mutex fMergeMutex;                                       // Mutex used to lock fMerger
-   std::mutex fQueueMutex;                                       // Mutex used to lock fQueue
-   std::queue<TBufferFile *> fQueue;                             // Queue to which data is pushed and merged
-   std::vector<std::weak_ptr<TBufferMergerFile>> fAttachedFiles; // Attached files
-   std::function<void(void)> fCallback;                          // Callback for when data is removed from queue
+   size_t fAutoSave{0};                                          //< AutoSave only every fAutoSave bytes
+   size_t fBuffered{0};                                          //< Number of bytes currently buffered
+   TFileMerger fMerger{false, false};                            //< TFileMerger used to merge all buffers
+   std::mutex fMergeMutex;                                       //< Mutex used to lock fMerger
+   std::mutex fQueueMutex;                                       //< Mutex used to lock fQueue
+   std::queue<TBufferFile *> fQueue;                             //< Queue to which data is pushed and merged
+   std::vector<std::weak_ptr<TBufferMergerFile>> fAttachedFiles; //< Attached files
+   std::function<void(void)> fCallback;                          //< Callback for when data is removed from queue
 };
 
 /**

--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -15,12 +15,10 @@
 #include "TFileMerger.h"
 #include "TMemFile.h"
 
-#include <condition_variable>
 #include <functional>
 #include <memory>
 #include <mutex>
 #include <queue>
-#include <thread>
 
 namespace ROOT {
 namespace Experimental {
@@ -108,15 +106,13 @@ private:
 
    void Merge();
    void Push(TBufferFile *buffer);
-   void WriteOutputFile();
 
    size_t fAutoSave{0};                                          // AutoSave only every fAutoSave bytes
    size_t fBuffered{0};                                          // Number of bytes currently buffered
    TFileMerger fMerger{false, false};                            // TFileMerger used to merge all buffers
+   std::mutex fMergeMutex;                                       // Mutex used to lock fMerger
    std::mutex fQueueMutex;                                       // Mutex used to lock fQueue
-   std::condition_variable fDataAvailable;                       // Condition variable used to wait for data
    std::queue<TBufferFile *> fQueue;                             // Queue to which data is pushed and merged
-   std::unique_ptr<std::thread> fMergingThread;                  // Worker thread that writes to disk
    std::vector<std::weak_ptr<TBufferMergerFile>> fAttachedFiles; // Attached files
    std::function<void(void)> fCallback;                          // Callback for when data is removed from queue
 };

--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -102,7 +102,7 @@ private:
    /** TBufferMerger has no copy operator */
    TBufferMerger &operator=(const TBufferMerger &);
 
-   void Init(TFile*);
+   void Init(std::unique_ptr<TFile>);
 
    void Merge();
    void Push(TBufferFile *buffer);

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -16,6 +16,8 @@
 #include "TROOT.h"
 #include "TVirtualMutex.h"
 
+#include <utility>
+
 namespace ROOT {
 namespace Experimental {
 
@@ -24,20 +26,20 @@ TBufferMerger::TBufferMerger(const char *name, Option_t *option, Int_t compress)
    // We cannot chain constructors or use in-place initialization here because
    // instantiating a TBufferMerger should not alter gDirectory's state.
    TDirectory::TContext ctxt;
-   Init(TFile::Open(name, option, /* title */ name, compress));
+   Init(std::unique_ptr<TFile>(TFile::Open(name, option, /* title */ name, compress)));
 }
 
 TBufferMerger::TBufferMerger(std::unique_ptr<TFile> output)
 {
-   Init(output.release());
+   Init(std::move(output));
 }
 
-void TBufferMerger::Init(TFile *output)
+void TBufferMerger::Init(std::unique_ptr<TFile> output)
 {
    if (!output || !output->IsWritable() || output->IsZombie())
       Error("TBufferMerger", "cannot write to output file");
 
-   fMerger.OutputFile(std::unique_ptr<TFile>(output));
+   fMerger.OutputFile(std::move(output));
 }
 
 TBufferMerger::~TBufferMerger()

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -38,7 +38,6 @@ void TBufferMerger::Init(TFile *output)
       Error("TBufferMerger", "cannot write to output file");
 
    fMerger.OutputFile(std::unique_ptr<TFile>(output));
-   fMergingThread.reset(new std::thread([&]() { this->WriteOutputFile(); }));
 }
 
 TBufferMerger::~TBufferMerger()
@@ -46,8 +45,8 @@ TBufferMerger::~TBufferMerger()
    for (const auto &f : fAttachedFiles)
       if (!f.expired()) Fatal("TBufferMerger", " TBufferMergerFiles must be destroyed before the server");
 
-   this->Push(nullptr);
-   fMergingThread->join();
+   if (!fQueue.empty())
+      Merge();
 }
 
 std::shared_ptr<TBufferMergerFile> TBufferMerger::GetFile()
@@ -73,9 +72,12 @@ void TBufferMerger::Push(TBufferFile *buffer)
 {
    {
       std::lock_guard<std::mutex> lock(fQueueMutex);
+      fBuffered += buffer->BufferSize();
       fQueue.push(buffer);
    }
-   fDataAvailable.notify_one();
+
+   if (fBuffered > fAutoSave)
+      Merge();
 }
 
 size_t TBufferMerger::GetAutoSave() const
@@ -90,37 +92,27 @@ void TBufferMerger::SetAutoSave(size_t size)
 
 void TBufferMerger::Merge()
 {
-   fBuffered = 0;
-   fMerger.PartialMerge();
-   fMerger.Reset();
+   {
+      std::lock_guard<std::mutex> m(fMergeMutex);
+      {
+         std::lock_guard<std::mutex> q(fQueueMutex);
+
+         while (!fQueue.empty()) {
+            std::unique_ptr<TBufferFile> buffer{fQueue.front()};
+            fMerger.AddAdoptFile(
+               new TMemFile(fMerger.GetOutputFileName(), buffer->Buffer(), buffer->BufferSize(), "READ"));
+            fQueue.pop();
+         }
+
+         fBuffered = 0;
+      }
+
+      fMerger.PartialMerge();
+      fMerger.Reset();
+   }
 
    if (fCallback)
       fCallback();
-}
-
-void TBufferMerger::WriteOutputFile()
-{
-   std::unique_ptr<TBufferFile> buffer;
-
-   while (true) {
-      std::unique_lock<std::mutex> lock(fQueueMutex);
-      fDataAvailable.wait(lock, [this]() { return !this->fQueue.empty(); });
-
-      buffer.reset(fQueue.front());
-      fQueue.pop();
-      lock.unlock();
-
-      if (!buffer)
-         break;
-
-      fBuffered += buffer->BufferSize();
-      fMerger.AddAdoptFile(new TMemFile(fMerger.GetOutputFileName(), buffer->Buffer(), buffer->BufferSize(), "read"));
-
-      if (fBuffered > fAutoSave)
-         Merge();
-   }
-
-   Merge();
 }
 
 } // namespace Experimental

--- a/io/io/test/TBufferMerger.cxx
+++ b/io/io/test/TBufferMerger.cxx
@@ -341,12 +341,12 @@ TEST(TBufferMerger, RegisterCallbackTasks)
 
       TTaskGroup tg;
 
-      /* callback: launches new tasks when called */
+      /* callback: launch up to two new tasks when called */
       merger.RegisterCallback([&]() {
          int i = 0;
          while (launched < tasks && ++i <= 2) {
-            tg.Run(task);
             ++launched;
+            tg.Run(task);
          }
       });
 


### PR DESCRIPTION
This adds back commit ff557b3, but this time we release the merge lock before calling a registered callback. That way, if the callback itself triggers another Merge(), it does not deadlock.