### PR TITLE
[DF] Try to fix dataframe_nodes test

### DIFF
--- a/tree/dataframe/src/RDFNodes.cxx
+++ b/tree/dataframe/src/RDFNodes.cxx
@@ -216,7 +216,7 @@ void TSlotStack::ReturnSlot(unsigned int slotNumber)
    R__ASSERT(count > 0U && "TSlotStack has a reference count relative to an index which will become negative.");
    count--;
    if (0U == count) {
-      index = UINT_MAX;
+      index = std::numeric_limits<unsigned int>::max();
       std::lock_guard<ROOT::TSpinMutex> guard(fMutex);
       fBuf[fCursor++] = slotNumber;
       R__ASSERT(fCursor <= fBuf.size() &&
@@ -231,7 +231,7 @@ unsigned int TSlotStack::GetSlot()
    auto &index = GetIndex();
    auto &count = GetCount();
    count++;
-   if (UINT_MAX != index)
+   if (std::numeric_limits<unsigned int>::max() != index)
       return index;
    std::lock_guard<ROOT::TSpinMutex> guard(fMutex);
    R__ASSERT(fCursor > 0 &&

--- a/tree/dataframe/test/dataframe_nodes.cxx
+++ b/tree/dataframe/test/dataframe_nodes.cxx
@@ -37,31 +37,12 @@ TEST(RDataFrameNodes, TSlotStackGetOneTooMuch)
 
 TEST(RDataFrameNodes, TSlotStackPutBackTooMany)
 {
-   std::mutex m;
-   auto theTest = [&m]() {
-      unsigned int n(2);
-      ROOT::Internal::RDF::TSlotStack s(n);
-
-      std::vector<std::thread> ts;
-
-      for (unsigned int i = 0; i < 2; ++i) {
-         ts.emplace_back([&s, &m]() {
-            std::lock_guard<std::mutex> lg(m);
-            s.GetSlot();
-         });
-      }
-      for (unsigned int i = 0; i < 2; ++i) {
-         ts.emplace_back([&s, &m, i]() {
-            std::lock_guard<std::mutex> lg(m);
-            s.ReturnSlot(i);
-         });
-      }
-
-      for (auto &&t : ts)
-         t.join();
+   auto theTest = []() {
+      ROOT::Internal::RDF::TSlotStack s(1);
+      s.ReturnSlot(0);
    };
 
-   ASSERT_DEATH(theTest(), "TSlotStack has a reference count relative to an index which will become negative");
+   EXPECT_DEATH(theTest(), "TSlotStack has a reference count relative to an index which will become negative");
 }
 
 #endif


### PR DESCRIPTION
This PR should be merged after `TSlotStack` is upgraded to not use static thread-local storage,
and one test case is expected to fail until this happens.