### PR TITLE
[WIP] Make multithreading work with independent tbb::task_arena instead of a tbb::task_scheduler singleton

### DIFF
--- a/core/base/inc/TROOT.h
+++ b/core/base/inc/TROOT.h
@@ -30,6 +30,7 @@
 #include "RConfigure.h"
 
 #include <atomic>
+#include <thread>
 
 class TClass;
 class TCanvas;
@@ -91,7 +92,7 @@ namespace ROOT {
    void EnableThreadSafety();
    /// \brief Enable ROOT's implicit multi-threading for all objects and methods that provide an internal
    /// parallelisation mechanism.
-   void EnableImplicitMT(UInt_t numthreads = 0);
+   void EnableImplicitMT(UInt_t numthreads = std::thread::hardware_concurrency());
    void DisableImplicitMT();
    Bool_t IsImplicitMTEnabled();
    UInt_t GetImplicitMTPoolSize();

--- a/core/imt/CMakeLists.txt
+++ b/core/imt/CMakeLists.txt
@@ -8,7 +8,7 @@ set(sources base.cxx TTaskGroup.cxx)
 if (imt)
   include_directories(SYSTEM ${TBB_INCLUDE_DIRS})
 
-  set(headers ${headers} ROOT/TPoolManager.hxx ROOT/TThreadExecutor.hxx ROOT/TFuture.hxx)
+  set(headers ${headers} ROOT/TThreadExecutor.hxx ROOT/TFuture.hxx)
   set(sources ${sources} TImplicitMT.cxx TThreadExecutor.cxx TPoolManager.cxx G__Imt.cxx)
   ROOT_GENERATE_DICTIONARY(G__Imt ${headers} STAGE1
                            MODULE Imt LINKDEF LinkDef.h

--- a/core/imt/inc/LinkDef.h
+++ b/core/imt/inc/LinkDef.h
@@ -5,7 +5,6 @@
 #pragma link off all functions;
 
 // Only for the autoload, autoparse. No IO of these classes is foreseen!
-#pragma link C++ class ROOT::Internal::TPoolManager-;
 #pragma link C++ class ROOT::TThreadExecutor-;
 #pragma link C++ class ROOT::Experimental::TTaskGroup-;
 

--- a/core/imt/inc/ROOT/TThreadExecutor.hxx
+++ b/core/imt/inc/ROOT/TThreadExecutor.hxx
@@ -30,6 +30,8 @@
 #include <memory>
 #include <numeric>
 
+namespace tbb{namespace interface7{class task_arena;}}
+
 namespace ROOT {
 
    class TThreadExecutor: public TExecutor<TThreadExecutor> {
@@ -40,6 +42,8 @@ namespace ROOT {
 
       TThreadExecutor(TThreadExecutor &) = delete;
       TThreadExecutor &operator=(TThreadExecutor &) = delete;
+
+      ~TThreadExecutor();
 
       template<class F>
       void Foreach(F func, unsigned nTimes);
@@ -104,6 +108,7 @@ namespace ROOT {
       auto SeqReduce(const std::vector<T> &objs, R redfunc) -> decltype(redfunc(objs));
 
       std::shared_ptr<ROOT::Internal::TPoolManager> fSched = nullptr;
+      std::unique_ptr<tbb::interface7::task_arena> fArena;
    };
 
    /************ TEMPLATE METHODS IMPLEMENTATION ******************/

--- a/core/imt/inc/ROOT/TThreadExecutor.hxx
+++ b/core/imt/inc/ROOT/TThreadExecutor.hxx
@@ -23,7 +23,6 @@
 #else
 
 #include "ROOT/TExecutor.hxx"
-#include "ROOT/TPoolManager.hxx"
 #include "TROOT.h"
 #include "TError.h"
 #include <functional>
@@ -105,9 +104,8 @@ namespace ROOT {
       float  ParallelReduce(const std::vector<float> &objs, const std::function<float(float a, float b)> &redfunc);
       template<class T, class R>
       auto SeqReduce(const std::vector<T> &objs, R redfunc) -> decltype(redfunc(objs));
-      struct Arena;
-      std::shared_ptr<ROOT::Internal::TPoolManager> fSched = nullptr;
-      std::unique_ptr<Arena> fArena;
+      class Sched;
+      std::unique_ptr<Sched> fScheduler;
    };
 
    /************ TEMPLATE METHODS IMPLEMENTATION ******************/

--- a/core/imt/inc/ROOT/TThreadExecutor.hxx
+++ b/core/imt/inc/ROOT/TThreadExecutor.hxx
@@ -88,6 +88,8 @@ namespace ROOT {
       template<class T, class BINARYOP> auto Reduce(const std::vector<T> &objs, BINARYOP redfunc) -> decltype(redfunc(objs.front(), objs.front()));
       template<class T, class R> auto Reduce(const std::vector<T> &objs, R redfunc) -> decltype(redfunc(objs));
 
+      unsigned GetPoolSize();
+
    protected:
       template<class F, class R, class Cond = noReferenceCond<F>>
       auto Map(F func, unsigned nTimes, R redfunc, unsigned nChunks) -> std::vector<typename std::result_of<F()>::type>;

--- a/core/imt/inc/ROOT/TThreadExecutor.hxx
+++ b/core/imt/inc/ROOT/TThreadExecutor.hxx
@@ -30,7 +30,6 @@
 #include <memory>
 #include <numeric>
 
-namespace tbb{namespace interface7{class task_arena;}}
 
 namespace ROOT {
 
@@ -106,9 +105,9 @@ namespace ROOT {
       float  ParallelReduce(const std::vector<float> &objs, const std::function<float(float a, float b)> &redfunc);
       template<class T, class R>
       auto SeqReduce(const std::vector<T> &objs, R redfunc) -> decltype(redfunc(objs));
-
+      struct Arena;
       std::shared_ptr<ROOT::Internal::TPoolManager> fSched = nullptr;
-      std::unique_ptr<tbb::interface7::task_arena> fArena;
+      std::unique_ptr<Arena> fArena;
    };
 
    /************ TEMPLATE METHODS IMPLEMENTATION ******************/

--- a/core/imt/src/TPoolManager.hxx
+++ b/core/imt/src/TPoolManager.hxx
@@ -46,32 +46,25 @@ namespace ROOT {
       \ingroup TPoolManager
       \brief A manager for the scheduler behind ROOT multithreading operations.
 
-      A manager for the multithreading scheduler that solves undefined behaviours and interferences between
-      classes and functions that made direct use of the scheduler, such as EnableImplicitMT() ot TThreadExecutor.
+      A lifetime manager for the multithreading scheduler in ROOT that provides bookkeeping and automatic
+      termination when not in use.
       */
 
       class TPoolManager {
       public:
-         friend std::shared_ptr<TPoolManager> GetPoolManager(UInt_t nThreads);
-         /// Returns the number of threads running when the scheduler has been instantiated within ROOT.
-         static UInt_t GetPoolSize();
+         friend std::shared_ptr<TPoolManager> GetPoolManager();
          /// Terminates the scheduler instantiated within ROOT.
          ~TPoolManager();
       private:
          ///Initializes the scheduler within ROOT. If the scheduler has already been initialized by the
          /// user before invoking the constructor it won't change its behaviour and it won't terminate it,
          /// but it will still keep record of the number of threads passed as a parameter.
-         TPoolManager(UInt_t nThreads = 0);
-         static UInt_t fgPoolSize;
+         TPoolManager();
          bool mustDelete = true;
          tbb::task_scheduler_init *fSched = nullptr;
       };
-      /// Get a shared pointer to the manager. Initialize the manager with nThreads if not active. If active,
-      /// the number of threads, even if specified otherwise, will remain the same.
-      ///
-      /// The number of threads will be able to change calling the factory function again after the last
-      /// remaining shared_ptr owning the object is destroyed or reasigned, which will trigger the destructor of the manager.
-      std::shared_ptr<TPoolManager> GetPoolManager(UInt_t nThreads = 0);
+      /// Get a shared pointer to the manager. Initialize the manager with if not active.
+      std::shared_ptr<TPoolManager> GetPoolManager();
    }
 }
 

--- a/core/imt/src/TThreadExecutor.cxx
+++ b/core/imt/src/TThreadExecutor.cxx
@@ -78,9 +78,10 @@ namespace ROOT {
 
    class TThreadExecutor::Sched {
    public:
-      Sched(unsigned nThreads) : fPoolPtr(ROOT::Internal::GetPoolManager()), fArena(std::make_unique<tbb::task_arena>(nThreads)){}
+      Sched(unsigned nThreads) : fPoolPtr(ROOT::Internal::GetPoolManager()), fArena(std::make_unique<tbb::task_arena>(nThreads)), fNThreads(nThreads){}
       std::shared_ptr<ROOT::Internal::TPoolManager> fPoolPtr;
       std::unique_ptr<tbb::task_arena> fArena;
+      unsigned fNThreads;
    };
 
    //////////////////////////////////////////////////////////////////////////
@@ -134,5 +135,9 @@ namespace ROOT {
             return std::accumulate(range.begin(), range.end(), init, redfunc);
          }, redfunc);});
       return res;
+   }
+
+   unsigned TThreadExecutor::GetPoolSize(){
+      return fScheduler->fNThreads;
    }
 }

--- a/core/imt/src/TThreadExecutor.cxx
+++ b/core/imt/src/TThreadExecutor.cxx
@@ -1,5 +1,7 @@
 #include "ROOT/TThreadExecutor.hxx"
+#include "TPoolManager.hxx"
 #include "ROOT/RMakeUnique.hxx"
+#include "TROOT.h"
 #include "tbb/tbb.h"
 //#include "tbb/task_arena.h"
 
@@ -74,31 +76,40 @@
 
 namespace ROOT {
 
-   struct TThreadExecutor::Arena{
-      std::unique_ptr<tbb::task_arena> arena;
+   class TThreadExecutor::Sched {
+   public:
+      Sched(unsigned nThreads) : fPoolPtr(ROOT::Internal::GetPoolManager()), fArena(std::make_unique<tbb::task_arena>(nThreads)){}
+      std::shared_ptr<ROOT::Internal::TPoolManager> fPoolPtr;
+      std::unique_ptr<tbb::task_arena> fArena;
    };
 
    //////////////////////////////////////////////////////////////////////////
    /// Class constructor.
    /// If the scheduler is active, gets a pointer to it.
    /// If not, initializes the pool of threads with the number of logical threads supported by the hardware.
-   TThreadExecutor::TThreadExecutor(): TThreadExecutor::TThreadExecutor(tbb::task_scheduler_init::default_num_threads()) {}
+   TThreadExecutor::TThreadExecutor(){
+      if(IsImplicitMTEnabled()) {
+         fScheduler = std::make_unique<Sched>(GetImplicitMTPoolSize());
+      } else
+      {
+         fScheduler = std::make_unique<Sched>(tbb::task_scheduler_init::default_num_threads()); 
+      }
+   }
+   
    //////////////////////////////////////////////////////////////////////////
    /// Class constructor.
    /// nThreads is the number of threads that will be spawned. If the scheduler is active (ImplicitMT enabled, another TThreadExecutor instance),
    /// it won't change the number of threads.
    TThreadExecutor::TThreadExecutor(UInt_t nThreads)
    {
-      fSched = ROOT::Internal::GetPoolManager(nThreads);
-      fArena = std::make_unique<Arena>();
-      fArena->arena = std::make_unique<tbb::task_arena>(ROOT::Internal::TPoolManager::GetPoolSize());
+      fScheduler = std::make_unique<Sched>(nThreads);
    }
 
    TThreadExecutor::~TThreadExecutor()=default;
 
    void TThreadExecutor::ParallelFor(unsigned int start, unsigned int end, unsigned step, const std::function<void(unsigned int i)> &f)
    {
-      fArena->arena->execute( [&](){
+      fScheduler->fArena->execute( [&](){
          tbb::parallel_for(start, end, step, f);
       });
    }
@@ -106,7 +117,7 @@ namespace ROOT {
    double TThreadExecutor::ParallelReduce(const std::vector<double> &objs, const std::function<double(double a, double b)> &redfunc)
    {
       double res{};
-      fArena->arena->execute( [&](){
+      fScheduler->fArena->execute( [&](){
          res = tbb::parallel_reduce(tbb::blocked_range<decltype(objs.begin())>(objs.begin(), objs.end()), double{},
          [redfunc](tbb::blocked_range<decltype(objs.begin())> const & range, double init) {
             return std::accumulate(range.begin(), range.end(), init, redfunc);
@@ -117,7 +128,7 @@ namespace ROOT {
    float TThreadExecutor::ParallelReduce(const std::vector<float> &objs, const std::function<float(float a, float b)> &redfunc)
    {
       float res{};
-      fArena->arena->execute( [&](){
+      fScheduler->fArena->execute( [&](){
          res =  tbb::parallel_reduce(tbb::blocked_range<decltype(objs.begin())>(objs.begin(), objs.end()), float{},
          [redfunc](tbb::blocked_range<decltype(objs.begin())> const & range, float init) {
             return std::accumulate(range.begin(), range.end(), init, redfunc);

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -857,16 +857,9 @@ inline T TF1::GradientParTempl(Int_t ipar, const T *x, Double_t eps)
    TF1 *func = (TF1 *)this;
    Double_t *parameters = GetParameters();
 
-   // If we are in a multi-threading scenario, make this function thread-safe
-   // using a copy of the parameters vector.
-   // TODO: Check that GetImplicitMTPoolSize is the best method to check that we
-   // have more than one thread accesing the resources.
-   std::vector<Double_t> parametersCopy;
-   if (ROOT::GetImplicitMTPoolSize() != 0) {
-      parametersCopy.resize(GetNpar());
-      std::copy(parameters, parameters + GetNpar(), parametersCopy.begin());
-      parameters = parametersCopy.data();
-   }
+   // Copy parameters for thread safety
+   std::vector<Double_t> parametersCopy(parameters, parameters+GetNpar());
+   parameters = parametersCopy.data();
 
    Double_t al, bl, h2;
    T f1, f2, g1, g2, d0, d2;

--- a/math/mathcore/inc/Fit/FitUtil.h
+++ b/math/mathcore/inc/Fit/FitUtil.h
@@ -365,7 +365,7 @@ namespace FitUtil {
    */
    double EvaluatePoissonBinPdf(const IModelFunction & func, const BinData & data, const double * x, unsigned int ipoint, double * g = 0);
 
-   unsigned setAutomaticChunking(unsigned nEvents);
+   unsigned setAutomaticChunking(unsigned nEvents, unsigned nThreads);
 
    template<class T>
    struct Evaluate {
@@ -465,7 +465,7 @@ namespace FitUtil {
 #ifdef R__USE_IMT
          } else if (executionPolicy == ROOT::Fit::ExecutionPolicy::kMultithread) {
             ROOT::TThreadExecutor pool;
-            auto chunks = nChunks != 0 ? nChunks : setAutomaticChunking(data.Size() / vecSize);
+            auto chunks = nChunks != 0 ? nChunks : setAutomaticChunking(data.Size() / vecSize, pool.GetPoolSize());
             res = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, data.Size() / vecSize), redFunction, chunks);
 #endif
          } else {
@@ -640,7 +640,7 @@ namespace FitUtil {
 #ifdef R__USE_IMT
          } else if (executionPolicy == ROOT::Fit::ExecutionPolicy::kMultithread) {
             ROOT::TThreadExecutor pool;
-            auto chunks = nChunks != 0 ? nChunks : setAutomaticChunking( numVectors);
+            auto chunks = nChunks != 0 ? nChunks : setAutomaticChunking( numVectors, pool.GetPoolSize());
             resArray = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, data.Size() / vecSize), redFunction, chunks);
 #endif
          } else {
@@ -844,7 +844,7 @@ namespace FitUtil {
 #ifdef R__USE_IMT
          } else if (executionPolicy == ROOT::Fit::ExecutionPolicy::kMultithread) {
             ROOT::TThreadExecutor pool;
-            auto chunks = nChunks != 0 ? nChunks : setAutomaticChunking(data.Size() / vecSize);
+            auto chunks = nChunks != 0 ? nChunks : setAutomaticChunking(data.Size() / vecSize, pool.GetPoolSize());
             res = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, data.Size() / vecSize), redFunction, chunks);
 #endif
          } else {
@@ -1016,7 +1016,7 @@ namespace FitUtil {
 #ifdef R__USE_IMT
          else if (executionPolicy == ROOT::Fit::ExecutionPolicy::kMultithread) {
             ROOT::TThreadExecutor pool;
-            auto chunks = nChunks != 0 ? nChunks : setAutomaticChunking(numVectors);
+            auto chunks = nChunks != 0 ? nChunks : setAutomaticChunking(numVectors, pool.GetPoolSize());
             gVec = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, numVectors), redFunction, chunks);
          }
 #endif
@@ -1199,7 +1199,7 @@ namespace FitUtil {
 #ifdef R__USE_IMT
          else if (executionPolicy == ROOT::Fit::ExecutionPolicy::kMultithread) {
             ROOT::TThreadExecutor pool;
-            auto chunks = nChunks != 0 ? nChunks : setAutomaticChunking(numVectors);
+            auto chunks = nChunks != 0 ? nChunks : setAutomaticChunking(numVectors, pool.GetPoolSize());
             gVec = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, numVectors), redFunction, chunks);
          }
 #endif
@@ -1349,7 +1349,7 @@ namespace FitUtil {
 #ifdef R__USE_IMT
          else if (executionPolicy == ROOT::Fit::ExecutionPolicy::kMultithread) {
             ROOT::TThreadExecutor pool;
-            auto chunks = nChunks != 0 ? nChunks : setAutomaticChunking(numVectors);
+            auto chunks = nChunks != 0 ? nChunks : setAutomaticChunking(numVectors, pool.GetPoolSize());
             gVec = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, numVectors), redFunction, chunks);
          }
 #endif

--- a/math/mathcore/src/FitUtil.cxx
+++ b/math/mathcore/src/FitUtil.cxx
@@ -391,7 +391,7 @@ namespace ROOT {
 #ifdef R__USE_IMT
   } else if(executionPolicy == ROOT::Fit::ExecutionPolicy::kMultithread) {
     ROOT::TThreadExecutor pool;
-    auto chunks = nChunks !=0? nChunks: setAutomaticChunking(data.Size());
+    auto chunks = nChunks !=0? nChunks: setAutomaticChunking(data.Size(), pool.GetPoolSize());
     res = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, n), redFunction, chunks);
 #endif
 //   } else if(executionPolicy == ROOT::Fit::kMultitProcess){
@@ -803,7 +803,7 @@ void FitUtil::EvaluateChi2Gradient(const IModelFunction &f, const BinData &data,
 #ifdef R__USE_IMT
    else if (executionPolicy == ROOT::Fit::ExecutionPolicy::kMultithread) {
       ROOT::TThreadExecutor pool;
-      auto chunks = nChunks != 0 ? nChunks : setAutomaticChunking(initialNPoints);
+      auto chunks = nChunks != 0 ? nChunks : setAutomaticChunking(initialNPoints, pool.GetPoolSize());
       g = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, initialNPoints), redFunction, chunks);
    }
 #endif
@@ -1043,7 +1043,7 @@ double FitUtil::EvaluateLogL(const IModelFunctionTempl<double> &func, const UnBi
 #ifdef R__USE_IMT
   } else if(executionPolicy == ROOT::Fit::ExecutionPolicy::kMultithread) {
     ROOT::TThreadExecutor pool;
-    auto chunks = nChunks !=0? nChunks: setAutomaticChunking(data.Size());
+    auto chunks = nChunks !=0? nChunks: setAutomaticChunking(data.Size(), pool.GetPoolSize());
     auto resArray = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, n), redFunction, chunks);
     logl=resArray.logvalue;
     sumW=resArray.weight;
@@ -1220,7 +1220,7 @@ void FitUtil::EvaluateLogLGradient(const IModelFunction &f, const UnBinData &dat
 #ifdef R__USE_IMT
    else if (executionPolicy == ROOT::Fit::ExecutionPolicy::kMultithread) {
       ROOT::TThreadExecutor pool;
-      auto chunks = nChunks != 0 ? nChunks : setAutomaticChunking(initialNPoints);
+      auto chunks = nChunks != 0 ? nChunks : setAutomaticChunking(initialNPoints, pool.GetPoolSize());
       g = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, initialNPoints), redFunction, chunks);
    }
 #endif
@@ -1542,7 +1542,7 @@ double FitUtil::EvaluatePoissonLogL(const IModelFunction &func, const BinData &d
 #ifdef R__USE_IMT
    } else if (executionPolicy == ROOT::Fit::ExecutionPolicy::kMultithread) {
       ROOT::TThreadExecutor pool;
-      auto chunks = nChunks != 0 ? nChunks : setAutomaticChunking(data.Size());
+      auto chunks = nChunks != 0 ? nChunks : setAutomaticChunking(data.Size(), pool.GetPoolSize());
       res = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, n), redFunction, chunks);
 #endif
       //   } else if(executionPolicy == ROOT::Fit::kMultitProcess){
@@ -1713,7 +1713,7 @@ void FitUtil::EvaluatePoissonLogLGradient(const IModelFunction &f, const BinData
 #ifdef R__USE_IMT
    else if (executionPolicy == ROOT::Fit::ExecutionPolicy::kMultithread) {
       ROOT::TThreadExecutor pool;
-      auto chunks = nChunks != 0 ? nChunks : setAutomaticChunking(initialNPoints);
+      auto chunks = nChunks != 0 ? nChunks : setAutomaticChunking(initialNPoints, pool.GetPoolSize());
       g = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, initialNPoints), redFunction, chunks);
    }
 #endif
@@ -1744,8 +1744,7 @@ void FitUtil::EvaluatePoissonLogLGradient(const IModelFunction &f, const BinData
 }
 
 
-unsigned FitUtil::setAutomaticChunking(unsigned nEvents){
-      auto ncpu  = ROOT::GetImplicitMTPoolSize();
+unsigned FitUtil::setAutomaticChunking(unsigned nEvents, unsigned ncpu){
       if (nEvents/ncpu < 1000) return ncpu;
       return nEvents/1000;
       //return ((nEvents/ncpu + 1) % 1000) *40 ; //arbitrary formula

--- a/math/mathcore/test/fit/testLogLExecPolicy.cxx
+++ b/math/mathcore/test/fit/testLogLExecPolicy.cxx
@@ -267,7 +267,7 @@ int main()
 {
    TestVector test(200000);
 
-   ROOT::EnableImplicitMT(0);  
+   ROOT::EnableImplicitMT();
    ROOT::EnableThreadSafety();
 
    //Sequential

--- a/tmva/tmva/inc/TMVA/DecisionTree.h
+++ b/tmva/tmva/inc/TMVA/DecisionTree.h
@@ -194,19 +194,6 @@ namespace TMVA {
 
    private:
       // utility functions
-      
-      // Only include parallelizatiion if the multithreading compilation flag is turned on
-      #ifdef R__USE_IMT 
-
-      // number of CPUs available for parallelization
-      UInt_t fNumPoolThreads = 1;
-
-      // #### number of threads in the pool
-      UInt_t GetNumThreadsInPool(){
-         return ROOT::GetImplicitMTPoolSize();
-      };
-
-      #endif
      
       // calculate the Purity out of the number of sig and bkg events collected
       // from individual samples.

--- a/tmva/tmva/inc/TMVA/LossFunction.h
+++ b/tmva/tmva/inc/TMVA/LossFunction.h
@@ -82,11 +82,7 @@ namespace TMVA {
    public:
 
       // constructors
-      LossFunction(){ 
-        #ifdef R__USE_IMT
-        fNumPoolThreads = GetNumThreadsInPool(); 
-        #endif
-      };
+      LossFunction(){};
       virtual ~LossFunction(){};
 
       // abstract methods that need to be implemented
@@ -96,17 +92,6 @@ namespace TMVA {
 
       virtual TString Name() = 0;
       virtual Int_t Id() = 0;
-
-   protected:
-      // #### only use multithreading if the compilation flag is turned on
-      #ifdef R__USE_IMT
-      UInt_t fNumPoolThreads = 1;
-
-      // #### number of threads in the pool
-      UInt_t GetNumThreadsInPool(){
-         return ROOT::GetImplicitMTPoolSize();
-      };
-      #endif
    };
 
    ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/inc/TMVA/MethodBDT.h
+++ b/tmva/tmva/inc/TMVA/MethodBDT.h
@@ -110,11 +110,6 @@ namespace TMVA {
       UInt_t   GetNTrees() const {return fForest.size();}
    private:
 
-      // #### number of threads in the pool
-      UInt_t GetNumThreadsInPool(){
-         return ROOT::GetImplicitMTPoolSize();
-      };
-
       Double_t GetMvaValue( Double_t* err, Double_t* errUpper, UInt_t useNTrees );
       Double_t PrivateGetMvaValue( const TMVA::Event *ev, Double_t* err=0, Double_t* errUpper=0, UInt_t useNTrees=0 );
       void     BoostMonitor(Int_t iTree);
@@ -304,11 +299,7 @@ namespace TMVA {
       // debugging flags
       static const Int_t               fgDebugLevel;     // debug level determining some printout/control plots etc.
 
-      UInt_t fNumPoolThreads = 1;   //! number of threads in pool
-
-
       // for backward compatibility
-
       ClassDef(MethodBDT,0);  // Analysis of Boosted Decision Trees
    };
 

--- a/tmva/tmva/src/DecisionTree.cxx
+++ b/tmva/tmva/src/DecisionTree.cxx
@@ -142,11 +142,7 @@ TMVA::DecisionTree::DecisionTree():
    fAnalysisType   (Types::kClassification),
    fDataSetInfo    (NULL)
 
-{
-   #ifdef R__USE_IMT
-   fNumPoolThreads = GetNumThreadsInPool();
-   #endif
-}
+{}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// constructor specifying the separation type, the min number of
@@ -198,10 +194,6 @@ TMVA::DecisionTree::DecisionTree( TMVA::SeparationBase *sepType, Float_t minSize
    }else{
       fAnalysisType = Types::kClassification;
    }
-
-   #ifdef R__USE_IMT
-   fNumPoolThreads = GetNumThreadsInPool();
-   #endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -418,7 +410,7 @@ UInt_t TMVA::DecisionTree::BuildTree( const std::vector<const TMVA::Event*> & ev
    // err and err2 for regression
 
    // #### Set up prerequisite info for multithreading
-   UInt_t nPartitions = fNumPoolThreads;
+   UInt_t nPartitions = TMVA::Config::Instance().GetThreadExecutor().GetPoolSize();
    auto seeds = ROOT::TSeqU(nPartitions);
 
    // #### need a lambda function to pass to TThreadExecutor::MapReduce (multi-threading)
@@ -1591,7 +1583,7 @@ Double_t TMVA::DecisionTree::TrainNodeFast( const EventConstList & eventSample,
    // #### So we have a loop through the events and a loop through the vars, but no loop through the cuts this is a calculation
 
    TrainNodeInfo nodeInfo(cNvars, nBins);
-   UInt_t nPartitions = fNumPoolThreads;
+   UInt_t nPartitions = TMVA::Config::Instance().GetThreadExecutor().GetPoolSize();
 
    // #### When nbins is low compared to ndata this version of parallelization is faster, so use it 
    // #### Parallelize by chunking the data into the same number of sections as we have processors

--- a/tmva/tmva/src/LossFunction.cxx
+++ b/tmva/tmva/src/LossFunction.cxx
@@ -85,7 +85,7 @@ void TMVA::HuberLossFunction::Init(std::vector<LossFunctionEventInfo>& evs){
 #ifdef R__USE_IMT
 Double_t TMVA::HuberLossFunction::CalculateSumOfWeights(std::vector<LossFunctionEventInfo>& evs){
 
-   UInt_t nPartitions = fNumPoolThreads;
+   UInt_t nPartitions = TMVA::Config::Instance().GetThreadExecutor().GetPoolSize();
    auto seeds = ROOT::TSeqU(nPartitions);
    auto redfunc = [](std::vector<Double_t> a) -> Double_t { return std::accumulate(a.begin(), a.end(), 0); };
 
@@ -281,7 +281,7 @@ void TMVA::HuberLossFunctionBDT::Init(std::map<const TMVA::Event*, LossFunctionE
 #ifdef R__USE_IMT
 void TMVA::HuberLossFunctionBDT::SetTargets(std::vector<const TMVA::Event*>& evs, std::map< const TMVA::Event*, LossFunctionEventInfo >& evinfomap){
 
-   UInt_t nPartitions = fNumPoolThreads;
+   UInt_t nPartitions = TMVA::Config::Instance().GetThreadExecutor().GetPoolSize();
    std::vector<LossFunctionEventInfo> eventvec(evs.size());
 
    auto seedscopy = ROOT::TSeqU(nPartitions);
@@ -466,7 +466,7 @@ void TMVA::LeastSquaresLossFunctionBDT::Init(std::map<const TMVA::Event*, LossFu
 #ifdef R__USE_IMT
 void TMVA::LeastSquaresLossFunctionBDT::SetTargets(std::vector<const TMVA::Event*>& evs, std::map< const TMVA::Event*, LossFunctionEventInfo >& evinfomap){
 
-   UInt_t nPartitions = fNumPoolThreads;
+   UInt_t nPartitions = TMVA::Config::Instance().GetThreadExecutor().GetPoolSize();
    auto seeds = ROOT::TSeqU(nPartitions);
 
    // need a lambda function to pass to TThreadExecutor::Map
@@ -598,7 +598,7 @@ void TMVA::AbsoluteDeviationLossFunctionBDT::Init(std::map<const TMVA::Event*, L
 #ifdef R__USE_IMT
 void TMVA::AbsoluteDeviationLossFunctionBDT::SetTargets(std::vector<const TMVA::Event*>& evs, std::map< const TMVA::Event*, LossFunctionEventInfo >& evinfomap){
 
-   UInt_t nPartitions = fNumPoolThreads;
+   UInt_t nPartitions = TMVA::Config::Instance().GetThreadExecutor().GetPoolSize();
    auto seeds = ROOT::TSeqU(nPartitions);
 
    // need a lambda function to pass to TThreadExecutor::Map

--- a/tmva/tmva/src/MethodBDT.cxx
+++ b/tmva/tmva/src/MethodBDT.cxx
@@ -214,12 +214,6 @@ TMVA::MethodBDT::MethodBDT( const TString& jobName,
    fMonitorNtuple = NULL;
    fSepType = NULL;
    fRegressionLossFunctionBDTG = nullptr;
-
-#ifdef R__USE_IMT
-   fNumPoolThreads = GetNumThreadsInPool();
-#else
-   fNumPoolThreads = 1;
-#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -279,12 +273,6 @@ TMVA::MethodBDT::MethodBDT( DataSetInfo& theData,
    // the result of the previous training (the decision trees) are read in via the
    // weight file. Make sure the the variables correspond to the ones used in
    // creating the "weight"-file
-   
-#ifdef R__USE_IMT
-   fNumPoolThreads = GetNumThreadsInPool();
-#else
-   fNumPoolThreads = 1;
-#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1494,7 +1482,7 @@ void TMVA::MethodBDT::UpdateTargetsRegression(std::vector<const TMVA::Event*>& e
    #ifdef R__USE_IMT // multithreaded version if ROOT was compiled with multithreading 
    if(!first){
      
-      UInt_t nPartitions = fNumPoolThreads;
+      UInt_t nPartitions = TMVA::Config::Instance().GetThreadExecutor().GetPoolSize();
       auto seeds = ROOT::TSeqU(nPartitions);
 
       // need a lambda function to pass to TThreadExecutor::MapReduce


### PR DESCRIPTION
***tl;dr;*** This PR eliminates (almost all of) the dependencies between the implicit and explicit multithreading execution modes in ROOT and allows the co-existance of several TThreadExecutor instances, each one executing on a different number of threads. 

It doesn't change any other behaviour in the eyes of the user.

TO DO:

- [ ] Decide on explicit-implicit MT execution modes' interactions
- [ ] Rename TPoolManager
- [ ] Decide if allowing change of the number of threads when calling several times EnableImplicitMT(x) with a varying x without an intermediate call to DisableImplicitMT()
- [ ] Add warnings 

***********************************************************************************

# Previous behaviour
Previous to this PR, the number of threads was limited during the lifetime of the tbb scheduler, kept alive by TPoolManager as a ```std::shared_ptr``` as long as references to it existed, to the value set on its initialization.

```cpp
//We initialize the scheduler with 4 threads
ROOT::EnableIMT(4);
{ 
    //The scheduler is active, so the value passed to TThreadExecutor
    //is overriden with the number of threads the scheduler has been
    //initialized with (4)
    TThreadExecutor executor(9);
}
ROOT::DisableIMT();

//The scheduler is not alive at this point, 
//so we initialize it with 2 threads
ROOT::EnableIMT(2);
ROOT::TThreadExecutor executor(8);
ROOT::DisableIMT();

executor.MapReduce(...); //Runs on two threads!

ROOT::EnableIMT(3);
//Still two threads! TThreadExecutor instance was keeping the scheduler alive
```
This also implies that given two co-existent instances of TThreadExecutor initialized with a different number of threads, the first one to be initialized forces on the second one the number of threads to work with.

```cpp
ROOT::TThreadExecutor executor(4);
ROOT::TThreadExecutor executor2(8); //will run limited to two threads!!
```
This setup was useful [to avoid undefined behaviours between the implicit and explicit parallelism modes of ROOT](https://indico.cern.ch/event/607814/contributions/2466931/attachments/1409778/2155811/TScheduler.pdf). 


# New behaviour
With this PR, we can separate this two modes of execution. We support the co-existance of several TThreadExecutors, each handling a different number of threads, by initializing the scheduler with the [default number of threads](tbb::task_scheduler_init::default_num_threads) and using a ```tbb::task_arena``` per TThreadExecutor to work with a subset of them instead.


```cpp

//Each of the executor manages its own tbb::task_arena,
//which allows the co-existance of TThreadExecutors
//handling different number of threads.
TThreadExecutor executor1(8); //will run on 8 threads
TThreadExecutor executor2(4); //will run on 4 threads

//IMT keeps a different task Arena too!
ROOT::EnableIMT(4); //4 threads will be used in IMT operations
//executor3 will be initialized with 4 threads for backward
//compatibility. Should we not allow this interaction? 
//Should it be initialized with the default number of threads?
TThreadExecutor executor3; //Implicit constructor. Initialized with 4 threads.
ROOT::DisableIMT();

ROOT::EnableIMT(2); //2 threads will be used in IMT operations
ROOT::TThreadExecutor executor(8); //Explicit number of threads. 
                                   // Will execute on 8 threads.
ROOT::EnableIMT(4); //2 threads will be used in IMT operations
                    //Doesn't change until disabled! 
                    //Should we allow it instead?
ROOT::DisableIMT();
```

We still destroy the scheduler when not in use, and TPoolManager only reason to exist is to manage it's lifetime (needs a name change):

```cpp
{
//TThreadExecutor holds a shared_ptr to the tbb::task_scheduler
TThreadExecutor executor1(8); //will run on 8 threads
}

//executor1 went out of scope and was destroyed together with the scheduler.
//No scheduler active at this point.

ROOT::EnableIMT(4);

//"IMT" holds holds a shared_ptr to the tbb::task_scheduler. Scheduler alive here.
// DisableIMT() will destroy the IMT reference to the scheduler. The reference count of
// the scheduler reaches zero and it gets destroyed.
ROOT::DisableIMT();


ROOT::EnableIMT(4);
TThreadExecutor executor3; //Implicit constructor. Initialized with 4 threads.
ROOT::DisableIMT();

//The scheduler is still alive here because of executor3
```