### PR TITLE
Shut up Clang too, since of course it doesn't know -Wpragmas

### DIFF
--- a/core/clingutils/res/TClingUtils.h
+++ b/core/clingutils/res/TClingUtils.h
@@ -22,13 +22,17 @@
 //#include <atomic>
 #include <stdlib.h>
 
+#if defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
 
 #include "clang/Basic/Module.h"
 
+#if defined(__GNUC__)
 #pragma GCC diagnostic pop
+#endif
 
 namespace llvm {
    class StringRef;


### PR DESCRIPTION
Why can't compilers simply ignore these options when they don't know?