### PR TITLE
[cxxmodules] Yank the last bit of ROOT_MODULES env variable.

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -4163,7 +4163,7 @@ int RootClingMain(int argc,
    bool writeEmptyRootPCM = false;
    bool selSyntaxOnly = false;
    bool noIncludePaths = false;
-   bool cxxmodule = getenv("ROOT_MODULES") != nullptr;
+   bool cxxmodule = false;
 
    // Collect the diagnostic pragmas linked to the usage of -W
    // Workaround for ROOT-5656


### PR DESCRIPTION
Relying on env vars causes more headaches than it solves. Our infrastructure
is prepared to work well without that, we need to just pass -cxxmodule to
rootcling.