### PR TITLE
[cxxmodules] Don't load rdict for cxxmodules

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1990,7 +1990,7 @@ void TCling::RegisterModule(const char* modulename,
 
    if (gIgnoredPCMNames.find(modulename) == gIgnoredPCMNames.end()) {
       TString pcmFileName(ROOT::TMetaUtils::GetModuleFileName(modulename).c_str());
-      if (!fCxxModulesEnabled && !LoadPCM(pcmFileName, headers, triggerFunc)) {
+      if (!hasCxxModule && !LoadPCM(pcmFileName, headers, triggerFunc)) {
          ::Error("TCling::RegisterModule", "cannot find dictionary module %s",
                  ROOT::TMetaUtils::GetModuleFileName(modulename).c_str());
       }

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1990,7 +1990,7 @@ void TCling::RegisterModule(const char* modulename,
 
    if (gIgnoredPCMNames.find(modulename) == gIgnoredPCMNames.end()) {
       TString pcmFileName(ROOT::TMetaUtils::GetModuleFileName(modulename).c_str());
-      if (!LoadPCM(pcmFileName, headers, triggerFunc)) {
+      if (!fCxxModulesEnabled && !LoadPCM(pcmFileName, headers, triggerFunc)) {
          ::Error("TCling::RegisterModule", "cannot find dictionary module %s",
                  ROOT::TMetaUtils::GetModuleFileName(modulename).c_str());
       }


### PR DESCRIPTION
Ideally we could stop generating rdict when runtime_cxxmodules is ON, like:
```
if (!hasCxxModules && gDriverConfig->fInitializeStreamerInfoROOTFile) {
   gDriverConfig->fInitializeStreamerInfoROOTFile(modGen.GetModuleFileName().c_str());
}
```
but doing that caused many errors in dictionary generation. So
apparently we can't do that. Instead, we can stop loading them at
runtime which gives around 1MB of improvement in memory.