### PR TITLE
http: use proper arguments of pthread_setname_np on OS X

### DIFF
--- a/net/http/civetweb/civetweb.c
+++ b/net/http/civetweb/civetweb.c
@@ -2697,8 +2697,13 @@ mg_set_thread_name(const char *name)
 #endif
 #elif defined(_GNU_SOURCE) && defined(__GLIBC__) \
     && ((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 12)))
-	/* pthread_setname_np first appeared in glibc in version 2.12*/
-	(void)pthread_setname_np(pthread_self(), threadName);
+   /* pthread_setname_np first appeared in glibc in version 2.12*/
+#if defined(__MACH__)
+   /* OS X only current thread name can be changed */
+   (void)pthread_setname_np(threadName);
+#else
+   (void)pthread_setname_np(pthread_self(), threadName);
+#endif
 #elif defined(__linux__)
 	/* on linux we can use the old prctl function */
 	(void)prctl(PR_SET_NAME, threadName, 0, 0, 0);


### PR DESCRIPTION
This is alternative to #2581 
Lets check if it compiles better