### PR TITLE
added cuda stream support to parallelize over events in the batch

### DIFF
--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu.h
@@ -333,12 +333,16 @@ public:
    static void AddConvBiases(TCpuMatrix<Scalar_t> &output, const TCpuMatrix<Scalar_t> &biases);
    ///@}
 
+   /** Dummy placeholder - preparation is currently only required for the CUDA architecture. */
+   static void PrepareInternals(std::vector<TCpuMatrix<Scalar_t>> &) {}
+
    /** Forward propagation in the Convolutional layer */
    static void ConvLayerForward(std::vector<TCpuMatrix<Scalar_t>> & output,
                                 std::vector<TCpuMatrix<Scalar_t>> & derivatives,
                                 const std::vector<TCpuMatrix<Scalar_t>> &input,
                                 const TCpuMatrix<Scalar_t> &weights, const TCpuMatrix<Scalar_t> & biases,
-                                const DNN::CNN::TConvParams & params, EActivationFunction activFunc);
+                                const DNN::CNN::TConvParams & params, EActivationFunction activFunc,
+                                std::vector<TCpuMatrix<Scalar_t>> & /* inputPrime */);
 
    /** @name Backward Propagation in Convolutional Layer
     */

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda.h
@@ -307,6 +307,9 @@ public:
     */
    ///@{
 
+   /** Attaches a cuda stream to each matrix in order to accomodate parallel kernel launches. */
+   static void PrepareInternals(std::vector<TCudaMatrix<AFloat>> & inputPrime);
+
    /** Calculate how many neurons "fit" in the output layer, given the input as well as the layer's hyperparameters. */
    static size_t calculateDimension(size_t imgDim, size_t fltDim, size_t padding, size_t stride);
 
@@ -345,7 +348,8 @@ public:
                                 std::vector<TCudaMatrix<AFloat>> & derivatives,
                                 const std::vector<TCudaMatrix<AFloat>> &input,
                                 const TCudaMatrix<AFloat> &weights, const TCudaMatrix<AFloat> & biases,
-                                const DNN::CNN::TConvParams & params, EActivationFunction activFunc);
+                                const DNN::CNN::TConvParams & params, EActivationFunction activFunc,
+                                std::vector<TCudaMatrix<AFloat>> & inputPrime);
 
    /** @name Backward Propagation in Convolutional Layer
     */

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Reference.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Reference.h
@@ -339,18 +339,16 @@ public:
    static void AddConvBiases(TMatrixT<AReal> &output, const TMatrixT<AReal> &biases);
    ///@}
 
-      /** Forward propagation in the Convolutional layer */
-   // static void ConvLayerForward(std::vector<TMatrixT<AReal>> & output, std::vector<TMatrixT<AReal>> & derivatives,
-   //                              const std::vector<TMatrixT<AReal>> &input,
-   //                              const TMatrixT<AReal> & weights, const TMatrixT<AReal> & biases,
-   //                              EActivationFunction func, const std::vector<int> & vIndices,
-   //                              size_t nlocalViews, size_t nlocalViewPixels,
-   //                              AReal dropoutProbability, bool applyDropout) {
+   /** Dummy placeholder - preparation is currently only required for the CUDA architecture. */
+   static void PrepareInternals(std::vector<TMatrixT<AReal>> &) {}
+
+   /** Forward propagation in the Convolutional layer */
    static void ConvLayerForward(std::vector<TMatrixT<AReal>> & /*output*/,
                                 std::vector<TMatrixT<AReal>> & /*derivatives*/,
                                 const std::vector<TMatrixT<AReal>> & /*input*/,
                                 const TMatrixT<AReal> & /*weights*/, const TMatrixT<AReal> & /*biases*/,
-                                const DNN::CNN::TConvParams & /*params*/, EActivationFunction /*activFunc*/) {
+                                const DNN::CNN::TConvParams & /*params*/, EActivationFunction /*activFunc*/,
+                                std::vector<TMatrixT<AReal>> & /*inputPrime*/) {
       Fatal("ConvLayerForward","This function is not implemented for ref architectures");
    }
 
@@ -367,22 +365,13 @@ public:
     *  in \p df and thus produces only a valid result, if it is applied the
     *  first time after the corresponding forward propagation has been per-
     *  formed. */
-   // static void ConvLayerBackward(std::vector<TMatrixT<AReal>> &activationGradientsBackward,
-   //                               TMatrixT<AReal> &weightGradients, TMatrixT<AReal> &biasGradients,
-   //                               std::vector<TMatrixT<AReal>> &df,
-   //                               const std::vector<TMatrixT<AReal>> &activationGradients,
-   //                               const TMatrixT<AReal> &weights, const std::vector<TMatrixT<AReal>> &activationBackward,
-   //                               size_t batchSize, size_t inputHeight, size_t inputWidth, size_t depth, size_t height,
-   //                               size_t width, size_t filterDepth, size_t filterHeight, size_t filterWidth,
-   //                               size_t nLocalViews) {
    static void ConvLayerBackward(std::vector<TMatrixT<AReal>> &,
                                  TMatrixT<AReal> &, TMatrixT<AReal> &,
                                  std::vector<TMatrixT<AReal>> &,
                                  const std::vector<TMatrixT<AReal>> &,
                                  const TMatrixT<AReal> &, const std::vector<TMatrixT<AReal>> &,
                                  size_t , size_t , size_t , size_t , size_t,
-                                 size_t , size_t , size_t , size_t ,
-                                 size_t ) {
+                                 size_t , size_t , size_t , size_t , size_t) {
       Fatal("ConvLayerBackward","This function is not implemented for ref architectures");
 
    }

--- a/tmva/tmva/src/DNN/Architectures/Cpu/Propagation.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Cpu/Propagation.cxx
@@ -295,7 +295,8 @@ void TCpu<AFloat>::ConvLayerForward(std::vector<TCpuMatrix<AFloat>> & output,
                                     std::vector<TCpuMatrix<AFloat>> & derivatives,
                                     const std::vector<TCpuMatrix<AFloat>> &input,
                                     const TCpuMatrix<AFloat> &weights, const TCpuMatrix<AFloat> & biases,
-                                    const DNN::CNN::TConvParams & params, EActivationFunction activFunc)
+                                    const DNN::CNN::TConvParams & params, EActivationFunction activFunc,
+                                    std::vector<TCpuMatrix<AFloat>> & /*  */)
 {
    size_t height = calculateDimension(params.inputHeight, params.filterHeight, params.paddingHeight, params.strideRows);
    size_t width = calculateDimension(params.inputWidth, params.filterWidth, params.paddingWidth, params.strideCols);
@@ -358,7 +359,7 @@ void TCpu<AFloat>::ConvLayerBackward(std::vector<TCpuMatrix<AFloat>> &activation
 
    // Calculate the activation gradients of the previous layer
    CalculateConvActivationGradients(activationGradientsBackward, df, weights, batchSize, inputHeight, inputWidth, depth,
-                                                                                         height, width, filterDepth, filterHeight, filterWidth);
+                                    height, width, filterDepth, filterHeight, filterWidth);
 
    // Calculate the weight gradients
    CalculateConvWeightGradients(weightGradients, df, activationsBackward, batchSize, inputHeight, inputWidth, depth,

--- a/tmva/tmva/test/DNN/CNN/TestConvNet.h
+++ b/tmva/tmva/test/DNN/CNN/TestConvNet.h
@@ -231,8 +231,17 @@ auto testConvLayerForward(const std::vector<typename Architecture::Matrix_t> &in
     TConvParams params(1, inputDepth, inputHeight, inputWidth, numberFilters, fltHeight, fltWidth, strideRows,
                        strideCols, zeroPaddingHeight, zeroPaddingWidth);
 
+
+    size_t height = (inputHeight - fltHeight + 2 * zeroPaddingHeight) / strideRows + 1;
+    size_t width = (inputWidth - fltWidth + 2 * zeroPaddingWidth) / strideCols + 1;
+    size_t nLocalViews = height * width;
+    size_t nLocalViewPixels = inputDepth * fltHeight * fltWidth;
+
+    std::vector<typename Architecture::Matrix_t> forwardMatrices;
+    forwardMatrices.emplace_back(nLocalViews, nLocalViewPixels);
+
     Architecture::ConvLayerForward(computedOutput, computedDerivatives, input, weights, biases, params,
-                                   EActivationFunction::kIdentity);
+                                   EActivationFunction::kIdentity, forwardMatrices);
 
     for (size_t slice = 0; slice < nRows; slice++) {
         for (size_t localView = 0; localView < nCols; localView++) {


### PR DESCRIPTION
Now using CUDA streams to support parallelization over events in the batch. This yields a 40% performance boost on high end GPUs (GTX 1080 Ti) and 10-15% on weaker models (Quadro 1000M).

Additionally, temporary matrices used by `Im2Col` in the forward pass are maintained as a `ConvLayer` data field in order to minimize cuda memory allocations.