### PR TITLE
[cxxmodules] Reduce the pcm duplicates.

### DIFF
--- a/graf3d/g3d/CMakeLists.txt
+++ b/graf3d/g3d/CMakeLists.txt
@@ -3,9 +3,6 @@
 ############################################################################
 
 ROOT_GLOB_HEADERS(headers1 ${CMAKE_CURRENT_SOURCE_DIR}/inc/*.h)
-list(REMOVE_ITEM headers1 ${CMAKE_CURRENT_SOURCE_DIR}/inc/X3DBuffer.h)
-set(headers2 X3DBuffer.h )
-
 ROOT_STANDARD_LIBRARY_PACKAGE(Graf3d
                               HEADERS ${headers1}
                               SOURCES *.cxx *.c


### PR DESCRIPTION
X3DBuffer.h is used indirectly by Graf3d and EG dictionaries. It does not
make a lot of sense to exclude it. Digging git history shows the import from
cvs so the real reason will probably remain unknown.