### PR TITLE
[RDF,Tutorial] Fetch file for NanoAOD tutorial from root.cern.ch/files

### DIFF
--- a/tutorials/dataframe/df102_NanoAODDimuonAnalysis.C
+++ b/tutorials/dataframe/df102_NanoAODDimuonAnalysis.C
@@ -31,7 +31,7 @@ void df102_NanoAODDimuonAnalysis()
    ROOT::EnableImplicitMT();
 
    // Create dataframe from NanoAOD file
-   ROOT::RDataFrame df("Events", "NanoAOD_DoubleMuon_CMS2011OpenData.root");
+   ROOT::RDataFrame df("Events", "http://root.cern.ch/files/NanoAOD_DoubleMuon_CMS2011OpenData.root");
 
    // Select events with more than two muons
    auto df_filtered = df.Filter("nMuon>=2", "More than two muons");


### PR DESCRIPTION
Fixes [these](http://cdash.cern.ch/testDetails.php?test=51845718&build=557493) kind of build errors due to missing file.

@Axel-Naumann Are the tutorial as well run in the CI/ nightlies? Since the file has 1.5GB, this could create some traffic to http://root.cern.ch/.