### PR TITLE
Fix print.C

### DIFF
--- a/interpreter/cling/test/Interfaces/print.C
+++ b/interpreter/cling/test/Interfaces/print.C
@@ -11,5 +11,5 @@
 #include "cling/Interpreter/Interpreter.h"
 
 int a = 21;
-gCling->toString("a");
-// CHECK: 21
+gCling->toString("int", &a);
+// CHECK: "21"


### PR DESCRIPTION
ToString takes typename and an object pointer