### PR TITLE
[ROOT-9829] Make Jupyter server listen on all interfaces (Port 6.16)

### DIFF
--- a/main/src/nbmain.cxx
+++ b/main/src/nbmain.cxx
@@ -140,6 +140,7 @@ static bool CreateJupyterConfig(string dest, string rootbin, string rootlib)
       out << "os.environ['PATH']            = '%s:%s/bin' % (rootbin,rootbin) + ':' + os.getenv('PATH', '')" << endl;
       out << "os.environ['LD_LIBRARY_PATH'] = '%s' % rootlib + ':' + os.getenv('LD_LIBRARY_PATH', '')" << endl;
 #endif
+      out << "c.NotebookApp.ip = '*'" << endl;
       out.close();
       return true;
    }


### PR DESCRIPTION
Users might want to connect to a notebook server launched with
'root --notebook' from another computer. This setting of the
Jupyter configuration makes that possible.

This also solves the issue explained here:

https://github.com/ipython/ipython/issues/6193

Depending on the network configuration of a machine/container,
binding on localhost might fail. This looks like the issue
reported on ROOT-9829.