### PR TITLE
[cxxmodules] Fix bloom filter without .gnu.hash

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -5935,7 +5935,8 @@ static bool LookupBloomFilter(llvm::object::ObjectFile *soFile, uint32_t hash) {
 
    StringRef contents = GetGnuHashSection(soFile);
    if (contents.size() < 16)
-      return false;
+      // We need to search if the library doesn't have .gnu.hash section!
+      return true;
    const char* hashContent = contents.data();
 
    // See https://flapenguin.me/2017/05/10/elf-lookup-dt-gnu-hash/ for .gnu.hash table layout.


### PR DESCRIPTION
In some node where ROOT was using lagacy compiler, they didn't compile
shared library with a linker flag --hash-style=gnu. So libraries didn't
have .gnu.hash section. We need to search symbols for these libraries,
     too.