### PR TITLE
Performance fix for MnMachinePrecision

### DIFF
--- a/math/minuit2/inc/Minuit2/MnMachinePrecision.h
+++ b/math/minuit2/inc/Minuit2/MnMachinePrecision.h
@@ -16,6 +16,13 @@ namespace ROOT {
 
    namespace Minuit2 {
 
+// compute machine precision only once
+struct MnStaticMachinePrecision {
+  MnStaticMachinePrecision();
+  double eps, eps2;
+};
+
+static const MnStaticMachinePrecision static_precision;
 
 /**
     determines the relative floating point arithmetic precision. The
@@ -28,7 +35,10 @@ class MnMachinePrecision {
 
 public:
 
-  MnMachinePrecision();
+  MnMachinePrecision() :
+    fEpsMac(static_precision.eps),
+    fEpsMa2(static_precision.eps2)
+  {}
 
   ~MnMachinePrecision() {}
 

--- a/math/minuit2/src/MnMachinePrecision.cxx
+++ b/math/minuit2/src/MnMachinePrecision.cxx
@@ -14,19 +14,18 @@ namespace ROOT {
 
    namespace Minuit2 {
 
-
-MnMachinePrecision::MnMachinePrecision() :
-   fEpsMac(4.0E-7),
-   fEpsMa2(2.*sqrt(4.0E-7)) {
+MnStaticMachinePrecision::MnStaticMachinePrecision() :
+   eps(4.0E-7),
+   eps2(2.*sqrt(4.0E-7)) {
 
    //determine machine precision
    /*
        char e[] = {"e"};
-       fEpsMac = 8.*dlamch_(e);
-       fEpsMa2 = 2.*sqrt(fEpsMac);
+       eps = 8.*dlamch_(e);
+       eps2 = 2.*sqrt(eps);
    */
 
-   //   std::cout<<"machine precision eps: "<<Eps()<<std::endl;
+   //   std::cout<<"machine precision eps: "<<eps()<<std::endl;
 
    MnTiny mytiny;
 
@@ -40,12 +39,11 @@ MnMachinePrecision::MnMachinePrecision() :
       epsp1 = one + epstry;
       epsbak = mytiny(epsp1);
       if(epsbak < epstry) {
-         fEpsMac = 8.*epstry;
-         fEpsMa2 = 2.*sqrt(fEpsMac);
+         eps = 8.*epstry;
+         eps2 = 2.*sqrt(eps);
          break;
       }
    }
-
 }
 
    }  // namespace Minuit2


### PR DESCRIPTION
I noticed while debugging Minuit, that `MnMachinePrecision`'s constructor is called many times during minimization. Every time it is created, it goes through a loop to computes the machine precision. Since the number is the same every time, this is a waste of CPU cycles.

This patch runs the loop only once and caches the result. New instances of MnMachinePrecision use the pre-computed value. The patch has no side effects.