### PR TITLE
bugfix for component selection handling fix

### DIFF
--- a/roofit/roofitcore/inc/RooRealIntegral.h
+++ b/roofit/roofitcore/inc/RooRealIntegral.h
@@ -77,9 +77,13 @@ public:
 
   virtual RooAbsReal* createIntegral(const RooArgSet& iset, const RooArgSet* nset=0, const RooNumIntConfig* cfg=0, const char* rangeName=0) const ;  
 
+  void setAllowComponentSelection(Bool_t allow);
+  Bool_t getAllowComponentSelection() const;
+  
 protected:
 
   mutable Bool_t _valid;
+  Bool_t _respectCompSelect;
 
   const RooArgSet& parameters() const ;
 
@@ -140,7 +144,7 @@ protected:
 
   virtual void operModeHook() ; // cache operation mode
 
-  ClassDef(RooRealIntegral,2) // Real-valued function representing an integral over a RooAbsReal object
+  ClassDef(RooRealIntegral,3) // Real-valued function representing an integral over a RooAbsReal object
 };
 
 #endif

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -968,6 +968,10 @@ const RooAbsReal *RooAbsReal::createPlotProjection(const RooArgSet &dependentVar
     return 0;
   }
 
+  if(projected->InheritsFrom(RooRealIntegral::Class())){
+    ((RooRealIntegral*)projected)->setAllowComponentSelection(true);
+  }
+
   projected->SetName(name.Data()) ;
   projected->SetTitle(title.Data()) ;
 

--- a/roofit/roofitcore/src/RooRealSumFunc.cxx
+++ b/roofit/roofitcore/src/RooRealSumFunc.cxx
@@ -309,6 +309,7 @@ Int_t RooRealSumFunc::getAnalyticalIntegralWN(RooArgSet &allVars, RooArgSet &ana
    RooAbsReal *func;
    while ((func = (RooAbsReal *)_funcIter->Next())) {
       RooAbsReal *funcInt = func->createIntegral(analVars, rangeName);
+     if(funcInt->InheritsFrom(RooRealIntegral::Class())) ((RooRealIntegral*)funcInt)->setAllowComponentSelection(true);
       cache->_funcIntList.addOwned(*funcInt);
       if (normSet && normSet->getSize() > 0) {
          RooAbsReal *funcNorm = func->createIntegral(*normSet);

--- a/roofit/roofitcore/src/RooRealSumPdf.cxx
+++ b/roofit/roofitcore/src/RooRealSumPdf.cxx
@@ -346,6 +346,7 @@ Int_t RooRealSumPdf::getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& anal
   RooAbsReal *func ;
   while((func=(RooAbsReal*)_funcIter->Next())) {
     RooAbsReal* funcInt = func->createIntegral(analVars,rangeName) ;
+    if(funcInt->InheritsFrom(RooRealIntegral::Class())) ((RooRealIntegral*)funcInt)->setAllowComponentSelection(true);
     cache->_funcIntList.addOwned(*funcInt) ;
     if (normSet && normSet->getSize()>0) {
       RooAbsReal* funcNorm = func->createIntegral(*normSet) ;


### PR DESCRIPTION
In #2033, an override switch for component selection was introduced. Unfortunately, this switch was not used at all the appropriate places yet. This PR adds the missing calls.