### PR TITLE
[cxxmodules] Allow ROOT_ prefix module to be implicitly build by rootcling

### DIFF
--- a/build/unix/module.modulemap
+++ b/build/unix/module.modulemap
@@ -1,6 +1,6 @@
 // This module contains header files from module Core which can be used in both
 // C and C++ context.
-module ROOT_Foundation_C [system] {
+module ROOT_Foundation_C  {
   module "ThreadLocalStorage.h" { header "ThreadLocalStorage.h" export * }
   module "strlcpy.h" { header "strlcpy.h" export * }
   module "snprintf.h" { header "snprintf.h" export * }
@@ -11,7 +11,7 @@ module ROOT_Foundation_C [system] {
 // This module contains header files from module Core which are used as
 // configuration for ROOT. They contain a lot of macro definitions which are
 // supposed to be textually expanded in each TU.
-module ROOT_Config [system] {
+module ROOT_Config  {
   // These headers are supposed to be only textually expanded for each TU.
   module "RVersion.h" { textual header "RVersion.h" export * }
   module "RConfig.h" { textual header "RConfig.h" export * }
@@ -23,10 +23,13 @@ module ROOT_Config [system] {
   export *
 }
 
+module ROOT_Rtypes {
+  module "RtypesCore.h" { header "RtypesCore.h" export * }
+}
+
 // This module contains header files from module Core which do not need -frtti.
 // They are mainly needed for ROOT stage1 build.
-module ROOT_Foundation_Stage1_NoRTTI [system] {
-  module "RtypesCore.h" { header "RtypesCore.h" export * }
+module ROOT_Foundation_Stage1_NoRTTI  {
   module "ESTLType.h" { header "ESTLType.h" export * }
   module "ROOT/RStringView.hxx" {
     // RWrap_libcpp_string_view.h is meant to be included only by ROOT/RStringView.hxx
@@ -55,9 +58,9 @@ module ROOT_Foundation_Stage1_NoRTTI [system] {
 // when there is no folder GL or contents in it.
 // module ROOT_Glew {
   // Depending on the platform we get some of these three installed.
-  module "glew.h" [system] { header "GL/glew.h" export * }
-  module "wglew.h" [system] { header "GL/wglew.h" export * }
-  module "glxew.h" [system] { header "GL/glxew.h" export * }
+  module "glew.h" { header "GL/glew.h" export * }
+  module "wglew.h" { header "GL/wglew.h" export * }
+  module "glxew.h" { header "GL/glxew.h" export * }
 //  link "lib/libGLEW.so"
 //}
 

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -3912,14 +3912,15 @@ public:
          }
       }
 
-      // Skip the diag only if we build a system module. We still print the diag
+      // Skip the diag only if we build a ROOT system module or a system module. We still print the diag
       // when building a non-system module as we will print an error below and the
       // user should see the detailed default clang diagnostic.
-      bool isSystemModuleDiag = module && module->IsSystem;
-      if (!isSystemModuleDiag)
+      bool isROOTSystemModuleDiag = module && llvm::StringRef(moduleName).startswith("ROOT_");
+      bool isSystemModuleDiag = module && module && module->IsSystem;
+      if (!isROOTSystemModuleDiag && !isSystemModuleDiag)
          fChild->HandleDiagnostic(DiagLevel, Info);
 
-      if (ID == remark_module_build && !isSystemModuleDiag) {
+      if (ID == remark_module_build && !isROOTSystemModuleDiag && !isSystemModuleDiag) {
          ROOT::TMetaUtils::Error(0,
                                  "Had to build non-system module %s implicitly. You first need to\n"
                                  "generate the dictionary for %s or mark the C++ module as a system\n"


### PR DESCRIPTION
Previously, [system] was used to mark modules which were supporsed be implicitly built by rootcling for runtime modules. This was a workaround, and it was causing SourceLocation error in cxxmodules as it is also using the same modulemap.
    
To remove the workaround, we are introducing a new convention that modules start with ROOT_ is treated as "ROOT system modules", which can be build implicitly.
