### PR TITLE
[TTreeReader] Fix ROOT-9316: reuse branch proxies for TTreeReader{Val…

### DIFF
--- a/tree/treeplayer/inc/TTreeReader.h
+++ b/tree/treeplayer/inc/TTreeReader.h
@@ -28,6 +28,7 @@
 
 #include <deque>
 #include <iterator>
+#include <unordered_map>
 
 class TDictionary;
 class TDirectory;
@@ -215,10 +216,26 @@ public:
    Iterator_t end() const { return Iterator_t(); }
 
 protected:
+   using NamedProxies_t = std::unordered_map<std::string, std::unique_ptr<ROOT::Internal::TNamedBranchProxy>>;
    void Initialize();
-   ROOT::Internal::TNamedBranchProxy* FindProxy(const char* branchname) const {
-      return (ROOT::Internal::TNamedBranchProxy*) fProxies.FindObject(branchname); }
-   TCollection* GetProxies() { return &fProxies; }
+   ROOT::Internal::TNamedBranchProxy* FindProxy(const char* branchname) const
+   {
+      const auto proxyIt = fProxies.find(branchname);
+      return fProxies.end() != proxyIt ? proxyIt->second.get() : nullptr;
+   }
+
+   void AddProxy(ROOT::Internal::TNamedBranchProxy *p)
+   {
+      auto bpName = p->GetName();
+#ifndef NDEBUG
+      if (fProxies.end() != fProxies.find(bpName)) {
+         std::string err = "A proxy with key " + std::string(bpName) + " was already stored!";
+         throw std::runtime_error(err);
+      }
+#endif
+
+      fProxies[bpName].reset(p);
+   }
 
    Bool_t RegisterValueReader(ROOT::Internal::TTreeReaderValueBase* reader);
    void DeregisterValueReader(ROOT::Internal::TTreeReaderValueBase* reader);
@@ -226,6 +243,13 @@ protected:
    EEntryStatus SetEntryBase(Long64_t entry, Bool_t local);
 
 private:
+
+   std::string GetProxyKey(const char *branchname)
+   {
+      std::string key(branchname);
+      //key += reinterpret_cast<std::uintptr_t>(fTree);
+      return key;
+   }
 
    enum EPropertyBits {
       kBitIsChain = BIT(14), ///< our tree is a chain
@@ -238,7 +262,7 @@ private:
    Int_t fMostRecentTreeNumber = -1; ///< TTree::GetTreeNumber() of the most recent tree
    ROOT::Internal::TBranchProxyDirector* fDirector = nullptr; ///< proxying director, owned
    std::deque<ROOT::Internal::TTreeReaderValueBase*> fValues; ///< readers that use our director
-   THashTable   fProxies; ///< attached ROOT::TNamedBranchProxies; owned
+   NamedProxies_t fProxies; ///< attached ROOT::TNamedBranchProxies; owned
 
    Long64_t fEntry = -1; ///< Current (non-local) entry of fTree or of fEntryList if set.
 

--- a/tree/treeplayer/inc/TTreeReaderUtils.h
+++ b/tree/treeplayer/inc/TTreeReaderUtils.h
@@ -38,13 +38,13 @@ namespace Internal {
    class TBranchProxyDirector;
    class TTreeReaderArrayBase;
 
-   class TNamedBranchProxy: public TObject {
+   class TNamedBranchProxy {
    public:
       TNamedBranchProxy(): fDict(0), fContentDict(0) {}
-      TNamedBranchProxy(TBranchProxyDirector* boss, TBranch* branch, const char* membername):
-         fProxy(boss, branch, membername), fDict(0), fContentDict(0) {}
+      TNamedBranchProxy(TBranchProxyDirector* boss, TBranch* branch, const char* fullname, const char* membername):
+         fProxy(boss, branch, membername), fDict(0), fContentDict(0), fFullName(fullname) {}
 
-      const char* GetName() const { return fProxy.GetBranchName(); }
+      const char* GetName() const { return fFullName.c_str(); }
       const Detail::TBranchProxy* GetProxy() const { return &fProxy; }
       Detail::TBranchProxy* GetProxy() { return &fProxy; }
       TDictionary* GetDict() const { return fDict; }
@@ -54,9 +54,9 @@ namespace Internal {
 
    private:
       Detail::TBranchProxy fProxy;
-      TDictionary*       fDict;
-      TDictionary*       fContentDict; // type of content, if a collection
-      ClassDef(TNamedBranchProxy, 0); // branch proxy with a name
+      TDictionary*         fDict;
+      TDictionary*         fContentDict; // type of content, if a collection
+      std::string          fFullName;
    };
 
    // Used by TTreeReaderArray

--- a/tree/treeplayer/src/TTreeReader.cxx
+++ b/tree/treeplayer/src/TTreeReader.cxx
@@ -203,7 +203,6 @@ TTreeReader::~TTreeReader()
       (*i)->MarkTreeReaderUnavailable();
    }
    delete fDirector;
-   fProxies.SetOwner();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/src/TTreeReaderArray.cxx
+++ b/tree/treeplayer/src/TTreeReaderArray.cxx
@@ -402,8 +402,8 @@ void ROOT::Internal::TTreeReaderArrayBase::CreateProxy()
             membername = branch->GetName();
          }
       }
-      namedProxy = new TNamedBranchProxy(fTreeReader->fDirector, branch, membername);
-      fTreeReader->GetProxies()->Add(namedProxy);
+      namedProxy = new TNamedBranchProxy(fTreeReader->fDirector, branch, fBranchName, membername);
+      fTreeReader->AddProxy(namedProxy);
       fProxy = namedProxy->GetProxy();
       if (fProxy)
          fSetupStatus = kSetupMatch;

--- a/tree/treeplayer/src/TTreeReaderValue.cxx
+++ b/tree/treeplayer/src/TTreeReaderValue.cxx
@@ -216,13 +216,19 @@ void ROOT::Internal::TTreeReaderValueBase::CreateProxy() {
    // Search for the branchname, determine what it contains, and wire the
    // TBranchProxy representing it to us so we can access its data.
 
-   TNamedBranchProxy* namedProxy
-      = (TNamedBranchProxy*)fTreeReader->FindObject(fBranchName);
+   TNamedBranchProxy* namedProxy = fTreeReader->FindProxy(fBranchName);
    if (namedProxy && namedProxy->GetDict() == fDict) {
       fProxy = namedProxy->GetProxy();
       fSetupStatus = kSetupMatch;
       return;
    }
+
+   // This allows to support names such as v.a where the branch was created with
+   // this syntax:
+   // myTree->Branch("v", &v, "a/I:b:/I")
+   // if the branch is not found, the fBranchName is chopped to the top level branch
+   // by this very method.
+   std::string originalBranchName = fBranchName.Data();
 
    TBranch* branch = fTreeReader->GetTree()->GetBranch(fBranchName);
    TLeaf *myLeaf = NULL;
@@ -425,8 +431,8 @@ void ROOT::Internal::TTreeReaderValueBase::CreateProxy() {
          membername = branch->GetName();
       }
    }
-   namedProxy = new TNamedBranchProxy(fTreeReader->fDirector, branch, membername);
-   fTreeReader->GetProxies()->Add(namedProxy);
+   namedProxy = new TNamedBranchProxy(fTreeReader->fDirector, branch, originalBranchName.c_str(), membername);
+   fTreeReader->AddProxy(namedProxy);
    fProxy = namedProxy->GetProxy();
    if (fProxy) {
       fSetupStatus = kSetupMatch;


### PR DESCRIPTION
…ue,Array}

when they are attached to the same branch.
TNamedBranchProxy did not implement a Hash method.
Therefore when adding TNamedBranchProxy instances to the THashList dedicated to their bookkeping in TTreeReader TObject::Hash was used.
Unfortunately when trying to find the TNamedBranchProxies, their name was used and the hash was built differently by THashList (based on the name).
In order to fix this the following steps were taken.
- THashList was replaced by an unordered_map with names as keys and unique_ptr<TNamedBranchProxy> as values. The unique_ptr is used to automatically manage ownership.
- The key is not the name of the branch as known by the branch any more but rather the name the user inputs in the constructor of the TTreeReader{Array,Value}.
- An exception is thrown in debug mode if the system tries to push in the TTreeReader collection of proxy with a name held by a proxy in that collection.
- The methods of TTreeReader were adapted to use this new container as well as the code in TTreeReaderValue and TTreeReaderArray.

A real usecase from CMS where the mass of the W boson is studied shows a significant speedup (30%).
The code uses TDataFrame and several nodes are created which read from the same branch in an input tree which holds weights in a collection.
This configuration stressed the performance degradation pattern fixed by this commit as it triggered multiple times the deserialisation of the "weights branch".

Thanks to Elisabetta Manca and Lorenzo Bianchini for providing the bug report and initial reproducer.