### PR TITLE
Disable validation of the diagnostic options when loading the C++ module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,7 @@ if(cxxmodules)
     message(FATAL_ERROR "cxxmodules is not supported by this compiler")
   endif()
 
-  set(ROOT_CXXMODULES_COMMONFLAGS "${ROOT_CXXMODULES_COMMONFLAGS} -fmodules -fmodules-cache-path=${CMAKE_BINARY_DIR}/include/pcms/ -Xclang -fno-validate-pch -fno-autolink -fdiagnostics-show-note-include-stack -Wno-module-import-in-extern-c")
+  set(ROOT_CXXMODULES_COMMONFLAGS "${ROOT_CXXMODULES_COMMONFLAGS} -fmodules -fmodules-cache-path=${CMAKE_BINARY_DIR}/include/pcms/ -Xclang -fno-validate-pch -fmodules-disable-diagnostic-validation -fno-autolink -fdiagnostics-show-note-include-stack -Wno-module-import-in-extern-c")
 
   # FIXME: We should remove this once libc++ supports -fmodules-local-submodule-visibility.
   if (APPLE)


### PR DESCRIPTION
With PCH+Module, sometimes compiler gives a hard error:
_Module file ‘<some-file path>.pcm' is out of date and needs to be rebuilt._
Adding fmodules-disable-diagnostic-validation helps in situation if two compiler instances only differ in diagnostic options, the later instance will not invalidate the original pcm.
Details: https://reviews.llvm.org/D22773