### PR TITLE
[modules] Enable builds on OSX with modules.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,7 @@ if(cxxmodules)
     message(FATAL_ERROR "cxxmodules is not supported by this compiler")
   endif()
 
-  set(ROOT_CXXMODULES_COMMONFLAGS "${ROOT_CXXMODULES_COMMONFLAGS} -fmodules -fmodules-cache-path=${CMAKE_BINARY_DIR}/include/pcms/ -Xclang -fno-validate-pch -fno-autolink -fdiagnostics-show-note-include-stack -Wno-module-import-in-extern-c")
+  set(ROOT_CXXMODULES_COMMONFLAGS "${ROOT_CXXMODULES_COMMONFLAGS} -fmodules -fmodules-cache-path=${CMAKE_BINARY_DIR}/include/pcms/ -Xclang -fno-validate-pch -fno-autolink -fdiagnostics-show-note-include-stack")
 
   # FIXME: We should remove this once libc++ supports -fmodules-local-submodule-visibility.
   if (APPLE)
@@ -249,14 +249,8 @@ endif()
 
 if (cxxmodules)
   # These vars are useful when we want to compile things without cxxmodules.
-  set(ROOT_CXXMODULES_CXXFLAGS "${ROOT_CXXMODULES_COMMONFLAGS} -fcxx-modules" CACHE STRING "Useful to filter out the modules-related cxxflags.")
+  set(ROOT_CXXMODULES_CXXFLAGS "${ROOT_CXXMODULES_COMMONFLAGS} -fcxx-modules -Xclang -fmodules-local-submodule-visibility -Wno-module-import-in-extern-c" CACHE STRING "Useful to filter out the modules-related cxxflags.")
   set(ROOT_CXXMODULES_CFLAGS "${ROOT_CXXMODULES_COMMONFLAGS}" CACHE STRING "Useful to filter out the modules-related cflags.")
-  if (NOT APPLE)
-    set(ROOT_CXXMODULES_CXXFLAGS "${ROOT_CXXMODULES_COMMONFLAGS} -Xclang -fmodules-local-submodule-visibility" CACHE STRING "Useful to filter out the modules-related cxxflags." FORCE)
-    set(ROOT_CXXMODULES_CFLAGS "${ROOT_CXXMODULES_COMMONFLAGS} -Xclang -fmodules-local-submodule-visibility" CACHE STRING "Useful to filter out the modules-related cflags." FORCE)
-
-  endif()
-
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${ROOT_CXXMODULES_CFLAGS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ROOT_CXXMODULES_CXXFLAGS}")
 endif(cxxmodules)

--- a/graf3d/CMakeLists.txt
+++ b/graf3d/CMakeLists.txt
@@ -1,3 +1,11 @@
+if(cxxmodules AND APPLE)
+  # FIXME: Any header of graf3d can trigger building of the OSX OpenGL module.
+  # It looks like our glew infrastructure combined with the OpenGL modulemap
+  # cannot be compiled with -fmodules-local-submodule-visibility yet.
+  # Strip out that flag.
+  string(REPLACE "-Xclang -fmodules-local-submodule-visibility" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+endif()
+
 add_subdirectory(g3d) # special CMakeLists.txt
 if(NOT WIN32 AND x11)
   add_subdirectory(x3d) # special CMakeLists.txt

--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -134,7 +134,8 @@ if(cxxmodules)
   string(REPLACE "${ROOT_CXXMODULES_CFLAGS}" "" CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
   if(libcxx)
     # FIXME: We cannot build LLVM/clang with modules on with libstdc++, yet.
-    set (LLVM_ENABLE_MODULES ON CACHE BOOL "Override the default LLVM_ENABLE_MODULES option value." )
+    # FIXME: We cannot build LLVM/clang with modules on with libc++, too.
+    #set (LLVM_ENABLE_MODULES ON CACHE BOOL "Override the default LLVM_ENABLE_MODULES option value." )
   endif(libcxx)
 endif(cxxmodules)
 


### PR DESCRIPTION
XCode 10 comes with -fmodules-local-submodule-visibility aware toolchain.

This patch adjusts a few flags to enable a cxxmodules=On builds for this
platform. This patch will pave our way for enabling runtime_cxxmodules on OSX.