### PR TITLE
[DF] Separate RDF entry count from TChain entry number for MT runs

### DIFF
--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -453,6 +453,9 @@ or [Snapshot](classROOT_1_1RDF_1_1RInterface.html#a233b7723e498967f4340705d2c4db
 provides "its own" values for these columns which do not necessarily correspond to the ones of the mother data frame. This is
 most notably the case where filters are used before deriving a cached/persistified dataframe.
 
+Note that in multi-thread event loops the values of `rdfentry_` _do not_ correspond to what would be the entry numbers
+of a TChain constructed over the same set of ROOT files, as the entries are processed in an unspecified order.
+
 ### Branch type guessing and explicit declaration of branch types
 C++ is a statically typed language: all types must be known at compile-time. This includes the types of the `TTree`
 branches we want to work on. For filters, temporary columns and some of the actions, **branch types are deduced from the

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -17,6 +17,7 @@
 #include "ROOT/TThreadExecutor.hxx"
 #endif
 
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <stdexcept>
@@ -247,12 +248,17 @@ void RLoopManager::RunTreeProcessorMT()
    RSlotStack slotStack(fNSlots);
    auto tp = std::make_unique<ROOT::TTreeProcessorMT>(*fTree);
 
-   tp->Process([this, &slotStack](TTreeReader &r) -> void {
+   std::atomic<ULong64_t> entryCount(0ull);
+
+   tp->Process([this, &slotStack, &entryCount](TTreeReader &r) -> void {
       auto slot = slotStack.GetSlot();
       InitNodeSlots(&r, slot);
+      const auto entryRange = r.GetEntriesRange(); // we trust TTreeProcessorMT to call SetEntriesRange
+      const auto nEntries = entryRange.second - entryRange.first;
+      auto count = entryCount.fetch_add(nEntries);
       // recursive call to check filters and conditionally execute actions
       while (r.Next()) {
-         RunAndCheckFilters(slot, r.GetCurrentEntry());
+         RunAndCheckFilters(slot, count++);
       }
       CleanUpTask(slot);
       slotStack.ReturnSlot(slot);


### PR DESCRIPTION
TTreeProcessorMT does not guarantee that TTreeReader::GetCurrentEntry
returns the global entry number of the underlying dataset.
RDF, however, needs a unique entry identifier to use for Filter/Define
cache invalidation, so for MT runs we now use an atomic counter.

As a consequence, in MT runs `rdfentry_` is now an arbitrary integer
with no connection to the underlying ROOT dataset.

This PR solves the same bug as #3051 , without the performance hit, at the cost of losing correspondence between RDF's `rdfentry_` column values and the global entry numbers in a corresponding TChain.