### PR TITLE
[TMVA] RTensor: Proposal for a C++ container with shape information

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
@@ -3,6 +3,9 @@ set(py_sources
   ROOT/pythonization/__init__.py
   ROOT/pythonization/_ttree.py
   ROOT/pythonization/_generic.py
+  ROOT/pythonization/_rvec.py
+  ROOT/pythonization/_rtensor.py
+  ROOT/pythonization/_stl_vector.py
 )
 
 set(sources
@@ -10,6 +13,7 @@ set(sources
   src/PyROOTStrings.cxx
   src/PyROOTWrapper.cxx
   src/TTreePyz.cxx
+  src/RTensorPyz.cxx
   src/GenericPyz.cxx
   src/Helpers.cxx
 )

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_rtensor.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_rtensor.py
@@ -1,0 +1,49 @@
+from libROOTPython import GetEndianess, GetVectorDataPointer, GetSizeOfType, AddRTensorGetSetItem
+from ROOT import pythonization
+from ROOT.pythonization._rvec import _array_interface_dtypes, _array_interface_dtype_map
+
+
+def get_array_interface(self):
+    cppname = type(self).__cppname__
+    for dtype in _array_interface_dtypes:
+        if cppname.endswith("<{}>".format(dtype)):
+            dtype_numpy = _array_interface_dtype_map[dtype]
+            dtype_size = GetSizeOfType(dtype)
+            endianess = GetEndianess()
+            shape = self.GetShape()
+            rvec = self.GetVector()
+            pointer = GetVectorDataPointer(rvec, type(rvec).__cppname__)
+            return {
+                "shape": tuple(shape),
+                "typestr": "{}{}{}".format(endianess, dtype_numpy, dtype_size),
+                "version": 3,
+                "data": (pointer, False)
+            }
+
+
+def add_array_interface_property(klass, name):
+    if True in [
+            name.endswith("<{}>".format(dtype))
+            for dtype in _array_interface_dtypes
+    ]:
+        klass.__array_interface__ = property(get_array_interface)
+
+
+def add_getsetitem(klass, name):
+    for dtype in _array_interface_dtypes:
+        if name.endswith("<{}>".format(dtype)):
+            AddRTensorGetSetItem(klass, dtype)
+
+
+@pythonization
+def pythonize_rtensor(klass, name):
+    # Parameters:
+    # klass: class to be pythonized
+    # name: string containing the name of the class
+
+    if name.startswith("TMVA::Experimental::RTensor<"):
+        # Add numpy array interface
+        add_array_interface_property(klass, name)
+        add_getsetitem(klass, name)
+
+    return True

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_rtensor.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_rtensor.py
@@ -13,8 +13,18 @@ def get_array_interface(self):
             shape = self.GetShape()
             rvec = self.GetDataAsVec()
             pointer = GetVectorDataPointer(rvec, type(rvec).__cppname__)
+            memory_order = self.GetMemoryOrder()
+            if memory_order == '\x00':  # RowMajor
+                strides = tuple([s * dtype_size for s in self.GetStrides()])
+            elif memory_order == '\x01':  # ColumnMajor
+                strides = tuple([s * dtype_size for s in self.GetStrides()])
+            else:
+                raise Exception(
+                    "Memory order %u not implemented to generate an array interface.",
+                    memory_order)
             return {
                 "shape": tuple(shape),
+                "strides": strides,
                 "typestr": "{}{}{}".format(endianess, dtype_numpy, dtype_size),
                 "version": 3,
                 "data": (pointer, False)

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_rtensor.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_rtensor.py
@@ -11,7 +11,7 @@ def get_array_interface(self):
             dtype_size = GetSizeOfType(dtype)
             endianess = GetEndianess()
             shape = self.GetShape()
-            rvec = self.GetVector()
+            rvec = self.GetDataAsVec()
             pointer = GetVectorDataPointer(rvec, type(rvec).__cppname__)
             return {
                 "shape": tuple(shape),

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
@@ -37,6 +37,8 @@ static PyMethodDef gPyROOTMethods[] = {{(char *)"PythonizeTTree", (PyCFunction)P
                                         (char *)"Get pointer to data of vector"},
                                        {(char *)"GetSizeOfType", (PyCFunction)PyROOT::GetSizeOfType, METH_VARARGS,
                                         (char *)"Get size of data-type"},
+                                       {(char *)"AddRTensorGetSetItem", (PyCFunction)PyROOT::AddRTensorGetSetItem, METH_VARARGS,
+                                        (char *)"Add pythonizatios for __getitem__ and __setitem__ to RTensor"},
                                        {NULL, NULL, 0, NULL}};
 
 #if PY_VERSION_HEX >= 0x03000000

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
@@ -11,6 +11,7 @@ PyObject *PythonizeTTree(PyObject *self, PyObject *args);
 PyObject *GetEndianess(PyObject *self);
 PyObject *GetVectorDataPointer(PyObject *self, PyObject *args);
 PyObject *GetSizeOfType(PyObject *self, PyObject *args);
+PyObject *AddRTensorGetSetItem(PyObject *self, PyObject *args);
 
 } // namespace PyROOT
 

--- a/bindings/pyroot_experimental/PyROOT/src/RTensorPyz.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/RTensorPyz.cxx
@@ -1,0 +1,90 @@
+#include "CPyCppyy.h"
+#include "PyROOTPythonize.h"
+#include "CPPInstance.h"
+#include "Utility.h"
+
+#include "TMVA/RTensor.hxx"
+
+#include <string>
+#include <vector>
+
+using namespace CPyCppyy;
+
+inline std::vector<size_t> GetIndicesFromTuple(PyObject *obj)
+{
+   std::vector<size_t> idx;
+   for (unsigned int i = 0; i < PyTuple_Size(obj); i++)
+      idx.push_back(PyInt_AsLong(PyTuple_GetItem(obj, i)));
+   return idx;
+}
+
+template <typename dtype>
+PyObject *RTensorGetItemFloat(CPPInstance *self, PyObject *obj)
+{
+   auto cobj = (TMVA::Experimental::RTensor<dtype> *)(self->GetObject());
+   auto idx = GetIndicesFromTuple(obj);
+   return PyFloat_FromDouble(cobj->At(idx));
+}
+
+template <typename dtype>
+PyObject *RTensorGetItemInt(CPPInstance *self, PyObject *obj)
+{
+   auto cobj = (TMVA::Experimental::RTensor<dtype> *)(self->GetObject());
+   auto idx = GetIndicesFromTuple(obj);
+   return PyLong_FromLong(cobj->At(idx));
+}
+
+template <typename dtype>
+PyObject *RTensorSetItemFloat(CPPInstance *self, PyObject *obj)
+{
+   auto cobj = (TMVA::Experimental::RTensor<dtype> *)(self->GetObject());
+   std::vector<size_t> idx = GetIndicesFromTuple(PyTuple_GetItem(obj, 0));
+   cobj->At(idx) = PyFloat_AsDouble(PyTuple_GetItem(obj, 1));
+   Py_INCREF(Py_None);
+   return Py_None;
+}
+
+template <typename dtype>
+PyObject *RTensorSetItemInt(CPPInstance *self, PyObject *obj)
+{
+   auto cobj = (TMVA::Experimental::RTensor<dtype> *)(self->GetObject());
+   std::vector<size_t> idx = GetIndicesFromTuple(PyTuple_GetItem(obj, 0));
+   cobj->At(idx) = PyInt_AsLong(PyTuple_GetItem(obj, 1));
+   Py_INCREF(Py_None);
+   return Py_None;
+}
+
+////////////////////////////////////////////////////////////////////////////
+/// \brief Add pythonizations for __getitem__ and __setitem__
+/// \param[in] self Always null, since this is a module function.
+/// \param[in] args Pointer to a Python tuple object containing the arguments
+/// received from Python.
+///
+/// This functions adds the pythonizations for __getitem__ and __setitem__
+/// so that elements of the object can be accessed in python with the []
+/// operator.
+PyObject *PyROOT::AddRTensorGetSetItem(PyObject * /* self */, PyObject *args)
+{
+   PyObject *pyclass = PyTuple_GetItem(args, 0);
+   std::string dtype = CPyCppyy_PyUnicode_AsString(PyTuple_GetItem(args, 1));
+   if (dtype == "float") {
+      Utility::AddToClass(pyclass, "__getitem__", (PyCFunction)RTensorGetItemFloat<float>, METH_O);
+      Utility::AddToClass(pyclass, "__setitem__", (PyCFunction)RTensorSetItemFloat<float>, METH_VARARGS);
+   } else if (dtype == "double") {
+      Utility::AddToClass(pyclass, "__getitem__", (PyCFunction)RTensorGetItemFloat<double>, METH_O);
+      Utility::AddToClass(pyclass, "__setitem__", (PyCFunction)RTensorSetItemFloat<double>, METH_VARARGS);
+   } else if (dtype == "int") {
+      Utility::AddToClass(pyclass, "__getitem__", (PyCFunction)RTensorGetItemInt<int>, METH_O);
+      Utility::AddToClass(pyclass, "__setitem__", (PyCFunction)RTensorSetItemFloat<int>, METH_VARARGS);
+   } else if (dtype == "long") {
+      Utility::AddToClass(pyclass, "__getitem__", (PyCFunction)RTensorGetItemInt<long>, METH_O);
+      Utility::AddToClass(pyclass, "__setitem__", (PyCFunction)RTensorSetItemFloat<long>, METH_VARARGS);
+   } else if (dtype == "unsigned int") {
+      Utility::AddToClass(pyclass, "__getitem__", (PyCFunction)RTensorGetItemInt<unsigned int>, METH_O);
+      Utility::AddToClass(pyclass, "__setitem__", (PyCFunction)RTensorSetItemFloat<unsigned int>, METH_VARARGS);
+   } else if (dtype == "unsigned long") {
+      Utility::AddToClass(pyclass, "__getitem__", (PyCFunction)RTensorGetItemInt<unsigned long>, METH_O);
+      Utility::AddToClass(pyclass, "__setitem__", (PyCFunction)RTensorSetItemFloat<unsigned long>, METH_VARARGS);
+   }
+   Py_RETURN_NONE;
+}

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -8,3 +8,5 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_branch_attr ttree_branch_attr.py
 ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_iterable ttree_iterable.py
                     COPY_TO_BUILDDIR TreeHelper.h)
 
+# RTensor pythonizations
+ROOT_ADD_PYUNITTEST(pyroot_rtensor rtensor.py)

--- a/bindings/pyroot_experimental/PyROOT/test/array_interface.py
+++ b/bindings/pyroot_experimental/PyROOT/test/array_interface.py
@@ -45,6 +45,42 @@ class ArrayInterface(unittest.TestCase):
             self.check_memory_adoption(root_obj, np_obj)
             self.check_shape((2, ), np_obj)
 
+    def test_RTensor(self):
+        shape = ROOT.std.vector("size_t")()
+        shape.push_back(2)
+        for dtype in self.dtypes:
+            root_obj = ROOT.TMVA.Experimental.RTensor(dtype)(shape)
+            np_obj = np.asarray(root_obj)
+            self.check_memory_adoption(root_obj, np_obj)
+            self.check_shape((2, ), np_obj)
+
+    def test_RTensor_dim2(self):
+        shape = ROOT.std.vector("size_t")((2, 2))
+        root_obj = ROOT.TMVA.Experimental.RTensor("float")(shape)
+        count = 0
+        np_ref = np.empty((2, 2), dtype="float32")
+        for i in range(2):
+            for j in range(2):
+                root_obj[i, j] = count
+                np_ref[i, j] = count
+                count += 1
+        np_obj = np.asarray(root_obj)
+        self.assertTrue((np_obj == np_ref).all())
+
+    def test_RTensor_dim3(self):
+        shape = ROOT.std.vector("size_t")((2, 2, 2))
+        root_obj = ROOT.TMVA.Experimental.RTensor("float")(shape)
+        count = 0
+        np_ref = np.empty((2, 2, 2), dtype="float32")
+        for i in range(2):
+            for j in range(2):
+                for k in range(2):
+                    root_obj[i, j, k] = count
+                    np_ref[i, j, k] = count
+                    count += 1
+        np_obj = np.asarray(root_obj)
+        self.assertTrue((np_obj == np_ref).all())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/bindings/pyroot_experimental/PyROOT/test/array_interface.py
+++ b/bindings/pyroot_experimental/PyROOT/test/array_interface.py
@@ -55,31 +55,41 @@ class ArrayInterface(unittest.TestCase):
             self.check_shape((2, ), np_obj)
 
     def test_RTensor_dim2(self):
-        shape = ROOT.std.vector("size_t")((2, 2))
-        root_obj = ROOT.TMVA.Experimental.RTensor("float")(shape)
-        count = 0
-        np_ref = np.empty((2, 2), dtype="float32")
-        for i in range(2):
-            for j in range(2):
-                root_obj[i, j] = count
-                np_ref[i, j] = count
-                count += 1
-        np_obj = np.asarray(root_obj)
-        self.assertTrue((np_obj == np_ref).all())
+        shape = ROOT.std.vector("size_t")((2, 3))
+        for memory_order in [
+                ROOT.TMVA.Experimental.MemoryOrder.RowMajor,
+                ROOT.TMVA.Experimental.MemoryOrder.ColumnMajor
+        ]:
+            root_obj = ROOT.TMVA.Experimental.RTensor("float")(shape,
+                                                               memory_order)
+            count = 0
+            np_ref = np.empty((2, 3), dtype="float32")
+            for i in range(np_ref.shape[0]):
+                for j in range(np_ref.shape[1]):
+                    root_obj[i, j] = count
+                    np_ref[i, j] = count
+                    count += 1
+            np_obj = np.asarray(root_obj)
+            self.assertTrue((np_obj == np_ref).all())
 
     def test_RTensor_dim3(self):
-        shape = ROOT.std.vector("size_t")((2, 2, 2))
-        root_obj = ROOT.TMVA.Experimental.RTensor("float")(shape)
-        count = 0
-        np_ref = np.empty((2, 2, 2), dtype="float32")
-        for i in range(2):
-            for j in range(2):
-                for k in range(2):
-                    root_obj[i, j, k] = count
-                    np_ref[i, j, k] = count
-                    count += 1
-        np_obj = np.asarray(root_obj)
-        self.assertTrue((np_obj == np_ref).all())
+        shape = ROOT.std.vector("size_t")((2, 3, 4))
+        for memory_order in [
+                ROOT.TMVA.Experimental.MemoryOrder.RowMajor,
+                ROOT.TMVA.Experimental.MemoryOrder.ColumnMajor
+        ]:
+            root_obj = ROOT.TMVA.Experimental.RTensor("float")(shape,
+                                                               memory_order)
+            count = 0
+            np_ref = np.empty((2, 3, 4), dtype="float32")
+            for i in range(np_ref.shape[0]):
+                for j in range(np_ref.shape[1]):
+                    for k in range(np_ref.shape[2]):
+                        root_obj[i, j, k] = count
+                        np_ref[i, j, k] = count
+                        count += 1
+            np_obj = np.asarray(root_obj)
+            self.assertTrue((np_obj == np_ref).all())
 
 
 if __name__ == '__main__':

--- a/bindings/pyroot_experimental/PyROOT/test/rtensor.py
+++ b/bindings/pyroot_experimental/PyROOT/test/rtensor.py
@@ -1,0 +1,41 @@
+import unittest
+import ROOT
+import numpy as np
+
+RTensor = ROOT.TMVA.Experimental.RTensor
+
+
+class ArrayInterface(unittest.TestCase):
+    dtypes = [
+        "int", "unsigned int", "long", "unsigned long", "float", "double"
+    ]
+
+    def test_getitem(self):
+        for dtype in self.dtypes:
+            data = ROOT.ROOT.VecOps.RVec(dtype)((0, 1, 2, 3, 4, 5))
+            shape = ROOT.std.vector("size_t")((2, 3))
+            x = RTensor(dtype)(data.data(), shape)
+            count = 0
+            for i in range(2):
+                for j in range(3):
+                    self.assertEqual(x[i, j], count)
+                    count += 1
+
+    def test_setitem(self):
+        for dtype in self.dtypes:
+            shape = ROOT.std.vector("size_t")((2, 3))
+            x = RTensor(dtype)(shape)
+            count = 0
+            for i in range(2):
+                for j in range(3):
+                    x[i, j] = count
+                    count += 1
+            count = 0
+            for i in range(2):
+                for j in range(3):
+                    self.assertEqual(x[i, j], count)
+                    count += 1
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bindings/pyroot_experimental/PyROOT/test/rtensor.py
+++ b/bindings/pyroot_experimental/PyROOT/test/rtensor.py
@@ -12,7 +12,7 @@ class ArrayInterface(unittest.TestCase):
 
     def test_getitem(self):
         for dtype in self.dtypes:
-            data = ROOT.ROOT.VecOps.RVec(dtype)((0, 1, 2, 3, 4, 5))
+            data = ROOT.std.vector(dtype)((0, 1, 2, 3, 4, 5))
             shape = ROOT.std.vector("size_t")((2, 3))
             x = RTensor(dtype)(data.data(), shape)
             count = 0
@@ -35,6 +35,15 @@ class ArrayInterface(unittest.TestCase):
                 for j in range(3):
                     self.assertEqual(x[i, j], count)
                     count += 1
+
+    def test_dim1(self):
+        shape = ROOT.std.vector("size_t")()
+        shape.push_back(2)
+        x = RTensor("float")(shape)
+        x[0] = 1
+        x[1] = 2
+        self.assertEqual(x[0], 1)
+        self.assertEqual(x[1], 2)
 
 
 if __name__ == '__main__':

--- a/tmva/tmva/CMakeLists.txt
+++ b/tmva/tmva/CMakeLists.txt
@@ -17,7 +17,7 @@ set(headers1 Configurable.h Factory.h  MethodBase.h MethodCompositeBase.h
 	     MethodHMatrix.h MethodPDERS.h MethodBDT.h MethodDT.h MethodSVM.h MethodBayesClassifier.h
 	     MethodFDA.h MethodMLP.h MethodBoost.h
 	     MethodPDEFoam.h MethodLD.h MethodCategory.h MethodDNN.h MethodDL.h
-             MethodCrossValidation.h)
+         MethodCrossValidation.h RTensor.hxx)
 set(headers2 TSpline2.h TSpline1.h PDF.h BinaryTree.h BinarySearchTreeNode.h BinarySearchTree.h 
 	     Timer.h RootFinder.h CrossEntropy.h DecisionTree.h DecisionTreeNode.h MisClassificationError.h 
 	     Node.h SdivSqrtSplusB.h SeparationBase.h RegressionVariance.h Tools.h Reader.h 
@@ -106,7 +106,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(TMVA
                               HEADERS ${theaders1} ${theaders2} ${theaders3} ${theaders4} ${theaders5}
                               SOURCES *.cxx ${DNN_FILES} ${DNN_CPU_FILES} DICTIONARY_OPTIONS "-writeEmptyRootPCM"
                               LIBRARIES Core MathCore Matrix ${DNN_CUDA_LIBRARIES} ${DNN_CPU_LIBRARIES}
-                              DEPENDENCIES Core RIO Hist Tree TreePlayer MLP Minuit XMLIO
+                              DEPENDENCIES Core RIO Hist Tree TreePlayer MLP Minuit XMLIO ROOTVecOps
                               INSTALL_OPTIONS ${installoptions})
 
 if(NOT gnuinstall)

--- a/tmva/tmva/inc/TMVA/RTensor.hxx
+++ b/tmva/tmva/inc/TMVA/RTensor.hxx
@@ -28,9 +28,7 @@ inline size_t GetSizeFromShape(const std::vector<size_t> &shape)
    return size;
 }
 
-/// Get cumulated shape vector. The cumulation is done from the last element to the first
-/// element of the shape vector for row-major memory order and from the first to the last
-/// element for column-major memory order.
+/// Get cumulated shape vector.
 /// This information is needed for the multi-dimensional indexing. See here:
 /// https://en.wikipedia.org/wiki/Row-_and_column-major_order
 inline std::vector<size_t> GetCumulatedShape(const std::vector<size_t> &shape, uint8_t memoryOrder)
@@ -48,9 +46,9 @@ inline std::vector<size_t> GetCumulatedShape(const std::vector<size_t> &shape, u
    } else if (memoryOrder == MemoryOrder::ColumnMajor) {
       for (size_t i = 0; i < size; i++) {
          if (i == 0) {
-            cumulatedShape[size - 1 - i] = 1;
+            cumulatedShape[i] = 1;
          } else {
-            cumulatedShape[size - 1 - i] = cumulatedShape[i - 1] * shape[i - 1];
+            cumulatedShape[i] = cumulatedShape[i - 1] * shape[i - 1];
          }
       }
    } else {
@@ -142,8 +140,9 @@ T &RTensor<T>::At(const std::vector<size_t> &idx)
 {
    size_t globalIndex = 0;
    const auto size = idx.size();
-   for (size_t i = 0; i < size; i++)
-      globalIndex += fCumulatedShape[size - 1 - i] * idx[size - 1 - i];
+   for (size_t i = 0; i < size; i++) {
+      globalIndex += fCumulatedShape[i] * idx[i];
+   }
    return *(fData.data() + globalIndex);
 }
 

--- a/tmva/tmva/inc/TMVA/RTensor.hxx
+++ b/tmva/tmva/inc/TMVA/RTensor.hxx
@@ -1,0 +1,165 @@
+#ifndef ROOT_TMVA_RTENSOR
+#define ROOT_TMVA_RTENSOR
+
+#include "ROOT/RVec.hxx"
+
+namespace TMVA {
+namespace Experimental {
+namespace Internal {
+
+/// Get size of tensor from shape vector
+inline size_t GetSizeFromShape(const std::vector<size_t> &shape)
+{
+   size_t size = 1;
+   for (auto &s : shape)
+      size *= s;
+   return size;
+}
+
+/// Get cumulated shape vector. The cumulation is done from the last element to the first
+/// element of the shape vector. This information is needed for the multi-dimensional
+/// indexing.
+inline std::vector<size_t> GetCumulatedShape(const std::vector<size_t> &shape)
+{
+   const auto size = shape.size();
+   std::vector<size_t> cumulatedShape(size);
+   for (size_t i = 0; i < size; i++) {
+      if (i == 0) {
+         cumulatedShape[size - 1 - i] = 1;
+      } else {
+         cumulatedShape[size - 1 - i] = cumulatedShape[size - 1 - i + 1] * shape[size - 1 - i + 1];
+      }
+   }
+   return cumulatedShape;
+}
+
+} // namespace TMVA::Experimental::Internal
+
+/// RTensor class
+template <typename T>
+class RTensor {
+public:
+   // Constructors
+   RTensor(const std::vector<size_t> &shape);
+   RTensor(T *data, const std::vector<size_t> &shape);
+
+   // Access elements
+   T &At(const std::vector<size_t> &idx);
+   template <typename... Idx>
+   T &operator()(Idx... idx);
+
+   // Shape modifications
+   void Reshape(const std::vector<size_t> &shape);
+
+   // Getter
+   size_t GetSize() const { return fSize; }
+   std::vector<size_t> GetShape() const { return fShape; }
+   T *GetData() { return fData.data(); }
+
+private:
+   size_t fSize;
+   std::vector<size_t> fShape;
+   std::vector<size_t> fCumulatedShape;
+   ROOT::VecOps::RVec<T> fData;
+};
+
+/// Construct a tensor from given shape and initialized with zeros
+template <typename T>
+RTensor<T>::RTensor(const std::vector<size_t> &shape)
+{
+   fShape = shape;
+   fCumulatedShape = Internal::GetCumulatedShape(shape);
+   fSize = Internal::GetSizeFromShape(shape);
+   fData = ROOT::VecOps::RVec<T>(fSize);
+}
+
+/// Construct a tensor adopting given data
+template <typename T>
+RTensor<T>::RTensor(T *data, const std::vector<size_t> &shape)
+{
+   fShape = shape;
+   fCumulatedShape = Internal::GetCumulatedShape(shape);
+   fSize = Internal::GetSizeFromShape(shape);
+   fData = ROOT::VecOps::RVec<T>(data, fSize);
+}
+
+/// Reshape tensor
+template <typename T>
+void RTensor<T>::Reshape(const std::vector<size_t> &shape)
+{
+   // TODO: assert mul(shape) == mul(new_shape)
+   fShape = shape;
+   fCumulatedShape = Internal::GetCumulatedShape(shape);
+}
+
+/// Access elements with vector of indices
+template <typename T>
+T &RTensor<T>::At(const std::vector<size_t> &idx)
+{
+   // TODO: assert idx.size() == fShape.size()
+   size_t globalIndex = 0;
+   const auto size = idx.size();
+   for (size_t i = 0; i < size; i++)
+      globalIndex += fCumulatedShape[size - 1 - i] * idx[size - 1 - i];
+   return *(fData.data() + globalIndex);
+}
+
+/// Access elements with call operator
+template <typename T>
+template <typename... Idx>
+T &RTensor<T>::operator()(Idx... idx)
+{
+   return this->At({static_cast<size_t>(idx)...});
+}
+
+/// Pretty printing
+template <typename T>
+std::ostream &operator<<(std::ostream &os, RTensor<T> &x)
+{
+   const auto shapeSize = x.GetShape().size();
+   if (shapeSize == 1) {
+      os << "{ ";
+      auto data = x.GetData();
+      const auto size = x.GetSize();
+      for (size_t i = 0; i < size; i++) {
+         os << *(data + i);
+         if (i != size - 1)
+            os << ", ";
+      }
+      os << " }";
+   } else if (shapeSize == 2) {
+      os << "{";
+      const auto shape = x.GetShape();
+      for (size_t i = 0; i < shape[0]; i++) {
+         os << " { ";
+         for (size_t j = 0; j < shape[1]; j++) {
+            os << x(i, j);
+            if (j < shape[1] - 1) {
+               os << ", ";
+            } else {
+               os << " ";
+            }
+         }
+         os << "}";
+      }
+      os << " }";
+   } else {
+      os << "{ printing not yet implemented for this dimension }";
+   }
+   return os;
+}
+
+} // namespace TMVA::Experimental
+} // namespace TMVA
+
+namespace cling {
+template <typename T>
+inline std::string printValue(TMVA::Experimental::RTensor<T> *x)
+{
+   std::stringstream ss;
+   ss << *x;
+   return ss.str();
+}
+} // namespace cling
+
+#endif // ROOT_TMVA_RTENSOR

--- a/tmva/tmva/inc/TMVA/RTensor.hxx
+++ b/tmva/tmva/inc/TMVA/RTensor.hxx
@@ -81,7 +81,7 @@ public:
    size_t GetSize() const { return fSize; }                // Return size of contiguous memory
    std::vector<size_t> GetShape() const { return fShape; } // Return shape
    T *GetData() { return fData.data(); }                   // Return pointer to data
-   ROOT::VecOps::RVec<T> GetVector() { return fData; }     // Return data as vector
+   ROOT::VecOps::RVec<T> &GetDataAsVec() { return fData; } // Return data as reference to vector
    uint8_t GetMemoryOrder() { return fMemoryOrder; }       // Return memory order
 
 private:
@@ -140,28 +140,13 @@ void RTensor<T>::Reshape(const std::vector<size_t> &shape)
 template <typename T>
 T &RTensor<T>::At(const std::vector<size_t> &idx)
 {
-   size_t globalIndex = 0;
    const auto size = idx.size();
    if (size != fShape.size()) {
       std::stringstream ss;
-      ss << "Indices { ";
-      for (size_t i = 0; i < idx.size(); i++) {
-         if (i != idx.size() - 1) {
-            ss << idx[i] << ", ";
-         } else {
-            ss << idx[i] << " }";
-         }
-      }
-      ss << " do not match shape { ";
-      for (size_t i = 0; i < fShape.size(); i++) {
-         if (i != fShape.size() - 1) {
-            ss << fShape[i] << ", ";
-         } else {
-            ss << fShape[i] << " }.";
-         }
-      }
+      ss << "Number of indices (" << size << ") do not match number of dimensions (" << fShape.size() << ").";
       throw std::runtime_error(ss.str());
    }
+   size_t globalIndex = 0;
    for (size_t i = 0; i < size; i++) {
       globalIndex += fCumulatedShape[i] * idx[i];
    }

--- a/tmva/tmva/test/CMakeLists.txt
+++ b/tmva/tmva/test/CMakeLists.txt
@@ -10,6 +10,7 @@ include_directories(${ROOT_INCLUDE_DIRS})
 ROOT_ADD_GTEST(TestRandomGenerator
                TestRandomGenerator.cxx
                LIBRARIES ${Libraries})
+ROOT_ADD_GTEST(rtensor rtensor.cxx LIBRARIES ROOTVecOps TMVA)
 
 project(tmva-tests)
 find_package(ROOT REQUIRED)

--- a/tmva/tmva/test/rtensor.cxx
+++ b/tmva/tmva/test/rtensor.cxx
@@ -1,0 +1,42 @@
+#include <gtest/gtest.h>
+#include <TMVA/RTensor.hxx>
+using namespace TMVA::Experimental;
+TEST(RTensor, GetElement)
+{
+   float data[6] = {0, 1, 2, 3, 4, 5};
+   RTensor<float> x(data, {2, 3});
+   auto shape = x.GetShape();
+   float count = 0.0;
+   for (size_t i = 0; i < shape[0]; i++) {
+      for (size_t j = 0; j < shape[1]; j++) {
+         EXPECT_EQ(count, x.At({i, j}));
+         EXPECT_EQ(count, x(i, j));
+         count++;
+      }
+   }
+}
+TEST(RTensor, SetElement)
+{
+   RTensor<float> x({2, 3});
+   auto shape = x.GetShape();
+   float count = 0.0;
+   for (size_t i = 0; i < shape[0]; i++) {
+      for (size_t j = 0; j < shape[1]; j++) {
+         x.At({i, j}) = count;
+         x(i, j) = count;
+         count++;
+      }
+   }
+   auto data = x.GetData();
+   for (size_t i = 0; i < shape.size(); i++)
+      EXPECT_EQ((float)i, *(data + i));
+}
+TEST(RTensor, AdoptMemory)
+{
+   float data[4] = {0, 0, 0, 0};
+   RTensor<float> x(data, {4});
+   for (size_t i = 0; i < 4; i++)
+      x(i) = (float)i;
+   for (size_t i = 0; i < 4; i++)
+      EXPECT_EQ((float)i, data[i]);
+}

--- a/tmva/tmva/test/rtensor.cxx
+++ b/tmva/tmva/test/rtensor.cxx
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 #include <TMVA/RTensor.hxx>
-#include <iostream> // DEBUG
 
 using namespace TMVA::Experimental;
 
@@ -59,35 +58,85 @@ TEST(RTensor, SetElement)
    }
 }
 
-TEST(RTensor, RowMajorMemoryOrder)
+TEST(RTensor, SetElementRowMajor)
 {
-   // Layout:
+   // Layout (logical):
    // 0, 1, 2
    // 3, 4, 5
-   float data[6] = {0, 1, 2, 3, 4, 5};
-   RTensor<float> x(data, {2, 3}, MemoryOrder::RowMajor);
-
+   RTensor<float> x({2, 3}, MemoryOrder::RowMajor);
    float count = 0;
    for (size_t i = 0; i < 2; i++) {
       for (size_t j = 0; j < 3; j++) {
-         EXPECT_EQ(count, x(i, j));
+         x(i, j) = count;
+         count++;
+      }
+   }
+
+   // Layout (physical):
+   // 0, 3, 1, 4, 2, 5
+   float ref[6] = {0, 1, 2, 3, 4, 5};
+   float *data = x.GetData();
+   for (size_t i = 0; i < 6; i++) {
+      EXPECT_EQ(data[i], ref[i]);
+   }
+}
+
+TEST(RTensor, SetElementColumnMajor)
+{
+   // Layout (logical):
+   // 0, 1, 2
+   // 3, 4, 5
+   RTensor<float> x({2, 3}, MemoryOrder::ColumnMajor);
+   float count = 0;
+   for (size_t i = 0; i < 2; i++) {
+      for (size_t j = 0; j < 3; j++) {
+         x(i, j) = count;
+         count++;
+      }
+   }
+
+   // Layout (physical):
+   // 0, 3, 1, 4, 2, 5
+   float ref[6] = {0, 3, 1, 4, 2, 5};
+   float *data = x.GetData();
+   for (size_t i = 0; i < 6; i++) {
+      EXPECT_EQ(data[i], ref[i]);
+   }
+}
+
+TEST(RTensor, GetElementRowMajor)
+{
+   // Layout (physical):
+   // 0, 3, 1, 4, 2, 5
+   float data[6] = {0, 1, 2, 3, 4, 5};
+   RTensor<float> x(data, {2, 3}, MemoryOrder::RowMajor);
+
+   // Layout (logical):
+   // 0, 1, 2
+   // 3, 4, 5
+   float count = 0;
+   for (size_t i = 0; i < 2; i++) {
+      for (size_t j = 0; j < 3; j++) {
+         EXPECT_EQ(x(i, j), count);
          count++;
       }
    }
 }
 
-TEST(RTensor, ColumnMajorMemoryOrder)
+TEST(RTensor, GetElementColumnMajor)
 {
-   // Layout:
-   // 0, 2, 4
-   // 1, 3, 5
-   float data[6] = {0, 2, 4, 1, 3, 5};
+   // Layout (physical):
+   // 0, 3, 1, 4, 2, 5
+   float data[6] = {0, 3, 1, 4, 2, 5};
    RTensor<float> x(data, {2, 3}, MemoryOrder::ColumnMajor);
 
+   // Layout (logical):
+   // 0, 1, 2
+   // 3, 4, 5
    float count = 0;
    for (size_t i = 0; i < 2; i++) {
       for (size_t j = 0; j < 3; j++) {
-         EXPECT_EQ(count, x(i, j));
+         EXPECT_EQ(x(i, j), count);
          count++;
       }
    }

--- a/tmva/tmva/test/rtensor.cxx
+++ b/tmva/tmva/test/rtensor.cxx
@@ -1,6 +1,31 @@
 #include <gtest/gtest.h>
 #include <TMVA/RTensor.hxx>
+#include <iostream> // DEBUG
+
 using namespace TMVA::Experimental;
+
+TEST(RTensor, AdoptMemory)
+{
+   float data[4] = {0, 0, 0, 0};
+   RTensor<float> x(data, {4});
+   for (size_t i = 0; i < 4; i++) {
+      x(i) = (float)i;
+   }
+   for (size_t i = 0; i < 4; i++) {
+      EXPECT_EQ((float)i, data[i]);
+   }
+}
+
+TEST(RTensor, InitWithZeros)
+{
+   RTensor<float> x({2, 3});
+   for (size_t i = 0; i < 2; i++) {
+      for (size_t j = 0; j < 3; j++) {
+         EXPECT_EQ(0.0, x(i, j));
+      }
+   }
+}
+
 TEST(RTensor, GetElement)
 {
    float data[6] = {0, 1, 2, 3, 4, 5};
@@ -15,6 +40,7 @@ TEST(RTensor, GetElement)
       }
    }
 }
+
 TEST(RTensor, SetElement)
 {
    RTensor<float> x({2, 3});
@@ -28,15 +54,41 @@ TEST(RTensor, SetElement)
       }
    }
    auto data = x.GetData();
-   for (size_t i = 0; i < shape.size(); i++)
+   for (size_t i = 0; i < shape.size(); i++) {
       EXPECT_EQ((float)i, *(data + i));
+   }
 }
-TEST(RTensor, AdoptMemory)
+
+TEST(RTensor, RowMajorMemoryOrder)
 {
-   float data[4] = {0, 0, 0, 0};
-   RTensor<float> x(data, {4});
-   for (size_t i = 0; i < 4; i++)
-      x(i) = (float)i;
-   for (size_t i = 0; i < 4; i++)
-      EXPECT_EQ((float)i, data[i]);
+   // Layout:
+   // 0, 1, 2
+   // 3, 4, 5
+   float data[6] = {0, 1, 2, 3, 4, 5};
+   RTensor<float> x(data, {2, 3}, MemoryOrder::RowMajor);
+
+   float count = 0;
+   for (size_t i = 0; i < 2; i++) {
+      for (size_t j = 0; j < 3; j++) {
+         EXPECT_EQ(count, x(i, j));
+         count++;
+      }
+   }
+}
+
+TEST(RTensor, ColumnMajorMemoryOrder)
+{
+   // Layout:
+   // 0, 2, 4
+   // 1, 3, 5
+   float data[6] = {0, 2, 4, 1, 3, 5};
+   RTensor<float> x(data, {2, 3}, MemoryOrder::ColumnMajor);
+
+   float count = 0;
+   for (size_t i = 0; i < 2; i++) {
+      for (size_t j = 0; j < 3; j++) {
+         EXPECT_EQ(count, x(i, j));
+         count++;
+      }
+   }
 }


### PR DESCRIPTION
A lot of code but mainly due to the tests and pythonizations. Main place to focus on is `TMVA/RTensor.hxx`.

In the following examples of the implemented features:

C++ example:

```cpp
using namespace TMVA::Experimental;
RTensor<float> x({2, 3}); // container with shape (2, 3)
x(0,0) = 1; // set element (0,0) to 1
cout << x(0, 0) << endl; // read element (0,0)
// Returns:
// 1
cout << x << endl;
// Returns:
// { { 1, 0, 0 } { 0, 0, 0 } }
```

Python example:

```python
import ROOT
x = ROOT.TMVA.Experimental.RTensor("float")((2, 3)) # container with shape (2, 3)
x[0,0] = 1 # set element (0,0)
print(x[0,0]) # read element (0,0)
# Returns:
# 1
print(x)
# Returns:
# { { 1, 0, 0 } { 0, 0, 0 } }
```

Memory adoption capability:

```cpp
using namespace TMVA::Experimental;
float data[6] = {1, 2, 3, 4, 5, 6};
RTensor<float> x(data, {2, 3}); // adopt memory with given shape
cout << x << endl;
// Returns:
// { { 1, 2, 3 } { 4, 5, 6 } }
```

Column-major and row-major memory ordering:

```cpp
using namespace TMVA::Experimental;
float data[6] = {1, 2, 3, 4, 5, 6};
RTensor<float> x(data, {2, 3}, MemoryOrder::RowMajor);
cout << x << endl;
// Returns:
// { { 1, 2, 3 } { 4, 5, 6 } }
RTensor<float> x(data, {2, 3}, MemoryOrder::ColumnMajor);
cout << x << endl;
// Returns:
// { { 1, 3, 5 } { 2, 4, 6 } }
```

RTensor to numpy conversion:

```python
import ROOT
data = ROOT.std.vector("float")((1, 2, 3, 4, 5, 6))
x = ROOT.TMVA.Experimental.RTensor("float")(data.data(), (2, 3))
print(x)
# Returns:
#  { { 1, 2, 3 } { 4, 5, 6 } }

import numpy
y = numpy.asarray(x)
print(y)
# Returns:
# [[1, 2, 3],
#  [4, 5, 6]]
```

Missing features:

- [ ] STL iterator interface
- [ ] `ExpandDim` and `Squeeze` methods (shape manipulation)
- [ ] `Apply` method (element manipulation, similar to STL iterator)
- [ ] `ROOT.AsTensor` method (`numpy.array` to `RTensor` conversion)