### PR TITLE
Fix TFormula::Print with verbose option

### DIFF
--- a/hist/hist/inc/TFormula.h
+++ b/hist/hist/inc/TFormula.h
@@ -100,10 +100,10 @@ private:
 
    using CallFuncSignature = TInterpreter::CallFuncIFacePtr_t::Generic_t;
    std::string       fGradGenerationInput; //! input query to clad to generate a gradient
-   CallFuncSignature fFuncPtr; //!  function pointer, owned by the JIT.
-   CallFuncSignature fGradFuncPtr; //!  function pointer, owned by the JIT.
+   CallFuncSignature fFuncPtr = nullptr; //!  function pointer, owned by the JIT.
+   CallFuncSignature fGradFuncPtr = nullptr; //!  function pointer, owned by the JIT.
+   void *   fLambdaPtr = nullptr;            //!  pointer to the lambda function
    static bool       fIsCladRuntimeIncluded;
-   void *   fLambdaPtr;                                    //!  pointer to the lambda function
 
    void     InputFormulaIntoCling();
    Bool_t   PrepareEvalMethod();

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -3567,8 +3567,8 @@ void TFormula::Print(Option_t *option) const
       }
       printf("Expression passed to Cling:\n");
       printf("\t%s\n",fClingInput.Data() );
-      printf("Generated Gradient:\n");
       if (fGradFuncPtr) {
+         printf("Generated Gradient:\n");
          printf("%s\n", fGradGenerationInput.c_str());
          printf("%s\n", GetGradientFormula().Data());
       }

--- a/test/TFormulaParsingTests.h
+++ b/test/TFormulaParsingTests.h
@@ -935,6 +935,28 @@ bool test48() {
    return ok;
 }
 
+bool test49() {
+   // test detailed printing of function
+   TFormula f1("f1","[A]*sin([B]*x)");
+   f1.Print("V");
+   bool ok = f1.IsValid(); 
+
+   TF2 f2("f2","[0]*x+[1]*y");
+   f2.Print("V");
+   ok |= f2.GetFormula()->IsValid();
+
+   // create using lambda expression, need to pass ndim and npar
+   TFormula f3("f3","[](double *x, double *p){ return p[0]*x[0] + p[1]; } ",1,2);
+   f3.Print("V");
+   ok |= f3.IsValid();
+
+   // create again using lambda from TF1, need to pass xmin(0.),xmax(1.), npar (1)
+   TF1 f4("f3","[](double *x, double *p){ return p[0]*x[0]; } ",0.,1.,1);  
+   f4.Print("V");
+   ok |= f3.IsValid();
+
+   return ok;
+}
 
 void PrintError(int itest)  {
    Error("TFormula test","test%d FAILED ",itest);
@@ -1001,6 +1023,7 @@ int runTests(bool debug = false) {
    IncrTest(itest); if (!test46() ) { PrintError(itest); }
    IncrTest(itest); if (!test47() ) { PrintError(itest); }
    IncrTest(itest); if (!test48() ) { PrintError(itest); }
+   IncrTest(itest); if (!test49() ) { PrintError(itest); }
 
    std::cout << ".\n";
 


### PR DESCRIPTION
This PR fixes the initialisation of the gradient function pointer which caused a failure in TFormula::Print("V")

The PR introduces also a test for TFormula::Print