### PR TITLE
component selection handling fix

### DIFF
--- a/roofit/roofitcore/inc/RooRealIntegral.h
+++ b/roofit/roofitcore/inc/RooRealIntegral.h
@@ -77,9 +77,13 @@ public:
 
   virtual RooAbsReal* createIntegral(const RooArgSet& iset, const RooArgSet* nset=0, const RooNumIntConfig* cfg=0, const char* rangeName=0) const ;  
 
+  void setAllowComponentSelection(Bool_t allow);
+  Bool_t getAllowComponentSelection() const;
+  
 protected:
 
   mutable Bool_t _valid;
+  Bool_t _respectCompSelect;
 
   const RooArgSet& parameters() const ;
 
@@ -140,7 +144,7 @@ protected:
 
   virtual void operModeHook() ; // cache operation mode
 
-  ClassDef(RooRealIntegral,2) // Real-valued function representing an integral over a RooAbsReal object
+  ClassDef(RooRealIntegral,3) // Real-valued function representing an integral over a RooAbsReal object
 };
 
 #endif

--- a/roofit/roofitcore/src/RooRealSumFunc.cxx
+++ b/roofit/roofitcore/src/RooRealSumFunc.cxx
@@ -309,6 +309,7 @@ Int_t RooRealSumFunc::getAnalyticalIntegralWN(RooArgSet &allVars, RooArgSet &ana
    RooAbsReal *func;
    while ((func = (RooAbsReal *)_funcIter->Next())) {
       RooAbsReal *funcInt = func->createIntegral(analVars, rangeName);
+     if(funcInt->InheritsFrom(RooRealIntegral::Class())) ((RooRealIntegral*)funcInt)->setAllowComponentSelection(true);
       cache->_funcIntList.addOwned(*funcInt);
       if (normSet && normSet->getSize() > 0) {
          RooAbsReal *funcNorm = func->createIntegral(*normSet);

--- a/roofit/roofitcore/src/RooRealSumPdf.cxx
+++ b/roofit/roofitcore/src/RooRealSumPdf.cxx
@@ -346,6 +346,7 @@ Int_t RooRealSumPdf::getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& anal
   RooAbsReal *func ;
   while((func=(RooAbsReal*)_funcIter->Next())) {
     RooAbsReal* funcInt = func->createIntegral(analVars,rangeName) ;
+    if(funcInt->InheritsFrom(RooRealIntegral::Class())) ((RooRealIntegral*)funcInt)->setAllowComponentSelection(true);
     cache->_funcIntList.addOwned(*funcInt) ;
     if (normSet && normSet->getSize()>0) {
       RooAbsReal* funcNorm = func->createIntegral(*normSet) ;


### PR DESCRIPTION
The RooFit::SelectComponents automatism is intended to allow plotting components of likelihoods.
However, the current implementation only works as intended for "flat" Likelihoods as created by HistFactory. Likliehoods with more elaborate structures, notably such containing nested instances of RooRealSumFunc and RooRealSumPdf exhibit a broken behavior, resulting in wrong values displayed and retrieved from the workspace.
This bugfix disables the component selection mechanisms inside RooRealIntegrals unless specifically requested otherwise, which solves the problem for most scenarios and leaves the user with the option to manually edit the Likelihood to produce the correct results in all other cases.