### PR TITLE
[TDF] Split jitting of Define and jitting of Filter

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -127,8 +127,10 @@ public:
                     "TInterface<T> can only be converted to TInterface<BaseOfT>");
       return TInterface<NewProxied>(fProxiedPtr, fImplWeakPtr, fValidCustomColumns, fDataSource);
    }
-   using TInterfaceJittedDefine =
-      TInterface<TTraits::TakeFirstParameter_t<decltype(TDFInternal::UpcastNode(fProxiedPtr))>>;
+   // TODO can this be not public?
+   // Windows needs the definition be done in two steps
+   using JittedDefineSharedPtr = decltype(TDFInternal::UpcastNode(fProxiedPtr));
+   using TInterfaceJittedDefine = TInterface<typename JittedDefineSharedPtr::element_type>;
    /// \endcond
 
    ////////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/inc/ROOT/TDFInterfaceUtils.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterfaceUtils.hxx
@@ -213,12 +213,17 @@ TActionBase *BuildAndBook(const ColumnNames_t &bl, const std::shared_ptr<double>
 
 using TmpBranchBasePtr_t = std::shared_ptr<TCustomColumnBase>;
 
-Long_t JitTransformation(void *thisPtr, std::string_view methodName, std::string_view interfaceTypeName,
-                         std::string_view name, std::string_view expression,
-                         const std::map<std::string, std::string> &aliasMap, const ColumnNames_t &branches,
-                         const std::vector<std::string> &customColumns,
-                         const std::map<std::string, TmpBranchBasePtr_t> &tmpBookedBranches, TTree *tree,
-                         std::string_view returnTypeName, TDataSource *ds);
+Long_t JitFilter(void *thisPtr, std::string_view interfaceTypeName, std::string_view name, std::string_view expression,
+                 const std::map<std::string, std::string> &aliasMap, const ColumnNames_t &branches,
+                 const std::vector<std::string> &customColumns,
+                 const std::map<std::string, TmpBranchBasePtr_t> &tmpBookedBranches, TTree *tree,
+                 std::string_view returnTypeName, TDataSource *ds);
+
+Long_t JitDefine(void *thisPtr, std::string_view interfaceTypeName, std::string_view name, std::string_view expression,
+                 const std::map<std::string, std::string> &aliasMap, const ColumnNames_t &branches,
+                 const std::vector<std::string> &customColumns,
+                 const std::map<std::string, TmpBranchBasePtr_t> &tmpBookedBranches, TTree *tree,
+                 std::string_view returnTypeName, TDataSource *ds);
 
 std::string JitBuildAndBook(const ColumnNames_t &bl, const std::string &prevNodeTypename, void *prevNode,
                             const std::type_info &art, const std::type_info &at, const void *r, TTree *tree,

--- a/tree/treeplayer/inc/ROOT/TDFInterfaceUtils.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterfaceUtils.hxx
@@ -216,8 +216,7 @@ using TmpBranchBasePtr_t = std::shared_ptr<TCustomColumnBase>;
 Long_t JitFilter(void *thisPtr, std::string_view interfaceTypeName, std::string_view name, std::string_view expression,
                  const std::map<std::string, std::string> &aliasMap, const ColumnNames_t &branches,
                  const std::vector<std::string> &customColumns,
-                 const std::map<std::string, TmpBranchBasePtr_t> &tmpBookedBranches, TTree *tree,
-                 std::string_view returnTypeName, TDataSource *ds);
+                 const std::map<std::string, TmpBranchBasePtr_t> &tmpBookedBranches, TTree *tree, TDataSource *ds);
 
 Long_t JitDefine(void *thisPtr, std::string_view interfaceTypeName, std::string_view name, std::string_view expression,
                  const std::map<std::string, std::string> &aliasMap, const ColumnNames_t &branches,


### PR DESCRIPTION
Resolves point 1. of [ROOT-9349](https://sft.its.cern.ch/jira/browse/ROOT-9349): "[TDF] Only invoke the interpreter once per event loop".

Instead of having one single `JitTransformation` function with two entry points (`CallJit{Define,Filter}`) we now have two separate functions `JitDefine` and `JitFilter` that share several helper functions.

There is slightly more code repetition than before, but the code is _much_ simpler.

By the time ROOT-9849 is completed `JitDefine` and `JitFilter` will be different enough to justify this separation.