### PR TITLE
[VecOps] Do not use extern templates on Windows, Linux gcc48/clang(all versions)

### DIFF
--- a/math/vecops/inc/ROOT/TVec.hxx
+++ b/math/vecops/inc/ROOT/TVec.hxx
@@ -15,6 +15,27 @@
 #ifndef ROOT_TVEC
 #define ROOT_TVEC
 
+#define _VECOPS_USE_EXTERN_TEMPLATES true
+
+// We do not support extern templates on Win
+#ifdef _WIN32
+#undef _VECOPS_USE_EXTERN_TEMPLATES
+#define _VECOPS_USE_EXTERN_TEMPLATES false
+#endif // _WIN32
+
+// We do not support extern templates on Linux if the compiler is old
+#ifdef R_LINUX
+#if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) <= 40800
+#undef _VECOPS_USE_EXTERN_TEMPLATES
+#define _VECOPS_USE_EXTERN_TEMPLATES false
+#endif // GCC version
+#ifdef __clang__
+#undef _VECOPS_USE_EXTERN_TEMPLATES
+#define _VECOPS_USE_EXTERN_TEMPLATES false
+#endif
+#endif // R__LINUX
+
+
 #include <ROOT/RStringView.hxx>
 #include <ROOT/TAdoptAllocator.hxx>
 #include <ROOT/TypeTraits.hxx>
@@ -695,7 +716,7 @@ std::ostream &operator<<(std::ostream &os, const TVec<T> &v)
    return os;
 }
 
-#ifndef _WIN32
+#if(_VECOPS_USE_EXTERN_TEMPLATES)
 
 #define TVEC_EXTERN_UNARY_OPERATOR(T, OP) \
    extern template TVec<T> operator OP<T>(const TVec<T> &);
@@ -871,7 +892,7 @@ TVEC_EXTERN_VDT_UNARY_FUNCTION(double, fast_atan)
 
 #endif // R__HAS_VDT
 
-#endif // _WIN32
+#endif // _VECOPS_USE_EXTERN_TEMPLATES
 
 } // End of VecOps NS
 
@@ -889,5 +910,7 @@ inline std::string printValue(ROOT::Experimental::VecOps::TVec<T> *tvec)
 }
 
 } // namespace cling
+
+#undef _VECOPS_USE_EXTERN_TEMPLATES
 
 #endif

--- a/math/vecops/src/TVec.cxx
+++ b/math/vecops/src/TVec.cxx
@@ -1,6 +1,26 @@
 #include "ROOT/TVec.hxx"
 
-#ifndef _WIN32
+#define _VECOPS_USE_EXTERN_TEMPLATES true
+
+// We do not support extern templates on Win
+#ifdef _WIN32
+#undef _VECOPS_USE_EXTERN_TEMPLATES
+#define _VECOPS_USE_EXTERN_TEMPLATES false
+#endif // _WIN32
+
+// We do not support extern templates on Linux if the compiler is old
+#ifdef R_LINUX
+#if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) <= 40800
+#undef _VECOPS_USE_EXTERN_TEMPLATES
+#define _VECOPS_USE_EXTERN_TEMPLATES false
+#endif // GCC version
+#ifdef __clang__
+#undef _VECOPS_USE_EXTERN_TEMPLATES
+#define _VECOPS_USE_EXTERN_TEMPLATES false
+#endif
+#endif // R__LINUX
+
+#if(_VECOPS_USE_EXTERN_TEMPLATES)
 
 namespace ROOT {
 namespace Experimental {
@@ -180,4 +200,4 @@ TVEC_DECLARE_VDT_UNARY_FUNCTION(double, fast_atan)
 } // namespace Experimental
 } // namespace ROOT
 
-#endif // _WIN32
+#endif // _VECOPS_USE_EXTERN_TEMPLATES


### PR DESCRIPTION
this functionality has been removed since there are still compilation errors.