### PR TITLE
[cxxmodules] Don't declare strings from rootmap for modules

### DIFF
--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -535,7 +535,7 @@ function (ROOT_CXXMODULES_APPEND_TO_MODULEMAP library library_headers)
       set(modulemap_entry "${modulemap_entry}  module \"${header}\" { ${textual_header}header \"${header}\" export * }\n")
     endif()
   endforeach()
-  #set(modulemap_entry "${modulemap_entry}  link \"lib/${library}\"\n")
+  set(modulemap_entry "${modulemap_entry}  link \"${library}\"\n")
   set(modulemap_entry "${modulemap_entry}  export *\n}\n\n")
   # Non ROOT projects need a modulemap generated for them in the current
   # directory. The same happens with test dictionaries in ROOT which are not

--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -535,7 +535,7 @@ function (ROOT_CXXMODULES_APPEND_TO_MODULEMAP library library_headers)
       set(modulemap_entry "${modulemap_entry}  module \"${header}\" { ${textual_header}header \"${header}\" export * }\n")
     endif()
   endforeach()
-  set(modulemap_entry "${modulemap_entry}  link \"${library}\"\n")
+  set(modulemap_entry "${modulemap_entry}  link \"${libprefix}${library}${libsuffix}\"\n")
   set(modulemap_entry "${modulemap_entry}  export *\n}\n\n")
   # Non ROOT projects need a modulemap generated for them in the current
   # directory. The same happens with test dictionaries in ROOT which are not

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -6712,7 +6712,8 @@ static std::string GetClassSharedLibsForModule(const char *cls, cling::LookupHel
       return {};
 
    using namespace clang;
-   if (const Decl *D = LH.findScope(cls, cling::LookupHelper::NoDiagnostics)) {
+   if (const Decl *D = LH.findScope(cls, cling::LookupHelper::NoDiagnostics,
+                                    /*type*/ nullptr, /*instantiate*/ false)) {
       if (!D->isFromASTFile()) {
          if (gDebug > 5)
             Warning("GetClassSharedLibsForModule", "Decl found for %s is not part of a module", cls);

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -6727,6 +6727,16 @@ static std::string GetClassSharedLibsForModule(const char *cls, cling::LookupHel
 
          void VisitDecl(const Decl *D)
          {
+            // FIXME: Such case is described ROOT-7765 where
+            // ROOT_GENERATE_DICTIONARY does not contain the list of headers.
+            // They are specified as #includes in the LinkDef file. This leads to
+            // generation of incomplete modulemap files and this logic fails to
+            // compute the corresponding module of D.
+            // FIXME: If we want to support such a case, we should not rely on
+            // the contents of the modulemap but mangle D and look it up in the
+            // .so files.
+            if (!D->hasOwningModule())
+               return;
             if (Module *M = D->getOwningModule()->getTopLevelModule())
                m_TopLevelModules.insert(M);
          }

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1203,13 +1203,20 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
    // to rootcling to set this flag depending on whether it wants to produce
    // C++ modules.
    TString vfsArg;
-   if (fCxxModulesEnabled && !fromRootCling) {
-      // We only set this flag, rest is done by the CIFactory.
-      interpArgs.push_back("-fmodules");
-      // We should never build modules during runtime, so let's enable the
-      // module build remarks from clang to make it easier to spot when we do
-      // this by accident.
-      interpArgs.push_back("-Rmodule-build");
+   if (fCxxModulesEnabled) {
+      if (!fromRootCling) {
+         // We only set this flag, rest is done by the CIFactory.
+         interpArgs.push_back("-fmodules");
+         // We should never build modules during runtime, so let's enable the
+         // module build remarks from clang to make it easier to spot when we do
+         // this by accident.
+         interpArgs.push_back("-Rmodule-build");
+      }
+      // ROOT implements its autoloading upon module's link directives. We
+      // generate module A { header "A.h" link "A.so" export * } where ROOT's
+      // facilities use the link directive to dynamically load the relevant
+      // library. So, we need to suppress clang's default autolink behavior.
+      interpArgs.push_back("-fno-autolink");
    }
 
 #ifdef R__FAST_MATH

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -101,6 +101,7 @@ private: // Data Members
    TString         fIncludePath;      // Interpreter include path.
    TString         fRootmapLoadPath;  // Dynamic load path for rootmap files.
    TEnv*           fMapfile;          // Association of classes to libraries.
+   std::vector<std::string> fAutoLoadLibStorage; // A storage to return a const char* from GetClassSharedLibsForModule.
    std::map<size_t,std::vector<const char*>> fClassesHeadersMap; // Map of classes hashes and headers associated
    std::map<const cling::Transaction*,size_t> fTransactionHeadersMap; // Map which transaction contains which autoparse.
    std::set<size_t> fLookedUpClasses; // Set of classes for which headers were looked up already

--- a/core/metacling/test/CMakeLists.txt
+++ b/core/metacling/test/CMakeLists.txt
@@ -1,1 +1,15 @@
-ROOT_ADD_UNITTEST_DIR(Core RIO)
+# Make llvm and clang available here as we are mostly testing methods directly
+# depending on them.
+include_directories(SYSTEM
+  ${CLANG_INCLUDE_DIRS}
+  ${LLVM_INCLUDE_DIRS}
+  ${CLAD_INCLUDE_DIRS}
+)
+
+include_directories(
+  ../res
+  ../../clingutils/res
+  ../../foundation/res
+  ${CLING_INCLUDE_DIRS}
+)
+ROOT_ADD_UNITTEST_DIR(Core RIO LLVMSupport)

--- a/interpreter/cling/include/cling/Interpreter/LookupHelper.h
+++ b/interpreter/cling/include/cling/Interpreter/LookupHelper.h
@@ -71,6 +71,8 @@ namespace cling {
     unsigned m_CacheHits = 0;
     /// Number of times we missed the cache.
     unsigned m_TotalParseRequests = 0;
+    /// If we are called recursively.
+    bool IsRecursivelyRunning = false;
 
   public:
     LookupHelper(clang::Parser* P, Interpreter* interp);

--- a/interpreter/cling/include/cling/Utils/ParserStateRAII.h
+++ b/interpreter/cling/include/cling/Utils/ParserStateRAII.h
@@ -36,6 +36,7 @@ namespace cling {
     bool OldSuppressAllDiagnostics;
     bool OldPPSuppressAllDiagnostics;
     bool OldSpellChecking;
+    clang::Token OldTok;
     clang::SourceLocation OldPrevTokLocation;
     unsigned short OldParenCount, OldBracketCount, OldBraceCount;
     unsigned OldTemplateParameterDepth;

--- a/interpreter/cling/lib/Utils/ParserStateRAII.cpp
+++ b/interpreter/cling/lib/Utils/ParserStateRAII.cpp
@@ -24,7 +24,7 @@ cling::ParserStateRAII::ParserStateRAII(Parser& p, bool skipToEOF)
     OldPPSuppressAllDiagnostics(p.getPreprocessor().getDiagnostics()
                                 .getSuppressAllDiagnostics()),
     OldSpellChecking(p.getPreprocessor().getLangOpts().SpellChecking),
-  OldPrevTokLocation(p.PrevTokLocation),
+  OldTok(p.Tok), OldPrevTokLocation(p.PrevTokLocation),
   OldParenCount(p.ParenCount), OldBracketCount(p.BracketCount),
   OldBraceCount(p.BraceCount),
   OldTemplateParameterDepth(p.TemplateParameterDepth),
@@ -54,6 +54,8 @@ cling::ParserStateRAII::~ParserStateRAII() {
   P->TemplateIds.swap(OldTemplateIds);
   if (SkipToEOF)
     P->SkipUntil(tok::eof);
+  else
+    P->Tok = OldTok;
   PP.enableIncrementalProcessing(ResetIncrementalProcessing);
   if (!SemaDiagHadErrors) {
     // Doesn't reset the diagnostic mappings


### PR DESCRIPTION
We don't need any input_line declration from rootmap for startup time. However it may cause a failure on tests when they have custom dictionaries.
    
Should give 5MB improvements for modules.
    
Patch by Yuka Takahashi and me!