### PR TITLE
Add explicit cast to (char*) for python 3.7 compatibility

### DIFF
--- a/bindings/pyroot/src/TPyROOTApplication.cxx
+++ b/bindings/pyroot/src/TPyROOTApplication.cxx
@@ -101,7 +101,7 @@ Bool_t PyROOT::TPyROOTApplication::CreatePyROOTApplication( Bool_t bLoadLibs )
       if ( argl && 0 < PyList_Size( argl ) ) argc = (int)PyList_GET_SIZE( argl );
       char** argv = new char*[ argc ];
       for ( int i = 1; i < argc; ++i ) {
-         char* argi = PyROOT_PyUnicode_AsString( PyList_GET_ITEM( argl, i ) );
+         char* argi = (char*) PyROOT_PyUnicode_AsString( PyList_GET_ITEM( argl, i ) );
          if ( strcmp( argi, "-" ) == 0 || strcmp( argi, "--" ) == 0 ) {
          // stop collecting options, the remaining are for the python script
             argc = i;    // includes program name


### PR DESCRIPTION
Compilation fails because of an implicit cast from `const char*` to `char*`

This fixes compilation of the root 5 legacy branch with python 3.7

(Don't ask why we still use root 5 :D)