### PR TITLE
Fix Copy constructor in TFormula (ROOT-9801)

### DIFF
--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -669,6 +669,8 @@ void TFormula::Copy(TObject &obj) const
    fnew.fClingInitialized = fClingInitialized;
    fnew.fAllParametersSetted = fAllParametersSetted;
    fnew.fClingName = fClingName;
+   fnew.fSavedInputFormula = fSavedInputFormula;
+   fnew.fLazyInitialization = fLazyInitialization;
 
    // case of function based on a C++  expression (lambda's) which is ready to be compiled
    if (fLambdaPtr && TestBit(TFormula::kLambda)) {
@@ -3421,8 +3423,8 @@ void TFormula::ReInitializeEvalMethod() {
       R__LOCKGUARD(gROOTMutex);
 
       // std::cout << "gClingFunctions list" << std::endl;
-      // for (auto thing : gClingFunctions)
-      //    std::cout << "gClingFunctions : " << thing.first << std::endl;
+      //  for (auto thing : gClingFunctions)
+      //     std::cout << "gClingFunctions : " << thing.first << std::endl;
 
       auto funcit = gClingFunctions.find(fSavedInputFormula);
 

--- a/test/TFormulaParsingTests.h
+++ b/test/TFormulaParsingTests.h
@@ -7,6 +7,8 @@
 #include "Math/ChebyshevPol.h"
 #include "TError.h"
 #include "TFile.h"
+#include "TMacro.h"
+#include "TSystem.h"
 
 #include <limits>
 #include <cstdlib>
@@ -936,6 +938,49 @@ bool test48() {
 }
 
 bool test49() {
+   // test copy consttructor in case of lazy initialization (i.e. when reading from a file)
+   TFile* f = TFile::Open("TFormulaTest49.root","RECREATE");   
+   if (!f) {
+      Error("test49","Error creating file for test49");
+      return false;
+   }
+   TF1 f1("f1","x*[0]");
+   f1.SetParameter(0,2); 
+   f1.Write();
+   f->Close();
+   // read the file 
+   f = TFile::Open("TFormulaTest49.root");   
+   if (!f) {
+      Error("test49","Error reading file for test49");
+      return false;
+   }
+   auto fr = (TF1*) f->Get("f1");
+   if (!fr) { 
+      Error("test49","Error reading function from file for test49");
+      return false;
+   }
+   // create a copy
+   TF1 fr2 = *fr;
+   bool ok = (fr->Eval(2.) == 4.);
+   ok |= ( fr2.Eval(2.) == fr->Eval(2.) ); 
+
+   // now read using an indpendent process (ROOT session)
+   // this should cause ROOT-9801
+
+   TMacro m;
+   m.AddLine("bool TFormulaTest49() { TFile * f = TFile::Open(\"TFormulaTest49.root\");"
+             "TF1 *f1 = (TF1*) f->Get(\"f1\"); TF1 f2 = *f1;"
+             "bool ok = (f1->Eval(2) == f2.Eval(2.)) && (f2.Eval(2.) == 4.);"
+             "if (!ok) Error(\"test49\",\"Error in test49 (lazy initialization)\");" 
+             "return ok; }");
+
+   m.SaveSource("TFormulaTest49.C");
+   int ret = gSystem->Exec("root -q -l -i TFormulaTest49.C");
+   ok |= (ret == 0);
+   return ok;
+}
+
+bool test50() {
    // test detailed printing of function
    TFormula f1("f1","[A]*sin([B]*x)");
    f1.Print("V");
@@ -957,6 +1002,8 @@ bool test49() {
 
    return ok;
 }
+
+///////////////////////////////////////////////////////////////////////////////////////
 
 void PrintError(int itest)  {
    Error("TFormula test","test%d FAILED ",itest);
@@ -1024,6 +1071,7 @@ int runTests(bool debug = false) {
    IncrTest(itest); if (!test47() ) { PrintError(itest); }
    IncrTest(itest); if (!test48() ) { PrintError(itest); }
    IncrTest(itest); if (!test49() ) { PrintError(itest); }
+   IncrTest(itest); if (!test50() ) { PrintError(itest); }
 
    std::cout << ".\n";
 


### PR DESCRIPTION
Fix ROOT-9801, by correctly copying the members for lazy initialization in TFormula::Copy. Add also a test for reproducing ROOT-9801