### PR TITLE
Unit tests for Pythonizations

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -1,2 +1,7 @@
+# General pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pretty_printing pretty_printing.py)
+
+# TTree pythonizations
+ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_branch_attr ttree_branch_attr.py
+                    COPY_TO_BUILDDIR TreeHelper.h)
 

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -4,4 +4,6 @@ ROOT_ADD_PYUNITTEST(pyroot_pretty_printing pretty_printing.py)
 # TTree pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_branch_attr ttree_branch_attr.py
                     COPY_TO_BUILDDIR TreeHelper.h)
+ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_iterable ttree_iterable.py
+                    COPY_TO_BUILDDIR TreeHelper.h)
 

--- a/bindings/pyroot_experimental/PyROOT/test/TreeHelper.h
+++ b/bindings/pyroot_experimental/PyROOT/test/TreeHelper.h
@@ -1,0 +1,53 @@
+
+// Helper struct for this test
+struct MyStruct {
+   int myint1;
+   int myint2;
+};
+
+// Writes a `TTree` on a file. The `TTree` has the following branches:
+// - floatb: branch of basic type (`float`)
+// - arrayb: branch of type array of doubles, size `arraysize`
+// - vectorb: branch of type `std::vector<double>`, size `arraysize`
+// - structb: struct branch of type `MyStruct`
+// - structleafb: struct branch of type `MyStruct`, created as a leaf list
+void CreateTTree(const char *filename, const char *treename, int nentries, int arraysize, int more)
+{
+   TFile f(filename, "RECREATE");
+   TTree t(treename, "Test tree");
+
+   // Float branch
+   float n;
+   t.Branch("floatb", &n);
+
+   // Array branch
+   auto a = new double[arraysize];
+   t.Branch("arrayb", a, std::string("arrayb[") + arraysize + "]/D");
+
+   // Vector branch
+   std::vector<double> v(arraysize);
+   t.Branch("vectorb", &v);
+
+   // Struct branches
+   MyStruct mystruct;
+   t.Branch("structb", &mystruct);
+   t.Branch("structleaflistb", &mystruct, "myintll1/I:myintll2/I");
+
+   for (int i = 0; i < nentries; ++i) {
+      n = i + more;
+
+      for (int j = 0; j < arraysize; ++j) {
+         a[j] = v[j] = i + j;
+      }
+
+      mystruct.myint1 = i + more;
+      mystruct.myint2 = i * more;
+
+      t.Fill();
+   }
+
+   f.Write();
+   f.Close();
+
+   delete[] a;
+}

--- a/bindings/pyroot_experimental/PyROOT/test/ttree_branch_attr.py
+++ b/bindings/pyroot_experimental/PyROOT/test/ttree_branch_attr.py
@@ -1,0 +1,82 @@
+import unittest
+
+import ROOT
+from libcppyy import SetOwnership
+
+
+class TTreeBranchAttr(unittest.TestCase):
+    """
+    Test for the pythonization that allows to access top-level tree branches/leaves as attributes
+    (i.e. `mytree.mybranch`)
+    """
+
+    filename  = 'treebranchattr.root'
+    treename  = 'mytree'
+    nentries  = 1
+    arraysize = 10
+    more      = 10
+
+    # Setup
+    @classmethod
+    def setUpClass(cls):
+        ROOT.gInterpreter.Declare('#include "TreeHelper.h"')
+        ROOT.CreateTTree(cls.filename, cls.treename, cls.nentries, cls.arraysize, cls.more)
+
+    # Helper
+    def get_file_and_tree(self):
+        f = ROOT.TFile(self.filename)
+        t = f.Get(self.treename)
+        # Prevent double deletion of the tree (Python and C++ TFile)
+        SetOwnership(t, False)
+
+        # Read first entry
+        t.GetEntry(0)
+
+        return f,t
+
+    # Tests
+    def test_basic_type_branch(self):
+        f,t = self.get_file_and_tree()
+
+        self.assertEqual(t.floatb, self.more)
+
+    def test_array_branch(self):
+        f,t = self.get_file_and_tree()
+
+        a = t.arrayb
+        
+        for j in range(self.arraysize):
+            self.assertEqual(a[j], j)
+
+    def test_vector_branch(self):
+        f,t = self.get_file_and_tree()
+
+        v = t.vectorb
+
+        for j in range(self.arraysize):
+            self.assertEqual(v[j], j)
+
+    def test_struct_branch(self):
+        f,t = self.get_file_and_tree()
+
+        ms = t.structb
+
+        self.assertEqual(ms.myint1, self.more)
+        self.assertEqual(ms.myint2, 0)
+
+    def test_struct_branch_leaflist(self):
+        f,t = self.get_file_and_tree()
+
+        self.assertEqual(t.myintll1, self.more)
+        self.assertEqual(t.myintll2, 0)
+
+    def test_alias_branch(self):
+        f,t = self.get_file_and_tree()
+
+        t.SetAlias('myalias', 'floatb')
+
+        self.assertEqual(t.myalias, t.floatb)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bindings/pyroot_experimental/PyROOT/test/ttree_iterable.py
+++ b/bindings/pyroot_experimental/PyROOT/test/ttree_iterable.py
@@ -1,0 +1,75 @@
+import unittest
+from array import array
+
+import ROOT
+from libcppyy import SetOwnership
+
+
+class TTreeIterable(unittest.TestCase):
+    """
+    Test for the pythonization that makes TTree instances iterable in Python. 
+    For example, this allows to do:
+    `for event in mytree:`
+         `...`
+    """
+
+    filename  = 'treeiterable.root'
+    treename  = 'mytree'
+    nentries  = 10
+    arraysize = 10
+    more      = 10
+
+    # Setup
+    @classmethod
+    def setUpClass(cls):
+        ROOT.gInterpreter.Declare('#include "TreeHelper.h"')                                          
+        ROOT.CreateTTree(cls.filename, cls.treename, cls.nentries, cls.arraysize, cls.more)
+
+    # Helper
+    def get_file_and_tree(self):
+        f = ROOT.TFile(self.filename)
+        t = f.Get(self.treename)
+        # Prevent double deletion of the tree (Python and C++ TFile)
+        SetOwnership(t, False)
+
+        return f,t
+
+    # Tests
+    def test_basic_type_branch(self):
+        f,t = self.get_file_and_tree()
+
+        n = array('f', [ 0. ])
+        t.SetBranchAddress('floatb', n)
+
+        i = 0
+        for entry in t:
+            self.assertEqual(n[0], i+self.more)
+            i += 1
+
+    def test_array_branch(self):
+        f,t = self.get_file_and_tree()
+
+        a = array('d', self.arraysize*[ 0. ])
+        t.SetBranchAddress('arrayb', a)
+
+        i = 0
+        for entry in t:
+            for j in range(self.arraysize):
+                self.assertEqual(a[j], i+j)
+            i += 1
+
+    def test_struct_branch(self):
+        f,t = self.get_file_and_tree()
+
+        ms = ROOT.MyStruct()
+        t.SetBranchAddress('structleaflistb', ms)
+
+        i = 0
+        for entry in t:
+            self.assertEqual(ms.myint1, i+self.more)
+            self.assertEqual(ms.myint2, i*self.more)
+            i += 1
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -1369,6 +1369,8 @@ endfunction()
 # ROOT_ADD_PYUNITTEST( <name> <file>)
 #----------------------------------------------------------------------------
 function(ROOT_ADD_PYUNITTEST name file)
+  CMAKE_PARSE_ARGUMENTS(ARG "" "" "COPY_TO_BUILDDIR" ${ARGN})
+
   set(ROOT_ENV ROOTSYS=${ROOTSYS}
       PATH=${ROOTSYS}/bin:$ENV{PATH}
       LD_LIBRARY_PATH=${ROOTSYS}/lib:$ENV{LD_LIBRARY_PATH}
@@ -1376,9 +1378,19 @@ function(ROOT_ADD_PYUNITTEST name file)
   string(REGEX REPLACE "[_]" "-" good_name "${name}")
   get_filename_component(file_name ${file} NAME)
   get_filename_component(file_dir ${file} DIRECTORY)
+
+  if(ARG_COPY_TO_BUILDDIR)
+    foreach(copy_file ${ARG_COPY_TO_BUILDDIR})
+      get_filename_component(abs_path ${copy_file} ABSOLUTE)
+      set(copy_files ${copy_files} ${abs_path})
+    endforeach()
+    set(copy_to_builddir COPY_TO_BUILDDIR ${copy_files})
+  endif()
+
   ROOT_ADD_TEST(pyunittests-${good_name}
                 COMMAND ${PYTHON_EXECUTABLE} -B -m unittest discover -s ${CMAKE_CURRENT_SOURCE_DIR}/${file_dir} -p ${file_name} -v
-                ENVIRONMENT ${ROOT_ENV})
+                ENVIRONMENT ${ROOT_ENV}
+                ${copy_to_builddir})
 endfunction()
 
 #----------------------------------------------------------------------------


### PR DESCRIPTION
Add a couple of unit tests for two pythonizations:
- Access a TTree branch as an attribute
- Make a TTree iterable

Both of them test different types of branches, which is especially relevant in the first test. The fact that the pythonization of `SetBranchAddress` is still not present in PyROOT experimental prevents the second test from testing more branch types (i.e. those that require a reference to a pointer); this is not an issue anyway since the code of the TTree-iterable pythonization is tested in its entirety by the current cases.