### PR TITLE
Adjust allowed test difference for 32-bit ix86

### DIFF
--- a/math/mathmore/test/VavilovTest.cxx
+++ b/math/mathmore/test/VavilovTest.cxx
@@ -886,7 +886,7 @@ void VavilovTest::GetCdfTestParams (const Vavilov& v, double& maxabsdiff, double
    }
    else {
       maxabsdiff = 1E-5;
-      maxcdfdiff = 5E-15;
+      maxcdfdiff = 7E-15;
    }
 }
 


### PR DESCRIPTION
The Vavilov test fails on 32 bit ix86 in Fedora 29

Testing Cdf and Cdf_c
kappa = 0.01
Max abs diff: 1.2e-07, max rel diff: 1.9e-05, max diff cdf+cdf_c-1: 6.2e-15, pass=0
kappa = 0.04
Max abs diff: 1.4e-07, max rel diff: 1.9e-05, max diff cdf+cdf_c-1: 1.1e-15, pass=1
kappa = 0.07
Max abs diff: 2.5e-06, max rel diff: 0.061, max diff cdf+cdf_c-1: 1.6e-15, pass=1
kappa = 0.1
Max abs diff: 6.1e-06, max rel diff: 0.038, max diff cdf+cdf_c-1: 6.7e-16, pass=1
kappa = 0.4
Max abs diff: 1.7e-06, max rel diff: 0.018, max diff cdf+cdf_c-1: 2.2e-16, pass=1
kappa = 0.7
Max abs diff: 2.5e-06, max rel diff: 0.0092, max diff cdf+cdf_c-1: 2.2e-16, pass=1
kappa = 1
Max abs diff: 1.9e-06, max rel diff: 0.0072, max diff cdf+cdf_c-1: 4.4e-16, pass=1
kappa = 4
Max abs diff: 2e-06, max rel diff: 0.15, max diff cdf+cdf_c-1: 2.2e-16, pass=1
kappa = 7
Max abs diff: 1.7e-06, max rel diff: 0.026, max diff cdf+cdf_c-1: 4.4e-16, pass=1
kappa = 10
Max abs diff: 2.2e-06, max rel diff: 0.033, max diff cdf+cdf_c-1: 2.2e-16, pass=1
Number of failed tests: 1

This PR changes the allowed error from 5e-15 to 7e-15, allowing the 6.2e-15 result to pass.

The test does not fail on Fedora 28 which uses the same compiler (gcc 8.1.1). The default compiler flags for ix86 have changed between Fedora 28 and 29 though, and the following flags were added: -msse2 -mfpmath=sse -mstackrealign. The -msse2 flag is my guess for the cause of the difference.
