### PR TITLE
Add release notes for 6.16 (PyROOT, notebooks, command line tools)

### DIFF
--- a/README/ReleaseNotes/v616/index.md
+++ b/README/ReleaseNotes/v616/index.md
@@ -338,9 +338,27 @@ available in cvmfs.
 
 ## Language Bindings
 
+### PyROOT
+  - Fixed support for templated functions when in need of:
+    - typedef resolution (`Foo<Float_t>` -> `Foo<float>`)
+    - namespace addition (`Foo<vector<float>>` -> `Foo<std::vector<float>>`)
+    - full name completion (`Foo<std::vector<float>>` -> `Foo<std::vector<float, std::allocator<float>>>`)
+
 ### Experimental PyROOT
-  - Pythonize TFile, TDirectory and TDirectoryFile. Most notably, implement attr syntax
-    for these classes.
+  - Added pythonisations for `TTree` and its subclasses (e.g. `TChain`, `TNtuple`)
+    - Pythonic iterator (`for event in tree:`)
+    - Access tree branches as attributes (`mytree.mybranch`)
+    - `TTree::Branch` pythonisation
+    - `TTree::SetBranchAddress` pythonisation
+  - Added pythonisations for `TDirectory` and its subclasses (e.g `TFile`, `TDirectoryFile`)
+    - Access directories/objects in `TDirectory`/`TDirectoryFile`/`TFile` as attributes
+    (`mydir1.mydir2.myhist`, `myfile.myhist`, `myfile.mydir.myhist`)
+    - `TDirectory::Get` pythonisation
+    - `TDirectory::WriteObject` pythonisation
+    - `TFile::Open` pythonisation
+  - Added pretty printing generic pythonisation for all classes
+  - Added interoperability with NumPy arrays for STL vectors and `RVec`s (zero-copy wrapping of
+  vectors and `RVec`s into NumPy arrays)
 
 ## JavaScript ROOT
 

--- a/README/ReleaseNotes/v616/index.md
+++ b/README/ReleaseNotes/v616/index.md
@@ -373,6 +373,9 @@ available in cvmfs.
 ## Tutorials
   - Refurbish text in the `RDataFrame` tutorials category.
 
+## Command line tools
+  - Fixed `rooteventselector` when both applying a cut (based on branch values) and selecting only
+  a subset of the branches. Previously, the size of the output file was bigger than expected.
 
 ## Class Reference Guide
 

--- a/README/ReleaseNotes/v616/index.md
+++ b/README/ReleaseNotes/v616/index.md
@@ -360,6 +360,13 @@ available in cvmfs.
   - Added interoperability with NumPy arrays for STL vectors and `RVec`s (zero-copy wrapping of
   vectors and `RVec`s into NumPy arrays)
 
+### Jupyter Notebook Integration
+  - Make sure the ROOT C++ Jupyter kernel runs with the same Python version (major and minor) that ROOT
+  was built with.
+  - Make the Jupyter server started with `root --notebook` listen on all interfaces. This can be useful
+  if the user wants to connect to the server remotely. It also fixes an issue observed when starting
+  the Jupyter server inside a Docker container.
+
 ## JavaScript ROOT
 
 


### PR DESCRIPTION
Add release notes for PyROOT (current and experimental), Jupyter notebook integration and command line tools.