### PR TITLE
[DF] Fixed ambiguous calls to Cache and Display

### DIFF
--- a/tree/dataframe/inc/ROOT/RDFInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterface.hxx
@@ -542,6 +542,19 @@ public:
       return Cache(selectedColumns);
    }
 
+   ////////////////////////////////////////////////////////////////////////////
+   /// \brief Save selected columns in memory
+   /// \param[in] columns to be cached in memory
+   ///
+   /// The content of the selected columns is saved in memory exploiting the functionality offered by
+   /// the Take action. No extra copy is carried out when serving cached data to the actions and
+   /// transformations requesting it.
+   RInterface<RLoopManager> Cache(std::initializer_list<std::string> columnList)
+   {
+      ColumnNames_t selectedColumns(columnList);
+      return Cache(selectedColumns);
+   }
+
    // clang-format off
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Creates a node that filters entries based on range: [begin, end)
@@ -1539,6 +1552,21 @@ public:
    RResultPtr<RDisplay> Display(std::string_view columnNameRegexp = "", const int &nRows = 5)
    {
       auto selectedColumns = ConvertRegexToColumns(columnNameRegexp, "Display");
+      return Display(selectedColumns, nRows);
+   }
+
+   ////////////////////////////////////////////////////////////////////////////
+   /// \brief Provides a representation of the events in the dataset
+   /// \param[in] columnList Names of the columns to be displayed
+   /// \param[in] rows Number of events for each column to be displayed
+   ///
+   /// This function returns a `RResultPtr<RDisplay>` containing all the events to be displayed, organized in tabular
+   /// form. RDisplay will either print on the standard output a summarized version through `Print()` or will return a
+   /// complete version through `AsString()`.
+   /// This overload automatically infers the column types.
+   RResultPtr<RDisplay> Display(std::initializer_list<std::string> columnList, const int &nRows = 5)
+   {
+      ColumnNames_t selectedColumns(columnList);
       return Display(selectedColumns, nRows);
    }
 

--- a/tree/dataframe/test/dataframe_cache.cxx
+++ b/tree/dataframe/test/dataframe_cache.cxx
@@ -30,6 +30,24 @@ TEST(Cache, FundType)
    }
 }
 
+TEST(Cache, Ambiguity)
+{
+// This test verifies that the correct method is called and there is no ambiguity between the JIT call to Cache using
+// a column list as a parameter and the JIT call to Cache using the Regexp.
+ROOT::RDataFrame tdf(5);
+int i = 1;
+auto d = tdf.Define("c0", [&i]() { return i++; }).Define("c1", []() { return 1.; });
+
+auto cached_1 = d.Cache({"c0"});
+auto cached_2 = d.Cache({"c0", "c1"});
+
+auto c_1 = cached_1.Count();
+auto c_2 = cached_2.Count();
+
+EXPECT_EQ(5UL, *c_1);
+EXPECT_EQ(5UL, *c_2);
+}
+
 /*
 // The contiguity has been dropped since now caching is backed up by a TDS
 // TODO: we can optimise this. The reason why addresses are not contiguous with

--- a/tree/dataframe/test/dataframe_simple.cxx
+++ b/tree/dataframe/test/dataframe_simple.cxx
@@ -788,6 +788,25 @@ TEST(RDFSimpleTests, DisplayJitTwoRows)
    ASSERT_STREQ(dd->AsString().c_str(), DisplayAsStringTwoRows.c_str());
 }
 
+static const std::string DisplayAsStringOneColumn("b1 | \n0  | \n0  | \n0  | \n0  | \n0  | \n   | \n");
+static const std::string DisplayAsStringTwoColumns(
+   "b1 | b2  | \n0  | 1   | \n   | 2   | \n   | 3   | \n0  | 1   | \n   | 2   | \n   | 3   | \n0  | 1   | \n   | 2   | "
+   "\n   | 3   | \n0  | 1   | \n   | 2   | \n   | 3   | \n0  | 1   | \n   | 2   | \n   | 3   | \n   |     | \n");
+
+TEST(RDFSimpleTests, DisplayAmbiguity)
+{
+   // This test verifies that the correct method is called and there is no ambiguity between the JIT call to Display
+   // using a column list as a parameter and the JIT call to Display using the Regexp.
+   RDataFrame rd1(10);
+   auto dd = rd1.Define("b1", []() { return 0; }).Define("b2", []() { return std::vector<int>({1, 2, 3}); });
+
+   auto display_1 = dd.Display({"b1"});
+   auto display_2 = dd.Display({"b1", "b2"});
+
+   ASSERT_STREQ(display_1->AsString().c_str(), DisplayAsStringOneColumn.c_str());
+   ASSERT_STREQ(display_2->AsString().c_str(), DisplayAsStringTwoColumns.c_str());
+}
+
 // run single-thread tests
 INSTANTIATE_TEST_CASE_P(Seq, RDFSimpleTests, ::testing::Values(false));
 


### PR DESCRIPTION
Using Cache() and Display() with an argument like {"x", "y"} matches both the string_view and the vector<string> overloads, causing ambiguity.