### PR TITLE
[Core] ROOT-9698 do not check for missing dictionary of unique_ptr<T>

### DIFF
--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -3854,6 +3854,15 @@ void TClass::GetMissingDictionariesWithRecursionCheck(TCollection& result, TColl
       return;
    }
 
+   if (TClassEdit::IsUniquePtr(fName)) {
+      const auto uniquePtrClName = TClassEdit::GetUniquePtrType(fName);
+      auto uniquePtrCl = TClass::GetClass(uniquePtrClName.c_str());
+      if (uniquePtrCl && !uniquePtrCl->HasDictionary()) {
+         uniquePtrCl->GetMissingDictionariesWithRecursionCheck(result, visited, recurse);
+      }
+      return;
+   }
+
    if (!HasDictionary()) {
       result.Add(this);
    }


### PR DESCRIPTION
but rather for the missing dictionary of T given the way in which we treat unique_ptrs.
A test is missing stil...