### PR TITLE
[DF] Fix rdfentry_

### DIFF
--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -145,8 +145,7 @@ namespace ROOT {
                                                TEntryList entryList, const std::vector<Long64_t> &nEntries,
                                                const std::vector<std::vector<Long64_t>> &friendEntries)
          {
-            const bool usingLocalEntries = friendInfo.fFriendNames.empty() && entryList.GetN() == 0;
-            if (fChain == nullptr || (usingLocalEntries && fileNames[0] != fChain->GetListOfFiles()->At(0)->GetTitle()))
+            if (fChain == nullptr)
                MakeChain(treeName, fileNames, friendInfo, nEntries, friendEntries);
 
             std::unique_ptr<TTreeReader> reader;


### PR DESCRIPTION
[TreeProcMT] Always use global entry numbers

Specifically:
- always build one TChain per slot containing all input files, as
  opposed to one TChain per task containing one file
- always do a preliminary pass over all input files to extract
  cluster boundaries and entry numbers

This change, with its runtime performance penalty, is to restore sanity in
RDataFrame: RDF expects `TTreeReader::GetCurrentEntry` to return global
(and therefore unique) entry numbers. Internally the entry number is
used to check for hit/miss on cached results of Filters and Defines,
and it is also passed to users as a `rdfentry_` column, in which
case users expect global entry numbers to be returned.

As a second step, and a mitigation for the performance drop, the preliminary file sweep could be parallelized.