### PR TITLE
[treereader] Do not warn about file change if *this is new:

### DIFF
--- a/tree/treeplayer/src/TTreeReader.cxx
+++ b/tree/treeplayer/src/TTreeReader.cxx
@@ -385,7 +385,8 @@ TTreeReader::EEntryStatus TTreeReader::SetEntryBase(Long64_t entry, Bool_t local
       return fEntryStatus;
    }
 
-   if (fMostRecentTreeNumber != treeNumberBeforeLoadTree) {
+   if (fMostRecentTreeNumber != -1 // We are not new-born
+       && fMostRecentTreeNumber != treeNumberBeforeLoadTree) {
       // This can happen if someone switched trees behind us.
       // Likely cause: a TChain::LoadTree() e.g. from TTree::Process().
       // This means that "local" should be set!


### PR DESCRIPTION
The reader cannot know who read that tree before, maybe another reader,
and warning about previous state right after birth is too much of a guess.
Fixes an issue where RDF creates exactly that situation.