### PR TITLE
[RDF,PyROOT] Add RDataFrame.AsNumpy feature

### DIFF
--- a/bindings/pyroot/src/Pythonize.cxx
+++ b/bindings/pyroot/src/Pythonize.cxx
@@ -2681,6 +2681,11 @@ Bool_t PyROOT::Pythonize( PyObject* pyclass, const std::string& name )
 
    }
 
+   else if ( name.find("ROOT::RDataFrame") == 0 || name.find("ROOT::RDF::RInterface<") == 0 ) {
+      PyObject_SetAttrString(pyclass, "AsNumpy",
+                             PyObject_GetAttrString( gRootModule, "_RDataFrameAsNumpy" ));
+   }
+
    else if ( name == "TStyle" ) {
       MethodProxy* ctor = (MethodProxy*)PyObject_GetAttr( pyclass, PyStrings::gInit );
       ctor->fMethodInfo->fFlags &= ~TCallContext::kIsCreator;

--- a/bindings/pyroot/test/CMakeLists.txt
+++ b/bindings/pyroot/test/CMakeLists.txt
@@ -4,6 +4,7 @@ ROOT_ADD_PYUNITTEST(pyroot_pretty_printing pretty_printing.py)
 ROOT_ADD_PYUNITTEST(pyroot_rvec rvec.py)
 if(NUMPY_FOUND)
   ROOT_ADD_PYUNITTEST(pyroot_array_interface array_interface.py)
+  ROOT_ADD_PYUNITTEST(pyroot_rdataframe_asnumpy rdataframe_asnumpy.py)
   # this excludes RDF for 32 bits builds because of clang/gcc abi issues
   if( CMAKE_SIZEOF_VOID_P EQUAL 8 )
     ROOT_ADD_PYUNITTEST(pyroot_ttree_asmatrix ttree_asmatrix.py)

--- a/bindings/pyroot/test/rdataframe_asnumpy.py
+++ b/bindings/pyroot/test/rdataframe_asnumpy.py
@@ -1,0 +1,199 @@
+import unittest
+import ROOT
+import numpy as np
+
+
+class RDataFrameAsNumpy(unittest.TestCase):
+    # Helpers
+    def make_tree(self, *dtypes):
+        tree = ROOT.TTree("test", "description")
+        col_names = ["col_{}".format(d) for d in dtypes]
+
+        col_vars = []
+        for dtype in dtypes:
+            if "F" in dtype:
+                var = np.empty(1, dtype=np.float32)
+            elif "D" in dtype:
+                var = np.empty(1, dtype=np.float64)
+            elif "I" in dtype:
+                var = np.empty(1, dtype=np.int32)
+            elif "i" in dtype:
+                var = np.empty(1, dtype=np.uint32)
+            elif "L" in dtype:
+                var = np.empty(1, dtype=np.int64)
+            elif "l" in dtype:
+                var = np.empty(1, dtype=np.uint64)
+            elif "S" in dtype:
+                var = np.empty(1, dtype=np.int16)
+            elif "s" in dtype:
+                var = np.empty(1, dtype=np.uint16)
+            elif "B" in dtype:
+                var = np.empty(1, dtype=np.int8)
+            elif "b" in dtype:
+                var = np.empty(1, dtype=np.uint8)
+            elif "O" in dtype:
+                var = np.empty(1, dtype=np.uint8)
+            else:
+                raise Exception(
+                    "Type {} not known to create branch.".format(dtype))
+            col_vars.append(var)
+
+        for dtype, name, var in zip(dtypes, col_names, col_vars):
+            tree.Branch(name, var, name + "/" + dtype)
+
+        reference = {col: [] for col in col_names}
+        for i in range(5):
+            for i_var, var in enumerate(col_vars):
+                var[0] = i
+                reference[col_names[i_var]].append(var[0])
+            tree.Fill()
+        reference = {col: np.array(reference[col]) for col in reference}
+
+        return tree, reference, dtypes, col_names, col_vars
+
+    # Tests
+    def test_branch_dtypes(self):
+        root_dtypes = ["S", "s", "I", "i", "L", "l", "F", "D"]
+        tree, ref, _, col_names, _ = self.make_tree(*root_dtypes)
+        df = ROOT.RDataFrame(tree)
+        npy = df.AsNumpy()
+        for col in col_names:
+            self.assertTrue(all(npy[col] == ref[col]))
+
+    def test_read_array(self):
+        ROOT.gInterpreter.Declare("""
+        std::array<unsigned int, 3> create_array(unsigned int n) {
+            return std::array<unsigned int, 3>({n, n, n});
+        }
+        """)
+        df = ROOT.RDataFrame(5).Define("x", "create_array(rdfentry_)")
+        npy = df.AsNumpy()
+        self.assertEqual(npy["x"].size, 5)
+        self.assertEqual(list(npy["x"][0]), [0, 0, 0])
+        self.assertIn("ROOT.array<unsigned int,3>", str(type(npy["x"][0])))
+
+    def test_read_th1f(self):
+        ROOT.gInterpreter.Declare("""
+        TH1F create_histo(unsigned int n) {
+            const auto str = TString::Format("h%i", n);
+            return TH1F(str, str, 4, 0, 1);
+        }
+        """)
+        df = ROOT.RDataFrame(5).Define("x", "create_histo(rdfentry_)")
+        npy = df.AsNumpy()
+        self.assertEqual(npy["x"].size, 5)
+        self.assertIn("ROOT.TH1F", str(type(npy["x"][0])))
+
+    def test_read_vector_constantsize(self):
+        ROOT.gInterpreter.Declare("""
+        std::vector<unsigned int> create_vector_constantsize(unsigned int n) {
+            return std::vector<unsigned int>({n, n, n});
+        }
+        """)
+        df = ROOT.RDataFrame(5).Define("x",
+                                       "create_vector_constantsize(rdfentry_)")
+        npy = df.AsNumpy()
+        self.assertEqual(npy["x"].size, 5)
+        self.assertEqual(list(npy["x"][0]), [0, 0, 0])
+        self.assertIn("ROOT.vector<unsigned int>", str(type(npy["x"][0])))
+
+    def test_read_vector_variablesize(self):
+        ROOT.gInterpreter.Declare("""
+        std::vector<unsigned int> create_vector_variablesize(unsigned int n) {
+            return std::vector<unsigned int>(n);
+        }
+        """)
+        df = ROOT.RDataFrame(5).Define("x",
+                                       "create_vector_variablesize(rdfentry_)")
+        npy = df.AsNumpy()
+        self.assertEqual(npy["x"].size, 5)
+        self.assertEqual(list(npy["x"][3]), [0, 0, 0])
+        self.assertIn("ROOT.vector<unsigned int>", str(type(npy["x"][0])))
+
+    def test_read_tlorentzvector(self):
+        ROOT.gInterpreter.Declare("""
+        TLorentzVector create_tlorentzvector() {
+            auto v = TLorentzVector();
+            v.SetPtEtaPhiM(1, 2, 3, 4);
+            return v;
+        }
+        """)
+        df = ROOT.RDataFrame(5).Define("x", "create_tlorentzvector()")
+        npy = df.AsNumpy()
+        self.assertEqual(npy["x"].size, 5)
+        self.assertIn("ROOT.TLorentzVector", str(type(npy["x"][0])))
+
+    def test_read_custom_class(self):
+        ROOT.gInterpreter.Declare("""
+        struct CustomClass {
+            unsigned int fMember = 42;
+        };
+        CustomClass create_custom_class() {
+            return CustomClass();
+        }
+        """)
+        df = ROOT.RDataFrame(5).Define("x", "create_custom_class()")
+        npy = df.AsNumpy()
+        self.assertEqual(npy["x"].size, 5)
+        self.assertIn("ROOT.CustomClass", str(type(npy["x"][0])))
+        self.assertEqual(npy["x"][0].fMember, 42)
+
+    def test_define_columns(self):
+        df = ROOT.RDataFrame(4).Define("x", "1").Define("y", "2").Define(
+            "z", "3")
+        npy = df.AsNumpy(columns=["x", "y"])
+        ref = {"x": np.array([1] * 4), "y": np.array([2] * 4)}
+        self.assertTrue(sorted(["x", "y"]) == sorted(npy.keys()))
+        self.assertTrue(any(ref["x"] == npy["x"]))
+        self.assertTrue(any(ref["y"] == npy["y"]))
+
+    def test_exclude_columns(self):
+        df = ROOT.RDataFrame(4).Define("x", "1").Define("y", "2").Define(
+            "z", "3")
+        npy = df.AsNumpy(exclude=["z"])
+        ref = {"x": np.array([1] * 4), "y": np.array([2] * 4)}
+        self.assertTrue(sorted(["x", "y"]) == sorted(npy.keys()))
+        self.assertTrue(any(ref["x"] == npy["x"]))
+        self.assertTrue(any(ref["y"] == npy["y"]))
+
+        df2 = ROOT.RDataFrame(4).Define("x", "1").Define("y", "2").Define(
+            "z", "3")
+        npy = df.AsNumpy(columns=["x", "y"], exclude=["y"])
+        ref = {"x": np.array([1] * 4)}
+        self.assertTrue(["x"] == npy.keys())
+        self.assertTrue(any(ref["x"] == npy["x"]))
+
+    def test_numpy_result_ptr(self):
+        df = ROOT.RDataFrame(4).Define("x", "(double)rdfentry_")
+        npy = df.AsNumpy()
+        x = npy["x"]
+        self.assertTrue(hasattr(x, "result_ptr"))
+
+    def test_numpy_slice(self):
+        df = ROOT.RDataFrame(4).Define("x", "(double)rdfentry_")
+        npy = df.AsNumpy()
+        x = npy["x"]
+        ref = np.array([0, 1, 2, 3])
+        self.assertTrue(all(x == ref))
+
+        x2 = x[:2]
+        ref2 = ref[:2]
+        self.assertTrue(all(x2 == ref2))
+
+    def create_slice_in_scope(self):
+        df = ROOT.RDataFrame(4).Define("x", "(double)rdfentry_")
+        npy = df.AsNumpy()
+        x = npy["x"]
+        x2 = x[:2]
+        return x2
+
+    def test_numpy_slice_in_scope(self):
+        x = self.create_slice_in_scope()
+        self.assertEqual(x.flags["OWNDATA"], False)
+        ref = np.array([0, 1])
+        self.assertTrue(all(x == ref))
+        self.assertTrue(hasattr(x, "result_ptr"))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tree/dataframe/inc/ROOT/RDF/PyROOTHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/PyROOTHelpers.hxx
@@ -60,6 +60,15 @@ void TTreeAsFlatMatrixHelper(TTree &tree, std::vector<BufType> &matrix, std::vec
    TTreeAsFlatMatrix<BufType, ColTypes...>(std::index_sequence_for<ColTypes...>(), tree, matrix, columns);
 }
 
+// RDataFrame.AsNumpy helpers
+
+// NOTE: This is a workaround for the missing Take action in the PyROOT interface
+template <typename T>
+ROOT::RDF::RResultPtr<std::vector<T>> RDataFrameTake(ROOT::RDF::RNode df, std::string_view column)
+{
+   return df.Take<T>(column);
+}
+
 } // namespace RDF
 } // namespace Internal
 } // namespace ROOT

--- a/tutorials/dataframe/df026_AsNumpyArrays.py
+++ b/tutorials/dataframe/df026_AsNumpyArrays.py
@@ -1,0 +1,70 @@
+## \file
+## \ingroup tutorial_dataframe
+## \notebook
+## This tutorial shows how read data of a RDataFrame into Numpy arrays.
+##
+## \macro_code
+## \macro_output
+##
+## \date December 2018
+## \author Stefan Wunsch
+
+import ROOT
+from sys import exit
+
+# Let's create a simple dataframe with ten rows and two columns
+df = ROOT.RDataFrame(10) \
+         .Define("x", "(int)rdfentry_") \
+         .Define("y", "1.f/(1.f+rdfentry_)")
+
+# Next, we want to access the data from Python as Numpy arrays. To do so, the
+# content of the dataframe is converted using the AsNumpy method. The returned
+# object is a dictionary with the column names as keys and 1D numpy arrays with
+# the content as values.
+npy = df.AsNumpy()
+print("Read-out of the full RDataFrame:\n{}\n".format(npy))
+
+# Since reading out data to memory is expensive, always try to read-out only what
+# is needed for your analysis. You can use all RDataFrame features to reduce your
+# dataset, e.g., the Filter transformation. Furthermore, you can can pass to the
+# AsNumpy method a whitelist of column names with the option `columns` or a blacklist
+# with column names with the option `exclude`.
+df2 = df.Filter("x>5")
+npy2 = df2.AsNumpy()
+print("Read-out of the filtered RDataFrame:\n{}\n".format(npy2))
+
+npy3 = df2.AsNumpy(columns=["x"])
+print("Read-out of the filtered RDataFrame with the columns option:\n{}\n".format(npy3))
+
+npy4 = df2.AsNumpy(exclude=["x"])
+print("Read-out of the filtered RDataFrame with the exclude option:\n{}\n".format(npy4))
+
+# You can read-out all objects from ROOT files since these are wrapped by PyROOT
+# in the Python world. However, be aware that objects other than fundamental types,
+# such as complex C++ objects and not int or float, are costly to read-out.
+ROOT.gInterpreter.Declare("""
+// Inject the C++ class CustomObject in the C++ runtime.
+class CustomObject {
+public:
+    int x = 42;
+};
+// Create a function that returns such an object. This is called to fill the dataframe.
+CustomObject fill_object() { return CustomObject(); }
+""")
+
+df3 = df.Define("custom_object", "fill_object()")
+npy5 = df3.AsNumpy()
+print("Read-out of C++ objects:\n{}\n".format(npy5["custom_object"]))
+print("Access to all methods and data members of the C++ object:\nObject: {}\nAccess data member: custom_object.x = {}\n".format(
+    repr(npy5["custom_object"][0]), npy5["custom_object"][0].x))
+
+# Note that you can pass the object returned by AsNumpy directly to pandas.DataFrame
+# including any complex C++ object that may be read-out.
+try:
+    import pandas
+except:
+    print("Failed to import pandas.")
+    exit()
+
+df = pandas.DataFrame(npy5)
+print("Content of the ROOT.RDataFrame as pandas.DataFrame:\n{}\n".format(df))


### PR DESCRIPTION
This implements the `RDataFrame` pythonization `AsNumpy`, which reads out the dataframe as a collection of numpy arrays. Here's an example how it looks like:

```python
df = ROOT.RDataFrame("Events", "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root") \
         .Filter("All(Muon_pt>30)", "Only events with muons that have pt larger 30GeV")
npy = df.AsNumpy(columns=["nMuon", "PV_npvs"])

print("Number of events selected: {}".format(npy["PV_npvs"].size))
print("Average number of primary vertices per event: {:.2f}".format(numpy.mean(npy["PV_npvs"])))
print("Average number of muons per event: {:.2f}".format(numpy.mean(npy["nMuon"])))
```
```
Number of events selected: 2846996
Average number of primary vertices per event: 16.03
Average number of muons per event: 1.29
```

In addition to reading fundamental types, we support reading out any type of C++ object in the file being returned as a numpy array of Python objects wrapped by PyROOT.

```python
ROOT.gInterpreter.Declare("""
// Inject the C++ class CustomObject in the C++ runtime.
class CustomObject {
public:
    int x = 42;
};
// Create a function that returns such an object. This is called to fill the dataframe.
CustomObject fill_object() { return CustomObject(); }
""")

df = ROOT.RDataFrame(4).Define("custom_object", "fill_object()")
npy = df.AsNumpy()
print(npy)
```
```
{'custom_object': array([<ROOT.CustomObject object at 0x64d8d50>,
       <ROOT.CustomObject object at 0x79bd140>,
       <ROOT.CustomObject object at 0x743f440>,
       <ROOT.CustomObject object at 0x7359710>], dtype=object)}
```