### PR TITLE
tree cloner history tracking

### DIFF
--- a/README/ReleaseNotes/v614/index.md
+++ b/README/ReleaseNotes/v614/index.md
@@ -52,6 +52,16 @@ The following people have contributed to this new version:
 
 ## TTree Libraries
    - Proxies are now properly re-used when multiple TTreeReader{Value,Array}s are associated to a single branch. Deserialisation is therefore performed once. This is an advantage for complex TDataFrame graphs.
+   - Add TBranch::BackFill to allowing the addition of new branches to an existing tree and keep the new basket clustered in the same way as the rest of the TTree.  Use with the following pattern.
+```
+  for(auto e = 0; e < tree->GetEntries(); ++e) { // loop over entries.
+    for(auto branch : branchCollection) {
+      // Update data for the branch
+      branch->BackFill();
+    }
+  }
+```
+Since we loop over all the branches for each new entry all the baskets for a cluster are consecutive in the file.
 
 ### TDataFrame
    - Histograms and profiles returned by TDataFrame (e.g. by a Histo1D action) are now not associated to a ROOT directory (their fDirectory is a nullptr).

--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -253,7 +253,7 @@ Bool_t TFileMerger::AddFile(TFile *source, Bool_t own, Bool_t cpProgress)
          Error("AddFile", "cannot open file %s", source->GetName());
       return kFALSE;
    } else {
-      if (fOutputFile && fOutputFile->GetCompressionLevel() != newfile->GetCompressionLevel()) fCompressionChange = kTRUE;
+      if (fOutputFile && fOutputFile->GetCompressionSettings() != newfile->GetCompressionSettings()) fCompressionChange = kTRUE;
 
       if (own || newfile != source) {
          newfile->SetBit(kCanDelete);

--- a/tree/tree/inc/TBranch.h
+++ b/tree/tree/inc/TBranch.h
@@ -147,6 +147,7 @@ public:
 
    virtual void      AddBasket(TBasket &b, Bool_t ondisk, Long64_t startEntry);
    virtual void      AddLastBasket(Long64_t startEntry);
+           Int_t     BackFill();
    virtual void      Browse(TBrowser *b);
    virtual void      DeleteBaskets(Option_t* option="");
    virtual void      DropBaskets(Option_t *option = "");

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -1844,8 +1844,11 @@ Int_t TBranch::LoadBaskets()
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Print TBranch parameters
+///
+/// If options contains "basketsInfo" print the entry number, location and size
+/// of each baskets.
 
-void TBranch::Print(Option_t*) const
+void TBranch::Print(Option_t *option) const
 {
    const int kLINEND = 77;
    Float_t cx = 1;
@@ -1916,6 +1919,7 @@ void TBranch::Print(Option_t*) const
       delete[] tmp;
    }
    Printf("%s", bline);
+
    if (fTotBytes > 2000000000) {
       Printf("*Entries :%lld : Total  Size=%11lld bytes  File Size  = %lld *",fEntries,totBytes,fZipBytes);
    } else {
@@ -1923,13 +1927,22 @@ void TBranch::Print(Option_t*) const
          Printf("*Entries :%9lld : Total  Size=%11lld bytes  File Size  = %10lld *",fEntries,totBytes,fZipBytes);
       } else {
          if (fWriteBasket > 0) {
-            Printf("*Entries :%9lld : Total  Size=%11lld bytes  All baskets in memory   *",fEntries,totBytes);
+               Printf("*Entries :%9lld : Total  Size=%11lld bytes  All baskets in memory   *",fEntries,totBytes);
          } else {
-            Printf("*Entries :%9lld : Total  Size=%11lld bytes  One basket in memory    *",fEntries,totBytes);
+               Printf("*Entries :%9lld : Total  Size=%11lld bytes  One basket in memory    *",fEntries,totBytes);
          }
       }
    }
    Printf("*Baskets :%9d : Basket Size=%11d bytes  Compression= %6.2f     *",fWriteBasket,fBasketSize,cx);
+
+   if (strncmp(option,"basketsInfo",strlen("basketsInfo"))==0) {
+      Int_t nbaskets = fWriteBasket;
+      for (Int_t i=0;i<nbaskets;i++) {
+         Printf("*Basket #%4d  entry=%6lld  pos=%6lld  size=%5d",
+                i, fBasketEntry[i], fBasketSeek[i], fBasketBytes[i]);
+      }
+   }
+
    Printf("*............................................................................*");
    delete [] bline;
    fgCount++;

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -596,6 +596,60 @@ void TBranch::AddLastBasket(Long64_t startEntry)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Loop on all leaves of this branch to back fill Basket buffer.
+///
+/// Use this routine when filling a branch individually to catch up with the
+/// number of entries in the TTree.
+///
+/// First TBranch::Fill and then if the number of entries of the branch reach
+/// one of TTree cluster's boundary, the basket is flushed.
+///
+/// The function returns the number of bytes committed to the memory basket.
+/// If a write error occurs, the number of bytes returned is -1.
+/// If no data are written, because e.g. the branch is disabled,
+/// the number of bytes returned is 0.
+///
+/// To insure that the baskets of each cluster are located close by in the
+/// file, when back-filling multiple branch do
+/// ~~~ {.cpp}
+///   for( auto e = 0; e < tree->GetEntries(); ++e ) { // loop over entries.
+///     for( auto branch : branchCollection) {
+///        // Update data for the branch
+///        branch->BackFill();
+///     }
+///   }
+///   // Since we loop over all the branches for each new entry
+///   // all the baskets for a cluster are consecutive in the file.
+/// ~~~
+/// rather than
+/// ~~~ {.cpp}
+///   for(auto branch : branchCollection) {
+///     for( auto e = 0; e < tree->GetEntries(); ++e ) { // loop over entries.
+///        // Update data for the branch
+///        branch->BackFill();
+///     }
+///   }
+///   // Since we loop over all the entries for one branch
+///   // all the baskets for that branch are consecutive.
+/// ~~~
+
+Int_t TBranch::BackFill() {
+
+   // Get the end of the next cluster.
+   auto cluster  = GetTree()->GetClusterIterator( GetEntries() );
+   cluster.Next();
+   auto endCluster = cluster.GetNextEntry();
+
+   auto result = FillImpl(nullptr);
+
+   if ( result && GetEntries() >= endCluster ) {
+      FlushBaskets();
+   }
+
+   return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Browser interface.
 
 void TBranch::Browse(TBrowser* b)

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -6134,9 +6134,11 @@ void TTree::ImportClusterRanges(TTree *fromtree)
             fClusterSize = new Long64_t[fMaxClusterRange];
          }
       }
-      fClusterRangeEnd[fNClusterRange] = fEntries - 1;
-      fClusterSize[fNClusterRange] = fAutoFlush<0 ? 0 : fAutoFlush;
-      ++fNClusterRange;
+      if (fEntries) {
+         fClusterRangeEnd[fNClusterRange] = fEntries - 1;
+         fClusterSize[fNClusterRange] = fAutoFlush<0 ? 0 : fAutoFlush;
+         ++fNClusterRange;
+      }
       for (Int_t i = 0 ; i < fromtree->fNClusterRange; ++i) {
          fClusterRangeEnd[fNClusterRange] = fEntries + fromtree->fClusterRangeEnd[i];
          fClusterSize[fNClusterRange] = fromtree->fClusterSize[i];
@@ -7891,7 +7893,7 @@ void TTree::SetAutoFlush(Long64_t autof /* = -30000000 */ )
    if (fAutoFlush > 0 || autof > 0) {
       // The mechanism was already enabled, let's record the previous
       // cluster if needed.
-      if (fFlushedBytes) {
+      if (fFlushedBytes && fEntries) {
          if ( (fNClusterRange+1) > fMaxClusterRange ) {
             if (fMaxClusterRange) {
                Int_t newsize = TMath::Max(10,Int_t(2*fMaxClusterRange));

--- a/tree/tree/src/TTreeCloner.cxx
+++ b/tree/tree/src/TTreeCloner.cxx
@@ -640,6 +640,11 @@ void TTreeCloner::ImportClusterRanges()
 
    fToTree->ImportClusterRanges( fFromTree->GetTree() );
 
+   // This is only updated by TTree::Fill upon seeing a Flush event in TTree::Fill
+   // So we need to propagate (this has also the advantage of turning on the
+   // history recording feature of SetAutoFlush for the next iteration)
+   fToTree->fFlushedBytes += fFromTree->fFlushedBytes;
+
    fToTree->SetEntries(fToTree->GetEntries() + fFromTree->GetTree()->GetEntries());
 }
 


### PR DESCRIPTION
This prevents the main issue leading to a file with bad cluster 'history' which was discovered while investigating [ROOT-9318](https://sft.its.cern.ch/jira/browse/ROOT-9318).