### PR TITLE
[ROOT-9489] Exclude Clang from install directive when using shared LLVM

### DIFF
--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -375,7 +375,7 @@ Please install Python or specify the PYTHON_EXECUTABLE CMake variable.")
 
 
 if (builtin_clang)
-  add_subdirectory(llvm/src/tools/clang)
+  add_subdirectory(llvm/src/tools/clang EXCLUDE_FROM_ALL)
 else()
   add_subdirectory(cling)
 endif()


### PR DESCRIPTION
exclude clang from install directive

Related JIRA issue: https://sft.its.cern.ch/jira/browse/ROOT-9489