### PR TITLE
XRootD Local Redirection in AliEn via TNetXNGFile

### DIFF
--- a/net/alien/CMakeLists.txt
+++ b/net/alien/CMakeLists.txt
@@ -3,8 +3,8 @@
 # @author Pere Mato, CERN
 ############################################################################
 
-include_directories(${ALIEN_INCLUDE_DIR})
-
+include_directories(${ALIEN_INCLUDE_DIR} ${XROOTD_INCLUDE_DIRS})
+add_definitions(${XROOTD_CFLAGS})
 ROOT_STANDARD_LIBRARY_PACKAGE(RAliEn
-                              LIBRARIES ${ALIEN_LIBRARIES}
-                              DEPENDENCIES XMLIO Netx Tree Proof)
+                              LIBRARIES ${ALIEN_LIBRARIES} ${XROOTD_LIBRARIES}
+                              DEPENDENCIES XMLIO Netx NetxNG Tree Proof)

--- a/net/alien/inc/TAlienFile.h
+++ b/net/alien/inc/TAlienFile.h
@@ -31,12 +31,11 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-#include "TXNetFile.h"
-
+#include "TNetXNGFile.h"
 
 class TUrl;
 
-class TAlienFile : public TXNetFile {
+class TAlienFile : public TNetXNGFile {
 
 private:
    TString fLfn;       // logical file name
@@ -50,7 +49,7 @@ private:
    Long64_t fOpenedAt; // Absolute value for time when opened
    Double_t fElapsed;  // Time elapsed to opem file
 public:
-   TAlienFile() : TXNetFile(), fLfn(), fAuthz(), fGUID(), fUrl(), fPfn(), fSE(), fImage(0), fNreplicas(0), fOpenedAt(0), fElapsed(0) { }
+   TAlienFile() : TNetXNGFile(), fLfn(), fAuthz(), fGUID(), fUrl(), fPfn(), fSE(), fImage(0), fNreplicas(0), fOpenedAt(0), fElapsed(0) { }
    TAlienFile(const char *purl, Option_t *option = "",
               const char *ftitle = "", Int_t compress = 1,
               Bool_t parallelopen = kFALSE, const char *lurl = 0,

--- a/net/alien/src/TAlienFile.cxx
+++ b/net/alien/src/TAlienFile.cxx
@@ -83,7 +83,7 @@ TAlienFile::TAlienFile(const char *purl, Option_t *option,
                        const char *ftitle, Int_t compress,
                        Bool_t parallelopen, const char *lurl,
                        const char *authz) :
-   TXNetFile(purl, option, ftitle, compress, 0, parallelopen, lurl)
+   TNetXNGFile(purl, option, ftitle, compress, 0, parallelopen, lurl)
 {
    TUrl logicalurl(lurl);
    fLfn = logicalurl.GetFile();
@@ -549,7 +549,7 @@ void TAlienFile::Close(Option_t * option)
 
 
    // Close file
-   TXNetFile::Close(option);
+   TNetXNGFile::Close(option);
 
    if (fOption == "READ")
       return;

--- a/net/netxng/inc/TNetXNGFile.h
+++ b/net/netxng/inc/TNetXNGFile.h
@@ -58,7 +58,8 @@ public:
       fFile(0), fUrl(0), fMode(XrdCl::OpenFlags::None), fInitCondVar(0),
       fReadvIorMax(0), fReadvIovMax(0) {}
    TNetXNGFile(const char *url, Option_t *mode = "", const char *title = "",
-               Int_t compress = 1, Int_t netopt = 0, Bool_t parallelopen = kFALSE);
+               Int_t compress = 1, Int_t netopt = 0, Bool_t parallelopen = kFALSE,
+	       const char *lurl = 0);
    virtual ~TNetXNGFile();
 
    virtual void     Init(Bool_t create);

--- a/net/netxng/src/TNetXNGFile.cxx
+++ b/net/netxng/src/TNetXNGFile.cxx
@@ -127,8 +127,9 @@ TNetXNGFile::TNetXNGFile(const char *url,
                          const char *title,
                          Int_t       compress,
                          Int_t       /*netopt*/,
-                         Bool_t      parallelopen) :
-   TFile(url, "NET", title, compress)
+                         Bool_t      parallelopen,
+			 const char *lurl) :
+   TFile((lurl ? lurl : url), "NET", title, compress)
 {
    using namespace XrdCl;
 
@@ -724,6 +725,18 @@ Bool_t TNetXNGFile::GetVectorReadLimits()
 
    if (!fQueryReadVParams)
       return kTRUE;
+
+   std::string lasturl;
+   fFile->GetProperty("LastURL",lasturl);
+   URL lrl(lasturl);
+   //local redirect will split vector reads into multiple local reads anyway,
+   // so we are fine with the default values
+   if(0==lrl.GetProtocol().compare("file") &&
+      0==lrl.GetHostId().compare("localhost")){
+       if (gDebug>=1) 
+          Info("GetVectorReadLimits","Local redirect, using default values");
+       return kTRUE;
+   }
 
 #if XrdVNUMBER >= 40000
    std::string dataServerStr;


### PR DESCRIPTION
This PR builds upon #2751
Lets TAlienFile be derived from TNetXNGFile instead of TXNetFile.

1. Changes the corrresponding CMakeLists.txt to include XRootD/NetxNG
2. Derives TAlienFile from TNetXNGFile and allows local redirection via the 'new' XRootD client (XrdCl) 

