### PR TITLE
[RooFit] Replace RooArgSet and RooDataSet mempools with single templated mempool

### DIFF
--- a/roofit/roofitcore/inc/RooArgSet.h
+++ b/roofit/roofitcore/inc/RooArgSet.h
@@ -21,12 +21,14 @@
 class RooArgList ;
 
 
-#define USEMEMPOOL
+#define USEMEMPOOLFORARGSET
+template <class RooSet_t, size_t>
+class MemPoolForRooSets;
 
 class RooArgSet : public RooAbsCollection {
 public:
   
-#ifdef USEMEMPOOL
+#ifdef USEMEMPOOLFORARGSET
   void* operator new (size_t bytes);
   void* operator new (size_t bytes, void* ptr) noexcept;
   void operator delete (void *ptr);
@@ -129,9 +131,14 @@ protected:
 
   Bool_t checkForDup(const RooAbsArg& arg, Bool_t silent) const ;
 
-  static char* _poolBegin ; //! Start of memory pool
-  static char* _poolCur ;   //! Next free slot in memory pool
-  static char* _poolEnd ;   //! End of memory pool  
+#ifdef USEMEMPOOLFORARGSET
+private:
+  typedef MemPoolForRooSets<RooArgSet, 10> MemPool;
+  //Initialise a static mem pool. It has to happen inside a function to solve the
+  //static initialisation order fiasco. At the end of the program, this might have
+  //to leak depending if RooArgSets are still alive. This depends on the order of destructions.
+  static MemPool* memPool();
+#endif
   
   ClassDef(RooArgSet,1) // Set of RooAbsArg objects
 };

--- a/roofit/roofitcore/inc/RooArgSet.h
+++ b/roofit/roofitcore/inc/RooArgSet.h
@@ -133,7 +133,7 @@ protected:
 
 #ifdef USEMEMPOOLFORARGSET
 private:
-  typedef MemPoolForRooSets<RooArgSet, 10> MemPool;
+  typedef MemPoolForRooSets<RooArgSet, 1200> MemPool; //600 = about 100 kb
   //Initialise a static mem pool. It has to happen inside a function to solve the
   //static initialisation order fiasco. At the end of the program, this might have
   //to leak depending if RooArgSets are still alive. This depends on the order of destructions.

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -23,13 +23,15 @@ class RooDataHist ;
 #include "RooAbsData.h"
 #include "RooDirItem.h"
 
-#define USEMEMPOOL
 
+#define USEMEMPOOLFORDATASET
+template <class RooSet_t, size_t>
+class MemPoolForRooSets;
 
 class RooDataSet : public RooAbsData, public RooDirItem {
 public:
 
-#ifdef USEMEMPOOL
+#ifdef USEMEMPOOLFORDATASET
   void* operator new (size_t bytes);
   void operator delete (void *ptr);
 #endif
@@ -129,6 +131,8 @@ public:
   void SetName(const char *name) ;
   void SetNameTitle(const char *name, const char* title) ;
 
+  static void cleanup();
+
 protected:
 
   virtual RooAbsData* cacheClone(const RooAbsArg* newCacheOwner, const RooArgSet* newCacheVars, const char* newName=0) ;
@@ -148,10 +152,11 @@ protected:
   RooArgSet _varsNoWgt ;   // Vars without weight variable 
   RooRealVar* _wgtVar ;    // Pointer to weight variable (if set) 
 
-  static void cleanup() ;
-  static char* _poolBegin ; //! Start of memory pool
-  static char* _poolCur ;   //! Next free slot in memory pool
-  static char* _poolEnd ;   //! End of memory pool  
+private:
+#ifdef USEMEMPOOLFORDATASET
+  typedef MemPoolForRooSets<RooDataSet, 10> MemPool;
+  static MemPool * memPool();
+#endif
 
   ClassDef(RooDataSet,2) // Unbinned data set
 };

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -154,7 +154,7 @@ protected:
 
 private:
 #ifdef USEMEMPOOLFORDATASET
-  typedef MemPoolForRooSets<RooDataSet, 10> MemPool;
+  typedef MemPoolForRooSets<RooDataSet, 300> MemPool; // 150 = about 100kb
   static MemPool * memPool();
 #endif
 

--- a/roofit/roofitcore/src/MemPoolForRooSets.h
+++ b/roofit/roofitcore/src/MemPoolForRooSets.h
@@ -1,0 +1,224 @@
+// @(#)root/roofit:$Id$
+// Author: Stephan Hageboeck, CERN, 10/2018
+/*************************************************************************
+ * Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+/** Memory pool for RooArgSet and RooDataSet.
+ * \class MemPoolForRooSets
+ * \ingroup roofitcore
+ * RooArgSet and RooDataSet were using a mempool that guarantees that allocating,
+ * de-allocating and re-allocating a set does not yield the same pointer. Since
+ * both were using the same logic, the functionality has been put in this class.
+ * This class solves RooFit's static destruction order problems by intentionally leaking
+ * arenas of the mempool that still contain live objects at the end of the program.
+ */
+
+#ifndef ROOFIT_ROOFITCORE_SRC_MEMPOOLFORROOSETS_H_
+#define ROOFIT_ROOFITCORE_SRC_MEMPOOLFORROOSETS_H_
+
+#include <vector>
+#include <algorithm>
+
+template <class RooSet_t, std::size_t POOLSIZE>
+class MemPoolForRooSets {
+
+  struct Arena {
+    Arena()
+      : memBegin{static_cast<RooSet_t *>(::operator new(POOLSIZE * sizeof(RooSet_t)))}, nextItem{memBegin},
+        memEnd{memBegin + POOLSIZE}, refCount{0}, teardownMode{false}
+    {
+    }
+
+    Arena(const Arena &) = delete;
+    Arena(Arena && other)
+      : memBegin{other.memBegin}, nextItem{other.nextItem}, memEnd{other.memEnd}, refCount{other.refCount},
+	teardownMode{other.teardownMode}
+#ifndef NDEBUG
+      , deletedElements { std::move(other.deletedElements) }
+#endif
+    {
+      // Needed for unique ownership
+      other.memBegin = nullptr;
+      other.refCount = 0;
+    }
+
+    Arena & operator=(const Arena &) = delete;
+    Arena & operator=(Arena && other)
+    {
+      memBegin = other.memBegin;
+      nextItem = other.nextItem;
+      memEnd   = other.memEnd;
+#ifndef NDEBUG
+      deletedElements = std::move(other.deletedElements);
+#endif
+      refCount     = other.refCount;
+      teardownMode = other.teardownMode;
+
+      other.memBegin = nullptr;
+      other.refCount = 0;
+
+      return *this;
+    }
+
+    // If there is any user left, the arena shouldn't be deleted.
+    // If this happens, nevertheless, one has an order of destruction problem.
+    ~Arena()
+    {
+      if (!memBegin) return;
+
+      if (refCount != 0) {
+        std::cerr << __FILE__ << ":" << __LINE__ << "Deleting arena " << memBegin << " with use count " << refCount
+                  << std::endl;
+        assert(false);
+      }
+
+      ::operator delete(memBegin);
+    }
+
+    bool inPool(void * ptr) const
+    {
+      auto       thePtr = static_cast<RooSet_t *>(ptr);
+      const bool inPool = memBegin <= thePtr && thePtr < memBegin + POOLSIZE;
+      return inPool;
+    }
+
+    bool isFull() const { return nextItem >= memBegin + POOLSIZE; }
+
+    bool empty() const { return refCount == 0; }
+
+    void * tryAllocate()
+    {
+      if (isFull()) return nullptr;
+
+      ++refCount;
+      return nextItem++;
+    }
+
+    bool tryDeallocate(void * ptr)
+    {
+      if (inPool(ptr)) {
+        --refCount;
+#ifndef NDEBUG
+        const std::size_t index = static_cast<RooSet_t *>(ptr) - memBegin;
+        assert(deletedElements.count(index) == 0);
+        deletedElements.insert(index);
+#endif
+        return true;
+      } else
+        return false;
+    }
+
+    RooSet_t * memBegin;
+    RooSet_t * nextItem;
+    RooSet_t * memEnd;
+    std::size_t refCount;
+    bool        teardownMode;
+#ifndef NDEBUG
+    std::set<std::size_t> deletedElements;
+#endif
+  };
+
+  private:
+  std::vector<Arena> fArenas;
+  bool               fTeardownMode{false};
+
+  public:
+  /// Create empty mem pool.
+  MemPoolForRooSets() : fArenas{} {}
+
+  MemPoolForRooSets(const MemPoolForRooSets &) = delete;
+  MemPoolForRooSets(MemPoolForRooSets &&)      = delete;
+  MemPoolForRooSets & operator=(const MemPoolForRooSets &) = delete;
+  MemPoolForRooSets & operator=(MemPoolForRooSets &&) = delete;
+
+  /// Destructor. Should not be called when RooArgSets or RooDataSets are still alive.
+  ~MemPoolForRooSets()
+  {
+    if (!empty()) {
+      std::cerr << __PRETTY_FUNCTION__ << " The mem pool being deleted is not empty. This will lead to crashes."
+                << std::endl;
+      assert(false);
+    }
+  }
+
+  /// Allocate memory for the templated set type. Fails if bytes != sizeof(RooSet_t).
+  void * allocate(std::size_t bytes)
+  {
+    assert(bytes == sizeof(RooSet_t));
+
+    if (fArenas.empty() || fArenas.back().isFull()) {
+      prune();
+      fArenas.emplace_back();
+    }
+
+    void * ptr = fArenas.back().tryAllocate();
+    assert(ptr != nullptr);
+
+    return ptr;
+  }
+
+  /// Deallocate memory for the templated set type if in pool.
+  ///\return True if element was in pool.
+  bool deallocate(void * ptr)
+  {
+    bool deallocSuccess = false;
+    for (auto & arena : fArenas) {
+      if (arena.tryDeallocate(ptr)) {
+        deallocSuccess = true;
+        break;
+      }
+    }
+
+    if (fTeardownMode) {
+      // Try pruning after each dealloc because we are tearing down
+      prune();
+    }
+
+    return deallocSuccess;
+  }
+
+  ////////////////////////////////////////////////////////////////////////////////
+  /// Delete arenas that don't have space and no users.
+  /// In fTeardownMode, it will also delete the arena that still has space.
+  ///
+  void prune()
+  {
+    bool doTeardown = fTeardownMode;
+
+    auto shouldFree = [doTeardown](Arena & arena) -> bool {
+      if (arena.refCount == 0 && (doTeardown || arena.isFull())) {
+        return true;
+      }
+
+      return false;
+    };
+
+    fArenas.erase(std::remove_if(fArenas.begin(), fArenas.end(), shouldFree), fArenas.end());
+  }
+
+  /// Test if pool is empty.
+  bool empty() const
+  {
+    return std::all_of(fArenas.begin(), fArenas.end(), [](const Arena & ar) { return ar.empty(); });
+  }
+
+  /// Set pool to teardown mode (at program end).
+  /// Will prune all empty arenas. Non-empty arenas will survive until all contained elements
+  /// are deleted. They may therefore leak if not all elements are destructed.
+  void teardown()
+  {
+    fTeardownMode = true;
+    for (auto & arena : fArenas) {
+      arena.teardownMode = true;
+    }
+
+    prune();
+  }
+};
+
+#endif /* ROOFIT_ROOFITCORE_SRC_MEMPOOLFORROOSETS_H_ */

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -67,8 +67,6 @@ void RooDataSet::cleanup() {}
 #else
 
 #include "MemPoolForRooSets.h"
-//typedef MemPoolForRooSets<RooDataSet, 10> RooDataSet::MemPool;
-
 
 RooDataSet::MemPool* RooDataSet::memPool() {
   RooSentinel::activate();

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -61,37 +61,30 @@ char* operator+( streampos&, char* );
 using namespace std;
 
 ClassImp(RooDataSet);
-;
+
+#ifndef USEMEMPOOLFORDATASET
+void RooDataSet::cleanup() {}
+#else
+
+#include "MemPoolForRooSets.h"
+//typedef MemPoolForRooSets<RooDataSet, 10> RooDataSet::MemPool;
 
 
-char* RooDataSet::_poolBegin = 0 ;
-char* RooDataSet::_poolCur = 0 ;
-char* RooDataSet::_poolEnd = 0 ;
-#define POOLSIZE 1048576
-
-struct POOLDATA 
-{
-  void* _base ;
-} ;
-
-static std::list<POOLDATA> _memPoolList ;
-
-////////////////////////////////////////////////////////////////////////////////
-/// Clear memoery pool on exit to avoid reported memory leaks
-
-void RooDataSet::cleanup()
-{
-  std::list<POOLDATA>::iterator iter = _memPoolList.begin() ;
-  while(iter!=_memPoolList.end()) {
-    free(iter->_base) ;
-    iter->_base=0 ;
-    ++iter ;
-  }
-  _memPoolList.clear() ;
+RooDataSet::MemPool* RooDataSet::memPool() {
+  RooSentinel::activate();
+  static auto * memPool = new RooDataSet::MemPool();
+  return memPool;
 }
 
+void RooDataSet::cleanup() {
+  auto pool = memPool();
+  pool->teardown();
 
-#ifdef USEMEMPOOL
+  //The pool will have to leak if it's not empty at this point.
+  if (pool->empty())
+    delete pool;
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Overloaded new operator guarantees that all RooDataSets allocated with new
@@ -102,62 +95,10 @@ void RooDataSet::cleanup()
 
 void* RooDataSet::operator new (size_t bytes)
 {
-  // cout << " RooDataSet::operator new(" << bytes << ")" << endl ;
+  //This will fail if a derived class uses this operator
+  assert(sizeof(RooDataSet) == bytes);
 
-  if (!_poolBegin || _poolCur + (sizeof(RooDataSet)) >= _poolEnd) {
-
-     if (_poolBegin != 0) {
-        oocxcoutD((TObject *)0, Caching) << "RooDataSet::operator new(), starting new 1MB memory pool" << endl;
-     }
-
-     // Start pruning empty memory pools if number exceeds 3
-     if (_memPoolList.size() > 3) {
-
-        void *toFree(0);
-
-        for (std::list<POOLDATA>::iterator poolIter = _memPoolList.begin(); poolIter != _memPoolList.end();
-             ++poolIter) {
-
-           // If pool is empty, delete it and remove it from list
-           if ((*(Int_t *)(poolIter->_base)) == 0) {
-              oocxcoutD((TObject *)0, Caching)
-                 << "RooDataSet::operator new(), pruning empty memory pool " << (void *)(poolIter->_base) << endl;
-
-              toFree = poolIter->_base;
-              _memPoolList.erase(poolIter);
-              break;
-           }
-        }
-
-        free(toFree);
-     }
-
-     void *mem = malloc(POOLSIZE);
-     memset(mem, TStorage::kObjectAllocMemValue, POOLSIZE);
-
-     _poolBegin = (char *)mem;
-     // Reserve space for pool counter at head of pool
-     _poolCur = _poolBegin + sizeof(Int_t);
-     _poolEnd = _poolBegin + (POOLSIZE);
-
-     // Clear pool counter
-     *((Int_t *)_poolBegin) = 0;
-
-     POOLDATA p;
-     p._base = mem;
-     _memPoolList.push_back(p);
-
-     RooSentinel::activate();
-  }
-
-  char* ptr = _poolCur ;
-  _poolCur += bytes ;
-
-  // Increment use counter of pool
-  (*((Int_t*)_poolBegin))++ ;
-
-  return ptr ;
-
+  return memPool()->allocate(bytes);
 }
 
 
@@ -168,13 +109,13 @@ void* RooDataSet::operator new (size_t bytes)
 void RooDataSet::operator delete (void* ptr)
 {
   // Decrease use count in pool that ptr is on
-  for (std::list<POOLDATA>::iterator poolIter =  _memPoolList.begin() ; poolIter!=_memPoolList.end() ; ++poolIter) {
-    if ((char*)ptr > (char*)poolIter->_base && (char*)ptr < (char*)poolIter->_base + POOLSIZE) {
-      (*(Int_t*)(poolIter->_base))-- ;
-      break ;
-    }
-  }
-  
+  if (memPool()->deallocate(ptr))
+    return;
+
+  std::cerr << __func__ << " " << ptr << " is not in any of the pools." << std::endl;
+
+  // Not part of any pool; use global op delete:
+  ::operator delete(ptr);
 }
 
 #endif

--- a/roofit/roofitcore/src/RooSentinel.cxx
+++ b/roofit/roofitcore/src/RooSentinel.cxx
@@ -43,6 +43,7 @@ installs an atexit() function that takes care of this
 #include "RooRealConstant.h"
 #include "RooResolutionModel.h"
 #include "RooExpensiveObjectCache.h"
+#include "RooDataSet.h"
 
 Bool_t RooSentinel::_active = kFALSE ;
 
@@ -60,6 +61,7 @@ static void CleanUpRooFitAtExit()
   RooRealConstant::cleanup() ;
   RooResolutionModel::cleanup() ;
   RooExpensiveObjectCache::cleanup() ;
+  RooDataSet::cleanup();
 }
 
 


### PR DESCRIPTION
This fixes ROOT-9571 and other crashes when RooPlots reach the end of main.

One may wonder whether mempools are a good idea. The answer is probably no, but disabling the mempool breaks the caching of normalisation results in RooFit. This relies on RooArgSet pointers being unique, i.e. OS-managed memory allocation doesn't work.

With the proposed implementation, there is just one (templated) mempool for both Roo(Arg|Data)Set. Possible future modifications (e.g. locks, thread-local arenas) need to be done only in one place and are way easier now. The mempool takes care of not deleting (in worst case leaking) any arenas with live objects at program end. This brings us much closer to solving all problems with global statics in RooFit.