### PR TITLE
Allow calling printValue() directly in ROOT

### DIFF
--- a/bindings/pyroot/src/Pythonize.cxx
+++ b/bindings/pyroot/src/Pythonize.cxx
@@ -2271,17 +2271,12 @@ namespace {
       std::string className = PyROOT_PyUnicode_AsString(cppname);
       Py_XDECREF(cppname);
 
-      void *myObj = self->GetObject();
-      std::stringstream ss;
-      ss << myObj;
-      std::string code = "*((" + className + "*)" + ss.str() + ")";
+      std::string pprint;
+      std::stringstream calcPrintValue;
+      calcPrintValue << "*((std::string*)" << &pprint << ") = cling::printValue((" << className << "*)"
+         << self->GetObject() << ");";
+      gInterpreter->Calc(calcPrintValue.str().c_str());
 
-      auto Value = gInterpreter->CreateTemporary();
-      std::string pprint = "";
-      if (gInterpreter->Evaluate(code.c_str(), *Value) == 1 /*success*/)
-         pprint = Value->ToTypeAndValueString().second;
-      delete Value;
-      pprint.erase(std::remove(pprint.begin(), pprint.end(), '\n'), pprint.end());
       return PyROOT_PyUnicode_FromString(pprint.c_str());
    }
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1285,6 +1285,9 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
 
    if (!fromRootCling) {
       fInterpreter->installLazyFunctionCreator(llvmLazyFunctionCreator);
+
+      // Allow calling printValue() directly instead of going through cling::Value::print()
+      cling::valuePrinterInternal::declarePrintValue(fInterpreter);
    }
 
    // Don't check whether modules' files exist.

--- a/interpreter/cling/include/cling/Interpreter/Value.h
+++ b/interpreter/cling/include/cling/Interpreter/Value.h
@@ -13,6 +13,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <type_traits>
+#include <string>
 
 namespace llvm {
   class raw_ostream;
@@ -282,6 +283,12 @@ namespace cling {
     void print(llvm::raw_ostream& Out, bool escape = false) const;
     void dump(bool escape = true) const;
   };
+
+  namespace valuePrinterInternal {
+    std::string printTypeInternal(const Value& V);
+    void declarePrintValue(Interpreter *Interp);
+    std::string printValueInternal(const Value& V);
+  } // end namespace valuePrinterInternal
 } // end namespace cling
 
 #endif // CLING_VALUE_H

--- a/interpreter/cling/lib/Interpreter/Value.cpp
+++ b/interpreter/cling/lib/Interpreter/Value.cpp
@@ -232,11 +232,6 @@ namespace cling {
     assert("unsupported type in Value, cannot cast simplistically!" && 0);
   }
 
-  namespace valuePrinterInternal {
-    std::string printTypeInternal(const Value& V);
-    std::string printValueInternal(const Value& V);
-  } // end namespace valuePrinterInternal
-
   void Value::print(llvm::raw_ostream& Out, bool Escape) const {
     // Save the default type string representation so output can occur as one
     // operation (calling printValueInternal below may write to stderr).

--- a/interpreter/cling/lib/Interpreter/ValuePrinter.cpp
+++ b/interpreter/cling/lib/Interpreter/ValuePrinter.cpp
@@ -15,7 +15,6 @@
 #include "cling/Interpreter/Interpreter.h"
 #include "cling/Interpreter/LookupHelper.h"
 #include "cling/Interpreter/Transaction.h"
-#include "cling/Interpreter/Value.h"
 #include "cling/Utils/AST.h"
 #include "cling/Utils/Casting.h"
 #include "cling/Utils/Output.h"
@@ -926,16 +925,20 @@ namespace cling {
       return printQualType(V.getASTContext(), V.getType());
     }
 
-    std::string printValueInternal(const Value &V) {
+    void declarePrintValue(Interpreter *Interp) {
       static bool includedRuntimePrintValue = false; // initialized only once as a static function variable
       // Include "RuntimePrintValue.h" only on the first printing.
       // This keeps the interpreter lightweight and reduces the startup time.
       if (!includedRuntimePrintValue) {
-        Interpreter* Interp = V.getInterpreter();
         LockCompilationDuringUserCodeExecutionRAII LCDUCER(*Interp);
         Interp->declare("#include \"cling/Interpreter/RuntimePrintValue.h\"");
         includedRuntimePrintValue = true;
       }
+    }
+
+    std::string printValueInternal(const Value &V) {
+      Interpreter* Interp = V.getInterpreter();
+      declarePrintValue(Interp);
       return printUnpackedClingValue(V);
     }
   } // end namespace valuePrinterInternal

--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -1058,27 +1058,4 @@ TVEC_EXTERN_VDT_UNARY_FUNCTION(double, fast_atan)
 
 } // End of ROOT NS
 
-namespace cling {
-template <typename T>
-inline std::string printValue(ROOT::VecOps::RVec<T> *rvecp)
-{
-   std::stringstream os;
-
-   auto &rvec = *rvecp;
-
-   os << "{ ";
-   const auto size = rvec.size();
-   if (size) {
-      for (std::size_t i = 0; i < size - 1; ++i) {
-         os << printValue(&(rvec[i])) << ", ";
-      }
-      os << printValue(&(rvec[size - 1]));
-   }
-   os << " }";
-
-   return os.str();
-}
-
-} // namespace cling
-
 #endif

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -788,7 +788,7 @@ TEST(VecOps, UnqiueCombinationsSingleVector)
 
 TEST(VecOps, PrintCollOfNonPrintable)
 {
-   auto code = "class A{};ROOT::VecOps::RVec<A> v(1);cling::printValue(&v);";
+   auto code = "class A{};ROOT::VecOps::RVec<A> v(1);&v";
    auto ret = gInterpreter->ProcessLine(code);
    EXPECT_TRUE(0 != ret) << "Error in printing an RVec collection of non printable objects.";
 }


### PR DESCRIPTION
As we discussed in #2644, the nicest interface for printing is
printValue, and we should support people using this rather than going
through cling::Value::print().

This patch contains:
- Implementation of declarePrintValue
- Re-Implementation of ClingPrintValue because I changed to use Evaluate
some time ago
- removing of RVec version of printValue which wasn't used at all
- Fix test/vecops_rvec.cxx, printValue is never supposed to be called by
a normal user.