### PR TITLE
mysql: use bool instead of my_bool type, fix ROOT-9624

### DIFF
--- a/sql/mysql/inc/TMySQLStatement.h
+++ b/sql/mysql/inc/TMySQLStatement.h
@@ -22,8 +22,12 @@ typedef struct { int dummy; } MYSQL_STMT;
 typedef struct { int dummy; } MYSQL_BIND;
 #endif
 
+// MariaDB is fork of MySQL and still include definition of my_bool
+// MariaDB major version is 10, therefore it confuses version ID here
+#ifndef MARIADB_VERSION_ID
 #if MYSQL_VERSION_ID > 80000
 typedef bool my_bool;
+#endif
 #endif
 
 class TMySQLStatement : public TSQLStatement {

--- a/sql/mysql/inc/TMySQLStatement.h
+++ b/sql/mysql/inc/TMySQLStatement.h
@@ -22,6 +22,10 @@ typedef struct { int dummy; } MYSQL_STMT;
 typedef struct { int dummy; } MYSQL_BIND;
 #endif
 
+#if MYSQL_VERSION_ID > 80000
+typedef bool my_bool;
+#endif
+
 class TMySQLStatement : public TSQLStatement {
 
 protected:
@@ -32,7 +36,7 @@ protected:
       Int_t         fSqlType;     //! sqltype of parameter
       Bool_t        fSign;        //! signed - not signed type
       ULong_t       fResLength;  //! length argument
-      bool          fResNull;    //! indicates if argument is null
+      my_bool       fResNull;    //! indicates if argument is null
       char*         fStrBuffer;  //! special buffer to be used for string conversions
       char*         fFieldName;  //! buffer for field name
    };

--- a/sql/mysql/inc/TMySQLStatement.h
+++ b/sql/mysql/inc/TMySQLStatement.h
@@ -32,7 +32,7 @@ protected:
       Int_t         fSqlType;     //! sqltype of parameter
       Bool_t        fSign;        //! signed - not signed type
       ULong_t       fResLength;  //! length argument
-      my_bool       fResNull;    //! indicates if argument is null
+      bool          fResNull;    //! indicates if argument is null
       char*         fStrBuffer;  //! special buffer to be used for string conversions
       char*         fFieldName;  //! buffer for field name
    };

--- a/sql/mysql/src/TMySQLServer.cxx
+++ b/sql/mysql/src/TMySQLServer.cxx
@@ -159,7 +159,7 @@ TMySQLServer::TMySQLServer(const char *db, const char *uid, const char *pw)
          if (opt.Contains("reconnect=")) {
            #if MYSQL_VERSION_ID >= 50013
             opt.Remove(0, 10);
-            my_bool reconnect_on = (opt=="1") || (opt=="true");
+            bool reconnect_on = (opt=="1") || (opt=="true");
             mysql_options(fMySQL, MYSQL_OPT_RECONNECT, (const char*) &reconnect_on);
             if (gDebug) Info("TMySQLServer","Set reconnect options %s", (reconnect_on ? "ON" : "OFF"));
            #else


### PR DESCRIPTION
Fixes https://sft.its.cern.ch/jira/projects/ROOT/issues/ROOT-9624

Description: https://bugs.mysql.com/bug.php?id=85131