### PR TITLE
[cxxmodules] Load libraries for each deserialized decls

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -476,6 +476,8 @@ void TCling::UpdateEnumConstants(TEnum* enumObj, TClass* cl) const {
 
 TEnum* TCling::CreateEnum(void *VD, TClass *cl) const
 {
+   cling::Interpreter::PushTransactionRAII RAII(fInterpreter);
+
    // Handle new enum declaration for either global and nested enums.
 
    // Create the enum type.
@@ -624,6 +626,13 @@ extern "C" R__DLLEXPORT void DestroyInterpreter(TInterpreter *interp)
 extern "C" int TCling__AutoLoadCallback(const char* className)
 {
    return ((TCling*)gCling)->AutoLoad(className);
+}
+
+extern "C" int TCling__AutoLoadLibrary(const char* Name)
+{
+   if (((TCling*)gCling)->IsLoaded(Name)) return 1;
+
+   return ((TCling*)gCling)->Load(Name);
 }
 
 extern "C" int TCling__AutoParseCallback(const char* className)
@@ -1890,7 +1899,9 @@ void TCling::RegisterModule(const char* modulename,
       }
    }
 
-   if (gIgnoredPCMNames.find(modulename) == gIgnoredPCMNames.end()) {
+   // Don't do "PCM" optimization with runtime modules because we are loading libraries at decl deserialization time and
+   // it triggers infinite deserialization chain.
+   if (!hasCxxModule && gIgnoredPCMNames.find(modulename) == gIgnoredPCMNames.end()) {
       if (!LoadPCM(pcmFileName, headers, triggerFunc)) {
          ::Error("TCling::RegisterModule", "cannot find dictionary module %s",
                  ROOT::TMetaUtils::GetModuleFileName(modulename).c_str());
@@ -2264,6 +2275,7 @@ void TCling::AddIncludePath(const char *path)
 void TCling::InspectMembers(TMemberInspector& insp, const void* obj,
                             const TClass* cl, Bool_t isTransient)
 {
+   cling::Interpreter::PushTransactionRAII RAII(fInterpreter);
    if (insp.GetObjectValidity() == TMemberInspector::kUnset) {
       insp.SetObjectValidity(obj ? TMemberInspector::kValidObjectGiven
                              : TMemberInspector::kNoObjectGiven);
@@ -3753,6 +3765,7 @@ void TCling::CreateListOfBaseClasses(TClass *cl) const
    }
    TClingClassInfo *tci = (TClingClassInfo *)cl->GetClassInfo();
    if (!tci) return;
+   cling::Interpreter::PushTransactionRAII RAII(fInterpreter);
    TClingBaseClassInfo t(fInterpreter, tci);
    TList *listOfBase = new TList;
    while (t.Next()) {
@@ -4508,6 +4521,7 @@ TInterpreter::DeclId_t TCling::GetFunctionWithPrototype(ClassInfo_t *opaque_cl, 
    R__LOCKGUARD(gInterpreterMutex);
    DeclId_t f;
    TClingClassInfo *cl = (TClingClassInfo*)opaque_cl;
+   cling::Interpreter::PushTransactionRAII RAII(fInterpreter);
    if (cl) {
       f = cl->GetMethod(method, proto, objectIsConst, 0 /*poffset*/, mode).GetDeclId();
    }
@@ -7535,6 +7549,7 @@ Long_t TCling::ClassInfo_GetBaseOffset(ClassInfo_t* fromDerived, ClassInfo_t* to
 
 Long_t TCling::BaseClassInfo_Property(BaseClassInfo_t* bcinfo) const
 {
+   cling::Interpreter::PushTransactionRAII RAII(fInterpreter);
    TClingBaseClassInfo* TClinginfo = (TClingBaseClassInfo*) bcinfo;
    return TClinginfo->Property();
 }

--- a/core/metacling/src/TClingCallbacks.h
+++ b/core/metacling/src/TClingCallbacks.h
@@ -12,6 +12,7 @@
 #include "cling/Interpreter/InterpreterCallbacks.h"
 
 #include <stack>
+#include <vector>
 
 namespace clang {
    class Decl;
@@ -27,6 +28,7 @@ namespace clang {
 namespace cling {
    class Interpreter;
    class Transaction;
+   class Module;
 }
 
 namespace llvm {
@@ -45,6 +47,7 @@ private:
    bool fIsAutoParsingSuspended;
    bool fPPOldFlag;
    bool fPPChanged;
+   std::vector<clang::Module*> fPendingModules;
 public:
    TClingCallbacks(cling::Interpreter* interp);
 
@@ -82,6 +85,8 @@ public:
    // The callback is used to update the list of globals in ROOT.
    //
    virtual void TransactionCommitted(const cling::Transaction &T);
+
+   virtual void beforeEmittingModuleForTransaction(const cling::Transaction &T);
 
    // The callback is used to update the list of globals in ROOT.
    //

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -607,6 +607,7 @@ ptrdiff_t TClingClassInfo::GetBaseOffset(TClingClassInfo* base, void* address, b
 {
 
    R__LOCKGUARD(gInterpreterMutex);
+   cling::Interpreter::PushTransactionRAII RAII(fInterp);
 
    // Check for the offset in the cache.
    auto iter = fOffsetCache.find(base->GetDecl());

--- a/core/metacling/src/TClingDataMemberInfo.cxx
+++ b/core/metacling/src/TClingDataMemberInfo.cxx
@@ -490,6 +490,7 @@ long TClingDataMemberInfo::TypeProperty() const
    if (!IsValid()) {
       return 0L;
    }
+   cling::Interpreter::PushTransactionRAII RAII(fInterp);
    const clang::ValueDecl *vd = llvm::dyn_cast<clang::ValueDecl>(GetDecl());
    clang::QualType qt = vd->getType();
    return TClingTypeInfo(fInterp, qt).Property();
@@ -528,6 +529,7 @@ const char *TClingDataMemberInfo::TypeName() const
    CheckForIoTypeAndName();
    if (!fIoType.empty()) return fIoType.c_str();
 
+   cling::Interpreter::PushTransactionRAII RAII(fInterp);
    // Note: This must be static because we return a pointer inside it!
    static std::string buf;
    buf.clear();

--- a/interpreter/cling/include/cling/Interpreter/InterpreterCallbacks.h
+++ b/interpreter/cling/include/cling/Interpreter/InterpreterCallbacks.h
@@ -132,6 +132,8 @@ namespace cling {
     ///
     virtual void TransactionCommitted(const Transaction&) {}
 
+    virtual void beforeEmittingModuleForTransaction(const Transaction&) {}
+
     ///\brief This callback is invoked whenever interpreter has reverted a
     /// transaction that has been fully committed.
     ///

--- a/interpreter/cling/include/cling/Interpreter/Transaction.h
+++ b/interpreter/cling/include/cling/Interpreter/Transaction.h
@@ -31,6 +31,7 @@ namespace clang {
   class Preprocessor;
   struct PrintingPolicy;
   class Sema;
+  class Module;
 }
 
 namespace llvm {
@@ -114,6 +115,9 @@ namespace cling {
     // init.
     typedef llvm::SmallVector<DelayCallInfo, 64> DeclQueue;
     typedef llvm::SmallVector<Transaction*, 2> NestedTransactions;
+
+    // Clang modules pcm
+    std::vector<clang::Module*> m_cxxmodules;
 
     ///\brief All seen declarations, except the deserialized ones.
     /// If we collect the declarations by walking the clang::DeclContext we
@@ -266,6 +270,16 @@ namespace cling {
       if (hasNestedTransactions())
         return m_NestedTransactions->rend();
       return const_reverse_nested_iterator(0);
+    }
+
+    void addModules(clang::Module* M) {
+      if (!M) return;
+      if (std::find(m_cxxmodules.begin(), m_cxxmodules.end(), M) == m_cxxmodules.end())
+        m_cxxmodules.push_back(M);
+    }
+
+    std::vector<clang::Module*> getModules() const {
+      return m_cxxmodules;
     }
 
     /// Macro iteration

--- a/interpreter/cling/lib/Interpreter/LookupHelper.cpp
+++ b/interpreter/cling/lib/Interpreter/LookupHelper.cpp
@@ -1731,6 +1731,7 @@ namespace cling {
                                                       DiagSetting diagOnOff,
                                                       bool objectIsConst) const{
     assert(scopeDecl && "Decl cannot be null");
+    Interpreter::PushTransactionRAII RAII(m_Interpreter);
 
     return execFindFunction<ParseProto>(*m_Parser, m_Interpreter,
                                         scopeDecl,

--- a/interpreter/cling/lib/Interpreter/MultiplexInterpreterCallbacks.h
+++ b/interpreter/cling/lib/Interpreter/MultiplexInterpreterCallbacks.h
@@ -77,6 +77,12 @@ namespace cling {
        }
      }
 
+     void beforeEmittingModuleForTransaction(const Transaction& T) override {
+       for (auto&& cb : m_Callbacks) {
+         cb->beforeEmittingModuleForTransaction(T);
+       }
+     }
+
      void TransactionUnloaded(const Transaction& T) override {
        for (auto&& cb : m_Callbacks) {
          cb->TransactionUnloaded(T);

--- a/interpreter/llvm/src/tools/clang/include/clang/Serialization/ASTReader.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/Serialization/ASTReader.h
@@ -1555,6 +1555,11 @@ public:
   void setDeserializationListener(ASTDeserializationListener *Listener,
                                   bool TakeOwnership = false);
 
+  ASTDeserializationListener *getDeserializationListener() {
+    return DeserializationListener;
+  };
+
+
   /// \brief Determine whether this AST reader has a global index.
   bool hasGlobalIndex() const { return (bool)GlobalIndex; }
 


### PR DESCRIPTION
This PR change contains:
- Registering DeserializationListener to ASTReader and get callbacks
when decls are deserialized.
  We inherited ASTDeserializationListener in DeclCollector and register
  DeserializationListener to our ASTReader at DeclCollector setup time.
  In the callback(DeclRead), we get owning modules from decls and store
  the information in Transaction.

- Load libraies for deserialized decls
  Before executeTransaction(where linking happens) we put our callback
  beforeEmittingModuleForTransaction in InterpreterCallbacks. This loads
  libraries when it wasn't in its first run, and store modules if it's
  in its first run. This is because Interpreter is not yet initialized
  at first run but we need to use Interpreter services when loading
  libraries.

I think this is the last piece of semantic change related to runtime
cxxmodules. This also enables us to reduce dependency on rootmap files.