### PR TITLE
Add --pedantic flag: no using namespace, no auto-#includes etc.

### DIFF
--- a/core/base/inc/CommandLineOptionsHelp.h
+++ b/core/base/inc/CommandLineOptionsHelp.h
@@ -67,7 +67,8 @@ Options:
   -l : do not show splash screen
   -t : enable thread-safety and implicit multi-threading (IMT)
  --web: display graphics in a web browser
- --notebook : execute ROOT notebook
+ --notebook: execute ROOT notebook
+ --strict-prompt: disable implicit `using namespace std`, auto-includes etc.
  dir : if dir is a valid directory cd to it before executing
 
   -?      : print usage

--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -372,6 +372,7 @@ void TApplication::GetOptions(Int_t *argc, char **argv)
    fNoLog = kFALSE;
    fQuit  = kFALSE;
    fFiles = 0;
+   bool strictPromptMode = false;
 
    if (!argc)
       return;
@@ -430,6 +431,10 @@ void TApplication::GetOptions(Int_t *argc, char **argv)
             if (gROOT->IsBatch()) opt.Prepend("batch");
             gROOT->SetWebDisplay(opt.Data());
          }
+      } else if (!strcmp(argv[i], "--strict-prompt")) {
+         // disable usability extensions.
+         argv[i] = null;
+         strictPromptMode = true;
       } else if (!strcmp(argv[i], "-e")) {
          argv[i] = null;
          ++i;
@@ -566,6 +571,9 @@ void TApplication::GetOptions(Int_t *argc, char **argv)
    // go back to startup directory
    if (pwd != "")
       gSystem->ChangeDirectory(pwd);
+
+   if (!strictPromptMode)
+      gInterpreter->EnablePromptUsabilityImprovements();
 
    // remove handled arguments from argument array
    j = 0;

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -4491,7 +4491,7 @@ int RootClingMain(int argc,
          ROOT::TMetaUtils::Error(0, "Error loading the default header files.\n");
          return 1;
       }
-   } else {
+   } else if (!onepcm) {
       // rootcling
       if (interp.declare("namespace std {} using namespace std;") != cling::Interpreter::kSuccess
             // CINT uses to define a few header implicitly, we need to do it explicitly.

--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -134,6 +134,7 @@ public:
    virtual void     ClearStack() = 0; // Delete existing temporary values
    virtual Bool_t   Declare(const char* code) = 0;
    virtual void     EnableAutoLoading() = 0;
+   virtual void     EnablePromptUsabilityImprovements() = 0;
    virtual void     EndOfLineAction() = 0;
    virtual TClass  *GetClass(const std::type_info& typeinfo, Bool_t load) const = 0;
    virtual Int_t    GetExitCode() const = 0;

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1283,14 +1283,12 @@ TCling::TCling(const char *name, const char *title)
                             "using std::string;\n"
                             "#include <cassert>\n");
    } else {
-      fInterpreter->declare("#include \"Rtypes.h\"\n"
-                            + gClassDefInterpMacro + "\n"
-                            + gInterpreterClassDef + "\n"
-                            "#undef ClassImp\n"
-                            "#define ClassImp(X);\n"
-                            "#include <string>\n"
-                            "using namespace std;\n"
-                            "#include <cassert>\n");
+      std::string preamble = "#include \"Rtypes.h\"\n"
+                              + gClassDefInterpMacro + "\n"
+                              + gInterpreterClassDef + "\n"
+                              "#undef ClassImp\n"
+                              "#define ClassImp(X);\n";
+      fInterpreter->declare(preamble);
    }
 
    // We are now ready (enough is loaded) to init the list of opaque typedefs.
@@ -1366,6 +1364,17 @@ void TCling::Initialize()
 {
    fClingCallbacks->Initialize();
 }
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Enable prompt usability improvements: `using namespace std` etc.
+void TCling::EnablePromptUsabilityImprovements()
+{
+   fInterpreter->declare("#include <string>\n"
+                         "using namespace std;\n"
+                         "#include <cassert>\n");
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Wrapper around dladdr (and friends)

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -181,6 +181,7 @@ public: // Public Interface
    void    ClearStack(); // Delete existing temporary values
    Bool_t  Declare(const char* code);
    void    EnableAutoLoading();
+   void    EnablePromptUsabilityImprovements();
    void    EndOfLineAction();
    TClass *GetClass(const std::type_info& typeinfo, Bool_t load) const;
    Int_t   GetExitCode() const { return fExitCode; }


### PR DESCRIPTION
E.g. useful for testing whether we have a "using namespace std" in our headers!