### PR TITLE
[ROOT-9685] Launch the Jupyter ROOT C++ kernel with ROOT's Python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,9 @@ foreach(var ${variables})
   endif()
 endforeach()
 
+#---Make sure the Jupyter ROOT C++ kernel runs with the same Python that ROOT is built with-----
+configure_file(${CMAKE_SOURCE_DIR}/etc/notebook/kernels/root/kernel.json.in ${CMAKE_BINARY_DIR}/etc/notebook/kernels/root/kernel.json)
+
 #---Move (copy) directories to binary tree------------------------------------------------------
 set(stamp_file ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/move_artifacts.stamp)
 add_custom_command(OUTPUT ${stamp_file}

--- a/etc/notebook/kernels/root/kernel.json.in
+++ b/etc/notebook/kernels/root/kernel.json.in
@@ -2,7 +2,7 @@
  "language": "c++",
  "display_name": "ROOT C++",
  "argv": [
-  "python",
+  "@PYTHON_EXECUTABLE@",
   "-m",
   "JupyROOT.kernel.rootkernel",
   "-f",


### PR DESCRIPTION
This addresses the issue reported by [ROOT-9685](https://sft.its.cern.ch/jira/browse/ROOT-9685).

We need to make sure the ROOT C++ kernel of Jupyter runs with the same Python that ROOT was built with.

Since this cannot be enforced by the user by setting the `$PATH` variable (Jupyter ignores that variable and picks Python from the system), we need to enforce it from the kernel file with a full path to the right Python binary.