### PR TITLE
[cxxmodules] Fix nightlies by autoload dependency libraries

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -367,6 +367,16 @@ extern "C" void TCling__RestoreInterpreterMutex(void *delta)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Lookup libraries in LD_LIBRARY_PATH and DYLD_LIBRARY_PATH with mangled_name,
+/// which is extracted by error messages we get from callback from cling. Return true
+/// when the missing library was autoloaded.
+
+extern "C" bool TCling__LibraryLoadingFailed(const std::string& errmessage, const std::string& libStem, bool permanent, bool resolved)
+{
+   return ((TCling*)gCling)->LibraryLoadingFailed(errmessage, libStem, permanent, resolved);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Reset the interpreter lock to the state it had before interpreter-related
 /// calls happened.
 
@@ -5867,6 +5877,25 @@ Int_t TCling::AutoParse(const char *cls)
    return nHheadersParsed > 0 ? 1 : 0;
 }
 
+// This is a function which gets callback from cling when DynamicLibraryManager->loadLibrary failed for some reason.
+// Try to solve the problem by autoloading. Return true when autoloading success, return
+// false if not.
+bool TCling::LibraryLoadingFailed(const std::string& errmessage, const std::string& libStem, bool permanent, bool resolved)
+{
+   StringRef errMsg(errmessage);
+   if (errMsg.contains("undefined symbol: ")) {
+      std::string mangled_name = std::string(errMsg.split("undefined symbol: ").second);
+      void* res = ((TCling*)gCling)->LazyFunctionCreatorAutoload(mangled_name);
+      cling::DynamicLibraryManager* DLM = fInterpreter->getDynamicLibraryManager();
+      if (res && DLM && (DLM->loadLibrary(libStem, permanent, resolved) == cling::DynamicLibraryManager::kLoadLibSuccess))
+        // Return success when LazyFunctionCreatorAutoload could find mangled_name
+        return true;
+   }
+
+   return false;
+}
+
+
 static void* LazyFunctionCreatorAutoloadForModule(const std::string& mangled_name,
       cling::Interpreter *fInterpreter) {
    using namespace llvm::object;
@@ -5894,7 +5923,10 @@ static void* LazyFunctionCreatorAutoloadForModule(const std::string& mangled_nam
          if (!it.second)
             continue;
          StringRef DirPath(Path);
-         if (!is_directory(DirPath))
+         // Skip current directory, because what we want to autoload is not a random shared libraries but libraries generated
+         // by ROOT. In fact, some tests were failing because of this as they have their custom shared libraries (which is not supporsed
+         // to be autoloaded)
+         if (!is_directory(DirPath) || Path == ".")
             continue;
 
          std::error_code EC;

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -177,6 +177,7 @@ public: // Public Interface
    Int_t   AutoLoad(const std::type_info& typeinfo, Bool_t knowDictNotLoaded = kFALSE);
    Int_t   AutoParse(const char* cls);
    void*   LazyFunctionCreatorAutoload(const std::string& mangled_name);
+   bool   LibraryLoadingFailed(const std::string&, const std::string&, bool, bool);
    Bool_t  IsAutoLoadNamespaceCandidate(const char* name);
    Bool_t  IsAutoLoadNamespaceCandidate(const clang::NamespaceDecl* nsDecl);
    void    ClearFileBusy();

--- a/core/metacling/src/TClingCallbacks.cxx
+++ b/core/metacling/src/TClingCallbacks.cxx
@@ -56,6 +56,7 @@ extern "C" {
    int TCling__CompileMacro(const char *fileName, const char *options);
    void TCling__SplitAclicMode(const char* fileName, std::string &mode,
                   std::string &args, std::string &io, std::string &fname);
+   bool TCling__LibraryLoadingFailed(const std::string&, const std::string&, bool, bool);
    void TCling__LibraryLoadedRTTI(const void* dyLibHandle,
                                   llvm::StringRef canonicalName);
    void TCling__LibraryUnloadedRTTI(const void* dyLibHandle,
@@ -122,6 +123,12 @@ void TClingCallbacks::InclusionDirective(clang::SourceLocation sLoc/*HashLoc*/,
    LookupResult RHeader(SemaR, Name, sLoc, Sema::LookupOrdinaryName);
 
    tryAutoParseInternal(localString, RHeader, SemaR.getCurScope(), FE);
+}
+
+// TCling__LibraryLoadingFailed is a function in TCling which handles errmessage
+bool TClingCallbacks::LibraryLoadingFailed(const std::string& errmessage, const std::string& libStem,
+    bool permanent, bool resolved) {
+  return TCling__LibraryLoadingFailed(errmessage, libStem, permanent, resolved);
 }
 
 // Preprocessor callbacks used to handle special cases like for example:

--- a/core/metacling/src/TClingCallbacks.h
+++ b/core/metacling/src/TClingCallbacks.h
@@ -58,6 +58,8 @@ public:
    void SetAutoParsingSuspended(bool val = true) { fIsAutoParsingSuspended = val; }
    bool IsAutoParsingSuspended() { return fIsAutoParsingSuspended; }
 
+   virtual bool LibraryLoadingFailed(const std::string&, const std::string&, bool, bool);
+
    virtual void InclusionDirective(clang::SourceLocation /*HashLoc*/,
                                    const clang::Token &/*IncludeTok*/,
                                    llvm::StringRef FileName,

--- a/interpreter/cling/include/cling/Interpreter/InterpreterCallbacks.h
+++ b/interpreter/cling/include/cling/Interpreter/InterpreterCallbacks.h
@@ -125,6 +125,12 @@ namespace cling {
     virtual bool LookupObject(const clang::DeclContext*, clang::DeclarationName);
     virtual bool LookupObject(clang::TagDecl*);
 
+    /// \brief This callback is invoked whenever the interpreter failed to load a library.
+    ///
+    /// \param[in] - Error message and parameters passed to loadLibrary
+    /// \returns true if the error was handled.
+    virtual bool LibraryLoadingFailed(const std::string&, const std::string&, bool, bool) { return 0; }
+
     ///\brief This callback is invoked whenever interpreter has committed new
     /// portion of declarations.
     ///

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -1092,6 +1092,7 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
       auto& HS = CI->getHeaderSearchOpts();
       addPrebuiltModulePaths(HS, getPathsFromEnv(getenv("LD_LIBRARY_PATH")));
       addPrebuiltModulePaths(HS, getPathsFromEnv(getenv("DYLD_LIBRARY_PATH")));
+      HS.AddPrebuiltModulePath(".");
     }
 
     // Set up compiler language and target

--- a/interpreter/cling/lib/Interpreter/DynamicLibraryManager.cpp
+++ b/interpreter/cling/lib/Interpreter/DynamicLibraryManager.cpp
@@ -206,6 +206,12 @@ namespace cling {
     std::string errMsg;
     DyLibHandle dyLibHandle = platform::DLOpen(canonicalLoadedLib, &errMsg);
     if (!dyLibHandle) {
+      // We emit callback to LibraryLoadingFailed when we get error with error message.
+      if (InterpreterCallbacks* C = getCallbacks()) {
+        if (C->LibraryLoadingFailed(errMsg, libStem, permanent, resolved))
+          return kLoadLibSuccess;
+      }
+
       cling::errs() << "cling::DynamicLibraryManager::loadLibrary(): " << errMsg
                     << '\n';
       return kLoadLibLoadError;

--- a/interpreter/cling/lib/Interpreter/MultiplexInterpreterCallbacks.h
+++ b/interpreter/cling/lib/Interpreter/MultiplexInterpreterCallbacks.h
@@ -77,6 +77,15 @@ namespace cling {
        }
      }
 
+     bool LibraryLoadingFailed(const std::string& errmessage, const std::string& libStem, bool permanent,
+         bool resolved) override {
+       for (auto&& cb : m_Callbacks) {
+         if (bool res = cb->LibraryLoadingFailed(errmessage, libStem, permanent, resolved))
+           return res;
+       }
+       return 0;
+     }
+
      void TransactionUnloaded(const Transaction& T) override {
        for (auto&& cb : m_Callbacks) {
          cb->TransactionUnloaded(T);


### PR DESCRIPTION
We had test failures in runtime nightlies such as this one:
https://epsft-jenkins.cern.ch/view/ROOT/job/root-nightly-runtime-cxxmodules/95/BUILDTYPE=Debug,COMPILER=gcc62,LABEL=slc6/testReport/junit/projectroot.roottest.root.math/smatrix/roottest_root_math_smatrix_testKalman/
https://epsft-jenkins.cern.ch/view/ROOT/job/root-nightly-runtime-cxxmodules/BUILDTYPE=Debug,COMPILER=gcc62,LABEL=slc6/lastCompletedBuild/testReport/projectroot.roottest.root.meta/evolution/roottest_root_meta_evolution_execMixedBaseClass_v2/

Failures were due to what @pcanal commented in #2135, that some so files in
roottest doesn't have external linkage. (It means that if you call
    dlopen(libfoo.so), linux kernel can't find dependency libraries and it
    emits "undefined symbol" error when they try to initialize global
    variables in libfoo.so but couldn't find symbol definition)
With pch, rootmap files were providing information about the depending library.

However we stopped generating rootmap files in #2127 and that's why we
got these failures. To fix this issue, I implemented a callback to
TCling which gets called when DynamicLibraryManager fails with
"undefined error".

I'm open to suggestion especially in DynamicLibraryManager.cpp.