### PR TITLE
[cling] Add a dependency on clangSema to clingInterpreter.

### DIFF
--- a/interpreter/cling/lib/Interpreter/CMakeLists.txt
+++ b/interpreter/cling/lib/Interpreter/CMakeLists.txt
@@ -54,6 +54,10 @@ set(CLING_DEPENDS)
 if(TARGET ClangDriverOptions)
   set(CLING_DEPENDS ClangDriverOptions)
 endif()
+# clangSema will make sure all of the dependencies of clingInterpreter are met.
+if(TARGET clangSema)
+  set(CLING_DEPENDS "${CLING_DEPENDS};clangSema")
+endif()
 
 
 add_cling_library(clingInterpreter OBJECT


### PR DESCRIPTION
We use the target clingInterpreter in a few places as a general dependency rule making sure the cling infrastructure is already built.

In some cases, such as clad, the highly parallel builds trigger build of clad before clangSema, clangBasic and clangAST are built.

This patch ensures the right dependencies are in order.