### PR TITLE
Avoid setting fCollProxy multiple times.

### DIFF
--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -2395,6 +2395,14 @@ TVirtualCollectionProxy* TBranchElement::GetCollectionProxy()
       } else {
          // We are not a top-level branch.
          TVirtualStreamerInfo* si = thiscast->GetInfoImp();
+         if (fCollProxy) {
+            // The GetInfo set fProxy for us, let's not
+            // redo it; the value of fCollProxy is possibly
+            // used/recorded is the actions sequences, so
+            // if we change it here, we would need to propagate
+            // the change.
+            return fCollProxy;
+         }
          TStreamerElement* se = si->GetElement(fID);
          cl = se->GetClassPointer();
       }


### PR DESCRIPTION
GetCollectionProxy during the setting of fCollProxy calls
TBranchElement::GetInfoImp that in some cases sets fCollProxy
and ends up recording it (sometimes) in the action sequence.
When GetCollectionProxy sets it too (i.e. change it) there is
now a disconnect between the branch and the action sequences that
lead to the action sequence to used an unset collection proxy:

  Fatal in <TGenCollectionProxy>: Size> Logic error - no proxy object set.
  aborting