### PR TITLE
WebGui - enable eve7 with Qt5 and CEF 

### DIFF
--- a/etc/eve7/index.html
+++ b/etc/eve7/index.html
@@ -29,12 +29,15 @@
       </div>
 
       <script type='text/javascript'>
+
+        var evedir = JSROOT.source_dir.replace(/jsrootsys/g, "evedir");
+
         function InitUI(handle) {
 
-           jQuery.sap.registerModulePath("eve", "/evedir/");
-           
+           jQuery.sap.registerModulePath("eve", evedir);
+
            var kind = JSROOT.GetUrlOption('view');
-           
+
            if (!kind) {
               new JSROOT.sap.ui.xmlview({
                   id: "TopEveId",
@@ -49,12 +52,12 @@
              }).placeAt("EveDiv");
            }
         }
-        
+
         if (JSROOT.GetUrlOption('nogl')!==null) JSROOT.gStyle.NoWebGL = true;
         if (JSROOT.GetUrlOption('libs')!==null) JSROOT.use_full_libs = true;
-        
+
         JSROOT.ConnectWebWindow({
-           prereq: "openui5;user:evedir/EveManager.js",
+           prereq: "openui5;user:" + evedir + "EveManager.js",
 //           openui5src: "jsroot",    // use JSROOT provided package, experimental
 //           openui5libs: "sap.m, sap.ui.layout, sap.ui.unified", // customize openui5 libs
            prereq_logdiv: "EveDiv",

--- a/etc/http/scripts/JSRootPainter.openui5.js
+++ b/etc/http/scripts/JSRootPainter.openui5.js
@@ -57,7 +57,9 @@
    if (JSROOT.openui5src == 'jsroot') src = JSROOT.source_dir + "openui5dist/"; else
    if (typeof JSROOT.openui5src == 'string') src = JSROOT.openui5src;
 
-   console.log('Use openui5 from ', src);
+   if ((src.indexOf("roothandler")==0) && (src.indexOf("://")<0)) src = src.replace(/\:\//g,"://");
+   
+   console.log('Use openui5 from ' + src);
 
    // this is location of openui5 scripts when working with THttpServer or when scripts are installed inside JSROOT
    element.setAttribute('src', src + "resources/sap-ui-core-nojQuery.js"); // latest openui5 version

--- a/graf3d/eve7/inc/ROOT/REveManager.hxx
+++ b/graf3d/eve7/inc/ROOT/REveManager.hxx
@@ -14,6 +14,8 @@
 
 #include <ROOT/REveElement.hxx>
 
+#include <ROOT/RWebDisplayArgs.hxx>
+
 #include "TSysEvtHandler.h"
 #include "TTimer.h"
 
@@ -236,7 +238,7 @@ public:
 
    void BroadcastElementsOf(REveElement::List_t &els);
 
-   void Show(const std::string &where = "");
+   void Show(const RWebDisplayArgs &args = "");
 
    ClassDef(REveManager, 0); // Eve application manager.
 };

--- a/graf3d/eve7/src/REveManager.cxx
+++ b/graf3d/eve7/src/REveManager.cxx
@@ -163,6 +163,7 @@ REveManager::REveManager() : // (Bool_t map_window, Option_t* opt) :
    fWebWindow->SetDataCallBack([this](unsigned connid, const std::string &arg) { this->HttpServerCallback(connid, arg); });
    fWebWindow->SetGeometry(900, 700); // configure predefined window geometry
    fWebWindow->SetConnLimit(100); // maximal number of connections
+   fWebWindow->SetMaxQueueLength(30); // number of allowed entries in the window queue
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -933,13 +934,13 @@ void REveManager::BroadcastElementsOf(REveElement::List_t& els)
 /// Show eve manager in specified browser
 /// If rootrc variable WebEve.DisableShow configured, just HTTP server will be started and URL printout
 
-void REveManager::Show(const std::string &where)
+void REveManager::Show(const RWebDisplayArgs &args)
 {
    if (gEnv->GetValue("WebEve.DisableShow", 0) != 0) {
       std::string url = fWebWindow->GetUrl(true);
       printf("EVE URL %s\n", url.c_str());
    } else {
-      fWebWindow->Show(where);
+      fWebWindow->Show(args);
    }
 }
 

--- a/gui/cefdisplay/src/simple_app.cxx
+++ b/gui/cefdisplay/src/simple_app.cxx
@@ -20,6 +20,7 @@
 #include "THttpServer.h"
 #include "THttpCallArg.h"
 #include "TUrl.h"
+#include "TEnv.h"
 #include "TTimer.h"
 #include "TApplication.h"
 #include "TROOT.h"
@@ -514,8 +515,9 @@ protected:
          // Initialize CEF for the browser process.
          CefInitialize(main_args, settings, fCefApp.get(), nullptr);
 
+         Int_t interval = gEnv->GetValue("WebGui.CefTimer", 10);
          // let run CEF message loop, should be improved later
-         TCefTimer *timer = new TCefTimer(10, kTRUE);
+         TCefTimer *timer = new TCefTimer((interval > 0) ? interval : 10, kTRUE);
          timer->TurnOn();
 
          return std::make_unique<RCefWebDisplayHandle>(args.GetFullUrl());

--- a/gui/qt5webdisplay/rootqt5.cpp
+++ b/gui/qt5webdisplay/rootqt5.cpp
@@ -22,8 +22,8 @@
 
 #include "TROOT.h"
 #include "TApplication.h"
-#include "TRint.h"
 #include "TTimer.h"
+#include "TEnv.h"
 #include "TThread.h"
 #include "THttpServer.h"
 
@@ -36,8 +36,6 @@
 #include <ROOT/RWebDisplayHandle.hxx>
 #include <ROOT/RMakeUnique.hxx>
 #include <ROOT/TLogger.hxx>
-
-#include <stdio.h>
 
 class TQt5Timer : public TTimer {
 public:
@@ -90,8 +88,11 @@ protected:
          }
 
          if (!fTimer) {
-            fTimer = new TQt5Timer(10, kTRUE);
-            fTimer->TurnOn();
+            Int_t interval = gEnv->GetValue("WebGui.Qt5Timer", 1);
+            if (interval > 0) {
+               fTimer = new TQt5Timer(interval, kTRUE);
+               fTimer->TurnOn();
+            }
          }
 
          std::unique_ptr<RootUrlSchemeHandler> handler;

--- a/gui/qt5webdisplay/rooturlschemehandler.cpp
+++ b/gui/qt5webdisplay/rooturlschemehandler.cpp
@@ -133,7 +133,7 @@ public:
 RootUrlSchemeHandler::RootUrlSchemeHandler(THttpServer *server, int counter)
    : QWebEngineUrlSchemeHandler(), fServer(server)
 {
-   fProtocol = Form("roothander%d", counter);
+   fProtocol = Form("roothandler%d", counter);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/gui/webdisplay/inc/ROOT/RWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindow.hxx
@@ -116,7 +116,7 @@ private:
    std::mutex fConnMutex;                           ///<! mutex used to protect connection list
    unsigned fConnLimit{1};                          ///<! number of allowed active connections
    bool fNativeOnlyConn{false};                     ///<! only native connection are allowed, created by Show() method
-   static const unsigned fMaxQueueLength{10};       ///<! maximal number of queue entries
+   unsigned fMaxQueueLength{10};                    ///<! maximal number of queue entries
    WebWindowDataCallback_t fDataCallback;           ///<! main callback when data over channel 1 is arrived
    std::thread::id fDataThrdId;                     ///<! thread id where data callback should be invoked
    std::queue<DataEntry> fDataQueue;                ///<! data queue for main callback
@@ -203,6 +203,14 @@ public:
    /////////////////////////////////////////////////////////////////////////
    /// returns configured connections limit (0 - default)
    unsigned GetConnLimit() const { return fConnLimit; }
+
+   /////////////////////////////////////////////////////////////////////////
+   /// configures maximal queue length of data which can be held by window
+   void SetMaxQueueLength(unsigned len = 10) { fMaxQueueLength = len; }
+
+   /////////////////////////////////////////////////////////////////////////
+   /// Return maximal queue length of data which can be held by window
+   unsigned GetMaxQueueLength() const { return fMaxQueueLength; }
 
    /////////////////////////////////////////////////////////////////////////
    /// configures that only native (own-created) connections are allowed

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -895,7 +895,7 @@ bool ROOT::Experimental::RWebWindow::CanSend(unsigned connid, bool direct)
       if (direct && (!conn->fQueue.empty() || (conn->fSendCredits == 0) || conn->fDoingSend))
          return false;
 
-      if (conn->fQueue.size() >= fMaxQueueLength)
+      if (conn->fQueue.size() >= GetMaxQueueLength())
          return false;
    }
 
@@ -939,7 +939,7 @@ void ROOT::Experimental::RWebWindow::SubmitData(unsigned connid, bool txt, std::
 
       std::lock_guard<std::mutex> grd(conn->fMutex);
 
-      if (conn->fQueue.size() < fMaxQueueLength) {
+      if (conn->fQueue.size() < GetMaxQueueLength()) {
          if (--cnt)
             conn->fQueue.emplace(chid, txt, std::string(data)); // make copy
          else


### PR DESCRIPTION
These are local displays and have tiny difference with standard HTTP communication.
Also Openui require very strict URL formatting.
Also qt5 web display performance increased.

Now one can use local display for eve7 and all other custom applications with complex HTML layout
