### PR TITLE
[ROOT-9797] Properly apply exclusion of branches and cut (Port 6.16)

### DIFF
--- a/main/python/cmdLineUtils.py
+++ b/main/python/cmdLineUtils.py
@@ -818,19 +818,20 @@ def _copyTreeSubset(sourceFile,sourcePathSplit,destFile,destPathSplit,firstEvent
         lastEvent = nbrEntries-1
     numberOfEntries = (lastEvent-firstEvent)+1
 
-    # "Skim" events based on branch values using selectionString
-    # as well as selecting a range of events by index
-    outputTree = bigTree.CopyTree(selectionString,"",numberOfEntries,firstEvent)
-
     # "Slim" tree by removing branches -
     # This is done after the skimming to allow for the user to skim on a
     # branch they no longer need to keep
+    outputTree = bigTree
     if branchexclude:
         _setBranchStatus(outputTree,branchexclude,0)
     if branchinclude:
         _setBranchStatus(outputTree,branchinclude,1)
     if branchexclude or branchinclude:
         outputTree = outputTree.CloneTree()
+
+    # "Skim" events based on branch values using selectionString
+    # as well as selecting a range of events by index
+    outputTree = outputTree.CopyTree(selectionString,"",numberOfEntries,firstEvent)
 
     outputTree.Write()
     return retcode


### PR DESCRIPTION
The previous version of the code in rooteventselector first applied
the cut by invoking CopyTree on the input TTree, getting an output
tree as a result. After that, it deactivated the branches to exclude
and called CloneTree on the aforementioned output tree, thus getting
the final tree. When following this strategy, the final tree is
bigger than the input tree, probably because the intermediate tree
data (before the cloning) is also stored.

In order to successfully combine the exclusion of branches and a cut
we need to reverse the order of operations: first deactivate branches
and clone the tree, then apply the cut with CopyTree.

Note that keeping the initial solution, only changing the call
to Write on the final tree with Write("", ROOT.TObject.kOverwrite)
does not work either.