### PR TITLE
Fix installation error

### DIFF
--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -847,13 +847,6 @@ install(FILES ${CMAKE_BINARY_DIR}/etc/root.mimes
               ${CMAKE_BINARY_DIR}/etc/system.rootdaemonrc
               DESTINATION ${CMAKE_INSTALL_SYSCONFDIR})
 
-install(FILES ${CMAKE_BINARY_DIR}/etc/daemons/rootd.rc.d
-              ${CMAKE_BINARY_DIR}/etc/daemons/proofd.rc.d
-              PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
-                          GROUP_EXECUTE GROUP_READ
-                          WORLD_EXECUTE WORLD_READ
-              DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/daemons)
-
 install(FILES ${CMAKE_BINARY_DIR}/etc/daemons/rootd.xinetd
               ${CMAKE_BINARY_DIR}/etc/daemons/proofd.xinetd
               DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/daemons)


### PR DESCRIPTION
This is a leftover from e6d7c53889f35bfbb986bf1890a89501b6900d41,
     dependency for rootd.rc.d needs to be deleted.

This patch fixes this error when you run install:
```
CMake Error at cmake_install.cmake:132 (file):
  file INSTALL cannot find
  "/build/yuka/build-py2-rootpy/BUILD/slc7_amd64_gcc700/lcg/root/6.15.01-cms/build/etc/daemons/rootd.rc.d".
```