### PR TITLE
Fixes for Python 3.7

### DIFF
--- a/bindings/pyroot/src/TPyROOTApplication.cxx
+++ b/bindings/pyroot/src/TPyROOTApplication.cxx
@@ -101,7 +101,7 @@ Bool_t PyROOT::TPyROOTApplication::CreatePyROOTApplication( Bool_t bLoadLibs )
       if ( argl && 0 < PyList_Size( argl ) ) argc = (int)PyList_GET_SIZE( argl );
       char** argv = new char*[ argc ];
       for ( int i = 1; i < argc; ++i ) {
-         char* argi = PyROOT_PyUnicode_AsString( PyList_GET_ITEM( argl, i ) );
+         char* argi = const_cast< char* >( PyROOT_PyUnicode_AsString( PyList_GET_ITEM( argl, i ) ) );
          if ( strcmp( argi, "-" ) == 0 || strcmp( argi, "--" ) == 0 ) {
          // stop collecting options, the remaining are for the python script
             argc = i;    // includes program name


### PR DESCRIPTION
 * PyROOT_PyUnicode_AsString changed return type from char* to const char*

Follow up to #2982 

The other fixes from the commit were not applicable to 5-34-00