### PR TITLE
[VecOps] Add Where helper

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -904,6 +904,66 @@ RVec<T> Intersect(const RVec<T>& v1, const RVec<T>& v2, bool v2_is_sorted = fals
    return r;
 }
 
+/// Return the elements of v1 if the condition c is true and v2 if the
+/// condition c is false.
+template <typename T>
+RVec<T> Where(const RVec<int>& c, const RVec<T>& v1, const RVec<T>& v2)
+{
+   using size_type = typename RVec<T>::size_type;
+   const size_type size = c.size();
+   RVec<T> r;
+   r.reserve(size);
+   for (size_type i=0; i<size; i++) {
+      r.emplace_back(c[i] != 0 ? v1[i] : v2[i]);
+   }
+   return r;
+}
+
+/// Return the elements of v1 if the condition c is true and sets the value v2
+/// if the condition c is false.
+template <typename T>
+RVec<T> Where(const RVec<int>& c, const RVec<T>& v1, T v2)
+{
+   using size_type = typename RVec<T>::size_type;
+   const size_type size = c.size();
+   RVec<T> r;
+   r.reserve(size);
+   for (size_type i=0; i<size; i++) {
+      r.emplace_back(c[i] != 0 ? v1[i] : v2);
+   }
+   return r;
+}
+
+/// Return the elements of v2 if the condition c is false and sets the value v1
+/// if the condition c is true.
+template <typename T>
+RVec<T> Where(const RVec<int>& c, T v1, const RVec<T>& v2)
+{
+   using size_type = typename RVec<T>::size_type;
+   const size_type size = c.size();
+   RVec<T> r;
+   r.reserve(size);
+   for (size_type i=0; i<size; i++) {
+      r.emplace_back(c[i] != 0 ? v1 : v2[i]);
+   }
+   return r;
+}
+
+/// Return a vector with the value v2 if the condition c is false and sets the
+/// value v1 if the condition c is true.
+template <typename T>
+RVec<T> Where(const RVec<int>& c, T v1, T v2)
+{
+   using size_type = typename RVec<T>::size_type;
+   const size_type size = c.size();
+   RVec<T> r;
+   r.reserve(size);
+   for (size_type i=0; i<size; i++) {
+      r.emplace_back(c[i] != 0 ? v1 : v2);
+   }
+   return r;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Print a RVec at the prompt:
 template <class T>

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -825,3 +825,28 @@ TEST(VecOps, Intersect)
    auto v6 = Intersect(v1, v2, true);
    CheckEqual(v6, ref1);
 }
+
+TEST(VecOps, Where)
+{
+   // Use two vectors as arguments
+   RVec<float> v0{1, 2, 3, 4};
+   RVec<float> v1{-1, -2, -3, -4};
+   auto v3 = Where(v0 > 1 && v0 < 4, v0, v1);
+   RVec<float> ref1{-1, 2, 3, -4};
+   CheckEqual(v3, ref1);
+
+   // Broadcast false argument
+   auto v4 = Where(v0 == 2 || v0 == 4, v0, -1.0f);
+   RVec<float> ref2{-1, 2, -1, 4};
+   CheckEqual(v4, ref2);
+
+   // Broadcast true argument
+   auto v5 = Where(v0 == 2 || v0 == 4, -1.0f, v1);
+   RVec<float> ref3{-1, -1, -3, -1};
+   CheckEqual(v5, ref3);
+
+   // Broadcast both arguments
+   auto v6 = Where(v0 == 2 || v0 == 4, -1.0f, 1.0f);
+   RVec<float> ref4{1, -1, 1, -1};
+   CheckEqual(v6, ref4);
+}

--- a/tutorials/vecops/vo003_LogicalOperations.C
+++ b/tutorials/vecops/vo003_LogicalOperations.C
@@ -49,4 +49,8 @@ void vo003_LogicalOperations()
    // Suppose the pts of the muons with a pt greater than 10 and eta smaller than 2.1 are needed:
    auto good_mu_pt = mu_pt[mu_pt > 10 && abs(mu_eta) < 2.1];
    std::cout << "mu_pt = " << mu_pt << "  mu_pt[ mu_pt > 10 && abs(mu_eta) < 2.1] = " << good_mu_pt << std::endl;
+
+   // Advanced logical operations with masking can be performed with the Where helper.
+   auto masked_mu_pt = Where(abs(mu_eta) < 2., mu_pt, -999.);
+   std::cout << "mu_pt if abs(mu_eta) < 2 else -999 = " << masked_mu_pt << std::endl;
 }


### PR DESCRIPTION
Add helper `Where` similar to `numpy.where`. See following examples for the use-cases:

```cpp
using namespace ROOT::VecOps;
RVec<float> v1 = {1, 2, 3, 4};
RVec<float> v2 = {-1, -2, -3, -4};

// Case 1: I want a vector with the elements of v1 if a condition is true and the element of v2 otherwise.
auto v3 = Where(v1>2, v1, v2);
// Returns: { -1, -2, 3, 4 }

// Case 2: I want the elements of vector v1 if a condition is true and the value v2 in the other cases.
auto v4  = Where(v1 != 4, v1, -999.0f);
// Returns: { 1, 2, 3, -999 }

// Case 3: I want the elements of vector v2 if a condition is false and the value v1 in the other cases.
auto v5  = Where(v1 == 4, -999.0f, v2);
// Returns: { -1, -2, -3, -999 }

// Case 4: I want a vector with the value v1 if a condition is true and the value v2 in the other cases.
auto v6  = Where(v1 == 4, 1.0f, 0.0f);
// Returns: { 0, 0, 0, 1 }
```

`numpy.where` is pretty often used ([see here](https://galeascience.wordpress.com/2016/08/10/top-10-pandas-numpy-and-scipy-functions-on-github/)):

![](https://galeascience.files.wordpress.com/2016/08/popular_numpy_functions1.png?w=768)

**TODO:**
- [x] Add feature to a tutorial