### PR TITLE
Fixes ROOT-9513

### DIFF
--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -1968,7 +1968,7 @@ namespace {
          ids.back().fInfo = info;
       }
 
-      if (nextel->CannotSplit())
+      if (nextel->CannotSplit() || nextel->IsTransient())
          continue;
 
       TClass *elementClass = nextel->GetClassPointer();


### PR DESCRIPTION
In GatherArtificialElements do not drill through transient data member.
They are guaranteed to not have induced any branches and often do not have dictionary information (or have members/bases that do not).

See https://github.com/cms-sw/cmssw/pull/22594