### PR TITLE
[TREEPROCMT] Fix possible nullptr dereference (thanks coverity!)

### DIFF
--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -128,6 +128,8 @@ Internal::FriendInfo TTreeProcessorMT::GetFriendInfo(TTree &tree)
          }
       } else {
          const auto f = frTree->GetCurrentFile();
+         if (!f)
+            throw std::runtime_error("Friend trees with no associated file are not supported.");
          fileNames.emplace_back(f->GetName());
       }
    }


### PR DESCRIPTION
Reported by coverity [here](https://coverity.cern.ch/reports.htm#v14989/p10001/fileInstanceId=765920049&defectInstanceId=397454685&mergedDefectId=98847)