### PR TITLE
Fix TTreeCache issue related to learning from ROOT-9773.

### DIFF
--- a/io/io/inc/TFileCacheRead.h
+++ b/io/io/inc/TFileCacheRead.h
@@ -100,6 +100,7 @@ public:
    virtual void        SetEnablePrefetching(Bool_t setPrefetching = kFALSE);
    virtual Bool_t      IsEnablePrefetching() const { return fEnablePrefetching; };
    virtual Bool_t      IsLearning() const {return kFALSE;}
+   virtual Int_t       LearnBranch(TBranch * /*b*/, Bool_t /*subbranches*/ = kFALSE) { return 0; }
    virtual void        Prefetch(Long64_t pos, Int_t len);
    virtual void        Print(Option_t *option="") const;
    virtual Int_t       ReadBufferExt(char *buf, Long64_t pos, Int_t len, Int_t &loc);

--- a/tree/tree/inc/TTreeCache.h
+++ b/tree/tree/inc/TTreeCache.h
@@ -155,6 +155,7 @@ public:
    virtual Bool_t       IsLearning() const {return fIsLearning;}
 
    virtual Bool_t       FillBuffer();
+   virtual Int_t        LearnBranch(TBranch *b, Bool_t subgbranches = kFALSE);
    virtual void         LearnPrefill();
 
    virtual void         Print(Option_t *option="") const;

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -1210,7 +1210,7 @@ TBasket* TBranch::GetBasket(Int_t basketnumber)
       R__LOCKGUARD_IMT(gROOTMutex); // Lock for parallel TTree I/O
       TFileCacheRead *pf = fTree->GetReadCache(file);
       if (pf){
-         if (pf->IsLearning()) pf->AddBranch(this);
+         if (pf->IsLearning()) pf->LearnBranch(this, kFALSE);
          if (fSkipZip) pf->SetSkipZip();
       }
    }


### PR DESCRIPTION
Specifically this fixes the one described at:
   https://sft.its.cern.ch/jira/browse/ROOT-9773?focusedCommentId=87824&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-87824
where the issue was that adding a single branch did not close the learning and 'worth' provoke a learning
prefill.

We solved this by distinguishing at the interface level adding branch manual and adding branch as
part of the learning.  We can now avoid the LearningPrefill during manual adds.