### PR TITLE
Apply fix from ddc88ff2 to voxelized navigation, too

### DIFF
--- a/geom/geom/src/TGeoNavigator.cxx
+++ b/geom/geom/src/TGeoNavigator.cxx
@@ -1177,7 +1177,8 @@ TGeoNode *TGeoNavigator::FindNextDaughterBoundary(Double_t *point, Double_t *dir
          current->cd();
          current->MasterToLocal(point, lpoint);
          current->MasterToLocalVect(dir, ldir);
-         if (current->IsOverlapping() && current->GetVolume()->Contains(lpoint)) continue;
+         if (current->IsOverlapping() && current->GetVolume()->Contains(lpoint) &&
+             current->GetVolume()->GetShape()->Safety(lpoint, kTRUE) > gTolerance) continue;
          snext = current->GetVolume()->GetShape()->DistFromOutside(lpoint, ldir, 3, fStep);
          sumchecked++;
 //         printf("checked %d from %d : snext=%g\n", sumchecked, nd, snext);

--- a/test/stressGeometry.cxx
+++ b/test/stressGeometry.cxx
@@ -159,7 +159,7 @@ const Int_t versions[NG] =  {5, //aleph
                              6, //alice3
                              4, //babar2
                              3, //belle
-                             5}; //atlas
+                             6}; //atlas
 // The timings below are on my machine PIV 3GHz
 const Double_t cp_brun[NG] = {1.9,  //aleph
                               0.1,  //barres


### PR DESCRIPTION
This commit fixes navigation in overlapping nodes when the point is
close to the boundary. See also:
https://root-forum.cern.ch/t/unexpected-navigation-behaviour-with-overlapping-nodes/26618

This is a backport of commit db6a19aa4 from master.