### PR TITLE
v6 14 Fix runtime_modules compilation failure

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1266,7 +1266,7 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
 
       LoadModules({"ROOT_Foundation_C", "ROOT_Config", "ROOT_Foundation_Stage1_NoRTTI", "Core", "RIO"}, *fInterpreter);
       if (!fromRootCling)
-         LoadModules({"TreePlayer", "VecOps"}, *fInterpreter);
+         LoadModules({"TreePlayer", "ROOTVecOps"}, *fInterpreter);
 
       // Check that the gROOT macro was exported by any core module.
       assert(fInterpreter->getMacro("gROOT") && "Couldn't load gROOT macro?");


### PR DESCRIPTION
VecOps was renamed to ROOTVecOps at some point. The failure can be seen in https://github.com/root-project/root/pull/2890#issuecomment-434707107 for example