### PR TITLE
Adding non const version of Minimizer

### DIFF
--- a/math/minuit2/inc/Minuit2/MnApplication.h
+++ b/math/minuit2/inc/Minuit2/MnApplication.h
@@ -58,6 +58,7 @@ public:
    */
    virtual FunctionMinimum operator()(unsigned int maxfcn = 0, double tolerance = 0.1);
 
+   virtual ModularFunctionMinimizer& Minimizer() = 0;
    virtual const ModularFunctionMinimizer& Minimizer() const = 0;
 
    const MnMachinePrecision& Precision() const {return fState.Precision();}

--- a/math/minuit2/inc/Minuit2/MnFumiliMinimize.h
+++ b/math/minuit2/inc/Minuit2/MnFumiliMinimize.h
@@ -61,6 +61,7 @@ public:
 
    virtual ~MnFumiliMinimize() { }
 
+   FumiliMinimizer& Minimizer() {return fMinimizer;}
    const FumiliMinimizer& Minimizer() const {return fMinimizer;}
 
    const FumiliFCNBase & Fcnbase() const { return fFCN; }

--- a/math/minuit2/inc/Minuit2/MnMigrad.h
+++ b/math/minuit2/inc/Minuit2/MnMigrad.h
@@ -74,6 +74,7 @@ public:
 
    ~MnMigrad() {}
 
+   ModularFunctionMinimizer& Minimizer() {return fMinimizer;}
    const ModularFunctionMinimizer& Minimizer() const {return fMinimizer;}
 
 private:

--- a/math/minuit2/inc/Minuit2/MnMinimize.h
+++ b/math/minuit2/inc/Minuit2/MnMinimize.h
@@ -73,6 +73,7 @@ public:
 
    ~MnMinimize() {}
 
+   ModularFunctionMinimizer& Minimizer() {return fMinimizer;}
    const ModularFunctionMinimizer& Minimizer() const {return fMinimizer;}
 
 private:

--- a/math/minuit2/inc/Minuit2/MnScan.h
+++ b/math/minuit2/inc/Minuit2/MnScan.h
@@ -54,6 +54,7 @@ public:
 
    ~MnScan() {}
 
+   ModularFunctionMinimizer& Minimizer() {return fMinimizer;}
    const ModularFunctionMinimizer& Minimizer() const {return fMinimizer;}
 
    std::vector<std::pair<double, double> > Scan(unsigned int par, unsigned int maxsteps = 41, double low = 0., double high = 0.);

--- a/math/minuit2/inc/Minuit2/MnSimplex.h
+++ b/math/minuit2/inc/Minuit2/MnSimplex.h
@@ -57,6 +57,7 @@ public:
 
    ~MnSimplex() {}
 
+   ModularFunctionMinimizer& Minimizer() {return fMinimizer;}
    const ModularFunctionMinimizer& Minimizer() const {return fMinimizer;}
 
 private:


### PR DESCRIPTION
I think this is the correct fix for #1677; the non-const version of `Minimizer()` was missing from the interface. `Builder()` already has both const and non-const versions, so this should be enough to fix the chain `MnMigrad.Minimizer().Builder().SetPrintLevel(...)`. @HDembinski please check.