### PR TITLE
Fix ROOT-9533 - Custom colors are not saved into .root and .json output

### DIFF
--- a/core/base/src/TColor.cxx
+++ b/core/base/src/TColor.cxx
@@ -1415,7 +1415,7 @@ Bool_t TColor::DefinedColors()
 {
    // After initialization gDefinedColors == 649. If it is bigger it means some new
    // colors have been defined
-   Bool_t hasChanged = (gDefinedColors - gLastDefinedColors) > 50;
+   Bool_t hasChanged = (gDefinedColors - gLastDefinedColors) > 0;
    gLastDefinedColors = gDefinedColors;
    return hasChanged;
 }


### PR DESCRIPTION
Custom colors were not saved in the root files, as described here https://sft.its.cern.ch/jira/browse/ROOT-9533