### PR TITLE
[RDF] Fix inconsistency in RDF::Snapshot interfaces for jitted calls

### DIFF
--- a/tree/dataframe/inc/ROOT/RDFInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterface.hxx
@@ -464,6 +464,25 @@ public:
    }
    // clang-format on
 
+   // clang-format off
+   ////////////////////////////////////////////////////////////////////////////
+   /// \brief Save selected columns to disk, in a new TTree `treename` in file `filename`.
+   /// \param[in] treename The name of the output TTree
+   /// \param[in] filename The name of the output TFile
+   /// \param[in] columnList The list of names of the columns/branches to be written
+   /// \param[in] options RSnapshotOptions struct with extra options to pass to TFile and TTree
+   ///
+   /// This function returns a `RDataFrame` built with the output tree as a source.
+   /// The types of the columns are automatically inferred and do not need to be specified.
+   RResultPtr<RInterface<RLoopManager>> Snapshot(std::string_view treename, std::string_view filename,
+                                                 std::initializer_list<std::string> columnList,
+                                                 const RSnapshotOptions &options = RSnapshotOptions())
+   {
+      ColumnNames_t selectedColumns(columnList);
+      return Snapshot(treename, filename, selectedColumns, options);
+   }
+   // clang-format on
+
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Save selected columns in memory
    /// \param[in] columns to be cached in memory

--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -15,8 +15,6 @@
 #include "TChain.h"
 #include "TDirectory.h"
 
-;
-
 // clang-format off
 /**
 * \class ROOT::RDataFrame

--- a/tree/dataframe/test/dataframe_snapshot.cxx
+++ b/tree/dataframe/test/dataframe_snapshot.cxx
@@ -103,6 +103,17 @@ const std::vector<std::string> RDFSnapshotArrays::kFileNames = {"test_snapshotar
 
 /********* SINGLE THREAD TESTS ***********/
 
+TEST_F(RDFSnapshot, SnapshotCallAmbiguities)
+{
+   auto filename = "Snapshot_interface.root";
+
+   tdf.Snapshot("t", filename, "an.*");
+   tdf.Snapshot("t", filename, {"ans"});
+   tdf.Snapshot("t", filename, {{"ans"}});
+
+   gSystem->Unlink(filename);
+}
+
 // Test for ROOT-9210
 TEST_F(RDFSnapshot, Snapshot_aliases)
 {


### PR DESCRIPTION
now Snapshot accepts to identify columns:
- A regex as a string_view
- A vector<string>
- A initializer_list<string>

This allows users to invoke it as follows:
1. tdf.Snapshot("t", filename, "an*");
2. tdf.Snapshot("t", filename, {"ans"});
3. tdf.Snapshot("t", filename, {{"ans"}});

Before this change, 2. did not compile because of the ambiguity.