### PR TITLE
[Exp PyROOT] Document the types of helpers in PyROOT

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
@@ -20,7 +20,7 @@ set(sources
   src/TFilePyz.cxx
   src/TTreePyz.cxx
   src/GenericPyz.cxx
-  src/Helpers.cxx
+  src/PyzPythonHelpers.cxx
   src/PyzCppHelpers.cxx
 )
 

--- a/bindings/pyroot_experimental/PyROOT/src/PyzCppHelpers.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyzCppHelpers.cxx
@@ -8,6 +8,13 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+/**
+
+Set of helper functions that are invoked from the C++ implementation of
+pythonizations.
+
+*/
+
 #include "PyzCppHelpers.hxx"
 
 #include "CPyCppyy.h"

--- a/bindings/pyroot_experimental/PyROOT/src/PyzPythonHelpers.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyzPythonHelpers.cxx
@@ -9,6 +9,14 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+/**
+
+Set of helper functions that are invoked from the pythonizors, on the
+Python side. For that purpose, they are included in the interface of the
+PyROOT extension module.
+
+*/
+
 #include "CPyCppyy.h"
 #include "CPPInstance.h"
 #include "PyROOTPythonize.h"


### PR DESCRIPTION
There are two types of helper functions in PyROOT: those that are used from the pythonizors in Python and those that are used from the C++ implementation of the pythonizations. Only the former are exposed in the interface of the PyROOT extension module. This PR adds the necessary documentation to explain this.