### PR TITLE
Speedup TOffsetGeneration

### DIFF
--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -146,8 +146,8 @@ TObject *TObject::Clone(const char *) const
    if (gDirectory) {
      return gDirectory->CloneObject(this);
    } else {
-     Fatal("Clone","No gDirectory set");
-     return 0;
+     // Some of the streamer (eg. roofit's) expect(ed?) a valid gDirectory during streaming.
+     return gROOT->Clone();
    }
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -89,7 +89,7 @@ ROOT_LINKER_LIBRARY(Aclock Aclock.cxx G__Aclock.cxx LIBRARIES Graf Gpad)
 ROOT_GENERATE_DICTIONARY(G__TBench ${CMAKE_CURRENT_SOURCE_DIR}/TBench.h MODULE TBench LINKDEF benchLinkDef.h DEPENDENCIES MathCore Tree)
 ROOT_LINKER_LIBRARY(TBench TBench.cxx G__TBench.cxx LIBRARIES Core MathCore RIO Tree)
 ROOT_EXECUTABLE(bench bench.cxx LIBRARIES Core TBench)
-ROOT_ADD_TEST(test-bench COMMAND bench LABELS longtest)
+ROOT_ADD_TEST(test-bench COMMAND bench -s LABELS longtest)
 
 #--stress------------------------------------------------------------------------------------
   ROOT_EXECUTABLE(stress stress.cxx LIBRARIES Event Core Hist RIO Tree Gpad Postscript)

--- a/test/bench.cxx
+++ b/test/bench.cxx
@@ -115,6 +115,7 @@ int main(int argc, char **argv)
 {
    bool writereferences = false;
    bool memberwise = false;
+   bool shortrun = false;
 
    TVirtualStreamerInfo::SetStreamMemberWise(kFALSE);
    // by default stream objects objectwise
@@ -126,10 +127,12 @@ int main(int argc, char **argv)
          memberwise = true;
       } else if (strstr(argv[a],"-r")) {
          writereferences = true;
+      } else if (strstr(argv[a],"-s")) {
+         shortrun = true;
       }
    }
-   int nhits       = 1000;
-   int nevents     = 400;
+   int nhits       = shortrun ? 10 : 1000;
+   int nevents     = shortrun ? 40 : 400;
 
    Double_t cptot = 0;
 

--- a/tree/tree/test/TOffsetGeneration.cxx
+++ b/tree/tree/test/TOffsetGeneration.cxx
@@ -22,7 +22,7 @@ protected:
       features.Set(ROOT::Experimental::EIOFeatures::kGenerateOffsetMap);
       tree->SetIOFeatures(features);
       tree->SetBit(TTree::kOnlyFlushAtCluster);
-      tree->SetAutoSave(10);
+      tree->SetAutoFlush(10);
       Int_t sample[10];
       Int_t elem = 1;
       tree->Branch("elem", &elem, "elem/I");
@@ -39,7 +39,7 @@ protected:
       file = new TFile("TOffsetGeneration2.root", "RECREATE");
       tree = new TTree("tree", "A test tree");
       tree->SetBit(TTree::kOnlyFlushAtCluster);
-      tree->SetAutoSave(10);
+      tree->SetAutoFlush(10);
       tree->Branch("elem", &elem, "elem/I");
       tree->Branch("sample", &sample, "sample[elem]/I");
 
@@ -52,7 +52,7 @@ protected:
       file = new TFile("TOffsetGeneration3.root", "RECREATE");
       tree = new TTree("tree", "A test tree");
       tree->SetBit(TTree::kOnlyFlushAtCluster);
-      tree->SetAutoSave(5000);
+      tree->SetAutoFlush(5000);
       ElementStruct sample2;
       sample2.i = 1;
       double d[10];
@@ -72,7 +72,7 @@ protected:
       features.Set(ROOT::Experimental::EIOFeatures::kGenerateOffsetMap);
       tree2->SetIOFeatures(features);
       tree2->SetBit(TTree::kOnlyFlushAtCluster);
-      tree2->SetAutoSave(5000);
+      tree2->SetAutoFlush(5000);
       sample2.i = 1;
       sample2.d = d;
       tree2->Branch("sample", &sample2, 32*1024, 99);
@@ -93,8 +93,8 @@ protected:
       tree->SetIOFeatures(features);
       tree->SetBit(TTree::kOnlyFlushAtCluster);
       tree2->SetBit(TTree::kOnlyFlushAtCluster);
-      tree->SetAutoSave(5000);
-      tree2->SetAutoSave(5000);
+      tree->SetAutoFlush(5000);
+      tree2->SetAutoFlush(5000);
       sample2.i = 1;
       sample2.d = d;
       auto br = tree->Branch("sample", &sample2, 32*1024, 99);


### PR DESCRIPTION
Slow performance was due to excessive fsync and writing of TTree objects resulting in byte written to disk far exceeding the file size ...  (code was using AutoSave instead of AutoFlush).

Added speeding up of test-bench.