### PR TITLE
[smatrix] Spell out the default argument.

### DIFF
--- a/math/smatrix/inc/Math/MatrixFunctions.h
+++ b/math/smatrix/inc/Math/MatrixFunctions.h
@@ -924,8 +924,8 @@ inline Expr<TensorMulOp<VecExpr<A,T,D1>, VecExpr<B,T,D2>  >, T, D1, D2 >
 // TensorProd (SVector x SVector)
 //==============================================================================
 template <class T, unsigned int D1, unsigned int D2>
-inline SMatrix<T,D1,D2>  TensorProd(const SVector<T,D1>& lhs, const SVector<T,D2>& rhs) {
-  SMatrix<T,D1,D2> tmp;
+inline SMatrix<T,D1,D2,MatRepStd<T, D1, D2>> TensorProd(const SVector<T,D1>& lhs, const SVector<T,D2>& rhs) {
+  SMatrix<T,D1,D2,MatRepStd<T, D1, D2>> tmp;
   for (unsigned int i=0; i< D1; ++i)
     for (unsigned int j=0; j< D2; ++j) {
       tmp(i,j) = lhs[i]*rhs[j];
@@ -936,9 +936,9 @@ inline SMatrix<T,D1,D2>  TensorProd(const SVector<T,D1>& lhs, const SVector<T,D2
 //==============================================================================
 // TensorProd (VecExpr x SVector)
 //==============================================================================
- template <class T, unsigned int D1, unsigned int D2, class A>
-inline SMatrix<T,D1,D2>  TensorProd(const VecExpr<A,T,D1>& lhs, const SVector<T,D2>& rhs) {
-  SMatrix<T,D1,D2> tmp;
+template <class T, unsigned int D1, unsigned int D2, class A>
+inline SMatrix<T,D1,D2,MatRepStd<T, D1, D2>>  TensorProd(const VecExpr<A,T,D1>& lhs, const SVector<T,D2>& rhs) {
+  SMatrix<T,D1,D2,MatRepStd<T, D1, D2>> tmp;
   for (unsigned int i=0; i< D1; ++i)
     for (unsigned int j=0; j< D2; ++j)
       tmp(i,j) = lhs.apply(i) * rhs.apply(j);
@@ -948,9 +948,9 @@ inline SMatrix<T,D1,D2>  TensorProd(const VecExpr<A,T,D1>& lhs, const SVector<T,
 //==============================================================================
 // TensorProd (SVector x VecExpr)
 //==============================================================================
- template <class T, unsigned int D1, unsigned int D2, class A>
-inline SMatrix<T,D1,D2> TensorProd(const SVector<T,D1>& lhs, const VecExpr<A,T,D2>& rhs) {
-  SMatrix<T,D1,D2> tmp;
+template <class T, unsigned int D1, unsigned int D2, class A>
+inline SMatrix<T,D1,D2, MatRepStd<T, D1, D2>> TensorProd(const SVector<T,D1>& lhs, const VecExpr<A,T,D2>& rhs) {
+  SMatrix<T,D1,D2,MatRepStd<T, D1, D2>> tmp;
   for (unsigned int i=0; i< D1; ++i)
     for (unsigned int j=0; j< D2; ++j)
       tmp(i,j) = lhs.apply(i) * rhs.apply(j);
@@ -962,9 +962,9 @@ inline SMatrix<T,D1,D2> TensorProd(const SVector<T,D1>& lhs, const VecExpr<A,T,D
 // TensorProd (VecExpr x VecExpr)
 //==============================================================================
 
- template <class T, unsigned int D1, unsigned int D2, class A, class B>
-inline SMatrix<T,D1,D2  > TensorProd(const VecExpr<A,T,D1>& lhs, const VecExpr<B,T,D2>& rhs) {
-  SMatrix<T,D1,D2> tmp;
+template <class T, unsigned int D1, unsigned int D2, class A, class B>
+inline SMatrix<T,D1,D2,MatRepStd<T, D1, D2>> TensorProd(const VecExpr<A,T,D1>& lhs, const VecExpr<B,T,D2>& rhs) {
+  SMatrix<T,D1,D2,MatRepStd<T, D1, D2>> tmp;
   for (unsigned int i=0; i< D1; ++i)
     for (unsigned int j=0; j< D2; ++j)
       tmp(i,j) = lhs.apply(i) * rhs.apply(j);


### PR DESCRIPTION
If we include the definition of SMatrix after MathFunctions.h (which
relies on HelperOps.h (to forward declare SMatrix) we cannot see the
default arguments.

Patch by Lorenzo Moneta and me!

(cherry picked from commit d4b004c641b1e939250eb17721083a2016172bef)