### PR TITLE
[DF][ROOT-9865][ROOT-9860] Handle snapshot of C arrays drastically changing ther size

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1067,9 +1067,10 @@ public:
       // With this code, we set the value of the pointer in the output branch anew when needed.
       // Nota bene: the extra ",0" after the invocation of SetAddress, is because that method returns void and 
       // we need an int for the expander list.
-      int expander[] = {
-         (fBranches[S] && fBranchAddresses[S] != GetData(values) ? fBranches[S]->SetAddress(GetData(values)),0 : 0, 0)...,
-         0};
+      int expander[] = {(fBranches[S] && fBranchAddresses[S] != GetData(values)
+                         ? fBranches[S]->SetAddress(GetData(values)),
+                         fBranchAddresses[S] = GetData(values), 0 : 0, 0)...,
+                        0};
       (void)expander; // avoid unused variable warnings for older compilers such as gcc 4.9
    }
 
@@ -1227,9 +1228,8 @@ public:
       // Nota bene: the extra ",0" after the invocation of SetAddress, is because that method returns void and
       // we need an int for the expander list.
       int expander[] = {(fBranches[slot][S] && fBranchAddresses[slot][S] != GetData(values)
-                            ? fBranches[slot][S]->SetAddress(GetData(values)),0
-                            : 0,
-                         0)...,
+                         ? fBranches[slot][S]->SetAddress(GetData(values)),
+                         fBranchAddresses[slot][S] = GetData(values), 0 : 0, 0)...,
                         0};
       (void)expander; // avoid unused variable warnings for older compilers such as gcc 4.9
    }

--- a/tree/dataframe/test/dataframe_snapshot.cxx
+++ b/tree/dataframe/test/dataframe_snapshot.cxx
@@ -458,6 +458,13 @@ void ReadWriteCarray(const char *outFileNameBase)
    t.Branch("vb", vb, "vb[size]/O");
    
    // Size 1
+   size = 1;
+   v[0] = 12;
+   vb[0] = true;
+   t.Fill();
+
+   // Size 0 (see ROOT-9860)
+   size = 0;
    t.Fill();
 
    // Size 100k: this reallocates!
@@ -469,7 +476,7 @@ void ReadWriteCarray(const char *outFileNameBase)
    t.Fill();
 
    // Size 3
-   size = 3U;
+   size = 3;
    v[0] = 42;
    v[1] = 43;
    v[2] = 44;
@@ -487,6 +494,13 @@ void ReadWriteCarray(const char *outFileNameBase)
       TTreeReader r(treename, &f2);
       TTreeReaderArray<int> rv(r, "v");
       TTreeReaderArray<bool> rvb(r, "vb");
+
+      // Size 1
+      r.Next();
+      EXPECT_EQ(rv.GetSize(), 1u);
+      EXPECT_EQ(rv[0], 12);
+      EXPECT_EQ(rvb.GetSize(), 1u);
+      EXPECT_TRUE(rvb[0]);
 
       // Size 0
       r.Next();


### PR DESCRIPTION
from one entry to another.
It can happen that the size of C arrays stored in branches varies a lot
from event to event. It can happen also that a very small array becomes
suddently very big. This triggers a reallocation of the buffer ROOT
uses internally to hold the read content.
When snapshotting, RDataFrame, was setting the addresses of the output
tree only once at the 1st event processed (per slot). This of course could
lead to the persistification of corrupted values.

This change allow to keep track of the changing addresses and properly
handle them via the TBranch::SetAddress method.

A test is also added to the suite in order to avoid regressions in the
future.

Nota bene: this **does also** fix ROOT-9860
