### PR TITLE
In BuildOld, don't make all unique_ptr as having -> in comment.

### DIFF
--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -1974,7 +1974,6 @@ void TStreamerInfo::BuildOld()
       std::string typeNameBuf;
       const char* dmType = nullptr;
       Bool_t dmIsPtr = false;
-      Bool_t isUniquePtr = false;
       TDataType* dt(nullptr);
       Int_t ndim = 0 ; //dm->GetArrayDim();
       std::array<Int_t, 5> maxIndices; // 5 is the maximum supported in TStreamerElement::SetMaxIndex
@@ -2010,7 +2009,7 @@ void TStreamerInfo::BuildOld()
             Bool_t nameChanged;
             typeNameBuf = TClassEdit::GetNameForIO(dmType, TClassEdit::EModType::kNone, &nameChanged);
             if (nameChanged) {
-               isUniquePtr = dmIsPtr = TClassEdit::IsUniquePtr(dmType);
+               dmIsPtr = TClassEdit::IsUniquePtr(dmType);
                dmType = typeNameBuf.c_str();
             }
             if ((isStdArray = TClassEdit::IsStdArray(dmType))){ // We tackle the std array case
@@ -2255,7 +2254,7 @@ void TStreamerInfo::BuildOld()
          if (element->GetNewType() != -2) {
             if (dm) {
                if (dmIsPtr) {
-                  if (isUniquePtr || strncmp(dm->GetTitle(),"->",2)==0) {
+                  if (strncmp(dm->GetTitle(),"->",2)==0) {
                      // We are fine, nothing to do.
                      if (newClass->IsTObject()) {
                         newType = kObjectp;


### PR DESCRIPTION
unique_ptr can be nullptr too sometimes *and* anyway TStreamerInfo::Build does not make the same restriction.
The mismatch lead to baffling error message like:

Warning in <TStreamerInfo::BuildOld>: Cannot convert A::h from type: B to type: B, skip element

This solves one of the problems seen in https://sft.its.cern.ch/jira/browse/ROOT-9702.