### PR TITLE
[DF][ROOT-9783] Add DF ctors to isolate upfront an event range

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -116,6 +116,8 @@ class RLoopManager : public RNodeBase {
    /// A unique ID that identifies the computation graph that starts with this RLoopManager.
    /// Used, for example, to jit objects in a namespace reserved for this computation graph
    const unsigned int fID = GetNextID();
+   ULong64_t fStartEvt;
+   ULong64_t fEndEvt;
 
    std::vector<RCustomColumnBase *>
       fCustomColumns; ///< The loopmanager tracks all columns created, without owning them.
@@ -135,9 +137,9 @@ class RLoopManager : public RNodeBase {
    static unsigned int GetNextID();
 
 public:
-   RLoopManager(TTree *tree, const ColumnNames_t &defaultBranches);
+   RLoopManager(TTree *tree, const ColumnNames_t &defaultBranches, ULong64_t startEvt = 0ULL, ULong64_t endEvt = 0ULL);
    RLoopManager(ULong64_t nEmptyEntries);
-   RLoopManager(std::unique_ptr<RDataSource> ds, const ColumnNames_t &defaultBranches);
+   RLoopManager(std::unique_ptr<RDataSource> ds, const ColumnNames_t &defaultBranches, ULong64_t startEvt = 0ULL, ULong64_t endEvt = 0ULL);
    RLoopManager(const RLoopManager &) = delete;
    RLoopManager &operator=(const RLoopManager &) = delete;
 

--- a/tree/dataframe/inc/ROOT/RDataFrame.hxx
+++ b/tree/dataframe/inc/ROOT/RDataFrame.hxx
@@ -41,13 +41,13 @@ namespace TTraits = ROOT::TypeTraits;
 class RDataFrame : public ROOT::RDF::RInterface<RDFDetail::RLoopManager> {
 public:
    using ColumnNames_t = RDFDetail::ColumnNames_t;
-   RDataFrame(std::string_view treeName, std::string_view filenameglob, const ColumnNames_t &defaultBranches = {});
+   RDataFrame(std::string_view treeName, std::string_view filenameglob, const ColumnNames_t &defaultBranches = {}, ULong64_t startEvt = 0ULL, ULong64_t endEvt = 0ULL);
    RDataFrame(std::string_view treename, const std::vector<std::string> &filenames,
-              const ColumnNames_t &defaultBranches = {});
-   RDataFrame(std::string_view treeName, ::TDirectory *dirPtr, const ColumnNames_t &defaultBranches = {});
-   RDataFrame(TTree &tree, const ColumnNames_t &defaultBranches = {});
+              const ColumnNames_t &defaultBranches = {}, ULong64_t startEvt = 0ULL, ULong64_t endEvt = 0ULL);
+   RDataFrame(std::string_view treeName, ::TDirectory *dirPtr, const ColumnNames_t &defaultBranches = {}, ULong64_t startEvt = 0ULL, ULong64_t endEvt = 0ULL);
+   RDataFrame(TTree &tree, const ColumnNames_t &defaultBranches = {}, ULong64_t startEvt = 0ULL, ULong64_t endEvt = 0ULL);
    RDataFrame(ULong64_t numEntries);
-   RDataFrame(std::unique_ptr<ROOT::RDF::RDataSource>, const ColumnNames_t &defaultBranches = {});
+   RDataFrame(std::unique_ptr<ROOT::RDF::RDataSource>, const ColumnNames_t &defaultBranches = {}, ULong64_t startEvt = 0ULL, ULong64_t endEvt = 0ULL);
 };
 
 } // ns ROOT

--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -645,7 +645,7 @@ ROOT::RDataFrame df(10);
 auto maybeRangedDF = MaybeAddRange(df, true);
 ~~~
 
-The conversion to ROOT::RDF::RNode is cheap, but it will introduce an extra virtual call during the RDataFrame event 
+The conversion to ROOT::RDF::RNode is cheap, but it will introduce an extra virtual call during the RDataFrame event
 loop (in most cases, the resulting performance impact should be negligible).
 
 As a final note, remember that RDataFrame actions do not return another dataframe, but a RResultPtr<T>, where T is the
@@ -796,8 +796,8 @@ namespace RDFInternal = ROOT::Internal::RDF;
 /// The default branches are looked at in case no branch is specified in the
 /// booking of actions or transformations.
 /// See RInterface for the documentation of the methods available.
-RDataFrame::RDataFrame(std::string_view treeName, TDirectory *dirPtr, const ColumnNames_t &defaultBranches)
-   : RInterface<RDFDetail::RLoopManager>(std::make_shared<RDFDetail::RLoopManager>(nullptr, defaultBranches))
+RDataFrame::RDataFrame(std::string_view treeName, TDirectory *dirPtr, const ColumnNames_t &defaultBranches, ULong64_t startEvt, ULong64_t endEvt)
+   : RInterface<RDFDetail::RLoopManager>(std::make_shared<RDFDetail::RLoopManager>(nullptr, defaultBranches, startEvt, endEvt))
 {
    if (!dirPtr) {
       auto msg = "Invalid TDirectory!";
@@ -822,8 +822,8 @@ RDataFrame::RDataFrame(std::string_view treeName, TDirectory *dirPtr, const Colu
 /// The default branches are looked at in case no branch is specified in the
 /// booking of actions or transformations.
 /// See RInterface for the documentation of the methods available.
-RDataFrame::RDataFrame(std::string_view treeName, std::string_view filenameglob, const ColumnNames_t &defaultBranches)
-   : RInterface<RDFDetail::RLoopManager>(std::make_shared<RDFDetail::RLoopManager>(nullptr, defaultBranches))
+RDataFrame::RDataFrame(std::string_view treeName, std::string_view filenameglob, const ColumnNames_t &defaultBranches, ULong64_t startEvt, ULong64_t endEvt)
+   : RInterface<RDFDetail::RLoopManager>(std::make_shared<RDFDetail::RLoopManager>(nullptr, defaultBranches, startEvt, endEvt))
 {
    const std::string treeNameInt(treeName);
    const std::string filenameglobInt(filenameglob);
@@ -842,8 +842,8 @@ RDataFrame::RDataFrame(std::string_view treeName, std::string_view filenameglob,
 /// The default branches are looked at in case no branch is specified in the booking of actions or transformations.
 /// See RInterface for the documentation of the methods available.
 RDataFrame::RDataFrame(std::string_view treeName, const std::vector<std::string> &fileglobs,
-                       const ColumnNames_t &defaultBranches)
-   : RInterface<RDFDetail::RLoopManager>(std::make_shared<RDFDetail::RLoopManager>(nullptr, defaultBranches))
+                       const ColumnNames_t &defaultBranches, ULong64_t startEvt, ULong64_t endEvt)
+   : RInterface<RDFDetail::RLoopManager>(std::make_shared<RDFDetail::RLoopManager>(nullptr, defaultBranches, startEvt, endEvt))
 {
    std::string treeNameInt(treeName);
    auto chain = std::make_shared<TChain>(treeNameInt.c_str());
@@ -860,8 +860,8 @@ RDataFrame::RDataFrame(std::string_view treeName, const std::vector<std::string>
 /// The default branches are looked at in case no branch is specified in the
 /// booking of actions or transformations.
 /// See RInterface for the documentation of the methods available.
-RDataFrame::RDataFrame(TTree &tree, const ColumnNames_t &defaultBranches)
-   : RInterface<RDFDetail::RLoopManager>(std::make_shared<RDFDetail::RLoopManager>(&tree, defaultBranches))
+RDataFrame::RDataFrame(TTree &tree, const ColumnNames_t &defaultBranches, ULong64_t startEvt, ULong64_t endEvt)
+   : RInterface<RDFDetail::RLoopManager>(std::make_shared<RDFDetail::RLoopManager>(&tree, defaultBranches, startEvt, endEvt))
 {
 }
 
@@ -886,8 +886,8 @@ RDataFrame::RDataFrame(ULong64_t numEntries)
 ///
 /// A dataframe associated to a datasource will query it to access column values.
 /// See RInterface for the documentation of the methods available.
-RDataFrame::RDataFrame(std::unique_ptr<ROOT::RDF::RDataSource> ds, const ColumnNames_t &defaultBranches)
-   : RInterface<RDFDetail::RLoopManager>(std::make_shared<RDFDetail::RLoopManager>(std::move(ds), defaultBranches))
+RDataFrame::RDataFrame(std::unique_ptr<ROOT::RDF::RDataSource> ds, const ColumnNames_t &defaultBranches, ULong64_t startEvt, ULong64_t endEvt)
+   : RInterface<RDFDetail::RLoopManager>(std::make_shared<RDFDetail::RLoopManager>(std::move(ds), defaultBranches, startEvt, endEvt))
 {
 }
 


### PR DESCRIPTION
there are usecases, e.g. distributed RDF, where it is necessary
to specify sub-event ranges and read only those entries. These
new constructors help in that direction.