### PR TITLE
RooLinkedList::At optimization

### DIFF
--- a/roofit/roofitcore/inc/RooLinkedList.h
+++ b/roofit/roofitcore/inc/RooLinkedList.h
@@ -18,6 +18,7 @@
 
 #include <map>
 #include <list>
+#include <vector>
 
 #include "TNamed.h"
 #include "RooLinkedListElem.h"
@@ -126,6 +127,8 @@ private:
   typedef RooLinkedListImplDetails::Pool Pool;
   /// shared memory pool for allocation of RooLinkedListElems
   static Pool* _pool; //!
+
+  std::vector<RooLinkedListElem *> _at; //! index list for quick index through ::At
 
   ClassDef(RooLinkedList,3) // Doubly linked list for storage of RooAbsArg objects
 };

--- a/roofit/roofitcore/src/RooLinkedList.cxx
+++ b/roofit/roofitcore/src/RooLinkedList.cxx
@@ -443,7 +443,8 @@ void RooLinkedList::Add(TObject* arg, Int_t refCount)
 
   _size++ ;
   _last->_refCount = refCount ;
-  
+
+  _at.push_back(_last);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -466,7 +467,11 @@ Bool_t RooLinkedList::Remove(TObject* arg)
   // Update first,last if necessary
   if (elem==_first) _first=elem->_next ;
   if (elem==_last) _last=elem->_prev ;
-  
+
+  // Remove from index array
+  auto at_elem_it = std::find(_at.begin(), _at.end(), elem);
+  _at.erase(at_elem_it);
+
   // Delete and shrink
   _size-- ;
   deleteElement(elem) ;	
@@ -491,13 +496,15 @@ TObject* RooLinkedList::At(Int_t index) const
   // Check range
   if (index<0 || index>=_size) return 0 ;
 
-  
-  // Walk list
-  RooLinkedListElem* ptr = _first;
-  while(index--) ptr = ptr->_next ;
-  
-  // Return arg
-  return ptr->_arg ;
+  return _at[index]->_arg;
+//
+//
+//  // Walk list
+//  RooLinkedListElem* ptr = _first;
+//  while(index--) ptr = ptr->_next ;
+//
+//  // Return arg
+//  return ptr->_arg ;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -565,6 +572,9 @@ void RooLinkedList::Clear(Option_t *)
     delete _htableLink ;
     _htableLink = new RooHashTable(hsize,RooHashTable::Pointer) ;       
   }
+
+  // empty index array
+  _at.clear();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -595,6 +605,9 @@ void RooLinkedList::Delete(Option_t *)
     delete _htableLink ;
     _htableLink = new RooHashTable(hsize,RooHashTable::Pointer) ;       
   }
+
+  // empty index array
+  _at.clear();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -752,6 +765,14 @@ void RooLinkedList::Sort(Bool_t ascend)
 {
   if (ascend) _first = mergesort_impl<true>(_first, _size, &_last);
   else _first = mergesort_impl<false>(_first, _size, &_last);
+
+  // rebuild index array
+  RooLinkedListElem* elem = _first;
+  Int_t index = 0;
+  do {
+    _at[index++] = elem;
+    elem = elem->_next;
+  } while (elem != _last);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooLinkedList.cxx
+++ b/roofit/roofitcore/src/RooLinkedList.cxx
@@ -768,11 +768,9 @@ void RooLinkedList::Sort(Bool_t ascend)
 
   // rebuild index array
   RooLinkedListElem* elem = _first;
-  Int_t index = 0;
-  do {
-    _at[index++] = elem;
-    elem = elem->_next;
-  } while (elem != _last);
+  for (auto it = _at.begin(); it != _at.end(); ++it, elem = elem->_next) {
+    *it = elem;
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
`RooLinkedList::At(ix)` was implemented using an `ix`-step walk through the list. We found that in HistFactory models, `At` was used to loop over the list, which thus caused a lot of double walking through the list.

This PR (a cherry-pick from the [roofit-dev fork](https://github.com/roofit-dev/root/tree/linked_list_at)) improves this situation by replacing `At`'s walk by a direct lookup from a `std::vector` of `RooLinkedListElem` pointers.

In our HistFactory-based benchmark, this gave a significant speed boost of 1.6x on a likelihood minimization task.

Since this was not the focus of the roofit-dev project, unfortunately, I had no time yet to wrap up this feature into a nice PR, do rigorous testing and benchmarking, etcetera. I would appreciate reviews and suggestions or additional commits for improvements. For instance, I put `//!` behind the index vector (the name of this `//!` feature currently eludes me), so I wouldn't have to update the class version, but I guess this will break the class when it is (de)serialized. I'll gladly take any advice on how to best handle this.