### PR TITLE
[Math] Avoid std::string in signature of template class method

### DIFF
--- a/math/mathcore/inc/Math/MixMaxEngine.h
+++ b/math/mathcore/inc/Math/MixMaxEngine.h
@@ -156,7 +156,7 @@ namespace ROOT {
          Result_t IntRndm();
 
          /// get name of the generator
-         static std::string Name();
+         static const char *Name();
 
       protected:
          // protected functions used for tesing the generator

--- a/math/mathcore/inc/Math/MixMaxEngine.icc
+++ b/math/mathcore/inc/Math/MixMaxEngine.icc
@@ -154,11 +154,9 @@ namespace Math {
    }
 
    template<int N, int S>
-   std::string MixMaxEngine<N,S>::Name()  {
-      std::string name =  "MixMax";
-      name += Util::ToString(N);
-      if (S > 0) name += std::string("_") + Util::ToString(S);
-      return name; 
+   const char *MixMaxEngine<N, S>::Name() {
+      static const std::string name = "MixMax" + Util::ToString(N) + (S > 0 ? "_" + Util::ToString(S) : "");
+      return name.c_str();
    }
    
    } // namespace Math

--- a/math/mathcore/inc/TRandomGen.h
+++ b/math/mathcore/inc/TRandomGen.h
@@ -52,8 +52,8 @@ public:
    
    TRandomGen(ULong_t seed=1) {
       fEngine.SetSeed(seed);
-      SetName(TString::Format("Random_%s",fEngine.Name().c_str() ) );
-      SetTitle(TString::Format("Random number generator: %s",fEngine.Name().c_str() ));
+      SetName(TString::Format("Random_%s", std::string(fEngine.Name()).c_str()));
+      SetTitle(TString::Format("Random number generator: %s", std::string(fEngine.Name()).c_str()));
    }
    virtual ~TRandomGen() {}
    using TRandom::Rndm; 


### PR DESCRIPTION
Because of a bug in gcc-5, the extern template instantiation of
MixMaxEngine::Name would lack the correct cxx11 abi attribute in the
mangled name (required because std::string is part of the signature),
so compilers which correctly add the cxx abi attribute would not
find the symbol in the shared library.

We now eturn a const char* pointing to contents of a static string instead.

This PR supersedes #1932 .