### PR TITLE
Optimize call to GetBasket(fWriteBasket)

### DIFF
--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -821,7 +821,7 @@ Int_t TBranch::FillImpl(ROOT::Internal::TBranchIMTHelper *imtHelper)
       return 0;
    }
 
-   TBasket* basket = GetBasket(fWriteBasket);
+   TBasket* basket = (TBasket*)fBaskets.UncheckedAt(fWriteBasket);
    if (!basket) {
       basket = fTree->CreateBasket(this); //  create a new basket
       if (!basket) return 0;


### PR DESCRIPTION
According to my benchmarks with gcc 8.1, it brings ~3% performance improvement in the serialization of floats.