### PR TITLE
[DS] Fix backwards compatibility of RDataSource

### DIFF
--- a/tree/dataframe/inc/ROOT/RArrowDS.hxx
+++ b/tree/dataframe/inc/ROOT/RArrowDS.hxx
@@ -41,7 +41,7 @@ public:
    void InitSlot(unsigned int slot, ULong64_t firstEntry) override;
    void SetNSlots(unsigned int nSlots) override;
    void Initialise() override;
-   std::string GetDataSourceType() override;
+   std::string GetLabel() override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////

--- a/tree/dataframe/inc/ROOT/RCsvDS.hxx
+++ b/tree/dataframe/inc/ROOT/RCsvDS.hxx
@@ -78,7 +78,7 @@ public:
    bool HasColumn(std::string_view colName) const;
    bool SetEntry(unsigned int slot, ULong64_t entry);
    void SetNSlots(unsigned int nSlots);
-   std::string GetDataSourceType();
+   std::string GetLabel();
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////

--- a/tree/dataframe/inc/ROOT/RDF/RLazyDSImpl.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLazyDSImpl.hxx
@@ -200,7 +200,7 @@ public:
       }
    }
 
-   std::string GetDataSourceType() { return "LazyDS"; }
+   std::string GetLabel() { return "LazyDS"; }
 };
 
 } // ns RDF

--- a/tree/dataframe/inc/ROOT/RDataSource.hxx
+++ b/tree/dataframe/inc/ROOT/RDataSource.hxx
@@ -204,7 +204,11 @@ public:
    // clang-format on
    virtual void Finalise() {}
 
-   virtual std::string GetDataSourceType() = 0;
+   /// \brief Return a string representation of the datasource type.
+   /// The returned string will be used by ROOT::RDF::SaveGraph() to represent
+   /// the datasource in the visualization of the computation graph.
+   /// Concrete datasources can override the default implementation.
+   virtual std::string GetDataSourceType() { return "custom datasource"; }
 
 protected:
    /// type-erased vector of pointers to pointers to column values - one per slot

--- a/tree/dataframe/inc/ROOT/RDataSource.hxx
+++ b/tree/dataframe/inc/ROOT/RDataSource.hxx
@@ -208,7 +208,7 @@ public:
    /// The returned string will be used by ROOT::RDF::SaveGraph() to represent
    /// the datasource in the visualization of the computation graph.
    /// Concrete datasources can override the default implementation.
-   virtual std::string GetLabel() { return "custom datasource"; }
+   virtual std::string GetLabel() { return "Custom Datasource"; }
 
 protected:
    /// type-erased vector of pointers to pointers to column values - one per slot

--- a/tree/dataframe/inc/ROOT/RDataSource.hxx
+++ b/tree/dataframe/inc/ROOT/RDataSource.hxx
@@ -208,7 +208,7 @@ public:
    /// The returned string will be used by ROOT::RDF::SaveGraph() to represent
    /// the datasource in the visualization of the computation graph.
    /// Concrete datasources can override the default implementation.
-   virtual std::string GetDataSourceType() { return "custom datasource"; }
+   virtual std::string GetLabel() { return "custom datasource"; }
 
 protected:
    /// type-erased vector of pointers to pointers to column values - one per slot

--- a/tree/dataframe/inc/ROOT/RRootDS.hxx
+++ b/tree/dataframe/inc/ROOT/RRootDS.hxx
@@ -50,7 +50,7 @@ public:
    bool SetEntry(unsigned int slot, ULong64_t entry);
    void SetNSlots(unsigned int nSlots);
    void Initialise();
-   std::string GetDataSourceType();
+   std::string GetLabel();
 };
 
 RDataFrame MakeRootDataFrame(std::string_view treeName, std::string_view fileNameGlob);

--- a/tree/dataframe/inc/ROOT/RSqliteDS.hxx
+++ b/tree/dataframe/inc/ROOT/RSqliteDS.hxx
@@ -108,7 +108,7 @@ public:
    std::vector<std::pair<ULong64_t, ULong64_t>> GetEntryRanges() final;
    bool SetEntry(unsigned int slot, ULong64_t entry) final;
    void Initialise() final;
-   std::string GetDataSourceType() final;
+   std::string GetLabel() final;
 
 protected:
    Record_t GetColumnReadersImpl(std::string_view name, const std::type_info &) final;

--- a/tree/dataframe/inc/ROOT/RTrivialDS.hxx
+++ b/tree/dataframe/inc/ROOT/RTrivialDS.hxx
@@ -42,7 +42,7 @@ public:
    bool SetEntry(unsigned int slot, ULong64_t entry);
    void SetNSlots(unsigned int nSlots);
    void Initialise();
-   std::string GetDataSourceType();
+   std::string GetLabel();
 };
 
 RInterface<RDFDetail::RLoopManager, RTrivialDS> MakeTrivialDataFrame(ULong64_t size, bool skipEvenEntries = false);

--- a/tree/dataframe/src/RArrowDS.cxx
+++ b/tree/dataframe/src/RArrowDS.cxx
@@ -479,7 +479,7 @@ void RArrowDS::Initialise()
 {
 }
 
-std::string RArrowDS::GetDataSourceType()
+std::string RArrowDS::GetLabel()
 {
    return "ArrowDS";
 }

--- a/tree/dataframe/src/RCsvDS.cxx
+++ b/tree/dataframe/src/RCsvDS.cxx
@@ -446,7 +446,7 @@ void RCsvDS::SetNSlots(unsigned int nSlots)
    fBoolEvtValues.resize(nColumns, std::deque<bool>(fNSlots));
 }
 
-std::string RCsvDS::GetDataSourceType()
+std::string RCsvDS::GetLabel()
 {
    return "RCsv";
 }

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -408,7 +408,7 @@ std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode> RLoopManager::GetG
 {
    std::string name;
    if (fDataSource) {
-      name = fDataSource->GetDataSourceType();
+      name = fDataSource->GetLabel();
    } else if (fTree) {
       name = fTree->GetName();
    } else {

--- a/tree/dataframe/src/RRootDS.cxx
+++ b/tree/dataframe/src/RRootDS.cxx
@@ -155,7 +155,7 @@ void RRootDS::Initialise()
    fEntryRanges.back().second += reminder;
 }
 
-std::string RRootDS::GetDataSourceType()
+std::string RRootDS::GetLabel()
 {
    return "Root";
 }

--- a/tree/dataframe/src/RSqliteDS.cxx
+++ b/tree/dataframe/src/RSqliteDS.cxx
@@ -562,7 +562,7 @@ void RSqliteDS::Initialise()
       throw std::runtime_error("SQlite error, reset");
 }
 
-std::string RSqliteDS::GetDataSourceType()
+std::string RSqliteDS::GetLabel()
 {
    return "RSqliteDS";
 }

--- a/tree/dataframe/src/RTrivialDS.cxx
+++ b/tree/dataframe/src/RTrivialDS.cxx
@@ -84,7 +84,7 @@ void RTrivialDS::Initialise()
    fEntryRanges.back().second += fSize % fNSlots;
 }
 
-std::string RTrivialDS::GetDataSourceType()
+std::string RTrivialDS::GetLabel()
 {
    return "TrivialDS";
 }

--- a/tree/dataframe/test/RNonCopiableColumnDS.hxx
+++ b/tree/dataframe/test/RNonCopiableColumnDS.hxx
@@ -41,7 +41,7 @@ public:
    };
    bool SetEntry(unsigned int, ULong64_t){ return true;};
    void SetNSlots(unsigned int){};
-   std::string GetDataSourceType(){
+   std::string GetLabel(){
       return "NonCopiableColumnDS";
    }
 };

--- a/tree/dataframe/test/RStreamingDS.hxx
+++ b/tree/dataframe/test/RStreamingDS.hxx
@@ -34,7 +34,7 @@ public:
    bool SetEntry(unsigned int, ULong64_t) final { return true; }
    void Initialise() final { fCounter = 0; }
 
-   std::string GetDataSourceType() final { return "Streaming"; }
+   std::string GetLabel() final { return "Streaming"; }
 
 protected:
    std::vector<void *> GetColumnReadersImpl(std::string_view name, const std::type_info &t) final


### PR DESCRIPTION
Addition of a pure virtual method to a public class breaks backwards compatibility, add a default implementation as suggested by @amadio 