### PR TITLE
[ROOT-9685] Run the Jupyter ROOT C++ kernel with ROOT's Python version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,9 @@ foreach(var ${variables})
   endif()
 endforeach()
 
+#---Make sure the Jupyter ROOT C++ kernel runs with the same Python version as ROOT-----
+configure_file(${CMAKE_SOURCE_DIR}/etc/notebook/kernels/root/kernel.json.in ${CMAKE_BINARY_DIR}/etc/notebook/kernels/root/kernel.json)
+
 #---Move (copy) directories to binary tree------------------------------------------------------
 set(stamp_file ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/move_artifacts.stamp)
 add_custom_command(OUTPUT ${stamp_file}

--- a/etc/notebook/kernels/root/kernel.json.in
+++ b/etc/notebook/kernels/root/kernel.json.in
@@ -2,7 +2,7 @@
  "language": "c++",
  "display_name": "ROOT C++",
  "argv": [
-  "python",
+  "python@PYTHON_VERSION_MAJOR@.@PYTHON_VERSION_MINOR@",
   "-m",
   "JupyROOT.kernel.rootkernel",
   "-f",


### PR DESCRIPTION
This PR supersedes #2899.

We need to make sure the ROOT C++ kernel of Jupyter runs with the same Python version that ROOT was built with.

Since running the kernel with a particular Python installation cannot be enforced by the user by setting the `$PATH` variable (Jupyter ignores that variable and picks Python from the system), we need to enforce it from the kernel file.

We can't define a full path to the right Python binary in the kernel.json file because that path could be different in the machine where ROOT is built and the machine where the C++ kernel runs.
The best we can do is include the major and minor version in the kernel.json file, so that we make sure the kernel is not executed with an incompatible version, which would likely lead to a crash.