### PR TITLE
ROOT-9483 -- Prevent nullptr deref. in compiled macros

### DIFF
--- a/tmva/tmvagui/src/mvaeffs.cxx
+++ b/tmva/tmvagui/src/mvaeffs.cxx
@@ -512,7 +512,16 @@ void TMVA::mvaeffs(TString dataset, TString fin ,
 {
    TMVAGlob::Initialize( useTMVAStyle );
 
-   StatDialogMVAEffs* gGui = new StatDialogMVAEffs(dataset,gClient->GetRoot(), 1000, 1000);
+   TGClient * graphicsClient = TGClient::Instance();
+   if (graphicsClient == nullptr) {
+      // When including mvaeffs in a stand-alone macro, the graphics subsystem
+      // is not initialised and `TGClient::Instance` is a nullptr.
+      graphicsClient = new TGClient();
+   }
+
+   StatDialogMVAEffs* gGui = new StatDialogMVAEffs(dataset, 
+      graphicsClient->GetRoot(), 1000, 1000);
+
 
    TFile* file = TMVAGlob::OpenFile( fin );
    gGui->ReadHistograms(file);


### PR DESCRIPTION
When compiling TMVA GUI methods stand alone (e.g. clang++ not through `root -l`) the graphics subsystem of ROOT is not initialised leading to a null pointer dereference.

See [ROOT-9483](https://sft.its.cern.ch/jira/browse/ROOT-9483?filter=-2)