### PR TITLE
[Exp PyROOT] Test char array branches are properly read as Python str

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/test/TreeHelper.h
+++ b/bindings/pyroot_experimental/PyROOT/test/TreeHelper.h
@@ -8,6 +8,7 @@ struct MyStruct {
 // Writes a `TTree` on a file. The `TTree` has the following branches:
 // - floatb: branch of basic type (`float`)
 // - arrayb: branch of type array of doubles, size `arraysize`
+// - chararrayb: branch of type array of characters, size 10
 // - vectorb: branch of type `std::vector<double>`, size `arraysize`
 // - structb: struct branch of type `MyStruct`
 // - structleafb: struct branch of type `MyStruct`, created as a leaf list
@@ -25,6 +26,10 @@ void CreateTTree(const char *filename, const char *treename, int nentries, int a
    auto a = new double[arraysize];
    t.Branch("arrayb", a, std::string("arrayb[") + arraysize + "]/D");
 
+   // Char array branch
+   char s[10] = "onetwo";
+   t.Branch("chararrayb", s, std::string("chararrayb[") + sizeof(s) + "]/C");
+
    // Vector branch
    std::vector<double> v(arraysize);
    t.Branch("vectorb", &v);
@@ -40,6 +45,11 @@ void CreateTTree(const char *filename, const char *treename, int nentries, int a
       for (int j = 0; j < arraysize; ++j) {
          a[j] = v[j] = i + j;
       }
+
+      if (i % 2 == 0)
+         s[3] = '\0';
+      else
+         s[3] = 't';
 
       mystruct.myint1 = i + more;
       mystruct.myint2 = i * more;

--- a/bindings/pyroot_experimental/PyROOT/test/ttree_branch_attr.py
+++ b/bindings/pyroot_experimental/PyROOT/test/ttree_branch_attr.py
@@ -16,7 +16,7 @@ class TTreeBranchAttr(unittest.TestCase):
     filename  = 'treebranchattr.root'
     treename  = 'mytree'
     tuplename = 'mytuple'
-    nentries  = 1
+    nentries  = 2
     arraysize = 10
     more      = 10
 
@@ -80,9 +80,19 @@ class TTreeBranchAttr(unittest.TestCase):
 
         for ds in t,c:
             a = ds.arrayb
-        
+
             for j in range(self.arraysize):
                 self.assertEqual(a[j], j)
+
+    def test_char_array_branch(self):
+        f,t,c = self.get_tree_and_chain()
+
+        for ds in t,c:
+            self.assertEqual(ds.chararrayb, 'one')
+
+            ds.GetEntry(1)
+
+            self.assertEqual(ds.chararrayb, 'onetwo')
 
     def test_vector_branch(self):
         f,t,c = self.get_tree_and_chain()


### PR DESCRIPTION
This PR adds a test to check the right behaviour when reading character arrays into Python strings, as reported in [ROOT-9768](https://sft.its.cern.ch/jira/browse/ROOT-9768).

In modern Cppyy (and therefore in experimental PyROOT), character arrays are treated differently than numeric arrays: they are converted into Python strings taking into account the '\0' character that marks end of string in C.
