### PR TITLE
Fix incompatibility with R on case-insensitive file systems

### DIFF
--- a/bindings/r/CMakeLists.txt
+++ b/bindings/r/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 set(libname RInterface)
 
-include_directories(SYSTEM ${R_INCLUDE_DIRS})
+include_directories(${R_INCLUDE_DIRS})
 
 ROOT_ADD_CXX_FLAG(CMAKE_CXX_FLAGS -Wno-overloaded-virtual)
 
@@ -20,4 +20,6 @@ set(R_HEADERS ${CMAKE_SOURCE_DIR}/bindings/r/inc/TRInterface.h
 ROOT_STANDARD_LIBRARY_PACKAGE(RInterface
                               HEADERS ${R_HEADERS}
                               LIBRARIES ${R_LIBRARIES} readline
+                              DICTIONARY_OPTIONS -I${R_INCLUDE_DIR}
                               DEPENDENCIES Core Matrix Thread RIO)
+target_include_directories(RInterface BEFORE PRIVATE ${R_INCLUDE_DIR})

--- a/core/base/inc/ROOT/RConfig.h
+++ b/core/base/inc/ROOT/RConfig.h
@@ -19,7 +19,7 @@
  *                                                                       *
  *************************************************************************/
 
-#include "RVersion.h"
+#include "../RVersion.h"
 #include "RConfigure.h"
 
 

--- a/math/rtools/CMakeLists.txt
+++ b/math/rtools/CMakeLists.txt
@@ -3,7 +3,7 @@
 # @author Pere Mato, CERN
 ############################################################################
 
-include_directories(SYSTEM ${R_INCLUDE_DIRS})
+include_directories(${R_INCLUDE_DIRS})
 
 ROOT_ADD_CXX_FLAG(CMAKE_CXX_FLAGS -Wno-overloaded-virtual)
 
@@ -11,6 +11,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Rtools
                               HEADERS Math/RMinimizer.h
                               LIBRARIES ${R_LIBRARIES}
                               DEPENDENCIES Core MathCore RInterface)
+target_include_directories(Rtools BEFORE PRIVATE ${R_INCLUDE_DIR})
 
 FILE(COPY "${CMAKE_SOURCE_DIR}/etc/plugins/ROOT@@Math@@Minimizer/P090_RMinimizer.C" DESTINATION "${CMAKE_BINARY_DIR}/etc/plugins/ROOT@@Math@@Minimizer/")
 

--- a/tmva/rmva/CMakeLists.txt
+++ b/tmva/rmva/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 set(libname RMVA)
 
-include_directories(SYSTEM ${R_INCLUDE_DIRS})
+include_directories(${R_INCLUDE_DIRS})
 
 set(R_HEADERS ${CMAKE_SOURCE_DIR}/tmva/rmva/inc/TMVA/RMethodBase.h 
               ${CMAKE_SOURCE_DIR}/tmva/rmva/inc/TMVA/MethodC50.h
@@ -19,4 +19,6 @@ ROOT_ADD_CXX_FLAG(CMAKE_CXX_FLAGS -Wno-overloaded-virtual)
 ROOT_STANDARD_LIBRARY_PACKAGE(RMVA
                               HEADERS ${R_HEADERS}
                               LIBRARIES ${R_LIBRARIES}
+                              DICTIONARY_OPTIONS -I${R_INCLUDE_DIR}
                               DEPENDENCIES Core Matrix Thread RIO RInterface TMVA)
+target_include_directories(RMVA BEFORE PRIVATE ${R_INCLUDE_DIR})


### PR DESCRIPTION
Fix for [ROOT-9620](https://sft.its.cern.ch/jira/browse/ROOT-9620) backported to 6.14 (already merged into master, see #2597).