### PR TITLE
[PyROOT][WIP] `TTree.AsMatrix(columns)` functionality

### DIFF
--- a/bindings/pyroot/ROOT.py
+++ b/bindings/pyroot/ROOT.py
@@ -238,6 +238,29 @@ def _TTree__iter__( self ):
 
 _root.CreateScopeProxy( "TTree" ).__iter__    = _TTree__iter__
 
+def _proxy__array_interface__(self):
+    getter_array_interface = "_get__array_interface__"
+    if hasattr(self, getter_array_interface):
+        return self._get__array_interface__()
+    else:
+        raise Exception("Class {} does not have method {}.".format(
+            type(self), getter_array_interface))
+
+for pyclass in [
+        "TVectorT<{DTYPE}>",
+        "TMatrixT<{DTYPE}>",
+        "std::vector<{DTYPE}>",
+        "Experimental::VecOps::TVec<{DTYPE}>"
+        ]:
+    if "TVectorT" in pyclass or "TMatrixT" in pyclass:
+        dtypes = ["float", "double"]
+    else:
+        dtypes = ["float", "double", "int", "unsigned int", "long", "unsigned long"]
+    for dtype in dtypes:
+        class_scope = _root.CreateScopeProxy(pyclass.format(DTYPE=dtype))
+        class_scope._proxy__array_interface__ = _proxy__array_interface__
+        class_scope.__array_interface__ = property(class_scope._proxy__array_interface__)
+
 
 ### RINT command emulation ------------------------------------------------------
 def _excepthook( exctype, value, traceb ):

--- a/bindings/pyroot/inc/LinkDef.h
+++ b/bindings/pyroot/inc/LinkDef.h
@@ -13,6 +13,9 @@
 #pragma link C++ class TPyMultiGradFunction;
 
 #pragma link C++ namespace PyROOT;
+#pragma link C++ function PyROOT::TTreeAsFlatMatrix;
+#pragma link C++ function PyROOT::GetAddress;
+#pragma link C++ function PyROOT::GetVectorAddress;
 #pragma link C++ class PyROOT::TPyException;
 #pragma link C++ class PyROOT::TPyROOTApplication;
 

--- a/bindings/pyroot/inc/TTreeAsFlatMatrix.h
+++ b/bindings/pyroot/inc/TTreeAsFlatMatrix.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include "TTree.h"
+#include "ROOT/TDataFrame.hxx"
+#include "Rtypes.h"
+#include <utility>
+
+namespace PyROOT {
+    template <typename dtype>
+    ULong64_t GetVectorAddress(std::vector<dtype> &p){return reinterpret_cast<ULong64_t>(&p);}
+
+    inline ULong64_t GetAddress(std::vector<std::string> &p){return reinterpret_cast<ULong64_t>(&p);}
+    inline ULong64_t GetAddress(TTree &p){return reinterpret_cast<ULong64_t>(&p);}
+
+    template <typename BufType, typename... ColTypes, unsigned long... Idx>
+    void TTreeAsFlatMatrix(
+            std::index_sequence<Idx...>, TTree& tree, std::vector<BufType>& matrix, std::vector<std::string>& columns)
+    {
+        BufType* buffer = matrix.data();
+
+        auto fillMatrix = [buffer](ColTypes... cols, ULong64_t entry) {
+            int expander[] = { (buffer[entry * sizeof...(Idx) + Idx] = cols, 0)... };
+            (void)expander;
+         };
+
+        auto columnsWithEntry = columns;
+        columnsWithEntry.emplace_back("tdfentry_");
+
+        ROOT::Experimental::TDataFrame dataframe(tree, columns);
+        dataframe.Foreach(fillMatrix, columnsWithEntry);
+    }
+
+    template <typename BufType, typename... ColTypes>
+    void TTreeAsFlatMatrixHelper(TTree& tree, std::vector<BufType>& matrix, std::vector<std::string>& columns)
+    {
+        TTreeAsFlatMatrix<BufType, ColTypes...>(std::index_sequence_for<ColTypes...>(), tree, matrix, columns);
+    }
+}

--- a/bindings/pyroot/src/Pythonize.cxx
+++ b/bindings/pyroot/src/Pythonize.cxx
@@ -2268,7 +2268,6 @@ namespace {
    void AddArrayInterface(PyObject *pyclass, PyCFunction func)
    {
       Utility::AddToClass(pyclass, "_get__array_interface__", func, METH_NOARGS);
-      Utility::AddProperty(pyclass, "_get__array_interface__", "__array_interface__");
    }
 
    PyObject *FillArrayInterfaceDict(UInt_t bytes, char type)

--- a/bindings/pyroot/src/TTreeAsFlatMatrix.cxx
+++ b/bindings/pyroot/src/TTreeAsFlatMatrix.cxx
@@ -1,0 +1,1 @@
+#include "TTreeAsFlatMatrix.h"

--- a/bindings/pyroot/src/Utility.cxx
+++ b/bindings/pyroot/src/Utility.cxx
@@ -255,27 +255,6 @@ Bool_t PyROOT::Utility::AddToClass( PyObject* pyclass, const char* label, PyCall
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Add the given function with name 'func' to the class as read-only property 'property'.
-
-Bool_t PyROOT::Utility::AddProperty(PyObject *pyclass, const char *func, const char *property)
-{
-   PyObject *builtin = PyImport_ImportModule("__builtin__");
-   PyObject *property_class = PyObject_GetAttrString(builtin, "property");
-   PyObject *func_obj = PyObject_GetAttrString(pyclass, func);
-   PyObject *arglist = Py_BuildValue("(O)", func_obj);
-   PyObject *property_obj = PyObject_CallObject(property_class, arglist);
-   PyObject_SetAttrString(pyclass, property, property_obj);
-
-   Py_DECREF(builtin);
-   Py_DECREF(property_class);
-   Py_DECREF(func_obj);
-   Py_DECREF(arglist);
-   Py_DECREF(property_obj);
-
-   return kTRUE;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Helper to add base class methods to the derived class one (this covers the
 /// 'using' cases, which the dictionary does not provide).
 

--- a/bindings/pyroot/src/Utility.cxx
+++ b/bindings/pyroot/src/Utility.cxx
@@ -255,6 +255,27 @@ Bool_t PyROOT::Utility::AddToClass( PyObject* pyclass, const char* label, PyCall
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Add the given function with name 'func' to the class as read-only property 'property'.
+
+Bool_t PyROOT::Utility::AddProperty(PyObject *pyclass, const char *func, const char *property)
+{
+   PyObject *builtin = PyImport_ImportModule("__builtin__");
+   PyObject *property_class = PyObject_GetAttrString(builtin, "property");
+   PyObject *func_obj = PyObject_GetAttrString(pyclass, func);
+   PyObject *arglist = Py_BuildValue("(O)", func_obj);
+   PyObject *property_obj = PyObject_CallObject(property_class, arglist);
+   PyObject_SetAttrString(pyclass, property, property_obj);
+
+   Py_DECREF(builtin);
+   Py_DECREF(property_class);
+   Py_DECREF(func_obj);
+   Py_DECREF(arglist);
+   Py_DECREF(property_obj);
+
+   return kTRUE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Helper to add base class methods to the derived class one (this covers the
 /// 'using' cases, which the dictionary does not provide).
 

--- a/bindings/pyroot/src/Utility.h
+++ b/bindings/pyroot/src/Utility.h
@@ -31,9 +31,6 @@ namespace PyROOT {
 
       Bool_t AddUsingToClass( PyObject* pyclass, const char* method );
 
-      // helper to add properties to classes
-      Bool_t AddProperty(PyObject *pyclass, const char *func, const char *property);
-
       // helpers for dynamically constructing binary operators
       Bool_t AddBinaryOperator( PyObject* left, PyObject* right,
          const char* op, const char* label, const char* alt_label = NULL );

--- a/bindings/pyroot/src/Utility.h
+++ b/bindings/pyroot/src/Utility.h
@@ -31,7 +31,10 @@ namespace PyROOT {
 
       Bool_t AddUsingToClass( PyObject* pyclass, const char* method );
 
-   // helpers for dynamically constructing binary operators
+      // helper to add properties to classes
+      Bool_t AddProperty(PyObject *pyclass, const char *func, const char *property);
+
+      // helpers for dynamically constructing binary operators
       Bool_t AddBinaryOperator( PyObject* left, PyObject* right,
          const char* op, const char* label, const char* alt_label = NULL );
       Bool_t AddBinaryOperator( PyObject* pyclass,

--- a/bindings/pyroot/test/CMakeLists.txt
+++ b/bindings/pyroot/test/CMakeLists.txt
@@ -2,5 +2,6 @@ ROOT_ADD_PYUNITTEST(pyroot_conversions conversions.py)
 ROOT_ADD_PYUNITTEST(pyroot_list_initialization list_initialization.py)
 if(NUMPY_FOUND)
     ROOT_ADD_PYUNITTEST(pyroot_array_interface array_interface.py)
+    ROOT_ADD_PYUNITTEST(pyroot_ttree_asmatrix ttree_asmatrix.py)
 endif()
 

--- a/bindings/pyroot/test/CMakeLists.txt
+++ b/bindings/pyroot/test/CMakeLists.txt
@@ -1,2 +1,6 @@
-ROOT_ADD_PYUNITTESTS(pyroot)
+ROOT_ADD_PYUNITTEST(pyroot_conversions conversions.py)
+ROOT_ADD_PYUNITTEST(pyroot_list_initialization list_initialization.py)
+if(NUMPY_FOUND)
+    ROOT_ADD_PYUNITTEST(pyroot_array_interface array_interface.py)
+endif()
 

--- a/bindings/pyroot/test/array_interface.py
+++ b/bindings/pyroot/test/array_interface.py
@@ -1,0 +1,78 @@
+import unittest
+import ROOT
+import numpy as np
+
+
+class ArrayInterface(unittest.TestCase):
+    # Helpers
+    def get_maximum_for_dtype(self, dtype):
+        if np.issubdtype(dtype, np.integer):
+            return np.iinfo(dtype).max
+        if np.issubdtype(dtype, np.floating):
+            return np.finfo(dtype).max
+
+    def get_minimum_for_dtype(self, dtype):
+        if np.issubdtype(dtype, np.integer):
+            return np.iinfo(dtype).min
+        if np.issubdtype(dtype, np.floating):
+            return np.finfo(dtype).min
+
+    def check_memory_adoption_vector(self, root_obj, np_obj):
+        root_obj[0] = self.get_maximum_for_dtype(np_obj.dtype)
+        root_obj[1] = self.get_minimum_for_dtype(np_obj.dtype)
+        self.assertEqual(root_obj[0], np_obj[0])
+        self.assertEqual(root_obj[1], np_obj[1])
+
+    def check_memory_adoption_matrix(self, root_obj, np_obj):
+        root_obj[0][0] = self.get_maximum_for_dtype(np_obj.dtype)
+        root_obj[1][0] = self.get_minimum_for_dtype(np_obj.dtype)
+        self.assertEqual(root_obj[0][0], np_obj[0, 0])
+        self.assertEqual(root_obj[1][0], np_obj[1, 0])
+
+    def check_shape_vector(self, expected_shape, np_obj):
+        self.assertEqual(expected_shape, np_obj.shape)
+
+    def check_shape_matrix(self, expected_shape, np_obj):
+        self.assertEqual(expected_shape, np_obj.shape)
+
+    # TVector
+    def test_TVector(self):
+        for dtype in ["float", "double"]:
+            root_obj = ROOT.TVectorT(dtype)(2)
+            np_obj = np.asarray(root_obj)
+            self.check_memory_adoption_vector(root_obj, np_obj)
+            self.check_shape_vector((2, ), np_obj)
+
+    # TVec
+    def test_TVec(self):
+        for dtype in [
+                "int", "unsigned int", "long", "unsigned long", "float",
+                "double"
+        ]:
+            root_obj = ROOT.Experimental.VecOps.TVec(dtype)(2)
+            np_obj = np.asarray(root_obj)
+            self.check_memory_adoption_vector(root_obj, np_obj)
+            self.check_shape_vector((2, ), np_obj)
+
+    # STL vector
+    def test_STLVector(self):
+        for dtype in [
+                "int", "unsigned int", "long", "unsigned long", "float",
+                "double"
+        ]:
+            root_obj = ROOT.std.vector(dtype)(2)
+            np_obj = np.asarray(root_obj)
+            self.check_memory_adoption_vector(root_obj, np_obj)
+            self.check_shape_vector((2, ), np_obj)
+
+    # TMatrix
+    def test_TMatrix(self):
+        for dtype in ["float", "double"]:
+            root_obj = ROOT.TMatrixT(dtype)(2, 1)
+            np_obj = np.asarray(root_obj)
+            self.check_memory_adoption_matrix(root_obj, np_obj)
+            self.check_shape_matrix((2, 1), np_obj)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bindings/pyroot/test/ttree_asmatrix.py
+++ b/bindings/pyroot/test/ttree_asmatrix.py
@@ -1,0 +1,86 @@
+import unittest
+import ROOT
+import numpy as np
+
+
+class TTreeAsMatrix(unittest.TestCase):
+    # Helpers
+    def make_tree(self, *dtypes):
+        tree = ROOT.TTree("tree", "tree")
+        col_names = ["col{}".format(i) for i in range(len(dtypes))]
+
+        col_vars = []
+        for dtype in dtypes:
+            if "F" in dtype:
+                var = np.empty(1, dtype=np.float32)
+            elif "D" in dtype:
+                var = np.empty(1, dtype=np.float64)
+            elif "I" in dtype:
+                var = np.empty(1, dtype=np.int32)
+            elif "i" in dtype:
+                var = np.empty(1, dtype=np.uint32)
+            elif "L" in dtype:
+                var = np.empty(1, dtype=np.int64)
+            elif "l" in dtype:
+                var = np.empty(1, dtype=np.uint64)
+            else:
+                raise Exception(
+                    "Type {} not known to create branch.".format(dtype))
+            col_vars.append(var)
+
+        for dtype, name, var in zip(dtypes, col_names, col_vars):
+            tree.Branch(name, var, name + "/" + dtype)
+
+        reference = []
+        for i in range(10):
+            row = []
+            for i_var, var in enumerate(col_vars):
+                var[0] = i + i_var
+                row.append(var[0])
+            reference.append(row)
+            tree.Fill()
+
+        return tree, reference, dtypes, col_names, col_vars
+
+    def make_example(self, *dtypes):
+        tree, reference, dtypes, col_names, col_vars = self.make_tree(*dtypes)
+        matrix_ttree = tree.AsMatrix(col_names)
+        matrix_ref = np.asarray(reference)
+        return matrix_ttree, matrix_ref
+
+    # Tests
+    def test_instance(self):
+        tree, _, _, col_names, _ = self.make_tree("F", "F")
+        tree.AsMatrix(col_names)
+
+    def test_shape(self):
+        matrix_ttree, matrix_ref = self.make_example("F", "F")
+        for i in range(2):
+            self.assertEqual(matrix_ttree.shape[i], matrix_ref.shape[i])
+
+    def test_values(self):
+        matrix_ttree, matrix_ref = self.make_example("F", "F")
+        for i in range(matrix_ref.shape[0]):
+            for j in range(matrix_ref.shape[1]):
+                self.assertEqual(matrix_ttree[i, j], matrix_ref[i, j])
+
+    def test_zero_entries(self):
+        tree = ROOT.TTree("tree", "tree")
+        var = np.empty(1, np.float32)
+        tree.Branch("col", var, "col/F")
+        try:
+            tree.AsMatrix(["col"])
+            self.assertFail()
+        except Exception as exception:
+            self.assertEqual("Tree has no entries.", exception.args[0])
+
+    def test_dtypes(self):
+        matrix_ttree, matrix_ref = self.make_example("F", "D", "I", "i", "L",
+                                                     "l")
+        for i in range(matrix_ref.shape[0]):
+            for j in range(matrix_ref.shape[1]):
+                self.assertEqual(matrix_ttree[i, j], matrix_ref[i, j])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR is on top of #1777 and adds the method `TTree.AsMatrix(columns)` as pythonization, which returns the content of the tree as numpy array powered by `TDataFrame`.

TODO:
- Infere the final datatype of the numpy array in a clever way (currently `double` is the default)
- More error-handling?
- More tests? Corner-cases missed?
- What about not supported datatypes? Currently implemented for `float`, `double`, `int`, `unsigned int`, `long`, `unsigned long`. This is dependent on the memory adption feature of #1777 for `std.vector`.