### PR TITLE
TH::Divide create Sumw2 if binomial errors are requested

### DIFF
--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -2898,8 +2898,8 @@ Bool_t TH1::Divide(const TH1 *h1, const TH1 *h2, Double_t c1, Double_t c2, Optio
       return kFALSE;
    }
 
-   //    Create Sumw2 if h1 or h2 have Sumw2 set
-   if (fSumw2.fN == 0 && (h1->GetSumw2N() != 0 || h2->GetSumw2N() != 0)) Sumw2();
+   //    Create Sumw2 if h1 or h2 have Sumw2 set, or if binomial errors are explicitly requested
+   if (fSumw2.fN == 0 && (h1->GetSumw2N() != 0 || h2->GetSumw2N() != 0 || binomial)) Sumw2();
 
    SetMinimum();
    SetMaximum();


### PR DESCRIPTION
request wouldn't make sense otherwise
cf https://root-forum.cern.ch/t/th2-tefficiency-example/

This collides with #2610 
 * I see two different approaches, either keep the computations consistent
 * or implicitly do what the user probably wants
(of cause the warning could go in both cases)