### PR TITLE
v7: draw_mt.cxx force loading of WebDisplay lib

### DIFF
--- a/tutorials/v7/draw_mt.cxx
+++ b/tutorials/v7/draw_mt.cxx
@@ -22,7 +22,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-R__LOAD_LIBRARY(libROOTGpadv7);
+R__LOAD_LIBRARY(libROOTWebDisplay);
 
 #include "ROOT/RHist.hxx"
 #include "ROOT/RCanvas.hxx"


### PR DESCRIPTION
Probably will fix problem with running macro in batch mode