### PR TITLE
Use TPadPos in TLine

### DIFF
--- a/graf2d/primitives/v7/inc/ROOT/TLine.hxx
+++ b/graf2d/primitives/v7/inc/ROOT/TLine.hxx
@@ -19,6 +19,7 @@
 #include <ROOT/TDrawable.hxx>
 #include <ROOT/TDrawingAttr.hxx>
 #include <ROOT/TDrawingOptsBase.hxx>
+#include <ROOT/TPadPos.hxx>
 #include <ROOT/TPad.hxx>
 #include <ROOT/TPadPainter.hxx>
 
@@ -45,22 +46,16 @@ class DrawingOpts: public TDrawingOptsBase {
    TDrawingAttr<int> fLineStyle{*this, "Line.Style", 1.};                  ///< The line style.
    TDrawingAttr<float>  fLineOpacity{*this, "Line.Opacity", 1.};           ///< The line opacity.
 
-
-
-
 public:
    /// The color of the line.
    void SetLineColor(const TColor &col) { fLineColor = col; }
    TDrawingAttr<TColor> &GetLineColor() { return fLineColor; }
    const TColor &GetLineColor() const   { return fLineColor.Get(); }
 
-
-
    ///The width of the line.
     void SetLineWidth(int width) { fLineWidth = width; }
     TDrawingAttr<int> &GetLineWidth() { return fLineWidth; }
     int GetLineWidth() const   { return (int)fLineWidth; }
-
 
     ///The style of the line.
     void SetLineStyle(int style) { fLineStyle = style; }
@@ -78,10 +73,8 @@ private:
 
    /// Line's coordinates
 
-   double fX1{0.};           ///< X of 1st point
-   double fY1{0.};           ///< Y of 1st point
-   double fX2{0.};           ///< X of 2nd point
-   double fY2{0.};           ///< Y of 2nd point
+   TPadPos fP1;           ///< 1st point
+   TPadPos fP2;           ///< 2nd point
 
    /// Line attributes
    DrawingOpts fOpts;
@@ -89,17 +82,13 @@ private:
 public:
    TLine() = default;
 
-   TLine(double x1, double y1, double x2, double y2 ) : fX1(x1), fY1(y1), fX2(x2), fY2(y2) {}
+   TLine(TPadPos p1, TPadPos p2) : fP1(p1), fP2(p2) {}
 
-   void SetX1(double x1) { fX1 = x1; }
-   void SetY1(double y1) { fY1 = y1; }
-   void SetX2(double x2) { fX2 = x2; }
-   void SetY2(double y2) { fY2 = y2; }
+   void SetP1(TPadPos p1) { fP1 = p1; }
+   void SetP2(TPadPos p2) { fP2 = p2; }
 
-   double GetX1() const { return fX1; }
-   double GetY1() const { return fY1; }
-   double GetX2() const { return fX2; }
-   double GetY2() const { return fY2; }
+   TPadPos GetP1() const { return fP1; }
+   TPadPos GetP2() const { return fP2; }
 
    /// Get the drawing options.
    DrawingOpts &GetOptions() { return fOpts; }

--- a/tutorials/v7/line.cxx
+++ b/tutorials/v7/line.cxx
@@ -45,36 +45,12 @@ void line()
       canvas->Draw(line);
     }
 
-   p1.fHoriz = 0._normal;
-   p1.fVert  = 0._normal;
-   p2.fHoriz = 1._normal;
-   p2.fVert  = 1._normal;
-   auto line  = std::make_shared<Experimental::TLine>(p1, p2); canvas->Draw(line);
-   p1.fHoriz = 0.1_normal;
-   p1.fVert  = 0.1_normal;
-   p2.fHoriz = 0.9_normal;
-   p2.fVert  = 0.1_normal;
-   auto line1 = std::make_shared<Experimental::TLine>(p1, p2); canvas->Draw(line1);
-   p1.fHoriz = 0.9_normal;
-   p1.fVert  = 0.1_normal;
-   p2.fHoriz = 0.9_normal;
-   p2.fVert  = 0.9_normal;
-   auto line2 = std::make_shared<Experimental::TLine>(p1, p2); canvas->Draw(line2);
-   p1.fHoriz = 0.9_normal;
-   p1.fVert  = 0.9_normal;
-   p2.fHoriz = 0.1_normal;
-   p2.fVert  = 0.9_normal;
-   auto line3 = std::make_shared<Experimental::TLine>(p1, p2); canvas->Draw(line3);
-   p1.fHoriz = 0.1_normal;
-   p1.fVert  = 0.1_normal;
-   p2.fHoriz = 0.1_normal;
-   p2.fVert  = 0.9_normal;
-   auto line4 = std::make_shared<Experimental::TLine>(p1, p2); canvas->Draw(line4);
-   p1.fHoriz = 0.0_normal;
-   p1.fVert  = 1.0_normal;
-   p2.fHoriz = 1.0_normal;
-   p2.fVert  = 0.0_normal;
-   auto line0 = std::make_shared<Experimental::TLine>(p1, p2); canvas->Draw(line0);
+   canvas->Draw(Experimental::TLine({0.0_normal, 0.0_normal}, {1.0_normal,1.0_normal}));
+   canvas->Draw(Experimental::TLine({0.1_normal, 0.1_normal}, {0.9_normal,0.1_normal}));
+   canvas->Draw(Experimental::TLine({0.9_normal, 0.1_normal}, {0.9_normal,0.9_normal}));
+   canvas->Draw(Experimental::TLine({0.9_normal, 0.9_normal}, {0.1_normal,0.9_normal}));
+   canvas->Draw(Experimental::TLine({0.1_normal, 0.1_normal}, {0.1_normal,0.9_normal}));
+   canvas->Draw(Experimental::TLine({0.0_normal, 1.0_normal}, {1.0_normal,0.0_normal}));
 
    canvas->Show();
 }

--- a/tutorials/v7/line.cxx
+++ b/tutorials/v7/line.cxx
@@ -8,7 +8,7 @@
 /// is welcome!
 /// \authors Olivier couet, Iliana Betsou
 
-R__LOAD_LIBRARY(libGpad);
+R__LOAD_LIBRARY(libROOTGpadv7);
 
 #include "ROOT/TCanvas.hxx"
 #include "ROOT/TColor.hxx"
@@ -18,16 +18,26 @@ R__LOAD_LIBRARY(libGpad);
 void line()
 {
    using namespace ROOT;
+   using namespace ROOT::Experimental;
 
    // Create a canvas to be displayed.
    auto canvas = Experimental::TCanvas::Create("Canvas Title");
 
+   TPadPos p1,p2;
+
+   p1.fHoriz = 0._normal;
+   p1.fVert  = 0._normal;
+
    for (double i = 0; i < 360; i+=1) {
       double ang = i * TMath::Pi() / 180;
-      double x = 0.3*TMath::Cos(ang) + 0.5;
-      double y = 0.3*TMath::Sin(ang) + 0.5;
+      double x   = 0.3*TMath::Cos(ang) + 0.5;
+      double y   = 0.3*TMath::Sin(ang) + 0.5;
 
-      auto line = std::make_shared<Experimental::TLine>({0.5_normal, 0.5_normal} , {x_normal, y_normal});
+      // temporary because x_normal and y_normal do not work
+      p2.fHoriz = 1._normal;
+      p2.fVert  = 1._normal;
+
+      auto line = std::make_shared<Experimental::TLine>(p1 , p2);
 
       auto col = Experimental::TColor(0.0025*i, 0, 0);
       line->GetOptions().SetLineColor(col);
@@ -36,12 +46,36 @@ void line()
       canvas->Draw(line);
     }
 
-  auto line  = std::make_shared<Experimental::TLine>({0.0_normal, 0.0_normal} , {1.0_normal, 1.0_normal}); canvas->Draw(line);
-  auto line1 = std::make_shared<Experimental::TLine>({0.1_normal, 0.1_normal} , {0.9_normal, 0.1_normal}); canvas->Draw(line1);
-  auto line2 = std::make_shared<Experimental::TLine>({0.9_normal, 0.1_normal} , {0.9_normal, 0.9_normal}); canvas->Draw(line2);
-  auto line3 = std::make_shared<Experimental::TLine>({0.9_normal, 0.9_normal} , {0.1_normal, 0.9_normal}); canvas->Draw(line3);
-  auto line4 = std::make_shared<Experimental::TLine>({0.1_normal, 0.1_normal} , {0.1_normal, 0.9_normal}); canvas->Draw(line4);
-  auto line0 = std::make_shared<Experimental::TLine>({0.0_normal, 1.0_normal} , {1.0_normal, 0.0_normal}); canvas->Draw(line0);
+   p1.fHoriz = 0._normal;
+   p1.fVert  = 0._normal;
+   p2.fHoriz = 1._normal;
+   p2.fVert  = 1._normal;
+   auto line  = std::make_shared<Experimental::TLine>(p1, p2); canvas->Draw(line);
+   p1.fHoriz = 0.1_normal;
+   p1.fVert  = 0.1_normal;
+   p2.fHoriz = 0.9_normal;
+   p2.fVert  = 0.1_normal;
+   auto line1 = std::make_shared<Experimental::TLine>(p1, p2); canvas->Draw(line1);
+   p1.fHoriz = 0.9_normal;
+   p1.fVert  = 0.1_normal;
+   p2.fHoriz = 0.9_normal;
+   p2.fVert  = 0.9_normal;
+   auto line2 = std::make_shared<Experimental::TLine>(p1, p2); canvas->Draw(line2);
+   p1.fHoriz = 0.9_normal;
+   p1.fVert  = 0.9_normal;
+   p2.fHoriz = 0.1_normal;
+   p2.fVert  = 0.9_normal;
+   auto line3 = std::make_shared<Experimental::TLine>(p1, p2); canvas->Draw(line3);
+   p1.fHoriz = 0.1_normal;
+   p1.fVert  = 0.1_normal;
+   p2.fHoriz = 0.1_normal;
+   p2.fVert  = 0.9_normal;
+   auto line4 = std::make_shared<Experimental::TLine>(p1, p2); canvas->Draw(line4);
+   p1.fHoriz = 0.0_normal;
+   p1.fVert  = 1.0_normal;
+   p2.fHoriz = 1.0_normal;
+   p2.fVert  = 0.0_normal;
+   auto line0 = std::make_shared<Experimental::TLine>(p1, p2); canvas->Draw(line0);
 
    canvas->Show();
 }

--- a/tutorials/v7/line.cxx
+++ b/tutorials/v7/line.cxx
@@ -13,6 +13,7 @@ R__LOAD_LIBRARY(libGpad);
 #include "ROOT/TCanvas.hxx"
 #include "ROOT/TColor.hxx"
 #include "ROOT/TLine.hxx"
+#include <ROOT/TPadPos.hxx>
 
 void line()
 {
@@ -21,14 +22,12 @@ void line()
    // Create a canvas to be displayed.
    auto canvas = Experimental::TCanvas::Create("Canvas Title");
 
-
-
    for (double i = 0; i < 360; i+=1) {
       double ang = i * TMath::Pi() / 180;
       double x = 0.3*TMath::Cos(ang) + 0.5;
       double y = 0.3*TMath::Sin(ang) + 0.5;
 
-      auto line = std::make_shared<Experimental::TLine>(0.5 ,0.5 ,x, y);
+      auto line = std::make_shared<Experimental::TLine>({0.5_normal, 0.5_normal} , {x_normal, y_normal});
 
       auto col = Experimental::TColor(0.0025*i, 0, 0);
       line->GetOptions().SetLineColor(col);
@@ -37,12 +36,12 @@ void line()
       canvas->Draw(line);
     }
 
-   auto line  = std::make_shared<Experimental::TLine>(0. ,0. ,1. ,1.);     canvas->Draw(line);
-   auto line1 = std::make_shared<Experimental::TLine>(0.1 ,0.1 ,0.9 ,0.1); canvas->Draw(line1);
-   auto line2 = std::make_shared<Experimental::TLine>(0.9 ,0.1 ,0.9 ,0.9); canvas->Draw(line2);
-   auto line3 = std::make_shared<Experimental::TLine>(0.9 ,0.9 ,0.1 ,0.9); canvas->Draw(line3);
-   auto line4 = std::make_shared<Experimental::TLine>(0.1 ,0.1 ,0.1 ,0.9); canvas->Draw(line4);
-   auto line0 = std::make_shared<Experimental::TLine>(0. ,1. ,1. ,0.);     canvas->Draw(line0);
+  auto line  = std::make_shared<Experimental::TLine>({0.0_normal, 0.0_normal} , {1.0_normal, 1.0_normal}); canvas->Draw(line);
+  auto line1 = std::make_shared<Experimental::TLine>({0.1_normal, 0.1_normal} , {0.9_normal, 0.1_normal}); canvas->Draw(line1);
+  auto line2 = std::make_shared<Experimental::TLine>({0.9_normal, 0.1_normal} , {0.9_normal, 0.9_normal}); canvas->Draw(line2);
+  auto line3 = std::make_shared<Experimental::TLine>({0.9_normal, 0.9_normal} , {0.1_normal, 0.9_normal}); canvas->Draw(line3);
+  auto line4 = std::make_shared<Experimental::TLine>({0.1_normal, 0.1_normal} , {0.1_normal, 0.9_normal}); canvas->Draw(line4);
+  auto line0 = std::make_shared<Experimental::TLine>({0.0_normal, 1.0_normal} , {1.0_normal, 0.0_normal}); canvas->Draw(line0);
 
    canvas->Show();
 }

--- a/tutorials/v7/line.cxx
+++ b/tutorials/v7/line.cxx
@@ -33,9 +33,8 @@ void line()
       double x   = 0.3*TMath::Cos(ang) + 0.5;
       double y   = 0.3*TMath::Sin(ang) + 0.5;
 
-      // temporary because x_normal and y_normal do not work
-      p2.fHoriz = 1._normal;
-      p2.fVert  = 1._normal;
+      p2.fHoriz = TPadLength::Normal(x);
+      p2.fVert  = TPadLength::Normal(y);
 
       auto line = std::make_shared<Experimental::TLine>(p1 , p2);
 


### PR DESCRIPTION
The line.cxx example has been modified accordingly. But when executed it gives errors messages like:
error: no matching literal operator for call to 'operator""_normal'