### PR TITLE
[DF] Avoid TChain::AddClone in Snapshot when unnecessary

### DIFF
--- a/tree/dataframe/inc/ROOT/RDFActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFActionHelpers.hxx
@@ -814,8 +814,12 @@ public:
          // not an empty-source RDF
          fInputTrees[slot] = r->GetTree();
          // AddClone guarantees that if the input file changes the branches of the output tree are updated with the new
-         // addresses of the branch values
-         fInputTrees[slot]->AddClone(fOutputTrees[slot].top().get());
+         // addresses of the branch values. We need this in case of friend trees with different cluster granularity
+         // than the main tree.
+         // FIXME: AddClone might result in many many (safe) warnings printed by TTree::CopyAddresses, see ROOT-9487.
+         const auto friendsListPtr = fInputTrees[slot]->GetListOfFriends();
+         if (friendsListPtr && friendsListPtr->GetEntries() > 0)
+            fInputTrees[slot]->AddClone(fOutputTrees[slot].top().get());
       }
       fIsFirstEvent[slot] = 1; // reset first event flag for this slot
    }


### PR DESCRIPTION
Since output trees are recreated for each task, and each task only
processes one tree cluster (and never crosses file boundaries), we
don't need to add the output trees as clones of the input tress
unless the input trees have friends (which might cross file boundaries)
even if the main tree does not.

Usage of AddClone here is undesirable in the general case because
it generates many (safe) warnings printed at screen during the event
loop, see ROOT-9487.