### PR TITLE
[DF] Move action ownership from RLoopManager to RResultPtr

### DIFF
--- a/tree/dataframe/inc/ROOT/RDFNodes.hxx
+++ b/tree/dataframe/inc/ROOT/RDFNodes.hxx
@@ -372,6 +372,7 @@ public:
    virtual void InitSlot(TTreeReader *r, unsigned int slot) = 0;
    virtual void TriggerChildrenCount() = 0;
    virtual void FinalizeSlot(unsigned int) = 0;
+   virtual void Finalize() = 0;
    /// This method is invoked to update a partial result during the event loop, right before passing the result to a
    /// user-defined callback registered via RResultPtr::RegisterCallback
    virtual void *PartialUpdate(unsigned int slot) = 0;
@@ -392,6 +393,7 @@ public:
    void InitSlot(TTreeReader *r, unsigned int slot) final;
    void TriggerChildrenCount() final;
    void FinalizeSlot(unsigned int) final;
+   void Finalize() final;
    void *PartialUpdate(unsigned int slot) final;
 };
 
@@ -413,7 +415,6 @@ public:
 
    RAction(const RAction &) = delete;
    RAction &operator=(const RAction &) = delete;
-   ~RAction() { fHelper.Finalize(); }
 
    void Initialize() final { fHelper.Initialize(); }
 
@@ -447,6 +448,8 @@ public:
    }
 
    void ClearValueReaders(unsigned int slot) { ResetRDFValueTuple(fValues[slot], TypeInd_t()); }
+
+   void Finalize() final { fHelper.Finalize(); }
 
    /// This method is invoked to update a partial result during the event loop, right before passing the result to a
    /// user-defined callback registered via RResultPtr::RegisterCallback

--- a/tree/dataframe/inc/ROOT/RDFUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDFUtils.hxx
@@ -126,6 +126,13 @@ struct ValueType<ROOT::VecOps::RVec<T>, false> {
 
 std::vector<std::string> ReplaceDotWithUnderscore(const std::vector<std::string> &columnNames);
 
+/// Erase `that` element from vector `v`
+template <typename T>
+void Erase(const T &that, std::vector<T> &v)
+{
+   v.erase(std::remove(v.begin(), v.end(), that), v.end());
+}
+
 } // end NS RDF
 } // end NS Internal
 } // end NS ROOT

--- a/tree/dataframe/src/RDFNodes.cxx
+++ b/tree/dataframe/src/RDFNodes.cxx
@@ -82,6 +82,12 @@ void RJittedAction::FinalizeSlot(unsigned int slot)
    fConcreteAction->FinalizeSlot(slot);
 }
 
+void RJittedAction::Finalize()
+{
+   R__ASSERT(fConcreteAction != nullptr);
+   fConcreteAction->Finalize();
+}
+
 void *RJittedAction::PartialUpdate(unsigned int slot)
 {
    R__ASSERT(fConcreteAction != nullptr);
@@ -565,6 +571,8 @@ void RLoopManager::CleanUpNodes()
    fMustRunNamedFilters = false;
 
    // forget RActions and detach TResultProxies
+   for (auto &ptr : fBookedActions)
+      ptr->Finalize();
    fBookedActions.clear();
    for (auto readiness : fResProxyReadiness) {
       *readiness = true;

--- a/tree/dataframe/src/RDFNodes.cxx
+++ b/tree/dataframe/src/RDFNodes.cxx
@@ -673,9 +673,14 @@ TTree *RLoopManager::GetTree() const
    return fTree.get();
 }
 
-void RLoopManager::Book(const ActionBasePtr_t &actionPtr)
+void RLoopManager::Book(RDFInternal::RActionBase *actionPtr)
 {
    fBookedActions.emplace_back(actionPtr);
+}
+
+void RLoopManager::Deregister(RDFInternal::RActionBase *actionPtr)
+{
+   RDFInternal::Erase(actionPtr, fBookedActions);
 }
 
 void RLoopManager::Book(const FilterBasePtr_t &filterPtr)


### PR DESCRIPTION
This is a first step towards the change in ownership management
required by ROOT-9416, and unblocks development of features that depend on actions staying around even after their event-loop has completed, e.g. generalized merging mechanism, necessary for distributed execution
