### PR TITLE
[cxxmodules] Add missing guard

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -3493,6 +3493,8 @@ std::string AtlernateTuple(const char *classname)
    guard << guard_name;
 
    std::ostringstream alternateTuple;
+   alternateTuple << "#ifdef __ROOTCLING__" << "\n";
+   alternateTuple << "#undef __ROOTCLING__" << "\n";
    alternateTuple << "#ifndef " << guard.str() << "\n";
    alternateTuple << "#define " << guard.str() << "\n";
    alternateTuple << "namespace ROOT { namespace Internal {\n";
@@ -3532,6 +3534,7 @@ std::string AtlernateTuple(const char *classname)
 
    alternateTuple << "};\n";
    alternateTuple << "}}\n";
+   alternateTuple << "#endif\n";
    alternateTuple << "#endif\n";
    if (!gCling->Declare(alternateTuple.str().c_str())) {
       Error("Load","Could not declare %s",alternateName.c_str());


### PR DESCRIPTION
This was causing roottest-root-core-execStatusBitsCheck failure.

TEmulatedTuple is injected to AST by creating virtual file called
`input_line_<number>`. This is the same way as we inject "ClassDef(name,
  id)" and we need to `undef __ROOTCLING__` in that case (because it's not
  ROOTCLING)
