### PR TITLE
Link ROOTDataFrame library to RDAVIX library in ROOT

### DIFF
--- a/net/davix/CMakeLists.txt
+++ b/net/davix/CMakeLists.txt
@@ -10,11 +10,10 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RDAVIX
   SOURCES
     src/TDavixFile.cxx
     src/TDavixSystem.cxx
-  LIBRARIES
-    Davix::Davix
   DEPENDENCIES
     Net
     RIO
 )
 
 target_compile_options(RDAVIX PRIVATE -Wno-deprecated-declarations)
+target_link_libraries(RDAVIX PUBLIC Davix::Davix)

--- a/tree/dataframe/CMakeLists.txt
+++ b/tree/dataframe/CMakeLists.txt
@@ -15,7 +15,6 @@ endif()
 
 if(sqlite)
   list(APPEND RDATAFRAME_EXTRA_HEADERS ROOT/RSqliteDS.hxx)
-  list(APPEND RDATAFRAME_EXTRA_INCLUDES -I${SQLITE_INCLUDE_DIR})
 endif()
 
 ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
@@ -101,10 +100,9 @@ endif()
 
 if(sqlite)
   target_sources(ROOTDataFrame PRIVATE src/RSqliteDS.cxx)
-  target_include_directories(ROOTDataFrame PRIVATE ${SQLITE_INCLUDE_DIR})
-  target_link_libraries(ROOTDataFrame PRIVATE ${SQLITE_LIBRARIES})
+  target_link_libraries(ROOTDataFrame PRIVATE RSQLite)
   if (davix)
-    target_link_libraries(ROOTDataFrame PRIVATE Davix::Davix)
+    target_link_libraries(ROOTDataFrame PRIVATE RDAVIX)
   endif()
 endif()
 


### PR DESCRIPTION
When Davix is builtin, libdavix is static and the symbols get copied both into RDAVIX and ROOTDataFrame, and clash at runtime because there are multiple copies of the same symbols. To resolve this problem, we link ROOTDataFrame to RDAVIX only, but for that we have to propagate the include directory by using PUBLIC linking explicitly. Also, since the header for SQLite is not needed during dictionary generation, we can remove it from the DICTIONARY_OPTIONS of ROOTDataFrame as well.