### PR TITLE
[TMVA] Minimization-DNN remove input randomness

### DIFF
--- a/tmva/tmva/test/DNN/Utility.h
+++ b/tmva/tmva/test/DNN/Utility.h
@@ -321,18 +321,15 @@ void fillMatrix(AMatrix &X, AReal x)
 /*! Fill matrix with random, Gaussian-distributed values. */
 //______________________________________________________________________________
 template <typename AMatrix>
-void randomMatrix(AMatrix &X, double mean = 0.0, double sigma = 1.0)
+void randomMatrix(AMatrix &X, double mean = 0.0, double sigma = 1.0,
+                  TRandom & rand = *gRandom)
 {
-   // use default ROOT generator
-   TRandom & rand = *gRandom; 
-
    size_t m = X.GetNrows();
    size_t n = X.GetNcols();
 
    for (size_t i = 0; i < m; ++i)
       for (size_t j = 0; j < n; ++j)
          X(i,j) = rand.Gaus(mean, sigma);
-
 }
 
 /*! Fill matrix with random, uniform-distributed values in [-1, 1] */


### PR DESCRIPTION
Sporadic test failures are caused by the randomness of the test input.
(For some inputs the training does not converge). This patch "fixes"
this by removing the randomness from the input to the tests.

One source of randomness still remains, the dataloader shuffles the
batches internally, relying on a source of randomness that is not
reachable from the outside.

However, the variability in test output is _significantly_ reduced.