### PR TITLE
[PyROOT] Make array interface pythonizations lazy

### DIFF
--- a/bindings/pyroot/ROOT.py
+++ b/bindings/pyroot/ROOT.py
@@ -241,23 +241,10 @@ def _TTree__iter__( self ):
 _root.CreateScopeProxy( "TTree" ).__iter__    = _TTree__iter__
 
 # Array interface
-def _proxy__array_interface__(self):
-    getter_array_interface = "_get__array_interface__"
-    if hasattr(self, getter_array_interface):
-        return self._get__array_interface__()
-    else:
-        raise Exception("Class {} does not have method {}.".format(
-            type(self), getter_array_interface))
+def _add__array_interface__(self):
+    self.__array_interface__ = property(self._get__array_interface__)
 
-for pyclass in [
-        "std::vector<{dtype}>",
-        "ROOT::VecOps::RVec<{dtype}>"
-        ]:
-    dtypes = ["float", "double", "int", "unsigned int", "long", "unsigned long"]
-    for dtype in dtypes:
-        class_scope = _root.CreateScopeProxy(pyclass.format(dtype=dtype))
-        class_scope._proxy__array_interface__ = _proxy__array_interface__
-        class_scope.__array_interface__ = property(class_scope._proxy__array_interface__)
+_root._add__array_interface__ = _add__array_interface__
 
 # TTree.AsMatrix functionality
 def _TTreeAsMatrix(self, columns=None, exclude=None, dtype="double", return_labels=False):

--- a/bindings/pyroot/src/Pythonize.cxx
+++ b/bindings/pyroot/src/Pythonize.cxx
@@ -2278,7 +2278,14 @@ namespace {
    //- Adding array interface to classes ---------------
    void AddArrayInterface(PyObject *pyclass, PyCFunction func)
    {
+      // Add a getter for the array interface dict to the class.
       Utility::AddToClass(pyclass, "_get__array_interface__", func, METH_NOARGS);
+      // Add the dictionary as property to the class so that it updates automatically if accessed.
+      // NOTE: Since we are not able to add a property easily from C++, we do this in Python.
+      auto f = PyObject_GetAttrString(gRootModule, "_add__array_interface__");
+      auto r = PyObject_CallFunction(f, (char*)"O", pyclass);
+      Py_DECREF(f);
+      Py_DECREF(r);
    }
 
    template <typename dtype>


### PR DESCRIPTION
This makes the array interface pythonizations truly lazy so that the classes are not touched during `import ROOT`.