### PR TITLE
Fix for error if include_directories are empty

### DIFF
--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -294,7 +294,10 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
     endif()
   endforeach()
 
-  list(REMOVE_DUPLICATES includedirs)
+  if(includedirs)
+    list(REMOVE_DUPLICATES includedirs)
+  endif()
+
   #---Get the list of definitions---------------------------
   get_directory_property(defs COMPILE_DEFINITIONS)
   foreach( d ${defs})


### PR DESCRIPTION
Running ROOT_GENERATE_DICTIONARY when you have not set any global include directories (which will happen if you are using modern CMake principles) and don't have an `inc` dir will cause CMake to crash due to REMOVE_DUPLICATES failing to run on an empty list. 

This fixes that crash.