### PR TITLE
[cxxmodules] Testing! Do not iterate over subdirectories

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/Lex/HeaderSearch.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Lex/HeaderSearch.cpp
@@ -270,10 +270,6 @@ Module *HeaderSearch::lookupModule(StringRef ModuleName, StringRef SearchName) {
     if (SearchDirs[Idx].haveSearchedAllModuleMaps())
       continue;
 
-    // Load all module maps in the immediate subdirectories of this search
-    // directory.
-    loadSubdirectoryModuleMaps(SearchDirs[Idx]);
-
     // Look again for the module.
     Module = ModMap.findModule(ModuleName);
     if (Module)


### PR DESCRIPTION
In clang/lib/Lex/HeaderSearch.cpp HeaderSearch::lookupModule(StringRef ModuleName, StringRef SearchName),
  1. It searches for ModuleName in modulemap directly under the search directory (E.g "/usr/include" or "/home/yuka/build/include")
  2. It searches for ModuleName in modulemap in a subdirectory of the search directory with the same name as the module

If it couldn't find ModuleName in both 1 and 2, it comes to this line
 283     // Load all module maps in the immediate subdirectories of this search
 284     // directory.
 285     loadSubdirectoryModuleMaps(SearchDirs[Idx]);
Which results in iterating over all files in the search path for example "/usr/include".

For us, we had a problem with CMSSW because Clang started to load our default installed root modulemap in "usr/include/root/module.modulemap".