### PR TITLE
[ROOT-9417] Removing obsolete code from TFile (compression algorithm and level of …

### DIFF
--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -3709,11 +3709,7 @@ void TFile::WriteStreamerInfo()
       // Only add the list of rules if we have something to say.
       list.Add(&listOfRules);
    }
-
-   // always write with compression on
-   Int_t compress = fCompress;
-   fCompress = 1;
-
+   
    //free previous StreamerInfo record
    if (fSeekInfo) MakeFree(fSeekInfo,fSeekInfo+fNbytesInfo-1);
    //Create new key
@@ -3723,10 +3719,7 @@ void TFile::WriteStreamerInfo()
    fNbytesInfo = key.GetNbytes();
    SumBuffer(key.GetObjlen());
    key.WriteFile(0);
-
    fClassIndex->fArray[0] = 0;
-   fCompress = compress;
-
    list.RemoveLast(); // remove the listOfRules.
 }
 

--- a/math/mathcore/test/stress/testSMatrix.cxx
+++ b/math/mathcore/test/stress/testSMatrix.cxx
@@ -104,7 +104,7 @@ TYPED_TEST_P(SMatrixTest, TestSMatrix)
       name = name0 + "," + this->GetRepSName() + ">";
       typeName = "ROOT::Math::" + name0 + "," + this->GetRepName32() + ">";
 
-      estSize = this->fNGen * 4 * this->fDim + 10000;
+      estSize = this->fNGen * 4 * this->fDim + 60158;
       scale = 0.1 / std::numeric_limits<double>::epsilon();
       fsize32 = this->fVectorTest.TestWrite(this->v1, typeName);
       EXPECT_TRUE(IsNear(name + " write", fsize32, estSize, scale));

--- a/test/stressMathCore.cxx
+++ b/test/stressMathCore.cxx
@@ -1366,7 +1366,7 @@ int testSMatrix(int ngen, bool testio=false) {
    typeName = "ROOT::Math::"+name0+ "," + Rep::name32()  + ">";
 
 
-   estSize = ngen* 4 * Dim + 10000;
+   estSize = ngen* 4 * Dim + 60158;
    scale = 0.1 / std::numeric_limits<double>::epsilon();
    fsize32 = a.testWrite(v1,typeName);     iret |= a.check(name+" write",fsize32,estSize,scale);
    ir = a.testRead(v1);   iret |= a.check(name+" read",ir,0);


### PR DESCRIPTION
…StreamerInfo should the same as in TFile).
It is looks like it is old code that breaks reading files by older ROOT releases, which were written by 6.13/02  and directly defined compression  algorithm for the files (ZLIB or any other except of default LZ4).