### PR TITLE
 [DF] Give nodes shared ownership of their parents

### DIFF
--- a/tree/dataframe/inc/ROOT/RDFInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterface.hxx
@@ -153,9 +153,9 @@ public:
          RDFInternal::DefineDataSourceColumns(validColumnNames, *loopManager, *fDataSource,
                                               std::make_index_sequence<nColumns>(), ColTypes_t());
       using F_t = RDFDetail::RFilter<F, Proxied>;
-      auto FilterPtr = std::make_shared<F_t>(std::move(f), validColumnNames, fProxiedPtr, name);
-      loopManager->Book(FilterPtr);
-      return RInterface<F_t, DS_t>(FilterPtr, fImplWeakPtr, fValidCustomColumns, fBranchNames, fDataSource);
+      auto filterPtr = std::make_shared<F_t>(std::move(f), validColumnNames, fProxiedPtr, name);
+      loopManager->Book(filterPtr.get());
+      return RInterface<F_t, DS_t>(std::move(filterPtr), fImplWeakPtr, fValidCustomColumns, fBranchNames, fDataSource);
    }
 
    ////////////////////////////////////////////////////////////////////////////
@@ -213,9 +213,9 @@ public:
       RDFInternal::BookFilterJit(jittedFilter.get(), upcastNodeOnHeap, prevNodeTypeName, name, expression, aliasMap,
                                  branches, customColumns, tree, fDataSource, df->GetID());
 
-      df->Book(jittedFilter);
-      return RInterface<RDFDetail::RJittedFilter, DS_t>(jittedFilter, fImplWeakPtr, fValidCustomColumns, fBranchNames,
-                                                        fDataSource);
+      df->Book(jittedFilter.get());
+      return RInterface<RDFDetail::RJittedFilter, DS_t>(std::move(jittedFilter), fImplWeakPtr, fValidCustomColumns,
+                                                        fBranchNames, fDataSource);
    }
 
    // clang-format off
@@ -561,10 +561,10 @@ public:
 
       auto df = GetLoopManager();
       using Range_t = RDFDetail::RRange<Proxied>;
-      auto RangePtr = std::make_shared<Range_t>(begin, end, stride, fProxiedPtr);
-      df->Book(RangePtr);
-      RInterface<RDFDetail::RRange<Proxied>> tdf_r(RangePtr, fImplWeakPtr, fValidCustomColumns,
-                                                   fBranchNames,  fDataSource);
+      auto rangePtr = std::make_shared<Range_t>(begin, end, stride, fProxiedPtr);
+      df->Book(rangePtr.get());
+      RInterface<RDFDetail::RRange<Proxied>> tdf_r(std::move(rangePtr), fImplWeakPtr, fValidCustomColumns, fBranchNames,
+                                                   fDataSource);
       return tdf_r;
    }
 

--- a/tree/dataframe/inc/ROOT/RDFInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterface.hxx
@@ -153,7 +153,7 @@ public:
          RDFInternal::DefineDataSourceColumns(validColumnNames, *loopManager, *fDataSource,
                                               std::make_index_sequence<nColumns>(), ColTypes_t());
       using F_t = RDFDetail::RFilter<F, Proxied>;
-      auto FilterPtr = std::make_shared<F_t>(std::move(f), validColumnNames, *fProxiedPtr, name);
+      auto FilterPtr = std::make_shared<F_t>(std::move(f), validColumnNames, fProxiedPtr, name);
       loopManager->Book(FilterPtr);
       return RInterface<F_t, DS_t>(FilterPtr, fImplWeakPtr, fValidCustomColumns, fBranchNames, fDataSource);
    }
@@ -204,17 +204,18 @@ public:
       const auto branches = tree ? RDFInternal::GetBranchNames(*tree) : ColumnNames_t();
       const auto &customColumns = df->GetCustomColumnNames();
 
-      auto upcastNode = RDFInternal::UpcastNode(fProxiedPtr);
-      RInterface<typename decltype(upcastNode)::element_type> upcastInterface(upcastNode, fImplWeakPtr,
-                                                                              fValidCustomColumns, fBranchNames, fDataSource);
+      auto upcastNodeOnHeap = RDFInternal::MakeSharedOnHeap(RDFInternal::UpcastNode(fProxiedPtr));
+      using BaseNodeType_t = typename std::remove_pointer<decltype(upcastNodeOnHeap)>::type::element_type;
+      RInterface<BaseNodeType_t> upcastInterface(*upcastNodeOnHeap, fImplWeakPtr, fValidCustomColumns, fBranchNames,
+                                                 fDataSource);
       const auto prevNodeTypeName = upcastInterface.GetNodeTypeName();
       const auto jittedFilter = std::make_shared<RDFDetail::RJittedFilter>(df.get(), name);
-      RDFInternal::BookFilterJit(jittedFilter.get(), upcastNode.get(), prevNodeTypeName, name, expression, aliasMap,
+      RDFInternal::BookFilterJit(jittedFilter.get(), upcastNodeOnHeap, prevNodeTypeName, name, expression, aliasMap,
                                  branches, customColumns, tree, fDataSource, df->GetID());
 
       df->Book(jittedFilter);
-      return RInterface<RDFDetail::RJittedFilter, DS_t>(jittedFilter, fImplWeakPtr, fValidCustomColumns,
-                                                        fBranchNames, fDataSource);
+      return RInterface<RDFDetail::RJittedFilter, DS_t>(jittedFilter, fImplWeakPtr, fValidCustomColumns, fBranchNames,
+                                                        fDataSource);
    }
 
    // clang-format off
@@ -560,7 +561,7 @@ public:
 
       auto df = GetLoopManager();
       using Range_t = RDFDetail::RRange<Proxied>;
-      auto RangePtr = std::make_shared<Range_t>(begin, end, stride, *fProxiedPtr);
+      auto RangePtr = std::make_shared<Range_t>(begin, end, stride, fProxiedPtr);
       df->Book(RangePtr);
       RInterface<RDFDetail::RRange<Proxied>> tdf_r(RangePtr, fImplWeakPtr, fValidCustomColumns,
                                                    fBranchNames,  fDataSource);
@@ -625,7 +626,7 @@ public:
                                               std::make_index_sequence<nColumns>(), ColTypes_t());
       using Helper_t = RDFInternal::ForeachSlotHelper<F>;
       using Action_t = RDFInternal::RAction<Helper_t, Proxied>;
-      auto action = std::make_unique<Action_t>(Helper_t(std::move(f)), validColumnNames, *fProxiedPtr);
+      auto action = std::make_unique<Action_t>(Helper_t(std::move(f)), validColumnNames, fProxiedPtr);
       loopManager->Book(action.get());
       loopManager->Run();
    }
@@ -691,7 +692,7 @@ public:
       auto cSPtr = std::make_shared<ULong64_t>(0);
       using Helper_t = RDFInternal::CountHelper;
       using Action_t = RDFInternal::RAction<Helper_t, Proxied>;
-      auto action = std::make_unique<Action_t>(Helper_t(cSPtr, nSlots), ColumnNames_t({}), *fProxiedPtr);
+      auto action = std::make_unique<Action_t>(Helper_t(cSPtr, nSlots), ColumnNames_t({}), fProxiedPtr);
       df->Book(action.get());
       return MakeResultPtr(cSPtr, df, std::move(action));
    }
@@ -719,7 +720,7 @@ public:
       using Action_t = RDFInternal::RAction<Helper_t, Proxied>;
       auto valuesPtr = std::make_shared<COLL>();
       const auto nSlots = loopManager->GetNSlots();
-      auto action = std::make_unique<Action_t>(Helper_t(valuesPtr, nSlots), validColumnNames, *fProxiedPtr);
+      auto action = std::make_unique<Action_t>(Helper_t(valuesPtr, nSlots), validColumnNames, fProxiedPtr);
       loopManager->Book(action.get());
       return MakeResultPtr(valuesPtr, loopManager, std::move(action));
    }
@@ -1307,7 +1308,7 @@ public:
       using Helper_t = RDFInternal::ReportHelper<Proxied>;
       using Action_t = RDFInternal::RAction<Helper_t, Proxied>;
       auto action =
-         std::make_unique<Action_t>(Helper_t(rep, fProxiedPtr, returnEmptyReport), ColumnNames_t({}), *fProxiedPtr);
+         std::make_unique<Action_t>(Helper_t(rep, fProxiedPtr, returnEmptyReport), ColumnNames_t({}), fProxiedPtr);
       lm->Book(action.get());
       return MakeResultPtr(rep, lm, std::move(action));
    }
@@ -1416,7 +1417,7 @@ public:
       using Action_t = typename RDFInternal::RAction<Helper_t, Proxied>;
       auto action = std::make_unique<Action_t>(
          Helper_t(std::move(aggregator), std::move(merger), accObjPtr, loopManager->GetNSlots()), validColumnNames,
-         *fProxiedPtr);
+         fProxiedPtr);
       loopManager->Book(action.get());
       return MakeResultPtr(accObjPtr, loopManager, std::move(action));
    }
@@ -1487,7 +1488,7 @@ public:
       auto lm = GetLoopManager();
       using Action_t = typename RDFInternal::RAction<Helper, Proxied, TTraits::TypeList<ColumnTypes...>>;
       auto resPtr = h.GetResultPtr();
-      auto action = std::make_unique<Action_t>(Helper(std::forward<Helper>(h)), columns, *fProxiedPtr);
+      auto action = std::make_unique<Action_t>(Helper(std::forward<Helper>(h)), columns, fProxiedPtr);
       lm->Book(action.get());
       return MakeResultPtr(resPtr, lm, std::move(action));
    }
@@ -1587,7 +1588,7 @@ private:
          RDFInternal::DefineDataSourceColumns(selectedCols, *lm, *fDataSource, std::make_index_sequence<nColumns>(),
                                               RDFInternal::TypeList<BranchTypes...>());
       const auto nSlots = lm->GetNSlots();
-      auto action = RDFInternal::BuildAction<BranchTypes...>(selectedCols, r, nSlots, *fProxiedPtr, ActionTag{});
+      auto action = RDFInternal::BuildAction<BranchTypes...>(selectedCols, r, nSlots, fProxiedPtr, ActionTag{});
       lm->Book(action.get());
       return MakeResultPtr(r, lm, std::move(action));
    }
@@ -1607,12 +1608,13 @@ private:
       const auto &customColumns = lm->GetCustomColumnNames();
       auto tree = lm->GetTree();
       auto rOnHeap = RDFInternal::MakeSharedOnHeap(r);
-      auto upcastNode = RDFInternal::UpcastNode(fProxiedPtr);
-      RInterface<TypeTraits::TakeFirstParameter_t<decltype(upcastNode)>> upcastInterface(
-         upcastNode, fImplWeakPtr, fValidCustomColumns, fBranchNames, fDataSource);
+      auto upcastNodeOnHeap = RDFInternal::MakeSharedOnHeap(RDFInternal::UpcastNode(fProxiedPtr));
+      using BaseNodeType_t = typename std::remove_pointer<decltype(upcastNodeOnHeap)>::type::element_type;
+      RInterface<BaseNodeType_t> upcastInterface(*upcastNodeOnHeap, fImplWeakPtr, fValidCustomColumns, fBranchNames,
+                                                 fDataSource);
       auto jittedActionOnHeap = RDFInternal::MakeSharedOnHeap(std::make_shared<RDFInternal::RJittedAction>(*lm));
       auto toJit =
-         RDFInternal::JitBuildAction(validColumnNames, upcastInterface.GetNodeTypeName(), upcastNode.get(),
+         RDFInternal::JitBuildAction(validColumnNames, upcastInterface.GetNodeTypeName(), upcastNodeOnHeap,
                                      typeid(std::shared_ptr<ActionResultType>), typeid(ActionTag), rOnHeap, tree,
                                      nSlots, customColumns, fDataSource, jittedActionOnHeap, lm->GetID());
       lm->Book(jittedActionOnHeap->get());
@@ -1712,14 +1714,14 @@ private:
          using Helper_t = RDFInternal::SnapshotHelper<ColumnTypes...>;
          using Action_t = RDFInternal::RAction<Helper_t, Proxied, TTraits::TypeList<ColumnTypes...>>;
          actionPtr.reset(new Action_t(Helper_t(filename, dirname, treename, validCols, columnList, options), validCols,
-                                      *fProxiedPtr));
+                                      fProxiedPtr));
       } else {
          // multi-thread snapshot
          using Helper_t = RDFInternal::SnapshotHelperMT<ColumnTypes...>;
          using Action_t = RDFInternal::RAction<Helper_t, Proxied>;
          actionPtr.reset(
             new Action_t(Helper_t(lm->GetNSlots(), filename, dirname, treename, validCols, columnList, options),
-                         validCols, *fProxiedPtr));
+                         validCols, fProxiedPtr));
       }
 
       lm->Book(actionPtr.get());

--- a/tree/dataframe/inc/ROOT/RDFInterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterfaceUtils.hxx
@@ -117,84 +117,91 @@ struct HistoUtils<T, true> {
 // Generic filling (covers Histo2D, Histo3D, Profile1D and Profile2D actions, with and without weights)
 template <typename... BranchTypes, typename ActionTag, typename ActionResultType, typename PrevNodeType>
 std::unique_ptr<RActionBase> BuildAction(const ColumnNames_t &bl, const std::shared_ptr<ActionResultType> &h,
-                                         const unsigned int nSlots, PrevNodeType &prevNode, ActionTag)
+                                         const unsigned int nSlots, std::shared_ptr<PrevNodeType> prevNode, ActionTag)
 {
    using Helper_t = FillTOHelper<ActionResultType>;
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<BranchTypes...>>;
-   return std::make_unique<Action_t>(Helper_t(h, nSlots), bl, prevNode);
+   return std::make_unique<Action_t>(Helper_t(h, nSlots), bl, std::move(prevNode));
 }
 
 // Histo1D filling (must handle the special case of distinguishing FillTOHelper and FillHelper
 template <typename... BranchTypes, typename PrevNodeType>
-std::unique_ptr<RActionBase> BuildAction(const ColumnNames_t &bl, const std::shared_ptr<::TH1D> &h,
-                                         const unsigned int nSlots, PrevNodeType &prevNode, ActionTags::Histo1D)
+std::unique_ptr<RActionBase>
+BuildAction(const ColumnNames_t &bl, const std::shared_ptr<::TH1D> &h, const unsigned int nSlots,
+            std::shared_ptr<PrevNodeType> prevNode, ActionTags::Histo1D)
 {
    auto hasAxisLimits = HistoUtils<::TH1D>::HasAxisLimits(*h);
 
    if (hasAxisLimits) {
       using Helper_t = FillTOHelper<::TH1D>;
       using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<BranchTypes...>>;
-      return std::make_unique<Action_t>(Helper_t(h, nSlots), bl, prevNode);
+      return std::make_unique<Action_t>(Helper_t(h, nSlots), bl, std::move(prevNode));
    } else {
       using Helper_t = FillHelper;
       using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<BranchTypes...>>;
-      return std::make_unique<Action_t>(Helper_t(h, nSlots), bl, prevNode);
+      return std::make_unique<Action_t>(Helper_t(h, nSlots), bl, std::move(prevNode));
    }
 }
 
 template <typename... BranchTypes, typename PrevNodeType>
-std::unique_ptr<RActionBase> BuildAction(const ColumnNames_t &bl, const std::shared_ptr<TGraph> &g,
-                                         const unsigned int nSlots, PrevNodeType &prevNode, ActionTags::Graph)
+std::unique_ptr<RActionBase>
+BuildAction(const ColumnNames_t &bl, const std::shared_ptr<TGraph> &g, const unsigned int nSlots,
+            std::shared_ptr<PrevNodeType> prevNode, ActionTags::Graph)
 {
    using Helper_t = FillTGraphHelper;
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<BranchTypes...>>;
-   return std::make_unique<Action_t>(Helper_t(g, nSlots), bl, prevNode);
+   return std::make_unique<Action_t>(Helper_t(g, nSlots), bl, std::move(prevNode));
 }
 
 // Min action
 template <typename BranchType, typename PrevNodeType, typename ActionResultType>
-std::unique_ptr<RActionBase> BuildAction(const ColumnNames_t &bl, const std::shared_ptr<ActionResultType> &minV,
-                                         const unsigned int nSlots, PrevNodeType &prevNode, ActionTags::Min)
+std::unique_ptr<RActionBase>
+BuildAction(const ColumnNames_t &bl, const std::shared_ptr<ActionResultType> &minV, const unsigned int nSlots,
+            std::shared_ptr<PrevNodeType> prevNode, ActionTags::Min)
 {
    using Helper_t = MinHelper<ActionResultType>;
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<BranchType>>;
-   return std::make_unique<Action_t>(Helper_t(minV, nSlots), bl, prevNode);
+   return std::make_unique<Action_t>(Helper_t(minV, nSlots), bl, std::move(prevNode));
 }
 
 // Max action
 template <typename BranchType, typename PrevNodeType, typename ActionResultType>
-std::unique_ptr<RActionBase> BuildAction(const ColumnNames_t &bl, const std::shared_ptr<ActionResultType> &maxV,
-                                         const unsigned int nSlots, PrevNodeType &prevNode, ActionTags::Max)
+std::unique_ptr<RActionBase>
+BuildAction(const ColumnNames_t &bl, const std::shared_ptr<ActionResultType> &maxV, const unsigned int nSlots,
+            std::shared_ptr<PrevNodeType> prevNode, ActionTags::Max)
 {
    using Helper_t = MaxHelper<ActionResultType>;
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<BranchType>>;
-   return std::make_unique<Action_t>(Helper_t(maxV, nSlots), bl, prevNode);
+   return std::make_unique<Action_t>(Helper_t(maxV, nSlots), bl, std::move(prevNode));
 }
 
 // Sum action
 template <typename BranchType, typename PrevNodeType, typename ActionResultType>
-std::unique_ptr<RActionBase> BuildAction(const ColumnNames_t &bl, const std::shared_ptr<ActionResultType> &sumV,
-                                         const unsigned int nSlots, PrevNodeType &prevNode, ActionTags::Sum)
+std::unique_ptr<RActionBase>
+BuildAction(const ColumnNames_t &bl, const std::shared_ptr<ActionResultType> &sumV, const unsigned int nSlots,
+            std::shared_ptr<PrevNodeType> prevNode, ActionTags::Sum)
 {
    using Helper_t = SumHelper<ActionResultType>;
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<BranchType>>;
-   return std::make_unique<Action_t>(Helper_t(sumV, nSlots), bl, prevNode);
+   return std::make_unique<Action_t>(Helper_t(sumV, nSlots), bl, std::move(prevNode));
 }
 
 // Mean action
 template <typename BranchType, typename PrevNodeType>
-std::unique_ptr<RActionBase> BuildAction(const ColumnNames_t &bl, const std::shared_ptr<double> &meanV,
-                                         const unsigned int nSlots, PrevNodeType &prevNode, ActionTags::Mean)
+std::unique_ptr<RActionBase>
+BuildAction(const ColumnNames_t &bl, const std::shared_ptr<double> &meanV, const unsigned int nSlots,
+            std::shared_ptr<PrevNodeType> prevNode, ActionTags::Mean)
 {
    using Helper_t = MeanHelper;
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<BranchType>>;
-   return std::make_unique<Action_t>(Helper_t(meanV, nSlots), bl, prevNode);
+   return std::make_unique<Action_t>(Helper_t(meanV, nSlots), bl, std::move(prevNode));
 }
 
 // Standard Deviation action
 template <typename BranchType, typename PrevNodeType>
-std::unique_ptr<RActionBase> BuildAction(const ColumnNames_t &bl, const std::shared_ptr<double> &stdDeviationV,
-                                         const unsigned int nSlots, PrevNodeType &prevNode, ActionTags::StdDev)
+std::unique_ptr<RActionBase>
+BuildAction(const ColumnNames_t &bl, const std::shared_ptr<double> &stdDeviationV, const unsigned int nSlots,
+            std::shared_ptr<PrevNodeType> prevNode, ActionTags::StdDev)
 {
    using Helper_t = StdDevHelper;
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<BranchType>>;
@@ -215,7 +222,7 @@ void CheckCustomColumn(std::string_view definedCol, TTree *treePtr, const Column
 
 std::string PrettyPrintAddr(const void *const addr);
 
-void BookFilterJit(RJittedFilter *jittedFilter, void *prevNode, std::string_view prevNodeTypeName,
+void BookFilterJit(RJittedFilter *jittedFilter, void *prevNodeOnHeap, std::string_view prevNodeTypeName,
                    std::string_view name, std::string_view expression,
                    const std::map<std::string, std::string> &aliasMap, const ColumnNames_t &branches,
                    const ColumnNames_t &customColumns, TTree *tree, RDataSource *ds, unsigned int namespaceID);
@@ -287,7 +294,7 @@ void DefineDataSourceColumns(const std::vector<std::string> &columns, RLoopManag
 // this function is meant to be called by the jitted code generated by BookFilterJit
 template <typename F, typename PrevNode>
 void JitFilterHelper(F &&f, const ColumnNames_t &cols, std::string_view name, RJittedFilter *jittedFilter,
-                     PrevNode *prevNode)
+                     std::shared_ptr<PrevNode> *prevNodeOnHeap)
 {
    // mock Filter logic -- validity checks and Define-ition of RDataSource columns
    using F_t = RFilter<F, PrevNode>;
@@ -299,7 +306,8 @@ void JitFilterHelper(F &&f, const ColumnNames_t &cols, std::string_view name, RJ
    if (ds)
       RDFInternal::DefineDataSourceColumns(cols, lm, *ds, std::make_index_sequence<nColumns>(), ColTypes_t());
 
-   jittedFilter->SetFilter(std::make_unique<F_t>(std::move(f), cols, *prevNode, name));
+   jittedFilter->SetFilter(std::make_unique<F_t>(std::move(f), cols, *prevNodeOnHeap, name));
+   delete prevNodeOnHeap;
 }
 
 template <typename F>
@@ -319,20 +327,22 @@ void JitDefineHelper(F &&f, const ColumnNames_t &cols, std::string_view name, RL
 
 /// Convenience function invoked by jitted code to build action nodes at runtime
 template <typename ActionTag, typename... BranchTypes, typename PrevNodeType, typename ActionResultType>
-void CallBuildAction(PrevNodeType &prevNode, const ColumnNames_t &bl, const unsigned int nSlots,
+void CallBuildAction(std::shared_ptr<PrevNodeType> *prevNodeOnHeap, const ColumnNames_t &bl, const unsigned int nSlots,
                      const std::shared_ptr<ActionResultType> *rOnHeap,
                      std::shared_ptr<RJittedAction> *jittedActionOnHeap)
 {
    // if we are here it means we are jitting, if we are jitting the loop manager must be alive
-   auto &loopManager = *prevNode.GetLoopManagerUnchecked();
+   auto &prevNodePtr = *prevNodeOnHeap;
+   auto &loopManager = *prevNodePtr->GetLoopManagerUnchecked();
    using ColTypes_t = TypeList<BranchTypes...>;
    constexpr auto nColumns = ColTypes_t::list_size;
    auto ds = loopManager.GetDataSource();
    if (ds)
       DefineDataSourceColumns(bl, loopManager, *ds, std::make_index_sequence<nColumns>(), ColTypes_t());
-   auto actionPtr = BuildAction<BranchTypes...>(bl, *rOnHeap, nSlots, prevNode, ActionTag{});
+   auto actionPtr = BuildAction<BranchTypes...>(bl, *rOnHeap, nSlots, std::move(prevNodePtr), ActionTag{});
    (*jittedActionOnHeap)->SetAction(std::move(actionPtr));
    delete rOnHeap;
+   delete prevNodeOnHeap;
    delete jittedActionOnHeap;
 }
 

--- a/tree/dataframe/inc/ROOT/RDFNodes.hxx
+++ b/tree/dataframe/inc/ROOT/RDFNodes.hxx
@@ -33,6 +33,7 @@
 #include <string>
 #include <thread>
 #include <tuple>
+#include <type_traits>
 #include <vector>
 
 namespace ROOT {

--- a/tree/dataframe/inc/ROOT/RDFNodes.hxx
+++ b/tree/dataframe/inc/ROOT/RDFNodes.hxx
@@ -402,14 +402,15 @@ class RAction final : public RActionBase {
 
    Helper fHelper;
    const ColumnNames_t fBranches;
+   const std::shared_ptr<PrevDataFrame> fPrevDataPtr;
    PrevDataFrame &fPrevData;
    std::vector<RDFValueTuple_t<ColumnTypes_t>> fValues;
    bool fHasRun = false;
 
 public:
-   RAction(Helper &&h, const ColumnNames_t &bl, PrevDataFrame &pd)
-      : RActionBase(pd.GetLoopManagerUnchecked(), pd.GetLoopManagerUnchecked()->GetNSlots()), fHelper(std::move(h)),
-        fBranches(bl), fPrevData(pd), fValues(fNSlots)
+   RAction(Helper &&h, const ColumnNames_t &bl, std::shared_ptr<PrevDataFrame> pd)
+      : RActionBase(pd->GetLoopManagerUnchecked(), pd->GetLoopManagerUnchecked()->GetNSlots()), fHelper(std::move(h)),
+        fBranches(bl), fPrevDataPtr(std::move(pd)), fPrevData(*fPrevDataPtr), fValues(fNSlots)
    {
    }
 
@@ -697,13 +698,14 @@ class RFilter final : public RFilterBase {
 
    FilterF fFilter;
    const ColumnNames_t fBranches;
+   const std::shared_ptr<PrevDataFrame> fPrevDataPtr;
    PrevDataFrame &fPrevData;
    std::vector<RDFInternal::RDFValueTuple_t<ColumnTypes_t>> fValues;
 
 public:
-   RFilter(FilterF &&f, const ColumnNames_t &bl, PrevDataFrame &pd, std::string_view name = "")
-      : RFilterBase(pd.GetLoopManagerUnchecked(), name, pd.GetLoopManagerUnchecked()->GetNSlots()),
-        fFilter(std::move(f)), fBranches(bl), fPrevData(pd), fValues(fNSlots)
+   RFilter(FilterF &&f, const ColumnNames_t &bl, std::shared_ptr<PrevDataFrame> pd, std::string_view name = "")
+      : RFilterBase(pd->GetLoopManagerUnchecked(), name, pd->GetLoopManagerUnchecked()->GetNSlots()),
+        fFilter(std::move(f)), fBranches(bl), fPrevDataPtr(std::move(pd)), fPrevData(*fPrevDataPtr), fValues(fNSlots)
    {
    }
 
@@ -825,12 +827,13 @@ public:
 
 template <typename PrevData>
 class RRange final : public RRangeBase {
+   const std::shared_ptr<PrevData> fPrevDataPtr;
    PrevData &fPrevData;
 
 public:
-   RRange(unsigned int start, unsigned int stop, unsigned int stride, PrevData &pd)
-      : RRangeBase(pd.GetLoopManagerUnchecked(), start, stop, stride, pd.GetLoopManagerUnchecked()->GetNSlots()),
-        fPrevData(pd)
+   RRange(unsigned int start, unsigned int stop, unsigned int stride, std::shared_ptr<PrevData> pd)
+      : RRangeBase(pd->GetLoopManagerUnchecked(), start, stop, stride, pd->GetLoopManagerUnchecked()->GetNSlots()),
+        fPrevDataPtr(std::move(pd)), fPrevData(*fPrevDataPtr)
    {
    }
 

--- a/tree/dataframe/src/RDFNodes.cxx
+++ b/tree/dataframe/src/RDFNodes.cxx
@@ -689,7 +689,7 @@ void RLoopManager::Deregister(RDFInternal::RActionBase *actionPtr)
    RDFInternal::Erase(actionPtr, fBookedActions);
 }
 
-void RLoopManager::Book(const FilterBasePtr_t &filterPtr)
+void RLoopManager::Book(RFilterBase *filterPtr)
 {
    fBookedFilters.emplace_back(filterPtr);
    if (filterPtr->HasName()) {
@@ -698,15 +698,26 @@ void RLoopManager::Book(const FilterBasePtr_t &filterPtr)
    }
 }
 
+void RLoopManager::Deregister(RFilterBase *filterPtr)
+{
+   RDFInternal::Erase(filterPtr, fBookedFilters);
+   RDFInternal::Erase(filterPtr, fBookedNamedFilters);
+}
+
 void RLoopManager::Book(const RCustomColumnBasePtr_t &columnPtr)
 {
    const auto &name = columnPtr->GetName();
    fBookedCustomColumns[name] = columnPtr;
 }
 
-void RLoopManager::Book(const RangeBasePtr_t &rangePtr)
+void RLoopManager::Book(RRangeBase *rangePtr)
 {
    fBookedRanges.emplace_back(rangePtr);
+}
+
+void RLoopManager::Deregister(RRangeBase *rangePtr)
+{
+   RDFInternal::Erase(rangePtr, fBookedRanges);
 }
 
 // dummy call, end of recursive chain of calls

--- a/tree/dataframe/test/dataframe_regression_tests.hxx
+++ b/tree/dataframe/test/dataframe_regression_tests.hxx
@@ -21,22 +21,6 @@ void FillTree(const char *filename, const char *treeName, int nevents = 0)
 }
 }
 
-TEST(TEST_CATEGORY, InvalidRef)
-{
-   auto getFilterNode = []() {
-      ROOT::RDataFrame d(5);
-      return d.Filter([]() { return true; });
-   };
-   int ret(1);
-   auto f = getFilterNode();
-   try {
-      f.Filter([]() { return true; });
-   } catch (const std::runtime_error &) {
-      ret = 0;
-   }
-   EXPECT_EQ(0, ret) << "No exception thrown when the original tdf went out of scope.";
-}
-
 TEST(TEST_CATEGORY, MultipleTriggerRun)
 {
    auto fileName = "dataframe_regression_0.root";


### PR DESCRIPTION
This solves ROOT-9416.

- users now do not have to take care that the head node of the dataframe remains in scope
- these kind of constructs are now allowed in python and C++:
```c++
auto df = RDataFrame(...).Filter(...);
```
- these kind of constructs are now allowed in python:
```c++
df = RDataFrame(...)
df = df.Filter(...)
```

EDIT:
Failures in roottests are fixed by [PR 212](https://github.com/root-project/roottest/pull/212) in roottest.