### PR TITLE
[TDF] Outline virtual ~TCustomColumnBase() /vtable key function:

### DIFF
--- a/tree/dataframe/inc/ROOT/TDFNodes.hxx
+++ b/tree/dataframe/inc/ROOT/TDFNodes.hxx
@@ -445,7 +445,7 @@ protected:
 public:
    TCustomColumnBase(TLoopManager *df, std::string_view name, const unsigned int nSlots, const bool isDSColumn);
    TCustomColumnBase &operator=(const TCustomColumnBase &) = delete;
-   virtual ~TCustomColumnBase() = default;
+   virtual ~TCustomColumnBase(); // outlined defaulted.
 
    virtual void InitSlot(TTreeReader *r, unsigned int slot) = 0;
    virtual void *GetValuePtr(unsigned int slot) = 0;

--- a/tree/dataframe/src/TDFNodes.cxx
+++ b/tree/dataframe/src/TDFNodes.cxx
@@ -62,6 +62,9 @@ TCustomColumnBase::TCustomColumnBase(TLoopManager *implPtr, std::string_view nam
 {
 }
 
+// pin vtable. Work around cling JIT issue.
+TCustomColumnBase::~TCustomColumnBase() = default;
+
 std::string TCustomColumnBase::GetName() const
 {
    return fName;


### PR DESCRIPTION
cling has a CodeGen problem that I am continuing to study.
This seems to work around the issue for now.