### PR TITLE
Updating dependencies for onepcm in case of runtime_cxxmodules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,7 +354,13 @@ endif()
 
 if(runtime_cxxmodules)
   # Dummy target that does nothing, we don't need a PCH for modules.
+  # Onepcm target has all dependencies needed for allDict.cxx.pch, which allow
+  # to test hsimple.C after all C++ modules are updated.
   add_custom_target(onepcm)
+  foreach(target_dependency ${ROOT_LIBRARY_TARGETS})
+    add_dependencies(onepcm ${target_dependency})
+  endforeach()
+  unset(ROOT_LIBRARY_TARGETS CACHE)
   set(FIXME_TEMPORARILY_EXCLUDED_FOR_RUNTIME_CXXMODULES On)
 else()
   add_custom_command(OUTPUT etc/allDict.cxx.pch

--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -961,6 +961,11 @@ function(ROOT_STANDARD_LIBRARY_PACKAGE libname)
     set(MODULE_GEN_ARG)
   endif()
 
+  if(runtime_cxxmodules)
+    # Record ROOT targets to be used as a dependency targets for "onepcm" target.
+    set(ROOT_LIBRARY_TARGETS "${ROOT_LIBRARY_TARGETS};${libname}" CACHE STRING "List of ROOT targets generated from ROOT_STANDARD_LIBRARY_PACKAGE()" FORCE)
+  endif()
+
   ROOT_GENERATE_DICTIONARY(G__${libname} ${ARG_HEADERS}
                           ${MODULE_GEN_ARG}
                           ${STAGE1_FLAG}


### PR DESCRIPTION
Added dependencies to onepcm target to protect from running to early in build system.
ROOT_LIBRARY_TARGETS records all targets that is used for generation of allDict.cxx.pch.