### PR TITLE
[PyROOT] Fix TTree.AsMatrix tutorial for Mac OS

### DIFF
--- a/tutorials/pyroot/pyroot002_TTreeAsMatrix.py
+++ b/tutorials/pyroot/pyroot002_TTreeAsMatrix.py
@@ -34,7 +34,7 @@ def make_example():
         tree.Fill()
     root_file.Write()
 
-    return root_file, tree
+    return (root_file, x, y), tree
 
 
 # The conversion of the TTree to a numpy array is implemented with multi-


### PR DESCRIPTION
This PR fixes following failures:
1. http://cdash.cern.ch/testDetails.php?test=42006642&build=497548
2. http://cdash.cern.ch/testDetails.php?test=42274691&build=497583

Before merging it should be understood why.

@etejedor The tests for `TTree.AsMatrix` run all fine but the tutorial fails occasionally with a segfault (only on Mac OS and only on these two versions). It is not related to the `TTree.AsMatrix` code but to the creation of a `TFile` inside a Python function. Any ideas?