### PR TITLE
[DF] Add MakeVec<N,T> helper function

### DIFF
--- a/tree/dataframe/inc/ROOT/RDFHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFHelpers.hxx
@@ -15,16 +15,12 @@
 
 #include <ROOT/TypeTraits.hxx>
 
-#include <algorithm> // std::transform
 #include <functional>
-#include <iterator> // std::back_inserter
-#include <stdexcept>
-#include <string>
 #include <type_traits>
-#include <vector>
 
 namespace ROOT {
 namespace Internal {
+namespace RDF {
 template <typename... ArgTypes, typename F>
 std::function<bool(ArgTypes...)> NotHelper(ROOT::TypeTraits::TypeList<ArgTypes...>, F &&f)
 {
@@ -36,10 +32,12 @@ std::function<bool(ArgTypes...)> NotHelper(ROOT::TypeTraits::TypeList<ArgTypes..
 {
    return std::function<bool(ArgTypes...)>([=](ArgTypes... args) mutable { return !f(args...); });
 }
+} // namespace RDF
 } // namespace Internal
 
 
 namespace RDF {
+namespace RDFInternal = ROOT::Internal::RDF;
 // clag-format off
 /// Given a callable with signature bool(T1, T2, ...) return a callable with same signature that returns the negated
 /// result
@@ -50,10 +48,10 @@ namespace RDF {
 template <typename F,
           typename Args = typename ROOT::TypeTraits::CallableTraits<typename std::decay<F>::type>::arg_types_nodecay,
           typename Ret = typename ROOT::TypeTraits::CallableTraits<typename std::decay<F>::type>::ret_type>
-auto Not(F &&f) -> decltype(ROOT::Internal::NotHelper(Args(), std::forward<F>(f)))
+auto Not(F &&f) -> decltype(RDFInternal::NotHelper(Args(), std::forward<F>(f)))
 {
    static_assert(std::is_same<Ret, bool>::value, "RDF::Not requires a callable that returns a bool.");
-   return ROOT::Internal::NotHelper(Args(), std::forward<F>(f));
+   return RDFInternal::NotHelper(Args(), std::forward<F>(f));
 }
 
 } // namespace RDF

--- a/tree/dataframe/inc/ROOT/RDFHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFHelpers.hxx
@@ -39,8 +39,7 @@ std::function<bool(ArgTypes...)> NotHelper(ROOT::TypeTraits::TypeList<ArgTypes..
 namespace RDF {
 namespace RDFInternal = ROOT::Internal::RDF;
 // clag-format off
-/// Given a callable with signature bool(T1, T2, ...) return a callable with same signature that returns the negated
-/// result
+/// Given a callable with signature bool(T1, T2, ...) return a callable with same signature that returns the negated result
 ///
 /// The callable must have one single non-template definition of operator(). This is a limitation with respect to
 /// std::not_fn, required for interoperability with RDataFrame.

--- a/tree/dataframe/test/dataframe_helpers.cxx
+++ b/tree/dataframe/test/dataframe_helpers.cxx
@@ -1,7 +1,10 @@
+#include <ROOT/RDataFrame.hxx>
 #include <ROOT/RDFHelpers.hxx>
 #include "gtest/gtest.h"
+#include <algorithm>
 #include <vector>
-;
+using namespace ROOT;
+using namespace ROOT::RDF;
 
 struct TrueFunctor {
    bool operator()() const { return true; }
@@ -16,13 +19,16 @@ TEST(RDFHelpers, Not)
 {
    // Not(lambda)
    auto l = []() { return true; };
-   EXPECT_EQ(ROOT::RDF::Not(l)(), !l());
+   EXPECT_EQ(Not(l)(), !l());
    // Not(functor)
    TrueFunctor t;
-   auto falseFunctor = ROOT::RDF::Not(t);
+   auto falseFunctor = Not(t);
    EXPECT_EQ(falseFunctor(), false);
-   EXPECT_EQ(ROOT::RDF::Not(TrueFunctor())(), false);
+   EXPECT_EQ(Not(TrueFunctor())(), false);
    // Not(freeFunction)
-   EXPECT_EQ(ROOT::RDF::Not(trueFunction)(), false);
+   EXPECT_EQ(Not(trueFunction)(), false);
+
+   // Not+RDF
+   EXPECT_EQ(1u, *RDataFrame(1).Filter(Not(Not(l))).Count());
 }
 

--- a/tree/dataframe/test/dataframe_helpers.cxx
+++ b/tree/dataframe/test/dataframe_helpers.cxx
@@ -1,5 +1,6 @@
 #include <ROOT/RDataFrame.hxx>
 #include <ROOT/RDFHelpers.hxx>
+#include <ROOT/RIntegerSequence.hxx>
 #include "gtest/gtest.h"
 #include <algorithm>
 #include <vector>
@@ -32,3 +33,17 @@ TEST(RDFHelpers, Not)
    EXPECT_EQ(1u, *RDataFrame(1).Filter(Not(Not(l))).Count());
 }
 
+TEST(RDFHelpers, MakeVec)
+{
+   auto One = [] { return 1; };
+   auto df = RDataFrame(1).Define("one", One).Define("_1", One);
+
+   auto TwoOnes = [](const std::vector<int> &v) { return v.size() == 2 && v[0] == 1 && v[1] == 1; };
+#if R__HAS_VARIABLE_TEMPLATES
+   auto with_vec = df.Define("ones", MakeVec<2, int>::func, {"one", "_1"});
+#else
+   auto with_vec =
+      df.Define("ones", ROOT::Internal::RDF::MakeVecHelper<std::make_index_sequence<2>, int>::func, {"one", "_1"});
+#endif
+   EXPECT_EQ(1u, *with_vec.Filter(TwoOnes, {"ones"}).Count());
+}


### PR DESCRIPTION
MakeVec<N, T> is a callable that takes N arguments of type T and returns a std::vector<T> containing copies of the arguments.

Example usage:
```c++
df.Define("all_triggers", MakeVec<3, bool>, {"trigger1", "trigger2", "trigger3"})
```

@stwunsch might find this useful.