### PR TITLE
Fix memory leak in GetStreamInfoListImpl (using std::vector as buffer)

### DIFF
--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -133,6 +133,7 @@ The structure of a directory is shown in TDirectoryFile::TDirectoryFile
 #include "TThreadSlots.h"
 #include "TGlobal.h"
 #include "TMath.h"
+#include "ROOT/RMakeUnique.hxx"
 
 using std::sqrt;
 
@@ -1330,9 +1331,9 @@ std::pair<TList *, Int_t> TFile::GetStreamerInfoListImpl(bool lookupSICache)
    TList *list = 0;
    if (fSeekInfo) {
       TDirectory::TContext ctxt(this); // gFile and gDirectory used in ReadObj
-      TKey *key = new TKey(this);
-      char *buffer = new char[fNbytesInfo+1];
-      char *buf    = buffer;
+      auto key = std::make_unique<TKey>(this);
+      std::vector<char> buffer(fNbytesInfo+1);
+      auto buf = buffer.data();
       Seek(fSeekInfo);
       if (ReadBuffer(buf,fNbytesInfo)) {
          // ReadBuffer returns kTRUE in case of failure.
@@ -1352,10 +1353,8 @@ std::pair<TList *, Int_t> TFile::GetStreamerInfoListImpl(bool lookupSICache)
       (void) lookupSICache;
 #endif
       key->ReadKeyBuffer(buf);
-      list = dynamic_cast<TList*>(key->ReadObjWithBuffer(buffer));
+      list = dynamic_cast<TList*>(key->ReadObjWithBuffer(buffer.data()));
       if (list) list->SetOwner();
-      delete [] buffer;
-      delete key;
    } else {
       list = (TList*)Get("StreamerInfo"); //for versions 2.26 (never released)
    }


### PR DESCRIPTION
Sorry for spamming PRs!

#2420 Implements the fix with an updated backport of `std::make_unique`. However, a solution with `std::vector` is probably more feasible.