### PR TITLE
Additional improvements for MethodDL for CPU/GPU usage

### DIFF
--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu.h
@@ -112,6 +112,11 @@ public:
    static void Copy(TCpuMatrix<Scalar_t> & B,
                     const TCpuMatrix<Scalar_t> & A);
 
+   // copy from another type of matrix
+   template<typename AMatrix_t>
+   static void CopyDiffArch(TCpuMatrix<Scalar_t> & B, const AMatrix_t & A); 
+
+
    /** Above functions extended to vectors */
    static void ScaleAdd(std::vector<TCpuMatrix<Scalar_t>> & A,
                         const std::vector<TCpuMatrix<Scalar_t>> & B,
@@ -119,6 +124,11 @@ public:
 
    static void Copy(std::vector<TCpuMatrix<Scalar_t>> & A,
                     const std::vector<TCpuMatrix<Scalar_t>> & B);
+
+   // copy from another architecture
+   template<typename AMatrix_t>
+   static void CopyDiffArch(std::vector<TCpuMatrix<Scalar_t>> & A,
+                    const std::vector<AMatrix_t> & B);
 
    ///@}
 
@@ -461,6 +471,30 @@ public:
    static Scalar_t Sum(const TCpuMatrix<Scalar_t> &A);
 
 };
+
+//____________________________________________________________________________
+template <typename Real_t>
+template <typename AMatrix_t>
+void TCpu<Real_t>::CopyDiffArch(TCpuMatrix<Real_t> &B,
+                        const AMatrix_t &A)
+{
+   // copy from another architecture using the reference one
+   // this is not very efficient since creates temporary objects
+   TMatrixT<Real_t> tmp = A;
+   Copy(B, TCpuMatrix<Real_t>(tmp) ); 
+}
+
+//____________________________________________________________________________
+template <typename Real_t>
+template <typename AMatrix_t>
+void TCpu<Real_t>::CopyDiffArch(std::vector<TCpuMatrix<Real_t>> &B,
+                            const std::vector<AMatrix_t> &A)
+{
+   for (size_t i = 0; i < B.size(); ++i) {
+      CopyDiffArch(B[i], A[i]);
+   }
+}
+
 
 } // namespace DNN
 } // namespace TMVA

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda.h
@@ -117,7 +117,7 @@ public:
 
    // copy from another type of matrix
    template<typename AMatrix_t>
-   static void CopyDiffArch(TCudaMatrix<AFloat_t> & B, const AMatrix_t & A); 
+   static void CopyDiffArch(TCudaMatrix<Scalar_t> & B, const AMatrix_t & A); 
 
 
    /** Above functions extended to vectors */
@@ -475,21 +475,21 @@ public:
 };
 
 //____________________________________________________________________________
-template <typename Real_t>
+template <typename AFloat>
 template <typename AMatrix_t>
-void TCpu<Real_t>::CopyDiffArch(TCpuMatrix<Real_t> &B,
+void TCuda<AFloat>::CopyDiffArch(TCudaMatrix<AFloat> &B,
                         const AMatrix_t &A)
 {
    // copy from another architecture using the reference one
    // this is not very efficient since creates temporary objects
    TMatrixT<Real_t> tmp = A;
-   Copy(B, TCpuMatrix<Real_t>(tmp) ); 
+   Copy(B, TCudaMatrix<AFloat>(tmp) ); 
 }
 
 //____________________________________________________________________________
-template <typename Real_t>
+template <typename AFloat>
 template <typename AMatrix_t>
-void TCpu<Real_t>::CopyDiffArch(std::vector<TCpuMatrix<Real_t>> &B,
+void TCuda<AFloat>::CopyDiffArch(std::vector<TCudaMatrix<AFloat>> &B,
                             const std::vector<AMatrix_t> &A)
 {
    for (size_t i = 0; i < B.size(); ++i) {

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda.h
@@ -482,7 +482,7 @@ void TCuda<AFloat>::CopyDiffArch(TCudaMatrix<AFloat> &B,
 {
    // copy from another architecture using the reference one
    // this is not very efficient since creates temporary objects
-   TMatrixT<Real_t> tmp = A;
+   TMatrixT<AFloat> tmp = A;
    Copy(B, TCudaMatrix<AFloat>(tmp) ); 
 }
 

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda.h
@@ -115,6 +115,11 @@ public:
    static void Copy(TCudaMatrix<AFloat> & B,
                     const TCudaMatrix<AFloat> & A);
 
+   // copy from another type of matrix
+   template<typename AMatrix_t>
+   static void CopyDiffArch(TCudaMatrix<AFloat_t> & B, const AMatrix_t & A); 
+
+
    /** Above functions extended to vectors */
    static void ScaleAdd(std::vector<TCudaMatrix<Scalar_t>> & A,
                         const std::vector<TCudaMatrix<Scalar_t>> & B,
@@ -122,6 +127,12 @@ public:
 
    static void Copy(std::vector<TCudaMatrix<Scalar_t>> & A,
                     const std::vector<TCudaMatrix<Scalar_t>> & B);
+
+   // copy from another architecture
+   template<typename AMatrix_t>
+   static void CopyDiffArch(std::vector<TCudaMatrix<Scalar_t>> & A,
+                    const std::vector<AMatrix_t> & B);
+
 
    ///@}
 
@@ -462,6 +473,29 @@ public:
    /** Compute the sum of all elements in \p A */
    static AFloat Sum(const TCudaMatrix<AFloat> &A);
 };
+
+//____________________________________________________________________________
+template <typename Real_t>
+template <typename AMatrix_t>
+void TCpu<Real_t>::CopyDiffArch(TCpuMatrix<Real_t> &B,
+                        const AMatrix_t &A)
+{
+   // copy from another architecture using the reference one
+   // this is not very efficient since creates temporary objects
+   TMatrixT<Real_t> tmp = A;
+   Copy(B, TCpuMatrix<Real_t>(tmp) ); 
+}
+
+//____________________________________________________________________________
+template <typename Real_t>
+template <typename AMatrix_t>
+void TCpu<Real_t>::CopyDiffArch(std::vector<TCpuMatrix<Real_t>> &B,
+                            const std::vector<AMatrix_t> &A)
+{
+   for (size_t i = 0; i < B.size(); ++i) {
+      CopyDiffArch(B[i], A[i]);
+   }
+}
 
 } // namespace DNN
 } // namespace TMVA

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Reference.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Reference.h
@@ -110,13 +110,22 @@ public:
    static void Copy(TMatrixT<Scalar_t> & A,
                     const TMatrixT<Scalar_t> & B);
 
+   // copy from another type of matrix
+   template<typename AMatrix_t>
+   static void CopyDiffArch(TMatrixT<Scalar_t> & A, const AMatrix_t & B); 
+
+
    /** Above functions extended to vectors */
    static void ScaleAdd(std::vector<TMatrixT<Scalar_t>> & A,
                         const std::vector<TMatrixT<Scalar_t>> & B,
                         Scalar_t beta = 1.0);
 
-   static void Copy(std::vector<TMatrixT<Scalar_t>> & A,
-                    const std::vector<TMatrixT<Scalar_t>> & B);
+   static void Copy(std::vector<TMatrixT<Scalar_t>> & A, const std::vector<TMatrixT<Scalar_t>> & B);
+
+   // copy from another architecture
+   template<typename AMatrix_t>
+   static void CopyDiffArch(std::vector<TMatrixT<Scalar_t> > & A, const std::vector<AMatrix_t> & B);
+
 
    ///@}
 
@@ -511,6 +520,27 @@ public:
 
 };
 
+
+// implement the templated member functions
+template <typename AReal>
+template <typename AMatrix_t>
+void TReference<AReal>::CopyDiffArch(TMatrixT<AReal> &A, const AMatrix_t &B)
+{
+   TMatrixT<AReal> tmp = B;
+   A = tmp;
+}
+   
+template <typename AReal>
+template <typename AMatrix_t> 
+void TReference<AReal>::CopyDiffArch(std::vector<TMatrixT<AReal>> &A, const std::vector<AMatrix_t> &B)
+{
+   for (size_t i = 0; i < A.size(); ++i) {
+      CopyDiffArch(A[i], B[i]);
+   }
+}
+
+
+   
 } // namespace DNN
 } // namespace TMVA
 

--- a/tmva/tmva/inc/TMVA/MethodDL.h
+++ b/tmva/tmva/inc/TMVA/MethodDL.h
@@ -134,6 +134,9 @@ private:
    void ParseLstmLayer(DNN::TDeepNet<Architecture_t, Layer_t> &deepNet,
                        std::vector<DNN::TDeepNet<Architecture_t, Layer_t>> &nets, TString layerString, TString delim);
 
+   template <typename Architecture_t>
+   void TrainDeepNet(); 
+   
    size_t fInputDepth;  ///< The depth of the input.
    size_t fInputHeight; ///< The height of the input.
    size_t fInputWidth;  ///< The width of the input.

--- a/tmva/tmva/inc/TMVA/MethodDL.h
+++ b/tmva/tmva/inc/TMVA/MethodDL.h
@@ -77,15 +77,16 @@ class MethodDL : public MethodBase {
 private:
    // Key-Value vector type, contining the values for the training options
    using KeyValueVector_t = std::vector<std::map<TString, TString>>;
-#ifdef R__HAS_TMVAGPU
-   using ArchitectureImpl_t = TMVA::DNN::TCuda<Double_t>;
-#else
+// #ifdef R__HAS_TMVAGPU
+//    using ArchitectureImpl_t = TMVA::DNN::TCuda<Double_t>;
+// #else
+// do not use arch GPU for evaluation. It is too slow for batch size=1   
 #ifdef R__HAS_TMVACPU
    using ArchitectureImpl_t = TMVA::DNN::TCpu<Double_t>;
 #else
    using ArchitectureImpl_t = TMVA::DNN::TReference<Double_t>;
 #endif  
-#endif
+//#endif
    using DeepNetImpl_t = TMVA::DNN::TDeepNet<ArchitectureImpl_t>;
    std::unique_ptr<DeepNetImpl_t> fNet;
 

--- a/tmva/tmva/src/MethodDL.cxx
+++ b/tmva/tmva/src/MethodDL.cxx
@@ -224,43 +224,49 @@ void MethodDL::ProcessOptions()
             << Endl;
    }
    
-   // the architecture can now be set only at compile time in MethodDL
-#ifdef R__HAS_TMVAGPU
-   if (fArchitectureString != "GPU") {
-      Log() << kERROR << "TMVA has been built with CUDA backend enabled  "
-         "you need to rebuild ROOT with -Dcuda=Off if you want to use the  "
-            <<  fArchitectureString << "  architecture "
-            << Endl;
-   
-      Log() << kINFO << "Will use now the GPU architecture !" << Endl;
-   }
-   fArchitectureString = "GPU";
-#else  // R__HAS_TMVGPU is not defined 
+   // the architecture can now be set at runtime as an option
+
 
    if (fArchitectureString == "GPU") {
+#ifndef R__HAS_TMVAGPU    // case TMVA does not support GPU
       Log() << kERROR << "CUDA backend not enabled. Please make sure "
          "you have CUDA installed and it was successfully "
-         "detected by CMAKE."
+         "detected by CMAKE by using -Dcuda=On "
             << Endl;
-   }
 #ifdef R__HAS_TMVACPU
-   if (fArchitectureString != "CPU") {
+      fArchitectureString = "CPU";
       Log() << kINFO << "Will use now the CPU architecture !" << Endl;
+#else 
+      fArchitectureString = "Standard";
+      Log() << kINFO << "Will use now the Standard architecture !" << Endl;
+#endif
+#else
+      Log() << kINFO << "Will use now the GPU architecture !" << Endl;
+#endif
    }
-   fArchitectureString = "CPU";
-#else   // R__HAS_TMVCPU and GPU are not defined 
-   if (fArchitectureString == "CPU") {
-      Log() << kFATAL << "Multi-core CPU backend not enabled. Please make sure "
-                         "you have a BLAS implementation and it was successfully "
+
+   else if (fArchitectureString == "CPU") {
+#ifndef R__HAS_TMVACPU  // TMVA has no CPU support
+      Log() << kERROR << "Multi-core CPU backend not enabled. Please make sure "
+                          "you have a BLAS implementation and it was successfully "
                          "detected by CMake as well that the imt CMake flag is set."
             << Endl;
-   } else {
-      // here can be only standard architecture
-      Log() << kINFO << "Will try using the deprectaed STANDARD architecture !" << Endl;
+#ifdef R__HAS_TMVAGPU
+      fArchitectureString = "GPU";
+      Log() << kINFO << "Will use now the GPU architecture !" << Endl;
+#else 
+      fArchitectureString = "Standard";
+      Log() << kINFO << "Will use now the Standard architecture !" << Endl;
+#endif
+#else
+      Log() << kINFO << "Will use now the CPU architecture !" << Endl;
+#endif
+   }
+
+   else { 
+      Log() << kINFO << "Will use the deprected STANDARD architecture !" << Endl;
       fArchitectureString = "STANDARD";
    }
-#endif // DNNCPU
-#endif
 
    // Input Layout
    ParseInputLayout();
@@ -951,55 +957,19 @@ Bool_t MethodDL::HasAnalysisType(Types::EAnalysisType type, UInt_t numberClasses
    return kFALSE;
 }
 
+
 ////////////////////////////////////////////////////////////////////////////////
-void MethodDL::Train()
+///  Implementation of architecture specific train method
+///
+template <typename Architecture_t>
+void MethodDL::TrainDeepNet()
 {
-   if (fInteractive) {
-      Log() << kFATAL << "Not implemented yet" << Endl;
-      return;
-   }
-
-   bool debug = Log().GetMinType() == kDEBUG;
-
-   if (this->GetArchitectureString() == "GPU") {
-#ifdef R__HAS_TMVAGPU
-      Log() << kINFO << "Start of deep neural network training on GPU." << Endl << Endl;
-#else
-      Log() << kFATAL << "CUDA backend not enabled. Please make sure "
-         "you have CUDA installed and it was successfully "
-         "detected by CMAKE."
-             << Endl;
-      return;
-#endif
-   } else if (this->GetArchitectureString() == "OpenCL") {
-      Log() << kFATAL << "OpenCL backend not yet supported." << Endl;
-      return;
-   } else if (this->GetArchitectureString() == "CPU") {
-#ifdef R__HAS_TMVACPU
-      Log() << kINFO << "Start of deep neural network training on CPU." << Endl << Endl;
-#else
-      Log() << kFATAL << "Multi-core CPU backend not enabled. Please make sure "
-                      "you have a BLAS implementation and it was successfully "
-                      "detected by CMake as well that the imt CMake flag is set."
-            << Endl;
-      return;
-#endif
-   }
-
-/// definitions for CUDA
-#ifdef R__HAS_TMVAGPU // Included only if DNNCUDA flag is set.
-   using Architecture_t = DNN::TCuda<Double_t>;
-#else
-#ifdef R__HAS_TMVACPU // Included only if DNNCPU flag is set.
-   using Architecture_t = DNN::TCpu<Double_t>;
-#else
-   using Architecture_t = DNN::TReference<Double_t>;
-#endif
-#endif
-
-   using Scalar_t = Architecture_t::Scalar_t;
+   
+   using Scalar_t = typename Architecture_t::Scalar_t;
    using DeepNet_t = TMVA::DNN::TDeepNet<Architecture_t>;
    using TensorDataLoader_t = TTensorDataLoader<TMVAInput_t, Architecture_t>;
+
+   bool debug = Log().GetMinType() == kDEBUG;
 
    // Determine the number of training and testing examples
    size_t nTrainingSamples = GetEventCollection(Types::kTraining).size();
@@ -1043,11 +1013,11 @@ void MethodDL::Train()
       //        This should be case if first layer is a Dense 1 and input tensor must be ( 1 x batch_size x input_features )
 
       if (batchDepth != batchSize && batchDepth > 1) {
-         Error("TrainCpu","Given batch depth of %zu (specified in BatchLayout)  should be equal to given batch size %zu",batchDepth,batchSize);
+         Error("Train","Given batch depth of %zu (specified in BatchLayout)  should be equal to given batch size %zu",batchDepth,batchSize);
          return;
       }
       if (batchDepth == 1 && batchSize > 1 && batchSize != batchHeight ) {
-         Error("TrainCpu","Given batch height of %zu (specified in BatchLayout)  should be equal to given batch size %zu",batchHeight,batchSize);
+         Error("Train","Given batch height of %zu (specified in BatchLayout)  should be equal to given batch size %zu",batchHeight,batchSize);
          return;
       }
 
@@ -1061,7 +1031,7 @@ void MethodDL::Train()
       if (batchHeight == batchSize && batchDepth == 1) 
          badLayout |=  ( inputDepth * inputHeight * inputWidth !=  batchWidth);
       if (badLayout) {
-         Error("TrainCpu","Given input layout %zu x %zu x %zu is not compatible with  batch layout %zu x %zu x  %zu ",
+         Error("Train","Given input layout %zu x %zu x %zu is not compatible with  batch layout %zu x %zu x  %zu ",
                inputDepth,inputHeight,inputWidth,batchDepth,batchHeight,batchWidth);
          return;
       }
@@ -1300,6 +1270,62 @@ void MethodDL::Train()
    }  // end loop on training Phase
 
 }
+
+////////////////////////////////////////////////////////////////////////////////
+void MethodDL::Train()
+{
+   if (fInteractive) {
+      Log() << kFATAL << "Not implemented yet" << Endl;
+      return;
+   }
+
+   if (this->GetArchitectureString() == "GPU") {
+#ifdef R__HAS_TMVAGPU
+      Log() << kINFO << "Start of deep neural network training on GPU." << Endl << Endl;
+      TrainDeepNet<DNN::TCuda<Double_t> >(); 
+#else
+      Log() << kFATAL << "CUDA backend not enabled. Please make sure "
+         "you have CUDA installed and it was successfully "
+         "detected by CMAKE."
+             << Endl;
+      return;
+#endif
+   } else if (this->GetArchitectureString() == "OpenCL") {
+      Log() << kFATAL << "OpenCL backend not yet supported." << Endl;
+      return;
+   } else if (this->GetArchitectureString() == "CPU") {
+#ifdef R__HAS_TMVACPU
+      Log() << kINFO << "Start of deep neural network training on CPU." << Endl << Endl;
+      TrainDeepNet<DNN::TCpu<Double_t> >(); 
+#else
+      Log() << kFATAL << "Multi-core CPU backend not enabled. Please make sure "
+                      "you have a BLAS implementation and it was successfully "
+                      "detected by CMake as well that the imt CMake flag is set."
+            << Endl;
+      return;
+#endif
+   } else if (this->GetArchitectureString() == "Reference") {
+      Log() << kINFO << "Start of deep neural network training on Reference architecture" << Endl << Endl;
+      TrainDeepNet<DNN::TReference<Double_t> >(); 
+   }
+   else {
+      Log() << kFATAL << this->GetArchitectureString() << 
+                      " is not  a supported archiectire for TMVA::MethodDL"
+            << Endl;
+   }
+   
+// /// definitions for CUDA
+// #ifdef R__HAS_TMVAGPU // Included only if DNNCUDA flag is set.
+//    using Architecture_t = DNN::TCuda<Double_t>;
+// #else
+// #ifdef R__HAS_TMVACPU // Included only if DNNCPU flag is set.
+//    using Architecture_t = DNN::TCpu<Double_t>;
+// #else
+//    using Architecture_t = DNN::TReference<Double_t>;
+// #endif
+// #endif
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 Double_t MethodDL::GetMvaValue(Double_t * /*errLower*/, Double_t * /*errUpper*/)

--- a/tmva/tmva/src/MethodDL.cxx
+++ b/tmva/tmva/src/MethodDL.cxx
@@ -1094,9 +1094,12 @@ void MethodDL::Train()
          // copy initial weights from fNet to deepnet
          for (size_t i = 0; i < deepNet.GetDepth(); ++i) {
             const auto & nLayer = fNet->GetLayerAt(i); 
-            const auto & dLayer = deepNet.GetLayerAt(i); 
-            dLayer->CopyWeights(nLayer->GetWeights()); 
-            dLayer->CopyBiases(nLayer->GetBiases());
+            const auto & dLayer = deepNet.GetLayerAt(i);
+            // could use a traits for detecting equal architectures
+           // dLayer->CopyWeights(nLayer->GetWeights()); 
+           //  dLayer->CopyBiases(nLayer->GetBiases());
+            Architecture_t::CopyDiffArch(dLayer->GetWeights(), nLayer->GetWeights() );
+            Architecture_t::CopyDiffArch(dLayer->GetBiases(), nLayer->GetBiases() );
          }
       }
 
@@ -1224,8 +1227,10 @@ void MethodDL::Train()
                for (size_t i = 0; i < deepNet.GetDepth(); ++i) {
                   const auto & nLayer = fNet->GetLayerAt(i); 
                   const auto & dLayer = deepNet.GetLayerAt(i); 
-                  nLayer->CopyWeights(dLayer->GetWeights()); 
-                  nLayer->CopyBiases(dLayer->GetBiases());
+                  //nLayer->CopyWeights(dLayer->GetWeights()); 
+                  //nLayer->CopyBiases(dLayer->GetBiases());
+                  ArchitectureImpl_t::CopyDiffArch(nLayer->GetWeights(), dLayer->GetWeights() );
+                  ArchitectureImpl_t::CopyDiffArch(nLayer->GetBiases(), dLayer->GetBiases() );
                   // std::cout << "Weights for layer " << i << std::endl;
                   // for (size_t k = 0; k < dlayer->GetWeights().size(); ++k) 
                   //    dLayer->GetWeightsAt(k).Print(); 


### PR DESCRIPTION
Make now the possibility to select the architecture of MethodDL at runtime
Use for the evaluation of the network only CPU or Standard architecture and not GPU that is not efficient on a per/event base
Add support for copying weights between different architectures