### PR TITLE
[ROOT-9859] Fall-back to __repr__ in __str__ if cling returns an address

### DIFF
--- a/bindings/pyroot/src/Pythonize.cxx
+++ b/bindings/pyroot/src/Pythonize.cxx
@@ -2275,7 +2275,9 @@ namespace {
       if (printResult.find("@0x") == 0) {
          // Fall back to __repr__ if we just get an address from cling
          auto method = PyObject_GetAttrString((PyObject*)self, "__repr__");
-         return PyObject_CallObject(method, nullptr);
+         auto res = PyObject_CallObject(method, nullptr);
+         Py_DECREF(method);
+         return res;
       } else {
          return PyROOT_PyUnicode_FromString(printResult.c_str());
       }

--- a/bindings/pyroot/src/Pythonize.cxx
+++ b/bindings/pyroot/src/Pythonize.cxx
@@ -2272,7 +2272,13 @@ namespace {
       Py_XDECREF(cppname);
 
       std::string printResult = gInterpreter->ToString(className.c_str(), self->GetObject());
-      return PyROOT_PyUnicode_FromString(printResult.c_str());
+      if (printResult.find("@0x") == 0) {
+         // Fall back to __repr__ if we just get an address from cling
+         auto method = PyObject_GetAttrString((PyObject*)self, "__repr__");
+         return PyObject_CallObject(method, nullptr);
+      } else {
+         return PyROOT_PyUnicode_FromString(printResult.c_str());
+      }
    }
 
    //- Adding array interface to classes ---------------

--- a/bindings/pyroot/test/pretty_printing.py
+++ b/bindings/pyroot/test/pretty_printing.py
@@ -55,7 +55,10 @@ class PrettyPrinting(unittest.TestCase):
         ROOT.gInterpreter.Declare('class MyClass {};')
         x = ROOT.MyClass()
         self._print(x)
-        self.assertIn("MyClass object at", x.__str__())
+        s = x.__str__()
+        r = x.__repr__()
+        self.assertIn("MyClass object at", s)
+        self.assertEqual(s, r)
 
 
 if __name__ == '__main__':

--- a/bindings/pyroot/test/pretty_printing.py
+++ b/bindings/pyroot/test/pretty_printing.py
@@ -50,6 +50,13 @@ class PrettyPrinting(unittest.TestCase):
         self._print(x)
         self.assertEqual("Name: name Title: title NbinsX: 10", x.__str__())
 
+    def test_user_class(self):
+        # Test fall-back to __repr__
+        ROOT.gInterpreter.Declare('class MyClass {};')
+        x = ROOT.MyClass()
+        self._print(x)
+        self.assertIn("MyClass object at", x.__str__())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/bindings/pyroot_experimental/PyROOT/src/GenericPyz.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/GenericPyz.cxx
@@ -30,7 +30,9 @@ PyObject *ClingPrintValue(CPPInstance *self)
    if (printResult.find("@0x") == 0) {
       // Fall back to __repr__ if we just get an address from cling
       auto method = PyObject_GetAttrString((PyObject*)self, "__repr__");
-      return PyObject_CallObject(method, nullptr);
+      auto res = PyObject_CallObject(method, nullptr);
+      Py_DECREF(method);
+      return res;
    } else {
       return CPyCppyy_PyUnicode_FromString(printResult.c_str());
    }

--- a/bindings/pyroot_experimental/PyROOT/src/GenericPyz.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/GenericPyz.cxx
@@ -27,7 +27,13 @@ PyObject *ClingPrintValue(CPPInstance *self)
 {
    const std::string className = GetCppName(self);
    auto printResult = gInterpreter->ToString(className.c_str(), self->GetObject());
-   return CPyCppyy_PyUnicode_FromString(printResult.c_str());
+   if (printResult.find("@0x") == 0) {
+      // Fall back to __repr__ if we just get an address from cling
+      auto method = PyObject_GetAttrString((PyObject*)self, "__repr__");
+      return PyObject_CallObject(method, nullptr);
+   } else {
+      return CPyCppyy_PyUnicode_FromString(printResult.c_str());
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/bindings/pyroot_experimental/PyROOT/src/GenericPyz.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/GenericPyz.cxx
@@ -1,4 +1,4 @@
-// Author: Stefan Wunsch CERN  06/2018
+// Author: Stefan Wunsch, Enric Tejedor CERN  06/2018
 // Original PyROOT code by Wim Lavrijsen, LBL
 
 /*************************************************************************
@@ -16,9 +16,6 @@
 #include "TInterpreter.h"
 #include "TInterpreterValue.h"
 
-#include <sstream>
-#include <algorithm>
-
 using namespace CPyCppyy;
 
 std::string GetCppName(CPPInstance *self)
@@ -29,15 +26,8 @@ std::string GetCppName(CPPInstance *self)
 PyObject *ClingPrintValue(CPPInstance *self)
 {
    const std::string className = GetCppName(self);
-   std::stringstream code;
-   code << "*((" << className << "*)" << self->GetObject() << ")";
-
-   auto value = gInterpreter->MakeInterpreterValue();
-   std::string pprint = "";
-   if (gInterpreter->Evaluate(code.str().c_str(), *value) == 1 /*success*/)
-      pprint = value->ToTypeAndValueString().second;
-   pprint.erase(std::remove(pprint.begin(), pprint.end(), '\n'), pprint.end());
-   return CPyCppyy_PyUnicode_FromString(pprint.c_str());
+   auto printResult = gInterpreter->ToString(className.c_str(), self->GetObject());
+   return CPyCppyy_PyUnicode_FromString(printResult.c_str());
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/bindings/pyroot_experimental/PyROOT/test/pretty_printing.py
+++ b/bindings/pyroot_experimental/PyROOT/test/pretty_printing.py
@@ -45,7 +45,11 @@ class PrettyPrinting(unittest.TestCase):
         ROOT.gInterpreter.Declare('class MyClass {};')
         x = ROOT.MyClass()
         self._print(x)
-        self.assertIn("MyClass object at", x.__str__())
+        s = x.__str__()
+        r = x.__repr__()
+        self.assertIn("MyClass object at", s)
+        self.assertEqual(s, r)
+
 
     # TNamed and TObject are not pythonized because these object are touched
     # by PyROOT before any pythonizations are added. Following, the classes

--- a/bindings/pyroot_experimental/PyROOT/test/pretty_printing.py
+++ b/bindings/pyroot_experimental/PyROOT/test/pretty_printing.py
@@ -40,6 +40,13 @@ class PrettyPrinting(unittest.TestCase):
         self._print(x)
         self.assertEqual("Name: name Title: title NbinsX: 10", x.__str__())
 
+    def test_user_class(self):
+        # Test fall-back to __repr__
+        ROOT.gInterpreter.Declare('class MyClass {};')
+        x = ROOT.MyClass()
+        self._print(x)
+        self.assertIn("MyClass object at", x.__str__())
+
     # TNamed and TObject are not pythonized because these object are touched
     # by PyROOT before any pythonizations are added. Following, the classes
     # are not piped through the pythonizor functions again.

--- a/tutorials/pyroot/pyroot003_prettyPrinting.py
+++ b/tutorials/pyroot/pyroot003_prettyPrinting.py
@@ -9,7 +9,7 @@
 ## \macro_code
 ##
 ## \date June 2018
-## \author Stefan Wunsch
+## \author Stefan Wunsch, Enric Tejedor
 
 import ROOT
 
@@ -36,3 +36,11 @@ obj
 # The print output behaves similar to the ROOT prompt, e.g., here for a ROOT histogram.
 hist = ROOT.TH1F("name", "title", 10, 0, 1)
 print(hist)
+
+# If cling cannot produce any nice representation for the class, we fall back to a
+# "<ClassName at address>" format, which is what `__repr__` returns
+ROOT.gInterpreter.Declare('class MyClass {};')
+m = ROOT.MyClass()
+print(m)
+print(str(m) == repr(m))
+


### PR DESCRIPTION
This PR addresses the report in [ROOT-9859](https://sft.its.cern.ch/jira/browse/ROOT-9859) about the change in behaviour of `__str__`, which now relies on cling to obtain a pretty printing for a class.

With this PR, if what we obtain from cling is not pretty but just an address, we fall back to `__repr__` in `__str__`. The PR contains the changes for both current and experimental PyROOT, together with their respective tests and tutorials.