### PR TITLE
API Redesign

### DIFF
--- a/tmva/tmva/inc/TMVA/DNN/CNN/ConvLayer.h
+++ b/tmva/tmva/inc/TMVA/DNN/CNN/ConvLayer.h
@@ -46,6 +46,19 @@ public:
    using Scalar_t = typename Architecture_t::Scalar_t;
 
 private:
+   bool inline isInteger(Scalar_t x) const { return x == floor(x); }
+
+   /* Calculate the output dimension of the convolutional layer */
+   size_t calculateDimension(size_t imgDim, size_t fltDim, size_t padding, size_t stride);
+
+   /* Calculate the number of pixels in a single receptive field */
+   size_t inline calculateNLocalViewPixels(size_t depth, size_t height, size_t width) { return depth * height * width; }
+
+   /* Calculate the number of receptive fields in an image given the filter and image sizes */
+   size_t calculateNLocalViews(size_t inputHeight, size_t filterHeight, size_t paddingHeight, size_t strideRows,
+                               size_t inputWidth, size_t filterWidth, size_t paddingWidth, size_t strideCols);
+
+protected:
    size_t fFilterDepth;  ///< The depth of the filter.
    size_t fFilterHeight; ///< The height of the filter.
    size_t fFilterWidth;  ///< The width of the filter.
@@ -53,13 +66,14 @@ private:
    size_t fStrideRows; ///< The number of row pixels to slid the filter each step.
    size_t fStrideCols; ///< The number of column pixels to slid the filter each step.
 
-   size_t fPaddingHeight; ///< The number of zero layers added top and bottom of the input.
-   size_t fPaddingWidth;  ///< The number of zero layers left and right of the input.
-
    size_t fNLocalViewPixels; ///< The number of pixels in one local image view.
    size_t fNLocalViews;      ///< The number of local views in one image.
 
    Scalar_t fDropoutProbability; ///< Probability that an input is active.
+
+private:
+   size_t fPaddingHeight; ///< The number of zero layers added top and bottom of the input.
+   size_t fPaddingWidth;  ///< The number of zero layers left and right of the input.
 
    std::vector<Matrix_t> fDerivatives; ///< First fDerivatives of the activations of this layer.
 
@@ -71,11 +85,10 @@ private:
    ERegularization fReg;   ///< The regularization method.
    Scalar_t fWeightDecay;  ///< The weight decay.
 
+
 public:
    /*! Constructor. */
-   TConvLayer(size_t BatchSize, size_t InputDepth, size_t InputHeight, size_t InputWidth, size_t Depth, size_t Height,
-              size_t Width, size_t WeightsNRows, size_t WeightsNCols, size_t BiasesNRows, size_t BiasesNCols,
-              size_t OutputNSlices, size_t OutputNRows, size_t OutputNCols, EInitialization Init, size_t FilterDepth,
+   TConvLayer(size_t BatchSize, size_t InputDepth, size_t InputHeight, size_t InputWidth, size_t Depth, EInitialization Init,
               size_t FilterHeight, size_t FilterWidth, size_t StrideRows, size_t StrideCols, size_t PaddingHeight,
               size_t PaddingWidth, Scalar_t DropoutProbability, EActivationFunction f, ERegularization Reg,
               Scalar_t WeightDecay);
@@ -145,23 +158,32 @@ public:
 //______________________________________________________________________________
 template <typename Architecture_t>
 TConvLayer<Architecture_t>::TConvLayer(size_t batchSize, size_t inputDepth, size_t inputHeight, size_t inputWidth,
-                                       size_t depth, size_t height, size_t width, size_t weightsNRows,
-                                       size_t weightsNCols, size_t biasesNRows, size_t biasesNCols,
-                                       size_t outputNSlices, size_t outputNRows, size_t outputNCols,
-                                       EInitialization init, size_t filterDepth, size_t filterHeight,
-                                       size_t filterWidth, size_t strideRows, size_t strideCols, size_t paddingHeight,
-                                       size_t paddingWidth, Scalar_t dropoutProbability, EActivationFunction f,
-                                       ERegularization reg, Scalar_t weightDecay)
-   : VGeneralLayer<Architecture_t>(batchSize, inputDepth, inputHeight, inputWidth, depth, height, width, 1,
-                                   weightsNRows, weightsNCols, 1, biasesNRows, biasesNCols, outputNSlices, outputNRows,
-                                   outputNCols, init),
-     fFilterDepth(filterDepth), fFilterHeight(filterHeight), fFilterWidth(filterWidth), fStrideRows(strideRows),
-     fStrideCols(strideCols), fPaddingHeight(paddingHeight), fPaddingWidth(paddingWidth),
-     fNLocalViewPixels(filterDepth * filterHeight * filterWidth), fNLocalViews(height * width),
-     fDropoutProbability(dropoutProbability), fDerivatives(), fF(f), fReg(reg), fWeightDecay(weightDecay)
+                                       size_t depth, EInitialization init, size_t filterHeight, size_t filterWidth,
+                                       size_t strideRows, size_t strideCols, size_t paddingHeight, size_t paddingWidth,
+                                       Scalar_t dropoutProbability, EActivationFunction f, ERegularization reg,
+                                       Scalar_t weightDecay)
+   : VGeneralLayer<Architecture_t>(batchSize, inputDepth, inputHeight, inputWidth, depth,
+                                   calculateDimension(inputHeight, filterHeight, paddingHeight, strideRows),
+                                   calculateDimension(inputWidth, filterWidth, paddingWidth, strideCols),
+                                   1, depth, calculateNLocalViewPixels(inputDepth, filterHeight, filterWidth),
+                                   1, depth, 1, batchSize, depth,
+                                   calculateNLocalViews(inputHeight, filterHeight, paddingHeight, strideRows,
+                                                        inputWidth, filterWidth, paddingWidth, strideCols),
+                                   init),
+     fFilterDepth(inputDepth), fFilterHeight(filterHeight), fFilterWidth(filterWidth), fStrideRows(strideRows),
+     fStrideCols(strideCols), fNLocalViewPixels(calculateNLocalViewPixels(inputDepth, filterHeight, filterWidth)),
+     fNLocalViews(calculateNLocalViews(inputHeight, filterHeight, paddingHeight, strideRows,
+                                       inputWidth, filterWidth, paddingWidth, strideCols)),
+     fDropoutProbability(dropoutProbability), fPaddingHeight(paddingHeight), fPaddingWidth(paddingWidth),
+     fDerivatives(), fF(f), fReg(reg), fWeightDecay(weightDecay)
 {
-   for (size_t i = 0; i < outputNSlices; i++) {
-      fDerivatives.emplace_back(outputNRows, outputNCols);
+   /** Each element in the vector is a `T_Matrix` representing an event, therefore `vec.size() == batchSize`.
+    *  Cells in these matrices are distributed in the following manner:
+    *  Each row represents a single feature map, therefore we have `nRows == depth`.
+    *  Each column represents a single pixel in that feature map, therefore we have `nCols == nLocalViews`.
+    **/
+   for (size_t i = 0; i < batchSize; i++) {
+      fDerivatives.emplace_back(depth, fNLocalViews);
    }
 }
 
@@ -351,6 +373,28 @@ void TConvLayer<Architecture_t>::ReadWeightsFromXML(void *parent)
    this->ReadMatrixXML(parent,"Biases", this -> GetBiasesAt(0));
 }
 
+template <typename Architecture_t>
+size_t TConvLayer<Architecture_t>::calculateDimension(int imgDim, int fltDim, int padding, int stride)
+{
+    Scalar_t dimension = ((imgDim - fltDim + 2 * padding) / stride) + 1;
+    if (!isInteger(dimension) || dimension <= 0) {
+        Fatal("calculateDimension", "Not compatible hyper parameters for layer - (imageDim, filterDim, padding, stride) %d , %d , %d , %d",
+              imgDim, fltDim, padding, stride);
+    }
+
+    return (size_t)dimension;
+}
+
+template <typename Architecture_t>
+size_t TConvLayer<Architecture_t>::calculateNLocalViews(int inputHeight, int filterHeight, int paddingHeight,
+                                                        int strideRows, int inputWidth, int filterWidth,
+                                                        int paddingWidth, int strideCols)
+{
+    int height = calculateDimension(inputHeight, filterHeight, paddingHeight, strideRows);
+    int width = calculateDimension(inputWidth, filterWidth, paddingWidth, strideCols);
+
+    return height * width;
+}
 
 } // namespace CNN
 } // namespace DNN

--- a/tmva/tmva/inc/TMVA/DNN/CNN/ConvLayer.h
+++ b/tmva/tmva/inc/TMVA/DNN/CNN/ConvLayer.h
@@ -374,7 +374,7 @@ void TConvLayer<Architecture_t>::ReadWeightsFromXML(void *parent)
 }
 
 template <typename Architecture_t>
-size_t TConvLayer<Architecture_t>::calculateDimension(int imgDim, int fltDim, int padding, int stride)
+size_t TConvLayer<Architecture_t>::calculateDimension(size_t  imgDim, size_t  fltDim, size_t  padding, size_t  stride)
 {
     Scalar_t dimension = ((imgDim - fltDim + 2 * padding) / stride) + 1;
     if (!isInteger(dimension) || dimension <= 0) {
@@ -386,9 +386,9 @@ size_t TConvLayer<Architecture_t>::calculateDimension(int imgDim, int fltDim, in
 }
 
 template <typename Architecture_t>
-size_t TConvLayer<Architecture_t>::calculateNLocalViews(int inputHeight, int filterHeight, int paddingHeight,
-                                                        int strideRows, int inputWidth, int filterWidth,
-                                                        int paddingWidth, int strideCols)
+size_t TConvLayer<Architecture_t>::calculateNLocalViews(size_t inputHeight, size_t  filterHeight, size_t  paddingHeight,
+                                                        size_t  strideRows, size_t  inputWidth, size_t  filterWidth,
+                                                        size_t  paddingWidth, size_t  strideCols)
 {
     int height = calculateDimension(inputHeight, filterHeight, paddingHeight, strideRows);
     int width = calculateDimension(inputWidth, filterWidth, paddingWidth, strideCols);

--- a/tmva/tmva/inc/TMVA/DNN/DeepNet.h
+++ b/tmva/tmva/inc/TMVA/DNN/DeepNet.h
@@ -380,8 +380,8 @@ auto TDeepNet<Architecture_t, Layer_t>::calculateDimension(int imgDim, int fltDi
 {
    Scalar_t dimension = ((imgDim - fltDim + 2 * padding) / stride) + 1;
    if (!isInteger(dimension) || dimension <= 0) {
-      this->Print(); 
-      int iLayer = fLayers.size(); 
+      this->Print();
+      int iLayer = fLayers.size();
       Fatal("calculateDimension","Not compatible hyper parameters for layer %d - (imageDim, filterDim, padding, stride) %d , %d , %d , %d",
             iLayer, imgDim, fltDim, padding, stride);
       // std::cout << " calculateDimension - Not compatible hyper parameters (imgDim, fltDim, padding, stride)"
@@ -405,16 +405,6 @@ TConvLayer<Architecture_t> *TDeepNet<Architecture_t, Layer_t>::AddConvLayer(size
    size_t inputDepth;
    size_t inputHeight;
    size_t inputWidth;
-   size_t height;
-   size_t width;
-   size_t filterDepth;
-   size_t weightsNRows = depth;
-   size_t weightsNCols;
-   size_t biasesNRows = depth;
-   size_t biasesNCols = 1;
-   size_t outputNSlices = this->GetBatchSize();
-   size_t outputNRows = depth;
-   size_t outputNCols;
    EInitialization init = this->GetInitialization();
    ERegularization reg = this->GetRegularization();
    Scalar_t decay = this->GetWeightDecay();
@@ -430,19 +420,12 @@ TConvLayer<Architecture_t> *TDeepNet<Architecture_t, Layer_t>::AddConvLayer(size
       inputWidth = lastLayer->GetWidth();
    }
 
-   height = calculateDimension(inputHeight, filterHeight, paddingHeight, strideRows);
-   width = calculateDimension(inputWidth, filterWidth, paddingWidth, strideCols);
 
-   filterDepth = inputDepth;
-
-   weightsNCols = filterDepth * filterHeight * filterWidth;
-   outputNCols = height * width;
 
    // Create the conv layer
    TConvLayer<Architecture_t> *convLayer = new TConvLayer<Architecture_t>(
-      batchSize, inputDepth, inputHeight, inputWidth, depth, height, width, weightsNRows, weightsNCols, biasesNRows,
-      biasesNCols, outputNSlices, outputNRows, outputNCols, init, filterDepth, filterHeight, filterWidth, strideRows,
-      strideCols, paddingHeight, paddingWidth, dropoutProbability, f, reg, decay);
+           batchSize, inputDepth, inputHeight, inputWidth, depth, init, filterHeight, filterWidth, strideRows,
+           strideCols, paddingHeight, paddingWidth, dropoutProbability, f, reg, decay);
 
    fLayers.push_back(convLayer);
    return convLayer;
@@ -465,11 +448,6 @@ TMaxPoolLayer<Architecture_t> *TDeepNet<Architecture_t, Layer_t>::AddMaxPoolLaye
    size_t inputDepth;
    size_t inputHeight;
    size_t inputWidth;
-   size_t height;
-   size_t width;
-   size_t outputNSlices = this->GetBatchSize();
-   size_t outputNRows;
-   size_t outputNCols;
 
    if (fLayers.size() == 0) {
       inputDepth = this->GetInputDepth();
@@ -482,15 +460,9 @@ TMaxPoolLayer<Architecture_t> *TDeepNet<Architecture_t, Layer_t>::AddMaxPoolLaye
       inputWidth = lastLayer->GetWidth();
    }
 
-   height = calculateDimension(inputHeight, frameHeight, 0, strideRows);
-   width = calculateDimension(inputWidth, frameWidth, 0, strideCols);
-
-   outputNRows = inputDepth;
-   outputNCols = height * width;
-
    TMaxPoolLayer<Architecture_t> *maxPoolLayer = new TMaxPoolLayer<Architecture_t>(
-      batchSize, inputDepth, inputHeight, inputWidth, height, width, outputNSlices, outputNRows, outputNCols,
-      frameHeight, frameWidth, strideRows, strideCols, dropoutProbability);
+      batchSize, inputDepth, inputHeight, inputWidth, frameHeight, frameWidth,
+      strideRows, strideCols, dropoutProbability);
 
    // But this creates a copy or what?
    fLayers.push_back(maxPoolLayer);

--- a/tmva/tmva/src/MethodDL.cxx
+++ b/tmva/tmva/src/MethodDL.cxx
@@ -684,8 +684,8 @@ void MethodDL::ParseMaxPoolLayer(DNN::TDeepNet<Architecture_t, Layer_t> &deepNet
                                  TString delim)
 {
 
-   int frameHeight = 0;
-   int frameWidth = 0;
+   int filterHeight = 0;
+   int filterWidth = 0;
    int strideRows = 0;
    int strideCols = 0;
 
@@ -697,15 +697,15 @@ void MethodDL::ParseMaxPoolLayer(DNN::TDeepNet<Architecture_t, Layer_t> &deepNet
 
    for (; token != nullptr; token = (TObjString *)nextToken()) {
       switch (idxToken) {
-      case 1: // frame height
+      case 1: // filter height
       {
          TString strFrmHeight(token->GetString());
-         frameHeight = strFrmHeight.Atoi();
+         filterHeight = strFrmHeight.Atoi();
       } break;
-      case 2: // frame width
+      case 2: // filter width
       {
          TString strFrmWidth(token->GetString());
-         frameWidth = strFrmWidth.Atoi();
+         filterWidth = strFrmWidth.Atoi();
       } break;
       case 3: // stride in rows
       {
@@ -723,10 +723,11 @@ void MethodDL::ParseMaxPoolLayer(DNN::TDeepNet<Architecture_t, Layer_t> &deepNet
 
    // Add the Max pooling layer
    // TMaxPoolLayer<Architecture_t> *maxPoolLayer =
-   deepNet.AddMaxPoolLayer(frameHeight, frameWidth, strideRows, strideCols);
+   deepNet.AddMaxPoolLayer(filterHeight, filterWidth, strideRows, strideCols);
 
    // Add the same layer to fNet
-   if (fBuildNet) fNet->AddMaxPoolLayer(frameHeight, frameWidth, strideRows, strideCols);
+   if (fBuildNet) fNet->AddMaxPoolLayer(filterHeight, filterWidth, strideRows, strideCols);
+
 
    //TMaxPoolLayer<Architecture_t> *copyMaxPoolLayer = new TMaxPoolLayer<Architecture_t>(*maxPoolLayer);
 
@@ -1603,14 +1604,14 @@ void MethodDL::ReadWeightsFromXML(void * rootXML)
       else if (layerName == "MaxPoolLayer") {
 
          // read maxpool layer info
-         size_t frameHeight, frameWidth = 0;
+         size_t filterHeight, filterWidth = 0;
          size_t strideRows, strideCols = 0;
-         gTools().ReadAttr(layerXML, "FrameHeight", frameHeight);
-         gTools().ReadAttr(layerXML, "FrameWidth", frameWidth);
+         gTools().ReadAttr(layerXML, "FilterHeight", filterHeight);
+         gTools().ReadAttr(layerXML, "FilterWidth", filterWidth);
          gTools().ReadAttr(layerXML, "StrideRows", strideRows);
          gTools().ReadAttr(layerXML, "StrideCols", strideCols);
 
-         fNet->AddMaxPoolLayer(frameHeight, frameWidth, strideRows, strideCols);
+         fNet->AddMaxPoolLayer(filterHeight, filterWidth, strideRows, strideCols);
       }
       else if (layerName == "ReshapeLayer") {
 


### PR DESCRIPTION
# API Redesign

## Goal

The goal is this PR is to improve the API of the CNN layers (MaxPooling and Conv currently), by eliminating redundant constructor arguments and fields. By redundant in this context, I refer to arguments that can be directly computed from others, and fields that unnecesseraly exist in multiple classes.

## Key points

Below some discussion points on design decisions I made, but still consider debatable. 
Since my experience in production level C++ is very limited I highly value opinions from experienced colleagues and previous authors of the module.

### Making `MaxPoolingLayer` a sub-class of `ConvLayer`

Every layer type in a convolutional network follows the logic existing in our `ConvLayer`:

A filter is sliding over the input and at each step applies an operation to the input elements within its receptive field to produce a single output element.

* In a convolutional layer this operation is a linear combination with learnable parameters.
* In an average pooling layer the operation is a linear combination with constant parameters (and equal to the inverse of the receptive field's size).
* In a max pooling layer its a non linear operation.

As we can see they all share the same logic and therefore fields.

## Results

1. Common fields between the 2 layer types in the CNN module are now not duplicated (strides sizes, padding sizes, filter sizes). The same for the 4 `protected` methods in `ConvLayer`.

2. We now have a cleaner API, as the constructor arguments where reduced from 26 to 16 without any change in the functionality).

