### PR TITLE
[cxxmodules] Install all pcms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -411,6 +411,13 @@ else()
   install(DIRECTORY ${CMAKE_BINARY_DIR}/etc/dictpch DESTINATION ${CMAKE_INSTALL_SYSCONFDIR})
 endif()
 
+# FIXME: Add a post-build script where you compare the lib/*.pcm list to the reference, so as not to install random pcms.
+install(
+   DIRECTORY ${CMAKE_BINARY_DIR}/lib/
+   DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   FILES_MATCHING PATTERN "*.pcm"
+)
+
 #---hsimple.root---------(use the executable for clearer dependencies and proper return code)---
 add_custom_target(hsimple ALL DEPENDS tutorials/hsimple.root)
 add_dependencies(hsimple onepcm)


### PR DESCRIPTION
Previously, only pcms which were generated by rootcling was installed.
For example, stl.pcm and _Builtin_intrinsics.pcm were not copied to
install directory and was implicitly build to
/tmp/org.llvm.clang.yuka../ at runtime. This behavior is not what we
want, we want all our root related pcms to be prebuilt and just be
installed and used from that location.