### PR TITLE
Fix issues when linking libROOTDataFrame to Davix

### DIFF
--- a/tree/dataframe/CMakeLists.txt
+++ b/tree/dataframe/CMakeLists.txt
@@ -15,7 +15,6 @@ endif()
 
 if(sqlite)
   list(APPEND RDATAFRAME_EXTRA_HEADERS ROOT/RSqliteDS.hxx)
-  list(APPEND RDATAFRAME_EXTRA_INCLUDES -I${SQLITE_INCLUDE_DIR})
 endif()
 
 ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
@@ -102,9 +101,18 @@ endif()
 if(sqlite)
   target_sources(ROOTDataFrame PRIVATE src/RSqliteDS.cxx)
   target_include_directories(ROOTDataFrame PRIVATE ${SQLITE_INCLUDE_DIR})
-  target_link_libraries(ROOTDataFrame PRIVATE ${SQLITE_LIBRARIES})
+  target_link_libraries(ROOTDataFrame PRIVATE RSQLite)
   if (davix)
-    target_link_libraries(ROOTDataFrame PRIVATE Davix::Davix)
+    # TODO(jblomer): Use Davix through an abstraction layer in RDAVIX to avoid linking issues
+    if (builtin_davix)
+      # The builtin version is statically linked, thus we link against RDAVIX to avoid a symbol conflict
+      # if libROOTDataFrame and libRDAVIX are used together.
+      target_include_directories(ROOTDataFrame PRIVATE ${DAVIX_INCLUDE_DIRS})
+      target_link_libraries(ROOTDataFrame PRIVATE RDAVIX)
+    else()
+      # If the system libDavix is used, RDAVIX does not contain the Davix symbols itself
+      target_link_libraries(ROOTDataFrame PRIVATE Davix::Davix)
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
The built-in Davix is statically linked, the one picked up from the system is dynamically linked. We need to distinguish the two cases when linking against Davix in libROOTDataFrame. This should be better handled by not using Davix directly from RDataFrame.