### PR TITLE
TWebCanvas  - use TVirtualPS interface for custom objects drawings

### DIFF
--- a/etc/http/changes.md
+++ b/etc/http/changes.md
@@ -12,13 +12,27 @@
 9. Migrate to Node.js 8, do not support older versions 
 
 
+## Changes in 5.5.2
+1. Fix - draw TH2Poly bins outline when no content specified
+2. Fix - always set axis interactive handlers (#170)
+3. Fix - take into account zaxis properties when drawing color palette (#171)
+
+
+## Changes in 5.5.1
+1. Fix - adjust v7 part to new class naming convention, started with R
+2. Fix - show RCanvas title
+3. New - implement 'nocache' option for JSROOT scripts loading. When specified in URL with
+   JSRootCore.js script, tries to avoid scripts caching problem by adding stamp parameter to all URLs
+4. New - provide simple drawing for TObjString (#164) 
+
+
 ## Changes in 5.5.0
-1. Introduce JSROOT.StoreJSON() function. It creates JSON code for the 
+1. Introduce JSROOT.StoreJSON() function. It creates JSON code for the
    TCanvas with all drawn objects inside. Allows to store current canvas state
 2. Support "item=img:file.png" parameter to insert images in existing layout (#151)
 3. Support TTree drawing into TGraph (#153), thanks @cozzyd
 4. Let configure "&toolbar=right" in URL to change position of tool buttons
-5. Let configure "&divsize=500x400" in URL of size of main div element (default - full browser)  
+5. Let configure "&divsize=500x400" in URL of size of main div element (default - full browser)
 6. Implement "optstat1001" and "optfit101" draw options for histograms
 7. Remove "autocol" options - standard "plc" should be used instead
 8. Provide drawing of artificial "$legend" item - it creates TLegend for all primitives in pad

--- a/etc/http/scripts/JSRootCore.js
+++ b/etc/http/scripts/JSRootCore.js
@@ -96,7 +96,7 @@
 
    "use strict";
 
-   JSROOT.version = "5.6.0 19/10/2018";
+   JSROOT.version = "dev 26/10/2018";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;
@@ -1857,6 +1857,7 @@
                  this._math = JSROOT.Math;
                  _func = _func.replace(/TMath::Prob\(/g, 'this._math.Prob(')
                               .replace(/TMath::Gaus\(/g, 'this._math.Gaus(')
+                              .replace(/TMath::BreitWigner\(/g, 'this._math.BreitWigner(')
                               .replace(/xygaus\(/g, 'this._math.gausxy(this, x, y, ')
                               .replace(/gaus\(/g, 'this._math.gaus(this, x, ')
                               .replace(/gausn\(/g, 'this._math.gausn(this, x, ')

--- a/etc/http/scripts/JSRootIOEvolution.js
+++ b/etc/http/scripts/JSRootIOEvolution.js
@@ -2712,6 +2712,30 @@
          }
       }
 
+      cs['TMaterial'] = function(buf,obj) {
+         var v = buf.last_read_version;
+         buf.ClassStreamer(obj, "TNamed");
+         obj.fNumber = buf.ntoi4();
+         obj.fA = buf.ntof();
+         obj.fZ = buf.ntof();
+         obj.fDensity = buf.ntof();
+         if (v>2) {
+            buf.ClassStreamer(obj, "TAttFill");
+            obj.fRadLength = buf.ntof();
+            obj.fInterLength = buf.ntof();
+         } else {
+            obj.fRadLength = obj.fInterLength = 0;
+         }
+      }
+
+      cs['TMixture'] = function(buf,obj) {
+         buf.ClassStreamer(obj, "TMaterial");
+         obj.fNmixt = buf.ntoi4();
+         obj.fAmixt = buf.ReadFastArray(buf.ntoi4(), JSROOT.IO.kFloat);
+         obj.fZmixt = buf.ReadFastArray(buf.ntoi4(), JSROOT.IO.kFloat);
+         obj.fWmixt = buf.ReadFastArray(buf.ntoi4(), JSROOT.IO.kFloat);
+      }
+
       // these are direct streamers - not follow version/checksum logic
 
       var ds = JSROOT.IO.DirectStreamers;

--- a/etc/http/scripts/JSRootMath.js
+++ b/etc/http/scripts/JSRootMath.js
@@ -638,6 +638,11 @@
    };
 
    /** @memberOf JSROOT.Math */
+   JSROOT.Math.BreitWigner = function(x, mean, gamma) {
+      return gamma/((x-mean)*(x-mean) + gamma*gamma/4) / 2 / Math.PI;
+   }
+
+   /** @memberOf JSROOT.Math */
    JSROOT.Math.gaus = function(f, x, i) {
       // function used when gaus(0) used in the TFormula
       return f.GetParValue(i+0) * Math.exp(-0.5 * Math.pow((x-f.GetParValue(i+1)) / f.GetParValue(i+2), 2));

--- a/etc/http/scripts/JSRootPainter.hist.js
+++ b/etc/http/scripts/JSRootPainter.hist.js
@@ -6431,28 +6431,27 @@
    }
 
    THStackPainter.prototype.GetMinMax = function(iserr, pad) {
-      var res = { min : 0, max : 0 },
+      var res = { min: 0, max: 0 },
           stack = this.GetObject();
 
       if (this.nostack) {
          for (var i = 0; i < stack.fHists.arr.length; ++i) {
             var resh = this.GetHistMinMax(stack.fHists.arr[i], iserr);
-            if (i==0) res = resh; else {
-               if (resh.min < res.min) res.min = resh.min;
-               if (resh.max > res.max) res.max = resh.max;
+            if (i==0) {
+               res = resh;
+             } else {
+               res.min = Math.min(res.min, resh.min);
+               res.max = Math.max(res.max, resh.max);
             }
          }
-
-         if (stack.fMaximum != -1111)
-            res.max = stack.fMaximum;
-         else
-            res.max *= 1.05;
-
-         if (stack.fMinimum != -1111) res.min = stack.fMinimum;
       } else {
          res.min = this.GetHistMinMax(stack.fStack.arr[0], iserr).min;
-         res.max = this.GetHistMinMax(stack.fStack.arr[stack.fStack.arr.length-1], iserr).max * 1.05;
+         res.max = this.GetHistMinMax(stack.fStack.arr[stack.fStack.arr.length-1], iserr).max;
       }
+
+      if (stack.fMaximum != -1111) res.max = stack.fMaximum;
+      res.max *= 1.05;
+      if (stack.fMinimum != -1111) res.min = stack.fMinimum;
 
       if (pad) {
          if (pad.fLogy) {

--- a/etc/http/scripts/JSRootPainter.v7.js
+++ b/etc/http/scripts/JSRootPainter.v7.js
@@ -3316,6 +3316,9 @@
       if (this.iscan && snap.fTitle && document)
          document.title = snap.fTitle;
 
+      if (this.iscan && snap.fTitle && document)
+         document.title = snap.fTitle;
+
       if (this.snapid === undefined) {
          // first time getting snap, create all gui elements first
 

--- a/etc/http/style/JSRootPainter.css
+++ b/etc/http/style/JSRootPainter.css
@@ -426,16 +426,15 @@
 .jsroot .fast_command {
     width: 30px;
     height: 30px;
-    margin-left: 3px;
-    margin-top: 3px;
-    padding: 0px;
+    margin: 2px;
+    padding: 2px;
+    border-width: 2px;
 }
 
 .jsroot .fast_command img {
     max-width: 100%;
     max-height: 100%;
 }
-
 
 /*--------------------------------------------------
   Flexible MDI display

--- a/gui/webgui6/inc/LinkDef.h
+++ b/gui/webgui6/inc/LinkDef.h
@@ -19,7 +19,6 @@
 #pragma link C++ class TWebPadPainter+;
 #pragma link C++ class TWebPS+;
 #pragma link C++ class TWebPainting+;
-#pragma link C++ class TWebPainterAttributes+;
 #pragma link C++ class TWebSnapshot+;
 #pragma link C++ class TPadWebSnapshot+;
 #pragma link C++ class TWebMenuItem+;

--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -36,7 +36,7 @@ class TObjLink;
 class TWebSnapshot;
 class TPadWebSnapshot;
 class THttpServer;
-class TWebCanvas;
+class TWebPS;
 
 /// Class used to transport drawing options from the client
 class TWebObjectOptions {
@@ -125,7 +125,7 @@ protected:
 
    Bool_t AddCanvasSpecials(TPadWebSnapshot *master);
    TString CreateSnapshot(TPad *pad, TPadWebSnapshot *master = nullptr, TList *tempbuf = nullptr);
-   TWebSnapshot *CreateObjectSnapshot(TPad *pad, TObject *obj, const char *opt);
+   TWebSnapshot *CreateObjectSnapshot(TPad *pad, TObject *obj, const char *opt, TWebPS *masterps = nullptr);
 
    TObject *FindPrimitive(const char *id, TPad *pad = nullptr, TObjLink **padlnk = nullptr);
    Bool_t DecodeAllRanges(const char *arg);

--- a/gui/webgui6/inc/TWebPS.h
+++ b/gui/webgui6/inc/TWebPS.h
@@ -27,7 +27,6 @@ class TWebPS : public TVirtualPS {
 
 public:
    TWebPS();
-   virtual ~TWebPS() = default;
 
    Bool_t IsEmptyPainting() const { return fPainting ? fPainting->IsEmpty() : kTRUE; }
    TWebPainting *GetPainting() { return fPainting.get(); }
@@ -57,6 +56,13 @@ public:
    void DrawPS(Int_t n, Double_t *xw, Double_t *yw) override;
    void Text(Double_t x, Double_t y, const char *str) override;
    void Text(Double_t x, Double_t y, const wchar_t *str) override;
+
+private:
+   //Let's make this clear:
+   TWebPS(const TWebPS &rhs) = delete;
+   TWebPS(TWebPS && rhs) = delete;
+   TWebPS & operator = (const TWebPS &rhs) = delete;
+   TWebPS & operator = (TWebPS && rhs) = delete;
 
    ClassDefOverride(TWebPS, 0) // Redirection of VirtualPS to Web painter
 };

--- a/gui/webgui6/inc/TWebPS.h
+++ b/gui/webgui6/inc/TWebPS.h
@@ -17,66 +17,22 @@
 
 #include "TWebPadPainter.h"
 
+#include <memory>
+
 class TWebPS : public TVirtualPS {
 
-   TWebPainting *fPainting{nullptr};      ///!< object to store all painting
+   std::unique_ptr<TWebPainting> fPainting;    ///!< object to store all painting
 
    enum EAttrKinds { attrLine = 0x1, attrFill = 0x2, attrMarker = 0x4, attrText = 0x8 };
 
    Float_t *StoreOperation(const std::string &oper, unsigned attrkind, int opersize = 0);
 
 public:
-   TWebPS() {}
-   virtual ~TWebPS();
+   TWebPS();
+   virtual ~TWebPS() = default;
 
-   TWebPainting *TakePainting();
-   void ResetPainting();
-
-   //Redirect calls to WebPainter
-   //Line attributes.
-/*   Color_t  GetLineColor() const override { return fPainter.GetLineColor(); }
-   Style_t  GetLineStyle() const override { return fPainter.GetLineStyle(); }
-   Width_t  GetLineWidth() const override { return fPainter.GetLineWidth(); }
-
-   void     SetLineColor(Color_t lcolor) override { fPainter.SetLineColor(lcolor); }
-   void     SetLineStyle(Style_t lstyle) override { fPainter.SetLineStyle(lstyle); }
-   void     SetLineWidth(Width_t lwidth) override { fPainter.SetLineWidth(lwidth); }
-
-   //Fill attributes.
-   Color_t  GetFillColor() const override { return fPainter.GetFillColor(); }
-   Style_t  GetFillStyle() const override { return fPainter.GetFillStyle(); }
-   Bool_t   IsTransparent() const override { return fPainter.IsTransparent(); }
-
-   void     SetFillColor(Color_t fcolor)  override { fPainter.SetFillColor(fcolor); }
-   void     SetFillStyle(Style_t fstyle)  override { fPainter.SetFillStyle(fstyle); }
-   void     SetOpacity(Int_t percent) { fPainter.SetOpacity(percent); }
-
-   //Text attributes.
-   Short_t  GetTextAlign() const override { return fPainter.GetTextAlign(); }
-   Float_t  GetTextAngle() const override { return fPainter.GetTextAngle(); }
-   Color_t  GetTextColor() const override { return fPainter.GetTextColor(); }
-   Font_t   GetTextFont()  const override { return fPainter.GetTextFont(); }
-   Float_t  GetTextSize()  const override { return fPainter.GetTextSize(); }
-   Float_t  GetTextMagnitude() const { return fPainter.GetTextMagnitude(); }
-
-   void     SetTextAlign(Short_t align) override { fPainter.SetTextAlign(align); }
-   void     SetTextAngle(Float_t tangle) override { fPainter.SetTextAngle(tangle); }
-   void     SetTextColor(Color_t tcolor) override { fPainter.SetTextColor(tcolor); }
-   void     SetTextFont(Font_t tfont) override { fPainter.SetTextFont(tfont); }
-   void     SetTextSize(Float_t tsize) override { fPainter.SetTextSize(tsize); }
-   void     SetTextSizePixels(Int_t npixels) override { fPainter.SetTextSizePixels(npixels); }
-
-   //MISSING in base class - Marker attributes
-
-   Color_t   GetMarkerColor() const override  { return fPainter.GetMarkerColor(); }
-   Size_t    GetMarkerSize() const override  { return fPainter.GetMarkerSize(); }
-   Style_t   GetMarkerStyle() const override  { return fPainter.GetMarkerStyle(); }
-
-   void      SetMarkerColor(Color_t cindex) override  { fPainter.SetMarkerColor(cindex); }
-   void      SetMarkerSize(Float_t markersize) override  { fPainter.SetMarkerSize(markersize); }
-   void      SetMarkerStyle(Style_t markerstyle) override  { fPainter.SetMarkerStyle(markerstyle); }
-
-*/
+   TWebPainting *GetPainting() { return fPainting.get(); }
+   TWebPainting *TakePainting() { return fPainting.release(); }
 
    /// not yet implemented
 
@@ -88,7 +44,6 @@ public:
    void NewPage() override {}
    void Open(const char *, Int_t = -111) override {}
    void SetColor(Float_t, Float_t, Float_t) override {}
-
 
    // overwritten methods
    void DrawBox(Double_t x1, Double_t y1, Double_t x2, Double_t y2) override;

--- a/gui/webgui6/inc/TWebPS.h
+++ b/gui/webgui6/inc/TWebPS.h
@@ -38,6 +38,7 @@ public:
       fPainting->FixSize();
       return fPainting.release();
    }
+   void CreatePainting();
 
    /// not yet implemented
 

--- a/gui/webgui6/inc/TWebPS.h
+++ b/gui/webgui6/inc/TWebPS.h
@@ -13,17 +13,28 @@
 
 #include "TVirtualPS.h"
 
+#include "TWebPainting.h"
+
 #include "TWebPadPainter.h"
 
 class TWebPS : public TVirtualPS {
-   TWebPadPainter &fPainter;
+
+   TWebPainting *fPainting{nullptr};      ///!< object to store all painting
+
+   enum EAttrKinds { attrLine = 0x1, attrFill = 0x2, attrMarker = 0x4, attrText = 0x8 };
+
+   Float_t *StoreOperation(const std::string &oper, unsigned attrkind, int opersize = 0);
+
 public:
-   TWebPS(TWebPadPainter &p) : fPainter(p) {}
-   virtual ~TWebPS() = default;
+   TWebPS() {}
+   virtual ~TWebPS();
+
+   TWebPainting *TakePainting();
+   void ResetPainting();
 
    //Redirect calls to WebPainter
    //Line attributes.
-   Color_t  GetLineColor() const override { return fPainter.GetLineColor(); }
+/*   Color_t  GetLineColor() const override { return fPainter.GetLineColor(); }
    Style_t  GetLineStyle() const override { return fPainter.GetLineStyle(); }
    Width_t  GetLineWidth() const override { return fPainter.GetLineWidth(); }
 
@@ -65,43 +76,28 @@ public:
    void      SetMarkerSize(Float_t markersize) override  { fPainter.SetMarkerSize(markersize); }
    void      SetMarkerStyle(Style_t markerstyle) override  { fPainter.SetMarkerStyle(markerstyle); }
 
+*/
+
+   /// not yet implemented
+
    void CellArrayBegin(Int_t, Int_t, Double_t, Double_t, Double_t, Double_t) override  {}
    void CellArrayFill(Int_t, Int_t, Int_t)  override {}
    void CellArrayEnd()  override  {}
    void Close(Option_t * = "")  override  {}
    void DrawFrame(Double_t, Double_t, Double_t, Double_t, Int_t, Int_t, Int_t, Int_t) override {}
-
-   void DrawBox(Double_t x1, Double_t y1, Double_t x2, Double_t y2) override
-   {
-      fPainter.DrawBox(x1, y1, x2, y2, fPainter.GetFillStyle() ? TVirtualPadPainter::kFilled : TVirtualPadPainter::kHollow);
-   }
-   void DrawPolyMarker(Int_t n, Float_t *x, Float_t *y) override { fPainter.DrawPolyMarker(n, x, y); }
-   void DrawPolyMarker(Int_t n, Double_t *x, Double_t *y) override { fPainter.DrawPolyMarker(n, x, y); }
-   void DrawPS(Int_t n, Float_t *xw, Float_t *yw) override
-   {
-      if (n == 2)
-         fPainter.DrawLine(xw[0], yw[0], xw[1], yw[1]);
-      else
-         fPainter.DrawPolyLine(n, xw, yw);
-   }
-   void DrawPS(Int_t n, Double_t *xw, Double_t *yw) override
-   {
-      if (n == 2)
-         fPainter.DrawLine(xw[0], yw[0], xw[1], yw[1]);
-      else
-         fPainter.DrawPolyLine(n, xw, yw);
-   }
    void NewPage() override {}
    void Open(const char *, Int_t = -111) override {}
-   void Text(Double_t x, Double_t y, const char *str) override
-   {
-      fPainter.DrawText(x, y, str, TVirtualPadPainter::kClear);
-   }
-   void Text(Double_t x, Double_t y, const wchar_t *str) override
-   {
-      fPainter.DrawText(x, y, str, TVirtualPadPainter::kClear);
-   }
    void SetColor(Float_t, Float_t, Float_t) override {}
+
+
+   // overwritten methods
+   void DrawBox(Double_t x1, Double_t y1, Double_t x2, Double_t y2) override;
+   void DrawPolyMarker(Int_t n, Float_t *x, Float_t *y) override;
+   void DrawPolyMarker(Int_t n, Double_t *x, Double_t *y) override;
+   void DrawPS(Int_t n, Float_t *xw, Float_t *yw) override;
+   void DrawPS(Int_t n, Double_t *xw, Double_t *yw) override;
+   void Text(Double_t x, Double_t y, const char *str) override;
+   void Text(Double_t x, Double_t y, const wchar_t *str) override;
 
    ClassDefOverride(TWebPS, 0) // Redirection of VirtualPS to Web painter
 };

--- a/gui/webgui6/inc/TWebPS.h
+++ b/gui/webgui6/inc/TWebPS.h
@@ -73,7 +73,7 @@ public:
 
    void DrawBox(Double_t x1, Double_t y1, Double_t x2, Double_t y2) override
    {
-      fPainter.DrawBox(x1, y1, x2, y2, TVirtualPadPainter::kHollow);
+      fPainter.DrawBox(x1, y1, x2, y2, fPainter.GetFillStyle() ? TVirtualPadPainter::kFilled : TVirtualPadPainter::kHollow);
    }
    void DrawPolyMarker(Int_t n, Float_t *x, Float_t *y) override { fPainter.DrawPolyMarker(n, x, y); }
    void DrawPolyMarker(Int_t n, Double_t *x, Double_t *y) override { fPainter.DrawPolyMarker(n, x, y); }

--- a/gui/webgui6/inc/TWebPS.h
+++ b/gui/webgui6/inc/TWebPS.h
@@ -31,8 +31,13 @@ public:
    TWebPS();
    virtual ~TWebPS() = default;
 
+   Bool_t IsEmptyPainting() const { return fPainting ? fPainting->IsEmpty() : kTRUE; }
    TWebPainting *GetPainting() { return fPainting.get(); }
-   TWebPainting *TakePainting() { return fPainting.release(); }
+   TWebPainting *TakePainting()
+   {
+      fPainting->FixSize();
+      return fPainting.release();
+   }
 
    /// not yet implemented
 

--- a/gui/webgui6/inc/TWebPS.h
+++ b/gui/webgui6/inc/TWebPS.h
@@ -15,8 +15,6 @@
 
 #include "TWebPainting.h"
 
-#include "TWebPadPainter.h"
-
 #include <memory>
 
 class TWebPS : public TVirtualPS {

--- a/gui/webgui6/inc/TWebPadPainter.h
+++ b/gui/webgui6/inc/TWebPadPainter.h
@@ -44,85 +44,81 @@ protected:
    Float_t *StoreOperation(const std::string &oper, unsigned attrkind, int opersize = 0);
 
 public:
+
    TWebPadPainter() = default;
-   virtual ~TWebPadPainter() = default;
 
    void SetPainting(TWebPainting *p) { fPainting = p; }
 
-
-   //Final overriders for TVirtualPadPainter pure virtual functions.
+   //Final overrides for TVirtualPadPainter pure virtual functions.
    //1. Part, which simply catch attributes.
    //Line attributes.
-   Color_t  GetLineColor() const { return TAttLine::GetLineColor(); }
-   Style_t  GetLineStyle() const { return TAttLine::GetLineStyle(); }
-   Width_t  GetLineWidth() const { return TAttLine::GetLineWidth(); }
+   Color_t  GetLineColor() const override { return TAttLine::GetLineColor(); }
+   Style_t  GetLineStyle() const override { return TAttLine::GetLineStyle(); }
+   Width_t  GetLineWidth() const override { return TAttLine::GetLineWidth(); }
 
-   void     SetLineColor(Color_t lcolor) { TAttLine::SetLineColor(lcolor); }
-   void     SetLineStyle(Style_t lstyle) { TAttLine::SetLineStyle(lstyle); }
-   void     SetLineWidth(Width_t lwidth) { TAttLine::SetLineWidth(lwidth); }
+   void     SetLineColor(Color_t lcolor) override { TAttLine::SetLineColor(lcolor); }
+   void     SetLineStyle(Style_t lstyle) override { TAttLine::SetLineStyle(lstyle); }
+   void     SetLineWidth(Width_t lwidth) override { TAttLine::SetLineWidth(lwidth); }
 
    //Fill attributes.
-   Color_t  GetFillColor() const { return TAttFill::GetFillColor(); }
-   Style_t  GetFillStyle() const { return TAttFill::GetFillStyle(); }
-   Bool_t   IsTransparent() const { return TAttFill::IsTransparent(); }
+   Color_t  GetFillColor() const override { return TAttFill::GetFillColor(); }
+   Style_t  GetFillStyle() const override { return TAttFill::GetFillStyle(); }
+   Bool_t   IsTransparent() const override { return TAttFill::IsTransparent(); }
 
-   void     SetFillColor(Color_t fcolor)  { TAttFill::SetFillColor(fcolor); }
-   void     SetFillStyle(Style_t fstyle) { TAttFill::SetFillStyle(fstyle); }
-   void     SetOpacity(Int_t percent) { TAttFill::SetFillStyle(4000 + percent); }
+   void     SetFillColor(Color_t fcolor) override { TAttFill::SetFillColor(fcolor); }
+   void     SetFillStyle(Style_t fstyle) override { TAttFill::SetFillStyle(fstyle); }
+   void     SetOpacity(Int_t percent) override { TAttFill::SetFillStyle(4000 + percent); }
 
    //Text attributes.
-   Short_t  GetTextAlign() const { return TAttText::GetTextAlign(); }
-   Float_t  GetTextAngle() const { return TAttText::GetTextAngle(); }
-   Color_t  GetTextColor() const { return TAttText::GetTextColor(); }
-   Font_t   GetTextFont()  const { return TAttText::GetTextFont(); }
-   Float_t  GetTextSize()  const { return TAttText::GetTextSize(); }
-   Float_t  GetTextMagnitude() const { return  0; }
+   Short_t  GetTextAlign() const override { return TAttText::GetTextAlign(); }
+   Float_t  GetTextAngle() const override { return TAttText::GetTextAngle(); }
+   Color_t  GetTextColor() const override { return TAttText::GetTextColor(); }
+   Font_t   GetTextFont()  const override { return TAttText::GetTextFont(); }
+   Float_t  GetTextSize()  const override { return TAttText::GetTextSize(); }
+   Float_t  GetTextMagnitude() const override { return  0; }
 
-   void     SetTextAlign(Short_t align) { TAttText::SetTextAlign(align); }
-   void     SetTextAngle(Float_t tangle) { TAttText::SetTextAngle(tangle); }
-   void     SetTextColor(Color_t tcolor) { TAttText::SetTextColor(tcolor); }
-   void     SetTextFont(Font_t tfont) { TAttText::SetTextFont(tfont); }
-   void     SetTextSize(Float_t tsize) { TAttText::SetTextSize(tsize); }
-   void     SetTextSizePixels(Int_t npixels) { TAttText::SetTextSizePixels(npixels); }
+   void     SetTextAlign(Short_t align) override { TAttText::SetTextAlign(align); }
+   void     SetTextAngle(Float_t tangle) override { TAttText::SetTextAngle(tangle); }
+   void     SetTextColor(Color_t tcolor) override { TAttText::SetTextColor(tcolor); }
+   void     SetTextFont(Font_t tfont) override { TAttText::SetTextFont(tfont); }
+   void     SetTextSize(Float_t tsize) override { TAttText::SetTextSize(tsize); }
+   void     SetTextSizePixels(Int_t npixels) override { TAttText::SetTextSizePixels(npixels); }
 
    //2. "Off-screen management" part.
-   Int_t    CreateDrawable(UInt_t, UInt_t) { return -1; }
-   void     ClearDrawable() {}
-   void     CopyDrawable(Int_t, Int_t, Int_t) {}
-   void     DestroyDrawable(Int_t) {}
-   void     SelectDrawable(Int_t) {}
+   Int_t    CreateDrawable(UInt_t, UInt_t) override { return -1; }
+   void     ClearDrawable() override {}
+   void     CopyDrawable(Int_t, Int_t, Int_t) override {}
+   void     DestroyDrawable(Int_t) override {}
+   void     SelectDrawable(Int_t) override {}
    //jpg, png, bmp, gif output.
-   void     SaveImage(TVirtualPad *, const char *, Int_t) const {}
+   void     SaveImage(TVirtualPad *, const char *, Int_t) const override {}
 
 
    //TASImage support (noop for a non-gl pad).
    void     DrawPixels(const unsigned char *pixelData, UInt_t width, UInt_t height,
-                       Int_t dstX, Int_t dstY, Bool_t enableAlphaBlending);
+                       Int_t dstX, Int_t dstY, Bool_t enableAlphaBlending) override;
 
-   void     DrawLine(Double_t x1, Double_t y1, Double_t x2, Double_t y2);
-   void     DrawLineNDC(Double_t u1, Double_t v1, Double_t u2, Double_t v2);
+   void     DrawLine(Double_t x1, Double_t y1, Double_t x2, Double_t y2) override;
+   void     DrawLineNDC(Double_t u1, Double_t v1, Double_t u2, Double_t v2) override;
 
-   void     DrawBox(Double_t x1, Double_t y1, Double_t x2, Double_t y2, EBoxMode mode);
+   void     DrawBox(Double_t x1, Double_t y1, Double_t x2, Double_t y2, EBoxMode mode) override;
    //TPad needs double and float versions.
-   void     DrawFillArea(Int_t n, const Double_t *x, const Double_t *y);
-   void     DrawFillArea(Int_t n, const Float_t *x, const Float_t *y);
+   void     DrawFillArea(Int_t n, const Double_t *x, const Double_t *y) override;
+   void     DrawFillArea(Int_t n, const Float_t *x, const Float_t *y) override;
 
    //TPad needs both double and float versions of DrawPolyLine.
-   void     DrawPolyLine(Int_t n, const Double_t *x, const Double_t *y);
-   void     DrawPolyLine(Int_t n, const Float_t *x, const Float_t *y);
-   void     DrawPolyLineNDC(Int_t n, const Double_t *u, const Double_t *v);
+   void     DrawPolyLine(Int_t n, const Double_t *x, const Double_t *y) override;
+   void     DrawPolyLine(Int_t n, const Float_t *x, const Float_t *y) override;
+   void     DrawPolyLineNDC(Int_t n, const Double_t *u, const Double_t *v) override;
 
    //TPad needs both versions.
-   void     DrawPolyMarker(Int_t n, const Double_t *x, const Double_t *y);
-   void     DrawPolyMarker(Int_t n, const Float_t *x, const Float_t *y);
+   void     DrawPolyMarker(Int_t n, const Double_t *x, const Double_t *y) override;
+   void     DrawPolyMarker(Int_t n, const Float_t *x, const Float_t *y) override;
 
-   void     DrawText(Double_t x, Double_t y, const char *text, ETextMode mode);
-   void     DrawText(Double_t x, Double_t y, const wchar_t *text, ETextMode mode);
-   void     DrawTextNDC(Double_t u, Double_t v, const char *text, ETextMode mode);
-   void     DrawTextNDC(Double_t u, Double_t v, const wchar_t *text, ETextMode mode);
-
-   // reimplementing some direct X11 calls, which are not fetched
-   void     DrawFillArea(Int_t n, TPoint *xy);
+   void     DrawText(Double_t x, Double_t y, const char *text, ETextMode mode) override;
+   void     DrawText(Double_t x, Double_t y, const wchar_t *text, ETextMode mode) override;
+   void     DrawTextNDC(Double_t u, Double_t v, const char *text, ETextMode mode) override;
+   void     DrawTextNDC(Double_t u, Double_t v, const wchar_t *text, ETextMode mode) override;
 
 private:
    //Let's make this clear:
@@ -131,7 +127,7 @@ private:
    TWebPadPainter & operator = (const TWebPadPainter &rhs) = delete;
    TWebPadPainter & operator = (TWebPadPainter && rhs) = delete;
 
-   ClassDef(TWebPadPainter, 0) //Abstract interface for painting in TPad
+   ClassDefOverride(TWebPadPainter, 0) //Abstract interface for painting in TPad
 };
 
 #endif

--- a/gui/webgui6/inc/TWebPadPainter.h
+++ b/gui/webgui6/inc/TWebPadPainter.h
@@ -13,6 +13,11 @@
 
 #include "TVirtualPadPainter.h"
 
+#include "TAttLine.h"
+#include "TAttFill.h"
+#include "TAttText.h"
+#include "TAttMarker.h"
+
 #include "TWebPainting.h"
 
 #include <memory>
@@ -26,91 +31,73 @@ TWebPadPainter tries to support old Paint methods of the ROOT classes.
 Main classes (like histograms or graphs) should be painted on JavaScript side
 */
 
-class TWebPadPainter : public TVirtualPadPainter {
+class TWebPadPainter : public TVirtualPadPainter, public TAttLine, public TAttFill, public TAttText, public TAttMarker {
 
 friend class TWebCanvas;
 
 protected:
 
-   std::unique_ptr<TWebPainterAttributes> fAttr; ///!< current attributes
-   unsigned fAttrChanged{0};              ///!< mask identify which attributes were changed
-   TWebPainting *fPainting{nullptr};      ///!< object to store all painting
-   UInt_t fCw{0}, fCh{0};                 ///!< canvas dimensions, need for back pixel conversion
-   Float_t fKx{1.}, fKy{1.};              ///!< coefficient to recalculate pixel coordinates
+   TWebPainting *fPainting{nullptr};      ///!< object to store all painting, owned by TWebPS object
 
    enum { attrLine = 0x1, attrFill = 0x2, attrMarker = 0x4, attrText = 0x8, attrAll = 0xf };
 
-   TWebPainterAttributes *Attr(unsigned mask = attrAll);
-
-   void StoreOperation(const char* opt, TObject* obj = nullptr, unsigned attrmask = attrAll);
-
-   Float_t *Reserve(Int_t sz);
+   Float_t *StoreOperation(const std::string &oper, unsigned attrkind, int opersize = 0);
 
 public:
    TWebPadPainter() = default;
-   virtual ~TWebPadPainter();
+   virtual ~TWebPadPainter() = default;
 
-   TWebPainting *TakePainting();
-   void ResetPainting();
+   void SetPainting(TWebPainting *p) { fPainting = p; }
 
-   void SetWebCanvasSize(UInt_t w, UInt_t h);
 
    //Final overriders for TVirtualPadPainter pure virtual functions.
-   //1. Part, which simply delegates to TVirtualX.
+   //1. Part, which simply catch attributes.
    //Line attributes.
-   Color_t  GetLineColor() const { return fAttr ? fAttr->GetLineColor() : 0; }
-   Style_t  GetLineStyle() const { return fAttr ? fAttr->GetLineStyle() : 0; }
-   Width_t  GetLineWidth() const { return fAttr ? fAttr->GetLineWidth() : 0; }
+   Color_t  GetLineColor() const { return TAttLine::GetLineColor(); }
+   Style_t  GetLineStyle() const { return TAttLine::GetLineStyle(); }
+   Width_t  GetLineWidth() const { return TAttLine::GetLineWidth(); }
 
-   void     SetLineColor(Color_t lcolor) { if (GetLineColor()!=lcolor) Attr(attrLine)->SetLineColor(lcolor); }
-   void     SetLineStyle(Style_t lstyle) { if (GetLineStyle()!=lstyle) Attr(attrLine)->SetLineStyle(lstyle); }
-   void     SetLineWidth(Width_t lwidth) { if (GetLineWidth()!=lwidth) Attr(attrLine)->SetLineWidth(lwidth); }
+   void     SetLineColor(Color_t lcolor) { TAttLine::SetLineColor(lcolor); }
+   void     SetLineStyle(Style_t lstyle) { TAttLine::SetLineStyle(lstyle); }
+   void     SetLineWidth(Width_t lwidth) { TAttLine::SetLineWidth(lwidth); }
 
    //Fill attributes.
-   Color_t  GetFillColor() const { return fAttr ? fAttr->GetFillColor() : 0; }
-   Style_t  GetFillStyle() const { return fAttr ? fAttr->GetFillStyle() : 0; }
-   Bool_t   IsTransparent() const { return fAttr ? fAttr->IsTransparent() : kFALSE; }
+   Color_t  GetFillColor() const { return TAttFill::GetFillColor(); }
+   Style_t  GetFillStyle() const { return TAttFill::GetFillStyle(); }
+   Bool_t   IsTransparent() const { return TAttFill::IsTransparent(); }
 
-   void     SetFillColor(Color_t fcolor)  { if (GetFillColor()!=fcolor) Attr(attrFill)->SetFillColor(fcolor); }
-   void     SetFillStyle(Style_t fstyle) { if (GetFillStyle()!=fstyle) Attr(attrFill)->SetFillStyle(fstyle); }
-   void     SetOpacity(Int_t percent) { if (GetFillStyle()!=4000+percent) Attr(attrFill)->SetFillStyle(4000 + percent); }
+   void     SetFillColor(Color_t fcolor)  { TAttFill::SetFillColor(fcolor); }
+   void     SetFillStyle(Style_t fstyle) { TAttFill::SetFillStyle(fstyle); }
+   void     SetOpacity(Int_t percent) { TAttFill::SetFillStyle(4000 + percent); }
 
    //Text attributes.
-   Short_t  GetTextAlign() const { return fAttr ? fAttr->GetTextAlign() : 0; }
-   Float_t  GetTextAngle() const { return fAttr ? fAttr->GetTextAngle() : 0; }
-   Color_t  GetTextColor() const { return fAttr ? fAttr->GetTextColor() : 0; }
-   Font_t   GetTextFont()  const { return fAttr ? fAttr->GetTextFont() : 0; }
-   Float_t  GetTextSize()  const { return fAttr ? fAttr->GetTextSize() : 0; }
+   Short_t  GetTextAlign() const { return TAttText::GetTextAlign(); }
+   Float_t  GetTextAngle() const { return TAttText::GetTextAngle(); }
+   Color_t  GetTextColor() const { return TAttText::GetTextColor(); }
+   Font_t   GetTextFont()  const { return TAttText::GetTextFont(); }
+   Float_t  GetTextSize()  const { return TAttText::GetTextSize(); }
    Float_t  GetTextMagnitude() const { return  0; }
 
-   void     SetTextAlign(Short_t align) { if (GetTextAlign()!=align) Attr(attrText)->SetTextAlign(align); }
-   void     SetTextAngle(Float_t tangle) { if (GetTextAngle()!=tangle) Attr(attrText)->SetTextAngle(tangle); }
-   void     SetTextColor(Color_t tcolor) { if (GetTextColor()!=tcolor) Attr(attrText)->SetTextColor(tcolor); }
-   void     SetTextFont(Font_t tfont) { if (GetTextFont()!=tfont) Attr(attrText)->SetTextFont(tfont); }
-   void     SetTextSize(Float_t tsize) { if (GetTextSize()!=tsize) Attr(attrText)->SetTextSize(tsize); }
-   void     SetTextSizePixels(Int_t npixels) { Attr(attrText)->SetTextSizePixels(npixels); }
-
-   //MISSING in base class - Marker attributes
-
-   Color_t   GetMarkerColor() const { return fAttr ? fAttr->GetMarkerColor() : 0; }
-   Size_t    GetMarkerSize() const { return fAttr ? fAttr->GetMarkerSize() : 0; }
-   Style_t   GetMarkerStyle() const { return fAttr ? fAttr->GetMarkerStyle() : 0; }
-
-   void      SetMarkerColor(Color_t cindex) { if (GetMarkerColor()!=cindex) Attr(attrMarker)->SetMarkerColor(cindex); }
-   void      SetMarkerSize(Float_t markersize) { if (GetMarkerSize()!=markersize) Attr(attrMarker)->SetMarkerSize(markersize); }
-   void      SetMarkerStyle(Style_t markerstyle) { if (GetMarkerStyle()!=markerstyle) Attr(attrMarker)->SetMarkerStyle(markerstyle); }
+   void     SetTextAlign(Short_t align) { TAttText::SetTextAlign(align); }
+   void     SetTextAngle(Float_t tangle) { TAttText::SetTextAngle(tangle); }
+   void     SetTextColor(Color_t tcolor) { TAttText::SetTextColor(tcolor); }
+   void     SetTextFont(Font_t tfont) { TAttText::SetTextFont(tfont); }
+   void     SetTextSize(Float_t tsize) { TAttText::SetTextSize(tsize); }
+   void     SetTextSizePixels(Int_t npixels) { TAttText::SetTextSizePixels(npixels); }
 
    //2. "Off-screen management" part.
-   Int_t    CreateDrawable(UInt_t w, UInt_t h);
-   void     ClearDrawable();
-   void     CopyDrawable(Int_t id, Int_t px, Int_t py);
-   void     DestroyDrawable(Int_t device);
-   void     SelectDrawable(Int_t device);
+   Int_t    CreateDrawable(UInt_t, UInt_t) { return -1; }
+   void     ClearDrawable() {}
+   void     CopyDrawable(Int_t, Int_t, Int_t) {}
+   void     DestroyDrawable(Int_t) {}
+   void     SelectDrawable(Int_t) {}
+   //jpg, png, bmp, gif output.
+   void     SaveImage(TVirtualPad *, const char *, Int_t) const {}
+
 
    //TASImage support (noop for a non-gl pad).
    void     DrawPixels(const unsigned char *pixelData, UInt_t width, UInt_t height,
                        Int_t dstX, Int_t dstY, Bool_t enableAlphaBlending);
-
 
    void     DrawLine(Double_t x1, Double_t y1, Double_t x2, Double_t y2);
    void     DrawLineNDC(Double_t u1, Double_t v1, Double_t u2, Double_t v2);
@@ -133,9 +120,6 @@ public:
    void     DrawText(Double_t x, Double_t y, const wchar_t *text, ETextMode mode);
    void     DrawTextNDC(Double_t u, Double_t v, const char *text, ETextMode mode);
    void     DrawTextNDC(Double_t u, Double_t v, const wchar_t *text, ETextMode mode);
-
-   //jpg, png, bmp, gif output.
-   void     SaveImage(TVirtualPad *pad, const char *fileName, Int_t type) const;
 
    // reimplementing some direct X11 calls, which are not fetched
    void     DrawFillArea(Int_t n, TPoint *xy);

--- a/gui/webgui6/inc/TWebPainting.h
+++ b/gui/webgui6/inc/TWebPainting.h
@@ -18,6 +18,9 @@
 #include "TAttMarker.h"
 #include "TArrayF.h"
 
+#include <vector>
+#include <string>
+
 /** Class to store actual drawing attributes */
 class TWebPainterAttributes : public TObject, public TAttFill, public TAttLine, public TAttMarker, public TAttText  {
    public:
@@ -30,16 +33,19 @@ class TWebPainterAttributes : public TObject, public TAttFill, public TAttLine, 
 class TWebPainting : public TObject {
 
    protected:
-      TList   fOper;                /// list of last draw operations
-      Int_t   fSize{0};             ///!< filled buffer size
-      TArrayF fBuf;                 /// array of points for all operations
+      std::vector<std::string> fOper; /// list of operations
+      Int_t fSize{0};                 ///<! filled buffer size
+      TArrayF fBuf;                   /// array of points for all operations
 
    public:
 
-      TWebPainting()  { fOper.SetOwner(kTRUE); }
-      virtual ~TWebPainting() { fOper.Delete(); }
+      TWebPainting()  {  }
+      virtual ~TWebPainting() {  }
 
-      void Add(TObject *obj, const char *opt) { fOper.Add(obj, opt); }
+      void Add(TObject *, const char *) { }
+
+      void AddOper(const std::string &oper) { fOper.emplace_back(oper); }
+
       Float_t *Reserve(Int_t sz);
 
       // Set actual filled size

--- a/gui/webgui6/inc/TWebPainting.h
+++ b/gui/webgui6/inc/TWebPainting.h
@@ -35,7 +35,7 @@ class TWebPainting : public TObject {
       TWebPainting()  {}
       virtual ~TWebPainting() {}
 
-      void Add(TObject *, const char *) { }
+      Bool_t IsEmpty() const { return (fOper.size() == 0) && (fBuf.GetSize() == 0); }
 
       void AddOper(const std::string &oper) { fOper.emplace_back(oper); }
 

--- a/gui/webgui6/inc/TWebPainting.h
+++ b/gui/webgui6/inc/TWebPainting.h
@@ -17,6 +17,7 @@
 #include "TAttText.h"
 #include "TAttMarker.h"
 #include "TArrayF.h"
+#include "TColor.h"
 
 #include <vector>
 #include <string>
@@ -44,6 +45,8 @@ class TWebPainting : public TObject {
       void AddMarkerAttr(const TAttMarker &attr);
 
       Float_t *Reserve(Int_t sz);
+
+      void AddColor(TColor *col, Bool_t onlyindx = kFALSE);
 
       // Set actual filled size
       void FixSize() { fBuf.Set(fSize); }

--- a/gui/webgui6/inc/TWebPainting.h
+++ b/gui/webgui6/inc/TWebPainting.h
@@ -30,10 +30,14 @@ class TWebPainting : public TObject {
       Int_t fSize{0};                 ///<! filled buffer size
       TArrayF fBuf;                   /// array of points for all operations
 
+      TAttLine fLastLine;             ///<! last line attributes
+      TAttFill fLastFill;             ///<! last fill attributes
+      TAttMarker fLastMarker;         ///<! last marker attributes
+
    public:
 
-      TWebPainting()  {}
-      virtual ~TWebPainting() {}
+      TWebPainting();
+      virtual ~TWebPainting() = default;
 
       Bool_t IsEmpty() const { return (fOper.size() == 0) && (fBuf.GetSize() == 0); }
 

--- a/gui/webgui6/inc/TWebPainting.h
+++ b/gui/webgui6/inc/TWebPainting.h
@@ -21,14 +21,6 @@
 #include <vector>
 #include <string>
 
-/** Class to store actual drawing attributes */
-class TWebPainterAttributes : public TObject, public TAttFill, public TAttLine, public TAttMarker, public TAttText  {
-   public:
-      virtual ~TWebPainterAttributes() = default;
-
-      ClassDef(TWebPainterAttributes,1) // different draw attributes used by the painter
-};
-
 /** Object used to store paint operations and deliver them to JSROOT */
 class TWebPainting : public TObject {
 
@@ -39,12 +31,17 @@ class TWebPainting : public TObject {
 
    public:
 
-      TWebPainting()  {  }
-      virtual ~TWebPainting() {  }
+      TWebPainting()  {}
+      virtual ~TWebPainting() {}
 
       void Add(TObject *, const char *) { }
 
       void AddOper(const std::string &oper) { fOper.emplace_back(oper); }
+
+      void AddLineAttr(const TAttLine &attr);
+      void AddFillAttr(const TAttFill &attr);
+      void AddTextAttr(const TAttText &attr);
+      void AddMarkerAttr(const TAttMarker &attr);
 
       Float_t *Reserve(Int_t sz);
 

--- a/gui/webgui6/inc/TWebPainting.h
+++ b/gui/webgui6/inc/TWebPainting.h
@@ -46,7 +46,7 @@ class TWebPainting : public TObject {
 
       Float_t *Reserve(Int_t sz);
 
-      void AddColor(TColor *col, Bool_t onlyindx = kFALSE);
+      void AddColor(Int_t indx, TColor *col);
 
       // Set actual filled size
       void FixSize() { fBuf.Set(fSize); }

--- a/gui/webgui6/inc/TWebSnapshot.h
+++ b/gui/webgui6/inc/TWebSnapshot.h
@@ -21,19 +21,19 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "TObject.h"
-#include "TString.h"
 
 #include <vector>
+#include <memory>
+#include <string>
 
 class TWebSnapshot : public TObject {
 
 protected:
-
-   TString    fObjectID;            ///<   object identifier
-   TString    fOption;              ///<   object draw option
-   Int_t      fKind{0};             ///<   kind of snapshots
-   TObject   *fSnapshot{nullptr};   ///<   snapshot data
-   Bool_t     fOwner{kFALSE};       ///<!  if objected owned
+   std::string fObjectID;       ///<   object identifier
+   std::string fOption;         ///<   object draw option
+   Int_t fKind{0};              ///<   kind of snapshots
+   TObject *fSnapshot{nullptr}; ///<   snapshot data
+   Bool_t fOwner{kFALSE};       ///<!  if objected owned
 
    void SetKind(Int_t kind) { fKind = kind; }
 
@@ -49,15 +49,15 @@ public:
 
    virtual ~TWebSnapshot();
 
-   void SetObjectIDAsPtr(void* ptr);
-   void SetObjectID(const char* id) { fObjectID = id; }
-   const char* GetObjectID() const { return fObjectID.Data(); }
+   void SetObjectIDAsPtr(void *ptr);
+   void SetObjectID(const std::string &id) { fObjectID = id; }
+   const char* GetObjectID() const { return fObjectID.c_str(); }
 
-   void SetOption(const char* opt) { fOption = opt; }
+   void SetOption(const std::string &opt) { fOption = opt; }
 
-   void SetSnapshot(Int_t kind, TObject* shot, Bool_t owner = kFALSE);
+   void SetSnapshot(Int_t kind, TObject *snapshot, Bool_t owner = kFALSE);
    Int_t GetKind() const { return fKind; }
-   TObject* GetSnapshot() const { return fSnapshot; }
+   TObject *GetSnapshot() const { return fSnapshot; }
 
    ClassDef(TWebSnapshot,1)  // Object painting snapshot, used for JSROOT
 };
@@ -67,14 +67,14 @@ public:
 class TPadWebSnapshot : public TWebSnapshot {
 protected:
    bool fActive{false};                      ///< true when pad is active
-   std::vector<TWebSnapshot*> fPrimitives;   ///< list of all primitives, drawn in the pad
+   std::vector<std::unique_ptr<TWebSnapshot>> fPrimitives;   ///< list of all primitives, drawn in the pad
 public:
    TPadWebSnapshot() { SetKind(kSubPad); }
-   virtual ~TPadWebSnapshot();
 
    void SetActive(bool on = true) { fActive = on; }
-   void Add(TWebSnapshot *snap) { fPrimitives.push_back(snap); }
+   void Add(TWebSnapshot *snap) { fPrimitives.emplace_back(snap); }
 
    ClassDef(TPadWebSnapshot,1)  // Pad painting snapshot, used for JSROOT
 };
+
 #endif

--- a/gui/webgui6/inc/TWebSnapshot.h
+++ b/gui/webgui6/inc/TWebSnapshot.h
@@ -44,8 +44,7 @@ public:
      kObject = 1,      // object itself
      kSVG = 2,         // list of SVG primitives
      kSubPad = 3,      // subpad
-     kColors = 4,      // list of ROOT colors
-     kPalette = 5      // current color palette
+     kColors = 4       // list of ROOT colors + palette
    };
 
    virtual ~TWebSnapshot();

--- a/gui/webgui6/inc/TWebSnapshot.h
+++ b/gui/webgui6/inc/TWebSnapshot.h
@@ -32,7 +32,7 @@ protected:
    TString    fObjectID;            ///<   object identifier
    TString    fOption;              ///<   object draw option
    Int_t      fKind{0};             ///<   kind of snapshots
-   TObject*   fSnapshot{nullptr};   ///<   snapshot data
+   TObject   *fSnapshot{nullptr};   ///<   snapshot data
    Bool_t     fOwner{kFALSE};       ///<!  if objected owned
 
    void SetKind(Int_t kind) { fKind = kind; }
@@ -40,11 +40,12 @@ protected:
 public:
 
    enum {
-     kNone = 0,         // dummy
-     kObject = 1,       // object itself
-     kSVG = 2,          // list of SVG primitives
-     kSubPad = 3,       // subpad
-     kSpecial = 4       // special object like list of colors or palette
+     kNone = 0,        // dummy
+     kObject = 1,      // object itself
+     kSVG = 2,         // list of SVG primitives
+     kSubPad = 3,      // subpad
+     kColors = 4,      // list of ROOT colors
+     kPalette = 5      // current color palette
    };
 
    virtual ~TWebSnapshot();

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -183,9 +183,6 @@ TWebSnapshot *TWebCanvas::CreateObjectSnapshot(TPad *pad, TObject *obj, const ch
          TView *view = nullptr;
          TVirtualPad *savepad = gPad;
 
-         painter->ResetPainting();                                        // ensure painter is created
-         painter->SetWebCanvasSize(Canvas()->GetWw(), Canvas()->GetWh()); // provide canvas dimension
-
          pad->cd();
 
          if (obj->InheritsFrom(TAtt3D::Class())) {
@@ -200,6 +197,8 @@ TWebSnapshot *TWebCanvas::CreateObjectSnapshot(TPad *pad, TObject *obj, const ch
          TVirtualPS *saveps = gVirtualPS;
          TWebPS ps;
          gVirtualPS = &ps;
+         painter->SetPainting(ps.GetPainting());
+
 
          // calling Paint function for the object
          obj->Paint(opt);
@@ -211,6 +210,7 @@ TWebSnapshot *TWebCanvas::CreateObjectSnapshot(TPad *pad, TObject *obj, const ch
             pad->SetView(nullptr);
          }
 
+         painter->SetPainting(nullptr);
          p = ps.TakePainting();
          gVirtualPS = saveps;
 

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -198,7 +198,8 @@ TWebSnapshot *TWebCanvas::CreateObjectSnapshot(TPad *pad, TObject *obj, const ch
          }
 
          TVirtualPS *saveps = gVirtualPS;
-         gVirtualPS = new TWebPS(*painter);
+         TWebPS ps;
+         gVirtualPS = &ps;
 
          // calling Paint function for the object
          obj->Paint(opt);
@@ -210,10 +211,8 @@ TWebSnapshot *TWebCanvas::CreateObjectSnapshot(TPad *pad, TObject *obj, const ch
             pad->SetView(nullptr);
          }
 
-         delete gVirtualPS;
+         p = ps.TakePainting();
          gVirtualPS = saveps;
-
-         p = painter->TakePainting();
 
          fHasSpecials = kTRUE;
 
@@ -356,8 +355,8 @@ TString TWebCanvas::CreateSnapshot(TPad *pad, TPadWebSnapshot *master, TList *pr
 
    TString res = TBufferJSON::ConvertToJSON(curr, 23);
 
-   // static int filecnt = 0;
-   // TBufferJSON::ExportToFile(TString::Format("snapshot_%d.json", (filecnt++) % 10).Data(), curr);
+   static int filecnt = 0;
+   TBufferJSON::ExportToFile(TString::Format("snapshot_%d.json", (filecnt++) % 10).Data(), curr);
 
    delete curr; // destroy created snapshot
 

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -78,8 +78,8 @@ Bool_t TWebCanvas::IsJSSupportedClass(TObject *obj)
                             {"TGaxis", false},
                             {"TPave", true},
                             {"TArrow", false},
-                            {"TBox", false},  // in principle, can be handled via TWebPainter
-                            {"TWbox", false}, // some extra calls which cannout be handled via TWebPainter
+//                            {"TBox", false},  // in principle, can be handled via TWebPainter
+                            {"TWbox", false}, // some extra calls which cannot be handled via TWebPainter
                             {"TLine", false}, // also can be handler via TWebPainter
                             {"TText", false},
                             {"TLatex", false},
@@ -87,15 +87,15 @@ Bool_t TWebCanvas::IsJSSupportedClass(TObject *obj)
                             {"TMarker", false},
                             {"TPolyMarker3D", false},
                             {"TGraph2D", false},
-                            {0, false}};
+                            {nullptr, false}};
 
    // fast check of class name
-   for (int i = 0; supported_classes[i].name != 0; ++i)
+   for (int i = 0; supported_classes[i].name != nullptr; ++i)
       if (strcmp(supported_classes[i].name, obj->ClassName()) == 0)
          return kTRUE;
 
    // now check inheritance only for configured classes
-   for (int i = 0; supported_classes[i].name != 0; ++i)
+   for (int i = 0; supported_classes[i].name != nullptr; ++i)
       if (supported_classes[i].with_derived)
          if (obj->InheritsFrom(supported_classes[i].name))
             return kTRUE;
@@ -182,7 +182,6 @@ TWebSnapshot *TWebCanvas::CreateObjectSnapshot(TPad *pad, TObject *obj, const ch
       } else {
          TView *view = nullptr;
          TVirtualPad *savepad = gPad;
-         TVirtualPS *saveps = gVirtualPS;
 
          painter->ResetPainting();                                        // ensure painter is created
          painter->SetWebCanvasSize(Canvas()->GetWw(), Canvas()->GetWh()); // provide canvas dimension
@@ -196,9 +195,10 @@ TWebSnapshot *TWebCanvas::CreateObjectSnapshot(TPad *pad, TObject *obj, const ch
 
             // Set view to perform first auto-range (scaling) pass
             view->SetAutoRange(kTRUE);
-
-            gVirtualPS = new TWebPS(*painter);
          }
+
+         TVirtualPS *saveps = gVirtualPS;
+         gVirtualPS = new TWebPS(*painter);
 
          // calling Paint function for the object
          obj->Paint(opt);
@@ -208,9 +208,10 @@ TWebSnapshot *TWebCanvas::CreateObjectSnapshot(TPad *pad, TObject *obj, const ch
             // call 3D paint once again to make real drawing
             obj->Paint(opt);
             pad->SetView(nullptr);
-            delete gVirtualPS;
-            gVirtualPS = saveps;
          }
+
+         delete gVirtualPS;
+         gVirtualPS = saveps;
 
          p = painter->TakePainting();
 
@@ -355,7 +356,6 @@ TString TWebCanvas::CreateSnapshot(TPad *pad, TPadWebSnapshot *master, TList *pr
 
    TString res = TBufferJSON::ConvertToJSON(curr, 23);
 
-   // TODO: this is only for debugging, remove it later
    // static int filecnt = 0;
    // TBufferJSON::ExportToFile(TString::Format("snapshot_%d.json", (filecnt++) % 10).Data(), curr);
 

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -237,42 +237,40 @@ TWebSnapshot *TWebCanvas::CreateObjectSnapshot(TPad *pad, TObject *obj, const ch
 
 Bool_t TWebCanvas::AddCanvasSpecials(TPadWebSnapshot *master)
 {
-   // if (!TColor::DefinedColors()) return 0;
+   if (!TColor::DefinedColors()) return kFALSE;
+
    TObjArray *colors = (TObjArray *)gROOT->GetListOfColors();
 
    if (!colors)
       return kFALSE;
-   Int_t cnt = 0;
+
+/*   Int_t cnt = 0;
    for (Int_t n = 0; n <= colors->GetLast(); ++n)
       if (colors->At(n) != nullptr)
          cnt++;
    if (cnt <= 598)
       return kFALSE; // normally there are 598 colors defined
+*/
 
    TWebSnapshot *sub = new TWebSnapshot();
    TWebPainting *listofcols = new TWebPainting;
    for (Int_t n = 0; n <= colors->GetLast(); ++n)
-      if (colors->At(n) != nullptr)
-         listofcols->AddColor((TColor *)colors->At(n));
+      if (colors->At(n))
+         listofcols->AddColor(n, (TColor *)colors->At(n));
    listofcols->FixSize();
 
-   sub->SetSnapshot(TWebSnapshot::kSpecial, listofcols, kTRUE);
+   sub->SetSnapshot(TWebSnapshot::kColors, listofcols, kTRUE);
    master->Add(sub);
-
-   if (gDebug > 1)
-      Info("AddCanvasSpecials", "ADD COLORS TABLES %d", cnt);
 
    // save the current palette
    TArrayI pal = TColor::GetPalette();
-   Int_t palsize = pal.GetSize();
-
    TWebPainting *palette = new TWebPainting;
-   for (Int_t i = 0; i < palsize; i++)
-      palette->AddColor(gROOT->GetColor(pal[i]), kTRUE);
+   for (Int_t i = 0; i < pal.GetSize(); i++)
+      palette->AddColor(-1, gROOT->GetColor(pal[i]));
    palette->FixSize();
 
    sub = new TWebSnapshot();
-   sub->SetSnapshot(TWebSnapshot::kSpecial, palette, kTRUE);
+   sub->SetSnapshot(TWebSnapshot::kPalette, palette, kTRUE);
    master->Add(sub);
 
    return kTRUE;

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -250,7 +250,13 @@ Bool_t TWebCanvas::AddCanvasSpecials(TPadWebSnapshot *master)
       return kFALSE; // normally there are 598 colors defined
 
    TWebSnapshot *sub = new TWebSnapshot();
-   sub->SetSnapshot(TWebSnapshot::kSpecial, colors);
+   TWebPainting *listofcols = new TWebPainting;
+   for (Int_t n = 0; n <= colors->GetLast(); ++n)
+      if (colors->At(n) != nullptr)
+         listofcols->AddColor((TColor *)colors->At(n));
+   listofcols->FixSize();
+
+   sub->SetSnapshot(TWebSnapshot::kSpecial, listofcols, kTRUE);
    master->Add(sub);
 
    if (gDebug > 1)
@@ -259,13 +265,14 @@ Bool_t TWebCanvas::AddCanvasSpecials(TPadWebSnapshot *master)
    // save the current palette
    TArrayI pal = TColor::GetPalette();
    Int_t palsize = pal.GetSize();
-   TObjArray *CurrentColorPalette = new TObjArray();
-   CurrentColorPalette->SetName("CurrentColorPalette");
+
+   TWebPainting *palette = new TWebPainting;
    for (Int_t i = 0; i < palsize; i++)
-      CurrentColorPalette->Add(gROOT->GetColor(pal[i]));
+      palette->AddColor(gROOT->GetColor(pal[i]), kTRUE);
+   palette->FixSize();
 
    sub = new TWebSnapshot();
-   sub->SetSnapshot(TWebSnapshot::kSpecial, CurrentColorPalette, kTRUE);
+   sub->SetSnapshot(TWebSnapshot::kSpecial, palette, kTRUE);
    master->Add(sub);
 
    return kTRUE;
@@ -355,8 +362,8 @@ TString TWebCanvas::CreateSnapshot(TPad *pad, TPadWebSnapshot *master, TList *pr
 
    TString res = TBufferJSON::ConvertToJSON(curr, 23);
 
-   static int filecnt = 0;
-   TBufferJSON::ExportToFile(TString::Format("snapshot_%d.json", (filecnt++) % 10).Data(), curr);
+   // static int filecnt = 0;
+   // TBufferJSON::ExportToFile(TString::Format("snapshot_%d.json", (filecnt++) % 10).Data(), curr);
 
    delete curr; // destroy created snapshot
 

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -252,25 +252,21 @@ Bool_t TWebCanvas::AddCanvasSpecials(TPadWebSnapshot *master)
       return kFALSE; // normally there are 598 colors defined
 */
 
+   TArrayI pal = TColor::GetPalette();
+
    TWebSnapshot *sub = new TWebSnapshot();
    TWebPainting *listofcols = new TWebPainting;
    for (Int_t n = 0; n <= colors->GetLast(); ++n)
       if (colors->At(n))
          listofcols->AddColor(n, (TColor *)colors->At(n));
+
+   // store palette in the buffer
+   Float_t *tgt = listofcols->Reserve(pal.GetSize());
+   for (Int_t i = 0; i < pal.GetSize(); i++)
+      tgt[i] = pal[i];
    listofcols->FixSize();
 
    sub->SetSnapshot(TWebSnapshot::kColors, listofcols, kTRUE);
-   master->Add(sub);
-
-   // save the current palette
-   TArrayI pal = TColor::GetPalette();
-   TWebPainting *palette = new TWebPainting;
-   for (Int_t i = 0; i < pal.GetSize(); i++)
-      palette->AddColor(-1, gROOT->GetColor(pal[i]));
-   palette->FixSize();
-
-   sub = new TWebSnapshot();
-   sub->SetSnapshot(TWebSnapshot::kPalette, palette, kTRUE);
    master->Add(sub);
 
    return kTRUE;

--- a/gui/webgui6/src/TWebPS.cxx
+++ b/gui/webgui6/src/TWebPS.cxx
@@ -14,7 +14,7 @@
 
 TWebPS::TWebPS()
 {
-   fPainting = std::make_unique<TWebPainting>();
+   CreatePainting();
 }
 
 void TWebPS::CreatePainting()

--- a/gui/webgui6/src/TWebPS.cxx
+++ b/gui/webgui6/src/TWebPS.cxx
@@ -17,6 +17,12 @@ TWebPS::TWebPS()
    fPainting = std::make_unique<TWebPainting>();
 }
 
+void TWebPS::CreatePainting()
+{
+   fPainting = std::make_unique<TWebPainting>();
+}
+
+
 Float_t *TWebPS::StoreOperation(const std::string &oper, unsigned attrkind, int opersize)
 {
    if (attrkind & attrLine)

--- a/gui/webgui6/src/TWebPS.cxx
+++ b/gui/webgui6/src/TWebPS.cxx
@@ -9,3 +9,139 @@
  *************************************************************************/
 
 #include "TWebPS.h"
+
+TWebPS::~TWebPS()
+{
+   ResetPainting();
+}
+
+TWebPainting *TWebPS::TakePainting()
+{
+   TWebPainting *res = fPainting;
+   fPainting = nullptr;
+   return res;
+}
+
+void TWebPS::ResetPainting()
+{
+   if (fPainting) delete fPainting;
+   fPainting = nullptr;
+}
+
+
+Float_t *TWebPS::StoreOperation(const std::string &oper, unsigned attrkind, int opersize)
+{
+   if (!fPainting) fPainting = new TWebPainting();
+
+   if (attrkind & attrLine)
+      fPainting->AddOper(std::string("lattr:") +
+                         std::to_string((int)GetLineColor()) + ":" +
+                         std::to_string((int)GetLineStyle()) + ":" +
+                         std::to_string((int)GetLineWidth()));
+
+   if (attrkind & attrFill)
+      fPainting->AddOper(std::string("fattr:") +
+                         std::to_string((int)GetFillColor()) + ":" +
+                         std::to_string((int)GetFillStyle()));
+
+   if (attrkind & attrMarker)
+      fPainting->AddOper(std::string("mattr:") +
+                         std::to_string((int)GetMarkerColor()) + ":" +
+                         std::to_string((int)GetMarkerStyle()) + ":" +
+                         std::to_string((int)GetMarkerSize()));
+
+   if (attrkind & attrText)
+      fPainting->AddOper(std::string("tattr:") +
+                         std::to_string((int)GetTextColor()) + ":" +
+                         std::to_string((int)GetTextFont()) + ":" +
+                         std::to_string((int)(GetTextSize()>=1 ? GetTextSize() : -1000*GetTextSize())) + ":" +
+                         std::to_string((int)GetTextAlign()) + ":" +
+                         std::to_string((int)GetTextAngle()));
+
+   fPainting->AddOper(oper);
+
+   return fPainting->Reserve(opersize);
+}
+
+void TWebPS::DrawBox(Double_t x1, Double_t y1, Double_t x2, Double_t y2)
+{
+   Float_t *buf = (GetFillStyle() > 0) ? StoreOperation("bbox", attrFill, 4) : StoreOperation("rect", attrLine, 4);
+
+   buf[0] = x1;
+   buf[1] = y1;
+   buf[2] = x2;
+   buf[3] = y2;
+}
+
+void TWebPS::DrawPolyMarker(Int_t nPoints, Float_t *x, Float_t *y)
+{
+   if (nPoints < 1) return;
+
+   Float_t *buf = StoreOperation(std::string("pmark:") + std::to_string(nPoints), attrLine | attrMarker, nPoints*2);
+
+   for (Int_t n=0;n<nPoints;++n) {
+      buf[n*2] = x[n];
+      buf[n*2+1] = y[n];
+   }
+}
+
+void TWebPS::DrawPolyMarker(Int_t nPoints, Double_t *x, Double_t *y)
+{
+   if (nPoints < 1) return;
+
+   Float_t *buf = StoreOperation(std::string("pmark:") + std::to_string(nPoints), attrLine | attrMarker, nPoints*2);
+
+   for (Int_t n=0;n<nPoints;++n) {
+      buf[n*2] = x[n];
+      buf[n*2+1] = y[n];
+   }
+}
+
+void TWebPS::DrawPS(Int_t nPoints, Float_t *xw, Float_t *yw)
+{
+   Float_t *buf = nullptr;
+   if (nPoints < 0) {
+      nPoints = -nPoints;
+      if ((GetFillStyle() <= 0) || (nPoints < 2))  return;
+      buf = StoreOperation("pfill:" + std::to_string(nPoints), attrFill, nPoints*2);
+   } else {
+      if ((GetLineWidth() <= 0) || (nPoints < 2))  return;
+      buf = StoreOperation("pline:" + std::to_string(nPoints), attrLine, nPoints*2);
+   }
+   for (Int_t n=0;n<nPoints;++n) {
+      buf[n*2] = xw[n];
+      buf[n*2+1] = yw[n];
+   }
+}
+
+void TWebPS::DrawPS(Int_t nPoints, Double_t *xw, Double_t *yw)
+{
+   Float_t *buf = nullptr;
+   if (nPoints < 0) {
+      nPoints = -nPoints;
+      if ((GetFillStyle() <= 0) || (nPoints < 2))  return;
+      buf = StoreOperation("pfill:" + std::to_string(nPoints), attrFill, nPoints*2);
+   } else {
+      if ((GetLineWidth() <= 0) || (nPoints < 2))  return;
+      buf = StoreOperation("pline:" + std::to_string(nPoints), attrLine, nPoints*2);
+   }
+   for (Int_t n=0;n<nPoints;++n) {
+      buf[n*2] = xw[n];
+      buf[n*2+1] = yw[n];
+   }
+}
+
+void TWebPS::Text(Double_t x, Double_t y, const char *str)
+{
+   Float_t *buf = StoreOperation(std::string("text:") + str, attrText, 2);
+   buf[0] = x;
+   buf[1] = y;
+}
+
+
+void TWebPS::Text(Double_t x, Double_t y, const wchar_t *)
+{
+   Float_t *buf = StoreOperation(std::string("text:") + "wchar_t", attrText, 2);
+   buf[0] = x;
+   buf[1] = y;
+}

--- a/gui/webgui6/src/TWebPS.cxx
+++ b/gui/webgui6/src/TWebPS.cxx
@@ -10,53 +10,26 @@
 
 #include "TWebPS.h"
 
-TWebPS::~TWebPS()
-{
-   ResetPainting();
-}
+#include <ROOT/RMakeUnique.hxx>
 
-TWebPainting *TWebPS::TakePainting()
+TWebPS::TWebPS()
 {
-   TWebPainting *res = fPainting;
-   fPainting = nullptr;
-   return res;
+   fPainting = std::make_unique<TWebPainting>();
 }
-
-void TWebPS::ResetPainting()
-{
-   if (fPainting) delete fPainting;
-   fPainting = nullptr;
-}
-
 
 Float_t *TWebPS::StoreOperation(const std::string &oper, unsigned attrkind, int opersize)
 {
-   if (!fPainting) fPainting = new TWebPainting();
-
    if (attrkind & attrLine)
-      fPainting->AddOper(std::string("lattr:") +
-                         std::to_string((int)GetLineColor()) + ":" +
-                         std::to_string((int)GetLineStyle()) + ":" +
-                         std::to_string((int)GetLineWidth()));
+      fPainting->AddLineAttr(*this);
 
    if (attrkind & attrFill)
-      fPainting->AddOper(std::string("fattr:") +
-                         std::to_string((int)GetFillColor()) + ":" +
-                         std::to_string((int)GetFillStyle()));
+      fPainting->AddFillAttr(*this);
 
    if (attrkind & attrMarker)
-      fPainting->AddOper(std::string("mattr:") +
-                         std::to_string((int)GetMarkerColor()) + ":" +
-                         std::to_string((int)GetMarkerStyle()) + ":" +
-                         std::to_string((int)GetMarkerSize()));
+      fPainting->AddMarkerAttr(*this);
 
    if (attrkind & attrText)
-      fPainting->AddOper(std::string("tattr:") +
-                         std::to_string((int)GetTextColor()) + ":" +
-                         std::to_string((int)GetTextFont()) + ":" +
-                         std::to_string((int)(GetTextSize()>=1 ? GetTextSize() : -1000*GetTextSize())) + ":" +
-                         std::to_string((int)GetTextAlign()) + ":" +
-                         std::to_string((int)GetTextAngle()));
+      fPainting->AddTextAttr(*this);
 
    fPainting->AddOper(oper);
 
@@ -102,7 +75,7 @@ void TWebPS::DrawPS(Int_t nPoints, Float_t *xw, Float_t *yw)
    Float_t *buf = nullptr;
    if (nPoints < 0) {
       nPoints = -nPoints;
-      if ((GetFillStyle() <= 0) || (nPoints < 2))  return;
+      if ((GetFillStyle() <= 0) || (nPoints < 3))  return;
       buf = StoreOperation("pfill:" + std::to_string(nPoints), attrFill, nPoints*2);
    } else {
       if ((GetLineWidth() <= 0) || (nPoints < 2))  return;
@@ -119,7 +92,7 @@ void TWebPS::DrawPS(Int_t nPoints, Double_t *xw, Double_t *yw)
    Float_t *buf = nullptr;
    if (nPoints < 0) {
       nPoints = -nPoints;
-      if ((GetFillStyle() <= 0) || (nPoints < 2))  return;
+      if ((GetFillStyle() <= 0) || (nPoints < 3))  return;
       buf = StoreOperation("pfill:" + std::to_string(nPoints), attrFill, nPoints*2);
    } else {
       if ((GetLineWidth() <= 0) || (nPoints < 2))  return;

--- a/gui/webgui6/src/TWebPadPainter.cxx
+++ b/gui/webgui6/src/TWebPadPainter.cxx
@@ -10,8 +10,6 @@
 
 #include "TWebPadPainter.h"
 #include "TCanvas.h"
-#include "TObjString.h"
-#include "TPoint.h"
 #include "TError.h"
 #include "TImage.h"
 #include "TROOT.h"
@@ -67,7 +65,8 @@ void TWebPadPainter::DrawPixels(const unsigned char * /*pixelData*/, UInt_t /*wi
 
 void TWebPadPainter::DrawLine(Double_t x1, Double_t y1, Double_t x2, Double_t y2)
 {
-   if (GetLineWidth()<=0) return;
+   if (GetLineWidth() <= 0)
+      return;
 
    auto buf = StoreOperation("pline:2", attrLine, 4);
    if (buf) {
@@ -85,6 +84,7 @@ void TWebPadPainter::DrawLine(Double_t x1, Double_t y1, Double_t x2, Double_t y2
 void TWebPadPainter::DrawLineNDC(Double_t u1, Double_t v1, Double_t u2, Double_t v2)
 {
    if (GetLineWidth()<=0) return;
+
    ::Error("DrawLineNDC", "Not supported correctly");
 
    auto buf = StoreOperation("pline:2", attrLine, 4);
@@ -124,27 +124,30 @@ void TWebPadPainter::DrawBox(Double_t x1, Double_t y1, Double_t x2, Double_t y2,
 
 void TWebPadPainter::DrawFillArea(Int_t nPoints, const Double_t *xs, const Double_t *ys)
 {
-   if ((GetFillStyle() <= 0) || (nPoints < 3))  return;
-   auto buf = StoreOperation("pfill:" + std::to_string(nPoints), attrFill, nPoints*2);
+   if ((GetFillStyle() <= 0) || (nPoints < 3))
+      return;
+
+   auto buf = StoreOperation("pfill:" + std::to_string(nPoints), attrFill, nPoints * 2);
    if (buf)
-      for (Int_t n=0;n<nPoints;++n) {
-         buf[n*2] = xs[n];
-         buf[n*2+1] = ys[n];
+      for (Int_t n = 0; n < nPoints; ++n) {
+         buf[n * 2] = xs[n];
+         buf[n * 2 + 1] = ys[n];
       }
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Paint filled area.
 
 void TWebPadPainter::DrawFillArea(Int_t nPoints, const Float_t *xs, const Float_t *ys)
 {
-   if ((GetFillStyle() <= 0) || (nPoints < 3))  return;
-   auto buf = StoreOperation("pfill:" + std::to_string(nPoints), attrFill, nPoints*2);
+   if ((GetFillStyle() <= 0) || (nPoints < 3))
+      return;
+
+   auto buf = StoreOperation("pfill:" + std::to_string(nPoints), attrFill, nPoints * 2);
    if (buf)
-      for (Int_t n=0;n<nPoints;++n) {
-         buf[n*2] = xs[n];
-         buf[n*2+1] = ys[n];
+      for (Int_t n = 0; n < nPoints; ++n) {
+         buf[n * 2] = xs[n];
+         buf[n * 2 + 1] = ys[n];
       }
 }
 
@@ -153,82 +156,84 @@ void TWebPadPainter::DrawFillArea(Int_t nPoints, const Float_t *xs, const Float_
 
 void TWebPadPainter::DrawPolyLine(Int_t nPoints, const Double_t *xs, const Double_t *ys)
 {
-   if ((GetLineWidth() <= 0) || (nPoints < 2))  return;
-   auto buf = StoreOperation("pline:" + std::to_string(nPoints), attrLine, nPoints*2);
+   if ((GetLineWidth() <= 0) || (nPoints < 2))
+      return;
+
+   auto buf = StoreOperation("pline:" + std::to_string(nPoints), attrLine, nPoints * 2);
    if (buf)
-      for (Int_t n=0;n<nPoints;++n) {
-         buf[n*2] = xs[n];
-         buf[n*2+1] = ys[n];
+      for (Int_t n = 0; n < nPoints; ++n) {
+         buf[n * 2] = xs[n];
+         buf[n * 2 + 1] = ys[n];
       }
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Paint polyline.
 
 void TWebPadPainter::DrawPolyLine(Int_t nPoints, const Float_t *xs, const Float_t *ys)
 {
-   if ((GetLineWidth() <= 0) || (nPoints < 2))  return;
-   auto buf = StoreOperation("pline:" + std::to_string(nPoints), attrLine, nPoints*2);
+   if ((GetLineWidth() <= 0) || (nPoints < 2))
+      return;
+
+   auto buf = StoreOperation("pline:" + std::to_string(nPoints), attrLine, nPoints * 2);
    if (buf)
-      for (Int_t n=0;n<nPoints;++n) {
-         buf[n*2] = xs[n];
-         buf[n*2+1] = ys[n];
+      for (Int_t n = 0; n < nPoints; ++n) {
+         buf[n * 2] = xs[n];
+         buf[n * 2 + 1] = ys[n];
       }
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Paint polyline in normalized coordinates.
 
 void TWebPadPainter::DrawPolyLineNDC(Int_t nPoints, const Double_t *u, const Double_t *v)
 {
+   if ((GetLineWidth() <= 0) || (nPoints < 2))
+      return;
 
-   if ((GetLineWidth() <= 0) || (nPoints < 2))  return;
    ::Error("DrawPolyLineNDC", "Not supported correctly");
 
-   auto buf = StoreOperation("pline:" + std::to_string(nPoints), attrLine, nPoints*2);
+   auto buf = StoreOperation("pline:" + std::to_string(nPoints), attrLine, nPoints * 2);
    if (buf)
-      for (Int_t n=0;n<nPoints;++n) {
-         buf[n*2] = u[n];
-         buf[n*2+1] = v[n];
+      for (Int_t n = 0; n < nPoints; ++n) {
+         buf[n * 2] = u[n];
+         buf[n * 2 + 1] = v[n];
       }
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Paint polymarker.
 
 void TWebPadPainter::DrawPolyMarker(Int_t nPoints, const Double_t *x, const Double_t *y)
 {
-   if (nPoints < 1) return;
+   if (nPoints < 1)
+      return;
 
-   auto buf = StoreOperation(std::string("pmark:") + std::to_string(nPoints), attrLine | attrMarker, nPoints*2);
+   auto buf = StoreOperation(std::string("pmark:") + std::to_string(nPoints), attrLine | attrMarker, nPoints * 2);
 
    if (buf)
-      for (Int_t n=0;n<nPoints;++n) {
-         buf[n*2] = x[n];
-         buf[n*2+1] = y[n];
+      for (Int_t n = 0; n < nPoints; ++n) {
+         buf[n * 2] = x[n];
+         buf[n * 2 + 1] = y[n];
       }
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Paint polymarker.
 
 void TWebPadPainter::DrawPolyMarker(Int_t nPoints, const Float_t *x, const Float_t *y)
 {
-   if (nPoints < 1) return;
+   if (nPoints < 1)
+      return;
 
-   auto buf = StoreOperation(std::string("pmark:") + std::to_string(nPoints), attrLine | attrMarker, nPoints*2);
+   auto buf = StoreOperation(std::string("pmark:") + std::to_string(nPoints), attrLine | attrMarker, nPoints * 2);
 
    if (buf)
-      for (Int_t n=0;n<nPoints;++n) {
-         buf[n*2] = x[n];
-         buf[n*2+1] = y[n];
+      for (Int_t n = 0; n < nPoints; ++n) {
+         buf[n * 2] = x[n];
+         buf[n * 2 + 1] = y[n];
       }
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Paint text.
@@ -242,7 +247,6 @@ void TWebPadPainter::DrawText(Double_t x, Double_t y, const char *text, ETextMod
    }
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Special version working with wchar_t and required by TMathText.
 
@@ -255,13 +259,15 @@ void TWebPadPainter::DrawText(Double_t x, Double_t y, const wchar_t * /*text*/, 
    }
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Paint text in normalized coordinates.
 
 void TWebPadPainter::DrawTextNDC(Double_t u, Double_t v, const char *text, ETextMode /*mode*/)
 {
+   ::Error("DrawTextNDC", "Not supported correctly");
+
    auto buf = StoreOperation(std::string("text:") + text, attrText, 2);
+
    if (buf) {
       buf[0] = u;
       buf[1] = v;
@@ -273,25 +279,12 @@ void TWebPadPainter::DrawTextNDC(Double_t u, Double_t v, const char *text, EText
 
 void TWebPadPainter::DrawTextNDC(Double_t  u , Double_t v, const wchar_t * /*text*/, ETextMode /*mode*/)
 {
+   ::Error("DrawTextNDC", "Not supported correctly");
+
    auto buf = StoreOperation(std::string("text:") + "wchar_t", attrText, 2);
+
    if (buf) {
       buf[0] = u;
       buf[1] = v;
    }
 }
-
-
-////////////////////////////////////////////////////////////////////////////////////
-/// Reimplement X function
-
-void TWebPadPainter::DrawFillArea(Int_t nPoints, TPoint *xy)
-{
-   if ((GetFillStyle() <= 0) || (nPoints < 3))  return;
-   auto buf = StoreOperation("pfill:" + std::to_string(nPoints), attrFill, nPoints*2);
-   if (buf)
-      for (Int_t n=0;n<nPoints;++n) {
-         buf[n*2] = gPad->PixeltoX(xy[n].fX);
-         buf[n*2+1] = gPad->PixeltoY(xy[n].fY);
-      }
-}
-

--- a/gui/webgui6/src/TWebPainting.cxx
+++ b/gui/webgui6/src/TWebPainting.cxx
@@ -59,24 +59,19 @@ void TWebPainting::AddMarkerAttr(const TAttMarker &attr)
            std::to_string((int) attr.GetMarkerSize()));
 }
 
-void TWebPainting::AddColor(TColor *col, Bool_t onlyindx)
+void TWebPainting::AddColor(Int_t indx, TColor *col)
 {
    if (!col) return;
-   if (onlyindx) {
-      AddOper("col:" + std::to_string(col->GetNumber()));
-   } else if (col->GetAlpha() == 1) {
-      AddOper("rgb:" + std::to_string(col->GetNumber()));
-      auto buf = Reserve(3);
-      buf[0] = (int) (255*col->GetRed());
-      buf[1] = (int) (255*col->GetGreen());
-      buf[2] = (int) (255*col->GetBlue());
-   } else {
-      AddOper("rga:" + std::to_string(col->GetNumber()));
-      auto buf = Reserve(4);
-      buf[0] = (int) (255*col->GetRed());
-      buf[1] = (int) (255*col->GetGreen());
-      buf[2] = (int) (255*col->GetBlue());
-      buf[3] = (int) (1000*col->GetAlpha());
-   }
+
+   TString code;
+
+   if (col->GetAlpha() == 1)
+      code.Form("rgb(%d,%d,%d)", (int) (255*col->GetRed()), (int) (255*col->GetGreen()), (int) (255*col->GetBlue()));
+   else
+      code.Form("rgba(%d,%d,%d,%5.3f)", (int) (255*col->GetRed()), (int) (255*col->GetGreen()), (int) (255*col->GetBlue()), col->GetAlpha());
+   if (indx>=0)
+      code.Prepend(TString::Format("%d:", indx));
+
+   AddOper(code.Data());
 }
 

--- a/gui/webgui6/src/TWebPainting.cxx
+++ b/gui/webgui6/src/TWebPainting.cxx
@@ -58,3 +58,25 @@ void TWebPainting::AddMarkerAttr(const TAttMarker &attr)
            std::to_string((int) attr.GetMarkerStyle()) + ":" +
            std::to_string((int) attr.GetMarkerSize()));
 }
+
+void TWebPainting::AddColor(TColor *col, Bool_t onlyindx)
+{
+   if (!col) return;
+   if (onlyindx) {
+      AddOper("col:" + std::to_string(col->GetNumber()));
+   } else if (col->GetAlpha() == 1) {
+      AddOper("rgb:" + std::to_string(col->GetNumber()));
+      auto buf = Reserve(3);
+      buf[0] = (int) (255*col->GetRed());
+      buf[1] = (int) (255*col->GetGreen());
+      buf[2] = (int) (255*col->GetBlue());
+   } else {
+      AddOper("rga:" + std::to_string(col->GetNumber()));
+      auto buf = Reserve(4);
+      buf[0] = (int) (255*col->GetRed());
+      buf[1] = (int) (255*col->GetGreen());
+      buf[2] = (int) (255*col->GetBlue());
+      buf[3] = (int) (1000*col->GetAlpha());
+   }
+}
+

--- a/gui/webgui6/src/TWebPainting.cxx
+++ b/gui/webgui6/src/TWebPainting.cxx
@@ -10,6 +10,14 @@
 
 #include "TWebPainting.h"
 
+TWebPainting::TWebPainting()
+{
+   fLastFill.SetFillStyle(9999);
+   fLastLine.SetLineWidth(-123);
+   fLastMarker.SetMarkerStyle(9999);
+}
+
+
 Float_t *TWebPainting::Reserve(Int_t sz)
 {
    if (sz <= 0)
@@ -28,6 +36,12 @@ Float_t *TWebPainting::Reserve(Int_t sz)
 
 void TWebPainting::AddLineAttr(const TAttLine &attr)
 {
+   if ((attr.GetLineColor() == fLastLine.GetLineColor()) &&
+       (attr.GetLineStyle() == fLastLine.GetLineStyle()) &&
+       (attr.GetLineWidth() == fLastLine.GetLineWidth())) return;
+
+   fLastLine = attr;
+
    AddOper(std::string("lattr:") +
            std::to_string((int) attr.GetLineColor()) + ":" +
            std::to_string((int) attr.GetLineStyle()) + ":" +
@@ -36,6 +50,11 @@ void TWebPainting::AddLineAttr(const TAttLine &attr)
 
 void TWebPainting::AddFillAttr(const TAttFill &attr)
 {
+   if ((fLastFill.GetFillColor() == attr.GetFillColor()) &&
+       (fLastFill.GetFillStyle() == attr.GetFillStyle())) return;
+
+   fLastFill = attr;
+
    AddOper(std::string("fattr:") +
            std::to_string((int) attr.GetFillColor()) + ":" +
            std::to_string((int) attr.GetFillStyle()));
@@ -53,6 +72,12 @@ void TWebPainting::AddTextAttr(const TAttText &attr)
 
 void TWebPainting::AddMarkerAttr(const TAttMarker &attr)
 {
+   if ((attr.GetMarkerColor() == fLastMarker.GetMarkerColor()) &&
+       (attr.GetMarkerStyle() == fLastMarker.GetMarkerStyle()) &&
+       (attr.GetMarkerSize() == fLastMarker.GetMarkerSize())) return;
+
+   fLastMarker = attr;
+
    AddOper(std::string("mattr:") +
            std::to_string((int) attr.GetMarkerColor()) + ":" +
            std::to_string((int) attr.GetMarkerStyle()) + ":" +

--- a/gui/webgui6/src/TWebPainting.cxx
+++ b/gui/webgui6/src/TWebPainting.cxx
@@ -12,6 +12,9 @@
 
 Float_t *TWebPainting::Reserve(Int_t sz)
 {
+   if (sz <= 0)
+      return nullptr;
+
    if (fSize + sz > fBuf.GetSize()) {
       Int_t nextsz = fBuf.GetSize() + TMath::Max(1024, (sz/128 + 1) * 128);
       fBuf.Set(nextsz);

--- a/gui/webgui6/src/TWebPainting.cxx
+++ b/gui/webgui6/src/TWebPainting.cxx
@@ -25,3 +25,36 @@ Float_t *TWebPainting::Reserve(Int_t sz)
    return res; // return size where drawing can start
 }
 
+
+void TWebPainting::AddLineAttr(const TAttLine &attr)
+{
+   AddOper(std::string("lattr:") +
+           std::to_string((int) attr.GetLineColor()) + ":" +
+           std::to_string((int) attr.GetLineStyle()) + ":" +
+           std::to_string((int) attr.GetLineWidth()));
+}
+
+void TWebPainting::AddFillAttr(const TAttFill &attr)
+{
+   AddOper(std::string("fattr:") +
+           std::to_string((int) attr.GetFillColor()) + ":" +
+           std::to_string((int) attr.GetFillStyle()));
+}
+
+void TWebPainting::AddTextAttr(const TAttText &attr)
+{
+   AddOper(std::string("tattr:") +
+           std::to_string((int) attr.GetTextColor()) + ":" +
+           std::to_string((int) attr.GetTextFont()) + ":" +
+           std::to_string((int) (attr.GetTextSize()>=1 ? attr.GetTextSize() : -1000*attr.GetTextSize())) + ":" +
+           std::to_string((int) attr.GetTextAlign()) + ":" +
+           std::to_string((int) attr.GetTextAngle()));
+}
+
+void TWebPainting::AddMarkerAttr(const TAttMarker &attr)
+{
+   AddOper(std::string("mattr:") +
+           std::to_string((int) attr.GetMarkerColor()) + ":" +
+           std::to_string((int) attr.GetMarkerStyle()) + ":" +
+           std::to_string((int) attr.GetMarkerSize()));
+}

--- a/gui/webgui6/src/TWebSnapshot.cxx
+++ b/gui/webgui6/src/TWebSnapshot.cxx
@@ -23,11 +23,11 @@ TWebSnapshot::~TWebSnapshot()
 ///////////////////////////////////////////////////////////////////////////////////////////
 /// SetUse pointer to assign object id - TString::Hash
 
-void TWebSnapshot::SetSnapshot(Int_t kind, TObject *shot, Bool_t owner)
+void TWebSnapshot::SetSnapshot(Int_t kind, TObject *snapshot, Bool_t owner)
 {
    if (fSnapshot && fOwner) delete fSnapshot;
    fKind = kind;
-   fSnapshot = shot;
+   fSnapshot = snapshot;
    fOwner = owner;
 }
 
@@ -37,17 +37,5 @@ void TWebSnapshot::SetSnapshot(Int_t kind, TObject *shot, Bool_t owner)
 void TWebSnapshot::SetObjectIDAsPtr(void *ptr)
 {
    UInt_t hash = TString::Hash(&ptr, sizeof(ptr));
-   SetObjectID(TString::UItoa(hash,10));
+   SetObjectID(std::to_string(hash));
 }
-
-
-///////////////////////////////////////////////////////////////////////////////////////////
-/// destructor
-
-TPadWebSnapshot::~TPadWebSnapshot()
-{
-   for (auto &&item: fPrimitives)
-      delete item;
-   fPrimitives.clear();
-}
-


### PR DESCRIPTION
While TCanvas, shown in web-browser, marked as batch canvas, all customs object painting performed via gVirtualPS classes. Therefore one need to catch all these calls and record for SVG creation in the client. TWebPadPainter is remained as fall-back solution if some objects painter does not follow strictly the ROOT painting logic. 
Highly optimize data which are transferred to clients - avoid large TObject overhead for simple fill/line/marker attributes. 
Try to merge painting if there are too many objects on the TCanvas - like in tutorials/graphics/greyscale.C macro. In such case simple SVG fails - one should try to combine primitives drawn with same attributes