### PR TITLE
Json: let disable "_typename" tag in JSON

### DIFF
--- a/io/io/inc/TBufferJSON.h
+++ b/io/io/inc/TBufferJSON.h
@@ -34,6 +34,8 @@ public:
 
    void SetTypenameTag(const char *tag = "_typename");
 
+   void SetTypeversionTag(const char *tag = nullptr);
+
    static TString ConvertToJSON(const TObject *obj, Int_t compact = 0, const char *member_name = nullptr);
    static TString
    ConvertToJSON(const void *obj, const TClass *cl, Int_t compact = 0, const char *member_name = nullptr);
@@ -290,6 +292,7 @@ protected:
    TString fArraySepar;    ///<!  depending from compression level, ", " or ","
    TString fNumericLocale; ///<!  stored value of setlocale(LC_NUMERIC), which should be recovered at the end
    TString fTypeNameTag;   ///<! JSON member used for storing class name, when empty - no class name will be stored
+   TString fTypeVersionTag;  ///<! JSON member used to store class version, default empty
 
    ClassDef(TBufferJSON, 1) // a specialized TBuffer to only write objects into JSON format
 };

--- a/io/io/inc/TBufferJSON.h
+++ b/io/io/inc/TBufferJSON.h
@@ -32,6 +32,8 @@ public:
 
    void SetCompact(int level);
 
+   void SetTypenameTag(const char *tag = "_typename");
+
    static TString ConvertToJSON(const TObject *obj, Int_t compact = 0, const char *member_name = nullptr);
    static TString
    ConvertToJSON(const void *obj, const TClass *cl, Int_t compact = 0, const char *member_name = nullptr);
@@ -227,7 +229,7 @@ protected:
    void JsonDisablePostprocessing();
    Int_t JsonSpecialClass(const TClass *cl) const;
 
-   void JsonStartElement(const TStreamerElement *elem, const TClass *base_class = nullptr);
+   void JsonStartElement(const TStreamerElement *elem, const TClass *base_class = nullptr, Bool_t first_element = kFALSE);
 
    void PerformPostProcessing(TJSONStackObj *stack, const TClass *obj_cl = nullptr);
 

--- a/io/io/inc/TBufferJSON.h
+++ b/io/io/inc/TBufferJSON.h
@@ -293,7 +293,7 @@ protected:
    TString fNumericLocale; ///<!  stored value of setlocale(LC_NUMERIC), which should be recovered at the end
    TString fTypeNameTag;   ///<! JSON member used for storing class name, when empty - no class name will be stored
    TString fTypeVersionTag;  ///<! JSON member used to store class version, default empty
-   TExMap *fSkipClasses{nullptr}; ///<! list of classes, which class info is not stored
+   TObjArray *fSkipClasses{nullptr}; ///<! list of classes, which class info is not stored
 
    ClassDef(TBufferJSON, 1) // a specialized TBuffer to only write objects into JSON format
 };

--- a/io/io/inc/TBufferJSON.h
+++ b/io/io/inc/TBufferJSON.h
@@ -31,10 +31,10 @@ public:
    virtual ~TBufferJSON();
 
    void SetCompact(int level);
-
    void SetTypenameTag(const char *tag = "_typename");
-
    void SetTypeversionTag(const char *tag = nullptr);
+   void SetSkipClassInfo(const TClass *cl);
+   Bool_t IsSkipClassInfo(const TClass *cl) const;
 
    static TString ConvertToJSON(const TObject *obj, Int_t compact = 0, const char *member_name = nullptr);
    static TString
@@ -293,6 +293,7 @@ protected:
    TString fNumericLocale; ///<!  stored value of setlocale(LC_NUMERIC), which should be recovered at the end
    TString fTypeNameTag;   ///<! JSON member used for storing class name, when empty - no class name will be stored
    TString fTypeVersionTag;  ///<! JSON member used to store class version, default empty
+   TExMap *fSkipClasses{nullptr}; ///<! list of classes, which class info is not stored
 
    ClassDef(TBufferJSON, 1) // a specialized TBuffer to only write objects into JSON format
 };

--- a/io/io/inc/TBufferJSON.h
+++ b/io/io/inc/TBufferJSON.h
@@ -284,8 +284,10 @@ protected:
    std::deque<TJSONStackObj *> fStack; ///<!  hierarchy of currently streamed element
    Int_t fCompact{0};  ///<!  0 - no any compression, 1 - no spaces in the begin, 2 - no new lines, 3 - no spaces at all
    TString fSemicolon; ///<!  depending from compression level, " : " or ":"
+   Int_t fArrayCompact{0}; ///<!  0 - no array compression, 1 - exclude leading/trailing zeros, 2 - check value repetition
    TString fArraySepar;    ///<!  depending from compression level, ", " or ","
    TString fNumericLocale; ///<!  stored value of setlocale(LC_NUMERIC), which should be recovered at the end
+   TString fTypeNameTag;   ///<! JSON member used for storing class name, when empty - no class name will be stored
 
    ClassDef(TBufferJSON, 1) // a specialized TBuffer to only write objects into JSON format
 };

--- a/io/io/inc/TBufferJSON.h
+++ b/io/io/inc/TBufferJSON.h
@@ -278,11 +278,11 @@ protected:
                                             void (TBufferJSON::*method)(const T *, Int_t, const char *));
 
    TString fOutBuffer;                 ///<!  main output buffer for json code
-   TString *fOutput;                   ///<!  current output buffer for json code
+   TString *fOutput{nullptr};          ///<!  current output buffer for json code
    TString fValue;                     ///<!  buffer for current value
-   unsigned fJsonrCnt;                 ///<!  counter for all objects, used for referencing
+   unsigned fJsonrCnt{0};              ///<!  counter for all objects, used for referencing
    std::deque<TJSONStackObj *> fStack; ///<!  hierarchy of currently streamed element
-   Int_t fCompact;     ///<!  0 - no any compression, 1 - no spaces in the begin, 2 - no new lines, 3 - no spaces at all
+   Int_t fCompact{0};  ///<!  0 - no any compression, 1 - no spaces in the begin, 2 - no new lines, 3 - no spaces at all
    TString fSemicolon; ///<!  depending from compression level, " : " or ":"
    TString fArraySepar;    ///<!  depending from compression level, ", " or ","
    TString fNumericLocale; ///<!  stored value of setlocale(LC_NUMERIC), which should be recovered at the end

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -479,18 +479,18 @@ void TBufferJSON::SetTypeversionTag(const char *tag)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Specify class which type information (name and version) will not be stored in JSON
-/// One can configure several such classes
-/// Allows to excluded type information for only these classes
+/// Specify class which typename will not be stored in JSON
+/// Several classes can be configured
+/// To exclude typeinfo for all classes, call TBufferJSON::SetTypenameTag("")
 
 void TBufferJSON::SetSkipClassInfo(const TClass *cl)
 {
    if (!cl)
       return;
    if (!fSkipClasses)
-      fSkipClasses = new TExMap();
+      fSkipClasses = new TObjArray();
 
-   fSkipClasses->Add(Void_Hash(cl), 777);
+   fSkipClasses->Add(const_cast<TClass *>(cl));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -500,7 +500,7 @@ Bool_t TBufferJSON::IsSkipClassInfo(const TClass *cl) const
 {
    if (!cl || !fSkipClasses) return kFALSE;
 
-   return fSkipClasses->GetValue(Void_Hash(cl)) == 777;
+   return fSkipClasses->FindObject(cl) != nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -88,17 +88,16 @@ enum { json_TArray = 100, json_TCollection = -130, json_TString = 110, json_stds
 
 class TArrayIndexProducer {
 protected:
-   Int_t fTotalLen;
-   Int_t fCnt;
-   const char *fSepar;
+   Int_t fTotalLen{0};
+   Int_t fCnt{-1};
+   const char *fSepar{nullptr};
    TArrayI fIndicies;
    TArrayI fMaxIndex;
    TString fRes;
-   Bool_t fIsArray;
+   Bool_t fIsArray{kFALSE};
 
 public:
-   TArrayIndexProducer(TStreamerElement *elem, Int_t arraylen, const char *separ)
-      : fTotalLen(0), fCnt(-1), fSepar(separ), fIndicies(), fMaxIndex(), fRes(), fIsArray(kFALSE)
+   TArrayIndexProducer(TStreamerElement *elem, Int_t arraylen, const char *separ) : fSepar(separ)
    {
       Bool_t usearrayindx = elem && (elem->GetArrayDim() > 0);
       Bool_t isloop = elem && ((elem->GetType() == TStreamerInfo::kStreamLoop) ||
@@ -134,8 +133,7 @@ public:
       }
    }
 
-   TArrayIndexProducer(TDataMember *member, Int_t extradim, const char *separ)
-      : fTotalLen(0), fCnt(-1), fSepar(separ), fIndicies(), fMaxIndex(), fRes(), fIsArray(kFALSE)
+   TArrayIndexProducer(TDataMember *member, Int_t extradim, const char *separ) : fSepar(separ)
    {
       Int_t ndim = member->GetArrayDim();
       if (extradim > 0)
@@ -254,26 +252,22 @@ public:
 
 class TJSONStackObj : public TObject {
 public:
-   TStreamerInfo *fInfo;       //!
-   TStreamerElement *fElem;    //! element in streamer info
-   Bool_t fIsStreamerInfo;     //!
-   Bool_t fIsElemOwner;        //!
-   Bool_t fIsPostProcessed;    //! indicate that value is written
-   Bool_t fIsObjStarted;       //! indicate that object writing started, should be closed in postprocess
-   Bool_t fAccObjects;         //! if true, accumulate whole objects in values
-   TObjArray fValues;          //! raw values
-   Int_t fLevel;               //! indent level
-   TArrayIndexProducer *fIndx; //! producer of ndim indexes
-
-   nlohmann::json *fNode; //! JSON node, used for reading
-   Int_t fStlIndx;        //! index of object in STL container
-   Int_t fStlMap;         //! special iterator over STL map::key members
-   Version_t fClVersion;  //! keep actual class version, workaround for ReadVersion in custom streamer
+   TStreamerInfo *fInfo{nullptr};       //!
+   TStreamerElement *fElem{nullptr};    //! element in streamer info
+   Bool_t fIsStreamerInfo{kFALSE};      //!
+   Bool_t fIsElemOwner{kFALSE};         //!
+   Bool_t fIsPostProcessed{kFALSE};     //! indicate that value is written
+   Bool_t fIsObjStarted{kFALSE};        //! indicate that object writing started, should be closed in postprocess
+   Bool_t fAccObjects{kFALSE};          //! if true, accumulate whole objects in values
+   TObjArray fValues;                   //! raw values
+   Int_t fLevel{0};                     //! indent level
+   TArrayIndexProducer *fIndx{nullptr}; //! producer of ndim indexes
+   nlohmann::json *fNode{nullptr}; //! JSON node, used for reading
+   Int_t fStlIndx{-1};             //! index of object in STL container
+   Int_t fStlMap{-1};              //! special iterator over STL map::key members
+   Version_t fClVersion{0};        //! keep actual class version, workaround for ReadVersion in custom streamer
 
    TJSONStackObj()
-      : TObject(), fInfo(nullptr), fElem(nullptr), fIsStreamerInfo(kFALSE), fIsElemOwner(kFALSE),
-        fIsPostProcessed(kFALSE), fIsObjStarted(kFALSE), fAccObjects(kFALSE), fValues(), fLevel(0), fIndx(nullptr),
-        fNode(nullptr), fStlIndx(-1), fStlMap(-1), fClVersion(0)
    {
       fValues.SetOwner(kTRUE);
    }
@@ -437,8 +431,8 @@ TString TBufferJSON::ConvertToJSON(const TObject *obj, Int_t compact, const char
 //
 // Second digit of compact parameter defines algorithm for arrays compression
 //  - 0 - no compression, standard JSON array
-//  - 1 - exclude leading, trailing zeros, required JSROOT v5
-//  - 2 - check values repetition and empty gaps, required JSROOT v5
+//  - 1 - exclude leading and trailing zeros
+//  - 2 - check values repetition and empty gaps
 
 void TBufferJSON::SetCompact(int level)
 {
@@ -458,8 +452,8 @@ void TBufferJSON::SetCompact(int level)
 ///
 /// Second digit of compact parameter defines algorithm for arrays compression
 ///  - 0 - no compression, standard JSON array
-///  - 1 - exclude leading, trailing zeros, required JSROOT v5
-///  - 2 - check values repetition and empty gaps, required JSROOT v5
+///  - 1 - exclude leading and trailing zeros
+///  - 2 - check values repetition and empty gaps
 ///
 /// Maximal compression achieved when compact parameter equal to 23
 /// When member_name specified, converts only this data member


### PR DESCRIPTION
In many applications JSON can be used without any class info, 
therefore typename can be excluded. Especially useful, when it dominates total output size.
Typical example:

    {
     "_typename":"ROOT::Experumantal::REveGeomNode",
     "id": 0,
     "chlds": [],
    "name": "abc"
    }

Use std::unique_ptr for temporary-create objects.

Use std::vector<std::string> instead of TObjArray of TObjString