### PR TITLE
[TMVA] ROOT-9194 -- Sporadic timeouts for TMVARegression

### DIFF
--- a/tutorials/tmva/TMVARegression.C
+++ b/tutorials/tmva/TMVARegression.C
@@ -76,10 +76,10 @@ void TMVARegression( TString myMethodList = "" )
    Use["LD"]		        = 1;
    //
    // Function Discriminant analysis
-   Use["FDA_GA"]          = 1;
-   Use["FDA_MC"]          = 0;
-   Use["FDA_MT"]          = 0;
-   Use["FDA_GAMT"]        = 0;
+   Use["FDA_GA"] = 0;
+   Use["FDA_MC"] = 0;
+   Use["FDA_MT"] = 1;
+   Use["FDA_GAMT"] = 0;
    //
    // Neural Network
    Use["MLP"]             = 1;


### PR DESCRIPTION
Sometimes the genetic optimiser of the functional discriminant analysis
method takes a long time to complete. The TMVA manual suggest that the
first FitMethod to try should be "Minuit", not "GA". (GA stands for
genetic algorithm in this case).

This commit disables FDA_GA and enables FDA_MT in as default methods in
the tutorial TMVARegression.C.