### PR TITLE
Minuit2 standalone improvements

### DIFF
--- a/math/minuit2/Minuit2Config.cmake.in
+++ b/math/minuit2/Minuit2Config.cmake.in
@@ -40,3 +40,11 @@ if(minuit2_mpi)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/Minuit2Targets.cmake")
+
+add_library(Minuit2::Math IMPORTED INTERFACE)
+set_property(TARGET Minuit2::Math
+             PROPERTY INTERFACE_LINK_LIBRARIES Minuit2::Minuit2Math)
+
+add_library(Minuit2::Common IMPORTED INTERFACE)
+set_property(TARGET Minuit2::Common
+             PROPERTY INTERFACE_LINK_LIBRARIES Minuit2::Minuit2Common)

--- a/math/minuit2/StandAlone.cmake
+++ b/math/minuit2/StandAlone.cmake
@@ -1,4 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.1...3.11)
+
+if(${CMAKE_VERSION} VERSION_LESS 3.12)
+    cmake_policy(VERSION ${CMAKE_VERSION})
+endif()
 
 include(FeatureSummary)
 include(CMakeDependentOption)

--- a/math/minuit2/StandAlone.cmake
+++ b/math/minuit2/StandAlone.cmake
@@ -58,15 +58,15 @@ endif()
 # If using this with add_subdirectory, the Minuit2
 # namespace does not get automatically prepended,
 # so including an alias for that.
-add_library(Common INTERFACE)
-add_library(Minuit2::Common ALIAS Common)
+add_library(Minuit2Common INTERFACE)
+add_library(Minuit2::Common ALIAS Minuit2Common)
 
 # OpenMP support
 if(minuit2_omp)
     if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
         message(STATUS "Building Minuit2 with OpenMP support")
     endif()
-    target_link_libraries(Common INTERFACE OpenMP::OpenMP_CXX)
+    target_link_libraries(Minuit2Common INTERFACE OpenMP::OpenMP_CXX)
 endif()
 
 # MPI support
@@ -76,8 +76,8 @@ if(minuit2_mpi)
         message(STATUS "Building Minuit2 with MPI support")
         message(STATUS "Run: ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} EXECUTABLE ${MPIEXEC_POSTFLAGS} ARGS")
     endif()
-    target_compile_definitions(Common INTERFACE MPIPROC)
-    target_link_libraries(Common INTERFACE MPI::MPI_CXX)
+    target_compile_definitions(Minuit2Common INTERFACE MPIPROC)
+    target_link_libraries(Minuit2Common INTERFACE MPI::MPI_CXX)
 endif()
 
 # Add the libraries
@@ -95,7 +95,7 @@ write_basic_package_version_file(
     )
 
 # Now, install the Interface targets
-install(TARGETS Common
+install(TARGETS Minuit2Common
         EXPORT Minuit2Targets
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib
@@ -117,7 +117,7 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Minuit2Config.cmake" "${CMAKE_CURRENT
         )
 
 # Allow build directory to work for CMake import
-export(TARGETS Common Math Minuit2 NAMESPACE Minuit2:: FILE Minuit2Targets.cmake)
+export(TARGETS Minuit2Common Minuit2Math Minuit2 NAMESPACE Minuit2:: FILE Minuit2Targets.cmake)
 export(PACKAGE Minuit2)
 
 # Only add tests and docs if this is the main project

--- a/math/minuit2/doc/CMakeLists.txt
+++ b/math/minuit2/doc/CMakeLists.txt
@@ -32,7 +32,7 @@ else()
         set(DOXYGEN EXTRACT_PRIVATE YES)
         set(DOXYGEN_EXTRACT_STATIC YES)
 
-        get_target_property(MATH_SOURCES Math SOURCES)
+        get_target_property(MATH_SOURCES Minuit2Math SOURCES)
         get_target_property(MINUIT2_SOURCES Minuit2 SOURCES)
 
         file(READ Minuit2.md MINUIT2_MAINPAGE)

--- a/math/minuit2/src/CMakeLists.txt
+++ b/math/minuit2/src/CMakeLists.txt
@@ -217,7 +217,7 @@ target_compile_definitions(
 target_compile_features(Minuit2 PUBLIC cxx_nullptr cxx_nonstatic_member_init)
 set_target_properties(Minuit2 PROPERTIES CXX_EXTENSIONS OFF)
 
-target_link_libraries(Minuit2 PUBLIC Math Common)
+target_link_libraries(Minuit2 PUBLIC Minuit2Math Minuit2Common)
 
 install(TARGETS Minuit2
         EXPORT Minuit2Targets

--- a/math/minuit2/src/math/CMakeLists.txt
+++ b/math/minuit2/src/math/CMakeLists.txt
@@ -34,18 +34,18 @@ copy_standalone(SOURCE ../../../mathcore/src DESTINATION .
     FILES ${MATH_SOURCES})
 
 # Adding the headers helps IDEs show the correct headers on targets
-add_library(Math
+add_library(Minuit2Math
     ${MATH_SOURCES}
     ${MATH_HEADERS}
     ${FIT_HEADERS}
     )
 
 # Add alias for direct inclusion
-add_library(Minuit2::Math ALIAS Math)
+add_library(Minuit2::Math ALIAS Minuit2Math)
 
 # Build and install directories are different, using CMake Generator expression
 target_include_directories(
-    Math
+    Minuit2Math
     PUBLIC
     $<BUILD_INTERFACE:${Minuit2_SOURCE_DIR}/inc>
     $<INSTALL_INTERFACE:include/Minuit2>
@@ -54,30 +54,30 @@ target_include_directories(
 # We need to add the ROOT mathcore directories if build inside of ROOT without standalone)
 if(minuit2_inroot AND NOT minuit2_standalone)
     target_include_directories(
-        Math
+        Minuit2Math
         PUBLIC
         $<BUILD_INTERFACE:${Minuit2_SOURCE_DIR}/../mathcore/inc>
         )
 endif()
 
 target_compile_definitions(
-    Math
+    Minuit2Math
     PRIVATE
     MATH_NO_PLUGIN_MANAGER
     )
 
 target_compile_definitions(
-    Math
+    Minuit2Math
     PUBLIC
     ROOT_Math_VecTypes
     )
 
-target_link_libraries(Math PUBLIC Common)
+target_link_libraries(Minuit2Math PUBLIC Minuit2Common)
 
-target_compile_features(Math PUBLIC cxx_auto_type cxx_static_assert)
-set_target_properties(Math PROPERTIES CXX_EXTENSIONS OFF)
+target_compile_features(Minuit2Math PUBLIC cxx_auto_type cxx_static_assert)
+set_target_properties(Minuit2Math PROPERTIES CXX_EXTENSIONS OFF)
 
-install(TARGETS Math
+install(TARGETS Minuit2Math
         EXPORT Minuit2Targets
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib


### PR DESCRIPTION
This adds two improvements (split into two commits) to the standalone Minuit2 build. First, warnings are reduced using the new syntax coming out in CMake 3.12, with a fallback for 3.1-3.11 versions.

The other fix is a protection added to the target names "Math" and "Common"; in CMake when this is built with `add_subdirectory`, these target names may clash with the master project or other `add_subdirectory` usages. The protection only kicks in if building as a subdirectory.