### PR TITLE
[ACLiC] Require "no missing symbols", like we do for ROOT (ROOT-9759):

### DIFF
--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -771,9 +771,10 @@ if(WIN32)
   # We cannot use the compiledata.sh script for windows
   configure_file(${CMAKE_SOURCE_DIR}/cmake/scripts/compiledata.win32.in ${CMAKE_BINARY_DIR}/include/compiledata.h NEWLINE_STYLE UNIX)
 else()
+  string(REPLACE "\"" "\\\"" ESCAPED_LINKER_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS} ${CMAKE_SHARED_LINKER_FLAGS}")
   execute_process(COMMAND ${CMAKE_SOURCE_DIR}/build/unix/compiledata.sh ${CMAKE_BINARY_DIR}/include/compiledata.h "${CXX}"
         "${CMAKE_CXX_FLAGS_RELEASE}" "${CMAKE_CXX_FLAGS_DEBUG}" "${CMAKE_CXX_FLAGS}"
-        "${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS}" "${CMAKE_EXE_FLAGS}"
+        "${ESCAPED_LINKER_FLAGS}" "${CMAKE_EXE_FLAGS}"
         "${LibSuffix}" "${SYSLIBS}"
         "${libdir}" "-lCore" "-lRint" "${incdir}" "" "" "${ROOT_ARCHITECTURE}" "" "${explicitlink}" )
 endif()


### PR DESCRIPTION
We pass ROOT's shared library flags to ACLiC.
This includes -Wl,--no-undefined on Linux.
With this flag, ACLiC refuses to build a shared library that uses a missing symbol.
This prevents ROOT-9759, where the missing symbol is only hit at execution time,
too late for it to be handled gracefully.