### PR TITLE
Fix inconsistent behavior in TClusterIterator when there are clusters but fAutoFlush is still negative.

### DIFF
--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -548,7 +548,7 @@ TTree::TClusterIterator::TClusterIterator(TTree *tree, Long64_t firstEntry) : fT
       } else {
          autoflush = fTree->fClusterSize[fClusterRange];
       }
-      if (autoflush == 0) {
+      if (autoflush <= 0) {
          autoflush = GetEstimatedClusterSize();
       }
       fStartEntry = pedestal + entryInRange - entryInRange%autoflush;


### PR DESCRIPTION


With a file has several cluster range but has fAutoFlush set to a negative value: eg.

t->Print("clusters");
******************************************************************************
*Tree    :t         : t                                                      *
*Entries :     1000 : Total =          424803 bytes  File  Size =      33982 *
*        :          : Tree compression factor =  12.78                       *
******************************************************************************
Cluster Range #  Entry Start      Last Entry        Size
0                0                49                  10
….
18               900              949                 10
19               950              999              -2000000

TClusterIterator was not estimate correctly the cluster size of the last range.
This resulted in some circumstances to message like:

Error in <TTreeCache::FillBuffer>: Inconsistency: fCurrentClusterStart=900 fEntryCurrent=950 fNextClusterStart=956 but fCurrentEntry should not be in between the two
Error in <TTreeCache::FillBuffer>: Inconsistency: fCurrentClusterStart=950 fEntryCurrent=950 fNextClusterStart=953 but fCurrentEntry should not be in between the two
Error in <TTreeCache::FillBuffer>: Inconsistency: fCurrentClusterStart=950 fEntryCurrent=950 fNextClusterStart=953 but fCurrentEntry should not be in between the two
Error in <TTreeCache::FillBuffer>: Inconsistency: fCurrentClusterStart=950 fEntryCurrent=950 fNextClusterStart=953 but fCurrentEntry should not be in between the two

A work-around is to increase the TTreeCacheSize to be large enough that it would contains
all the entries of the last range.

See https://root-forum.cern.ch/t/ttreecache-fillbuffer-error-with-root-6-14-04/30914
the same problem was also reported by CMS.