### PR TITLE
[Experimental PyROOT] Generic pythonizations

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
@@ -2,6 +2,7 @@ set(py_sources
   ROOT/__init__.py
   ROOT/pythonization/__init__.py
   ROOT/pythonization/_ttree.py
+  ROOT/pythonization/_generic.py
 )
 
 set(sources
@@ -9,6 +10,7 @@ set(sources
   src/PyROOTStrings.cxx
   src/PyROOTWrapper.cxx
   src/TTreePyz.cxx
+  src/GenericPyz.cxx
 )
 
 file(COPY python/ROOT DESTINATION ${localruntimedir})
@@ -21,3 +23,5 @@ foreach(py_source ${py_sources})
 endforeach()
 
 ROOT_LINKER_LIBRARY(ROOTPython ${sources} LIBRARIES Core Tree cppyy)
+
+ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_generic.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_generic.py
@@ -1,0 +1,13 @@
+from libROOTPython import PythonizeGeneric
+from ROOT import pythonization
+
+@pythonization
+def pythonizegeneric(klass, name):
+    # Parameters:
+    # klass: class to be pythonized
+    # name: string containing the name of the class
+
+    # Add pythonizations generically to all classes
+    PythonizeGeneric(klass)
+
+    return True

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_ttree.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_ttree.py
@@ -21,7 +21,7 @@ def pythonize_ttree(klass, name):
     # Parameters:
     # klass: class to be pythonized
     # name: string containing the name of the class
-    
+
     if name == 'TTree':
         # Pythonic iterator
         klass.__iter__ = _TTree__iter__
@@ -29,5 +29,5 @@ def pythonize_ttree(klass, name):
         # C++ pythonizations
         # - tree.branch syntax
         PythonizeTTree(klass)
-     
+
     return True

--- a/bindings/pyroot_experimental/PyROOT/src/GenericPyz.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/GenericPyz.cxx
@@ -1,0 +1,41 @@
+#include "CPyCppyy.h"
+#include "PyROOTPythonize.h"
+#include "CPPInstance.h"
+#include "Utility.h"
+#include "TInterpreter.h"
+
+#include <sstream>
+
+using namespace CPyCppyy;
+
+std::string GetCppName(CPPInstance *self)
+{
+   return Cppyy::GetScopedFinalName(self->ObjectIsA());
+}
+
+PyObject *ClingPrintValue(CPPInstance *self)
+{
+   const std::string className = GetCppName(self);
+   std::string pprint;
+   std::stringstream calcPrintValue;
+   calcPrintValue << "*((std::string*)" << &pprint << ") = cling::printValue((" << className << "*)"
+                  << self->GetObject() << ");";
+   gInterpreter->Calc(calcPrintValue.str().c_str());
+   return CPyCppyy_PyUnicode_FromString(pprint.c_str());
+}
+
+////////////////////////////////////////////////////////////////////////////
+/// \brief Add generic features to any class
+/// \param[in] self Always null, since this is a module function.
+/// \param[in] args Pointer to a Python tuple object containing the arguments
+/// received from Python.
+///
+/// This function adds the following pythonizations:
+/// - Prints the object more user-friendly than cppyy by using the output of
+///   cling::printValue as the return value of the special method __str__.
+PyObject *PyROOT::PythonizeGeneric(PyObject * /* self */, PyObject *args)
+{
+   PyObject *pyclass = PyTuple_GetItem(args, 0);
+   Utility::AddToClass(pyclass, "__str__", (PyCFunction)ClingPrintValue);
+   Py_RETURN_NONE;
+}

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
@@ -29,6 +29,8 @@ PyObject *gRootModule = 0;
 // Methods offered by the interface
 static PyMethodDef gPyROOTMethods[] = {{(char *)"PythonizeTTree", (PyCFunction)PyROOT::PythonizeTTree, METH_VARARGS,
                                         (char *)"Pythonizations for class TTree"},
+                                       {(char *)"PythonizeGeneric", (PyCFunction)PyROOT::PythonizeGeneric, METH_VARARGS,
+                                        (char *)"Generic pythonizations for all classes"},
                                        {NULL, NULL, 0, NULL}};
 
 #if PY_VERSION_HEX >= 0x03000000

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
@@ -6,6 +6,7 @@
 
 namespace PyROOT {
 
+PyObject *PythonizeGeneric(PyObject *self, PyObject *args);
 PyObject *PythonizeTTree(PyObject *self, PyObject *args);
 
 } // namespace PyROOT

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -1,0 +1,2 @@
+ROOT_ADD_PYUNITTEST(pyroot_pretty_printing pretty_printing.py)
+

--- a/bindings/pyroot_experimental/PyROOT/test/pretty_printing.py
+++ b/bindings/pyroot_experimental/PyROOT/test/pretty_printing.py
@@ -1,0 +1,60 @@
+import unittest
+import ROOT
+
+
+class PrettyPrinting(unittest.TestCase):
+    # Helpers
+    def _print(self, obj):
+        print("print({}) -> {}".format(repr(obj), obj))
+
+    # Tests
+    def test_RVec(self):
+        x = ROOT.ROOT.VecOps.RVec("float")(4)
+        for i in range(x.size()):
+            x[i] = i
+        self._print(x)
+        self.assertIn("{ 0", x.__str__())
+
+    def test_STLVector(self):
+        x = ROOT.std.vector("float")(4)
+        for i in range(x.size()):
+            x[i] = i
+        self._print(x)
+        self.assertIn("{ 0", x.__str__())
+
+    def test_STLMap(self):
+        x = ROOT.std.map("string", "int")()
+        for i, s in enumerate(["foo", "bar"]):
+            x[s] = i
+        self._print(x)
+        self.assertIn("foo", x.__str__())
+        self.assertIn("bar", x.__str__())
+
+    def test_STLPair(self):
+        x = ROOT.std.pair("string", "int")("foo", 42)
+        self._print(x)
+        self.assertIn("foo", x.__str__())
+
+    def test_TH1F(self):
+        x = ROOT.TH1F("name", "title", 10, 0, 1)
+        self._print(x)
+        self.assertEqual("Name: name Title: title NbinsX: 10", x.__str__())
+
+    # TNamed and TObject are not pythonized because these object are touched
+    # by PyROOT before any pythonizations are added. Following, the classes
+    # are not piped through the pythonizor functions again.
+    """
+    def test_TNamed(self):
+        x = ROOT.TNamed("name", "title")
+        self._print(x)
+        self.assertEqual("Name: name Title: title", x.__str__())
+
+    def test_TObject(self):
+        x = ROOT.TObject()
+        self._print(x)
+        self.assertEqual("Name: TObject Title: Basic ROOT object", x.__str__())
+    """
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
There are generic pythonizations to be added. I've started with the pretty printing feature.

Additionally, I've added a `test` directory with the unit-tests and adjusted the build system.

More generic possible pythonizations:

 - `__cppname__` attribute (It vanished in the new cppyy? I could do a workaround/pythonization.)
- Ideas?