### PR TITLE
[cxxmodules] Evaluate code with interpreter in pretty print

### DIFF
--- a/core/meta/inc/TInterpreterValue.h
+++ b/core/meta/inc/TInterpreterValue.h
@@ -38,6 +38,7 @@ public:
 
    virtual const void* GetValAddr() const = 0;
    virtual void* GetValAddr() = 0;
+   virtual std::pair<std::string, std::string> ToTypeAndValueString() const = 0;
 
    virtual Bool_t      IsValid() const = 0;
    virtual Double_t    GetAsDouble() const = 0;

--- a/core/metacling/src/TClingValue.cxx
+++ b/core/metacling/src/TClingValue.cxx
@@ -44,6 +44,23 @@ TClingValue& TClingValue::operator=(TClingValue &Other) {
    return *this;
 }
 
+std::pair<std::string, std::string> TClingValue::ToTypeAndValueString() const {
+  std::string output = ToString();
+  int paren_level = 0;
+
+  for (int pos = 0; pos < output.size(); ++pos) {
+    if (output[pos] == '(')
+      ++paren_level;
+    else if (output[pos] == ')') {
+      --paren_level;
+      if (!paren_level)
+        return std::make_pair(output.substr(0, pos + 1), output.substr(pos + 2));
+    }
+  }
+
+  return std::make_pair("", output);
+}
+
 Bool_t TClingValue::IsValid() const {
    return ToCV().isValid();
 }

--- a/core/metacling/src/TClingValue.h
+++ b/core/metacling/src/TClingValue.h
@@ -54,6 +54,7 @@ public:
    const void* GetValAddr() const { return &fValue; }
    void* GetValAddr() { return &fValue; }
 
+   std::pair<std::string, std::string> ToTypeAndValueString() const;
    Bool_t      IsValid() const;
    Double_t    GetAsDouble() const;
    Long_t      GetAsLong() const;


### PR DESCRIPTION
This is an alternative implementation of #2194. Changed Pythonize to
call Evaluate instead of doing Calc on code containing
cling::printValue.