### PR TITLE
[cmake] Narrow the list of included directories.

### DIFF
--- a/core/clingutils/CMakeLists.txt
+++ b/core/clingutils/CMakeLists.txt
@@ -10,23 +10,21 @@ ROOT_GLOB_HEADERS(headers ${CMAKE_CURRENT_SOURCE_DIR}/inc/*.h)
 
 set(ClingUtils_dict_headers ${headers} PARENT_SCOPE)
 
+ROOT_OBJECT_LIBRARY(ClingUtils ${sources})
+add_dependencies(ClingUtils CLING)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/res ${CMAKE_CURRENT_SOURCE_DIR}/../foundation/res)
-include_directories(${CLING_INCLUDE_DIRS})
+target_include_directories(ClingUtils PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/res ${CMAKE_CURRENT_SOURCE_DIR}/../foundation/res)
+target_include_directories(ClingUtils PRIVATE ${CLING_INCLUDE_DIRS})
 # Register the llvm include directories after clangs. This instructs the compiler to resolve
 # headers from our builtin clang. That's an issue when we are building with bultin_llvm=Off
 # and we have installed clang headers, too.
-include_directories(SYSTEM ${CLANG_INCLUDE_DIRS} ${LLVM_INCLUDE_DIRS})
+target_include_directories(ClingUtils PRIVATE SYSTEM ${CLANG_INCLUDE_DIRS} ${LLVM_INCLUDE_DIRS})
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CLING_CXXFLAGS}")
 
 # This is to avoid warnings coming from GCC 7 in llvm/src/include/llvm/ADT/DenseMap.h:1010
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
   ROOT_ADD_CXX_FLAG(CMAKE_CXX_FLAGS -Wno-maybe-uninitialized)
 endif()
-
-ROOT_OBJECT_LIBRARY(ClingUtils ${sources})
-
-add_dependencies(ClingUtils CLING)
 
 ROOT_INSTALL_HEADERS()
 

--- a/core/dictgen/CMakeLists.txt
+++ b/core/dictgen/CMakeLists.txt
@@ -10,15 +10,22 @@
 
 ROOT_GLOB_SOURCES(sources ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cxx)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src
-        ${CMAKE_CURRENT_SOURCE_DIR}/res
-        ${CMAKE_CURRENT_SOURCE_DIR}/../foundation/res
-        ${CMAKE_CURRENT_SOURCE_DIR}/../clingutils/res)
-include_directories(${CLING_INCLUDE_DIRS})
+ROOT_OBJECT_LIBRARY(Dictgen
+  ${sources}
+)
+add_dependencies(Dictgen CLING)
+
+target_include_directories(Dictgen PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/src
+  ${CMAKE_CURRENT_SOURCE_DIR}/res
+  ${CMAKE_CURRENT_SOURCE_DIR}/../foundation/res
+  ${CMAKE_CURRENT_SOURCE_DIR}/../clingutils/res
+)
+target_include_directories(Dictgen PRIVATE ${CLING_INCLUDE_DIRS})
 # Register the llvm include directories after clangs. This instructs the compiler to resolve
 # headers from our builtin clang. That's an issue when we are building with bultin_llvm=Off
 # and we have installed clang headers, too.
-include_directories(SYSTEM ${CLANG_INCLUDE_DIRS} ${LLVM_INCLUDE_DIRS})
+target_include_directories(Dictgen PRIVATE SYSTEM ${CLANG_INCLUDE_DIRS} ${LLVM_INCLUDE_DIRS})
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CLING_CXXFLAGS}")
 CHECK_CXX_COMPILER_FLAG("-fno-rtti" CXX_HAS_fno_rtti)
@@ -27,9 +34,3 @@ if(CXX_HAS_fno_rtti)
     set_source_files_properties(src/LinkdefReader.cxx    PROPERTIES COMPILE_FLAGS "-fno-rtti")
     set_source_files_properties(src/TModuleGenerator.cxx PROPERTIES COMPILE_FLAGS "-fno-rtti")
 endif()
-
-ROOT_OBJECT_LIBRARY(Dictgen
-  ${sources}
-)
-
-add_dependencies(Dictgen CLING)


### PR DESCRIPTION
This patch makes the include paths related to the given target.

The side effect is that rootcling gets significantly less -I flags because cmake scans for the content of the INCLUDE_DIRECTORIES which now contains less and more relevant information.