### PR TITLE
[cxxmodules] Change the linkage of functions and template specializat…

### DIFF
--- a/interpreter/cling/include/cling/Interpreter/DynamicLookupLifetimeHandler.h
+++ b/interpreter/cling/include/cling/Interpreter/DynamicLookupLifetimeHandler.h
@@ -75,7 +75,7 @@ namespace runtime {
                       Interpreter* Interp);
 
       ///\brief Returns the created object.
-      void* getMemory() const { return m_Memory; }
+      inline void* getMemory() const { return m_Memory; }
 
       /// \brief Clears up the free store, when LifetimeHandler goes out of
       /// scope.

--- a/interpreter/cling/include/cling/Interpreter/DynamicLookupRuntimeUniverse.h
+++ b/interpreter/cling/include/cling/Interpreter/DynamicLookupRuntimeUniverse.h
@@ -47,7 +47,7 @@ namespace runtime {
     /// @param[in] DC The declaration context, in which the expression will be
     /// evaluated at runtime.
     template<typename T>
-    T EvaluateT(DynamicExprInfo* ExprInfo, clang::DeclContext* DC ) {
+    inline T EvaluateT(DynamicExprInfo* ExprInfo, clang::DeclContext* DC ) {
       Value result(EvaluateDynamicExpression(gCling, ExprInfo, DC));
       if (result.isValid())
         // Check whether the expected return type and the actual return type are
@@ -60,7 +60,7 @@ namespace runtime {
     /// \brief EvaluateT specialization for the case where we instantiate with
     /// void.
     template<>
-    void EvaluateT(DynamicExprInfo* ExprInfo, clang::DeclContext* DC ) {
+    inline void EvaluateT(DynamicExprInfo* ExprInfo, clang::DeclContext* DC ) {
       EvaluateDynamicExpression(gCling, ExprInfo, DC);
     }
   } // end namespace internal

--- a/interpreter/cling/include/cling/Interpreter/RuntimePrintValue.h
+++ b/interpreter/cling/include/cling/Interpreter/RuntimePrintValue.h
@@ -138,7 +138,7 @@ namespace cling {
     }
 
     // For std::vector<bool> elements
-    std::string printValue(const bool& B, const void* = 0) {
+    inline std::string printValue(const bool& B, const void* = 0) {
       return cling::printValue(&B);
     }
 

--- a/interpreter/cling/include/cling/Interpreter/Value.h
+++ b/interpreter/cling/include/cling/Interpreter/Value.h
@@ -267,7 +267,7 @@ namespace cling {
     /// casting the value of builtins (except void), enums and pointers.
     /// Values referencing an object are treated as pointers to the object.
     template <typename T>
-    T simplisticCastAs() const {
+    inline T simplisticCastAs() const {
       return CastFwd<T>::cast(*this);
     }
 


### PR DESCRIPTION
…ions.

static, static inline, always_inline, and extern inline functions can
always be deferred. Normal inline functions can be deferred in C99/C++.
Implicit template instantiations can also be deferred in C++.

This patch changes the linkage of the declarations from strong to weak.
It allows clang to defer the deserialization from pch/pcm until their use.