### PR TITLE
Remove Tree dependency from libMultiProc

### DIFF
--- a/core/multiproc/CMakeLists.txt
+++ b/core/multiproc/CMakeLists.txt
@@ -10,4 +10,4 @@ ROOT_STANDARD_LIBRARY_PACKAGE(MultiProc
                               OBJECT_LIBRARY
                               HEADERS ${headers}
                               LIBRARIES Core Net dl
-                              DEPENDENCIES Core Net Tree)
+                              DEPENDENCIES Core Net)


### PR DESCRIPTION
Not necessary since the refactoring done by Gerri.