### PR TITLE
TTreeCache::FillBuffer Updates

### DIFF
--- a/io/io/inc/TFile.h
+++ b/io/io/inc/TFile.h
@@ -204,7 +204,7 @@ public:
    Long64_t            GetArchiveOffset() const { return fArchiveOffset; }
    Int_t               GetBestBuffer() const;
    virtual Int_t       GetBytesToPrefetch() const;
-   TFileCacheRead     *GetCacheRead(TObject* tree = 0) const;
+   TFileCacheRead     *GetCacheRead(const TObject* tree = 0) const;
    TFileCacheWrite    *GetCacheWrite() const;
    TArrayC            *GetClassIndex() const { return fClassIndex; }
    Int_t               GetCompressionAlgorithm() const;

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -1213,7 +1213,7 @@ void TFile::ResetErrno() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Return a pointer to the current read cache.
 
-TFileCacheRead *TFile::GetCacheRead(TObject* tree) const
+TFileCacheRead *TFile::GetCacheRead(const TObject* tree) const
 {
    if (!tree) {
       if (!fCacheRead && fCacheReadMap->GetSize() == 1) {

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -159,7 +159,6 @@ protected:
 
    Long64_t         GetCacheAutoSize(Bool_t withDefault = kFALSE) const;
    char             GetNewlineValue(std::istream &inputStream);
-   TTreeCache      *GetReadCache(TFile *file, Bool_t create = kFALSE);
    void             ImportClusterRanges(TTree *fromtree);
    void             MoveReadCache(TFile *src, TDirectory *dir);
    Int_t            SetCacheSizeAux(Bool_t autocache = kTRUE, Long64_t cacheSize = 0);
@@ -426,6 +425,8 @@ public:
    TVirtualTreePlayer     *GetPlayer();
    virtual Int_t           GetPacketSize() const { return fPacketSize; }
    virtual TVirtualPerfStats *GetPerfStats() const { return fPerfStats; }
+           TTreeCache     *GetReadCache(TFile *file) const;
+           TTreeCache     *GetReadCache(TFile *file, Bool_t create);
    virtual Long64_t        GetReadEntry()  const { return fReadEntry; }
    virtual Long64_t        GetReadEvent()  const { return fReadEntry; }
    virtual Int_t           GetScanField()  const { return fScanField; }

--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -251,7 +251,7 @@ Int_t TBasket::LoadBasketBuffers(Long64_t pos, Int_t len, TFile *file, TTree *tr
    fBufferRef->SetParent(file);
    char *buffer = fBufferRef->Buffer();
    file->Seek(pos);
-   TFileCacheRead *pf = file->GetCacheRead(tree);
+   TFileCacheRead *pf = tree->GetReadCache(file);
    if (pf) {
       TVirtualPerfStats* temp = gPerfStats;
       if (tree->GetPerfStats()) gPerfStats = tree->GetPerfStats();
@@ -465,7 +465,7 @@ Int_t TBasket::ReadBasketBuffers(Long64_t pos, Int_t len, TFile *file)
    TFileCacheRead *pf = nullptr;
    {
       R__LOCKGUARD_IMT(gROOTMutex); // Lock for parallel TTree I/O
-      pf = file->GetCacheRead(fBranch->GetTree());
+      pf = fBranch->GetTree()->GetReadCache(file);
    }
    if (pf) {
       Int_t res = -1;

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -1208,7 +1208,7 @@ TBasket* TBranch::GetBasket(Int_t basketnumber)
    //add branch to cache (if any)
    {
       R__LOCKGUARD_IMT(gROOTMutex); // Lock for parallel TTree I/O
-      TFileCacheRead *pf = file->GetCacheRead(fTree);
+      TFileCacheRead *pf = fTree->GetReadCache(file);
       if (pf){
          if (pf->IsLearning()) pf->AddBranch(this);
          if (fSkipZip) pf->SetSkipZip();

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -191,8 +191,9 @@ TChain::~TChain()
    fFiles = 0;
 
    //first delete cache if exists
-   if (fFile && fFile->GetCacheRead(fTree)) {
-      delete fFile->GetCacheRead(fTree);
+   auto tc = fFile ? fTree->GetReadCache(fFile) : nullptr;
+   if (tc) {
+      delete tc;
       fFile->SetCacheRead(0, fTree);
    }
 
@@ -1421,10 +1422,10 @@ Long64_t TChain::LoadTree(Long64_t entry)
             // to see if a TTree is already loaded.
             // However, this prevent using the following to reuse
             // the TTreeCache object.
-            tpf = (TTreeCache*) fFile->GetCacheRead(fTree);
+            tpf = fTree->GetReadCache(fFile);
             if (tpf) {
                tpf->ResetCache();
-               }
+            }
 
             fFile->SetCacheRead(0, fTree);
             // If the tree has clones, copy them into the chain

--- a/tree/tree/src/TTreeCache.cxx
+++ b/tree/tree/src/TTreeCache.cxx
@@ -1220,7 +1220,7 @@ Bool_t TTreeCache::FillBuffer()
       if (fCurrentClusterStart != -1 || fNextClusterStart != -1) {
          if (!(fEntryCurrent < fCurrentClusterStart || fEntryCurrent >= fNextClusterStart)) {
             Error("FillBuffer", "Inconsistency: fCurrentClusterStart=%lld fEntryCurrent=%lld fNextClusterStart=%lld "
-                                "but fCurrentEntry should not be in between the two",
+                                "but fEntryCurrent should not be in between the two",
                   fCurrentClusterStart, fEntryCurrent, fNextClusterStart);
          }
       }

--- a/tree/tree/src/TTreeCache.cxx
+++ b/tree/tree/src/TTreeCache.cxx
@@ -1519,7 +1519,7 @@ Bool_t TTreeCache::FillBuffer()
                b->fCacheInfo.SetIsInCache(j);
 
                if (showMore || gDebug > 6)
-                  Info("FillBuffer", "*** Registering branch %d basket %d", i, j);
+                  Info("FillBuffer", "*** Registering branch %d basket %d %s", i, j, b->GetName());
 
                if (!cursor[i].fLoadedOnce) {
                   cursor[i].fLoadedOnce = kTRUE;

--- a/tree/tree/src/TTreeCache.cxx
+++ b/tree/tree/src/TTreeCache.cxx
@@ -2179,6 +2179,8 @@ void TTreeCache::LearnPrefill()
    Long64_t emaxOld = fEntryMax;
    Long64_t ecurrentOld = fEntryCurrent;
    Long64_t enextOld = fEntryNext;
+   auto currentClusterStartOld = fCurrentClusterStart;
+   auto nextClusterStartOld = fNextClusterStart;
 
    fEntryMin = fEntryCurrent;
    fEntryMax = fEntryNext;
@@ -2200,4 +2202,6 @@ void TTreeCache::LearnPrefill()
    fEntryMax = emaxOld;
    fEntryCurrent = ecurrentOld;
    fEntryNext = enextOld;
+   fCurrentClusterStart = currentClusterStartOld;
+   fNextClusterStart = nextClusterStartOld;
 }

--- a/tree/tree/src/TTreeCache.cxx
+++ b/tree/tree/src/TTreeCache.cxx
@@ -1060,6 +1060,9 @@ Bool_t TTreeCache::FillBuffer()
    Long64_t entry = tree->GetReadEntry();
    Long64_t fEntryCurrentMax = 0;
 
+   if (entry < fEntryMin || fEntryMax < entry)
+      return kFALSE;
+
    if (fEnablePrefetching) { // Prefetching mode
       if (fIsLearning) { // Learning mode
          if (fEntryNext >= 0 && entry >= fEntryNext) {

--- a/tree/tree/src/TTreeCloner.cxx
+++ b/tree/tree/src/TTreeCloner.cxx
@@ -34,6 +34,7 @@ Class implementing or helping  the various TTree cloning method
 #include "TLeafO.h"
 #include "TLeafC.h"
 #include "TFileCacheRead.h"
+#include "TTreeCache.h"
 
 #include <algorithm>
 
@@ -561,7 +562,7 @@ void TTreeCloner::CreateCache()
 {
    if (fCacheSize && fFromTree->GetCurrentFile()) {
       TFile *f = fFromTree->GetCurrentFile();
-      auto prev = f->GetCacheRead(fFromTree);
+      auto prev = fFromTree->GetReadCache(f);
       if (fFileCache && prev == fFileCache) {
          return;
       }


### PR DESCRIPTION
This fixes the problem described in http://root-forum.cern.ch/t/ttreecache-fillbuffer-error-with-root-6-14-04/30914/1 (And avoid the same error message in another circumstance).