### PR TITLE
[DF] Rename {T => R}SlotStack, move it to its own header and source files

### DIFF
--- a/tree/dataframe/inc/ROOT/RDFNodes.hxx
+++ b/tree/dataframe/inc/ROOT/RDFNodes.hxx
@@ -30,7 +30,7 @@
 #include <functional>
 #include <limits>
 #include <map>
-#include <numeric> // std::accumulate (FillReport), std::iota (TSlotStack)
+#include <numeric> // std::accumulate (FillReport), std::iota (RSlotStack)
 #include <stack>
 #include <string>
 #include <thread>
@@ -56,7 +56,7 @@ class GraphCreatorHelper;
 // indexed by thread ids.
 // WARNING: this class does not work as a regular stack. The size is
 // fixed at construction time and no blocking is foreseen.
-class TSlotStack {
+class RSlotStack {
 private:
    unsigned int &GetCount();
    unsigned int &GetIndex();
@@ -65,8 +65,8 @@ private:
    ROOT::TRWSpinLock fRWLock;
 
 public:
-   TSlotStack() = delete;
-   TSlotStack(unsigned int size) : fCursor(size), fBuf(size) { std::iota(fBuf.begin(), fBuf.end(), 0U); }
+   RSlotStack() = delete;
+   RSlotStack(unsigned int size) : fCursor(size), fBuf(size) { std::iota(fBuf.begin(), fBuf.end(), 0U); }
    void ReturnSlot(unsigned int slotNumber);
    unsigned int GetSlot();
    std::map<std::thread::id, unsigned int> fCountMap;

--- a/tree/dataframe/inc/ROOT/RDFNodes.hxx
+++ b/tree/dataframe/inc/ROOT/RDFNodes.hxx
@@ -20,7 +20,6 @@
 #include "ROOT/RIntegerSequence.hxx"
 #include "ROOT/RMakeUnique.hxx"
 #include "ROOT/RVec.hxx"
-#include "ROOT/TRWSpinLock.hxx"
 #include "ROOT/TypeTraits.hxx"
 #include "TError.h"
 #include "TTreeReaderArray.h"
@@ -30,10 +29,8 @@
 #include <functional>
 #include <limits>
 #include <map>
-#include <numeric> // std::accumulate (FillReport), std::iota (RSlotStack)
 #include <stack>
 #include <string>
-#include <thread>
 #include <tuple>
 #include <type_traits>
 #include <vector>
@@ -51,31 +48,8 @@ namespace Internal {
 namespace RDF {
 class RActionBase;
 class GraphCreatorHelper;
-
-// This is an helper class to allow to pick a slot resorting to a map
-// indexed by thread ids.
-// WARNING: this class does not work as a regular stack. The size is
-// fixed at construction time and no blocking is foreseen.
-class RSlotStack {
-private:
-   unsigned int &GetCount();
-   unsigned int &GetIndex();
-   unsigned int fCursor;
-   std::vector<unsigned int> fBuf;
-   ROOT::TRWSpinLock fRWLock;
-
-public:
-   RSlotStack() = delete;
-   RSlotStack(unsigned int size) : fCursor(size), fBuf(size) { std::iota(fBuf.begin(), fBuf.end(), 0U); }
-   void ReturnSlot(unsigned int slotNumber);
-   unsigned int GetSlot();
-   std::map<std::thread::id, unsigned int> fCountMap;
-   std::map<std::thread::id, unsigned int> fIndexMap;
-};
-} // namespace RDF
-} // namespace Internal
-
-
+} // ns RDF
+} // ns Internal
 
 namespace Detail {
 namespace RDF {

--- a/tree/dataframe/inc/ROOT/RSlotStack.hxx
+++ b/tree/dataframe/inc/ROOT/RSlotStack.hxx
@@ -1,0 +1,48 @@
+// Author: Enrico Guiraud, Danilo Piparo CERN  03/2017
+
+/*************************************************************************
+ * Copyright (C) 1995-2016, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_RSLOTSTACK
+#define ROOT_RSLOTSTACK
+
+#include "ROOT/TRWSpinLock.hxx"
+
+#include <map>
+#include <thread>
+#include <vector>
+
+namespace ROOT {
+namespace Internal {
+namespace RDF {
+
+/// This is an helper class to allow to pick a slot resorting to a map
+/// indexed by thread ids.
+/// WARNING: this class does not work as a regular stack. The size is
+/// fixed at construction time and no blocking is foreseen.
+class RSlotStack {
+private:
+   unsigned int &GetCount();
+   unsigned int &GetIndex();
+   unsigned int fCursor;
+   std::vector<unsigned int> fBuf;
+   ROOT::TRWSpinLock fRWLock;
+
+public:
+   RSlotStack() = delete;
+   RSlotStack(unsigned int size);
+   void ReturnSlot(unsigned int slotNumber);
+   unsigned int GetSlot();
+   std::map<std::thread::id, unsigned int> fCountMap;
+   std::map<std::thread::id, unsigned int> fIndexMap;
+};
+} // ns RDF
+} // ns Internal
+} // ns ROOT
+
+#endif

--- a/tree/dataframe/src/RSlotStack.cxx
+++ b/tree/dataframe/src/RSlotStack.cxx
@@ -1,0 +1,84 @@
+// Author: Enrico Guiraud, Danilo Piparo CERN  03/2017
+
+/*************************************************************************
+ * Copyright (C) 1995-2016, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include <ROOT/RSlotStack.hxx>
+#include <TError.h> // R__ASSERT
+
+#include <limits>
+#include <numeric>
+
+ROOT::Internal::RDF::RSlotStack::RSlotStack(unsigned int size) : fCursor(size), fBuf(size)
+{
+   std::iota(fBuf.begin(), fBuf.end(), 0U);
+}
+
+unsigned int &ROOT::Internal::RDF::RSlotStack::GetCount()
+{
+   const auto tid = std::this_thread::get_id();
+   {
+      ROOT::TRWSpinLockReadGuard rg(fRWLock);
+      auto it = fCountMap.find(tid);
+      if (fCountMap.end() != it)
+         return it->second;
+   }
+
+   {
+      ROOT::TRWSpinLockWriteGuard rg(fRWLock);
+      return (fCountMap[tid] = 0U);
+   }
+}
+unsigned int &ROOT::Internal::RDF::RSlotStack::GetIndex()
+{
+   const auto tid = std::this_thread::get_id();
+
+   {
+      ROOT::TRWSpinLockReadGuard rg(fRWLock);
+      if (fIndexMap.end() != fIndexMap.find(tid))
+         return fIndexMap[tid];
+   }
+
+   {
+      ROOT::TRWSpinLockWriteGuard rg(fRWLock);
+      return (fIndexMap[tid] = std::numeric_limits<unsigned int>::max());
+   }
+}
+
+void ROOT::Internal::RDF::RSlotStack::ReturnSlot(unsigned int slotNumber)
+{
+   auto &index = GetIndex();
+   auto &count = GetCount();
+   R__ASSERT(count > 0U && "RSlotStack has a reference count relative to an index which will become negative.");
+   count--;
+   if (0U == count) {
+      index = std::numeric_limits<unsigned int>::max();
+      ROOT::TRWSpinLockWriteGuard guard(fRWLock);
+      fBuf[fCursor++] = slotNumber;
+      R__ASSERT(fCursor <= fBuf.size() &&
+                "RSlotStack assumes that at most a fixed number of values can be present in the "
+                "stack. fCursor is greater than the size of the internal buffer. This violates "
+                "such assumption.");
+   }
+}
+
+unsigned int ROOT::Internal::RDF::RSlotStack::GetSlot()
+{
+   auto &index = GetIndex();
+   auto &count = GetCount();
+   count++;
+   if (std::numeric_limits<unsigned int>::max() != index)
+      return index;
+   ROOT::TRWSpinLockWriteGuard guard(fRWLock);
+   R__ASSERT(fCursor > 0 &&
+             "RSlotStack assumes that a value can be always obtained. In this case fCursor is <=0 and this "
+             "violates such assumption.");
+   index = fBuf[--fCursor];
+   return index;
+}
+

--- a/tree/dataframe/test/dataframe_nodes.cxx
+++ b/tree/dataframe/test/dataframe_nodes.cxx
@@ -1,5 +1,6 @@
 #include <ROOT/RDataFrame.hxx>
 #include <ROOT/RDFNodes.hxx>
+#include <ROOT/RSlotStack.hxx>
 #include <TSystem.h>
 
 #include <mutex>

--- a/tree/dataframe/test/dataframe_nodes.cxx
+++ b/tree/dataframe/test/dataframe_nodes.cxx
@@ -7,20 +7,20 @@
 
 #include "gtest/gtest.h"
 
-TEST(RDataFrameNodes, TSlotStackCheckSameThreadSameSlot)
+TEST(RDataFrameNodes, RSlotStackCheckSameThreadSameSlot)
 {
    unsigned int n(7);
-   ROOT::Internal::RDF::TSlotStack s(n);
+   ROOT::Internal::RDF::RSlotStack s(n);
    EXPECT_EQ(s.GetSlot(), s.GetSlot());
 }
 
 #ifndef NDEBUG
 
-TEST(RDataFrameNodes, TSlotStackGetOneTooMuch)
+TEST(RDataFrameNodes, RSlotStackGetOneTooMuch)
 {
    auto theTest = []() {
       unsigned int n(2);
-      ROOT::Internal::RDF::TSlotStack s(n);
+      ROOT::Internal::RDF::RSlotStack s(n);
 
       std::vector<std::thread> ts;
 
@@ -32,17 +32,17 @@ TEST(RDataFrameNodes, TSlotStackGetOneTooMuch)
          t.join();
    };
 
-   EXPECT_DEATH(theTest(), "TSlotStack assumes that a value can be always obtained.");
+   EXPECT_DEATH(theTest(), "RSlotStack assumes that a value can be always obtained.");
 }
 
-TEST(RDataFrameNodes, TSlotStackPutBackTooMany)
+TEST(RDataFrameNodes, RSlotStackPutBackTooMany)
 {
    auto theTest = []() {
-      ROOT::Internal::RDF::TSlotStack s(1);
+      ROOT::Internal::RDF::RSlotStack s(1);
       s.ReturnSlot(0);
    };
 
-   EXPECT_DEATH(theTest(), "TSlotStack has a reference count relative to an index which will become negative");
+   EXPECT_DEATH(theTest(), "RSlotStack has a reference count relative to an index which will become negative");
 }
 
 #endif


### PR DESCRIPTION
This is the first change of a series of PRs that decouples the different RDF nodes from each other and, to make sure they stay decoupled, separates them in different headers and source files