### PR TITLE
[TTree] Create event clusters when TTree is flushed.

### DIFF
--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -364,7 +364,7 @@ public:
    virtual TBranch        *FindBranch(const char* name);
    virtual TLeaf          *FindLeaf(const char* name);
    virtual Int_t           Fit(const char* funcname, const char* varexp, const char* selection = "", Option_t* option = "", Option_t* goption = "", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0); // *MENU*
-   virtual Int_t           FlushBaskets(bool create_cluster = true) const;
+   virtual Int_t           FlushBaskets(Bool_t create_cluster = true) const;
    virtual const char     *GetAlias(const char* aliasName) const;
    virtual Long64_t        GetAutoFlush() const {return fAutoFlush;}
    virtual Long64_t        GetAutoSave()  const {return fAutoSave;}

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -142,6 +142,8 @@ private:
 
    void             InitializeBranchLists(bool checkLeafCount);
    void             SortBranchesByTime();
+   Int_t            FlushBasketsImpl() const;
+   void             MarkEventCluster();
 
 protected:
    virtual void     KeepCircular();
@@ -234,10 +236,11 @@ public:
    class TClusterIterator
    {
    private:
-      TTree    *fTree;        // TTree upon which we are iterating.
-      Int_t    fClusterRange; // Which cluster range are we looking at.
-      Long64_t fStartEntry;   // Where does the cluster start.
-      Long64_t fNextEntry;    // Where does the cluster end (exclusive).
+      TTree    *fTree;         // TTree upon which we are iterating.
+      Int_t    fClusterRange;  // Which cluster range are we looking at.
+      Long64_t fStartEntry;    // Where does the cluster start.
+      Long64_t fNextEntry;     // Where does the cluster end (exclusive).
+      Long64_t fEstimatedSize; // If positive, the calculated estimated tree size.
 
       Long64_t GetEstimatedClusterSize();
 
@@ -361,7 +364,7 @@ public:
    virtual TBranch        *FindBranch(const char* name);
    virtual TLeaf          *FindLeaf(const char* name);
    virtual Int_t           Fit(const char* funcname, const char* varexp, const char* selection = "", Option_t* option = "", Option_t* goption = "", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0); // *MENU*
-   virtual Int_t           FlushBaskets() const;
+   virtual Int_t           FlushBaskets(bool create_cluster = true) const;
    virtual const char     *GetAlias(const char* aliasName) const;
    virtual Long64_t        GetAutoFlush() const {return fAutoFlush;}
    virtual Long64_t        GetAutoSave()  const {return fAutoSave;}

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -596,12 +596,13 @@ Long64_t TTree::TClusterIterator::GetEstimatedClusterSize()
             }
          }
       }
-      if (cacheSize > 0) {
-         clusterEstimate = fTree->GetEntries() * cacheSize / zipBytes;
-         if (clusterEstimate == 0)
-            clusterEstimate = 1;
+      // If neither file nor tree has a cache, use the current default.
+      if (cacheSize <= 0) {
+         cacheSize = 30000000;
       }
-      fEstimatedSize = clusterEstimate;
+      clusterEstimate = fTree->GetEntries() * cacheSize / zipBytes;
+      // If there are no entries, then just default to 1.
+      fEstimatedSize = clusterEstimate ? clusterEstimate : 1;
    }
    return fEstimatedSize;
 }

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -4885,7 +4885,7 @@ struct BoolRAIIToggle {
 /// locks when they invoke ROOT.
 ///
 /// Return the number of bytes written or -1 in case of write error.
-Int_t TTree::FlushBaskets(bool create_cluster) const
+Int_t TTree::FlushBaskets(Bool_t create_cluster) const
 {
     Int_t retval = FlushBasketsImpl();
     if (retval == -1) return retval;

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -523,12 +523,9 @@ TTree::TFriendLock::~TFriendLock()
 /// Regular constructor.
 /// TTree is not set as const, since we might modify if it is a TChain.
 
-TTree::TClusterIterator::TClusterIterator(TTree *tree, Long64_t firstEntry) : fTree(tree), fClusterRange(0), fStartEntry(0), fNextEntry(0)
+TTree::TClusterIterator::TClusterIterator(TTree *tree, Long64_t firstEntry) : fTree(tree), fClusterRange(0), fStartEntry(0), fNextEntry(0), fEstimatedSize(-1)
 {
-   if ( fTree->GetAutoFlush() <= 0 ) {
-      // Case of old files before November 9 2009
-      fStartEntry = firstEntry;
-   } else if (fTree->fNClusterRange) {
+   if (fTree->fNClusterRange) {
       // Find the correct cluster range.
       //
       // Since fClusterRangeEnd contains the inclusive upper end of the range, we need to search for the
@@ -555,6 +552,9 @@ TTree::TClusterIterator::TClusterIterator(TTree *tree, Long64_t firstEntry) : fT
          autoflush = GetEstimatedClusterSize();
       }
       fStartEntry = pedestal + entryInRange - entryInRange%autoflush;
+   } else if ( fTree->GetAutoFlush() <= 0 ) {
+      // Case of old files before November 9 2009 *or* small tree where AutoFlush was never set.
+      fStartEntry = firstEntry;
    } else {
       fStartEntry = firstEntry - firstEntry%fTree->GetAutoFlush();
    }
@@ -562,15 +562,27 @@ TTree::TClusterIterator::TClusterIterator(TTree *tree, Long64_t firstEntry) : fT
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// In the case where the cluster size was not fixed (old files and
-/// case where autoflush was explicitly set to zero, we need estimate
+/// Estimate the cluster size.
+///
+/// In almost all cases, this quickly returns the size of the auto-flush
+/// in the TTree.
+///
+/// However, in the case where the cluster size was not fixed (old files and
+/// case where autoflush was explicitly set to zero), we need estimate
 /// a cluster size in relation to the size of the cache.
+///
+/// After this value is calculated once for the TClusterIterator, it is
+/// cached and reused in future calls.
 
 Long64_t TTree::TClusterIterator::GetEstimatedClusterSize()
 {
+   auto autoFlush = fTree->GetAutoFlush();
+   if (autoFlush > 0) return autoFlush;
+   if (fEstimatedSize > 0) return fEstimatedSize;
+
    Long64_t zipBytes = fTree->GetZipBytes();
    if (zipBytes == 0) {
-      return fTree->GetEntries() - 1;
+      fEstimatedSize = fTree->GetEntries() - 1;
    } else {
       Long64_t clusterEstimate = 1;
       Long64_t cacheSize = fTree->GetCacheSize();
@@ -589,8 +601,9 @@ Long64_t TTree::TClusterIterator::GetEstimatedClusterSize()
          if (clusterEstimate == 0)
             clusterEstimate = 1;
       }
-      return clusterEstimate;
+      fEstimatedSize = clusterEstimate;
    }
+   return fEstimatedSize;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -600,15 +613,11 @@ Long64_t TTree::TClusterIterator::GetEstimatedClusterSize()
 Long64_t TTree::TClusterIterator::Next()
 {
    fStartEntry = fNextEntry;
-   if ( fTree->GetAutoFlush() <= 0 ) {
-      // Case of old files before November 9 2009
-      Long64_t clusterEstimate = GetEstimatedClusterSize();
-      fNextEntry = fStartEntry + clusterEstimate;
-   } else {
+   if (fTree->fNClusterRange || fTree->GetAutoFlush() > 0) {
       if (fClusterRange == fTree->fNClusterRange) {
          // We are looking at a range which size
          // is defined by AutoFlush itself and goes to the GetEntries.
-         fNextEntry += fTree->GetAutoFlush();
+         fNextEntry += GetEstimatedClusterSize();
       } else {
          if (fStartEntry > fTree->fClusterRangeEnd[fClusterRange]) {
             ++fClusterRange;
@@ -616,7 +625,7 @@ Long64_t TTree::TClusterIterator::Next()
          if (fClusterRange == fTree->fNClusterRange) {
             // We are looking at the last range which size
             // is defined by AutoFlush itself and goes to the GetEntries.
-            fNextEntry += fTree->GetAutoFlush();
+            fNextEntry += GetEstimatedClusterSize();
          } else {
             Long64_t clusterSize = fTree->fClusterSize[fClusterRange];
             if (clusterSize == 0) {
@@ -631,6 +640,9 @@ Long64_t TTree::TClusterIterator::Next()
             }
          }
       }
+   } else {
+      // Case of old files before November 9 2009
+      fNextEntry = fStartEntry + GetEstimatedClusterSize();
    }
    if (fNextEntry > fTree->GetEntries()) {
       fNextEntry = fTree->GetEntries();
@@ -645,15 +657,11 @@ Long64_t TTree::TClusterIterator::Next()
 Long64_t TTree::TClusterIterator::Previous()
 {
    fNextEntry = fStartEntry;
-   if (fTree->GetAutoFlush() <= 0) {
-      // Case of old files before November 9 2009
-      Long64_t clusterEstimate = GetEstimatedClusterSize();
-      fStartEntry = fNextEntry - clusterEstimate;
-   } else {
+   if (fTree->fNClusterRange || fTree->GetAutoFlush() > 0) {
       if (fClusterRange == 0 || fTree->fNClusterRange == 0) {
          // We are looking at a range which size
          // is defined by AutoFlush itself.
-         fStartEntry -= fTree->GetAutoFlush();
+         fStartEntry -= GetEstimatedClusterSize();
       } else {
          if (fNextEntry <= fTree->fClusterRangeEnd[fClusterRange]) {
             --fClusterRange;
@@ -669,6 +677,9 @@ Long64_t TTree::TClusterIterator::Previous()
             fStartEntry -= clusterSize;
          }
       }
+   } else {
+      // Case of old files before November 9 2009 or trees that never auto-flushed.
+      fStartEntry = fNextEntry - GetEstimatedClusterSize();
    }
    if (fStartEntry < 0) {
       fStartEntry = 0;
@@ -1392,7 +1403,7 @@ Long64_t TTree::AutoSave(Option_t* option)
 
    if (opt.Contains("flushbaskets")) {
       if (gDebug > 0) Info("AutoSave", "calling FlushBaskets \n");
-      FlushBaskets();
+      FlushBasketsImpl();
    }
 
    fSavedBytes = GetZipBytes();
@@ -4461,7 +4472,7 @@ Int_t TTree::Fill()
 
          if (autoFlush || autoSave) {
             // First call FlushBasket to make sure that fTotBytes is up to date.
-            FlushBaskets();
+            FlushBasketsImpl();
             OptimizeBaskets(GetTotBytes(), 1, "");
             autoFlush = false; // avoid auto flushing again later
 
@@ -4513,7 +4524,7 @@ Int_t TTree::Fill()
    }
 
    if (autoFlush) {
-      FlushBaskets();
+      FlushBasketsImpl();
       if (gDebug > 0)
          Info("TTree::Fill", "FlushBaskets() called at entry %lld, fZipBytes=%lld, fFlushedBytes=%lld\n", fEntries,
               GetZipBytes(), fFlushedBytes);
@@ -4521,7 +4532,7 @@ Int_t TTree::Fill()
    }
 
    if (autoSave) {
-      AutoSave(); // does not call FlushBaskets() again
+      AutoSave(); // does not call FlushBasketsImpl() again
       if (gDebug > 0)
          Info("TTree::Fill", "AutoSave called at entry %lld, fZipBytes=%lld, fSavedBytes=%lld\n", fEntries,
               GetZipBytes(), fSavedBytes);
@@ -4842,7 +4853,11 @@ struct BoolRAIIToggle {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Write to disk all the basket that have not yet been individually written.
+/// Write to disk all the basket that have not yet been individually written and
+/// create an event cluster boundary (by default).
+///
+/// If the caller wishes to flush the baskets but not create an event cluster,
+/// then set create_cluster to false.
 ///
 /// If ROOT has IMT-mode enabled, this will launch multiple TBB tasks in parallel
 /// via TThreadExecutor to do this operation; one per basket compression.  If the
@@ -4869,8 +4884,24 @@ struct BoolRAIIToggle {
 /// locks when they invoke ROOT.
 ///
 /// Return the number of bytes written or -1 in case of write error.
+Int_t TTree::FlushBaskets(bool create_cluster) const
+{
+    Int_t retval = FlushBasketsImpl();
+    if (retval == -1) return retval;
 
-Int_t TTree::FlushBaskets() const
+    if (create_cluster) const_cast<TTree *>(this)->MarkEventCluster();
+    return retval;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Internal implementation of the FlushBaskets algorithm.
+/// Unlike the public interface, this does NOT create an explicit event cluster
+/// boundary; it is up to the (internal) caller to determine whether that should
+/// done.
+///
+/// Otherwise, the comments for FlushBaskets applies.
+///
+Int_t TTree::FlushBasketsImpl() const
 {
    if (!fDirectory) return 0;
    Int_t nbytes = 0;
@@ -6719,7 +6750,7 @@ Bool_t TTree::Notify()
 void TTree::OptimizeBaskets(ULong64_t maxMemory, Float_t minComp, Option_t *option)
 {
    //Flush existing baskets if the file is writable
-   if (this->GetDirectory()->IsWritable()) this->FlushBaskets();
+   if (this->GetDirectory()->IsWritable()) this->FlushBasketsImpl();
 
    TString opt( option );
    opt.ToLower();
@@ -7830,31 +7861,53 @@ void TTree::SetAutoFlush(Long64_t autof /* = -30000000 */ )
    // size never varies (If there is only one value of AutoFlush for the whole TTree).
 
    if( fAutoFlush != autof) {
-      if (fAutoFlush > 0 || autof > 0) {
+      if ((fAutoFlush > 0 || autof > 0) && fFlushedBytes) {
          // The mechanism was already enabled, let's record the previous
          // cluster if needed.
-         if (fFlushedBytes && fEntries) {
-            if ( (fNClusterRange+1) > fMaxClusterRange ) {
-               if (fMaxClusterRange) {
-                  Int_t newsize = TMath::Max(10,Int_t(2*fMaxClusterRange));
-                  fClusterRangeEnd = (Long64_t*)TStorage::ReAlloc(fClusterRangeEnd,
-                                                                  newsize*sizeof(Long64_t),fMaxClusterRange*sizeof(Long64_t));
-                  fClusterSize = (Long64_t*)TStorage::ReAlloc(fClusterSize,
-                                                            newsize*sizeof(Long64_t),fMaxClusterRange*sizeof(Long64_t));
-                  fMaxClusterRange = newsize;
-               } else {
-                  fMaxClusterRange = 2;
-                  fClusterRangeEnd = new Long64_t[fMaxClusterRange];
-                  fClusterSize = new Long64_t[fMaxClusterRange];
-               }
-            }
-            fClusterRangeEnd[fNClusterRange] = fEntries - 1;
-            fClusterSize[fNClusterRange] = fAutoFlush<0 ? 0 : fAutoFlush;
-            ++fNClusterRange;
-         }
+         MarkEventCluster();
       }
       fAutoFlush = autof;
    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Mark the previous event as being at the end of the event cluster.
+///
+/// So, if fEntries is set to 10 (and this is the first cluster) when MarkEventCluster
+/// is called, then the first cluster has 9 events.
+void TTree::MarkEventCluster()
+{
+    if (!fEntries) return;
+
+    if ( (fNClusterRange+1) > fMaxClusterRange ) {
+        if (fMaxClusterRange) {
+            // Resize arrays to hold a larger event cluster.
+            Int_t newsize = TMath::Max(10,Int_t(2*fMaxClusterRange));
+            fClusterRangeEnd = (Long64_t*)TStorage::ReAlloc(fClusterRangeEnd,
+                                                            newsize*sizeof(Long64_t),fMaxClusterRange*sizeof(Long64_t));
+            fClusterSize = (Long64_t*)TStorage::ReAlloc(fClusterSize,
+                                                        newsize*sizeof(Long64_t),fMaxClusterRange*sizeof(Long64_t));
+            fMaxClusterRange = newsize;
+        } else {
+            // Cluster ranges have never been initialized; create them now.
+            fMaxClusterRange = 2;
+            fClusterRangeEnd = new Long64_t[fMaxClusterRange];
+            fClusterSize = new Long64_t[fMaxClusterRange];
+        }
+    }
+    fClusterRangeEnd[fNClusterRange] = fEntries - 1;
+    // If we are auto-flushing, then the cluster size is the same as the current auto-flush setting.
+    if (fAutoFlush > 0) {
+        // Even if the user triggers MarkEventRange prior to fAutoFlush being present, the TClusterIterator
+        // will appropriately go to the next event range.
+        fClusterSize[fNClusterRange] = fAutoFlush;
+    // Otherwise, assume there is one cluster per event range (e.g., user is manually controlling the flush).
+    } else if (fNClusterRange == 0) {
+        fClusterSize[fNClusterRange] = fEntries;
+    } else {
+        fClusterSize[fNClusterRange] = fClusterRangeEnd[fNClusterRange] - fClusterRangeEnd[fNClusterRange-1];
+    }
+    ++fNClusterRange;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -9220,7 +9273,7 @@ void TTree::UseCurrentStyle()
 
 Int_t TTree::Write(const char *name, Int_t option, Int_t bufsize) const
 {
-   FlushBaskets();
+   FlushBasketsImpl();
    return TObject::Write(name, option, bufsize);
 }
 


### PR DESCRIPTION
Several of us were surprised to discover that calling `TTree::FlushBaskets()` does not actually create a new event cluster in terms of the TTree metadata -- even though it effectively creates an event cluster in terms of the physical disk layout!

There may be cases where the user has special knowledge of the file where using the internally-calculated auto-flush intervals result in poor choices; CMS's NanoAOD is one such case.  However, when CMS switched to calling `FlushBaskets` explicitly and disabling `AutoFlush`, this triggered unexpected behavior in `RDataFrame` as the file did not appear to have any proper event clusters.

This change causes the `FlushBaskets` method to create an explicit event cluster.  As we used the old behavior in some ROOT unit tests, the prior behavior is now accessible through a flag passed to the method.

Fixes: ROOT-9442