### PR TITLE
[DF] Misc coverity fixes

### DIFF
--- a/tree/dataframe/inc/ROOT/RDFInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterface.hxx
@@ -790,7 +790,7 @@ public:
    template <typename V = RDFDetail::TInferType, typename W = RDFDetail::TInferType>
    RResultPtr<::TH1D> Histo1D(const TH1DModel &model, std::string_view vName, std::string_view wName)
    {
-      auto columnViews = {vName, wName};
+      const std::vector<std::string_view> columnViews = {vName, wName};
       const auto userColumns = RDFInternal::AtLeastOneEmptyString(columnViews)
                                   ? ColumnNames_t()
                                   : ColumnNames_t(columnViews.begin(), columnViews.end());
@@ -857,7 +857,7 @@ public:
       if (!RDFInternal::HistoUtils<::TH2D>::HasAxisLimits(*h)) {
          throw std::runtime_error("2D histograms with no axes limits are not supported yet.");
       }
-      auto columnViews = {v1Name, v2Name};
+      const std::vector<std::string_view> columnViews = {v1Name, v2Name};
       const auto userColumns = RDFInternal::AtLeastOneEmptyString(columnViews)
                                   ? ColumnNames_t()
                                   : ColumnNames_t(columnViews.begin(), columnViews.end());
@@ -890,7 +890,7 @@ public:
       if (!RDFInternal::HistoUtils<::TH2D>::HasAxisLimits(*h)) {
          throw std::runtime_error("2D histograms with no axes limits are not supported yet.");
       }
-      auto columnViews = {v1Name, v2Name, wName};
+      const std::vector<std::string_view> columnViews = {v1Name, v2Name, wName};
       const auto userColumns = RDFInternal::AtLeastOneEmptyString(columnViews)
                                   ? ColumnNames_t()
                                   : ColumnNames_t(columnViews.begin(), columnViews.end());
@@ -929,7 +929,7 @@ public:
       if (!RDFInternal::HistoUtils<::TH3D>::HasAxisLimits(*h)) {
          throw std::runtime_error("3D histograms with no axes limits are not supported yet.");
       }
-      auto columnViews = {v1Name, v2Name, v3Name};
+      const std::vector<std::string_view> columnViews = {v1Name, v2Name, v3Name};
       const auto userColumns = RDFInternal::AtLeastOneEmptyString(columnViews)
                                   ? ColumnNames_t()
                                   : ColumnNames_t(columnViews.begin(), columnViews.end());
@@ -964,7 +964,7 @@ public:
       if (!RDFInternal::HistoUtils<::TH3D>::HasAxisLimits(*h)) {
          throw std::runtime_error("3D histograms with no axes limits are not supported yet.");
       }
-      auto columnViews = {v1Name, v2Name, v3Name, wName};
+      const std::vector<std::string_view> columnViews = {v1Name, v2Name, v3Name, wName};
       const auto userColumns = RDFInternal::AtLeastOneEmptyString(columnViews)
                                   ? ColumnNames_t()
                                   : ColumnNames_t(columnViews.begin(), columnViews.end());
@@ -1001,7 +1001,7 @@ public:
       if (!RDFInternal::HistoUtils<::TProfile>::HasAxisLimits(*h)) {
          throw std::runtime_error("Profiles with no axes limits are not supported yet.");
       }
-      auto columnViews = {v1Name, v2Name};
+      const std::vector<std::string_view> columnViews = {v1Name, v2Name};
       const auto userColumns = RDFInternal::AtLeastOneEmptyString(columnViews)
                                   ? ColumnNames_t()
                                   : ColumnNames_t(columnViews.begin(), columnViews.end());
@@ -1035,7 +1035,7 @@ public:
       if (!RDFInternal::HistoUtils<::TProfile>::HasAxisLimits(*h)) {
          throw std::runtime_error("Profile histograms with no axes limits are not supported yet.");
       }
-      auto columnViews = {v1Name, v2Name, wName};
+      const std::vector<std::string_view> columnViews = {v1Name, v2Name, wName};
       const auto userColumns = RDFInternal::AtLeastOneEmptyString(columnViews)
                                   ? ColumnNames_t()
                                   : ColumnNames_t(columnViews.begin(), columnViews.end());
@@ -1075,7 +1075,7 @@ public:
       if (!RDFInternal::HistoUtils<::TProfile2D>::HasAxisLimits(*h)) {
          throw std::runtime_error("2D profiles with no axes limits are not supported yet.");
       }
-      auto columnViews = {v1Name, v2Name, v3Name};
+      const std::vector<std::string_view> columnViews = {v1Name, v2Name, v3Name};
       const auto userColumns = RDFInternal::AtLeastOneEmptyString(columnViews)
                                   ? ColumnNames_t()
                                   : ColumnNames_t(columnViews.begin(), columnViews.end());
@@ -1111,7 +1111,7 @@ public:
       if (!RDFInternal::HistoUtils<::TProfile2D>::HasAxisLimits(*h)) {
          throw std::runtime_error("2D profiles with no axes limits are not supported yet.");
       }
-      auto columnViews = {v1Name, v2Name, v3Name, wName};
+      const std::vector<std::string_view> columnViews = {v1Name, v2Name, v3Name, wName};
       const auto userColumns = RDFInternal::AtLeastOneEmptyString(columnViews)
                                   ? ColumnNames_t()
                                   : ColumnNames_t(columnViews.begin(), columnViews.end());

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -119,6 +119,8 @@ void GetBranchNamesImpl(TTree &t, std::set<std::string> &bNamesReg, ColumnNames_
 
             bool dotIsImplied = false;
             auto be = dynamic_cast<TBranchElement *>(b);
+            if (!be)
+               throw std::runtime_error("GetBranchNames: unsupported branch type");
             // TClonesArray (3) and STL collection (4)
             if (be->GetType() == 3 || be->GetType() == 4)
                dotIsImplied = true;


### PR DESCRIPTION
@etejedor @pcanal is it true that a `TBranch` is either that or a `TBranchElement` in our case?

better said, here's what we do:

```c++
const auto branches = t.GetListOfBranches();
for (auto b : *branches) {
   TBranch *branch = static_cast<TBranch *>(b);
   if (branch->IsA() == TBranch::Class()) {
        /* ... */
   } else {
      auto be = static_cast<TBranchElement *>(b);
        /* ... */
   }
}
```

Are these the only two possible cases?