### PR TITLE
[cxxmodules] Headerparsing is switched off by default

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1676,14 +1676,12 @@ void TCling::RegisterModule(const char* modulename,
 
    // Treat Aclic Libs in a special way. Do not delay the parsing.
    bool hasHeaderParsingOnDemand = fHeaderParsingOnDemand;
-   bool isACLiC = false;
-   if (hasHeaderParsingOnDemand &&
-       strstr(modulename, "_ACLiC_dict") != nullptr){
+   bool isACLiC = strstr(modulename, "_ACLiC_dict") != nullptr;
+   if (hasHeaderParsingOnDemand && isACLiC) {
       if (gDebug>1)
          Info("TCling::RegisterModule",
               "Header parsing on demand is active but this is an Aclic library. Disabling it for this library.");
       hasHeaderParsingOnDemand = false;
-      isACLiC = true;
    }
 
 


### PR DESCRIPTION
This fixes few modules bugs.