### PR TITLE
[DF] Introduced tutorial for Fill TGraph custom action ROOT-9462

### DIFF
--- a/tree/dataframe/inc/ROOT/RDFInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterface.hxx
@@ -43,6 +43,7 @@
 #include "TChain.h"
 #include "TDirectory.h"
 #include "TError.h"
+#include "TGraph.h" // For Graph action
 #include "TH1.h" // For Histo actions
 #include "TH2.h" // For Histo actions
 #include "TH3.h" // For Histo actions
@@ -990,6 +991,30 @@ public:
                                   ? ColumnNames_t()
                                   : ColumnNames_t(columnViews.begin(), columnViews.end());
       return CreateAction<RDFInternal::ActionTags::Profile1D, V1, V2>(userColumns, h);
+   }
+
+   ////////////////////////////////////////////////////////////////////////////
+   /// \brief Fill and return a graph (*lazy action*)
+   /// \tparam V1 The type of the column used to fill the x axis of the graph.
+   /// \tparam V2 The type of the column used to fill the y axis of the graph.
+   /// \param[in] v1Name The name of the column that will fill the x axis.
+   /// \param[in] v2Name The name of the column that will fill the y axis.
+   ///
+   /// Columns can be of a container type (e.g. std::vector<double>), in which case the graph
+   /// is filled with each one of the elements of the container.
+   /// If Multithreading is enabled, the order in which points are inserted can't be forseeen.
+   /// If the Graph has to be drawn, it is suggested to the user to sort it on the x before printing.
+   /// This action is *lazy*: upon invocation of this method the calculation is
+   /// booked but not executed. See RResultPtr documentation.
+   template <typename V1 = RDFDetail::TInferType, typename V2 = RDFDetail::TInferType>
+   RResultPtr<::TGraph> Graph(std::string_view v1Name = "", std::string_view v2Name = "")
+   {
+      auto graph = std::make_shared<::TGraph>();
+      const std::vector<std::string_view> columnViews = {v1Name, v2Name};
+      const auto userColumns = RDFInternal::AtLeastOneEmptyString(columnViews)
+                               ? ColumnNames_t()
+                               : ColumnNames_t(columnViews.begin(), columnViews.end());
+      return CreateAction<RDFInternal::ActionTags::Graph, V1, V2>(userColumns, graph);
    }
 
    ////////////////////////////////////////////////////////////////////////////

--- a/tree/dataframe/inc/ROOT/RDFInterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterfaceUtils.hxx
@@ -74,6 +74,7 @@ namespace ActionTags {
 struct Histo1D{};
 struct Histo2D{};
 struct Histo3D{};
+struct Graph{};
 struct Profile1D{};
 struct Profile2D{};
 struct Min{};
@@ -149,6 +150,18 @@ RActionBase *BuildAndBook(const ColumnNames_t &bl, const std::shared_ptr<::TH1D>
    }
 
    return actionBase;
+}
+
+template <typename... BranchTypes, typename PrevNodeType>
+RActionBase *
+BuildAndBook(const ColumnNames_t &bl, const std::shared_ptr<TGraph> &g, const unsigned int nSlots,
+             RLoopManager &loopManager, PrevNodeType &prevNode, ActionTags::Graph)
+{
+   using Helper_t = FillTGraphHelper;
+   using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<BranchTypes...>>;
+   auto action = std::make_shared<Action_t>(Helper_t(g, nSlots), bl, prevNode);
+   loopManager.Book(action);
+   return action.get();
 }
 
 // Min action

--- a/tree/dataframe/test/dataframe_simple.cxx
+++ b/tree/dataframe/test/dataframe_simple.cxx
@@ -459,6 +459,8 @@ TEST_P(RDFSimpleTests, Aggregate)
    EXPECT_EQ(*r2, 120);
 }
 
+
+
 TEST_P(RDFSimpleTests, AggregateGraph)
 {
    auto d = RDataFrame(20).DefineSlotEntry("x", [](unsigned int, ULong64_t e) { return static_cast<double>(e); });
@@ -484,6 +486,41 @@ TEST_P(RDFSimpleTests, AggregateGraph)
    for (int i = 0; i < 20; ++i) {
       EXPECT_DOUBLE_EQ(points[i].first, i);
       EXPECT_DOUBLE_EQ(points[i].second, i * i);
+   }
+}
+
+TEST_P(RDFSimpleTests, Graph)
+{
+   static const int NR_ELEMENTS = 20;
+
+   // Define the source for the graph
+   std::vector<int> source(NR_ELEMENTS);
+   for (int i = 0; i < NR_ELEMENTS; ++i)
+      source[i] = i;
+
+   // Create the graph from the Dataframe
+   ROOT::RDataFrame d(NR_ELEMENTS);
+   auto dd = d.DefineSlotEntry("x1",
+                               [&source](unsigned int slot, ULong64_t entry) {
+                                  (void)slot;
+                                  return source[entry];
+                               })
+                .DefineSlotEntry("x2", [&source](unsigned int slot, ULong64_t entry) {
+                   (void)slot;
+                   return source[entry];
+                });
+
+   auto dfGraph = dd.Graph("x1", "x2");
+   EXPECT_EQ(dfGraph->GetN(), NR_ELEMENTS);
+
+   //To perform the test, it's easier to sort
+   dfGraph->Sort();
+
+   Double_t x, y;
+   for (int i = 0; i < NR_ELEMENTS; ++i) {
+      dfGraph->GetPoint(i, x, y);
+      EXPECT_EQ(i, x);
+      EXPECT_EQ(i, y);
    }
 }
 

--- a/tutorials/dataframe/df021_createTGraph.C
+++ b/tutorials/dataframe/df021_createTGraph.C
@@ -1,0 +1,42 @@
+/// \file
+/// \ingroup tutorial_dataframe
+/// \notebook
+/// This tutorial shows how to fill a TGraph using the Dataframe.
+///
+/// \macro_code
+///
+/// \date July 2018
+/// \author Enrico Guiraud, Danilo Piparo, Massimo Tumolo
+
+
+
+void df021_createTGraph()
+{
+   ROOT::EnableImplicitMT(2);
+
+   const unsigned int NR_ELEMENTS = 160;
+   std::vector<int> x(NR_ELEMENTS);
+   std::vector<int> y(NR_ELEMENTS);
+
+   for (int i = 0; i < NR_ELEMENTS; ++i){
+      y[i] = pow(i,2);
+      x[i] = i;
+   }
+
+   ROOT::RDataFrame d(NR_ELEMENTS);
+   auto dd = d.DefineSlotEntry("x",
+                               [&x](unsigned int slot, ULong64_t entry) {
+                                  (void)slot;
+                                  return x[entry];
+                               })
+                .DefineSlotEntry("y", [&y](unsigned int slot, ULong64_t entry) {
+                   (void)slot;
+                   return y[entry];
+                });
+
+   auto graph = dd.Graph("x", "y");
+
+   // This tutorial is ran with multithreading enabled. The order in which points are inserted is not known, so to have a meaningful representation points are sorted.
+   graph->Sort();
+   graph->DrawClone("APL");
+}


### PR DESCRIPTION
Using this custom action it is possible to fill a TGraph starting from two Dataframe columns.
Using this helper in Multithread, the order in which points are connected can't be forseen and may result in unexpected noise in the drawing. However, in the constructor it is possible to specify if a sort on the x axis is needed.

This commit solves the Jira issue ROOT-9462