### PR TITLE
[DF] No need for shared_from_this anymore

### DIFF
--- a/tree/dataframe/inc/ROOT/RDFInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterface.hxx
@@ -129,8 +129,7 @@ public:
    /// \brief Only enabled when building a RInterface<RLoopManager>
    template <typename T = Proxied, typename std::enable_if<std::is_same<T, RLoopManager>::value, int>::type = 0>
    RInterface(const std::shared_ptr<Proxied> &proxied)
-      : fProxiedPtr(proxied), fImplWeakPtr(proxied->GetSharedPtr()), fValidCustomColumns(),
-        fDataSource(proxied->GetDataSource())
+      : fProxiedPtr(proxied), fImplWeakPtr(proxied), fValidCustomColumns(), fDataSource(proxied->GetDataSource())
    {
       AddDefaultColumns();
    }

--- a/tree/dataframe/inc/ROOT/RDFNodes.hxx
+++ b/tree/dataframe/inc/ROOT/RDFNodes.hxx
@@ -86,7 +86,7 @@ class RRangeBase;
 using RangeBasePtr_t = std::shared_ptr<RRangeBase>;
 using RangeBaseVec_t = std::vector<RangeBasePtr_t>;
 
-class RLoopManager : public std::enable_shared_from_this<RLoopManager> {
+class RLoopManager {
    using RDataSource = ROOT::RDF::RDataSource;
    enum class ELoopType { kROOTFiles, kROOTFilesMT, kNoFiles, kNoFilesMT, kDataSource, kDataSourceMT };
 
@@ -181,7 +181,6 @@ public:
 
    void Run();
    RLoopManager *GetLoopManagerUnchecked();
-   std::shared_ptr<RLoopManager> GetSharedPtr() { return shared_from_this(); }
    const ColumnNames_t &GetDefaultColumnNames() const;
    const ColumnNames_t &GetCustomColumnNames() const { return fCustomColumnNames; };
    TTree *GetTree() const;


### PR DESCRIPTION
Hi @lmoneta, this is a small fix that removes unused code.
It's is not critical to backport it to v6.14, it's just a nice-to-have to keep the two branches in sync.

Please let me know if it's ok for you to merge or not.
Cheers,
Enrico