### PR TITLE
[DF] ROOT-9468 - Add TColumnValue extern templates for common types

### DIFF
--- a/tree/dataframe/inc/LinkDef.h
+++ b/tree/dataframe/inc/LinkDef.h
@@ -35,6 +35,22 @@
 #pragma link C++ class ROOT::RDF::RTrivialDS-;
 #pragma link C++ class ROOT::RDF::RRootDS-;
 #pragma link C++ class ROOT::RDF::RCsvDS-;
+#pragma link C++ class ROOT::Internal::RDF::TColumnValue<int>-;
+#pragma link C++ class ROOT::Internal::RDF::TColumnValue<unsigned int>-;
+#pragma link C++ class ROOT::Internal::RDF::TColumnValue<char>-;
+#pragma link C++ class ROOT::Internal::RDF::TColumnValue<unsigned char>-;
+#pragma link C++ class ROOT::Internal::RDF::TColumnValue<float>-;
+#pragma link C++ class ROOT::Internal::RDF::TColumnValue<double>-;
+#pragma link C++ class ROOT::Internal::RDF::TColumnValue<Long64_t>-;
+#pragma link C++ class ROOT::Internal::RDF::TColumnValue<ULong64_t>-;
+#pragma link C++ class ROOT::Internal::RDF::TColumnValue<std::vector<int>>-;
+#pragma link C++ class ROOT::Internal::RDF::TColumnValue<std::vector<unsigned int>>-;
+#pragma link C++ class ROOT::Internal::RDF::TColumnValue<std::vector<char>>-;
+#pragma link C++ class ROOT::Internal::RDF::TColumnValue<std::vector<unsigned char>>-;
+#pragma link C++ class ROOT::Internal::RDF::TColumnValue<std::vector<float>>-;
+#pragma link C++ class ROOT::Internal::RDF::TColumnValue<std::vector<double>>-;
+#pragma link C++ class ROOT::Internal::RDF::TColumnValue<std::vector<Long64_t>>-;
+#pragma link C++ class ROOT::Internal::RDF::TColumnValue<std::vector<ULong64_t>>-;
 
 #endif
 

--- a/tree/dataframe/inc/ROOT/RDFNodes.hxx
+++ b/tree/dataframe/inc/ROOT/RDFNodes.hxx
@@ -246,8 +246,8 @@ class TColumnValue {
 
    // ColumnValue_t is the type of the column or the type of the elements of an array column
    using ColumnValue_t = typename std::conditional<MustUseRVec_t::value, TakeFirstParameter_t<T>, T>::type;
-   using TreeReader_t =
-      typename std::conditional<MustUseRVec_t::value, TTreeReaderArray<ColumnValue_t>, TTreeReaderValue<ColumnValue_t>>::type;
+   using TreeReader_t = typename std::conditional<MustUseRVec_t::value, TTreeReaderArray<ColumnValue_t>,
+                                                  TTreeReaderValue<ColumnValue_t>>::type;
 
    /// TColumnValue has a slightly different behaviour whether the column comes from a TTreeReader, a RDataFrame Define
    /// or a RDataSource. It stores which it is as an enum.
@@ -270,7 +270,7 @@ class TColumnValue {
    /// Non-owning ptrs to the node responsible for the custom column. Needed when querying custom values.
    std::vector<RCustomColumnBase *> fCustomColumns;
    /// Enumerator for the different properties of the branch storage in memory
-   enum class EStorageType : char { kContiguous, kUnknown, kSparse};
+   enum class EStorageType : char { kContiguous, kUnknown, kSparse };
    /// Signal whether we ever checked that the branch we are reading with a TTreeReaderArray stores array elements
    /// in contiguous memory. Only used when T == RVec<U>.
    EStorageType fStorageType = EStorageType::kUnknown;
@@ -279,8 +279,7 @@ class TColumnValue {
    bool fCopyWarningPrinted = false;
 
 public:
-
-   TColumnValue() {};
+   TColumnValue(){};
 
    void SetTmpColumn(unsigned int slot, RCustomColumnBase *tmpColumn);
 
@@ -916,12 +915,13 @@ T &TColumnValue<T>::Get(Long64_t entry)
             swap(fRVec, emptyVec);
          }
       } else {
-         // The storage is not contiguous or we don't know yet: we cannot but copy into the tvec
+// The storage is not contiguous or we don't know yet: we cannot but copy into the tvec
 #ifndef NDEBUG
          if (!fCopyWarningPrinted) {
-            Warning("TColumnValue::Get",
-                  "Branch %s hangs from a non-split branch. For this reason, it cannot be accessed via a RVec. A copy is being performed in order to properly read the content.",
-                  readerArray.GetBranchName());
+            Warning("TColumnValue::Get", "Branch %s hangs from a non-split branch. For this reason, it cannot be "
+                                         "accessed via a RVec. A copy is being performed in order to properly read the "
+                                         "content.",
+                    readerArray.GetBranchName());
             fCopyWarningPrinted = true;
          }
 #else

--- a/tree/dataframe/inc/ROOT/RDFNodes.hxx
+++ b/tree/dataframe/inc/ROOT/RDFNodes.hxx
@@ -278,7 +278,7 @@ class TColumnValue {
 public:
    static constexpr bool fgMustUseRVec = MustUseRVec;
 
-   TColumnValue() = default;
+   TColumnValue() {};
 
    void SetTmpColumn(unsigned int slot, RCustomColumnBase *tmpColumn);
 
@@ -313,6 +313,25 @@ public:
       }
    }
 };
+
+// Some extern instaniations to speed-up compilation/interpretation time
+extern template class TColumnValue<int>;
+extern template class TColumnValue<unsigned int>;
+extern template class TColumnValue<char>;
+extern template class TColumnValue<unsigned char>;
+extern template class TColumnValue<float>;
+extern template class TColumnValue<double>;
+extern template class TColumnValue<Long64_t>;
+extern template class TColumnValue<ULong64_t>;
+extern template class TColumnValue<std::vector<int>>;
+extern template class TColumnValue<std::vector<unsigned int>>;
+extern template class TColumnValue<std::vector<char>>;
+extern template class TColumnValue<std::vector<unsigned char>>;
+extern template class TColumnValue<std::vector<float>>;
+extern template class TColumnValue<std::vector<double>>;
+extern template class TColumnValue<std::vector<Long64_t>>;
+extern template class TColumnValue<std::vector<ULong64_t>>;
+
 
 template <typename T>
 struct TRDFValueTuple {

--- a/tree/dataframe/inc/ROOT/RDFNodes.hxx
+++ b/tree/dataframe/inc/ROOT/RDFNodes.hxx
@@ -317,6 +317,9 @@ public:
 };
 
 // Some extern instaniations to speed-up compilation/interpretation time
+// These are not active if c++17 is enabled because of a bug in our clang
+// See ROOT-9499.
+#if __cplusplus < 201703L
 extern template class TColumnValue<int>;
 extern template class TColumnValue<unsigned int>;
 extern template class TColumnValue<char>;
@@ -333,7 +336,7 @@ extern template class TColumnValue<std::vector<float>>;
 extern template class TColumnValue<std::vector<double>>;
 extern template class TColumnValue<std::vector<Long64_t>>;
 extern template class TColumnValue<std::vector<ULong64_t>>;
-
+#endif
 
 template <typename T>
 struct TRDFValueTuple {

--- a/tree/dataframe/inc/ROOT/RDFNodes.hxx
+++ b/tree/dataframe/inc/ROOT/RDFNodes.hxx
@@ -239,12 +239,15 @@ TTree branch or from a temporary column respectively.
 RDataFrame nodes can store tuples of TColumnValues and retrieve an updated
 value for the column via the `Get` method.
 **/
-template <typename T, bool MustUseRVec = IsRVec_t<T>::value>
+template <typename T>
 class TColumnValue {
+
+   using MustUseRVec_t = IsRVec_t<T>;
+
    // ColumnValue_t is the type of the column or the type of the elements of an array column
-   using ColumnValue_t = typename std::conditional<MustUseRVec, TakeFirstParameter_t<T>, T>::type;
+   using ColumnValue_t = typename std::conditional<MustUseRVec_t::value, TakeFirstParameter_t<T>, T>::type;
    using TreeReader_t =
-      typename std::conditional<MustUseRVec, TTreeReaderArray<ColumnValue_t>, TTreeReaderValue<ColumnValue_t>>::type;
+      typename std::conditional<MustUseRVec_t::value, TTreeReaderArray<ColumnValue_t>, TTreeReaderValue<ColumnValue_t>>::type;
 
    /// TColumnValue has a slightly different behaviour whether the column comes from a TTreeReader, a RDataFrame Define
    /// or a RDataSource. It stores which it is as an enum.
@@ -276,7 +279,6 @@ class TColumnValue {
    bool fCopyWarningPrinted = false;
 
 public:
-   static constexpr bool fgMustUseRVec = MustUseRVec;
 
    TColumnValue() {};
 
@@ -289,12 +291,12 @@ public:
    }
 
    /// This overload is used to return scalar quantities (i.e. types that are not read into a RVec)
-   template <typename U = T, typename std::enable_if<!TColumnValue<U>::fgMustUseRVec, int>::type = 0>
+   template <typename U = T, typename std::enable_if<!TColumnValue<U>::MustUseRVec_t::value, int>::type = 0>
    T &Get(Long64_t entry);
 
    /// This overload is used to return arrays (i.e. types that are read into a RVec).
    /// In this case the returned T is always a RVec<ColumnValue_t>.
-   template <typename U = T, typename std::enable_if<TColumnValue<U>::fgMustUseRVec, int>::type = 0>
+   template <typename U = T, typename std::enable_if<TColumnValue<U>::MustUseRVec_t::value, int>::type = 0>
    T &Get(Long64_t entry);
 
    void Reset()
@@ -844,8 +846,8 @@ public:
 namespace Internal {
 namespace RDF {
 
-template <typename T, bool B>
-void TColumnValue<T, B>::SetTmpColumn(unsigned int slot, ROOT::Detail::RDF::RCustomColumnBase *customColumn)
+template <typename T>
+void TColumnValue<T>::SetTmpColumn(unsigned int slot, ROOT::Detail::RDF::RCustomColumnBase *customColumn)
 {
    fCustomColumns.emplace_back(customColumn);
    if (customColumn->GetTypeId() != typeid(T))
@@ -866,9 +868,9 @@ void TColumnValue<T, B>::SetTmpColumn(unsigned int slot, ROOT::Detail::RDF::RCus
 // This method is executed inside the event-loop, many times per entry
 // If need be, the if statement can be avoided using thunks
 // (have both branches inside functions and have a pointer to the branch to be executed)
-template <typename T, bool B>
-template <typename U, typename std::enable_if<!TColumnValue<U>::fgMustUseRVec, int>::type>
-T &TColumnValue<T, B>::Get(Long64_t entry)
+template <typename T>
+template <typename U, typename std::enable_if<!TColumnValue<U>::MustUseRVec_t::value, int>::type>
+T &TColumnValue<T>::Get(Long64_t entry)
 {
    if (fColumnKind == EColumnKind::kTree) {
       return *(fTreeReaders.back()->Get());
@@ -879,9 +881,9 @@ T &TColumnValue<T, B>::Get(Long64_t entry)
 }
 
 /// This overload is used to return arrays (i.e. types that are read into a RVec)
-template <typename T, bool B>
-template <typename U, typename std::enable_if<TColumnValue<U>::fgMustUseRVec, int>::type>
-T &TColumnValue<T, B>::Get(Long64_t entry)
+template <typename T>
+template <typename U, typename std::enable_if<TColumnValue<U>::MustUseRVec_t::value, int>::type>
+T &TColumnValue<T>::Get(Long64_t entry)
 {
    if (fColumnKind == EColumnKind::kTree) {
       auto &readerArray = *fTreeReaders.back();

--- a/tree/dataframe/src/RDFNodes.cxx
+++ b/tree/dataframe/src/RDFNodes.cxx
@@ -52,7 +52,10 @@ RActionBase::RActionBase(RLoopManager *implPtr, const unsigned int nSlots) : fLo
 {
 }
 
-// Extern templates
+// Some extern instaniations to speed-up compilation/interpretation time
+// These are not active if c++17 is enabled because of a bug in our clang
+// See ROOT-9499.
+#if __cplusplus < 201703L
 template class TColumnValue<int>;
 template class TColumnValue<unsigned int>;
 template class TColumnValue<char>;
@@ -69,6 +72,7 @@ template class TColumnValue<std::vector<float>>;
 template class TColumnValue<std::vector<double>>;
 template class TColumnValue<std::vector<Long64_t>>;
 template class TColumnValue<std::vector<ULong64_t>>;
+#endif
 } // end NS RDF
 } // end NS Internal
 } // end NS ROOT

--- a/tree/dataframe/src/RDFNodes.cxx
+++ b/tree/dataframe/src/RDFNodes.cxx
@@ -52,6 +52,23 @@ RActionBase::RActionBase(RLoopManager *implPtr, const unsigned int nSlots) : fLo
 {
 }
 
+// Extern templates
+template class TColumnValue<int>;
+template class TColumnValue<unsigned int>;
+template class TColumnValue<char>;
+template class TColumnValue<unsigned char>;
+template class TColumnValue<float>;
+template class TColumnValue<double>;
+template class TColumnValue<Long64_t>;
+template class TColumnValue<ULong64_t>;
+template class TColumnValue<std::vector<int>>;
+template class TColumnValue<std::vector<unsigned int>>;
+template class TColumnValue<std::vector<char>>;
+template class TColumnValue<std::vector<unsigned char>>;
+template class TColumnValue<std::vector<float>>;
+template class TColumnValue<std::vector<double>>;
+template class TColumnValue<std::vector<Long64_t>>;
+template class TColumnValue<std::vector<ULong64_t>>;
 } // end NS RDF
 } // end NS Internal
 } // end NS ROOT


### PR DESCRIPTION
this mitigates ROOT-9468 speeding up considerably the instantiation of large templates, such as Snapshot of many columns.
It is helpful in general too.