### PR TITLE
[cxxmodules] Fall back to Header parsing on demand if we have no module.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1176,8 +1176,6 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
 #ifdef R__USE_CXXMODULES
    useCxxModules = true;
 #endif
-   if (useCxxModules)
-     fHeaderParsingOnDemand = false;
 
    llvm::install_fatal_error_handler(&exceptionErrorHandler);
 
@@ -1754,6 +1752,10 @@ void TCling::RegisterModule(const char* modulename,
    // declarations into the interpreter, except for those we really need for
    // I/O; see rootcling.cxx after the call to TCling__GetInterpreter().
    if (fromRootCling) return;
+
+   // When we cannot provide a module for the library we should enable header
+   // parsing. This 'mixed' mode ensures gradual migration to modules.
+   fHeaderParsingOnDemand = !hasCxxModule;
 
    // Treat Aclic Libs in a special way. Do not delay the parsing.
    bool hasHeaderParsingOnDemand = fHeaderParsingOnDemand;


### PR DESCRIPTION
We assumed that we will always have module file and unconditionally disable
header parsing on demand. However, the major use-case is gradual migration
to modules. In this scenario (tested by root-meta-fwdDecls-fwdDeclarations),
we have a dictionary which has no module file and still relies on the old
behavior. This can realistically happen when users gradually migrate to
modules. For example, we have modules-aware ROOT and untouched third party
code.

This patch enables header parsing on demand when we have no module file
available.