### PR TITLE
Try to fix PyMVA unit tests

### DIFF
--- a/tmva/pymva/test/testPyAdaBoostMulticlass.C
+++ b/tmva/pymva/test/testPyAdaBoostMulticlass.C
@@ -13,7 +13,7 @@
 int testPyAdaBoostMulticlass(){
    // Get data file
    std::cout << "Get test data..." << std::endl;
-   TString fname = "./tmva_example_multiple_background.root";
+   TString fname = "../../../runtutorials/tmva_example_multiple_background.root";
    if (gSystem->AccessPathName(fname)){  // file does not exist in local directory
       std::cout << "Create multiclass test data..." << std::endl;
       TString createDataMacro = TString(gROOT->GetTutorialsDir()) + "/tmva/createData.C";

--- a/tmva/pymva/test/testPyGTBMulticlass.C
+++ b/tmva/pymva/test/testPyGTBMulticlass.C
@@ -13,7 +13,7 @@
 int testPyGTBMulticlass(){
    // Get data file
    std::cout << "Get test data..." << std::endl;
-   TString fname = "./tmva_example_multiple_background.root";
+   TString fname = "../../../runtutorials/tmva_example_multiple_background.root";
    if (gSystem->AccessPathName(fname)){  // file does not exist in local directory
       std::cout << "Create multiclass test data..." << std::endl;
       TString createDataMacro = TString(gROOT->GetTutorialsDir()) + "/tmva/createData.C";

--- a/tmva/pymva/test/testPyRandomForestMulticlass.C
+++ b/tmva/pymva/test/testPyRandomForestMulticlass.C
@@ -13,7 +13,7 @@
 int testPyRandomForestMulticlass(){
    // Get data file
    std::cout << "Get test data..." << std::endl;
-   TString fname = "./tmva_example_multiple_background.root";
+   TString fname = "../../../runtutorials/tmva_example_multiple_background.root";
    if (gSystem->AccessPathName(fname)){  // file does not exist in local directory
       std::cout << "Create multiclass test data..." << std::endl;
       TString createDataMacro = TString(gROOT->GetTutorialsDir()) + "/tmva/createData.C";
@@ -26,6 +26,7 @@ int testPyRandomForestMulticlass(){
    // Setup PyMVA and factory
    std::cout << "Setup TMVA..." << std::endl;
    TMVA::PyMethodBase::PyInitialize();
+
    TFile* outputFile = TFile::Open("ResultsTestPyRandomForestMulticlass.root", "RECREATE");
    TMVA::Factory *factory = new TMVA::Factory("testPyRandomForestMulticlass", outputFile,
       "!V:Silent:Color:!DrawProgressBar:AnalysisType=multiclass");

--- a/tmva/pymva/test/testPyRandomForestMulticlass.C
+++ b/tmva/pymva/test/testPyRandomForestMulticlass.C
@@ -26,7 +26,6 @@ int testPyRandomForestMulticlass(){
    // Setup PyMVA and factory
    std::cout << "Setup TMVA..." << std::endl;
    TMVA::PyMethodBase::PyInitialize();
-
    TFile* outputFile = TFile::Open("ResultsTestPyRandomForestMulticlass.root", "RECREATE");
    TMVA::Factory *factory = new TMVA::Factory("testPyRandomForestMulticlass", outputFile,
       "!V:Silent:Color:!DrawProgressBar:AnalysisType=multiclass");


### PR DESCRIPTION
- 3 PyMVA Multiclass tests fails cause they are opening `./tmva_example_multiple_background.root` which doesn't contain required input TTree objects.
- As a dirty workaround I've changed input file path to be `../../../runtutorials/tmva_example_multiple_background.root` to use same tree filled by `runtutorials` unit-tests.