### PR TITLE
add kDoNotDisconnect support to TFilePrefetch

### DIFF
--- a/io/io/inc/TFilePrefetch.h
+++ b/io/io/inc/TFilePrefetch.h
@@ -74,7 +74,7 @@ public:
    Bool_t    BinarySearchReadList(TFPBlock*, Long64_t, Int_t, Int_t*);
    Long64_t  GetWaitTime();
 
-   void      SetFile(TFile*);
+   void      SetFile(TFile* file, TFile::ECacheAction action = TFile::kDisconnect);
    std::condition_variable &GetCondNewBlock() { return fNewBlockAdded; };
    void      WaitFinishPrefetch();
    Bool_t    IsPrefetchFinished() const { return fPrefetchFinished; }

--- a/io/io/src/TFileCacheRead.cxx
+++ b/io/io/src/TFileCacheRead.cxx
@@ -560,7 +560,7 @@ void TFileCacheRead::SetFile(TFile *file, TFile::ECacheAction action)
    if (fPrefetch) {
       if (action == TFile::kDisconnect)
          SecondPrefetch(0, 0);
-      fPrefetch->SetFile(file);
+      fPrefetch->SetFile(file, action);
    }
 }
 

--- a/io/io/src/TFilePrefetch.cxx
+++ b/io/io/src/TFilePrefetch.cxx
@@ -20,6 +20,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cctype>
+#include <cassert>
 
 static const int kMAX_READ_SIZE    = 2;   //maximum size of the read list of blocks
 
@@ -311,26 +312,31 @@ TThread* TFilePrefetch::GetThread() const
 ///  - clear all blocks from prefetching and read list
 ///  - reset the file pointer
 
-void TFilePrefetch::SetFile(TFile *file)
+void TFilePrefetch::SetFile(TFile *file, TFile::ECacheAction action)
 {
-   if (!fThreadJoined) {
-     fSemChangeFile->Wait();
-   }
+   if (action == TFile::kDisconnect) {
+      if (!fThreadJoined) {
+        fSemChangeFile->Wait();
+      }
 
-   if (fFile) {
-     // Remove all pending and read blocks
-     fMutexPendingList.lock();
-     fPendingBlocks->Clear();
-     fMutexPendingList.unlock();
+      if (fFile) {
+        // Remove all pending and read blocks
+        fMutexPendingList.lock();
+        fPendingBlocks->Clear();
+        fMutexPendingList.unlock();
 
-     fMutexReadList.lock();
-     fReadBlocks->Clear();
-     fMutexReadList.unlock();
-   }
+        fMutexReadList.lock();
+        fReadBlocks->Clear();
+        fMutexReadList.unlock();
+      }
 
-   fFile = file;
-   if (!fThreadJoined) {
-     fSemChangeFile->Post();
+      fFile = file;
+      if (!fThreadJoined) {
+        fSemChangeFile->Post();
+      }
+   } else {
+      // kDoNotDisconnect must reconnect to the same file
+      assert((fFile == file) && "kDoNotDisconnect must reattach to the same file");
    }
 }
 


### PR DESCRIPTION
This PR propagates the disconnect action from TFileCacheRead to TFilePrefetch.  This is needed to restore TFilePrefetch compatibility with the CMS use of kDoNotDisconnect to swap TTreeCaches.  CMS frequently swaps TTree caches with code like

     filePtr_->SetCacheRead(cache, nullptr , TFile::kDoNotDisconnect);
     branch->GetEntry(entryNumber);
     filePtr_->SetCacheRead(nullptr, nullptr , TFile::kDoNotDisconnect);

This is done partially for ownership reasons and partially because CMS uses multiple TTreeCaches for different use cases (one cache for frequently read branches, a second for less frequently accessed branches, and potentially one or two more specialized use cases).  kDoNotDisconnect tells the TFile that this cache may later be reconnected to the TFile, so it should not disconnect the cache from the file.  TFile propagates the flag to TFileCacheRead, but TFileCacheRead does not propagate it to TFilePrefetch.  If pre-fetching is enabled, TFilePrefetch clears its cached blocks due to this commit:

https://github.com/root-project/root/commit/4290bf4942285b754b2edb7bffd122bcf36c979d

which added clearing of the read and pending prefetch lists when SetFile() is called.  This violates the assumptions made by TTreeCache in the kDoNotDisconnect case, leading to a deadlock where `TTreeCache::ReadBufferPrefetch` waits forever on a buffer that has been cleared from the prefetched and pending lists.  This patch propagates the kDisconnect/kDoNotDisconnect  action flag to `TFilePrefetch::SetFile`, only clearing the fetched and pending lists in the kDisconnect case.

(The same end could be accomplished more simply by just not calling TFilePrefetch::SetFile() for the kDoNotDisconnect case; propagating the action seems more correct to me, but it is a matter of taste.)