### PR TITLE
webgui: add possibility to record data, transferred via web socket

### DIFF
--- a/gui/webdisplay/inc/ROOT/RWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindow.hxx
@@ -124,6 +124,10 @@ private:
    unsigned fWidth{0};                              ///<! initial window width when displayed
    unsigned fHeight{0};                             ///<! initial window height when displayed
    float fOperationTmout{50.};                      ///<! timeout in seconds to perform synchronous operation, default 50s
+   std::string fProtocolFileName;                   ///<! local file where communication protocol will be written
+   int fProtocolCnt{-1};                            ///<! counter for protocol recording
+   unsigned fProtocolConnId{0};                     ///<! connection id, which is used for writing protocol
+   std::string fProtocol;                           ///<! protocol
 
    std::shared_ptr<RWebWindowWSHandler> CreateWSHandler(std::shared_ptr<RWebWindowsManager> mgr, unsigned id, double tmout);
 
@@ -220,7 +224,6 @@ public:
    /// returns true if only native (own-created) connections are allowed
    bool IsNativeOnlyConn() const { return fNativeOnlyConn; }
 
-   /// Returns current number of active clients connections
    int NumConnections();
 
    unsigned GetConnectionId(int num = 0);
@@ -265,6 +268,8 @@ public:
    void SendBinary(unsigned connid, const void *data, std::size_t len);
 
    void SendBinary(unsigned connid, std::string &&data);
+
+   void RecordData(const std::string &fname = "protocol.json");
 
    std::string RelativeAddr(std::shared_ptr<RWebWindow> &win);
 

--- a/gui/webdisplay/inc/ROOT/RWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindow.hxx
@@ -127,6 +127,7 @@ private:
    std::string fProtocolFileName;                   ///<! local file where communication protocol will be written
    int fProtocolCnt{-1};                            ///<! counter for protocol recording
    unsigned fProtocolConnId{0};                     ///<! connection id, which is used for writing protocol
+   std::string fProtocolPrefix;                     ///<! prefix for created files names
    std::string fProtocol;                           ///<! protocol
 
    std::shared_ptr<RWebWindowWSHandler> CreateWSHandler(std::shared_ptr<RWebWindowsManager> mgr, unsigned id, double tmout);
@@ -269,7 +270,7 @@ public:
 
    void SendBinary(unsigned connid, std::string &&data);
 
-   void RecordData(const std::string &fname = "protocol.json");
+   void RecordData(const std::string &fname = "protocol.json", const std::string &fprefix = "");
 
    std::string RelativeAddr(std::shared_ptr<RWebWindow> &win);
 

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -586,17 +586,20 @@ bool ROOT::Experimental::RWebWindow::ProcessWS(THttpCallArg &arg)
       conn->fRecvStamp = stamp;
    }
 
-   if (fProtocolCnt>=0)
+   if (fProtocolCnt >= 0)
       if (!fProtocolConnId || (conn->fConnId == fProtocolConnId)) {
          fProtocolConnId = conn->fConnId; // remember connection
 
-         if (fProtocol.length()>2)
-            fProtocol.insert(fProtocol.length()-1,",");
-         fProtocol.insert(fProtocol.length()-1, "\"send\"");
+         // record send event only for normal channel or very first message via ch0
+         if ((nchannel != 0) || (cdata.find("READY=") == 0)) {
+            if (fProtocol.length() > 2)
+               fProtocol.insert(fProtocol.length() - 1, ",");
+            fProtocol.insert(fProtocol.length() - 1, "\"send\"");
 
-         std::ofstream pfs(fProtocolFileName);
-         pfs.write(fProtocol.c_str(), fProtocol.length());
-         pfs.close();
+            std::ofstream pfs(fProtocolFileName);
+            pfs.write(fProtocol.c_str(), fProtocol.length());
+            pfs.close();
+         }
       }
 
    if (nchannel == 0) {
@@ -966,7 +969,7 @@ void ROOT::Experimental::RWebWindow::SubmitData(unsigned connid, bool txt, std::
 
    for (auto &&conn : arr) {
 
-      if (fProtocolCnt>=0)
+      if (fProtocolCnt >= 0)
          if (!fProtocolConnId || (conn->fConnId == fProtocolConnId)) {
             fProtocolConnId = conn->fConnId; // remember connection
             std::string fname = fProtocolPrefix;
@@ -978,9 +981,9 @@ void ROOT::Experimental::RWebWindow::SubmitData(unsigned connid, bool txt, std::
             ofs.write(data.c_str(), data.length());
             ofs.close();
 
-            if (fProtocol.length()>2)
-               fProtocol.insert(fProtocol.length()-1,",");
-            fProtocol.insert(fProtocol.length()-1, std::string("\"") + fname + std::string("\""));
+            if (fProtocol.length() > 2)
+               fProtocol.insert(fProtocol.length() - 1, ",");
+            fProtocol.insert(fProtocol.length() - 1, std::string("\"") + fname + std::string("\""));
 
             std::ofstream pfs(fProtocolFileName);
             pfs.write(fProtocol.c_str(), fProtocol.length());

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -28,6 +28,7 @@
 #include <utility>
 #include <assert.h>
 #include <algorithm>
+#include <fstream>
 
 //////////////////////////////////////////////////////////////////////////////////////////
 /// Destructor for WebConn
@@ -483,7 +484,6 @@ void ROOT::Experimental::RWebWindow::CheckInactiveConnections()
 
 }
 
-
 //////////////////////////////////////////////////////////////////////////////////////////
 /// Processing of websockets call-backs, invoked from RWebWindowWSHandler
 /// Method invoked from http server thread, therefore appropriate mutex must be used on all relevant data
@@ -585,6 +585,19 @@ bool ROOT::Experimental::RWebWindow::ProcessWS(THttpCallArg &arg)
       conn->fClientCredits = (int)can_send;
       conn->fRecvStamp = stamp;
    }
+
+   if (fProtocolCnt>=0)
+      if (!fProtocolConnId || (conn->fConnId == fProtocolConnId)) {
+         fProtocolConnId = conn->fConnId; // remember connection
+
+         if (fProtocol.length()>2)
+            fProtocol.insert(fProtocol.length()-1,",");
+         fProtocol.insert(fProtocol.length()-1, "\"send\"");
+
+         std::ofstream pfs(fProtocolFileName);
+         pfs.write(fProtocol.c_str(), fProtocol.length());
+         pfs.close();
+      }
 
    if (nchannel == 0) {
       // special system channel
@@ -777,7 +790,6 @@ void ROOT::Experimental::RWebWindow::Sync()
    CheckInactiveConnections();
 }
 
-
 ///////////////////////////////////////////////////////////////////////////////////
 /// Returns relative URL address for the specified window
 /// Address can be required if one needs to access data from one window into another window
@@ -796,11 +808,30 @@ std::string ROOT::Experimental::RWebWindow::RelativeAddr(std::shared_ptr<RWebWin
    return res;
 }
 
+///////////////////////////////////////////////////////////////////////////////////
 /// Returns current number of active clients connections
+
 int ROOT::Experimental::RWebWindow::NumConnections()
 {
    std::lock_guard<std::mutex> grd(fConnMutex);
    return fConn.size();
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////
+/// Configures recording of communication data in protocol file
+/// Provided filename will be used to store JSON array with names of written files - text or binary
+/// If data was send from client, "send" entry will be placed. JSON file will look like:
+///    ["send","msg0.txt","send","msg1.txt","msg2.txt"]
+/// If empty file name is provided, data recording will be disabled
+/// Recorded data can be used in JSROOT directly to test client code without running C++ server
+
+void ROOT::Experimental::RWebWindow::RecordData(const std::string &fname)
+{
+   fProtocolFileName = fname;
+   fProtocolCnt = fProtocolFileName.empty() ? -1 : 0;
+   fProtocolConnId = fProtocolFileName.empty() ? 0 : GetConnectionId(0);
+   fProtocol = "[]"; // empty array
 }
 
 ///////////////////////////////////////////////////////////////////////////////////
@@ -813,7 +844,6 @@ unsigned ROOT::Experimental::RWebWindow::GetConnectionId(int num)
    if (num>=(int)fConn.size() || !fConn[num]->fActive) return 0;
    return fConn[num]->fConnId;
 }
-
 
 ///////////////////////////////////////////////////////////////////////////////////
 /// returns true if specified connection id exists
@@ -836,7 +866,6 @@ bool ROOT::Experimental::RWebWindow::HasConnection(unsigned connid, bool only_ac
 
    return false;
 }
-
 
 ///////////////////////////////////////////////////////////////////////////////////
 /// Closes all connection to clients
@@ -935,6 +964,27 @@ void ROOT::Experimental::RWebWindow::SubmitData(unsigned connid, bool txt, std::
    timestamp_t stamp = std::chrono::system_clock::now();
 
    for (auto &&conn : arr) {
+
+      if (fProtocolCnt>=0)
+         if (!fProtocolConnId || (conn->fConnId == fProtocolConnId)) {
+            fProtocolConnId = conn->fConnId; // remember connection
+            std::string fname("msg");
+            fname.append(std::to_string(fProtocolCnt++));
+            fname.append(txt ? ".txt" : ".bin");
+
+            std::ofstream ofs(fname);
+            ofs.write(data.c_str(), data.length());
+            ofs.close();
+
+            if (fProtocol.length()>2)
+               fProtocol.insert(fProtocol.length()-1,",");
+            fProtocol.insert(fProtocol.length()-1, std::string("\"") + fname + std::string("\""));
+
+            std::ofstream pfs(fProtocolFileName);
+            pfs.write(fProtocol.c_str(), fProtocol.length());
+            pfs.close();
+         }
+
       conn->fSendStamp = stamp;
 
       std::lock_guard<std::mutex> grd(conn->fMutex);

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -826,11 +826,12 @@ int ROOT::Experimental::RWebWindow::NumConnections()
 /// If empty file name is provided, data recording will be disabled
 /// Recorded data can be used in JSROOT directly to test client code without running C++ server
 
-void ROOT::Experimental::RWebWindow::RecordData(const std::string &fname)
+void ROOT::Experimental::RWebWindow::RecordData(const std::string &fname, const std::string &fprefix)
 {
    fProtocolFileName = fname;
    fProtocolCnt = fProtocolFileName.empty() ? -1 : 0;
    fProtocolConnId = fProtocolFileName.empty() ? 0 : GetConnectionId(0);
+   fProtocolPrefix = fprefix;
    fProtocol = "[]"; // empty array
 }
 
@@ -968,7 +969,8 @@ void ROOT::Experimental::RWebWindow::SubmitData(unsigned connid, bool txt, std::
       if (fProtocolCnt>=0)
          if (!fProtocolConnId || (conn->fConnId == fProtocolConnId)) {
             fProtocolConnId = conn->fConnId; // remember connection
-            std::string fname("msg");
+            std::string fname = fProtocolPrefix;
+            fname.append("msg");
             fname.append(std::to_string(fProtocolCnt++));
             fname.append(txt ? ".txt" : ".bin");
 

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -268,6 +268,17 @@ std::shared_ptr<ROOT::Experimental::RWebWindow> ROOT::Experimental::RWebWindowsM
 
    auto wshandler = win->CreateWSHandler(Instance(), ++fIdCnt, dflt_tmout);
 
+   if (gEnv->GetValue("WebGui.RecordData", 0) > 0) {
+      std::string fname, prefix;
+      if (fIdCnt > 1) {
+         prefix = std::string("f") + std::to_string(fIdCnt) + "_";
+         fname = std::string("protcol") + std::to_string(fIdCnt) + ".json";
+      } else {
+         fname = "protocol.json";
+      }
+      win->RecordData(fname, prefix);
+   }
+
    fServer->RegisterWS(wshandler);
 
    return win;

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -356,6 +356,7 @@ std::string ROOT::Experimental::RWebWindowsManager::GetUrl(const ROOT::Experimen
 ///   WebGui.FirefoxRandomProfile: usage of random Firefox profile -1 never, 0 - only for batch mode (dflt), 1 - always
 ///   WebGui.LaunchTmout: time required to start process in seconds (default 30 s)
 ///   WebGui.OperationTmout: time required to perform WebWindow operation like execute command or update drawings
+///   WebGui.RecordData: if specified enables data recording for each web window 0 - off, 1 - on
 ///
 ///   Http-server related parameters documented in RWebWindowsManager::CreateServer() method
 


### PR DESCRIPTION
Such data can be used with JSROOT for testing only client side without running of C++
Of course, client is not fully-functional, but many aspects can be tested much-much easier