### PR TITLE
[cxxmodules] Fix a compile error

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1260,7 +1260,7 @@ TCling::TCling(const char *name, const char *title)
 
       LoadModules({"ROOT_Foundation_C", "ROOT_Config", "ROOT_Foundation_Stage1_NoRTTI", "Core", "RIO"}, *fInterpreter);
       if (!fromRootCling)
-         LoadModules({"TreePlayer", "VecOps"}, *fInterpreter);
+         LoadModules({"TreePlayer", "ROOTVecOps"}, *fInterpreter);
 
       // Check that the gROOT macro was exported by any core module.
       assert(fInterpreter->getMacro("gROOT") && "Couldn't load gROOT macro?");


### PR DESCRIPTION
"VecOps" was hardcoded in TCling.cxx and VecOps were renamed to
"ROOTVecOps" afterwards.