### PR TITLE
[ROOT-9872] Enable nested namespace when loading enum fwdDecls

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1872,8 +1872,8 @@ void TCling::RegisterModule(const char* modulename,
                   while (nsPos < enumPos && nsPos != std::string::npos) {
                      // we have a namespace, let's put it in the collection of scopes
                      const auto nsNameStart = nsPos + 10;
-                     const auto nsNameEnd = fwdDeclsLine.find('{', nsNameStart) - nsNameStart;
-                     const auto nsName = fwdDeclsLine.substr(nsNameStart, nsNameEnd);
+                     const auto nsNameEnd = fwdDeclsLine.find('{', nsNameStart);
+                     const auto nsName = fwdDeclsLine.substr(nsNameStart, nsNameEnd - nsNameStart);
                      scopes.push_back(nsName);
                      nsPos = fwdDeclsLine.find("namespace", nsNameEnd);
                   }


### PR DESCRIPTION
When building with CMSSW, root was being in an infinite loop when
parsing this forward declaration at TCling::RegisterModule:
`namespace reco{namespace btau{enum  __attribute__((annotate(\"$clingAutoload$DataFormats/BTauReco/interface/TaggingVariable.h\"))) TaggingVariableName : unsigned int;}}`

This patch fixes the bug which nsPos was always the size of namespace
name (4, in this case)