### PR TITLE
Resolve memory over-write due to execution of a I/O rule on wrong object

### DIFF
--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -2015,7 +2015,15 @@ static void GatherArtificialElements(const TObjArray &branches, TStreamerInfoAct
             ids.back().fNestedIDs->fOwnOnfileObject = kTRUE;
          }
          ids.back().fNestedIDs->fOnfileObject = onfileObject;
-         GatherArtificialElements(branches, ids.back().fNestedIDs->fIDs, ename + ".", nextinfo, offset + nextel->GetOffset());
+         TString subprefix;
+         if (prefix.Length() && nextel->IsA() == TStreamerBase::Class()) {
+             // We skip the name of the base class if there is already a prefix.
+             // See TBranchElement::Unroll
+             subprefix = prefix;
+         } else {
+             subprefix = ename + ".";
+         }
+         GatherArtificialElements(branches, ids.back().fNestedIDs->fIDs, subprefix, nextinfo, offset + nextel->GetOffset());
          if (ids.back().fNestedIDs->fIDs.empty())
             ids.pop_back();
       }


### PR DESCRIPTION

This prevent the inappropriate execution on a rule intent for
an inner object on the outer object('s memory space)

In a case where the top level branch is:
```
 1 edm::Wrapper<std::vector<pat::CompositeCandidate, std::allocator<pat::CompositeCandidate> > >
```
which contains
```
 2    16, obj, vector<pat::CompositeCandidate> simple base pat::PATObject<reco::CompositeCandidate>
 3         360, overlapItems_, vector<edm::PtrVector<reco::Candidate> > simple base edm::PtrVectorBase
 4             48, cachedItems_, atomic<vector<const void*>*> ***TRANSIENT-WITH-RULE**
```
The TStreamerInfo Action Sequence for (4) was being executed the obj branch/level

 The bug was that GatherArtificialElements would drill through (3) eventhough
 it was not split and it did so because it did not recognize there was a branch for
 it because it added (errorneously) the name of the base class in the branch prefix.