### PR TITLE
[cxxmodules] Fix failing fedora build (ROOT-9445)

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -5949,7 +5949,11 @@ static void* LazyFunctionCreatorAutoloadForModule(const std::string& mangled_nam
 /// Autoload a library based on a missing symbol.
 
 void* TCling::LazyFunctionCreatorAutoload(const std::string& mangled_name) {
-   if (fInterpreter->getCI()->getLangOpts().Modules)
+   bool useCxxModules = false;
+#ifdef R__USE_CXXMODULES
+   useCxxModules = true;
+#endif
+   if (useCxxModules)
       return LazyFunctionCreatorAutoloadForModule(mangled_name, fInterpreter);
 
    // First see whether the symbol is in the library that we are currently


### PR DESCRIPTION
Fedora was calling LazyFunctionCreatorAutoloadForModule from rootcling where fInterpreter was not initialized yet.
