### PR TITLE
[clad] Bump clad version to v0.4.

### DIFF
--- a/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
@@ -218,14 +218,6 @@ static void HandlePlugins(CompilerInstance& CI,
         Consumers.push_back(std::move(PluginConsumer));
     }
   }
-
-  // Copied from Lex/Pragma.cpp
-
-  // Pragmas added by plugins
-  for (PragmaHandlerRegistry::iterator it = PragmaHandlerRegistry::begin(),
-          ie = PragmaHandlerRegistry::end(); it != ie; ++it) {
-     CI.getPreprocessor().AddPragmaHandler(it->instantiate().release());
-  }
 }
 
 namespace cling {

--- a/interpreter/cling/tools/plugins/clad/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/clad/CMakeLists.txt
@@ -22,7 +22,7 @@ if(MSVC)
   ExternalProject_Add(
     clad
     GIT_REPOSITORY https://github.com/vgvassilev/clad.git
-    GIT_TAG v0.3
+    GIT_TAG v0.4
     UPDATE_COMMAND ""
     CMAKE_ARGS -G ${CMAKE_GENERATOR} -DCLAD_BUILD_STATIC_ONLY=ON
                -DCMAKE_INSTALL_PREFIX=${CLING_PLUGIN_INSTALL_PREFIX}
@@ -50,7 +50,7 @@ else()
   ExternalProject_Add(
     clad
     GIT_REPOSITORY https://github.com/vgvassilev/clad.git
-    GIT_TAG v0.3
+    GIT_TAG v0.4
     UPDATE_COMMAND ""
     CMAKE_ARGS -G ${CMAKE_GENERATOR}
                -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}


### PR DESCRIPTION
The new release includes some improvements in both Forward and
Reverse mode:
  * Support `x += y`, `x -= y`, `x *= y`, `x /= y`, `x++`, `x--`, `++x`, `--x`
    in forward mode.
  * Reduce emission of unused expressions
  * Add a special `#pragma clad ON/OFF/DEFAULT` to annotate regions which
    contain derivatives
  * Various small optimizations

See more at: https://github.com/vgvassilev/clad/blob/v0.4/docs/ReleaseNotes.md