### PR TITLE
Fix in RDF and cxxmodules

### DIFF
--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -786,7 +786,7 @@ RDataFrame::RDataFrame(std::string_view treeName, std::string_view filenameglob,
 /// See RInterface for the documentation of the methods available.
 RDataFrame::RDataFrame(std::string_view treeName, const std::vector<std::string> &fileglobs,
                        const ColumnNames_t &defaultBranches)
-   : RDF::RInterface<RDFDetail::RLoopManager>(
+   : RInterface<RDFDetail::RLoopManager>(
         std::make_shared<RDFDetail::RLoopManager>(nullptr, defaultBranches))
 {
    std::string treeNameInt(treeName);


### PR DESCRIPTION
It is fixing:
..root/tree/dataframe/src/RDataFrame.cxx:789:6: error: reference to 'RDF' is ambiguous
   : RDF::RInterface<RDFDetail::RLoopManager>(
     ^
In module 'ROOTDataFrame' imported ..root/tree/dataframe/src/RDataFrame.cxx:14:
..include/ROOT/RCutFlowReport.hxx:29:11: note: candidate found by name lookup is 'ROOT::RDF'
namespace RDF {
          ^
..root/tree/dataframe/src/RDataFrame.cxx:721:11: note: candidate found by name lookup is 'ROOT::Detail::RDF'
namespace RDF {
          ^
..tree/dataframe/src/RDataFrame.cxx:789:11: error: member initializer (null) does not name a non-static data member or base class
   : RDF::RInterface<RDFDetail::RLoopManager>(
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~