### PR TITLE
[PyROOT] Maintain correct type for index_sequence_for on 32bit

### DIFF
--- a/bindings/pyroot/inc/TTreeAsFlatMatrix.h
+++ b/bindings/pyroot/inc/TTreeAsFlatMatrix.h
@@ -25,7 +25,7 @@ namespace PyROOT {
     inline ULong64_t GetAddress(std::vector<std::string> &p){return reinterpret_cast<ULong64_t>(&p);}
     inline ULong64_t GetAddress(TTree &p){return reinterpret_cast<ULong64_t>(&p);}
 
-    template <typename BufType, typename... ColTypes, unsigned long... Idx>
+    template <typename BufType, typename... ColTypes, std::size_t... Idx>
     void TTreeAsFlatMatrix(
             std::index_sequence<Idx...>, TTree& tree, std::vector<BufType>& matrix, std::vector<std::string>& columns)
     {


### PR DESCRIPTION
Fixes probably (**!**) the failure here: http://cdash.cern.ch/viewTest.php?onlyfailed&buildid=494701

I've enforced `unsigned long` as type for `index_sequence_for`, which seems not to hold true on 32bit. `std::size_t` should resolve to the correct type on all systems ([Doc](http://en.cppreference.com/w/cpp/utility/integer_sequence)).