### PR TITLE
[TMVA] root-8988 -- Validate batchsize before training

### DIFF
--- a/tmva/tmva/src/MethodDL.cxx
+++ b/tmva/tmva/src/MethodDL.cxx
@@ -1377,6 +1377,21 @@ void MethodDL::Train()
       return;
    }
 
+   for (TTrainingSettings & settings : fTrainingSettings) {
+      size_t nTrainingSamples = GetEventCollection(Types::kTraining).size();
+      size_t nTestSamples = GetEventCollection(Types::kTesting).size();
+
+      if (nTrainingSamples < settings.batchSize or
+          nTestSamples < settings.batchSize) {
+         Log() << kFATAL << "Number of samples in the datasets are train: ("
+                         << nTrainingSamples << ") test: (" << nTestSamples
+                         << "). One of these is smaller than the batch size of "
+                         << settings.batchSize << ". Please increase the batch"
+                         << " size to be at least the same size as the smallest"
+                         << " of them." << Endl;
+      }
+  }
+
    // using for training same scalar type defined for the prediction
    if (this->GetArchitectureString() == "GPU") {
 #ifdef R__HAS_TMVAGPU

--- a/tmva/tmva/src/MethodDNN.cxx
+++ b/tmva/tmva/src/MethodDNN.cxx
@@ -659,6 +659,24 @@ void TMVA::MethodDNN::Train()
       fIPyMaxIter = 100;
    }
 
+   for (TTrainingSettings & settings : fTrainingSettings) {
+      size_t nValidationSamples = GetNumValidationSamples();
+      size_t nTrainingSamples = GetEventCollection(Types::kTraining).size() - nValidationSamples;
+      size_t nTestSamples = nValidationSamples;
+
+      if (nTrainingSamples < settings.batchSize or
+          nValidationSamples < settings.batchSize or
+          nTestSamples < settings.batchSize) {
+         Log() << kFATAL << "Number of samples in the datasets are train: "
+                         << nTrainingSamples << " valid: " << nValidationSamples
+                         << " test: " << nTestSamples << ". "
+                         << "One of these is smaller than the batch size of "
+                         << settings.batchSize << ". Please increase the batch"
+                         << " size to be at least the same size as the smallest"
+                         << " of these values." << Endl;
+      }
+  }
+
    if (fArchitectureString == "GPU") {
        TrainGpu();
        if (!fExitFromTraining) fIPyMaxIter = fIPyCurrentIter;


### PR DESCRIPTION
In MethodDNN one could start training with a batch size larger than the number of events in training leading to non-sensical output. TMVA now properly warns (fatal warning) and suggests a fix (decrease batch size).