### PR TITLE
[WIP] TClass knows if it or any ancestor has multiple inheritance when it has a dict

### DIFF
--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -127,7 +127,11 @@ public:
    };
 
 private:
-
+   enum EASTPropertyBits {
+      kHasMultipleInheritance    = BIT(0),
+      kInheritsFromTObject       = BIT(1),
+      kInheritsDirectFromTObject = BIT(2)
+   };
 
 
    class TDeclNameRegistry {
@@ -252,6 +256,8 @@ private:
    mutable std::atomic<StreamerImpl_t> fStreamerImpl; //! Pointer to the function implementing streaming for this class
 #endif
 
+   Long64_t fASTProperty; // all the properties aiming to reduce accesses to the interpreter
+
    Bool_t             CanSplitBaseAllow();
    TListOfFunctions  *GetMethodList();
    TMethod           *GetClassMethod(Long_t faddr);
@@ -265,6 +271,9 @@ private:
              Bool_t silent);
    void ForceReload (TClass* oldcl);
    void LoadClassInfo() const;
+   void SetASTBit(Long64_t f) { fASTProperty |= f; }
+   void RestASTBit(Long64_t f) { fASTProperty &= ~f; }
+   Bool_t TestASTBit(Long64_t f) const { return (Bool_t) (0 != (fASTProperty & f)); }
 
    static TClass     *LoadClassDefault(const char *requestedname, Bool_t silent);
    static TClass     *LoadClassCustom(const char *requestedname, Bool_t silent);

--- a/core/meta/inc/TGenericClassInfo.h
+++ b/core/meta/inc/TGenericClassInfo.h
@@ -68,24 +68,25 @@ namespace ROOT {
       Detail::TCollectionProxyInfo *fCollectionStreamerInfo;
       std::vector<ROOT::Internal::TSchemaHelper>  fReadRules;
       std::vector<ROOT::Internal::TSchemaHelper>  fReadRawRules;
+      Bool_t                      fHasMultipleInheritance;
 
    public:
       TGenericClassInfo(const char *fullClassname,
                        const char *declFileName, Int_t declFileLine,
                        const std::type_info &info, const Internal::TInitBehavior *action,
                        DictFuncPtr_t dictionary,
-                       TVirtualIsAProxy *isa, Int_t pragmabits, Int_t sizof);
+                       TVirtualIsAProxy *isa, Int_t pragmabits, Int_t sizof, bool hasMI = true);
 
       TGenericClassInfo(const char *fullClassname, Int_t version,
                        const char *declFileName, Int_t declFileLine,
                        const std::type_info &info, const Internal::TInitBehavior *action,
                        DictFuncPtr_t dictionary,
-                       TVirtualIsAProxy *isa, Int_t pragmabits, Int_t sizof);
+                       TVirtualIsAProxy *isa, Int_t pragmabits, Int_t sizof, bool hasMI = true);
 
       TGenericClassInfo(const char *fullClassname, Int_t version,
                         const char *declFileName, Int_t declFileLine,
                         const Internal::TInitBehavior *action,
-                        DictFuncPtr_t dictionary, Int_t pragmabits);
+                        DictFuncPtr_t dictionary, Int_t pragmabits, bool hasMI = true);
 
       void Init(Int_t pragmabits);
       ~TGenericClassInfo();

--- a/core/meta/src/TGenericClassInfo.cxx
+++ b/core/meta/src/TGenericClassInfo.cxx
@@ -86,7 +86,7 @@ namespace Internal {
                                         const char *declFileName, Int_t declFileLine,
                                         const std::type_info &info, const Internal::TInitBehavior  *action,
                                         DictFuncPtr_t dictionary,
-                                        TVirtualIsAProxy *isa, Int_t pragmabits, Int_t sizof)
+                                        TVirtualIsAProxy *isa, Int_t pragmabits, Int_t sizof, Bool_t hasMI)
       : fAction(action), fClass(0), fClassName(fullClassname),
         fDeclFileName(declFileName), fDeclFileLine(declFileLine),
         fDictionary(dictionary), fInfo(info),
@@ -95,7 +95,7 @@ namespace Internal {
         fVersion(1),
         fMerge(0),fResetAfterMerge(0),fNew(0),fNewArray(0),fDelete(0),fDeleteArray(0),fDestructor(0), fDirAutoAdd(0), fStreamer(0),
         fStreamerFunc(0), fConvStreamerFunc(0), fCollectionProxy(0), fSizeof(sizof), fPragmaBits(pragmabits),
-        fCollectionProxyInfo(0), fCollectionStreamerInfo(0)
+        fCollectionProxyInfo(0), fCollectionStreamerInfo(0), fHasMultipleInheritance(hasMI)
    {
       // Constructor.
 
@@ -106,7 +106,7 @@ namespace Internal {
                                         const char *declFileName, Int_t declFileLine,
                                         const std::type_info &info, const Internal::TInitBehavior  *action,
                                         DictFuncPtr_t dictionary,
-                                        TVirtualIsAProxy *isa, Int_t pragmabits, Int_t sizof)
+                                        TVirtualIsAProxy *isa, Int_t pragmabits, Int_t sizof, Bool_t hasMI)
       : fAction(action), fClass(0), fClassName(fullClassname),
         fDeclFileName(declFileName), fDeclFileLine(declFileLine),
         fDictionary(dictionary), fInfo(info),
@@ -115,7 +115,7 @@ namespace Internal {
         fVersion(version),
         fMerge(0),fResetAfterMerge(0),fNew(0),fNewArray(0),fDelete(0),fDeleteArray(0),fDestructor(0), fDirAutoAdd(0), fStreamer(0),
         fStreamerFunc(0), fConvStreamerFunc(0), fCollectionProxy(0), fSizeof(sizof), fPragmaBits(pragmabits),
-        fCollectionProxyInfo(0), fCollectionStreamerInfo(0)
+        fCollectionProxyInfo(0), fCollectionStreamerInfo(0), fHasMultipleInheritance(hasMI)
 
    {
       // Constructor with version number and no showmembers.
@@ -128,7 +128,7 @@ namespace Internal {
    TGenericClassInfo::TGenericClassInfo(const char *fullClassname, Int_t version,
                                         const char *declFileName, Int_t declFileLine,
                                         const Internal::TInitBehavior  *action,
-                                        DictFuncPtr_t dictionary, Int_t pragmabits)
+                                        DictFuncPtr_t dictionary, Int_t pragmabits, Bool_t hasMI)
       : fAction(action), fClass(0), fClassName(fullClassname),
         fDeclFileName(declFileName), fDeclFileLine(declFileLine),
         fDictionary(dictionary), fInfo(typeid(TForNamespace)),
@@ -137,7 +137,7 @@ namespace Internal {
         fVersion(version),
         fMerge(0),fResetAfterMerge(0),fNew(0),fNewArray(0),fDelete(0),fDeleteArray(0),fDestructor(0), fDirAutoAdd(0), fStreamer(0),
         fStreamerFunc(0), fConvStreamerFunc(0), fCollectionProxy(0), fSizeof(0), fPragmaBits(pragmabits),
-        fCollectionProxyInfo(0), fCollectionStreamerInfo(0)
+        fCollectionProxyInfo(0), fCollectionStreamerInfo(0), fHasMultipleInheritance(hasMI)
 
    {
       // Constructor for namespace
@@ -285,6 +285,9 @@ namespace Internal {
 
          CreateRuleSet( fReadRules, true );
          CreateRuleSet( fReadRawRules, false );
+
+         // Declare if it has multiple inheritance or not
+         if (fHasMultipleInheritance) fClass->SetASTBit(TClass::EASTPropertyBits::kHasMultipleInheritance);
       }
       return fClass;
    }


### PR DESCRIPTION
this PR aims to reduce the contention in TClass::GetBaseClassOffset.
Zero is returned as offset value if the class that the TClass instance represents
and all of its ancestors has no multiple inheritance.
This information can be checked without accessing the interpreter, and therewith
acquiring the global lock, because it now originally resides in the dictionaries.
The information is put in the dictionaries by rootcling, which explores the
inheritance chain *at build time*.

The expectation is to reduce *considerably* contention due to accesses to the interpreter and caches of offsets in the TClassInfo instances.

Potentially, this mechanism can be upgraded inserting in the dictionaries
not only the aforementioned information, but also the offsets to all the
bases.