### PR TITLE
[backport][clang] Backport r328404: "[ODRHash] Support pointer and re…

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/AST/ODRHash.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/AST/ODRHash.cpp
@@ -563,6 +563,24 @@ public:
     VisitFunctionType(T);
   }
 
+  void VisitPointerType(const PointerType *T) {
+    AddQualType(T->getPointeeType());
+    VisitType(T);
+  }
+
+  void VisitReferenceType(const ReferenceType *T) {
+    AddQualType(T->getPointeeTypeAsWritten());
+    VisitType(T);
+  }
+
+  void VisitLValueReferenceType(const LValueReferenceType *T) {
+    VisitReferenceType(T);
+  }
+
+  void VisitRValueReferenceType(const RValueReferenceType *T) {
+    VisitReferenceType(T);
+  }
+
   void VisitTypedefType(const TypedefType *T) {
     AddDecl(T->getDecl());
     QualType UnderlyingType = T->getDecl()->getUnderlyingType();


### PR DESCRIPTION
…ference types."

This patch reduces deserializing of lazy template specializations from the PCH as it reduces the hash collisions (now we distinguish between pointer and reference types).