### PR TITLE
Fix ROOT-9662 race condition in TStreamerInfo loading.

### DIFF
--- a/core/thread/inc/ROOT/RConcurrentHashColl.hxx
+++ b/core/thread/inc/ROOT/RConcurrentHashColl.hxx
@@ -32,13 +32,10 @@ public:
    class HashValue {
        friend std::ostream &operator<<(std::ostream &os, const RConcurrentHashColl::HashValue &h);
    private:
-      ULong64_t fDigest[4];
+      ULong64_t fDigest[4] = {0, 0, 0, 0};
 
    public:
-      HashValue() {
-         for(auto d : fDigest)
-         d = 0;
-      }
+      HashValue() = default;
       HashValue(const char *data, int len);
       ULong64_t const *Get() const { return fDigest; }
    };

--- a/core/thread/inc/ROOT/RConcurrentHashColl.hxx
+++ b/core/thread/inc/ROOT/RConcurrentHashColl.hxx
@@ -12,6 +12,7 @@
 #define ROOT_RConcurrentHashColl
 
 #include <memory>
+#include "Rtypes.h"
 
 namespace ROOT {
 
@@ -28,13 +29,65 @@ private:
    mutable std::unique_ptr<ROOT::TRWSpinLock> fRWLock;
 
 public:
+   class HashValue {
+       friend std::ostream &operator<<(std::ostream &os, const RConcurrentHashColl::HashValue &h);
+   private:
+      ULong64_t fDigest[4];
+
+   public:
+      HashValue() {
+         for(auto d : fDigest)
+         d = 0;
+      }
+      HashValue(const char *data, int len);
+      ULong64_t const *Get() const { return fDigest; }
+   };
+
    RConcurrentHashColl();
    ~RConcurrentHashColl();
+
+   /// Return true if the hash is already in already there
+   bool Find(const HashValue &hash) const;
+
    /// If the hash is there, return false. Otherwise, insert the hash and return true;
    bool Insert(char *buf, int len) const;
+
+   /// If the hash is there, return false. Otherwise, insert the hash and return true;
+   bool Insert(const HashValue &hash) const;
+
+   /// Return the hash object corresponding to the buffer.
+   static HashValue Hash(char *buf, int len);
 };
+
+inline bool operator==(const RConcurrentHashColl::HashValue &lhs, const RConcurrentHashColl::HashValue &rhs)
+{
+   auto l = lhs.Get();
+   auto r = rhs.Get();
+   return l[0] == r[0] && l[1] == r[1] && l[2] == r[2] && l[3] == r[3];
+}
 
 } // End NS Internal
 } // End NS ROOT
+
+namespace std {
+template <>
+struct less<ROOT::Internal::RConcurrentHashColl::HashValue> {
+   bool operator()(const ROOT::Internal::RConcurrentHashColl::HashValue &lhs, const ROOT::Internal::RConcurrentHashColl::HashValue &rhs) const
+   {
+      /// Check piece by piece the 4 64 bits ints which make up the hash.
+      auto l = lhs.Get();
+      auto r = rhs.Get();
+      // clang-format off
+      return l[0] < r[0] ? true :
+               l[0] > r[0] ? false :
+                 l[1] < r[1] ? true :
+                   l[1] > r[1] ? false :
+                     l[2] < r[2] ? true :
+                       l[2] > r[2] ? false :
+                         l[3] < r[3] ? true : false;
+      // clang-format on
+   }
+};
+} // End NS std
 
 #endif

--- a/core/thread/src/RConcurrentHashColl.cxx
+++ b/core/thread/src/RConcurrentHashColl.cxx
@@ -9,18 +9,46 @@
 namespace ROOT {
 namespace Internal {
 
+
+std::ostream &operator<<(std::ostream &os, const RConcurrentHashColl::HashValue &h)
+{
+   auto digest = h.Get();
+   os << digest[0] << "-" << digest[1] << "-" << digest[2] << "-" << digest[3];
+   return os;
+}
+
+RConcurrentHashColl::HashValue::HashValue(const char *data, int len)
+{
+   // The cast here is because in the TBuffer ecosystem, the type used is char*
+   Sha256(reinterpret_cast<const unsigned char *>(data), len, fDigest);
+}
+
 struct RHashSet {
-   std::set<ROOT::Internal::RSha256Hash> fSet;
+   std::set<ROOT::Internal::RConcurrentHashColl::HashValue> fSet;
 };
 
 RConcurrentHashColl::RConcurrentHashColl()
    : fHashSet(std::make_unique<RHashSet>()), fRWLock(std::make_unique<ROOT::TRWSpinLock>()){};
+
 RConcurrentHashColl::~RConcurrentHashColl() = default;
+
+/// Return true if the hash is already in already there
+bool RConcurrentHashColl::Find(const HashValue &hash) const
+{
+   ROOT::TRWSpinLockReadGuard rg(*fRWLock);
+   return (fHashSet->fSet.end() != fHashSet->fSet.find(hash));
+}
+
+/// If the buffer is there, return false. Otherwise, insert the hash and return true
+RConcurrentHashColl::HashValue RConcurrentHashColl::Hash(char *buffer, int len)
+{
+   return HashValue(buffer, len);
+}
 
 /// If the buffer is there, return false. Otherwise, insert the hash and return true
 bool RConcurrentHashColl::Insert(char *buffer, int len) const
 {
-   RSha256Hash hash(buffer, len);
+   HashValue hash(buffer, len);
 
    {
       ROOT::TRWSpinLockReadGuard rg(*fRWLock);
@@ -32,6 +60,14 @@ bool RConcurrentHashColl::Insert(char *buffer, int len) const
       fHashSet->fSet.insert(hash);
       return true;
    }
+}
+
+/// If the buffer is there, return false. Otherwise, insert the hash and return true
+bool RConcurrentHashColl::Insert(const HashValue &hash) const
+{
+   ROOT::TRWSpinLockWriteGuard wg(*fRWLock);
+   auto ret = fHashSet->fSet.insert(hash);
+   return ret.second;
 }
 
 } // End NS Internal

--- a/io/io/inc/TFile.h
+++ b/io/io/inc/TFile.h
@@ -131,7 +131,9 @@ protected:
    Bool_t                    FlushWriteCache();
    Int_t                     ReadBufferViaCache(char *buf, Int_t len);
    Int_t                     WriteBufferViaCache(const char *buf, Int_t len);
-   std::pair<TList *, Int_t> GetStreamerInfoListImpl(bool readSI);
+
+   struct InfoListRet;
+   InfoListRet GetStreamerInfoListImpl(bool readSI);
 
    // Creating projects
    Int_t         MakeProjectParMake(const char *packname, const char *filename);


### PR DESCRIPTION
When noting that a TStreamerInfo set has already been processed, we
must do it in 3 separates steps:
  - check it was seen before
  - read and process the set
  - record that the set as been seen.

The previous situation:
  - check and record that the set as been seen
  - read and process the set
led to a race condition if a second thread was checking the same
set before the second step was completed (in which case the
second thread was believing that the set was process and looking
for the result of the process (one of the StreamerInfo) but could
not find it.

We extend RConcurrentHashColl to have 2 new operations
  - standalone Hash calculation
  - standalone Find of hash
  - standalone Insert of hash.
and we use it to split the check and the recording as described
previously.

(this is an addendum to 95bf468438)