### PR TITLE
[TDF] Do not keep dot-less branch name if it was part of a longer one

### DIFF
--- a/tree/treeplayer/src/TDFInterfaceUtils.cxx
+++ b/tree/treeplayer/src/TDFInterfaceUtils.cxx
@@ -318,8 +318,8 @@ std::vector<std::string> FindUsedColumnNames(std::string_view expression, const 
 {
    // To help matching the regex
    const std::string paddedExpr = " " + std::string(expression) + " ";
-   int paddedExprLen = paddedExpr.size();
    static const std::string regexBit("[^a-zA-Z0-9_]");
+   Ssiz_t matchedLen;
 
    std::vector<std::string> usedBranches;
 
@@ -327,7 +327,7 @@ std::vector<std::string> FindUsedColumnNames(std::string_view expression, const 
    for (auto &brName : customColumns) {
       std::string bNameRegexContent = regexBit + brName + regexBit;
       TRegexp bNameRegex(bNameRegexContent.c_str());
-      if (-1 != bNameRegex.Index(paddedExpr.c_str(), &paddedExprLen)) {
+      if (-1 != bNameRegex.Index(paddedExpr.c_str(), &matchedLen)) {
          usedBranches.emplace_back(brName);
       }
    }
@@ -339,7 +339,7 @@ std::vector<std::string> FindUsedColumnNames(std::string_view expression, const 
       Replace(escapedBrName, std::string("."), std::string("\\."));
       std::string bNameRegexContent = regexBit + escapedBrName + regexBit;
       TRegexp bNameRegex(bNameRegexContent.c_str());
-      if (-1 != bNameRegex.Index(paddedExpr.c_str(), &paddedExprLen)) {
+      if (-1 != bNameRegex.Index(paddedExpr.c_str(), &matchedLen)) {
          usedBranches.emplace_back(brName);
       }
    }
@@ -348,7 +348,7 @@ std::vector<std::string> FindUsedColumnNames(std::string_view expression, const 
    for (auto &col : dsColumns) {
       std::string bNameRegexContent = regexBit + col + regexBit;
       TRegexp bNameRegex(bNameRegexContent.c_str());
-      if (-1 != bNameRegex.Index(paddedExpr.c_str(), &paddedExprLen)) {
+      if (-1 != bNameRegex.Index(paddedExpr.c_str(), &matchedLen)) {
          // if not already found among the other columns
          if (std::find(usedBranches.begin(), usedBranches.end(), col) == usedBranches.end())
             usedBranches.emplace_back(col);
@@ -360,7 +360,7 @@ std::vector<std::string> FindUsedColumnNames(std::string_view expression, const 
       auto &alias = alias_colName.first;
       std::string bNameRegexContent = regexBit + alias + regexBit;
       TRegexp bNameRegex(bNameRegexContent.c_str());
-      if (-1 != bNameRegex.Index(paddedExpr.c_str(), &paddedExprLen)) {
+      if (-1 != bNameRegex.Index(paddedExpr.c_str(), &matchedLen)) {
          // if not already found among the other columns
          if (std::find(usedBranches.begin(), usedBranches.end(), alias) == usedBranches.end())
             usedBranches.emplace_back(alias);

--- a/tree/treeplayer/src/TDFInterfaceUtils.cxx
+++ b/tree/treeplayer/src/TDFInterfaceUtils.cxx
@@ -403,20 +403,20 @@ std::vector<std::string> ColumnTypesAsString(ColumnNames_t &colNames, ColumnName
       // The map is a const reference, so no operator[]
       const auto isCustomCol =
          std::find(customColNames.begin(), customColNames.end(), realColName) != customColNames.end();
-      const auto brTypeName = ColumnName2ColumnTypeName(realColName, namespaceID, tree, ds, isCustomCol);
+      const auto colTypeName = ColumnName2ColumnTypeName(realColName, namespaceID, tree, ds, isCustomCol);
       if (colName.find('.') != std::string::npos) {
-         // If the branch name contains dots, replace its name with a dummy
+         // If the column name contains dots, replace its name with a dummy
          auto numRepl = Replace(expr, colName, *v);
          if (numRepl == 0) {
-            // Discard this branch: we could not replace it, although we matched it previously
-            // This is because it is a substring of a branch we already replaced in the expression
-            // e.g. "a.b" is a substring branch of "a.b.c"
+            // Discard this column: we could not replace it, although we matched it previously
+            // This is because it is a substring of a column we already replaced in the expression
+            // e.g. "a.b" is a substring column of "a.b.c"
             c = colNames.erase(c);
             v = varNames.erase(v);
             continue;
          }
       }
-      colTypes.emplace_back(brTypeName);
+      colTypes.emplace_back(colTypeName);
       ++c, ++v;
    }
 

--- a/tree/treeplayer/src/TDFInterfaceUtils.cxx
+++ b/tree/treeplayer/src/TDFInterfaceUtils.cxx
@@ -408,6 +408,20 @@ std::vector<std::string> ColumnTypesAsString(ColumnNames_t &colNames, ColumnName
             v = varNames.erase(v);
             continue;
          }
+      } else {
+         // Column name with no dots: check the name is still there
+         // it might have only been there as part of a column name with dots, e.g. "a" inside "a.b.c"
+         const auto paddedExpr = " " + expr + " ";
+         static const std::string noWordChars("[^a-zA-Z0-9_]");
+         const auto colNameRxBody = noWordChars + colName + noWordChars;
+         TRegexp colNameRegex(colNameRxBody.c_str());
+         Ssiz_t matchedLen;
+         const auto colStillThere = colNameRegex.Index(paddedExpr.c_str(), &matchedLen) != -1;
+         if (!colStillThere) {
+            c = colNames.erase(c);
+            v = varNames.erase(v);
+            continue;
+         }
       }
 
       // Replace the colName with the real one in case colName it's an alias

--- a/tree/treeplayer/src/TDFInterfaceUtils.cxx
+++ b/tree/treeplayer/src/TDFInterfaceUtils.cxx
@@ -404,7 +404,7 @@ std::vector<std::string> ColumnTypesAsString(ColumnNames_t &colNames, ColumnName
       const auto isCustomCol =
          std::find(customColNames.begin(), customColNames.end(), realColName) != customColNames.end();
       const auto brTypeName = ColumnName2ColumnTypeName(realColName, namespaceID, tree, ds, isCustomCol);
-      if (colName.find(".") != std::string::npos) {
+      if (colName.find('.') != std::string::npos) {
          // If the branch name contains dots, replace its name with a dummy
          auto numRepl = Replace(expr, colName, *v);
          if (numRepl == 0) {


### PR DESCRIPTION
For example, in an expression string such as "el.px > 0", it could
happen that both "el.px" and "el" were recognized as columns used
inside the expression. Even after "el.px" was replaced with "el_px"
"el" matched the expression and was kept as a valid, used column name.
This commit adds an extra check to verify that "el" still appears as
a standalone column name, even after "el.px" has been replaced.

Note that it's guaranteed that "el.px" will always match before "el" because
our generation of all possible branchnames is depth-first.