### PR TITLE
[cmake] Split ROOT_SHOW_OPTIONS into a more generic ROOT_GET_OPTIONS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ ROOT_CHECK_OUT_OF_SOURCE_BUILD()
 
 #---Here we look for installed software and switch on and of the different build options--------
 include(SearchInstalledSoftware)
-ROOT_SHOW_OPTIONS()
+ROOT_SHOW_ENABLED_OPTIONS()
 
 #---Here we add tcmalloc to the linker flags if needed------------------------------------------
 if (TCMALLOC_FOUND)

--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -24,20 +24,32 @@ function(ROOT_APPLY_OPTIONS)
 endfunction()
 
 #---------------------------------------------------------------------------------------------------
-#---ROOT_SHOW_OPTIONS([var] )
+#---ROOT_GET_OPTIONS(result ENABLED)
 #---------------------------------------------------------------------------------------------------
-function(ROOT_SHOW_OPTIONS)
+function(ROOT_GET_OPTIONS result)
+  CMAKE_PARSE_ARGUMENTS(ARG "ENABLED" "" "" ${ARGN})
   set(enabled)
   foreach(opt ${root_build_options})
-    if(${opt})
+    if(ARG_ENABLED)
+      if(${opt})
+        set(enabled "${enabled} ${opt}")
+      endif()
+    else()
       set(enabled "${enabled} ${opt}")
     endif()
   endforeach()
-  if(NOT ARGN)
-    message(STATUS "Enabled support for: ${enabled}")
-  else()
-    set(${ARGN} "${enabled}" PARENT_SCOPE)
-  endif()
+  set(${result} "${enabled}" PARENT_SCOPE)
+endfunction()
+
+#---------------------------------------------------------------------------------------------------
+#---ROOT_SHOW_ENABLED_OPTIONS()
+#---------------------------------------------------------------------------------------------------
+function(ROOT_SHOW_ENABLED_OPTIONS)
+  set(enabled_opts)
+  ROOT_GET_OPTIONS(enabled_opts ENABLED)
+  foreach(opt ${enabled_opts})
+    message(STATUS "Enabled support for: ${opt}")
+  endforeach()
 endfunction()
 
 #---------------------------------------------------------------------------------------------------

--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -645,7 +645,7 @@ else()
 endif()
 
 #---root-config----------------------------------------------------------------------------------------------
-ROOT_SHOW_OPTIONS(features)
+ROOT_GET_OPTIONS(features ENABLED)
 string(REPLACE "c++11" "cxx11" features ${features}) # change the name of the c++11 feature needed for root-config.in
 set(configfeatures ${features})
 set(configargs ${ROOT_CONFIGARGS})
@@ -684,7 +684,8 @@ configure_file(${CMAKE_SOURCE_DIR}/config/Makefile.in config/Makefile.config NEW
 configure_file(${CMAKE_SOURCE_DIR}/config/mimes.unix.in ${CMAKE_BINARY_DIR}/etc/root.mimes NEWLINE_STYLE UNIX)
 
 #---Generate the ROOTConfig files to be used by CMake projects-----------------------------------------------
-ROOT_SHOW_OPTIONS(ROOT_ENABLED_OPTIONS)
+ROOT_GET_OPTIONS(ROOT_ALL_OPTIONS)
+ROOT_GET_OPTIONS(ROOT_ENABLED_OPTIONS ENABLED)
 configure_file(${CMAKE_SOURCE_DIR}/cmake/scripts/ROOTConfig-version.cmake.in
                ${CMAKE_BINARY_DIR}/ROOTConfig-version.cmake @ONLY NEWLINE_STYLE UNIX)
 

--- a/cmake/scripts/ROOTConfig.cmake.in
+++ b/cmake/scripts/ROOTConfig.cmake.in
@@ -69,9 +69,10 @@ endif()
 
 #----------------------------------------------------------------------------
 # Setup components and options
-set(_root_options @ROOT_ENABLED_OPTIONS@)
+set(_root_enabled_options @ROOT_ENABLED_OPTIONS@)
+set(_root_all_options @ROOT_ALL_OPTIONS@)
 
-foreach(_opt ${_root_options})
+foreach(_opt ${_root_enabled_options})
   set(ROOT_${_opt}_FOUND TRUE)
 endforeach()
 


### PR DESCRIPTION
Export in ROOTConfig.cmake the list of all options, too.

This patch is a prerequisite to fix ROOT-9405.