### PR TITLE
[PyROOT] Fix lazy array interface pythonization for Python 3

### DIFF
--- a/bindings/pyroot/ROOT.py
+++ b/bindings/pyroot/ROOT.py
@@ -242,7 +242,10 @@ _root.CreateScopeProxy( "TTree" ).__iter__    = _TTree__iter__
 
 # Array interface
 def _add__array_interface__(self):
-    self.__array_interface__ = property(self._get__array_interface__)
+    # This proxy fixes attaching the property in Python 3.
+    def _proxy__array_interface__(x):
+        return x._get__array_interface__()
+    self.__array_interface__ = property(_proxy__array_interface__)
 
 _root._add__array_interface__ = _add__array_interface__
 


### PR DESCRIPTION
@etejedor This seems to fix the problem with attaching a property to the class definition. I do not understand why we get an `bad argument to internal function` if we skip the proxy function ...

Edit: These are the test failures: http://cdash.cern.ch/viewTest.php?onlyfailed&buildid=604404