### PR TITLE
Add support for disable MustCleanup in TCheckHashRecursiveRemoveConsi…

### DIFF
--- a/core/base/inc/TROOT.h
+++ b/core/base/inc/TROOT.h
@@ -381,6 +381,15 @@ namespace ROOT {
    TROOT *GetROOT();
    namespace Internal {
       R__EXTERN TROOT *gROOTLocal;
+
+      inline void SetRequireCleanup(TObject &obj) {
+         obj.SetBit(kIsReferenced);
+         obj.SetUniqueID(0);
+      }
+
+      inline Bool_t RequiresCleanup(TObject &obj) {
+         return obj.TestBit(kIsReferenced) && obj.GetUniqueID() == 0;
+      }
    }
 
    /// \brief call RecursiveRemove for obj if gROOT is valid
@@ -391,7 +400,7 @@ namespace ROOT {
    {
       if (obj.TestBit(kMustCleanup)) {
          TROOT *root = ROOT::Internal::gROOTLocal;
-         if (root && root != &obj && root->MustClean()) {
+         if (root && root != &obj && (root->MustClean() || Internal::RequiresCleanup(obj))) {
             root->RecursiveRemove(&obj);
             obj.ResetBit(kMustCleanup);
          }


### PR DESCRIPTION
…stency.

If the user calls 'gROOT->SetMustCleanup(kFALSE);'
the RecursiveRemove mechanism is disabled, nonetheless we still need to have
TCheckHashRecursiveRemoveConsistency return the intended answer.
So the disabling is now 'lifted' for the object created by TCheckHashRecursiveRemoveConsistency.

This fixes ROOT-9369