### PR TITLE
http: let better control cache settings from web server

### DIFF
--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -138,6 +138,10 @@ ROOT::Experimental::RWebWindowsManager::~RWebWindowsManager()
 /// If required, one could change websocket timeouts (default is 10000 ms)
 ///
 ///      WebGui.HttpWSTmout: 10000
+///
+/// Following parameter controls browser max-age caching parameter for files (default 3600)
+///
+///      WebGui.HttpMaxAge: 3600
 
 bool ROOT::Experimental::RWebWindowsManager::CreateServer(bool with_http)
 {
@@ -178,6 +182,7 @@ bool ROOT::Experimental::RWebWindowsManager::CreateServer(bool with_http)
    int http_min = gEnv->GetValue("WebGui.HttpPortMin", 8800);
    int http_max = gEnv->GetValue("WebGui.HttpPortMax", 9800);
    int http_wstmout = gEnv->GetValue("WebGui.HttpWSTmout", 10000);
+   int http_maxage = gEnv->GetValue("WebGui.HttpMaxAge", -1);
    fLaunchTmout = gEnv->GetValue("WebGui.LaunchTmout", 30.);
    const char *http_loopback = gEnv->GetValue("WebGui.HttpLoopback", "no");
    const char *http_bind = gEnv->GetValue("WebGui.HttpBind", "");
@@ -221,6 +226,9 @@ bool ROOT::Experimental::RWebWindowsManager::CreateServer(bool with_http)
       } else {
          url.Append("localhost");
       }
+
+      if (http_maxage >= 0)
+         engine.Append(TString::Format("&max_age=%d", http_maxage));
 
       if (use_secure) {
          engine.Append("&ssl_cert=");
@@ -353,6 +361,8 @@ void ROOT::Experimental::RWebWindowsManager::TestProg(TString &prog, const std::
 ///   WebGui.FirefoxRandomProfile: usage of random Firefox profile -1 never, 0 - only for batch mode (dflt), 1 - always
 ///   WebGui.LaunchTmout: time required to start process in seconds (default 30 s)
 ///   WebGui.OperationTmout: time required to perform WebWindow operation like execute command or update drawings
+///
+///   Http-server related parameters documented in RWebWindowsManager::CreateServer() method
 
 unsigned ROOT::Experimental::RWebWindowsManager::Show(ROOT::Experimental::RWebWindow &win, bool batch_mode, const std::string &_where)
 {

--- a/net/http/inc/THttpCallArg.h
+++ b/net/http/inc/THttpCallArg.h
@@ -186,6 +186,8 @@ public:
 
    void AddHeader(const char *name, const char *value);
 
+   void AddNoCacheHeader();
+
    /** returns number of fields in header */
    Int_t NumHeader() const { return CountHeader(fHeader).Atoi(); }
 

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -244,7 +244,7 @@ static int begin_request_handler(struct mg_connection *conn, void *)
             if (engine->GetMaxAge() > 0)
                arg->AddHeader("Cache-Control", TString::Format("max-age=%d", engine->GetMaxAge()));
             else
-               arg->AddHeader("Cache-Control", "private, no-cache, no-store, must-revalidate, max-age=0, proxy-revalidate, s-maxage=0");
+               arg->AddNoCacheHeader();
             arg->SetZipping();
          }
       } else {

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -241,7 +241,10 @@ static int begin_request_handler(struct mg_connection *conn, void *)
          } else {
             arg->SetContentType(THttpServer::GetMimeType(filename.Data()));
             arg->SetContent(std::move(buf));
-            arg->AddHeader("Cache-Control", "max-age=3600");
+            if (engine->GetMaxAge() > 0)
+               arg->AddHeader("Cache-Control", TString::Format("max-age=%d", engine->GetMaxAge()));
+            else
+               arg->AddHeader("Cache-Control", "private, no-cache, no-store, must-revalidate, max-age=0, proxy-revalidate, s-maxage=0");
             arg->SetZipping();
          }
       } else {
@@ -511,11 +514,12 @@ Bool_t TCivetweb::Create(const char *args)
             }
 
             if (url.HasOption("nocache"))
-               max_age = "0";
+               fMaxAge = 0;
 
-            const char *ma = url.GetValueFromOptions("max_age");
-            if (ma)
-               max_age = ma;
+            if (url.HasOption("max_age"))
+               fMaxAge = url.GetIntValueFromOptions("max_age");
+
+            max_age.Form("%d", fMaxAge);
          }
       }
    }

--- a/net/http/src/TCivetweb.h
+++ b/net/http/src/TCivetweb.h
@@ -22,7 +22,8 @@ protected:
    TString fTopName;            ///<! name of top item
    Bool_t fDebug{kFALSE};       ///<! debug mode
    Bool_t fTerminating{kFALSE}; ///<! server doing shutdown and not react on requests
-   Bool_t fOnlySecured;         ///<! if server should run only https protocol
+   Bool_t fOnlySecured{kFALSE}; ///<! if server should run only https protocol
+   Int_t fMaxAge{3600};         ///<! max-age parameter
 
    virtual void Terminate() { fTerminating = kTRUE; }
 
@@ -41,6 +42,8 @@ public:
    Bool_t IsTerminating() const { return fTerminating; }
 
    Int_t ProcessLog(const char *message);
+
+   Int_t GetMaxAge() const { return fMaxAge; }
 };
 
 #endif

--- a/net/http/src/THttpCallArg.cxx
+++ b/net/http/src/THttpCallArg.cxx
@@ -347,6 +347,14 @@ void THttpCallArg::AddHeader(const char *name, const char *value)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Set CacheControl http header to disable browser caching
+
+void THttpCallArg::AddNoCacheHeader()
+{
+   AddHeader("Cache-Control", "private, no-cache, no-store, must-revalidate, max-age=0, proxy-revalidate, s-maxage=0");
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Fills HTTP header, which can be send at the beggining of reply on the http request
 /// \param name is HTTP protocol name (default "HTTP/1.1")
 

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -846,6 +846,7 @@ void THttpServer::ProcessRequest(THttpCallArg *arg)
             fname.ReplaceAll("$jsrootsys", fJSROOTSYS);
 
             arg->fContent = ReadFileContent(fname.Data());
+            arg->AddNoCacheHeader();
          }
       }
 
@@ -882,8 +883,8 @@ void THttpServer::ProcessRequest(THttpCallArg *arg)
 
             arg->ReplaceAllinContent(hjsontag, h_json.Data());
 
-            arg->AddHeader("Cache-Control",
-                           "private, no-cache, no-store, must-revalidate, max-age=0, proxy-revalidate, s-maxage=0");
+            arg->AddNoCacheHeader();
+
             if (arg->fQuery.Index("nozip") == kNPOS)
                arg->SetZipping();
          }
@@ -931,8 +932,7 @@ void THttpServer::ProcessRequest(THttpCallArg *arg)
             if (fSniffer->Produce(arg->fPathName.Data(), "root.json", "compact=23", str))
                arg->ReplaceAllinContent(rootjsontag, str);
          }
-         arg->AddHeader("Cache-Control",
-                        "private, no-cache, no-store, must-revalidate, max-age=0, proxy-revalidate, s-maxage=0");
+         arg->AddNoCacheHeader();
          if (arg->fQuery.Index("nozip") == kNPOS)
             arg->SetZipping();
          arg->SetContentType("text/html");
@@ -1017,8 +1017,7 @@ void THttpServer::ProcessRequest(THttpCallArg *arg)
    }
 
    // try to avoid caching on the browser
-   arg->AddHeader("Cache-Control",
-                  "private, no-cache, no-store, must-revalidate, max-age=0, proxy-revalidate, s-maxage=0");
+   arg->AddNoCacheHeader();
 
    // potentially add cors header
    if (IsCors())


### PR DESCRIPTION
With CacheControl HTTP header one could specify how long browser will store files in cache.
Now one can configure for all file requests max-age parameters.
Introduce WebGui.HttpMaxAge rootrc parameter.
When WebGui.HttpMaxAge=0, all kind of caching should be disabled