### PR TITLE
TRef weak scaling

### DIFF
--- a/README/ReleaseNotes/v614/index.md
+++ b/README/ReleaseNotes/v614/index.md
@@ -286,6 +286,7 @@ Upgrade JSROOT to v5.4.1. Following new features implemented:
   - Show how to inspect a `TCutFlowReport` object.
 
 ## Class Reference Guide
+
   - Replace low resolution images with bigger ones more suited for modern screens.
 
 ## Build System and Configuration

--- a/README/ReleaseNotes/v616/index.md
+++ b/README/ReleaseNotes/v616/index.md
@@ -62,6 +62,9 @@ Instead, use `Root.CompressionAlgorithm` which sets the compression algorithm ac
 * 3: legacy, please don't use
 * 4: LZ4 (the current default)
 
+### TRef
+
+* Improve thread scability of TRef. Creating and looking up a lot of TRef from the same processID now has practically perfect weak scaling.
 
 ## I/O Libraries
 

--- a/core/base/inc/TProcessID.h
+++ b/core/base/inc/TProcessID.h
@@ -80,7 +80,8 @@ protected:
    static TProcessID *fgPID;      //Pointer to current session ProcessID
    static TObjArray  *fgPIDs;     //Table of ProcessIDs
    static TExMap     *fgObjPIDs;  //Table pointer to pids
-   static UInt_t      fgNumber;   //Referenced objects count
+
+   static std::atomic_uint      fgNumber;   //Referenced objects count
 
 public:
    TProcessID();

--- a/core/base/src/TProcessID.cxx
+++ b/core/base/src/TProcessID.cxx
@@ -53,9 +53,13 @@ of TUUIDs.
 
 TObjArray  *TProcessID::fgPIDs   = 0; //pointer to the list of TProcessID
 TProcessID *TProcessID::fgPID    = 0; //pointer to the TProcessID of the current session
-UInt_t      TProcessID::fgNumber = 0; //Current referenced object instance count
+std::atomic_uint TProcessID::fgNumber(0); //Current referenced object instance count
 TExMap     *TProcessID::fgObjPIDs= 0; //Table (pointer,pids)
 ClassImp(TProcessID);
+
+static std::atomic<TProcessID *> gIsValidCache;
+using PIDCacheContent_t = std::pair<Int_t, TProcessID*>;
+static std::atomic<PIDCacheContent_t *> gGetProcessWithUIDCache;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return hash value for this object.
@@ -90,7 +94,17 @@ TProcessID::~TProcessID()
 {
    delete fObjects;
    fObjects = 0;
-   R__LOCKGUARD(gROOTMutex);
+
+   TProcessID *This = this; // We need a referencable value for the 1st argument
+   gIsValidCache.compare_exchange_strong(This, nullptr);
+
+   auto current = gGetProcessWithUIDCache.load();
+   if (current && current->second == this) {
+      gGetProcessWithUIDCache.compare_exchange_strong(current, nullptr);
+      delete current;
+   }
+
+   R__WRITE_LOCKGUARD(ROOT::gCoreMutex);
    fgPIDs->Remove(this);
 }
 
@@ -99,7 +113,7 @@ TProcessID::~TProcessID()
 
 TProcessID *TProcessID::AddProcessID()
 {
-   R__LOCKGUARD(gROOTMutex);
+   R__WRITE_LOCKGUARD(ROOT::gCoreMutex);
 
    if (fgPIDs && fgPIDs->GetEntriesFast() >= 65534) {
       if (fgPIDs->GetEntriesFast() == 65534) {
@@ -138,7 +152,7 @@ TProcessID *TProcessID::AddProcessID()
 
 UInt_t TProcessID::AssignID(TObject *obj)
 {
-   R__LOCKGUARD(gROOTMutex);
+   R__WRITE_LOCKGUARD(ROOT::gCoreMutex);
 
    UInt_t uid = obj->GetUniqueID() & 0xffffff;
    if (obj == fgPID->GetObjectWithID(uid)) return uid;
@@ -187,7 +201,7 @@ void TProcessID::CheckInit()
 
 void TProcessID::Cleanup()
 {
-   R__LOCKGUARD(gROOTMutex);
+   R__WRITE_LOCKGUARD(ROOT::gCoreMutex);
 
    fgPIDs->Delete();
    gROOT->GetListOfCleanups()->Remove(fgPIDs);
@@ -248,16 +262,30 @@ UInt_t TProcessID::GetNProcessIDs()
 
 TProcessID *TProcessID::GetProcessWithUID(UInt_t uid, const void *obj)
 {
-   R__LOCKGUARD(gROOTMutex);
 
    Int_t pid = (uid>>24)&0xff;
    if (pid==0xff) {
       // Look up the pid in the table (pointer,pid)
       if (fgObjPIDs==0) return 0;
       ULong_t hash = Void_Hash(obj);
+
+      R__READ_LOCKGUARD(ROOT::gCoreMutex);
       pid = fgObjPIDs->GetValue(hash,(Long_t)obj);
+      return (TProcessID*)fgPIDs->At(pid);
+   } else {
+      auto current = gGetProcessWithUIDCache.load();
+      if (current && current->first == pid)
+         return current->second;
+
+      R__READ_LOCKGUARD(ROOT::gCoreMutex);
+      auto res = (TProcessID*)fgPIDs->At(pid);
+
+      auto next = new PIDCacheContent_t(pid, res);
+      auto old = gGetProcessWithUIDCache.exchange(next);
+      delete old;
+
+      return res;
    }
-   return (TProcessID*)fgPIDs->At(pid);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -329,11 +357,20 @@ TObjArray *TProcessID::GetPIDs()
 
 Bool_t TProcessID::IsValid(TProcessID *pid)
 {
-   R__LOCKGUARD(gROOTMutex);
+   if (gIsValidCache == pid)
+      return kTRUE;
+
+   R__READ_LOCKGUARD(ROOT::gCoreMutex);
 
    if (fgPIDs==0) return kFALSE;
-   if (fgPIDs->IndexOf(pid) >= 0) return kTRUE;
-   if (pid == (TProcessID*)gROOT->GetUUIDs())  return kTRUE;
+   if (fgPIDs->IndexOf(pid) >= 0) {
+      gIsValidCache = pid;
+      return kTRUE;
+   }
+    if (pid == (TProcessID*)gROOT->GetUUIDs()) {
+      gIsValidCache = pid;
+      return kTRUE;
+   }
    return kFALSE;
 }
 
@@ -376,6 +413,7 @@ void TProcessID::RecursiveRemove(TObject *obj)
    if (!obj->TestBit(kIsReferenced)) return;
    UInt_t uid = obj->GetUniqueID() & 0xffffff;
    if (obj == GetObjectWithID(uid)) {
+      R__WRITE_LOCKGUARD(ROOT::gCoreMutex);
       if (fgObjPIDs) {
          ULong64_t hash = Void_Hash(obj);
          fgObjPIDs->Remove(hash,(Long64_t)obj);

--- a/core/base/src/TRef.cxx
+++ b/core/base/src/TRef.cxx
@@ -384,6 +384,7 @@ TObject *TRef::GetObject() const
    //the reference may be in the TRefTable
    TRefTable *table = TRefTable::GetRefTable();
    if (table) {
+      R__WRITE_LOCKGUARD(ROOT::gCoreMutex);
       table->SetUID(uid, fPID);
       table->Notify();
    }
@@ -397,6 +398,7 @@ TObject *TRef::GetObject() const
       Int_t execid = TestBits(0xff0000);
       if (execid > 0) {
          execid = execid>>16;
+         R__WRITE_LOCKGUARD(ROOT::gCoreMutex);
          TExec *exec = (TExec*)fgExecs->At(execid-1);
          if (exec) {
             //we expect the object to be returned via TRef::SetStaticObject


### PR DESCRIPTION
Improve thread scability of TRef. Creating and looking up a lot of TRef from the same processID now has practically perfect weak scaling.

Use Read/Write lock where relevant.
    
Cache the last result of TProcessID::IsValid and TProcessID::GetProcessWithUID as
most often the same PID will be used for most of the process lifetime.
