### PR TITLE
Let CMake manage RPATH entries

### DIFF
--- a/cmake/modules/SetUpMacOS.cmake
+++ b/cmake/modules/SetUpMacOS.cmake
@@ -139,7 +139,7 @@ if (CMAKE_SYSTEM_NAME MATCHES Darwin)
   endif()
 
   #---Set Linker flags----------------------------------------------------------------------
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}  -mmacosx-version-min=${MACOSX_VERSION} -Wl,-rpath,@loader_path/../lib")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -mmacosx-version-min=${MACOSX_VERSION}")
 
 
 else (CMAKE_SYSTEM_NAME MATCHES Darwin)


### PR DESCRIPTION
Adding RPATH entries manually and via CMAKE_*RPATH* facilities may lead
to conflict of authorities. This instance in particular tries to add the
same RPATH entry twice (fails on MacOS).