### PR TITLE
[PyROOT] Pretty printing feature using cling::printValue

### DIFF
--- a/bindings/pyroot/test/CMakeLists.txt
+++ b/bindings/pyroot/test/CMakeLists.txt
@@ -3,5 +3,6 @@ ROOT_ADD_PYUNITTEST(pyroot_list_initialization list_initialization.py)
 if(NUMPY_FOUND)
     ROOT_ADD_PYUNITTEST(pyroot_array_interface array_interface.py)
     ROOT_ADD_PYUNITTEST(pyroot_ttree_asmatrix ttree_asmatrix.py)
+    ROOT_ADD_PYUNITTEST(pyroot_pretty_printing pretty_printing.py)
 endif()
 

--- a/bindings/pyroot/test/pretty_printing.py
+++ b/bindings/pyroot/test/pretty_printing.py
@@ -1,0 +1,55 @@
+import unittest
+import ROOT
+
+
+class PrettyPrinting(unittest.TestCase):
+    # Helpers
+    def _print(self, obj):
+        print("print({}) -> {}".format(obj.__cppname__, obj))
+
+    # Tests
+    def test_RVec(self):
+        x = ROOT.VecOps.RVec("float")(4)
+        for i in range(x.size()):
+            x[i] = i
+        self._print(x)
+        self.assertIn("{ 0", x.__str__())
+
+    def test_STLVector(self):
+        x = ROOT.std.vector("float")(4)
+        for i in range(x.size()):
+            x[i] = i
+        self._print(x)
+        self.assertIn("{ 0", x.__str__())
+
+    def test_STLMap(self):
+        x = ROOT.std.map("string", "int")()
+        for i, s in enumerate(["foo", "bar"]):
+            x[s] = i
+        self._print(x)
+        self.assertIn("foo", x.__str__())
+        self.assertIn("bar", x.__str__())
+
+    def test_STLPair(self):
+        x = ROOT.std.pair("string", "int")("foo", 42)
+        self._print(x)
+        self.assertIn("foo", x.__str__())
+
+    def test_TNamed(self):
+        x = ROOT.TNamed("name", "title")
+        self._print(x)
+        self.assertEqual("Name: name Title: title", x.__str__())
+
+    def test_TObject(self):
+        x = ROOT.TObject()
+        self._print(x)
+        self.assertEqual("Name: TObject Title: Basic ROOT object", x.__str__())
+
+    def test_TH1F(self):
+        x = ROOT.TH1F("name", "title", 10, 0, 1)
+        self._print(x)
+        self.assertEqual("Name: name Title: title NbinsX: 10", x.__str__())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
~~TBD: Pretty-printing feature for RVec~~
Pretty printing feature for PyROOT!

**ROOT.VecOps.RVec:**
```python
>>> v = ROOT.ROOT.VecOps.RVec('float')(3)
>>> for i in range(3): v[i] = i
>>> print(v)
{ 0, 1, 2 }
```

**std.vector:**
```python
>>> v = ROOT.std.vector('float')(5)
>>> for i in range(len(v)): v[i] = i
>>> print(v)
{ 0.00000f, 1.00000f, 2.00000f, 3.00000f, 4.00000f }
```

**std.map:**
```python
>>> m = ROOT.std.map("string", "int")()
>>> m["foo"] = 42
>>> m["bar"] = -1
>>> print(m)
{ "bar" => -1, "foo" => 42 }
```

**ROOT.RDataFrame:**
```python
>>> f = ROOT.TFile("test.root", "RECREATE")
>>> tree = ROOT.TTree("foo", "bar")
>>> [do sth with the tree ...]
>>> df = ROOT.RDataFrame("foo", "test.root")
>>> print(df)
A data frame built on top of the foo dataset.
```

**Recursive pretty-printing:**
```python
>>> v = ROOT.std.vector("vector<float>")(2)
>>> v[0].push_back(1)
>>> v[0].push_back(2)
>>> v[1].push_back(-3)
>>> v[1].push_back(-4)
>>> print(v)
{ { 1.00000f, 2.00000f }, { -3.00000f, -4.00000f } }
```

**Uncommon types in STL containers:**
```python
>>> v = ROOT.std.vector("TObject")(2)
>>> v[0] = ROOT.TObject()
>>> v[1] = ROOT.TObject()
>>> print(v)
{ @0x3fbb980, @0x3fbb990 }
```