### PR TITLE
 [RDF] Remove RDF from the build in case the platform is a 32bits one

### DIFF
--- a/bindings/pyroot/CMakeLists.txt
+++ b/bindings/pyroot/CMakeLists.txt
@@ -13,11 +13,26 @@ if(WIN32)
                 -include:_G__cpp_setupG__Thread
                 -include:_G__cpp_setupG__MathCore)
 endif()
+
+set(PYROOT_HEADERS inc/TPyFitFunction.h    inc/TPython.h
+                   inc/TPyArg.h            inc/TPyROOTApplication.h
+                   inc/TTreeAsFlatMatrix.h inc/TPyDispatcher.h
+                   inc/TPyReturn.h         inc/TPyException.h
+                   inc/TPySelector.h)
+
+set(PYROOT_PKG_DEPENDENCIES Core MathCore Net Rint Tree ROOTVecOps ROOTDataFrame)
+
+if( CMAKE_SIZEOF_VOID_P EQUAL 4 ) # With this we exclude ROOTDataFrame on 32 bits builds
+  list(REMOVE_ITEM PYROOT_HEADERS inc/TTreeAsFlatMatrix.h)
+  list(REMOVE_ITEM PYROOT_PKG_DEPENDENCIES ROOTDataFrame)
+endif()
+
 ROOT_STANDARD_LIBRARY_PACKAGE(PyROOT
                               NO_INSTALL_HEADERS
+                              HEADERS ${PYROOT_HEADERS}
                               DICTIONARY_OPTIONS "-writeEmptyRootPCM"
                               LIBRARIES Core Net Tree MathCore Rint ${PYTHON_LIBRARIES}
-                              DEPENDENCIES Core MathCore Net Rint Tree ROOTDataFrame ROOTVecOps)
+                              DEPENDENCIES ${PYROOT_PKG_DEPENDENCIES})
 ROOT_LINKER_LIBRARY(JupyROOT ../JupyROOT/src/*.cxx DEPENDENCIES Core CMAKENOEXPORT)
 
 if(MSVC)

--- a/bindings/pyroot/ROOT.py
+++ b/bindings/pyroot/ROOT.py
@@ -168,7 +168,7 @@ if not _builtin_cppyy:
 
 ### configuration ---------------------------------------------------------------
 class _Configuration( object ):
-   __slots__ = [ 'IgnoreCommandLineOptions', 'StartGuiThread', 'ExposeCppMacros', 
+   __slots__ = [ 'IgnoreCommandLineOptions', 'StartGuiThread', 'ExposeCppMacros',
                  '_gts', 'DisableRootLogon' ]
 
    def __init__( self ):
@@ -379,7 +379,9 @@ def _TTreeAsMatrix(self, columns=None, exclude=None, dtype="double", return_labe
     else:
         return reshaped_matrix_np
 
-_root.CreateScopeProxy( "TTree" ).AsMatrix = _TTreeAsMatrix
+# This Pythonisation is there only for 64 bits builds
+if (sys.maxsize > 2**32): # https://docs.python.org/3/library/platform.html#cross-platform
+    _root.CreateScopeProxy( "TTree" ).AsMatrix = _TTreeAsMatrix
 
 
 ### RINT command emulation ------------------------------------------------------
@@ -702,7 +704,7 @@ class ModuleFacade( types.ModuleType ):
             import time
             def _inputhook(context):
                while not context.input_is_ready():
-                  _root.gSystem.ProcessEvents()  
+                  _root.gSystem.ProcessEvents()
                   time.sleep( 0.01 )
             pt_inputhooks.register('ROOT',_inputhook)
             if get_ipython() : get_ipython().run_line_magic('gui', 'ROOT')

--- a/bindings/pyroot/test/CMakeLists.txt
+++ b/bindings/pyroot/test/CMakeLists.txt
@@ -3,7 +3,10 @@ ROOT_ADD_PYUNITTEST(pyroot_list_initialization list_initialization.py)
 ROOT_ADD_PYUNITTEST(pyroot_pretty_printing pretty_printing.py)
 ROOT_ADD_PYUNITTEST(pyroot_rvec rvec.py)
 if(NUMPY_FOUND)
-    ROOT_ADD_PYUNITTEST(pyroot_array_interface array_interface.py)
+  ROOT_ADD_PYUNITTEST(pyroot_array_interface array_interface.py)
+  # this excludes RDF for 32 bits builds because of clang/gcc abi issues
+  if( CMAKE_SIZEOF_VOID_P EQUAL 8 )
     ROOT_ADD_PYUNITTEST(pyroot_ttree_asmatrix ttree_asmatrix.py)
+  endif()
 endif()
 

--- a/build/unix/makepchinput.py
+++ b/build/unix/makepchinput.py
@@ -229,7 +229,7 @@ def isDirForPCH(dirName):
    Check if the directory corresponds to a module whose headers must belong to
    the PCH
    """
-   PCHPatternsWhitelist = ("interpreter/",
+   PCHPatternsWhitelist = ["interpreter/",
                            "core/",
                            "io/io",
                            "net/net",
@@ -246,8 +246,8 @@ def isDirForPCH(dirName):
                            "bindings/pyroot",
                            "roofit/",
                            "tmva",
-                           "main")
-   PCHPatternsBlacklist = ("graf2d/qt",
+                           "main"]
+   PCHPatternsBlacklist = ["graf2d/qt",
                            "gui/guihtml",
                            "gui/guibuilder",
                            "math/fftw",
@@ -259,7 +259,7 @@ def isDirForPCH(dirName):
                            "math/splot",
                            "math/unuran",
                            "math/vdt",
-                           "tmva/rmva")
+                           "tmva/rmva"]
 
    accepted = isAnyPatternInString(PCHPatternsWhitelist,dirName) and \
                not isAnyPatternInString(PCHPatternsBlacklist,dirName)

--- a/build/unix/makepchinput.py
+++ b/build/unix/makepchinput.py
@@ -261,6 +261,9 @@ def isDirForPCH(dirName):
                            "math/vdt",
                            "tmva/rmva"]
 
+   if (sys.maxsize <= 2**32): # https://docs.python.org/3/library/platform.html#cross-platform
+      PCHPatternsBlacklist.append("tree/dataframe")
+
    accepted = isAnyPatternInString(PCHPatternsWhitelist,dirName) and \
                not isAnyPatternInString(PCHPatternsBlacklist,dirName)
 

--- a/config/root-config.in
+++ b/config/root-config.in
@@ -72,9 +72,14 @@ fi
 newlib="-lNew"
 rootglibs="-lGui"
 rootevelibs="-lEve -lEG -lGeom -lGed -lRGL"
-rootlibs="-lCore -lImt -lRIO -lNet -lHist -lGraf -lGraf3d -lGpad -lROOTDataFrame -lROOTVecOps -lTree -lTreePlayer\
+rootlibs="-lCore -lImt -lRIO -lNet -lHist -lGraf -lGraf3d -lGpad -lROOTVecOps -lTree -lTreePlayer\
           -lRint -lPostscript -lMatrix -lPhysics -lMathCore -lThread\
           -lMultiProc"
+
+if [ `uname -m` != 'i686' ]; then
+   rootlibs="$rootlibs -lROOTDataFrame"
+fi
+
 
 if test "$platform" = "win32"; then
    rootulibs="-include:_G__cpp_setupG__Net        \

--- a/tree/CMakeLists.txt
+++ b/tree/CMakeLists.txt
@@ -1,4 +1,6 @@
 add_subdirectory(tree)        # special CMakeLists.txt
 add_subdirectory(treeplayer)  # special CMakeLists.txt
 add_subdirectory(treeviewer)  # special CMakeLists.txt
-add_subdirectory(dataframe)  # special CMakeLists.txt
+if( CMAKE_SIZEOF_VOID_P EQUAL 8 ) # this excludes RDF for 32 bits builds because of clang/gcc abi issues
+  add_subdirectory(dataframe)  # special CMakeLists.txt
+endif()

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -196,6 +196,10 @@ if(root7)
       )
 endif()
 
+if( CMAKE_SIZEOF_VOID_P EQUAL 4 )
+  set(bits32_veto dataframe/*.C)
+endif()
+
 #---These ones are disabled !!! ------------------------------------
 set(extra_veto
   htmlex.C
@@ -246,6 +250,7 @@ set(all_veto hsimple.C
              ${classic_veto}
              ${pythia_veto}
              ${root7_veto}
+             ${bits32_veto}
              )
 
 file(GLOB_RECURSE tutorials RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.C)
@@ -397,11 +402,16 @@ if(ROOT_python_FOUND)
     list(APPEND pyveto math/Bessel.py)
     list(APPEND pyveto math/tStudent.py)
   endif()
-  
+
   list(REMOVE_ITEM pytutorials ${pyveto})
   if(ROOT_CLASSIC_BUILD)
     set(classic_veto_py dataframe/df*.py)
     list(REMOVE_ITEM pytutorials ${classic_veto_py})
+  endif()
+
+  if( CMAKE_SIZEOF_VOID_P EQUAL 4 )
+    set(bits32_veto_py dataframe/*.py)
+    list(REMOVE_ITEM pytutorials ${bits32_veto_py})
   endif()
 
   #---Python tutorials dependencies--------------------------------------


### PR DESCRIPTION
this is done until the present ABI issues between gcc and clang are
solved, most notably the ones concerning shared_ptrs.

This PR relates to roottest PR root-project/roottest#216