### PR TITLE
Fix gcc8 warnings in GUI

### DIFF
--- a/gui/gui/inc/TGGC.h
+++ b/gui/gui/inc/TGGC.h
@@ -33,8 +33,8 @@ class TGGC : public TObject, public TRefCnt {
 friend class TGGCPool;
 
 protected:
-   GCValues_t     fValues;     // graphics context values + mask
-   GContext_t     fContext;    // graphics context handle
+   GCValues_t fValues = {}; // graphics context values + mask
+   GContext_t fContext;     // graphics context handle
 
    TGGC(GCValues_t *values, Bool_t calledByGCPool);
    void UpdateValues(GCValues_t *v);

--- a/gui/gui/src/TGGC.cxx
+++ b/gui/gui/src/TGGC.cxx
@@ -48,7 +48,7 @@ TGGC::TGGC(GCValues_t *values, Bool_t)
                               fValues.fDashLen);
       }
    } else {
-      memset(&fValues, 0, sizeof(GCValues_t));
+      fValues = {};
       fContext = 0;
    }
    SetRefCount(1);
@@ -62,7 +62,7 @@ TGGC::TGGC(GCValues_t *values)
    fContext = 0;
    // case of default ctor at program startup before gClient exists
    if (!values) {
-      memset(&fValues, 0, sizeof(GCValues_t));
+      fValues = {};
       fContext = 0;
       SetRefCount(1);
       return;


### PR DESCRIPTION
Fix this kind of warnings with gcc8:
Warning: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'struct GCValues_t'; use assignment or value-initialization instead