### PR TITLE
[PyROOT] Port fixes for Python3.7

### DIFF
--- a/bindings/pyroot/src/PyRootType.cxx
+++ b/bindings/pyroot/src/PyRootType.cxx
@@ -100,7 +100,7 @@ namespace {
             if ( ! attr && ! PyRootType_CheckExact( pyclass ) && PyType_Check( pyclass ) ) {
                PyErr_Clear();
                PyObject* pycppname = PyObject_GetAttr( pyclass, PyStrings::gCppName );
-               char* cppname = PyROOT_PyUnicode_AsString(pycppname);
+               const char* cppname = PyROOT_PyUnicode_AsString(pycppname);
                Py_DECREF(pycppname);
                Cppyy::TCppScope_t scope = Cppyy::GetScope( cppname );
                TClass* klass = TClass::GetClass( cppname );

--- a/bindings/pyroot/src/Pythonize.cxx
+++ b/bindings/pyroot/src/Pythonize.cxx
@@ -975,9 +975,7 @@ namespace {
       vi->vi_len = vi->vi_pos = 0;
       vi->vi_len = PySequence_Size( v );
 
-#ifndef R__WIN32 // prevent error LNK2001: unresolved external symbol __PyGC_generation0
-      _PyObject_GC_TRACK( vi );
-#endif
+      PyObject_GC_Track( vi );
       return (PyObject*)vi;
    }
 

--- a/bindings/pyroot/src/TPyROOTApplication.cxx
+++ b/bindings/pyroot/src/TPyROOTApplication.cxx
@@ -98,7 +98,7 @@ Bool_t PyROOT::TPyROOTApplication::CreatePyROOTApplication( Bool_t bLoadLibs )
       if ( argl && 0 < PyList_Size( argl ) ) argc = (int)PyList_GET_SIZE( argl );
       char** argv = new char*[ argc ];
       for ( int i = 1; i < argc; ++i ) {
-         char* argi = PyROOT_PyUnicode_AsString( PyList_GET_ITEM( argl, i ) );
+         char* argi = const_cast< char* >( PyROOT_PyUnicode_AsString( PyList_GET_ITEM( argl, i ) ) );
          if ( strcmp( argi, "-" ) == 0 || strcmp( argi, "--" ) == 0 ) {
          // stop collecting options, the remaining are for the python script
             argc = i;    // includes program name


### PR DESCRIPTION
* PyROOT_PyUnicode_AsString changed return type from char* to const char*
 * Using _PyObject_GC_TRACK results in linking error:
   undefined reference to `_PyGC_generation0'
   The python documentation says this about _PyObject_GC_TRACK:
   "A macro version of PyObject_GC_Track(). It should not be used for
   extension modules."
   So it should not be used. Calling PyObject_GC_Track instead avoids the
   undefined symbol. I also removed the #ifndef R__WIN32 since the
   comment indicates that this was added to avoid the same issue on
   windows. Calling PyObject_GC_Track instead of using the
   _PyObject_GC_TRACK macro should fix the undefined symbol probelem on
   windows too.