### PR TITLE
Set cache file dir when using CACHEREAD option

### DIFF
--- a/tmva/tmva/test/DNN/CNN/TestMethodDLCNN.h
+++ b/tmva/tmva/test/DNN/CNN/TestMethodDLCNN.h
@@ -49,14 +49,12 @@ void testMethodDL_CNN(TString architectureStr)
    // Load the input data
 
    TString fname = "imagesData.root";
-   TString fopt = "CACHEREAD";
-   // auto input = TFile::Open(fname,fopt);
 
    // generate the files
    // 1000 for testing 1000 for training
    makeImages(2000);
 
-   auto input = TFile::Open(fname, fopt);
+   auto input = TFile::Open(fname);
 
    R__ASSERT(input);
 

--- a/tmva/tmva/test/DNN/TestMethodDLOptimization.h
+++ b/tmva/tmva/test/DNN/TestMethodDLOptimization.h
@@ -52,6 +52,7 @@ void testMethodDL_DNN(TString architectureStr, TString optimizerStr)
    TFile *input(0);
    // TString fname = "tmva_class_example.root";
    TString fname = "http://root.cern.ch/files/tmva_class_example.root";
+   TFile::SetCacheFileDir(".");
    TString fopt = "CACHEREAD";
    input = TFile::Open(fname, fopt);
 


### PR DESCRIPTION
Must call TFile::SetCacheFileDir in order for CACHEREAD option to work. Makes the test work in offline mode with pre-cached file.