### PR TITLE
[Geo][ROOT-9837] Avoid name clashes

### DIFF
--- a/geom/geocad/inc/TGeoToOCC.h
+++ b/geom/geocad/inc/TGeoToOCC.h
@@ -12,6 +12,14 @@
 #ifndef ROOT_TGeoToOCC
 #define ROOT_TGeoToOCC
 
+// ROOT-9837: manage the macro called Handle defined
+// in the Standard_Macro.hxx file. The name `Handle`
+// cannot leak out of these headers otherwise name
+// clashes will occour.
+#ifndef Handle
+#define Handle(ClassName) Handle_##ClassName
+#endif
+
 //Cascade
 #include <Standard_Version.hxx>
 
@@ -58,6 +66,12 @@ public:
    TopoDS_Shape Reverse(TopoDS_Shape Shape);
 
 };
+
+// ROOT-9837
+#ifdef Handle
+#undef Handle
+#endif
+
 #endif
 
 

--- a/geom/geocad/inc/TOCCToStep.h
+++ b/geom/geocad/inc/TOCCToStep.h
@@ -16,6 +16,14 @@
 #include "TGeoMatrix.h"
 #include "TGeoToOCC.h"
 
+// ROOT-9837: manage the macro called Handle defined
+// in the Standard_Macro.hxx file. The name `Handle`
+// cannot leak out of these headers otherwise name
+// clashes will occour.
+#ifndef Handle
+#define Handle(ClassName) Handle_##ClassName
+#endif
+
 #include <TDF_Label.hxx>
 #include <XCAFDoc_ShapeTool.hxx>
 #include <TDocStd_Document.hxx>
@@ -32,7 +40,7 @@ private:
    STEPCAFControl_Writer    fWriter; //the step file pointer
    Handle(TDocStd_Document) fDoc;    //the step document element
 
-   // The following probably shouldn't be data members. 
+   // The following probably shouldn't be data members.
    LabelMap_t               fTree;   //tree of Label's volumes
    TDF_Label                fLabel;  //label of the OCC shape element
    TGeoToOCC                  fRootShape;
@@ -58,5 +66,10 @@ public:
 
    void      OCCWriteStep(const char *fname);
 };
+
+// ROOT-9837
+#ifdef Handle
+#undef Handle
+#endif
 
 #endif

--- a/geom/geocad/src/TGeoToOCC.cxx
+++ b/geom/geocad/src/TGeoToOCC.cxx
@@ -45,7 +45,12 @@ A log file is created in `/tmp/TGeoCad.log`
 */
 
 #include "TGeoToOCC.h"
-
+// ROOT-9837: the macro `Handle` has been undefined
+// we need to redefine it as it is done in the oce
+// header Standard_Macro.hxx
+#ifndef Handle
+#define Handle(ClassName) Handle_##ClassName
+#endif
 
 //Cascade
 

--- a/geom/geocad/src/TGeoToStep.cxx
+++ b/geom/geocad/src/TGeoToStep.cxx
@@ -37,13 +37,19 @@ CreateGeometry method:
 ~~~
 
 The resulting STEP file will be saved in the current directory and called
-output_geometry.stp and will have converted all the nodes up to and 
+output_geometry.stp and will have converted all the nodes up to and
 including level 3.
 To compile the TGeoCad module on ROOT, OpenCascade must be installed!
 */
 
 #include "TGeoManager.h"
 #include "TOCCToStep.h"
+// ROOT-9837: the macro `Handle` has been undefined
+// we need to redefine it as it is done in the oce
+// header Standard_Macro.hxx
+#ifndef Handle
+#define Handle(ClassName) Handle_##ClassName
+#endif
 #include "TGeoToStep.h"
 #include "TString.h"
 #include "TClass.h"


### PR DESCRIPTION
workaround to contain leaks of the name `Handle` which is defined as a macro. Ideally, the headers should be re-written in order not to need direct inclusion of oce headers.