### PR TITLE
ROOT-9316: reuse branch proxies for TTreeReader{Value,Array} when they are attached to the same branch.

### DIFF
--- a/tree/treeplayer/inc/TTreeReaderUtils.h
+++ b/tree/treeplayer/inc/TTreeReaderUtils.h
@@ -38,13 +38,13 @@ namespace Internal {
    class TBranchProxyDirector;
    class TTreeReaderArrayBase;
 
-   class TNamedBranchProxy: public TObject {
+   class TNamedBranchProxy {
    public:
       TNamedBranchProxy(): fDict(0), fContentDict(0) {}
-      TNamedBranchProxy(TBranchProxyDirector* boss, TBranch* branch, const char* membername):
-         fProxy(boss, branch, membername), fDict(0), fContentDict(0) {}
+      TNamedBranchProxy(TBranchProxyDirector* boss, TBranch* branch, const char* fullname, const char* membername):
+         fProxy(boss, branch, membername), fDict(0), fContentDict(0), fFullName(fullname) {}
 
-      const char* GetName() const { return fProxy.GetBranchName(); }
+      const char* GetName() const { return fFullName.c_str(); }
       const Detail::TBranchProxy* GetProxy() const { return &fProxy; }
       Detail::TBranchProxy* GetProxy() { return &fProxy; }
       TDictionary* GetDict() const { return fDict; }
@@ -54,9 +54,9 @@ namespace Internal {
 
    private:
       Detail::TBranchProxy fProxy;
-      TDictionary*       fDict;
-      TDictionary*       fContentDict; // type of content, if a collection
-      ClassDef(TNamedBranchProxy, 0); // branch proxy with a name
+      TDictionary*         fDict;
+      TDictionary*         fContentDict; // type of content, if a collection
+      std::string          fFullName;
    };
 
    // Used by TTreeReaderArray

--- a/tree/treeplayer/src/TTreeReader.cxx
+++ b/tree/treeplayer/src/TTreeReader.cxx
@@ -206,7 +206,6 @@ TTreeReader::~TTreeReader()
       (*i)->MarkTreeReaderUnavailable();
    }
    delete fDirector;
-   fProxies.SetOwner();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/src/TTreeReaderArray.cxx
+++ b/tree/treeplayer/src/TTreeReaderArray.cxx
@@ -404,8 +404,8 @@ void ROOT::Internal::TTreeReaderArrayBase::CreateProxy()
             membername = branch->GetName();
          }
       }
-      namedProxy = new TNamedBranchProxy(fTreeReader->fDirector, branch, membername);
-      fTreeReader->GetProxies()->Add(namedProxy);
+      namedProxy = new TNamedBranchProxy(fTreeReader->fDirector, branch, fBranchName, membername);
+      fTreeReader->AddProxy(namedProxy);
       fProxy = namedProxy->GetProxy();
       if (fProxy)
          fSetupStatus = kSetupMatch;


### PR DESCRIPTION
TNamedBranchProxy did not implement a Hash method.
Therefore when adding TNamedBranchProxy instances to the THashList dedicated to their bookkeping in TTreeReader TObject::Hash was used.
Unfortunately when trying to find the TNamedBranchProxies, their name was used and the hash was built differently by THashList (based on the name).
In order to fix this the following steps were taken.
- THashList was replaced by an unordered_map with names as keys and unique_ptr<TNamedBranchProxy> as values. The unique_ptr is used to automatically manage ownership.
- The methods of TTreeReader were adapted to use this new container as well as the code in TTreeReaderValue and TTreeReaderArray

A real usecase from CMS where the mass of the W boson is studied shows a significant speedup (30%).
The code uses TDataFrame and several nodes are created which read from the same branch in an input tree which holds weights in a collection.
This configuration stressed the performance degradation pattern fixed by this commit as it triggered multiple times the deserialisation of the "weights branch".

Thanks to Elisabetta Manca and Lorenzo Bianchini for providing the bug report and initial reproducer.

These changes will need to be backported at least to ROOT 6.12
