### PR TITLE
[VecOps][DF] Minimal vector<bool> support 

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -38,6 +38,18 @@
 
 namespace ROOT {
 
+namespace Internal {
+namespace VecOps {
+/// This is a workaround to gently avoid users to use RVec<bool>
+template<typename T>
+void CheckForRVecBool()
+{
+   static_assert(!std::is_same<bool, T>::value,
+                 "An instance of RVec<bool> has been requested but this is not yet supported." );
+}
+} // End NS VecOps
+} // End NS Intenral
+
 namespace VecOps {
 // clang-format off
 /**
@@ -159,24 +171,24 @@ private:
 
 public:
    // constructors
-   RVec() {}
+   RVec() { ROOT::Internal::VecOps::CheckForRVecBool<T>(); }
 
-   explicit RVec(size_type count) : fData(count) {}
+   explicit RVec(size_type count) : fData(count) { ROOT::Internal::VecOps::CheckForRVecBool<T>(); }
 
-   RVec(size_type count, const T &value) : fData(count, value) {}
+   RVec(size_type count, const T &value) : fData(count, value) { ROOT::Internal::VecOps::CheckForRVecBool<T>(); }
 
-   RVec(const RVec<T> &v) : fData(v.fData) {}
+   RVec(const RVec<T> &v) : fData(v.fData) { ROOT::Internal::VecOps::CheckForRVecBool<T>(); }
 
-   RVec(RVec<T> &&v) : fData(std::move(v.fData)) {}
+   RVec(RVec<T> &&v) : fData(std::move(v.fData)) { ROOT::Internal::VecOps::CheckForRVecBool<T>(); }
 
-   RVec(const std::vector<T> &v) : fData(v.cbegin(), v.cend()) {}
+   RVec(const std::vector<T> &v) : fData(v.cbegin(), v.cend()) { ROOT::Internal::VecOps::CheckForRVecBool<T>(); }
 
-   RVec(pointer p, size_type n) : fData(n, T(), ROOT::Detail::VecOps::RAdoptAllocator<T>(p)) {}
+   RVec(pointer p, size_type n) : fData(n, T(), ROOT::Detail::VecOps::RAdoptAllocator<T>(p)) { ROOT::Internal::VecOps::CheckForRVecBool<T>(); }
 
    template <class InputIt>
-   RVec(InputIt first, InputIt last) : fData(first, last) {}
+   RVec(InputIt first, InputIt last) : fData(first, last) { ROOT::Internal::VecOps::CheckForRVecBool<T>(); }
 
-   RVec(std::initializer_list<T> init) : fData(init) {}
+   RVec(std::initializer_list<T> init) : fData(init) { ROOT::Internal::VecOps::CheckForRVecBool<T>(); }
 
    // assignment
    RVec<T> &operator=(const RVec<T> &v)

--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -45,7 +45,7 @@ template<typename T>
 void CheckForRVecBool()
 {
    static_assert(!std::is_same<bool, T>::value,
-                 "An instance of RVec<bool> has been requested but this is not yet supported." );
+                 "An instance of RVec<bool> has been requested but this is not yet supported. Please use std::vector<bool>." );
 }
 } // End NS VecOps
 } // End NS Intenral

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -617,3 +617,14 @@ TEST(VecOps, All)
    vi = {1, 1};
    EXPECT_TRUE(All(vi));
 }
+
+TEST(VecOps, RVecBoolError)
+{
+   testing::internal::CaptureStderr();
+   auto ret = gInterpreter->Calc("ROOT::VecOps::RVec<bool> w;");
+   std::string output = testing::internal::GetCapturedStderr();
+   EXPECT_EQ(ret, 0); // this tests the interpretation failed
+   auto pos = output.find("An instance of RVec<bool> has been requested but this is not yet supported.");
+   EXPECT_TRUE(std::string::npos != pos) << "There was an issue while prompting the static assert."
+                                         << " The error message was: \n" << output << std::endl;
+}

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -69,9 +69,7 @@ TEST(VecOps, CopyCtor)
 class TLeakChecker {
 public:
    static bool fgDestroyed;
-   ~TLeakChecker(){
-      fgDestroyed = true;
-   }
+   ~TLeakChecker() { fgDestroyed = true; }
 };
 bool TLeakChecker::fgDestroyed = false;
 
@@ -89,7 +87,6 @@ TEST(VecOps, CopyCtorCheckNoLeak)
    TLeakChecker::fgDestroyed = false;
    ref.clear();
    EXPECT_TRUE(TLeakChecker::fgDestroyed);
-
 }
 
 TEST(VecOps, MoveCtor)
@@ -105,7 +102,7 @@ TEST(VecOps, Conversion)
    ROOT::VecOps::RVec<float> fvec{1.0f, 2.0f, 3.0f};
    ROOT::VecOps::RVec<unsigned> uvec{1u, 2u, 3u};
 
-   ROOT::VecOps::RVec<int>  ivec = uvec;
+   ROOT::VecOps::RVec<int> ivec = uvec;
    ROOT::VecOps::RVec<long> lvec = ivec;
 
    EXPECT_EQ(1, ivec[0]);
@@ -413,9 +410,9 @@ TEST(VecOps, MathFuncs)
    ROOT::VecOps::RVec<double> v{1, 2, 3};
    ROOT::VecOps::RVec<double> w{1, 4, 27};
 
-   CheckEqual(pow(1,v), u, " error checking math function pow");
-   CheckEqual(pow(v,1), v, " error checking math function pow");
-   CheckEqual(pow(v,v), w, " error checking math function pow");
+   CheckEqual(pow(1, v), u, " error checking math function pow");
+   CheckEqual(pow(v, 1), v, " error checking math function pow");
+   CheckEqual(pow(v, v), w, " error checking math function pow");
 
    CheckEqual(sqrt(v), Map(v, [](double x) { return std::sqrt(x); }), " error checking math function sqrt");
    CheckEqual(log(v), Map(v, [](double x) { return std::log(x); }), " error checking math function log");
@@ -434,7 +431,7 @@ TEST(VecOps, MathFuncs)
    CheckEqual(atanh(v), Map(v, [](double x) { return std::atanh(x); }), " error checking math function atanh");
 
 #ifdef R__HAS_VDT
-   #define CHECK_VDT_FUNC(F) \
+#define CHECK_VDT_FUNC(F) \
    CheckEqual(fast_##F(v), Map(v, [](double x) { return vdt::fast_##F(x); }), "error checking vdt function " #F);
 
    CHECK_VDT_FUNC(exp)
@@ -464,7 +461,7 @@ TEST(VecOps, PhysicsSelections)
    CheckEqual(goodMuons_pt, goodMuons_pt_ref, "Muons quality cut");
 }
 
-template<typename T0>
+template <typename T0>
 void CheckEq(const T0 &v, const T0 &ref)
 {
    auto vsize = v.size();
@@ -480,18 +477,20 @@ TEST(VecOps, inputOutput)
    auto filename = "vecops_inputoutput.root";
    auto treename = "t";
 
-   const ROOT::VecOps::RVec<double>::Impl_t dref {1., 2., 3.};
-   const ROOT::VecOps::RVec<float>::Impl_t fref {1.f, 2.f, 3.f};
-   const ROOT::VecOps::RVec<UInt_t>::Impl_t uiref {1, 2, 3};
-   const ROOT::VecOps::RVec<ULong_t>::Impl_t ulref {1UL, 2UL, 3UL};
-   const ROOT::VecOps::RVec<ULong64_t>::Impl_t ullref {1ULL, 2ULL, 3ULL};
-   const ROOT::VecOps::RVec<UShort_t>::Impl_t usref {1, 2, 3};
-   const ROOT::VecOps::RVec<UChar_t>::Impl_t ucref {1, 2, 3};
-   const ROOT::VecOps::RVec<Int_t>::Impl_t iref {1, 2, 3};;
-   const ROOT::VecOps::RVec<Long_t>::Impl_t lref {1UL, 2UL, 3UL};;
-   const ROOT::VecOps::RVec<Long64_t>::Impl_t llref {1ULL, 2ULL, 3ULL};
-   const ROOT::VecOps::RVec<Short_t>::Impl_t sref {1, 2, 3};
-   const ROOT::VecOps::RVec<Char_t>::Impl_t cref {1, 2, 3};
+   const ROOT::VecOps::RVec<double>::Impl_t dref{1., 2., 3.};
+   const ROOT::VecOps::RVec<float>::Impl_t fref{1.f, 2.f, 3.f};
+   const ROOT::VecOps::RVec<UInt_t>::Impl_t uiref{1, 2, 3};
+   const ROOT::VecOps::RVec<ULong_t>::Impl_t ulref{1UL, 2UL, 3UL};
+   const ROOT::VecOps::RVec<ULong64_t>::Impl_t ullref{1ULL, 2ULL, 3ULL};
+   const ROOT::VecOps::RVec<UShort_t>::Impl_t usref{1, 2, 3};
+   const ROOT::VecOps::RVec<UChar_t>::Impl_t ucref{1, 2, 3};
+   const ROOT::VecOps::RVec<Int_t>::Impl_t iref{1, 2, 3};
+   ;
+   const ROOT::VecOps::RVec<Long_t>::Impl_t lref{1UL, 2UL, 3UL};
+   ;
+   const ROOT::VecOps::RVec<Long64_t>::Impl_t llref{1ULL, 2ULL, 3ULL};
+   const ROOT::VecOps::RVec<Short_t>::Impl_t sref{1, 2, 3};
+   const ROOT::VecOps::RVec<Char_t>::Impl_t cref{1, 2, 3};
 
    {
       auto d = dref;
@@ -568,30 +567,29 @@ TEST(VecOps, inputOutput)
    CheckEq(*f, fref);
 
    gSystem->Unlink(filename);
-
 }
 
 TEST(VecOps, SimpleStatOps)
 {
-   ROOT::VecOps::RVec<double> v0 {};
+   ROOT::VecOps::RVec<double> v0{};
    ASSERT_DOUBLE_EQ(Sum(v0), 0.);
    ASSERT_DOUBLE_EQ(Mean(v0), 0.);
    ASSERT_DOUBLE_EQ(StdDev(v0), 0.);
    ASSERT_DOUBLE_EQ(Var(v0), 0.);
 
-   ROOT::VecOps::RVec<double> v1 {42.};
+   ROOT::VecOps::RVec<double> v1{42.};
    ASSERT_DOUBLE_EQ(Sum(v1), 42.);
    ASSERT_DOUBLE_EQ(Mean(v1), 42.);
    ASSERT_DOUBLE_EQ(StdDev(v1), 0.);
    ASSERT_DOUBLE_EQ(Var(v1), 0.);
 
-   ROOT::VecOps::RVec<double> v2 {1., 2., 3.};
+   ROOT::VecOps::RVec<double> v2{1., 2., 3.};
    ASSERT_DOUBLE_EQ(Sum(v2), 6.);
    ASSERT_DOUBLE_EQ(Mean(v2), 2.);
    ASSERT_DOUBLE_EQ(Var(v2), 1.);
    ASSERT_DOUBLE_EQ(StdDev(v2), 1.);
-   
-   ROOT::VecOps::RVec<double> v3 {10., 20., 32.};
+
+   ROOT::VecOps::RVec<double> v3{10., 20., 32.};
    ASSERT_DOUBLE_EQ(Sum(v3), 62.);
    ASSERT_DOUBLE_EQ(Mean(v3), 20.666666666666668);
    ASSERT_DOUBLE_EQ(Var(v3), 121.33333333333337);
@@ -600,7 +598,7 @@ TEST(VecOps, SimpleStatOps)
 
 TEST(VecOps, Any)
 {
-   ROOT::VecOps::RVec<int> vi {0, 1, 2};
+   ROOT::VecOps::RVec<int> vi{0, 1, 2};
    EXPECT_TRUE(Any(vi));
    vi = {0, 0, 0};
    EXPECT_FALSE(Any(vi));
@@ -610,7 +608,7 @@ TEST(VecOps, Any)
 
 TEST(VecOps, All)
 {
-   ROOT::VecOps::RVec<int> vi {0, 1, 2};
+   ROOT::VecOps::RVec<int> vi{0, 1, 2};
    EXPECT_FALSE(All(vi));
    vi = {0, 0, 0};
    EXPECT_FALSE(All(vi));
@@ -626,5 +624,6 @@ TEST(VecOps, RVecBoolError)
    EXPECT_EQ(ret, 0); // this tests the interpretation failed
    auto pos = output.find("An instance of RVec<bool> has been requested but this is not yet supported.");
    EXPECT_TRUE(std::string::npos != pos) << "There was an issue while prompting the static assert."
-                                         << " The error message was: \n" << output << std::endl;
+                                         << " The error message was: \n"
+                                         << output << std::endl;
 }

--- a/tree/dataframe/inc/ROOT/RDFNodes.hxx
+++ b/tree/dataframe/inc/ROOT/RDFNodes.hxx
@@ -246,6 +246,8 @@ class TColumnValue {
    using TreeReader_t =
       typename std::conditional<MustUseRVec, TTreeReaderArray<ColumnValue_t>, TTreeReaderValue<ColumnValue_t>>::type;
 
+   /// Shortcut type for the internal RVec cache. We need to avoid RVec<bool>
+   using MaybeRVec_t = typename std::conditional<MustUseRVec, RVec<ColumnValue_t>, std::nullptr_t>::type;
    /// TColumnValue has a slightly different behaviour whether the column comes from a TTreeReader, a RDataFrame Define
    /// or a RDataSource. It stores which it is as an enum.
    enum class EColumnKind { kTree, kCustomColumn, kDataSource, kInvalid };
@@ -272,7 +274,7 @@ class TColumnValue {
    /// in contiguous memory. Only used when T == RVec<U>.
    EStorageType fStorageType = EStorageType::kUnknown;
    /// If MustUseRVec, i.e. we are reading an array, we return a reference to this RVec to clients
-   RVec<ColumnValue_t> fRVec;
+   MaybeRVec_t fRVec;
    bool fCopyWarningPrinted = false;
 
 public:

--- a/tree/dataframe/inc/ROOT/RDFUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDFUtils.hxx
@@ -101,6 +101,9 @@ struct IsRVec_t : public std::false_type {};
 template <typename T>
 struct IsRVec_t<ROOT::VecOps::RVec<T>> : public std::true_type {};
 
+template <>
+struct IsRVec_t<ROOT::VecOps::RVec<bool>> : public std::false_type {};
+
 // Check the value_type type of a type with a SFINAE to allow compilation in presence
 // fundamental types
 template <typename T, bool IsContainer = IsContainer<typename std::decay<T>::type>::value>

--- a/tree/dataframe/inc/ROOT/RDFUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDFUtils.hxx
@@ -101,9 +101,6 @@ struct IsRVec_t : public std::false_type {};
 template <typename T>
 struct IsRVec_t<ROOT::VecOps::RVec<T>> : public std::true_type {};
 
-template <>
-struct IsRVec_t<ROOT::VecOps::RVec<bool>> : public std::false_type {};
-
 // Check the value_type type of a type with a SFINAE to allow compilation in presence
 // fundamental types
 template <typename T, bool IsContainer = IsContainer<typename std::decay<T>::type>::value>

--- a/tree/dataframe/src/RDFUtils.cxx
+++ b/tree/dataframe/src/RDFUtils.cxx
@@ -191,7 +191,11 @@ std::string ColumnName2ColumnTypeName(const std::string &colName, unsigned int n
 
    if (colType.empty() && tree) {
       colType = GetBranchOrLeafTypeName(*tree, colName);
-      if (vector2tvec && TClassEdit::IsSTLCont(colType) == ROOT::ESTLType::kSTLvector) {
+      if (vector2tvec &&
+         TClassEdit::IsSTLCont(colType) == ROOT::ESTLType::kSTLvector &&
+         // If the type is a vector of bool, do not use RVec<bool> but rather vector<bool>
+         // since the type RVec<bool> is not yet supported.
+         0 != strncmp(colType.c_str(), "vector<bool", 11)) {
          std::vector<std::string> split;
          int dummy;
          TClassEdit::GetSplit(colType.c_str(), split, dummy);

--- a/tree/dataframe/test/dataframe_snapshot.cxx
+++ b/tree/dataframe/test/dataframe_snapshot.cxx
@@ -470,6 +470,29 @@ TEST(RDFSnapshotMore, Lazy)
    gSystem->Unlink(fname1);
 }
 
+// This test makes sure that vector<bool> is read as such and not as RVec<bool>
+// in presence of jitted actions/transformations
+TEST(RDFSnapshotMore, WriteReadVectorOfBool)
+{
+   auto fileName = "ReadVectorOfBool.root";
+   auto treeName = "t";
+   // Create sample dataset
+   {
+      RDataFrame d(1);
+      d.Define("v",[](){return std::vector<bool>({true, true, false, false});})
+       .Snapshot(treeName, fileName);
+   }
+
+   RDataFrame d(treeName, fileName);
+   auto c1 = d.Filter("(v == std::vector<bool>({true, true, false, false}))")
+              .Count();
+   auto c2 = d.Filter("(v == std::vector<bool>({true, true, false}))")
+              .Count();
+   EXPECT_EQ(1U, *c1);
+   EXPECT_EQ(0U, *c2);
+
+   gSystem->Unlink(fileName);
+}
 
 /********* MULTI THREAD TESTS ***********/
 #ifdef R__USE_IMT


### PR DESCRIPTION
This PR introduces:
- A mechanism to forbid istantiation of RVec<bool>
- A mechanism to treat vector<bool> as such and not as RVec<bool> with jitted actions and transformations
- Tests