### PR TITLE
[cxxmodules] TCling needs to autoparse headers which it has no module for:

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1162,8 +1162,6 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
 #ifdef R__USE_CXXMODULES
    useCxxModules = true;
 #endif
-   if (useCxxModules)
-     fHeaderParsingOnDemand = false;
 
    llvm::install_fatal_error_handler(&exceptionErrorHandler);
 
@@ -1832,7 +1830,7 @@ void TCling::RegisterModule(const char* modulename,
       } // if (dyLibName)
    } // if (!lateRegistration)
 
-   if (hasHeaderParsingOnDemand && fwdDeclsCode){
+   if (hasHeaderParsingOnDemand && fwdDeclsCode && !hasCxxModule){
       // We now parse the forward declarations. All the classes are then modified
       // in order for them to have an external lexical storage.
       std::string fwdDeclsCodeLessEnums;

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1971,7 +1971,11 @@ void TCling::RegisterModule(const char* modulename,
 
    bool ModuleWasSuccessfullyLoaded = false;
    if (hasCxxModule) {
-      std::string ModuleName = llvm::StringRef(modulename).substr(3).str();
+      std::string ModuleName = modulename;
+      // Remove lib from modulename if any
+      if (llvm::StringRef(modulename).startswith("lib"))
+         ModuleName = modulename + 3;
+
       // FIXME: We should only complain for modules which we know to exist. For example, we should not complain about
       // modules such as GenVector32 because it needs to fall back to GenVector.
       ModuleWasSuccessfullyLoaded = LoadModule(ModuleName, *fInterpreter, /*Complain=*/ false);

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -1090,6 +1090,7 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
     // modules because we would miss the annotations that rootcling creates.
     if (COpts.CxxModules) {
       auto& HS = CI->getHeaderSearchOpts();
+      utils::AddIncludePaths(".", HS);
       addPrebuiltModulePaths(HS, getPathsFromEnv(getenv("LD_LIBRARY_PATH")));
       addPrebuiltModulePaths(HS, getPathsFromEnv(getenv("DYLD_LIBRARY_PATH")));
       HS.AddPrebuiltModulePath(".");


### PR DESCRIPTION
Fixes roottest/cling/reflex/classVersion_rflx.log.