### PR TITLE
xml: fix gcc8 warning with strncpy arguments

### DIFF
--- a/io/xml/src/TXMLEngine.cxx
+++ b/io/xml/src/TXMLEngine.cxx
@@ -1362,7 +1362,7 @@ XMLDocPointer_t TXMLEngine::ParseString(const char *xmlstring)
 {
    if ((xmlstring == 0) || (strlen(xmlstring) == 0))
       return 0;
-   TXMLInputStream inp(false, xmlstring, 2 * strlen(xmlstring));
+   TXMLInputStream inp(false, xmlstring, 100000);
    return ParseStream(&inp);
 }
 


### PR DESCRIPTION
At this place buffer was allocated using length of source string.
gcc does not like when strncpy length argument directly derives from
source string length. Actually, buffer should not depend from source
length - here it was workaround for old problem, which is already fixed.
Therefore just use constant buffer length