### PR TITLE
[PyROOT] Add tutorial for pretty printing feature

### DIFF
--- a/tutorials/pyroot/pyroot003_prettyPrinting.py
+++ b/tutorials/pyroot/pyroot003_prettyPrinting.py
@@ -1,0 +1,38 @@
+## \file
+## \ingroup tutorial_pyroot
+## \notebook -nodraw
+## This tutorial illustrates the pretty printing feature of PyROOT, which reveals
+## the content of the object if a string representation is requested, e.g., by
+## Python's print statement. The printing behaves similar to the ROOT prompt
+## powered by the C++ interpreter cling.
+##
+## \macro_code
+##
+## \date June 2018
+## \author Stefan Wunsch
+
+import ROOT
+
+# Create an object with PyROOT
+obj = ROOT.std.vector("int")(3)
+for i in range(obj.size()):
+    obj[i] = i
+
+# Print the object, which reveals the content. Note that `print` calls the special
+# method `__str__` of the object internally.
+print(obj)
+
+# The output can be retrieved as string by any function that triggers the `__str__`
+# special method of the object, e.g., `str` or `format`.
+print(str(obj))
+print("{}".format(obj))
+
+# Note that the interactive Python prompt does not call `__str__`, it calls
+# `__repr__`, which implements a formal and unique string representation of
+# the object.
+print(repr(obj))
+obj
+
+# The print output behaves similar to the ROOT prompt, e.g., here for a ROOT histogram.
+hist = ROOT.TH1F("name", "title", 10, 0, 1)
+print(hist)


### PR DESCRIPTION
Document the feature in a tutorial and point out the difference between `__str__` and `__repr__` in Python (and what `print` calls).