### PR TITLE
[TMVA] ROOT-9799 -- aka ROOT-9444 for v6.14

### DIFF
--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu/CpuMatrix.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu/CpuMatrix.h
@@ -25,29 +25,41 @@
 #include "CpuBuffer.h"
 #include <TMVA/Config.h>
 
-//#define DEBUG_TMVA_TCPUMATRIX
+// #define DEBUG_TMVA_TCPUMATRIX
 #if defined(DEBUG_TMVA_TCPUMATRIX)
-#define PrintMatrix(mat, text)                                                                             \
-   {                                                                                                       \
-      auto _dpointer = mat.GetRawDataPointer();                                                            \
-      if (_dpointer == NULL) {                                                                             \
-         std::cout << #mat << " is null pointer" << std::endl;                                             \
-         exit(1);                                                                                          \
-      }                                                                                                    \
-      auto _nrows = mat.GetNrows();                                                                        \
-      auto _ncols = mat.GetNcols();                                                                        \
-      std::cout << "---------------------" << text << " " << #mat << "(" << _nrows << "," << _ncols << ")" \
-                << "--------------------" << std::endl;                                                    \
-      for (size_t _i = 0; _i < _nrows; _i++) {                                                               \
-         for (size_t _j = 0; _j < _ncols; _j++) {                                                            \
-            std::cout << mat(_i, _j);                                                                      \
-            if (_j < _ncols - 1) std::cout << ",";                                                         \
-         }                                                                                                 \
-         std::cout << std::endl;                                                                           \
-      }                                                                                                    \
-   }
+/*
+ * Debug(!) function for printing matrices.
+ * 
+ * Prints the input expression `mat` using preprocessor directives (with
+ * `#mat`). E.g. `PrintMatrix(matA, "Test")` _could_ generate
+ * "matA is null pointer".
+ *
+ * Note: This is a preprocessor macro. It does _not_ respect namespaces.
+ * 
+ * @param mat  Matrix to print
+ * @param text Name of matrix
+ */
+#define TMVA_DNN_PrintTCpuMatrix(mat, text)                                                                \
+{                                                                                                      \
+   auto _dpointer = mat.GetRawDataPointer();                                                           \
+   if (_dpointer == NULL) {                                                                            \
+      std::cout << #mat << " is null pointer" << std::endl;                                            \
+      exit(1);                                                                                         \
+   }                                                                                                   \
+   auto _nrows = mat.GetNrows();                                                                       \
+   auto _ncols = mat.GetNcols();                                                                       \
+   std::cout << "---------------------" << text << " " << #mat << "(" << _nrows << "," << _ncols << ")"\
+             << "--------------------" << std::endl;                                                   \
+   for (size_t _i = 0; _i < _nrows; _i++) {                                                            \
+      for (size_t _j = 0; _j < _ncols; _j++) {                                                         \
+         std::cout << mat(_i, _j);                                                                     \
+         if (_j < _ncols - 1) std::cout << ",";                                                        \
+      }                                                                                                \
+      std::cout << std::endl;                                                                          \
+   }                                                                                                   \
+}
 #else
-#define PrintMatrix(mat, text)
+#define TMVA_DNN_PrintTCpuMatrix(mat, text)
 #endif
 
 namespace TMVA
@@ -143,8 +155,8 @@ public:
 
    // print matrix
    void Print() const {
-      TCpuMatrix cpuMatrix = *this; 
-      PrintMatrix(cpuMatrix,"CpuMatrix");
+      TCpuMatrix cpuMatrix = *this;
+      TMVA_DNN_PrintTCpuMatrix(cpuMatrix,"CpuMatrix");
    }
    
 

--- a/tmva/tmva/inc/TMVA/DNN/CNN/ConvLayer.h
+++ b/tmva/tmva/inc/TMVA/DNN/CNN/ConvLayer.h
@@ -266,10 +266,10 @@ auto TConvLayer<Architecture_t>::Forward(std::vector<Matrix_t> &input, bool appl
       //    printf("Layer parameters : %d x %d , filter %d x %d , stride %d %d , pad %d %d \n",this->GetInputHeight(), this->GetInputWidth(), this->GetFilterHeight(),
       //                         this->GetFilterWidth(), this->GetStrideRows(), this->GetStrideCols(),
       //           this->GetPaddingHeight(), this->GetPaddingWidth() );
-      //    // PrintMatrix(inputTr);
-      //    //PrintMatrix(inputTr2);
-      // }         
-      // R__ASSERT(!diff); 
+      //    // TMVA_DNN_PrintTCpuMatrix(inputTr);
+      //    // TMVA_DNN_PrintTCpuMatrix(inputTr2);
+      // }
+      // R__ASSERT(!diff);
       Architecture_t::MultiplyTranspose(this->GetOutputAt(i), this->GetWeightsAt(0), inputTr);
       Architecture_t::AddConvBiases(this->GetOutputAt(i), this->GetBiasesAt(0));
 

--- a/tmva/tmva/src/DNN/Architectures/Cpu/Propagation.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Cpu/Propagation.cxx
@@ -142,7 +142,7 @@ void TCpu<AFloat>::Im2col(TCpuMatrix<AFloat> &A, const TCpuMatrix<AFloat> &B, si
          currLocalView++;
       }
    }
-   //PrintMatrix(A,"FromIm2Col"); 
+   //TMVA_DNN_PrintTCpuMatrix(A,"FromIm2Col");
 }
 
 //____________________________________________________________________________
@@ -234,8 +234,8 @@ void TCpu<AFloat>::Im2colFast(TCpuMatrix<AFloat> &A, const TCpuMatrix<AFloat> &B
    }
 
 #endif
-   // PrintMatrix(A,"FromFastIm2Col");
-   // PrintMatrix(B,"input to Im2Col");
+   // TMVA_DNN_PrintTCpuMatrix(A,"FromFastIm2Col");
+   // TMVA_DNN_PrintTCpuMatrix(B,"input to Im2Col");
    // std::cout << "V vector " << V.size() << std::endl;
    // for ( int i = 0; i < n; ++i) {
    //    std::cout << V[i] << "  ";
@@ -364,11 +364,11 @@ void TCpu<AFloat>::CalculateConvActivationGradients(std::vector<TCpuMatrix<AFloa
    
    // Transform the weights
 
-   //PrintMatrix(weights,"weights");
+   //TMVA_DNN_PrintTCpuMatrix(weights,"weights");
    // filter depth must be same as input depth
    TCpuMatrix<AFloat> rotWeights(filterDepth, depth * filterHeight * filterWidth);
    RotateWeights(rotWeights, weights, filterDepth, filterHeight, filterWidth, weights.GetNrows());
-   //PrintMatrix(rotWeights,"rot-weights");
+   //TMVA_DNN_PrintTCpuMatrix(rotWeights,"rot-weights");
 
    // Calculate the zero paddings
    size_t tempZeroPaddingHeight = (size_t)(floor((inputHeight - height + filterHeight - 1) / 2));
@@ -404,12 +404,12 @@ void TCpu<AFloat>::CalculateConvActivationGradients(std::vector<TCpuMatrix<AFloa
       
       Im2colFast(dfTr, df[i], vIndices); 
 
-       //PrintMatrix(df[i],"df[i]");
-       //PrintMatrix(dfTr,"dfTr");
+       //TMVA_DNN_PrintTCpuMatrix(df[i],"df[i]");
+       //TMVA_DNN_PrintTCpuMatrix(dfTr,"dfTr");
 
        MultiplyTranspose(activationGradientsBackward[i], rotWeights, dfTr);
 
-       //PrintMatrix(activationGradientsBackward[i],"activGrad-result");
+       //TMVA_DNN_PrintTCpuMatrix(activationGradientsBackward[i],"activGrad-result");
 
    };
 
@@ -453,14 +453,14 @@ void TCpu<AFloat>::CalculateConvWeightGradients(TCpuMatrix<AFloat> &weightGradie
    std::vector< TCpuMatrix<AFloat> > vres;//(batchSize); 
    for (size_t i = 0; i < batchSize; i++) {
       vres.emplace_back(depth, nLocalViewPixels);
-      //PrintMatrix(df[i],"df");
-      //PrintMatrix(activationsBackward[i],"df");
+      //TMVA_DNN_PrintTCpuMatrix(df[i],"df");
+      //TMVA_DNN_PrintTCpuMatrix(activationsBackward[i],"df");
       
    }
    
    auto fmap = [&](int i) { 
  
-      //PrintMatrix(df[i],"df-i");
+      //TMVA_DNN_PrintTCpuMatrix(df[i],"df-i");
       TCpuMatrix<AFloat> xTr(nLocalViews, nLocalViewPixels);
       TCpuMatrix<AFloat> res(depth, nLocalViewPixels);
 
@@ -473,10 +473,10 @@ void TCpu<AFloat>::CalculateConvWeightGradients(TCpuMatrix<AFloat> &weightGradie
       Im2colFast(xTr, activationsBackward[i], vIndices);
 
       //std::cout << "doing im2colfast" << std::endl;
-      //PrintMatrix(xTr,"xTr-i");
-      //PrintMatrix(activationsBackward[i],"actbackward-i");
+      //TMVA_DNN_PrintTCpuMatrix(xTr,"xTr-i");
+      //TMVA_DNN_PrintTCpuMatrix(activationsBackward[i],"actbackward-i");
       Multiply(vres[i], df[i], xTr);
-      //PrintMatrix(vres[i],"res_ofMT");
+      //TMVA_DNN_PrintTCpuMatrix(vres[i],"res_ofMT");
 
       return;
       //return res;
@@ -487,7 +487,7 @@ void TCpu<AFloat>::CalculateConvWeightGradients(TCpuMatrix<AFloat> &weightGradie
 //   auto freduce = [&](const std::vector<TCpuMatrix<AFloat>> & vres) { 
       R__ASSERT(vres.size() == batchSize); 
       for (size_t i = 0; i < batchSize; i++) {
-         //PrintMatrix(vres[i],"res");
+         //TMVA_DNN_PrintTCpuMatrix(vres[i],"res");
          for (size_t j = 0; j < depth; j++) {
             for (size_t k = 0; k < filterDepth; k++) {
                size_t kOffset = k * filterSize; 
@@ -497,12 +497,12 @@ void TCpu<AFloat>::CalculateConvWeightGradients(TCpuMatrix<AFloat> &weightGradie
                }
             }
          }
-         // PrintMatrix(weightGradients,"weights_i");
+         // TMVA_DNN_PrintTCpuMatrix(weightGradients,"weights_i");
       }
       //  };
   
    //TCpuMatrix<AFloat>::GetThreadExecutor().MapReduce(fmap, ROOT::TSeqI( batchSize ) , freduce);
-   //PrintMatrix(weightGradients,"W-Grad");
+   //TMVA_DNN_PrintTCpuMatrix(weightGradients,"W-Grad");
 }
 
 //____________________________________________________________________________

--- a/tmva/tmva/src/DNN/Architectures/Cpu/RecurrentPropagation.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Cpu/RecurrentPropagation.cxx
@@ -39,11 +39,11 @@ auto TCpu<AFloat>::RecurrentLayerBackward(TCpuMatrix<AFloat> & state_gradients_b
 {
 
    // std::cout << "Recurrent Propo" << std::endl;
-   // PrintMatrix(df,"DF");
-   // PrintMatrix(state_gradients_backward,"State grad");
-   // PrintMatrix(input_weight_gradients,"input w grad");
-   // PrintMatrix(state,"state");
-   // PrintMatrix(input,"input");
+   // TMVA_DNN_PrintTCpuMatrix(df,"DF");
+   // TMVA_DNN_PrintTCpuMatrix(state_gradients_backward,"State grad");
+   // TMVA_DNN_PrintTCpuMatrix(input_weight_gradients,"input w grad");
+   // TMVA_DNN_PrintTCpuMatrix(state,"state");
+   // TMVA_DNN_PrintTCpuMatrix(input,"input");
    
    // Compute element-wise product.
    Hadamard(df, state_gradients_backward);  // B x H 
@@ -73,10 +73,10 @@ auto TCpu<AFloat>::RecurrentLayerBackward(TCpuMatrix<AFloat> & state_gradients_b
 
    //std::cout << "RecurrentPropo: end " << std::endl;
 
-   // PrintMatrix(state_gradients_backward,"State grad");
-   // PrintMatrix(input_weight_gradients,"input w grad");
-   // PrintMatrix(bias_gradients,"bias grad");
-   // PrintMatrix(input_gradient,"input grad");
+   // TMVA_DNN_PrintTCpuMatrix(state_gradients_backward,"State grad");
+   // TMVA_DNN_PrintTCpuMatrix(input_weight_gradients,"input w grad");
+   // TMVA_DNN_PrintTCpuMatrix(bias_gradients,"bias grad");
+   // TMVA_DNN_PrintTCpuMatrix(input_gradient,"input grad");
 
    return input_gradient;
 }

--- a/tmva/tmva/test/DNN/CNN/TestConvNet.h
+++ b/tmva/tmva/test/DNN/CNN/TestConvNet.h
@@ -337,7 +337,7 @@ auto testConvBackwardPass(size_t batchSize, size_t imgDepth, size_t imgHeight, s
 //    std::cout << "Netwrok weights for Layer 0  " << std::endl; 
 //    std::cout << "weight depth = " << w0.size() << std::endl;
 //    for (size_t i = 0; i < w0.size();   ++i)
-//       PrintMatrix(w0[i],"weight-layer0");
+//       TMVA_DNN_PrintTCpuMatrix(w0[i],"weight-layer0");
 // #endif  
    
    std::vector<Matrix_t> X;
@@ -348,7 +348,7 @@ auto testConvBackwardPass(size_t batchSize, size_t imgDepth, size_t imgHeight, s
        // print input
 #ifdef DEBUGH  
       std::cout << "INPUT - batch " << i << std::endl;
-      PrintMatrix(X[i],"input");
+      TMVA_DNN_PrintTCpuMatrix(X[i],"input");
 #endif  
    }
 
@@ -370,7 +370,7 @@ auto testConvBackwardPass(size_t batchSize, size_t imgDepth, size_t imgHeight, s
       auto & df = convLayer->GetDerivatives();
       std::cout << "Derivatives - size " << df.size() << std::endl;
       for (size_t ii=0; ii< df.size(); ++ii)
-         PrintMatrix(df[ii],"Derivatives");
+         TMVA_DNN_PrintTCpuMatrix(df[ii],"Derivatives");
    }
 #endif
 

--- a/tmva/tmva/test/DNN/CNN/TestConvNet.h
+++ b/tmva/tmva/test/DNN/CNN/TestConvNet.h
@@ -394,7 +394,7 @@ auto testConvBackwardPass(size_t batchSize, size_t imgDepth, size_t imgHeight, s
       if (gw.size() > 0) { 
          std::cout << "Weight gradient from back-propagation - vector size is " << gw.size()  << std::endl;
          if (gw[0].GetNElements() < 100 ) { 
-            PrintMatrix(gw[0],"WeightGrad");
+            TMVA_DNN_PrintTCpuMatrix(gw[0],"WeightGrad");
          }
          else
             std::cout << "BP Weight Gradient ( " << gw[0].GetNrows() << " x " << gw[0].GetNcols() << " ) , ...... skip printing (too many elements ) " << std::endl;  
@@ -407,7 +407,7 @@ auto testConvBackwardPass(size_t batchSize, size_t imgDepth, size_t imgHeight, s
          std::cout << "Activation gradient from back-propagation  - vector size is " << actGrad.size() << std::endl;
          if (actGrad[0].GetNElements() < 100 ) { 
             for (size_t ii = 0; ii < actGrad.size(); ++ii) 
-               PrintMatrix(actGrad[ii],"ActivationGrad");
+               TMVA_DNN_PrintTCpuMatrix(actGrad[ii],"ActivationGrad");
          } else
             std::cout << "Activation Gradient ( " << actGrad[0].GetNrows() << " x " << actGrad[0].GetNcols() << " ) , ...... skip printing (too many elements ) " << std::endl;
       }
@@ -421,7 +421,7 @@ auto testConvBackwardPass(size_t batchSize, size_t imgDepth, size_t imgHeight, s
       std::cout << "layer output size " << outL.size() << std::endl;
       if (outL.size() > 0) {
          if (outL[0].GetNElements() < 100 ) { 
-            PrintMatrix(outL[0],"LayerOutput-Matrix0");
+            TMVA_DNN_PrintTCpuMatrix(outL[0],"LayerOutput-Matrix0");
          } else
             std::cout << "Layer Output ( " << outL[0].GetNrows() << " x " << outL[0].GetNcols() << " ) , ...... skip printing (too many elements ) " << std::endl;
       }


### PR DESCRIPTION
[ROOT-9799](https://sft.its.cern.ch/jira/browse/ROOT-9799)
[ROOT-9444](https://sft.its.cern.ch/jira/browse/ROOT-9444)

The `PrintMatrix` was declared in the global namespace which means that if you define your own PrintMatrix macro you can have a name clash.

This PR "qualifies" the name using the prefix TMVA_DNN_

Supersedes PR#2980.