### PR TITLE
[TreePlayer] Remove leftover debug output

### DIFF
--- a/tree/treeplayer/src/TTreeReaderValue.cxx
+++ b/tree/treeplayer/src/TTreeReaderValue.cxx
@@ -150,9 +150,7 @@ void ROOT::Internal::TTreeReaderValueBase::NotifyNewTree(TTree* newTree) {
    if (!fHaveLeaf)
       return;
 
-   std::cout << "Getting branch " << fBranchName << std::endl;
    TBranch *myBranch = newTree->GetBranch(fBranchName);
-   std::cout << "Got Branch " << myBranch->GetName() << std::endl;
 
    if (!myBranch) {
       fReadStatus = kReadError;


### PR DESCRIPTION
This should fix the failures in `roottest-root-tree-reader-make` that we see in the v6.14 nightlies