### PR TITLE
Moving ROOT to use generic compression algorithm/level/settings

### DIFF
--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -39,6 +39,18 @@
 #endif
 #endif
 
+#if defined(R__WIN32)
+// adding attribute "deprecated" used in Compression.h
+// Visual C++.
+#define ROOT_DEPRECATED __declspec(deprecated)
+// gcc.
+#elif defined __GNUC__
+#define ROOT_DEPRECATED __attribute__((deprecated))
+// Other compilers: ignore the qualifier.
+#else
+#define ROOT_DEPRECATED
+#endif
+
 //---- forward declared class types --------------------------------------------
 
 class TClass;

--- a/core/zip/inc/Compression.h
+++ b/core/zip/inc/Compression.h
@@ -12,9 +12,7 @@
 #ifndef ROOT_Compression
 #define ROOT_Compression
 
-#if defined(__cplusplus)
 namespace ROOT {
-#endif
 
 /// The global settings depend on a global variable named R__ZipMode which can be
 /// modified by a global function named R__SetZipMode. Both are defined in Bits.h.
@@ -33,16 +31,19 @@ namespace ROOT {
 /// Level 0 means no compression.
 ///
 /// Recommendation for the compression algorithm's levels:
-///  - ZLIB is recommended to be used with compression level 1 [101] 
-///  - LZMA is recommended to be used with compression level 7-8 (higher is better, 
+///  - ZLIB is recommended to be used with compression level 1 [101]
+///  - LZMA is recommended to be used with compression level 7-8 (higher is better,
 ///   since in the case of LZMA we don't care about compression/decompression speed)
 ///   [207 - 208]
 ///  - LZ4 is recommended to be used with compression level 4 [404]
 
 
 enum ECompressionAlgorithm {
-   /// Use the global compression setting
-   kUseGlobalCompressionSetting,
+   /// Some objects use this value to denote that the compression algorithm
+   /// should be inherited from the parent object (e.g., TBranch should get the algorithm from the TTree)
+   kInheritCompressionAlgorithm = -1,
+   /// Use the global compression algorithm
+   kUseGlobalCompressionAlgorithm = 0,
    /// Use ZLIB compression
    kZLIB,
    /// Use LZMA compression
@@ -55,14 +56,37 @@ enum ECompressionAlgorithm {
    kUndefinedCompressionAlgorithm
 };
 
+enum ECompressionLevel {
+   /// Some objects use this value to denote that the compression algorithm
+   /// should be inherited from the parent object
+   kInheritCompressionLevel = -1,
+   // Compression level reserved for "uncompressed state"
+   kUncompressedLevel = 0,
+   // Compression level reserved when we are not sure what to use (1 is for the fastest compression)
+   kUseMinCompressionLevel = 1,
+   kDefaultZLIB = 1,
+   kDefaultLZ4 = 4,
+   kDefaultOld = 6,
+   kDefaultLZMA = 7
+};
+
+enum ECompressionSetting {
+   /// Use the global compression setting for this process; may be affected by rootrc.
+   kUseGlobalCompressionSetting = 0,
+   /// Use the compile-time default setting
+   kUseCompiledDefaultCompressionSetting = 404,
+   /// Use the default analysis setting; fast reading but poor compression ratio
+   kUseAnalysisCompressionSetting = 404,
+   /// Use the recommended general-purpose setting; moderate read / write speed and compression ratio
+   kUseGeneralPurposeCompressionSetting = 101,
+   /// Use the setting that results in the smallest files; very slow read and write
+   kUseSmallestCompressionSetting = 207
+};
+
 /// Deprecated name, do *not* use:
-static const enum ECompressionAlgorithm kUseGlobalSetting = kUseGlobalCompressionSetting;
+static constexpr ECompressionAlgorithm kUseGlobalSetting __attribute__ ((deprecated)) = kUseGlobalCompressionAlgorithm;
 
-#if defined(__cplusplus)
-
-   int CompressionSettings(ECompressionAlgorithm algorithm,
-                           int compressionLevel);
+int CompressionSettings(ECompressionAlgorithm algorithm, int compressionLevel);
 }
-#endif
 
 #endif

--- a/core/zip/inc/Compression.h
+++ b/core/zip/inc/Compression.h
@@ -12,6 +12,8 @@
 #ifndef ROOT_Compression
 #define ROOT_Compression
 
+#include "Rtypes.h"
+
 namespace ROOT {
 
 /// The global settings depend on a global variable named R__ZipMode which can be
@@ -84,7 +86,7 @@ enum ECompressionSetting {
 };
 
 /// Deprecated name, do *not* use:
-static constexpr ECompressionAlgorithm kUseGlobalSetting __attribute__ ((deprecated)) = kUseGlobalCompressionAlgorithm;
+ROOT_DEPRECATED static constexpr ECompressionAlgorithm kUseGlobalSetting = kUseGlobalCompressionAlgorithm;
 
 int CompressionSettings(ECompressionAlgorithm algorithm, int compressionLevel);
 }

--- a/core/zip/src/RZip.cxx
+++ b/core/zip/src/RZip.cxx
@@ -86,7 +86,7 @@ void R__zipMultipleAlgorithm(int cxlevel, int *srcsize, char *src, int *tgtsize,
     return;
   }
 
-  if (compressionAlgorithm == ROOT::ECompressionAlgorithm::kUseGlobalCompressionSetting) {
+  if (compressionAlgorithm == ROOT::ECompressionAlgorithm::kUseGlobalCompressionAlgorithm) {
     compressionAlgorithm = R__ZipMode;
   }
 
@@ -97,7 +97,7 @@ void R__zipMultipleAlgorithm(int cxlevel, int *srcsize, char *src, int *tgtsize,
   } else if (compressionAlgorithm == ROOT::ECompressionAlgorithm::kLZ4) {
      R__zipLZ4(cxlevel, srcsize, src, tgtsize, tgt, irep);
      return;
-  } else if (compressionAlgorithm == ROOT::ECompressionAlgorithm::kOldCompressionAlgo || compressionAlgorithm == ROOT::ECompressionAlgorithm::kUseGlobalCompressionSetting) {
+  } else if (compressionAlgorithm == ROOT::ECompressionAlgorithm::kOldCompressionAlgo || compressionAlgorithm == ROOT::ECompressionAlgorithm::kUseGlobalCompressionAlgorithm) {
      R__zipOld(cxlevel, srcsize, src, tgtsize, tgt, irep);
      return;
   } else {
@@ -239,7 +239,7 @@ static void R__zipZLIB(int cxlevel, int *srcsize, char *src, int *tgtsize, char 
 
 void R__zip(int cxlevel, int *srcsize, char *src, int *tgtsize, char *tgt, int *irep) {
    R__zipMultipleAlgorithm(cxlevel, srcsize, src, tgtsize, tgt, irep,
-                           ROOT::ECompressionAlgorithm::kUseGlobalCompressionSetting);
+                           ROOT::ECompressionAlgorithm::kUseGlobalCompressionAlgorithm);
 }
 
 /**

--- a/hist/hbook/inc/THbookBranch.h
+++ b/hist/hbook/inc/THbookBranch.h
@@ -30,8 +30,8 @@ protected:
 
 public:
    THbookBranch() {;}
-   THbookBranch(TTree *tree, const char *name, void *address, const char *leaflist, Int_t basketsize=32000, Int_t compress=-1);
-   THbookBranch(TBranch *branch, const char *name, void *address, const char *leaflist, Int_t basketsize=32000, Int_t compress=-1);
+   THbookBranch(TTree *tree, const char *name, void *address, const char *leaflist, Int_t basketsize=32000, Int_t compress = ROOT::kInheritCompressionAlgorithm);
+   THbookBranch(TBranch *branch, const char *name, void *address, const char *leaflist, Int_t basketsize=32000, Int_t compress = ROOT::kInheritCompressionAlgorithm);
    virtual ~THbookBranch();
    virtual void     Browse(TBrowser *b);
    virtual Int_t    GetEntry(Long64_t entry=0, Int_t getall=0);

--- a/io/castor/inc/TCastorFile.h
+++ b/io/castor/inc/TCastorFile.h
@@ -33,7 +33,7 @@ private:
 
 public:
    TCastorFile(const char *url, Option_t *option = "", const char *ftitle = "",
-               Int_t compress = 1, Int_t netopt = 0);
+               Int_t compress = ROOT::kUseGeneralPurposeCompressionSetting, Int_t netopt = 0);
    TCastorFile() : TNetFile() { fIsCastor = fWrittenTo = kFALSE; }
    virtual ~TCastorFile() { }
 

--- a/io/dcache/inc/TDCacheFile.h
+++ b/io/dcache/inc/TDCacheFile.h
@@ -41,7 +41,7 @@ private:
 
 public:
    TDCacheFile(const char *path, Option_t *option="",
-               const char *ftitle="", Int_t compress=1);
+               const char *ftitle="", Int_t compress = ROOT::kUseGeneralPurposeCompressionSetting);
 
    ~TDCacheFile();
 

--- a/io/gfal/inc/TGFALFile.h
+++ b/io/gfal/inc/TGFALFile.h
@@ -35,7 +35,7 @@ private:
 
 public:
    TGFALFile(const char *url, Option_t *option="",
-             const char *ftitle="", Int_t compress=1);
+             const char *ftitle="", Int_t compress = ROOT::kUseGeneralPurposeCompressionSetting);
    ~TGFALFile();
 
    Bool_t  ReadBuffer(char *buf, Int_t len);

--- a/io/hdfs/inc/THDFSFile.h
+++ b/io/hdfs/inc/THDFSFile.h
@@ -13,7 +13,6 @@
 #define ROOT_THDFSFile
 
 #include "TFile.h"
-
 #include "TSystem.h"
 
 class THDFSFile : public TFile {
@@ -36,7 +35,7 @@ private:
 
 public:
    THDFSFile(const char *path, Option_t *option="",
-             const char *ftitle="", Int_t compress=1);
+             const char *ftitle="", Int_t compress = ROOT::kUseGeneralPurposeCompressionSetting);
    virtual ~THDFSFile();
 
    void ResetErrno() const;

--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -45,7 +45,7 @@ public:
     * @param option Output file creation options
     * @param compression Output file compression level
     */
-   TBufferMerger(const char *name, Option_t *option = "RECREATE", Int_t compress = 1);
+   TBufferMerger(const char *name, Option_t *option = "RECREATE", Int_t compress = ROOT::kUseGeneralPurposeCompressionSetting);
 
    /** Constructor
     * @param output Output \c TFile

--- a/io/io/inc/TDirectoryFile.h
+++ b/io/io/inc/TDirectoryFile.h
@@ -21,6 +21,7 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
+#include "Compression.h"
 #include "TDirectory.h"
 
 class TList;
@@ -98,7 +99,7 @@ public:
    virtual void        ls(Option_t *option="") const;
    virtual TDirectory *mkdir(const char *name, const char *title="");
    virtual TFile      *OpenFile(const char *name, Option_t *option= "",
-                            const char *ftitle = "", Int_t compress = 1,
+                            const char *ftitle = "", Int_t compress = ROOT::kUseGeneralPurposeCompressionSetting,
                             Int_t netopt = 0);
    virtual void        Purge(Short_t nkeep=1);
    virtual void        ReadAll(Option_t *option="");

--- a/io/io/inc/TFile.h
+++ b/io/io/inc/TFile.h
@@ -23,6 +23,7 @@
 
 #include <atomic>
 
+#include "Compression.h"
 #include "TDirectoryFile.h"
 #include "TMap.h"
 #include "TUrl.h"
@@ -167,7 +168,7 @@ private:
 
    static void   CpProgress(Long64_t bytesread, Long64_t size, TStopwatch &watch);
    static TFile *OpenFromCache(const char *name, Option_t * = "",
-                               const char *ftitle = "", Int_t compress = 1,
+                               const char *ftitle = "", Int_t compress = ROOT::kUseGeneralPurposeCompressionSetting,
                                Int_t netopt = 0);
 
 public:
@@ -186,7 +187,7 @@ public:
    enum EFileType { kDefault = 0, kLocal = 1, kNet = 2, kWeb = 3, kFile = 4, kMerge = 5};
 
    TFile();
-   TFile(const char *fname, Option_t *option="", const char *ftitle="", Int_t compress=1);
+   TFile(const char *fname, Option_t *option="", const char *ftitle="", Int_t compress = ROOT::kUseGeneralPurposeCompressionSetting);
    virtual ~TFile();
    virtual void        Close(Option_t *option=""); // *MENU*
    virtual void        Copy(TObject &) const { MayNotUse("Copy(TObject &)"); }
@@ -264,9 +265,9 @@ public:
    virtual void        Seek(Long64_t offset, ERelativeTo pos = kBeg);
    virtual void        SetCacheRead(TFileCacheRead *cache, TObject* tree = 0, ECacheAction action = kDisconnect);
    virtual void        SetCacheWrite(TFileCacheWrite *cache);
-   virtual void        SetCompressionAlgorithm(Int_t algorithm=0);
-   virtual void        SetCompressionLevel(Int_t level=1);
-   virtual void        SetCompressionSettings(Int_t settings=1);
+   virtual void        SetCompressionAlgorithm(Int_t algorithm = ROOT::kUseGlobalCompressionAlgorithm);
+   virtual void        SetCompressionLevel(Int_t level = ROOT::kUseMinCompressionLevel);
+   virtual void        SetCompressionSettings(Int_t settings = ROOT::kUseGeneralPurposeCompressionSetting);
    virtual void        SetEND(Long64_t last) { fEND = last; }
    virtual void        SetOffset(Long64_t offset, ERelativeTo pos = kBeg);
    virtual void        SetOption(Option_t *option=">") { fOption = option; }
@@ -284,10 +285,10 @@ public:
 
    static TFileOpenHandle
                       *AsyncOpen(const char *name, Option_t *option = "",
-                                 const char *ftitle = "", Int_t compress = 1,
+                                 const char *ftitle = "", Int_t compress = ROOT::kUseGeneralPurposeCompressionSetting,
                                  Int_t netopt = 0);
    static TFile       *Open(const char *name, Option_t *option = "",
-                            const char *ftitle = "", Int_t compress = 1,
+                            const char *ftitle = "", Int_t compress = ROOT::kUseGeneralPurposeCompressionSetting,
                             Int_t netopt = 0);
    static TFile       *Open(TFileOpenHandle *handle);
 
@@ -354,7 +355,7 @@ private:
    Int_t    fNetOpt;     ///< Network options
    TFile   *fFile;       ///< TFile instance of the file being opened
 
-   TFileOpenHandle(TFile *f) : TNamed("",""), fOpt(""), fCompress(1),
+   TFileOpenHandle(TFile *f) : TNamed("",""), fOpt(""), fCompress(ROOT::kUseGeneralPurposeCompressionSetting),
                                fNetOpt(0), fFile(f) { }
    TFileOpenHandle(const char *n, const char *o, const char *t, Int_t cmp,
                    Int_t no) : TNamed(n,t), fOpt(o), fCompress(cmp),

--- a/io/io/inc/TMemFile.h
+++ b/io/io/inc/TMemFile.h
@@ -77,8 +77,8 @@ private:
    TMemFile &operator=(const TMemFile&); // Not implemented.
 
 public:
-   TMemFile(const char *name, Option_t *option="", const char *ftitle="", Int_t compress=1);
-   TMemFile(const char *name, char *buffer, Long64_t size, Option_t *option="", const char *ftitle="", Int_t compress=1);
+   TMemFile(const char *name, Option_t *option="", const char *ftitle="", Int_t compress = ROOT::kUseGeneralPurposeCompressionSetting);
+   TMemFile(const char *name, char *buffer, Long64_t size, Option_t *option="", const char *ftitle="", Int_t compress = ROOT::kUseGeneralPurposeCompressionSetting);
    TMemFile(const char *name, ExternalDataPtr_t data);
    TMemFile(const TMemFile &orig);
    virtual ~TMemFile();

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -173,7 +173,7 @@ AddPseudoGlobals() {
 ////////////////////////////////////////////////////////////////////////////////
 /// File default Constructor.
 
-TFile::TFile() : TDirectoryFile(), fInfoCache(0)
+TFile::TFile() : TDirectoryFile(), fCompress(ROOT::kUseGlobalCompressionAlgorithm), fInfoCache(0)
 {
    fD               = -1;
    fFree            = 0;
@@ -181,7 +181,6 @@ TFile::TFile() : TDirectoryFile(), fInfoCache(0)
    fSumBuffer       = 0;
    fSum2Buffer      = 0;
    fClassIndex      = 0;
-   fCompress        = 0;
    fProcessIDs      = 0;
    fNProcessIDs     = 0;
    fOffset          = 0;
@@ -208,7 +207,6 @@ TFile::TFile() : TDirectoryFile(), fInfoCache(0)
    fBytesRead      = 0;
    fBytesReadExtra = 0;
    fBytesWrite     = 0;
-   fCompress       = 0;
    fNbytesFree     = 0;
    fNbytesInfo     = 0;
    fSeekFree       = 0;
@@ -323,7 +321,7 @@ TFile::TFile() : TDirectoryFile(), fInfoCache(0)
 ///
 
 TFile::TFile(const char *fname1, Option_t *option, const char *ftitle, Int_t compress)
-           : TDirectoryFile(), fUrl(fname1,kTRUE), fInfoCache(0), fOpenPhases(0)
+           : TDirectoryFile(), fCompress(compress), fUrl(fname1,kTRUE), fInfoCache(0), fOpenPhases(0)
 {
    if (!gROOT)
       ::Fatal("TFile::TFile", "ROOT system not initialized");
@@ -368,7 +366,6 @@ TFile::TFile(const char *fname1, Option_t *option, const char *ftitle, Int_t com
    fVersion      = gROOT->GetVersionInt();  //ROOT version in integer format
    fUnits        = 4;
    fOption       = option;
-   fCompress     = compress;
    fWritten      = 0;
    fSumBuffer    = 0;
    fSum2Buffer   = 0;
@@ -2205,8 +2202,7 @@ void TFile::SetCompressionAlgorithm(Int_t algorithm)
 {
    if (algorithm < 0 || algorithm >= ROOT::kUndefinedCompressionAlgorithm) algorithm = 0;
    if (fCompress < 0) {
-      // if the level is not defined yet use 1 as a default
-      fCompress = 100 * algorithm + 1;
+      fCompress = 100 * algorithm + ROOT::kUseMinCompressionLevel;
    } else {
       int level = fCompress % 100;
       fCompress = 100 * algorithm + level;

--- a/io/rfio/inc/TRFIOFile.h
+++ b/io/rfio/inc/TRFIOFile.h
@@ -12,6 +12,7 @@
 #ifndef ROOT_TRFIOFile
 #define ROOT_TRFIOFile
 
+#include "Compression.h"
 #include "TFile.h"
 #include "TSystem.h"
 
@@ -33,7 +34,7 @@ private:
 
 public:
    TRFIOFile(const char *url, Option_t *option="",
-             const char *ftitle="", Int_t compress=1);
+             const char *ftitle="", Int_t compress = ROOT::kUseGeneralPurposeCompressionSetting);
    ~TRFIOFile();
 
    Int_t   GetErrno() const;

--- a/io/sql/src/TBufferSQL2.cxx
+++ b/io/sql/src/TBufferSQL2.cxx
@@ -57,8 +57,8 @@ ClassImp(TBufferSQL2);
 
 TBufferSQL2::TBufferSQL2()
    : TBufferText(), fSQL(nullptr), fIOVersion(1), fStructure(nullptr), fStk(0), fReadBuffer(), fErrorFlag(0),
-     fCompressLevel(0), fReadVersionBuffer(-1), fObjIdCounter(1), fIgnoreVerification(kFALSE), fCurrentData(nullptr),
-     fObjectsInfos(nullptr), fFirstObjId(0), fLastObjId(0), fPoolsMap(nullptr)
+     fCompressLevel(ROOT::kUseGlobalCompressionAlgorithm), fReadVersionBuffer(-1), fObjIdCounter(1), fIgnoreVerification(kFALSE),
+     fCurrentData(nullptr), fObjectsInfos(nullptr), fFirstObjId(0), fLastObjId(0), fPoolsMap(nullptr)
 {
 }
 
@@ -69,8 +69,8 @@ TBufferSQL2::TBufferSQL2()
 
 TBufferSQL2::TBufferSQL2(TBuffer::EMode mode, TSQLFile *file)
    : TBufferText(mode, file), fSQL(nullptr), fIOVersion(1), fStructure(nullptr), fStk(0), fReadBuffer(), fErrorFlag(0),
-     fCompressLevel(0), fReadVersionBuffer(-1), fObjIdCounter(1), fIgnoreVerification(kFALSE), fCurrentData(nullptr),
-     fObjectsInfos(nullptr), fFirstObjId(0), fLastObjId(0), fPoolsMap(nullptr)
+     fCompressLevel(ROOT::kUseGlobalCompressionAlgorithm), fReadVersionBuffer(-1), fObjIdCounter(1), fIgnoreVerification(kFALSE),
+     fCurrentData(nullptr), fObjectsInfos(nullptr), fFirstObjId(0), fLastObjId(0), fPoolsMap(nullptr)
 {
    fSQL = file;
    if (file) {

--- a/io/sql/src/TSQLFile.cxx
+++ b/io/sql/src/TSQLFile.cxx
@@ -328,7 +328,7 @@ TSQLFile::TSQLFile(const char *dbname, Option_t *option, const char *user, const
    fVersion = gROOT->GetVersionInt(); // ROOT version in integer format
    fUnits = 4;
    fOption = option;
-   SetCompressionLevel(5);
+   SetCompressionLevel(ROOT::kUseGeneralPurposeCompressionSetting  % 100);
    fWritten = 0;
    fSumBuffer = 0;
    fSum2Buffer = 0;

--- a/io/xml/inc/TBufferXML.h
+++ b/io/xml/inc/TBufferXML.h
@@ -12,6 +12,7 @@
 #ifndef ROOT_TBufferXML
 #define ROOT_TBufferXML
 
+#include "Compression.h"
 #include "TBufferText.h"
 #include "TXMLSetup.h"
 #include "TXMLEngine.h"
@@ -227,9 +228,9 @@ protected:
    Int_t GetCompressionAlgorithm() const;
    Int_t GetCompressionLevel() const;
    Int_t GetCompressionSettings() const;
-   void SetCompressionAlgorithm(Int_t algorithm = 0);
-   void SetCompressionLevel(Int_t level = 1);
-   void SetCompressionSettings(Int_t settings = 1);
+   void SetCompressionAlgorithm(Int_t algorithm = ROOT::kUseGlobalCompressionAlgorithm);
+   void SetCompressionLevel(Int_t level = ROOT::kUseMinCompressionLevel);
+   void SetCompressionSettings(Int_t settings = ROOT::kUseGeneralPurposeCompressionSetting);
    void SetXML(TXMLEngine *xml) { fXML = xml; }
 
    void XmlWriteBlock(XMLNodePointer_t node);

--- a/io/xml/inc/TXMLFile.h
+++ b/io/xml/inc/TXMLFile.h
@@ -12,6 +12,7 @@
 #ifndef ROOT_TXMLFile
 #define ROOT_TXMLFile
 
+#include "Compression.h"
 #include "TXMLEngine.h"
 #include "TFile.h"
 #include "TXMLSetup.h"
@@ -49,7 +50,7 @@ private:
 
 public:
    TXMLFile();
-   TXMLFile(const char *filename, Option_t *option = "read", const char *title = "title", Int_t compression = 1);
+   TXMLFile(const char *filename, Option_t *option = "read", const char *title = "title", Int_t compression = ROOT::kUseGeneralPurposeCompressionSetting);
    virtual ~TXMLFile();
 
    virtual void Close(Option_t *option = ""); // *MENU*

--- a/io/xml/src/TBufferXML.cxx
+++ b/io/xml/src/TBufferXML.cxx
@@ -365,8 +365,7 @@ void TBufferXML::SetCompressionAlgorithm(Int_t algorithm)
    if (algorithm < 0 || algorithm >= ROOT::kUndefinedCompressionAlgorithm)
       algorithm = 0;
    if (fCompressLevel < 0) {
-      // if the level is not defined yet use 1 as a default
-      fCompressLevel = 100 * algorithm + 1;
+      fCompressLevel = 100 * algorithm + ROOT::kUseMinCompressionLevel;
    } else {
       int level = fCompressLevel % 100;
       fCompressLevel = 100 * algorithm + level;

--- a/main/src/hadd.cxx
+++ b/main/src/hadd.cxx
@@ -12,7 +12,7 @@
          (targetfile is overwritten if it exists)
 
   When the -f option is specified, one can also specify the compression
-  level of the target file. By default the compression level is 1, but
+  level of the target file. By default the compression level is 1 (kDefaultZLIB), but
   if "-f0" is specified, the target file will not be compressed.
   if "-f6" is specified, the compression level 6 will be used.
 
@@ -69,7 +69,7 @@
             to support files with nested directories.
            Toby Burnett implemented the possibility to use indirect files.
  */
-
+#include "Compression.h"
 #include <ROOT/RConfig.h>
 #include "ROOT/TIOFeatures.hxx"
 #include <string>
@@ -124,7 +124,7 @@ int main( int argc, char **argv )
       std::cout << "If the option -experimental-io-features is used (and an argument provided), then\n"
                    "   the corresponding experimental feature will be enabled for output trees." << std::endl;
       std::cout << "When -the -f option is specified, one can also specify the compression level of\n"
-                   "   the target file.  By default the compression level is 4."
+                   "   the target file.  By default the compression level is kDefaultZLIB."
                 << std::endl;
       std::cout << "If \"-fk\" is specified, the target file contain the baskets with the same\n"
                    "   compression as in the input files unless -O is specified.  The meta data will\n"
@@ -421,9 +421,9 @@ int main( int argc, char **argv )
          if (firstInput && !firstInput->IsZombie())
             newcomp = firstInput->GetCompressionSettings();
          else
-            newcomp = 1;
+            newcomp = ROOT::kUseGeneralPurposeCompressionSetting % 100;
          delete firstInput;
-      } else newcomp = 1; // default compression level.
+      } else newcomp = ROOT::kUseGeneralPurposeCompressionSetting  % 100; // default compression level.
    }
    if (verbosity > 1) {
       if (keepCompressionAsIs && !reoptimize)

--- a/net/alien/inc/TAlienFile.h
+++ b/net/alien/inc/TAlienFile.h
@@ -52,7 +52,7 @@ private:
 public:
    TAlienFile() : TXNetFile(), fLfn(), fAuthz(), fGUID(), fUrl(), fPfn(), fSE(), fImage(0), fNreplicas(0), fOpenedAt(0), fElapsed(0) { }
    TAlienFile(const char *purl, Option_t *option = "",
-              const char *ftitle = "", Int_t compress = 1,
+              const char *ftitle = "", Int_t compress = ROOT::kUseGeneralPurposeCompressionSetting,
               Bool_t parallelopen = kFALSE, const char *lurl = 0,
               const char *authz = 0);
    virtual ~TAlienFile();
@@ -80,7 +80,7 @@ protected:
 
 public:
    static TAlienFile *Open(const char *lfn, const Option_t *option = "",
-                           const char *title = "", Int_t compress = 1,
+                           const char *title = "", Int_t compress = ROOT::kUseGeneralPurposeCompressionSetting,
                            Bool_t parallelopen = kFALSE);
    static TString     SUrl(const char *lfn);
 

--- a/net/davix/inc/TDavixFile.h
+++ b/net/davix/inc/TDavixFile.h
@@ -93,7 +93,7 @@ public:
     ///
     /// Several parameters can be used if separated with whitespace
 
-   TDavixFile(const char* url, Option_t *option="", const char *ftitle="", Int_t compress=1);
+   TDavixFile(const char* url, Option_t *option="", const char *ftitle="", Int_t compress = ROOT::kUseGeneralPurposeCompressionSetting);
 
    ~TDavixFile();
 

--- a/net/net/inc/TMessage.h
+++ b/net/net/inc/TMessage.h
@@ -22,6 +22,7 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
+#include "Compression.h"
 #include "TBufferFile.h"
 #include "MessageTypes.h"
 #include "TBits.h"
@@ -80,9 +81,9 @@ public:
    Int_t    GetCompressionAlgorithm() const;
    Int_t    GetCompressionLevel() const;
    Int_t    GetCompressionSettings() const;
-   void     SetCompressionAlgorithm(Int_t algorithm=0);
-   void     SetCompressionLevel(Int_t level=1);
-   void     SetCompressionSettings(Int_t settings=1);
+   void     SetCompressionAlgorithm(Int_t algorithm = ROOT::kUseGlobalCompressionAlgorithm);
+   void     SetCompressionLevel(Int_t level = ROOT::kUseMinCompressionLevel);
+   void     SetCompressionSettings(Int_t settings = ROOT::kUseGeneralPurposeCompressionSetting);
    Int_t    Compress();
    Int_t    Uncompress();
    char    *CompBuffer() const { return fBufComp; }

--- a/net/net/inc/TNetFile.h
+++ b/net/net/inc/TNetFile.h
@@ -60,7 +60,7 @@ protected:
 
 public:
    TNetFile(const char *url, Option_t *option = "", const char *ftitle = "",
-            Int_t compress = 1, Int_t netopt = 0);
+            Int_t compress = ROOT::kUseGeneralPurposeCompressionSetting, Int_t netopt = 0);
    TNetFile() : fEndpointUrl(), fUser(), fSocket(0), fProtocol(0), fErrorCode(0), fNetopt(0) { }
    virtual ~TNetFile();
 

--- a/net/net/inc/TParallelMergingFile.h
+++ b/net/net/inc/TParallelMergingFile.h
@@ -46,7 +46,7 @@ private:
    TMessage fMessage;
 
 public:
-   TParallelMergingFile(const char *filename, Option_t *option = "", const char *ftitle = "", Int_t compress = 1);
+   TParallelMergingFile(const char *filename, Option_t *option = "", const char *ftitle = "", Int_t compress = ROOT::kUseGeneralPurposeCompressionSetting);
    ~TParallelMergingFile();
 
    virtual void   Close(Option_t *option="");

--- a/net/net/inc/TSocket.h
+++ b/net/net/inc/TSocket.h
@@ -24,6 +24,7 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
+#include "Compression.h"
 #include "TNamed.h"
 #include "TBits.h"
 #include "TInetAddress.h"
@@ -99,7 +100,7 @@ protected:
 
    static Int_t  fgClientProtocol; // client "protocol" version
 
-   TSocket() : fAddress(), fBytesRecv(0), fBytesSent(0), fCompress(0),
+   TSocket() : fAddress(), fBytesRecv(0), fBytesSent(0), fCompress(ROOT::kUseGlobalCompressionAlgorithm),
                fLocalAddress(), fRemoteProtocol(), fSecContext(0), fService(),
                fServType(kSOCKD), fSocket(-1), fTcpWindowSize(0), fUrl(),
                fBitsInfo(), fUUIDs(0), fLastUsageMtx(0), fLastUsage() { }
@@ -163,9 +164,9 @@ public:
    virtual Int_t         SendObject(const TObject *obj, Int_t kind = kMESS_OBJECT);
    virtual Int_t         SendRaw(const void *buffer, Int_t length,
                                  ESendRecvOptions opt = kDefault);
-   void                  SetCompressionAlgorithm(Int_t algorithm=0);
-   void                  SetCompressionLevel(Int_t level=1);
-   void                  SetCompressionSettings(Int_t settings=1);
+   void                  SetCompressionAlgorithm(Int_t algorithm = ROOT::kUseGlobalCompressionAlgorithm);
+   void                  SetCompressionLevel(Int_t level = ROOT::kUseMinCompressionLevel);
+   void                  SetCompressionSettings(Int_t settings = ROOT::kUseGeneralPurposeCompressionSetting);
    virtual Int_t         SetOption(ESockOptions opt, Int_t val);
    void                  SetRemoteProtocol(Int_t rproto) { fRemoteProtocol = rproto; }
    void                  SetSecContext(TSecContext *ctx) { fSecContext = ctx; }

--- a/net/net/inc/TUDPSocket.h
+++ b/net/net/inc/TUDPSocket.h
@@ -131,9 +131,9 @@ public:
    virtual Int_t         SendObject(const TObject *obj, Int_t kind = kMESS_OBJECT);
    virtual Int_t         SendRaw(const void *buffer, Int_t length,
                                  ESendRecvOptions opt = kDefault);
-   void                  SetCompressionAlgorithm(Int_t algorithm=0);
-   void                  SetCompressionLevel(Int_t level=1);
-   void                  SetCompressionSettings(Int_t settings=1);
+   void                  SetCompressionAlgorithm(Int_t algorithm = ROOT::kUseGlobalCompressionAlgorithm);
+   void                  SetCompressionLevel(Int_t level = ROOT::kUseMinCompressionLevel);
+   void                  SetCompressionSettings(Int_t settings = ROOT::kUseGeneralPurposeCompressionSetting);
    virtual Int_t         SetOption(ESockOptions opt, Int_t val);
    void                  SetRemoteProtocol(Int_t rproto) { fRemoteProtocol = rproto; }
    void                  SetSecContext(TSecContext *ctx) { fSecContext = ctx; }

--- a/net/net/src/TMessage.cxx
+++ b/net/net/src/TMessage.cxx
@@ -44,7 +44,8 @@ ClassImp(TMessage);
 /// (only if message is > 256 bytes).
 
 TMessage::TMessage(UInt_t what, Int_t bufsiz) :
-   TBufferFile(TBuffer::kWrite, bufsiz + 2*sizeof(UInt_t))
+   TBufferFile(TBuffer::kWrite, bufsiz + 2*sizeof(UInt_t)),
+   fCompress(ROOT::kUseGlobalCompressionAlgorithm)
 {
    // space at the beginning of the message reserved for the message length
    UInt_t   reserved = 0;
@@ -54,7 +55,6 @@ TMessage::TMessage(UInt_t what, Int_t bufsiz) :
    *this << what;
 
    fClass      = 0;
-   fCompress   = 0;
    fBufComp    = 0;
    fBufCompCur = 0;
    fCompPos    = 0;
@@ -68,14 +68,14 @@ TMessage::TMessage(UInt_t what, Int_t bufsiz) :
 /// Create a TMessage object for reading objects. The objects will be
 /// read from buf. Use the What() method to get the message type.
 
-TMessage::TMessage(void *buf, Int_t bufsize) : TBufferFile(TBuffer::kRead, bufsize, buf)
+TMessage::TMessage(void *buf, Int_t bufsize) : TBufferFile(TBuffer::kRead, bufsize, buf),
+                                               fCompress(ROOT::kUseGlobalCompressionAlgorithm)
 {
    // skip space at the beginning of the message reserved for the message length
    fBufCur += sizeof(UInt_t);
 
    *this >> fWhat;
 
-   fCompress   = 0;
    fBufComp    = 0;
    fBufCompCur = 0;
    fCompPos    = 0;
@@ -239,7 +239,7 @@ void TMessage::SetCompressionAlgorithm(Int_t algorithm)
    if (algorithm < 0 || algorithm >= ROOT::kUndefinedCompressionAlgorithm) algorithm = 0;
    Int_t newCompress;
    if (fCompress < 0) {
-      newCompress = 100 * algorithm + 1;
+      newCompress = 100 * algorithm + ROOT::kUseMinCompressionLevel;
    } else {
       int level = fCompress % 100;
       newCompress = 100 * algorithm + level;

--- a/net/net/src/TSocket.cxx
+++ b/net/net/src/TSocket.cxx
@@ -75,7 +75,7 @@ ClassImp(TSocket);
 /// closed on program termination.
 
 TSocket::TSocket(TInetAddress addr, const char *service, Int_t tcpwindowsize)
-         : TNamed(addr.GetHostName(), service)
+         : TNamed(addr.GetHostName(), service), fCompress(ROOT::kUseGlobalCompressionAlgorithm)
 {
    R__ASSERT(gROOT);
    R__ASSERT(gSystem);
@@ -92,7 +92,6 @@ TSocket::TSocket(TInetAddress addr, const char *service, Int_t tcpwindowsize)
    fAddress.fPort = gSystem->GetServiceByName(service);
    fBytesSent = 0;
    fBytesRecv = 0;
-   fCompress = 0;
    fTcpWindowSize = tcpwindowsize;
    fUUIDs = 0;
    fLastUsageMtx = 0;
@@ -121,7 +120,7 @@ TSocket::TSocket(TInetAddress addr, const char *service, Int_t tcpwindowsize)
 /// closed on program termination.
 
 TSocket::TSocket(TInetAddress addr, Int_t port, Int_t tcpwindowsize)
-         : TNamed(addr.GetHostName(), "")
+         : TNamed(addr.GetHostName(), ""), fCompress(ROOT::kUseGlobalCompressionAlgorithm)
 {
    R__ASSERT(gROOT);
    R__ASSERT(gSystem);
@@ -139,7 +138,6 @@ TSocket::TSocket(TInetAddress addr, Int_t port, Int_t tcpwindowsize)
    SetTitle(fService);
    fBytesSent = 0;
    fBytesRecv = 0;
-   fCompress = 0;
    fTcpWindowSize = tcpwindowsize;
    fUUIDs = 0;
    fLastUsageMtx = 0;
@@ -165,7 +163,7 @@ TSocket::TSocket(TInetAddress addr, Int_t port, Int_t tcpwindowsize)
 /// closed on program termination.
 
 TSocket::TSocket(const char *host, const char *service, Int_t tcpwindowsize)
-         : TNamed(host, service)
+         : TNamed(host, service), fCompress(ROOT::kUseGlobalCompressionAlgorithm)
 {
    R__ASSERT(gROOT);
    R__ASSERT(gSystem);
@@ -183,7 +181,6 @@ TSocket::TSocket(const char *host, const char *service, Int_t tcpwindowsize)
    SetName(fAddress.GetHostName());
    fBytesSent = 0;
    fBytesRecv = 0;
-   fCompress = 0;
    fTcpWindowSize = tcpwindowsize;
    fUUIDs = 0;
    fLastUsageMtx = 0;
@@ -211,7 +208,7 @@ TSocket::TSocket(const char *host, const char *service, Int_t tcpwindowsize)
 /// closed on program termination.
 
 TSocket::TSocket(const char *url, Int_t port, Int_t tcpwindowsize)
-         : TNamed(TUrl(url).GetHost(), "")
+         : TNamed(TUrl(url).GetHost(), ""), fCompress(ROOT::kUseGlobalCompressionAlgorithm)
 {
    R__ASSERT(gROOT);
    R__ASSERT(gSystem);
@@ -233,7 +230,6 @@ TSocket::TSocket(const char *url, Int_t port, Int_t tcpwindowsize)
    SetTitle(fService);
    fBytesSent = 0;
    fBytesRecv = 0;
-   fCompress = 0;
    fTcpWindowSize = tcpwindowsize;
    fUUIDs = 0;
    fLastUsageMtx = 0;
@@ -254,7 +250,8 @@ TSocket::TSocket(const char *url, Int_t port, Int_t tcpwindowsize)
 /// sockets list which will make sure that any open sockets are properly
 /// closed on program termination.
 
-TSocket::TSocket(const char *sockpath) : TNamed(sockpath, "")
+TSocket::TSocket(const char *sockpath) : TNamed(sockpath, ""),
+                                         fCompress(ROOT::kUseGlobalCompressionAlgorithm)
 {
    R__ASSERT(gROOT);
    R__ASSERT(gSystem);
@@ -270,7 +267,6 @@ TSocket::TSocket(const char *sockpath) : TNamed(sockpath, "")
    SetTitle(fService);
    fBytesSent = 0;
    fBytesRecv = 0;
-   fCompress  = 0;
    fTcpWindowSize = -1;
    fUUIDs = 0;
    fLastUsageMtx  = 0;
@@ -286,7 +282,7 @@ TSocket::TSocket(const char *sockpath) : TNamed(sockpath, "")
 /// Create a socket. The socket will adopt previously opened TCP socket with
 /// descriptor desc.
 
-TSocket::TSocket(Int_t desc) : TNamed("", "")
+TSocket::TSocket(Int_t desc) : TNamed("", ""), fCompress(ROOT::kUseGlobalCompressionAlgorithm)
 {
    R__ASSERT(gROOT);
    R__ASSERT(gSystem);
@@ -297,7 +293,6 @@ TSocket::TSocket(Int_t desc) : TNamed("", "")
    fServType       = kSOCKD;
    fBytesSent      = 0;
    fBytesRecv      = 0;
-   fCompress       = 0;
    fTcpWindowSize = -1;
    fUUIDs          = 0;
    fLastUsageMtx   = 0;
@@ -316,7 +311,8 @@ TSocket::TSocket(Int_t desc) : TNamed("", "")
 /// descriptor desc. The sockpath arg is for info purposes only. Use
 /// this method to adopt e.g. a socket created via socketpair().
 
-TSocket::TSocket(Int_t desc, const char *sockpath) : TNamed(sockpath, "")
+TSocket::TSocket(Int_t desc, const char *sockpath) : TNamed(sockpath, ""),
+                                                     fCompress(ROOT::kUseGlobalCompressionAlgorithm)
 {
    R__ASSERT(gROOT);
    R__ASSERT(gSystem);
@@ -332,7 +328,6 @@ TSocket::TSocket(Int_t desc, const char *sockpath) : TNamed(sockpath, "")
    SetTitle(fService);
    fBytesSent = 0;
    fBytesRecv = 0;
-   fCompress  = 0;
    fTcpWindowSize = -1;
    fUUIDs = 0;
    fLastUsageMtx  = 0;
@@ -1051,8 +1046,7 @@ void TSocket::SetCompressionAlgorithm(Int_t algorithm)
 {
    if (algorithm < 0 || algorithm >= ROOT::kUndefinedCompressionAlgorithm) algorithm = 0;
    if (fCompress < 0) {
-      // if the level is not defined yet use 1 as a default
-      fCompress = 100 * algorithm + 1;
+      fCompress = 100 * algorithm + ROOT::kUseMinCompressionLevel;
    } else {
       int level = fCompress % 100;
       fCompress = 100 * algorithm + level;

--- a/net/net/src/TUDPSocket.cxx
+++ b/net/net/src/TUDPSocket.cxx
@@ -53,7 +53,7 @@ ClassImp(TUDPSocket);
 /// closed on program termination.
 
 TUDPSocket::TUDPSocket(TInetAddress addr, const char *service)
-         : TNamed(addr.GetHostName(), service)
+         : TNamed(addr.GetHostName(), service), fCompress(ROOT::kUseGlobalCompressionAlgorithm)
 {
    R__ASSERT(gROOT);
    R__ASSERT(gSystem);
@@ -70,7 +70,6 @@ TUDPSocket::TUDPSocket(TInetAddress addr, const char *service)
    fAddress.fPort = gSystem->GetServiceByName(service);
    fBytesSent = 0;
    fBytesRecv = 0;
-   fCompress = 0;
    fUUIDs = 0;
    fLastUsageMtx = 0;
    ResetBit(TUDPSocket::kBrokenConn);
@@ -100,7 +99,7 @@ TUDPSocket::TUDPSocket(TInetAddress addr, const char *service)
 /// closed on program termination.
 
 TUDPSocket::TUDPSocket(TInetAddress addr, Int_t port)
-         : TNamed(addr.GetHostName(), "")
+         : TNamed(addr.GetHostName(), ""), fCompress(ROOT::kUseGlobalCompressionAlgorithm)
 {
    R__ASSERT(gROOT);
    R__ASSERT(gSystem);
@@ -118,7 +117,6 @@ TUDPSocket::TUDPSocket(TInetAddress addr, Int_t port)
    SetTitle(fService);
    fBytesSent = 0;
    fBytesRecv = 0;
-   fCompress = 0;
    fUUIDs = 0;
    fLastUsageMtx = 0;
    ResetBit(TUDPSocket::kBrokenConn);
@@ -144,7 +142,7 @@ TUDPSocket::TUDPSocket(TInetAddress addr, Int_t port)
 /// closed on program termination.
 
 TUDPSocket::TUDPSocket(const char *host, const char *service)
-         : TNamed(host, service)
+         : TNamed(host, service), fCompress(ROOT::kUseGlobalCompressionAlgorithm)
 {
    R__ASSERT(gROOT);
    R__ASSERT(gSystem);
@@ -162,7 +160,6 @@ TUDPSocket::TUDPSocket(const char *host, const char *service)
    SetName(fAddress.GetHostName());
    fBytesSent = 0;
    fBytesRecv = 0;
-   fCompress = 0;
    fUUIDs = 0;
    fLastUsageMtx = 0;
    ResetBit(TUDPSocket::kBrokenConn);
@@ -190,7 +187,7 @@ TUDPSocket::TUDPSocket(const char *host, const char *service)
 /// closed on program termination.
 
 TUDPSocket::TUDPSocket(const char *url, Int_t port)
-         : TNamed(TUrl(url).GetHost(), "")
+         : TNamed(TUrl(url).GetHost(), ""), fCompress(ROOT::kUseGlobalCompressionAlgorithm)
 {
    R__ASSERT(gROOT);
    R__ASSERT(gSystem);
@@ -212,7 +209,6 @@ TUDPSocket::TUDPSocket(const char *url, Int_t port)
    SetTitle(fService);
    fBytesSent = 0;
    fBytesRecv = 0;
-   fCompress = 0;
    fUUIDs = 0;
    fLastUsageMtx = 0;
    ResetBit(TUDPSocket::kBrokenConn);
@@ -233,7 +229,8 @@ TUDPSocket::TUDPSocket(const char *url, Int_t port)
 /// sockets list which will make sure that any open sockets are properly
 /// closed on program termination.
 
-TUDPSocket::TUDPSocket(const char *sockpath) : TNamed(sockpath, "")
+TUDPSocket::TUDPSocket(const char *sockpath) : TNamed(sockpath, ""),
+                                               fCompress(ROOT::kUseGlobalCompressionAlgorithm)
 {
    R__ASSERT(gROOT);
    R__ASSERT(gSystem);
@@ -249,7 +246,6 @@ TUDPSocket::TUDPSocket(const char *sockpath) : TNamed(sockpath, "")
    SetTitle(fService);
    fBytesSent = 0;
    fBytesRecv = 0;
-   fCompress  = 0;
    fUUIDs = 0;
    fLastUsageMtx  = 0;
    ResetBit(TUDPSocket::kBrokenConn);
@@ -265,7 +261,7 @@ TUDPSocket::TUDPSocket(const char *sockpath) : TNamed(sockpath, "")
 /// Create a socket. The socket will adopt previously opened TCP socket with
 /// descriptor desc.
 
-TUDPSocket::TUDPSocket(Int_t desc) : TNamed("", "")
+TUDPSocket::TUDPSocket(Int_t desc) : TNamed("", ""), fCompress(ROOT::kUseGlobalCompressionAlgorithm)
 {
    R__ASSERT(gROOT);
    R__ASSERT(gSystem);
@@ -276,7 +272,6 @@ TUDPSocket::TUDPSocket(Int_t desc) : TNamed("", "")
    fServType       = kSOCKD;
    fBytesSent      = 0;
    fBytesRecv      = 0;
-   fCompress       = 0;
    fUUIDs          = 0;
    fLastUsageMtx   = 0;
    ResetBit(TUDPSocket::kBrokenConn);
@@ -295,7 +290,8 @@ TUDPSocket::TUDPSocket(Int_t desc) : TNamed("", "")
 /// descriptor desc. The sockpath arg is for info purposes only. Use
 /// this method to adopt e.g. a socket created via socketpair().
 
-TUDPSocket::TUDPSocket(Int_t desc, const char *sockpath) : TNamed(sockpath, "")
+TUDPSocket::TUDPSocket(Int_t desc, const char *sockpath) : TNamed(sockpath, ""),
+                                                           fCompress(ROOT::kUseGlobalCompressionAlgorithm)
 {
    R__ASSERT(gROOT);
    R__ASSERT(gSystem);
@@ -311,7 +307,6 @@ TUDPSocket::TUDPSocket(Int_t desc, const char *sockpath) : TNamed(sockpath, "")
    SetTitle(fService);
    fBytesSent = 0;
    fBytesRecv = 0;
-   fCompress  = 0;
    fUUIDs = 0;
    fLastUsageMtx  = 0;
    ResetBit(TUDPSocket::kBrokenConn);
@@ -1022,8 +1017,8 @@ void TUDPSocket::SetCompressionAlgorithm(Int_t algorithm)
 {
    if (algorithm < 0 || algorithm >= ROOT::kUndefinedCompressionAlgorithm) algorithm = 0;
    if (fCompress < 0) {
-      // if the level is not defined yet use 1 as a default
-      fCompress = 100 * algorithm + 1;
+      // if the level is not defined yet use 4 as a default (with ZLIB was 1)
+      fCompress = 100 * algorithm + ROOT::kUseMinCompressionLevel;
    } else {
       int level = fCompress % 100;
       fCompress = 100 * algorithm + level;

--- a/roofit/roofitcore/src/RooAbsCategory.cxx
+++ b/roofit/roofitcore/src/RooAbsCategory.cxx
@@ -30,6 +30,7 @@ is provided to modify the contents, nor a public interface to define states.
 
 #include "RooFit.h"
 
+#include "Compression.h"
 #include "Riostream.h"
 #include "Riostream.h"
 #include <stdlib.h>
@@ -46,19 +47,19 @@ is provided to modify the contents, nor a public interface to define states.
 
 using namespace std;
 
-ClassImp(RooAbsCategory); 
+ClassImp(RooAbsCategory);
 ;
 
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor
 
-RooAbsCategory::RooAbsCategory(const char *name, const char *title) : 
+RooAbsCategory::RooAbsCategory(const char *name, const char *title) :
   RooAbsArg(name,title), _value("NULL",0), _treeVar(kFALSE)
 {
   _typeIter = _types.MakeIterator() ;
-  setValueDirty() ;  
-  setShapeDirty() ;  
+  setValueDirty() ;
+  setShapeDirty() ;
 }
 
 
@@ -67,7 +68,7 @@ RooAbsCategory::RooAbsCategory(const char *name, const char *title) :
 /// Copy constructor, copies the registered category states from the original.
 
 RooAbsCategory::RooAbsCategory(const RooAbsCategory& other,const char* name) :
-  RooAbsArg(other,name), _value(other._value), _treeVar(other._treeVar) 
+  RooAbsArg(other,name), _value(other._value), _treeVar(other._treeVar)
 {
   _typeIter = _types.MakeIterator() ;
 
@@ -88,7 +89,7 @@ RooAbsCategory::RooAbsCategory(const RooAbsCategory& other,const char* name) :
 
 RooAbsCategory::~RooAbsCategory()
 {
-  // We own the contents of _types 
+  // We own the contents of _types
   delete _typeIter ;
   _types.Delete() ;
 }
@@ -96,7 +97,7 @@ RooAbsCategory::~RooAbsCategory()
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return index number of current state 
+/// Return index number of current state
 
 Int_t RooAbsCategory::getIndex() const
 {
@@ -113,7 +114,7 @@ Int_t RooAbsCategory::getIndex() const
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return label string of current state 
+/// Return label string of current state
 
 const char* RooAbsCategory::getLabel() const
 {
@@ -127,7 +128,7 @@ const char* RooAbsCategory::getLabel() const
   const char* ret = _value.GetName() ;
   // If label is not set, do it now on the fly
   if (ret==0) {
-    _value.SetName(lookupType(_value.getVal())->GetName()) ;    
+    _value.SetName(lookupType(_value.getVal())->GetName()) ;
   }
   return _value.GetName() ;
 }
@@ -140,7 +141,7 @@ const char* RooAbsCategory::getLabel() const
 RooCatType RooAbsCategory::traceEval() const
 {
   RooCatType value = evaluate() ;
-  
+
   // Standard tracing code goes here
   if (!isValid(value)) {
   }
@@ -186,7 +187,7 @@ Bool_t RooAbsCategory::operator==(const char* label) const
 /// Equality operator with another RooAbsArg. Only functional
 /// is also a RooAbsCategory, will return true if index is the same
 
-Bool_t RooAbsCategory::operator==(const RooAbsArg& other) 
+Bool_t RooAbsCategory::operator==(const RooAbsArg& other)
 {
   const RooAbsCategory* otherCat = dynamic_cast<const RooAbsCategory*>(&other) ;
   return otherCat ? operator==(otherCat->getIndex()) : kFALSE ;
@@ -195,7 +196,7 @@ Bool_t RooAbsCategory::operator==(const RooAbsArg& other)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Bool_t RooAbsCategory::isIdentical(const RooAbsArg& other, Bool_t assumeSameType)  
+Bool_t RooAbsCategory::isIdentical(const RooAbsArg& other, Bool_t assumeSameType)
 {
   if (!assumeSameType) {
     const RooAbsCategory* otherCat = dynamic_cast<const RooAbsCategory*>(&other) ;
@@ -237,8 +238,8 @@ const RooCatType* RooAbsCategory::defineType(const char* label)
   // Find lowest unused index
   Int_t index(-1) ;
   while(lookupType(++index,kFALSE)) ;
-  
-  // Assign this index to given label 
+
+  // Assign this index to given label
   return defineType(label,index) ;
 }
 
@@ -247,7 +248,7 @@ const RooCatType* RooAbsCategory::defineType(const char* label)
 /// Internal version of defineType that does not check if type
 /// already exists
 
-const RooCatType* RooAbsCategory::defineTypeUnchecked(const char* label, Int_t index) 
+const RooCatType* RooAbsCategory::defineTypeUnchecked(const char* label, Int_t index)
 {
   Bool_t first = _types.GetEntries()?kFALSE:kTRUE ;
   RooCatType *newType = new RooCatType(label,index) ;
@@ -256,7 +257,7 @@ const RooCatType* RooAbsCategory::defineTypeUnchecked(const char* label, Int_t i
   if (first) _value = RooCatType(label,index) ;
   setShapeDirty() ;
 
-  return newType ;  
+  return newType ;
 }
 
 
@@ -264,16 +265,16 @@ const RooCatType* RooAbsCategory::defineTypeUnchecked(const char* label, Int_t i
 ////////////////////////////////////////////////////////////////////////////////
 /// Define new state with given name and index number.
 
-const RooCatType* RooAbsCategory::defineType(const char* label, Int_t index) 
+const RooCatType* RooAbsCategory::defineType(const char* label, Int_t index)
 {
   if (isValidIndex(index)) {
-    coutE(InputArguments) << "RooAbsCategory::defineType(" << GetName() << "): index " 
+    coutE(InputArguments) << "RooAbsCategory::defineType(" << GetName() << "): index "
 			  << index << " already assigned" << endl ;
     return 0 ;
   }
 
   if (isValidLabel(label)) {
-    coutE(InputArguments) << "RooAbsCategory::defineType(" << GetName() << "): label " 
+    coutE(InputArguments) << "RooAbsCategory::defineType(" << GetName() << "): label "
 			  << label << " already assigned or not allowed" << endl ;
     return 0 ;
   }
@@ -286,7 +287,7 @@ const RooCatType* RooAbsCategory::defineType(const char* label, Int_t index)
 ////////////////////////////////////////////////////////////////////////////////
 /// Delete all currently defined states
 
-void RooAbsCategory::clearTypes() 
+void RooAbsCategory::clearTypes()
 {
   _types.Delete() ;
   _value = RooCatType("",0) ;
@@ -298,7 +299,7 @@ void RooAbsCategory::clearTypes()
 ////////////////////////////////////////////////////////////////////////////////
 /// Find our type that matches the specified type, or return 0 for no match.
 
-const RooCatType* RooAbsCategory::lookupType(const RooCatType &other, Bool_t printError) const 
+const RooCatType* RooAbsCategory::lookupType(const RooCatType &other, Bool_t printError) const
 {
   RooCatType* type ;
   _typeIter->Reset() ;
@@ -324,7 +325,7 @@ const RooCatType* RooAbsCategory::lookupType(Int_t index, Bool_t printError) con
 {
   RooCatType* type ;
   _typeIter->Reset() ;
-  while((type=(RooCatType*)_typeIter->Next())){  
+  while((type=(RooCatType*)_typeIter->Next())){
     if((*type) == index) return type; // delegate comparison to RooCatType
   }
   if (printError) {
@@ -339,11 +340,11 @@ const RooCatType* RooAbsCategory::lookupType(Int_t index, Bool_t printError) con
 ////////////////////////////////////////////////////////////////////////////////
 /// Find our type corresponding to the specified label, or return 0 for no match.
 
-const RooCatType* RooAbsCategory::lookupType(const char* label, Bool_t printError) const 
+const RooCatType* RooAbsCategory::lookupType(const char* label, Bool_t printError) const
 {
   RooCatType* type ;
   _typeIter->Reset() ;
-  while((type=(RooCatType*)_typeIter->Next())){  
+  while((type=(RooCatType*)_typeIter->Next())){
     if((*type) == label) return type; // delegate comparison to RooCatType
   }
 
@@ -352,7 +353,7 @@ const RooCatType* RooAbsCategory::lookupType(const char* label, Bool_t printErro
   Int_t idx=strtol(label,&endptr,10)  ;
   if (endptr==label+strlen(label)) {
     _typeIter->Reset() ;
-    while((type=(RooCatType*)_typeIter->Next())){  
+    while((type=(RooCatType*)_typeIter->Next())){
        if((*type) == idx) return type; // delegate comparison to RooCatType
      }
   }
@@ -399,15 +400,15 @@ Roo1DTable* RooAbsCategory::createTable(const char *label)  const
 ////////////////////////////////////////////////////////////////////////////////
 /// Read object contents from stream (dummy for now)
 
-Bool_t RooAbsCategory::readFromStream(istream&, Bool_t, Bool_t) 
+Bool_t RooAbsCategory::readFromStream(istream&, Bool_t, Bool_t)
 {
   return kFALSE ;
-} 
+}
 
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Write object contents to ostream 
+/// Write object contents to ostream
 
 void RooAbsCategory::writeToStream(ostream& os, Bool_t compact) const
 {
@@ -464,7 +465,7 @@ void RooAbsCategory::printMultiline(ostream& os, Int_t contents, Bool_t verbose,
 void RooAbsCategory::attachToVStore(RooVectorDataStore& vstore)
 {
   RooVectorDataStore::CatVector* cv = vstore.addCategory(this) ;
-  cv->setBuffer(&_value) ;  
+  cv->setBuffer(&_value) ;
 }
 
 
@@ -487,66 +488,66 @@ void RooAbsCategory::attachToTree(TTree& t, Int_t bufSize)
     if (!typeName.CompareTo("Int_t")) {
       // Imported TTree: attach only index field as branch
 
-      coutI(DataHandling) << "RooAbsCategory::attachToTree(" << GetName() << ") TTree branch " << GetName() 
+      coutI(DataHandling) << "RooAbsCategory::attachToTree(" << GetName() << ") TTree branch " << GetName()
 			  << " will be interpreted as category index" << endl ;
-      
+
       t.SetBranchAddress(cleanName,&((Int_t&)_value._value)) ;
-      setAttribute("INTIDXONLY_TREE_BRANCH",kTRUE) ;      
+      setAttribute("INTIDXONLY_TREE_BRANCH",kTRUE) ;
       _treeVar = kTRUE ;
       return ;
     } else if (!typeName.CompareTo("UChar_t")) {
-      coutI(DataHandling) << "RooAbsReal::attachToTree(" << GetName() << ") TTree UChar_t branch " << GetName() 
+      coutI(DataHandling) << "RooAbsReal::attachToTree(" << GetName() << ") TTree UChar_t branch " << GetName()
 			  << " will be interpreted as category index" << endl ;
       t.SetBranchAddress(cleanName,&_byteValue) ;
       setAttribute("UCHARIDXONLY_TREE_BRANCH",kTRUE) ;
       _treeVar = kTRUE ;
       return ;
-    } 
+    }
 
     if (branch->GetCompressionLevel()<0) {
       cxcoutD(DataHandling) << "RooAbsCategory::attachToTree(" << GetName() << ") Fixing compression level of branch " << GetName() << endl ;
-      branch->SetCompressionLevel(1) ;
+      branch->SetCompressionLevel(ROOT::kUseGlobalCompressionSetting % 100) ;
     }
   }
 
-  // Native TTree: attach both index and label of category as branches  
+  // Native TTree: attach both index and label of category as branches
   TString idxName(cleanName) ;
-  TString lblName(cleanName) ;  
+  TString lblName(cleanName) ;
   idxName.Append("_idx") ;
   lblName.Append("_lbl") ;
-  
+
   // First determine if branch is taken
-  if ((branch = t.GetBranch(idxName))) {    
+  if ((branch = t.GetBranch(idxName))) {
 
     t.SetBranchAddress(idxName,&((Int_t&)_value._value)) ;
     if (branch->GetCompressionLevel()<0) {
       cxcoutD(Contents) << "RooAbsCategory::attachToTree(" << GetName() << ") Fixing compression level of branch " << idxName << endl ;
-      branch->SetCompressionLevel(1) ;
+      branch->SetCompressionLevel(ROOT::kUseGlobalCompressionSetting % 100) ;
     }
-    
-  } else {    
+
+  } else {
     TString format(idxName);
     format.Append("/I");
     void* ptr = &(_value._value) ;
     branch = t.Branch(idxName, ptr, (const Text_t*)format, bufSize);
-    branch->SetCompressionLevel(1) ;
+    branch->SetCompressionLevel(ROOT::kUseGlobalCompressionSetting % 100) ;
   }
-  
+
   // First determine if branch is taken
   if ((branch = t.GetBranch(lblName))) {
 
     t.SetBranchAddress(lblName,_value._label) ;
     if (branch->GetCompressionLevel()<0) {
       cxcoutD(DataHandling) << "RooAbsCategory::attachToTree(" << GetName() << ") Fixing compression level of branch " << lblName << endl ;
-      branch->SetCompressionLevel(1) ;
+      branch->SetCompressionLevel(ROOT::kUseGlobalCompressionSetting % 100) ;
     }
 
-  } else {    
+  } else {
     TString format(lblName);
     format.Append("/C");
     void* ptr = _value._label ;
     branch = t.Branch(lblName, ptr, (const Text_t*)format, bufSize);
-    branch->SetCompressionLevel(1) ;
+    branch->SetCompressionLevel(ROOT::kUseGlobalCompressionSetting % 100) ;
   }
 
 }
@@ -556,23 +557,23 @@ void RooAbsCategory::attachToTree(TTree& t, Int_t bufSize)
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill tree branches associated with current object with current value
 
-void RooAbsCategory::fillTreeBranch(TTree& t) 
+void RooAbsCategory::fillTreeBranch(TTree& t)
 {
   TString idxName(GetName()) ;
-  TString lblName(GetName()) ;  
+  TString lblName(GetName()) ;
   idxName.Append("_idx") ;
   lblName.Append("_lbl") ;
 
   // First determine if branch is taken
   TBranch* idxBranch = t.GetBranch(idxName) ;
   TBranch* lblBranch = t.GetBranch(lblName) ;
-  if (!idxBranch||!lblBranch) { 
+  if (!idxBranch||!lblBranch) {
     coutF(DataHandling) << "RooAbsCategory::fillTreeBranch(" << GetName() << ") ERROR: not attached to tree" << endl ;
     assert(0) ;
   }
 
   idxBranch->Fill() ;
-  lblBranch->Fill() ;  
+  lblBranch->Fill() ;
 }
 
 
@@ -580,10 +581,10 @@ void RooAbsCategory::fillTreeBranch(TTree& t)
 ////////////////////////////////////////////////////////////////////////////////
 /// (De)activate associate tree branch
 
-void RooAbsCategory::setTreeBranchStatus(TTree& t, Bool_t active) 
+void RooAbsCategory::setTreeBranchStatus(TTree& t, Bool_t active)
 {
   TBranch* branch = t.GetBranch(Form("%s_idx",GetName())) ;
-  if (branch) { 
+  if (branch) {
     t.SetBranchStatus(Form("%s_idx",GetName()),active?1:0) ;
     t.SetBranchStatus(Form("%s_lbl",GetName()),active?1:0) ;
   }
@@ -594,9 +595,9 @@ void RooAbsCategory::setTreeBranchStatus(TTree& t, Bool_t active)
 ////////////////////////////////////////////////////////////////////////////////
 /// Explicitly synchronize RooAbsCategory internal cache
 
-void RooAbsCategory::syncCache(const RooArgSet*) 
-{ 
-  getIndex() ; 
+void RooAbsCategory::syncCache(const RooArgSet*)
+{
+  getIndex() ;
 }
 
 
@@ -607,7 +608,7 @@ void RooAbsCategory::syncCache(const RooArgSet*)
 /// cache is clean(valid) before this function is called, e.g. by
 /// calling syncCache() on the source.
 
-void RooAbsCategory::copyCache(const RooAbsArg* source, Bool_t /*valueOnly*/, Bool_t setValDirty) 
+void RooAbsCategory::copyCache(const RooAbsArg* source, Bool_t /*valueOnly*/, Bool_t setValDirty)
 {
   RooAbsCategory* other = static_cast<RooAbsCategory*>(const_cast<RooAbsArg*>(source)) ;
 
@@ -620,9 +621,9 @@ void RooAbsCategory::copyCache(const RooAbsArg* source, Bool_t /*valueOnly*/, Bo
       if (type) {
 	_value = *type ;
       } else {
-	coutE(DataHandling) << "RooAbsCategory::copyCache(" << GetName() 
-			    << ") ERROR: index of source arg " << source->GetName() 
-			    << " is invalid (" << other->_value._value 
+	coutE(DataHandling) << "RooAbsCategory::copyCache(" << GetName()
+			    << ") ERROR: index of source arg " << source->GetName()
+			    << " is invalid (" << other->_value._value
 			    << "), value not updated" << endl ;
       }
     } if (source->getAttribute("UCHARIDXONLY_TREE_BRANCH")) {
@@ -632,12 +633,12 @@ void RooAbsCategory::copyCache(const RooAbsArg* source, Bool_t /*valueOnly*/, Bo
       if (type) {
 	_value = *type ;
       } else {
-	coutE(DataHandling) << "RooAbsCategory::copyCache(" << GetName() 
-			    << ") ERROR: index of source arg " << source->GetName() 
+	coutE(DataHandling) << "RooAbsCategory::copyCache(" << GetName()
+			    << ") ERROR: index of source arg " << source->GetName()
 			    << " is invalid (" << tmp
 			    << "), value not updated" << endl ;
       }
-    } 
+    }
   }
 
   if (setValDirty) {
@@ -651,7 +652,7 @@ void RooAbsCategory::copyCache(const RooAbsArg* source, Bool_t /*valueOnly*/, Bo
 /// Return state definition of ordinal nth defined state,
 /// needed by the generator mechanism.
 
-const RooCatType* RooAbsCategory::getOrdinal(UInt_t n, const char* /*rangeName*/) const 
+const RooCatType* RooAbsCategory::getOrdinal(UInt_t n, const char* /*rangeName*/) const
 {
   return (const RooCatType*)_types.At(n);
 }
@@ -661,10 +662,10 @@ const RooCatType* RooAbsCategory::getOrdinal(UInt_t n, const char* /*rangeName*/
 ////////////////////////////////////////////////////////////////////////////////
 /// Create a RooCategory fundamental object with our properties.
 
-RooAbsArg *RooAbsCategory::createFundamental(const char* newname) const 
+RooAbsArg *RooAbsCategory::createFundamental(const char* newname) const
 {
-  // Add and precalculate new category column 
-  RooCategory *fund= new RooCategory(newname?newname:GetName(),GetTitle()) ; 
+  // Add and precalculate new category column
+  RooCategory *fund= new RooCategory(newname?newname:GetName(),GetTitle()) ;
 
   // Copy states
   TIterator* tIter = typeIterator() ;
@@ -682,7 +683,7 @@ RooAbsArg *RooAbsCategory::createFundamental(const char* newname) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Determine if category has 2 or 3 states with index values -1,0,1
 
-Bool_t RooAbsCategory::isSignType(Bool_t mustHaveZero) const 
+Bool_t RooAbsCategory::isSignType(Bool_t mustHaveZero) const
 {
   if (numTypes()>3||numTypes()<2) return kFALSE ;
   if (mustHaveZero&&numTypes()!=3) return kFALSE ;
@@ -693,7 +694,7 @@ Bool_t RooAbsCategory::isSignType(Bool_t mustHaveZero) const
   while((type=(RooCatType*)tIter->Next())) {
     if (abs(type->getVal())>1) ret=kFALSE ;
   }
-  
+
   delete tIter ;
   return ret ;
 }

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -86,6 +86,7 @@
 
 #include "Riostream.h"
 
+#include "Compression.h"
 #include "Math/IFunction.h"
 #include "TMath.h"
 #include "TObjString.h"
@@ -2711,7 +2712,7 @@ Double_t RooAbsReal::getPropagatedError(const RooFitResult &fr, const RooArgSet 
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Plot function or PDF on frame with support for visualization of the uncertainty encoded in the given fit result fr.
-/// \param[in] frame RooPlot to plot on 
+/// \param[in] frame RooPlot to plot on
 /// \param[in] fr The RooFitResult, where errors can be extracted
 /// \param[in] Z  The desired significance (width) of the error band
 /// \param[in] params If non-zero, consider only the subset of the parameters in fr for the error evaluation
@@ -3238,7 +3239,7 @@ void RooAbsReal::attachToTree(TTree& t, Int_t bufSize)
 
     if (branch->GetCompressionLevel()<0) {
       // cout << "RooAbsReal::attachToTree(" << GetName() << ") Fixing compression level of branch " << cleanName << endl ;
-      branch->SetCompressionLevel(1) ;
+      branch->SetCompressionLevel(ROOT::kUseGlobalCompressionSetting % 100) ;
     }
 
 //      cout << "RooAbsReal::attachToTree(" << cleanName << "): branch already exists in tree " << (void*)&t << ", changing address" << endl ;
@@ -3248,7 +3249,7 @@ void RooAbsReal::attachToTree(TTree& t, Int_t bufSize)
     TString format(cleanName);
     format.Append("/D");
     branch = t.Branch(cleanName, &_value, (const Text_t*)format, bufSize);
-    branch->SetCompressionLevel(1) ;
+    branch->SetCompressionLevel(ROOT::kUseGlobalCompressionSetting % 100) ;
     //      cout << "RooAbsReal::attachToTree(" << cleanName << "): creating new branch in tree " << (void*)&t << endl ;
   }
 
@@ -4779,4 +4780,3 @@ void RooAbsReal::setParameterizeIntegral(const RooArgSet& paramVars)
   }
   setStringAttribute("CACHEPARAMINT",plist.c_str()) ;
 }
-

--- a/roofit/roofitcore/src/RooAbsString.cxx
+++ b/roofit/roofitcore/src/RooAbsString.cxx
@@ -25,10 +25,11 @@ string value
 Implementation of RooAbsString may be derived, there no interface
 is provided to modify the contents
 **/
-// 
+//
 
 #include "RooFit.h"
 
+#include "Compression.h"
 #include "Riostream.h"
 #include "Riostream.h"
 #include "TObjString.h"
@@ -42,7 +43,7 @@ is provided to modify the contents
 
 using namespace std;
 
-ClassImp(RooAbsString); 
+ClassImp(RooAbsString);
 ;
 
 
@@ -57,8 +58,8 @@ RooAbsString::RooAbsString() : RooAbsArg(), _len(128) , _value(new char[128])
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor
 
-RooAbsString::RooAbsString(const char *name, const char *title, Int_t bufLen) : 
-  RooAbsArg(name,title), _len(bufLen), _value(new char[bufLen]) 
+RooAbsString::RooAbsString(const char *name, const char *title, Int_t bufLen) :
+  RooAbsArg(name,title), _len(bufLen), _value(new char[bufLen])
 {
   setValueDirty() ;
   setShapeDirty() ;
@@ -69,7 +70,7 @@ RooAbsString::RooAbsString(const char *name, const char *title, Int_t bufLen) :
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy constructor
 
-RooAbsString::RooAbsString(const RooAbsString& other, const char* name) : 
+RooAbsString::RooAbsString(const RooAbsString& other, const char* name) :
   RooAbsArg(other, name), _len(other._len), _value(new char[other._len])
 {
   strlcpy(_value,other._value,_len) ;
@@ -95,8 +96,8 @@ const char* RooAbsString::getVal() const
   if (isValueDirty()) {
     clearValueDirty() ;
     strlcpy(_value,traceEval(),_len) ;
-  } 
-  
+  }
+
   return _value ;
 }
 
@@ -113,7 +114,7 @@ Bool_t RooAbsString::operator==(const char* value) const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Bool_t RooAbsString::isIdentical(const RooAbsArg& other, Bool_t assumeSameType)  
+Bool_t RooAbsString::isIdentical(const RooAbsArg& other, Bool_t assumeSameType)
 {
   if (!assumeSameType) {
     const RooAbsString* otherString = dynamic_cast<const RooAbsString*>(&other) ;
@@ -128,7 +129,7 @@ Bool_t RooAbsString::isIdentical(const RooAbsArg& other, Bool_t assumeSameType)
 ////////////////////////////////////////////////////////////////////////////////
 /// Equality operator comparing to another RooAbsArg
 
-Bool_t RooAbsString::operator==(const RooAbsArg& other) 
+Bool_t RooAbsString::operator==(const RooAbsArg& other)
 {
   const RooAbsString* otherString = dynamic_cast<const RooAbsString*>(&other) ;
   return otherString ? operator==(otherString->getVal()) : kFALSE ;
@@ -139,10 +140,10 @@ Bool_t RooAbsString::operator==(const RooAbsArg& other)
 ////////////////////////////////////////////////////////////////////////////////
 ///Read object contents from stream (dummy for now)
 
-Bool_t RooAbsString::readFromStream(istream& /*is*/, Bool_t /*compact*/, Bool_t /*verbose*/) 
+Bool_t RooAbsString::readFromStream(istream& /*is*/, Bool_t /*compact*/, Bool_t /*verbose*/)
 {
   return kFALSE ;
-} 
+}
 
 
 
@@ -168,7 +169,7 @@ void RooAbsString::printValue(ostream& os) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Check if current value is valid
 
-Bool_t RooAbsString::isValid() const 
+Bool_t RooAbsString::isValid() const
 {
   return isValidString(getVal()) ;
 }
@@ -178,7 +179,7 @@ Bool_t RooAbsString::isValid() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Check if given string value is valid
 
-Bool_t RooAbsString::isValidString(const char* value, Bool_t /*printError*/) const 
+Bool_t RooAbsString::isValidString(const char* value, Bool_t /*printError*/) const
 {
   // Protect against string overflows
   if (TString(value).Length()>_len) return kFALSE ;
@@ -190,9 +191,9 @@ Bool_t RooAbsString::isValidString(const char* value, Bool_t /*printError*/) con
 ////////////////////////////////////////////////////////////////////////////////
 /// Hook function for trace evaluation
 
-Bool_t RooAbsString::traceEvalHook(const char* /*value*/) const 
-{ 
-  return kFALSE ; 
+Bool_t RooAbsString::traceEvalHook(const char* /*value*/) const
+{
+  return kFALSE ;
 }
 
 
@@ -203,7 +204,7 @@ Bool_t RooAbsString::traceEvalHook(const char* /*value*/) const
 TString RooAbsString::traceEval() const
 {
   TString value = evaluate() ;
-  
+
   //Standard tracing code goes here
   if (!isValidString(value)) {
     cxcoutD(Tracing) << "RooAbsString::traceEval(" << GetName() << "): new output too long (>" << _len << " chars): " << value << endl ;
@@ -220,9 +221,9 @@ TString RooAbsString::traceEval() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Forcibly bring internal cache up-to-date
 
-void RooAbsString::syncCache(const RooArgSet*) 
-{ 
-  getVal() ; 
+void RooAbsString::syncCache(const RooArgSet*)
+{
+  getVal() ;
 }
 
 
@@ -233,7 +234,7 @@ void RooAbsString::syncCache(const RooArgSet*)
 /// Warning: This function copies the cached values of source,
 ///          it is the callers responsibility to make sure the cache is clean
 
-void RooAbsString::copyCache(const RooAbsArg* source, Bool_t /*valueOnly*/, Bool_t setValDirty) 
+void RooAbsString::copyCache(const RooAbsArg* source, Bool_t /*valueOnly*/, Bool_t setValDirty)
 {
   RooAbsString* other = dynamic_cast<RooAbsString*>(const_cast<RooAbsArg*>(source)) ;
   assert(other!=0) ;
@@ -257,30 +258,30 @@ void RooAbsString::attachToTree(TTree& t, Int_t bufSize)
     t.SetBranchAddress(GetName(),_value) ;
     if (branch->GetCompressionLevel()<0) {
       cxcoutD(DataHandling) << "RooAbsString::attachToTree(" << GetName() << ") Fixing compression level of branch " << GetName() << endl ;
-      branch->SetCompressionLevel(1) ;
+      branch->SetCompressionLevel(ROOT::kUseGlobalCompressionSetting % 100) ;
     }
   } else {
     TString format(GetName());
     format.Append("/C");
     branch = t.Branch(GetName(), _value, (const Text_t*)format, bufSize);
-    branch->SetCompressionLevel(1) ;
+    branch->SetCompressionLevel(ROOT::kUseGlobalCompressionSetting % 100) ;
   }
 }
- 
+
 
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill tree branch associated with this object
 
-void RooAbsString::fillTreeBranch(TTree& t) 
+void RooAbsString::fillTreeBranch(TTree& t)
 {
   // First determine if branch is taken
   TBranch* branch = t.GetBranch(GetName()) ;
-  if (!branch) { 
+  if (!branch) {
     coutE(DataHandling) << "RooAbsString::fillTreeBranch(" << GetName() << ") ERROR: not attached to tree" << endl ;
     assert(0) ;
   }
-  branch->Fill() ;  
+  branch->Fill() ;
 }
 
 
@@ -288,10 +289,10 @@ void RooAbsString::fillTreeBranch(TTree& t)
 ////////////////////////////////////////////////////////////////////////////////
 /// (De)Activate associated tree branch
 
-void RooAbsString::setTreeBranchStatus(TTree& t, Bool_t active) 
+void RooAbsString::setTreeBranchStatus(TTree& t, Bool_t active)
 {
   TBranch* branch = t.GetBranch(GetName()) ;
-  if (branch) { 
+  if (branch) {
     t.SetBranchStatus(GetName(),active?1:0) ;
   }
 }
@@ -301,8 +302,8 @@ void RooAbsString::setTreeBranchStatus(TTree& t, Bool_t active)
 ////////////////////////////////////////////////////////////////////////////////
 /// Create a RooStringVar fundamental object with our properties.
 
-RooAbsArg *RooAbsString::createFundamental(const char* newname) const 
+RooAbsArg *RooAbsString::createFundamental(const char* newname) const
 {
-  RooStringVar *fund= new RooStringVar(newname?newname:GetName(),GetTitle(),"") ; 
+  RooStringVar *fund= new RooStringVar(newname?newname:GetName(),GetTitle(),"") ;
   return fund;
 }

--- a/roofit/roostats/inc/RooStats/SamplingDistPlot.h
+++ b/roofit/roostats/inc/RooStats/SamplingDistPlot.h
@@ -12,6 +12,7 @@
 #ifndef ROOSTATS_SamplingDistPlot
 #define ROOSTATS_SamplingDistPlot
 
+#include "Compression.h"
 #include "RooList.h"
 #include "RooPrintable.h"
 #include "TNamed.h"
@@ -96,7 +97,7 @@ namespace RooStats {
     void SetYRange( double mi, double ma ) { fYMin = mi; fYMax = ma; }
 
     /// write to Root file
-    void DumpToFile(const char* RootFileName, Option_t *option="", const char *ftitle="", Int_t compress=1);
+    void DumpToFile(const char* RootFileName, Option_t *option="", const char *ftitle="", Int_t compress = ROOT::kUseGeneralPurposeCompressionSetting);
 
   private:
     std::vector<Double_t> fSamplingDistr;

--- a/tree/tree/inc/TBranch.h
+++ b/tree/tree/inc/TBranch.h
@@ -25,6 +25,8 @@
 
 #include <memory>
 
+#include "Compression.h"
+
 #include "TNamed.h"
 
 #include "TObjArray.h"
@@ -148,8 +150,8 @@ private:
 
 public:
    TBranch();
-   TBranch(TTree *tree, const char *name, void *address, const char *leaflist, Int_t basketsize=32000, Int_t compress=-1);
-   TBranch(TBranch *parent, const char *name, void *address, const char *leaflist, Int_t basketsize=32000, Int_t compress=-1);
+   TBranch(TTree *tree, const char *name, void *address, const char *leaflist, Int_t basketsize=32000, Int_t compress = ROOT::kInheritCompressionAlgorithm);
+   TBranch(TBranch *parent, const char *name, void *address, const char *leaflist, Int_t basketsize=32000, Int_t compress = ROOT::kInheritCompressionAlgorithm);
    virtual ~TBranch();
 
    virtual void      AddBasket(TBasket &b, Bool_t ondisk, Long64_t startEntry);
@@ -227,9 +229,9 @@ public:
    virtual void      SetAutoDelete(Bool_t autodel=kTRUE);
    virtual void      SetBasketSize(Int_t buffsize);
    virtual void      SetBufferAddress(TBuffer *entryBuffer);
-   void              SetCompressionAlgorithm(Int_t algorithm=0);
-   void              SetCompressionLevel(Int_t level=1);
-   void              SetCompressionSettings(Int_t settings=1);
+   void              SetCompressionAlgorithm(Int_t algorithm = ROOT::kUseGlobalCompressionAlgorithm);
+   void              SetCompressionLevel(Int_t level = ROOT::kUseMinCompressionLevel);
+   void              SetCompressionSettings(Int_t settings = ROOT::kUseGeneralPurposeCompressionSetting);
    virtual void      SetEntries(Long64_t entries);
    virtual void      SetEntryOffsetLen(Int_t len, Bool_t updateSubBranches = kFALSE);
    virtual void      SetFirstEntry( Long64_t entry );

--- a/tree/tree/inc/TBranchElement.h
+++ b/tree/tree/inc/TBranchElement.h
@@ -130,8 +130,8 @@ protected:
    inline void              ValidateAddress() const;
 
    void Init(TTree *tree, TBranch *parent, const char* name, TStreamerInfo* sinfo, Int_t id, char* pointer, Int_t basketsize = 32000, Int_t splitlevel = 0, Int_t btype = 0);
-   void Init(TTree *tree, TBranch *parent, const char* name, TClonesArray* clones, Int_t basketsize = 32000, Int_t splitlevel = 0, Int_t compress = -1);
-   void Init(TTree *tree, TBranch *parent, const char* name, TVirtualCollectionProxy* cont, Int_t basketsize = 32000, Int_t splitlevel = 0, Int_t compress = -1);
+   void Init(TTree *tree, TBranch *parent, const char* name, TClonesArray* clones, Int_t basketsize = 32000, Int_t splitlevel = 0, Int_t compress = ROOT::kInheritCompressionAlgorithm);
+   void Init(TTree *tree, TBranch *parent, const char* name, TVirtualCollectionProxy* cont, Int_t basketsize = 32000, Int_t splitlevel = 0, Int_t compress = ROOT::kInheritCompressionAlgorithm);
 
    void SetActionSequence(TClass *originalClass, TStreamerInfo *localInfo, TStreamerInfoActions::TActionSequence::SequenceGetter_t create, TStreamerInfoActions::TActionSequence *&actionSequence);
    void ReadLeavesImpl(TBuffer& b);
@@ -170,11 +170,11 @@ protected:
 public:
    TBranchElement();
    TBranchElement(TTree *tree, const char* name, TStreamerInfo* sinfo, Int_t id, char* pointer, Int_t basketsize = 32000, Int_t splitlevel = 0, Int_t btype = 0);
-   TBranchElement(TTree *tree, const char* name, TClonesArray* clones, Int_t basketsize = 32000, Int_t splitlevel = 0, Int_t compress = -1);
-   TBranchElement(TTree *tree, const char* name, TVirtualCollectionProxy* cont, Int_t basketsize = 32000, Int_t splitlevel = 0, Int_t compress = -1);
+   TBranchElement(TTree *tree, const char* name, TClonesArray* clones, Int_t basketsize = 32000, Int_t splitlevel = 0, Int_t compress = ROOT::kInheritCompressionAlgorithm);
+   TBranchElement(TTree *tree, const char* name, TVirtualCollectionProxy* cont, Int_t basketsize = 32000, Int_t splitlevel = 0, Int_t compress = ROOT::kInheritCompressionAlgorithm);
    TBranchElement(TBranch *parent, const char* name, TStreamerInfo* sinfo, Int_t id, char* pointer, Int_t basketsize = 32000, Int_t splitlevel = 0, Int_t btype = 0);
-   TBranchElement(TBranch *parent, const char* name, TClonesArray* clones, Int_t basketsize = 32000, Int_t splitlevel = 0, Int_t compress = -1);
-   TBranchElement(TBranch *parent, const char* name, TVirtualCollectionProxy* cont, Int_t basketsize = 32000, Int_t splitlevel = 0, Int_t compress = -1);
+   TBranchElement(TBranch *parent, const char* name, TClonesArray* clones, Int_t basketsize = 32000, Int_t splitlevel = 0, Int_t compress = ROOT::kInheritCompressionAlgorithm);
+   TBranchElement(TBranch *parent, const char* name, TVirtualCollectionProxy* cont, Int_t basketsize = 32000, Int_t splitlevel = 0, Int_t compress = ROOT::kInheritCompressionAlgorithm);
 
    virtual                  ~TBranchElement();
 

--- a/tree/tree/inc/TBranchObject.h
+++ b/tree/tree/inc/TBranchObject.h
@@ -46,8 +46,8 @@ protected:
 
 public:
    TBranchObject();
-   TBranchObject(TBranch *parent, const char *name, const char *classname, void *addobj, Int_t basketsize=32000, Int_t splitlevel = 0, Int_t compress=-1, Bool_t isptrptr = kTRUE);
-   TBranchObject(TTree *tree, const char *name, const char *classname, void *addobj, Int_t basketsize=32000, Int_t splitlevel = 0, Int_t compress=-1, Bool_t isptrptr = kTRUE);
+   TBranchObject(TBranch *parent, const char *name, const char *classname, void *addobj, Int_t basketsize=32000, Int_t splitlevel = 0, Int_t compress = ROOT::kInheritCompressionAlgorithm, Bool_t isptrptr = kTRUE);
+   TBranchObject(TTree *tree, const char *name, const char *classname, void *addobj, Int_t basketsize=32000, Int_t splitlevel = 0, Int_t compress = ROOT::kInheritCompressionAlgorithm, Bool_t isptrptr = kTRUE);
    virtual ~TBranchObject();
 
    virtual void        Browse(TBrowser *b);

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -26,6 +26,7 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
+#include "Compression.h"
 #include "ROOT/TIOFeatures.hxx"
 #include "TArrayD.h"
 #include "TArrayI.h"

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -2347,7 +2347,7 @@ void TBranch::SetCompressionAlgorithm(Int_t algorithm)
 {
    if (algorithm < 0 || algorithm >= ROOT::kUndefinedCompressionAlgorithm) algorithm = 0;
    if (fCompress < 0) {
-      fCompress = 100 * algorithm + 1;
+      fCompress = 100 * algorithm + ROOT::kUseMinCompressionLevel;
    } else {
       int level = fCompress % 100;
       fCompress = 100 * algorithm + level;

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -2385,7 +2385,7 @@ TBranch* TTree::BronchExec(const char* name, const char* classname, void* addr, 
    }
 
    if (splitlevel < 0 || ((splitlevel == 0) && hasCustomStreamer && cl->IsTObject())) {
-      TBranchObject* branch = new TBranchObject(this, name, classname, addr, bufsize, 0, /*compress=*/ -1, isptrptr);
+      TBranchObject* branch = new TBranchObject(this, name, classname, addr, bufsize, 0, /*compress=*/ ROOT::kInheritCompressionAlgorithm, isptrptr);
       fBranches.Add(branch);
       return branch;
    }
@@ -6864,7 +6864,7 @@ void TTree::OptimizeBaskets(ULong64_t maxMemory, Float_t minComp, Option_t *opti
          if (branch->GetZipBytes() > 0) comp = totBytes/Double_t(branch->GetZipBytes());
          if (comp > 1 && comp < minComp) {
             if (pDebug) Info("OptimizeBaskets", "Disabling compression for branch : %s\n",branch->GetName());
-            branch->SetCompressionSettings(0);
+            branch->SetCompressionSettings(ROOT::kUseGlobalCompressionAlgorithm);
          }
       }
       // coverity[divide_by_zero] newMemsize can not be zero as there is at least one leaf
@@ -8501,7 +8501,7 @@ void TTree::SetCircular(Long64_t maxEntries)
       //a file, reset the compression level to the file compression level
       if (fDirectory) {
          TFile* bfile = fDirectory->GetFile();
-         Int_t compress = 1;
+         Int_t compress = ROOT::kUseGeneralPurposeCompressionSetting;
          if (bfile) {
             compress = bfile->GetCompressionSettings();
          }


### PR DESCRIPTION
It is a first step to move to generic settings for compression algorithms. I managed to clean all places where was not properly used "magic numbers".
Next step will be to introduce a new class CompressionSetting that will provide more general switch for compression algorithms. ( preview concept https://github.com/bbockelm/root/commit/4c856f9408d9184cfaf4dc4727b7e32e5e4e3433 )

In this PR we already using ZLIB as default (for test correctness we need to land https://github.com/root-project/root/pull/2889 and  https://github.com/root-project/roottest/pull/247 before this pr).
```
$ root hsimple.root 
   --------------------------------------------------------------------
  | Welcome to ROOT 6.15/01                          https://root.cern |
  |                                       (c) 1995-2018, The ROOT Team |
  | Built for linuxx8664gcc on Nov 01 2018, 17:35:38                   |
  | From heads/default-compression-switcher@v6-13-04-1973-gb4ccd4f330  |
  | Try '.help', '.demo', '.license', '.credits', '.quit'/'.q'         |
   --------------------------------------------------------------------

root [0] 
Attaching file hsimple.root as _file0...
(TFile *) 0x55f79b0e6360
root [1] _file0->GetCompressionAlgorithm()
(int) 1
root [2] _file0->GetCompressionLevel()
(int) 1
root [3] _file0->GetCompressionSettings()
(int) 101
root [4]
```