### PR TITLE
Remove warnings discovered by -Wunused-private-field (Clang 8)

### DIFF
--- a/interpreter/llvm/src/include/llvm/CodeGen/PBQP/Solution.h
+++ b/interpreter/llvm/src/include/llvm/CodeGen/PBQP/Solution.h
@@ -29,11 +29,6 @@ namespace PBQP {
     using SelectionsMap = std::map<GraphBase::NodeId, unsigned>;
     SelectionsMap selections;
 
-    unsigned r0Reductions = 0;
-    unsigned r1Reductions = 0;
-    unsigned r2Reductions = 0;
-    unsigned rNReductions = 0;
-
   public:
     /// \brief Initialise an empty solution.
     Solution() = default;


### PR DESCRIPTION
 Fix in LLVM trunk: https://reviews.llvm.org/rL317091