### PR TITLE
[ROOT-9550] Revert "Do not include internal PostgreSQL header"

### DIFF
--- a/sql/pgsql/inc/TPgSQLStatement.h
+++ b/sql/pgsql/inc/TPgSQLStatement.h
@@ -15,6 +15,7 @@
 #include "TSQLStatement.h"
 
 #include <libpq-fe.h>
+#include <pg_config.h> // to get PG_VERSION_NUM
 #ifdef USE_LDAP
 #undef USE_LDAP
 #endif


### PR DESCRIPTION
This reverts commit 6fa43c88b40e058f0c1dfeed9f25f852ee57a6ea. That commit breaks support of old versions of PostgreSQL (9.x). Since the classic build has been removed, this change should be reverted.

More information: [ROOT-9550](https://sft.its.cern.ch/jira/browse/ROOT-9550).