### PR TITLE
[DF] LoopManager tracks run actions

### DIFF
--- a/tree/dataframe/inc/ROOT/RDFNodes.hxx
+++ b/tree/dataframe/inc/ROOT/RDFNodes.hxx
@@ -118,6 +118,7 @@ class RLoopManager {
    };
 
    std::vector<RDFInternal::RActionBase *> fBookedActions; ///< Non-owning pointers to actions to be run
+   std::vector<RDFInternal::RActionBase *> fRunActions; ///< Non-owning pointers to actions already run
    std::vector<RFilterBase *> fBookedFilters;
    std::vector<RFilterBase *> fBookedNamedFilters; ///< Contains a subset of fBookedFilters, i.e. only the named filters
    std::map<std::string, RCustomColumnBasePtr_t> fBookedCustomColumns;
@@ -201,6 +202,8 @@ public:
    void AddFilterName(std::vector<std::string> &) {}
    /// For each booked filter, returns either the name or "Unnamed Filter"
    std::vector<std::string> GetFiltersNames();
+   /// For all the actions, either booked or run
+   std::vector<RDFInternal::RActionBase *> GetAllActions();
 };
 } // end ns RDF
 } // end ns Detail

--- a/tree/dataframe/src/RDFNodes.cxx
+++ b/tree/dataframe/src/RDFNodes.cxx
@@ -583,6 +583,8 @@ void RLoopManager::CleanUpNodes()
    // forget RActions and detach TResultProxies
    for (auto &ptr : fBookedActions)
       ptr->Finalize();
+
+   fRunActions.insert(fRunActions.begin(), fBookedActions.begin(), fBookedActions.end());
    fBookedActions.clear();
 
    // reset children counts
@@ -686,6 +688,7 @@ void RLoopManager::Book(RDFInternal::RActionBase *actionPtr)
 
 void RLoopManager::Deregister(RDFInternal::RActionBase *actionPtr)
 {
+   RDFInternal::Erase(actionPtr, fRunActions);
    RDFInternal::Erase(actionPtr, fBookedActions);
 }
 
@@ -749,6 +752,13 @@ std::vector<std::string> RLoopManager::GetFiltersNames()
       filters.push_back(name);
    }
    return filters;
+}
+
+std::vector<RDFInternal::RActionBase *> RLoopManager::GetAllActions(){
+   std::vector<RDFInternal::RActionBase *> actions;
+   actions.insert(actions.begin(), fBookedActions.begin(), fBookedActions.end());
+   actions.insert(actions.begin(), fRunActions.begin(), fRunActions.end());
+   return actions;
 }
 
 RRangeBase::RRangeBase(RLoopManager *implPtr, unsigned int start, unsigned int stop, unsigned int stride,


### PR DESCRIPTION
The LoopManager now tracks the actions that have already run. This commit is needed by the Graph drawing PR.

This can't be directly tested as the LM is not exposed. To test it I used the following code, not commited.

RInterface has a Test() method that just call GetAllActions() on the RLoopManager.

```
TEST_P(RDFSimpleTests, Action)
{
RDataFrame rd1(8);
EXPECT_EQ(rd1.Test().size(), 0);
auto a1 = rd1.StdDev<ULong64_t>("tdfentry_");
EXPECT_EQ(rd1.Test().size(), 1);
auto a2 = rd1.Mean<>("tdfentry_");
EXPECT_EQ(rd1.Test().size(), 2);
auto a3 = rd1.Count();

EXPECT_EQ(rd1.Test().size(), 3);
*a1;
EXPECT_EQ(rd1.Test().size(), 3);
{
   auto a4 = rd1.StdDev<ULong64_t>("tdfentry_");
   EXPECT_EQ(rd1.Test().size(), 4);
}
EXPECT_EQ(rd1.Test().size(), 3);
{
   auto a4 = rd1.StdDev<ULong64_t>("tdfentry_");
   EXPECT_EQ(rd1.Test().size(), 4);
   *a4;
}
EXPECT_EQ(rd1.Test().size(), 3);
}
```