### PR TITLE
Add deprecation messages in PQ2, old deamons and authentication tools

### DIFF
--- a/main/src/ssh2rpd.cxx
+++ b/main/src/ssh2rpd.cxx
@@ -13,6 +13,12 @@
 //                                                                      //
 // ssh2rpd                                                              //
 //                                                                      //
+//-------------------------- Nota Bene ---------------------------------//
+// The ssh2rpd tool is deprecated and not maintained any longer and     //
+// will be removed in ROOT v6.16/00. Please contact the ROOT team in    //
+// the unlikely event this change is disruptive for your workflow.      //
+//----------------------------------------------------------------------//
+//                                                                      //
 // Small program to communicate successful result of sshd auth to the   //
 // relevant rootd and proofd daemons                                    //
 //                                                                      //
@@ -58,6 +64,14 @@ void Info(const char *va_(fmt), ...)
 
 }
 
+void PrintDeprecation(bool withctx = true)
+{
+   if (withctx) printf(" \n");
+   printf(" NB: The ssh2rpd tool is deprecated and not maintained any longer and will be removed in ROOT v6.16/00\n");
+   printf("     Please contact the ROOT team in the unlikely event this change is disruptive for your workflow.\n");
+   if (withctx) printf(" \n");
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Small program to communicate successful result of sshd auth to the
 /// relevant root server daemons.
@@ -66,6 +80,8 @@ int main(int argc, char **argv)
 {
    char *pipeId = 0;
    char *tmpDir = 0;
+
+   PrintDeprecation();
 
    if (argc < 3) {
       Info("ssh2rpd: argc=%d"

--- a/man/man1/pq2-ana-dist.1
+++ b/man/man1/pq2-ana-dist.1
@@ -4,6 +4,13 @@
 .TH PQ2-ANA-DIST 1 "Version 5" "ROOT"
 .\" NAME should be all caps, SECTION should be 1-8, maybe w/ subsection
 .\" other parms are allowed: see man(7), man(1)
+.SH NOTA BENE
+.B The PQ2 tools are deprecated will be removed in ROOT v6.16/00.
+.PP
+Please contact the ROOT team at
+.UR http://root.cern.ch/
+.I http://root.cern.ch
+in the unlikely event this change is disruptive for your workflow.
 .SH NAME
 pq2-ana-dist \- Analyse the file distribution of a dataset (or a set of datasets) from a dataset meta-repository based on ROOT files
 .SH SYNOPSIS

--- a/man/man1/pq2-cache.1
+++ b/man/man1/pq2-cache.1
@@ -4,6 +4,13 @@
 .TH PQ2-CACHE 1 "Version 5" "ROOT"
 .\" NAME should be all caps, SECTION should be 1-8, maybe w/ subsection
 .\" other parms are allowed: see man(7), man(1)
+.SH NOTA BENE
+.B The PQ2 tools are deprecated and will be removed in ROOT v6.16/00.
+.PP
+Please contact the ROOT team at
+.UR http://root.cern.ch/
+.I http://root.cern.ch
+in the unlikely event this change is disruptive for your workflow.
 .SH NAME
 pq2-cache \- display or clear the local cache content of a remote dataset meta-repository based on ROOT files
 .SH SYNOPSIS

--- a/man/man1/pq2-info-server.1
+++ b/man/man1/pq2-info-server.1
@@ -4,6 +4,13 @@
 .TH PQ2-INFO-SERVER 1 "Version 5" "ROOT"
 .\" NAME should be all caps, SECTION should be 1-8, maybe w/ subsection
 .\" other parms are allowed: see man(7), man(1)
+.SH NOTA BENE
+.B The PQ2 tools are deprecated and will be removed in ROOT v6.16/00.
+.PP
+Please contact the ROOT team at
+.UR http://root.cern.ch/
+.I http://root.cern.ch
+in the unlikely event this change is disruptive for your workflow.
 .SH NAME
 pq2-info-server \- Display info about the datasets on a given server from a dataset meta-repository based on ROOT files
 .SH SYNOPSIS

--- a/man/man1/pq2-ls-files-server.1
+++ b/man/man1/pq2-ls-files-server.1
@@ -4,6 +4,13 @@
 .TH PQ2-LS-FILES-SERVER 1 "Version 5" "ROOT"
 .\" NAME should be all caps, SECTION should be 1-8, maybe w/ subsection
 .\" other parms are allowed: see man(7), man(1)
+.SH NOTA BENE
+.B The PQ2 tools are deprecated and will be removed in ROOT v6.16/00.
+.PP
+Please contact the ROOT team at
+.UR http://root.cern.ch/
+.I http://root.cern.ch
+in the unlikely event this change is disruptive for your workflow.
 .SH NAME
 pq2-ls-files-server \- List the file content of a dataset on a given server from a dataset meta-repository based on ROOT files
 .SH SYNOPSIS

--- a/man/man1/pq2-ls-files.1
+++ b/man/man1/pq2-ls-files.1
@@ -4,6 +4,13 @@
 .TH PQ2-LS-FILES 1 "Version 5" "ROOT"
 .\" NAME should be all caps, SECTION should be 1-8, maybe w/ subsection
 .\" other parms are allowed: see man(7), man(1)
+.SH NOTA BENE
+.B The PQ2 tools are deprecated and will be removed in ROOT v6.16/00.
+.PP
+Please contact the ROOT team at
+.UR http://root.cern.ch/
+.I http://root.cern.ch
+in the unlikely event this change is disruptive for your workflow.
 .SH NAME
 pq2-ls-files \- List the file content of a dataset from a dataset meta-repository based on ROOT files
 .SH SYNOPSIS

--- a/man/man1/pq2-ls.1
+++ b/man/man1/pq2-ls.1
@@ -4,6 +4,13 @@
 .TH PQ2-LS 1 "Version 5" "ROOT"
 .\" NAME should be all caps, SECTION should be 1-8, maybe w/ subsection
 .\" other parms are allowed: see man(7), man(1)
+.SH NOTA BENE
+.B The PQ2 tools are deprecated and will be removed in ROOT v6.16/00.
+.PP
+Please contact the ROOT team at
+.UR http://root.cern.ch/
+.I http://root.cern.ch
+in the unlikely event this change is disruptive for your workflow.
 .SH NAME
 pq2-ls \- List the available datasets in a dataset meta-repository based on ROOT files
 .SH SYNOPSIS

--- a/man/man1/pq2-put.1
+++ b/man/man1/pq2-put.1
@@ -4,6 +4,13 @@
 .TH PQ2-PUT 1 "Version 5" "ROOT"
 .\" NAME should be all caps, SECTION should be 1-8, maybe w/ subsection
 .\" other parms are allowed: see man(7), man(1)
+.SH NOTA BENE
+.B The PQ2 tools are deprecated and will be removed in ROOT v6.16/00.
+.PP
+Please contact the ROOT team at
+.UR http://root.cern.ch/
+.I http://root.cern.ch
+in the unlikely event this change is disruptive for your workflow.
 .SH NAME
 pq2-put \- Register one or more datasets in a dataset meta-repository based on ROOT files
 .SH SYNOPSIS

--- a/man/man1/pq2-redistribute.1
+++ b/man/man1/pq2-redistribute.1
@@ -4,6 +4,13 @@
 .TH PQ2-REDISTRIBUTE 1 "Version 5" "ROOT"
 .\" NAME should be all caps, SECTION should be 1-8, maybe w/ subsection
 .\" other parms are allowed: see man(7), man(1)
+.SH NOTA BENE
+.B The PQ2 tools are deprecated and will be removed in ROOT v6.16/00.
+.PP
+Please contact the ROOT team at
+.UR http://root.cern.ch/
+.I http://root.cern.ch
+in the unlikely event this change is disruptive for your workflow.
 .SH NAME
 pq2-redistribute \- Execute the file movements as determined by pq2-ana-dist
 .SH SYNOPSIS

--- a/man/man1/pq2-rm.1
+++ b/man/man1/pq2-rm.1
@@ -4,6 +4,13 @@
 .TH PQ2-RM 1 "Version 5" "ROOT"
 .\" NAME should be all caps, SECTION should be 1-8, maybe w/ subsection
 .\" other parms are allowed: see man(7), man(1)
+.SH NOTA BENE
+.B The PQ2 tools are deprecated and will be removed in ROOT v6.16/00.
+.PP
+Please contact the ROOT team at
+.UR http://root.cern.ch/
+.I http://root.cern.ch
+in the unlikely event this change is disruptive for your workflow.
 .SH NAME
 pq2-rm \- Remove one or more datasets from a dataset meta-repository based on ROOT files
 .SH SYNOPSIS

--- a/man/man1/pq2-verify.1
+++ b/man/man1/pq2-verify.1
@@ -4,6 +4,13 @@
 .TH PQ2-VERIFY 1 "Version 5" "ROOT"
 .\" NAME should be all caps, SECTION should be 1-8, maybe w/ subsection
 .\" other parms are allowed: see man(7), man(1)
+.SH NOTA BENE
+.B The PQ2 tools are deprecated and will be removed in ROOT v6.16/00.
+.PP
+Please contact the ROOT team at
+.UR http://root.cern.ch/
+.I http://root.cern.ch
+in the unlikely event this change is disruptive for your workflow.
 .SH NAME
 pq2-verify \- Extract the content one or more datasets from a dataset meta-repository based on ROOT files
 .SH SYNOPSIS

--- a/man/man1/pq2.1
+++ b/man/man1/pq2.1
@@ -4,6 +4,13 @@
 .TH PQ2 1 "Version 5" "ROOT"
 .\" NAME should be all caps, SECTION should be 1-8, maybe w/ subsection
 .\" other parms are allowed: see man(7), man(1)
+.SH NOTA BENE
+.B The PQ2 tools are deprecated and will be removed in ROOT v6.16/00.
+.PP
+Please contact the ROOT team at
+.UR http://root.cern.ch/
+.I http://root.cern.ch
+in the unlikely event this change is disruptive for your workflow.
 .SH NAME
 pq2 \- The command line interface to a dataset meta-repository based on ROOT files
 .SH SYNOPSIS

--- a/man/man1/proofd.1
+++ b/man/man1/proofd.1
@@ -4,6 +4,13 @@
 .TH PROOFD 1 "Version 3" "ROOT"
 .\" NAME should be all caps, SECTION should be 1-8, maybe w/ subsection
 .\" other parms are allowed: see man(7), man(1)
+.SH NOTA BENE
+.B The proofd daemon is deprecated and will be removed in ROOT v6.16/00.
+.PP
+Please contact the ROOT team at
+.UR http://root.cern.ch/
+.I http://root.cern.ch
+in the unlikely event this change is disruptive for your workflow.
 .SH NAME
 proofd \- PROOF (The Parallel ROOT Facility)
 

--- a/man/man1/rootd.1
+++ b/man/man1/rootd.1
@@ -4,6 +4,13 @@
 .TH ROOTD 1 "Version 4" "ROOT"
 .\" NAME should be all caps, SECTION should be 1-8, maybe w/ subsection
 .\" other parms are allowed: see man(7), man(1)
+.SH NOTA BENE
+.B The rootd daemon deprecated and will be removed in ROOT v6.16/00.
+.PP
+Please contact the ROOT team at
+.UR http://root.cern.ch/
+.I http://root.cern.ch
+in the unlikely event this change is disruptive for your workflow.
 .SH NAME
 rootd \- The ROOT file server daemon
 .SH SYNOPSIS

--- a/man/man1/setup-pq2.1
+++ b/man/man1/setup-pq2.1
@@ -4,6 +4,13 @@
 .TH SETUP-PQ2 1 "Version 5" "ROOT"
 .\" NAME should be all caps, SECTION should be 1-8, maybe w/ subsection
 .\" other parms are allowed: see man(7), man(1)
+.SH NOTA BENE
+.B The PQ2 tools are deprecated and will be removed in ROOT v6.16/00.
+.PP
+Please contact the ROOT team at
+.UR http://root.cern.ch/
+.I http://root.cern.ch
+in the unlikely event this change is disruptive for your workflow.
 .SH NAME
 setup-pq2 \- Script defining the environment for the PQ2 tools
 .SH SYNOPSIS

--- a/man/man1/ssh2rpd.1
+++ b/man/man1/ssh2rpd.1
@@ -4,6 +4,13 @@
 .TH SSH2RPD 1 "Version 3" "ROOT"
 .\" NAME should be all caps, SECTION should be 1-8, maybe w/ subsection
 .\" other parms are allowed: see man(7), man(1)
+.SH NOTA BENE
+.B The ssh2rpd utility is deprecated and will be removed in ROOT v6.16/00.
+.PP
+Please contact the ROOT team at
+.UR http://root.cern.ch/
+.I http://root.cern.ch
+in the unlikely event this change is disruptive for your workflow.
 .SH NAME
 ssh2rpd \- ROOT utility to help in authentication
 .SH SYNOPSIS

--- a/man/man1/system.rootdaemonrc.1
+++ b/man/man1/system.rootdaemonrc.1
@@ -4,6 +4,13 @@
 .TH SYSTEM.ROOTDAEMONRC 1 "Version 4" "ROOT"
 .\" NAME should be all caps, SECTION should be 1-8, maybe w/ subsection
 .\" other parms are allowed: see man(7), man(1)
+.SH NOTA BENE
+.B Usage of this file is deprecated and will be removed in future versions of ROOT.
+.PP
+Please contact the ROOT team at
+.UR http://root.cern.ch/
+.I http://root.cern.ch
+in the unlikely event this change is disruptive for your workflow.
 .SH NAME
 system.rootdaemonrc, .rootdaemonrc \- access control directives for ROOT daemons
 .SH LOCATIONS

--- a/net/rootd/src/rootd.cxx
+++ b/net/rootd/src/rootd.cxx
@@ -14,6 +14,13 @@
 // Rootd                                                                //
 //                                                                      //
 // Root remote file server daemon.                                      //
+//                                                                      //
+//-------------------------- Nota Bene ---------------------------------//
+// The rootd daemon is deprecated and not maintained any longer and     //
+// will be removed in ROOT v6.16/00. Please contact the ROOT team in    //
+// the unlikely event this change is disruptive for your workflow.      //
+//----------------------------------------------------------------------//
+//                                                                      //
 // This small server is started either by inetd when a client requests  //
 // a connection to a rootd server or by hand (i.e. from the command     //
 // line). The rootd server works with the ROOT TNetFile class. It       //
@@ -2333,6 +2340,14 @@ void Usage(const char* name, int rc)
    exit(rc);
 }
 
+void PrintDeprecation(bool withctx = true)
+{
+   if (withctx) printf(" \n");
+   printf(" NB: The rootd daemon is deprecated and not maintained any longer and will be removed in ROOT v6.16/00\n");
+   printf("     Please contact the ROOT team in the unlikely event this change is disruptive for your workflow.\n");
+   if (withctx) printf(" \n");
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 int main(int argc, char **argv)
@@ -2371,6 +2386,8 @@ int main(int argc, char **argv)
 
    // Output to syslog ...
    RpdSetSysLogFlag(1);
+
+   PrintDeprecation();
 
    // ... unless we are running in the foreground and we are
    // attached to terminal; make also sure that "-i" and "-f"

--- a/proof/pq2/src/pq2main.cxx
+++ b/proof/pq2/src/pq2main.cxx
@@ -39,6 +39,15 @@ TString ferr;
 TString fres;
 Int_t gverbose = 0;
 
+void PrintDeprecation(bool withctx = true)
+{
+   if (withctx) printf(" \n");
+   printf(" NB: The PQ2 tools are deprecated and not maintained any longer and will be removed in ROOT v6.16/00\n");
+   printf("     Please contact the ROOT team in the unlikely event this change is disruptive for your workflow.\n");
+   if (withctx) printf(" \n");
+}
+
+
 //_____________________________batch only_____________________
 int main(int argc, char **argv)
 {
@@ -74,8 +83,12 @@ int main(int argc, char **argv)
       printf("   serviceurl    entry point of the service to be used to get the information (PROOF master\n");
       printf("                 or data server) in the form '[user@]host.domain[:port]'\n");
       printf(" \n");
+      PrintDeprecation(false);
+      printf(" \n");
       gSystem->Exit(0);
    }
+
+   PrintDeprecation();
 
    // Parse options
    const char *action = 0;
@@ -346,6 +359,8 @@ int main(int argc, char **argv)
       if (!gSystem->AccessPathName(flog)) Printf(" -> %s", flog.Data());
       if (!gSystem->AccessPathName(fres)) Printf(" -> %s", fres.Data());
    }
+
+   PrintDeprecation();
 
    gSystem->Exit(rc);
 }

--- a/proof/proofd/src/proofd.cxx
+++ b/proof/proofd/src/proofd.cxx
@@ -14,6 +14,13 @@
 // Proofd                                                               //
 //                                                                      //
 // PROOF, Parallel ROOT Facility, front-end daemon.                     //
+//                                                                      //
+//-------------------------- Nota Bene ---------------------------------//
+// The proofd daemon is deprecated and not maintained any longer and    //
+// will be removed in ROOT v6.16/00. Please contact the ROOT team in    //
+// the unlikely event this change is disruptive for your workflow.      //
+//----------------------------------------------------------------------//
+//                                                                      //
 // This small server is started either by inetd when a client requests  //
 // a connection to a PROOF server or by hand (i.e. from the command     //
 // line). By default proofd uses port 1093 (allocated by IANA,          //
@@ -781,6 +788,14 @@ void Usage(const char* name, int rc)
    exit(rc);
 }
 
+void PrintDeprecation(bool withctx = true)
+{
+   if (withctx) printf(" \n");
+   printf(" NB: The proofd daemon is deprecated and not maintained any longer and will be removed in ROOT v6.16/00\n");
+   printf("     Please contact the ROOT team in the unlikely event this change is disruptive for your workflow.\n");
+   if (withctx) printf(" \n");
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 int main(int argc, char **argv)
@@ -810,6 +825,8 @@ int main(int argc, char **argv)
 
    // Output to syslog ...
    RpdSetSysLogFlag(1);
+
+   PrintDeprecation();
 
    // ... unless we are running in the foreground and we are
    // attached to terminal; make also sure that "-i" and "-f"


### PR DESCRIPTION
This patch adds deprecation messages in the pq2 steering main, in rootd, proofd, ssh2rpd, and in all related man pages. Part of the agreed deprecation campaign.  