### PR TITLE
Fix execUnloading test which sometimes fails with centos7/gcc7

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -4189,6 +4189,7 @@ Int_t TCling::GenerateDictionary(const char* classes, const char* includes /* = 
 TInterpreter::DeclId_t TCling::GetDataMember(ClassInfo_t *opaque_cl, const char *name) const
 {
    R__LOCKGUARD(gInterpreterMutex);
+   cling::Interpreter::PushTransactionRAII RAII(fInterpreter);
    DeclId_t d;
    TClingClassInfo *cl = (TClingClassInfo*)opaque_cl;
 


### PR DESCRIPTION
https://epsft-jenkins.cern.ch/job/root-pullrequests-build/29347/testReport/projectroot.roottest.root/meta/roottest_root_meta_execUnloading_auto/

TCling::GetDataMember is triggering deserialization. I think
we had RAII here in the past but maybe it was accidentaly deleted?