### PR TITLE
http: remove depricated methods

### DIFF
--- a/README/ReleaseNotes/v618/index.md
+++ b/README/ReleaseNotes/v618/index.md
@@ -33,7 +33,7 @@ The following people have contributed to this new version:
 
 ### THttpServer classes
 
-Following deprecated methods were removed:
+The following methods were deprecated and removed:
 
    * Bool_t THttpServer::SubmitHttp(THttpCallArg *arg, Bool_t can_run_immediately = kFALSE, Bool_t ownership = kFALSE);
    * Bool_t THttpServer::ExecuteHttp(THttpCallArg *arg)
@@ -42,8 +42,7 @@ Following deprecated methods were removed:
    * void THttpCallArg::FillHttpHeader(TString &buf, const char *header = nullptr);
    * void THttpCallArg::SetBinData(void *data, Long_t length);
    
-   
-Methods should be replaced by equivalent methods with other signature:
+The methods could be replaced by equivalent methods with other signature:
 
    * Bool_t THttpServer::SubmitHttp(std::shared_ptr<THttpCallArg> arg, Bool_t can_run_immediately = kFALSE);
    * Bool_t THttpServer::ExecuteHttp(std::shared_ptr<THttpCallArg> arg);

--- a/README/ReleaseNotes/v618/index.md
+++ b/README/ReleaseNotes/v618/index.md
@@ -29,6 +29,30 @@ The following people have contributed to this new version:
  Vassil Vassilev, Princeton/CMS,\
  Wouter Verkerke, NIKHEF/Atlas,
 
+## Deprecation and Removal
+
+### THttpServer classes
+
+Following deprecated methods were removed:
+
+   * Bool_t THttpServer::SubmitHttp(THttpCallArg *arg, Bool_t can_run_immediately = kFALSE, Bool_t ownership = kFALSE);
+   * Bool_t THttpServer::ExecuteHttp(THttpCallArg *arg)
+   * Bool_t TRootSniffer::Produce(const char *path, const char *file, const char *options, void *&ptr, Long_t &length, TString &str);
+   * TString THttpCallArg::GetPostDataAsString();
+   * void THttpCallArg::FillHttpHeader(TString &buf, const char *header = nullptr);
+   * void THttpCallArg::SetBinData(void *data, Long_t length);
+   
+   
+Methods should be replaced by equivalent methods with other signature:
+
+   * Bool_t THttpServer::SubmitHttp(std::shared_ptr<THttpCallArg> arg, Bool_t can_run_immediately = kFALSE);
+   * Bool_t THttpServer::ExecuteHttp(std::shared_ptr<THttpCallArg> arg);
+   * Bool_t TRootSniffer::Produce(const std::string &path, const std::string &file, const std::string &options, std::string &res);   
+   * const void *THttpCallArg::GetPostData() const;
+   * Long_t THttpCallArg::GetPostDataLength() const;
+   * std::string THttpCallArg::FillHttpHeader(const char *header = nullptr);
+   * void THttpCallArg::SetContent(std::string &&cont);
+
 
 ## Core Libraries
 

--- a/net/http/inc/THttpCallArg.h
+++ b/net/http/inc/THttpCallArg.h
@@ -137,10 +137,6 @@ public:
    /** return length of posted with request data */
    Long_t GetPostDataLength() const { return (Long_t) fPostData.length(); }
 
-   /** returns post data as TString */
-   TString GetPostDataAsString() const _R__DEPRECATED_618("Use other methods to access POST data")
-   { return TString(fPostData.c_str()); }
-
    /** returns path name from request URL */
    const char *GetPathName() const { return fPathName.Data(); }
 
@@ -210,7 +206,6 @@ public:
    /** add extra http header value to the reply */
    void SetExtraHeader(const char *name, const char *value) { AddHeader(name, value); }
 
-   void FillHttpHeader(TString &buf, const char *header = nullptr) _R__DEPRECATED_618("Use method returning std::string");
    std::string FillHttpHeader(const char *header = nullptr);
 
    // these methods used to return results of http request processing
@@ -225,8 +220,6 @@ public:
    Bool_t IsXml() const { return IsContentType("text/xml"); }
    Bool_t IsJson() const { return IsContentType("application/json"); }
    Bool_t IsBinary() const { return IsContentType("application/x-binary"); }
-
-   void SetBinData(void *data, Long_t length) _R__DEPRECATED_618("Use SetContent(std::string &&)");
 
    Long_t GetContentLength() const { return (Long_t) fContent.length(); }
    const void *GetContent() const { return fContent.data(); }

--- a/net/http/inc/THttpServer.h
+++ b/net/http/inc/THttpServer.h
@@ -52,7 +52,6 @@ protected:
    std::string fCors;            ///<! CORS: sets Access-Control-Allow-Origin header for ProcessRequest responses
 
    std::mutex fMutex;                                        ///<! mutex to protect list with arguments
-   TList fCallArgs;                                          ///<! submitted arguments (deprecated)
    std::queue<std::shared_ptr<THttpCallArg>> fArgs;          ///<! submitted arguments
 
    std::mutex fWSMutex;                                      ///<! mutex to protect WS handler lists

--- a/net/http/inc/THttpServer.h
+++ b/net/http/inc/THttpServer.h
@@ -125,9 +125,6 @@ public:
    Bool_t IsFileRequested(const char *uri, TString &res) const;
 
    /** Execute HTTP request */
-   Bool_t ExecuteHttp(THttpCallArg *arg) _R__DEPRECATED_618("Please use ExecuteHttp(std::shared_ptr<THttpCallArg>)");
-
-   /** Execute HTTP request */
    Bool_t ExecuteHttp(std::shared_ptr<THttpCallArg> arg);
 
    /** Submit HTTP request */

--- a/net/http/inc/THttpServer.h
+++ b/net/http/inc/THttpServer.h
@@ -131,9 +131,6 @@ public:
    Bool_t ExecuteHttp(std::shared_ptr<THttpCallArg> arg);
 
    /** Submit HTTP request */
-   Bool_t SubmitHttp(THttpCallArg *arg, Bool_t can_run_immediately = kFALSE, Bool_t ownership = kFALSE) _R__DEPRECATED_618("Please use SubmitHttp(std::shared_ptr<THttpCallArg>,bool)");
-
-   /** Submit HTTP request */
    Bool_t SubmitHttp(std::shared_ptr<THttpCallArg> arg, Bool_t can_run_immediately = kFALSE);
 
    /** Process submitted requests, must be called from appropriate thread */

--- a/net/http/inc/TRootSniffer.h
+++ b/net/http/inc/TRootSniffer.h
@@ -239,8 +239,6 @@ public:
 
    virtual ULong_t GetItemHash(const char *itemname);
 
-   Bool_t Produce(const char *path, const char *file, const char *options, void *&ptr, Long_t &length, TString &str) _R__DEPRECATED_618("Use signature with std::string");
-
    Bool_t Produce(const std::string &path, const std::string &file, const std::string &options, std::string &res);
 
    ClassDef(TRootSniffer, 0) // Sniffer of ROOT objects (basic version)

--- a/net/http/src/THttpCallArg.cxx
+++ b/net/http/src/THttpCallArg.cxx
@@ -267,27 +267,6 @@ void THttpCallArg::ReplaceAllinContent(const std::string &from, const std::strin
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// \deprecated use SetContent(std::string &&arg) signature instead
-/// set binary data, which will be returned as reply body
-/// Memory should be allocated with std::malloc().
-/// THttpCallArg take over ownership over specified memory.
-/// Memory will be released by calling std::free() function.
-
-void THttpCallArg::SetBinData(void *data, Long_t length)
-{
-   // string content must be cleared in any case
-   if (length <= 0) {
-      fContent.clear();
-   } else {
-      fContent.resize(length);
-      if (data) {
-         std::copy((const char *)data, (const char *)data + length, fContent.begin());
-         free(data);
-      }
-   }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// set complete path of requested http element
 /// For instance, it could be "/folder/subfolder/get.bin"
 /// Here "/folder/subfolder/" is element path and "get.bin" requested file.
@@ -375,16 +354,6 @@ std::string THttpCallArg::FillHttpHeader(const char *name)
                       GetContentType(), GetContentLength(), fHeader.Data()));
 
    return hdr;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// \depricated use FillHttpHeader with other signature
-/// Fills HTTP header, which can be send at the beggining of reply on the http request
-/// \param name is HTTP protocol name (default "HTTP/1.1")
-
-void THttpCallArg::FillHttpHeader(TString &hdr, const char *name)
-{
-    hdr = FillHttpHeader(name).c_str();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -585,33 +585,6 @@ Bool_t THttpServer::ExecuteHttp(std::shared_ptr<THttpCallArg> arg)
    return kTRUE;
 }
 
-////////////////////////////////////////////////////////////////////////////////
-/// \deprecated Signature with shared_ptr should be used
-/// Executes http request, specified in THttpCallArg structure
-/// Method can be called from any thread
-/// Actual execution will be done in main ROOT thread, where analysis code is running.
-
-Bool_t THttpServer::ExecuteHttp(THttpCallArg *arg)
-{
-   if (fTerminated)
-      return kFALSE;
-
-   if ((fMainThrdId != 0) && (fMainThrdId == TThread::SelfId())) {
-      // should not happen, but one could process requests directly without any signaling
-
-      ProcessRequest(arg);
-
-      return kTRUE;
-   }
-
-   // add call arg to the list
-   std::unique_lock<std::mutex> lk(fMutex);
-   fCallArgs.Add(arg);
-   // and now wait until request is processed
-   arg->fCond.wait(lk);
-
-   return kTRUE;
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Submit http request, specified in THttpCallArg structure

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -614,44 +614,6 @@ Bool_t THttpServer::ExecuteHttp(THttpCallArg *arg)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// \deprecated Signature with shared_ptr should be used
-/// Submit http request, specified in THttpCallArg structure
-/// Contrary to ExecuteHttp, it will not block calling thread.
-/// User should reimplement THttpCallArg::HttpReplied() method
-/// to react when HTTP request is executed.
-/// Method can be called from any thread
-/// Actual execution will be done in main ROOT thread, where analysis code is running.
-/// When called from main thread and can_run_immediately==kTRUE, will be
-/// executed immediately.
-/// If ownership==kTRUE, THttpCallArg object will be destroyed by the THttpServer
-/// Returns kTRUE when was executed.
-
-Bool_t THttpServer::SubmitHttp(THttpCallArg *arg, Bool_t can_run_immediately, Bool_t ownership)
-{
-   if (fTerminated) {
-      if (ownership)
-         delete arg;
-      return kFALSE;
-   }
-
-   if (can_run_immediately && (fMainThrdId != 0) && (fMainThrdId == TThread::SelfId())) {
-      ProcessRequest(arg);
-      arg->NotifyCondition();
-      if (ownership)
-         delete arg;
-      return kTRUE;
-   }
-
-   // add call arg to the list
-   std::unique_lock<std::mutex> lk(fMutex);
-   if (ownership)
-      fArgs.push(std::shared_ptr<THttpCallArg>(arg));
-   else
-      fCallArgs.Add(arg);
-   return kFALSE;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Submit http request, specified in THttpCallArg structure
 /// Contrary to ExecuteHttp, it will not block calling thread.
 /// User should reimplement THttpCallArg::HttpReplied() method

--- a/net/http/src/TRootSniffer.cxx
+++ b/net/http/src/TRootSniffer.cxx
@@ -1464,43 +1464,6 @@ Bool_t TRootSniffer::ProduceImage(Int_t /*kind*/, const std::string & /*path*/, 
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// \deprecated Use signature with std::string
-/// Method produce different kind of data out of object
-/// Parameter 'path' specifies object or object member
-/// Supported 'file' (case sensitive):
-///   "root.bin"  - binary data
-///   "root.png"  - png image
-///   "root.jpeg" - jpeg image
-///   "root.gif"  - gif image
-///   "root.xml"  - xml representation
-///   "root.json" - json representation
-///   "exe.json"  - method execution with json reply
-///   "exe.bin"   - method execution with binary reply
-///   "exe.txt"   - method execution with debug output
-///   "cmd.json"  - execution of registered commands
-/// Result returned either as string or binary buffer,
-/// which should be released with free() call
-
-Bool_t TRootSniffer::Produce(const char *path, const char *file, const char *options, void *&ptr, Long_t &length,
-                                 TString &str)
-{
-   std::string data;
-   if (!Produce(path, file, options, data))
-      return kFALSE;
-   if (strstr(file, ".json") || strstr(file, ".xml") || strstr(file, ".txt")) {
-      str = data.c_str();
-      ptr = 0;
-      length = 0;
-   } else {
-      str.Clear();
-      length = data.length();
-      ptr = malloc(length + 1);
-      memcpy(ptr, data.data(), length + 1); // copy including zero at the end
-   }
-   return kTRUE;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Method produce different kind of data out of object
 /// Parameter 'path' specifies object or object member
 /// Supported 'file' (case sensitive):


### PR DESCRIPTION
Since ~8 months methods were not used inside ROOT 
I expect very few users who really used them - this is only for custom applications with sub-classes