### PR TITLE
[TMVA] Add multiprocessing to parallelise CV

### DIFF
--- a/tmva/tmva/inc/TMVA/Config.h
+++ b/tmva/tmva/inc/TMVA/Config.h
@@ -75,6 +75,9 @@ namespace TMVA {
       void   SetDrawProgressBar( Bool_t d ) { fDrawProgressBar = d; }
       UInt_t GetNCpu() { return fNCpu; }
 
+      UInt_t GetNumWorkers() const { return fNWorkers; }
+      void   SetNumWorkers(UInt_t n) { fNWorkers = n; }
+
 #ifdef R__USE_IMT
       ROOT::TThreadExecutor &GetThreadExecutor() { return fPool; }
 #endif
@@ -131,11 +134,13 @@ namespace TMVA {
       std::atomic<Bool_t> fSilent;                // no output at all
       std::atomic<Bool_t> fWriteOptionsReference; // if set true: Configurable objects write file with option reference
       std::atomic<Bool_t> fDrawProgressBar;       // draw progress bar to indicate training evolution
+      std::atomic<UInt_t> fNWorkers;              // Default number of workers for multi-process jobs
 #else
       Bool_t fUseColoredConsole;     // coloured standard output
       Bool_t fSilent;                // no output at all
       Bool_t fWriteOptionsReference; // if set true: Configurable objects write file with option reference
       Bool_t fDrawProgressBar;       // draw progress bar to indicate training evolution
+      UInt_t fNWorkers;              // Default number of workers for multi-process jobs
 #endif
       mutable MsgLogger* fLogger;   // message logger
       MsgLogger& Log() const { return *fLogger; }

--- a/tmva/tmva/inc/TMVA/Config.h
+++ b/tmva/tmva/inc/TMVA/Config.h
@@ -130,17 +130,17 @@ namespace TMVA {
    private:
 
 #if __cplusplus > 199711L
+      std::atomic<Bool_t> fDrawProgressBar;       // draw progress bar to indicate training evolution
+      std::atomic<UInt_t> fNWorkers;              // Default number of workers for multi-process jobs
       std::atomic<Bool_t> fUseColoredConsole;     // coloured standard output
       std::atomic<Bool_t> fSilent;                // no output at all
       std::atomic<Bool_t> fWriteOptionsReference; // if set true: Configurable objects write file with option reference
-      std::atomic<Bool_t> fDrawProgressBar;       // draw progress bar to indicate training evolution
-      std::atomic<UInt_t> fNWorkers;              // Default number of workers for multi-process jobs
 #else
+      Bool_t fDrawProgressBar;       // draw progress bar to indicate training evolution
+      UInt_t fNWorkers;              // Default number of workers for multi-process jobs
       Bool_t fUseColoredConsole;     // coloured standard output
       Bool_t fSilent;                // no output at all
       Bool_t fWriteOptionsReference; // if set true: Configurable objects write file with option reference
-      Bool_t fDrawProgressBar;       // draw progress bar to indicate training evolution
-      UInt_t fNWorkers;              // Default number of workers for multi-process jobs
 #endif
       mutable MsgLogger* fLogger;   // message logger
       MsgLogger& Log() const { return *fLogger; }

--- a/tmva/tmva/inc/TMVA/DataSet.h
+++ b/tmva/tmva/inc/TMVA/DataSet.h
@@ -117,6 +117,8 @@ namespace TMVA {
       void      DeleteResults   ( const TString &,
                                   Types::ETreeType type,
                                   Types::EAnalysisType analysistype );
+      void      DeleteAllResults(Types::ETreeType type,
+                                 Types::EAnalysisType analysistype);
 
       void      SetVerbose( Bool_t ) {}
 

--- a/tmva/tmva/src/Config.cxx
+++ b/tmva/tmva/src/Config.cxx
@@ -54,12 +54,12 @@ TMVA::Config& TMVA::gConfig() { return TMVA::Config::Instance(); }
 /// constructor - set defaults
 
 TMVA::Config::Config() :
+   fDrawProgressBar      ( kFALSE ),
+   fNWorkers             (1),
    fUseColoredConsole    ( kTRUE  ),
    fSilent               ( kFALSE ),
    fWriteOptionsReference( kFALSE ),
-   fDrawProgressBar      ( kFALSE ),
-   fLogger               ( new MsgLogger("Config") ),
-   fNWorkers             (1)
+   fLogger               (new MsgLogger("Config"))
 {
    // plotting
    fVariablePlotting.fTimesRMS = 8.0;

--- a/tmva/tmva/src/Config.cxx
+++ b/tmva/tmva/src/Config.cxx
@@ -58,7 +58,8 @@ TMVA::Config::Config() :
    fSilent               ( kFALSE ),
    fWriteOptionsReference( kFALSE ),
    fDrawProgressBar      ( kFALSE ),
-   fLogger               ( new MsgLogger("Config") )
+   fLogger               ( new MsgLogger("Config") ),
+   fNWorkers             (1)
 {
    // plotting
    fVariablePlotting.fTimesRMS = 8.0;

--- a/tmva/tmva/src/CrossValidation.cxx
+++ b/tmva/tmva/src/CrossValidation.cxx
@@ -457,8 +457,8 @@ TMVA::CrossValidationFoldResult TMVA::CrossValidation::ProcessFold(UInt_t iFold,
 
    // Clean-up for this fold
    {
-      smethod->Data()->DeleteResults(foldTitle, Types::kTraining, smethod->GetAnalysisType());
-      smethod->Data()->DeleteResults(foldTitle, Types::kTesting, smethod->GetAnalysisType());
+      smethod->Data()->DeleteAllResults(Types::kTraining, smethod->GetAnalysisType());
+      smethod->Data()->DeleteAllResults(Types::kTesting, smethod->GetAnalysisType());
    }
 
    fFoldFactory->DeleteAllMethods();

--- a/tmva/tmva/src/CrossValidation.cxx
+++ b/tmva/tmva/src/CrossValidation.cxx
@@ -551,7 +551,9 @@ void TMVA::CrossValidation::Evaluate()
       IMethod *method_interface = fFactory->GetMethod(fDataLoader.get()->GetName(), methodTitle);
       MethodCrossValidation *method = dynamic_cast<MethodCrossValidation *>(method_interface);
 
-      fFactory->WriteDataInformation(method->fDataSetInfo);
+      if (fOutputFile) {
+         fFactory->WriteDataInformation(method->fDataSetInfo);
+      }
 
       Event::SetIsTraining(kTRUE);
       method->TrainMethod();

--- a/tmva/tmva/src/DataSet.cxx
+++ b/tmva/tmva/src/DataSet.cxx
@@ -720,6 +720,34 @@ TTree* TMVA::DataSet::GetTree( Types::ETreeType type )
 
    }
 
+   // Sanity check, ensure all result sets have the expected number of events
+   for (auto && itMethod : fResults.at(t)) {
+      auto numEvents = GetNEvents(type);
+      auto results = itMethod.second;
+      auto resultsName = itMethod.first;
+
+      Long64_t numEventsResults = 0;
+      auto analysisType = results->GetAnalysisType();
+      if (analysisType == Types::kClassification) {
+         numEventsResults = dynamic_cast<ResultsClassification *>(results)->GetSize();
+      } else if (analysisType == Types::kMulticlass) {
+         numEventsResults = dynamic_cast<ResultsMulticlass *>(results)->GetSize();
+      } else if (analysisType == Types::kRegression) {
+         numEventsResults = dynamic_cast<ResultsRegression *>(results)->GetSize();
+      } else {
+         Log() << kFATAL << "Unexpected analysisType." << Endl;
+      }
+
+      if (numEventsResults != numEvents) {
+         Log() << kFATAL << "An error occurred in DataSet::GetTree. "
+                            "Inconsistent size of result for result with name '"
+                         << resultsName << "'."
+                         << " Size is '" << std::to_string(numEventsResults)
+                         << "'.'"
+                         << " Expected '" << numEvents << "'." << Endl;
+      }
+   }
+
    // loop through all the events
    for (Long64_t iEvt = 0; iEvt < GetNEvents( type ); iEvt++) {
       // write the event-variables

--- a/tmva/tmva/src/DataSet.cxx
+++ b/tmva/tmva/src/DataSet.cxx
@@ -764,32 +764,27 @@ TTree* TMVA::DataSet::GetTree( Types::ETreeType type )
 
 
       // loop through all the results and write the branches
-      n=0;
-      for (std::map<TString, Results*>::iterator itMethod = fResults.at(t).begin();
-           itMethod != fResults.at(t).end(); ++itMethod) {
-         Results* results = itMethod->second;
+      auto iMethod = 0;
+      for (auto && itMethod : fResults.at(t)) {
+         auto & results = *itMethod.second;
+         auto analysisType = results.GetAnalysisType();
 
-         const std::vector< Float_t >& vals = results->operator[](iEvt);
+         auto const & vals = results[iEvt];
 
-         if (itMethod->second->GetAnalysisType() == Types::kClassification) {
-            // classification
-            metVals[n][0] = vals[0];
-         }
-         else if (itMethod->second->GetAnalysisType() == Types::kMulticlass) {
-            // multiclass classification
-            for (UInt_t nCls = 0, nClsEnd=fdsi->GetNClasses(); nCls < nClsEnd; nCls++) {
+         if (analysisType == Types::kClassification) {
+            metVals[iMethod][0] = vals[0];
+         } else if (analysisType == Types::kMulticlass) {
+            for (UInt_t nCls = 0; nCls < fdsi->GetNClasses(); nCls++) {
                Float_t val = vals.at(nCls);
-               metVals[n][nCls] = val;
+               metVals[iMethod][nCls] = val;
             }
-         }
-         else if (itMethod->second->GetAnalysisType() == Types::kRegression) {
-            // regression
+         } else if (analysisType == Types::kRegression) {
             for (UInt_t nTgts = 0; nTgts < fdsi->GetNTargets(); nTgts++) {
                Float_t val = vals.at(nTgts);
-               metVals[n][nTgts] = val;
+               metVals[iMethod][nTgts] = val;
             }
          }
-         n++;
+         ++iMethod;
       }
       // fill the variables into the tree
       tree->Fill();

--- a/tmva/tmva/src/DataSet.cxx
+++ b/tmva/tmva/src/DataSet.cxx
@@ -336,6 +336,35 @@ void TMVA::DataSet::DeleteResults( const TString & resultsName,
             << " of type " << type << " which I should have deleted" << Endl;
    }
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Deletes all results currently in the dataset.
+///
+void TMVA::DataSet::DeleteAllResults(Types::ETreeType type,
+                                     Types::EAnalysisType /* analysistype */ )
+{
+   if (fResults.empty()) return;
+
+   if (UInt_t(type) > fResults.size()){
+      Log()<<kFATAL<< Form("Dataset[%s] : ",fdsi->GetName()) << "you asked for an Treetype (training/testing/...)"
+           << " whose index " << type << " does not exist " << Endl;
+   }
+
+   std::map<TString, Results *> & resultsForType = fResults[UInt_t(type)];
+
+   for (auto && it : resultsForType) {
+      auto & resultsName = it.first;
+
+      Log() << kDEBUG << Form("Dataset[%s] : ", fdsi->GetName())
+                      << " DeleteAllResults previous existing result: "
+                      << resultsName << " of type " << type << Endl;
+
+      delete it.second;
+   }
+
+   resultsForType.clear();
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// divide training set
 

--- a/tmva/tmva/test/crossvalidation/CMakeLists.txt
+++ b/tmva/tmva/test/crossvalidation/CMakeLists.txt
@@ -10,6 +10,9 @@ include_directories(${ROOT_INCLUDE_DIRS})
 ROOT_ADD_GTEST(testCrossValidationSplitting
                TestCrossValidationSplitting.cxx
                LIBRARIES ${Libraries})
+ROOT_ADD_GTEST(testCrossValidationMultiProc
+               TestCrossValidationMultiProc.cxx
+               LIBRARIES ${Libraries})
 
 # Tests
 ROOT_EXECUTABLE(testCrossValidationSerialise

--- a/tmva/tmva/test/crossvalidation/TestCrossValidationMultiProc.cxx
+++ b/tmva/tmva/test/crossvalidation/TestCrossValidationMultiProc.cxx
@@ -1,0 +1,152 @@
+
+#include "gtest/gtest.h"
+
+#include <TFile.h>
+#include <TMath.h>
+#include <TTree.h>
+#include <TString.h>
+#include <TSystem.h>
+
+#include "TMVA/CrossValidation.h"
+#include "TMVA/DataLoader.h"
+#include "TMVA/Reader.h"
+#include "TMVA/Tools.h"
+
+#include <vector>
+
+constexpr UInt_t NUM_FOLDS = 2;
+constexpr UInt_t NUM_EVENTS = 100;
+constexpr UInt_t NUM_EVENTS_SIG = NUM_EVENTS / 2;
+constexpr UInt_t NUM_EVENTS_BKG = NUM_EVENTS - NUM_EVENTS_SIG;
+
+/**
+ * Generates two slightly offset gaussians and returns a non-owning pointer
+ * to a TTree.
+ */
+TTree *genTree(Int_t nPoints, Double_t offset, Double_t scale = 0.3, UInt_t seed = 100)
+{
+   TRandom3 rng(seed);
+   Float_t x = 0;
+   Float_t y = 0;
+   UInt_t id = 0;
+
+   auto data = new TTree();
+   data->Branch("x", &x, "x/F");
+   data->Branch("y", &y, "y/F");
+   data->Branch("EventNumber", &id, "EventNumber/I");
+
+   for (Int_t n = 0; n < nPoints; ++n) {
+      x = rng.Gaus(offset, scale);
+      y = rng.Gaus(offset, scale);
+      data->Fill();
+      ++id;
+   }
+
+   // Important: Disconnects the tree from the memory locations of x and y.
+   data->ResetBranchAddresses();
+   return data;
+}
+
+/**
+ * Trains a TMVA method using the specified number of worker processes.
+ * @param  numWorkers Number of processes to use for parallel fold execution.
+ * @return            The path to the weight file where the method was stored
+ *                    and the time it took to execute the evaluation, exluding
+ *                    data generation, in seconds.
+ */
+std::pair<std::string, double> runCrossValidation(UInt_t numWorkers)
+{
+   using clock_t = std::chrono::high_resolution_clock;
+   using milli_t = std::chrono::duration<double, std::milli>;
+
+   TTree *sigTree = genTree(NUM_EVENTS_SIG, 0.3, 0.3, 100);
+   TTree *bkgTree = genTree(NUM_EVENTS_BKG, 0.3, 0.3, 101);
+
+   auto *dataloader = new TMVA::DataLoader("cv-multiproc");
+   dataloader->AddSignalTree(sigTree);
+   dataloader->AddBackgroundTree(bkgTree);
+
+   dataloader->AddVariable("x", 'D');
+   dataloader->AddVariable("y", 'D');
+   dataloader->AddSpectator("EventNumber", 'I');
+
+   TString dataloaderOptions = Form("SplitMode=Block:nTrain_Signal=%i"
+                                    ":nTrain_Background=%i:!V",
+                                    NUM_EVENTS_SIG, NUM_EVENTS_BKG);
+   dataloader->PrepareTrainingAndTestTree("", dataloaderOptions);
+
+   // TMVA::CrossValidation takes ownership of dataloader
+   std::string splitExpr = "int([EventNumber])%int([NumFolds]";
+   TMVA::CrossValidation cv{Form("%i-proc", numWorkers), dataloader,
+                            Form("Silent:AnalysisType=Classification"
+                                 ":NumWorkerProcs=%i:NumFolds=%i"
+                                 ":SplitExpr=%s)",
+                                 numWorkers, NUM_FOLDS, splitExpr.c_str())};
+
+   cv.BookMethod(TMVA::Types::kBDT, "BDT", "!H:!V:NTrees=100:MaxDepth=3");
+
+   auto StartTime = clock_t::now();
+   cv.Evaluate();
+   auto EndTime = clock_t::now();
+   double duration = milli_t(EndTime - StartTime).count() / 1000.0;
+
+   delete sigTree;
+   delete bkgTree;
+
+   std::string dsname{dataloader->GetName()};
+   std::string cvname{cv.GetName()};
+   std::string weightPath = dsname + "/weights/" + cvname + "_BDT.weights.xml";
+   return std::make_pair(weightPath, duration);
+}
+
+/**
+ * Verify that the two methods generate the same output when presented the same
+ * input.
+ * @param methodA Path to a method weight file.
+ * @param methodB Another path to method weight file.
+ */
+void verify(std::string methodA, std::string methodB)
+{
+   TMVA::Reader reader;
+   Float_t x;
+   Float_t y;
+   Float_t id;
+
+   reader.AddVariable("x", &x);
+   reader.AddVariable("y", &y);
+   reader.AddSpectator("EventNumber", &id);
+
+   reader.BookMVA("BDT1", methodA.c_str());
+   reader.BookMVA("BDT2", methodB.c_str());
+
+   TTree *tree = genTree(NUM_EVENTS, 0.3, 0.3, 200);
+
+   for (Long64_t ievt = 0; ievt < NUM_EVENTS; ievt++) {
+      tree->GetEntry(ievt);
+
+      Float_t valA = reader.EvaluateMVA("BDT1");
+      Float_t valB = reader.EvaluateMVA("BDT2");
+
+      ASSERT_EQ(valA, valB) << "Output when using a single proces and multiple"
+                               " processes differ! >:(";
+   }
+}
+
+TEST(CrossValidationMultiprocess, EqualOutputTo)
+{
+   // Generate two methods, one created with a single process, the other in
+   // parallel using TProcessExecutor.
+   auto p1 = runCrossValidation(1);
+   auto p2 = runCrossValidation(2);
+
+   // Print duration
+   double duration1 = std::get<1>(p1);
+   double duration2 = std::get<1>(p2);
+   std::cout << "CV with 1 process took  : " << duration1 << std::endl;
+   std::cout << "CV with 2 processes took: " << duration2 << std::endl;
+
+   // Verify that the two models generate the same output given the same input.
+   std::string weightPath1 = std::get<0>(p1);
+   std::string weightPath2 = std::get<0>(p2);
+   verify(weightPath1, weightPath2);
+}

--- a/tmva/tmva/test/crossvalidation/TestCrossValidationMultiProc.cxx
+++ b/tmva/tmva/test/crossvalidation/TestCrossValidationMultiProc.cxx
@@ -56,8 +56,8 @@ TTree *genTree(Int_t nPoints, Double_t offset, Double_t scale = 0.3, UInt_t seed
  */
 std::pair<std::string, double> runCrossValidation(UInt_t numWorkers)
 {
-   using clock_t = std::chrono::high_resolution_clock;
-   using milli_t = std::chrono::duration<double, std::milli>;
+   using cv_clock_t = std::chrono::high_resolution_clock;
+   using cv_milli_t = std::chrono::duration<double, std::milli>;
 
    TTree *sigTree = genTree(NUM_EVENTS_SIG, 0.3, 0.3, 100);
    TTree *bkgTree = genTree(NUM_EVENTS_BKG, 0.3, 0.3, 101);
@@ -85,10 +85,10 @@ std::pair<std::string, double> runCrossValidation(UInt_t numWorkers)
 
    cv.BookMethod(TMVA::Types::kBDT, "BDT", "!H:!V:NTrees=100:MaxDepth=3");
 
-   auto StartTime = clock_t::now();
+   auto StartTime = cv_clock_t::now();
    cv.Evaluate();
-   auto EndTime = clock_t::now();
-   double duration = milli_t(EndTime - StartTime).count() / 1000.0;
+   auto EndTime = cv_clock_t::now();
+   double duration = cv_milli_t(EndTime - StartTime).count() / 1000.0;
 
    delete sigTree;
    delete bkgTree;
@@ -127,7 +127,7 @@ void verify(std::string methodA, std::string methodB)
       Float_t valA = reader.EvaluateMVA("BDT1");
       Float_t valB = reader.EvaluateMVA("BDT2");
 
-      ASSERT_EQ(valA, valB) << "Output when using a single proces and multiple"
+      ASSERT_EQ(valA, valB) << "Output when using a single process and multiple"
                                " processes differ! >:(";
    }
 }

--- a/tutorials/tmva/TMVACrossValidation.C
+++ b/tutorials/tmva/TMVACrossValidation.C
@@ -68,8 +68,9 @@
 #include "TSystem.h"
 #include "TROOT.h"
 
-#include "TMVA/Factory.h"
+#include "TMVA/CrossValidation.h"
 #include "TMVA/DataLoader.h"
+#include "TMVA/Factory.h"
 #include "TMVA/Tools.h"
 #include "TMVA/TMVAGui.h"
 
@@ -186,20 +187,20 @@ int TMVACrossValidation()
                             ":SplitExpr=%s",
                             analysisType.Data(), numFolds, splitExpr.Data());
 
-   TMVA::CrossValidation ce{"TMVACrossValidation", dataloader, outputFile, cvOptions};
+   TMVA::CrossValidation cv{"TMVACrossValidation", dataloader, outputFile, cvOptions};
 
    // --------------------------------------------------------------------------
 
    //
    // Books a method to use for evaluation
    //
-   ce.BookMethod(TMVA::Types::kBDT, "BDTG",
-                 "!H:!V:NTrees=100:MinNodeSize=2.5%:BoostType=Grad:"
-                 "Shrinkage=0.10:nCuts=20:MaxDepth=2");
+   cv.BookMethod(TMVA::Types::kBDT, "BDTG",
+                 "!H:!V:NTrees=100:MinNodeSize=2.5%:BoostType=Grad"
+                 ":NegWeightTreatment=Pray:Shrinkage=0.10:nCuts=20"
+                 ":MaxDepth=2");
 
-   ce.BookMethod(TMVA::Types::kFisher, "Fisher",
-                 "H:!V:Fisher:VarTransform=None:CreateMVAPdfs:"
-                 "PDFInterpolMVAPdf=Spline2:NbinsMVAPdf=50:NsmoothMVAPdf=10");
+   cv.BookMethod(TMVA::Types::kFisher, "Fisher",
+                 "!H:!V:Fisher:VarTransform=None");
 
    // --------------------------------------------------------------------------
 
@@ -208,7 +209,7 @@ int TMVACrossValidation()
    // Evaluates the booked methods once for each fold and aggregates the result
    // in the specified output file.
    //
-   ce.Evaluate();
+   cv.Evaluate();
 
    // --------------------------------------------------------------------------
 
@@ -217,10 +218,10 @@ int TMVACrossValidation()
    // booked method.
    //
    size_t iMethod = 0;
-   for (auto && result : ce.GetResults()) {
-      std::cout << "Summary for method " << ce.GetMethods()[iMethod++].GetValue<TString>("MethodName")
+   for (auto && result : cv.GetResults()) {
+      std::cout << "Summary for method " << cv.GetMethods()[iMethod++].GetValue<TString>("MethodName")
                 << std::endl;
-      for (UInt_t iFold = 0; iFold<ce.GetNumFolds(); ++iFold) {
+      for (UInt_t iFold = 0; iFold<cv.GetNumFolds(); ++iFold) {
          std::cout << "\tFold " << iFold << ": "
                    << "ROC int: " << result.GetROCValues()[iFold]
                    << ", "


### PR DESCRIPTION
Based on PR #858. Implements only parts relevant for CV.

Rudimentary performance benchmark with ~60000 events with 2-fold CV
```
Multiproc: root -l -b -q TMVACrossValidation.C  15.82s user 0.46s system 152% cpu 10.679 total
Standard: root -l -b -q TMVACrossValidation.C  14.31s user 0.25s system 99% cpu 14.652 total
```
Which translates into a 4 second speed up.

A different example, with a deeper bdt forest and 10-fold CV, almost halves the required time on my machine :)
```
Single     : root -l -b -q TMVACrossValidation.C  33.66s user 1.99s system 98%  cpu 36.369 total
Multiproc 2: root -l -b -q TMVACrossValidation.C  39.14s user 2.68s system 167% cpu 25.016 total
Multiproc 4: root -l -b -q TMVACrossValidation.C  46.52s user 3.50s system 233% cpu 21.420 total
```

For the second example, these changes to `TMVACrossValidation.C` were used.
```
/* ...snip... */
TString cvOptions = Form("!V:NumWorkerProcs=4"
/* ...snip... */
cv.BookMethod(TMVA::Types::kBDT, "BDTG",
              "!H:!V:NTrees=1000:MinNodeSize=2.5%:BoostType=Grad"
              ":NegWeightTreatment=Pray:Shrinkage=0.10:nCuts=20"
              ":MaxDepth=6");
/* ...snip... */
// cv.BookMethod(TMVA::Types::kFisher, "Fisher",
//               "!H:!V:Fisher:VarTransform=None");
/* ...snip... */
```