### PR TITLE
[TREEPROC] Refactoring: move dataset info to TTreeProcessorMT 

### DIFF
--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -54,6 +54,16 @@ namespace ROOT {
          Long64_t end;
       };
 
+      /// Names, aliases, and file names of a TTree's or TChain's friends
+      using NameAlias = std::pair<std::string, std::string>;
+      struct FriendInfo {
+         /// Pairs of names and aliases of friend trees/chains
+         std::vector<Internal::NameAlias> fFriendNames;
+         /// Names of the files where each friend is stored. fFriendFileNames[i] is the list of files for friend with
+         /// name fFriendNames[i]
+         std::vector<std::vector<std::string>> fFriendFileNames;
+      };
+
       // EntryClusters and number of entries per file
       using ClustersAndEntries = std::pair<std::vector<std::vector<EntryCluster>>, std::vector<Long64_t>>;
       ClustersAndEntries MakeClusters(const std::string &treename, const std::vector<std::string> &filenames);
@@ -61,64 +71,40 @@ namespace ROOT {
       class TTreeView {
       private:
          using TreeReaderEntryListPair = std::pair<std::unique_ptr<TTreeReader>, std::unique_ptr<TEntryList>>;
-         using NameAlias = std::pair<std::string, std::string>;
 
          // NOTE: fFriends must come before fChain to be deleted after it, see ROOT-9281 for more details
          std::vector<std::unique_ptr<TChain>> fFriends; ///< Friends of the tree/chain
          std::unique_ptr<TChain> fChain;                ///< Chain on which to operate
-         std::vector<std::string> fFileNames;           ///< Names of the files
-         std::string fTreeName;                         ///< Name of the tree
-         TEntryList fEntryList; ///< User-defined selection of entry numbers to be processed, empty if none was provided
          std::vector<Long64_t> fLoadedEntries;          ///<! Per-task loaded entries (for task interleaving)
-         std::vector<NameAlias> fFriendNames;           ///< <name,alias> pairs of the friends of the tree/chain
-         std::vector<std::vector<std::string>> fFriendFileNames; ///< Names of the files where friends are stored
-
-         ////////////////////////////////////////////////////////////////////////////////
-         /// If not treeName was provided to the ctor, use the name of the first TTree in the first file, else throw.
-         void GetTreeNameIfNeeded()
-         {
-            // If the tree name is empty, look for a tree in the file
-            if (fTreeName.empty()) {
-               ::TDirectory::TContext ctxt(gDirectory);
-               std::unique_ptr<TFile> f(TFile::Open(fFileNames[0].c_str()));
-               TIter next(f->GetListOfKeys());
-               while (TKey *key = (TKey *)next()) {
-                  const char *className = key->GetClassName();
-                  if (strcmp(className, "TTree") == 0) {
-                     fTreeName = key->GetName();
-                     break;
-                  }
-               }
-               if (fTreeName.empty()) {
-                  auto msg = "Cannot find any tree in file " + fFileNames[0];
-                  throw std::runtime_error(msg);
-               }
-            }
-         }
 
          ////////////////////////////////////////////////////////////////////////////////
          /// Construct fChain, also adding friends if needed and injecting knowledge of offsets if available.
-         void MakeChain(const std::vector<std::string> &fileNames, const std::vector<Long64_t> &nEntries,
+         void MakeChain(const std::string &treeName, const std::vector<std::string> &fileNames,
+                        const FriendInfo &friendInfo, const std::vector<Long64_t> &nEntries,
                         const std::vector<std::vector<Long64_t>> &friendEntries)
          {
-            fChain.reset(new TChain(fTreeName.c_str()));
+            const std::vector<NameAlias> &friendNames = friendInfo.fFriendNames;
+            const std::vector<std::vector<std::string>> &friendFileNames = friendInfo.fFriendFileNames;
+
+            fChain.reset(new TChain(treeName.c_str()));
             const auto nFiles = fileNames.size();
             for (auto i = 0u; i < nFiles; ++i) {
                fChain->Add(fileNames[i].c_str(), nEntries[i]);
             }
             fChain->ResetBit(TObject::kMustCleanup);
 
-            const auto nFriends = fFriendNames.size();
+            fFriends.clear();
+            const auto nFriends = friendNames.size();
             for (auto i = 0u; i < nFriends; ++i) {
-               const auto &friendName = fFriendNames[i];
+               const auto &friendName = friendNames[i];
                const auto &name = friendName.first;
                const auto &alias = friendName.second;
 
                // Build a friend chain
                auto frChain = std::make_unique<TChain>(name.c_str());
-               const auto nFileNames = fFriendFileNames[i].size();
+               const auto nFileNames = friendFileNames[i].size();
                for (auto j = 0u; j < nFileNames; ++j)
-                  frChain->Add(fFriendFileNames[i][j].c_str(), friendEntries[i][j]);
+                  frChain->Add(friendFileNames[i][j].c_str(), friendEntries[i][j]);
 
                // Make it friends with the main chain
                fChain->AddFriend(frChain.get(), alias.c_str());
@@ -126,56 +112,21 @@ namespace ROOT {
             }
          }
 
-         ////////////////////////////////////////////////////////////////////////////////
-         /// Get and store the names, aliases and file names of the friends of the tree.
-         void StoreFriends(const TTree &tree, bool isTree)
-         {
-            auto friends = tree.GetListOfFriends();
-            if (!friends)
-               return;
-
-            for (auto fr : *friends) {
-               auto frTree = static_cast<TFriendElement *>(fr)->GetTree();
-
-               // Check if friend tree has an alias
-               auto realName = frTree->GetName();
-               auto alias = tree.GetFriendAlias(frTree);
-               if (alias) {
-                  fFriendNames.emplace_back(std::make_pair(realName, std::string(alias)));
-               } else {
-                  fFriendNames.emplace_back(std::make_pair(realName, ""));
-               }
-
-               // Store the file names of the friend tree
-               fFriendFileNames.emplace_back();
-               auto &fileNames = fFriendFileNames.back();
-               if (isTree) {
-                  auto f = frTree->GetCurrentFile();
-                  fileNames.emplace_back(f->GetName());
-               } else {
-                  auto frChain = static_cast<TChain *>(frTree);
-                  for (auto f : *(frChain->GetListOfFiles())) {
-                     fileNames.emplace_back(f->GetTitle());
-                  }
-               }
-            }
-         }
-
-         TreeReaderEntryListPair MakeReaderWithEntryList(Long64_t start, Long64_t end)
+         TreeReaderEntryListPair MakeReaderWithEntryList(TEntryList &globalList, Long64_t start, Long64_t end)
          {
             // TEntryList and SetEntriesRange do not work together (the former has precedence).
             // We need to construct a TEntryList that contains only those entry numbers in our desired range.
-            auto elist = std::make_unique<TEntryList>();
-            Long64_t entry = fEntryList.GetEntry(0);
+            auto localList = std::make_unique<TEntryList>();
+            Long64_t entry = globalList.GetEntry(0);
             do {
                if (entry >= end)
                   break;
                else if (entry >= start)
-                  elist->Enter(entry);
-            } while ((entry = fEntryList.Next()) >= 0);
+                  localList->Enter(entry);
+            } while ((entry = globalList.Next()) >= 0);
 
-            auto reader = std::make_unique<TTreeReader>(fChain.get(), elist.get());
-            return std::make_pair(std::move(reader), std::move(elist));
+            auto reader = std::make_unique<TTreeReader>(fChain.get(), localList.get());
+            return std::make_pair(std::move(reader), std::move(localList));
          }
 
          std::unique_ptr<TTreeReader> MakeReader(Long64_t start, Long64_t end)
@@ -187,132 +138,30 @@ namespace ROOT {
          }
 
       public:
-         //////////////////////////////////////////////////////////////////////////
-         /// Constructor based on a file name.
-         /// \param[in] fn Name of the file containing the tree to process.
-         /// \param[in] tn Name of the tree to process. If not provided,
-         ///               the implementation will automatically search for a
-         ///               tree in the file.
-         TTreeView(std::string_view fn, std::string_view tn) : fTreeName(tn)
-         {
-            fFileNames.emplace_back(fn);
-            GetTreeNameIfNeeded();
-         }
+         TTreeView() {}
 
-         //////////////////////////////////////////////////////////////////////////
-         /// Constructor based on a collection of file names.
-         /// \param[in] fns Collection of file names containing the tree to process.
-         /// \param[in] tn Name of the tree to process. If not provided,
-         ///               the implementation will automatically search for a
-         ///               tree in the collection of files.
-         TTreeView(const std::vector<std::string_view>& fns, std::string_view tn) : fTreeName(tn)
-         {
-            if (fns.size() > 0) {
-               for (auto& fn : fns)
-                  fFileNames.emplace_back(fn);
-            }
-            else {
-               auto msg = "The provided list of file names is empty, cannot process tree " + fTreeName;
-               throw std::runtime_error(msg);
-            }
-            GetTreeNameIfNeeded();
-         }
-
-         //////////////////////////////////////////////////////////////////////////
-         /// Constructor based on a TTree.
-         /// \param[in] tree Tree or chain of files containing the tree to process.
-         TTreeView(TTree& tree) : fTreeName(tree.GetName())
-         {
-            static const TClassRef clRefTChain("TChain");
-            if (clRefTChain == tree.IsA()) {
-               TObjArray* filelist = static_cast<TChain&>(tree).GetListOfFiles();
-               if (filelist->GetEntries() > 0) { 
-                  for (auto f : *filelist)
-                     fFileNames.emplace_back(f->GetTitle());
-                  StoreFriends(tree, false);
-               }
-               else {
-                  auto msg = "The provided chain of files is empty, cannot process tree " + fTreeName;
-                  throw std::runtime_error(msg);
-               }
-            }
-            else {
-               TFile *f = tree.GetCurrentFile();
-               if (f) {
-                  fFileNames.emplace_back(f->GetName());
-                  StoreFriends(tree, true);
-               }
-               else {
-                  auto msg = "The specified TTree is not linked to any file, in-memory-only trees are not supported. Cannot process tree " + fTreeName;
-                  throw std::runtime_error(msg);
-               } 
-            }
-         }
-
-         //////////////////////////////////////////////////////////////////////////
-         /// Constructor based on a TTree and a TEntryList.
-         /// \param[in] tree Tree or chain of files containing the tree to process.
-         /// \param[in] entries List of entry numbers to process.
-         TTreeView(TTree& tree, TEntryList& entries) : TTreeView(tree)
-         {
-            Long64_t numEntries = entries.GetN();
-            for (Long64_t i = 0; i < numEntries; ++i) {
-               fEntryList.Enter(entries.GetEntry(i));
-            }
-         }
-
-         //////////////////////////////////////////////////////////////////////////
-         /// Copy constructor.
-         /// \param[in] view Object to copy.
-         TTreeView(const TTreeView &view) : fTreeName(view.fTreeName), fEntryList(view.fEntryList)
-         {
-            for (auto& fn : view.fFileNames)
-               fFileNames.emplace_back(fn);
-
-            for (auto &fn : view.fFriendNames)
-               fFriendNames.emplace_back(fn);
-
-            for (auto &ffn : view.fFriendFileNames) {
-               fFriendFileNames.emplace_back();
-               auto &fileNames = fFriendFileNames.back();
-               for (auto &name : ffn) {
-                  fileNames.emplace_back(name);
-               }
-            }
-         }
+         // no-op, we don't want to copy the local TChains
+         TTreeView(const TTreeView &) {}
 
          //////////////////////////////////////////////////////////////////////////
          /// Get a TTreeReader for the current tree of this view.
-         TreeReaderEntryListPair GetTreeReader(Long64_t start, Long64_t end, const std::vector<std::string> &fileNames,
-                                               const std::vector<Long64_t> &nEntries,
+         TreeReaderEntryListPair GetTreeReader(Long64_t start, Long64_t end, const std::string &treeName,
+                                               const std::vector<std::string> &fileNames, const FriendInfo &friendInfo,
+                                               TEntryList entryList, const std::vector<Long64_t> &nEntries,
                                                const std::vector<std::vector<Long64_t>> &friendEntries)
          {
-            MakeChain(fileNames, nEntries, friendEntries);
+            MakeChain(treeName, fileNames, friendInfo, nEntries, friendEntries);
 
             std::unique_ptr<TTreeReader> reader;
-            std::unique_ptr<TEntryList> elist;
-            if (fEntryList.GetN() > 0) {
-               std::tie(reader, elist) = MakeReaderWithEntryList(start, end);
+            std::unique_ptr<TEntryList> localList;
+            if (entryList.GetN() > 0) {
+               std::tie(reader, localList) = MakeReaderWithEntryList(entryList, start, end);
             } else {
                reader = MakeReader(start, end);
             }
 
             // we need to return the entry list too, as it needs to be in scope as long as the reader is
-            return std::make_pair(std::move(reader), std::move(elist));
-         }
-
-         //////////////////////////////////////////////////////////////////////////
-         /// Get the filenames for this view.
-         const std::vector<std::string> &GetFileNames() const
-         {
-            return fFileNames;
-         }
-
-         //////////////////////////////////////////////////////////////////////////
-         /// Get the name of the tree of this view.
-         std::string GetTreeName() const
-         {
-            return fTreeName;
+            return std::make_pair(std::move(reader), std::move(localList));
          }
 
          //////////////////////////////////////////////////////////////////////////
@@ -328,37 +177,29 @@ namespace ROOT {
                fChain->LoadTree(fLoadedEntries.back());
             }
          }
-
-         const std::vector<NameAlias> &GetFriendNames() const
-         {
-            return fFriendNames;
-         }
-
-         const std::vector<std::vector<std::string>> &GetFriendFileNames() const
-         {
-            return fFriendFileNames;
-         }
-
-         const TEntryList &GetEntryList() const
-         {
-            return fEntryList;
-         }
       };
    } // End of namespace Internal
 
-
    class TTreeProcessorMT {
    private:
+      const std::vector<std::string> fFileNames; ///< Names of the files
+      const std::string fTreeName;               ///< Name of the tree
+      /// User-defined selection of entry numbers to be processed, empty if none was provided
+      const TEntryList fEntryList;
+      const Internal::FriendInfo fFriendInfo;
+
       ROOT::TThreadedObject<ROOT::Internal::TTreeView> treeView; ///<! Thread-local TreeViews
+
+      Internal::FriendInfo GetFriendInfo(TTree &tree);
+      std::string GetTreeName();
 
    public:
       TTreeProcessorMT(std::string_view filename, std::string_view treename = "");
-      TTreeProcessorMT(const std::vector<std::string_view>& filenames, std::string_view treename = "");
-      TTreeProcessorMT(TTree& tree);
-      TTreeProcessorMT(TTree& tree, TEntryList& entries);
- 
-      void Process(std::function<void(TTreeReader&)> func);
+      TTreeProcessorMT(const std::vector<std::string_view> &filenames, std::string_view treename = "");
+      TTreeProcessorMT(TTree &tree, const TEntryList &entries);
+      TTreeProcessorMT(TTree &tree);
 
+      void Process(std::function<void(TTreeReader &)> func);
    };
 
 } // End of namespace ROOT

--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -193,7 +193,7 @@ namespace ROOT {
       ROOT::TThreadedObject<ROOT::Internal::TTreeView> treeView; ///<! Thread-local TreeViews
 
       Internal::FriendInfo GetFriendInfo(TTree &tree);
-      std::string GetTreeName();
+      std::string FindTreeName();
 
    public:
       TTreeProcessorMT(std::string_view filename, std::string_view treename = "");

--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -150,7 +150,9 @@ namespace ROOT {
                                                TEntryList entryList, const std::vector<Long64_t> &nEntries,
                                                const std::vector<std::vector<Long64_t>> &friendEntries)
          {
-            MakeChain(treeName, fileNames, friendInfo, nEntries, friendEntries);
+            const bool usingLocalEntries = friendInfo.fFriendNames.empty() && entryList.GetN() == 0;
+            if (usingLocalEntries || fChain == nullptr)
+               MakeChain(treeName, fileNames, friendInfo, nEntries, friendEntries);
 
             std::unique_ptr<TTreeReader> reader;
             std::unique_ptr<TEntryList> localList;

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -103,7 +103,7 @@ Internal::FriendInfo TTreeProcessorMT::GetFriendInfo(TTree &tree)
 
    const auto friends = tree.GetListOfFriends();
    if (!friends)
-      return Internal::FriendInfo{};
+      return Internal::FriendInfo();
 
    for (auto fr : *friends) {
       const auto frTree = static_cast<TFriendElement *>(fr)->GetTree();

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -135,7 +135,7 @@ Internal::FriendInfo TTreeProcessorMT::GetFriendInfo(TTree &tree)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Retrieve the name of the first TTree in the first input file, else throw.
-std::string TTreeProcessorMT::GetTreeName()
+std::string TTreeProcessorMT::FindTreeName()
 {
    std::string treeName;
 
@@ -165,7 +165,7 @@ std::string TTreeProcessorMT::GetTreeName()
 ///                     the implementation will automatically search for a
 ///                     tree in the file.
 TTreeProcessorMT::TTreeProcessorMT(std::string_view filename, std::string_view treename)
-   : fFileNames({std::string(filename)}), fTreeName(treename.empty() ? GetTreeName() : treename) {}
+   : fFileNames({std::string(filename)}), fTreeName(treename.empty() ? FindTreeName() : treename) {}
 
 std::vector<std::string> CheckAndConvert(const std::vector<std::string_view> & views)
 {
@@ -186,7 +186,7 @@ std::vector<std::string> CheckAndConvert(const std::vector<std::string_view> & v
 ///                     the implementation will automatically search for a
 ///                     tree in the collection of files.
 TTreeProcessorMT::TTreeProcessorMT(const std::vector<std::string_view> &filenames, std::string_view treename)
-   : fFileNames(CheckAndConvert(filenames)), fTreeName(treename.empty() ? GetTreeName() : treename) {}
+   : fFileNames(CheckAndConvert(filenames)), fTreeName(treename.empty() ? FindTreeName() : treename) {}
 
 std::vector<std::string> GetFilesFromTree(TTree &tree)
 {

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -91,13 +91,93 @@ std::vector<std::vector<Long64_t>> GetFriendEntries(const std::vector<std::pair<
 }
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Get and store the names, aliases and file names of the friends of the tree.
+/// \param[in] tree The main tree whose friends to 
+Internal::FriendInfo TTreeProcessorMT::GetFriendInfo(TTree &tree)
+{
+   std::vector<Internal::NameAlias> friendNames;
+   std::vector<std::vector<std::string>> friendFileNames;
+
+   const auto friends = tree.GetListOfFriends();
+   if (!friends)
+      return Internal::FriendInfo{};
+
+   for (auto fr : *friends) {
+      const auto frTree = static_cast<TFriendElement *>(fr)->GetTree();
+
+      // Check if friend tree has an alias
+      const auto realName = frTree->GetName();
+      const auto alias = tree.GetFriendAlias(frTree);
+      if (alias) {
+         friendNames.emplace_back(std::make_pair(realName, std::string(alias)));
+      } else {
+         friendNames.emplace_back(std::make_pair(realName, ""));
+      }
+
+      // Store the file names of the friend tree
+      friendFileNames.emplace_back();
+      auto &fileNames = friendFileNames.back();
+      const bool isChain = tree.IsA() == TClassRef("TChain");
+      if (isChain) {
+         const auto frChain = static_cast<TChain *>(frTree);
+         for (auto f : *(frChain->GetListOfFiles())) {
+            fileNames.emplace_back(f->GetTitle());
+         }
+      } else {
+         const auto f = frTree->GetCurrentFile();
+         fileNames.emplace_back(f->GetName());
+      }
+   }
+
+   return Internal::FriendInfo{std::move(friendNames), std::move(friendFileNames)};
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Retrieve the name of the first TTree in the first input file, else throw.
+std::string TTreeProcessorMT::GetTreeName()
+{
+   std::string treeName;
+
+   if (fFileNames.empty())
+      throw std::runtime_error("Empty list of files and no tree name provided");
+
+   ::TDirectory::TContext ctxt(gDirectory);
+   std::unique_ptr<TFile> f(TFile::Open(fFileNames[0].c_str()));
+   TIter next(f->GetListOfKeys());
+   while (TKey *key = (TKey *)next()) {
+      const char *className = key->GetClassName();
+      if (strcmp(className, "TTree") == 0) {
+         treeName = key->GetName();
+         break;
+      }
+   }
+   if (treeName.empty())
+      throw std::runtime_error("Cannot find any tree in file " + fFileNames[0]);
+
+   return treeName;
+}
+
 ////////////////////////////////////////////////////////////////////////
 /// Constructor based on a file name.
 /// \param[in] filename Name of the file containing the tree to process.
 /// \param[in] treename Name of the tree to process. If not provided,
 ///                     the implementation will automatically search for a
 ///                     tree in the file.
-TTreeProcessorMT::TTreeProcessorMT(std::string_view filename, std::string_view treename) : treeView(filename, treename) {}
+TTreeProcessorMT::TTreeProcessorMT(std::string_view filename, std::string_view treename)
+   : fFileNames({std::string(filename)}), fTreeName(treename.empty() ? GetTreeName() : treename) {}
+
+std::vector<std::string> CheckAndConvert(const std::vector<std::string_view> & views)
+{
+   if (views.empty())
+      throw std::runtime_error("The provided list of file names is empty");
+
+   std::vector<std::string> strings;
+   strings.reserve(views.size());
+   for (const auto &v : views)
+      strings.emplace_back(v);
+   return strings;
+}
 
 ////////////////////////////////////////////////////////////////////////
 /// Constructor based on a collection of file names.
@@ -105,18 +185,47 @@ TTreeProcessorMT::TTreeProcessorMT(std::string_view filename, std::string_view t
 /// \param[in] treename Name of the tree to process. If not provided,
 ///                     the implementation will automatically search for a
 ///                     tree in the collection of files.
-TTreeProcessorMT::TTreeProcessorMT(const std::vector<std::string_view> &filenames, std::string_view treename) : treeView(filenames, treename) {}
+TTreeProcessorMT::TTreeProcessorMT(const std::vector<std::string_view> &filenames, std::string_view treename)
+   : fFileNames(CheckAndConvert(filenames)), fTreeName(treename.empty() ? GetTreeName() : treename) {}
 
-////////////////////////////////////////////////////////////////////////
-/// Constructor based on a TTree.
-/// \param[in] tree Tree or chain of files containing the tree to process.
-TTreeProcessorMT::TTreeProcessorMT(TTree &tree) : treeView(tree) {}
+std::vector<std::string> GetFilesFromTree(TTree &tree)
+{
+   std::vector<std::string> filenames;
+
+   const bool isChain = tree.IsA() == TClassRef("TChain");
+   if (isChain) {
+      TObjArray *filelist = static_cast<TChain &>(tree).GetListOfFiles();
+      const auto nFiles = filelist->GetEntries();
+      if (nFiles == 0)
+         throw std::runtime_error("The provided chain of files is empty");
+      filenames.reserve(nFiles);
+      for (auto f : *filelist)
+         filenames.emplace_back(f->GetTitle());
+   } else {
+      TFile *f = tree.GetCurrentFile();
+      if (!f) {
+         const auto msg = "The specified TTree is not linked to any file, in-memory-only trees are not supported.";
+         throw std::runtime_error(msg);
+      }
+
+      filenames.emplace_back(f->GetName());
+   }
+
+   return filenames;
+}
 
 ////////////////////////////////////////////////////////////////////////
 /// Constructor based on a TTree and a TEntryList.
 /// \param[in] tree Tree or chain of files containing the tree to process.
 /// \param[in] entries List of entry numbers to process.
-TTreeProcessorMT::TTreeProcessorMT(TTree &tree, TEntryList &entries) : treeView(tree, entries) {}
+TTreeProcessorMT::TTreeProcessorMT(TTree &tree, const TEntryList &entries)
+   : fFileNames(GetFilesFromTree(tree)), fTreeName(tree.GetName()), fEntryList(entries),
+     fFriendInfo(GetFriendInfo(tree)) {}
+
+////////////////////////////////////////////////////////////////////////
+/// Constructor based on a TTree.
+/// \param[in] tree Tree or chain of files containing the tree to process.
+TTreeProcessorMT::TTreeProcessorMT(TTree &tree) : TTreeProcessorMT(tree, TEntryList()) {}
 
 //////////////////////////////////////////////////////////////////////////////
 /// Process the entries of a TTree in parallel. The user-provided function
@@ -137,21 +246,22 @@ TTreeProcessorMT::TTreeProcessorMT(TTree &tree, TEntryList &entries) : treeView(
 /// \param[in] func User-defined function that processes a subrange of entries
 void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
 {
+   const std::vector<Internal::NameAlias> &friendNames = fFriendInfo.fFriendNames;
+   const std::vector<std::vector<std::string>> &friendFileNames = fFriendInfo.fFriendFileNames;
+
    // If an entry list or friend trees are present, we need to generate clusters with global entry numbers,
    // so we do it here for all files.
-   const bool hasFriends = !treeView->GetFriendNames().empty();
-   const bool hasEntryList = treeView->GetEntryList().GetN() > 0;
+   const bool hasFriends = !friendNames.empty();
+   const bool hasEntryList = fEntryList.GetN() > 0;
    const bool shouldRetrieveAllClusters = hasFriends || hasEntryList;
-   const auto clustersAndEntries = shouldRetrieveAllClusters
-                                      ? Internal::MakeClusters(treeView->GetTreeName(), treeView->GetFileNames())
-                                      : Internal::ClustersAndEntries{};
+   const auto clustersAndEntries =
+      shouldRetrieveAllClusters ? Internal::MakeClusters(fTreeName, fFileNames) : Internal::ClustersAndEntries{};
    const auto &clusters = clustersAndEntries.first;
    const auto &entries = clustersAndEntries.second;
 
    // Retrieve number of entries for each file for each friend tree
    const auto friendEntries =
-      hasFriends ? Internal::GetFriendEntries(treeView->GetFriendNames(), treeView->GetFriendFileNames())
-                 : std::vector<std::vector<Long64_t>>{};
+      hasFriends ? Internal::GetFriendEntries(friendNames, friendFileNames) : std::vector<std::vector<Long64_t>>{};
 
    TThreadExecutor pool;
    // Parent task, spawns tasks that process each of the entry clusters for each input file
@@ -162,12 +272,10 @@ void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
       // Otherwise get cluster information only for the file we need to process and use local entry numbers
       const bool shouldUseGlobalEntries = hasFriends || hasEntryList;
       // theseFiles contains either all files or just the single file to process
-      const auto &theseFiles = shouldUseGlobalEntries ? treeView->GetFileNames()
-                                                      : std::vector<std::string>({treeView->GetFileNames()[fileIdx]});
+      const auto &theseFiles = shouldUseGlobalEntries ? fFileNames : std::vector<std::string>({fFileNames[fileIdx]});
       // Evaluate clusters (with local entry numbers) and number of entries for this file, if needed
-      const auto theseClustersAndEntries = shouldUseGlobalEntries
-                                              ? Internal::ClustersAndEntries{}
-                                              : Internal::MakeClusters(treeView->GetTreeName(), theseFiles);
+      const auto theseClustersAndEntries =
+         shouldUseGlobalEntries ? Internal::ClustersAndEntries{} : Internal::MakeClusters(fTreeName, theseFiles);
 
       // All clusters for the file to process, either with global or local entry numbers
       const auto &thisFileClusters = shouldUseGlobalEntries ? clusters[fileIdx] : theseClustersAndEntries.first[0];
@@ -182,7 +290,8 @@ void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
 
          std::unique_ptr<TTreeReader> reader;
          std::unique_ptr<TEntryList> elist;
-         std::tie(reader, elist) = treeView->GetTreeReader(c.start, c.end, theseFiles, theseEntries, friendEntries);
+         std::tie(reader, elist) = treeView->GetTreeReader(c.start, c.end, fTreeName, theseFiles, fFriendInfo,
+                                                           fEntryList, theseEntries, friendEntries);
          func(*reader);
 
          // In case of task interleaving, we need to load here the tree of the parent task
@@ -192,7 +301,7 @@ void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
       pool.Foreach(processCluster, thisFileClusters);
    };
 
-   std::vector<std::size_t> fileIdxs(treeView->GetFileNames().size());
+   std::vector<std::size_t> fileIdxs(fFileNames.size());
    std::iota(fileIdxs.begin(), fileIdxs.end(), 0u);
 
    // Enable this IMT use case (activate its locks)

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -94,6 +94,8 @@ std::vector<std::vector<Long64_t>> GetFriendEntries(const std::vector<std::pair<
 ////////////////////////////////////////////////////////////////////////////////
 /// Get and store the names, aliases and file names of the friends of the tree.
 /// \param[in] tree The main tree whose friends to 
+///
+/// Note that "friends of friends" and circular references in the lists of friends are not supported.
 Internal::FriendInfo TTreeProcessorMT::GetFriendInfo(TTree &tree)
 {
    std::vector<Internal::NameAlias> friendNames;

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -120,7 +120,7 @@ Internal::FriendInfo TTreeProcessorMT::GetFriendInfo(TTree &tree)
       // Store the file names of the friend tree
       friendFileNames.emplace_back();
       auto &fileNames = friendFileNames.back();
-      const bool isChain = tree.IsA() == TClassRef("TChain");
+      const bool isChain = tree.IsA() == TChain::Class();
       if (isChain) {
          const auto frChain = static_cast<TChain *>(frTree);
          for (auto f : *(frChain->GetListOfFiles())) {
@@ -194,7 +194,7 @@ std::vector<std::string> GetFilesFromTree(TTree &tree)
 {
    std::vector<std::string> filenames;
 
-   const bool isChain = tree.IsA() == TClassRef("TChain");
+   const bool isChain = tree.IsA() == TChain::Class();
    if (isChain) {
       TObjArray *filelist = static_cast<TChain &>(tree).GetListOfFiles();
       const auto nFiles = filelist->GetEntries();


### PR DESCRIPTION
Previously all the dataset information was stored in the thread-local
TTreeViews, causing data duplication between threads and requiring
that TTreeProcessorMT queries it when it needs part of it.
Now TTreeProcessorMT stores all the dataset information (tree name,
filenames, friend names, friend file names, entry list) as constant
thread-global data which is passed down to TTreeView::GetTreeReader.