### PR TITLE
Update clad to v0.2

### DIFF
--- a/interpreter/cling/tools/plugins/clad/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/clad/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CLADDIFFERENTIATOR_LIB
 ExternalProject_Add(
   clad
   GIT_REPOSITORY https://github.com/vgvassilev/clad.git
-  GIT_TAG v0.1
+  GIT_TAG v0.2
   UPDATE_COMMAND ""
   CMAKE_ARGS -G ${CMAKE_GENERATOR}
              -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
@@ -26,6 +26,7 @@ ExternalProject_Add(
              -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
              -DCMAKE_INSTALL_PREFIX=${CLING_PLUGIN_INSTALL_PREFIX}
              -DCLAD_PATH_TO_LLVM_BUILD=${LLVM_DIR}
+             -DCLAD_BUILD_STATIC_ONLY=ON
   BUILD_BYPRODUCTS ${CLADDIFFERENTIATOR_LIB}
   # Wrap download, configure and build steps in a script to log output
   LOG_DOWNLOAD ON


### PR DESCRIPTION
The relevant highlights are:

* Support better Windows (thanks to Bertrand Bellenot!);

* Disabled automatic discovery of system LLVM -- clad should only
  search for LLVM at DCLAD_PATH_TO_LLVM_BUILD. On some platforms
  (discovered by Oksana Shadura via rootbench) clad discovers the
  system LLVM which is compatible in principle but this is not what
  we want for ROOT.

* Implemented -CLAD_BUILD_STATIC_ONLY -- this covers the ROOT usecase
  where we do not need shared objects but link the libraries against
  another shared object (libCling.so). This allows platforms which have
  disabled LLVM_ENABLE_PLUGINS to still build clad and use it. Such
  example is CYGWIN and Windows.

See more at: https://github.com/vgvassilev/clad/releases/tag/v0.2