### PR TITLE
[TREEPROCMT] Quit loop over TEntryList as soon as we exceed range

### DIFF
--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -166,7 +166,9 @@ namespace ROOT {
             auto elist = std::make_unique<TEntryList>();
             Long64_t entry = fEntryList.GetEntry(0);
             do {
-               if (entry >= start && entry < end) // TODO can quit this loop early when entry >= end
+               if (entry >= end)
+                  break;
+               else if (entry >= start)
                   elist->Enter(entry);
             } while ((entry = fEntryList.Next()) >= 0);
 


### PR DESCRIPTION
The code assumes that `TEntryList` loops over entries in increasing order.
@pcanal @gganis is this always the case?