### PR TITLE
[Tutorial] Use eospublic to host files used in df101_h1Analysis script

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -84,7 +84,8 @@ if(NOT ROOT_xml_FOUND)
 endif()
 
 if(NOT XROOTD_FOUND)
-  set(xrootd_veto dataframe/df102_NanoAODDimuonAnalysis.C)
+  set(xrootd_veto dataframe/df102_NanoAODDimuonAnalysis.C
+                  dataframe/df101_h1Analysis.C)
 endif()
 
 # variables identifying the package must have the package name  in lower case (it corresponds to the CMake option name)

--- a/tutorials/dataframe/df101_h1Analysis.C
+++ b/tutorials/dataframe/df101_h1Analysis.C
@@ -100,10 +100,10 @@ void FitAndPlotH2(TH2 &h2)
 void df101_h1Analysis()
 {
    TChain chain("h42");
-   chain.Add("http://root.cern.ch/files/h1/dstarmb.root");
-   chain.Add("http://root.cern.ch/files/h1/dstarp1a.root");
-   chain.Add("http://root.cern.ch/files/h1/dstarp1b.root");
-   chain.Add("http://root.cern.ch/files/h1/dstarp2.root");
+   chain.Add("root://eospublic.cern.ch//eos/root-eos/h1/dstarmb.root");
+   chain.Add("root://eospublic.cern.ch//eos/root-eos/h1/dstarp1a.root");
+   chain.Add("root://eospublic.cern.ch//eos/root-eos/h1/dstarp1b.root");
+   chain.Add("root://eospublic.cern.ch//eos/root-eos/h1/dstarp2.root");
 
    ROOT::EnableImplicitMT(4);
 


### PR DESCRIPTION
Use publiceos + xrootd to fetch files remotely for h1 analysis dataframe example.
Tutorial is now vetoed if xrootd is not found.