### PR TITLE
[cxxmodules] Do not generate rdict files if we have a module.

### DIFF
--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -371,6 +371,7 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
 
   if(cpp_module_file)
     set(newargs -cxxmodule ${newargs})
+    set(pcm_name)
   endif()
 
   #---what rootcling command to use--------------------------

--- a/core/clingutils/res/TClingUtils.h
+++ b/core/clingutils/res/TClingUtils.h
@@ -400,7 +400,7 @@ bool hasOpaqueTypedef(const AnnotatedRecordDecl &cl, const cling::Interpreter &i
 bool HasResetAfterMerge(clang::CXXRecordDecl const*, const cling::Interpreter&);
 
 //______________________________________________________________________________
-bool NeedDestructor(clang::CXXRecordDecl const*);
+bool NeedDestructor(clang::CXXRecordDecl const*, const cling::Interpreter&);
 
 //______________________________________________________________________________
 bool NeedTemplateKeyword(clang::CXXRecordDecl const*);

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1973,7 +1973,7 @@ void TCling::RegisterModule(const char* modulename,
 
    if (gIgnoredPCMNames.find(modulename) == gIgnoredPCMNames.end()) {
       TString pcmFileName(ROOT::TMetaUtils::GetModuleFileName(modulename).c_str());
-      if (!LoadPCM(pcmFileName, headers, triggerFunc)) {
+      if (!hasCxxModule && !LoadPCM(pcmFileName, headers, triggerFunc)) {
          ::Error("TCling::RegisterModule", "cannot find dictionary module %s",
                  ROOT::TMetaUtils::GetModuleFileName(modulename).c_str());
       }


### PR DESCRIPTION
## Overview

RDICT files store some useful information (in particular about class offsets) in ROOT files to avoid the potentially expensive call to the interpreter if the information is not the PCH. For example, ROOT's `libGeom` and other third-party code. This is done to circumvent the costly call to `ShowMembers` which will require parsing.

CxxModules diminish that benefit as providing a finer grained control over the information deserialization. We see no observable benefits in generating RDICT files next to our pcm files. 

## Performance results

We have run several times all tests in `roottest/io` and `roottest/meta/MakeProject` folders and compared the results with and without generating RDICT (namely with ROOT master with `-Druntime_cxxmodules=On` with and without this PR). They are available [here](https://docs.google.com/spreadsheets/d/1Y_swct0USyX1DMp0tJOPdZzvmvIOTXOS9s7n08wCb2I/edit?usp=sharing) and [here](https://docs.google.com/spreadsheets/d/1s5LbPmhGBfhimirA0GH87nyEKcrGUfCX80H7-fOrjAU/edit?usp=sharing).

### Methodology

  We have a forwarding `root.exe` which essentially calls `/usr/bin/time -v root.exe $@`. We have processed and stored this information in csv files. We have run in:
  * (no)dict1-cold -- Tests are run immediately after restarting the physical test machine.
  * (no)dict1a-cold -- Tests are run immediately after restarting the physical test machine. Second time.
  * (no)dict2 -- Tests are run once again after running (no)dict1-cold;
  * (no)dict3 -- Tests are run once again after running (no)dict2;
  * (no)dict4 -- Tests are run once again after running (no)dict3;
  * (no)dict5 -- Tests are run once again after running (no)dict4.

The values of each column in (no)dict* are the sum of each value produced after running each test under roottest/io.  The average values are computed in the columns under `dict` and `nodict`. The difference is shown in `diff`.

There are two known test failures wrt to modules whose values are ignored.

The machine specification is `Intel(R) Core(TM) i3-7100 CPU @ 3.90GHz` dual core, 8GB RAM and a **HDD**, run on Ubuntu 18.04.

### Results Interpretation

RDICT mostly intend to reduce the memory footprint during IO. We see no direct benefits in the memory footprint. The average of the max RSS of the sum of the max RSS of every test is higher. There is also a tendency towards faster execution.


