### PR TITLE
WIP: Minuit2 MPI move to C bindings

### DIFF
--- a/math/minuit2/inc/Minuit2/MPIProcess.h
+++ b/math/minuit2/inc/Minuit2/MPIProcess.h
@@ -34,7 +34,7 @@ namespace Minuit2 {
          MPI_Initialized(&initialized);
          if (initialized) {
             int finalized = 0;
-            MPI_Finalized(&finalized);
+            MPI_Finalized(&finalized); 
             if (!finalized) {
                int rank = 0;
                MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -91,8 +91,11 @@ namespace Minuit2 {
                       << rank << " processor"
                       << std::endl;
          }
-         MPI_Comm_size(MPI_COMM_WORLD, &fgGlobalSize);
-         MPI_Comm_rank(MPI_COMM_WORLD, &fgGlobalRank);
+         int global_size, global_rank;
+         MPI_Comm_size(MPI_COMM_WORLD, &global_size);
+         MPI_Comm_rank(MPI_COMM_WORLD, &global_rank);
+         fgGlobalSize = (unsigned int) global_size;
+         fgGlobalRank = (unsigned int) global_rank;
 #endif
       }
 
@@ -125,11 +128,11 @@ namespace Minuit2 {
 
    private:
       unsigned int fNelements;
-      int fSize;
-      int fRank;
+      unsigned int fSize;
+      unsigned int fRank;
 
-      static int fgGlobalSize;
-      static int fgGlobalRank;
+      static unsigned int fgGlobalSize;
+      static unsigned int fgGlobalRank;
 
       static unsigned int fgCartSizeX;
       static unsigned int fgCartSizeY;

--- a/math/minuit2/inc/Minuit2/MPIProcess.h
+++ b/math/minuit2/inc/Minuit2/MPIProcess.h
@@ -30,12 +30,20 @@ namespace Minuit2 {
    public:
       ~MPITerminate() {
 #ifdef MPIPROC
-         if (MPI::Is_initialized() && !(MPI::Is_finalized())) {
-            std::cout << "Info --> MPITerminate:: End MPI on #"
-                      << MPI::COMM_WORLD.Get_rank() << " processor"
-                      << std::endl;
+         int initialized = 0;
+         MPI_Initialized(&initialized);
+         if (initialized) {
+            int finalized = 0;
+            MPI_Finalized(&finalized);
+            if (!finalized) {
+               int rank = 0;
+               MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+               std::cout << "Info --> MPITerminate:: End MPI on #"
+                         << rank << " processor"
+                         << std::endl;
 
-            MPI::Finalize();
+               MPI_Finalize();
+            }
          }
 #endif
       }
@@ -71,23 +79,25 @@ namespace Minuit2 {
       static unsigned int GetMPIGlobalSize() { StartMPI(); return fgGlobalSize; }
       static inline void StartMPI() {
 #ifdef MPIPROC
-         if (!(MPI::Is_initialized())) {
-            MPI::Init();
+         int initialized = 0;
+         MPI_Initialized(&initialized);
+         if (!(initialized)) {
+            int argc = 0;
+            char** argv = NULL;
+            MPI_Init(&argc, &argv);
+            int rank = 0;
+            MPI_Comm_rank(MPI_COMM_WORLD, &rank);
             std::cout << "Info --> MPIProcess::StartMPI: Start MPI on #"
-                      << MPI::COMM_WORLD.Get_rank() << " processor"
+                      << rank << " processor"
                       << std::endl;
          }
-         fgGlobalSize = MPI::COMM_WORLD.Get_size();
-         fgGlobalRank = MPI::COMM_WORLD.Get_rank();
+         MPI_Comm_size(MPI_COMM_WORLD, &fgGlobalSize);
+         MPI_Comm_rank(MPI_COMM_WORLD, &fgGlobalRank);
 #endif
       }
 
       static void TerminateMPI() {
 #ifdef MPIPROC
-         if (fgCommunicators[0]!=0 && fgCommunicators[1]!=0) {
-            delete fgCommunicators[0]; fgCommunicators[0] = 0; fgIndecesComm[0] = 0;
-            delete fgCommunicators[1]; fgCommunicators[1] = 0; fgIndecesComm[1] = 0;
-         }
 
          MPITerminate();
 
@@ -102,7 +112,7 @@ namespace Minuit2 {
 
 #ifdef MPIPROC
          if (fSize>1) {
-            fgCommunicator->Allreduce(&sub,&total,1,MPI::DOUBLE,MPI::SUM);
+            MPI_Allreduce(&sub, &total, 1, MPI_DOUBLE, MPI_SUM, *fgCommunicator);
          }
 #endif
       }
@@ -115,11 +125,11 @@ namespace Minuit2 {
 
    private:
       unsigned int fNelements;
-      unsigned int fSize;
-      unsigned int fRank;
+      int fSize;
+      int fRank;
 
-      static unsigned int fgGlobalSize;
-      static unsigned int fgGlobalRank;
+      static int fgGlobalSize;
+      static int fgGlobalRank;
 
       static unsigned int fgCartSizeX;
       static unsigned int fgCartSizeY;
@@ -130,9 +140,10 @@ namespace Minuit2 {
       unsigned int fNumElements4JobOut;
 
 #ifdef MPIPROC
-      static MPI::Intracomm *fgCommunicator;
+      static MPI_Comm fgCommunicatorWorld; //Need to be able to point to the world communicator
+      static MPI_Comm *fgCommunicator;
       static int fgIndexComm; // maximum 2 communicators, so index can be 0 and 1
-      static MPI::Intracomm *fgCommunicators[2]; // maximum 2 communicators
+      static MPI_Comm fgCommunicators[2]; // maximum 2 communicators
       static unsigned int fgIndecesComm[2];
 #endif
 

--- a/math/minuit2/src/MPIProcess.cxx
+++ b/math/minuit2/src/MPIProcess.cxx
@@ -16,8 +16,8 @@ namespace ROOT {
 
 namespace Minuit2 {
 
-   unsigned int MPIProcess::fgGlobalSize = 1;
-   unsigned int MPIProcess::fgGlobalRank = 0;
+   int MPIProcess::fgGlobalSize = 1;
+   int MPIProcess::fgGlobalRank = 0;
 
    // By default all procs are for X
    unsigned int MPIProcess::fgCartSizeX = 0;
@@ -26,9 +26,10 @@ namespace Minuit2 {
    bool MPIProcess::fgNewCart = true;
 
 #ifdef MPIPROC
-   MPI::Intracomm* MPIProcess::fgCommunicator = 0;
+   MPI_Comm MPIProcess::fgCommunicatorWorld = MPI_COMM_NULL;
+   MPI_Comm* MPIProcess::fgCommunicator = 0;
    int MPIProcess::fgIndexComm = -1; // -1 for no-initialization
-   MPI::Intracomm* MPIProcess::fgCommunicators[2] = {0};
+   MPI_Comm MPIProcess::fgCommunicators[2] = {MPI_COMM_NULL};
    unsigned int MPIProcess::fgIndecesComm[2] = {0};
 #endif
 
@@ -55,8 +56,8 @@ namespace Minuit2 {
             int color = fgGlobalRank / fgCartSizeY;
             int key = fgGlobalRank % fgCartSizeY;
 
-            fgCommunicators[0] = new MPI::Intracomm(MPI::COMM_WORLD.Split(key,color)); // rows for Minuit
-            fgCommunicators[1] = new MPI::Intracomm(MPI::COMM_WORLD.Split(color,key)); // columns for NLL
+            MPI_Comm_split(MPI_COMM_WORLD, key, color, &fgCommunicators[0]); // rows for Minuit
+            MPI_Comm_split(MPI_COMM_WORLD, color, key, &fgCommunicators[1]); // columns for NLL
 
             fgNewCart = false;
 
@@ -64,17 +65,21 @@ namespace Minuit2 {
 
          fgIndexComm++;
 
-         if (fgIndexComm>1 || fgCommunicator==(&(MPI::COMM_WORLD))) { // Remember, no more than 2 dimensions in the topology!
+         int comparison = 0;
+         MPI_Comm_compare(MPI_COMM_WORLD, *fgCommunicator, &comparison);
+
+         if (fgIndexComm>1 || comparison == MPI_IDENT) { // Remember, no more than 2 dimensions in the topology!
             std::cerr << "Error --> MPIProcess::MPIProcess: Requiring more than 2 dimensions in the topology!" << std::endl;
-            MPI::COMM_WORLD.Abort(-1);
+            MPI_Abort(MPI_COMM_WORLD, -1);
          }
 
          // requiring columns as first call. In this case use all nodes
+         MPI_Comm_dup(MPI_COMM_WORLD, &fgCommunicatorWorld);
          if (((unsigned int)fgIndexComm)<indexComm)
-            fgCommunicator = &(MPI::COMM_WORLD);
+            fgCommunicator = &fgCommunicatorWorld;
          else {
             fgIndecesComm[fgIndexComm] = indexComm;
-            fgCommunicator = fgCommunicators[fgIndecesComm[fgIndexComm]];
+            fgCommunicator = &fgCommunicators[fgIndecesComm[fgIndexComm]];
          }
 
       }
@@ -91,12 +96,10 @@ namespace Minuit2 {
 
          if (fgIndexComm<0) {
             if (fgCartSizeX==fgCartDimension) {
-               fgCommunicators[0] = &(MPI::COMM_WORLD);
-               fgCommunicators[1] = 0;
+               MPI_Comm_dup(MPI_COMM_WORLD, &fgCommunicators[0]);
             }
             else {
-               fgCommunicators[0] = 0;
-               fgCommunicators[1] = &(MPI::COMM_WORLD);
+               MPI_Comm_dup(MPI_COMM_WORLD, &fgCommunicators[1]);
             }
          }
 
@@ -104,26 +107,26 @@ namespace Minuit2 {
 
          if (fgIndexComm>1) { // Remember, no more than 2 nested MPI calls!
             std::cerr << "Error --> MPIProcess::MPIProcess: More than 2 nested MPI calls!" << std::endl;
-            MPI::COMM_WORLD.Abort(-1);
+            MPI_Abort(MPI_COMM_WORLD, -1);
          }
 
          fgIndecesComm[fgIndexComm] = indexComm;
 
          // require 2 nested communicators
-         if (fgCommunicator!=0 && fgCommunicators[indexComm]!=0) {
+         if (fgCommunicator!=0 && fgCommunicators[indexComm]!=MPI_COMM_NULL) {
             std::cout << "Warning --> MPIProcess::MPIProcess: Requiring 2 nested MPI calls!" << std::endl;
             std::cout << "Warning --> MPIProcess::MPIProcess: Ignoring second call." << std::endl;
             fgIndecesComm[fgIndexComm] = (indexComm==0) ? 1 : 0;
          }
 
-         fgCommunicator = fgCommunicators[fgIndecesComm[fgIndexComm]];
+         fgCommunicator = &fgCommunicators[fgIndecesComm[fgIndexComm]];
 
       }
 
       // set size and rank
       if (fgCommunicator!=0) {
-         fSize = fgCommunicator->Get_size();
-         fRank = fgCommunicator->Get_rank();
+         MPI_Comm_size(*fgCommunicator, &fSize);
+         MPI_Comm_rank(*fgCommunicator, &fRank);
       }
       else {
          // no MPI calls
@@ -134,7 +137,7 @@ namespace Minuit2 {
 
       if (fSize>fNelements) {
          std::cerr << "Error --> MPIProcess::MPIProcess: more processors than elements!" << std::endl;
-         MPI::COMM_WORLD.Abort(-1);
+         MPI_Abort(MPI_COMM_WORLD, -1);
       }
 
 #endif
@@ -151,7 +154,7 @@ namespace Minuit2 {
       fgCommunicator = 0;
       fgIndexComm--;
       if (fgIndexComm==0)
-         fgCommunicator = fgCommunicators[fgIndecesComm[fgIndexComm]];
+         fgCommunicator = &fgCommunicators[fgIndecesComm[fgIndexComm]];
 
 #endif
 
@@ -269,8 +272,8 @@ namespace Minuit2 {
          offsets[i] = nconts[i-1] + offsets[i-1];
       }
 
-      fgCommunicator->Allgatherv(ivector,svector,MPI::DOUBLE,
-                                ovector,nconts,offsets,MPI::DOUBLE);
+      MPI_Allgatherv(ivector, svector, MPI_DOUBLE, ovector, nconts,
+                     offsets, MPI_DOUBLE, *fgCommunicator);
 
    }
 
@@ -298,10 +301,6 @@ namespace Minuit2 {
          fgCartDimension = fgCartSizeX * fgCartSizeY;
          fgNewCart = true;
 
-         if (fgCommunicators[0]!=0 && fgCommunicators[1]!=0) {
-            delete fgCommunicators[0]; fgCommunicators[0] = 0; fgIndecesComm[0] = 0;
-            delete fgCommunicators[1]; fgCommunicators[1] = 0; fgIndecesComm[1] = 0;
-         }
       }
 
       return true;

--- a/math/minuit2/src/MPIProcess.cxx
+++ b/math/minuit2/src/MPIProcess.cxx
@@ -16,8 +16,8 @@ namespace ROOT {
 
 namespace Minuit2 {
 
-   int MPIProcess::fgGlobalSize = 1;
-   int MPIProcess::fgGlobalRank = 0;
+   unsigned int MPIProcess::fgGlobalSize = 1;
+   unsigned int MPIProcess::fgGlobalRank = 0;
 
    // By default all procs are for X
    unsigned int MPIProcess::fgCartSizeX = 0;
@@ -125,8 +125,11 @@ namespace Minuit2 {
 
       // set size and rank
       if (fgCommunicator!=0) {
-         MPI_Comm_size(*fgCommunicator, &fSize);
-         MPI_Comm_rank(*fgCommunicator, &fRank);
+         int size, rank;
+         MPI_Comm_size(*fgCommunicator, &size);
+         MPI_Comm_rank(*fgCommunicator, &rank);
+         fSize = (unsigned int) size;
+         fRank = (unsigned int) rank;
       }
       else {
          // no MPI calls

--- a/math/minuit2/src/MnPrint.cxx
+++ b/math/minuit2/src/MnPrint.cxx
@@ -26,6 +26,10 @@
 #define PRECISION 13
 #define WIDTH     20
 
+#ifdef MPIPROC
+#include "mpi.h"
+#endif
+
 
 namespace ROOT {
 
@@ -37,6 +41,17 @@ int gPrintLevel = 3;
 int gPrintLevel = 0;
 #endif
 
+#ifdef MPIPROC
+static inline bool IsMPIRankZero() {
+   int rank;
+   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+   return rank==0;
+}
+#else
+static inline bool IsMPIRankZero() {
+   return true;
+}
+#endif
 
 int MnPrint::SetLevel(int level) {
    int prevLevel  = gPrintLevel;
@@ -49,6 +64,7 @@ int MnPrint::Level( ) {
 }
 
 void MnPrint::PrintFcn(std::ostream & os, double value, bool endline) {
+   if ( !IsMPIRankZero() ) return;
    int pr = os.precision(PRECISION);
    os << value;
    if (endline) os << std::endl;
@@ -61,6 +77,7 @@ void MnPrint::PrintState(std::ostream & os, const MinimumState & state, const ch
 }
 
 void MnPrint::PrintState(std::ostream & os, double fval, double edm, int ncalls, const char * msg, int iter) {
+   if ( !IsMPIRankZero() ) return;
    // helper function to print function value, edm and ncalls  and message in one single line
    os << msg;
    if (iter>=0) os << std::setw(3) << iter;
@@ -74,6 +91,7 @@ void MnPrint::PrintState(std::ostream & os, double fval, double edm, int ncalls,
 
 
 std::ostream& operator<<(std::ostream& os, const LAVector& vec) {
+   if ( !IsMPIRankZero() ) return os;
    // print a vector
    os << "LAVector parameters:" << std::endl;
    int pr = os.precision(PRECISION);
@@ -89,6 +107,7 @@ std::ostream& operator<<(std::ostream& os, const LAVector& vec) {
 }
 
 std::ostream& operator<<(std::ostream& os, const LASymMatrix& matrix) {
+   if ( !IsMPIRankZero() ) return os;
    // print a matrix
    os << "LASymMatrix parameters:" << std::endl;
    int pr = os.precision(8);
@@ -107,6 +126,7 @@ std::ostream& operator<<(std::ostream& os, const LASymMatrix& matrix) {
 }
 
 std::ostream& operator<<(std::ostream& os, const MnUserParameters& par) {
+   if ( !IsMPIRankZero() ) return os;
    // print the MnUserParameter object
    os << std::endl;
 
@@ -156,6 +176,7 @@ std::ostream& operator<<(std::ostream& os, const MnUserParameters& par) {
 }
 
 std::ostream& operator<<(std::ostream& os, const MnUserCovariance& matrix) {
+   if ( !IsMPIRankZero() ) return os;
    // print the MnUserCovariance
    os << std::endl;
 
@@ -193,6 +214,7 @@ std::ostream& operator<<(std::ostream& os, const MnUserCovariance& matrix) {
 }
 
 std::ostream& operator<<(std::ostream& os, const MnGlobalCorrelationCoeff& coeff) {
+   if ( !IsMPIRankZero() ) return os;
    // print the global correlation coefficient
    os << std::endl;
 
@@ -211,6 +233,7 @@ std::ostream& operator<<(std::ostream& os, const MnGlobalCorrelationCoeff& coeff
 }
 
 std::ostream& operator<<(std::ostream& os, const MnUserParameterState& state) {
+   if ( !IsMPIRankZero() ) return os;
    // print the MnUserParameterState
    os << std::endl;
 
@@ -243,6 +266,7 @@ std::ostream& operator<<(std::ostream& os, const MnUserParameterState& state) {
 }
 
 std::ostream& operator<<(std::ostream& os, const FunctionMinimum& min) {
+   if ( !IsMPIRankZero() ) return os;
    // print the FunctionMinimum
    os << std::endl;
    if(!min.IsValid()) {
@@ -282,6 +306,7 @@ std::ostream& operator<<(std::ostream& os, const FunctionMinimum& min) {
 }
 
 std::ostream& operator<<(std::ostream& os, const MinimumState& min) {
+   if ( !IsMPIRankZero() ) return os;
 
    os << std::endl;
    int pr = os.precision(PRECISION);
@@ -300,6 +325,7 @@ std::ostream& operator<<(std::ostream& os, const MinimumState& min) {
 }
 
 std::ostream& operator<<(std::ostream& os, const MnMachinePrecision& prec) {
+   if ( !IsMPIRankZero() ) return os;
    // print the Precision
    os << std::endl;
 
@@ -313,6 +339,7 @@ std::ostream& operator<<(std::ostream& os, const MnMachinePrecision& prec) {
 }
 
 std::ostream& operator<<(std::ostream& os, const MinosError& me) {
+   if ( !IsMPIRankZero() ) return os;
    // print the Minos Error
    os << std::endl;
 
@@ -355,6 +382,7 @@ std::ostream& operator<<(std::ostream& os, const MinosError& me) {
 }
 
 std::ostream& operator<<(std::ostream& os, const ContoursError& ce) {
+   if ( !IsMPIRankZero() ) return os;
    // print the ContoursError
    os << std::endl;
    os <<"Contours # of function calls: "<<ce.NFcn()<<std::endl;


### PR DESCRIPTION
This was applied from a .patch from the PR GooFit/Minuit2#1 from @gudlaugu. All credit/blame should be directed to @gudlaugu, I'm just the middleman. This patch is useful because MPI 3 no longer even includes support for the C++ bindings.

I've added one small obvious fix to warnings, but otherwise all credit/blame should be directed to @gudlaugu.

Original discussion in #1689.