### PR TITLE
[TDF] Extend TDataSource API to allow skipping of entries

### DIFF
--- a/README/ReleaseNotes/v614/index.md
+++ b/README/ReleaseNotes/v614/index.md
@@ -74,6 +74,7 @@ Since we loop over all the branches for each new entry all the baskets for a clu
      ```
 
 #### New features
+   - The TDataSource interface changed. The `TDataSource::SetEntry` method now returns a boolean. If true the entry is processed within the event loop managed by the tdf, skipped otherwise.
    - The TLazyDS data source has been added. It allows to create a source starting from ResultProxies to vectors.
    - `TDataFrameInterface<T>::Report` returns a `TCutflowReport` object which can be inspected programmatically.
    - Add `Aggregate` action and implement `Reduce` in terms of it.

--- a/tree/treeplayer/inc/ROOT/TArrowDS.hxx
+++ b/tree/treeplayer/inc/ROOT/TArrowDS.hxx
@@ -38,7 +38,7 @@ public:
    std::vector<std::pair<ULong64_t, ULong64_t>> GetEntryRanges() override;
    std::string GetTypeName(std::string_view colName) const override;
    bool HasColumn(std::string_view colName) const override;
-   void SetEntry(unsigned int slot, ULong64_t entry) override;
+   bool SetEntry(unsigned int slot, ULong64_t entry) override;
    void InitSlot(unsigned int slot, ULong64_t firstEntry) override;
    void SetNSlots(unsigned int nSlots) override;
    void Initialise() override;

--- a/tree/treeplayer/inc/ROOT/TCsvDS.hxx
+++ b/tree/treeplayer/inc/ROOT/TCsvDS.hxx
@@ -67,7 +67,7 @@ public:
    std::vector<std::pair<ULong64_t, ULong64_t>> GetEntryRanges();
    std::string GetTypeName(std::string_view colName) const;
    bool HasColumn(std::string_view colName) const;
-   void SetEntry(unsigned int slot, ULong64_t entry);
+   bool SetEntry(unsigned int slot, ULong64_t entry);
    void SetNSlots(unsigned int nSlots);
    void Initialise();
 };

--- a/tree/treeplayer/inc/ROOT/TDataSource.hxx
+++ b/tree/treeplayer/inc/ROOT/TDataSource.hxx
@@ -149,8 +149,9 @@ public:
    /// \param[in] entry The entry which needs to be pointed to by the reader pointers
    /// Slots are adopted to accommodate parallel data processing. Different workers will loop over different ranges and
    /// will be labelled by different "slot" values.
+   /// Returns *true* if the entry has to be processed, *false* otherwise.
    // clang-format on
-   virtual void SetEntry(unsigned int slot, ULong64_t entry) = 0;
+   virtual bool SetEntry(unsigned int slot, ULong64_t entry) = 0;
 
    // clang-format off
    /// \brief Convenience method called before starting an event-loop.

--- a/tree/treeplayer/inc/ROOT/TLazyDS.hxx
+++ b/tree/treeplayer/inc/ROOT/TLazyDS.hxx
@@ -151,9 +151,10 @@ public:
       return endIt != fColTypesMap.find(key);
    }
 
-   void SetEntry(unsigned int slot, ULong64_t entry)
+   bool SetEntry(unsigned int slot, ULong64_t entry)
    {
       SetEntryHelper(slot, entry, std::index_sequence_for<ColumnTypes...>());
+      return true;
    }
 
    void SetNSlots(unsigned int nSlots)

--- a/tree/treeplayer/inc/ROOT/TRootDS.hxx
+++ b/tree/treeplayer/inc/ROOT/TRootDS.hxx
@@ -34,7 +34,7 @@ public:
    void InitSlot(unsigned int slot, ULong64_t firstEntry);
    void FinaliseSlot(unsigned int slot);
    std::vector<std::pair<ULong64_t, ULong64_t>> GetEntryRanges();
-   void SetEntry(unsigned int slot, ULong64_t entry);
+   bool SetEntry(unsigned int slot, ULong64_t entry);
    void SetNSlots(unsigned int nSlots);
    void Initialise();
 };

--- a/tree/treeplayer/inc/ROOT/TTrivialDS.hxx
+++ b/tree/treeplayer/inc/ROOT/TTrivialDS.hxx
@@ -12,6 +12,7 @@ class TTrivialDS final : public ROOT::Experimental::TDF::TDataSource {
 private:
    unsigned int fNSlots = 0U;
    ULong64_t fSize = 0ULL;
+   bool fSkipEvenEntries = false;
    std::vector<std::pair<ULong64_t, ULong64_t>> fEntryRanges;
    std::vector<std::string> fColNames{"col0"};
    std::vector<ULong64_t> fCounter;
@@ -19,18 +20,18 @@ private:
    std::vector<void *> GetColumnReadersImpl(std::string_view name, const std::type_info &);
 
 public:
-   TTrivialDS(ULong64_t size);
+   TTrivialDS(ULong64_t size, bool skipEvenEntries = false);
    ~TTrivialDS();
    const std::vector<std::string> &GetColumnNames() const;
    bool HasColumn(std::string_view colName) const;
    std::string GetTypeName(std::string_view) const;
    std::vector<std::pair<ULong64_t, ULong64_t>> GetEntryRanges();
-   void SetEntry(unsigned int slot, ULong64_t entry);
+   bool SetEntry(unsigned int slot, ULong64_t entry);
    void SetNSlots(unsigned int nSlots);
    void Initialise();
 };
 
-TDataFrame MakeTrivialDataFrame(ULong64_t size);
+TDataFrame MakeTrivialDataFrame(ULong64_t size, bool skipEvenEntries = false);
 
 } // ns TDF
 } // ns Experimental

--- a/tree/treeplayer/src/TArrowDS.cxx
+++ b/tree/treeplayer/src/TArrowDS.cxx
@@ -21,7 +21,7 @@ ROOT::Experimental::TDF::MakeArrowDataFrame, which accepts one parameter:
 1. An arrow::Table smart pointer.
 
 The types of the columns are derived from the types in the associated
-arrow::Schema. 
+arrow::Schema.
 
 */
 // clang-format on
@@ -401,13 +401,14 @@ bool TArrowDS::HasColumn(std::string_view colName) const
    return true;
 }
 
-void TArrowDS::SetEntry(unsigned int slot, ULong64_t entry)
+bool TArrowDS::SetEntry(unsigned int slot, ULong64_t entry)
 {
    for (auto link : fGetterIndex) {
       auto column = fTable->column(link.first);
       auto &getter = fValueGetters[link.second];
       getter->SetEntry(slot, entry);
    }
+   return true;
 }
 
 void TArrowDS::InitSlot(unsigned int slot, ULong64_t entry)

--- a/tree/treeplayer/src/TCsvDS.cxx
+++ b/tree/treeplayer/src/TCsvDS.cxx
@@ -347,7 +347,7 @@ bool TCsvDS::HasColumn(std::string_view colName) const
    return fHeaders.end() != std::find(fHeaders.begin(), fHeaders.end(), colName);
 }
 
-void TCsvDS::SetEntry(unsigned int slot, ULong64_t entry)
+bool TCsvDS::SetEntry(unsigned int slot, ULong64_t entry)
 {
    int colIndex = 0;
    for (auto &colType : fColTypesList) {
@@ -372,6 +372,7 @@ void TCsvDS::SetEntry(unsigned int slot, ULong64_t entry)
       }
       colIndex++;
    }
+   return true;
 }
 
 void TCsvDS::SetNSlots(unsigned int nSlots)

--- a/tree/treeplayer/src/TDFNodes.cxx
+++ b/tree/treeplayer/src/TDFNodes.cxx
@@ -256,8 +256,9 @@ void TLoopManager::RunDataSource()
       for (const auto &range : ranges) {
          auto end = range.second;
          for (auto entry = range.first; entry < end; ++entry) {
-            fDataSource->SetEntry(0u, entry);
-            RunAndCheckFilters(0u, entry);
+            if (fDataSource->SetEntry(0u, entry)) {
+               RunAndCheckFilters(0u, entry);
+            }
          }
       }
       fDataSource->FinaliseSlot(0u);
@@ -281,8 +282,9 @@ void TLoopManager::RunDataSourceMT()
       fDataSource->InitSlot(slot, range.first);
       const auto end = range.second;
       for (auto entry = range.first; entry < end; ++entry) {
-         fDataSource->SetEntry(slot, entry);
-         RunAndCheckFilters(slot, entry);
+         if(fDataSource->SetEntry(slot, entry)) {
+            RunAndCheckFilters(slot, entry);
+         }
       }
       CleanUpTask(slot);
       fDataSource->FinaliseSlot(slot);

--- a/tree/treeplayer/src/TRootDS.cxx
+++ b/tree/treeplayer/src/TRootDS.cxx
@@ -119,9 +119,10 @@ std::vector<std::pair<ULong64_t, ULong64_t>> TRootDS::GetEntryRanges()
    return entryRanges;
 }
 
-void TRootDS::SetEntry(unsigned int slot, ULong64_t entry)
+bool TRootDS::SetEntry(unsigned int slot, ULong64_t entry)
 {
    fChains[slot]->GetEntry(entry);
+   return true;
 }
 
 void TRootDS::SetNSlots(unsigned int nSlots)

--- a/tree/treeplayer/src/TTrivialDS.cxx
+++ b/tree/treeplayer/src/TTrivialDS.cxx
@@ -21,7 +21,7 @@ std::vector<void *> TTrivialDS::GetColumnReadersImpl(std::string_view, const std
    return ret;
 }
 
-TTrivialDS::TTrivialDS(ULong64_t size) : fSize(size)
+TTrivialDS::TTrivialDS(ULong64_t size, bool skipEvenEntries) : fSize(size), fSkipEvenEntries(skipEvenEntries)
 {
 }
 
@@ -50,9 +50,13 @@ std::vector<std::pair<ULong64_t, ULong64_t>> TTrivialDS::GetEntryRanges()
    return ranges;
 }
 
-void TTrivialDS::SetEntry(unsigned int slot, ULong64_t entry)
+bool TTrivialDS::SetEntry(unsigned int slot, ULong64_t entry)
 {
+   if (fSkipEvenEntries && 0 == entry % 2) {
+      return false;
+   }
    fCounter[slot] = entry;
+   return true;
 }
 
 void TTrivialDS::SetNSlots(unsigned int nSlots)
@@ -79,9 +83,9 @@ void TTrivialDS::Initialise()
    fEntryRanges.back().second += fSize % fNSlots;
 }
 
-TDataFrame MakeTrivialDataFrame(ULong64_t size)
+TDataFrame MakeTrivialDataFrame(ULong64_t size, bool skipEvenEntries)
 {
-   ROOT::Experimental::TDataFrame tdf(std::make_unique<TTrivialDS>(size));
+   ROOT::Experimental::TDataFrame tdf(std::make_unique<TTrivialDS>(size, skipEvenEntries));
    return tdf;
 }
 

--- a/tree/treeplayer/test/dataframe/TNonCopiableDS.hxx
+++ b/tree/treeplayer/test/dataframe/TNonCopiableDS.hxx
@@ -36,6 +36,6 @@ public:
       auto entryRanges(std::move(fEntryRanges)); // empty fEntryRanges
       return entryRanges;
    };
-   void SetEntry(unsigned int, ULong64_t){};
+   bool SetEntry(unsigned int, ULong64_t){ return true;};
    void SetNSlots(unsigned int){};
 };

--- a/tree/treeplayer/test/dataframe/TStreamingDS.hxx
+++ b/tree/treeplayer/test/dataframe/TStreamingDS.hxx
@@ -31,7 +31,7 @@ public:
       ++fCounter;
       return ranges;
    }
-   void SetEntry(unsigned int, ULong64_t) {}
+   bool SetEntry(unsigned int, ULong64_t) {return true;}
    void Initialise() { fCounter = 0; }
 protected:
    std::vector<void *> GetColumnReadersImpl(std::string_view name, const std::type_info &t) {

--- a/tree/treeplayer/test/dataframe/datasource_trivial.cxx
+++ b/tree/treeplayer/test/dataframe/datasource_trivial.cxx
@@ -105,6 +105,31 @@ TEST(TTrivialDS, FromATDF)
    EXPECT_DOUBLE_EQ(22., *min2);
 }
 
+TEST(TTrivialDS, SkipEntries)
+{
+   auto nevts = 8;
+   TTrivialDS tdsOdd(nevts, true);
+   tdsOdd.SetNSlots(1);
+   auto retVal = false;
+   for (auto ievt : ROOT::TSeqI(nevts)) {
+      EXPECT_EQ(retVal, tdsOdd.SetEntry(0, ievt));
+      retVal = !retVal;
+   }
+
+   TTrivialDS tdsAll(nevts);
+   tdsAll.SetNSlots(1);
+   retVal = true;
+   for (auto ievt : ROOT::TSeqI(nevts)) {
+      EXPECT_TRUE(retVal == tdsAll.SetEntry(0, ievt));
+   }
+
+
+   auto tdfOdd = ROOT::Experimental::TDF::MakeTrivialDataFrame(20ULL, true);
+   EXPECT_EQ(*tdfOdd.Count(), 10ULL);
+   auto tdfAll = ROOT::Experimental::TDF::MakeTrivialDataFrame(20ULL);
+   EXPECT_EQ(*tdfAll.Count(), 20ULL);
+}
+
 #ifdef R__B64
 
 TEST(TTrivialDS, FromATDFWithJitting)
@@ -198,6 +223,14 @@ TEST(TTrivialDS, Cache)
       EXPECT_EQ(e, i);
       ++i;
    }
+}
+
+TEST(TTrivialDS, SkipEntriesMT)
+{
+   auto tdfOdd = ROOT::Experimental::TDF::MakeTrivialDataFrame(80ULL, true);
+   EXPECT_EQ(*tdfOdd.Count(), 40ULL);
+   auto tdfAll = ROOT::Experimental::TDF::MakeTrivialDataFrame(80ULL);
+   EXPECT_EQ(*tdfAll.Count(), 80ULL);
 }
 
 #endif // R__USE_IMT


### PR DESCRIPTION
This PR addresses https://sft.its.cern.ch/jira/browse/ROOT-9328 , submitted on behalf of the Alice O2 team.
The TDataSource::SetEntry method now returns a boolean. If true, the entry is considered in the event loop managed by TDataFrame, if false, the entry is skipped.