### PR TITLE
Flag in Minuit2 when the covariance matrix is not positive defined at the first iteration (after MnSeed). 

### DIFF
--- a/math/minuit/inc/TMinuitMinimizer.h
+++ b/math/minuit/inc/TMinuitMinimizer.h
@@ -230,6 +230,9 @@ public:
    /// By default they are suppressed only when the printlevel is <= 0
    void SuppressMinuitWarnings(bool nowarn=true);
 
+   /// set debug mode. Return true if setting was successfull
+   bool SetDebug(bool on = true); 
+
 protected:
 
    /// implementation of FCN for Minuit
@@ -257,6 +260,7 @@ protected:
 
    ///check parameter
    bool CheckVarIndex(unsigned int ivar) const;
+
 
 private:
 

--- a/math/minuit/src/TMinuitMinimizer.cxx
+++ b/math/minuit/src/TMinuitMinimizer.cxx
@@ -1060,7 +1060,23 @@ bool TMinuitMinimizer::Hesse() {
    return true;
 }
 
+bool TMinuitMinimizer::SetDebug(bool on) {
+   // set debug mode
 
+   if (fMinuit == 0) {
+      Error("TMinuitMinimizer::SetDebug","invalid TMinuit pointer. Need to call first SetFunction and SetVariable");
+      return false;
+   }
+   int ierr = 0;
+   double arglist[1];
+   arglist[0] = 1;
+   if (on) 
+      fMinuit->mnexcm("SET DEBUG",arglist,1,ierr);
+   else
+      fMinuit->mnexcm("SET NODEBUG",arglist,1,ierr);
+
+   return (ierr == 0); 
+}
 //    } // end namespace Fit
 
 // } // end namespace ROOT

--- a/math/minuit2/src/Minuit2Minimizer.cxx
+++ b/math/minuit2/src/Minuit2Minimizer.cxx
@@ -564,6 +564,12 @@ bool  Minuit2Minimizer::ExamineMinimum(const ROOT::Minuit2::FunctionMinimum & mi
 
    fStatus = 0;
    std::string txt;
+   if (!min.HasPosDefCovar() ) {
+      // this happens normally when Hesse failed
+      // it can happen in case MnSeed failed (see ROOT-9522)
+      txt = "Covar is not pos def";
+      fStatus = 5;
+   }
    if (min.HasMadePosDefCovar() ) {
       txt = "Covar was made pos def";
       fStatus = 1;
@@ -592,7 +598,7 @@ bool  Minuit2Minimizer::ExamineMinimum(const ROOT::Minuit2::FunctionMinimum & mi
       if (fStatus == 0) {
          // this should not happen
          txt = "unknown failure";
-         fStatus = 5;
+         fStatus = 6;
       }
       std::string msg = "Minimization did NOT converge, " + txt;
       MN_INFO_MSG2("Minuit2Minimizer::Minimize",msg);

--- a/math/minuit2/src/NegativeG2LineSearch.cxx
+++ b/math/minuit2/src/NegativeG2LineSearch.cxx
@@ -109,6 +109,10 @@ MinimumState NegativeG2LineSearch::operator()(const MnFcn& fcn, const MinimumSta
    MinimumError err(mat, 1.);
    double edm = VariableMetricEDMEstimator().Estimate(dgrad, err);
 
+   if (edm < 0) {
+      err = MinimumError(mat, MinimumError::MnNotPosDef() ); 
+   }
+
    return MinimumState(pa, err, dgrad, edm, fcn.NumOfCalls());
 }
 


### PR DESCRIPTION
In this case we return an invalid function minimum. 

This should fix ROOT-9522 which shows that when minimizing concave functions (like -x^2) we returned a wrong minimum as valid 