### PR TITLE
Include Vc without going through VecCore in testGenvectorVc

### DIFF
--- a/test/testGenVectorVc.cxx
+++ b/test/testGenVectorVc.cxx
@@ -1,10 +1,15 @@
 // ROOT
-#include "Math/Types.h"
 #include "Math/GenVector/PositionVector3D.h"
 #include "Math/GenVector/DisplacementVector3D.h"
 #include "Math/GenVector/Plane3D.h"
 #include "Math/GenVector/Transform3D.h"
 #include "TStopwatch.h"
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wall"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#include <Vc/Vc>
+#pragma GCC diagnostic pop
 
 // STL
 #include <random>


### PR DESCRIPTION
We uncovered this bug from the changes in fail-on-missing behavior. The test uses only Vc, and uses it directly:

```
root/test/testGenVectorVc.cxx:67:30: error: ‘Vc’ was not declared in this scope
     typedef std::vector<Data, Vc::Allocator<Data>> Vector;
                              ^
```