### PR TITLE
[IO] Backport hashing of StreamerInfos before injecting them in the type system

### DIFF
--- a/core/foundation/res/ROOT/RSha256.hxx
+++ b/core/foundation/res/ROOT/RSha256.hxx
@@ -1,0 +1,317 @@
+// Author: Danilo Piparo May 2018
+// Inspired by public domain code of Igor Pavlov: https://github.com/jb55/sha256.c
+
+/*************************************************************************
+ * Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_RSHA
+#define ROOT_RSHA
+
+#include "Rtypes.h"
+#include <stdlib.h>
+#include <stdint.h>
+
+#ifdef _MSC_VER
+
+#define ROTL32(v, n) _rotl((v), (n))
+#define ROTL64(v, n) _rotl64((v), (n))
+
+#define ROTR32(v, n) _rotr((v), (n))
+#define ROTR64(v, n) _rotr64((v), (n))
+
+#else
+
+#define U8V(v) ((uint8_t)(v)&0xFFU)
+#define U16V(v) ((uint16_t)(v)&0xFFFFU)
+#define U32V(v) ((uint32_t)(v)&0xFFFFFFFFU)
+#define U64V(v) ((uint64_t)(v)&0xFFFFFFFFFFFFFFFFU)
+
+#define ROTL32(v, n) (U32V((uint32_t)(v) << (n)) | ((uint32_t)(v) >> (32 - (n))))
+
+// tests fail if we don't have this cast...
+#define ROTL64(v, n) (U64V((uint64_t)(v) << (n)) | ((uint64_t)(v) >> (64 - (n))))
+
+#define ROTR32(v, n) ROTL32(v, 32 - (n))
+#define ROTR64(v, n) ROTL64(v, 64 - (n))
+
+#endif
+
+#define ROTL8(v, n) (U8V((uint8_t)(v) << (n)) | ((uint8_t)(v) >> (8 - (n))))
+
+#define ROTL16(v, n) (U16V((uint16_t)(v) << (n)) | ((uint16_t)(v) >> (16 - (n))))
+
+#define ROTR8(v, n) ROTL8(v, 8 - (n))
+#define ROTR16(v, n) ROTL16(v, 16 - (n))
+
+#define SHA256_DIGEST_SIZE 32
+
+typedef struct sha256_t {
+   uint32_t state[8];
+   uint64_t count;
+   unsigned char buffer[64];
+} sha256_t;
+
+void sha256_init(sha256_t *p);
+void sha256_update(sha256_t *p, const unsigned char *data, size_t size);
+void sha256_final(sha256_t *p, unsigned char *digest);
+void sha256_hash(unsigned char *buf, const unsigned char *data, size_t size);
+
+/* define it for speed optimization */
+#define _SHA256_UNROLL
+#define _SHA256_UNROLL2
+
+void sha256_init(sha256_t *p)
+{
+   p->state[0] = 0x6a09e667;
+   p->state[1] = 0xbb67ae85;
+   p->state[2] = 0x3c6ef372;
+   p->state[3] = 0xa54ff53a;
+   p->state[4] = 0x510e527f;
+   p->state[5] = 0x9b05688c;
+   p->state[6] = 0x1f83d9ab;
+   p->state[7] = 0x5be0cd19;
+   p->count = 0;
+}
+
+#define S0(x) (ROTR32(x, 2) ^ ROTR32(x, 13) ^ ROTR32(x, 22))
+#define S1(x) (ROTR32(x, 6) ^ ROTR32(x, 11) ^ ROTR32(x, 25))
+#define s0(x) (ROTR32(x, 7) ^ ROTR32(x, 18) ^ (x >> 3))
+#define s1(x) (ROTR32(x, 17) ^ ROTR32(x, 19) ^ (x >> 10))
+
+#define blk0(i) (W[i] = data[i])
+#define blk2(i) (W[i & 15] += s1(W[(i - 2) & 15]) + W[(i - 7) & 15] + s0(W[(i - 15) & 15]))
+
+#define Ch(x, y, z) (z ^ (x & (y ^ z)))
+#define Maj(x, y, z) ((x & y) | (z & (x | y)))
+
+#define a(i) T[(0 - (i)) & 7]
+#define b(i) T[(1 - (i)) & 7]
+#define c(i) T[(2 - (i)) & 7]
+#define d(i) T[(3 - (i)) & 7]
+#define e(i) T[(4 - (i)) & 7]
+#define f(i) T[(5 - (i)) & 7]
+#define g(i) T[(6 - (i)) & 7]
+#define h(i) T[(7 - (i)) & 7]
+
+#ifdef _SHA256_UNROLL2
+
+#define R(a, b, c, d, e, f, g, h, i)                              \
+   h += S1(e) + Ch(e, f, g) + K[i + j] + (j ? blk2(i) : blk0(i)); \
+   d += h;                                                        \
+   h += S0(a) + Maj(a, b, c)
+
+#define RX_8(i)                        \
+   R(a, b, c, d, e, f, g, h, i);       \
+   R(h, a, b, c, d, e, f, g, (i + 1)); \
+   R(g, h, a, b, c, d, e, f, (i + 2)); \
+   R(f, g, h, a, b, c, d, e, (i + 3)); \
+   R(e, f, g, h, a, b, c, d, (i + 4)); \
+   R(d, e, f, g, h, a, b, c, (i + 5)); \
+   R(c, d, e, f, g, h, a, b, (i + 6)); \
+   R(b, c, d, e, f, g, h, a, (i + 7))
+
+#else
+
+#define R(i)                                                                     \
+   h(i) += S1(e(i)) + Ch(e(i), f(i), g(i)) + K[i + j] + (j ? blk2(i) : blk0(i)); \
+   d(i) += h(i);                                                                 \
+   h(i) += S0(a(i)) + Maj(a(i), b(i), c(i))
+
+#ifdef _SHA256_UNROLL
+
+#define RX_8(i) \
+   R(i + 0);    \
+   R(i + 1);    \
+   R(i + 2);    \
+   R(i + 3);    \
+   R(i + 4);    \
+   R(i + 5);    \
+   R(i + 6);    \
+   R(i + 7);
+
+#endif
+
+#endif
+
+static const uint32_t K[64] = {
+   0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+   0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+   0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+   0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+   0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+   0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+   0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+   0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
+
+static void sha256_transform(uint32_t *state, const uint32_t *data)
+{
+   uint32_t W[16];
+   unsigned j;
+#ifdef _SHA256_UNROLL2
+   uint32_t a, b, c, d, e, f, g, h;
+   a = state[0];
+   b = state[1];
+   c = state[2];
+   d = state[3];
+   e = state[4];
+   f = state[5];
+   g = state[6];
+   h = state[7];
+#else
+   uint32_t T[8];
+   for (j = 0; j < 8; j++)
+      T[j] = state[j];
+#endif
+
+   for (j = 0; j < 64; j += 16) {
+#if defined(_SHA256_UNROLL) || defined(_SHA256_UNROLL2)
+      RX_8(0);
+      RX_8(8);
+#else
+      unsigned i;
+      for (i = 0; i < 16; i++) {
+         R(i);
+      }
+#endif
+   }
+
+#ifdef _SHA256_UNROLL2
+   state[0] += a;
+   state[1] += b;
+   state[2] += c;
+   state[3] += d;
+   state[4] += e;
+   state[5] += f;
+   state[6] += g;
+   state[7] += h;
+#else
+   for (j = 0; j < 8; j++)
+      state[j] += T[j];
+#endif
+
+   /* Wipe variables */
+   /* memset(W, 0, sizeof(W)); */
+   /* memset(T, 0, sizeof(T)); */
+}
+
+#undef S0
+#undef S1
+#undef s0
+#undef s1
+
+static void sha256_write_byte_block(sha256_t *p)
+{
+   uint32_t data32[16];
+   unsigned i;
+   for (i = 0; i < 16; i++)
+      data32[i] = ((uint32_t)(p->buffer[i * 4]) << 24) + ((uint32_t)(p->buffer[i * 4 + 1]) << 16) +
+                  ((uint32_t)(p->buffer[i * 4 + 2]) << 8) + ((uint32_t)(p->buffer[i * 4 + 3]));
+   sha256_transform(p->state, data32);
+}
+
+void sha256_update(sha256_t *p, const unsigned char *data, size_t size)
+{
+   uint32_t curBufferPos = (uint32_t)p->count & 0x3F;
+   while (size > 0) {
+      p->buffer[curBufferPos++] = *data++;
+      p->count++;
+      size--;
+      if (curBufferPos == 64) {
+         curBufferPos = 0;
+         sha256_write_byte_block(p);
+      }
+   }
+}
+
+void sha256_final(sha256_t *p, unsigned char *digest)
+{
+   uint64_t lenInBits = (p->count << 3);
+   uint32_t curBufferPos = (uint32_t)p->count & 0x3F;
+   unsigned i;
+   p->buffer[curBufferPos++] = 0x80;
+   while (curBufferPos != (64 - 8)) {
+      curBufferPos &= 0x3F;
+      if (curBufferPos == 0)
+         sha256_write_byte_block(p);
+      p->buffer[curBufferPos++] = 0;
+   }
+   for (i = 0; i < 8; i++) {
+      p->buffer[curBufferPos++] = (unsigned char)(lenInBits >> 56);
+      lenInBits <<= 8;
+   }
+   sha256_write_byte_block(p);
+
+   for (i = 0; i < 8; i++) {
+      *digest++ = (unsigned char)(p->state[i] >> 24);
+      *digest++ = (unsigned char)(p->state[i] >> 16);
+      *digest++ = (unsigned char)(p->state[i] >> 8);
+      *digest++ = (unsigned char)(p->state[i]);
+   }
+   sha256_init(p);
+}
+
+namespace ROOT {
+namespace Internal {
+
+/// This helper class represents a sha256 hash. Operator == and std::less
+/// complete its functionality.
+class RSha256Hash {
+private:
+   void Sha256(const unsigned char *data, int len)
+   {
+      // Here the final cast is to match the interface of the C code and
+      // the data member. The lenght is the same!
+      sha256_init(&fHash);
+      sha256_update(&fHash, data, len);
+      sha256_final(&fHash, reinterpret_cast<unsigned char *>(fDigest));
+   }
+
+   sha256_t fHash;
+   ULong64_t fDigest[4];
+
+public:
+   RSha256Hash(const char *data, int len)
+   {
+      // The cast here is because in the TBuffer ecosystem, the type used is char*
+      Sha256(reinterpret_cast<const unsigned char *>(data), len);
+   }
+   ULong64_t const *Get() const { return fDigest; }
+};
+
+bool operator==(const RSha256Hash &lhs, const RSha256Hash &rhs)
+{
+   auto l = lhs.Get();
+   auto r = rhs.Get();
+   return l[0] == r[0] && l[1] == r[1] && l[2] == r[2] && l[3] == r[3];
+}
+
+} // End NS Internal
+} // End NS ROOT
+
+namespace std {
+template <>
+struct less<ROOT::Internal::RSha256Hash> {
+   bool operator()(const ROOT::Internal::RSha256Hash &lhs, const ROOT::Internal::RSha256Hash &rhs) const
+   {
+      /// Check piece by piece the 4 64 bits ints which make up the hash.
+      auto l = lhs.Get();
+      auto r = rhs.Get();
+      // clang-format off
+      return l[0] < r[0] ? true :
+               l[0] > r[0] ? false :
+                 l[1] < r[1] ? true :
+                   l[1] > r[1] ? false :
+                     l[2] < r[2] ? true :
+                       l[2] > r[2] ? false :
+                         l[3] < r[3] ? true : false;
+      // clang-format on
+   }
+};
+} // End NS std
+
+#endif

--- a/core/foundation/res/ROOT/RSha256.hxx
+++ b/core/foundation/res/ROOT/RSha256.hxx
@@ -150,7 +150,7 @@ static const uint32_t K[64] = {
 
 static void sha256_transform(uint32_t *state, const uint32_t *data)
 {
-   uint32_t W[16];
+   uint32_t W[16] = {0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U};
    unsigned j;
 #ifdef _SHA256_UNROLL2
    uint32_t a, b, c, d, e, f, g, h;

--- a/core/foundation/res/TSpinLockGuard.h
+++ b/core/foundation/res/TSpinLockGuard.h
@@ -18,18 +18,18 @@ namespace ROOT {
 namespace Internal {
 
 /**
- * \class ROOT::Internal::TSpinLockGuard
+* \class ROOT::Internal::TSpinLockGuard
 * \brief A spin mutex-as-code-guard class.
 * \ingroup Foundation
 * This class allows to acquire spin locks in combination with a std::atomic_flag variable.
 * For example:
-* ~~~ {.cpp}
+* ~~~{.cpp}
 * mutable std::atomic_flag fSpinLock;
 * [...]
 * ROOT::Internal::TSpinLockGuard slg(fSpinLock);
 * // do something important
 * [...]
-* ~~~ {.cpp}
+* ~~~{.cpp}
 */
 
 class TSpinLockGuard {

--- a/core/thread/CMakeLists.txt
+++ b/core/thread/CMakeLists.txt
@@ -2,10 +2,12 @@
 # CMakeLists.txt file for building ROOT core/thread package
 ############################################################################
 
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../foundation/res)
+
 set(headers TAtomicCount.h TCondition.h TConditionImp.h TMutex.h TMutexImp.h
             TRWLock.h ROOT/TRWSpinLock.hxx TSemaphore.h TThread.h TThreadFactory.h
             TThreadImp.h ROOT/TThreadedObject.hxx TThreadPool.h
-            ThreadLocalStorage.h ROOT/TSpinMutex.hxx ROOT/TReentrantRWLock.hxx)
+            ThreadLocalStorage.h ROOT/TSpinMutex.hxx ROOT/TReentrantRWLock.hxx ROOT/RConcurrentHashColl.hxx)
 if(NOT WIN32)
   set(headers ${headers} TPosixCondition.h TPosixMutex.h
                          TPosixThread.h TPosixThreadFactory.h PosixThreadInc.h)
@@ -18,7 +20,7 @@ endif()
 
 set(sources TCondition.cxx TConditionImp.cxx TMutex.cxx TMutexImp.cxx
             TRWLock.cxx TRWSpinLock.cxx TSemaphore.cxx TThread.cxx TThreadFactory.cxx
-            TThreadImp.cxx TRWMutexImp.cxx TReentrantRWLock.cxx)
+            TThreadImp.cxx TRWMutexImp.cxx TReentrantRWLock.cxx RConcurrentHashColl.cxx)
 if(NOT WIN32)
   set(sources ${sources} TPosixCondition.cxx TPosixMutex.cxx
                          TPosixThread.cxx TPosixThreadFactory.cxx)

--- a/core/thread/inc/ROOT/RConcurrentHashColl.hxx
+++ b/core/thread/inc/ROOT/RConcurrentHashColl.hxx
@@ -1,0 +1,40 @@
+// Author: Danilo Piparo May 2018
+
+/*************************************************************************
+ * Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_RConcurrentHashColl
+#define ROOT_RConcurrentHashColl
+
+#include <memory>
+
+namespace ROOT {
+
+class TRWSpinLock;
+
+namespace Internal {
+
+struct RHashSet;
+
+/// This class is a TS set of unsigned set
+class RConcurrentHashColl {
+private:
+   mutable std::unique_ptr<RHashSet> fHashSet;
+   mutable std::unique_ptr<ROOT::TRWSpinLock> fRWLock;
+
+public:
+   RConcurrentHashColl();
+   ~RConcurrentHashColl();
+   /// If the hash is there, return false. Otherwise, insert the hash and return true;
+   bool Insert(char *buf, int len) const;
+};
+
+} // End NS Internal
+} // End NS ROOT
+
+#endif

--- a/core/thread/inc/ROOT/TRWSpinLock.hxx
+++ b/core/thread/inc/ROOT/TRWSpinLock.hxx
@@ -38,6 +38,25 @@ public:
    void WriteLock();
    void WriteUnLock();
 };
+
+class TRWSpinLockReadGuard {
+private:
+   TRWSpinLock &fLock;
+
+public:
+   TRWSpinLockReadGuard(TRWSpinLock &lock) : fLock(lock) { fLock.ReadLock(); }
+   ~TRWSpinLockReadGuard() { fLock.ReadUnLock(); }
+};
+
+class TRWSpinLockWriteGuard {
+private:
+   TRWSpinLock &fLock;
+
+public:
+   TRWSpinLockWriteGuard(TRWSpinLock &lock) : fLock(lock) { fLock.WriteLock(); }
+   ~TRWSpinLockWriteGuard() { fLock.WriteUnLock(); }
+};
+
 } // end of namespace ROOT
 
 #endif

--- a/core/thread/inc/ROOT/TRWSpinLock.hxx
+++ b/core/thread/inc/ROOT/TRWSpinLock.hxx
@@ -18,27 +18,26 @@
 #include <atomic>
 #include <condition_variable>
 
-
 namespace ROOT {
-   class TRWSpinLock {
-   private:
-      std::atomic<int>             fReaders; ///<! Number of readers
-      std::atomic<int>             fReaderReservation; ///<! A reader wants access
-      std::atomic<int>             fWriterReservation; ///<! A writer wants access
-      std::atomic<bool>            fWriter;  ///<! Is there a writer?
-      ROOT::TSpinMutex             fMutex;   ///<! RWlock internal mutex
-      std::condition_variable_any  fCond;    ///<! RWlock internal condition variable
+class TRWSpinLock {
+private:
+   std::atomic<int> fReaders;           ///<! Number of readers
+   std::atomic<int> fReaderReservation; ///<! A reader wants access
+   std::atomic<int> fWriterReservation; ///<! A writer wants access
+   std::atomic<bool> fWriter;           ///<! Is there a writer?
+   ROOT::TSpinMutex fMutex;             ///<! RWlock internal mutex
+   std::condition_variable_any fCond;   ///<! RWlock internal condition variable
 
-   public:
-      ////////////////////////////////////////////////////////////////////////
-      /// Regular constructor.
-      TRWSpinLock() : fReaders(0), fReaderReservation(0), fWriterReservation(0), fWriter(false) {}
+public:
+   ////////////////////////////////////////////////////////////////////////
+   /// Regular constructor.
+   TRWSpinLock() : fReaders(0), fReaderReservation(0), fWriterReservation(0), fWriter(false) {}
 
-      void ReadLock();
-      void ReadUnLock();
-      void WriteLock();
-      void WriteUnLock();
-   };
+   void ReadLock();
+   void ReadUnLock();
+   void WriteLock();
+   void WriteUnLock();
+};
 } // end of namespace ROOT
 
 #endif

--- a/core/thread/inc/ROOT/TRWSpinLock.hxx
+++ b/core/thread/inc/ROOT/TRWSpinLock.hxx
@@ -44,8 +44,8 @@ private:
    TRWSpinLock &fLock;
 
 public:
-   TRWSpinLockReadGuard(TRWSpinLock &lock) : fLock(lock) { fLock.ReadLock(); }
-   ~TRWSpinLockReadGuard() { fLock.ReadUnLock(); }
+   TRWSpinLockReadGuard(TRWSpinLock &lock);
+   ~TRWSpinLockReadGuard();
 };
 
 class TRWSpinLockWriteGuard {
@@ -53,8 +53,8 @@ private:
    TRWSpinLock &fLock;
 
 public:
-   TRWSpinLockWriteGuard(TRWSpinLock &lock) : fLock(lock) { fLock.WriteLock(); }
-   ~TRWSpinLockWriteGuard() { fLock.WriteUnLock(); }
+   TRWSpinLockWriteGuard(TRWSpinLock &lock);
+   ~TRWSpinLockWriteGuard();
 };
 
 } // end of namespace ROOT

--- a/core/thread/src/RConcurrentHashColl.cxx
+++ b/core/thread/src/RConcurrentHashColl.cxx
@@ -1,0 +1,38 @@
+#include <ROOT/RConcurrentHashColl.hxx>
+#include <ROOT/RMakeUnique.hxx>
+#include <ROOT/TRWSpinLock.hxx>
+#include <ROOT/TSeq.hxx>
+#include <ROOT/RSha256.hxx>
+
+#include <set>
+
+namespace ROOT {
+namespace Internal {
+
+struct RHashSet {
+   std::set<ROOT::Internal::RSha256Hash> fSet;
+};
+
+RConcurrentHashColl::RConcurrentHashColl()
+   : fHashSet(std::make_unique<RHashSet>()), fRWLock(std::make_unique<ROOT::TRWSpinLock>()){};
+RConcurrentHashColl::~RConcurrentHashColl() = default;
+
+/// If the buffer is there, return false. Otherwise, insert the hash and return true
+bool RConcurrentHashColl::Insert(char *buffer, int len) const
+{
+   RSha256Hash hash(buffer, len);
+
+   {
+      ROOT::TRWSpinLockReadGuard rg(*fRWLock);
+      if (fHashSet->fSet.end() != fHashSet->fSet.find(hash))
+         return false;
+   }
+   {
+      ROOT::TRWSpinLockWriteGuard wg(*fRWLock);
+      fHashSet->fSet.insert(hash);
+      return true;
+   }
+}
+
+} // End NS Internal
+} // End NS ROOT

--- a/core/thread/src/TRWSpinLock.cxx
+++ b/core/thread/src/TRWSpinLock.cxx
@@ -110,3 +110,25 @@ void TRWSpinLock::WriteUnLock()
    fCond.notify_all();
 }
 
+
+TRWSpinLockReadGuard::TRWSpinLockReadGuard(TRWSpinLock &lock) : fLock(lock)
+{
+   fLock.ReadLock();
+}
+
+TRWSpinLockReadGuard::~TRWSpinLockReadGuard()
+{
+   fLock.ReadUnLock();
+}
+
+TRWSpinLockWriteGuard::TRWSpinLockWriteGuard(TRWSpinLock &lock) : fLock(lock)
+{
+   fLock.WriteLock();
+}
+
+TRWSpinLockWriteGuard::~TRWSpinLockWriteGuard()
+{
+   fLock.WriteUnLock();
+}
+
+

--- a/io/io/inc/TFile.h
+++ b/io/io/inc/TFile.h
@@ -29,6 +29,7 @@
 
 #ifdef R__USE_IMT
 #include "ROOT/TRWSpinLock.hxx"
+#include "ROOT/RConcurrentHashColl.hxx"
 #include <mutex>
 #endif
 
@@ -106,8 +107,9 @@ protected:
    TList           *fOpenPhases;     ///<!Time info about open phases
 
 #ifdef R__USE_IMT
-   static ROOT::TRWSpinLock fgRwLock;    ///<!Read-write lock to protect global PID list
-   std::mutex               fWriteMutex; ///<!Lock for writing baskets / keys into the file.
+   static ROOT::TRWSpinLock                   fgRwLock;     ///<!Read-write lock to protect global PID list
+   std::mutex                                 fWriteMutex;  ///<!Lock for writing baskets / keys into the file.
+   static ROOT::Internal::RConcurrentHashColl fgTsSIHashes; ///<!TS Set of hashes built from read streamer infos
 #endif
 
    static TList    *fgAsyncOpenRequests; //List of handles for pending open requests
@@ -126,9 +128,10 @@ protected:
    static Bool_t    fgReadInfo;              ///<if true (default) ReadStreamerInfo is called when opening a file
    virtual EAsyncOpenStatus GetAsyncOpenStatus() { return fAsyncOpenStatus; }
    virtual void  Init(Bool_t create);
-   Bool_t        FlushWriteCache();
-   Int_t         ReadBufferViaCache(char *buf, Int_t len);
-   Int_t         WriteBufferViaCache(const char *buf, Int_t len);
+   Bool_t                    FlushWriteCache();
+   Int_t                     ReadBufferViaCache(char *buf, Int_t len);
+   Int_t                     WriteBufferViaCache(const char *buf, Int_t len);
+   std::pair<TList *, Int_t> GetStreamerInfoListImpl(bool readSI);
 
    // Creating projects
    Int_t         MakeProjectParMake(const char *packname, const char *filename);

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -1343,7 +1343,7 @@ std::pair<TList *, Int_t> TFile::GetStreamerInfoListImpl(bool lookupSICache)
 
 #ifdef R__USE_IMT
       if (lookupSICache) {
-         if (fgTsSIHashes.Insert(buf,fNbytesInfo)) {
+         if (!fgTsSIHashes.Insert(buf,fNbytesInfo)) {
             return {nullptr, 0};
          }
       }
@@ -3738,7 +3738,11 @@ void TFile::WriteStreamerInfo()
       // Only add the list of rules if we have something to say.
       list.Add(&listOfRules);
    }
-   
+
+   // always write with compression on
+   Int_t compress = fCompress;
+   fCompress = 1;
+
    //free previous StreamerInfo record
    if (fSeekInfo) MakeFree(fSeekInfo,fSeekInfo+fNbytesInfo-1);
    //Create new key
@@ -3748,7 +3752,10 @@ void TFile::WriteStreamerInfo()
    fNbytesInfo = key.GetNbytes();
    SumBuffer(key.GetObjlen());
    key.WriteFile(0);
+
    fClassIndex->fArray[0] = 0;
+   fCompress = compress;
+
    list.RemoveLast(); // remove the listOfRules.
 }
 

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -1341,12 +1341,15 @@ std::pair<TList *, Int_t> TFile::GetStreamerInfoListImpl(bool lookupSICache)
          return {nullptr, 1};
       }
 
+#ifdef R__USE_IMT
       if (lookupSICache) {
-         if (!fgTsSIHashes.Insert(buf,fNbytesInfo)) {
+         if (fgTsSIHashes.Insert(buf,fNbytesInfo)) {
             return {nullptr, 0};
          }
       }
-
+#endif
+      (void) lookupSICache;
+#else
       key->ReadKeyBuffer(buf);
       list = dynamic_cast<TList*>(key->ReadObjWithBuffer(buffer));
       if (list) list->SetOwner();

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -1347,9 +1347,9 @@ std::pair<TList *, Int_t> TFile::GetStreamerInfoListImpl(bool lookupSICache)
             return {nullptr, 0};
          }
       }
-#endif
-      (void) lookupSICache;
 #else
+      (void) lookupSICache;
+#endif
       key->ReadKeyBuffer(buf);
       list = dynamic_cast<TList*>(key->ReadObjWithBuffer(buffer));
       if (list) list->SetOwner();

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -3739,10 +3739,6 @@ void TFile::WriteStreamerInfo()
       list.Add(&listOfRules);
    }
 
-   // always write with compression on
-   Int_t compress = fCompress;
-   fCompress = 1;
-
    //free previous StreamerInfo record
    if (fSeekInfo) MakeFree(fSeekInfo,fSeekInfo+fNbytesInfo-1);
    //Create new key
@@ -3754,7 +3750,6 @@ void TFile::WriteStreamerInfo()
    key.WriteFile(0);
 
    fClassIndex->fArray[0] = 0;
-   fCompress = compress;
 
    list.RemoveLast(); // remove the listOfRules.
 }


### PR DESCRIPTION
Skip the processing of streamer infos if those have been read before.
This has been working for a week in master.