### PR TITLE
[cxxmodules] Fix failing execNestedClasses test for modules

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1765,6 +1765,7 @@ void TCling::RegisterModule(const char* modulename,
 
    // When we cannot provide a module for the library we should enable header
    // parsing. This 'mixed' mode ensures gradual migration to modules.
+   llvm::SaveAndRestore<bool> SaveHeaderParsing(fHeaderParsingOnDemand);
    fHeaderParsingOnDemand = !hasCxxModule;
 
    // Treat Aclic Libs in a special way. Do not delay the parsing.

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -92,6 +92,11 @@ if(NOT ROOT_r_FOUND)
   set(r_veto  r/*.C)
 endif()
 
+# FIXME: Temporary workaround for runtime_cxxmodule
+if (FIXME_TEMPORARILY_EXCLUDED_FOR_RUNTIME_CXXMODULES)
+  set(runtime_cxxmodules_veto r/Function.C)
+endif()
+
 if(WIN32)
   set(histfactory_veto histfactory/*.C
                        roostats/StandardFrequentistDiscovery.C) # histfactory doesn't work on Windows
@@ -242,6 +247,7 @@ set(all_veto hsimple.C
              ${opengl_veto}
              ${gviz_veto}
              ${r_veto}
+             ${runtime_cxxmodules_veto}
              ${histfactory_veto}
              ${tbb_veto}
              ${imt_veto}


### PR DESCRIPTION
We needed to save and restore fHeaderParsingOnDemand value when exitting
RegisterModule function, so as not to enter wrong branch here: https://github.com/root-project/root/blob/master/core/metacling/src/TCling.cxx#L5899

Patch by Vassil and me.