### PR TITLE
[DF] Use spin mutex in RSlotStack instead of rw-spin lock

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RSlotStack.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RSlotStack.hxx
@@ -11,11 +11,11 @@
 #ifndef ROOT_RSLOTSTACK
 #define ROOT_RSLOTSTACK
 
-#include "ROOT/TRWSpinLock.hxx"
-
+#include <memory>
 #include <stack>
 
 namespace ROOT {
+class TSpinMutex;
 namespace Internal {
 namespace RDF {
 
@@ -27,7 +27,7 @@ class RSlotStack {
 private:
    const unsigned int fSize;
    std::stack<unsigned int> fStack;
-   ROOT::TRWSpinLock fRWLock;
+   std::unique_ptr<ROOT::TSpinMutex> fMutexPtr;
 
 public:
    RSlotStack() = delete;

--- a/tree/dataframe/inc/ROOT/RDF/RSlotStack.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RSlotStack.hxx
@@ -35,8 +35,8 @@ public:
    void ReturnSlot(unsigned int slotNumber);
    unsigned int GetSlot();
 };
-} // ns RDF
-} // ns Internal
-} // ns ROOT
+} // namespace RDF
+} // namespace Internal
+} // namespace ROOT
 
 #endif

--- a/tree/dataframe/src/RSlotStack.cxx
+++ b/tree/dataframe/src/RSlotStack.cxx
@@ -14,6 +14,8 @@
 #include <ROOT/RDF/RSlotStack.hxx>
 #include <TError.h> // R__ASSERT
 
+#include <mutex> // std::lock_guard
+
 ROOT::Internal::RDF::RSlotStack::RSlotStack(unsigned int size) : fSize(size), fMutexPtr(std::make_unique<ROOT::TSpinMutex>())
 {
    for (auto i : ROOT::TSeqU(size)) fStack.push(i);

--- a/tree/dataframe/src/RSlotStack.cxx
+++ b/tree/dataframe/src/RSlotStack.cxx
@@ -16,9 +16,11 @@
 
 #include <mutex> // std::lock_guard
 
-ROOT::Internal::RDF::RSlotStack::RSlotStack(unsigned int size) : fSize(size), fMutexPtr(std::make_unique<ROOT::TSpinMutex>())
+ROOT::Internal::RDF::RSlotStack::RSlotStack(unsigned int size)
+   : fSize(size), fMutexPtr(std::make_unique<ROOT::TSpinMutex>())
 {
-   for (auto i : ROOT::TSeqU(size)) fStack.push(i);
+   for (auto i : ROOT::TSeqU(size))
+      fStack.push(i);
 }
 
 void ROOT::Internal::RDF::RSlotStack::ReturnSlot(unsigned int slot)


### PR DESCRIPTION
This is a performance optimisation.
We do not need a rw lock in this case because a write lock is needed
both when a slot is taken out of the stack and when it's put back.
The header of the class has also been made slimmer thanks to the usage
of a fwd declaration.