### PR TITLE
Revert "[TTreeProcMT] Fix COV-98763: large variable passed by value"

### DIFF
--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -142,7 +142,7 @@ namespace ROOT {
          /// Get a TTreeReader for the current tree of this view.
          TreeReaderEntryListPair GetTreeReader(Long64_t start, Long64_t end, const std::string &treeName,
                                                const std::vector<std::string> &fileNames, const FriendInfo &friendInfo,
-                                               TEntryList &entryList, const std::vector<Long64_t> &nEntries,
+                                               TEntryList entryList, const std::vector<Long64_t> &nEntries,
                                                const std::vector<std::vector<Long64_t>> &friendEntries)
          {
             const bool usingLocalEntries = friendInfo.fFriendNames.empty() && entryList.GetN() == 0;
@@ -168,7 +168,7 @@ namespace ROOT {
       const std::vector<std::string> fFileNames; ///< Names of the files
       const std::string fTreeName;               ///< Name of the tree
       /// User-defined selection of entry numbers to be processed, empty if none was provided
-      TEntryList fEntryList;
+      const TEntryList fEntryList; // const to be sure to avoid race conditions among TTreeViews
       const Internal::FriendInfo fFriendInfo;
 
       ROOT::TThreadedObject<ROOT::Internal::TTreeView> treeView; ///<! Thread-local TreeViews


### PR DESCRIPTION
We get races if all threads access the same TEntryList reference.
This reverts commit f0556c0b49c4229b8c690dbc39ff5deda44be1e5,
and adds a comment so we remember in the future.