### PR TITLE
[VecOps] Rename Sorted and Reversed to Sort and Reverse

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -115,8 +115,8 @@ std::sort(v.begin(), v.end());
 
 For convinience, helpers are provided too:
 ~~~{.cpp}
-auto sorted_v = Sorted(v);
-auto reversed_v = Reversed(v);
+auto sorted_v = Sort(v);
+auto reversed_v = Reverse(v);
 ~~~
 
 ### Manipulation of indices
@@ -761,7 +761,7 @@ RVec<T> Take(const RVec<T> &v, const int n)
 
 /// Return copy of reversed vector
 template <typename T>
-RVec<T> Reversed(const RVec<T> &v)
+RVec<T> Reverse(const RVec<T> &v)
 {
    RVec<T> r(v);
    std::reverse(r.begin(), r.end());
@@ -770,7 +770,7 @@ RVec<T> Reversed(const RVec<T> &v)
 
 /// Return copy of vector with elements sorted in ascending order
 template <typename T>
-RVec<T> Sorted(const RVec<T> &v)
+RVec<T> Sort(const RVec<T> &v)
 {
    RVec<T> r(v);
    std::sort(r.begin(), r.end());
@@ -781,7 +781,7 @@ RVec<T> Sorted(const RVec<T> &v)
 /// The comparison operator has to fullfill the same requirements than the
 /// operator taken by std::sort.
 template <typename T, typename Compare>
-RVec<T> Sorted(const RVec<T> &v, Compare &&c)
+RVec<T> Sort(const RVec<T> &v, Compare &&c)
 {
    RVec<T> r(v);
    std::sort(r.begin(), r.end(), std::forward<Compare>(c));

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -664,47 +664,47 @@ TEST(VecOps, TakeLast)
    CheckEqual(v2, none);
 }
 
-TEST(VecOps, Reversed)
+TEST(VecOps, Reverse)
 {
    ROOT::VecOps::RVec<int> v0{0, 1, 2};
 
-   auto v1 = Reversed(v0);
+   auto v1 = Reverse(v0);
    ROOT::VecOps::RVec<int> ref{2, 1, 0};
    CheckEqual(v1, ref);
 
    // Corner-case: Empty vector
    ROOT::VecOps::RVec<int> none{};
-   auto v2 = Reversed(none);
+   auto v2 = Reverse(none);
    CheckEqual(v2, none);
 }
 
-TEST(VecOps, Sorted)
+TEST(VecOps, Sort)
 {
    ROOT::VecOps::RVec<int> v{2, 0, 1};
 
    // Sort in ascending order
-   auto v1 = Sorted(v);
+   auto v1 = Sort(v);
    ROOT::VecOps::RVec<int> ref{0, 1, 2};
    CheckEqual(v1, ref);
 
    // Corner-case: Empty vector
    ROOT::VecOps::RVec<int> none{};
-   auto v2 = Sorted(none);
+   auto v2 = Sort(none);
    CheckEqual(v2, none);
 }
 
-TEST(VecOps, SortedWithComparisonOperator)
+TEST(VecOps, SortWithComparisonOperator)
 {
    ROOT::VecOps::RVec<int> v{2, 0, 1};
 
    // Sort with comparison operator
-   auto v1 = Sorted(v, std::greater<int>());
+   auto v1 = Sort(v, std::greater<int>());
    ROOT::VecOps::RVec<int> ref{2, 1, 0};
    CheckEqual(v1, ref);
 
    // Corner-case: Empty vector
    ROOT::VecOps::RVec<int> none{};
-   auto v2 = Sorted(none, std::greater<int>());
+   auto v2 = Sort(none, std::greater<int>());
    CheckEqual(v2, none);
 }
 

--- a/tutorials/dataframe/df102_NanoAODDimuonAnalysis.C
+++ b/tutorials/dataframe/df102_NanoAODDimuonAnalysis.C
@@ -39,7 +39,7 @@ void df102_NanoAODDimuonAnalysis()
    // Find muon pair with highest pt and opposite charge
    auto find_pair = [](const RVec<float> &pt, const RVec<int> &charge) {
       // Get indices that sort the muon pts in descending order
-      const auto idx = Reversed(Argsort(pt));
+      const auto idx = Reverse(Argsort(pt));
 
       // Find muon with second-highest pt and opposite charge
       const auto i1 = idx[0];

--- a/tutorials/vecops/vo004_SortAndSelect.C
+++ b/tutorials/vecops/vo004_SortAndSelect.C
@@ -22,11 +22,11 @@ void vo004_SortAndSelect()
 
    // For convenience, ROOT implements helpers, e.g., to get a sorted copy of
    // an RVec ...
-   auto v3 = Sorted(v1);
+   auto v3 = Sort(v1);
    std::cout << "Sort vector " << v1 << ": " << v3 << std::endl;
 
    // ... or a reversed copy of an RVec.
-   auto v4 = Reversed(v1);
+   auto v4 = Reverse(v1);
    std::cout << "Reverse vector " << v1 << ": " << v4 << std::endl;
 
    // Helpers are provided to get the indices that sort the vector and to
@@ -47,7 +47,7 @@ void vo004_SortAndSelect()
 
    // Because the helpers return a copy of the input, you can chain the operations
    // conveniently.
-   auto v9 = Reversed(Take(Sorted(v1), -2));
+   auto v9 = Reverse(Take(Sort(v1), -2));
    std::cout << "Sort the vector " << v1 << ", take the two last elements and "
              << "reverse the selection: " << v9 << std::endl;
 }

--- a/tutorials/vecops/vo004_SortAndSelect.py
+++ b/tutorials/vecops/vo004_SortAndSelect.py
@@ -10,7 +10,7 @@
 ## \author Stefan Wunsch
 
 import ROOT
-from ROOT.VecOps import RVec, Argsort, Take, Sorted, Reversed
+from ROOT.VecOps import RVec, Argsort, Take, Sort, Reverse
 
 # RVec can be sorted in Python with the inbuilt sorting function because
 # PyROOT implements a Python iterator
@@ -21,11 +21,11 @@ print("Sort vector {}: {}".format(v1, v2))
 
 # For convenience, ROOT implements helpers, e.g., to get a sorted copy of
 # an RVec ...
-v2 = Sorted(v1);
+v2 = Sort(v1);
 print("Sort vector {}: {}".format(v1, v2))
 
 # ... or a reversed copy of an RVec.
-v2 = Reversed(v1);
+v2 = Reverse(v1);
 print("Reverse vector {}: {}".format(v1, v2))
 
 # Helpers are provided to get the indices that sort the vector and to
@@ -45,5 +45,5 @@ print("Take the two first and last elements of vector {}: {}, {}".format(v1, v2,
 
 # Because the VecOps helpers return a copy of the input, you can chain the operations
 # conveniently.
-v2 = Reversed(Take(Sorted(v1), -2))
+v2 = Reverse(Take(Sort(v1), -2))
 print("Sort the vector {}, take the two last elements and reverse the selection: {}".format(v1, v2))


### PR DESCRIPTION
As discussed with @bluehood and @dpiparo, having "passive" function names is not desirable. Therefore, we adapt the interface accordingly.