### PR TITLE
Revert "[cxxmodules] Don't generate rootmap files with cxxmodules"

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -5096,7 +5096,7 @@ int RootClingMain(int argc,
       else return a + " " + b;
    });
 
-   bool rootMapNeeded = (!rootmapFileName.empty() || !rootmapLibName.empty()) && !cxxmodule;
+   bool rootMapNeeded = !rootmapFileName.empty() || !rootmapLibName.empty();
 
    std::list<std::string> classesNames;
    std::list<std::string> classesNamesForRootmap;


### PR DESCRIPTION
This reverts commit 8bb0a978a34e8f026a98642afe118e15d2356b6c.

With ACLiC, which means if you do "root.exe hsimple.C+", ROOT generates
library for hsimple.C and execute this library instead of interpreting it at
runtime. This didn't work with our "preloading modules" infrastructure,
as it's not even interpreting.

We can fix this by
1. Adding NEEDED section when generating so files.
   This is like a "static linker" solution, which means we'll change
   rootcling_impl to properly add dependency libraries.
2. Try to get callback from library
   I think this makes ACLiC slower, so I like the 1st solution

However, for now, let's just revert this patch.

edit:
https://gist.github.com/yamaguchi1024/644b7ee431fce460fb27c1402e92c903
https://gist.github.com/yamaguchi1024/d5a69666d1e10f0b2cfc176a07792420