### PR TITLE
Adding a ROOT::Libraries target for Modern CMake usage

### DIFF
--- a/cmake/scripts/ROOTConfig.cmake.in
+++ b/cmake/scripts/ROOTConfig.cmake.in
@@ -76,7 +76,11 @@ foreach(_opt ${_root_options})
 endforeach()
 
 #----------------------------------------------------------------------------
-# Now set them to ROOT_LIBRARIES
+# Prepare utility interface targets
+add_library(ROOT::Libraries INTERFACE IMPORTED)
+
+#----------------------------------------------------------------------------
+# Now set them to ROOT_LIBRARIES and ROOT::Libraries
 set(ROOT_LIBRARIES)
 if(MSVC)
   set(CMAKE_FIND_LIBRARY_PREFIXES "lib")
@@ -88,6 +92,11 @@ foreach(_cpt Core Imt RIO Net Hist Graf Graf3d Gpad Tree TreePlayer Rint Postscr
     mark_as_advanced(ROOT_${_cpt}_LIBRARY)
     list(APPEND ROOT_LIBRARIES ${ROOT_${_cpt}_LIBRARY})
     list(REMOVE_ITEM ROOT_FIND_COMPONENTS ${_cpt})
+  endif()
+  if(TARGET ROOT::${_cpt})
+      set_property(TARGET ROOT::Libraries APPEND PROPERTY INTERFACE_LINK_LIBRARIES ROOT::${_cpt})
+  else()
+    message(WARNING "Trying to link ROOT::Libraries to ROOT::${_cpt} but it is missing")
   endif()
 endforeach()
 if(ROOT_LIBRARIES)


### PR DESCRIPTION
I was looking into ways to improve the target-based usage of ROOT in CMake. I found the missing `INTERFACE_INCLUDE_DIRECTORIES` has already been added to master (Yay!), but there are still other additions that could really help a user trying to use targets:

| New target | Usage |
|---|---|
| `ROOT::Libraries` | This is the target equivalent of `ROOT_LIBRARIES`, and links all common and requested components. |
| ~~`ROOT::Flags`~~ | ~~The target equivalent of `ROOT_*_FLAGS`, `ROOT_DEFINITIONS`, and `ROOT_EXE_LINKER_FLAGS`. Adds the flags that ROOT recommends; this is a smart target and will add `C`, `CXX`, and `FORTRAN` flags as needed depending on the target you link to.~~ |

~~I have added `_LIST` versions of `FLAGS` variables, since CMake expects the flags to be a real list in most cases (really everywhere except in the `CMAKE_CXX_FLAGS` variable itself). Actually changing them to CMake lists directly might break users code, so this way is safer.~~

Target based approach before (showing the old INCLUDE issue too).

```cmake
cmake_minimum_required(VERSION 3.4)

project(RootSimpleExample LANGUAGES CXX)
find_package(ROOT CONFIG REQUIRED COMPONENTS RooFit RooFitCore)
# Note: Symbols missing compiling error if user forgets RooFitCore!

# Already fixed in ROOT master
set_property(TARGET ROOT::Core PROPERTY
    INTERFACE_INCLUDE_DIRECTORIES "${ROOT_INCLUDE_DIRS}")

# Fix for ROOT_*_FLAGS not actually being a CMake list
separate_arguments(ROOT_CXX_FLAGS)
separate_arguments(ROOT_EXE_LINKER_FLAGS)

# Setting up the recommended ROOT flags
add_library(ROOT::Flags IMPORTED INTERFACE)
set_property(TARGET ROOT::Flags APPEND PROPERTY
    INTERFACE_COMPILE_OPTIONS ${ROOT_CXX_FLAGS})
set_property(TARGET ROOT::Flags APPEND PROPERTY
    INTERFACE_COMPILE_DEFINITIONS ${ROOT_DEFINITIONS})
#set_property(TARGET ROOT::Flags APPEND PROPERTY
#    INTERFACE_LINK_LIBRARIES ${ROOT_EXE_LINKER_FLAGS})

# Adding an exectuable program and linking to needed ROOT libraries
add_executable(RootSimpleExample SimpleExample.cxx)
target_link_libraries(RootSimpleExample PUBLIC
    ROOT::Core ROOT::Imt ROOT::RIO ROOT::Net ROOT::Hist
    ROOT::Graf ROOT::Graf3d ROOT::Gpad ROOT::Tree ROOT::TreePlayer
    ROOT::Rint ROOT::Postscript ROOT::Matrix ROOT::Physics
    ROOT::MathCore ROOT::Thread ROOT::RooFit
    ROOT::Flags)
```
> Note: I'm listing all the libraries that ROOT adds by default, though due to dependency resolution, a few of them might not be needed to achieve the same result.

After:

```cmake
cmake_minimum_required(VERSION 3.4)

project(RootSimpleExample LANGUAGES CXX)
find_package(ROOT CONFIG REQUIRED COMPONENTS RooFit)

# Adding an exectuable program and linking to needed ROOT libraries
add_executable(RootSimpleExample SimpleExample.cxx)
target_link_libraries(RootSimpleExample PUBLIC ROOT::Libraries ROOT::Flags)
```