### PR TITLE
Additional fix for rule scheduling in TBranchElement. 

### DIFF
--- a/io/io/inc/TStreamerInfoActions.h
+++ b/io/io/inc/TStreamerInfoActions.h
@@ -16,6 +16,7 @@
 #include <ROOT/RMakeUnique.hxx>
 
 #include "TStreamerInfo.h"
+#include "TVirtualArray.h"
 #include <assert.h>
 
 /**
@@ -141,9 +142,13 @@ namespace TStreamerInfoActions {
    struct TNestedIDs {
       TNestedIDs() = default;
       TNestedIDs(TStreamerInfo *info, Int_t offset) : fInfo(info), fOffset(offset) {}
-
+      ~TNestedIDs() {
+         if (fOwnOnfileObject)
+            delete fOnfileObject;
+      }
       TStreamerInfo *fInfo = nullptr; ///< Not owned.
-      TVirtualArray *fOnfileObject = nullptr; ///< Not owned.
+      TVirtualArray *fOnfileObject = nullptr;
+      Bool_t         fOwnOnfileObject = kFALSE;
       Int_t          fOffset;
       TIDs           fIDs;
    };

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -1940,7 +1940,7 @@ TStreamerInfo *TBranchElement::FindOnfileInfo(TClass *valueClass, const TObjArra
 }
 
 namespace {
-   static void GatherArtificialElements(const TObjArray &branches, TStreamerInfoActions::TIDs &ids, TString prefix, TStreamerInfo *info, Int_t offset) {
+static void GatherArtificialElements(const TObjArray &branches, TStreamerInfoActions::TIDs &ids, TString prefix, TStreamerInfo *info, Int_t offset) {
    size_t ndata = info->GetNelement();
    for (size_t i =0; i < ndata; ++i) {
       TStreamerElement *nextel = info->GetElement(i);

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -1994,6 +1994,10 @@ static void GatherArtificialElements(const TObjArray &branches, TStreamerInfoAct
             }
          }
          ids.emplace_back(nextinfo, offset + nextel->GetOffset());
+         if (!onfileObject && nextinfo && nextinfo->GetNelement() && nextinfo->GetElement(0)->GetType() == TStreamerInfo::kCacheNew) {
+            onfileObject = new TVirtualArray( info->GetElement(0)->GetClassPointer(), 1 /* is that always right? */ );
+            ids.back().fNestedIDs->fOwnOnfileObject = kTRUE;
+         }
          ids.back().fNestedIDs->fOnfileObject = onfileObject;
          GatherArtificialElements(branches, ids.back().fNestedIDs->fIDs, ename + ".", nextinfo, offset + nextel->GetOffset());
          if (ids.back().fNestedIDs->fIDs.empty())

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -1960,8 +1960,9 @@ static void GatherArtificialElements(const TObjArray &branches, TStreamerInfoAct
          ename = ename.Remove(pos);
       }
 
+      TBranchElement *be = (TBranchElement*)branches.FindObject(ename);
       if (nextel->IsA() == TStreamerArtificial::Class()
-         && branches.FindObject(ename) == nullptr) {
+         && be == nullptr) {
 
          ids.push_back(i);
          ids.back().fElement = nextel;
@@ -1972,7 +1973,6 @@ static void GatherArtificialElements(const TObjArray &branches, TStreamerInfoAct
          continue;
 
       TClass *elementClass = nextel->GetClassPointer();
-      TBranchElement *be = (TBranchElement*)branches.FindObject(ename);
       if (elementClass && (!be || be->GetType() == -2)) {
          TStreamerInfo *nextinfo = nullptr;
 

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -3621,7 +3621,7 @@ static void PrintElements(const TStreamerInfo *info, const TStreamerInfoActions:
       if (id >= 0)
          info->GetElement(id)->ls();
       else if (cursor.fNestedIDs) {
-         Printf("      With subobject of type %s offset = %d", cursor.fNestedIDs->fInfo->GetName(), cursor.fNestedIDs->fOffset);
+         Printf("      Within subobject of type %s offset = %d", cursor.fNestedIDs->fInfo->GetName(), cursor.fNestedIDs->fOffset);
          PrintElements(cursor.fNestedIDs->fInfo, cursor.fNestedIDs->fIDs);
       }
    }
@@ -3665,7 +3665,7 @@ void TBranchElement::Print(Option_t* option) const
             // Search for the correct version.
             localInfo = FindOnfileInfo(fClonesClass, fBranches);
          }
-         Printf("   With new ids:");
+         Printf("   With elements:");
          if (fType != 3 && fType != 4)
             localInfo->GetElement(fID)->ls();
          PrintElements(localInfo, fNewIDs);


### PR DESCRIPTION
This is an additional fix for cms-sw/cmssw#22594

If one of the class associated with a TBranchElement has a base class and/or sub-object class that
has a rule that requires a cache (onfileObject) object to stage the original data *but* does not
have branch in the TTree that also neeed the same cache object, we need to associate a cache
object with the StreamerInfoAction sequence that needs it (associated with a higher level branch)
and give it ownership of this cache object)