### PR TITLE
[cxxmodules] Temporary excluding tests for cxxmodules build bot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,6 +353,7 @@ endif()
 if(runtime_cxxmodules)
   # Dummy target that does nothing, we don't need a PCH for modules.
   add_custom_target(onepcm)
+  set(FIXME_TEMPORARILY_EXCLUDED_FOR_RUNTIME_CXXMODULES On)
 else()
   add_custom_command(OUTPUT etc/allDict.cxx.pch
                     COMMAND ${CMAKE_COMMAND} -E env ROOTIGNOREPREFIX=1 ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/etc/dictpch/makepch.py etc/allDict.cxx.pch ${__allIncludes} -I${CMAKE_BINARY_DIR}/include

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -246,6 +246,8 @@ ROOT_ADD_TEST(test-stressiterators-interpreted COMMAND ${ROOT_root_CMD} -b -q -l
               FAILREGEX "FAILED|Error in" DEPENDS test-stressiterators)
 
 #--stressInterpreter-------------------------------------------------------------------------
+# FIXME: Temporary workaround for runtime_cxxmodule
+if(NOT FIXME_TEMPORARILY_EXCLUDED_FOR_RUNTIME_CXXMODULES)
 ROOT_EXECUTABLE(stressInterpreter stressInterpreter.cxx LIBRARIES Core)
 if(WIN32)
   set(cleantmpfiles POSTCMD cmd /c del AutoDict_*)
@@ -255,6 +257,7 @@ ROOT_ADD_TEST(test-stressinterpreter COMMAND stressInterpreter
                                               $<TARGET_FILE_DIR:stressInterpreter>/stressInterpreter.cxx
               ${cleantmpfiles}
               FAILREGEX Error|FAILED)
+endif()
 
 #--stressHepix-------------------------------------------------------------------------------
 ROOT_EXECUTABLE(stressHepix stressHepix.cxx LIBRARIES Core)

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -65,6 +65,19 @@ if(NOT ROOT_minuit2_FOUND)
                    tutorials/roostats/rs_bernsteinCorrection.C)
 endif()
 
+# FIXME: Temporary workaround for runtime_cxxmodule
+if(FIXME_TEMPORARILY_EXCLUDED_FOR_RUNTIME_CXXMODULES)
+  set(runtime_cxxmodules_veto dataframe/tdf013_InspectAnalysis.C
+                              fit/fithist.C
+                              graphics/markerwarning.C
+                              math/quasirandom.C
+                              multicore/mp103_processSelector.C
+                              pythia/pythia8.C
+                              roostats/Zbi_Zgamma.C
+                              roostats/rs_numbercountingutils.C
+                              r/DataFrame.C)
+endif()
+
 if(NOT ROOT_roofit_FOUND)
   set(roofit_veto  fit/RoofitDemo.C
                    roofit/*.C roostats/*.C histfactory/*.C)
@@ -221,6 +234,7 @@ set(all_veto hsimple.C
              ${extra_veto}
              ${gui_veto}
              ${minuit2_veto}
+             ${runtime_cxxmodules_veto}
              ${roofit_veto}
              ${unuran_veto}
              ${xml_veto}
@@ -393,6 +407,12 @@ if(ROOT_python_FOUND)
   if(ROOT_CLASSIC_BUILD)
     set(classic_veto_py dataframe/tdf*.py)
     list(REMOVE_ITEM pytutorials ${classic_veto_py})
+  endif()
+
+  if(FIXME_TEMPORARILY_EXCLUDED_FOR_RUNTIME_CXXMODULES)
+    set(runtime_cxxmodules_veto_py dataframe/tdf002_dataModel.py
+                                   math/tStudent.py)
+    list(REMOVE_ITEM pytutorials ${runtime_cxxmodules_veto_py})
   endif()
 
   #---Python tutorials dependencies--------------------------------------


### PR DESCRIPTION
This excludes tests which are failing in runtime modules nightly builds.
We want to add runtime modules bot to incrementals and PRs so that
people can fix their bugs before commiting.