### PR TITLE
webgui: correctly check if browser executable was found

### DIFF
--- a/gui/webdisplay/inc/ROOT/RWebDisplayHandle.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebDisplayHandle.hxx
@@ -36,6 +36,7 @@ protected:
    class Creator {
    public:
       virtual std::unique_ptr<RWebDisplayHandle> Display(const RWebDisplayArgs &args) = 0;
+      virtual bool IsActive() const { return true; }
       virtual ~Creator() = default;
    };
 
@@ -62,13 +63,14 @@ protected:
    public:
       ChromeCreator();
       virtual ~ChromeCreator() = default;
+      bool IsActive() const override { return !fProg.empty(); }
    };
 
    class FirefoxCreator : public BrowserCreator {
    public:
       FirefoxCreator();
       virtual ~FirefoxCreator() = default;
-
+      bool IsActive() const override { return !fProg.empty(); }
       std::string MakeProfile(TString &exec, bool batch) override;
    };
 

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -387,8 +387,8 @@ std::unique_ptr<ROOT::Experimental::RWebDisplayHandle> ROOT::Experimental::RWebD
    std::unique_ptr<RWebDisplayHandle> handle;
 
    auto try_creator = [&](std::unique_ptr<Creator> &creator) {
-      if (!creator) return false;
-
+      if (!creator || !creator->IsActive())
+         return false;
       handle = creator->Display(args);
       return handle ? true : false;
    };


### PR DESCRIPTION
For Chrome and Firefox browsers full executable path should exists.
It is required to correctly start it with the fork. 
If browser executable was not detected - no need to try it