### PR TITLE
[DF] Better jitted defines

### DIFF
--- a/tree/dataframe/inc/LinkDef.h
+++ b/tree/dataframe/inc/LinkDef.h
@@ -22,6 +22,7 @@
 #pragma link C++ class ROOT::Detail::RDF::RFilterBase-;
 #pragma link C++ class ROOT::Detail::RDF::RJittedFilter-;
 #pragma link C++ class ROOT::Detail::RDF::RCustomColumnBase-;
+#pragma link C++ class ROOT::Detail::RDF::RJittedCustomColumn-;
 #pragma link C++ class ROOT::Internal::RDF::CountHelper-;
 #pragma link C++ class ROOT::Detail::RDF::RRangeBase-;
 #pragma link C++ class ROOT::Detail::RDF::RLoopManager-;

--- a/tree/dataframe/inc/ROOT/RDFInterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterfaceUtils.hxx
@@ -303,7 +303,8 @@ void JitFilterHelper(F &&f, const ColumnNames_t &cols, std::string_view name, RJ
 }
 
 template <typename F>
-void JitDefineHelper(F &&f, const ColumnNames_t &cols, std::string_view name, RLoopManager *lm)
+void JitDefineHelper(F &&f, const ColumnNames_t &cols, std::string_view name, RLoopManager *lm,
+                     RJittedCustomColumn &jittedCustomCol)
 {
    using NewCol_t = RCustomColumn<F, TCCHelperTypes::TNothing>;
    using ColTypes_t = typename TTraits::CallableTraits<F>::arg_types;
@@ -313,7 +314,7 @@ void JitDefineHelper(F &&f, const ColumnNames_t &cols, std::string_view name, RL
    if (ds)
       RDFInternal::DefineDataSourceColumns(cols, *lm, *ds, std::make_index_sequence<nColumns>(), ColTypes_t());
 
-   lm->Book(std::make_shared<NewCol_t>(name, std::move(f), cols, lm));
+   jittedCustomCol.SetCustomColumn(std::make_unique<NewCol_t>(name, std::move(f), cols, lm));
 }
 
 /// Convenience function invoked by jitted code to build action nodes at runtime

--- a/tree/dataframe/inc/ROOT/RDFNodes.hxx
+++ b/tree/dataframe/inc/ROOT/RDFNodes.hxx
@@ -479,7 +479,7 @@ public:
    virtual void Update(unsigned int slot, Long64_t entry) = 0;
    virtual void ClearValueReaders(unsigned int slot) = 0;
    bool IsDataSourceColumn() const { return fIsDataSourceColumn; }
-   void InitNode();
+   virtual void InitNode();
 };
 
 /// A wrapper around a concrete RCustomColumn, which forwards all calls to it
@@ -491,16 +491,17 @@ class RJittedCustomColumn : public RCustomColumnBase
    std::unique_ptr<RCustomColumnBase> fConcreteCustomColumn = nullptr;
 
 public:
-   RJittedCustomColumn(RLoopManager *lm, std::string_view name, unsigned int nSlots, bool isDSColumn)
-      : RCustomColumnBase(lm, name, nSlots, isDSColumn) {}
+   RJittedCustomColumn(RLoopManager &lm, std::string_view name)
+      : RCustomColumnBase(&lm, name, lm.GetNSlots(), /*isDSColumn=*/false) {}
 
-   void SetFilter(std::unique_ptr<RCustomColumnBase> c) { fConcreteCustomColumn = std::move(c); }
+   void SetCustomColumn(std::unique_ptr<RCustomColumnBase> c) { fConcreteCustomColumn = std::move(c); }
 
    void InitSlot(TTreeReader *r, unsigned int slot) final;
    void *GetValuePtr(unsigned int slot) final;
    const std::type_info &GetTypeId() const final;
    void Update(unsigned int slot, Long64_t entry) final;
    void ClearValueReaders(unsigned int slot) final;
+   void InitNode() final;
 };
 
 // clang-format off

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -568,6 +568,8 @@ void BookDefineJit(std::string_view name, std::string_view expression, RLoopMana
 
    TryToJitExpression(dotlessExpr, varNames, usedColTypes, hasReturnStmt);
 
+   const auto jittedCustomColumn = std::make_shared<RJittedCustomColumn>(lm, name);
+
    const auto definelambda = BuildLambdaString(dotlessExpr, varNames, usedColTypes, hasReturnStmt);
    const auto lambdaName = "eval_" + std::string(name);
    const auto ns = "__tdf" + std::to_string(namespaceID);
@@ -591,9 +593,11 @@ void BookDefineJit(std::string_view name, std::string_view expression, RLoopMana
    if (!usedBranches.empty())
       defineInvocation.seekp(-2, defineInvocation.cur); // remove the last ",
    defineInvocation << "}, \"" << name << "\", reinterpret_cast<ROOT::Detail::RDF::RLoopManager*>("
-                    << PrettyPrintAddr(&lm) << "));";
+                    << PrettyPrintAddr(&lm) << "), *reinterpret_cast<ROOT::Detail::RDF::RJittedCustomColumn*>("
+                    << PrettyPrintAddr(jittedCustomColumn.get()) << "));";
 
    lm.AddCustomColumnName(name);
+   lm.Book(jittedCustomColumn);
    lm.ToJit(defineInvocation.str());
 }
 

--- a/tree/dataframe/src/RDFNodes.cxx
+++ b/tree/dataframe/src/RDFNodes.cxx
@@ -101,6 +101,36 @@ void RCustomColumnBase::InitNode()
    fLastCheckedEntry = std::vector<Long64_t>(fNSlots, -1);
 }
 
+void RJittedCustomColumn::InitSlot(TTreeReader *r, unsigned int slot)
+{
+   R__ASSERT(fConcreteCustomColumn != nullptr);
+   fConcreteCustomColumn->InitSlot(r, slot);
+}
+
+void *RJittedCustomColumn::GetValuePtr(unsigned int slot)
+{
+   R__ASSERT(fConcreteCustomColumn != nullptr);
+   fConcreteCustomColumn->GetValuePtr(slot);
+}
+
+const std::type_info &RJittedCustomColumn::GetTypeId() const
+{
+   R__ASSERT(fConcreteCustomColumn != nullptr);
+   fConcreteCustomColumn->GetTypeId();
+}
+
+void RJittedCustomColumn::Update(unsigned int slot, Long64_t entry)
+{
+   R__ASSERT(fConcreteCustomColumn != nullptr);
+   fConcreteCustomColumn->Update(slot, entry);
+}
+
+void RJittedCustomColumn::ClearValueReaders(unsigned int slot)
+{
+   R__ASSERT(fConcreteCustomColumn != nullptr);
+   fConcreteCustomColumn->ClearValueReaders(slot);
+}
+
 RFilterBase::RFilterBase(RLoopManager *implPtr, std::string_view name, const unsigned int nSlots)
    : fLoopManager(implPtr), fLastResult(nSlots), fAccepted(nSlots), fRejected(nSlots), fName(name), fNSlots(nSlots)
 {

--- a/tree/dataframe/src/RDFNodes.cxx
+++ b/tree/dataframe/src/RDFNodes.cxx
@@ -110,13 +110,13 @@ void RJittedCustomColumn::InitSlot(TTreeReader *r, unsigned int slot)
 void *RJittedCustomColumn::GetValuePtr(unsigned int slot)
 {
    R__ASSERT(fConcreteCustomColumn != nullptr);
-   fConcreteCustomColumn->GetValuePtr(slot);
+   return fConcreteCustomColumn->GetValuePtr(slot);
 }
 
 const std::type_info &RJittedCustomColumn::GetTypeId() const
 {
    R__ASSERT(fConcreteCustomColumn != nullptr);
-   fConcreteCustomColumn->GetTypeId();
+   return fConcreteCustomColumn->GetTypeId();
 }
 
 void RJittedCustomColumn::Update(unsigned int slot, Long64_t entry)
@@ -129,6 +129,12 @@ void RJittedCustomColumn::ClearValueReaders(unsigned int slot)
 {
    R__ASSERT(fConcreteCustomColumn != nullptr);
    fConcreteCustomColumn->ClearValueReaders(slot);
+}
+
+void RJittedCustomColumn::InitNode()
+{
+   R__ASSERT(fConcreteCustomColumn != nullptr);
+   fConcreteCustomColumn->InitNode();
 }
 
 RFilterBase::RFilterBase(RLoopManager *implPtr, std::string_view name, const unsigned int nSlots)


### PR DESCRIPTION
In line with what it's done for jitted filters, now the jitting
of custom columns creates the RCustomColumn and assigns it as the
fConcreteCustomColumn of the corresponding RJittedCustomColumn that
was previously booked.
This avoids having the situation in which a certain custom column
has been "booked" but is not yet present in the map of custom columns.

It will also help with the "local custom columns" that are coming
with ROOT-9465.