### PR TITLE
Fix C++ version check to support clang 4

### DIFF
--- a/core/foundation/test/testNotFn.cxx
+++ b/core/foundation/test/testNotFn.cxx
@@ -1,4 +1,4 @@
-#if __cplusplus < 201703L && !defined(_MSC_VER)
+#if __cplusplus < 201403L && !defined(_MSC_VER)
 
 #include "ROOT/RNotFn.hxx"
 


### PR DESCRIPTION
Using clang 4 to build with C++ 17 support fails as `__cplusplus` is defined as [`201406L`](https://github.com/llvm-mirror/clang/blob/release_40/lib/Frontend/InitPreprocessor.cpp#L379) for `cxx17`.

This is needed for the macOS conda package, but it can be left as a patch that is applied before configuring if you would rather keep the checking against the correct value.