### PR TITLE
Increase tolerance in stressHistogram buffer tests

### DIFF
--- a/test/stressHistogram.cxx
+++ b/test/stressHistogram.cxx
@@ -6633,16 +6633,9 @@ bool testH1BufferWeights() {
       h2->Fill(x,w);
    }
 
-   int pr = std::cout.precision(15);
-   double eps = TMath::Limits<double>::Epsilon();
-
-   // Adjust the threshold on ARM64 bits. On this RISC architecture,
-   // there is a difference when incrementing the sumwx with variables
-   // saved in memory (in the histogram buffer) and passed as function
-   // arguments (Fill(x,w)).
-#ifdef __aarch64__
-   eps*=28;
-#endif
+   // We use 30 epsilon below because some platforms (ARM64, x86_64)
+   // have rounding errors exceedint a few ulps and make the test fail.
+   double eps = 30 * std::numeric_limits<double>::epsilon();
 
    bool itest = false;
 
@@ -6652,11 +6645,11 @@ bool testH1BufferWeights() {
    h2->GetStats(s2);
    std::vector<std::string> snames = {"sumw","sumw2","sumwx","sumwx2"};
    for (unsigned int i  =0; i < snames.size(); ++i) {
-     itest = equals(s1[i],s2[i],eps );
-     if (defaultEqualOptions & cmpOptDebug ) {
-       std::cout << "Statistics " << snames[i] << "  = " << s1[i] << "  " << s2[i] << " -  " << itest << std::endl;
-     }
-     iret |= itest;
+      itest = equals(s1[i],s2[i],eps );
+      if (defaultEqualOptions & cmpOptDebug ) {
+         std::cout << "Statistics " << snames[i] << "  = " << s1[i] << "  " << s2[i] << " -  " << itest << std::endl;
+      }
+      iret |= itest;
    }
 
    // another fill will reset the histogram
@@ -6673,14 +6666,12 @@ bool testH1BufferWeights() {
 
    iret |= equals("testh1bufferweight",h1,h2,cmpOptStats,eps);
 
-   std::cout.precision(pr);
+   std::cout.precision(15);
 
    if (cleanHistos) delete h1;
 
    if ( defaultEqualOptions & cmpOptPrint )
       std::cout << "Buffer Weighted H1:\t" << (iret?"FAILED":"OK") << std::endl;
-
-
 
    return iret;
 }


### PR DESCRIPTION
The buffer tests for histograms have slightly different rounding errors between buffered/not buffered histograms which exceed a few epsilons, so the test fails if the tolerances are too strict.

*Note:* This test doesn't fail on Jenkins, but *does* fail on my machine without this patch.