### PR TITLE
[cxxmodules] Reduce amout of loaded libraries

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -6144,6 +6144,8 @@ void TCling::UpdateListsOnCommitted(const cling::Transaction &T) {
    // Thus the iteration over the deserialized decls must be last.
    for (cling::Transaction::const_iterator I = T.deserialized_decls_begin(),
            E = T.deserialized_decls_end(); I != E; ++I) {
+      if (I->m_Call == cling::Transaction::kCCIFromDeserializationListener)
+         continue;
       for (DeclGroupRef::const_iterator DI = I->m_DGR.begin(),
               DE = I->m_DGR.end(); DI != DE; ++DI)
          if (TransactionDeclSet.find(*DI) == TransactionDeclSet.end()) {

--- a/core/metacling/src/TClingCallbacks.h
+++ b/core/metacling/src/TClingCallbacks.h
@@ -49,7 +49,10 @@ private:
    bool fPPChanged;
    // This vector holds a clang cxxmodules where corresponding library should be loaded in Transaction
    // afterwards.
-   std::vector<clang::Module*> fPendingCxxModules;
+   std::vector<const clang::Module*> fPendingCxxModules;
+
+   // This vector holds a clang cxxmodules which are already loaded in this Transaction.
+   std::vector<const clang::Module*> m_loadedClangModules;
 public:
    TClingCallbacks(cling::Interpreter* interp);
 

--- a/interpreter/cling/include/cling/Interpreter/Transaction.h
+++ b/interpreter/cling/include/cling/Interpreter/Transaction.h
@@ -54,6 +54,7 @@ namespace cling {
   class Transaction {
   public:
     enum ConsumerCallInfo {
+      kCCIFromDeserializationListener,
       kCCINone,
       kCCIHandleTopLevelDecl,
       kCCIHandleInterestingDecl,
@@ -115,11 +116,6 @@ namespace cling {
     // init.
     typedef llvm::SmallVector<DelayCallInfo, 64> DeclQueue;
     typedef llvm::SmallVector<Transaction*, 2> NestedTransactions;
-
-    ///\brief The list of cxxmodules, which is collected by DeserializationListener
-    /// and will be used to load corresponding libraries.
-    ///
-    std::vector<clang::Module*> m_CxxModules;
 
     ///\brief All seen declarations, except the deserialized ones.
     /// If we collect the declarations by walking the clang::DeclContext we
@@ -272,17 +268,6 @@ namespace cling {
       if (hasNestedTransactions())
         return m_NestedTransactions->rend();
       return const_reverse_nested_iterator(0);
-    }
-
-    void addClangModule(clang::Module* M) {
-      assert(M && "addClangModules: passed clang::Module pointer is null");
-
-      if (std::find(m_CxxModules.rbegin(), m_CxxModules.rend(), M) == m_CxxModules.rend())
-        m_CxxModules.push_back(M);
-    }
-
-    const std::vector<clang::Module*> &getClangModules() const {
-      return m_CxxModules;
     }
 
     /// Macro iteration

--- a/interpreter/cling/lib/Interpreter/DeclCollector.cpp
+++ b/interpreter/cling/lib/Interpreter/DeclCollector.cpp
@@ -327,11 +327,8 @@ namespace cling {
     assert(D && "Decl doesn't exist!");
     if (!D->hasOwningModule()) return;
 
-    clang::Module *M = D->getOwningModule();
-    M = M->getTopLevelModule();
-
-    // Add interesting module to Transaction's m_cxxmodules; Corresponding library will be loaded.
-    m_CurTransaction->addClangModule(M);
+    // Add clang::decls to to Transaction's m_ClangDecls; Corresponding library will be loaded.
+    m_CurTransaction->append(Transaction::DelayCallInfo(clang::DeclGroupRef(const_cast<clang::Decl*>(D)), Transaction::kCCIFromDeserializationListener));
   }
 
 } // namespace cling

--- a/interpreter/cling/lib/Interpreter/Transaction.cpp
+++ b/interpreter/cling/lib/Interpreter/Transaction.cpp
@@ -177,7 +177,7 @@ namespace cling {
       }
     }
 
-    if (comesFromASTReader(DCI.m_DGR))
+    if (comesFromASTReader(DCI.m_DGR) || DCI.m_Call == kCCIFromDeserializationListener)
       m_DeserializedDeclQueue.push_back(DCI);
     else
       m_DeclQueue.push_back(DCI);


### PR DESCRIPTION
This patch reduces loaded libraries to half, nearly the same amount of pch's.
    
What I did is:
1. Change DeclCollector and Transaction to collect clang::Decls, not
clang::Modules so that we still have decls information after finishing
deserialization.
2. In TClingCallbacks, we check if the decl is "isUsed()" or not. If
not, we don't want to load corresponding libararies.

```
w/o
yuka@yukadesk:~/module-release$ lsof -p 25477 | grep so | wc -l
88
with
yuka@yukadesk:~/module-release$ lsof -p 23676 | grep so | wc -l                                          
37

PCH
yuka@yukadesk:~/root-release$ lsof -p 9664 | grep so | wc -l
32

w/o
Processing tutorials/hsimple.C...
hsimple   : Real Time =   0.08 seconds Cpu Time =   0.07 seconds
(TFile *) 0x5563018a1d30
Processing /home/yuka/CERN/ROOT/memory.C...
 cpu  time = 1.524314 seconds
 sys  time = 0.157075 seconds
 res  memory = 546.867 Mbytes
 vir  memory = 895.184 Mbytes

with
Processing tutorials/hsimple.C...
hsimple   : Real Time =   0.05 seconds Cpu Time =   0.05 seconds
(TFile *) 0x55c8a399bfa0
Processing /home/yuka/CERN/ROOT/memory.C...
 cpu  time = 0.371789 seconds
 sys  time = 0.069116 seconds
 res  memory = 273.5 Mbytes
 vir  memory = 461.43 Mbytes

```
