### PR TITLE
Support systems with no `manpath` nor `man` in thisroot.sh

### DIFF
--- a/config/thisroot.sh
+++ b/config/thisroot.sh
@@ -91,10 +91,12 @@ fi
 
 if [ -z "${MANPATH}" ]; then
    # Grab the default man path before setting the path to avoid duplicates
-   if `which manpath > /dev/null 2>&1` ; then
+   if command -v manpath >/dev/null; then
       default_manpath=`manpath`
-   else
+   elif command -v man >/dev/null; then
       default_manpath=`man -w 2> /dev/null`
+   else
+      default_manpath=""
    fi
 fi
 


### PR DESCRIPTION
Admittedly a corner case, but running `source thisroot.sh` returned exit code 127 in a pretty bare docker image where no `manpath` nor `man` executables were present.

Works on my computer™