### PR TITLE
[StreamerAction] Do not rely on RVO returning an owning SequencePtr:

### DIFF
--- a/io/io/inc/TStreamerInfoActions.h
+++ b/io/io/inc/TStreamerInfoActions.h
@@ -205,6 +205,11 @@ namespace TStreamerInfoActions {
          Bool_t fOwner = kFALSE;
 
          SequencePtr() = default;
+
+         SequencePtr(SequencePtr &&from) : fSequence(from.fSequence), fOwner(from.fOwner) {
+            from.fOwner = false;
+         }
+
          SequencePtr(TStreamerInfoActions::TActionSequence *sequence,  Bool_t owner) : fSequence(sequence), fOwner(owner) {}
 
          ~SequencePtr() {


### PR DESCRIPTION
On certain Windows builds, `return {..., true}` would create a local SequencePtr, return a copy, then destruct the local - which in turn would delete fSequence. Instead, move the local and remember that the local has lost ownership.