### PR TITLE
[BUILD] Add libVecOps to the dependencies of libTreePlayer

### DIFF
--- a/tree/treeplayer/CMakeLists.txt
+++ b/tree/treeplayer/CMakeLists.txt
@@ -43,7 +43,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(TreePlayer
                               SOURCES ${sources}
                               DICTIONARY_OPTIONS "-writeEmptyRootPCM"
                               LIBRARIES ${TBB_LIBRARIES} ${ARROW_SHARED_LIB}
-                              DEPENDENCIES Tree Graf3d Graf Hist Gpad RIO MathCore
+                              DEPENDENCIES Tree Graf3d Graf Hist Gpad RIO MathCore VecOps
                               ${TREEPLAYER_DEPENDENCIES})
 
 #---Extra rules-------------------------------------------------------


### PR DESCRIPTION
This should solve some problems with TDF jitting.
To be removed when TDataFrame moves out of libTreePlayer.

The change is fairly trivial. Will merge if the jenkins builds are reasonably green.