### PR TITLE
[cxxmodules]Restoring back compilation of runtime cxxmodules build after af5a2b4f…

### DIFF
--- a/core/multiproc/inc/ROOT/TProcessExecutor.hxx
+++ b/core/multiproc/inc/ROOT/TProcessExecutor.hxx
@@ -16,8 +16,6 @@
 #include "MPCode.h"
 #include "MPSendRecv.h"
 #include "PoolUtils.h"
-#include "TChain.h"
-#include "TChainElement.h"
 #include "TError.h"
 #include "TFileCollection.h"
 #include "TFileInfo.h"


### PR DESCRIPTION
…338974e4f0763a66506bbc54fe80e3cb
Failure in CDash:
```
In file included from input_line_13:8:
/.../build/include/ROOT/TProcessExecutor.hxx:19:10: remark: building module 'Tree' as '/.../build/lib/Tree.pcm' [-Rmodule-build]
#include "TChain.h"
         ^

Error: Had to build non-system module Tree implicitly. You first need to

generate the dictionary for Tree or mark the C++ module as a system
module if you provided your own system modulemap file:
Tree [system] { ... }
```