### PR TITLE
More warnings from Clang 7.0 [trunk]

### DIFF
--- a/test/stressLinear.cxx
+++ b/test/stressLinear.cxx
@@ -807,7 +807,8 @@ void mstress_binary_ebe_op(Int_t rsize, Int_t csize)
   ok &= VerifyMatrixValue(m1,pattern,gVerbose,EPSILON);
   if (gVerbose)
     std::cout << "  subtracting the matrix from itself" << std::endl;
-  m1 -= m1;
+  // Hiding the self-subtraction from the compiler, causing warning by -Wself-assign-overloaded in clang 7.0
+  m1 -= static_cast<TMatrixD&>(m1);
   ok &= VerifyMatrixValue(m1,0.,gVerbose,EPSILON);
   if (gVerbose)
     std::cout << "  adding two matrices together" << std::endl;
@@ -828,7 +829,8 @@ void mstress_binary_ebe_op(Int_t rsize, Int_t csize)
   ok &= VerifyMatrixIdentity(m,m1,gVerbose,EPSILON);
   if (gVerbose)
     std::cout << "   clear both m and m1, by subtracting from itself and via add()" << std::endl;
-  m1 -= m1;
+  // Hiding the self-subtraction from the compiler, causing warning by -Wself-assign-overloaded in clang 7.0
+  m1 -= static_cast<TMatrixD&>(m1);
   Add(m,-3.,mp);
   ok &= VerifyMatrixIdentity(m,m1,gVerbose,EPSILON);
 
@@ -2589,7 +2591,8 @@ void spstress_binary_ebe_op(Int_t rsize, Int_t csize)
   ok &= VerifyMatrixValue(m1,pattern,gVerbose,EPSILON);
   if (gVerbose)
     std::cout << "  subtracting the matrix from itself" << std::endl;
-  m1 -= m1;
+  // Hiding the self-subtraction from the compiler, causing warning by -Wself-assign-overloaded in clang 7.0
+  m1 -= static_cast<TMatrixDSparse&>(m1);
   ok &= VerifyMatrixValue(m1,0.,gVerbose,EPSILON);
   m1.SetSparseIndex(m_d);
 
@@ -2607,7 +2610,8 @@ void spstress_binary_ebe_op(Int_t rsize, Int_t csize)
   ok &= VerifyMatrixIdentity(m,m1,gVerbose,EPSILON);
   if (gVerbose)
     std::cout << "   clear both m and m1, by subtracting from itself and via add()" << std::endl;
-  m1 -= m1;
+  // Hiding the self-subtraction from the compiler, causing warning by -Wself-assign-overloaded in clang 7.0
+  m1 -= static_cast<TMatrixDSparse&>(m1);
   Add(m,-3.,mp);
   ok &= VerifyMatrixIdentity(m,m1,gVerbose,EPSILON);
 
@@ -3444,7 +3448,8 @@ void vstress_binary_op(Int_t vsize)
   ok &= VerifyVectorValue(v1,pattern,gVerbose,EPSILON);
   if (gVerbose)
     std::cout << "  subtracting the vector from itself" << std::endl;
-  v1 -= v1;
+  // Hiding the self-subtraction from the compiler, causing warning by -Wself-assign-overloaded in clang 7.0
+  v1 -= static_cast<TVectorD&>(v1);
   ok &= VerifyVectorValue(v1,0.,gVerbose,EPSILON);
   if (gVerbose)
     std::cout << "  adding two vectors together" << std::endl;
@@ -3473,7 +3478,8 @@ void vstress_binary_op(Int_t vsize)
   ok &= VerifyVectorIdentity(v,v1,gVerbose,epsilon);
   if (gVerbose)
     std::cout << "   clear both v and v1, by subtracting from itself and via add()" << std::endl;
-  v1 -= v1;
+  // Hiding the self-subtraction from the compiler, causing warning by -Wself-assign-overloaded in clang 7.0
+  v1 -= static_cast<TVectorD&>(v1);
   Add(v,-3.,vp);
   ok &= VerifyVectorIdentity(v,v1,gVerbose,epsilon);
 

--- a/test/vmatrix.cxx
+++ b/test/vmatrix.cxx
@@ -580,7 +580,8 @@ void stress_binary_ebe_op(Int_t rsize, Int_t csize)
   ok &= VerifyMatrixValue(m1,pattern,gVerbose,EPSILON);
   if (gVerbose)
     std::cout << "  subtracting the matrix from itself" << std::endl;
-  m1 -= m1;
+  // Hiding the self-subtraction from the compiler, causing warning by -Wself-assign-overloaded in clang 7.0
+  m1 -= static_cast<TMatrixD&>(m1);
   ok &= VerifyMatrixValue(m1,0.,gVerbose,EPSILON);
   if (gVerbose)
     std::cout << "  adding two matrices together" << std::endl;
@@ -601,7 +602,8 @@ void stress_binary_ebe_op(Int_t rsize, Int_t csize)
   ok &= VerifyMatrixIdentity(m,m1,gVerbose,EPSILON);
   if (gVerbose)
     std::cout << "   clear both m and m1, by subtracting from itself and via add()" << std::endl;
-  m1 -= m1;
+  // Hiding the self-subtraction from the compiler, causing warning by -Wself-assign-overloaded in clang 7.0
+  m1 -= static_cast<TMatrixD&>(m1);
   Add(m,-3.,mp);
   ok &= VerifyMatrixIdentity(m,m1,gVerbose,EPSILON);
 

--- a/test/vvector.cxx
+++ b/test/vvector.cxx
@@ -373,7 +373,8 @@ void stress_binary_op(Int_t vsize)
   ok &= VerifyVectorValue(v1,pattern,gVerbose,EPSILON);
   if (gVerbose)
     std::cout << "  subtracting the vector from itself" << std::endl;
-  v1 -= v1;
+  // Hiding the self-subtraction from the compiler, causing warning by -Wself-assign-overloaded in clang 7.0
+  v1 -= static_cast<TVectorD&>(v1);
   ok &= VerifyVectorValue(v1,0.,gVerbose,EPSILON);
   if (gVerbose)
     std::cout << "  adding two vectors together" << std::endl;
@@ -403,7 +404,8 @@ void stress_binary_op(Int_t vsize)
   ok &= VerifyVectorIdentity(v,v1,gVerbose,epsilon);
   if (gVerbose)
     std::cout << "   clear both v and v1, by subtracting from itself and via add()" << std::endl;
-  v1 -= v1;
+  // Hiding the self-subtraction from the compiler, causing warning by -Wself-assign-overloaded in clang 7.0
+  v1 -= static_cast<TVectorD&>(v1);
   Add(v,-3.,vp);
   ok &= VerifyVectorIdentity(v,v1,gVerbose,epsilon);
 

--- a/tmva/tmva/src/DecisionTree.cxx
+++ b/tmva/tmva/src/DecisionTree.cxx
@@ -1601,7 +1601,7 @@ Double_t TMVA::DecisionTree::TrainNodeFast( const EventConstList & eventSample,
 
       // need a lambda function to pass to TThreadExecutor::MapReduce
       auto f = [this, &eventSample, &fisherCoeff, &useVariable, &invBinWidth,
-                &nBins, &xmin, &xmax, &cNvars, &nPartitions](UInt_t partition = 0){
+                &nBins, &xmin, &cNvars, &nPartitions](UInt_t partition = 0){
 
          UInt_t start = 1.0*partition/nPartitions*eventSample.size();
          UInt_t end   = (partition+1.0)/nPartitions*eventSample.size();


### PR DESCRIPTION
Suppressing warnings for Clang trunk for newly introduced "-Wseff-assign-overloaded" (ongoing discussion https://reviews.llvm.org/D45766)