### PR TITLE
Add TGraph2D::GetPoint

### DIFF
--- a/hist/hist/inc/TGraph2D.h
+++ b/hist/hist/inc/TGraph2D.h
@@ -133,6 +133,7 @@ public:
    virtual Double_t      GetYminE() const {return GetYmin();};
    virtual Double_t      GetZmaxE() const {return GetZmax();};
    virtual Double_t      GetZminE() const {return GetZmin();};
+   virtual Int_t         GetPoint(Int_t i, Double_t &x, Double_t &y, Double_t &z) const;
    Double_t              Interpolate(Double_t x, Double_t y);
    void                  Paint(Option_t *option="");
    virtual void          Print(Option_t *chopt="") const;

--- a/hist/hist/src/TGraph2D.cxx
+++ b/hist/hist/src/TGraph2D.cxx
@@ -1256,6 +1256,19 @@ Double_t TGraph2D::GetZmin() const
    return v;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Get x, y and z values for point number i.
+/// The function returns -1 in case of an invalid request or the point number otherwise
+
+Int_t TGraph2D::GetPoint(Int_t i, Double_t &x, Double_t &y, Double_t &z) const
+{
+   if (i < 0 || i >= fNpoints) return -1;
+   if (!fX || !fY || !fZ) return -1;
+   x = fX[i];
+   y = fY[i];
+   z = fZ[i];
+   return i;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Finds the z value at the position (x,y) thanks to


### PR DESCRIPTION
Implementation and behavior is the same as `TGraph::GetPoint`.
PR was motivated by a friend from ATLAS who asked why `TGraph` had a `GetPoint` method but `TGraph2D` didn't. If this feature is undesired feel free to close the PR.

I could not find tests for `TGraph2D`'s methods anywhere, so I attach a minimal test for this method here:
```cpp
#include <TGraph2D.h>
#include <TError.h>

int main()
{
   TGraph2D g;
   g.SetPoint(0, 1., 2., 3.);
   double x, y, z;
   R__ASSERT(-1 == g.GetPoint(-3, x, y, z));
   R__ASSERT(-1 == g.GetPoint(1, x, y, z));
   R__ASSERT(0 == g.GetPoint(0, x, y, z));
   R__ASSERT(1. == x);
   R__ASSERT(2. == y);
   R__ASSERT(3. == z);
   return 0;
}
```