### PR TITLE
[VecOps] Get elements of RVec by passing vector of indices to operator[]

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -276,6 +276,17 @@ public:
       return ret;
    }
 
+   RVec<T> operator[](const RVec<size_type> &idx) const
+   {
+      const size_type n = idx.size();
+      RVec<T> ret;
+      ret.reserve(n);
+      for(auto& i : idx) {
+         ret.emplace_back(fData[i]);
+      }
+      return ret;
+   }
+
    reference front() { return fData.front(); }
    const_reference front() const { return fData.front(); }
    reference back() { return fData.back(); }
@@ -731,12 +742,7 @@ RVec<typename RVec<T>::size_type> Argsort(const RVec<T> &v)
 template <typename T>
 RVec<T> Take(const RVec<T> &v, const RVec<typename RVec<T>::size_type> &i)
 {
-   using size_type = typename RVec<T>::size_type;
-   const size_type isize = i.size();
-   RVec<T> r(isize);
-   for (size_type k = 0; k < isize; k++)
-      r[k] = v[i[k]];
-   return r;
+   return v[i];
 }
 
 /// Return first elements of a vector if n>0 and last elements if n<0

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -665,6 +665,15 @@ TEST(VecOps, TakeLast)
    CheckEqual(v2, none);
 }
 
+TEST(VecOps, TakeOperator)
+{
+   ROOT::VecOps::RVec<int> v0{2, 0, 1};
+   ROOT::VecOps::RVec<typename ROOT::VecOps::RVec<int>::size_type> i{1, 2, 0, 0, 0};
+   auto v1 = v0[i];
+   ROOT::VecOps::RVec<int> ref{0, 1, 2, 2, 2};
+   CheckEqual(v1, ref);
+}
+
 TEST(VecOps, Reverse)
 {
    ROOT::VecOps::RVec<int> v0{0, 1, 2};


### PR DESCRIPTION
Add template specialization for `RVec<T>::operator[]` to access elements by passing a vector of indices. Here an example:

```cpp
using namespace ROOT::VecOps;
RVec<float> v = {1, 2, 3, 4, 5};
RVec<size_t> idx = {0, 2, 4};
cout << v[idx] << endl;
// Returns: { 1, 3, 5 }
```

This enable numpy-like element access and a more convenient handling of index magic. See following scenario:

```cpp
using namespace ROOT::VecOps;
RVec<float> v = {2, 1, 0};
auto idx = Argsort(v);
cout << v[idx] << endl;
// Returns: { 0, 1, 2 }
```

**TODO:**

- [ ] Add this feature to a tutorial