### PR TITLE
Remove requirement for C++14 for compiling cppyy

### DIFF
--- a/bindings/pyroot_experimental/cppyy/CMakeLists.txt
+++ b/bindings/pyroot_experimental/cppyy/CMakeLists.txt
@@ -1,7 +1,3 @@
-if(NOT (cxx14 OR cxx17))
-  message(FATAL_ERROR "Cppyy requires C++14 standard or later")
-endif()
-
 add_subdirectory(cppyy-backend)
 add_subdirectory(CPyCppyy)
 add_subdirectory(cppyy)


### PR DESCRIPTION
Cppyy supports C++11. This has been pointed out to me by Wim, but I forgot to actually remove the check.