### PR TITLE
remove usage of TFormula in TActivation*

### DIFF
--- a/tmva/tmva/inc/TMVA/TActivationIdentity.h
+++ b/tmva/tmva/inc/TMVA/TActivationIdentity.h
@@ -32,7 +32,6 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-#include "TFormula.h"
 #include "TString.h"
 
 #include "TMVA/TActivation.h"

--- a/tmva/tmva/inc/TMVA/TActivationRadial.h
+++ b/tmva/tmva/inc/TMVA/TActivationRadial.h
@@ -32,7 +32,6 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-#include "TFormula.h"
 #include "TString.h"
 
 #include "TMVA/TActivation.h"
@@ -43,8 +42,8 @@ namespace TMVA {
     
    public:
 
-      TActivationRadial();
-      ~TActivationRadial();
+      TActivationRadial() {}
+      ~TActivationRadial() {}
 
       // evaluate the activation function
       Double_t Eval(Double_t arg);
@@ -65,9 +64,6 @@ namespace TMVA {
       virtual void MakeFunction(std::ostream& fout, const TString& fncName);
 
    private:
-
-      TFormula* fEqn;                // equation of radial basis function
-      TFormula* fEqnDerivative;      // equation of derivative
 
       ClassDef(TActivationRadial,0);  // Radial basis activation function for TNeuron
    };

--- a/tmva/tmva/inc/TMVA/TActivationReLU.h
+++ b/tmva/tmva/inc/TMVA/TActivationReLU.h
@@ -32,7 +32,6 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-#include "TFormula.h"
 #include "TString.h"
 
 #include "TMVA/TActivation.h"
@@ -43,8 +42,8 @@ namespace TMVA {
     
    public:
 
-      TActivationReLU();
-      ~TActivationReLU();
+      TActivationReLU() {}
+      ~TActivationReLU() {}
 
       // evaluate the activation function
       Double_t Eval(Double_t arg) { return arg>0 ? arg : 0;}
@@ -66,7 +65,7 @@ namespace TMVA {
 
    private:
 
-      ClassDef(TActivationReLU,0); // Tanh sigmoid activation function for TNeuron
+      ClassDef(TActivationReLU,0); // Rectified Linear Unit activation function for TNeuron
    };
 
 } // namespace TMVA

--- a/tmva/tmva/inc/TMVA/TActivationSigmoid.h
+++ b/tmva/tmva/inc/TMVA/TActivationSigmoid.h
@@ -32,7 +32,6 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-#include "TFormula.h"
 #include "TString.h"
 
 #include "TMVA/TActivation.h"
@@ -43,8 +42,8 @@ namespace TMVA {
     
    public:
 
-      TActivationSigmoid();
-      ~TActivationSigmoid();
+      TActivationSigmoid() {}
+      ~TActivationSigmoid() {}
 
       // evaluate the activation function
       Double_t Eval(Double_t arg);
@@ -65,9 +64,6 @@ namespace TMVA {
       virtual void MakeFunction(std::ostream& fout, const TString& fncName);
 
    private:
-
-      TFormula* fEqn;                // equation of sigmoid
-      TFormula* fEqnDerivative;      // equation of sigmoid derivative
 
       ClassDef(TActivationSigmoid,0); // Sigmoid activation function for TNeuron
    };

--- a/tmva/tmva/inc/TMVA/TActivationTanh.h
+++ b/tmva/tmva/inc/TMVA/TActivationTanh.h
@@ -32,7 +32,6 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-#include "TFormula.h"
 #include "TString.h"
 
 #include "TMVA/TActivation.h"
@@ -43,8 +42,8 @@ namespace TMVA {
     
    public:
 
-      TActivationTanh();
-      ~TActivationTanh();
+      TActivationTanh() {}
+      ~TActivationTanh() {}
 
       // evaluate the activation function
       Double_t Eval(Double_t arg);

--- a/tmva/tmva/src/TActivationRadial.cxx
+++ b/tmva/tmva/src/TActivationRadial.cxx
@@ -20,19 +20,16 @@
  * modification, are permitted according to the terms listed in LICENSE           *
  * (http://tmva.sourceforge.net/LICENSE)                                          *
  **********************************************************************************/
-
+  
 /*! \class TMVA::TActivationRadial
 \ingroup TMVA
-Radial basis  activation function for ANN. This really simple implementation
-uses TFormula and should probably be replaced with something more
-efficient later.
+Radial basis  activation function for ANN.
 */
 
 #include "TMVA/TActivationRadial.h"
 
 #include "TMVA/TActivation.h"
 
-#include "TFormula.h"
 #include "TMath.h"
 #include "TString.h"
 
@@ -43,30 +40,11 @@ static const Int_t  UNINITIALIZED = -1;
 ClassImp(TMVA::TActivationRadial);
 
 ////////////////////////////////////////////////////////////////////////////////
-/// constructor for gaussian with center 0, width 1
-
-TMVA::TActivationRadial::TActivationRadial()
-{
-   fEqn           = new TFormula("Gaussian",   "TMath::Exp(-x^2/2.0)");
-   fEqnDerivative = new TFormula("derivative", "-x*TMath::Exp(-x^2/2.0)");
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// destructor
-
-TMVA::TActivationRadial::~TActivationRadial()
-{
-   if (fEqn != NULL) delete fEqn;
-   if (fEqnDerivative != NULL) delete fEqnDerivative;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// evaluate gaussian
 
 Double_t TMVA::TActivationRadial::Eval(Double_t arg)
 {
-   if (fEqn == NULL) return UNINITIALIZED;
-   return fEqn->Eval(arg);
+  return TMath::Exp(-arg*arg*0.5);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -74,8 +52,7 @@ Double_t TMVA::TActivationRadial::Eval(Double_t arg)
 
 Double_t TMVA::TActivationRadial::EvalDerivative(Double_t arg)
 {
-   if (fEqnDerivative == NULL) return UNINITIALIZED;
-   return fEqnDerivative->Eval(arg);
+  return -arg*TMath::Exp(-arg*arg*0.5);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -83,16 +60,7 @@ Double_t TMVA::TActivationRadial::EvalDerivative(Double_t arg)
 
 TString TMVA::TActivationRadial::GetExpression()
 {
-   TString expr = "";
-
-   if (fEqn == NULL) expr += "<null>";
-   else              expr += fEqn->GetExpFormula();
-
-   expr += "\t\t";
-
-   if (fEqnDerivative == NULL) expr += "<null>";
-   else                        expr += fEqnDerivative->GetExpFormula();
-
+   TString expr = "TMath::Exp(-x^2/2.0)\t\t-x*TMath::Exp(-x^2/2.0)";
    return expr;
 }
 

--- a/tmva/tmva/src/TActivationReLU.cxx
+++ b/tmva/tmva/src/TActivationReLU.cxx
@@ -30,29 +30,12 @@ Rectified Linear Unit activation function for TNeuron
 
 #include "TMVA/TActivation.h"
 
-#include "TFormula.h"
 #include "TMath.h"
 #include "TString.h"
 
 #include <iostream>
 
 ClassImp(TMVA::TActivationReLU);
-
-////////////////////////////////////////////////////////////////////////////////
-/// constructor for ReLU
-
-TMVA::TActivationReLU::TActivationReLU()
-{
-   // sorry, I really don't know what I would possibly want to do here ;)
-
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// destructor
-
-TMVA::TActivationReLU::~TActivationReLU()
-{
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// get expressions for the tanh and its derivative
@@ -65,7 +48,7 @@ TString TMVA::TActivationReLU::GetExpression()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// writes the sigmoid activation function source code
+/// writes the Rectified Linear Unit activation function source code
 
 void TMVA::TActivationReLU::MakeFunction( std::ostream& fout, const TString& fncName )
 {

--- a/tmva/tmva/src/TActivationSigmoid.cxx
+++ b/tmva/tmva/src/TActivationSigmoid.cxx
@@ -23,16 +23,13 @@
 
 /*! \class TMVA::TActivationSigmoid
 \ingroup TMVA
-Sigmoid activation function for TNeuron. This really simple implementation
-uses TFormula and should probably be replaced with something more
-efficient later.
+Sigmoid activation function for TNeuron.
 */
 
 #include "TMVA/TActivationSigmoid.h"
 
 #include "TMVA/TActivation.h"
 
-#include "TFormula.h"
 #include "TMath.h"
 #include "TString.h"
 
@@ -43,33 +40,11 @@ static const Int_t  UNINITIALIZED = -1;
 ClassImp(TMVA::TActivationSigmoid);
 
 ////////////////////////////////////////////////////////////////////////////////
-/// constructor for sigmoid normalized in [0,1]
-
-TMVA::TActivationSigmoid::TActivationSigmoid()
-{
-   fEqn = new TFormula("sigmoid", "1.0/(1.0+TMath::Exp(-x))");
-   fEqnDerivative =
-      new TFormula("derivative", "TMath::Exp(-x)/(1.0+TMath::Exp(-x))^2");
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// destructor
-
-TMVA::TActivationSigmoid::~TActivationSigmoid()
-{
-   if (fEqn != NULL) delete fEqn;
-   if (fEqnDerivative != NULL) delete fEqnDerivative;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// evaluate the sigmoid
 
 Double_t TMVA::TActivationSigmoid::Eval(Double_t arg)
 {
-   if (fEqn == NULL) return UNINITIALIZED;
-   return fEqn->Eval(arg);
-
-   //return EvalFast(arg);
+  return 1.0/(1.0+TMath::Exp(-arg));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -77,10 +52,8 @@ Double_t TMVA::TActivationSigmoid::Eval(Double_t arg)
 
 Double_t TMVA::TActivationSigmoid::EvalDerivative(Double_t arg)
 {
-   if (fEqnDerivative == NULL) return UNINITIALIZED;
-   return fEqnDerivative->Eval(arg);
-
-   //return EvalDerivativeFast(arg);
+  Double_t tmp = (1.0+TMath::Exp(-arg));
+  return TMath::Exp(-arg)/(tmp*tmp);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -88,16 +61,7 @@ Double_t TMVA::TActivationSigmoid::EvalDerivative(Double_t arg)
 
 TString TMVA::TActivationSigmoid::GetExpression()
 {
-   TString expr = "";
-
-   if (fEqn == NULL) expr += "<null>";
-   else              expr += fEqn->GetExpFormula();
-
-   expr += "\t\t";
-
-   if (fEqnDerivative == NULL) expr += "<null>";
-   else                        expr += fEqnDerivative->GetExpFormula();
-
+   TString expr = "1.0/(1.0+TMath::Exp(-x))\t\tTMath::Exp(-x)/(1.0+TMath::Exp(-x))^2";
    return expr;
 }
 

--- a/tmva/tmva/src/TActivationTanh.cxx
+++ b/tmva/tmva/src/TActivationTanh.cxx
@@ -23,37 +23,19 @@
 
 /*! \class TMVA::TActivationTanh
 \ingroup TMVA
-Tanh activation function for ANN. This really simple implementation
-uses TFormula and should probably be replaced with something more
-efficient later.
+Tanh activation function for ANN.
 */
 
 #include "TMVA/TActivationTanh.h"
 
 #include "TMVA/TActivation.h"
 
-#include "TFormula.h"
 #include "TMath.h"
 #include "TString.h"
 
 #include <iostream>
 
 ClassImp(TMVA::TActivationTanh);
-
-////////////////////////////////////////////////////////////////////////////////
-/// constructor for tanh sigmoid (normalized in [-1,1])
-
-TMVA::TActivationTanh::TActivationTanh()
-{
-   fFAST=kTRUE;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// destructor
-
-TMVA::TActivationTanh::~TActivationTanh()
-{
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// a fast tanh approximation
@@ -95,7 +77,7 @@ TString TMVA::TActivationTanh::GetExpression()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// writes the sigmoid activation function source code
+/// writes the Tanh sigmoid activation function source code
 
 void TMVA::TActivationTanh::MakeFunction( std::ostream& fout, const TString& fncName )
 {


### PR DESCRIPTION
Effectively do what the old comments already say should be done.

Remove the indirection to TFormula in TActivationFunction and call C++ code directly.

This makes the constructors and destructors trivial (might even default them,
no opinion from my side, happy to update if you have a preference).

Also update the comments, where they seem just copy&paste from other files along with the skeleton.

PS: I thought I had already discussed (part of?) this at some point in the past but really don't recall.


And I guess in a moment from now I will see what clang-format thinks about the change.