### PR TITLE
[TDF] ROOT-9418: Define returns TInterface<Proxied, DS_t>

### DIFF
--- a/tree/dataframe/inc/ROOT/TDFInterface.hxx
+++ b/tree/dataframe/inc/ROOT/TDFInterface.hxx
@@ -116,12 +116,6 @@ class TInterface {
    TDataSource *const fDataSource = nullptr;
 
 public:
-   /// \cond HIDDEN_SYMBOLS
-   // Windows needs the definition be done in two steps
-   using JittedDefineSharedPtr = decltype(TDFInternal::UpcastNode(fProxiedPtr));
-   using TInterfaceJittedDefine = TInterface<typename JittedDefineSharedPtr::element_type, DS_t>;
-   /// \endcond
-
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Copy-assignment operator for TInterface.
    TInterface &operator=(const TInterface &) = default;

--- a/tree/dataframe/inc/ROOT/TDFInterface.hxx
+++ b/tree/dataframe/inc/ROOT/TDFInterface.hxx
@@ -334,7 +334,7 @@ public:
    /// of branches/columns.
    ///
    /// Refer to the first overload of this method for the full documentation.
-   TInterfaceJittedDefine Define(std::string_view name, std::string_view expression)
+   TInterface<Proxied, DS_t> Define(std::string_view name, std::string_view expression)
    {
       auto lm = GetLoopManager();
       // this check must be done before jitting lest we throw exceptions in jitted code
@@ -1390,7 +1390,7 @@ public:
    /// This method books a custom action for execution. The behavior of the action is completely dependent on the
    /// Helper object provided by the caller. The minimum required interface for the helper is the following (more
    /// methods can be present, e.g. a constructor that takes the number of worker threads is usually useful):
-   /// 
+   ///
    /// * Helper must publicly inherit from ROOT::Detail::TDF::TActionImpl<Helper>
    /// * Helper(Helper &&): a move-constructor is required. Copy-constructors are discouraged.
    /// * Result_t: alias for the type of the result of this action helper. Must be default-constructible.

--- a/tree/dataframe/test/dataframe_ranges.cxx
+++ b/tree/dataframe/test/dataframe_ranges.cxx
@@ -46,6 +46,20 @@ TEST_F(TDFRanges, FromDefine)
    EXPECT_EQ(*count, 10u);
 }
 
+TEST_F(TDFRanges, ToDefine)
+{
+   auto &d = GetTDF();
+   auto count = d.Range(0, 10).Define("dummy", []() { return 42; }).Count();
+   EXPECT_EQ(10U, *count);
+}
+
+TEST_F(TDFRanges, ToDefine_jitted)
+{
+   auto &d = GetTDF();
+   auto count = d.Range(0, 10).Define("dummy", "tdfentry_").Count();
+   EXPECT_EQ(10U, *count);
+}
+
 TEST_F(TDFRanges, EarlyStop)
 {
    auto &d = GetTDF();


### PR DESCRIPTION
- Fixes: [https://sft.its.cern.ch/jira/browse/ROOT-9418](https://sft.its.cern.ch/jira/browse/ROOT-9418)
- Adds a google test for `Range` with `Define` (with and without jitted functions)