### PR TITLE
[TDF][TO REVERT] Use ProcessLine instead of Calc for jitting

### DIFF
--- a/tree/treeplayer/src/TDFNodes.cxx
+++ b/tree/treeplayer/src/TDFNodes.cxx
@@ -466,7 +466,7 @@ void TLoopManager::CleanUpTask(unsigned int slot)
 void TLoopManager::JitActions()
 {
    auto error = TInterpreter::EErrorCode::kNoError;
-   gInterpreter->Calc(fToJit.c_str(), &error);
+   gInterpreter->ProcessLine(fToJit.c_str(), &error);
    if (TInterpreter::EErrorCode::kNoError != error) {
       std::string exceptionText =
          "An error occurred while jitting. The lines above might indicate the cause of the crash\n";


### PR DESCRIPTION
...in the hope to get a clearer picture about the test failures
when jitting