### PR TITLE
[VecOps] Add Nonzero and Intersect helpers

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -864,6 +864,46 @@ RVec<RVec<typename RVec<T>::size_type>> Combinations(const RVec<T>& v, const typ
    }
 }
 
+/// Return the indices of the elements which are not zero
+template <typename T>
+RVec<typename RVec<T>::size_type> Nonzero(const RVec<T> &v)
+{
+   using size_type = typename RVec<T>::size_type;
+   RVec<size_type> r;
+   const auto size = v.size();
+   r.reserve(size);
+   for(size_type i=0; i<size; i++) {
+      if(v[i] != 0) {
+         r.emplace_back(i);
+      }
+   }
+   return r;
+}
+
+/// Return the intersection of elements of two RVecs.
+/// Each element of v1 is looked up in v2 and added to the returned vector if
+/// found. Following, the order of v1 is preserved. If v2 is already sorted, the
+/// optional argument v2_is_sorted can be used to toggle of the internal sorting
+/// step, therewith optimising runtime.
+template <typename T>
+RVec<T> Intersect(const RVec<T>& v1, const RVec<T>& v2, bool v2_is_sorted = false)
+{
+   RVec<T> v2_sorted;
+   if (!v2_is_sorted) v2_sorted = Sort(v2);
+   const auto v2_begin = v2_is_sorted ? v2.begin() : v2_sorted.begin();
+   const auto v2_end = v2_is_sorted ? v2.end() : v2_sorted.end();
+   RVec<T> r;
+   const auto size = v1.size();
+   r.reserve(size);
+   using size_type = typename RVec<T>::size_type;
+   for(size_type i=0; i<size; i++) {
+      if (std::binary_search(v2_begin, v2_end, v1[i])) {
+         r.emplace_back(v1[i]);
+      }
+   }
+   return r;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Print a RVec at the prompt:
 template <class T>

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -792,3 +792,36 @@ TEST(VecOps, PrintCollOfNonPrintable)
    auto ret = gInterpreter->ProcessLine(code);
    EXPECT_TRUE(0 != ret) << "Error in printing an RVec collection of non printable objects.";
 }
+
+TEST(VecOps, Nonzero)
+{
+   ROOT::VecOps::RVec<int> v1{0, 1, 0, 3, 4, 0, 6};
+   ROOT::VecOps::RVec<float> v2{0, 1, 0, 3, 4, 0, 6};
+   auto v3 = Nonzero(v1);
+   auto v4 = Nonzero(v2);
+   ROOT::VecOps::RVec<size_t> ref1{1, 3, 4, 6};
+   CheckEqual(v3, ref1);
+   CheckEqual(v4, ref1);
+
+   auto v5 = v1[v1<2];
+   auto v6 = Nonzero(v5);
+   ROOT::VecOps::RVec<size_t> ref2{1};
+   CheckEqual(v6, ref2);
+}
+
+TEST(VecOps, Intersect)
+{
+   ROOT::VecOps::RVec<int> v1{0, 1, 2, 3};
+   ROOT::VecOps::RVec<int> v2{2, 3, 4, 5};
+   auto v3 = Intersect(v1, v2);
+   ROOT::VecOps::RVec<int> ref1{2, 3};
+   CheckEqual(v3, ref1);
+
+   ROOT::VecOps::RVec<int> v4{4, 5, 3, 2};
+   auto v5 = Intersect(v1, v4);
+   CheckEqual(v5, ref1);
+
+   // v2 already sorted
+   auto v6 = Intersect(v1, v2, true);
+   CheckEqual(v6, ref1);
+}

--- a/tutorials/vecops/vo006_IndexManipulation.C
+++ b/tutorials/vecops/vo006_IndexManipulation.C
@@ -1,0 +1,46 @@
+/// \file
+/// \ingroup tutorial_vecops
+/// \notebook -nodraw
+/// In this tutorial we demonstrate RVec helpers for index manipulation.
+///
+/// \macro_code
+/// \macro_output
+///
+/// \date September 2018
+/// \author Stefan Wunsch
+
+using namespace ROOT::VecOps;
+
+void vo006_IndexManipulation()
+{
+   // We assume that we have multiple linked collections, the elements of which
+   // represent different objects.
+   RVec<float> muon_pt = {20.0, 30.0, 10.0, 25.0};
+   RVec<float> muon_eta = {1.0, -2.0, 0.5, 2.5};
+
+   for (size_t i = 0; i < muon_pt.size(); i++) {
+      std::cout << "Muon " << i + 1 << " (pt, eta): " << muon_pt[i] << ", "
+                << muon_eta[i] << std::endl;
+   }
+
+   // First, let's make a selection and write out all indices, which pass.
+   auto idx_select = Nonzero(muon_pt > 15 && abs(muon_eta) < 2.5);
+
+   // Second, get indices that sort one of the collections in descending order.
+   auto idx_sort = Reverse(Argsort(muon_pt));
+
+   // Finally, we find all indices present in both collections of indices retrieved
+   // from sorting and selecting.
+   // Note, that the order of the first list passed to the Intersect helper is
+   // contained.
+   auto idx = Intersect(idx_sort, idx_select);
+
+   // Take from all lists the elements of the passing objects.
+   auto good_muon_pt = Take(muon_pt, idx);
+   auto good_muon_eta = Take(muon_eta, idx);
+
+   for (size_t i = 0; i < idx.size(); i++) {
+      std::cout << "Selected muon " << i + 1 << " (pt, eta): " << good_muon_pt[i]
+                << ", " << good_muon_eta[i] << std::endl;
+   }
+}


### PR DESCRIPTION
`Nonzero` simply goes through the input vector and checks whether an element is zero or not. The time complexity is `O(N)`.

`Intersect` goes through the  vector `v1` and searches each element in the vector `v2`. The approach is sorting `v2` first and loop trivially over `v1`. The resulting time complexity is `O(N1*log(N2))`.

A common use-case is shown below:

```cpp
using namespace ROOT::VecOps;

// user data, e.g., in NanoAOD format
RVec<int> Muon_charge = {1, -1, 1};
RVec<float> Muon_pt = {20.0, 30.0, 10.0};
RVec<float> Muon_eta = {1.0, -2.0, 0.5};

// make first selection based on Muon charge
auto idx_mask = Nonzero(Muon_charge>0);

// get indices that sort Muon pt with descending values and pass the previous selection
auto idx_sorted = Reverse(Argsort(Muon_pt));
auto idx_selection = Intersect(idx_sorted, idx_mask);

// get Muon eta of positive Muons sorted by pt
auto values = Take(Muon_eta, idx_selection);
// Returns: { 1, 0.5 }
```

This scenario is very common in processing of NanoAOD files.

The naming matches the numpy API with [`numpy.nonzero`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.nonzero.html) and [`numpy.intersect1d`](https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.intersect1d.html).

**TODO:**

- [x] Write a tutorial when we agreed on the functionality.
- [x] Change the API for `Sorted` and `Reversed` to `Sort` and `Reverse` before merging this.