### PR TITLE
Also buffer Sema.UndefinedButUsed:

### DIFF
--- a/core/metacling/src/ClingRAII.h
+++ b/core/metacling/src/ClingRAII.h
@@ -25,12 +25,14 @@ namespace ROOT {
           decltype(clang::Sema::ExprCleanupObjects) fExprCleanupObjects;
           decltype(clang::Sema::MaybeODRUseExprs) fMaybeODRUseExprs;
           decltype(clang::Sema::FunctionScopes) fFunctionScopes;
+          decltype(clang::Sema::UndefinedButUsed) fUndefinedButUsed;
           clang::Sema& fSema;
           void Swapem() {
              std::swap(fCleanup, fSema.Cleanup);
              std::swap(fExprCleanupObjects, fSema.ExprCleanupObjects);
              std::swap(fMaybeODRUseExprs, fSema.MaybeODRUseExprs);
              std::swap(fFunctionScopes, fSema.FunctionScopes);
+             std::swap(fUndefinedButUsed, fSema.UndefinedButUsed);
           }
           SemaExprCleanupsRAII(clang::Sema& S): fSema(S) {
              fFunctionScopes.push_back(new clang::sema::FunctionScopeInfo(S.Diags));


### PR DESCRIPTION
Else Sema::checkUndefinedButUsed() will complain about things it did not see
and should not care about (because they are only relevant to the Sema state
outside the recursive parse).