### PR TITLE
Fix memory leak in GetStreamInfoListImpl (working with make_unique backport)

### DIFF
--- a/core/foundation/inc/ROOT/RMakeUnique.hxx
+++ b/core/foundation/inc/ROOT/RMakeUnique.hxx
@@ -14,20 +14,48 @@
 #ifndef ROOT_RMakeUnique
 #define ROOT_RMakeUnique
 
-#include <memory>
-
 #if __cplusplus < 201402L && !defined(_MSC_VER)
 
+#include <cstddef>
+#include <memory>
+#include <type_traits>
 #include <utility>
 
-namespace std {
+// Implementation taken from https://isocpp.org/files/papers/N3656.txt
 
-template <typename T, typename... Args>
-std::unique_ptr<T> make_unique(Args &&... args)
+namespace std {
+template <class T>
+struct _Unique_if {
+   typedef unique_ptr<T> _Single_object;
+};
+
+template <class T>
+struct _Unique_if<T[]> {
+   typedef unique_ptr<T[]> _Unknown_bound;
+};
+
+template <class T, size_t N>
+struct _Unique_if<T[N]> {
+   typedef void _Known_bound;
+};
+
+template <class T, class... Args>
+typename _Unique_if<T>::_Single_object make_unique(Args &&... args)
 {
-   return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+   return unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
+
+template <class T>
+typename _Unique_if<T>::_Unknown_bound make_unique(size_t n)
+{
+   typedef typename remove_extent<T>::type U;
+   return unique_ptr<T>(new U[n]());
 }
+
+template <class T, class... Args>
+typename _Unique_if<T>::_Known_bound make_unique(Args &&...) = delete;
+}
+
 #endif
 
 #endif

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -133,6 +133,7 @@ The structure of a directory is shown in TDirectoryFile::TDirectoryFile
 #include "TThreadSlots.h"
 #include "TGlobal.h"
 #include "TMath.h"
+#include "ROOT/RMakeUnique.hxx"
 
 using std::sqrt;
 
@@ -1330,9 +1331,9 @@ std::pair<TList *, Int_t> TFile::GetStreamerInfoListImpl(bool lookupSICache)
    TList *list = 0;
    if (fSeekInfo) {
       TDirectory::TContext ctxt(this); // gFile and gDirectory used in ReadObj
-      TKey *key = new TKey(this);
-      char *buffer = new char[fNbytesInfo+1];
-      char *buf    = buffer;
+      auto key = std::make_unique<TKey>(this);
+      auto buffer = std::make_unique<char[]>(fNbytesInfo+1);
+      auto buf = buffer.get();
       Seek(fSeekInfo);
       if (ReadBuffer(buf,fNbytesInfo)) {
          // ReadBuffer returns kTRUE in case of failure.
@@ -1352,10 +1353,8 @@ std::pair<TList *, Int_t> TFile::GetStreamerInfoListImpl(bool lookupSICache)
       (void) lookupSICache;
 #endif
       key->ReadKeyBuffer(buf);
-      list = dynamic_cast<TList*>(key->ReadObjWithBuffer(buffer));
+      list = dynamic_cast<TList*>(key->ReadObjWithBuffer(buffer.get()));
       if (list) list->SetOwner();
-      delete [] buffer;
-      delete key;
    } else {
       list = (TList*)Get("StreamerInfo"); //for versions 2.26 (never released)
    }


### PR DESCRIPTION
This is the same PR than #2361 but with a fixed backport of `std::make_unique` for the case `std::make_unique<T[]>(N)` and c++11.