### PR TITLE
Reland "[cxxmodules] Check correctly if the decl was cached."

### DIFF
--- a/core/dictgen/src/BaseSelectionRule.cxx
+++ b/core/dictgen/src/BaseSelectionRule.cxx
@@ -229,7 +229,8 @@ BaseSelectionRule::EMatchType BaseSelectionRule::Match(const clang::NamedDecl *d
       if (name_value == name) {
          const_cast<BaseSelectionRule*>(this)->SetMatchFound(true);
          return kName;
-      } else if ( !fCXXRecordDecl || fCXXRecordDecl != (void*)-1) {
+      } else if (fCXXRecordDecl == nullptr ||
+            (fCXXRecordDecl != (void*)-1 && isTypedefNametoRecordDecl && !decl->hasOwningModule())){
          // Possibly take the most expensive path if the fCXXRecordDecl is not
          // set or we already took the expensive path and found nothing (-1).
          const clang::CXXRecordDecl *target


### PR DESCRIPTION
Improve the commit by tighten condition to take an expensive branch.

In BaseSelectionRule::Match, for normal CXXRecordDecl, nothing need to be worried as
you can just compare name or pointer and that's it. However when you have typedef, it means that you can't just compare name (it's different!) or pointer (it's also different). And here, ScopeSearch is not actually searching the argument. It's just renewing the fCXXRecordDecl from fName to keep it up with the current interpreter state. Also, rootcling needed to parse header to get the actual definition of typedef, because rootmap file given to the invocation was lacking the necessary information. For example it contained `typedef typedefB`, from this there is no way to know which RecordDecl is underneath. With modules, we don't use rootmap files.

Thus we need to check if it's a typdef or not, and if it was a typedef,
make sure that it didn't take the same branch with the same interp
state (by checking (void*)-1) and it's not from modules.

This improves cxxmodules res memory by 90MB.
```
before:
 res  memory = 345.816 Mbytes
after
 res  memory = 267.582 Mbytes
```

Also, this fasten rootcling 2 times.
```
before:
        User time (seconds): 2.56
after:
        User time (seconds): 1.35
```