### PR TITLE
Disabling MakeInterpreterValue gtest for rt cxxmodules

### DIFF
--- a/core/metacling/test/TClingTests.cxx
+++ b/core/metacling/test/TClingTests.cxx
@@ -112,6 +112,7 @@ TEST_F(TClingTests, GetEnumWithSameVariableName)
    ASSERT_TRUE(en != nullptr);
 }
 
+#ifndef R__USE_CXXMODULES
 // Check if we can get the source code of function definitions.
 TEST_F(TClingTests, MakeInterpreterValue)
 {
@@ -120,3 +121,4 @@ TEST_F(TClingTests, MakeInterpreterValue)
    gInterpreter->Evaluate("my_func_to_print", *v);
    ASSERT_THAT(v->ToString(), testing::HasSubstr("void my_func_to_print"));
 }
+#endif


### PR DESCRIPTION
Preparing to add rt cxxmodules in PRs