### PR TITLE
[VecOps] Allow to emplace_back on RVec<bool> on all platforms

### DIFF
--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -76,6 +76,15 @@ public:
 };
 bool TLeakChecker::fgDestroyed = false;
 
+// This test is here to check that emplace_back works
+// also for T==bool. Indeed, on some platform, vector<bool>
+// has no emplace_back. Notable examples are osx 10.14 and gcc 4.8
+TEST(VecOps, EmplaceBack)
+{
+   ROOT::RVec<bool> vb; vb.emplace_back(true);
+   ROOT::RVec<int> vi; vi.emplace_back(1);
+}
+
 TEST(VecOps, CopyCtorCheckNoLeak)
 {
    ROOT::VecOps::RVec<TLeakChecker> ref;


### PR DESCRIPTION
This is a workaround for a limitation of compilers such as
gcc 4.8 amd clang on osx 10.14 for which std::vector<bool>::emplace_back
is not defined.
We have now a template for all types while at the bottom of this file
the partial specialisation for T == bool, which uses push_back.