### PR TITLE
Add CheckTObjectHashConsistency to interpreter ClassDef version.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -295,6 +295,7 @@ private: \
 public: \
    static TClass *Class() { static TClass* sIsA = 0; if (!sIsA) sIsA = TClass::GetClass(#name); return sIsA; } \
    static const char *Class_Name() { return #name; } \
+   virtual_keyword Bool_t CheckTObjectHashConsistency() const overrd { return true; } \
    static Version_t Class_Version() { return id; } \
    static TClass *Dictionary() { return 0; } \
    virtual_keyword TClass *IsA() const overrd { return name::Class(); } \


### PR DESCRIPTION
Fixes e.g. eve tutorials.