### PR TITLE
[WIP] Add support for combined short options

### DIFF
--- a/rootx/src/rootx.cxx
+++ b/rootx/src/rootx.cxx
@@ -477,9 +477,9 @@ int main(int argc, char **argv)
       if ((strlen(argv[i]) > 2) && (argv[i][0] == '-') && (argv[i][1] != '-')) {
         // Parse short options, possibly combined
         for (char *optItr = &argv[i][1]; *optItr != '\0'; ++optItr) {
-          if (*optItr == 'b')         batch    = true;
-          if (*optItr == 'l')         gNoLogo  = true;
-          if (*optItr == 'a')         about    = true;
+          if (*optItr == 'b') batch    = true;
+          if (*optItr == 'l') gNoLogo  = true;
+          if (*optItr == 'a') about    = true;
         }
       }
    }

--- a/rootx/src/rootx.cxx
+++ b/rootx/src/rootx.cxx
@@ -472,12 +472,16 @@ int main(int argc, char **argv)
          PrintUsage(argv[0]);
          return 1;
       }
-      if (!strcmp(argv[i], "-b"))         batch    = true;
-      if (!strcmp(argv[i], "-l"))         gNoLogo  = true;
-      if (!strcmp(argv[i], "-ll"))        gNoLogo  = true;
-      if (!strcmp(argv[i], "-a"))         about    = true;
       if (!strcmp(argv[i], "-config"))    gNoLogo  = true;
       if (!strcmp(argv[i], "--notebook")) notebook = true;
+      if ((strlen(argv[i]) > 2) && (argv[i][0] == '-') && (argv[i][1] != '-')) {
+        // Parse short options, possibly combined
+        for (char *optItr = &argv[i][1]; *optItr != '\0'; ++optItr) {
+          if (*optItr == 'b')         batch    = true;
+          if (*optItr == 'l')         gNoLogo  = true;
+          if (*optItr == 'a')         about    = true;
+        }
+      }
    }
 
    if (notebook) {


### PR DESCRIPTION
This enabled shorter command line invocations like `root -qle 1+1` instead of `root -q -l -e 1+1`. Not sure how we should go about testing. The non-combined options are sort of tested by running `hsimple.C` at the end of the build.