### PR TITLE
DNN optimisations for Cuda

### DIFF
--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu.h
@@ -518,6 +518,12 @@ public:
     * \p A
     */
    static void SqrtElementWise(TCpuMatrix<Scalar_t> &A);
+
+     // optimizer functions
+   static void AdamUpdate(TCpuMatrix<Scalar_t> & A, const TCpuMatrix<Scalar_t> & M, const TCpuMatrix<Scalar_t> & V, Scalar_t alpha, Scalar_t eps);
+   static void AdamUpdateFirstMom(TCpuMatrix<Scalar_t> & A, const TCpuMatrix<Scalar_t> & B, Scalar_t beta);
+   static void AdamUpdateSecondMom(TCpuMatrix<Scalar_t> & A, const TCpuMatrix<Scalar_t> & B, Scalar_t beta);
+
 };
 
 //____________________________________________________________________________

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda.h
@@ -525,6 +525,12 @@ public:
     * \p A
     */
    static void SqrtElementWise(TCudaMatrix<AFloat> &A);
+
+  // optimizer functions
+   static void AdamUpdate(TCudaMatrix<AFloat> & A, const TCudaMatrix<AFloat> & M, const TCudaMatrix<AFloat> & V, AFloat alpha, AFloat eps);
+   static void AdamUpdateFirstMom(TCudaMatrix<AFloat> & A, const TCudaMatrix<AFloat> & B, AFloat beta);
+   static void AdamUpdateSecondMom(TCudaMatrix<AFloat> & A, const TCudaMatrix<AFloat> & B, AFloat beta);
+
 };
 
 //____________________________________________________________________________

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Reference.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Reference.h
@@ -498,6 +498,15 @@ public:
     */
    static void SqrtElementWise(TMatrixT<AReal> &A);
 
+   // optimizer update functions
+
+   /// Update functions for ADAM optimizer
+   static void AdamUpdate(TMatrixT<AReal> & A, const TMatrixT<AReal> & M, const TMatrixT<AReal> & V, AReal alpha, AReal eps);
+   static void AdamUpdateFirstMom(TMatrixT<AReal> & A, const TMatrixT<AReal> & B, AReal beta);
+   static void AdamUpdateSecondMom(TMatrixT<AReal> & A, const TMatrixT<AReal> & B, AReal beta);
+
+
+
    //____________________________________________________________________________
    //
    // AutoEncoder Propagation

--- a/tmva/tmva/inc/TMVA/DNN/SGD.h
+++ b/tmva/tmva/inc/TMVA/DNN/SGD.h
@@ -115,6 +115,8 @@ TSGD<Architecture_t, Layer_t, DeepNet_t>::TSGD(Scalar_t learningRate, DeepNet_t 
    }
 }
 
+
+
 //_________________________________________________________________________________________________
 template <typename Architecture_t, typename Layer_t, typename DeepNet_t>
 auto TSGD<Architecture_t, Layer_t, DeepNet_t>::UpdateWeights(size_t layerIndex, std::vector<Matrix_t> &weights,
@@ -122,14 +124,12 @@ auto TSGD<Architecture_t, Layer_t, DeepNet_t>::UpdateWeights(size_t layerIndex, 
 {
    // accumulating the current layer past weight gradients to include the current weight gradients.
    // Vt = momentum * Vt-1 + currentGradients
+
    std::vector<Matrix_t> &currentLayerPastWeightGradients = this->GetPastWeightGradientsAt(layerIndex);
+
    for (size_t k = 0; k < currentLayerPastWeightGradients.size(); k++) {
-      Matrix_t accumulation(currentLayerPastWeightGradients[k].GetNrows(),
-                            currentLayerPastWeightGradients[k].GetNcols());
-      initialize<Architecture_t>(accumulation, EInitialization::kZero);
-      Architecture_t::ScaleAdd(accumulation, currentLayerPastWeightGradients[k], this->GetMomentum());
-      Architecture_t::ScaleAdd(accumulation, weightGradients[k], 1.0);
-      Architecture_t::Copy(currentLayerPastWeightGradients[k], accumulation);
+      Architecture_t::ConstMult(currentLayerPastWeightGradients[k], this->GetMomentum());
+      Architecture_t::ScaleAdd(currentLayerPastWeightGradients[k], weightGradients[k], 1.0);
    }
 
    // updating the weights.
@@ -146,13 +146,12 @@ auto TSGD<Architecture_t, Layer_t, DeepNet_t>::UpdateBiases(size_t layerIndex, s
 {
    // accumulating the current layer past bias gradients to include the current bias gradients.
    // Vt = momentum * Vt-1 + currentGradients
+
    std::vector<Matrix_t> &currentLayerPastBiasGradients = this->GetPastBiasGradientsAt(layerIndex);
+
    for (size_t k = 0; k < currentLayerPastBiasGradients.size(); k++) {
-      Matrix_t accumulation(currentLayerPastBiasGradients[k].GetNrows(), currentLayerPastBiasGradients[k].GetNcols());
-      initialize<Architecture_t>(accumulation, EInitialization::kZero);
-      Architecture_t::ScaleAdd(accumulation, currentLayerPastBiasGradients[k], this->GetMomentum());
-      Architecture_t::ScaleAdd(accumulation, biasGradients[k], 1.0);
-      Architecture_t::Copy(currentLayerPastBiasGradients[k], accumulation);
+      Architecture_t::ConstMult(currentLayerPastBiasGradients[k], this->GetMomentum());
+      Architecture_t::ScaleAdd(currentLayerPastBiasGradients[k], biasGradients[k], 1.0);
    }
 
    // updating the biases

--- a/tmva/tmva/inc/TMVA/DataSetFactory.h
+++ b/tmva/tmva/inc/TMVA/DataSetFactory.h
@@ -273,7 +273,8 @@ namespace TMVA {
       TString                    fVerboseLevel;      // VerboseLevel
 
       // Printing
-      Bool_t fCorrelations; // Whether to print correlations or not
+      Bool_t fCorrelations = kFALSE;          // Whether to print correlations or not
+      Bool_t fComputeCorrelations = kFALSE;   // Whether to force computation of correlations or not
 
       Bool_t                     fScaleWithPreselEff; // how to deal with requested #events in connection with preselection cuts 
 

--- a/tmva/tmva/src/DNN/Architectures/Cpu/Arithmetic.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Cpu/Arithmetic.cxx
@@ -248,5 +248,46 @@ void TCpu<Real_t>::SqrtElementWise(TCpuMatrix<Real_t> &A)
    A.Map(f);
 }
 
+/// Adam updates 
+//____________________________________________________________________________
+template<typename Real_t>
+void TCpu<Real_t>::AdamUpdate(TCpuMatrix<Real_t> &A, const TCpuMatrix<Real_t> & M, const TCpuMatrix<Real_t> & V, Real_t alpha, Real_t eps)
+{
+   // ADAM update the weights.
+   // Weight = Weight - alpha * M / (sqrt(V) + epsilon)
+   Real_t * a = A.GetRawDataPointer();
+   const Real_t * m = M.GetRawDataPointer(); 
+   const Real_t * v = V.GetRawDataPointer();
+   for (size_t index = 0; index < A.GetNoElements() ; ++index) {
+      a[index] = a[index] - alpha * m[index]/( sqrt(v[index]) + eps);
+   }
+}
+
+//____________________________________________________________________________
+template<typename Real_t>
+void TCpu<Real_t>::AdamUpdateFirstMom(TCpuMatrix<Real_t> &A, const TCpuMatrix<Real_t> & B, Real_t beta)
+{
+   // First momentum weight gradient update for ADAM
+   // Mt = beta1 * Mt-1 + (1-beta1) * WeightGradients
+   Real_t * a = A.GetRawDataPointer();
+   const Real_t * b = B.GetRawDataPointer();
+   for (size_t index = 0; index < A.GetNoElements() ; ++index) {
+      a[index] = beta * a[index] + (1.-beta) * b[index];
+   }
+}
+//____________________________________________________________________________
+template<typename Real_t>
+void TCpu<Real_t>::AdamUpdateSecondMom(TCpuMatrix<Real_t> &A, const TCpuMatrix<Real_t> & B, Real_t beta)
+{
+   // Second momentum weight gradient update for ADAM 
+   // Vt = beta2 * Vt-1 + (1-beta2) * WeightGradients^2
+   Real_t * a = A.GetRawDataPointer();
+   const Real_t * b = B.GetRawDataPointer();
+   for (size_t index = 0; index < A.GetNoElements() ; ++index) {
+      a[index] = beta * a[index] + (1.-beta) * b[index] * b[index];
+   }
+}
+
+
 } // DNN
 } // TMVA

--- a/tmva/tmva/src/DNN/Architectures/Cuda/Arithmetic.cu
+++ b/tmva/tmva/src/DNN/Architectures/Cuda/Arithmetic.cu
@@ -401,6 +401,57 @@ void TCuda<AFloat>::SqrtElementWise(TCudaMatrix<AFloat> &A)
        (int) A.GetNcols());
 }
 
+/// Adam updates 
+//____________________________________________________________________________
+template<typename AFloat>
+void TCuda<AFloat>::AdamUpdate(TCudaMatrix<AFloat> &A, const TCudaMatrix<AFloat> & M, const TCudaMatrix<AFloat> & V, AFloat alpha, AFloat eps)
+{
+   dim3 blockDims = TDevice::BlockDims2D();
+   dim3 gridDims  = TDevice::GridDims2D(A);
+   cudaStream_t s = A.GetComputeStream();
+   ::TMVA::DNN::Cuda::AdamUpdate<<<gridDims, blockDims, 0, s>>>(
+       A.GetDataPointer(),
+       M.GetDataPointer(),
+       V.GetDataPointer(),
+       (int) A.GetNrows(),
+       (int) A.GetNcols(),
+       alpha, eps);
+}
 
+//____________________________________________________________________________
+template<typename AFloat>
+void TCuda<AFloat>::AdamUpdateFirstMom(TCudaMatrix<AFloat> &A, const TCudaMatrix<AFloat> & B, AFloat beta)
+{
+   dim3 blockDims = TDevice::BlockDims2D();
+   dim3 gridDims  = TDevice::GridDims2D(A);
+   cudaStream_t s = A.GetComputeStream();
+   ::TMVA::DNN::Cuda::AdamUpdateFirstMom<<<gridDims, blockDims, 0, s>>>(
+       A.GetDataPointer(),
+       B.GetDataPointer(),
+       (int) A.GetNrows(),
+       (int) A.GetNcols(), beta);
+}
+
+//____________________________________________________________________________
+template<typename AFloat>
+void TCuda<AFloat>::AdamUpdateSecondMom(TCudaMatrix<AFloat> &A, const TCudaMatrix<AFloat> & B, AFloat beta)
+{
+   dim3 blockDims = TDevice::BlockDims2D();
+   dim3 gridDims  = TDevice::GridDims2D(A);
+   cudaStream_t s = A.GetComputeStream();
+   ::TMVA::DNN::Cuda::AdamUpdateSecondMom<<<gridDims, blockDims, 0, s>>>(
+       A.GetDataPointer(),
+       B.GetDataPointer(),
+       (int) A.GetNrows(),
+       (int) A.GetNcols(), beta);
+}
+
+
+
+
+
+
+
+   
 } // DNN
 } // TMVA

--- a/tmva/tmva/src/DNN/Architectures/Cuda/Kernels.cuh
+++ b/tmva/tmva/src/DNN/Architectures/Cuda/Kernels.cuh
@@ -400,10 +400,55 @@ __global__ void SqrtElementWise(AFloat * A,
    }
 }
 
+
+/// optimizer kernel functions
+
+//____________________________________________________________________________
+template<typename AFloat>
+__global__ void AdamUpdate(AFloat * A, const AFloat * M, const AFloat * V,
+                           int m, int n, AFloat alpha, AFloat eps)
+{
+   int i = blockDim.y * blockIdx.y + threadIdx.y;
+   int j = blockDim.x * blockIdx.x + threadIdx.x;
+   int index = j * m + i;
+
+   if ((i < m) && (j < n)) {
+      A[index] = A[index] - alpha * M[index]/( sqrt(V[index]) + eps);
+   }
+}
+
+//____________________________________________________________________________
+template<typename AFloat>
+__global__ void AdamUpdateFirstMom(AFloat * A, const AFloat * B,
+                           int m, int n, AFloat beta)
+{
+   int i = blockDim.y * blockIdx.y + threadIdx.y;
+   int j = blockDim.x * blockIdx.x + threadIdx.x;
+   int index = j * m + i;
+
+   if ((i < m) && (j < n)) {
+      A[index] = beta * A[index] + (1.-beta) * B[index];
+   }
+}
+
+//____________________________________________________________________________
+template<typename AFloat>
+__global__ void AdamUpdateSecondMom(AFloat * A, const AFloat * B,
+                           int m, int n, AFloat beta)
+{
+   int i = blockDim.y * blockIdx.y + threadIdx.y;
+   int j = blockDim.x * blockIdx.x + threadIdx.x;
+   int index = j * m + i;
+
+   if ((i < m) && (j < n)) {
+      A[index] = beta * A[index] + (1.-beta) * B[index] * B[index];
+   }
+}
+
 //____________________________________________________________________________
 template<typename AFloat>
 __global__ void IdentityDerivative(AFloat * A,
-                                   int m, int n)
+                                   int m, int n)   
 {
    int i = blockDim.y * blockIdx.y + threadIdx.y;
    int j = blockDim.x * blockIdx.x + threadIdx.x;

--- a/tmva/tmva/src/DNN/Architectures/Reference/Arithmetic.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Reference/Arithmetic.cxx
@@ -97,6 +97,45 @@ void TReference<AReal>::SqrtElementWise(TMatrixT<AReal> &A)
       }
    }
 }
+/// Adam updates 
+//____________________________________________________________________________
+template<typename AReal>
+void TReference<AReal>::AdamUpdate(TMatrixT<AReal> &A, const TMatrixT<AReal> & M, const TMatrixT<AReal> & V, AReal alpha, AReal eps)
+{
+   // ADAM update the weights.
+   // Weight = Weight - alpha * M / (sqrt(V) + epsilon)
+   AReal * a = A.GetMatrixArray();
+   const AReal * m = M.GetMatrixArray();
+   const AReal * v = V.GetMatrixArray();
+   for (size_t index = 0; index < A.GetNoElements() ; ++index) {
+      a[index] = a[index] - alpha * m[index]/( sqrt(v[index]) + eps);
+   }
+}
 
+//____________________________________________________________________________
+template<typename AReal>
+void TReference<AReal>::AdamUpdateFirstMom(TMatrixT<AReal> &A, const TMatrixT<AReal> & B, AReal beta)
+{
+   // First momentum weight gradient update for ADAM 
+   // Mt = beta1 * Mt-1 + (1-beta1) * WeightGradients
+   AReal * a = A.GetMatrixArray();
+   const AReal * b = B.GetMatrixArray();
+   for (size_t index = 0; index < A.GetNoElements() ; ++index) {
+      a[index] = beta * a[index] + (1.-beta) * b[index];
+   }
+}   
+//____________________________________________________________________________
+template<typename AReal>
+void TReference<AReal>::AdamUpdateSecondMom(TMatrixT<AReal> &A, const TMatrixT<AReal> & B, AReal beta)
+{
+   // Second  momentum weight gradient update for ADAM 
+   // Vt = beta2 * Vt-1 + (1-beta2) * WeightGradients^2
+   AReal * a = A.GetMatrixArray();
+   const AReal * b = B.GetMatrixArray();
+   for (size_t index = 0; index < A.GetNoElements() ; ++index) {
+      a[index] = beta * a[index] + (1.-beta) * b[index] * b[index];
+   }
+}
+   
 } // namespace DNN
 } // namespace TMVA

--- a/tmva/tmva/src/DNN/Architectures/Reference/Arithmetic.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Reference/Arithmetic.cxx
@@ -107,7 +107,7 @@ void TReference<AReal>::AdamUpdate(TMatrixT<AReal> &A, const TMatrixT<AReal> & M
    AReal * a = A.GetMatrixArray();
    const AReal * m = M.GetMatrixArray();
    const AReal * v = V.GetMatrixArray();
-   for (size_t index = 0; index < A.GetNoElements() ; ++index) {
+   for (int index = 0; index < A.GetNoElements() ; ++index) {
       a[index] = a[index] - alpha * m[index]/( sqrt(v[index]) + eps);
    }
 }
@@ -120,7 +120,7 @@ void TReference<AReal>::AdamUpdateFirstMom(TMatrixT<AReal> &A, const TMatrixT<AR
    // Mt = beta1 * Mt-1 + (1-beta1) * WeightGradients
    AReal * a = A.GetMatrixArray();
    const AReal * b = B.GetMatrixArray();
-   for (size_t index = 0; index < A.GetNoElements() ; ++index) {
+   for (int index = 0; index < A.GetNoElements() ; ++index) {
       a[index] = beta * a[index] + (1.-beta) * b[index];
    }
 }   
@@ -132,7 +132,7 @@ void TReference<AReal>::AdamUpdateSecondMom(TMatrixT<AReal> &A, const TMatrixT<A
    // Vt = beta2 * Vt-1 + (1-beta2) * WeightGradients^2
    AReal * a = A.GetMatrixArray();
    const AReal * b = B.GetMatrixArray();
-   for (size_t index = 0; index < A.GetNoElements() ; ++index) {
+   for (int index = 0; index < A.GetNoElements() ; ++index) {
       a[index] = beta * a[index] + (1.-beta) * b[index] * b[index];
    }
 }

--- a/tmva/tmva/src/DataSetFactory.cxx
+++ b/tmva/tmva/src/DataSetFactory.cxx
@@ -128,7 +128,7 @@ TMVA::DataSet* TMVA::DataSetFactory::CreateDataSet( TMVA::DataSetInfo& dsi,
    // build the first dataset from the data input
    DataSet * ds = BuildInitialDataSet( dsi, dataInput );
 
-   if (ds->GetNEvents() > 1 && dsi.GetNVariables() < 10) {
+   if (ds->GetNEvents() > 1 && fComputeCorrelations ) {
       CalcMinMax(ds,dsi);
 
       // from the the final dataset build the correlation matrix
@@ -657,7 +657,9 @@ TMVA::DataSetFactory::InitOptions( TMVA::DataSetInfo& dsi,
 
    fCorrelations = kTRUE;
    splitSpecs.DeclareOptionRef(fCorrelations, "Correlations", "Boolean to show correlation output (Default: true)");
-
+   fComputeCorrelations = kTRUE;
+   splitSpecs.DeclareOptionRef(fComputeCorrelations, "CalcCorrelations", "Compute correlations and also some variable statistics, e.g. min/max (Default: true )");
+   
    splitSpecs.ParseOptions();
    splitSpecs.CheckForUnusedOptions();
 

--- a/tmva/tmva/src/DataSetFactory.cxx
+++ b/tmva/tmva/src/DataSetFactory.cxx
@@ -128,7 +128,7 @@ TMVA::DataSet* TMVA::DataSetFactory::CreateDataSet( TMVA::DataSetInfo& dsi,
    // build the first dataset from the data input
    DataSet * ds = BuildInitialDataSet( dsi, dataInput );
 
-   if (ds->GetNEvents() > 1) {
+   if (ds->GetNEvents() > 1 && dsi.GetNVariables() < 10) {
       CalcMinMax(ds,dsi);
 
       // from the the final dataset build the correlation matrix


### PR DESCRIPTION
This PR provides some optimisation for Cuda. In particular: 

- optimise update weights/gradient of SGD and ADAM/ 
    -   We avoid now creating temporary matrices in SGD 
    - For ADAM it is more efficient defining three new updates functions which will blenched on the GPU. This also avoid creating temporaries 

 These changes speed-up by almost a factor of 2 the code in GPU for dense layer when using ADAM and restore the previous performances for SGD

- optimise also computation of  convolutional weight gradients. 
In this case we can just simply use the ScaleAdd function. A speed up of ~ 20% is obtained 

This PR also adds a commit that remove the computation of correlation matrix in case of large number of variables 