### PR TITLE
Reland "[cxxmodules] Check correctly if the decl was cached."

### DIFF
--- a/core/dictgen/res/BaseSelectionRule.h
+++ b/core/dictgen/res/BaseSelectionRule.h
@@ -63,6 +63,7 @@ private:
    std::list<std::string> fFileSubPatterns;        // a list of subpatterns, generated form a file_pattern attribute
    bool                   fMatchFound;             // this is true if this selection rule has been used at least once
    const clang::CXXRecordDecl  *fCXXRecordDecl;    // Record decl of the entity searched for.
+   bool  fCXXRecordDeclLookupFailed = false;       // True if we search for the fCXXRecordDecl and failed.
    const clang::Type           *fRequestedType;    // Same as the record decl but with some of the typedef preserved (Double32_t, Float16_t, etc..)
    cling::Interpreter *fInterp;
 

--- a/core/dictgen/src/BaseSelectionRule.cxx
+++ b/core/dictgen/src/BaseSelectionRule.cxx
@@ -218,7 +218,7 @@ BaseSelectionRule::EMatchType BaseSelectionRule::Match(const clang::NamedDecl *d
                                   ROOT::TMetaUtils::GetUnderlyingRecordDecl(typedefNameDecl->getUnderlyingType());
       }
 
-   if (! isTypedefNametoRecordDecl && fCXXRecordDecl !=0 && fCXXRecordDecl != (void*)-1) {
+   if (! isTypedefNametoRecordDecl && !fCXXRecordDecl && !fCXXRecordDeclLookupFailed) {
       const clang::CXXRecordDecl *target = fCXXRecordDecl;
       if ( target && D && target == D ) {
          //               fprintf(stderr,"DECL MATCH: %s %s\n",name_value.c_str(),name.c_str());
@@ -229,8 +229,9 @@ BaseSelectionRule::EMatchType BaseSelectionRule::Match(const clang::NamedDecl *d
       if (name_value == name) {
          const_cast<BaseSelectionRule*>(this)->SetMatchFound(true);
          return kName;
-      } else if ( fCXXRecordDecl != (void*)-1 ) {
-         // Try a real match!
+      } else if (!fCXXRecordDecl && !fCXXRecordDeclLookupFailed) {
+         // Possibly take the most expensive path if the fCXXRecordDecl is not
+         // set or we already took the expensive path and found nothing.
          const clang::CXXRecordDecl *target
             = fHasFromTypedefAttribute ? nullptr : ROOT::TMetaUtils::ScopeSearch(name_value.c_str(), *fInterp,
                                                    true /*diagnose*/, 0);
@@ -239,7 +240,7 @@ BaseSelectionRule::EMatchType BaseSelectionRule::Match(const clang::NamedDecl *d
             const_cast<BaseSelectionRule*>(this)->fCXXRecordDecl = target;
          } else {
             // If the lookup failed, let's not try it again, so mark the value has invalid.
-            const_cast<BaseSelectionRule*>(this)->fCXXRecordDecl = (clang::CXXRecordDecl*)-1;
+            const_cast<BaseSelectionRule*>(this)->fCXXRecordDeclLookupFailed = true;
          }
          if ( target && D && target == D ) {
             const_cast<BaseSelectionRule*>(this)->SetMatchFound(true);

--- a/core/dictgen/src/BaseSelectionRule.cxx
+++ b/core/dictgen/src/BaseSelectionRule.cxx
@@ -229,9 +229,8 @@ BaseSelectionRule::EMatchType BaseSelectionRule::Match(const clang::NamedDecl *d
       if (name_value == name) {
          const_cast<BaseSelectionRule*>(this)->SetMatchFound(true);
          return kName;
-      } else if ( !fCXXRecordDecl || fCXXRecordDecl != (void*)-1) {
-         // Possibly take the most expensive path if the fCXXRecordDecl is not
-         // set or we already took the expensive path and found nothing (-1).
+      } else if ( fCXXRecordDecl != (void*)-1 ) {
+         // Try a real match!
          const clang::CXXRecordDecl *target
             = fHasFromTypedefAttribute ? nullptr : ROOT::TMetaUtils::ScopeSearch(name_value.c_str(), *fInterp,
                                                    true /*diagnose*/, 0);


### PR DESCRIPTION
Instead of checking for -1 and ending in strange pointer-bool conversion, we use a data member to tell us if we have looked up the record decl already.

