### PR TITLE
[VecOps] Add RVec helpers for sorting and selecting elements

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -680,11 +680,66 @@ RVec<typename RVec<T>::size_type> Argsort(const RVec<T> &v)
 
 /// Return elements of a vector at given indices
 template <typename T>
-RVec<T> ByIndices(const RVec<T> &v, const RVec<typename RVec<T>::size_type> &i)
+RVec<T> Take(const RVec<T> &v, const RVec<typename RVec<T>::size_type> &i)
 {
-   RVec<T> r(i.size());
-   for (unsigned int k = 0; k < i.size(); k++)
+   using size_type = typename RVec<T>::size_type;
+   const size_type vsize = v.size();
+   const size_type isize = i.size();
+   RVec<T> r(isize);
+   for (size_type k = 0; k < isize; k++)
       r[k] = v[i[k]];
+   return r;
+}
+
+/// Return first elements of a vector if n>0 and last elements if n<0
+template <typename T>
+RVec<T> Take(const RVec<T> &v, const int n)
+{
+   using size_type = typename RVec<T>::size_type;
+   const size_type size = v.size();
+   const size_type absn = std::abs(n);
+   if (absn > size) {
+      std::stringstream ss;
+      ss << "Try to take " << absn << " elements but vector has only size " << size << ".";
+      throw std::runtime_error(ss.str());
+   }
+   RVec<T> r(absn);
+   if (n < 0) {
+      for (size_type k = 0; k < absn; k++)
+         r[k] = v[size - absn + k];
+   } else {
+      for (size_type k = 0; k < absn; k++)
+         r[k] = v[k];
+   }
+   return r;
+}
+
+/// Return copy of reversed vector
+template <typename T>
+RVec<T> Reversed(const RVec<T> &v)
+{
+   RVec<T> r(v);
+   std::reverse(r.begin(), r.end());
+   return r;
+}
+
+/// Return copy of vector with elements sorted in ascending order
+template <typename T>
+RVec<T> Sorted(const RVec<T> &v)
+{
+   RVec<T> r(v);
+   std::sort(r.begin(), r.end());
+   return r;
+}
+
+/// Return copy of vector with elements sorted based on comparison operator.
+/// The comparison operator has to fullfill the same requirements than the
+/// operator taken by std::sort.
+template <typename T, typename Compare>
+RVec<T> Sorted(const RVec<T> &v, Compare &&c)
+{
+   RVec<T> r(v);
+   std::sort(r.begin(), r.end(), std::forward<Compare>(c));
    return r;
 }
 

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -627,11 +627,83 @@ TEST(VecOps, Argsort)
    CheckEqual(i, ref);
 }
 
-TEST(VecOps, ByIndices)
+TEST(VecOps, TakeIndices)
 {
    ROOT::VecOps::RVec<int> v0{2, 0, 1};
-   ROOT::VecOps::RVec<typename ROOT::VecOps::RVec<int>::size_type> i{1, 2, 0};
-   auto v1 = ByIndices(v0, i);
+   ROOT::VecOps::RVec<typename ROOT::VecOps::RVec<int>::size_type> i{1, 2, 0, 0, 0};
+   auto v1 = Take(v0, i);
+   ROOT::VecOps::RVec<int> ref{0, 1, 2, 2, 2};
+   CheckEqual(v1, ref);
+}
+
+TEST(VecOps, TakeFirst)
+{
+   ROOT::VecOps::RVec<int> v0{0, 1, 2};
+
+   auto v1 = Take(v0, 2);
+   ROOT::VecOps::RVec<int> ref{0, 1};
+   CheckEqual(v1, ref);
+
+   // Corner-case: Take zero entries
+   auto v2 = Take(v0, 0);
+   ROOT::VecOps::RVec<int> none{};
+   CheckEqual(v2, none);
+}
+
+TEST(VecOps, TakeLast)
+{
+   ROOT::VecOps::RVec<int> v0{0, 1, 2};
+
+   auto v1 = Take(v0, -2);
+   ROOT::VecOps::RVec<int> ref{1, 2};
+   CheckEqual(v1, ref);
+
+   // Corner-case: Take zero entries
+   auto v2 = Take(v0, 0);
+   ROOT::VecOps::RVec<int> none{};
+   CheckEqual(v2, none);
+}
+
+TEST(VecOps, Reversed)
+{
+   ROOT::VecOps::RVec<int> v0{0, 1, 2};
+
+   auto v1 = Reversed(v0);
+   ROOT::VecOps::RVec<int> ref{2, 1, 0};
+   CheckEqual(v1, ref);
+
+   // Corner-case: Empty vector
+   ROOT::VecOps::RVec<int> none{};
+   auto v2 = Reversed(none);
+   CheckEqual(v2, none);
+}
+
+TEST(VecOps, Sorted)
+{
+   ROOT::VecOps::RVec<int> v{2, 0, 1};
+
+   // Sort in ascending order
+   auto v1 = Sorted(v);
    ROOT::VecOps::RVec<int> ref{0, 1, 2};
    CheckEqual(v1, ref);
+
+   // Corner-case: Empty vector
+   ROOT::VecOps::RVec<int> none{};
+   auto v2 = Sorted(none);
+   CheckEqual(v2, none);
+}
+
+TEST(VecOps, SortedWithComparisonOperator)
+{
+   ROOT::VecOps::RVec<int> v{2, 0, 1};
+
+   // Sort with comparison operator
+   auto v1 = Sorted(v, std::greater<int>());
+   ROOT::VecOps::RVec<int> ref{2, 1, 0};
+   CheckEqual(v1, ref);
+
+   // Corner-case: Empty vector
+   ROOT::VecOps::RVec<int> none{};
+   auto v2 = Sorted(none, std::greater<int>());
+   CheckEqual(v2, none);
 }

--- a/tutorials/vecops/vo004_SortAndSelect.C
+++ b/tutorials/vecops/vo004_SortAndSelect.C
@@ -1,0 +1,53 @@
+/// \file
+/// \ingroup tutorial_vecops
+/// \notebook -nodraw
+/// In this tutorial we learn how elements of an RVec can be easily sorted and
+/// selected.
+///
+/// \macro_code
+///
+/// \date August 2018
+/// \author Stefan Wunsch
+
+using namespace ROOT::VecOps;
+
+void vo004_SortAndSelect()
+{
+   // Because RVec implements an iterator, the class is fully compatible with
+   // the sorting algorithms in the standard library.
+   RVec<double> v1{6., 4., 5.};
+   RVec<double> v2(v1);
+   std::sort(v2.begin(), v2.end());
+   std::cout << "Sort vector " << v1 << ": " << v2 << std::endl;
+
+   // For convenience, ROOT implements helpers, e.g., to get a sorted copy of
+   // an RVec ...
+   auto v3 = Sorted(v1);
+   std::cout << "Sort vector " << v1 << ": " << v3 << std::endl;
+
+   // ... or a reversed copy of an RVec.
+   auto v4 = Reversed(v1);
+   std::cout << "Reverse vector " << v1 << ": " << v4 << std::endl;
+
+   // Helpers are provided to get the indices that sort the vector and to
+   // select these indices from an RVec.
+   auto i = Argsort(v1);
+   std::cout << "Indices that sort the vector " << v1 << ": " << i << std::endl;
+
+   RVec<double> v5{9., 7., 8.};
+   auto v6 = Take(v5, i);
+   std::cout << "Sort vector " << v5 << " respective to the previously"
+             << " determined indices: " << v6 << std::endl;
+
+   // Take can also be used to get the first or last elements of an RVec.
+   auto v7 = Take(v1, 2);
+   auto v8 = Take(v1, -2);
+   std::cout << "Take the two first and last elements of vector " << v1
+             << ": " << v7 << ", " << v8 << std::endl;
+
+   // Because the helpers return a copy of the input, you can chain the operations
+   // conveniently.
+   auto v9 = Reversed(Take(Sorted(v1), -2));
+   std::cout << "Sort the vector " << v1 << ", take the two last elements and "
+             << "reverse the selection: " << v9 << std::endl;
+}

--- a/tutorials/vecops/vo004_SortAndSelect.py
+++ b/tutorials/vecops/vo004_SortAndSelect.py
@@ -1,0 +1,49 @@
+## \file
+## \ingroup tutorial_vecops
+## \notebook -nodraw
+## In this tutorial we learn how elements of an RVec can be easily sorted and
+## selected.
+##
+## \macro_code
+##
+## \date August 2018
+## \author Stefan Wunsch
+
+import ROOT
+from ROOT.VecOps import RVec, Argsort, Take, Sorted, Reversed
+
+# RVec can be sorted in Python with the inbuilt sorting function because
+# PyROOT implements a Python iterator
+v1 = RVec("double")(3)
+v1[0], v1[1], v1[2] = 6, 4, 5
+v2 = sorted(v1)
+print("Sort vector {}: {}".format(v1, v2))
+
+# For convenience, ROOT implements helpers, e.g., to get a sorted copy of
+# an RVec ...
+v2 = Sorted(v1);
+print("Sort vector {}: {}".format(v1, v2))
+
+# ... or a reversed copy of an RVec.
+v2 = Reversed(v1);
+print("Reverse vector {}: {}".format(v1, v2))
+
+# Helpers are provided to get the indices that sort the vector and to
+# select these indices from an RVec.
+v2 = Argsort(v1)
+print("Indices that sort the vector {}: {}".format(v1, v2))
+
+v3 = RVec("double")(3)
+v3[0], v3[1], v3[2] = 9, 7, 8
+v4 = Take(v3, v2)
+print("Sort vector {} respective to the previously determined indices: {}".format(v3, v4))
+
+# Take can also be used to get the first or last elements of an RVec.
+v2 = Take(v1, 2)
+v3 = Take(v1, -2)
+print("Take the two first and last elements of vector {}: {}, {}".format(v1, v2, v3))
+
+# Because the VecOps helpers return a copy of the input, you can chain the operations
+# conveniently.
+v2 = Reversed(Take(Sorted(v1), -2))
+print("Sort the vector {}, take the two last elements and reverse the selection: {}".format(v1, v2))


### PR DESCRIPTION
Introduce helpers for `VecOps::RVec` to sort and select the elements:

1. `Take`: Take elements either at given indices or first/last elements
4. `Sorted`: Sort either in ascending order or by given comparison operator, e.g., `std::greater<T>`.
5. `Reversed`: Reverse elements of `RVec`

On purpose, all operations are designed to be *not* inplace (in comparison to the STL API), because we want most often a copy, e.g., for `RDataFrame::Define` calls.

Main target is to support convenient selection of elements in physics object selection. E.g. sort the pt vector, and take the two largest values in descending order:

```cpp
>>> using namespace ROOT::VecOps;
>>> RVec<float> pt = {200, 50, 20, 100, 10};
>>> auto selection = Reversed(Take(Sorted(pt), 2))
(ROOT::VecOps::RVec<float> &) { 200, 100 }
```