### PR TITLE
Fix ROOT-9662 race condition in TStreamerInfo loading.

### DIFF
--- a/core/foundation/res/ROOT/RSha256.hxx
+++ b/core/foundation/res/ROOT/RSha256.hxx
@@ -264,67 +264,17 @@ void sha256_final(sha256_t *p, unsigned char *digest)
 
 } // End NS SHA256
 
-
-/// This helper class represents a sha256 hash. Operator == and std::less
-/// complete its functionality.
-class RSha256Hash {
-   friend std::ostream &operator<<(std::ostream &os, const ROOT::Internal::RSha256Hash &h)
-   {
-      auto digest = h.Get();
-      os << digest[0] << "-" << digest[1] << "-" << digest[2] << "-" << digest[3];
-      return os;
-   }
-private:
-   void Sha256(const unsigned char *data, int len)
-   {
-      // Here the final cast is to match the interface of the C code and
-      // the data member. The lenght is the same!
-      SHA256::sha256_init(&fHash);
-      SHA256::sha256_update(&fHash, data, len);
-      SHA256::sha256_final(&fHash, reinterpret_cast<unsigned char *>(fDigest));
-   }
-
-   SHA256::sha256_t fHash;
-   ULong64_t fDigest[4];
-
-public:
-   RSha256Hash(const char *data, int len)
-   {
-      // The cast here is because in the TBuffer ecosystem, the type used is char*
-      Sha256(reinterpret_cast<const unsigned char *>(data), len);
-   }
-   ULong64_t const *Get() const { return fDigest; }
-};
-
-bool operator==(const RSha256Hash &lhs, const RSha256Hash &rhs)
+void Sha256(const unsigned char *data, int len, ULong64_t *fDigest)
 {
-   auto l = lhs.Get();
-   auto r = rhs.Get();
-   return l[0] == r[0] && l[1] == r[1] && l[2] == r[2] && l[3] == r[3];
+   // Here the final cast is to match the interface of the C code and
+   // the data member. The lenght is the same!
+   SHA256::sha256_t hash;
+   SHA256::sha256_init(&hash);
+   SHA256::sha256_update(&hash, data, len);
+   SHA256::sha256_final(&hash, reinterpret_cast<unsigned char *>(fDigest));
 }
 
 } // End NS Internal
 } // End NS ROOT
-
-namespace std {
-template <>
-struct less<ROOT::Internal::RSha256Hash> {
-   bool operator()(const ROOT::Internal::RSha256Hash &lhs, const ROOT::Internal::RSha256Hash &rhs) const
-   {
-      /// Check piece by piece the 4 64 bits ints which make up the hash.
-      auto l = lhs.Get();
-      auto r = rhs.Get();
-      // clang-format off
-      return l[0] < r[0] ? true :
-               l[0] > r[0] ? false :
-                 l[1] < r[1] ? true :
-                   l[1] > r[1] ? false :
-                     l[2] < r[2] ? true :
-                       l[2] > r[2] ? false :
-                         l[3] < r[3] ? true : false;
-      // clang-format on
-   }
-};
-} // End NS std
 
 #endif

--- a/core/thread/inc/ROOT/RConcurrentHashColl.hxx
+++ b/core/thread/inc/ROOT/RConcurrentHashColl.hxx
@@ -12,6 +12,7 @@
 #define ROOT_RConcurrentHashColl
 
 #include <memory>
+#include "Rtypes.h"
 
 namespace ROOT {
 
@@ -28,13 +29,65 @@ private:
    mutable std::unique_ptr<ROOT::TRWSpinLock> fRWLock;
 
 public:
+   class HashValue {
+       friend std::ostream &operator<<(std::ostream &os, const RConcurrentHashColl::HashValue &h);
+   private:
+      ULong64_t fDigest[4];
+
+   public:
+      HashValue() {
+         for(auto d : fDigest)
+         d = 0;
+      }
+      HashValue(const char *data, int len);
+      ULong64_t const *Get() const { return fDigest; }
+   };
+
    RConcurrentHashColl();
    ~RConcurrentHashColl();
+
+   /// Return true if the hash is already in already there
+   bool Find(const HashValue &hash) const;
+
    /// If the hash is there, return false. Otherwise, insert the hash and return true;
    bool Insert(char *buf, int len) const;
+
+   /// If the hash is there, return false. Otherwise, insert the hash and return true;
+   bool Insert(const HashValue &hash) const;
+
+   /// Return the hash object corresponding to the buffer.
+   static HashValue Hash(char *buf, int len);
 };
+
+inline bool operator==(const RConcurrentHashColl::HashValue &lhs, const RConcurrentHashColl::HashValue &rhs)
+{
+   auto l = lhs.Get();
+   auto r = rhs.Get();
+   return l[0] == r[0] && l[1] == r[1] && l[2] == r[2] && l[3] == r[3];
+}
 
 } // End NS Internal
 } // End NS ROOT
+
+namespace std {
+template <>
+struct less<ROOT::Internal::RConcurrentHashColl::HashValue> {
+   bool operator()(const ROOT::Internal::RConcurrentHashColl::HashValue &lhs, const ROOT::Internal::RConcurrentHashColl::HashValue &rhs) const
+   {
+      /// Check piece by piece the 4 64 bits ints which make up the hash.
+      auto l = lhs.Get();
+      auto r = rhs.Get();
+      // clang-format off
+      return l[0] < r[0] ? true :
+               l[0] > r[0] ? false :
+                 l[1] < r[1] ? true :
+                   l[1] > r[1] ? false :
+                     l[2] < r[2] ? true :
+                       l[2] > r[2] ? false :
+                         l[3] < r[3] ? true : false;
+      // clang-format on
+   }
+};
+} // End NS std
 
 #endif

--- a/core/thread/src/RConcurrentHashColl.cxx
+++ b/core/thread/src/RConcurrentHashColl.cxx
@@ -9,18 +9,46 @@
 namespace ROOT {
 namespace Internal {
 
+
+std::ostream &operator<<(std::ostream &os, const RConcurrentHashColl::HashValue &h)
+{
+   auto digest = h.Get();
+   os << digest[0] << "-" << digest[1] << "-" << digest[2] << "-" << digest[3];
+   return os;
+}
+
+RConcurrentHashColl::HashValue::HashValue(const char *data, int len)
+{
+   // The cast here is because in the TBuffer ecosystem, the type used is char*
+   Sha256(reinterpret_cast<const unsigned char *>(data), len, fDigest);
+}
+
 struct RHashSet {
-   std::set<ROOT::Internal::RSha256Hash> fSet;
+   std::set<ROOT::Internal::RConcurrentHashColl::HashValue> fSet;
 };
 
 RConcurrentHashColl::RConcurrentHashColl()
    : fHashSet(std::make_unique<RHashSet>()), fRWLock(std::make_unique<ROOT::TRWSpinLock>()){};
+
 RConcurrentHashColl::~RConcurrentHashColl() = default;
+
+/// Return true if the hash is already in already there
+bool RConcurrentHashColl::Find(const HashValue &hash) const
+{
+   ROOT::TRWSpinLockReadGuard rg(*fRWLock);
+   return (fHashSet->fSet.end() != fHashSet->fSet.find(hash));
+}
+
+/// If the buffer is there, return false. Otherwise, insert the hash and return true
+RConcurrentHashColl::HashValue RConcurrentHashColl::Hash(char *buffer, int len)
+{
+   return HashValue(buffer, len);
+}
 
 /// If the buffer is there, return false. Otherwise, insert the hash and return true
 bool RConcurrentHashColl::Insert(char *buffer, int len) const
 {
-   RSha256Hash hash(buffer, len);
+   HashValue hash(buffer, len);
 
    {
       ROOT::TRWSpinLockReadGuard rg(*fRWLock);
@@ -32,6 +60,14 @@ bool RConcurrentHashColl::Insert(char *buffer, int len) const
       fHashSet->fSet.insert(hash);
       return true;
    }
+}
+
+/// If the buffer is there, return false. Otherwise, insert the hash and return true
+bool RConcurrentHashColl::Insert(const HashValue &hash) const
+{
+   ROOT::TRWSpinLockWriteGuard wg(*fRWLock);
+   auto ret = fHashSet->fSet.insert(hash);
+   return ret.second;
 }
 
 } // End NS Internal

--- a/io/io/inc/TFile.h
+++ b/io/io/inc/TFile.h
@@ -131,7 +131,9 @@ protected:
    Bool_t                    FlushWriteCache();
    Int_t                     ReadBufferViaCache(char *buf, Int_t len);
    Int_t                     WriteBufferViaCache(const char *buf, Int_t len);
-   std::pair<TList *, Int_t> GetStreamerInfoListImpl(bool readSI);
+
+   struct InfoListRet;
+   InfoListRet GetStreamerInfoListImpl(bool readSI);
 
    // Creating projects
    Int_t         MakeProjectParMake(const char *packname, const char *filename);

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -133,6 +133,7 @@ The structure of a directory is shown in TDirectoryFile::TDirectoryFile
 #include "TThreadSlots.h"
 #include "TGlobal.h"
 #include "ROOT/RMakeUnique.hxx"
+#include "ROOT/RConcurrentHashColl.hxx"
 
 using std::sqrt;
 
@@ -1319,13 +1320,23 @@ const TList *TFile::GetStreamerInfoCache()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// \brief Simple struct of the return value of GetStreamerInfoListImpl
+struct TFile::InfoListRet {
+   TList *fList;
+   Int_t  fReturnCode;
+   ROOT::Internal::RConcurrentHashColl::HashValue fHash;
+};
+
+////////////////////////////////////////////////////////////////////////////////
 /// See documentation of GetStreamerInfoList for more details.
 /// This is an internal method which returns the list of streamer infos and also
 /// information about the success of the operation.
 
-std::pair<TList *, Int_t> TFile::GetStreamerInfoListImpl(bool lookupSICache)
+TFile::InfoListRet TFile::GetStreamerInfoListImpl(bool lookupSICache)
 {
-   if (fIsPcmFile) return {nullptr, 1}; // No schema evolution for ROOT PCM files.
+   ROOT::Internal::RConcurrentHashColl::HashValue hash;
+
+   if (fIsPcmFile) return {nullptr, 1, hash}; // No schema evolution for ROOT PCM files.
 
    TList *list = 0;
    if (fSeekInfo) {
@@ -1338,14 +1349,15 @@ std::pair<TList *, Int_t> TFile::GetStreamerInfoListImpl(bool lookupSICache)
          // ReadBuffer returns kTRUE in case of failure.
          Warning("GetRecordHeader","%s: failed to read the StreamerInfo data from disk.",
                  GetName());
-         return {nullptr, 1};
+         return {nullptr, 1, hash};
       }
 
 #ifdef R__USE_IMT
       if (lookupSICache) {
-         if (!fgTsSIHashes.Insert(buf,fNbytesInfo)) {
+         hash = fgTsSIHashes.Hash(buf, fNbytesInfo);
+         if (fgTsSIHashes.Find(hash)) {
             if (gDebug > 0) Info("GetStreamerInfo", "The streamer info record for file %s has already been treated, skipping it.", GetName());
-            return {nullptr, 0};
+            return {nullptr, 0, hash};
          }
       }
 #else
@@ -1367,10 +1379,10 @@ std::pair<TList *, Int_t> TFile::GetStreamerInfoListImpl(bool lookupSICache)
    if (list == 0) {
       Info("GetStreamerInfoList", "cannot find the StreamerInfo record in file %s",
            GetName());
-      return {nullptr, 1};
+      return {nullptr, 1, hash};
    }
 
-   return {list, 0};
+   return {list, 0, hash};
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1395,7 +1407,7 @@ std::pair<TList *, Int_t> TFile::GetStreamerInfoListImpl(bool lookupSICache)
 
 TList *TFile::GetStreamerInfoList()
 {
-   return GetStreamerInfoListImpl(/*lookupSICache*/ false).first;
+   return GetStreamerInfoListImpl(/*lookupSICache*/ false).fList;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -3501,8 +3513,8 @@ Int_t TFile::MakeProjectParProofInf(const char *pack, const char *proofinf)
 void TFile::ReadStreamerInfo()
 {
    auto listRetcode = GetStreamerInfoListImpl(/*lookupSICache*/ true);
-   TList *list = listRetcode.first;
-   auto retcode = listRetcode.second;
+   TList *list = listRetcode.fList;
+   auto retcode = listRetcode.fReturnCode;
    if (!list) {
       if (retcode) MakeZombie();
       return;
@@ -3604,6 +3616,12 @@ void TFile::ReadStreamerInfo()
    fClassIndex->fArray[0] = 0;
    list->Clear();  //this will delete all TStreamerInfo objects with kCanDelete bit set
    delete list;
+
+#ifdef R__USE_IMT
+   // We are done processing the record, let future calls and other threads that it
+   // has been done.
+   fgTsSIHashes.Insert(listRetcode.fHash);
+#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
When noting that a TStreamerInfo set has already been processed, we
must do it in 3 separates steps:
  - check it was seen before
  - read and process the set
  - record that the set as been seen.

The previous situation:
  - check and record that the set as been seen
  - read and process the set
led to a race condition if a second thread was checking the same
set before the second step was completed (in which case the
second thread was believing that the set was process and looking
for the result of the process (one of the StreamerInfo) but could
not find it.

We extend RConcurrentHashColl to have 2 new operations
  - standalone Hash calculation
  - standalone Find of hash
  - standalone Insert of hash.
and we use it to split the check and the recording as described
previously.

(this is an addendum to 95bf468438)