### PR TITLE
Add R__HAS_VARIABLE_TEMPLATES macro

### DIFF
--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -636,6 +636,12 @@ else()
    set(has_found_attribute_always_inline undef)
 endif()
 
+if ("cxx_variable_templates" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+   set(hasvariabletemplates define)
+else()
+   set(hasvariabletemplates undef)
+endif()
+
 #---root-config----------------------------------------------------------------------------------------------
 ROOT_SHOW_OPTIONS(features)
 string(REPLACE "c++11" "cxx11" features ${features}) # change the name of the c++11 feature needed for root-config.in

--- a/config/RConfigure.in
+++ b/config/RConfigure.in
@@ -38,6 +38,7 @@
 #@hasstdapply@ R__HAS_STD_APPLY /**/
 #@hasstdinvoke@ R__HAS_STD_INVOKE /**/
 #@hasstdindexsequence@ R__HAS_STD_INDEX_SEQUENCE /**/
+#@hasvariabletemplates@ R__HAS_VARIABLE_TEMPLATES /**/
 #@has_found_attribute_always_inline@ R__HAS_ATTRIBUTE_ALWAYS_INLINE /**/
 #@hasllvm@ R__EXTERN_LLVMDIR @llvmdir@
 #@useimt@ R__USE_IMT   /**/


### PR DESCRIPTION
It should be defined if C++14 variable templates are available, but it doesn't seem to work -- it's always undefined in my tests. Help? :sweat_smile: 