### PR TITLE
Remove genvector build option, will be always ON from now on

### DIFF
--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -113,7 +113,6 @@ ROOT_BUILD_OPTION(fitsio ON "Read images and data from FITS files, requires cfit
 ROOT_BUILD_OPTION(fortran OFF "Enable the Fortran components of ROOT")
 set(gcctoolchain "" CACHE PATH "Path for the gcctoolchain in case not the system gcc is used to build clang/LLVM")
 ROOT_BUILD_OPTION(gdml ON "GDML writer and reader")
-ROOT_BUILD_OPTION(genvector ON "Build the new libGenVector library")
 ROOT_BUILD_OPTION(geocad OFF "ROOT-CAD Interface")
 ROOT_BUILD_OPTION(gfal ON "GFAL support, requires libgfal")
 ROOT_BUILD_OPTION(globus OFF "Globus authentication support, requires Globus toolkit")

--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -389,7 +389,6 @@ set(gslincdir ${GSL_INCLUDE_DIR})
 set(gslflags)
 
 set(shadowpw ${value${shadowpw}})
-set(buildgenvector ${value${genvector}})
 set(buildmathmore ${value${mathmore}})
 set(buildcling ${value${cling}})
 set(buildroofit ${value${roofit}})

--- a/config/Makefile.in
+++ b/config/Makefile.in
@@ -400,8 +400,6 @@ SHADOWFLAGS    := @shadowpw@
 SHADOWLIB      :=
 SHADOWLIBDIR   :=
 
-BUILDGENVECTOR := @buildgenvector@
-
 BUILDMATHMORE  := @buildmathmore@
 GSLFLAGS       := $(filter-out -I/usr/include, @gslflags@)
 GSLLIBDIR      := @gsllibdir@


### PR DESCRIPTION
The CMake build system is broken with genvector=OFF (does not really disable genvector, and tests fail if that is fixed). Therefore, it was decided that it's better to just make this always ON and remove the option for disabling it altogether. See #2155 for more details.