### PR TITLE
[DF] Throw if name of defined column is not a valid C++ var name

### DIFF
--- a/tree/dataframe/test/dataframe_interface.cxx
+++ b/tree/dataframe/test/dataframe_interface.cxx
@@ -185,3 +185,18 @@ TEST(RDataFrameInterface, JitDefaultColumns)
    auto minEntry = f.Min("tdfentry_");
    EXPECT_EQ(*maxEntry, *minEntry);
 }
+
+TEST(RDataFrameInterface, InvalidDefine)
+{
+   RDataFrame df(1);
+   try {
+      df.Define("1", [] { return true; });
+   } catch (const std::runtime_error &e) {
+      EXPECT_STREQ("Cannot define column \"1\": not a valid C++ variable name.", e.what());
+   }
+   try {
+      df.Define("a-b", "true");
+   } catch (const std::runtime_error &e) {
+      EXPECT_STREQ("Cannot define column \"a-b\": not a valid C++ variable name.", e.what());
+   }
+}


### PR DESCRIPTION
Since v6.14, `RDataFrame` chokes (while jitting) in case the name of a `Define`'s custom column is not a valid C++ variable name. It didn't before, by accident.

This PR adds a check for this pre-condition and makes sure that an exception is thrown if it's not respected.