### PR TITLE
Avoid wild over read in badly clusted files

### DIFF
--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -6972,7 +6972,7 @@ void TTree::Print(Option_t* option) const
    Printf("*        :          : Tree compression factor = %6.2f                       *", cx);
    Printf("******************************************************************************");
 
-   if (strncmp(option,"clusterRange",strlen("clusters"))==0) {
+   if (strncmp(option,"clusters",strlen("clusters"))==0) {
       Printf("%-16s %-16s %-16s %5s",
              "Cluster Range #", "Entry Start", "Last Entry", "Size");
       Int_t index= 0;

--- a/tree/tree/src/TTreeCache.cxx
+++ b/tree/tree/src/TTreeCache.cxx
@@ -962,6 +962,7 @@ Bool_t TTreeCache::FillBuffer()
    TTree::TClusterIterator clusterIter = tree->GetClusterIterator(entry);
    fEntryCurrent = clusterIter();
    fEntryNext = clusterIter.GetNextEntry();
+   auto firstClusterEnd = fEntryNext;
 
    if (fEntryCurrent < fEntryMin) fEntryCurrent = fEntryMin;
    if (fEntryMax <= 0) fEntryMax = tree->GetEntries();
@@ -1159,6 +1160,21 @@ Bool_t TTreeCache::FillBuffer()
       fEntryNext = clusterIter.GetNextEntry();
       if (fEntryNext > fEntryMax) fEntryNext = fEntryMax;
    } while (kTRUE);
+
+   if (fEntryCurrent > entry || entry >= fEntryNext) {
+      // Something went very wrong and even-though we searched for the baskets
+      // holding 'entry' we somehow ended up with a range of entries that does
+      // validate.  So we must have been unable to find or fit the needed basket.
+      // And thus even-though, we know the corresponding baskets wont be in the cache,
+      // Let's make it official that 'entry' is within the range of this TTreeCache ('s search.)
+
+      // Without this, the next read will be flagged as 'out-of-range' and then we start at
+      // the exact same point as this FillBuffer execution resulting in both the requested
+      // entry still not being part of the cache **and** the beginning of the cluster being
+      // read **again**.
+
+      fEntryNext = firstClusterEnd;
+   }
 
    if (fEnablePrefetching) {
       if (fIsLearning) {

--- a/tree/tree/src/TTreeCache.cxx
+++ b/tree/tree/src/TTreeCache.cxx
@@ -1031,7 +1031,7 @@ Bool_t TTreeCache::FillBuffer()
             //we have found the branch. We now register all its baskets
             //from the requested offset to the basket below fEntrymax
             Int_t blistsize = b->GetListOfBaskets()->GetSize();
-            Int_t j=minBasket;  // We need this out of the loop so we can find out how far we went.
+            Int_t j = minBasket;  // We need this out of the loop so we can find out how far we went.
             Bool_t firstBasketSeen = kFALSE;
             for (;j<nb;j++) {
                // This basket has already been read, skip it


### PR DESCRIPTION
    Prevent wild over-read when reading badly clustered file.
    
    In some cases where the memory available to the TTreeCache can not fit the entirety
    of (potentially odd-shaped) cluster, the TTreeCache could end up with a situation
    where (starting at some point) it is invalidated at each entry *and* the basket
    from the previous cluster boundary up to some entry number less than the current
    entry are loaded over and over again (until the entry number reaches the next cluster
    boundary).
    
    In a case encountered by CMS, a TTree has a recorded cluster size of 165 events.  However the TTree
    appears to not have been clustered; most basket size are the same and seem to be flushed at 139 events
    interval.  A few branches are flushed less frequently, for example EventAuxiliary is flushed every 459
    entries.
    
    As a consequence when entry 417 is requested, the cluster boundary is calculated as 330 and
    the first end as 495.  Then all basket containing entries in that range are loaded, including
    EventAuxiliary's basket containing entries 459 to 917.  Then 917 is the highest available (partial)
    entry available.  Thus the next time the TTreeCache is invalidated is when entry 918 is requested.
    As that point the cluster boundary is calculated as 845 and the first end as 495, however
    (with the small enough TTreeCache size), the cache is full as soon as the basket for EventAuxiliary
    is added.  This resulted in a 'valid' range for this cache of 845 to 917 and lead to the reading
    all the baskets added so far ... and thus eventhough none of them would be used for reading
    and they already had been read once in memory.  Then for entry 919, the exact same behavior
    repeated.
    
    The solution consist on marking the 'minimum' valid range as being 'at least' one cluster wide.
    
    Thus in the example above for entry 918 through 989, **only** the missing baskets are read
    individually resulting in 'degraded' performance but **not** a wild over-read.
    
    A future enhancement would be, in those cases, restart the next buffer from the last valid
    entry + 1 rather than the previous event boundary.  This would result in a 'slightly' over-read
    (some baskets might be read twice) rather than the wild useless over-read we had.