### PR TITLE
[TMVA] Reduce work done in CV regression tutorial

### DIFF
--- a/tutorials/tmva/TMVACrossValidationRegression.C
+++ b/tutorials/tmva/TMVACrossValidationRegression.C
@@ -167,15 +167,8 @@ int TMVACrossValidationRegression()
    // Books a method to use for evaluation
    //
    cv.BookMethod(TMVA::Types::kBDT, "BDTG",
-                 "!H:!V:NTrees=2000::BoostType=Grad:Shrinkage=0.1:"
-                 "UseBaggedBoost:BaggedSampleFraction=0.5:nCuts=20:MaxDepth=3:"
-                 "MaxDepth=4");
-
-   cv.BookMethod(TMVA::Types::kMLP, "MLP",
-                 "!H:!V:VarTransform=Norm:NeuronType=tanh:NCycles=200:"
-                 "HiddenLayers=N+20:TestRate=6:TrainingMethod=BFGS:"
-                 "Sampling=0.3:SamplingEpoch=0.8:ConvergenceImprove=1e-6:"
-                 "ConvergenceTests=15:!UseRegulator" );
+                 "!H:!V:NTrees=500:BoostType=Grad:Shrinkage=0.1:"
+                 "UseBaggedBoost:BaggedSampleFraction=0.5:nCuts=20:MaxDepth=3");
 
    // --------------------------------------------------------------------------
 

--- a/tutorials/tmva/TMVACrossValidationRegression.C
+++ b/tutorials/tmva/TMVACrossValidationRegression.C
@@ -101,7 +101,7 @@ int TMVACrossValidationRegression()
    // --------------------------------------------------------------------------
 
    // Create a ROOT output file where TMVA will store ntuples, histograms, etc.
-   TString outfileName("TMVAReg.root");
+   TString outfileName("TMVARegCv.root");
    TFile * outputFile = TFile::Open(outfileName, "RECREATE");
 
    TString infileName("./files/tmva_reg_example.root");
@@ -112,14 +112,14 @@ int TMVACrossValidationRegression()
    dataloader->AddVariable("var1", "Variable 1", "units", 'F');
    dataloader->AddVariable("var2", "Variable 2", "units", 'F');
 
-   dataloader->AddSpectator("spec1 := var1*100 + var2*100", 'F');
-
    // Add the variable carrying the regression target
    dataloader->AddTarget("fvalue");
 
    TTree * regTree = (TTree*)inputFile->Get("TreeR");
    dataloader->AddRegressionTree(regTree, 1.0);
-   dataloader->SetWeightExpression("var1", "Regression");
+
+   // Individual events can be weighted
+   // dataloader->SetWeightExpression("weight", "Regression");
 
    std::cout << "--- TMVACrossValidationRegression: Using input file: " << inputFile->GetName() << std::endl;
 


### PR DESCRIPTION
The tutorial was sometimes timing out on some nodes. To reduce the workload running the MLP has been skipped and the number of trees in the BDT is cut by a factor 4.  On my machine running time went from 77s to 10s.