### PR TITLE
[cxxmodules] Autoload less libraries

### DIFF
--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -3383,11 +3383,6 @@ void ROOT::TMetaUtils::GetFullyQualifiedTypeName(std::string &typenamestr,
                                                  const clang::QualType &qtype,
                                                  const cling::Interpreter &interpreter)
 {
-   // We need this barrior because GetFullyQualifiedTypeName is triggering deserialization
-   // This calling the same name function GetFullyQualifiedTypeName, but this should stay here because
-   // callee doesn't have an interpreter pointer
-   cling::Interpreter::PushTransactionRAII RAII(const_cast<cling::Interpreter*>(&interpreter));
-
    GetFullyQualifiedTypeName(typenamestr,
                              qtype,
                              interpreter.getCI()->getASTContext());

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -5873,88 +5873,111 @@ static void* LazyFunctionCreatorAutoloadForModule(const std::string& mangled_nam
    using namespace llvm::sys::path;
    using namespace llvm::sys::fs;
 
-   static constexpr std::hash<std::string> hash_fn;
-   // size_t is a hashed mangled_name and libs[(uint8_t)mname_lib_table.second] = library's
-   // name in string.
-   static std::unordered_map<size_t, uint8_t> mname_lib_table;
-   static std::vector<std::string> libs;
-   // Initialize library table at first run
-   static bool fFirstRun = true;
-
    R__LOCKGUARD(gInterpreterMutex);
 
-   // Initialize the table
-   if (fFirstRun) {
-      clang::Preprocessor &PP = fInterpreter->getCI()->getPreprocessor();
-      const HeaderSearchOptions &HSOpts = PP.getHeaderSearchInfo().getHeaderSearchOpts();
-      auto ModulePaths(HSOpts.PrebuiltModulePaths);
+   static constexpr std::hash<std::string> hash_fn;
+   // size_t is a hashed mangled_name and libs[(uint16_t)hashToLibNameIndex.second] = library's
+   // name in string.
+   static std::unordered_map<size_t, uint16_t> hashToLibNameIndex;
+   // vector of library which are in table, with full path
+   static std::vector<std::string> LoadableLibs;
 
-      // sort and eliminate dupicate path
-      std::sort(ModulePaths.begin(), ModulePaths.end());
-      auto last = std::unique(ModulePaths.begin(), ModulePaths.end());
-      ModulePaths.erase(last, ModulePaths.end());
-
-      cling::DynamicLibraryManager* dyLibManager = fInterpreter->getDynamicLibraryManager();
-
-      int cur_lib = 0;
-      // Take path here eg. "/home/foo/module-release/lib/"
-      for (auto Path : ModulePaths) {
-         StringRef DirPath(Path);
-         if (DirPath.empty() || !is_directory(DirPath) || Path == ".")
-            continue;
-
-         // Check this not a random system directory (should contain pcm)
-         std::error_code EC;
-         bool is_build = false;
-         for (llvm::sys::fs::directory_iterator DirIt(DirPath, EC), DirEnd;
-               DirIt != DirEnd && !EC; DirIt.increment(EC)) {
-            std::string FileName(DirIt->path());
-            if (extension(FileName) == ".pcm") {
-               is_build = true;
-               break;
-            }
-         }
-
-         if (!is_build)
-            continue;
-
-         // Iterate over files under this path. We want to get each ".so" files
-         for (llvm::sys::fs::directory_iterator DirIt(DirPath, EC), DirEnd;
-               DirIt != DirEnd && !EC; DirIt.increment(EC)) {
-            std::string LibName(DirIt->path());
-            if (llvm::sys::fs::is_directory(LibName) || extension(LibName) != ".so")
-               continue;
-
-            // TCling::IsLoaded is incredibly slow!
-            if (dyLibManager->isLibraryLoaded(LibName.c_str()))
-               continue;
-
-            libs.push_back(LibName);
-            auto SoFile = ObjectFile::createObjectFile(LibName);
-            if (SoFile) {
-               auto RealSoFile = SoFile.get().getBinary();
-               auto Symbols = RealSoFile->symbols();
-               for (auto S : Symbols) {
-                  // DO NOT insert to table if symbol was weak or undefined
-                  if (S.getFlags() == SymbolRef::SF_Weak || S.getFlags() == SymbolRef::SF_Undefined) continue;
-
-                  // Put into map
-                  mname_lib_table.insert(std::make_pair(hash_fn(S.getName().get()), cur_lib));
-               }
-            }
-            cur_lib++;
-         }
-      }
-      fFirstRun = false;
-   }
-
-   auto key = mname_lib_table.find(hash_fn(mangled_name));
-   if (key != mname_lib_table.end()) {
-      std::string LoadedLibName = libs[key->second];
+   // If library information was already loaded to the table, just search and return that.
+   auto iter = hashToLibNameIndex.find(hash_fn(mangled_name));
+   if (iter != hashToLibNameIndex.end()) {
+      std::string LoadedLibName = LoadableLibs[iter->second];
       if (!LoadedLibName.empty() && (gSystem->Load(LoadedLibName.c_str(), "", false) < 0))
          Error("LazyFunctionCreatorAutoloadForModule", "Failed to load library %s", LoadedLibName.c_str());
+      void* addr = llvm::sys::DynamicLibrary::SearchForAddressOfSymbol(mangled_name.c_str());
+      return addr;
    }
 
+   static const clang::Preprocessor &PP = fInterpreter->getCI()->getPreprocessor();
+   static const HeaderSearchOptions &HSOpts = PP.getHeaderSearchInfo().getHeaderSearchOpts();
+   static const auto ModulePaths(HSOpts.PrebuiltModulePaths);
+   static cling::DynamicLibraryManager* dyLibManager = fInterpreter->getDynamicLibraryManager();
+
+   // Store the information of path so that we don't have to iterate over the same path again and again.
+   static std::unordered_set<std::string> AlreadyLookedPath;
+   // This is different from LoadableLibs. AlreadyLookedLibraries contains filename like "libfoo.so", so that
+   // we can avoid the same library in different path loaded twice.
+   static std::unordered_set<std::string> AlreadyLookedLibraries;
+   static int cur_lib = 0;
+
+   // Take path here eg. "/home/foo/module-release/lib/"
+   for (auto Path : ModulePaths) {
+      // Already searched?
+      if (AlreadyLookedPath.find(Path) != AlreadyLookedPath.end())
+         continue;
+
+      StringRef DirPath(Path);
+      if (!is_directory(DirPath)) {
+         AlreadyLookedPath.insert(Path);
+         continue;
+      }
+
+      // We don't want to do directory_iterator several times because it contains HDD access
+      std::vector<std::string> Libraries;
+
+      // Check this not a random system directory (should contain pcm)
+      std::error_code EC;
+      bool dirHasPCM = false;
+      for (llvm::sys::fs::directory_iterator DirIt(DirPath, EC), DirEnd;
+            DirIt != DirEnd && !EC; DirIt.increment(EC)) {
+         std::string FileName(DirIt->path());
+         if (extension(FileName) == ".pcm")
+            dirHasPCM = true;
+
+         if (!llvm::sys::fs::is_directory(FileName) && extension(FileName) == ".so")
+            Libraries.push_back(FileName);
+      }
+
+      if (!dirHasPCM) {
+         AlreadyLookedPath.insert(Path);
+         continue;
+      }
+
+      std::string lib_found = "";
+
+      // Iterate over files under this path. We want to get each ".so" files
+      for (std::string LibName : Libraries) {
+         // Is it already searched?
+         if (AlreadyLookedLibraries.find(filename(LibName)) != AlreadyLookedLibraries.end())
+            continue;
+
+         AlreadyLookedLibraries.insert(filename(LibName));
+
+         // TCling::IsLoaded is incredibly slow!
+         if (dyLibManager->isLibraryLoaded(LibName.c_str()))
+            continue;
+
+         LoadableLibs.push_back(LibName);
+         auto SoFile = ObjectFile::createObjectFile(LibName);
+         if (SoFile) {
+            auto RealSoFile = SoFile.get().getBinary();
+            auto Symbols = RealSoFile->symbols();
+            for (auto S : Symbols) {
+               // DO NOT insert to table if symbol was weak or undefined
+               if (S.getFlags() == SymbolRef::SF_Weak || S.getFlags() == SymbolRef::SF_Undefined) continue;
+
+               // Put into map
+               hashToLibNameIndex.insert(std::make_pair(hash_fn(S.getName().get()), cur_lib));
+               if (S.getName().get() == mangled_name)
+                  lib_found = LibName;
+            }
+         }
+         cur_lib++;
+         if (!lib_found.empty()) {
+            if (gSystem->Load(lib_found.c_str(), "", false) < 0)
+               Error("LazyFunctionCreatorAutoloadForModule", "Failed to load library %s", lib_found.c_str());
+            void* addr = llvm::sys::DynamicLibrary::SearchForAddressOfSymbol(mangled_name.c_str());
+            return addr;
+         }
+      }
+      AlreadyLookedPath.insert(Path);
+   }
+
+   // This means there is not library containing this mangled_name!
    void* addr = llvm::sys::DynamicLibrary::SearchForAddressOfSymbol(mangled_name.c_str());
    return addr;
 }

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -5949,9 +5949,8 @@ static void* LazyFunctionCreatorAutoloadForModule(const std::string& mangled_nam
 /// Autoload a library based on a missing symbol.
 
 void* TCling::LazyFunctionCreatorAutoload(const std::string& mangled_name) {
-#ifdef R__USE_CXXMODULES
-   return LazyFunctionCreatorAutoloadForModule(mangled_name, fInterpreter);
-#endif
+   if (fInterpreter->getCI()->getLangOpts().Modules)
+      return LazyFunctionCreatorAutoloadForModule(mangled_name, fInterpreter);
 
    // First see whether the symbol is in the library that we are currently
    // loading. It will have access to the symbols of its dependent libraries,

--- a/core/metacling/src/TClingCallbacks.cxx
+++ b/core/metacling/src/TClingCallbacks.cxx
@@ -50,7 +50,6 @@ extern "C" {
    Decl* TCling__GetObjectDecl(TObject *obj);
    int TCling__AutoLoadCallback(const char* className);
    int TCling__AutoParseCallback(const char* className);
-   void TCling__AutoLoadLibraryForModules(const char* StemName);
    const char* TCling__GetClassSharedLibs(const char* className);
 //    int TCling__IsAutoLoadNamespaceCandidate(const char* name);
    int TCling__IsAutoLoadNamespaceCandidate(const clang::NamespaceDecl* name);
@@ -748,29 +747,6 @@ void TClingCallbacks::TransactionCommitted(const Transaction &T) {
       Initialize();
 
    TCling__UpdateListsOnCommitted(T, m_Interpreter);
-}
-
-// Collect modules and put them into fPendingCxxModules at first run. Interpreter is not yet initialized at first run
-// but we need to use interpreter services when loading libraries.
-void TClingCallbacks::beforeExecuteTransaction(const Transaction &T) {
-
-  const std::vector<clang::Module*> &modules = T.getClangModules();
-
-  if (fFirstRun) {
-    for (auto M : modules)
-      fPendingCxxModules.push_back(M);
-    return;
-  }
-
-  if (!fPendingCxxModules.empty()) {
-    for (auto M : fPendingCxxModules)
-      TCling__AutoLoadLibraryForModules(M->Name.c_str());
-    fPendingCxxModules.clear();
-    return;
-  }
-
-  for (auto M : modules)
-    TCling__AutoLoadLibraryForModules(M->Name.c_str());
 }
 
 // The callback is used to update the list of globals in ROOT.

--- a/core/metacling/src/TClingCallbacks.h
+++ b/core/metacling/src/TClingCallbacks.h
@@ -12,7 +12,6 @@
 #include "cling/Interpreter/InterpreterCallbacks.h"
 
 #include <stack>
-#include <vector>
 
 namespace clang {
    class Decl;
@@ -28,7 +27,6 @@ namespace clang {
 namespace cling {
    class Interpreter;
    class Transaction;
-   class Module;
 }
 
 namespace llvm {
@@ -47,9 +45,6 @@ private:
    bool fIsAutoParsingSuspended;
    bool fPPOldFlag;
    bool fPPChanged;
-   // This vector holds a clang cxxmodules where corresponding library should be loaded in Transaction
-   // afterwards.
-   std::vector<clang::Module*> fPendingCxxModules;
 public:
    TClingCallbacks(cling::Interpreter* interp);
 
@@ -87,8 +82,6 @@ public:
    // The callback is used to update the list of globals in ROOT.
    //
    virtual void TransactionCommitted(const cling::Transaction &T);
-
-   virtual void beforeExecuteTransaction(const cling::Transaction &T);
 
    // The callback is used to update the list of globals in ROOT.
    //

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -1267,10 +1267,6 @@ const char *TClingClassInfo::Name() const
    if (const NamedDecl* ND = llvm::dyn_cast<NamedDecl>(fDecl)) {
       PrintingPolicy Policy(fDecl->getASTContext().getPrintingPolicy());
       llvm::raw_string_ostream stream(buf);
-
-      // getNameForDiagnostic can trigger deserialization
-      cling::Interpreter::PushTransactionRAII RAII(fInterp);
-
       ND->getNameForDiagnostic(stream, Policy, /*Qualified=*/false);
    }
    return buf.c_str();

--- a/core/metacling/src/TClingDataMemberInfo.cxx
+++ b/core/metacling/src/TClingDataMemberInfo.cxx
@@ -308,9 +308,6 @@ long TClingDataMemberInfo::Offset()
    const Decl *D = GetDecl();
    ASTContext& C = D->getASTContext();
    if (const FieldDecl *FldD = dyn_cast<FieldDecl>(D)) {
-      // getASTRecordLayout can trigger deserialization
-      cling::Interpreter::PushTransactionRAII RAII(fInterp);
-
       // The current member is a non-static data member.
       const clang::RecordDecl *RD = FldD->getParent();
       const clang::ASTRecordLayout &Layout = C.getASTRecordLayout(RD);

--- a/core/metacling/src/TClingTypeInfo.cxx
+++ b/core/metacling/src/TClingTypeInfo.cxx
@@ -168,10 +168,6 @@ long TClingTypeInfo::Property() const
          // Note: Now we have class, struct, union only.
          const clang::CXXRecordDecl *CRD =
             llvm::dyn_cast<clang::CXXRecordDecl>(TD);
-
-         // isAbstract can trigger deserialization
-         cling::Interpreter::PushTransactionRAII RAII(fInterp);
-
          if (CRD->isClass()) {
             property |= kIsClass;
          }

--- a/interpreter/cling/include/cling/Interpreter/InterpreterCallbacks.h
+++ b/interpreter/cling/include/cling/Interpreter/InterpreterCallbacks.h
@@ -132,13 +132,6 @@ namespace cling {
     ///
     virtual void TransactionCommitted(const Transaction&) {}
 
-    ///\brief This callback is invoked before a transaction is executed.
-    /// This event happens after a transaction was committed and LLVM IR was produced.
-    ///
-    ///\param[in] - The transaction to be executed.
-    ///
-    virtual void beforeExecuteTransaction(const Transaction&) {}
-
     ///\brief This callback is invoked whenever interpreter has reverted a
     /// transaction that has been fully committed.
     ///

--- a/interpreter/cling/include/cling/Interpreter/Transaction.h
+++ b/interpreter/cling/include/cling/Interpreter/Transaction.h
@@ -31,7 +31,6 @@ namespace clang {
   class Preprocessor;
   struct PrintingPolicy;
   class Sema;
-  class Module;
 }
 
 namespace llvm {
@@ -115,11 +114,6 @@ namespace cling {
     // init.
     typedef llvm::SmallVector<DelayCallInfo, 64> DeclQueue;
     typedef llvm::SmallVector<Transaction*, 2> NestedTransactions;
-
-    ///\brief The list of cxxmodules, which is collected by DeserializationListener
-    /// and will be used to load corresponding libraries.
-    ///
-    std::vector<clang::Module*> m_CxxModules;
 
     ///\brief All seen declarations, except the deserialized ones.
     /// If we collect the declarations by walking the clang::DeclContext we
@@ -272,17 +266,6 @@ namespace cling {
       if (hasNestedTransactions())
         return m_NestedTransactions->rend();
       return const_reverse_nested_iterator(0);
-    }
-
-    void addClangModule(clang::Module* M) {
-      assert(M && "addClangModules: passed clang::Module pointer is null");
-
-      if (std::find(m_CxxModules.rbegin(), m_CxxModules.rend(), M) == m_CxxModules.rend())
-        m_CxxModules.push_back(M);
-    }
-
-    const std::vector<clang::Module*> &getClangModules() const {
-      return m_CxxModules;
     }
 
     /// Macro iteration

--- a/interpreter/cling/lib/Interpreter/DeclCollector.cpp
+++ b/interpreter/cling/lib/Interpreter/DeclCollector.cpp
@@ -321,17 +321,4 @@ namespace cling {
     m_Consumer->HandleCXXStaticMemberVarInstantiation(D);
   }
 
-  void DeclCollector::DeclRead(clang::serialization::DeclID, const clang::Decl *D) {
-    assertHasTransaction(m_CurTransaction);
-
-    assert(D && "Decl doesn't exist!");
-    if (!D->hasOwningModule()) return;
-
-    clang::Module *M = D->getOwningModule();
-    M = M->getTopLevelModule();
-
-    // Add interesting module to Transaction's m_cxxmodules; Corresponding library will be loaded.
-    m_CurTransaction->addClangModule(M);
-  }
-
 } // namespace cling

--- a/interpreter/cling/lib/Interpreter/DeclCollector.h
+++ b/interpreter/cling/lib/Interpreter/DeclCollector.h
@@ -11,7 +11,6 @@
 #define CLING_DECL_COLLECTOR_H
 
 #include "clang/AST/ASTConsumer.h"
-#include "clang/Serialization/ASTDeserializationListener.h"
 
 #include "ASTTransformer.h"
 
@@ -25,7 +24,6 @@ namespace clang {
   class DeclGroupRef;
   class Preprocessor;
   class Token;
-  class Module;
 }
 
 namespace cling {
@@ -42,7 +40,7 @@ namespace cling {
   /// cling::DeclCollector is responsible for appending all the declarations
   /// seen by clang.
   ///
-  class DeclCollector : public clang::ASTConsumer , public clang::ASTDeserializationListener {
+  class DeclCollector : public clang::ASTConsumer {
     /// \brief PPCallbacks overrides/ Macro support
     class PPAdapter;
 
@@ -118,11 +116,6 @@ namespace cling {
 
     // dyn_cast/isa support
     static bool classof(const clang::ASTConsumer*) { return true; }
-    static bool classof(const clang::ASTDeserializationListener*) { return true; }
-
-    ///\brief ASTDeserializationListener function which gets callback when a decl is deserialized
-    void DeclRead(clang::serialization::DeclID, const clang::Decl *D) final;
-
   };
 } // namespace cling
 

--- a/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
@@ -44,7 +44,6 @@
 #include "clang/Sema/Sema.h"
 #include "clang/Sema/SemaDiagnostic.h"
 #include "clang/Serialization/ASTWriter.h"
-#include "clang/Serialization/ASTReader.h"
 
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
@@ -226,13 +225,6 @@ namespace cling {
     Transaction* CurT = beginTransaction(CO);
     Preprocessor& PP = m_CI->getPreprocessor();
     DiagnosticsEngine& Diags = m_CI->getSema().getDiagnostics();
-
-    ASTReader* Reader = m_CI->getModuleManager().get();
-    assert(isa<ASTDeserializationListener>(m_Consumer));
-    ASTDeserializationListener* Listener = cast<ASTDeserializationListener>(m_Consumer);
-    // FIXME: We should create a multiplexing deserialization listener if there is one already attached.
-    if (Reader && Listener && !Reader->getDeserializationListener())
-      Reader->setDeserializationListener(Listener);
 
     // Pull in PCH.
     const std::string& PCHFileName

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -1529,9 +1529,6 @@ namespace cling {
     assert(!isInSyntaxOnlyMode() && "Running on what?");
     assert(T.getState() == Transaction::kCommitted && "Must be committed");
 
-    if (InterpreterCallbacks* callbacks = getCallbacks())
-      callbacks->beforeExecuteTransaction(T);
-
     const std::shared_ptr<llvm::Module>& M = T.getModule();
     if (!M)
       return Interpreter::kExeNoModule;

--- a/interpreter/cling/lib/Interpreter/LookupHelper.cpp
+++ b/interpreter/cling/lib/Interpreter/LookupHelper.cpp
@@ -1452,9 +1452,9 @@ namespace cling {
 
     DigestArgsInput inputEval;
     llvm::SmallVector<Expr*, 4> GivenArgs;
-    Interpreter::PushTransactionRAII pushedT(Interp);
     if (!inputEval(GivenArgs,funcArgs,diagOnOff,P,Interp)) return 0;
 
+    Interpreter::PushTransactionRAII pushedT(Interp);
     return findFunction(foundDC,
                         funcName, GivenArgs, objectIsConst,
                         Context, Interp, functionSelector,

--- a/interpreter/cling/lib/Interpreter/MultiplexInterpreterCallbacks.h
+++ b/interpreter/cling/lib/Interpreter/MultiplexInterpreterCallbacks.h
@@ -77,12 +77,6 @@ namespace cling {
        }
      }
 
-     void beforeExecuteTransaction(const Transaction& T) override {
-       for (auto&& cb : m_Callbacks) {
-         cb->beforeExecuteTransaction(T);
-       }
-     }
-
      void TransactionUnloaded(const Transaction& T) override {
        for (auto&& cb : m_Callbacks) {
          cb->TransactionUnloaded(T);

--- a/interpreter/llvm/src/tools/clang/include/clang/Serialization/ASTReader.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/Serialization/ASTReader.h
@@ -1555,10 +1555,6 @@ public:
   void setDeserializationListener(ASTDeserializationListener *Listener,
                                   bool TakeOwnership = false);
 
-  ASTDeserializationListener *getDeserializationListener() {
-    return DeserializationListener;
-  };
-
   /// \brief Determine whether this AST reader has a global index.
   bool hasGlobalIndex() const { return (bool)GlobalIndex; }
 


### PR DESCRIPTION
In previous allmodules&autoloading patch, we used callback from
DeserializationListener to get Decl and loaded corresponding libraries.
It worked, but the performance was bad because ROOT was loading
excessive libraries.

In this patch, we use TCling::LazyFunctionCreatorAutoloadForModule. This
function gets callback when "mangled_name" was not found in loaded
libraries thus we have to the load corresponding library and lookup
again.

I used unordered_map to store mangled identifier and library pair. I'm
doing an optimization by hashing mangled name and storing library not by
name but by uint8 and hold uint8-name information in another vector.
Also tried std::map but unorderd_map was more performant. There are
better hash table like:
https://probablydance.com/2018/05/28/a-new-fast-hash-table-in-response-to-googles-new-fast-hash-table/
we can try to use them if this part gets crucial.

With this patch:
```
Processing tutorials/hsimple.C...
hsimple   : Real Time =   0.04 seconds Cpu Time =   0.03 seconds
(TFile *) 0x562b37a14fe0
Processing /home/yuka/CERN/ROOT/memory.C...
cpu  time = 0.362307 seconds
sys  time = 0.039741 seconds
res  memory = 278.215 Mbytes
vir  memory = 448.973 Mbytes
```

W/o this patch:
```
Processing tutorials/hsimple.C...
hsimple   : Real Time =   0.08 seconds Cpu Time =   0.07 seconds
(TFile *) 0x5563018a1d30
Processing /home/yuka/CERN/ROOT/memory.C...
cpu  time = 1.524314 seconds
sys  time = 0.157075 seconds
res  memory = 546.867 Mbytes
vir  memory = 895.184 Mbytes
```

So it improves time by 4x times and memory by 2x.