### PR TITLE
Fixed use of TString to compile with gcc 8.1

### DIFF
--- a/geom/gdml/src/TGDMLWrite.cxx
+++ b/geom/gdml/src/TGDMLWrite.cxx
@@ -1477,8 +1477,8 @@ XMLNodePointer_t TGDMLWrite::CreateElConeN(TGeoScaledShape * geoShape)
    Double_t sy = geoShape->GetScale()->GetScale()[1];
    Double_t ry1 = sy * rx1;
 
-   std::string format(TString::Format("%s/%s", fltPrecision.Data(), fltPrecision.Data()));
-   fGdmlE->NewAttr(mainN, 0, "dx", TString::Format(format.c_str(), rx1, z));
+   std::string format(TString::Format("%s/%s", fltPrecision.Data(), fltPrecision.Data()).Data());
+   fGdmlE->NewAttr(mainN, 0, "dx", TString::Format(format.c_str(), rx2, z));
    fGdmlE->NewAttr(mainN, 0, "dy", TString::Format(format.c_str(), ry1, z));
    fGdmlE->NewAttr(mainN, 0, "zmax", TString::Format(fltPrecision.Data(), zmax));
    fGdmlE->NewAttr(mainN, 0, "zcut", TString::Format(fltPrecision.Data(), zcut));

--- a/geom/gdml/src/TGDMLWrite.cxx
+++ b/geom/gdml/src/TGDMLWrite.cxx
@@ -1478,7 +1478,7 @@ XMLNodePointer_t TGDMLWrite::CreateElConeN(TGeoScaledShape * geoShape)
    Double_t ry1 = sy * rx1;
 
    std::string format(TString::Format("%s/%s", fltPrecision.Data(), fltPrecision.Data()).Data());
-   fGdmlE->NewAttr(mainN, 0, "dx", TString::Format(format.c_str(), rx2, z));
+   fGdmlE->NewAttr(mainN, 0, "dx", TString::Format(format.c_str(), rx1, z));
    fGdmlE->NewAttr(mainN, 0, "dy", TString::Format(format.c_str(), ry1, z));
    fGdmlE->NewAttr(mainN, 0, "zmax", TString::Format(fltPrecision.Data(), zmax));
    fGdmlE->NewAttr(mainN, 0, "zcut", TString::Format(fltPrecision.Data(), zcut));

--- a/tmva/tmva/src/Factory.cxx
+++ b/tmva/tmva/src/Factory.cxx
@@ -503,7 +503,7 @@ TMVA::MethodBase* TMVA::Factory::BookMethod(TMVA::DataLoader *loader, Types::EMV
 TMVA::MethodBase* TMVA::Factory::BookMethodWeightfile(DataLoader *loader, TMVA::Types::EMVA methodType, const TString &weightfile)
 {
    TString datasetname = loader->GetName();
-   std::string methodTypeName = std::string(Types::Instance().GetMethodName(methodType));
+   std::string methodTypeName = std::string(Types::Instance().GetMethodName(methodType).Data());
    DataSetInfo &dsi = loader->DefaultDataSetInfo();
    
    IMethod *im = ClassifierFactory::Instance().Create(methodTypeName, dsi, weightfile );

--- a/tmva/tmva/src/MethodCrossValidation.cxx
+++ b/tmva/tmva/src/MethodCrossValidation.cxx
@@ -154,7 +154,7 @@ TMVA::MethodBase *
 TMVA::MethodCrossValidation::InstantiateMethodFromXML(TString methodTypeName, TString weightfile) const
 {
    TMVA::MethodBase *m = dynamic_cast<MethodBase *>(
-      ClassifierFactory::Instance().Create(std::string(methodTypeName), DataInfo(), weightfile));
+      ClassifierFactory::Instance().Create(std::string(methodTypeName.Data()), DataInfo(), weightfile));
 
    if (m->GetMethodType() == Types::kCategory) {
       Log() << kFATAL << "MethodCategory not supported for the moment." << Endl;


### PR DESCRIPTION
Needed to fix construction of `std::string` from `TString` by using TString's Data method.