### PR TITLE
[Dictgen] ROOT-9635 ROOT-9615: filter out unwanted rootcling args.

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -3735,9 +3735,13 @@ bool IsImplementationName(const std::string &filename)
 
 int ShouldIgnoreClingArgument(const std::string& argument)
 {
-   if (argument == "-pipe") return 1;
-   if (argument == "-fPIC") return 1;
-   if (argument == "-fpic") return 1;
+   auto vetos = {"-pipe", "-fPIC", "-fpic",
+                 "-fno-plt", "--save-temps" };
+
+   for (auto veto : vetos) {
+      if (argument == veto) return 1;
+   }
+
    if (ROOT::TMetaUtils::BeginsWith(argument, "--gcc-toolchain="))
       return 1;
 


### PR DESCRIPTION
(cherry picked from commit 26f54569b46d3d2daae838cf55195d436be7ac80)