### PR TITLE
Fix a warning about redefinition of DNNCPU macro for Clang 8.0.0

### DIFF
--- a/tmva/tmva/inc/TMVA/MethodDNN.h
+++ b/tmva/tmva/inc/TMVA/MethodDNN.h
@@ -53,17 +53,11 @@
 #include "TMVA/DNN/Architectures/Reference.h"
 
 #ifdef R__HAS_TMVACPU
-#define DNNCPU
-#endif
-#ifdef R__HAS_TMVAGPU
-#define DNNCUDA
-#endif
-
-#ifdef DNNCPU
+#define DNNCPU 1
 #include "TMVA/DNN/Architectures/Cpu.h"
 #endif
-
-#ifdef DNNCUDA
+#ifdef R__HAS_TMVAGPU
+#define DNNCUDA 1
 #include "TMVA/DNN/Architectures/Cuda.h"
 #endif
 


### PR DESCRIPTION
Fix to avoid redefinition of injected value of macro in test stressTMVA. Visible for C++ module build for Clang 8.0.0:
```
In file included from <module-includes>:26:  ../build/include/TMVA/MethodDNN.h:56:9: warning: 'DNNCPU' macro redefined [-Wmacro-redefined]

#define DNNCPU

While building module 'TMVA' imported from /.../root/test/stressTMVA.cxx:70: In file included from <built-in>:379:
#define DNNCPU 1
```


