### PR TITLE
[clad] Specify where the clang header files are.

### DIFF
--- a/interpreter/cling/tools/plugins/clad/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/clad/CMakeLists.txt
@@ -27,6 +27,7 @@ if(MSVC)
     CMAKE_ARGS -G ${CMAKE_GENERATOR} -DCLAD_BUILD_STATIC_ONLY=ON
                -DCMAKE_INSTALL_PREFIX=${CLING_PLUGIN_INSTALL_PREFIX}
                -DCLAD_PATH_TO_LLVM_BUILD=${LLVM_BINARY_DIR}
+               -DCLANG_INCLUDE_DIRS=${CLANG_INCLUDE_DIRS}
     BUILD_COMMAND ${CMAKE_COMMAND} --build . --config ${_clad_build_type}
     # Wrap download, configure and build steps in a script to log output
     LOG_DOWNLOAD ON
@@ -53,6 +54,7 @@ else()
                -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
                -DCMAKE_INSTALL_PREFIX=${CLING_PLUGIN_INSTALL_PREFIX}
                -DCLAD_PATH_TO_LLVM_BUILD=${LLVM_BINARY_DIR}
+               -DCLANG_INCLUDE_DIRS=${CLANG_INCLUDE_DIRS}
                -DCLAD_BUILD_STATIC_ONLY=ON
     BUILD_BYPRODUCTS ${CLADDIFFERENTIATOR_LIB}
     # Wrap download, configure and build steps in a script to log output


### PR DESCRIPTION
In cases where we build ROOT with -Dbuiltin_llvm=Off -Dbuiltin_clang=On and we have installed both llvm and clang in /usr/ clad will pick up the clang headers from there too.

This patch gives higher priority to the header files which ROOT is supposed to use. It fixes a very obscure initialization issue due to different versions of the ASTContext.h installed and used by ROOT.