### PR TITLE
[VecOps][Wip] Introduce the RStrongBool type for representing the results of logical operators

### DIFF
--- a/math/vecops/CMakeLists.txt
+++ b/math/vecops/CMakeLists.txt
@@ -5,10 +5,12 @@
 set(HEADERS
   ROOT/RAdoptAllocator.hxx
   ROOT/RVec.hxx
+  ROOT/RStrongBool.hxx
 )
 
 set(SOURCES
   RAdoptAllocator.cxx
+  RStrongBool.cxx
   RVec.cxx
 )
 

--- a/math/vecops/inc/LinkDef.h
+++ b/math/vecops/inc/LinkDef.h
@@ -10,6 +10,7 @@
 #ifdef __CLING__
 
 #pragma link C++ namespace ROOT::VecOps;
+#pragma link C++ namespace ROOT::VecOps::RStrongBool+;
 
 #pragma link C++ class ROOT::VecOps::RVec<float>-;
 #pragma link C++ class ROOT::VecOps::RVec<double>-;
@@ -26,6 +27,8 @@
 #pragma link C++ class ROOT::VecOps::RVec<unsigned long>-;
 #pragma link C++ class ROOT::VecOps::RVec<unsigned long long>-;
 
+#pragma link C++ class ROOT::VecOps::RVec<ROOT::VecOps::RStrongBool>-;
+
 #pragma link C++ class ROOT::VecOps::RVec<float>::Impl_t+;
 #pragma link C++ class ROOT::VecOps::RVec<double>::Impl_t+;
 
@@ -40,5 +43,7 @@
 #pragma link C++ class ROOT::VecOps::RVec<unsigned int>::Impl_t+;
 #pragma link C++ class ROOT::VecOps::RVec<unsigned long>::Impl_t+;
 #pragma link C++ class ROOT::VecOps::RVec<unsigned long long>::Impl_t+;
+
+#pragma link C++ class ROOT::VecOps::RVec<ROOT::VecOps::RStrongBool>::Impl_t+;
 
 #endif

--- a/math/vecops/inc/ROOT/RStrongBool.hxx
+++ b/math/vecops/inc/ROOT/RStrongBool.hxx
@@ -1,0 +1,54 @@
+// Author: Danilo Piparo CERN  06/2018
+
+/*************************************************************************
+ * Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_RStrongBool
+#define ROOT_RStrongBool
+
+#include <iostream>
+
+namespace ROOT {
+namespace VecOps {
+
+// clang-format off
+///////////////////////////////////////////////////////////////////////////////
+/// \brief Strongly typed boolean type to prevent casts.
+/// The storage of the value is of type int.
+// clang-format on
+class RStrongBool final {
+public:
+  RStrongBool();
+  ~RStrongBool();
+  template<typename T>
+  RStrongBool(T val) = delete;
+  RStrongBool(bool val);
+  // this is inlined to workaround missing symbols errors
+  explicit operator bool() const
+{
+	return bool(fVal);
+}
+private:
+  int fVal;
+};
+
+} // End NS VecOps
+} // End NS ROOT
+
+// this is inlined to workaround missing symbols errors
+inline std::ostream& operator<< (std::ostream& stream, ROOT::VecOps::RStrongBool sb)
+{
+	stream << (sb ? "true" : "false");
+	return stream;
+}
+
+namespace cling {
+std::string printValue(::ROOT::VecOps::RStrongBool *sb);
+} // End NS Cling
+
+#endif

--- a/math/vecops/src/RStrongBool.cxx
+++ b/math/vecops/src/RStrongBool.cxx
@@ -1,0 +1,34 @@
+// Author: Danilo Piparo CERN  06/2018
+
+/*************************************************************************
+ * Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/RStrongBool.hxx"
+
+#include <string>
+
+namespace ROOT {
+namespace VecOps {
+
+RStrongBool::RStrongBool() : fVal(false){};
+RStrongBool::~RStrongBool() = default;
+RStrongBool::RStrongBool(bool val) : fVal{val}
+{
+}
+
+} // End NS VecOps
+} // End NS ROOT
+
+namespace cling {
+
+std::string printValue(::ROOT::VecOps::RStrongBool *sb)
+{
+   return bool(*sb) ? "true" : "false";
+}
+
+} // End NS cling

--- a/math/vecops/src/RVec.cxx
+++ b/math/vecops/src/RVec.cxx
@@ -14,9 +14,9 @@ namespace VecOps {
    template auto operator OP(const RVec<T> &v0, const RVec<T> &v1) -> RVec<decltype(v0[0] OP v1[0])>;
 
 #define TVEC_DECLARE_LOGICAL_OPERATOR(T, OP)                   \
-   template RVec<int> operator OP(const RVec<T> &, const T &); \
-   template RVec<int> operator OP(const T &, const RVec<T> &); \
-   template RVec<int> operator OP(const RVec<T> &, const RVec<T> &);
+   template RVec<RStrongBool> operator OP(const RVec<T> &, const T &); \
+   template RVec<RStrongBool> operator OP(const T &, const RVec<T> &); \
+   template RVec<RStrongBool> operator OP(const RVec<T> &, const RVec<T> &);
 
 #define TVEC_DECLARE_ASSIGN_OPERATOR(T, OP)             \
    template RVec<T> &operator OP(RVec<T> &, const T &); \

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -314,20 +314,20 @@ TEST(VecOps, PrintOps)
 { -1, 0, 1 }
 { 2, 4, 6 }
 { 0.5, 1, 1.5 }
-{ 0, 0, 1 }
-{ 0, 1, 1 }
-{ 0, 1, 0 }
-{ 1, 1, 0 }
-{ 1, 0, 0 }
+{ false, false, true }
+{ false, true, true }
+{ false, true, false }
+{ true, true, false }
+{ true, false, false }
 { 3, 4, 5 }
 { 1, 0, -1 }
 { 2, 4, 6 }
 { 2, 1, 0.666667 }
-{ 1, 0, 0 }
-{ 1, 1, 0 }
-{ 0, 1, 0 }
-{ 0, 1, 1 }
-{ 0, 0, 1 }
+{ true, false, false }
+{ true, true, false }
+{ false, true, false }
+{ false, true, true }
+{ false, false, true }
 )ref0";
    auto t0 = PrintRVec(v, 2.);
    EXPECT_STREQ(t0.c_str(), ref0);
@@ -336,20 +336,20 @@ TEST(VecOps, PrintOps)
 { -2, -2, -2 }
 { 3, 8, 15 }
 { 0, 0, 0 }
-{ 0, 0, 0 }
-{ 0, 0, 0 }
-{ 0, 0, 0 }
-{ 1, 1, 1 }
-{ 1, 1, 1 }
+{ false, false, false }
+{ false, false, false }
+{ false, false, false }
+{ true, true, true }
+{ true, true, true }
 { 4, 6, 8 }
 { 2, 2, 2 }
 { 3, 8, 15 }
 { 3, 2, 1 }
-{ 1, 1, 1 }
-{ 1, 1, 1 }
-{ 0, 0, 0 }
-{ 0, 0, 0 }
-{ 0, 0, 0 }
+{ true, true, true }
+{ true, true, true }
+{ false, false, false }
+{ false, false, false }
+{ false, false, false }
 )ref1";
    auto t1 = PrintRVec(v, ref + 2);
    EXPECT_STREQ(t1.c_str(), ref1);
@@ -361,20 +361,20 @@ TEST(VecOps, PrintOps)
 { -1, 0, 1 }
 { 2, 4, 6 }
 { 0.5, 1, 1.5 }
-{ 0, 0, 1 }
-{ 0, 1, 1 }
-{ 0, 1, 0 }
-{ 1, 1, 0 }
-{ 1, 0, 0 }
+{ false, false, true }
+{ false, true, true }
+{ false, true, false }
+{ true, true, false }
+{ true, false, false }
 { 3, 4, 5 }
 { 1, 0, -1 }
 { 2, 4, 6 }
 { 2, 1, 0.666667 }
-{ 1, 0, 0 }
-{ 1, 1, 0 }
-{ 0, 1, 0 }
-{ 0, 1, 1 }
-{ 0, 0, 1 }
+{ true, false, false }
+{ true, true, false }
+{ false, true, false }
+{ false, true, true }
+{ false, false, true }
 )ref2";
    auto t2 = PrintRVec(v, 2.);
    EXPECT_STREQ(t2.c_str(), ref2);
@@ -384,20 +384,20 @@ TEST(VecOps, PrintOps)
 { -2, -2, -2 }
 { 3, 8, 15 }
 { 0, 0, 0 }
-{ 0, 0, 0 }
-{ 0, 0, 0 }
-{ 0, 0, 0 }
-{ 1, 1, 1 }
-{ 1, 1, 1 }
+{ false, false, false }
+{ false, false, false }
+{ false, false, false }
+{ true, true, true }
+{ true, true, true }
 { 4, 6, 8 }
 { 2, 2, 2 }
 { 3, 8, 15 }
 { 3, 2, 1 }
-{ 1, 1, 1 }
-{ 1, 1, 1 }
-{ 0, 0, 0 }
-{ 0, 0, 0 }
-{ 0, 0, 0 }
+{ true, true, true }
+{ true, true, true }
+{ false, false, false }
+{ false, false, false }
+{ false, false, false }
 )ref3";
    auto t3 = PrintRVec(v, ref + 2);
    EXPECT_STREQ(t3.c_str(), ref3);
@@ -590,7 +590,7 @@ TEST(VecOps, SimpleStatOps)
    ASSERT_DOUBLE_EQ(Mean(v2), 2.);
    ASSERT_DOUBLE_EQ(Var(v2), 1.);
    ASSERT_DOUBLE_EQ(StdDev(v2), 1.);
-   
+
    ROOT::VecOps::RVec<double> v3 {10., 20., 32.};
    ASSERT_DOUBLE_EQ(Sum(v3), 62.);
    ASSERT_DOUBLE_EQ(Mean(v3), 20.666666666666668);
@@ -600,20 +600,20 @@ TEST(VecOps, SimpleStatOps)
 
 TEST(VecOps, Any)
 {
-   ROOT::VecOps::RVec<int> vi {0, 1, 2};
+   ROOT::VecOps::RVec<ROOT::VecOps::RStrongBool> vi {false, true, true};
    EXPECT_TRUE(Any(vi));
-   vi = {0, 0, 0};
+   vi = {false, false, false};
    EXPECT_FALSE(Any(vi));
-   vi = {1, 1};
+   vi = {true, true};
    EXPECT_TRUE(Any(vi));
 }
 
 TEST(VecOps, All)
 {
-   ROOT::VecOps::RVec<int> vi {0, 1, 2};
+   ROOT::VecOps::RVec<ROOT::VecOps::RStrongBool> vi {false, true, true};
    EXPECT_FALSE(All(vi));
-   vi = {0, 0, 0};
+   vi = {false, false, false};
    EXPECT_FALSE(All(vi));
-   vi = {1, 1};
+   vi = {true, true};
    EXPECT_TRUE(All(vi));
 }

--- a/tree/dataframe/test/dataframe_vecops.cxx
+++ b/tree/dataframe/test/dataframe_vecops.cxx
@@ -22,7 +22,8 @@ TEST(RDFAndVecOps, ReadStdVectorAsRVec)
    RDataFrame d(treename, fname);
    auto checkRVec = [](const RVec<int> &v) {
       EXPECT_EQ(v.size(), 3u);
-      EXPECT_TRUE(All(v == RVec<int>{1, 2, 3}));
+      const auto ref = RVec<int>({1, 2, 3});
+      EXPECT_TRUE(All(v == ref));
    };
    d.Foreach(checkRVec, {"v"});
 


### PR DESCRIPTION
Before, the boolean type considered by the vecops was int.