### PR TITLE
[cxxmodules] Build cling runtime into module.

### DIFF
--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -293,7 +293,7 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
 
   if(CMAKE_PROJECT_NAME STREQUAL ROOT)
     set(includedirs -I${CMAKE_SOURCE_DIR}
-                    -I${CMAKE_SOURCE_DIR}/interpreter/cling/include # This is for the RuntimeUniverse
+                    -I${CMAKE_BINARY_DIR}/etc/cling/ # This is for the RuntimeUniverse
                     -I${CMAKE_BINARY_DIR}/include)
     set(excludepaths ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
   elseif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/inc)

--- a/core/clingutils/CMakeLists.txt
+++ b/core/clingutils/CMakeLists.txt
@@ -87,7 +87,8 @@ install(DIRECTORY ${CMAKE_BINARY_DIR}/etc/cling/lib/clang/${CLANG_RESOURCE_DIR_V
 #---Install a bunch of files to /etc/cling------------------------------------
 set(clinginclude    ${CMAKE_SOURCE_DIR}/interpreter/cling/include)
 
-foreach(file  Interpreter/DynamicExprInfo.h
+foreach(file module.modulemap.build
+        Interpreter/DynamicExprInfo.h
         Interpreter/DynamicLookupRuntimeUniverse.h
         Interpreter/DynamicLookupLifetimeHandler.h
         Interpreter/Exception.h
@@ -95,10 +96,16 @@ foreach(file  Interpreter/DynamicExprInfo.h
         Interpreter/RuntimeUniverse.h
         Interpreter/Value.h)
   get_filename_component(path ${file} PATH)
-  list(APPEND copy_commands COMMAND ${CMAKE_COMMAND} -E copy ${clinginclude}/cling/${file} ${CMAKE_BINARY_DIR}/etc/cling/${file})
+  set(dest_file ${file})
+  if (${file} STREQUAL "module.modulemap.build")
+    set(dest_file "module.modulemap")
+  else()
+    # We do not want our modulemap to be considered part of the PCH.
+    set_property(GLOBAL APPEND PROPERTY CLINGETCPCH etc/cling/${dest_file})
+  endif()
+  list(APPEND copy_commands COMMAND ${CMAKE_COMMAND} -E copy ${clinginclude}/cling/${file} ${CMAKE_BINARY_DIR}/etc/cling/${dest_file})
   list(APPEND files_to_copy ${clinginclude}/cling/${file})
-  set_property(GLOBAL APPEND PROPERTY CLINGETCPCH etc/cling/${file})
-  install(FILES ${clinginclude}/cling/${file} DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/cling/${path})
+  install(FILES ${clinginclude}/cling/${file} DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/cling/${path}/${dest_file})
 endforeach()
 
 foreach(file  multimap  multiset)

--- a/interpreter/cling/include/cling/module.modulemap.build
+++ b/interpreter/cling/include/cling/module.modulemap.build
@@ -9,32 +9,3 @@ module Cling_Runtime {
   module "Value.h" { header "Interpreter/Value.h" export * }
   export *
 }
-
-module Cling_Interpreter {
-  requires cplusplus
-  umbrella "Interpreter"
-
-  textual header "Interpreter/ClingOptions.inc"
-
-  module * { export * }
-}
-
-module Cling_MetaProcessor {
-  requires cplusplus
-  umbrella "MetaProcessor"
-  module * { export * }
-
-}
-
-module Cling_UserInterface {
-  requires cplusplus
-  umbrella "UserInterface"
-  module * { export * }
-
-}
-
-module Cling_Utils {
-  requires cplusplus
-  umbrella "Utils"
-  module * { export * }
-}


### PR DESCRIPTION
The improvement is by 20% from (260MB to 210MB) and within the reach of the PCH.