### PR TITLE
Fix FindOracle.cmake to find version 18.x

### DIFF
--- a/cmake/modules/FindOracle.cmake
+++ b/cmake/modules/FindOracle.cmake
@@ -55,7 +55,7 @@ FIND_LIBRARY(
 )
 FIND_LIBRARY(
     ORACLE_LIBRARY_LNNZ
-    NAMES libnnz10 nnz10 libnnz11 nnz11 libnnz12 nnz12 ociw32
+    NAMES libnnz10 nnz10 libnnz11 nnz11 libnnz12 nnz12 nnz18 ociw32
     PATHS ${ORACLE_LIB_LOCATION}
 )
 


### PR DESCRIPTION
Just add the new library name so that it can be found. This can probably even skip CI, as I tested locally and it won't be tested by our builds against a new enough Oracle client.