### PR TITLE
Eve7: try to avoid TVirtualx.h and GL_glu.h in same file

### DIFF
--- a/graf3d/eve7/inc/ROOT/REveCsgOps.hxx
+++ b/graf3d/eve7/inc/ROOT/REveCsgOps.hxx
@@ -5,8 +5,6 @@
 #define ROOT7_REveCsgOps
 
 #include "Rtypes.h"
-#include "TPad.h"
-#include "TVirtualViewer3D.h"
 
 class TBuffer3D;
 class TGeoCompositeShape;
@@ -29,76 +27,8 @@ TBaseMesh *ConvertToMesh(const TBuffer3D &buff);
 TBaseMesh *BuildUnion(const TBaseMesh *leftOperand, const TBaseMesh *rightOperand);
 TBaseMesh *BuildIntersection(const TBaseMesh *leftOperand, const TBaseMesh *rightOperand);
 TBaseMesh *BuildDifference(const TBaseMesh *leftOperand, const TBaseMesh *rightOperand);
-
-//==============================================================================
-//==============================================================================
-
-// Internal pad class overriding handling of updates and 3D-viewers.
-
-class TCsgPad : public TPad {
-   TVirtualViewer3D *fViewer3D;
-
-public:
-   TCsgPad(TVirtualViewer3D *vv3d);
-   virtual ~TCsgPad() {}
-
-   // XXXX cling chkes on the following if override is specified.
-   // Also, it can not see fViewer3D from TPad.
-   // As if TPad.h would not be read / parsed correctly.
-
-   Bool_t IsBatch() const { return kTRUE; }
-
-   void Update() {}
-
-   TVirtualViewer3D *GetViewer3D(Option_t * /*type*/ = "") { return fViewer3D; }
-};
-
-//------------------------------------------------------------------------------
-
-// Internal VV3D for extracting composite shapes.
-
-class TCsgVV3D : public TVirtualViewer3D {
-
-   // Composite shape specific
-   typedef std::pair<UInt_t, TBaseMesh *> CSPart_t;
-
-   std::vector<CSPart_t> fCSTokens;
-   Int_t fCSIndex;
-   mutable bool fCompositeOpen;
-
-   TBaseMesh *BuildComposite();
-
-public:
-   std::unique_ptr<TBaseMesh> fResult;
-
-   TCsgVV3D();
-   virtual ~TCsgVV3D() {}
-
-   // virtual stuff that is used.
-   Int_t AddObject(const TBuffer3D &buffer, Bool_t *addChildren = nullptr) override;
-   Bool_t OpenComposite(const TBuffer3D &buffer, Bool_t *addChildren = nullptr) override;
-   void CloseComposite() override;
-   void AddCompositeOp(UInt_t operation) override;
-
-   // virtual crap that needs to be defined but is not used/needed.
-   Int_t AddObject(UInt_t, const TBuffer3D &, Bool_t * = 0) override { return -1; }
-   Bool_t CanLoopOnPrimitives() const override { return kTRUE; }
-   void PadPaint(TVirtualPad *) override {}
-   void ObjectPaint(TObject *, Option_t * = "") override {}
-
-   Int_t DistancetoPrimitive(Int_t, Int_t) override { return 9999; }
-   void ExecuteEvent(Int_t, Int_t, Int_t) override {}
-
-   Bool_t PreferLocalFrame() const override { return kTRUE; }
-
-   void BeginScene() override {}
-   Bool_t BuildingScene() const override { return kTRUE; }
-   void EndScene() override {}
-};
-
-//------------------------------------------------------------------------------
-
 TBaseMesh *BuildFromCompositeShape(TGeoCompositeShape *cshape, Int_t n_seg);
+
 
 } // namespace EveCsg
 } // namespace Experimental

--- a/graf3d/eve7/src/REveCsgOps.cxx
+++ b/graf3d/eve7/src/REveCsgOps.cxx
@@ -2775,16 +2775,16 @@ class TCsgVV3D : public TVirtualViewer3D {
    typedef std::pair<UInt_t, TBaseMesh *> CSPart_t;
 
    std::vector<CSPart_t> fCSTokens;
-   Int_t fCSIndex;
-   mutable bool fCompositeOpen;
+   Int_t fCSIndex{0};
+   mutable bool fCompositeOpen{false};
 
    TBaseMesh *BuildComposite();
 
 public:
    std::unique_ptr<TBaseMesh> fResult;
 
-   TCsgVV3D();
-   virtual ~TCsgVV3D() {}
+   TCsgVV3D() = default;
+   virtual ~TCsgVV3D() = default;
 
    // virtual stuff that is used.
    Int_t AddObject(const TBuffer3D &buffer, Bool_t *addChildren = nullptr) override;
@@ -2808,12 +2808,6 @@ public:
    void EndScene() override {}
 };
 
-
-TCsgVV3D::TCsgVV3D() :
-   fCompositeOpen(kFALSE)
-{}
-
-
 Int_t TCsgVV3D::AddObject(const TBuffer3D& buffer, Bool_t* addChildren)
 {
    if (fCompositeOpen)
@@ -2822,7 +2816,7 @@ Int_t TCsgVV3D::AddObject(const TBuffer3D& buffer, Bool_t* addChildren)
       fCSTokens.push_back(std::make_pair(TBuffer3D::kCSNoOp, newMesh));
    }
 
-   if (addChildren)  *addChildren = kTRUE;
+   if (addChildren) *addChildren = kTRUE;
 
    return TBuffer3D::kNone;
 }

--- a/graf3d/eve7/src/REveCsgOps.cxx
+++ b/graf3d/eve7/src/REveCsgOps.cxx
@@ -62,6 +62,8 @@
    31.03.05 Timur Pocheptsov.
 */
 
+#include <ROOT/REveCsgOps.hxx>
+
 #include <algorithm>
 #include <vector>
 
@@ -69,7 +71,6 @@
 #include "Rtypes.h"
 #include "TMath.h"
 
-#include <ROOT/REveCsgOps.hxx>
 #include <ROOT/REveGeoShape.hxx>
 #include <ROOT/REveUtil.hxx>
 
@@ -78,6 +79,9 @@
 #include "TGeoBoolNode.h"
 #include "TGeoCompositeShape.h"
 #include "TGeoMatrix.h"
+#include "TPad.h"
+#include "TVirtualViewer3D.h"
+
 
 namespace ROOT {
 namespace Experimental {
@@ -2729,20 +2733,81 @@ TBaseMesh *BuildDifference(const TBaseMesh *l, const TBaseMesh *r)
 }
 
 
-
 //==============================================================================
 // TCsgPad
 //==============================================================================
 
-TCsgPad::TCsgPad(TVirtualViewer3D *vv3d)
-{
-   fViewer3D = vv3d;
-   fPrimitives = new TList;
-}
+// Internal pad class overriding handling of updates and 3D-viewers.
+
+class TCsgPad : public TPad {
+   TVirtualViewer3D *fViewer3D{nullptr};
+
+public:
+   TCsgPad(TVirtualViewer3D *vv3d)
+   {
+      fViewer3D = vv3d;
+      fPrimitives = new TList;
+   }
+   virtual ~TCsgPad() {}
+
+   // XXXX cling checks on the following if override is specified.
+   // Also, it can not see fViewer3D from TPad.
+   // As if TPad.h would not be read / parsed correctly.
+
+   Bool_t IsBatch() const { return kTRUE; }
+
+   void Update() {}
+
+   TVirtualViewer3D *GetViewer3D(Option_t * /*type*/ = "") { return fViewer3D; }
+};
+
 
 //==============================================================================
 // TCsgVV3D
 //==============================================================================
+
+
+// Internal VV3D for extracting composite shapes.
+
+class TCsgVV3D : public TVirtualViewer3D {
+
+   // Composite shape specific
+   typedef std::pair<UInt_t, TBaseMesh *> CSPart_t;
+
+   std::vector<CSPart_t> fCSTokens;
+   Int_t fCSIndex;
+   mutable bool fCompositeOpen;
+
+   TBaseMesh *BuildComposite();
+
+public:
+   std::unique_ptr<TBaseMesh> fResult;
+
+   TCsgVV3D();
+   virtual ~TCsgVV3D() {}
+
+   // virtual stuff that is used.
+   Int_t AddObject(const TBuffer3D &buffer, Bool_t *addChildren = nullptr) override;
+   Bool_t OpenComposite(const TBuffer3D &buffer, Bool_t *addChildren = nullptr) override;
+   void CloseComposite() override;
+   void AddCompositeOp(UInt_t operation) override;
+
+   // virtual crap that needs to be defined but is not used/needed.
+   Int_t AddObject(UInt_t, const TBuffer3D &, Bool_t * = 0) override { return -1; }
+   Bool_t CanLoopOnPrimitives() const override { return kTRUE; }
+   void PadPaint(TVirtualPad *) override {}
+   void ObjectPaint(TObject *, Option_t * = "") override {}
+
+   Int_t DistancetoPrimitive(Int_t, Int_t) override { return 9999; }
+   void ExecuteEvent(Int_t, Int_t, Int_t) override {}
+
+   Bool_t PreferLocalFrame() const override { return kTRUE; }
+
+   void BeginScene() override {}
+   Bool_t BuildingScene() const override { return kTRUE; }
+   void EndScene() override {}
+};
+
 
 TCsgVV3D::TCsgVV3D() :
    fCompositeOpen(kFALSE)


### PR DESCRIPTION
TVirtualX.h contains not correct definition "class GLUtesselator", which is conflicts with real "struct  GLUtesselator". 
For now just avoid use of both includes in one place.
In principle, one should remove GLUtesselator for TVirtualX at all