### PR TITLE
Fail to configure with mismatched versions of Python and its libraries

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -475,6 +475,12 @@ if(python)
       set(tmva-pymva OFF CACHE BOOL "Disabled because numpy not found (${tmva-pymva_description})" FORCE)
     endif()
   endif()
+
+  if(NOT "${PYTHON_VERSION_STRING}" STREQUAL "${PYTHONLIBS_VERSION_STRING}")
+    message(FATAL_ERROR "Version mismatch between Python interpreter (${PYTHON_VERSION_STRING})"
+    " and libraries (${PYTHONLIBS_VERSION_STRING}).\nROOT cannot work with this configuration. "
+    "Please specify only PYTHON_EXECUTABLE to CMake with an absolute path to ensure matching versions are found.")
+  endif()
 endif()
 
 #---Check for Ruby installation-------------------------------------------------------


### PR DESCRIPTION
This is a *very common* problem that keeps hitting out users and even our own builds in Jenkins. We need to fail to configure with mismatched versions of Python and its libraries, as ROOT will fail at runtime with such a broken configuration anyway. The error message should be enough to quickly fix the configuration.