### PR TITLE
http: latest civetweb 1.11 plus OpenSSL patches

### DIFF
--- a/net/http/civetweb/CREDITS.md
+++ b/net/http/civetweb/CREDITS.md
@@ -1,9 +1,13 @@
 # Civetweb Contributors
 
 * Abhishek Lekshmanan
+* Abramo Bagnara
 * Adam Bailey
 * Alan Somers
+* Alberto Bignotti
 * Alex Kozlov
+* AndreyArsov
+* Anton Te
 * bel2125
 * Ben M. Ward
 * BigJoe
@@ -18,6 +22,8 @@
 * Christian Mauderer
 * Christopher Galas
 * cjh
+* Colden Cullen
+* Colm Sloan
 * Daniel Oaks
 * Daniel Rempel
 * Danny Al-Gaaf
@@ -28,42 +34,55 @@
 * ehlertjd
 * Eric Tsau
 * Erik Beran
+* Erik Partridge
 * extergnoto
-* F-Secure Corporation
 * feneuilflo
 * Fernando G. Aranda
+* Frank Hilliger
+* F-Secure Corporation
 * Grahack
 * grenclave
 * grunk
+* Guilherme Amadio
 * hansipie
 * HariKamath Kamath
 * Henry Chang
+* Herve Codina
+* ImgBotApp
 * Jack
+* Jacob Repp
 * Jacob Skillin
 * Jan Willem Janssen
 * Jeremy Lin
 * Jim Evans
 * jmc-
+* Joakim L. Gilje
 * Jochen Scheib
-* Joe Mucchiello
 * Joel Gallant
+* Joe Mucchiello
 * Johan De Taeye
+* John Faith
 * Jordan
 * Jordan Shelley
 * Joshua Boyd
 * Joshua D. Boyd
 * kakwa
 * kalphamon
+* Karol Mroz
+* Keith Holman
 * Keith Kyzivat
 * Kevin Branigan
 * Kevin Wojniak
+* Khem Raj
 * Kimmo Mustonen
 * Lammert Bies
 * Lawrence
-* Li Peng
 * Lianghui
+* Li Peng
+* Luka Rahne
 * Maarten Fremouw
 * makrsmark
+* marco
 * Mark Lakata
 * Martin Gaida
 * Mateusz Gralka
@@ -72,6 +91,8 @@
 * Morgan McGuire
 * mrdvlpr.xnu
 * Neil Jensen
+* newsoft
+* nfrmtkr
 * Nick Hildebrant
 * Nigel Stewart
 * nihildeb
@@ -79,32 +100,41 @@
 * palortoff
 * Patrick Drechsler
 * Patrick Trinkle
-* Paul Sokolovsky
 * Paulo Brizolara
+* Paul Sokolovsky
 * pavel.pimenov
 * PavelVozenilek
 * Perttu Ahola
 * Peter Foerster
 * Philipp Friedenberger
 * Philipp Hasper
-* Red54
-* Richard Screene
 * pkvamme
+* Radoslaw Zarzynski
+* Red54
+* Retallack Mark mark.retallack
+* Richard Screene
+* ryankopf
 * Sage Weil
 * Sangwhan Moon
 * Saumitra Vikram
 * Scott Nations
+* Sergey Linev
 * sgmesservey
 * shantanugadgil
 * Simon Hailes
 * slidertom
 * SpaceLord
 * sunfch
+* suzukibitman
 * thewaterymoon
 * THILMANT, Bernard
 * Thomas Davis
+* Thorsten Horstmann
 * tnoho
+* Tomas Andrle
+* Tom Deblauwe
 * Toni Wilk
+* Torben Jonas
 * Ulrich Hertlein
 * Walt Steverson
 * webxer
@@ -112,6 +142,8 @@
 * xeoshow
 * xtne6f
 * Yehuda Sadeh
+* Yury Z
+* zhen.wang
 
 # Mongoose Contributors
 CivetWeb is based on the Mongoose code.  The following users contributed to the original Mongoose release between 2010 and 2013.  This list was generated from the Mongoose GIT logs.  It does not contain contributions from the Mongoose mailing list.  There is no record for contributors prior to 2010.

--- a/net/http/civetweb/LICENSE.md
+++ b/net/http/civetweb/LICENSE.md
@@ -11,7 +11,7 @@ Civetweb License
 
 ### Included with all features.
 
-> Copyright (c) 2013-2017 The CivetWeb developers ([CREDITS.md](https://github.com/civetweb/civetweb/blob/master/CREDITS.md))
+> Copyright (c) 2013-2018 The CivetWeb developers ([CREDITS.md](https://github.com/civetweb/civetweb/blob/master/CREDITS.md))
 >
 > Copyright (c) 2004-2013 Sergey Lyubka
 >
@@ -73,7 +73,7 @@ SQLite3 License
 
 http://www.sqlite.org/copyright.html
 
-> 2001 September 15
+> 2001-09-15
 >
 > The author disclaims copyright to this source code.  In place of
 > a legal notice, here is a blessing:
@@ -88,11 +88,11 @@ lsqlite3 License
 
 ### Included only if built with Lua and SQLite support.
 
-> Copyright (C) 2002-2013 Tiago Dionizio, Doug Currie
+> Copyright (C) 2002-2016 Tiago Dionizio, Doug Currie
 > All rights reserved.
 > Author    : Tiago Dionizio <tiago.dionizio@ist.utl.pt>
 > Author    : Doug Currie <doug.currie@alum.mit.edu>
-> Library   : lsqlite3 - a SQLite 3 database binding for Lua 5
+> Library   : lsqlite3 - an SQLite 3 database binding for Lua 5
 >
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
@@ -120,7 +120,7 @@ Lua File System License
 
 http://keplerproject.github.io/luafilesystem/license.html
 
-> Copyright © 2003 Kepler Project.
+> Copyright Kepler Project 2003 (http://www.keplerproject.org/luafilesystem)
 >
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
@@ -186,7 +186,7 @@ https://github.com/svaarala/duktape/blob/master/LICENSE.txt
 > 
 > (http://opensource.org/licenses/MIT)
 > 
-> Copyright (c) 2013-2015 by Duktape authors (see AUTHORS.rst)
+> Copyright (c) 2013-2017 by Duktape authors (see AUTHORS.rst)
 >
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
@@ -205,4 +205,37 @@ https://github.com/svaarala/duktape/blob/master/LICENSE.txt
 > LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 > THE SOFTWARE.
+
+
+
+zlib License
+------
+
+### Included only if built with zlib support.
+
+https://www.zlib.net/zlib_license.html
+
+> zlib.h -- interface of the 'zlib' general purpose compression library
+> version 1.2.11, January 15th, 2017
+>
+> Copyright (C) 1995-2017 Jean-loup Gailly and Mark Adler
+>
+> This software is provided 'as-is', without any express or implied
+> warranty.  In no event will the authors be held liable for any damages
+> arising from the use of this software.
+>
+> Permission is granted to anyone to use this software for any purpose,
+> including commercial applications, and to alter it and redistribute it
+> freely, subject to the following restrictions:
+>
+> 1. The origin of this software must not be misrepresented; you must not
+>    claim that you wrote the original software. If you use this software
+>    in a product, an acknowledgment in the product documentation would be
+>    appreciated but is not required.
+> 2. Altered source versions must be plainly marked as such, and must not be
+>    misrepresented as being the original software.
+> 3. This notice may not be removed or altered from any source distribution.
+>
+> Jean-loup Gailly        Mark Adler
+> jloup@gzip.org          madler@alumni.caltech.edu
 

--- a/net/http/civetweb/README.md
+++ b/net/http/civetweb/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![GitHub contributors](https://img.shields.io/github/contributors/civetweb/civetweb.svg)](https://github.com/civetweb/civetweb/blob/master/CREDITS.md)
 
-Continuous integration for Linux and OSX ([Travis CI](https://travis-ci.org/civetweb/civetweb)):
+Continuous integration for Linux and macOS ([Travis CI](https://travis-ci.org/civetweb/civetweb)):
 
 [![Travis Build Status](https://travis-ci.org/civetweb/civetweb.svg?branch=master)](https://travis-ci.org/civetweb/civetweb)
 
@@ -140,7 +140,7 @@ Contributions are welcome provided all contributions carry the MIT license.
 
 DO NOT APPLY fixes copied from Mongoose to this project to prevent GPL tainting.
 Since 2013, CivetWeb and Mongoose are developed independently.
-By now the code base differs, so patches cannot be safely transfered in either direction.
+By now the code base differs, so patches cannot be safely transferred in either direction.
 
 Some guidelines can be found in [docs/Contribution.md](https://github.com/civetweb/civetweb/blob/master/docs/Contribution.md).
 

--- a/net/http/civetweb/civetweb.c
+++ b/net/http/civetweb/civetweb.c
@@ -1,4 +1,4 @@
-﻿/* Copyright (c) 2013-2017 the Civetweb developers
+/* Copyright (c) 2013-2018 the Civetweb developers
  * Copyright (c) 2004-2013 Sergey Lyubka
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -20,11 +20,36 @@
  * THE SOFTWARE.
  */
 
+#if defined(__GNUC__) || defined(__MINGW32__)
+#define GCC_VERSION                                                            \
+	(__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#if GCC_VERSION >= 40500
+/* gcc diagnostic pragmas available */
+#define GCC_DIAGNOSTIC
+#endif
+#endif
+
+#if defined(GCC_DIAGNOSTIC)
+/* Disable unused macros warnings - not all defines are required
+ * for all systems and all compilers. */
+#pragma GCC diagnostic ignored "-Wunused-macros"
+/* A padding warning is just plain useless */
+#pragma GCC diagnostic ignored "-Wpadded"
+#endif
+
+#if defined(__clang__) /* GCC does not (yet) support this pragma */
+/* We must set some flags for the headers we include. These flags
+ * are reserved ids according to C99, so we need to disable a
+ * warning for that. */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wreserved-id-macro"
+#endif
+
 #if defined(_WIN32)
 #if !defined(_CRT_SECURE_NO_WARNINGS)
 #define _CRT_SECURE_NO_WARNINGS /* Disable deprecation warning in VS2005 */
 #endif
-#ifndef _WIN32_WINNT /* defined for tdm-gcc so we can use getnameinfo */
+#if !defined(_WIN32_WINNT) /* defined for tdm-gcc so we can use getnameinfo */
 #define _WIN32_WINNT 0x0501
 #endif
 #else
@@ -34,23 +59,32 @@
 #if defined(__linux__) && !defined(_XOPEN_SOURCE)
 #define _XOPEN_SOURCE 600 /* For flockfile() on Linux */
 #endif
-#ifndef _LARGEFILE_SOURCE
+#if !defined(_LARGEFILE_SOURCE)
 #define _LARGEFILE_SOURCE /* For fseeko(), ftello() */
 #endif
-#ifndef _FILE_OFFSET_BITS
+#if !defined(_FILE_OFFSET_BITS)
 #define _FILE_OFFSET_BITS 64 /* Use 64-bit file offsets by default */
 #endif
-#ifndef __STDC_FORMAT_MACROS
+#if !defined(__STDC_FORMAT_MACROS)
 #define __STDC_FORMAT_MACROS /* <inttypes.h> wants this for C++ */
 #endif
-#ifndef __STDC_LIMIT_MACROS
+#if !defined(__STDC_LIMIT_MACROS)
 #define __STDC_LIMIT_MACROS /* C++ wants that for INT64_MAX */
 #endif
-#ifdef __sun
+#if !defined(_DARWIN_UNLIMITED_SELECT)
+#define _DARWIN_UNLIMITED_SELECT
+#endif
+#if defined(__sun)
 #define __EXTENSIONS__  /* to expose flockfile and friends in stdio.h */
 #define __inline inline /* not recognized on older compiler versions */
 #endif
 #endif
+
+#if defined(__clang__)
+/* Enable reserved-id-macro warning again. */
+#pragma GCC diagnostic pop
+#endif
+
 
 #if defined(USE_LUA)
 #define USE_TIMERS
@@ -77,12 +111,10 @@
 /* This code uses static_assert to check some conditions.
  * Unfortunately some compilers still do not support it, so we have a
  * replacement function here. */
-#if defined(_MSC_VER) && (_MSC_VER >= 1600)
-#define mg_static_assert static_assert
-#elif defined(__cplusplus) && (__cplusplus >= 201103L)
-#define mg_static_assert static_assert
-#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ > 201100L
 #define mg_static_assert _Static_assert
+#elif defined(__cplusplus) && __cplusplus >= 201103L
+#define mg_static_assert static_assert
 #else
 char static_assert_replacement[1];
 #define mg_static_assert(cond, txt)                                            \
@@ -97,8 +129,8 @@ mg_static_assert(sizeof(void *) >= sizeof(int), "data type size check");
 
 
 /* Alternative queue is well tested and should be the new default */
-#ifdef NO_ALTERNATIVE_QUEUE
-#ifdef ALTERNATIVE_QUEUE
+#if defined(NO_ALTERNATIVE_QUEUE)
+#if defined(ALTERNATIVE_QUEUE)
 #error "Define ALTERNATIVE_QUEUE or NO_ALTERNATIVE_QUEUE or none, but not both"
 #endif
 #else
@@ -107,7 +139,7 @@ mg_static_assert(sizeof(void *) >= sizeof(int), "data type size check");
 
 
 /* DTL -- including winsock2.h works better if lean and mean */
-#ifndef WIN32_LEAN_AND_MEAN
+#if !defined(WIN32_LEAN_AND_MEAN)
 #define WIN32_LEAN_AND_MEAN
 #endif
 
@@ -116,25 +148,81 @@ mg_static_assert(sizeof(void *) >= sizeof(int), "data type size check");
  * Symbian is no longer maintained since 2014-01-01.
  * Recent versions of CivetWeb are no longer tested for Symbian.
  * It makes no sense, to support an abandoned operating system.
- * All remaining "#ifdef __SYMBIAN__" cases will be droped from
- * the code sooner or later.
  */
-#pragma message                                                                \
-    "Symbian is no longer maintained. CivetWeb will drop Symbian support."
+#error "Symbian is no longer maintained. CivetWeb no longer supports Symbian."
 #define NO_SSL /* SSL is not supported */
 #define NO_CGI /* CGI is not supported */
 #define PATH_MAX FILENAME_MAX
 #endif /* __SYMBIAN32__ */
 
 
-#ifndef CIVETWEB_HEADER_INCLUDED
+#if !defined(CIVETWEB_HEADER_INCLUDED)
 /* Include the header file here, so the CivetWeb interface is defined for the
  * entire implementation, including the following forward definitions. */
 #include "civetweb.h"
 #endif
 
+#if !defined(DEBUG_TRACE)
+#if defined(DEBUG)
+static void DEBUG_TRACE_FUNC(const char *func,
+                             unsigned line,
+                             PRINTF_FORMAT_STRING(const char *fmt),
+                             ...) PRINTF_ARGS(3, 4);
 
-#ifndef IGNORE_UNUSED_RESULT
+#define DEBUG_TRACE(fmt, ...)                                                  \
+	DEBUG_TRACE_FUNC(__func__, __LINE__, fmt, __VA_ARGS__)
+
+#define NEED_DEBUG_TRACE_FUNC
+
+#else
+#define DEBUG_TRACE(fmt, ...)                                                  \
+	do {                                                                       \
+	} while (0)
+#endif /* DEBUG */
+#endif /* DEBUG_TRACE */
+
+
+#if !defined(DEBUG_ASSERT)
+#if defined(DEBUG)
+#define DEBUG_ASSERT(cond)                                                     \
+	do {                                                                       \
+		if (!(cond)) {                                                         \
+			DEBUG_TRACE("ASSERTION FAILED: %s", #cond);                        \
+			exit(2); /* Exit with error */                                     \
+		}                                                                      \
+	} while (0)
+#else
+#define DEBUG_ASSERT(cond)
+#endif /* DEBUG */
+#endif
+
+
+#if defined(__GNUC__) && defined(GCC_INSTRUMENTATION)
+void __cyg_profile_func_enter(void *this_fn, void *call_site)
+    __attribute__((no_instrument_function));
+
+void __cyg_profile_func_exit(void *this_fn, void *call_site)
+    __attribute__((no_instrument_function));
+
+void
+__cyg_profile_func_enter(void *this_fn, void *call_site)
+{
+	if ((void *)this_fn != (void *)printf) {
+		printf("E %p %p\n", this_fn, call_site);
+	}
+}
+
+void
+__cyg_profile_func_exit(void *this_fn, void *call_site)
+{
+	if ((void *)this_fn != (void *)printf) {
+		printf("X %p %p\n", this_fn, call_site);
+	}
+}
+#endif
+
+
+#if !defined(IGNORE_UNUSED_RESULT)
 #define IGNORE_UNUSED_RESULT(a) ((void)((a) && 1))
 #endif
 
@@ -150,7 +238,7 @@ mg_static_assert(sizeof(void *) >= sizeof(int), "data type size check");
  * but is used, the compiler raises a completely idiotic
  * "used-but-marked-unused" warning - and
  *   #pragma GCC diagnostic ignored "-Wused-but-marked-unused"
- * raises error: unknown option after ‘#pragma GCC diagnostic’.
+ * raises error: unknown option after "#pragma GCC diagnostic".
  * Disable this warning completely, until the GCC guys sober up
  * again.
  */
@@ -164,16 +252,17 @@ mg_static_assert(sizeof(void *) >= sizeof(int), "data type size check");
 #endif
 
 
-#ifndef _WIN32_WCE /* Some ANSI #includes are not available on Windows CE */
-#include <sys/types.h>
-#include <sys/stat.h>
+/* Some ANSI #includes are not available on Windows CE */
+#if !defined(_WIN32_WCE)
 #include <errno.h>
-#include <signal.h>
 #include <fcntl.h>
+#include <signal.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #endif /* !_WIN32_WCE */
 
 
-#ifdef __clang__
+#if defined(__clang__)
 /* When using -Weverything, clang does not accept it's own headers
  * in a release build configuration. Disable what is too much in
  * -Weverything. */
@@ -191,13 +280,15 @@ mg_static_assert(sizeof(void *) >= sizeof(int), "data type size check");
  * #pragma clang diagnostic ignored "-Wdate-time"
  * So we just have to disable ALL warnings for some lines
  * of code.
+ * This seems to be a known GCC bug, not resolved since 2012:
+ * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53431
  */
 #endif
 
 
-#ifdef __MACH__ /* Apple OSX section */
+#if defined(__MACH__) /* Apple OSX section */
 
-#ifdef __clang__
+#if defined(__clang__)
 #if (__clang_major__ == 3) && ((__clang_minor__ == 7) || (__clang_minor__ == 8))
 /* Avoid warnings for Xcode 7. It seems it does no longer exist in Xcode 8 */
 #pragma clang diagnostic ignored "-Wno-reserved-id-macro"
@@ -208,12 +299,11 @@ mg_static_assert(sizeof(void *) >= sizeof(int), "data type size check");
 #define CLOCK_MONOTONIC (1)
 #define CLOCK_REALTIME (2)
 
-#include <sys/errno.h>
-#include <sys/time.h>
 #include <mach/clock.h>
 #include <mach/mach.h>
 #include <mach/mach_time.h>
-#include <assert.h>
+#include <sys/errno.h>
+#include <sys/time.h>
 
 /* clock_gettime is not implemented on OSX prior to 10.12 */
 static int
@@ -238,12 +328,11 @@ _civet_clock_gettime(int clk_id, struct timespec *t)
 
 		if (clock_start_time == 0) {
 			kern_return_t mach_status = mach_timebase_info(&timebase_ifo);
-#if defined(DEBUG)
-			assert(mach_status == KERN_SUCCESS);
-#else
+			DEBUG_ASSERT(mach_status == KERN_SUCCESS);
+
 			/* appease "unused variable" warning for release builds */
 			(void)mach_status;
-#endif
+
 			clock_start_time = now;
 		}
 
@@ -259,7 +348,7 @@ _civet_clock_gettime(int clk_id, struct timespec *t)
 }
 
 /* if clock_gettime is declared, then __CLOCK_AVAILABILITY will be defined */
-#ifdef __CLOCK_AVAILABILITY
+#if defined(__CLOCK_AVAILABILITY)
 /* If we compiled with Mac OSX 10.12 or later, then clock_gettime will be
  * declared but it may be NULL at runtime. So we need to check before using
  * it. */
@@ -279,28 +368,75 @@ _civet_safe_clock_gettime(int clk_id, struct timespec *t)
 #endif
 
 
-#include <time.h>
-#include <stdlib.h>
-#include <stdarg.h>
-#include <assert.h>
-#include <string.h>
 #include <ctype.h>
 #include <limits.h>
+#include <stdarg.h>
 #include <stddef.h>
-#include <stdio.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
 
-#ifndef INT64_MAX
+/********************************************************************/
+/* CivetWeb configuration defines */
+/********************************************************************/
+
+/* Maximum number of threads that can be configured.
+ * The number of threads actually created depends on the "num_threads"
+ * configuration parameter, but this is the upper limit. */
+#if !defined(MAX_WORKER_THREADS)
+#define MAX_WORKER_THREADS (1024 * 64) /* in threads (count) */
+#endif
+
+/* Timeout interval for select/poll calls.
+ * The timeouts depend on "*_timeout_ms" configuration values, but long
+ * timeouts are split into timouts as small as SOCKET_TIMEOUT_QUANTUM.
+ * This reduces the time required to stop the server. */
+#if !defined(SOCKET_TIMEOUT_QUANTUM)
+#define SOCKET_TIMEOUT_QUANTUM (2000) /* in ms */
+#endif
+
+/* Do not try to compress files smaller than this limit. */
+#if !defined(MG_FILE_COMPRESSION_SIZE_LIMIT)
+#define MG_FILE_COMPRESSION_SIZE_LIMIT (1024) /* in bytes */
+#endif
+
+#if !defined(PASSWORDS_FILE_NAME)
+#define PASSWORDS_FILE_NAME ".htpasswd"
+#endif
+
+/* Initial buffer size for all CGI environment variables. In case there is
+ * not enough space, another block is allocated. */
+#if !defined(CGI_ENVIRONMENT_SIZE)
+#define CGI_ENVIRONMENT_SIZE (4096) /* in bytes */
+#endif
+
+/* Maximum number of environment variables. */
+#if !defined(MAX_CGI_ENVIR_VARS)
+#define MAX_CGI_ENVIR_VARS (256) /* in variables (count) */
+#endif
+
+/* General purpose buffer size. */
+#if !defined(MG_BUF_LEN) /* in bytes */
+#define MG_BUF_LEN (1024 * 8)
+#endif
+
+/* Size of the accepted socket queue (in case the old queue implementation
+ * is used). */
+#if !defined(MGSQLEN)
+#define MGSQLEN (20) /* count */
+#endif
+
+
+/********************************************************************/
+
+/* Helper makros */
+#define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
+
+/* Standard defines */
+#if !defined(INT64_MAX)
 #define INT64_MAX (9223372036854775807)
-#endif
-
-
-#ifndef MAX_WORKER_THREADS
-#define MAX_WORKER_THREADS (1024 * 64)
-#endif
-
-#ifndef SOCKET_TIMEOUT_QUANTUM /* in ms */
-#define SOCKET_TIMEOUT_QUANTUM (2000)
 #endif
 
 #define SHUTDOWN_RD (0)
@@ -313,8 +449,7 @@ mg_static_assert(MAX_WORKER_THREADS >= 1,
 mg_static_assert(sizeof(size_t) == 4 || sizeof(size_t) == 8,
                  "size_t data type size check");
 
-#if defined(_WIN32)                                                            \
-    && !defined(__SYMBIAN32__) /* WINDOWS / UNIX include block */
+#if defined(_WIN32) /* WINDOWS include block */
 #include <windows.h>
 #include <winsock2.h> /* DTL add for SO_EXCLUSIVE */
 #include <ws2tcpip.h>
@@ -322,25 +457,25 @@ mg_static_assert(sizeof(size_t) == 4 || sizeof(size_t) == 8,
 typedef const char *SOCK_OPT_TYPE;
 
 #if !defined(PATH_MAX)
-#define PATH_MAX (MAX_PATH)
-#endif
-
-#if !defined(PATH_MAX)
-#define PATH_MAX (4096)
+#define W_PATH_MAX (MAX_PATH)
+/* at most three UTF-8 chars per wchar_t */
+#define PATH_MAX (W_PATH_MAX * 3)
+#else
+#define W_PATH_MAX ((PATH_MAX + 2) / 3)
 #endif
 
 mg_static_assert(PATH_MAX >= 1, "path length must be a positive number");
 
-#ifndef _IN_PORT_T
-#ifndef in_port_t
+#if !defined(_IN_PORT_T)
+#if !defined(in_port_t)
 #define in_port_t u_short
 #endif
 #endif
 
-#ifndef _WIN32_WCE
-#include <process.h>
+#if !defined(_WIN32_WCE)
 #include <direct.h>
 #include <io.h>
+#include <process.h>
 #else            /* _WIN32_WCE */
 #define NO_CGI   /* WinCE has no pipes */
 #define NO_POPEN /* WinCE has no popen */
@@ -379,15 +514,23 @@ typedef long off_t;
 #define NO_SOCKLEN_T
 
 #if defined(_WIN64) || defined(__MINGW64__)
+#if !defined(SSL_LIB)
 #define SSL_LIB "ssleay64.dll"
+#endif
+#if !defined(CRYPTO_LIB)
 #define CRYPTO_LIB "libeay64.dll"
+#endif
 #else
+#if !defined(SSL_LIB)
 #define SSL_LIB "ssleay32.dll"
+#endif
+#if !defined(CRYPTO_LIB)
 #define CRYPTO_LIB "libeay32.dll"
+#endif
 #endif
 
 #define O_NONBLOCK (0)
-#ifndef W_OK
+#if !defined(W_OK)
 #define W_OK (2) /* http://msdn.microsoft.com/en-us/library/1w06ktdy.aspx */
 #endif
 #if !defined(EWOULDBLOCK)
@@ -403,10 +546,10 @@ typedef long off_t;
 #define mg_sleep(x) (Sleep(x))
 
 #define pipe(x) _pipe(x, MG_BUF_LEN, _O_BINARY)
-#ifndef popen
+#if !defined(popen)
 #define popen(x, y) (_popen(x, y))
 #endif
-#ifndef pclose
+#if !defined(pclose)
 #define pclose(x) (_pclose(x))
 #endif
 #define close(x) (_close(x))
@@ -420,7 +563,14 @@ typedef long off_t;
 #define funlockfile(x) (LeaveCriticalSection(&global_log_file_lock))
 #define sleep(x) (Sleep((x)*1000))
 #define rmdir(x) (_rmdir(x))
+#if defined(_WIN64) || !defined(__MINGW32__)
+/* Only MinGW 32 bit is missing this function */
 #define timegm(x) (_mkgmtime(x))
+#else
+time_t timegm(struct tm *tm);
+#define NEED_TIMEGM
+#endif
+
 
 #if !defined(fileno)
 #define fileno(x) (_fileno(x))
@@ -434,19 +584,19 @@ typedef struct {
 	struct mg_workerTLS *waiting_thread; /* The chain of threads */
 } pthread_cond_t;
 
-#ifndef __clockid_t_defined
+#if !defined(__clockid_t_defined)
 typedef DWORD clockid_t;
 #endif
-#ifndef CLOCK_MONOTONIC
+#if !defined(CLOCK_MONOTONIC)
 #define CLOCK_MONOTONIC (1)
 #endif
-#ifndef CLOCK_REALTIME
+#if !defined(CLOCK_REALTIME)
 #define CLOCK_REALTIME (2)
 #endif
-#ifndef CLOCK_THREAD
+#if !defined(CLOCK_THREAD)
 #define CLOCK_THREAD (3)
 #endif
-#ifndef CLOCK_PROCESS
+#if !defined(CLOCK_PROCESS)
 #define CLOCK_PROCESS (4)
 #endif
 
@@ -454,7 +604,7 @@ typedef DWORD clockid_t;
 #if defined(_MSC_VER) && (_MSC_VER >= 1900)
 #define _TIMESPEC_DEFINED
 #endif
-#ifndef _TIMESPEC_DEFINED
+#if !defined(_TIMESPEC_DEFINED)
 struct timespec {
 	time_t tv_sec; /* seconds */
 	long tv_nsec;  /* nanoseconds */
@@ -465,7 +615,7 @@ struct timespec {
 #define MUST_IMPLEMENT_CLOCK_GETTIME
 #endif
 
-#ifdef MUST_IMPLEMENT_CLOCK_GETTIME
+#if defined(MUST_IMPLEMENT_CLOCK_GETTIME)
 #define clock_gettime mg_clock_gettime
 static int
 clock_gettime(clockid_t clk_id, struct timespec *tp)
@@ -475,6 +625,13 @@ clock_gettime(clockid_t clk_id, struct timespec *tp)
 	BOOL ok = FALSE;
 	double d;
 	static double perfcnt_per_sec = 0.0;
+	static BOOL initialized = FALSE;
+
+	if (!initialized) {
+		QueryPerformanceFrequency((LARGE_INTEGER *)&li);
+		perfcnt_per_sec = 1.0 / li.QuadPart;
+		initialized = TRUE;
+	}
 
 	if (tp) {
 		memset(tp, 0, sizeof(*tp));
@@ -494,18 +651,12 @@ clock_gettime(clockid_t clk_id, struct timespec *tp)
 		} else if (clk_id == CLOCK_MONOTONIC) {
 
 			/* BEGIN: CLOCK_MONOTONIC = stopwatch (time differences) */
-			if (perfcnt_per_sec == 0.0) {
-				QueryPerformanceFrequency((LARGE_INTEGER *)&li);
-				perfcnt_per_sec = 1.0 / li.QuadPart;
-			}
-			if (perfcnt_per_sec != 0.0) {
-				QueryPerformanceCounter((LARGE_INTEGER *)&li);
-				d = li.QuadPart * perfcnt_per_sec;
-				tp->tv_sec = (time_t)d;
-				d -= tp->tv_sec;
-				tp->tv_nsec = (long)(d * 1.0E9);
-				ok = TRUE;
-			}
+			QueryPerformanceCounter((LARGE_INTEGER *)&li);
+			d = li.QuadPart * perfcnt_per_sec;
+			tp->tv_sec = (time_t)d;
+			d -= (double)tp->tv_sec;
+			tp->tv_nsec = (long)(d * 1.0E9);
+			ok = TRUE;
 			/* END: CLOCK_MONOTONIC */
 
 		} else if (clk_id == CLOCK_THREAD) {
@@ -572,8 +723,6 @@ static void path_to_unicode(const struct mg_connection *conn,
 
 /* All file operations need to be rewritten to solve #246. */
 
-#include "file_ops.inl"
-
 struct mg_file;
 
 static const char *
@@ -591,14 +740,13 @@ typedef struct DIR {
 	struct dirent result;
 } DIR;
 
-#if defined(_WIN32) && !defined(POLLIN)
-#ifndef HAVE_POLL
+#if defined(_WIN32)
+#if !defined(HAVE_POLL)
 struct pollfd {
 	SOCKET fd;
 	short events;
 	short revents;
 };
-#define POLLIN (0x0300)
 #endif
 #endif
 
@@ -607,30 +755,29 @@ struct pollfd {
 #pragma comment(lib, "Ws2_32.lib")
 #endif
 
-#else /* defined(_WIN32) && !defined(__SYMBIAN32__) -                          \
-         WINDOWS / UNIX include block */
+#else /* defined(_WIN32) - WINDOWS vs UNIX include block */
 
-#include <sys/wait.h>
-#include <sys/socket.h>
-#include <sys/poll.h>
-#include <netinet/in.h>
 #include <arpa/inet.h>
-#include <sys/time.h>
-#include <sys/utsname.h>
-#include <stdint.h>
 #include <inttypes.h>
 #include <netdb.h>
+#include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <stdint.h>
+#include <sys/poll.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/utsname.h>
+#include <sys/wait.h>
 typedef const void *SOCK_OPT_TYPE;
 
 #if defined(ANDROID)
 typedef unsigned short int in_port_t;
 #endif
 
+#include <dirent.h>
+#include <grp.h>
 #include <pwd.h>
 #include <unistd.h>
-#include <grp.h>
-#include <dirent.h>
 #define vsnprintf_impl vsnprintf
 
 #if !defined(NO_SSL_DL) && !defined(NO_SSL)
@@ -648,7 +795,7 @@ typedef unsigned short int in_port_t;
 #define CRYPTO_LIB "libcrypto.so"
 #endif
 #endif
-#ifndef O_BINARY
+#if !defined(O_BINARY)
 #define O_BINARY (0)
 #endif /* O_BINARY */
 #define closesocket(a) (close(a))
@@ -667,7 +814,7 @@ typedef int SOCKET;
 
 #if defined(__hpux)
 /* HPUX 11 does not have monotonic, fall back to realtime */
-#ifndef CLOCK_MONOTONIC
+#if !defined(CLOCK_MONOTONIC)
 #define CLOCK_MONOTONIC CLOCK_REALTIME
 #endif
 
@@ -682,18 +829,74 @@ typedef int SOCKET;
 #define socklen_t int
 #endif /* hpux */
 
-#endif /* defined(_WIN32) && !defined(__SYMBIAN32__) -                         \
-          WINDOWS / UNIX include block */
+#endif /* defined(_WIN32) - WINDOWS vs UNIX include block */
+
+/* Maximum queue length for pending connections. This value is passed as
+ * parameter to the "listen" socket call. */
+#if !defined(SOMAXCONN)
+/* This symbol may be defined in winsock2.h so this must after that include */
+#define SOMAXCONN (100) /* in pending connections (count) */
+#endif
+
+/* In case our C library is missing "timegm", provide an implementation */
+#if defined(NEED_TIMEGM)
+static inline int
+is_leap(int y)
+{
+	return (y % 4 == 0 && y % 100 != 0) || y % 400 == 0;
+}
+
+static inline int
+count_leap(int y)
+{
+	return (y - 1969) / 4 - (y - 1901) / 100 + (y - 1601) / 400;
+}
+
+time_t
+timegm(struct tm *tm)
+{
+	static const unsigned short ydays[] = {
+	    0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365};
+	int year = tm->tm_year + 1900;
+	int mon = tm->tm_mon;
+	int mday = tm->tm_mday - 1;
+	int hour = tm->tm_hour;
+	int min = tm->tm_min;
+	int sec = tm->tm_sec;
+
+	if (year < 1970 || mon < 0 || mon > 11 || mday < 0
+	    || (mday >= ydays[mon + 1] - ydays[mon]
+	                    + (mon == 1 && is_leap(year) ? 1 : 0))
+	    || hour < 0 || hour > 23 || min < 0 || min > 59 || sec < 0 || sec > 60)
+		return -1;
+
+	time_t res = year - 1970;
+	res *= 365;
+	res += mday;
+	res += ydays[mon] + (mon > 1 && is_leap(year) ? 1 : 0);
+	res += count_leap(year);
+
+	res *= 24;
+	res += hour;
+	res *= 60;
+	res += min;
+	res *= 60;
+	res += sec;
+	return res;
+}
+#endif /* NEED_TIMEGM */
+
 
 /* va_copy should always be a macro, C99 and C++11 - DTL */
-#ifndef va_copy
+#if !defined(va_copy)
 #define va_copy(x, y) ((x) = (y))
 #endif
 
-#ifdef _WIN32
+
+#if defined(_WIN32)
 /* Create substitutes for POSIX functions in Win32. */
 
-#if defined(__MINGW32__)
+#if defined(GCC_DIAGNOSTIC)
 /* Show no warning in case system functions are not used. */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
@@ -715,7 +918,7 @@ static int
 pthread_key_create(
     pthread_key_t *key,
     void (*_ignored)(void *) /* destructor not supported for Windows */
-    )
+)
 {
 	(void)_ignored;
 
@@ -750,7 +953,7 @@ pthread_getspecific(pthread_key_t key)
 	return TlsGetValue(key);
 }
 
-#if defined(__MINGW32__)
+#if defined(GCC_DIAGNOSTIC)
 /* Enable unused function warning again */
 #pragma GCC diagnostic pop
 #endif
@@ -761,18 +964,10 @@ static pthread_mutexattr_t pthread_mutex_attr;
 #endif /* _WIN32 */
 
 
-#define PASSWORDS_FILE_NAME ".htpasswd"
-#define CGI_ENVIRONMENT_SIZE (4096)
-#define MAX_CGI_ENVIR_VARS (256)
-#define MG_BUF_LEN (8192)
-
-#define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
-
-
 #if defined(_WIN32_WCE)
 /* Create substitutes for POSIX functions in Win32. */
 
-#if defined(__MINGW32__)
+#if defined(GCC_DIAGNOSTIC)
 /* Show no warning in case system functions are not used. */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
@@ -881,8 +1076,8 @@ FUNCTION_MAY_BE_UNUSED
 static int
 rename(const char *a, const char *b)
 {
-	wchar_t wa[PATH_MAX];
-	wchar_t wb[PATH_MAX];
+	wchar_t wa[W_PATH_MAX];
+	wchar_t wb[W_PATH_MAX];
 	path_to_unicode(NULL, a, wa, ARRAY_SIZE(wa));
 	path_to_unicode(NULL, b, wb, ARRAY_SIZE(wb));
 
@@ -900,7 +1095,7 @@ FUNCTION_MAY_BE_UNUSED
 static int
 stat(const char *name, struct stat *st)
 {
-	wchar_t wbuf[PATH_MAX];
+	wchar_t wbuf[W_PATH_MAX];
 	WIN32_FILE_ATTRIBUTE_DATA attr;
 	time_t creation_time, write_time;
 
@@ -932,7 +1127,7 @@ stat(const char *name, struct stat *st)
 #define EACCES 13
 #define ENOENT 2
 
-#if defined(__MINGW32__)
+#if defined(GCC_DIAGNOSTIC)
 /* Enable unused function warning again */
 #pragma GCC diagnostic pop
 #endif
@@ -940,15 +1135,11 @@ stat(const char *name, struct stat *st)
 #endif /* defined(_WIN32_WCE) */
 
 
-#if defined(__GNUC__) || defined(__MINGW32__)
+#if defined(GCC_DIAGNOSTIC)
 /* Show no warning in case system functions are not used. */
-#define GCC_VERSION                                                            \
-	(__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
-#if GCC_VERSION >= 40500
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
-#endif /* GCC_VERSION >= 40500 */
-#endif /* defined(__GNUC__) || defined(__MINGW32__) */
+#endif /* defined(GCC_DIAGNOSTIC) */
 #if defined(__clang__)
 /* Show no warning in case system functions are not used. */
 #pragma clang diagnostic push
@@ -958,7 +1149,7 @@ stat(const char *name, struct stat *st)
 static pthread_mutex_t global_lock_mutex;
 
 
-#if defined(_WIN32) && !defined(__SYMBIAN32__)
+#if defined(_WIN32)
 /* Forward declaration for Windows */
 FUNCTION_MAY_BE_UNUSED
 static int pthread_mutex_lock(pthread_mutex_t *mutex);
@@ -989,7 +1180,7 @@ static int
 mg_atomic_inc(volatile int *addr)
 {
 	int ret;
-#if defined(_WIN32) && !defined(__SYMBIAN32__) && !defined(NO_ATOMICS)
+#if defined(_WIN32) && !defined(NO_ATOMICS)
 	/* Depending on the SDK, this function uses either
 	 * (volatile unsigned int *) or (volatile LONG *),
 	 * so whatever you use, the other SDK is likely to raise a warning. */
@@ -1012,7 +1203,7 @@ static int
 mg_atomic_dec(volatile int *addr)
 {
 	int ret;
-#if defined(_WIN32) && !defined(__SYMBIAN32__) && !defined(NO_ATOMICS)
+#if defined(_WIN32) && !defined(NO_ATOMICS)
 	/* Depending on the SDK, this function uses either
 	 * (volatile unsigned int *) or (volatile LONG *),
 	 * so whatever you use, the other SDK is likely to raise a warning. */
@@ -1035,7 +1226,7 @@ static int64_t
 mg_atomic_add(volatile int64_t *addr, int64_t value)
 {
 	int64_t ret;
-#if defined(_WIN64) && !defined(__SYMBIAN32__) && !defined(NO_ATOMICS)
+#if defined(_WIN64) && !defined(NO_ATOMICS)
 	ret = InterlockedAdd64(addr, value);
 #elif defined(__GNUC__)                                                        \
     && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 0)))           \
@@ -1052,12 +1243,10 @@ mg_atomic_add(volatile int64_t *addr, int64_t value)
 #endif
 
 
-#if defined(__GNUC__)
+#if defined(GCC_DIAGNOSTIC)
 /* Show no warning in case system functions are not used. */
-#if GCC_VERSION >= 40500
 #pragma GCC diagnostic pop
-#endif /* GCC_VERSION >= 40500 */
-#endif /* defined(__GNUC__) */
+#endif /* defined(GCC_DIAGNOSTIC) */
 #if defined(__clang__)
 /* Show no warning in case system functions are not used. */
 #pragma clang diagnostic pop
@@ -1326,22 +1515,22 @@ static void mg_snprintf(const struct mg_connection *conn,
 
 /* This following lines are just meant as a reminder to use the mg-functions
  * for memory management */
-#ifdef malloc
+#if defined(malloc)
 #undef malloc
 #endif
-#ifdef calloc
+#if defined(calloc)
 #undef calloc
 #endif
-#ifdef realloc
+#if defined(realloc)
 #undef realloc
 #endif
-#ifdef free
+#if defined(free)
 #undef free
 #endif
-#ifdef snprintf
+#if defined(snprintf)
 #undef snprintf
 #endif
-#ifdef vsnprintf
+#if defined(vsnprintf)
 #undef vsnprintf
 #endif
 #define malloc DO_NOT_USE_THIS_FUNCTION__USE_mg_malloc
@@ -1349,8 +1538,9 @@ static void mg_snprintf(const struct mg_connection *conn,
 #define realloc DO_NOT_USE_THIS_FUNCTION__USE_mg_realloc
 #define free DO_NOT_USE_THIS_FUNCTION__USE_mg_free
 #define snprintf DO_NOT_USE_THIS_FUNCTION__USE_mg_snprintf
-#ifdef _WIN32 /* vsnprintf must not be used in any system, * \ \ \             \
-               * but this define only works well for Windows. */
+#if defined(_WIN32)
+/* vsnprintf must not be used in any system,
+ * but this define only works well for Windows. */
 #define vsnprintf DO_NOT_USE_THIS_FUNCTION__USE_mg_vsnprintf
 #endif
 
@@ -1365,24 +1555,28 @@ static int mg_ssl_initialized = 0;
 static pthread_key_t sTlsKey; /* Thread local storage index */
 static int thread_idx_max = 0;
 
+#if defined(MG_LEGACY_INTERFACE)
+#define MG_ALLOW_USING_GET_REQUEST_INFO_FOR_RESPONSE
+#endif
 
 struct mg_workerTLS {
 	int is_master;
 	unsigned long thread_idx;
-#if defined(_WIN32) && !defined(__SYMBIAN32__)
+#if defined(_WIN32)
 	HANDLE pthread_cond_helper_mutex;
 	struct mg_workerTLS *next_waiting_thread;
+#endif
+#if defined(MG_ALLOW_USING_GET_REQUEST_INFO_FOR_RESPONSE)
+	char txtbuf[4];
 #endif
 };
 
 
-#if defined(__GNUC__) || defined(__MINGW32__)
+#if defined(GCC_DIAGNOSTIC)
 /* Show no warning in case system functions are not used. */
-#if GCC_VERSION >= 40500
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
-#endif /* GCC_VERSION >= 40500 */
-#endif /* defined(__GNUC__) || defined(__MINGW32__) */
+#endif /* defined(GCC_DIAGNOSTIC) */
 #if defined(__clang__)
 /* Show no warning in case system functions are not used. */
 #pragma clang diagnostic push
@@ -1404,11 +1598,11 @@ FUNCTION_MAY_BE_UNUSED
 static unsigned long
 mg_current_thread_id(void)
 {
-#ifdef _WIN32
+#if defined(_WIN32)
 	return GetCurrentThreadId();
 #else
 
-#ifdef __clang__
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunreachable-code"
 /* For every compiler, either "sizeof(pthread_t) > sizeof(unsigned long)"
@@ -1442,7 +1636,7 @@ mg_current_thread_id(void)
 		return ret;
 	}
 
-#ifdef __clang__
+#if defined(__clang__)
 #pragma clang diagnostic pop
 #endif
 
@@ -1460,25 +1654,17 @@ mg_get_current_time_ns(void)
 }
 
 
-#if defined(__GNUC__)
+#if defined(GCC_DIAGNOSTIC)
 /* Show no warning in case system functions are not used. */
-#if GCC_VERSION >= 40500
 #pragma GCC diagnostic pop
-#endif /* GCC_VERSION >= 40500 */
-#endif /* defined(__GNUC__) */
+#endif /* defined(GCC_DIAGNOSTIC) */
 #if defined(__clang__)
 /* Show no warning in case system functions are not used. */
 #pragma clang diagnostic pop
 #endif
 
 
-#if !defined(DEBUG_TRACE)
-#if defined(DEBUG)
-static void DEBUG_TRACE_FUNC(const char *func,
-                             unsigned line,
-                             PRINTF_FORMAT_STRING(const char *fmt),
-                             ...) PRINTF_ARGS(3, 4);
-
+#if defined(NEED_DEBUG_TRACE_FUNC)
 static void
 DEBUG_TRACE_FUNC(const char *func, unsigned line, const char *fmt, ...)
 {
@@ -1514,40 +1700,21 @@ DEBUG_TRACE_FUNC(const char *func, unsigned line, const char *fmt, ...)
 	funlockfile(stdout);
 	nslast = nsnow;
 }
-
-#define DEBUG_TRACE(fmt, ...)                                                  \
-	DEBUG_TRACE_FUNC(__func__, __LINE__, fmt, __VA_ARGS__)
-
-#else
-#define DEBUG_TRACE(fmt, ...)                                                  \
-	do {                                                                       \
-	} while (0)
-#endif /* DEBUG */
-#endif /* DEBUG_TRACE */
+#endif /* NEED_DEBUG_TRACE_FUNC */
 
 
 #define MD5_STATIC static
 #include "md5.inl"
 
 /* Darwin prior to 7.0 and Win32 do not have socklen_t */
-#ifdef NO_SOCKLEN_T
+#if defined(NO_SOCKLEN_T)
 typedef int socklen_t;
 #endif /* NO_SOCKLEN_T */
-#define _DARWIN_UNLIMITED_SELECT
 
 #define IP_ADDR_STR_LEN (50) /* IPv6 hex string is 46 chars */
 
 #if !defined(MSG_NOSIGNAL)
 #define MSG_NOSIGNAL (0)
-#endif
-
-#if !defined(SOMAXCONN)
-#define SOMAXCONN (100)
-#endif
-
-/* Size of the accepted socket queue */
-#if !defined(MGSQLEN)
-#define MGSQLEN (20)
 #endif
 
 
@@ -1556,16 +1723,34 @@ typedef struct SSL SSL; /* dummy for SSL argument to push/pull */
 typedef struct SSL_CTX SSL_CTX;
 #else
 #if defined(NO_SSL_DL)
-#include <openssl/ssl.h>
-#include <openssl/err.h>
-#include <openssl/crypto.h>
-#include <openssl/x509.h>
-#include <openssl/pem.h>
-#include <openssl/engine.h>
-#include <openssl/conf.h>
-#include <openssl/dh.h>
 #include <openssl/bn.h>
+#include <openssl/conf.h>
+#include <openssl/crypto.h>
+#include <openssl/dh.h>
+#include <openssl/engine.h>
+#include <openssl/err.h>
 #include <openssl/opensslv.h>
+#include <openssl/pem.h>
+#include <openssl/ssl.h>
+#include <openssl/tls1.h>
+#include <openssl/x509.h>
+
+#if defined(WOLFSSL_VERSION)
+/* Additional defines for WolfSSL, see
+ * https://github.com/civetweb/civetweb/issues/583 */
+#include "wolfssl_extras.inl"
+#endif
+
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+/* If OpenSSL headers are included, automatically select the API version */
+#if !defined(OPENSSL_API_1_1)
+#define OPENSSL_API_1_1
+#endif
+#define OPENSSL_REMOVE_THREAD_STATE()
+#else
+#define OPENSSL_REMOVE_THREAD_STATE() ERR_remove_thread_state(NULL)
+#endif
+
 #else
 
 /* SSL loaded dynamically from DLL.
@@ -1620,6 +1805,12 @@ typedef struct x509 X509;
 #define SSL_ERROR_WANT_CONNECT (7)
 #define SSL_ERROR_WANT_ACCEPT (8)
 
+#define TLSEXT_TYPE_server_name (0)
+#define TLSEXT_NAMETYPE_host_name (0)
+#define SSL_TLSEXT_ERR_OK (0)
+#define SSL_TLSEXT_ERR_ALERT_WARNING (1)
+#define SSL_TLSEXT_ERR_ALERT_FATAL (2)
+#define SSL_TLSEXT_ERR_NOACK (3)
 
 struct ssl_func {
 	const char *name;  /* SSL function name */
@@ -1627,7 +1818,7 @@ struct ssl_func {
 };
 
 
-#ifdef OPENSSL_API_1_1
+#if defined(OPENSSL_API_1_1)
 
 #define SSL_free (*(void (*)(SSL *))ssl_sw[0].ptr)
 #define SSL_accept (*(int (*)(SSL *))ssl_sw[1].ptr)
@@ -1636,12 +1827,13 @@ struct ssl_func {
 #define SSL_write (*(int (*)(SSL *, const void *, int))ssl_sw[4].ptr)
 #define SSL_get_error (*(int (*)(SSL *, int))ssl_sw[5].ptr)
 #define SSL_set_fd (*(int (*)(SSL *, SOCKET))ssl_sw[6].ptr)
-#define SSL_new (*(SSL * (*)(SSL_CTX *))ssl_sw[7].ptr)
-#define SSL_CTX_new (*(SSL_CTX * (*)(SSL_METHOD *))ssl_sw[8].ptr)
-#define TLS_server_method (*(SSL_METHOD * (*)(void))ssl_sw[9].ptr)
+#define SSL_new (*(SSL * (*)(SSL_CTX *)) ssl_sw[7].ptr)
+#define SSL_CTX_new (*(SSL_CTX * (*)(SSL_METHOD *)) ssl_sw[8].ptr)
+#define TLS_server_method (*(SSL_METHOD * (*)(void)) ssl_sw[9].ptr)
 #define OPENSSL_init_ssl                                                       \
 	(*(int (*)(uint64_t opts,                                                  \
-	           const OPENSSL_INIT_SETTINGS *settings))ssl_sw[10].ptr)
+	           const OPENSSL_INIT_SETTINGS *settings))ssl_sw[10]               \
+	      .ptr)
 #define SSL_CTX_use_PrivateKey_file                                            \
 	(*(int (*)(SSL_CTX *, const char *, int))ssl_sw[11].ptr)
 #define SSL_CTX_use_certificate_file                                           \
@@ -1651,20 +1843,21 @@ struct ssl_func {
 #define SSL_CTX_free (*(void (*)(SSL_CTX *))ssl_sw[14].ptr)
 #define SSL_CTX_use_certificate_chain_file                                     \
 	(*(int (*)(SSL_CTX *, const char *))ssl_sw[15].ptr)
-#define TLS_client_method (*(SSL_METHOD * (*)(void))ssl_sw[16].ptr)
+#define TLS_client_method (*(SSL_METHOD * (*)(void)) ssl_sw[16].ptr)
 #define SSL_pending (*(int (*)(SSL *))ssl_sw[17].ptr)
 #define SSL_CTX_set_verify                                                     \
 	(*(void (*)(SSL_CTX *,                                                     \
 	            int,                                                           \
-	            int (*verify_callback)(int, X509_STORE_CTX *)))ssl_sw[18].ptr)
+	            int (*verify_callback)(int, X509_STORE_CTX *)))ssl_sw[18]      \
+	      .ptr)
 #define SSL_shutdown (*(int (*)(SSL *))ssl_sw[19].ptr)
 #define SSL_CTX_load_verify_locations                                          \
 	(*(int (*)(SSL_CTX *, const char *, const char *))ssl_sw[20].ptr)
 #define SSL_CTX_set_default_verify_paths (*(int (*)(SSL_CTX *))ssl_sw[21].ptr)
 #define SSL_CTX_set_verify_depth (*(void (*)(SSL_CTX *, int))ssl_sw[22].ptr)
-#define SSL_get_peer_certificate (*(X509 * (*)(SSL *))ssl_sw[23].ptr)
+#define SSL_get_peer_certificate (*(X509 * (*)(SSL *)) ssl_sw[23].ptr)
 #define SSL_get_version (*(const char *(*)(SSL *))ssl_sw[24].ptr)
-#define SSL_get_current_cipher (*(SSL_CIPHER * (*)(SSL *))ssl_sw[25].ptr)
+#define SSL_get_current_cipher (*(SSL_CIPHER * (*)(SSL *)) ssl_sw[25].ptr)
 #define SSL_CIPHER_get_name                                                    \
 	(*(const char *(*)(const SSL_CIPHER *))ssl_sw[26].ptr)
 #define SSL_CTX_check_private_key (*(int (*)(SSL_CTX *))ssl_sw[27].ptr)
@@ -1676,15 +1869,34 @@ struct ssl_func {
 #define SSL_CTX_set_options                                                    \
 	(*(unsigned long (*)(SSL_CTX *, unsigned long))ssl_sw[31].ptr)
 #define SSL_CTX_set_info_callback                                              \
-	(*(void (*)(SSL_CTX * ctx,                                                 \
-	            void (*callback)(const SSL * s, int, int)))ssl_sw[32].ptr)
-#define SSL_get_ex_data (*(char *(*)(SSL *, int))ssl_sw[33].ptr)
+	(*(void (*)(SSL_CTX * ctx, void (*callback)(const SSL *, int, int)))       \
+	      ssl_sw[32]                                                           \
+	          .ptr)
+#define SSL_get_ex_data (*(char *(*)(const SSL *, int))ssl_sw[33].ptr)
 #define SSL_set_ex_data (*(void (*)(SSL *, int, char *))ssl_sw[34].ptr)
+#define SSL_CTX_callback_ctrl                                                  \
+	(*(long (*)(SSL_CTX *, int, void (*)(void)))ssl_sw[35].ptr)
+#define SSL_get_servername                                                     \
+	(*(const char *(*)(const SSL *, int type))ssl_sw[36].ptr)
+#define SSL_set_SSL_CTX (*(SSL_CTX * (*)(SSL *, SSL_CTX *)) ssl_sw[37].ptr)
+#define SSL_ctrl (*(long (*)(SSL *, int, long, void *))ssl_sw[38].ptr)
 
 #define SSL_CTX_clear_options(ctx, op)                                         \
 	SSL_CTX_ctrl((ctx), SSL_CTRL_CLEAR_OPTIONS, (op), NULL)
 #define SSL_CTX_set_ecdh_auto(ctx, onoff)                                      \
 	SSL_CTX_ctrl(ctx, SSL_CTRL_SET_ECDH_AUTO, onoff, NULL)
+
+#define SSL_CTRL_SET_TLSEXT_SERVERNAME_CB 53
+#define SSL_CTRL_SET_TLSEXT_SERVERNAME_ARG 54
+#define SSL_CTRL_SET_TLSEXT_HOSTNAME 55
+#define SSL_CTX_set_tlsext_servername_callback(ctx, cb)                        \
+	SSL_CTX_callback_ctrl(ctx,                                                 \
+	                      SSL_CTRL_SET_TLSEXT_SERVERNAME_CB,                   \
+	                      (void (*)(void))cb)
+#define SSL_CTX_set_tlsext_servername_arg(ctx, arg)                            \
+	SSL_CTX_ctrl(ctx, SSL_CTRL_SET_TLSEXT_SERVERNAME_ARG, 0, (void *)arg)
+#define SSL_set_tlsext_host_name(ctx, arg)                                     \
+	SSL_ctrl(ctx, SSL_CTRL_SET_TLSEXT_HOSTNAME, 0, (void *)arg)
 
 #define X509_get_notBefore(x) ((x)->cert_info->validity->notBefore)
 #define X509_get_notAfter(x) ((x)->cert_info->validity->notAfter)
@@ -1694,31 +1906,32 @@ struct ssl_func {
 
 #define ERR_get_error (*(unsigned long (*)(void))crypto_sw[0].ptr)
 #define ERR_error_string (*(char *(*)(unsigned long, char *))crypto_sw[1].ptr)
-#define ERR_remove_state (*(void (*)(unsigned long))crypto_sw[2].ptr)
-#define CONF_modules_unload (*(void (*)(int))crypto_sw[3].ptr)
-#define X509_free (*(void (*)(X509 *))crypto_sw[4].ptr)
-#define X509_get_subject_name (*(X509_NAME * (*)(X509 *))crypto_sw[5].ptr)
-#define X509_get_issuer_name (*(X509_NAME * (*)(X509 *))crypto_sw[6].ptr)
+#define CONF_modules_unload (*(void (*)(int))crypto_sw[2].ptr)
+#define X509_free (*(void (*)(X509 *))crypto_sw[3].ptr)
+#define X509_get_subject_name (*(X509_NAME * (*)(X509 *)) crypto_sw[4].ptr)
+#define X509_get_issuer_name (*(X509_NAME * (*)(X509 *)) crypto_sw[5].ptr)
 #define X509_NAME_oneline                                                      \
-	(*(char *(*)(X509_NAME *, char *, int))crypto_sw[7].ptr)
-#define X509_get_serialNumber (*(ASN1_INTEGER * (*)(X509 *))crypto_sw[8].ptr)
+	(*(char *(*)(X509_NAME *, char *, int))crypto_sw[6].ptr)
+#define X509_get_serialNumber (*(ASN1_INTEGER * (*)(X509 *)) crypto_sw[7].ptr)
 #define EVP_get_digestbyname                                                   \
-	(*(const EVP_MD *(*)(const char *))crypto_sw[9].ptr)
+	(*(const EVP_MD *(*)(const char *))crypto_sw[8].ptr)
 #define EVP_Digest                                                             \
 	(*(int (*)(                                                                \
 	    const void *, size_t, void *, unsigned int *, const EVP_MD *, void *)) \
-	      crypto_sw[10].ptr)
-#define i2d_X509 (*(int (*)(X509 *, unsigned char **))crypto_sw[11].ptr)
-#define BN_bn2hex (*(char *(*)(const BIGNUM *a))crypto_sw[12].ptr)
+	      crypto_sw[9]                                                         \
+	          .ptr)
+#define i2d_X509 (*(int (*)(X509 *, unsigned char **))crypto_sw[10].ptr)
+#define BN_bn2hex (*(char *(*)(const BIGNUM *a))crypto_sw[11].ptr)
 #define ASN1_INTEGER_to_BN                                                     \
-	(*(BIGNUM * (*)(const ASN1_INTEGER *ai, BIGNUM *bn))crypto_sw[13].ptr)
-#define BN_free (*(void (*)(const BIGNUM *a))crypto_sw[14].ptr)
-#define CRYPTO_free (*(void (*)(void *addr))crypto_sw[15].ptr)
+	(*(BIGNUM * (*)(const ASN1_INTEGER *ai, BIGNUM *bn)) crypto_sw[12].ptr)
+#define BN_free (*(void (*)(const BIGNUM *a))crypto_sw[13].ptr)
+#define CRYPTO_free (*(void (*)(void *addr))crypto_sw[14].ptr)
 
 #define OPENSSL_free(a) CRYPTO_free(a)
 
+#define OPENSSL_REMOVE_THREAD_STATE()
 
-/* set_ssl_option() function updates this array.
+/* init_ssl_ctx() function updates this array.
  * It loads SSL library dynamically and changes NULLs to the actual addresses
  * of respective functions. The macros above (like SSL_connect()) are really
  * just calling these functions indirectly via the pointer. */
@@ -1757,6 +1970,10 @@ static struct ssl_func ssl_sw[] = {{"SSL_free", NULL},
                                    {"SSL_CTX_set_info_callback", NULL},
                                    {"SSL_get_ex_data", NULL},
                                    {"SSL_set_ex_data", NULL},
+                                   {"SSL_CTX_callback_ctrl", NULL},
+                                   {"SSL_get_servername", NULL},
+                                   {"SSL_set_SSL_CTX", NULL},
+                                   {"SSL_ctrl", NULL},
                                    {NULL, NULL}};
 
 
@@ -1764,7 +1981,6 @@ static struct ssl_func ssl_sw[] = {{"SSL_free", NULL},
  * lib. */
 static struct ssl_func crypto_sw[] = {{"ERR_get_error", NULL},
                                       {"ERR_error_string", NULL},
-                                      {"ERR_remove_state", NULL},
                                       {"CONF_modules_unload", NULL},
                                       {"X509_free", NULL},
                                       {"X509_get_subject_name", NULL},
@@ -1788,9 +2004,9 @@ static struct ssl_func crypto_sw[] = {{"ERR_get_error", NULL},
 #define SSL_write (*(int (*)(SSL *, const void *, int))ssl_sw[4].ptr)
 #define SSL_get_error (*(int (*)(SSL *, int))ssl_sw[5].ptr)
 #define SSL_set_fd (*(int (*)(SSL *, SOCKET))ssl_sw[6].ptr)
-#define SSL_new (*(SSL * (*)(SSL_CTX *))ssl_sw[7].ptr)
-#define SSL_CTX_new (*(SSL_CTX * (*)(SSL_METHOD *))ssl_sw[8].ptr)
-#define SSLv23_server_method (*(SSL_METHOD * (*)(void))ssl_sw[9].ptr)
+#define SSL_new (*(SSL * (*)(SSL_CTX *)) ssl_sw[7].ptr)
+#define SSL_CTX_new (*(SSL_CTX * (*)(SSL_METHOD *)) ssl_sw[8].ptr)
+#define SSLv23_server_method (*(SSL_METHOD * (*)(void)) ssl_sw[9].ptr)
 #define SSL_library_init (*(int (*)(void))ssl_sw[10].ptr)
 #define SSL_CTX_use_PrivateKey_file                                            \
 	(*(int (*)(SSL_CTX *, const char *, int))ssl_sw[11].ptr)
@@ -1802,20 +2018,21 @@ static struct ssl_func crypto_sw[] = {{"ERR_get_error", NULL},
 #define SSL_load_error_strings (*(void (*)(void))ssl_sw[15].ptr)
 #define SSL_CTX_use_certificate_chain_file                                     \
 	(*(int (*)(SSL_CTX *, const char *))ssl_sw[16].ptr)
-#define SSLv23_client_method (*(SSL_METHOD * (*)(void))ssl_sw[17].ptr)
+#define SSLv23_client_method (*(SSL_METHOD * (*)(void)) ssl_sw[17].ptr)
 #define SSL_pending (*(int (*)(SSL *))ssl_sw[18].ptr)
 #define SSL_CTX_set_verify                                                     \
 	(*(void (*)(SSL_CTX *,                                                     \
 	            int,                                                           \
-	            int (*verify_callback)(int, X509_STORE_CTX *)))ssl_sw[19].ptr)
+	            int (*verify_callback)(int, X509_STORE_CTX *)))ssl_sw[19]      \
+	      .ptr)
 #define SSL_shutdown (*(int (*)(SSL *))ssl_sw[20].ptr)
 #define SSL_CTX_load_verify_locations                                          \
 	(*(int (*)(SSL_CTX *, const char *, const char *))ssl_sw[21].ptr)
 #define SSL_CTX_set_default_verify_paths (*(int (*)(SSL_CTX *))ssl_sw[22].ptr)
 #define SSL_CTX_set_verify_depth (*(void (*)(SSL_CTX *, int))ssl_sw[23].ptr)
-#define SSL_get_peer_certificate (*(X509 * (*)(SSL *))ssl_sw[24].ptr)
+#define SSL_get_peer_certificate (*(X509 * (*)(SSL *)) ssl_sw[24].ptr)
 #define SSL_get_version (*(const char *(*)(SSL *))ssl_sw[25].ptr)
-#define SSL_get_current_cipher (*(SSL_CIPHER * (*)(SSL *))ssl_sw[26].ptr)
+#define SSL_get_current_cipher (*(SSL_CIPHER * (*)(SSL *)) ssl_sw[26].ptr)
 #define SSL_CIPHER_get_name                                                    \
 	(*(const char *(*)(const SSL_CIPHER *))ssl_sw[27].ptr)
 #define SSL_CTX_check_private_key (*(int (*)(SSL_CTX *))ssl_sw[28].ptr)
@@ -1825,10 +2042,16 @@ static struct ssl_func crypto_sw[] = {{"ERR_get_error", NULL},
 #define SSL_CTX_set_cipher_list                                                \
 	(*(int (*)(SSL_CTX *, const char *))ssl_sw[31].ptr)
 #define SSL_CTX_set_info_callback                                              \
-	(*(void (*)(SSL_CTX * ctx,                                                 \
-	            void (*callback)(const SSL * s, int, int)))ssl_sw[32].ptr)
-#define SSL_get_ex_data (*(char *(*)(SSL *, int))ssl_sw[33].ptr)
+	(*(void (*)(SSL_CTX *, void (*callback)(const SSL *, int, int)))ssl_sw[32] \
+	      .ptr)
+#define SSL_get_ex_data (*(char *(*)(const SSL *, int))ssl_sw[33].ptr)
 #define SSL_set_ex_data (*(void (*)(SSL *, int, char *))ssl_sw[34].ptr)
+#define SSL_CTX_callback_ctrl                                                  \
+	(*(long (*)(SSL_CTX *, int, void (*)(void)))ssl_sw[35].ptr)
+#define SSL_get_servername                                                     \
+	(*(const char *(*)(const SSL *, int type))ssl_sw[36].ptr)
+#define SSL_set_SSL_CTX (*(SSL_CTX * (*)(SSL *, SSL_CTX *)) ssl_sw[37].ptr)
+#define SSL_ctrl (*(long (*)(SSL *, int, long, void *))ssl_sw[38].ptr)
 
 #define SSL_CTX_set_options(ctx, op)                                           \
 	SSL_CTX_ctrl((ctx), SSL_CTRL_OPTIONS, (op), NULL)
@@ -1837,6 +2060,17 @@ static struct ssl_func crypto_sw[] = {{"ERR_get_error", NULL},
 #define SSL_CTX_set_ecdh_auto(ctx, onoff)                                      \
 	SSL_CTX_ctrl(ctx, SSL_CTRL_SET_ECDH_AUTO, onoff, NULL)
 
+#define SSL_CTRL_SET_TLSEXT_SERVERNAME_CB 53
+#define SSL_CTRL_SET_TLSEXT_SERVERNAME_ARG 54
+#define SSL_CTRL_SET_TLSEXT_HOSTNAME 55
+#define SSL_CTX_set_tlsext_servername_callback(ctx, cb)                        \
+	SSL_CTX_callback_ctrl(ctx,                                                 \
+	                      SSL_CTRL_SET_TLSEXT_SERVERNAME_CB,                   \
+	                      (void (*)(void))cb)
+#define SSL_CTX_set_tlsext_servername_arg(ctx, arg)                            \
+	SSL_CTX_ctrl(ctx, SSL_CTRL_SET_TLSEXT_SERVERNAME_ARG, 0, (void *)arg)
+#define SSL_set_tlsext_host_name(ctx, arg)                                     \
+	SSL_ctrl(ctx, SSL_CTRL_SET_TLSEXT_HOSTNAME, 0, (void *)arg)
 
 #define X509_get_notBefore(x) ((x)->cert_info->validity->notBefore)
 #define X509_get_notAfter(x) ((x)->cert_info->validity->notAfter)
@@ -1858,11 +2092,11 @@ static struct ssl_func crypto_sw[] = {{"ERR_get_error", NULL},
 #define CRYPTO_cleanup_all_ex_data (*(void (*)(void))crypto_sw[9].ptr)
 #define EVP_cleanup (*(void (*)(void))crypto_sw[10].ptr)
 #define X509_free (*(void (*)(X509 *))crypto_sw[11].ptr)
-#define X509_get_subject_name (*(X509_NAME * (*)(X509 *))crypto_sw[12].ptr)
-#define X509_get_issuer_name (*(X509_NAME * (*)(X509 *))crypto_sw[13].ptr)
+#define X509_get_subject_name (*(X509_NAME * (*)(X509 *)) crypto_sw[12].ptr)
+#define X509_get_issuer_name (*(X509_NAME * (*)(X509 *)) crypto_sw[13].ptr)
 #define X509_NAME_oneline                                                      \
 	(*(char *(*)(X509_NAME *, char *, int))crypto_sw[14].ptr)
-#define X509_get_serialNumber (*(ASN1_INTEGER * (*)(X509 *))crypto_sw[15].ptr)
+#define X509_get_serialNumber (*(ASN1_INTEGER * (*)(X509 *)) crypto_sw[15].ptr)
 #define i2c_ASN1_INTEGER                                                       \
 	(*(int (*)(ASN1_INTEGER *, unsigned char **))crypto_sw[16].ptr)
 #define EVP_get_digestbyname                                                   \
@@ -1870,17 +2104,23 @@ static struct ssl_func crypto_sw[] = {{"ERR_get_error", NULL},
 #define EVP_Digest                                                             \
 	(*(int (*)(                                                                \
 	    const void *, size_t, void *, unsigned int *, const EVP_MD *, void *)) \
-	      crypto_sw[18].ptr)
+	      crypto_sw[18]                                                        \
+	          .ptr)
 #define i2d_X509 (*(int (*)(X509 *, unsigned char **))crypto_sw[19].ptr)
 #define BN_bn2hex (*(char *(*)(const BIGNUM *a))crypto_sw[20].ptr)
 #define ASN1_INTEGER_to_BN                                                     \
-	(*(BIGNUM * (*)(const ASN1_INTEGER *ai, BIGNUM *bn))crypto_sw[21].ptr)
+	(*(BIGNUM * (*)(const ASN1_INTEGER *ai, BIGNUM *bn)) crypto_sw[21].ptr)
 #define BN_free (*(void (*)(const BIGNUM *a))crypto_sw[22].ptr)
 #define CRYPTO_free (*(void (*)(void *addr))crypto_sw[23].ptr)
 
 #define OPENSSL_free(a) CRYPTO_free(a)
 
-/* set_ssl_option() function updates this array.
+/* use here ERR_remove_state,
+ * while on some platforms function is not included into library due to
+ * deprication */
+#define OPENSSL_REMOVE_THREAD_STATE() ERR_remove_state(0)
+
+/* init_ssl_ctx() function updates this array.
  * It loads SSL library dynamically and changes NULLs to the actual addresses
  * of respective functions. The macros above (like SSL_connect()) are really
  * just calling these functions indirectly via the pointer. */
@@ -1919,6 +2159,10 @@ static struct ssl_func ssl_sw[] = {{"SSL_free", NULL},
                                    {"SSL_CTX_set_info_callback", NULL},
                                    {"SSL_get_ex_data", NULL},
                                    {"SSL_set_ex_data", NULL},
+                                   {"SSL_CTX_callback_ctrl", NULL},
+                                   {"SSL_get_servername", NULL},
+                                   {"SSL_set_SSL_CTX", NULL},
+                                   {"SSL_ctrl", NULL},
                                    {NULL, NULL}};
 
 
@@ -2005,10 +2249,14 @@ struct mg_file_in_memory {
 struct mg_file_access {
 	/* File properties filled by mg_fopen: */
 	FILE *fp;
-	/* TODO (low): Replace "membuf" implementation by a "file in memory"
-	 * support library. Use some struct mg_file_in_memory *mf; instead of
-	 * membuf char pointer. */
+#if defined(MG_USE_OPEN_FILE)
+	/* TODO (low): Remove obsolete "file in memory" implementation.
+	 * In an "early 2017" discussion at Google groups
+	 * https://groups.google.com/forum/#!topic/civetweb/h9HT4CmeYqI
+	 * we decided to get rid of this feature (after some fade-out
+	 * phase). */
 	const char *membuf;
+#endif
 };
 
 struct mg_file {
@@ -2016,16 +2264,28 @@ struct mg_file {
 	struct mg_file_access access;
 };
 
+#if defined(MG_USE_OPEN_FILE)
+
 #define STRUCT_FILE_INITIALIZER                                                \
 	{                                                                          \
+		{(uint64_t)0, (time_t)0, 0, 0, 0},                                     \
 		{                                                                      \
-			(uint64_t)0, (time_t)0, 0, 0, 0                                    \
-		}                                                                      \
-		,                                                                      \
-		{                                                                      \
-			(FILE *) NULL, (const char *)NULL                                  \
+			(FILE *)NULL, (const char *)NULL                                   \
 		}                                                                      \
 	}
+
+#else
+
+#define STRUCT_FILE_INITIALIZER                                                \
+	{                                                                          \
+		{(uint64_t)0, (time_t)0, 0, 0, 0},                                     \
+		{                                                                      \
+			(FILE *)NULL                                                       \
+		}                                                                      \
+	}
+
+#endif
+
 
 /* Describes listening socket, or socket which was accept()-ed by the master
  * thread and queued for future handling by the worker thread. */
@@ -2039,8 +2299,48 @@ struct socket {
 	unsigned char in_use;    /* Is valid */
 };
 
-/* NOTE(lsm): this enum shoulds be in sync with the config_options below. */
+
+/* Enum const for all options must be in sync with
+ * static struct mg_option config_options[]
+ * This is tested in the unit test (test/private.c)
+ * "Private Config Options"
+ */
 enum {
+	/* Once for each server */
+	LISTENING_PORTS,
+	NUM_THREADS,
+	RUN_AS_USER,
+	CONFIG_TCP_NODELAY, /* Prepended CONFIG_ to avoid conflict with the
+	                     * socket option typedef TCP_NODELAY. */
+	MAX_REQUEST_SIZE,
+	LINGER_TIMEOUT,
+#if defined(__linux__)
+	ALLOW_SENDFILE_CALL,
+#endif
+#if defined(_WIN32)
+	CASE_SENSITIVE_FILES,
+#endif
+	THROTTLE,
+	ACCESS_LOG_FILE,
+	ERROR_LOG_FILE,
+	ENABLE_KEEP_ALIVE,
+	REQUEST_TIMEOUT,
+	KEEP_ALIVE_TIMEOUT,
+#if defined(USE_WEBSOCKET)
+	WEBSOCKET_TIMEOUT,
+	ENABLE_WEBSOCKET_PING_PONG,
+#endif
+	DECODE_URL,
+#if defined(USE_LUA)
+	LUA_BACKGROUND_SCRIPT,
+	LUA_BACKGROUND_SCRIPT_PARAMS,
+#endif
+#if defined(USE_TIMERS)
+	CGI_TIMEOUT,
+#endif
+
+	/* Once for each domain */
+	DOCUMENT_ROOT,
 	CGI_EXTENSIONS,
 	CGI_ENVIRONMENT,
 	PUT_DELETE_PASSWORDS_FILE,
@@ -2049,26 +2349,15 @@ enum {
 	AUTHENTICATION_DOMAIN,
 	ENABLE_AUTH_DOMAIN_CHECK,
 	SSI_EXTENSIONS,
-	THROTTLE,
-	ACCESS_LOG_FILE,
 	ENABLE_DIRECTORY_LISTING,
-	ERROR_LOG_FILE,
 	GLOBAL_PASSWORDS_FILE,
 	INDEX_FILES,
-	ENABLE_KEEP_ALIVE,
 	ACCESS_CONTROL_LIST,
 	EXTRA_MIME_TYPES,
-	LISTENING_PORTS,
-	DOCUMENT_ROOT,
 	SSL_CERTIFICATE,
 	SSL_CERTIFICATE_CHAIN,
-	NUM_THREADS,
-	RUN_AS_USER,
 	URL_REWRITE_PATTERN,
 	HIDE_FILES,
-	REQUEST_TIMEOUT,
-	KEEP_ALIVE_TIMEOUT,
-	LINGER_TIMEOUT,
 	SSL_DO_VERIFY_PEER,
 	SSL_CA_PATH,
 	SSL_CA_FILE,
@@ -2078,16 +2367,13 @@ enum {
 	SSL_PROTOCOL_VERSION,
 	SSL_SHORT_TRUST,
 
-#if defined(USE_WEBSOCKET)
-	WEBSOCKET_TIMEOUT,
-#endif
-
-	DECODE_URL,
-
 #if defined(USE_LUA)
 	LUA_PRELOAD_FILE,
 	LUA_SCRIPT_EXTENSIONS,
 	LUA_SERVER_PAGE_EXTENSIONS,
+#if defined(MG_EXPERIMENTAL_INTERFACES)
+	LUA_DEBUG_PARAMS,
+#endif
 #endif
 #if defined(USE_DUKTAPE)
 	DUKTAPE_SCRIPT_EXTENSIONS,
@@ -2104,129 +2390,128 @@ enum {
 	ACCESS_CONTROL_ALLOW_METHODS,
 	ACCESS_CONTROL_ALLOW_HEADERS,
 	ERROR_PAGES,
-	CONFIG_TCP_NODELAY, /* Prepended CONFIG_ to avoid conflict with the
-                     * socket option typedef TCP_NODELAY. */
 #if !defined(NO_CACHING)
 	STATIC_FILE_MAX_AGE,
 #endif
 #if !defined(NO_SSL)
 	STRICT_HTTPS_MAX_AGE,
 #endif
-#if defined(__linux__)
-	ALLOW_SENDFILE_CALL,
-#endif
-#if defined(_WIN32)
-	CASE_SENSITIVE_FILES,
-#endif
-#if defined(USE_LUA)
-	LUA_BACKGROUND_SCRIPT,
-	LUA_BACKGROUND_SCRIPT_PARAMS,
-#endif
 	ADDITIONAL_HEADER,
-	MAX_REQUEST_SIZE,
 	ALLOW_INDEX_SCRIPT_SUB_RES,
 
 	NUM_OPTIONS
 };
 
 
-/* Config option name, config types, default value */
-static struct mg_option config_options[] = {
-    {"cgi_pattern", CONFIG_TYPE_EXT_PATTERN, "**.cgi$|**.pl$|**.php$"},
-    {"cgi_environment", CONFIG_TYPE_STRING_LIST, NULL},
-    {"put_delete_auth_file", CONFIG_TYPE_FILE, NULL},
-    {"cgi_interpreter", CONFIG_TYPE_FILE, NULL},
-    {"protect_uri", CONFIG_TYPE_STRING_LIST, NULL},
-    {"authentication_domain", CONFIG_TYPE_STRING, "mydomain.com"},
-    {"enable_auth_domain_check", CONFIG_TYPE_BOOLEAN, "yes"},
-    {"ssi_pattern", CONFIG_TYPE_EXT_PATTERN, "**.shtml$|**.shtm$"},
-    {"throttle", CONFIG_TYPE_STRING_LIST, NULL},
-    {"access_log_file", CONFIG_TYPE_FILE, NULL},
-    {"enable_directory_listing", CONFIG_TYPE_BOOLEAN, "yes"},
-    {"error_log_file", CONFIG_TYPE_FILE, NULL},
-    {"global_auth_file", CONFIG_TYPE_FILE, NULL},
+/* Config option name, config types, default value.
+ * Must be in the same order as the enum const above.
+ */
+static const struct mg_option config_options[] = {
+
+    /* Once for each server */
+    {"listening_ports", MG_CONFIG_TYPE_STRING_LIST, "8080"},
+    {"num_threads", MG_CONFIG_TYPE_NUMBER, "50"},
+    {"run_as_user", MG_CONFIG_TYPE_STRING, NULL},
+    {"tcp_nodelay", MG_CONFIG_TYPE_NUMBER, "0"},
+    {"max_request_size", MG_CONFIG_TYPE_NUMBER, "16384"},
+    {"linger_timeout_ms", MG_CONFIG_TYPE_NUMBER, NULL},
+#if defined(__linux__)
+    {"allow_sendfile_call", MG_CONFIG_TYPE_BOOLEAN, "yes"},
+#endif
+#if defined(_WIN32)
+    {"case_sensitive", MG_CONFIG_TYPE_BOOLEAN, "no"},
+#endif
+    {"throttle", MG_CONFIG_TYPE_STRING_LIST, NULL},
+    {"access_log_file", MG_CONFIG_TYPE_FILE, NULL},
+    {"error_log_file", MG_CONFIG_TYPE_FILE, NULL},
+    {"enable_keep_alive", MG_CONFIG_TYPE_BOOLEAN, "no"},
+    {"request_timeout_ms", MG_CONFIG_TYPE_NUMBER, "30000"},
+    {"keep_alive_timeout_ms", MG_CONFIG_TYPE_NUMBER, "500"},
+#if defined(USE_WEBSOCKET)
+    {"websocket_timeout_ms", MG_CONFIG_TYPE_NUMBER, NULL},
+    {"enable_websocket_ping_pong", MG_CONFIG_TYPE_BOOLEAN, "no"},
+#endif
+    {"decode_url", MG_CONFIG_TYPE_BOOLEAN, "yes"},
+#if defined(USE_LUA)
+    {"lua_background_script", MG_CONFIG_TYPE_FILE, NULL},
+    {"lua_background_script_params", MG_CONFIG_TYPE_STRING_LIST, NULL},
+#endif
+#if defined(USE_TIMERS)
+    {"cgi_timeout_ms", MG_CONFIG_TYPE_NUMBER, NULL},
+#endif
+
+    /* Once for each domain */
+    {"document_root", MG_CONFIG_TYPE_DIRECTORY, NULL},
+    {"cgi_pattern", MG_CONFIG_TYPE_EXT_PATTERN, "**.cgi$|**.pl$|**.php$"},
+    {"cgi_environment", MG_CONFIG_TYPE_STRING_LIST, NULL},
+    {"put_delete_auth_file", MG_CONFIG_TYPE_FILE, NULL},
+    {"cgi_interpreter", MG_CONFIG_TYPE_FILE, NULL},
+    {"protect_uri", MG_CONFIG_TYPE_STRING_LIST, NULL},
+    {"authentication_domain", MG_CONFIG_TYPE_STRING, "mydomain.com"},
+    {"enable_auth_domain_check", MG_CONFIG_TYPE_BOOLEAN, "yes"},
+    {"ssi_pattern", MG_CONFIG_TYPE_EXT_PATTERN, "**.shtml$|**.shtm$"},
+    {"enable_directory_listing", MG_CONFIG_TYPE_BOOLEAN, "yes"},
+    {"global_auth_file", MG_CONFIG_TYPE_FILE, NULL},
     {"index_files",
-     CONFIG_TYPE_STRING_LIST,
-#ifdef USE_LUA
+     MG_CONFIG_TYPE_STRING_LIST,
+#if defined(USE_LUA)
      "index.xhtml,index.html,index.htm,"
      "index.lp,index.lsp,index.lua,index.cgi,"
      "index.shtml,index.php"},
 #else
      "index.xhtml,index.html,index.htm,index.cgi,index.shtml,index.php"},
 #endif
-    {"enable_keep_alive", CONFIG_TYPE_BOOLEAN, "no"},
-    {"access_control_list", CONFIG_TYPE_STRING_LIST, NULL},
-    {"extra_mime_types", CONFIG_TYPE_STRING_LIST, NULL},
-    {"listening_ports", CONFIG_TYPE_STRING_LIST, "8080"},
-    {"document_root", CONFIG_TYPE_DIRECTORY, NULL},
-    {"ssl_certificate", CONFIG_TYPE_FILE, NULL},
-    {"ssl_certificate_chain", CONFIG_TYPE_FILE, NULL},
-    {"num_threads", CONFIG_TYPE_NUMBER, "50"},
-    {"run_as_user", CONFIG_TYPE_STRING, NULL},
-    {"url_rewrite_patterns", CONFIG_TYPE_STRING_LIST, NULL},
-    {"hide_files_patterns", CONFIG_TYPE_EXT_PATTERN, NULL},
-    {"request_timeout_ms", CONFIG_TYPE_NUMBER, "30000"},
-    {"keep_alive_timeout_ms", CONFIG_TYPE_NUMBER, "500"},
-    {"linger_timeout_ms", CONFIG_TYPE_NUMBER, NULL},
+    {"access_control_list", MG_CONFIG_TYPE_STRING_LIST, NULL},
+    {"extra_mime_types", MG_CONFIG_TYPE_STRING_LIST, NULL},
+    {"ssl_certificate", MG_CONFIG_TYPE_FILE, NULL},
+    {"ssl_certificate_chain", MG_CONFIG_TYPE_FILE, NULL},
+    {"url_rewrite_patterns", MG_CONFIG_TYPE_STRING_LIST, NULL},
+    {"hide_files_patterns", MG_CONFIG_TYPE_EXT_PATTERN, NULL},
 
-    /* TODO(Feature): this is no longer a boolean, but yes/no/optional */
-    {"ssl_verify_peer", CONFIG_TYPE_BOOLEAN, "no"},
+    {"ssl_verify_peer", MG_CONFIG_TYPE_YES_NO_OPTIONAL, "no"},
 
-    {"ssl_ca_path", CONFIG_TYPE_DIRECTORY, NULL},
-    {"ssl_ca_file", CONFIG_TYPE_FILE, NULL},
-    {"ssl_verify_depth", CONFIG_TYPE_NUMBER, "9"},
-    {"ssl_default_verify_paths", CONFIG_TYPE_BOOLEAN, "yes"},
-    {"ssl_cipher_list", CONFIG_TYPE_STRING, NULL},
-    {"ssl_protocol_version", CONFIG_TYPE_NUMBER, "0"},
-    {"ssl_short_trust", CONFIG_TYPE_BOOLEAN, "no"},
-#if defined(USE_WEBSOCKET)
-    {"websocket_timeout_ms", CONFIG_TYPE_NUMBER, "30000"},
-#endif
-    {"decode_url", CONFIG_TYPE_BOOLEAN, "yes"},
+    {"ssl_ca_path", MG_CONFIG_TYPE_DIRECTORY, NULL},
+    {"ssl_ca_file", MG_CONFIG_TYPE_FILE, NULL},
+    {"ssl_verify_depth", MG_CONFIG_TYPE_NUMBER, "9"},
+    {"ssl_default_verify_paths", MG_CONFIG_TYPE_BOOLEAN, "yes"},
+    {"ssl_cipher_list", MG_CONFIG_TYPE_STRING, NULL},
+    {"ssl_protocol_version", MG_CONFIG_TYPE_NUMBER, "0"},
+    {"ssl_short_trust", MG_CONFIG_TYPE_BOOLEAN, "no"},
 
 #if defined(USE_LUA)
-    {"lua_preload_file", CONFIG_TYPE_FILE, NULL},
-    {"lua_script_pattern", CONFIG_TYPE_EXT_PATTERN, "**.lua$"},
-    {"lua_server_page_pattern", CONFIG_TYPE_EXT_PATTERN, "**.lp$|**.lsp$"},
+    {"lua_preload_file", MG_CONFIG_TYPE_FILE, NULL},
+    {"lua_script_pattern", MG_CONFIG_TYPE_EXT_PATTERN, "**.lua$"},
+    {"lua_server_page_pattern", MG_CONFIG_TYPE_EXT_PATTERN, "**.lp$|**.lsp$"},
+#if defined(MG_EXPERIMENTAL_INTERFACES)
+    {"lua_debug", MG_CONFIG_TYPE_STRING, NULL},
+#endif
 #endif
 #if defined(USE_DUKTAPE)
     /* The support for duktape is still in alpha version state.
      * The name of this config option might change. */
-    {"duktape_script_pattern", CONFIG_TYPE_EXT_PATTERN, "**.ssjs$"},
+    {"duktape_script_pattern", MG_CONFIG_TYPE_EXT_PATTERN, "**.ssjs$"},
 #endif
 
 #if defined(USE_WEBSOCKET)
-    {"websocket_root", CONFIG_TYPE_DIRECTORY, NULL},
+    {"websocket_root", MG_CONFIG_TYPE_DIRECTORY, NULL},
 #endif
 #if defined(USE_LUA) && defined(USE_WEBSOCKET)
-    {"lua_websocket_pattern", CONFIG_TYPE_EXT_PATTERN, "**.lua$"},
+    {"lua_websocket_pattern", MG_CONFIG_TYPE_EXT_PATTERN, "**.lua$"},
 #endif
-    {"access_control_allow_origin", CONFIG_TYPE_STRING, "*"},
-    {"access_control_allow_methods", CONFIG_TYPE_STRING, "*"},
-    {"access_control_allow_headers", CONFIG_TYPE_STRING, "*"},
-    {"error_pages", CONFIG_TYPE_DIRECTORY, NULL},
-    {"tcp_nodelay", CONFIG_TYPE_NUMBER, "0"},
+    {"access_control_allow_origin", MG_CONFIG_TYPE_STRING, "*"},
+    {"access_control_allow_methods", MG_CONFIG_TYPE_STRING, "*"},
+    {"access_control_allow_headers", MG_CONFIG_TYPE_STRING, "*"},
+    {"error_pages", MG_CONFIG_TYPE_DIRECTORY, NULL},
 #if !defined(NO_CACHING)
-    {"static_file_max_age", CONFIG_TYPE_NUMBER, "3600"},
+    {"static_file_max_age", MG_CONFIG_TYPE_NUMBER, "3600"},
 #endif
 #if !defined(NO_SSL)
-    {"strict_transport_security_max_age", CONFIG_TYPE_NUMBER, NULL},
+    {"strict_transport_security_max_age", MG_CONFIG_TYPE_NUMBER, NULL},
 #endif
-#if defined(__linux__)
-    {"allow_sendfile_call", CONFIG_TYPE_BOOLEAN, "yes"},
-#endif
-#if defined(_WIN32)
-    {"case_sensitive", CONFIG_TYPE_BOOLEAN, "no"},
-#endif
-#if defined(USE_LUA)
-    {"lua_background_script", CONFIG_TYPE_FILE, NULL},
-    {"lua_background_script_params", CONFIG_TYPE_STRING_LIST, NULL},
-#endif
-    {"additional_header", CONFIG_TYPE_STRING_MULTILINE, NULL},
-    {"max_request_size", CONFIG_TYPE_NUMBER, "16384"},
-    {"allow_index_script_resource", CONFIG_TYPE_BOOLEAN, "no"},
+    {"additional_header", MG_CONFIG_TYPE_STRING_MULTILINE, NULL},
+    {"allow_index_script_resource", MG_CONFIG_TYPE_BOOLEAN, "no"},
 
-    {NULL, CONFIG_TYPE_UNKNOWN, NULL}};
+    {NULL, MG_CONFIG_TYPE_UNKNOWN, NULL}};
 
 
 /* Check if the config_options and the corresponding enum have compatible
@@ -2249,6 +2534,10 @@ struct mg_handler_info {
 
 	/* Handler for http/https or authorization requests. */
 	mg_request_handler handler;
+	unsigned int refcount;
+	pthread_mutex_t refcount_mutex; /* Protects refcount */
+	pthread_cond_t
+	    refcount_cond; /* Signaled when handler refcount is decremented */
 
 	/* Handler for ws/wss (websocket) requests. */
 	mg_websocket_connect_handler connect_handler;
@@ -2278,21 +2567,63 @@ enum {
 };
 
 
+struct mg_domain_context {
+	SSL_CTX *ssl_ctx;                 /* SSL context */
+	char *config[NUM_OPTIONS];        /* Civetweb configuration parameters */
+	struct mg_handler_info *handlers; /* linked list of uri handlers */
+
+	/* Server nonce */
+	uint64_t auth_nonce_mask;  /* Mask for all nonce values */
+	unsigned long nonce_count; /* Used nonces, used for authentication */
+
+#if defined(USE_LUA) && defined(USE_WEBSOCKET)
+	/* linked list of shared lua websockets */
+	struct mg_shared_lua_websocket_list *shared_lua_websockets;
+#endif
+
+	/* Linked list of domains */
+	struct mg_domain_context *next;
+};
+
+
 struct mg_context {
-	volatile int stop_flag;        /* Should we stop event loop */
-	SSL_CTX *ssl_ctx;              /* SSL context */
-	char *config[NUM_OPTIONS];     /* Civetweb configuration parameters */
-	struct mg_callbacks callbacks; /* User-defined callback function */
-	void *user_data;               /* User-defined data */
-	int context_type;              /* See CONTEXT_* above */
+
+	/* Part 1 - Physical context:
+	 * This holds threads, ports, timeouts, ...
+	 * set for the entire server, independent from the
+	 * addressed hostname.
+	 */
+
+	/* Connection related */
+	int context_type; /* See CONTEXT_* above */
 
 	struct socket *listening_sockets;
 	struct pollfd *listening_socket_fds;
 	unsigned int num_listening_sockets;
 
+	struct mg_connection *worker_connections; /* The connection struct, pre-
+	                                           * allocated for each worker */
+
+#if defined(USE_SERVER_STATS)
+	int active_connections;
+	int max_connections;
+	int64_t total_connections;
+	int64_t total_requests;
+	int64_t total_data_read;
+	int64_t total_data_written;
+#endif
+
+	/* Thread related */
+	volatile int stop_flag;       /* Should we stop event loop */
 	pthread_mutex_t thread_mutex; /* Protects (max|num)_threads */
 
-#ifdef ALTERNATIVE_QUEUE
+	pthread_t masterthreadid; /* The master thread ID */
+	unsigned int
+	    cfg_worker_threads;      /* The number of configured worker threads. */
+	pthread_t *worker_threadids; /* The worker thread IDs */
+
+/* Connection to thread dispatching */
+#if defined(ALTERNATIVE_QUEUE)
 	struct socket *client_socks;
 	void **client_wait_events;
 #else
@@ -2303,49 +2634,42 @@ struct mg_context {
 	pthread_cond_t sq_empty;      /* Signaled when socket is consumed */
 #endif
 
+	/* Memory related */
 	unsigned int max_request_size; /* The max request size */
 
-	pthread_t masterthreadid; /* The master thread ID */
-	unsigned int
-	    cfg_worker_threads;      /* The number of configured worker threads. */
-	pthread_t *worker_threadids; /* The worker thread IDs */
-	struct mg_connection *worker_connections; /* The connection struct, pre-
-	                                           * allocated for each worker */
+#if defined(USE_SERVER_STATS)
+	struct mg_memory_stat ctx_memory;
+#endif
 
+	/* Operating system related */
+	char *systemName;  /* What operating system is running */
 	time_t start_time; /* Server start time, used for authentication
 	                    * and for diagnstics. */
-
-	uint64_t auth_nonce_mask;    /* Mask for all nonce values */
-	pthread_mutex_t nonce_mutex; /* Protects nonce_count */
-	unsigned long nonce_count;   /* Used nonces, used for authentication */
-
-	char *systemName; /* What operating system is running */
-
-	/* linked list of uri handlers */
-	struct mg_handler_info *handlers;
-
-#if defined(USE_LUA) && defined(USE_WEBSOCKET)
-	/* linked list of shared lua websockets */
-	struct mg_shared_lua_websocket_list *shared_lua_websockets;
-#endif
 
 #if defined(USE_TIMERS)
 	struct ttimers *timers;
 #endif
 
+/* Lua specific: Background operations and shared websockets */
 #if defined(USE_LUA)
 	void *lua_background_state;
 #endif
 
-#if defined(USE_SERVER_STATS)
-	int active_connections;
-	int max_connections;
-	int64_t total_connections;
-	int64_t total_requests;
-	struct mg_memory_stat ctx_memory;
-	int64_t total_data_read;
-	int64_t total_data_written;
-#endif
+	/* Server nonce */
+	pthread_mutex_t nonce_mutex; /* Protects nonce_count */
+
+	/* Server callbacks */
+	struct mg_callbacks callbacks; /* User-defined callback function */
+	void *user_data;               /* User-defined data */
+
+	/* Part 2 - Logical domain:
+	 * This holds hostname, TLS certificate, document root, ...
+	 * set for a domain hosted at the server.
+	 * There may be multiple domains hosted at one physical server.
+	 * The default domain "dd" is the first element of a list of
+	 * domains.
+	 */
+	struct mg_domain_context dd; /* default domain */
 };
 
 
@@ -2374,7 +2698,8 @@ struct mg_connection {
 	struct mg_request_info request_info;
 	struct mg_response_info response_info;
 
-	struct mg_context *ctx;
+	struct mg_context *phys_ctx;
+	struct mg_domain_context *dom_ctx;
 
 #if defined(USE_SERVER_STATS)
 	int conn_state; /* 0 = undef, numerical value may change in different
@@ -2382,6 +2707,7 @@ struct mg_connection {
 	                 * mg_get_connection_info_impl */
 #endif
 
+	const char *host;         /* Host (HTTP/1.1 header or SNI) */
 	SSL *ssl;                 /* SSL descriptor */
 	SSL_CTX *client_ssl_ctx;  /* SSL context for client connections */
 	struct socket client;     /* Connected client */
@@ -2410,7 +2736,7 @@ struct mg_connection {
 	int in_websocket_handling; /* 1 if in read_websocket */
 #endif
 	int handled_requests; /* Number of requests handled by this connection
-	                         */
+	                       */
 	int buf_size;         /* Buffer size */
 	int request_len;      /* Size of the request + headers in a buffer */
 	int data_len;         /* Total size of data in a buffer */
@@ -2445,6 +2771,16 @@ static int is_websocket_protocol(const struct mg_connection *conn);
 #endif
 
 
+#define mg_cry_internal(conn, fmt, ...)                                        \
+	mg_cry_internal_wrap(conn, __func__, __LINE__, fmt, __VA_ARGS__)
+
+static void mg_cry_internal_wrap(const struct mg_connection *conn,
+                                 const char *func,
+                                 unsigned line,
+                                 const char *fmt,
+                                 ...) PRINTF_ARGS(4, 5);
+
+
 #if !defined(NO_THREAD_NAME)
 #if defined(_WIN32) && defined(_MSC_VER)
 /* Set the thread name for debugging purposes in Visual Studio
@@ -2463,33 +2799,12 @@ typedef struct tagTHREADNAME_INFO {
 
 #include <sys/prctl.h>
 #include <sys/sendfile.h>
-#ifdef ALTERNATIVE_QUEUE
+#if defined(ALTERNATIVE_QUEUE)
 #include <sys/eventfd.h>
 #endif /* ALTERNATIVE_QUEUE */
 
 
 #if defined(ALTERNATIVE_QUEUE)
-
-
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunreachable-code"
-/* For every system, "(sizeof(int) == sizeof(void *))" is either always
- * true or always false. One of the two branches is unreachable in any case.
- * Unfortunately the C standard does not define a way to check this at
- * compile time, since the #if preprocessor conditions can not use the sizeof
- * operator as an argument. */
-#endif
-
-#if defined(__GNUC__) || defined(__MINGW32__)
-/* GCC does not realize one branch is unreachable, so it raises some
- * pointer cast warning within the unreachable branch.
- */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wint-to-pointer-cast"
-#pragma GCC diagnostic ignored "-Wpointer-to-int-cast"
-#endif
-
 
 static void *
 event_create(void)
@@ -2502,15 +2817,12 @@ event_create(void)
 		/* However, Linux does not return 0 on success either. */
 		return 0;
 	}
-	if (sizeof(int) == sizeof(void *)) {
-		ret = (void *)evhdl;
+
+	ret = (int *)mg_malloc(sizeof(int));
+	if (ret) {
+		*ret = evhdl;
 	} else {
-		ret = (int *)mg_malloc(sizeof(int));
-		if (ret) {
-			*ret = evhdl;
-		} else {
-			(void)close(evhdl);
-		}
+		(void)close(evhdl);
 	}
 
 	return (void *)ret;
@@ -2523,18 +2835,14 @@ event_wait(void *eventhdl)
 	uint64_t u;
 	int evhdl, s;
 
-	if (sizeof(int) == sizeof(void *)) {
-		evhdl = (int)eventhdl;
-	} else {
-		if (!eventhdl) {
-			/* error */
-			return 0;
-		}
-		evhdl = *(int *)eventhdl;
+	if (!eventhdl) {
+		/* error */
+		return 0;
 	}
+	evhdl = *(int *)eventhdl;
 
 	s = (int)read(evhdl, &u, sizeof(u));
-	if (s != sizeof(uint64_t)) {
+	if (s != sizeof(u)) {
 		/* error */
 		return 0;
 	}
@@ -2549,18 +2857,14 @@ event_signal(void *eventhdl)
 	uint64_t u = 1;
 	int evhdl, s;
 
-	if (sizeof(int) == sizeof(void *)) {
-		evhdl = (int)eventhdl;
-	} else {
-		if (!eventhdl) {
-			/* error */
-			return 0;
-		}
-		evhdl = *(int *)eventhdl;
+	if (!eventhdl) {
+		/* error */
+		return 0;
 	}
+	evhdl = *(int *)eventhdl;
 
 	s = (int)write(evhdl, &u, sizeof(u));
-	if (s != sizeof(uint64_t)) {
+	if (s != sizeof(u)) {
 		/* error */
 		return 0;
 	}
@@ -2573,28 +2877,16 @@ event_destroy(void *eventhdl)
 {
 	int evhdl;
 
-	if (sizeof(int) == sizeof(void *)) {
-		evhdl = (int)eventhdl;
-		close(evhdl);
-	} else {
-		if (!eventhdl) {
-			/* error */
-			return;
-		}
-		evhdl = *(int *)eventhdl;
-		close(evhdl);
-		mg_free(eventhdl);
+	if (!eventhdl) {
+		/* error */
+		return;
 	}
+	evhdl = *(int *)eventhdl;
+
+	close(evhdl);
+	mg_free(eventhdl);
 }
 
-
-#if defined(__GNUC__) || defined(__MINGW32__)
-#pragma GCC diagnostic pop
-#endif
-
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
 
 #endif
 
@@ -2676,8 +2968,7 @@ mg_set_thread_name(const char *name)
 #if defined(_WIN32)
 #if defined(_MSC_VER)
 	/* Windows and Visual Studio Compiler */
-	__try
-	{
+	__try {
 		THREADNAME_INFO info;
 		info.dwType = 0x1000;
 		info.szName = threadName;
@@ -2688,21 +2979,19 @@ mg_set_thread_name(const char *name)
 		               0,
 		               sizeof(info) / sizeof(ULONG_PTR),
 		               (ULONG_PTR *)&info);
-	}
-	__except(EXCEPTION_EXECUTE_HANDLER)
-	{
+	} __except (EXCEPTION_EXECUTE_HANDLER) {
 	}
 #elif defined(__MINGW32__)
 /* No option known to set thread name for MinGW */
 #endif
-#elif defined(_GNU_SOURCE) && defined(__GLIBC__) \
+#elif defined(_GNU_SOURCE) && defined(__GLIBC__)                               \
     && ((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 12)))
-   /* pthread_setname_np first appeared in glibc in version 2.12*/
+/* pthread_setname_np first appeared in glibc in version 2.12*/
 #if defined(__MACH__)
-   /* OS X only current thread name can be changed */
-   (void)pthread_setname_np(threadName);
+	/* OS X only current thread name can be changed */
+	(void)pthread_setname_np(threadName);
 #else
-   (void)pthread_setname_np(pthread_self(), threadName);
+	(void)pthread_setname_np(pthread_self(), threadName);
 #endif
 #elif defined(__linux__)
 	/* on linux we can use the old prctl function */
@@ -2722,8 +3011,8 @@ const char **
 mg_get_valid_option_names(void)
 {
 	/* This function is deprecated. Use mg_get_valid_options instead. */
-	static const char *
-	    data[2 * sizeof(config_options) / sizeof(config_options[0])] = {0};
+	static const char
+	    *data[2 * sizeof(config_options) / sizeof(config_options[0])] = {0};
 	int i;
 
 	for (i = 0; config_options[i].name != NULL; i++) {
@@ -2777,8 +3066,8 @@ open_file_in_memory(const struct mg_connection *conn,
 		return 0;
 	}
 
-	if (conn->ctx->callbacks.open_file) {
-		buf = conn->ctx->callbacks.open_file(conn, path, &size);
+	if (conn->phys_ctx->callbacks.open_file) {
+		buf = conn->phys_ctx->callbacks.open_file(conn, path, &size);
 		if (buf != NULL) {
 			if (filep == NULL) {
 				/* This is a file in memory, but we cannot store the
@@ -2833,7 +3122,12 @@ is_file_opened(const struct mg_file_access *fileacc)
 	if (!fileacc) {
 		return 0;
 	}
+
+#if defined(MG_USE_OPEN_FILE)
 	return (fileacc->membuf != NULL) || (fileacc->fp != NULL);
+#else
+	return (fileacc->fp != NULL);
+#endif
 }
 
 
@@ -2860,7 +3154,9 @@ mg_fopen(const struct mg_connection *conn,
 		return 0;
 	}
 	filep->access.fp = NULL;
+#if defined(MG_USE_OPEN_FILE)
 	filep->access.membuf = NULL;
+#endif
 
 	if (!is_file_in_memory(conn, path)) {
 
@@ -2873,9 +3169,9 @@ mg_fopen(const struct mg_connection *conn,
 			return 0;
 		}
 
-#ifdef _WIN32
+#if defined(_WIN32)
 		{
-			wchar_t wbuf[PATH_MAX];
+			wchar_t wbuf[W_PATH_MAX];
 			path_to_unicode(conn, path, wbuf, ARRAY_SIZE(wbuf));
 			switch (mode) {
 			case MG_FOPEN_MODE_READ:
@@ -2916,11 +3212,13 @@ mg_fopen(const struct mg_connection *conn,
 		return (filep->access.fp != NULL);
 
 	} else {
+#if defined(MG_USE_OPEN_FILE)
 		/* is_file_in_memory returned true */
 		if (open_file_in_memory(conn, path, filep, mode)) {
 			/* file is in memory */
 			return (filep->access.membuf != NULL);
 		}
+#endif
 	}
 
 	/* Open failed */
@@ -2936,8 +3234,10 @@ mg_fclose(struct mg_file_access *fileacc)
 	if (fileacc != NULL) {
 		if (fileacc->fp != NULL) {
 			ret = fclose(fileacc->fp);
+#if defined(MG_USE_OPEN_FILE)
 		} else if (fileacc->membuf != NULL) {
 			ret = 0;
+#endif
 		}
 		/* reset all members of fileacc */
 		memset(fileacc, 0, sizeof(*fileacc));
@@ -2992,11 +3292,13 @@ mg_strcasecmp(const char *s1, const char *s2)
 
 
 static char *
-mg_strndup(const char *ptr, size_t len)
+mg_strndup_ctx(const char *ptr, size_t len, struct mg_context *ctx)
 {
 	char *p;
+	(void)ctx; /* Avoid Visual Studio warning if USE_SERVER_STATS is not
+	            * defined */
 
-	if ((p = (char *)mg_malloc(len + 1)) != NULL) {
+	if ((p = (char *)mg_malloc_ctx(len + 1, ctx)) != NULL) {
 		mg_strlcpy(p, ptr, len + 1);
 	}
 
@@ -3005,9 +3307,15 @@ mg_strndup(const char *ptr, size_t len)
 
 
 static char *
+mg_strdup_ctx(const char *str, struct mg_context *ctx)
+{
+	return mg_strndup_ctx(str, strlen(str), ctx);
+}
+
+static char *
 mg_strdup(const char *str)
 {
-	return mg_strndup(str, strlen(str));
+	return mg_strndup_ctx(str, strlen(str), NULL);
 }
 
 
@@ -3047,7 +3355,7 @@ mg_vsnprintf(const struct mg_connection *conn,
 		return;
 	}
 
-#ifdef __clang__
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wformat-nonliteral"
 /* Using fmt as a non-literal is intended here, since it is mostly called
@@ -3057,7 +3365,7 @@ mg_vsnprintf(const struct mg_connection *conn,
 	n = (int)vsnprintf_impl(buf, buflen, fmt, ap);
 	ok = (n >= 0) && ((size_t)n < buflen);
 
-#ifdef __clang__
+#if defined(__clang__)
 #pragma clang diagnostic pop
 #endif
 
@@ -3069,10 +3377,10 @@ mg_vsnprintf(const struct mg_connection *conn,
 		if (truncated) {
 			*truncated = 1;
 		}
-		mg_cry(conn,
-		       "truncating vsnprintf buffer: [%.*s]",
-		       (int)((buflen > 200) ? 200 : (buflen - 1)),
-		       buf);
+		mg_cry_internal(conn,
+		                "truncating vsnprintf buffer: [%.*s]",
+		                (int)((buflen > 200) ? 200 : (buflen - 1)),
+		                buf);
 		n = (int)buflen - 1;
 	}
 	buf[n] = '\0';
@@ -3115,18 +3423,19 @@ mg_get_option(const struct mg_context *ctx, const char *name)
 	int i;
 	if ((i = get_option_index(name)) == -1) {
 		return NULL;
-	} else if (!ctx || ctx->config[i] == NULL) {
+	} else if (!ctx || ctx->dd.config[i] == NULL) {
 		return "";
 	} else {
-		return ctx->config[i];
+		return ctx->dd.config[i];
 	}
 }
 
+#define mg_get_option DO_NOT_USE_THIS_FUNCTION_INTERNALLY__access_directly
 
 struct mg_context *
 mg_get_context(const struct mg_connection *conn)
 {
-	return (conn == NULL) ? (struct mg_context *)NULL : (conn->ctx);
+	return (conn == NULL) ? (struct mg_context *)NULL : (conn->phys_ctx);
 }
 
 
@@ -3262,10 +3571,18 @@ sockaddr_to_string(char *buf, size_t len, const union usa *usa)
 static void
 gmt_time_string(char *buf, size_t buf_len, time_t *t)
 {
+#if !defined(REENTRANT_TIME)
 	struct tm *tm;
 
 	tm = ((t != NULL) ? gmtime(t) : NULL);
 	if (tm != NULL) {
+#else
+	struct tm _tm;
+	struct tm *tm = &_tm;
+
+	if (t != NULL) {
+		gmtime_r(t, tm);
+#endif
 		strftime(buf, buf_len, "%a, %d %b %Y %H:%M:%S GMT", tm);
 	} else {
 		mg_strlcpy(buf, "Thu, 01 Jan 1970 00:00:00 GMT", buf_len);
@@ -3283,21 +3600,45 @@ mg_difftimespec(const struct timespec *ts_now, const struct timespec *ts_before)
 }
 
 
+#if defined(MG_EXTERNAL_FUNCTION_mg_cry_internal_impl)
+static void mg_cry_internal_impl(const struct mg_connection *conn,
+                                 const char *func,
+                                 unsigned line,
+                                 const char *fmt,
+                                 va_list ap);
+#include "external_mg_cry_internal_impl.inl"
+#else
+
 /* Print error message to the opened error log stream. */
-void
-mg_cry(const struct mg_connection *conn, const char *fmt, ...)
+static void
+mg_cry_internal_impl(const struct mg_connection *conn,
+                     const char *func,
+                     unsigned line,
+                     const char *fmt,
+                     va_list ap)
 {
 	char buf[MG_BUF_LEN], src_addr[IP_ADDR_STR_LEN];
-	va_list ap;
 	struct mg_file fi;
 	time_t timestamp;
 
-	va_start(ap, fmt);
+	/* Unused, in the RELEASE build */
+	(void)func;
+	(void)line;
+
+#if defined(GCC_DIAGNOSTIC)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#endif
+
 	IGNORE_UNUSED_RESULT(vsnprintf_impl(buf, sizeof(buf), fmt, ap));
-	va_end(ap);
+
+#if defined(GCC_DIAGNOSTIC)
+#pragma GCC diagnostic pop
+#endif
+
 	buf[sizeof(buf) - 1] = 0;
 
-	DEBUG_TRACE("mg_cry: %s", buf);
+	DEBUG_TRACE("mg_cry called from %s:%u: %s", func, line, buf);
 
 	if (!conn) {
 		puts(buf);
@@ -3307,14 +3648,15 @@ mg_cry(const struct mg_connection *conn, const char *fmt, ...)
 	/* Do not lock when getting the callback value, here and below.
 	 * I suppose this is fine, since function cannot disappear in the
 	 * same way string option can. */
-	if ((conn->ctx->callbacks.log_message == NULL)
-	    || (conn->ctx->callbacks.log_message(conn, buf) == 0)) {
+	if ((conn->phys_ctx->callbacks.log_message == NULL)
+	    || (conn->phys_ctx->callbacks.log_message(conn, buf) == 0)) {
 
-		if (conn->ctx->config[ERROR_LOG_FILE] != NULL) {
+		if (conn->dom_ctx->config[ERROR_LOG_FILE] != NULL) {
 			if (mg_fopen(conn,
-			             conn->ctx->config[ERROR_LOG_FILE],
+			             conn->dom_ctx->config[ERROR_LOG_FILE],
 			             MG_FOPEN_MODE_APPEND,
-			             &fi) == 0) {
+			             &fi)
+			    == 0) {
 				fi.access.fp = NULL;
 			}
 		} else {
@@ -3350,6 +3692,35 @@ mg_cry(const struct mg_connection *conn, const char *fmt, ...)
 	}
 }
 
+#endif /* Externally provided function */
+
+
+static void
+mg_cry_internal_wrap(const struct mg_connection *conn,
+                     const char *func,
+                     unsigned line,
+                     const char *fmt,
+                     ...)
+{
+	va_list ap;
+	va_start(ap, fmt);
+	mg_cry_internal_impl(conn, func, line, fmt, ap);
+	va_end(ap);
+}
+
+
+void
+mg_cry(const struct mg_connection *conn, const char *fmt, ...)
+{
+	va_list ap;
+	va_start(ap, fmt);
+	mg_cry_internal_impl(conn, "user", 0, fmt, ap);
+	va_end(ap);
+}
+
+
+#define mg_cry DO_NOT_USE_THIS_FUNCTION__USE_mg_cry_internal
+
 
 /* Return fake connection structure. Used for logging, if connection
  * is not applicable at the moment of logging. */
@@ -3357,7 +3728,8 @@ static struct mg_connection *
 fc(struct mg_context *ctx)
 {
 	static struct mg_connection fake_connection;
-	fake_connection.ctx = ctx;
+	fake_connection.phys_ctx = ctx;
+	fake_connection.dom_ctx = &(ctx->dd);
 	return &fake_connection;
 }
 
@@ -3375,14 +3747,22 @@ mg_get_request_info(const struct mg_connection *conn)
 	if (!conn) {
 		return NULL;
 	}
-#if 1 /* TODO: deal with legacy */
+#if defined(MG_ALLOW_USING_GET_REQUEST_INFO_FOR_RESPONSE)
 	if (conn->connection_type == CONNECTION_TYPE_RESPONSE) {
-		static char txt[16];
+		char txt[16];
+		struct mg_workerTLS *tls =
+		    (struct mg_workerTLS *)pthread_getspecific(sTlsKey);
+
 		sprintf(txt, "%03i", conn->response_info.status_code);
+		if (strlen(txt) == 3) {
+			memcpy(tls->txtbuf, txt, 4);
+		} else {
+			strcpy(tls->txtbuf, "ERR");
+		}
 
 		((struct mg_connection *)conn)->request_info.local_uri =
 		    ((struct mg_connection *)conn)->request_info.request_uri =
-		        txt; /* TODO: not thread safe */
+		        tls->txtbuf; /* use thread safe buffer */
 
 		((struct mg_connection *)conn)->request_info.num_headers =
 		    conn->response_info.num_headers;
@@ -3414,7 +3794,7 @@ mg_get_response_info(const struct mg_connection *conn)
 static const char *
 get_proto_name(const struct mg_connection *conn)
 {
-#ifdef __clang__
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunreachable-code"
 /* Depending on USE_WEBSOCKET and NO_SSL, some oft the protocols might be
@@ -3432,7 +3812,7 @@ get_proto_name(const struct mg_connection *conn)
 
 	return proto;
 
-#ifdef __clang__
+#if defined(__clang__)
 #pragma clang diagnostic pop
 #endif
 }
@@ -3455,7 +3835,10 @@ mg_get_request_link(const struct mg_connection *conn, char *buf, size_t buflen)
 		}
 
 		if ((ri->request_uri != NULL)
-		    && strcmp(ri->local_uri, ri->request_uri)) {
+		    && (0 != strcmp(ri->local_uri, ri->request_uri))) {
+			/* The request uri is different from the local uri.
+			 * This is usually if an absolute URI, including server
+			 * name has been provided. */
 			mg_snprintf(conn,
 			            &truncated,
 			            buf,
@@ -3467,7 +3850,11 @@ mg_get_request_link(const struct mg_connection *conn, char *buf, size_t buflen)
 				return -1;
 			}
 			return 0;
+
 		} else {
+
+			/* The common case is a relative URI, so we have to
+			 * construct an absolute URI from server name and port */
 
 #if defined(USE_IPV6)
 			int is_ipv6 = (conn->client.lsa.sa.sa_family == AF_INET6);
@@ -3478,11 +3865,11 @@ mg_get_request_link(const struct mg_connection *conn, char *buf, size_t buflen)
 #endif
 			int def_port = ri->is_ssl ? 443 : 80;
 			int auth_domain_check_enabled =
-			    conn->ctx->config[ENABLE_AUTH_DOMAIN_CHECK]
-			    && (!mg_strcasecmp(conn->ctx->config[ENABLE_AUTH_DOMAIN_CHECK],
-			                       "yes"));
+			    conn->dom_ctx->config[ENABLE_AUTH_DOMAIN_CHECK]
+			    && (!mg_strcasecmp(
+			           conn->dom_ctx->config[ENABLE_AUTH_DOMAIN_CHECK], "yes"));
 			const char *server_domain =
-			    conn->ctx->config[AUTHENTICATION_DOMAIN];
+			    conn->dom_ctx->config[AUTHENTICATION_DOMAIN];
 
 			char portstr[16];
 			char server_ip[48];
@@ -3564,21 +3951,17 @@ skip_quoted(char **buf,
 		*buf = end_word;
 	} else {
 
-#if defined(__GNUC__) || defined(__MINGW32__)
+#if defined(GCC_DIAGNOSTIC)
 /* Disable spurious conversion warning for GCC */
-#if GCC_VERSION >= 40500
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
-#endif /* GCC_VERSION >= 40500 */
-#endif /* defined(__GNUC__) || defined(__MINGW32__) */
+#endif /* defined(GCC_DIAGNOSTIC) */
 
 		end_whitespace = end_word + strspn(&end_word[1], whitespace) + 1;
 
-#if defined(__GNUC__) || defined(__MINGW32__)
-#if GCC_VERSION >= 40500
+#if defined(GCC_DIAGNOSTIC)
 #pragma GCC diagnostic pop
-#endif /* GCC_VERSION >= 40500 */
-#endif /* defined(__GNUC__) || defined(__MINGW32__) */
+#endif /* defined(GCC_DIAGNOSTIC) */
 
 		for (p = end_word; p < end_whitespace; p++) {
 			*p = '\0';
@@ -3608,7 +3991,7 @@ get_header(const struct mg_header *hdr, int num_hdr, const char *name)
 
 #if defined(USE_WEBSOCKET)
 /* Retrieve requested HTTP header multiple values, and return the number of
- * found occurences */
+ * found occurrences */
 static int
 get_req_headers(const struct mg_request_info *ri,
                 const char *name,
@@ -3643,7 +4026,7 @@ mg_get_header(const struct mg_connection *conn, const char *name)
 	}
 	if (conn->connection_type == CONNECTION_TYPE_RESPONSE) {
 		return get_header(conn->response_info.http_headers,
-		                  conn->request_info.num_headers,
+		                  conn->response_info.num_headers,
 		                  name);
 	}
 	return NULL;
@@ -3736,10 +4119,8 @@ header_has_option(const char *header, const char *option)
 	struct vec opt_vec;
 	struct vec eq_vec;
 
-	/*
-	assert(option != NULL);
-	assert(option[0] != '\0');
-	*/
+	DEBUG_ASSERT(option != NULL);
+	DEBUG_ASSERT(option[0] != '\0');
 
 	while ((header = next_option(header, &opt_vec, &eq_vec)) != NULL) {
 		if (mg_strncasecmp(option, opt_vec.ptr, opt_vec.len) == 0)
@@ -3751,22 +4132,22 @@ header_has_option(const char *header, const char *option)
 
 
 /* Perform case-insensitive match of string against pattern */
-static int
+static ptrdiff_t
 match_prefix(const char *pattern, size_t pattern_len, const char *str)
 {
 	const char *or_str;
-	size_t i;
-	int j, len, res;
+	ptrdiff_t i, j, len, res;
 
 	if ((or_str = (const char *)memchr(pattern, '|', pattern_len)) != NULL) {
 		res = match_prefix(pattern, (size_t)(or_str - pattern), str);
-		return (res > 0) ? res : match_prefix(or_str + 1,
-		                                      (size_t)((pattern + pattern_len)
-		                                               - (or_str + 1)),
-		                                      str);
+		return (res > 0) ? res
+		                 : match_prefix(or_str + 1,
+		                                (size_t)((pattern + pattern_len)
+		                                         - (or_str + 1)),
+		                                str);
 	}
 
-	for (i = 0, j = 0; (i < pattern_len); i++, j++) {
+	for (i = 0, j = 0; (i < (ptrdiff_t)pattern_len); i++, j++) {
 		if ((pattern[i] == '?') && (str[j] != '\0')) {
 			continue;
 		} else if (pattern[i] == '$') {
@@ -3775,11 +4156,11 @@ match_prefix(const char *pattern, size_t pattern_len, const char *str)
 			i++;
 			if (pattern[i] == '*') {
 				i++;
-				len = (int)strlen(str + j);
+				len = strlen(str + j);
 			} else {
-				len = (int)strcspn(str + j, "/");
+				len = strcspn(str + j, "/");
 			}
-			if (i == pattern_len) {
+			if (i == (ptrdiff_t)pattern_len) {
 				return j + len;
 			}
 			do {
@@ -3790,7 +4171,7 @@ match_prefix(const char *pattern, size_t pattern_len, const char *str)
 			return -1;
 		}
 	}
-	return j;
+	return (ptrdiff_t)j;
 }
 
 
@@ -3809,7 +4190,7 @@ should_keep_alive(const struct mg_connection *conn)
 		return 0;
 	}
 
-	if (mg_strcasecmp(conn->ctx->config[ENABLE_KEEP_ALIVE], "yes") != 0) {
+	if (mg_strcasecmp(conn->dom_ctx->config[ENABLE_KEEP_ALIVE], "yes") != 0) {
 		/* Close, if keep alive is not enabled */
 		return 0;
 	}
@@ -3839,11 +4220,11 @@ should_keep_alive(const struct mg_connection *conn)
 static int
 should_decode_url(const struct mg_connection *conn)
 {
-	if (!conn || !conn->ctx) {
+	if (!conn || !conn->dom_ctx) {
 		return 0;
 	}
 
-	return (mg_strcasecmp(conn->ctx->config[DECODE_URL], "yes") == 0);
+	return (mg_strcasecmp(conn->dom_ctx->config[DECODE_URL], "yes") == 0);
 }
 
 
@@ -3872,7 +4253,7 @@ send_static_cache_header(struct mg_connection *conn)
 #if !defined(NO_CACHING)
 	/* Read the server config to check how long a file may be cached.
 	 * The configuration is in seconds. */
-	int max_age = atoi(conn->ctx->config[STATIC_FILE_MAX_AGE]);
+	int max_age = atoi(conn->dom_ctx->config[STATIC_FILE_MAX_AGE]);
 	if (max_age <= 0) {
 		/* 0 means "do not cache". All values <0 are reserved
 		 * and may be used differently in the future. */
@@ -3901,11 +4282,11 @@ static int
 send_additional_header(struct mg_connection *conn)
 {
 	int i = 0;
-	const char *header = conn->ctx->config[ADDITIONAL_HEADER];
+	const char *header = conn->dom_ctx->config[ADDITIONAL_HEADER];
 
 #if !defined(NO_SSL)
-	if (conn->ctx->config[STRICT_HTTPS_MAX_AGE]) {
-		int max_age = atoi(conn->ctx->config[STRICT_HTTPS_MAX_AGE]);
+	if (conn->dom_ctx->config[STRICT_HTTPS_MAX_AGE]) {
+		int max_age = atoi(conn->dom_ctx->config[STRICT_HTTPS_MAX_AGE]);
 		if (max_age >= 0) {
 			i += mg_printf(conn,
 			               "Strict-Transport-Security: max-age=%u\r\n",
@@ -3960,7 +4341,7 @@ mg_get_response_code_text(const struct mg_connection *conn, int response_code)
 		return "Partial Content"; /* RFC2616 Section 10.2.7 */
 	case 207:
 		return "Multi-Status"; /* RFC2518 Section 10.2, RFC4918 Section 11.1
-		                          */
+		                        */
 	case 208:
 		return "Already Reported"; /* RFC5842 Section 7.1 */
 
@@ -4020,7 +4401,7 @@ mg_get_response_code_text(const struct mg_connection *conn, int response_code)
 		return "Unsupported Media Type"; /* RFC2616 Section 10.4.16 */
 	case 416:
 		return "Requested range not satisfiable"; /* RFC2616 Section 10.4.17
-		                                             */
+		                                           */
 	case 417:
 		return "Expectation Failed"; /* RFC2616 Section 10.4.18 */
 
@@ -4093,7 +4474,9 @@ mg_get_response_code_text(const struct mg_connection *conn, int response_code)
 	default:
 		/* This error code is unknown. This should not happen. */
 		if (conn) {
-			mg_cry(conn, "Unknown HTTP response code: %u", response_code);
+			mg_cry_internal(conn,
+			                "Unknown HTTP response code: %u",
+			                response_code);
 		}
 
 		/* Return at least a category according to RFC 2616 Section 10. */
@@ -4124,10 +4507,14 @@ mg_get_response_code_text(const struct mg_connection *conn, int response_code)
 }
 
 
-void
-mg_send_http_error(struct mg_connection *conn, int status, const char *fmt, ...)
+static int
+mg_send_http_error_impl(struct mg_connection *conn,
+                        int status,
+                        const char *fmt,
+                        va_list args)
 {
-	char buf[MG_BUF_LEN];
+	char errmsg_buf[MG_BUF_LEN];
+	char path_buf[PATH_MAX];
 	va_list ap;
 	int len, i, page_handler_found, scope, truncated, has_body;
 	char date[64];
@@ -4135,17 +4522,46 @@ mg_send_http_error(struct mg_connection *conn, int status, const char *fmt, ...)
 	const char *error_handler = NULL;
 	struct mg_file error_page_file = STRUCT_FILE_INITIALIZER;
 	const char *error_page_file_ext, *tstr;
+	int handled_by_callback = 0;
 
 	const char *status_text = mg_get_response_code_text(conn, status);
 
-	if (conn == NULL) {
-		return;
+	if ((conn == NULL) || (fmt == NULL)) {
+		return -2;
 	}
 
+	/* Set status (for log) */
 	conn->status_code = status;
-	if (conn->in_error_handler || (conn->ctx->callbacks.http_error == NULL)
-	    || conn->ctx->callbacks.http_error(conn, status)) {
 
+	/* Errors 1xx, 204 and 304 MUST NOT send a body */
+	has_body = ((status > 199) && (status != 204) && (status != 304));
+
+	/* Prepare message in buf, if required */
+	if (has_body
+	    || (!conn->in_error_handler
+	        && (conn->phys_ctx->callbacks.http_error != NULL))) {
+		/* Store error message in errmsg_buf */
+		va_copy(ap, args);
+		mg_vsnprintf(conn, NULL, errmsg_buf, sizeof(errmsg_buf), fmt, ap);
+		va_end(ap);
+		/* In a debug build, print all html errors */
+		DEBUG_TRACE("Error %i - [%s]", status, errmsg_buf);
+	}
+
+	/* If there is a http_error callback, call it.
+	 * But don't do it recursively, if callback calls mg_send_http_error again.
+	 */
+	if (!conn->in_error_handler
+	    && (conn->phys_ctx->callbacks.http_error != NULL)) {
+		/* Mark in_error_handler to avoid recursion and call user callback. */
+		conn->in_error_handler = 1;
+		handled_by_callback =
+		    (conn->phys_ctx->callbacks.http_error(conn, status, errmsg_buf)
+		     == 0);
+		conn->in_error_handler = 0;
+	}
+
+	if (!handled_by_callback) {
 		/* Check for recursion */
 		if (conn->in_error_handler) {
 			DEBUG_TRACE(
@@ -4153,8 +4569,8 @@ mg_send_http_error(struct mg_connection *conn, int status, const char *fmt, ...)
 			    status);
 		} else {
 			/* Send user defined error pages, if defined */
-			error_handler = conn->ctx->config[ERROR_PAGES];
-			error_page_file_ext = conn->ctx->config[INDEX_FILES];
+			error_handler = conn->dom_ctx->config[ERROR_PAGES];
+			error_page_file_ext = conn->dom_ctx->config[INDEX_FILES];
 			page_handler_found = 0;
 
 			if (error_handler != NULL) {
@@ -4163,8 +4579,8 @@ mg_send_http_error(struct mg_connection *conn, int status, const char *fmt, ...)
 					case 1: /* Handler for specific error, e.g. 404 error */
 						mg_snprintf(conn,
 						            &truncated,
-						            buf,
-						            sizeof(buf) - 32,
+						            path_buf,
+						            sizeof(path_buf) - 32,
 						            "%serror%03u.",
 						            error_handler,
 						            status);
@@ -4174,8 +4590,8 @@ mg_send_http_error(struct mg_connection *conn, int status, const char *fmt, ...)
 					         * for all server errors (500-599) */
 						mg_snprintf(conn,
 						            &truncated,
-						            buf,
-						            sizeof(buf) - 32,
+						            path_buf,
+						            sizeof(path_buf) - 32,
 						            "%serror%01uxx.",
 						            error_handler,
 						            status / 100);
@@ -4183,8 +4599,8 @@ mg_send_http_error(struct mg_connection *conn, int status, const char *fmt, ...)
 					default: /* Handler for all errors */
 						mg_snprintf(conn,
 						            &truncated,
-						            buf,
-						            sizeof(buf) - 32,
+						            path_buf,
+						            sizeof(path_buf) - 32,
 						            "%serror.",
 						            error_handler);
 						break;
@@ -4195,23 +4611,32 @@ mg_send_http_error(struct mg_connection *conn, int status, const char *fmt, ...)
 					 * from the config, not from a client. */
 					(void)truncated;
 
-					len = (int)strlen(buf);
+					len = (int)strlen(path_buf);
 
 					tstr = strchr(error_page_file_ext, '.');
 
 					while (tstr) {
 						for (i = 1;
 						     (i < 32) && (tstr[i] != 0) && (tstr[i] != ',');
-						     i++)
-							buf[len + i - 1] = tstr[i];
-						buf[len + i - 1] = 0;
+						     i++) {
+							/* buffer overrun is not possible here, since
+							 * (i < 32) && (len < sizeof(path_buf) - 32)
+							 * ==> (i + len) < sizeof(path_buf) */
+							path_buf[len + i - 1] = tstr[i];
+						}
+						/* buffer overrun is not possible here, since
+						 * (i <= 32) && (len < sizeof(path_buf) - 32)
+						 * ==> (i + len) <= sizeof(path_buf) */
+						path_buf[len + i - 1] = 0;
 
-						if (mg_stat(conn, buf, &error_page_file.stat)) {
-							DEBUG_TRACE("Check error page %s - found", buf);
+						if (mg_stat(conn, path_buf, &error_page_file.stat)) {
+							DEBUG_TRACE("Check error page %s - found",
+							            path_buf);
 							page_handler_found = 1;
 							break;
 						}
-						DEBUG_TRACE("Check error page %s - not found", buf);
+						DEBUG_TRACE("Check error page %s - not found",
+						            path_buf);
 
 						tstr = strchr(tstr + i, '.');
 					}
@@ -4220,17 +4645,14 @@ mg_send_http_error(struct mg_connection *conn, int status, const char *fmt, ...)
 
 			if (page_handler_found) {
 				conn->in_error_handler = 1;
-				handle_file_based_request(conn, buf, &error_page_file);
+				handle_file_based_request(conn, path_buf, &error_page_file);
 				conn->in_error_handler = 0;
-				return;
+				return 0;
 			}
 		}
 
 		/* No custom error page. Send default error page. */
 		gmt_time_string(date, sizeof(date), &curtime);
-
-		/* Errors 1xx, 204 and 304 MUST NOT send a body */
-		has_body = ((status > 199) && (status != 204) && (status != 304));
 
 		conn->must_close = 1;
 		mg_printf(conn, "HTTP/1.1 %d %s\r\n", status, status_text);
@@ -4246,29 +4668,181 @@ mg_send_http_error(struct mg_connection *conn, int status, const char *fmt, ...)
 		          "Connection: close\r\n\r\n",
 		          date);
 
-		/* Errors 1xx, 204 and 304 MUST NOT send a body */
+		/* HTTP responses 1xx, 204 and 304 MUST NOT send a body */
 		if (has_body) {
+			/* For other errors, send a generic error message. */
 			mg_printf(conn, "Error %d: %s\n", status, status_text);
-
-			if (fmt != NULL) {
-				va_start(ap, fmt);
-				mg_vsnprintf(conn, NULL, buf, sizeof(buf), fmt, ap);
-				va_end(ap);
-				mg_write(conn, buf, strlen(buf));
-				DEBUG_TRACE("Error %i - [%s]", status, buf);
-			}
+			mg_write(conn, errmsg_buf, strlen(errmsg_buf));
 
 		} else {
 			/* No body allowed. Close the connection. */
 			DEBUG_TRACE("Error %i", status);
 		}
 	}
+	return 0;
 }
 
-#if defined(_WIN32) && !defined(__SYMBIAN32__)
+
+int
+mg_send_http_error(struct mg_connection *conn, int status, const char *fmt, ...)
+{
+	va_list ap;
+	int ret;
+
+	va_start(ap, fmt);
+	ret = mg_send_http_error_impl(conn, status, fmt, ap);
+	va_end(ap);
+
+	return ret;
+}
+
+
+int
+mg_send_http_ok(struct mg_connection *conn,
+                const char *mime_type,
+                long long content_length)
+{
+	char date[64];
+	time_t curtime = time(NULL);
+
+	if ((mime_type == NULL) || (*mime_type == 0)) {
+		/* Parameter error */
+		return -2;
+	}
+
+	gmt_time_string(date, sizeof(date), &curtime);
+
+	mg_printf(conn,
+	          "HTTP/1.1 200 OK\r\n"
+	          "Content-Type: %s\r\n"
+	          "Date: %s\r\n"
+	          "Connection: %s\r\n",
+	          mime_type,
+	          date,
+	          suggest_connection_header(conn));
+
+	send_no_cache_header(conn);
+	send_additional_header(conn);
+	if (content_length < 0) {
+		mg_printf(conn, "Transfer-Encoding: chunked\r\n\r\n");
+	} else {
+		mg_printf(conn,
+		          "Content-Length: %" UINT64_FMT "\r\n\r\n",
+		          (uint64_t)content_length);
+	}
+
+	return 0;
+}
+
+
+int
+mg_send_http_redirect(struct mg_connection *conn,
+                      const char *target_url,
+                      int redirect_code)
+{
+	/* Send a 30x redirect response.
+	 *
+	 * Redirect types (status codes):
+	 *
+	 * Status | Perm/Temp | Method              | Version
+	 *   301  | permanent | POST->GET undefined | HTTP/1.0
+	 *   302  | temporary | POST->GET undefined | HTTP/1.0
+	 *   303  | temporary | always use GET      | HTTP/1.1
+	 *   307  | temporary | always keep method  | HTTP/1.1
+	 *   308  | permanent | always keep method  | HTTP/1.1
+	 */
+	const char *redirect_text;
+	int ret;
+	size_t content_len = 0;
+	char reply[MG_BUF_LEN];
+
+	/* In case redirect_code=0, use 307. */
+	if (redirect_code == 0) {
+		redirect_code = 307;
+	}
+
+	/* In case redirect_code is none of the above, return error. */
+	if ((redirect_code != 301) && (redirect_code != 302)
+	    && (redirect_code != 303) && (redirect_code != 307)
+	    && (redirect_code != 308)) {
+		/* Parameter error */
+		return -2;
+	}
+
+	/* Get proper text for response code */
+	redirect_text = mg_get_response_code_text(conn, redirect_code);
+
+	/* If target_url is not defined, redirect to "/". */
+	if ((target_url == NULL) || (*target_url == 0)) {
+		target_url = "/";
+	}
+
+#if defined(MG_SEND_REDIRECT_BODY)
+	/* TODO: condition name? */
+
+	/* Prepare a response body with a hyperlink.
+	 *
+	 * According to RFC2616 (and RFC1945 before):
+	 * Unless the request method was HEAD, the entity of the
+	 * response SHOULD contain a short hypertext note with a hyperlink to
+	 * the new URI(s).
+	 *
+	 * However, this response body is not useful in M2M communication.
+	 * Probably the original reason in the RFC was, clients not supporting
+	 * a 30x HTTP redirect could still show the HTML page and let the user
+	 * press the link. Since current browsers support 30x HTTP, the additional
+	 * HTML body does not seem to make sense anymore.
+	 *
+	 * The new RFC7231 (Section 6.4) does no longer recommend it ("SHOULD"),
+	 * but it only notes:
+	 * The server's response payload usually contains a short
+	 * hypertext note with a hyperlink to the new URI(s).
+	 *
+	 * Deactivated by default. If you need the 30x body, set the define.
+	 */
+	mg_snprintf(
+	    conn,
+	    NULL /* ignore truncation */,
+	    reply,
+	    sizeof(reply),
+	    "<html><head>%s</head><body><a href=\"%s\">%s</a></body></html>",
+	    redirect_text,
+	    target_url,
+	    target_url);
+	content_len = strlen(reply);
+#else
+	reply[0] = 0;
+#endif
+
+	/* Do not send any additional header. For all other options,
+	 * including caching, there are suitable defaults. */
+	ret = mg_printf(conn,
+	                "HTTP/1.1 %i %s\r\n"
+	                "Location: %s\r\n"
+	                "Content-Length: %u\r\n"
+	                "Connection: %s\r\n\r\n",
+	                redirect_code,
+	                redirect_text,
+	                target_url,
+	                (unsigned int)content_len,
+	                suggest_connection_header(conn));
+
+	/* Send response body */
+	if (ret > 0) {
+		/* ... unless it is a HEAD request */
+		if (0 != strcmp(conn->request_info.request_method, "HEAD")) {
+			ret = mg_write(conn, reply, content_len);
+		}
+	}
+
+	return (ret > 0) ? ret : -1;
+}
+
+
+#if defined(_WIN32)
 /* Create substitutes for POSIX functions in Win32. */
 
-#if defined(__MINGW32__)
+#if defined(GCC_DIAGNOSTIC)
 /* Show no warning in case system functions are not used. */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
@@ -4301,7 +4875,7 @@ pthread_mutex_lock(pthread_mutex_t *mutex)
 }
 
 
-#ifdef ENABLE_UNUSED_PTHREAD_FUNCTIONS
+#if defined(ENABLE_UNUSED_PTHREAD_FUNCTIONS)
 FUNCTION_MAY_BE_UNUSED
 static int
 pthread_mutex_trylock(pthread_mutex_t *mutex)
@@ -4340,7 +4914,7 @@ FUNCTION_MAY_BE_UNUSED
 static int
 pthread_cond_timedwait(pthread_cond_t *cv,
                        pthread_mutex_t *mutex,
-                       const struct timespec *abstime)
+                       FUNCTION_MAY_BE_UNUSED const struct timespec *abstime)
 {
 	struct mg_workerTLS **ptls,
 	    *tls = (struct mg_workerTLS *)pthread_getspecific(sTlsKey);
@@ -4418,7 +4992,7 @@ pthread_cond_signal(pthread_cond_t *cv)
 		cv->waiting_thread = cv->waiting_thread->next_waiting_thread;
 
 		ok = SetEvent(wkup);
-		assert(ok);
+		DEBUG_ASSERT(ok);
 	}
 	LeaveCriticalSection(&cv->threadIdSec);
 
@@ -4445,7 +5019,7 @@ static int
 pthread_cond_destroy(pthread_cond_t *cv)
 {
 	EnterCriticalSection(&cv->threadIdSec);
-	assert(cv->waiting_thread == NULL);
+	DEBUG_ASSERT(cv->waiting_thread == NULL);
 	LeaveCriticalSection(&cv->threadIdSec);
 	DeleteCriticalSection(&cv->threadIdSec);
 
@@ -4453,7 +5027,7 @@ pthread_cond_destroy(pthread_cond_t *cv)
 }
 
 
-#ifdef ALTERNATIVE_QUEUE
+#if defined(ALTERNATIVE_QUEUE)
 FUNCTION_MAY_BE_UNUSED
 static void *
 event_create(void)
@@ -4488,7 +5062,7 @@ event_destroy(void *eventhdl)
 #endif
 
 
-#if defined(__MINGW32__)
+#if defined(GCC_DIAGNOSTIC)
 /* Enable unused function warning again */
 #pragma GCC diagnostic pop
 #endif
@@ -4540,7 +5114,7 @@ path_to_unicode(const struct mg_connection *conn,
                 size_t wbuf_len)
 {
 	char buf[PATH_MAX], buf2[PATH_MAX];
-	wchar_t wbuf2[MAX_PATH + 1];
+	wchar_t wbuf2[W_PATH_MAX + 1];
 	DWORD long_len, err;
 	int (*fcompare)(const wchar_t *, const wchar_t *) = mg_wcscasecmp;
 
@@ -4567,8 +5141,9 @@ path_to_unicode(const struct mg_connection *conn,
 	 * As a default, Windows is not case sensitive, but the case sensitive
 	 * file name check can be activated by an additional configuration. */
 	if (conn) {
-		if (conn->ctx->config[CASE_SENSITIVE_FILES]
-		    && !mg_strcasecmp(conn->ctx->config[CASE_SENSITIVE_FILES], "yes")) {
+		if (conn->dom_ctx->config[CASE_SENSITIVE_FILES]
+		    && !mg_strcasecmp(conn->dom_ctx->config[CASE_SENSITIVE_FILES],
+		                      "yes")) {
 			/* Use case sensitive compare function */
 			fcompare = wcscmp;
 		}
@@ -4620,7 +5195,7 @@ mg_stat(const struct mg_connection *conn,
         const char *path,
         struct mg_file_stat *filep)
 {
-	wchar_t wbuf[PATH_MAX];
+	wchar_t wbuf[W_PATH_MAX];
 	WIN32_FILE_ATTRIBUTE_DATA info;
 	time_t creation_time;
 
@@ -4650,7 +5225,7 @@ mg_stat(const struct mg_connection *conn,
 		/* last_modified = now ... assumes the file may change during
 		 * runtime,
 		 * so every mg_fopen call may return different data */
-		/* last_modified = conn->ctx.start_time;
+		/* last_modified = conn->phys_ctx.start_time;
 		 * May be used it the data does not change during runtime. This
 		 * allows
 		 * browser caching. Since we do not know, we have to assume the file
@@ -4695,7 +5270,7 @@ mg_stat(const struct mg_connection *conn,
 static int
 mg_remove(const struct mg_connection *conn, const char *path)
 {
-	wchar_t wbuf[PATH_MAX];
+	wchar_t wbuf[W_PATH_MAX];
 	path_to_unicode(conn, path, wbuf, ARRAY_SIZE(wbuf));
 	return DeleteFileW(wbuf) ? 0 : -1;
 }
@@ -4704,7 +5279,7 @@ mg_remove(const struct mg_connection *conn, const char *path)
 static int
 mg_mkdir(const struct mg_connection *conn, const char *path, int mode)
 {
-	wchar_t wbuf[PATH_MAX];
+	wchar_t wbuf[W_PATH_MAX];
 	(void)mode;
 	path_to_unicode(conn, path, wbuf, ARRAY_SIZE(wbuf));
 	return CreateDirectoryW(wbuf, NULL) ? 0 : -1;
@@ -4713,7 +5288,7 @@ mg_mkdir(const struct mg_connection *conn, const char *path, int mode)
 
 /* Create substitutes for POSIX functions in Win32. */
 
-#if defined(__MINGW32__)
+#if defined(GCC_DIAGNOSTIC)
 /* Show no warning in case system functions are not used. */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
@@ -4726,7 +5301,7 @@ static DIR *
 mg_opendir(const struct mg_connection *conn, const char *name)
 {
 	DIR *dir = NULL;
-	wchar_t wpath[PATH_MAX];
+	wchar_t wpath[W_PATH_MAX];
 	DWORD attrs;
 
 	if (name == NULL) {
@@ -4736,8 +5311,8 @@ mg_opendir(const struct mg_connection *conn, const char *name)
 	} else {
 		path_to_unicode(conn, name, wpath, ARRAY_SIZE(wpath));
 		attrs = GetFileAttributesW(wpath);
-		if (attrs != 0xFFFFFFFF && ((attrs & FILE_ATTRIBUTE_DIRECTORY)
-		                            == FILE_ATTRIBUTE_DIRECTORY)) {
+		if ((wcslen(wpath) + 2 < ARRAY_SIZE(wpath)) && (attrs != 0xFFFFFFFF)
+		    && ((attrs & FILE_ATTRIBUTE_DIRECTORY) != 0)) {
 			(void)wcscat(wpath, L"\\*");
 			dir->handle = FindFirstFileW(wpath, &dir->info);
 			dir->result.d_name[0] = '\0';
@@ -4805,13 +5380,18 @@ mg_readdir(DIR *dir)
 }
 
 
-#ifndef HAVE_POLL
+#if !defined(HAVE_POLL)
+#define POLLIN (1)  /* Data ready - read will not block. */
+#define POLLPRI (2) /* Priority data ready. */
+#define POLLOUT (4) /* Send queue not full - write will not block. */
+
 FUNCTION_MAY_BE_UNUSED
 static int
 poll(struct pollfd *pfd, unsigned int n, int milliseconds)
 {
 	struct timeval tv;
-	fd_set set;
+	fd_set rset;
+	fd_set wset;
 	unsigned int i;
 	int result;
 	SOCKET maxfd = 0;
@@ -4819,10 +5399,15 @@ poll(struct pollfd *pfd, unsigned int n, int milliseconds)
 	memset(&tv, 0, sizeof(tv));
 	tv.tv_sec = milliseconds / 1000;
 	tv.tv_usec = (milliseconds % 1000) * 1000;
-	FD_ZERO(&set);
+	FD_ZERO(&rset);
+	FD_ZERO(&wset);
 
 	for (i = 0; i < n; i++) {
-		FD_SET((SOCKET)pfd[i].fd, &set);
+		if (pfd[i].events & POLLIN) {
+			FD_SET((SOCKET)pfd[i].fd, &rset);
+		} else if (pfd[i].events & POLLOUT) {
+			FD_SET((SOCKET)pfd[i].fd, &wset);
+		}
 		pfd[i].revents = 0;
 
 		if (pfd[i].fd > maxfd) {
@@ -4830,10 +5415,13 @@ poll(struct pollfd *pfd, unsigned int n, int milliseconds)
 		}
 	}
 
-	if ((result = select((int)maxfd + 1, &set, NULL, NULL, &tv)) > 0) {
+	if ((result = select((int)maxfd + 1, &rset, &wset, NULL, &tv)) > 0) {
 		for (i = 0; i < n; i++) {
-			if (FD_ISSET(pfd[i].fd, &set)) {
-				pfd[i].revents = POLLIN;
+			if (FD_ISSET(pfd[i].fd, &rset)) {
+				pfd[i].revents |= POLLIN;
+			}
+			if (FD_ISSET(pfd[i].fd, &wset)) {
+				pfd[i].revents |= POLLOUT;
 			}
 		}
 	}
@@ -4850,7 +5438,7 @@ poll(struct pollfd *pfd, unsigned int n, int milliseconds)
 #endif /* HAVE_POLL */
 
 
-#if defined(__MINGW32__)
+#if defined(GCC_DIAGNOSTIC)
 /* Enable unused function warning again */
 #pragma GCC diagnostic pop
 #endif
@@ -4934,7 +5522,7 @@ mg_join_thread(pthread_t threadid)
 /* If SSL is loaded dynamically, dlopen/dlclose is required. */
 /* Create substitutes for POSIX functions in Win32. */
 
-#if defined(__MINGW32__)
+#if defined(GCC_DIAGNOSTIC)
 /* Show no warning in case system functions are not used. */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
@@ -4945,7 +5533,7 @@ FUNCTION_MAY_BE_UNUSED
 static HANDLE
 dlopen(const char *dll_name, int flags)
 {
-	wchar_t wbuf[PATH_MAX];
+	wchar_t wbuf[W_PATH_MAX];
 	(void)flags;
 	path_to_unicode(NULL, dll_name, wbuf, ARRAY_SIZE(wbuf));
 	return LoadLibraryW(wbuf);
@@ -4968,7 +5556,7 @@ dlclose(void *handle)
 }
 
 
-#if defined(__MINGW32__)
+#if defined(GCC_DIAGNOSTIC)
 /* Enable unused function warning again */
 #pragma GCC diagnostic pop
 #endif
@@ -4979,12 +5567,41 @@ dlclose(void *handle)
 #if !defined(NO_CGI)
 #define SIGKILL (0)
 
+
 static int
 kill(pid_t pid, int sig_num)
 {
 	(void)TerminateProcess((HANDLE)pid, (UINT)sig_num);
 	(void)CloseHandle((HANDLE)pid);
 	return 0;
+}
+
+
+#if !defined(WNOHANG)
+#define WNOHANG (1)
+#endif
+
+
+static pid_t
+waitpid(pid_t pid, int *status, int flags)
+{
+	DWORD timeout = INFINITE;
+	DWORD waitres;
+
+	(void)status; /* Currently not used by any client here */
+
+	if ((flags | WNOHANG) == WNOHANG) {
+		timeout = 0;
+	}
+
+	waitres = WaitForSingleObject((HANDLE)pid, timeout);
+	if (waitres == WAIT_OBJECT_0) {
+		return pid;
+	}
+	if (waitres == WAIT_TIMEOUT) {
+		return 0;
+	}
+	return (pid_t)-1;
 }
 
 
@@ -5061,7 +5678,7 @@ spawn_process(struct mg_connection *conn,
 	                     0);
 
 	/* If CGI file is a script, try to read the interpreter line */
-	interp = conn->ctx->config[CGI_INTERPRETER];
+	interp = conn->dom_ctx->config[CGI_INTERPRETER];
 	if (interp == NULL) {
 		buf[0] = buf[1] = '\0';
 
@@ -5075,7 +5692,11 @@ spawn_process(struct mg_connection *conn,
 		}
 
 		if (mg_fopen(conn, cmdline, MG_FOPEN_MODE_READ, &file)) {
+#if defined(MG_USE_OPEN_FILE)
 			p = (char *)file.access.membuf;
+#else
+			p = (char *)NULL;
+#endif
 			mg_fgets(buf, sizeof(buf), &file, &p);
 			(void)mg_fclose(&file.access); /* ignore error on read only file */
 			buf[sizeof(buf) - 1] = '\0';
@@ -5129,8 +5750,9 @@ spawn_process(struct mg_connection *conn,
 	                   envblk,
 	                   NULL,
 	                   &si,
-	                   &pi) == 0) {
-		mg_cry(
+	                   &pi)
+	    == 0) {
+		mg_cry_internal(
 		    conn, "%s: CreateProcess(%s): %ld", __func__, cmdline, (long)ERRNO);
 		pi.hProcess = (pid_t)-1;
 		/* goto spawn_cleanup; */
@@ -5162,6 +5784,7 @@ set_non_blocking_mode(SOCKET sock)
 	unsigned long non_blocking = 1;
 	return ioctlsocket(sock, (long)FIONBIO, &non_blocking);
 }
+
 #else
 
 static int
@@ -5184,7 +5807,7 @@ mg_stat(const struct mg_connection *conn,
 		filep->size = tmp_file.stat.size;
 		filep->last_modified = time(NULL);
 		filep->location = 2;
-		/* TODO: for 1.10: restructure how files in memory are handled */
+		/* TODO: remove legacy "files in memory" feature */
 
 		return 1;
 	}
@@ -5205,10 +5828,10 @@ set_close_on_exec(SOCKET fd, struct mg_connection *conn /* may be null */)
 {
 	if (fcntl(fd, F_SETFD, FD_CLOEXEC) != 0) {
 		if (conn) {
-			mg_cry(conn,
-			       "%s: fcntl(F_SETFD FD_CLOEXEC) failed: %s",
-			       __func__,
-			       strerror(ERRNO));
+			mg_cry_internal(conn,
+			                "%s: fcntl(F_SETFD FD_CLOEXEC) failed: %s",
+			                __func__,
+			                strerror(ERRNO));
 		}
 	}
 }
@@ -5275,7 +5898,7 @@ mg_join_thread(pthread_t threadid)
 }
 
 
-#ifndef NO_CGI
+#if !defined(NO_CGI)
 static pid_t
 spawn_process(struct mg_connection *conn,
               const char *prog,
@@ -5304,25 +5927,26 @@ spawn_process(struct mg_connection *conn,
 	} else if (pid == 0) {
 		/* Child */
 		if (chdir(dir) != 0) {
-			mg_cry(conn, "%s: chdir(%s): %s", __func__, dir, strerror(ERRNO));
+			mg_cry_internal(
+			    conn, "%s: chdir(%s): %s", __func__, dir, strerror(ERRNO));
 		} else if (dup2(fdin[0], 0) == -1) {
-			mg_cry(conn,
-			       "%s: dup2(%d, 0): %s",
-			       __func__,
-			       fdin[0],
-			       strerror(ERRNO));
+			mg_cry_internal(conn,
+			                "%s: dup2(%d, 0): %s",
+			                __func__,
+			                fdin[0],
+			                strerror(ERRNO));
 		} else if (dup2(fdout[1], 1) == -1) {
-			mg_cry(conn,
-			       "%s: dup2(%d, 1): %s",
-			       __func__,
-			       fdout[1],
-			       strerror(ERRNO));
+			mg_cry_internal(conn,
+			                "%s: dup2(%d, 1): %s",
+			                __func__,
+			                fdout[1],
+			                strerror(ERRNO));
 		} else if (dup2(fderr[1], 2) == -1) {
-			mg_cry(conn,
-			       "%s: dup2(%d, 2): %s",
-			       __func__,
-			       fderr[1],
-			       strerror(ERRNO));
+			mg_cry_internal(conn,
+			                "%s: dup2(%d, 2): %s",
+			                __func__,
+			                fderr[1],
+			                strerror(ERRNO));
 		} else {
 			/* Keep stderr and stdout in two different pipes.
 			 * Stdout will be sent back to the client,
@@ -5338,27 +5962,27 @@ spawn_process(struct mg_connection *conn,
 
 			/* After exec, all signal handlers are restored to their default
 			 * values, with one exception of SIGCHLD. According to
-			 * POSIX.1-2001 and Linux's implementation, SIGCHLD's handler will
-			 * leave unchanged after exec if it was set to be ignored. Restore
-			 * it to default action. */
+			 * POSIX.1-2001 and Linux's implementation, SIGCHLD's handler
+			 * will leave unchanged after exec if it was set to be ignored.
+			 * Restore it to default action. */
 			signal(SIGCHLD, SIG_DFL);
 
-			interp = conn->ctx->config[CGI_INTERPRETER];
+			interp = conn->dom_ctx->config[CGI_INTERPRETER];
 			if (interp == NULL) {
 				(void)execle(prog, prog, NULL, envp);
-				mg_cry(conn,
-				       "%s: execle(%s): %s",
-				       __func__,
-				       prog,
-				       strerror(ERRNO));
+				mg_cry_internal(conn,
+				                "%s: execle(%s): %s",
+				                __func__,
+				                prog,
+				                strerror(ERRNO));
 			} else {
 				(void)execle(interp, interp, prog, NULL, envp);
-				mg_cry(conn,
-				       "%s: execle(%s %s): %s",
-				       __func__,
-				       interp,
-				       prog,
-				       strerror(ERRNO));
+				mg_cry_internal(conn,
+				                "%s: execle(%s %s): %s",
+				                __func__,
+				                interp,
+				                prog,
+				                strerror(ERRNO));
 			}
 		}
 		exit(EXIT_FAILURE);
@@ -5493,7 +6117,7 @@ push_inner(struct mg_context *ctx,
 	int n, err;
 	unsigned ms_wait = SOCKET_TIMEOUT_QUANTUM; /* Sleep quantum in ms */
 
-#ifdef _WIN32
+#if defined(_WIN32)
 	typedef int len_t;
 #else
 	typedef size_t len_t;
@@ -5509,7 +6133,7 @@ push_inner(struct mg_context *ctx,
 		return -2;
 	}
 
-#ifdef NO_SSL
+#if defined(NO_SSL)
 	if (ssl) {
 		return -2;
 	}
@@ -5519,7 +6143,7 @@ push_inner(struct mg_context *ctx,
 	 * shuts down. */
 	for (;;) {
 
-#ifndef NO_SSL
+#if !defined(NO_SSL)
 		if (ssl != NULL) {
 			n = SSL_write(ssl, buf, len);
 			if (n <= 0) {
@@ -5549,7 +6173,7 @@ push_inner(struct mg_context *ctx,
 		} else {
 			n = (int)send(sock, buf, (len_t)len, MSG_NOSIGNAL);
 			err = (n < 0) ? ERRNO : 0;
-#ifdef _WIN32
+#if defined(_WIN32)
 			if (err == WSAEWOULDBLOCK) {
 				err = 0;
 				n = 0;
@@ -5591,37 +6215,21 @@ push_inner(struct mg_context *ctx,
 
 		/* If send failed, wait before retry */
 		if (fp != NULL) {
-			/* For files, just wait a fixed time,
-			 * maybe an average disk seek time. */
-			mg_sleep(ms_wait > 10 ? 10 : ms_wait);
+			/* For files, just wait a fixed time.
+			 * Maybe it helps, maybe not. */
+			mg_sleep(5);
 		} else {
-			/* For sockets, wait for the socket using select */
-			fd_set wfds;
-			struct timeval tv;
-			int sret;
+			/* For sockets, wait for the socket using poll */
+			struct pollfd pfd[1];
+			int pollres;
 
-#if defined(__GNUC__) || defined(__MINGW32__)
-/* GCC seems to have a flaw with it's own socket macros:
- * http://www.linuxquestions.org/questions/programming-9/impossible-to-use-gcc-with-wconversion-and-standard-socket-macros-841935/
- */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wsign-conversion"
-#endif
-
-			FD_ZERO(&wfds);
-			FD_SET(sock, &wfds);
-			tv.tv_sec = (time_t)(ms_wait / 1000);
-			tv.tv_usec = (long)((ms_wait % 1000) * 1000);
-
-			sret = select((int)sock + 1, NULL, &wfds, NULL, &tv);
-
-#if defined(__GNUC__) || defined(__MINGW32__)
-#pragma GCC diagnostic pop
-#endif
-
-			if (sret > 0) {
-				/* We got ready to write. Don't check the timeout
-				 * but directly go back to write again. */
+			pfd[0].fd = sock;
+			pfd[0].events = POLLOUT;
+			pollres = mg_poll(pfd, 1, (int)(ms_wait), &(ctx->stop_flag));
+			if (ctx->stop_flag) {
+				return -2;
+			}
+			if (pollres > 0) {
 				continue;
 			}
 		}
@@ -5657,8 +6265,8 @@ push_all(struct mg_context *ctx,
 		return -1;
 	}
 
-	if (ctx->config[REQUEST_TIMEOUT]) {
-		timeout = atoi(ctx->config[REQUEST_TIMEOUT]) / 1000.0;
+	if (ctx->dd.config[REQUEST_TIMEOUT]) {
+		timeout = atoi(ctx->dd.config[REQUEST_TIMEOUT]) / 1000.0;
 	}
 
 	while ((len > 0) && (ctx->stop_flag == 0)) {
@@ -5695,12 +6303,12 @@ pull_inner(FILE *fp,
 {
 	int nread, err = 0;
 
-#ifdef _WIN32
+#if defined(_WIN32)
 	typedef int len_t;
 #else
 	typedef size_t len_t;
 #endif
-#ifndef NO_SSL
+#if !defined(NO_SSL)
 	int ssl_pending;
 #endif
 
@@ -5726,7 +6334,7 @@ pull_inner(FILE *fp,
 			return -2;
 		}
 
-#ifndef NO_SSL
+#if !defined(NO_SSL)
 	} else if ((conn->ssl != NULL)
 	           && ((ssl_pending = SSL_pending(conn->ssl)) > 0)) {
 		/* We already know there is no more data buffered in conn->buf
@@ -5758,9 +6366,11 @@ pull_inner(FILE *fp,
 
 		pfd[0].fd = conn->client.sock;
 		pfd[0].events = POLLIN;
-		pollres =
-		    mg_poll(pfd, 1, (int)(timeout * 1000.0), &(conn->ctx->stop_flag));
-		if (conn->ctx->stop_flag) {
+		pollres = mg_poll(pfd,
+		                  1,
+		                  (int)(timeout * 1000.0),
+		                  &(conn->phys_ctx->stop_flag));
+		if (conn->phys_ctx->stop_flag) {
 			return -2;
 		}
 		if (pollres > 0) {
@@ -5795,9 +6405,11 @@ pull_inner(FILE *fp,
 
 		pfd[0].fd = conn->client.sock;
 		pfd[0].events = POLLIN;
-		pollres =
-		    mg_poll(pfd, 1, (int)(timeout * 1000.0), &(conn->ctx->stop_flag));
-		if (conn->ctx->stop_flag) {
+		pollres = mg_poll(pfd,
+		                  1,
+		                  (int)(timeout * 1000.0),
+		                  &(conn->phys_ctx->stop_flag));
+		if (conn->phys_ctx->stop_flag) {
 			return -2;
 		}
 		if (pollres > 0) {
@@ -5816,7 +6428,7 @@ pull_inner(FILE *fp,
 		}
 	}
 
-	if (conn->ctx->stop_flag) {
+	if (conn->phys_ctx->stop_flag) {
 		return -2;
 	}
 
@@ -5827,7 +6439,7 @@ pull_inner(FILE *fp,
 
 	if (nread < 0) {
 /* socket error - check errno */
-#ifdef _WIN32
+#if defined(_WIN32)
 		if (err == WSAEWOULDBLOCK) {
 			/* TODO (low): check if this is still required */
 			/* standard case if called from close_socket_gracefully */
@@ -5854,7 +6466,7 @@ pull_inner(FILE *fp,
 			/* EAGAIN/EWOULDBLOCK:
 			 * standard case if called from close_socket_gracefully
 			 * => should return -1 */
-			/* or timeout occured
+			/* or timeout occurred
 			 * => the code must stay in the while loop */
 
 			/* EINTR can be generated on a socket with a timeout set even
@@ -5868,7 +6480,7 @@ pull_inner(FILE *fp,
 #endif
 	}
 
-	/* Timeout occured, but no data available. */
+	/* Timeout occurred, but no data available. */
 	return -1;
 }
 
@@ -5880,15 +6492,15 @@ pull_all(FILE *fp, struct mg_connection *conn, char *buf, int len)
 	double timeout = -1.0;
 	uint64_t start_time = 0, now = 0, timeout_ns = 0;
 
-	if (conn->ctx->config[REQUEST_TIMEOUT]) {
-		timeout = atoi(conn->ctx->config[REQUEST_TIMEOUT]) / 1000.0;
+	if (conn->dom_ctx->config[REQUEST_TIMEOUT]) {
+		timeout = atoi(conn->dom_ctx->config[REQUEST_TIMEOUT]) / 1000.0;
 	}
 	if (timeout >= 0.0) {
 		start_time = mg_get_current_time_ns();
 		timeout_ns = (uint64_t)(timeout * 1.0E9);
 	}
 
-	while ((len > 0) && (conn->ctx->stop_flag == 0)) {
+	while ((len > 0) && (conn->phys_ctx->stop_flag == 0)) {
 		n = pull_inner(fp, conn, buf + nread, len, timeout);
 		if (n == -2) {
 			if (nread == 0) {
@@ -5963,8 +6575,8 @@ mg_read_inner(struct mg_connection *conn, void *buf, size_t len)
 	int64_t n, buffered_len, nread;
 	int64_t len64 =
 	    (int64_t)((len > INT_MAX) ? INT_MAX : len); /* since the return value is
-	                                               * int, we may not read more
-	                                               * bytes */
+	                                                 * int, we may not read more
+	                                                 * bytes */
 	const char *body;
 
 	if (conn == NULL) {
@@ -6158,24 +6770,26 @@ mg_write(struct mg_connection *conn, const void *buf, size_t len)
 		if (allowed > (int64_t)len) {
 			allowed = (int64_t)len;
 		}
-		if ((total = push_all(conn->ctx,
+		if ((total = push_all(conn->phys_ctx,
 		                      NULL,
 		                      conn->client.sock,
 		                      conn->ssl,
 		                      (const char *)buf,
-		                      (int64_t)allowed)) == allowed) {
+		                      (int64_t)allowed))
+		    == allowed) {
 			buf = (const char *)buf + total;
 			conn->last_throttle_bytes += total;
-			while ((total < (int64_t)len) && (conn->ctx->stop_flag == 0)) {
+			while ((total < (int64_t)len) && (conn->phys_ctx->stop_flag == 0)) {
 				allowed = (conn->throttle > ((int64_t)len - total))
 				              ? (int64_t)len - total
 				              : conn->throttle;
-				if ((n = push_all(conn->ctx,
+				if ((n = push_all(conn->phys_ctx,
 				                  NULL,
 				                  conn->client.sock,
 				                  conn->ssl,
 				                  (const char *)buf,
-				                  (int64_t)allowed)) != allowed) {
+				                  (int64_t)allowed))
+				    != allowed) {
 					break;
 				}
 				sleep(1);
@@ -6186,7 +6800,7 @@ mg_write(struct mg_connection *conn, const void *buf, size_t len)
 			}
 		}
 	} else {
-		total = push_all(conn->ctx,
+		total = push_all(conn->phys_ctx,
 		                 NULL,
 		                 conn->client.sock,
 		                 conn->ssl,
@@ -6236,6 +6850,14 @@ mg_send_chunk(struct mg_connection *conn,
 
 	return t;
 }
+
+
+#if defined(GCC_DIAGNOSTIC)
+/* This block forwards format strings to printf implementations,
+ * so we need to disable the format-nonliteral warning. */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#endif
 
 
 /* Alternative alloc_vprintf() for non-compliant C runtimes */
@@ -6296,7 +6918,7 @@ alloc_vprintf(char **out_buf,
 		/* C runtime is not standard compliant, vsnprintf() returned -1.
 		 * Switch to alternative code path that uses incremental
 		 * allocations.
-		*/
+		 */
 		va_copy(ap_copy, ap);
 		len = alloc_vprintf2(out_buf, fmt, ap_copy);
 		va_end(ap_copy);
@@ -6327,6 +6949,12 @@ alloc_vprintf(char **out_buf,
 
 	return len;
 }
+
+
+#if defined(GCC_DIAGNOSTIC)
+/* Enable format-nonliteral warning again. */
+#pragma GCC diagnostic pop
+#endif
 
 
 static int
@@ -6438,7 +7066,7 @@ mg_get_var2(const char *data,
 				if (s == NULL) {
 					s = e;
 				}
-				/* assert(s >= p); */
+				DEBUG_ASSERT(s >= p);
 				if (s < p) {
 					return -3;
 				}
@@ -6613,8 +7241,9 @@ is_put_or_delete_method(const struct mg_connection *conn)
 {
 	if (conn) {
 		const char *s = conn->request_info.request_method;
-		return (s != NULL) && (!strcmp(s, "PUT") || !strcmp(s, "DELETE")
-		                       || !strcmp(s, "MKCOL") || !strcmp(s, "PATCH"));
+		return (s != NULL)
+		       && (!strcmp(s, "PUT") || !strcmp(s, "DELETE")
+		           || !strcmp(s, "MKCOL") || !strcmp(s, "PATCH"));
 	}
 	return 0;
 }
@@ -6625,26 +7254,29 @@ static int
 extention_matches_script(
     struct mg_connection *conn, /* in: request (must be valid) */
     const char *filename        /* in: filename  (must be valid) */
-    )
+)
 {
 #if !defined(NO_CGI)
-	if (match_prefix(conn->ctx->config[CGI_EXTENSIONS],
-	                 strlen(conn->ctx->config[CGI_EXTENSIONS]),
-	                 filename) > 0) {
+	if (match_prefix(conn->dom_ctx->config[CGI_EXTENSIONS],
+	                 strlen(conn->dom_ctx->config[CGI_EXTENSIONS]),
+	                 filename)
+	    > 0) {
 		return 1;
 	}
 #endif
 #if defined(USE_LUA)
-	if (match_prefix(conn->ctx->config[LUA_SCRIPT_EXTENSIONS],
-	                 strlen(conn->ctx->config[LUA_SCRIPT_EXTENSIONS]),
-	                 filename) > 0) {
+	if (match_prefix(conn->dom_ctx->config[LUA_SCRIPT_EXTENSIONS],
+	                 strlen(conn->dom_ctx->config[LUA_SCRIPT_EXTENSIONS]),
+	                 filename)
+	    > 0) {
 		return 1;
 	}
 #endif
 #if defined(USE_DUKTAPE)
-	if (match_prefix(conn->ctx->config[DUKTAPE_SCRIPT_EXTENSIONS],
-	                 strlen(conn->ctx->config[DUKTAPE_SCRIPT_EXTENSIONS]),
-	                 filename) > 0) {
+	if (match_prefix(conn->dom_ctx->config[DUKTAPE_SCRIPT_EXTENSIONS],
+	                 strlen(conn->dom_ctx->config[DUKTAPE_SCRIPT_EXTENSIONS]),
+	                 filename)
+	    > 0) {
 		return 1;
 	}
 #endif
@@ -6666,7 +7298,7 @@ substitute_index_file(struct mg_connection *conn,
                       size_t path_len,
                       struct mg_file_stat *filestat)
 {
-	const char *list = conn->ctx->config[INDEX_FILES];
+	const char *list = conn->dom_ctx->config[INDEX_FILES];
 	struct vec filename_vec;
 	size_t n = strlen(path);
 	int found = 0;
@@ -6683,7 +7315,7 @@ substitute_index_file(struct mg_connection *conn,
 	 * path and see if the file exists. If it exists, break the loop */
 	while ((list = next_option(list, &filename_vec, NULL)) != NULL) {
 		/* Ignore too long entries that may overflow path buffer */
-		if (filename_vec.len > (path_len - (n + 2))) {
+		if ((filename_vec.len + 1) > (path_len - (n + 1))) {
 			continue;
 		}
 
@@ -6717,16 +7349,16 @@ interpret_uri(struct mg_connection *conn, /* in/out: request (must be valid) */
               int *is_script_resource,       /* out: handled by a script? */
               int *is_websocket_request,     /* out: websocket connetion? */
               int *is_put_or_delete_request  /* out: put/delete a file? */
-              )
+)
 {
 	char const *accept_encoding;
 
 #if !defined(NO_FILES)
 	const char *uri = conn->request_info.local_uri;
-	const char *root = conn->ctx->config[DOCUMENT_ROOT];
+	const char *root = conn->dom_ctx->config[DOCUMENT_ROOT];
 	const char *rewrite;
 	struct vec a, b;
-	int match_len;
+	ptrdiff_t match_len;
 	char gz_path[PATH_MAX];
 	int truncated;
 #if !defined(NO_CGI) || defined(USE_LUA) || defined(USE_DUKTAPE)
@@ -6752,8 +7384,8 @@ interpret_uri(struct mg_connection *conn, /* in/out: request (must be valid) */
 #if defined(USE_WEBSOCKET)
 	*is_websocket_request = is_websocket_protocol(conn);
 #if !defined(NO_FILES)
-	if (*is_websocket_request && conn->ctx->config[WEBSOCKET_ROOT]) {
-		root = conn->ctx->config[WEBSOCKET_ROOT];
+	if (*is_websocket_request && conn->dom_ctx->config[WEBSOCKET_ROOT]) {
+		root = conn->dom_ctx->config[WEBSOCKET_ROOT];
 	}
 #endif /* !NO_FILES */
 #else  /* USE_WEBSOCKET */
@@ -6791,7 +7423,7 @@ interpret_uri(struct mg_connection *conn, /* in/out: request (must be valid) */
 	}
 
 	/* Step 7: URI rewriting */
-	rewrite = conn->ctx->config[URL_REWRITE_PATTERN];
+	rewrite = conn->dom_ctx->config[URL_REWRITE_PATTERN];
 	while ((rewrite = next_option(rewrite, &a, &b)) != NULL) {
 		if ((match_len = match_prefix(a.ptr, a.len, uri)) > 0) {
 			mg_snprintf(conn,
@@ -6814,6 +7446,9 @@ interpret_uri(struct mg_connection *conn, /* in/out: request (must be valid) */
 	/* Local file path and name, corresponding to requested URI
 	 * is now stored in "filename" variable. */
 	if (mg_stat(conn, filename, filestat)) {
+		int uri_len = (int)strlen(uri);
+		int is_uri_end_slash = (uri_len > 0) && (uri[uri_len - 1] == '/');
+
 		/* 8.1: File exists. */
 		*is_found = 1;
 
@@ -6835,7 +7470,7 @@ interpret_uri(struct mg_connection *conn, /* in/out: request (must be valid) */
 
 		/* 8.3: If the request target is a directory, there could be
 		 * a substitute file (index.html, index.cgi, ...). */
-		if (filestat->is_directory) {
+		if (filestat->is_directory && is_uri_end_slash) {
 			/* Use a local copy here, since substitute_index_file will
 			 * change the content of the file status */
 			struct mg_file_stat tmp_filestat;
@@ -6892,7 +7527,7 @@ interpret_uri(struct mg_connection *conn, /* in/out: request (must be valid) */
 	/* Step 10: Script resources may handle sub-resources */
 	/* Support PATH_INFO for CGI scripts. */
 	tmp_str_len = strlen(filename);
-	tmp_str = (char *)mg_malloc_ctx(tmp_str_len + PATH_MAX + 1, conn->ctx);
+	tmp_str = (char *)mg_malloc_ctx(tmp_str_len + PATH_MAX + 1, conn->phys_ctx);
 	if (!tmp_str) {
 		/* Out of memory */
 		goto interpret_cleanup;
@@ -6901,7 +7536,8 @@ interpret_uri(struct mg_connection *conn, /* in/out: request (must be valid) */
 
 	/* Check config, if index scripts may have sub-resources */
 	allow_substitute_script_subresources =
-	    !mg_strcasecmp(conn->ctx->config[ALLOW_INDEX_SCRIPT_SUB_RES], "yes");
+	    !mg_strcasecmp(conn->dom_ctx->config[ALLOW_INDEX_SCRIPT_SUB_RES],
+	                   "yes");
 
 	sep_pos = tmp_str_len;
 	while (sep_pos > 0) {
@@ -6941,7 +7577,8 @@ interpret_uri(struct mg_connection *conn, /* in/out: request (must be valid) */
 						            filename);
 
 						/* this index file is a script */
-						tmp_str2 = mg_strdup(filename + sep_pos + 1);
+						tmp_str2 = mg_strdup_ctx(filename + sep_pos + 1,
+						                         conn->phys_ctx);
 						mg_snprintf(conn,
 						            &truncated,
 						            filename,
@@ -7075,14 +7712,17 @@ parse_date_string(const char *datetime)
 	            &year,
 	            &hour,
 	            &minute,
-	            &second) == 6) || (sscanf(datetime,
-	                                      "%d %3s %d %d:%d:%d",
-	                                      &day,
-	                                      month_str,
-	                                      &year,
-	                                      &hour,
-	                                      &minute,
-	                                      &second) == 6)
+	            &second)
+	     == 6)
+	    || (sscanf(datetime,
+	               "%d %3s %d %d:%d:%d",
+	               &day,
+	               month_str,
+	               &year,
+	               &hour,
+	               &minute,
+	               &second)
+	        == 6)
 	    || (sscanf(datetime,
 	               "%*3s, %d %3s %d %d:%d:%d",
 	               &day,
@@ -7090,14 +7730,17 @@ parse_date_string(const char *datetime)
 	               &year,
 	               &hour,
 	               &minute,
-	               &second) == 6) || (sscanf(datetime,
-	                                         "%d-%3s-%d %d:%d:%d",
-	                                         &day,
-	                                         month_str,
-	                                         &year,
-	                                         &hour,
-	                                         &minute,
-	                                         &second) == 6)) {
+	               &second)
+	        == 6)
+	    || (sscanf(datetime,
+	               "%d-%3s-%d %d:%d:%d",
+	               &day,
+	               month_str,
+	               &year,
+	               &hour,
+	               &minute,
+	               &second)
+	        == 6)) {
 		month = get_month_index(month_str);
 		if ((month >= 0) && (year >= 1970)) {
 			memset(&tm, 0, sizeof(tm));
@@ -7271,7 +7914,7 @@ mg_get_builtin_mime_type(const char *path)
 /* Look at the "path" extension and figure what mime type it has.
  * Store mime type in the vector. */
 static void
-get_mime_type(struct mg_context *ctx, const char *path, struct vec *vec)
+get_mime_type(struct mg_connection *conn, const char *path, struct vec *vec)
 {
 	struct vec ext_vec, mime_vec;
 	const char *list, *ext;
@@ -7279,7 +7922,7 @@ get_mime_type(struct mg_context *ctx, const char *path, struct vec *vec)
 
 	path_len = strlen(path);
 
-	if ((ctx == NULL) || (vec == NULL)) {
+	if ((conn == NULL) || (vec == NULL)) {
 		if (vec != NULL) {
 			memset(vec, '\0', sizeof(struct vec));
 		}
@@ -7288,7 +7931,7 @@ get_mime_type(struct mg_context *ctx, const char *path, struct vec *vec)
 
 	/* Scan user-defined mime types first, in case user wants to
 	 * override default mime types. */
-	list = ctx->config[EXTRA_MIME_TYPES];
+	list = conn->dom_ctx->config[EXTRA_MIME_TYPES];
 	while ((list = next_option(list, &ext_vec, &mime_vec)) != NULL) {
 		/* ext now points to the path suffix */
 		ext = path + path_len - ext_vec.len;
@@ -7392,17 +8035,18 @@ open_auth_file(struct mg_connection *conn,
                const char *path,
                struct mg_file *filep)
 {
-	if ((conn != NULL) && (conn->ctx != NULL)) {
+	if ((conn != NULL) && (conn->dom_ctx != NULL)) {
 		char name[PATH_MAX];
-		const char *p, *e, *gpass = conn->ctx->config[GLOBAL_PASSWORDS_FILE];
+		const char *p, *e,
+		    *gpass = conn->dom_ctx->config[GLOBAL_PASSWORDS_FILE];
 		int truncated;
 
 		if (gpass != NULL) {
 			/* Use global passwords file */
 			if (!mg_fopen(conn, gpass, MG_FOPEN_MODE_READ, filep)) {
-#ifdef DEBUG
-				/* Use mg_cry here, since gpass has been configured. */
-				mg_cry(conn, "fopen(%s): %s", gpass, strerror(ERRNO));
+#if defined(DEBUG)
+				/* Use mg_cry_internal here, since gpass has been configured. */
+				mg_cry_internal(conn, "fopen(%s): %s", gpass, strerror(ERRNO));
 #endif
 			}
 			/* Important: using local struct mg_file to test path for
@@ -7421,8 +8065,9 @@ open_auth_file(struct mg_connection *conn,
 			            PASSWORDS_FILE_NAME);
 
 			if (truncated || !mg_fopen(conn, name, MG_FOPEN_MODE_READ, filep)) {
-#ifdef DEBUG
-				/* Don't use mg_cry here, but only a trace, since this is
+#if defined(DEBUG)
+				/* Don't use mg_cry_internal here, but only a trace, since this
+				 * is
 				 * a typical case. It will occur for every directory
 				 * without a password file. */
 				DEBUG_TRACE("fopen(%s): %s", name, strerror(ERRNO));
@@ -7445,8 +8090,9 @@ open_auth_file(struct mg_connection *conn,
 			            PASSWORDS_FILE_NAME);
 
 			if (truncated || !mg_fopen(conn, name, MG_FOPEN_MODE_READ, filep)) {
-#ifdef DEBUG
-				/* Don't use mg_cry here, but only a trace, since this is
+#if defined(DEBUG)
+				/* Don't use mg_cry_internal here, but only a trace, since this
+				 * is
 				 * a typical case. It will occur for every directory
 				 * without a password file. */
 				DEBUG_TRACE("fopen(%s): %s", name, strerror(ERRNO));
@@ -7528,7 +8174,7 @@ parse_auth_header(struct mg_connection *conn,
 		}
 	}
 
-#ifndef NO_NONCE_CHECK
+#if !defined(NO_NONCE_CHECK)
 	/* Read the nonce from the response. */
 	if (ah->nonce == NULL) {
 		return 0;
@@ -7540,7 +8186,7 @@ parse_auth_header(struct mg_connection *conn,
 	}
 
 	/* Convert the nonce from the client to a number. */
-	nonce ^= conn->ctx->auth_nonce_mask;
+	nonce ^= conn->dom_ctx->auth_nonce_mask;
 
 	/* The converted number corresponds to the time the nounce has been
 	 * created. This should not be earlier than the server start. */
@@ -7550,14 +8196,15 @@ parse_auth_header(struct mg_connection *conn,
 	/* However, the reasonable default is to not accept a nonce from a
 	 * previous start, so if anyone changed the access rights between
 	 * two restarts, a new login is required. */
-	if (nonce < (uint64_t)conn->ctx->start_time) {
+	if (nonce < (uint64_t)conn->phys_ctx->start_time) {
 		/* nonce is from a previous start of the server and no longer valid
 		 * (replay attack?) */
 		return 0;
 	}
 	/* Check if the nonce is too high, so it has not (yet) been used by the
 	 * server. */
-	if (nonce >= ((uint64_t)conn->ctx->start_time + conn->ctx->nonce_count)) {
+	if (nonce >= ((uint64_t)conn->phys_ctx->start_time
+	              + conn->dom_ctx->nonce_count)) {
 		return 0;
 	}
 #else
@@ -7566,7 +8213,8 @@ parse_auth_header(struct mg_connection *conn,
 
 	/* CGI needs it as REMOTE_USER */
 	if (ah->user != NULL) {
-		conn->request_info.remote_user = mg_strdup(ah->user);
+		conn->request_info.remote_user =
+		    mg_strdup_ctx(ah->user, conn->phys_ctx);
 	} else {
 		return 0;
 	}
@@ -7578,14 +8226,19 @@ parse_auth_header(struct mg_connection *conn,
 static const char *
 mg_fgets(char *buf, size_t size, struct mg_file *filep, char **p)
 {
+#if defined(MG_USE_OPEN_FILE)
 	const char *eof;
 	size_t len;
 	const char *memend;
+#else
+	(void)p; /* parameter is unused */
+#endif
 
 	if (!filep) {
 		return NULL;
 	}
 
+#if defined(MG_USE_OPEN_FILE)
 	if ((filep->access.membuf != NULL) && (*p != NULL)) {
 		memend = (const char *)&filep->access.membuf[filep->stat.size];
 		/* Search for \n from p till the end of stream */
@@ -7601,7 +8254,9 @@ mg_fgets(char *buf, size_t size, struct mg_file *filep, char **p)
 		buf[len] = '\0';
 		*p += len;
 		return len ? eof : NULL;
-	} else if (filep->access.fp != NULL) {
+	} else /* filep->access.fp block below */
+#endif
+	    if (filep->access.fp != NULL) {
 		return fgets(buf, (int)size, filep->access.fp);
 	} else {
 		return NULL;
@@ -7635,7 +8290,7 @@ read_auth_file(struct mg_file *filep,
                struct read_auth_file_struct *workdata,
                int depth)
 {
-	char *p;
+	char *p = NULL /* init if MG_USE_OPEN_FILE is not set */;
 	int is_authorized = 0;
 	struct mg_file fp;
 	size_t l;
@@ -7644,8 +8299,10 @@ read_auth_file(struct mg_file *filep,
 		return 0;
 	}
 
-	/* Loop over passwords file */
+/* Loop over passwords file */
+#if defined(MG_USE_OPEN_FILE)
 	p = (char *)filep->access.membuf;
+#endif
 	while (mg_fgets(workdata->buf, sizeof(workdata->buf), filep, &p) != NULL) {
 		l = strlen(workdata->buf);
 		while (l > 0) {
@@ -7686,28 +8343,28 @@ read_auth_file(struct mg_file *filep,
 						return is_authorized;
 					}
 				} else {
-					mg_cry(workdata->conn,
-					       "%s: cannot open authorization file: %s",
-					       __func__,
-					       workdata->buf);
+					mg_cry_internal(workdata->conn,
+					                "%s: cannot open authorization file: %s",
+					                __func__,
+					                workdata->buf);
 				}
 				continue;
 			}
 			/* everything is invalid for the moment (might change in the
 			 * future) */
-			mg_cry(workdata->conn,
-			       "%s: syntax error in authorization file: %s",
-			       __func__,
-			       workdata->buf);
+			mg_cry_internal(workdata->conn,
+			                "%s: syntax error in authorization file: %s",
+			                __func__,
+			                workdata->buf);
 			continue;
 		}
 
 		workdata->f_domain = strchr(workdata->f_user, ':');
 		if (workdata->f_domain == NULL) {
-			mg_cry(workdata->conn,
-			       "%s: syntax error in authorization file: %s",
-			       __func__,
-			       workdata->buf);
+			mg_cry_internal(workdata->conn,
+			                "%s: syntax error in authorization file: %s",
+			                __func__,
+			                workdata->buf);
 			continue;
 		}
 		*(char *)(workdata->f_domain) = 0;
@@ -7715,10 +8372,10 @@ read_auth_file(struct mg_file *filep,
 
 		workdata->f_ha1 = strchr(workdata->f_domain, ':');
 		if (workdata->f_ha1 == NULL) {
-			mg_cry(workdata->conn,
-			       "%s: syntax error in authorization file: %s",
-			       __func__,
-			       workdata->buf);
+			mg_cry_internal(workdata->conn,
+			                "%s: syntax error in authorization file: %s",
+			                __func__,
+			                workdata->buf);
 			continue;
 		}
 		*(char *)(workdata->f_ha1) = 0;
@@ -7748,7 +8405,7 @@ authorize(struct mg_connection *conn, struct mg_file *filep, const char *realm)
 	struct read_auth_file_struct workdata;
 	char buf[MG_BUF_LEN];
 
-	if (!conn || !conn->ctx) {
+	if (!conn || !conn->dom_ctx) {
 		return 0;
 	}
 
@@ -7762,7 +8419,7 @@ authorize(struct mg_connection *conn, struct mg_file *filep, const char *realm)
 	if (realm) {
 		workdata.domain = realm;
 	} else {
-		workdata.domain = conn->ctx->config[AUTHENTICATION_DOMAIN];
+		workdata.domain = conn->dom_ctx->config[AUTHENTICATION_DOMAIN];
 	}
 
 	return read_auth_file(filep, &workdata, INITIAL_DEPTH);
@@ -7803,11 +8460,11 @@ check_authorization(struct mg_connection *conn, const char *path)
 	struct mg_file file = STRUCT_FILE_INITIALIZER;
 	int authorized = 1, truncated;
 
-	if (!conn || !conn->ctx) {
+	if (!conn || !conn->dom_ctx) {
 		return 0;
 	}
 
-	list = conn->ctx->config[PROTECT_URI];
+	list = conn->dom_ctx->config[PROTECT_URI];
 	while ((list = next_option(list, &uri_vec, &filename_vec)) != NULL) {
 		if (!memcmp(conn->request_info.local_uri, uri_vec.ptr, uri_vec.len)) {
 			mg_snprintf(conn,
@@ -7820,11 +8477,11 @@ check_authorization(struct mg_connection *conn, const char *path)
 
 			if (truncated
 			    || !mg_fopen(conn, fname, MG_FOPEN_MODE_READ, &file)) {
-				mg_cry(conn,
-				       "%s: cannot open %s: %s",
-				       __func__,
-				       fname,
-				       strerror(errno));
+				mg_cry_internal(conn,
+				                "%s: cannot open %s: %s",
+				                __func__,
+				                fname,
+				                strerror(errno));
 			}
 			break;
 		}
@@ -7849,18 +8506,18 @@ send_authorization_request(struct mg_connection *conn, const char *realm)
 {
 	char date[64];
 	time_t curtime = time(NULL);
-	uint64_t nonce = (uint64_t)(conn->ctx->start_time);
+	uint64_t nonce = (uint64_t)(conn->phys_ctx->start_time);
 
 	if (!realm) {
-		realm = conn->ctx->config[AUTHENTICATION_DOMAIN];
+		realm = conn->dom_ctx->config[AUTHENTICATION_DOMAIN];
 	}
 
-	(void)pthread_mutex_lock(&conn->ctx->nonce_mutex);
-	nonce += conn->ctx->nonce_count;
-	++conn->ctx->nonce_count;
-	(void)pthread_mutex_unlock(&conn->ctx->nonce_mutex);
+	(void)pthread_mutex_lock(&conn->phys_ctx->nonce_mutex);
+	nonce += conn->dom_ctx->nonce_count;
+	++conn->dom_ctx->nonce_count;
+	(void)pthread_mutex_unlock(&conn->phys_ctx->nonce_mutex);
 
-	nonce ^= conn->ctx->auth_nonce_mask;
+	nonce ^= conn->dom_ctx->auth_nonce_mask;
 	conn->status_code = 401;
 	conn->must_close = 1;
 
@@ -7889,7 +8546,7 @@ int
 mg_send_digest_access_authentication_request(struct mg_connection *conn,
                                              const char *realm)
 {
-	if (conn && conn->ctx) {
+	if (conn && conn->dom_ctx) {
 		send_authorization_request(conn, realm);
 		return 0;
 	}
@@ -7903,7 +8560,7 @@ is_authorized_for_put(struct mg_connection *conn)
 {
 	if (conn) {
 		struct mg_file file = STRUCT_FILE_INITIALIZER;
-		const char *passfile = conn->ctx->config[PUT_DELETE_PASSWORDS_FILE];
+		const char *passfile = conn->dom_ctx->config[PUT_DELETE_PASSWORDS_FILE];
 		int ret = 0;
 
 		if (passfile != NULL
@@ -8084,9 +8741,11 @@ connect_socket(struct mg_context *ctx /* may be NULL */,
                size_t ebuf_len,
                SOCKET *sock /* output: socket, must not be NULL */,
                union usa *sa /* output: socket address, must not be NULL  */
-               )
+)
 {
 	int ip_ver = 0;
+	int conn_ret = -1;
+	int ret;
 	*sock = INVALID_SOCKET;
 	memset(sa, 0, sizeof(*sa));
 
@@ -8116,7 +8775,7 @@ connect_socket(struct mg_context *ctx /* may be NULL */,
 
 #if !defined(NO_SSL)
 #if !defined(NO_SSL_DL)
-#ifdef OPENSSL_API_1_1
+#if defined(OPENSSL_API_1_1)
 	if (use_ssl && (TLS_client_method == NULL)) {
 		mg_snprintf(NULL,
 		            NULL, /* No truncation check for ebuf */
@@ -8149,7 +8808,7 @@ connect_socket(struct mg_context *ctx /* may be NULL */,
 		sa->sin.sin_family = AF_INET;
 		sa->sin.sin_port = htons((uint16_t)port);
 		ip_ver = 4;
-#ifdef USE_IPV6
+#if defined(USE_IPV6)
 	} else if (mg_inet_pton(AF_INET6, host, &sa->sin6, sizeof(sa->sin6))) {
 		sa->sin6.sin6_family = AF_INET6;
 		sa->sin6.sin6_port = htons((uint16_t)port);
@@ -8158,7 +8817,7 @@ connect_socket(struct mg_context *ctx /* may be NULL */,
 		/* While getaddrinfo on Windows will work with [::1],
 		 * getaddrinfo on Linux only works with ::1 (without []). */
 		size_t l = strlen(host + 1);
-		char *h = (l > 1) ? mg_strdup(host + 1) : NULL;
+		char *h = (l > 1) ? mg_strdup_ctx(host + 1, ctx) : NULL;
 		if (h) {
 			h[l - 1] = 0;
 			if (mg_inet_pton(AF_INET6, h, &sa->sin6, sizeof(sa->sin6))) {
@@ -8184,7 +8843,7 @@ connect_socket(struct mg_context *ctx /* may be NULL */,
 	if (ip_ver == 4) {
 		*sock = socket(PF_INET, SOCK_STREAM, 0);
 	}
-#ifdef USE_IPV6
+#if defined(USE_IPV6)
 	else if (ip_ver == 6) {
 		*sock = socket(PF_INET6, SOCK_STREAM, 0);
 	}
@@ -8200,47 +8859,107 @@ connect_socket(struct mg_context *ctx /* may be NULL */,
 		return 0;
 	}
 
-	set_close_on_exec(*sock, fc(ctx));
-
-	if ((ip_ver == 4)
-	    && (connect(*sock, (struct sockaddr *)&sa->sin, sizeof(sa->sin))
-	        == 0)) {
-		/* connected with IPv4 */
-		if (0 == set_non_blocking_mode(*sock)) {
-			/* Ok */
-			return 1;
-		}
-		/* failed */
-		/* TODO: specific error message */
+	if (0 != set_non_blocking_mode(*sock)) {
+		mg_snprintf(NULL,
+		            NULL, /* No truncation check for ebuf */
+		            ebuf,
+		            ebuf_len,
+		            "Cannot set socket to non-blocking: %s",
+		            strerror(ERRNO));
+		closesocket(*sock);
+		*sock = INVALID_SOCKET;
+		return 0;
 	}
 
-#ifdef USE_IPV6
-	if ((ip_ver == 6)
-	    && (connect(*sock, (struct sockaddr *)&sa->sin6, sizeof(sa->sin6))
-	        == 0)) {
+	set_close_on_exec(*sock, fc(ctx));
+
+	if (ip_ver == 4) {
+		/* connected with IPv4 */
+		conn_ret = connect(*sock,
+		                   (struct sockaddr *)((void *)&sa->sin),
+		                   sizeof(sa->sin));
+	}
+#if defined(USE_IPV6)
+	else if (ip_ver == 6) {
 		/* connected with IPv6 */
-		if (0 == set_non_blocking_mode(*sock)) {
-			/* Ok */
-			return 1;
-		}
-		/* failed */
-		/* TODO: specific error message */
+		conn_ret = connect(*sock,
+		                   (struct sockaddr *)((void *)&sa->sin6),
+		                   sizeof(sa->sin6));
 	}
 #endif
 
-	/* Not connected */
-	mg_snprintf(NULL,
-	            NULL, /* No truncation check for ebuf */
-	            ebuf,
-	            ebuf_len,
-	            "connect(%s:%d): %s",
-	            host,
-	            port,
-	            strerror(ERRNO));
-	closesocket(*sock);
-	*sock = INVALID_SOCKET;
+#if defined(_WIN32)
+	if (conn_ret != 0) {
+		DWORD err = WSAGetLastError(); /* could return WSAEWOULDBLOCK */
+		conn_ret = (int)err;
+#if !defined(EINPROGRESS)
+#define EINPROGRESS (WSAEWOULDBLOCK) /* Winsock equivalent */
+#endif                               /* if !defined(EINPROGRESS) */
+	}
+#endif
 
-	return 0;
+	if ((conn_ret != 0) && (conn_ret != EINPROGRESS)) {
+		/* Data for getsockopt */
+		int sockerr = -1;
+		void *psockerr = &sockerr;
+
+#if defined(_WIN32)
+		int len = (int)sizeof(sockerr);
+#else
+		socklen_t len = (socklen_t)sizeof(sockerr);
+#endif
+
+		/* Data for poll */
+		struct pollfd pfd[1];
+		int pollres;
+		int ms_wait = 10000; /* 10 second timeout */
+
+		/* For a non-blocking socket, the connect sequence is:
+		 * 1) call connect (will not block)
+		 * 2) wait until the socket is ready for writing (select or poll)
+		 * 3) check connection state with getsockopt
+		 */
+		pfd[0].fd = *sock;
+		pfd[0].events = POLLOUT;
+		pollres = mg_poll(pfd, 1, (int)(ms_wait), &(ctx->stop_flag));
+
+		if (pollres != 1) {
+			/* Not connected */
+			mg_snprintf(NULL,
+			            NULL, /* No truncation check for ebuf */
+			            ebuf,
+			            ebuf_len,
+			            "connect(%s:%d): timeout",
+			            host,
+			            port);
+			closesocket(*sock);
+			*sock = INVALID_SOCKET;
+			return 0;
+		}
+
+#if defined(_WIN32)
+		ret = getsockopt(*sock, SOL_SOCKET, SO_ERROR, (char *)psockerr, &len);
+#else
+		ret = getsockopt(*sock, SOL_SOCKET, SO_ERROR, psockerr, &len);
+#endif
+
+		if ((ret != 0) || (sockerr != 0)) {
+			/* Not connected */
+			mg_snprintf(NULL,
+			            NULL, /* No truncation check for ebuf */
+			            ebuf,
+			            ebuf_len,
+			            "connect(%s:%d): error %s",
+			            host,
+			            port,
+			            strerror(sockerr));
+			closesocket(*sock);
+			*sock = INVALID_SOCKET;
+			return 0;
+		}
+	}
+
+	return 1;
 }
 
 
@@ -8278,7 +8997,12 @@ print_dir_entry(struct de *de)
 	size_t hrefsize;
 	char *href;
 	char size[64], mod[64];
+#if defined(REENTRANT_TIME)
+	struct tm _tm;
+	struct tm *tm = &_tm;
+#else
 	struct tm *tm;
+#endif
 
 	hrefsize = PATH_MAX * 3; /* worst case */
 	href = (char *)mg_malloc(hrefsize);
@@ -8329,7 +9053,11 @@ print_dir_entry(struct de *de)
 	/* Note: mg_snprintf will not cause a buffer overflow above.
 	 * So, string truncation checks are not required here. */
 
+#if defined(REENTRANT_TIME)
+	localtime_r(&de->file.last_modified, tm);
+#else
 	tm = localtime(&de->file.last_modified);
+#endif
 	if (tm != NULL) {
 		strftime(mod, sizeof(mod), "%d-%b-%Y %H:%M", tm);
 	} else {
@@ -8395,9 +9123,9 @@ compare_dir_entries(const void *p1, const void *p2)
 static int
 must_hide_file(struct mg_connection *conn, const char *path)
 {
-	if (conn && conn->ctx) {
+	if (conn && conn->dom_ctx) {
 		const char *pw_pattern = "**" PASSWORDS_FILE_NAME "$";
-		const char *pattern = conn->ctx->config[HIDE_FILES];
+		const char *pattern = conn->dom_ctx->config[HIDE_FILES];
 		return (match_prefix(pw_pattern, strlen(pw_pattern), path) > 0)
 		       || ((pattern != NULL)
 		           && (match_prefix(pattern, strlen(pattern), path) > 0));
@@ -8446,11 +9174,11 @@ scan_directory(struct mg_connection *conn,
 			}
 
 			if (!mg_stat(conn, path, &de.file)) {
-				mg_cry(conn,
-				       "%s: mg_stat(%s) failed: %s",
-				       __func__,
-				       path,
-				       strerror(ERRNO));
+				mg_cry_internal(conn,
+				                "%s: mg_stat(%s) failed: %s",
+				                __func__,
+				                path,
+				                strerror(ERRNO));
 			}
 			de.file_name = dp->d_name;
 			cb(&de, data);
@@ -8501,11 +9229,11 @@ remove_directory(struct mg_connection *conn, const char *dir)
 			}
 
 			if (!mg_stat(conn, path, &de.file)) {
-				mg_cry(conn,
-				       "%s: mg_stat(%s) failed: %s",
-				       __func__,
-				       path,
-				       strerror(ERRNO));
+				mg_cry_internal(conn,
+				                "%s: mg_stat(%s) failed: %s",
+				                __func__,
+				                path,
+				                strerror(ERRNO));
 				ok = 0;
 			}
 
@@ -8674,18 +9402,21 @@ send_file_data(struct mg_connection *conn,
 	                                      : (int64_t)(filep->stat.size);
 	offset = (offset < 0) ? 0 : ((offset > size) ? size : offset);
 
+#if defined(MG_USE_OPEN_FILE)
 	if ((len > 0) && (filep->access.membuf != NULL) && (size > 0)) {
 		/* file stored in memory */
 		if (len > size - offset) {
 			len = size - offset;
 		}
 		mg_write(conn, filep->access.membuf + offset, (size_t)len);
-	} else if (len > 0 && filep->access.fp != NULL) {
+	} else /* else block below */
+#endif
+	    if (len > 0 && filep->access.fp != NULL) {
 /* file stored on disk */
 #if defined(__linux__)
 		/* sendfile is only available for Linux */
 		if ((conn->ssl == 0) && (conn->throttle == 0)
-		    && (!mg_strcasecmp(conn->ctx->config[ALLOW_SENDFILE_CALL],
+		    && (!mg_strcasecmp(conn->dom_ctx->config[ALLOW_SENDFILE_CALL],
 		                       "yes"))) {
 			off_t sf_offs = (off_t)offset;
 			ssize_t sf_sent;
@@ -8727,7 +9458,10 @@ send_file_data(struct mg_connection *conn,
 		}
 #endif
 		if ((offset > 0) && (fseeko(filep->access.fp, offset, SEEK_SET) != 0)) {
-			mg_cry(conn, "%s: fseeko() failed: %s", __func__, strerror(ERRNO));
+			mg_cry_internal(conn,
+			                "%s: fseeko() failed: %s",
+			                __func__,
+			                strerror(ERRNO));
 			mg_send_http_error(
 			    conn,
 			    500,
@@ -8788,18 +9522,23 @@ static void
 fclose_on_exec(struct mg_file_access *filep, struct mg_connection *conn)
 {
 	if (filep != NULL && filep->fp != NULL) {
-#ifdef _WIN32
+#if defined(_WIN32)
 		(void)conn; /* Unused. */
 #else
 		if (fcntl(fileno(filep->fp), F_SETFD, FD_CLOEXEC) != 0) {
-			mg_cry(conn,
-			       "%s: fcntl(F_SETFD FD_CLOEXEC) failed: %s",
-			       __func__,
-			       strerror(ERRNO));
+			mg_cry_internal(conn,
+			                "%s: fcntl(F_SETFD FD_CLOEXEC) failed: %s",
+			                __func__,
+			                strerror(ERRNO));
 		}
 #endif
 	}
 }
+
+
+#if defined(USE_ZLIB)
+#include "mod_zlib.inl"
+#endif
 
 
 static void
@@ -8819,14 +9558,23 @@ handle_static_file_request(struct mg_connection *conn,
 	char gz_path[PATH_MAX];
 	const char *encoding = "";
 	const char *cors1, *cors2, *cors3;
-	int allow_on_the_fly_compression;
+	int is_head_request;
 
-	if ((conn == NULL) || (conn->ctx == NULL) || (filep == NULL)) {
+#if defined(USE_ZLIB)
+	/* Compression is allowed, unless there is a reason not to use compression.
+	 * If the file is already compressed, too small or a "range" request was
+	 * made, on the fly compression is not possible. */
+	int allow_on_the_fly_compression = 1;
+#endif
+
+	if ((conn == NULL) || (conn->dom_ctx == NULL) || (filep == NULL)) {
 		return;
 	}
 
+	is_head_request = !strcmp(conn->request_info.request_method, "HEAD");
+
 	if (mime_type == NULL) {
-		get_mime_type(conn->ctx, path, &mime_vec);
+		get_mime_type(conn, path, &mime_vec);
 	} else {
 		mime_vec.ptr = mime_type;
 		mime_vec.len = strlen(mime_type);
@@ -8842,10 +9590,14 @@ handle_static_file_request(struct mg_connection *conn,
 	conn->status_code = 200;
 	range[0] = '\0';
 
+#if defined(USE_ZLIB)
 	/* if this file is in fact a pre-gzipped file, rewrite its filename
 	 * it's important to rewrite the filename after resolving
 	 * the mime type from it, to preserve the actual file's type */
-	allow_on_the_fly_compression = conn->accept_gzip;
+	if (!conn->accept_gzip) {
+		allow_on_the_fly_compression = 0;
+	}
+#endif
 
 	if (filep->stat.is_gzipped) {
 		mg_snprintf(conn, &truncated, gz_path, sizeof(gz_path), "%s.gz", path);
@@ -8861,8 +9613,10 @@ handle_static_file_request(struct mg_connection *conn,
 		path = gz_path;
 		encoding = "Content-Encoding: gzip\r\n";
 
+#if defined(USE_ZLIB)
 		/* File is already compressed. No "on the fly" compression. */
 		allow_on_the_fly_compression = 0;
+#endif
 	}
 
 	if (!mg_fopen(conn, path, MG_FOPEN_MODE_READ, filep)) {
@@ -8876,7 +9630,8 @@ handle_static_file_request(struct mg_connection *conn,
 
 	fclose_on_exec(&filep->access, conn);
 
-	/* If Range: header specified, act accordingly */
+	/* If "Range" request was made: parse header, send only selected part
+	 * of the file. */
 	r1 = r2 = 0;
 	hdr = mg_get_header(conn, "Range");
 	if ((hdr != NULL) && ((n = parse_range_header(hdr, &r1, &r2)) > 0)
@@ -8906,10 +9661,22 @@ handle_static_file_request(struct mg_connection *conn,
 		            filep->stat.size);
 		msg = "Partial Content";
 
+#if defined(USE_ZLIB)
 		/* Do not compress ranges. */
 		allow_on_the_fly_compression = 0;
+#endif
 	}
 
+/* Do not compress small files. Small files do not benefit from file
+ * compression, but there is still some overhead. */
+#if defined(USE_ZLIB)
+	if (filep->stat.size < MG_FILE_COMPRESSION_SIZE_LIMIT) {
+		/* File is below the size limit. */
+		allow_on_the_fly_compression = 0;
+	}
+#endif
+
+	/* Standard CORS header */
 	hdr = mg_get_header(conn, "Origin");
 	if (hdr) {
 		/* Cross-origin resource sharing (CORS), see
@@ -8918,7 +9685,7 @@ handle_static_file_request(struct mg_connection *conn,
 		 * -
 		 * preflight is not supported for files. */
 		cors1 = "Access-Control-Allow-Origin: ";
-		cors2 = conn->ctx->config[ACCESS_CONTROL_ALLOW_ORIGIN];
+		cors2 = conn->dom_ctx->config[ACCESS_CONTROL_ALLOW_ORIGIN];
 		cors3 = "\r\n";
 	} else {
 		cors1 = cors2 = cors3 = "";
@@ -8931,51 +9698,55 @@ handle_static_file_request(struct mg_connection *conn,
 	gmt_time_string(lm, sizeof(lm), &filep->stat.last_modified);
 	construct_etag(etag, sizeof(etag), &filep->stat);
 
-	/* On the fly compression allowed */
-	if (allow_on_the_fly_compression) {
-		;
-		/* TODO: add interface to compression module */
-		/* e.g., def from https://zlib.net/zlib_how.html */
-		/* Check license (zlib has a permissive license, but */
-		/* is still not MIT) and use dynamic binding like */
-		/* done with OpenSSL */
-		/* See #199 (https://github.com/civetweb/civetweb/issues/199) */
-	}
-
 	/* Send header */
 	(void)mg_printf(conn,
 	                "HTTP/1.1 %d %s\r\n"
-	                "%s%s%s"
-	                "Date: %s\r\n",
+	                "%s%s%s" /* CORS */
+	                "Date: %s\r\n"
+	                "Last-Modified: %s\r\n"
+	                "Etag: %s\r\n"
+	                "Content-Type: %.*s\r\n"
+	                "Connection: %s\r\n",
 	                conn->status_code,
 	                msg,
 	                cors1,
 	                cors2,
 	                cors3,
-	                date);
-	send_static_cache_header(conn);
-	send_additional_header(conn);
-
-	(void)mg_printf(conn,
-	                "Last-Modified: %s\r\n"
-	                "Etag: %s\r\n"
-	                "Content-Type: %.*s\r\n"
-	                "Content-Length: %" INT64_FMT "\r\n"
-	                "Connection: %s\r\n"
-	                "Accept-Ranges: bytes\r\n"
-	                "%s%s",
+	                date,
 	                lm,
 	                etag,
 	                (int)mime_vec.len,
 	                mime_vec.ptr,
-	                cl,
-	                suggest_connection_header(conn),
-	                range,
-	                encoding);
+	                suggest_connection_header(conn));
+	send_static_cache_header(conn);
+	send_additional_header(conn);
+
+#if defined(USE_ZLIB)
+	/* On the fly compression allowed */
+	if (allow_on_the_fly_compression) {
+		/* For on the fly compression, we don't know the content size in
+		 * advance, so we have to use chunked encoding */
+		(void)mg_printf(conn,
+		                "Content-Encoding: gzip\r\n"
+		                "Transfer-Encoding: chunked\r\n");
+	} else
+#endif
+	{
+		/* Without on-the-fly compression, we know the content-length
+		 * and we can use ranges (with on-the-fly compression we cannot).
+		 * So we send these response headers only in this case. */
+		(void)mg_printf(conn,
+		                "Content-Length: %" INT64_FMT "\r\n"
+		                "Accept-Ranges: bytes\r\n"
+		                "%s" /* range */
+		                "%s" /* encoding */,
+		                cl,
+		                range,
+		                encoding);
+	}
 
 	/* The previous code must not add any header starting with X- to make
 	 * sure no one of the additional_headers is included twice */
-
 	if (additional_headers != NULL) {
 		(void)mg_printf(conn,
 		                "%.*s\r\n\r\n",
@@ -8985,14 +9756,52 @@ handle_static_file_request(struct mg_connection *conn,
 		(void)mg_printf(conn, "\r\n");
 	}
 
-	if (strcmp(conn->request_info.request_method, "HEAD") != 0) {
-		send_file_data(conn, filep, r1, cl);
+	if (!is_head_request) {
+#if defined(USE_ZLIB)
+		if (allow_on_the_fly_compression) {
+			/* Compress and send */
+			send_compressed_data(conn, filep);
+		} else
+#endif
+		{
+			/* Send file directly */
+			send_file_data(conn, filep, r1, cl);
+		}
 	}
 	(void)mg_fclose(&filep->access); /* ignore error on read only file */
 }
 
 
+int
+mg_send_file_body(struct mg_connection *conn, const char *path)
+{
+	struct mg_file file = STRUCT_FILE_INITIALIZER;
+	if (!mg_fopen(conn, path, MG_FOPEN_MODE_READ, &file)) {
+		return -1;
+	}
+	fclose_on_exec(&file.access, conn);
+	send_file_data(conn, &file, 0, INT64_MAX);
+	(void)mg_fclose(&file.access); /* Ignore errors for readonly files */
+	return 0;                      /* >= 0 for OK */
+}
+
+
 #if !defined(NO_CACHING)
+/* Return True if we should reply 304 Not Modified. */
+static int
+is_not_modified(const struct mg_connection *conn,
+                const struct mg_file_stat *filestat)
+{
+	char etag[64];
+	const char *ims = mg_get_header(conn, "If-Modified-Since");
+	const char *inm = mg_get_header(conn, "If-None-Match");
+	construct_etag(etag, sizeof(etag), filestat);
+
+	return ((inm != NULL) && !mg_strcasecmp(etag, inm))
+	       || ((ims != NULL)
+	           && (filestat->last_modified <= parse_date_string(ims)));
+}
+
 static void
 handle_not_modified_static_file_request(struct mg_connection *conn,
                                         struct mg_file *filep)
@@ -9031,7 +9840,7 @@ handle_not_modified_static_file_request(struct mg_connection *conn,
 void
 mg_send_file(struct mg_connection *conn, const char *path)
 {
-	mg_send_mime_file(conn, path, NULL);
+	mg_send_mime_file2(conn, path, NULL, NULL);
 }
 
 
@@ -9058,8 +9867,14 @@ mg_send_mime_file2(struct mg_connection *conn,
 	}
 
 	if (mg_stat(conn, path, &file.stat)) {
-		if (file.stat.is_directory) {
-			if (!mg_strcasecmp(conn->ctx->config[ENABLE_DIRECTORY_LISTING],
+#if !defined(NO_CACHING)
+		if (is_not_modified(conn, &file.stat)) {
+			/* Send 304 "Not Modified" - this must not send any body data */
+			handle_not_modified_static_file_request(conn, &file);
+		} else
+#endif /* NO_CACHING */
+		    if (file.stat.is_directory) {
+			if (!mg_strcasecmp(conn->dom_ctx->config[ENABLE_DIRECTORY_LISTING],
 			                   "yes")) {
 				handle_directory_request(conn, path);
 			} else {
@@ -9083,7 +9898,7 @@ mg_send_mime_file2(struct mg_connection *conn,
  * Return  1  if the path leads to a file.
  * Return -1  for if the path is too long.
  * Return -2  if path can not be created.
-*/
+ */
 static int
 put_dir(struct mg_connection *conn, const char *path)
 {
@@ -9126,7 +9941,10 @@ remove_bad_file(const struct mg_connection *conn, const char *path)
 {
 	int r = mg_remove(conn, path);
 	if (r != 0) {
-		mg_cry(conn, "%s: Cannot remove invalid file %s", __func__, path);
+		mg_cry_internal(conn,
+		                "%s: Cannot remove invalid file %s",
+		                __func__,
+		                path);
 	}
 }
 
@@ -9140,7 +9958,7 @@ mg_store_body(struct mg_connection *conn, const char *path)
 	struct mg_file fi;
 
 	if (conn->consumed_content != 0) {
-		mg_cry(conn, "%s: Contents already consumed", __func__);
+		mg_cry_internal(conn, "%s: Contents already consumed", __func__);
 		return -11;
 	}
 
@@ -9395,7 +10213,7 @@ parse_http_request(char *buf, int len, struct mg_request_info *ri)
 	int request_length;
 	int init_skip = 0;
 
-	/* Reset attributes. DO NOT TOUCH is_ssl, remote_ip, remote_addr,
+	/* Reset attributes. DO NOT TOUCH is_ssl, remote_addr,
 	 * remote_port */
 	ri->remote_user = ri->request_method = ri->request_uri = ri->http_version =
 	    NULL;
@@ -9514,16 +10332,6 @@ parse_http_response(char *buf, int len, struct mg_response_info *ri)
 	}
 	buf[response_length - 1] = '\0';
 
-
-	/* TODO: Define mg_response_info and implement parsing */
-	(void)buf;
-	(void)len;
-	(void)ri;
-
-	/* RFC says that all initial whitespaces should be ingored */
-	while ((*buf != '\0') && isspace(*(unsigned char *)buf)) {
-		buf++;
-	}
 	if ((*buf == 0) || (*buf == '\r') || (*buf == '\n')) {
 		return -1;
 	}
@@ -9610,16 +10418,16 @@ read_message(FILE *fp,
 
 	memset(&last_action_time, 0, sizeof(last_action_time));
 
-	if (conn->ctx->config[REQUEST_TIMEOUT]) {
+	if (conn->dom_ctx->config[REQUEST_TIMEOUT]) {
 		/* value of request_timeout is in seconds, config in milliseconds */
-		request_timeout = atof(conn->ctx->config[REQUEST_TIMEOUT]) / 1000.0;
+		request_timeout = atof(conn->dom_ctx->config[REQUEST_TIMEOUT]) / 1000.0;
 	} else {
 		request_timeout = -1.0;
 	}
 	if (conn->handled_requests > 0) {
-		if (conn->ctx->config[KEEP_ALIVE_TIMEOUT]) {
+		if (conn->dom_ctx->config[KEEP_ALIVE_TIMEOUT]) {
 			request_timeout =
-			    atof(conn->ctx->config[KEEP_ALIVE_TIMEOUT]) / 1000.0;
+			    atof(conn->dom_ctx->config[KEEP_ALIVE_TIMEOUT]) / 1000.0;
 		}
 	}
 
@@ -9630,7 +10438,7 @@ read_message(FILE *fp,
 
 	while (request_len == 0) {
 		/* Full request not yet received */
-		if (conn->ctx->stop_flag != 0) {
+		if (conn->phys_ctx->stop_flag != 0) {
 			/* Server is to be stopped. */
 			return -1;
 		}
@@ -9667,24 +10475,6 @@ read_message(FILE *fp,
 }
 
 
-#if !defined(NO_CACHING)
-/* Return True if we should reply 304 Not Modified. */
-static int
-is_not_modified(const struct mg_connection *conn,
-                const struct mg_file_stat *filestat)
-{
-	char etag[64];
-	const char *ims = mg_get_header(conn, "If-Modified-Since");
-	const char *inm = mg_get_header(conn, "If-None-Match");
-	construct_etag(etag, sizeof(etag), filestat);
-
-	return ((inm != NULL) && !mg_strcasecmp(etag, inm))
-	       || ((ims != NULL)
-	           && (filestat->last_modified <= parse_date_string(ims)));
-}
-#endif /* !NO_CACHING */
-
-
 #if !defined(NO_CGI) || !defined(NO_FILES)
 static int
 forward_body_data(struct mg_connection *conn, FILE *fp, SOCKET sock, SSL *ssl)
@@ -9698,12 +10488,12 @@ forward_body_data(struct mg_connection *conn, FILE *fp, SOCKET sock, SSL *ssl)
 	if (!conn) {
 		return 0;
 	}
-	if (conn->ctx->config[REQUEST_TIMEOUT]) {
-		timeout = atoi(conn->ctx->config[REQUEST_TIMEOUT]) / 1000.0;
+	if (conn->dom_ctx->config[REQUEST_TIMEOUT]) {
+		timeout = atoi(conn->dom_ctx->config[REQUEST_TIMEOUT]) / 1000.0;
 	}
 
 	expect = mg_get_header(conn, "Expect");
-	/* assert(fp != NULL); */
+	DEBUG_ASSERT(fp != NULL);
 	if (!fp) {
 		mg_send_http_error(conn, 500, "%s", "Error: NULL File");
 		return 0;
@@ -9734,8 +10524,8 @@ forward_body_data(struct mg_connection *conn, FILE *fp, SOCKET sock, SSL *ssl)
 		buffered_len = (int64_t)(conn->data_len) - (int64_t)conn->request_len
 		               - conn->consumed_content;
 
-		/* assert(buffered_len >= 0); */
-		/* assert(conn->consumed_content == 0); */
+		DEBUG_ASSERT(buffered_len >= 0);
+		DEBUG_ASSERT(conn->consumed_content == 0);
 
 		if ((buffered_len < 0) || (conn->consumed_content != 0)) {
 			mg_send_http_error(conn, 500, "%s", "Error: Size mismatch");
@@ -9747,7 +10537,8 @@ forward_body_data(struct mg_connection *conn, FILE *fp, SOCKET sock, SSL *ssl)
 				buffered_len = (int)conn->content_len;
 			}
 			body = conn->buf + conn->request_len + conn->consumed_content;
-			push_all(conn->ctx, fp, sock, ssl, body, (int64_t)buffered_len);
+			push_all(
+			    conn->phys_ctx, fp, sock, ssl, body, (int64_t)buffered_len);
 			conn->consumed_content += buffered_len;
 		}
 
@@ -9763,7 +10554,8 @@ forward_body_data(struct mg_connection *conn, FILE *fp, SOCKET sock, SSL *ssl)
 				break;
 			}
 			if (nread > 0) {
-				if (push_all(conn->ctx, fp, sock, ssl, buf, nread) != nread) {
+				if (push_all(conn->phys_ctx, fp, sock, ssl, buf, nread)
+				    != nread) {
 					break;
 				}
 			}
@@ -9786,6 +10578,15 @@ forward_body_data(struct mg_connection *conn, FILE *fp, SOCKET sock, SSL *ssl)
 	return success;
 }
 #endif
+
+
+#if defined(USE_TIMERS)
+
+#define TIMER_API static
+#include "timer.inl"
+
+#endif /* USE_TIMERS */
+
 
 #if !defined(NO_CGI)
 /* This structure helps to create an environment for the spawned CGI
@@ -9835,13 +10636,14 @@ addenv(struct cgi_environment *env, const char *fmt, ...)
 		if (space <= n) {
 			/* Allocate new buffer */
 			n = env->buflen + CGI_ENVIRONMENT_SIZE;
-			added = (char *)mg_realloc_ctx(env->buf, n, env->conn->ctx);
+			added = (char *)mg_realloc_ctx(env->buf, n, env->conn->phys_ctx);
 			if (!added) {
 				/* Out of memory */
-				mg_cry(env->conn,
-				       "%s: Cannot allocate memory for CGI variable [%s]",
-				       __func__,
-				       fmt);
+				mg_cry_internal(
+				    env->conn,
+				    "%s: Cannot allocate memory for CGI variable [%s]",
+				    __func__,
+				    fmt);
 				return;
 			}
 			env->buf = added;
@@ -9872,10 +10674,10 @@ addenv(struct cgi_environment *env, const char *fmt, ...)
 	/* Now update the variable index */
 	space = (env->varlen - env->varused);
 	if (space < 2) {
-		mg_cry(env->conn,
-		       "%s: Cannot register CGI variable [%s]",
-		       __func__,
-		       fmt);
+		mg_cry_internal(env->conn,
+		                "%s: Cannot register CGI variable [%s]",
+		                __func__,
+		                fmt);
 		return;
 	}
 
@@ -9903,28 +10705,29 @@ prepare_cgi_environment(struct mg_connection *conn,
 	env->conn = conn;
 	env->buflen = CGI_ENVIRONMENT_SIZE;
 	env->bufused = 0;
-	env->buf = (char *)mg_malloc_ctx(env->buflen, conn->ctx);
+	env->buf = (char *)mg_malloc_ctx(env->buflen, conn->phys_ctx);
 	if (env->buf == NULL) {
-		mg_cry(conn,
-		       "%s: Not enough memory for environmental buffer",
-		       __func__);
+		mg_cry_internal(conn,
+		                "%s: Not enough memory for environmental buffer",
+		                __func__);
 		return -1;
 	}
 	env->varlen = MAX_CGI_ENVIR_VARS;
 	env->varused = 0;
-	env->var = (char **)mg_malloc_ctx(env->buflen * sizeof(char *), conn->ctx);
+	env->var =
+	    (char **)mg_malloc_ctx(env->buflen * sizeof(char *), conn->phys_ctx);
 	if (env->var == NULL) {
-		mg_cry(conn,
-		       "%s: Not enough memory for environmental variables",
-		       __func__);
+		mg_cry_internal(conn,
+		                "%s: Not enough memory for environmental variables",
+		                __func__);
 		mg_free(env->buf);
 		return -1;
 	}
 
-	addenv(env, "SERVER_NAME=%s", conn->ctx->config[AUTHENTICATION_DOMAIN]);
-	addenv(env, "SERVER_ROOT=%s", conn->ctx->config[DOCUMENT_ROOT]);
-	addenv(env, "DOCUMENT_ROOT=%s", conn->ctx->config[DOCUMENT_ROOT]);
-	addenv(env, "SERVER_SOFTWARE=%s/%s", "Civetweb", mg_version());
+	addenv(env, "SERVER_NAME=%s", conn->dom_ctx->config[AUTHENTICATION_DOMAIN]);
+	addenv(env, "SERVER_ROOT=%s", conn->dom_ctx->config[DOCUMENT_ROOT]);
+	addenv(env, "DOCUMENT_ROOT=%s", conn->dom_ctx->config[DOCUMENT_ROOT]);
+	addenv(env, "SERVER_SOFTWARE=CivetWeb/%s", mg_version());
 
 	/* Prepare the environment block */
 	addenv(env, "%s", "GATEWAY_INTERFACE=CGI/1.1");
@@ -9975,11 +10778,11 @@ prepare_cgi_environment(struct mg_connection *conn,
 
 	addenv(env, "SCRIPT_FILENAME=%s", prog);
 	if (conn->path_info == NULL) {
-		addenv(env, "PATH_TRANSLATED=%s", conn->ctx->config[DOCUMENT_ROOT]);
+		addenv(env, "PATH_TRANSLATED=%s", conn->dom_ctx->config[DOCUMENT_ROOT]);
 	} else {
 		addenv(env,
 		       "PATH_TRANSLATED=%s%s",
-		       conn->ctx->config[DOCUMENT_ROOT],
+		       conn->dom_ctx->config[DOCUMENT_ROOT],
 		       conn->path_info);
 	}
 
@@ -10048,10 +10851,10 @@ prepare_cgi_environment(struct mg_connection *conn,
 		                  conn->request_info.http_headers[i].name);
 
 		if (truncated) {
-			mg_cry(conn,
-			       "%s: HTTP header variable too long [%s]",
-			       __func__,
-			       conn->request_info.http_headers[i].name);
+			mg_cry_internal(conn,
+			                "%s: HTTP header variable too long [%s]",
+			                __func__,
+			                conn->request_info.http_headers[i].name);
 			continue;
 		}
 
@@ -10070,13 +10873,53 @@ prepare_cgi_environment(struct mg_connection *conn,
 	}
 
 	/* Add user-specified variables */
-	s = conn->ctx->config[CGI_ENVIRONMENT];
+	s = conn->dom_ctx->config[CGI_ENVIRONMENT];
 	while ((s = next_option(s, &var_vec, NULL)) != NULL) {
 		addenv(env, "%.*s", (int)var_vec.len, var_vec.ptr);
 	}
 
 	env->var[env->varused] = NULL;
 	env->buf[env->bufused] = '\0';
+
+	return 0;
+}
+
+
+/* Data for CGI process control: PID and number of references */
+struct process_control_data {
+	pid_t pid;
+	int references;
+};
+
+static int
+abort_process(void *data)
+{
+	/* Waitpid checks for child status and won't work for a pid that does not
+	 * identify a child of the current process. Thus, if the pid is reused,
+	 * we will not affect a different process. */
+	struct process_control_data *proc = (struct process_control_data *)data;
+	int status = 0;
+	int refs;
+	pid_t ret_pid;
+
+	ret_pid = waitpid(proc->pid, &status, WNOHANG);
+	if ((ret_pid != (pid_t)-1) && (status == 0)) {
+		/* Stop child process */
+		DEBUG_TRACE("CGI timer: Stop child process %p\n", proc->pid);
+		kill(proc->pid, SIGABRT);
+
+		/* Wait until process is terminated (don't leave zombies) */
+		while (waitpid(proc->pid, &status, 0) != (pid_t)-1) /* nop */
+			;
+	} else {
+		DEBUG_TRACE("CGI timer: Child process %p already stopped\n", proc->pid);
+	}
+	/* Dec reference counter */
+	refs = mg_atomic_dec(&proc->references);
+	if (refs == 0) {
+		/* no more references - free data */
+		mg_free(data);
+	}
 
 	return 0;
 }
@@ -10096,13 +10939,22 @@ handle_cgi_request(struct mg_connection *conn, const char *prog)
 	FILE *in = NULL, *out = NULL, *err = NULL;
 	struct mg_file fout = STRUCT_FILE_INITIALIZER;
 	pid_t pid = (pid_t)-1;
+	struct process_control_data *proc = NULL;
+
+#if defined(USE_TIMERS)
+	double cgi_timeout = -1.0;
+	if (conn->dom_ctx->config[CGI_TIMEOUT]) {
+		/* Get timeout in seconds */
+		cgi_timeout = atof(conn->dom_ctx->config[CGI_TIMEOUT]) * 0.001;
+	}
+#endif
 
 	if (conn == NULL) {
 		return;
 	}
 
 	buf = NULL;
-	buflen = 16384;
+	buflen = conn->phys_ctx->max_request_size;
 	i = prepare_cgi_environment(conn, prog, &blk);
 	if (i != 0) {
 		blk.buf = NULL;
@@ -10116,7 +10968,7 @@ handle_cgi_request(struct mg_connection *conn, const char *prog)
 	(void)mg_snprintf(conn, &truncated, dir, sizeof(dir), "%s", prog);
 
 	if (truncated) {
-		mg_cry(conn, "Error: CGI program \"%s\": Path too long", prog);
+		mg_cry_internal(conn, "Error: CGI program \"%s\": Path too long", prog);
 		mg_send_http_error(conn, 500, "Error: %s", "CGI path too long");
 		goto done;
 	}
@@ -10131,14 +10983,23 @@ handle_cgi_request(struct mg_connection *conn, const char *prog)
 
 	if ((pipe(fdin) != 0) || (pipe(fdout) != 0) || (pipe(fderr) != 0)) {
 		status = strerror(ERRNO);
-		mg_cry(conn,
-		       "Error: CGI program \"%s\": Can not create CGI pipes: %s",
-		       prog,
-		       status);
+		mg_cry_internal(
+		    conn,
+		    "Error: CGI program \"%s\": Can not create CGI pipes: %s",
+		    prog,
+		    status);
 		mg_send_http_error(conn,
 		                   500,
 		                   "Error: Cannot create CGI pipe: %s",
 		                   status);
+		goto done;
+	}
+
+	proc = (struct process_control_data *)
+	    mg_malloc_ctx(sizeof(struct process_control_data), conn->phys_ctx);
+	if (proc == NULL) {
+		mg_cry_internal(conn, "Error: CGI program \"%s\": Out or memory", prog);
+		mg_send_http_error(conn, 500, "Error: Out of memory [%s]", prog);
 		goto done;
 	}
 
@@ -10147,26 +11008,46 @@ handle_cgi_request(struct mg_connection *conn, const char *prog)
 
 	if (pid == (pid_t)-1) {
 		status = strerror(ERRNO);
-		mg_cry(conn,
-		       "Error: CGI program \"%s\": Can not spawn CGI process: %s",
-		       prog,
-		       status);
+		mg_cry_internal(
+		    conn,
+		    "Error: CGI program \"%s\": Can not spawn CGI process: %s",
+		    prog,
+		    status);
 		mg_send_http_error(conn,
 		                   500,
 		                   "Error: Cannot spawn CGI process [%s]: %s",
 		                   prog,
 		                   status);
+		mg_free(proc);
+		proc = NULL;
 		goto done;
 	}
 
-	/* Make sure child closes all pipe descriptors. It must dup them to 0,1
-	 */
+	/* Store data in shared process_control_data */
+	proc->pid = pid;
+	proc->references = 1;
+
+#if defined(USE_TIMERS)
+	if (cgi_timeout > 0.0) {
+		proc->references = 2;
+
+		// Start a timer for CGI
+		timer_add(conn->phys_ctx,
+		          cgi_timeout /* in seconds */,
+		          0.0,
+		          1,
+		          abort_process,
+		          (void *)proc);
+	}
+#endif
+
+	/* Make sure child closes all pipe descriptors. It must dup them to 0,1 */
 	set_close_on_exec((SOCKET)fdin[0], conn);  /* stdin read */
-	set_close_on_exec((SOCKET)fdout[1], conn); /* stdout write */
-	set_close_on_exec((SOCKET)fderr[1], conn); /* stderr write */
 	set_close_on_exec((SOCKET)fdin[1], conn);  /* stdin write */
 	set_close_on_exec((SOCKET)fdout[0], conn); /* stdout read */
+	set_close_on_exec((SOCKET)fdout[1], conn); /* stdout write */
 	set_close_on_exec((SOCKET)fderr[0], conn); /* stderr read */
+	set_close_on_exec((SOCKET)fderr[1], conn); /* stderr write */
 
 	/* Parent closes only one side of the pipes.
 	 * If we don't mark them as closed, close() attempt before
@@ -10179,10 +11060,10 @@ handle_cgi_request(struct mg_connection *conn, const char *prog)
 
 	if ((in = fdopen(fdin[1], "wb")) == NULL) {
 		status = strerror(ERRNO);
-		mg_cry(conn,
-		       "Error: CGI program \"%s\": Can not open stdin: %s",
-		       prog,
-		       status);
+		mg_cry_internal(conn,
+		                "Error: CGI program \"%s\": Can not open stdin: %s",
+		                prog,
+		                status);
 		mg_send_http_error(conn,
 		                   500,
 		                   "Error: CGI can not open fdin\nfopen: %s",
@@ -10192,10 +11073,10 @@ handle_cgi_request(struct mg_connection *conn, const char *prog)
 
 	if ((out = fdopen(fdout[0], "rb")) == NULL) {
 		status = strerror(ERRNO);
-		mg_cry(conn,
-		       "Error: CGI program \"%s\": Can not open stdout: %s",
-		       prog,
-		       status);
+		mg_cry_internal(conn,
+		                "Error: CGI program \"%s\": Can not open stdout: %s",
+		                prog,
+		                status);
 		mg_send_http_error(conn,
 		                   500,
 		                   "Error: CGI can not open fdout\nfopen: %s",
@@ -10205,13 +11086,13 @@ handle_cgi_request(struct mg_connection *conn, const char *prog)
 
 	if ((err = fdopen(fderr[0], "rb")) == NULL) {
 		status = strerror(ERRNO);
-		mg_cry(conn,
-		       "Error: CGI program \"%s\": Can not open stderr: %s",
-		       prog,
-		       status);
+		mg_cry_internal(conn,
+		                "Error: CGI program \"%s\": Can not open stderr: %s",
+		                prog,
+		                status);
 		mg_send_http_error(conn,
 		                   500,
-		                   "Error: CGI can not open fdout\nfopen: %s",
+		                   "Error: CGI can not open fderr\nfopen: %s",
 		                   status);
 		goto done;
 	}
@@ -10228,9 +11109,10 @@ handle_cgi_request(struct mg_connection *conn, const char *prog)
 		/* This is a POST/PUT request, or another request with body data. */
 		if (!forward_body_data(conn, in, INVALID_SOCKET, NULL)) {
 			/* Error sending the body data */
-			mg_cry(conn,
-			       "Error: CGI program \"%s\": Forward body data failed",
-			       prog);
+			mg_cry_internal(
+			    conn,
+			    "Error: CGI program \"%s\": Forward body data failed",
+			    prog);
 			goto done;
 		}
 	}
@@ -10245,17 +11127,18 @@ handle_cgi_request(struct mg_connection *conn, const char *prog)
 	 * Do not send anything back to client, until we buffer in all
 	 * HTTP headers. */
 	data_len = 0;
-	buf = (char *)mg_malloc_ctx(buflen, conn->ctx);
+	buf = (char *)mg_malloc_ctx(buflen, conn->phys_ctx);
 	if (buf == NULL) {
 		mg_send_http_error(conn,
 		                   500,
 		                   "Error: Not enough memory for CGI buffer (%u bytes)",
 		                   (unsigned int)buflen);
-		mg_cry(conn,
-		       "Error: CGI program \"%s\": Not enough memory for buffer (%u "
-		       "bytes)",
-		       prog,
-		       (unsigned int)buflen);
+		mg_cry_internal(
+		    conn,
+		    "Error: CGI program \"%s\": Not enough memory for buffer (%u "
+		    "bytes)",
+		    prog,
+		    (unsigned int)buflen);
 		goto done;
 	}
 
@@ -10269,26 +11152,28 @@ handle_cgi_request(struct mg_connection *conn, const char *prog)
 		 * stderr. */
 		i = pull_all(err, conn, buf, (int)buflen);
 		if (i > 0) {
-			mg_cry(conn,
-			       "Error: CGI program \"%s\" sent error "
-			       "message: [%.*s]",
-			       prog,
-			       i,
-			       buf);
+			/* CGI program explicitly sent an error */
+			/* Write the error message to the internal log */
+			mg_cry_internal(conn,
+			                "Error: CGI program \"%s\" sent error "
+			                "message: [%.*s]",
+			                prog,
+			                i,
+			                buf);
+			/* Don't send the error message back to the client */
 			mg_send_http_error(conn,
 			                   500,
-			                   "Error: CGI program \"%s\" sent error "
-			                   "message: [%.*s]",
-			                   prog,
-			                   i,
-			                   buf);
+			                   "Error: CGI program \"%s\" failed.",
+			                   prog);
 		} else {
-			mg_cry(conn,
-			       "Error: CGI program sent malformed or too big "
-			       "(>%u bytes) HTTP headers: [%.*s]",
-			       (unsigned)buflen,
-			       data_len,
-			       buf);
+			/* CGI program did not explicitly send an error, but a broken
+			 * respon header */
+			mg_cry_internal(conn,
+			                "Error: CGI program sent malformed or too big "
+			                "(>%u bytes) HTTP headers: [%.*s]",
+			                (unsigned)buflen,
+			                data_len,
+			                buf);
 
 			mg_send_http_error(conn,
 			                   500,
@@ -10299,6 +11184,7 @@ handle_cgi_request(struct mg_connection *conn, const char *prog)
 			                   buf);
 		}
 
+		/* in both cases, abort processing CGI */
 		goto done;
 	}
 
@@ -10318,7 +11204,7 @@ handle_cgi_request(struct mg_connection *conn, const char *prog)
 		}
 	} else if (get_header(ri.http_headers, ri.num_headers, "Location")
 	           != NULL) {
-		conn->status_code = 302;
+		conn->status_code = 307;
 	} else {
 		conn->status_code = 200;
 	}
@@ -10345,8 +11231,8 @@ handle_cgi_request(struct mg_connection *conn, const char *prog)
 	mg_write(conn, buf + headers_len, (size_t)(data_len - headers_len));
 
 	/* Read the rest of CGI output and send to the client */
+	DEBUG_TRACE("CGI: %s", "forward all data");
 	send_file_data(conn, &fout, 0, INT64_MAX);
-
 	DEBUG_TRACE("CGI: %s", "all data sent");
 
 done:
@@ -10354,15 +11240,9 @@ done:
 	mg_free(blk.buf);
 
 	if (pid != (pid_t)-1) {
-		kill(pid, SIGKILL);
-#if !defined(_WIN32)
-		{
-			int st;
-			while (waitpid(pid, &st, 0) != -1)
-				; /* clean zombies */
-		}
-#endif
+		abort_process((void *)proc);
 	}
+
 	if (fdin[0] != -1) {
 		close(fdin[0]);
 	}
@@ -10413,11 +11293,11 @@ mkcol(struct mg_connection *conn, const char *path)
 
 	memset(&de.file, 0, sizeof(de.file));
 	if (!mg_stat(conn, path, &de.file)) {
-		mg_cry(conn,
-		       "%s: mg_stat(%s) failed: %s",
-		       __func__,
-		       path,
-		       strerror(ERRNO));
+		mg_cry_internal(conn,
+		                "%s: mg_stat(%s) failed: %s",
+		                __func__,
+		                path,
+		                strerror(ERRNO));
 	}
 
 	if (de.file.last_modified) {
@@ -10452,7 +11332,7 @@ mkcol(struct mg_connection *conn, const char *path)
 		          "Content-Length: 0\r\n"
 		          "Connection: %s\r\n\r\n",
 		          suggest_connection_header(conn));
-	} else if (rc == -1) {
+	} else {
 		if (errno == EEXIST) {
 			mg_send_http_error(
 			    conn, 405, "Error: mkcol(%s): %s", path, strerror(ERRNO));
@@ -10497,6 +11377,7 @@ put_file(struct mg_connection *conn, const char *path)
 			/* File exists and is not a directory. */
 			/* Can it be replaced? */
 
+#if defined(MG_USE_OPEN_FILE)
 			if (file.access.membuf != NULL) {
 				/* This is an "in-memory" file, that can not be replaced */
 				mg_send_http_error(conn,
@@ -10506,6 +11387,7 @@ put_file(struct mg_connection *conn, const char *path)
 				                   path);
 				return;
 			}
+#endif
 
 			/* Check if the server may write this file */
 			if (access(path, W_OK) == 0) {
@@ -10714,7 +11596,7 @@ do_ssi_include(struct mg_connection *conn,
 		                  path,
 		                  sizeof(path),
 		                  "%s/%s",
-		                  conn->ctx->config[DOCUMENT_ROOT],
+		                  conn->dom_ctx->config[DOCUMENT_ROOT],
 		                  file_name);
 
 	} else if (sscanf(tag, " abspath=\"%511[^\"]\"", file_name) == 1) {
@@ -10744,26 +11626,27 @@ do_ssi_include(struct mg_connection *conn,
 		}
 
 	} else {
-		mg_cry(conn, "Bad SSI #include: [%s]", tag);
+		mg_cry_internal(conn, "Bad SSI #include: [%s]", tag);
 		return;
 	}
 
 	if (truncated) {
-		mg_cry(conn, "SSI #include path length overflow: [%s]", tag);
+		mg_cry_internal(conn, "SSI #include path length overflow: [%s]", tag);
 		return;
 	}
 
 	if (!mg_fopen(conn, path, MG_FOPEN_MODE_READ, &file)) {
-		mg_cry(conn,
-		       "Cannot open SSI #include: [%s]: fopen(%s): %s",
-		       tag,
-		       path,
-		       strerror(ERRNO));
+		mg_cry_internal(conn,
+		                "Cannot open SSI #include: [%s]: fopen(%s): %s",
+		                tag,
+		                path,
+		                strerror(ERRNO));
 	} else {
 		fclose_on_exec(&file.access, conn);
-		if (match_prefix(conn->ctx->config[SSI_EXTENSIONS],
-		                 strlen(conn->ctx->config[SSI_EXTENSIONS]),
-		                 path) > 0) {
+		if (match_prefix(conn->dom_ctx->config[SSI_EXTENSIONS],
+		                 strlen(conn->dom_ctx->config[SSI_EXTENSIONS]),
+		                 path)
+		    > 0) {
 			send_ssi_file(conn, path, &file, include_level + 1);
 		} else {
 			send_file_data(conn, &file, 0, INT64_MAX);
@@ -10781,11 +11664,14 @@ do_ssi_exec(struct mg_connection *conn, char *tag)
 	struct mg_file file = STRUCT_FILE_INITIALIZER;
 
 	if (sscanf(tag, " \"%1023[^\"]\"", cmd) != 1) {
-		mg_cry(conn, "Bad SSI #exec: [%s]", tag);
+		mg_cry_internal(conn, "Bad SSI #exec: [%s]", tag);
 	} else {
 		cmd[1023] = 0;
 		if ((file.access.fp = popen(cmd, "r")) == NULL) {
-			mg_cry(conn, "Cannot SSI #exec: [%s]: %s", cmd, strerror(ERRNO));
+			mg_cry_internal(conn,
+			                "Cannot SSI #exec: [%s]: %s",
+			                cmd,
+			                strerror(ERRNO));
 		} else {
 			send_file_data(conn, &file, 0, INT64_MAX);
 			pclose(file.access.fp);
@@ -10798,13 +11684,18 @@ do_ssi_exec(struct mg_connection *conn, char *tag)
 static int
 mg_fgetc(struct mg_file *filep, int offset)
 {
+	(void)offset; /* unused in case MG_USE_OPEN_FILE is set */
+
 	if (filep == NULL) {
 		return EOF;
 	}
+#if defined(MG_USE_OPEN_FILE)
 	if ((filep->access.membuf != NULL) && (offset >= 0)
 	    && (((unsigned int)(offset)) < filep->stat.size)) {
 		return ((const unsigned char *)filep->access.membuf)[offset];
-	} else if (filep->access.fp != NULL) {
+	} else /* else block below */
+#endif
+	    if (filep->access.fp != NULL) {
 		return fgetc(filep->access.fp);
 	} else {
 		return EOF;
@@ -10822,7 +11713,7 @@ send_ssi_file(struct mg_connection *conn,
 	int ch, offset, len, in_tag, in_ssi_tag;
 
 	if (include_level > 10) {
-		mg_cry(conn, "SSI #include level is too deep (%s)", path);
+		mg_cry_internal(conn, "SSI #include level is too deep (%s)", path);
 		return;
 	}
 
@@ -10842,18 +11733,18 @@ send_ssi_file(struct mg_connection *conn,
 					/* Handle SSI tag */
 					buf[len] = 0;
 
-					if (!memcmp(buf + 5, "include", 7)) {
+					if ((len > 12) && !memcmp(buf + 5, "include", 7)) {
 						do_ssi_include(conn, path, buf + 12, include_level + 1);
 #if !defined(NO_POPEN)
-					} else if (!memcmp(buf + 5, "exec", 4)) {
+					} else if ((len > 9) && !memcmp(buf + 5, "exec", 4)) {
 						do_ssi_exec(conn, buf + 9);
 #endif /* !NO_POPEN */
 					} else {
-						mg_cry(conn,
-						       "%s: unknown SSI "
-						       "command: \"%s\"",
-						       path,
-						       buf);
+						mg_cry_internal(conn,
+						                "%s: unknown SSI "
+						                "command: \"%s\"",
+						                path,
+						                buf);
 					}
 					len = 0;
 					in_ssi_tag = in_tag = 0;
@@ -10877,19 +11768,23 @@ send_ssi_file(struct mg_connection *conn,
 
 				if ((len + 2) > (int)sizeof(buf)) {
 					/* Tag to long for buffer */
-					mg_cry(conn, "%s: tag is too large", path);
+					mg_cry_internal(conn, "%s: tag is too large", path);
 					return;
 				}
 			}
 
 		} else {
-			/* We are not in a tag yet. */
 
+			/* We are not in a tag yet. */
 			if (ch == '<') {
 				/* Tag is opening */
 				in_tag = 1;
-				/* Flush current buffer */
-				(void)mg_write(conn, buf, (size_t)len);
+
+				if (len > 0) {
+					/* Flush current buffer.
+					 * Buffer is filled with "len" bytes. */
+					(void)mg_write(conn, buf, (size_t)len);
+				}
 				/* Store the < */
 				len = 1;
 				buf[0] = '<';
@@ -10930,7 +11825,7 @@ handle_ssi_file_request(struct mg_connection *conn,
 	if (mg_get_header(conn, "Origin")) {
 		/* Cross-origin resource sharing (CORS). */
 		cors1 = "Access-Control-Allow-Origin: ";
-		cors2 = conn->ctx->config[ACCESS_CONTROL_ALLOW_ORIGIN];
+		cors2 = conn->dom_ctx->config[ACCESS_CONTROL_ALLOW_ORIGIN];
 		cors3 = "\r\n";
 	} else {
 		cors1 = cors2 = cors3 = "";
@@ -11078,7 +11973,7 @@ handle_propfind(struct mg_connection *conn,
 
 	gmt_time_string(date, sizeof(date), &curtime);
 
-	if (!conn || !path || !filep || !conn->ctx) {
+	if (!conn || !path || !filep || !conn->dom_ctx) {
 		return;
 	}
 
@@ -11104,8 +11999,9 @@ handle_propfind(struct mg_connection *conn,
 
 	/* If it is a directory, print directory entries too if Depth is not 0
 	 */
-	if (filep && filep->is_directory
-	    && !mg_strcasecmp(conn->ctx->config[ENABLE_DIRECTORY_LISTING], "yes")
+	if (filep->is_directory
+	    && !mg_strcasecmp(conn->dom_ctx->config[ENABLE_DIRECTORY_LISTING],
+	                      "yes")
 	    && ((depth == NULL) || (strcmp(depth, "0") != 0))) {
 		scan_directory(conn, path, conn, &print_dav_dir_entry);
 	}
@@ -11146,16 +12042,12 @@ mg_unlock_context(struct mg_context *ctx)
 	}
 }
 
-#if defined(USE_TIMERS)
-#define TIMER_API static
-#include "timer.inl"
-#endif /* USE_TIMERS */
 
-#ifdef USE_LUA
+#if defined(USE_LUA)
 #include "mod_lua.inl"
 #endif /* USE_LUA */
 
-#ifdef USE_DUKTAPE
+#if defined(USE_DUKTAPE)
 #include "mod_duktape.inl"
 #endif /* USE_DUKTAPE */
 
@@ -11181,6 +12073,8 @@ send_websocket_handshake(struct mg_connection *conn, const char *websock_key)
 		return 0;
 	}
 
+	DEBUG_TRACE("%s", "Send websocket handshake");
+
 	SHA1_Init(&sha_ctx);
 	SHA1_Update(&sha_ctx, (unsigned char *)buf, (uint32_t)strlen(buf));
 	SHA1_Final((unsigned char *)sha, &sha_ctx);
@@ -11203,6 +12097,16 @@ send_websocket_handshake(struct mg_connection *conn, const char *websock_key)
 }
 
 
+#if !defined(MG_MAX_UNANSWERED_PING)
+/* Configuration of the maximum number of websocket PINGs that might
+ * stay unanswered before the connection is considered broken.
+ * Note: The name of this define may still change (until it is
+ * defined as a compile parameter in a documentation).
+ */
+#define MG_MAX_UNANSWERED_PING (5)
+#endif
+
+
 static void
 read_websocket(struct mg_connection *conn,
                mg_websocket_data_handler ws_data_handler,
@@ -11214,6 +12118,7 @@ read_websocket(struct mg_connection *conn,
 	 * begins after it. */
 	unsigned char *buf = (unsigned char *)conn->buf + conn->request_len;
 	int n, error, exit_by_callback;
+	int ret;
 
 	/* body_len is the length of the entire queue in bytes
 	 * len is the length of the current message
@@ -11224,32 +12129,46 @@ read_websocket(struct mg_connection *conn,
 
 	/* "The masking key is a 32-bit value chosen at random by the client."
 	 * http://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-17#section-5
-	*/
+	 */
 	unsigned char mask[4];
 
 	/* data points to the place where the message is stored when passed to
-	 * the
-	 * websocket_data callback.  This is either mem on the stack, or a
+	 * the websocket_data callback.  This is either mem on the stack, or a
 	 * dynamically allocated buffer if it is too large. */
 	unsigned char mem[4096];
 	unsigned char mop; /* mask flag and opcode */
+
+
+	/* Variables used for connection monitoring */
 	double timeout = -1.0;
+	int enable_ping_pong = 0;
+	int ping_count = 0;
 
-	if (conn->ctx->config[WEBSOCKET_TIMEOUT]) {
-		timeout = atoi(conn->ctx->config[WEBSOCKET_TIMEOUT]) / 1000.0;
-	}
-	if ((timeout <= 0.0) && (conn->ctx->config[REQUEST_TIMEOUT])) {
-		timeout = atoi(conn->ctx->config[REQUEST_TIMEOUT]) / 1000.0;
+	if (conn->dom_ctx->config[ENABLE_WEBSOCKET_PING_PONG]) {
+		enable_ping_pong =
+		    !mg_strcasecmp(conn->dom_ctx->config[ENABLE_WEBSOCKET_PING_PONG],
+		                   "yes");
 	}
 
+	if (conn->dom_ctx->config[WEBSOCKET_TIMEOUT]) {
+		timeout = atoi(conn->dom_ctx->config[WEBSOCKET_TIMEOUT]) / 1000.0;
+	}
+	if ((timeout <= 0.0) && (conn->dom_ctx->config[REQUEST_TIMEOUT])) {
+		timeout = atoi(conn->dom_ctx->config[REQUEST_TIMEOUT]) / 1000.0;
+	}
+
+	/* Enter data processing loop */
+	DEBUG_TRACE("Websocket connection %s:%u start data processing loop",
+	            conn->request_info.remote_addr,
+	            conn->request_info.remote_port);
 	conn->in_websocket_handling = 1;
 	mg_set_thread_name("wsock");
 
 	/* Loop continuously, reading messages from the socket, invoking the
 	 * callback, and waiting repeatedly until an error occurs. */
-	while (!conn->ctx->stop_flag && !conn->must_close) {
+	while (!conn->phys_ctx->stop_flag && !conn->must_close) {
 		header_len = 0;
-		assert(conn->data_len >= conn->request_len);
+		DEBUG_ASSERT(conn->data_len >= conn->request_len);
 		if ((body_len = (size_t)(conn->data_len - conn->request_len)) >= 2) {
 			len = buf[1] & 127;
 			mask_len = (buf[1] & 128) ? 4 : 0;
@@ -11271,7 +12190,10 @@ read_websocket(struct mg_connection *conn,
 
 				if (data_len > (uint64_t)0x7FFF0000ul) {
 					/* no can do */
-					mg_cry(conn, "websocket out of memory; closing connection");
+					mg_cry_internal(
+					    conn,
+					    "%s",
+					    "websocket out of memory; closing connection");
 					break;
 				}
 			}
@@ -11282,12 +12204,15 @@ read_websocket(struct mg_connection *conn,
 			unsigned char *data = mem;
 
 			if ((size_t)data_len > (size_t)sizeof(mem)) {
-				data =
-				    (unsigned char *)mg_malloc_ctx((size_t)data_len, conn->ctx);
+				data = (unsigned char *)mg_malloc_ctx((size_t)data_len,
+				                                      conn->phys_ctx);
 				if (data == NULL) {
 					/* Allocation failed, exit the loop and then close the
 					 * connection */
-					mg_cry(conn, "websocket out of memory; closing connection");
+					mg_cry_internal(
+					    conn,
+					    "%s",
+					    "websocket out of memory; closing connection");
 					break;
 				}
 			}
@@ -11301,7 +12226,7 @@ read_websocket(struct mg_connection *conn,
 
 			/* Read frame payload from the first message in the queue into
 			 * data and advance the queue by moving the memory in place. */
-			assert(body_len >= header_len);
+			DEBUG_ASSERT(body_len >= header_len);
 			if (data_len + (uint64_t)header_len > (uint64_t)body_len) {
 				mop = buf[0]; /* current mask and opcode */
 				/* Overflow case */
@@ -11325,7 +12250,10 @@ read_websocket(struct mg_connection *conn,
 					}
 				}
 				if (error) {
-					mg_cry(conn, "Websocket pull failed; closing connection");
+					mg_cry_internal(
+					    conn,
+					    "%s",
+					    "Websocket pull failed; closing connection");
 					if (data != mem) {
 						mg_free(data);
 					}
@@ -11363,25 +12291,60 @@ read_websocket(struct mg_connection *conn,
 				}
 			}
 
-			/* Exit the loop if callback signals to exit (server side),
-			 * or "connection close" opcode received (client side). */
 			exit_by_callback = 0;
-			if ((ws_data_handler != NULL)
-			    && !ws_data_handler(conn,
-			                        mop,
-			                        (char *)data,
-			                        (size_t)data_len,
-			                        callback_data)) {
-				exit_by_callback = 1;
+			if (enable_ping_pong && ((mop & 0xF) == MG_WEBSOCKET_OPCODE_PONG)) {
+				/* filter PONG messages */
+				DEBUG_TRACE("PONG from %s:%u",
+				            conn->request_info.remote_addr,
+				            conn->request_info.remote_port);
+				/* No unanwered PINGs left */
+				ping_count = 0;
+			} else if (enable_ping_pong
+			           && ((mop & 0xF) == MG_WEBSOCKET_OPCODE_PING)) {
+				/* reply PING messages */
+				DEBUG_TRACE("Reply PING from %s:%u",
+				            conn->request_info.remote_addr,
+				            conn->request_info.remote_port);
+				ret = mg_websocket_write(conn,
+				                         MG_WEBSOCKET_OPCODE_PONG,
+				                         (char *)data,
+				                         (size_t)data_len);
+				if (ret <= 0) {
+					/* Error: send failed */
+					DEBUG_TRACE("Reply PONG failed (%i)", ret);
+					break;
+				}
+
+
+			} else {
+				/* Exit the loop if callback signals to exit (server side),
+				 * or "connection close" opcode received (client side). */
+				if ((ws_data_handler != NULL)
+				    && !ws_data_handler(conn,
+				                        mop,
+				                        (char *)data,
+				                        (size_t)data_len,
+				                        callback_data)) {
+					exit_by_callback = 1;
+				}
 			}
 
+			/* It a buffer has been allocated, free it again */
 			if (data != mem) {
 				mg_free(data);
 			}
 
-			if (exit_by_callback
-			    || ((mop & 0xf) == WEBSOCKET_OPCODE_CONNECTION_CLOSE)) {
+			if (exit_by_callback) {
+				DEBUG_TRACE("Callback requests to close connection from %s:%u",
+				            conn->request_info.remote_addr,
+				            conn->request_info.remote_port);
+				break;
+			}
+			if ((mop & 0xf) == MG_WEBSOCKET_OPCODE_CONNECTION_CLOSE) {
 				/* Opcode == 8, connection close */
+				DEBUG_TRACE("Message requests to close connection from %s:%u",
+				            conn->request_info.remote_addr,
+				            conn->request_info.remote_port);
 				break;
 			}
 
@@ -11396,19 +12359,56 @@ read_websocket(struct mg_connection *conn,
 			               timeout);
 			if (n <= -2) {
 				/* Error, no bytes read */
+				DEBUG_TRACE("PULL from %s:%u failed",
+				            conn->request_info.remote_addr,
+				            conn->request_info.remote_port);
 				break;
 			}
 			if (n > 0) {
 				conn->data_len += n;
+				/* Reset open PING count */
+				ping_count = 0;
 			} else {
+				if (!conn->phys_ctx->stop_flag && !conn->must_close) {
+					if (ping_count > MG_MAX_UNANSWERED_PING) {
+						/* Stop sending PING */
+						DEBUG_TRACE("Too many (%i) unanswered ping from %s:%u "
+						            "- closing connection",
+						            ping_count,
+						            conn->request_info.remote_addr,
+						            conn->request_info.remote_port);
+						break;
+					}
+					if (enable_ping_pong) {
+						/* Send Websocket PING message */
+						DEBUG_TRACE("PING to %s:%u",
+						            conn->request_info.remote_addr,
+						            conn->request_info.remote_port);
+						ret = mg_websocket_write(conn,
+						                         MG_WEBSOCKET_OPCODE_PING,
+						                         NULL,
+						                         0);
+
+						if (ret <= 0) {
+							/* Error: send failed */
+							DEBUG_TRACE("Send PING failed (%i)", ret);
+							break;
+						}
+						ping_count++;
+					}
+				}
 				/* Timeout: should retry */
 				/* TODO: get timeout def */
 			}
 		}
 	}
 
+	/* Leave data processing loop */
 	mg_set_thread_name("worker");
 	conn->in_websocket_handling = 0;
+	DEBUG_TRACE("Websocket connection %s:%u left data processing loop",
+	            conn->request_info.remote_addr,
+	            conn->request_info.remote_port);
 }
 
 
@@ -11420,11 +12420,10 @@ mg_websocket_write_exec(struct mg_connection *conn,
                         uint32_t masking_key)
 {
 	unsigned char header[14];
-	size_t headerLen = 1;
+	size_t headerLen;
+	int retval;
 
-	int retval = -1;
-
-#if defined(__GNUC__) || defined(__MINGW32__)
+#if defined(GCC_DIAGNOSTIC)
 /* Disable spurious conversion warning for GCC */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
@@ -11432,7 +12431,7 @@ mg_websocket_write_exec(struct mg_connection *conn,
 
 	header[0] = 0x80u | (unsigned char)((unsigned)opcode & 0xf);
 
-#if defined(__GNUC__) || defined(__MINGW32__)
+#if defined(GCC_DIAGNOSTIC)
 #pragma GCC diagnostic pop
 #endif
 
@@ -11464,7 +12463,6 @@ mg_websocket_write_exec(struct mg_connection *conn,
 		headerLen += 4;
 	}
 
-
 	/* Note that POSIX/Winsock's send() is threadsafe
 	 * http://stackoverflow.com/questions/1981372/are-parallel-calls-to-send-recv-on-the-same-socket-valid
 	 * but mongoose's mg_printf/mg_write is not (because of the loop in
@@ -11479,11 +12477,17 @@ mg_websocket_write_exec(struct mg_connection *conn,
 	(void)mg_lock_connection(conn);
 
 	retval = mg_write(conn, header, headerLen);
-	if (dataLen > 0) {
-		retval = mg_write(conn, data, dataLen);
+	if (retval != (int)headerLen) {
+		/* Did not send complete header */
+		retval = -1;
+	} else {
+		if (dataLen > 0) {
+			retval = mg_write(conn, data, dataLen);
+		}
+		/* if dataLen == 0, the header length (2) is returned */
 	}
 
-	/* TODO: Remove this unlock as well, when lock is moved. */
+	/* TODO: Remove this unlock as well, when lock is removed. */
 	mg_unlock_connection(conn);
 
 	return retval;
@@ -11533,16 +12537,22 @@ mg_websocket_client_write(struct mg_connection *conn,
 {
 	int retval = -1;
 	char *masked_data =
-	    (char *)mg_malloc_ctx(((dataLen + 7) / 4) * 4, conn->ctx);
-	uint32_t masking_key = (uint32_t)get_random();
+	    (char *)mg_malloc_ctx(((dataLen + 7) / 4) * 4, conn->phys_ctx);
+	uint32_t masking_key = 0;
 
 	if (masked_data == NULL) {
 		/* Return -1 in an error case */
-		mg_cry(conn,
-		       "Cannot allocate buffer for masked websocket response: "
-		       "Out of memory");
+		mg_cry_internal(conn,
+		                "%s",
+		                "Cannot allocate buffer for masked websocket response: "
+		                "Out of memory");
 		return -1;
 	}
+
+	do {
+		/* Get a masking key - but not 0 */
+		masking_key = (uint32_t)get_random();
+	} while (masking_key == 0);
 
 	mask_data(data, dataLen, masking_key, masked_data);
 
@@ -11567,7 +12577,7 @@ handle_websocket_request(struct mg_connection *conn,
 {
 	const char *websock_key = mg_get_header(conn, "Sec-WebSocket-Key");
 	const char *version = mg_get_header(conn, "Sec-WebSocket-Version");
-	int lua_websock = 0;
+	ptrdiff_t lua_websock = 0;
 
 #if !defined(USE_LUA)
 	(void)path;
@@ -11648,7 +12658,8 @@ handle_websocket_request(struct mg_connection *conn,
 						if ((strlen(subprotocols->subprotocols[idx]) == len)
 						    && (strncmp(curSubProtocol,
 						                subprotocols->subprotocols[idx],
-						                len) == 0)) {
+						                len)
+						        == 0)) {
 							acceptedWebSocketSubprotocol =
 							    subprotocols->subprotocols[idx];
 							break;
@@ -11660,6 +12671,7 @@ handle_websocket_request(struct mg_connection *conn,
 
 			conn->request_info.acceptedWebSocketSubprotocol =
 			    acceptedWebSocketSubprotocol;
+
 		} else if (nbSubprotocolHeader > 0) {
 			/* keep legacy behavior */
 			const char *protocol = protocols[0];
@@ -11697,16 +12709,16 @@ handle_websocket_request(struct mg_connection *conn,
 			return;
 		}
 	}
+
 #if defined(USE_LUA)
 	/* Step 3: No callback. Check if Lua is responsible. */
 	else {
 		/* Step 3.1: Check if Lua is responsible. */
-		if (conn->ctx->config[LUA_WEBSOCKET_EXTENSIONS]) {
-			lua_websock =
-			    match_prefix(conn->ctx->config[LUA_WEBSOCKET_EXTENSIONS],
-			                 strlen(
-			                     conn->ctx->config[LUA_WEBSOCKET_EXTENSIONS]),
-			                 path);
+		if (conn->dom_ctx->config[LUA_WEBSOCKET_EXTENSIONS]) {
+			lua_websock = match_prefix(
+			    conn->dom_ctx->config[LUA_WEBSOCKET_EXTENSIONS],
+			    strlen(conn->dom_ctx->config[LUA_WEBSOCKET_EXTENSIONS]),
+			    path);
 		}
 
 		if (lua_websock) {
@@ -11781,7 +12793,7 @@ is_websocket_protocol(const struct mg_connection *conn)
 	if (upgrade == NULL) {
 		return 0; /* fail early, don't waste time checking other header
 		           * fields
-		             */
+		           */
 	}
 	if (!mg_strcasestr(upgrade, "websocket")) {
 		return 0;
@@ -11845,8 +12857,9 @@ set_throttle(const char *spec, uint32_t remote_ip, const char *uri)
 	while ((spec = next_option(spec, &vec, &val)) != NULL) {
 		mult = ',';
 		if ((val.ptr == NULL) || (sscanf(val.ptr, "%lf%c", &v, &mult) < 1)
-		    || (v < 0) || ((lowercase(&mult) != 'k')
-		                   && (lowercase(&mult) != 'm') && (mult != ','))) {
+		    || (v < 0)
+		    || ((lowercase(&mult) != 'k') && (lowercase(&mult) != 'm')
+		        && (mult != ','))) {
 			continue;
 		}
 		v *= (lowercase(&mult) == 'k')
@@ -11907,7 +12920,7 @@ mg_upload_field_found(const char *key,
 	(void)key;
 
 	if (!filename) {
-		mg_cry(fud->conn, "%s: No filename set", __func__);
+		mg_cry_internal(fud->conn, "%s: No filename set", __func__);
 		return FORM_FIELD_STORAGE_ABORT;
 	}
 	mg_snprintf(fud->conn,
@@ -11917,8 +12930,8 @@ mg_upload_field_found(const char *key,
 	            "%s/%s",
 	            fud->destination_dir,
 	            filename);
-	if (!truncated) {
-		mg_cry(fud->conn, "%s: File path too long", __func__);
+	if (truncated) {
+		mg_cry_internal(fud->conn, "%s: File path too long", __func__);
 		return FORM_FIELD_STORAGE_ABORT;
 	}
 	return FORM_FIELD_STORAGE_STORE;
@@ -11950,7 +12963,7 @@ mg_upload_field_stored(const char *path, long long file_size, void *user_data)
 	(void)file_size;
 
 	fud->num_uploaded_files++;
-	fud->conn->ctx->callbacks.upload(fud->conn, path);
+	fud->conn->phys_ctx->callbacks.upload(fud->conn, path);
 
 	return 0;
 }
@@ -11971,7 +12984,7 @@ mg_upload(struct mg_connection *conn, const char *destination_dir)
 	ret = mg_handle_form_request(conn, &fdh);
 
 	if (ret < 0) {
-		mg_cry(conn, "%s: Error while parsing the request", __func__);
+		mg_cry_internal(conn, "%s: Error while parsing the request", __func__);
 	}
 
 	return fud.num_uploaded_files;
@@ -11993,57 +13006,180 @@ get_first_ssl_listener_index(const struct mg_context *ctx)
 }
 
 
-static void
-redirect_to_https_port(struct mg_connection *conn, int ssl_index)
+/* Return host (without port) */
+/* Use mg_free to free the result */
+static const char *
+alloc_get_host(struct mg_connection *conn)
 {
-	char host[1025];
-	const char *host_header;
-	size_t hostlen;
+	char buf[1025];
+	size_t buflen = sizeof(buf);
+	const char *host_header = get_header(conn->request_info.http_headers,
+	                                     conn->request_info.num_headers,
+	                                     "Host");
+	char *host;
 
-	host_header = mg_get_header(conn, "Host");
-	hostlen = sizeof(host);
 	if (host_header != NULL) {
 		char *pos;
 
-		mg_strlcpy(host, host_header, hostlen);
-		host[hostlen - 1] = '\0';
-		pos = strchr(host, ':');
-		if (pos != NULL) {
-			*pos = '\0';
+		/* Create a local copy of the "Host" header, since it might be
+		 * modified here. */
+		mg_strlcpy(buf, host_header, buflen);
+		buf[buflen - 1] = '\0';
+		host = buf;
+		while (isspace(*host)) {
+			host++;
 		}
+
+		/* If the "Host" is an IPv6 address, like [::1], parse until ]
+		 * is found. */
+		if (*host == '[') {
+			pos = strchr(host, ']');
+			if (!pos) {
+				/* Malformed hostname starts with '[', but no ']' found */
+				DEBUG_TRACE("%s", "Host name format error '[' without ']'");
+				return NULL;
+			}
+			/* terminate after ']' */
+			pos[1] = 0;
+		} else {
+			/* Otherwise, a ':' separates hostname and port number */
+			pos = strchr(host, ':');
+			if (pos != NULL) {
+				*pos = '\0';
+			}
+		}
+
+		if (conn->ssl) {
+			/* This is a HTTPS connection, maybe we have a hostname
+			 * from SNI (set in ssl_servername_callback). */
+			const char *sslhost = conn->dom_ctx->config[AUTHENTICATION_DOMAIN];
+			if (sslhost && (conn->dom_ctx != &(conn->phys_ctx->dd))) {
+				/* We are not using the default domain */
+				if (mg_strcasecmp(host, sslhost)) {
+					/* Mismatch between SNI domain and HTTP domain */
+					DEBUG_TRACE("Host mismatch: SNI: %s, HTTPS: %s",
+					            sslhost,
+					            host);
+					return NULL;
+				}
+			}
+			DEBUG_TRACE("HTTPS Host: %s", host);
+
+		} else {
+			struct mg_domain_context *dom = &(conn->phys_ctx->dd);
+			while (dom) {
+				if (!mg_strcasecmp(host, dom->config[AUTHENTICATION_DOMAIN])) {
+
+					/* Found matching domain */
+					DEBUG_TRACE("HTTP domain %s found",
+					            dom->config[AUTHENTICATION_DOMAIN]);
+
+					/* TODO: Check if this is a HTTP or HTTPS domain */
+					conn->dom_ctx = dom;
+					break;
+				}
+				dom = dom->next;
+			}
+
+			DEBUG_TRACE("HTTP Host: %s", host);
+		}
+
 	} else {
-		/* Cannot get host from the Host: header.
-		 * Fallback to our IP address. */
-		if (conn) {
-			sockaddr_to_string(host, hostlen, &conn->client.lsa);
-		}
+		sockaddr_to_string(buf, buflen, &conn->client.lsa);
+		host = buf;
+
+		DEBUG_TRACE("IP: %s", host);
 	}
 
+	return mg_strdup_ctx(host, conn->phys_ctx);
+}
+
+
+static void
+redirect_to_https_port(struct mg_connection *conn, int ssl_index)
+{
+	char target_url[MG_BUF_LEN];
+	int truncated = 0;
+
+	conn->must_close = 1;
+
 	/* Send host, port, uri and (if it exists) ?query_string */
-	if (conn) {
-		mg_printf(conn,
-		          "HTTP/1.1 302 Found\r\nLocation: https://%s:%d%s%s%s\r\n\r\n",
-		          host,
+	if (conn->host) {
+
+		/* Use "308 Permanent Redirect" */
+		int redirect_code = 308;
+
+		/* Create target URL */
+		mg_snprintf(
+		    conn,
+		    &truncated,
+		    target_url,
+		    sizeof(target_url),
+		    "https://%s:%d%s%s%s",
+
+		    conn->host,
 #if defined(USE_IPV6)
-		          (conn->ctx->listening_sockets[ssl_index].lsa.sa.sa_family
-		           == AF_INET6)
-		              ? (int)ntohs(conn->ctx->listening_sockets[ssl_index]
-		                               .lsa.sin6.sin6_port)
-		              :
+		    (conn->phys_ctx->listening_sockets[ssl_index].lsa.sa.sa_family
+		     == AF_INET6)
+		        ? (int)ntohs(conn->phys_ctx->listening_sockets[ssl_index]
+		                         .lsa.sin6.sin6_port)
+		        :
 #endif
-		              (int)ntohs(conn->ctx->listening_sockets[ssl_index]
-		                             .lsa.sin.sin_port),
-		          conn->request_info.local_uri,
-		          (conn->request_info.query_string == NULL) ? "" : "?",
-		          (conn->request_info.query_string == NULL)
-		              ? ""
-		              : conn->request_info.query_string);
+		        (int)ntohs(conn->phys_ctx->listening_sockets[ssl_index]
+		                       .lsa.sin.sin_port),
+		    conn->request_info.local_uri,
+		    (conn->request_info.query_string == NULL) ? "" : "?",
+		    (conn->request_info.query_string == NULL)
+		        ? ""
+		        : conn->request_info.query_string);
+
+		/* Check overflow in location buffer (will not occur if MG_BUF_LEN
+		 * is used as buffer size) */
+		if (truncated) {
+			mg_send_http_error(conn, 500, "%s", "Redirect URL too long");
+			return;
+		}
+
+		/* Use redirect helper function */
+		mg_send_http_redirect(conn, target_url, redirect_code);
 	}
 }
 
 
 static void
-mg_set_handler_type(struct mg_context *ctx,
+handler_info_acquire(struct mg_handler_info *handler_info)
+{
+	pthread_mutex_lock(&handler_info->refcount_mutex);
+	handler_info->refcount++;
+	pthread_mutex_unlock(&handler_info->refcount_mutex);
+}
+
+
+static void
+handler_info_release(struct mg_handler_info *handler_info)
+{
+	pthread_mutex_lock(&handler_info->refcount_mutex);
+	handler_info->refcount--;
+	pthread_cond_signal(&handler_info->refcount_cond);
+	pthread_mutex_unlock(&handler_info->refcount_mutex);
+}
+
+
+static void
+handler_info_wait_unused(struct mg_handler_info *handler_info)
+{
+	pthread_mutex_lock(&handler_info->refcount_mutex);
+	while (handler_info->refcount) {
+		pthread_cond_wait(&handler_info->refcount_cond,
+		                  &handler_info->refcount_mutex);
+	}
+	pthread_mutex_unlock(&handler_info->refcount_mutex);
+}
+
+
+static void
+mg_set_handler_type(struct mg_context *phys_ctx,
+                    struct mg_domain_context *dom_ctx,
                     const char *uri,
                     int handler_type,
                     int is_delete_request,
@@ -12060,12 +13196,12 @@ mg_set_handler_type(struct mg_context *ctx,
 	size_t urilen = strlen(uri);
 
 	if (handler_type == WEBSOCKET_HANDLER) {
-		/* assert(handler == NULL); */
-		/* assert(is_delete_request || connect_handler!=NULL ||
-		 *        ready_handler!=NULL || data_handler!=NULL ||
-		 *        close_handler!=NULL);
-		 */
-		/* assert(auth_handler == NULL); */
+		DEBUG_ASSERT(handler == NULL);
+		DEBUG_ASSERT(is_delete_request || connect_handler != NULL
+		             || ready_handler != NULL || data_handler != NULL
+		             || close_handler != NULL);
+
+		DEBUG_ASSERT(auth_handler == NULL);
 		if (handler != NULL) {
 			return;
 		}
@@ -12078,11 +13214,11 @@ mg_set_handler_type(struct mg_context *ctx,
 			return;
 		}
 	} else if (handler_type == REQUEST_HANDLER) {
-		/* assert(connect_handler==NULL && ready_handler==NULL &&
-		 *        data_handler==NULL && close_handler==NULL); */
-		/* assert(is_delete_request || (handler!=NULL));
-		 */
-		/* assert(auth_handler == NULL); */
+		DEBUG_ASSERT(connect_handler == NULL && ready_handler == NULL
+		             && data_handler == NULL && close_handler == NULL);
+		DEBUG_ASSERT(is_delete_request || (handler != NULL));
+		DEBUG_ASSERT(auth_handler == NULL);
+
 		if ((connect_handler != NULL) || (ready_handler != NULL)
 		    || (data_handler != NULL) || (close_handler != NULL)) {
 			return;
@@ -12094,10 +13230,10 @@ mg_set_handler_type(struct mg_context *ctx,
 			return;
 		}
 	} else { /* AUTH_HANDLER */
-		     /* assert(handler == NULL); */
-		     /* assert(connect_handler==NULL && ready_handler==NULL &&
-		      *        data_handler==NULL && close_handler==NULL); */
-		/* assert(auth_handler != NULL); */
+		DEBUG_ASSERT(handler == NULL);
+		DEBUG_ASSERT(connect_handler == NULL && ready_handler == NULL
+		             && data_handler == NULL && close_handler == NULL);
+		DEBUG_ASSERT(auth_handler != NULL);
 		if (handler != NULL) {
 			return;
 		}
@@ -12110,20 +13246,24 @@ mg_set_handler_type(struct mg_context *ctx,
 		}
 	}
 
-	if (!ctx) {
+	if (!phys_ctx || !dom_ctx) {
 		return;
 	}
 
-	mg_lock_context(ctx);
+	mg_lock_context(phys_ctx);
 
 	/* first try to find an existing handler */
-	lastref = &(ctx->handlers);
-	for (tmp_rh = ctx->handlers; tmp_rh != NULL; tmp_rh = tmp_rh->next) {
+	lastref = &(dom_ctx->handlers);
+	for (tmp_rh = dom_ctx->handlers; tmp_rh != NULL; tmp_rh = tmp_rh->next) {
 		if (tmp_rh->handler_type == handler_type) {
 			if ((urilen == tmp_rh->uri_len) && !strcmp(tmp_rh->uri, uri)) {
 				if (!is_delete_request) {
 					/* update existing handler */
 					if (handler_type == REQUEST_HANDLER) {
+						/* Wait for end of use before updating */
+						handler_info_wait_unused(tmp_rh);
+
+						/* Ok, the handler is no more use -> Update it */
 						tmp_rh->handler = handler;
 					} else if (handler_type == WEBSOCKET_HANDLER) {
 						tmp_rh->subprotocols = subprotocols;
@@ -12137,11 +13277,20 @@ mg_set_handler_type(struct mg_context *ctx,
 					tmp_rh->cbdata = cbdata;
 				} else {
 					/* remove existing handler */
+					if (handler_type == REQUEST_HANDLER) {
+						/* Wait for end of use before removing */
+						handler_info_wait_unused(tmp_rh);
+
+						/* Ok, the handler is no more used -> Destroy resources
+						 */
+						pthread_cond_destroy(&tmp_rh->refcount_cond);
+						pthread_mutex_destroy(&tmp_rh->refcount_mutex);
+					}
 					*lastref = tmp_rh->next;
 					mg_free(tmp_rh->uri);
 					mg_free(tmp_rh);
 				}
-				mg_unlock_context(ctx);
+				mg_unlock_context(phys_ctx);
 				return;
 			}
 		}
@@ -12151,28 +13300,47 @@ mg_set_handler_type(struct mg_context *ctx,
 	if (is_delete_request) {
 		/* no handler to set, this was a remove request to a non-existing
 		 * handler */
-		mg_unlock_context(ctx);
+		mg_unlock_context(phys_ctx);
 		return;
 	}
 
 	tmp_rh =
 	    (struct mg_handler_info *)mg_calloc_ctx(sizeof(struct mg_handler_info),
 	                                            1,
-	                                            ctx);
+	                                            phys_ctx);
 	if (tmp_rh == NULL) {
-		mg_unlock_context(ctx);
-		mg_cry(fc(ctx), "%s", "Cannot create new request handler struct, OOM");
+		mg_unlock_context(phys_ctx);
+		mg_cry_internal(fc(phys_ctx),
+		                "%s",
+		                "Cannot create new request handler struct, OOM");
 		return;
 	}
-	tmp_rh->uri = mg_strdup(uri);
+	tmp_rh->uri = mg_strdup_ctx(uri, phys_ctx);
 	if (!tmp_rh->uri) {
-		mg_unlock_context(ctx);
+		mg_unlock_context(phys_ctx);
 		mg_free(tmp_rh);
-		mg_cry(fc(ctx), "%s", "Cannot create new request handler struct, OOM");
+		mg_cry_internal(fc(phys_ctx),
+		                "%s",
+		                "Cannot create new request handler struct, OOM");
 		return;
 	}
 	tmp_rh->uri_len = urilen;
 	if (handler_type == REQUEST_HANDLER) {
+		/* Init refcount mutex and condition */
+		if (0 != pthread_mutex_init(&tmp_rh->refcount_mutex, NULL)) {
+			mg_unlock_context(phys_ctx);
+			mg_free(tmp_rh);
+			mg_cry_internal(fc(phys_ctx), "%s", "Cannot init refcount mutex");
+			return;
+		}
+		if (0 != pthread_cond_init(&tmp_rh->refcount_cond, NULL)) {
+			mg_unlock_context(phys_ctx);
+			pthread_mutex_destroy(&tmp_rh->refcount_mutex);
+			mg_free(tmp_rh);
+			mg_cry_internal(fc(phys_ctx), "%s", "Cannot init refcount cond");
+			return;
+		}
+		tmp_rh->refcount = 0;
 		tmp_rh->handler = handler;
 	} else if (handler_type == WEBSOCKET_HANDLER) {
 		tmp_rh->subprotocols = subprotocols;
@@ -12188,7 +13356,7 @@ mg_set_handler_type(struct mg_context *ctx,
 	tmp_rh->next = NULL;
 
 	*lastref = tmp_rh;
-	mg_unlock_context(ctx);
+	mg_unlock_context(phys_ctx);
 }
 
 
@@ -12199,6 +13367,7 @@ mg_set_request_handler(struct mg_context *ctx,
                        void *cbdata)
 {
 	mg_set_handler_type(ctx,
+	                    &(ctx->dd),
 	                    uri,
 	                    REQUEST_HANDLER,
 	                    handler == NULL,
@@ -12248,6 +13417,7 @@ mg_set_websocket_handler_with_subprotocols(
 	                        && (data_handler == NULL)
 	                        && (close_handler == NULL);
 	mg_set_handler_type(ctx,
+	                    &(ctx->dd),
 	                    uri,
 	                    WEBSOCKET_HANDLER,
 	                    is_delete_request,
@@ -12269,6 +13439,7 @@ mg_set_auth_handler(struct mg_context *ctx,
                     void *cbdata)
 {
 	mg_set_handler_type(ctx,
+	                    &(ctx->dd),
 	                    uri,
 	                    AUTH_HANDLER,
 	                    handler == NULL,
@@ -12293,7 +13464,8 @@ get_request_handler(struct mg_connection *conn,
                     mg_websocket_data_handler *data_handler,
                     mg_websocket_close_handler *close_handler,
                     mg_authorization_handler *auth_handler,
-                    void **cbdata)
+                    void **cbdata,
+                    struct mg_handler_info **handler_info)
 {
 	const struct mg_request_info *request_info = mg_get_request_info(conn);
 	if (request_info) {
@@ -12301,14 +13473,14 @@ get_request_handler(struct mg_connection *conn,
 		size_t urilen = strlen(uri);
 		struct mg_handler_info *tmp_rh;
 
-		if (!conn || !conn->ctx) {
+		if (!conn || !conn->phys_ctx || !conn->dom_ctx) {
 			return 0;
 		}
 
-		mg_lock_context(conn->ctx);
+		mg_lock_context(conn->phys_ctx);
 
 		/* first try for an exact match */
-		for (tmp_rh = conn->ctx->handlers; tmp_rh != NULL;
+		for (tmp_rh = conn->dom_ctx->handlers; tmp_rh != NULL;
 		     tmp_rh = tmp_rh->next) {
 			if (tmp_rh->handler_type == handler_type) {
 				if ((urilen == tmp_rh->uri_len) && !strcmp(tmp_rh->uri, uri)) {
@@ -12320,18 +13492,21 @@ get_request_handler(struct mg_connection *conn,
 						*close_handler = tmp_rh->close_handler;
 					} else if (handler_type == REQUEST_HANDLER) {
 						*handler = tmp_rh->handler;
+						/* Acquire handler and give it back */
+						handler_info_acquire(tmp_rh);
+						*handler_info = tmp_rh;
 					} else { /* AUTH_HANDLER */
 						*auth_handler = tmp_rh->auth_handler;
 					}
 					*cbdata = tmp_rh->cbdata;
-					mg_unlock_context(conn->ctx);
+					mg_unlock_context(conn->phys_ctx);
 					return 1;
 				}
 			}
 		}
 
 		/* next try for a partial match, we will accept uri/something */
-		for (tmp_rh = conn->ctx->handlers; tmp_rh != NULL;
+		for (tmp_rh = conn->dom_ctx->handlers; tmp_rh != NULL;
 		     tmp_rh = tmp_rh->next) {
 			if (tmp_rh->handler_type == handler_type) {
 				if ((tmp_rh->uri_len < urilen) && (uri[tmp_rh->uri_len] == '/')
@@ -12344,18 +13519,21 @@ get_request_handler(struct mg_connection *conn,
 						*close_handler = tmp_rh->close_handler;
 					} else if (handler_type == REQUEST_HANDLER) {
 						*handler = tmp_rh->handler;
+						/* Acquire handler and give it back */
+						handler_info_acquire(tmp_rh);
+						*handler_info = tmp_rh;
 					} else { /* AUTH_HANDLER */
 						*auth_handler = tmp_rh->auth_handler;
 					}
 					*cbdata = tmp_rh->cbdata;
-					mg_unlock_context(conn->ctx);
+					mg_unlock_context(conn->phys_ctx);
 					return 1;
 				}
 			}
 		}
 
 		/* finally try for pattern match */
-		for (tmp_rh = conn->ctx->handlers; tmp_rh != NULL;
+		for (tmp_rh = conn->dom_ctx->handlers; tmp_rh != NULL;
 		     tmp_rh = tmp_rh->next) {
 			if (tmp_rh->handler_type == handler_type) {
 				if (match_prefix(tmp_rh->uri, tmp_rh->uri_len, uri) > 0) {
@@ -12367,17 +13545,20 @@ get_request_handler(struct mg_connection *conn,
 						*close_handler = tmp_rh->close_handler;
 					} else if (handler_type == REQUEST_HANDLER) {
 						*handler = tmp_rh->handler;
+						/* Acquire handler and give it back */
+						handler_info_acquire(tmp_rh);
+						*handler_info = tmp_rh;
 					} else { /* AUTH_HANDLER */
 						*auth_handler = tmp_rh->auth_handler;
 					}
 					*cbdata = tmp_rh->cbdata;
-					mg_unlock_context(conn->ctx);
+					mg_unlock_context(conn->phys_ctx);
 					return 1;
 				}
 			}
 		}
 
-		mg_unlock_context(conn->ctx);
+		mg_unlock_context(conn->phys_ctx);
 	}
 	return 0; /* none found */
 }
@@ -12454,6 +13635,7 @@ handle_request(struct mg_connection *conn)
 	int i;
 	struct mg_file file = STRUCT_FILE_INITIALIZER;
 	mg_request_handler callback_handler = NULL;
+	struct mg_handler_info *handler_info = NULL;
 	struct mg_websocket_subprotocols *subprotocols;
 	mg_websocket_connect_handler ws_connect_handler = NULL;
 	mg_websocket_ready_handler ws_ready_handler = NULL;
@@ -12477,7 +13659,7 @@ handle_request(struct mg_connection *conn)
 
 	/* 1.2. do a https redirect, if required. Do not decode URIs yet. */
 	if (!conn->client.is_ssl && conn->client.ssl_redir) {
-		ssl_index = get_first_ssl_listener_index(conn->ctx);
+		ssl_index = get_first_ssl_listener_index(conn->phys_ctx);
 		if (ssl_index >= 0) {
 			redirect_to_https_port(conn, ssl_index);
 		} else {
@@ -12487,7 +13669,9 @@ handle_request(struct mg_connection *conn)
 			                   503,
 			                   "%s",
 			                   "Error: SSL forward not configured properly");
-			mg_cry(conn, "Can not redirect to SSL, no SSL port available");
+			mg_cry_internal(conn,
+			                "%s",
+			                "Can not redirect to SSL, no SSL port available");
 		}
 		return;
 	}
@@ -12508,16 +13692,16 @@ handle_request(struct mg_connection *conn)
 	DEBUG_TRACE("URL: %s", ri->local_uri);
 
 	/* 2. if this ip has limited speed, set it for this connection */
-	conn->throttle = set_throttle(conn->ctx->config[THROTTLE],
+	conn->throttle = set_throttle(conn->dom_ctx->config[THROTTLE],
 	                              get_remote_ip(conn),
 	                              ri->local_uri);
 
 	/* 3. call a "handle everything" callback, if registered */
-	if (conn->ctx->callbacks.begin_request != NULL) {
+	if (conn->phys_ctx->callbacks.begin_request != NULL) {
 		/* Note that since V1.7 the "begin_request" function is called
 		 * before an authorization check. If an authorization check is
 		 * required, use a request_handler instead. */
-		i = conn->ctx->callbacks.begin_request(conn);
+		i = conn->phys_ctx->callbacks.begin_request(conn);
 		if (i > 0) {
 			/* callback already processed the request. Store the
 			   return value as a status code for the access log. */
@@ -12543,9 +13727,9 @@ handle_request(struct mg_connection *conn)
 		 * access_control_allow_methods is not NULL and not an empty string.
 		 * In this case, scripts can still handle CORS. */
 		const char *cors_meth_cfg =
-		    conn->ctx->config[ACCESS_CONTROL_ALLOW_METHODS];
+		    conn->dom_ctx->config[ACCESS_CONTROL_ALLOW_METHODS];
 		const char *cors_orig_cfg =
-		    conn->ctx->config[ACCESS_CONTROL_ALLOW_ORIGIN];
+		    conn->dom_ctx->config[ACCESS_CONTROL_ALLOW_ORIGIN];
 		const char *cors_origin =
 		    get_header(ri->http_headers, ri->num_headers, "Origin");
 		const char *cors_acrm = get_header(ri->http_headers,
@@ -12582,7 +13766,7 @@ handle_request(struct mg_connection *conn)
 			if (cors_acrh != NULL) {
 				/* CORS request is asking for additional headers */
 				const char *cors_hdr_cfg =
-				    conn->ctx->config[ACCESS_CONTROL_ALLOW_HEADERS];
+				    conn->dom_ctx->config[ACCESS_CONTROL_ALLOW_HEADERS];
 
 				if ((cors_hdr_cfg != NULL) && (*cors_hdr_cfg != 0)) {
 					/* Allow only if access_control_allow_headers is
@@ -12624,7 +13808,8 @@ handle_request(struct mg_connection *conn)
 	                        &ws_data_handler,
 	                        &ws_close_handler,
 	                        NULL,
-	                        &callback_data)) {
+	                        &callback_data,
+	                        &handler_info)) {
 		/* 5.2.1. A callback will handle this request. All requests
 		 * handled
 		 * by a callback have to be considered as requests to a script
@@ -12634,6 +13819,7 @@ handle_request(struct mg_connection *conn)
 		is_put_or_delete_request = is_put_or_delete_method(conn);
 	} else {
 	no_callback_resource:
+
 		/* 5.2.2. No callback is responsible for this request. The URI
 		 * addresses a file based resource (static content or Lua/cgi
 		 * scripts in the file system). */
@@ -12659,7 +13845,8 @@ handle_request(struct mg_connection *conn)
 	                        NULL,
 	                        NULL,
 	                        &auth_handler,
-	                        &auth_callback_data)) {
+	                        &auth_callback_data,
+	                        NULL)) {
 		if (!auth_handler(conn, auth_callback_data)) {
 			return;
 		}
@@ -12670,7 +13857,7 @@ handle_request(struct mg_connection *conn)
 #if defined(NO_FILES)
 		if (1) {
 #else
-		if (conn->ctx->config[DOCUMENT_ROOT] == NULL) {
+		if (conn->dom_ctx->config[DOCUMENT_ROOT] == NULL) {
 #endif
 			/* This server does not have any real files, thus the
 			 * PUT/DELETE methods are not valid. */
@@ -12707,6 +13894,10 @@ handle_request(struct mg_connection *conn)
 	if (is_callback_resource) {
 		if (!is_websocket_request) {
 			i = callback_handler(conn, callback_data);
+
+			/* Callback handler will not be used anymore. Release it */
+			handler_info_release(handler_info);
+
 			if (i > 0) {
 				/* Do nothing, callback has served the request. Store
 				 * then return value as status code for the log and discard
@@ -12783,7 +13974,7 @@ handle_request(struct mg_connection *conn)
 				                         NULL,
 				                         NULL,
 				                         NULL,
-				                         &conn->ctx->callbacks);
+				                         conn->phys_ctx->user_data);
 			} else {
 				/* Script was in an illegal path */
 				mg_send_http_error(conn, 403, "%s", "Forbidden");
@@ -12799,7 +13990,7 @@ handle_request(struct mg_connection *conn)
 			    deprecated_websocket_ready_wrapper,
 			    deprecated_websocket_data_wrapper,
 			    NULL,
-			    &conn->ctx->callbacks);
+			    conn->phys_ctx->user_data);
 #else
 			mg_send_http_error(conn, 404, "%s", "Not found");
 #endif
@@ -12817,7 +14008,7 @@ handle_request(struct mg_connection *conn)
 #else
 	/* 9b. This request is either for a static file or resource handled
 	 * by a script file. Thus, a DOCUMENT_ROOT must exist. */
-	if (conn->ctx->config[DOCUMENT_ROOT] == NULL) {
+	if (conn->dom_ctx->config[DOCUMENT_ROOT] == NULL) {
 		mg_send_http_error(conn, 404, "%s", "Not Found");
 		return;
 	}
@@ -12912,7 +14103,7 @@ handle_request(struct mg_connection *conn)
 		/* Substitute files have already been handled above. */
 		/* Here we can either generate and send a directory listing,
 		 * or send an "access denied" error. */
-		if (!mg_strcasecmp(conn->ctx->config[ENABLE_DIRECTORY_LISTING],
+		if (!mg_strcasecmp(conn->dom_ctx->config[ENABLE_DIRECTORY_LISTING],
 		                   "yes")) {
 			handle_directory_request(conn, path);
 		} else {
@@ -12924,15 +14115,9 @@ handle_request(struct mg_connection *conn)
 		return;
 	}
 
+	/* 15. read a normal file with GET or HEAD */
 	handle_file_based_request(conn, path, &file);
 #endif /* !defined(NO_FILES) */
-
-#if 0
-            /* Perform redirect and auth checks before calling begin_request()
-             * handler.
-             * Otherwise, begin_request() would need to perform auth checks and
-             * redirects. */
-#endif
 }
 
 
@@ -12941,16 +14126,17 @@ handle_file_based_request(struct mg_connection *conn,
                           const char *path,
                           struct mg_file *file)
 {
-	if (!conn || !conn->ctx) {
+	if (!conn || !conn->dom_ctx) {
 		return;
 	}
 
 	if (0) {
-#ifdef USE_LUA
-	} else if (match_prefix(conn->ctx->config[LUA_SERVER_PAGE_EXTENSIONS],
-	                        strlen(
-	                            conn->ctx->config[LUA_SERVER_PAGE_EXTENSIONS]),
-	                        path) > 0) {
+#if defined(USE_LUA)
+	} else if (match_prefix(
+	               conn->dom_ctx->config[LUA_SERVER_PAGE_EXTENSIONS],
+	               strlen(conn->dom_ctx->config[LUA_SERVER_PAGE_EXTENSIONS]),
+	               path)
+	           > 0) {
 		if (is_in_script_path(conn, path)) {
 			/* Lua server page: an SSI like page containing mostly plain
 			 * html
@@ -12962,9 +14148,11 @@ handle_file_based_request(struct mg_connection *conn,
 			mg_send_http_error(conn, 403, "%s", "Forbidden");
 		}
 
-	} else if (match_prefix(conn->ctx->config[LUA_SCRIPT_EXTENSIONS],
-	                        strlen(conn->ctx->config[LUA_SCRIPT_EXTENSIONS]),
-	                        path) > 0) {
+	} else if (match_prefix(conn->dom_ctx->config[LUA_SCRIPT_EXTENSIONS],
+	                        strlen(
+	                            conn->dom_ctx->config[LUA_SCRIPT_EXTENSIONS]),
+	                        path)
+	           > 0) {
 		if (is_in_script_path(conn, path)) {
 			/* Lua in-server module script: a CGI like script used to
 			 * generate
@@ -12977,10 +14165,11 @@ handle_file_based_request(struct mg_connection *conn,
 		}
 #endif
 #if defined(USE_DUKTAPE)
-	} else if (match_prefix(conn->ctx->config[DUKTAPE_SCRIPT_EXTENSIONS],
-	                        strlen(
-	                            conn->ctx->config[DUKTAPE_SCRIPT_EXTENSIONS]),
-	                        path) > 0) {
+	} else if (match_prefix(
+	               conn->dom_ctx->config[DUKTAPE_SCRIPT_EXTENSIONS],
+	               strlen(conn->dom_ctx->config[DUKTAPE_SCRIPT_EXTENSIONS]),
+	               path)
+	           > 0) {
 		if (is_in_script_path(conn, path)) {
 			/* Call duktape to generate the page */
 			mg_exec_duktape_script(conn, path);
@@ -12990,9 +14179,10 @@ handle_file_based_request(struct mg_connection *conn,
 		}
 #endif
 #if !defined(NO_CGI)
-	} else if (match_prefix(conn->ctx->config[CGI_EXTENSIONS],
-	                        strlen(conn->ctx->config[CGI_EXTENSIONS]),
-	                        path) > 0) {
+	} else if (match_prefix(conn->dom_ctx->config[CGI_EXTENSIONS],
+	                        strlen(conn->dom_ctx->config[CGI_EXTENSIONS]),
+	                        path)
+	           > 0) {
 		if (is_in_script_path(conn, path)) {
 			/* CGI scripts may support all HTTP methods */
 			handle_cgi_request(conn, path);
@@ -13001,9 +14191,10 @@ handle_file_based_request(struct mg_connection *conn,
 			mg_send_http_error(conn, 403, "%s", "Forbidden");
 		}
 #endif /* !NO_CGI */
-	} else if (match_prefix(conn->ctx->config[SSI_EXTENSIONS],
-	                        strlen(conn->ctx->config[SSI_EXTENSIONS]),
-	                        path) > 0) {
+	} else if (match_prefix(conn->dom_ctx->config[SSI_EXTENSIONS],
+	                        strlen(conn->dom_ctx->config[SSI_EXTENSIONS]),
+	                        path)
+	           > 0) {
 		if (is_in_script_path(conn, path)) {
 			handle_ssi_file_request(conn, path, file);
 		} else {
@@ -13120,15 +14311,26 @@ parse_port_string(const struct vec *vec, struct socket *so, int *ip_version)
 		*ip_version = 4;
 
 	} else if ((cb = strchr(vec->ptr, ':')) != NULL) {
-		/* Could be a hostname */
-		/* Will only work for RFC 952 compliant hostnames,
+		/* String could be a hostname. This check algotithm
+		 * will only work for RFC 952 compliant hostnames,
 		 * starting with a letter, containing only letters,
 		 * digits and hyphen ('-'). Newer specs may allow
 		 * more, but this is not guaranteed here, since it
 		 * may interfere with rules for port option lists. */
 
-		*(char *)cb = 0; /* Use a const cast here and modify the string.
-		                  * We are going to restore the string later. */
+		/* According to RFC 1035, hostnames are restricted to 255 characters
+		 * in total (63 between two dots). */
+		char hostname[256];
+		size_t hostnlen = (size_t)(cb - vec->ptr);
+
+		if (hostnlen >= sizeof(hostname)) {
+			/* This would be invalid in any case */
+			*ip_version = 0;
+			return 0;
+		}
+
+		memcpy(hostname, vec->ptr, hostnlen);
+		hostname[hostnlen] = 0;
 
 		if (mg_inet_pton(
 		        AF_INET, vec->ptr, &so->lsa.sin, sizeof(so->lsa.sin))) {
@@ -13136,7 +14338,7 @@ parse_port_string(const struct vec *vec, struct socket *so, int *ip_version)
 				*ip_version = 4;
 				so->lsa.sin.sin_family = AF_INET;
 				so->lsa.sin.sin_port = htons((uint16_t)port);
-				len += (int)(cb - vec->ptr) + 1;
+				len += (int)(hostnlen + 1);
 			} else {
 				port = 0;
 				len = 0;
@@ -13150,7 +14352,7 @@ parse_port_string(const struct vec *vec, struct socket *so, int *ip_version)
 				*ip_version = 6;
 				so->lsa.sin6.sin6_family = AF_INET6;
 				so->lsa.sin.sin_port = htons((uint16_t)port);
-				len += (int)(cb - vec->ptr) + 1;
+				len += (int)(hostnlen + 1);
 			} else {
 				port = 0;
 				len = 0;
@@ -13158,7 +14360,6 @@ parse_port_string(const struct vec *vec, struct socket *so, int *ip_version)
 #endif
 		}
 
-		*(char *)cb = ':'; /* restore the string */
 
 	} else {
 		/* Parsing failure. */
@@ -13180,14 +14381,72 @@ parse_port_string(const struct vec *vec, struct socket *so, int *ip_version)
 		return 1;
 	}
 
-	/* Reset ip_version to 0 of there is an error */
+	/* Reset ip_version to 0 if there is an error */
 	*ip_version = 0;
 	return 0;
 }
 
 
+/* Is there any SSL port in use? */
 static int
-set_ports_option(struct mg_context *ctx)
+is_ssl_port_used(const char *ports)
+{
+	if (ports) {
+		/* There are several different allowed syntax variants:
+		 * - "80" for a single port using every network interface
+		 * - "localhost:80" for a single port using only localhost
+		 * - "80,localhost:8080" for two ports, one bound to localhost
+		 * - "80,127.0.0.1:8084,[::1]:8086" for three ports, one bound
+		 *   to IPv4 localhost, one to IPv6 localhost
+		 * - "+80" use port 80 for IPv4 and IPv6
+		 * - "+80r,+443s" port 80 (HTTP) is a redirect to port 443 (HTTPS),
+		 *   for both: IPv4 and IPv4
+		 * - "+443s,localhost:8080" port 443 (HTTPS) for every interface,
+		 *   additionally port 8080 bound to localhost connections
+		 *
+		 * If we just look for 's' anywhere in the string, "localhost:80"
+		 * will be detected as SSL (false positive).
+		 * Looking for 's' after a digit may cause false positives in
+		 * "my24service:8080".
+		 * Looking from 's' backward if there are only ':' and numbers
+		 * before will not work for "24service:8080" (non SSL, port 8080)
+		 * or "24s" (SSL, port 24).
+		 *
+		 * Remark: Initially hostnames were not allowed to start with a
+		 * digit (according to RFC 952), this was allowed later (RFC 1123,
+		 * Section 2.1).
+		 *
+		 * To get this correct, the entire string must be parsed as a whole,
+		 * reading it as a list element for element and parsing with an
+		 * algorithm equivalent to parse_port_string.
+		 *
+		 * In fact, we use local interface names here, not arbitrary hostnames,
+		 * so in most cases the only name will be "localhost".
+		 *
+		 * So, for now, we use this simple algorithm, that may still return
+		 * a false positive in bizarre cases.
+		 */
+		int i;
+		int portslen = (int)strlen(ports);
+		char prevIsNumber = 0;
+
+		for (i = 0; i < portslen; i++) {
+			if (prevIsNumber && (ports[i] == 's' || ports[i] == 'r')) {
+				return 1;
+			}
+			if (ports[i] >= '0' && ports[i] <= '9') {
+				prevIsNumber = 1;
+			} else {
+				prevIsNumber = 0;
+			}
+		}
+	}
+	return 0;
+}
+
+
+static int
+set_ports_option(struct mg_context *phys_ctx)
 {
 	const char *list;
 	int on = 1;
@@ -13205,36 +14464,36 @@ set_ports_option(struct mg_context *ctx)
 	int portsTotal = 0;
 	int portsOk = 0;
 
-	if (!ctx) {
+	if (!phys_ctx) {
 		return 0;
 	}
 
 	memset(&so, 0, sizeof(so));
 	memset(&usa, 0, sizeof(usa));
 	len = sizeof(usa);
-	list = ctx->config[LISTENING_PORTS];
+	list = phys_ctx->dd.config[LISTENING_PORTS];
 
 	while ((list = next_option(list, &vec, NULL)) != NULL) {
 
 		portsTotal++;
 
 		if (!parse_port_string(&vec, &so, &ip_version)) {
-			mg_cry(fc(ctx),
-			       "%.*s: invalid port spec (entry %i). Expecting list of: %s",
-			       (int)vec.len,
-			       vec.ptr,
-			       portsTotal,
-			       "[IP_ADDRESS:]PORT[s|r]");
+			mg_cry_internal(
+			    fc(phys_ctx),
+			    "%.*s: invalid port spec (entry %i). Expecting list of: %s",
+			    (int)vec.len,
+			    vec.ptr,
+			    portsTotal,
+			    "[IP_ADDRESS:]PORT[s|r]");
 			continue;
 		}
 
 #if !defined(NO_SSL)
-		if (so.is_ssl && ctx->ssl_ctx == NULL) {
+		if (so.is_ssl && phys_ctx->dd.ssl_ctx == NULL) {
 
-			mg_cry(fc(ctx),
-			       "Cannot add SSL socket (entry %i). Is -ssl_certificate "
-			       "option set?",
-			       portsTotal);
+			mg_cry_internal(fc(phys_ctx),
+			                "Cannot add SSL socket (entry %i)",
+			                portsTotal);
 			continue;
 		}
 #endif
@@ -13242,11 +14501,13 @@ set_ports_option(struct mg_context *ctx)
 		if ((so.sock = socket(so.lsa.sa.sa_family, SOCK_STREAM, 6))
 		    == INVALID_SOCKET) {
 
-			mg_cry(fc(ctx), "cannot create socket (entry %i)", portsTotal);
+			mg_cry_internal(fc(phys_ctx),
+			                "cannot create socket (entry %i)",
+			                portsTotal);
 			continue;
 		}
 
-#ifdef _WIN32
+#if defined(_WIN32)
 		/* Windows SO_REUSEADDR lets many procs binds to a
 		 * socket, SO_EXCLUSIVEADDRUSE makes the bind fail
 		 * if someone already has the socket -- DTL */
@@ -13260,45 +14521,66 @@ set_ports_option(struct mg_context *ctx)
 		               SOL_SOCKET,
 		               SO_EXCLUSIVEADDRUSE,
 		               (SOCK_OPT_TYPE)&on,
-		               sizeof(on)) != 0) {
+		               sizeof(on))
+		    != 0) {
 
 			/* Set reuse option, but don't abort on errors. */
-			mg_cry(fc(ctx),
-			       "cannot set socket option SO_EXCLUSIVEADDRUSE (entry %i)",
-			       portsTotal);
+			mg_cry_internal(
+			    fc(phys_ctx),
+			    "cannot set socket option SO_EXCLUSIVEADDRUSE (entry %i)",
+			    portsTotal);
 		}
 #else
 		if (setsockopt(so.sock,
 		               SOL_SOCKET,
 		               SO_REUSEADDR,
 		               (SOCK_OPT_TYPE)&on,
-		               sizeof(on)) != 0) {
+		               sizeof(on))
+		    != 0) {
 
 			/* Set reuse option, but don't abort on errors. */
-			mg_cry(fc(ctx),
-			       "cannot set socket option SO_REUSEADDR (entry %i)",
-			       portsTotal);
+			mg_cry_internal(fc(phys_ctx),
+			                "cannot set socket option SO_REUSEADDR (entry %i)",
+			                portsTotal);
 		}
 #endif
 
 		if (ip_version > 4) {
+/* Could be 6 for IPv6 onlyor 10 (4+6) for IPv4+IPv6 */
 #if defined(USE_IPV6)
-			if (ip_version == 6) {
+			if (ip_version > 6) {
 				if (so.lsa.sa.sa_family == AF_INET6
 				    && setsockopt(so.sock,
 				                  IPPROTO_IPV6,
 				                  IPV6_V6ONLY,
 				                  (void *)&off,
-				                  sizeof(off)) != 0) {
+				                  sizeof(off))
+				           != 0) {
 
 					/* Set IPv6 only option, but don't abort on errors. */
-					mg_cry(fc(ctx),
-					       "cannot set socket option IPV6_V6ONLY (entry %i)",
-					       portsTotal);
+					mg_cry_internal(
+					    fc(phys_ctx),
+					    "cannot set socket option IPV6_V6ONLY=off (entry %i)",
+					    portsTotal);
+				}
+			} else {
+				if (so.lsa.sa.sa_family == AF_INET6
+				    && setsockopt(so.sock,
+				                  IPPROTO_IPV6,
+				                  IPV6_V6ONLY,
+				                  (void *)&on,
+				                  sizeof(on))
+				           != 0) {
+
+					/* Set IPv6 only option, but don't abort on errors. */
+					mg_cry_internal(
+					    fc(phys_ctx),
+					    "cannot set socket option IPV6_V6ONLY=on (entry %i)",
+					    portsTotal);
 				}
 			}
 #else
-			mg_cry(fc(ctx), "IPv6 not available");
+			mg_cry_internal(fc(phys_ctx), "%s", "IPv6 not available");
 			closesocket(so.sock);
 			so.sock = INVALID_SOCKET;
 			continue;
@@ -13309,12 +14591,12 @@ set_ports_option(struct mg_context *ctx)
 
 			len = sizeof(so.lsa.sin);
 			if (bind(so.sock, &so.lsa.sa, len) != 0) {
-				mg_cry(fc(ctx),
-				       "cannot bind to %.*s: %d (%s)",
-				       (int)vec.len,
-				       vec.ptr,
-				       (int)ERRNO,
-				       strerror(errno));
+				mg_cry_internal(fc(phys_ctx),
+				                "cannot bind to %.*s: %d (%s)",
+				                (int)vec.len,
+				                vec.ptr,
+				                (int)ERRNO,
+				                strerror(errno));
 				closesocket(so.sock);
 				so.sock = INVALID_SOCKET;
 				continue;
@@ -13325,12 +14607,12 @@ set_ports_option(struct mg_context *ctx)
 
 			len = sizeof(so.lsa.sin6);
 			if (bind(so.sock, &so.lsa.sa, len) != 0) {
-				mg_cry(fc(ctx),
-				       "cannot bind to IPv6 %.*s: %d (%s)",
-				       (int)vec.len,
-				       vec.ptr,
-				       (int)ERRNO,
-				       strerror(errno));
+				mg_cry_internal(fc(phys_ctx),
+				                "cannot bind to IPv6 %.*s: %d (%s)",
+				                (int)vec.len,
+				                vec.ptr,
+				                (int)ERRNO,
+				                strerror(errno));
 				closesocket(so.sock);
 				so.sock = INVALID_SOCKET;
 				continue;
@@ -13338,9 +14620,10 @@ set_ports_option(struct mg_context *ctx)
 		}
 #endif
 		else {
-			mg_cry(fc(ctx),
-			       "cannot bind: address family not supported (entry %i)",
-			       portsTotal);
+			mg_cry_internal(
+			    fc(phys_ctx),
+			    "cannot bind: address family not supported (entry %i)",
+			    portsTotal);
 			closesocket(so.sock);
 			so.sock = INVALID_SOCKET;
 			continue;
@@ -13348,12 +14631,12 @@ set_ports_option(struct mg_context *ctx)
 
 		if (listen(so.sock, SOMAXCONN) != 0) {
 
-			mg_cry(fc(ctx),
-			       "cannot listen to %.*s: %d (%s)",
-			       (int)vec.len,
-			       vec.ptr,
-			       (int)ERRNO,
-			       strerror(errno));
+			mg_cry_internal(fc(phys_ctx),
+			                "cannot listen to %.*s: %d (%s)",
+			                (int)vec.len,
+			                vec.ptr,
+			                (int)ERRNO,
+			                strerror(errno));
 			closesocket(so.sock);
 			so.sock = INVALID_SOCKET;
 			continue;
@@ -13363,12 +14646,12 @@ set_ports_option(struct mg_context *ctx)
 		    || (usa.sa.sa_family != so.lsa.sa.sa_family)) {
 
 			int err = (int)ERRNO;
-			mg_cry(fc(ctx),
-			       "call to getsockname failed %.*s: %d (%s)",
-			       (int)vec.len,
-			       vec.ptr,
-			       err,
-			       strerror(errno));
+			mg_cry_internal(fc(phys_ctx),
+			                "call to getsockname failed %.*s: %d (%s)",
+			                (int)vec.len,
+			                vec.ptr,
+			                err,
+			                strerror(errno));
 			closesocket(so.sock);
 			so.sock = INVALID_SOCKET;
 			continue;
@@ -13385,40 +14668,42 @@ set_ports_option(struct mg_context *ctx)
 		}
 
 		if ((ptr = (struct socket *)
-		         mg_realloc_ctx(ctx->listening_sockets,
-		                        (ctx->num_listening_sockets + 1)
-		                            * sizeof(ctx->listening_sockets[0]),
-		                        ctx)) == NULL) {
+		         mg_realloc_ctx(phys_ctx->listening_sockets,
+		                        (phys_ctx->num_listening_sockets + 1)
+		                            * sizeof(phys_ctx->listening_sockets[0]),
+		                        phys_ctx))
+		    == NULL) {
 
-			mg_cry(fc(ctx), "%s", "Out of memory");
+			mg_cry_internal(fc(phys_ctx), "%s", "Out of memory");
 			closesocket(so.sock);
 			so.sock = INVALID_SOCKET;
 			continue;
 		}
 
 		if ((pfd = (struct pollfd *)
-		         mg_realloc_ctx(ctx->listening_socket_fds,
-		                        (ctx->num_listening_sockets + 1)
-		                            * sizeof(ctx->listening_socket_fds[0]),
-		                        ctx)) == NULL) {
+		         mg_realloc_ctx(phys_ctx->listening_socket_fds,
+		                        (phys_ctx->num_listening_sockets + 1)
+		                            * sizeof(phys_ctx->listening_socket_fds[0]),
+		                        phys_ctx))
+		    == NULL) {
 
-			mg_cry(fc(ctx), "%s", "Out of memory");
+			mg_cry_internal(fc(phys_ctx), "%s", "Out of memory");
 			closesocket(so.sock);
 			so.sock = INVALID_SOCKET;
 			mg_free(ptr);
 			continue;
 		}
 
-		set_close_on_exec(so.sock, fc(ctx));
-		ctx->listening_sockets = ptr;
-		ctx->listening_sockets[ctx->num_listening_sockets] = so;
-		ctx->listening_socket_fds = pfd;
-		ctx->num_listening_sockets++;
+		set_close_on_exec(so.sock, fc(phys_ctx));
+		phys_ctx->listening_sockets = ptr;
+		phys_ctx->listening_sockets[phys_ctx->num_listening_sockets] = so;
+		phys_ctx->listening_socket_fds = pfd;
+		phys_ctx->num_listening_sockets++;
 		portsOk++;
 	}
 
 	if (portsOk != portsTotal) {
-		close_all_listening_sockets(ctx);
+		close_all_listening_sockets(phys_ctx);
 		portsOk = 0;
 	}
 
@@ -13439,6 +14724,11 @@ header_val(const struct mg_connection *conn, const char *header)
 }
 
 
+#if defined(MG_EXTERNAL_FUNCTION_log_access)
+static void log_access(const struct mg_connection *conn);
+#include "external_log_access.inl"
+#else
+
 static void
 log_access(const struct mg_connection *conn)
 {
@@ -13452,15 +14742,16 @@ log_access(const struct mg_connection *conn)
 
 	char buf[4096];
 
-	if (!conn || !conn->ctx) {
+	if (!conn || !conn->dom_ctx) {
 		return;
 	}
 
-	if (conn->ctx->config[ACCESS_LOG_FILE] != NULL) {
+	if (conn->dom_ctx->config[ACCESS_LOG_FILE] != NULL) {
 		if (mg_fopen(conn,
-		             conn->ctx->config[ACCESS_LOG_FILE],
+		             conn->dom_ctx->config[ACCESS_LOG_FILE],
 		             MG_FOPEN_MODE_APPEND,
-		             &fi) == 0) {
+		             &fi)
+		    == 0) {
 			fi.access.fp = NULL;
 		}
 	} else {
@@ -13469,7 +14760,8 @@ log_access(const struct mg_connection *conn)
 
 	/* Log is written to a file and/or a callback. If both are not set,
 	 * executing the rest of the function is pointless. */
-	if ((fi.access.fp == NULL) && (conn->ctx->callbacks.log_access == NULL)) {
+	if ((fi.access.fp == NULL)
+	    && (conn->phys_ctx->callbacks.log_access == NULL)) {
 		return;
 	}
 
@@ -13505,8 +14797,8 @@ log_access(const struct mg_connection *conn)
 	            referer,
 	            user_agent);
 
-	if (conn->ctx->callbacks.log_access) {
-		conn->ctx->callbacks.log_access(conn, buf);
+	if (conn->phys_ctx->callbacks.log_access) {
+		conn->phys_ctx->callbacks.log_access(conn, buf);
 	}
 
 	if (fi.access.fp) {
@@ -13523,26 +14815,28 @@ log_access(const struct mg_connection *conn)
 			ok = 0;
 		}
 		if (!ok) {
-			mg_cry(conn,
-			       "Error writing log file %s",
-			       conn->ctx->config[ACCESS_LOG_FILE]);
+			mg_cry_internal(conn,
+			                "Error writing log file %s",
+			                conn->dom_ctx->config[ACCESS_LOG_FILE]);
 		}
 	}
 }
+
+#endif /* Externally provided function */
 
 
 /* Verify given socket address against the ACL.
  * Return -1 if ACL is malformed, 0 if address is disallowed, 1 if allowed.
  */
 static int
-check_acl(struct mg_context *ctx, uint32_t remote_ip)
+check_acl(struct mg_context *phys_ctx, uint32_t remote_ip)
 {
 	int allowed, flag;
 	uint32_t net, mask;
 	struct vec vec;
 
-	if (ctx) {
-		const char *list = ctx->config[ACCESS_CONTROL_LIST];
+	if (phys_ctx) {
+		const char *list = phys_ctx->dd.config[ACCESS_CONTROL_LIST];
 
 		/* If any ACL is set, deny by default */
 		allowed = (list == NULL) ? '+' : '-';
@@ -13551,9 +14845,9 @@ check_acl(struct mg_context *ctx, uint32_t remote_ip)
 			flag = vec.ptr[0];
 			if ((flag != '+' && flag != '-')
 			    || (parse_net(&vec.ptr[1], &net, &mask) == 0)) {
-				mg_cry(fc(ctx),
-				       "%s: subnet must be [+|-]x.x.x.x[/x]",
-				       __func__);
+				mg_cry_internal(fc(phys_ctx),
+				                "%s: subnet must be [+|-]x.x.x.x[/x]",
+				                __func__);
 				return -1;
 			}
 
@@ -13570,43 +14864,55 @@ check_acl(struct mg_context *ctx, uint32_t remote_ip)
 
 #if !defined(_WIN32)
 static int
-set_uid_option(struct mg_context *ctx)
+set_uid_option(struct mg_context *phys_ctx)
 {
-	struct passwd *pw;
-	if (ctx) {
-		const char *uid = ctx->config[RUN_AS_USER];
-		int success = 0;
+	int success = 0;
 
-		if (uid == NULL) {
+	if (phys_ctx) {
+		/* We are currently running as curr_uid. */
+		const uid_t curr_uid = getuid();
+		/* If set, we want to run as run_as_user. */
+		const char *run_as_user = phys_ctx->dd.config[RUN_AS_USER];
+		const struct passwd *to_pw = NULL;
+
+		if (run_as_user != NULL && (to_pw = getpwnam(run_as_user)) == NULL) {
+			/* run_as_user does not exist on the system. We can't proceed
+			 * further. */
+			mg_cry_internal(fc(phys_ctx),
+			                "%s: unknown user [%s]",
+			                __func__,
+			                run_as_user);
+		} else if (run_as_user == NULL || curr_uid == to_pw->pw_uid) {
+			/* There was either no request to change user, or we're already
+			 * running as run_as_user. Nothing else to do.
+			 */
 			success = 1;
 		} else {
-			if ((pw = getpwnam(uid)) == NULL) {
-				mg_cry(fc(ctx), "%s: unknown user [%s]", __func__, uid);
-			} else if (setgid(pw->pw_gid) == -1) {
-				mg_cry(fc(ctx),
-				       "%s: setgid(%s): %s",
-				       __func__,
-				       uid,
-				       strerror(errno));
-			} else if (setgroups(0, NULL)) {
-				mg_cry(fc(ctx),
-				       "%s: setgroups(): %s",
-				       __func__,
-				       strerror(errno));
-			} else if (setuid(pw->pw_uid) == -1) {
-				mg_cry(fc(ctx),
-				       "%s: setuid(%s): %s",
-				       __func__,
-				       uid,
-				       strerror(errno));
+			/* Valid change request.  */
+			if (setgid(to_pw->pw_gid) == -1) {
+				mg_cry_internal(fc(phys_ctx),
+				                "%s: setgid(%s): %s",
+				                __func__,
+				                run_as_user,
+				                strerror(errno));
+			} else if (setgroups(0, NULL) == -1) {
+				mg_cry_internal(fc(phys_ctx),
+				                "%s: setgroups(): %s",
+				                __func__,
+				                strerror(errno));
+			} else if (setuid(to_pw->pw_uid) == -1) {
+				mg_cry_internal(fc(phys_ctx),
+				                "%s: setuid(%s): %s",
+				                __func__,
+				                run_as_user,
+				                strerror(errno));
 			} else {
 				success = 1;
 			}
 		}
-
-		return success;
 	}
-	return 0;
+
+	return success;
 }
 #endif /* !_WIN32 */
 
@@ -13629,8 +14935,10 @@ tls_dtor(void *key)
 
 #if !defined(NO_SSL)
 
-static int
-ssl_use_pem_file(struct mg_context *ctx, const char *pem, const char *chain);
+static int ssl_use_pem_file(struct mg_context *phys_ctx,
+                            struct mg_domain_context *dom_ctx,
+                            const char *pem,
+                            const char *chain);
 static const char *ssl_error(void);
 
 
@@ -13647,12 +14955,12 @@ refresh_trust(struct mg_connection *conn)
 	const char *chain;
 	int should_verify_peer;
 
-	if ((pem = conn->ctx->config[SSL_CERTIFICATE]) == NULL) {
-		/* If peem is NULL and conn->ctx->callbacks.init_ssl is not,
+	if ((pem = conn->dom_ctx->config[SSL_CERTIFICATE]) == NULL) {
+		/* If peem is NULL and conn->phys_ctx->callbacks.init_ssl is not,
 		 * refresh_trust still can not work. */
 		return 0;
 	}
-	chain = conn->ctx->config[SSL_CERTIFICATE_CHAIN];
+	chain = conn->dom_ctx->config[SSL_CERTIFICATE_CHAIN];
 	if (chain == NULL) {
 		/* pem is not NULL here */
 		chain = pem;
@@ -13670,35 +14978,39 @@ refresh_trust(struct mg_connection *conn)
 		data_check = t;
 
 		should_verify_peer = 0;
-		if (conn->ctx->config[SSL_DO_VERIFY_PEER] != NULL) {
-			if (mg_strcasecmp(conn->ctx->config[SSL_DO_VERIFY_PEER], "yes")
+		if (conn->dom_ctx->config[SSL_DO_VERIFY_PEER] != NULL) {
+			if (mg_strcasecmp(conn->dom_ctx->config[SSL_DO_VERIFY_PEER], "yes")
 			    == 0) {
 				should_verify_peer = 1;
-			} else if (mg_strcasecmp(conn->ctx->config[SSL_DO_VERIFY_PEER],
-			                         "optional") == 0) {
+			} else if (mg_strcasecmp(conn->dom_ctx->config[SSL_DO_VERIFY_PEER],
+			                         "optional")
+			           == 0) {
 				should_verify_peer = 1;
 			}
 		}
 
 		if (should_verify_peer) {
-			char *ca_path = conn->ctx->config[SSL_CA_PATH];
-			char *ca_file = conn->ctx->config[SSL_CA_FILE];
-			if (SSL_CTX_load_verify_locations(conn->ctx->ssl_ctx,
+			char *ca_path = conn->dom_ctx->config[SSL_CA_PATH];
+			char *ca_file = conn->dom_ctx->config[SSL_CA_FILE];
+			if (SSL_CTX_load_verify_locations(conn->dom_ctx->ssl_ctx,
 			                                  ca_file,
-			                                  ca_path) != 1) {
-				mg_cry(fc(conn->ctx),
-				       "SSL_CTX_load_verify_locations error: %s "
-				       "ssl_verify_peer requires setting "
-				       "either ssl_ca_path or ssl_ca_file. Is any of them "
-				       "present in "
-				       "the .conf file?",
-				       ssl_error());
+			                                  ca_path)
+			    != 1) {
+				mg_cry_internal(
+				    fc(conn->phys_ctx),
+				    "SSL_CTX_load_verify_locations error: %s "
+				    "ssl_verify_peer requires setting "
+				    "either ssl_ca_path or ssl_ca_file. Is any of them "
+				    "present in "
+				    "the .conf file?",
+				    ssl_error());
 				return 0;
 			}
 		}
 
 		if (1 == mg_atomic_inc(p_reload_lock)) {
-			if (ssl_use_pem_file(conn->ctx, pem, chain) == 0) {
+			if (ssl_use_pem_file(conn->phys_ctx, conn->dom_ctx, pem, chain)
+			    == 0) {
 				return 0;
 			}
 			*p_reload_lock = 0;
@@ -13712,7 +15024,7 @@ refresh_trust(struct mg_connection *conn)
 	return 1;
 }
 
-#ifdef OPENSSL_API_1_1
+#if defined(OPENSSL_API_1_1)
 #else
 static pthread_mutex_t *ssl_mutexes;
 #endif /* OPENSSL_API_1_1 */
@@ -13721,7 +15033,8 @@ static int
 sslize(struct mg_connection *conn,
        SSL_CTX *s,
        int (*func)(SSL *),
-       volatile int *stop_server)
+       volatile int *stop_server,
+       const struct mg_client_options *client_options)
 {
 	int ret, err;
 	int short_trust;
@@ -13732,8 +15045,8 @@ sslize(struct mg_connection *conn,
 	}
 
 	short_trust =
-	    (conn->ctx->config[SSL_SHORT_TRUST] != NULL)
-	    && (mg_strcasecmp(conn->ctx->config[SSL_SHORT_TRUST], "yes") == 0);
+	    (conn->dom_ctx->config[SSL_SHORT_TRUST] != NULL)
+	    && (mg_strcasecmp(conn->dom_ctx->config[SSL_SHORT_TRUST], "yes") == 0);
 
 	if (short_trust) {
 		int trust_ret = refresh_trust(conn);
@@ -13751,15 +15064,17 @@ sslize(struct mg_connection *conn,
 	ret = SSL_set_fd(conn->ssl, conn->client.sock);
 	if (ret != 1) {
 		err = SSL_get_error(conn->ssl, ret);
-		(void)err; /* TODO: set some error message */
+		mg_cry_internal(conn, "SSL error %i, destroying SSL context", err);
 		SSL_free(conn->ssl);
 		conn->ssl = NULL;
-/* Avoid CRYPTO_cleanup_all_ex_data(); See discussion:
- * https://wiki.openssl.org/index.php/Talk:Library_Initialization */
-#ifndef OPENSSL_API_1_1
-		ERR_remove_state(0);
-#endif
+		OPENSSL_REMOVE_THREAD_STATE();
 		return 0;
+	}
+
+	if (client_options) {
+		if (client_options->host_name) {
+			SSL_set_tlsext_host_name(conn->ssl, client_options->host_name);
+		}
 	}
 
 	/* SSL functions may fail and require to be called again:
@@ -13771,8 +15086,8 @@ sslize(struct mg_connection *conn,
 			err = SSL_get_error(conn->ssl, ret);
 			if ((err == SSL_ERROR_WANT_CONNECT)
 			    || (err == SSL_ERROR_WANT_ACCEPT)
-			    || (err == SSL_ERROR_WANT_READ)
-			    || (err == SSL_ERROR_WANT_WRITE)) {
+			    || (err == SSL_ERROR_WANT_READ) || (err == SSL_ERROR_WANT_WRITE)
+			    || (err == SSL_ERROR_WANT_X509_LOOKUP)) {
 				/* Need to retry the function call "later".
 				 * See https://linux.die.net/man/3/ssl_get_error
 				 * This is typical for non-blocking sockets. */
@@ -13785,12 +15100,12 @@ sslize(struct mg_connection *conn,
 			} else if (err == SSL_ERROR_SYSCALL) {
 				/* This is an IO error. Look at errno. */
 				err = errno;
-				/* TODO: set some error message */
-				(void)err;
+				mg_cry_internal(conn, "SSL syscall error %i", err);
 				break;
+
 			} else {
-				/* This is an SSL specific error */
-				/* TODO: set some error message */
+				/* This is an SSL specific error, e.g. SSL_ERROR_SSL */
+				mg_cry_internal(conn, "sslize error: %s", ssl_error());
 				break;
 			}
 
@@ -13803,11 +15118,7 @@ sslize(struct mg_connection *conn,
 	if (ret != 1) {
 		SSL_free(conn->ssl);
 		conn->ssl = NULL;
-/* Avoid CRYPTO_cleanup_all_ex_data(); See discussion:
- * https://wiki.openssl.org/index.php/Talk:Library_Initialization */
-#ifndef OPENSSL_API_1_1
-		ERR_remove_state(0);
-#endif
+		OPENSSL_REMOVE_THREAD_STATE();
 		return 0;
 	}
 
@@ -13891,10 +15202,10 @@ ssl_get_client_cert_info(struct mg_connection *conn)
 		/* ASN1_digest is deprecated. Do the calculation manually,
 		 * using EVP_Digest. */
 		ilen = i2d_X509(cert, NULL);
-		tmp_buf =
-		    (ilen > 0)
-		        ? (unsigned char *)mg_malloc_ctx((unsigned)ilen + 1, conn->ctx)
-		        : NULL;
+		tmp_buf = (ilen > 0)
+		              ? (unsigned char *)mg_malloc_ctx((unsigned)ilen + 1,
+		                                               conn->phys_ctx)
+		              : NULL;
 		if (tmp_buf) {
 			tmp_p = tmp_buf;
 			(void)i2d_X509(cert, &tmp_p);
@@ -13911,29 +15222,32 @@ ssl_get_client_cert_info(struct mg_connection *conn)
 		}
 
 		conn->request_info.client_cert = (struct mg_client_cert *)
-		    mg_malloc_ctx(sizeof(struct mg_client_cert), conn->ctx);
+		    mg_malloc_ctx(sizeof(struct mg_client_cert), conn->phys_ctx);
 		if (conn->request_info.client_cert) {
-			conn->request_info.client_cert->subject = mg_strdup(str_subject);
-			conn->request_info.client_cert->issuer = mg_strdup(str_issuer);
-			conn->request_info.client_cert->serial = mg_strdup(str_serial);
-			conn->request_info.client_cert->finger = mg_strdup(str_finger);
+			conn->request_info.client_cert->peer_cert = (void *)cert;
+			conn->request_info.client_cert->subject =
+			    mg_strdup_ctx(str_subject, conn->phys_ctx);
+			conn->request_info.client_cert->issuer =
+			    mg_strdup_ctx(str_issuer, conn->phys_ctx);
+			conn->request_info.client_cert->serial =
+			    mg_strdup_ctx(str_serial, conn->phys_ctx);
+			conn->request_info.client_cert->finger =
+			    mg_strdup_ctx(str_finger, conn->phys_ctx);
 		} else {
-			mg_cry(conn,
-			       "Out of memory: Cannot allocate memory for client "
-			       "certificate");
+			mg_cry_internal(conn,
+			                "%s",
+			                "Out of memory: Cannot allocate memory for client "
+			                "certificate");
 		}
 
 		/* Strings returned from bn_bn2hex must be freed using OPENSSL_free,
 		 * see https://linux.die.net/man/3/bn_bn2hex */
 		OPENSSL_free(str_serial);
-
-		/* Free certificate memory */
-		X509_free(cert);
 	}
 }
 
 
-#ifdef OPENSSL_API_1_1
+#if defined(OPENSSL_API_1_1)
 #else
 static void
 ssl_locking_callback(int mode, int mutex_num, const char *file, int line)
@@ -13977,7 +15291,7 @@ load_dll(char *ebuf, size_t ebuf_len, const char *dll_name, struct ssl_func *sw)
 
 	ok = 1;
 	for (fp = sw; fp->name != NULL; fp++) {
-#ifdef _WIN32
+#if defined(_WIN32)
 		/* GetProcAddress() returns pointer to function */
 		u.fp = (void (*)(void))dlsym(dll_handle, fp->name);
 #else
@@ -14044,7 +15358,7 @@ static int cryptolib_users = 0; /* Reference counter for crypto library. */
 static int
 initialize_ssl(char *ebuf, size_t ebuf_len)
 {
-#ifdef OPENSSL_API_1_1
+#if defined(OPENSSL_API_1_1)
 	if (ebuf_len > 0) {
 		ebuf[0] = 0;
 	}
@@ -14053,6 +15367,14 @@ initialize_ssl(char *ebuf, size_t ebuf_len)
 	if (!cryptolib_dll_handle) {
 		cryptolib_dll_handle = load_dll(ebuf, ebuf_len, CRYPTO_LIB, crypto_sw);
 		if (!cryptolib_dll_handle) {
+			mg_snprintf(NULL,
+			            NULL, /* No truncation check for ebuf */
+			            ebuf,
+			            ebuf_len,
+			            "%s: error loading library %s",
+			            __func__,
+			            CRYPTO_LIB);
+			DEBUG_TRACE("%s", ebuf);
 			return 0;
 		}
 	}
@@ -14063,7 +15385,7 @@ initialize_ssl(char *ebuf, size_t ebuf_len)
 	}
 
 #else /* not OPENSSL_API_1_1 */
-	int i;
+	int i, num_locks;
 	size_t size;
 
 	if (ebuf_len > 0) {
@@ -14074,6 +15396,14 @@ initialize_ssl(char *ebuf, size_t ebuf_len)
 	if (!cryptolib_dll_handle) {
 		cryptolib_dll_handle = load_dll(ebuf, ebuf_len, CRYPTO_LIB, crypto_sw);
 		if (!cryptolib_dll_handle) {
+			mg_snprintf(NULL,
+			            NULL, /* No truncation check for ebuf */
+			            ebuf,
+			            ebuf_len,
+			            "%s: error loading library %s",
+			            __func__,
+			            CRYPTO_LIB);
+			DEBUG_TRACE("%s", ebuf);
 			return 0;
 		}
 	}
@@ -14086,65 +15416,114 @@ initialize_ssl(char *ebuf, size_t ebuf_len)
 	/* Initialize locking callbacks, needed for thread safety.
 	 * http://www.openssl.org/support/faq.html#PROG1
 	 */
-	i = CRYPTO_num_locks();
-	if (i < 0) {
-		i = 0;
+	num_locks = CRYPTO_num_locks();
+	if (num_locks < 0) {
+		num_locks = 0;
 	}
-	size = sizeof(pthread_mutex_t) * ((size_t)(i));
+	size = sizeof(pthread_mutex_t) * ((size_t)(num_locks));
 
-	if (size == 0) {
+	/* allocate mutex array, if required */
+	if (num_locks == 0) {
+		/* No mutex array required */
 		ssl_mutexes = NULL;
-	} else if ((ssl_mutexes = (pthread_mutex_t *)mg_malloc(size)) == NULL) {
-		mg_snprintf(NULL,
-		            NULL, /* No truncation check for ebuf */
-		            ebuf,
-		            ebuf_len,
-		            "%s: cannot allocate mutexes: %s",
-		            __func__,
-		            ssl_error());
+	} else {
+		/* Mutex array required - allocate it */
+		ssl_mutexes = (pthread_mutex_t *)mg_malloc(size);
 
-		return 0;
-	}
+		/* Check OOM */
+		if (ssl_mutexes == NULL) {
+			mg_snprintf(NULL,
+			            NULL, /* No truncation check for ebuf */
+			            ebuf,
+			            ebuf_len,
+			            "%s: cannot allocate mutexes: %s",
+			            __func__,
+			            ssl_error());
+			DEBUG_TRACE("%s", ebuf);
+			return 0;
+		}
 
-	for (i = 0; i < CRYPTO_num_locks(); i++) {
-		pthread_mutex_init(&ssl_mutexes[i], &pthread_mutex_attr);
+		/* initialize mutex array */
+		for (i = 0; i < num_locks; i++) {
+			if (0 != pthread_mutex_init(&ssl_mutexes[i], &pthread_mutex_attr)) {
+				mg_snprintf(NULL,
+				            NULL, /* No truncation check for ebuf */
+				            ebuf,
+				            ebuf_len,
+				            "%s: error initializing mutex %i of %i",
+				            __func__,
+				            i,
+				            num_locks);
+				DEBUG_TRACE("%s", ebuf);
+				mg_free(ssl_mutexes);
+				return 0;
+			}
+		}
 	}
 
 	CRYPTO_set_locking_callback(&ssl_locking_callback);
 	CRYPTO_set_id_callback(&mg_current_thread_id);
 #endif /* OPENSSL_API_1_1 */
 
+#if !defined(NO_SSL_DL)
+	if (!ssllib_dll_handle) {
+		ssllib_dll_handle = load_dll(ebuf, ebuf_len, SSL_LIB, ssl_sw);
+		if (!ssllib_dll_handle) {
+#if !defined(OPENSSL_API_1_1)
+			mg_free(ssl_mutexes);
+#endif
+			DEBUG_TRACE("%s", ebuf);
+			return 0;
+		}
+	}
+#endif /* NO_SSL_DL */
+
+#if defined(OPENSSL_API_1_1)
+	/* Initialize SSL library */
+	OPENSSL_init_ssl(0, NULL);
+	OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS
+	                     | OPENSSL_INIT_LOAD_CRYPTO_STRINGS,
+	                 NULL);
+#else
+	/* Initialize SSL library */
+	SSL_library_init();
+	SSL_load_error_strings();
+#endif
+
 	return 1;
 }
 
 
 static int
-ssl_use_pem_file(struct mg_context *ctx, const char *pem, const char *chain)
+ssl_use_pem_file(struct mg_context *phys_ctx,
+                 struct mg_domain_context *dom_ctx,
+                 const char *pem,
+                 const char *chain)
 {
-	if (SSL_CTX_use_certificate_file(ctx->ssl_ctx, pem, 1) == 0) {
-		mg_cry(fc(ctx),
-		       "%s: cannot open certificate file %s: %s",
-		       __func__,
-		       pem,
-		       ssl_error());
+	if (SSL_CTX_use_certificate_file(dom_ctx->ssl_ctx, pem, 1) == 0) {
+		mg_cry_internal(fc(phys_ctx),
+		                "%s: cannot open certificate file %s: %s",
+		                __func__,
+		                pem,
+		                ssl_error());
 		return 0;
 	}
 
 	/* could use SSL_CTX_set_default_passwd_cb_userdata */
-	if (SSL_CTX_use_PrivateKey_file(ctx->ssl_ctx, pem, 1) == 0) {
-		mg_cry(fc(ctx),
-		       "%s: cannot open private key file %s: %s",
-		       __func__,
-		       pem,
-		       ssl_error());
+	if (SSL_CTX_use_PrivateKey_file(dom_ctx->ssl_ctx, pem, 1) == 0) {
+		mg_cry_internal(fc(phys_ctx),
+		                "%s: cannot open private key file %s: %s",
+		                __func__,
+		                pem,
+		                ssl_error());
 		return 0;
 	}
 
-	if (SSL_CTX_check_private_key(ctx->ssl_ctx) == 0) {
-		mg_cry(fc(ctx),
-		       "%s: certificate and private key do not match: %s",
-		       __func__,
-		       pem);
+	if (SSL_CTX_check_private_key(dom_ctx->ssl_ctx) == 0) {
+		mg_cry_internal(fc(phys_ctx),
+		                "%s: certificate and private key do not match: %s",
+		                __func__,
+		                pem);
 		return 0;
 	}
 
@@ -14157,12 +15536,12 @@ ssl_use_pem_file(struct mg_context *ctx, const char *pem, const char *chain)
 	 * an optional chain file for the ssl stack.
 	 */
 	if (chain) {
-		if (SSL_CTX_use_certificate_chain_file(ctx->ssl_ctx, chain) == 0) {
-			mg_cry(fc(ctx),
-			       "%s: cannot use certificate chain file %s: %s",
-			       __func__,
-			       pem,
-			       ssl_error());
+		if (SSL_CTX_use_certificate_chain_file(dom_ctx->ssl_ctx, chain) == 0) {
+			mg_cry_internal(fc(phys_ctx),
+			                "%s: cannot use certificate chain file %s: %s",
+			                __func__,
+			                pem,
+			                ssl_error());
 			return 0;
 		}
 	}
@@ -14170,11 +15549,11 @@ ssl_use_pem_file(struct mg_context *ctx, const char *pem, const char *chain)
 }
 
 
-#ifdef OPENSSL_API_1_1
+#if defined(OPENSSL_API_1_1)
 static unsigned long
 ssl_get_protocol(int version_id)
 {
-	long unsigned ret = SSL_OP_ALL;
+	long unsigned ret = (long unsigned)SSL_OP_ALL;
 	if (version_id > 0)
 		ret |= SSL_OP_NO_SSLv2;
 	if (version_id > 1)
@@ -14189,7 +15568,7 @@ ssl_get_protocol(int version_id)
 static long
 ssl_get_protocol(int version_id)
 {
-	long ret = SSL_OP_ALL;
+	long ret = (long)SSL_OP_ALL;
 	if (version_id > 0)
 		ret |= SSL_OP_NO_SSLv2;
 	if (version_id > 1)
@@ -14205,14 +15584,21 @@ ssl_get_protocol(int version_id)
 
 /* SSL callback documentation:
  * https://www.openssl.org/docs/man1.1.0/ssl/SSL_set_info_callback.html
+ * https://wiki.openssl.org/index.php/Manual:SSL_CTX_set_info_callback(3)
  * https://linux.die.net/man/3/ssl_set_info_callback */
+/* Note: There is no "const" for the first argument in the documentation
+ * examples, however some (maybe most, but not all) headers of OpenSSL versions
+ * / OpenSSL compatibility layers have it. Having a different definition will
+ * cause a warning in C and an error in C++. Use "const SSL *", while
+ * automatical conversion from "SSL *" works for all compilers, but not other
+ * way around */
 static void
 ssl_info_callback(const SSL *ssl, int what, int ret)
 {
 	(void)ret;
 
 	if (what & SSL_CB_HANDSHAKE_START) {
-		SSL_get_app_data((SSL *)ssl);
+		SSL_get_app_data(ssl);
 	}
 	if (what & SSL_CB_HANDSHAKE_DONE) {
 		/* TODO: check for openSSL 1.1 */
@@ -14222,12 +15608,78 @@ ssl_info_callback(const SSL *ssl, int what, int ret)
 }
 
 
-/* Dynamically load SSL library. Set up ctx->ssl_ctx pointer. */
 static int
-set_ssl_option(struct mg_context *ctx)
+ssl_servername_callback(SSL *ssl, int *ad, void *arg)
 {
-	const char *pem;
-	const char *chain;
+	struct mg_context *ctx = (struct mg_context *)arg;
+	struct mg_domain_context *dom =
+	    (struct mg_domain_context *)ctx ? &(ctx->dd) : NULL;
+
+#if defined(GCC_DIAGNOSTIC)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-align"
+#endif /* defined(GCC_DIAGNOSTIC) */
+
+	/* We used an aligned pointer in SSL_set_app_data */
+	struct mg_connection *conn = (struct mg_connection *)SSL_get_app_data(ssl);
+
+#if defined(GCC_DIAGNOSTIC)
+#pragma GCC diagnostic pop
+#endif /* defined(GCC_DIAGNOSTIC) */
+
+	const char *servername = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
+
+	(void)ad;
+
+	if ((ctx == NULL) || (conn->phys_ctx == ctx)) {
+		DEBUG_TRACE("%s", "internal error - assertion failed");
+		return SSL_TLSEXT_ERR_NOACK;
+	}
+
+	/* Old clients (Win XP) will not support SNI. Then, there
+	 * is no server name available in the request - we can
+	 * only work with the default certificate.
+	 * Multiple HTTPS hosts on one IP+port are only possible
+	 * with a certificate containing all alternative names.
+	 */
+	if ((servername == NULL) || (*servername == 0)) {
+		DEBUG_TRACE("%s", "SSL connection not supporting SNI");
+		conn->dom_ctx = &(ctx->dd);
+		SSL_set_SSL_CTX(ssl, conn->dom_ctx->ssl_ctx);
+		return SSL_TLSEXT_ERR_NOACK;
+	}
+
+	DEBUG_TRACE("TLS connection to host %s", servername);
+
+	while (dom) {
+		if (!mg_strcasecmp(servername, dom->config[AUTHENTICATION_DOMAIN])) {
+
+			/* Found matching domain */
+			DEBUG_TRACE("TLS domain %s found",
+			            dom->config[AUTHENTICATION_DOMAIN]);
+			SSL_set_SSL_CTX(ssl, dom->ssl_ctx);
+			conn->dom_ctx = dom;
+			return SSL_TLSEXT_ERR_OK;
+		}
+		dom = dom->next;
+	}
+
+	/* Default domain */
+	DEBUG_TRACE("TLS default domain %s used",
+	            ctx->dd.config[AUTHENTICATION_DOMAIN]);
+	conn->dom_ctx = &(ctx->dd);
+	SSL_set_SSL_CTX(ssl, conn->dom_ctx->ssl_ctx);
+	return SSL_TLSEXT_ERR_OK;
+}
+
+
+/* Setup SSL CTX as required by CivetWeb */
+static int
+init_ssl_ctx_impl(struct mg_context *phys_ctx,
+                  struct mg_domain_context *dom_ctx,
+                  const char *pem,
+                  const char *chain)
+{
 	int callback_ret;
 	int should_verify_peer;
 	int peer_certificate_optional;
@@ -14235,132 +15687,101 @@ set_ssl_option(struct mg_context *ctx)
 	const char *ca_file;
 	int use_default_verify_paths;
 	int verify_depth;
-	time_t now_rt = time(NULL);
 	struct timespec now_mt;
 	md5_byte_t ssl_context_id[16];
 	md5_state_t md5state;
 	int protocol_ver;
-	char ebuf[128];
 
-	/* If PEM file is not specified and the init_ssl callback
-	 * is not specified, skip SSL initialization. */
-	if (!ctx) {
-		return 0;
-	}
-	if ((pem = ctx->config[SSL_CERTIFICATE]) == NULL
-	    && ctx->callbacks.init_ssl == NULL) {
-		return 1;
-	}
-	chain = ctx->config[SSL_CERTIFICATE_CHAIN];
-	if (chain == NULL) {
-		chain = pem;
-	}
-	if ((chain != NULL) && (*chain == 0)) {
-		chain = NULL;
-	}
-
-	if (!initialize_ssl(ebuf, sizeof(ebuf))) {
-		mg_cry(fc(ctx), "%s", ebuf);
-		return 0;
-	}
-
-#if !defined(NO_SSL_DL)
-	if (!ssllib_dll_handle) {
-		ssllib_dll_handle = load_dll(ebuf, sizeof(ebuf), SSL_LIB, ssl_sw);
-		if (!ssllib_dll_handle) {
-			mg_cry(fc(ctx), "%s", ebuf);
-			return 0;
-		}
-	}
-#endif /* NO_SSL_DL */
-
-#ifdef OPENSSL_API_1_1
-	/* Initialize SSL library */
-	OPENSSL_init_ssl(0, NULL);
-	OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS
-	                     | OPENSSL_INIT_LOAD_CRYPTO_STRINGS,
-	                 NULL);
-
-	if ((ctx->ssl_ctx = SSL_CTX_new(TLS_server_method())) == NULL) {
-		mg_cry(fc(ctx), "SSL_CTX_new (server) error: %s", ssl_error());
+#if defined(OPENSSL_API_1_1)
+	if ((dom_ctx->ssl_ctx = SSL_CTX_new(TLS_server_method())) == NULL) {
+		mg_cry_internal(fc(phys_ctx),
+		                "SSL_CTX_new (server) error: %s",
+		                ssl_error());
 		return 0;
 	}
 #else
-	/* Initialize SSL library */
-	SSL_library_init();
-	SSL_load_error_strings();
-
-	if ((ctx->ssl_ctx = SSL_CTX_new(SSLv23_server_method())) == NULL) {
-		mg_cry(fc(ctx), "SSL_CTX_new (server) error: %s", ssl_error());
+	if ((dom_ctx->ssl_ctx = SSL_CTX_new(SSLv23_server_method())) == NULL) {
+		mg_cry_internal(fc(phys_ctx),
+		                "SSL_CTX_new (server) error: %s",
+		                ssl_error());
 		return 0;
 	}
 #endif /* OPENSSL_API_1_1 */
 
-	SSL_CTX_clear_options(ctx->ssl_ctx,
+	SSL_CTX_clear_options(dom_ctx->ssl_ctx,
 	                      SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1
 	                          | SSL_OP_NO_TLSv1_1);
-	protocol_ver = atoi(ctx->config[SSL_PROTOCOL_VERSION]);
-	SSL_CTX_set_options(ctx->ssl_ctx, ssl_get_protocol(protocol_ver));
-	SSL_CTX_set_options(ctx->ssl_ctx, SSL_OP_SINGLE_DH_USE);
-	SSL_CTX_set_options(ctx->ssl_ctx, SSL_OP_CIPHER_SERVER_PREFERENCE);
-	SSL_CTX_set_options(ctx->ssl_ctx,
+	protocol_ver = atoi(dom_ctx->config[SSL_PROTOCOL_VERSION]);
+	SSL_CTX_set_options(dom_ctx->ssl_ctx, ssl_get_protocol(protocol_ver));
+	SSL_CTX_set_options(dom_ctx->ssl_ctx, SSL_OP_SINGLE_DH_USE);
+	SSL_CTX_set_options(dom_ctx->ssl_ctx, SSL_OP_CIPHER_SERVER_PREFERENCE);
+	SSL_CTX_set_options(dom_ctx->ssl_ctx,
 	                    SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION);
-	SSL_CTX_set_options(ctx->ssl_ctx, SSL_OP_NO_COMPRESSION);
+	SSL_CTX_set_options(dom_ctx->ssl_ctx, SSL_OP_NO_COMPRESSION);
 #if !defined(NO_SSL_DL)
-	SSL_CTX_set_ecdh_auto(ctx->ssl_ctx, 1);
+	SSL_CTX_set_ecdh_auto(dom_ctx->ssl_ctx, 1);
 #endif /* NO_SSL_DL */
 
-	/* Depending on the OpenSSL version, the callback may be
-	 * 'void (*)(SSL *, int, int)' or 'void (*)(const SSL *, int, int)'
-	 * yielding in an "incompatible-pointer-type" warning for the other
-	 * version. It seems to be "unclear" what is correct:
-	 * https://bugs.launchpad.net/ubuntu/+source/openssl/+bug/1147526
+	/* In SSL documentation examples callback defined without const specifier
+	 * 'void (*)(SSL *, int, int)'   See:
 	 * https://www.openssl.org/docs/man1.0.2/ssl/ssl.html
 	 * https://www.openssl.org/docs/man1.1.0/ssl/ssl.html
+	 * But in the source code const SSL is used:
+	 * 'void (*)(const SSL *, int, int)' See:
 	 * https://github.com/openssl/openssl/blob/1d97c8435171a7af575f73c526d79e1ef0ee5960/ssl/ssl.h#L1173
-	 * Disable this warning here.
-	 * Alternative would be a version dependent ssl_info_callback and
-	 * a const-cast to call 'char *SSL_get_app_data(SSL *ssl)' there.
+	 * Problem about wrong documentation described, but not resolved:
+	 * https://bugs.launchpad.net/ubuntu/+source/openssl/+bug/1147526
+	 * Wrong const cast ignored on C or can be suppressed by compiler flags.
+	 * But when compiled with modern C++ compiler, correct const should be
+	 * provided
 	 */
-	SSL_CTX_set_info_callback(ctx->ssl_ctx, ssl_info_callback);
+	SSL_CTX_set_info_callback(dom_ctx->ssl_ctx, ssl_info_callback);
+
+	SSL_CTX_set_tlsext_servername_callback(dom_ctx->ssl_ctx,
+	                                       ssl_servername_callback);
+	SSL_CTX_set_tlsext_servername_arg(dom_ctx->ssl_ctx, phys_ctx);
 
 	/* If a callback has been specified, call it. */
-	callback_ret =
-	    (ctx->callbacks.init_ssl == NULL)
-	        ? 0
-	        : (ctx->callbacks.init_ssl(ctx->ssl_ctx, ctx->user_data));
+	callback_ret = (phys_ctx->callbacks.init_ssl == NULL)
+	                   ? 0
+	                   : (phys_ctx->callbacks.init_ssl(dom_ctx->ssl_ctx,
+	                                                   phys_ctx->user_data));
 
 	/* If callback returns 0, civetweb sets up the SSL certificate.
 	 * If it returns 1, civetweb assumes the calback already did this.
 	 * If it returns -1, initializing ssl fails. */
 	if (callback_ret < 0) {
-		mg_cry(fc(ctx), "SSL callback returned error: %i", callback_ret);
+		mg_cry_internal(fc(phys_ctx),
+		                "SSL callback returned error: %i",
+		                callback_ret);
 		return 0;
 	}
 	if (callback_ret > 0) {
-		if (pem != NULL) {
-			(void)SSL_CTX_use_certificate_chain_file(ctx->ssl_ctx, pem);
-		}
+		/* Callback did everything. */
 		return 1;
 	}
 
-	/* Use some UID as session context ID. */
+	/* Use some combination of start time, domain and port as a SSL
+	 * context ID. This should be unique on the current machine. */
 	md5_init(&md5state);
-	md5_append(&md5state, (const md5_byte_t *)&now_rt, sizeof(now_rt));
 	clock_gettime(CLOCK_MONOTONIC, &now_mt);
 	md5_append(&md5state, (const md5_byte_t *)&now_mt, sizeof(now_mt));
 	md5_append(&md5state,
-	           (const md5_byte_t *)ctx->config[LISTENING_PORTS],
-	           strlen(ctx->config[LISTENING_PORTS]));
-	md5_append(&md5state, (const md5_byte_t *)ctx, sizeof(*ctx));
+	           (const md5_byte_t *)phys_ctx->dd.config[LISTENING_PORTS],
+	           strlen(phys_ctx->dd.config[LISTENING_PORTS]));
+	md5_append(&md5state,
+	           (const md5_byte_t *)dom_ctx->config[AUTHENTICATION_DOMAIN],
+	           strlen(dom_ctx->config[AUTHENTICATION_DOMAIN]));
+	md5_append(&md5state, (const md5_byte_t *)phys_ctx, sizeof(*phys_ctx));
+	md5_append(&md5state, (const md5_byte_t *)dom_ctx, sizeof(*dom_ctx));
 	md5_finish(&md5state, ssl_context_id);
 
-	SSL_CTX_set_session_id_context(ctx->ssl_ctx,
-	                               (const unsigned char *)&ssl_context_id,
+	SSL_CTX_set_session_id_context(dom_ctx->ssl_ctx,
+	                               (unsigned char *)ssl_context_id,
 	                               sizeof(ssl_context_id));
 
 	if (pem != NULL) {
-		if (!ssl_use_pem_file(ctx, pem, chain)) {
+		if (!ssl_use_pem_file(phys_ctx, dom_ctx, pem, chain)) {
 			return 0;
 		}
 	}
@@ -14369,12 +15790,13 @@ set_ssl_option(struct mg_context *ctx)
 	/* Default is "no". */
 	should_verify_peer = 0;
 	peer_certificate_optional = 0;
-	if (ctx->config[SSL_DO_VERIFY_PEER] != NULL) {
-		if (mg_strcasecmp(ctx->config[SSL_DO_VERIFY_PEER], "yes") == 0) {
+	if (dom_ctx->config[SSL_DO_VERIFY_PEER] != NULL) {
+		if (mg_strcasecmp(dom_ctx->config[SSL_DO_VERIFY_PEER], "yes") == 0) {
 			/* Yes, they are mandatory */
 			should_verify_peer = 1;
 			peer_certificate_optional = 0;
-		} else if (mg_strcasecmp(ctx->config[SSL_DO_VERIFY_PEER], "optional")
+		} else if (mg_strcasecmp(dom_ctx->config[SSL_DO_VERIFY_PEER],
+		                         "optional")
 		           == 0) {
 			/* Yes, they are optional */
 			should_verify_peer = 1;
@@ -14383,51 +15805,55 @@ set_ssl_option(struct mg_context *ctx)
 	}
 
 	use_default_verify_paths =
-	    (ctx->config[SSL_DEFAULT_VERIFY_PATHS] != NULL)
-	    && (mg_strcasecmp(ctx->config[SSL_DEFAULT_VERIFY_PATHS], "yes") == 0);
+	    (dom_ctx->config[SSL_DEFAULT_VERIFY_PATHS] != NULL)
+	    && (mg_strcasecmp(dom_ctx->config[SSL_DEFAULT_VERIFY_PATHS], "yes")
+	        == 0);
 
 	if (should_verify_peer) {
-		ca_path = ctx->config[SSL_CA_PATH];
-		ca_file = ctx->config[SSL_CA_FILE];
-		if (SSL_CTX_load_verify_locations(ctx->ssl_ctx, ca_file, ca_path)
+		ca_path = dom_ctx->config[SSL_CA_PATH];
+		ca_file = dom_ctx->config[SSL_CA_FILE];
+		if (SSL_CTX_load_verify_locations(dom_ctx->ssl_ctx, ca_file, ca_path)
 		    != 1) {
-			mg_cry(fc(ctx),
-			       "SSL_CTX_load_verify_locations error: %s "
-			       "ssl_verify_peer requires setting "
-			       "either ssl_ca_path or ssl_ca_file. Is any of them "
-			       "present in "
-			       "the .conf file?",
-			       ssl_error());
+			mg_cry_internal(fc(phys_ctx),
+			                "SSL_CTX_load_verify_locations error: %s "
+			                "ssl_verify_peer requires setting "
+			                "either ssl_ca_path or ssl_ca_file. "
+			                "Is any of them present in the "
+			                ".conf file?",
+			                ssl_error());
 			return 0;
 		}
 
 		if (peer_certificate_optional) {
-			SSL_CTX_set_verify(ctx->ssl_ctx, SSL_VERIFY_PEER, NULL);
+			SSL_CTX_set_verify(dom_ctx->ssl_ctx, SSL_VERIFY_PEER, NULL);
 		} else {
-			SSL_CTX_set_verify(ctx->ssl_ctx,
+			SSL_CTX_set_verify(dom_ctx->ssl_ctx,
 			                   SSL_VERIFY_PEER
 			                       | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
 			                   NULL);
 		}
 
 		if (use_default_verify_paths
-		    && (SSL_CTX_set_default_verify_paths(ctx->ssl_ctx) != 1)) {
-			mg_cry(fc(ctx),
-			       "SSL_CTX_set_default_verify_paths error: %s",
-			       ssl_error());
+		    && (SSL_CTX_set_default_verify_paths(dom_ctx->ssl_ctx) != 1)) {
+			mg_cry_internal(fc(phys_ctx),
+			                "SSL_CTX_set_default_verify_paths error: %s",
+			                ssl_error());
 			return 0;
 		}
 
-		if (ctx->config[SSL_VERIFY_DEPTH]) {
-			verify_depth = atoi(ctx->config[SSL_VERIFY_DEPTH]);
-			SSL_CTX_set_verify_depth(ctx->ssl_ctx, verify_depth);
+		if (dom_ctx->config[SSL_VERIFY_DEPTH]) {
+			verify_depth = atoi(dom_ctx->config[SSL_VERIFY_DEPTH]);
+			SSL_CTX_set_verify_depth(dom_ctx->ssl_ctx, verify_depth);
 		}
 	}
 
-	if (ctx->config[SSL_CIPHER_LIST] != NULL) {
-		if (SSL_CTX_set_cipher_list(ctx->ssl_ctx, ctx->config[SSL_CIPHER_LIST])
+	if (dom_ctx->config[SSL_CIPHER_LIST] != NULL) {
+		if (SSL_CTX_set_cipher_list(dom_ctx->ssl_ctx,
+		                            dom_ctx->config[SSL_CIPHER_LIST])
 		    != 1) {
-			mg_cry(fc(ctx), "SSL_CTX_set_cipher_list error: %s", ssl_error());
+			mg_cry_internal(fc(phys_ctx),
+			                "SSL_CTX_set_cipher_list error: %s",
+			                ssl_error());
 		}
 	}
 
@@ -14435,10 +15861,88 @@ set_ssl_option(struct mg_context *ctx)
 }
 
 
+/* Check if SSL is required.
+ * If so, dynamically load SSL library
+ * and set up ctx->ssl_ctx pointer. */
+static int
+init_ssl_ctx(struct mg_context *phys_ctx, struct mg_domain_context *dom_ctx)
+{
+	void *ssl_ctx = 0;
+	int callback_ret;
+	const char *pem;
+	const char *chain;
+	char ebuf[128];
+
+	if (!phys_ctx) {
+		return 0;
+	}
+
+	if (!dom_ctx) {
+		dom_ctx = &(phys_ctx->dd);
+	}
+
+	if (!is_ssl_port_used(dom_ctx->config[LISTENING_PORTS])) {
+		/* No SSL port is set. No need to setup SSL. */
+		return 1;
+	}
+
+	/* Check for external SSL_CTX */
+	callback_ret =
+	    (phys_ctx->callbacks.external_ssl_ctx == NULL)
+	        ? 0
+	        : (phys_ctx->callbacks.external_ssl_ctx(&ssl_ctx,
+	                                                phys_ctx->user_data));
+
+	if (callback_ret < 0) {
+		mg_cry_internal(fc(phys_ctx),
+		                "external_ssl_ctx callback returned error: %i",
+		                callback_ret);
+		return 0;
+	} else if (callback_ret > 0) {
+		dom_ctx->ssl_ctx = (SSL_CTX *)ssl_ctx;
+		if (!initialize_ssl(ebuf, sizeof(ebuf))) {
+			mg_cry_internal(fc(phys_ctx), "%s", ebuf);
+			return 0;
+		}
+		return 1;
+	}
+	/* else: external_ssl_ctx does not exist or returns 0,
+	 * CivetWeb should continue initializing SSL */
+
+	/* If PEM file is not specified and the init_ssl callback
+	 * is not specified, setup will fail. */
+	if (((pem = dom_ctx->config[SSL_CERTIFICATE]) == NULL)
+	    && (phys_ctx->callbacks.init_ssl == NULL)) {
+		/* No certificate and no callback:
+		 * Essential data to set up TLS is missing.
+		 */
+		mg_cry_internal(fc(phys_ctx),
+		                "Initializing SSL failed: -%s is not set",
+		                config_options[SSL_CERTIFICATE].name);
+		return 0;
+	}
+
+	chain = dom_ctx->config[SSL_CERTIFICATE_CHAIN];
+	if (chain == NULL) {
+		chain = pem;
+	}
+	if ((chain != NULL) && (*chain == 0)) {
+		chain = NULL;
+	}
+
+	if (!initialize_ssl(ebuf, sizeof(ebuf))) {
+		mg_cry_internal(fc(phys_ctx), "%s", ebuf);
+		return 0;
+	}
+
+	return init_ssl_ctx_impl(phys_ctx, dom_ctx, pem, chain);
+}
+
+
 static void
 uninitialize_ssl(void)
 {
-#ifdef OPENSSL_API_1_1
+#if defined(OPENSSL_API_1_1)
 
 	if (mg_atomic_dec(&cryptolib_users) == 0) {
 
@@ -14463,7 +15967,7 @@ uninitialize_ssl(void)
 		ERR_free_strings();
 		EVP_cleanup();
 		CRYPTO_cleanup_all_ex_data();
-		ERR_remove_state(0);
+		OPENSSL_REMOVE_THREAD_STATE();
 
 		for (i = 0; i < CRYPTO_num_locks(); i++) {
 			pthread_mutex_destroy(&ssl_mutexes[i]);
@@ -14477,13 +15981,20 @@ uninitialize_ssl(void)
 
 
 static int
-set_gpass_option(struct mg_context *ctx)
+set_gpass_option(struct mg_context *phys_ctx, struct mg_domain_context *dom_ctx)
 {
-	if (ctx) {
+	if (phys_ctx) {
 		struct mg_file file = STRUCT_FILE_INITIALIZER;
-		const char *path = ctx->config[GLOBAL_PASSWORDS_FILE];
-		if ((path != NULL) && !mg_stat(fc(ctx), path, &file.stat)) {
-			mg_cry(fc(ctx), "Cannot open %s: %s", path, strerror(ERRNO));
+		const char *path;
+		if (!dom_ctx) {
+			dom_ctx = &(phys_ctx->dd);
+		}
+		path = dom_ctx->config[GLOBAL_PASSWORDS_FILE];
+		if ((path != NULL) && !mg_stat(fc(phys_ctx), path, &file.stat)) {
+			mg_cry_internal(fc(phys_ctx),
+			                "Cannot open %s: %s",
+			                path,
+			                strerror(ERRNO));
 			return 0;
 		}
 		return 1;
@@ -14493,9 +16004,9 @@ set_gpass_option(struct mg_context *ctx)
 
 
 static int
-set_acl_option(struct mg_context *ctx)
+set_acl_option(struct mg_context *phys_ctx)
 {
-	return check_acl(ctx, (uint32_t)0x7f000001UL) != -1;
+	return check_acl(phys_ctx, (uint32_t)0x7f000001UL) != -1;
 }
 
 
@@ -14550,7 +16061,7 @@ set_sock_timeout(SOCKET sock, int milliseconds)
 {
         int r0 = 0, r1, r2;
 
-#ifdef _WIN32
+#if defined(_WIN32)
         /* Windows specific */
 
         DWORD tv = (DWORD)milliseconds;
@@ -14595,7 +16106,8 @@ set_tcp_nodelay(SOCKET sock, int nodelay_on)
 	               IPPROTO_TCP,
 	               TCP_NODELAY,
 	               (SOCK_OPT_TYPE)&nodelay_on,
-	               sizeof(nodelay_on)) != 0) {
+	               sizeof(nodelay_on))
+	    != 0) {
 		/* Error */
 		return 1;
 	}
@@ -14641,8 +16153,8 @@ close_socket_gracefully(struct mg_connection *conn)
 	} while (n > 0);
 #endif
 
-	if (conn->ctx->config[LINGER_TIMEOUT]) {
-		linger_timeout = atoi(conn->ctx->config[LINGER_TIMEOUT]);
+	if (conn->dom_ctx->config[LINGER_TIMEOUT]) {
+		linger_timeout = atoi(conn->dom_ctx->config[LINGER_TIMEOUT]);
 	}
 
 	/* Set linger option according to configuration */
@@ -14655,7 +16167,7 @@ close_socket_gracefully(struct mg_connection *conn)
 #pragma warning(push)
 #pragma warning(disable : 4244)
 #endif
-#if defined(__GNUC__) || defined(__MINGW32__)
+#if defined(GCC_DIAGNOSTIC)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #endif
@@ -14665,7 +16177,7 @@ close_socket_gracefully(struct mg_connection *conn)
 
 		linger.l_linger = (linger_timeout + 999) / 1000;
 
-#if defined(__GNUC__) || defined(__MINGW32__)
+#if defined(GCC_DIAGNOSTIC)
 #pragma GCC diagnostic pop
 #endif
 #if defined(_MSC_VER)
@@ -14682,15 +16194,20 @@ close_socket_gracefully(struct mg_connection *conn)
 	} else if (getsockopt(conn->client.sock,
 	                      SOL_SOCKET,
 	                      SO_ERROR,
+#if defined(_WIN32) /* WinSock uses different data type here */
 	                      (char *)&error_code,
-	                      &opt_len) != 0) {
+#else
+	                      &error_code,
+#endif
+	                      &opt_len)
+	           != 0) {
 		/* Cannot determine if socket is already closed. This should
 		 * not occur and never did in a test. Log an error message
 		 * and continue. */
-		mg_cry(conn,
-		       "%s: getsockopt(SOL_SOCKET SO_ERROR) failed: %s",
-		       __func__,
-		       strerror(ERRNO));
+		mg_cry_internal(conn,
+		                "%s: getsockopt(SOL_SOCKET SO_ERROR) failed: %s",
+		                __func__,
+		                strerror(ERRNO));
 	} else if (error_code == ECONNRESET) {
 		/* Socket already closed by client/peer, close socket without linger
 		 */
@@ -14701,13 +16218,15 @@ close_socket_gracefully(struct mg_connection *conn)
 		               SOL_SOCKET,
 		               SO_LINGER,
 		               (char *)&linger,
-		               sizeof(linger)) != 0) {
-			mg_cry(conn,
-			       "%s: setsockopt(SOL_SOCKET SO_LINGER(%i,%i)) failed: %s",
-			       __func__,
-			       linger.l_onoff,
-			       linger.l_linger,
-			       strerror(ERRNO));
+		               sizeof(linger))
+		    != 0) {
+			mg_cry_internal(
+			    conn,
+			    "%s: setsockopt(SOL_SOCKET SO_LINGER(%i,%i)) failed: %s",
+			    __func__,
+			    linger.l_onoff,
+			    linger.l_linger,
+			    strerror(ERRNO));
 		}
 	}
 
@@ -14737,9 +16256,9 @@ close_connection(struct mg_connection *conn)
 	conn->must_close = 1;
 
 	/* call the connection_close callback if assigned */
-	if (conn->ctx->callbacks.connection_close != NULL) {
-		if (conn->ctx->context_type == CONTEXT_SERVER) {
-			conn->ctx->callbacks.connection_close(conn);
+	if (conn->phys_ctx->callbacks.connection_close != NULL) {
+		if (conn->phys_ctx->context_type == CONTEXT_SERVER) {
+			conn->phys_ctx->callbacks.connection_close(conn);
 		}
 	}
 
@@ -14753,23 +16272,24 @@ close_connection(struct mg_connection *conn)
 	conn->conn_state = 7; /* closing */
 #endif
 
-#ifndef NO_SSL
+#if !defined(NO_SSL)
 	if (conn->ssl != NULL) {
-		/* Run SSL_shutdown twice to ensure completly close SSL connection
+		/* Run SSL_shutdown twice to ensure completely close SSL connection
 		 */
 		SSL_shutdown(conn->ssl);
 		SSL_free(conn->ssl);
-/* Avoid CRYPTO_cleanup_all_ex_data(); See discussion:
- * https://wiki.openssl.org/index.php/Talk:Library_Initialization */
-#ifndef OPENSSL_API_1_1
-		ERR_remove_state(0);
-#endif
+		OPENSSL_REMOVE_THREAD_STATE();
 		conn->ssl = NULL;
 	}
 #endif
 	if (conn->client.sock != INVALID_SOCKET) {
 		close_socket_gracefully(conn);
 		conn->client.sock = INVALID_SOCKET;
+	}
+
+	if (conn->host) {
+		mg_free((void *)conn->host);
+		conn->host = NULL;
 	}
 
 	mg_unlock_connection(conn);
@@ -14787,27 +16307,27 @@ mg_close_connection(struct mg_connection *conn)
 	struct mg_context *client_ctx = NULL;
 #endif /* defined(USE_WEBSOCKET) */
 
-	if ((conn == NULL) || (conn->ctx == NULL)) {
+	if ((conn == NULL) || (conn->phys_ctx == NULL)) {
 		return;
 	}
 
 #if defined(USE_WEBSOCKET)
-	if (conn->ctx->context_type == CONTEXT_SERVER) {
+	if (conn->phys_ctx->context_type == CONTEXT_SERVER) {
 		if (conn->in_websocket_handling) {
 			/* Set close flag, so the server thread can exit. */
 			conn->must_close = 1;
 			return;
 		}
 	}
-	if (conn->ctx->context_type == CONTEXT_WS_CLIENT) {
+	if (conn->phys_ctx->context_type == CONTEXT_WS_CLIENT) {
 
 		unsigned int i;
 
 		/* ws/wss client */
-		client_ctx = conn->ctx;
+		client_ctx = conn->phys_ctx;
 
 		/* client context: loops must end */
-		conn->ctx->stop_flag = 1;
+		client_ctx->stop_flag = 1;
 		conn->must_close = 1;
 
 		/* We need to get the client thread out of the select/recv call
@@ -14826,7 +16346,7 @@ mg_close_connection(struct mg_connection *conn)
 
 	close_connection(conn);
 
-#ifndef NO_SSL
+#if !defined(NO_SSL)
 	if (conn->client_ssl_ctx != NULL) {
 		SSL_CTX_free((SSL_CTX *)conn->client_ssl_ctx);
 	}
@@ -14839,11 +16359,11 @@ mg_close_connection(struct mg_connection *conn)
 		mg_free(client_ctx);
 		(void)pthread_mutex_destroy(&conn->mutex);
 		mg_free(conn);
-	} else if (conn->ctx->context_type == CONTEXT_HTTP_CLIENT) {
+	} else if (conn->phys_ctx->context_type == CONTEXT_HTTP_CLIENT) {
 		mg_free(conn);
 	}
 #else
-	if (conn->ctx->context_type == CONTEXT_HTTP_CLIENT) { /* Client */
+	if (conn->phys_ctx->context_type == CONTEXT_HTTP_CLIENT) { /* Client */
 		mg_free(conn);
 	}
 #endif /* defined(USE_WEBSOCKET) */
@@ -14873,10 +16393,8 @@ mg_connect_client_impl(const struct mg_client_options *client_options,
 	size_t conn_size = ((sizeof(struct mg_connection) + 7) >> 3) << 3;
 	size_t ctx_size = ((sizeof(struct mg_context) + 7) >> 3) << 3;
 
-	conn = (struct mg_connection *)mg_calloc_ctx(1,
-	                                             conn_size + ctx_size
-	                                                 + max_req_size,
-	                                             &common_client_context);
+	conn = (struct mg_connection *)mg_calloc_ctx(
+	    1, conn_size + ctx_size + max_req_size, &common_client_context);
 
 	if (conn == NULL) {
 		mg_snprintf(NULL,
@@ -14888,10 +16406,22 @@ mg_connect_client_impl(const struct mg_client_options *client_options,
 		return NULL;
 	}
 
-	conn->ctx = (struct mg_context *)(((char *)conn) + conn_size);
+#if defined(GCC_DIAGNOSTIC)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-align"
+#endif /* defined(GCC_DIAGNOSTIC) */
+	/* conn_size is aligned to 8 bytes */
+
+	conn->phys_ctx = (struct mg_context *)(((char *)conn) + conn_size);
+
+#if defined(GCC_DIAGNOSTIC)
+#pragma GCC diagnostic pop
+#endif /* defined(GCC_DIAGNOSTIC) */
+
 	conn->buf = (((char *)conn) + conn_size + ctx_size);
 	conn->buf_size = (int)max_req_size;
-	conn->ctx->context_type = CONTEXT_HTTP_CLIENT;
+	conn->phys_ctx->context_type = CONTEXT_HTTP_CLIENT;
+	conn->dom_ctx = &(conn->phys_ctx->dd);
 
 	if (!connect_socket(&common_client_context,
 	                    client_options->host,
@@ -14907,8 +16437,8 @@ mg_connect_client_impl(const struct mg_client_options *client_options,
 		return NULL;
 	}
 
-#ifndef NO_SSL
-#ifdef OPENSSL_API_1_1
+#if !defined(NO_SSL)
+#if defined(OPENSSL_API_1_1)
 	if (use_ssl
 	    && (conn->client_ssl_ctx = SSL_CTX_new(TLS_client_method())) == NULL) {
 		mg_snprintf(NULL,
@@ -14937,7 +16467,7 @@ mg_connect_client_impl(const struct mg_client_options *client_options,
 #endif /* NO_SSL */
 
 
-#ifdef USE_IPV6
+#if defined(USE_IPV6)
 	len = (sa.sa.sa_family == AF_INET) ? sizeof(conn->client.rsa.sin)
 	                                   : sizeof(conn->client.rsa.sin6);
 	psa = (sa.sa.sa_family == AF_INET)
@@ -14952,15 +16482,31 @@ mg_connect_client_impl(const struct mg_client_options *client_options,
 	conn->client.lsa = sa;
 
 	if (getsockname(sock, psa, &len) != 0) {
-		mg_cry(conn, "%s: getsockname() failed: %s", __func__, strerror(ERRNO));
+		mg_cry_internal(conn,
+		                "%s: getsockname() failed: %s",
+		                __func__,
+		                strerror(ERRNO));
 	}
 
 	conn->client.is_ssl = use_ssl ? 1 : 0;
-	(void)pthread_mutex_init(&conn->mutex, &pthread_mutex_attr);
+	if (0 != pthread_mutex_init(&conn->mutex, &pthread_mutex_attr)) {
+		mg_snprintf(NULL,
+		            NULL, /* No truncation check for ebuf */
+		            ebuf,
+		            ebuf_len,
+		            "Can not create mutex");
+#if !defined(NO_SSL)
+		SSL_CTX_free(conn->client_ssl_ctx);
+#endif
+		closesocket(sock);
+		mg_free(conn);
+		return NULL;
+	}
 
-#ifndef NO_SSL
+
+#if !defined(NO_SSL)
 	if (use_ssl) {
-		common_client_context.ssl_ctx = conn->client_ssl_ctx;
+		common_client_context.dd.ssl_ctx = conn->client_ssl_ctx;
 
 		/* TODO: Check ssl_verify_peer and ssl_ca_path here.
 		 * SSL_CTX_set_verify call is needed to switch off server
@@ -14971,6 +16517,7 @@ mg_connect_client_impl(const struct mg_client_options *client_options,
 
 		if (client_options->client_cert) {
 			if (!ssl_use_pem_file(&common_client_context,
+			                      &(common_client_context.dd),
 			                      client_options->client_cert,
 			                      NULL)) {
 				mg_snprintf(NULL,
@@ -14997,7 +16544,8 @@ mg_connect_client_impl(const struct mg_client_options *client_options,
 		if (!sslize(conn,
 		            conn->client_ssl_ctx,
 		            SSL_connect,
-		            &(conn->ctx->stop_flag))) {
+		            &(conn->phys_ctx->stop_flag),
+		            client_options)) {
 			mg_snprintf(NULL,
 			            NULL, /* No truncation check for ebuf */
 			            ebuf,
@@ -15012,8 +16560,10 @@ mg_connect_client_impl(const struct mg_client_options *client_options,
 #endif
 
 	if (0 != set_non_blocking_mode(sock)) {
-		/* TODO: handle error */
-		;
+		mg_cry_internal(conn,
+		                "Cannot set non-blocking mode for client %s:%i",
+		                client_options->host,
+		                client_options->port);
 	}
 
 	return conn;
@@ -15130,7 +16680,8 @@ get_uri_type(const char *uri)
 	for (i = 0; abs_uri_protocols[i].proto != NULL; i++) {
 		if (mg_strncasecmp(uri,
 		                   abs_uri_protocols[i].proto,
-		                   abs_uri_protocols[i].proto_len) == 0) {
+		                   abs_uri_protocols[i].proto_len)
+		    == 0) {
 
 			hostend = strchr(uri + abs_uri_protocols[i].proto_len, '/');
 			if (!hostend) {
@@ -15169,27 +16720,15 @@ get_rel_url_at_current_server(const char *uri, const struct mg_connection *conn)
 	char *portend;
 
 	auth_domain_check_enabled =
-	    !mg_strcasecmp(conn->ctx->config[ENABLE_AUTH_DOMAIN_CHECK], "yes");
-
-	if (!auth_domain_check_enabled) {
-		return 0;
-	}
-
-	server_domain = conn->ctx->config[AUTHENTICATION_DOMAIN];
-	if (!server_domain) {
-		return 0;
-	}
-	server_domain_len = strlen(server_domain);
-	if (!server_domain_len) {
-		return 0;
-	}
+	    !mg_strcasecmp(conn->dom_ctx->config[ENABLE_AUTH_DOMAIN_CHECK], "yes");
 
 	/* DNS is case insensitive, so use case insensitive string compare here
 	 */
 	for (i = 0; abs_uri_protocols[i].proto != NULL; i++) {
 		if (mg_strncasecmp(uri,
 		                   abs_uri_protocols[i].proto,
-		                   abs_uri_protocols[i].proto_len) == 0) {
+		                   abs_uri_protocols[i].proto_len)
+		    == 0) {
 
 			hostbegin = uri + abs_uri_protocols[i].proto_len;
 			hostend = strchr(hostbegin, '/');
@@ -15244,17 +16783,19 @@ get_rel_url_at_current_server(const char *uri, const struct mg_connection *conn)
 	 * or http://mydomain.com.fake/path/file.ext).
 	 */
 	if (auth_domain_check_enabled) {
+		server_domain = conn->dom_ctx->config[AUTHENTICATION_DOMAIN];
+		server_domain_len = strlen(server_domain);
+		if ((server_domain_len == 0) || (hostbegin == NULL)) {
+			return 0;
+		}
 		if ((request_domain_len == server_domain_len)
 		    && (!memcmp(server_domain, hostbegin, server_domain_len))) {
 			/* Request is directed to this server - full name match. */
 		} else {
 			if (request_domain_len < (server_domain_len + 2)) {
-				/* Request is directed to another server: The server name is
-				 * longer
-				 * than
-				 * the request name. Drop this case here to avoid overflows
-				 * in
-				 * the
+				/* Request is directed to another server: The server name
+				 * is longer than the request name.
+				 * Drop this case here to avoid overflows in the
 				 * following checks. */
 				return 0;
 			}
@@ -15264,9 +16805,10 @@ get_rel_url_at_current_server(const char *uri, const struct mg_connection *conn)
 				 * like notmyserver.com */
 				return 0;
 			}
-			if (0 != memcmp(server_domain,
-			                hostbegin + request_domain_len - server_domain_len,
-			                server_domain_len)) {
+			if (0
+			    != memcmp(server_domain,
+			              hostbegin + request_domain_len - server_domain_len,
+			              server_domain_len)) {
 				/* Request is directed to another server:
 				 * The server name is different. */
 				return 0;
@@ -15304,8 +16846,7 @@ get_message(struct mg_connection *conn, char *ebuf, size_t ebuf_len, int *err)
 
 	conn->request_len =
 	    read_message(NULL, conn, conn->buf, conn->buf_size, &conn->data_len);
-	/* assert(conn->request_len < 0 || conn->data_len >= conn->request_len);
-	 */
+	DEBUG_ASSERT(conn->request_len < 0 || conn->data_len >= conn->request_len);
 	if ((conn->request_len >= 0) && (conn->data_len < conn->request_len)) {
 		mg_snprintf(conn,
 		            NULL, /* No truncation check for ebuf */
@@ -15375,9 +16916,25 @@ get_request(struct mg_connection *conn, char *ebuf, size_t ebuf_len, int *err)
 	}
 
 	/* Message is a valid request */
+
+	/* Is there a "host" ? */
+	conn->host = alloc_get_host(conn);
+	if (!conn->host) {
+		mg_snprintf(conn,
+		            NULL, /* No truncation check for ebuf */
+		            ebuf,
+		            ebuf_len,
+		            "%s",
+		            "Bad request: Host mismatch");
+		*err = 400;
+		return 0;
+	}
+
+	/* Do we know the content length? */
 	if ((cl = get_header(conn->request_info.http_headers,
 	                     conn->request_info.num_headers,
-	                     "Content-Length")) != NULL) {
+	                     "Content-Length"))
+	    != NULL) {
 		/* Request/response has content length set */
 		char *endptr = NULL;
 		conn->content_len = strtoll(cl, &endptr, 10);
@@ -15395,17 +16952,32 @@ get_request(struct mg_connection *conn, char *ebuf, size_t ebuf_len, int *err)
 		conn->request_info.content_length = conn->content_len;
 	} else if ((cl = get_header(conn->request_info.http_headers,
 	                            conn->request_info.num_headers,
-	                            "Transfer-Encoding")) != NULL
+	                            "Transfer-Encoding"))
+	               != NULL
 	           && !mg_strcasecmp(cl, "chunked")) {
 		conn->is_chunked = 1;
 		conn->content_len = -1; /* unknown content length */
-	} else if (get_http_method_info(conn->request_info.request_method)
-	               ->request_has_body) {
-		/* POST or PUT request without content length set */
-		conn->content_len = -1; /* unknown content length */
 	} else {
-		/* Other request */
-		conn->content_len = 0; /* No content */
+		const struct mg_http_method_info *meth =
+		    get_http_method_info(conn->request_info.request_method);
+		if (!meth) {
+			/* No valid HTTP method */
+			mg_snprintf(conn,
+			            NULL, /* No truncation check for ebuf */
+			            ebuf,
+			            ebuf_len,
+			            "%s",
+			            "Bad request");
+			*err = 411;
+			return 0;
+		}
+		if (meth->request_has_body) {
+			/* POST or PUT request without content length set */
+			conn->content_len = -1; /* unknown content length */
+		} else {
+			/* Other request */
+			conn->content_len = 0; /* No content */
+		}
 	}
 
 	conn->connection_type = CONNECTION_TYPE_REQUEST; /* Valid request */
@@ -15435,9 +17007,12 @@ get_response(struct mg_connection *conn, char *ebuf, size_t ebuf_len, int *err)
 	}
 
 	/* Message is a valid response */
+
+	/* Do we know the content length? */
 	if ((cl = get_header(conn->response_info.http_headers,
 	                     conn->response_info.num_headers,
-	                     "Content-Length")) != NULL) {
+	                     "Content-Length"))
+	    != NULL) {
 		/* Request/response has content length set */
 		char *endptr = NULL;
 		conn->content_len = strtoll(cl, &endptr, 10);
@@ -15459,7 +17034,8 @@ get_response(struct mg_connection *conn, char *ebuf, size_t ebuf_len, int *err)
 
 	} else if ((cl = get_header(conn->response_info.http_headers,
 	                            conn->response_info.num_headers,
-	                            "Transfer-Encoding")) != NULL
+	                            "Transfer-Encoding"))
+	               != NULL
 	           && !mg_strcasecmp(cl, "chunked")) {
 		conn->is_chunked = 1;
 		conn->content_len = -1; /* unknown content length */
@@ -15480,8 +17056,8 @@ mg_get_response(struct mg_connection *conn,
 {
 	int err, ret;
 	char txt[32]; /* will not overflow */
-	struct mg_context *octx;
-	struct mg_context rctx;
+	char *save_timeout;
+	char *new_timeout;
 
 	if (ebuf_len > 0) {
 		ebuf[0] = '\0';
@@ -15498,22 +17074,21 @@ mg_get_response(struct mg_connection *conn,
 	}
 
 	/* Implementation of API function for HTTP clients */
-	octx = conn->ctx;
-	rctx = *(conn->ctx);
+	save_timeout = conn->dom_ctx->config[REQUEST_TIMEOUT];
 
 	if (timeout >= 0) {
 		mg_snprintf(conn, NULL, txt, sizeof(txt), "%i", timeout);
-		rctx.config[REQUEST_TIMEOUT] = txt;
+		new_timeout = txt;
 		/* Not required for non-blocking sockets.
 		set_sock_timeout(conn->client.sock, timeout);
 		*/
 	} else {
-		rctx.config[REQUEST_TIMEOUT] = NULL;
+		new_timeout = NULL;
 	}
 
-	conn->ctx = &rctx;
+	conn->dom_ctx->config[REQUEST_TIMEOUT] = new_timeout;
 	ret = get_response(conn, ebuf, ebuf_len, &err);
-	conn->ctx = octx;
+	conn->dom_ctx->config[REQUEST_TIMEOUT] = save_timeout;
 
 #if defined(MG_LEGACY_INTERFACE)
 	/* TODO: 1) uri is deprecated;
@@ -15572,7 +17147,7 @@ mg_download(const char *host,
 		}
 	}
 
-	/* if an error occured, close the connection */
+	/* if an error occurred, close the connection */
 	if ((ebuf[0] != '\0') && (conn != NULL)) {
 		mg_close_connection(conn);
 		conn = NULL;
@@ -15592,7 +17167,7 @@ struct websocket_client_thread_data {
 
 
 #if defined(USE_WEBSOCKET)
-#ifdef _WIN32
+#if defined(_WIN32)
 static unsigned __stdcall websocket_client_thread(void *data)
 #else
 static void *
@@ -15602,13 +17177,23 @@ websocket_client_thread(void *data)
 	struct websocket_client_thread_data *cdata =
 	    (struct websocket_client_thread_data *)data;
 
+#if !defined(_WIN32)
+	struct sigaction sa;
+
+	/* Ignore SIGPIPE */
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = SIG_IGN;
+	sigaction(SIGPIPE, &sa, NULL);
+#endif
+
 	mg_set_thread_name("ws-clnt");
 
-	if (cdata->conn->ctx) {
-		if (cdata->conn->ctx->callbacks.init_thread) {
+	if (cdata->conn->phys_ctx) {
+		if (cdata->conn->phys_ctx->callbacks.init_thread) {
 			/* 3 indicates a websocket client thread */
-			/* TODO: check if conn->ctx can be set */
-			cdata->conn->ctx->callbacks.init_thread(cdata->conn->ctx, 3);
+			/* TODO: check if conn->phys_ctx can be set */
+			cdata->conn->phys_ctx->callbacks.init_thread(cdata->conn->phys_ctx,
+			                                             3);
 		}
 	}
 
@@ -15622,11 +17207,11 @@ websocket_client_thread(void *data)
 
 	/* The websocket_client context has only this thread. If it runs out,
 	   set the stop_flag to 2 (= "stopped"). */
-	cdata->conn->ctx->stop_flag = 2;
+	cdata->conn->phys_ctx->stop_flag = 2;
 
 	mg_free((void *)cdata);
 
-#ifdef _WIN32
+#if defined(_WIN32)
 	return 0;
 #else
 	return NULL;
@@ -15674,6 +17259,11 @@ mg_connect_websocket_client(const char *host,
 		                "\r\n";
 	}
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
+
 	/* Establish the client connection and request upgrade */
 	conn = mg_download(host,
 	                   port,
@@ -15685,6 +17275,10 @@ mg_connect_websocket_client(const char *host,
 	                   host,
 	                   magic,
 	                   origin);
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 	/* Connection object will be null if something goes wrong */
 	if (conn == NULL) {
@@ -15721,7 +17315,13 @@ mg_connect_websocket_client(const char *host,
 	/* For client connections, mg_context is fake. Since we need to set a
 	 * callback function, we need to create a copy and modify it. */
 	newctx = (struct mg_context *)mg_malloc(sizeof(struct mg_context));
-	memcpy(newctx, conn->ctx, sizeof(struct mg_context));
+	if (!newctx) {
+		DEBUG_TRACE("%s\r\n", "Out of memory");
+		mg_free(conn);
+		return NULL;
+	}
+
+	memcpy(newctx, conn->phys_ctx, sizeof(struct mg_context));
 	newctx->user_data = user_data;
 	newctx->context_type = CONTEXT_WS_CLIENT; /* ws/wss client context */
 	newctx->cfg_worker_threads = 1; /* one worker thread will be created */
@@ -15729,9 +17329,19 @@ mg_connect_websocket_client(const char *host,
 	    (pthread_t *)mg_calloc_ctx(newctx->cfg_worker_threads,
 	                               sizeof(pthread_t),
 	                               newctx);
-	conn->ctx = newctx;
+
+	conn->phys_ctx = newctx;
+	conn->dom_ctx = &(newctx->dd);
+
 	thread_data = (struct websocket_client_thread_data *)
 	    mg_calloc_ctx(sizeof(struct websocket_client_thread_data), 1, newctx);
+	if (!thread_data) {
+		DEBUG_TRACE("%s\r\n", "Out of memory");
+		mg_free(newctx);
+		mg_free(conn);
+		return NULL;
+	}
+
 	thread_data->conn = conn;
 	thread_data->data_handler = data_func;
 	thread_data->close_handler = close_func;
@@ -15742,7 +17352,8 @@ mg_connect_websocket_client(const char *host,
 	 * called on the client connection */
 	if (mg_start_thread_with_id(websocket_client_thread,
 	                            (void *)thread_data,
-	                            newctx->worker_threadids) != 0) {
+	                            newctx->worker_threadids)
+	    != 0) {
 		mg_free((void *)thread_data);
 		mg_free((void *)newctx->worker_threadids);
 		mg_free((void *)newctx);
@@ -15776,7 +17387,7 @@ init_connection(struct mg_connection *conn)
 {
 	/* Is keep alive allowed by the server */
 	int keep_alive_enabled =
-	    !mg_strcasecmp(conn->ctx->config[ENABLE_KEEP_ALIVE], "yes");
+	    !mg_strcasecmp(conn->dom_ctx->config[ENABLE_KEEP_ALIVE], "yes");
 
 	if (!keep_alive_enabled) {
 		conn->must_close = 1;
@@ -15793,10 +17404,10 @@ init_connection(struct mg_connection *conn)
 #endif
 
 	/* call the init_connection callback if assigned */
-	if (conn->ctx->callbacks.init_connection != NULL) {
-		if (conn->ctx->context_type == CONTEXT_SERVER) {
+	if (conn->phys_ctx->callbacks.init_connection != NULL) {
+		if (conn->phys_ctx->context_type == CONTEXT_SERVER) {
 			void *conn_data = NULL;
-			conn->ctx->callbacks.init_connection(conn, &conn_data);
+			conn->phys_ctx->callbacks.init_connection(conn, &conn_data);
 			mg_set_user_connection_data(conn, conn_data);
 		}
 	}
@@ -15806,7 +17417,7 @@ init_connection(struct mg_connection *conn)
 /* Process a connection - may handle multiple requests
  * using the same connection.
  * Must be called with a valid connection (conn  and
- * conn->ctx must be valid).
+ * conn->phys_ctx must be valid).
  */
 static void
 process_new_connection(struct mg_connection *conn)
@@ -15818,12 +17429,12 @@ process_new_connection(struct mg_connection *conn)
 	int reqerr, uri_type;
 
 #if defined(USE_SERVER_STATS)
-	int mcon = mg_atomic_inc(&(conn->ctx->active_connections));
-	mg_atomic_add(&(conn->ctx->total_connections), 1);
-	if (mcon > (conn->ctx->max_connections)) {
+	int mcon = mg_atomic_inc(&(conn->phys_ctx->active_connections));
+	mg_atomic_add(&(conn->phys_ctx->total_connections), 1);
+	if (mcon > (conn->phys_ctx->max_connections)) {
 		/* could use atomic compare exchange, but this
 		 * seems overkill for statistics data */
-		conn->ctx->max_connections = mcon;
+		conn->phys_ctx->max_connections = mcon;
 	}
 #endif
 
@@ -15848,7 +17459,7 @@ process_new_connection(struct mg_connection *conn)
 			 * the server, or it was incomplete or a timeout. Send an
 			 * error message and close the connection. */
 			if (reqerr > 0) {
-				/*assert(ebuf[0] != '\0');*/
+				DEBUG_ASSERT(ebuf[0] != '\0');
 				mg_send_http_error(conn, reqerr, "%s", ebuf);
 			}
 		} else if (strcmp(ri->http_version, "1.0")
@@ -15917,16 +17528,17 @@ process_new_connection(struct mg_connection *conn)
 #if defined(USE_SERVER_STATS)
 				conn->conn_state = 5; /* processed */
 
-				mg_atomic_add(&(conn->ctx->total_data_read),
+				mg_atomic_add(&(conn->phys_ctx->total_data_read),
 				              conn->consumed_content);
-				mg_atomic_add(&(conn->ctx->total_data_written),
+				mg_atomic_add(&(conn->phys_ctx->total_data_written),
 				              conn->num_bytes_sent);
 #endif
 
 				DEBUG_TRACE("%s", "handle_request done");
 
-				if (conn->ctx->callbacks.end_request != NULL) {
-					conn->ctx->callbacks.end_request(conn, conn->status_code);
+				if (conn->phys_ctx->callbacks.end_request != NULL) {
+					conn->phys_ctx->callbacks.end_request(conn,
+					                                      conn->status_code);
 					DEBUG_TRACE("%s", "end_request callback done");
 				}
 				log_access(conn);
@@ -15950,7 +17562,7 @@ process_new_connection(struct mg_connection *conn)
 		 * memmove's below.
 		 * Therefore, memorize should_keep_alive() result now for later
 		 * use in loop exit condition. */
-		keep_alive = (conn->ctx->stop_flag == 0) && should_keep_alive(conn)
+		keep_alive = (conn->phys_ctx->stop_flag == 0) && should_keep_alive(conn)
 		             && (conn->content_len >= 0);
 
 
@@ -15960,7 +17572,7 @@ process_new_connection(struct mg_connection *conn)
 		                   < (int64_t)conn->data_len))
 		                  ? (int)(conn->request_len + conn->content_len)
 		                  : conn->data_len;
-		/*assert(discard_len >= 0);*/
+		DEBUG_ASSERT(discard_len >= 0);
 		if (discard_len < 0) {
 			DEBUG_TRACE("internal error: discard_len = %li",
 			            (long int)discard_len);
@@ -15972,8 +17584,8 @@ process_new_connection(struct mg_connection *conn)
 			memmove(conn->buf, conn->buf + discard_len, (size_t)conn->data_len);
 		}
 
-		/* assert(conn->data_len >= 0); */
-		/* assert(conn->data_len <= conn->buf_size); */
+		DEBUG_ASSERT(conn->data_len >= 0);
+		DEBUG_ASSERT(conn->data_len <= conn->buf_size);
 
 		if ((conn->data_len < 0) || (conn->data_len > conn->buf_size)) {
 			DEBUG_TRACE("internal error: data_len = %li, buf_size = %li",
@@ -15993,8 +17605,8 @@ process_new_connection(struct mg_connection *conn)
 	close_connection(conn);
 
 #if defined(USE_SERVER_STATS)
-	mg_atomic_add(&(conn->ctx->total_requests), conn->handled_requests);
-	mg_atomic_dec(&(conn->ctx->active_connections));
+	mg_atomic_add(&(conn->phys_ctx->total_requests), conn->handled_requests);
+	mg_atomic_dec(&(conn->phys_ctx->active_connections));
 #endif
 }
 
@@ -16006,7 +17618,7 @@ produce_socket(struct mg_context *ctx, const struct socket *sp)
 {
 	unsigned int i;
 
-	for (;;) {
+	while (!ctx->stop_flag) {
 		for (i = 0; i < ctx->cfg_worker_threads; i++) {
 			/* find a free worker slot and signal it */
 			if (ctx->client_socks[i].in_use == 0) {
@@ -16125,7 +17737,7 @@ worker_thread_run(struct worker_thread_args *thread_args)
 
 	tls.is_master = 0;
 	tls.thread_idx = (unsigned)mg_atomic_inc(&thread_idx_max);
-#if defined(_WIN32) && !defined(__SYMBIAN32__)
+#if defined(_WIN32)
 	tls.pthread_cond_helper_mutex = CreateEvent(NULL, FALSE, FALSE, NULL);
 #endif
 
@@ -16141,9 +17753,9 @@ worker_thread_run(struct worker_thread_args *thread_args)
 	if (((int)thread_args->index < 0)
 	    || ((unsigned)thread_args->index
 	        >= (unsigned)ctx->cfg_worker_threads)) {
-		mg_cry(fc(ctx),
-		       "Internal error: Invalid worker index %i",
-		       (int)thread_args->index);
+		mg_cry_internal(fc(ctx),
+		                "Internal error: Invalid worker index %i",
+		                (int)thread_args->index);
 		return NULL;
 	}
 	conn = ctx->worker_connections + thread_args->index;
@@ -16151,31 +17763,44 @@ worker_thread_run(struct worker_thread_args *thread_args)
 	/* Request buffers are not pre-allocated. They are private to the
 	 * request and do not contain any state information that might be
 	 * of interest to anyone observing a server status.  */
-	conn->buf = (char *)mg_malloc_ctx(ctx->max_request_size, conn->ctx);
+	conn->buf = (char *)mg_malloc_ctx(ctx->max_request_size, conn->phys_ctx);
 	if (conn->buf == NULL) {
-		mg_cry(fc(ctx),
-		       "Out of memory: Cannot allocate buffer for worker %i",
-		       (int)thread_args->index);
+		mg_cry_internal(fc(ctx),
+		                "Out of memory: Cannot allocate buffer for worker %i",
+		                (int)thread_args->index);
 		return NULL;
 	}
 	conn->buf_size = (int)ctx->max_request_size;
 
-	conn->ctx = ctx;
+	conn->phys_ctx = ctx;
+	conn->dom_ctx = &(ctx->dd); /* Use default domain and default host */
+	conn->host = NULL;          /* until we have more information. */
+
 	conn->thread_index = thread_args->index;
 	conn->request_info.user_data = ctx->user_data;
 	/* Allocate a mutex for this connection to allow communication both
 	 * within the request handler and from elsewhere in the application
 	 */
-	(void)pthread_mutex_init(&conn->mutex, &pthread_mutex_attr);
+	if (0 != pthread_mutex_init(&conn->mutex, &pthread_mutex_attr)) {
+		mg_free(conn->buf);
+		mg_cry_internal(fc(ctx), "%s", "Cannot create mutex");
+		return NULL;
+	}
 
 #if defined(USE_SERVER_STATS)
 	conn->conn_state = 1; /* not consumed */
 #endif
 
+#if defined(ALTERNATIVE_QUEUE)
+	while ((ctx->stop_flag == 0)
+	       && consume_socket(ctx, &conn->client, conn->thread_index)) {
+#else
 	/* Call consume_socket() even when ctx->stop_flag > 0, to let it
 	 * signal sq_empty condvar to wake up the master waiting in
 	 * produce_socket() */
 	while (consume_socket(ctx, &conn->client, conn->thread_index)) {
+#endif
+
 		conn->conn_birth_time = time(NULL);
 
 /* Fill in IP, port info early so even if SSL setup below fails,
@@ -16200,21 +17825,18 @@ worker_thread_run(struct worker_thread_args *thread_args)
 		DEBUG_TRACE("Start processing connection from %s",
 		            conn->request_info.remote_addr);
 
-#if defined(MG_LEGACY_INTERFACE)
-		/* This legacy interface only works for the IPv4 case */
-		addr = ntohl(conn->client.rsa.sin.sin_addr.s_addr);
-		memcpy(&conn->request_info.remote_ip, &addr, 4);
-#endif
-
 		conn->request_info.is_ssl = conn->client.is_ssl;
 
 		if (conn->client.is_ssl) {
-#ifndef NO_SSL
+#if !defined(NO_SSL)
 			/* HTTPS connection */
 			if (sslize(conn,
-			           conn->ctx->ssl_ctx,
+			           conn->dom_ctx->ssl_ctx,
 			           SSL_accept,
-			           &(conn->ctx->stop_flag))) {
+			           &(conn->phys_ctx->stop_flag),
+			           NULL)) {
+				/* conn->dom_ctx is set in get_request */
+
 				/* Get SSL client certificate information (if set) */
 				ssl_get_client_cert_info(conn);
 
@@ -16227,6 +17849,10 @@ worker_thread_run(struct worker_thread_args *thread_args)
 					mg_free((void *)(conn->request_info.client_cert->issuer));
 					mg_free((void *)(conn->request_info.client_cert->serial));
 					mg_free((void *)(conn->request_info.client_cert->finger));
+					/* Free certificate memory */
+					X509_free(
+					    (X509 *)conn->request_info.client_cert->peer_cert);
+					conn->request_info.client_cert->peer_cert = 0;
 					conn->request_info.client_cert->subject = 0;
 					conn->request_info.client_cert->issuer = 0;
 					conn->request_info.client_cert->serial = 0;
@@ -16234,6 +17860,9 @@ worker_thread_run(struct worker_thread_args *thread_args)
 					mg_free(conn->request_info.client_cert);
 					conn->request_info.client_cert = 0;
 				}
+			} else {
+				/* make sure the connection is cleaned up on SSL failure */
+				close_connection(conn);
 			}
 #endif
 		} else {
@@ -16246,7 +17875,7 @@ worker_thread_run(struct worker_thread_args *thread_args)
 
 
 	pthread_setspecific(sTlsKey, NULL);
-#if defined(_WIN32) && !defined(__SYMBIAN32__)
+#if defined(_WIN32)
 	CloseHandle(tls.pthread_cond_helper_mutex);
 #endif
 	pthread_mutex_destroy(&conn->mutex);
@@ -16266,7 +17895,7 @@ worker_thread_run(struct worker_thread_args *thread_args)
 
 
 /* Threads have different return types on Windows and Unix. */
-#ifdef _WIN32
+#if defined(_WIN32)
 static unsigned __stdcall worker_thread(void *thread_func_param)
 {
 	struct worker_thread_args *pwta =
@@ -16281,6 +17910,13 @@ worker_thread(void *thread_func_param)
 {
 	struct worker_thread_args *pwta =
 	    (struct worker_thread_args *)thread_func_param;
+	struct sigaction sa;
+
+	/* Ignore SIGPIPE */
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = SIG_IGN;
+	sigaction(SIGPIPE, &sa, NULL);
+
 	worker_thread_run(pwta);
 	mg_free(thread_func_param);
 	return NULL;
@@ -16288,6 +17924,8 @@ worker_thread(void *thread_func_param)
 #endif /* _WIN32 */
 
 
+/* This is an internal function, thus all arguments are expected to be
+ * valid - a NULL check is not required. */
 static void
 accept_new_connection(const struct socket *listener, struct mg_context *ctx)
 {
@@ -16296,15 +17934,14 @@ accept_new_connection(const struct socket *listener, struct mg_context *ctx)
 	socklen_t len = sizeof(so.rsa);
 	int on = 1;
 
-	if (!listener) {
-		return;
-	}
-
 	if ((so.sock = accept(listener->sock, &so.rsa.sa, &len))
 	    == INVALID_SOCKET) {
 	} else if (!check_acl(ctx, ntohl(*(uint32_t *)&so.rsa.sin.sin_addr))) {
 		sockaddr_to_string(src_addr, sizeof(src_addr), &so.rsa);
-		mg_cry(fc(ctx), "%s: %s is not allowed to connect", __func__, src_addr);
+		mg_cry_internal(fc(ctx),
+		                "%s: %s is not allowed to connect",
+		                __func__,
+		                src_addr);
 		closesocket(so.sock);
 	} else {
 		/* Put so socket structure into the queue */
@@ -16313,10 +17950,10 @@ accept_new_connection(const struct socket *listener, struct mg_context *ctx)
 		so.is_ssl = listener->is_ssl;
 		so.ssl_redir = listener->ssl_redir;
 		if (getsockname(so.sock, &so.lsa.sa, &len) != 0) {
-			mg_cry(fc(ctx),
-			       "%s: getsockname() failed: %s",
-			       __func__,
-			       strerror(ERRNO));
+			mg_cry_internal(fc(ctx),
+			                "%s: getsockname() failed: %s",
+			                __func__,
+			                strerror(ERRNO));
 		}
 
 		/* Set TCP keep-alive. This is needed because if HTTP-level
@@ -16330,11 +17967,13 @@ accept_new_connection(const struct socket *listener, struct mg_context *ctx)
 		               SOL_SOCKET,
 		               SO_KEEPALIVE,
 		               (SOCK_OPT_TYPE)&on,
-		               sizeof(on)) != 0) {
-			mg_cry(fc(ctx),
-			       "%s: setsockopt(SOL_SOCKET SO_KEEPALIVE) failed: %s",
-			       __func__,
-			       strerror(ERRNO));
+		               sizeof(on))
+		    != 0) {
+			mg_cry_internal(
+			    fc(ctx),
+			    "%s: setsockopt(SOL_SOCKET SO_KEEPALIVE) failed: %s",
+			    __func__,
+			    strerror(ERRNO));
 		}
 
 		/* Disable TCP Nagle's algorithm. Normally TCP packets are coalesced
@@ -16344,13 +17983,14 @@ accept_new_connection(const struct socket *listener, struct mg_context *ctx)
 		 * when HTTP 1.1 persistent connections are used and the responses
 		 * are relatively small (eg. less than 1400 bytes).
 		 */
-		if ((ctx != NULL) && (ctx->config[CONFIG_TCP_NODELAY] != NULL)
-		    && (!strcmp(ctx->config[CONFIG_TCP_NODELAY], "1"))) {
+		if ((ctx->dd.config[CONFIG_TCP_NODELAY] != NULL)
+		    && (!strcmp(ctx->dd.config[CONFIG_TCP_NODELAY], "1"))) {
 			if (set_tcp_nodelay(so.sock, 1) != 0) {
-				mg_cry(fc(ctx),
-				       "%s: setsockopt(IPPROTO_TCP TCP_NODELAY) failed: %s",
-				       __func__,
-				       strerror(ERRNO));
+				mg_cry_internal(
+				    fc(ctx),
+				    "%s: setsockopt(IPPROTO_TCP TCP_NODELAY) failed: %s",
+				    __func__,
+				    strerror(ERRNO));
 			}
 		}
 
@@ -16400,7 +18040,7 @@ master_thread_run(void *thread_func_param)
 #endif
 
 /* Initialize thread local storage */
-#if defined(_WIN32) && !defined(__SYMBIAN32__)
+#if defined(_WIN32)
 	tls.pthread_cond_helper_mutex = CreateEvent(NULL, FALSE, FALSE, NULL);
 #endif
 	tls.is_master = 1;
@@ -16483,7 +18123,7 @@ master_thread_run(void *thread_func_param)
 
 	DEBUG_TRACE("%s", "exiting");
 
-#if defined(_WIN32) && !defined(__SYMBIAN32__)
+#if defined(_WIN32)
 	CloseHandle(tls.pthread_cond_helper_mutex);
 #endif
 	pthread_setspecific(sTlsKey, NULL);
@@ -16496,7 +18136,7 @@ master_thread_run(void *thread_func_param)
 
 
 /* Threads have different return types on Windows and Unix. */
-#ifdef _WIN32
+#if defined(_WIN32)
 static unsigned __stdcall master_thread(void *thread_func_param)
 {
 	master_thread_run(thread_func_param);
@@ -16506,6 +18146,13 @@ static unsigned __stdcall master_thread(void *thread_func_param)
 static void *
 master_thread(void *thread_func_param)
 {
+	struct sigaction sa;
+
+	/* Ignore SIGPIPE */
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = SIG_IGN;
+	sigaction(SIGPIPE, &sa, NULL);
+
 	master_thread_run(thread_func_param);
 	return NULL;
 }
@@ -16550,26 +18197,40 @@ free_context(struct mg_context *ctx)
 
 	/* Deallocate config parameters */
 	for (i = 0; i < NUM_OPTIONS; i++) {
-		if (ctx->config[i] != NULL) {
+		if (ctx->dd.config[i] != NULL) {
 #if defined(_MSC_VER)
 #pragma warning(suppress : 6001)
 #endif
-			mg_free(ctx->config[i]);
+			mg_free(ctx->dd.config[i]);
 		}
 	}
 
 	/* Deallocate request handlers */
-	while (ctx->handlers) {
-		tmp_rh = ctx->handlers;
-		ctx->handlers = tmp_rh->next;
+	while (ctx->dd.handlers) {
+		tmp_rh = ctx->dd.handlers;
+		ctx->dd.handlers = tmp_rh->next;
+		if (tmp_rh->handler_type == REQUEST_HANDLER) {
+			pthread_cond_destroy(&tmp_rh->refcount_cond);
+			pthread_mutex_destroy(&tmp_rh->refcount_mutex);
+		}
 		mg_free(tmp_rh->uri);
 		mg_free(tmp_rh);
 	}
 
-#ifndef NO_SSL
+#if !defined(NO_SSL)
 	/* Deallocate SSL context */
-	if (ctx->ssl_ctx != NULL) {
-		SSL_CTX_free(ctx->ssl_ctx);
+	if (ctx->dd.ssl_ctx != NULL) {
+		void *ssl_ctx = (void *)ctx->dd.ssl_ctx;
+		int callback_ret =
+		    (ctx->callbacks.external_ssl_ctx == NULL)
+		        ? 0
+		        : (ctx->callbacks.external_ssl_ctx(&ssl_ctx, ctx->user_data));
+
+		if (callback_ret == 0) {
+			SSL_CTX_free(ctx->dd.ssl_ctx);
+		}
+		/* else: ignore error and ommit SSL_CTX_free in case
+		 * callback_ret is 1 */
 	}
 #endif /* !NO_SSL */
 
@@ -16619,9 +18280,9 @@ mg_stop(struct mg_context *ctx)
 	mg_join_thread(mt);
 	free_context(ctx);
 
-#if defined(_WIN32) && !defined(__SYMBIAN32__)
+#if defined(_WIN32)
 	(void)WSACleanup();
-#endif /* _WIN32 && !__SYMBIAN32__ */
+#endif /* _WIN32 */
 }
 
 
@@ -16640,13 +18301,13 @@ get_system_name(char **sysName)
 	DWORD dwBuild = 0;
 	BOOL wowRet, isWoW = FALSE;
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER)
 #pragma warning(push)
 /* GetVersion was declared deprecated */
 #pragma warning(disable : 4996)
 #endif
 	dwVersion = GetVersion();
-#ifdef _MSC_VER
+#if defined(_MSC_VER)
 #pragma warning(pop)
 #endif
 
@@ -16691,10 +18352,10 @@ mg_start(const struct mg_callbacks *callbacks,
 
 	struct mg_workerTLS tls;
 
-#if defined(_WIN32) && !defined(__SYMBIAN32__)
+#if defined(_WIN32)
 	WSADATA data;
 	WSAStartup(MAKEWORD(2, 2), &data);
-#endif /* _WIN32 && !__SYMBIAN32__ */
+#endif /* _WIN32  */
 
 	/* Allocate context and initialize reasonable general case defaults. */
 	if ((ctx = (struct mg_context *)mg_calloc(1, sizeof(*ctx))) == NULL) {
@@ -16702,32 +18363,56 @@ mg_start(const struct mg_callbacks *callbacks,
 	}
 
 	/* Random number generator will initialize at the first call */
-	ctx->auth_nonce_mask =
+	ctx->dd.auth_nonce_mask =
 	    (uint64_t)get_random() ^ (uint64_t)(ptrdiff_t)(options);
 
 	if (mg_init_library_called == 0) {
 		/* Legacy INIT, if mg_start is called without mg_init_library.
 		 * Note: This may cause a memory leak */
-		mg_init_library(0);
+		const char *ports_option =
+		    config_options[LISTENING_PORTS].default_value;
+
+		if (options) {
+			const char **run_options = options;
+			const char *optname = config_options[LISTENING_PORTS].name;
+
+			/* Try to find the "listening_ports" option */
+			while (*run_options) {
+				if (!strcmp(*run_options, optname)) {
+					ports_option = run_options[1];
+				}
+				run_options += 2;
+			}
+		}
+
+		if (is_ssl_port_used(ports_option)) {
+			/* Initialize with SSL support */
+			mg_init_library(MG_FEATURES_TLS);
+		} else {
+			/* Initialize without SSL support */
+			mg_init_library(MG_FEATURES_DEFAULT);
+		}
 	}
 
 	tls.is_master = -1;
 	tls.thread_idx = (unsigned)mg_atomic_inc(&thread_idx_max);
-#if defined(_WIN32) && !defined(__SYMBIAN32__)
+#if defined(_WIN32)
 	tls.pthread_cond_helper_mutex = NULL;
 #endif
 	pthread_setspecific(sTlsKey, &tls);
 
-	ok = 0 == pthread_mutex_init(&ctx->thread_mutex, &pthread_mutex_attr);
+	ok = (0 == pthread_mutex_init(&ctx->thread_mutex, &pthread_mutex_attr));
 #if !defined(ALTERNATIVE_QUEUE)
-	ok &= 0 == pthread_cond_init(&ctx->sq_empty, NULL);
-	ok &= 0 == pthread_cond_init(&ctx->sq_full, NULL);
+	ok &= (0 == pthread_cond_init(&ctx->sq_empty, NULL));
+	ok &= (0 == pthread_cond_init(&ctx->sq_full, NULL));
 #endif
-	ok &= 0 == pthread_mutex_init(&ctx->nonce_mutex, &pthread_mutex_attr);
+	ok &= (0 == pthread_mutex_init(&ctx->nonce_mutex, &pthread_mutex_attr));
 	if (!ok) {
 		/* Fatal error - abort start. However, this situation should never
 		 * occur in practice. */
-		mg_cry(fc(ctx), "Cannot initialize thread synchronization objects");
+		mg_cry_internal(fc(ctx),
+		                "%s",
+		                "Cannot initialize thread synchronization objects");
 		mg_free(ctx);
 		pthread_setspecific(sTlsKey, NULL);
 		return NULL;
@@ -16739,69 +18424,73 @@ mg_start(const struct mg_callbacks *callbacks,
 		ctx->callbacks.exit_context = 0;
 	}
 	ctx->user_data = user_data;
-	ctx->handlers = NULL;
+	ctx->dd.handlers = NULL;
+	ctx->dd.next = NULL;
 
 #if defined(USE_LUA) && defined(USE_WEBSOCKET)
-	ctx->shared_lua_websockets = 0;
+	ctx->dd.shared_lua_websockets = NULL;
 #endif
 
+	/* Store options */
 	while (options && (name = *options++) != NULL) {
 		if ((idx = get_option_index(name)) == -1) {
-			mg_cry(fc(ctx), "Invalid option: %s", name);
+			mg_cry_internal(fc(ctx), "Invalid option: %s", name);
 			free_context(ctx);
 			pthread_setspecific(sTlsKey, NULL);
 			return NULL;
 		} else if ((value = *options++) == NULL) {
-			mg_cry(fc(ctx), "%s: option value cannot be NULL", name);
+			mg_cry_internal(fc(ctx), "%s: option value cannot be NULL", name);
 			free_context(ctx);
 			pthread_setspecific(sTlsKey, NULL);
 			return NULL;
 		}
-		if (ctx->config[idx] != NULL) {
-			mg_cry(fc(ctx), "warning: %s: duplicate option", name);
-			mg_free(ctx->config[idx]);
+		if (ctx->dd.config[idx] != NULL) {
+			mg_cry_internal(fc(ctx), "warning: %s: duplicate option", name);
+			mg_free(ctx->dd.config[idx]);
 		}
-		ctx->config[idx] = mg_strdup(value);
+		ctx->dd.config[idx] = mg_strdup_ctx(value, ctx);
 		DEBUG_TRACE("[%s] -> [%s]", name, value);
 	}
 
 	/* Set default value if needed */
 	for (i = 0; config_options[i].name != NULL; i++) {
 		default_value = config_options[i].default_value;
-		if ((ctx->config[i] == NULL) && (default_value != NULL)) {
-			ctx->config[i] = mg_strdup(default_value);
+		if ((ctx->dd.config[i] == NULL) && (default_value != NULL)) {
+			ctx->dd.config[i] = mg_strdup_ctx(default_value, ctx);
 		}
 	}
 
-	itmp = atoi(ctx->config[MAX_REQUEST_SIZE]);
-
+	/* Request size option */
+	itmp = atoi(ctx->dd.config[MAX_REQUEST_SIZE]);
 	if (itmp < 1024) {
-		mg_cry(fc(ctx), "max_request_size too small");
+		mg_cry_internal(fc(ctx), "%s", "max_request_size too small");
 		free_context(ctx);
 		pthread_setspecific(sTlsKey, NULL);
 		return NULL;
 	}
 	ctx->max_request_size = (unsigned)itmp;
 
-	workerthreadcount = atoi(ctx->config[NUM_THREADS]);
+	/* Worker thread count option */
+	workerthreadcount = atoi(ctx->dd.config[NUM_THREADS]);
 
 	if (workerthreadcount > MAX_WORKER_THREADS) {
-		mg_cry(fc(ctx), "Too many worker threads");
+		mg_cry_internal(fc(ctx), "%s", "Too many worker threads");
 		free_context(ctx);
 		pthread_setspecific(sTlsKey, NULL);
 		return NULL;
 	}
 
 	if (workerthreadcount <= 0) {
-		mg_cry(fc(ctx), "Invalid number of worker threads");
+		mg_cry_internal(fc(ctx), "%s", "Invalid number of worker threads");
 		free_context(ctx);
 		pthread_setspecific(sTlsKey, NULL);
 		return NULL;
 	}
 
+/* Document root */
 #if defined(NO_FILES)
-	if (ctx->config[DOCUMENT_ROOT] != NULL) {
-		mg_cry(fc(ctx), "%s", "Document root must not be set");
+	if (ctx->dd.config[DOCUMENT_ROOT] != NULL) {
+		mg_cry_internal(fc(ctx), "%s", "Document root must not be set");
 		free_context(ctx);
 		pthread_setspecific(sTlsKey, NULL);
 		return NULL;
@@ -16812,12 +18501,15 @@ mg_start(const struct mg_callbacks *callbacks,
 
 #if defined(USE_LUA)
 	/* If a Lua background script has been configured, start it. */
-	if (ctx->config[LUA_BACKGROUND_SCRIPT] != NULL) {
+	if (ctx->dd.config[LUA_BACKGROUND_SCRIPT] != NULL) {
 		char ebuf[256];
-		lua_State *state = (void *)mg_prepare_lua_context_script(
-		    ctx->config[LUA_BACKGROUND_SCRIPT], ctx, ebuf, sizeof(ebuf));
+		struct vec opt_vec;
+		struct vec eq_vec;
+		const char *sparams;
+		lua_State *state = mg_prepare_lua_context_script(
+		    ctx->dd.config[LUA_BACKGROUND_SCRIPT], ctx, ebuf, sizeof(ebuf));
 		if (!state) {
-			mg_cry(fc(ctx), "lua_background_script error: %s", ebuf);
+			mg_cry_internal(fc(ctx), "lua_background_script error: %s", ebuf);
 			free_context(ctx);
 			pthread_setspecific(sTlsKey, NULL);
 			return NULL;
@@ -16827,9 +18519,7 @@ mg_start(const struct mg_callbacks *callbacks,
 		lua_newtable(state);
 		reg_boolean(state, "shutdown", 0);
 
-		struct vec opt_vec;
-		struct vec eq_vec;
-		const char *sparams = ctx->config[LUA_BACKGROUND_SCRIPT_PARAMS];
+		sparams = ctx->dd.config[LUA_BACKGROUND_SCRIPT_PARAMS];
 
 		while ((sparams = next_option(sparams, &opt_vec, &eq_vec)) != NULL) {
 			reg_llstring(
@@ -16846,9 +18536,9 @@ mg_start(const struct mg_callbacks *callbacks,
 
 	/* NOTE(lsm): order is important here. SSL certificates must
 	 * be initialized before listening ports. UID must be set last. */
-	if (!set_gpass_option(ctx) ||
+	if (!set_gpass_option(ctx, NULL) ||
 #if !defined(NO_SSL)
-	    !set_ssl_option(ctx) ||
+	    !init_ssl_ctx(ctx, NULL) ||
 #endif
 	    !set_ports_option(ctx) ||
 #if !defined(_WIN32)
@@ -16860,18 +18550,15 @@ mg_start(const struct mg_callbacks *callbacks,
 		return NULL;
 	}
 
-#if !defined(_WIN32) && !defined(__SYMBIAN32__)
-	/* Ignore SIGPIPE signal, so if browser cancels the request, it
-	 * won't kill the whole process. */
-	(void)signal(SIGPIPE, SIG_IGN);
-#endif /* !_WIN32 && !__SYMBIAN32__ */
-
 	ctx->cfg_worker_threads = ((unsigned int)(workerthreadcount));
 	ctx->worker_threadids = (pthread_t *)mg_calloc_ctx(ctx->cfg_worker_threads,
 	                                                   sizeof(pthread_t),
 	                                                   ctx);
+
 	if (ctx->worker_threadids == NULL) {
-		mg_cry(fc(ctx), "Not enough memory for worker thread ID array");
+		mg_cry_internal(fc(ctx),
+		                "%s",
+		                "Not enough memory for worker thread ID array");
 		free_context(ctx);
 		pthread_setspecific(sTlsKey, NULL);
 		return NULL;
@@ -16881,7 +18568,9 @@ mg_start(const struct mg_callbacks *callbacks,
 	                                          sizeof(struct mg_connection),
 	                                          ctx);
 	if (ctx->worker_connections == NULL) {
-		mg_cry(fc(ctx), "Not enough memory for worker thread connection array");
+		mg_cry_internal(fc(ctx),
+		                "%s",
+		                "Not enough memory for worker thread connection array");
 		free_context(ctx);
 		pthread_setspecific(sTlsKey, NULL);
 		return NULL;
@@ -16894,7 +18583,9 @@ mg_start(const struct mg_callbacks *callbacks,
 	                           ctx->cfg_worker_threads,
 	                           ctx);
 	if (ctx->client_wait_events == NULL) {
-		mg_cry(fc(ctx), "Not enough memory for worker event array");
+		mg_cry_internal(fc(ctx),
+		                "%s",
+		                "Not enough memory for worker event array");
 		mg_free(ctx->worker_threadids);
 		free_context(ctx);
 		pthread_setspecific(sTlsKey, NULL);
@@ -16905,9 +18596,11 @@ mg_start(const struct mg_callbacks *callbacks,
 	    (struct socket *)mg_calloc_ctx(sizeof(ctx->client_socks[0]),
 	                                   ctx->cfg_worker_threads,
 	                                   ctx);
-	if (ctx->client_wait_events == NULL) {
-		mg_cry(fc(ctx), "Not enough memory for worker socket array");
-		mg_free(ctx->client_socks);
+	if (ctx->client_socks == NULL) {
+		mg_cry_internal(fc(ctx),
+		                "%s",
+		                "Not enough memory for worker socket array");
+		mg_free(ctx->client_wait_events);
 		mg_free(ctx->worker_threadids);
 		free_context(ctx);
 		pthread_setspecific(sTlsKey, NULL);
@@ -16917,12 +18610,13 @@ mg_start(const struct mg_callbacks *callbacks,
 	for (i = 0; (unsigned)i < ctx->cfg_worker_threads; i++) {
 		ctx->client_wait_events[i] = event_create();
 		if (ctx->client_wait_events[i] == 0) {
-			mg_cry(fc(ctx), "Error creating worker event %i", i);
+			mg_cry_internal(fc(ctx), "Error creating worker event %i", i);
 			while (i > 0) {
 				i--;
 				event_destroy(ctx->client_wait_events[i]);
 			}
 			mg_free(ctx->client_socks);
+			mg_free(ctx->client_wait_events);
 			mg_free(ctx->worker_threadids);
 			free_context(ctx);
 			pthread_setspecific(sTlsKey, NULL);
@@ -16934,7 +18628,7 @@ mg_start(const struct mg_callbacks *callbacks,
 
 #if defined(USE_TIMERS)
 	if (timers_init(ctx) != 0) {
-		mg_cry(fc(ctx), "Error creating timers");
+		mg_cry_internal(fc(ctx), "%s", "Error creating timers");
 		free_context(ctx);
 		pthread_setspecific(sTlsKey, NULL);
 		return NULL;
@@ -16963,7 +18657,8 @@ mg_start(const struct mg_callbacks *callbacks,
 		if ((wta == NULL)
 		    || (mg_start_thread_with_id(worker_thread,
 		                                wta,
-		                                &ctx->worker_threadids[i]) != 0)) {
+		                                &ctx->worker_threadids[i])
+		        != 0)) {
 
 			/* thread was not created */
 			if (wta != NULL) {
@@ -16971,14 +18666,14 @@ mg_start(const struct mg_callbacks *callbacks,
 			}
 
 			if (i > 0) {
-				mg_cry(fc(ctx),
-				       "Cannot start worker thread %i: error %ld",
-				       i + 1,
-				       (long)ERRNO);
+				mg_cry_internal(fc(ctx),
+				                "Cannot start worker thread %i: error %ld",
+				                i + 1,
+				                (long)ERRNO);
 			} else {
-				mg_cry(fc(ctx),
-				       "Cannot create threads: error %ld",
-				       (long)ERRNO);
+				mg_cry_internal(fc(ctx),
+				                "Cannot create threads: error %ld",
+				                (long)ERRNO);
 				free_context(ctx);
 				pthread_setspecific(sTlsKey, NULL);
 				return NULL;
@@ -16992,6 +18687,116 @@ mg_start(const struct mg_callbacks *callbacks,
 }
 
 
+#if defined(MG_EXPERIMENTAL_INTERFACES)
+/* Add an additional domain to an already running web server. */
+int
+mg_start_domain(struct mg_context *ctx, const char **options)
+{
+	const char *name;
+	const char *value;
+	const char *default_value;
+	struct mg_domain_context *new_dom;
+	struct mg_domain_context *dom;
+	int idx, i;
+
+	if ((ctx == NULL) || (ctx->stop_flag != 0) || (options == NULL)) {
+		return -1;
+	}
+
+	new_dom = (struct mg_domain_context *)
+	    mg_calloc_ctx(1, sizeof(struct mg_domain_context), ctx);
+
+	if (!new_dom) {
+		/* Out of memory */
+		return -6;
+	}
+
+	/* Store options - TODO: unite duplicate code */
+	while (options && (name = *options++) != NULL) {
+		if ((idx = get_option_index(name)) == -1) {
+			mg_cry_internal(fc(ctx), "Invalid option: %s", name);
+			mg_free(new_dom);
+			return -2;
+		} else if ((value = *options++) == NULL) {
+			mg_cry_internal(fc(ctx), "%s: option value cannot be NULL", name);
+			mg_free(new_dom);
+			return -2;
+		}
+		if (new_dom->config[idx] != NULL) {
+			mg_cry_internal(fc(ctx), "warning: %s: duplicate option", name);
+			mg_free(new_dom->config[idx]);
+		}
+		new_dom->config[idx] = mg_strdup_ctx(value, ctx);
+		DEBUG_TRACE("[%s] -> [%s]", name, value);
+	}
+
+	/* Authentication domain is mandatory */
+	/* TODO: Maybe use a new option hostname? */
+	if (!new_dom->config[AUTHENTICATION_DOMAIN]) {
+		mg_cry_internal(fc(ctx), "%s", "authentication domain required");
+		mg_free(new_dom);
+		return -4;
+	}
+
+	/* Set default value if needed. Take the config value from
+	 * ctx as a default value. */
+	for (i = 0; config_options[i].name != NULL; i++) {
+		default_value = ctx->dd.config[i];
+		if ((new_dom->config[i] == NULL) && (default_value != NULL)) {
+			new_dom->config[i] = mg_strdup_ctx(default_value, ctx);
+		}
+	}
+
+	new_dom->handlers = NULL;
+	new_dom->next = NULL;
+	new_dom->nonce_count = 0;
+	new_dom->auth_nonce_mask =
+	    (uint64_t)get_random() ^ ((uint64_t)get_random() << 31);
+
+#if defined(USE_LUA) && defined(USE_WEBSOCKET)
+	new_dom->shared_lua_websockets = NULL;
+#endif
+
+	if (!init_ssl_ctx(ctx, new_dom)) {
+		/* Init SSL failed */
+		mg_free(new_dom);
+		return -3;
+	}
+
+	/* Add element to linked list. */
+	mg_lock_context(ctx);
+
+	idx = 0;
+	dom = &(ctx->dd);
+	for (;;) {
+		if (!strcasecmp(new_dom->config[AUTHENTICATION_DOMAIN],
+		                dom->config[AUTHENTICATION_DOMAIN])) {
+			/* Domain collision */
+			mg_cry_internal(fc(ctx),
+			                "domain %s already in use",
+			                new_dom->config[AUTHENTICATION_DOMAIN]);
+			mg_free(new_dom);
+			return -5;
+		}
+
+		/* Count number of domains */
+		idx++;
+
+		if (dom->next == NULL) {
+			dom->next = new_dom;
+			break;
+		}
+		dom = dom->next;
+	}
+
+	mg_unlock_context(ctx);
+
+	/* Return domain number */
+	return idx;
+}
+#endif
+
+
 /* Feature check API function */
 unsigned
 mg_check_feature(unsigned feature)
@@ -17001,49 +18806,55 @@ mg_check_feature(unsigned feature)
  * This bit mask is created at compile time, according to the active
  * preprocessor defines. It is a single const value at runtime. */
 #if !defined(NO_FILES)
-	                                    | 0x0001u
+	                                    | MG_FEATURES_FILES
 #endif
 #if !defined(NO_SSL)
-	                                    | 0x0002u
+	                                    | MG_FEATURES_SSL
 #endif
 #if !defined(NO_CGI)
-	                                    | 0x0004u
+	                                    | MG_FEATURES_CGI
 #endif
 #if defined(USE_IPV6)
-	                                    | 0x0008u
+	                                    | MG_FEATURES_IPV6
 #endif
 #if defined(USE_WEBSOCKET)
-	                                    | 0x0010u
+	                                    | MG_FEATURES_WEBSOCKET
 #endif
 #if defined(USE_LUA)
-	                                    | 0x0020u
+	                                    | MG_FEATURES_LUA
 #endif
 #if defined(USE_DUKTAPE)
-	                                    | 0x0040u
+	                                    | MG_FEATURES_SSJS
 #endif
 #if !defined(NO_CACHING)
-	                                    | 0x0080u
+	                                    | MG_FEATURES_CACHE
 #endif
 #if defined(USE_SERVER_STATS)
-	                                    | 0x0100u
+	                                    | MG_FEATURES_STATS
+#endif
+#if defined(USE_ZLIB)
+	                                    | MG_FEATURES_COMPRESSION
 #endif
 
 /* Set some extra bits not defined in the API documentation.
  * These bits may change without further notice. */
 #if defined(MG_LEGACY_INTERFACE)
-	                                    | 0x8000u
+	                                    | 0x00008000u
+#endif
+#if defined(MG_EXPERIMENTAL_INTERFACES)
+	                                    | 0x00004000u
 #endif
 #if defined(MEMORY_DEBUGGING)
-	                                    | 0x0100u
+	                                    | 0x00001000u
 #endif
 #if defined(USE_TIMERS)
-	                                    | 0x0200u
+	                                    | 0x00020000u
 #endif
 #if !defined(NO_NONCE_CHECK)
-	                                    | 0x0400u
+	                                    | 0x00040000u
 #endif
 #if !defined(NO_POPEN)
-	                                    | 0x0800u
+	                                    | 0x00080000u
 #endif
 	    ;
 	return (feature & feature_set);
@@ -17107,7 +18918,6 @@ mg_get_system_info_impl(char *buffer, int buflen)
 	/* System info */
 	{
 #if defined(_WIN32)
-#if !defined(__SYMBIAN32__)
 		DWORD dwVersion = 0;
 		DWORD dwMajorVersion = 0;
 		DWORD dwMinorVersion = 0;
@@ -17115,13 +18925,13 @@ mg_get_system_info_impl(char *buffer, int buflen)
 
 		GetSystemInfo(&si);
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER)
 #pragma warning(push)
 /* GetVersion was declared deprecated */
 #pragma warning(disable : 4996)
 #endif
 		dwVersion = GetVersion();
-#ifdef _MSC_VER
+#if defined(_MSC_VER)
 #pragma warning(pop)
 #endif
 
@@ -17154,14 +18964,6 @@ mg_get_system_info_impl(char *buffer, int buflen)
 		if (system_info_length < buflen) {
 			strcat0(buffer, block);
 		}
-
-#else
-		mg_snprintf(NULL, NULL, block, sizeof(block), "%s - Symbian%s", eol);
-		system_info_length += (int)strlen(block);
-		if (system_info_length < buflen) {
-			strcat0(buffer, block);
-		}
-#endif
 #else
 		struct utsname name;
 		memset(&name, 0, sizeof(name));
@@ -17194,22 +18996,23 @@ mg_get_system_info_impl(char *buffer, int buflen)
 		            "\"feature_list\" : \"Server:%s%s%s%s%s%s%s%s%s\",%s",
 		            (unsigned long)mg_check_feature(0xFFFFFFFFu),
 		            eol,
-		            mg_check_feature(1) ? " Files" : "",
-		            mg_check_feature(2) ? " HTTPS" : "",
-		            mg_check_feature(4) ? " CGI" : "",
-		            mg_check_feature(8) ? " IPv6" : "",
-		            mg_check_feature(16) ? " WebSockets" : "",
-		            mg_check_feature(32) ? " Lua" : "",
-		            mg_check_feature(64) ? " JavaScript" : "",
-		            mg_check_feature(128) ? " Cache" : "",
-		            mg_check_feature(256) ? " Stats" : "",
+		            mg_check_feature(MG_FEATURES_FILES) ? " Files" : "",
+		            mg_check_feature(MG_FEATURES_SSL) ? " HTTPS" : "",
+		            mg_check_feature(MG_FEATURES_CGI) ? " CGI" : "",
+		            mg_check_feature(MG_FEATURES_IPV6) ? " IPv6" : "",
+		            mg_check_feature(MG_FEATURES_WEBSOCKET) ? " WebSockets"
+		                                                    : "",
+		            mg_check_feature(MG_FEATURES_LUA) ? " Lua" : "",
+		            mg_check_feature(MG_FEATURES_SSJS) ? " JavaScript" : "",
+		            mg_check_feature(MG_FEATURES_CACHE) ? " Cache" : "",
+		            mg_check_feature(MG_FEATURES_STATS) ? " Stats" : "",
 		            eol);
 		system_info_length += (int)strlen(block);
 		if (system_info_length < buflen) {
 			strcat0(buffer, block);
 		}
 
-#ifdef USE_LUA
+#if defined(USE_LUA)
 		mg_snprintf(NULL,
 		            NULL,
 		            block,
@@ -17242,14 +19045,11 @@ mg_get_system_info_impl(char *buffer, int buflen)
 
 	/* Build date */
 	{
-
-// Sergey Linev: remove this kind of warning suppression, most probably for old GCC
-//#if defined(__GNUC__)
-//#pragma GCC diagnostic push
+#if defined(GCC_DIAGNOSTIC)
+#pragma GCC diagnostic push
 /* Disable bogus compiler warning -Wdate-time */
-// #pragma GCC diagnostic ignored "-Wall"
-// #pragma GCC diagnostic ignored "-Werror"
-//#endif
+#pragma GCC diagnostic ignored "-Wdate-time"
+#endif
 		mg_snprintf(NULL,
 		            NULL,
 		            block,
@@ -17258,9 +19058,9 @@ mg_get_system_info_impl(char *buffer, int buflen)
 		            __DATE__,
 		            eol);
 
-//#if defined(__GNUC__)
-//#pragma GCC diagnostic pop
-//#endif
+#if defined(GCC_DIAGNOSTIC)
+#pragma GCC diagnostic pop
+#endif
 
 		system_info_length += (int)strlen(block);
 		if (system_info_length < buflen) {
@@ -17405,26 +19205,26 @@ mg_get_system_info_impl(char *buffer, int buflen)
 	/* Determine 32/64 bit data mode.
 	 * see https://en.wikipedia.org/wiki/64-bit_computing */
 	{
-		mg_snprintf(
-		    NULL,
-		    NULL,
-		    block,
-		    sizeof(block),
-		    "\"data_model\" : \"int:%u/%u/%u/%u, float:%u/%u/%u, char:%u/%u, "
-		    "ptr:%u, size:%u, time:%u\"%s",
-		    (unsigned)sizeof(short),
-		    (unsigned)sizeof(int),
-		    (unsigned)sizeof(long),
-		    (unsigned)sizeof(long long),
-		    (unsigned)sizeof(float),
-		    (unsigned)sizeof(double),
-		    (unsigned)sizeof(long double),
-		    (unsigned)sizeof(char),
-		    (unsigned)sizeof(wchar_t),
-		    (unsigned)sizeof(void *),
-		    (unsigned)sizeof(size_t),
-		    (unsigned)sizeof(time_t),
-		    eol);
+		mg_snprintf(NULL,
+		            NULL,
+		            block,
+		            sizeof(block),
+		            "\"data_model\" : \"int:%u/%u/%u/%u, float:%u/%u/%u, "
+		            "char:%u/%u, "
+		            "ptr:%u, size:%u, time:%u\"%s",
+		            (unsigned)sizeof(short),
+		            (unsigned)sizeof(int),
+		            (unsigned)sizeof(long),
+		            (unsigned)sizeof(long long),
+		            (unsigned)sizeof(float),
+		            (unsigned)sizeof(double),
+		            (unsigned)sizeof(long double),
+		            (unsigned)sizeof(char),
+		            (unsigned)sizeof(wchar_t),
+		            (unsigned)sizeof(void *),
+		            (unsigned)sizeof(size_t),
+		            (unsigned)sizeof(time_t),
+		            eol);
 		system_info_length += (int)strlen(block);
 		if (system_info_length < buflen) {
 			strcat0(buffer, block);
@@ -17476,8 +19276,8 @@ mg_get_context_info_impl(const struct mg_context *ctx, char *buffer, int buflen)
 		strcat0(buffer, block);
 	}
 
-	/* Memory information */
-	if (ms) {
+	if (ms) { /* <-- should be always true */
+		/* Memory information */
 		mg_snprintf(NULL,
 		            NULL,
 		            block,
@@ -17503,9 +19303,15 @@ mg_get_context_info_impl(const struct mg_context *ctx, char *buffer, int buflen)
 		}
 	}
 
-
-	/* Connections information */
 	if (ctx) {
+		/* Declare all variables at begin of the block, to comply
+		 * with old C standards. */
+		char start_time_str[64] = {0};
+		char now_str[64] = {0};
+		time_t start_time = ctx->start_time;
+		time_t now = time(NULL);
+
+		/* Connections information */
 		mg_snprintf(NULL,
 		            NULL,
 		            block,
@@ -17528,10 +19334,8 @@ mg_get_context_info_impl(const struct mg_context *ctx, char *buffer, int buflen)
 		if (context_info_length + reserved_len < buflen) {
 			strcat0(buffer, block);
 		}
-	}
 
-	/* Requests information */
-	if (ctx) {
+		/* Requests information */
 		mg_snprintf(NULL,
 		            NULL,
 		            block,
@@ -17548,10 +19352,8 @@ mg_get_context_info_impl(const struct mg_context *ctx, char *buffer, int buflen)
 		if (context_info_length + reserved_len < buflen) {
 			strcat0(buffer, block);
 		}
-	}
 
-	/* Data information */
-	if (ctx) {
+		/* Data information */
 		mg_snprintf(NULL,
 		            NULL,
 		            block,
@@ -17571,15 +19373,8 @@ mg_get_context_info_impl(const struct mg_context *ctx, char *buffer, int buflen)
 		if (context_info_length + reserved_len < buflen) {
 			strcat0(buffer, block);
 		}
-	}
 
-	/* Execution time information */
-	if (ctx) {
-		char start_time_str[64] = {0};
-		char now_str[64] = {0};
-		time_t start_time = ctx->start_time;
-		time_t now = time(NULL);
-
+		/* Execution time information */
 		gmt_time_string(start_time_str,
 		                sizeof(start_time_str) - 1,
 		                &start_time);
@@ -17623,7 +19418,7 @@ mg_get_context_info_impl(const struct mg_context *ctx, char *buffer, int buflen)
 #endif
 
 
-#ifdef MG_EXPERIMENTAL_INTERFACES
+#if defined(MG_EXPERIMENTAL_INTERFACES)
 /* Get connection information. It can be printed or stored by the caller.
  * Return the size of available information. */
 static int
@@ -17922,7 +19717,7 @@ mg_get_context_info(const struct mg_context *ctx, char *buffer, int buflen)
 }
 
 
-#ifdef MG_EXPERIMENTAL_INTERFACES
+#if defined(MG_EXPERIMENTAL_INTERFACES)
 int
 mg_get_connection_info(const struct mg_context *ctx,
                        int idx,
@@ -17965,12 +19760,13 @@ mg_init_library(unsigned features)
 		if (0 != pthread_key_create(&sTlsKey, tls_dtor)) {
 			/* Fatal error - abort start. However, this situation should
 			 * never occur in practice. */
+			mg_global_unlock();
 			return 0;
 		}
 
-#if defined(_WIN32) && !defined(__SYMBIAN32__)
+#if defined(_WIN32)
 		InitializeCriticalSection(&global_log_file_lock);
-#endif /* _WIN32 && !__SYMBIAN32__ */
+#endif
 #if !defined(_WIN32)
 		pthread_mutexattr_init(&pthread_mutex_attr);
 		pthread_mutexattr_settype(&pthread_mutex_attr, PTHREAD_MUTEX_RECURSIVE);
@@ -17981,16 +19777,17 @@ mg_init_library(unsigned features)
 #endif
 	}
 
+	mg_global_unlock();
 
 #if !defined(NO_SSL)
-	if (features_to_init & 2) {
+	if (features_to_init & MG_FEATURES_SSL) {
 		if (!mg_ssl_initialized) {
 			if (initialize_ssl(ebuf, sizeof(ebuf))) {
 				mg_ssl_initialized = 1;
 			} else {
 				(void)ebuf;
-				/* TODO: print error */
-				features_inited &= ~(2u);
+				DEBUG_TRACE("Initializing SSL failed: %s", ebuf);
+				features_inited &= ~((unsigned)(MG_FEATURES_SSL));
 			}
 		} else {
 			/* ssl already initialized */
@@ -17999,16 +19796,16 @@ mg_init_library(unsigned features)
 #endif
 
 	/* Start WinSock for Windows */
+	mg_global_lock();
 	if (mg_init_library_called <= 0) {
-#if defined(_WIN32) && !defined(__SYMBIAN32__)
+#if defined(_WIN32)
 		WSADATA data;
 		WSAStartup(MAKEWORD(2, 2), &data);
-#endif /* _WIN32 && !__SYMBIAN32__ */
+#endif /* _WIN32 */
 		mg_init_library_called = 1;
 	} else {
 		mg_init_library_called++;
 	}
-
 	mg_global_unlock();
 
 	return features_inited;
@@ -18027,9 +19824,9 @@ mg_exit_library(void)
 
 	mg_init_library_called--;
 	if (mg_init_library_called == 0) {
-#if defined(_WIN32) && !defined(__SYMBIAN32__)
+#if defined(_WIN32)
 		(void)WSACleanup();
-#endif /* _WIN32 && !__SYMBIAN32__ */
+#endif /* _WIN32  */
 #if !defined(NO_SSL)
 		if (mg_ssl_initialized) {
 			uninitialize_ssl();
@@ -18037,9 +19834,9 @@ mg_exit_library(void)
 		}
 #endif
 
-#if defined(_WIN32) && !defined(__SYMBIAN32__)
+#if defined(_WIN32)
 		(void)DeleteCriticalSection(&global_log_file_lock);
-#endif /* _WIN32 && !__SYMBIAN32__ */
+#endif /* _WIN32 */
 #if !defined(_WIN32)
 		(void)pthread_mutexattr_destroy(&pthread_mutex_attr);
 #endif

--- a/net/http/civetweb/civetweb.h
+++ b/net/http/civetweb/civetweb.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2013-2017 the Civetweb developers
+/* Copyright (c) 2013-2018 the Civetweb developers
  * Copyright (c) 2004-2013 Sergey Lyubka
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -23,11 +23,10 @@
 #ifndef CIVETWEB_HEADER_INCLUDED
 #define CIVETWEB_HEADER_INCLUDED
 
-#define CIVETWEB_VERSION "1.10"
+#define CIVETWEB_VERSION "1.12"
 #define CIVETWEB_VERSION_MAJOR (1)
-#define CIVETWEB_VERSION_MINOR (10)
+#define CIVETWEB_VERSION_MINOR (12)
 #define CIVETWEB_VERSION_PATCH (0)
-#define CIVETWEB_VERSION_RELEASED
 
 #ifndef CIVETWEB_API
 #if defined(_WIN32)
@@ -45,12 +44,64 @@
 #endif
 #endif
 
-#include <stdio.h>
 #include <stddef.h>
+#include <stdio.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
+
+
+/* Init Features */
+enum {
+	MG_FEATURES_DEFAULT = 0x0u,
+
+	/* Support files from local directories */
+	/* Will only work, if NO_FILES is not set. */
+	MG_FEATURES_FILES = 0x1u,
+
+	/* Support transport layer security (TLS). */
+	/* SSL is still often used synonymously for TLS. */
+	/* Will only work, if NO_SSL is not set. */
+	MG_FEATURES_TLS = 0x2u,
+	MG_FEATURES_SSL = 0x2u,
+
+	/* Support common gateway interface (CGI). */
+	/* Will only work, if NO_CGI is not set. */
+	MG_FEATURES_CGI = 0x4u,
+
+	/* Support IPv6. */
+	/* Will only work, if USE_IPV6 is set. */
+	MG_FEATURES_IPV6 = 0x8u,
+
+	/* Support WebSocket protocol. */
+	/* Will only work, if USE_WEBSOCKET is set. */
+	MG_FEATURES_WEBSOCKET = 0x10u,
+
+	/* Support server side Lua scripting. */
+	/* Will only work, if USE_LUA is set. */
+	MG_FEATURES_LUA = 0x20u,
+
+	/* Support server side JavaScript scripting. */
+	/* Will only work, if USE_DUKTAPE is set. */
+	MG_FEATURES_SSJS = 0x40u,
+
+	/* Provide data required for caching files. */
+	/* Will only work, if NO_CACHING is not set. */
+	MG_FEATURES_CACHE = 0x80u,
+
+	/* Collect server status information. */
+	/* Will only work, if USE_SERVER_STATS is set. */
+	MG_FEATURES_STATS = 0x100u,
+
+	/* Support on-the-fly compression. */
+	/* Will only work, if USE_ZLIB is set. */
+	MG_FEATURES_COMPRESSION = 0x200u,
+
+	/* Collect server status information. */
+	/* Will only work, if USE_SERVER_STATS is set. */
+	MG_FEATURES_ALL = 0xFFFFu
+};
 
 
 /* Initialize this library. This should be called once before any other
@@ -58,6 +109,11 @@ extern "C" {
  * thread safe.
  * Parameters:
  *   features: bit mask for features to be initialized.
+ *             Note: The TLS libraries (like OpenSSL) is initialized
+ *                   only if the MG_FEATURES_TLS bit is set.
+ *                   Currently the other bits do not influence
+ *                   initialization, but this may change in future
+ *                   versions.
  * Return value:
  *   initialized features
  *   0: error
@@ -87,14 +143,14 @@ struct mg_header {
 
 /* This structure contains information about the HTTP request. */
 struct mg_request_info {
-	const char *request_method; /* "GET", "POST", etc */
-	const char *request_uri;    /* URL-decoded URI (absolute or relative,
-	                             * as in the request) */
-	const char *local_uri;      /* URL-decoded URI (relative). Can be NULL
-	                             * if the request_uri does not address a
-	                             * resource at the server host. */
-#if defined(MG_LEGACY_INTERFACE)
-	const char *uri; /* Deprecated: use local_uri instead */
+	const char *request_method;  /* "GET", "POST", etc */
+	const char *request_uri;     /* URL-decoded URI (absolute or relative,
+	                              * as in the request) */
+	const char *local_uri;       /* URL-decoded URI (relative). Can be NULL
+	                              * if the request_uri does not address a
+	                              * resource at the server host. */
+#if defined(MG_LEGACY_INTERFACE) /* 2017-02-04, deprecated 2014-09-14 */
+	const char *uri;             /* Deprecated: use local_uri instead */
 #endif
 	const char *http_version; /* E.g. "1.0", "1.1" */
 	const char *query_string; /* URL part after '?', not including '?', or
@@ -102,11 +158,6 @@ struct mg_request_info {
 	const char *remote_user;  /* Authenticated user, or NULL if no auth
 	                             used */
 	char remote_addr[48];     /* Client's IP address as a string. */
-
-#if defined(MG_LEGACY_INTERFACE)
-	long remote_ip; /* Client's IP address. Deprecated: use remote_addr instead
-	                   */
-#endif
 
 	long long content_length; /* Length (in bytes) of the request body,
 	                             can be -1 if no length was given. */
@@ -145,12 +196,14 @@ struct mg_response_info {
 /* Client certificate information (part of mg_request_info) */
 /* New nomenclature. */
 struct mg_client_cert {
+	void *peer_cert;
 	const char *subject;
 	const char *issuer;
 	const char *serial;
 	const char *finger;
 };
 
+#if defined(MG_LEGACY_INTERFACE) /* 2017-10-05 */
 /* Old nomenclature. */
 struct client_cert {
 	const char *subject;
@@ -158,6 +211,7 @@ struct client_cert {
 	const char *serial;
 	const char *finger;
 };
+#endif
 
 
 /* This structure needs to be passed to mg_start(), to let civetweb know
@@ -200,7 +254,21 @@ struct mg_callbacks {
 	    -1: initializing ssl fails. */
 	int (*init_ssl)(void *ssl_context, void *user_data);
 
-#if defined(MG_LEGACY_INTERFACE)
+	/* Called when civetweb is about to create or free a SSL_CTX.
+	Parameters:
+	   ssl_ctx: SSL_CTX pointer. NULL at creation time, Not NULL when mg_context
+	            will be freed
+	     user_data: parameter user_data passed when starting the server.
+	   Return value:
+	     0: civetweb will continue to create the context, just as if the
+	        callback would not be present.
+	        The value in *ssl_ctx when the function returns is ignored.
+	     1: civetweb will copy the value from *ssl_ctx to the civetweb context
+	        and doesn't create its own.
+	    -1: initializing ssl fails.*/
+	int (*external_ssl_ctx)(void **ssl_ctx, void *user_data);
+
+#if defined(MG_LEGACY_INTERFACE) /* 2015-08-19 */
 	/* Called when websocket request is received, before websocket handshake.
 	   Return value:
 	     0: civetweb proceeds with websocket handshake.
@@ -245,40 +313,14 @@ struct mg_callbacks {
 	*/
 	void (*connection_close)(const struct mg_connection *);
 
-#if defined(MG_USE_OPEN_FILE)
-	/* Note: The "file in memory" feature is a deletion candidate, since
-	 * it complicates the code, and does not add any value compared to
-	 * "mg_add_request_handler".
-	 * See this discussion thread:
-	 * https://groups.google.com/forum/#!topic/civetweb/h9HT4CmeYqI
-	 * If you disagree, if there is any situation this is indeed useful
-	 * and cannot trivially be replaced by another existing feature,
-	 * please contribute to this discussion during the next 3 month
-	 * (till end of April 2017), otherwise this feature might be dropped
-	 * in future releases. */
-
-	/* Called when civetweb tries to open a file. Used to intercept file open
-	   calls, and serve file data from memory instead.
-	   Parameters:
-	      path:     Full path to the file to open.
-	      data_len: Placeholder for the file size, if file is served from
-	                memory.
-	   Return value:
-	     NULL: do not serve file from memory, proceed with normal file open.
-	     non-NULL: pointer to the file contents in memory. data_len must be
-	       initialized with the size of the memory block. */
-	const char *(*open_file)(const struct mg_connection *,
-	                         const char *path,
-	                         size_t *data_len);
-#endif
-
 	/* Called when civetweb is about to serve Lua server page, if
 	   Lua support is enabled.
 	   Parameters:
+	     conn: current connection.
 	     lua_context: "lua_State *" pointer. */
-	void (*init_lua)(const struct mg_connection *, void *lua_context);
+	void (*init_lua)(const struct mg_connection *conn, void *lua_context);
 
-#if defined(MG_LEGACY_INTERFACE)
+#if defined(MG_LEGACY_INTERFACE) /* 2016-05-14 */
 	/* Called when civetweb has uploaded a file to a temporary directory as a
 	   result of mg_upload() call.
 	   Note that mg_upload is deprecated. Use mg_handle_form_request instead.
@@ -290,11 +332,15 @@ struct mg_callbacks {
 	/* Called when civetweb is about to send HTTP error to the client.
 	   Implementing this callback allows to create custom error pages.
 	   Parameters:
+	     conn: current connection.
 	     status: HTTP error status code.
+	     errmsg: error message text.
 	   Return value:
 	     1: run civetweb error handler.
 	     0: callback already handled the error. */
-	int (*http_error)(struct mg_connection *, int status);
+	int (*http_error)(struct mg_connection *conn,
+	                  int status,
+	                  const char *errmsg);
 
 	/* Called after civetweb context has been created, before requests
 	   are processed.
@@ -370,6 +416,29 @@ CIVETWEB_API struct mg_context *mg_start(const struct mg_callbacks *callbacks,
    release all associated resources. This function blocks until all Civetweb
    threads are stopped. Context pointer becomes invalid. */
 CIVETWEB_API void mg_stop(struct mg_context *);
+
+
+#if defined(MG_EXPERIMENTAL_INTERFACES)
+/* Add an additional domain to an already running web server.
+ *
+ * Parameters:
+ *   ctx: Context handle of a server started by mg_start.
+ *   options: NULL terminated list of option_name, option_value pairs that
+ *            specify CivetWeb configuration parameters.
+ *
+ * Return:
+ *   < 0 in case of an error
+ *    -1 for a parameter error
+ *    -2 invalid options
+ *    -3 initializing SSL failed
+ *    -4 mandatory domain option missing
+ *    -5 duplicate domain
+ *    -6 out of memory
+ *   > 0 index / handle of a new domain
+ */
+CIVETWEB_API int mg_start_domain(struct mg_context *ctx,
+                                 const char **configuration_options);
+#endif
 
 
 /* mg_request_handler
@@ -531,6 +600,14 @@ CIVETWEB_API void *mg_get_user_data(const struct mg_context *ctx);
 
 
 /* Set user data for the current connection. */
+/* Note: This function is deprecated. Use the init_connection callback
+   instead to initialize the user connection data pointer. It is
+   reccomended to supply a pointer to some user defined data structure
+   as conn_data initializer in init_connection. In case it is required
+   to change some data after the init_connection call, store another
+   data pointer in the user defined data structure and modify that
+   pointer. In either case, after the init_connection callback, only
+   calls to mg_get_user_connection_data should be required. */
 CIVETWEB_API void mg_set_user_connection_data(struct mg_connection *conn,
                                               void *data);
 
@@ -553,7 +630,7 @@ CIVETWEB_API int
 mg_get_request_link(const struct mg_connection *conn, char *buf, size_t buflen);
 
 
-#if defined(MG_LEGACY_INTERFACE)
+#if defined(MG_LEGACY_INTERFACE) /* 2014-02-21 */
 /* Return array of strings that represent valid configuration options.
    For each option, option name and default value is returned, i.e. the
    number of entries in the array equals to number_of_options x 2.
@@ -570,6 +647,7 @@ struct mg_option {
 };
 
 /* Old nomenclature */
+#if defined(MG_LEGACY_INTERFACE) /* 2017-10-05 */
 enum {
 	CONFIG_TYPE_UNKNOWN = 0x0,
 	CONFIG_TYPE_NUMBER = 0x1,
@@ -581,6 +659,7 @@ enum {
 	CONFIG_TYPE_STRING_LIST = 0x7,
 	CONFIG_TYPE_STRING_MULTILINE = 0x8
 };
+#endif
 
 /* New nomenclature */
 enum {
@@ -592,7 +671,8 @@ enum {
 	MG_CONFIG_TYPE_BOOLEAN = 0x5,
 	MG_CONFIG_TYPE_EXT_PATTERN = 0x6,
 	MG_CONFIG_TYPE_STRING_LIST = 0x7,
-	MG_CONFIG_TYPE_STRING_MULTILINE = 0x8
+	MG_CONFIG_TYPE_STRING_MULTILINE = 0x8,
+	MG_CONFIG_TYPE_YES_NO_OPTIONAL = 0x9
 };
 
 /* Return array of struct mg_option, representing all valid configuration
@@ -623,10 +703,12 @@ CIVETWEB_API int mg_get_server_ports(const struct mg_context *ctx,
                                      struct mg_server_ports *ports);
 
 
-#if defined(MG_LEGACY_INTERFACE)
+#if defined(MG_LEGACY_INTERFACE) /* 2017-04-02 */
 /* Deprecated: Use mg_get_server_ports instead. */
-CIVETWEB_API size_t
-mg_get_ports(const struct mg_context *ctx, size_t size, int *ports, int *ssl);
+CIVETWEB_API size_t mg_get_ports(const struct mg_context *ctx,
+                                 size_t size,
+                                 int *ports,
+                                 int *ssl);
 #endif
 
 
@@ -726,7 +808,7 @@ CIVETWEB_API void mg_lock_connection(struct mg_connection *conn);
 CIVETWEB_API void mg_unlock_connection(struct mg_connection *conn);
 
 
-#if defined(MG_LEGACY_INTERFACE)
+#if defined(MG_LEGACY_INTERFACE) /* 2014-06-21 */
 #define mg_lock mg_lock_connection
 #define mg_unlock mg_unlock_connection
 #endif
@@ -739,7 +821,7 @@ CIVETWEB_API void mg_unlock_context(struct mg_context *ctx);
 
 
 /* Opcodes, from http://tools.ietf.org/html/rfc6455 */
-/* Old nomenclature */
+#if defined(MG_LEGACY_INTERFACE) /* 2017-10-05 */
 enum {
 	WEBSOCKET_OPCODE_CONTINUATION = 0x0,
 	WEBSOCKET_OPCODE_TEXT = 0x1,
@@ -748,6 +830,7 @@ enum {
 	WEBSOCKET_OPCODE_PING = 0x9,
 	WEBSOCKET_OPCODE_PONG = 0xa
 };
+#endif
 
 /* New nomenclature */
 enum {
@@ -794,15 +877,65 @@ CIVETWEB_API int mg_send_chunk(struct mg_connection *conn,
                                unsigned int chunk_len);
 
 
-/* Send contents of the entire file together with HTTP headers. */
+/* Send contents of the entire file together with HTTP headers.
+ * Parameters:
+ *   conn: Current connection information.
+ *   path: Full path to the file to send.
+ * This function has been superseded by mg_send_mime_file
+ */
 CIVETWEB_API void mg_send_file(struct mg_connection *conn, const char *path);
 
 
+/* Send contents of the file without HTTP headers.
+ * The code must send a valid HTTP response header before using this function.
+ *
+ * Parameters:
+ *   conn: Current connection information.
+ *   path: Full path to the file to send.
+ *
+ * Return:
+ *   < 0   Error
+ */
+CIVETWEB_API int mg_send_file_body(struct mg_connection *conn,
+                                   const char *path);
+
+
 /* Send HTTP error reply. */
-CIVETWEB_API void mg_send_http_error(struct mg_connection *conn,
-                                     int status_code,
-                                     PRINTF_FORMAT_STRING(const char *fmt),
-                                     ...) PRINTF_ARGS(3, 4);
+CIVETWEB_API int mg_send_http_error(struct mg_connection *conn,
+                                    int status_code,
+                                    PRINTF_FORMAT_STRING(const char *fmt),
+                                    ...) PRINTF_ARGS(3, 4);
+
+
+/* Send "HTTP 200 OK" response header.
+ * After calling this function, use mg_write or mg_send_chunk to send the
+ * response body.
+ * Parameters:
+ *   conn: Current connection handle.
+ *   mime_type: Set Content-Type for the following content.
+ *   content_length: Size of the following content, if content_length >= 0.
+ *                   Will set transfer-encoding to chunked, if set to -1.
+ * Return:
+ *   < 0   Error
+ */
+CIVETWEB_API int mg_send_http_ok(struct mg_connection *conn,
+                                 const char *mime_type,
+                                 long long content_length);
+
+
+/* Send "HTTP 30x" redirect response.
+ * The response has content-size zero: do not send any body data after calling
+ * this function.
+ * Parameters:
+ *   conn: Current connection handle.
+ *   target_url: New location.
+ *   redirect_code: HTTP redirect type. Could be 301, 302, 303, 307, 308.
+ * Return:
+ *   < 0   Error (-1 send error, -2 parameter error)
+ */
+CIVETWEB_API int mg_send_http_redirect(struct mg_connection *conn,
+                                       const char *target_url,
+                                       int redirect_code);
 
 
 /* Send HTTP digest access authentication request.
@@ -979,7 +1112,7 @@ CIVETWEB_API int mg_get_cookie(const char *cookie,
 /* Download data from the remote web server.
      host: host name to connect to, e.g. "foo.com", or "10.12.40.1".
      port: port number, e.g. 80.
-     use_ssl: wether to use SSL connection.
+     use_ssl: whether to use SSL connection.
      error_buffer, error_buffer_size: error message placeholder.
      request_fmt,...: HTTP request.
    Return:
@@ -1005,7 +1138,7 @@ mg_download(const char *host,
 CIVETWEB_API void mg_close_connection(struct mg_connection *conn);
 
 
-#if defined(MG_LEGACY_INTERFACE)
+#if defined(MG_LEGACY_INTERFACE) /* 2016-05-14 */
 /* File upload functionality. Each uploaded file gets saved into a temporary
    file and MG_UPLOAD event is sent.
    Return number of uploaded files.
@@ -1052,7 +1185,8 @@ struct mg_form_data_handler {
 	 *   user_data: Value of the member user_data of mg_form_data_handler
 	 *
 	 * Return value:
-	 *   TODO: Needs to be defined.
+	 *   The return code determines how the server should continue processing
+	 *   the current request (See MG_FORM_FIELD_HANDLE_*).
 	 */
 	int (*field_get)(const char *key,
 	                 const char *value,
@@ -1073,7 +1207,8 @@ struct mg_form_data_handler {
 	 *   user_data: Value of the member user_data of mg_form_data_handler
 	 *
 	 * Return value:
-	 *   TODO: Needs to be defined.
+	 *   The return code determines how the server should continue processing
+	 *   the current request (See MG_FORM_FIELD_HANDLE_*).
 	 */
 	int (*field_store)(const char *path, long long file_size, void *user_data);
 
@@ -1084,10 +1219,10 @@ struct mg_form_data_handler {
 
 /* Return values definition for the "field_found" callback in
  * mg_form_data_handler. */
-/* Old nomenclature */
+#if defined(MG_LEGACY_INTERFACE) /* 2017-10-05 */
 enum {
 	/* Skip this field (neither get nor store it). Continue with the
-     * next field. */
+	 * next field. */
 	FORM_FIELD_STORAGE_SKIP = 0x0,
 	/* Get the field value. */
 	FORM_FIELD_STORAGE_GET = 0x1,
@@ -1096,11 +1231,11 @@ enum {
 	/* Stop parsing this request. Skip the remaining fields. */
 	FORM_FIELD_STORAGE_ABORT = 0x10
 };
-
+#endif
 /* New nomenclature */
 enum {
 	/* Skip this field (neither get nor store it). Continue with the
-     * next field. */
+	 * next field. */
 	MG_FORM_FIELD_STORAGE_SKIP = 0x0,
 	/* Get the field value. */
 	MG_FORM_FIELD_STORAGE_GET = 0x1,
@@ -1109,6 +1244,18 @@ enum {
 	/* Stop parsing this request. Skip the remaining fields. */
 	MG_FORM_FIELD_STORAGE_ABORT = 0x10
 };
+
+/* Return values for "field_get" and "field_store" */
+enum {
+	/* Only "field_get": If there is more data in this field, get the next
+	 * chunk. Otherwise: handle the next field. */
+	MG_FORM_FIELD_HANDLE_GET = 0x1,
+	/* Handle the next field */
+	MG_FORM_FIELD_HANDLE_NEXT = 0x8,
+	/* Stop parsing this request */
+	MG_FORM_FIELD_HANDLE_ABORT = 0x10
+};
+
 
 /* Process form data.
  * Returns the number of fields handled, or < 0 in case of an error.
@@ -1241,6 +1388,7 @@ struct mg_client_options {
 	int port;
 	const char *client_cert;
 	const char *server_cert;
+	const char *host_name;
 	/* TODO: add more data */
 };
 

--- a/net/http/civetweb/file_ops.inl
+++ b/net/http/civetweb/file_ops.inl
@@ -1,1 +1,0 @@
-/* currently not required */

--- a/net/http/civetweb/handle_form.inl
+++ b/net/http/civetweb/handle_form.inl
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016-2017 the Civetweb developers
+/* Copyright (c) 2016-2018 the Civetweb developers
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,7 +40,7 @@ url_encoded_field_found(const struct mg_connection *conn,
 	    mg_url_decode(key, (int)key_len, key_dec, (int)sizeof(key_dec), 1);
 
 	if (((size_t)key_dec_len >= (size_t)sizeof(key_dec)) || (key_dec_len < 0)) {
-		return FORM_FIELD_STORAGE_SKIP;
+		return MG_FORM_FIELD_STORAGE_SKIP;
 	}
 
 	if (filename) {
@@ -53,8 +53,8 @@ url_encoded_field_found(const struct mg_connection *conn,
 		if (((size_t)filename_dec_len >= (size_t)sizeof(filename_dec))
 		    || (filename_dec_len < 0)) {
 			/* Log error message and skip this field. */
-			mg_cry(conn, "%s: Cannot decode filename", __func__);
-			return FORM_FIELD_STORAGE_SKIP;
+			mg_cry_internal(conn, "%s: Cannot decode filename", __func__);
+			return MG_FORM_FIELD_STORAGE_SKIP;
 		}
 	} else {
 		filename_dec[0] = 0;
@@ -63,16 +63,20 @@ url_encoded_field_found(const struct mg_connection *conn,
 	ret =
 	    fdh->field_found(key_dec, filename_dec, path, path_len, fdh->user_data);
 
-	if ((ret & 0xF) == FORM_FIELD_STORAGE_GET) {
+	if ((ret & 0xF) == MG_FORM_FIELD_STORAGE_GET) {
 		if (fdh->field_get == NULL) {
-			mg_cry(conn, "%s: Function \"Get\" not available", __func__);
-			return FORM_FIELD_STORAGE_SKIP;
+			mg_cry_internal(conn,
+			                "%s: Function \"Get\" not available",
+			                __func__);
+			return MG_FORM_FIELD_STORAGE_SKIP;
 		}
 	}
-	if ((ret & 0xF) == FORM_FIELD_STORAGE_STORE) {
+	if ((ret & 0xF) == MG_FORM_FIELD_STORAGE_STORE) {
 		if (fdh->field_store == NULL) {
-			mg_cry(conn, "%s: Function \"Store\" not available", __func__);
-			return FORM_FIELD_STORAGE_SKIP;
+			mg_cry_internal(conn,
+			                "%s: Function \"Store\" not available",
+			                __func__);
+			return MG_FORM_FIELD_STORAGE_SKIP;
 		}
 	}
 
@@ -90,16 +94,16 @@ url_encoded_field_get(const struct mg_connection *conn,
 {
 	char key_dec[1024];
 
-	char *value_dec = (char *)mg_malloc_ctx(value_len + 1, conn->ctx);
+	char *value_dec = (char *)mg_malloc_ctx(value_len + 1, conn->phys_ctx);
 	int value_dec_len, ret;
 
 	if (!value_dec) {
 		/* Log error message and stop parsing the form data. */
-		mg_cry(conn,
-		       "%s: Not enough memory (required: %lu)",
-		       __func__,
-		       (unsigned long)(value_len + 1));
-		return FORM_FIELD_STORAGE_ABORT;
+		mg_cry_internal(conn,
+		                "%s: Not enough memory (required: %lu)",
+		                __func__,
+		                (unsigned long)(value_len + 1));
+		return MG_FORM_FIELD_STORAGE_ABORT;
 	}
 
 	mg_url_decode(key, (int)key_len, key_dec, (int)sizeof(key_dec), 1);
@@ -177,7 +181,7 @@ mg_handle_form_request(struct mg_connection *conn,
 {
 	const char *content_type;
 	char path[512];
-	char buf[1024]; /* Must not be smaller than ~900 - see sanity check */
+	char buf[MG_BUF_LEN]; /* Must not be smaller than ~900 */
 	int field_storage;
 	int buf_fill = 0;
 	int r;
@@ -203,7 +207,7 @@ mg_handle_form_request(struct mg_connection *conn,
 	if (!has_body_data) {
 		const char *data;
 
-		if (strcmp(conn->request_info.request_method, "GET")) {
+		if (0 != strcmp(conn->request_info.request_method, "GET")) {
 			/* No body data, but not a GET request.
 			 * This is not a valid form request. */
 			return -1;
@@ -232,14 +236,16 @@ mg_handle_form_request(struct mg_connection *conn,
 
 			/* In every "field_found" callback we ask what to do with the
 			 * data ("field_storage"). This could be:
-			 * FORM_FIELD_STORAGE_SKIP (0) ... ignore the value of this field
-			 * FORM_FIELD_STORAGE_GET (1) ... read the data and call the get
-			 *                              callback function
-			 * FORM_FIELD_STORAGE_STORE (2) ... store the data in a file
-			 * FORM_FIELD_STORAGE_READ (3) ... let the user read the data
-			 *                               (for parsing long data on the fly)
-			 *                               (currently not implemented)
-			 * FORM_FIELD_STORAGE_ABORT (flag) ... stop parsing
+			 * MG_FORM_FIELD_STORAGE_SKIP (0):
+			 *   ignore the value of this field
+			 * MG_FORM_FIELD_STORAGE_GET (1):
+			 *   read the data and call the get callback function
+			 * MG_FORM_FIELD_STORAGE_STORE (2):
+			 *   store the data in a file
+			 * MG_FORM_FIELD_STORAGE_READ (3):
+			 *   let the user read the data (for parsing long data on the fly)
+			 * MG_FORM_FIELD_STORAGE_ABORT (flag):
+			 *   stop parsing
 			 */
 			memset(path, 0, sizeof(path));
 			field_count++;
@@ -262,12 +268,20 @@ mg_handle_form_request(struct mg_connection *conn,
 				next = val + vallen;
 			}
 
-			if (field_storage == FORM_FIELD_STORAGE_GET) {
+			if (field_storage == MG_FORM_FIELD_STORAGE_GET) {
 				/* Call callback */
-				url_encoded_field_get(
+				r = url_encoded_field_get(
 				    conn, data, (size_t)keylen, val, (size_t)vallen, fdh);
+				if (r == MG_FORM_FIELD_HANDLE_ABORT) {
+					/* Stop request handling */
+					break;
+				}
+				if (r == MG_FORM_FIELD_HANDLE_NEXT) {
+					/* Skip to next field */
+					field_storage = MG_FORM_FIELD_STORAGE_SKIP;
+				}
 			}
-			if (field_storage == FORM_FIELD_STORAGE_STORE) {
+			if (field_storage == MG_FORM_FIELD_STORAGE_STORE) {
 				/* Store the content to a file */
 				if (mg_fopen(conn, path, MG_FOPEN_MODE_WRITE, &fstore) == 0) {
 					fstore.access.fp = NULL;
@@ -277,10 +291,10 @@ mg_handle_form_request(struct mg_connection *conn,
 					size_t n = (size_t)
 					    fwrite(val, 1, (size_t)vallen, fstore.access.fp);
 					if ((n != (size_t)vallen) || (ferror(fstore.access.fp))) {
-						mg_cry(conn,
-						       "%s: Cannot write file %s",
-						       __func__,
-						       path);
+						mg_cry_internal(conn,
+						                "%s: Cannot write file %s",
+						                __func__,
+						                path);
 						(void)mg_fclose(&fstore.access);
 						remove_bad_file(conn, path);
 					}
@@ -290,23 +304,31 @@ mg_handle_form_request(struct mg_connection *conn,
 						r = mg_fclose(&fstore.access);
 						if (r == 0) {
 							/* stored successfully */
-							field_stored(conn, path, file_size, fdh);
+							r = field_stored(conn, path, file_size, fdh);
+							if (r == MG_FORM_FIELD_HANDLE_ABORT) {
+								/* Stop request handling */
+								break;
+							}
+
 						} else {
-							mg_cry(conn,
-							       "%s: Error saving file %s",
-							       __func__,
-							       path);
+							mg_cry_internal(conn,
+							                "%s: Error saving file %s",
+							                __func__,
+							                path);
 							remove_bad_file(conn, path);
 						}
 						fstore.access.fp = NULL;
 					}
 
 				} else {
-					mg_cry(conn, "%s: Cannot create file %s", __func__, path);
+					mg_cry_internal(conn,
+					                "%s: Cannot create file %s",
+					                __func__,
+					                path);
 				}
 			}
 
-			/* if (field_storage == FORM_FIELD_STORAGE_READ) { */
+			/* if (field_storage == MG_FORM_FIELD_STORAGE_READ) { */
 			/* The idea of "field_storage=read" is to let the API user read
 			 * data chunk by chunk and to some data processing on the fly.
 			 * This should avoid the need to store data in the server:
@@ -319,8 +341,8 @@ mg_handle_form_request(struct mg_connection *conn,
 			 */
 			/* } */
 
-			if ((field_storage & FORM_FIELD_STORAGE_ABORT)
-			    == FORM_FIELD_STORAGE_ABORT) {
+			if ((field_storage & MG_FORM_FIELD_STORAGE_ABORT)
+			    == MG_FORM_FIELD_STORAGE_ABORT) {
 				/* Stop parsing the request */
 				break;
 			}
@@ -335,8 +357,12 @@ mg_handle_form_request(struct mg_connection *conn,
 	content_type = mg_get_header(conn, "Content-Type");
 
 	if (!content_type
-	    || !mg_strcasecmp(content_type, "APPLICATION/X-WWW-FORM-URLENCODED")
-	    || !mg_strcasecmp(content_type, "APPLICATION/WWW-FORM-URLENCODED")) {
+	    || !mg_strncasecmp(content_type,
+	                       "APPLICATION/X-WWW-FORM-URLENCODED",
+	                       33)
+	    || !mg_strncasecmp(content_type,
+	                       "APPLICATION/WWW-FORM-URLENCODED",
+	                       31)) {
 		/* The form data is in the request body data, encoded in key/value
 		 * pairs. */
 		int all_data_read = 0;
@@ -397,19 +423,22 @@ mg_handle_form_request(struct mg_connection *conn,
 			                                        sizeof(path) - 1,
 			                                        fdh);
 
-			if ((field_storage & FORM_FIELD_STORAGE_ABORT)
-			    == FORM_FIELD_STORAGE_ABORT) {
+			if ((field_storage & MG_FORM_FIELD_STORAGE_ABORT)
+			    == MG_FORM_FIELD_STORAGE_ABORT) {
 				/* Stop parsing the request */
 				break;
 			}
 
-			if (field_storage == FORM_FIELD_STORAGE_STORE) {
+			if (field_storage == MG_FORM_FIELD_STORAGE_STORE) {
 				if (mg_fopen(conn, path, MG_FOPEN_MODE_WRITE, &fstore) == 0) {
 					fstore.access.fp = NULL;
 				}
 				file_size = 0;
 				if (!fstore.access.fp) {
-					mg_cry(conn, "%s: Cannot create file %s", __func__, path);
+					mg_cry_internal(conn,
+					                "%s: Cannot create file %s",
+					                __func__,
+					                path);
 				}
 			}
 
@@ -424,35 +453,43 @@ mg_handle_form_request(struct mg_connection *conn,
 				} else {
 					vallen = (ptrdiff_t)strlen(val);
 					next = val + vallen;
+					end_of_key_value_pair_found = all_data_read;
 				}
 
-				if (field_storage == FORM_FIELD_STORAGE_GET) {
+				if (field_storage == MG_FORM_FIELD_STORAGE_GET) {
 #if 0
 					if (!end_of_key_value_pair_found && !all_data_read) {
 						/* This callback will deliver partial contents */
 					}
-#else
-					(void)all_data_read; /* avoid warning */
 #endif
 
 					/* Call callback */
-					url_encoded_field_get(conn,
-					                      ((get_block > 0) ? NULL : buf),
-					                      ((get_block > 0) ? 0
-					                                       : (size_t)keylen),
-					                      val,
-					                      (size_t)vallen,
-					                      fdh);
+					r = url_encoded_field_get(conn,
+					                          ((get_block > 0) ? NULL : buf),
+					                          ((get_block > 0)
+					                               ? 0
+					                               : (size_t)keylen),
+					                          val,
+					                          (size_t)vallen,
+					                          fdh);
 					get_block++;
+					if (r == MG_FORM_FIELD_HANDLE_ABORT) {
+						/* Stop request handling */
+						break;
+					}
+					if (r == MG_FORM_FIELD_HANDLE_NEXT) {
+						/* Skip to next field */
+						field_storage = MG_FORM_FIELD_STORAGE_SKIP;
+					}
 				}
 				if (fstore.access.fp) {
 					size_t n = (size_t)
 					    fwrite(val, 1, (size_t)vallen, fstore.access.fp);
 					if ((n != (size_t)vallen) || (ferror(fstore.access.fp))) {
-						mg_cry(conn,
-						       "%s: Cannot write file %s",
-						       __func__,
-						       path);
+						mg_cry_internal(conn,
+						                "%s: Cannot write file %s",
+						                __func__,
+						                path);
 						mg_fclose(&fstore.access);
 						remove_bad_file(conn, path);
 					}
@@ -464,6 +501,7 @@ mg_handle_form_request(struct mg_connection *conn,
 					memmove(buf,
 					        buf + (size_t)used,
 					        sizeof(buf) - (size_t)used);
+					next = buf;
 					buf_fill -= (int)used;
 					if ((size_t)buf_fill < (sizeof(buf) - 1)) {
 
@@ -471,6 +509,10 @@ mg_handle_form_request(struct mg_connection *conn,
 						r = mg_read(conn, buf + (size_t)buf_fill, to_read);
 						if (r < 0) {
 							/* read error */
+							if (fstore.access.fp) {
+								mg_fclose(&fstore.access);
+								remove_bad_file(conn, path);
+							}
 							return -1;
 						}
 						if (r != (int)to_read) {
@@ -496,12 +538,24 @@ mg_handle_form_request(struct mg_connection *conn,
 				r = mg_fclose(&fstore.access);
 				if (r == 0) {
 					/* stored successfully */
-					field_stored(conn, path, file_size, fdh);
+					r = field_stored(conn, path, file_size, fdh);
+					if (r == MG_FORM_FIELD_HANDLE_ABORT) {
+						/* Stop request handling */
+						break;
+					}
 				} else {
-					mg_cry(conn, "%s: Error saving file %s", __func__, path);
+					mg_cry_internal(conn,
+					                "%s: Error saving file %s",
+					                __func__,
+					                path);
 					remove_bad_file(conn, path);
 				}
 				fstore.access.fp = NULL;
+			}
+
+			if (all_data_read && (buf_fill == 0)) {
+				/* nothing more to process */
+				break;
 			}
 
 			/* Proceed to next entry */
@@ -546,10 +600,10 @@ mg_handle_form_request(struct mg_connection *conn,
 		boundary = (char *)mg_malloc(bl + 1);
 		if (!boundary) {
 			/* Out of memory */
-			mg_cry(conn,
-			       "%s: Cannot allocate memory for boundary [%lu]",
-			       __func__,
-			       (unsigned long)bl);
+			mg_cry_internal(conn,
+			                "%s: Cannot allocate memory for boundary [%lu]",
+			                __func__,
+			                (unsigned long)bl);
 			return -1;
 		}
 		memcpy(boundary, fbeg, bl);
@@ -578,20 +632,10 @@ mg_handle_form_request(struct mg_connection *conn,
 			 * leading hyphens.
 			 */
 
-			/* The initial sanity check
-			 * (bl + 800 > sizeof(buf))
-			 * is no longer required, since sizeof(buf) == 1024
-			 *
-			 * Original comment:
-			 */
-			/* Sanity check:  The algorithm can not work if bl >= sizeof(buf),
-			 * and it will not work effectively, if the buf is only a few byte
-			 * larger than bl, or if buf can not hold the multipart header
-			 * plus the boundary.
-			 * Check some reasonable number here, that should be fulfilled by
-			 * any reasonable request from every browser. If it is not
-			 * fulfilled, it might be a hand-made request, intended to
-			 * interfere with the algorithm. */
+			/* The algorithm can not work if bl >= sizeof(buf), or if buf
+			 * can not hold the multipart header plus the boundary.
+			 * Requests with long boundaries are not RFC compliant, maybe they
+			 * are intended attacks to interfere with this algorithm. */
 			mg_free(boundary);
 			return -1;
 		}
@@ -603,7 +647,7 @@ mg_handle_form_request(struct mg_connection *conn,
 		}
 
 		for (part_no = 0;; part_no++) {
-			size_t towrite, n;
+			size_t towrite, fnlen, n;
 			int get_block;
 
 			r = mg_read(conn,
@@ -624,7 +668,7 @@ mg_handle_form_request(struct mg_connection *conn,
 
 			if (part_no == 0) {
 				int d = 0;
-				while ((d < buf_fill) && (buf[d] != '-')) {
+				while ((buf[d] != '-') && (d < buf_fill)) {
 					d++;
 				}
 				if ((d > 0) && (buf[d] == '-')) {
@@ -639,7 +683,7 @@ mg_handle_form_request(struct mg_connection *conn,
 				mg_free(boundary);
 				return -1;
 			}
-			if (strncmp(buf + 2, boundary, bl)) {
+			if (0 != strncmp(buf + 2, boundary, bl)) {
 				/* Malformed request */
 				mg_free(boundary);
 				return -1;
@@ -774,8 +818,13 @@ mg_handle_form_request(struct mg_connection *conn,
 					fend = fbeg + strcspn(fbeg, ",; \t");
 				}
 			}
-			if (!fbeg) {
+
+			if (!fbeg || !fend) {
+				fbeg = NULL;
 				fend = NULL;
+				fnlen = 0;
+			} else {
+				fnlen = (size_t)(fend - fbeg);
 			}
 
 			/* In theory, it could be possible that someone crafts
@@ -793,8 +842,8 @@ mg_handle_form_request(struct mg_connection *conn,
 			field_storage = url_encoded_field_found(conn,
 			                                        nbeg,
 			                                        (size_t)(nend - nbeg),
-			                                        fbeg,
-			                                        (size_t)(fend - fbeg),
+			                                        ((fnlen > 0) ? fbeg : NULL),
+			                                        fnlen,
 			                                        path,
 			                                        sizeof(path) - 1,
 			                                        fdh);
@@ -806,7 +855,7 @@ mg_handle_form_request(struct mg_connection *conn,
 			                       boundary,
 			                       bl);
 
-			if (field_storage == FORM_FIELD_STORAGE_STORE) {
+			if (field_storage == MG_FORM_FIELD_STORAGE_STORE) {
 				/* Store the content to a file */
 				if (mg_fopen(conn, path, MG_FOPEN_MODE_WRITE, &fstore) == 0) {
 					fstore.access.fp = NULL;
@@ -814,7 +863,10 @@ mg_handle_form_request(struct mg_connection *conn,
 				file_size = 0;
 
 				if (!fstore.access.fp) {
-					mg_cry(conn, "%s: Cannot create file %s", __func__, path);
+					mg_cry_internal(conn,
+					                "%s: Cannot create file %s",
+					                __func__,
+					                path);
 				}
 			}
 
@@ -828,28 +880,36 @@ mg_handle_form_request(struct mg_connection *conn,
 				 * in the buffer. */
 				towrite -= bl + 4;
 
-				if (field_storage == FORM_FIELD_STORAGE_GET) {
-					unencoded_field_get(conn,
-					                    ((get_block > 0) ? NULL : nbeg),
-					                    ((get_block > 0)
-					                         ? 0
-					                         : (size_t)(nend - nbeg)),
-					                    hend,
-					                    towrite,
-					                    fdh);
+				if (field_storage == MG_FORM_FIELD_STORAGE_GET) {
+					r = unencoded_field_get(conn,
+					                        ((get_block > 0) ? NULL : nbeg),
+					                        ((get_block > 0)
+					                             ? 0
+					                             : (size_t)(nend - nbeg)),
+					                        hend,
+					                        towrite,
+					                        fdh);
 					get_block++;
+					if (r == MG_FORM_FIELD_HANDLE_ABORT) {
+						/* Stop request handling */
+						break;
+					}
+					if (r == MG_FORM_FIELD_HANDLE_NEXT) {
+						/* Skip to next field */
+						field_storage = MG_FORM_FIELD_STORAGE_SKIP;
+					}
 				}
 
-				if (field_storage == FORM_FIELD_STORAGE_STORE) {
+				if (field_storage == MG_FORM_FIELD_STORAGE_STORE) {
 					if (fstore.access.fp) {
 
 						/* Store the content of the buffer. */
 						n = (size_t)fwrite(hend, 1, towrite, fstore.access.fp);
 						if ((n != towrite) || (ferror(fstore.access.fp))) {
-							mg_cry(conn,
-							       "%s: Cannot write file %s",
-							       __func__,
-							       path);
+							mg_cry_internal(conn,
+							                "%s: Cannot write file %s",
+							                __func__,
+							                path);
 							mg_fclose(&fstore.access);
 							remove_bad_file(conn, path);
 						}
@@ -867,16 +927,16 @@ mg_handle_form_request(struct mg_connection *conn,
 				            sizeof(buf) - 1 - (size_t)buf_fill);
 				if (r < 0) {
 					/* read error */
+					if (fstore.access.fp) {
+						mg_fclose(&fstore.access);
+						remove_bad_file(conn, path);
+					}
 					mg_free(boundary);
 					return -1;
 				}
 				buf_fill += r;
 				buf[buf_fill] = 0;
-				if (buf_fill < 1) {
-					/* No data */
-					mg_free(boundary);
-					return -1;
-				}
+				/* buf_fill is at least 8 here */
 
 				/* Find boundary */
 				next = search_boundary(buf, (size_t)buf_fill, boundary, bl);
@@ -884,26 +944,35 @@ mg_handle_form_request(struct mg_connection *conn,
 
 			towrite = (size_t)(next - hend);
 
-			if (field_storage == FORM_FIELD_STORAGE_GET) {
+			if (field_storage == MG_FORM_FIELD_STORAGE_GET) {
 				/* Call callback */
-				unencoded_field_get(conn,
-				                    ((get_block > 0) ? NULL : nbeg),
-				                    ((get_block > 0) ? 0
-				                                     : (size_t)(nend - nbeg)),
-				                    hend,
-				                    towrite,
-				                    fdh);
+				r = unencoded_field_get(conn,
+				                        ((get_block > 0) ? NULL : nbeg),
+				                        ((get_block > 0)
+				                             ? 0
+				                             : (size_t)(nend - nbeg)),
+				                        hend,
+				                        towrite,
+				                        fdh);
+				if (r == MG_FORM_FIELD_HANDLE_ABORT) {
+					/* Stop request handling */
+					break;
+				}
+				if (r == MG_FORM_FIELD_HANDLE_NEXT) {
+					/* Skip to next field */
+					field_storage = MG_FORM_FIELD_STORAGE_SKIP;
+				}
 			}
 
-			if (field_storage == FORM_FIELD_STORAGE_STORE) {
+			if (field_storage == MG_FORM_FIELD_STORAGE_STORE) {
 
 				if (fstore.access.fp) {
 					n = (size_t)fwrite(hend, 1, towrite, fstore.access.fp);
 					if ((n != towrite) || (ferror(fstore.access.fp))) {
-						mg_cry(conn,
-						       "%s: Cannot write file %s",
-						       __func__,
-						       path);
+						mg_cry_internal(conn,
+						                "%s: Cannot write file %s",
+						                __func__,
+						                path);
 						mg_fclose(&fstore.access);
 						remove_bad_file(conn, path);
 					} else {
@@ -911,12 +980,16 @@ mg_handle_form_request(struct mg_connection *conn,
 						r = mg_fclose(&fstore.access);
 						if (r == 0) {
 							/* stored successfully */
-							field_stored(conn, path, file_size, fdh);
+							r = field_stored(conn, path, file_size, fdh);
+							if (r == MG_FORM_FIELD_HANDLE_ABORT) {
+								/* Stop request handling */
+								break;
+							}
 						} else {
-							mg_cry(conn,
-							       "%s: Error saving file %s",
-							       __func__,
-							       path);
+							mg_cry_internal(conn,
+							                "%s: Error saving file %s",
+							                __func__,
+							                path);
 							remove_bad_file(conn, path);
 						}
 					}
@@ -924,8 +997,8 @@ mg_handle_form_request(struct mg_connection *conn,
 				}
 			}
 
-			if ((field_storage & FORM_FIELD_STORAGE_ABORT)
-			    == FORM_FIELD_STORAGE_ABORT) {
+			if ((field_storage & MG_FORM_FIELD_STORAGE_ABORT)
+			    == MG_FORM_FIELD_STORAGE_ABORT) {
 				/* Stop parsing the request */
 				break;
 			}

--- a/net/http/civetweb/md5.inl
+++ b/net/http/civetweb/md5.inl
@@ -34,7 +34,7 @@
   1999-05-03 lpd Original version.
  */
 
-#ifndef md5_INCLUDED
+#if !defined(md5_INCLUDED)
 #define md5_INCLUDED
 
 /*
@@ -57,7 +57,7 @@ typedef struct md5_state_s {
 	md5_byte_t buf[64];  /* accumulate block */
 } md5_state_t;
 
-#ifdef __cplusplus
+#if defined(__cplusplus)
 extern "C" {
 #endif
 
@@ -71,7 +71,7 @@ md5_append(md5_state_t *pms, const md5_byte_t *data, size_t nbytes);
 /* Finish the message and return the digest. */
 MD5_STATIC void md5_finish(md5_state_t *pms, md5_byte_t digest[16]);
 
-#ifdef __cplusplus
+#if defined(__cplusplus)
 } /* end extern "C" */
 #endif
 
@@ -130,12 +130,12 @@ MD5_STATIC void md5_finish(md5_state_t *pms, md5_byte_t digest[16]);
   1999-05-03 lpd Original version.
  */
 
-#ifndef MD5_STATIC
+#if !defined(MD5_STATIC)
 #include <string.h>
 #endif
 
 #undef BYTE_ORDER /* 1 = big-endian, -1 = little-endian, 0 = unknown */
-#ifdef ARCH_IS_BIG_ENDIAN
+#if defined(ARCH_IS_BIG_ENDIAN)
 #define BYTE_ORDER (ARCH_IS_BIG_ENDIAN ? 1 : -1)
 #else
 #define BYTE_ORDER (0)
@@ -309,7 +309,7 @@ md5_process(md5_state_t *pms, const md5_byte_t *data /*[64]*/)
 
 /* Round 2. */
 /* Let [abcd k s i] denote the operation
-     a = b + ((a + G(b,c,d) + X[k] + T[i]) <<< s). */
+	 a = b + ((a + G(b,c,d) + X[k] + T[i]) <<< s). */
 #define G(x, y, z) (((x) & (z)) | ((y) & ~(z)))
 #define SET(a, b, c, d, k, s, Ti)                                              \
 	t = a + G(b, c, d) + X[k] + Ti;                                            \
@@ -336,7 +336,7 @@ md5_process(md5_state_t *pms, const md5_byte_t *data /*[64]*/)
 
 /* Round 3. */
 /* Let [abcd k s t] denote the operation
-     a = b + ((a + H(b,c,d) + X[k] + T[i]) <<< s). */
+	 a = b + ((a + H(b,c,d) + X[k] + T[i]) <<< s). */
 #define H(x, y, z) ((x) ^ (y) ^ (z))
 #define SET(a, b, c, d, k, s, Ti)                                              \
 	t = a + H(b, c, d) + X[k] + Ti;                                            \
@@ -363,7 +363,7 @@ md5_process(md5_state_t *pms, const md5_byte_t *data /*[64]*/)
 
 /* Round 4. */
 /* Let [abcd k s t] denote the operation
-     a = b + ((a + I(b,c,d) + X[k] + T[i]) <<< s). */
+	 a = b + ((a + I(b,c,d) + X[k] + T[i]) <<< s). */
 #define I(x, y, z) ((y) ^ ((x) | ~(z)))
 #define SET(a, b, c, d, k, s, Ti)                                              \
 	t = a + I(b, c, d) + X[k] + Ti;                                            \

--- a/net/http/civetweb/sha1.inl
+++ b/net/http/civetweb/sha1.inl
@@ -86,8 +86,8 @@ A million repetitions of "a"
   34AA973C D4C4DAA4 F61EEB2B DBAD2731 6534016F
 */
 
-#include <string.h>
 #include <stdint.h>
+#include <string.h>
 
 typedef struct {
 	uint32_t state[5];
@@ -122,9 +122,10 @@ blk0(CHAR64LONG16 *block, int i)
 }
 
 #define blk(block, i)                                                          \
-	(block->l[i & 15] = rol(block->l[(i + 13) & 15] ^ block->l[(i + 8) & 15]   \
-	                            ^ block->l[(i + 2) & 15] ^ block->l[i & 15],   \
-	                        1))
+	((block)->l[(i)&15] =                                                      \
+	     rol((block)->l[((i) + 13) & 15] ^ (block)->l[((i) + 8) & 15]          \
+	             ^ (block)->l[((i) + 2) & 15] ^ (block)->l[(i)&15],            \
+	         1))
 
 /* (R0+R1), R2, R3, R4 are the different operations used in SHA1 */
 #define R0(v, w, x, y, z, i)                                                   \


### PR DESCRIPTION
Should solve different compilation warnings.
Use directly version from head - not waiting for next release which typically happens once a year.
Version 1.11 was released 10 September 2018 (10 days ago)