### PR TITLE
Protect contents of .vscode from `git clean -df`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ project.xcworkspace
 .DS_Store
 
 # Visual Code
-.vscode/*
+.vscode
 .build
 
 # CLion


### PR DESCRIPTION
Previous spelling worked for `git clean -f` but not `git clean -df`