### PR TITLE
[DF] Store RJittedAction on the heap to avoid use after delete

### DIFF
--- a/tree/dataframe/inc/ROOT/RDFInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterface.hxx
@@ -1610,14 +1610,14 @@ private:
       auto upcastNode = RDFInternal::UpcastNode(fProxiedPtr);
       RInterface<TypeTraits::TakeFirstParameter_t<decltype(upcastNode)>> upcastInterface(
          upcastNode, fImplWeakPtr, fValidCustomColumns, fBranchNames, fDataSource);
-      auto jittedAction = std::make_unique<RDFInternal::RJittedAction>(*lm);
+      auto jittedActionOnHeap = RDFInternal::MakeSharedOnHeap(std::make_shared<RDFInternal::RJittedAction>(*lm));
       auto toJit =
          RDFInternal::JitBuildAction(validColumnNames, upcastInterface.GetNodeTypeName(), upcastNode.get(),
                                      typeid(std::shared_ptr<ActionResultType>), typeid(ActionTag), rOnHeap, tree,
-                                     nSlots, customColumns, fDataSource, jittedAction.get(), lm->GetID());
-      lm->Book(jittedAction.get());
+                                     nSlots, customColumns, fDataSource, jittedActionOnHeap, lm->GetID());
+      lm->Book(jittedActionOnHeap->get());
       lm->ToJit(toJit);
-      return MakeResultPtr(r, lm, std::move(jittedAction));
+      return MakeResultPtr(r, lm, *jittedActionOnHeap);
    }
 
    template <typename F, typename CustomColumnType, typename RetType = typename TTraits::CallableTraits<F>::ret_type>

--- a/tree/dataframe/inc/ROOT/RDFInterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterfaceUtils.hxx
@@ -225,7 +225,7 @@ void BookDefineJit(std::string_view name, std::string_view expression, RLoopMana
 std::string JitBuildAction(const ColumnNames_t &bl, const std::string &prevNodeTypename, void *prevNode,
                            const std::type_info &art, const std::type_info &at, void *r, TTree *tree,
                            const unsigned int nSlots, const ColumnNames_t &customColumns, RDataSource *ds,
-                           RJittedAction *jittedAction, unsigned int namespaceID);
+                           std::shared_ptr<RJittedAction> *jittedActionOnHeap, unsigned int namespaceID);
 
 // allocate a shared_ptr on the heap, return a reference to it. the user is responsible of deleting the shared_ptr*.
 // this function is meant to only be used by RInterface's action methods, and should be deprecated as soon as we find
@@ -320,7 +320,8 @@ void JitDefineHelper(F &&f, const ColumnNames_t &cols, std::string_view name, RL
 /// Convenience function invoked by jitted code to build action nodes at runtime
 template <typename ActionTag, typename... BranchTypes, typename PrevNodeType, typename ActionResultType>
 void CallBuildAction(PrevNodeType &prevNode, const ColumnNames_t &bl, const unsigned int nSlots,
-                     const std::shared_ptr<ActionResultType> *rOnHeap, RJittedAction *jittedAction)
+                     const std::shared_ptr<ActionResultType> *rOnHeap,
+                     std::shared_ptr<RJittedAction> *jittedActionOnHeap)
 {
    // if we are here it means we are jitting, if we are jitting the loop manager must be alive
    auto &loopManager = *prevNode.GetLoopManagerUnchecked();
@@ -330,8 +331,9 @@ void CallBuildAction(PrevNodeType &prevNode, const ColumnNames_t &bl, const unsi
    if (ds)
       DefineDataSourceColumns(bl, loopManager, *ds, std::make_index_sequence<nColumns>(), ColTypes_t());
    auto actionPtr = BuildAction<BranchTypes...>(bl, *rOnHeap, nSlots, prevNode, ActionTag{});
-   jittedAction->SetAction(std::move(actionPtr));
+   (*jittedActionOnHeap)->SetAction(std::move(actionPtr));
    delete rOnHeap;
+   delete jittedActionOnHeap;
 }
 
 /// The contained `type` alias is `double` if `T == TInferType`, `U` if `T == std::container<U>`, `T` otherwise.

--- a/tree/dataframe/inc/ROOT/RResultPtr.hxx
+++ b/tree/dataframe/inc/ROOT/RResultPtr.hxx
@@ -33,7 +33,7 @@ using ROOT::RDF::RResultPtr;
 // Fwd decl for RResultPtr
 template <typename T>
 RResultPtr<T> MakeResultPtr(const std::shared_ptr<T> &r, const std::shared_ptr<RLoopManager> &df,
-                            std::unique_ptr<ROOT::Internal::RDF::RActionBase> actionPtr);
+                            std::shared_ptr<ROOT::Internal::RDF::RActionBase> actionPtr);
 } // ns RDF
 } // ns Detail
 
@@ -73,7 +73,7 @@ class RResultPtr {
    // friend declarations
    template <typename T1>
    friend RResultPtr<T1>
-   RDFDetail::MakeResultPtr(const std::shared_ptr<T1> &, const SPTLM_t &, std::unique_ptr<RDFInternal::RActionBase>);
+   RDFDetail::MakeResultPtr(const std::shared_ptr<T1> &, const SPTLM_t &, std::shared_ptr<RDFInternal::RActionBase>);
    template <class T1, class T2>
    friend bool operator==(const RResultPtr<T1> &lhs, const RResultPtr<T2> &rhs);
    template <class T1, class T2>
@@ -125,7 +125,7 @@ class RResultPtr {
    }
 
    RResultPtr(std::shared_ptr<T> objPtr, std::shared_ptr<bool> readiness, std::shared_ptr<RDFDetail::RLoopManager> lm,
-              std::unique_ptr<RDFInternal::RActionBase> actionPtr)
+              std::shared_ptr<RDFInternal::RActionBase> actionPtr)
       : fReadiness(readiness), fImplWeakPtr(std::move(lm)), fObjPtr(std::move(objPtr)), fActionPtr(std::move(actionPtr))
    {
    }
@@ -336,7 +336,7 @@ namespace RDF {
 /// This overload is invoked by non-jitted actions, as they have access to RAction before constructing RResultPtr.
 template <typename T>
 RResultPtr<T> MakeResultPtr(const std::shared_ptr<T> &r, const std::shared_ptr<RLoopManager> &df,
-                            std::unique_ptr<RDFInternal::RActionBase> actionPtr)
+                            std::shared_ptr<RDFInternal::RActionBase> actionPtr)
 {
    auto readiness = std::make_shared<bool>(false);
    auto resPtr = RResultPtr<T>(r, readiness, df, std::move(actionPtr));

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -639,7 +639,7 @@ void BookDefineJit(std::string_view name, std::string_view expression, RLoopMana
 std::string JitBuildAction(const ColumnNames_t &bl, const std::string &prevNodeTypename, void *prevNode,
                            const std::type_info &art, const std::type_info &at, void *rOnHeap, TTree *tree,
                            const unsigned int nSlots, const ColumnNames_t &customColumns, RDataSource *ds,
-                           RJittedAction *jittedAction, unsigned int namespaceID)
+                           std::shared_ptr<RJittedAction> *jittedActionOnHeap, unsigned int namespaceID)
 {
    auto nBranches = bl.size();
 
@@ -690,8 +690,8 @@ std::string JitBuildAction(const ColumnNames_t &bl, const std::string &prevNodeT
    }
    createAction_str << "}, " << std::dec << std::noshowbase << nSlots << ", reinterpret_cast<" << actionResultTypeName
                     << "*>(" << PrettyPrintAddr(rOnHeap) << ")"
-                    << ", reinterpret_cast<ROOT::Internal::RDF::RJittedAction*>(" << PrettyPrintAddr(jittedAction)
-                    << "));";
+                    << ", reinterpret_cast<std::shared_ptr<ROOT::Internal::RDF::RJittedAction>*>("
+                    << PrettyPrintAddr(jittedActionOnHeap) << "));";
    return createAction_str.str();
 }
 


### PR DESCRIPTION
The use after delete might happen in case the corresponding RResultPtr
goes out of scope before the concrete action is jitted.