### PR TITLE
Add VDT include directory when building with external vdt

### DIFF
--- a/tmva/tmva/CMakeLists.txt
+++ b/tmva/tmva/CMakeLists.txt
@@ -222,6 +222,11 @@ else()
 endif()
 endif()
 
+if (vdt AND NOT builtin_vdt)
+  include_directories(${VDT_INCLUDE_DIRS})
+endif()
+
+
 if(imt)
   set(TMVA_DEPENDENCIES Imt)
 endif()


### PR DESCRIPTION
Compilation of TMVA fails now when using an external VDT. This PR fixes this issue