### PR TITLE
Compile geom/geom with -O2 with GCC 4.x

### DIFF
--- a/geom/geom/CMakeLists.txt
+++ b/geom/geom/CMakeLists.txt
@@ -23,3 +23,8 @@ set(headers2 TGeoPatternFinder.h TGeoCache.h TVirtualMagField.h
 ROOT_STANDARD_LIBRARY_PACKAGE(Geom
                               HEADERS ${headers1} ${headers2}
                               DEPENDENCIES Thread RIO MathCore)
+
+# GCC 4.x has bugs with -O3 or -Ofast that break Geom
+if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5)
+  target_compile_options(Geom -O2)
+endif()


### PR DESCRIPTION
GCC 4.x has bugs with -O3/-Ofast that break TGeo.