### PR TITLE
Add TChain::SetName.

### DIFF
--- a/tree/tree/inc/TChain.h
+++ b/tree/tree/inc/TChain.h
@@ -158,6 +158,7 @@ public:
    virtual void      SetEntryListFile(const char *filename="", Option_t *opt="");
    virtual void      SetEventList(TEventList *evlist);
    virtual void      SetMakeClass(Int_t make) { TTree::SetMakeClass(make); if (fTree) fTree->SetMakeClass(make);}
+   virtual void      SetName(const char *name);
    virtual void      SetPacketSize(Int_t size = 100);
    virtual void      SetProof(Bool_t on = kTRUE, Bool_t refresh = kFALSE, Bool_t gettreeheader = kFALSE);
    virtual void      SetWeight(Double_t w=1, Option_t *option="");

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -2729,6 +2729,29 @@ void TChain::SetEventList(TEventList *evlist)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Change the name of this TChain.
+
+void TChain::SetName(const char* name)
+{
+   {
+      // Should this be extended to include the call to TTree::SetName?
+      R__WRITE_LOCKGUARD(ROOT::gCoreMutex); // Take the lock once rather than 3 times.
+      gROOT->GetListOfCleanups()->Remove(this);
+      gROOT->GetListOfSpecials()->Remove(this);
+      gROOT->GetListOfDataSets()->Remove(this);
+   }
+   TTree::SetName(name);
+   {
+      // Should this be extended to include the call to TTree::SetName?
+      R__WRITE_LOCKGUARD(ROOT::gCoreMutex); // Take the lock once rather than 3 times.
+      gROOT->GetListOfCleanups()->Add(this);
+      gROOT->GetListOfSpecials()->Add(this);
+      gROOT->GetListOfDataSets()->Add(this);
+   }
+
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Set number of entries per packet for parallel root.
 
 void TChain::SetPacketSize(Int_t size)


### PR DESCRIPTION
Allows renaming a TChain, without this the registration in the list of specials,
list of cleanups and list of datasets are corrupted