### PR TITLE
Implement --pedantic option

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -946,7 +946,7 @@ if(cling)
     set(CLING_CXXFLAGS "${CLING_CXXFLAGS} -Wno-missing-field-initializers")
   endif()
   #---These are the libraries that we link ROOT with CLING---------------------------
-  set(CLING_LIBRARIES clingInterpreter clingMetaProcessor clingUtils)
+  set(CLING_LIBRARIES clingInterpreter clingMetaProcessor clingUtils clingUserInterface)
   add_custom_target(CLING)
   add_dependencies(CLING ${CLING_LIBRARIES})
   if (builtin_llvm)

--- a/core/base/inc/TApplication.h
+++ b/core/base/inc/TApplication.h
@@ -64,6 +64,7 @@ private:
    Bool_t             fNoLogo;          //Do not show splash screen and welcome message
    Bool_t             fQuit;            //Exit after having processed input files
    Bool_t             fUseMemstat;      //Run with TMemStat enabled
+   Bool_t             fUsePedantic;     //Run with --pedantic enabled
    TObjArray         *fFiles;           //Array of input files or C++ expression (TObjString's) specified via argv
    TString            fWorkDir;         //Working directory specified via argv
    TString            fIdleCommand;     //Command to execute while application is idle

--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -99,7 +99,7 @@ static void CallEndOfProcessCleanups()
 
 TApplication::TApplication() :
    fArgc(0), fArgv(0), fAppImp(0), fIsRunning(kFALSE), fReturnFromRun(kFALSE),
-   fNoLog(kFALSE), fNoLogo(kFALSE), fQuit(kFALSE), fUseMemstat(kFALSE),
+   fNoLog(kFALSE), fNoLogo(kFALSE), fQuit(kFALSE), fUseMemstat(kFALSE), fUsePedantic(kFALSE),
    fFiles(0), fIdleTimer(0), fSigHandler(0), fExitOnException(kDontExit),
    fAppRemote(0)
 {
@@ -123,7 +123,7 @@ TApplication::TApplication() :
 TApplication::TApplication(const char *appClassName, Int_t *argc, char **argv,
                            void * /*options*/, Int_t numOptions) :
    fArgc(0), fArgv(0), fAppImp(0), fIsRunning(kFALSE), fReturnFromRun(kFALSE),
-   fNoLog(kFALSE), fNoLogo(kFALSE), fQuit(kFALSE), fUseMemstat(kFALSE),
+   fNoLog(kFALSE), fNoLogo(kFALSE), fQuit(kFALSE), fUseMemstat(kFALSE), fUsePedantic(kFALSE),
    fFiles(0), fIdleTimer(0), fSigHandler(0), fExitOnException(kDontExit),
    fAppRemote(0)
 {
@@ -211,6 +211,9 @@ TApplication::TApplication(const char *appClassName, Int_t *argc, char **argv,
          gROOT->ProcessLine(Form("new TMemStat(\"%s\",%d,%d);",ssystem,buffersize,maxcalls));
       }
    }
+
+   if (fUsePedantic)
+      gInterpreter->CallPedantic();
 
    //Needs to be done last
    gApplication = this;
@@ -389,6 +392,9 @@ void TApplication::GetOptions(Int_t *argc, char **argv)
          Terminate(0);
       } else if (!strcmp(argv[i], "-memstat")) {
          fUseMemstat = kTRUE;
+         argv[i] = null;
+      } else if (!strcmp(argv[i], "--pedantic")) {
+         fUsePedantic = kTRUE;
          argv[i] = null;
       } else if (!strcmp(argv[i], "-b")) {
          MakeBatch();

--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -156,6 +156,7 @@ public:
    virtual Int_t    Load(const char *filenam, Bool_t system = kFALSE) = 0;
    virtual void     LoadMacro(const char *filename, EErrorCode *error = 0) = 0;
    virtual Int_t    LoadLibraryMap(const char *rootmapfile = 0) = 0;
+   virtual void     CallPedantic() = 0;
    virtual Int_t    RescanLibraryMap() = 0;
    virtual Int_t    ReloadAllSharedLibraryMaps() = 0;
    virtual Int_t    UnloadAllSharedLibraryMaps() = 0;

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -94,6 +94,7 @@ clang/LLVM technology.
 #include "clang/Sema/Sema.h"
 #include "clang/Parse/Parser.h"
 
+#include "cling/UserInterface/UserInterface.h"
 #include "cling/Interpreter/ClangInternalState.h"
 #include "cling/Interpreter/DynamicLibraryManager.h"
 #include "cling/Interpreter/Interpreter.h"
@@ -1075,6 +1076,19 @@ inline bool TCling::TUniqueString::Append(const std::string& str)
    return notPresent;
 }
 
+void TCling::CallPedantic() {
+   fPedanticInterp->installLazyFunctionCreator(llvmLazyFunctionCreator);
+   fPedanticInterp->enableDynamicLookup();
+   fPedanticInterp->getCI()->getPreprocessorOpts().DisablePCHValidation = true;
+   fPedanticInterp->getCI()->getLangOpts().SpellChecking = false;
+   const cling::InvocationOptions& Opts = fPedanticInterp->getOptions();
+
+   cling::UserInterface Ui(*fPedanticInterp);
+   Ui.runInteractively(Opts.NoLogo);
+   ::fflush(stdout);
+   ::fflush(stderr);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 ///\returns true if the module was loaded.
 static bool LoadModule(const std::string &ModuleName, cling::Interpreter &interp, bool Complain = true)
@@ -1280,6 +1294,10 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
    }
 
    fInterpreter = new cling::Interpreter(interpArgs.size(),
+                                         &(interpArgs[0]),
+                                         llvmResourceDir);
+
+   fPedanticInterp = new cling::Interpreter(interpArgs.size(),
                                          &(interpArgs[0]),
                                          llvmResourceDir);
 

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -111,6 +111,7 @@ private: // Data Members
    TObjArray*      fRootmapFiles;     // Loaded rootmap files.
    Bool_t          fLockProcessLine;  // True if ProcessLine should lock gInterpreterMutex.
    Bool_t          fAllowLibLoad;     // True if library load is allowed (i.e. not in rootcling)
+   cling::Interpreter*   fPedanticInterp;    // Pedantic Interpreter without any includes.
 
    cling::Interpreter*   fInterpreter;   // The interpreter.
    cling::MetaProcessor* fMetaProcessor; // The metaprocessor.
@@ -170,6 +171,7 @@ public: // Public Interface
 
    cling::Interpreter *GetInterpreterImpl() { return fInterpreter; }
 
+   void    CallPedantic();
    void    AddIncludePath(const char* path);
    void   *GetAutoLoadCallBack() const { return fAutoLoadCallBack; }
    void   *SetAutoLoadCallBack(void* cb) { void* prev = fAutoLoadCallBack; fAutoLoadCallBack = cb; return prev; }

--- a/interpreter/cling/lib/CMakeLists.txt
+++ b/interpreter/cling/lib/CMakeLists.txt
@@ -8,6 +8,7 @@
 
 add_subdirectory(Interpreter)
 add_subdirectory(MetaProcessor)
+add_subdirectory(UserInterface)
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/UserInterface/textinput OR
    CLING_INCLUDE_TESTS)
    add_subdirectory(UserInterface)


### PR DESCRIPTION
This option gives clean/raw Cling without any includes. This is intended
to be used for debugging purposes.

```
[yuka@yuka-arch module-release]$ bin/root.exe --pedantic

****************** CLING ******************
* Type C++ code and press enter to run it *
*             Type .q to exit             *
*******************************************
[cling]$ int a = 1;
[cling]$ a
(int) 1
[cling]$ std::vector<int> b;
input_line_7:2:7: error: no member named 'vector' in namespace 'std'
 std::vector<int> b;
 ~~~~~^
input_line_7:2:17: error: expected '(' for function-style cast or type construction
 std::vector<int> b;
             ~~~^
input_line_7:2:19: error: use of undeclared identifier 'b'
 std::vector<int> b;
                  ^
[cling]$ #include <vector>
[cling]$ std::vector<int> b;
[cling]$ b = {1,2,3}
(std::vector &) { 1, 2, 3 }
```