### PR TITLE
Add possibility to specify number of threads in PyKeras and set specific Tensorflow session config options

### DIFF
--- a/tmva/pymva/inc/TMVA/MethodPyKeras.h
+++ b/tmva/pymva/inc/TMVA/MethodPyKeras.h
@@ -74,6 +74,7 @@ namespace TMVA {
       TString fFilenameModel; // Filename of the previously exported Keras model
       UInt_t fBatchSize {0}; // Training batch size
       UInt_t fNumEpochs {0}; // Number of training epochs
+      Int_t fNumThreads {0}; // Number of CPU threads (if 0 uses default values)
       Int_t fVerbose; // Keras verbosity during training
       Bool_t fContinueTraining; // Load weights from previous training
       Bool_t fSaveBestOnly; // Store only weights with smallest validation loss

--- a/tmva/pymva/inc/TMVA/MethodPyKeras.h
+++ b/tmva/pymva/inc/TMVA/MethodPyKeras.h
@@ -69,10 +69,12 @@ namespace TMVA {
 
       void GetHelpMessage() const;
 
+      /// enumeration defining the used Keras backend
+      enum EBackendType { kUndefined = -1, kTensorFlow = 0, kTheano = 1, kCNTK = 2 };
+
       /// Get the Keras backend (can be: TensorFlow, Theano or CNTK)
-      enum EBackendType { kUndefined = -1, kTensorFlow = 0, kTheano = 1, kCNTK = 2 }; 
-      EBackendType GetKerasBackend(); 
-      TString GetKerasBackendName(); 
+      EBackendType GetKerasBackend();
+      TString GetKerasBackendName();
 
     private:
 

--- a/tmva/pymva/inc/TMVA/MethodPyKeras.h
+++ b/tmva/pymva/inc/TMVA/MethodPyKeras.h
@@ -69,6 +69,11 @@ namespace TMVA {
 
       void GetHelpMessage() const;
 
+      /// Get the Keras backend (can be: TensorFlow, Theano or CNTK)
+      enum EBackendType { kUndefined = -1, kTensorFlow = 0, kTheano = 1, kCNTK = 2 }; 
+      EBackendType GetKerasBackend(); 
+      TString GetKerasBackendName(); 
+
     private:
 
       TString fFilenameModel; // Filename of the previously exported Keras model
@@ -82,6 +87,7 @@ namespace TMVA {
       TString fLearningRateSchedule; // Set new learning rate at specific epochs
       TString fTensorBoard;          // Store log files during training
       TString fNumValidationString;  // option string defining the number of validation events
+      TString fGpuOptions;    // GPU options (for Tensorflow to set in session_config.gpu_options)
 
       bool fModelIsSetup = false; // flag whether model is loaded, neede for getMvaValue during evaluation
       float* fVals = nullptr; // variables array used for GetMvaValue

--- a/tmva/pymva/src/MethodPyKeras.cxx
+++ b/tmva/pymva/src/MethodPyKeras.cxx
@@ -161,26 +161,35 @@ void MethodPyKeras::ProcessOptions() {
       fFilenameTrainedModel = GetWeightFileDir() + "/TrainedModel_" + GetName() + ".h5";
    }
 
-   // set up number of threads
-   // this code should be added as first thing using Keras
-   int num_threads = fNumThreads; 
-   std::cout << "init Pykeras with " << num_threads << std::endl;
-   if (num_threads > 0) {
-      // check if tensorflow backend
-      PyRunString("keras_backend =  keras.backend.backend()");
-      PyObject * keras_backend = PyDict_GetItemString(fLocalNS,"keras_backend");
-      char * keras_backend_str = PyString_AsString(keras_backend); 
-      if (keras_backend_str != nullptr && TString(keras_backend_str) == "tensorflow")  { 
-         Log() << kINFO << "Using tensorflow backend with the given " << num_threads << " threads " << Endl;
-         PyRunString("import tensorflow as tf");
-         PyRunString("from keras.backend import tensorflow_backend as K");
-         PyRunString(TString::Format("session_conf = tf.ConfigProto(intra_op_parallelism_threads=%d,inter_op_parallelism_threads=%d)",num_threads,num_threads));
-         PyRunString("sess = tf.Session(config=session_conf)"); 
-         PyRunString("K.set_session(sess)");
+   // set here some specific options for Tensorflow backend
+   //  -  when using tensorflow gpu set option to allow memory growth to avoid allocating all memory
+   //  -  set up number of threads for CPU if NumThreads option was specified
+
+   // check first if using tensorflow backend
+   PyRunString("keras_backend_is_tf =  keras.backend.backend() == \"tensorflow\"");
+   PyObject * keras_backend_is_tf = PyDict_GetItemString(fLocalNS,"keras_backend_is_tf");
+   if (keras_backend_is_tf != nullptr && keras_backend_is_tf == Py_True)  {
+      Log() << kINFO << "Using tensorflow backend - setting special config options "  << Endl;
+      PyRunString("import tensorflow as tf");
+      PyRunString("from keras.backend import tensorflow_backend as K");
+      // in case specify number of threads
+      int num_threads = fNumThreads;
+      if (num_threads > 0) {
+         std::cout << "init Pykeras with " << num_threads << std::endl;
+         PyRunString(TString::Format("session_conf = tf.ConfigProto(intra_op_parallelism_threads=%d,inter_op_parallelism_threads=%d)",
+                                     num_threads,num_threads));
       }
-      else { 
-         Log() << kWARNING << "Cannot set the given " << num_threads << " threads when using " << keras_backend_str << " backend"  << Endl;
-      }
+      else
+         PyRunString("session_conf = tf.ConfigProto()");
+
+      PyRunString("session_conf.gpu_options.allow_growth = True"); // for GPU's (needed for new RTX cards)
+      PyRunString("sess = tf.Session(config=session_conf)");
+      PyRunString("K.set_session(sess)");
+
+   }
+   else {
+      if (fNumThreads > 0)
+         Log() << kWARNING << "Cannot set the given " << fNumThreads << " threads when not using tensorflow as  backend"  << Endl;
    }
 
    // Setup model, either the initial model from `fFilenameModel` or


### PR DESCRIPTION
Add a new  option in PyKeras to select the number of running threads when running keras with tensorflow.

If nothing is specified, tensor flow normally runs by default on all available cores