### PR TITLE
[cxxmodules] Implement to_string interface to gInterpreter

### DIFF
--- a/bindings/pyroot/src/Pythonize.cxx
+++ b/bindings/pyroot/src/Pythonize.cxx
@@ -2271,18 +2271,8 @@ namespace {
       std::string className = PyROOT_PyUnicode_AsString(cppname);
       Py_XDECREF(cppname);
 
-      void *myObj = self->GetObject();
-      std::stringstream ss;
-      ss << myObj;
-      std::string code = "*((" + className + "*)" + ss.str() + ")";
-
-      auto Value = gInterpreter->CreateTemporary();
-      std::string pprint = "";
-      if (gInterpreter->Evaluate(code.c_str(), *Value) == 1 /*success*/)
-         pprint = Value->ToTypeAndValueString().second;
-      delete Value;
-      pprint.erase(std::remove(pprint.begin(), pprint.end(), '\n'), pprint.end());
-      return PyROOT_PyUnicode_FromString(pprint.c_str());
+      std::string printResult = gInterpreter->ToString(className.c_str(), self->GetObject());
+      return PyROOT_PyUnicode_FromString(printResult.c_str());
    }
 
    //- Adding array interface to classes ---------------

--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -221,6 +221,7 @@ public:
    virtual Bool_t   IsProcessLineLocked() const = 0;
    virtual void     SetProcessLineLock(Bool_t lock = kTRUE) = 0;
    virtual const char *TypeName(const char *s) = 0;
+   virtual std::string ToString(const char *type, void *obj) = 0;
 
    virtual void     SnapshotMutexState(ROOT::TVirtualRWMutex* mtx) = 0;
    virtual void     ForgetMutexState() = 0;

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1075,6 +1075,11 @@ inline bool TCling::TUniqueString::Append(const std::string& str)
    return notPresent;
 }
 
+std::string TCling::ToString(const char* type, void* obj)
+{
+   return fInterpreter->toString(type, obj);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 ///\returns true if the module was loaded.
 static bool LoadModule(const std::string &ModuleName, cling::Interpreter &interp, bool Complain = true)

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -264,6 +264,7 @@ public: // Public Interface
    virtual TEnum*   CreateEnum(void *VD, TClass *cl) const;
    virtual void     UpdateEnumConstants(TEnum* enumObj, TClass* cl) const;
    virtual void     LoadEnums(TListOfEnums& cl) const;
+   virtual std::string ToString(const char* type, void *obj);
    TString GetMangledName(TClass* cl, const char* method, const char* params, Bool_t objectIsConst = kFALSE);
    TString GetMangledNameWithPrototype(TClass* cl, const char* method, const char* proto, Bool_t objectIsConst = kFALSE, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch);
    void*   GetInterfaceMethod(TClass* cl, const char* method, const char* params, Bool_t objectIsConst = kFALSE);

--- a/interpreter/cling/include/cling/Interpreter/Interpreter.h
+++ b/interpreter/cling/include/cling/Interpreter/Interpreter.h
@@ -405,6 +405,9 @@ namespace cling {
     void GetIncludePaths(llvm::SmallVectorImpl<std::string>& incpaths,
                          bool withSystem, bool withFlags);
 
+    ///\brief Call printValue( "(type*)" + obj ) and return string
+    std::string toString(const char* type, void* obj);
+
     ///\brief Prints the current include paths that are used.
     ///
     ///\param[in] S - stream to dump to or nullptr for default (cling::outs)

--- a/interpreter/cling/lib/Interpreter/ValuePrinter.cpp
+++ b/interpreter/cling/lib/Interpreter/ValuePrinter.cpp
@@ -926,16 +926,20 @@ namespace cling {
       return printQualType(V.getASTContext(), V.getType());
     }
 
-    std::string printValueInternal(const Value &V) {
+    void declarePrintValue(Interpreter &Interp) {
       static bool includedRuntimePrintValue = false; // initialized only once as a static function variable
       // Include "RuntimePrintValue.h" only on the first printing.
       // This keeps the interpreter lightweight and reduces the startup time.
       if (!includedRuntimePrintValue) {
-        Interpreter* Interp = V.getInterpreter();
-        LockCompilationDuringUserCodeExecutionRAII LCDUCER(*Interp);
-        Interp->declare("#include \"cling/Interpreter/RuntimePrintValue.h\"");
+        Interp.declare("#include \"cling/Interpreter/RuntimePrintValue.h\"");
         includedRuntimePrintValue = true;
       }
+    }
+
+    std::string printValueInternal(const Value &V) {
+      Interpreter* Interp = V.getInterpreter();
+      LockCompilationDuringUserCodeExecutionRAII LCDUCER(*Interp);
+      declarePrintValue(*Interp);
       return printUnpackedClingValue(V);
     }
   } // end namespace valuePrinterInternal

--- a/interpreter/cling/test/Interfaces/print.C
+++ b/interpreter/cling/test/Interfaces/print.C
@@ -1,0 +1,15 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling 2>&1 | FileCheck %s
+
+#include "cling/Interpreter/Interpreter.h"
+
+int a = 21;
+gCling->toString("a");
+// CHECK: "21"

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -788,7 +788,7 @@ TEST(VecOps, UnqiueCombinationsSingleVector)
 
 TEST(VecOps, PrintCollOfNonPrintable)
 {
-   auto code = "class A{};ROOT::VecOps::RVec<A> v(1);cling::printValue(&v);";
+   auto code = "class A{};ROOT::VecOps::RVec<A> v(1);v";
    auto ret = gInterpreter->ProcessLine(code);
    EXPECT_TRUE(0 != ret) << "Error in printing an RVec collection of non printable objects.";
 }


### PR DESCRIPTION
This is the final version of "printValue" discussion.

We agreed that printValue interface should be altered to to_string
interface, which can be invoked `gInterpreter->to_string(XYZ)`.

This patch contains:

- Implementation of to_string in Interpreter.cpp
- Re-Implementation of ClingPrintValue to use to_string because I changed to use Evaluate some time ago.
- Removing of RVec version of printValue which wasn't used at all
- Fix test/vecops_rvec.cxx, printValue is never supposed to be called by a normal user.