### PR TITLE
[PyROOT] Add all STL vector pythonizations to RVecs

### DIFF
--- a/bindings/pyroot/src/Pythonize.cxx
+++ b/bindings/pyroot/src/Pythonize.cxx
@@ -2504,7 +2504,7 @@ Bool_t PyROOT::Pythonize( PyObject* pyclass, const std::string& name )
 
    }
 
-   else if ( IsTemplatedSTLClass( name, "vector" ) ) {
+   else if ( IsTemplatedSTLClass( name, "vector" ) || (name.find("ROOT::VecOps::RVec<") == 0) ) {
 
       if ( HasAttrDirect( pyclass, PyStrings::gLen ) && HasAttrDirect( pyclass, PyStrings::gAt ) ) {
          Utility::AddToClass( pyclass, "_vector__at", "at" );
@@ -2541,21 +2541,37 @@ Bool_t PyROOT::Pythonize( PyObject* pyclass, const std::string& name )
          Utility::AddToClass( pyclass, "__setitem__", (PyCFunction) VectorBoolSetItem );
       }
 
-      // add array interface
-      if (name.find("<float>") != std::string::npos) {
+      // add array interface for STL vectors
+      if (name.find("ROOT::VecOps::RVec<") == 0) {
+      } else if (name == "vector<float>") {
          AddArrayInterface(pyclass, (PyCFunction)STLVectorArrayInterface<float, 'f'>);
-      } else if (name.find("<double>") != std::string::npos) {
+      } else if (name == "vector<double>") {
          AddArrayInterface(pyclass, (PyCFunction)STLVectorArrayInterface<double, 'f'>);
-      } else if (name.find("<int>") != std::string::npos) {
+      } else if (name == "vector<int>") {
          AddArrayInterface(pyclass, (PyCFunction)STLVectorArrayInterface<int, 'i'>);
-      } else if (name.find("<unsigned int>") != std::string::npos) {
+      } else if (name == "vector<unsigned int>") {
          AddArrayInterface(pyclass, (PyCFunction)STLVectorArrayInterface<unsigned int, 'u'>);
-      } else if (name.find("<long>") != std::string::npos) {
+      } else if (name == "vector<long>") {
          AddArrayInterface(pyclass, (PyCFunction)STLVectorArrayInterface<long, 'i'>);
-      } else if (name.find("<unsigned long>") != std::string::npos) {
+      } else if (name == "vector<unsigned long>") {
          AddArrayInterface(pyclass, (PyCFunction)STLVectorArrayInterface<unsigned long, 'u'>);
       }
 
+      // add array interface for RVecs
+      if (name.find("ROOT::VecOps::RVec<") != 0) {
+      } else if (name == "ROOT::VecOps::RVec<float>") {
+         AddArrayInterface(pyclass, (PyCFunction)RVecArrayInterface<float, 'f'>);
+      } else if (name == "ROOT::VecOps::RVec<double>") {
+         AddArrayInterface(pyclass, (PyCFunction)RVecArrayInterface<double, 'f'>);
+      } else if (name == "ROOT::VecOps::RVec<int>") {
+         AddArrayInterface(pyclass, (PyCFunction)RVecArrayInterface<int, 'i'>);
+      } else if (name == "ROOT::VecOps::RVec<unsigned int>") {
+         AddArrayInterface(pyclass, (PyCFunction)RVecArrayInterface<unsigned int, 'u'>);
+      } else if (name == "ROOT::VecOps::RVec<long>") {
+         AddArrayInterface(pyclass, (PyCFunction)RVecArrayInterface<long, 'i'>);
+      } else if (name == "ROOT::VecOps::RVec<unsigned long>") {
+         AddArrayInterface(pyclass, (PyCFunction)RVecArrayInterface<unsigned long, 'u'>);
+      }
    }
 
    else if ( IsTemplatedSTLClass( name, "map" ) ) {
@@ -2743,23 +2759,6 @@ Bool_t PyROOT::Pythonize( PyObject* pyclass, const std::string& name )
 
    else if ( name == "RooSimultaneous" )
       Utility::AddUsingToClass( pyclass, "plotOn" );
-
-   else if (name.find("RVec<") != std::string::npos) {
-      // add array interface
-      if (name.find("<float>") != std::string::npos) {
-         AddArrayInterface(pyclass, (PyCFunction)RVecArrayInterface<float, 'f'>);
-      } else if (name.find("<double>") != std::string::npos) {
-         AddArrayInterface(pyclass, (PyCFunction)RVecArrayInterface<double, 'f'>);
-      } else if (name.find("<int>") != std::string::npos) {
-         AddArrayInterface(pyclass, (PyCFunction)RVecArrayInterface<int, 'i'>);
-      } else if (name.find("<unsigned int>") != std::string::npos) {
-         AddArrayInterface(pyclass, (PyCFunction)RVecArrayInterface<unsigned int, 'u'>);
-      } else if (name.find("<long>") != std::string::npos) {
-         AddArrayInterface(pyclass, (PyCFunction)RVecArrayInterface<long, 'i'>);
-      } else if (name.find("<unsigned long>") != std::string::npos) {
-         AddArrayInterface(pyclass, (PyCFunction)RVecArrayInterface<unsigned long, 'u'>);
-      }
-   }
 
    // TODO: store these on the pythonizations module, not on gRootModule
    // TODO: externalize this code and use update handlers on the python side

--- a/bindings/pyroot/test/CMakeLists.txt
+++ b/bindings/pyroot/test/CMakeLists.txt
@@ -1,8 +1,9 @@
 ROOT_ADD_PYUNITTEST(pyroot_conversions conversions.py)
 ROOT_ADD_PYUNITTEST(pyroot_list_initialization list_initialization.py)
+ROOT_ADD_PYUNITTEST(pyroot_pretty_printing pretty_printing.py)
+ROOT_ADD_PYUNITTEST(pyroot_rvec rvec.py)
 if(NUMPY_FOUND)
     ROOT_ADD_PYUNITTEST(pyroot_array_interface array_interface.py)
     ROOT_ADD_PYUNITTEST(pyroot_ttree_asmatrix ttree_asmatrix.py)
-    ROOT_ADD_PYUNITTEST(pyroot_pretty_printing pretty_printing.py)
 endif()
 

--- a/bindings/pyroot/test/rvec.py
+++ b/bindings/pyroot/test/rvec.py
@@ -1,0 +1,37 @@
+import unittest
+import ROOT
+
+
+class RVec(unittest.TestCase):
+    dtype = "float"
+
+    def test_memoryadoption(self):
+        x = ROOT.std.vector("float")(1)
+        x[0] = 1
+        y = ROOT.VecOps.RVec(self.dtype)(x.data(), x.size())
+        self.assertEqual(x[0], y[0])
+
+    def test_getset(self):
+        x = ROOT.VecOps.RVec(self.dtype)(1)
+        x[0] = 1
+        self.assertEqual(x[0], 1)
+        self.assertEqual(x.at(0), 1)
+
+    def test_iter(self):
+        x = ROOT.VecOps.RVec(self.dtype)(3)
+        x[0], x[1], x[2] = 1, 2, 3
+        for i, y in enumerate(x):
+            self.assertEqual(y, x[i])
+
+    def test_push_back(self):
+        x = ROOT.VecOps.RVec(self.dtype)()
+        x.push_back(1)
+        self.assertEqual(x[0], 1)
+
+    def test_len(self):
+        x = ROOT.VecOps.RVec(self.dtype)(3)
+        self.assertEqual(len(x), 3)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add all STL vector pythonizations to RVec. ~Possibly needs further unit-tests.~ Added further unit-tests.

This ~should fix~ fixes the failing iterating over RVecs in Python on mac machines.

Made selection of appropriate pythonizations more fool proof (`RVec<RVec<T>>` was treated similar to `RVec<T>` due to lazy string magic). Thanks @amadio!