### PR TITLE
I/O of TTreePlayer

### DIFF
--- a/math/vecops/inc/LinkDef.h
+++ b/math/vecops/inc/LinkDef.h
@@ -7,7 +7,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#ifdef __ROOTCLING__
+#ifdef __CINT__
 
 #pragma link C++ class ROOT::Experimental::VecOps::TVec<float>-;
 #pragma link C++ class ROOT::Experimental::VecOps::TVec<double>-;

--- a/tree/dataframe/inc/LinkDef.h
+++ b/tree/dataframe/inc/LinkDef.h
@@ -8,7 +8,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#ifdef __ROOTCLING__
+#ifdef __CINT__
 
 #pragma link C++ nestedtypedefs;
 #pragma link C++ nestedclasses;

--- a/tree/treeplayer/inc/LinkDef.h
+++ b/tree/treeplayer/inc/LinkDef.h
@@ -8,7 +8,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#ifdef __ROOTCLING__
+#ifdef __CINT__
 
 #pragma link C++ nestedtypedefs;
 #pragma link C++ nestedclasses;


### PR DESCRIPTION
    Revert "Use preprocessor macro __ROOTCLING__ instead of __CINT__ in linkdef"
    
    This reverts commit 915d488afd46a8e8199484ab77861bb47d8bac09.
    
    The replacement prevented the recording of the data member documentation
    strings for the content of the library and thus was breaking the I/O, in
    particular transientness, for thoses classes, eg TTreePerfStats.
    (See below for an example).
    
    This seems to be due to the fact that we need/must not add __ROOTCLING__
    during the parsing that will be recorded in the the pch, see in
    core/dictgen/src/rootcling_impl.cxx line 4334:
    
        // We do not want __ROOTCLING__ in the pch!
        if (!onepcm) {
           clingArgs.push_back("-D__ROOTCLING__");
    
    So, at least for now, we need to keep using __CINT__ for the LinkDef.h
    of the libraries included in the PCH.
    
    See:
    
    root [0] TClass::GetClass("TTreePerfStats")->GetStreamerInfo()->ls()
    
    StreamerInfo for class: TTreePerfStats, version=7, checksum=0x1f86d003
      TVirtualPerfStats BASE            offset=  0 type= 0 ABC for collecting PROOF statistics
      int            fTreeCacheSize  offset= 16 type= 3 TTreeCache buffer size
      int            fNleaves        offset= 20 type= 3 Number of leaves in the tree
    
    vs
    
    root [0] TClass::GetClass("TTreePerfStats")->GetStreamerInfo()->ls()
    
    StreamerInfo for class: TTreePerfStats, version=6, checksum=0x84181ab4
      TVirtualPerfStats BASE            offset=  0 type= 0 ABC for collecting PROOF statistics
      int            fTreeCacheSize  offset= 16 type= 3
      int            fNleaves        offset= 20 type= 3
