### PR TITLE
[Cxxmodules] Rely LazyFunctionAutoLoad for loading libraries

### DIFF
--- a/interpreter/cling/lib/Interpreter/DeclCollector.cpp
+++ b/interpreter/cling/lib/Interpreter/DeclCollector.cpp
@@ -13,6 +13,7 @@
 #include "cling/Interpreter/Transaction.h"
 #include "cling/Utils/AST.h"
 
+#include "clang/Frontend/CompilerInstance.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
@@ -236,7 +237,8 @@ namespace cling {
     assertHasTransaction(m_CurTransaction);
     Transaction::DelayCallInfo DCI(DGR, Transaction::kCCIHandleInterestingDecl);
     m_CurTransaction->append(DCI);
-    if (m_Consumer
+    // With Cxxmodules, rely on LazyFunctionAutoLoad to load libraries
+    if (m_Consumer && !m_IncrParser->getCI()->getLangOpts().Modules
         && (!comesFromASTReader(DGR) || !shouldIgnore(*DGR.begin())))
       m_Consumer->HandleTopLevelDecl(DGR);
   }

--- a/interpreter/cling/lib/Interpreter/IncrementalExecutor.h
+++ b/interpreter/cling/lib/Interpreter/IncrementalExecutor.h
@@ -56,6 +56,11 @@ namespace cling {
     ///
     std::unique_ptr<IncrementalJIT> m_JIT;
 
+    bool hasCxxModules;
+
+    // Symbols which were already notified to NotifyLazyFunctionCreators
+    std::vector<std::string> allreadyNotified;
+
     // optimizer etc passes
     std::unique_ptr<BackendPasses> m_BackendPasses;
 


### PR DESCRIPTION
"InterestingDecl"s are decls which compiler needs to know its address.
We were causing deserialization from HandleInterestingDecl to resolve
the address, but given that modules have smarter way to solve symbols
in LazyFunctionAutoLoad, we can use this instead.

This improves modules startup time by 13Mbytes.