### PR TITLE
Fix check for matching versions of Python and its libraries

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -476,7 +476,7 @@ if(python)
     endif()
   endif()
 
-  if(NOT "${PYTHON_VERSION_STRING}" STREQUAL "${PYTHONLIBS_VERSION_STRING}")
+  if(NOT "${PYTHONLIBS_VERSION_STRING}" MATCHES "${PYTHON_VERSION_STRING}")
     message(FATAL_ERROR "Version mismatch between Python interpreter (${PYTHON_VERSION_STRING})"
     " and libraries (${PYTHONLIBS_VERSION_STRING}).\nROOT cannot work with this configuration. "
     "Please specify only PYTHON_EXECUTABLE to CMake with an absolute path to ensure matching versions are found.")


### PR DESCRIPTION
On Windows, these are e.g. 3.5 and 3.5.5, so comparing for equality is too strict.