### PR TITLE
[PyROOT] Add numpy array interface

### DIFF
--- a/bindings/pyroot/src/Pythonize.cxx
+++ b/bindings/pyroot/src/Pythonize.cxx
@@ -42,6 +42,10 @@
 #include "TStreamerElement.h"
 #include "TStreamerInfo.h"
 
+#include "TMatrix.h"
+#include "TVector.h"
+#include "ROOT/TVec.hxx"
+
 // Standard
 #include <stdexcept>
 #include <string>
@@ -2260,8 +2264,82 @@ namespace {
       return BindCppObject( addr, (Cppyy::TCppType_t)Cppyy::GetScope( "TObject" ), kFALSE );
    }
 
+   //- Adding array interface to classes ---------------
+   void AddArrayInterface(PyObject *pyclass, PyCFunction func)
+   {
+      Utility::AddToClass(pyclass, "_get__array_interface__", func, METH_NOARGS);
+      Utility::AddProperty(pyclass, "_get__array_interface__", "__array_interface__");
+   }
 
-//- simplistic len() functions -------------------------------------------------
+   PyObject *FillArrayInterfaceDict(UInt_t bytes, char type)
+   {
+      PyObject *dict = PyDict_New();
+      PyDict_SetItemString(dict, "version", PyLong_FromLong(3));
+#ifdef R__BYTESWAP
+      const char endianess = '<';
+#else
+      const char endianess = '>';
+#endif
+      PyDict_SetItemString(dict, "typestr",
+                           PyString_FromString(TString::Format("%c%c%i", endianess, type, bytes).Data()));
+      return dict;
+   }
+
+   template <typename dtype, UInt_t bytes, char typestr>
+   PyObject *TMatrixArrayInterface(ObjectProxy *self)
+   {
+      TMatrixT<dtype> *cobj = (TMatrixT<dtype> *)(self->GetObject());
+
+      PyObject *dict = FillArrayInterfaceDict(bytes, typestr);
+      PyDict_SetItemString(dict, "shape",
+                           PyTuple_Pack(2, PyLong_FromLong(cobj->GetNrows()), PyLong_FromLong(cobj->GetNcols())));
+      PyDict_SetItemString(dict, "data",
+                           PyTuple_Pack(2, PyLong_FromLong(reinterpret_cast<long>(cobj->GetMatrixArray())), Py_False));
+
+      return dict;
+   }
+
+   template <typename dtype, UInt_t bytes, char typestr>
+   PyObject *TVectorArrayInterface(ObjectProxy *self)
+   {
+      TVectorT<dtype> *cobj = (TVectorT<dtype> *)(self->GetObject());
+
+      PyObject *dict = FillArrayInterfaceDict(bytes, typestr);
+      PyDict_SetItemString(dict, "shape", PyTuple_Pack(1, PyLong_FromLong(cobj->GetNoElements())));
+      PyDict_SetItemString(dict, "data",
+                           PyTuple_Pack(2, PyLong_FromLong(reinterpret_cast<long>(cobj->GetMatrixArray())), Py_False));
+
+      return dict;
+   }
+
+   template <typename dtype, UInt_t bytes, char typestr>
+   PyObject *STLVectorArrayInterface(ObjectProxy *self)
+   {
+      std::vector<dtype> *cobj = (std::vector<dtype> *)(self->GetObject());
+
+      PyObject *dict = FillArrayInterfaceDict(bytes, typestr);
+      PyDict_SetItemString(dict, "shape", PyTuple_Pack(1, PyLong_FromLong(cobj->size())));
+      PyDict_SetItemString(dict, "data",
+                           PyTuple_Pack(2, PyLong_FromLong(reinterpret_cast<long>(cobj->data())), Py_False));
+
+      return dict;
+   }
+
+   template <typename dtype, UInt_t bytes, char typestr>
+   PyObject *TVecArrayInterface(ObjectProxy *self)
+   {
+      using ROOT::Experimental::VecOps::TVec;
+      TVec<dtype> *cobj = (TVec<dtype> *)(self->GetObject());
+
+      PyObject *dict = FillArrayInterfaceDict(bytes, typestr);
+      PyDict_SetItemString(dict, "shape", PyTuple_Pack(1, PyLong_FromLong(cobj->size())));
+      PyDict_SetItemString(dict, "data",
+                           PyTuple_Pack(2, PyLong_FromLong(reinterpret_cast<long>(cobj->data())), Py_False));
+
+      return dict;
+   }
+
+   //- simplistic len() functions -------------------------------------------------
    PyObject* ReturnThree( ObjectProxy*, PyObject* ) {
       return PyInt_FromLong( 3 );
    }
@@ -2465,6 +2543,21 @@ Bool_t PyROOT::Pythonize( PyObject* pyclass, const std::string& name )
          Utility::AddToClass( pyclass, "__setitem__", (PyCFunction) VectorBoolSetItem );
       }
 
+      // add array interface
+      if (name.find("<float>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)STLVectorArrayInterface<float, 4, 'f'>);
+      } else if (name.find("<double>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)STLVectorArrayInterface<double, 8, 'f'>);
+      } else if (name.find("<int>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)STLVectorArrayInterface<int, 4, 'i'>);
+      } else if (name.find("<unsigned int>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)STLVectorArrayInterface<unsigned int, 4, 'u'>);
+      } else if (name.find("<long>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)STLVectorArrayInterface<long, 8, 'i'>);
+      } else if (name.find("<unsigned long>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)STLVectorArrayInterface<unsigned long, 8, 'u'>);
+      }
+
    }
 
    else if ( IsTemplatedSTLClass( name, "map" ) ) {
@@ -2633,11 +2726,18 @@ Bool_t PyROOT::Pythonize( PyObject* pyclass, const std::string& name )
 
    }
 
-   else if ( name.substr(0,8) == "TVectorT" ) {  // allow proper iteration
+   else if (name.find("TVectorT") != std::string::npos) {
+      // allow proper iteration
       Utility::AddToClass( pyclass, "__len__", "GetNoElements" );
       Utility::AddToClass( pyclass, "_getitem__unchecked", "__getitem__" );
       Utility::AddToClass( pyclass, "__getitem__", (PyCFunction) CheckedGetItem, METH_O );
 
+      // add array interface
+      if (name.find("<float>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)TVectorArrayInterface<float, 4, 'f'>);
+      } else if (name.find("<double>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)TVectorArrayInterface<double, 8, 'f'>);
+      }
    }
 
    else if ( name.substr(0,6) == "TArray" && name != "TArray" ) {    // allow proper iteration
@@ -2653,9 +2753,34 @@ Bool_t PyROOT::Pythonize( PyObject* pyclass, const std::string& name )
    else if ( name == "RooSimultaneous" )
       Utility::AddUsingToClass( pyclass, "plotOn" );
 
+   else if (name.find("TMatrixT") != std::string::npos) {
+      // add array interface
+      if (name.find("<float>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)TMatrixArrayInterface<float, 4, 'f'>);
+      } else if (name.find("<double>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)TMatrixArrayInterface<double, 8, 'f'>);
+      }
+   }
 
-// TODO: store these on the pythonizations module, not on gRootModule
-// TODO: externalize this code and use update handlers on the python side
+   else if (name.find("TVec<") != std::string::npos) {
+      // add array interface
+      if (name.find("<float>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)TVecArrayInterface<float, 4, 'f'>);
+      } else if (name.find("<double>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)TVecArrayInterface<double, 8, 'f'>);
+      } else if (name.find("<int>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)TVecArrayInterface<int, 4, 'i'>);
+      } else if (name.find("<unsigned int>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)TVecArrayInterface<unsigned int, 4, 'u'>);
+      } else if (name.find("<long>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)TVecArrayInterface<long, 8, 'i'>);
+      } else if (name.find("<unsigned long>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)TVecArrayInterface<unsigned long, 8, 'u'>);
+      }
+   }
+
+   // TODO: store these on the pythonizations module, not on gRootModule
+   // TODO: externalize this code and use update handlers on the python side
    PyObject* userPythonizations = PyObject_GetAttrString( gRootModule, "UserPythonizations" );
    PyObject* pythonizationScope = PyObject_GetAttrString( gRootModule, "PythonizationScope" );
 

--- a/bindings/pyroot/src/Utility.cxx
+++ b/bindings/pyroot/src/Utility.cxx
@@ -255,6 +255,27 @@ Bool_t PyROOT::Utility::AddToClass( PyObject* pyclass, const char* label, PyCall
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Add the given function with name 'func' to the class as read-only property 'property'.
+
+Bool_t PyROOT::Utility::AddProperty(PyObject *pyclass, const char *func, const char *property)
+{
+   PyObject *builtin = PyImport_ImportModule("__builtin__");
+   PyObject *property_class = PyObject_GetAttrString(builtin, "property");
+   PyObject *func_obj = PyObject_GetAttrString(pyclass, func);
+   PyObject *arglist = Py_BuildValue("(O)", func_obj);
+   PyObject *property_obj = PyObject_CallObject(property_class, arglist);
+   PyObject_SetAttrString(pyclass, property, property_obj);
+
+   Py_DECREF(builtin);
+   Py_DECREF(property_class);
+   Py_DECREF(func_obj);
+   Py_DECREF(arglist);
+   Py_DECREF(property_obj);
+
+   return kTRUE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Helper to add base class methods to the derived class one (this covers the
 /// 'using' cases, which the dictionary does not provide).
 

--- a/bindings/pyroot/src/Utility.h
+++ b/bindings/pyroot/src/Utility.h
@@ -31,7 +31,10 @@ namespace PyROOT {
 
       Bool_t AddUsingToClass( PyObject* pyclass, const char* method );
 
-   // helpers for dynamically constructing binary operators
+      // helper to add properties to classes
+      Bool_t AddProperty(PyObject *pyclass, const char *func, const char *property);
+
+      // helpers for dynamically constructing binary operators
       Bool_t AddBinaryOperator( PyObject* left, PyObject* right,
          const char* op, const char* label, const char* alt_label = NULL );
       Bool_t AddBinaryOperator( PyObject* pyclass,

--- a/bindings/pyroot/test/CMakeLists.txt
+++ b/bindings/pyroot/test/CMakeLists.txt
@@ -1,2 +1,6 @@
-ROOT_ADD_PYUNITTESTS(pyroot)
+ROOT_ADD_PYUNITTEST(pyroot_conversions conversions.py)
+ROOT_ADD_PYUNITTEST(pyroot_list_initialization list_initialization.py)
+if(NUMPY_FOUND)
+    ROOT_ADD_PYUNITTEST(pyroot_array_interface array_interface.py)
+endif()
 

--- a/bindings/pyroot/test/array_interface.py
+++ b/bindings/pyroot/test/array_interface.py
@@ -1,0 +1,78 @@
+import unittest
+import ROOT
+import numpy as np
+
+
+class ArrayInterface(unittest.TestCase):
+    # Helpers
+    def get_maximum_for_dtype(self, dtype):
+        if np.issubdtype(dtype, np.integer):
+            return np.iinfo(dtype).max
+        if np.issubdtype(dtype, np.floating):
+            return np.finfo(dtype).max
+
+    def get_minimum_for_dtype(self, dtype):
+        if np.issubdtype(dtype, np.integer):
+            return np.iinfo(dtype).min
+        if np.issubdtype(dtype, np.floating):
+            return np.finfo(dtype).min
+
+    def check_memory_adoption_vector(self, root_obj, np_obj):
+        root_obj[0] = self.get_maximum_for_dtype(np_obj.dtype)
+        root_obj[1] = self.get_minimum_for_dtype(np_obj.dtype)
+        self.assertEqual(root_obj[0], np_obj[0])
+        self.assertEqual(root_obj[1], np_obj[1])
+
+    def check_memory_adoption_matrix(self, root_obj, np_obj):
+        root_obj[0][0] = self.get_maximum_for_dtype(np_obj.dtype)
+        root_obj[1][0] = self.get_minimum_for_dtype(np_obj.dtype)
+        self.assertEqual(root_obj[0][0], np_obj[0, 0])
+        self.assertEqual(root_obj[1][0], np_obj[1, 0])
+
+    def check_shape_vector(self, expected_shape, np_obj):
+        self.assertEqual(expected_shape, np_obj.shape)
+
+    def check_shape_matrix(self, expected_shape, np_obj):
+        self.assertEqual(expected_shape, np_obj.shape)
+
+    # TVector
+    def test_TVector(self):
+        for dtype in ["float", "double"]:
+            root_obj = ROOT.TVectorT(dtype)(2)
+            np_obj = np.asarray(root_obj)
+            self.check_memory_adoption_vector(root_obj, np_obj)
+            self.check_shape_vector((2, ), np_obj)
+
+    # TVec
+    def test_TVec(self):
+        for dtype in [
+                "int", "unsigned int", "long", "unsigned long", "float",
+                "double"
+        ]:
+            root_obj = ROOT.Experimental.VecOps.TVec(dtype)(2)
+            np_obj = np.asarray(root_obj)
+            self.check_memory_adoption_vector(root_obj, np_obj)
+            self.check_shape_vector((2, ), np_obj)
+
+    # STL vector
+    def test_STLVector(self):
+        for dtype in [
+                "int", "unsigned int", "long", "unsigned long", "float",
+                "double"
+        ]:
+            root_obj = ROOT.std.vector(dtype)(2)
+            np_obj = np.asarray(root_obj)
+            self.check_memory_adoption_vector(root_obj, np_obj)
+            self.check_shape_vector((2, ), np_obj)
+
+    # TMatrix
+    def test_TMatrix(self):
+        for dtype in ["float", "double"]:
+            root_obj = ROOT.TMatrixT(dtype)(2, 1)
+            np_obj = np.asarray(root_obj)
+            self.check_memory_adoption_matrix(root_obj, np_obj)
+            self.check_shape_matrix((2, 1), np_obj)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Added numpy array interface for
 - `TVec`
 - `TVector`
 - `TMatrix`
 - `std::vector`

and data types
 - `float`
 - `double`
- `int` (only `TVec` and `std::vector`)
- `long` (only `TVec` and `std::vector`)
- `unsigned int` (only `TVec` and `std::vector`)
- `unsigned long` (only `TVec` and `std::vector`)

WIP:
 - ~~Which classes to be added?~~
 - ~~Which data types?~~
 - ~~What about the `numpy` dependence of the unittest?~~ I asked for numpy to activate the test.
 - ~~Segfault for `TMatrixT("int")` and `TVectorT("int")`?~~ Not a problem of this PR.
 - ~~Check endianess during compile-time?~~ Checked for `R__BYTESWAP` with pre-compiler.
 - ~~What about histogram classes?~~ Not possible to maintain same return structure than `numpy.hist` solely by tweaking the array interface (that was the actual idea)
 - ~~What about the unsigned types?~~ Done for `std::vector` and `TVec`