### PR TITLE
use printLevel for MN_INFO_MSG calls

### DIFF
--- a/math/minuit2/src/VariableMetricBuilder.cxx
+++ b/math/minuit2/src/VariableMetricBuilder.cxx
@@ -67,7 +67,7 @@ FunctionMinimum VariableMetricBuilder::Minimum(const MnFcn& fcn, const GradientC
    edmval *= 0.002;
 
    int printLevel = PrintLevel();
-
+   MnPrint::SetLevel(printLevel); // use printLevel for MN_INFO_MSG calls
 
 #ifdef DEBUG
    std::cout<<"VariableMetricBuilder convergence when edm < "<<edmval<<std::endl;


### PR DESCRIPTION
The macros MN_INFO_MSG and friends check the global MnPrint::Level() before they print anything, which is not synchronized with the local printLevel in the class. The expected behavior is that MN_INFO_MSG and friends correspond to the local printLevel in the class.

A call was added to synchronize MnPrint::Level() with the local printLevel.