### PR TITLE
Enable offset array generation for TLeafElement

### DIFF
--- a/tree/tree/inc/TLeaf.h
+++ b/tree/tree/inc/TLeaf.h
@@ -31,6 +31,10 @@ class TBrowser;
 
 class TLeaf : public TNamed {
 
+private:
+
+   virtual Int_t GetOffsetHeaderSize() const {return 0;}
+
 protected:
 
    Int_t       fNdata;           ///<! Number of elements in fAddress data buffer

--- a/tree/tree/inc/TLeafElement.h
+++ b/tree/tree/inc/TLeafElement.h
@@ -34,12 +34,15 @@ protected:
    Int_t               fID;           ///<  element serial number in fInfo
    Int_t               fType;         ///<  leaf type
 
+private:
+   virtual Int_t       GetOffsetHeaderSize() const {return 1;}
+
 public:
    TLeafElement();
    TLeafElement(TBranch *parent, const char *name, Int_t id, Int_t type);
    virtual ~TLeafElement();
 
-   virtual Bool_t   CanGenerateOffsetArray() { return false; }
+   virtual Bool_t   CanGenerateOffsetArray() { return fLeafCount && fLenType; }
    virtual Int_t   *GenerateOffsetArrayBase(Int_t /*base*/, Int_t /*events*/) { return nullptr; }
    virtual Int_t    GetLen() const {return ((TBranchElement*)fBranch)->GetNdata()*fLen;}
    TMethodCall     *GetMethodCall(const char *name);

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -208,6 +208,10 @@ TBranchElement::TBranchElement(TTree *tree, const char* bname, TStreamerInfo* si
 , fWriteIterators(0)
 , fPtrIterators(0)
 {
+   if (tree) {
+      ROOT::TIOFeatures features = tree->GetIOFeatures();
+      SetIOFeatures(features);
+   }
    Init(tree, 0, bname,sinfo,id,pointer,basketsize,splitlevel,btype);
 }
 
@@ -251,6 +255,8 @@ TBranchElement::TBranchElement(TBranch *parent, const char* bname, TStreamerInfo
 , fWriteIterators(0)
 , fPtrIterators(0)
 {
+   ROOT::TIOFeatures features = parent->GetIOFeatures();
+   SetIOFeatures(features);
    Init(parent ? parent->GetTree() : 0, parent, bname,sinfo,id,pointer,basketsize,splitlevel,btype);
 }
 

--- a/tree/tree/src/TLeaf.cxx
+++ b/tree/tree/src/TLeaf.cxx
@@ -164,6 +164,7 @@ Int_t *TLeaf::GenerateOffsetArrayBase(Int_t base, Int_t events) const
       return nullptr;
    }
 
+   Int_t header = GetOffsetHeaderSize();
    Long64_t orig_entry = std::max(fBranch->GetReadEntry(), 0LL); // -1 indicates to start at the beginning
    Long64_t orig_leaf_entry = fLeafCount->GetBranch()->GetReadEntry();
    Int_t len = 0;
@@ -171,7 +172,7 @@ Int_t *TLeaf::GenerateOffsetArrayBase(Int_t base, Int_t events) const
       retval[idx] = offset;
       fLeafCount->GetBranch()->GetEntry(orig_entry + idx);
       len = static_cast<Int_t>(fLeafCount->GetValue());
-      offset += fLenType * len;
+      offset += fLenType * len + header;
    }
    fLeafCount->GetBranch()->GetEntry(orig_leaf_entry);
 

--- a/tree/tree/src/TLeafElement.cxx
+++ b/tree/tree/src/TLeafElement.cxx
@@ -37,9 +37,9 @@ TLeafElement::TLeafElement(): TLeaf()
 /// Create a LeafObject.
 
 TLeafElement::TLeafElement(TBranch *parent, const char *name, Int_t id, Int_t type)
-   : TLeaf(parent, name,name),
-     fLenType(0)
+   : TLeaf(parent, name,name)
 {
+   fLenType    = 0;
    fAbsAddress = 0;
    fID         = id;
    fType       = type;
@@ -52,45 +52,47 @@ TLeafElement::TLeafElement(TBranch *parent, const char *name, Int_t id, Int_t ty
 
       if ((bareType >= TVirtualStreamerInfo::kUChar && bareType <= TVirtualStreamerInfo::kULong)
           || bareType == TVirtualStreamerInfo::kULong64)
-      SetUnsigned();
+      {
+         SetUnsigned();
+      }
 
       auto bareTypeCopy = static_cast<EDataType>(bareType);
       switch (bareTypeCopy) {
-          case kChar_t: // fall-through
-          case kUChar_t: // fall-through
-          case kchar: // fall-through
-          case kBool_t:
-              fLenType = 1;
-              break;
-          case kShort_t: // fall-through
-          case kUShort_t: // fall-through
-          case kFloat16_t:
-              fLenType = 2;
-              break;
-          case kFloat_t: // fall-through
-          case kDouble32_t: // fall-through
-          case kInt_t: // fall-through
-          case kUInt_t:
-              fLenType = 4;
-              break;
-          case kLong_t: // fall-through
-          case kULong_t: // fall-through
-          case kLong64_t: // fall-through
-          case kULong64_t: // fall-through
-          case kDouble_t:
-              fLenType = 8;
-              break;
-          // All cases I don't know how to handle.
-          case kOther_t: // fall-through
-          case kNoType_t: // fall-through
-          case kCounter: // fall-through
-          case kCharStar: // fall-through
-          case kBits: // fall-through
-          case kVoid_t: // fall-through
-          case kDataTypeAliasUnsigned_t: // fall-through
-          case kDataTypeAliasSignedChar_t: // fall-through
-          case kNumDataTypes: // fall-through
-              fLenType = 0;
+         case kChar_t: // fall-through
+         case kUChar_t: // fall-through
+         case kchar: // fall-through
+         case kBool_t:
+            fLenType = 1;
+            break;
+         case kShort_t: // fall-through
+         case kUShort_t: // fall-through
+         case kFloat16_t:
+            fLenType = 2;
+            break;
+         case kFloat_t: // fall-through
+         case kDouble32_t: // fall-through
+         case kInt_t: // fall-through
+         case kUInt_t:
+            fLenType = 4;
+            break;
+         case kLong_t: // fall-through
+         case kULong_t: // fall-through
+         case kLong64_t: // fall-through
+         case kULong64_t: // fall-through
+         case kDouble_t:
+            fLenType = 8;
+            break;
+         // All cases I don't know how to handle.
+         case kOther_t: // fall-through
+         case kNoType_t: // fall-through
+         case kCounter: // fall-through
+         case kCharStar: // fall-through
+         case kBits: // fall-through
+         case kVoid_t: // fall-through
+         case kDataTypeAliasUnsigned_t: // fall-through
+         case kDataTypeAliasSignedChar_t: // fall-through
+         case kNumDataTypes: // fall-through
+            fLenType = 0;
       };
    }
 }

--- a/tree/tree/src/TLeafElement.cxx
+++ b/tree/tree/src/TLeafElement.cxx
@@ -37,7 +37,8 @@ TLeafElement::TLeafElement(): TLeaf()
 /// Create a LeafObject.
 
 TLeafElement::TLeafElement(TBranch *parent, const char *name, Int_t id, Int_t type)
-   :TLeaf(parent, name,name)
+   : TLeaf(parent, name,name),
+     fLenType(0)
 {
    fAbsAddress = 0;
    fID         = id;
@@ -52,6 +53,45 @@ TLeafElement::TLeafElement(TBranch *parent, const char *name, Int_t id, Int_t ty
       if ((bareType >= TVirtualStreamerInfo::kUChar && bareType <= TVirtualStreamerInfo::kULong)
           || bareType == TVirtualStreamerInfo::kULong64)
       SetUnsigned();
+
+      auto bareTypeCopy = static_cast<EDataType>(bareType);
+      switch (bareTypeCopy) {
+          case kChar_t: // fall-through
+          case kUChar_t: // fall-through
+          case kchar: // fall-through
+          case kBool_t:
+              fLenType = 1;
+              break;
+          case kShort_t: // fall-through
+          case kUShort_t: // fall-through
+          case kFloat16_t:
+              fLenType = 2;
+              break;
+          case kFloat_t: // fall-through
+          case kDouble32_t: // fall-through
+          case kInt_t: // fall-through
+          case kUInt_t:
+              fLenType = 4;
+              break;
+          case kLong_t: // fall-through
+          case kULong_t: // fall-through
+          case kLong64_t: // fall-through
+          case kULong64_t: // fall-through
+          case kDouble_t:
+              fLenType = 8;
+              break;
+          // All cases I don't know how to handle.
+          case kOther_t: // fall-through
+          case kNoType_t: // fall-through
+          case kCounter: // fall-through
+          case kCharStar: // fall-through
+          case kBits: // fall-through
+          case kVoid_t: // fall-through
+          case kDataTypeAliasUnsigned_t: // fall-through
+          case kDataTypeAliasSignedChar_t: // fall-through
+          case kNumDataTypes: // fall-through
+              fLenType = 0;
+      };
    }
 }
 

--- a/tree/tree/test/CMakeLists.txt
+++ b/tree/tree/test/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+ROOT_STANDARD_LIBRARY_PACKAGE(ElementStruct NO_INSTALL_HEADER HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/ElementStruct.h SOURCES ElementStruct.cxx LINKDEF ElementStructLinkDef.h DEPENDENCIES RIO)
+ROOT_ADD_GTEST(testTOffsetGeneration TOffsetGeneration.cxx LIBRARIES RIO Tree MathCore ElementStruct)
 ROOT_ADD_GTEST(testTBasket TBasket.cxx LIBRARIES RIO Tree)
 ROOT_ADD_GTEST(testTBranch TBranch.cxx LIBRARIES RIO Tree MathCore)
 ROOT_ADD_GTEST(testTIOFeatures TIOFeatures.cxx LIBRARIES RIO Tree)

--- a/tree/tree/test/ElementStruct.cxx
+++ b/tree/tree/test/ElementStruct.cxx
@@ -1,0 +1,2 @@
+#include "ElementStruct.h"
+

--- a/tree/tree/test/ElementStruct.h
+++ b/tree/tree/test/ElementStruct.h
@@ -1,0 +1,13 @@
+#include "Rtypes.h"
+#include "TObject.h"
+
+/**
+ * The ElementStruct has no purpose except to provide
+ * inputs to the test cases.
+ */
+
+class ElementStruct {
+public:
+   int    i;
+   double *d; //[i]
+};

--- a/tree/tree/test/ElementStructLinkDef.h
+++ b/tree/tree/test/ElementStructLinkDef.h
@@ -1,0 +1,9 @@
+#ifdef __CINT__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class ElementStruct+;
+
+#endif

--- a/tree/tree/test/TOffsetGeneration.cxx
+++ b/tree/tree/test/TOffsetGeneration.cxx
@@ -1,0 +1,186 @@
+#include "TFile.h"
+#include "TTree.h"
+#include "TBranch.h"
+#include "TBranchElement.h"
+#include "TLeafElement.h"
+#include "TRandom.h"
+
+#include "gtest/gtest.h"
+
+#include "ElementStruct.h"
+
+class TOffsetGeneration : public ::testing::Test {
+protected:
+   static constexpr int fEventCount = 10000;
+
+   virtual void SetUp()
+   {
+      TRandom *random = new TRandom(837);
+      auto file = new TFile("TOffsetGeneration1.root", "RECREATE");
+      auto tree = new TTree("tree", "A test tree");
+      ROOT::TIOFeatures features;
+      features.Set(ROOT::Experimental::EIOFeatures::kGenerateOffsetMap);
+      tree->SetIOFeatures(features);
+      tree->SetBit(TTree::kOnlyFlushAtCluster);
+      tree->SetAutoSave(10);
+      Int_t sample[10];
+      Int_t elem = 1;
+      tree->Branch("elem", &elem, "elem/I");
+      tree->Branch("sample", &sample, "sample[elem]/I");
+
+      for (Int_t ev = 0; ev < fEventCount; ev++) {
+         sample[0] = random->Gaus(100, 7);
+         tree->Fill();
+      }
+      file->Write();
+      delete tree;
+      delete file;
+
+      file = new TFile("TOffsetGeneration2.root", "RECREATE");
+      tree = new TTree("tree", "A test tree");
+      tree->SetBit(TTree::kOnlyFlushAtCluster);
+      tree->SetAutoSave(10);
+      tree->Branch("elem", &elem, "elem/I");
+      tree->Branch("sample", &sample, "sample[elem]/I");
+
+      for (Int_t ev = 0; ev < fEventCount; ev++) {
+         sample[0] = random->Gaus(100, 7);
+         tree->Fill();
+      }
+      file->Write();
+
+      file = new TFile("TOffsetGeneration3.root", "RECREATE");
+      tree = new TTree("tree", "A test tree");
+      tree->SetBit(TTree::kOnlyFlushAtCluster);
+      tree->SetAutoSave(5000);
+      ElementStruct sample2;
+      sample2.i = 1;
+      double d[10];
+      sample2.d = d;
+      tree->Branch("sample", &sample2, 32*1024, 99);
+
+      for (Int_t ev = 0; ev < fEventCount; ev++) {
+         sample2.d[0] = random->Gaus(100, 7);
+         tree->Fill();
+      }
+      file->Write();
+      file->Close();
+      delete file;
+
+      file = new TFile("TOffsetGeneration4.root", "RECREATE");
+      auto tree2 = new TTree("tree2", "A test tree");
+      features.Set(ROOT::Experimental::EIOFeatures::kGenerateOffsetMap);
+      tree2->SetIOFeatures(features);
+      tree2->SetBit(TTree::kOnlyFlushAtCluster);
+      tree2->SetAutoSave(5000);
+      sample2.i = 1;
+      sample2.d = d;
+      tree2->Branch("sample", &sample2, 32*1024, 99);
+
+      for (Int_t ev = 0; ev < fEventCount; ev++) {
+         sample2.d[0] = random->Gaus(100, 7);
+         tree2->Fill();
+      }
+      file->Write();
+
+      delete tree2;
+      delete file;
+
+      file = new TFile("TOffsetGeneration5.root", "RECREATE");
+      tree = new TTree("tree", "A test tree");
+      tree2 = new TTree("tree2", "A test tree");
+      features.Set(ROOT::Experimental::EIOFeatures::kGenerateOffsetMap);
+      tree->SetIOFeatures(features);
+      tree->SetBit(TTree::kOnlyFlushAtCluster);
+      tree2->SetBit(TTree::kOnlyFlushAtCluster);
+      tree->SetAutoSave(5000);
+      tree2->SetAutoSave(5000);
+      sample2.i = 1;
+      sample2.d = d;
+      auto br = tree->Branch("sample", &sample2, 32*1024, 99);
+      br->SetAutoDelete(kFALSE);
+      auto br2 = tree2->Branch("sample", &sample2, 32*1024, 99);
+      br2->SetAutoDelete(kFALSE);
+      tree->Branch("elem", &elem, "elem/I");
+      tree->Branch("sample2", &sample, "sample2[elem]/I");
+
+      for (Int_t ev = 0; ev < 10; ev++) {
+         sample2.i = ev;
+         elem = ev;
+         for (Int_t idx = 0; idx < ev; idx++) {
+            sample2.d[idx] = random->Gaus(100, 7);
+            sample[idx] = random->Gaus(100, 7);
+         }
+         tree->Fill();
+         tree2->Fill();
+      }
+      file->Write();
+      delete random;
+      delete file;
+   }
+};
+
+TEST_F(TOffsetGeneration, offsetArrayValues)
+{
+   std::unique_ptr<TFile> file(new TFile("TOffsetGeneration5.root"));
+   auto tree = static_cast<TTree *>(file->Get("tree"));
+   auto br = tree->GetBranch("d");
+   auto basket = br->GetBasket(0);
+   auto tree2 = static_cast<TTree *>(file->Get("tree2"));
+   auto br2 = tree2->GetBranch("d");
+   auto basket2 = br2->GetBasket(0);
+   auto br3 = tree->GetBranch("sample2");
+   auto basket3 = br3->GetBasket(0);
+   Int_t *offsetArray = basket->GetEntryOffset();
+   Int_t *offsetArray2 = basket2->GetEntryOffset();
+   Int_t *offsetArray3 = basket3->GetEntryOffset();
+
+   Int_t lastOffset = offsetArray[0];
+   Int_t lastOffsetPrim = offsetArray3[0];
+   for (Int_t idx = 0; idx < 10; idx++) {
+      //printf("Event #%d; generated offset: %d, right offset: %d, primitive offset: %d\n", idx, offsetArray[idx], offsetArray2[idx], offsetArray3[idx]);
+      Int_t curOffset = offsetArray[idx];
+      Int_t curOffsetPrim = offsetArray3[idx];
+      if (idx) {
+         ASSERT_EQ(curOffset - lastOffset, (idx - 1) * 8 + 1);
+         ASSERT_EQ(curOffsetPrim - lastOffsetPrim, (idx - 1) * 4);
+      }
+      lastOffset = offsetArray[idx];
+      lastOffsetPrim = offsetArray3[idx];
+      ASSERT_EQ(offsetArray[idx], offsetArray2[idx]);
+   }
+}
+
+TEST_F(TOffsetGeneration, primitiveTest)
+{
+   std::unique_ptr<TFile> file(new TFile("TOffsetGeneration1.root"));
+   auto tree = static_cast<TTree *>(file->Get("tree"));
+   auto br = tree->GetBranch("sample");
+   ASSERT_TRUE(br->GetTotalSize() < fEventCount * 14);
+
+   file.reset(new TFile("TOffsetGeneration2.root"));
+   tree = static_cast<TTree *>(file->Get("tree"));
+   br = tree->GetBranch("sample");
+   ASSERT_TRUE(br->GetTotalSize() > fEventCount * 14);
+}
+
+TEST_F(TOffsetGeneration, elementsTest)
+{
+   std::unique_ptr<TFile> file(new TFile("TOffsetGeneration3.root"));
+   auto tree = static_cast<TTree *>(file->Get("tree"));
+   auto br = tree->GetBranch("d");
+   ASSERT_TRUE(br->GetTotalSize() > fEventCount * 10);
+
+   file.reset(new TFile("TOffsetGeneration4.root"));
+   tree = static_cast<TTree *>(file->Get("tree2"));
+   br = tree->GetBranch("d");
+   TClass *expectedClass = nullptr;
+   EDataType expectedType;
+   ASSERT_FALSE(br->GetExpectedType(expectedClass, expectedType));
+
+   // Verifies splitting is working correctly.
+   TLeaf *leaf = static_cast<TBranchElement*>(br)->FindLeaf("d");
+   ASSERT_TRUE(leaf);
+
+   ASSERT_TRUE(br->GetTotalSize() < fEventCount * 10);
+}


### PR DESCRIPTION
`TLeafElement` is one of the existing holes for offset array generation - if you serialize a class containing data elements whose size is kept in a separate index variable, we can definitely generate the offset array separately.

This PR closes that hole.

Further, unit tests are included to ensure that the offset array generation is doing as expected.

Fixes ROOT-9634.