### PR TITLE
Updating size of the file for stress test 

### DIFF
--- a/test/stress.cxx
+++ b/test/stress.cxx
@@ -361,7 +361,7 @@ void stress2()
       if (last < lastgood - 200 || last > lastgood + 200 || comp < 1.5 || comp > 2.1)
          OK = kFALSE;
 #else
-      Long64_t lastgood = 10032;  // changes in TFormula (v12)
+      Long64_t lastgood = 10034;  // changes in TFormula (v12)
       if (last < lastgood - 200 || last > lastgood + 200 || comp < 2.0 || comp > 2.4)
          OK = kFALSE;
 #endif


### PR DESCRIPTION
We need changes because of a new format for compression settings.
We can see failure on Windows.

Test  2 : Check size & compression factor of a Root file........ FAILED
         last =10034, comp=2.193206