### PR TITLE
[Exp PyROOT] Associate len with getter methods of size of container classes

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_generic.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_generic.py
@@ -12,7 +12,7 @@ from libROOTPython import AddPrettyPrintingPyz
 from ROOT import pythonization
 
 def add_len(klass, getter_name):
-	# Parameters:
+    # Parameters:
     # klass: class to be pythonized
     # getter_name: name of the method to be associated with `len` in `klass`
 

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_rooabscollection.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_rooabscollection.py
@@ -1,0 +1,23 @@
+# Author: Enric Tejedor CERN  11/2018
+
+################################################################################
+# Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from ROOT import pythonization
+
+from ._generic import add_len
+
+@pythonization()
+def pythonize_rooabscollection(klass, name):
+    # Parameters:
+    # klass: class to be pythonized
+    # name: string containing the name of the class
+
+    if name == 'RooAbsCollection':
+        # Support `len(c)` as `c.getSize()`
+        add_len(klass, 'getSize')

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tarray.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tarray.py
@@ -1,0 +1,23 @@
+# Author: Enric Tejedor CERN  11/2018
+
+################################################################################
+# Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from ROOT import pythonization
+
+from ._generic import add_len
+
+@pythonization()
+def pythonize_tarray(klass, name):
+    # Parameters:
+    # klass: class to be pythonized
+    # name: string containing the name of the class
+
+    if name == 'TArray':
+        # Support `len(a)` as `a.GetSize()`
+        add_len(klass, 'GetSize')

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tcollection.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tcollection.py
@@ -1,4 +1,4 @@
-# Author: Stefan Wunsch CERN  06/2018
+# Author: Enric Tejedor CERN  11/2018
 
 ################################################################################
 # Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.                      #
@@ -8,23 +8,16 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
-from libROOTPython import AddPrettyPrintingPyz
 from ROOT import pythonization
 
-def add_len(klass, getter_name):
-	# Parameters:
-    # klass: class to be pythonized
-    # getter_name: name of the method to be associated with `len` in `klass`
-
-    klass.__len__ = getattr(klass, getter_name)
+from ._generic import add_len
 
 @pythonization()
-def pythonizegeneric(klass, name):
+def pythonize_tcollection(klass, name):
     # Parameters:
     # klass: class to be pythonized
     # name: string containing the name of the class
 
-    # Add pretty printing via setting the __str__ special function
-    AddPrettyPrintingPyz(klass)
-
-    return True
+    if name == 'TCollection':
+        # Support `len(c)` as `c.GetEntries()`
+        add_len(klass, 'GetEntries')

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_ttree.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_ttree.py
@@ -12,8 +12,6 @@ from libROOTPython import AddBranchAttrSyntax, SetBranchAddressPyz, BranchPyz
 
 from ROOT import pythonization
 
-from cppyy.gbl import TClass
-
 # TTree iterator
 def _TTree__iter__(self):
     i = 0

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -16,3 +16,6 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_setbranchaddress ttree_setbranchaddress.py
                     COPY_TO_BUILDDIR TreeHelper.h)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_branch ttree_branch.py
                     COPY_TO_BUILDDIR TreeHelper.h)
+
+# TCollection and subclasses pythonizations
+ROOT_ADD_PYUNITTEST(pyroot_pyz_tcollection_len tcollection_len.py)

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -22,3 +22,6 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_tcollection_len tcollection_len.py)
 
 # TArray and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tarray_len tarray_len.py)
+
+# RooAbsCollection and subclasses pythonizations
+ROOT_ADD_PYUNITTEST(pyroot_pyz_rooabscollection_len rooabscollection_len.py)

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -19,3 +19,6 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_branch ttree_branch.py
 
 # TCollection and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tcollection_len tcollection_len.py)
+
+# TArray and subclasses pythonizations
+ROOT_ADD_PYUNITTEST(pyroot_pyz_tarray_len tarray_len.py)

--- a/bindings/pyroot_experimental/PyROOT/test/rooabscollection_len.py
+++ b/bindings/pyroot_experimental/PyROOT/test/rooabscollection_len.py
@@ -1,0 +1,32 @@
+import unittest
+
+import ROOT
+
+
+class RooAbsCollectionLen(unittest.TestCase):
+    """
+    Test for the pythonization that allows to access the number of elements of a
+    RooAbsCollection (or subclass) by calling `len` on it.
+    """
+
+    num_elems = 3
+    rooabsarg_list = [ ROOT.RooStringVar(str(i),'','') for i in range(num_elems) ]
+    tlist = ROOT.TList()
+
+    # Setup
+    @classmethod
+    def setUpClass(cls):
+        for elem in cls.rooabsarg_list:
+            cls.tlist.Add(elem)
+
+    # Helpers
+    def check_len(self, c):
+        self.assertEqual(len(c), self.num_elems)
+        self.assertEqual(len(c), c.getSize())
+
+    # Tests
+    def test_rooarglist(self):
+        self.check_len(ROOT.RooArgList(self.tlist))
+
+    def test_rooargset(self):
+        self.check_len(ROOT.RooArgSet(self.tlist))

--- a/bindings/pyroot_experimental/PyROOT/test/tarray_len.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tarray_len.py
@@ -1,0 +1,24 @@
+import unittest
+
+import ROOT
+
+
+class TArrayLen(unittest.TestCase):
+    """
+    Test for the pythonization that allows to access the number of elements of a
+    TArray (or subclass) by calling `len` on it.
+    """
+
+    num_elems = 3
+
+    # Helpers
+    def check_len(self, a):
+        self.assertEqual(len(a), self.num_elems)
+        self.assertEqual(len(a), a.GetSize())
+
+    # Tests
+    def test_tarrayi(self):
+        self.check_len(ROOT.TArrayI(self.num_elems))
+
+    def test_tarrayd(self):
+        self.check_len(ROOT.TArrayD(self.num_elems))

--- a/bindings/pyroot_experimental/PyROOT/test/tcollection_len.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tcollection_len.py
@@ -1,0 +1,31 @@
+import unittest
+
+import ROOT
+
+
+class TCollectionLen(unittest.TestCase):
+    """
+    Test for the pythonization that allows to access the number of elements of a
+    TCollection (or subclass) by calling `len` on it.
+    """
+
+    num_elems = 3
+    tobject_list = [ ROOT.TObject() for _ in range(num_elems) ]
+
+    # Helpers
+    def add_elems_check_len(self, c):
+        for elem in self.tobject_list:
+            c.Add(elem)
+
+        self.assertEqual(len(c), self.num_elems)
+        self.assertEqual(len(c), c.GetEntries())
+
+    # Tests
+    def test_tlist(self):
+        self.add_elems_check_len(ROOT.TList())
+
+    def test_tobjarray(self):
+        self.add_elems_check_len(ROOT.TObjArray())
+
+    def test_thashtable(self):
+        self.add_elems_check_len(ROOT.THashTable())


### PR DESCRIPTION
As a follow up of the discussion in ROOT-9846:

https://sft.its.cern.ch/jira/browse/ROOT-9846

This PR injects the necessary pythonizations to support the `len(c)` syntax when getting the size of containers (`TCollection`, `TArray`, `RooAbsCollection` and their respective derivates) from Python.