### PR TITLE
Fix dataframe_snapshot test on Windows

### DIFF
--- a/tree/dataframe/test/dataframe_snapshot.cxx
+++ b/tree/dataframe/test/dataframe_snapshot.cxx
@@ -452,11 +452,6 @@ TEST(RDFSnapshotMore, Lazy)
    const auto treename = "t";
    const auto fname0 = "lazy0.root";
    const auto fname1 = "lazy1.root";
-#ifdef _MSC_VER
-   // on Windows, make sure the file is not here beforehand
-   gSystem->Unlink(fname0);
-   gSystem->Unlink(fname1);
-#endif
    RDataFrame d(1);
    auto v = 0U;
    auto genf = [&v](){++v;return 42;};
@@ -506,12 +501,6 @@ TEST(RDFSnapshotMore, ManyTasksPerThread)
    const std::string inputFilePrefix = "snapshot_manytasks_";
    const auto tasksPerThread = 8u;
    const auto nInputFiles = nSlots * tasksPerThread;
-#ifdef _MSC_VER
-   // on Windows, make sure the files are not here beforehand
-   for (auto i = 0u; i < nInputFiles; ++i)
-      gSystem->Unlink((inputFilePrefix + std::to_string(i) + ".root").c_str());
-   gSystem->Unlink("snapshot_manytasks_out.root");
-#endif
    ROOT::RDataFrame d(1);
    auto dd = d.Define("x", []() { return 42; });
    for (auto i = 0u; i < nInputFiles; ++i)

--- a/tree/dataframe/test/dataframe_snapshot.cxx
+++ b/tree/dataframe/test/dataframe_snapshot.cxx
@@ -262,7 +262,7 @@ TEST_F(RDFSnapshotArrays, SingleThread)
    // template Snapshot
    // "size" _must_ be listed before "varSizeArr"!
    auto dt = tdf.Snapshot<RVec<float>, unsigned int, RVec<double>>(
-      "outTree", "test_snapshotRVecout.root", {"fixedSizeArr", "size", "varSizeArr"});
+      "outTree", "test_snapshotRVecoutST.root", {"fixedSizeArr", "size", "varSizeArr"});
 
    checkSnapshotArrayFile(dt, kNEvents);
 }
@@ -272,7 +272,7 @@ TEST_F(RDFSnapshotArrays, SingleThreadJitted)
    RDataFrame tdf("arrayTree", kFileNames);
    // jitted Snapshot
    // "size" _must_ be listed before "varSizeArr"!
-   auto dj = tdf.Snapshot("outTree", "test_snapshotRVecout.root", {"fixedSizeArr", "size", "varSizeArr"});
+   auto dj = tdf.Snapshot("outTree", "test_snapshotRVecoutSTJitted.root", {"fixedSizeArr", "size", "varSizeArr"});
 
    checkSnapshotArrayFile(dj, kNEvents);
 }
@@ -452,6 +452,11 @@ TEST(RDFSnapshotMore, Lazy)
    const auto treename = "t";
    const auto fname0 = "lazy0.root";
    const auto fname1 = "lazy1.root";
+#ifdef _MSC_VER
+   // on Windows, make sure the file is not here beforehand
+   gSystem->Unlink(fname0);
+   gSystem->Unlink(fname1);
+#endif
    RDataFrame d(1);
    auto v = 0U;
    auto genf = [&v](){++v;return 42;};
@@ -501,6 +506,12 @@ TEST(RDFSnapshotMore, ManyTasksPerThread)
    const std::string inputFilePrefix = "snapshot_manytasks_";
    const auto tasksPerThread = 8u;
    const auto nInputFiles = nSlots * tasksPerThread;
+#ifdef _MSC_VER
+   // on Windows, make sure the files are not here beforehand
+   for (auto i = 0u; i < nInputFiles; ++i)
+      gSystem->Unlink((inputFilePrefix + std::to_string(i) + ".root").c_str());
+   gSystem->Unlink("snapshot_manytasks_out.root");
+#endif
    ROOT::RDataFrame d(1);
    auto dd = d.Define("x", []() { return 42; });
    for (auto i = 0u; i < nInputFiles; ++i)
@@ -546,7 +557,7 @@ TEST_F(RDFSnapshotArrays, MultiThread)
 
    RDataFrame tdf("arrayTree", kFileNames);
    auto dt = tdf.Snapshot<RVec<float>, unsigned int, RVec<double>>(
-      "outTree", "test_snapshotRVecout.root", {"fixedSizeArr", "size", "varSizeArr"});
+      "outTree", "test_snapshotRVecoutMT.root", {"fixedSizeArr", "size", "varSizeArr"});
 
    checkSnapshotArrayFileMT(dt, kNEvents);
 
@@ -558,7 +569,7 @@ TEST_F(RDFSnapshotArrays, MultiThreadJitted)
    ROOT::EnableImplicitMT(4);
 
    RDataFrame tdf("arrayTree", kFileNames);
-   auto dj = tdf.Snapshot("outTree", "test_snapshotRVecout.root", {"fixedSizeArr", "size", "varSizeArr"});
+   auto dj = tdf.Snapshot("outTree", "test_snapshotRVecoutMTJitted.root", {"fixedSizeArr", "size", "varSizeArr"});
 
    checkSnapshotArrayFileMT(dj, kNEvents);
 


### PR DESCRIPTION
On Windows, one cannot delete a file while used by a process, so use different file names and make sure they are deleted beforehand