### PR TITLE
[v7hist] Outline ~RHistDrawableBase() to help cling/GCC.

### DIFF
--- a/hist/histdraw/v7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdraw/v7/inc/ROOT/RHistDrawable.hxx
@@ -62,7 +62,7 @@ extern template class RHistPainterBase<3>;
 template <class DERIVED>
 class RHistDrawableBase: public RDrawableBase<DERIVED> {
 public:
-   virtual ~RHistDrawableBase() = default;
+   virtual ~RHistDrawableBase();
 
    void PopulateMenu(RMenuItems &) final;
 

--- a/hist/histdraw/v7/src/RHistDrawable.cxx
+++ b/hist/histdraw/v7/src/RHistDrawable.cxx
@@ -86,6 +86,9 @@ template class RHistPainterBase<2>;
 template class RHistPainterBase<3>;
 } // namespace Internal
 
+template <class DERIVED>
+RHistDrawableBase<DERIVED>::~RHistDrawableBase() = default;
+
 template class RHistDrawableBase<RHistDrawable<1>>;
 template class RHistDrawableBase<RHistDrawable<2>>;
 template class RHistDrawableBase<RHistDrawable<3>>;


### PR DESCRIPTION
Should fix cling's missing dtor symbol on GCC builds.