### PR TITLE
Updates for generation of correct relative path for core headers

### DIFF
--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -272,6 +272,7 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
                      rootcling_stage1 textinput thread unix winnt zip)
     foreach(core_folder ${core_folders})
       string(REPLACE "${CMAKE_SOURCE_DIR}/core/${core_folder}/inc/" ""  headerfiles "${headerfiles}")
+      string(REPLACE "${CMAKE_BINARY_DIR}/include/" "" headerfiles "${headerfiles}")
     endforeach()
   endif()
 
@@ -281,6 +282,7 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
   if(PROJECT_NAME STREQUAL ROOT)
     foreach(hf ${headerfiles})
       string(REPLACE "${PROJECT_SOURCE_DIR}" "" hfrel "${hf}")
+      string(REPLACE "${CMAKE_BINARY_DIR}/include/" "" hfrel "${hf}")
       # Test folders don't follow this pattern and need absolute paths,
       # so we don't run our sanity check on them.
       if(NOT "${hfrel}" MATCHES "/test/")


### PR DESCRIPTION
After removing globbing in core module, if to fetch a fresh master
some headers were not able to get a valid relative path causing next error:
-- /home/oksana/CERN_sources/root/builds/include/TArrayF.h
CMake Error at cmake/modules/RootNewMacros.cmake:292 (message):
  Header path '/home/oksana/CERN_sources/root/builds/include/TArrayF.h'
  TArrayF.h is not relative!
Call Stack (most recent call first):
  core/base/CMakeLists.txt:232 (ROOT_GENERATE_DICTIONARY)
Adding extra replacement pattern, matching - $CMAKE_BUILD_DIR/include, fixes issue.