### PR TITLE
Use NEW behavior for CMake policy CMP0072 and CMP0077

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.4.3 FATAL_ERROR)
 
-set(policy_new CMP0068)
+set(policy_new CMP0068 CMP0072)
 foreach(policy ${policy_new})
   if(POLICY ${policy})
     cmake_policy(SET ${policy} NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.4.3 FATAL_ERROR)
 
-set(policy_new CMP0068 CMP0072)
+set(policy_new CMP0068 CMP0072 CMP0077)
 foreach(policy ${policy_new})
   if(POLICY ${policy})
     cmake_policy(SET ${policy} NEW)

--- a/geom/geocad/src/TGeoToOCC.cxx
+++ b/geom/geocad/src/TGeoToOCC.cxx
@@ -832,13 +832,18 @@ TopoDS_Shape TGeoToOCC::OCC_Arb8(Double_t, Double_t* , Double_t *points)
 }
 
 
-
-TopoDS_Shape TGeoToOCC::OCC_Box(Double_t dx, Double_t dy, Double_t dz, Double_t OX, Double_t OY, Double_t OZ )
+TopoDS_Shape TGeoToOCC::OCC_Box(Double_t dx, Double_t dy, Double_t dz,
+                                Double_t OX, Double_t OY, Double_t OZ)
 {
-   TopoDS_Solid box;
-   if (dz==0)dz=0.1;
-   if (dy==0)dy=0.1;if (dx==0)dx=0.1;
-   box = BRepPrimAPI_MakeBox( gp_Pnt(OX-dx, OY-dy, OZ-dz), dx*2, dy*2, dz*2);
+   if (dz == 0.0)
+      dz = 0.1;
+   if (dy == 0.0)
+      dy = 0.1;
+   if (dx == 0.0)
+      dx = 0.1;
+
+   TopoDS_Solid box = BRepPrimAPI_MakeBox(gp_Pnt(OX - dx, OY - dy, OZ - dz),
+                                          2.0 * dx, 2.0 * dy, 2.0 * dz);
    return Reverse(box);
 }
 


### PR DESCRIPTION
This selects "GLVND" as default for OpenGL libraries
in the module to find OpenGL. The OLD behavior uses
the legacy library.