### PR TITLE
[IMT] Remove more code to cope with task interleaving

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RSlotStack.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RSlotStack.hxx
@@ -13,9 +13,7 @@
 
 #include "ROOT/TRWSpinLock.hxx"
 
-#include <map>
-#include <thread>
-#include <vector>
+#include <stack>
 
 namespace ROOT {
 namespace Internal {
@@ -27,10 +25,8 @@ namespace RDF {
 /// fixed at construction time and no blocking is foreseen.
 class RSlotStack {
 private:
-   unsigned int &GetCount();
-   unsigned int &GetIndex();
-   unsigned int fCursor;
-   std::vector<unsigned int> fBuf;
+   const unsigned int fSize;
+   std::stack<unsigned int> fStack;
    ROOT::TRWSpinLock fRWLock;
 
 public:
@@ -38,8 +34,6 @@ public:
    RSlotStack(unsigned int size);
    void ReturnSlot(unsigned int slotNumber);
    unsigned int GetSlot();
-   std::map<std::thread::id, unsigned int> fCountMap;
-   std::map<std::thread::id, unsigned int> fIndexMap;
 };
 } // ns RDF
 } // ns Internal

--- a/tree/dataframe/src/RSlotStack.cxx
+++ b/tree/dataframe/src/RSlotStack.cxx
@@ -8,77 +8,27 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+#include <ROOT/TSeq.hxx>
 #include <ROOT/RDF/RSlotStack.hxx>
 #include <TError.h> // R__ASSERT
 
-#include <limits>
-#include <numeric>
-
-ROOT::Internal::RDF::RSlotStack::RSlotStack(unsigned int size) : fCursor(size), fBuf(size)
+ROOT::Internal::RDF::RSlotStack::RSlotStack(unsigned int size) : fSize(size)
 {
-   std::iota(fBuf.begin(), fBuf.end(), 0U);
+   for (auto i : ROOT::TSeqU(size)) fStack.push(i);
 }
 
-unsigned int &ROOT::Internal::RDF::RSlotStack::GetCount()
+void ROOT::Internal::RDF::RSlotStack::ReturnSlot(unsigned int slot)
 {
-   const auto tid = std::this_thread::get_id();
-   {
-      ROOT::TRWSpinLockReadGuard rg(fRWLock);
-      auto it = fCountMap.find(tid);
-      if (fCountMap.end() != it)
-         return it->second;
-   }
-
-   {
-      ROOT::TRWSpinLockWriteGuard rg(fRWLock);
-      return (fCountMap[tid] = 0U);
-   }
-}
-unsigned int &ROOT::Internal::RDF::RSlotStack::GetIndex()
-{
-   const auto tid = std::this_thread::get_id();
-
-   {
-      ROOT::TRWSpinLockReadGuard rg(fRWLock);
-      auto it = fIndexMap.find(tid);
-      if (fIndexMap.end() != it)
-         return it->second;
-   }
-
-   {
-      ROOT::TRWSpinLockWriteGuard rg(fRWLock);
-      return (fIndexMap[tid] = std::numeric_limits<unsigned int>::max());
-   }
-}
-
-void ROOT::Internal::RDF::RSlotStack::ReturnSlot(unsigned int slotNumber)
-{
-   auto &index = GetIndex();
-   auto &count = GetCount();
-   R__ASSERT(count > 0U && "RSlotStack has a reference count relative to an index which will become negative.");
-   count--;
-   if (0U == count) {
-      index = std::numeric_limits<unsigned int>::max();
-      ROOT::TRWSpinLockWriteGuard guard(fRWLock);
-      fBuf[fCursor++] = slotNumber;
-      R__ASSERT(fCursor <= fBuf.size() &&
-                "RSlotStack assumes that at most a fixed number of values can be present in the "
-                "stack. fCursor is greater than the size of the internal buffer. This violates "
-                "such assumption.");
-   }
+   ROOT::TRWSpinLockWriteGuard guard(fRWLock);
+   R__ASSERT(fStack.size() < fSize && "Trying to put back a slot to a full stack!");
+   fStack.push(slot);
 }
 
 unsigned int ROOT::Internal::RDF::RSlotStack::GetSlot()
 {
-   auto &index = GetIndex();
-   auto &count = GetCount();
-   count++;
-   if (std::numeric_limits<unsigned int>::max() != index)
-      return index;
    ROOT::TRWSpinLockWriteGuard guard(fRWLock);
-   R__ASSERT(fCursor > 0 &&
-             "RSlotStack assumes that a value can be always obtained. In this case fCursor is <=0 and this "
-             "violates such assumption.");
-   index = fBuf[--fCursor];
-   return index;
+   R__ASSERT(!fStack.empty() && "Trying to pop a slot from an empty stack!");
+   const auto slot = fStack.top();
+   fStack.pop();
+   return slot;
 }

--- a/tree/dataframe/test/dataframe_nodes.cxx
+++ b/tree/dataframe/test/dataframe_nodes.cxx
@@ -11,7 +11,7 @@ TEST(RDataFrameNodes, RSlotStackCheckSameThreadSameSlot)
 {
    unsigned int n(7);
    ROOT::Internal::RDF::RSlotStack s(n);
-   EXPECT_EQ(s.GetSlot(), s.GetSlot());
+   EXPECT_EQ(s.GetSlot()-1, s.GetSlot());
 }
 
 #ifndef NDEBUG
@@ -32,7 +32,7 @@ TEST(RDataFrameNodes, RSlotStackGetOneTooMuch)
          t.join();
    };
 
-   EXPECT_DEATH(theTest(), "RSlotStack assumes that a value can be always obtained.");
+   EXPECT_DEATH(theTest(), "Trying to pop a slot from an empty stack!");
 }
 
 TEST(RDataFrameNodes, RSlotStackPutBackTooMany)
@@ -42,7 +42,7 @@ TEST(RDataFrameNodes, RSlotStackPutBackTooMany)
       s.ReturnSlot(0);
    };
 
-   EXPECT_DEATH(theTest(), "RSlotStack has a reference count relative to an index which will become negative");
+   EXPECT_DEATH(theTest(), "Trying to put back a slot to a full stack!");
 }
 
 #endif

--- a/tree/dataframe/test/dataframe_nodes.cxx
+++ b/tree/dataframe/test/dataframe_nodes.cxx
@@ -7,13 +7,6 @@
 
 #include "gtest/gtest.h"
 
-TEST(RDataFrameNodes, RSlotStackCheckSameThreadSameSlot)
-{
-   unsigned int n(7);
-   ROOT::Internal::RDF::RSlotStack s(n);
-   EXPECT_EQ(s.GetSlot()-1, s.GetSlot());
-}
-
 #ifndef NDEBUG
 
 TEST(RDataFrameNodes, RSlotStackGetOneTooMuch)

--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -71,7 +71,6 @@ namespace ROOT {
          // NOTE: fFriends must come before fChain to be deleted after it, see ROOT-9281 for more details
          std::vector<std::unique_ptr<TChain>> fFriends; ///< Friends of the tree/chain
          std::unique_ptr<TChain> fChain;                ///< Chain on which to operate
-         std::vector<Long64_t> fLoadedEntries;          ///<! Per-task loaded entries (for task interleaving)
 
          ////////////////////////////////////////////////////////////////////////////////
          /// Construct fChain, also adding friends if needed and injecting knowledge of offsets if available.
@@ -160,20 +159,6 @@ namespace ROOT {
 
             // we need to return the entry list too, as it needs to be in scope as long as the reader is
             return std::make_pair(std::move(reader), std::move(localList));
-         }
-
-         //////////////////////////////////////////////////////////////////////////
-         /// Push a new loaded entry to the stack.
-         void PushTaskFirstEntry(Long64_t entry) { fLoadedEntries.push_back(entry); }
-
-         //////////////////////////////////////////////////////////////////////////
-         /// Restore the tree of the previous loaded entry, if any.
-         void PopTaskFirstEntry()
-         {
-            fLoadedEntries.pop_back();
-            if (fLoadedEntries.size() > 0) {
-               fChain->LoadTree(fLoadedEntries.back());
-            }
          }
       };
    } // End of namespace Internal

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -335,17 +335,11 @@ void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
          shouldUseGlobalEntries ? entries : std::vector<Long64_t>({theseClustersAndEntries.second[0]});
 
       auto processCluster = [&](const Internal::EntryCluster &c) {
-         // This task will operate with the tree that contains start
-         treeView->PushTaskFirstEntry(c.start);
-
          std::unique_ptr<TTreeReader> reader;
          std::unique_ptr<TEntryList> elist;
          std::tie(reader, elist) = treeView->GetTreeReader(c.start, c.end, fTreeName, theseFiles, fFriendInfo,
                                                            fEntryList, theseEntries, friendEntries);
          func(*reader);
-
-         // In case of task interleaving, we need to load here the tree of the parent task
-         treeView->PopTaskFirstEntry();
       };
 
       pool.Foreach(processCluster, thisFileClusters);


### PR DESCRIPTION
Remove the code dedicated to the handling of task interleaving in RSlotStack and TTreeProcessorMT.