### PR TITLE
[RDF] Make copy-constructor external and add extern templates of Take…

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -424,6 +424,17 @@ public:
 // 3. The column is an RVec, the collection is not a vector
 // 4. The column is an RVec, the collection is a vector
 
+template <typename T, typename COLL>
+void FillColl(const T& v, COLL& c) {
+   c.emplace_back(v);
+}
+
+// Use push_back for std::vector<bool> since some compilers do not support emplace_back.
+template <typename COLL>
+void FillColl(const bool v, COLL& c) {
+   c.push_back(v);
+}
+
 // Case 1.: The column is not an RVec, the collection is not a vector
 // No optimisations, no transformations: just copies.
 template <typename RealT_t, typename T, typename COLL>
@@ -443,7 +454,7 @@ public:
 
    void InitTask(TTreeReader *, unsigned int) {}
 
-   void Exec(unsigned int slot, T &v) { fColls[slot]->emplace_back(v); }
+   void Exec(unsigned int slot, T &v) { FillColl(v, *fColls[slot]); }
 
    void Initialize() { /* noop */}
 
@@ -452,8 +463,8 @@ public:
       auto rColl = fColls[0];
       for (unsigned int i = 1; i < fColls.size(); ++i) {
          auto &coll = fColls[i];
-         for (T &v : *coll) {
-            rColl->emplace_back(v);
+         for (const T &v : *coll) {
+            FillColl(v, *rColl);
          }
       }
    }
@@ -485,7 +496,7 @@ public:
 
    void InitTask(TTreeReader *, unsigned int) {}
 
-   void Exec(unsigned int slot, T &v) { fColls[slot]->emplace_back(v); }
+   void Exec(unsigned int slot, T &v) { FillColl(v, *fColls[slot]); }
 
    void Initialize() { /* noop */}
 

--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -438,7 +438,7 @@ public:
       for (unsigned int i = 1; i < nSlots; ++i)
          fColls.emplace_back(std::make_shared<COLL>());
    }
-   TakeHelper(TakeHelper &&) = default;
+   TakeHelper(TakeHelper &&);
    TakeHelper(const TakeHelper &) = delete;
 
    void InitTask(TTreeReader *, unsigned int) {}
@@ -480,7 +480,7 @@ public:
          fColls.emplace_back(v);
       }
    }
-   TakeHelper(TakeHelper &&) = default;
+   TakeHelper(TakeHelper &&);
    TakeHelper(const TakeHelper &) = delete;
 
    void InitTask(TTreeReader *, unsigned int) {}
@@ -522,7 +522,7 @@ public:
       for (unsigned int i = 1; i < nSlots; ++i)
          fColls.emplace_back(std::make_shared<COLL>());
    }
-   TakeHelper(TakeHelper &&) = default;
+   TakeHelper(TakeHelper &&);
    TakeHelper(const TakeHelper &) = delete;
 
    void InitTask(TTreeReader *, unsigned int) {}
@@ -564,7 +564,7 @@ public:
          fColls.emplace_back(v);
       }
    }
-   TakeHelper(TakeHelper &&) = default;
+   TakeHelper(TakeHelper &&);
    TakeHelper(const TakeHelper &) = delete;
 
    void InitTask(TTreeReader *, unsigned int) {}
@@ -589,6 +589,32 @@ public:
 
    std::string GetActionName() { return "Take"; }
 };
+
+// Extern templates for TakeHelper
+// NOTE: The move-constructor of specializations declared as extern templates
+// must be defined out of line, otherwise cling fails to find its symbol.
+template <typename RealT_t, typename T, typename COLL>
+TakeHelper<RealT_t, T, COLL>::TakeHelper(TakeHelper<RealT_t, T, COLL> &&) = default;
+template <typename RealT_t, typename T>
+TakeHelper<RealT_t, T, std::vector<T>>::TakeHelper(TakeHelper<RealT_t, T, std::vector<T>> &&) = default;
+template <typename RealT_t, typename COLL>
+TakeHelper<RealT_t, RVec<RealT_t>, COLL>::TakeHelper(TakeHelper<RealT_t, RVec<RealT_t>, COLL> &&) = default;
+template <typename RealT_t>
+TakeHelper<RealT_t, RVec<RealT_t>, std::vector<RealT_t>>::TakeHelper(TakeHelper<RealT_t, RVec<RealT_t>, std::vector<RealT_t>> &&) = default;
+
+// External templates are disabled for gcc5 since this version wrongly omits the C++11 ABI attribute
+#if __GNUC__ > 5
+extern template class TakeHelper<bool, bool, std::vector<bool>>;
+extern template class TakeHelper<unsigned int, unsigned int, std::vector<unsigned int>>;
+extern template class TakeHelper<unsigned long, unsigned long, std::vector<unsigned long>>;
+extern template class TakeHelper<unsigned long long, unsigned long long, std::vector<unsigned long long>>;
+extern template class TakeHelper<int, int, std::vector<int>>;
+extern template class TakeHelper<long, long, std::vector<long>>;
+extern template class TakeHelper<long long, long long, std::vector<long long>>;
+extern template class TakeHelper<float, float, std::vector<float>>;
+extern template class TakeHelper<double, double, std::vector<double>>;
+#endif
+
 
 template <typename ResultType>
 class MinHelper : public RActionImpl<MinHelper<ResultType>> {

--- a/tree/dataframe/src/RDFActionHelpers.cxx
+++ b/tree/dataframe/src/RDFActionHelpers.cxx
@@ -220,6 +220,19 @@ template void StdDevHelper::Exec(unsigned int, const std::vector<char> &);
 template void StdDevHelper::Exec(unsigned int, const std::vector<int> &);
 template void StdDevHelper::Exec(unsigned int, const std::vector<unsigned int> &);
 
+// External templates are disabled for gcc5 since this version wrongly omits the C++11 ABI attribute
+#if __GNUC__ > 5
+template class TakeHelper<bool, bool, std::vector<bool>>;
+template class TakeHelper<unsigned int, unsigned int, std::vector<unsigned int>>;
+template class TakeHelper<unsigned long, unsigned long, std::vector<unsigned long>>;
+template class TakeHelper<unsigned long long, unsigned long long, std::vector<unsigned long long>>;
+template class TakeHelper<int, int, std::vector<int>>;
+template class TakeHelper<long, long, std::vector<long>>;
+template class TakeHelper<long long, long long, std::vector<long long>>;
+template class TakeHelper<float, float, std::vector<float>>;
+template class TakeHelper<double, double, std::vector<double>>;
+#endif
+
 } // end NS RDF
 } // end NS Internal
 } // end NS ROOT

--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -18,6 +18,7 @@ ROOT_ADD_GTEST(dataframe_ranges dataframe_ranges.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_leaves dataframe_leaves.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_vecops dataframe_vecops.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_resptr dataframe_resptr.cxx LIBRARIES ROOTDataFrame)
+ROOT_ADD_GTEST(dataframe_take dataframe_take.cxx LIBRARIES ROOTDataFrame)
 
 if (imt)
    ROOT_ADD_GTEST(dataframe_concurrency dataframe_concurrency.cxx LIBRARIES ROOTDataFrame)

--- a/tree/dataframe/test/dataframe_take.cxx
+++ b/tree/dataframe/test/dataframe_take.cxx
@@ -1,0 +1,12 @@
+#include "ROOT/RDataFrame.hxx"
+#include "gtest/gtest.h"
+
+TEST(RDataFrameTake, Bool)
+{
+   ROOT::RDataFrame df(1);
+   auto df2 = df.Define("x", "(bool)true");
+   auto result_ptr = df2.Take<bool>("x");
+   auto vec = result_ptr.GetValue();
+   EXPECT_EQ(vec.size(), 1u);
+   EXPECT_EQ(vec[0], true);
+}

--- a/tree/dataframe/test/dataframe_take.cxx
+++ b/tree/dataframe/test/dataframe_take.cxx
@@ -1,4 +1,5 @@
 #include "ROOT/RDataFrame.hxx"
+#include "ROOT/RVec.hxx"
 #include "gtest/gtest.h"
 
 TEST(RDataFrameTake, Bool)
@@ -9,4 +10,21 @@ TEST(RDataFrameTake, Bool)
    auto vec = result_ptr.GetValue();
    EXPECT_EQ(vec.size(), 1u);
    EXPECT_EQ(vec[0], true);
+
+   auto result_ptr2 = df2.Take<bool, ROOT::VecOps::RVec<bool>>("x");
+   auto vec2 = result_ptr2.GetValue();
+   EXPECT_EQ(vec2.size(), 1u);
+   EXPECT_EQ(vec2[0], true);
+}
+
+TEST(RDataFrameTake, VectorBool)
+{
+   ROOT::RDataFrame df(1);
+   auto df2 = df.Define("x", "std::vector<bool>({true, false})");
+   auto result_ptr = df2.Take<std::vector<bool>>("x");
+   auto vec = result_ptr.GetValue();
+   EXPECT_EQ(vec.size(), 1u);
+   EXPECT_EQ(vec[0].size(), 2u);
+   EXPECT_EQ(vec[0][0], true);
+   EXPECT_EQ(vec[0][1], false);
 }


### PR DESCRIPTION
…Helper for basic types

Make copy-constructor extern and put extern templates of the `TakeHelper` to speed-up the `Take` action of basic types. This prepares #3107.

~~TODO: Put ifdef guards to catch errors with gcc5 and others.~~