### PR TITLE
[DF][ROOT-9463] Avoid redundant results in GetColumnNames

### DIFF
--- a/tree/dataframe/inc/ROOT/RDFInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterface.hxx
@@ -1330,7 +1330,7 @@ public:
       auto df = GetLoopManager();
       auto tree = df->GetTree();
       if (tree) {
-         auto branchNames = RDFInternal::GetBranchNames(*tree);
+         auto branchNames = RDFInternal::GetBranchNames(*tree, /*allowDuplicates=*/false);
          allColumns.insert(allColumns.end(), branchNames.begin(), branchNames.end());
       }
 

--- a/tree/dataframe/inc/ROOT/RDFInterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterfaceUtils.hxx
@@ -379,7 +379,7 @@ struct TNeedJitting<TInferType> {
    static constexpr bool value = true;
 };
 
-ColumnNames_t GetBranchNames(TTree &t);
+ColumnNames_t GetBranchNames(TTree &t, bool allowDuplicates = true);
 
 ColumnNames_t GetTopLevelBranchNames(TTree &t);
 

--- a/tree/dataframe/test/dataframe_interface.cxx
+++ b/tree/dataframe/test/dataframe_interface.cxx
@@ -134,11 +134,9 @@ TEST(RDataFrameInterface, GetColumnNamesFromTree)
    t.Branch("b", &b);
    RDataFrame tdf(t);
    auto names = tdf.GetColumnNames();
+   EXPECT_EQ(2U, names.size());
    EXPECT_STREQ("a", names[0].c_str());
-   EXPECT_STREQ("a.a", names[1].c_str());
-   EXPECT_STREQ("b", names[2].c_str());
-   EXPECT_STREQ("b.b", names[3].c_str());
-   EXPECT_EQ(4U, names.size());
+   EXPECT_STREQ("b", names[1].c_str());
 }
 
 TEST(RDataFrameInterface, GetColumnNamesFromOrdering)
@@ -149,11 +147,10 @@ TEST(RDataFrameInterface, GetColumnNamesFromOrdering)
    t.Branch("aaa", &b);
    RDataFrame tdf(t);
    auto names = tdf.GetColumnNames();
+   EXPECT_EQ(2U, names.size());
    EXPECT_STREQ("zzz", names[0].c_str());
-   EXPECT_STREQ("zzz.zzz", names[1].c_str());
-   EXPECT_STREQ("aaa", names[2].c_str());
-   EXPECT_STREQ("aaa.aaa", names[3].c_str());
-   EXPECT_EQ(4U, names.size());
+   EXPECT_STREQ("aaa", names[1].c_str());
+
 }
 
 TEST(RDataFrameInterface, GetColumnNamesFromSource)


### PR DESCRIPTION
As reported in ROOT-9463, the result of GetColumnNames is redundant. A simple reproducer:
```
TFile f("f.root", "recreate");
TTree t("t", "t");
int a;
t.Branch("a", &a);
a = 42;
t.Fill();
t.Write();
f.Close();
ROOT::RDataFrame df("t", "f.root");

for (auto x : df.GetColumnNames())
   std::cout <<x <<std::endl;
```

This redundancy is now not exposed to the user.

**It would be nice** to have more tests on real use cases.