### PR TITLE
Patch from Vassil! Add the cwg to the prebuilt module cache path.

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -1083,6 +1083,7 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
       auto& HS = CI->getHeaderSearchOpts();
       addPrebuiltModulePaths(HS, getPathsFromEnv(getenv("LD_LIBRARY_PATH")));
       addPrebuiltModulePaths(HS, getPathsFromEnv(getenv("DYLD_LIBRARY_PATH")));
+      HS.AddPrebuiltModulePath(".");
     }
 
     // Set up compiler language and target


### PR DESCRIPTION
Some modules (produced by rootcling) are located in the cwg and they
should be resolved from there without being rebuilt.