### PR TITLE
Revert "Insure TTreeCloner keep the AutoFlush history."

### DIFF
--- a/tree/tree/src/TTreeCloner.cxx
+++ b/tree/tree/src/TTreeCloner.cxx
@@ -640,11 +640,6 @@ void TTreeCloner::ImportClusterRanges()
 
    fToTree->ImportClusterRanges( fFromTree->GetTree() );
 
-   // This is only updated by TTree::Fill upon seeing a Flush event in TTree::Fill
-   // So we need to propagate (this has also the advantage of turning on the
-   // history recording feature of SetAutoFlush for the next iteration)
-   fToTree->fFlushedBytes += fFromTree->fFlushedBytes;
-
    fToTree->SetEntries(fToTree->GetEntries() + fFromTree->GetTree()->GetEntries());
 }
 


### PR DESCRIPTION
This reverts commit 6657223efbc8d356fe3103c7010922dded6791a2.
It caused [failures](http://cdash.cern.ch/testDetails.php?test=40653603&build=483771)
in gtest-tree-treeplayer-test-dataframe-snapshot (see discussion at #1800 ).