### PR TITLE
[TreePlayer] ROOT-9312: Fix

### DIFF
--- a/tree/treeplayer/inc/TTreeReaderValue.h
+++ b/tree/treeplayer/inc/TTreeReaderValue.h
@@ -88,6 +88,7 @@ namespace Internal {
       void RegisterWithTreeReader();
       void NotifyNewTree(TTree* newTree);
 
+      TBranch* SearchBranchWithCompositeName(TLeaf *&myleaf, TDictionary *&branchActualType, std::string &err);
       virtual void CreateProxy();
       const char* GetBranchDataType(TBranch* branch,
                                     TDictionary* &dict) const;

--- a/tree/treeplayer/src/TTreeReaderValue.cxx
+++ b/tree/treeplayer/src/TTreeReaderValue.cxx
@@ -150,9 +150,7 @@ void ROOT::Internal::TTreeReaderValueBase::NotifyNewTree(TTree* newTree) {
    if (!fHaveLeaf)
       return;
 
-   std::cout << "Getting branch " << fBranchName << std::endl;
    TBranch *myBranch = newTree->GetBranch(fBranchName);
-   std::cout << "Got Branch " << myBranch->GetName() << std::endl;
 
    if (!myBranch) {
       fReadStatus = kReadError;

--- a/tree/treeplayer/src/TTreeReaderValue.cxx
+++ b/tree/treeplayer/src/TTreeReaderValue.cxx
@@ -150,7 +150,9 @@ void ROOT::Internal::TTreeReaderValueBase::NotifyNewTree(TTree* newTree) {
    if (!fHaveLeaf)
       return;
 
+   std::cout << "Getting branch " << fBranchName << std::endl;
    TBranch *myBranch = newTree->GetBranch(fBranchName);
+   std::cout << "Got Branch " << myBranch->GetName() << std::endl;
 
    if (!myBranch) {
       fReadStatus = kReadError;
@@ -193,28 +195,192 @@ void* ROOT::Internal::TTreeReaderValueBase::GetAddress() {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// \brief Search a branch the name of which contains a "."
+/// \param[out] myLeaf The leaf identified by the name if found (can be untouched).
+/// \param[out] branchActualType Dictionary associated to the type of the leaf (can be untouched).
+/// \param[out] errMsg The error message (can be untouched).
+/// \return The address of the branch if found, nullptr otherwise
+/// This method allows to efficiently search for branches which have names which
+/// contain "dots", for example "w.v.a" or "v.a".
+/// Therefore, it allows to support names such as v.a where the branch was
+/// created with this syntax:
+/// ```{.cpp}
+/// myTree->Branch("v", &v, "a/I:b:/I")
+/// ```
+/// The method has some side effects, namely it can modify fSetupStatus, fProxy
+/// and fStaticClassOffsets/fHaveStaticClassOffsets.
+TBranch *ROOT::Internal::TTreeReaderValueBase::SearchBranchWithCompositeName(TLeaf *&myLeaf, TDictionary *&branchActualType, std::string &errMsg)
+{
+   TRegexp leafNameExpression ("\\.[a-zA-Z0-9_]+$");
+   TString leafName (fBranchName(leafNameExpression));
+   TString branchName = fBranchName(0, fBranchName.Length() - leafName.Length());
+   auto branch = fTreeReader->GetTree()->GetBranch(branchName);
+   if (!branch){
+      std::vector<TString> nameStack;
+      nameStack.push_back(TString()); //Trust me
+      nameStack.push_back(leafName.Strip(TString::kBoth, '.'));
+      leafName = branchName(leafNameExpression);
+      branchName = branchName(0, branchName.Length() - leafName.Length());
+
+      branch = fTreeReader->GetTree()->GetBranch(branchName);
+      if (!branch) branch = fTreeReader->GetTree()->GetBranch(branchName + ".");
+      if (leafName.Length()) nameStack.push_back(leafName.Strip(TString::kBoth, '.'));
+
+      while (!branch && branchName.Contains(".")){
+         leafName = branchName(leafNameExpression);
+         branchName = branchName(0, fBranchName.Length() - leafName.Length());
+         branch = fTreeReader->GetTree()->GetBranch(branchName);
+         if (!branch) branch = fTreeReader->GetTree()->GetBranch(branchName + ".");
+         nameStack.push_back(leafName.Strip(TString::kBoth, '.'));
+      }
+
+      if (branch && branch->IsA() == TBranchElement::Class()){
+         TBranchElement *myBranchElement = (TBranchElement*)branch;
+
+         TString traversingBranch = nameStack.back();
+         nameStack.pop_back();
+
+         bool found = true;
+
+         TDataType *finalDataType = 0;
+
+         std::vector<Long64_t> offsets;
+         Long64_t offset = 0;
+         TClass *elementClass = 0;
+
+         TObjArray *myObjArray = myBranchElement->GetInfo()->GetElements();
+         TVirtualStreamerInfo *myInfo = myBranchElement->GetInfo();
+
+         while (nameStack.size() && found){
+            found = false;
+
+            for (int i = 0; i < myObjArray->GetEntries(); ++i){
+
+               TStreamerElement *tempStreamerElement = (TStreamerElement*)myObjArray->At(i);
+
+               if (!strcmp(tempStreamerElement->GetName(), traversingBranch.Data())){
+                  offset += myInfo->GetElementOffset(i);
+
+                  traversingBranch = nameStack.back();
+                  nameStack.pop_back();
+
+                  elementClass = tempStreamerElement->GetClass();
+                  if (elementClass) {
+                     myInfo = elementClass->GetStreamerInfo(0);
+                     myObjArray = myInfo->GetElements();
+                     // FIXME: this is odd, why is 'i' not also reset????
+                  }
+                  else {
+                     finalDataType = TDataType::GetDataType((EDataType)tempStreamerElement->GetType());
+                     if (!finalDataType) {
+                        TDictionary* seType = TDictionary::GetDictionary(tempStreamerElement->GetTypeName());
+                        if (seType && seType->IsA() == TDataType::Class()) {
+                           finalDataType = TDataType::GetDataType((EDataType)((TDataType*)seType)->GetType());
+                        }
+                     }
+                  }
+
+                  if (tempStreamerElement->IsaPointer()){
+                     offsets.push_back(offset);
+                     offset = 0;
+                  }
+
+                  found = true;
+                  break;
+               }
+            }
+         }
+
+         offsets.push_back(offset);
+
+         if (found){
+            fStaticClassOffsets = offsets;
+            fHaveStaticClassOffsets = 1;
+
+            if (fDict != finalDataType && fDict != elementClass){
+               errMsg = "Wrong data type ";
+               errMsg += finalDataType ? finalDataType->GetName() : elementClass ? elementClass->GetName() : "UNKNOWN";
+               fSetupStatus = kSetupMismatch;
+               fProxy = 0;
+               return nullptr;
+            }
+         }
+      }
+
+
+      if (!fHaveStaticClassOffsets) {
+         errMsg = "The tree does not have a branch called ";
+         errMsg += fBranchName;
+         errMsg += ". You could check with TTree::Print() for available branches.";
+         fSetupStatus = kSetupMissingBranch;
+         fProxy = 0;
+         return nullptr;
+      }
+   }
+   else {
+      myLeaf = branch->GetLeaf(TString(leafName(1, leafName.Length())));
+      if (!myLeaf){
+         errMsg = "The tree does not have a branch, nor a sub-branch called ";
+         errMsg += fBranchName;
+         errMsg += ". You could check with TTree::Print() for available branches.";
+         fSetupStatus = kSetupMissingBranch;
+         fProxy = 0;
+         return nullptr;
+      }
+      else {
+         TDictionary *tempDict = TDictionary::GetDictionary(myLeaf->GetTypeName());
+         if (tempDict && tempDict->IsA() == TDataType::Class() && TDictionary::GetDictionary(((TDataType*)tempDict)->GetTypeName()) == fDict){
+            //fLeafOffset = myLeaf->GetOffset() / 4;
+            branchActualType = fDict;
+            fLeaf = myLeaf;
+            fBranchName = branchName;
+            fLeafName = leafName(1, leafName.Length());
+            fHaveLeaf = fLeafName.Length() > 0;
+            fSetupStatus = kSetupMatchLeaf;
+         }
+         else {
+            errMsg = "Leaf of type ";
+            errMsg += myLeaf->GetTypeName();
+            errMsg += " cannot be read by TTreeReaderValue<";
+            errMsg += fDict->GetName();
+            errMsg += ">.";
+            fSetupStatus = kSetupMismatch;
+            return nullptr;
+         }
+      }
+   }
+
+   return branch;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Create the proxy object for our branch.
 
 void ROOT::Internal::TTreeReaderValueBase::CreateProxy() {
+
+   constexpr const char* errPrefix = "TTreeReaderValueBase::CreateProxy()";
+
    if (fProxy) {
       return;
    }
 
    fSetupStatus = kSetupInternalError; // Fallback; set to something concrete below.
    if (!fTreeReader) {
-      Error("TTreeReaderValueBase::CreateProxy()", "TTreeReader object not set / available for branch %s!",
+      Error(errPrefix, "TTreeReader object not set / available for branch %s!",
             fBranchName.Data());
       fSetupStatus = kSetupTreeDestructed;
       return;
    }
+
+   auto branchFromFullName = fTreeReader->GetTree()->GetBranch(fBranchName);
+
    if (!fDict) {
-      TBranch* br = fTreeReader->GetTree()->GetBranch(fBranchName);
       const char* brDataType = "{UNDETERMINED}";
-      if (br) {
+      if (branchFromFullName) {
          TDictionary* brDictUnused = 0;
-         brDataType = GetBranchDataType(br, brDictUnused);
+         brDataType = GetBranchDataType(branchFromFullName, brDictUnused);
       }
-      Error("TTreeReaderValueBase::CreateProxy()", "The template argument type T of %s accessing branch %s (which contains data of type %s) is not known to ROOT. You will need to create a dictionary for it.",
+      Error(errPrefix, "The template argument type T of %s accessing branch %s (which contains data of type %s) is not known to ROOT. You will need to create a dictionary for it.",
             GetDerivedTypeName(), fBranchName.Data(), brDataType);
       fSetupStatus = kSetupMissingDictionary;
       return;
@@ -230,162 +396,53 @@ void ROOT::Internal::TTreeReaderValueBase::CreateProxy() {
       return;
    }
 
-   // This allows to support names such as v.a where the branch was created with
-   // this syntax:
-   // myTree->Branch("v", &v, "a/I:b:/I")
-   // if the branch is not found, the fBranchName is chopped to the top level branch
-   // by this very method.
-   std::string originalBranchName = fBranchName.Data();
+   const std::string originalBranchName = fBranchName.Data();
 
-   TBranch* branch = fTreeReader->GetTree()->GetBranch(fBranchName);
-   TLeaf *myLeaf = NULL;
-   TDictionary* branchActualType = 0;
+   TLeaf *myLeaf = nullptr;
+   TDictionary* branchActualType = nullptr;
+   std::string errMsg;
+
+   TBranch *branch = nullptr;
+   // If the branch name contains at least a dot, we analyse it in detail and
+   // we give priority to the branch identified over the one which is found
+   // with the TTree::GetBranch method. This allow to correctly pick the desired
+   // branch in cases where a TTree has two branches, one called for example
+   // "w.v.a" and another one called "v.a".
+   // This behaviour is described in ROOT-9312.
+   if (fBranchName.Contains(".")) {
+      branch = SearchBranchWithCompositeName(myLeaf, branchActualType, errMsg);
+   }
 
    if (!branch) {
-      if (fBranchName.Contains(".")){
-         TRegexp leafNameExpression ("\\.[a-zA-Z0-9_]+$");
-         TString leafName (fBranchName(leafNameExpression));
-         TString branchName = fBranchName(0, fBranchName.Length() - leafName.Length());
-         branch = fTreeReader->GetTree()->GetBranch(branchName);
-         if (!branch){
-            std::vector<TString> nameStack;
-            nameStack.push_back(TString()); //Trust me
-            nameStack.push_back(leafName.Strip(TString::kBoth, '.'));
-            leafName = branchName(leafNameExpression);
-            branchName = branchName(0, branchName.Length() - leafName.Length());
-
-            branch = fTreeReader->GetTree()->GetBranch(branchName);
-            if (!branch) branch = fTreeReader->GetTree()->GetBranch(branchName + ".");
-            if (leafName.Length()) nameStack.push_back(leafName.Strip(TString::kBoth, '.'));
-
-            while (!branch && branchName.Contains(".")){
-               leafName = branchName(leafNameExpression);
-               branchName = branchName(0, fBranchName.Length() - leafName.Length());
-               branch = fTreeReader->GetTree()->GetBranch(branchName);
-               if (!branch) branch = fTreeReader->GetTree()->GetBranch(branchName + ".");
-               nameStack.push_back(leafName.Strip(TString::kBoth, '.'));
-            }
-
-            if (branch && branch->IsA() == TBranchElement::Class()){
-               TBranchElement *myBranchElement = (TBranchElement*)branch;
-
-               TString traversingBranch = nameStack.back();
-               nameStack.pop_back();
-
-               bool found = true;
-
-               TDataType *finalDataType = 0;
-
-               std::vector<Long64_t> offsets;
-               Long64_t offset = 0;
-               TClass *elementClass = 0;
-
-               TObjArray *myObjArray = myBranchElement->GetInfo()->GetElements();
-               TVirtualStreamerInfo *myInfo = myBranchElement->GetInfo();
-
-               while (nameStack.size() && found){
-                  found = false;
-
-                  for (int i = 0; i < myObjArray->GetEntries(); ++i){
-
-                     TStreamerElement *tempStreamerElement = (TStreamerElement*)myObjArray->At(i);
-
-                     if (!strcmp(tempStreamerElement->GetName(), traversingBranch.Data())){
-                        offset += myInfo->GetElementOffset(i);
-
-                        traversingBranch = nameStack.back();
-                        nameStack.pop_back();
-
-                        elementClass = tempStreamerElement->GetClass();
-                        if (elementClass) {
-                           myInfo = elementClass->GetStreamerInfo(0);
-                           myObjArray = myInfo->GetElements();
-                           // FIXME: this is odd, why is 'i' not also reset????
-                        }
-                        else {
-                           finalDataType = TDataType::GetDataType((EDataType)tempStreamerElement->GetType());
-                           if (!finalDataType) {
-                              TDictionary* seType = TDictionary::GetDictionary(tempStreamerElement->GetTypeName());
-                              if (seType && seType->IsA() == TDataType::Class()) {
-                                 finalDataType = TDataType::GetDataType((EDataType)((TDataType*)seType)->GetType());
-                              }
-                           }
-                        }
-
-                        if (tempStreamerElement->IsaPointer()){
-                           offsets.push_back(offset);
-                           offset = 0;
-                        }
-
-                        found = true;
-                        break;
-                     }
-                  }
-               }
-
-               offsets.push_back(offset);
-
-               if (found){
-                  fStaticClassOffsets = offsets;
-                  fHaveStaticClassOffsets = 1;
-
-                  if (fDict != finalDataType && fDict != elementClass){
-                     Error("TTreeReaderValueBase::CreateProxy", "Wrong data type %s", finalDataType ? finalDataType->GetName() : elementClass ? elementClass->GetName() : "UNKNOWN");
-                     fSetupStatus = kSetupMismatch;
-                     fProxy = 0;
-                     return;
-                  }
-               }
-            }
-
-
-            if (!fHaveStaticClassOffsets) {
-               Error("TTreeReaderValueBase::CreateProxy()", "The tree does not have a branch called %s. You could check with TTree::Print() for available branches.", fBranchName.Data());
-               fSetupStatus = kSetupMissingBranch;
-               fProxy = 0;
-               return;
-            }
+      // We had an error, the branch name had no "." or we simply did not find anything.
+      // We check if we had a branch found with the full name with a dot in it.
+      branch = branchFromFullName;
+      if (!branch) {
+         // Also that one was empty. We need to error out. We do it properly: at
+         // first we check if the routine to find branches with names with a "."
+         // provided a specific error message. If not, we go with a generic message.
+         if (errMsg.empty()) {
+            errMsg = "The tree does not have a branch called ";
+            errMsg += fBranchName.Data();
+            errMsg += ". You could check with TTree::Print() for available branches.";
          }
-         else {
-            myLeaf = branch->GetLeaf(TString(leafName(1, leafName.Length())));
-            if (!myLeaf){
-               Error("TTreeReaderValueBase::CreateProxy()",
-                     "The tree does not have a branch, nor a sub-branch called %s. You could check with TTree::Print() for available branches.", fBranchName.Data());
-               fSetupStatus = kSetupMissingBranch;
-               fProxy = 0;
-               return;
-            }
-            else {
-               TDictionary *tempDict = TDictionary::GetDictionary(myLeaf->GetTypeName());
-               if (tempDict && tempDict->IsA() == TDataType::Class() && TDictionary::GetDictionary(((TDataType*)tempDict)->GetTypeName()) == fDict){
-                  //fLeafOffset = myLeaf->GetOffset() / 4;
-                  branchActualType = fDict;
-                  fLeaf = myLeaf;
-                  fBranchName = branchName;
-                  fLeafName = leafName(1, leafName.Length());
-                  fHaveLeaf = fLeafName.Length() > 0;
-                  fSetupStatus = kSetupMatchLeaf;
-               }
-               else {
-                  Error("TTreeReaderValueBase::CreateProxy()",
-                        "Leaf of type %s cannot be read by TTreeReaderValue<%s>.", myLeaf->GetTypeName(), fDict->GetName());
-                  fSetupStatus = kSetupMismatch;
-               }
-            }
-         }
-      }
-      else {
-         Error("TTreeReaderValueBase::CreateProxy()", "The tree does not have a branch called %s. You could check with TTree::Print() for available branches.", fBranchName.Data());
-         fProxy = 0;
+         Error(errPrefix, errMsg.c_str());
          return;
+      } else {
+         // The branch found with the simplest search approach was successful.
+         // We reset the state, we continue
+         fSetupStatus = kSetupInternalError;
+         fStaticClassOffsets = {};
+         fHaveStaticClassOffsets = 0;
       }
    }
 
    if (!myLeaf && !fHaveStaticClassOffsets) {
+      // The following two lines cannot be swapped. The GetBranchDataType can
+      // change the value of branchActualType
       const char* branchActualTypeName = GetBranchDataType(branch, branchActualType);
-
       if (!branchActualType) {
-         Error("TTreeReaderValueBase::CreateProxy()", "The branch %s contains data of type %s, which does not have a dictionary.",
+         Error(errPrefix, "The branch %s contains data of type %s, which does not have a dictionary.",
                fBranchName.Data(), branchActualTypeName ? branchActualTypeName : "{UNDETERMINED TYPE}");
          fProxy = 0;
          return;
@@ -407,7 +464,7 @@ void ROOT::Internal::TTreeReaderValueBase::CreateProxy() {
             }
          }
          if (complainAboutMismatch) {
-            Error("TTreeReaderValueBase::CreateProxy()",
+            Error(errPrefix,
                   "The branch %s contains data of type %s. It cannot be accessed by a TTreeReaderValue<%s>",
                   fBranchName.Data(), branchActualType->GetName(),
                   fDict->GetName());
@@ -415,7 +472,6 @@ void ROOT::Internal::TTreeReaderValueBase::CreateProxy() {
          }
       }
    }
-
 
    // Update named proxy's dictionary
    if (namedProxy && !namedProxy->GetDict()) {

--- a/tree/treeplayer/src/TTreeReaderValue.cxx
+++ b/tree/treeplayer/src/TTreeReaderValue.cxx
@@ -426,7 +426,10 @@ void ROOT::Internal::TTreeReaderValueBase::CreateProxy() {
             errMsg += fBranchName.Data();
             errMsg += ". You could check with TTree::Print() for available branches.";
          }
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
          Error(errPrefix, errMsg.c_str());
+#pragma GCC diagnostic pop
          return;
       } else {
          // The branch found with the simplest search approach was successful.

--- a/tree/treeplayer/test/data.h
+++ b/tree/treeplayer/test/data.h
@@ -12,4 +12,13 @@ struct Data {
    Float16_t fFloat16;
 };
 
+struct V {
+   int a = -100;
+};
+
+struct W {
+   int b;
+   V v;
+};
+
 #endif

--- a/tree/treeplayer/test/leafs.cxx
+++ b/tree/treeplayer/test/leafs.cxx
@@ -180,3 +180,23 @@ TEST(TTreeReaderLeafs, ArrayWithReaderValue)
    *valueOfArr;
    EXPECT_FALSE(valueOfArr.IsValid());
 }
+
+
+TEST(TTreeReaderLeafs, NamesWithDots)
+{
+   gInterpreter->ProcessLine(".L data.h+");
+
+   TTree tree("t", "t");
+   V v;
+   v.a = 64;
+   tree.Branch("v", &v, "a/I");
+   W w;
+   w.v.a = 132;
+   tree.Branch("w", &w);
+   tree.Fill();
+
+   TTreeReader tr(&tree);
+   TTreeReaderValue<int> rv(tr, "v.a");
+   tr.Next();
+   EXPECT_EQ(*rv, 64) << "The wrong leaf has been read!";
+}


### PR DESCRIPTION
If a TTree contains

    a branch "v" with a leaf "a", created with t.Branch("v", &a, "a/I")
    a branch "w" containing a split struct that has a datamember "v" with a datamember "a"

constructing TTreeReaderValue<int>(r, "v.a") attaches the reader to "w.v.a" instead of "v.a". Note that in this scenario there is no way to access "v.a", because constructing TTreeReaderValue<int>(r, "v") attaches to "w.v" 