### PR TITLE
[cxxmodules] Add support for ACLiC with cxxmodules

### DIFF
--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -3509,6 +3509,11 @@ int TSystem::CompileMacro(const char *filename, Option_t *opt,
    }
    mapfileStream.close();
 
+   bool useCxxModules = false;
+#ifdef R__USE_CXXMODULES
+   useCxxModules = true;
+#endif
+
    // ======= Generate the rootcling command line
    TString rcling = "rootcling";
    PrependPathName(TROOT::GetBinDir(), rcling);
@@ -3516,6 +3521,10 @@ int TSystem::CompileMacro(const char *filename, Option_t *opt,
    rcling += mapfile;
    rcling += "\" -f \"";
    rcling.Append(dict).Append("\" ");
+
+   if (useCxxModules)
+      rcling += " -cxxmodule ";
+
    if (produceRootmap) {
       rcling += " -rml " + libname + " -rmf \"" + libmapfilename + "\" ";
    }

--- a/core/dictgen/res/Scanner.h
+++ b/core/dictgen/res/Scanner.h
@@ -70,7 +70,7 @@ public:
    typedef std::vector<const clang::FunctionDecl*> FunctionColl_t;
    typedef std::vector<const clang::VarDecl*> VariableColl_t;
    typedef std::vector<const clang::EnumDecl*> EnumColl_t;
-   typedef void (*DeclCallback)(const char *type);
+   typedef void (*DeclCallback)(const clang::RecordDecl*);
    typedef std::map<const clang::Decl*,const BaseSelectionRule*> DeclsSelRulesMap_t;
 
    enum class EScanType : char {kNormal, kTwoPasses, kOnePCM};
@@ -112,7 +112,7 @@ public:
 
    // Utility routines.  Most belongs in TMetaUtils and should be shared with rootcling.cxx
    bool GetDeclName(clang::Decl* D, std::string& name) const;
-   bool GetDeclQualName(const clang::Decl* D, std::string& qual_name) const;
+   static bool GetDeclQualName(const clang::Decl* D, std::string& qual_name);
    bool GetFunctionPrototype(clang::Decl* D, std::string& prototype) const;
 
    static const char* fgClangDeclKey; // property key used for CLang declaration objects

--- a/core/dictgen/src/Scanner.cxx
+++ b/core/dictgen/src/Scanner.cxx
@@ -653,9 +653,7 @@ bool RScanner::TreatRecordDeclOrTypedefNameDecl(clang::TypeDecl* typeDecl)
       // them either directly or indirectly.   Any false positive can be
       // resolved by removing the spurrious dependency in the (user) header
       // files.
-      std::string qual_name;
-      GetDeclQualName(recordDecl,qual_name);
-      fRecordDeclCallback(qual_name.c_str());
+      fRecordDeclCallback(recordDecl);
    }
 
    // in case it is implicit or a forward declaration, we are not interested.
@@ -992,7 +990,7 @@ bool RScanner::GetDeclName(clang::Decl* D, std::string& name) const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool RScanner::GetDeclQualName(const clang::Decl* D, std::string& qual_name) const
+bool RScanner::GetDeclQualName(const clang::Decl* D, std::string& qual_name)
 {
    auto N = dyn_cast<const clang::NamedDecl> (D);
 


### PR DESCRIPTION
For ACLiC, we have to generate ".out" files which contains dependency
library name separated by " ". This was done by creating
std::vector<(identifier from rootmap file), (library name)> and comparing this with decls from the input file.
However with modules, we want not to use rootmap files. Module's name
already contains information about library (modulename should be
consistent to the library) so we need not to store all information in
the vector anymore.