### PR TITLE
[PyROOT] Prevent module confusion when running doctest tests

### DIFF
--- a/bindings/pyroot/JupyROOT/__init__.py
+++ b/bindings/pyroot/JupyROOT/__init__.py
@@ -1,4 +1,4 @@
-from JupyROOT import cppcompleter, utils
+from JupyROOT.helpers import cppcompleter, utils
 
 if '__IPYTHON__' in __builtins__ and __IPYTHON__:
     cppcompleter.load_ipython_extension(get_ipython())

--- a/bindings/pyroot/JupyROOT/helpers/cppcompleter.py
+++ b/bindings/pyroot/JupyROOT/helpers/cppcompleter.py
@@ -5,7 +5,7 @@
 #  Author: Enric Tejedor <enric.tejedor.saavedra@cern.ch> CERN
 #-----------------------------------------------------------------------------
 
-from JupyROOT import utils
+from JupyROOT.helpers import utils
 import ROOT
 
 # Jit a wrapper for the ttabcom

--- a/bindings/pyroot/JupyROOT/helpers/handlers.py
+++ b/bindings/pyroot/JupyROOT/helpers/handlers.py
@@ -13,7 +13,7 @@ from time import sleep as timeSleep
 from sys import platform
 from os import path
 
-_lib = CDLL(path.join(path.dirname(path.dirname(__file__)), 'libJupyROOT.so'))
+_lib = CDLL(path.join(path.dirname(path.dirname(path.dirname(__file__))), 'libJupyROOT.so'))
 
 class IOHandler(object):
     r'''Class used to capture output from C/C++ libraries.

--- a/bindings/pyroot/JupyROOT/helpers/utils.py
+++ b/bindings/pyroot/JupyROOT/helpers/utils.py
@@ -23,7 +23,7 @@ from IPython.display import HTML
 from IPython.core.extensions import ExtensionManager
 import IPython.display
 import ROOT
-from JupyROOT import handlers
+from JupyROOT.helpers import handlers
 
 # We want iPython to take over the graphics
 ROOT.gROOT.SetBatch()

--- a/bindings/pyroot/JupyROOT/kernel/magics/jsrootmagic.py
+++ b/bindings/pyroot/JupyROOT/kernel/magics/jsrootmagic.py
@@ -4,7 +4,7 @@
 #  Authors: Danilo Piparo <Danilo.Piparo@cern.ch> CERN
 #-----------------------------------------------------------------------------
 
-from JupyROOT.utils import enableJSVis, disableJSVis, enableJSVisDebug, TBufferJSONErrorMessage, TBufferJSONAvailable
+from JupyROOT.helpers.utils import enableJSVis, disableJSVis, enableJSVisDebug, TBufferJSONErrorMessage, TBufferJSONAvailable
 
 from metakernel import Magic, option
 

--- a/bindings/pyroot/JupyROOT/kernel/rootkernel.py
+++ b/bindings/pyroot/JupyROOT/kernel/rootkernel.py
@@ -23,9 +23,9 @@ except ImportError:
 
 import ROOT
 
-from JupyROOT.utils import setStyle, invokeAclic, GetDrawers
-from JupyROOT.handlers import RunAsyncAndPrint
-from JupyROOT.cppcompleter import CppCompleter
+from JupyROOT.helpers.utils import setStyle, invokeAclic, GetDrawers
+from JupyROOT.helpers.handlers import RunAsyncAndPrint
+from JupyROOT.helpers.cppcompleter import CppCompleter
 from JupyROOT.kernel.utils import GetIOHandler, GetExecutor, GetDeclarer, MagicLoader
 
 import IPython

--- a/bindings/pyroot/JupyROOT/kernel/utils.py
+++ b/bindings/pyroot/JupyROOT/kernel/utils.py
@@ -14,7 +14,7 @@ from glob import glob
 
 import importlib
 
-from JupyROOT.handlers import IOHandler, JupyROOTDeclarer, JupyROOTExecutor
+from JupyROOT.helpers.handlers import IOHandler, JupyROOTDeclarer, JupyROOTExecutor
 
 import ROOT
 

--- a/bindings/pyroot/JupyROOT/magics/cppmagic.py
+++ b/bindings/pyroot/JupyROOT/magics/cppmagic.py
@@ -1,7 +1,7 @@
 
 from IPython.core.magic import (Magics, magics_class, cell_magic)
 from IPython.core.magic_arguments import (argument, magic_arguments, parse_argstring)
-from JupyROOT import utils
+from JupyROOT.helpers import utils
 
 
 @magics_class

--- a/bindings/pyroot/JupyROOT/magics/jsrootmagic.py
+++ b/bindings/pyroot/JupyROOT/magics/jsrootmagic.py
@@ -6,7 +6,7 @@
 
 from IPython.core.magic import (Magics, magics_class, line_magic)
 from IPython.core.magic_arguments import (argument, magic_arguments, parse_argstring)
-from JupyROOT.utils import enableJSVis, disableJSVis, enableJSVisDebug
+from JupyROOT.helpers.utils import enableJSVis, disableJSVis, enableJSVisDebug
 
 @magics_class
 class JSRootMagics(Magics):


### PR DESCRIPTION
When running doctest tests with `python -m doctest testfile.py`, doctest changes the current working directory to the directory where `testfile.py` is. This is problematic for our JupyROOT doctest tests, located in `$ROOT_SRC/bindings/pyroot/JupyROOT`, because Python will prepend that directory to the `PYTHONPATH`. Since such directory contains other Python modules, those will have precedence over any other module from the system. This caused a problem e.g. with `$ROOT_SRC/bindings/pyroot/JupyROOT/html`, which was wrongly picked instead of the system's package called html. For example, this can be seen [here](https://epsft-jenkins.cern.ch/job/root-pullrequests-build/50688/testReport/projectroot.roottest.python/JupyROOT/roottest_python_JupyROOT_cppcompleter_doctest/).

This commit proposes a reorganization of the Python modules in `$ROOT_SRC/bindings/pyroot/JupyROOT`, in particular those that contain doctest tests, so that the interference caused by doctest does not happen.