### PR TITLE
Fix memory leak in GetStreamInfoListImpl

### DIFF
--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -133,6 +133,7 @@ The structure of a directory is shown in TDirectoryFile::TDirectoryFile
 #include "TThreadSlots.h"
 #include "TGlobal.h"
 #include "TMath.h"
+#include "ROOT/RMakeUnique.hxx"
 
 using std::sqrt;
 
@@ -1330,9 +1331,9 @@ std::pair<TList *, Int_t> TFile::GetStreamerInfoListImpl(bool lookupSICache)
    TList *list = 0;
    if (fSeekInfo) {
       TDirectory::TContext ctxt(this); // gFile and gDirectory used in ReadObj
-      TKey *key = new TKey(this);
-      char *buffer = new char[fNbytesInfo+1];
-      char *buf    = buffer;
+      auto key = std::make_unique<TKey>(this);
+      auto buffer = std::make_unique<char[]>(fNbytesInfo+1);
+      auto buf = buffer.get();
       Seek(fSeekInfo);
       if (ReadBuffer(buf,fNbytesInfo)) {
          // ReadBuffer returns kTRUE in case of failure.
@@ -1352,10 +1353,8 @@ std::pair<TList *, Int_t> TFile::GetStreamerInfoListImpl(bool lookupSICache)
       (void) lookupSICache;
 #endif
       key->ReadKeyBuffer(buf);
-      list = dynamic_cast<TList*>(key->ReadObjWithBuffer(buffer));
+      list = dynamic_cast<TList*>(key->ReadObjWithBuffer(buffer.get()));
       if (list) list->SetOwner();
-      delete [] buffer;
-      delete key;
    } else {
       list = (TList*)Get("StreamerInfo"); //for versions 2.26 (never released)
    }


### PR DESCRIPTION
The program used for finding the leaks is as follows:

```cpp
#include "ROOT/RDataFrame.hxx"
#include "TSystem.h"

bool memory() {
  ProcInfo_t info;
  gSystem->GetProcInfo(&info);
  printf(" res  memory = %g Mbytes\n", info.fMemResident / 1024.);
  return true;
}

constexpr auto file = "small.root";

void test() {
  ROOT::EnableImplicitMT(1);
  auto df = ROOT::RDataFrame("Events", file);
  df.Filter("Muon_pt.size()>0")
      .Define("pt", "Muon_pt[0]")
      .Filter(memory)
      .Snapshot("Events", "output.root", {"pt"});
}

int main() { test(); }
```

The valgrind output before the fix:

```
==20802== LEAK SUMMARY:
==20802==    definitely lost: 54,488 bytes in 222 blocks
==20802==    indirectly lost: 23,816 bytes in 199 blocks
==20802==      possibly lost: 71,130 bytes in 610 blocks
==20802==    still reachable: 74,920,340 bytes in 100,971 blocks
==20802==                       of which reachable via heuristic:
==20802==                         newarray           : 25,424 bytes in 49 blocks
==20802==                         multipleinheritance: 1,048 bytes in 3 blocks
==20802==         suppressed: 6,366,063 bytes in 65,508 blocks
```

And the valgrind output after the fix:

```
==22182== LEAK SUMMARY:
==22182==    definitely lost: 6,424 bytes in 202 blocks
==22182==    indirectly lost: 23,936 bytes in 200 blocks
==22182==      possibly lost: 61,230 bytes in 610 blocks
==22182==    still reachable: 74,911,268 bytes in 100,857 blocks
==22182==                       of which reachable via heuristic:
==22182==                         newarray           : 25,424 bytes in 49 blocks
==22182==                         multipleinheritance: 928 bytes in 2 blocks
==22182==         suppressed: 6,374,775 bytes in 65,619 blocks
```