### PR TITLE
[DF][NFC] Improve doc, use aliases for return types

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -82,6 +82,9 @@ using RNode = RInterface<::ROOT::Detail::RDF::RNodeBase, void>;
  * \brief The public interface to the RDataFrame federation of classes
  * \tparam Proxied One of the "node" base types (e.g. RLoopManager, RFilterBase). The user never specifies this type manually.
  * \tparam DataSource The type of the RDataSource which is providing the data to the data frame. There is no source by default.
+ *
+ * The documentation of each method features a one liner illustrating how to use the method, for example showing how
+ * the majority of the template parameters are automatically deduced requiring no or very little effort by the user.
  */
 // clang-format on
 template <typename Proxied, typename DataSource = void>

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -75,6 +75,7 @@ class RInterface;
 
 using RNode = RInterface<::ROOT::Detail::RDF::RNodeBase, void>;
 
+// clang-format off
 /**
  * \class ROOT::RDF::RInterface
  * \ingroup dataframe
@@ -82,6 +83,7 @@ using RNode = RInterface<::ROOT::Detail::RDF::RNodeBase, void>;
  * \tparam Proxied One of the "node" base types (e.g. RLoopManager, RFilterBase). The user never specifies this type manually.
  * \tparam DataSource The type of the RDataSource which is providing the data to the data frame. There is no source by default.
  */
+// clang-format on
 template <typename Proxied, typename DataSource = void>
 class RInterface {
    using DS_t = DataSource;
@@ -1978,10 +1980,10 @@ private:
    // This overload is chosen when the callable passed to Define or DefineSlot returns void.
    // It simply fires a compile-time error. This is preferable to a static_assert in the main `Define` overload because
    // this way compilation of `Define` has no way to continue after throwing the error.
-   template <typename F, typename CustomColumnType, typename RetType = typename TTraits::CallableTraits<F>::ret_type, bool IsFStringConv = std::is_convertible<F, std::string>::value, bool IsRetTypeDefConstr = std::is_default_constructible<RetType>::value>
-   typename std::enable_if<!IsFStringConv &&
-                              !IsRetTypeDefConstr,
-                           RInterface<Proxied, DS_t>>::type
+   template <typename F, typename CustomColumnType, typename RetType = typename TTraits::CallableTraits<F>::ret_type,
+             bool IsFStringConv = std::is_convertible<F, std::string>::value,
+             bool IsRetTypeDefConstr = std::is_default_constructible<RetType>::value>
+   typename std::enable_if<!IsFStringConv && !IsRetTypeDefConstr, RInterface<Proxied, DS_t>>::type
    DefineImpl(std::string_view, F, const ColumnNames_t &)
    {
       static_assert(std::is_default_constructible<typename TTraits::CallableTraits<F>::ret_type>::value,

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -79,7 +79,8 @@ using RNode = RInterface<::ROOT::Detail::RDF::RNodeBase, void>;
  * \class ROOT::RDF::RInterface
  * \ingroup dataframe
  * \brief The public interface to the RDataFrame federation of classes
- * \tparam T One of the "node" base types (e.g. RLoopManager, RFilterBase). The user never specifies this type manually.
+ * \tparam Proxied One of the "node" base types (e.g. RLoopManager, RFilterBase). The user never specifies this type manually.
+ * \tparam DataSource The type of the RDataSource which is providing the data to the data frame. There is no source by default.
  */
 template <typename Proxied, typename DataSource = void>
 class RInterface {
@@ -1977,9 +1978,9 @@ private:
    // This overload is chosen when the callable passed to Define or DefineSlot returns void.
    // It simply fires a compile-time error. This is preferable to a static_assert in the main `Define` overload because
    // this way compilation of `Define` has no way to continue after throwing the error.
-   template <typename F, typename CustomColumnType, typename RetType = typename TTraits::CallableTraits<F>::ret_type>
-   typename std::enable_if<!std::is_convertible<F, std::string>::value &&
-                              !std::is_default_constructible<RetType>::value,
+   template <typename F, typename CustomColumnType, typename RetType = typename TTraits::CallableTraits<F>::ret_type, bool IsFStringConv = std::is_convertible<F, std::string>::value, bool IsRetTypeDefConstr = std::is_default_constructible<RetType>::value>
+   typename std::enable_if<!IsFStringConv &&
+                              !IsRetTypeDefConstr,
                            RInterface<Proxied, DS_t>>::type
    DefineImpl(std::string_view, F, const ColumnNames_t &)
    {


### PR DESCRIPTION
and templates in the context of private methods to avoid doc squeezed to the right.