### PR TITLE
Add missing cling transaction

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -3365,6 +3365,8 @@ Int_t TCling::DeleteVariable(const char* name)
       }
       unscopedName += posScope + 2;
    }
+   // Could trigger deserialization of decls.
+   cling::Interpreter::PushTransactionRAII RAII(fInterpreter);
    clang::NamedDecl* nVarDecl
       = cling::utils::Lookup::Named(&fInterpreter->getSema(), unscopedName, declCtx);
    if (!nVarDecl) {
@@ -4246,6 +4248,8 @@ TInterpreter::DeclId_t TCling::GetDataMember(ClassInfo_t *opaque_cl, const char 
    LookupResult R(SemaR, DName, SourceLocation(), Sema::LookupOrdinaryName,
                   Sema::ForRedeclaration);
 
+   // Could trigger deserialization of decls.
+   cling::Interpreter::PushTransactionRAII RAII(fInterpreter);
    cling::utils::Lookup::Named(&SemaR, R);
 
    LookupResult::Filter F = R.makeFilter();
@@ -4285,6 +4289,8 @@ TInterpreter::DeclId_t TCling::GetEnum(TClass *cl, const char *name) const
          }
          if (dc) {
             // If it is a data member enum.
+            // Could trigger deserialization of decls.
+            cling::Interpreter::PushTransactionRAII RAII(fInterpreter);
             possibleEnum = cling::utils::Lookup::Named(&fInterpreter->getSema(), name, dc);
          } else {
             Error("TCling::GetEnum", "DeclContext not found for %s .\n", name);
@@ -4292,6 +4298,8 @@ TInterpreter::DeclId_t TCling::GetEnum(TClass *cl, const char *name) const
       }
    } else {
       // If it is a global enum.
+      // Could trigger deserialization of decls.
+      cling::Interpreter::PushTransactionRAII RAII(fInterpreter);
       possibleEnum = cling::utils::Lookup::Named(&fInterpreter->getSema(), name);
    }
    if (possibleEnum && (possibleEnum != (clang::Decl*)-1)


### PR DESCRIPTION
This was discovered running
```
root.exe -b -l -q roottest/root/meta/execUnloading.C
```
but does **not** solve its instability (it sometimes properly inform the TClass of the unloading and sometimes doesn't):
```
35c35
< The state of MyClass is: 1
---
> The state of MyClass is: 3
37,38c37,40
< <<data>> unloaded.
< <<method>> unloaded.
---
> <<data>> is unloaded, but still valid.
> <<method>> is unloaded, but still valid.
> The unloaded data member data should not be in the list of data members.
> The unloaded function member method should not be in the list of data members.
```
So it seems in that in some case the unloading is not done.