### PR TITLE
[Experimental PyROOT] Restructure generic pythonizations

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_generic.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_generic.py
@@ -1,4 +1,4 @@
-from libROOTPython import PythonizeGeneric
+from libROOTPython import AddPrettyPrintingPyz
 from ROOT import pythonization
 
 @pythonization
@@ -7,7 +7,7 @@ def pythonizegeneric(klass, name):
     # klass: class to be pythonized
     # name: string containing the name of the class
 
-    # Add pythonizations generically to all classes
-    PythonizeGeneric(klass)
+    # Add pretty printing via setting the __str__ special function
+    AddPrettyPrintingPyz(klass)
 
     return True

--- a/bindings/pyroot_experimental/PyROOT/src/GenericPyz.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/GenericPyz.cxx
@@ -31,15 +31,15 @@ PyObject *ClingPrintValue(CPPInstance *self)
 }
 
 ////////////////////////////////////////////////////////////////////////////
-/// \brief Add generic features to any class
+/// \brief Add pretty printing pythonization
 /// \param[in] self Always null, since this is a module function.
 /// \param[in] args Pointer to a Python tuple object containing the arguments
 /// received from Python.
 ///
-/// This function adds the following pythonizations:
-/// - Prints the object more user-friendly than cppyy by using the output of
-///   cling::printValue as the return value of the special method __str__.
-PyObject *PyROOT::PythonizeGeneric(PyObject * /* self */, PyObject *args)
+/// This function adds the following pythonizations to print the object more
+/// user-friendly than cppyy by using the output of cling::printValue as the
+/// return value of the special method __str__.
+PyObject *PyROOT::AddPrettyPrintingPyz(PyObject * /* self */, PyObject *args)
 {
    PyObject *pyclass = PyTuple_GetItem(args, 0);
    Utility::AddToClass(pyclass, "__str__", (PyCFunction)ClingPrintValue);

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
@@ -29,8 +29,8 @@ PyObject *gRootModule = 0;
 // Methods offered by the interface
 static PyMethodDef gPyROOTMethods[] = {{(char *)"PythonizeTTree", (PyCFunction)PyROOT::PythonizeTTree, METH_VARARGS,
                                         (char *)"Pythonizations for class TTree"},
-                                       {(char *)"PythonizeGeneric", (PyCFunction)PyROOT::PythonizeGeneric, METH_VARARGS,
-                                        (char *)"Generic pythonizations for all classes"},
+                                       {(char *)"AddPrettyPrintingPyz", (PyCFunction)PyROOT::AddPrettyPrintingPyz, METH_VARARGS,
+                                        (char *)"Add pretty printing pythonization"},
                                        {NULL, NULL, 0, NULL}};
 
 #if PY_VERSION_HEX >= 0x03000000

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
@@ -6,7 +6,7 @@
 
 namespace PyROOT {
 
-PyObject *PythonizeGeneric(PyObject *self, PyObject *args);
+PyObject *AddPrettyPrintingPyz(PyObject *self, PyObject *args);
 PyObject *PythonizeTTree(PyObject *self, PyObject *args);
 
 } // namespace PyROOT


### PR DESCRIPTION
Restructure generic pythonization with the following idea:

1. We would like to have a `_className.py` per class, where all pythonizations are added. However, for the very generic ones, a `_generic.py` file is added.
2. Rename the implementation of the pretty printing (generic) pythonization so that it's much more clear what you have to expect in the file.
3. ~~Rename the C++ side of the pythonization from `GenericPythonization` to `AddPrettyPrintingPyz` so that the python side of the pythonization is much more readable. This allows us to see all added pythonizations directly in the pythonization `_className.py` files.~~ We agreed on keeping teh `GenericPyz.cxx` filename of the source, although we want to rename the function `PythonizeGeneric` in a more meaningful way to `AddPrettyPrintingPyz`. That keeps the structure of the sources (one file per class) and enables us to see all pythonization for a class on the python side in the `_class.py` files.