### PR TITLE
[TREEPROCMT] Explicitly initialize fFriendInfo in ctors

### DIFF
--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -167,7 +167,7 @@ std::string TTreeProcessorMT::FindTreeName()
 ///                     the implementation will automatically search for a
 ///                     tree in the file.
 TTreeProcessorMT::TTreeProcessorMT(std::string_view filename, std::string_view treename)
-   : fFileNames({std::string(filename)}), fTreeName(treename.empty() ? FindTreeName() : treename) {}
+   : fFileNames({std::string(filename)}), fTreeName(treename.empty() ? FindTreeName() : treename), fFriendInfo() {}
 
 std::vector<std::string> CheckAndConvert(const std::vector<std::string_view> & views)
 {
@@ -188,7 +188,7 @@ std::vector<std::string> CheckAndConvert(const std::vector<std::string_view> & v
 ///                     the implementation will automatically search for a
 ///                     tree in the collection of files.
 TTreeProcessorMT::TTreeProcessorMT(const std::vector<std::string_view> &filenames, std::string_view treename)
-   : fFileNames(CheckAndConvert(filenames)), fTreeName(treename.empty() ? FindTreeName() : treename) {}
+   : fFileNames(CheckAndConvert(filenames)), fTreeName(treename.empty() ? FindTreeName() : treename), fFriendInfo() {}
 
 std::vector<std::string> GetFilesFromTree(TTree &tree)
 {


### PR DESCRIPTION
This should fix clang's compilation error:
"constructor for 'ROOT::TTreeProcessorMT' must explicitly initialize the const member 'fFriendInfo'"