### PR TITLE
[TDF] Backport variable bins fix to v6.12

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFHistoModels.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFHistoModels.hxx
@@ -39,6 +39,7 @@ struct TH1DModel {
    TH1DModel(const char *name, const char *title, int nbinsx, double xlow, double xup);
    TH1DModel(const char *name, const char *title, int nbinsx, const float *xbins);
    TH1DModel(const char *name, const char *title, int nbinsx, const double *xbins);
+   std::shared_ptr<::TH1D> GetHistogram() const;
 };
 
 struct TH2DModel {
@@ -63,6 +64,7 @@ struct TH2DModel {
    TH2DModel(const char *name, const char *title, int nbinsx, double xlow, double xup, int nbinsy, const double *ybins);
    TH2DModel(const char *name, const char *title, int nbinsx, const double *xbins, int nbinsy, const double *ybins);
    TH2DModel(const char *name, const char *title, int nbinsx, const float *xbins, int nbinsy, const float *ybins);
+   std::shared_ptr<::TH2D> GetHistogram() const;
 };
 
 struct TH3DModel {
@@ -91,6 +93,7 @@ struct TH3DModel {
              int nbinsz, const float *zbins);
    TH3DModel(const char *name, const char *title, int nbinsx, const double *xbins, int nbinsy, const double *ybins,
              int nbinsz, const double *zbins);
+   std::shared_ptr<::TH3D> GetHistogram() const;
 };
 
 struct TProfile1DModel {
@@ -115,6 +118,7 @@ struct TProfile1DModel {
    TProfile1DModel(const char *name, const char *title, int nbinsx, const double *xbins, const char *option = "");
    TProfile1DModel(const char *name, const char *title, int nbinsx, const double *xbins, double ylow, double yup,
                    const char *option = "");
+   std::shared_ptr<::TProfile> GetProfile() const;
 };
 
 struct TProfile2DModel {
@@ -146,6 +150,7 @@ struct TProfile2DModel {
                    const double *ybins, const char *option = "");
    TProfile2DModel(const char *name, const char *title, int nbinsx, const double *xbins, int nbinsy,
                    const double *ybins, const char *option = "");
+   std::shared_ptr<::TProfile2D> GetProfile() const;
 };
 
 } // ns TDF

--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -963,11 +963,7 @@ public:
       std::shared_ptr<::TH1D> h(nullptr);
       {
          ROOT::Internal::TDF::TIgnoreErrorLevelRAII iel(kError);
-         if (model.fBinXEdges.empty()) {
-            h = std::make_shared<::TH1D>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp);
-         } else {
-            h = std::make_shared<::TH1D>(model.fName, model.fTitle, model.fNbinsX, model.fBinXEdges.data());
-         }
+         h = model.GetHistogram();
       }
 
       if (h->GetXaxis()->GetXmax() == h->GetXaxis()->GetXmin())
@@ -1000,11 +996,7 @@ public:
       std::shared_ptr<::TH1D> h(nullptr);
       {
          ROOT::Internal::TDF::TIgnoreErrorLevelRAII iel(kError);
-         if (model.fBinXEdges.empty()) {
-            h = std::make_shared<::TH1D>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp);
-         } else {
-            h = std::make_shared<::TH1D>(model.fName, model.fTitle, model.fNbinsX, model.fBinXEdges.data());
-         }
+         h = model.GetHistogram();
       }
       return CreateAction<TDFInternal::ActionTypes::Histo1D, V, W>(userColumns, h);
    }
@@ -1059,16 +1051,7 @@ public:
       std::shared_ptr<::TH2D> h(nullptr);
       {
          ROOT::Internal::TDF::TIgnoreErrorLevelRAII iel(kError);
-         if (model.fBinXEdges.empty() && model.fBinYEdges.empty()) {
-            h = std::make_shared<::TH2D>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp,
-                                         model.fNbinsY, model.fYLow, model.fYUp);
-         } else if (!model.fBinXEdges.empty() && model.fBinYEdges.empty()) {
-            h = std::make_shared<::TH2D>(model.fName, model.fTitle, model.fNbinsX, model.fBinXEdges.data(),
-                                         model.fNbinsY, model.fYLow, model.fYUp);
-         } else {
-            h = std::make_shared<::TH2D>(model.fName, model.fTitle, model.fNbinsX, model.fBinXEdges.data(),
-                                         model.fNbinsY, model.fBinYEdges.data());
-         }
+         h = model.GetHistogram();
       }
       if (!TDFInternal::HistoUtils<::TH2D>::HasAxisLimits(*h)) {
          throw std::runtime_error("2D histograms with no axes limits are not supported yet.");
@@ -1101,16 +1084,7 @@ public:
       std::shared_ptr<::TH2D> h(nullptr);
       {
          ROOT::Internal::TDF::TIgnoreErrorLevelRAII iel(kError);
-         if (model.fBinXEdges.empty() && model.fBinYEdges.empty()) {
-            h = std::make_shared<::TH2D>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp,
-                                         model.fNbinsY, model.fYLow, model.fYUp);
-         } else if (!model.fBinXEdges.empty() && model.fBinYEdges.empty()) {
-            h = std::make_shared<::TH2D>(model.fName, model.fTitle, model.fNbinsX, model.fBinXEdges.data(),
-                                         model.fNbinsY, model.fYLow, model.fYUp);
-         } else {
-            h = std::make_shared<::TH2D>(model.fName, model.fTitle, model.fNbinsX, model.fBinXEdges.data(),
-                                         model.fNbinsY, model.fBinYEdges.data());
-         }
+         h = model.GetHistogram();
       }
       if (!TDFInternal::HistoUtils<::TH2D>::HasAxisLimits(*h)) {
          throw std::runtime_error("2D histograms with no axes limits are not supported yet.");
@@ -1149,15 +1123,7 @@ public:
       std::shared_ptr<::TH3D> h(nullptr);
       {
          ROOT::Internal::TDF::TIgnoreErrorLevelRAII iel(kError);
-         if (model.fBinXEdges.empty() && model.fBinYEdges.empty() && model.fBinZEdges.empty()) {
-            h =
-               std::make_shared<::TH3D>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp,
-                                        model.fNbinsY, model.fYLow, model.fYUp, model.fNbinsZ, model.fZLow, model.fZUp);
-         } else {
-            h =
-               std::make_shared<::TH3D>(model.fName, model.fTitle, model.fNbinsX, model.fBinXEdges.data(),
-                                        model.fNbinsY, model.fBinYEdges.data(), model.fNbinsZ, model.fBinZEdges.data());
-         }
+         h = model.GetHistogram();
       }
       if (!TDFInternal::HistoUtils<::TH3D>::HasAxisLimits(*h)) {
          throw std::runtime_error("3D histograms with no axes limits are not supported yet.");
@@ -1192,15 +1158,7 @@ public:
       std::shared_ptr<::TH3D> h(nullptr);
       {
          ROOT::Internal::TDF::TIgnoreErrorLevelRAII iel(kError);
-         if (model.fBinXEdges.empty() && model.fBinYEdges.empty() && model.fBinZEdges.empty()) {
-            h =
-               std::make_shared<::TH3D>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp,
-                                        model.fNbinsY, model.fYLow, model.fYUp, model.fNbinsZ, model.fZLow, model.fZUp);
-         } else {
-            h =
-               std::make_shared<::TH3D>(model.fName, model.fTitle, model.fNbinsX, model.fBinXEdges.data(),
-                                        model.fNbinsY, model.fBinYEdges.data(), model.fNbinsZ, model.fBinZEdges.data());
-         }
+         h = model.GetHistogram();
       }
       if (!TDFInternal::HistoUtils<::TH3D>::HasAxisLimits(*h)) {
          throw std::runtime_error("3D histograms with no axes limits are not supported yet.");
@@ -1236,8 +1194,7 @@ public:
       std::shared_ptr<::TProfile> h(nullptr);
       {
          ROOT::Internal::TDF::TIgnoreErrorLevelRAII iel(kError);
-         h = std::make_shared<::TProfile>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp,
-                                          model.fYLow, model.fYUp, model.fOption);
+         h = model.GetProfile();
       }
 
       if (!TDFInternal::HistoUtils<::TProfile>::HasAxisLimits(*h)) {
@@ -1271,8 +1228,7 @@ public:
       std::shared_ptr<::TProfile> h(nullptr);
       {
          ROOT::Internal::TDF::TIgnoreErrorLevelRAII iel(kError);
-         h = std::make_shared<::TProfile>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp,
-                                          model.fYLow, model.fYUp, model.fOption);
+         h = model.GetProfile();
       }
 
       if (!TDFInternal::HistoUtils<::TProfile>::HasAxisLimits(*h)) {
@@ -1312,9 +1268,7 @@ public:
       std::shared_ptr<::TProfile2D> h(nullptr);
       {
          ROOT::Internal::TDF::TIgnoreErrorLevelRAII iel(kError);
-         h = std::make_shared<::TProfile2D>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp,
-                                            model.fNbinsY, model.fYLow, model.fYUp, model.fZLow, model.fZUp,
-                                            model.fOption);
+         h = model.GetProfile();
       }
 
       if (!TDFInternal::HistoUtils<::TProfile2D>::HasAxisLimits(*h)) {
@@ -1350,9 +1304,7 @@ public:
       std::shared_ptr<::TProfile2D> h(nullptr);
       {
          ROOT::Internal::TDF::TIgnoreErrorLevelRAII iel(kError);
-         h = std::make_shared<::TProfile2D>(model.fName, model.fTitle, model.fNbinsX, model.fXLow, model.fXUp,
-                                            model.fNbinsY, model.fYLow, model.fYUp, model.fZLow, model.fZUp,
-                                            model.fOption);
+         h = model.GetProfile();
       }
 
       if (!TDFInternal::HistoUtils<::TProfile2D>::HasAxisLimits(*h)) {

--- a/tree/treeplayer/src/TDFHistoModels.cxx
+++ b/tree/treeplayer/src/TDFHistoModels.cxx
@@ -39,14 +39,44 @@
 * \brief A struct which stores the parameters of a TProfile2D
 */
 
+template <typename T>
+inline void FillVector(std::vector<double> &v, int size, T *a)
+{
+   v.reserve(size);
+   for (auto i : ROOT::TSeq<int>(size + 1))
+      v.push_back(a[i]);
+}
+
+template <>
+inline void FillVector<double>(std::vector<double> &v, int size, double *a)
+{
+   v.assign(a, a + (size_t)(size + 1));
+}
+
+inline void SetAxisProperties(const TAxis *axis, double &low, double &up, std::vector<double> &edges)
+{
+   // Check if this histo has fixed binning
+   // Same technique of "Int_t TAxis::FindBin(Double_t)"
+   if (!axis->GetXbins()->fN) {
+      low = axis->GetXmin();
+      up = axis->GetXmax();
+   } else {
+      // This histo has variable binning
+      const auto size = axis->GetNbins() + 1;
+      edges.reserve(size);
+      for (auto i : ROOT::TSeq<int>(1, size))
+         edges.push_back(axis->GetBinLowEdge(i));
+      edges.push_back(axis->GetBinUpEdge(size - 1));
+   }
+}
+
 namespace ROOT {
 namespace Experimental {
 namespace TDF {
 
-TH1DModel::TH1DModel(const ::TH1D &h)
-   : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX()), fXLow(h.GetXaxis()->GetXmin()),
-     fXUp(h.GetXaxis()->GetXmax())
+TH1DModel::TH1DModel(const ::TH1D &h) : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX())
 {
+   SetAxisProperties(h.GetXaxis(), fXLow, fXUp, fBinXEdges);
 }
 TH1DModel::TH1DModel(const char *name, const char *title, int nbinsx, double xlow, double xup)
    : fName(name), fTitle(title), fNbinsX(nbinsx), fXLow(xlow), fXUp(xup)
@@ -55,24 +85,30 @@ TH1DModel::TH1DModel(const char *name, const char *title, int nbinsx, double xlo
 TH1DModel::TH1DModel(const char *name, const char *title, int nbinsx, const float *xbins)
    : fName(name), fTitle(title), fNbinsX(nbinsx)
 {
-   fBinXEdges.reserve(nbinsx);
-   for (auto i : ROOT::TSeq<int>(nbinsx))
-      fBinXEdges.push_back(xbins[i]);
+   FillVector(fBinXEdges, nbinsx, xbins);
 }
 TH1DModel::TH1DModel(const char *name, const char *title, int nbinsx, const double *xbins)
    : fName(name), fTitle(title), fNbinsX(nbinsx)
 {
-   fBinXEdges.assign(xbins, xbins + (size_t)nbinsx);
+   FillVector(fBinXEdges, nbinsx, xbins);
+}
+std::shared_ptr<::TH1D> TH1DModel::GetHistogram() const
+{
+   if (fBinXEdges.empty()) {
+      return std::make_shared<::TH1D>(fName, fTitle, fNbinsX, fXLow, fXUp);
+   } else {
+      return std::make_shared<::TH1D>(fName, fTitle, fNbinsX, fBinXEdges.data());
+   }
 }
 TH1DModel::~TH1DModel()
 {
 }
 
 TH2DModel::TH2DModel(const ::TH2D &h)
-   : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX()), fXLow(h.GetXaxis()->GetXmin()),
-     fXUp(h.GetXaxis()->GetXmax()), fNbinsY(h.GetNbinsY()), fYLow(h.GetYaxis()->GetXmin()),
-     fYUp(h.GetYaxis()->GetXmax())
+   : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX()), fNbinsY(h.GetNbinsY())
 {
+   SetAxisProperties(h.GetXaxis(), fXLow, fXUp, fBinXEdges);
+   SetAxisProperties(h.GetYaxis(), fYLow, fYUp, fBinYEdges);
 }
 TH2DModel::TH2DModel(const char *name, const char *title, int nbinsx, double xlow, double xup, int nbinsy, double ylow,
                      double yup)
@@ -83,43 +119,52 @@ TH2DModel::TH2DModel(const char *name, const char *title, int nbinsx, const doub
                      double yup)
    : fName(name), fTitle(title), fNbinsX(nbinsx), fNbinsY(nbinsy), fYLow(ylow), fYUp(yup)
 {
-   fBinXEdges.assign(xbins, xbins + (size_t)nbinsx);
+   FillVector(fBinXEdges, nbinsx, xbins);
 }
 TH2DModel::TH2DModel(const char *name, const char *title, int nbinsx, double xlow, double xup, int nbinsy,
                      const double *ybins)
    : fName(name), fTitle(title), fNbinsX(nbinsx), fXLow(xlow), fXUp(xup), fNbinsY(nbinsy)
 {
-   fBinYEdges.assign(ybins, ybins + (size_t)nbinsy);
+   FillVector(fBinYEdges, nbinsy, ybins);
 }
 TH2DModel::TH2DModel(const char *name, const char *title, int nbinsx, const double *xbins, int nbinsy,
                      const double *ybins)
    : fName(name), fTitle(title), fNbinsX(nbinsx), fNbinsY(nbinsy)
 {
-   fBinXEdges.assign(xbins, xbins + (size_t)nbinsx);
-   fBinYEdges.assign(ybins, ybins + (size_t)nbinsy);
+   FillVector(fBinXEdges, nbinsx, xbins);
+   FillVector(fBinYEdges, nbinsy, ybins);
 }
 TH2DModel::TH2DModel(const char *name, const char *title, int nbinsx, const float *xbins, int nbinsy,
                      const float *ybins)
    : fName(name), fTitle(title), fNbinsX(nbinsx), fNbinsY(nbinsy)
 {
-   fBinXEdges.reserve(nbinsx);
-   for (auto i : ROOT::TSeq<int>(nbinsx))
-      fBinXEdges.push_back(xbins[i]);
-   fBinYEdges.reserve(nbinsy);
-   for (auto i : ROOT::TSeq<int>(nbinsy))
-      fBinXEdges.push_back(ybins[i]);
+   FillVector(fBinXEdges, nbinsx, xbins);
+   FillVector(fBinYEdges, nbinsy, ybins);
 }
-
+std::shared_ptr<::TH2D> TH2DModel::GetHistogram() const
+{
+   auto xEdgesEmpty = fBinXEdges.empty();
+   auto yEdgesEmpty = fBinYEdges.empty();
+   if (xEdgesEmpty && yEdgesEmpty) {
+      return std::make_shared<::TH2D>(fName, fTitle, fNbinsX, fXLow, fXUp, fNbinsY, fYLow, fYUp);
+   } else if (!xEdgesEmpty && yEdgesEmpty) {
+      return std::make_shared<::TH2D>(fName, fTitle, fNbinsX, fBinXEdges.data(), fNbinsY, fYLow, fYUp);
+   } else if (xEdgesEmpty && !yEdgesEmpty) {
+      return std::make_shared<::TH2D>(fName, fTitle, fNbinsX, fXLow, fXUp, fNbinsY, fBinYEdges.data());
+   } else {
+      return std::make_shared<::TH2D>(fName, fTitle, fNbinsX, fBinXEdges.data(), fNbinsY, fBinYEdges.data());
+   }
+}
 TH2DModel::~TH2DModel()
 {
 }
 
 TH3DModel::TH3DModel(const ::TH3D &h)
-   : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX()), fXLow(h.GetXaxis()->GetXmin()),
-     fXUp(h.GetXaxis()->GetXmax()), fNbinsY(h.GetNbinsY()), fYLow(h.GetYaxis()->GetXmin()),
-     fYUp(h.GetYaxis()->GetXmax()), fNbinsZ(h.GetNbinsZ()), fZLow(h.GetZaxis()->GetXmin()),
-     fZUp(h.GetZaxis()->GetXmax())
+   : fName(h.GetName()), fTitle(h.GetTitle()), fNbinsX(h.GetNbinsX()), fNbinsY(h.GetNbinsY()), fNbinsZ(h.GetNbinsZ())
 {
+   SetAxisProperties(h.GetXaxis(), fXLow, fXUp, fBinXEdges);
+   SetAxisProperties(h.GetYaxis(), fYLow, fYUp, fBinYEdges);
+   SetAxisProperties(h.GetZaxis(), fZLow, fZUp, fBinZEdges);
 }
 TH3DModel::TH3DModel(const char *name, const char *title, int nbinsx, double xlow, double xup, int nbinsy, double ylow,
                      double yup, int nbinsz, double zlow, double zup)
@@ -131,25 +176,27 @@ TH3DModel::TH3DModel(const char *name, const char *title, int nbinsx, const doub
                      const double *ybins, int nbinsz, const double *zbins)
    : fName(name), fTitle(title), fNbinsX(nbinsx), fNbinsY(nbinsy), fNbinsZ(nbinsz)
 {
-   fBinXEdges.assign(xbins, xbins + (size_t)nbinsx);
-   fBinYEdges.assign(ybins, ybins + (size_t)nbinsy);
-   fBinZEdges.assign(zbins, zbins + (size_t)nbinsz);
+   FillVector(fBinXEdges, nbinsx, xbins);
+   FillVector(fBinYEdges, nbinsy, ybins);
+   FillVector(fBinZEdges, nbinsz, zbins);
 }
 TH3DModel::TH3DModel(const char *name, const char *title, int nbinsx, const float *xbins, int nbinsy,
                      const float *ybins, int nbinsz, const float *zbins)
    : fName(name), fTitle(title), fNbinsX(nbinsx), fNbinsY(nbinsy), fNbinsZ(nbinsz)
 {
-   fBinXEdges.reserve(nbinsx);
-   for (auto i : ROOT::TSeq<int>(nbinsx))
-      fBinXEdges.push_back(xbins[i]);
-   fBinYEdges.reserve(nbinsy);
-   for (auto i : ROOT::TSeq<int>(nbinsy))
-      fBinXEdges.push_back(ybins[i]);
-   fBinZEdges.reserve(nbinsz);
-   for (auto i : ROOT::TSeq<int>(nbinsz))
-      fBinZEdges.push_back(zbins[i]);
+   FillVector(fBinXEdges, nbinsx, xbins);
+   FillVector(fBinYEdges, nbinsy, ybins);
+   FillVector(fBinZEdges, nbinsz, zbins);
 }
-
+std::shared_ptr<::TH3D> TH3DModel::GetHistogram() const
+{
+   if (fBinXEdges.empty() && fBinYEdges.empty() && fBinZEdges.empty()) {
+      return std::make_shared<::TH3D>(fName, fTitle, fNbinsX, fXLow, fXUp, fNbinsY, fYLow, fYUp, fNbinsZ, fZLow, fZUp);
+   } else {
+      return std::make_shared<::TH3D>(fName, fTitle, fNbinsX, fBinXEdges.data(), fNbinsY, fBinYEdges.data(), fNbinsZ,
+                                      fBinZEdges.data());
+   }
+}
 TH3DModel::~TH3DModel()
 {
 }
@@ -177,23 +224,24 @@ TProfile1DModel::TProfile1DModel(const char *name, const char *title, int nbinsx
                                  const char *option)
    : fName(name), fTitle(title), fNbinsX(nbinsx), fOption(option)
 {
-   fBinXEdges.reserve(nbinsx);
-   for (auto i : ROOT::TSeq<int>(nbinsx))
-      fBinXEdges.push_back(xbins[i]);
+   FillVector(fBinXEdges, nbinsx, xbins);
 }
 TProfile1DModel::TProfile1DModel(const char *name, const char *title, int nbinsx, const double *xbins,
                                  const char *option)
    : fName(name), fTitle(title), fNbinsX(nbinsx), fOption(option)
 {
-   fBinXEdges.assign(xbins, xbins + (size_t)nbinsx);
+   FillVector(fBinXEdges, nbinsx, xbins);
 }
 TProfile1DModel::TProfile1DModel(const char *name, const char *title, int nbinsx, const double *xbins, double ylow,
                                  double yup, const char *option)
    : fName(name), fTitle(title), fNbinsX(nbinsx), fYLow(ylow), fYUp(yup), fOption(option)
 {
-   fBinXEdges.assign(xbins, xbins + (size_t)nbinsx);
+   FillVector(fBinXEdges, nbinsx, xbins);
 }
-
+std::shared_ptr<::TProfile> TProfile1DModel::GetProfile() const
+{
+   return std::make_shared<::TProfile>(fName, fTitle, fNbinsX, fXLow, fXUp, fYLow, fYUp, fOption);
+}
 TProfile1DModel::~TProfile1DModel()
 {
 }
@@ -222,22 +270,28 @@ TProfile2DModel::TProfile2DModel(const char *name, const char *title, int nbinsx
                                  double ylow, double yup, const char *option)
    : fName(name), fTitle(title), fNbinsX(nbinsx), fNbinsY(nbinsy), fYLow(ylow), fYUp(yup), fOption(option)
 {
-   fBinXEdges.assign(xbins, xbins + (size_t)nbinsx);
+   FillVector(fBinXEdges, nbinsx, xbins);
 }
 
 TProfile2DModel::TProfile2DModel(const char *name, const char *title, int nbinsx, double xlow, double xup, int nbinsy,
                                  const double *ybins, const char *option)
    : fName(name), fTitle(title), fNbinsX(nbinsx), fXLow(xlow), fXUp(xup), fNbinsY(nbinsy), fOption(option)
 {
-   fBinYEdges.assign(ybins, ybins + (size_t)nbinsy);
+   FillVector(fBinYEdges, nbinsy, ybins);
 }
 
 TProfile2DModel::TProfile2DModel(const char *name, const char *title, int nbinsx, const double *xbins, int nbinsy,
                                  const double *ybins, const char *option)
    : fName(name), fTitle(title), fNbinsX(nbinsx), fNbinsY(nbinsy), fOption(option)
 {
-   fBinYEdges.assign(xbins, xbins + (size_t)nbinsx);
-   fBinYEdges.assign(ybins, ybins + (size_t)nbinsy);
+   FillVector(fBinXEdges, nbinsx, xbins);
+   FillVector(fBinYEdges, nbinsy, ybins);
+}
+
+std::shared_ptr<::TProfile2D> TProfile2DModel::GetProfile() const
+{
+   return std::make_shared<::TProfile2D>(fName, fTitle, fNbinsX, fXLow, fXUp, fNbinsY, fYLow, fYUp, fZLow, fZUp,
+                                         fOption);
 }
 
 TProfile2DModel::~TProfile2DModel()

--- a/tree/treeplayer/test/dataframe/dataframe_histomodels.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_histomodels.cxx
@@ -1,32 +1,58 @@
 #include "ROOT/TDataFrame.hxx"
+#include "ROOT/TSeq.hxx"
 
 #include "gtest/gtest.h"
 
 using namespace ROOT::Experimental;
+
+template <typename COLL>
+void CheckBins(const TAxis *axis, const COLL &v)
+{
+   auto nBins = axis->GetNbins();
+   auto nBinsp1 = nBins + 1;
+   auto nBinsm1 = nBins - 1;
+   EXPECT_EQ(nBinsp1, (int)v.size());
+   for (auto i : ROOT::TSeqI(1, nBinsp1)) {
+      EXPECT_DOUBLE_EQ(axis->GetBinLowEdge(i), (double)v[i - 1]);
+   }
+   EXPECT_DOUBLE_EQ(axis->GetBinUpEdge(nBinsm1), (double)v[nBinsm1]);
+}
 
 TEST(TDataFrameHistoModels, Histo1D)
 {
    TDataFrame tdf(10);
    auto x = 0.;
    auto d = tdf.Define("x", [&x]() { return x++; }).Define("w", [&x]() { return x + 1.; });
-   auto h1 = d.Histo1D(::TH1D("h1", "h1", 64, 0, 10), "x");
-   auto h2 = d.Histo1D({"h2", "h2", 64, 0, 10}, "x");
-   auto h1w = d.Histo1D(::TH1D("h0w", "h0w", 64, 0, 10), "x", "w");
-   auto h2w = d.Histo1D({"h2w", "h2w", 64, 0, 10}, "x", "w");
+   auto h1 = d.Histo1D(::TH1D("h1", "h1", 10, 0, 10), "x");
+   auto h2 = d.Histo1D({"h2", "h2", 10, 0, 10}, "x");
+   auto h1w = d.Histo1D(::TH1D("h0w", "h0w", 10, 0, 10), "x", "w");
+   auto h2w = d.Histo1D({"h2w", "h2w", 10, 0, 10}, "x", "w");
    std::vector<float> edgesf{1, 2, 3, 4, 5, 6, 10};
-   auto h1edgesf = d.Histo1D(::TH1D("h1edgesf", "h1edgesf", (int)edgesf.size(), edgesf.data()), "x");
-   auto h2edgesf = d.Histo1D({"h2edgesf", "h2edgesf", (int)edgesf.size(), edgesf.data()}, "x");
+   auto h1edgesf = d.Histo1D(::TH1D("h1edgesf", "h1edgesf", (int)edgesf.size() - 1, edgesf.data()), "x");
+   auto h2edgesf = d.Histo1D({"h2edgesf", "h2edgesf", (int)edgesf.size() - 1, edgesf.data()}, "x");
    std::vector<double> edgesd{1, 2, 3, 4, 5, 6, 10};
-   auto h1edgesd = d.Histo1D(::TH1D("h1edgesd", "h1edgesd", (int)edgesd.size(), edgesd.data()), "x");
-   auto h2edgesd = d.Histo1D({"h2edgesd", "h2edgesd", (int)edgesd.size(), edgesd.data()}, "x");
+   auto h1edgesd = d.Histo1D(::TH1D("h1edgesd", "h1edgesd", (int)edgesd.size() - 1, edgesd.data()), "x");
+   auto h2edgesd = d.Histo1D({"h2edgesd", "h2edgesd", (int)edgesd.size() - 1, edgesd.data()}, "x");
 
-   TDF::TH1DModel m0("m0", "m0", 64, 0, 10);
-   TDF::TH1DModel m1(::TH1D("m1", "m1", 64, 0, 10));
+   TDF::TH1DModel m0("m0", "m0", 10, 0, 10);
+   TDF::TH1DModel m1(::TH1D("m1", "m1", 10, 0, 10));
 
    auto hm0 = d.Histo1D(m0, "x");
    auto hm1 = d.Histo1D(m1, "x");
    auto hm0w = d.Histo1D(m0, "x", "w");
    auto hm1w = d.Histo1D(m1, "x", "w");
+
+   std::vector<double> ref({0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10.});
+
+   CheckBins(h1->GetXaxis(), ref);
+   CheckBins(h2->GetXaxis(), ref);
+   CheckBins(hm0->GetXaxis(), ref);
+   CheckBins(hm1->GetXaxis(), ref);
+
+   CheckBins(h1edgesf->GetXaxis(), edgesf);
+   CheckBins(h2edgesf->GetXaxis(), edgesf);
+   CheckBins(h1edgesd->GetXaxis(), edgesd);
+   CheckBins(h2edgesd->GetXaxis(), edgesd);
 }
 
 TEST(TDataFrameHistoModels, Histo2D)
@@ -34,32 +60,64 @@ TEST(TDataFrameHistoModels, Histo2D)
    TDataFrame tdf(10);
    auto x = 0.;
    auto d = tdf.Define("x", [&x]() { return x++; }).Define("y", [&x]() { return x + .1; });
-   auto h1 = d.Histo2D(::TH2D("h1", "h1", 64, 0, 10, 64, 0, 10), "x", "y");
-   auto h2 = d.Histo2D({"h2", "h2", 64, 0, 10, 64, 0, 10}, "x", "y");
+   auto h1 = d.Histo2D(::TH2D("h1", "h1", 10, 0, 10, 5, 0, 10), "x", "y");
+   auto h2 = d.Histo2D({"h2", "h2", 10, 0, 10, 5, 0, 10}, "x", "y");
    std::vector<double> edgesX{1, 2, 3, 4, 5, 6, 10};
-   std::vector<double> edgesY{1, 2, 3, 4, 5, 6, 10};
-   auto h1eX = d.Histo2D(::TH2D("h1eX", "h1eX", (int)edgesX.size(), edgesX.data(), 64, 0, 10), "x", "y");
-   auto h2eX = d.Histo2D({"h2eX", "h2eX", (int)edgesX.size(), edgesX.data(), 64, 0, 10}, "x", "y");
-   auto h1eY = d.Histo2D(::TH2D("h1eX", "h1eX", 64, 0, 10, (int)edgesX.size(), edgesX.data()), "x", "y");
-   auto h2eY = d.Histo2D({"h2eX", "h2eX", 64, 0, 10, (int)edgesX.size(), edgesX.data()}, "x", "y");
+   std::vector<double> edgesY{1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 10.1};
+   auto h1eX = d.Histo2D(::TH2D("h1eX", "h1eX", (int)edgesX.size() - 1, edgesX.data(), 5, 0, 10), "x", "y");
+   auto h2eX = d.Histo2D({"h2eX", "h2eX", (int)edgesX.size() - 1, edgesX.data(), 5, 0, 10}, "x", "y");
+   auto h1eY = d.Histo2D(::TH2D("h1eY", "h1eY", 5, 0, 10, (int)edgesY.size() - 1, edgesY.data()), "x", "y");
+   auto h2eY = d.Histo2D({"h2eY", "h2eY", 5, 0, 10, (int)edgesY.size() - 1, edgesY.data()}, "x", "y");
    auto h1eXeY = d.Histo2D(
-      ::TH2D("h1eXeY", "h1eXeY", (int)edgesX.size(), edgesX.data(), (int)edgesY.size(), edgesY.data()), "x", "y");
-   auto h2eXeY =
-      d.Histo2D({"h2eXeY", "h2eXeY", (int)edgesX.size(), edgesX.data(), (int)edgesY.size(), edgesY.data()}, "x", "y");
+      ::TH2D("h1eXeY", "h1eXeY", (int)edgesX.size() - 1, edgesX.data(), (int)edgesY.size() - 1, edgesY.data()), "x",
+      "y");
+   auto h2eXeY = d.Histo2D(
+      {"h2eXeY", "h2eXeY", (int)edgesX.size() - 1, edgesX.data(), (int)edgesY.size() - 1, edgesY.data()}, "x", "y");
    std::vector<float> edgesXf{1, 2, 3, 4, 5, 6, 10};
-   std::vector<float> edgesYf{1, 2, 3, 4, 5, 6, 10};
+   std::vector<float> edgesYf{1.1f, 2.1f, 3.1f, 4.1f, 5.1f, 6.1f, 10.1f};
    auto h1eXeYf = d.Histo2D(
-      ::TH2D("h1eXeYf", "h1eXeYf", (int)edgesXf.size(), edgesXf.data(), (int)edgesYf.size(), edgesYf.data()), "x", "y");
+      ::TH2D("h1eXeYf", "h1eXeYf", (int)edgesXf.size() - 1, edgesXf.data(), (int)edgesYf.size() - 1, edgesYf.data()),
+      "x", "y");
    auto h2eXeYf = d.Histo2D(
-      {"h2eXeYf", "h2eXeYf", (int)edgesXf.size(), edgesXf.data(), (int)edgesYf.size(), edgesYf.data()}, "x", "y");
+      {"h2eXeYf", "h2eXeYf", (int)edgesXf.size() - 1, edgesXf.data(), (int)edgesYf.size() - 1, edgesYf.data()}, "x",
+      "y");
 
-   TDF::TH2DModel m0("m0", "m0", 64, 0, 10, 64, 0, 10);
-   TDF::TH2DModel m1(::TH2D("m1", "m1", 64, 0, 10, 64, 0, 10));
+   TDF::TH2DModel m0("m0", "m0", 10, 0, 10, 5, 0, 10);
+   TDF::TH2DModel m1(::TH2D("m1", "m1", 10, 0, 10, 5, 0, 10));
 
    auto hm0 = d.Histo2D(m0, "x", "y");
    auto hm1 = d.Histo2D(m1, "x", "y");
    auto hm0w = d.Histo2D(m0, "x", "y", "x");
    auto hm1w = d.Histo2D(m1, "x", "y", "x");
+
+   std::vector<double> ref0({0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10.});
+   std::vector<double> ref1({0., 2., 4., 6., 8., 10.});
+
+   CheckBins(h1->GetXaxis(), ref0);
+   CheckBins(h1->GetYaxis(), ref1);
+   CheckBins(h2->GetXaxis(), ref0);
+   CheckBins(h2->GetYaxis(), ref1);
+   CheckBins(h1eX->GetXaxis(), edgesX);
+   CheckBins(h1eX->GetYaxis(), ref1);
+   CheckBins(h2eX->GetXaxis(), edgesX);
+   CheckBins(h2eX->GetYaxis(), ref1);
+   CheckBins(h1eY->GetXaxis(), ref1);
+   CheckBins(h1eY->GetYaxis(), edgesY);
+   CheckBins(h2eY->GetXaxis(), ref1);
+   CheckBins(h2eY->GetYaxis(), edgesY);
+   CheckBins(hm0->GetXaxis(), ref0);
+   CheckBins(hm0->GetYaxis(), ref1);
+   CheckBins(hm1->GetXaxis(), ref0);
+   CheckBins(hm1->GetYaxis(), ref1);
+
+   CheckBins(h1eXeY->GetXaxis(), edgesX);
+   CheckBins(h1eXeY->GetYaxis(), edgesY);
+   CheckBins(h2eXeY->GetXaxis(), edgesX);
+   CheckBins(h2eXeY->GetYaxis(), edgesY);
+   CheckBins(h1eXeYf->GetXaxis(), edgesXf);
+   CheckBins(h1eXeYf->GetYaxis(), edgesYf);
+   CheckBins(h2eXeYf->GetXaxis(), edgesXf);
+   CheckBins(h2eXeYf->GetYaxis(), edgesYf);
 }
 
 TEST(TDataFrameHistoModels, Histo3D)
@@ -69,24 +127,47 @@ TEST(TDataFrameHistoModels, Histo3D)
    auto d = tdf.Define("x", [&x]() { return x++; }).Define("y", [&x]() { return x + .1; }).Define("z", [&x]() {
       return x + .1;
    });
-   auto h1 = d.Histo3D(::TH3D("h1", "h1", 64, 0, 10, 64, 0, 10, 64, 0, 10), "x", "y", "z");
-   auto h2 = d.Histo3D({"h2", "h2", 64, 0, 10, 64, 0, 10, 64, 0, 10}, "x", "y", "z");
+   auto h1 = d.Histo3D(::TH3D("h1", "h1", 10, 0, 10, 5, 0, 10, 2, 0, 10), "x", "y", "z");
+   auto h2 = d.Histo3D({"h2", "h2", 10, 0, 10, 5, 0, 10, 2, 0, 10}, "x", "y", "z");
 
    std::vector<double> edgesXd{1, 2, 3, 4, 5, 6, 10};
-   std::vector<double> edgesYd{1, 2, 3, 4, 5, 6, 10};
-   std::vector<double> edgesZd{1, 2, 3, 4, 5, 6, 10};
-   auto h1e = d.Histo3D(::TH3D("h1e", "h1e", (int)edgesXd.size(), edgesXd.data(), (int)edgesYd.size(), edgesYd.data(),
-                               (int)edgesZd.size(), edgesZd.data()),
+   std::vector<double> edgesYd{1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 10.1};
+   std::vector<double> edgesZd{1.2, 2.2, 3.2, 4.2, 5.2, 6.2, 10.2};
+   auto h1e = d.Histo3D(::TH3D("h1e", "h1e", (int)edgesXd.size() - 1, edgesXd.data(), (int)edgesYd.size() - 1,
+                               edgesYd.data(), (int)edgesZd.size() - 1, edgesZd.data()),
                         "x", "y", "z");
-   auto h2e = d.Histo3D({"h2e", "h2e", (int)edgesXd.size(), edgesXd.data(), (int)edgesYd.size(), edgesYd.data(),
-                         (int)edgesZd.size(), edgesZd.data()},
+   auto h2e = d.Histo3D({"h2e", "h2e", (int)edgesXd.size() - 1, edgesXd.data(), (int)edgesYd.size() - 1, edgesYd.data(),
+                         (int)edgesZd.size() - 1, edgesZd.data()},
                         "x", "y", "z");
 
-   TDF::TH3DModel m0("m0", "m0", 64, 0, 10, 64, 0, 10, 64, 0, 10);
-   TDF::TH3DModel m1(::TH3D("m1", "m1", 64, 0, 10, 64, 0, 10, 64, 0, 10));
+   TDF::TH3DModel m0("m0", "m0", 2, 0, 10, 5, 0, 10, 10, 0, 10);
+   TDF::TH3DModel m1(::TH3D("m1", "m1", 2, 0, 10, 5, 0, 10, 10, 0, 10));
 
    auto hm0 = d.Histo3D(m0, "x", "y", "z");
    auto hm1 = d.Histo3D(m1, "x", "y", "z");
    auto hm0w = d.Histo3D(m0, "x", "y", "z", "z");
    auto hm1w = d.Histo3D(m1, "x", "y", "z", "z");
+
+   std::vector<double> ref0({0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10.});
+   std::vector<double> ref1({0., 2., 4., 6., 8., 10.});
+   std::vector<double> ref2({0., 5., 10.});
+
+   CheckBins(h1e->GetXaxis(), edgesXd);
+   CheckBins(h1e->GetYaxis(), edgesYd);
+   CheckBins(h1e->GetZaxis(), edgesZd);
+   CheckBins(h2e->GetXaxis(), edgesXd);
+   CheckBins(h2e->GetYaxis(), edgesYd);
+   CheckBins(h2e->GetZaxis(), edgesZd);
+   CheckBins(h1->GetXaxis(), ref0);
+   CheckBins(h1->GetYaxis(), ref1);
+   CheckBins(h1->GetZaxis(), ref2);
+   CheckBins(h2->GetXaxis(), ref0);
+   CheckBins(h2->GetYaxis(), ref1);
+   CheckBins(h2->GetZaxis(), ref2);
+   CheckBins(hm0->GetXaxis(), ref2);
+   CheckBins(hm0->GetYaxis(), ref1);
+   CheckBins(hm0->GetZaxis(), ref0);
+   CheckBins(hm0w->GetXaxis(), ref2);
+   CheckBins(hm0w->GetYaxis(), ref1);
+   CheckBins(hm0w->GetZaxis(), ref0);
 }


### PR DESCRIPTION
the implementation of histo models has been simplified avoiding code duplication.
The creation of the shared_pointer containing the histogram has been moved to
the model classes, in order to simplify the TDFInterface.
Test coverage has been significantly increased.