### PR TITLE
[cxxmodules] Respect LD_LIBRARY_PATH order and save memory

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -5884,19 +5884,23 @@ static void* LazyFunctionCreatorAutoloadForModule(const std::string& mangled_nam
    R__LOCKGUARD(gInterpreterMutex);
 
    static bool sFirstRun = true;
-   // We don't want to do directory_iterator several times because it contains HDD access
-   static std::set<std::string> sLibraries;
+   // sLibraies contains pair of sPaths[i] (eg. /home/foo/module) and library name (eg. libTMVA.so). The
+   // reason why we're separating sLibraries and sPaths is that we have a lot of
+   // dupulication in path, for example we have "/home/foo/module-release/lib/libFoo.so", "/home/../libBar.so", "/home/../lib.."
+   // and it's waste of memory to store the full path.
+   static std::vector< std::pair<uint32_t, std::string> > sLibraries;
+   static std::vector<StringRef> sPaths;
 
    if (sFirstRun) {
       // Store the information of path so that we don't have to iterate over the same path again and again.
       std::unordered_set<std::string> alreadyLookedPath;
       const clang::Preprocessor &PP = fInterpreter->getCI()->getPreprocessor();
       const HeaderSearchOptions &HSOpts = PP.getHeaderSearchInfo().getHeaderSearchOpts();
-      const auto ModulePaths(HSOpts.PrebuiltModulePaths);
+      const std::vector<std::string>& ModulePaths(HSOpts.PrebuiltModulePaths);
       cling::DynamicLibraryManager* dyLibManager = fInterpreter->getDynamicLibraryManager();
 
       // Take path here eg. "/home/foo/module-release/lib/"
-      for (auto Path : ModulePaths) {
+      for (const std::string& Path : ModulePaths) {
          // Already searched?
          auto it = alreadyLookedPath.insert(Path);
          if (!it.second)
@@ -5904,6 +5908,8 @@ static void* LazyFunctionCreatorAutoloadForModule(const std::string& mangled_nam
          StringRef DirPath(Path);
          if (!is_directory(DirPath))
             continue;
+
+         sPaths.push_back(Path);
 
          std::error_code EC;
          for (llvm::sys::fs::directory_iterator DirIt(DirPath, EC), DirEnd;
@@ -5916,7 +5922,7 @@ static void* LazyFunctionCreatorAutoloadForModule(const std::string& mangled_nam
                // for symbols that cannot be found (neither by dlsym nor in the JIT).
                if (dyLibManager->isLibraryLoaded(FileName.c_str()))
                   continue;
-               sLibraries.insert(FileName);
+               sLibraries.push_back(std::make_pair(sPaths.size() - 1, llvm::sys::path::filename(FileName)));
             }
          }
       }
@@ -5924,7 +5930,10 @@ static void* LazyFunctionCreatorAutoloadForModule(const std::string& mangled_nam
    }
 
    // Iterate over files under this path. We want to get each ".so" files
-   for (const std::string& LibName : sLibraries) {
+   for (std::pair<uint32_t, std::string> &P : sLibraries) {
+      llvm::SmallString<400> Vec(sPaths[P.first]);
+      llvm::sys::path::append(Vec, StringRef(P.second));
+      std::string LibName = Vec.str();
       auto SoFile = ObjectFile::createObjectFile(LibName);
       if (SoFile) {
          auto RealSoFile = SoFile.get().getBinary();
@@ -5939,11 +5948,13 @@ static void* LazyFunctionCreatorAutoloadForModule(const std::string& mangled_nam
                continue;
             }
 
-            if (S.getName().get() == mangled_name) {
+            if (SymNameErr.get() == mangled_name) {
                if (gSystem->Load(LibName.c_str(), "", false) < 0)
                   Error("LazyFunctionCreatorAutoloadForModule", "Failed to load library %s", LibName.c_str());
 
-               sLibraries.erase(LibName);
+               // We want to delete a loaded library from sLibraries cache, because sLibraries is
+               // a vector of candidate libraries which might be loaded in the future.
+               sLibraries.erase(std::remove(sLibraries.begin(), sLibraries.end(), P), sLibraries.end());
                void* addr = llvm::sys::DynamicLibrary::SearchForAddressOfSymbol(mangled_name.c_str());
                return addr;
             }


### PR DESCRIPTION
std::set was not good because it sorted libraries by alphabetical order
and didn't preserve LD_LIBRARY_PATH order information. We can use
std::vector instead. (Erasing rarely happens and doesn't cost so much)

Path prefix like "/home/yuka/modules/lib/" costs memory, I
think it makes sense to avoid path duplication in sLibraries and make sPaths
vector for this prefix.

With this patch
```
Processing tutorials/hsimple.C...
hsimple   : Real Time =   0.14 seconds Cpu Time =   0.14 seconds
(TFile *) 0x31eb0d0
Processing memory.C...
 cpu  time = 0.861813 seconds
 sys  time = 0.155326 seconds
 res  memory = 178.988 Mbytes
 vir  memory = 435.332 Mbytes
```

w/o
```
Processing tutorials/hsimple.C...
hsimple   : Real Time =   0.21 seconds Cpu Time =   0.20 seconds
(TFile *) 0x30db6e0
Processing memory.C...
 cpu  time = 1.266833 seconds
 sys  time = 0.227562 seconds
 res  memory = 178.965 Mbytes
 vir  memory = 435.301 Mbytes
```

Actually cpu time improved