### PR TITLE
[cxxmodules] Add missing header file.

### DIFF
--- a/build/unix/libc.modulemap
+++ b/build/unix/libc.modulemap
@@ -4,6 +4,10 @@ module "libc" [system] {
     export *
     textual header "assert.h"
   }
+  module "string.h" {
+    export *
+    header "string.h"
+  }
   module "ctype.h" {
     export *
     header "ctype.h"


### PR DESCRIPTION
This reduces the duplications in all modules reducing the overall
modules size by 1MB.