### PR TITLE
From Axel: Empty token queue for late parsed templates also for pending instantiations.

### DIFF
--- a/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
@@ -471,6 +471,17 @@ namespace cling {
       Transaction* nestedT = beginTransaction(T->getCompilationOpts());
       // Pull all template instantiations in that came from the consumers.
       getCI()->getSema().PerformPendingInstantiations();
+#ifdef LLVM_ON_WIN32
+      // Microsoft-specific:
+      // Late parsed templates can leave unswallowed "macro"-like tokens.
+      // They will seriously confuse the Parser when entering the next
+      // source file. So lex until we are EOF.
+      Token Tok;
+      do {
+        getCI()->getSema().getPreprocessor().Lex(Tok);
+      } while (Tok.isNot(tok::eof));
+#endif
+
       ParseResultTransaction nestedPRT = endTransaction(nestedT);
       commitTransaction(nestedPRT);
       m_Consumer->setTransaction(prevConsumerT);

--- a/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
@@ -477,6 +477,7 @@ namespace cling {
       // They will seriously confuse the Parser when entering the next
       // source file. So lex until we are EOF.
       Token Tok;
+      Tok.setKind(tok::eof);
       do {
         getCI()->getSema().getPreprocessor().Lex(Tok);
       } while (Tok.isNot(tok::eof));
@@ -754,6 +755,7 @@ namespace cling {
     // They will seriously confuse the Parser when entering the next
     // source file. So lex until we are EOF.
     Token Tok;
+    Tok.setKind(tok::eof);
     do {
       PP.Lex(Tok);
     } while (Tok.isNot(tok::eof));


### PR DESCRIPTION
Late parsed templated are parsed from a token chain, as if expanding a macro. This confuses subsequent parses. Make sure that the token quere is emptied, which is exactly what ParseInternal() does after parsing.