### PR TITLE
Testing jenkins

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -367,6 +367,14 @@ extern "C" void TCling__RestoreInterpreterMutex(void *delta)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Lookup libraries in LD_LIBRARY_PATH and DYLD_LIBRARY_PATH with mangled_name
+
+extern "C" void TCling__LazyFunctionCallback(std::string mangled_name)
+{
+   ((TCling*)gCling)->LazyFunctionCreatorAutoload(mangled_name);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Reset the interpreter lock to the state it had before interpreter-related
 /// calls happened.
 

--- a/core/metacling/src/TClingCallbacks.cxx
+++ b/core/metacling/src/TClingCallbacks.cxx
@@ -56,6 +56,7 @@ extern "C" {
    int TCling__CompileMacro(const char *fileName, const char *options);
    void TCling__SplitAclicMode(const char* fileName, std::string &mode,
                   std::string &args, std::string &io, std::string &fname);
+   void TCling__LazyFunctionCallback(std::string);
    void TCling__LibraryLoadedRTTI(const void* dyLibHandle,
                                   llvm::StringRef canonicalName);
    void TCling__LibraryUnloadedRTTI(const void* dyLibHandle,
@@ -122,6 +123,12 @@ void TClingCallbacks::InclusionDirective(clang::SourceLocation sLoc/*HashLoc*/,
    LookupResult RHeader(SemaR, Name, sLoc, Sema::LookupOrdinaryName);
 
    tryAutoParseInternal(localString, RHeader, SemaR.getCurScope(), FE);
+}
+
+// TCling__LazyFunctionCallback is a function in TCling which lookups libraries which has
+// a definition of mangled_name
+void TClingCallbacks::LazyFunctionCallback(std::string mangled_name) {
+  TCling__LazyFunctionCallback(mangled_name);
 }
 
 // Preprocessor callbacks used to handle special cases like for example:

--- a/core/metacling/src/TClingCallbacks.h
+++ b/core/metacling/src/TClingCallbacks.h
@@ -58,6 +58,8 @@ public:
    void SetAutoParsingSuspended(bool val = true) { fIsAutoParsingSuspended = val; }
    bool IsAutoParsingSuspended() { return fIsAutoParsingSuspended; }
 
+   virtual void LazyFunctionCallback(std::string mangled_name);
+
    virtual void InclusionDirective(clang::SourceLocation /*HashLoc*/,
                                    const clang::Token &/*IncludeTok*/,
                                    llvm::StringRef FileName,

--- a/interpreter/cling/include/cling/Interpreter/AutoloadCallback.h
+++ b/interpreter/cling/include/cling/Interpreter/AutoloadCallback.h
@@ -57,6 +57,7 @@ namespace cling {
                             llvm::StringRef RelativePath,
                             const clang::Module *Imported);
     void TransactionCommitted(const Transaction& T);
+    void LazyFunctionCallback(std::string mangled_name) {}
 
   private:
     void report(clang::SourceLocation l, llvm::StringRef name,

--- a/interpreter/cling/include/cling/Interpreter/InterpreterCallbacks.h
+++ b/interpreter/cling/include/cling/Interpreter/InterpreterCallbacks.h
@@ -125,6 +125,8 @@ namespace cling {
     virtual bool LookupObject(const clang::DeclContext*, clang::DeclarationName);
     virtual bool LookupObject(clang::TagDecl*);
 
+   virtual void LazyFunctionCallback(std::string mangled_name) {}
+
     ///\brief This callback is invoked whenever interpreter has committed new
     /// portion of declarations.
     ///

--- a/interpreter/cling/lib/Interpreter/MultiplexInterpreterCallbacks.h
+++ b/interpreter/cling/lib/Interpreter/MultiplexInterpreterCallbacks.h
@@ -77,6 +77,12 @@ namespace cling {
        }
      }
 
+     void LazyFunctionCallback(std::string mangled_name) override {
+       for (auto&& cb : m_Callbacks) {
+         cb->LazyFunctionCallback(mangled_name);
+       }
+     }
+
      void TransactionUnloaded(const Transaction& T) override {
        for (auto&& cb : m_Callbacks) {
          cb->TransactionUnloaded(T);


### PR DESCRIPTION
We had test failures in runtime nightlies such as this one:
https://epsft-jenkins.cern.ch/view/ROOT/job/root-nightly-runtime-cxxmodules/95/BUILDTYPE=Debug,COMPILER=gcc62,LABEL=slc6/testReport/junit/projectroot.roottest.root.math/smatrix/roottest_root_math_smatrix_testKalman/

Failures were due to what @pcanal commented in #2135, that some so files in
roottest doesn't have external linkage. (It means that if you call
    dlopen(libfoo.so), linux kernel can't find dependency libraries and it
    emits "undefined symbol" error when they try to initialize global
    variables in libfoo.so but couldn't find symbol definition)
With pch, rootmap files were providing information about the depending library.

However we stopped generating rootmap files in #2127 and that's why we
got these failures. To fix this issue, I implemented a callback to
TCling which gets called when DynamicLibraryManager fails with
"undefined error".

I'm open to suggestion especially in DynamicLibraryManager.cpp.