### PR TITLE
TTreeCache vs TTreeReader, TDF and TTree::Draw

### DIFF
--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -6244,6 +6244,9 @@ Long64_t TTree::LoadTree(Long64_t entry)
       return -1;
    }
 
+   // create cache if wanted
+   if (fCacheDoAutoInit && entry >=0) SetCacheSizeAux();
+
    if (fNotify) {
       if (fReadEntry < 0) {
          fNotify->Notify();

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -5254,7 +5254,8 @@ Long64_t TTree::GetCacheAutoSize(Bool_t withDefault /* = kFALSE */ ) const
 TTree::TClusterIterator TTree::GetClusterIterator(Long64_t firstentry)
 {
    // create cache if wanted
-   if (fCacheDoAutoInit) SetCacheSizeAux();
+   if (fCacheDoAutoInit)
+      SetCacheSizeAux();
 
    return TClusterIterator(this,firstentry);
 }
@@ -5433,7 +5434,8 @@ Int_t TTree::GetEntry(Long64_t entry, Int_t getall)
    fReadEntry = entry;
 
    // create cache if wanted
-   if (fCacheDoAutoInit) SetCacheSizeAux();
+   if (fCacheDoAutoInit)
+      SetCacheSizeAux();
 
    Int_t nbranches = fBranches.GetEntriesFast();
    Int_t nb=0;
@@ -5717,7 +5719,8 @@ Int_t TTree::GetEntryWithIndex(Int_t major, Int_t minor)
       return -1;
    }
    // create cache if wanted
-   if (fCacheDoAutoInit) SetCacheSizeAux();
+   if (fCacheDoAutoInit)
+      SetCacheSizeAux();
 
    Int_t i;
    Int_t nbytes = 0;
@@ -6019,7 +6022,8 @@ Double_t TTree::GetMaximum(const char* columname)
    }
 
    // create cache if wanted
-   if (fCacheDoAutoInit) SetCacheSizeAux();
+   if (fCacheDoAutoInit)
+      SetCacheSizeAux();
 
    TBranch* branch = leaf->GetBranch();
    Double_t cmax = -DBL_MAX;
@@ -6058,7 +6062,8 @@ Double_t TTree::GetMinimum(const char* columname)
    }
 
    // create cache if wanted
-   if (fCacheDoAutoInit) SetCacheSizeAux();
+   if (fCacheDoAutoInit)
+      SetCacheSizeAux();
 
    TBranch* branch = leaf->GetBranch();
    Double_t cmin = DBL_MAX;
@@ -6098,7 +6103,8 @@ TTreeCache *TTree::GetReadCache(TFile *file, Bool_t create /* = kFALSE */ )
    TTreeCache *pe = dynamic_cast<TTreeCache*>(file->GetCacheRead(this));
    if (pe && pe->GetTree() != this) pe = 0;
    if (create && !pe) {
-      if (fCacheDoAutoInit) SetCacheSizeAux(kTRUE, -1);
+      if (fCacheDoAutoInit)
+         SetCacheSizeAux(kTRUE, -1);
       pe = dynamic_cast<TTreeCache*>(file->GetCacheRead(this));
       if (pe && pe->GetTree() != this) pe = 0;
    }
@@ -6245,7 +6251,8 @@ Long64_t TTree::LoadTree(Long64_t entry)
    }
 
    // create cache if wanted
-   if (fCacheDoAutoInit && entry >=0) SetCacheSizeAux();
+   if (fCacheDoAutoInit && entry >=0)
+      SetCacheSizeAux();
 
    if (fNotify) {
       if (fReadEntry < 0) {


### PR DESCRIPTION
Previously it was only done in
   TTree::GetClusterIterator
   TTree::GetEntry
   TTree::GetEntryWithIndex
   TTree::GetMaximum
   TTree::GetMinimum
   TTree::GetReadCache
   TTree::SetCacheSize

In particular it was not triggered by TTree::Draw, TDF nor TTreeReader,
they are using only:

   TTree::LoadTree and TBranch::GetEntry

The one use case still not covered is

   file->GetObject(treename, tree);
   auto b = tree->GetBranch(branchname);
   b->GetEntry(entryNumber)=;

But it would require to either enable it in the TTree constructor
(too soon?) or TBranch::GetEntry (too often?)