### PR TITLE
Add std::make_unique backport supporting std::make_unique<T[]>(N)

### DIFF
--- a/core/foundation/inc/ROOT/RMakeUnique.hxx
+++ b/core/foundation/inc/ROOT/RMakeUnique.hxx
@@ -14,20 +14,48 @@
 #ifndef ROOT_RMakeUnique
 #define ROOT_RMakeUnique
 
-#include <memory>
-
 #if __cplusplus < 201402L && !defined(_MSC_VER)
 
+#include <cstddef>
+#include <memory>
+#include <type_traits>
 #include <utility>
 
-namespace std {
+// Implementation taken from https://isocpp.org/files/papers/N3656.txt
 
-template <typename T, typename... Args>
-std::unique_ptr<T> make_unique(Args &&... args)
+namespace std {
+template <class T>
+struct _Unique_if {
+   typedef unique_ptr<T> _Single_object;
+};
+
+template <class T>
+struct _Unique_if<T[]> {
+   typedef unique_ptr<T[]> _Unknown_bound;
+};
+
+template <class T, size_t N>
+struct _Unique_if<T[N]> {
+   typedef void _Known_bound;
+};
+
+template <class T, class... Args>
+typename _Unique_if<T>::_Single_object make_unique(Args &&... args)
 {
-   return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+   return unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
+
+template <class T>
+typename _Unique_if<T>::_Unknown_bound make_unique(size_t n)
+{
+   typedef typename remove_extent<T>::type U;
+   return unique_ptr<T>(new U[n]());
 }
+
+template <class T, class... Args>
+typename _Unique_if<T>::_Known_bound make_unique(Args &&...) = delete;
+}
+
 #endif
 
 #endif


### PR DESCRIPTION
Improved backport of `std::make_unique` supporting the `std::make_unique<T[]>(N)` case.
Code is taken from the original proposal of the feature [here](https://isocpp.org/files/papers/N3656.txt).

To be discussed: Does this violate any licence?

@Axel-Naumann Do you know whether we can take the code?