### PR TITLE
Change DynamicExprInfo.h from forward decl to include

### DIFF
--- a/interpreter/cling/include/cling/Interpreter/DynamicLookupRuntimeUniverse.h
+++ b/interpreter/cling/include/cling/Interpreter/DynamicLookupRuntimeUniverse.h
@@ -13,7 +13,7 @@
 #error "This file must not be included by compiled programs."
 #endif
 
-class DynamicExprInfo;
+#include "cling/Interpreter/DynamicExprInfo.h"
 #include "cling/Interpreter/DynamicLookupLifetimeHandler.h"
 #include "cling/Interpreter/Value.h"
 


### PR DESCRIPTION
This was causing some test failures in cxx modules and in cling.