### PR TITLE
[TDF] Add TInterface::Book method to let users register a custom action

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFActionHelpers.hxx
@@ -44,6 +44,18 @@
 /// \cond HIDDEN_SYMBOLS
 
 namespace ROOT {
+namespace Detail {
+namespace TDF {
+
+template <typename Helper>
+class TActionImpl {
+public:
+   void InitSlot(TTreeReader *r, unsigned int slot) { static_cast<Helper &>(*this).InitTask(r, slot); }
+};
+
+} // namespace TDF
+} // namespace Detail
+
 namespace Internal {
 namespace TDF {
 using namespace ROOT::TypeTraits;

--- a/tree/treeplayer/test/dataframe/dataframe_simple.cxx
+++ b/tree/treeplayer/test/dataframe/dataframe_simple.cxx
@@ -486,6 +486,35 @@ TEST_P(TDFSimpleTests, AggregateGraph)
    }
 }
 
+class MaxSlotHelper : public ROOT::Detail::TDF::TActionImpl<MaxSlotHelper> {
+   const std::shared_ptr<unsigned int> fMaxSlot; // final result
+   std::vector<unsigned int> fMaxSlots;          // per-thread partial results
+public:
+   MaxSlotHelper(unsigned int nSlots)
+      : fMaxSlot(std::make_shared<unsigned int>(std::numeric_limits<unsigned int>::lowest())),
+        fMaxSlots(nSlots, std::numeric_limits<unsigned int>::lowest())
+   {
+   }
+   MaxSlotHelper(MaxSlotHelper &&) = default;
+   MaxSlotHelper(const MaxSlotHelper &) = delete;
+   using ColumnTypes_t = ROOT::TypeTraits::TypeList<unsigned int>;
+   using Result_t = unsigned int;
+   ROOT::Detail::TDF::ColumnNames_t GetColumnNames() const { return {"tdfslot_"}; }
+   std::shared_ptr<unsigned int> GetResultPtr() const { return fMaxSlot; }
+   void Initialize() {}
+   void InitTask(TTreeReader *, unsigned int) {}
+   void Exec(unsigned int slot, unsigned int /*slot2*/) { fMaxSlots[slot] = std::max(fMaxSlots[slot], slot); }
+   void Finalize() { *fMaxSlot = *std::max_element(fMaxSlots.begin(), fMaxSlots.end()); }
+};
+
+TEST_P(TDFSimpleTests, BookCustomAction)
+{
+   TDataFrame d(1);
+   const auto nWorkers = std::max(1u, ROOT::GetImplicitMTPoolSize());
+   auto maxSlot = d.Book(MaxSlotHelper(nWorkers));
+   EXPECT_EQ(*maxSlot, nWorkers-1);
+}
+
 // run single-thread tests
 INSTANTIATE_TEST_CASE_P(Seq, TDFSimpleTests, ::testing::Values(false));
 


### PR DESCRIPTION
Documentation of the method reported here for ease of review:

This method books a custom action for execution. The behavior of the action is completely dependent on the
Helper object provided by the caller. The minimum required interface for the helper is the following (more
methods can be present, e.g. a constructor that takes the number of worker threads is usually useful):

* Helper must publicly inherit from ROOT::Detail::TDF::TActionImpl<Helper>
* Helper(Helper &&): a move-constructor is required. Copy-constructors are discouraged.
* ColumnTypes_t: alias for a ROOT::TypeTraits::TypeList instantiation that specifies the types of the
  columns to be passed to this action helper.
* Result_t: alias for the type of the result of this action helper. Must be default-constructible.
* ROOT::Detail::TDF::ColumnNames_t GetColumnNames() const: return the names of the columns processed by this
  action. The number of names must be equal to the size of ColumnTypes_t.
* void Exec(unsigned int slot, ColumnTypes...columnValues): each working thread shall call this method
  during the event-loop, possibly concurrently. No two threads will ever call Exec with the same 'slot' value:
  this parameter is there to facilitate writing thread-safe helpers. The other arguments will be the values of
  the requested columns for the particular entry being processed.
* void InitTask(TTreeReader *, unsigned int slot): each working thread shall call this method during the event
  loop, before processing a batch of entries (possibly read from the TTreeReader passed as argument, if not null).
  This method can be used e.g. to prepare the helper to process a batch of entries in a given thread. Can be no-op.
* void Initialize(): this method is called once before starting the event-loop. Useful for setup operations.
                     Can be no-op.
* void Finalize(): this method is called at the end of the event loop. Commonly used to finalize the contents
  of the result.
* Result_t &PartialUpdate(unsigned int slot): this method is optional, i.e. can be omitted. If present, it should
  return the value of the partial result of this action for the given 'slot'. Different threads might call this
  method concurrently, but will always pass different 'slot' numbers.
* std::shared_ptr<Result_t> GetResultPtr() const: return a shared_ptr to the result of this action (of type
  Result_t). The TResultPtr returned by Book will point to this object.
