### PR TITLE
Fix test compilation on RHEL 7

### DIFF
--- a/tree/dataframe/test/dataframe_resptr.cxx
+++ b/tree/dataframe/test/dataframe_resptr.cxx
@@ -45,11 +45,11 @@ TEST(RResultPtr, ImplConv)
                 return (int)1;
              }).Histo1D<int>("i");
 
-   EXPECT_TRUE(m);
+   EXPECT_TRUE(m != nullptr);
    EXPECT_FALSE(hasRun);
 
    *m;
 
-   EXPECT_TRUE(m);
+   EXPECT_TRUE(m != nullptr);
    EXPECT_TRUE(hasRun);
 }


### PR DESCRIPTION
Fix compilation of dataframe-resptr test on RHEL/EPEL 7 using the default compiler (gcc 4.8.5) and the gtest library provided by the system (gtest 1.6.0) instead of the bundled one.

Error message with the original sources:
````
In file included from /usr/include/gtest/gtest.h:57:0,
                 from /builddir/build/BUILD/root-6.14.00/tree/dataframe/test/dataframe_resptr.cxx:2:
/builddir/build/BUILD/root-6.14.00/tree/dataframe/test/dataframe_resptr.cxx: In member function 'virtual void RResultPtr_ImplConv_Test::TestBody()':
/builddir/build/BUILD/root-6.14.00/tree/dataframe/test/dataframe_resptr.cxx:48:4: error: no matching function for call to 'testing::AssertionResult::AssertionResult(ROOT::RDF::RResultPtr<TH1D>&)'
    EXPECT_TRUE(m);
    ^
/builddir/build/BUILD/root-6.14.00/tree/dataframe/test/dataframe_resptr.cxx:48:4: note: candidates are:
In file included from /builddir/build/BUILD/root-6.14.00/tree/dataframe/test/dataframe_resptr.cxx:2:0:
/usr/include/gtest/gtest.h:271:12: note: testing::AssertionResult::AssertionResult(bool)
   explicit AssertionResult(bool success) : success_(success) {}
            ^
/usr/include/gtest/gtest.h:271:12: note:   no known conversion for argument 1 from 'ROOT::RDF::RResultPtr<TH1D>' to 'bool'
/usr/include/gtest/gtest.h:269:3: note: testing::AssertionResult::AssertionResult(const testing::AssertionResult&)
   AssertionResult(const AssertionResult& other);
   ^
/usr/include/gtest/gtest.h:269:3: note:   no known conversion for argument 1 from 'ROOT::RDF::RResultPtr<TH1D>' to 'const testing::AssertionResult&'
````