### PR TITLE
TTreeCache FillBuffer enhancements

### DIFF
--- a/core/base/inc/TVirtualPerfStats.h
+++ b/core/base/inc/TVirtualPerfStats.h
@@ -26,6 +26,7 @@
 
 
 class TFile;
+class TBranch;
 
 
 class TVirtualPerfStats : public TObject {
@@ -70,6 +71,12 @@ public:
    virtual Long64_t GetBytesRead() const = 0;
    virtual void SetNumEvents(Long64_t num) = 0;
    virtual Long64_t GetNumEvents() const = 0;
+
+   virtual void PrintBasketInfo(Option_t * option = "") const = 0;
+   virtual void SetLoaded(TBranch *b, size_t basketNumber) = 0;
+   virtual void SetLoadedMiss(TBranch *b, size_t basketNumber) = 0;
+   virtual void SetMissed(TBranch *b, size_t basketNumber) = 0;
+   virtual void SetUsed(TBranch *b, size_t basketNumber) = 0;
 
    static const char *EventType(EEventType type);
 

--- a/core/cont/inc/TBits.h
+++ b/core/cont/inc/TBits.h
@@ -41,6 +41,7 @@ protected:
    void DoLeftShift(UInt_t shift);
    void DoRightShift(UInt_t shift);
    void DoFlip();
+   void Resize(UInt_t newlen);
 
 public:
    TBits(UInt_t nbits = 8);
@@ -191,21 +192,27 @@ inline std::ostream &operator<<(std::ostream& os, const TBits& rhs)
 
 // inline functions...
 
+inline void TBits::Resize(UInt_t newbitnumber)
+{
+   // Update the allocated size.
+   UInt_t new_size = (newbitnumber/8) + 1;
+   if (new_size > fNbytes) {
+      new_size *= 2;
+      UChar_t *old_location = fAllBits;
+      fAllBits = new UChar_t[new_size];
+      memcpy(fAllBits,old_location,fNbytes);
+      memset(fAllBits+fNbytes ,0, new_size-fNbytes);
+      fNbytes = new_size;
+      delete [] old_location;
+   }
+}
+
 inline void TBits::SetBitNumber(UInt_t bitnumber, Bool_t value)
 {
    // Set bit number 'bitnumber' to be value
 
    if (bitnumber >= fNbits) {
-      UInt_t new_size = (bitnumber/8) + 1;
-      if (new_size > fNbytes) {
-         new_size *= 2;
-         UChar_t *old_location = fAllBits;
-         fAllBits = new UChar_t[new_size];
-         memcpy(fAllBits,old_location,fNbytes);
-         memset(fAllBits+fNbytes ,0, new_size-fNbytes);
-         fNbytes = new_size;
-         delete [] old_location;
-      }
+      Resize(bitnumber);
       fNbits = bitnumber+1;
    }
    UInt_t  loc = bitnumber/8;

--- a/core/cont/src/TBits.cxx
+++ b/core/cont/src/TBits.cxx
@@ -212,12 +212,14 @@ void TBits::DoFlip()
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Execute the left shift operation.
+/// Note: This does extent the number of bits (i.e. no data loss)
 
 void TBits::DoLeftShift(UInt_t shift)
 {
    if (shift==0) return;
    const UInt_t wordshift = shift / 8;
    const UInt_t offset = shift % 8;
+   Resize(fNbits + shift);
    if (offset==0) {
       for(UInt_t n = fNbytes - 1; n >= wordshift; --n) {
          fAllBits[n] = fAllBits[ n - wordshift ];
@@ -231,6 +233,7 @@ void TBits::DoLeftShift(UInt_t shift)
       fAllBits[wordshift] = fAllBits[0] << offset;
    }
    memset(fAllBits,0,wordshift);
+   fNbits += shift;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -241,21 +244,30 @@ void TBits::DoRightShift(UInt_t shift)
    if (shift==0) return;
    const UInt_t wordshift = shift / 8;
    const UInt_t offset = shift % 8;
-   const UInt_t limit = fNbytes - wordshift - 1;
+   if ( fNbytes < (wordshift + 1) ) {
+       memset(fAllBits, 0, fNbytes);
+       fNbits = 0;
+   } else {
+      const UInt_t limit = fNbytes - wordshift - 1;
 
-   if (offset == 0)
-      for (UInt_t n = 0; n <= limit; ++n)
-         fAllBits[n] = fAllBits[n + wordshift];
-   else
-   {
-      const UInt_t sub_offset = 8 - offset;
-      for (UInt_t n = 0; n < limit; ++n)
-         fAllBits[n] = (fAllBits[n + wordshift] >> offset) |
-                       (fAllBits[n + wordshift + 1] << sub_offset);
-      fAllBits[limit] = fAllBits[fNbytes-1] >> offset;
+      if (offset == 0)
+         for (UInt_t n = 0; n <= limit; ++n)
+               fAllBits[n] = fAllBits[n + wordshift];
+      else
+      {
+         const UInt_t sub_offset = 8 - offset;
+         for (UInt_t n = 0; n < limit; ++n)
+             fAllBits[n] = (fAllBits[n + wordshift] >> offset) |
+                           (fAllBits[n + wordshift + 1] << sub_offset);
+         fAllBits[limit] = fAllBits[fNbytes-1] >> offset;
+      }
+
+      memset(&(fAllBits[limit + 1]),0, fNbytes - limit - 1);
+      if (fNbits < shift)
+         fNbits = 0;
+      else
+         fNbits -= shift;
    }
-
-   memset(&(fAllBits[limit + 1]),0, fNbytes - limit - 1);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/proof/proofplayer/inc/TPerfStats.h
+++ b/proof/proofplayer/inc/TPerfStats.h
@@ -131,6 +131,12 @@ public:
    void SetNumEvents(Long64_t num) { fNumEvents = num; }
    Long64_t GetNumEvents() const { return fNumEvents; }
 
+   void        PrintBasketInfo(Option_t * = "") const {}
+   void        SetLoaded(TBranch *, size_t) {}
+   void        SetLoadedMiss(TBranch *, size_t) {}
+   void        SetMissed(TBranch *, size_t) {}
+   void        SetUsed(TBranch *, size_t) {}
+
    static void Start(TList *input, TList *output);
    static void Stop();
    static void Setup(TList *input);

--- a/tree/tree/inc/TBranch.h
+++ b/tree/tree/inc/TBranch.h
@@ -35,6 +35,8 @@
 
 #include "ROOT/TIOFeatures.hxx"
 
+#include "TBranchCacheInfo.h"
+
 class TTree;
 class TBasket;
 class TLeaf;
@@ -115,6 +117,9 @@ protected:
    TList      *fBrowsables;       ///<! List of TVirtualBranchBrowsables used for Browse()
 
    Bool_t      fSkipZip;          ///<! After being read, the buffer will not be unzipped.
+
+   using CacheInfo_t = ROOT::Internal::TBranchCacheInfo;
+   CacheInfo_t fCacheInfo;        ///<! Hold info about which basket are in the cache and if they have been retrieved from the cache.
 
    typedef void (TBranch::*ReadLeaves_t)(TBuffer &b);
    ReadLeaves_t fReadLeaves;      ///<! Pointer to the ReadLeaves implementation to use.
@@ -210,6 +215,7 @@ public:
    virtual void      KeepCircular(Long64_t maxEntries);
    virtual Int_t     LoadBaskets();
    virtual void      Print(Option_t *option="") const;
+           void      PrintCacheInfo() const;
    virtual void      ReadBasket(TBuffer &b);
    virtual void      Refresh(TBranch *b);
    virtual void      Reset(Option_t *option="");

--- a/tree/tree/inc/TBranch.h
+++ b/tree/tree/inc/TBranch.h
@@ -43,6 +43,7 @@ class TDirectory;
 class TFile;
 class TClonesArray;
 class TTreeCloner;
+class TTreeCache;
 
    const Int_t kDoNotProcess = BIT(10); // Active bit for branches
    const Int_t kIsClone      = BIT(11); // to indicate a TBranchClones
@@ -60,6 +61,7 @@ class TBranch : public TNamed , public TAttFill {
    using TIOFeatures = ROOT::TIOFeatures;
 
 protected:
+   friend class TTreeCache;
    friend class TTreeCloner;
    friend class TTree;
 

--- a/tree/tree/inc/TBranchCacheInfo.h
+++ b/tree/tree/inc/TBranchCacheInfo.h
@@ -1,0 +1,167 @@
+// @(#)root/tree:$Id$
+// Author: Philippe Canal, 2018
+
+/*************************************************************************
+ * Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TBranchCacheInfo
+#define ROOT_TBranchCacheInfo
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// TBranchCacheInfo                                                     //
+//                                                                      //
+// Hold info about which basket are in the cache and if they            //
+// have been retrieved from the cache.                                  //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+
+#include "Rtypes.h"
+#include "TBits.h"
+#include "TString.h" // for Printf
+
+#include <vector>
+
+class TBranch;
+
+namespace ROOT {
+namespace Internal {
+
+class TBranchCacheInfo {
+
+   enum EStates {
+      kLoaded = 0,
+      kUsed = 1,
+      kVetoed = 2,
+      kSize = 3
+   };
+
+   Int_t fBasketPedestal{-1}; // Lowest basket we have information for.  Its data is in bits [0-3[.
+   TBits fInfo;               // kSize bits per baskets (loaded, used, vetoed)
+
+   // Update the pedestal to be less or equal to basketNumber, shift the bits if needed.
+   void UpdatePedestal(Int_t basketNumber)
+   {
+      //fBasketPedestal = 0;
+      //return;
+      if (fBasketPedestal == -1) {
+         fBasketPedestal = basketNumber;
+      } else if (basketNumber < fBasketPedestal) {
+         auto delta = fBasketPedestal - basketNumber;
+         fBasketPedestal = basketNumber;
+         fInfo <<= (delta * kSize);
+      }
+   }
+
+   // Return true if the basket has been marked as having the 'what' state.
+   Bool_t TestState(Int_t basketNumber, EStates what) const {
+      if (basketNumber < fBasketPedestal)
+         return kFALSE;
+      return fInfo.TestBitNumber(kSize * (basketNumber - fBasketPedestal) + what);
+   }
+
+   // Mark if the basket has been marked has the 'what' state.
+   void SetState(Int_t basketNumber, EStates what) {
+      if (fBasketPedestal <= basketNumber)
+         fInfo.SetBitNumber(kSize * (basketNumber - fBasketPedestal) + what, true);
+   }
+
+
+public:
+
+   // Return true if the basket has been marked as 'used'
+   Bool_t HasBeenUsed(Int_t basketNumber) const
+   {
+      return TestState(basketNumber, kUsed);
+   }
+
+   // Mark if the basket has been marked as 'used'
+   void SetUsed(Int_t basketNumber)
+   {
+      UpdatePedestal(basketNumber);
+      SetState(basketNumber, kUsed);
+   }
+
+   // Return true if the basket is currently in the cache.
+   Bool_t IsInCache(Int_t basketNumber) const
+   {
+      return TestState(basketNumber, kLoaded);
+   }
+
+   // Mark if the basket is currently in the cache.
+   void SetIsInCache(Int_t basketNumber)
+   {
+      UpdatePedestal(basketNumber);
+      SetState(basketNumber, kLoaded);
+   }
+
+   // Mark if the basket should be vetoed in the next round.
+   // This happens when the basket was loaded in the previous round
+   // and was not used and is overlapping to the next round/cluster
+   void Veto(Int_t basketNumber)
+   {
+      UpdatePedestal(basketNumber);
+      SetState(basketNumber, kVetoed);
+   }
+
+   // Return true if the basket is currently vetoed.
+   Bool_t IsVetoed(Int_t basketNumber) const
+   {
+      return TestState(basketNumber, kVetoed);
+   }
+
+   // Return true if all the baskets that are marked loaded are also
+   // mark as used.
+   Bool_t AllUsed() const {
+      auto len = fInfo.GetNbits() / kSize + 1;
+      for(UInt_t b = 0; b  < len ; ++b) {
+         if (fInfo[kSize*b + kLoaded] && !fInfo[kSize*b + kUsed]) {
+            // Not loaded or (loaded and used)
+            return kFALSE;
+         }
+      }
+      return kTRUE;
+   }
+
+   // Return true if ....
+   void GetUnused(std::vector<Int_t> unused)
+   {
+      unused.clear();
+      auto len = fInfo.GetNbits() / kSize + 1;
+      for(UInt_t b = 0; b  < len ; ++b) {
+         if (fInfo[kSize*b + kVetoed]) {
+            unused.push_back(fBasketPedestal + b);
+         }
+      }
+   }
+
+   // Reset all info.
+   void Reset()
+   {
+      fBasketPedestal = -1;
+      fInfo.ResetAllBits();
+   }
+
+   // Print the infor we have for the baskets.
+   void Print(const char *owner, Long64_t *entries) const {
+      if (!owner || !entries)
+         return;
+      auto len = fInfo.GetNbits() / kSize + 1;
+      if (fBasketPedestal>=0) for(UInt_t b = 0; b  < len ; ++b) {
+         Printf("Branch %s : basket %d loaded=%d used=%d start entry=%lld",
+                owner, b+fBasketPedestal,
+                (bool)fInfo[kSize*b+kLoaded], (bool)fInfo[kSize*b+kUsed],
+                entries[fBasketPedestal + b]);
+      }
+   }
+};
+
+} // Internal
+} // ROOT
+
+#endif // ROOT_TBranchCacheInfo

--- a/tree/tree/inc/TTreeCache.h
+++ b/tree/tree/inc/TTreeCache.h
@@ -42,6 +42,8 @@ protected:
    Long64_t     fEntryMax{1};         ///<! last entry in the cache
    Long64_t     fEntryCurrent{-1};    ///<! current lowest entry number in the cache
    Long64_t     fEntryNext{-1};       ///<! next entry number where cache must be filled
+   Long64_t     fCurrentClusterStart{-1}; ///<! Start of the cluster(s) where the current content was picked out
+   Long64_t     fNextClusterStart{-1};   ///<! End+1 of the cluster(s) where the current content was picked out
    Int_t        fNbranches{0};        ///<! Number of branches in the cache
    Int_t        fNReadOk{0};          ///<  Number of blocks read and found in the cache
    Int_t        fNMissReadOk{0};      ///<  Number of blocks read, not found in the primary cache, and found in the secondary cache.

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -39,6 +39,7 @@
 #include "TTreeCacheUnzip.h"
 #include "TVirtualMutex.h"
 #include "TVirtualPad.h"
+#include "TVirtualPerfStats.h"
 
 #include "TBranchIMTHelper.h"
 
@@ -1234,6 +1235,11 @@ TBasket* TBranch::GetBasket(Int_t basketnumber)
    }
 
    ++fNBaskets;
+
+   auto perfStats = GetTree()->GetPerfStats();
+   if (perfStats)
+      perfStats->SetUsed(this, basketnumber);
+
    fBaskets.AddAt(basket,basketnumber);
    return basket;
 }

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -9,6 +9,9 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+
+#include "TBranchCacheInfo.h"
+
 #include "TBranch.h"
 
 #include "Compression.h"
@@ -1236,6 +1239,7 @@ TBasket* TBranch::GetBasket(Int_t basketnumber)
 
    ++fNBaskets;
 
+   fCacheInfo.SetUsed(basketnumber);
    auto perfStats = GetTree()->GetPerfStats();
    if (perfStats)
       perfStats->SetUsed(this, basketnumber);
@@ -2009,6 +2013,14 @@ void TBranch::Print(Option_t *option) const
    Printf("*............................................................................*");
    delete [] bline;
    fgCount++;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Print the information we have about which basket is currently cached and
+/// whether they have been 'used'/'read' from the cache.
+
+void TBranch::PrintCacheInfo() const {
+   fCacheInfo.Print(GetName(), fBasketEntry);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/tree/src/TTreeCache.cxx
+++ b/tree/tree/src/TTreeCache.cxx
@@ -1015,8 +1015,12 @@ Bool_t TTreeCache::FillBuffer()
       prevNtot = fNtotCurrentBuf;
       Int_t nextMinBasket = INT_MAX;
       UInt_t pass = 0;
-      while (pass < 2) {
-         // The first pass we add one basket per branches.
+
+      auto CollectBaskets = [this, elist, chainOffset, entry, clusterIterations, resetBranchInfo,
+       &lowestMaxEntry, &maxReadEntry, &nextMinBasket, &minBasket, &minEntry,
+       &ranges, &memRanges, &reqRanges,
+       &fNtotCurrentBuf, &nReadPrefRequest](UInt_t pass, Bool_t narrow) {
+        // The first pass we add one basket per branches around the requested entry
          // then in the second pass we add the other baskets of the cluster.
          // This is to support the case where the cache is too small to hold a full cluster.
          ++pass;
@@ -1129,7 +1133,13 @@ Bool_t TTreeCache::FillBuffer()
             if (j < nextMinBasket) nextMinBasket = j;
             if (gDebug > 0) printf("Entry: %lld, registering baskets branch %s, fEntryNext=%lld, fNseek=%d, fNtotCurrentBuf=%d\n",minEntry,((TBranch*)fBranches->UncheckedAt(i))->GetName(),fEntryNext,fNseek,fNtotCurrentBuf);
          }
-      } // loop for the 2 passes.
+      };
+
+      ++pass;
+      CollectBaskets(pass, narrow);
+      ++pass;
+      CollectBaskets(pass, narrow);
+
       clusterIterations++;
 
       minEntry = clusterIter.Next();

--- a/tree/tree/src/TTreeCache.cxx
+++ b/tree/tree/src/TTreeCache.cxx
@@ -1110,7 +1110,7 @@ Bool_t TTreeCache::FillBuffer()
    if (fEntryCurrent <= entry && entry < fEntryNext) return kFALSE;
 
    // Triggered by the user, not the learning phase
-   if (entry == -1)  entry = 0;
+   if (entry == -1) entry = 0;
 
    Bool_t resetBranchInfo = kFALSE;
    if (entry < fCurrentClusterStart || fNextClusterStart <= entry) {
@@ -1241,7 +1241,7 @@ Bool_t TTreeCache::FillBuffer()
             Info("CollectBaskets", "Called with pass=%d narrow=%d maxCollectEntry=%lld", pass, narrow, maxCollectEntry);
 
          Bool_t filled = kFALSE;
-         for (Int_t i=0;i<fNbranches;i++) {
+         for (Int_t i = 0; i < fNbranches; ++i) {
             TBranch *b = (TBranch*)fBranches->UncheckedAt(i);
             if (b->GetDirectory()==0) continue;
             if (b->GetDirectory()->GetFile() != fFile) continue;
@@ -1539,10 +1539,10 @@ Bool_t TTreeCache::FillBuffer()
       }
 
       //for the reverse reading case
-      if (!fIsLearning && fReverseRead){
+      if (!fIsLearning && fReverseRead) {
          if (clusterIterations >= fFillTimes)
             break;
-         if (minEntry >= fEntryCurrentMax && fEntryCurrentMax >0)
+         if (minEntry >= fEntryCurrentMax && fEntryCurrentMax > 0)
             break;
       }
       fEntryNext = clusterIter.GetNextEntry();
@@ -1794,7 +1794,8 @@ Int_t TTreeCache::ReadBufferNormal(char *buf, Long64_t pos, Int_t len){
 /// even if the cache lookup succeeds, because it will try to prefetch the next block
 /// as soon as we start reading from the current block.
 
-Int_t TTreeCache::ReadBufferPrefetch(char *buf, Long64_t pos, Int_t len){
+Int_t TTreeCache::ReadBufferPrefetch(char *buf, Long64_t pos, Int_t len)
+{
    if (TFileCacheRead::ReadBuffer(buf, pos, len) == 1){
       //call FillBuffer to prefetch next block if necessary
       //(if we are currently reading from the last block available)

--- a/tree/tree/src/TTreeCache.cxx
+++ b/tree/tree/src/TTreeCache.cxx
@@ -1083,7 +1083,7 @@ Bool_t TTreeCache::FillBuffer()
    if (showMore || gDebug > 6)
       Info("FillBuffer","***** Called for entry %lld", entry);
 
-   if (fEntryCurrent <= entry && entry < fEntryNext) {
+   if (!fIsLearning && fEntryCurrent <= entry && entry < fEntryNext) {
       // Check if all the basket in the cache have already be used and
       // thus we can reuse the cache.
       Bool_t allUsed = kTRUE;

--- a/tree/tree/src/TTreeCache.cxx
+++ b/tree/tree/src/TTreeCache.cxx
@@ -1071,7 +1071,7 @@ Bool_t TTreeCache::FillBuffer()
 
    // Set to true to enable all debug output without having to set gDebug
    // Replace this once we have a per module and/or per class debuging level/setting.
-   constexpr bool showMore = kFALSE;
+   static constexpr bool showMore = kFALSE;
 
    static const auto PrintAllCacheInfo = [this]() {
       for (Int_t i=0;i<fNbranches;i++) {

--- a/tree/treeplayer/inc/TTreePerfStats.h
+++ b/tree/treeplayer/inc/TTreePerfStats.h
@@ -23,6 +23,7 @@
 
 #include "TVirtualPerfStats.h"
 #include "TString.h"
+#include <vector>
 
 
 class TBrowser;
@@ -34,6 +35,14 @@ class TGraphErrors;
 class TGaxis;
 class TText;
 class TTreePerfStats : public TVirtualPerfStats {
+
+public:
+   struct BasketInfo {
+      UInt_t fUsed = {0};       // Number of times the basket was requested from the disk.
+      UInt_t fLoaded = {0};     // Number of times the basket was put in the primary TTreeCache
+      UInt_t fLoadedMiss = {0}; // Number of times the basket was put in the secondary cache
+      UInt_t fMissed = {0};     // Number of times the basket was read directly from the file.
+   };
 
 protected:
    Int_t         fTreeCacheSize; //TTreeCache buffer size
@@ -58,6 +67,11 @@ protected:
    TStopwatch   *fWatch;         //TStopwatch pointer
    TGaxis       *fRealTimeAxis;  //pointer to TGaxis object showing real-time
    TText        *fHostInfoText;  //Graphics Text object with the fHostInfo data
+
+
+   std::vector<std::vector<BasketInfo> > fBasketsInfo; // Details on which baskets was used, cached, 'miss-cached' or read uncached.Browse
+
+   BasketInfo& GetBasketInfo(TBranch *b, size_t basketNumber);
 
 public:
    TTreePerfStats();
@@ -117,7 +131,13 @@ public:
    virtual void     SetTreeCacheSize(Int_t nbytes) {fTreeCacheSize = nbytes;}
    virtual void     SetUnzipTime(Double_t uztime) {fUnzipTime = uztime;}
 
-   ClassDef(TTreePerfStats,6)  // TTree I/O performance measurement
+   virtual void     PrintBasketInfo(Option_t * option = "") const;
+   virtual void     SetLoaded(TBranch *b, size_t basketNumber) { ++GetBasketInfo(b, basketNumber).fLoaded; }
+   virtual void     SetLoadedMiss(TBranch *b, size_t basketNumber) { ++GetBasketInfo(b, basketNumber).fLoadedMiss; }
+   virtual void     SetMissed(TBranch *b, size_t basketNumber) { ++GetBasketInfo(b, basketNumber).fMissed; }
+   virtual void     SetUsed(TBranch *b, size_t basketNumber) { ++GetBasketInfo(b, basketNumber).fUsed; }
+
+   ClassDef(TTreePerfStats,7)  // TTree I/O performance measurement
 };
 
 #endif

--- a/tree/treeplayer/src/TTreePerfStats.cxx
+++ b/tree/treeplayer/src/TTreePerfStats.cxx
@@ -85,6 +85,7 @@ The Physical disk speed is DiskIO + DiskIO*ReadExtra/100.
 #include "Riostream.h"
 #include "TFile.h"
 #include "TTree.h"
+#include "TTreeCache.h"
 #include "TAxis.h"
 #include "TBrowser.h"
 #include "TVirtualPad.h"
@@ -338,6 +339,41 @@ void TTreePerfStats::Finish()
    }
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Return the BasketInfo corresponding to the given branch and basket.
+
+TTreePerfStats::BasketInfo &TTreePerfStats::GetBasketInfo(TBranch *br, size_t basketNumber)
+{
+   static BasketInfo fallback;
+
+   // First find the branch index.
+   TFile *file = fTree->GetCurrentFile();
+   if (!file)
+      return fallback;
+
+  TTreeCache *cache = dynamic_cast<TTreeCache*>(file->GetCacheRead(fTree));
+  if (!cache)
+     return fallback;
+
+  auto branches = cache->GetCachedBranches();
+  Int_t index = -1;
+  for(Int_t i = 0; i < branches->GetEntries(); ++i) {
+    if (br == branches->UncheckedAt(i)) {
+       index = i;
+       break;
+    }
+  }
+  if (index < 0)
+     return fallback;
+  if (fBasketsInfo.size() <= (size_t)index)
+     fBasketsInfo.resize(index+1);
+
+  auto &brvec(fBasketsInfo[index]);
+  if (brvec.size() <= basketNumber)
+    brvec.resize(basketNumber+1);
+
+  return brvec[basketNumber];
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Draw the TTree I/O perf graph.
@@ -429,6 +465,7 @@ void TTreePerfStats::Print(Option_t * option) const
    TString opts(option);
    opts.ToLower();
    Bool_t unzip = opts.Contains("unzip");
+   Bool_t basket = opts.Contains("basket");
    TTreePerfStats *ps = (TTreePerfStats*)this;
    ps->Finish();
 
@@ -457,7 +494,74 @@ void TTreePerfStats::Print(Option_t * option) const
       printf("ReadStrCP = %7.3f MBytes/s\n",1e-6*fCompress*fBytesRead/(fCpuTime-fUnzipTime));
       printf("ReadZipCP = %7.3f MBytes/s\n",1e-6*fCompress*fBytesRead/fUnzipTime);
    }
+   if (basket)
+      PrintBasketInfo(option);
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Print the TTree basket information
+
+void TTreePerfStats::PrintBasketInfo(Option_t * option) const {
+
+   TString opts(option);
+   opts.ToLower();
+   Bool_t all = opts.Contains("allbasketinfo");
+
+   TFile *file = fTree->GetCurrentFile();
+   if (!file)
+      return;
+
+   TTreeCache *cache = dynamic_cast<TTreeCache*>(file->GetCacheRead(fTree));
+   if (!cache)
+      return;
+
+   auto branches = cache->GetCachedBranches();
+   for(size_t i = 0; i < fBasketsInfo.size(); ++i) {
+      const char *branchname = branches->At(i)->GetName();
+
+      printf("  br=%ld %s read not cached: ", i, branchname);
+      if (fBasketsInfo[i].size() == 0) {
+         printf("none");
+      } else for(size_t j = 0; j < fBasketsInfo[i].size(); ++j) {
+         if (fBasketsInfo[i][j].fMissed) printf("%ld ", j);
+      }
+      printf("\n");
+
+      printf("  br=%ld %s cached more than once: ", i, branchname);
+      for(size_t j = 0; j < fBasketsInfo[i].size(); ++j) {
+         auto &info( fBasketsInfo[i][j] );
+         if ((info.fLoaded + info.fLoadedMiss) > 1)
+            printf("%ld[%d,%d] ", j, info.fLoaded, info.fLoadedMiss);
+      }
+      printf("\n");
+
+      printf("  br=%ld %s cached but not used: ", i, branchname);
+      for(size_t j = 0; j < fBasketsInfo[i].size(); ++j) {
+         auto &info( fBasketsInfo[i][j] );
+         if ( (info.fLoaded + info.fLoadedMiss) && !info.fUsed) {
+            if (info.fLoadedMiss)
+               printf("%ld[%d,%d] ", j, info.fLoaded, info.fLoadedMiss);
+            else
+               printf("%ld ", j);
+         }
+      }
+      printf("\n");
+
+      if (all) {
+         printf("  br=%ld %s: ", i, branchname);
+         for(size_t j = 0; j < fBasketsInfo[i].size(); ++j) {
+            auto &info( fBasketsInfo[i][j] );
+            printf("%ld[%d,%d,%d,%d] ", j, info.fUsed, info.fLoaded, info.fLoadedMiss, info.fMissed);
+         }
+         printf("\n");
+      }
+   }
+   for(Int_t i = fBasketsInfo.size(); i < branches->GetEntries(); ++i) {
+      printf("  br=%d %s: no basket information\n", i, branches->At(i)->GetName());
+   }
+
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Save this object to filename


### PR DESCRIPTION
Significant revamp of FillBuffer.

The new scheme insures a much more stable and efficient behavior in case of low
memory given by the user compared to the size of the buffer or 'odd' basket
layout.

The basket collection is now done in 4 phases:

1. One basket per branch, basket must contains the request entry and is not yet loaded or used,
2. Even out by adding baskets so that all branches reach the same entry (or close)
3. Add the remaining branches from the current cluster.
4. Add the basket from the begining of the clsuter to the current entry (if any)

then repeat the 4 steps for the next cluster.

The iteration is stopped as soon as the cache is 'full' as defined by these
rules:

 - During step 1 of the first cluster, continue up to 4 times the user requested
   cache size
 - During steps 2 to 4 of the first cluster, continue up to 2 times the user
   requested cache sizep
 - During steps 2 to 4, the 'first' basket of a branch is accepted up to 4 times
   the user requested cache size (i.e as if it had been selected during the 1st
   step)
 - During the other clusters, continue up to the user requested cache size

A basket if rejected/skipped if its individual size is larger than the user
requested cache size


In addition, upon seeing a cache miss, FillBuffer now detects if all the basket
in the cache have already been used (read from the cache) in which case we can\
discard them and load the next set of baskets.

As a side effect, we now keep a record of which baskets are in the cache and
which of those baskets have been used.  The TTreePerfStats now keep a complete
log of all the basket that are:
   - loaded in the main cache (and how many times)
   - loaded in the 'misss' cache (and how many times)
   - used
   - read directly (complete cache miss)
This will be helpful in understanding situation of over-read or slow operations.


