### PR TITLE
Add VDT to list of builtin targets so it builds before ROOT

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1471,7 +1471,8 @@ if(vdt OR builtin_vdt)
             DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
     install(DIRECTORY ${CMAKE_BINARY_DIR}/include/vdt
             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT extra-headers)
-          set(vdt ON CACHE BOOL "Enabled because builtin_vdt enabled (${vdt_description})" FORCE)
+    set(vdt ON CACHE BOOL "Enabled because builtin_vdt enabled (${vdt_description})" FORCE)
+    set_property(GLOBAL APPEND PROPERTY ROOT_BUILTIN_TARGETS VDT)
   endif()
 endif()
 


### PR DESCRIPTION
The dependency of `Vdt::Vdt` imported target should have been automatically added by CMake due to it being listed in the `BUILD_BYPRODUCTS` of the `ExternalProject_Add()` command, but not all versions of CMake work, so it is necessary to build it early by force. Targets listed in `ROOT_BUILTIN_TARGETS`
get added as a dependency of the move_headers target, which is reasonable since they often provide headers without which ROOT cannot be built in any case (e.g. `vdt/vdtMath.h`).