### PR TITLE
[TTree] Avoid time-consuming part of FindLeaf if leaf name has no '.'

### DIFF
--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -4695,6 +4695,8 @@ TLeaf* TTree::FindLeaf(const char* searchname)
    TString longname;
    TString longtitle;
 
+   const bool searchnameHasDot = strchr(searchname, '.') != nullptr;
+
    // For leaves we allow for one level up to be prefixed to the name.
    TIter next(GetListOfLeaves());
    TLeaf* leaf = 0;
@@ -4721,6 +4723,8 @@ TLeaf* TTree::FindLeaf(const char* searchname)
       if (subsearchname && leaftitle == subsearchname) {
          return leaf;
       }
+      if (!searchnameHasDot)
+         continue;
       TBranch* branch = leaf->GetBranch();
       if (branch) {
          longname.Form("%s.%s",branch->GetName(),leafname.Data());


### PR DESCRIPTION
Just a proposal :)
Feel free to close if not interesting.

The `TString::Form` calls in `TTree::FindLeaf` are by far the most expensive calls in the function and show up as a significant part of the runtime of `TTreeReaderArray::CreateProxy`.
If I'm not mistaken all that logic can be skipped in case `searchname` does not contain a dot, with significant speed-ups for such a `FindLeaf` call.