### PR TITLE
Fix memory leak in TTreeReaderArray

### DIFF
--- a/tree/treeplayer/inc/TTreeReaderArray.h
+++ b/tree/treeplayer/inc/TTreeReaderArray.h
@@ -33,7 +33,7 @@ namespace Internal {
    public:
       TTreeReaderArrayBase(TTreeReader* reader, const char* branchname,
                            TDictionary* dict):
-         TTreeReaderValueBase(reader, branchname, dict), fImpl(0) {}
+         TTreeReaderValueBase(reader, branchname, dict) {}
 
       std::size_t GetSize() const { return fImpl->GetSize(GetProxy()); }
       Bool_t IsEmpty() const { return !GetSize(); }
@@ -50,7 +50,7 @@ namespace Internal {
                                            TString& contentTypeName,
                                            TDictionary* &dict);
 
-      TVirtualCollectionReader* fImpl; // Common interface to collections
+      std::unique_ptr<TVirtualCollectionReader> fImpl; // Common interface to collections
 
       // FIXME: re-introduce once we have ClassDefInline!
       //ClassDef(TTreeReaderArrayBase, 0);//Accessor to member of an object stored in a collection

--- a/tree/treeplayer/src/TTreeReaderArray.cxx
+++ b/tree/treeplayer/src/TTreeReaderArray.cxx
@@ -24,6 +24,7 @@
 #include "TTreeReader.h"
 #include "TGenCollectionProxy.h"
 #include "TRegexp.h"
+#include "ROOT/RMakeUnique.hxx"
 
 #include <memory>
 
@@ -539,13 +540,13 @@ void ROOT::Internal::TTreeReaderArrayBase::SetImpl(TBranch* branch, TLeaf* myLea
 
    if (myLeaf){
       if (!myLeaf->GetLeafCount()){
-         fImpl = new TLeafReader(this);
+         fImpl = std::make_unique<TLeafReader>(this);
       }
       else {
          TString leafFullName = myLeaf->GetBranch()->GetName();
          leafFullName += ".";
          leafFullName += myLeaf->GetLeafCount()->GetName();
-         fImpl = new TLeafParameterSizeReader(fTreeReader, leafFullName.Data(), this);
+         fImpl = std::make_unique<TLeafParameterSizeReader>(fTreeReader, leafFullName.Data(), this);
       }
       fSetupStatus = kSetupMatchLeaf;
    }
@@ -564,39 +565,39 @@ void ROOT::Internal::TTreeReaderArrayBase::SetImpl(TBranch* branch, TLeaf* myLea
          if (fSetupStatus == kSetupInternalError)
             fSetupStatus = kSetupMatch;
          if (element->IsA() == TStreamerSTL::Class()){
-            fImpl = new TSTLReader();
+            fImpl = std::make_unique<TSTLReader>();
          }
          else if (element->IsA() == TStreamerObject::Class()){
             //fImpl = new TObjectArrayReader(); // BArray[12]
 
             if (element->GetClass() == TClonesArray::Class()){
-               fImpl = new TClonesReader();
+               fImpl = std::make_unique<TClonesReader>();
             }
             else {
-               fImpl = new TArrayFixedSizeReader(element->GetArrayLength());
+               fImpl = std::make_unique<TArrayFixedSizeReader>(element->GetArrayLength());
             }
          }
          else if (element->IsA() == TStreamerLoop::Class()) {
-            fImpl = new TArrayParameterSizeReader(fTreeReader, branchElement->GetBranchCount()->GetName());
+            fImpl = std::make_unique<TArrayParameterSizeReader>(fTreeReader, branchElement->GetBranchCount()->GetName());
          }
          else if (element->IsA() == TStreamerBasicType::Class()){
             if (branchElement->GetType() == TBranchElement::kSTLMemberNode){
-               fImpl = new TBasicTypeArrayReader();
+               fImpl = std::make_unique<TBasicTypeArrayReader>();
             }
             else if (branchElement->GetType() == TBranchElement::kClonesMemberNode){
-               fImpl = new TBasicTypeClonesReader(element->GetOffset());
+               fImpl = std::make_unique<TBasicTypeClonesReader>(element->GetOffset());
             }
             else {
-               fImpl = new TArrayFixedSizeReader(element->GetArrayLength());
-               ((TObjectArrayReader*)fImpl)->SetBasicTypeSize(((TDataType*)fDict)->Size());
+               fImpl = std::make_unique<TArrayFixedSizeReader>(element->GetArrayLength());
+               ((TObjectArrayReader*)fImpl.get())->SetBasicTypeSize(((TDataType*)fDict)->Size());
             }
          }
          else if (element->IsA() == TStreamerBasicPointer::Class()) {
-            fImpl = new TArrayParameterSizeReader(fTreeReader, branchElement->GetBranchCount()->GetName());
-            ((TArrayParameterSizeReader*)fImpl)->SetBasicTypeSize(((TDataType*)fDict)->Size());
+            fImpl = std::make_unique<TArrayParameterSizeReader>(fTreeReader, branchElement->GetBranchCount()->GetName());
+            ((TArrayParameterSizeReader*)fImpl.get())->SetBasicTypeSize(((TDataType*)fDict)->Size());
          }
          else if (element->IsA() == TStreamerBase::Class()){
-            fImpl = new TClonesReader();
+            fImpl = std::make_unique<TClonesReader>();
          } else {
             Error("TTreeReaderArrayBase::SetImpl()",
                   "Cannot read branch %s: unhandled streamer element type %s",
@@ -606,7 +607,7 @@ void ROOT::Internal::TTreeReaderArrayBase::SetImpl(TBranch* branch, TLeaf* myLea
       }
       else { // We are at root node?
          if (branchElement->GetClass()->GetCollectionProxy()){
-            fImpl = new TCollectionLessSTLReader(branchElement->GetClass()->GetCollectionProxy());
+            fImpl = std::make_unique<TCollectionLessSTLReader>(branchElement->GetClass()->GetCollectionProxy());
          }
       }
    } else if (branch->IsA() == TBranch::Class()) {
@@ -621,12 +622,12 @@ void ROOT::Internal::TTreeReaderArrayBase::SetImpl(TBranch* branch, TLeaf* myLea
       if (fSetupStatus == kSetupInternalError)
          fSetupStatus = kSetupMatch;
       if (!sizeLeaf) {
-         fImpl = new TArrayFixedSizeReader(size);
+         fImpl = std::make_unique<TArrayFixedSizeReader>(size);
       }
       else {
-         fImpl = new TArrayParameterSizeReader(fTreeReader, sizeLeaf->GetName());
+         fImpl = std::make_unique<TArrayParameterSizeReader>(fTreeReader, sizeLeaf->GetName());
       }
-      ((TObjectArrayReader*)fImpl)->SetBasicTypeSize(((TDataType*)fDict)->Size());
+      ((TObjectArrayReader*)fImpl.get())->SetBasicTypeSize(((TDataType*)fDict)->Size());
    } else if (branch->IsA() == TBranchClones::Class()) {
       Error("TTreeReaderArrayBase::SetImpl", "Support for branches of type TBranchClones not implemented");
       fSetupStatus = kSetupInternalError;
@@ -635,7 +636,7 @@ void ROOT::Internal::TTreeReaderArrayBase::SetImpl(TBranch* branch, TLeaf* myLea
       fSetupStatus = kSetupInternalError;
    } else if (branch->IsA() == TBranchSTL::Class()) {
       Error("TTreeReaderArrayBase::SetImpl", "Support for branches of type TBranchSTL not implemented");
-      fImpl = new TSTLReader();
+      fImpl = std::make_unique<TSTLReader>();
       fSetupStatus = kSetupInternalError;
    } else if (branch->IsA() == TBranchRef::Class()) {
       Error("TTreeReaderArrayBase::SetImpl", "Support for branches of type TBranchRef not implemented");


### PR DESCRIPTION
Second fix after #2361 with same test program.

Valgrind output before fix (but with fix of #2361):

```
==22182== LEAK SUMMARY:
==22182==    definitely lost: 6,424 bytes in 202 blocks
==22182==    indirectly lost: 23,936 bytes in 200 blocks
==22182==      possibly lost: 61,230 bytes in 610 blocks
==22182==    still reachable: 74,911,268 bytes in 100,857 blocks
==22182==                       of which reachable via heuristic:
==22182==                         newarray           : 25,424 bytes in 49 blocks
==22182==                         multipleinheritance: 928 bytes in 2 blocks
==22182==         suppressed: 6,374,775 bytes in 65,619 blocks
```

Valgrind output after fix:

```
==5872== LEAK SUMMARY:
==5872==    definitely lost: 24 bytes in 2 blocks
==5872==    indirectly lost: 56 bytes in 1 blocks
==5872==      possibly lost: 60,990 bytes in 608 blocks
==5872==    still reachable: 74,909,841 bytes in 100,876 blocks
==5872==                       of which reachable via heuristic:
==5872==                         newarray           : 25,424 bytes in 49 blocks
==5872==                         multipleinheritance: 2,136 bytes in 3 blocks
==5872==         suppressed: 6,378,087 bytes in 65,619 blocks
```