### PR TITLE
http: try to avoid civetweb warnings on clang/mac

### DIFF
--- a/net/http/civetweb/civetweb.c
+++ b/net/http/civetweb/civetweb.c
@@ -28,7 +28,7 @@
 #define _WIN32_WINNT 0x0501
 #endif
 #else
-#if defined(__GNUC__) && !defined(_GNU_SOURCE)
+#if !defined(_GNU_SOURCE)
 #define _GNU_SOURCE /* for setgroups(), pthread_setname_np() */
 #endif
 #if defined(__linux__) && !defined(_XOPEN_SOURCE)


### PR DESCRIPTION
One should always enable _GNU_SOURCE to use extra functionality from
glibc