### PR TITLE
[TDF] Fix ambiguous namespace

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFInterfaceUtils.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterfaceUtils.hxx
@@ -55,6 +55,7 @@ namespace TDF {
 using namespace ROOT::Detail::TDF;
 using namespace ROOT::Experimental::TDF;
 namespace TTraits = ROOT::TypeTraits;
+namespace TDFInternal = ROOT::Internal::TDF;
 
 /// An helper object that sets and resets gErrorIgnoreLevel via RAII.
 class TIgnoreErrorLevelRAII {


### PR DESCRIPTION
@bluehood On my system ROOT builds only with this namespace declaration. Otherwise the compiler says it is ambiguous. Why does this fail only on my system (currently ubuntu1604).