### PR TITLE
[DF] Add cumulative efficiency to cutflow report

### DIFF
--- a/tree/dataframe/src/RCutFlowReport.cxx
+++ b/tree/dataframe/src/RCutFlowReport.cxx
@@ -26,7 +26,7 @@ void RCutFlowReport::Print()
       const auto all = ci.GetAll();
       const auto eff = ci.GetEff();
       const auto cumulativeEff = 100.f * float(pass) / float(allEntries);
-      Printf("%-10s: pass=%-10lld all=%-10lld -- eff=%8.3f %% cumulative eff=%8.3f %%", name.c_str(), pass, all, eff, cumulativeEff);
+      Printf("%-10s: pass=%-10lld all=%-10lld -- eff=%3.2f %% cumulative eff=%3.2f %%", name.c_str(), pass, all, eff, cumulativeEff);
    }
 }
 const TCutInfo &RCutFlowReport::operator[](std::string_view cutName)

--- a/tree/dataframe/src/RCutFlowReport.cxx
+++ b/tree/dataframe/src/RCutFlowReport.cxx
@@ -19,12 +19,14 @@ namespace RDF {
 
 void RCutFlowReport::Print()
 {
+   const auto allEntries = fCutInfos.empty() ? 0ULL : fCutInfos.begin()->GetAll();
    for (auto &&ci : fCutInfos) {
-      auto &name = ci.GetName();
-      auto pass = ci.GetPass();
-      auto all = ci.GetAll();
-      auto eff = ci.GetEff();
-      Printf("%-10s: pass=%-10lld all=%-10lld -- %8.3f %%", name.c_str(), pass, all, eff);
+      const auto &name = ci.GetName();
+      const auto pass = ci.GetPass();
+      const auto all = ci.GetAll();
+      const auto eff = ci.GetEff();
+      const auto cumulativeEff = 100.f * float(pass) / float(allEntries);
+      Printf("%-10s: pass=%-10lld all=%-10lld -- eff=%8.3f %% cumulative eff=%8.3f %%", name.c_str(), pass, all, eff, cumulativeEff);
    }
 }
 const TCutInfo &RCutFlowReport::operator[](std::string_view cutName)

--- a/tree/dataframe/test/dataframe_report.cxx
+++ b/tree/dataframe/test/dataframe_report.cxx
@@ -22,9 +22,9 @@ TEST(RDataFrameReport, AnalyseCuts)
    testing::internal::CaptureStdout();
    repPr->Print();
    std::string output = testing::internal::GetCapturedStdout();
-   auto expOut = "cut0      : pass=67         all=128        --   52.344 %\n"
-                 "cut1      : pass=59         all=67         --   88.060 %\n"
-                 "cut2      : pass=50         all=59         --   84.746 %\n";
+   auto expOut = "cut0      : pass=67         all=128        -- eff=52.34 % cumulative eff=52.34 %\n"
+                 "cut1      : pass=59         all=67         -- eff=88.06 % cumulative eff=46.09 %\n"
+                 "cut2      : pass=50         all=59         -- eff=84.75 % cumulative eff=39.06 %\n";
 
    EXPECT_STREQ(output.c_str(), expOut);
 


### PR DESCRIPTION
Implement the cumulative efficiency in the cutflow report as suggested at the ATLAS newcomers event.
