### PR TITLE
 [DF] Use LoadTree(0), not GetEntry(0), to reset TChain state 

### DIFF
--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -116,6 +116,11 @@ void RLoopManager::RunTreeProcessorMT()
 /// Run event loop over one or multiple ROOT files, in sequence.
 void RLoopManager::RunTreeReader()
 {
+   if (fTree->IsA() == TClass::GetClass("TChain")) {
+      // in case this is not the first event loop, we bring the chain back to the first tree
+      // to avoid warnings from TTreeReader
+      fTree->LoadTree(0);
+   }
    TTreeReader r(fTree.get());
    if (0 == fTree->GetEntriesFast())
       return;
@@ -126,7 +131,6 @@ void RLoopManager::RunTreeReader()
    while (r.Next() && fNStopsReceived < fNChildren) {
       RunAndCheckFilters(0, r.GetCurrentEntry());
    }
-   fTree->GetEntry(0);
 }
 
 /// Run event loop over data accessed through a DataSource, in sequence.


### PR DESCRIPTION
The latter performs extra reading that we do not need.
With many thanks to @JavierCVilla !