### PR TITLE
TMVA/DNN/Architectures/Cpu:CpuMatrix.h: Disable debugging macro.

### DIFF
--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu/CpuMatrix.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu/CpuMatrix.h
@@ -25,7 +25,7 @@
 #include "CpuBuffer.h"
 #include <TMVA/Config.h>
 
-#define DEBUG_TMVA_TCPUMATRIX
+//#define DEBUG_TMVA_TCPUMATRIX
 #if defined(DEBUG_TMVA_TCPUMATRIX)
 #define PrintMatrix(mat, text)                                                                             \
    {                                                                                                       \


### PR DESCRIPTION
This fixes https://sft.its.cern.ch/jira/browse/ROOT-9444.