### PR TITLE
[VecOps] Add helpers to compute combinations of collections

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -742,6 +742,66 @@ RVec<T> Sorted(const RVec<T> &v, Compare &&c)
    return r;
 }
 
+/// Return the indices, which represent all combinations of the elements of two
+/// vectors.
+template <typename T1, typename T2>
+RVec<RVec<typename RVec<T1>::size_type>> Combinations(const RVec<T1> &v1, const RVec<T2> &v2)
+{
+   using size_type = typename RVec<T1>::size_type;
+   size_type size1 = v1.size();
+   size_type size2 = v2.size();
+   RVec<RVec<size_type>> r(2);
+   r[0].resize(size1*size2);
+   r[1].resize(size1*size2);
+   size_type c = 0;
+   for(size_type i=0; i<size1; i++) {
+      for(size_type j=0; j<size2; j++) {
+         r[0][c] = i;
+         r[1][c] = j;
+         c++;
+      }
+   }
+   return r;
+}
+
+/// Return the indices, which represent all unique n-tuple combinations of the
+/// elements of a given vector.
+template <typename T>
+RVec<RVec<typename RVec<T>::size_type>> Combinations(const RVec<T>& v, const typename RVec<T>::size_type n)
+{
+   using size_type = typename RVec<T>::size_type;
+   const size_type s = v.size();
+   if (n > s) {
+      std::stringstream ss;
+      ss << "Cannot make unique combinations of size " << n << " from vector of size " << s << ".";
+      throw std::runtime_error(ss.str());
+   }
+   RVec<size_type> indices(s);
+   for(size_type k=0; k<s; k++)
+      indices[k] = k;
+   RVec<RVec<size_type>> c(n);
+   for(size_type k=0; k<n; k++)
+      c[k].emplace_back(indices[k]);
+   while (true) {
+      bool run_through = true;
+      long i = n - 1;
+      for (; i>=0; i--) {
+         if (indices[i] != i + s - n){
+            run_through = false;
+            break;
+         }
+      }
+      if (run_through) {
+         return c;
+      }
+      indices[i]++;
+      for (long j=i+1; j<(long)n; j++)
+         indices[j] = indices[j-1] + 1;
+      for(size_type k=0; k<n; k++)
+         c[k].emplace_back(indices[k]);
+   }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Print a RVec at the prompt:
 template <class T>

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -718,3 +718,69 @@ TEST(VecOps, RVecBool)
    EXPECT_EQ(v.size(), 2u);
    CheckEqual(v2, v);
 }
+
+TEST(VecOps, CombinationsTwoVectors)
+{
+   ROOT::VecOps::RVec<int> v1{1, 2, 3};
+   ROOT::VecOps::RVec<int> v2{-4, -5};
+
+   auto idx = Combinations(v1, v2);
+   auto c1 = Take(v1, idx[0]);
+   auto c2 = Take(v2, idx[1]);
+   auto v3 = c1 * c2;
+
+   RVec<int> ref{-4, -5, -8, -10, -12, -15};
+   CheckEqual(v3, ref);
+
+   // Corner-case: One collection is empty
+   RVec<int> empty_int{};
+   auto idx2 = Combinations(v1, empty_int);
+   RVec<size_t> empty_size{};
+   CheckEqual(idx2[0], empty_size);
+   CheckEqual(idx2[1], empty_size);
+}
+
+TEST(VecOps, UnqiueCombinationsSingleVector)
+{
+   // Doubles: x + y
+   ROOT::VecOps::RVec<int> v1{1, 2, 3};
+   auto idx1 = Combinations(v1, 2);
+   auto c1 = Take(v1, idx1[0]);
+   auto c2 = Take(v1, idx1[1]);
+   auto v2 = c1 + c2;
+   RVec<int> ref1{
+      3,  // 1+2
+      4,  // 1+3
+      5}; // 2+3
+   CheckEqual(v2, ref1);
+
+   // Triples: x * y * z
+   ROOT::VecOps::RVec<int> v3{1, 2, 3, 4};
+   auto idx2 = Combinations(v3, 3);
+   auto c3 = Take(v3, idx2[0]);
+   auto c4 = Take(v3, idx2[1]);
+   auto c5 = Take(v3, idx2[2]);
+   auto v4 = c3 * c4 * c5;
+   RVec<int> ref2{
+      6,  // 1*2*3
+      8,  // 1*2*3
+      12, // 1*3*4
+      24};// 2*3*4
+   CheckEqual(v4, ref2);
+
+   // Corner-case: Single combination
+   ROOT::VecOps::RVec<int> v5{1};
+   auto idx3 = Combinations(v5, 1);
+   EXPECT_EQ(idx3.size(), 1u);
+   EXPECT_EQ(idx3[0].size(), 1u);
+   EXPECT_EQ(idx3[0][0], 0u);
+
+   // Corner-case: Insert empty vector
+   ROOT::VecOps::RVec<int> empty_int{};
+   auto idx4 = Combinations(empty_int, 0);
+   EXPECT_EQ(idx4.size(), 0u);
+
+   // Corner-case: Request "zero-tuples"
+   auto idx5 = Combinations(v1, 0);
+   EXPECT_EQ(idx5.size(), 0u);
+}

--- a/tutorials/vecops/vo005_Combinations.C
+++ b/tutorials/vecops/vo005_Combinations.C
@@ -1,0 +1,56 @@
+/// \file
+/// \ingroup tutorial_vecops
+/// \notebook -nodraw
+/// In this tutorial we learn how combinations of RVecs can be build.
+///
+/// \macro_code
+///
+/// \date August 2018
+/// \author Stefan Wunsch
+
+using namespace ROOT::VecOps;
+
+void vo005_Combinations()
+{
+   // The starting point are two collections and we want to calculate the result
+   // of combinations of the elements.
+   RVec<double> v1{1., 2., 3.};
+   RVec<double> v2{-4., -5.};
+
+   // To get the indices, which result in all combinations, you can call the
+   // following helper.
+   auto idx = Combinations(v1, v2);
+
+   // Next, the respective elements can be taken via the computed indices.
+   auto c1 = Take(v1, idx[0]);
+   auto c2 = Take(v2, idx[1]);
+
+   // Finally, you can perform any set of operations conveniently.
+   auto v3 = c1 * c2;
+
+   std::cout << "Combinations of " << v1 << " and " << v2 << ":" << std::endl;
+   for(size_t i=0; i<v3.size(); i++) {
+       std::cout << c1[i] << " * " << c2[i] << " = " << v3[i] << std::endl;
+   }
+   std::cout << std::endl;
+
+   // However, if you want to compute operations on unique combinations of a
+   // single RVec, you can perform this as follows.
+
+   // Get the indices of unique triples for the given vector.
+   RVec<double> v4{1., 2., 3., 4.};
+   auto idx2 = Combinations(v4, 3);
+
+   // Take the elements and compute any operation on the returned collections.
+   auto c3 = Take(v4, idx2[0]);
+   auto c4 = Take(v4, idx2[1]);
+   auto c5 = Take(v4, idx2[2]);
+
+   auto v5 = c3 * c4 * c5;
+
+   std::cout << "Unique triples of " << v4 << ":" << std::endl;
+   for(size_t i=0; i<v4.size(); i++) {
+       std::cout << c3[i] << " * " << c4[i] << " * " << c5[i] << " = " << v5[i] << std::endl;
+   }
+   std::cout << std::endl;
+}

--- a/tutorials/vecops/vo005_Combinations.py
+++ b/tutorials/vecops/vo005_Combinations.py
@@ -1,0 +1,54 @@
+## \file
+## \ingroup tutorial_vecops
+## \notebook -nodraw
+## In this tutorial we learn how combinations of RVecs can be build.
+##
+## \macro_code
+##
+## \date August 2018
+## \author Stefan Wunsch
+
+import ROOT
+from ROOT.VecOps import RVec, Take, Combinations
+
+# RVec can be sorted in Python with the inbuilt sorting function because
+# PyROOT implements a Python iterator
+v1 = RVec("double")(3)
+v1[0], v1[1], v1[2] = 1, 2, 3
+v2 = RVec("double")(2)
+v2[0], v2[1] = -4, -5
+
+# To get the indices, which result in all combinations, you can call the
+# following helper.
+idx = Combinations(v1, v2)
+
+# Next, the respective elements can be taken via the computed indices.
+c1 = Take(v1, idx[0])
+c2 = Take(v2, idx[1])
+
+# Finally, you can perform any set of operations conveniently.
+v3 = c1 * c2
+
+print("Combinations of {} and {}:".format(v1, v2))
+for i in range(len(v3)):
+    print("{} * {} = {}".format(c1[i], c2[i], v3[i]))
+print
+
+# However, if you want to compute operations on unique combinations of a
+# single RVec, you can perform this as follows.
+
+# Get the indices of unique triples for the given vector.
+v4 = RVec("double")(4)
+v4[0], v4[1], v4[2], v4[3] = 1, 2, 3, 4
+idx2 = Combinations(v4, 3)
+
+# Take the elements and compute any operation on the returned collections.
+c3 = Take(v4, idx2[0])
+c4 = Take(v4, idx2[1])
+c5 = Take(v4, idx2[2])
+
+v5 = c3 * c4 * c5
+
+print("Unique triples of {}:".format(v4))
+for i in range(len(v5)):
+    print("{} * {} * {} = {}".format(c3[i], c4[i], c5[i], v5[i]))


### PR DESCRIPTION
Basic workflow is as follows (have a look at the commited tutorial):

**Combinations of two vectors:**
```cpp
RVec<double> v1{1., 2., 3.};
RVec<double> v2{-4., -5.};
auto idx = Combinations(v1, v2);
auto c1 = Take(v1, idx[0]);
auto c2 = Take(v2, idx[1]);
auto v3 = c1 * c2;
```

**Unique combinations of elements from a single vector:**
```cpp
RVec<double> v1{1., 2., 3.};
auto idx = Combinations(v1, 2);
auto c1 = Take(v1, idx[0]);
auto c2 = Take(v1, idx[1]);
auto v2 = c1 * c2;
```
Depends on #2351