### PR TITLE
v7: repair many scripts from tutorials/v7 folder

### DIFF
--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -16,7 +16,11 @@ ROOT_GLOB_HEADERS(Base_dict_headers ${CMAKE_CURRENT_SOURCE_DIR}/inc/LinkDef?.h
 				    ${CMAKE_CURRENT_SOURCE_DIR}/inc/ROOT/TSequentialExecutor.hxx)
 if(root7)
     set(root7src v7/src/*.cxx)
-    ROOT_GLOB_HEADERS(Base_v7_dict_headers ${CMAKE_CURRENT_SOURCE_DIR}/v7/inc/ROOT/T*.hxx)
+    set(Base_v7_dict_headers ${CMAKE_CURRENT_SOURCE_DIR}/v7/inc/ROOT/RDrawable.hxx
+                             ${CMAKE_CURRENT_SOURCE_DIR}/v7/inc/ROOT/TDirectoryEntry.hxx
+                             ${CMAKE_CURRENT_SOURCE_DIR}/v7/inc/ROOT/TIndexIter.hxx
+                             ${CMAKE_CURRENT_SOURCE_DIR}/v7/inc/ROOT/TLogger.hxx
+    )
 endif()
 ROOT_GLOB_SOURCES(sources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/src src/*.cxx ${root7src})
 

--- a/core/base/inc/LinkDef3.h
+++ b/core/base/inc/LinkDef3.h
@@ -270,8 +270,8 @@
 #pragma link C++ class TParameter<Long_t>+;
 #pragma link C++ class TParameter<Long64_t>+;
 
-#ifdef ROOT7_TDrawable
-#pragma link C++ class ROOT::Experimental::TDrawable+;
+#ifdef ROOT7_RDrawable
+#pragma link C++ class ROOT::Experimental::RDrawable+;
 #endif
 
 #endif

--- a/etc/http/changes.md
+++ b/etc/http/changes.md
@@ -1,12 +1,19 @@
 # JSROOT changelog
 
+## Changes in 5.5.1
+1. Implement 'nocache' option for JSROOT scripts lodaing. When specified in URL with
+   JSRootCore.js script, tries to avoid scripts caching problem by adding stamp parameter to all URLs.
+2. Adjust v7 part to new class naming convention, started with R
+3. Show RCanvas title
+
+
 ## Changes in 5.5.0
-1. Introduce JSROOT.StoreJSON() function. It creates JSON code for the 
+1. Introduce JSROOT.StoreJSON() function. It creates JSON code for the
    TCanvas with all drawn objects inside. Allows to store current canvas state
 2. Support "item=img:file.png" parameter to insert images in existing layout (#151)
 3. Support TTree drawing into TGraph (#153), thanks @cozzyd
 4. Let configure "&toolbar=right" in URL to change position of tool buttons
-5. Let configure "&divsize=500x400" in URL of size of main div element (default - full browser)  
+5. Let configure "&divsize=500x400" in URL of size of main div element (default - full browser)
 6. Implement "optstat1001" and "optfit101" draw options for histograms
 7. Remove "autocol" options - standard "plc" should be used instead
 8. Provide drawing of artificial "$legend" item - it creates TLegend for all primitives in pad

--- a/etc/http/scripts/JSRootCore.js
+++ b/etc/http/scripts/JSRootCore.js
@@ -96,12 +96,13 @@
 
    "use strict";
 
-   JSROOT.version = "5.5.0 6/07/2018";
+   JSROOT.version = "5.5.1 16/07/2018";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;
    JSROOT.source_fullpath = ""; // full name of source script
    JSROOT.bower_dir = null; // when specified, use standard libs from bower location
+   JSROOT.nocache = false;
    JSROOT.sources = ['core']; // indicates which major sources were loaded
 
    JSROOT.id_counter = 0;
@@ -965,16 +966,14 @@
          isrootjs = true;
          filename = filename.slice(3);
          if (JSROOT.use_full_libs) filename = "libs/" + filename.slice(8, filename.length-7) + ".js";
-      } else
-      if (filename.indexOf("$$$")===0) {
+      } else if (filename.indexOf("$$$")===0) {
          isrootjs = true;
          filename = filename.slice(3);
          if ((filename.indexOf("style/")==0) && JSROOT.source_min &&
              (filename.lastIndexOf('.css')==filename.length-4) &&
              (filename.indexOf('.min.css')<0))
             filename = filename.slice(0, filename.length-4) + '.min.css';
-      } else
-      if (filename.indexOf("###")===0) {
+      } else if (filename.indexOf("###")===0) {
          isbower = true;
          filename = filename.slice(3);
       }
@@ -1019,6 +1018,9 @@
          document.getElementById(debugout).innerHTML = "loading " + filename + " ...";
       else
          JSROOT.progress("loading " + filename + " ...");
+
+      if (JSROOT.nocache && isrootjs && (filename.indexOf("?")<0))
+         filename += "?stamp=" + JSROOT.nocache;
 
       if (isstyle) {
          element = document.createElement("link");
@@ -2217,6 +2219,8 @@
       }
 
       var src = JSROOT.source_fullpath;
+
+      if (JSROOT.GetUrlOption('nocache', src)!=null) JSROOT.nocache = (new Date).getTime(); // use timestamp to overcome cache limitation
 
       if (JSROOT.GetUrlOption('gui', src) !== null)
          return window_on_load( function() { JSROOT.BuildSimpleGUI(); } );

--- a/etc/http/scripts/JSRootPainter.v7.js
+++ b/etc/http/scripts/JSRootPainter.v7.js
@@ -2865,7 +2865,7 @@
 
       if (arr)
          for (var n=0;n<arr.length;++n)
-            if (arr[n] && arr[n]._typename != "ROOT::Experimental::TPadDisplayItem") return true;
+            if (arr[n] && arr[n]._typename != "ROOT::Experimental::RPadDisplayItem") return true;
 
       return false;
    }
@@ -3154,7 +3154,7 @@
 
          if (objpainter) {
 
-            if (snap._typename == "ROOT::Experimental::TPadDisplayItem")  // subpad
+            if (snap._typename == "ROOT::Experimental::RPadDisplayItem")  // subpad
                return objpainter.RedrawPadSnap(snap, draw_callback);
 
             if (objpainter.UpdateObject(snap.fObject, snap.fOption || "")) objpainter.Redraw();
@@ -3162,7 +3162,7 @@
             continue; // call next
          }
 
-         if (snap._typename == "ROOT::Experimental::TPadDisplayItem") { // subpad
+         if (snap._typename == "ROOT::Experimental::RPadDisplayItem") { // subpad
 
             var subpad = snap; // not subpad, but just attributes
 
@@ -3192,7 +3192,7 @@
 
          var handle = { func: draw_callback };
 
-         if (snap._typename === "ROOT::Experimental::TObjectDisplayItem")
+         if (snap._typename === "ROOT::Experimental::RObjectDisplayItem")
             if (!this.frame_painter())
                return JSROOT.draw(this.divid, { _typename: "TFrame", $dummy: true }, "", function() {
                   handle.func("workaround"); // call function with "workaround" as argument
@@ -3238,6 +3238,9 @@
       if (!snap || !snap.fPrimitives) return;
 
       var padattr = snap.fPadAttributes || { fCw: 0, fCh: 0 }; // for the moment no canvas attributes are provided
+
+      if (this.iscan && snap.fTitle && document)
+         document.title = snap.fTitle;
 
       if (this.snapid === undefined) {
          // first time getting snap, create all gui elements first
@@ -4110,10 +4113,10 @@
       return painter;
    }
 
-   // JSROOT.addDrawFunc({ name: "ROOT::Experimental::TPadDisplayItem", icon: "img_canvas", func: drawPad, opt: "" });
+   // JSROOT.addDrawFunc({ name: "ROOT::Experimental::RPadDisplayItem", icon: "img_canvas", func: drawPad, opt: "" });
 
-   JSROOT.addDrawFunc({ name: "ROOT::Experimental::THistDrawable<1>", icon: "img_histo1d", prereq: "v7hist", func: "JSROOT.v7.drawHist1", opt: "" });
-   JSROOT.addDrawFunc({ name: "ROOT::Experimental::THistDrawable<2>", icon: "img_histo2d", prereq: "v7hist", func: "JSROOT.v7.drawHist2", opt: "" });
+   JSROOT.addDrawFunc({ name: "ROOT::Experimental::RHistDrawable<1>", icon: "img_histo1d", prereq: "v7hist", func: "JSROOT.v7.drawHist1", opt: "" });
+   JSROOT.addDrawFunc({ name: "ROOT::Experimental::RHistDrawable<2>", icon: "img_histo2d", prereq: "v7hist", func: "JSROOT.v7.drawHist2", opt: "" });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RText", icon: "img_text", prereq: "v7more", func: "JSROOT.v7.drawText", opt: "", direct: true });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RLine", icon: "img_graph", prereq: "v7more", func: "JSROOT.v7.drawLine", opt: "", direct: true });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RMarker", icon: "img_graph", prereq: "v7more", func: "JSROOT.v7.drawMarker", opt: "", direct: true });

--- a/etc/http/scripts/JSRootPainter.v7hist.js
+++ b/etc/http/scripts/JSRootPainter.v7hist.js
@@ -207,7 +207,7 @@
       }
       if (!axis || axis.GetBinCoord) return axis;
 
-      if (axis._typename == "ROOT::Experimental::TAxisEquidistant") {
+      if (axis._typename == "ROOT::Experimental::RAxisEquidistant") {
          axis.min = axis.fLow;
          axis.max = axis.fLow + (axis.fNBins-2)/axis.fInvBinWidth;
 

--- a/graf2d/gpadv7/v7/inc/ROOT/RObjectDrawable.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RObjectDrawable.hxx
@@ -81,10 +81,10 @@ public:
 
 /// Interface to graphics taking a shared_ptr<TObject>.
 /// Must be on global scope, else lookup cannot find it (no ADL for TObject).
-inline std::unique_ptr<ROOT::Experimental::RObjectDrawable>
+inline std::shared_ptr<ROOT::Experimental::RObjectDrawable>
 GetDrawable(const std::shared_ptr<TObject> &obj, const std::string &opt = "")
 {
-   return std::make_unique<ROOT::Experimental::RObjectDrawable>(obj, opt);
+   return std::make_shared<ROOT::Experimental::RObjectDrawable>(obj, opt);
 }
 
 #endif

--- a/graf2d/gpadv7/v7/inc/ROOT/RPadDisplayItem.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RPadDisplayItem.hxx
@@ -15,6 +15,7 @@
 
 #ifndef ROOT7_RPadDisplayItem
 #define ROOT7_RPadDisplayItem
+
 #include <ROOT/RDisplayItem.hxx>
 #include <ROOT/RFrame.hxx>
 #include <ROOT/RPad.hxx>
@@ -33,16 +34,18 @@ public:
 
 
 protected:
-   const RFrame *fFrame{nullptr};   ///< temporary pointer on frame object
+   const RFrame *fFrame{nullptr};             ///< temporary pointer on frame object
    const RPadDrawingOpts *fDrawOpts{nullptr}; ///< temporary pointer on pad drawing options
-   const RPadExtent *fSize{nullptr};  ///< temporary pointer on pad size attributes
-   PadPrimitives_t fPrimitives; ///< display items for all primitives in the pad
+   const RPadExtent *fSize{nullptr};          ///< temporary pointer on pad size attributes
+   std::string fTitle;                        ///< title of the pad
+   PadPrimitives_t fPrimitives;               ///< display items for all primitives in the pad
 public:
    RPadDisplayItem() = default;
    virtual ~RPadDisplayItem() {}
    void SetFrame(const RFrame *f) { fFrame = f; }
    void SetDrawOpts(const RPadDrawingOpts *opts) { fDrawOpts = opts; }
    void SetSize(const RPadExtent *sz) { fSize = sz; }
+   void SetTitle(const std::string &title) { fTitle = title; }
    PadPrimitives_t &GetPrimitives() { return fPrimitives; }
    void Add(std::unique_ptr<RDisplayItem> &&item) { fPrimitives.push_back(std::move(item)); }
    void Clear()
@@ -51,6 +54,7 @@ public:
       fFrame = nullptr;
       fDrawOpts = nullptr;
       fSize = nullptr;
+      fTitle.clear();
    }
 };
 

--- a/graf2d/primitives/v7/src/RStyle.cxx
+++ b/graf2d/primitives/v7/src/RStyle.cxx
@@ -68,7 +68,7 @@ static RStyle GetInitialCurrent()
    static constexpr const char* kDefaultStyleName = "plain";
    auto iDefStyle = GetGlobalStyles().find(std::string(kDefaultStyleName));
    if (iDefStyle == GetGlobalStyles().end()) {
-      R__ERROR_HERE("Gpad") << "Cannot find initial default style named \"" << kDefaultStyleName
+      R__INFO_HERE("Gpad") << "Cannot find initial default style named \"" << kDefaultStyleName
       << "\", using an empty one.";
       RStyle defStyle(kDefaultStyleName);
       return RStyle::Register(std::move(defStyle));

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -617,6 +617,7 @@ std::string ROOT::Experimental::TCanvasPainter::CreateSnapshot(const ROOT::Exper
    PaintDrawables(can);
 
    fPadDisplayItem->SetObjectID("canvas"); // for canvas itself use special id
+   fPadDisplayItem->SetTitle(can.GetTitle());
 
    TString res = TBufferJSON::ToJSON(fPadDisplayItem.get(), 23);
 

--- a/hist/hist/v7/speed/histspeedtest.cxx
+++ b/hist/hist/v7/speed/histspeedtest.cxx
@@ -13,8 +13,8 @@
 #include "TH2.h"
 #include "TH3.h"
 
-#include "ROOT/THist.hxx"
-#include "ROOT/THistBufferedFill.hxx"
+#include "ROOT/RHist.hxx"
+#include "ROOT/RHistBufferedFill.hxx"
 
 using namespace ROOT;
 using namespace std;
@@ -49,7 +49,7 @@ GetUncertainty() const { return GetStat().GetUncertainty(); }
  */
 
 #ifndef STATCLASSES
-#define STATCLASSES Experimental::THistStatContent, Experimental::THistStatUncertainty
+#define STATCLASSES Experimental::RHistStatContent, Experimental::RHistStatUncertainty
 #endif
 
 struct Timer {
@@ -99,7 +99,7 @@ struct BinEdges {
          fYBins[i] = minValue + range * y[i];
    }
 
-   using AConf_t = Experimental::TAxisConfig;
+   using AConf_t = Experimental::RAxisConfig;
 
    AConf_t GetConfigX() const { return AConf_t(std::span<double>(fXBins).to_vector()); }
    AConf_t GetConfigY() const { return AConf_t(std::span<double>(fYBins).to_vector()); }
@@ -163,7 +163,7 @@ template <typename T>
 struct Dim<T, 2> {
 
    constexpr static unsigned short kNDim = 2;
-   using ExpTH2 = Experimental::THist<kNDim, T, STATCLASSES>;
+   using ExpTH2 = Experimental::RHist<kNDim, T, STATCLASSES>;
 
    using FillFunc_t = std::add_pointer_t<long(ExpTH2 &hist, std::vector<double> &input, std::string_view type)>;
 
@@ -195,7 +195,7 @@ struct Dim<T, 2> {
    inline static long fillN(ExpTH2 &hist, std::vector<double> &input, std::string_view gType)
    {
 
-      using array_t = Experimental::Hist::TCoordArray<2>;
+      using array_t = Experimental::Hist::RCoordArray<2>;
       array_t *values = (array_t *)(&input[0]);
       constexpr size_t stride = gStride;
 
@@ -212,7 +212,7 @@ struct Dim<T, 2> {
 
    inline static long fillBuffered(ExpTH2 &hist, std::vector<double> &input, std::string_view gType)
    {
-      Experimental::THistBufferedFill<ExpTH2> filler(hist);
+      Experimental::RHistBufferedFill<ExpTH2> filler(hist);
       std::string title = MakeTitle(gVersion, GetHist<kNDim, T>(), "fills (buffered)   ", gType);
       {
          Timer t(title.c_str(), input.size() / 2);
@@ -238,7 +238,7 @@ template <typename T>
 struct Dim<T, 1> {
 
    constexpr static unsigned short kNDim = 1;
-   using ExpTH1 = Experimental::THist<kNDim, T, STATCLASSES>;
+   using ExpTH1 = Experimental::RHist<kNDim, T, STATCLASSES>;
 
    using FillFunc_t = std::add_pointer_t<long(ExpTH1 &hist, std::vector<double> &input, std::string_view type)>;
 
@@ -277,7 +277,7 @@ struct Dim<T, 1> {
    inline static long fillN(ExpTH1 &hist, std::vector<double> &input, std::string_view gType)
    {
 
-      using array_t = Experimental::Hist::TCoordArray<1>;
+      using array_t = Experimental::Hist::RCoordArray<1>;
       array_t *values = (array_t *)(&input[0]);
       constexpr size_t stride = gStride;
 
@@ -294,7 +294,7 @@ struct Dim<T, 1> {
 
    inline static long fillBuffered(ExpTH1 &hist, std::vector<double> &input, std::string_view gType)
    {
-      Experimental::THistBufferedFill<ExpTH1> filler(hist);
+      Experimental::RHistBufferedFill<ExpTH1> filler(hist);
       std::string title = MakeTitle(gVersion, GetHist<kNDim, T>(), "fills (buffered)   ", gType);
       {
          Timer t(title.c_str(), input.size());

--- a/hist/hist/v7/speed/runall.sh
+++ b/hist/hist/v7/speed/runall.sh
@@ -11,7 +11,7 @@ set -x
 
 function run {
    echo "Data Class: $1" | tee $1.1e6.$$.speedlog | tee $1.1e8.$$.speedlog
-   ${CXX} -o speedtest speedtest.cxx `root-config --cflags --libs` -O3 "-DSTATCLASSES=$1"
+   ${CXX} -o speedtest histspeedtest.cxx `root-config --cflags --libs` -O3 "-DSTATCLASSES=$1"
    # ${prefix} ./speedtest 1e6 > $1.1e6.$$.log
    # rvalgrind --tool=callgrind --callgrind-out-file=callgrind.out.$1.%p --dump-instr=yes ./speedtest 1e6 > $1.1e6.$$.vallog
    ./speedtest 1e6 $what >> $1.1e6.$$.speedlog

--- a/math/mathcore/v7/inc/ROOT/TFit.hxx
+++ b/math/mathcore/v7/inc/ROOT/TFit.hxx
@@ -21,7 +21,7 @@
 
 #include "ROOT/RSpan.hxx"
 
-#include "ROOT/THist.hxx"
+#include "ROOT/RHist.hxx"
 
 namespace ROOT {
 namespace Experimental {
@@ -35,8 +35,8 @@ public:
    TFunction(std::function<double(const std::array<double, DIMENSION> &, const std::span<double> par)> func) {}
 };
 
-template <int DIMENSIONS, class PRECISION, template <int D_, class P_, template <class P__> class S_> class... STAT>
-TFitResult FitTo(const THist<DIMENSIONS, PRECISION, STAT...> &hist, const TFunction<DIMENSIONS> &func,
+template <int DIMENSIONS, class PRECISION, template <int D_, class P_> class... STAT>
+TFitResult FitTo(const RHist<DIMENSIONS, PRECISION, STAT...> &hist, const TFunction<DIMENSIONS> &func,
                  std::span<double> paramInit)
 {
    return TFitResult();

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -189,7 +189,7 @@ else()
   endif()
 endif()
 
-if(ROOT_root7_FOUND)
+if(root7)
   set(root7_veto dataframe/df013_InspectAnalysis.C)
 endif()
 
@@ -246,8 +246,8 @@ set(all_veto hsimple.C
              )
 
 file(GLOB_RECURSE tutorials RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.C)
-if(ROOT_root7_FOUND)
-  file(GLOB_RECURSE tutorials_v7 RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/v7 *.cxx)
+if(root7)
+  file(GLOB_RECURSE tutorials_v7 RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} v7/*.cxx)
   list(APPEND tutorials ${tutorials_v7})
 endif()
 file(GLOB tutorials_veto RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${all_veto})

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -191,7 +191,9 @@ else()
 endif()
 
 if(root7)
-  set(root7_veto dataframe/df013_InspectAnalysis.C)
+  set(root7_veto dataframe/df013_InspectAnalysis.C
+                 v7/fitpanel.cxx
+      )
 endif()
 
 #---These ones are disabled !!! ------------------------------------

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -37,6 +37,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CTestCustom.cmake ${CMAKE_CURRENT_BIN
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/rootlogon.C "{
   // Needed by ACLiC to use the current dicrectory for scratch area
   gSystem->SetBuildDir(\".\", kTRUE);
+  gROOT->SetWebDisplay(\"batch\");
 }")
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/rootalias.C "")
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/rootlogoff.C "{}")

--- a/tutorials/v7/concurrentfill.cxx
+++ b/tutorials/v7/concurrentfill.cxx
@@ -16,8 +16,8 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include "ROOT/THist.hxx"
-#include "ROOT/THistConcurrentFill.hxx"
+#include "ROOT/RHist.hxx"
+#include "ROOT/RHistConcurrentFill.hxx"
 
 #include <iostream>
 #include <future>
@@ -33,7 +33,7 @@ double wasteCPUTime(std::mt19937 &gen)
           std::generate_canonical<double, 100>(gen);
 }
 
-using Filler_t = Experimental::THistConcurrentFiller<Experimental::TH2D, 1024>;
+using Filler_t = Experimental::RHistConcurrentFiller<Experimental::RH2D, 1024>;
 
 /// This function is called within each thread: it spends some CPU time and then
 /// fills a number into the histogram, through the Filler_t. This is repeated
@@ -47,15 +47,15 @@ void theTask(Filler_t filler)
 }
 
 /// This example fills a histogram concurrently, from several threads.
-void concurrentHistFill(Experimental::TH2D &hist)
+void concurrentHistFill(Experimental::RH2D &hist)
 {
-   // THistConcurrentFillManager allows multiple threads to fill the histogram
+   // RHistConcurrentFillManager allows multiple threads to fill the histogram
    // concurrently.
    //
    // Details: each thread's Fill() calls are buffered. once the buffer is full,
-   // the THistConcurrentFillManager locks and flushes the buffer into the
+   // the RHistConcurrentFillManager locks and flushes the buffer into the
    // histogram.
-   Experimental::THistConcurrentFillManager<Experimental::TH2D> fillMgr(hist);
+   Experimental::RHistConcurrentFillManager<Experimental::RH2D> fillMgr(hist);
 
    std::array<std::thread, 8> threads;
 
@@ -73,7 +73,7 @@ void concurrentHistFill(Experimental::TH2D &hist)
 void concurrentfill()
 {
    // This histogram will be filled from several threads.
-   Experimental::TH2D hist{{100, 0., 1.}, {{0., 1., 2., 3., 10.}}};
+   Experimental::RH2D hist{{100, 0., 1.}, {{0., 1., 2., 3., 10.}}};
 
    concurrentHistFill(hist);
 

--- a/tutorials/v7/draw.cxx
+++ b/tutorials/v7/draw.cxx
@@ -20,7 +20,7 @@
 
 R__LOAD_LIBRARY(libROOTHistDraw);
 
-#include "ROOT/THist.hxx"
+#include "ROOT/RHist.hxx"
 #include "ROOT/RCanvas.hxx"
 #include "ROOT/RColor.hxx"
 #include "ROOT/TDirectory.hxx"
@@ -30,9 +30,9 @@ void draw()
    using namespace ROOT;
 
    // Create the histogram.
-   Experimental::TAxisConfig xaxis("x", 10, 0., 1.);
-   Experimental::TAxisConfig yaxis("y", {0., 1., 2., 3., 10.});
-   auto pHist = std::make_shared<Experimental::TH2D>(xaxis, yaxis);
+   Experimental::RAxisConfig xaxis("x", 10, 0., 1.);
+   Experimental::RAxisConfig yaxis("y", {0., 1., 2., 3., 10.});
+   auto pHist = std::make_shared<Experimental::RH2D>(xaxis, yaxis);
 
    // Fill a few points.
    pHist->Fill({0.01, 1.02});

--- a/tutorials/v7/draw_subpads.cxx
+++ b/tutorials/v7/draw_subpads.cxx
@@ -15,7 +15,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include "ROOT/THist.hxx"
+#include "ROOT/RHist.hxx"
 #include "ROOT/RCanvas.hxx"
 #include "ROOT/RPad.hxx"
 
@@ -23,7 +23,7 @@ void draw_subpads() {
   using namespace ROOT;
 
   // Create the histogram.
-  Experimental::TAxisConfig xaxis(10, 0., 10.);
+  Experimental::RAxisConfig xaxis(10, 0., 10.);
   auto pHist1 = std::make_shared<Experimental::TH1D>(xaxis);
   auto pHist2 = std::make_shared<Experimental::TH1D>(xaxis);
   auto pHist3 = std::make_shared<Experimental::TH1D>(xaxis);

--- a/tutorials/v7/draw_subpads.cxx
+++ b/tutorials/v7/draw_subpads.cxx
@@ -24,9 +24,9 @@ void draw_subpads() {
 
   // Create the histogram.
   Experimental::RAxisConfig xaxis(10, 0., 10.);
-  auto pHist1 = std::make_shared<Experimental::TH1D>(xaxis);
-  auto pHist2 = std::make_shared<Experimental::TH1D>(xaxis);
-  auto pHist3 = std::make_shared<Experimental::TH1D>(xaxis);
+  auto pHist1 = std::make_shared<Experimental::RH1D>(xaxis);
+  auto pHist2 = std::make_shared<Experimental::RH1D>(xaxis);
+  auto pHist3 = std::make_shared<Experimental::RH1D>(xaxis);
 
   // Fill a few points.
   pHist1->Fill(1);

--- a/tutorials/v7/draw_th1.cxx
+++ b/tutorials/v7/draw_th1.cxx
@@ -49,5 +49,7 @@ void draw_th1() {
    canvas->Draw(pHist2)->SetLineColor(Experimental::RColor::kBlue);
 
    canvas->Show();
-   canvas->SaveAs("th1.png");
+   // Saving to PNG doesn't work reliably in batch yet:
+   if (!gROOT->IsWebDisplayBatch())
+      canvas->SaveAs("th1.png");
 }

--- a/tutorials/v7/draw_th1.cxx
+++ b/tutorials/v7/draw_th1.cxx
@@ -21,16 +21,16 @@
 
 R__LOAD_LIBRARY(libROOTGpadv7);
 
-#include "ROOT/THist.hxx"
+#include "ROOT/RHist.hxx"
 #include "ROOT/RCanvas.hxx"
 
 void draw_th1() {
    using namespace ROOT;
 
    // Create the histogram.
-   Experimental::TAxisConfig xaxis(10, 0., 10.);
-   auto pHist = std::make_shared<Experimental::TH1D>(xaxis);
-   auto pHist2 = std::make_shared<Experimental::TH1D>(xaxis);
+   Experimental::RAxisConfig xaxis(10, 0., 10.);
+   auto pHist = std::make_shared<Experimental::RH1D>(xaxis);
+   auto pHist2 = std::make_shared<Experimental::RH1D>(xaxis);
 
    // Fill a few points.
    pHist->Fill(1);

--- a/tutorials/v7/draw_v6.cxx
+++ b/tutorials/v7/draw_v6.cxx
@@ -52,14 +52,17 @@ void draw_v6()
    canvas->Update(false,
                   [](bool res) { std::cout << "Second Update done = " << (res ? "true" : "false") << std::endl; });
 
-   // request to create PNG file in asynchronous mode and specify lambda function as callback
-   // when request processed by the client, callback invoked with result value
-   canvas->SaveAs("draw.png", true,
-                  [](bool res) { std::cout << "Producing PNG done res = " << (res ? "true" : "false") << std::endl; });
+   // Saving to PNG doesn't work reliably in batch yet:
+   if (!gROOT->IsWebDisplayBatch()) {
+      // request to create PNG file in asynchronous mode and specify lambda function as callback
+      // when request processed by the client, callback invoked with result value
+      canvas->SaveAs("draw.png", true,
+                     [](bool res) { std::cout << "Producing PNG done res = " << (res ? "true" : "false") << std::endl; });
 
-   // this function executed in synchronous mode (async = false is default),
-   // mean previous file saving will be completed as well at this point
-   canvas->SaveAs("draw.svg"); // synchronous
+      // this function executed in synchronous mode (async = false is default),
+      // mean previous file saving will be completed as well at this point
+      canvas->SaveAs("draw.svg"); // synchronous
+   }
 
    // hide canvas after 10 seconds - close all connections and close all opened windows
    // gSystem->Sleep(10000);

--- a/tutorials/v7/draw_v6.cxx
+++ b/tutorials/v7/draw_v6.cxx
@@ -30,9 +30,9 @@ void draw_v6()
 {
    using namespace ROOT;
 
-   static constexpr int npoints = 4;
-   double x[npoints] = {0., 1., 2., 3.};
-   double y[npoints] = {.1, .2, .3, .4};
+   static constexpr int npoints = 10;
+   double x[npoints] = { 0., 1., 2., 3., 4., 5., 6., 7., 8., 9. };
+   double y[npoints] = { .1, .2, .3, .4, .3, .2, .1, .2, .3, .4 };
    auto gr = std::make_shared<TGraph>(npoints, x, y);
    auto canvas = Experimental::RCanvas::Create("v7 RCanvas showing a v6 TGraph");
    canvas->Draw(gr, "AL");

--- a/tutorials/v7/fitpanel.cxx
+++ b/tutorials/v7/fitpanel.cxx
@@ -17,7 +17,7 @@
 
 R__LOAD_LIBRARY(libGpad);
 
-#include "ROOT/THist.hxx"
+#include "ROOT/RHist.hxx"
 #include "ROOT/RCanvas.hxx"
 #include "ROOT/TFitPanel.hxx"
 #include "ROOT/TDirectory.hxx"
@@ -27,8 +27,8 @@ void fitpanel0() {
   using namespace ROOT;
 
   // Create the histogram.
-  Experimental::TAxisConfig xaxis(10, 0., 10.);
-  auto pHist = std::make_shared<Experimental::TH1D>(xaxis);
+  Experimental::RAxisConfig xaxis(10, 0., 10.);
+  auto pHist = std::make_shared<Experimental::RH1D>(xaxis);
 
   // Fill a few points.
   pHist->Fill(1);
@@ -57,9 +57,9 @@ void fitpanel() {
    using namespace ROOT;
 
    // TODO - also keep axis correctly in the help
-   auto xaxis = std::make_shared<Experimental::TAxisConfig>(10, 0., 10.);
+   auto xaxis = std::make_shared<Experimental::RAxisConfig>(10, 0., 10.);
    // Create the histogram.
-   auto pHist = std::make_shared<Experimental::TH1D>(*xaxis.get());
+   auto pHist = std::make_shared<Experimental::RH1D>(*xaxis.get());
 
    // Fill a few points.
    pHist->Fill(1);
@@ -68,7 +68,7 @@ void fitpanel() {
    pHist->Fill(3);
 
    auto canvas = Experimental::RCanvas::Create("Canvas Title");
-   canvas->Draw(pHist)->SetLineColor(Experimental::TColor::kRed);
+   canvas->Draw(pHist)->SetLineColor(Experimental::RColor::kRed);
 
    canvas->Show();
    canvas->Update(); // need to ensure canvas is drawn

--- a/tutorials/v7/histops.cxx
+++ b/tutorials/v7/histops.cxx
@@ -25,12 +25,12 @@ void histops()
    using namespace ROOT;
    // Create a 2D histogram with an X axis with equidistant bins, and a y axis
    // with irregular binning.
-   Experimental::TH2D hist1({100, 0., 1.}, {{0., 1., 2., 3., 10.}});
+   Experimental::RH2D hist1({100, 0., 1.}, {{0., 1., 2., 3., 10.}});
 
    // Fill weight 1. at the coordinate 0.01, 1.02.
    hist1.Fill({0.01, 1.02});
 
-   Experimental::TH2D hist2({{{10, 0., 1.}, {{0., 1., 2., 3., 10.}}}});
+   Experimental::RH2D hist2({{{10, 0., 1.}, {{0., 1., 2., 3., 10.}}}});
    // Fill weight 1. at the coordinate 0.01, 1.02.
    hist2.Fill({0.01, 1.02});
 

--- a/tutorials/v7/histops.cxx
+++ b/tutorials/v7/histops.cxx
@@ -16,7 +16,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include "ROOT/THist.hxx"
+#include "ROOT/RHist.hxx"
 #include <iostream>
 
 void histops()

--- a/tutorials/v7/pad.cxx
+++ b/tutorials/v7/pad.cxx
@@ -22,19 +22,25 @@ R__LOAD_LIBRARY(libROOTGpadv7);
 
 #include "ROOT/RCanvas.hxx"
 #include "ROOT/RFrame.hxx"
-#include "ROOT/Rline.hxx"
+#include "ROOT/RLine.hxx"
 
 void pad()
 {
    using namespace ROOT;
    using namespace ROOT::Experimental;
 
-   auto canvas = Experimental::RCanvas::Create("what to do with a pad!");
+   auto canvas = RCanvas::Create("what to do with a pad!");
    auto pads   = canvas->Divide(3, 3);
-   auto &pad12 = pads[1][2];
-   pad12->SetAllAxisBounds({{50., 250.}, {-1., 1.}});
+   //auto &pad12 = pads[1][2];
+   //pad12->SetAllAxisBounds({{50., 250.}, {-1., 1.}});
    // Please fix Rline such that {x,y} are TPadPos!
-   //pad12->Draw(Experimental::Rline({100._user, 0.5_normal}, {200._user, 0.5_normal}));
+   // pad12->Draw(Experimental::RLine({100._user, 0.5_normal}, {200._user, 0.5_normal}));
+
+   for (int i=0;i<3;++i)
+      for (int j=0;j<3;++j) {
+        pads[i][j]->Draw(Experimental::RLine({0.1_normal, 0.1_normal}, {0.9_normal,0.9_normal}));
+        pads[i][j]->Draw(Experimental::RLine({0.1_normal, 0.9_normal}, {0.9_normal,0.1_normal}));
+      }
 
    canvas->Show();
 }

--- a/tutorials/v7/perf.cxx
+++ b/tutorials/v7/perf.cxx
@@ -16,9 +16,9 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include "ROOT/THist.hxx"
+#include "ROOT/RHist.hxx"
 #include "ROOT/TFit.hxx"
-#include "ROOT/THistBufferedFill.hxx"
+#include "ROOT/RHistBufferedFill.hxx"
 
 #include <chrono>
 #include <iostream>
@@ -30,7 +30,7 @@ long createNew(int count)
 {
    long ret = 1;
    for (int i = 0; i < count; ++i) {
-      Experimental::TH2D hist({{{100, 0., 1.}, {{0., 1., 2., 3., 10.}}}});
+      Experimental::RH2D hist({{{100, 0., 1.}, {{0., 1., 2., 3., 10.}}}});
       ret ^= (long)&hist;
    }
    return ret;
@@ -38,7 +38,7 @@ long createNew(int count)
 
 long fillNew(int count)
 {
-   Experimental::TH2D hist({{{100, 0., 1.}, {{0., 1., 2., 3., 10.}}}});
+   Experimental::RH2D hist({{{100, 0., 1.}, {{0., 1., 2., 3., 10.}}}});
    for (int i = 0; i < count; ++i)
       hist.Fill({0.611, 0.611});
    return hist.GetNDim();
@@ -46,8 +46,8 @@ long fillNew(int count)
 
 long fillN(int count)
 {
-   Experimental::TH2D hist({{{100, 0., 1.}, {{0., 1., 2., 3., 10.}}}});
-   std::vector<Experimental::Hist::TCoordArray<2>> v(count);
+   Experimental::RH2D hist({{{100, 0., 1.}, {{0., 1., 2., 3., 10.}}}});
+   std::vector<Experimental::Hist::RCoordArray<2>> v(count);
    for (int i = 0; i < count; ++i)
       v[i] = {0.611, 0.611};
    hist.FillN(v);
@@ -56,8 +56,8 @@ long fillN(int count)
 
 long fillBufferedNew(int count)
 {
-   Experimental::TH2D hist({{{100, 0., 1.}, {{0., 1., 2., 3., 10.}}}});
-   Experimental::THistBufferedFill<Experimental::TH2D> filler(hist);
+   Experimental::RH2D hist({{{100, 0., 1.}, {{0., 1., 2., 3., 10.}}}});
+   Experimental::RHistBufferedFill<Experimental::RH2D> filler(hist);
    for (int i = 0; i < count; ++i)
       filler.Fill({0.611, 0.611});
    return hist.GetNDim();

--- a/tutorials/v7/perfcomp.cxx
+++ b/tutorials/v7/perfcomp.cxx
@@ -16,9 +16,9 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include "ROOT/THist.hxx"
+#include "ROOT/RHist.hxx"
 #include "ROOT/TFit.hxx"
-#include "ROOT/THistBufferedFill.hxx"
+#include "ROOT/RHistBufferedFill.hxx"
 
 #include "TH2.h"
 
@@ -32,7 +32,7 @@ long createNewII(int count)
 {
    long ret = 1;
    for (int i = 0; i < count; ++i) {
-      Experimental::TH2D hist({{{{0., 0.1, 0.3, 1.}}, {{0., 1., 2., 3., 10.}}}});
+      Experimental::RH2D hist({{{{0., 0.1, 0.3, 1.}}, {{0., 1., 2., 3., 10.}}}});
       ret ^= (long)&hist;
    }
    return ret;
@@ -63,7 +63,7 @@ long createOldII(int count)
 
 long fillNewII(int count)
 {
-   Experimental::TH2D hist({{{{0., 0.1, 0.3, 1.}}, {{0., 1., 2., 3., 10.}}}});
+   Experimental::RH2D hist({{{{0., 0.1, 0.3, 1.}}, {{0., 1., 2., 3., 10.}}}});
    for (int i = 0; i < count; ++i)
       hist.Fill({0.611, 0.611});
    return hist.GetNDim();
@@ -79,8 +79,8 @@ long fillOldII(int count)
 
 long fillNII(int count)
 {
-   Experimental::TH2D hist({{{{0., 0.1, 0.3, 1.}}, {{0., 1., 2., 3., 10.}}}});
-   std::vector<Experimental::Hist::TCoordArray<2>> v(count);
+   Experimental::RH2D hist({{{{0., 0.1, 0.3, 1.}}, {{0., 1., 2., 3., 10.}}}});
+   std::vector<Experimental::Hist::RCoordArray<2>> v(count);
    for (int i = 0; i < count; ++i)
       v[i] = {0.611, 0.611};
    hist.FillN(v);
@@ -98,8 +98,8 @@ long fillBufferedOldII(int count)
 
 long fillBufferedNewII(int count)
 {
-   Experimental::TH2D hist({{{{0., 0.1, 0.3, 1.}}, {{0., 1., 2., 3., 10.}}}});
-   Experimental::THistBufferedFill<Experimental::TH2D> filler(hist);
+   Experimental::RH2D hist({{{{0., 0.1, 0.3, 1.}}, {{0., 1., 2., 3., 10.}}}});
+   Experimental::RHistBufferedFill<Experimental::RH2D> filler(hist);
    for (int i = 0; i < count; ++i)
       filler.Fill({0.611, 0.611});
    return hist.GetNDim();
@@ -111,7 +111,7 @@ long createNewEE(int count)
 {
    long ret = 1;
    for (int i = 0; i < count; ++i) {
-      Experimental::TH2D hist({{{100, 0., 1.}, {5, 0., 10.}}});
+      Experimental::RH2D hist({{{100, 0., 1.}, {5, 0., 10.}}});
       ret ^= (long)&hist;
    }
    return ret;
@@ -129,7 +129,7 @@ long createOldEE(int count)
 
 long fillNewEE(int count)
 {
-   Experimental::TH2D hist({{{100, 0., 1.}, {5, 0., 10.}}});
+   Experimental::RH2D hist({{{100, 0., 1.}, {5, 0., 10.}}});
    for (int i = 0; i < count; ++i)
       hist.Fill({0.611, 0.611});
    return hist.GetNDim();
@@ -145,8 +145,8 @@ long fillOldEE(int count)
 
 long fillNEE(int count)
 {
-   Experimental::TH2D hist({{{100, 0., 1.}, {5, 0., 10.}}});
-   std::vector<Experimental::Hist::TCoordArray<2>> v(count);
+   Experimental::RH2D hist({{{100, 0., 1.}, {5, 0., 10.}}});
+   std::vector<Experimental::Hist::RCoordArray<2>> v(count);
    for (int i = 0; i < count; ++i)
       v[i] = {0.611, 0.611};
    hist.FillN(v);
@@ -164,8 +164,8 @@ long fillBufferedOldEE(int count)
 
 long fillBufferedNewEE(int count)
 {
-   Experimental::TH2D hist({{{100, 0., 1.}, {5, 0., 10.}}});
-   Experimental::THistBufferedFill<Experimental::TH2D> filler(hist);
+   Experimental::RH2D hist({{{100, 0., 1.}, {5, 0., 10.}}});
+   Experimental::RHistBufferedFill<Experimental::RH2D> filler(hist);
    for (int i = 0; i < count; ++i)
       filler.Fill({0.611, 0.611});
    return hist.GetNDim();
@@ -200,5 +200,4 @@ void perfcomp()
    time(fillOldEE, fillNewEE, 100 * factor, "2D fills [EE]");
    time(fillBufferedOldII, fillBufferedNewII, 100 * factor, "2D fills (buffered) [II]");
    time(fillBufferedOldEE, fillBufferedNewEE, 100 * factor, "2D fills (buffered) [EE]");
-   return 0;
 }

--- a/tutorials/v7/simple.cxx
+++ b/tutorials/v7/simple.cxx
@@ -16,7 +16,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include "ROOT/THist.hxx"
+#include "ROOT/RHist.hxx"
 #include "ROOT/TFit.hxx"
 #include "ROOT/TFile.hxx"
 
@@ -26,14 +26,14 @@ void simple()
 
    // Create a 2D histogram with an X axis with equidistant bins, and a y axis
    // with irregular binning.
-   Experimental::TAxisConfig xAxis(100, 0., 1.);
-   Experimental::TAxisConfig yAxis({0., 1., 2., 3., 10.});
-   Experimental::TH2D histFromVars(xAxis, yAxis);
+   Experimental::RAxisConfig xAxis(100, 0., 1.);
+   Experimental::RAxisConfig yAxis({0., 1., 2., 3., 10.});
+   Experimental::RH2D histFromVars(xAxis, yAxis);
 
    // Or the short in-place version:
    // Create a 2D histogram with an X axis with equidistant bins, and a y axis
    // with irregular binning.
-   Experimental::TH2D hist({100, 0., 1.}, {{0., 1., 2., 3., 10.}});
+   Experimental::RH2D hist({100, 0., 1.}, {{0., 1., 2., 3., 10.}});
 
    // Fill weight 1. at the coordinate 0.01, 1.02.
    hist.Fill({0.01, 1.02});


### PR DESCRIPTION
After renaming of v7 classes not all places in JSROOT were fixed (or I lost them).
Plus most of tutorials were not adjusted.

Now all tutorials are working. Plus RCanvas title now shown as web-page title