### PR TITLE
Fix compilation error on Windows

### DIFF
--- a/tree/treeplayer/test/dataframe/dataframe_callbacks.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_callbacks.cxx
@@ -360,7 +360,7 @@ TEST_F(TDFCallbacksMT, Histo1DWithFillTOHelper)
    std::array<ULong64_t, gNSlots> is;
    is.fill(0ull);
    constexpr ULong64_t everyN = 1ull;
-   h.OnPartialResultSlot(everyN, [&is](unsigned int slot, value_t &h_) {
+   h.OnPartialResultSlot(everyN, [&](unsigned int slot, value_t &h_) {
       is[slot] += everyN;
       EXPECT_EQ(h_.GetEntries(), is[slot]);
    });
@@ -376,7 +376,7 @@ TEST_F(TDFCallbacksMT, Histo1DWithFillHelper)
    std::array<ULong64_t, gNSlots> is;
    is.fill(0ull);
    constexpr ULong64_t everyN = 1ull;
-   h.OnPartialResultSlot(everyN, [&is](unsigned int slot, value_t &h_) {
+   h.OnPartialResultSlot(everyN, [&](unsigned int slot, value_t &h_) {
       is[slot] += everyN;
       EXPECT_EQ(h_.GetEntries(), is[slot]);
    });


### PR DESCRIPTION
Fix the compilation error C3493: 'everyN' cannot be implicitly captured because no default capture mode has been specified