### PR TITLE
Support new Hexagon type in TEveBoxSet + 2 bufixes

### DIFF
--- a/graf3d/eve/inc/TEveBoxSet.h
+++ b/graf3d/eve/inc/TEveBoxSet.h
@@ -32,7 +32,8 @@ public:
       kBT_AABox,           // axis-aligned box: specify (x,y,z) and (w, h, d)
       kBT_AABoxFixedDim,   // axis-aligned box w/ fixed dimensions: specify (x,y,z)
       kBT_Cone,
-      kBT_EllipticCone
+      kBT_EllipticCone,
+      kBT_Hex
    };
 
    struct BFreeBox_t       : public DigitBase_t { Float_t fVertices[8][3]; };
@@ -46,6 +47,8 @@ public:
    struct BCone_t          : public DigitBase_t { TEveVector fPos, fDir; Float_t fR; };
 
    struct BEllipticCone_t  : public BCone_t     { Float_t fR2, fAngle; };
+
+   struct BHex_t           : public DigitBase_t { TEveVector fPos; Float_t fR, fAngle, fDepth; };
 
 protected:
    EBoxType_e        fBoxType;      // Type of rendered box.
@@ -73,6 +76,8 @@ public:
 
    void AddCone(const TEveVector& pos, const TEveVector& dir, Float_t r);
    void AddEllipticCone(const TEveVector& pos, const TEveVector& dir, Float_t r, Float_t r2, Float_t angle=0);
+
+   void AddHex(const TEveVector& pos, Float_t r, Float_t angle, Float_t depth);
 
    virtual void ComputeBBox();
    // virtual void Paint(Option_t* option = "");

--- a/graf3d/eve/inc/TEveGeoShape.h
+++ b/graf3d/eve/inc/TEveGeoShape.h
@@ -85,7 +85,7 @@ protected:
 
 public:
    TEveGeoShapeProjected();
-   virtual ~TEveGeoShapeProjected() {}
+   virtual ~TEveGeoShapeProjected();
 
    virtual void SetProjection(TEveProjectionManager* proj, TEveProjectable* model);
    virtual void UpdateProjection();

--- a/graf3d/eve/src/TEveBoxSet.cxx
+++ b/graf3d/eve/src/TEveBoxSet.cxx
@@ -75,6 +75,7 @@ Int_t TEveBoxSet::SizeofAtom(TEveBoxSet::EBoxType_e bt)
       case kBT_AABoxFixedDim:        return sizeof(BAABoxFixedDim_t);
       case kBT_Cone:                 return sizeof(BCone_t);
       case kBT_EllipticCone:         return sizeof(BEllipticCone_t);
+      case kBT_Hex:                  return sizeof(BHex_t);
       default:                       throw(eH + "unexpected atom type.");
    }
    return 0;
@@ -191,6 +192,25 @@ void TEveBoxSet::AddEllipticCone(const TEveVector& pos, const TEveVector& dir,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Create a hexagonal prism with center of one hexagon at pos, radius of
+/// hexagon vertices r, rotation angle angle (in degrees), and length along z
+/// of depth. To be used for box-type kBT_Hex.
+
+void TEveBoxSet::AddHex(const TEveVector& pos, Float_t r, Float_t angle, Float_t depth)
+{
+   static const TEveException eH("TEveBoxSet::AddEllipticCone ");
+
+   if (fBoxType != kBT_Hex)
+      throw(eH + "expect hex box-type.");
+
+   BHex_t* hex = (BHex_t*) NewDigit();
+   hex->fPos   = pos;
+   hex->fR     = r;
+   hex->fAngle = angle;
+   hex->fDepth = depth;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Fill bounding-box information of the base-class TAttBBox (virtual method).
 /// If member 'TEveFrameBox* fFrame' is set, frame's corners are used as bbox.
 
@@ -249,6 +269,7 @@ void TEveBoxSet::ComputeBBox()
          }
          break;
       }
+
       case kBT_Cone:
       {
          Float_t mag2=0, mag2Max=0, rMax=0;
@@ -264,6 +285,7 @@ void TEveBoxSet::ComputeBBox()
          fBBox[1] += off;fBBox[3] += off;fBBox[5] += off;
          break;
       }
+
       case kBT_EllipticCone:
       {
          Float_t mag2=0, mag2Max=0, rMax=0;
@@ -280,6 +302,23 @@ void TEveBoxSet::ComputeBBox()
          fBBox[1] += off;fBBox[3] += off;fBBox[5] += off;
          break;
       }
+
+      case kBT_Hex:
+      {
+         while (bi.next()) {
+            BHex_t& h = * (BHex_t*) bi();
+            BBoxCheckPoint(h.fPos.fX - h.fR, h.fPos.fY - h.fR, h.fPos.fZ);
+            BBoxCheckPoint(h.fPos.fX + h.fR, h.fPos.fY - h.fR, h.fPos.fZ);
+            BBoxCheckPoint(h.fPos.fX + h.fR, h.fPos.fY + h.fR, h.fPos.fZ);
+            BBoxCheckPoint(h.fPos.fX - h.fR, h.fPos.fY + h.fR, h.fPos.fZ);
+            BBoxCheckPoint(h.fPos.fX - h.fR, h.fPos.fY - h.fR, h.fPos.fZ + h.fDepth);
+            BBoxCheckPoint(h.fPos.fX + h.fR, h.fPos.fY - h.fR, h.fPos.fZ + h.fDepth);
+            BBoxCheckPoint(h.fPos.fX + h.fR, h.fPos.fY + h.fR, h.fPos.fZ + h.fDepth);
+            BBoxCheckPoint(h.fPos.fX - h.fR, h.fPos.fY + h.fR, h.fPos.fZ + h.fDepth);
+         }
+         break;
+      }
+
       default:
       {
          throw(eH + "unsupported box-type.");

--- a/graf3d/eve/src/TEveGeoShape.cxx
+++ b/graf3d/eve/src/TEveGeoShape.cxx
@@ -468,6 +468,14 @@ TEveGeoShapeProjected::TEveGeoShapeProjected() :
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Destructor.
+
+TEveGeoShapeProjected::~TEveGeoShapeProjected()
+{
+   delete fBuff;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// This should never be called as this class is only used for 3D
 /// projections.
 /// The implementation is required as this metod is abstract.

--- a/graf3d/eve/src/TEveQuadSet.cxx
+++ b/graf3d/eve/src/TEveQuadSet.cxx
@@ -241,7 +241,7 @@ void TEveQuadSet::AddHexagon(Float_t a, Float_t b, Float_t c, Float_t r)
          break;
       }
       default:
-         throw(eH + "expect line quad-type.");
+         throw eH + "expects hexagon quad-type.";
    }
 }
 

--- a/tutorials/eve/boxset.C
+++ b/tutorials/eve/boxset.C
@@ -155,3 +155,36 @@ TEveBoxSet* boxset_freebox(Int_t num=100, Bool_t registerSet=kTRUE)
 
    return q;
 }
+
+TEveBoxSet* boxset_hex(Float_t x=0, Float_t y=0, Float_t z=0,
+                       Int_t num=100, Bool_t registerSet=kTRUE)
+{
+   TEveManager::Create();
+
+   TRandom r(0);
+
+   auto q = new TEveBoxSet("BoxSet");
+   q->Reset(TEveBoxSet::kBT_Hex, kTRUE, 64);
+
+   for (Int_t i=0; i<num; ++i) {
+      q->AddHex(TEveVector(r.Uniform(-10, 10), r.Uniform(-10, 10), r.Uniform(-10, 10)),
+                r.Uniform(0.2, 1), r.Uniform(0, 60), r.Uniform(0.2, 5));
+      q->DigitColor(r.Uniform(20, 255), r.Uniform(20, 255),
+                    r.Uniform(20, 255), r.Uniform(20, 255));
+   }
+   q->RefitPlex();
+
+   q->SetPickable(true);
+   q->SetAlwaysSecSelect(true);
+
+   TEveTrans& t = q->RefMainTrans();
+   t.SetPos(x, y, z);
+
+   if (registerSet)
+   {
+      gEve->AddElement(q);
+      gEve->Redraw3D(kTRUE);
+   }
+
+   return q;
+}


### PR DESCRIPTION
1. Add support for hexagont box-type (BHex_t) in TEveBoxSet. See
tutorials/eve/boxset.C, new function boxset_hex().

2. Bugfix in TEveBoxSet -- box set did not work with TEnv setting of
`OpenGL.UseDisplayLists 0`.

3. Memory leak fix in TEveGeoShapeProjected -- TBuffer3D member fBuff was
not freed in destructor.