### PR TITLE
Fix printing test in Cling

### DIFF
--- a/interpreter/cling/test/Interfaces/print.C
+++ b/interpreter/cling/test/Interfaces/print.C
@@ -12,4 +12,4 @@
 
 int a = 21;
 gCling->toString("a");
-// CHECK: "21"
+// CHECK: 21


### PR DESCRIPTION
Testsuit was actually looking at '"' for match, comparing literal 21
should be enough.