### PR TITLE
Fix for ROOT-9336 observed in TH1::Merge

### DIFF
--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -135,7 +135,7 @@ protected:
    virtual void     SavePrimitiveHelp(std::ostream &out, const char *hname, Option_t *option = "");
    static Bool_t    RecomputeAxisLimits(TAxis& destAxis, const TAxis& anAxis);
    static Bool_t    SameLimitsAndNBins(const TAxis& axis1, const TAxis& axis2);
-   Bool_t   IsEmpty() const { return fTsumw == 0 && GetEntries() == 0; } //need to use GetEntries() in case of buffer histograms
+   Bool_t   IsEmpty() const;
 
    inline static Double_t AutoP2GetPower2(Double_t x, Bool_t next = kTRUE);
    inline static Int_t AutoP2GetBins(Int_t n);


### PR DESCRIPTION
The failure seen in ROOT-9336 merging ATLAS histogram was caused by a bug in TH1::IsEmpty and 
TH1::ResetStats/GetStats 
TH1::ResetStats was setting the entries to zero for histograms with labels and the function TH1::IsEmpty was assuming than an histogram is empty if fTsumw AND entries == 0.

Now we fix the protected function Th1::IsEmpty used in TH1Merger for the cas…e when both fTSumw=0 and fEntries=0, but in reality the bin contents are not zero.
We Add in this case a check to all bin contents, including underflow/overflows

We fix also TH1::GetStats() for the case of labels histograms.  In this case when you have   fTSumw=0  and fEntries !=0 (happening for the cases  after calling SetBinContent or TH1::ResetStats) you want to compute the correct fTsumw and fTsumw2 values.
With these fixes now ResetStats() works correctly and set the correct histogram statistics (e.g. number of entries). 
