### PR TITLE
Allow plugins to handle custom pragmas.

### DIFF
--- a/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
@@ -218,6 +218,14 @@ static void HandlePlugins(CompilerInstance& CI,
         Consumers.push_back(std::move(PluginConsumer));
     }
   }
+
+  // Copied from Lex/Pragma.cpp
+
+  // Pragmas added by plugins
+  for (PragmaHandlerRegistry::iterator it = PragmaHandlerRegistry::begin(),
+          ie = PragmaHandlerRegistry::end(); it != ie; ++it) {
+     CI.getPreprocessor().AddPragmaHandler(it->instantiate().release());
+  }
 }
 
 namespace cling {

--- a/interpreter/cling/test/Plugins/Simple.C
+++ b/interpreter/cling/test/Plugins/Simple.C
@@ -6,4 +6,9 @@
 int dummy = 15;
 
 // CHECK-NEXT:PluginConsumer::HandleTopLevelDecl
+
+#pragma demoplugin
+
+// CHECK:DemoPluginPragmaHandler::HandlePragma
+
 .q

--- a/interpreter/cling/tools/plugins/example/DemoPlugin.cpp
+++ b/interpreter/cling/tools/plugins/example/DemoPlugin.cpp
@@ -8,6 +8,7 @@
 //------------------------------------------------------------------------------
 
 #include "clang/Frontend/FrontendPluginRegistry.h"
+#include "clang/Lex/Preprocessor.h"
 
 struct PluginConsumer : public clang::ASTConsumer {
   virtual bool HandleTopLevelDecl(clang::DeclGroupRef DGR) {
@@ -38,6 +39,22 @@ protected:
   }
 };
 
+// Define a pragma handler for #pragma demoplugin
+class DemoPluginPragmaHandler : public clang::PragmaHandler {
+public:
+  DemoPluginPragmaHandler() : clang::PragmaHandler("demoplugin") { }
+  void HandlePragma(clang::Preprocessor &PP,
+                    clang::PragmaIntroducerKind Introducer,
+                    clang::Token &PragmaTok) {
+    llvm::outs() << "DemoPluginPragmaHandler::HandlePragma\n";
+    // Handle the pragma
+  }
+};
+
 // Register the PluginASTAction in the registry.
 static clang::FrontendPluginRegistry::Add<Action<PluginConsumer> >
 X("DemoPlugin", "Used to test plugin mechanisms in cling.");
+
+// Register the DemoPluginPragmaHandler in the registry.
+static clang::PragmaHandlerRegistry::Add<DemoPluginPragmaHandler>
+Y("demoplugin","Used to test plugin-attached pragrams in cling.");


### PR DESCRIPTION
This will help clad implement pattern such as:
#pragma clad on
// code which needs derivation
#pragma clad off