### PR TITLE
Add missing headers in TMVA and MathCore

### DIFF
--- a/math/mathcore/CMakeLists.txt
+++ b/math/mathcore/CMakeLists.txt
@@ -15,7 +15,10 @@ set(MATHCORE_HEADERS TRandom.h
   Math/ChebyshevPol.h Math/KDTree.h Math/TDataPoint.h Math/TDataPointN.h Math/Delaunay2D.h
   Math/Random.h Math/TRandomEngine.h Math/RandomFunctions.h Math/StdEngine.h Math/Math.h
   Math/MersenneTwisterEngine.h Math/MixMaxEngine.h   TRandomGen.h Math/LCGEngine.h
-  Math/Types.h Math/Util.h Math/WrappedFunction.h
+  Math/Types.h Math/Util.h Math/WrappedFunction.h Math/IMinimizer1D.h Math/IParamFunctionfwd.h
+  Math/MinimizerVariableTransformation.h Math/MultiDimParamFunctionAdapter.h Math/OneDimFunctionAdapter.h
+  Math/PdfFunc.h Math/PdfFuncMathCore.h Math/ProbFunc.h Math/ProbFuncMathCore.h Math/QuantFunc.h
+  Math/QuantFuncMathCore.h Math/WrappedParamFunction.h
 )
 
 if(veccore)

--- a/tmva/tmva/CMakeLists.txt
+++ b/tmva/tmva/CMakeLists.txt
@@ -37,7 +37,9 @@ set(headers4 NeuralNet.h TNeuron.h TSynapse.h TActivationChooser.h TActivation.h
 	     VariableTransformBase.h VarTransformHandler.h VariableIdentityTransform.h VariableDecorrTransform.h VariablePCATransform.h
 	     VariableGaussTransform.h VariableNormalizeTransform.h VariableRearrangeTransform.h VariableTransform.h ROCCalc.h ROCCurve.h)
 
-set(headers5 Envelope.h VariableImportance.h CrossValidation.h CvSplit.h HyperParameterOptimisation.h Classification.h Event.h Results.h ResultsClassification.h ResultsRegression.h ResultsMulticlass.h VariableInfo.h ClassInfo.h DataLoader.h DataSet.h DataSetInfo.h DataInputHandler.h DataSetManager.h DataSetFactory.h LossFunction.h )
+set(headers5 Envelope.h VariableImportance.h CrossValidation.h CvSplit.h HyperParameterOptimisation.h Classification.h Event.h Results.h ResultsClassification.h ResultsRegression.h ResultsMulticlass.h VariableInfo.h ClassInfo.h DataLoader.h DataSet.h DataSetInfo.h DataInputHandler.h DataSetManager.h DataSetFactory.h LossFunction.h ClassifierFactory.h ConvergenceTest.h ExpectedErrorPruneTool.h IPruneTool.h LDA.h MethodCFMlpANN_def.h ModulekNN.h Monitoring.h
+NodekNN.h Option.h OptionMap.h Pattern.h RuleCut.h RuleEnsemble.h RuleFitParams.h Rule.h SVKernelFunction.h SVKernelMatrix.h SVWorkingSet.h
+TransformationHandler.h Version.h Volume.h)
 
 #---Need to suffix each header name by TMVA/  -----------------
 foreach(hs headers1 headers2 headers3 headers4 headers5)


### PR DESCRIPTION
These headers are modular, this makes pcm a little bit smaller.