### PR TITLE
[cling] Implement clang plugin support.

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -785,36 +785,6 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
     }
   };
 
-
-  static void HandlePlugins(CompilerInstance& CI,
-                         std::vector<std::unique_ptr<ASTConsumer>>& Consumers) {
-    // Copied from Frontend/FrontendAction.cpp.
-    // FIXME: Remove when we switch to the new cling driver.
-    for (const std::string& Path : CI.getFrontendOpts().Plugins) {
-       std::string Error;
-       if (llvm::sys::DynamicLibrary::LoadLibraryPermanently(Path.c_str(),
-                                                             &Error))
-          CI.getDiagnostics().Report(clang::diag::err_fe_unable_to_load_plugin)
-             << Path << Error;
-    }
-
-    // If there are no registered plugins we don't need to wrap the consumer
-    if (FrontendPluginRegistry::begin() == FrontendPluginRegistry::end())
-      return;
-
-    for (auto it = clang::FrontendPluginRegistry::begin(),
-              ie = clang::FrontendPluginRegistry::end();
-         it != ie; ++it) {
-       std::unique_ptr<clang::PluginASTAction> P(it->instantiate());
-       if (P->ParseArgs(CI, CI.getFrontendOpts().PluginArgs[it->getName()])) {
-         std::unique_ptr<ASTConsumer> PluginConsumer
-           = P->CreateASTConsumer(CI, /*InputFile*/ "");
-         Consumers.push_back(std::move(PluginConsumer));
-       }
-       assert(P->getActionType() != clang::PluginASTAction::ReplaceAction);
-    }
-  }
-
   static CompilerInstance*
   createCIImpl(std::unique_ptr<llvm::MemoryBuffer> Buffer,
                const CompilerOptions& COpts, const char* LLVMDir,
@@ -988,7 +958,6 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
     CI->setDiagnostics(Diags.get()); // Diags is ref-counted
     if (!OnlyLex)
       CI->getDiagnosticOpts().ShowColors = cling::utils::ColorizeOutput();
-
 
     // Copied from CompilerInstance::createDiagnostics:
     // Chain in -verify checker, if requested.
@@ -1203,8 +1172,6 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
       SM->pushModuleBuildStack(COpts.ModuleName,
                                FullSourceLoc(SourceLocation(), *SM));
     }
-
-    HandlePlugins(*CI, Consumers);
 
     std::unique_ptr<clang::MultiplexConsumer> multiConsumer(
         new clang::MultiplexConsumer(std::move(Consumers)));

--- a/interpreter/cling/lib/Interpreter/DeclCollector.cpp
+++ b/interpreter/cling/lib/Interpreter/DeclCollector.cpp
@@ -102,13 +102,14 @@ namespace cling {
     }
   };
 
-  void DeclCollector::Setup(IncrementalParser* IncrParser, ASTConsumer* Consumer,
+  void DeclCollector::Setup(IncrementalParser* IncrParser,
+                            std::unique_ptr<ASTConsumer> Consumer,
                             clang::Preprocessor& PP) {
     m_IncrParser = IncrParser;
-    m_Consumer = Consumer;
+    m_Consumer = std::move(Consumer);
     PP.addPPCallbacks(std::unique_ptr<PPCallbacks>(new PPAdapter(this)));
   }
-  
+
   bool DeclCollector::comesFromASTReader(DeclGroupRef DGR) const {
     assert(!DGR.isNull() && "DeclGroupRef is Null!");
     assertHasTransaction(m_CurTransaction);

--- a/interpreter/cling/lib/Interpreter/DeclCollector.h
+++ b/interpreter/cling/lib/Interpreter/DeclCollector.h
@@ -52,9 +52,9 @@ namespace cling {
     ///
     std::vector<std::unique_ptr<WrapperTransformer>> m_WrapperTransformers;
 
-    IncrementalParser* m_IncrParser;
-    clang::ASTConsumer* m_Consumer;
-    Transaction* m_CurTransaction;
+    IncrementalParser* m_IncrParser = nullptr;
+    std::unique_ptr<clang::ASTConsumer> m_Consumer;
+    Transaction* m_CurTransaction = nullptr;
 
     /// Whether Transform() is active; prevents recursion.
     bool m_Transforming = false;
@@ -74,8 +74,7 @@ namespace cling {
     ASTTransformer::Result TransformDecl(clang::Decl* D) const;
 
   public:
-    DeclCollector() :
-      m_IncrParser(0), m_Consumer(0), m_CurTransaction(0) {}
+    DeclCollector() {}
 
     virtual ~DeclCollector();
 
@@ -89,7 +88,8 @@ namespace cling {
         WT->SetConsumer(this);
     }
 
-    void Setup(IncrementalParser* IncrParser, ASTConsumer* Consumer,
+    void Setup(IncrementalParser* IncrParser,
+               std::unique_ptr<ASTConsumer> Consumer,
                clang::Preprocessor& PP);
 
     /// \{

--- a/interpreter/cling/lib/Interpreter/IncrementalParser.h
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.h
@@ -27,6 +27,7 @@ namespace llvm {
 }
 
 namespace clang {
+  class ASTConsumer;
   class CodeGenerator;
   class CompilerInstance;
   class DiagnosticConsumer;
@@ -81,11 +82,11 @@ namespace cling {
     std::deque<Transaction*> m_Transactions;
 
     ///\brief Number of created modules.
-    unsigned m_ModuleNo;
+    unsigned m_ModuleNo = 0;
 
     ///\brief Code generator
     ///
-    std::unique_ptr<clang::CodeGenerator> m_CodeGen;
+    clang::CodeGenerator* m_CodeGen = nullptr;
 
     ///\brief Pool of reusable block-allocated transactions.
     ///
@@ -120,8 +121,8 @@ namespace cling {
                     bool isChildInterpreter);
     clang::CompilerInstance* getCI() const { return m_CI.get(); }
     clang::Parser* getParser() const { return m_Parser.get(); }
-    clang::CodeGenerator* getCodeGenerator() const { return m_CodeGen.get(); }
-    bool hasCodeGenerator() const { return m_CodeGen.get(); }
+    clang::CodeGenerator* getCodeGenerator() const { return m_CodeGen; }
+    bool hasCodeGenerator() const { return m_CodeGen; }
     clang::SourceLocation getLastMemoryBufferEndLoc() const;
 
     /// \{

--- a/interpreter/cling/test/Plugins/Simple.C
+++ b/interpreter/cling/test/Plugins/Simple.C
@@ -1,0 +1,9 @@
+// RUN: cat %s | %cling -fplugin=%cling_obj_root/tools/plugins/example/libclingDemoPlugin%shlibext | FileCheck %s
+
+// CHECK:Action::ParseArgs
+// CHECK-NEXT:Action::CreateASTConsumer
+
+int dummy = 15;
+
+// CHECK-NEXT:PluginConsumer::HandleTopLevelDecl
+.q

--- a/interpreter/cling/test/lit.cfg
+++ b/interpreter/cling/test/lit.cfg
@@ -261,6 +261,7 @@ if not lit_config.quiet:
     lit_config.note('using cling: %r' % config.cling)
 
 #Start cling with nologo
+config.substitutions.append(('%cling_obj_root', cling_obj_root))
 config.substitutions.append( ('%cling', config.cling + ' --nologo') )
 if not os.getenv('CLING'):
   # Add a substitution for the builds generated include dir before install

--- a/interpreter/cling/tools/CMakeLists.txt
+++ b/interpreter/cling/tools/CMakeLists.txt
@@ -14,6 +14,4 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../lib/UserInterface/textinput
   add_subdirectory(demo)
 endif()
 
-if(CLING_BUILD_PLUGINS)
-  add_subdirectory(plugins)
-endif()
+add_subdirectory(plugins)

--- a/interpreter/cling/tools/plugins/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/CMakeLists.txt
@@ -1,45 +1,31 @@
-#------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------
 # CLING - the C++ LLVM-based InterpreterG :)
 #
 # This file is dual-licensed: you can choose to license it under the University
 # of Illinois Open Source License or the GNU Lesser General Public License. See
 # LICENSE.TXT for details.
-#------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------
+if (CLING_INCLUDE_TESTS OR CLING_BUILD_PLUGINS)
+  add_subdirectory(example)
+endif()
 
-## If we drop a compatible cmake project in this folder we should automatically
-## pick it up and build it.
-#function(LISTSUBDIRS result curdir)
-#  file(GLOB children RELATIVE ${curdir} ${curdir}/*)
-#  set(dirlist "")
-#  foreach(child ${children})
-#    if(IS_DIRECTORY ${curdir}/${child})
-#      if(APPEND dirlist ${child})
-#    endif()
-#  endforeach()
-#  set(${result} ${dirlist} PARENT_SCOPE)
-#endfunction()
+if (CLING_BUILD_PLUGINS)
+#  # If we drop a compatible cmake project in this folder we should automatically
+#  # pick it up and build it.
+#  function(LISTSUBDIRS result curdir)
+#    file(GLOB children RELATIVE ${curdir} ${curdir}/*)
+#    set(dirlist "")
+#    foreach(child ${children})
+#      if(IS_DIRECTORY ${curdir}/${child})
+#        list(APPEND dirlist ${child})
+#      endif()
+#      endforeach()
+#      set(${result} ${dirlist} PARENT_SCOPE)
+#  endfunction()
 #
-#LISTSUBDIRS(subdirs ${CMAKE_CURRENT_SOURCE_DIR}/plugins/)
-#foreach(subdir ${SUBDIRS})
-#  add_subdirectory(${subdir})
-#endforeach()
-
-ExternalProject_Add(
-  clad
-  GIT_REPOSITORY https://github.com/vgvassilev/clad.git
-  GIT_TAG master
-  UPDATE_COMMAND ""
-  CMAKE_ARGS -G ${CMAKE_GENERATOR}
-             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-             -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-             -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
-             -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-             -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-             -DCMAKE_INSTALL_PREFIX=${CLING_PLUGIN_INSTALL_PREFIX}
-             -DCLAD_PATH_TO_LLVM_BUILD=${LLVM_DIR}
-  #BUILD_BYPRODUCTS ${_gtest_byproducts}
-  # Wrap download, configure and build steps in a script to log output
-  LOG_DOWNLOAD ON
-  LOG_CONFIGURE ON
-  LOG_BUILD ON
-  )
+#  LISTSUBDIRS(subdirs ${CMAKE_CURRENT_SOURCE_DIR}/plugins/)
+#  foreach(subdir ${SUBDIRS})
+#    add_subdirectory(${subdir})
+#  endforeach()
+  add_subdirectory(clad)
+endif(CLING_BUILD_PLUGINS)

--- a/interpreter/cling/tools/plugins/clad/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/clad/CMakeLists.txt
@@ -1,0 +1,28 @@
+#-------------------------------------------------------------------------------
+# CLING - the C++ LLVM-based InterpreterG :)
+#
+# This file is dual-licensed: you can choose to license it under the University
+# of Illinois Open Source License or the GNU Lesser General Public License. See
+# LICENSE.TXT for details.
+#-------------------------------------------------------------------------------
+
+ExternalProject_Add(
+  clad
+  GIT_REPOSITORY https://github.com/vgvassilev/clad.git
+  GIT_TAG master
+  UPDATE_COMMAND ""
+  CMAKE_ARGS -G ${CMAKE_GENERATOR}
+             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+             -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+             -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
+             -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+             -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+             -DCMAKE_INSTALL_PREFIX=${CLING_PLUGIN_INSTALL_PREFIX}
+             -DCLAD_PATH_TO_LLVM_BUILD=${LLVM_DIR}
+  #BUILD_BYPRODUCTS ${_gtest_byproducts}
+  # Wrap download, configure and build steps in a script to log output
+  LOG_DOWNLOAD ON
+  LOG_CONFIGURE ON
+  LOG_BUILD ON
+  )
+

--- a/interpreter/cling/tools/plugins/example/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/example/CMakeLists.txt
@@ -1,0 +1,17 @@
+#-------------------------------------------------------------------------------
+# CLING - the C++ LLVM-based InterpreterG :)
+#
+# This file is dual-licensed: you can choose to license it under the University
+# of Illinois Open Source License or the GNU Lesser General Public License. See
+# LICENSE.TXT for details.
+#-------------------------------------------------------------------------------
+
+add_cling_library(clingDemoPlugin SHARED DemoPlugin.cpp)
+
+set_target_properties(clingDemoPlugin PROPERTIES  LIBRARY_OUTPUT_DIRECTORY ".")
+if(APPLE)
+  target_link_libraries(clingDemoPlugin PUBLIC -Wl,-bind_at_load -Wl,-undefined -Wl,dynamic_lookup)
+elseif(NOT MSVC)
+  target_link_libraries(clingDemoPlugin PUBLIC -Wl,--unresolved-symbols=ignore-in-object-files)
+endif()
+

--- a/interpreter/cling/tools/plugins/example/DemoPlugin.cpp
+++ b/interpreter/cling/tools/plugins/example/DemoPlugin.cpp
@@ -1,0 +1,43 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+// author:  Vassil Vassilev <vvasilev@cern.ch>
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+#include "clang/Frontend/FrontendPluginRegistry.h"
+
+struct PluginConsumer : public clang::ASTConsumer {
+  virtual bool HandleTopLevelDecl(clang::DeclGroupRef DGR) {
+    llvm::outs() << "PluginConsumer::HandleTopLevelDecl\n";
+    return true; // Happiness
+  }
+};
+
+template<typename ConsumerType>
+class Action : public clang::PluginASTAction {
+protected:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance&,
+                    llvm::StringRef /*InFile*/) override {
+    llvm::outs() << "Action::CreateASTConsumer\n";
+    return std::unique_ptr<clang::ASTConsumer>(new ConsumerType());
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &,
+                 const std::vector<std::string>&) override {
+    llvm::outs() << "Action::ParseArgs\n";
+    // return false; // Tells clang not to create the plugin.
+    return true; // Happiness
+  }
+
+  PluginASTAction::ActionType getActionType() override {
+    return AddBeforeMainAction;
+  }
+};
+
+// Register the PluginASTAction in the registry.
+static clang::FrontendPluginRegistry::Add<Action<PluginConsumer> >
+X("DemoPlugin", "Used to test plugin mechanisms in cling.");


### PR DESCRIPTION
Clang allows third party shared libraries to provide user-defined
extensions. For example, a custom libTemplateInstantiation.so can
visualize all template instantiation chains in clang. To enable it
one needs to pass a set of options such as -fplugin.

Cling should be able to inherently work with clang plugins. However,
cling still does not make full use of the clang driver where the plugin
setup is handled.

This patch enables plugins in cling and extends them in some aspects.
In particular, cling allows loading of plugins from shared libraries
but also if they are linked to the same library where cling is. This is
very useful in cases where cling runs itself in a shared library (eg
libCling). Users of libCling (such as ROOT) prefer to keep all llvm and
clang related symbols local to avoid symbol clashes if there is another
version of clang and llvm linked against a package. This can be done by
dlopen-ing libCling with RTLD_LOCAL visibility mode. Then the only way
for clang plugins to work in this scenario is to be linked to libCling.

Patch by Aleksandr Efremov (@efremale) and me.