### PR TITLE
Derived TBufferSQL from TBufferText

### DIFF
--- a/tree/tree/inc/TBufferSQL.h
+++ b/tree/tree/inc/TBufferSQL.h
@@ -39,10 +39,50 @@ private:
    TBufferSQL(const TBufferSQL &);        // not implemented
    void operator=(const TBufferSQL &);    // not implemented
 
+protected:
+
+   virtual void WriteObjectClass(const void *actualObjStart, const TClass *actualClass, Bool_t cacheReuse);
+
+   template <typename T>
+   R__ALWAYS_INLINE void SqlWriteArray(const T *vname, Int_t n)
+   {
+      WriteInt(n);
+      WriteFastArray(vname, n);
+   }
+
+   template <typename T>
+   R__ALWAYS_INLINE Int_t SqlReadArray(T *&vname, Bool_t st = kFALSE)
+   {
+      Int_t n = 0;
+      ReadInt(n);
+      if (n && !vname && !st) vname = new T[n];
+      ReadFastArray(vname, n);
+      return n;
+   }
+
 public:
    TBufferSQL() = default;
-   TBufferSQL(TBuffer::EMode mode, std::vector<Int_t> *vc, TString *insert_query, TSQLRow **rowPtr);
+   TBufferSQL(TBuffer::EMode mode, Int_t bufsiz, std::vector<Int_t> *vc, TString *insert_query, TSQLRow **rowPtr);
    ~TBufferSQL();
+
+   // suppress TBuffer not used TBuffer methods
+
+   virtual TClass *ReadClass(const TClass *cl = nullptr, UInt_t *objTag = nullptr);
+   virtual void WriteClass(const TClass *cl);
+   virtual Version_t ReadVersion(UInt_t *start = nullptr, UInt_t *bcnt = nullptr, const TClass *cl = nullptr);
+   virtual UInt_t WriteVersion(const TClass *cl, Bool_t useBcnt = kFALSE);
+   virtual void *ReadObjectAny(const TClass *clCast);
+   virtual void SkipObjectAny();
+   virtual void IncrementLevel(TVirtualStreamerInfo *);
+   virtual TVirtualStreamerInfo *GetInfo();
+   virtual void SetStreamerElementNumber(TStreamerElement *elem, Int_t comp_type);
+   virtual void DecrementLevel(TVirtualStreamerInfo *);
+   virtual void ClassBegin(const TClass *, Version_t = -1);
+   virtual void ClassEnd(const TClass *);
+   virtual void ClassMember(const char *name, const char *typeName = nullptr, Int_t arrsize1 = -1, Int_t arrsize2 = -1);
+   virtual void StreamObject(void *obj, const TClass *cl, const TClass *onFileClass = nullptr);
+   using TBufferText::StreamObject;
+
 
    void ResetOffset();
 
@@ -83,6 +123,48 @@ public:
    virtual   void     WriteStdString(const std::string *s);
    using              TBuffer::WriteStdString;
    virtual   void     WriteCharStar(char *s);
+
+   virtual   void     WriteArray(const Bool_t *b, Int_t n) { SqlWriteArray(b, n); }
+   virtual   void     WriteArray(const Char_t *c, Int_t n) { SqlWriteArray(c, n); }
+   virtual   void     WriteArray(const UChar_t *c, Int_t n) { SqlWriteArray(c, n); }
+   virtual   void     WriteArray(const Short_t *h, Int_t n) { SqlWriteArray(h, n); }
+   virtual   void     WriteArray(const UShort_t *h, Int_t n)  { SqlWriteArray(h, n); }
+   virtual   void     WriteArray(const Int_t *i, Int_t n)  { SqlWriteArray(i, n); }
+   virtual   void     WriteArray(const UInt_t *i, Int_t n)  { SqlWriteArray(i, n); }
+   virtual   void     WriteArray(const Long_t *l, Int_t n)  { SqlWriteArray(l, n); }
+   virtual   void     WriteArray(const ULong_t *l, Int_t n)  { SqlWriteArray(l, n); }
+   virtual   void     WriteArray(const Long64_t *l, Int_t n)  { SqlWriteArray(l, n); }
+   virtual   void     WriteArray(const ULong64_t *l, Int_t n)  { SqlWriteArray(l, n); }
+   virtual   void     WriteArray(const Float_t *f, Int_t n)  { SqlWriteArray(f, n); }
+   virtual   void     WriteArray(const Double_t *d, Int_t n)  { SqlWriteArray(d, n); }
+
+   virtual   Int_t    ReadArray(Bool_t *&b) { return SqlReadArray(b); }
+   virtual   Int_t    ReadArray(Char_t *&c) { return SqlReadArray(c); }
+   virtual   Int_t    ReadArray(UChar_t *&c)  { return SqlReadArray(c); }
+   virtual   Int_t    ReadArray(Short_t *&h)  { return SqlReadArray(h); }
+   virtual   Int_t    ReadArray(UShort_t *&h)  { return SqlReadArray(h); }
+   virtual   Int_t    ReadArray(Int_t *&i)  { return SqlReadArray(i); }
+   virtual   Int_t    ReadArray(UInt_t *&i)  { return SqlReadArray(i); }
+   virtual   Int_t    ReadArray(Long_t *&l)  { return SqlReadArray(l); }
+   virtual   Int_t    ReadArray(ULong_t *&l)  { return SqlReadArray(l); }
+   virtual   Int_t    ReadArray(Long64_t *&l)  { return SqlReadArray(l); }
+   virtual   Int_t    ReadArray(ULong64_t *&l)  { return SqlReadArray(l); }
+   virtual   Int_t    ReadArray(Float_t *&f)  { return SqlReadArray(f); }
+   virtual   Int_t    ReadArray(Double_t *&d)  { return SqlReadArray(d); }
+
+   virtual   Int_t    ReadStaticArray(Bool_t *b) { return SqlReadArray(b, kTRUE); }
+   virtual   Int_t    ReadStaticArray(Char_t *c) { return SqlReadArray(c, kTRUE); }
+   virtual   Int_t    ReadStaticArray(UChar_t *c) { return SqlReadArray(c, kTRUE); }
+   virtual   Int_t    ReadStaticArray(Short_t *h) { return SqlReadArray(h, kTRUE); }
+   virtual   Int_t    ReadStaticArray(UShort_t *h) { return SqlReadArray(h, kTRUE); }
+   virtual   Int_t    ReadStaticArray(Int_t *i) { return SqlReadArray(i, kTRUE); }
+   virtual   Int_t    ReadStaticArray(UInt_t *i) { return SqlReadArray(i, kTRUE); }
+   virtual   Int_t    ReadStaticArray(Long_t *l) { return SqlReadArray(l, kTRUE); }
+   virtual   Int_t    ReadStaticArray(ULong_t *l) { return SqlReadArray(l, kTRUE); }
+   virtual   Int_t    ReadStaticArray(Long64_t *l) { return SqlReadArray(l, kTRUE); }
+   virtual   Int_t    ReadStaticArray(ULong64_t *l) { return SqlReadArray(l, kTRUE); }
+   virtual   Int_t    ReadStaticArray(Float_t *f) { return SqlReadArray(f, kTRUE); }
+   virtual   Int_t    ReadStaticArray(Double_t *d) { return SqlReadArray(d, kTRUE); }
 
    virtual   void     WriteFastArray(const Bool_t    *b, Int_t n);
    virtual   void     WriteFastArray(const Char_t    *c, Int_t n);

--- a/tree/tree/inc/TBufferSQL.h
+++ b/tree/tree/inc/TBufferSQL.h
@@ -20,31 +20,28 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-#include "TBufferFile.h"
+#include "TBufferText.h"
 #include "TString.h"
-
 
 class TSQLResult;
 class TSQLRow;
 
-class TBufferSQL : public TBufferFile {
+class TBufferSQL : public TBufferText {
 
 private:
    std::vector<Int_t>::const_iterator fIter;
 
-   std::vector<Int_t>  *fColumnVec;   //!
-   TString             *fInsertQuery; //!
-   TSQLRow            **fRowPtr;      //!
+   std::vector<Int_t>  *fColumnVec{nullptr};   //!
+   TString             *fInsertQuery{nullptr}; //!
+   TSQLRow            **fRowPtr{nullptr};      //!
 
    // TBuffer objects cannot be copied or assigned
    TBufferSQL(const TBufferSQL &);        // not implemented
    void operator=(const TBufferSQL &);    // not implemented
 
 public:
-   TBufferSQL();
+   TBufferSQL() = default;
    TBufferSQL(TBuffer::EMode mode, std::vector<Int_t> *vc, TString *insert_query, TSQLRow **rowPtr);
-   TBufferSQL(TBuffer::EMode mode, Int_t bufsiz, std::vector<Int_t> *vc, TString *insert_query, TSQLRow **rowPtr);
-   TBufferSQL(TBuffer::EMode mode, Int_t bufsiz, std::vector<Int_t> *vc, TString *insert_query, TSQLRow **rowPtr,void *buf, Bool_t adopt = kTRUE);
    ~TBufferSQL();
 
    void ResetOffset();
@@ -101,8 +98,8 @@ public:
    virtual   void     WriteFastArray(const ULong64_t *l, Int_t n);
    virtual   void     WriteFastArray(const Float_t   *f, Int_t n);
    virtual   void     WriteFastArray(const Double_t  *d, Int_t n);
-   virtual   void     WriteFastArray(void  *start,  const TClass *cl, Int_t n=1, TMemberStreamer *s=0);
-   virtual   Int_t    WriteFastArray(void **startp, const TClass *cl, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s=0);
+   virtual   void     WriteFastArray(void  *start,  const TClass *cl, Int_t n=1, TMemberStreamer *s=nullptr);
+   virtual   Int_t    WriteFastArray(void **startp, const TClass *cl, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s=nullptr);
 
    virtual   void     ReadFastArray(Bool_t    *, Int_t );
    virtual   void     ReadFastArray(Char_t    *, Int_t );
@@ -118,14 +115,8 @@ public:
    virtual   void     ReadFastArray(ULong64_t *, Int_t );
    virtual   void     ReadFastArray(Float_t   *, Int_t );
    virtual   void     ReadFastArray(Double_t  *, Int_t );
-   virtual   void     ReadFastArrayFloat16(Float_t  *f, Int_t n, TStreamerElement *ele=0);
-   virtual   void     ReadFastArrayDouble32(Double_t  *d, Int_t n, TStreamerElement *ele=0);
-   virtual   void     ReadFastArrayWithFactor(Float_t *ptr, Int_t n, Double_t factor, Double_t minvalue) ;
-   virtual   void     ReadFastArrayWithNbits(Float_t *ptr, Int_t n, Int_t nbits);
-   virtual   void     ReadFastArrayWithFactor(Double_t *ptr, Int_t n, Double_t factor, Double_t minvalue);
-   virtual   void     ReadFastArrayWithNbits(Double_t *ptr, Int_t n, Int_t nbits) ;
-   virtual   void     ReadFastArray(void  *, const TClass *, Int_t n=1, TMemberStreamer *s=0, const TClass *onFileClass=0);
-   virtual   void     ReadFastArray(void **, const TClass *, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s=0, const TClass *onFileClass=0);
+   virtual   void     ReadFastArray(void  *, const TClass *, Int_t n=1, TMemberStreamer *s=nullptr, const TClass *onFileClass=nullptr);
+   virtual   void     ReadFastArray(void **, const TClass *, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s=nullptr, const TClass *onFileClass=nullptr);
 
    ClassDef(TBufferSQL, 0); // Implementation of TBuffer to load and write to a SQL database
 

--- a/tree/tree/src/TBasketSQL.cxx
+++ b/tree/tree/src/TBasketSQL.cxx
@@ -9,16 +9,12 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#ifndef TBASKETSQL_CXX
-#define TBASKETSQL_CXX
+#include "TBasketSQL.h"
 
-#include "TBasket.h"
-#include "TBuffer.h"
 #include "TTree.h"
 #include "TBranch.h"
 #include "TFile.h"
 #include "TMath.h"
-#include "TBasketSQL.h"
 #include <Riostream.h>
 #include <vector>
 #include "TTreeSQL.h"
@@ -26,7 +22,7 @@
 
 ClassImp(TBasketSQL);
 
-namespace std {} using namespace std;
+using namespace std;
 
 /** \class TBasketSQL
 \ingroup tree
@@ -102,7 +98,7 @@ void TBasketSQL::CreateBuffer(const char *name, TString title,
 
    if(vc==0) {
       fBufferRef = 0;
-      Error("CreateBuffer","Need a vector of columns\n");
+      Error("CreateBuffer","Need a vector of columns");
    } else {
       fBufferRef   = new TBufferSQL(TBuffer::kWrite, fBufferSize, vc, fInsertQuery, fRowPtr);
    }
@@ -158,5 +154,3 @@ void TBasketSQL::Update(Int_t, Int_t)
    ((TBufferSQL*)fBufferRef)->ResetOffset();
    fNevBuf++;
 }
-
-#endif

--- a/tree/tree/src/TBufferSQL.cxx
+++ b/tree/tree/src/TBufferSQL.cxx
@@ -17,24 +17,25 @@ Implement TBuffer for a SQL backend.
 #include "TBufferSQL.h"
 
 #include <stdio.h>
+#include <stdlib.h>
+
 #include "Riostream.h"
 #include "TError.h"
 
-#include "TBasketSQL.h"
 #include "TSQLResult.h"
 #include "TSQLRow.h"
-#include <stdlib.h>
 
 ClassImp(TBufferSQL);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor.
 
-TBufferSQL::TBufferSQL(TBuffer::EMode mode, std::vector<Int_t> *vc,
+TBufferSQL::TBufferSQL(TBuffer::EMode mode, Int_t bufsiz, std::vector<Int_t> *vc,
                        TString *insert_query, TSQLRow ** r) :
    TBufferText(mode),
    fColumnVec(vc), fInsertQuery(insert_query), fRowPtr(r)
 {
+   fBufSize = bufsiz;
    fIter = fColumnVec->begin();
 }
 
@@ -44,6 +45,117 @@ TBufferSQL::TBufferSQL(TBuffer::EMode mode, std::vector<Int_t> *vc,
 TBufferSQL::~TBufferSQL()
 {
    delete fColumnVec;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// suppressed function of TBuffer
+
+TClass *TBufferSQL::ReadClass(const TClass *, UInt_t *)
+{
+   return nullptr;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// suppressed function of TBuffer
+
+void TBufferSQL::WriteClass(const TClass *)
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// suppressed function of TBuffer
+
+Version_t TBufferSQL::ReadVersion(UInt_t *, UInt_t *, const TClass *)
+{
+   return 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// suppressed function of TBuffer
+
+UInt_t TBufferSQL::WriteVersion(const TClass * /*cl*/, Bool_t /* useBcnt */)
+{
+   return 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// suppressed function of TBuffer
+
+void *TBufferSQL::ReadObjectAny(const TClass *)
+{
+   return nullptr;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// suppressed function of TBuffer
+
+void TBufferSQL::SkipObjectAny()
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// suppressed function of TBuffer
+
+void TBufferSQL::IncrementLevel(TVirtualStreamerInfo *)
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// suppressed function of TBuffer
+
+void TBufferSQL::DecrementLevel(TVirtualStreamerInfo *)
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Return current streamer info element
+
+TVirtualStreamerInfo *TBufferSQL::GetInfo()
+{
+   return nullptr;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// suppressed function of TBuffer
+
+void TBufferSQL::SetStreamerElementNumber(TStreamerElement *, Int_t)
+{
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// suppressed function of TBuffer
+
+void TBufferSQL::ClassBegin(const TClass *, Version_t)
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// suppressed function of TBuffer
+
+void TBufferSQL::ClassEnd(const TClass *)
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// suppressed function of TBuffer
+
+void TBufferSQL::ClassMember(const char *, const char *, Int_t, Int_t)
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// stream object to/from buffer
+
+void TBufferSQL::StreamObject(void *, const TClass *, const TClass *)
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// suppressed function of TBuffer
+
+void TBufferSQL::WriteObjectClass(const void *, const TClass *, Bool_t)
+{
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -681,7 +793,7 @@ void TBufferSQL::ReadFastArray(UShort_t *us, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// ReadFastArray SQL implementation.
 
-void     TBufferSQL::ReadFastArray(Int_t *in, Int_t n)
+void TBufferSQL::ReadFastArray(Int_t *in, Int_t n)
 {
    for(int i=0; i<n; ++i) {
       in[i] = atoi((*fRowPtr)->GetField(*fIter));
@@ -692,7 +804,7 @@ void     TBufferSQL::ReadFastArray(Int_t *in, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// ReadFastArray SQL implementation.
 
-void     TBufferSQL::ReadFastArray(UInt_t *ui, Int_t n)
+void TBufferSQL::ReadFastArray(UInt_t *ui, Int_t n)
 {
    for(int i=0; i<n; ++i) {
       ui[i] = atoi((*fRowPtr)->GetField(*fIter));
@@ -766,7 +878,7 @@ void TBufferSQL::ReadFastArray(Double_t *d, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// ReadFastArray SQL implementation.
 
-void     TBufferSQL::ReadFastArray(void  *, const TClass *, Int_t, TMemberStreamer *, const TClass *)
+void TBufferSQL::ReadFastArray(void *, const TClass *, Int_t, TMemberStreamer *, const TClass *)
 {
    Fatal("ReadFastArray(void  *, const TClass *, Int_t, TMemberStreamer *, const TClass *)","Not implemented yet");
 }
@@ -774,7 +886,7 @@ void     TBufferSQL::ReadFastArray(void  *, const TClass *, Int_t, TMemberStream
 ////////////////////////////////////////////////////////////////////////////////
 /// ReadFastArray SQL implementation.
 
-void     TBufferSQL::ReadFastArray(void **, const TClass *, Int_t, Bool_t, TMemberStreamer *, const TClass *)
+void TBufferSQL::ReadFastArray(void **, const TClass *, Int_t, Bool_t, TMemberStreamer *, const TClass *)
 {
    Fatal("ReadFastArray(void **, const TClass *, Int_t, Bool_t, TMemberStreamer *, const TClass *)","Not implemented yet");
 }


### PR DESCRIPTION
Use TBufferText instead of TBufferFile as base class for TBufferSQL

One can benefit from some definitions, done in TBufferText.
For instance, one could use configurable float format there in the future.

From other side, it is not really necessary. TBufferSQL works only with TBasketSQL and basic data types. Seems to be, object streaming not supported anyway