### PR TITLE
Catch exceptions by reference and not by value in TMVA

### DIFF
--- a/tmva/tmva/src/DataSet.cxx
+++ b/tmva/tmva/src/DataSet.cxx
@@ -170,7 +170,7 @@ Long64_t TMVA::DataSet::GetNClassEvents( Int_t type, UInt_t classNumber )
    try {
       return fClassEvents.at(type).at(classNumber);
    }
-   catch (std::out_of_range) {
+   catch (std::out_of_range &) {
       ClassInfo* ci = fdsi->GetClassInfo( classNumber );
       Log() << kFATAL << Form("Dataset[%s] : ",fdsi->GetName()) << "No " << (type==0?"training":(type==1?"testing":"_unknown_type_"))
             << " events for class " << (ci==NULL?"_no_name_known_":ci->GetName()) << " (index # "<<classNumber<<")"

--- a/tmva/tmva/src/Reader.cxx
+++ b/tmva/tmva/src/Reader.cxx
@@ -633,7 +633,7 @@ Float_t TMVA::Reader::EvaluateRegression( UInt_t tgtNumber, const TString& metho
    try {
       return EvaluateRegression(methodTag, aux).at(tgtNumber);
    }
-   catch (std::out_of_range) {
+   catch (std::out_of_range &) {
       Log() << kWARNING << "Regression could not be evaluated for target-number " << tgtNumber << Endl;
       return 0;
    }
@@ -699,7 +699,7 @@ Float_t TMVA::Reader::EvaluateMulticlass( UInt_t clsNumber, const TString& metho
    try {
       return EvaluateMulticlass(methodTag, aux).at(clsNumber);
    }
-   catch (std::out_of_range) {
+   catch (std::out_of_range &) {
       Log() << kWARNING << "Multiclass could not be evaluated for class-number " << clsNumber << Endl;
       return 0;
    }

--- a/tmva/tmva/src/VariableGaussTransform.cxx
+++ b/tmva/tmva/src/VariableGaussTransform.cxx
@@ -748,7 +748,7 @@ void TMVA::VariableGaussTransform::MakeFunction( std::ostream& fout, const TStri
                if( type != 'v' ){
                   Log() << kWARNING << "MakeClass for the Gauss transformation works only for the transformation of variables. The transformation of targets/spectators is not implemented." << Endl;
                }
-            }catch( std::out_of_range ){
+            }catch( std::out_of_range &){
                Log() << kWARNING << "MakeClass for the Gauss transformation searched for a non existing variable index (" << ivar << ")" << Endl;
             }
 


### PR DESCRIPTION
Fix ROOT-9611 by catching exceptions by reference.
