### PR TITLE
[RDF] Go back to jitting with Calc instead of ProcessLine 

### DIFF
--- a/tree/dataframe/src/RDFNodes.cxx
+++ b/tree/dataframe/src/RDFNodes.cxx
@@ -469,7 +469,7 @@ void RLoopManager::CleanUpTask(unsigned int slot)
 void RLoopManager::JitActions()
 {
    auto error = TInterpreter::EErrorCode::kNoError;
-   gInterpreter->ProcessLine(fToJit.c_str(), &error);
+   gInterpreter->Calc(fToJit.c_str(), &error);
    if (TInterpreter::EErrorCode::kNoError != error) {
       std::string exceptionText =
          "An error occurred while jitting. The lines above might indicate the cause of the crash\n";


### PR DESCRIPTION
Revert "[TDF][TO REVERT] Use ProcessLine instead of Calc for jitting"
This reverts commit 2859675.