### PR TITLE
[ROOT-9836] Include templated function in list of overloads

### DIFF
--- a/bindings/pyroot/src/PyRootType.cxx
+++ b/bindings/pyroot/src/PyRootType.cxx
@@ -114,7 +114,10 @@ namespace {
                         const size_t nmeth = Cppyy::GetNumMethods( scope );
                         for ( size_t imeth = 0; imeth < nmeth; ++imeth ) {
                            Cppyy::TCppMethod_t method = Cppyy::GetMethod( scope, imeth );
-                           if ( Cppyy::GetMethodName( method ) == name )
+                           auto currentName = Cppyy::GetMethodName(method);
+                           // We need to compare with the resolved name too, in case there are
+                           // typedefs to be resolved (e.g. Float_t -> float)
+                           if (currentName == name || currentName == Cppyy::ResolveName(name))
                               overloads.push_back( new TFunctionHolder( scope, method ) );
                         }
 


### PR DESCRIPTION
This PR fixes the issue described in:

https://sft.its.cern.ch/jira/browse/ROOT-9836

This should help with the development of `RDataFrame.AsMatrix` by @stwunsch .

More information can be found in the commit message.