### PR TITLE
Use VecCore through imported target

### DIFF
--- a/math/mathcore/CMakeLists.txt
+++ b/math/mathcore/CMakeLists.txt
@@ -112,11 +112,6 @@ if(imt)
   set(MATHCORE_DEPENDENCIES Imt)
 endif()
 
-if(veccore)
-  set(MATHCORE_BUILTINS VECCORE)
-  set(MATHCORE_LIBRARIES ${VecCore_LIBRARIES})
-endif()
-
 ROOT_STANDARD_LIBRARY_PACKAGE(MathCore
   HEADERS
     ${HEADERS}
@@ -187,7 +182,10 @@ ROOT_STANDARD_LIBRARY_PACKAGE(MathCore
     ${MATHCORE_BUILTINS}
 )
 
-target_compile_definitions(MathCore INTERFACE ${VecCore_DEFINITIONS})
 target_link_libraries(MathCore PUBLIC ${CMAKE_THREAD_LIBS_INIT})
+
+if (veccore)
+  target_link_libraries(MathCore PUBLIC VecCore::VecCore)
+endif()
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -329,9 +329,9 @@ endif()
 
 #--VecCore basic test------------------------------------------------------------------------------
 if(ROOT_veccore_FOUND)
-  ROOT_EXECUTABLE(test-veccore test-veccore.cxx LIBRARIES ${VecCore_LIBRARIES} BUILTINS VECCORE)
-  target_include_directories(test-veccore BEFORE PRIVATE ${VecCore_INCLUDE_DIRS})
-  target_compile_definitions(test-veccore PRIVATE ${VecCore_DEFINITIONS})
+  ROOT_EXECUTABLE(test-veccore test-veccore.cxx)
+  target_link_libraries(test-veccore PRIVATE VecCore::VecCore)
+
   if(VecCore_Vc_FOUND)
     ROOT_ADD_TEST(VecCore COMMAND test-veccore REGEX "Vc")
   else()


### PR DESCRIPTION
I would like to be able to merge this, but `-Dbuiltin_veccore=ON` is broken with imported targets...