### PR TITLE
[DF] Generate list of valid branch names once

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -244,7 +244,7 @@ void BookFilterJit(RJittedFilter *jittedFilter, void *prevNodeOnHeap, std::strin
 
 void BookDefineJit(std::string_view name, std::string_view expression, RLoopManager &lm, RDataSource *ds,
                    const std::shared_ptr<RJittedCustomColumn> &jittedCustomColumn,
-                   const RDFInternal::RBookedCustomColumns &customCols);
+                   const RDFInternal::RBookedCustomColumns &customCols, const ColumnNames_t &branches);
 
 std::string JitBuildAction(const ColumnNames_t &bl, void *prevNode, const std::type_info &art, const std::type_info &at,
                            void *r, TTree *tree, const unsigned int nSlots,
@@ -270,8 +270,7 @@ bool AtLeastOneEmptyString(const std::vector<std::string_view> strings);
 std::shared_ptr<RNodeBase> UpcastNode(std::shared_ptr<RNodeBase> ptr);
 
 ColumnNames_t GetValidatedColumnNames(RLoopManager &lm, const unsigned int nColumns, const ColumnNames_t &columns,
-                                      const ColumnNames_t &datasetColumns, const ColumnNames_t &validCustomColumns,
-                                      RDataSource *ds);
+                                      const ColumnNames_t &validCustomColumns, RDataSource *ds);
 
 std::vector<bool> FindUndefinedDSColumns(const ColumnNames_t &requestedCols, const ColumnNames_t &definedDSCols);
 
@@ -438,8 +437,6 @@ template <>
 struct TNeedJitting<RInferredType> {
    static constexpr bool value = true;
 };
-
-ColumnNames_t GetBranchNames(TTree &t, bool allowDuplicates = true);
 
 ColumnNames_t GetTopLevelBranchNames(TTree &t);
 

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -105,7 +105,6 @@ class RInterface {
    RLoopManager *fLoopManager;
    /// Non-owning pointer to a data-source object. Null if no data-source. RLoopManager has ownership of the object.
    RDataSource *fDataSource = nullptr;
-   std::shared_ptr<const ColumnNames_t> fBranchNames; ///< Cache of the chain columns names
 
    /// Contains the custom columns defined up to this node.
    RDFInternal::RBookedCustomColumns fCustomColumns;
@@ -153,7 +152,7 @@ public:
    operator RNode() const
    {
       return RNode(std::static_pointer_cast<::ROOT::Detail::RDF::RNodeBase>(fProxiedPtr), *fLoopManager, fCustomColumns,
-                   fBranchNames, fDataSource);
+                   fDataSource);
    }
 
    ////////////////////////////////////////////////////////////////////////////
@@ -200,7 +199,7 @@ public:
 
       auto filterPtr = std::make_shared<F_t>(std::move(f), validColumnNames, fProxiedPtr, newColumns, name);
       fLoopManager->Book(filterPtr.get());
-      return RInterface<F_t, DS_t>(std::move(filterPtr), *fLoopManager, newColumns, fBranchNames, fDataSource);
+      return RInterface<F_t, DS_t>(std::move(filterPtr), *fLoopManager, newColumns, fDataSource);
    }
 
    ////////////////////////////////////////////////////////////////////////////
@@ -246,23 +245,19 @@ public:
    /// Refer to the first overload of this method for the full documentation.
    RInterface<RDFDetail::RJittedFilter, DS_t> Filter(std::string_view expression, std::string_view name = "")
    {
-      const auto &aliasMap = fLoopManager->GetAliasMap();
-      auto *const tree = fLoopManager->GetTree();
-      const auto branches = tree ? RDFInternal::GetBranchNames(*tree) : ColumnNames_t();
-
       // deleted by the jitted call to JitFilterHelper
       auto upcastNodeOnHeap = RDFInternal::MakeSharedOnHeap(RDFInternal::UpcastNode(fProxiedPtr));
       using BaseNodeType_t = typename std::remove_pointer<decltype(upcastNodeOnHeap)>::type::element_type;
-      RInterface<BaseNodeType_t> upcastInterface(*upcastNodeOnHeap, *fLoopManager, fCustomColumns, fBranchNames,
-                                                 fDataSource);
+      RInterface<BaseNodeType_t> upcastInterface(*upcastNodeOnHeap, *fLoopManager, fCustomColumns, fDataSource);
       const auto jittedFilter = std::make_shared<RDFDetail::RJittedFilter>(fLoopManager, name);
 
-      RDFInternal::BookFilterJit(jittedFilter.get(), upcastNodeOnHeap, name, expression, aliasMap, branches,
-                                 fCustomColumns, tree, fDataSource, fLoopManager->GetID());
+      RDFInternal::BookFilterJit(jittedFilter.get(), upcastNodeOnHeap, name, expression, fLoopManager->GetAliasMap(),
+                                 fLoopManager->GetBranchNames(), fCustomColumns, fLoopManager->GetTree(), fDataSource,
+                                 fLoopManager->GetID());
 
       fLoopManager->Book(jittedFilter.get());
       return RInterface<RDFDetail::RJittedFilter, DS_t>(std::move(jittedFilter), *fLoopManager, fCustomColumns,
-                                                        fBranchNames, fDataSource);
+                                                        fDataSource);
    }
 
    // clang-format off
@@ -380,7 +375,8 @@ public:
       auto jittedCustomColumn =
          std::make_shared<RDFDetail::RJittedCustomColumn>(fLoopManager, name, fLoopManager->GetNSlots());
 
-      RDFInternal::BookDefineJit(name, expression, *fLoopManager, fDataSource, jittedCustomColumn, fCustomColumns);
+      RDFInternal::BookDefineJit(name, expression, *fLoopManager, fDataSource, jittedCustomColumn, fCustomColumns,
+                                 fLoopManager->GetBranchNames());
 
       RDFInternal::RBookedCustomColumns newCols(fCustomColumns);
       newCols.AddName(name);
@@ -388,7 +384,7 @@ public:
 
       fLoopManager->RegisterCustomColumn(jittedCustomColumn.get());
 
-      RInterface<Proxied, DS_t> newInterface(fProxiedPtr, *fLoopManager, std::move(newCols), fBranchNames, fDataSource);
+      RInterface<Proxied, DS_t> newInterface(fProxiedPtr, *fLoopManager, std::move(newCols), fDataSource);
 
       return newInterface;
    }
@@ -424,7 +420,7 @@ public:
       RDFInternal::RBookedCustomColumns newCols(fCustomColumns);
 
       newCols.AddName(alias);
-      RInterface<Proxied, DS_t> newInterface(fProxiedPtr, *fLoopManager, std::move(newCols), fBranchNames, fDataSource);
+      RInterface<Proxied, DS_t> newInterface(fProxiedPtr, *fLoopManager, std::move(newCols), fDataSource);
 
       return newInterface;
    }
@@ -495,8 +491,8 @@ public:
       const auto nsID = fLoopManager->GetID();
       std::stringstream snapCall;
       auto upcastNode = RDFInternal::UpcastNode(fProxiedPtr);
-      RInterface<TTraits::TakeFirstParameter_t<decltype(upcastNode)>> upcastInterface(
-         fProxiedPtr, *fLoopManager, fCustomColumns, fBranchNames, fDataSource);
+      RInterface<TTraits::TakeFirstParameter_t<decltype(upcastNode)>> upcastInterface(fProxiedPtr, *fLoopManager,
+                                                                                      fCustomColumns, fDataSource);
 
       // build a string equivalent to
       // "resPtr = (RInterface<nodetype*>*)(this)->Snapshot<Ts...>(args...)"
@@ -617,8 +613,8 @@ public:
       const auto nsID = fLoopManager->GetID();
       std::stringstream cacheCall;
       auto upcastNode = RDFInternal::UpcastNode(fProxiedPtr);
-      RInterface<TTraits::TakeFirstParameter_t<decltype(upcastNode)>> upcastInterface(
-         fProxiedPtr, *fLoopManager, fCustomColumns, fBranchNames, fDataSource);
+      RInterface<TTraits::TakeFirstParameter_t<decltype(upcastNode)>> upcastInterface(fProxiedPtr, *fLoopManager,
+                                                                                      fCustomColumns, fDataSource);
       // build a string equivalent to
       // "(RInterface<nodetype*>*)(this)->Cache<Ts...>(*(ColumnNames_t*)(&columnList))"
       RInterface<RLoopManager> resRDF(std::make_shared<ROOT::Detail::RDF::RLoopManager>(0));
@@ -695,8 +691,7 @@ public:
       using Range_t = RDFDetail::RRange<Proxied>;
       auto rangePtr = std::make_shared<Range_t>(begin, end, stride, fProxiedPtr);
       fLoopManager->Book(rangePtr.get());
-      RInterface<RDFDetail::RRange<Proxied>> tdf_r(std::move(rangePtr), *fLoopManager, fCustomColumns, fBranchNames,
-                                                   fDataSource);
+      RInterface<RDFDetail::RRange<Proxied>> tdf_r(std::move(rangePtr), *fLoopManager, fCustomColumns, fDataSource);
       return tdf_r;
    }
 
@@ -1616,7 +1611,7 @@ public:
       if(fCustomColumns.HasName(columnName)) return true;
 
       if (auto tree = fLoopManager->GetTree()) {
-         const auto branchNames = RDFInternal::GetBranchNames(*tree, /*allowDuplicates=*/true);
+         const auto &branchNames = fLoopManager->GetBranchNames();
          const auto branchNamesEnd = branchNames.end();
          if (branchNamesEnd != std::find(branchNames.begin(), branchNamesEnd, columnName)) return true;
       }
@@ -1983,8 +1978,7 @@ private:
 
       auto upcastNodeOnHeap = RDFInternal::MakeSharedOnHeap(RDFInternal::UpcastNode(fProxiedPtr));
       using BaseNodeType_t = typename std::remove_pointer<decltype(upcastNodeOnHeap)>::type::element_type;
-      RInterface<BaseNodeType_t> upcastInterface(*upcastNodeOnHeap, *fLoopManager, fCustomColumns, fBranchNames,
-                                                 fDataSource);
+      RInterface<BaseNodeType_t> upcastInterface(*upcastNodeOnHeap, *fLoopManager, fCustomColumns, fDataSource);
 
       auto jittedActionOnHeap =
          RDFInternal::MakeSharedOnHeap(std::make_shared<RDFInternal::RJittedAction>(*fLoopManager));
@@ -2045,7 +2039,7 @@ private:
       newCols.AddName(name);
       newCols.AddColumn(newColumn, name);
 
-      RInterface<Proxied> newInterface(fProxiedPtr, *fLoopManager, std::move(newCols), fBranchNames, fDataSource);
+      RInterface<Proxied> newInterface(fProxiedPtr, *fLoopManager, std::move(newCols), fDataSource);
 
       return newInterface;
    }
@@ -2161,8 +2155,8 @@ private:
 
 protected:
    RInterface(const std::shared_ptr<Proxied> &proxied, RLoopManager &lm, RDFInternal::RBookedCustomColumns columns,
-              const std::shared_ptr<const ColumnNames_t> &datasetColumns, RDataSource *ds)
-      : fProxiedPtr(proxied), fLoopManager(&lm), fDataSource(ds), fBranchNames(datasetColumns), fCustomColumns(columns)
+              RDataSource *ds)
+      : fProxiedPtr(proxied), fLoopManager(&lm), fDataSource(ds), fCustomColumns(columns)
    {
    }
 
@@ -2174,12 +2168,7 @@ protected:
    /// which is expensive in terms of runtime, is called at most once.
    ColumnNames_t GetValidatedColumnNames(const unsigned int nColumns, const ColumnNames_t &columns)
    {
-      auto tree = fLoopManager->GetTree();
-      if (tree && !fBranchNames) {
-         fBranchNames = std::make_shared<ColumnNames_t>(RDFInternal::GetBranchNames(*tree));
-      }
-      return RDFInternal::GetValidatedColumnNames(*fLoopManager, nColumns, columns,
-                                                  (tree ? *fBranchNames : ColumnNames_t{}), fCustomColumns.GetNames(),
+      return RDFInternal::GetValidatedColumnNames(*fLoopManager, nColumns, columns, fCustomColumns.GetNames(),
                                                   fDataSource);
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -31,6 +31,8 @@ class RDataSource;
 
 namespace Internal {
 namespace RDF {
+ColumnNames_t GetBranchNames(TTree &t, bool allowDuplicates = true);
+
 class RActionBase;
 class GraphNode;
 
@@ -117,8 +119,9 @@ class RLoopManager : public RNodeBase {
    /// Used, for example, to jit objects in a namespace reserved for this computation graph
    const unsigned int fID = GetNextID();
 
-   std::vector<RCustomColumnBase *>
-      fCustomColumns; ///< The loopmanager tracks all columns created, without owning them.
+   std::vector<RCustomColumnBase *> fCustomColumns; ///< Non-owning container of all custom columns created so far.
+   /// Cache of the tree/chain branch names. Never access directy, always use GetBranchNames().
+   ColumnNames_t fValidBranchNames;
 
    void RunEmptySourceMT();
    void RunEmptySource();
@@ -187,6 +190,8 @@ public:
 
    std::vector<RDFInternal::RActionBase *> GetBookedActions() { return fBookedActions; }
    std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode> GetGraph();
+
+   const ColumnNames_t &GetBranchNames();
 };
 
 } // ns RDF

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -19,7 +19,6 @@
 #include <TRegexp.h>
 #include <TString.h>
 #include <TTree.h>
-#include <TBranchElement.h>
 
 #include <iosfwd>
 #include <stdexcept>
@@ -50,150 +49,6 @@ namespace RDF {
 // the one in the vector
 class RActionBase;
 
-bool ContainsLeaf(const std::set<TLeaf *> &leaves, TLeaf *leaf)
-{
-   return (leaves.find(leaf) != leaves.end());
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// This overload does not perform any check on the duplicates.
-/// It is used for TBranch objects.
-void UpdateList(std::set<std::string> &bNamesReg, ColumnNames_t &bNames, std::string &branchName,
-                std::string &friendName)
-{
-
-   if (!friendName.empty()) {
-      // In case of a friend tree, users might prepend its name/alias to the branch names
-      auto friendBName = friendName + "." + branchName;
-      if (bNamesReg.insert(friendBName).second)
-         bNames.push_back(friendBName);
-   }
-
-   if (bNamesReg.insert(branchName).second)
-      bNames.push_back(branchName);
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// This overloads makes sure that the TLeaf has not been already inserted.
-void UpdateList(std::set<std::string> &bNamesReg, ColumnNames_t &bNames, std::string &branchName,
-                std::string &friendName, std::set<TLeaf *> &foundLeaves, TLeaf *leaf, bool allowDuplicates)
-{
-   const bool canAdd = allowDuplicates ? true : !ContainsLeaf(foundLeaves, leaf);
-   if (!canAdd) {
-      return;
-   }
-
-   UpdateList(bNamesReg, bNames, branchName, friendName);
-
-   foundLeaves.insert(leaf);
-}
-
-void ExploreBranch(TTree &t, std::set<std::string> &bNamesReg, ColumnNames_t &bNames, TBranch *b, std::string prefix,
-                   std::string &friendName)
-{
-   for (auto sb : *b->GetListOfBranches()) {
-      TBranch *subBranch = static_cast<TBranch *>(sb);
-      auto subBranchName = std::string(subBranch->GetName());
-      auto fullName = prefix + subBranchName;
-
-      std::string newPrefix;
-      if (!prefix.empty())
-         newPrefix = fullName + ".";
-
-      ExploreBranch(t, bNamesReg, bNames, subBranch, newPrefix, friendName);
-
-      if (t.GetBranch(fullName.c_str())) {
-         UpdateList(bNamesReg, bNames, fullName, friendName);
-
-      } else if (t.GetBranch(subBranchName.c_str())) {
-         UpdateList(bNamesReg, bNames, subBranchName, friendName);
-      }
-   }
-}
-
-void GetBranchNamesImpl(TTree &t, std::set<std::string> &bNamesReg, ColumnNames_t &bNames,
-                        std::set<TTree *> &analysedTrees, std::string &friendName, bool allowDuplicates)
-{
-   std::set<TLeaf *> foundLeaves;
-   if (!analysedTrees.insert(&t).second) {
-      return;
-   }
-
-   const auto branches = t.GetListOfBranches();
-   if (branches) {
-      std::string prefix = "";
-      for (auto b : *branches) {
-         TBranch *branch = static_cast<TBranch *>(b);
-         auto branchName = std::string(branch->GetName());
-         if (branch->IsA() == TBranch::Class()) {
-            // Leaf list
-            auto listOfLeaves = branch->GetListOfLeaves();
-            if (listOfLeaves->GetEntries() == 1) {
-               auto leaf = static_cast<TLeaf *>(listOfLeaves->At(0));
-               auto leafName = std::string(leaf->GetName());
-               if (leafName == branchName) {
-                  UpdateList(bNamesReg, bNames, branchName, friendName, foundLeaves, leaf, allowDuplicates);
-               }
-            }
-
-            for (auto leaf : *listOfLeaves) {
-               auto castLeaf = static_cast<TLeaf *>(leaf);
-               auto leafName = std::string(leaf->GetName());
-               auto fullName = branchName + "." + leafName;
-               UpdateList(bNamesReg, bNames, fullName, friendName, foundLeaves, castLeaf, allowDuplicates);
-            }
-         } else {
-            // TBranchElement
-            // Check if there is explicit or implicit dot in the name
-
-            bool dotIsImplied = false;
-            auto be = dynamic_cast<TBranchElement *>(b);
-            if (!be)
-               throw std::runtime_error("GetBranchNames: unsupported branch type");
-            // TClonesArray (3) and STL collection (4)
-            if (be->GetType() == 3 || be->GetType() == 4)
-               dotIsImplied = true;
-
-            if (dotIsImplied || branchName.back() == '.')
-               ExploreBranch(t, bNamesReg, bNames, branch, "", friendName);
-            else
-               ExploreBranch(t, bNamesReg, bNames, branch, branchName + ".", friendName);
-
-            UpdateList(bNamesReg, bNames, branchName, friendName);
-         }
-      }
-   }
-
-   auto friendTrees = t.GetListOfFriends();
-
-   if (!friendTrees)
-      return;
-
-   for (auto friendTreeObj : *friendTrees) {
-      auto friendTree = ((TFriendElement *)friendTreeObj)->GetTree();
-
-      std::string frName;
-      auto alias = t.GetFriendAlias(friendTree);
-      if (alias != nullptr)
-         frName = std::string(alias);
-      else
-         frName = std::string(friendTree->GetName());
-
-      GetBranchNamesImpl(*friendTree, bNamesReg, bNames, analysedTrees, frName, allowDuplicates);
-   }
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// Get all the branches names, including the ones of the friend trees
-ColumnNames_t GetBranchNames(TTree &t, bool allowDuplicates)
-{
-   std::set<std::string> bNamesSet;
-   ColumnNames_t bNames;
-   std::set<TTree *> analysedTrees;
-   std::string emptyFrName = "";
-   GetBranchNamesImpl(t, bNamesSet, bNames, analysedTrees, emptyFrName, allowDuplicates);
-   return bNames;
-}
 
 void GetTopLevelBranchNamesImpl(TTree &t, std::set<std::string> &bNamesReg, ColumnNames_t &bNames,
                                 std::set<TTree *> &analysedTrees)
@@ -622,11 +477,10 @@ void BookFilterJit(RJittedFilter *jittedFilter, void *prevNodeOnHeap, std::strin
 // Jit a Define call
 void BookDefineJit(std::string_view name, std::string_view expression, RLoopManager &lm, RDataSource *ds,
                    const std::shared_ptr<RJittedCustomColumn> &jittedCustomColumn,
-                   const RDFInternal::RBookedCustomColumns &customCols)
+                   const RDFInternal::RBookedCustomColumns &customCols, const ColumnNames_t &branches)
 {
    const auto &aliasMap = lm.GetAliasMap();
    auto *const tree = lm.GetTree();
-   const auto branches = tree ? RDFInternal::GetBranchNames(*tree) : ColumnNames_t();
    const auto namespaceID = lm.GetID();
    const auto &dsColumns = ds ? ds->GetColumnNames() : ColumnNames_t{};
 
@@ -766,12 +620,12 @@ std::shared_ptr<RNodeBase> UpcastNode(std::shared_ptr<RNodeBase> ptr)
 /// * check that selected column names refer to valid branches, custom columns or datasource columns (throw if not)
 /// Return the list of selected column names.
 ColumnNames_t GetValidatedColumnNames(RLoopManager &lm, const unsigned int nColumns, const ColumnNames_t &columns,
-                                      const ColumnNames_t &datasetColumns, const ColumnNames_t &validCustomColumns,
-                                      RDataSource *ds)
+                                      const ColumnNames_t &validCustomColumns, RDataSource *ds)
 {
    const auto &defaultColumns = lm.GetDefaultColumnNames();
    auto selectedColumns = SelectColumns(nColumns, columns, defaultColumns);
-   const auto unknownColumns = FindUnknownColumns(selectedColumns, datasetColumns, validCustomColumns,
+   const auto &validBranchNames = lm.GetBranchNames();
+   const auto unknownColumns = FindUnknownColumns(selectedColumns, validBranchNames, validCustomColumns,
                                                   ds ? ds->GetColumnNames() : ColumnNames_t{});
 
    if (!unknownColumns.empty()) {


### PR DESCRIPTION
- GetBranchNames is now a public method of RLoopManager
- fBranchNames is now RLoopManager::fValidBranchNames
- the first call to GetBranchNames evaluates the list of
  valid branch names (expensive operation) and stores it
  in fValidBranchNames. Subsequent calls simply return
  the cached value
- code in RInterface has been simplified as a consequence

A test python application which booked O(100k) operations in situations where caching was not performed sees an improvement of the RDF setup time from 17s to 6s.