### PR TITLE
[cxxmodule] Fix df tests by declaring RuntimePrintValue at Interprete…

### DIFF
--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -398,6 +398,7 @@ namespace cling {
     if (!NoRuntime) {
       if (LangOpts.CPlusPlus) {
         Strm << "#include \"cling/Interpreter/RuntimeUniverse.h\"\n";
+        Strm << "#include \"cling/Interpreter/RuntimePrintValue.h\"\n";
         if (EmitDefinitions)
           Strm << "namespace cling { class Interpreter; namespace runtime { "
                   "Interpreter* gCling=(Interpreter*)" << ThisP << ";}}\n";


### PR DESCRIPTION
…r init time

This declaration will be a no-op when we enable Cling module again (see
2577).

It looks that Cling users(in other part of ROOT code) are treating printValue
function as an utility function of Interpreter which must be available at their code's
initialization time (E.g. This failure was introduced by 40f3fa94677).
So I think it makes sense to make this printValue function available at
Interpreter's initialization time.