### PR TITLE
v6.14 fix ROOT-9694

### DIFF
--- a/README/ReleaseNotes/v614/index.md
+++ b/README/ReleaseNotes/v614/index.md
@@ -509,6 +509,44 @@ Released on August 23, 2018
 
 These changes will be part of the future 6.14/06
 
+### I/O
+
+* To allow for increase run-time performance and increase thread scalability the override ability of `TFile::GetStreamerInfoList` is replaced by an override of `TFile::GetStreamerInfoListImp` with updated return type and arguments.   If a class override `TFile::GetStreamerInfoList` you will now see a compilation error like:
+
+```
+/opt/build/root_builds/rootcling.cmake/include/TSQLFile.h:225:19: error: declaration of 'GetStreamerInfoList' overrides a 'final' function
+virtual TList *GetStreamerInfoList();
+^
+/opt/build/root_builds/rootcling.cmake/include/TFile.h:231:24: note: overridden virtual function is here
+virtual TList      *GetStreamerInfoList() final; // Note: to override behavior, please override GetStreamerInfoListImpl
+^
+```
+
+Instead you need to override the protected method:
+
+```
+InfoListRet GetStreamerInfoListImpl(bool lookupSICache);
+```
+
+which can be implemented as
+
+```
+InfoListRet DerivedClass::GetStreamerInfoListImpl(bool /*lookupSICache*/) {
+ROOT::Internal::RConcurrentHashColl::HashValue hash;
+TList *infolist = nullptr;
+//
+// Body of the former Derived::GetStreamerInfoList with the
+// return statement replaced with something like:
+
+// The second element indicates success or failure of the load.
+// (i.e. {nullptr, 0, hash} indicates the list has already been processed
+//  {nullptr, 1, hash} indicates the list failed to be loaded
+return {infolist, 0, hash};
+}
+```
+
+See `TFile::GetStreamerInfoListImpl` implementation for an example on how to implement the caching.
+
 ### RDataFrame
 * throw if name of defined column is not a valid C++ name
 

--- a/io/io/inc/TFile.h
+++ b/io/io/inc/TFile.h
@@ -26,10 +26,10 @@
 #include "TDirectoryFile.h"
 #include "TMap.h"
 #include "TUrl.h"
+#include "ROOT/RConcurrentHashColl.hxx"
 
 #ifdef R__USE_IMT
 #include "ROOT/TRWSpinLock.hxx"
-#include "ROOT/RConcurrentHashColl.hxx"
 #include <mutex>
 #endif
 
@@ -132,8 +132,15 @@ protected:
    Int_t                     ReadBufferViaCache(char *buf, Int_t len);
    Int_t                     WriteBufferViaCache(const char *buf, Int_t len);
 
-   struct InfoListRet;
-   InfoListRet GetStreamerInfoListImpl(bool readSI);
+   ////////////////////////////////////////////////////////////////////////////////
+   /// \brief Simple struct of the return value of GetStreamerInfoListImpl
+   struct InfoListRet {
+      TList *fList;
+      Int_t  fReturnCode;
+      ROOT::Internal::RConcurrentHashColl::HashValue fHash;
+   };
+
+   virtual InfoListRet GetStreamerInfoListImpl(bool lookupSICache);
 
    // Creating projects
    Int_t         MakeProjectParMake(const char *packname, const char *filename);
@@ -228,7 +235,7 @@ public:
    virtual Long64_t    GetSeekFree() const {return fSeekFree;}
    virtual Long64_t    GetSeekInfo() const {return fSeekInfo;}
    virtual Long64_t    GetSize() const;
-   virtual TList      *GetStreamerInfoList();
+   virtual TList      *GetStreamerInfoList() final; // Note: to override behavior, please override GetStreamerInfoListImpl
    const   TList      *GetStreamerInfoCache();
    virtual void        IncrementProcessIDs() { fNProcessIDs++; }
    virtual Bool_t      IsArchive() const { return fIsArchive; }

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -1321,14 +1321,6 @@ const TList *TFile::GetStreamerInfoCache()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// \brief Simple struct of the return value of GetStreamerInfoListImpl
-struct TFile::InfoListRet {
-   TList *fList;
-   Int_t  fReturnCode;
-   ROOT::Internal::RConcurrentHashColl::HashValue fHash;
-};
-
-////////////////////////////////////////////////////////////////////////////////
 /// See documentation of GetStreamerInfoList for more details.
 /// This is an internal method which returns the list of streamer infos and also
 /// information about the success of the operation.
@@ -1370,12 +1362,6 @@ TFile::InfoListRet TFile::GetStreamerInfoListImpl(bool lookupSICache)
    } else {
       list = (TList*)Get("StreamerInfo"); //for versions 2.26 (never released)
    }
-
-   // Before giving up, try to invoke GetStreamerInfoList, in case we are
-   // in a call stack which started from an inherited class such as TXMLFile or
-   // TSQLFile
-
-   if (!list) list = GetStreamerInfoList();
 
    if (list == 0) {
       Info("GetStreamerInfoList", "cannot find the StreamerInfo record in file %s",

--- a/io/sql/inc/TSQLFile.h
+++ b/io/sql/inc/TSQLFile.h
@@ -55,6 +55,8 @@ protected:
    virtual void DirWriteKeys(TDirectory *);
    virtual void DirWriteHeader(TDirectory *);
 
+   InfoListRet GetStreamerInfoListImpl(bool lookupSICache);
+
    // functions to manipulate basic tables (Configurations, Objects, Keys) in database
    void SaveToDatabase();
    Bool_t ReadConfigurations();
@@ -222,7 +224,6 @@ public:
    virtual Long64_t GetSeekFree() const { return 0; }
    virtual Long64_t GetSeekInfo() const { return 0; }
    virtual Long64_t GetSize() const { return 0; }
-   virtual TList *GetStreamerInfoList();
 
    Bool_t IsMySQL() const;
    virtual Bool_t IsOpen() const;

--- a/io/sql/src/TSQLFile.cxx
+++ b/io/sql/src/TSQLFile.cxx
@@ -889,22 +889,24 @@ TObject *TSQLFile::ReadSpecialObject(Long64_t keyid, TObject *obj)
 /// List of streamer infos is always stored with key:id 0,
 /// which is not shown in normal keys list
 
-TList *TSQLFile::GetStreamerInfoList()
+TFile::InfoListRet TSQLFile::GetStreamerInfoListImpl(bool /* lookupSICache */)
 {
    //   return new TList;
 
    if (gDebug > 1)
       Info("GetStreamerInfoList", "Start reading of streamer infos");
 
+   ROOT::Internal::RConcurrentHashColl::HashValue hash;
+
    TObject *obj = ReadSpecialObject(sqlio::Ids_StreamerInfos);
 
    TList *list = dynamic_cast<TList *>(obj);
    if (list == 0) {
       delete obj;
-      list = new TList;
+      return {nullptr, 1, hash};
    }
 
-   return list;
+   return {list, 0, hash};
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/io/xml/inc/TXMLFile.h
+++ b/io/xml/inc/TXMLFile.h
@@ -40,6 +40,8 @@ protected:
    virtual void DirWriteKeys(TDirectory *);
    virtual void DirWriteHeader(TDirectory *);
 
+   InfoListRet GetStreamerInfoListImpl(bool lookupSICache);
+
 private:
    // let the compiler do the job. gcc complains when the following line is activated
    // TXMLFile(const TXMLFile &) {}            //Files cannot be copied
@@ -67,7 +69,7 @@ public:
    virtual Long64_t GetSeekFree() const { return 0; }
    virtual Long64_t GetSeekInfo() const { return 0; }
    virtual Long64_t GetSize() const { return 0; }
-   virtual TList *GetStreamerInfoList();
+
    Int_t GetIOVersion() const { return fIOVersion; }
 
    virtual Bool_t IsOpen() const;

--- a/io/xml/src/TXMLFile.cxx
+++ b/io/xml/src/TXMLFile.cxx
@@ -725,10 +725,12 @@ void TXMLFile::WriteStreamerInfo()
 /// Read streamerinfo structures from xml format and provide them in the list
 /// It is user responsibility to destroy this list
 
-TList *TXMLFile::GetStreamerInfoList()
+TFile::InfoListRet TXMLFile::GetStreamerInfoListImpl(bool /* lookupSICache */)
 {
+   ROOT::Internal::RConcurrentHashColl::HashValue hash;
+
    if (!fStreamerInfoNode)
-      return nullptr;
+      return {nullptr, 1, hash};
 
    TList *list = new TList();
 
@@ -769,7 +771,7 @@ TList *TXMLFile::GetStreamerInfoList()
 
    list->SetOwner();
 
-   return list;
+   return {list, 0, hash};
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fix ROOT-9694, GetStreamerInfoList infinite recursion.

Commit b6523df introduces the infinite recursion whenever
there was a problem reading the StreamerInfo record and
introduces a useless attempt to read from file in the case
of a class derived from TFile that overrid GetStreamerInfoList.

To allow for increase run-time performance and increase thread
scalability the override ability of TFile::GetStreamerInfoList
is replaced by an override of TFile::GetStreamerInfoListImp with
updated return type and arguments.   If a class override
TFile::GetStreamerInfoList you will now see a compilation error like:
{code}
/opt/build/root_builds/rootcling.cmake/include/TSQLFile.h:225:19: error: declaration of 'GetStreamerInfoList' overrides a 'final' function
   virtual TList *GetStreamerInfoList();
                  ^
/opt/build/root_builds/rootcling.cmake/include/TFile.h:231:24: note: overridden virtual function is here
   virtual TList      *GetStreamerInfoList() final; // Note: to override behavior, please override GetStreamerInfoListImpl
                       ^
{code}

Instead you need to override the protected method:

{code}
   InfoListRet GetStreamerInfoListImpl(bool lookupSICache);
{code}

which can be implemented as
{code}
  InfoListRet DerivedClass::GetStreamerInfoListImpl(bool /*lookupSICache*/) {
       ROOT::Internal::RConcurrentHashColl::HashValue hash;
       TList *infolist = nullptr;
       //
       // Body of the former Derived::GetStreamerInfoList with the
       // return statement replaced with something like:

       // The second element indicates success or failure of the load.
       // (i.e. {nullptr, 0, hash} indicates the list has already been processed
       //  {nullptr, 1, hash} indicates the list failed to be loaded
       return {infolist, 0, hash};
  }
{code}

See TFile::GetStreamerInfoListImpl implementation for an example on how to implement the caching.