### PR TITLE
[VecOps,RVec] Proposal for sorting utils

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -669,9 +669,9 @@ void swap(RVec<T> &lhs, RVec<T> &rhs)
 
 /// Return indices that sort the vector
 template <typename T>
-RVec<size_t> Argsort(const RVec<T> &v)
+RVec<typename RVec<T>::size_type> Argsort(const RVec<T> &v)
 {
-   using size_type = typename std::vector<T>::size_type;
+   using size_type = typename RVec<T>::size_type;
    RVec<size_type> i(v.size());
    std::iota(i.begin(), i.end(), 0);
    std::sort(i.begin(), i.end(), [&v](size_type i1, size_type i2) { return v[i1] < v[i2]; });
@@ -680,7 +680,7 @@ RVec<size_t> Argsort(const RVec<T> &v)
 
 /// Return elements of a vector at given indices
 template <typename T>
-RVec<T> ByIndices(const RVec<T> &v, const RVec<typename std::vector<T>::size_type> &i)
+RVec<T> ByIndices(const RVec<T> &v, const RVec<typename RVec<T>::size_type> &i)
 {
    RVec<T> r(i.size());
    for (unsigned int k = 0; k < i.size(); k++)

--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -667,6 +667,27 @@ void swap(RVec<T> &lhs, RVec<T> &rhs)
    lhs.swap(rhs);
 }
 
+/// Return indices that sort the vector
+template <typename T>
+RVec<size_t> Argsort(const RVec<T> &v)
+{
+   using size_type = typename std::vector<T>::size_type;
+   RVec<size_type> i(v.size());
+   std::iota(i.begin(), i.end(), 0);
+   std::sort(i.begin(), i.end(), [&v](size_type i1, size_type i2) { return v[i1] < v[i2]; });
+   return i;
+}
+
+/// Return elements of a vector at given indices
+template <typename T>
+RVec<T> ByIndices(const RVec<T> &v, const RVec<typename std::vector<T>::size_type> &i)
+{
+   RVec<T> r(i.size());
+   for (unsigned int k = 0; k < i.size(); k++)
+      r[k] = v[i[k]];
+   return r;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Print a RVec at the prompt:
 template <class T>

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -590,7 +590,7 @@ TEST(VecOps, SimpleStatOps)
    ASSERT_DOUBLE_EQ(Mean(v2), 2.);
    ASSERT_DOUBLE_EQ(Var(v2), 1.);
    ASSERT_DOUBLE_EQ(StdDev(v2), 1.);
-   
+
    ROOT::VecOps::RVec<double> v3 {10., 20., 32.};
    ASSERT_DOUBLE_EQ(Sum(v3), 62.);
    ASSERT_DOUBLE_EQ(Mean(v3), 20.666666666666668);
@@ -616,4 +616,22 @@ TEST(VecOps, All)
    EXPECT_FALSE(All(vi));
    vi = {1, 1};
    EXPECT_TRUE(All(vi));
+}
+
+TEST(VecOps, Argsort)
+{
+   ROOT::VecOps::RVec<int> v {2, 0, 1};
+   using size_type = typename ROOT::VecOps::RVec<int>::size_type;
+   auto i = Argsort(v);
+   ROOT::VecOps::RVec<size_type> ref {1, 2, 0};
+   CheckEqual(i, ref);
+}
+
+TEST(VecOps, ByIndices)
+{
+   ROOT::VecOps::RVec<int> v0 {2, 0, 1};
+   ROOT::VecOps::RVec<typename ROOT::VecOps::RVec<int>::size_type> i {1, 2, 0};
+   auto v1 = ByIndices(v0, i);
+   ROOT::VecOps::RVec<int> ref {0, 1, 2};
+   CheckEqual(v1, ref);
 }

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -620,18 +620,18 @@ TEST(VecOps, All)
 
 TEST(VecOps, Argsort)
 {
-   ROOT::VecOps::RVec<int> v {2, 0, 1};
+   ROOT::VecOps::RVec<int> v{2, 0, 1};
    using size_type = typename ROOT::VecOps::RVec<int>::size_type;
    auto i = Argsort(v);
-   ROOT::VecOps::RVec<size_type> ref {1, 2, 0};
+   ROOT::VecOps::RVec<size_type> ref{1, 2, 0};
    CheckEqual(i, ref);
 }
 
 TEST(VecOps, ByIndices)
 {
-   ROOT::VecOps::RVec<int> v0 {2, 0, 1};
-   ROOT::VecOps::RVec<typename ROOT::VecOps::RVec<int>::size_type> i {1, 2, 0};
+   ROOT::VecOps::RVec<int> v0{2, 0, 1};
+   ROOT::VecOps::RVec<typename ROOT::VecOps::RVec<int>::size_type> i{1, 2, 0};
    auto v1 = ByIndices(v0, i);
-   ROOT::VecOps::RVec<int> ref {0, 1, 2};
+   ROOT::VecOps::RVec<int> ref{0, 1, 2};
    CheckEqual(v1, ref);
 }


### PR DESCRIPTION
Making a proposal to add utils for sorting of collections. The use-case is to get the indices of the largset/smallest elements of a vector, e.g., `Muon_pt` and retrieve a subset of other vectors from these, e.g., `Muon_eta`, ... . Already solved by @amadio in [this](https://root-forum.cern.ch/t/sort-struct-of-array-format-with-rvec/29485) forum post.

```cpp
root [1] using namespace ROOT::VecOps;
root [2] RVec<float> x({3, 1, 2})
(ROOT::VecOps::RVec<float> &) { 3, 1, 2 }
root [3] auto i = Argsort(x)
(ROOT::VecOps::RVec<unsigned long> &) { 1, 2, 0 }
root [4] auto y = ByIndices(x, i)
(ROOT::VecOps::RVec<float> &) { 1, 2, 3 }
```

Functionalities and naming TBD.