### PR TITLE
[TDF] Add Initialize method to TAction(Base) and invoke it before the evt loop

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFNodes.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFNodes.hxx
@@ -344,6 +344,7 @@ public:
    virtual ~TActionBase() = default;
 
    virtual void Run(unsigned int slot, Long64_t entry) = 0;
+   virtual void Initialize() = 0;
    virtual void InitSlot(TTreeReader *r, unsigned int slot) = 0;
    virtual void TriggerChildrenCount() = 0;
    virtual void ClearValueReaders(unsigned int slot) = 0;
@@ -371,6 +372,11 @@ public:
    TAction(const TAction &) = delete;
    TAction &operator=(const TAction &) = delete;
    ~TAction() { fHelper.Finalize(); }
+
+   void Initialize() final
+   {
+      fHelper.Initialize();
+   }
 
    void InitSlot(TTreeReader *r, unsigned int slot) final
    {

--- a/tree/treeplayer/src/TDFNodes.cxx
+++ b/tree/treeplayer/src/TDFNodes.cxx
@@ -421,6 +421,8 @@ void TLoopManager::InitNodes()
       customColumn.second->InitNode();
    for (auto &range : fBookedRanges)
       range->InitNode();
+   for (auto &ptr : fBookedActions)
+      ptr->Initialize();
 }
 
 /// Perform clean-up operations. To be called at the end of each event loop.

--- a/tree/treeplayer/test/dataframe/dataframe_snapshot.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_snapshot.cxx
@@ -447,10 +447,14 @@ TEST(TDFSnapshotMore, Lazy)
    TSnapshotOptions opts = {"RECREATE", ROOT::kZLIB, 0, 0, 99, true};
    auto ds = d.Define("c0", genf).Snapshot<int>(treename, fname0, {"c0"}, opts);
    EXPECT_EQ(v, 0U);
+   EXPECT_TRUE(gSystem->AccessPathName(fname0)); // This returns FALSE if the file IS there
    auto ds2 = ds->Define("c1", genf).Snapshot<int>(treename, fname1, {"c1"}, opts);
    EXPECT_EQ(v, 1U);
+   EXPECT_FALSE(gSystem->AccessPathName(fname0));
+   EXPECT_TRUE(gSystem->AccessPathName(fname1));
    *ds2;
    EXPECT_EQ(v, 2U);
+   EXPECT_FALSE(gSystem->AccessPathName(fname1));
    gSystem->Unlink(fname0);
    gSystem->Unlink(fname1);
 }


### PR DESCRIPTION
for each action.

Leverage this new functionality, invisible to the user, to properly delay the snapshot,
not writing an empty output file during the construction of the action but rather
delay it to the beginning of the event loop.
This somehow is more consistent with the overall laziness in TDataFrame.