### PR TITLE
[TDF] Fix bogus warning in gcc6.2

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
@@ -750,6 +750,7 @@ public:
                          0)...,
                         0};
       (void)expander; // avoid unused variable warnings for older compilers such as gcc 4.9
+      (void)slot;     // avoid unused variable warnings in gcc6.2
    }
 
    void Finalize()


### PR DESCRIPTION
This warning was first seen in rootbench:

```c++
root-benchmark/BUILDTYPE/Release/COMPILER/gcc62/LABEL/performance-cc7/build/include/ROOT/TDFActionHelpers.hxx:745:34:
warning: parameter ‘slot’ set but not used [-Wunused-but-set-parameter]
    void SetBranches(unsigned int slot, BranchTypes&... values, StaticSeq<S...> /*dummy*/)
                                  ^~~~
```