### PR TITLE
[TDF] Refactor Columnname2columntypename

### DIFF
--- a/tree/treeplayer/test/dataframe/dataframe_utils.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_utils.cxx
@@ -68,8 +68,8 @@ TEST(TDataFrameUtils, DeduceAllPODsFromColumns)
                                                      {"Long64_t", "Long64_t"},
                                                      {"ULong64_t", "ULong64_t"},
                                                      {"bool", "Bool_t"},
-                                                     {"arrint", "ROOT::Experimental::VecOps::TVec<Int_t>"},
-                                                     {"vararrint", "ROOT::Experimental::VecOps::TVec<Int_t>"}};
+                                                     {"arrint.a", "ROOT::Experimental::VecOps::TVec<Int_t>"},
+                                                     {"vararrint.a", "ROOT::Experimental::VecOps::TVec<Int_t>"}};
 
    for (auto &nameType : nameTypes) {
       auto typeName = ROOT::Internal::TDF::ColumnName2ColumnTypeName(nameType.first, &t, nullptr);
@@ -95,8 +95,8 @@ TEST(TDataFrameUtils, DeduceTypeOfBranchesWithCustomTitle)
 
    std::map<const char *, const char *> nameTypes = {{"float", "Float_t"},
                                                      {"i", "Int_t"},
-                                                     {"arrint", "ROOT::Experimental::VecOps::TVec<Int_t>"},
-                                                     {"vararrint", "ROOT::Experimental::VecOps::TVec<Int_t>"}};
+                                                     {"arrint.a", "ROOT::Experimental::VecOps::TVec<Int_t>"},
+                                                     {"vararrint.a", "ROOT::Experimental::VecOps::TVec<Int_t>"}};
 
    for (auto &nameType : nameTypes) {
       auto typeName = ROOT::Internal::TDF::ColumnName2ColumnTypeName(nameType.first, &t, nullptr);


### PR DESCRIPTION
The logic to get the typename of a TTree leaf/branch is now factored
out into its own function, has been streamlined, and support for
leafnames with multiple dots ("b1.b2.leaf") has been added.