### PR TITLE
[cling] Fix valgrind error in CIFactory/AddRuntimeIncludePaths.

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -664,7 +664,8 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
         llvm::sys::path::append(P, "clang");
         if (!llvm::sys::fs::is_directory(P.str())) {
           // LLVM is not installed. Try resolving clang from its usual location.
-          P = llvm::sys::path::parent_path(P);
+          llvm::SmallString<512> PParent = llvm::sys::path::parent_path(P);
+          P = PParent;
           llvm::sys::path::append(P, "..", "tools", "clang", "include");
           if (llvm::sys::fs::is_directory(P.str()))
             utils::AddIncludePaths(P.str(), HOpts, nullptr);


### PR DESCRIPTION
Fixes
```
==19429== Source and destination overlap in memcpy(0xffeffca40, 0xffeffca40, 49)
==19429==    at 0x403223C: memcpy@@GLIBC_2.14 (vg_replace_strmem.c:1018)
==19429==    by 0x7B9DCB3: uninitialized_copy<const char, char> (SmallVector.h:296)
==19429==    by 0x7B9DCB3: append<const char *, void> (SmallVector.h:402)
==19429==    by 0x7B9DCB3: append<const char *> (SmallString.h:76)
==19429==    by 0x7B9DCB3: operator+= (SmallString.h:286)
==19429==    by 0x7B9DCB3: operator= (SmallString.h:282)
==19429==    by 0x7B9DCB3: AddRuntimeIncludePaths (CIFactory.cpp:667)
```