### PR TITLE
Add training-validation split in MethodDL and PyKeras

### DIFF
--- a/tmva/pymva/inc/TMVA/MethodPyKeras.h
+++ b/tmva/pymva/inc/TMVA/MethodPyKeras.h
@@ -80,6 +80,7 @@ namespace TMVA {
       Int_t fTriesEarlyStopping; // Stop training if validation loss is not decreasing for several epochs
       TString fLearningRateSchedule; // Set new learning rate at specific epochs
       TString fTensorBoard;          // Store log files during training
+      TString fNumValidationString;  // option string defining the number of validation events
 
       bool fModelIsSetup = false; // flag whether model is loaded, neede for getMvaValue during evaluation
       float* fVals = nullptr; // variables array used for GetMvaValue
@@ -89,6 +90,7 @@ namespace TMVA {
       TString fFilenameTrainedModel; // output filename for trained model
 
       void SetupKerasModel(Bool_t loadTrainedModel); // setups the needed variables loads the model
+      UInt_t  GetNumValidationSamples();  // get numer of validation events according to given option
 
       ClassDef(MethodPyKeras, 0);
    };

--- a/tmva/tmva/inc/TMVA/MethodDL.h
+++ b/tmva/tmva/inc/TMVA/MethodDL.h
@@ -151,6 +151,9 @@ private:
    template <typename Architecture_t>
    std::vector<Double_t> PredictDeepNet(Long64_t firstEvt, Long64_t lastEvt, size_t batchSize, Bool_t logProgress); 
 
+   /// parce the validation string and return the number of event data used for validation 
+   UInt_t GetNumValidationSamples();
+
    
    size_t fInputDepth;  ///< The depth of the input.
    size_t fInputHeight; ///< The height of the input.
@@ -173,6 +176,7 @@ private:
    TString fTrainingStrategyString;     ///< The string defining the training strategy
    TString fWeightInitializationString; ///< The string defining the weight initialization method
    TString fArchitectureString;         ///< The string defining the architecure: CPU or GPU
+   TString fNumValidationString;        ///< The string defining the number (or percentage) of training data used for validation
    bool fResume;
    bool fBuildNet;                     ///< Flag to control whether to build fNet, the stored network used for the evaluation
 
@@ -185,7 +189,7 @@ protected:
    // provide a help message
    void GetHelpMessage() const;
 
-   virtual std::vector<Double_t> GetMvaValues(Long64_t firstEvt, Long64_t lastEvt, Bool_t logProgress); 
+   virtual std::vector<Double_t> GetMvaValues(Long64_t firstEvt, Long64_t lastEvt, Bool_t logProgress);
 
 
 public:

--- a/tmva/tmva/src/MethodDL.cxx
+++ b/tmva/tmva/src/MethodDL.cxx
@@ -178,6 +178,9 @@ void MethodDL::DeclareOptions()
 
    DeclareOptionRef(fRandomSeed = 0, "RandomSeed", "Random seed used for weight initialization and batch shuffling");
 
+   DeclareOptionRef(fNumValidationString = "20%", "ValidationSize", "Part of the training data to use for validation. "
+                    "Specify as 0.2 or 20% to use a fifth of the data set as validation set. "
+                    "Specify as 100 to use exactly 100 events. (Default: 20%)");
 
    DeclareOptionRef(fArchitectureString = "CPU", "Architecture", "Which architecture to perform the training on.");
    AddPreDefVal(TString("STANDARD"));
@@ -988,6 +991,65 @@ Bool_t MethodDL::HasAnalysisType(Types::EAnalysisType type, UInt_t numberClasses
    return kFALSE;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Validation of the ValidationSize option. Allowed formats are 20%, 0.2 and
+/// 100 etc.
+///    - 20% and 0.2 selects 20% of the training set as validation data.
+///    - 100 selects 100 events as the validation data.
+///
+/// @return number of samples in validation set
+///
+UInt_t TMVA::MethodDL::GetNumValidationSamples()
+{
+   Int_t nValidationSamples = 0;
+   UInt_t trainingSetSize = GetEventCollection(Types::kTraining).size();
+
+   // Parsing + Validation
+   // --------------------
+   if (fNumValidationString.EndsWith("%")) {
+      // Relative spec. format 20%
+      TString intValStr = TString(fNumValidationString.Strip(TString::kTrailing, '%'));
+
+      if (intValStr.IsFloat()) {
+         Double_t valSizeAsDouble = fNumValidationString.Atof() / 100.0;
+         nValidationSamples = GetEventCollection(Types::kTraining).size() * valSizeAsDouble;
+      } else {
+         Log() << kFATAL << "Cannot parse number \"" << fNumValidationString
+               << "\". Expected string like \"20%\" or \"20.0%\"." << Endl;
+      }
+   } else if (fNumValidationString.IsFloat()) {
+      Double_t valSizeAsDouble = fNumValidationString.Atof();
+
+      if (valSizeAsDouble < 1.0) {
+         // Relative spec. format 0.2
+         nValidationSamples = GetEventCollection(Types::kTraining).size() * valSizeAsDouble;
+      } else {
+         // Absolute spec format 100 or 100.0
+         nValidationSamples = valSizeAsDouble;
+      }
+   } else {
+      Log() << kFATAL << "Cannot parse number \"" << fNumValidationString << "\". Expected string like \"0.2\" or \"100\"."
+            << Endl;
+   }
+
+   // Value validation
+   // ----------------
+   if (nValidationSamples < 0) {
+      Log() << kFATAL << "Validation size \"" << fNumValidationString << "\" is negative." << Endl;
+   }
+
+   if (nValidationSamples == 0) {
+      Log() << kFATAL << "Validation size \"" << fNumValidationString << "\" is zero." << Endl;
+   }
+
+   if (nValidationSamples >= (Int_t)trainingSetSize) {
+      Log() << kFATAL << "Validation size \"" << fNumValidationString
+            << "\" is larger than or equal in size to training set (size=\"" << trainingSetSize << "\")." << Endl;
+   }
+
+   return nValidationSamples;
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 ///  Implementation of architecture specific train method
@@ -1004,9 +1066,6 @@ void MethodDL::TrainDeepNet()
 
    bool debug = Log().GetMinType() == kDEBUG;
 
-   // Determine the number of training and testing examples
-   size_t nTrainingSamples = GetEventCollection(Types::kTraining).size();
-   size_t nTestSamples = GetEventCollection(Types::kTesting).size();
 
    // Determine the number of outputs
    // //    size_t outputSize = 1;
@@ -1017,10 +1076,20 @@ void MethodDL::TrainDeepNet()
    // //    }
 
    // set the random seed for weight initialization
-   Architecture_t::SetRandomSeed(fRandomSeed); 
+   Architecture_t::SetRandomSeed(fRandomSeed);
+
+   ///split training data in training and validation data
+   // and determine the number of training and testing examples
+
+   size_t nValidationSamples = GetNumValidationSamples();
+   size_t nTrainingSamples = GetEventCollection(Types::kTraining).size() - nValidationSamples;
+
+   const std::vector<TMVA::Event *> &allData = GetEventCollection(Types::kTraining);
+   const std::vector<TMVA::Event *> eventCollectionTraining{allData.begin(), allData.begin() + nTrainingSamples};
+   const std::vector<TMVA::Event *> eventCollectionValidation{allData.begin() + nTrainingSamples, allData.end()};
 
    size_t trainingPhase = 1;
-      
+
    for (TTrainingSettings &settings : this->GetTrainingSettings()) {
 
       size_t nThreads = 1;       // FIXME threads are hard coded to 1, no use of slave threads or multi-threading
@@ -1069,6 +1138,16 @@ void MethodDL::TrainDeepNet()
          Error("Train","Given input layout %zu x %zu x %zu is not compatible with  batch layout %zu x %zu x  %zu ",
                inputDepth,inputHeight,inputWidth,batchDepth,batchHeight,batchWidth);
          return;
+      }
+
+      // check batch size is compatible with number of events
+      if (nTrainingSamples < settings.batchSize || nValidationSamples < settings.batchSize) {
+         Log() << kFATAL << "Number of samples in the datasets are train: ("
+               << nTrainingSamples << ") test: (" << nValidationSamples
+               << "). One of these is smaller than the batch size of "
+               << settings.batchSize << ". Please increase the batch"
+               << " size to be at least the same size as the smallest"
+               << " of them." << Endl;
       }
 
 
@@ -1123,15 +1202,16 @@ void MethodDL::TrainDeepNet()
          if (Log().GetMinType() <= kINFO)
             deepNet.Print();
       }
+      Log() << "Using " << nTrainingSamples << " events for training and " <<  nValidationSamples << " for testing" << Endl; 
 
-      // Loading the training and testing datasets
-      TMVAInput_t trainingTuple = std::tie(GetEventCollection(Types::kTraining), DataInfo());
+      // Loading the training and validation datasets
+      TMVAInput_t trainingTuple = std::tie(eventCollectionTraining, DataInfo());
       TensorDataLoader_t trainingData(trainingTuple, nTrainingSamples, deepNet.GetBatchSize(),
                                       deepNet.GetBatchDepth(), deepNet.GetBatchHeight(), deepNet.GetBatchWidth(),
                                       deepNet.GetOutputWidth(), nThreads);
 
-      TMVAInput_t testTuple = std::tie(GetEventCollection(Types::kTesting), DataInfo());
-      TensorDataLoader_t testingData(testTuple, nTestSamples, deepNet.GetBatchSize(),
+      TMVAInput_t validationTuple = std::tie(eventCollectionValidation, DataInfo());
+      TensorDataLoader_t validationData(validationTuple, nValidationSamples, deepNet.GetBatchSize(),
                                      deepNet.GetBatchDepth(), deepNet.GetBatchHeight(), deepNet.GetBatchWidth(),
                                      deepNet.GetOutputWidth(), nThreads);
 
@@ -1141,18 +1221,18 @@ void MethodDL::TrainDeepNet()
 
       Bool_t includeRegularization = (R != DNN::ERegularization::kNone); 
 
-      Double_t minTestError = 0.0;
-      for (auto batch : testingData) {
+      Double_t minValError = 0.0;
+      for (auto batch : validationData) {
          auto inputTensor = batch.GetInput();
          auto outputMatrix = batch.GetOutput();
          auto weights = batch.GetWeights();
          // should we apply droput to the loss ??
-         minTestError += deepNet.Loss(inputTensor, outputMatrix, weights, false, false);
+         minValError += deepNet.Loss(inputTensor, outputMatrix, weights, false, false);
       }
       // add Regularization term
       Double_t regzTerm = (includeRegularization) ? deepNet.RegularizationTerm() : 0.0; 
-      minTestError /= (Double_t)(nTestSamples / settings.batchSize);
-      minTestError += regzTerm;
+      minValError /= (Double_t)(nValidationSamples / settings.batchSize);
+      minValError += regzTerm;
 
 
       // create a pointer to base class VOptimizer
@@ -1202,13 +1282,13 @@ void MethodDL::TrainDeepNet()
       Log() << "Training phase " << trainingPhase << " of " << this->GetTrainingSettings().size() << ":    "
             << "Learning rate = " << settings.learningRate 
             << " regularization " << (char) settings.regularization 
-            << " minimum error = " << minTestError
+            << " minimum error = " << minValError
             << Endl;
       if (!fInteractive) {
          std::string separator(62, '-');
          Log() << separator << Endl;
          Log() << std::setw(10) << "Epoch"
-               << " | " << std::setw(12) << "Train Err." << std::setw(12) << "Test Err." 
+               << " | " << std::setw(12) << "Train Err." << std::setw(12) << "Val. Err." 
                << std::setw(12) << "t(s)/epoch" << std::setw(12)  << "t(s)/Loss"
                << std::setw(12) << "nEvents/s"
                << std::setw(12) << "Conv. Steps" << Endl;
@@ -1263,31 +1343,31 @@ void MethodDL::TrainDeepNet()
 
             t1 = std::chrono::system_clock::now();
 
-            // Compute test error.
-            Double_t testError = 0.0;
-            for (auto batch : testingData) {
+            // Compute validation error.
+            Double_t valError = 0.0;
+            for (auto batch : validationData) {
                auto inputTensor = batch.GetInput();
                auto outputMatrix = batch.GetOutput();
                auto weights = batch.GetWeights();
                // should we apply droput to the loss ??
-               testError += deepNet.Loss(inputTensor, outputMatrix, weights, false, false);
+               valError += deepNet.Loss(inputTensor, outputMatrix, weights, false, false);
             }
             // normalize loss to number of batches and add regularization term 
             Double_t regTerm = (includeRegularization) ? deepNet.RegularizationTerm() : 0.0; 
-            testError /= (Double_t)(nTestSamples / settings.batchSize);
-            testError += regTerm; 
+            valError /= (Double_t)(nValidationSamples / settings.batchSize);
+            valError += regTerm; 
             
             t2 = std::chrono::system_clock::now();
 
             // checking for convergence
-            if (testError < minTestError) {
+            if (valError < minValError) {
                convergenceCount = 0;
             } else {
                convergenceCount += settings.testInterval;
             }
 
             // copy configuration when reached a minimum error
-            if (testError < minTestError ) {
+            if (valError < minValError ) {
                // Copy weights from deepNet to fNet
                Log() << std::setw(10) << optimizer->GetGlobalStep()
                      << " Minimum Test error found - save the configuration " << Endl;
@@ -1300,10 +1380,10 @@ void MethodDL::TrainDeepNet()
                   // for (size_t k = 0; k < dlayer->GetWeights().size(); ++k) 
                   //    dLayer->GetWeightsAt(k).Print(); 
                }
-               minTestError = testError;
+               minValError = valError;
             }
-            else if ( minTestError <= 0. )
-               minTestError = testError; 
+            else if ( minValError <= 0. )
+               minValError = valError; 
 
 
             Double_t trainingError = 0.0;
@@ -1339,7 +1419,7 @@ void MethodDL::TrainDeepNet()
 
             Log() << std::setw(10) << optimizer->GetGlobalStep()  << " | "
                   << std::setw(12) << trainingError
-                  << std::setw(12) << testError
+                  << std::setw(12) << valError
                   << std::setw(12) << seconds / settings.testInterval
                   << std::setw(12)  << elapsed_testing.count()
                   << std::setw(12) << 1. / eventTime
@@ -1376,21 +1456,6 @@ void MethodDL::Train()
       Log() << kFATAL << "Not implemented yet" << Endl;
       return;
    }
-
-   for (TTrainingSettings & settings : fTrainingSettings) {
-      size_t nTrainingSamples = GetEventCollection(Types::kTraining).size();
-      size_t nTestSamples = GetEventCollection(Types::kTesting).size();
-
-      if (nTrainingSamples < settings.batchSize or
-          nTestSamples < settings.batchSize) {
-         Log() << kFATAL << "Number of samples in the datasets are train: ("
-                         << nTrainingSamples << ") test: (" << nTestSamples
-                         << "). One of these is smaller than the batch size of "
-                         << settings.batchSize << ". Please increase the batch"
-                         << " size to be at least the same size as the smallest"
-                         << " of them." << Endl;
-      }
-  }
 
    // using for training same scalar type defined for the prediction
    if (this->GetArchitectureString() == "GPU") {


### PR DESCRIPTION
Separate in method DL the training data in pure training and validation which is used to 
stop the iterative optimisation process. 

Similar split should also be done now in PyKeras