### PR TITLE
Improve TH1::Merge for histogram with labels

### DIFF
--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -334,7 +334,8 @@ public:
    virtual void     LabelsDeflate(Option_t *axis="X");
    virtual void     LabelsInflate(Option_t *axis="X");
    virtual void     LabelsOption(Option_t *option="h", Option_t *axis="X");
-   virtual Long64_t Merge(TCollection *list);
+   virtual Long64_t Merge(TCollection *list) { return Merge(list,""); }
+   virtual Long64_t Merge(TCollection *list, Option_t * option);
    virtual Bool_t   Multiply(TF1 *f1, Double_t c1=1);
    virtual Bool_t   Multiply(const TH1 *h1);
    virtual Bool_t   Multiply(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1, Option_t *option=""); // *MENU*

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -5462,6 +5462,11 @@ Bool_t TH1::RecomputeAxisLimits(TAxis& destAxis, const TAxis& anAxis)
 /// The function returns the total number of entries in the result histogram
 /// if the merge is successful, -1 otherwise.
 ///
+/// Possible option:
+///   -NOL : the merger will ignore the labels and merge the histograms bin by bin using bin center values to match bins
+///   -NOCHECK:  the histogram will not perform a check for duplicate labels in case of axes with labels. The check
+///              (enabled by default) slows down the merging
+///
 /// IMPORTANT remark. The axis x may have different number
 /// of bins and different limits, BUT the largest bin width must be
 /// a multiple of the smallest bin width and the upper limit must also
@@ -5491,13 +5496,13 @@ Bool_t TH1::RecomputeAxisLimits(TAxis& destAxis, const TAxis& anAxis)
 /// }
 /// ~~~
 
-Long64_t TH1::Merge(TCollection *li)
+Long64_t TH1::Merge(TCollection *li,Option_t * opt)
 {
     if (!li) return 0;
     if (li->IsEmpty()) return (Long64_t) GetEntries();
 
     // use TH1Merger class
-    TH1Merger merger(*this,*li);
+    TH1Merger merger(*this,*li,opt);
     Bool_t ret =  merger();
 
     return (ret) ? GetEntries() : -1;

--- a/hist/hist/src/TH1Merger.cxx
+++ b/hist/hist/src/TH1Merger.cxx
@@ -240,6 +240,10 @@ TH1Merger::EMergerType TH1Merger::ExamineHistograms() {
 
    isAutoP2 = fH0->TestBit(TH1::kAutoBinPTwo) ? kTRUE : kFALSE;
 
+   // if the option alphanumeric merge is set
+   // we assume we do not have labels 
+   if (fNoLabelMerge)  allHaveLabels = kFALSE; 
+
    // start looping on the histograms 
 
    do  {
@@ -877,24 +881,79 @@ Bool_t TH1Merger::DifferentAxesMerge() {
    return kTRUE;
 }
 
+/**
+   Find a duplicate labels in an axis label list
+*/
+Bool_t TH1Merger::HasDuplicateLabels(THashList * labels) {
+   
+   if (!labels) return kFALSE; 
+
+   for (const auto * obj: *labels) {
+      auto objList = labels->GetListForObject(obj);
+      //objList->ls();
+      if (objList->GetSize() > 1 ) {
+         // check here if in the list we have duplicates
+         std::unordered_set<std::string> s;
+         for ( const auto * o: *objList) {
+            auto ret = s.insert(std::string(o->GetName() ));
+            if (!ret.second) return kTRUE; 
+         }
+      }
+   }
+   return kFALSE;
+}
+
+/**
+ Check if histogram has duplicate labels
+ Return an integer with bit set correponding 
+  on the axis that has duplicate labels 
+  e.g. duplicate labels on x axis : return 1
+       duplicate labels on x and z axis : return 5
+
+*/
+Int_t TH1Merger::CheckForDuplicateLabels(const TH1 * hist) {
+   
+   R__ASSERT(hist != nullptr);
+
+   auto labelsX = hist->GetXaxis()->GetLabels();
+   auto labelsY = hist->GetYaxis()->GetLabels();
+   auto labelsZ = hist->GetZaxis()->GetLabels();
+
+   Int_t res = 0; 
+   if (HasDuplicateLabels(labelsX) ) {
+      Warning("TH1Merger::CheckForDuplicateLabels","Histogram %s has duplicate labels in the x axis",hist->GetName());
+      res |= 1;
+   }
+   if (HasDuplicateLabels(labelsY) ) {
+      Warning("TH1Merger::CheckForDuplicateLabels","Histogram %s has duplicate labels in the y axis",hist->GetName());
+      res |= 2;
+   }
+   if (HasDuplicateLabels(labelsZ) ) {
+      Warning("TH1Merger::CheckForDuplicateLabels","Histogram %s has duplicate labels in the z axis",hist->GetName());
+      res |= 4;
+   }
+   return res; 
+}
 
 /**
    Merge histograms with labels 
 */
 Bool_t TH1Merger::LabelMerge() { 
 
-   
    Double_t stats[TH1::kNstat], totstats[TH1::kNstat];
    for (Int_t i=0;i<TH1::kNstat;i++) {totstats[i] = stats[i] = 0;}
    fH0->GetStats(totstats);
    Double_t nentries = fH0->GetEntries();
+
+   // check for duplicate labels
+   if (!fNoCheck && nentries > 0) CheckForDuplicateLabels(fH0); 
 
    TIter next(&fInputList); 
    while (TH1* hist=(TH1*)next()) {
 
       if (gDebug)
          Info("TH1Merger::LabelMerge","Merging histogram %s into %s",hist->GetName(), fH0->GetName() );
-      
+
       // skip empty histograms
       if (hist->IsEmpty()) continue; 
 
@@ -908,6 +967,9 @@ Bool_t TH1Merger::LabelMerge() {
       auto labelsY = hist->GetYaxis()->GetLabels();
       auto labelsZ = hist->GetZaxis()->GetLabels();
       R__ASSERT(!( labelsX == nullptr  && labelsY == nullptr && labelsZ == nullptr));
+
+      // check if histogram has duplicate labels
+      if (!fNoCheck && hist->GetEntries() > 0) CheckForDuplicateLabels(hist); 
 
       // loop on bins of the histogram and do the merge
       for (Int_t ibin = 0; ibin < hist->fNcells; ibin++) {

--- a/hist/hist/src/TH1Merger.h
+++ b/hist/hist/src/TH1Merger.h
@@ -46,13 +46,27 @@ public:
       return outAxis.FindBin(inAxis.GetBinCenter(ibin));
    }
 
+   // Function to find if axis label list  has duplicates
+   static Bool_t HasDuplicateLabels(THashList * labels);
+
+    // check if histogram has duplicate labels
+   static Int_t CheckForDuplicateLabels(const TH1 * hist);
    
-   TH1Merger(TH1 & h, TCollection & l) :
+   
+   TH1Merger(TH1 & h, TCollection & l, Option_t * opt = "") :
       fH0(&h),
       fHClone(nullptr),
       fNewAxisFlag(0)
    {
-      fInputList.AddAll(&l); 
+      fInputList.AddAll(&l);
+      TString option(opt);
+      if (!option.IsNull() ) { 
+         option.ToUpper();
+         if (option.Contains("NOL") ) 
+            fNoLabelMerge = true;
+          if (option.Contains("NOCHECK") ) 
+            fNoCheck = true; 
+      }
    }
 
    ~TH1Merger() {
@@ -88,11 +102,13 @@ private:
    Bool_t LabelMerge();
 
 
+   Bool_t fNoLabelMerge = kFALSE; // force merger to not use labels and do bin center by bin center
+   Bool_t fNoCheck = kFALSE;     // skip check on duplicate labels 
    TH1 * fH0;  //! histogram on which the list is merged
    TH1 * fHClone;  //! copy of fH0 - managed by this class
    TList fInputList; // input histogram List
    TAxis fNewXAxis; 
    TAxis fNewYAxis; 
    TAxis fNewZAxis; 
-   UInt_t fNewAxisFlag; 
+   UInt_t fNewAxisFlag;
 };


### PR DESCRIPTION
Add possibilities to pass options in TH1::Merge
Print a warning in case of duplicate labels.
Add an option to force merge numeric (bin centre by bin center values)  and an option to skip duplicate labels check, which can be quite expensive in term of CPU time