### PR TITLE
[RDF] Add AsRNode helper to cast RDF nodes to common type ROOT::RDF::…

### DIFF
--- a/tree/dataframe/inc/ROOT/RDFHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFHelpers.hxx
@@ -136,6 +136,16 @@ void SaveGraph(NodeType node, const std::string &outputFile)
    out.close();
 }
 
+// clang-format off
+/// Cast a RDataFrame node to the common type ROOT::RDF::RNode
+/// \param[in] Any node of a RDataFrame graph
+// clang-format on
+template <typename NodeType>
+RNode AsRNode(NodeType node)
+{
+   return node;
+}
+
 } // namespace RDF
 } // namespace ROOT
 #endif


### PR DESCRIPTION
…RNode

This prepares #3107, which needs a cast of a dataframe node to `ROOT::RDF::RNode` as part of the pythonization. @bluehood pointed out that this might be of general use so I've factored it out in this PR.