### PR TITLE
Muti-threading support in Web GUI classes

### DIFF
--- a/etc/http/changes.md
+++ b/etc/http/changes.md
@@ -1,23 +1,20 @@
 # JSROOT changelog
 
-## Changes in 5.5.1
-1. Implement 'nocache' option for JSROOT scripts lodaing. When specified in URL with
-   JSRootCore.js script, tries to avoid scripts caching problem by adding stamp parameter to all URLs.
-2. Adjust v7 part to new class naming convention, started with R
-3. Show RCanvas title
+## Changes in dev
+1. Fix drawing and update v7 histograms 
 
 
 ## Changes in 5.5.0
-1. Introduce JSROOT.StoreJSON() function. It creates JSON code for the
+1. Introduce JSROOT.StoreJSON() function. It creates JSON code for the 
    TCanvas with all drawn objects inside. Allows to store current canvas state
 2. Support "item=img:file.png" parameter to insert images in existing layout (#151)
 3. Support TTree drawing into TGraph (#153), thanks @cozzyd
 4. Let configure "&toolbar=right" in URL to change position of tool buttons
-5. Let configure "&divsize=500x400" in URL of size of main div element (default - full browser)
+5. Let configure "&divsize=500x400" in URL of size of main div element (default - full browser)  
 6. Implement "optstat1001" and "optfit101" draw options for histograms
 7. Remove "autocol" options - standard "plc" should be used instead
 8. Provide drawing of artificial "$legend" item - it creates TLegend for all primitives in pad
-   Can be used when several histograms or several graphs superimposed.
+   Can be used when several histograms or several graphs superimposed
 9. Let configure "&toolbar=vert" in URL to change orientation of tool buttons
 10. Improve markers and error bars drawing for TH1/TProfile
 

--- a/etc/http/scripts/JSRootCore.js
+++ b/etc/http/scripts/JSRootCore.js
@@ -96,7 +96,7 @@
 
    "use strict";
 
-   JSROOT.version = "5.5.1 16/07/2018";
+   JSROOT.version = "dev 22/08/2018";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;
@@ -1488,6 +1488,16 @@
             JSROOT.Create("TAttMarker", obj);
             JSROOT.extend(obj, { fLabel: "", fObject: null, fOption: "" });
             break;
+         case 'TText':
+            JSROOT.Create("TNamed", obj);
+            JSROOT.Create("TAttText", obj);
+            JSROOT.extend(obj, { fLimitFactorSize: 3, fOriginSize: 0.04 });
+            break;
+         case 'TLatex':
+            JSROOT.Create("TText", obj);
+            JSROOT.Create("TAttLine", obj);
+            JSROOT.extend(obj, { fX: 0, fY: 0 });
+            break;
          case 'TObjString':
             JSROOT.Create("TObject", obj);
             JSROOT.extend(obj, { fString: "" });
@@ -1632,7 +1642,8 @@
             break;
          case 'TCanvas':
             JSROOT.Create("TPad", obj);
-            JSROOT.extend(obj, { fDoubleBuffer: 0, fRetained: true, fXsizeUser: 0,
+            JSROOT.extend(obj, { fNumPaletteColor: 0, fNextPaletteColor: 0, fDISPLAY: "$DISPLAY",
+                                 fDoubleBuffer: 0, fRetained: true, fXsizeUser: 0,
                                  fYsizeUser: 0, fXsizeReal: 20, fYsizeReal: 10,
                                  fWindowTopX: 0, fWindowTopY: 0, fWindowWidth: 0, fWindowHeight: 0,
                                  fCw: 500, fCh: 300, fCatt: JSROOT.Create("TAttCanvas"),
@@ -1802,7 +1813,10 @@
 
       if ((typename === "TPaveText") || (typename === "TPaveStats")) {
          m.AddText = function(txt) {
-            this.fLines.Add({ _typename: 'TLatex', fTitle: txt, fTextColor: 1 });
+            // this.fLines.Add({ _typename: 'TLatex', fTitle: txt, fTextColor: 1 });
+            var line = JSROOT.Create("TLatex");
+            line.fTitle = txt;
+            this.fLines.Add(line);
          }
          m.Clear = function() {
             this.fLines.Clear();

--- a/etc/http/scripts/JSRootPainter.js
+++ b/etc/http/scripts/JSRootPainter.js
@@ -5523,7 +5523,7 @@
       }
 
       painter.Draw = function() {
-         var txt = this.txt.value;
+         var txt = (this.txt._typename && (this.txt._typename == "TObjString")) ? this.txt.fString : this.txt.value;
          if (typeof txt != 'string') txt = "<undefined>";
 
          var mathjax = this.txt.mathjax || (JSROOT.gStyle.Latex == 4);
@@ -5641,6 +5641,7 @@
    JSROOT.addDrawFunc({ name: "TWebPainting", icon: "img_graph", prereq: "more2d", func: "JSROOT.Painter.drawWebPainting" });
    JSROOT.addDrawFunc({ name: "TPadWebSnapshot", icon: "img_canvas", func: JSROOT.Painter.drawPadSnapshot });
    JSROOT.addDrawFunc({ name: "kind:Text", icon: "img_text", func: JSROOT.Painter.drawRawText });
+   JSROOT.addDrawFunc({ name: "TObjString", icon: "img_text", func: JSROOT.Painter.drawRawText });
    JSROOT.addDrawFunc({ name: "TF1", icon: "img_tf1", prereq: "math;more2d", func: "JSROOT.Painter.drawFunction" });
    JSROOT.addDrawFunc({ name: "TF2", icon: "img_tf2", prereq: "math;hist", func: "JSROOT.Painter.drawTF2" });
    JSROOT.addDrawFunc({ name: "TSpline3", icon: "img_tf1", prereq: "more2d", func: "JSROOT.Painter.drawSpline" });

--- a/etc/http/scripts/JSRootPainter.more.js
+++ b/etc/http/scripts/JSRootPainter.more.js
@@ -1912,7 +1912,7 @@
    }
 
    TGraphPainter.prototype.PerformDrawing = function(divid, hpainter) {
-      if (hpainter) this.axes_draw = true;
+      if (hpainter) { this.axes_draw = true; hpainter.$secondary = true; }
       this.SetDivId(divid);
       this.DrawBins();
       this.DrawNextFunction(0, this.DrawingReady.bind(this));

--- a/etc/http/scripts/JSRootPainter.v6.js
+++ b/etc/http/scripts/JSRootPainter.v6.js
@@ -4548,7 +4548,10 @@
    /// produce JSON for TCanvas, which can be used to display canvas once again
    TCanvasPainter.prototype.ProduceJSON = function() {
 
-      var canv = this.GetObject();
+      var canv = this.GetObject(),
+          fill0 = (canv.fFillStyle == 0);
+
+      if (fill0) canv.fFillStyle = 1001;
 
       if (!this.normal_canvas) {
 
@@ -4563,6 +4566,8 @@
       }
 
       var res = JSROOT.toJSON(canv);
+
+      if (fill0) canv.fFillStyle = 0;
 
       if (!this.normal_canvas)
          canv.fPrimitives.Clear();

--- a/etc/http/scripts/JSRootPainter.v7.js
+++ b/etc/http/scripts/JSRootPainter.v7.js
@@ -3283,7 +3283,7 @@
          var sub = this.painters[k];
          if (sub.snapid===undefined) continue; // look only for painters with snapid
 
-         for (var i=1;i<snap.fPrimitives.length;++i)
+         for (var i=0;i<snap.fPrimitives.length;++i)
             if (snap.fPrimitives[i].fObjectID === sub.snapid) { sub = null; isanyfound = true; break; }
 
          if (sub) {

--- a/graf2d/gpadv7/v7/inc/ROOT/RCanvas.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RCanvas.hxx
@@ -86,8 +86,11 @@ public:
    /// Display the canvas.
    void Show(const std::string &where = "");
 
-   /// Close all canvas displays
+   /// Hide all canvas displays
    void Hide();
+
+   /// Remove canvas from global canvas lists, will be destroyed when shared_ptr will be removed
+   void Remove();
 
    /// Insert panel into the canvas, canvas should be shown at this moment
    template <class PANEL>
@@ -104,6 +107,9 @@ public:
 
    /// update drawing
    void Update(bool async = false, CanvasCallback_t callback = nullptr);
+
+   /// Run canvas functionality for given time
+   void Run(double tm = 0.);
 
    /// Save canvas in image file
    void SaveAs(const std::string &filename, bool async = false, CanvasCallback_t callback = nullptr);

--- a/graf2d/gpadv7/v7/inc/ROOT/RCanvas.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RCanvas.hxx
@@ -126,7 +126,7 @@ public:
       return {{pos[0] / fSize[0], pos[1] / fSize[1]}};
    }
 
-   static const std::vector<std::shared_ptr<RCanvas>> &GetCanvases();
+   static const std::vector<std::shared_ptr<RCanvas>> GetCanvases();
 };
 
 } // namespace Experimental

--- a/graf2d/gpadv7/v7/inc/ROOT/RCanvas.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RCanvas.hxx
@@ -108,7 +108,7 @@ public:
    /// update drawing
    void Update(bool async = false, CanvasCallback_t callback = nullptr);
 
-   /// Run canvas functionality for given time
+   /// Run canvas functionality for given time (in seconds)
    void Run(double tm = 0.);
 
    /// Save canvas in image file

--- a/graf2d/gpadv7/v7/inc/ROOT/RVirtualCanvasPainter.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RVirtualCanvasPainter.hxx
@@ -65,6 +65,9 @@ public:
 
    virtual int NumDisplays() const = 0;
 
+   /// run canvas functionality in caller thread, not needed when main thread is used
+   virtual void Run(double tm = 0.) = 0;
+
    virtual bool AddPanel(std::shared_ptr<TWebWindow>) { return false; }
 
    /// Loads the plugin that implements this class.

--- a/graf2d/gpadv7/v7/src/RCanvas.cxx
+++ b/graf2d/gpadv7/v7/src/RCanvas.cxx
@@ -178,10 +178,43 @@ void ROOT::Experimental::RCanvas::Remove()
    GetHeldCanvases(dummy, this);
 }
 
-
 //////////////////////////////////////////////////////////////////////////
-/// Run canvas functionality for given time
-/// If canvas was not drawn - just perform simple sleep
+/// Run canvas functionality for the given time (in seconds)
+/// Used to process canvas-related actions in the appropriate thread context.
+/// Must be regularly called when canvas created and used in extra thread.
+/// When canvas is not yet displayed - just performs sleep for given time interval.
+///
+/// Example of usage:
+///
+/// ~~~ {.cpp}
+/// void draw_canvas(bool &run_loop, std::make_shared<RH1D> hist)
+/// {
+///   auto canvas = RCanvas::Create("Canvas title");
+///   canvas->Draw(hist)->SetLineColor(RColor::kBlue);
+///   canvas->Show();
+///   while (run_loop) {
+///      pHist->Fill(1);
+///      canvas->Modified();
+///      canvas->Update();
+///      canvas->Run(0.1); // process canvas events
+///   }
+///
+///   canvas->Remove();
+/// }
+///
+/// int main()
+/// {
+///    RAxisConfig xaxis(100, -10., 10.);
+///    auto pHist = std::make_shared<RH1D>(xaxis);
+///    bool run_loop = true;
+///
+///    std::thread thrd(draw_canvas, run_loop, pHist);
+///    std::this_thread::sleep_for(std::chrono::seconds(100));
+///    run_loop = false;
+///    thrd.join();
+///    return 0;
+/// }
+/// ~~~
 
 void ROOT::Experimental::RCanvas::Run(double tm)
 {

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -27,6 +27,8 @@
 #include <string>
 #include <vector>
 #include <list>
+#include <thread>
+#include <chrono>
 #include <fstream>
 
 #include "TList.h"
@@ -158,6 +160,8 @@ public:
    virtual void NewDisplay(const std::string &where) override;
 
    virtual int NumDisplays() const override;
+
+   virtual void Run(double tm = 0.) override;
 
    virtual bool AddPanel(std::shared_ptr<TWebWindow>) override;
 
@@ -723,4 +727,18 @@ void ROOT::Experimental::TCanvasPainter::PopFrontCommand(bool result)
    fCmds.front().CallBack(result);
 
    fCmds.pop_front();
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+/// Run canvas functionality for specified period of time
+/// Required when canvas used not from the main thread
+
+void ROOT::Experimental::TCanvasPainter::Run(double tm)
+{
+   if (fWindow) {
+      fWindow->Run(tm);
+   } else if (tm>0) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(int(tm*1000)));
+   }
+
 }

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -341,6 +341,9 @@ void ROOT::Experimental::TCanvasPainter::CheckDataToSend()
 void ROOT::Experimental::TCanvasPainter::CanvasUpdated(uint64_t ver, bool async,
                                                        ROOT::Experimental::CanvasCallback_t callback)
 {
+   if (fWindow)
+      fWindow->Sync();
+
    if (ver && fSnapshotDelivered && (ver <= fSnapshotDelivered)) {
       // if given canvas version was already delivered to clients, can return immediately
       if (callback)

--- a/gui/webdisplay/inc/ROOT/TWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindow.hxx
@@ -117,7 +117,7 @@ private:
 
    std::vector<std::shared_ptr<WebConn>> GetConnections(unsigned connid = 0);
 
-   std::shared_ptr<WebConn> _FindConnection(unsigned wsid);
+   std::shared_ptr<WebConn> FindConnection(unsigned wsid, bool make_new = false);
 
    std::shared_ptr<WebConn> RemoveConnection(unsigned wsid);
 

--- a/gui/webdisplay/inc/ROOT/TWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindow.hxx
@@ -192,6 +192,8 @@ public:
 
    bool CanSend(unsigned connid, bool direct = true);
 
+   int SendQueueLength(unsigned connid);
+
    void Send(unsigned connid, const std::string &data);
 
    void SendBinary(unsigned connid, const void *data, std::size_t len);

--- a/gui/webdisplay/inc/ROOT/TWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindow.hxx
@@ -210,6 +210,8 @@ public:
 
    void Sync();
 
+   void Run(double tm = 0.);
+
    bool Show(const std::string &where = "");
 
    bool CanSend(unsigned connid, bool direct = true);

--- a/gui/webdisplay/inc/ROOT/TWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindow.hxx
@@ -63,6 +63,7 @@ private:
       unsigned fWSId{0};             ///<! websocket id
       std::string fProcId;           ///<! client process identifier (when exists)
       int fReady{0};                 ///<! 0 - not ready, 1..9 - interim, 10 - done
+      std::mutex fMutex;             ///<! mutex must be used to protect all following data
       int fRecvCount{0};             ///<! number of received packets, should return back with next sending
       int fSendCredits{0};           ///<! how many send operation can be performed without confirmation from other side
       int fClientCredits{0};         ///<! number of credits received from client
@@ -106,7 +107,7 @@ private:
 
    std::shared_ptr<WebConn> RemoveConnection(unsigned wsid);
 
-   void SendDataViaConnection(std::shared_ptr<WebConn> &conn, bool txt, const std::string &data, int chid);
+   std::string _MakeSendHeader(std::shared_ptr<WebConn> &conn, bool txt, const std::string &data, int chid);
 
    void SubmitData(unsigned connid, bool txt, std::string &&data, int chid = 1);
 

--- a/gui/webdisplay/inc/ROOT/TWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindow.hxx
@@ -67,6 +67,7 @@ private:
       int fRecvCount{0};             ///<! number of received packets, should return back with next sending
       int fSendCredits{0};           ///<! how many send operation can be performed without confirmation from other side
       int fClientCredits{0};         ///<! number of credits received from client
+      bool fDoingSend{false};        ///<! true when performing send operation
       std::queue<QueueItem> fQueue;  ///<! output queue
       WebWindowDataCallback_t fCallBack; ///<! additional data callback for extra channels
       WebConn() = default;
@@ -101,6 +102,8 @@ private:
 
    bool ProcessWS(THttpCallArg &arg);
 
+   void CompleteMTSend(unsigned wsid);
+
    std::vector<std::shared_ptr<WebConn>> GetConnections(unsigned connid = 0);
 
    std::shared_ptr<WebConn> _FindConnection(unsigned wsid);
@@ -110,6 +113,8 @@ private:
    std::string _MakeSendHeader(std::shared_ptr<WebConn> &conn, bool txt, const std::string &data, int chid);
 
    void SubmitData(unsigned connid, bool txt, std::string &&data, int chid = 1);
+
+   bool CheckDataToSend(std::shared_ptr<WebConn> &conn);
 
    void CheckDataToSend(bool only_once = false);
 

--- a/gui/webdisplay/inc/ROOT/TWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindow.hxx
@@ -87,7 +87,7 @@ private:
    std::string fDefaultPage;                        ///<! HTML page (or file name) returned when window URL is opened
    std::string fPanelName;                          ///<! panel name which should be shown in the window
    unsigned fId{0};                                 ///<! unique identifier
-   std::unique_ptr<TWebWindowWSHandler> fWSHandler; ///<! specialize websocket handler for all incoming connections
+   std::shared_ptr<TWebWindowWSHandler> fWSHandler; ///<! specialize websocket handler for all incoming connections
    bool fShown{false};                              ///<! true when window was shown at least once
    unsigned fConnCnt{0};                            ///<! counter of new connections to assign ids
    std::vector<std::shared_ptr<WebConn>> fConn;     ///<! list of all accepted connections

--- a/gui/webdisplay/inc/ROOT/TWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindow.hxx
@@ -115,7 +115,7 @@ private:
 
    bool ProcessWS(THttpCallArg &arg);
 
-   void CompleteMTSend(unsigned wsid);
+   void CompleteWSSend(unsigned wsid);
 
    std::vector<std::shared_ptr<WebConn>> GetConnections(unsigned connid = 0);
 

--- a/gui/webdisplay/inc/ROOT/TWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindow.hxx
@@ -230,7 +230,9 @@ public:
 
    void SetDataCallBack(WebWindowDataCallback_t func);
 
-   int WaitFor(WebWindowWaitFunc_t check, double tm = -1);
+   int WaitFor(WebWindowWaitFunc_t check);
+
+   int WaitForTimed(WebWindowWaitFunc_t check, double tm = 0);
 };
 
 } // namespace Experimental

--- a/gui/webdisplay/inc/ROOT/TWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindow.hxx
@@ -125,7 +125,7 @@ private:
 
    void ProvideData(unsigned connid, std::string &&arg);
 
-   void InovkeCallbacks(bool force = false);
+   void InvokeCallbacks(bool force = false);
 
    void SubmitData(unsigned connid, bool txt, std::string &&data, int chid = 1);
 

--- a/gui/webdisplay/inc/ROOT/TWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindow.hxx
@@ -87,6 +87,8 @@ private:
    std::string fDefaultPage;                        ///<! HTML page (or file name) returned when window URL is opened
    std::string fPanelName;                          ///<! panel name which should be shown in the window
    unsigned fId{0};                                 ///<! unique identifier
+   bool fProcessMT{false};                          ///<! if window event processing performed in dedicated thread
+   bool fSendMT{false};                             ///<! true is special threads should be used for sending data
    std::shared_ptr<TWebWindowWSHandler> fWSHandler; ///<! specialize websocket handler for all incoming connections
    bool fShown{false};                              ///<! true when window was shown at least once
    unsigned fConnCnt{0};                            ///<! counter of new connections to assign ids

--- a/gui/webdisplay/inc/ROOT/TWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindow.hxx
@@ -218,7 +218,7 @@ public:
 
    bool CanSend(unsigned connid, bool direct = true);
 
-   int SendQueueLength(unsigned connid);
+   int GetSendQueueLength(unsigned connid);
 
    void Send(unsigned connid, const std::string &data);
 

--- a/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
@@ -44,9 +44,9 @@ private:
    std::string fAddr;                    ///<!  HTTP address of the server
    std::mutex fMutex;                    ///<!  main mutex to protect
    int fMutexBooked{0};                  ///<!  flag indicating that mutex is booked for some long operation
-   std::thread::id  fBookedThrd;         ///<!  thread where mutex is booked, can be reused
+   std::thread::id fBookedThrd;          ///<!  thread where mutex is booked, can be reused
+   unsigned fIdCnt{0};                   ///<! counter for identifiers
    // std::list<std::shared_ptr<TWebWindow>> fDisplays;   ///<! list of existing displays (not used at the moment)
-   unsigned fIdCnt{0}; ///<! counter for identifiers
 
    bool CreateHttpServer(bool with_http = false);
 

--- a/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
@@ -44,10 +44,17 @@ private:
    std::mutex fMutex;                    ///<!  main mutex to protect
    int fMutexBooked{0};                  ///<!  flag indicating that mutex is booked for some long operation
    std::thread::id fBookedThrd;          ///<!  thread where mutex is booked, can be reused
-   unsigned fIdCnt{0};                   ///<! counter for identifiers
+   unsigned fIdCnt{0};                   ///<!  counter for identifiers
+   bool fUseHttpThrd{false};             ///<!  use special thread for THttpServer
+   bool fUseSenderThreads{false};        ///<!  use extra threads for sending data from RWebWindow to clients
    // std::list<std::shared_ptr<TWebWindow>> fDisplays;   ///<! list of existing displays (not used at the moment)
 
-   static bool IsUseHttpThread();
+   /// Returns true if extra threads to send data via websockets will be used (default off)
+   bool IsUseHttpThread() const { return fUseHttpThrd; }
+
+   /// Returns true if extra threads to send data via websockets will be used (default off)
+   bool IsUseSenderThreads() const { return fUseSenderThreads; }
+
    bool CreateHttpServer(bool with_http = false);
 
    void Unregister(TWebWindow &win);
@@ -69,11 +76,6 @@ public:
 
    /// Returns THttpServer instance
    THttpServer *GetServer() const { return fServer.get(); }
-
-   static void SetUseHttpThread(bool on = true);
-
-   static void SetUseSenderThreads(bool on = true);
-   static bool IsUseSenderThreads();
 
    static std::shared_ptr<TWebWindowsManager> &Instance();
 

--- a/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
@@ -18,7 +18,8 @@
 
 #include <memory>
 #include <string>
-// #include <list>
+#include <thread>
+#include <mutex>
 
 #include "THttpEngine.h"
 
@@ -30,13 +31,20 @@ class THttpWSHandler;
 namespace ROOT {
 namespace Experimental {
 
+class TWebWindowManagerGuard;
+
+
 class TWebWindowsManager {
 
    friend class TWebWindow;
+   friend class TWebWindowManagerGuard;
 
 private:
    std::unique_ptr<THttpServer> fServer; ///<!  central communication with the all used displays
-   std::string fAddr;                    ///<!   HTTP address of the server
+   std::string fAddr;                    ///<!  HTTP address of the server
+   std::mutex fMutex;                    ///<!  main mutex to protect
+   int fMutexBooked{0};                  ///<!  flag indicating that mutex is booked for some long operation
+   std::thread::id  fBookedThrd;         ///<!  thread where mutex is booked, can be reused
    // std::list<std::shared_ptr<TWebWindow>> fDisplays;   ///<! list of existing displays (not used at the moment)
    unsigned fIdCnt{0}; ///<! counter for identifiers
 

--- a/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
@@ -33,7 +33,6 @@ namespace Experimental {
 
 class TWebWindowManagerGuard;
 
-
 class TWebWindowsManager {
 
    friend class TWebWindow;
@@ -69,6 +68,10 @@ public:
 
    /// Returns THttpServer instance
    THttpServer *GetServer() const { return fServer.get(); }
+
+   static void SetUseHttpThread(bool on = true);
+   static void SetUseSenderThreads(bool on = true);
+   static bool IsUseSenderThreads();
 
    static std::shared_ptr<TWebWindowsManager> &Instance();
 

--- a/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
@@ -69,6 +69,8 @@ private:
 
    int WaitFor(TWebWindow &win, WebWindowWaitFunc_t check, bool timed = false, double tm = -1);
 
+   static bool IsMainThrd();
+
 public:
    TWebWindowsManager();
 
@@ -78,8 +80,6 @@ public:
    THttpServer *GetServer() const { return fServer.get(); }
 
    static std::shared_ptr<TWebWindowsManager> &Instance();
-
-   static bool IsMainThrd();
 
    std::shared_ptr<TWebWindow> CreateWindow(bool batch_mode = false);
 

--- a/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
@@ -49,7 +49,7 @@ private:
    bool fUseSenderThreads{false};        ///<!  use extra threads for sending data from RWebWindow to clients
    // std::list<std::shared_ptr<TWebWindow>> fDisplays;   ///<! list of existing displays (not used at the moment)
 
-   /// Returns true if extra threads to send data via websockets will be used (default off)
+   /// Returns true if http server use special thread for requests processing (default off)
    bool IsUseHttpThread() const { return fUseHttpThrd; }
 
    /// Returns true if extra threads to send data via websockets will be used (default off)
@@ -67,7 +67,7 @@ private:
 
    void TestProg(TString &prog, const std::string &nexttry);
 
-   int WaitFor(TWebWindow &win, WebWindowWaitFunc_t check, double tm = -1);
+   int WaitFor(TWebWindow &win, WebWindowWaitFunc_t check, bool timed = false, double tm = -1);
 
 public:
    TWebWindowsManager();

--- a/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
@@ -52,6 +52,8 @@ private:
 
    void TestProg(TString &prog, const std::string &nexttry);
 
+   int WaitFor(TWebWindow &win, WebWindowWaitFunc_t check, double tm = -1);
+
 public:
    TWebWindowsManager();
 
@@ -62,9 +64,9 @@ public:
 
    static std::shared_ptr<TWebWindowsManager> &Instance();
 
-   std::shared_ptr<TWebWindow> CreateWindow(bool batch_mode = false);
+   static bool IsMainThrd();
 
-   int WaitFor(WebWindowWaitFunc_t check, double tm = -1);
+   std::shared_ptr<TWebWindow> CreateWindow(bool batch_mode = false);
 
    void Terminate();
 };

--- a/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/TWebWindowsManager.hxx
@@ -47,6 +47,7 @@ private:
    unsigned fIdCnt{0};                   ///<! counter for identifiers
    // std::list<std::shared_ptr<TWebWindow>> fDisplays;   ///<! list of existing displays (not used at the moment)
 
+   static bool IsUseHttpThread();
    bool CreateHttpServer(bool with_http = false);
 
    void Unregister(TWebWindow &win);
@@ -70,6 +71,7 @@ public:
    THttpServer *GetServer() const { return fServer.get(); }
 
    static void SetUseHttpThread(bool on = true);
+
    static void SetUseSenderThreads(bool on = true);
    static bool IsUseSenderThreads();
 

--- a/gui/webdisplay/src/TWebWindow.cxx
+++ b/gui/webdisplay/src/TWebWindow.cxx
@@ -109,7 +109,7 @@ void ROOT::Experimental::TWebWindow::SetPanelName(const std::string &name)
 void ROOT::Experimental::TWebWindow::CreateWSHandler()
 {
    if (!fWSHandler) {
-      fSendMT = TWebWindowsManager::IsUseSenderThreads();
+      fSendMT = fMgr->IsUseSenderThreads();
       fWSHandler = std::make_shared<TWebWindowWSHandler>(*this, Form("win%u", GetId()));
    }
 }
@@ -723,7 +723,7 @@ void ROOT::Experimental::TWebWindow::SetDataCallBack(WebWindowDataCallback_t fun
    fDataThrdId = std::this_thread::get_id();
    if (!TWebWindowsManager::IsMainThrd()) {
       fProcessMT = true;
-   } else if (TWebWindowsManager::IsUseHttpThread()) {
+   } else if (fMgr->IsUseHttpThread()) {
       // special thread is used by the manager, but main thread used for the canvas - not supported
       R__ERROR_HERE("webgui") << "create web window from main thread when THttpServer created with special thread - not supported";
    }

--- a/gui/webdisplay/src/TWebWindow.cxx
+++ b/gui/webdisplay/src/TWebWindow.cxx
@@ -33,10 +33,11 @@ namespace Experimental {
 class TWebWindowWSHandler : public THttpWSHandler {
 public:
    TWebWindow &fWindow; ///<! window reference
+   bool fSenderMT;      ///<! support multithreading for senders
 
    /// constructor
-   TWebWindowWSHandler(TWebWindow &wind, const char *name)
-      : THttpWSHandler(name, "TWebWindow websockets handler"), fWindow(wind)
+   TWebWindowWSHandler(TWebWindow &wind, const char *name, bool sendermt = false)
+      : THttpWSHandler(name, "TWebWindow websockets handler"), fWindow(wind), fSenderMT(sendermt)
    {
    }
 
@@ -53,7 +54,7 @@ public:
    virtual Bool_t ProcessWS(THttpCallArg *arg) override { return arg && !IsDisabled() ? fWindow.ProcessWS(*arg) : kFALSE; }
 
    /// Allows usage of multithreading in send operations
-   virtual Bool_t AllowMT() const { return kTRUE; }
+   virtual Bool_t AllowMT() const { return fSenderMT; }
 
    /// React on completion of multithreaded send operaiotn
    virtual void CompleteMTSend(UInt_t wsid) { if (!IsDisabled()) fWindow.CompleteMTSend(wsid); }
@@ -139,7 +140,7 @@ void ROOT::Experimental::TWebWindow::SetPanelName(const std::string &name)
 void ROOT::Experimental::TWebWindow::CreateWSHandler()
 {
    if (!fWSHandler)
-      fWSHandler = std::make_unique<TWebWindowWSHandler>(*this, Form("win%u", GetId()));
+      fWSHandler = std::make_unique<TWebWindowWSHandler>(*this, Form("win%u", GetId()), ROOT::Experimental::TWebWindowsManager::IsUseSenderThreads());
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/gui/webdisplay/src/TWebWindow.cxx
+++ b/gui/webdisplay/src/TWebWindow.cxx
@@ -773,3 +773,16 @@ int ROOT::Experimental::TWebWindow::WaitFor(WebWindowWaitFunc_t check, double ti
 {
    return fMgr->WaitFor(*this, check, timelimit);
 }
+
+/////////////////////////////////////////////////////////////////////////////////
+/// Run window functionality for specified time
+/// If no action can be performed - just sleep specified time
+
+void ROOT::Experimental::TWebWindow::Run(double tm)
+{
+   if (tm <= 0) {
+      Sync();
+   } else {
+      WaitFor([](double) { return 0; }, tm);
+   }
+}

--- a/gui/webdisplay/src/TWebWindow.cxx
+++ b/gui/webdisplay/src/TWebWindow.cxx
@@ -529,6 +529,8 @@ bool ROOT::Experimental::TWebWindow::CanSend(unsigned connid, bool direct)
 
    for (auto &&conn : arr) {
 
+      std::lock_guard<std::mutex> grd(conn->fMutex);
+
       if (direct && (!conn->fQueue.empty() || (conn->fSendCredits == 0)))
          return false;
 
@@ -538,6 +540,27 @@ bool ROOT::Experimental::TWebWindow::CanSend(unsigned connid, bool direct)
 
    return true;
 }
+
+///////////////////////////////////////////////////////////////////////////////////
+/// returns send queue length for specified connection
+/// if connid==0, maximal value for all connections are returned
+/// If wrong connection is specified, -1 is return
+
+int ROOT::Experimental::TWebWindow::SendQueueLength(unsigned connid)
+{
+   auto arr = GetConnections(connid);
+
+   int maxq = -1;
+
+   for (auto &&conn : arr) {
+      std::lock_guard<std::mutex> grd(conn->fMutex);
+      int len = conn->fQueue.size();
+      if (len > maxq) maxq = len;
+   }
+
+   return maxq;
+}
+
 
 ///////////////////////////////////////////////////////////////////////////////////
 /// Internal method to send data

--- a/gui/webdisplay/src/TWebWindow.cxx
+++ b/gui/webdisplay/src/TWebWindow.cxx
@@ -215,14 +215,14 @@ void ROOT::Experimental::TWebWindow::ProvideData(unsigned connid, std::string &&
       fDataQueue.emplace(connid, std::move(arg));
    }
 
-   InovkeCallbacks();
+   InvokeCallbacks();
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
 /// Invoke callbacks with existing data
 /// Must be called from appropriate thread
 
-void ROOT::Experimental::TWebWindow::InovkeCallbacks(bool force)
+void ROOT::Experimental::TWebWindow::InvokeCallbacks(bool force)
 {
    if ((fDataThrdId != std::this_thread::get_id()) && !force)
       return;
@@ -238,6 +238,7 @@ void ROOT::Experimental::TWebWindow::InovkeCallbacks(bool force)
          DataEntry &entry = fDataQueue.front();
          connid = entry.fConnId;
          arg = std::move(entry.fData);
+         fDataQueue.pop();
       }
 
       fDataCallback(connid, arg);
@@ -770,5 +771,5 @@ void ROOT::Experimental::TWebWindow::SetDataCallBack(WebWindowDataCallback_t fun
 
 int ROOT::Experimental::TWebWindow::WaitFor(WebWindowWaitFunc_t check, double timelimit)
 {
-   return fMgr->WaitFor(check, timelimit);
+   return fMgr->WaitFor(*this, check, timelimit);
 }

--- a/gui/webdisplay/src/TWebWindow.cxx
+++ b/gui/webdisplay/src/TWebWindow.cxx
@@ -67,9 +67,7 @@ ROOT::Experimental::TWebWindow::~TWebWindow()
 
    if (fMgr) {
 
-      auto arr = GetConnections();
-
-      for (auto &&conn : arr)
+      for (auto &&conn : GetConnections())
          if (conn->fActive) {
             conn->fActive = false;
             fMgr->HaltClient(conn->fProcId);
@@ -172,7 +170,7 @@ std::shared_ptr<ROOT::Experimental::TWebWindow::WebConn> ROOT::Experimental::TWe
 
    for (size_t n=0; n<fConn.size();++n)
       if (fConn[n]->fWSId == wsid) {
-         auto res = std::move(fConn[n]);
+         std::shared_ptr<WebConn> res = std::move(fConn[n]);
          fConn.erase(fConn.begin() + n);
          res->fActive = false;
          return res;
@@ -617,16 +615,14 @@ bool ROOT::Experimental::TWebWindow::CanSend(unsigned connid, bool direct)
 
 ///////////////////////////////////////////////////////////////////////////////////
 /// returns send queue length for specified connection
-/// if connid==0, maximal value for all connections are returned
+/// if connid==0, maximal value for all connections is returned
 /// If wrong connection is specified, -1 is return
 
-int ROOT::Experimental::TWebWindow::SendQueueLength(unsigned connid)
+int ROOT::Experimental::TWebWindow::GetSendQueueLength(unsigned connid)
 {
-   auto arr = GetConnections(connid);
-
    int maxq = -1;
 
-   for (auto &&conn : arr) {
+   for (auto &&conn : GetConnections(connid)) {
       std::lock_guard<std::mutex> grd(conn->fMutex);
       int len = conn->fQueue.size();
       if (len > maxq) maxq = len;

--- a/gui/webdisplay/src/TWebWindow.cxx
+++ b/gui/webdisplay/src/TWebWindow.cxx
@@ -731,17 +731,31 @@ void ROOT::Experimental::TWebWindow::SetDataCallBack(WebWindowDataCallback_t fun
 
 /////////////////////////////////////////////////////////////////////////////////
 /// Waits until provided check function or lambdas returns non-zero value
-/// Runs application mainloop and short sleeps in-between
-/// timelimit (in seconds) defines how long to wait (0 - forever, negative - default value)
-/// Function has following signature: int func(double spent_tm)
-/// Parameter spent_tm is time in seconds, which already spent inside function
+/// Check function has following signature: int func(double spent_tm)
 /// Waiting will be continued, if function returns zero.
-/// First non-zero value breaks waiting loop and result is returned (or 0 if time is expired).
+/// Parameter spent_tm is time in seconds, which already spent inside the function
+/// First non-zero value breaks loop and result is returned.
+/// Runs application mainloop and short sleeps in-between
 
-int ROOT::Experimental::TWebWindow::WaitFor(WebWindowWaitFunc_t check, double timelimit)
+int ROOT::Experimental::TWebWindow::WaitFor(WebWindowWaitFunc_t check)
 {
-   return fMgr->WaitFor(*this, check, timelimit);
+   return fMgr->WaitFor(*this, check);
 }
+
+/////////////////////////////////////////////////////////////////////////////////
+/// Waits until provided check function or lambdas returns non-zero value
+/// Check function has following signature: int func(double spent_tm)
+/// Waiting will be continued, if function returns zero.
+/// Parameter spent_tm is time in seconds, which already spent inside the function
+/// First non-zero value breaks waiting loop and result is returned (or 0 if time is expired).
+/// Runs application mainloop and short sleeps in-between
+/// timelimit (in seconds) defines how long to wait (if value <=0, WebGui.WaitForTmout parameter will be used)
+
+int ROOT::Experimental::TWebWindow::WaitForTimed(WebWindowWaitFunc_t check, double timelimit)
+{
+   return fMgr->WaitFor(*this, check, true, timelimit);
+}
+
 
 /////////////////////////////////////////////////////////////////////////////////
 /// Run window functionality for specified time
@@ -757,6 +771,6 @@ void ROOT::Experimental::TWebWindow::Run(double tm)
    if (tm <= 0) {
       Sync();
    } else {
-      WaitFor([](double) { return 0; }, tm);
+      WaitForTimed([](double) { return 0; }, tm);
    }
 }

--- a/gui/webdisplay/src/TWebWindowWSHandler.hxx
+++ b/gui/webdisplay/src/TWebWindowWSHandler.hxx
@@ -28,11 +28,10 @@ namespace Experimental {
 class TWebWindowWSHandler : public THttpWSHandler {
 public:
    TWebWindow &fWindow; ///<! window reference
-   bool fSenderMT;      ///<! support multithreading for senders
 
    /// constructor
-   TWebWindowWSHandler(TWebWindow &wind, const char *name, bool sendermt = false)
-      : THttpWSHandler(name, "TWebWindow websockets handler"), fWindow(wind), fSenderMT(sendermt)
+   TWebWindowWSHandler(TWebWindow &wind, const char *name)
+      : THttpWSHandler(name, "TWebWindow websockets handler"), fWindow(wind)
    {
    }
 
@@ -49,10 +48,10 @@ public:
    virtual Bool_t ProcessWS(THttpCallArg *arg) override { return arg && !IsDisabled() ? fWindow.ProcessWS(*arg) : kFALSE; }
 
    /// Allow processing of WS actions in arbitrary thread
-   virtual Bool_t AllowMTProcess() const { return kTRUE; }
+   virtual Bool_t AllowMTProcess() const { return fWindow.fProcessMT; }
 
    /// Allows usage of multithreading in send operations
-   virtual Bool_t AllowMTSend() const { return fSenderMT; }
+   virtual Bool_t AllowMTSend() const { return fWindow.fSendMT; }
 
    /// React on completion of multithreaded send operaiotn
    virtual void CompleteMTSend(UInt_t wsid) { if (!IsDisabled()) fWindow.CompleteMTSend(wsid); }

--- a/gui/webdisplay/src/TWebWindowWSHandler.hxx
+++ b/gui/webdisplay/src/TWebWindowWSHandler.hxx
@@ -6,7 +6,7 @@
 /// is welcome!
 
 /*************************************************************************
- * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -35,9 +35,7 @@ public:
    {
    }
 
-   virtual ~TWebWindowWSHandler()
-   {
-   }
+   virtual ~TWebWindowWSHandler() = default;
 
    /// returns content of default web-page
    /// THttpWSHandler interface

--- a/gui/webdisplay/src/TWebWindowWSHandler.hxx
+++ b/gui/webdisplay/src/TWebWindowWSHandler.hxx
@@ -31,7 +31,7 @@ public:
 
    /// constructor
    TWebWindowWSHandler(TWebWindow &wind, const char *name)
-      : THttpWSHandler(name, "TWebWindow websockets handler"), fWindow(wind)
+      : THttpWSHandler(name, "TWebWindow websockets handler", kFALSE), fWindow(wind)
    {
    }
 

--- a/gui/webdisplay/src/TWebWindowWSHandler.hxx
+++ b/gui/webdisplay/src/TWebWindowWSHandler.hxx
@@ -39,20 +39,20 @@ public:
 
    /// returns content of default web-page
    /// THttpWSHandler interface
-   virtual TString GetDefaultPageContent() override { return IsDisabled() ? "" : fWindow.fDefaultPage.c_str(); }
+   TString GetDefaultPageContent() override { return IsDisabled() ? "" : fWindow.fDefaultPage.c_str(); }
 
    /// Process websocket request - called from THttpServer thread
    /// THttpWSHandler interface
-   virtual Bool_t ProcessWS(THttpCallArg *arg) override { return arg && !IsDisabled() ? fWindow.ProcessWS(*arg) : kFALSE; }
+   Bool_t ProcessWS(THttpCallArg *arg) override { return arg && !IsDisabled() ? fWindow.ProcessWS(*arg) : kFALSE; }
 
    /// Allow processing of WS actions in arbitrary thread
-   virtual Bool_t AllowMTProcess() const { return fWindow.fProcessMT; }
+   Bool_t AllowMTProcess() const override { return fWindow.fProcessMT; }
 
-   /// Allows usage of multithreading in send operations
-   virtual Bool_t AllowMTSend() const { return fWindow.fSendMT; }
+   /// Allows usage of special threads for send operations
+   Bool_t AllowMTSend() const override { return fWindow.fSendMT; }
 
-   /// React on completion of multithreaded send operaiotn
-   virtual void CompleteWSSend(UInt_t wsid) { if (!IsDisabled()) fWindow.CompleteWSSend(wsid); }
+   /// React on completion of multithreaded send operation
+   void CompleteWSSend(UInt_t wsid) override { if (!IsDisabled()) fWindow.CompleteWSSend(wsid); }
 };
 
 } // namespace Experimental

--- a/gui/webdisplay/src/TWebWindowWSHandler.hxx
+++ b/gui/webdisplay/src/TWebWindowWSHandler.hxx
@@ -1,0 +1,64 @@
+/// \file ROOT/TWebWindowWSHandler.hxx
+/// \ingroup WebGui ROOT7
+/// \author Sergey Linev <s.linev@gsi.de>
+/// \date 2018-08-20
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_TWebWindowWSHandler
+#define ROOT7_TWebWindowWSHandler
+
+#include "THttpWSHandler.h"
+
+#include <ROOT/TWebWindow.hxx>
+
+namespace ROOT {
+namespace Experimental {
+
+/// just wrapper to deliver websockets call-backs to the TWebWindow class
+
+class TWebWindowWSHandler : public THttpWSHandler {
+public:
+   TWebWindow &fWindow; ///<! window reference
+   bool fSenderMT;      ///<! support multithreading for senders
+
+   /// constructor
+   TWebWindowWSHandler(TWebWindow &wind, const char *name, bool sendermt = false)
+      : THttpWSHandler(name, "TWebWindow websockets handler"), fWindow(wind), fSenderMT(sendermt)
+   {
+   }
+
+   virtual ~TWebWindowWSHandler()
+   {
+   }
+
+   /// returns content of default web-page
+   /// THttpWSHandler interface
+   virtual TString GetDefaultPageContent() override { return IsDisabled() ? "" : fWindow.fDefaultPage.c_str(); }
+
+   /// Process websocket request - called from THttpServer thread
+   /// THttpWSHandler interface
+   virtual Bool_t ProcessWS(THttpCallArg *arg) override { return arg && !IsDisabled() ? fWindow.ProcessWS(*arg) : kFALSE; }
+
+   /// Allow processing of WS actions in arbitrary thread
+   virtual Bool_t AllowMTProcess() const { return kTRUE; }
+
+   /// Allows usage of multithreading in send operations
+   virtual Bool_t AllowMTSend() const { return fSenderMT; }
+
+   /// React on completion of multithreaded send operaiotn
+   virtual void CompleteMTSend(UInt_t wsid) { if (!IsDisabled()) fWindow.CompleteMTSend(wsid); }
+};
+
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/gui/webdisplay/src/TWebWindowWSHandler.hxx
+++ b/gui/webdisplay/src/TWebWindowWSHandler.hxx
@@ -54,7 +54,7 @@ public:
    virtual Bool_t AllowMTSend() const { return fWindow.fSendMT; }
 
    /// React on completion of multithreaded send operaiotn
-   virtual void CompleteMTSend(UInt_t wsid) { if (!IsDisabled()) fWindow.CompleteMTSend(wsid); }
+   virtual void CompleteWSSend(UInt_t wsid) { if (!IsDisabled()) fWindow.CompleteWSSend(wsid); }
 };
 
 } // namespace Experimental

--- a/gui/webdisplay/src/TWebWindowsManager.cxx
+++ b/gui/webdisplay/src/TWebWindowsManager.cxx
@@ -103,11 +103,6 @@ Method TWebWindowsManager::Show() used to show window in specified location.
 
 std::shared_ptr<ROOT::Experimental::TWebWindowsManager> &ROOT::Experimental::TWebWindowsManager::Instance()
 {
-   // use special mutex to access manager instance
-   // it prevents situation when method called from many threads and many instances will be tried to created
-   static std::recursive_mutex sInstanceMutex;
-
-   std::lock_guard<std::recursive_mutex> grd(sInstanceMutex);
    static std::shared_ptr<TWebWindowsManager> sInstance = std::make_shared<ROOT::Experimental::TWebWindowsManager>();
    return sInstance;
 }

--- a/gui/webdisplay/src/TWebWindowsManager.cxx
+++ b/gui/webdisplay/src/TWebWindowsManager.cxx
@@ -95,6 +95,24 @@ ROOT::Experimental::TWebWindowsManager::~TWebWindowsManager()
 /// In that case only connection from localhost will be available:
 ///
 ///      WebGui.HttpLoopback: yes
+///
+/// Or one could specify hostname which should be used for binding of server socket
+///
+///      WebGui.HttpBind: hostname | ipaddress
+///
+/// To use secured protocol, following parameter should be specified
+///
+///      WebGui.UseHttps: yes
+///      WebGui.ServerCert: sertificate_filename.pem
+///
+/// One also can configure usage of special thread of processing of http server requests
+///
+///      WebGui.ServerThrd: yes
+///
+/// If required, one could change websocket timeouts (default is 10000 ms)
+///
+///      WebGui.HttpWStmout: 10000
+
 
 bool ROOT::Experimental::TWebWindowsManager::CreateHttpServer(bool with_http)
 {
@@ -109,6 +127,7 @@ bool ROOT::Experimental::TWebWindowsManager::CreateHttpServer(bool with_http)
    int http_max = gEnv->GetValue("WebGui.HttpPortMax", 9800);
    int http_wstmout = gEnv->GetValue("WebGui.HttpWStmout", 10000);
    const char *http_loopback = gEnv->GetValue("WebGui.HttpLoopback", "no");
+   const char *serv_thrd = gEnv->GetValue("WebGui.ServerThrd", "no");
    const char *http_bind = gEnv->GetValue("WebGui.HttpBind", "");
    const char *http_ssl = gEnv->GetValue("WebGui.UseHttps", "no");
    const char *ssl_cert = gEnv->GetValue("WebGui.ServerCert", "rootserver.pem");
@@ -121,6 +140,9 @@ bool ROOT::Experimental::TWebWindowsManager::CreateHttpServer(bool with_http)
       R__ERROR_HERE("WebDisplay") << "Not allowed to create real HTTP server, check WebGui.HttpPort variable";
       return false;
    }
+
+   if (serv_thrd && strstr(serv_thrd, "yes"))
+      fServer->CreateServerThread();
 
    if (gApplication)
       gApplication->Connect("Terminate(Int_t)", "THttpServer", fServer.get(), "SetTerminate()");

--- a/gui/webdisplay/src/TWebWindowsManager.cxx
+++ b/gui/webdisplay/src/TWebWindowsManager.cxx
@@ -746,18 +746,19 @@ void ROOT::Experimental::TWebWindowsManager::HaltClient(const std::string &proci
 /// Waits until provided check function or lambdas returns non-zero value
 /// Regularly calls WebWindow::Sync() method to let run event loop
 /// If call from the main thread, runs system events processing
-/// timelimit (in seconds) defines how long to wait (0 - forever, negative - default value)
-/// Function has following signature: int func(double spent_tm)
+/// Check function has following signature: int func(double spent_tm)
 /// Parameter spent_tm is time in seconds, which already spent inside function
 /// Waiting will be continued, if function returns zero.
 /// First non-zero value breaks waiting loop and result is returned (or 0 if time is expired).
+/// If parameter timed is true, timelimit (in seconds) defines how long to wait
+/// If value is negative, WebGui.WaitForTmout value will be used
 
-int ROOT::Experimental::TWebWindowsManager::WaitFor(TWebWindow &win, WebWindowWaitFunc_t check, double timelimit)
+int ROOT::Experimental::TWebWindowsManager::WaitFor(TWebWindow &win, WebWindowWaitFunc_t check, bool timed, double timelimit)
 {
    int res(0), cnt(0);
    double spent = 0;
 
-   if (timelimit < 0)
+   if (timed && (timelimit < 0))
       timelimit = gEnv->GetValue("WebGui.WaitForTmout", 100.);
 
    auto start = std::chrono::high_resolution_clock::now();
@@ -777,7 +778,7 @@ int ROOT::Experimental::TWebWindowsManager::WaitFor(TWebWindow &win, WebWindowWa
 
       spent = elapsed.count() * 1e-3; // use ms precision
 
-      if ((timelimit > 0) && (spent > timelimit))
+      if (timed && (spent > timelimit))
          return 0;
 
       cnt++;

--- a/gui/webdisplay/src/TWebWindowsManager.cxx
+++ b/gui/webdisplay/src/TWebWindowsManager.cxx
@@ -783,7 +783,7 @@ int ROOT::Experimental::TWebWindowsManager::WaitFor(TWebWindow &win, WebWindowWa
       cnt++;
    }
 
-   R__DEBUG_HERE("WebDisplay") << "Waiting result " << res << " spent time " << spent << " ntry " << cnt;
+   // R__DEBUG_HERE("WebDisplay") << "Waiting result " << res << " spent time " << spent << " ntry " << cnt;
 
    return res;
 }

--- a/gui/webdisplay/src/TWebWindowsManager.cxx
+++ b/gui/webdisplay/src/TWebWindowsManager.cxx
@@ -18,7 +18,7 @@
 #include <ROOT/TLogger.hxx>
 
 #include "THttpServer.h"
-#include "THttpWSHandler.h"
+#include "TWebWindowWSHandler.hxx"
 
 #include "RConfigure.h"
 #include "TSystem.h"
@@ -339,7 +339,7 @@ std::shared_ptr<ROOT::Experimental::TWebWindow> ROOT::Experimental::TWebWindowsM
 
    win->CreateWSHandler();
 
-   fServer->Register("/web7gui", (THttpWSHandler *)win->fWSHandler.get());
+   fServer->RegisterWS(win->fWSHandler);
 
    return win;
 }
@@ -353,7 +353,7 @@ void ROOT::Experimental::TWebWindowsManager::Unregister(ROOT::Experimental::TWeb
    // TODO: close all active connections of the window
 
    if (win.fWSHandler)
-      fServer->Unregister((THttpWSHandler *)win.fWSHandler.get());
+      fServer->UnregisterWS(win.fWSHandler);
 
    //   for (auto displ = fDisplays.begin(); displ != fDisplays.end(); displ++) {
    //      if (displ->get() == win) {
@@ -373,9 +373,9 @@ std::string ROOT::Experimental::TWebWindowsManager::GetUrl(ROOT::Experimental::T
       return "";
    }
 
-   std::string addr = "/web7gui/";
+   std::string addr = "/";
 
-   addr.append(((THttpWSHandler *)win.fWSHandler.get())->GetName());
+   addr.append(win.fWSHandler->GetName());
 
    if (win.IsBatchMode())
       addr.append("/?batch_mode");

--- a/hist/histpainter/v7/src/RHistPainter.cxx
+++ b/hist/histpainter/v7/src/RHistPainter.cxx
@@ -30,9 +30,6 @@ class RHistPainter1D : public RHistPainterBase<1> {
 public:
    void Paint(RDrawable &drw, const RHistDrawingOpts<1> & /*opts*/, RPadPainter &pad) final
    {
-      // TODO: paint!
-      std::cout << "Painting 1D histogram @" << &drw << '\n';
-
       assert(dynamic_cast<RHistDrawable<1> *>(&drw) && "Wrong drawable type");
       RHistDrawable<1> &hd = static_cast<RHistDrawable<1> &>(drw);
 
@@ -46,7 +43,6 @@ class RHistPainter2D : public RHistPainterBase<2> {
 public:
    void Paint(RDrawable &drw, const RHistDrawingOpts<2> & /*opts*/, RPadPainter &pad) final
    {
-      std::cout << "Painting 2D histogram @" << &drw << '\n';
       assert(dynamic_cast<RHistDrawable<2> *>(&drw) && "Wrong drawable type");
       RHistDrawable<2> &hd = static_cast<RHistDrawable<2> &>(drw);
 

--- a/net/http/inc/THttpServer.h
+++ b/net/http/inc/THttpServer.h
@@ -51,9 +51,12 @@ protected:
    std::string fDrawPageCont;    ///<! content of draw html page
    std::string fCors;            ///<! CORS: sets Access-Control-Allow-Origin header for ProcessRequest responses
 
-   std::mutex fMutex; ///<! mutex to protect list with arguments
-   TList fCallArgs;   ///<! submitted arguments
-   std::queue<std::shared_ptr<THttpCallArg>> fArgs; ///<! submitted arguments
+   std::mutex fMutex;                                        ///<! mutex to protect list with arguments
+   TList fCallArgs;                                          ///<! submitted arguments (deprecated)
+   std::queue<std::shared_ptr<THttpCallArg>> fArgs;          ///<! submitted arguments
+
+   std::mutex fWSMutex;                                      ///<! mutex to protect WS handler lists
+   std::vector<std::shared_ptr<THttpWSHandler>> fWSHandlers; ///<! list of WS handlers
 
    virtual void MissedRequest(THttpCallArg *arg);
 
@@ -139,6 +142,18 @@ public:
 
    /** Unregister object */
    Bool_t Unregister(TObject *obj);
+
+   /** Register WS handler*/
+   void RegisterWS(std::shared_ptr<THttpWSHandler> ws);
+
+   /** Unregister WS handler*/
+   void UnregisterWS(std::shared_ptr<THttpWSHandler> ws);
+
+   /** Find web-socket handler with given name */
+   std::shared_ptr<THttpWSHandler> FindWS(const char *name);
+
+   /** Execute WS request */
+   Bool_t ExecuteWS(std::shared_ptr<THttpCallArg> &arg, Bool_t external_thrd = kFALSE, Bool_t wait_process = kFALSE);
 
    /** Restrict access to specified object */
    void Restrict(const char *path, const char *options);

--- a/net/http/inc/THttpServer.h
+++ b/net/http/inc/THttpServer.h
@@ -131,8 +131,8 @@ public:
    /** Submit HTTP request */
    Bool_t SubmitHttp(std::shared_ptr<THttpCallArg> arg, Bool_t can_run_immediately = kFALSE);
 
-   /** Process submitted requests, must be called from main thread */
-   void ProcessRequests();
+   /** Process submitted requests, must be called from appropriate thread */
+   Int_t ProcessRequests();
 
    /** Register object in subfolder */
    Bool_t Register(const char *subfolder, TObject *obj);

--- a/net/http/inc/THttpWSHandler.h
+++ b/net/http/inc/THttpWSHandler.h
@@ -28,12 +28,13 @@ friend class THttpServer;
 private:
 
    std::vector<std::shared_ptr<THttpWSEngine>> fEngines;         ///<!  list of active WS engines (connections)
+   Bool_t fDisabled;                                             ///<!  when true, all operations will be ignored
 
-   THttpWSEngine *FindEngine(UInt_t id) const;
+   std::shared_ptr<THttpWSEngine> FindEngine(UInt_t id) const;
 
    Bool_t HandleWS(std::shared_ptr<THttpCallArg> &arg);
 
-   void RemoveEngine(THttpWSEngine *engine);
+   void RemoveEngine(std::shared_ptr<THttpWSEngine> &engine);
 
 protected:
 
@@ -55,8 +56,14 @@ public:
    /// Allow send operations in separate threads (when supported by websocket engine)
    virtual Bool_t AllowMT() const { return kFALSE; }
 
+   /// Returns true when processing of websockets is disabled
+   Bool_t IsDisabled() const { return fDisabled; }
+
+   /// Disable all processing of websockets, normally called shortly before destructor
+   void SetDisabled() { fDisabled = kTRUE; }
+
    /// Return kTRUE if websocket with given ID exists
-   Bool_t HasWS(UInt_t wsid) const { return FindEngine(wsid) != 0; }
+   Bool_t HasWS(UInt_t wsid) const { return !!FindEngine(wsid); }
 
    /// Returns current number of websocket connections
    Int_t GetNumWS() const { return fEngines.size(); }

--- a/net/http/inc/THttpWSHandler.h
+++ b/net/http/inc/THttpWSHandler.h
@@ -39,6 +39,9 @@ protected:
 
    THttpWSHandler(const char *name, const char *title);
 
+   /// Method called when multi-threaded send operation is completed
+   virtual void CompleteMTSend(UInt_t) {}
+
 public:
    virtual ~THttpWSHandler();
 
@@ -48,6 +51,9 @@ public:
    /// If not specified, default index.htm page will be shown
    /// Used by the webcanvas
    virtual TString GetDefaultPageContent() { return ""; }
+
+   /// Allow send operations in separate threads (when supported by websocket engine)
+   virtual Bool_t AllowMT() const { return kFALSE; }
 
    /// Return kTRUE if websocket with given ID exists
    Bool_t HasWS(UInt_t wsid) const { return FindEngine(wsid) != 0; }
@@ -59,11 +65,11 @@ public:
 
    void CloseWS(UInt_t wsid);
 
-   void SendWS(UInt_t wsid, const void *buf, int len);
+   Int_t SendWS(UInt_t wsid, const void *buf, int len);
 
-   void SendHeaderWS(UInt_t wsid, const char *hdr, const void *buf, int len);
+   Int_t SendHeaderWS(UInt_t wsid, const char *hdr, const void *buf, int len);
 
-   void SendCharStarWS(UInt_t wsid, const char *str);
+   Int_t SendCharStarWS(UInt_t wsid, const char *str);
 
    virtual Bool_t ProcessWS(THttpCallArg *arg) = 0;
 

--- a/net/http/inc/THttpWSHandler.h
+++ b/net/http/inc/THttpWSHandler.h
@@ -41,7 +41,7 @@ private:
 
    Int_t PerformSend(std::shared_ptr<THttpWSEngine> engine);
 
-   void RemoveEngine(std::shared_ptr<THttpWSEngine> &engine);
+   void RemoveEngine(std::shared_ptr<THttpWSEngine> &engine, Bool_t terminate = kFALSE);
 
    Int_t CompleteSend(std::shared_ptr<THttpWSEngine> &engine);
 

--- a/net/http/inc/THttpWSHandler.h
+++ b/net/http/inc/THttpWSHandler.h
@@ -53,10 +53,13 @@ public:
    /// Used by the webcanvas
    virtual TString GetDefaultPageContent() { return ""; }
 
-   /// Allow send operations in separate threads (when supported by websocket engine)
-   virtual Bool_t AllowMT() const { return kFALSE; }
+   /// Allow processing of WS requests in arbitrary thread
+   virtual Bool_t AllowMTProcess() const { return kFALSE; }
 
-   /// Returns true when processing of websockets is disabled
+   /// Allow send operations in separate threads (when supported by websocket engine)
+   virtual Bool_t AllowMTSend() const { return kFALSE; }
+
+   /// Returns true when processing of websockets is disabled, set shortly before handler need to be destroyed
    Bool_t IsDisabled() const { return fDisabled; }
 
    /// Disable all processing of websockets, normally called shortly before destructor

--- a/net/http/inc/TRootSniffer.h
+++ b/net/http/inc/TRootSniffer.h
@@ -13,8 +13,8 @@
 #define ROOT_TRootSniffer
 
 #include "TNamed.h"
-
 #include "TList.h"
+#include <memory>
 
 class TFolder;
 class TKey;
@@ -120,6 +120,7 @@ protected:
    TString fObjectsPath;    ///<! default path for registered objects
    Bool_t fReadOnly{kTRUE}; ///<! indicate if sniffer allowed to change ROOT structures - like read objects from file
    Bool_t fScanGlobalDir{kTRUE};       ///<! when enabled (default), scan gROOT for histograms, canvases, open files
+   std::unique_ptr<TFolder> fTopFolder; ///<! own top TFolder object, used for registering objects
    THttpCallArg *fCurrentArg{nullptr}; ///<! current http arguments (if any)
    Int_t fCurrentRestrict{0};          ///<! current restriction for last-found object
    TString fCurrentAllowedMethods;     ///<! list of allowed methods, extracted when analyzed object restrictions
@@ -191,6 +192,10 @@ public:
    Bool_t HasRestriction(const char *item_name);
 
    Int_t CheckRestriction(const char *item_name);
+
+   void CreateOwnTopFolder();
+
+   TFolder *GetTopFolder(Bool_t force = kFALSE);
 
    /** When enabled (default), sniffer scans gROOT for files, canvases, histograms */
    void SetScanGlobalDir(Bool_t on = kTRUE) { fScanGlobalDir = on; }

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -38,10 +38,7 @@ protected:
 public:
    TCivetwebWSEngine(struct mg_connection *conn) : THttpWSEngine(), fWSconn(conn) {}
 
-   virtual ~TCivetwebWSEngine()
-   {
-      TCivetwebWSEngine::ClearHandle(kTRUE);
-   }
+   virtual ~TCivetwebWSEngine() {}
 
    virtual UInt_t GetId() const { return TString::Hash((void *)&fWSconn, sizeof(void *)); }
 

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -33,23 +33,23 @@ protected:
    struct mg_connection *fWSconn;
 
    /// True websocket requires extra thread to parallelize sending
-   virtual Bool_t SupportSendThrd() const { return kTRUE; }
+   Bool_t SupportSendThrd() const override { return kTRUE; }
 
 public:
    TCivetwebWSEngine(struct mg_connection *conn) : THttpWSEngine(), fWSconn(conn) {}
 
-   virtual ~TCivetwebWSEngine() {}
+   virtual ~TCivetwebWSEngine() = default;
 
-   virtual UInt_t GetId() const { return TString::Hash((void *)&fWSconn, sizeof(void *)); }
+   UInt_t GetId() const override { return TString::Hash((void *)&fWSconn, sizeof(void *)); }
 
-   virtual void ClearHandle(Bool_t terminate) override
+   void ClearHandle(Bool_t terminate) override
    {
       if (fWSconn && terminate)
          mg_websocket_write(fWSconn, MG_WEBSOCKET_OPCODE_CONNECTION_CLOSE, nullptr, 0);
       fWSconn = nullptr;
    }
 
-   virtual void Send(const void *buf, int len)
+   void Send(const void *buf, int len) override
    {
       if (fWSconn)
          mg_websocket_write(fWSconn, MG_WEBSOCKET_OPCODE_BINARY, (const char *)buf, len);
@@ -59,7 +59,7 @@ public:
    /// Special method to send binary data with text header
    /// For normal websocket it is two separated operation, for other engines could be combined together,
    /// but emulates as two messages on client side
-   virtual void SendHeader(const char *hdr, const void *buf, int len)
+   void SendHeader(const char *hdr, const void *buf, int len) override
    {
       if (fWSconn) {
          mg_websocket_write(fWSconn, MG_WEBSOCKET_OPCODE_TEXT, hdr, strlen(hdr));
@@ -67,7 +67,7 @@ public:
       }
    }
 
-   virtual void SendCharStar(const char *str)
+   void SendCharStar(const char *str) override
    {
       if (fWSconn)
          mg_websocket_write(fWSconn, MG_WEBSOCKET_OPCODE_TEXT, str, strlen(str));

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -35,6 +35,12 @@ protected:
    /// Indicate if engine support send operation from different threads
    virtual Bool_t SupportMT() const { return kTRUE; }
 
+   /// One always can send data to websocket - as long as previous send operation completed
+   virtual Bool_t CanSendDirectly() { return kTRUE; }
+
+   /// True websocket requires extra thread to parallelize sending
+   virtual Bool_t RequireSendThrd() const { return kTRUE; }
+
 public:
    TCivetwebWSEngine(struct mg_connection *conn) : THttpWSEngine(), fWSconn(conn) {}
 

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -38,9 +38,19 @@ protected:
 public:
    TCivetwebWSEngine(struct mg_connection *conn) : THttpWSEngine(), fWSconn(conn) {}
 
+   virtual ~TCivetwebWSEngine()
+   {
+      TCivetwebWSEngine::ClearHandle(kTRUE);
+   }
+
    virtual UInt_t GetId() const { return TString::Hash((void *)&fWSconn, sizeof(void *)); }
 
-   virtual void ClearHandle() { fWSconn = nullptr; }
+   virtual void ClearHandle(Bool_t terminate) override
+   {
+      if (fWSconn && terminate)
+         mg_websocket_write(fWSconn, MG_WEBSOCKET_OPCODE_CONNECTION_CLOSE, nullptr, 0);
+      fWSconn = nullptr;
+   }
 
    virtual void Send(const void *buf, int len)
    {

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -32,6 +32,9 @@ class TCivetwebWSEngine : public THttpWSEngine {
 protected:
    struct mg_connection *fWSconn;
 
+   /// Indicate if engine support send operation from different threads
+   virtual Bool_t SupportMT() const { return kTRUE; }
+
 public:
    TCivetwebWSEngine(struct mg_connection *conn) : THttpWSEngine(), fWSconn(conn) {}
 

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -88,7 +88,7 @@ int websocket_connect_handler(const struct mg_connection *conn, void *)
    arg->SetWSId(TString::Hash((void *)&conn, sizeof(void *)));
    arg->SetMethod("WS_CONNECT");
 
-   Bool_t execres = serv->ExecuteHttp(arg);
+   Bool_t execres = serv->ExecuteWS(arg, kTRUE, kTRUE);
 
    return execres && !arg->Is404() ? 0 : 1;
 }
@@ -114,7 +114,7 @@ void websocket_ready_handler(struct mg_connection *conn, void *)
    // delegate ownership to the arg, id will be automatically set
    arg->CreateWSEngine<TCivetwebWSEngine>(conn);
 
-   serv->ExecuteHttp(arg);
+   serv->ExecuteWS(arg, kTRUE, kTRUE);
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -146,7 +146,7 @@ int websocket_data_handler(struct mg_connection *conn, int, char *data, size_t l
 
    arg->SetPostData(std::string(data,len));
 
-   serv->ExecuteHttp(arg);
+   serv->ExecuteWS(arg, kTRUE, kTRUE);
 
    return 1;
 }
@@ -170,7 +170,7 @@ void websocket_close_handler(const struct mg_connection *conn, void *)
    arg->SetWSId(TString::Hash((void *)&conn, sizeof(void *)));
    arg->SetMethod("WS_CLOSE");
 
-   serv->SubmitHttp(arg); // delegate ownership to server
+   serv->ExecuteWS(arg, kTRUE, kFALSE); // do not wait for result of execution
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -32,14 +32,8 @@ class TCivetwebWSEngine : public THttpWSEngine {
 protected:
    struct mg_connection *fWSconn;
 
-   /// Indicate if engine support send operation from different threads
-   virtual Bool_t SupportMT() const { return kTRUE; }
-
-   /// One always can send data to websocket - as long as previous send operation completed
-   virtual Bool_t CanSendDirectly() { return kTRUE; }
-
    /// True websocket requires extra thread to parallelize sending
-   virtual Bool_t RequireSendThrd() const { return kTRUE; }
+   virtual Bool_t SupportSendThrd() const { return kTRUE; }
 
 public:
    TCivetwebWSEngine(struct mg_connection *conn) : THttpWSEngine(), fWSconn(conn) {}

--- a/net/http/src/THttpLongPollEngine.cxx
+++ b/net/http/src/THttpLongPollEngine.cxx
@@ -40,7 +40,6 @@ THttpLongPollEngine::THttpLongPollEngine(bool raw) : THttpWSEngine(), fRaw(raw)
 
 THttpLongPollEngine::~THttpLongPollEngine()
 {
-   // THttpLongPollEngine::ClearHandle(kTRUE);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/net/http/src/THttpLongPollEngine.cxx
+++ b/net/http/src/THttpLongPollEngine.cxx
@@ -28,12 +28,19 @@
 
 const std::string THttpLongPollEngine::gLongPollNope = "<<nope>>";
 
-
 //////////////////////////////////////////////////////////////////////////
 /// constructor
 
 THttpLongPollEngine::THttpLongPollEngine(bool raw) : THttpWSEngine(), fRaw(raw)
 {
+}
+
+//////////////////////////////////////////////////////////////////////////
+/// destructor
+
+THttpLongPollEngine::~THttpLongPollEngine()
+{
+   // THttpLongPollEngine::ClearHandle(kTRUE);
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -46,9 +53,9 @@ UInt_t THttpLongPollEngine::GetId() const
 }
 
 //////////////////////////////////////////////////////////////////////////
-/// clear request, waiting for next portion of data
+/// clear request, normally called shortly before destructor
 
-void THttpLongPollEngine::ClearHandle()
+void THttpLongPollEngine::ClearHandle(Bool_t)
 {
    std::shared_ptr<THttpCallArg> poll;
 

--- a/net/http/src/THttpLongPollEngine.h
+++ b/net/http/src/THttpLongPollEngine.h
@@ -37,6 +37,8 @@ protected:
 
    std::string MakeBuffer(const void *buf, int len, const char *hdr = nullptr);
 
+   virtual Bool_t CanSendDirectly() { return fPoll; }
+
 public:
    THttpLongPollEngine(bool raw = false);
 

--- a/net/http/src/THttpLongPollEngine.h
+++ b/net/http/src/THttpLongPollEngine.h
@@ -38,19 +38,19 @@ public:
    THttpLongPollEngine(bool raw = false);
    virtual ~THttpLongPollEngine();
 
-   virtual UInt_t GetId() const override;
+   UInt_t GetId() const override;
 
-   virtual void ClearHandle(Bool_t) override;
+   void ClearHandle(Bool_t) override;
 
-   virtual void Send(const void *buf, int len) override;
+   void Send(const void *buf, int len) override;
 
-   virtual void SendCharStar(const char *buf) override;
+   void SendCharStar(const char *buf) override;
 
-   virtual void SendHeader(const char *hdr, const void *buf, int len) override;
+   void SendHeader(const char *hdr, const void *buf, int len) override;
 
-   virtual Bool_t PreProcess(std::shared_ptr<THttpCallArg> &arg) override;
+   Bool_t PreProcess(std::shared_ptr<THttpCallArg> &arg) override;
 
-   virtual void PostProcess(std::shared_ptr<THttpCallArg> &arg) override;
+   void PostProcess(std::shared_ptr<THttpCallArg> &arg) override;
 };
 
 #endif

--- a/net/http/src/THttpLongPollEngine.h
+++ b/net/http/src/THttpLongPollEngine.h
@@ -36,10 +36,11 @@ protected:
 
 public:
    THttpLongPollEngine(bool raw = false);
+   virtual ~THttpLongPollEngine();
 
    virtual UInt_t GetId() const override;
 
-   virtual void ClearHandle() override;
+   virtual void ClearHandle(Bool_t) override;
 
    virtual void Send(const void *buf, int len) override;
 

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -1089,12 +1089,14 @@ Bool_t THttpServer::ExecuteWS(std::shared_ptr<THttpCallArg> &arg, Bool_t externa
       return kTRUE;
    }
 
-   if (!handler) {
+   if (!handler)
       return kFALSE;
-   } else if (arg->fFileName == "root.websocket") {
+
+   Bool_t process = kFALSE;
+
+   if (arg->fFileName == "root.websocket") {
       // handling of web socket
-      if (!handler->HandleWS(arg))
-         arg->Set404();
+      process = handler->HandleWS(arg);
    } else if (arg->fFileName == "root.longpoll") {
       // ROOT emulation of websocket with polling requests
       if ((arg->fQuery == "connect") || (arg->fQuery == "connect_raw")) {
@@ -1115,8 +1117,8 @@ Bool_t THttpServer::ExecuteWS(std::shared_ptr<THttpCallArg> &arg, Bool_t externa
          } else {
             arg->TakeWSEngine(); // delete handle
          }
-         if (!arg->IsText())
-            arg->Set404();
+
+         process = arg->IsText();
       } else {
          TUrl url;
          url.SetOptions(arg->fQuery);
@@ -1130,16 +1132,13 @@ Bool_t THttpServer::ExecuteWS(std::shared_ptr<THttpCallArg> &arg, Bool_t externa
             arg->SetMethod("WS_DATA");
          }
 
-         if (!handler->HandleWS(arg))
-            arg->Set404();
+         process = handler->HandleWS(arg);
       }
-   } else {
-      // non-supported WS kind
-      arg->Set404();
-      return kFALSE;
    }
 
-   return kTRUE;
+   if (!process) arg->Set404();
+
+   return process;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -22,7 +22,6 @@
 #include "TRegexp.h"
 
 #include "THttpEngine.h"
-#include "THttpWSEngine.h"
 #include "THttpLongPollEngine.h"
 #include "THttpWSHandler.h"
 #include "TRootSniffer.h"

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -162,6 +162,8 @@ THttpServer::THttpServer(const char *engine) : TNamed("http", "ROOT http server"
    TRootSniffer *sniff = nullptr;
    if (strstr(engine, "basic_sniffer")) {
       sniff = new TRootSniffer("sniff");
+      sniff->SetScanGlobalDir(kFALSE);
+      sniff->CreateOwnTopFolder(); // use dedicated folder
    } else {
       sniff = (TRootSniffer *)gROOT->ProcessLineSync("new TRootSnifferFull(\"sniff\");");
    }

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -810,9 +810,11 @@ void THttpServer::ProcessRequest(THttpCallArg *arg)
 
    if (arg->fFileName.IsNull() || (arg->fFileName == "index.htm")) {
 
-      THttpWSHandler *handler(nullptr);
+      auto wsptr = FindWS(arg->GetPathName());
 
-      if (arg->fFileName.IsNull())
+      auto handler = wsptr.get();
+
+      if (!handler)
          handler = dynamic_cast<THttpWSHandler *>(fSniffer->FindTObjectInHierarchy(arg->fPathName.Data()));
 
       if (handler) {

--- a/net/http/src/THttpWSEngine.cxx
+++ b/net/http/src/THttpWSEngine.cxx
@@ -34,7 +34,7 @@ void THttpWSEngine::SendCharStar(const char *str)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Method should be invoked before processing data coming from websocket
-/// If method returns kTRUE, this is data is processed internally and
+/// If method returns kTRUE, data is processed internally and
 /// not dedicated for further usage
 
 Bool_t THttpWSEngine::PreviewData(std::shared_ptr<THttpCallArg> &)
@@ -44,8 +44,9 @@ Bool_t THttpWSEngine::PreviewData(std::shared_ptr<THttpCallArg> &)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Method invoked after user process data received via websocket
-/// Normally request is no longer usable after that
+/// If returns kTRUE, websocket can be checked if next operation can be performed
 
-void THttpWSEngine::PostProcess(std::shared_ptr<THttpCallArg> &)
+Bool_t THttpWSEngine::PostProcess(std::shared_ptr<THttpCallArg> &)
 {
+   return kFALSE;
 }

--- a/net/http/src/THttpWSEngine.cxx
+++ b/net/http/src/THttpWSEngine.cxx
@@ -37,16 +37,14 @@ void THttpWSEngine::SendCharStar(const char *str)
 /// If method returns kTRUE, data is processed internally and
 /// not dedicated for further usage
 
-Bool_t THttpWSEngine::PreviewData(std::shared_ptr<THttpCallArg> &)
+Bool_t THttpWSEngine::PreProcess(std::shared_ptr<THttpCallArg> &)
 {
    return kFALSE;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Method invoked after user process data received via websocket
-/// If returns kTRUE, websocket can be checked if next operation can be performed
 
-Bool_t THttpWSEngine::PostProcess(std::shared_ptr<THttpCallArg> &)
+void THttpWSEngine::PostProcess(std::shared_ptr<THttpCallArg> &)
 {
-   return kFALSE;
 }

--- a/net/http/src/THttpWSEngine.h
+++ b/net/http/src/THttpWSEngine.h
@@ -27,7 +27,7 @@ private:
    friend class THttpWSHandler;
 
    bool fMTSend{false};     ///<!  true when send operation runs, set under locked fMutex from WSHandler
-   bool fDisabled{false};   ///<!  set shortly before cleanup
+   bool fDisabled{false};   ///<!  true shortly before cleanup, set under locked fMutex from WSHandler
 
    std::mutex fDataMutex;                              ///<! protects data submited for send operation
    enum { kNone, kData, kHeader, kText } fKind{kNone}; ///<! kind of operation
@@ -47,12 +47,9 @@ protected:
 public:
    virtual ~THttpWSEngine() {}
 
-   /// Returns kTRUE when handle is deactivated and need to be destroyed
-   Bool_t IsDisabled() const { return fDisabled; }
-
    virtual UInt_t GetId() const = 0;
 
-   virtual void ClearHandle() = 0;
+   virtual void ClearHandle(Bool_t) = 0;
 
    virtual void Send(const void *buf, int len) = 0;
 

--- a/net/http/src/THttpWSEngine.h
+++ b/net/http/src/THttpWSEngine.h
@@ -33,10 +33,10 @@ private:
 
    std::thread fSendThrd;    ///<! dedicated thread for all send operations
    bool fHasSendThrd{false}; ///<! if any special thread was started
-   std::mutex fCondMutex;    ///<! mutex used to access acondition
+   std::mutex fCondMutex;    ///<! mutex used to access condition
    std::condition_variable fCond; ///<! condition used to sync with sending thread
 
-   std::mutex fDataMutex;                              ///<! protects data submited for send operation
+   std::mutex fDataMutex;                              ///<! protects data submitted for send operation
    enum { kNone, kData, kHeader, kText } fKind{kNone}; ///<! kind of operation
    bool fDoingSend{false};                             ///<! doing send operation in other thread
    std::string fData;                                  ///<! data (binary or text)

--- a/net/http/src/THttpWSEngine.h
+++ b/net/http/src/THttpWSEngine.h
@@ -17,7 +17,9 @@
 #include "THttpCallArg.h"
 
 #include <mutex>
+#include <thread>
 #include <string>
+#include <condition_variable>
 
 class THttpWSHandler;
 
@@ -28,6 +30,11 @@ private:
 
    bool fMTSend{false};     ///<!  true when send operation runs, set under locked fMutex from WSHandler
    bool fDisabled{false};   ///<!  true shortly before cleanup, set under locked fMutex from WSHandler
+
+   std::thread fSendThrd;    ///<! dedicated thread for all send operations
+   bool fHasSendThrd{false}; ///<! if any special thread was started
+   std::mutex fCondMutex;    ///<! mutex used to access acondition
+   std::condition_variable fCond; ///<! condition used to sync with sending thread
 
    std::mutex fDataMutex;                              ///<! protects data submited for send operation
    enum { kNone, kData, kHeader, kText } fKind{kNone}; ///<! kind of operation

--- a/net/http/src/THttpWSEngine.h
+++ b/net/http/src/THttpWSEngine.h
@@ -56,9 +56,9 @@ public:
 
    virtual void SendCharStar(const char *str);
 
-   virtual Bool_t PreviewData(std::shared_ptr<THttpCallArg> &arg);
+   virtual Bool_t PreProcess(std::shared_ptr<THttpCallArg> &arg);
 
-   virtual Bool_t PostProcess(std::shared_ptr<THttpCallArg> &arg);
+   virtual void PostProcess(std::shared_ptr<THttpCallArg> &arg);
 };
 
 #endif

--- a/net/http/src/THttpWSEngine.h
+++ b/net/http/src/THttpWSEngine.h
@@ -39,12 +39,16 @@ protected:
    THttpWSEngine() = default;
 
    /// Indicate if engine require extra thread to complete postponed thread operation
-   virtual Bool_t RequireSendThrd() const { return kFALSE; }
+   virtual Bool_t SupportSendThrd() const { return kFALSE; }
 
-   virtual Bool_t CanSendDirectly() { return kFALSE; }
+   /// One always can send data to websocket - as long as previous send operation completed
+   virtual Bool_t CanSendDirectly() { return kTRUE; }
 
 public:
    virtual ~THttpWSEngine() {}
+
+   /// Returns kTRUE when handle is deactivated and need to be destroyed
+   Bool_t IsDisabled() const { return fDisabled; }
 
    virtual UInt_t GetId() const = 0;
 

--- a/net/http/src/THttpWSEngine.h
+++ b/net/http/src/THttpWSEngine.h
@@ -16,10 +16,20 @@
 
 #include "THttpCallArg.h"
 
+class THttpWSHandler;
+
 class THttpWSEngine {
+
+private:
+   friend class THttpWSHandler;
+
+   bool fMTSend{false};     ///<  true when multithreaded send operation is active
 
 protected:
    THttpWSEngine() = default;
+
+   /// Indicate if engine support send operation from different threads
+   virtual Bool_t SupportMT() const { return kFALSE; }
 
 public:
    virtual ~THttpWSEngine() {}

--- a/net/http/src/THttpWSHandler.cxx
+++ b/net/http/src/THttpWSHandler.cxx
@@ -66,7 +66,7 @@ ClassImp(THttpWSHandler);
 ////////////////////////////////////////////////////////////////////////////////
 /// normal constructor
 
-THttpWSHandler::THttpWSHandler(const char *name, const char *title) : TNamed(name, title), fEngines(), fDisabled(kFALSE)
+THttpWSHandler::THttpWSHandler(const char *name, const char *title) : TNamed(name, title)
 {
 }
 
@@ -79,26 +79,51 @@ THttpWSHandler::~THttpWSHandler()
    SetDisabled();
 }
 
+/// Returns current number of websocket connections
+Int_t THttpWSHandler::GetNumWS()
+{
+   std::lock_guard<std::mutex> grd(fMutex);
+   return fEngines.size();
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Return websocket id with given sequential number
-/// Number of websockets return with GetNumWS() method
+/// Number of websockets returned with GetNumWS() method
 
-UInt_t THttpWSHandler::GetWS(Int_t num) const
+UInt_t THttpWSHandler::GetWS(Int_t num)
 {
+   std::lock_guard<std::mutex> grd(fMutex);
    auto iter = fEngines.begin() + num;
    return (*iter)->GetId();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Find websocket connection handle with given id
+/// If book_send parameter specified, have to book send operation under the mutex
 
-std::shared_ptr<THttpWSEngine> THttpWSHandler::FindEngine(UInt_t wsid) const
+std::shared_ptr<THttpWSEngine> THttpWSHandler::FindEngine(UInt_t wsid, Bool_t book_send)
 {
-   if (IsDisabled()) return nullptr;
+   if (IsDisabled())
+      return nullptr;
+
+   std::lock_guard<std::mutex> grd(fMutex);
 
    for (auto &eng : fEngines)
-      if (eng->GetId() == wsid)
+      if (eng->GetId() == wsid) {
+
+         // not allow to work with disabled engine
+         if (eng->fDisabled)
+            return nullptr;
+
+         if (book_send) {
+            if (eng->fMTSend) {
+               Error("FindEngine", "Try to book next send operation before previous completed");
+               return nullptr;
+            }
+            eng->fMTSend = kTRUE;
+         }
          return eng;
+      }
 
    return nullptr;
 }
@@ -108,12 +133,21 @@ std::shared_ptr<THttpWSEngine> THttpWSHandler::FindEngine(UInt_t wsid) const
 
 void THttpWSHandler::RemoveEngine(std::shared_ptr<THttpWSEngine> &engine)
 {
-   for (auto iter = fEngines.begin(); iter != fEngines.end(); iter++)
-      if (*iter == engine) {
-         engine->ClearHandle();
-         fEngines.erase(iter);
-         break;
-      }
+   {
+      std::lock_guard<std::mutex> grd(fMutex);
+
+      for (auto iter = fEngines.begin(); iter != fEngines.end(); iter++)
+         if (*iter == engine) {
+            if (engine->fMTSend)
+               Error("RemoveEngine", "Trying to remove WS engine during send operation");
+
+            engine->fDisabled = true;
+            fEngines.erase(iter);
+            break;
+         }
+   }
+
+   engine->ClearHandle();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -126,7 +160,8 @@ void THttpWSHandler::RemoveEngine(std::shared_ptr<THttpWSEngine> &engine)
 
 Bool_t THttpWSHandler::HandleWS(std::shared_ptr<THttpCallArg> &arg)
 {
-   if (IsDisabled()) return kFALSE;
+   if (IsDisabled())
+      return kFALSE;
 
    if (!arg->GetWSId())
       return ProcessWS(arg.get());
@@ -145,7 +180,10 @@ Bool_t THttpWSHandler::HandleWS(std::shared_ptr<THttpCallArg> &arg)
       }
 
       engine = arg->TakeWSEngine();
-      fEngines.push_back(engine);
+      {
+         std::lock_guard<std::mutex> grd(fMutex);
+         fEngines.emplace_back(engine);
+      }
 
       if (!ProcessWS(arg.get())) {
          // if connection refused, remove engine again
@@ -167,13 +205,20 @@ Bool_t THttpWSHandler::HandleWS(std::shared_ptr<THttpCallArg> &arg)
       return ProcessWS(arg.get());
    }
 
-   if (engine && engine->PreviewData(arg))
-      return kTRUE;
+   Bool_t check_send  = engine ? engine->PreviewData(arg) : kFALSE;
 
-   Bool_t res = ProcessWS(arg.get());
+   Bool_t res = kTRUE;
 
-   if (engine)
-      engine->PostProcess(arg);
+   if (!check_send) {
+
+      res = ProcessWS(arg.get());
+
+      check_send = engine ? engine->PostProcess(arg) : kFALSE;
+   }
+
+   if (check_send)
+      PerformSend(engine);
+
 
    return res;
 }
@@ -191,40 +236,115 @@ void THttpWSHandler::CloseWS(UInt_t wsid)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Send binary data via given websocket id
-/// Returns -1 - in case of error,
-///          0 - when operation was executed immediately,
-///          1 - when send operation will be performed in different thread,
+/// Returns -1 - in case of error
+///          0 - when operation was executed immediately
+///          1 - when send operation will be performed in different thread
 
 Int_t THttpWSHandler::SendWS(UInt_t wsid, const void *buf, int len)
 {
-   auto engine = FindEngine(wsid);
+   auto engine = FindEngine(wsid, kTRUE);
    if (!engine) return -1;
 
-   if (engine->fMTSend) {
-      Error("SendWS", "Call next send operation before previous is completed");
-      return -1;
-   }
-
-   if (!AllowMTSend() || !engine->SupportMT()) {
+   if (!AllowMTSend() && engine->CanSendDirectly()) {
       engine->Send(buf, len);
+      engine->fMTSend = false; // probably we do not need to lock mutex to reset flag
+      CompleteWSSend(engine->GetId());
       return 0;
    }
 
-   engine->fMTSend = true;
+   // now we indicate that there is data and any thread can access it
+   {
+      std::lock_guard<std::mutex> grd(engine->fDataMutex);
 
-   std::string argbuf;
-   argbuf.resize(len);
-   std::copy((const char *)buf, (const char *)buf + len, argbuf.begin());
+      if (engine->fKind != THttpWSEngine::kNone) {
+         Error("SendWS", "Data kind is not empty - something screwed up");
+         return -1;
+      }
 
-   std::thread thrd([this, argbuf, engine] {
-      engine->Send(argbuf.data(), argbuf.length());
-      engine->fMTSend = false;
-      if (!IsDisabled()) CompleteMTSend(engine->GetId());
+      engine->fData.resize(len);
+      std::copy((const char *)buf, (const char *)buf + len, engine->fData.begin());
+
+      engine->fDoingSend = false;
+      engine->fKind = THttpWSEngine::kData;
+   }
+
+   return RunSendingThrd(engine);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Send data stored in the buffer
+/// Returns 0 - when operation was executed immediately
+///         1 - when send operation will be performed in different thread
+
+Int_t THttpWSHandler::RunSendingThrd(std::shared_ptr<THttpWSEngine> engine)
+{
+   // actually lonpoll engine does not require thread to reply data in buffer
+   if (!engine->RequireSendThrd()) {
+
+      if (engine->CanSendDirectly())
+         return PerformSend(engine);
+
+      // handling will be performed in http request handler
+      return 1;
+   }
+
+   std::thread thrd([this, engine] {
+      PerformSend(engine);
    });
 
    thrd.detach(); // let continue thread execution without thread handle
 
    return 1;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Perform send operation, stored in buffer
+
+Int_t THttpWSHandler::PerformSend(std::shared_ptr<THttpWSEngine> engine)
+{
+   {
+      std::lock_guard<std::mutex> grd(engine->fDataMutex);
+
+      // no need to do somthing - operation was processed already by somebody else
+      if (engine->fKind == THttpWSEngine::kNone)
+         return 0;
+
+      if (engine->fDoingSend)
+         return 1;
+      engine->fDoingSend = true;
+   }
+
+   if (IsDisabled() || engine->fDisabled)
+      return 0;
+
+   switch (engine->fKind) {
+   case THttpWSEngine::kData:
+      engine->Send(engine->fData.data(), engine->fData.length());
+      break;
+   case THttpWSEngine::kHeader:
+      engine->SendHeader(engine->fHdr.c_str(), engine->fData.data(), engine->fData.length());
+      break;
+   case THttpWSEngine::kText:
+      engine->SendCharStar(engine->fData.c_str());
+      break;
+   default:
+      break;
+   }
+
+   engine->fData.clear();
+   engine->fHdr.clear();
+
+   {
+      std::lock_guard<std::mutex> grd(engine->fDataMutex);
+      engine->fDoingSend = false;
+      engine->fKind = THttpWSEngine::kNone;
+   }
+
+   engine->fMTSend = false; // probably we do not need to lock mutex to reset flag
+   CompleteWSSend(engine->GetId());
+
+   return 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -235,34 +355,35 @@ Int_t THttpWSHandler::SendWS(UInt_t wsid, const void *buf, int len)
 
 Int_t THttpWSHandler::SendHeaderWS(UInt_t wsid, const char *hdr, const void *buf, int len)
 {
-   auto engine = FindEngine(wsid);
+   auto engine = FindEngine(wsid, kTRUE);
    if (!engine) return -1;
 
-   if (engine->fMTSend) {
-      Error("SendHeaderWS", "Call next send operation before previous is completed");
-      return -1;
-   }
-
-   if (!AllowMTSend() || !engine->SupportMT()) {
+   if (!AllowMTSend() && engine->CanSendDirectly()) {
       engine->SendHeader(hdr, buf, len);
+      engine->fMTSend = false; // probably we do not need to lock mutex to reset flag
+      CompleteWSSend(engine->GetId());
       return 0;
    }
 
-   engine->fMTSend = true;
 
-   std::string arghdr(hdr), argbuf;
-   argbuf.resize(len);
-   std::copy((const char *)buf, (const char *)buf + len, argbuf.begin());
+   // now we indicate that there is data and any thread can access it
+   {
+      std::lock_guard<std::mutex> grd(engine->fDataMutex);
 
-   std::thread thrd([this, arghdr, argbuf, engine] {
-      engine->SendHeader(arghdr.c_str(), argbuf.data(), argbuf.length());
-      engine->fMTSend = false;
-      if (!IsDisabled()) CompleteMTSend(engine->GetId());
-   });
+      if (engine->fKind != THttpWSEngine::kNone) {
+         Error("SendWS", "Data kind is not empty - something screwed up");
+         return -1;
+      }
 
-   thrd.detach(); // let continue thread execution without thread handle
+      engine->fHdr = hdr;
+      engine->fData.resize(len);
+      std::copy((const char *)buf, (const char *)buf + len, engine->fData.begin());
 
-   return 1;
+      engine->fDoingSend = false;
+      engine->fKind = THttpWSEngine::kHeader;
+   }
+
+   return RunSendingThrd(engine);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -273,30 +394,30 @@ Int_t THttpWSHandler::SendHeaderWS(UInt_t wsid, const char *hdr, const void *buf
 
 Int_t THttpWSHandler::SendCharStarWS(UInt_t wsid, const char *str)
 {
-   auto engine = FindEngine(wsid);
+   auto engine = FindEngine(wsid, kTRUE);
    if (!engine) return -1;
 
-   if (engine->fMTSend) {
-      Error("SendCharStarWS", "Call next send operation before previous is completed");
-      return -1;
-   }
-
-   if (!AllowMTSend() || !engine->SupportMT()) {
+   if (!AllowMTSend() && engine->CanSendDirectly()) {
       engine->SendCharStar(str);
+      engine->fMTSend = false; // probably we do not need to lock mutex to reset flag
+      CompleteWSSend(engine->GetId());
       return 0;
    }
 
-   engine->fMTSend = true;
+   // now we indicate that there is data and any thread can access it
+   {
+      std::lock_guard<std::mutex> grd(engine->fDataMutex);
 
-   std::string arg(str);
+      if (engine->fKind != THttpWSEngine::kNone) {
+         Error("SendWS", "Data kind is not empty - something screwed up");
+         return -1;
+      }
 
-   std::thread thrd([this, arg, engine] {
-      engine->SendCharStar(arg.c_str());
-      engine->fMTSend = false;
-      if (!IsDisabled()) CompleteMTSend(engine->GetId());
-   });
+      engine->fData = str;
 
-   thrd.detach(); // let continue thread execution without thread handle
+      engine->fDoingSend = false;
+      engine->fKind = THttpWSEngine::kText;
+   }
 
-   return 1;
+   return RunSendingThrd(engine);
 }

--- a/net/http/src/THttpWSHandler.cxx
+++ b/net/http/src/THttpWSHandler.cxx
@@ -94,6 +94,7 @@ THttpWSHandler::~THttpWSHandler()
          eng->fCond.notify_all();
          eng->fSendThrd.join();
       }
+      eng->ClearHandle(kTRUE); // terminate connection before starting destructor
    }
 }
 

--- a/net/http/src/THttpWSHandler.cxx
+++ b/net/http/src/THttpWSHandler.cxx
@@ -194,7 +194,7 @@ void THttpWSHandler::SendWS(UInt_t wsid, const void *buf, int len)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Send binary data with binary data via given websocket id
+/// Send binary data with text header via given websocket id
 
 void THttpWSHandler::SendHeaderWS(UInt_t wsid, const char *hdr, const void *buf, int len)
 {

--- a/net/http/src/THttpWSHandler.cxx
+++ b/net/http/src/THttpWSHandler.cxx
@@ -205,7 +205,7 @@ Int_t THttpWSHandler::SendWS(UInt_t wsid, const void *buf, int len)
       return -1;
    }
 
-   if (!AllowMT() || !engine->SupportMT()) {
+   if (!AllowMTSend() || !engine->SupportMT()) {
       engine->Send(buf, len);
       return 0;
    }
@@ -243,7 +243,7 @@ Int_t THttpWSHandler::SendHeaderWS(UInt_t wsid, const char *hdr, const void *buf
       return -1;
    }
 
-   if (!AllowMT() || !engine->SupportMT()) {
+   if (!AllowMTSend() || !engine->SupportMT()) {
       engine->SendHeader(hdr, buf, len);
       return 0;
    }
@@ -281,7 +281,7 @@ Int_t THttpWSHandler::SendCharStarWS(UInt_t wsid, const char *str)
       return -1;
    }
 
-   if (!AllowMT() || !engine->SupportMT()) {
+   if (!AllowMTSend() || !engine->SupportMT()) {
       engine->SendCharStar(str);
       return 0;
    }

--- a/net/http/src/TRootSniffer.cxx
+++ b/net/http/src/TRootSniffer.cxx
@@ -33,6 +33,7 @@
 #include "TVirtualMutex.h"
 #include "TRootSnifferStore.h"
 #include "THttpCallArg.h"
+#include "ROOT/RMakeUnique.hxx"
 
 #include <stdlib.h>
 #include <vector>
@@ -918,12 +919,10 @@ void TRootSniffer::CreateOwnTopFolder()
 
    SetScanGlobalDir(kFALSE);
 
-   // this only works with C++14, which is not yet default for ROOT
-   // fTopFolder = std::make_unique<TFolder>("http","Dedicated instance");
+   // this only works with c++14, use ROOT wrapper
+   fTopFolder = std::make_unique<TFolder>("http","Dedicated instance");
 
-   fTopFolder.reset(new TFolder("http","Dedicated instance"));
-
-   // not sure if we have to add folder to list of cleanups
+   // not sure if we have to add that private folder to global list of cleanups
 
    // R__LOCKGUARD(gROOTMutex);
    // gROOT->GetListOfCleanups()->Add(fTopFolder.get());

--- a/net/http/src/TRootSniffer.cxx
+++ b/net/http/src/TRootSniffer.cxx
@@ -918,7 +918,10 @@ void TRootSniffer::CreateOwnTopFolder()
 
    SetScanGlobalDir(kFALSE);
 
-   fTopFolder = std::make_unique<TFolder>("http","Dedicated instance");
+   // this only works with C++14, which is not yet default for ROOT
+   // fTopFolder = std::make_unique<TFolder>("http","Dedicated instance");
+
+   fTopFolder.reset(new TFolder("http","Dedicated instance"));
 
    // not sure if we have to add folder to list of cleanups
 

--- a/tutorials/http/ws.C
+++ b/tutorials/http/ws.C
@@ -11,8 +11,9 @@
 class TUserHandler : public THttpWSHandler {
    public:
       UInt_t fWSId;
+      Int_t fServCnt;
 
-      TUserHandler(const char *name = 0, const char *title = 0) : THttpWSHandler(name, title), fWSId(0) {}
+      TUserHandler(const char *name = 0, const char *title = 0) : THttpWSHandler(name, title), fWSId(0), fServCnt(0) {}
 
       // load custom HTML page when open correpondent address
       TString GetDefaultPageContent() { return "file:ws.htm"; }
@@ -42,7 +43,7 @@ class TUserHandler : public THttpWSHandler {
            TString str = arg->GetPostDataAsString();
            printf("Client msg: %s\n", str.Data());
            TDatime now;
-           SendCharStarWS(arg->GetWSId(), Form("Server replies %s", now.AsString()));
+           SendCharStarWS(arg->GetWSId(), Form("Server replies:%s server counter:%d", now.AsString(), fServCnt++));
            return kTRUE;
         }
 
@@ -53,7 +54,7 @@ class TUserHandler : public THttpWSHandler {
       virtual Bool_t HandleTimer(TTimer *)
       {
          TDatime now;
-         if (fWSId) SendCharStarWS(fWSId, Form("Server sends data %s", now.AsString()));
+         if (fWSId) SendCharStarWS(fWSId, Form("Server sends data:%s server counter:%d", now.AsString(), fServCnt++));
          return kTRUE;
       }
 

--- a/tutorials/http/ws.htm
+++ b/tutorials/http/ws.htm
@@ -11,20 +11,21 @@
       <h3>Log protocol:</h3>
       <div id="LogDiv"></div>
    </body>
-   
+
    <script type='text/javascript'>
-   
+
       var path = window.location.href;
       path = path.replace("http://", "ws://") + "root.websocket";
+      var cnt  = 0;
 
       function show(str) {
          document.getElementById('LogDiv').insertAdjacentHTML( 'beforeend', '<text>' + str + '</text><br/>');
          console.log(str);
       }
-   
+
       console.log('starting socket ' + path);
       var socket = new WebSocket(path);
-      
+
       socket.onopen = function() {
          show('websocket initialized');
          this._ready = true;
@@ -34,7 +35,7 @@
       socket.onmessage = function(e) {
          var msg = e.data;
          if (typeof msg != 'string') return console.log("unsupported message kind: " + (typeof msg));
-         
+
          show('get: ' + msg);
       }
 
@@ -48,11 +49,11 @@
          this._ready = false;
          show('websocket error' + err);
       }
-      
+
       // sends data every 5 seconds
       setInterval(function() {
-         if (socket._ready) socket.send("Client time " + new Date().toTimeString());
-      }, 5000);
+         if (socket._ready) socket.send("Client time " + new Date().toTimeString() + " client counter:" + (cnt++));
+      }, 1000);
 
    </script>
 

--- a/tutorials/v7/draw_mt.cxx
+++ b/tutorials/v7/draw_mt.cxx
@@ -26,6 +26,7 @@ R__LOAD_LIBRARY(libROOTGpadv7);
 
 #include "ROOT/RHist.hxx"
 #include "ROOT/RCanvas.hxx"
+#include "ROOT/TWebWindowsManager.hxx"
 
 #include "TRandom3.h"
 
@@ -58,7 +59,7 @@ void draw_canvas(const std::string &title, RColor col)
 
    canvas->Show();
 
-   for (int loop=0;loop<10;++loop) {
+   for (int loop=0;loop<50;++loop) {
 
       for(int n=0;n<10000;++n) {
          random.Rannor(px,py);
@@ -84,10 +85,11 @@ void draw_canvas(const std::string &title, RColor col)
 
 void draw_mt()
 {
+   TWebWindowsManager::SetUseHttpThread(true);
+   TWebWindowsManager::SetUseSenderThreads(true);
+
    std::thread thrd1(draw_canvas, "First canvas", RColor::kRed);
-
    std::thread thrd2(draw_canvas, "Second canvas", RColor::kBlue);
-
    std::thread thrd3(draw_canvas, "Third canvas", RColor::kGreen);
 
    thrd1.detach();

--- a/tutorials/v7/draw_mt.cxx
+++ b/tutorials/v7/draw_mt.cxx
@@ -30,7 +30,7 @@ R__LOAD_LIBRARY(libROOTGpadv7);
 #include "TRandom3.h"
 
 #include <thread>
-#include <chrono>
+// #include <chrono>
 
 using namespace ROOT::Experimental;
 
@@ -58,7 +58,7 @@ void draw_canvas(const std::string &title, RColor col)
 
    canvas->Show();
 
-   for (int loop=0;loop<100;++loop) {
+   for (int loop=0;loop<10;++loop) {
 
       for(int n=0;n<10000;++n) {
          random.Rannor(px,py);
@@ -66,15 +66,20 @@ void draw_canvas(const std::string &title, RColor col)
          pHist2->Fill(py+2);
       }
 
-      std::this_thread::sleep_for(std::chrono::milliseconds(500));
+      // std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
       canvas->Modified();
       canvas->Update();
+
+      canvas->Run(0.5); // let run canvas code for next 0.5 seconds
    }
 
    //   canvas->SaveAs("th1.png");
 
    printf("%s completed\n", title.c_str());
+
+   // remove from global list, will be destroyed with thread exit
+   canvas->Remove();
 }
 
 void draw_mt()

--- a/tutorials/v7/draw_mt.cxx
+++ b/tutorials/v7/draw_mt.cxx
@@ -29,6 +29,7 @@ R__LOAD_LIBRARY(libROOTGpadv7);
 #include "ROOT/TWebWindowsManager.hxx"
 
 #include "TRandom3.h"
+#include "TEnv.h"
 
 #include <thread>
 // #include <chrono>
@@ -83,8 +84,8 @@ void draw_canvas(const std::string &title, RColor col)
 
 void draw_mt()
 {
-   TWebWindowsManager::SetUseHttpThread(true);
-   TWebWindowsManager::SetUseSenderThreads(true);
+   gEnv->SetValue("WebGui.HttpThrd","yes");
+   gEnv->SetValue("WebGui.SenderThrds","yes");
 
    std::thread thrd1(draw_canvas, "First canvas", RColor::kRed);
    std::thread thrd2(draw_canvas, "Second canvas", RColor::kBlue);

--- a/tutorials/v7/draw_mt.cxx
+++ b/tutorials/v7/draw_mt.cxx
@@ -1,0 +1,91 @@
+/// \file
+/// \ingroup tutorial_v7
+///
+/// This macro demonstrate usage of ROOT7 graphics from many threads
+/// Three different canvases in three different threads are started and regularly updated.
+/// Extra thread created in background and used to run http protocol, in/out websocket communications and process http requests
+/// Main application thread (CLING interactive session) remains fully functional
+///
+/// \macro_code
+///
+/// \date 2018-08-16
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+/// \author Sergey Linev
+
+/*************************************************************************
+ * Copyright (C) 1995-2015, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+R__LOAD_LIBRARY(libROOTGpadv7);
+// R__LOAD_LIBRARY(libROOTGraphicsPrimitives);
+// R__LOAD_LIBRARY(libROOTHistDraw);
+
+#include "ROOT/RHist.hxx"
+#include "ROOT/RCanvas.hxx"
+
+#include "TRandom3.h"
+
+#include <thread>
+#include <chrono>
+
+using namespace ROOT::Experimental;
+
+void draw_canvas(const std::string &title, RColor col)
+{
+   // Create histograms
+   RAxisConfig xaxis(100, -10., 10.);
+   auto pHist = std::make_shared<RH1D>(xaxis);
+   auto pHist2 = std::make_shared<RH1D>(xaxis);
+
+   TRandom3 random;
+   Float_t px, py;
+
+   for(int n=0;n<10000;++n) {
+      random.Rannor(px,py);
+      pHist->Fill(px-2);
+      pHist2->Fill(py+2);
+   }
+
+   // Create a canvas to be displayed.
+   auto canvas = RCanvas::Create(title);
+   canvas->Draw(pHist)->SetLineColor(col);
+   // canvas->Draw(pHist)->SetLineColor(RColor::kRed);
+   // canvas->Draw(pHist2)->SetLineColor(RColor::kBlue);
+
+   canvas->Show();
+
+   for (int loop=0;loop<100;++loop) {
+
+      for(int n=0;n<10000;++n) {
+         random.Rannor(px,py);
+         pHist->Fill(px-2);
+         pHist2->Fill(py+2);
+      }
+
+      std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+      canvas->Modified();
+      canvas->Update();
+   }
+
+   //   canvas->SaveAs("th1.png");
+
+   printf("%s completed\n", title.c_str());
+}
+
+void draw_mt()
+{
+   std::thread thrd1(draw_canvas, "First canvas", RColor::kRed);
+
+   std::thread thrd2(draw_canvas, "Second canvas", RColor::kBlue);
+
+   std::thread thrd3(draw_canvas, "Third canvas", RColor::kGreen);
+
+   thrd1.detach();
+   thrd2.detach();
+   thrd3.detach();
+}

--- a/tutorials/v7/draw_mt.cxx
+++ b/tutorials/v7/draw_mt.cxx
@@ -54,8 +54,7 @@ void draw_canvas(const std::string &title, RColor col)
    // Create a canvas to be displayed.
    auto canvas = RCanvas::Create(title);
    canvas->Draw(pHist)->SetLineColor(col);
-   // canvas->Draw(pHist)->SetLineColor(RColor::kRed);
-   // canvas->Draw(pHist2)->SetLineColor(RColor::kBlue);
+   canvas->Draw(pHist2)->SetLineColor(RColor::kBlue);
 
    canvas->Show();
 
@@ -67,11 +66,10 @@ void draw_canvas(const std::string &title, RColor col)
          pHist2->Fill(py+2);
       }
 
-      // std::this_thread::sleep_for(std::chrono::milliseconds(500));
-
       canvas->Modified();
       canvas->Update();
 
+      // std::this_thread::sleep_for(std::chrono::milliseconds(500));
       canvas->Run(0.5); // let run canvas code for next 0.5 seconds
    }
 


### PR DESCRIPTION
This is first step to make Web GUI code running in multiple threads.
There are many threads introduced and many communication patterns are supported.

1. Provide special thread, which handle all http requests of THttpServer.
This thread serves JavaScript/HTML files and redirects websocket requests to recipients.
Try to reduce access to global ROOT structures from that thread - only list of classes for the moment is used. Potentially many THttpServer instances with such thread can run fully independent.

2. Let run websocket handlers (THttpWSHandler) in separate threads. 
Requires correct locking of shared resources.

3. Support special threads for sending data via websocket from server to clients. 
When many clients are connected to the same TWebWindow, slowest client can 
break down performance. With use of such specialized thread problem can be solved.

4. Implement all necessary locks and protections to use many TWebWindows in different user threads. 
Provide TWebWindow::Run(double) method, which allows to run window code in any user thread. 

Introduce tutorials/v7/draw_mt.cxx macro, which shows how three RCanvas instances can run
in three independent thread and regularly updated.

Of course, default behavior should work - all functionality runs in main thread. 
Means THttpServer requests processing, websockets processing, RCanvas handling - 
everything runs in main application thread. Simple, but not scalable.

This is very preliminary code , I still plan to change/extend some API.
Any comments comments are welcome