### PR TITLE
[RDF,PyROOT] Rename TTreeAsFlatMatrix header to PyROOTHelpers and cha…

### DIFF
--- a/bindings/pyroot/ROOT.py
+++ b/bindings/pyroot/ROOT.py
@@ -357,10 +357,10 @@ def _TTreeAsMatrix(self, columns=None, exclude=None, dtype="double", return_labe
     flat_matrix = _root.std.vector(dtype)(self.GetEntries()*len(columns))
 
     # Read the tree as flat std.vector(dtype)
-    tree_ptr = _root.ROOT.Detail.RDF.GetAddress(self)
-    columns_vector_ptr = _root.ROOT.Detail.RDF.GetAddress(columns_vector)
-    flat_matrix_ptr = _root.ROOT.Detail.RDF.GetVectorAddress(dtype)(flat_matrix)
-    jit_code = "ROOT::Detail::RDF::TTreeAsFlatMatrixHelper<{dtype}, {col_dtypes}>(*reinterpret_cast<TTree*>({tree_ptr}), *reinterpret_cast<std::vector<{dtype}>* >({flat_matrix_ptr}), *reinterpret_cast<std::vector<string>* >({columns_vector_ptr}));".format(
+    tree_ptr = _root.ROOT.Internal.RDF.GetAddress(self)
+    columns_vector_ptr = _root.ROOT.Internal.RDF.GetAddress(columns_vector)
+    flat_matrix_ptr = _root.ROOT.Internal.RDF.GetVectorAddress(dtype)(flat_matrix)
+    jit_code = "ROOT::Internal::RDF::TTreeAsFlatMatrixHelper<{dtype}, {col_dtypes}>(*reinterpret_cast<TTree*>({tree_ptr}), *reinterpret_cast<std::vector<{dtype}>* >({flat_matrix_ptr}), *reinterpret_cast<std::vector<string>* >({columns_vector_ptr}));".format(
             col_dtypes = ", ".join(col_dtypes),
             dtype = dtype,
             tree_ptr = tree_ptr,

--- a/tree/dataframe/CMakeLists.txt
+++ b/tree/dataframe/CMakeLists.txt
@@ -56,7 +56,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     ROOT/RDF/RRange.hxx
     ROOT/RDF/RSlotStack.hxx
     ROOT/RDF/Utils.hxx
-    ROOT/RDF/TTreeAsFlatMatrix.hxx
+    ROOT/RDF/PyROOTHelpers.hxx
     ${RDATAFRAME_EXTRA_HEADERS}
   SOURCES
     src/RActionBase.cxx

--- a/tree/dataframe/inc/ROOT/RDF/PyROOTHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/PyROOTHelpers.hxx
@@ -8,8 +8,8 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#ifndef ROOT_TTreeAsFlatMatrix
-#define ROOT_TTreeAsFlatMatrix
+#ifndef ROOT_PyROOTHelpers
+#define ROOT_PyROOTHelpers
 
 #include "ROOT/RDataFrame.hxx"
 
@@ -18,7 +18,7 @@
 #include <utility>
 
 namespace ROOT {
-namespace Detail {
+namespace Internal {
 namespace RDF {
 
 template <typename dtype>
@@ -61,7 +61,7 @@ void TTreeAsFlatMatrixHelper(TTree &tree, std::vector<BufType> &matrix, std::vec
 }
 
 } // namespace RDF
-} // namespace Detail
+} // namespace Internal
 } // namespace ROOT
 
 #endif


### PR DESCRIPTION
…nge namespace from Detail to Internal

This prepares #3107, which needs further C++ side PyROOT helpers in the RDataFrame library. I've changed the `Detail` namespace to the `Internal` once, since this makes more sense (imho).