### PR TITLE
[cxxmodules] Check correctly if the decl was cached.

### DIFF
--- a/core/dictgen/src/BaseSelectionRule.cxx
+++ b/core/dictgen/src/BaseSelectionRule.cxx
@@ -229,8 +229,9 @@ BaseSelectionRule::EMatchType BaseSelectionRule::Match(const clang::NamedDecl *d
       if (name_value == name) {
          const_cast<BaseSelectionRule*>(this)->SetMatchFound(true);
          return kName;
-      } else if ( fCXXRecordDecl != (void*)-1 ) {
-         // Try a real match!
+      } else if ( !fCXXRecordDecl || fCXXRecordDecl != (void*)-1) {
+         // Possibly take the most expensive path if the fCXXRecordDecl is not
+         // set or we already took the expensive path and found nothing (-1).
          const clang::CXXRecordDecl *target
             = fHasFromTypedefAttribute ? nullptr : ROOT::TMetaUtils::ScopeSearch(name_value.c_str(), *fInterp,
                                                    true /*diagnose*/, 0);


### PR DESCRIPTION
Rootcling always decided to take the most expensive path and make a
lookup even in the cases where it already has found the declaration
it looks for.

This patch speeds up visibly rootcling dictionary generation time
and reduces the pcm size from 340MB to 165MB on my machine. It also
reduces the rss memory usage from 350MB to 250MB for ROOT with
runtime_cxxmodules.

Patch by Axel Naumann(@Axel-Naumann) and me!