### PR TITLE
[Math] Do not instantiate MixMaxEngine extern templates in gcc-5 

### DIFF
--- a/core/base/inc/ROOT/RConfig.h
+++ b/core/base/inc/ROOT/RConfig.h
@@ -459,6 +459,13 @@
 #   define _R__UNIQUE_(X) X
 #endif
 
+/* gcc-5 fails to annotate with the cxx abi tag ([abi:cxx11]) mangled names of methods of template classes which would
+ * otherwise require it (e.g. methods that return std::string). This causes name mismatches and failures to load
+ * these kind of symbols on the part of well-behaved compilers. */
+#if !defined(__clang__) && __GNUC__ == 5 // clang also defines __GNUC__
+#   define R__GCC5_BROKEN_CXX11ABI
+#endif
+
 /*---- deprecation -----------------------------------------------------------*/
 #if defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)
 # if __GNUC__ == 5 && (__GNUC_MINOR__ == 1 || __GNUC_MINOR__ == 2)

--- a/math/mathcore/inc/Math/MixMaxEngine.h
+++ b/math/mathcore/inc/Math/MixMaxEngine.h
@@ -187,6 +187,7 @@ namespace ROOT {
       typedef MixMaxEngine<256,2> MixMaxEngine256;
       typedef MixMaxEngine<17,0> MixMaxEngine17;
       
+#ifndef R__GCC5_BROKEN_CXX11ABI
       extern template class MixMaxEngine<240,0>;
       extern template class MixMaxEngine<256,0>;
       extern template class MixMaxEngine<256,2>;
@@ -194,6 +195,7 @@ namespace ROOT {
       extern template class MixMaxEngine<17,0>;
       extern template class MixMaxEngine<17,1>;
       extern template class MixMaxEngine<17,2>;
+#endif
 
    } // end namespace Math
 

--- a/math/mathcore/src/MixMaxEngineImpl17.cxx
+++ b/math/mathcore/src/MixMaxEngineImpl17.cxx
@@ -1,4 +1,4 @@
-
+#ifndef R__GCC5_BROKEN_CXX11ABI
 
 // define number for used to Mixmax
 #define ROOT_MM_N 17
@@ -14,3 +14,5 @@ namespace ROOT {
       template class MixMaxEngine<17,2>;
    }
 }
+
+#endif

--- a/math/mathcore/src/MixMaxEngineImpl240.cxx
+++ b/math/mathcore/src/MixMaxEngineImpl240.cxx
@@ -1,3 +1,4 @@
+#ifndef R__GCC5_BROKEN_CXX11ABI
 
 
 // define number for used to Mixmax
@@ -12,3 +13,5 @@ namespace ROOT {
       template class MixMaxEngine<240,0>;
    }
 }
+
+#endif

--- a/math/mathcore/src/MixMaxEngineImpl256.cxx
+++ b/math/mathcore/src/MixMaxEngineImpl256.cxx
@@ -1,3 +1,4 @@
+#ifndef R__GCC5_BROKEN_CXX11ABI
 
 
 // define number for used to Mixmax
@@ -14,3 +15,5 @@ namespace ROOT {
       template class MixMaxEngine<256,4>;
    }
 }
+
+#endif


### PR DESCRIPTION
Because of a bug in gcc-5, the extern template instantiation of
MixMaxEngine::Name would lack the correct cxx11 abi attribute in the
mangled name, so compilers which correctly add the cxx abi attribute
would not find the symbol in the shared library.