### PR TITLE
Extended return value of operator* to TGeoHMatrix.

### DIFF
--- a/geom/geom/inc/TGeoMatrix.h
+++ b/geom/geom/inc/TGeoMatrix.h
@@ -131,6 +131,7 @@ public :
    TGeoTranslation &operator  =(const TGeoMatrix &matrix);
    TGeoTranslation &operator *=(const TGeoTranslation &other);
    TGeoTranslation  operator  *(const TGeoTranslation &right) const;
+   TGeoHMatrix      operator  *(const TGeoMatrix &right) const;
    Bool_t           operator ==(const TGeoTranslation &other) const;
 
    void                 Add(const TGeoTranslation *other);
@@ -187,6 +188,7 @@ public :
    TGeoRotation &operator  =(const TGeoMatrix &other);
    TGeoRotation &operator *=(const TGeoRotation &other);
    TGeoRotation  operator  *(const TGeoRotation &other) const;
+   TGeoHMatrix   operator  *(const TGeoMatrix &right) const;
    Bool_t        operator ==(const TGeoRotation &other) const;
 
    Bool_t               IsValid() const;
@@ -247,10 +249,11 @@ public :
    TGeoScale(const char *name, Double_t sx, Double_t sy, Double_t sz);
    virtual ~TGeoScale();
 
-   TGeoScale &operator  =(const TGeoMatrix &other);
-   TGeoScale &operator *=(const TGeoScale &other);
-   TGeoScale  operator  *(const TGeoScale &other) const;
-   Bool_t     operator ==(const TGeoScale &other) const;
+   TGeoScale  &operator  =(const TGeoMatrix &other);
+   TGeoScale  &operator *=(const TGeoScale &other);
+   TGeoScale   operator  *(const TGeoScale &other) const;
+   TGeoHMatrix operator  *(const TGeoMatrix &right) const;
+   Bool_t      operator ==(const TGeoScale &other) const;
 
    TGeoHMatrix          Inverse() const;
    void                 SetScale(Double_t sx, Double_t sy, Double_t sz);
@@ -433,7 +436,9 @@ public :
    TGeoHMatrix          Inverse() const;
    virtual TGeoMatrix  *MakeClone() const;
    void                 Multiply(const TGeoMatrix *right);
+   void                 Multiply(const TGeoMatrix &right) {Multiply(&right);}
    void                 MultiplyLeft(const TGeoMatrix *left);
+   void                 MultiplyLeft(const TGeoMatrix &left) {MultiplyLeft(&left);}
 
    virtual void         RotateX(Double_t angle);
    virtual void         RotateY(Double_t angle);

--- a/geom/geom/src/TGeoMatrix.cxx
+++ b/geom/geom/src/TGeoMatrix.cxx
@@ -654,6 +654,13 @@ TGeoTranslation TGeoTranslation::operator*(const TGeoTranslation &right) const
    return t;
 }
 
+TGeoHMatrix TGeoTranslation::operator*(const TGeoMatrix &right) const
+{
+   TGeoHMatrix t = *this;
+   t *= right;
+   return t;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Is-equal operator
 
@@ -939,6 +946,13 @@ TGeoRotation TGeoRotation::operator*(const TGeoRotation &right) const
    TGeoRotation r = *this;
    r *= right;
    return r;
+}
+
+TGeoHMatrix TGeoRotation::operator*(const TGeoMatrix &right) const
+{
+   TGeoHMatrix t = *this;
+   t *= right;
+   return t;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1478,6 +1492,13 @@ TGeoScale TGeoScale::operator*(const TGeoScale &right) const
    TGeoScale s = *this;
    s *= right;
    return s;
+}
+
+TGeoHMatrix TGeoScale::operator*(const TGeoMatrix &right) const
+{
+   TGeoHMatrix t = *this;
+   t *= right;
+   return t;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/geom/geom/test/TestMatrix.C
+++ b/geom/geom/test/TestMatrix.C
@@ -93,4 +93,21 @@ void TestMatrix()
 
   c3 *= c3.Inverse();
   myassert(c3 == identity, "combi trans inverse wrong");
+
+  // Test for Wolfgang Korsch's case
+  TGeoHMatrix href = tr1;
+  href *= TGeoRotation("", 0, 120, 0);
+  TGeoRotation r4;
+  r4.SetAngles(0, 90, 0);
+  TGeoRotation r5 = r4;
+  r4.SetAngles(0, 30, 0);
+  r5 = r5 * r4;
+  TGeoHMatrix combiH1TB = tr1 * r5;
+  myassert(combiH1TB == href, "translation multiplication demoted");
+
+  // Test for David Rohr's case
+  TGeoHMatrix h5 = href, h6 = href;
+  h5 *= h6.Inverse();
+  h6.Multiply(h6.Inverse());
+  myassert(h5 == h6 && h5 == identity, "inverse not matching");
 }


### PR DESCRIPTION
This promotes the result of operator* for matrices to TGeoHMatrix to be able to handle properly translation * rotation. Added Multiply(Left) methods taking const matrix reference.