### PR TITLE
[DF] Fix compilation error on mac1012, XCode9

### DIFF
--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -802,7 +802,7 @@ namespace RDFInternal = ROOT::Internal::RDF;
 /// booking of actions or transformations.
 /// See RInterface for the documentation of the methods available.
 RDataFrame::RDataFrame(std::string_view treeName, TDirectory *dirPtr, const ColumnNames_t &defaultBranches)
-   : RInterface<RDFDetail::RLoopManager>(std::make_shared<RDFDetail::RLoopManager>(nullptr, defaultBranches))
+   : RInterface(std::make_shared<RDFDetail::RLoopManager>(nullptr, defaultBranches))
 {
    if (!dirPtr) {
       auto msg = "Invalid TDirectory!";
@@ -828,7 +828,7 @@ RDataFrame::RDataFrame(std::string_view treeName, TDirectory *dirPtr, const Colu
 /// booking of actions or transformations.
 /// See RInterface for the documentation of the methods available.
 RDataFrame::RDataFrame(std::string_view treeName, std::string_view filenameglob, const ColumnNames_t &defaultBranches)
-   : RInterface<RDFDetail::RLoopManager>(std::make_shared<RDFDetail::RLoopManager>(nullptr, defaultBranches))
+   : RInterface(std::make_shared<RDFDetail::RLoopManager>(nullptr, defaultBranches))
 {
    const std::string treeNameInt(treeName);
    const std::string filenameglobInt(filenameglob);
@@ -848,7 +848,7 @@ RDataFrame::RDataFrame(std::string_view treeName, std::string_view filenameglob,
 /// See RInterface for the documentation of the methods available.
 RDataFrame::RDataFrame(std::string_view treeName, const std::vector<std::string> &fileglobs,
                        const ColumnNames_t &defaultBranches)
-   : RInterface<RDFDetail::RLoopManager>(std::make_shared<RDFDetail::RLoopManager>(nullptr, defaultBranches))
+   : RInterface(std::make_shared<RDFDetail::RLoopManager>(nullptr, defaultBranches))
 {
    std::string treeNameInt(treeName);
    auto chain = std::make_shared<TChain>(treeNameInt.c_str());
@@ -866,7 +866,7 @@ RDataFrame::RDataFrame(std::string_view treeName, const std::vector<std::string>
 /// booking of actions or transformations.
 /// See RInterface for the documentation of the methods available.
 RDataFrame::RDataFrame(TTree &tree, const ColumnNames_t &defaultBranches)
-   : RInterface<RDFDetail::RLoopManager>(std::make_shared<RDFDetail::RLoopManager>(&tree, defaultBranches))
+   : RInterface(std::make_shared<RDFDetail::RLoopManager>(&tree, defaultBranches))
 {
 }
 
@@ -879,7 +879,7 @@ RDataFrame::RDataFrame(TTree &tree, const ColumnNames_t &defaultBranches)
 /// and it will do so for all the previously-defined temporary branches.
 /// See RInterface for the documentation of the methods available.
 RDataFrame::RDataFrame(ULong64_t numEntries)
-   : RInterface<RDFDetail::RLoopManager>(std::make_shared<RDFDetail::RLoopManager>(numEntries))
+   : RInterface(std::make_shared<RDFDetail::RLoopManager>(numEntries))
 
 {
 }
@@ -892,7 +892,7 @@ RDataFrame::RDataFrame(ULong64_t numEntries)
 /// A dataframe associated to a datasource will query it to access column values.
 /// See RInterface for the documentation of the methods available.
 RDataFrame::RDataFrame(std::unique_ptr<ROOT::RDF::RDataSource> ds, const ColumnNames_t &defaultBranches)
-   : RInterface<RDFDetail::RLoopManager>(std::make_shared<RDFDetail::RLoopManager>(std::move(ds), defaultBranches))
+   : RInterface(std::make_shared<RDFDetail::RLoopManager>(std::move(ds), defaultBranches))
 {
 }
 


### PR DESCRIPTION
Link to compilation error:
https://epsft-jenkins.cern.ch/view/ROOT%20Nightly/job/root-nightly-master/1977/LABEL=mac1012,SPEC=noimt/parsed_console/

The error is due to a bug in clang3.5, reproducible in isolation:
https://godbolt.org/z/jtYXv6

The workaround is to avoid specifying the template parameters of a
template base class -- the full type is injected in the derived class
anyway (thanks Axel!).