### PR TITLE
[cxxmodules] Don't complain when modulemap for implicit modules has c…

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReader.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReader.cpp
@@ -3528,7 +3528,8 @@ ASTReader::ReadModuleMapFileBlock(RecordData &Record, ModuleFile &F,
 
     // Check the primary module map file.
     const FileEntry *StoredModMap = FileMgr.getFile(F.ModuleMapPath);
-    if (StoredModMap == nullptr || StoredModMap != ModMap) {
+    if (!PP.getPreprocessorOpts().DisablePCHValidation &&
+          (StoredModMap == nullptr || StoredModMap != ModMap)) {
       assert(ModMap && "found module is missing module map file");
       assert(ImportedBy && "top-level import should be verified");
       if ((ClientLoadCapabilities & ARR_OutOfDate) == 0)


### PR DESCRIPTION
…hanged

This patch (also) aims to make runtime module installable.

This part of code in Clang is comparing the location of "modulemap which
is currently loaded and gives a definition of current module (say, stl)
and "the location of the modulemap where the current implicit module (like stl) was built".

This was problematic for CMSSW, as they should install modulemaps
and prebuilt pcms to other directory. stl and libc pcms should be
prebuilt, installed and used from installed directory, so this check is
redundant for that usecase.