### PR TITLE
Add signal.h to libc.modulemap

### DIFF
--- a/build/unix/libc.modulemap
+++ b/build/unix/libc.modulemap
@@ -51,6 +51,11 @@ module "sys_types.h" [system] {
   header "sys/types.h"
 }
 
+module "signal.h" [system] {
+  export *
+  header "signal.h"
+}
+
 module "stdlib.h" [system] {
   export *
   header "stdlib.h"


### PR DESCRIPTION
This error: http://cdash.cern.ch/viewBuildError.php?buildid=567476
was caused because modules couldn't merge definition of struct __pthread_internal_list