### PR TITLE
[TDF] Check whether the top-level branch has 1 leaf with the same name

### DIFF
--- a/tree/treeplayer/src/TDFInterfaceUtils.cxx
+++ b/tree/treeplayer/src/TDFInterfaceUtils.cxx
@@ -102,8 +102,11 @@ void GetBranchNamesImpl(TTree &t, std::set<std::string> &bNamesReg, ColumnNames_
             // Leaf list
 
             auto listOfLeaves = branch->GetListOfLeaves();
-            if (listOfLeaves->GetEntries() == 1)
-               UpdateList(bNamesReg, bNames, branchName, friendName);
+            if (listOfLeaves->GetEntries() == 1) {
+               auto leafName = std::string(static_cast<TLeaf *>(listOfLeaves->At(0))->GetName());
+               if (leafName == branchName)
+                  UpdateList(bNamesReg, bNames, branchName, friendName);
+            }
 
             for (auto leaf : *listOfLeaves) {
                auto leafName = std::string(static_cast<TLeaf *>(leaf)->GetName());

--- a/tree/treeplayer/src/TDFInterfaceUtils.cxx
+++ b/tree/treeplayer/src/TDFInterfaceUtils.cxx
@@ -103,13 +103,13 @@ void GetBranchNamesImpl(TTree &t, std::set<std::string> &bNamesReg, ColumnNames_
 
             auto listOfLeaves = branch->GetListOfLeaves();
             if (listOfLeaves->GetEntries() == 1) {
-               auto leafName = std::string(static_cast<TLeaf *>(listOfLeaves->At(0))->GetName());
+               auto leafName = std::string(listOfLeaves->At(0)->GetName());
                if (leafName == branchName)
                   UpdateList(bNamesReg, bNames, branchName, friendName);
             }
 
             for (auto leaf : *listOfLeaves) {
-               auto leafName = std::string(static_cast<TLeaf *>(leaf)->GetName());
+               auto leafName = std::string(leaf->GetName());
                auto fullName = branchName + "." + leafName;
                UpdateList(bNamesReg, bNames, fullName, friendName);
             }

--- a/tree/treeplayer/test/dataframe/dataframe_leaves.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_leaves.cxx
@@ -42,7 +42,7 @@ struct S {
   int a, b;
 };
 
-TEST(TDFLeaves, LeavesWithDotNameClas)
+TEST(TDFLeaves, LeavesWithDotNameClass)
 {
    TTree t("t", "t");
    S s{40, 41};
@@ -58,3 +58,21 @@ TEST(TDFLeaves, LeavesWithDotNameClas)
    EXPECT_EQ(*four, 4);
    EXPECT_EQ(*ans, 42);
 }
+
+struct S2 {
+  int a;
+};
+
+TEST(TDFLeaves, OneLeafWithDotNameClass)
+{
+   TTree t("t", "t");
+   S2 s{40};
+   t.Branch("s", &s, "a/I");
+   t.Fill();
+   t.ResetBranchAddresses();
+   TDataFrame d(t);
+   auto res = d.Define("res", "s.a").Min<int>("res");
+
+   EXPECT_EQ(*res, 40);
+}
+


### PR DESCRIPTION
This fixes the case of the example shown by @bluehood in #1857 , when the top-level branch has just one leaf, but that leaf does not have the same name as the top-level branch.
In that case, the name of the top-level branch should not appear in the list (TTreeReader is not able to process it).