### PR TITLE
[ROOT-9876] Fix crash introduced by the lazy array interface if cppyy…

### DIFF
--- a/bindings/pyroot/src/Pythonize.cxx
+++ b/bindings/pyroot/src/Pythonize.cxx
@@ -2289,8 +2289,11 @@ namespace {
       // Add a getter for the array interface dict to the class.
       Utility::AddToClass(pyclass, "_get__array_interface__", func, METH_NOARGS);
       // Add the dictionary as property to the class so that it updates automatically if accessed.
-      // NOTE: Since we are not able to add a property easily from C++, we do this in Python.
+      // Since we are not able to add a property easily from C++, we do this in Python.
       auto f = PyObject_GetAttrString(gRootModule, "_add__array_interface__");
+      // In case cppyy is not invoked through PyROOT and the above callable is not found,
+      // we return early and don't add the property.
+      if (!f) return;
       auto r = PyObject_CallFunction(f, (char*)"O", pyclass);
       Py_DECREF(f);
       Py_DECREF(r);


### PR DESCRIPTION
… is not invoked through import ROOT

Fixes following JIRA tickets:

1. https://sft.its.cern.ch/jira/projects/ROOT/issues/ROOT-9876
2. https://sft.its.cern.ch/jira/browse/CORALCOOL-3028