### PR TITLE
[TDF] Use std::index_sequence instead of TDF::StaticSeq

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
@@ -20,13 +20,14 @@
 #include <vector>
 
 #include "Compression.h"
+#include "ROOT/RIntegerSequence.hxx"
+#include "ROOT/RStringView.hxx"
 #include "ROOT/TVec.hxx"
 #include "ROOT/TBufferMerger.hxx" // for SnapshotHelper
 #include "ROOT/TDFUtils.hxx"
 #include "ROOT/TSnapshotOptions.hxx"
 #include "ROOT/TThreadedObject.hxx"
 #include "ROOT/TypeTraits.hxx"
-#include "ROOT/RStringView.hxx"
 #include "RtypesCore.h"
 #include "TBranch.h"
 #include "TClassEdit.h"
@@ -647,14 +648,14 @@ public:
    void Exec(unsigned int /* slot */, BranchTypes&... values)
    {
       if (fIsFirstEvent) {
-         using ind_t = GenStaticSeq_t<sizeof...(BranchTypes)>;
+         using ind_t = std::index_sequence_for<BranchTypes...>;
          SetBranches(values..., ind_t());
       }
       fOutputTree->Fill();
    }
 
-   template <int... S>
-   void SetBranches(BranchTypes&... values, StaticSeq<S...> /*dummy*/)
+   template <std::size_t... S>
+   void SetBranches(BranchTypes&... values, std::index_sequence<S...> /*dummy*/)
    {
       // call TTree::Branch on all variadic template arguments
       int expander[] = {
@@ -730,7 +731,7 @@ public:
    void Exec(unsigned int slot, BranchTypes&... values)
    {
       if (fIsFirstEvent[slot]) {
-         using ind_t = GenStaticSeq_t<sizeof...(BranchTypes)>;
+         using ind_t = std::index_sequence_for<BranchTypes...>;
          SetBranches(slot, values..., ind_t());
          fIsFirstEvent[slot] = 0;
       }
@@ -741,8 +742,8 @@ public:
          fOutputFiles[slot]->Write();
    }
 
-   template <int... S>
-   void SetBranches(unsigned int slot, BranchTypes&... values, StaticSeq<S...> /*dummy*/)
+   template <std::size_t... S>
+   void SetBranches(unsigned int slot, BranchTypes&... values, std::index_sequence<S...> /*dummy*/)
    {
       // hack to call TTree::Branch on all variadic template arguments
       int expander[] = {(SetBranchesHelper(fInputTrees[slot], *fOutputTrees[slot], fInputBranchNames[S],

--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -24,6 +24,7 @@
 #include <typeinfo>
 #include <vector>
 
+#include "ROOT/RIntegerSequence.hxx"
 #include "ROOT/RStringView.hxx"
 #include "ROOT/TCutFlowReport.hxx"
 #include "ROOT/TDFActionHelpers.hxx"
@@ -171,7 +172,7 @@ public:
       const auto validColumnNames =
          TDFInternal::GetValidatedColumnNames(*loopManager, nColumns, columns, fValidCustomColumns, fDataSource);
       if (fDataSource)
-         TDFInternal::DefineDataSourceColumns(validColumnNames, *loopManager, TDFInternal::GenStaticSeq_t<nColumns>(),
+         TDFInternal::DefineDataSourceColumns(validColumnNames, *loopManager, std::make_index_sequence<nColumns>(),
                                               ColTypes_t(), *fDataSource);
       using F_t = TDFDetail::TFilter<F, Proxied>;
       auto FilterPtr = std::make_shared<F_t>(std::move(f), validColumnNames, *fProxiedPtr, name);
@@ -455,7 +456,7 @@ public:
    template <typename... BranchTypes>
    TInterface<TLoopManager> Cache(const ColumnNames_t &columnList)
    {
-      auto staticSeq = TDFInternal::GenStaticSeq_t<sizeof...(BranchTypes)>();
+      auto staticSeq = std::make_index_sequence<sizeof...(BranchTypes)>();
       return CacheImpl<BranchTypes...>(columnList, staticSeq);
    }
 
@@ -600,7 +601,7 @@ public:
       const auto validColumnNames =
          TDFInternal::GetValidatedColumnNames(*loopManager, nColumns, columns, fValidCustomColumns, fDataSource);
       if (fDataSource)
-         TDFInternal::DefineDataSourceColumns(validColumnNames, *loopManager, TDFInternal::GenStaticSeq_t<nColumns>(),
+         TDFInternal::DefineDataSourceColumns(validColumnNames, *loopManager, std::make_index_sequence<nColumns>(),
                                               ColTypes_t(), *fDataSource);
       using Helper_t = TDFInternal::ForeachSlotHelper<F>;
       using Action_t = TDFInternal::TAction<Helper_t, Proxied>;
@@ -693,7 +694,7 @@ public:
       const auto validColumnNames =
          TDFInternal::GetValidatedColumnNames(*loopManager, 1, columns, fValidCustomColumns, fDataSource);
       if (fDataSource)
-         TDFInternal::DefineDataSourceColumns(validColumnNames, *loopManager, TDFInternal::GenStaticSeq_t<1>(),
+         TDFInternal::DefineDataSourceColumns(validColumnNames, *loopManager, std::make_index_sequence<1>(),
                                               TTraits::TypeList<T>(), *fDataSource);
 
       using RealT_t = typename TDFDetail::TTakeRealTypes<T, COLL>::RealT_t;
@@ -1323,7 +1324,7 @@ public:
       const auto validColumnNames =
          TDFInternal::GetValidatedColumnNames(*loopManager, 1, columns, fValidCustomColumns, fDataSource);
       if (fDataSource)
-         TDFInternal::DefineDataSourceColumns(validColumnNames, *loopManager, TDFInternal::GenStaticSeq_t<nColumns>(),
+         TDFInternal::DefineDataSourceColumns(validColumnNames, *loopManager, std::make_index_sequence<nColumns>(),
                                               ArgTypes(), *fDataSource);
       auto accObjPtr = std::make_shared<U>(aggIdentity);
       using Helper_t = TDFInternal::AggregateHelper<AccFun, MergeFun, R, T, U>;
@@ -1471,7 +1472,7 @@ private:
       const auto selectedCols =
          TDFInternal::GetValidatedColumnNames(*lm, nColumns, columns, fValidCustomColumns, fDataSource);
       if (fDataSource)
-         TDFInternal::DefineDataSourceColumns(selectedCols, *lm, TDFInternal::GenStaticSeq_t<nColumns>(),
+         TDFInternal::DefineDataSourceColumns(selectedCols, *lm, std::make_index_sequence<nColumns>(),
                                               TDFInternal::TypeList<BranchTypes...>(), *fDataSource);
       const auto nSlots = fProxiedPtr->GetNSlots();
       auto actionPtr =
@@ -1528,7 +1529,7 @@ private:
       const auto validColumnNames =
          TDFInternal::GetValidatedColumnNames(*loopManager, nColumns, columns, fValidCustomColumns, fDataSource);
       if (fDataSource)
-         TDFInternal::DefineDataSourceColumns(validColumnNames, *loopManager, TDFInternal::GenStaticSeq_t<nColumns>(),
+         TDFInternal::DefineDataSourceColumns(validColumnNames, *loopManager, std::make_index_sequence<nColumns>(),
                                               ColTypes_t(), *fDataSource);
       using NewCol_t = TDFDetail::TCustomColumn<F, ExtraArgs>;
 
@@ -1576,7 +1577,7 @@ private:
          TDFInternal::GetValidatedColumnNames(*df, columnList.size(), columnList, fValidCustomColumns, fDataSource);
 
       if (fDataSource)
-         TDFInternal::DefineDataSourceColumns(validCols, *df, TDFInternal::GenStaticSeq_t<sizeof...(BranchTypes)>(),
+         TDFInternal::DefineDataSourceColumns(validCols, *df, std::index_sequence_for<BranchTypes...>(),
                                               TTraits::TypeList<BranchTypes...>(), *fDataSource);
 
       const std::string fullTreename(treename);
@@ -1621,8 +1622,8 @@ private:
 
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Implementation of cache
-   template <typename... BranchTypes, int... S>
-   TInterface<TLoopManager> CacheImpl(const ColumnNames_t &columnList, TDFInternal::StaticSeq<S...> s)
+   template <typename... BranchTypes, std::size_t... S>
+   TInterface<TLoopManager> CacheImpl(const ColumnNames_t &columnList, std::index_sequence<S...> s)
    {
 
       // Check at compile time that the columns types are copy constructible

--- a/tree/treeplayer/inc/ROOT/TDFInterfaceUtils.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterfaceUtils.hxx
@@ -11,12 +11,13 @@
 #ifndef ROOT_TDF_TINTERFACE_UTILS
 #define ROOT_TDF_TINTERFACE_UTILS
 
+#include <ROOT/RIntegerSequence.hxx>
+#include <ROOT/RStringView.hxx>
 #include <ROOT/TDFActionHelpers.hxx> // for BuildAndBook
 #include <ROOT/TDFNodes.hxx>
 #include <ROOT/TDFUtils.hxx>
 #include <ROOT/TypeTraits.hxx>
 #include <ROOT/TSeq.hxx>
-#include <ROOT/RStringView.hxx>
 #include <algorithm>
 #include <deque>
 #include <functional>
@@ -262,8 +263,8 @@ void DefineDSColumnHelper(std::string_view name, TLoopManager &lm, TDataSource &
 }
 
 /// Take a list of data-source column names and define the ones that haven't been defined yet.
-template <typename... ColumnTypes, int... S>
-void DefineDataSourceColumns(const std::vector<std::string> &columns, TLoopManager &lm, StaticSeq<S...>,
+template <typename... ColumnTypes, std::size_t... S>
+void DefineDataSourceColumns(const std::vector<std::string> &columns, TLoopManager &lm, std::index_sequence<S...>,
                              TTraits::TypeList<ColumnTypes...>, TDataSource &ds)
 {
    const auto mustBeDefined = FindUndefinedDSColumns(columns, lm.GetCustomColumnNames());
@@ -290,7 +291,7 @@ void CallBuildAndBook(PrevNodeType &prevNode, const ColumnNames_t &bl, const uns
    constexpr auto nColumns = ColTypes_t::list_size;
    auto ds = loopManager.GetDataSource();
    if (ds)
-      DefineDataSourceColumns(bl, loopManager, GenStaticSeq_t<nColumns>(), ColTypes_t(), *ds);
+      DefineDataSourceColumns(bl, loopManager, std::make_index_sequence<nColumns>(), ColTypes_t(), *ds);
    TActionBase *actionPtr =
       BuildAndBook<BranchTypes...>(bl, *rOnHeap, nSlots, loopManager, prevNode, (ActionType *)nullptr);
    **actionPtrPtrOnHeap = actionPtr;

--- a/tree/treeplayer/inc/ROOT/TDFNodesUtils.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFNodesUtils.hxx
@@ -11,6 +11,7 @@
 #ifndef ROOT_TDFNODES_UTILS
 #define ROOT_TDFNODES_UTILS
 
+#include "ROOT/RIntegerSequence.hxx"
 #include "ROOT/TVec.hxx"
 #include "ROOT/TDFUtils.hxx" // ColumnNames_t
 
@@ -40,10 +41,11 @@ using ReaderValueOrArray_t = typename TReaderValueOrArray<T>::Proxy_t;
 /// For real TTree branches a TTreeReader{Array,Value} is built and passed to the
 /// TColumnValue. For temporary columns a pointer to the corresponding variable
 /// is passed instead.
-template <typename TDFValueTuple, int... S>
+template <typename TDFValueTuple, std::size_t... S>
 void InitTDFValues(unsigned int slot, TDFValueTuple &valueTuple, TTreeReader *r, const ColumnNames_t &bn,
                    const ColumnNames_t &tmpbn,
-                   const std::map<std::string, std::shared_ptr<TCustomColumnBase>> &customCols, StaticSeq<S...>)
+                   const std::map<std::string, std::shared_ptr<TCustomColumnBase>> &customCols,
+                   std::index_sequence<S...>)
 {
    // isTmpBranch has length bn.size(). Elements are true if the corresponding
    // branch is a temporary branch created with Define, false if they are

--- a/tree/treeplayer/inc/ROOT/TDFUtils.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFUtils.hxx
@@ -68,25 +68,6 @@ struct IsVector_t : public std::false_type {};
 template <typename T, typename A>
 struct IsVector_t<std::vector<T, A>> : public std::true_type {};
 
-/// Compile-time integer sequence generator
-/// e.g. calling GenStaticSeq<3>::type() instantiates a StaticSeq<0,1,2>
-// TODO substitute all usages of StaticSeq and GenStaticSeq with std::index_sequence when it becomes available
-template <int...>
-struct StaticSeq {
-};
-
-template <int N, int... S>
-struct GenStaticSeq : GenStaticSeq<N - 1, N - 1, S...> {
-};
-
-template <int... S>
-struct GenStaticSeq<0, S...> {
-   using type = StaticSeq<S...>;
-};
-
-template <int... S>
-using GenStaticSeq_t = typename GenStaticSeq<S...>::type;
-
 const std::type_info &TypeName2TypeID(const std::string &name);
 
 std::string TypeID2TypeName(const std::type_info &id);


### PR DESCRIPTION
ROOT's backport of std::index_sequence has O(logN) instantiation
depth, versus StaticSeq's O(N). This guarantees that very large
sequences can be instantiated without exceeding default template
instantiation depths (900 for gcc, 1024 for clang).
std::index_sequence has also noticeably faster compile times.

To be merged after #1823 