### PR TITLE
Add a barrier to PI at the startup time

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1263,6 +1263,11 @@ TCling::TCling(const char *name, const char *title)
       // Check that the gROOT macro was exported by any core module.
       assert(fInterpreter->getMacro("gROOT") && "Couldn't load gROOT macro?");
 
+      // When R binding is enabled and R related headers are loaded, these header
+      // files include Constants.h, which defines PI macro. It screw up every user's code
+      // containing PI.
+      fInterpreter->declare("#ifdef PI\n #undef PI\n #endif\n");
+
       // C99 decided that it's a very good idea to name a macro `I` (the letter I).
       // This seems to screw up nearly all the template code out there as `I` is
       // common template parameter name and iterator variable name.


### PR DESCRIPTION
In ROOT, we should be able to lookup global variables, macros, and functions defined in external AST source. (For example gROOT, std::vector..)

When R binding is On, we import R related header files such as TRInterface.h and RExports.h. These header files include Constants.h, which defines `PI` like this:

```
 # define M_PI           3.14159265358979323846  /* pi */
 # define PI             M_PI
```

In theory, we should be able to lookup this as well, but rootmap files are
broken and it doesn't have information about macros. So what happened
were tutorials define PI by themselves (which is conflicting with above
    definition) but ROOT didn't emit errors.

In modules, we're trying to preload modules so that we don't miss these namespaces and macros. PI is also visible from ROOT and
treated as a macro, so users don't have to define it themselves.