### PR TITLE
Eve7: simplify generation of composite shape 

### DIFF
--- a/graf3d/eve7/CMakeLists.txt
+++ b/graf3d/eve7/CMakeLists.txt
@@ -84,7 +84,6 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTEve
     Physics 
     EG 
     TreePlayer 
-    RHTTP 
     ROOTWebDisplay
 )
 

--- a/graf3d/eve7/inc/LinkDef.h
+++ b/graf3d/eve7/inc/LinkDef.h
@@ -72,7 +72,6 @@
 // REveUtil
 #pragma link C++ class ROOT::Experimental::REveUtil+;
 #pragma link C++ class ROOT::Experimental::REveException+;
-#pragma link C++ class ROOT::Experimental::REvePadHolder+;
 #pragma link C++ class ROOT::Experimental::REveGeoManagerHolder+;
 #pragma link C++ class ROOT::Experimental::REveRefCnt+;
 #pragma link C++ class ROOT::Experimental::REveRefBackPtr+;

--- a/graf3d/eve7/inc/ROOT/REveCsgOps.hxx
+++ b/graf3d/eve7/inc/ROOT/REveCsgOps.hxx
@@ -6,10 +6,7 @@
 
 #include "Rtypes.h"
 
-#include <memory>
-
 class TBuffer3D;
-class TGeoCompositeShape;
 class TGeoMatrix;
 
 namespace ROOT {
@@ -26,7 +23,11 @@ public:
    virtual Int_t GetVertexIndex(Int_t polyNum, Int_t vertNum) const = 0;
 };
 
-std::unique_ptr<TBaseMesh> BuildFromCompositeShape(TGeoCompositeShape *cshape, Int_t n_seg);
+
+TBaseMesh *ConvertToMesh(const TBuffer3D &buff, TGeoMatrix *matr = nullptr);
+TBaseMesh *BuildUnion(const TBaseMesh *leftOperand, const TBaseMesh *rightOperand);
+TBaseMesh *BuildIntersection(const TBaseMesh *leftOperand, const TBaseMesh *rightOperand);
+TBaseMesh *BuildDifference(const TBaseMesh *leftOperand, const TBaseMesh *rightOperand);
 
 
 } // namespace EveCsg

--- a/graf3d/eve7/inc/ROOT/REveCsgOps.hxx
+++ b/graf3d/eve7/inc/ROOT/REveCsgOps.hxx
@@ -8,6 +8,7 @@
 
 class TBuffer3D;
 class TGeoCompositeShape;
+class TGeoMatrix;
 
 namespace ROOT {
 namespace Experimental {
@@ -23,11 +24,12 @@ public:
    virtual Int_t GetVertexIndex(Int_t polyNum, Int_t vertNum) const = 0;
 };
 
-TBaseMesh *ConvertToMesh(const TBuffer3D &buff);
+TBaseMesh *ConvertToMesh(const TBuffer3D &buff, TGeoMatrix *matr = nullptr);
 TBaseMesh *BuildUnion(const TBaseMesh *leftOperand, const TBaseMesh *rightOperand);
 TBaseMesh *BuildIntersection(const TBaseMesh *leftOperand, const TBaseMesh *rightOperand);
 TBaseMesh *BuildDifference(const TBaseMesh *leftOperand, const TBaseMesh *rightOperand);
 TBaseMesh *BuildFromCompositeShape(TGeoCompositeShape *cshape, Int_t n_seg);
+TBaseMesh *BuildFromCompositeShapeNew(TGeoCompositeShape *cshape, Int_t n_seg);
 
 
 } // namespace EveCsg

--- a/graf3d/eve7/inc/ROOT/REveCsgOps.hxx
+++ b/graf3d/eve7/inc/ROOT/REveCsgOps.hxx
@@ -7,7 +7,6 @@
 #include "Rtypes.h"
 
 class TBuffer3D;
-class TGeoMatrix;
 
 namespace ROOT {
 namespace Experimental {
@@ -24,7 +23,7 @@ public:
 };
 
 
-TBaseMesh *ConvertToMesh(const TBuffer3D &buff, TGeoMatrix *matr = nullptr);
+TBaseMesh *ConvertToMesh(const TBuffer3D &buff);
 TBaseMesh *BuildUnion(const TBaseMesh *leftOperand, const TBaseMesh *rightOperand);
 TBaseMesh *BuildIntersection(const TBaseMesh *leftOperand, const TBaseMesh *rightOperand);
 TBaseMesh *BuildDifference(const TBaseMesh *leftOperand, const TBaseMesh *rightOperand);

--- a/graf3d/eve7/inc/ROOT/REveCsgOps.hxx
+++ b/graf3d/eve7/inc/ROOT/REveCsgOps.hxx
@@ -6,6 +6,8 @@
 
 #include "Rtypes.h"
 
+#include <memory>
+
 class TBuffer3D;
 class TGeoCompositeShape;
 class TGeoMatrix;

--- a/graf3d/eve7/inc/ROOT/REveCsgOps.hxx
+++ b/graf3d/eve7/inc/ROOT/REveCsgOps.hxx
@@ -26,12 +26,9 @@ public:
    virtual Int_t GetVertexIndex(Int_t polyNum, Int_t vertNum) const = 0;
 };
 
-TBaseMesh *ConvertToMesh(const TBuffer3D &buff, TGeoMatrix *matr = nullptr);
-TBaseMesh *BuildUnion(const TBaseMesh *leftOperand, const TBaseMesh *rightOperand);
-TBaseMesh *BuildIntersection(const TBaseMesh *leftOperand, const TBaseMesh *rightOperand);
-TBaseMesh *BuildDifference(const TBaseMesh *leftOperand, const TBaseMesh *rightOperand);
-TBaseMesh *BuildFromCompositeShape(TGeoCompositeShape *cshape, Int_t n_seg);
-TBaseMesh *BuildFromCompositeShapeNew(TGeoCompositeShape *cshape, Int_t n_seg);
+// TBaseMesh *BuildFromCompositeShape(TGeoCompositeShape *cshape, Int_t n_seg);
+
+std::unique_ptr<TBaseMesh> BuildFromCompositeShapeNew(TGeoCompositeShape *cshape, Int_t n_seg);
 
 
 } // namespace EveCsg

--- a/graf3d/eve7/inc/ROOT/REveCsgOps.hxx
+++ b/graf3d/eve7/inc/ROOT/REveCsgOps.hxx
@@ -26,9 +26,7 @@ public:
    virtual Int_t GetVertexIndex(Int_t polyNum, Int_t vertNum) const = 0;
 };
 
-// TBaseMesh *BuildFromCompositeShape(TGeoCompositeShape *cshape, Int_t n_seg);
-
-std::unique_ptr<TBaseMesh> BuildFromCompositeShapeNew(TGeoCompositeShape *cshape, Int_t n_seg);
+std::unique_ptr<TBaseMesh> BuildFromCompositeShape(TGeoCompositeShape *cshape, Int_t n_seg);
 
 
 } // namespace EveCsg

--- a/graf3d/eve7/inc/ROOT/REveGeoPolyShape.hxx
+++ b/graf3d/eve7/inc/ROOT/REveGeoPolyShape.hxx
@@ -25,11 +25,6 @@ namespace Experimental {
 
 class REveRenderData;
 
-namespace EveCsg
-{
-class TBaseMesh;
-}
-
 class REveGeoPolyShape : public TGeoBBox
 {
 private:
@@ -69,13 +64,12 @@ protected:
 
 public:
    REveGeoPolyShape();
-   virtual ~REveGeoPolyShape() {}
+   REveGeoPolyShape(TGeoCompositeShape *cshp, Int_t n_seg);
 
-   static REveGeoPolyShape* Construct(TGeoCompositeShape *cshp, Int_t n_seg);
+   virtual ~REveGeoPolyShape() {}
 
    void FillRenderData(REveRenderData &rd);
 
-   void SetFromMesh(EveCsg::TBaseMesh* mesh);
    void SetFromBuff3D(const TBuffer3D& buffer);
 
    void EnforceTriangles();

--- a/graf3d/eve7/inc/ROOT/REveGeoShape.hxx
+++ b/graf3d/eve7/inc/ROOT/REveGeoShape.hxx
@@ -34,7 +34,7 @@ protected:
    TGeoShape *fShape{nullptr};
    TGeoCompositeShape *fCompositeShape{nullptr}; //! Temporary holder (if passed shape is composite shape).
 
-   static TGeoManager *fgGeoMangeur;
+   static TGeoManager *fgGeoManager;
 
    static REveGeoShape *SubImportShapeExtract(REveGeoShapeExtract *gse, REveElement *parent);
    REveGeoShapeExtract *DumpShapeTree(REveGeoShape *geon, REveGeoShapeExtract *parent = nullptr);
@@ -71,7 +71,7 @@ public:
    virtual std::unique_ptr<TBuffer3D> MakeBuffer3D();
    virtual TClass *ProjectedClass(const REveProjection *p) const;
 
-   static TGeoManager *GetGeoMangeur();
+   static TGeoManager *GetGeoManager();
    static TGeoHMatrix *GetGeoHMatrixIdentity();
 
    ClassDef(REveGeoShape, 0); // Wrapper for TGeoShape with absolute positioning and color attributes allowing display of extracted

--- a/graf3d/eve7/inc/ROOT/REveTreeTools.hxx
+++ b/graf3d/eve7/inc/ROOT/REveTreeTools.hxx
@@ -27,7 +27,7 @@ class REveSelectorToEventList : public TSelectorDraw {
    REveSelectorToEventList &operator=(const REveSelectorToEventList &); // Not implemented
 
 protected:
-   TEventList *fEvList;
+   TEventList *fEvList{nullptr};
    TList fInput;
 
 public:
@@ -36,8 +36,7 @@ public:
    virtual Int_t Version() const { return 1; }
    virtual Bool_t Process(Long64_t entry);
 
-   ClassDef(REveSelectorToEventList,
-            1); // TSelector that stores entry numbers of matching TTree entries into an event-list.
+   ClassDef(REveSelectorToEventList, 1); // TSelector that stores entry numbers of matching TTree entries into an event-list.
 };
 
 /******************************************************************************/
@@ -63,8 +62,7 @@ public:
    ETreeVarType_e GetSourceCS() const { return fSourceCS; }
    void SetSourceCS(ETreeVarType_e cs) { fSourceCS = cs; }
 
-   ClassDef(REvePointSelectorConsumer,
-            1); // Virtual base for classes that can be filled from TTree data via the REvePointSelector class.
+   ClassDef(REvePointSelectorConsumer, 1); // Virtual base for classes that can be filled from TTree data via the REvePointSelector class.
 };
 
 class REvePointSelector : public TSelectorDraw {
@@ -72,8 +70,8 @@ class REvePointSelector : public TSelectorDraw {
    REvePointSelector &operator=(const REvePointSelector &); // Not implemented
 
 protected:
-   TTree *fTree;
-   REvePointSelectorConsumer *fConsumer;
+   TTree *fTree{nullptr};
+   REvePointSelectorConsumer *fConsumer{nullptr};
 
    TString fVarexp;
    TString fSelection;
@@ -84,11 +82,11 @@ protected:
    TList fInput;
 
 public:
-   REvePointSelector(TTree *t = 0, REvePointSelectorConsumer *c = 0, const char *vexp = "", const char *sel = "");
+   REvePointSelector(TTree *t = nullptr, REvePointSelectorConsumer *c = nullptr, const char *vexp = "", const char *sel = "");
    virtual ~REvePointSelector() {}
 
-   virtual Long64_t Select(const char *selection = 0);
-   virtual Long64_t Select(TTree *t, const char *selection = 0);
+   virtual Long64_t Select(const char *selection = nullptr);
+   virtual Long64_t Select(TTree *t, const char *selection = nullptr);
    virtual void TakeAction();
 
    TTree *GetTree() const { return fTree; }

--- a/graf3d/eve7/inc/ROOT/REveUtil.hxx
+++ b/graf3d/eve7/inc/ROOT/REveUtil.hxx
@@ -23,7 +23,6 @@
 #include <set>
 #include <exception>
 
-class TVirtualPad;
 class TGeoManager;
 
 namespace ROOT {
@@ -110,34 +109,14 @@ REveException operator+(const REveException &s1, const char *s2);
 // Exception-safe global variable holders
 /******************************************************************************/
 
-class REvePadHolder {
-private:
-   TVirtualPad *fOldPad;
-   Bool_t fModifyUpdateP;
-
-   REvePadHolder(const REvePadHolder &);            // Not implemented
-   REvePadHolder &operator=(const REvePadHolder &); // Not implemented
-
-public:
-   REvePadHolder(Bool_t modify_update_p, TVirtualPad *new_pad = 0, Int_t subpad = 0);
-   virtual ~REvePadHolder();
-
-   ClassDef(REvePadHolder, 0); // Exception-safe wrapper for temporary setting of gPad variable.
-};
-
 class REveGeoManagerHolder {
 private:
-   TGeoManager *fManager;
-   Int_t fNSegments;
-
-   REveGeoManagerHolder(const REveGeoManagerHolder &);            // Not implemented
-   REveGeoManagerHolder &operator=(const REveGeoManagerHolder &); // Not implemented
+   TGeoManager *fManager{nullptr};  ///<!  hold manager
+   Int_t fNSegments{0};             ///<!  previous settings for num segments
 
 public:
-   REveGeoManagerHolder(TGeoManager *new_gmgr = 0, Int_t n_seg = 0);
-   virtual ~REveGeoManagerHolder();
-
-   ClassDef(REveGeoManagerHolder, 0); // Exception-safe wrapper for temporary setting of gGeoManager variable.
+   REveGeoManagerHolder(TGeoManager *new_gmgr = nullptr, Int_t n_seg = 0);
+   ~REveGeoManagerHolder();
 };
 
 /******************************************************************************/

--- a/graf3d/eve7/src/REveCsgOps.cxx
+++ b/graf3d/eve7/src/REveCsgOps.cxx
@@ -1674,21 +1674,18 @@ private:
    PLIST fPolys;
 
 public:
-   VLIST       &Verts(){return fVerts;}
-   const VLIST &Verts()const{return fVerts;}
-   PLIST       &Polys(){return fPolys;}
-   const PLIST &Polys()const{return fPolys;}
+   VLIST &Verts() { return fVerts; }
+   const VLIST &Verts() const { return fVerts; }
+   PLIST &Polys() { return fPolys; }
+   const PLIST &Polys() const { return fPolys; }
 
-   //TBaseMesh's final-overriders
-   Int_t          NumberOfPolys()const{return fPolys.size();}
-   Int_t          NumberOfVertices()const{return fVerts.size();}
-   Int_t          SizeOfPoly(Int_t polyIndex)const{return fPolys[polyIndex].Size();}
-   const Double_t *GetVertex(Int_t vertexNum)const{return fVerts[vertexNum].GetValue();}
+   // TBaseMesh's final-overriders
+   Int_t NumberOfPolys() const override { return fPolys.size(); }
+   Int_t NumberOfVertices() const override { return fVerts.size(); }
+   Int_t SizeOfPoly(Int_t polyIndex) const override { return fPolys[polyIndex].Size(); }
+   const Double_t *GetVertex(Int_t vertexNum) const override { return fVerts[vertexNum].GetValue(); }
 
-   Int_t GetVertexIndex(Int_t polyNum, Int_t vertexNum)const
-   {
-      return fPolys[polyNum][vertexNum];
-   }
+   Int_t GetVertexIndex(Int_t polyNum, Int_t vertexNum) const override { return fPolys[polyNum][vertexNum]; }
 };
 
 const Int_t cofacTable[3][2] = {{1,2}, {0,2}, {0,1}};

--- a/graf3d/eve7/src/REveCsgOps.cxx
+++ b/graf3d/eve7/src/REveCsgOps.cxx
@@ -2892,6 +2892,52 @@ TBaseMesh* TCsgVV3D::BuildComposite()
 
 //------------------------------------------------------------------------------
 
+/** \class REvePadHolder
+\ingroup REve
+Exception safe wrapper for setting gPad.
+Optionally calls gPad->Modified()/Update() in destructor.
+*/
+
+
+class REvePadHolder {
+private:
+   TVirtualPad *fOldPad{nullptr}; ///<!
+   Bool_t fModifyUpdateP{kFALSE}; ///<!
+
+public:
+   REvePadHolder(Bool_t modify_update_p, TVirtualPad *new_pad = 0, Int_t subpad = 0);
+   ~REvePadHolder();
+};
+
+////////////////////////////////////////////////////////////////////////////////
+/// Constructor.
+
+REvePadHolder::REvePadHolder(Bool_t modify_update_p, TVirtualPad* new_pad, Int_t subpad) :
+   fOldPad        (gPad),
+   fModifyUpdateP (modify_update_p)
+{
+   if (new_pad != 0)
+      new_pad->cd(subpad);
+   else
+      gPad = 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Destructor.
+
+REvePadHolder::~REvePadHolder()
+{
+   if (fModifyUpdateP && gPad != 0) {
+      gPad->Modified();
+      gPad->Update();
+   }
+   gPad = fOldPad;
+}
+
+
+
+
+
 TBaseMesh *BuildFromCompositeShape(TGeoCompositeShape *cshape, Int_t n_seg)
 {
    TCsgVV3D      vv3d;
@@ -2970,8 +3016,10 @@ std::unique_ptr<TBaseMesh> MakeMesh(TGeoMatrix *matr, TGeoShape *shape)
    return res;
 }
 
-std::unique_ptr<TBaseMesh> BuildFromCompositeShapeNew(TGeoCompositeShape *cshape, Int_t)
+std::unique_ptr<TBaseMesh> BuildFromCompositeShapeNew(TGeoCompositeShape *cshape, Int_t n_seg)
 {
+   REveGeoManagerHolder gmgr(REveGeoShape::GetGeoManager(), n_seg);
+
    return MakeMesh(nullptr, cshape);
 }
 

--- a/graf3d/eve7/src/REveCsgOps.cxx
+++ b/graf3d/eve7/src/REveCsgOps.cxx
@@ -72,13 +72,6 @@
 #include "Rtypes.h"
 #include "TMath.h"
 
-// #include <ROOT/REveGeoShape.hxx>
-// #include <ROOT/REveUtil.hxx>
-
-// #include "TBuffer3DTypes.h"
-#include "TGeoMatrix.h"
-
-
 namespace ROOT {
 namespace Experimental {
 namespace EveCsg {
@@ -2639,22 +2632,15 @@ AMesh_t *build_difference(const AMesh_t &meshA, const AMesh_t &meshB, Bool_t pre
 
 /////////////////////////////////////////////////////////////////////////////
 
-TBaseMesh *ConvertToMesh(const TBuffer3D &buff, TGeoMatrix *matr)
+TBaseMesh *ConvertToMesh(const TBuffer3D &buff)
 {
    AMesh_t *newMesh = new AMesh_t;
    const Double_t *v = buff.fPnts;
 
    newMesh->Verts().resize(buff.NbPnts());
 
-   Double_t dmaster[3];
-
    for (Int_t i = 0; i < (int) buff.NbPnts(); ++i) {
-      if (matr) {
-         matr->LocalToMaster(&v[i*3], dmaster);
-         newMesh->Verts()[i] = TVertexBase(dmaster[0], dmaster[1], dmaster[2]);
-      } else {
-         newMesh->Verts()[i] = TVertexBase(v[i * 3], v[i * 3 + 1], v[i * 3 + 2]);
-      }
+      newMesh->Verts()[i] = TVertexBase(v[i * 3], v[i * 3 + 1], v[i * 3 + 2]);
    }
 
    const Int_t *segs = buff.fSegs;

--- a/graf3d/eve7/src/REveCsgOps.cxx
+++ b/graf3d/eve7/src/REveCsgOps.cxx
@@ -2944,8 +2944,6 @@ TBaseMesh *BuildFromCompositeShape(TGeoCompositeShape *cshape, Int_t n_seg)
 
 TBaseMesh *MakeMesh(TGeoMatrix *matr, TGeoShape *shape)
 {
-
-
    TGeoCompositeShape *comp = dynamic_cast<TGeoCompositeShape *> (shape);
 
    if (!comp) {
@@ -2964,11 +2962,16 @@ TBaseMesh *MakeMesh(TGeoMatrix *matr, TGeoShape *shape)
    mright.Multiply(node->GetRightMatrix());
    auto right = MakeMesh(&mright, node->GetRightShape());
 
-   if (node->IsA() == TGeoUnion::Class()) return EveCsg::BuildUnion(left, right);
-   if (node->IsA() == TGeoIntersection::Class()) return EveCsg::BuildIntersection(left, right);
-   if (node->IsA() == TGeoSubtraction::Class()) return EveCsg::BuildDifference(left, right);
+   TBaseMesh *res = nullptr;
 
-   return nullptr;
+   if (node->IsA() == TGeoUnion::Class()) res = EveCsg::BuildUnion(left, right);
+   if (node->IsA() == TGeoIntersection::Class()) res = EveCsg::BuildIntersection(left, right);
+   if (node->IsA() == TGeoSubtraction::Class()) res = EveCsg::BuildDifference(left, right);
+
+   delete left;
+   delete right;
+
+   return res;
 }
 
 TBaseMesh *BuildFromCompositeShapeNew(TGeoCompositeShape *cshape, Int_t n_seg)

--- a/graf3d/eve7/src/REveCsgOps.cxx
+++ b/graf3d/eve7/src/REveCsgOps.cxx
@@ -68,17 +68,14 @@
 #include <vector>
 #include <cassert>
 
-
 #include "TBuffer3D.h"
 #include "Rtypes.h"
 #include "TMath.h"
 
-#include <ROOT/REveGeoShape.hxx>
-#include <ROOT/REveUtil.hxx>
+// #include <ROOT/REveGeoShape.hxx>
+// #include <ROOT/REveUtil.hxx>
 
-#include "TBuffer3DTypes.h"
-#include "TGeoBoolNode.h"
-#include "TGeoCompositeShape.h"
+// #include "TBuffer3DTypes.h"
 #include "TGeoMatrix.h"
 
 
@@ -2736,49 +2733,5 @@ TBaseMesh *BuildDifference(const TBaseMesh *l, const TBaseMesh *r)
    return build_difference(*static_cast<const AMesh_t *>(l), *static_cast<const AMesh_t *>(r), kFALSE);
 }
 
-
-//------------------------------------------------------------------------------
-
-////////////////////////////////////////////////////////////////////////
-/// Function produces mesh for provided shape, applying matrix to the result
-
-std::unique_ptr<TBaseMesh> MakeMesh(TGeoMatrix *matr, TGeoShape *shape)
-{
-   TGeoCompositeShape *comp = dynamic_cast<TGeoCompositeShape *> (shape);
-
-   std::unique_ptr<TBaseMesh> res;
-
-   if (!comp) {
-      std::unique_ptr<TBuffer3D> b3d(shape->MakeBuffer3D());
-      res.reset(EveCsg::ConvertToMesh(*b3d.get(), matr));
-   } else {
-      auto node = comp->GetBoolNode();
-
-      TGeoHMatrix mleft, mright;
-      if (matr) { mleft = *matr; mright = *matr; }
-
-      mleft.Multiply(node->GetLeftMatrix());
-      auto left = MakeMesh(&mleft, node->GetLeftShape());
-
-      mright.Multiply(node->GetRightMatrix());
-      auto right = MakeMesh(&mright, node->GetRightShape());
-
-      if (node->IsA() == TGeoUnion::Class()) res.reset(EveCsg::BuildUnion(left.get(), right.get()));
-      if (node->IsA() == TGeoIntersection::Class()) res.reset(EveCsg::BuildIntersection(left.get(), right.get()));
-      if (node->IsA() == TGeoSubtraction::Class()) res.reset(EveCsg::BuildDifference(left.get(), right.get()));
-   }
-
-   return res;
-}
-
-////////////////////////////////////////////////////////////////////////
-/// Function produces mesh for composite shape
-
-std::unique_ptr<TBaseMesh> BuildFromCompositeShape(TGeoCompositeShape *cshape, Int_t n_seg)
-{
-   REveGeoManagerHolder gmgr(REveGeoShape::GetGeoManager(), n_seg);
-
-   return MakeMesh(nullptr, cshape);
-}
 
 }}}

--- a/graf3d/eve7/src/REveCsgOps.cxx
+++ b/graf3d/eve7/src/REveCsgOps.cxx
@@ -2820,7 +2820,7 @@ Int_t TCsgVV3D::AddObject(const TBuffer3D& buffer, Bool_t* addChildren)
 {
    if (fCompositeOpen)
    {
-      auto newMesh = ConvertToMesh(buffer);
+      auto newMesh = ConvertToMesh(buffer, nullptr);
       fCSTokens.push_back(std::make_pair(TBuffer3D::kCSNoOp, newMesh));
    }
 
@@ -2971,10 +2971,9 @@ std::unique_ptr<TBaseMesh> MakeMesh(TGeoMatrix *matr, TGeoShape *shape)
    return res;
 }
 
-TBaseMesh *BuildFromCompositeShapeNew(TGeoCompositeShape *cshape, Int_t n_seg)
+std::unique_ptr<TBaseMesh> BuildFromCompositeShapeNew(TGeoCompositeShape *cshape, Int_t n_seg)
 {
-   auto res = MakeMesh(nullptr, cshape);
-   return res.release();
+   return MakeMesh(nullptr, cshape);
 }
 
 

--- a/graf3d/eve7/src/REveCsgOps.cxx
+++ b/graf3d/eve7/src/REveCsgOps.cxx
@@ -66,6 +66,8 @@
 
 #include <algorithm>
 #include <vector>
+#include <cassert>
+
 
 #include "TBuffer3D.h"
 #include "Rtypes.h"
@@ -2968,10 +2970,9 @@ std::unique_ptr<TBaseMesh> MakeMesh(TGeoMatrix *matr, TGeoShape *shape)
    return res;
 }
 
-std::unique_ptr<TBaseMesh> BuildFromCompositeShapeNew(TGeoCompositeShape *cshape, Int_t n_seg)
+std::unique_ptr<TBaseMesh> BuildFromCompositeShapeNew(TGeoCompositeShape *cshape, Int_t)
 {
    return MakeMesh(nullptr, cshape);
 }
-
 
 }}}

--- a/graf3d/eve7/src/REveElement.cxx
+++ b/graf3d/eve7/src/REveElement.cxx
@@ -27,6 +27,8 @@
 #include "TColor.h"
 
 #include "json.hpp"
+#include <cassert>
+
 
 #include <algorithm>
 

--- a/graf3d/eve7/src/REveGeoPolyShape.cxx
+++ b/graf3d/eve7/src/REveGeoPolyShape.cxx
@@ -163,16 +163,16 @@ void REveGeoPolyShape::SetFromBuff3D(const TBuffer3D& buffer)
       segmentInd--;
       Int_t segEnds[] = {segs[s1 * 3 + 1], segs[s1 * 3 + 2],
                          segs[s2 * 3 + 1], segs[s2 * 3 + 2]};
-      Int_t numPnts[3] = {0};
+      Int_t numPnts[3];
 
       if (segEnds[0] == segEnds[2]) {
-         numPnts[0] = segEnds[1], numPnts[1] = segEnds[0], numPnts[2] = segEnds[3];
+         numPnts[0] = segEnds[1]; numPnts[1] = segEnds[0]; numPnts[2] = segEnds[3];
       } else if (segEnds[0] == segEnds[3]) {
-         numPnts[0] = segEnds[1], numPnts[1] = segEnds[0], numPnts[2] = segEnds[2];
+         numPnts[0] = segEnds[1]; numPnts[1] = segEnds[0]; numPnts[2] = segEnds[2];
       } else if (segEnds[1] == segEnds[2]) {
-         numPnts[0] = segEnds[0], numPnts[1] = segEnds[1], numPnts[2] = segEnds[3];
+         numPnts[0] = segEnds[0]; numPnts[1] = segEnds[1]; numPnts[2] = segEnds[3];
       } else {
-         numPnts[0] = segEnds[0], numPnts[1] = segEnds[1], numPnts[2] = segEnds[2];
+         numPnts[0] = segEnds[0]; numPnts[1] = segEnds[1]; numPnts[2] = segEnds[2];
       }
 
       fPolyDesc[currInd] = 3;
@@ -319,7 +319,7 @@ void REveGeoPolyShape::FillBuffer3D(TBuffer3D& b, Int_t reqSections, Bool_t) con
       b.SetSectionsValid(TBuffer3D::kCore);
    }
 
-   if (reqSections & TBuffer3D::kRawSizes || reqSections & TBuffer3D::kRaw)
+   if ((reqSections & TBuffer3D::kRawSizes) || (reqSections & TBuffer3D::kRaw))
    {
       Int_t nvrt = fVertices.size() / 3;
       Int_t nseg = 0;

--- a/graf3d/eve7/src/REveGeoPolyShape.cxx
+++ b/graf3d/eve7/src/REveGeoPolyShape.cxx
@@ -10,6 +10,8 @@
  *************************************************************************/
 
 #include "Rtypes.h"
+#include <cassert>
+
 
 #include <ROOT/REveGeoPolyShape.hxx>
 #include <ROOT/REveGeoShape.hxx>
@@ -21,7 +23,6 @@
 #include "TBuffer3D.h"
 #include "TBuffer3DTypes.h"
 
-#include "TList.h"
 #include "TGeoBoolNode.h"
 #include "TGeoCompositeShape.h"
 #include "TGeoMatrix.h"

--- a/graf3d/eve7/src/REveGeoPolyShape.cxx
+++ b/graf3d/eve7/src/REveGeoPolyShape.cxx
@@ -66,7 +66,7 @@ REveGeoPolyShape* REveGeoPolyShape::Construct(TGeoCompositeShape *cshape, Int_t 
    egps->fDY = cshape->GetDY();
    egps->fDZ = cshape->GetDZ();
 
-   auto mesh = EveCsg::BuildFromCompositeShapeNew(cshape, n_seg);
+   auto mesh = EveCsg::BuildFromCompositeShape(cshape, n_seg);
    egps->SetFromMesh(mesh.get());
 
    return egps;

--- a/graf3d/eve7/src/REveGeoPolyShape.cxx
+++ b/graf3d/eve7/src/REveGeoPolyShape.cxx
@@ -65,7 +65,7 @@ REveGeoPolyShape* REveGeoPolyShape::Construct(TGeoCompositeShape *cshape, Int_t 
    egps->fDY = cshape->GetDY();
    egps->fDZ = cshape->GetDZ();
 
-   EveCsg::TBaseMesh *mesh = EveCsg::BuildFromCompositeShape(cshape, n_seg);
+   EveCsg::TBaseMesh *mesh = EveCsg::BuildFromCompositeShapeNew(cshape, n_seg);
    egps->SetFromMesh(mesh);
    delete mesh;
 

--- a/graf3d/eve7/src/REveGeoPolyShape.cxx
+++ b/graf3d/eve7/src/REveGeoPolyShape.cxx
@@ -65,9 +65,8 @@ REveGeoPolyShape* REveGeoPolyShape::Construct(TGeoCompositeShape *cshape, Int_t 
    egps->fDY = cshape->GetDY();
    egps->fDZ = cshape->GetDZ();
 
-   EveCsg::TBaseMesh *mesh = EveCsg::BuildFromCompositeShapeNew(cshape, n_seg);
-   egps->SetFromMesh(mesh);
-   delete mesh;
+   auto mesh = EveCsg::BuildFromCompositeShapeNew(cshape, n_seg);
+   egps->SetFromMesh(mesh.get());
 
    return egps;
 }

--- a/graf3d/eve7/src/REveGeoShape.cxx
+++ b/graf3d/eve7/src/REveGeoShape.cxx
@@ -132,7 +132,7 @@ REveGeoShape::~REveGeoShape()
 
 TGeoShape* REveGeoShape::MakePolyShape()
 {
-   return REveGeoPolyShape::Construct(fCompositeShape, fNSegments);
+   return new REveGeoPolyShape(fCompositeShape, fNSegments);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf3d/eve7/src/REveGeoShape.cxx
+++ b/graf3d/eve7/src/REveGeoShape.cxx
@@ -53,7 +53,7 @@ namespace
       TGeoIdentity *old_id = gGeoIdentity;
       gGeoManager = 0;
       TGeoManager* mgr = new TGeoManager();
-      mgr->SetNameTitle("REveGeoShape::fgGeoMangeur",
+      mgr->SetNameTitle("REveGeoShape::fgGeoManager",
                         "Static geo manager used for wrapped TGeoShapes.");
       gGeoIdentity = new TGeoIdentity("Identity");
       gGeoManager  = old;
@@ -83,7 +83,7 @@ it gets forwarded to geo-manager and this tesselation detail is
 used when creating the buffer passed to GL.
 */
 
-TGeoManager* REX::REveGeoShape::fgGeoMangeur = init_geo_mangeur();
+TGeoManager* REX::REveGeoShape::fgGeoManager = init_geo_mangeur();
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return static geo-manager that is used internally to make shapes
@@ -91,9 +91,9 @@ TGeoManager* REX::REveGeoShape::fgGeoMangeur = init_geo_mangeur();
 /// Set gGeoManager to this object when creating TGeoShapes to be
 /// passed into EveGeoShapes.
 
-TGeoManager* REveGeoShape::GetGeoMangeur()
+TGeoManager* REveGeoShape::GetGeoManager()
 {
-   return fgGeoMangeur;
+   return fgGeoManager;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -163,7 +163,7 @@ void REveGeoShape::BuildRenderData()
 
    } else {
 
-      REveGeoManagerHolder gmgr(fgGeoMangeur, fNSegments);
+      REveGeoManagerHolder gmgr(fgGeoManager, fNSegments);
 
       std::unique_ptr<TBuffer3D> b3d(fShape->MakeBuffer3D());
 
@@ -203,7 +203,7 @@ void REveGeoShape::SetNSegments(Int_t s)
 
 void REveGeoShape::SetShape(TGeoShape *s)
 {
-   REveGeoManagerHolder gmgr(fgGeoMangeur);
+   REveGeoManagerHolder gmgr(fgGeoManager);
 
    if (fCompositeShape) {
       delete fShape;
@@ -257,7 +257,7 @@ void REveGeoShape::Paint(Option_t* /*option*/)
    if (!fShape)
       return;
 
-   REveGeoManagerHolder gmgr(fgGeoMangeur, fNSegments);
+   REveGeoManagerHolder gmgr(fgGeoManager, fNSegments);
 
    if (fCompositeShape)
    {
@@ -406,7 +406,7 @@ REveGeoShapeExtract* REveGeoShape::DumpShapeTree(REveGeoShape* gsre,
 REveGeoShape* REveGeoShape::ImportShapeExtract(REveGeoShapeExtract* gse,
                                                REveElement*         parent)
 {
-   REveGeoManagerHolder gmgr(fgGeoMangeur);
+   REveGeoManagerHolder gmgr(fgGeoManager);
    REveManager::RRedrawDisabler redrawOff(REX::gEve);
    REveGeoShape* gsre = SubImportShapeExtract(gse, parent);
    gsre->ElementChanged();
@@ -475,7 +475,7 @@ std::unique_ptr<TBuffer3D> REveGeoShape::MakeBuffer3D()
       return buff;
    }
 
-   REveGeoManagerHolder gmgr(fgGeoMangeur, fNSegments);
+   REveGeoManagerHolder gmgr(fgGeoManager, fNSegments);
 
    buff.reset(fShape->MakeBuffer3D());
    REveTrans &mx    = RefMainTrans();

--- a/graf3d/eve7/src/REvePointSet.cxx
+++ b/graf3d/eve7/src/REvePointSet.cxx
@@ -16,10 +16,6 @@
 #include <ROOT/REveTrans.hxx>
 #include <ROOT/REveRenderData.hxx>
 
-#include "TTree.h"
-#include "TTreePlayer.h"
-#include "TF3.h"
-
 #include "TColor.h"
 
 #include "json.hpp"

--- a/graf3d/eve7/src/REvePolygonSetProjected.cxx
+++ b/graf3d/eve7/src/REvePolygonSetProjected.cxx
@@ -21,6 +21,7 @@
 #include "TVirtualViewer3D.h"
 
 #include "json.hpp"
+#include <cassert>
 
 
 using namespace ROOT::Experimental;

--- a/graf3d/eve7/src/REveScene.cxx
+++ b/graf3d/eve7/src/REveScene.cxx
@@ -18,6 +18,7 @@
 #include <ROOT/RWebWindow.hxx>
 
 #include "json.hpp"
+#include <cassert>
 
 
 using namespace ROOT::Experimental;

--- a/graf3d/eve7/src/REveSelection.cxx
+++ b/graf3d/eve7/src/REveSelection.cxx
@@ -287,8 +287,8 @@ void REveSelection::DeactivateSelection()
 
 REveElement* REveSelection::MapPickedToSelected(REveElement* el)
 {
-   if (el == 0)
-      return 0;
+   if (el == nullptr)
+      return nullptr;
 
    if (el->ForwardSelection())
    {
@@ -299,7 +299,7 @@ REveElement* REveSelection::MapPickedToSelected(REveElement* el)
    {
       case kPS_Ignore:
       {
-         return 0;
+         return nullptr;
       }
       case kPS_Element:
       {

--- a/graf3d/eve7/src/REveTrackPropagator.cxx
+++ b/graf3d/eve7/src/REveTrackPropagator.cxx
@@ -15,8 +15,6 @@
 
 #include "TMath.h"
 
-#include <cassert>
-
 using namespace ROOT::Experimental;
 namespace REX = ROOT::Experimental;
 

--- a/graf3d/eve7/src/REveTreeTools.cxx
+++ b/graf3d/eve7/src/REveTreeTools.cxx
@@ -114,7 +114,7 @@ Long64_t REvePointSelector::Select(const char* selection)
 ////////////////////////////////////////////////////////////////////////////////
 /// Process tree 't', select points matching 'selection'.
 
-Long64_t REvePointSelector::Select(TTree* t, const char* selection)
+Long64_t REvePointSelector::Select(TTree *t, const char *selection)
 {
    fTree = t;
    return Select(selection);

--- a/graf3d/eve7/src/REveUtil.cxx
+++ b/graf3d/eve7/src/REveUtil.cxx
@@ -24,7 +24,6 @@
 
 #include "TROOT.h"
 #include "TInterpreter.h"
-#include "TVirtualPad.h"
 #include "TSystem.h"
 
 #include "TGClient.h"
@@ -364,37 +363,6 @@ REveException REX::operator+(const REveException &s1,  const char *s2)
 { REveException r(s1); r += s2; return r; }
 
 
-/** \class REvePadHolder
-\ingroup REve
-Exception safe wrapper for setting gPad.
-Optionally calls gPad->Modified()/Update() in destructor.
-*/
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor.
-
-REvePadHolder::REvePadHolder(Bool_t modify_update_p, TVirtualPad* new_pad, Int_t subpad) :
-   fOldPad        (gPad),
-   fModifyUpdateP (modify_update_p)
-{
-   if (new_pad != 0)
-      new_pad->cd(subpad);
-   else
-      gPad = 0;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Destructor.
-
-REvePadHolder::~REvePadHolder()
-{
-   if (fModifyUpdateP && gPad != 0) {
-      gPad->Modified();
-      gPad->Update();
-   }
-   gPad = fOldPad;
-}
-
 /** \class REveGeoManagerHolder
 \ingroup REve
 Exception safe wrapper for setting gGeoManager.
@@ -423,7 +391,7 @@ REveGeoManagerHolder::REveGeoManagerHolder(TGeoManager* new_gmgr, Int_t n_seg) :
    }
    else
    {
-      gGeoIdentity = 0;
+      gGeoIdentity = nullptr;
    }
 }
 
@@ -443,7 +411,7 @@ REveGeoManagerHolder::~REveGeoManagerHolder()
    }
    else
    {
-      gGeoIdentity = 0;
+      gGeoIdentity = nullptr;
    }
 }
 


### PR DESCRIPTION
Previous solution from Matevz (@osschar) was using gPad and TVirtualViewer3D - forcing to link complete libGpad for that.
Now composite shape created directly using REveCsgOps function.
Prepare code to use normal CsgOps which is now identical with REveCsgOps