### PR TITLE
[cxxmodules] Remove uses of Gtypes.h

### DIFF
--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -9,6 +9,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/res ${CMAKE_CURRENT_SOURCE_DIR}/
 ROOT_GLOB_HEADERS(Base_dict_headers ${CMAKE_CURRENT_SOURCE_DIR}/inc/LinkDef?.h
                                     ${CMAKE_CURRENT_SOURCE_DIR}/inc/T*.h
                                     ${CMAKE_CURRENT_SOURCE_DIR}/inc/Rtypes.h
+                                    ${CMAKE_CURRENT_SOURCE_DIR}/inc/Gtypes.h
                                     ${CMAKE_CURRENT_SOURCE_DIR}/inc/GuiTypes.h
                                     ${CMAKE_CURRENT_SOURCE_DIR}/inc/MessageTypes.h
                                     ${CMAKE_CURRENT_SOURCE_DIR}/inc/KeySymbols.h

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -114,7 +114,6 @@ FARPROC dlsym(void *library, const char *function_name)
 #endif
 
 #include "Riostream.h"
-#include "Gtypes.h"
 #include "TROOT.h"
 #include "TClass.h"
 #include "TClassEdit.h"

--- a/graf2d/qt/inc/TQtBrush.h
+++ b/graf2d/qt/inc/TQtBrush.h
@@ -22,7 +22,6 @@
 #endif
 
 #include "Rtypes.h"
-#include "Gtypes.h"
 
 class TAttFill;
 class TPoint;

--- a/graf3d/eve/inc/TEveStraightLineSet.h
+++ b/graf3d/eve/inc/TEveStraightLineSet.h
@@ -14,7 +14,6 @@
 
 #include "TEveUtil.h"
 
-#include <Gtypes.h>
 #include "TNamed.h"
 #include "TQObject.h"
 #include "TAtt3D.h"

--- a/graf3d/gl/inc/TGLScene.h
+++ b/graf3d/gl/inc/TGLScene.h
@@ -15,8 +15,6 @@
 #include "TGLSceneBase.h"
 #include "TGLSceneInfo.h"
 
-#include "Gtypes.h"
-
 #include <map>
 #include <vector>
 


### PR DESCRIPTION
It was deprecated (by comment) and emptied in year 2000.

This patch removes all uses of it and 'registers' it to the modulemap to avoid our duplication algorithms do not find it as a duplicate.