### PR TITLE
[DF] ROOT-9628: do not crash when dealing with corrupted files

### DIFF
--- a/tree/dataframe/src/RDFNodes.cxx
+++ b/tree/dataframe/src/RDFNodes.cxx
@@ -483,7 +483,7 @@ void RLoopManager::RunTreeProcessorMT()
 void RLoopManager::RunTreeReader()
 {
    TTreeReader r(fTree.get());
-   if (0 == fTree->GetEntriesFast())
+   if (0 == fTree->GetEntries())
       return;
    InitNodeSlots(&r, 0);
 


### PR DESCRIPTION
in case keys could not be recovered, the file was made a Zombie
and caused the system to crash.
Relates to https://github.com/root-project/roottest/pull/217