### PR TITLE
[VecOps] Disable finite math functions for old glibc

### DIFF
--- a/math/vecops/CMakeLists.txt
+++ b/math/vecops/CMakeLists.txt
@@ -29,4 +29,10 @@ endif()
 
 target_compile_options(ROOTVecOps PRIVATE -O3 -ffast-math)
 
+include(CheckCXXSymbolExists)
+check_symbol_exists(m __sqrt_finite HAVE_FINITE_MATH)
+if(NOT HAVE_FINITE_MATH)
+  target_compile_options(ROOTVecOps PRIVATE -fno-finite-math-only)
+endif()
+
 ROOT_ADD_TEST_SUBDIRECTORY(test)


### PR DESCRIPTION
These functions (enabled when -ffast-math is used) were only added
in glibc 2.15. However, SLC 6 still uses glibc 2.12 and clang does
not check before emitting the symbols, so linkage with clang is
broken when fast math is enabled.