### PR TITLE
[VecOps] Rename helper ByIndices to Take

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -680,7 +680,7 @@ RVec<typename RVec<T>::size_type> Argsort(const RVec<T> &v)
 
 /// Return elements of a vector at given indices
 template <typename T>
-RVec<T> ByIndices(const RVec<T> &v, const RVec<typename RVec<T>::size_type> &i)
+RVec<T> Take(const RVec<T> &v, const RVec<typename RVec<T>::size_type> &i)
 {
    RVec<T> r(i.size());
    for (unsigned int k = 0; k < i.size(); k++)

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -627,11 +627,11 @@ TEST(VecOps, Argsort)
    CheckEqual(i, ref);
 }
 
-TEST(VecOps, ByIndices)
+TEST(VecOps, Take)
 {
    ROOT::VecOps::RVec<int> v0{2, 0, 1};
    ROOT::VecOps::RVec<typename ROOT::VecOps::RVec<int>::size_type> i{1, 2, 0};
-   auto v1 = ByIndices(v0, i);
+   auto v1 = Take(v0, i);
    ROOT::VecOps::RVec<int> ref{0, 1, 2};
    CheckEqual(v1, ref);
 }


### PR DESCRIPTION
@dpiparo and I agreed that the naming of `ByIndices` is not very lucky. I would propose to use `Take` following `numpy.take` as described [here](https://docs.scipy.org/doc/numpy/reference/generated/numpy.take.html).