### PR TITLE
[DF] ROOT-9491 Add common base class to all node types

### DIFF
--- a/tree/dataframe/inc/ROOT/RDFInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterface.hxx
@@ -77,7 +77,8 @@ namespace TTraits = ROOT::TypeTraits;
 
 template <typename Proxied, typename DataSource>
 class RInterface;
-using Node = RInterface<::ROOT::Detail::RDF::RNode, void>;
+
+using RNode = RInterface<::ROOT::Detail::RDF::RNodeBase, void>;
 
 /**
 * \class ROOT::RDF::RInterface
@@ -126,10 +127,10 @@ public:
       AddDefaultColumns();
    }
 
-   operator Node() const
+   operator RNode() const
    {
-      return Node(std::static_pointer_cast<::ROOT::Detail::RDF::RNode>(fProxiedPtr), fImplWeakPtr, fValidCustomColumns,
-                  fBranchNames, fDataSource);
+      return RNode(std::static_pointer_cast<::ROOT::Detail::RDF::RNodeBase>(fProxiedPtr), fImplWeakPtr,
+                   fValidCustomColumns, fBranchNames, fDataSource);
    }
 
    ////////////////////////////////////////////////////////////////////////////
@@ -413,7 +414,7 @@ public:
       RResultPtr<RInterface<RLoopManager>> resPtr;
       snapCall << "*reinterpret_cast<ROOT::RDF::RResultPtr<ROOT::RDF::RInterface<ROOT::Detail::RDF::RLoopManager>>*>("
                << RDFInternal::PrettyPrintAddr(&resPtr)
-               << ") = reinterpret_cast<ROOT::RDF::RInterface<ROOT::Detail::RDF::RNode>*>("
+               << ") = reinterpret_cast<ROOT::RDF::RInterface<ROOT::Detail::RDF::RNodeBase>*>("
                << RDFInternal::PrettyPrintAddr(&upcastInterface) << ")->Snapshot<";
 
       const auto &customCols = df->GetCustomColumnNames();
@@ -524,7 +525,7 @@ public:
       RInterface<RLoopManager> resRDF(std::make_shared<ROOT::Detail::RDF::RLoopManager>(0));
       cacheCall << "*reinterpret_cast<ROOT::RDF::RInterface<ROOT::Detail::RDF::RLoopManager>*>("
                 << RDFInternal::PrettyPrintAddr(&resRDF)
-                << ") = reinterpret_cast<ROOT::RDF::RInterface<ROOT::Detail::RDF::RNode>*>("
+                << ") = reinterpret_cast<ROOT::RDF::RInterface<ROOT::Detail::RDF::RNodeBase>*>("
                 << RDFInternal::PrettyPrintAddr(&upcastInterface) << ")->Cache<";
 
       const auto &customCols = df->GetCustomColumnNames();

--- a/tree/dataframe/inc/ROOT/RDFInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterface.hxx
@@ -210,8 +210,8 @@ public:
       RInterface<BaseNodeType_t> upcastInterface(*upcastNodeOnHeap, fImplWeakPtr, fValidCustomColumns, fBranchNames,
                                                  fDataSource);
       const auto jittedFilter = std::make_shared<RDFDetail::RJittedFilter>(df.get(), name);
-      RDFInternal::BookFilterJit(jittedFilter.get(), upcastNodeOnHeap, "ROOT::Detail::RDF::RNode", name, expression,
-                                 aliasMap, branches, customColumns, tree, fDataSource, df->GetID());
+      RDFInternal::BookFilterJit(jittedFilter.get(), upcastNodeOnHeap, name, expression, aliasMap, branches,
+                                 customColumns, tree, fDataSource, df->GetID());
 
       df->Book(jittedFilter.get());
       return RInterface<RDFDetail::RJittedFilter, DS_t>(std::move(jittedFilter), fImplWeakPtr, fValidCustomColumns,
@@ -1708,8 +1708,8 @@ private:
                                                  fDataSource);
       auto jittedActionOnHeap = RDFInternal::MakeSharedOnHeap(std::make_shared<RDFInternal::RJittedAction>(*lm));
       auto toJit = RDFInternal::JitBuildAction(
-         validColumnNames, "ROOT::Detail::RDF::RNode", upcastNodeOnHeap, typeid(std::shared_ptr<ActionResultType>),
-         typeid(ActionTag), rOnHeap, tree, nSlots, customColumns, fDataSource, jittedActionOnHeap, lm->GetID());
+         validColumnNames, upcastNodeOnHeap, typeid(std::shared_ptr<ActionResultType>), typeid(ActionTag), rOnHeap,
+         tree, nSlots, customColumns, fDataSource, jittedActionOnHeap, lm->GetID());
       lm->Book(jittedActionOnHeap->get());
       lm->ToJit(toJit);
       return MakeResultPtr(r, lm, *jittedActionOnHeap);

--- a/tree/dataframe/inc/ROOT/RDFInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterface.hxx
@@ -209,10 +209,9 @@ public:
       using BaseNodeType_t = typename std::remove_pointer<decltype(upcastNodeOnHeap)>::type::element_type;
       RInterface<BaseNodeType_t> upcastInterface(*upcastNodeOnHeap, fImplWeakPtr, fValidCustomColumns, fBranchNames,
                                                  fDataSource);
-      const auto prevNodeTypeName = upcastInterface.GetNodeTypeName();
       const auto jittedFilter = std::make_shared<RDFDetail::RJittedFilter>(df.get(), name);
-      RDFInternal::BookFilterJit(jittedFilter.get(), upcastNodeOnHeap, prevNodeTypeName, name, expression, aliasMap,
-                                 branches, customColumns, tree, fDataSource, df->GetID());
+      RDFInternal::BookFilterJit(jittedFilter.get(), upcastNodeOnHeap, "ROOT::Detail::RDF::RNode", name, expression,
+                                 aliasMap, branches, customColumns, tree, fDataSource, df->GetID());
 
       df->Book(jittedFilter.get());
       return RInterface<RDFDetail::RJittedFilter, DS_t>(std::move(jittedFilter), fImplWeakPtr, fValidCustomColumns,
@@ -400,12 +399,12 @@ public:
       RInterface<TTraits::TakeFirstParameter_t<decltype(upcastNode)>> upcastInterface(fProxiedPtr, fImplWeakPtr,
                                                                                       fValidCustomColumns, fBranchNames,  fDataSource);
       // build a string equivalent to
-      // "(RInterface<nodetype*>*)(this)->Snapshot<Ts...>(treename,filename,*(ColumnNames_t*)(&columnList), options)"
+      // "resPtr = (RInterface<nodetype*>*)(this)->Snapshot<Ts...>(args...)"
       RResultPtr<RInterface<RLoopManager>> resPtr;
       snapCall << "*reinterpret_cast<ROOT::RDF::RResultPtr<ROOT::RDF::RInterface<ROOT::Detail::RDF::RLoopManager>>*>("
-               << RDFInternal::PrettyPrintAddr(&resPtr) << ") = reinterpret_cast<ROOT::RDF::RInterface<"
-               << upcastInterface.GetNodeTypeName() << ">*>(" << RDFInternal::PrettyPrintAddr(&upcastInterface)
-               << ")->Snapshot<";
+               << RDFInternal::PrettyPrintAddr(&resPtr)
+               << ") = reinterpret_cast<ROOT::RDF::RInterface<ROOT::Detail::RDF::RNode>*>("
+               << RDFInternal::PrettyPrintAddr(&upcastInterface) << ")->Snapshot<";
 
       const auto &customCols = df->GetCustomColumnNames();
       const auto dontConvertVector = false;
@@ -514,9 +513,9 @@ public:
       // "(RInterface<nodetype*>*)(this)->Cache<Ts...>(*(ColumnNames_t*)(&columnList))"
       RInterface<RLoopManager> resRDF(std::make_shared<ROOT::Detail::RDF::RLoopManager>(0));
       cacheCall << "*reinterpret_cast<ROOT::RDF::RInterface<ROOT::Detail::RDF::RLoopManager>*>("
-                << RDFInternal::PrettyPrintAddr(&resRDF) << ") = reinterpret_cast<ROOT::RDF::RInterface<"
-                << upcastInterface.GetNodeTypeName() << ">*>(" << RDFInternal::PrettyPrintAddr(&upcastInterface)
-                << ")->Cache<";
+                << RDFInternal::PrettyPrintAddr(&resRDF)
+                << ") = reinterpret_cast<ROOT::RDF::RInterface<ROOT::Detail::RDF::RNode>*>("
+                << RDFInternal::PrettyPrintAddr(&upcastInterface) << ")->Cache<";
 
       const auto &customCols = df->GetCustomColumnNames();
       for (auto &c : columnList) {
@@ -1671,11 +1670,6 @@ private:
       }
    }
 
-   /// Return string containing fully qualified type name of the node pointed by fProxied.
-   /// The method is only defined for RInterface<{RFilterBase,RCustomColumnBase,RRangeBase,RLoopManager}> as it should
-   /// only be called on "upcast" RInterfaces.
-   inline static std::string GetNodeTypeName();
-
    // Type was specified by the user, no need to infer it
    template <typename ActionTag, typename... BranchTypes, typename ActionResultType,
              typename std::enable_if<!RDFInternal::TNeedJitting<BranchTypes...>::value, int>::type = 0>
@@ -1713,10 +1707,9 @@ private:
       RInterface<BaseNodeType_t> upcastInterface(*upcastNodeOnHeap, fImplWeakPtr, fValidCustomColumns, fBranchNames,
                                                  fDataSource);
       auto jittedActionOnHeap = RDFInternal::MakeSharedOnHeap(std::make_shared<RDFInternal::RJittedAction>(*lm));
-      auto toJit =
-         RDFInternal::JitBuildAction(validColumnNames, upcastInterface.GetNodeTypeName(), upcastNodeOnHeap,
-                                     typeid(std::shared_ptr<ActionResultType>), typeid(ActionTag), rOnHeap, tree,
-                                     nSlots, customColumns, fDataSource, jittedActionOnHeap, lm->GetID());
+      auto toJit = RDFInternal::JitBuildAction(
+         validColumnNames, "ROOT::Detail::RDF::RNode", upcastNodeOnHeap, typeid(std::shared_ptr<ActionResultType>),
+         typeid(ActionTag), rOnHeap, tree, nSlots, customColumns, fDataSource, jittedActionOnHeap, lm->GetID());
       lm->Book(jittedActionOnHeap->get());
       lm->ToJit(toJit);
       return MakeResultPtr(r, lm, *jittedActionOnHeap);
@@ -1915,30 +1908,6 @@ protected:
    }
 
 };
-
-template <>
-inline std::string RInterface<RDFDetail::RFilterBase>::GetNodeTypeName()
-{
-   return "ROOT::Detail::RDF::RFilterBase";
-}
-
-template <>
-inline std::string RInterface<RDFDetail::RLoopManager>::GetNodeTypeName()
-{
-   return "ROOT::Detail::RDF::RLoopManager";
-}
-
-template <>
-inline std::string RInterface<RDFDetail::RRangeBase>::GetNodeTypeName()
-{
-   return "ROOT::Detail::RDF::RRangeBase";
-}
-
-template <>
-inline std::string RInterface<RDFDetail::RJittedFilter>::GetNodeTypeName()
-{
-   return "ROOT::Detail::RDF::RJittedFilter";
-}
 
 } // end NS RDF
 

--- a/tree/dataframe/inc/ROOT/RDFInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterface.hxx
@@ -75,6 +75,10 @@ namespace RDFDetail = ROOT::Detail::RDF;
 namespace RDFInternal = ROOT::Internal::RDF;
 namespace TTraits = ROOT::TypeTraits;
 
+template <typename Proxied, typename DataSource>
+class RInterface;
+using Node = RInterface<::ROOT::Detail::RDF::RNode, void>;
+
 /**
 * \class ROOT::RDF::RInterface
 * \ingroup dataframe
@@ -120,6 +124,12 @@ public:
       : fProxiedPtr(proxied), fImplWeakPtr(proxied), fValidCustomColumns(), fDataSource(proxied->GetDataSource())
    {
       AddDefaultColumns();
+   }
+
+   operator Node() const
+   {
+      return Node(std::static_pointer_cast<::ROOT::Detail::RDF::RNode>(fProxiedPtr), fImplWeakPtr, fValidCustomColumns,
+                  fBranchNames, fDataSource);
    }
 
    ////////////////////////////////////////////////////////////////////////////

--- a/tree/dataframe/inc/ROOT/RDFInterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterfaceUtils.hxx
@@ -261,13 +261,9 @@ std::shared_ptr<T> *MakeSharedOnHeap(const std::shared_ptr<T> &shPtr)
 
 bool AtLeastOneEmptyString(const std::vector<std::string_view> strings);
 
-/* The following functions upcast shared ptrs to RFilter, RCustomColumn, RRange to their parent class (***Base).
- * Shared ptrs to RLoopManager are just copied, as well as shared ptrs to ***Base classes. */
-std::shared_ptr<RFilterBase> UpcastNode(const std::shared_ptr<RFilterBase> ptr);
-std::shared_ptr<RCustomColumnBase> UpcastNode(const std::shared_ptr<RCustomColumnBase> ptr);
-std::shared_ptr<RRangeBase> UpcastNode(const std::shared_ptr<RRangeBase> ptr);
-std::shared_ptr<RLoopManager> UpcastNode(const std::shared_ptr<RLoopManager> ptr);
-std::shared_ptr<RJittedFilter> UpcastNode(const std::shared_ptr<RJittedFilter> ptr);
+/// Take a shared_ptr<AnyNodeType> and return a shared_ptr<RNode>.
+/// This works for RLoopManager nodes as well as filters and ranges.
+std::shared_ptr<RNode> UpcastNode(std::shared_ptr<RNode> ptr);
 
 ColumnNames_t GetValidatedColumnNames(RLoopManager &lm, const unsigned int nColumns, const ColumnNames_t &columns,
                                       const ColumnNames_t &datasetColumns, const ColumnNames_t &validCustomColumns,

--- a/tree/dataframe/inc/ROOT/RDFInterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterfaceUtils.hxx
@@ -235,17 +235,17 @@ void CheckCustomColumn(std::string_view definedCol, TTree *treePtr, const Column
 
 std::string PrettyPrintAddr(const void *const addr);
 
-void BookFilterJit(RJittedFilter *jittedFilter, void *prevNodeOnHeap, std::string_view prevNodeTypeName,
-                   std::string_view name, std::string_view expression,
+void BookFilterJit(RJittedFilter *jittedFilter, void *prevNodeOnHeap, std::string_view name,
+                   std::string_view expression,
                    const std::map<std::string, std::string> &aliasMap, const ColumnNames_t &branches,
                    const ColumnNames_t &customColumns, TTree *tree, RDataSource *ds, unsigned int namespaceID);
 
 void BookDefineJit(std::string_view name, std::string_view expression, RLoopManager &lm, RDataSource *ds);
 
-std::string JitBuildAction(const ColumnNames_t &bl, const std::string &prevNodeTypename, void *prevNode,
-                           const std::type_info &art, const std::type_info &at, void *r, TTree *tree,
-                           const unsigned int nSlots, const ColumnNames_t &customColumns, RDataSource *ds,
-                           std::shared_ptr<RJittedAction> *jittedActionOnHeap, unsigned int namespaceID);
+std::string JitBuildAction(const ColumnNames_t &bl, void *prevNode, const std::type_info &art, const std::type_info &at,
+                           void *r, TTree *tree, const unsigned int nSlots, const ColumnNames_t &customColumns,
+                           RDataSource *ds, std::shared_ptr<RJittedAction> *jittedActionOnHeap,
+                           unsigned int namespaceID);
 
 // allocate a shared_ptr on the heap, return a reference to it. the user is responsible of deleting the shared_ptr*.
 // this function is meant to only be used by RInterface's action methods, and should be deprecated as soon as we find

--- a/tree/dataframe/inc/ROOT/RDFInterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterfaceUtils.hxx
@@ -261,9 +261,9 @@ std::shared_ptr<T> *MakeSharedOnHeap(const std::shared_ptr<T> &shPtr)
 
 bool AtLeastOneEmptyString(const std::vector<std::string_view> strings);
 
-/// Take a shared_ptr<AnyNodeType> and return a shared_ptr<RNode>.
+/// Take a shared_ptr<AnyNodeType> and return a shared_ptr<RNodeBase>.
 /// This works for RLoopManager nodes as well as filters and ranges.
-std::shared_ptr<RNode> UpcastNode(std::shared_ptr<RNode> ptr);
+std::shared_ptr<RNodeBase> UpcastNode(std::shared_ptr<RNodeBase> ptr);
 
 ColumnNames_t GetValidatedColumnNames(RLoopManager &lm, const unsigned int nColumns, const ColumnNames_t &columns,
                                       const ColumnNames_t &datasetColumns, const ColumnNames_t &validCustomColumns,

--- a/tree/dataframe/inc/ROOT/RDFNodes.hxx
+++ b/tree/dataframe/inc/ROOT/RDFNodes.hxx
@@ -88,6 +88,7 @@ public:
    virtual void PartialReport(ROOT::RDF::RCutFlowReport &) const = 0;
    virtual void IncrChildrenCount() = 0;
    virtual void StopProcessing() = 0;
+   virtual void AddFilterName(std::vector<std::string> &filters) = 0;
 };
 
 class RLoopManager : public RNode {
@@ -674,7 +675,6 @@ public:
    }
    virtual void ClearValueReaders(unsigned int slot) = 0;
    virtual void InitNode();
-   virtual void AddFilterName(std::vector<std::string> &filters) = 0;
 };
 
 /// A wrapper around a concrete RFilter, which forwards all calls to it
@@ -799,7 +799,7 @@ public:
    }
 };
 
-class RRangeBase {
+class RRangeBase : public RNode {
 protected:
    RLoopManager *fLoopManager; ///< A raw pointer to the RLoopManager at the root of this functional graph. It is only
                                /// guaranteed to contain a valid address during an event loop.
@@ -823,12 +823,7 @@ public:
    virtual ~RRangeBase() { fLoopManager->Deregister(this); }
 
    RLoopManager *GetLoopManagerUnchecked() const;
-   virtual bool CheckFilters(unsigned int slot, Long64_t entry) = 0;
-   virtual void Report(ROOT::RDF::RCutFlowReport &) const = 0;
-   virtual void PartialReport(ROOT::RDF::RCutFlowReport &) const = 0;
-   virtual void IncrChildrenCount() = 0;
-   virtual void StopProcessing() = 0;
-   virtual void AddFilterName(std::vector<std::string> &filters) = 0;
+
    void ResetChildrenCount()
    {
       fNChildren = 0;

--- a/tree/dataframe/inc/ROOT/RDFNodes.hxx
+++ b/tree/dataframe/inc/ROOT/RDFNodes.hxx
@@ -80,15 +80,15 @@ class RLoopManager;
 /// Base class for non-leaf nodes of the computational graph.
 /// It only exposes the bare minimum interface required to work as a generic part of the computation graph.
 /// RDataFrames and results of transformations can be cast to this type via ROOT::RDF::ToCommonNodeType.
-class RNode {
+class RNodeBase {
 protected:
    RLoopManager *fLoopManager;
    unsigned int fNChildren{0};      ///< Number of nodes of the functional graph hanging from this object
    unsigned int fNStopsReceived{0}; ///< Number of times that a children node signaled to stop processing entries.
 
 public:
-   RNode(RLoopManager *lm = nullptr) : fLoopManager(lm) {}
-   virtual ~RNode() {}
+   RNodeBase(RLoopManager *lm = nullptr) : fLoopManager(lm) {}
+   virtual ~RNodeBase() {}
    virtual bool CheckFilters(unsigned int, Long64_t) = 0;
    virtual void Report(ROOT::RDF::RCutFlowReport &) const = 0;
    virtual void PartialReport(ROOT::RDF::RCutFlowReport &) const = 0;
@@ -105,7 +105,7 @@ public:
    virtual RLoopManager *GetLoopManagerUnchecked() { return fLoopManager; }
 };
 
-class RLoopManager : public RNode {
+class RLoopManager : public RNodeBase {
    using RDataSource = ROOT::RDF::RDataSource;
    enum class ELoopType { kROOTFiles, kROOTFilesMT, kNoFiles, kNoFilesMT, kDataSource, kDataSourceMT };
    using Callback_t = std::function<void(unsigned int)>;
@@ -649,7 +649,7 @@ public:
    void ClearValueReaders(unsigned int slot) final { RDFInternal::ResetRDFValueTuple(fValues[slot], TypeInd_t()); }
 };
 
-class RFilterBase : public RNode {
+class RFilterBase : public RNodeBase {
 protected:
    std::vector<Long64_t> fLastCheckedEntry;
    std::vector<int> fLastResult = {true}; // std::vector<bool> cannot be used in a MT context safely
@@ -801,7 +801,7 @@ public:
    }
 };
 
-class RRangeBase : public RNode {
+class RRangeBase : public RNodeBase {
 protected:
    unsigned int fStart;
    unsigned int fStop;

--- a/tree/dataframe/inc/ROOT/RDFNodes.hxx
+++ b/tree/dataframe/inc/ROOT/RDFNodes.hxx
@@ -75,6 +75,21 @@ using RCustomColumnBasePtr_t = std::shared_ptr<RCustomColumnBase>;
 class RFilterBase;
 class RRangeBase;
 
+class RLoopManager;
+
+/// Base class for non-leaf nodes of the computational graph.
+/// It only exposes the bare minimum interface required to work as a generic part of the computation graph.
+/// RDataFrames and results of transformations can be cast to this type via ROOT::RDF::ToCommonNodeType.
+class RNode {
+public:
+   virtual ~RNode() {}
+   virtual bool CheckFilters(unsigned int, Long64_t) = 0;
+   virtual void Report(ROOT::RDF::RCutFlowReport &) const = 0;
+   virtual void PartialReport(ROOT::RDF::RCutFlowReport &) const = 0;
+   virtual void IncrChildrenCount() = 0;
+   virtual void StopProcessing() = 0;
+};
+
 class RLoopManager {
    using RDataSource = ROOT::RDF::RDataSource;
    enum class ELoopType { kROOTFiles, kROOTFilesMT, kNoFiles, kNoFilesMT, kDataSource, kDataSourceMT };

--- a/tree/dataframe/inc/ROOT/RDFNodes.hxx
+++ b/tree/dataframe/inc/ROOT/RDFNodes.hxx
@@ -83,6 +83,8 @@ class RLoopManager;
 class RNode {
 protected:
    RLoopManager *fLoopManager;
+   unsigned int fNChildren{0};      ///< Number of nodes of the functional graph hanging from this object
+   unsigned int fNStopsReceived{0}; ///< Number of times that a children node signaled to stop processing entries.
 
 public:
    RNode(RLoopManager *lm) : fLoopManager(lm) {}
@@ -93,6 +95,13 @@ public:
    virtual void IncrChildrenCount() = 0;
    virtual void StopProcessing() = 0;
    virtual void AddFilterName(std::vector<std::string> &filters) = 0;
+
+   virtual void ResetChildrenCount()
+   {
+      fNChildren = 0;
+      fNStopsReceived = 0;
+   }
+
    RLoopManager *GetLoopManagerUnchecked() const { return fLoopManager; }
 };
 
@@ -152,8 +161,6 @@ class RLoopManager : public RNode {
    const ULong64_t fNEmptyEntries{0};
    const unsigned int fNSlots{1};
    bool fMustRunNamedFilters{true};
-   unsigned int fNChildren{0};      ///< Number of nodes of the functional graph hanging from this object
-   unsigned int fNStopsReceived{0}; ///< Number of times that a children node signaled to stop processing entries.
    const ELoopType fLoopType; ///< The kind of event loop that is going to be run (e.g. on ROOT files, on no files)
    std::string fToJit;        ///< code that should be jitted and executed right before the event loop
    const std::unique_ptr<RDataSource> fDataSource; ///< Owning pointer to a data-source object. Null if no data-source
@@ -648,8 +655,6 @@ protected:
    std::vector<ULong64_t> fAccepted = {0};
    std::vector<ULong64_t> fRejected = {0};
    const std::string fName;
-   unsigned int fNChildren{0};      ///< Number of nodes of the functional graph hanging from this object
-   unsigned int fNStopsReceived{0}; ///< Number of times that a children node signaled to stop processing entries.
    const unsigned int fNSlots;      ///< Number of thread slots used by this node, inherited from parent node.
 
 public:
@@ -661,11 +666,6 @@ public:
    bool HasName() const;
    std::string GetName() const;
    virtual void FillReport(ROOT::RDF::RCutFlowReport &) const;
-   virtual void ResetChildrenCount()
-   {
-      fNChildren = 0;
-      fNStopsReceived = 0;
-   }
    virtual void TriggerChildrenCount() = 0;
    virtual void ResetReportCount()
    {
@@ -808,8 +808,6 @@ protected:
    Long64_t fLastCheckedEntry{-1};
    bool fLastResult{true};
    ULong64_t fNProcessedEntries{0};
-   unsigned int fNChildren{0};      ///< Number of nodes of the functional graph hanging from this object
-   unsigned int fNStopsReceived{0}; ///< Number of times that a children node signaled to stop processing entries.
    bool fHasStopped{false};         ///< True if the end of the range has been reached
    const unsigned int fNSlots;      ///< Number of thread slots used by this node, inherited from parent node.
 
@@ -821,11 +819,6 @@ public:
    RRangeBase &operator=(const RRangeBase &) = delete;
    virtual ~RRangeBase() { fLoopManager->Deregister(this); }
 
-   void ResetChildrenCount()
-   {
-      fNChildren = 0;
-      fNStopsReceived = 0;
-   }
    void InitNode() { ResetCounters(); }
 };
 

--- a/tree/dataframe/inc/ROOT/RDFNodes.hxx
+++ b/tree/dataframe/inc/ROOT/RDFNodes.hxx
@@ -87,7 +87,7 @@ protected:
    unsigned int fNStopsReceived{0}; ///< Number of times that a children node signaled to stop processing entries.
 
 public:
-   RNode(RLoopManager *lm) : fLoopManager(lm) {}
+   RNode(RLoopManager *lm = nullptr) : fLoopManager(lm) {}
    virtual ~RNode() {}
    virtual bool CheckFilters(unsigned int, Long64_t) = 0;
    virtual void Report(ROOT::RDF::RCutFlowReport &) const = 0;
@@ -102,7 +102,7 @@ public:
       fNStopsReceived = 0;
    }
 
-   RLoopManager *GetLoopManagerUnchecked() const { return fLoopManager; }
+   virtual RLoopManager *GetLoopManagerUnchecked() { return fLoopManager; }
 };
 
 class RLoopManager : public RNode {
@@ -194,6 +194,7 @@ public:
    RLoopManager &operator=(const RLoopManager &) = delete;
 
    void BuildJittedNodes();
+   RLoopManager *GetLoopManagerUnchecked() final { return this; }
    void Run();
    const ColumnNames_t &GetDefaultColumnNames() const;
    const ColumnNames_t &GetCustomColumnNames() const { return fCustomColumnNames; };

--- a/tree/dataframe/inc/ROOT/RDFNodes.hxx
+++ b/tree/dataframe/inc/ROOT/RDFNodes.hxx
@@ -90,7 +90,7 @@ public:
    virtual void StopProcessing() = 0;
 };
 
-class RLoopManager {
+class RLoopManager : public RNode {
    using RDataSource = ROOT::RDF::RDataSource;
    enum class ELoopType { kROOTFiles, kROOTFilesMT, kNoFiles, kNoFilesMT, kDataSource, kDataSourceMT };
    using Callback_t = std::function<void(unsigned int)>;
@@ -196,15 +196,15 @@ public:
    void Book(const RCustomColumnBasePtr_t &columnPtr);
    void Book(RRangeBase *rangePtr);
    void Deregister(RRangeBase *rangePtr);
-   bool CheckFilters(int, unsigned int);
+   bool CheckFilters(unsigned int, Long64_t) final;
    unsigned int GetNSlots() const { return fNSlots; }
    bool MustRunNamedFilters() const { return fMustRunNamedFilters; }
-   void Report(ROOT::RDF::RCutFlowReport &rep) const;
+   void Report(ROOT::RDF::RCutFlowReport &rep) const final;
    /// End of recursive chain of calls, does nothing
-   void PartialReport(ROOT::RDF::RCutFlowReport &) const {}
+   void PartialReport(ROOT::RDF::RCutFlowReport &) const final {}
    void SetTree(const std::shared_ptr<TTree> &tree) { fTree = tree; }
-   void IncrChildrenCount() { ++fNChildren; }
-   void StopProcessing() { ++fNStopsReceived; }
+   void IncrChildrenCount() final { ++fNChildren; }
+   void StopProcessing() final { ++fNStopsReceived; }
    void ToJit(const std::string &s) { fToJit.append(s); }
    const ColumnNames_t &GetDefinedDataSourceColumns() const { return fDefinedDataSourceColumns; }
    void AddDataSourceColumn(std::string_view name) { fDefinedDataSourceColumns.emplace_back(name); }

--- a/tree/dataframe/inc/ROOT/RDFNodes.hxx
+++ b/tree/dataframe/inc/ROOT/RDFNodes.hxx
@@ -636,7 +636,7 @@ public:
    void ClearValueReaders(unsigned int slot) final { RDFInternal::ResetRDFValueTuple(fValues[slot], TypeInd_t()); }
 };
 
-class RFilterBase {
+class RFilterBase : public RNode {
 protected:
    RLoopManager *fLoopManager; ///< A raw pointer to the RLoopManager at the root of this functional graph. It is only
                                /// guaranteed to contain a valid address during an event loop.
@@ -655,15 +655,10 @@ public:
    virtual ~RFilterBase() { fLoopManager->Deregister(this); }
 
    virtual void InitSlot(TTreeReader *r, unsigned int slot) = 0;
-   virtual bool CheckFilters(unsigned int slot, Long64_t entry) = 0;
-   virtual void Report(ROOT::RDF::RCutFlowReport &) const = 0;
-   virtual void PartialReport(ROOT::RDF::RCutFlowReport &) const = 0;
    RLoopManager *GetLoopManagerUnchecked() const;
    bool HasName() const;
    std::string GetName() const;
    virtual void FillReport(ROOT::RDF::RCutFlowReport &) const;
-   virtual void IncrChildrenCount() = 0;
-   virtual void StopProcessing() = 0;
    virtual void ResetChildrenCount()
    {
       fNChildren = 0;

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -601,7 +601,7 @@ void BookFilterJit(RJittedFilter *jittedFilter, void *prevNodeOnHeap, std::strin
       filterInvocation.seekp(-2, filterInvocation.cur); // remove the last ",
    filterInvocation << "}, \"" << name << "\", "
                     << "reinterpret_cast<ROOT::Detail::RDF::RJittedFilter*>(" << jittedFilterAddr << "), "
-                    << "reinterpret_cast<std::shared_ptr<ROOT::Detail::RDF::RNode>*>(" << prevNodeAddr << "));";
+                    << "reinterpret_cast<std::shared_ptr<ROOT::Detail::RDF::RNodeBase>*>(" << prevNodeAddr << "));";
 
    jittedFilter->GetLoopManagerUnchecked()->ToJit(filterInvocation.str());
 }
@@ -710,8 +710,8 @@ std::string JitBuildAction(const ColumnNames_t &bl, void *prevNode, const std::t
       createAction_str << ", " << colType;
    // on Windows, to prefix the hexadecimal value of a pointer with '0x',
    // one need to write: std::hex << std::showbase << (size_t)pointer
-   createAction_str << ">(reinterpret_cast<std::shared_ptr<ROOT::Detail::RDF::RNode>*>(" << PrettyPrintAddr(prevNode)
-                    << "), {";
+   createAction_str << ">(reinterpret_cast<std::shared_ptr<ROOT::Detail::RDF::RNodeBase>*>("
+                    << PrettyPrintAddr(prevNode) << "), {";
    for (auto i = 0u; i < bl.size(); ++i) {
       if (i != 0u)
          createAction_str << ", ";
@@ -733,7 +733,7 @@ bool AtLeastOneEmptyString(const std::vector<std::string_view> strings)
    return false;
 }
 
-std::shared_ptr<RNode> UpcastNode(std::shared_ptr<RNode> ptr) { return ptr; }
+std::shared_ptr<RNodeBase> UpcastNode(std::shared_ptr<RNodeBase> ptr) { return ptr; }
 
 /// Given the desired number of columns and the user-provided list of columns:
 /// * fallback to using the first nColumns default columns if needed (or throw if nColumns > nDefaultColumns)

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -562,10 +562,10 @@ std::string PrettyPrintAddr(const void *const addr)
 
 // Jit a string filter expression and jit-and-call this->Filter with the appropriate arguments
 // Return pointer to the new functional chain node returned by the call, cast to Long_t
-void BookFilterJit(RJittedFilter *jittedFilter, void *prevNodeOnHeap, std::string_view prevNodeTypeName,
-                   std::string_view name, std::string_view expression,
-                   const std::map<std::string, std::string> &aliasMap, const ColumnNames_t &branches,
-                   const ColumnNames_t &customCols, TTree *tree, RDataSource *ds, unsigned int namespaceID)
+void BookFilterJit(RJittedFilter *jittedFilter, void *prevNodeOnHeap, std::string_view name,
+                   std::string_view expression, const std::map<std::string, std::string> &aliasMap,
+                   const ColumnNames_t &branches, const ColumnNames_t &customCols, TTree *tree, RDataSource *ds,
+                   unsigned int namespaceID)
 {
    const auto &dsColumns = ds ? ds->GetColumnNames() : ColumnNames_t{};
 
@@ -601,7 +601,7 @@ void BookFilterJit(RJittedFilter *jittedFilter, void *prevNodeOnHeap, std::strin
       filterInvocation.seekp(-2, filterInvocation.cur); // remove the last ",
    filterInvocation << "}, \"" << name << "\", "
                     << "reinterpret_cast<ROOT::Detail::RDF::RJittedFilter*>(" << jittedFilterAddr << "), "
-                    << "reinterpret_cast<std::shared_ptr<" << prevNodeTypeName << ">*>(" << prevNodeAddr << "));";
+                    << "reinterpret_cast<std::shared_ptr<ROOT::Detail::RDF::RNode>*>(" << prevNodeAddr << "));";
 
    jittedFilter->GetLoopManagerUnchecked()->ToJit(filterInvocation.str());
 }
@@ -664,10 +664,10 @@ void BookDefineJit(std::string_view name, std::string_view expression, RLoopMana
 
 // Jit and call something equivalent to "this->BuildAndBook<BranchTypes...>(params...)"
 // (see comments in the body for actual jitted code)
-std::string JitBuildAction(const ColumnNames_t &bl, const std::string &prevNodeTypename, void *prevNode,
-                           const std::type_info &art, const std::type_info &at, void *rOnHeap, TTree *tree,
-                           const unsigned int nSlots, const ColumnNames_t &customColumns, RDataSource *ds,
-                           std::shared_ptr<RJittedAction> *jittedActionOnHeap, unsigned int namespaceID)
+std::string JitBuildAction(const ColumnNames_t &bl, void *prevNode, const std::type_info &art, const std::type_info &at,
+                           void *rOnHeap, TTree *tree, const unsigned int nSlots, const ColumnNames_t &customColumns,
+                           RDataSource *ds, std::shared_ptr<RJittedAction> *jittedActionOnHeap,
+                           unsigned int namespaceID)
 {
    auto nBranches = bl.size();
 
@@ -710,7 +710,7 @@ std::string JitBuildAction(const ColumnNames_t &bl, const std::string &prevNodeT
       createAction_str << ", " << colType;
    // on Windows, to prefix the hexadecimal value of a pointer with '0x',
    // one need to write: std::hex << std::showbase << (size_t)pointer
-   createAction_str << ">(reinterpret_cast<std::shared_ptr<" << prevNodeTypename << ">*>(" << PrettyPrintAddr(prevNode)
+   createAction_str << ">(reinterpret_cast<std::shared_ptr<ROOT::Detail::RDF::RNode>*>(" << PrettyPrintAddr(prevNode)
                     << "), {";
    for (auto i = 0u; i < bl.size(); ++i) {
       if (i != 0u)

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -733,32 +733,7 @@ bool AtLeastOneEmptyString(const std::vector<std::string_view> strings)
    return false;
 }
 
-/*** Take a shared_ptr<Node<T1,T2,...>> and return a shared_ptr<NodeBase> ***/
-std::shared_ptr<RFilterBase> UpcastNode(const std::shared_ptr<RFilterBase> ptr)
-{
-   return ptr;
-}
-
-std::shared_ptr<RCustomColumnBase> UpcastNode(const std::shared_ptr<RCustomColumnBase> ptr)
-{
-   return ptr;
-}
-
-std::shared_ptr<RRangeBase> UpcastNode(const std::shared_ptr<RRangeBase> ptr)
-{
-   return ptr;
-}
-
-std::shared_ptr<RLoopManager> UpcastNode(const std::shared_ptr<RLoopManager> ptr)
-{
-   return ptr;
-}
-
-std::shared_ptr<RJittedFilter> UpcastNode(const std::shared_ptr<RJittedFilter> ptr)
-{
-   return ptr;
-}
-/****************************************************************************/
+std::shared_ptr<RNode> UpcastNode(std::shared_ptr<RNode> ptr) { return ptr; }
 
 /// Given the desired number of columns and the user-provided list of columns:
 /// * fallback to using the first nColumns default columns if needed (or throw if nColumns > nDefaultColumns)

--- a/tree/dataframe/src/RDFNodes.cxx
+++ b/tree/dataframe/src/RDFNodes.cxx
@@ -724,7 +724,7 @@ void RLoopManager::Deregister(RRangeBase *rangePtr)
 }
 
 // dummy call, end of recursive chain of calls
-bool RLoopManager::CheckFilters(int, unsigned int)
+bool RLoopManager::CheckFilters(unsigned int, Long64_t)
 {
    return true;
 }

--- a/tree/dataframe/src/RDFNodes.cxx
+++ b/tree/dataframe/src/RDFNodes.cxx
@@ -183,7 +183,7 @@ void RJittedCustomColumn::InitNode()
 }
 
 RFilterBase::RFilterBase(RLoopManager *implPtr, std::string_view name, const unsigned int nSlots)
-   : RNode(implPtr), fLastResult(nSlots), fAccepted(nSlots), fRejected(nSlots), fName(name), fNSlots(nSlots)
+   : RNodeBase(implPtr), fLastResult(nSlots), fAccepted(nSlots), fRejected(nSlots), fName(name), fNSlots(nSlots)
 {
 }
 
@@ -753,7 +753,7 @@ std::vector<RDFInternal::RActionBase *> RLoopManager::GetAllActions(){
 
 RRangeBase::RRangeBase(RLoopManager *implPtr, unsigned int start, unsigned int stop, unsigned int stride,
                        const unsigned int nSlots)
-   : RNode(implPtr), fStart(start), fStop(stop), fStride(stride), fNSlots(nSlots)
+   : RNodeBase(implPtr), fStart(start), fStop(stop), fStride(stride), fNSlots(nSlots)
 {
 }
 

--- a/tree/dataframe/src/RDFNodes.cxx
+++ b/tree/dataframe/src/RDFNodes.cxx
@@ -183,13 +183,8 @@ void RJittedCustomColumn::InitNode()
 }
 
 RFilterBase::RFilterBase(RLoopManager *implPtr, std::string_view name, const unsigned int nSlots)
-   : fLoopManager(implPtr), fLastResult(nSlots), fAccepted(nSlots), fRejected(nSlots), fName(name), fNSlots(nSlots)
+   : RNode(implPtr), fLastResult(nSlots), fAccepted(nSlots), fRejected(nSlots), fName(name), fNSlots(nSlots)
 {
-}
-
-RLoopManager *RFilterBase::GetLoopManagerUnchecked() const
-{
-   return fLoopManager;
 }
 
 bool RFilterBase::HasName() const
@@ -368,20 +363,20 @@ unsigned int TSlotStack::GetSlot()
 }
 
 RLoopManager::RLoopManager(TTree *tree, const ColumnNames_t &defaultBranches)
-   : fTree(std::shared_ptr<TTree>(tree, [](TTree *) {})), fDefaultColumns(defaultBranches),
+   : RNode(this), fTree(std::shared_ptr<TTree>(tree, [](TTree *) {})), fDefaultColumns(defaultBranches),
      fNSlots(RDFInternal::GetNSlots()),
      fLoopType(ROOT::IsImplicitMTEnabled() ? ELoopType::kROOTFilesMT : ELoopType::kROOTFiles)
 {
 }
 
 RLoopManager::RLoopManager(ULong64_t nEmptyEntries)
-   : fNEmptyEntries(nEmptyEntries), fNSlots(RDFInternal::GetNSlots()),
+   : RNode(this), fNEmptyEntries(nEmptyEntries), fNSlots(RDFInternal::GetNSlots()),
      fLoopType(ROOT::IsImplicitMTEnabled() ? ELoopType::kNoFilesMT : ELoopType::kNoFiles)
 {
 }
 
 RLoopManager::RLoopManager(std::unique_ptr<RDataSource> ds, const ColumnNames_t &defaultBranches)
-   : fDefaultColumns(defaultBranches), fNSlots(RDFInternal::GetNSlots()),
+   : RNode(this), fDefaultColumns(defaultBranches), fNSlots(RDFInternal::GetNSlots()),
      fLoopType(ROOT::IsImplicitMTEnabled() ? ELoopType::kDataSourceMT : ELoopType::kDataSource),
      fDataSource(std::move(ds))
 {
@@ -665,11 +660,6 @@ void RLoopManager::Run()
    CleanUpNodes();
 }
 
-RLoopManager *RLoopManager::GetLoopManagerUnchecked()
-{
-   return this;
-}
-
 /// Return the list of default columns -- empty if none was provided when constructing the RDataFrame
 const ColumnNames_t &RLoopManager::GetDefaultColumnNames() const
 {
@@ -763,13 +753,8 @@ std::vector<RDFInternal::RActionBase *> RLoopManager::GetAllActions(){
 
 RRangeBase::RRangeBase(RLoopManager *implPtr, unsigned int start, unsigned int stop, unsigned int stride,
                        const unsigned int nSlots)
-   : fLoopManager(implPtr), fStart(start), fStop(stop), fStride(stride), fNSlots(nSlots)
+   : RNode(implPtr), fStart(start), fStop(stop), fStride(stride), fNSlots(nSlots)
 {
-}
-
-RLoopManager *RRangeBase::GetLoopManagerUnchecked() const
-{
-   return fLoopManager;
 }
 
 void RRangeBase::ResetCounters()

--- a/tree/dataframe/src/RDFNodes.cxx
+++ b/tree/dataframe/src/RDFNodes.cxx
@@ -363,20 +363,20 @@ unsigned int TSlotStack::GetSlot()
 }
 
 RLoopManager::RLoopManager(TTree *tree, const ColumnNames_t &defaultBranches)
-   : RNode(this), fTree(std::shared_ptr<TTree>(tree, [](TTree *) {})), fDefaultColumns(defaultBranches),
+   : fTree(std::shared_ptr<TTree>(tree, [](TTree *) {})), fDefaultColumns(defaultBranches),
      fNSlots(RDFInternal::GetNSlots()),
      fLoopType(ROOT::IsImplicitMTEnabled() ? ELoopType::kROOTFilesMT : ELoopType::kROOTFiles)
 {
 }
 
 RLoopManager::RLoopManager(ULong64_t nEmptyEntries)
-   : RNode(this), fNEmptyEntries(nEmptyEntries), fNSlots(RDFInternal::GetNSlots()),
+   : fNEmptyEntries(nEmptyEntries), fNSlots(RDFInternal::GetNSlots()),
      fLoopType(ROOT::IsImplicitMTEnabled() ? ELoopType::kNoFilesMT : ELoopType::kNoFiles)
 {
 }
 
 RLoopManager::RLoopManager(std::unique_ptr<RDataSource> ds, const ColumnNames_t &defaultBranches)
-   : RNode(this), fDefaultColumns(defaultBranches), fNSlots(RDFInternal::GetNSlots()),
+   : fDefaultColumns(defaultBranches), fNSlots(RDFInternal::GetNSlots()),
      fLoopType(ROOT::IsImplicitMTEnabled() ? ELoopType::kDataSourceMT : ELoopType::kDataSource),
      fDataSource(std::move(ds))
 {

--- a/tree/dataframe/test/dataframe_interface.cxx
+++ b/tree/dataframe/test/dataframe_interface.cxx
@@ -306,3 +306,17 @@ TEST(RDataFrameInterface, GetColumnType)
 
    gSystem->Unlink(fname);
 }
+
+TEST(RDFHelpers, CastToNode)
+{
+   ROOT::RDataFrame d(1);
+   ROOT::RDF::Node n(d);
+   auto n2 = ROOT::RDF::Node(n.Filter([] { return true; }));
+   auto n3 = ROOT::RDF::Node(n2.Filter("true"));
+   auto n4 = ROOT::RDF::Node(n3.Define("x", [] { return 42; }));
+   auto n5 = ROOT::RDF::Node(n4.Define("y", "x"));
+   auto n6 = ROOT::RDF::Node(n5.Range(0,0));
+   auto n7 = ROOT::RDF::Node(n.Filter([] { return true; }, {}, "myfilter"));
+   auto c = n6.Count();
+   EXPECT_EQ(*c, 1ull);
+}

--- a/tree/dataframe/test/dataframe_interface.cxx
+++ b/tree/dataframe/test/dataframe_interface.cxx
@@ -310,13 +310,13 @@ TEST(RDataFrameInterface, GetColumnType)
 TEST(RDFHelpers, CastToNode)
 {
    ROOT::RDataFrame d(1);
-   ROOT::RDF::Node n(d);
-   auto n2 = ROOT::RDF::Node(n.Filter([] { return true; }));
-   auto n3 = ROOT::RDF::Node(n2.Filter("true"));
-   auto n4 = ROOT::RDF::Node(n3.Define("x", [] { return 42; }));
-   auto n5 = ROOT::RDF::Node(n4.Define("y", "x"));
-   auto n6 = ROOT::RDF::Node(n5.Range(0,0));
-   auto n7 = ROOT::RDF::Node(n.Filter([] { return true; }, {}, "myfilter"));
+   ROOT::RDF::RNode n(d);
+   auto n2 = ROOT::RDF::RNode(n.Filter([] { return true; }));
+   auto n3 = ROOT::RDF::RNode(n2.Filter("true"));
+   auto n4 = ROOT::RDF::RNode(n3.Define("x", [] { return 42; }));
+   auto n5 = ROOT::RDF::RNode(n4.Define("y", "x"));
+   auto n6 = ROOT::RDF::RNode(n5.Range(0,0));
+   auto n7 = ROOT::RDF::RNode(n.Filter([] { return true; }, {}, "myfilter"));
    auto c = n6.Count();
    EXPECT_EQ(*c, 1ull);
 }


### PR DESCRIPTION
There are a number of trivial operations that users often want to perform on dataframes that are surprisingly hard to get right, for example adding several `Define`s in a loop or conditionally adding a `Filter` depending on a runtime boolean (both use-cases are challenging in C++, trivial in python).

The way I see it, difficulties boil down to the fact that different dataframe nodes have different types (because their types incorporate e.g. the type of the callable passed to a `Filter` and the type of their parent node in the computation graph).

In this PR I propose to add a common base class `ROOT::RDF::RNode` to all nodes of the graph (except leaves a.k.a results, which have a completely different interface),
so that users can, for example:
* take any dataframe node by reference in non-template functions as `RNode&`
* `emplace_back` dataframe nodes in ~`std::vector<RNode>`~  `vector<RInterface<RNode>>`
* have non-const pointers to dataframe nodes

and so on.

For example, conditionally adding a `Range` do a dataframe now looks like this:

```c++
auto maybe_ranged = [&df, mustAddRange] {                                                                                       
      return mustAddRange ? ROOT::RDF::RNode(d.Range(1))
                          : ROOT::RDF::RNode(d);                   
}();  
```

while before this PR one would have to add fake `Filter("true")` filters to normalize the return type of the lambda, involving the interpreter for no reason.

Internal `RDataFrame` code is also simplified by the introduction of this common base class.
The only downside I can think of is that if this mechanism is abused users might end up with extra, unnecessary virtual calls in their event loop -- on the other hand, this mechanism should only be used in situations that required either complex template magic or dirty and slow tricks before.

Questions:
* can we come up with a better name than `ROOT::RDF::ToCommonNodeType` for the function that upcasts any dataframe object to the same type?
* should this cast only be explicit through an upcasting function call or should we allow implicit casts?