### PR TITLE
Add option to support the Full Beeston-Barlow handling for HistFactory, as well as mixed Full/Light handling

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/Systematics.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Systematics.h
@@ -328,6 +328,9 @@ namespace HistFactory {
 
     void SetInputFile( const std::string& InputFile ) { fInputFile = InputFile; }
     std::string GetInputFile() { return fInputFile; }
+ 
+    void SetStackLabel( const std::string& StackLabel ) { fStackLabel = StackLabel; }
+    std::string GetStackLabel() { return fStackLabel; }    
 
     void SetHistoName( const std::string& HistoName ) { fHistoName = HistoName; }
     std::string GetHistoName() { return fHistoName; }
@@ -342,7 +345,8 @@ namespace HistFactory {
   protected:
 
     bool fActivate;
-    bool fUseHisto; // Use an external histogram for the errors 
+    bool fUseHisto; // Use an external histogram for the errors
+    std::string fStackLabel;
     std::string fInputFile;
     std::string fHistoName;
     std::string fHistoPath;

--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -1355,6 +1355,13 @@ namespace HistFactory{
 
       if( sample.GetStatError().GetActivate() ) {
 
+        std::string stat_err_contrib_name;
+        if(!sample.GetStatError().GetStackLabel().empty()){
+          stat_err_contrib_name = sample.GetStatError().GetStackLabel() + "_" + channel_name;
+        } else {
+          stat_err_contrib_name = channel_name;
+        }
+        
 	if( fObsNameVec.size() > 3 ) {
 	  std::cout << "Cannot include Stat Error for histograms of more than 3 dimensions." 
 		    << std::endl; 
@@ -1444,7 +1451,7 @@ namespace HistFactory{
 	  // Next, try to get the ParamHistFunc (it may have been 
 	  // created by another sample in this channel)
 	  // or create it if it doesn't yet exist:
-	  statFuncName = "mc_stat_" + channel_name;
+	  statFuncName = "mc_stat_" + stat_err_contrib_name;
 	  ParamHistFunc* paramHist = (ParamHistFunc*) proto->function( statFuncName.c_str() );
 	  if( paramHist == NULL ) {
 
@@ -1458,7 +1465,7 @@ namespace HistFactory{
 	  
 	    // Create the list of terms to
 	    // control the bin heights:
-	    std::string ParamSetPrefix  = "gamma_stat_" + channel_name;
+	    std::string ParamSetPrefix  = "gamma_stat_" + stat_err_contrib_name;
 	    Double_t gammaMin = 0.0;
 	    Double_t gammaMax = 10.0;
 	    RooArgList statFactorParams = ParamHistFunc::createParamSet(*proto, 
@@ -1478,7 +1485,7 @@ namespace HistFactory{
 	  // Create the node as a product
 	  // of this function and the 
 	  // expected value from MC
-	  statNodeName = sample.GetName() + "_" + channel_name + "_overallSyst_x_StatUncert";
+	  statNodeName = sample.GetName() + "_" + stat_err_contrib_name + "_overallSyst_x_StatUncert";
 	
 	  RooAbsReal* expFunc = (RooAbsReal*) proto->function( syst_x_expectedPrefix.c_str() );
 	  RooProduct nodeWithMcStat(statNodeName.c_str(), statNodeName.c_str(),


### PR DESCRIPTION
HistFactory has only been supporting the "Light" Version of the Beeston-Barlow method so far.
This MR adds an option to assign "stack labels" to individual contributions of the stack. By default, the stack labels will all be empty, reproducing the behavior of the Beeston-Barlow-Light approach.
However, assigning non-empty stack labels will trigger the labeled sections to be treated as separate stacks in terms of the MC stat uncertainty handling. In the limit of assigning a separate stack label for each contribution, this corresponds to the Full Beeston-Barlow handling.