### PR TITLE
[ROOT-9617] Add TTree::SetBranchAddress pythonization

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_ttree.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_ttree.py
@@ -1,5 +1,5 @@
 
-from libROOTPython import PythonizeTTree, SetBranchAddressPyz
+from libROOTPython import AddBranchAttrSyntax, SetBranchAddressPyz
 
 from ROOT import pythonization
 
@@ -36,9 +36,8 @@ def pythonize_ttree(klass, name):
         # Pythonic iterator
         klass.__iter__ = _TTree__iter__
 
-        # C++ pythonizations
-        # - tree.branch syntax
-        PythonizeTTree(klass)
+        # tree.branch syntax
+        AddBranchAttrSyntax(klass)
 
         # SetBranchAddress
         klass._OriginalSetBranchAddress = klass.SetBranchAddress

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
@@ -27,8 +27,8 @@ PyObject *gRootModule = 0;
 }
 
 // Methods offered by the interface
-static PyMethodDef gPyROOTMethods[] = {{(char *)"PythonizeTTree", (PyCFunction)PyROOT::PythonizeTTree, METH_VARARGS,
-                                        (char *)"Pythonizations for class TTree"},
+static PyMethodDef gPyROOTMethods[] = {{(char *)"AddBranchAttrSyntax", (PyCFunction)PyROOT::AddBranchAttrSyntax, METH_VARARGS,
+                                        (char *)"Allow to access branches as tree attributes"},
                                        {(char *)"SetBranchAddressPyz", (PyCFunction)PyROOT::SetBranchAddressPyz, METH_VARARGS,
                                         (char *)"Pythonization for TTree::SetBranchAddress"},
                                        {(char *)"AddPrettyPrintingPyz", (PyCFunction)PyROOT::AddPrettyPrintingPyz, METH_VARARGS,

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
@@ -29,6 +29,8 @@ PyObject *gRootModule = 0;
 // Methods offered by the interface
 static PyMethodDef gPyROOTMethods[] = {{(char *)"PythonizeTTree", (PyCFunction)PyROOT::PythonizeTTree, METH_VARARGS,
                                         (char *)"Pythonizations for class TTree"},
+                                       {(char *)"SetBranchAddressPyz", (PyCFunction)PyROOT::SetBranchAddressPyz, METH_VARARGS,
+                                        (char *)"Pythonization for TTree::SetBranchAddress"},
                                        {(char *)"AddPrettyPrintingPyz", (PyCFunction)PyROOT::AddPrettyPrintingPyz, METH_VARARGS,
                                         (char *)"Add pretty printing pythonization"},
                                        {(char *)"GetEndianess", (PyCFunction)PyROOT::GetEndianess, METH_NOARGS,

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
@@ -8,6 +8,7 @@ namespace PyROOT {
 
 PyObject *AddPrettyPrintingPyz(PyObject *self, PyObject *args);
 PyObject *PythonizeTTree(PyObject *self, PyObject *args);
+PyObject *SetBranchAddressPyz(PyObject *self, PyObject *args);
 PyObject *GetEndianess(PyObject *self);
 PyObject *GetVectorDataPointer(PyObject *self, PyObject *args);
 PyObject *GetSizeOfType(PyObject *self, PyObject *args);

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
@@ -7,7 +7,7 @@
 namespace PyROOT {
 
 PyObject *AddPrettyPrintingPyz(PyObject *self, PyObject *args);
-PyObject *PythonizeTTree(PyObject *self, PyObject *args);
+PyObject *AddBranchAttrSyntax(PyObject *self, PyObject *args);
 PyObject *SetBranchAddressPyz(PyObject *self, PyObject *args);
 PyObject *GetEndianess(PyObject *self);
 PyObject *GetVectorDataPointer(PyObject *self, PyObject *args);

--- a/bindings/pyroot_experimental/PyROOT/src/TTreePyz.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/TTreePyz.cxx
@@ -174,6 +174,21 @@ PyObject *PyROOT::PythonizeTTree(PyObject * /* self */, PyObject *args)
    Py_RETURN_NONE;
 }
 
+////////////////////////////////////////////////////////////////////////////
+/// \brief Add pythonization for TTree::SetBranchAddress.
+/// \param[in] self Always null, since this is a module function.
+/// \param[in] args Pointer to a Python tuple object containing the arguments
+/// received from Python.
+///
+/// Modify the behaviour of SetBranchAddress so that proxy references can be passed
+/// as arguments from the Python side, more precisely in cases where the C++
+/// implementation of the method expects the address of a pointer.
+///
+/// For example:
+/// ~~~{.python}
+/// v = ROOT.std.vector('int')()
+/// t.SetBranchAddress("my_vector_branch", v)
+/// ~~~
 PyObject *PyROOT::SetBranchAddressPyz(PyObject * /* self */, PyObject *args)
 {
    PyObject *treeObj = nullptr, *name = nullptr, *address = nullptr;

--- a/bindings/pyroot_experimental/PyROOT/src/TTreePyz.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/TTreePyz.cxx
@@ -193,7 +193,12 @@ PyObject *PyROOT::SetBranchAddressPyz(PyObject * /* self */, PyObject *args)
    int argc = PyTuple_GET_SIZE(args);
 
    // Look for the (const char*, void*) overload
-   if (argc == 3 && PyArg_ParseTuple(args, const_cast<char *>("OSO:SetBranchAddress"), &treeObj, &name, &address)) {
+#if PY_VERSION_HEX < 0x03000000
+   auto argParseStr = "OSO:SetBranchAddress";
+#else
+   auto argParseStr = "OUO:SetBranchAddress";
+#endif
+   if (argc == 3 && PyArg_ParseTuple(args, const_cast<char *>(argParseStr), &treeObj, &name, &address)) {
 
       auto treeProxy = (CPPInstance *)treeObj;
       TTree *tree = (TTree *)GetClass(treeProxy)->DynamicCast(TTree::Class(), treeProxy->GetObject());

--- a/bindings/pyroot_experimental/PyROOT/src/TTreePyz.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/TTreePyz.cxx
@@ -157,17 +157,14 @@ PyObject *GetAttr(const CPPInstance *self, PyObject *pyname)
 }
 
 ////////////////////////////////////////////////////////////////////////////
-/// \brief Add pythonizations to the TTree class.
+/// \brief Allow branches to be accessed as attributes of a tree.
 /// \param[in] self Always null, since this is a module function.
 /// \param[in] args Pointer to a Python tuple object containing the arguments
 /// received from Python.
 ///
-/// Inject new behaviour into the TTree class so that it can be used from
-/// Python in a simpler or more pythonic way.
-///
-/// This function adds the following pythonizations:
-/// - Allow access to branches/leaves as if they were data members (e.g. mytree.branch)
-PyObject *PyROOT::PythonizeTTree(PyObject * /* self */, PyObject *args)
+/// Allow access to branches/leaves as if they were Python data attributes of the tree
+/// (e.g. mytree.branch)
+PyObject *PyROOT::AddBranchAttrSyntax(PyObject * /* self */, PyObject *args)
 {
    PyObject *pyclass = PyTuple_GetItem(args, 0);
    Utility::AddToClass(pyclass, "__getattr__", (PyCFunction)GetAttr, METH_O);

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # General pythonizations
-ROOT_ADD_PYUNITTEST(pyroot_pretty_printing pretty_printing.py)
-ROOT_ADD_PYUNITTEST(pyroot_array_interface array_interface.py)
+ROOT_ADD_PYUNITTEST(pyroot_pyz_pretty_printing pretty_printing.py)
+ROOT_ADD_PYUNITTEST(pyroot_pyz_array_interface array_interface.py)
 
 # TTree pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_branch_attr ttree_branch_attr.py

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -7,4 +7,5 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_branch_attr ttree_branch_attr.py
                     COPY_TO_BUILDDIR TreeHelper.h)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_iterable ttree_iterable.py
                     COPY_TO_BUILDDIR TreeHelper.h)
-
+ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_setbranchaddress ttree_setbranchaddress.py
+                    COPY_TO_BUILDDIR TreeHelper.h)

--- a/bindings/pyroot_experimental/PyROOT/test/ttree_setbranchaddress.py
+++ b/bindings/pyroot_experimental/PyROOT/test/ttree_setbranchaddress.py
@@ -3,6 +3,7 @@ from array import array
 
 import ROOT
 from libcppyy import SetOwnership
+import numpy as np
 
 
 class TTreeSetBranchAddress(unittest.TestCase):
@@ -50,6 +51,16 @@ class TTreeSetBranchAddress(unittest.TestCase):
         f,t = self.get_file_and_tree()
 
         a = array('d', self.arraysize*[ 0. ])
+        t.SetBranchAddress('arrayb', a)
+        t.GetEntry(0)
+
+        for j in range(self.arraysize):
+            self.assertEqual(a[j], j)
+
+    def test_numpy_array_branch(self):
+        f,t = self.get_file_and_tree()
+
+        a = np.array(self.arraysize*[ 0. ]) # dtype='float64'
         t.SetBranchAddress('arrayb', a)
         t.GetEntry(0)
 

--- a/bindings/pyroot_experimental/PyROOT/test/ttree_setbranchaddress.py
+++ b/bindings/pyroot_experimental/PyROOT/test/ttree_setbranchaddress.py
@@ -1,0 +1,92 @@
+import unittest
+from array import array
+
+import ROOT
+from libcppyy import SetOwnership
+
+
+class TTreeSetBranchAddress(unittest.TestCase):
+    """
+    Test for the pythonization of TTree::SetBranchAddress, which allows to pass proxy references
+    as arguments from the Python side. Example:
+    `v = ROOT.std.vector('int')()`
+    `t.SetBranchAddress("my_vector_branch", v)`
+    """
+
+    filename  = 'treesetbranchaddress.root'
+    treename  = 'mytree'
+    nentries  = 1
+    arraysize = 10
+    more      = 10
+
+    # Setup
+    @classmethod
+    def setUpClass(cls):
+        ROOT.gInterpreter.Declare('#include "TreeHelper.h"')
+        ROOT.CreateTTree(cls.filename, cls.treename, cls.nentries, cls.arraysize, cls.more)
+
+    # Helper
+    def get_file_and_tree(self):
+        f = ROOT.TFile(self.filename)
+        t = f.Get(self.treename)
+        # Prevent double deletion of the tree (Python and C++ TFile)
+        SetOwnership(t, False)
+
+        return f,t
+
+    # Tests
+    # Basic type, array and struct leaf list do not actually need the pythonization,
+    # but testing anyway for the sake of completeness
+    def test_basic_type_branch(self):
+        f,t = self.get_file_and_tree()
+
+        n = array('f', [ 0. ])
+        t.SetBranchAddress('floatb', n)
+        t.GetEntry(0)
+
+        self.assertEqual(n[0], self.more)
+
+    def test_array_branch(self):
+        f,t = self.get_file_and_tree()
+
+        a = array('d', self.arraysize*[ 0. ])
+        t.SetBranchAddress('arrayb', a)
+        t.GetEntry(0)
+
+        for j in range(self.arraysize):
+            self.assertEqual(a[j], j)
+
+    def test_struct_branch_leaflist(self):
+        f,t = self.get_file_and_tree()
+
+        ms = ROOT.MyStruct()
+        t.SetBranchAddress('structleaflistb', ms)
+        t.GetEntry(0)
+
+        self.assertEqual(ms.myint1, self.more)
+        self.assertEqual(ms.myint2, 0)
+
+    # Vector and struct do benefit from the pythonization
+    def test_vector_branch(self):
+        f,t = self.get_file_and_tree()
+
+        v = ROOT.std.vector('double')()
+        t.SetBranchAddress('vectorb', v)
+        t.GetEntry(0)
+
+        for j in range(self.arraysize):
+            self.assertEqual(v[j], j)
+
+    def test_struct_branch(self):
+        f,t = self.get_file_and_tree()
+
+        ms = ROOT.MyStruct()
+        t.SetBranchAddress('structb', ms)
+        t.GetEntry(0)
+
+        self.assertEqual(ms.myint1, self.more)
+        self.assertEqual(ms.myint2, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Modify the behaviour of SetBranchAddress so that proxy references can be passed as arguments from the Python side, more precisely in cases where the C++ implementation of the method expects the address of a pointer.

For example:
```python
v = ROOT.std.vector('int')()
t.SetBranchAddress("my_vector_branch", v)
```

Pending items:
- Check failure in Python 3
- Test other overloads
- Any other case to support? E.g. SetBranchAddress of individual elements in a struct?
- Use helper method `GetClass` that was factored out