### PR TITLE
[RooFit] Improve RooFFTConvPdf

### DIFF
--- a/roofit/roofitcore/inc/RooExpensiveObjectCache.h
+++ b/roofit/roofitcore/inc/RooExpensiveObjectCache.h
@@ -62,7 +62,7 @@ public:
     void setPayload(TObject* obj) { _payload = obj ; }
     const char* ownerName() const { return _ownerName.Data() ; }
 
-    void print() ;
+    void print() const;
 
   protected:
     

--- a/roofit/roofitcore/inc/RooFFTConvPdf.h
+++ b/roofit/roofitcore/inc/RooFFTConvPdf.h
@@ -21,7 +21,8 @@
 class RooRealVar ;
 
 #include <map>
- 
+
+///PDF for the numerical (FFT) convolution of two PDFs.
 class RooFFTConvPdf : public RooAbsCachedPdf {
 public:
 
@@ -121,6 +122,8 @@ protected:
   RooSetProxy  _cacheObs ; // Non-convolution observables that are also cached
 
 private:
+
+  void prepareFFTBinning(RooRealVar& convVar) const;
 
   ClassDef(RooFFTConvPdf,1) // Convolution operator p.d.f based on numeric Fourier transforms
 };

--- a/roofit/roofitcore/src/RooExpensiveObjectCache.cxx
+++ b/roofit/roofitcore/src/RooExpensiveObjectCache.cxx
@@ -43,7 +43,7 @@ ClassImp(RooExpensiveObjectCache);
 ClassImp(RooExpensiveObjectCache::ExpensiveObject);
   ;
 
-RooExpensiveObjectCache* RooExpensiveObjectCache::_instance = 0 ;
+RooExpensiveObjectCache* RooExpensiveObjectCache::_instance = nullptr ;
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -75,7 +75,7 @@ RooExpensiveObjectCache::~RooExpensiveObjectCache()
   }
 
   if (_instance == this) {
-    _instance = 0 ;
+    _instance = nullptr ;
   }
 }
 
@@ -343,17 +343,17 @@ void RooExpensiveObjectCache::print() const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void RooExpensiveObjectCache::ExpensiveObject::print() 
+void RooExpensiveObjectCache::ExpensiveObject::print() const
 {
   cout << _payload->IsA()->GetName() << "::" << _payload->GetName() ;
   if (_realRefParams.size()>0 || _catRefParams.size()>0) {
     cout << " parameters=( " ;
-    map<TString,Double_t>::iterator iter = _realRefParams.begin() ;
+    auto iter = _realRefParams.begin() ;
     while(iter!=_realRefParams.end()) {
       cout << iter->first << "=" << iter->second << " " ;
       ++iter ;
     }  
-    map<TString,Int_t>::iterator iter2 = _catRefParams.begin() ;
+    auto iter2 = _catRefParams.begin() ;
     while(iter2!=_catRefParams.end()) {
       cout << iter2->first << "=" << iter2->second << " " ;
       ++iter2 ;

--- a/roofit/roofitcore/src/RooFFTConvPdf.cxx
+++ b/roofit/roofitcore/src/RooFFTConvPdf.cxx
@@ -11,93 +11,101 @@
   *****************************************************************************/ 
 
 //////////////////////////////////////////////////////////////////////////////
-//
- // 
- // This class implement a generic one-dimensional numeric convolution of two p.d.f.
- // and can convolve any two RooAbsPdfs. The class exploits the convolution theorem
- //
- //       f(x) (*) g(x) --F--> f(k_i) * g(k_i)
- //
- // and calculate the convolution by calculate a Real->Complex FFT of both input p.d.fs
- // multiplying the complex coefficients and performing the reverse Complex->Real FFT
- // to get the result in the input space. This class using the ROOT FFT Interface to
- // the (free) FFTW3 package (www.fftw.org) and requires that your ROOT installation is
- // compiled with the --enable-fftw3 option (instructions for Linux follow)
- //
- // Note that the performance in terms of speed and stability of RooFFTConvPdf is 
- // vastly superior to that of RooNumConvPdf 
- //
- // An important feature of FFT convolutions is that the observable is treated in a
- // cyclical way. This is correct & desirable behavior for cyclical observables such as angles,
- // but it may not be for other observables. The effect that is observed is that if
- // p.d.f is zero at xMin and non-zero at xMax some spillover occurs and
- // a rising tail may appear at xMin. This effect can be reduced or eliminated by
- // introducing a buffer zone in the FFT calculation. If this feature is activated
- // input the sampling array for the FFT calculation is extended in both directions
- // and filled with repetitions of the lowest bin value and highest bin value
- // respectively. The buffer bins are stripped again when the FFT output values
- // are transferred to the p.d.f cache. The default buffer size is 10% of the
- // observable domain size and can be changed with setBufferFraction() member function.
- // 
- // This class is a caching p.d.f inheriting from RooAbsCachedPdf. If this p.d.f 
- // is evaluated for a particular value of x, the FFT calculate the values for the
- // p.d.f at all points in observables space for the given choice of parameters,
- // which are stored in the cache. Subsequent evaluations of RooFFTConvPdf with
- // identical parameters will retrieve results from the cache. If one or more
- // of the parameters change, the cache will be updated.
- // 
- // The sampling density of the cache is controlled by the binning of the 
- // the convolution observable, which can be changed from RooRealVar::setBins(N)
- // For good results N should be large (>1000). Additional interpolation of
- // cache values may improve the result if courser binning are chosen. These can be 
- // set in the constructor or through the setInterpolationOrder() member function. 
- // For N>1000 interpolation will not substantially improve the performance.
- //
- // Additionial information on caching activities can be displayed by monitoring
- // the message stream with topic "Caching" at the INFO level, i.e. 
- // do RooMsgService::instance().addStream(RooMsgService::INFO,Topic("Caching")) 
- // to see these message on stdout
- //
- // Multi-dimensional convolutions are not supported yet, but will be in the future
- // as FFTW can calculate them
- //
- // ---
- // 
- // Installing a copy of FFTW on Linux and compiling ROOT to use it
- // 
- // 1) Go to www.fftw.org and download the latest stable version (a .tar.gz file)
- //
- // If you have root access to your machine and want to make a system installation of FFTW
- //
- //   2) Untar fftw-XXX.tar.gz in /tmp, cd into the untarred directory 
- //       and type './configure' followed by 'make install'. 
- //       This will install fftw in /usr/local/bin,lib etc...
- //
- //   3) Start from a source installation of ROOT. If you now have a binary distribution,
- //      first download a source tar ball from root.cern.ch for your ROOT version and untar it.
- //      Run 'configure', following the instruction from 'configure --help' but be sure run 'configure' 
- //      with additional flags '--enable-fftw3' and '--enable-roofit', then run 'make'
- //         
- // 
- // If you do not have root access and want to make a private installation of FFTW
- //
- //   2) Make a private install area for FFTW, e.g. /home/myself/fftw
- //
- //   3) Untar fftw-XXX.tar.gz in /tmp, cd into the untarred directory
- //       and type './configure --prefix=/home/myself/fftw' followed by 'make install'. 
- //       Substitute /home/myself/fftw with a directory of your choice. This
- //       procedure will install FFTW in the location designated by you
- // 
- //   4) Start from a source installation of ROOT. If you now have a binary distribution,
- //      first download a source tar ball from root.cern.ch for your ROOT version and untar it.
- //      Run 'configure', following the instruction from 'configure --help' but be sure run 'configure' 
- //      with additional flags
- //       '--enable-fftw3', 
- //       '--with-fftw3-incdir=/home/myself/fftw/include', 
- //       '--width-fftw3-libdir=/home/myself/fftw/lib' and 
- //       '--enable-roofit' 
- //      Then run 'make'
-//
+/// \class RooFFTConvPdf
+/// \ingroup Roofitcore
+///
+/// This class implements a generic one-dimensional numeric convolution of two PDFs
+/// and can convolve any two RooAbsPdfs. The class exploits the convolution theorem
+/// \f[
+///       f(x) * g(x) \rightarrow F(k_i) \cdot G(k_i)
+/// \f]
+/// and calculate the convolution by calculate a Real->Complex FFT of both input p.d.fs
+/// multiplying the complex coefficients and performing the reverse Complex->Real FFT
+/// to get the result in the input space. This class using the ROOT FFT Interface to
+/// the (free) FFTW3 package (www.fftw.org) and requires that your ROOT installation is
+/// compiled with the `fftw3=ON` (default). More instructions below.
+///
+/// Note that the performance in terms of speed and stability of RooFFTConvPdf is 
+/// vastly superior to that of RooNumConvPdf 
+///
+/// An important feature of FFT convolutions is that the observable is assumed to be
+/// cyclical. This is correct & desirable behavior for cyclical observables such as angles,
+/// but it may not be for other observables. The effect that is observed is that if
+/// p.d.f is zero at xMin and non-zero at xMax some spillover occurs and
+/// a rising tail may appear at xMin.
+/// This is inevitable when using FFTs, because the FFT behaves as if an input with e.g. 3 bins was:
+/// ` ... 0 1 2 0 1 2 0 1 2 ... `
+///
+/// Therefore, if bins 0 and 2 are not equal, the FFT sees a step at the boundary, which causes
+/// problems in Fourier space.
+///
+/// The spillover or discontinuity can be reduced or eliminated by
+/// introducing a buffer zone in the FFT calculation. If this feature is activated,
+/// the sampling array for the FFT calculation is extended in both directions
+/// and padded with the lowest/highest bin.
+/// Example:
+/// ```
+///     original:                -5 -4 -3 -2 -1 0 +1 +2 +3 +4 +5
+///     add buffer zones:    U U -5 -4 -3 -2 -1 0 +1 +2 +3 +4 +5 O O
+///     rotate:              0 +1 +2 +3 +4 +5 O O U U -5 -4 -3 -2 -1
+/// ```
+/// The buffer bins are stripped away when the FFT output values
+/// are transferred to the p.d.f cache. The default buffer size is 10% of the
+/// observable domain size and can be changed with the `setBufferFraction()` member function.
+/// 
+/// This class is a caching p.d.f inheriting from RooAbsCachedPdf. If this p.d.f 
+/// is evaluated for a particular value of x, the FFT calculates the values for the
+/// p.d.f at all points in observable space for the given choice of parameters,
+/// which are stored in the cache. Subsequent evaluations of RooFFTConvPdf with
+/// identical parameters will retrieve results from the cache. If one or more
+/// of the parameters change, the cache will be updated, i.e., a new FFT runs.
+/// 
+/// The sampling density of the cache is controlled by the binning of the 
+/// the convolution observable, which can be changed from RooRealVar::setBins(N)
+/// For good results N should be large (>1000). Additional interpolation of
+/// cache values may improve the result if coarse binnings are chosen. These can be
+/// set in the constructor or through the `setInterpolationOrder()` member function.
+/// For N>1000 interpolation will not substantially improve the performance.
+///
+/// Additionial information on caching activities can be displayed by monitoring
+/// the message stream with topic "Caching" at the INFO level, i.e. 
+/// do `RooMsgService::instance().addStream(RooMsgService::INFO,Topic("Caching"))`
+/// to see these message on stdout.
+///
+/// Multi-dimensional convolutions are not supported at the moment.
+///
+/// ---
+/// 
+/// Installing a copy of FFTW on Linux and compiling ROOT to use it
+/// -------
+/// 
+/// You have two options:
+/// * ROOT can automatically install FFTW for itself, see `builtin_fftw3` at https://root.cern.ch/building-root
+/// * Install FFTW and let ROOT discover it. `fftw3` is on by default (see https://root.cern.ch/building-root)
+///
+/// 1) Go to www.fftw.org and download the latest stable version (a .tar.gz file)
+///
+/// If you have root access to your machine and want to make a system installation of FFTW
+///
+///   2) Untar fftw-XXX.tar.gz in /tmp, cd into the untarred directory 
+///       and type './configure' followed by 'make install'. 
+///       This will install fftw in /usr/local/bin,lib etc...
+///
+///   3) Start from a source installation of ROOT. ROOT should discover it. See https://root.cern.ch/building-root
+///         
+/// 
+/// If you do not have root access and want to make a private installation of FFTW
+///
+///   2) Make a private install area for FFTW, e.g. /home/myself/fftw
+///
+///   3) Untar fftw-XXX.tar.gz in /tmp, cd into the untarred directory
+///       and type './configure --prefix=/home/myself/fftw' followed by 'make install'. 
+///       Substitute /home/myself/fftw with a directory of your choice. This
+///       procedure will install FFTW in the location designated by you
+/// 
+///   4) Start from a source installation of ROOT.
+///      Look up and set the proper paths for ROOT to discover FFTW. See https://root.cern.ch/building-root
+///
 
 
 #include "Riostream.h" 
@@ -129,9 +137,15 @@ ClassImp(RooFFTConvPdf);
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Constructor for convolution of pdf1 (x) pdf2 in observable convVar. The binning used for the FFT sampling is controlled
-/// by the binning named "cache" in the convolution observable. The resulting FFT convolved histogram is interpolated at
-/// order 'ipOrder' A minimum binning of 1000 bins is recommended.
+/// Constructor for numerical (FFT) convolution of PDFs.
+/// \param[in] name Name of this PDF
+/// \param[in] title Title for plotting this PDF
+/// \param[in] convVar Observable to convolve the PDFs in \attention Use a high number of bins (>= 1000) for good accuracy.
+/// \param[in] pdf1 First PDF to be convolved
+/// \param[in] pdf2 Second PDF to be convolved
+/// \param[in] ipOrder Order for interpolation of the discrete FFT outputs
+/// The binning used for the FFT sampling is controlled by the binning named "cache" in the convolution observable `convVar`.
+/// If such a binning is not set, the same number of bins as for `convVar` will be used.
 
 RooFFTConvPdf::RooFFTConvPdf(const char *name, const char *title, RooRealVar& convVar, RooAbsPdf& pdf1, RooAbsPdf& pdf2, Int_t ipOrder) :
   RooAbsCachedPdf(name,title,ipOrder),
@@ -145,23 +159,19 @@ RooFFTConvPdf::RooFFTConvPdf(const char *name, const char *title, RooRealVar& co
   _shift1(0),
   _shift2(0),
   _cacheObs("!cacheObs","Cached observables",this,kFALSE,kFALSE)
- { 
-   if (!convVar.hasBinning("cache")) {
-     convVar.setBinning(convVar.getBinning(),"cache") ;
-   }
-   
-   _shift2 = (convVar.getMax("cache")+convVar.getMin("cache"))/2 ;
+{
+  prepareFFTBinning(convVar);
 
-   calcParams() ;
+  _shift2 = (convVar.getMax("cache")+convVar.getMin("cache"))/2 ;
 
- } 
+  calcParams() ;
 
-
+}
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Constructor for convolution of pdf1 (x) pdf2 in observable convVar. The binning used for the FFT sampling is controlled
-/// by the binning named "cache" in the convolution observable. The resulting FFT convolved histogram is interpolated at
-/// order 'ipOrder' A minimum binning of 1000 bins is recommended.
+/// \copydoc RooFFTConvPdf(const char*, const char*, RooRealVar&, RooAbsPdf&, RooAbsPdf&, Int_t)
+/// \param[in] pdfConvVar If the variable used for convolution has a PDF, itself, this holds the PDF and
+/// convVar holds the variable. See also rf210_angularconv.C in the <a href="https://root.cern.ch/root/html/tutorials/roofit/index.html.">roofit tutorials</a>
 
 RooFFTConvPdf::RooFFTConvPdf(const char *name, const char *title, RooAbsReal& pdfConvVar, RooRealVar& convVar, RooAbsPdf& pdf1, RooAbsPdf& pdf2, Int_t ipOrder) :
   RooAbsCachedPdf(name,title,ipOrder),
@@ -175,15 +185,13 @@ RooFFTConvPdf::RooFFTConvPdf(const char *name, const char *title, RooAbsReal& pd
   _shift1(0),
   _shift2(0),
   _cacheObs("!cacheObs","Cached observables",this,kFALSE,kFALSE)
- { 
-   if (!convVar.hasBinning("cache")) {
-     convVar.setBinning(convVar.getBinning(),"cache") ;
-   }
-   
-   _shift2 = (convVar.getMax("cache")+convVar.getMin("cache"))/2 ;
+{
+  prepareFFTBinning(convVar);
 
-   calcParams() ;
- } 
+  _shift2 = (convVar.getMax("cache")+convVar.getMin("cache"))/2 ;
+
+  calcParams() ;
+}
 
 
 
@@ -214,6 +222,32 @@ RooFFTConvPdf::~RooFFTConvPdf()
 {
 }
 
+
+////////////////////////////////////////////////////////////////////////////////
+/// Try to improve the binning and inform user if possible.
+/// With a 10% buffer fraction, 930 raw bins yield 1024 FFT bins,
+/// a sweet spot for the speed of FFTW.
+
+void RooFFTConvPdf::prepareFFTBinning(RooRealVar& convVar) const {
+  if (!convVar.hasBinning("cache")) {
+    const RooAbsBinning& varBinning = convVar.getBinning();
+    const int optimal = static_cast<Int_t>(1024/(1.+_bufFrac));
+
+    //Can improve precision if binning is uniform
+    if (varBinning.numBins() < optimal && varBinning.isUniform()) {
+      coutI(Caching) << "Changing internal binning of variable '" << convVar.GetName()
+          << "' in FFT '" << fName << "'"
+          << " from " << varBinning.numBins()
+          << " to " << optimal << " to improve the precision of the numerical FFT."
+          << " This can be done manually by setting an additional binning named 'cache'." << std::endl;
+      convVar.setBinning(RooUniformBinning(varBinning.lowBound(), varBinning.highBound(), optimal, "cache"), "cache");
+    } else {
+      coutW(Caching) << "The internal binning of variable " << convVar.GetName()
+          << " is not uniform. The numerical FFT will likely yield wrong results." << std::endl;
+      convVar.setBinning(varBinning, "cache");
+    }
+  }
+}
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -313,7 +347,12 @@ RooFFTConvPdf::FFTCacheElem::FFTCacheElem(const RooFFTConvPdf& self, const RooAr
   // Save copy of original histX binning and make alternate binning
   // for extended range scanning
 
-  Int_t N = convObs->numBins() ;
+  const Int_t N = convObs->numBins();
+  if (N < 900) {
+    oocoutW(&self, Eval) << "The FFT convolution '" << self.GetName() << "' will run with " << N
+        << " bins. A decent accuracy for difficult convolutions is typically only reached with n >= 1000. Suggest to increase the number"
+        " of bins of the observable '" << convObs->GetName() << "'." << std::endl;
+  }
   Int_t Nbuf = static_cast<Int_t>((N*self.bufferFraction())/2 + 0.5) ;
   Double_t obw = (convObs->getMax() - convObs->getMin())/N ;
   Int_t N2 = N+2*Nbuf ;

--- a/roofit/roofitcore/src/RooLinearVar.cxx
+++ b/roofit/roofitcore/src/RooLinearVar.cxx
@@ -15,27 +15,26 @@
  *****************************************************************************/
 
 //////////////////////////////////////////////////////////////////////////////
-//
-// RooLinearVar is the most general form of a derived real-valued object that can
-// be used by RooRealIntegral to integrate over. The requirements for this are
-//
-//          - Can be modified directly (i.e. invertible formula)
-//          - Jacobian term in integral is constant (but not necessarily 1)
-//
-// This class implements the most general form that satisfy these requirement
-// 
-//    RLV = (slope)*x + (offset)
-//
-// X is required to be a RooRealVar to meet the invertibility criterium
-// (slope) and (offset) is are RooAbsReals, but may not overlap with x,
-// i.e. x may not be a server of (slope) and (offset)
-//
-// In the context of a dataset, (slope) may not contain any real-valued dependents
-// (satisfied constant Jacobian requirement). This check cannot be enforced at
-// construction time, but can be performed at run time through the isJacobianOK(depList)
-// member function.
-//
-//
+/// \class RooLinearVar
+/// RooLinearVar is the most general form of a derived real-valued object that can
+/// be used by RooRealIntegral to integrate over. The requirements for this are
+/// * Can be modified directly (i.e. invertible formula)
+/// * Jacobian term in integral is constant (but not necessarily 1)
+///
+/// This class implements the most general form that satisfy these requirement
+/// \f[
+///    RLV = \mathrm{slope} \cdot x + \mathrm{offset}
+/// \f]
+/// X is required to be a RooRealVar to meet the invertibility criterium
+/// `slope` and `offset` are RooAbsReals, but may not overlap with x,
+/// i.e. x may not be a server of `slope` and `offset`.
+///
+/// In the context of a dataset, `slope` may not contain any real-valued dependents
+/// (satisfied constant Jacobian requirement). This check cannot be enforced at
+/// construction time, but can be performed at run time through the isJacobianOK(depList)
+/// member function.
+///
+///
 
 #include "RooFit.h"
 #include "Riostream.h"


### PR DESCRIPTION
Improve precision of default FFT convolution by using more bins. Also improve documentation.

This is part of a solution to the problems described here:
https://root-forum.cern.ch/t/chained-pdf-definitions/29860/18