### PR TITLE
TWebCanvas: provide minimal support of 3D painters

### DIFF
--- a/gui/webgui6/CMakeLists.txt
+++ b/gui/webgui6/CMakeLists.txt
@@ -9,6 +9,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(WebGui6
     TWebMenuItem.h
     TWebPadPainter.h
     TWebPainting.h
+    TWebPS.h
     TWebSnapshot.h
   SOURCES
     src/TWebCanvas.cxx
@@ -16,6 +17,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(WebGui6
     src/TWebMenuItem.cxx
     src/TWebPadPainter.cxx
     src/TWebPainting.cxx
+    src/TWebPS.cxx
     src/TWebSnapshot.cxx
   LIBRARIES
     Core

--- a/gui/webgui6/inc/LinkDef.h
+++ b/gui/webgui6/inc/LinkDef.h
@@ -17,6 +17,7 @@
 #pragma link C++ class TWebGuiFactory+;
 #pragma link C++ class TWebCanvas+;
 #pragma link C++ class TWebPadPainter+;
+#pragma link C++ class TWebPS+;
 #pragma link C++ class TWebPainting+;
 #pragma link C++ class TWebPainterAttributes+;
 #pragma link C++ class TWebSnapshot+;

--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -125,7 +125,7 @@ protected:
 
    Bool_t AddCanvasSpecials(TPadWebSnapshot *master);
    TString CreateSnapshot(TPad *pad, TPadWebSnapshot *master = nullptr, TList *tempbuf = nullptr);
-   TWebSnapshot *CreateObjectSnapshot(TObject *obj, const char *opt);
+   TWebSnapshot *CreateObjectSnapshot(TPad *pad, TObject *obj, const char *opt);
 
    TObject *FindPrimitive(const char *id, TPad *pad = nullptr, TObjLink **padlnk = nullptr);
    Bool_t DecodeAllRanges(const char *arg);

--- a/gui/webgui6/inc/TWebPS.h
+++ b/gui/webgui6/inc/TWebPS.h
@@ -19,6 +19,52 @@ class TWebPS : public TVirtualPS {
    TWebPadPainter &fPainter;
 public:
    TWebPS(TWebPadPainter &p) : fPainter(p) {}
+
+   //Redirect calls to WebPainter
+   //Line attributes.
+   Color_t  GetLineColor() const { return fPainter.GetLineColor(); }
+   Style_t  GetLineStyle() const { return fPainter.GetLineStyle(); }
+   Width_t  GetLineWidth() const { return fPainter.GetLineWidth(); }
+
+   void     SetLineColor(Color_t lcolor) { fPainter.SetLineColor(lcolor); }
+   void     SetLineStyle(Style_t lstyle) { fPainter.SetLineStyle(lstyle); }
+   void     SetLineWidth(Width_t lwidth) { fPainter.SetLineWidth(lwidth); }
+
+   //Fill attributes.
+   Color_t  GetFillColor() const { return fPainter.GetFillColor(); }
+   Style_t  GetFillStyle() const { return fPainter.GetFillStyle(); }
+   Bool_t   IsTransparent() const { return fPainter.IsTransparent(); }
+
+   void     SetFillColor(Color_t fcolor)  { fPainter.SetFillColor(fcolor); }
+   void     SetFillStyle(Style_t fstyle) { fPainter.SetFillStyle(fstyle); }
+   void     SetOpacity(Int_t percent) { fPainter.SetOpacity(percent); }
+
+   //Text attributes.
+   Short_t  GetTextAlign() const { return fPainter.GetTextAlign(); }
+   Float_t  GetTextAngle() const { return fPainter.GetTextAngle(); }
+   Color_t  GetTextColor() const { return fPainter.GetTextColor(); }
+   Font_t   GetTextFont()  const { return fPainter.GetTextFont(); }
+   Float_t  GetTextSize()  const { return fPainter.GetTextSize(); }
+   Float_t  GetTextMagnitude() const { return fPainter.GetTextMagnitude(); }
+
+   void     SetTextAlign(Short_t align) { fPainter.SetTextAlign(align); }
+   void     SetTextAngle(Float_t tangle) { fPainter.SetTextAngle(tangle); }
+   void     SetTextColor(Color_t tcolor) { fPainter.SetTextColor(tcolor); }
+   void     SetTextFont(Font_t tfont) { fPainter.SetTextFont(tfont); }
+   void     SetTextSize(Float_t tsize) { fPainter.SetTextSize(tsize); }
+   void     SetTextSizePixels(Int_t npixels) { fPainter.SetTextSizePixels(npixels); }
+
+   //MISSING in base class - Marker attributes
+
+   Color_t   GetMarkerColor() const { return fPainter.GetMarkerColor(); }
+   Size_t    GetMarkerSize() const { return fPainter.GetMarkerSize(); }
+   Style_t   GetMarkerStyle() const { return fPainter.GetMarkerStyle(); }
+
+   void      SetMarkerColor(Color_t cindex) { fPainter.SetMarkerColor(cindex); }
+   void      SetMarkerSize(Float_t markersize) { fPainter.SetMarkerSize(markersize); }
+   void      SetMarkerStyle(Style_t markerstyle) { fPainter.SetMarkerStyle(markerstyle); }
+
+
    virtual void CellArrayBegin(Int_t W, Int_t H, Double_t x1, Double_t x2, Double_t y1, Double_t y2) {}
    virtual void CellArrayFill(Int_t r, Int_t g, Int_t b) {}
    virtual void CellArrayEnd()  {}

--- a/gui/webgui6/inc/TWebPS.h
+++ b/gui/webgui6/inc/TWebPS.h
@@ -19,70 +19,89 @@ class TWebPS : public TVirtualPS {
    TWebPadPainter &fPainter;
 public:
    TWebPS(TWebPadPainter &p) : fPainter(p) {}
+   virtual ~TWebPS() = default;
 
    //Redirect calls to WebPainter
    //Line attributes.
-   Color_t  GetLineColor() const { return fPainter.GetLineColor(); }
-   Style_t  GetLineStyle() const { return fPainter.GetLineStyle(); }
-   Width_t  GetLineWidth() const { return fPainter.GetLineWidth(); }
+   Color_t  GetLineColor() const override { return fPainter.GetLineColor(); }
+   Style_t  GetLineStyle() const override { return fPainter.GetLineStyle(); }
+   Width_t  GetLineWidth() const override { return fPainter.GetLineWidth(); }
 
-   void     SetLineColor(Color_t lcolor) { fPainter.SetLineColor(lcolor); }
-   void     SetLineStyle(Style_t lstyle) { fPainter.SetLineStyle(lstyle); }
-   void     SetLineWidth(Width_t lwidth) { fPainter.SetLineWidth(lwidth); }
+   void     SetLineColor(Color_t lcolor) override { fPainter.SetLineColor(lcolor); }
+   void     SetLineStyle(Style_t lstyle) override { fPainter.SetLineStyle(lstyle); }
+   void     SetLineWidth(Width_t lwidth) override { fPainter.SetLineWidth(lwidth); }
 
    //Fill attributes.
-   Color_t  GetFillColor() const { return fPainter.GetFillColor(); }
-   Style_t  GetFillStyle() const { return fPainter.GetFillStyle(); }
-   Bool_t   IsTransparent() const { return fPainter.IsTransparent(); }
+   Color_t  GetFillColor() const override { return fPainter.GetFillColor(); }
+   Style_t  GetFillStyle() const override { return fPainter.GetFillStyle(); }
+   Bool_t   IsTransparent() const override { return fPainter.IsTransparent(); }
 
-   void     SetFillColor(Color_t fcolor)  { fPainter.SetFillColor(fcolor); }
-   void     SetFillStyle(Style_t fstyle) { fPainter.SetFillStyle(fstyle); }
+   void     SetFillColor(Color_t fcolor)  override { fPainter.SetFillColor(fcolor); }
+   void     SetFillStyle(Style_t fstyle)  override { fPainter.SetFillStyle(fstyle); }
    void     SetOpacity(Int_t percent) { fPainter.SetOpacity(percent); }
 
    //Text attributes.
-   Short_t  GetTextAlign() const { return fPainter.GetTextAlign(); }
-   Float_t  GetTextAngle() const { return fPainter.GetTextAngle(); }
-   Color_t  GetTextColor() const { return fPainter.GetTextColor(); }
-   Font_t   GetTextFont()  const { return fPainter.GetTextFont(); }
-   Float_t  GetTextSize()  const { return fPainter.GetTextSize(); }
+   Short_t  GetTextAlign() const override { return fPainter.GetTextAlign(); }
+   Float_t  GetTextAngle() const override { return fPainter.GetTextAngle(); }
+   Color_t  GetTextColor() const override { return fPainter.GetTextColor(); }
+   Font_t   GetTextFont()  const override { return fPainter.GetTextFont(); }
+   Float_t  GetTextSize()  const override { return fPainter.GetTextSize(); }
    Float_t  GetTextMagnitude() const { return fPainter.GetTextMagnitude(); }
 
-   void     SetTextAlign(Short_t align) { fPainter.SetTextAlign(align); }
-   void     SetTextAngle(Float_t tangle) { fPainter.SetTextAngle(tangle); }
-   void     SetTextColor(Color_t tcolor) { fPainter.SetTextColor(tcolor); }
-   void     SetTextFont(Font_t tfont) { fPainter.SetTextFont(tfont); }
-   void     SetTextSize(Float_t tsize) { fPainter.SetTextSize(tsize); }
-   void     SetTextSizePixels(Int_t npixels) { fPainter.SetTextSizePixels(npixels); }
+   void     SetTextAlign(Short_t align) override { fPainter.SetTextAlign(align); }
+   void     SetTextAngle(Float_t tangle) override { fPainter.SetTextAngle(tangle); }
+   void     SetTextColor(Color_t tcolor) override { fPainter.SetTextColor(tcolor); }
+   void     SetTextFont(Font_t tfont) override { fPainter.SetTextFont(tfont); }
+   void     SetTextSize(Float_t tsize) override { fPainter.SetTextSize(tsize); }
+   void     SetTextSizePixels(Int_t npixels) override { fPainter.SetTextSizePixels(npixels); }
 
    //MISSING in base class - Marker attributes
 
-   Color_t   GetMarkerColor() const { return fPainter.GetMarkerColor(); }
-   Size_t    GetMarkerSize() const { return fPainter.GetMarkerSize(); }
-   Style_t   GetMarkerStyle() const { return fPainter.GetMarkerStyle(); }
+   Color_t   GetMarkerColor() const override  { return fPainter.GetMarkerColor(); }
+   Size_t    GetMarkerSize() const override  { return fPainter.GetMarkerSize(); }
+   Style_t   GetMarkerStyle() const override  { return fPainter.GetMarkerStyle(); }
 
-   void      SetMarkerColor(Color_t cindex) { fPainter.SetMarkerColor(cindex); }
-   void      SetMarkerSize(Float_t markersize) { fPainter.SetMarkerSize(markersize); }
-   void      SetMarkerStyle(Style_t markerstyle) { fPainter.SetMarkerStyle(markerstyle); }
+   void      SetMarkerColor(Color_t cindex) override  { fPainter.SetMarkerColor(cindex); }
+   void      SetMarkerSize(Float_t markersize) override  { fPainter.SetMarkerSize(markersize); }
+   void      SetMarkerStyle(Style_t markerstyle) override  { fPainter.SetMarkerStyle(markerstyle); }
+
+   void CellArrayBegin(Int_t, Int_t, Double_t, Double_t, Double_t, Double_t) override  {}
+   void CellArrayFill(Int_t, Int_t, Int_t)  override {}
+   void CellArrayEnd()  override  {}
+   void Close(Option_t * = "")  override  {}
+   void DrawBox(Double_t, Double_t, Double_t, Double_t) override   {}
+   void DrawFrame(Double_t, Double_t, Double_t, Double_t, Int_t, Int_t, Int_t, Int_t) override {}
 
 
-   virtual void CellArrayBegin(Int_t W, Int_t H, Double_t x1, Double_t x2, Double_t y1, Double_t y2) {}
-   virtual void CellArrayFill(Int_t r, Int_t g, Int_t b) {}
-   virtual void CellArrayEnd()  {}
-   virtual void Close(Option_t *opt = "")  {}
-   virtual void DrawBox(Double_t x1, Double_t y1, Double_t x2, Double_t y2)  {}
-   virtual void
-   DrawFrame(Double_t xl, Double_t yl, Double_t xt, Double_t yt, Int_t mode, Int_t border, Int_t dark, Int_t light)  {}
-   virtual void DrawPolyMarker(Int_t n, Float_t *x, Float_t *y)  {}
-   virtual void DrawPolyMarker(Int_t n, Double_t *x, Double_t *y)  {}
-   virtual void DrawPS(Int_t n, Float_t *xw, Float_t *yw)  {}
-   virtual void DrawPS(Int_t n, Double_t *xw, Double_t *yw)  {}
-   virtual void NewPage()  {}
-   virtual void Open(const char *filename, Int_t type = -111)  {}
-   virtual void Text(Double_t x, Double_t y, const char *string)  {}
-   virtual void Text(Double_t x, Double_t y, const wchar_t *string)  {}
-   virtual void SetColor(Float_t r, Float_t g, Float_t b)  {}
+   void DrawPolyMarker(Int_t n, Float_t *x, Float_t *y) override { fPainter.DrawPolyMarker(n, x, y); }
+   void DrawPolyMarker(Int_t n, Double_t *x, Double_t *y) override { fPainter.DrawPolyMarker(n, x, y); }
+   void DrawPS(Int_t n, Float_t *xw, Float_t *yw) override
+   {
+      if (n == 2)
+         fPainter.DrawLine(xw[0], yw[0], xw[1], yw[1]);
+      else
+         fPainter.DrawPolyLine(n, xw, yw);
+   }
+   void DrawPS(Int_t n, Double_t *xw, Double_t *yw) override
+   {
+      if (n == 2)
+         fPainter.DrawLine(xw[0], yw[0], xw[1], yw[1]);
+      else
+         fPainter.DrawPolyLine(n, xw, yw);
+   }
+   void NewPage() override {}
+   void Open(const char *, Int_t = -111) override {}
+   void Text(Double_t x, Double_t y, const char *str) override
+   {
+      fPainter.DrawText(x, y, str, TVirtualPadPainter::kClear);
+   }
+   void Text(Double_t x, Double_t y, const wchar_t *str) override
+   {
+      fPainter.DrawText(x, y, str, TVirtualPadPainter::kClear);
+   }
+   void SetColor(Float_t, Float_t, Float_t) override {}
 
-   ClassDef(TWebPS, 0) // Redirection of VirtualPS to Web painter
+   ClassDefOverride(TWebPS, 0) // Redirection of VirtualPS to Web painter
 };
 
 #endif

--- a/gui/webgui6/inc/TWebPS.h
+++ b/gui/webgui6/inc/TWebPS.h
@@ -1,0 +1,42 @@
+// Author:  Sergey Linev, GSI  23/10/2018
+
+/*************************************************************************
+ * Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TWebPS
+#define ROOT_TWebPS
+
+#include "TVirtualPS.h"
+
+#include "TWebPadPainter.h"
+
+class TWebPS : public TVirtualPS {
+   TWebPadPainter &fPainter;
+public:
+   TWebPS(TWebPadPainter &p) : fPainter(p) {}
+   virtual void CellArrayBegin(Int_t W, Int_t H, Double_t x1, Double_t x2, Double_t y1, Double_t y2) {}
+   virtual void CellArrayFill(Int_t r, Int_t g, Int_t b) {}
+   virtual void CellArrayEnd()  {}
+   virtual void Close(Option_t *opt = "")  {}
+   virtual void DrawBox(Double_t x1, Double_t y1, Double_t x2, Double_t y2)  {}
+   virtual void
+   DrawFrame(Double_t xl, Double_t yl, Double_t xt, Double_t yt, Int_t mode, Int_t border, Int_t dark, Int_t light)  {}
+   virtual void DrawPolyMarker(Int_t n, Float_t *x, Float_t *y)  {}
+   virtual void DrawPolyMarker(Int_t n, Double_t *x, Double_t *y)  {}
+   virtual void DrawPS(Int_t n, Float_t *xw, Float_t *yw)  {}
+   virtual void DrawPS(Int_t n, Double_t *xw, Double_t *yw)  {}
+   virtual void NewPage()  {}
+   virtual void Open(const char *filename, Int_t type = -111)  {}
+   virtual void Text(Double_t x, Double_t y, const char *string)  {}
+   virtual void Text(Double_t x, Double_t y, const wchar_t *string)  {}
+   virtual void SetColor(Float_t r, Float_t g, Float_t b)  {}
+
+   ClassDef(TWebPS, 0) // Redirection of VirtualPS to Web painter
+};
+
+#endif

--- a/gui/webgui6/inc/TWebPS.h
+++ b/gui/webgui6/inc/TWebPS.h
@@ -69,10 +69,12 @@ public:
    void CellArrayFill(Int_t, Int_t, Int_t)  override {}
    void CellArrayEnd()  override  {}
    void Close(Option_t * = "")  override  {}
-   void DrawBox(Double_t, Double_t, Double_t, Double_t) override   {}
    void DrawFrame(Double_t, Double_t, Double_t, Double_t, Int_t, Int_t, Int_t, Int_t) override {}
 
-
+   void DrawBox(Double_t x1, Double_t y1, Double_t x2, Double_t y2) override
+   {
+      fPainter.DrawBox(x1, y1, x2, y2, TVirtualPadPainter::kHollow);
+   }
    void DrawPolyMarker(Int_t n, Float_t *x, Float_t *y) override { fPainter.DrawPolyMarker(n, x, y); }
    void DrawPolyMarker(Int_t n, Double_t *x, Double_t *y) override { fPainter.DrawPolyMarker(n, x, y); }
    void DrawPS(Int_t n, Float_t *xw, Float_t *yw) override

--- a/gui/webgui6/inc/TWebPadPainter.h
+++ b/gui/webgui6/inc/TWebPadPainter.h
@@ -42,8 +42,6 @@ protected:
 
    TWebPainterAttributes *Attr();
 
-   void AcquireXAttributes(unsigned attrmask = attrAll);
-
    void StoreOperation(const char* opt, TObject* obj = nullptr, unsigned attrmask = attrAll);
 
    Float_t *Reserve(Int_t sz);

--- a/gui/webgui6/inc/TWebPadPainter.h
+++ b/gui/webgui6/inc/TWebPadPainter.h
@@ -33,14 +33,14 @@ friend class TWebCanvas;
 protected:
 
    std::unique_ptr<TWebPainterAttributes> fAttr; ///!< current attributes
-   bool fAttrChanged{false};              ///!< flag that attributes are changed after last paint operation
+   unsigned fAttrChanged{0};              ///!< mask identify which attributes were changed
    TWebPainting *fPainting{nullptr};      ///!< object to store all painting
    UInt_t fCw{0}, fCh{0};                 ///!< canvas dimensions, need for back pixel conversion
    Float_t fKx{1.}, fKy{1.};              ///!< coefficient to recalculate pixel coordinates
 
    enum { attrLine = 0x1, attrFill = 0x2, attrMarker = 0x4, attrText = 0x8, attrAll = 0xf };
 
-   TWebPainterAttributes *Attr();
+   TWebPainterAttributes *Attr(unsigned mask = attrAll);
 
    void StoreOperation(const char* opt, TObject* obj = nullptr, unsigned attrmask = attrAll);
 
@@ -62,18 +62,18 @@ public:
    Style_t  GetLineStyle() const { return fAttr ? fAttr->GetLineStyle() : 0; }
    Width_t  GetLineWidth() const { return fAttr ? fAttr->GetLineWidth() : 0; }
 
-   void     SetLineColor(Color_t lcolor) { if (GetLineColor()!=lcolor) Attr()->SetLineColor(lcolor); }
-   void     SetLineStyle(Style_t lstyle) { if (GetLineStyle()!=lstyle) Attr()->SetLineStyle(lstyle); }
-   void     SetLineWidth(Width_t lwidth) { if (GetLineWidth()!=lwidth) Attr()->SetLineWidth(lwidth); }
+   void     SetLineColor(Color_t lcolor) { if (GetLineColor()!=lcolor) Attr(attrLine)->SetLineColor(lcolor); }
+   void     SetLineStyle(Style_t lstyle) { if (GetLineStyle()!=lstyle) Attr(attrLine)->SetLineStyle(lstyle); }
+   void     SetLineWidth(Width_t lwidth) { if (GetLineWidth()!=lwidth) Attr(attrLine)->SetLineWidth(lwidth); }
 
    //Fill attributes.
    Color_t  GetFillColor() const { return fAttr ? fAttr->GetFillColor() : 0; }
    Style_t  GetFillStyle() const { return fAttr ? fAttr->GetFillStyle() : 0; }
    Bool_t   IsTransparent() const { return fAttr ? fAttr->IsTransparent() : kFALSE; }
 
-   void     SetFillColor(Color_t fcolor)  { if (GetFillColor()!=fcolor) Attr()->SetFillColor(fcolor); }
-   void     SetFillStyle(Style_t fstyle) { if (GetFillStyle()!=fstyle) Attr()->SetFillStyle(fstyle); }
-   void     SetOpacity(Int_t percent) { if (GetFillStyle()!=4000+percent) Attr()->SetFillStyle(4000 + percent); }
+   void     SetFillColor(Color_t fcolor)  { if (GetFillColor()!=fcolor) Attr(attrFill)->SetFillColor(fcolor); }
+   void     SetFillStyle(Style_t fstyle) { if (GetFillStyle()!=fstyle) Attr(attrFill)->SetFillStyle(fstyle); }
+   void     SetOpacity(Int_t percent) { if (GetFillStyle()!=4000+percent) Attr(attrFill)->SetFillStyle(4000 + percent); }
 
    //Text attributes.
    Short_t  GetTextAlign() const { return fAttr ? fAttr->GetTextAlign() : 0; }
@@ -83,12 +83,12 @@ public:
    Float_t  GetTextSize()  const { return fAttr ? fAttr->GetTextSize() : 0; }
    Float_t  GetTextMagnitude() const { return  0; }
 
-   void     SetTextAlign(Short_t align) { if (GetTextAlign()!=align) Attr()->SetTextAlign(align); }
-   void     SetTextAngle(Float_t tangle) { if (GetTextAngle()!=tangle) Attr()->SetTextAngle(tangle); }
-   void     SetTextColor(Color_t tcolor) { if (GetTextColor()!=tcolor) Attr()->SetTextColor(tcolor); }
-   void     SetTextFont(Font_t tfont) { if (GetTextFont()!=tfont) Attr()->SetTextFont(tfont); }
-   void     SetTextSize(Float_t tsize) { if (GetTextSize()!=tsize) Attr()->SetTextSize(tsize); }
-   void     SetTextSizePixels(Int_t npixels) { Attr()->SetTextSizePixels(npixels); }
+   void     SetTextAlign(Short_t align) { if (GetTextAlign()!=align) Attr(attrText)->SetTextAlign(align); }
+   void     SetTextAngle(Float_t tangle) { if (GetTextAngle()!=tangle) Attr(attrText)->SetTextAngle(tangle); }
+   void     SetTextColor(Color_t tcolor) { if (GetTextColor()!=tcolor) Attr(attrText)->SetTextColor(tcolor); }
+   void     SetTextFont(Font_t tfont) { if (GetTextFont()!=tfont) Attr(attrText)->SetTextFont(tfont); }
+   void     SetTextSize(Float_t tsize) { if (GetTextSize()!=tsize) Attr(attrText)->SetTextSize(tsize); }
+   void     SetTextSizePixels(Int_t npixels) { Attr(attrText)->SetTextSizePixels(npixels); }
 
    //MISSING in base class - Marker attributes
 
@@ -96,9 +96,9 @@ public:
    Size_t    GetMarkerSize() const { return fAttr ? fAttr->GetMarkerSize() : 0; }
    Style_t   GetMarkerStyle() const { return fAttr ? fAttr->GetMarkerStyle() : 0; }
 
-   void      SetMarkerColor(Color_t cindex) { if (GetMarkerColor()!=cindex) Attr()->SetMarkerColor(cindex); }
-   void      SetMarkerSize(Float_t markersize) { if (GetMarkerSize()!=markersize) Attr()->SetMarkerSize(markersize); }
-   void      SetMarkerStyle(Style_t markerstyle) { if (GetMarkerStyle()!=markerstyle) Attr()->SetMarkerStyle(markerstyle); }
+   void      SetMarkerColor(Color_t cindex) { if (GetMarkerColor()!=cindex) Attr(attrMarker)->SetMarkerColor(cindex); }
+   void      SetMarkerSize(Float_t markersize) { if (GetMarkerSize()!=markersize) Attr(attrMarker)->SetMarkerSize(markersize); }
+   void      SetMarkerStyle(Style_t markerstyle) { if (GetMarkerStyle()!=markerstyle) Attr(attrMarker)->SetMarkerStyle(markerstyle); }
 
    //2. "Off-screen management" part.
    Int_t    CreateDrawable(UInt_t w, UInt_t h);

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -325,7 +325,7 @@ TString TWebCanvas::CreateSnapshot(TPad *pad, TPadWebSnapshot *master, TList *pr
 
    // TODO: this is only for debugging, remove it later
    // static int filecnt = 0;
-   // TBufferJSON::ExportToFile(Form("snapshot_%d.json", (filecnt++) % 10), curr);
+   // TBufferJSON::ExportToFile(TString::Format("snapshot_%d.json", (filecnt++) % 10).Data(), curr);
 
    delete curr; // destroy created snapshot
 

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -198,9 +198,6 @@ TWebSnapshot *TWebCanvas::CreateObjectSnapshot(TPad *pad, TObject *obj, const ch
             view->SetAutoRange(kTRUE);
 
             gVirtualPS = new TWebPS(*painter);
-
-            printf("Detect 3D object %s %s view %p view3d %p\n", obj->GetName(), obj->ClassName(), pad->GetView(), pad->GetViewer3D());
-
          }
 
          // calling Paint function for the object
@@ -359,8 +356,8 @@ TString TWebCanvas::CreateSnapshot(TPad *pad, TPadWebSnapshot *master, TList *pr
    TString res = TBufferJSON::ConvertToJSON(curr, 23);
 
    // TODO: this is only for debugging, remove it later
-   static int filecnt = 0;
-   TBufferJSON::ExportToFile(TString::Format("snapshot_%d.json", (filecnt++) % 10).Data(), curr);
+   // static int filecnt = 0;
+   // TBufferJSON::ExportToFile(TString::Format("snapshot_%d.json", (filecnt++) % 10).Data(), curr);
 
    delete curr; // destroy created snapshot
 

--- a/gui/webgui6/src/TWebPS.cxx
+++ b/gui/webgui6/src/TWebPS.cxx
@@ -1,0 +1,11 @@
+// Author:  Sergey Linev, GSI  23/10/2018
+
+/*************************************************************************
+ * Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "TWebPS.h"

--- a/gui/webgui6/src/TWebPadPainter.cxx
+++ b/gui/webgui6/src/TWebPadPainter.cxx
@@ -74,42 +74,11 @@ Float_t *TWebPadPainter::Reserve(Int_t sz)
 }
 
 //////////////////////////////////////////////////////////////////////////
-/// Extract X11 attributes and store them
-/// With the mask one could specify which attributes are interested
-
-void TWebPadPainter::AcquireXAttributes(unsigned attrmask)
-{
-   if (gVirtualX) {
-      if (attrmask & attrLine) {
-         SetLineColor(gVirtualX->GetLineColor());
-         SetLineStyle(gVirtualX->GetLineStyle());
-         SetLineWidth(gVirtualX->GetLineWidth());
-      }
-      if (attrmask & attrFill) {
-         SetFillColor(gVirtualX->GetFillColor());
-         SetFillStyle(gVirtualX->GetFillStyle());
-      }
-      if (attrmask & attrMarker) {
-         SetMarkerColor(gVirtualX->GetMarkerColor());
-         SetMarkerSize(gVirtualX->GetMarkerSize());
-         SetMarkerStyle(gVirtualX->GetMarkerStyle());
-      }
-      if (attrmask & attrText) {
-         SetTextAlign(gVirtualX->GetTextAlign());
-         SetTextAngle(gVirtualX->GetTextAngle());
-         SetTextColor(gVirtualX->GetTextColor());
-         SetTextFont(gVirtualX->GetTextFont());
-         SetTextSize(gVirtualX->GetTextSize());
-      }
-   }
-}
-
+/// Store operation identifier with appropriate attributes
 
 void TWebPadPainter::StoreOperation(const char* opt, TObject* obj, unsigned attrmask)
 {
    if (!fPainting) fPainting = new TWebPainting();
-
-   AcquireXAttributes(attrmask);
 
    if (fAttrChanged) {
       fPainting->Add(fAttr->Clone(), "attr");
@@ -179,8 +148,6 @@ void TWebPadPainter::DrawPixels(const unsigned char * /*pixelData*/, UInt_t /*wi
 
 void TWebPadPainter::DrawLine(Double_t x1, Double_t y1, Double_t x2, Double_t y2)
 {
-   AcquireXAttributes(attrLine);
-
    if (GetLineWidth()<=0) return;
 
    StoreOperation("line", nullptr, attrLine);
@@ -198,8 +165,6 @@ void TWebPadPainter::DrawLine(Double_t x1, Double_t y1, Double_t x2, Double_t y2
 
 void TWebPadPainter::DrawLineNDC(Double_t u1, Double_t v1, Double_t u2, Double_t v2)
 {
-   AcquireXAttributes(attrLine);
-
    if (GetLineWidth()<=0) return;
 
    StoreOperation("linendc", nullptr, attrLine);
@@ -217,10 +182,6 @@ void TWebPadPainter::DrawLineNDC(Double_t u1, Double_t v1, Double_t u2, Double_t
 
 void TWebPadPainter::DrawBox(Double_t x1, Double_t y1, Double_t x2, Double_t y2, EBoxMode mode)
 {
-   // printf("PAINT BOX %4.2f %4.2f %4.2f %4.2f mode %d linecol %d\n", x1, y1, x2, y2, (int) mode, gVirtualX->GetLineColor());
-
-   // AcquireXAttributes(attrLine); // get only line attributes
-
    if (GetLineWidth()<=0 && mode == TVirtualPadPainter::kHollow) return;
 
    if (mode == TVirtualPadPainter::kHollow)
@@ -279,8 +240,6 @@ void TWebPadPainter::DrawFillArea(Int_t nPoints, const Float_t *xs, const Float_
 
 void TWebPadPainter::DrawPolyLine(Int_t nPoints, const Double_t *xs, const Double_t *ys)
 {
-   AcquireXAttributes(attrLine); // get only line attributes
-
    if (GetLineWidth()<=0) return;
 
    if (nPoints < 2) {
@@ -303,8 +262,6 @@ void TWebPadPainter::DrawPolyLine(Int_t nPoints, const Double_t *xs, const Doubl
 
 void TWebPadPainter::DrawPolyLine(Int_t nPoints, const Float_t *xs, const Float_t *ys)
 {
-   AcquireXAttributes(attrLine); // get only line attributes
-
    if (GetLineWidth()<=0) return;
 
    if (nPoints < 2) {
@@ -327,8 +284,6 @@ void TWebPadPainter::DrawPolyLine(Int_t nPoints, const Float_t *xs, const Float_
 
 void TWebPadPainter::DrawPolyLineNDC(Int_t nPoints, const Double_t *u, const Double_t *v)
 {
-   AcquireXAttributes(attrLine); // get only line attributes
-
    if (GetLineWidth()<=0) return;
 
    if (nPoints < 2) {

--- a/gui/webgui6/src/TWebPadPainter.cxx
+++ b/gui/webgui6/src/TWebPadPainter.cxx
@@ -57,12 +57,12 @@ void TWebPadPainter::ResetPainting()
 {
    if (fPainting) delete fPainting;
    fPainting = nullptr;
-   if (fAttr) fAttrChanged = kTRUE;
+   if (fAttr) fAttrChanged = attrAll;
 }
 
-TWebPainterAttributes *TWebPadPainter::Attr()
+TWebPainterAttributes *TWebPadPainter::Attr(unsigned mask)
 {
-   fAttrChanged = kTRUE;
+   fAttrChanged |= mask;
    if (!fAttr) fAttr = std::make_unique<TWebPainterAttributes>();
    return fAttr.get();
 }
@@ -80,9 +80,9 @@ void TWebPadPainter::StoreOperation(const char* opt, TObject* obj, unsigned attr
 {
    if (!fPainting) fPainting = new TWebPainting();
 
-   if (fAttrChanged) {
+   if (fAttrChanged & attrmask) {
       fPainting->Add(fAttr->Clone(), "attr");
-      fAttrChanged = kFALSE;
+      fAttrChanged = 0;
    }
    if (!obj) obj = new TObjString("any");
    fPainting->Add(obj, opt);


### PR DESCRIPTION
Up to now only TVirtualPadPainter interface was redefined.
Now also TVirtualPS is used, which is important for 3D painters.
This is just minimal workaround to support existing painters before appropriate JavaScript code will be provided.