### PR TITLE
critical bugfix in RooFit to avoid last bin getting lost in histogram

### DIFF
--- a/roofit/roofitcore/src/RooHistFunc.cxx
+++ b/roofit/roofitcore/src/RooHistFunc.cxx
@@ -512,10 +512,12 @@ std::list<Double_t>* RooHistFunc::binBoundaries(RooAbsRealLValue& obs, Double_t 
 
   list<Double_t>* hint = new list<Double_t> ;
 
+  Double_t delta = (xhi-xlo)*1e-8 ;
+
   // Construct array with pairs of points positioned epsilon to the left and
   // right of the bin boundaries
   for (Int_t i=0 ; i<binning->numBoundaries() ; i++) {
-    if (boundaries[i]>=xlo && boundaries[i]<=xhi) {
+    if (boundaries[i]>xlo-delta && boundaries[i]<xhi+delta) {
       
       Double_t boundary = boundaries[i] ;
       if (transform) {


### PR DESCRIPTION
We have recently discovered a critical bug in RooFit which (under some arcane circumstances) causes the last bin to go missing from a `RooHistFunc`. Notably, the occurence of this effect is a rounding issue that only happens for some values of upper bounds of observables. 

I have attached a python test case that showcases the problem. The assertion in the last line will fail in the current master of ROOT, but will succeed using the bugfix in this MR.

    import ROOT
    from math import pi
    
    xmin = -25.2
    xmax = 6.3
    nbins = 35
    hfname = "hists.root"
    
    histfile = ROOT.TFile.Open(hfname,"RECREATE")
    
    signalSR = ROOT.TH1F("signalSR","signal",nbins,xmin,xmax)
    signalSR.FillRandom("gaus")
    
    backgroundSR = ROOT.TH1F("backgroundSR","background",nbins,xmin,xmax)
    backgroundSR.FillRandom("pol0")
    
    signalCR = ROOT.TH1F("signalCR","signal",nbins,xmin,xmax)
    signalCR.FillRandom("pol0")
    
    backgroundCR = ROOT.TH1F("backgroundCR","background",nbins,xmin,xmax)
    backgroundCR.FillRandom("pol0")
    
    histfile.Write()
    histfile.Close()
    
    sigSR = ROOT.RooStats.HistFactory.Sample("signal","",hfname,"signalSR")
    sigSR.AddNormFactor("mu",1.,0.,10.,False)
    bkgSR = ROOT.RooStats.HistFactory.Sample("background","",hfname,"backgroundSR")
    bkgSR.AddNormFactor("norm",1.,0.,10.,False)
    
    sr = ROOT.RooStats.HistFactory.Channel("SR")
    sr.AddSample(sigSR)
    sr.AddSample(bkgSR)
    
    sigCR = ROOT.RooStats.HistFactory.Sample("signal","",hfname,"signalCR")
    sigCR.AddNormFactor("mu",1.,0.,10.,False)
    bkgCR = ROOT.RooStats.HistFactory.Sample("background","",hfname,"backgroundCR")
    bkgCR.AddNormFactor("norm",1.,0.,10.,False)
    
    cr = ROOT.RooStats.HistFactory.Channel("CR")
    cr.AddSample(sigCR)
    cr.AddSample(bkgCR)
    
    
    meas = ROOT.RooStats.HistFactory.Measurement("meas")
    meas.AddChannel(sr)
    meas.AddChannel(cr)
    

    meas.CollectHistograms()
    ws = ROOT.RooStats.HistFactory.HistoToWorkspaceFactoryFast.MakeCombinedModel(meas)
    pdf = ws.pdf("model_SR")
    obs = ws.var("obs_x_SR")
    hist = pdf.createHistogram("hist",obs,ROOT.RooFit.IntrinsicBinning(1))

    assert(hist.GetNbinsX() == nbins)