### PR TITLE
[TDF] ROOT-9357: Implement Snapshot as a lazy action

### DIFF
--- a/tree/treeplayer/inc/ROOT/TSnapshotOptions.hxx
+++ b/tree/treeplayer/inc/ROOT/TSnapshotOptions.hxx
@@ -24,16 +24,17 @@ struct TSnapshotOptions {
    TSnapshotOptions() = default;
    TSnapshotOptions(const TSnapshotOptions &) = default;
    TSnapshotOptions(TSnapshotOptions &&) = default;
-   TSnapshotOptions(std::string_view mode, ECAlgo comprAlgo, int comprLevel, int autoFlush, int splitLevel)
+   TSnapshotOptions(std::string_view mode, ECAlgo comprAlgo, int comprLevel, int autoFlush, int splitLevel, bool lazy)
       : fMode(mode), fCompressionAlgorithm(comprAlgo), fCompressionLevel{comprLevel}, fAutoFlush(autoFlush),
-        fSplitLevel(splitLevel)
+        fSplitLevel(splitLevel), fLazy(lazy)
    {
    }
    std::string fMode = "RECREATE";             //< Mode of creation of output file
-   ECAlgo fCompressionAlgorithm = ROOT::kLZ4; //< Compression algorithm of output file
+   ECAlgo fCompressionAlgorithm = ROOT::kLZ4;  //< Compression algorithm of output file
    int fCompressionLevel = 4;                  //< Compression level of output file
    int fAutoFlush = 0;                         //< AutoFlush value for output tree
    int fSplitLevel = 99;                       //< Split level of output tree
+   bool fLazy = false;                         //< Delay the snapshot of the dataset
 };
 }
 }

--- a/tree/treeplayer/test/dataframe/dataframe_cache.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_cache.cxx
@@ -115,11 +115,11 @@ TEST(Cache, InternalColumnsSnapshot)
    auto colName = "tdfMySecretcol_";
    auto orig = tdf.Define(colName, [&f]() { return f++; }).Define("dummy", []() { return 0.f; });
    auto cached = orig.Cache<float, float>({colName, "dummy"});
-   auto snapshot = cached.Snapshot("t", "InternalColumnsSnapshot.root", "", {"RECREATE", ROOT::kZLIB, 0, 0, 99});
+   auto snapshot = cached.Snapshot("t", "InternalColumnsSnapshot.root", "", {"RECREATE", ROOT::kZLIB, 0, 0, 99, false});
    int ret(1);
    try {
       testing::internal::CaptureStderr();
-      snapshot.Mean<ULong64_t>(colName);
+      snapshot->Mean<ULong64_t>(colName);
    } catch (const std::runtime_error &e) {
       ret = 0;
    }

--- a/tree/treeplayer/test/dataframe/datasource_csv.cxx
+++ b/tree/treeplayer/test/dataframe/datasource_csv.cxx
@@ -104,7 +104,7 @@ TEST(TCsvDS, Snapshot)
 {
    auto tdf = ROOT::Experimental::TDF::MakeCsvDataFrame(fileName0);
    auto snap = tdf.Snapshot<Long64_t>("data","csv2root.root", {"Age"});
-   auto ages = *snap.Take<Long64_t>("Age");
+   auto ages = *snap->Take<Long64_t>("Age");
    std::vector<Long64_t> agesRef {60LL, 50LL, 40LL, 30LL, 1LL, -1LL};
    for (auto i : ROOT::TSeqI(agesRef.size())) {
       EXPECT_EQ(ages[i], agesRef[i]);

--- a/tree/treeplayer/test/dataframe/datasource_trivial.cxx
+++ b/tree/treeplayer/test/dataframe/datasource_trivial.cxx
@@ -203,7 +203,7 @@ TEST(TTrivialDS, Snapshot)
    const auto fname = "datasource_trivial_snapshot.root";
    TDataFrame tdf(std::move(tds));
    auto tdf2 = tdf.Snapshot("t", fname, "col0");
-   auto c = tdf2.Take<ULong64_t>("col0");
+   auto c = tdf2->Take<ULong64_t>("col0");
    auto i = 0u;
    for (auto e : c) {
       EXPECT_EQ(e, i);

--- a/tutorials/dataframe/tdf007_snapshot.C
+++ b/tutorials/dataframe/tdf007_snapshot.C
@@ -87,7 +87,7 @@ int tdf007_snapshot()
    // Notice also how we can decide to be more explicit with the types of the
    // columns.
    auto snapshot_tdf = d2.Snapshot<int>(treeName, outFileName, {"b1_square"});
-   auto h = snapshot_tdf.Histo1D();
+   auto h = snapshot_tdf->Histo1D();
    auto c = new TCanvas();
    h->DrawClone();
 


### PR DESCRIPTION
 - A new parameter, the lazyness of the snapshot, has been added to the TSnapshotOptions
 - The Snapshot methods return a TResultPtr<TInteface<TLoopManager>> rather than a TInteface<TLoopManager>
 - Tests and tutorials adapted
 - New test for lazy snapshot added