### PR TITLE
Add missing libcrypto for undefined references

### DIFF
--- a/net/rootd/CMakeLists.txt
+++ b/net/rootd/CMakeLists.txt
@@ -4,6 +4,7 @@
 ############################################################################
 
 ROOT_EXECUTABLE(rootd *.cxx ${CMAKE_SOURCE_DIR}/core/clib/src/strlcpy.c
-  LIBRARIES rpdutil rsa ${GLOBUS_LIBRARIES} ${OPENSSL_LIBRARIES})
+  LIBRARIES rpdutil rsa ${GLOBUS_LIBRARIES} ${OPENSSL_LIBRARIES}
+  BUILTINS OPENSSL)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../rpdutils/res)

--- a/net/rpdutils/CMakeLists.txt
+++ b/net/rpdutils/CMakeLists.txt
@@ -40,5 +40,6 @@ set_property(TARGET rpdutil PROPERTY POSITION_INDEPENDENT_CODE ON)
 add_dependencies(rpdutil move_headers)
 
 ROOT_LINKER_LIBRARY(SrvAuth rpdutils.cxx ssh.cxx
-                    LIBRARIES rpdutil rsa ${GLOBUS_LIBRARIES} DEPENDENCIES Net)
-
+  LIBRARIES rpdutil rsa ${GLOBUS_LIBRARIES} ${OPENSSL_LIBRARIES}
+  DEPENDENCIES Net
+  BUILTINS OPENSSL)


### PR DESCRIPTION
Missing linking to the libcrypto library causes undefined symbols:

````
/usr/bin/ld: ../../lib/librpdutil.a(globus.cxx.o): in function `ROOT::GlbsToolCheckProxy(char**)':
/builddir/build/BUILD/root-6.14.02/net/rpdutils/src/globus.cxx:547: undefined reference to `PEM_read_X509'
/usr/bin/ld: /builddir/build/BUILD/root-6.14.02/net/rpdutils/src/globus.cxx:552: undefined reference to `X509_get_issuer_name'
/usr/bin/ld: /builddir/build/BUILD/root-6.14.02/net/rpdutils/src/globus.cxx:552: undefined reference to `X509_NAME_oneline'
/usr/bin/ld: ../../lib/librpdutil.a(globus.cxx.o): in function `ROOT::GlbsToolCheckCert(char**)':
/builddir/build/BUILD/root-6.14.02/net/rpdutils/src/globus.cxx:187: undefined reference to `PEM_read_X509'
/usr/bin/ld: /builddir/build/BUILD/root-6.14.02/net/rpdutils/src/globus.cxx:192: undefined reference to `X509_get_subject_name'
/usr/bin/ld: /builddir/build/BUILD/root-6.14.02/net/rpdutils/src/globus.cxx:192: undefined reference to `X509_NAME_oneline'
collect2: error: ld returned 1 exit status
````
