### PR TITLE
Change math.h to cmath in NeuralNet.h

### DIFF
--- a/tmva/tmva/inc/TMVA/NeuralNet.h
+++ b/tmva/tmva/inc/TMVA/NeuralNet.h
@@ -33,7 +33,7 @@
 #include <iterator>
 #include <functional>
 #include <tuple>
-#include <math.h>
+#include <cmath>
 #include <cassert>
 #include <random>
 #include <thread>


### PR DESCRIPTION
We needed to this change for avoiding infinite loop when building with cling modules