### PR TITLE
ROOT-9595: Replace XrdSecEntity::Reset() with assignment to default object

### DIFF
--- a/proof/proofd/src/XrdProofdProtocol.cxx
+++ b/proof/proofd/src/XrdProofdProtocol.cxx
@@ -524,7 +524,7 @@ void XrdProofdProtocol::Reset()
       fAuthProt->Delete();
       fAuthProt = 0;
    }
-   fSecEntity.Reset();
+   fSecEntity = XrdSecEntity();
    // Cleanup existing XrdProofdResponse objects
    std::vector<XrdProofdResponse *>::iterator ii = fResponses.begin(); // One per each logical connection
    while (ii != fResponses.end()) {


### PR DESCRIPTION
`XrdSecEntity::Reset()` is only available in newer versions of XRootD.

Fixes [ROOT-9595](https://sft.its.cern.ch/jira/browse/ROOT-9595).