### PR TITLE
Don't make a full list when we just want its size

### DIFF
--- a/core/meta/inc/TListOfFunctions.h
+++ b/core/meta/inc/TListOfFunctions.h
@@ -95,6 +95,8 @@ public:
    TObject   *Remove(TObject *obj);
    TObject   *Remove(TObjLink *lnk);
 
+   int Size();
+
    void Load();
    void Unload();
    void Unload(TFunction *func);

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -4386,11 +4386,7 @@ Int_t TClass::GetNmethods()
 {
    if (!HasInterpreterInfo()) return 0;
 
-   TList *lm = GetListOfMethods();
-   if (lm)
-      return lm->GetSize();
-   else
-      return 0;
+   return (*fMethod).Size();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/meta/src/TListOfFunctions.cxx
+++ b/core/meta/src/TListOfFunctions.cxx
@@ -401,6 +401,32 @@ void TListOfFunctions::Load()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Get a size of class
+
+int TListOfFunctions::Size()
+{
+   if (fClass && fClass->GetClassInfo() == 0) return 0;
+
+   R__LOCKGUARD(gInterpreterMutex);
+
+   ULong64_t currentTransaction = gInterpreter->GetInterpreterStateMarker();
+   if (currentTransaction == fLastLoadMarker) return 0;
+   fLastLoadMarker = currentTransaction;
+
+   ClassInfo_t *info;
+   if (fClass) info = fClass->GetClassInfo();
+   else info = gInterpreter->ClassInfo_Factory();
+
+   int res = 0;
+   MethodInfo_t *t = gInterpreter->MethodInfo_Factory(info);
+   while (gInterpreter->MethodInfo_Next(t)) res++;
+   gInterpreter->MethodInfo_Delete(t);
+
+   if (!fClass) gInterpreter->ClassInfo_Delete(info);
+   return res;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Mark 'all func' as being unloaded.
 /// After the unload, the function can no longer be found directly,
 /// until the decl can be found again in the interpreter (in which


### PR DESCRIPTION
Add Size() interface to TListOfFunctions and call this from GetNmethods,
so that we don't have to allocate memory for this.

Profiled the peak meory performance in valgrind
total(B) 
master: 427,544,680
HEAD: 427,542,328