### PR TITLE
Add missing include for std::shuffle

### DIFF
--- a/tmva/tmva/test/TestRandomGenerator.cxx
+++ b/tmva/tmva/test/TestRandomGenerator.cxx
@@ -10,6 +10,7 @@
 #include "TMVA/Tools.h"
 
 // Stdlib
+#include <algorithm>
 #include <iostream>
 
 // External


### PR DESCRIPTION
Build fails on Fedora 27 (gcc 7.3.1):
```
/builddir/build/BUILD/root-6.14.00/tmva/tmva/test/TestRandomGenerator.cxx: In function 'void test_example()':
/builddir/build/BUILD/root-6.14.00/tmva/tmva/test/TestRandomGenerator.cxx:88:9: error: 'shuffle' is not a member of 'std'
    std::shuffle(v.begin(), v.end(), rng);
         ^~~~~~~
```