### PR TITLE
Reverting clang patch 'Work around ROOT-6966 to unblock CMS and ATLAS…

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReader.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReader.cpp
@@ -2242,9 +2242,7 @@ ASTReader::ASTReadResult ASTReader::ReadOptionsBlock(
     }
 
     case TARGET_OPTIONS: {
-      // Work around ROOT-6966
-      //bool Complain = (ClientLoadCapabilities & ARR_ConfigurationMismatch) == 0;
-      bool Complain = false;
+      bool Complain = (ClientLoadCapabilities & ARR_ConfigurationMismatch) == 0;
       if (ParseTargetOptions(Record, Complain, Listener,
                              AllowCompatibleConfigurationMismatch))
         Result = ConfigurationMismatch;


### PR DESCRIPTION
…: do not validate arch.'

This patch was fixing https://sft.its.cern.ch/jira/browse/ROOT-6966 and real solution was deployed later on cling side, allowing to load target options and etc. from PCH in CIFactory.cpp.