### PR TITLE
Avoid out-of-bound read.

### DIFF
--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -1748,7 +1748,7 @@ Bool_t TFile::ReadBuffers(char *buf, Long64_t *pos, Int_t *len, Int_t nbuf)
             fgBytesRead     -= extra;
             n = 0;
          }
-         curbegin = pos[i];
+         curbegin = i < nbuf ? pos[i] : 0;
       }
    }
    if (buf2) delete [] buf2;


### PR DESCRIPTION
Note: This read was however harmless as the loop cut short immediately thereafter
without using the result of the read.