### PR TITLE
Use IsLibraryLoaded when you already know that file is a library

### DIFF
--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -3051,8 +3051,7 @@ int TSystem::CompileMacro(const char *filename, Option_t *opt,
    library = gSystem->UnixPathName(library);
 
    // ======= Check if the library need to loaded or compiled
-   if ( gInterpreter->IsLoaded(expFileName) &&
-       !gInterpreter->IsLoaded(library) ) {
+   if (!gInterpreter->IsLibraryLoaded(library) && gInterpreter->IsLoaded(expFileName)) {
       // the script has already been loaded in interpreted mode
       // Let's warn the user and unload it.
 
@@ -3255,7 +3254,7 @@ int TSystem::CompileMacro(const char *filename, Option_t *opt,
       }
    }
 
-   if ( gInterpreter->IsLoaded(library)
+   if ( gInterpreter->IsLibraryLoaded(library)
         || strlen(GetLibraries(library,"D",kFALSE)) != 0 ) {
       // The library has already been built and loaded.
 

--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -152,6 +152,7 @@ public:
    virtual void     Initialize() = 0;
    virtual void     InspectMembers(TMemberInspector&, const void* obj, const TClass* cl, Bool_t isTransient) = 0;
    virtual Bool_t   IsLoaded(const char *filename) const = 0;
+   virtual Bool_t   IsLibraryLoaded(const char *libname) const = 0;
    virtual Int_t    Load(const char *filenam, Bool_t system = kFALSE) = 0;
    virtual void     LoadMacro(const char *filename, EErrorCode *error = 0) = 0;
    virtual Int_t    LoadLibraryMap(const char *rootmapfile = 0) = 0;

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -203,6 +203,7 @@ public: // Public Interface
    virtual void Initialize();
    void    InspectMembers(TMemberInspector&, const void* obj, const TClass* cl, Bool_t isTransient);
    Bool_t  IsLoaded(const char* filename) const;
+   Bool_t  IsLibraryLoaded(const char* libname) const;
    Int_t   Load(const char* filenam, Bool_t system = kFALSE);
    void    LoadMacro(const char* filename, EErrorCode* error = 0);
    Int_t   LoadLibraryMap(const char* rootmapfile = 0);


### PR DESCRIPTION
TCling::IsLoaded was impressively slow because it's allowing "header"
input file. If you already know that your file is a library, it's better
to use IsLibraryLoaded as this makes a difference in performance.

Modules, w/o this patch
```
Processing tutorials/hsimple.C...
hsimple   : Real Time =   0.08 seconds Cpu Time =   0.07 seconds
(TFile *) 0x5563018a1d30
Processing /home/yuka/CERN/ROOT/memory.C...
cpu  time = 1.524314 seconds
sys  time = 0.157075 seconds
res  memory = 546.867 Mbytes
vir  memory = 895.184 Mbytes
```
With this patch
```
Processing tutorials/hsimple.C...
hsimple   : Real Time =   0.06 seconds Cpu Time =   0.04 seconds
(TFile *) 0x555b420dca90
Processing /home/yuka/CERN/ROOT/memory.C...
 cpu  time = 0.470026 seconds
 sys  time = 0.056668 seconds
 res  memory = 299.688 Mbytes
 vir  memory = 560.188 Mbytes
```
