### PR TITLE
Add a couple of missing PrettyPrintAddr()

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RDisplay.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDisplay.hxx
@@ -126,8 +126,8 @@ private:
    template <typename T, typename std::enable_if<!ROOT::TypeTraits::IsContainer<T>::value, int>::type = 0>
    bool AddInterpreterString(std::stringstream &stream, T &element, const int &index)
    {
-      stream << "*((std::string*)" << &(fRepresentations[index]) << ") = cling::printValue((" << fTypes[index] << "*)"
-             << ROOT::Internal::RDF::PrettyPrintAddr(&element) << ");";
+      stream << "*((std::string*)" << ROOT::Internal::RDF::PrettyPrintAddr(&(fRepresentations[index]))
+             << ") = cling::printValue((" << fTypes[index] << "*)" << ROOT::Internal::RDF::PrettyPrintAddr(&element) << ");";
       return false;
    }
 
@@ -154,8 +154,8 @@ private:
 
       // For each element, append a call and feed the proper type returned by GetSplit
       for (size_t i = 0; i < collectionSize; ++i) {
-         stream << "*((std::string*)" << &(fCollectionsRepresentations[index][i]) << ") = cling::printValue(("
-                << output[1] << "*)" << ROOT::Internal::RDF::PrettyPrintAddr(&(collection[i])) << ");";
+         stream << "*((std::string*)" << ROOT::Internal::RDF::PrettyPrintAddr(&(fCollectionsRepresentations[index][i]))
+                << ") = cling::printValue((" << output[1] << "*)" << ROOT::Internal::RDF::PrettyPrintAddr(&(collection[i])) << ");";
       }
       return true;
    }


### PR DESCRIPTION
Fix this kind of error message on Windows:
155: input_line_18:2:19: error: invalid digit 'B' in octal constant
155:  *((std::string*)0B8DCA20) = cling::printValue((int*)0xeff520);*((std::string*)0B8DB9E0) = cling::printValue((int*)0xb8c1250);*((std::string*)0B8DB9F8) = cling::printValue((int*)0xb8c1254);*((std::string*)0B8DBA10) = cling::printValue((int*)0xb8c1258);*((std::string*)0B8DCA50) = cling::printValue((double*)0xeff530);