### PR TITLE
Builtin GSL Fix, master branch (2018.05.09.)

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -430,7 +430,7 @@ if(mathmore OR builtin_gsl)
       INSTALL_DIR ${CMAKE_BINARY_DIR}
       CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix <INSTALL_DIR>
                         --libdir=<INSTALL_DIR>/lib
-                        --enable-shared=no
+                        --enable-shared=no --with-pic
                         CC=${CMAKE_C_COMPILER} CFLAGS=${CMAKE_C_FLAGS}
       LOG_DOWNLOAD 1 LOG_CONFIGURE 1 LOG_BUILD 1 LOG_INSTALL 1
       BUILD_BYPRODUCTS ${GSL_LIBRARIES}


### PR DESCRIPTION
Made it explicit that the builtin GSL build should use `-fPIC`. Without it the build, at least on SLC6 with GCC 6.2 would fail to link against the generated GSL library, with messages like:

```
[100%] Linking CXX shared library ../../lib/libMathMore.so
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(blas.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(deriv.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(eval.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lt1-init.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(integ.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(error.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(stream.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(strerror.o): relocation R_X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(qag.o): relocation R_X86_64_32S against symbol `gsl_integration_qk15' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(qagp.o): relocation R_X86_64_32S against symbol `gsl_integration_qk21' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(qags.o): relocation R_X86_64_32 against symbol `gsl_integration_qk21' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(qawc.o): relocation R_X86_64_32S against `.text' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(qk15.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(qk21.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(qk31.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(qk41.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(qk51.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(qk61.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(qng.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(workspace.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(accel.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(akima.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(cspline.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(poly.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(spline.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(tridiag.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lt10-init.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(brent.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(convergence.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(fsolver.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(golden.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(miser.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(plain.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(vegas.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lt12-convergence.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(covar.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(fdfsolver.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lmder.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(conjugate_fr.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(conjugate_pr.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lt14-convergence.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(fdfminimizer.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(steepest_descent.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(vector_bfgs.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(vector_bfgs2.o): relocation R_X86_64_32S against `.text' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(broyden.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lt16-convergence.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(dnewton.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lt17-fdfsolver.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lt18-fdjac.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lt19-fsolver.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(gnewton.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(hybrid.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(hybridj.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(newton.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lt34-init.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lt35-inline.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(permute.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(zsolve.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(zsolve_init.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(niederreiter-2.o): relocation R_X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(qrng.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(sobol.o): relocation R_X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(gausszig.o): relocation R_X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(landau.o): relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(default.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lt47-inline.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(ranlxd.o): relocation R_X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(ranlxs.o): relocation R_X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(rng.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(types.o): relocation R_X86_64_32S against undefined symbol `gsl_rng_generator_types' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(bisection.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lt48-brent.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lt49-convergence.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(falsepos.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lt50-fdfsolver.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lt51-fsolver.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lt52-newton.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(secant.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(steffenson.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(siman.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(airy.o): relocation R_X86_64_32 against `.data' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(airy_der.o): relocation R_X86_64_32 against `.data' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(airy_zero.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(bessel_Inu.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(bessel_Jnu.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(bessel_Knu.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(bessel_Ynu.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(bessel_j.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(bessel_olver.o): relocation R_X86_64_32 against `.data' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(bessel_temme.o): relocation R_X86_64_32 against `.data' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(bessel_y.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(coupling.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(ellint.o): relocation R_X86_64_32S against symbol `gsl_prec_eps' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(erfc.o): relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(exp.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(expint.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lt55-gamma.o): relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(gamma_inc.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(hyperg_0F1.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(hyperg_1F1.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(hyperg_2F1.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(hyperg_U.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(laguerre.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(legendre_poly.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(log.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(poch.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(pow_int.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(psi.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(trig.o): relocation R_X86_64_32 against `.data' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(zeta.o): relocation R_X86_64_32 against `.data' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lt60-copy.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lt62-init.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lt64-oper.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lt65-prop.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(vector.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lt67-view.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(gammainv.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(tdistinv.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(init.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(interp.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lu.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(qr.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(qrpt.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lt8-copy.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(matrix.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(rowcol.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(submatrix.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(swap.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(permutation.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(ran0.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(tt.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(bessel.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(bessel_I1.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(bessel_In.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(bessel_J0.o): relocation R_X86_64_32 against `.data' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(bessel_J1.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(bessel_Jn.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(bessel_K0.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lt54-beta.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(elementary.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lt56-hyperg.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(subvector.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(lt66-swap.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgsl.a(bessel_I0.o): relocation R_X86_64_32 against `.data' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(sgemm.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(sgemv.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(sger.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(srotm.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(ssymm.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(ssymv.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(ssyr.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(ssyr2.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(ssyr2k.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(ssyrk.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(strmm.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(strmv.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(strsm.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(strsv.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(dgemm.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(dgemv.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(dger.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(drotm.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(dsymm.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(dsymv.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(dsyr.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(dsyr2.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(dsyr2k.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(dsyrk.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(dtrmm.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(dtrmv.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(dtrsm.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(dtrsv.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(cgemm.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(cgemv.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(cgerc.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(cgeru.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(chemm.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(chemv.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(cher.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(cher2.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(cher2k.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(cherk.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(csymm.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(csyr2k.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(csyrk.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(ctrmm.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(ctrmv.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(ctrsm.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(ctrsv.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(zgemm.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(zgemv.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(zgerc.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(zgeru.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(zhemm.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(zhemv.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(zher.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(zher2.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(zher2k.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(zherk.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(zsymm.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(zsyr2k.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(zsyrk.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(ztrmm.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(ztrmv.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(ztrsm.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(ztrsv.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: ../../lib/libgslcblas.a(xerbla.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/contrib/bintuils/2.28/x86_64-slc6/bin/ld: final link failed: Nonrepresentable section on output
collect2: error: ld returned 1 exit status
make[3]: *** [lib/libMathMore.so] Error 1
make[2]: *** [math/mathmore/CMakeFiles/MathMore.dir/all] Error 2
make[1]: *** [math/mathmore/CMakeFiles/MathMore.dir/rule] Error 2
make: *** [MathMore] Error 2
```

This came from trying to build the master branch in the way that we build ROOT for the ATLAS analysis releases (https://gitlab.cern.ch/atlas/atlasexternals/blob/1.0/External/ROOT/CMakeLists.txt), using a command like:

```
cmake -Dall=ON -Dbuiltin_gsl=ON -Dbuiltin_freetype=ON -Dbuiltin_fftw3=ON -Dbuiltin_lzma=ON -DCMAKE_BUILD_TYPE=Release -Dcxx14=ON -Dxrootd=ON -Ddcache=ON -Ddavix=ON -Dbuiltin_veccore=ON ../root/
```