### PR TITLE
[cxxmodules] Better check if we should generate a C++ module

### DIFF
--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -387,7 +387,7 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
     endforeach()
   endif()
 
-  if(runtime_cxxmodules AND ARG_MODULE)
+  if(cpp_module_file)
     set(newargs -cxxmodule ${newargs})
   endif()
 


### PR DESCRIPTION
We currently have two checks (that are supposed to have the same
result) in the changed if-stmt and a few lines above where we
set cpp_module_file. Obviously if we generate a module, we should
also set cpp_module_file, however (due to the duplicated code) in
the case of multidicts we generate a module without specifying the
file. This probably causes CMake to behave incorrectly when rebuilding
PCM files.