### PR TITLE
Fix zero initialization in `TCudaMatrix`

### DIFF
--- a/core/foundation/res/TSpinLockGuard.h
+++ b/core/foundation/res/TSpinLockGuard.h
@@ -18,18 +18,18 @@ namespace ROOT {
 namespace Internal {
 
 /**
- * \class ROOT::Internal::TSpinLockGuard
+* \class ROOT::Internal::TSpinLockGuard
 * \brief A spin mutex-as-code-guard class.
 * \ingroup Foundation
 * This class allows to acquire spin locks in combination with a std::atomic_flag variable.
 * For example:
-* ~~~ {.cpp}
+* ~~~{.cpp}
 * mutable std::atomic_flag fSpinLock;
 * [...]
 * ROOT::Internal::TSpinLockGuard slg(fSpinLock);
 * // do something important
 * [...]
-* ~~~ {.cpp}
+* ~~~{.cpp}
 */
 
 class TSpinLockGuard {

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda/CudaMatrix.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda/CudaMatrix.h
@@ -166,9 +166,7 @@ public:
    }
 
    void Zero() {
-      AFloat * p = new AFloat[GetNoElements()]();
-      cudaMemcpy(GetDataPointer(), p, sizeof(AFloat) * GetNoElements(), cudaMemcpyHostToDevice);
-      delete[] p;
+      cudaMemset(GetDataPointer(), 0, sizeof(AFloat) * GetNoElements());
    }
 
 

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda/CudaMatrix.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda/CudaMatrix.h
@@ -165,11 +165,10 @@ public:
       mat.Print(); 
    }
 
-   void Zero() { 
-      // to be checked 
-      AFloat * p = GetDataPointer(); 
-      for (size_t i = 0; i < GetNoElements(); ++i)
-         p[i] = 0; 
+   void Zero() {
+      AFloat * p = new AFloat[GetNoElements()]();
+      cudaMemcpy(GetDataPointer(), p, sizeof(AFloat) * GetNoElements(), cudaMemcpyHostToDevice);
+      delete[] p;
    }
 
 


### PR DESCRIPTION
Fixes a previously fatal runtime error when trying to initialize a `cudaMatrix` with zeroes.

The previous implementation was trying to assign directly into a raw pointer to device memory, which is undefined behavior. The fixed implementations creates the array of zeroes in host memory and then copies to device.

