### PR TITLE
[PyROOT] Add numpy array interface to TVec and STL vector

### DIFF
--- a/bindings/pyroot/src/Pythonize.cxx
+++ b/bindings/pyroot/src/Pythonize.cxx
@@ -42,6 +42,8 @@
 #include "TStreamerElement.h"
 #include "TStreamerInfo.h"
 
+#include "ROOT/TVec.hxx"
+
 // Standard
 #include <stdexcept>
 #include <string>
@@ -2260,8 +2262,54 @@ namespace {
       return BindCppObject( addr, (Cppyy::TCppType_t)Cppyy::GetScope( "TObject" ), kFALSE );
    }
 
+   //- Adding array interface to classes ---------------
+   void AddArrayInterface(PyObject *pyclass, PyCFunction func)
+   {
+      Utility::AddToClass(pyclass, "_get__array_interface__", func, METH_NOARGS);
+   }
 
-//- simplistic len() functions -------------------------------------------------
+   PyObject *FillArrayInterfaceDict(UInt_t bytes, char type)
+   {
+      PyObject *dict = PyDict_New();
+      PyDict_SetItemString(dict, "version", PyLong_FromLong(3));
+#ifdef R__BYTESWAP
+      const char endianess = '<';
+#else
+      const char endianess = '>';
+#endif
+      PyDict_SetItemString(dict, "typestr",
+                           PyROOT_PyUnicode_FromString(TString::Format("%c%c%i", endianess, type, bytes).Data()));
+      return dict;
+   }
+
+   template <typename dtype, UInt_t bytes, char typestr>
+   PyObject *STLVectorArrayInterface(ObjectProxy *self)
+   {
+      std::vector<dtype> *cobj = (std::vector<dtype> *)(self->GetObject());
+
+      PyObject *dict = FillArrayInterfaceDict(bytes, typestr);
+      PyDict_SetItemString(dict, "shape", PyTuple_Pack(1, PyLong_FromLong(cobj->size())));
+      PyDict_SetItemString(dict, "data",
+                           PyTuple_Pack(2, PyLong_FromLong(reinterpret_cast<long>(cobj->data())), Py_False));
+
+      return dict;
+   }
+
+   template <typename dtype, UInt_t bytes, char typestr>
+   PyObject *TVecArrayInterface(ObjectProxy *self)
+   {
+      using ROOT::Experimental::VecOps::TVec;
+      TVec<dtype> *cobj = (TVec<dtype> *)(self->GetObject());
+
+      PyObject *dict = FillArrayInterfaceDict(bytes, typestr);
+      PyDict_SetItemString(dict, "shape", PyTuple_Pack(1, PyLong_FromLong(cobj->size())));
+      PyDict_SetItemString(dict, "data",
+                           PyTuple_Pack(2, PyLong_FromLong(reinterpret_cast<long>(cobj->data())), Py_False));
+
+      return dict;
+   }
+
+   //- simplistic len() functions -------------------------------------------------
    PyObject* ReturnThree( ObjectProxy*, PyObject* ) {
       return PyInt_FromLong( 3 );
    }
@@ -2465,6 +2513,21 @@ Bool_t PyROOT::Pythonize( PyObject* pyclass, const std::string& name )
          Utility::AddToClass( pyclass, "__setitem__", (PyCFunction) VectorBoolSetItem );
       }
 
+      // add array interface
+      if (name.find("<float>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)STLVectorArrayInterface<float, 4, 'f'>);
+      } else if (name.find("<double>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)STLVectorArrayInterface<double, 8, 'f'>);
+      } else if (name.find("<int>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)STLVectorArrayInterface<int, 4, 'i'>);
+      } else if (name.find("<unsigned int>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)STLVectorArrayInterface<unsigned int, 4, 'u'>);
+      } else if (name.find("<long>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)STLVectorArrayInterface<long, 8, 'i'>);
+      } else if (name.find("<unsigned long>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)STLVectorArrayInterface<unsigned long, 8, 'u'>);
+      }
+
    }
 
    else if ( IsTemplatedSTLClass( name, "map" ) ) {
@@ -2633,11 +2696,11 @@ Bool_t PyROOT::Pythonize( PyObject* pyclass, const std::string& name )
 
    }
 
-   else if ( name.substr(0,8) == "TVectorT" ) {  // allow proper iteration
+   else if (name.find("TVectorT") != std::string::npos) {
+      // allow proper iteration
       Utility::AddToClass( pyclass, "__len__", "GetNoElements" );
       Utility::AddToClass( pyclass, "_getitem__unchecked", "__getitem__" );
       Utility::AddToClass( pyclass, "__getitem__", (PyCFunction) CheckedGetItem, METH_O );
-
    }
 
    else if ( name.substr(0,6) == "TArray" && name != "TArray" ) {    // allow proper iteration
@@ -2653,9 +2716,25 @@ Bool_t PyROOT::Pythonize( PyObject* pyclass, const std::string& name )
    else if ( name == "RooSimultaneous" )
       Utility::AddUsingToClass( pyclass, "plotOn" );
 
+   else if (name.find("TVec<") != std::string::npos) {
+      // add array interface
+      if (name.find("<float>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)TVecArrayInterface<float, 4, 'f'>);
+      } else if (name.find("<double>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)TVecArrayInterface<double, 8, 'f'>);
+      } else if (name.find("<int>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)TVecArrayInterface<int, 4, 'i'>);
+      } else if (name.find("<unsigned int>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)TVecArrayInterface<unsigned int, 4, 'u'>);
+      } else if (name.find("<long>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)TVecArrayInterface<long, 8, 'i'>);
+      } else if (name.find("<unsigned long>") != std::string::npos) {
+         AddArrayInterface(pyclass, (PyCFunction)TVecArrayInterface<unsigned long, 8, 'u'>);
+      }
+   }
 
-// TODO: store these on the pythonizations module, not on gRootModule
-// TODO: externalize this code and use update handlers on the python side
+   // TODO: store these on the pythonizations module, not on gRootModule
+   // TODO: externalize this code and use update handlers on the python side
    PyObject* userPythonizations = PyObject_GetAttrString( gRootModule, "UserPythonizations" );
    PyObject* pythonizationScope = PyObject_GetAttrString( gRootModule, "PythonizationScope" );
 

--- a/bindings/pyroot/src/Utility.h
+++ b/bindings/pyroot/src/Utility.h
@@ -31,7 +31,7 @@ namespace PyROOT {
 
       Bool_t AddUsingToClass( PyObject* pyclass, const char* method );
 
-   // helpers for dynamically constructing binary operators
+      // helpers for dynamically constructing binary operators
       Bool_t AddBinaryOperator( PyObject* left, PyObject* right,
          const char* op, const char* label, const char* alt_label = NULL );
       Bool_t AddBinaryOperator( PyObject* pyclass,

--- a/bindings/pyroot/test/CMakeLists.txt
+++ b/bindings/pyroot/test/CMakeLists.txt
@@ -1,2 +1,6 @@
-ROOT_ADD_PYUNITTESTS(pyroot)
+ROOT_ADD_PYUNITTEST(pyroot_conversions conversions.py)
+ROOT_ADD_PYUNITTEST(pyroot_list_initialization list_initialization.py)
+if(NUMPY_FOUND)
+    ROOT_ADD_PYUNITTEST(pyroot_array_interface array_interface.py)
+endif()
 

--- a/bindings/pyroot/test/array_interface.py
+++ b/bindings/pyroot/test/array_interface.py
@@ -1,0 +1,50 @@
+import unittest
+import ROOT
+import numpy as np
+
+
+class ArrayInterface(unittest.TestCase):
+    # Helpers
+    dtypes = [
+        "int", "unsigned int", "long", "unsigned long", "float", "double"
+    ]
+
+    def get_maximum_for_dtype(self, dtype):
+        if np.issubdtype(dtype, np.integer):
+            return np.iinfo(dtype).max
+        if np.issubdtype(dtype, np.floating):
+            return np.finfo(dtype).max
+
+    def get_minimum_for_dtype(self, dtype):
+        if np.issubdtype(dtype, np.integer):
+            return np.iinfo(dtype).min
+        if np.issubdtype(dtype, np.floating):
+            return np.finfo(dtype).min
+
+    def check_memory_adoption(self, root_obj, np_obj):
+        root_obj[0] = self.get_maximum_for_dtype(np_obj.dtype)
+        root_obj[1] = self.get_minimum_for_dtype(np_obj.dtype)
+        self.assertEqual(root_obj[0], np_obj[0])
+        self.assertEqual(root_obj[1], np_obj[1])
+
+    def check_shape(self, expected_shape, np_obj):
+        self.assertEqual(expected_shape, np_obj.shape)
+
+    # Tests
+    def test_TVec(self):
+        for dtype in self.dtypes:
+            root_obj = ROOT.Experimental.VecOps.TVec(dtype)(2)
+            np_obj = np.asarray(root_obj)
+            self.check_memory_adoption(root_obj, np_obj)
+            self.check_shape((2, ), np_obj)
+
+    def test_STLVector(self):
+        for dtype in self.dtypes:
+            root_obj = ROOT.std.vector(dtype)(2)
+            np_obj = np.asarray(root_obj)
+            self.check_memory_adoption(root_obj, np_obj)
+            self.check_shape((2, ), np_obj)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Similar to #1777 but cleaned up and clearly separated from #1856.

Implements memory adoption of `TVec` and `std.vector` for data-types `int`, `unsigned int`, `long`, `unsigned long`, `float` and `double` with numpy arrays using `numpy.asarray(root_obj)`.