### PR TITLE
[ROOT-9364] Fix typename of gVirtualX in list of globals

### DIFF
--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -1770,7 +1770,7 @@ TCollection *TROOT::GetListOfGlobals(Bool_t load)
                                             (TGlobalMappedFunction::GlobalFunc_t)&TVirtualPad::Pad));
       fGlobals->Add(new TGlobalMappedFunction("gInterpreter", "TInterpreter*",
                                             (TGlobalMappedFunction::GlobalFunc_t)&TInterpreter::Instance));
-      fGlobals->Add(new TGlobalMappedFunction("gVirtualX", "TTVirtualX*",
+      fGlobals->Add(new TGlobalMappedFunction("gVirtualX", "TVirtualX*",
                                             (TGlobalMappedFunction::GlobalFunc_t)&TVirtualX::Instance));
       fGlobals->Add(new TGlobalMappedFunction("gDirectory", "TDirectory*",
                                             (TGlobalMappedFunction::GlobalFunc_t)&TDirectory::CurrentDirectory));


### PR DESCRIPTION
As pointed out by a user in this forum post:
https://root-forum.cern.ch/t/pyroot-6-and-gvirtualx-eeventtype-etc/28702/9
and explained in:
https://sft.its.cern.ch/jira/browse/ROOT-9364
importing gVirtualX from PyROOT leads to an error.

This PR fixes the issue, which is due to gVirtualX being added to the list of globals with a wrong type.
