### PR TITLE
Pass Mac1014 SDK isysroot to "external projects"

### DIFF
--- a/builtins/openssl/CMakeLists.txt
+++ b/builtins/openssl/CMakeLists.txt
@@ -20,6 +20,9 @@ endforeach()
 
 if(APPLE)
   set(OPENSSL_CONFIG_CMD ./Configure darwin64-x86_64-cc)
+  if (CMAKE_OSX_SYSROOT)
+    set(OSX_SYSROOT "-isysroot ${CMAKE_OSX_SYSROOT}")
+  endif()
 else()
   set(OPENSSL_CONFIG_CMD ./config)
 endif()
@@ -27,7 +30,7 @@ endif()
 ExternalProject_Add(OPENSSL
   URL ${OPENSSL_URL} URL_HASH ${OPENSSL_URLHASH}
   CONFIGURE_COMMAND ${OPENSSL_CONFIG_CMD} no-shared --prefix=<INSTALL_DIR>
-  BUILD_COMMAND make -j1 CC=${CMAKE_C_COMPILER}\ -fPIC
+  BUILD_COMMAND make -j1 CC=${CMAKE_C_COMPILER}\ -fPIC\ ${OSX_SYSROOT}
   INSTALL_COMMAND make install_sw
   BUILD_IN_SOURCE 1
   LOG_BUILD 1 LOG_CONFIGURE 1 LOG_DOWNLOAD 1 LOG_INSTALL 1

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -94,8 +94,12 @@ if(builtin_freetype)
       BUILD_BYPRODUCTS ${FREETYPE_LIBRARY})
   else()
     set(_freetype_cflags -O)
+    set(_freetype_cc ${CMAKE_C_COMPILER})
     if(ROOT_ARCHITECTURE MATCHES aix)
       set(_freetype_zlib --without-zlib)
+    endif()
+    if(CMAKE_OSX_SYSROOT)
+      set(_freetype_cc "${_freetype_cc} -isysroot ${CMAKE_OSX_SYSROOT}")
     endif()
     ExternalProject_Add(
       FREETYPE
@@ -104,7 +108,7 @@ if(builtin_freetype)
       CONFIGURE_COMMAND ./configure --prefix <INSTALL_DIR> --with-pic 
                          --disable-shared --with-png=no --with-bzip2=no 
                          --with-harfbuzz=no ${_freetype_zlib}
-                          CC=${CMAKE_C_COMPILER} CFLAGS=${_freetype_cflags}
+                          "CC=${_freetype_cc}" CFLAGS=${_freetype_cflags}
       INSTALL_COMMAND ""                    
       LOG_DOWNLOAD 1 LOG_CONFIGURE 1 LOG_BUILD 1 LOG_INSTALL 1 BUILD_IN_SOURCE 1
       BUILD_BYPRODUCTS ${FREETYPE_LIBRARY})

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -158,6 +158,9 @@ if(builtin_pcre)
       BUILD_BYPRODUCTS ${PCRE_LIBRARY})
   else()
     set(_pcre_cflags -O)
+    if(CMAKE_OSX_SYSROOT)
+      set(_pcre_cflags "${_pcre_cflags} -isysroot ${CMAKE_OSX_SYSROOT}")
+    endif()
     ExternalProject_Add(
       PCRE
       URL ${CMAKE_SOURCE_DIR}/core/pcre/src/pcre-${pcre_version}.tar.gz
@@ -207,6 +210,9 @@ if(builtin_lzma)
       set(LZMA_LDFLAGS "-Qunused-arguments")
     elseif( CMAKE_CXX_COMPILER_ID STREQUAL Intel)
       set(LZMA_CFLAGS "-wd188 -wd181 -wd1292 -wd10006 -wd10156 -wd2259 -wd981 -wd128 -wd3179 -wd2102")
+    endif()
+    if(CMAKE_OSX_SYSROOT)
+      set(LZMA_CFLAGS "${LZMA_CFLAGS} -isysroot ${CMAKE_OSX_SYSROOT}")
     endif()
     set(LZMA_LIBRARIES ${CMAKE_BINARY_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}lzma${CMAKE_STATIC_LIBRARY_SUFFIX})
     ExternalProject_Add(
@@ -384,6 +390,9 @@ if(builtin_afterimage)
     if(builtin_freetype)
       set(_ttf_include --with-ttf-includes=-I${FREETYPE_INCLUDE_DIR})
       set(_after_cflags "${_after_cflags} -DHAVE_FREETYPE_FREETYPE")
+    endif()
+    if(CMAKE_OSX_SYSROOT)
+      set(_after_cflags "${_after_cflags} -isysroot ${CMAKE_OSX_SYSROOT}")
     endif()
     ExternalProject_Add(
       AFTERIMAGE


### PR DESCRIPTION
While CMake knows about it, we need to pass it to `configure` invocations.
CMake decides to use the toolchain `cc`/`c++` which doesn't have the SDK includes - unlike `/usr/bin/cc` - which CMake doesn't use by default.

This fixes building ROOT on MacOS10.14 out of the box (i.e. without messing with `CMAKE_C_COMPILER` etc).