### PR TITLE
[DF] Fix ROOT-9632: do not throw if define return type is unknown to the interpreter

### DIFF
--- a/tree/dataframe/inc/ROOT/RDFInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterface.hxx
@@ -1748,9 +1748,12 @@ private:
       auto retTypeName = RDFInternal::TypeID2TypeName(typeid(RetType));
       std::string retTypeNameFwdDecl; // different from "" only if the type does not exist
       if (retTypeName.empty()) {
-         //const auto msg =
-         //   "Return type of Define expression was not understood. Type was " + std::string(typeid(RetType).name());
-         //throw std::runtime_error(msg);
+         // If we are here, it means that the type is not known to the interpreter.
+         // We extract its name, forward declare it and add a meaningful comment.
+         // This string will be jitted flawlessly. If the user later on uses the product of this define
+         // and therefore an incomplete type, the interpreter will prompt an error and also display
+         // the comment we nicely built which reminds the user about the absence of information about
+         // this type in the interpreter.
          int errCode(0);
          retTypeName = TClassEdit::DemangleTypeIdName(typeid(RetType), errCode);
          retTypeNameFwdDecl = "class " + retTypeName + ";/* Did you forget to declare type " + retTypeName + " in the interpreter?*/";

--- a/tree/dataframe/inc/ROOT/RDFInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDFInterface.hxx
@@ -42,6 +42,7 @@
 #include "RtypesCore.h" // for ULong64_t
 #include "TAxis.h"
 #include "TChain.h"
+#include "TClassEdit.h"
 #include "TDirectory.h"
 #include "TError.h"
 #include "TGraph.h" // For Graph action
@@ -1744,13 +1745,17 @@ private:
       using NewCol_t = RDFDetail::RCustomColumn<F, CustomColumnType>;
 
       // Declare return type to the interpreter, for future use by jitted actions
-      const auto retTypeName = RDFInternal::TypeID2TypeName(typeid(RetType));
+      auto retTypeName = RDFInternal::TypeID2TypeName(typeid(RetType));
+      std::string retTypeNameFwdDecl; // different from "" only if the type does not exist
       if (retTypeName.empty()) {
-         const auto msg =
-            "Return type of Define expression was not understood. Type was " + std::string(typeid(RetType).name());
-         throw std::runtime_error(msg);
+         //const auto msg =
+         //   "Return type of Define expression was not understood. Type was " + std::string(typeid(RetType).name());
+         //throw std::runtime_error(msg);
+         int errCode(0);
+         retTypeName = TClassEdit::DemangleTypeIdName(typeid(RetType), errCode);
+         retTypeNameFwdDecl = "class " + retTypeName + ";/* Did you forget to declare type " + retTypeName + " in the interpreter?*/";
       }
-      const auto retTypeDeclaration = "namespace __tdf" + std::to_string(loopManager->GetID()) + " { using " +
+      const auto retTypeDeclaration = "namespace __tdf" + std::to_string(loopManager->GetID()) + " { " + retTypeNameFwdDecl + " using " +
                                       std::string(name) + "_type = " + retTypeName + "; }";
       gInterpreter->Declare(retTypeDeclaration.c_str());
 

--- a/tree/dataframe/test/dataframe_simple.cxx
+++ b/tree/dataframe/test/dataframe_simple.cxx
@@ -175,6 +175,18 @@ TEST_P(RDFSimpleTests, Define_jitted)
    EXPECT_DOUBLE_EQ(1., *m);
 }
 
+struct RFoo {};
+
+TEST_P(RDFSimpleTests, Define_jitted_type_unknown_to_interpreter)
+{
+   RDataFrame tdf(10);
+   auto d = tdf.Define("foo", [](){return RFoo();});
+
+   // We check that the if nothing is done with RFoo in jitted strings
+   // everything works fine
+   EXPECT_EQ(10U, *d.Count());
+}
+
 TEST_P(RDFSimpleTests, Define_jitted_complex)
 {
    // this test case (as all others) is usually run twice, in IMT and non-IMT mode,


### PR DESCRIPTION
but add a comment to the jitted code in order to obtain a clear error message if
the user tries to use this type in a jitted action/transformation later in the chain.