### PR TITLE
Fix ROOT-9784.  Avoid to use empty name in v5 'replacement name'.

### DIFF
--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -1560,9 +1560,17 @@ namespace {
             std::string secondNewName;
             if (firstNewCl && !firstOldCl) {
                firstAltCl = FindAlternate(context, inside[1], firstNewName);
+            } else if (firstAltCl) {
+               firstNewName = firstAltCl->GetName();
+            } else {
+               firstNewName = inside[1];
             }
             if (secondNewCl && !secondOldCl) {
                secondAltCl = FindAlternate(context, inside[2], secondNewName);
+            } else if (secondAltCl) {
+               secondNewName = secondAltCl->GetName();
+            } else {
+               secondNewName  = inside[2];
             }
             if ((firstNewCl && firstAltCl != firstOldCl) ||
                 (secondNewCl && secondAltCl != secondOldCl) ) {
@@ -1570,9 +1578,9 @@ namespace {
                // Need to produce new name.
                std::string alternate = inside[0];
                alternate.append("<");
-               alternate.append(firstAltCl ? firstNewName : inside[1]);
+               alternate.append(firstNewName);
                alternate.append(",");
-               alternate.append(secondAltCl? secondNewName : inside[2]);
+               alternate.append(secondNewName);
                // We are intentionally dropping any further arguments,
                // they would be using the wrong typename and would also be
                // somewhat superflous since this is for the old layout.


### PR DESCRIPTION
The mechanism attempting to find v6 equivalent for names found
in v5 files (eg. adding missing namespaces) under some circunstances
(see ROOT-9784) would create class name with missing template parameter
(eg literally map<,RooExpensiveObjectCache::ExpensiveObject*>

This is a fix for commit c412ad28b4e242c853aac66eeed3c08bb135a16c