### PR TITLE
[TTreeReader] Error out if TTreeReaderValue is reading an array

### DIFF
--- a/tree/treeplayer/src/TTreeReaderValue.cxx
+++ b/tree/treeplayer/src/TTreeReaderValue.cxx
@@ -537,11 +537,14 @@ const char* ROOT::Internal::TTreeReaderValueBase::GetBranchDataType(TBranch* bra
          if (myLeaf){
             TDictionary *myDataType = TDictionary::GetDictionary(myLeaf->GetTypeName());
             if (myDataType && myDataType->IsA() == TDataType::Class()){
+               if (myLeaf->GetLeafCount() != nullptr || myLeaf->GetLenStatic() > 1) {
+                  Error("TTreeReaderValueBase::GetBranchDataType()", "Must use TTreeReaderArray to read branch %s: it contains an array or a collection.", branch->GetName());
+                  return 0;
+               }
                dict = TDataType::GetDataType((EDataType)((TDataType*)myDataType)->GetType());
                return myLeaf->GetTypeName();
             }
          }
-
 
          // leaflist. Can't represent.
          Error("TTreeReaderValueBase::GetBranchDataType()", "The branch %s was created using a leaf list and cannot be represented as a C++ type. Please access one of its siblings using a TTreeReaderArray:", branch->GetName());

--- a/tree/treeplayer/test/data.h
+++ b/tree/treeplayer/test/data.h
@@ -1,3 +1,6 @@
+#ifndef TTREEREADER_LEAF_TEST_DATA
+#define TTREEREADER_LEAF_TEST_DATA
+
 #include <vector>
 struct Data {
    unsigned int fUSize;
@@ -9,3 +12,4 @@ struct Data {
    Float16_t fFloat16;
 };
 
+#endif

--- a/tree/treeplayer/test/leafs.cxx
+++ b/tree/treeplayer/test/leafs.cxx
@@ -163,3 +163,20 @@ TEST(TTreeReaderLeafs, TArrayD) {
    EXPECT_DOUBLE_EQ(4., (*arr)[2]);
    EXPECT_DOUBLE_EQ(2., (*arr)[0]);
 }
+
+TEST(TTreeReaderLeafs, ArrayWithReaderValue)
+{
+   // reading a float[] with a TTreeReaderValue should cause an error
+
+   std::unique_ptr<TTree> tree(new TTree("arraywithreadervaluetree", "test tree"));
+   std::vector<double> arr = {42., 84.};
+   tree->Branch("arr", arr.data(), "arr[2]/D");
+   tree->Fill();
+   tree->ResetBranchAddresses();
+
+   TTreeReader tr(tree.get());
+   TTreeReaderValue<double> valueOfArr(tr, "arr");
+   tr.Next();
+   *valueOfArr;
+   EXPECT_FALSE(valueOfArr.IsValid());
+}


### PR DESCRIPTION
This fixes [ROOT-9322](https://sft.its.cern.ch/jira/browse/ROOT-9322).

If a `TTreeReaderValue` is used to read fixed or variable size array, TTreeReader now complains and does not finish construction successfully (rather than successfully construct and read only the first element of the array).

When such a (wrongly constructed) `TTreeReaderValue `is used, the following error messages are printed on screen:

```
Error in <TTreeReaderValueBase::GetBranchDataType()>: Must use TTreeReaderArray to read branch arr: it contains an array or a collection.
Error in <TTreeReaderValueBase::CreateProxy()>: The branch arr contains data of type {UNDETERMINED TYPE}, which does not have a dictionary.
Error in <TTreeReaderValue::Get()>: Value reader not properly initialized, did you remember to call TTreeReader.Set(Next)Entry()?
```

I could not find a way to avoid the last two `Error`s and still have `TTreeReaderValue::IsValid` return `false`.