### PR TITLE
The ASTReader knows better what needs CodeGenning.

### DIFF
--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -3383,6 +3383,7 @@ void ROOT::TMetaUtils::GetFullyQualifiedTypeName(std::string &typenamestr,
                                                  const clang::QualType &qtype,
                                                  const cling::Interpreter &interpreter)
 {
+   cling::Interpreter::PushTransactionRAII RAII(const_cast<cling::Interpreter*>(&interpreter));
    GetFullyQualifiedTypeName(typenamestr,
                              qtype,
                              interpreter.getCI()->getASTContext());

--- a/core/metacling/src/TClingBaseClassInfo.cxx
+++ b/core/metacling/src/TClingBaseClassInfo.cxx
@@ -90,6 +90,7 @@ TClingBaseClassInfo::TClingBaseClassInfo(cling::Interpreter* interp,
    : fInterp(interp), fClassInfo(0), fFirstTime(true), fDescend(false),
      fDecl(0), fIter(0), fBaseInfo(0), fOffset(0L), fClassInfoOwnership(false)
 {
+   cling::Interpreter::PushTransactionRAII RAII(interp);
    // Constructs a single base class base (no iterator) of derived; derived must be != 0.
    // The derived class info is referenced during the lifetime of the TClingBaseClassInfo.
    if (!derived->GetDecl()) {

--- a/core/metacling/src/TClingCallbacks.h
+++ b/core/metacling/src/TClingCallbacks.h
@@ -12,6 +12,7 @@
 #include "cling/Interpreter/InterpreterCallbacks.h"
 
 #include <stack>
+#include <vector>
 
 namespace clang {
    class Decl;
@@ -27,6 +28,7 @@ namespace clang {
 namespace cling {
    class Interpreter;
    class Transaction;
+   class Module;
 }
 
 namespace llvm {
@@ -45,6 +47,7 @@ private:
    bool fIsAutoParsingSuspended;
    bool fPPOldFlag;
    bool fPPChanged;
+   std::vector<clang::Module*> fPendingModules;
 public:
    TClingCallbacks(cling::Interpreter* interp);
 
@@ -82,6 +85,8 @@ public:
    // The callback is used to update the list of globals in ROOT.
    //
    virtual void TransactionCommitted(const cling::Transaction &T);
+
+   virtual void beforeEmittingModuleForTransaction(const cling::Transaction &T);
 
    // The callback is used to update the list of globals in ROOT.
    //

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -605,7 +605,6 @@ long TClingClassInfo::GetOffset(const CXXMethodDecl* md) const
 
 ptrdiff_t TClingClassInfo::GetBaseOffset(TClingClassInfo* base, void* address, bool isDerivedObject)
 {
-
    R__LOCKGUARD(gInterpreterMutex);
 
    // Check for the offset in the cache.

--- a/core/metacling/src/TClingDataMemberInfo.cxx
+++ b/core/metacling/src/TClingDataMemberInfo.cxx
@@ -305,6 +305,7 @@ long TClingDataMemberInfo::Offset()
       return -1L;
    }
 
+   cling::Interpreter::PushTransactionRAII RAII(fInterp);
    const Decl *D = GetDecl();
    ASTContext& C = D->getASTContext();
    if (const FieldDecl *FldD = dyn_cast<FieldDecl>(D)) {
@@ -490,6 +491,7 @@ long TClingDataMemberInfo::TypeProperty() const
    if (!IsValid()) {
       return 0L;
    }
+   cling::Interpreter::PushTransactionRAII RAII(fInterp);
    const clang::ValueDecl *vd = llvm::dyn_cast<clang::ValueDecl>(GetDecl());
    clang::QualType qt = vd->getType();
    return TClingTypeInfo(fInterp, qt).Property();
@@ -528,6 +530,7 @@ const char *TClingDataMemberInfo::TypeName() const
    CheckForIoTypeAndName();
    if (!fIoType.empty()) return fIoType.c_str();
 
+   cling::Interpreter::PushTransactionRAII RAII(fInterp);
    // Note: This must be static because we return a pointer inside it!
    static std::string buf;
    buf.clear();

--- a/core/metacling/src/TClingTypedefInfo.cxx
+++ b/core/metacling/src/TClingTypedefInfo.cxx
@@ -279,6 +279,8 @@ const char *TClingTypedefInfo::TrueName(const ROOT::TMetaUtils::TNormalizedCtxt 
    if (!IsValid()) {
       return "(unknown)";
    }
+   cling::Interpreter::PushTransactionRAII pushedT(fInterp);
+
    // Note: This must be static because we return a pointer to the internals.
    TTHREAD_TLS_DECL( std::string, truename);
    truename.clear();

--- a/interpreter/cling/include/cling/Interpreter/InterpreterCallbacks.h
+++ b/interpreter/cling/include/cling/Interpreter/InterpreterCallbacks.h
@@ -132,6 +132,8 @@ namespace cling {
     ///
     virtual void TransactionCommitted(const Transaction&) {}
 
+    virtual void beforeEmittingModuleForTransaction(const Transaction&) {}
+
     ///\brief This callback is invoked whenever interpreter has reverted a
     /// transaction that has been fully committed.
     ///

--- a/interpreter/cling/include/cling/Interpreter/Transaction.h
+++ b/interpreter/cling/include/cling/Interpreter/Transaction.h
@@ -31,6 +31,7 @@ namespace clang {
   class Preprocessor;
   struct PrintingPolicy;
   class Sema;
+  class Module;
 }
 
 namespace llvm {
@@ -114,6 +115,9 @@ namespace cling {
     // init.
     typedef llvm::SmallVector<DelayCallInfo, 64> DeclQueue;
     typedef llvm::SmallVector<Transaction*, 2> NestedTransactions;
+
+    // Clang modules pcm
+    std::vector<clang::Module*> m_cxxmodules;
 
     ///\brief All seen declarations, except the deserialized ones.
     /// If we collect the declarations by walking the clang::DeclContext we
@@ -266,6 +270,16 @@ namespace cling {
       if (hasNestedTransactions())
         return m_NestedTransactions->rend();
       return const_reverse_nested_iterator(0);
+    }
+
+    void addModules(clang::Module* M) {
+      if (!M) return;
+      if (std::find(m_cxxmodules.begin(), m_cxxmodules.end(), M) == m_cxxmodules.end())
+        m_cxxmodules.push_back(M);
+    }
+
+    std::vector<clang::Module*> getModules() const {
+      return m_cxxmodules;
     }
 
     /// Macro iteration

--- a/interpreter/cling/lib/Interpreter/DeclCollector.cpp
+++ b/interpreter/cling/lib/Interpreter/DeclCollector.cpp
@@ -235,6 +235,23 @@ namespace cling {
     assertHasTransaction(m_CurTransaction);
     Transaction::DelayCallInfo DCI(DGR, Transaction::kCCIHandleInterestingDecl);
     m_CurTransaction->append(DCI);
+
+    for (Decl* D : DGR) {
+      assert(D);
+      if (!D->hasOwningModule())
+        return;
+
+      clang::Module *M = D->getOwningModule();
+      if (!M)
+        return;
+      M = M->getTopLevelModule();
+
+      assert(M);
+      m_CurTransaction->addModules(M);
+    }
+
+    // FIXME: Why we are calling HandleTopLevelDecl here. Aren't we altering
+    // the semantics?
     if (m_Consumer
         && (!comesFromASTReader(DGR) || !shouldIgnore(*DGR.begin())))
       m_Consumer->HandleTopLevelDecl(DGR);

--- a/interpreter/cling/lib/Interpreter/DeclCollector.h
+++ b/interpreter/cling/lib/Interpreter/DeclCollector.h
@@ -11,7 +11,6 @@
 #define CLING_DECL_COLLECTOR_H
 
 #include "clang/AST/ASTConsumer.h"
-#include "clang/Serialization/ASTDeserializationListener.h"
 
 #include "ASTTransformer.h"
 
@@ -42,7 +41,7 @@ namespace cling {
   /// cling::DeclCollector is responsible for appending all the declarations
   /// seen by clang.
   ///
-  class DeclCollector : public clang::ASTConsumer , public clang::ASTDeserializationListener {
+  class DeclCollector : public clang::ASTConsumer {
     /// \brief PPCallbacks overrides/ Macro support
     class PPAdapter;
 
@@ -118,20 +117,6 @@ namespace cling {
 
     // dyn_cast/isa support
     static bool classof(const clang::ASTConsumer*) { return true; }
-
-    void DeclRead(clang::serialization::DeclID, const clang::Decl *D) {
-      assert(D);
-      if (!D->hasOwningModule())
-        return;
-
-      clang::Module *M = D->getOwningModule();
-      if (!M)
-        return;
-      M = M->getTopLevelModule();
-
-      assert(M);
-      m_CurTransaction->addModules(M);
-    }
   };
 } // namespace cling
 

--- a/interpreter/cling/lib/Interpreter/LookupHelper.cpp
+++ b/interpreter/cling/lib/Interpreter/LookupHelper.cpp
@@ -1731,6 +1731,7 @@ namespace cling {
                                                       DiagSetting diagOnOff,
                                                       bool objectIsConst) const{
     assert(scopeDecl && "Decl cannot be null");
+    Interpreter::PushTransactionRAII RAII(m_Interpreter);
 
     return execFindFunction<ParseProto>(*m_Parser, m_Interpreter,
                                         scopeDecl,

--- a/interpreter/cling/lib/Interpreter/MultiplexInterpreterCallbacks.h
+++ b/interpreter/cling/lib/Interpreter/MultiplexInterpreterCallbacks.h
@@ -77,6 +77,12 @@ namespace cling {
        }
      }
 
+     void beforeEmittingModuleForTransaction(const Transaction& T) override {
+       for (auto&& cb : m_Callbacks) {
+         cb->beforeEmittingModuleForTransaction(T);
+       }
+     }
+
      void TransactionUnloaded(const Transaction& T) override {
        for (auto&& cb : m_Callbacks) {
          cb->TransactionUnloaded(T);

--- a/interpreter/llvm/src/tools/clang/include/clang/Serialization/ASTReader.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/Serialization/ASTReader.h
@@ -1555,6 +1555,11 @@ public:
   void setDeserializationListener(ASTDeserializationListener *Listener,
                                   bool TakeOwnership = false);
 
+  ASTDeserializationListener *getDeserializationListener() {
+    return DeserializationListener;
+  };
+
+
   /// \brief Determine whether this AST reader has a global index.
   bool hasGlobalIndex() const { return (bool)GlobalIndex; }
 


### PR DESCRIPTION
    We were trying to collect the owning modules of every deserialized
    decl. Later, we loaded the corresponding library. This is too
    much because for some entities (such as forward declarations) we
    load the shared object file in vain because no CodeGen is
    required.
    
    This patch relies on the ASTReader to decide if a decl needs to
    be CodeGenned or not. If it requires an action from CodeGen the
    ASTReader passes it through the HandleInterestingDecl interface.
    
    This patch brings back to normal the amount of loaded libraries.
