### PR TITLE
[PyROOT] Fix swapped return values for TTree.AsMatrix with return_labels

### DIFF
--- a/bindings/pyroot/ROOT.py
+++ b/bindings/pyroot/ROOT.py
@@ -375,7 +375,7 @@ def _TTreeAsMatrix(self, columns=None, exclude=None, dtype="double", return_labe
             (int(len(flat_matrix)/len(columns)), len(columns)))
 
     if return_labels:
-        return (columns, reshaped_matrix_np)
+        return (reshaped_matrix_np, columns)
     else:
         return reshaped_matrix_np
 

--- a/bindings/pyroot/test/ttree_asmatrix.py
+++ b/bindings/pyroot/test/ttree_asmatrix.py
@@ -65,7 +65,7 @@ class TTreeAsMatrix(unittest.TestCase):
 
     def test_return_labels(self):
         tree, _, _, col_names, _ = self.make_tree("F", "F")
-        labels, matrix = tree.AsMatrix(col_names, return_labels=True)
+        matrix, labels = tree.AsMatrix(col_names, return_labels=True)
         self.assertEqual(labels, col_names)
 
     def test_exclude_columns(self):


### PR DESCRIPTION
Swapped the return values for enabled `return_labels` (now it's done as stated in the docs).