### PR TITLE
[DF] Optimise runtime of RSlotStack by removing useless duplicated map lookup

### DIFF
--- a/tree/dataframe/src/RSlotStack.cxx
+++ b/tree/dataframe/src/RSlotStack.cxx
@@ -40,8 +40,9 @@ unsigned int &ROOT::Internal::RDF::RSlotStack::GetIndex()
 
    {
       ROOT::TRWSpinLockReadGuard rg(fRWLock);
-      if (fIndexMap.end() != fIndexMap.find(tid))
-         return fIndexMap[tid];
+      auto it = fIndexMap.find(tid);
+      if (fIndexMap.end() != it)
+         return it->second;
    }
 
    {


### PR DESCRIPTION
This PR shall be backported to the 6.14 branch too.