### PR TITLE
[cxxmodules] Also install the overlay file and modulemaps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,9 +241,14 @@ if (NOT WIN32 AND NOT libcxx)
     list(GET __libcpp_full_paths_list 0 __libcpp_full_path)
 
     configure_file(${CMAKE_SOURCE_DIR}/build/unix/modulemap.overlay.yaml.in ${CMAKE_BINARY_DIR}/include/modulemap.overlay.yaml @ONLY)
+    configure_file(${CMAKE_SOURCE_DIR}/build/unix/modulemap-installed.overlay.yaml.in ${CMAKE_BINARY_DIR}/build/modulemap.overlay.yaml @ONLY)
+    install(FILES "${CMAKE_BINARY_DIR}/build/modulemap.overlay.yaml" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT headers)
 
     configure_file(${CMAKE_SOURCE_DIR}/build/unix/stl.modulemap ${CMAKE_BINARY_DIR}/include/stl.modulemap)
+    install(FILES "${CMAKE_BINARY_DIR}/include/stl.modulemap" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT headers)
     configure_file(${CMAKE_SOURCE_DIR}/build/unix/libc.modulemap ${CMAKE_BINARY_DIR}/include/libc.modulemap)
+    install(FILES "${CMAKE_BINARY_DIR}/include/libc.modulemap" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT headers)
+
   else()
     message(SEND_ERROR "Couldn't find c++ library paths, no modulemap overlay will be installed! (__libcpp_full_paths = '${__libcpp_full_paths}')")
   endif()

--- a/build/unix/modulemap-installed.overlay.yaml.in
+++ b/build/unix/modulemap-installed.overlay.yaml.in
@@ -1,0 +1,19 @@
+{
+  'version': 0,
+  'roots': [
+    { 'name': '@__libcpp_full_path@', 'type': 'directory',
+      'contents': [
+        { 'name': 'module.modulemap', 'type': 'file',
+          'external-contents': '@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@/stl.modulemap'
+        }
+      ]
+    },
+    { 'name': '/usr/include/', 'type': 'directory',
+      'contents': [
+        { 'name': 'module.modulemap', 'type': 'file',
+          'external-contents': '@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@/libc.modulemap'
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
ROOT needs an overlay files in the include directory during runtime
to correctly mount the system modulemaps for libc/STL. For this
we need to generate and install a new overlay file that points to
the *installed* modulemaps for those libraries.

We can't use the existing modulemap as this one still points to the
original build directory.

We also need to install the related stl/lib modulemaps.