### PR TITLE
[cxxmodules] Fix absolute paths for v7 headers in modulemap

### DIFF
--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -262,6 +262,8 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
     endif()
   endforeach()
   string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/inc/" ""  headerfiles "${headerfiles}")
+  string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/v7/inc/" ""  headerfiles "${headerfiles}")
+
   # Replace the non-standard folder layout of Core.
   if (ARG_STAGE1 AND ARG_MODULE STREQUAL "Core")
     # FIXME: Glob these folders.
@@ -270,6 +272,22 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
                      rootcling_stage1 textinput thread unix winnt zip)
     foreach(core_folder ${core_folders})
       string(REPLACE "${CMAKE_SOURCE_DIR}/core/${core_folder}/inc/" ""  headerfiles "${headerfiles}")
+    endforeach()
+  endif()
+
+  # Check that each path here is relative so that it no longer points to the build folder.
+  # If we don't do this, then for example the modulemap might contain absolute paths to the
+  # build folder which would break module compilation.
+  if(PROJECT_NAME STREQUAL ROOT)
+    foreach(hf ${headerfiles})
+      string(REPLACE "${PROJECT_SOURCE_DIR}" "" hfrel "${hf}")
+      # Test folders don't follow this pattern and need absolute paths,
+      # so we don't run our sanity check on them.
+      if(NOT "${hfrel}" MATCHES "/test/")
+        if(IS_ABSOLUTE "${hf}")
+          message(SEND_ERROR "Header path '${hf}' ${hfrel} is not relative!")
+        endif()
+      endif()
     endforeach()
   endif()
 


### PR DESCRIPTION
Our CMake code for making path to headers relative is broken
for the v7 headers (as they don't have the 'CURRENT_SOURCE/inc'
prefix we check for). This caused that we have absolute paths for
those headers in the modulemap we ship with ROOT.

This patch just hacks in the additional check for v7 headers
and a sanity check that should prevent this error in the future.