### PR TITLE
[cxxmodules] Don't put key function decl into eagerly deserialized decls

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/Serialization/ASTWriterDecl.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Serialization/ASTWriterDecl.cpp
@@ -2230,6 +2230,17 @@ static bool isRequiredDecl(const Decl *D, ASTContext &Context,
     return false;
   }
 
+  if (Context.getTargetInfo().getCXXABI().canKeyFunctionBeInline()) {
+    if (const CXXMethodDecl *MD = dyn_cast<CXXMethodDecl>(D)) {
+      const CXXRecordDecl *RD = MD->getParent();
+      if (MD->isOutOfLine() && RD->isDynamicClass()) {
+        const CXXMethodDecl *KeyFunc = Context.getCurrentKeyFunction(RD);
+        if (KeyFunc && KeyFunc->getCanonicalDecl() == MD->getCanonicalDecl())
+          return false;
+      }
+    }
+  }
+
   return Context.DeclMustBeEmitted(D);
 }
 


### PR DESCRIPTION
This returns the opposite condition (false) from the same code snippet
in ASTContext (true) https://github.com/root-project/root/blob/master/interpreter/llvm/src/tools/clang/lib/AST/ASTContext.cpp#L9091.

The idea is to make this as a guard before calling
ASTContext::DeclMustBeEmitted. Or we can also delete ASTContext code.
Testing.