### PR TITLE
ROOT-9319: Allow TBranchProxy to store the full branch name.

### DIFF
--- a/tree/treeplayer/inc/TBranchProxy.h
+++ b/tree/treeplayer/inc/TBranchProxy.h
@@ -108,6 +108,7 @@ namespace Detail {
       TBranchProxy(Internal::TBranchProxyDirector* boss, const char *top, const char *name, const char *membername);
       TBranchProxy(Internal::TBranchProxyDirector* boss, TBranchProxy *parent, const char* membername, const char* top = 0, const char* name = 0);
       TBranchProxy(Internal::TBranchProxyDirector* boss, TBranch* branch, const char* membername);
+      TBranchProxy(Internal::TBranchProxyDirector* boss, const char* branchname, TBranch* branch, const char* membername);
       virtual ~TBranchProxy();
 
       TBranchProxy* GetProxy() { return this; }

--- a/tree/treeplayer/inc/TTreeReaderUtils.h
+++ b/tree/treeplayer/inc/TTreeReaderUtils.h
@@ -42,7 +42,7 @@ namespace Internal {
    public:
       TNamedBranchProxy(): fDict(0), fContentDict(0) {}
       TNamedBranchProxy(TBranchProxyDirector* boss, TBranch* branch, const char* fullname, const char* membername):
-         fProxy(boss, branch, membername), fDict(0), fContentDict(0), fFullName(fullname) {}
+         fProxy(boss, fullname, branch, membername), fDict(0), fContentDict(0), fFullName(fullname) {}
 
       const char* GetName() const { return fFullName.c_str(); }
       const Detail::TBranchProxy* GetProxy() const { return &fProxy; }

--- a/tree/treeplayer/src/TBranchProxy.cxx
+++ b/tree/treeplayer/src/TBranchProxy.cxx
@@ -100,6 +100,38 @@ ROOT::Detail::TBranchProxy::TBranchProxy(TBranchProxyDirector* boss, TBranch* br
    boss->Attach(this);
 }
 
+/// For a fullBranchName that might contain a leading friend tree path (but
+/// access elements designating a leaf), but the leaf name such that it matches
+/// the "path" to branch.
+static std::string GetFriendBranchName(TTree* directorTree, TBranch* branch, const char* fullBranchName)
+{
+   if (directorTree == branch->GetTree())
+      return branch->GetName();
+
+   // Friend case:
+   std::string sFullBranchName = fullBranchName;
+   std::string::size_type pos = sFullBranchName.rfind(branch->GetName());
+   if (pos != std::string::npos) {
+      sFullBranchName.erase(pos);
+      sFullBranchName += branch->GetName();
+   }
+   return sFullBranchName;
+}
+
+/// Constructor taking the branch name, possibly of a friended tree.
+/// Used by TTreeReaderValue in place of TFriendProxy.
+ROOT::Detail::TBranchProxy::TBranchProxy(TBranchProxyDirector* boss, const char* branchname, TBranch* branch, const char* membername) :
+   fDirector(boss), fInitialized(false), fIsMember(membername != 0 && membername[0]), fIsClone(false), fIsaPointer(false),
+   fHasLeafCount(false), fBranchName(GetFriendBranchName(boss->GetTree(), branch, branchname)), fParent(0), fDataMember(membername),
+   fClassName(""), fClass(0), fElement(0), fMemberOffset(0), fOffset(0), fArrayLength(1),
+   fBranch(0), fBranchCount(0),
+   fLastTree(0), fRead(-1), fWhere(0),fCollection(0), fCurrentTreeNumber(-1)
+{
+   // Constructor.
+
+   boss->Attach(this);
+}
+
 ROOT::Detail::TBranchProxy::~TBranchProxy()
 {
    // Typical Destructor


### PR DESCRIPTION
Before, branch->GetName() would only capture the "local" branch name of a friended tree.
This relies on the use of TFriendProxy, which is not a useful concept for the TTeeReader.
OTOH the director of the main tree has no problems identifying the correct friend,
given a "fully scoped" branch name.