### PR TITLE
Introduce template to correctly handle each kind of global function

### DIFF
--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -1751,13 +1751,12 @@ TCollection *TROOT::GetListOfFunctionTemplates()
 }
 
 namespace {
-
-template<typename T>
-void AddToListOfGlobals(TListOfDataMembers *lst, const char *name, const char *tname, T funcptr) {
-   lst->Add(new TGlobalMappedFunc<T>(name,tname,funcptr));
+template <typename FuncRef>
+void AddToListOfGlobals(TListOfDataMembers *lst, const char *name, const char *tname, FuncRef &func)
+{
+   lst->Add(new TGlobalMappedFunc<FuncRef>(name, tname, func));
 }
-
-}
+} // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return list containing the TGlobals currently defined.
@@ -1772,11 +1771,11 @@ TCollection *TROOT::GetListOfGlobals(Bool_t load)
    if (!fGlobals) {
       // We add to the list the "funcky-fake" globals.
       fGlobals = new TListOfDataMembers(0);
-      AddToListOfGlobals(fGlobals, "gROOT", "TROOT*", &ROOT::GetROOT);
-      AddToListOfGlobals(fGlobals, "gPad", "TVirtualPad*", &TVirtualPad::Pad);
-      AddToListOfGlobals(fGlobals, "gInterpreter", "TInterpreter*", &TInterpreter::Instance);
-      AddToListOfGlobals(fGlobals, "gVirtualX", "TVirtualX*", &TVirtualX::Instance);
-      AddToListOfGlobals(fGlobals, "gDirectory", "TDirectory*", &TDirectory::CurrentDirectory);
+      AddToListOfGlobals(fGlobals, "gROOT", "TROOT*", ROOT::GetROOT);
+      AddToListOfGlobals(fGlobals, "gPad", "TVirtualPad*", TVirtualPad::Pad);
+      AddToListOfGlobals(fGlobals, "gInterpreter", "TInterpreter*", TInterpreter::Instance);
+      AddToListOfGlobals(fGlobals, "gVirtualX", "TVirtualX*", TVirtualX::Instance);
+      AddToListOfGlobals(fGlobals, "gDirectory", "TDirectory*", TDirectory::CurrentDirectory);
 
       // Don't let TGlobalMappedFunction delete our globals, now that we take them.
       fGlobals->AddAll(&TGlobalMappedFunctionBase::GetEarlyRegisteredGlobals());

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -1750,6 +1750,15 @@ TCollection *TROOT::GetListOfFunctionTemplates()
    return fFuncTemplate;
 }
 
+namespace {
+
+template<typename T>
+void AddToListOfGlobals(TListOfDataMembers *lst, const char *name, const char *tname, T funcptr) {
+   lst->Add(new TGlobalMappedFunc<T>(name,tname,funcptr));
+}
+
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Return list containing the TGlobals currently defined.
 /// Since globals are created and deleted during execution of the
@@ -1763,20 +1772,16 @@ TCollection *TROOT::GetListOfGlobals(Bool_t load)
    if (!fGlobals) {
       // We add to the list the "funcky-fake" globals.
       fGlobals = new TListOfDataMembers(0);
-      fGlobals->Add(new TGlobalMappedFunction("gROOT", "TROOT*",
-                                              (TGlobalMappedFunction::GlobalFunc_t)&ROOT::GetROOT));
-      fGlobals->Add(new TGlobalMappedFunction("gPad", "TVirtualPad*",
-                                            (TGlobalMappedFunction::GlobalFunc_t)&TVirtualPad::Pad));
-      fGlobals->Add(new TGlobalMappedFunction("gInterpreter", "TInterpreter*",
-                                            (TGlobalMappedFunction::GlobalFunc_t)&TInterpreter::Instance));
-      fGlobals->Add(new TGlobalMappedFunction("gVirtualX", "TVirtualX*",
-                                            (TGlobalMappedFunction::GlobalFunc_t)&TVirtualX::Instance));
-      fGlobals->Add(new TGlobalMappedFunction("gDirectory", "TDirectory*",
-                                            (TGlobalMappedFunction::GlobalFunc_t)&TDirectory::CurrentDirectory));
+      AddToListOfGlobals(fGlobals, "gROOT", "TROOT*", &ROOT::GetROOT);
+      AddToListOfGlobals(fGlobals, "gPad", "TVirtualPad*", &TVirtualPad::Pad);
+      AddToListOfGlobals(fGlobals, "gInterpreter", "TInterpreter*", &TInterpreter::Instance);
+      AddToListOfGlobals(fGlobals, "gVirtualX", "TVirtualX*", &TVirtualX::Instance);
+      AddToListOfGlobals(fGlobals, "gDirectory", "TDirectory*", &TDirectory::CurrentDirectory);
+
       // Don't let TGlobalMappedFunction delete our globals, now that we take them.
-      fGlobals->AddAll(&TGlobalMappedFunction::GetEarlyRegisteredGlobals());
-      TGlobalMappedFunction::GetEarlyRegisteredGlobals().SetOwner(kFALSE);
-      TGlobalMappedFunction::GetEarlyRegisteredGlobals().Clear();
+      fGlobals->AddAll(&TGlobalMappedFunctionBase::GetEarlyRegisteredGlobals());
+      TGlobalMappedFunctionBase::GetEarlyRegisteredGlobals().SetOwner(kFALSE);
+      TGlobalMappedFunctionBase::GetEarlyRegisteredGlobals().Clear();
    }
 
    if (!fInterpreter)

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -1752,9 +1752,9 @@ TCollection *TROOT::GetListOfFunctionTemplates()
 
 namespace {
 template <typename FuncRef>
-void AddToListOfGlobals(TListOfDataMembers *lst, const char *name, const char *tname, FuncRef &func)
+void AddToListOfGlobals(TListOfDataMembers *lst, const char *name, const char *tname, FuncRef *func)
 {
-   lst->Add(new TGlobalMappedFunc<FuncRef>(name, tname, func));
+   lst->Add(new TGlobalMappedFunctionTempl<FuncRef>(name, tname, func));
 }
 } // namespace
 
@@ -1771,11 +1771,11 @@ TCollection *TROOT::GetListOfGlobals(Bool_t load)
    if (!fGlobals) {
       // We add to the list the "funcky-fake" globals.
       fGlobals = new TListOfDataMembers(0);
-      AddToListOfGlobals(fGlobals, "gROOT", "TROOT*", ROOT::GetROOT);
-      AddToListOfGlobals(fGlobals, "gPad", "TVirtualPad*", TVirtualPad::Pad);
-      AddToListOfGlobals(fGlobals, "gInterpreter", "TInterpreter*", TInterpreter::Instance);
-      AddToListOfGlobals(fGlobals, "gVirtualX", "TVirtualX*", TVirtualX::Instance);
-      AddToListOfGlobals(fGlobals, "gDirectory", "TDirectory*", TDirectory::CurrentDirectory);
+      AddToListOfGlobals(fGlobals, "gROOT", "TROOT*", &ROOT::GetROOT);
+      AddToListOfGlobals(fGlobals, "gPad", "TVirtualPad*", &TVirtualPad::Pad);
+      AddToListOfGlobals(fGlobals, "gInterpreter", "TInterpreter*", &TInterpreter::Instance);
+      AddToListOfGlobals(fGlobals, "gVirtualX", "TVirtualX*", &TVirtualX::Instance);
+      AddToListOfGlobals(fGlobals, "gDirectory", "TDirectory*", &TDirectory::CurrentDirectory);
 
       // Don't let TGlobalMappedFunction delete our globals, now that we take them.
       fGlobals->AddAll(&TGlobalMappedFunctionBase::GetEarlyRegisteredGlobals());

--- a/core/base/src/TVirtualGL.cxx
+++ b/core/base/src/TVirtualGL.cxx
@@ -20,15 +20,14 @@ use the classes using OpenGL.
 
 ClassImp(TGLManager);
 
-TGLManager * (*gPtr2GLManager)() = 0;
+TGLManager * (*gPtr2GLManager)() = nullptr;
 
 namespace {
 static struct AddPseudoGlobals {
 AddPseudoGlobals() {
   // User "gCling" as synonym for "libCore static initialization has happened".
    // This code here must not trigger it.
-   TGlobalMappedFunction::Add(new TGlobalMappedFunction("gGLManager", "TVirtualGL*",
-                                 (TGlobalMappedFunction::GlobalFunc_t)&gGLManager));
+   TGlobalMappedFunction::AddGlobal("gGLManager", "TVirtualGL*", &TGLManager::Instance);
 }
 } gAddPseudoGlobals;
 }

--- a/core/base/src/TVirtualGL.cxx
+++ b/core/base/src/TVirtualGL.cxx
@@ -27,7 +27,7 @@ static struct AddPseudoGlobals {
 AddPseudoGlobals() {
   // User "gCling" as synonym for "libCore static initialization has happened".
    // This code here must not trigger it.
-   TGlobalMappedFunction::AddGlobal("gGLManager", "TVirtualGL*", TGLManager::Instance);
+   TGlobalMappedFunction::AddGlobal("gGLManager", "TVirtualGL*", &TGLManager::Instance);
 }
 } gAddPseudoGlobals;
 }

--- a/core/base/src/TVirtualGL.cxx
+++ b/core/base/src/TVirtualGL.cxx
@@ -27,7 +27,7 @@ static struct AddPseudoGlobals {
 AddPseudoGlobals() {
   // User "gCling" as synonym for "libCore static initialization has happened".
    // This code here must not trigger it.
-   TGlobalMappedFunction::AddGlobal("gGLManager", "TVirtualGL*", &TGLManager::Instance);
+   TGlobalMappedFunction::AddGlobal("gGLManager", "TVirtualGL*", TGLManager::Instance);
 }
 } gAddPseudoGlobals;
 }

--- a/core/meta/inc/TGlobal.h
+++ b/core/meta/inc/TGlobal.h
@@ -70,21 +70,22 @@ private:
    friend class TROOT;
 };
 
+/// Templated class to support any kind of function signature (with or without ref as ret value).
 template <typename FuncRef>
-// Class to map the "funcky" globals and be able to add them to the list of globals.
-class TGlobalMappedFunc : public TGlobalMappedFunctionBase {
+class TGlobalMappedFunctionTempl : public TGlobalMappedFunctionBase {
 public:
-   TGlobalMappedFunc(const char *name, const char *type, FuncRef &func)
-      : TGlobalMappedFunctionBase(name, type), fFuncPtr(&func)
+   TGlobalMappedFunctionTempl(const char *name, const char *type, FuncRef *func)
+      : TGlobalMappedFunctionBase(name, type), fFuncPtr(func)
    {
    }
-   virtual ~TGlobalMappedFunc() {}
+   virtual ~TGlobalMappedFunctionTempl() {}
    DeclId_t GetDeclId() const override { return (DeclId_t)(fFuncPtr); } // Used as DeclId because of uniqueness
    void *GetAddress() const override { return static_cast<void *>((*fFuncPtr)()); }
 
 private:
    FuncRef *fFuncPtr; // Function to call to get the address
 };
+
 
 /// keep this class for backwards compatibility
 class TGlobalMappedFunction : public TGlobalMappedFunctionBase {
@@ -101,9 +102,9 @@ public:
    void *GetAddress() const override { return static_cast<void *>((*fFuncPtr)()); }
 
    template <typename FuncRef>
-   static void AddGlobal(const char *name, const char *type, FuncRef &func)
+   static void AddGlobal(const char *name, const char *type, FuncRef *func)
    {
-      TGlobalMappedFunctionBase::Add(new TGlobalMappedFunc<FuncRef>(name, type, func));
+      TGlobalMappedFunctionBase::Add(new TGlobalMappedFunctionTempl<FuncRef>(name, type, func));
    }
 
 private:

--- a/core/meta/src/TGlobal.cxx
+++ b/core/meta/src/TGlobal.cxx
@@ -168,7 +168,10 @@ Bool_t TGlobal::Update(DataMemberInfo_t *info)
    return kTRUE;
 }
 
-TList& TGlobalMappedFunction::GetEarlyRegisteredGlobals()
+////////////////////////////////////////////////////////////////////////////////
+/// Return list of globals filled before ROOT if fully initialized
+
+TList& TGlobalMappedFunctionBase::GetEarlyRegisteredGlobals()
 {
    // Used to storeTGlobalMappedFunctions from other libs, before gROOT was initialized
    static TList fEarlyRegisteredGlobals;
@@ -180,7 +183,10 @@ TList& TGlobalMappedFunction::GetEarlyRegisteredGlobals()
    return fEarlyRegisteredGlobals;
 }
 
-void TGlobalMappedFunction::Add(TGlobalMappedFunction* gmf)
+////////////////////////////////////////////////////////////////////////////////
+/// Add global function to ROOT or intermediate list
+
+void TGlobalMappedFunctionBase::Add(TGlobalMappedFunctionBase* gmf)
 {
    // Add to GetEarlyRegisteredGlobals() if gROOT is not yet initialized; add to
    // gROOT->GetListOfGlobals() otherwise.

--- a/core/meta/src/TGlobal.cxx
+++ b/core/meta/src/TGlobal.cxx
@@ -176,9 +176,8 @@ TList& TGlobalMappedFunctionBase::GetEarlyRegisteredGlobals()
    // Used to storeTGlobalMappedFunctions from other libs, before gROOT was initialized
    static TList fEarlyRegisteredGlobals;
    // For thread-safe setting of SetOwner(kTRUE).
-   static bool earlyRegisteredGlobalsSetOwner
-      = (fEarlyRegisteredGlobals.SetOwner(kTRUE), true);
-   (void) earlyRegisteredGlobalsSetOwner; // silence unused var
+   static bool earlyRegisteredGlobalsSetOwner = (fEarlyRegisteredGlobals.SetOwner(kTRUE), true);
+   (void)earlyRegisteredGlobalsSetOwner; // silence unused var
 
    return fEarlyRegisteredGlobals;
 }

--- a/gui/gui/src/TGClient.cxx
+++ b/gui/gui/src/TGClient.cxx
@@ -57,7 +57,7 @@ static struct AddPseudoGlobals {
 AddPseudoGlobals() {
    // User "gCling" as synonym for "libCore static initialization has happened".
    // This code here must not trigger it.
-   TGlobalMappedFunction::AddGlobal("gClient", "TGClient*", TGClient::Instance);
+   TGlobalMappedFunction::AddGlobal("gClient", "TGClient*", &TGClient::Instance);
 }
 } gAddPseudoGlobals;
 }

--- a/gui/gui/src/TGClient.cxx
+++ b/gui/gui/src/TGClient.cxx
@@ -50,15 +50,14 @@
 #include "TGlobal.h"
 
 // Global pointer to the TGClient object
-static TGClient *gClientGlobal = 0;
+static TGClient *gClientGlobal = nullptr;
 
 namespace {
 static struct AddPseudoGlobals {
 AddPseudoGlobals() {
    // User "gCling" as synonym for "libCore static initialization has happened".
    // This code here must not trigger it.
-   TGlobalMappedFunction::Add(new TGlobalMappedFunction("gClient", "TGClient*",
-                                 (TGlobalMappedFunction::GlobalFunc_t)&TGClient::Instance));
+   TGlobalMappedFunction::AddGlobal("gClient", "TGClient*",&TGClient::Instance);
 }
 } gAddPseudoGlobals;
 }

--- a/gui/gui/src/TGClient.cxx
+++ b/gui/gui/src/TGClient.cxx
@@ -57,7 +57,7 @@ static struct AddPseudoGlobals {
 AddPseudoGlobals() {
    // User "gCling" as synonym for "libCore static initialization has happened".
    // This code here must not trigger it.
-   TGlobalMappedFunction::AddGlobal("gClient", "TGClient*",&TGClient::Instance);
+   TGlobalMappedFunction::AddGlobal("gClient", "TGClient*", TGClient::Instance);
 }
 } gAddPseudoGlobals;
 }

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -164,7 +164,7 @@ static struct AddPseudoGlobals {
 AddPseudoGlobals() {
    // User "gCling" as synonym for "libCore static initialization has happened".
    // This code here must not trigger it.
-   TGlobalMappedFunction::AddGlobal("gFile", "TFile*", TFile::CurrentFile);
+   TGlobalMappedFunction::AddGlobal("gFile", "TFile*", &TFile::CurrentFile);
 }
 } gAddPseudoGlobals;
 }

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -164,7 +164,7 @@ static struct AddPseudoGlobals {
 AddPseudoGlobals() {
    // User "gCling" as synonym for "libCore static initialization has happened".
    // This code here must not trigger it.
-   TGlobalMappedFunction::AddGlobal("gFile", "TFile*", &TFile::CurrentFile);
+   TGlobalMappedFunction::AddGlobal("gFile", "TFile*", TFile::CurrentFile);
 }
 } gAddPseudoGlobals;
 }

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -164,8 +164,7 @@ static struct AddPseudoGlobals {
 AddPseudoGlobals() {
    // User "gCling" as synonym for "libCore static initialization has happened".
    // This code here must not trigger it.
-   TGlobalMappedFunction::Add(new TGlobalMappedFunction("gFile", "TFile*",
-            (TGlobalMappedFunction::GlobalFunc_t)((void*)&TFile::CurrentFile)));
+   TGlobalMappedFunction::AddGlobal("gFile", "TFile*", &TFile::CurrentFile);
 }
 } gAddPseudoGlobals;
 }


### PR DESCRIPTION
Try to keep old interface as is - if by chance anybody uses it outside ROOT

In  any case, one **MUST** fix problem with TVirtualGL.cxx.
In original code (current master) not a pointer on the function but double pointer on the variable was provided - code was never working before