### PR TITLE
 [TDF] Template TInterface over the derived TDataSource type 

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFInterface.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFInterface.hxx
@@ -97,7 +97,7 @@ namespace TTraits = ROOT::TypeTraits;
 * \brief The public interface to the TDataFrame federation of classes
 * \tparam T One of the "node" base types (e.g. TLoopManager, TFilterBase). The user never specifies this type manually.
 */
-template <typename Proxied>
+template <typename Proxied, typename DataSource = void>
 class TInterface {
    using ColumnNames_t = TDFDetail::ColumnNames_t;
    using TFilterBase = TDFDetail::TFilterBase;
@@ -105,7 +105,7 @@ class TInterface {
    using TCustomColumnBase = TDFDetail::TCustomColumnBase;
    using TLoopManager = TDFDetail::TLoopManager;
    friend std::string cling::printValue(::ROOT::Experimental::TDataFrame *tdf); // For a nice printing at the prompt
-   template <typename T>
+   template <typename T, typename W>
    friend class TInterface;
 
    const std::shared_ptr<Proxied> fProxiedPtr;     ///< Smart pointer to the graph node encapsulated by this TInterface.

--- a/tree/treeplayer/inc/ROOT/TDataSource.hxx
+++ b/tree/treeplayer/inc/ROOT/TDataSource.hxx
@@ -25,7 +25,7 @@ namespace TDS {
 /// Mother class of TTypedPointerHolder. The instances
 /// of this class can be put in a container. Upon destruction,
 /// the correct deletion of the pointer is performed in the
-/// dauther class.
+/// derived class.
 class TPointerHolder {
 protected:
    void *fPointer{nullptr};


### PR DESCRIPTION
This will allow, in the future, to optimize loading of entries
from TDataSources: `GetColumnReaders` does not have to pass through
virtual calls to `TDataSource` anymore, which means that concrete
TDS's can provide custom, possibly lazy column readers which
TInterface will use directly.

Concretely I would make this mechanism opt-in: TDataSources can still implement the usual `GetColumnReadersImpl` method, but if they implement `GetColumnReadersFast<T>` (better names are welcome) `TInterface` will switch to using that one.
`GetColumnReadersFast<T>` is not limited to returning `vector<void *>` but can return smart objects which behave like pointers but can perform e.g. callbacks to their TDataSource.
This basically allows `TDataSources` to implement a mechanism similar to `TTreeReader`/`TTreeReaderValue`, if required for performance reasons or in order to implement certain features.