### PR TITLE
Added localredirect compatibility to TNetXNGFile

### DIFF
--- a/net/netxng/inc/TNetXNGFile.h
+++ b/net/netxng/inc/TNetXNGFile.h
@@ -60,6 +60,9 @@ public:
    TNetXNGFile(const char *url, Option_t *mode = "", const char *title = "",
                Int_t compress = 1, Int_t netopt = 0, Bool_t parallelopen = kFALSE,
 	       const char *lurl = 0);
+   TNetXNGFile(const char *url, Option_t *mode = "", const char *title = "",
+               Int_t compress = 1, Int_t netopt = 0, Bool_t parallelopen = kFALSE
+	       );
    virtual ~TNetXNGFile();
 
    virtual void     Init(Bool_t create);

--- a/net/netxng/inc/TNetXNGFile.h
+++ b/net/netxng/inc/TNetXNGFile.h
@@ -58,7 +58,8 @@ public:
       fFile(0), fUrl(0), fMode(XrdCl::OpenFlags::None), fInitCondVar(0),
       fReadvIorMax(0), fReadvIovMax(0) {}
    TNetXNGFile(const char *url, Option_t *mode = "", const char *title = "",
-               Int_t compress = 1, Int_t netopt = 0, Bool_t parallelopen = kFALSE);
+               Int_t compress = 1, Int_t netopt = 0, Bool_t parallelopen = kFALSE,
+	       const char *lurl = 0);
    virtual ~TNetXNGFile();
 
    virtual void     Init(Bool_t create);

--- a/net/netxng/inc/TNetXNGFile.h
+++ b/net/netxng/inc/TNetXNGFile.h
@@ -57,8 +57,8 @@ public:
    TNetXNGFile() : TFile(),
       fFile(0), fUrl(0), fMode(XrdCl::OpenFlags::None), fInitCondVar(0),
       fReadvIorMax(0), fReadvIovMax(0) {}
-   TNetXNGFile(const char *url, const char *lurl, Option_t *mode = "", const char *title = "",
-               Int_t compress = 1, Int_t netopt = 0, Bool_t parallelopen = kFALSE);
+   TNetXNGFile(const char *url, const char *lurl, Option_t *mode , const char *title ,
+               Int_t compress , Int_t netopt , Bool_t parallelopen );
    TNetXNGFile(const char *url, Option_t *mode = "", const char *title = "",
                Int_t compress = 1, Int_t netopt = 0, Bool_t parallelopen = kFALSE);
 

--- a/net/netxng/inc/TNetXNGFile.h
+++ b/net/netxng/inc/TNetXNGFile.h
@@ -1,4 +1,4 @@
-// @(#)root/netxng:$Id$
+
 /*************************************************************************
  * Copyright (C) 1995-2013, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -57,12 +57,11 @@ public:
    TNetXNGFile() : TFile(),
       fFile(0), fUrl(0), fMode(XrdCl::OpenFlags::None), fInitCondVar(0),
       fReadvIorMax(0), fReadvIovMax(0) {}
+   TNetXNGFile(const char *url, const char *lurl, Option_t *mode = "", const char *title = "",
+               Int_t compress = 1, Int_t netopt = 0, Bool_t parallelopen = kFALSE);
    TNetXNGFile(const char *url, Option_t *mode = "", const char *title = "",
-               Int_t compress = 1, Int_t netopt = 0, Bool_t parallelopen = kFALSE,
-	       const char *lurl = 0);
-   TNetXNGFile(const char *url, Option_t *mode = "", const char *title = "",
-               Int_t compress = 1, Int_t netopt = 0, Bool_t parallelopen = kFALSE
-	       );
+               Int_t compress = 1, Int_t netopt = 0, Bool_t parallelopen = kFALSE);
+
    virtual ~TNetXNGFile();
 
    virtual void     Init(Bool_t create);

--- a/net/netxng/src/TNetXNGFile.cxx
+++ b/net/netxng/src/TNetXNGFile.cxx
@@ -127,8 +127,9 @@ TNetXNGFile::TNetXNGFile(const char *url,
                          const char *title,
                          Int_t       compress,
                          Int_t       /*netopt*/,
-                         Bool_t      parallelopen) :
-   TFile(url, "NET", title, compress)
+                         Bool_t      parallelopen,
+			 const char *lurl) :
+   TFile((lurl ? lurl : url), "NET", title, compress)
 {
    using namespace XrdCl;
 
@@ -724,6 +725,18 @@ Bool_t TNetXNGFile::GetVectorReadLimits()
 
    if (!fQueryReadVParams)
       return kTRUE;
+
+   std::string lasturl;
+   fFile->GetProperty("LastURL",lasturl);
+   URL lrl(lasturl);
+   //local redirect will split vector reads into multiple local reads anyway,
+   // so we are fine with the default values
+   if(0==lrl.GetProtocol().compare("file") &&
+      0==lrl.GetHostId().compare("localhost")){
+       if (gDebug>=1) 
+          Info("GetVectorReadLimits","Local redirect, using default values");
+       return kTRUE;
+   }
 
 #if XrdVNUMBER >= 40000
    std::string dataServerStr;

--- a/net/netxng/src/TNetXNGFile.cxx
+++ b/net/netxng/src/TNetXNGFile.cxx
@@ -126,6 +126,14 @@ TNetXNGFile::TNetXNGFile(const char *url,
                          Option_t   *mode,
                          const char *title,
                          Int_t       compress,
+                         Int_t       netopt,
+                         Bool_t      parallelopen) :
+	TNetXNGFile(url,mode,title,compress,netopt,parallelopen,0){}
+
+TNetXNGFile::TNetXNGFile(const char *url,
+                         Option_t   *mode,
+                         const char *title,
+                         Int_t       compress,
                          Int_t       /*netopt*/,
                          Bool_t      parallelopen,
 			 const char *lurl) :

--- a/net/netxng/src/TNetXNGFile.cxx
+++ b/net/netxng/src/TNetXNGFile.cxx
@@ -128,15 +128,15 @@ TNetXNGFile::TNetXNGFile(const char *url,
                          Int_t       compress,
                          Int_t       netopt,
                          Bool_t      parallelopen) :
-	TNetXNGFile(url,mode,title,compress,netopt,parallelopen,0){}
+	TNetXNGFile(url,0,mode,title,compress,netopt,parallelopen){}
 
 TNetXNGFile::TNetXNGFile(const char *url,
+		         const char *lurl,
                          Option_t   *mode,
                          const char *title,
                          Int_t       compress,
                          Int_t       /*netopt*/,
-                         Bool_t      parallelopen,
-			 const char *lurl) :
+                         Bool_t      parallelopen) :
    TFile((lurl ? lurl : url), "NET", title, compress)
 {
    using namespace XrdCl;

--- a/net/netxng/src/TNetXNGFile.cxx
+++ b/net/netxng/src/TNetXNGFile.cxx
@@ -731,9 +731,9 @@ Bool_t TNetXNGFile::GetVectorReadLimits()
    URL lrl(lasturl);
    //local redirect will split vector reads into multiple local reads anyway,
    // so we are fine with the default values
-   if(0==lrl.GetProtocol().compare("file") &&
-      0==lrl.GetHostId().compare("localhost")){
-       if (gDebug>=1) 
+   if(lrl.GetProtocol().compare("file") == 0 &&
+      lrl.GetHostId().compare("localhost") == 0){
+       if (gDebug >= 1)
           Info("GetVectorReadLimits","Local redirect, using default values");
        return kTRUE;
    }
@@ -942,4 +942,3 @@ void TNetXNGFile::SetEnv()
                             || strlen(cenv) <= 0))
       gSystem->Setenv("XrdSecPWDVERIFYSRV",    val.Data());
 }
-


### PR DESCRIPTION
Added necessary changes to allow [XRootD local redirection](https://github.com/xrootd/xrootd/blob/8c9d0a9cc7f00cbb2db35be275c35126f3e091c0/docs/ReleaseNotes.txt#L14) from within TNetXNGFile.

1. Uses standard VectorReadLimits and does not query a XRootD data server (which is unknown in local redirection), when it is redirected to a local file
2. Adds a, const char *lurl (defaulted to 0) to TNetXNGFile's Constructor, and passes it to TFile, if set. This allows redirection to files that have a different name in the local file system and is important to allow derivation (for example TAlien and TJAlienFile) and to still keep functionality via TArchiveFile when the file name in the local file system does not match *.zip