### PR TITLE
[RF] Enable writing of RooDataSets to streams.

### DIFF
--- a/roofit/roofitcore/inc/RooArgSet.h
+++ b/roofit/roofitcore/inc/RooArgSet.h
@@ -104,6 +104,8 @@ public:
 
   RooAbsArg& operator[](const char* name) const ;   
 
+  /// Shortcut for readFromStream(std::istream&, Bool_t, const char*, const char*, Bool_t), setting
+  /// `flagReadAtt` and `section` to 0.
   virtual Bool_t readFromStream(std::istream& is, Bool_t compact, Bool_t verbose=kFALSE) {
     // I/O streaming interface (machine readable)
     return readFromStream(is, compact, 0, 0, verbose) ;

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -85,7 +85,8 @@ public:
   static RooDataSet *read(const char *filename, const RooArgList &variables,
 			  const char *opts= "", const char* commonPath="",
 			  const char *indexCatName=0) ;
-  Bool_t write(const char* filename) ;
+  Bool_t write(const char* filename) const;
+  Bool_t write(std::ostream & ofs) const;
 
 /*   void setWeightVar(const char* name=0) ; */
 /*   void setWeightVar(const RooAbsArg& arg) {  */

--- a/roofit/roofitcore/src/RooArgSet.cxx
+++ b/roofit/roofitcore/src/RooArgSet.cxx
@@ -674,26 +674,34 @@ Bool_t RooArgSet::readFromFile(const char* fileName, const char* flagReadAtt, co
 /// Write the contents of the argset in ASCII form to given stream.
 /// 
 /// A line is written for each element contained in the form
-/// <argName> = <argValue>
+/// `<argName> = <argValue>`
 /// 
-/// The <argValue> part of each element is written by the arguments' 
+/// The `<argValue>` part of each element is written by the arguments'
 /// writeToStream() function.
+/// \param os The stream to write to
+/// \param compact Write only the bare values, separated by ' '. Doing this,
+/// the stream cannot be read back into a RooArgSet, but only into a RooArgList, because the
+/// key names are lost.
 
 void RooArgSet::writeToStream(ostream& os, Bool_t compact, const char* /*section*/) const
 {
-  if (compact) {
-    coutE(InputArguments) << "RooArgSet::writeToStream(" << GetName() << ") compact mode not supported" << endl ;
-    return ;
-  }
-
   TIterator *iterat= createIterator();
   RooAbsArg *next = 0;
-  while((0 != (next= (RooAbsArg*)iterat->Next()))) {
-    os << next->GetName() << " = " ;
-    next->writeToStream(os,kFALSE) ;
-    os << endl ;
+
+  if (compact) {
+    while((0 != (next= (RooAbsArg*)iterat->Next()))) {
+      next->writeToStream(os,true);
+      os << " ";
+    }
+    os << endl;
+  } else {
+    while((0 != (next= (RooAbsArg*)iterat->Next()))) {
+      os << next->GetName() << " = " ;
+      next->writeToStream(os,kFALSE) ;
+      os << endl ;
+    }
   }
-  delete iterat;  
+  delete iterat;
 }
 
 
@@ -704,36 +712,37 @@ void RooArgSet::writeToStream(ostream& os, Bool_t compact, const char* /*section
 /// 
 /// The stream is read to end-of-file and each line is assumed to be
 /// of the form
-///
-/// <argName> = <argValue>
-/// 
+/// \code
+///   <argName> = <argValue>
+/// \endcode
 /// Lines starting with argNames not matching any element in the list
 /// will be ignored with a warning message. In addition limited C++ style 
 /// preprocessing and flow control is provided. The following constructions 
 /// are recognized:
-///
-/// > #include "include.file"       
-/// 
+/// \code
+///   include "include.file"
+/// \endcode
 /// Include given file, recursive inclusion OK
-/// 
-/// > if (<boolean_expression>)
-/// >   <name> = <value>
-/// >   ....
-/// > else if (<boolean_expression>)
-///     ....
-/// > else
-///     ....
-/// > endif
+/// \code
+/// if (<boolean_expression>)
+///   <name> = <value>
+///   ....
+/// else if (<boolean_expression>)
+///   ....
+/// else
+///   ....
+/// endif
+/// \endcode
 ///
 /// All expressions are evaluated by RooFormula, and may involve any of
 /// the sets variables. 
-///
-/// > echo <Message>
-///
+/// \code
+///   echo <Message>
+/// \endcode
 /// Print console message while reading from stream
-///
-/// > abort
-///
+/// \code
+///   abort
+/// \endcode
 /// Force termination of read sequence with error status 
 ///
 /// The value of each argument is read by the arguments readFromStream

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -21,7 +21,7 @@
 
 RooDataSet is a container class to hold unbinned data. Each data point
 in N-dimensional space is represented by a RooArgSet of RooRealVar, RooCategory 
-or RooStringVar objects 
+or RooStringVar objects.
 **/
 
 #include "RooFit.h"
@@ -1531,47 +1531,45 @@ RooPlot* RooDataSet::plotOnXY(RooPlot* frame, const RooCmdArg& arg1, const RooCm
 ////////////////////////////////////////////////////////////////////////////////
 /// Read given list of ascii files, and construct a data set, using the given
 /// ArgList as structure definition.
-///
-/// Multiple file names in fileList should be comma separated. Each
+/// \param fileList Multiple file names, comma separated. Each
 /// file is optionally prefixed with 'commonPath' if such a path is
 /// provided
-///
-/// The arglist specifies the dimensions of the dataset to be built
-/// and describes the order in which these dimensions appear in the
+/// \param varList Specify the dimensions of the dataset to be built.
+/// This list describes the order in which these dimensions appear in the
 /// ascii files to be read. 
-///
-/// Each line in the ascii file should contain N white space separated
-/// tokens, with N the number of args in 'variables'. Any text beyond
+/// Each line in the ascii file should contain N white-space separated
+/// tokens, with N the number of args in `varList`. Any text beyond
 /// N tokens will be ignored with a warning message.
-/// [ NB: This format is written by RooArgList::writeToStream() ]
+/// (NB: This is the default output of RooArgList::writeToStream())
+/// \param verbOpt `Q` be quiet, `D` debug mode (verbose)
+/// \param commonPath All filenames in `fileList` will be prefixed with this optional path.
+/// \param indexCatName Interpret the data as belonging to category `indexCatName`.
+/// When multiple files are read, a RooCategory arg in `varList` can
+/// optionally be designated to hold information about the source file
+/// of each data point. This feature is enabled by giving the name
+/// of the (already existing) category variable in `indexCatName`.
 /// 
-/// If the value of any of the variables on a given line exceeds the
+/// \attention If the value of any of the variables on a given line exceeds the
 /// fit range associated with that dimension, the entire line will be
 /// ignored. A warning message is printed in each case, unless the
-/// 'Q' verbose option is given. (Option 'D' will provide additional
-/// debugging information) The number of events read and skipped
+/// `Q` verbose option is given. The number of events read and skipped
 /// is always summarized at the end.
-///
-/// When multiple files are read, a RooCategory arg in 'variables' can 
-/// optionally be designated to hold information about the source file 
-/// of each data point. This feature is enabled by giving the name
-/// of the (already existing) category variable in 'indexCatName'
 ///
 /// If no further information is given a label name 'fileNNN' will
 /// be assigned to each event, where NNN is the sequential number of
-/// the source file in 'fileList'.
+/// the source file in `fileList`.
 /// 
-/// Alternatively it is possible to override the default label names
+/// Alternatively, it is possible to override the default label names
 /// of the index category by specifying them in the fileList string:
-/// When instead of "file1.txt,file2.txt" the string 
-/// "file1.txt:FOO,file2.txt:BAR" is specified, a state named "FOO"
+/// When instead of `file1.txt,file2.txt` the string
+/// `file1.txt:FOO,file2.txt:BAR` is specified, a state named "FOO"
 /// is assigned to the index category for each event originating from
 /// file1.txt. The labels FOO,BAR may be predefined in the index 
-/// category via defineType(), but don't have to be
+/// category via defineType(), but don't have to be.
 ///
 /// Finally, one can also assign the same label to multiple files,
-/// either by specifying "file1.txt:FOO,file2,txt:FOO,file3.txt:BAR"
-/// or "file1.txt,file2.txt:FOO,file3.txt:BAR"
+/// either by specifying `file1.txt:FOO,file2,txt:FOO,file3.txt:BAR`
+/// or `file1.txt,file2.txt:FOO,file3.txt:BAR`.
 ///
 
 RooDataSet *RooDataSet::read(const char *fileList, const RooArgList &varList,
@@ -1763,15 +1761,13 @@ RooDataSet *RooDataSet::read(const char *fileList, const RooArgList &varList,
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Write the contents of this dataset to an ASCII file with the specified name
+/// Write the contents of this dataset to an ASCII file with the specified name.
 /// Each event will be written as a single line containing the written values
 /// of each observable in the order they were declared in the dataset and
 /// separated by whitespaces
 
-Bool_t RooDataSet::write(const char* filename)
+Bool_t RooDataSet::write(const char* filename) const
 {
-  checkInit() ;
-
   // Open file for writing 
   ofstream ofs(filename) ;
   if (ofs.fail()) {
@@ -1781,18 +1777,28 @@ Bool_t RooDataSet::write(const char* filename)
 
   // Write all lines as arglist in compact mode
   coutI(DataHandling) << "RooDataSet::write(" << GetName() << ") writing ASCII file " << filename << endl ;
-  Int_t i ;
-  for (i=0 ; i<numEntries() ; i++) {
-    RooArgList list(*get(i),"line") ;
-    list.writeToStream(ofs,kTRUE) ;
+  return write(ofs);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Write the contents of this dataset to the stream.
+/// Each event will be written as a single line containing the written values
+/// of each observable in the order they were declared in the dataset and
+/// separated by whitespaces
+
+Bool_t RooDataSet::write(ostream & ofs) const {
+  checkInit();
+
+  for (Int_t i=0; i<numEntries(); ++i) {
+    get(i)->writeToStream(ofs,kTRUE);
   }
 
   if (ofs.fail()) {
     coutW(DataHandling) << "RooDataSet::write(" << GetName() << "): WARNING error(s) have occured in writing" << endl ;
   }
+
   return ofs.fail() ;
 }
-
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tutorials/roofit/rf102_dataimport.C
+++ b/tutorials/roofit/rf102_dataimport.C
@@ -98,9 +98,38 @@ void rf102_dataimport()
    // and RRV y defines a range [-10,10] this means that the RooDataSet below will have less entries than the TTree 'tree'
 
    RooDataSet ds("ds","ds",RooArgSet(x,y),Import(*tree)) ;
+   
+   
+   
+   // U s e   a s c i i   i m p o r t / e x p o r t   f o r   d a t a s e t s
+   // ------------------------------------------------------------------------------------
+   {
+   	  // Write data to output stream
+	  std::ofstream outstream("/tmp/rf102_testData.txt");
+	  // Optionally, adjust the stream here (e.g. std::setprecision)
+      ds.write(outstream);
+      outstream.close();
+   }
+   
+     
+   //Read data from input stream. The variables of the dataset need to be supplied
+   //to the RooDataSet::read() function.
+   std::cout << "\n-----------------------\nReading data from ASCII\n";
+   RooDataSet * dataReadBack = RooDataSet::read("/tmp/rf102_testData.txt",
+   RooArgList(x, y), //variables to be read. If the file has more fields, these are ignored.
+	     "D"); //Prints if a RooFit message stream listens for debug messages. Use Q for quiet.
+   
+   dataReadBack->Print("V");
+   
+   std::cout << "\nOriginal data, line 20:\n";
+   ds.get(20)->Print("V");
+   
+   std::cout << "\nRead-back data, line 20:\n";
+   dataReadBack->get(20)->Print("V");
 
 
-   // P l o t   d a t a s e t   w i t h   m u l t i p l e   b i n n i n g   c h o i c e s
+
+   // P l o t   d a t a s e t s  w i t h   m u l t i p l e   b i n n i n g   c h o i c e s
    // ------------------------------------------------------------------------------------
 
    // Print number of events in dataset
@@ -114,13 +143,19 @@ void rf102_dataimport()
    RooPlot* frame4 = y.frame(Title("Unbinned data shown with custom binning")) ;
    ds.plotOn(frame4,Binning(20)) ;
 
+   RooPlot* frame5 = y.frame(Title("Unbinned data read back from ASCII file")) ;
+   ds.plotOn(frame5,Binning(20)) ;
+   dataReadBack->plotOn(frame5, Binning(20), MarkerColor(kRed), MarkerStyle(5));
+   
    // Draw all frames on a canvas
-   TCanvas* c = new TCanvas("rf102_dataimport","rf102_dataimport",800,800) ;
-   c->Divide(2,2) ;
+   TCanvas* c = new TCanvas("rf102_dataimport","rf102_dataimport",1000,800) ;
+   c->Divide(3,2) ;
    c->cd(1) ; gPad->SetLeftMargin(0.15) ; frame->GetYaxis()->SetTitleOffset(1.4) ; frame->Draw() ;
    c->cd(2) ; gPad->SetLeftMargin(0.15) ; frame2->GetYaxis()->SetTitleOffset(1.4) ; frame2->Draw() ;
-   c->cd(3) ; gPad->SetLeftMargin(0.15) ; frame3->GetYaxis()->SetTitleOffset(1.4) ; frame3->Draw() ;
-   c->cd(4) ; gPad->SetLeftMargin(0.15) ; frame4->GetYaxis()->SetTitleOffset(1.4) ; frame4->Draw() ;
+   
+   c->cd(4) ; gPad->SetLeftMargin(0.15) ; frame3->GetYaxis()->SetTitleOffset(1.4) ; frame3->Draw() ;
+   c->cd(5) ; gPad->SetLeftMargin(0.15) ; frame4->GetYaxis()->SetTitleOffset(1.4) ; frame4->Draw() ;
+   c->cd(6) ; gPad->SetLeftMargin(0.15) ; frame4->GetYaxis()->SetTitleOffset(1.4) ; frame5->Draw() ;
 
 }
 

--- a/tutorials/roofit/rf102_dataimport.C
+++ b/tutorials/roofit/rf102_dataimport.C
@@ -104,9 +104,9 @@ void rf102_dataimport()
    // U s e   a s c i i   i m p o r t / e x p o r t   f o r   d a t a s e t s
    // ------------------------------------------------------------------------------------
    {
-   	  // Write data to output stream
-	  std::ofstream outstream("/tmp/rf102_testData.txt");
-	  // Optionally, adjust the stream here (e.g. std::setprecision)
+      // Write data to output stream
+      std::ofstream outstream("/tmp/rf102_testData.txt");
+      // Optionally, adjust the stream here (e.g. std::setprecision)
       ds.write(outstream);
       outstream.close();
    }
@@ -116,8 +116,8 @@ void rf102_dataimport()
    //to the RooDataSet::read() function.
    std::cout << "\n-----------------------\nReading data from ASCII\n";
    RooDataSet * dataReadBack = RooDataSet::read("/tmp/rf102_testData.txt",
-   RooArgList(x, y), //variables to be read. If the file has more fields, these are ignored.
-	     "D"); //Prints if a RooFit message stream listens for debug messages. Use Q for quiet.
+      RooArgList(x, y), //variables to be read. If the file has more fields, these are ignored.
+      "D"); //Prints if a RooFit message stream listens for debug messages. Use Q for quiet.
    
    dataReadBack->Print("V");
    


### PR DESCRIPTION
RooDataSets can be written to ASCII files. However, the output stream is not exposed to the user, i.e., the user cannot modify e.g. the precision. By exposing the stream to the user, the data set can be written to any ostream with user-defined stream modifiers.

The rf102 tutorial has been updated accordingly, input/output tests have been added.