### PR TITLE
[TMVA] CV - Add workaround for large event numbers

### DIFF
--- a/tutorials/tmva/TMVACrossValidation.C
+++ b/tutorials/tmva/TMVACrossValidation.C
@@ -85,8 +85,6 @@ TTree *genTree(Int_t nPoints, Double_t offset, Double_t scale, UInt_t seed = 100
    TTree *data = new TTree();
    data->Branch("x", &x, "x/F");
    data->Branch("y", &y, "y/F");
-
-   // EventID's can be large, set branch type to unsigned long
    data->Branch("eventID", &eventID, "eventID/I");
 
    for (Int_t n = 0; n < nPoints; ++n) {

--- a/tutorials/tmva/TMVACrossValidation.C
+++ b/tutorials/tmva/TMVACrossValidation.C
@@ -85,6 +85,8 @@ TTree *genTree(Int_t nPoints, Double_t offset, Double_t scale, UInt_t seed = 100
    TTree *data = new TTree();
    data->Branch("x", &x, "x/F");
    data->Branch("y", &y, "y/F");
+
+   // EventID's can be large, set branch type to unsigned long
    data->Branch("eventID", &eventID, "eventID/I");
 
    for (Int_t n = 0; n < nPoints; ++n) {
@@ -134,6 +136,15 @@ int TMVACrossValidation()
 
    // Spectator used for split
    dataloader->AddSpectator("eventID", 'I');
+
+   // NOTE: Currently TMVA treats all input variables, spectators etc as
+   //       floats. Thus, if the absolute value of the input is too large
+   //       there can be precision loss. This can especially be a problem for
+   //       cross validation with large event numbers.
+   //       A workaround is to define your splitting variable as:
+   //           `dataloader->AddSpectator("eventID := eventID % 4096", 'I');`
+   //       where 4096 should be a number much larger than the number of folds
+   //       you intend to run with.
 
    // Attaches the trees so they can be read from
    dataloader->AddSignalTree(sigTree, 1.0);


### PR DESCRIPTION
Currently TMVA considers all internal variables floats, if large event numbers are then input as part of "cv-in-app" these can overflow the float resulting in erroneous fold assignments.

A workaround is to reduce the input range when reading the input from the TTree as TTreeFormula retains awareness of the input type.