### PR TITLE
webgui: use fork() on Linux/Mac to start browsers in headless mode

### DIFF
--- a/config/rootrc.in
+++ b/config/rootrc.in
@@ -267,6 +267,8 @@ WebGui.HttpLoopback:        no
 # Use https protocol for the http server (default - no)
 WebGui.UseHttps:            no
 WebGui.ServerCert:          rootserver.pem
+# default timeout (in seconds) for synchronous actions like producing images on clients 
+WebGui.WaitForTmout:        100.0        
 
 # OpenGL options (defaults are shown)
 # Default user interaction model for 3D view manipulation assumes that user

--- a/gui/canvaspainter/CMakeLists.txt
+++ b/gui/canvaspainter/CMakeLists.txt
@@ -2,8 +2,6 @@
 # CMakeLists.txt file for building ROOT gui/canvaspainter package
 ############################################################################
 
-set(libname ROOTCanvasPainter)
-
 ROOT_GLOB_SOURCES(sources v7/src/*.cxx)
 
-ROOT_LINKER_LIBRARY(${libname} ${sources} DEPENDENCIES ROOTGpadv7 RHTTP ROOTWebDisplay)
+ROOT_LINKER_LIBRARY(ROOTCanvasPainter ${sources} DEPENDENCIES ROOTGpadv7 RHTTP ROOTWebDisplay)

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -366,7 +366,7 @@ void ROOT::Experimental::TCanvasPainter::CanvasUpdated(uint64_t ver, bool async,
 
    // wait 100 seconds that canvas is painted
    if (!async)
-      fWindow->WaitFor([this, ver](double tm) { return CheckDeliveredVersion(ver, tm); }, 100);
+      fWindow->WaitFor([this, ver](double tm) { return CheckDeliveredVersion(ver, tm); });
 }
 
 ///////////////////////////////////////////////////
@@ -414,7 +414,7 @@ void ROOT::Experimental::TCanvasPainter::DoWhenReady(const std::string &name, co
    CheckDataToSend();
 
    if (!async)
-      fWindow->WaitFor([this, name](double tm) { return CheckWaitingCmd(name, tm); }, 100);
+      fWindow->WaitFor([this, name](double tm) { return CheckWaitingCmd(name, tm); });
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -225,8 +225,7 @@ void ROOT::Experimental::TCanvasPainter::CancelUpdates()
    fSnapshotDelivered = 0;
    auto iter = fUpdatesLst.begin();
    while (iter != fUpdatesLst.end()) {
-      auto curr = iter;
-      iter++;
+      auto curr = iter++;
       curr->fCallback(false);
       fUpdatesLst.erase(curr);
    }
@@ -240,13 +239,12 @@ void ROOT::Experimental::TCanvasPainter::CancelCommands(unsigned connid)
 {
    auto iter = fCmds.begin();
    while (iter != fCmds.end()) {
-      auto next = iter;
-      next++;
-      if (!connid || (iter->fConnId == connid)) {
-         if (fWaitingCmdId == iter->fId)
+      auto curr = iter++;
+      if (!connid || (curr->fConnId == connid)) {
+         if (fWaitingCmdId == curr->fId)
             fWaitingCmdId.clear();
-         iter->CallBack(false);
-         fCmds.erase(iter);
+         curr->CallBack(false);
+         fCmds.erase(curr);
       }
    }
 }
@@ -364,7 +362,7 @@ void ROOT::Experimental::TCanvasPainter::CanvasUpdated(uint64_t ver, bool async,
       fUpdatesLst.push_back(item);
    }
 
-   // wait 100 seconds that canvas is painted
+   // wait that canvas is painted
    if (!async)
       fWindow->WaitFor([this, ver](double tm) { return CheckDeliveredVersion(ver, tm); });
 }
@@ -413,8 +411,11 @@ void ROOT::Experimental::TCanvasPainter::DoWhenReady(const std::string &name, co
 
    CheckDataToSend();
 
-   if (!async)
-      fWindow->WaitFor([this, name](double tm) { return CheckWaitingCmd(name, tm); });
+   if (async) return;
+
+   int res = fWindow->WaitFor([this, name](double tm) { return CheckWaitingCmd(name, tm); });
+   if (!res)
+      R__ERROR_HERE("CanvasPainter") << name << " fail with " << arg;
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/gui/fitpanelv7/CMakeLists.txt
+++ b/gui/fitpanelv7/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMakeLists.txt file for building ROOT gui/fitpanelv7
 ############################################################################
 
-ROOT_GLOB_HEADERS(FitPanelv7_headers ${CMAKE_CURRENT_SOURCE_DIR}/inc/ROOT/T*.hxx)
+ROOT_GLOB_HEADERS(FitPanelv7_headers inc/ROOT/T*.hxx)
 
 ROOT_STANDARD_LIBRARY_PACKAGE(ROOTFitPanelv7
                               HEADERS ${FitPanelv7_headers}

--- a/gui/webdisplay/CMakeLists.txt
+++ b/gui/webdisplay/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMakeLists.txt file for building ROOT gui/canvaspainter package
 ############################################################################
 
-ROOT_GLOB_HEADERS(WebDisplay_headers ${CMAKE_CURRENT_SOURCE_DIR}/inc/ROOT/T*.hxx)
+ROOT_GLOB_HEADERS(WebDisplay_headers inc/ROOT/T*.hxx)
 
 ROOT_STANDARD_LIBRARY_PACKAGE(ROOTWebDisplay
                               HEADERS ${WebDisplay_headers}

--- a/gui/webdisplay/inc/ROOT/TWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindow.hxx
@@ -192,7 +192,7 @@ public:
 
    void SetDataCallBack(WebWindowDataCallback_t func);
 
-   int WaitFor(WebWindowWaitFunc_t check, double tm);
+   int WaitFor(WebWindowWaitFunc_t check, double tm = -1);
 };
 
 } // namespace Experimental

--- a/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
@@ -48,6 +48,8 @@ private:
 
    bool Show(TWebWindow &win, const std::string &where);
 
+   void HaltClient(const std::string &procid);
+
 public:
    TWebWindowsManager();
 

--- a/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
@@ -62,7 +62,7 @@ public:
 
    std::shared_ptr<TWebWindow> CreateWindow(bool batch_mode = false);
 
-   int WaitFor(WebWindowWaitFunc_t check, double tm);
+   int WaitFor(WebWindowWaitFunc_t check, double tm = -1);
 
    void Terminate();
 };

--- a/gui/webdisplay/src/TWebWindow.cxx
+++ b/gui/webdisplay/src/TWebWindow.cxx
@@ -522,7 +522,7 @@ void ROOT::Experimental::TWebWindow::SetDataCallBack(WebWindowDataCallback_t fun
 /////////////////////////////////////////////////////////////////////////////////
 /// Waits until provided check function or lambdas returns non-zero value
 /// Runs application mainloop and short sleeps in-between
-/// timelimit (in seconds) defines how long to wait (0 - forever)
+/// timelimit (in seconds) defines how long to wait (0 - forever, negative - default value)
 /// Function has following signature: int func(double spent_tm)
 /// Parameter spent_tm is time in seconds, which already spent inside function
 /// Waiting will be continued, if function returns zero.

--- a/gui/webdisplay/src/TWebWindowsManager.cxx
+++ b/gui/webdisplay/src/TWebWindowsManager.cxx
@@ -423,21 +423,16 @@ bool ROOT::Experimental::TWebWindowsManager::Show(ROOT::Experimental::TWebWindow
 
    R__DEBUG_HERE("WebDisplay") << "Show web window in browser with cmd:\n" << exec;
 
-   bool use_fork = false;
-
    if (exec.Index("fork:") == 0) {
       exec.Remove(0, 5);
-      use_fork = true;
-   }
-
-   if (use_fork) {
 #if !defined(OS_WIN)
       std::unique_ptr<TObjArray> args(exec.Tokenize(" "));
-      if (!args) return false;
+      if (!args || (args->GetLast()<=0))
+         return false;
 
       std::vector<char *> argv;
-      for (Int_t n=0;n<=args->GetLast();++n)
-         argv.push_back((char *) args->At(n)->GetName());
+      for (Int_t n = 0; n <= args->GetLast(); ++n)
+         argv.push_back((char *)args->At(n)->GetName());
       argv.push_back(nullptr);
 
       int pid = fork(); // fork child

--- a/gui/webdisplay/src/TWebWindowsManager.cxx
+++ b/gui/webdisplay/src/TWebWindowsManager.cxx
@@ -479,7 +479,7 @@ void ROOT::Experimental::TWebWindowsManager::HaltClient(const std::string &proci
 //////////////////////////////////////////////////////////////////////////
 /// Waits until provided check function or lambdas returns non-zero value
 /// Runs application mainloop and short sleeps in-between
-/// timelimit (in seconds) defines how long to wait (0 - forever)
+/// timelimit (in seconds) defines how long to wait (0 - forever, negative - default value)
 /// Function has following signature: int func(double spent_tm)
 /// Parameter spent_tm is time in seconds, which already spent inside function
 /// Waiting will be continued, if function returns zero.
@@ -491,6 +491,8 @@ int ROOT::Experimental::TWebWindowsManager::WaitFor(WebWindowWaitFunc_t check, d
    tm.Start();
    double spent(0);
    int res(0), cnt(0);
+
+   if (timelimit < 0) timelimit = gEnv->GetValue("WebGui.WaitForTmout", 100.);
 
    while ((res = check(spent)) == 0) {
       gSystem->ProcessEvents();

--- a/gui/webdisplay/src/TWebWindowsManager.cxx
+++ b/gui/webdisplay/src/TWebWindowsManager.cxx
@@ -388,11 +388,17 @@ bool ROOT::Experimental::TWebWindowsManager::Show(ROOT::Experimental::TWebWindow
       else
          exec = gEnv->GetValue("WebGui.ChromeInteractive", "$prog --window-size=$width,$height --app=\'$url\' &");
    } else if (is_firefox) {
+      // to use firefox in batch mode at the same time as other firefox is running,
+      // one should use extra profile. This profile should be created first:
+      //    firefox -no-remote -CreateProfile root_batch
+      // And then in the start command one should add:
+      //    $prog -headless -no-remote -P root_batch -window-size=$width,$height $url
+      // By default, no profile is specified, but this requires that no firefox is running
 
       prog = gEnv->GetValue("WebGui.Firefox", where.c_str());
 
       if (win.IsBatchMode())
-         exec = gEnv->GetValue("WebGui.FirefoxBatch", "timeout 30 $prog -headless -window-size=$width,$height \'$url\' &");
+         exec = gEnv->GetValue("WebGui.FirefoxBatch", "fork: $prog -headless -no-remote -window-size=$width,$height $url");
       else
          exec = gEnv->GetValue("WebGui.FirefoxInteractive", "$prog -window-size=$width,$height \'$url\' &");
 


### PR DESCRIPTION
Both chrome and firefox browsers can be started, using fork().
One gets process id, which can be used later to kill browser when it does not required.
Special solution for Windows need to be provided.