### PR TITLE
[rootcling] nullptr payload and fwddecls if in PCH:

### DIFF
--- a/core/dictgen/res/TModuleGenerator.h
+++ b/core/dictgen/res/TModuleGenerator.h
@@ -44,7 +44,8 @@ namespace ROOT {
 
       TModuleGenerator(clang::CompilerInstance *CI,
                        bool inlineHeader,
-                       const std::string &shLibFileName);
+                       const std::string &shLibFileName,
+                       bool isInPCH);
       ~TModuleGenerator();
 
       // FIXME: remove once PCH is gone.
@@ -138,6 +139,7 @@ namespace ROOT {
 
       clang::CompilerInstance *fCI;
       bool fIsPCH;
+      bool fIsInPCH; // whether the headers of this module are part of the PCH.
       bool fInlineInputHeaders;
 
       std::string fDictionaryName; // Name of the dictionary, e.g. "Base"

--- a/core/dictgen/src/TModuleGenerator.cxx
+++ b/core/dictgen/src/TModuleGenerator.cxx
@@ -44,9 +44,11 @@ using namespace clang;
 
 TModuleGenerator::TModuleGenerator(CompilerInstance *CI,
                                    bool inlineInputHeaders,
-                                   const std::string &shLibFileName):
+                                   const std::string &shLibFileName,
+                                   bool writeEmptyRootPCM):
    fCI(CI),
    fIsPCH(shLibFileName == "allDict.cxx"),
+   fIsInPCH(writeEmptyRootPCM),
    fInlineInputHeaders(inlineInputHeaders),
    fDictionaryName(llvm::sys::path::stem(shLibFileName)),
    fDemangledDictionaryName(llvm::sys::path::stem(shLibFileName)),
@@ -375,6 +377,9 @@ void TModuleGenerator::WriteRegistrationSource(std::ostream &out,
       fwdDeclStringRAW += ")DICTFWDDCLS\"";
    }
 
+   if (fIsInPCH)
+      fwdDeclStringRAW = "nullptr";
+
    std::string payloadCode;
 
    // Increase the value of the diagnostics pointing out from which
@@ -451,12 +456,17 @@ void TModuleGenerator::WriteRegistrationSource(std::ostream &out,
    } else {
       WriteHeaderArray(out);
    };
+
+   std::string payloadcodeWrapped = "nullptr";
+   if (!fIsInPCH)
+      payloadcodeWrapped = "R\"DICTPAYLOAD(\n" + payloadCode + ")DICTPAYLOAD\"";
+
    out << "    };\n"
-       "    static const char* includePaths[] = {\n";
+       << "    static const char* includePaths[] = {\n";
    WriteIncludePathArray(out) <<
                               "    };\n"
                               "    static const char* fwdDeclCode = " << fwdDeclStringRAW << ";\n"
-                              "    static const char* payloadCode = R\"DICTPAYLOAD(\n" << payloadCode << ")DICTPAYLOAD\";\n"
+                              "    static const char* payloadCode = " << payloadcodeWrapped << ";\n"
                               "    " << headersClassesMapString << "\n"
                               "    static bool isInitialized = false;\n"
                               "    if (!isInitialized) {\n"

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -4665,7 +4665,8 @@ int RootClingMain(int argc,
 
    TModuleGenerator modGen(interp.getCI(),
                            inlineInputHeader,
-                           sharedLibraryPathName);
+                           sharedLibraryPathName,
+                           writeEmptyRootPCM);
 
    if (!gDriverConfig->fBuildingROOTStage1 && !filesIncludedByLinkdef.empty()) {
       pcmArgs.push_back(argv[linkdefLoc]);

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1726,7 +1726,8 @@ void TCling::RegisterModule(const char* modulename,
    // This is used to give Sema the same view on ACLiC'ed files (which
    // are then #included through the dictionary) as rootcling had.
    TString code = gNonInterpreterClassDef;
-   code += payloadCode;
+   if (payloadCode)
+      code += payloadCode;
 
    const char* dyLibName = nullptr;
    // If this call happens after dlopen has finished (i.e. late registration)


### PR DESCRIPTION
If a dictionary's headers are in the PCH, they get #includes at
startup. There is no need for forward declarations (to be parsed
at library load time) nor payloads (to be parsed at autoparsing time).

This should reduce the effect we see with recursive parsing, and
speed up ROOT (e.g. but not only the startup).