### PR TITLE
[cxxmodules] Don't explicitly load MathCore for modules

### DIFF
--- a/bindings/pyroot/ROOT.py
+++ b/bindings/pyroot/ROOT.py
@@ -750,7 +750,10 @@ class ModuleFacade( types.ModuleType ):
 
     # manually load libMathCore, for example to obtain gRandom
     # This can be removed once autoloading on selected variables is available
-      _root.gSystem.Load( "libMathCore" )
+    # If we have a pcm for the library, we don't have to explicitly load this as
+    # modules have an autoloading support.
+      if not _root.gInterpreter.HasPCMForLibrary("libMathCore"):
+         _root.gSystem.Load( "libMathCore" )
 
 sys.modules[ __name__ ] = ModuleFacade( sys.modules[ __name__ ] )
 del ModuleFacade

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -2835,7 +2835,7 @@ Bool_t TCling::HasPCMForLibrary(const char *libname) const
 
    clang::ModuleMap &moduleMap = fInterpreter->getCI()->getPreprocessor().getHeaderSearchInfo().getModuleMap();
    clang::Module *M = moduleMap.findModule(ModuleName);
-   return M && !M->IsMissingRequirement;
+   return M && !M->IsMissingRequirement && M->getASTFile();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/rint/src/TRint.cxx
+++ b/core/rint/src/TRint.cxx
@@ -159,7 +159,7 @@ TRint::TRint(const char *appClassName, Int_t *argc, char **argv, void *options,
    // Explicitly load libMathCore it cannot be auto-loaded it when using one
    // of its freestanding functions. Once functions can trigger autoloading we
    // can get rid of this.
-   if (!gClassTable->GetDict("TRandom"))
+   if (!gInterpreter->HasPCMForLibrary("libMathCore") && !gClassTable->GetDict("TRandom"))
       gSystem->Load("libMathCore");
 
    // Load some frequently used includes


### PR DESCRIPTION
With modules, we have autoloading of library feature
(LazyFunctionCreatorAutoloadForModule) so we can load TRandom function.
Thus, we don't have to explicitly load MathCore.

It improves memory by 3Mbytes
Patch by Oksana and me :D