### PR TITLE
[DF] Add PassAsVec helper function

### DIFF
--- a/tree/dataframe/inc/ROOT/RDFHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFHelpers.hxx
@@ -15,16 +15,12 @@
 
 #include <ROOT/TypeTraits.hxx>
 
-#include <algorithm> // std::transform
 #include <functional>
-#include <iterator> // std::back_inserter
-#include <stdexcept>
-#include <string>
 #include <type_traits>
-#include <vector>
 
 namespace ROOT {
 namespace Internal {
+namespace RDF {
 template <typename... ArgTypes, typename F>
 std::function<bool(ArgTypes...)> NotHelper(ROOT::TypeTraits::TypeList<ArgTypes...>, F &&f)
 {
@@ -36,10 +32,12 @@ std::function<bool(ArgTypes...)> NotHelper(ROOT::TypeTraits::TypeList<ArgTypes..
 {
    return std::function<bool(ArgTypes...)>([=](ArgTypes... args) mutable { return !f(args...); });
 }
+} // namespace RDF
 } // namespace Internal
 
 
 namespace RDF {
+namespace RDFInternal = ROOT::Internal::RDF;
 // clag-format off
 /// Given a callable with signature bool(T1, T2, ...) return a callable with same signature that returns the negated
 /// result
@@ -50,10 +48,10 @@ namespace RDF {
 template <typename F,
           typename Args = typename ROOT::TypeTraits::CallableTraits<typename std::decay<F>::type>::arg_types_nodecay,
           typename Ret = typename ROOT::TypeTraits::CallableTraits<typename std::decay<F>::type>::ret_type>
-auto Not(F &&f) -> decltype(ROOT::Internal::NotHelper(Args(), std::forward<F>(f)))
+auto Not(F &&f) -> decltype(RDFInternal::NotHelper(Args(), std::forward<F>(f)))
 {
    static_assert(std::is_same<Ret, bool>::value, "RDF::Not requires a callable that returns a bool.");
-   return ROOT::Internal::NotHelper(Args(), std::forward<F>(f));
+   return RDFInternal::NotHelper(Args(), std::forward<F>(f));
 }
 
 } // namespace RDF

--- a/tree/dataframe/inc/ROOT/RDFHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFHelpers.hxx
@@ -39,8 +39,7 @@ std::function<bool(ArgTypes...)> NotHelper(ROOT::TypeTraits::TypeList<ArgTypes..
 namespace RDF {
 namespace RDFInternal = ROOT::Internal::RDF;
 // clag-format off
-/// Given a callable with signature bool(T1, T2, ...) return a callable with same signature that returns the negated
-/// result
+/// Given a callable with signature bool(T1, T2, ...) return a callable with same signature that returns the negated result
 ///
 /// The callable must have one single non-template definition of operator(). This is a limitation with respect to
 /// std::not_fn, required for interoperability with RDataFrame.

--- a/tree/dataframe/test/dataframe_helpers.cxx
+++ b/tree/dataframe/test/dataframe_helpers.cxx
@@ -1,7 +1,10 @@
+#include <ROOT/RDataFrame.hxx>
 #include <ROOT/RDFHelpers.hxx>
 #include "gtest/gtest.h"
+#include <algorithm>
 #include <vector>
-;
+using namespace ROOT;
+using namespace ROOT::RDF;
 
 struct TrueFunctor {
    bool operator()() const { return true; }
@@ -16,13 +19,16 @@ TEST(RDFHelpers, Not)
 {
    // Not(lambda)
    auto l = []() { return true; };
-   EXPECT_EQ(ROOT::RDF::Not(l)(), !l());
+   EXPECT_EQ(Not(l)(), !l());
    // Not(functor)
    TrueFunctor t;
-   auto falseFunctor = ROOT::RDF::Not(t);
+   auto falseFunctor = Not(t);
    EXPECT_EQ(falseFunctor(), false);
-   EXPECT_EQ(ROOT::RDF::Not(TrueFunctor())(), false);
+   EXPECT_EQ(Not(TrueFunctor())(), false);
    // Not(freeFunction)
-   EXPECT_EQ(ROOT::RDF::Not(trueFunction)(), false);
+   EXPECT_EQ(Not(trueFunction)(), false);
+
+   // Not+RDF
+   EXPECT_EQ(1u, *RDataFrame(1).Filter(Not(Not(l))).Count());
 }
 

--- a/tree/dataframe/test/dataframe_helpers.cxx
+++ b/tree/dataframe/test/dataframe_helpers.cxx
@@ -1,10 +1,15 @@
 #include <ROOT/RDataFrame.hxx>
 #include <ROOT/RDFHelpers.hxx>
-#include "gtest/gtest.h"
+#include <ROOT/RVec.hxx>
+
 #include <algorithm>
+#include <deque>
 #include <vector>
+
+#include "gtest/gtest.h"
 using namespace ROOT;
 using namespace ROOT::RDF;
+using namespace ROOT::VecOps;
 
 struct TrueFunctor {
    bool operator()() const { return true; }
@@ -32,3 +37,15 @@ TEST(RDFHelpers, Not)
    EXPECT_EQ(1u, *RDataFrame(1).Filter(Not(Not(l))).Count());
 }
 
+TEST(RDFHelpers, PassAsVec)
+{
+   auto One = [] { return 1; };
+   auto df = RDataFrame(1).Define("one", One).Define("_1", One);
+
+   auto TwoOnes = [](const std::vector<int> &v) { return v.size() == 2 && v[0] == 1 && v[1] == 1; };
+   EXPECT_EQ(1u, *df.Filter(PassAsVec<2, int>(TwoOnes), {"one", "_1"}).Count());
+   auto TwoOnesRVec = [](const RVec<int> &v) { return v.size() == 2 && All(v == 1); };
+   EXPECT_EQ(1u, *df.Filter(PassAsVec<2, int>(TwoOnesRVec), {"one", "_1"}).Count());
+   auto TwoOnesDeque = [](const std::deque<int> &v) { return v.size() == 2 && v[0] == 1 && v[1] == 1; };
+   EXPECT_EQ(1u, *df.Filter(PassAsVec<2, int>(TwoOnesDeque), {"one", "_1"}).Count());
+}


### PR DESCRIPTION
Thanks @amadio for the suggestion!

`PassAsVec<N, T>(func)` is a callable that takes N arguments of type T,
passes them to func as a collection (`func({v1, v2, ...}`) and returns
the result of the call to `func`.

This helper makes it possible to pass several columns of the same
type to a callable that accepts a vector of that type. Example usage:
```c++
bool myVecFunc(std::vector<float> args);
df.Filter(PassAsVec<3, float>(myVecFunc), {"var1", "var2", "var3"});
```

@stwunsch could this be interesting for the new TMVA interfaces?