### PR TITLE
Avoid ldap.h sneaking in from wrong location as reported in SPI-1120

### DIFF
--- a/cmake/modules/FindLdap.cmake
+++ b/cmake/modules/FindLdap.cmake
@@ -8,7 +8,7 @@
 #  LDAP_LIBRARIES - libldap + liblber (if found) library
 
 
-find_path(LDAP_INCLUDE_DIR NAMES ldap.h HINTS ${LDAP_DIR}/include $ENV{LDAP_DIR}/include)
+find_path(LDAP_INCLUDE_DIR NAMES ldap.h HINTS ${LDAP_DIR}/include $ENV{LDAP_DIR}/include NO_CMAKE_ENVIRONMENT_PATH)
 find_library(LDAP_LIBRARY NAMES ldap HINTS ${LDAP_DIR}/lib $ENV{LDAP_DIR}/lib)
 find_library(LBER_LIBRARY NAMES lber HINTS ${LDAP_DIR}/lib $ENV{LDAP_DIR}/lib)
 


### PR DESCRIPTION
Prevent ldap.h sneaking in from wrong location as is the case during LCG release builds if ROOT is tried to be built with ldap support. All details can be found at SPI-1120