### PR TITLE
[DF] Add RJittedAction, a wrapper around jitted RActions

### DIFF
--- a/tree/dataframe/inc/ROOT/RDFInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterface.hxx
@@ -1564,10 +1564,10 @@ private:
          RDFInternal::DefineDataSourceColumns(selectedCols, *lm, *fDataSource, std::make_index_sequence<nColumns>(),
                                               RDFInternal::TypeList<BranchTypes...>());
       const auto nSlots = lm->GetNSlots();
-      auto actionPtr = RDFInternal::BuildAction<BranchTypes...>(selectedCols, r, nSlots, *fProxiedPtr, ActionTag{});
-      auto resPtr = MakeResultPtr(r, lm, actionPtr.get());
-      lm->Book(std::move(actionPtr));
-      return resPtr;
+      std::shared_ptr<RDFInternal::RActionBase> actionPtr =
+         RDFInternal::BuildAction<BranchTypes...>(selectedCols, r, nSlots, *fProxiedPtr, ActionTag{});
+      lm->Book(actionPtr);
+      return MakeResultPtr(r, lm, actionPtr.get());
    }
 
    // User did not specify type, do type inference

--- a/tree/dataframe/inc/ROOT/RDFInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterface.hxx
@@ -1590,11 +1590,12 @@ private:
          upcastNode, fImplWeakPtr, fValidCustomColumns, fBranchNames, fDataSource);
       auto resultProxyAndActionPtrPtr = MakeResultPtr(r, lm);
       auto &resultProxy = resultProxyAndActionPtrPtr.first;
-      auto actionPtrPtrOnHeap = RDFInternal::MakeSharedOnHeap(resultProxyAndActionPtrPtr.second);
+      auto jittedAction = std::make_shared<RDFInternal::RJittedAction>(*lm);
       auto toJit =
          RDFInternal::JitBuildAction(validColumnNames, upcastInterface.GetNodeTypeName(), upcastNode.get(),
                                      typeid(std::shared_ptr<ActionResultType>), typeid(ActionTag), rOnHeap, tree,
-                                     nSlots, customColumns, fDataSource, actionPtrPtrOnHeap, lm->GetID());
+                                     nSlots, customColumns, fDataSource, jittedAction.get(), lm->GetID());
+      lm->Book(jittedAction);
       lm->ToJit(toJit);
       return resultProxy;
    }

--- a/tree/dataframe/inc/ROOT/RDFInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterface.hxx
@@ -1564,9 +1564,10 @@ private:
          RDFInternal::DefineDataSourceColumns(selectedCols, *lm, *fDataSource, std::make_index_sequence<nColumns>(),
                                               RDFInternal::TypeList<BranchTypes...>());
       const auto nSlots = lm->GetNSlots();
-      auto actionPtr =
-         RDFInternal::BuildAndBook<BranchTypes...>(selectedCols, r, nSlots, *lm, *fProxiedPtr, ActionTag{});
-      return MakeResultPtr(r, lm, actionPtr);
+      auto actionPtr = RDFInternal::BuildAction<BranchTypes...>(selectedCols, r, nSlots, *fProxiedPtr, ActionTag{});
+      auto resPtr = MakeResultPtr(r, lm, actionPtr.get());
+      lm->Book(std::move(actionPtr));
+      return resPtr;
    }
 
    // User did not specify type, do type inference
@@ -1591,9 +1592,9 @@ private:
       auto &resultProxy = resultProxyAndActionPtrPtr.first;
       auto actionPtrPtrOnHeap = RDFInternal::MakeSharedOnHeap(resultProxyAndActionPtrPtr.second);
       auto toJit =
-         RDFInternal::JitBuildAndBook(validColumnNames, upcastInterface.GetNodeTypeName(), upcastNode.get(),
-                                      typeid(std::shared_ptr<ActionResultType>), typeid(ActionTag), rOnHeap, tree,
-                                      nSlots, customColumns, fDataSource, actionPtrPtrOnHeap, lm->GetID());
+         RDFInternal::JitBuildAction(validColumnNames, upcastInterface.GetNodeTypeName(), upcastNode.get(),
+                                     typeid(std::shared_ptr<ActionResultType>), typeid(ActionTag), rOnHeap, tree,
+                                     nSlots, customColumns, fDataSource, actionPtrPtrOnHeap, lm->GetID());
       lm->ToJit(toJit);
       return resultProxy;
    }

--- a/tree/dataframe/inc/ROOT/RDFInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterface.hxx
@@ -1588,16 +1588,15 @@ private:
       auto upcastNode = RDFInternal::UpcastNode(fProxiedPtr);
       RInterface<TypeTraits::TakeFirstParameter_t<decltype(upcastNode)>> upcastInterface(
          upcastNode, fImplWeakPtr, fValidCustomColumns, fBranchNames, fDataSource);
-      auto resultProxyAndActionPtrPtr = MakeResultPtr(r, lm);
-      auto &resultProxy = resultProxyAndActionPtrPtr.first;
       auto jittedAction = std::make_shared<RDFInternal::RJittedAction>(*lm);
+      auto resPtr = MakeResultPtr(r, lm, jittedAction.get());
       auto toJit =
          RDFInternal::JitBuildAction(validColumnNames, upcastInterface.GetNodeTypeName(), upcastNode.get(),
                                      typeid(std::shared_ptr<ActionResultType>), typeid(ActionTag), rOnHeap, tree,
                                      nSlots, customColumns, fDataSource, jittedAction.get(), lm->GetID());
       lm->Book(jittedAction);
       lm->ToJit(toJit);
-      return resultProxy;
+      return resPtr;
    }
 
    template <typename F, typename CustomColumnType, typename RetType = typename TTraits::CallableTraits<F>::ret_type>

--- a/tree/dataframe/inc/ROOT/RDFInterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterfaceUtils.hxx
@@ -121,8 +121,7 @@ std::unique_ptr<RActionBase> BuildAction(const ColumnNames_t &bl, const std::sha
 {
    using Helper_t = FillTOHelper<ActionResultType>;
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<BranchTypes...>>;
-   auto action = std::make_unique<Action_t>(Helper_t(h, nSlots), bl, prevNode);
-   return action;
+   return std::make_unique<Action_t>(Helper_t(h, nSlots), bl, prevNode);
 }
 
 // Histo1D filling (must handle the special case of distinguishing FillTOHelper and FillHelper
@@ -132,18 +131,15 @@ std::unique_ptr<RActionBase> BuildAction(const ColumnNames_t &bl, const std::sha
 {
    auto hasAxisLimits = HistoUtils<::TH1D>::HasAxisLimits(*h);
 
-   std::unique_ptr<RActionBase> actionBase;
    if (hasAxisLimits) {
       using Helper_t = FillTOHelper<::TH1D>;
       using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<BranchTypes...>>;
-      actionBase = std::make_unique<Action_t>(Helper_t(h, nSlots), bl, prevNode);
+      return std::make_unique<Action_t>(Helper_t(h, nSlots), bl, prevNode);
    } else {
       using Helper_t = FillHelper;
       using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<BranchTypes...>>;
-      actionBase = std::make_unique<Action_t>(Helper_t(h, nSlots), bl, prevNode);
+      return std::make_unique<Action_t>(Helper_t(h, nSlots), bl, prevNode);
    }
-
-   return actionBase;
 }
 
 template <typename... BranchTypes, typename PrevNodeType>
@@ -152,8 +148,7 @@ std::unique_ptr<RActionBase> BuildAction(const ColumnNames_t &bl, const std::sha
 {
    using Helper_t = FillTGraphHelper;
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<BranchTypes...>>;
-   auto action = std::make_unique<Action_t>(Helper_t(g, nSlots), bl, prevNode);
-   return action;
+   return std::make_unique<Action_t>(Helper_t(g, nSlots), bl, prevNode);
 }
 
 // Min action
@@ -163,8 +158,7 @@ std::unique_ptr<RActionBase> BuildAction(const ColumnNames_t &bl, const std::sha
 {
    using Helper_t = MinHelper<ActionResultType>;
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<BranchType>>;
-   auto action = std::make_unique<Action_t>(Helper_t(minV, nSlots), bl, prevNode);
-   return action;
+   return std::make_unique<Action_t>(Helper_t(minV, nSlots), bl, prevNode);
 }
 
 // Max action
@@ -174,8 +168,7 @@ std::unique_ptr<RActionBase> BuildAction(const ColumnNames_t &bl, const std::sha
 {
    using Helper_t = MaxHelper<ActionResultType>;
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<BranchType>>;
-   auto action = std::make_unique<Action_t>(Helper_t(maxV, nSlots), bl, prevNode);
-   return action;
+   return std::make_unique<Action_t>(Helper_t(maxV, nSlots), bl, prevNode);
 }
 
 // Sum action
@@ -185,8 +178,7 @@ std::unique_ptr<RActionBase> BuildAction(const ColumnNames_t &bl, const std::sha
 {
    using Helper_t = SumHelper<ActionResultType>;
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<BranchType>>;
-   auto action = std::make_unique<Action_t>(Helper_t(sumV, nSlots), bl, prevNode);
-   return action;
+   return std::make_unique<Action_t>(Helper_t(sumV, nSlots), bl, prevNode);
 }
 
 // Mean action
@@ -196,8 +188,7 @@ std::unique_ptr<RActionBase> BuildAction(const ColumnNames_t &bl, const std::sha
 {
    using Helper_t = MeanHelper;
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<BranchType>>;
-   auto action = std::make_unique<Action_t>(Helper_t(meanV, nSlots), bl, prevNode);
-   return action;
+   return std::make_unique<Action_t>(Helper_t(meanV, nSlots), bl, prevNode);
 }
 
 // Standard Deviation action
@@ -207,8 +198,7 @@ std::unique_ptr<RActionBase> BuildAction(const ColumnNames_t &bl, const std::sha
 {
    using Helper_t = StdDevHelper;
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<BranchType>>;
-   auto action = std::make_unique<Action_t>(Helper_t(stdDeviationV, nSlots), bl, prevNode);
-   return action;
+   return std::make_unique<Action_t>(Helper_t(stdDeviationV, nSlots), bl, prevNode);
 }
 
 /****** end BuildAction ******/

--- a/tree/dataframe/inc/ROOT/RDFNodes.hxx
+++ b/tree/dataframe/inc/ROOT/RDFNodes.hxx
@@ -380,7 +380,7 @@ private:
    std::unique_ptr<RActionBase> fConcreteAction;
 
 public:
-   RJittedAction(RLoopManager &lm, const unsigned int nSlots) : RActionBase(&lm, nSlots) {}
+   RJittedAction(RLoopManager &lm) : RActionBase(&lm, lm.GetNSlots()) {}
 
    void SetAction(std::unique_ptr<RActionBase> a) { fConcreteAction = std::move(a); }
 

--- a/tree/dataframe/inc/ROOT/RDFNodes.hxx
+++ b/tree/dataframe/inc/ROOT/RDFNodes.hxx
@@ -375,6 +375,23 @@ public:
    virtual void *PartialUpdate(unsigned int slot) = 0;
 };
 
+class RJittedAction : public RActionBase {
+private:
+   std::unique_ptr<RActionBase> fConcreteAction;
+
+public:
+   RJittedAction(RLoopManager &lm, const unsigned int nSlots) : RActionBase(&lm, nSlots) {}
+
+   void SetAction(std::unique_ptr<RActionBase> a) { fConcreteAction = std::move(a); }
+
+   void Run(unsigned int slot, Long64_t entry) final;
+   void Initialize() final;
+   void InitSlot(TTreeReader *r, unsigned int slot) final;
+   void TriggerChildrenCount() final;
+   void FinalizeSlot(unsigned int) final;
+   void *PartialUpdate(unsigned int slot) final;
+};
+
 template <typename Helper, typename PrevDataFrame, typename ColumnTypes_t = typename Helper::ColumnTypes_t>
 class RAction final : public RActionBase {
    using TypeInd_t = std::make_index_sequence<ColumnTypes_t::list_size>;

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -631,10 +631,10 @@ void BookDefineJit(std::string_view name, std::string_view expression, RLoopMana
 
 // Jit and call something equivalent to "this->BuildAndBook<BranchTypes...>(params...)"
 // (see comments in the body for actual jitted code)
-std::string JitBuildAndBook(const ColumnNames_t &bl, const std::string &prevNodeTypename, void *prevNode,
-                            const std::type_info &art, const std::type_info &at, const void *rOnHeap, TTree *tree,
-                            const unsigned int nSlots, const ColumnNames_t &customColumns, RDataSource *ds,
-                            const std::shared_ptr<RActionBase *> *const actionPtrPtr, unsigned int namespaceID)
+std::string JitBuildAction(const ColumnNames_t &bl, const std::string &prevNodeTypename, void *prevNode,
+                           const std::type_info &art, const std::type_info &at, const void *rOnHeap, TTree *tree,
+                           const unsigned int nSlots, const ColumnNames_t &customColumns, RDataSource *ds,
+                           const std::shared_ptr<RActionBase *> *const actionPtrPtr, unsigned int namespaceID)
 {
    auto nBranches = bl.size();
 
@@ -669,11 +669,11 @@ std::string JitBuildAndBook(const ColumnNames_t &bl, const std::string &prevNode
    const auto actionTypeName = actionTypeClass->GetName();
 
    // createAction_str will contain the following:
-   // ROOT::Internal::RDF::CallBuildAndBook<actionType, branchType1, branchType2...>(
+   // ROOT::Internal::RDF::CallBuildAction<actionType, branchType1, branchType2...>(
    //   *reinterpret_cast<PrevNodeType*>(prevNode), { bl[0], bl[1], ... }, reinterpret_cast<actionResultType*>(rOnHeap),
    //   reinterpret_cast<shared_ptr<RActionBase*>*>(actionPtrPtr))
    std::stringstream createAction_str;
-   createAction_str << "ROOT::Internal::RDF::CallBuildAndBook"
+   createAction_str << "ROOT::Internal::RDF::CallBuildAction"
                     << "<" << actionTypeName;
    for (auto &colType : columnTypeNames)
       createAction_str << ", " << colType;

--- a/tree/dataframe/src/RDFNodes.cxx
+++ b/tree/dataframe/src/RDFNodes.cxx
@@ -52,6 +52,42 @@ RActionBase::RActionBase(RLoopManager *implPtr, const unsigned int nSlots) : fLo
 {
 }
 
+void RJittedAction::Run(unsigned int slot, Long64_t entry)
+{
+   R__ASSERT(fConcreteAction != nullptr);
+   fConcreteAction->Run(slot, entry);
+}
+
+void RJittedAction::Initialize()
+{
+   R__ASSERT(fConcreteAction != nullptr);
+   fConcreteAction->Initialize();
+}
+
+void RJittedAction::InitSlot(TTreeReader *r, unsigned int slot)
+{
+   R__ASSERT(fConcreteAction != nullptr);
+   fConcreteAction->InitSlot(r, slot);
+}
+
+void RJittedAction::TriggerChildrenCount()
+{
+   R__ASSERT(fConcreteAction != nullptr);
+   fConcreteAction->TriggerChildrenCount();
+}
+
+void RJittedAction::FinalizeSlot(unsigned int slot)
+{
+   R__ASSERT(fConcreteAction != nullptr);
+   fConcreteAction->FinalizeSlot(slot);
+}
+
+void *RJittedAction::PartialUpdate(unsigned int slot)
+{
+   R__ASSERT(fConcreteAction != nullptr);
+   return fConcreteAction->PartialUpdate(slot);
+}
+
 // Some extern instaniations to speed-up compilation/interpretation time
 // These are not active if c++17 is enabled because of a bug in our clang
 // See ROOT-9499.


### PR DESCRIPTION
Currently, jitted actions spawn into existence right before the event
loop (at jitting time). This makes it impossible or unnecessarily complex to:
1) let RResultPtrs own actions
2) let actions own their previous node
3) detect that an action has been booked before the event loop has run

Points 1 and 2 are required by ROOT-9416.
Point 3 is required by several graph-traversing features, e.g. ROOT-9458.

The solution is to align the jitted action logic with jitted filters and
defines, and use a placeholder RJittedAction object that sits into the
computation graph and forwards all relevant calls to the concrete, jitted
action which will be created at a later time.

RResultPtr logic is also greatly simplified since its action pointer can now always be set at construction time and is always guaranteed to be valid (it points to the RJittedAction owned by the RLoopManager).