### PR TITLE
[D54097]Optimize clang::ASTReader by using DenseMap instead of vector

### DIFF
--- a/interpreter/llvm/src/tools/clang/include/clang/Serialization/ASTReader.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/Serialization/ASTReader.h
@@ -604,7 +604,8 @@ private:
   /// If the pointer at index I is non-NULL, then it refers to the
   /// MacroInfo for the identifier with ID=I+1 that has already
   /// been loaded.
-  std::vector<MacroInfo *> MacrosLoaded;
+  llvm::DenseMap<unsigned, MacroInfo *> MacrosLoaded;
+  unsigned NumMacrosLoaded = 0;
 
   typedef std::pair<IdentifierInfo *, serialization::SubmoduleID>
       LoadedMacroInfo;
@@ -1670,7 +1671,7 @@ public:
 
   /// \brief Returns the number of macros found in the chain.
   unsigned getTotalNumMacros() const {
-    return static_cast<unsigned>(MacrosLoaded.size());
+    return NumMacrosLoaded;
   }
 
   /// \brief Returns the number of types found in the chain.

--- a/interpreter/llvm/src/tools/clang/include/clang/Serialization/ASTReader.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/Serialization/ASTReader.h
@@ -446,7 +446,8 @@ private:
   ///
   /// When the pointer at index I is non-NULL, the type with
   /// ID = (I + 1) << FastQual::Width has already been loaded
-  std::vector<QualType> TypesLoaded;
+  llvm::DenseMap<unsigned, QualType> TypesLoaded;
+  unsigned NumTypesLoaded = 0;
 
   typedef ContinuousRangeMap<serialization::TypeID, ModuleFile *, 4>
     GlobalTypeMapType;
@@ -460,7 +461,8 @@ private:
   ///
   /// When the pointer at index I is non-NULL, the declaration with ID
   /// = I + 1 has already been loaded.
-  std::vector<Decl *> DeclsLoaded;
+  llvm::DenseMap<unsigned, Decl *> DeclsLoaded;
+  unsigned NumDeclsLoaded = 0;
 
   typedef ContinuousRangeMap<serialization::DeclID, ModuleFile *, 4>
     GlobalDeclMapType;
@@ -1673,12 +1675,12 @@ public:
 
   /// \brief Returns the number of types found in the chain.
   unsigned getTotalNumTypes() const {
-    return static_cast<unsigned>(TypesLoaded.size());
+    return NumTypesLoaded;
   }
 
   /// \brief Returns the number of declarations found in the chain.
   unsigned getTotalNumDecls() const {
-    return static_cast<unsigned>(DeclsLoaded.size());
+    return NumDeclsLoaded;
   }
 
   /// \brief Returns the number of submodules known.

--- a/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReader.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReader.cpp
@@ -6768,14 +6768,14 @@ QualType ASTReader::GetType(TypeID ID) {
   Index -= NUM_PREDEF_TYPE_IDS;
   assert(Index < NumTypesLoaded && "Type index out-of-range");
   if (TypesLoaded.find(Index) == TypesLoaded.end()) {
-    QualType Q = readTypeRecord(Index);
-    TypesLoaded.insert({Index, Q});
+    QualType QualTy = readTypeRecord(Index);
+    TypesLoaded.insert({Index, QualTy});
     if (TypesLoaded.find(Index) == TypesLoaded.end())
       return QualType();
 
-    Q->setFromAST();
+    QualTy->setFromAST();
     if (DeserializationListener)
-      DeserializationListener->TypeRead(TypeIdx::fromTypeID(ID), Q);
+      DeserializationListener->TypeRead(TypeIdx::fromTypeID(ID), QualTy);
   }
 
   return TypesLoaded.find(Index)->second.withFastQualifiers(FastQuals);

--- a/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -2560,8 +2560,9 @@ void ASTReader::ReadAttributes(ASTRecordReader &Record, AttrVec &Attrs) {
 /// so that future GetDecl calls will return this declaration rather
 /// than trying to load a new declaration.
 inline void ASTReader::LoadedDecl(unsigned Index, Decl *D) {
-  assert(!DeclsLoaded[Index] && "Decl loaded twice?");
-  DeclsLoaded[Index] = D;
+  assert((DeclsLoaded.find(Index) == DeclsLoaded.end()) &&
+         "Decl loaded twice?");
+  DeclsLoaded.insert({Index, D});
 }
 
 


### PR DESCRIPTION
Testing before submitting this patch to clang upstream!

This gives 20 MB memory improvement :D :D