### PR TITLE
Use NEW behavior for CMake policy CMP0051

### DIFF
--- a/interpreter/llvm/src/CMakeLists.txt
+++ b/interpreter/llvm/src/CMakeLists.txt
@@ -6,14 +6,14 @@ if(POLICY CMP0022)
   cmake_policy(SET CMP0022 NEW) # automatic when 2.8.12 is required
 endif()
 
-if (POLICY CMP0051)
-  # CMake 3.1 and higher include generator expressions of the form
-  # $<TARGETLIB:obj> in the SOURCES property.  These need to be
-  # stripped everywhere that access the SOURCES property, so we just
-  # defer to the OLD behavior of not including generator expressions
-  # in the output for now.
-  cmake_policy(SET CMP0051 OLD)
-endif()
+# if (POLICY CMP0051)
+#   # CMake 3.1 and higher include generator expressions of the form
+#   # $<TARGETLIB:obj> in the SOURCES property.  These need to be
+#   # stripped everywhere that access the SOURCES property, so we just
+#   # defer to the OLD behavior of not including generator expressions
+#   # in the output for now.
+#   cmake_policy(SET CMP0051 OLD)
+# endif()
 
 if(POLICY CMP0057)
   cmake_policy(SET CMP0057 NEW)


### PR DESCRIPTION
We need to move LLVM in ROOT to use the new behavior of policy CMP0051
as it will be removed soon and the warning below will become an error:

CMake Deprecation Warning at interpreter/llvm/src/CMakeLists.txt:15 (cmake_policy):
  The OLD behavior for policy CMP0051 will be removed from a future version
  of CMake.

  The cmake-policies(7) manual explains that the OLD behaviors of all
  policies are deprecated and that a policy should be set to OLD only under
  specific short-term circumstances.  Projects should be ported to the NEW
  behavior and not rely on setting a policy to OLD.