### PR TITLE
Fix ROOT-9701, IO read rules seemingly no longer executed.

### DIFF
--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -4112,7 +4112,7 @@ void TBranchElement::ReadLeavesCollection(TBuffer& b)
    }
    fNdata = n;
 
-   R__PushCache onfileObject(((TBufferFile&)b),fOnfileObject,n);
+   R__PushCache onfileObject(((TBufferFile&)b),fOnfileObject,1);
 
    // Note: Proxy-helper needs to "embrace" the entire
    //       streaming of this STL container if the container


### PR DESCRIPTION
The rule were actually still executed on the proper object and
in the right order.  However when we had

  - a top level object with a rule for one of its transient member
  - that top level object also having a data member that is an STL collection.

then the fOnfileObject (type TVirtualArray) was inadvertently resized
by the top node of the STL object (i.e 'type 4' branch) to the size of
the collection.

Before the improvement to the rule scheduling the ordering of operations
was:
   1 - a - resize the top level object's fOnfileObject to 1
   2 - b - read the input for the transient member into the fOnfileObject
   3 - c - execute the rule using the input/fOnfileObject and updating the transient member
   4 - d - resize the top level object's fOnfileObject to size of sub-collection

The last stage provoke a reallocation of the element of fOnfileObject (thus
losing the input but only 'after' it has been used.

With the new rule scheduling the order becomes

   1 - a - resize the top level object's fOnfileObject to 1
   2 - b - read the input for the transient member into the fOnfileObject
   3 - d - resize the top level object's fOnfileObject to size of sub-collection
   4 - c - execute the rule using the input/fOnfileObject and updating the transient member

and now the consequence of the inadvertent resize becomes visible.
i.e. for each entry where the sub-collection 'grows' the transient member
value will be invalid. [Note: in the example provided with ROOT-9701 the
sub-collection 'grows' by one at each entry]