### PR TITLE
virtualx: remove GLUtesselator forward declarations from TVirtualX.h

### DIFF
--- a/README/ReleaseNotes/v616/index.md
+++ b/README/ReleaseNotes/v616/index.md
@@ -53,6 +53,11 @@ Given that this effectively meant that Ruby was dysfunctional and given that nob
 The packages `afs`, `chirp`, `glite`, `sapdb`, `srp` and `ios` have been removed from ROOT.
 They were deprecated before, or never ported from configure, make to CMake.
 
+### Remove of unsused declarations from TVirtualX.h
+
+Remove GLUtesselator forward declarations, which is not used in TVirtualX classes.
+Use TGLUtil.h instead
+
 
 ## Core Libraries
 

--- a/core/base/inc/TVirtualX.h
+++ b/core/base/inc/TVirtualX.h
@@ -49,11 +49,6 @@ enum ECursor { kBottomLeft, kBottomRight, kTopLeft, kTopRight,
 class TPoint;
 class TString;
 class TGWin32Command;
-#ifdef __cplusplus
-   class GLUtesselator;
-#else
-   extern "C" { struct GLUtesselator; }
-#endif
 
 class TVirtualX : public TNamed, public TAttLine, public TAttFill, public TAttText, public TAttMarker {
 


### PR DESCRIPTION
It is not used in TVirtualX interfaces.
It is re-declared in TGLUtil.h include.
Was introduced 14 years ago with the commit:

https://github.com/root-project/root/commit/fc7ab2b

In my mind - it is wrong place