### PR TITLE
[VecOps] Fix RAdoptAllocator<bool>

### DIFF
--- a/math/vecops/inc/ROOT/RAdoptAllocator.hxx
+++ b/math/vecops/inc/ROOT/RAdoptAllocator.hxx
@@ -81,16 +81,6 @@ public:
    RAdoptAllocator &operator=(const RAdoptAllocator &) = default;
    RAdoptAllocator &operator=(RAdoptAllocator &&) = default;
 
-   /// Construct a value at a certain memory address
-   /// This method is a no op if memory has been adopted.
-   void construct(pointer p, const_reference val)
-   {
-      // We refuse to do anything since we assume the memory is already initialised
-      if (EAllocType::kAdopting == fAllocType)
-         return;
-      fStdAllocator.construct(p, val);
-   }
-
    /// Construct an object at a certain memory address
    /// \tparam U The type of the memory address at which the object needs to be constructed
    /// \tparam Args The arguments' types necessary for the construction of the object

--- a/math/vecops/inc/ROOT/RAdoptAllocator.hxx
+++ b/math/vecops/inc/ROOT/RAdoptAllocator.hxx
@@ -47,7 +47,6 @@ v.emplace_back(0.);
 now the vector *v* owns its memory as a regular vector.
 **/
 
-
 template <typename T>
 class RAdoptAllocator {
 public:
@@ -61,8 +60,11 @@ public:
    using const_reference = typename StdAlloc_t::const_reference;
    using size_type = typename StdAlloc_t::size_type;
    using difference_type = typename StdAlloc_t::difference_type;
-   template<typename U>
-   struct rebind { using other = RAdoptAllocator<U>; };
+   template <typename U>
+   struct rebind {
+      using other = RAdoptAllocator<U>;
+   };
+
 private:
    enum class EAllocType : char { kOwning, kAdopting, kAdoptingNoAllocYet };
    using StdAllocTraits_t = std::allocator_traits<StdAlloc_t>;
@@ -72,8 +74,7 @@ private:
 
 public:
    /// This is the constructor which allows the allocator to adopt a certain memory region.
-   RAdoptAllocator(pointer p)
-      : fInitialAddress(p), fAllocType(EAllocType::kAdoptingNoAllocYet){};
+   RAdoptAllocator(pointer p) : fInitialAddress(p), fAllocType(EAllocType::kAdoptingNoAllocYet){};
    RAdoptAllocator() = default;
    RAdoptAllocator(const RAdoptAllocator &) = default;
    RAdoptAllocator(RAdoptAllocator &&) = default;
@@ -129,27 +130,22 @@ public:
 
    bool operator==(const RAdoptAllocator<T> &other)
    {
-      return fInitialAddress == other.fInitialAddress &&
-             fAllocType == other.fAllocType &&
+      return fInitialAddress == other.fInitialAddress && fAllocType == other.fAllocType &&
              fStdAllocator == other.fStdAllocator;
    }
-   bool operator!=(const RAdoptAllocator<T> &other)
-   {
-      return !(*this == other);
-   }
+   bool operator!=(const RAdoptAllocator<T> &other) { return !(*this == other); }
 
-   template<class U>
-   void destroy(U* p)
+   template <class U>
+   void destroy(U *p)
    {
       if (EAllocType::kAdopting != fAllocType) {
          fStdAllocator.destroy(p);
       }
    }
-
 };
 
 } // End NS VecOps
-} // End NS Internal
+} // End NS Detail
 } // End NS ROOT
 
 #endif

--- a/math/vecops/test/CMakeLists.txt
+++ b/math/vecops/test/CMakeLists.txt
@@ -1,2 +1,2 @@
 ROOT_ADD_GTEST(vecops_rvec vecops_rvec.cxx LIBRARIES ROOTVecOps RIO Tree)
-ROOT_ADD_GTEST(vecops_radoptallocator vecops_radoptallocator.cxx LIBRARIES Core)
+ROOT_ADD_GTEST(vecops_radoptallocator vecops_radoptallocator.cxx LIBRARIES Core ROOTVecOps)

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -635,3 +635,14 @@ TEST(VecOps, ByIndices)
    ROOT::VecOps::RVec<int> ref{0, 1, 2};
    CheckEqual(v1, ref);
 }
+
+TEST(VecOps, RVecBool)
+{
+   // std::vector<bool> is special, so RVec<bool> is special
+   ROOT::VecOps::RVec<bool> v{true, false};
+   auto v2 = v;
+   EXPECT_EQ(v[0], true);
+   EXPECT_EQ(v[1], false);
+   EXPECT_EQ(v.size(), 2u);
+   CheckEqual(v2, v);
+}


### PR DESCRIPTION
This PR fixes ROOT-9453 ("Cannot instantiate RVec<bool>") and some related issues.

The different semantics of std::vector<bool> make memory adoption through a
custom allocator more complex -- namely, `RAdoptAllocator<bool>` must be
rebindable to `RAdoptAllocator<unsigned long>`, but if adopted memory is
really a buffer of bools, reinterpretation of the adopted buffer as a
different type is going to break things in horrible ways.
As a workaround, `RAdoptAllocator<bool>` is specialized to be a simple
allocator that forwards calls to `std::allocator`, never adopts memory, and
can be rebound to any other allocator (as it never adopts memory it can
rebind the same way that `std::allocator` can).

Note that this is not enough to support `RVec<bool>` columns in `RDataFrame`, for two main reasons:
* `TTreeReaderArray<bool>` is broken, see [ROOT-9570](https://sft.its.cern.ch/jira/browse/ROOT-9570)
* `RVec<bool>` cannot be constructed from a `(bool *, std::size_t)` pair and cannot adopt memory (because `RAdoptAllocator<bool>` cannot adopt memory, because of the problems mentioned above) 

So `RDataFrame` would still have to treat `RVec<bool>` differently:
* use a `TTreeReaderValue<std::vector<bool>>` to read the data from disk correctly
* copy the data into an `RVec<bool>`, without relying on memory adoption

These changes might be added by a future PR as they are outside of the scope of ROOT-9453 ("Cannot instantiate RVec<bool>"), _if_ this proposed solution to ROOT-9453 is accepted.