### PR TITLE
Adding pthread modulemap for net/http/civetweb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,8 @@ if (NOT WIN32 AND NOT libcxx)
     install(FILES "${CMAKE_BINARY_DIR}/include/stl.modulemap" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT headers)
     configure_file(${CMAKE_SOURCE_DIR}/build/unix/libc.modulemap ${CMAKE_BINARY_DIR}/include/libc.modulemap)
     install(FILES "${CMAKE_BINARY_DIR}/include/libc.modulemap" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT headers)
+    configure_file(${CMAKE_SOURCE_DIR}/build/unix/pthread.modulemap ${CMAKE_BINARY_DIR}/include/pthread.modulemap)
+    install(FILES "${CMAKE_BINARY_DIR}/include/pthread.modulemap" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT headers)
 
   else()
     message(SEND_ERROR "Couldn't find c++ library paths, no modulemap overlay will be installed! (__libcpp_full_paths = '${__libcpp_full_paths}')")

--- a/build/unix/modulemap-installed.overlay.yaml.in
+++ b/build/unix/modulemap-installed.overlay.yaml.in
@@ -14,6 +14,13 @@
           'external-contents': '@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@/libc.modulemap'
         }
       ]
+    },
+    { 'name': '/usr/include/', 'type': 'directory',
+      'contents': [
+        { 'name': 'module.modulemap', 'type': 'file',
+          'external-contents': '@CMAKE_BINARY_DIR@/include/pthread.modulemap'
+        }
+      ]
     }
   ]
 }

--- a/build/unix/modulemap.overlay.yaml.in
+++ b/build/unix/modulemap.overlay.yaml.in
@@ -14,6 +14,13 @@
           'external-contents': '@CMAKE_BINARY_DIR@/include/libc.modulemap'
         }
       ]
+    },
+    { 'name': '/usr/include/', 'type': 'directory',
+      'contents': [
+        { 'name': 'module.modulemap', 'type': 'file',
+          'external-contents': '@CMAKE_BINARY_DIR@/include/pthread.modulemap'
+        }
+      ]
     }
   ]
 }

--- a/build/unix/pthread.modulemap
+++ b/build/unix/pthread.modulemap
@@ -1,0 +1,1 @@
+module pthread [system] { header "pthread.h" export * }


### PR DESCRIPTION
Here we are trying to fix warning coming from civetweb.c:
```
/.../root/net/http/civetweb/civetweb.c:2701:8warning implicit declaration of function 'pthread_setname_np' is invalid in C99 [-Wimplicit-function-declaration]

    (void)pthread_setname_np(pthread_self(), threadName);
```
