### PR TITLE
[TREEPROCMT] Pass per-tree number of entries to thread-local TChains

### DIFF
--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -54,6 +54,9 @@ namespace ROOT {
          Long64_t end;
       };
 
+      std::vector<ROOT::Internal::EntryCluster>
+      MakeClusters(const std::string &treename, const std::vector<std::string> &filenames);
+
       class TTreeView {
       private:
          using TreeReaderEntryListPair = std::pair<std::unique_ptr<TTreeReader>, std::unique_ptr<TEntryList>>;
@@ -321,7 +324,6 @@ namespace ROOT {
    private:
       ROOT::TThreadedObject<ROOT::Internal::TTreeView> treeView; ///<! Thread-local TreeViews
 
-      std::vector<ROOT::Internal::EntryCluster> MakeClusters();
    public:
       TTreeProcessorMT(std::string_view filename, std::string_view treename = "");
       TTreeProcessorMT(const std::vector<std::string_view>& filenames, std::string_view treename = "");

--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -274,6 +274,7 @@ namespace ROOT {
                reader->SetEntriesRange(start, end);
             }
 
+            // we need to return the entry list too, as it needs to be in scope as long as the reader is
             return std::make_pair(std::move(reader), std::move(elist));
          }
 
@@ -293,11 +294,11 @@ namespace ROOT {
 
          //////////////////////////////////////////////////////////////////////////
          /// Push a new loaded entry to the stack.
-         void PushLoadedEntry(Long64_t entry) { fLoadedEntries.push_back(entry); }
+         void PushTaskFirstEntry(Long64_t entry) { fLoadedEntries.push_back(entry); }
 
          //////////////////////////////////////////////////////////////////////////
          /// Restore the tree of the previous loaded entry, if any.
-         void RestoreLoadedEntry()
+         void PopTaskFirstEntry()
          {
             fLoadedEntries.pop_back();
             if (fLoadedEntries.size() > 0) {

--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -60,8 +60,7 @@ namespace ROOT {
       class TTreeView {
       private:
          using TreeReaderEntryListPair = std::pair<std::unique_ptr<TTreeReader>, std::unique_ptr<TEntryList>>;
-
-         typedef std::pair<std::string, std::string> NameAlias;
+         using NameAlias = std::pair<std::string, std::string>;
 
          // NOTE: fFriends must come before fChain to be deleted after it, see ROOT-9281 for more details
          std::vector<std::unique_ptr<TChain>> fFriends; ///< Friends of the tree/chain
@@ -316,6 +315,16 @@ namespace ROOT {
             if (fLoadedEntries.size() > 0) {
                fChain->LoadTree(fLoadedEntries.back());
             }
+         }
+
+         const std::vector<NameAlias> &GetFriendNames() const
+         {
+            return fFriendNames;
+         }
+
+         const std::vector<std::vector<std::string>> &GetFriendFileNames() const
+         {
+            return fFriendFileNames;
          }
       };
    } // End of namespace Internal

--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -71,8 +71,8 @@ namespace ROOT {
          std::vector<std::vector<std::string>> fFriendFileNames; ///< Names of the files where friends are stored
 
          ////////////////////////////////////////////////////////////////////////////////
-         /// Initialize TTreeView.
-         void Init()
+         /// Construct fChain, also adding friends if needed
+         void MakeChain()
          {
             // If the tree name is empty, look for a tree in the file
             if (fTreeName.empty()) {
@@ -185,7 +185,6 @@ namespace ROOT {
          TTreeView(std::string_view fn, std::string_view tn) : fTreeName(tn)
          {
             fFileNames.emplace_back(fn);
-            Init();
          }
 
          //////////////////////////////////////////////////////////////////////////
@@ -199,7 +198,6 @@ namespace ROOT {
             if (fns.size() > 0) {
                for (auto& fn : fns)
                   fFileNames.emplace_back(fn);
-               Init();
             }
             else {
                auto msg = "The provided list of file names is empty, cannot process tree " + fTreeName;
@@ -219,7 +217,6 @@ namespace ROOT {
                   for (auto f : *filelist)
                      fFileNames.emplace_back(f->GetTitle());
                   StoreFriends(tree, false);
-                  Init();
                }
                else {
                   auto msg = "The provided chain of files is empty, cannot process tree " + fTreeName;
@@ -231,7 +228,6 @@ namespace ROOT {
                if (f) {
                   fFileNames.emplace_back(f->GetName());
                   StoreFriends(tree, true);
-                  Init();
                }
                else {
                   auto msg = "The specified TTree is not linked to any file, in-memory-only trees are not supported. Cannot process tree " + fTreeName;
@@ -270,14 +266,14 @@ namespace ROOT {
                   fileNames.emplace_back(name);
                }
             }
-
-            Init();
          }
 
          //////////////////////////////////////////////////////////////////////////
          /// Get a TTreeReader for the current tree of this view.
          TreeReaderEntryListPair GetTreeReader(Long64_t start, Long64_t end)
          {
+            MakeChain();
+
             std::unique_ptr<TTreeReader> reader;
             std::unique_ptr<TEntryList> elist;
             if (fEntryList.GetN() > 0) {

--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -188,7 +188,7 @@ namespace ROOT {
          {
             static const TClassRef clRefTChain("TChain");
             if (clRefTChain == tree.IsA()) {
-               TObjArray* filelist = dynamic_cast<TChain&>(tree).GetListOfFiles();
+               TObjArray* filelist = static_cast<TChain&>(tree).GetListOfFiles();
                if (filelist->GetEntries() > 0) { 
                   for (auto f : *filelist)
                      fFileNames.emplace_back(f->GetTitle());

--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -47,10 +47,10 @@ the threaded object.
 namespace ROOT {
    namespace Internal {
 
-      /// A cluster of entries as seen by TTreeView
-      struct TreeViewCluster {
-         Long64_t startEntry;
-         Long64_t endEntry;
+      /// A cluster of entries
+      struct EntryCluster {
+         Long64_t start;
+         Long64_t end;
       };
 
       class TTreeView {
@@ -313,7 +313,7 @@ namespace ROOT {
    private:
       ROOT::TThreadedObject<ROOT::Internal::TTreeView> treeView; ///<! Thread-local TreeViews
 
-      std::vector<ROOT::Internal::TreeViewCluster> MakeClusters();
+      std::vector<ROOT::Internal::EntryCluster> MakeClusters();
    public:
       TTreeProcessorMT(std::string_view filename, std::string_view treename = "");
       TTreeProcessorMT(const std::vector<std::string_view>& filenames, std::string_view treename = "");

--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -73,15 +73,15 @@ namespace ROOT {
          std::vector<std::vector<std::string>> fFriendFileNames; ///< Names of the files where friends are stored
 
          ////////////////////////////////////////////////////////////////////////////////
-         /// Construct fChain, also adding friends if needed and injecting knowledge of offsets if available.
-         void MakeChain(const std::vector<Long64_t> &nEntries, const std::vector<std::vector<Long64_t>> &friendEntries)
+         /// If not treeName was provided to the ctor, use the name of the first TTree in the first file, else throw.
+         void GetTreeNameIfNeeded()
          {
             // If the tree name is empty, look for a tree in the file
             if (fTreeName.empty()) {
                ::TDirectory::TContext ctxt(gDirectory);
                std::unique_ptr<TFile> f(TFile::Open(fFileNames[0].c_str()));
                TIter next(f->GetListOfKeys());
-               while (TKey *key = (TKey*)next()) {
+               while (TKey *key = (TKey *)next()) {
                   const char *className = key->GetClassName();
                   if (strcmp(className, "TTree") == 0) {
                      fTreeName = key->GetName();
@@ -93,7 +93,12 @@ namespace ROOT {
                   throw std::runtime_error(msg);
                }
             }
+         }
 
+         ////////////////////////////////////////////////////////////////////////////////
+         /// Construct fChain, also adding friends if needed and injecting knowledge of offsets if available.
+         void MakeChain(const std::vector<Long64_t> &nEntries, const std::vector<std::vector<Long64_t>> &friendEntries)
+         {
             fChain.reset(new TChain(fTreeName.c_str()));
             const auto nFiles = fFileNames.size();
             for (auto i = 0u; i < nFiles; ++i) {
@@ -187,6 +192,7 @@ namespace ROOT {
          TTreeView(std::string_view fn, std::string_view tn) : fTreeName(tn)
          {
             fFileNames.emplace_back(fn);
+            GetTreeNameIfNeeded();
          }
 
          //////////////////////////////////////////////////////////////////////////
@@ -205,6 +211,7 @@ namespace ROOT {
                auto msg = "The provided list of file names is empty, cannot process tree " + fTreeName;
                throw std::runtime_error(msg);
             }
+            GetTreeNameIfNeeded();
          }
 
          //////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -142,13 +142,16 @@ void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
    const auto &clusters = clustersAndEntries.first;
    const auto &entries = clustersAndEntries.second;
 
-   auto mapFunction = [this, &func, &entries](const ROOT::Internal::EntryCluster &c) {
+   const auto friendEntries =
+      ROOT::Internal::GetFriendEntries(treeView->GetFriendNames(), treeView->GetFriendFileNames());
+
+   auto mapFunction = [this, &func, &entries, &friendEntries](const ROOT::Internal::EntryCluster &c) {
       // This task will operate with the tree that contains start
       treeView->PushTaskFirstEntry(c.start);
 
       std::unique_ptr<TTreeReader> reader;
       std::unique_ptr<TEntryList> elist;
-      std::tie(reader, elist) = treeView->GetTreeReader(c.start, c.end, entries);
+      std::tie(reader, elist) = treeView->GetTreeReader(c.start, c.end, entries, friendEntries);
       func(*reader);
 
       // In case of task interleaving, we need to load here the tree of the parent task

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -63,6 +63,29 @@ MakeClusters(const std::string &treeName, const std::vector<std::string> &fileNa
 
    return std::make_pair(std::move(clusters), std::move(nEntries));
 }
+
+////////////////////////////////////////////////////////////////////////
+/// Return a vector containing the number of entries of each file of each friend TChain
+std::vector<std::vector<Long64_t>> GetFriendEntries(const std::vector<std::pair<std::string, std::string>> &friendNames,
+                                                    const std::vector<std::vector<std::string>> &friendFileNames)
+{
+   std::vector<std::vector<Long64_t>> friendEntries;
+   const auto nFriends = friendNames.size();
+   for (auto i = 0u; i < nFriends; ++i) {
+      std::vector<Long64_t> nEntries;
+      const auto &thisFriendName = friendNames[i].first;
+      const auto &thisFriendFiles = friendFileNames[i];
+      for (const auto &fname : thisFriendFiles) {
+         std::unique_ptr<TFile> f(TFile::Open(fname.c_str()));
+         TTree *t = nullptr; // owned by TFile
+         f->GetObject(thisFriendName.c_str(), t);
+         nEntries.emplace_back(t->GetEntries());
+      }
+      friendEntries.emplace_back(std::move(nEntries));
+   }
+
+   return friendEntries;
+}
 }
 }
 

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -113,8 +113,9 @@ void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
       // This task will operate with the tree that contains start
       treeView->PushTaskFirstEntry(c.start);
 
-      auto readerAndEntryList = treeView->GetTreeReader(c.start, c.end);
-      auto &reader = std::get<0>(readerAndEntryList);
+      std::unique_ptr<TTreeReader> reader;
+      std::unique_ptr<TEntryList> elist;
+      std::tie(reader, elist) = treeView->GetTreeReader(c.start, c.end);
       func(*reader);
 
       // In case of task interleaving, we need to load here the tree of the parent task

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -111,14 +111,14 @@ void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
 
    auto mapFunction = [this, &func](const ROOT::Internal::TreeViewCluster &c) {
       // This task will operate with the tree that contains startEntry
-      treeView->PushLoadedEntry(c.startEntry);
+      treeView->PushTaskFirstEntry(c.startEntry);
 
       auto readerAndEntryList = treeView->GetTreeReader(c.startEntry, c.endEntry);
       auto &reader = std::get<0>(readerAndEntryList);
       func(*reader);
 
       // In case of task interleaving, we need to load here the tree of the parent task
-      treeView->RestoreLoadedEntry();
+      treeView->PopTaskFirstEntry();
    };
 
    // Assume number of threads has been initialized via ROOT::EnableImplicitMT

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -31,6 +31,33 @@ objects.
 using namespace ROOT;
 
 ////////////////////////////////////////////////////////////////////////
+/// Return a vector of cluster boundaries for the given tree and files.
+std::vector<ROOT::Internal::EntryCluster>
+ROOT::Internal::MakeClusters(const std::string &treeName, const std::vector<std::string> &fileNames)
+{
+   TDirectory::TContext c;
+   std::vector<ROOT::Internal::EntryCluster> clusters;
+   const auto nFileNames = fileNames.size();
+   Long64_t offset = 0;
+   for (auto i = 0u; i < nFileNames; ++i) { // EntryCluster requires the index of the file the cluster belongs to
+      std::unique_ptr<TFile> f(TFile::Open(fileNames[i].c_str())); // need TFile::Open to load plugins if need be
+      TTree *t = nullptr; // not a leak, t will be deleted by f
+      f->GetObject(treeName.c_str(), t);
+      auto clusterIter = t->GetClusterIterator(0);
+      Long64_t start = 0, end = 0;
+      const Long64_t entries = t->GetEntries();
+      // Iterate over the clusters in the current file
+      while ((start = clusterIter()) < entries) {
+         end = clusterIter.GetNextEntry();
+         // Add the current file's offset to start and end to make them (chain) global
+         clusters.emplace_back(ROOT::Internal::EntryCluster{start + offset, end + offset});
+      }
+      offset += entries;
+   }
+   return clusters;
+}
+
+////////////////////////////////////////////////////////////////////////
 /// Constructor based on a file name.
 /// \param[in] filename Name of the file containing the tree to process.
 /// \param[in] treename Name of the tree to process. If not provided,
@@ -57,34 +84,6 @@ TTreeProcessorMT::TTreeProcessorMT(TTree &tree) : treeView(tree) {}
 /// \param[in] entries List of entry numbers to process.
 TTreeProcessorMT::TTreeProcessorMT(TTree &tree, TEntryList &entries) : treeView(tree, entries) {}
 
-////////////////////////////////////////////////////////////////////////
-/// Divide input data in clusters, i.e. the workloads to distribute to tasks
-std::vector<ROOT::Internal::EntryCluster> TTreeProcessorMT::MakeClusters()
-{
-   TDirectory::TContext c;
-   std::vector<ROOT::Internal::EntryCluster> clusters;
-   const auto &fileNames = treeView->GetFileNames();
-   const auto nFileNames = fileNames.size();
-   const auto &treeName = treeView->GetTreeName();
-   Long64_t offset = 0;
-   for (auto i = 0u; i < nFileNames; ++i) { // EntryCluster requires the index of the file the cluster belongs to
-      std::unique_ptr<TFile> f(TFile::Open(fileNames[i].c_str())); // need TFile::Open to load plugins if need be
-      TTree *t = nullptr;                                          // not a leak, t will be deleted by f
-      f->GetObject(treeName.c_str(), t);
-      auto clusterIter = t->GetClusterIterator(0);
-      Long64_t start = 0, end = 0;
-      const Long64_t entries = t->GetEntries();
-      // Iterate over the clusters in the current file and generate a task for each of them
-      while ((start = clusterIter()) < entries) {
-         end = clusterIter.GetNextEntry();
-         // Add the current file's offset to start and end to make them (chain) global
-         clusters.emplace_back(ROOT::Internal::EntryCluster{start + offset, end + offset});
-      }
-      offset += entries;
-   }
-   return clusters;
-}
-
 //////////////////////////////////////////////////////////////////////////////
 /// Process the entries of a TTree in parallel. The user-provided function
 /// receives a TTreeReader which can be used to iterate on a subrange of
@@ -107,7 +106,7 @@ void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
    // Enable this IMT use case (activate its locks)
    Internal::TParTreeProcessingRAII ptpRAII;
 
-   auto clusters = MakeClusters();
+   const auto clusters = ROOT::Internal::MakeClusters(treeView->GetTreeName(), treeView->GetFileNames());
 
    auto mapFunction = [this, &func](const ROOT::Internal::EntryCluster &c) {
       // This task will operate with the tree that contains start


### PR DESCRIPTION
This ensures that each thread-local TChain knows which tree contains
which global entry number without having to open all intermediate
files to check how many entries they contain, resulting in much
less contention in TTreeProcessorMT when multiple threads are loading
the right file to process.

An artificial example running on 342 files of about 2MB each, with 8 cores, release build of ROOT, has the following timings:
* current master, 8 cores: ~10s
* with this fix, 8 cores: ~3.5s
* no imt (current master and with the fix): ~1s

To merge after #2115.