### PR TITLE
[DF] Do not add output chain as clone of input chain in MT Snapshot

### DIFF
--- a/tree/dataframe/inc/ROOT/RDFActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFActionHelpers.hxx
@@ -803,9 +803,6 @@ public:
       if (r) {
          // not an empty-source RDF
          fInputTrees[slot] = r->GetTree();
-         // AddClone guarantees that if the input file changes the branches of the output tree are updated with the new
-         // addresses of the branch values
-         fInputTrees[slot]->AddClone(fOutputTrees[slot]);
       }
       fIsFirstEvent[slot] = 1; // reset first event flag for this slot
    }


### PR DESCRIPTION
There's no need for it, as in the MT case we build one output tree
per task (i.e. per input tree cluster), so there will be no need
of resetting output branch addresses.

TODO: test that this is still true when friends are present (I don't think it is?)