### PR TITLE
bug-fix: MinimumBuilder.cxx has an include issue

### DIFF
--- a/math/minuit2/src/MinimumBuilder.cxx
+++ b/math/minuit2/src/MinimumBuilder.cxx
@@ -8,10 +8,7 @@
  **********************************************************************/
 
 #include "Minuit2/MinimumBuilder.h"
-
-#if defined(DEBUG) || defined(WARNINGMSG)
 #include "Minuit2/MnPrint.h"
-#endif
 
 
 namespace ROOT {


### PR DESCRIPTION
MinimumBuilder.cxx does not compile if neither WARNINGMSG no…r DEBUG is set. Cherry-picked from #1677 to isolate that change from this one.