### PR TITLE
 [TREEPROCMT] Improve concurrency

### DIFF
--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -1,5 +1,5 @@
 // @(#)root/thread:$Id$
-// Author: Enric Tejedor, CERN  12/09/2016
+// Authors: Enric Tejedor, Enrico Guiraud CERN 05/06/2018
 
 /*************************************************************************
  * Copyright (C) 1995-2016, Rene Brun and Fons Rademakers.               *

--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -98,12 +98,13 @@ namespace ROOT {
 
          ////////////////////////////////////////////////////////////////////////////////
          /// Construct fChain, also adding friends if needed and injecting knowledge of offsets if available.
-         void MakeChain(const std::vector<Long64_t> &nEntries, const std::vector<std::vector<Long64_t>> &friendEntries)
+         void MakeChain(const std::vector<std::string> &fileNames, const std::vector<Long64_t> &nEntries,
+                        const std::vector<std::vector<Long64_t>> &friendEntries)
          {
             fChain.reset(new TChain(fTreeName.c_str()));
-            const auto nFiles = fFileNames.size();
+            const auto nFiles = fileNames.size();
             for (auto i = 0u; i < nFiles; ++i) {
-               fChain->Add(fFileNames[i].c_str(), nEntries[i]);
+               fChain->Add(fileNames[i].c_str(), nEntries[i]);
             }
             fChain->ResetBit(TObject::kMustCleanup);
 
@@ -282,10 +283,11 @@ namespace ROOT {
 
          //////////////////////////////////////////////////////////////////////////
          /// Get a TTreeReader for the current tree of this view.
-         TreeReaderEntryListPair GetTreeReader(Long64_t start, Long64_t end, const std::vector<Long64_t> &nEntries,
+         TreeReaderEntryListPair GetTreeReader(Long64_t start, Long64_t end, const std::vector<std::string> &fileNames,
+                                               const std::vector<Long64_t> &nEntries,
                                                const std::vector<std::vector<Long64_t>> &friendEntries)
          {
-            MakeChain(nEntries, friendEntries);
+            MakeChain(fileNames, nEntries, friendEntries);
 
             std::unique_ptr<TTreeReader> reader;
             std::unique_ptr<TEntryList> elist;
@@ -335,6 +337,11 @@ namespace ROOT {
          const std::vector<std::vector<std::string>> &GetFriendFileNames() const
          {
             return fFriendFileNames;
+         }
+
+         const TEntryList &GetEntryList() const
+         {
+            return fEntryList;
          }
       };
    } // End of namespace Internal

--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -54,7 +54,8 @@ namespace ROOT {
          Long64_t end;
       };
 
-      using ClustersAndEntries = std::pair<std::vector<EntryCluster>, std::vector<Long64_t>>;
+      // EntryClusters and number of entries per file
+      using ClustersAndEntries = std::pair<std::vector<std::vector<EntryCluster>>, std::vector<Long64_t>>;
       ClustersAndEntries MakeClusters(const std::string &treename, const std::vector<std::string> &filenames);
 
       class TTreeView {

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -146,19 +146,19 @@ void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
    const bool hasEntryList = treeView->GetEntryList().GetN() > 0;
    const bool shouldRetrieveAllClusters = hasFriends || hasEntryList;
    const auto clustersAndEntries = shouldRetrieveAllClusters
-                                      ? ROOT::Internal::MakeClusters(treeView->GetTreeName(), treeView->GetFileNames())
-                                      : ROOT::Internal::ClustersAndEntries{};
+                                      ? Internal::MakeClusters(treeView->GetTreeName(), treeView->GetFileNames())
+                                      : Internal::ClustersAndEntries{};
    const auto &clusters = clustersAndEntries.first;
    const auto &entries = clustersAndEntries.second;
 
    // Retrieve number of entries for each file for each friend tree
    const auto friendEntries =
-      hasFriends ? ROOT::Internal::GetFriendEntries(treeView->GetFriendNames(), treeView->GetFriendFileNames())
+      hasFriends ? Internal::GetFriendEntries(treeView->GetFriendNames(), treeView->GetFriendFileNames())
                  : std::vector<std::vector<Long64_t>>{};
 
    TThreadExecutor pool;
    // Parent task, spawns tasks that process each of the entry clusters for each input file
-   using ROOT::Internal::EntryCluster;
+   using Internal::EntryCluster;
    auto processFile = [&](std::size_t fileIdx) {
 
       // If cluster information is already present, build TChains with all input files and use global entry numbers
@@ -179,7 +179,7 @@ void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
       const auto &theseEntries =
          shouldUseGlobalEntries ? entries : std::vector<Long64_t>({theseClustersAndEntries.second[0]});
 
-      auto processCluster = [&](const ROOT::Internal::EntryCluster &c) {
+      auto processCluster = [&](const Internal::EntryCluster &c) {
          // This task will operate with the tree that contains start
          treeView->PushTaskFirstEntry(c.start);
 

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -1,5 +1,5 @@
 // @(#)root/thread:$Id$
-// Author: Enric Tejedor, CERN  12/09/2016
+// Authors: Enric Tejedor, Enrico Guiraud CERN  05/06/2018
 
 /*************************************************************************
  * Copyright (C) 1995-2016, Rene Brun and Fons Rademakers.               *

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -140,34 +140,62 @@ void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
    // Enable this IMT use case (activate its locks)
    Internal::TParTreeProcessingRAII ptpRAII;
 
-   // Retrieve cluster boundaries and number of entries for each file
-   const auto clustersAndEntries = ROOT::Internal::MakeClusters(treeView->GetTreeName(), treeView->GetFileNames());
-   const auto &clustersPerFile = clustersAndEntries.first;
+   // If an entry list or friend trees are present, we need to generate clusters with global entry numbers,
+   // so we do it here for all files.
+   const bool hasFriends = !treeView->GetFriendNames().empty();
+   const bool hasEntryList = treeView->GetEntryList().GetN() > 0;
+   const bool shouldRetrieveAllClusters = hasFriends || hasEntryList;
+   const auto clustersAndEntries = shouldRetrieveAllClusters
+                                      ? ROOT::Internal::MakeClusters(treeView->GetTreeName(), treeView->GetFileNames())
+                                      : ROOT::Internal::ClustersAndEntries{};
+   const auto &clusters = clustersAndEntries.first;
    const auto &entries = clustersAndEntries.second;
+
    // Retrieve number of entries for each file for each friend tree
    const auto friendEntries =
-      ROOT::Internal::GetFriendEntries(treeView->GetFriendNames(), treeView->GetFriendFileNames());
+      hasFriends ? ROOT::Internal::GetFriendEntries(treeView->GetFriendNames(), treeView->GetFriendFileNames())
+                 : std::vector<std::vector<Long64_t>>{};
 
    TThreadExecutor pool;
    // Parent task, spawns tasks that process each of the entry clusters for each input file
    using ROOT::Internal::EntryCluster;
-   auto processFile = [this, &func, &entries, &friendEntries, &pool](const std::vector<EntryCluster> &clusters) {
+   auto processFile = [&](std::size_t fileIdx) {
 
-      auto processCluster = [this, &func, &entries, &friendEntries](const ROOT::Internal::EntryCluster &c) {
+      // If cluster information is already present, build TChains with all input files and use global entry numbers
+      // Otherwise get cluster information only for the file we need to process and use local entry numbers
+      const bool shouldUseGlobalEntries = hasFriends || hasEntryList;
+      // theseFiles contains either all files or just the single file to process
+      const auto &theseFiles = shouldUseGlobalEntries ? treeView->GetFileNames()
+                                                      : std::vector<std::string>({treeView->GetFileNames()[fileIdx]});
+      // Evaluate clusters (with local entry numbers) and number of entries for this file, if needed
+      const auto theseClustersAndEntries = shouldUseGlobalEntries
+                                              ? Internal::ClustersAndEntries{}
+                                              : Internal::MakeClusters(treeView->GetTreeName(), theseFiles);
+
+      // All clusters for the file to process, either with global or local entry numbers
+      const auto &thisFileClusters = shouldUseGlobalEntries ? clusters[fileIdx] : theseClustersAndEntries.first[0];
+
+      // Either all number of entries or just the ones for this file
+      const auto &theseEntries =
+         shouldUseGlobalEntries ? entries : std::vector<Long64_t>({theseClustersAndEntries.second[0]});
+
+      auto processCluster = [&](const ROOT::Internal::EntryCluster &c) {
          // This task will operate with the tree that contains start
          treeView->PushTaskFirstEntry(c.start);
 
          std::unique_ptr<TTreeReader> reader;
          std::unique_ptr<TEntryList> elist;
-         std::tie(reader, elist) = treeView->GetTreeReader(c.start, c.end, entries, friendEntries);
+         std::tie(reader, elist) = treeView->GetTreeReader(c.start, c.end, theseFiles, theseEntries, friendEntries);
          func(*reader);
 
          // In case of task interleaving, we need to load here the tree of the parent task
          treeView->PopTaskFirstEntry();
       };
 
-      pool.Foreach(processCluster, clusters);
+      pool.Foreach(processCluster, thisFileClusters);
    };
 
-   pool.Foreach(processFile, clustersPerFile);
+   std::vector<std::size_t> fileIdxs(treeView->GetFileNames().size());
+   std::iota(fileIdxs.begin(), fileIdxs.end(), 0u);
+   pool.Foreach(processFile, fileIdxs);
 }

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -137,9 +137,6 @@ TTreeProcessorMT::TTreeProcessorMT(TTree &tree, TEntryList &entries) : treeView(
 /// \param[in] func User-defined function that processes a subrange of entries
 void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
 {
-   // Enable this IMT use case (activate its locks)
-   Internal::TParTreeProcessingRAII ptpRAII;
-
    // If an entry list or friend trees are present, we need to generate clusters with global entry numbers,
    // so we do it here for all files.
    const bool hasFriends = !treeView->GetFriendNames().empty();
@@ -197,5 +194,9 @@ void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
 
    std::vector<std::size_t> fileIdxs(treeView->GetFileNames().size());
    std::iota(fileIdxs.begin(), fileIdxs.end(), 0u);
+
+   // Enable this IMT use case (activate its locks)
+   Internal::TParTreeProcessingRAII ptpRAII;
+
    pool.Foreach(processFile, fileIdxs);
 }

--- a/tree/treeplayer/test/CMakeLists.txt
+++ b/tree/treeplayer/test/CMakeLists.txt
@@ -2,3 +2,4 @@ ROOT_ADD_UNITTEST_DIR(TreePlayer)
 add_custom_command(TARGET treetreeplayertestUnit POST_BUILD
                    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/data.h data.h)
 
+ROOT_ADD_GTEST(treeprocessormt_manyfiles treeprocmt/treeprocessormt_manyfiles.cxx LIBRARIES TreePlayer)

--- a/tree/treeplayer/test/treeprocmt/treeprocessormt_manyfiles.cxx
+++ b/tree/treeplayer/test/treeprocmt/treeprocessormt_manyfiles.cxx
@@ -1,0 +1,73 @@
+#include <atomic>
+#include <chrono>
+#include <random>
+#include <string>
+#include <thread>
+
+#include <TFile.h>
+#include <TTree.h>
+#include <TSystem.h>
+#include <TTreeReader.h>
+#include <TTreeReaderValue.h>
+#include <ROOT/TTreeProcessorMT.hxx>
+
+#include "gtest/gtest.h"
+
+void WriteFiles(const std::string &treename, const std::vector<std::string> &filenames)
+{
+   int v = 0;
+   for (const auto &f : filenames) {
+      TFile file(f.c_str(), "recreate");
+      TTree t(treename.c_str(), treename.c_str());
+      t.Branch("v", &v);
+      for (auto i = 0; i < 10; ++i) {
+         ++v;
+         t.Fill();
+      }
+      t.Write();
+   }
+}
+
+void DeleteFiles(const std::vector<std::string> &filenames)
+{
+   for (const auto &f : filenames)
+      gSystem->Unlink(f.c_str());
+}
+
+TEST(TreeProcessorMT, ManyFiles)
+{
+   const auto nFiles = 100u;
+   const std::string treename = "t";
+   std::vector<std::string> filenames;
+   for (auto i = 0u; i < nFiles; ++i)
+      filenames.emplace_back("treeprocmt_" + std::to_string(i) + ".root");
+
+   WriteFiles(treename, filenames);
+
+   std::atomic_int sum(0);
+   std::atomic_int count(0);
+   auto sumValues = [&sum, &count](TTreeReader &r) {
+      TTreeReaderValue<int> v(r, "v");
+      std::random_device seed;
+      std::default_random_engine eng(seed());
+      std::uniform_int_distribution<> rand(1, 100);
+      while (r.Next()) {
+         std::this_thread::sleep_for(std::chrono::nanoseconds(rand(eng)));
+         sum += *v;
+         ++count;
+      }
+   };
+
+   // TTreeProcMT requires a vector<string_view>
+   std::vector<std::string_view> fnames;
+   for (const auto &f : filenames)
+      fnames.emplace_back(f);
+
+   ROOT::TTreeProcessorMT proc(fnames, treename);
+   proc.Process(sumValues);
+   
+   EXPECT_EQ(count.load(), int(nFiles*10)); // 10 entries per file
+   EXPECT_EQ(sum.load(), 500500); // sum 1..nFiles*10
+
+   DeleteFiles(filenames);
+}


### PR DESCRIPTION
TTreeProcessorMT now spawns tasks that process clusters from tasks that process files:
this should decrease the amount of file switches that each thread-local
TChain performs during an event loop, as each thread will tend to
process clusters that belong to the same file.

In addition, when no friends and no TEntryList are present, we can avoid the preliminary full sweep of
input files, since we we can use local rather than global entry numbers.
In this case TTreeProcessorMT spawns one task per input file which first retrieves cluster boundaries
for that file and then spawns one sub-task per cluster.

I also added myself to the list of authors.

@etejedor there are a couple of things I am not super happy with in this implementation:
- each thread-local `TTreeView` duplicates all info about the dataset (file names, friend names, friend file names...)
- `TTreeProcessorMT` has to query all of this information from `TTreeView`
- ~~the per-file task should only call `Internal::MakeClusters` once (just noticed, that's an easy refactoring)~~ fixed and squashed

Moving the dataset info from `TTreeView` to `TTreeProcessorMT`, on the other hand, would mean adding even more parameters to `TTreeView::GetTreeReader`. What do you think?