### PR TITLE
[RDF Helpers] Add helper to create filelists from system directories

### DIFF
--- a/tree/dataframe/test/dataframe_helpers.cxx
+++ b/tree/dataframe/test/dataframe_helpers.cxx
@@ -5,6 +5,8 @@
 #include <algorithm>
 #include <deque>
 #include <vector>
+#include <sys/stat.h>
+#include <fstream>
 
 #include "gtest/gtest.h"
 using namespace ROOT;
@@ -48,4 +50,36 @@ TEST(RDFHelpers, PassAsVec)
    EXPECT_EQ(1u, *df.Filter(PassAsVec<2, int>(TwoOnesRVec), {"one", "_1"}).Count());
    auto TwoOnesDeque = [](const std::deque<int> &v) { return v.size() == 2 && v[0] == 1 && v[1] == 1; };
    EXPECT_EQ(1u, *df.Filter(PassAsVec<2, int>(TwoOnesDeque), {"one", "_1"}).Count());
+}
+
+TEST(RDFHelpers, ListFilesInDirectory)
+{
+   // Create directory
+   mkdir("test_RDFHelpers_CreateFilelist", S_IRWXU);
+
+   // Create some files
+   std::ofstream file1("test_RDFHelpers_CreateFilelist/a.log");
+   file1.close();
+   std::ofstream file2("test_RDFHelpers_CreateFilelist/b.log");
+   file2.close();
+   std::ofstream file3("test_RDFHelpers_CreateFilelist/c.txt");
+   file3.close();
+
+   // Create filelist with all files
+   auto list1 = CreateFilelist("test_RDFHelpers_CreateFilelist/");
+   EXPECT_EQ(3u, list1.size());
+   EXPECT_EQ("test_RDFHelpers_CreateFilelist/a.log", list1[0]);
+   EXPECT_EQ("test_RDFHelpers_CreateFilelist/b.log", list1[1]);
+   EXPECT_EQ("test_RDFHelpers_CreateFilelist/c.txt", list1[2]);
+
+   // Create filelist with given hint
+   auto list2 = CreateFilelist("test_RDFHelpers_CreateFilelist/", ".log");
+   EXPECT_EQ(2u, list2.size());
+   EXPECT_EQ("test_RDFHelpers_CreateFilelist/a.log", list2[0]);
+   EXPECT_EQ("test_RDFHelpers_CreateFilelist/b.log", list2[1]);
+
+   // Test joining input path to filename without trailing slash
+   auto list3 = CreateFilelist("test_RDFHelpers_CreateFilelist", ".txt");
+   EXPECT_EQ(1u, list3.size());
+   EXPECT_EQ("test_RDFHelpers_CreateFilelist/c.txt", list3[0]);
 }


### PR DESCRIPTION
@dpiparo @bluehood Do we need such a thing? It would be super convenient in the analysis workflow because often a bunch of files are laying around in a directory, which you need to put all together into RDF:

```bash
$ ls -l testdir/
a.root
b.root
c.root
```

```cpp
RDataFrame df("tree", CreateFilelist("testdir"));
```