### PR TITLE
[TTree][NFC][ROOT-4489] Document BuildIndex behaviour about preexisti…

### DIFF
--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -2506,6 +2506,9 @@ void TTree::Browse(TBrowser* b)
 ///
 /// A TTreeIndex object pointed by fTreeIndex is created.
 /// This object will be automatically deleted by the TTree destructor.
+/// If an index is already existing, this is replaced by the new one without being
+/// deleted. This behaviour prevents the deletion of a previously external index
+/// assigned to the TTree via the TTree::SetTreeIndex() method.
 /// See also comments in TTree::SetTreeIndex().
 
 Int_t TTree::BuildIndex(const char* majorname, const char* minorname /* = "0" */)


### PR DESCRIPTION
…ng indices

i.e. the re-creation of the index without deleting the old one in order to prevent
accidental deletion of previously assigned indices.