### PR TITLE
[PyROOT] Use GetLength from version 3.3 and onwards

### DIFF
--- a/bindings/pyroot/src/PyROOT.h
+++ b/bindings/pyroot/src/PyROOT.h
@@ -47,6 +47,18 @@
 #define PyDictEntry PyDictKeyEntry
 #endif
 
+// for 3.3 support
+#if PY_VERSION_HEX < 0x03030000
+// Use PyString_Size for a version lower than 3.0
+#if PY_VERSION_HEX < 0x03000000
+#define PyROOT_PyUnicode_GetSize            PyString_Size
+#else
+#define PyROOT_PyUnicode_GetSize            PyUnicode_GetSize
+#endif
+#else // if greater or equal than 3.3
+#define PyROOT_PyUnicode_GetSize            PyUnicode_GetLength
+#endif
+
 // for 3.0 support (backwards compatibility, really)
 #if PY_VERSION_HEX < 0x03000000
 #define PyBytes_Check                  PyString_Check
@@ -66,7 +78,6 @@
 #define PyROOT_PyUnicode_AsString           PyString_AS_STRING
 #define PyROOT_PyUnicode_AsStringChecked    PyString_AsString
 #define PyROOT_PyUnicode_GET_SIZE           PyString_GET_SIZE
-#define PyROOT_PyUnicode_GetSize            PyString_Size
 #define PyROOT_PyUnicode_FromFormat         PyString_FromFormat
 #define PyROOT_PyUnicode_FromString         PyString_FromString
 #define PyROOT_PyUnicode_InternFromString   PyString_InternFromString
@@ -99,7 +110,6 @@ static inline void* PyROOT_PyCapsule_GetPointer( PyObject* capsule, const char* 
 #define PyROOT_PyUnicode_CheckExact         PyUnicode_CheckExact
 #define PyROOT_PyUnicode_AsString           _PyUnicode_AsString
 #define PyROOT_PyUnicode_AsStringChecked    _PyUnicode_AsString
-#define PyROOT_PyUnicode_GetSize            PyUnicode_GetSize
 #define PyROOT_PyUnicode_GET_SIZE           PyUnicode_GET_SIZE
 #define PyROOT_PyUnicode_FromFormat         PyUnicode_FromFormat
 #define PyROOT_PyUnicode_FromString         PyUnicode_FromString


### PR DESCRIPTION
GetSize is deprecated from 3.3
(https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_GetSize) and
the new recommendation is to use PyUnicode_GetLength.