### PR TITLE
[cxxmodules] Checking if a flag is set needs bitwise operations.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -6052,8 +6052,16 @@ static void* LazyFunctionCreatorAutoloadForModule(const std::string& mangled_nam
 
          auto Symbols = RealSoFile->symbols();
          for (auto S : Symbols) {
-            // DO NOT insert to table if symbol was weak or undefined
-            if (S.getFlags() == SymbolRef::SF_Weak || S.getFlags() == SymbolRef::SF_Undefined) continue;
+            uint32_t Flags = S.getFlags();
+            // DO NOT insert to table if symbol was undefined
+            if (Flags & SymbolRef::SF_Undefined)
+               continue;
+
+            // FIXME:
+            // Only insert weak symbols from white-listed libraryes, such as
+            // ROOT libraries.
+            //  if (Flags & SymbolRef::SF_Weak)
+            //     continue;
 
             llvm::Expected<StringRef> SymNameErr = S.getName();
             if (!SymNameErr) {


### PR DESCRIPTION
This was detected by redundant loading on libRooStats when we are trying
to resolve _ZN5TTreeC1Ev. libRooStats contains it as an unresolved symbol
but the wrong flag checks did not filter it out.

This patch  should fix a few subtle test failures which fluctuate depending
on the linker optimizations.