### PR TITLE
Include test directory using ROOT_ADD_TEST_SUBDIRECTORY

### DIFF
--- a/graf2d/gpadv7/CMakeLists.txt
+++ b/graf2d/gpadv7/CMakeLists.txt
@@ -11,7 +11,4 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTGpadv7
                               DICTIONARY_OPTIONS "-writeEmptyRootPCM"
                               DEPENDENCIES ROOTGraphicsPrimitives)
 
-
-if(testing)
-   ROOT_ADD_TEST_SUBDIRECTORY(v7/test)
-endif()
+ROOT_ADD_TEST_SUBDIRECTORY(v7/test)

--- a/graf2d/primitives/CMakeLists.txt
+++ b/graf2d/primitives/CMakeLists.txt
@@ -11,6 +11,5 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTGraphicsPrimitives
                               SOURCES ${src}
                               DICTIONARY_OPTIONS "-writeEmptyRootPCM"
                               DEPENDENCIES RIO Core)
-if(testing)
-    add_subdirectory(v7/test)
-endif()
+
+ROOT_ADD_TEST_SUBDIRECTORY(v7/test)


### PR DESCRIPTION
Test directories should be added using ROOT_ADD_TEST_SUBDIRECTORY. If add_subdirectory is used the test binaries get installed during "make install".

if(testing) is redundant - it is already part of the ROOT_ADD_TEST_SUBDIRECTORY macro.
