### PR TITLE
[TMVA/BDT/IMT] fix memory leak

### DIFF
--- a/tmva/tmva/src/DecisionTree.cxx
+++ b/tmva/tmva/src/DecisionTree.cxx
@@ -1498,7 +1498,7 @@ Double_t TMVA::DecisionTree::TrainNodeFast( const EventConstList & eventSample,
             nBins[ivar] = node->GetSampleMax(ivar) - node->GetSampleMin(ivar) + 1;
          }
       }
-     
+
       cutValues[ivar] = new Double_t [nBins[ivar]];
    }
 
@@ -1855,15 +1855,15 @@ Double_t TMVA::DecisionTree::TrainNodeFast( const EventConstList & eventSample,
    // #### Now in TrainNodeInfo, but I got a malloc segfault when I tried to destruct arrays there.
    // #### So, I changed these from dynamic arrays to std::vector to fix this memory problem
    // #### so no need to destruct them anymore. I didn't see any performance drop as a result.
-   //for (UInt_t i=0; i<cNvars; i++) {
+   for (UInt_t i=0; i<cNvars; i++) {
    //   delete [] nodeInfo.nSelS[i];
    //   delete [] nodeInfo.nSelB[i];
    //   delete [] nodeInfo.nSelS_unWeighted[i];
    //   delete [] nodeInfo.nSelB_unWeighted[i];
    //   delete [] nodeInfo.target[i];
    //   delete [] nodeInfo.target2[i];
-   //   delete [] cutValues[i];
-   //}
+     delete [] cutValues[i];
+   }
    //delete [] nodeInfo.nSelS;
    //delete [] nodeInfo.nSelB;
    //delete [] nodeInfo.nSelS_unWeighted;


### PR DESCRIPTION
Hi,
I ran into a memory leak training a BDT yesterday.
Strangely only when running through the root_numpy interface.
The problem appears to scale with number of training events (somewhere between 6.4k and 12.8k training events I run out of RAM)
Valgrind/memcheck pointed into `TMVA::DecisionTree::TrainNodeFast` (assuming I read the output correctly. valgrind gave me some 370k lines and i tried with diff'ing a many-event run with a few-event run to get rid of unrelated issues)
since this is in an if IMT block, I tried rebuilding root without IMT => tada leak gone.
So diffing the if and else blocks of the preprocessor if (i.e. two different `TMVA::DecisionTree::TrainNodeFast` implementations) I noticed these lines commented out.

This patch does not fix the original problem for me, and I'm still on the chase, but the change looks right to me.