### PR TITLE
Work around to silent a compiler error on Windows

### DIFF
--- a/core/imt/inc/ROOT/TThreadExecutor.hxx
+++ b/core/imt/inc/ROOT/TThreadExecutor.hxx
@@ -308,6 +308,8 @@ namespace ROOT {
       if (nChunks == 0)
       {
 #ifdef _MSC_VER
+         // temporary work-around to silent the error C2668: 'ROOT::TThreadExecutor::Map':
+         // ambiguous call to overloaded function, due to a MS compiler bug
          unsigned start = *args.begin();
          unsigned end = *args.end();
          unsigned seqStep = args.step();

--- a/core/imt/inc/ROOT/TThreadExecutor.hxx
+++ b/core/imt/inc/ROOT/TThreadExecutor.hxx
@@ -307,7 +307,22 @@ namespace ROOT {
    auto TThreadExecutor::Map(F func, ROOT::TSeq<INTEGER> args, R redfunc, unsigned nChunks) -> std::vector<typename std::result_of<F(INTEGER)>::type> {
       if (nChunks == 0)
       {
+#ifdef _MSC_VER
+         unsigned start = *args.begin();
+         unsigned end = *args.end();
+         unsigned seqStep = args.step();
+
+         using retType = decltype(func(start));
+         std::vector<retType> reslist(end - start);
+         auto lambda = [&](unsigned int i)
+         {
+            reslist[i] = func(i);
+         };
+         ParallelFor(start, end, seqStep, lambda);
+         return reslist;
+#else
          return Map(func, args);
+#endif
       }
 
       unsigned start = *args.begin();


### PR DESCRIPTION
This (temporary) work-around silents the error C2668: 'ROOT::TThreadExecutor::Map': ambiguous call to overloaded function, due to a MS compiler bug (as reported here: https://developercommunity.visualstudio.com/content/problem/225022/wrong-error-c2668-ambiguous-call-to-overloaded-fun.html)