### PR TITLE
Reduce in half the TTreeReader overhead

### DIFF
--- a/core/base/inc/LinkDef2.h
+++ b/core/base/inc/LinkDef2.h
@@ -97,6 +97,7 @@
 #pragma link C++ class TMemberInspector;
 #pragma link C++ class TMessageHandler+;
 #pragma link C++ class TNamed+;
+#pragma link C++ class TNotifyLinkBase+;
 #pragma link C++ class TObjString+;
 #pragma link C++ class TObject-;
 #pragma link C++ class TRemoteObject-;

--- a/core/base/inc/TNotifyLink.h
+++ b/core/base/inc/TNotifyLink.h
@@ -1,0 +1,95 @@
+// @(#)root/base:$Id$
+// Author: Philippe Canal 2019
+
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TNotifyLink
+#define ROOT_TNotifyLink
+
+#include <TObject.h>
+#include <TError.h> // for R__ASSERT
+
+/** \class TNotifyLink
+\ingroup Base
+
+Links multiple listeners to be notified on TChain file changes.
+
+Neither TChain::SetNotify() nor this TNotifyLink take ownership of the object to be notified.
+
+eg.
+```
+auto notify = new TNotifyLink(object, fChain->GetNotify());
+fChain->SetNotify(notify);
+```
+**/
+
+class TNotifyLinkBase : public TObject {
+protected:
+   TNotifyLinkBase *fPrevious = nullptr;
+   TObject         *fNext = nullptr;
+
+public:
+
+   void Clear(Option_t * /*option*/ ="") {
+      auto current = this;
+      do {
+         auto next = dynamic_cast<TNotifyLinkBase*>(fNext);
+         current->fPrevious = nullptr;
+         current->fNext = nullptr;
+         current = next;
+      } while(current);
+   }
+
+   template <class Notifier>
+   void PrependLink(Notifier &notifier) {
+      fNext = notifier.GetNotify();
+      if (auto link = dynamic_cast<TNotifyLinkBase*>(fNext)) {
+         link->fPrevious = this;
+      }
+      notifier.SetNotify(this);
+   }
+
+   template <class Notifier>
+   void RemoveLink(Notifier &notifier) {
+      if (notifier.GetNotify() == this) {
+         R__ASSERT(fPrevious == nullptr && "The TNotifyLink head node should not have a previous element.");
+         notifier.SetNotify(fNext);
+      } else if (fPrevious) {
+         fPrevious->fNext = fNext;
+      }
+      if (auto link = dynamic_cast<TNotifyLinkBase*>(fNext)) {
+         link->fPrevious = fPrevious;
+      }
+      fPrevious = nullptr;
+      fNext = nullptr;
+   }
+
+   ClassDef(TNotifyLinkBase, 0);
+};
+
+template <class Type>
+class TNotifyLink : public TNotifyLinkBase {
+private:
+   Type *fCurrent;
+
+public:
+   TNotifyLink(Type *current) : fCurrent(current) {}
+
+   // Call Notify on the current and next object.
+   Bool_t Notify() override
+   {
+      auto result = fCurrent ? fCurrent->Notify() : kTRUE;
+      if (fNext) result &= fNext->Notify();
+      return result;
+   }
+
+   ClassDefOverride(TNotifyLink, 0);
+};
+
+#endif // ROOT_TNotifyLink

--- a/core/base/inc/TNotifyLink.h
+++ b/core/base/inc/TNotifyLink.h
@@ -35,11 +35,16 @@ protected:
    TObject         *fNext = nullptr;
 
 public:
+   // TTree status bits
+   enum EStatusBits {
+      kLinked = BIT(11) // Used when the TNotifyLink is connected to a TTree.
+   };
 
    void Clear(Option_t * /*option*/ ="") {
       auto current = this;
       do {
          auto next = dynamic_cast<TNotifyLinkBase*>(fNext);
+         current->ResetBit(kLinked);
          current->fPrevious = nullptr;
          current->fNext = nullptr;
          current = next;
@@ -48,6 +53,8 @@ public:
 
    template <class Notifier>
    void PrependLink(Notifier &notifier) {
+      SetBit(kLinked);
+
       fNext = notifier.GetNotify();
       if (auto link = dynamic_cast<TNotifyLinkBase*>(fNext)) {
          link->fPrevious = this;
@@ -57,6 +64,8 @@ public:
 
    template <class Notifier>
    void RemoveLink(Notifier &notifier) {
+      ResetBit(kLinked);
+
       if (notifier.GetNotify() == this) {
          R__ASSERT(fPrevious == nullptr && "The TNotifyLink head node should not have a previous element.");
          notifier.SetNotify(fNext);
@@ -68,6 +77,10 @@ public:
       }
       fPrevious = nullptr;
       fNext = nullptr;
+   }
+
+   Bool_t IsLinked() {
+      return TestBit(kLinked);
    }
 
    ClassDef(TNotifyLinkBase, 0);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -211,7 +211,7 @@ if(ROOT_roofit_FOUND)
 endif()
 
 #--stressHistFactory--------------------------------------------------------------------------------
-if(ROOT_roofit_FOUND AND ROOT_xml_FOUND)
+if(ROOT_roofit_FOUND AND GSL_FOUND AND ROOT_xml_FOUND)
   ROOT_EXECUTABLE(stressHistFactory stressHistFactory.cxx LIBRARIES RooStats HistFactory XMLParser)
   configure_file(HistFactoryTest.tar HistFactoryTest.tar COPYONLY)
   configure_file(stressHistFactory_ref.root stressHistFactory_ref.root COPYONLY)

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -395,6 +395,7 @@ End_Macro
 #include "TVirtualMutex.h"
 
 #include "TBranchIMTHelper.h"
+#include "TNotifyLink.h"
 
 #include <chrono>
 #include <cstddef>
@@ -881,6 +882,9 @@ TTree::TTree(const char* name, const char* title, Int_t splitlevel /* = 99 */,
 
 TTree::~TTree()
 {
+   if (auto link = dynamic_cast<TNotifyLinkBase*>(fNotify)) {
+      link->Clear();
+   }
    if (fAllocationCount && (gDebug > 0)) {
       Info("TTree::~TTree", "For tree %s, allocation count is %u.", GetName(), fAllocationCount.load());
 #ifdef R__TRACK_BASKET_ALLOC_TIME

--- a/tree/treeplayer/inc/LinkDef.h
+++ b/tree/treeplayer/inc/LinkDef.h
@@ -104,6 +104,7 @@
 #pragma link C++ class ROOT::Internal::TTreeReaderArrayBase+;
 #pragma link C++ class ROOT::Internal::TNamedBranchProxy+;
 #pragma link C++ class TNotifyLink<ROOT::Detail::TBranchProxy>;
+#pragma link C++ class TNotifyLink<TTreeReader>;
 
 #endif
 

--- a/tree/treeplayer/inc/LinkDef.h
+++ b/tree/treeplayer/inc/LinkDef.h
@@ -103,6 +103,7 @@
 #pragma link C++ class ROOT::Internal::TTreeReaderValueBase+;
 #pragma link C++ class ROOT::Internal::TTreeReaderArrayBase+;
 #pragma link C++ class ROOT::Internal::TNamedBranchProxy+;
+#pragma link C++ class TNotifyLink<ROOT::Detail::TBranchProxy>;
 
 #endif
 

--- a/tree/treeplayer/inc/TBranchProxy.h
+++ b/tree/treeplayer/inc/TBranchProxy.h
@@ -95,7 +95,7 @@ namespace Detail {
          TLeaf   *fLeafCount;    // eventual auxiliary leaf (for example holding the size)
       };
 
-      std::unique_ptr<TNotifyLink<TBranchProxy>> fNotify; // Callback object used by the TChain to update this proxy
+      TNotifyLink<TBranchProxy> fNotify; // Callback object used by the TChain to update this proxy
 
       TTree   *fLastTree; // TTree containing the last entry read
       Long64_t fRead;     // Last entry read

--- a/tree/treeplayer/inc/TBranchProxy.h
+++ b/tree/treeplayer/inc/TBranchProxy.h
@@ -119,6 +119,7 @@ namespace Detail {
       void Reset();
 
       Bool_t Notify() {
+         fRead = -1;
          return Setup();
       }
 

--- a/tree/treeplayer/inc/TBranchProxy.h
+++ b/tree/treeplayer/inc/TBranchProxy.h
@@ -97,13 +97,10 @@ namespace Detail {
 
       TNotifyLink<TBranchProxy> fNotify; // Callback object used by the TChain to update this proxy
 
-      TTree   *fLastTree; // TTree containing the last entry read
       Long64_t fRead;     // Last entry read
 
       void    *fWhere;    // memory location of the data
       TVirtualCollectionProxy *fCollection; // Handle to the collection containing the data chunk.
-
-      Int_t    fCurrentTreeNumber;
 
    public:
       virtual void Print();

--- a/tree/treeplayer/inc/TBranchProxyDirector.h
+++ b/tree/treeplayer/inc/TBranchProxyDirector.h
@@ -70,6 +70,7 @@ namespace Internal{
          }
       }
       TTree*   SetTree(TTree *newtree);
+      Bool_t   Notify();
 
    };
 

--- a/tree/treeplayer/inc/TBranchProxyDirector.h
+++ b/tree/treeplayer/inc/TBranchProxyDirector.h
@@ -15,6 +15,7 @@
 #include "Rtypes.h"
 
 #include <list>
+#include <vector>
 
 #ifdef R__OLDHPACC
 namespace std {
@@ -40,7 +41,7 @@ namespace Internal{
       Long64_t fEntry; // Entry currently being read.
 
       std::list<Detail::TBranchProxy*> fDirected;
-      std::list<TFriendProxy*> fFriends;
+      std::vector<TFriendProxy*> fFriends;
 
       TBranchProxyDirector(const TBranchProxyDirector &) : fTree(0), fEntry(-1) {;}
       TBranchProxyDirector& operator=(const TBranchProxyDirector&) {return *this;}

--- a/tree/treeplayer/inc/TBranchProxyDirector.h
+++ b/tree/treeplayer/inc/TBranchProxyDirector.h
@@ -36,7 +36,7 @@ namespace Internal{
 
       //This class could actually be the selector itself.
       TTree   *fTree;  // TTree we are currently looking at.
-      Long64_t fEntry; // Entry currently being read.
+      Long64_t fEntry; // Entry currently being read (in the local TTree rather than the TChain)
 
       std::list<Detail::TBranchProxy*> fDirected;
       std::vector<TFriendProxy*> fFriends;
@@ -52,11 +52,18 @@ namespace Internal{
       void     Attach(Detail::TBranchProxy* p);
       void     Attach(TFriendProxy* f);
       TH1F*    CreateHistogram(const char *options);
+
+      /// Return the current 'local' entry number; i.e. in the 'local' TTree rather than the TChain.
+      /// This value will be passed directly to TBranch::GetEntry.
       Long64_t GetReadEntry() const { return fEntry; }
+
       TTree*   GetTree() const { return fTree; };
       // void   Print();
+
+      /// Move to a new entry to read
+      /// entry is the 'local' entry number; i.e. in the 'local' TTree rather than the TChain.
+      /// This value will be passed directly to TBranch::GetEntry.
       void     SetReadEntry(Long64_t entry) {
-         // move to a new entry to read
          fEntry = entry;
          if (!fFriends.empty()) {
             std::for_each(fFriends.begin(), fFriends.end(), ResetReadEntry);

--- a/tree/treeplayer/inc/TBranchProxyDirector.h
+++ b/tree/treeplayer/inc/TBranchProxyDirector.h
@@ -13,16 +13,9 @@
 #define ROOT_TBranchProxyDirector
 
 #include "Rtypes.h"
-#include <list>
 #include <vector>
+#include <list>
 #include <algorithm>
-
-
-#ifdef R__OLDHPACC
-namespace std {
-   using ::list;
-}
-#endif
 
 class TH1F;
 class TTree;

--- a/tree/treeplayer/inc/TBranchProxyDirector.h
+++ b/tree/treeplayer/inc/TBranchProxyDirector.h
@@ -13,9 +13,10 @@
 #define ROOT_TBranchProxyDirector
 
 #include "Rtypes.h"
-
 #include <list>
 #include <vector>
+#include <algorithm>
+
 
 #ifdef R__OLDHPACC
 namespace std {
@@ -29,10 +30,14 @@ class TTree;
 namespace ROOT {
 namespace Detail {
    class TBranchProxy;
+   class TFriendProxy;
 }
 
 namespace Internal{
    class TFriendProxy;
+
+   // Helper function to call SetReadEntry on all TFriendProxy
+   void ResetReadEntry(TFriendProxy *fp);
 
    class TBranchProxyDirector {
 
@@ -57,7 +62,13 @@ namespace Internal{
       Long64_t GetReadEntry() const { return fEntry; }
       TTree*   GetTree() const { return fTree; };
       // void   Print();
-      void     SetReadEntry(Long64_t entry);
+      void     SetReadEntry(Long64_t entry) {
+         // move to a new entry to read
+         fEntry = entry;
+         if (!fFriends.empty()) {
+            std::for_each(fFriends.begin(), fFriends.end(), ResetReadEntry);
+         }
+      }
       TTree*   SetTree(TTree *newtree);
 
    };

--- a/tree/treeplayer/inc/TFriendProxy.h
+++ b/tree/treeplayer/inc/TFriendProxy.h
@@ -28,6 +28,8 @@ namespace Internal {
       TFriendProxy();
       TFriendProxy(TBranchProxyDirector *director, TTree *main, Int_t index);
 
+      TBranchProxyDirector *GetDirector() { return &fDirector; }
+
       Long64_t GetReadEntry() const;
       void     ResetReadEntry();
       void     Update(TTree *newmain);

--- a/tree/treeplayer/inc/TTreeReader.h
+++ b/tree/treeplayer/inc/TTreeReader.h
@@ -129,7 +129,8 @@ public:
       kEntryChainSetupError, ///< problem in accessing a chain element, e.g. file without the tree
       kEntryChainFileError, ///< problem in opening a chain's file
       kEntryDictionaryError, ///< problem reading dictionary info from tree
-      kEntryBeyondEnd ///< last entry loop has reached its end
+      kEntryBeyondEnd, ///< last entry loop has reached its end
+      kEntryUnknownError ///< LoadTree return less than -4, likely a 'newer' error code.
    };
 
    static constexpr const char * const fgEntryStatusText[kEntryBeyondEnd + 1] = {

--- a/tree/treeplayer/inc/TTreeReader.h
+++ b/tree/treeplayer/inc/TTreeReader.h
@@ -150,7 +150,7 @@ public:
       "last entry loop has reached its end"
    };
 
-   TTreeReader() = default;
+   TTreeReader();
 
    TTreeReader(TTree* tree, TEntryList* entryList = nullptr);
    TTreeReader(const char* keyname, TDirectory* dir, TEntryList* entryList = nullptr);
@@ -284,7 +284,7 @@ private:
    TEntryList* fEntryList = nullptr; ///< entry list to be used
    EEntryStatus fEntryStatus = kEntryNotLoaded; ///< status of most recent read request
    ELoadTreeStatus fLoadTreeStatus = kLoadTreeNone; ///< Indicator on how LoadTree was called 'last' time.
-   std::unique_ptr<TNotifyLink<TTreeReader>> fNotify; // Callback object used by the TChain to update this proxy
+   TNotifyLink<TTreeReader> fNotify; // Callback object used by the TChain to update this proxy
    ROOT::Internal::TBranchProxyDirector* fDirector = nullptr; ///< proxying director, owned
    std::deque<ROOT::Internal::TTreeReaderValueBase*> fValues; ///< readers that use our director
    NamedProxies_t fProxies; ///< attached ROOT::TNamedBranchProxies; owned

--- a/tree/treeplayer/inc/TTreeReader.h
+++ b/tree/treeplayer/inc/TTreeReader.h
@@ -135,7 +135,8 @@ public:
    };
 
    enum ELoadTreeStatus {
-      kLoadTreeNone = 0, ///< default state, Notify has not been called yet.
+      kNoTree = 0,       ///< default state, no TTree is connected (formerly 'Zombie' state)
+      kLoadTreeNone,     ///< Notify has not been called yet.
       kInternalLoadTree, ///< Notify/LoadTree was last called from SetEntryBase
       kExternalLoadTree  ///< User code called LoadTree directly.
    };
@@ -166,6 +167,8 @@ public:
    void SetTree(const char* keyname, TDirectory* dir, TEntryList* entryList = nullptr);
 
    Bool_t IsChain() const { return TestBit(kBitIsChain); }
+
+   Bool_t IsInvalid() const { return fLoadTreeStatus == kNoTree; }
 
    TTree* GetTree() const { return fTree; }
    TEntryList* GetEntryList() const { return fEntryList; }
@@ -283,7 +286,7 @@ private:
    TTree* fTree = nullptr; ///< tree that's read
    TEntryList* fEntryList = nullptr; ///< entry list to be used
    EEntryStatus fEntryStatus = kEntryNotLoaded; ///< status of most recent read request
-   ELoadTreeStatus fLoadTreeStatus = kLoadTreeNone; ///< Indicator on how LoadTree was called 'last' time.
+   ELoadTreeStatus fLoadTreeStatus = kNoTree;   ///< Indicator on how LoadTree was called 'last' time.
    TNotifyLink<TTreeReader> fNotify; // Callback object used by the TChain to update this proxy
    ROOT::Internal::TBranchProxyDirector* fDirector = nullptr; ///< proxying director, owned
    std::deque<ROOT::Internal::TFriendProxy*> fFriendProxies; ///< proxying for friend TTrees, owned

--- a/tree/treeplayer/inc/TTreeReader.h
+++ b/tree/treeplayer/inc/TTreeReader.h
@@ -286,6 +286,7 @@ private:
    ELoadTreeStatus fLoadTreeStatus = kLoadTreeNone; ///< Indicator on how LoadTree was called 'last' time.
    TNotifyLink<TTreeReader> fNotify; // Callback object used by the TChain to update this proxy
    ROOT::Internal::TBranchProxyDirector* fDirector = nullptr; ///< proxying director, owned
+   std::deque<ROOT::Internal::TFriendProxy*> fFriendProxies; ///< proxying for friend TTrees, owned
    std::deque<ROOT::Internal::TTreeReaderValueBase*> fValues; ///< readers that use our director
    NamedProxies_t fProxies; ///< attached ROOT::TNamedBranchProxies; owned
 

--- a/tree/treeplayer/inc/TTreeReader.h
+++ b/tree/treeplayer/inc/TTreeReader.h
@@ -295,6 +295,7 @@ private:
    Long64_t fEndEntry = -1LL;
    Long64_t fBeginEntry = 0LL; ///< This allows us to propagate the range to the TTreeCache
    Bool_t fProxiesSet = kFALSE; ///< True if the proxies have been set, false otherwise
+   Bool_t fSetEntryBaseCallingLoadTree = kFALSE; ///< True if during the LoadTree execution triggered by SetEntryBase.
 
    friend class ROOT::Internal::TTreeReaderValueBase;
    friend class ROOT::Internal::TTreeReaderArrayBase;

--- a/tree/treeplayer/inc/TTreeReader.h
+++ b/tree/treeplayer/inc/TTreeReader.h
@@ -263,6 +263,8 @@ protected:
 
    EEntryStatus SetEntryBase(Long64_t entry, Bool_t local);
 
+   Bool_t SetProxies();
+
 private:
 
    std::string GetProxyKey(const char *branchname)

--- a/tree/treeplayer/inc/TTreeReaderUtils.h
+++ b/tree/treeplayer/inc/TTreeReaderUtils.h
@@ -44,6 +44,11 @@ namespace Internal {
       TNamedBranchProxy(TBranchProxyDirector* boss, TBranch* branch, const char* fullname, const char* membername):
          fProxy(boss, fullname, branch, membername), fDict(0), fContentDict(0), fFullName(fullname) {}
 
+      // Constructor for friend case, the fullname (containing the name of the friend tree) may be different
+      // from the lookup name (without the name of the friend)
+      TNamedBranchProxy(TBranchProxyDirector* boss, TBranch* branch, const char* fullname, const char* proxyname, const char* membername):
+         fProxy(boss, proxyname, branch, membername), fDict(0), fContentDict(0), fFullName(fullname) {}
+
       const char* GetName() const { return fFullName.c_str(); }
       const Detail::TBranchProxy* GetProxy() const { return &fProxy; }
       Detail::TBranchProxy* GetProxy() { return &fProxy; }

--- a/tree/treeplayer/inc/TTreeReaderValue.h
+++ b/tree/treeplayer/inc/TTreeReaderValue.h
@@ -59,7 +59,13 @@ Base class of TTreeReaderValue.
          kReadError // problem reading data
       };
 
-      EReadStatus ProxyRead();
+      EReadStatus ProxyRead() { return (this->*fProxyReadFunc)(); }
+
+      EReadStatus ProxyReadDefaultImpl();
+
+      typedef Bool_t (ROOT::Detail::TBranchProxy::*BranchProxyRead_t)();
+      template <BranchProxyRead_t Func>
+      ROOT::Internal::TTreeReaderValueBase::EReadStatus ProxyReadTemplate();
 
       Bool_t IsValid() const { return fProxy && 0 == (int)fSetupStatus && 0 == (int)fReadStatus; }
       ESetupStatus GetSetupStatus() const { return fSetupStatus; }
@@ -107,6 +113,8 @@ Base class of TTreeReaderValue.
       Detail::TBranchProxy* fProxy = nullptr; // proxy for this branch, owned by TTreeReader
       TLeaf*       fLeaf = nullptr;
       std::vector<Long64_t> fStaticClassOffsets;
+      typedef EReadStatus (TTreeReaderValueBase::*Read_t)();
+      Read_t fProxyReadFunc = &TTreeReaderValueBase::ProxyReadDefaultImpl;      ///<! Pointer to the Read implementation to use.
 
       // FIXME: re-introduce once we have ClassDefInline!
       //ClassDef(TTreeReaderValueBase, 0);//Base class for accessors to data via TTreeReader

--- a/tree/treeplayer/src/TBranchProxy.cxx
+++ b/tree/treeplayer/src/TBranchProxy.cxx
@@ -30,7 +30,7 @@ ROOT::Detail::TBranchProxy::TBranchProxy() :
    fClassName(""), fClass(0), fElement(0), fMemberOffset(0), fOffset(0), fArrayLength(1),
    fBranch(0), fBranchCount(0),
    fNotify(this),
-   fLastTree(0), fRead(-1), fWhere(0),fCollection(0), fCurrentTreeNumber(-1)
+   fRead(-1), fWhere(0),fCollection(0)
 {
    // Constructor.
 };
@@ -42,7 +42,7 @@ ROOT::Detail::TBranchProxy::TBranchProxy(TBranchProxyDirector* boss, const char*
    fClassName(""), fClass(0), fElement(0), fMemberOffset(0), fOffset(0), fArrayLength(1),
    fBranch(0), fBranchCount(0),
    fNotify(this),
-   fLastTree(0), fRead(-1),  fWhere(0),fCollection(0), fCurrentTreeNumber(-1)
+   fRead(-1),  fWhere(0),fCollection(0)
 {
    // Constructor.
 
@@ -59,7 +59,7 @@ ROOT::Detail::TBranchProxy::TBranchProxy(TBranchProxyDirector* boss, const char 
    fClassName(""), fClass(0), fElement(0), fMemberOffset(0), fOffset(0), fArrayLength(1),
    fBranch(0), fBranchCount(0),
    fNotify(this),
-   fLastTree(0), fRead(-1), fWhere(0),fCollection(0), fCurrentTreeNumber(-1)
+   fRead(-1), fWhere(0),fCollection(0)
 {
    // Constructor.
 
@@ -79,7 +79,7 @@ ROOT::Detail::TBranchProxy::TBranchProxy(TBranchProxyDirector* boss, Detail::TBr
    fClassName(""), fClass(0), fElement(0), fMemberOffset(0), fOffset(0), fArrayLength(1),
    fBranch(0), fBranchCount(0),
    fNotify(this),
-   fLastTree(0), fRead(-1), fWhere(0),fCollection(0), fCurrentTreeNumber(-1)
+   fRead(-1), fWhere(0),fCollection(0)
 {
    // Constructor.
 
@@ -98,7 +98,7 @@ ROOT::Detail::TBranchProxy::TBranchProxy(TBranchProxyDirector* boss, TBranch* br
    fClassName(""), fClass(0), fElement(0), fMemberOffset(0), fOffset(0), fArrayLength(1),
    fBranch(0), fBranchCount(0),
    fNotify(this),
-   fLastTree(0), fRead(-1), fWhere(0),fCollection(0), fCurrentTreeNumber(-1)
+   fRead(-1), fWhere(0),fCollection(0)
 {
    // Constructor.
 
@@ -131,7 +131,7 @@ ROOT::Detail::TBranchProxy::TBranchProxy(TBranchProxyDirector* boss, const char*
    fClassName(""), fClass(0), fElement(0), fMemberOffset(0), fOffset(0), fArrayLength(1),
    fBranch(0), fBranchCount(0),
    fNotify(this),
-   fLastTree(0), fRead(-1), fWhere(0),fCollection(0), fCurrentTreeNumber(-1)
+   fRead(-1), fWhere(0),fCollection(0)
 {
    // Constructor.
 
@@ -161,10 +161,8 @@ void ROOT::Detail::TBranchProxy::Reset()
    fIsClone = false;
    fInitialized = false;
    fHasLeafCount = false;
-   fLastTree = 0;
    delete fCollection;
    fCollection = 0;
-   fCurrentTreeNumber = -1;
 }
 
 void ROOT::Detail::TBranchProxy::Print()
@@ -252,7 +250,7 @@ Bool_t ROOT::Detail::TBranchProxy::Setup()
 
       // This is not sufficient for following pointers
 
-   } else if (!fBranch || fCurrentTreeNumber != fDirector->GetTree()->GetTreeNumber() || fLastTree != fDirector->GetTree()) {
+   } else if (!fBranch) {
 
       // This does not allow (yet) to precede the branch name with
       // its mother's name
@@ -481,8 +479,6 @@ Bool_t ROOT::Detail::TBranchProxy::Setup()
    }
    if (fClass==TClonesArray::Class()) fIsClone = true;
    if (fWhere!=0) {
-      fLastTree = fDirector->GetTree();
-      fCurrentTreeNumber = fLastTree->GetTreeNumber();
       fInitialized = true;
       return true;
    } else {

--- a/tree/treeplayer/src/TBranchProxy.cxx
+++ b/tree/treeplayer/src/TBranchProxy.cxx
@@ -19,6 +19,7 @@ of the autoloading of branches as well as all the generic setup routine.
 #include "TBranchElement.h"
 #include "TStreamerElement.h"
 #include "TStreamerInfo.h"
+#include <ROOT/RMakeUnique.hxx>
 
 ClassImp(ROOT::Detail::TBranchProxy);
 
@@ -135,6 +136,8 @@ ROOT::Detail::TBranchProxy::TBranchProxy(TBranchProxyDirector* boss, const char*
 ROOT::Detail::TBranchProxy::~TBranchProxy()
 {
    // Typical Destructor
+   if (fNotify && fDirector && fDirector->GetTree())
+      fNotify->RemoveLink(*(fDirector->GetTree()));
 }
 
 void ROOT::Detail::TBranchProxy::Reset()
@@ -177,6 +180,10 @@ Bool_t ROOT::Detail::TBranchProxy::Setup()
 
    if (!fDirector->GetTree()) {
       return false;
+   }
+   if (!fNotify) {
+      fNotify = std::make_unique<TNotifyLink<TBranchProxy>>(this);
+      fNotify->PrependLink(*fDirector->GetTree());
    }
    if (fParent) {
 

--- a/tree/treeplayer/src/TBranchProxy.cxx
+++ b/tree/treeplayer/src/TBranchProxy.cxx
@@ -250,7 +250,7 @@ Bool_t ROOT::Detail::TBranchProxy::Setup()
 
       // This is not sufficient for following pointers
 
-   } else if (!fBranch) {
+   } else {
 
       // This does not allow (yet) to precede the branch name with
       // its mother's name

--- a/tree/treeplayer/src/TBranchProxyDirector.cxx
+++ b/tree/treeplayer/src/TBranchProxyDirector.cxx
@@ -38,7 +38,7 @@ namespace Internal {
    void Reset(Detail::TBranchProxy *x) { x->Reset(); }
 
    // Helper function to call SetReadEntry on all TFriendProxy
-   void ResetReadEntry(TFriendProxy *x) { x->ResetReadEntry(); }
+   void ResetReadEntry(TFriendProxy *fp) { fp->ResetReadEntry(); }
 
    // Helper class to call Update on all TFriendProxy
    struct Update {
@@ -126,15 +126,6 @@ namespace Internal {
 
       if (opt.Length() && opt.Contains("e")) hist->Sumw2();
       return hist;
-   }
-
-   void TBranchProxyDirector::SetReadEntry(Long64_t entry) {
-
-      // move to a new entry to read
-      fEntry = entry;
-      if (!fFriends.empty()) {
-         for_each(fFriends.begin(),fFriends.end(),ResetReadEntry);
-      }
    }
 
    TTree* TBranchProxyDirector::SetTree(TTree *newtree) {

--- a/tree/treeplayer/src/TBranchProxyDirector.cxx
+++ b/tree/treeplayer/src/TBranchProxyDirector.cxx
@@ -35,7 +35,7 @@ namespace ROOT {
 namespace Internal {
 
    // Helper function to call Reset on each TBranchProxy
-   void Reset(Detail::TBranchProxy *x) { x->Reset(); }
+   void NotifyDirected(Detail::TBranchProxy *x) { x->Notify(); }
 
    // Helper function to call SetReadEntry on all TFriendProxy
    void ResetReadEntry(TFriendProxy *fp) { fp->ResetReadEntry(); }
@@ -136,13 +136,17 @@ namespace Internal {
 
       TTree* oldtree = fTree;
       fTree = newtree;
+      Notify();
+      return oldtree;
+   }
+
+   Bool_t TBranchProxyDirector::Notify() {
       fEntry = -1;
-      //if (fInitialized) fInitialized = setup();
-      //fprintf(stderr,"calling SetTree for %p\n",this);
-      for_each(fDirected.begin(),fDirected.end(),Reset);
+
+      for_each(fDirected.begin(),fDirected.end(),NotifyDirected);
       Update update(fTree);
       for_each(fFriends.begin(),fFriends.end(),update);
-      return oldtree;
+      return kTRUE;
    }
 
 } // namespace Internal

--- a/tree/treeplayer/src/TTreeReader.cxx
+++ b/tree/treeplayer/src/TTreeReader.cxx
@@ -359,23 +359,45 @@ TTreeReader::EEntryStatus TTreeReader::SetEntryBase(Long64_t entry, Bool_t local
    TTree* treeToCallLoadOn = local ? fTree->GetTree() : fTree;
    Long64_t loadResult = treeToCallLoadOn->LoadTree(entryAfterList);
 
-   // ROOT-9628 We cover here the case when:
-   // - We deal with a TChain
-   // - The last file is opened
-   // - The TTree is not correctly loaded
-   // The system is robust against issues with TTrees associated to the chain
-   // when they are not at the end of it.
-   if (loadResult == -3 && TestBit(kBitIsChain) && !fTree->GetTree()) {
-      Warning("SetEntryBase()",
-              "There was an issue opening the last file associated to the TChain "
-              "being processed.");
-      fEntryStatus = kEntryChainFileError;
-      return fEntryStatus;
-   }
+   if (loadResult < 0) {
+      // ROOT-9628 We cover here the case when:
+      // - We deal with a TChain
+      // - The last file is opened
+      // - The TTree is not correctly loaded
+      // The system is robust against issues with TTrees associated to the chain
+      // when they are not at the end of it.
+      if (loadResult == -3 && TestBit(kBitIsChain) && !fTree->GetTree()) {
+         Warning("SetEntryBase()",
+               "There was an issue opening the last file associated to the TChain "
+               "being processed.");
+         fEntryStatus = kEntryChainFileError;
+         return fEntryStatus;
+      }
 
-   if (loadResult == -2) {
-      fDirector->SetTree(nullptr);
-      fEntryStatus = kEntryNotFound;
+      if (loadResult == -2) {
+         fDirector->SetTree(nullptr);
+         fEntryStatus = kEntryNotFound;
+         return fEntryStatus;
+      }
+
+      if (loadResult == -1) {
+         // The chain is empty
+         fEntryStatus = kEntryNotFound;
+         return fEntryStatus;
+      }
+
+      if (loadResult == -4) {
+         // The TChainElement corresponding to the entry is missing or
+         // the TTree is missing from the file.
+         fEntryStatus = kEntryNotFound;
+         return fEntryStatus;
+      }
+
+      Warning("SetEntryBase()",
+              "Unexpected error '%lld' in %::LoadTree", loadResult,
+              treeToCallLoadOn->IsA()->GetName());
+
+      fEntryStatus = kEntryUnknownError;
       return fEntryStatus;
    }
 

--- a/tree/treeplayer/src/TTreeReader.cxx
+++ b/tree/treeplayer/src/TTreeReader.cxx
@@ -354,16 +354,6 @@ TTreeReader::EEntryStatus TTreeReader::SetEntryBase(Long64_t entry, Bool_t local
       }
    }
 
-   if (fProxiesSet && fDirector && fDirector->GetReadEntry() == -1
-       && fMostRecentTreeNumber != -1) {
-      // Passed the end of the chain, Restart() was not called:
-      // don't try to load entries anymore. Can happen in these cases:
-      // while (tr.Next()) {something()};
-      // while (tr.Next()) {somethingelse()}; // should not be calling somethingelse().
-      fEntryStatus = kEntryNotFound;
-      return fEntryStatus;
-   }
-
    Int_t treeNumberBeforeLoadTree = fTree->GetTreeNumber();
 
    TTree* treeToCallLoadOn = local ? fTree->GetTree() : fTree;

--- a/tree/treeplayer/src/TTreeReader.cxx
+++ b/tree/treeplayer/src/TTreeReader.cxx
@@ -297,14 +297,11 @@ Bool_t TTreeReader::Notify()
    }
 
    fDirector->Notify();
+
    if (fProxiesSet) {
       for (auto value: fValues) {
          value->NotifyNewTree(fTree->GetTree());
       }
-   }
-
-   if (!fProxiesSet) {
-      return SetProxies();
    }
 
    return kTRUE;

--- a/tree/treeplayer/src/TTreeReader.cxx
+++ b/tree/treeplayer/src/TTreeReader.cxx
@@ -199,7 +199,7 @@ TTreeReader::TTreeReader(TTree* tree, TEntryList* entryList /*= nullptr*/):
 ////////////////////////////////////////////////////////////////////////////////
 /// Access data from the tree called keyname in the directory (e.g. TFile)
 /// dir, or the current directory if dir is NULL. If keyname cannot be
-/// found, or if it is not a TTree, IsZombie() will return true.
+/// found, or if it is not a TTree, IsInvalid() will return true.
 
 TTreeReader::TTreeReader(const char* keyname, TDirectory* dir, TEntryList* entryList /*= nullptr*/):
    fEntryList(entryList),
@@ -241,13 +241,12 @@ void TTreeReader::Initialize()
 {
    fEntry = -1;
    if (!fTree) {
-      MakeZombie();
       fEntryStatus = kEntryNoTree;
-      fLoadTreeStatus = kLoadTreeNone;
+      fLoadTreeStatus = kNoTree;
       return;
    }
 
-   ResetBit(kZombie);
+   fLoadTreeStatus = kLoadTreeNone;
    if (fTree->InheritsFrom(TChain::Class())) {
       SetBit(kBitIsChain);
    }
@@ -437,7 +436,7 @@ Long64_t TTreeReader::GetEntries(Bool_t force) const {
 
 TTreeReader::EEntryStatus TTreeReader::SetEntryBase(Long64_t entry, Bool_t local)
 {
-   if (IsZombie()) {
+   if (IsInvalid()) {
       fEntryStatus = kEntryNoTree;
       fEntry = -1;
       return fEntryStatus;
@@ -554,10 +553,12 @@ void TTreeReader::SetTree(TTree* tree, TEntryList* entryList /*= nullptr*/)
    fEntry = -1;
 
    if (fTree) {
-      ResetBit(kZombie);
+      fLoadTreeStatus = kLoadTreeNone;
       if (fTree->InheritsFrom(TChain::Class())) {
          SetBit(kBitIsChain);
       }
+   } else {
+      fLoadTreeStatus = kNoTree;
    }
 
    if (!fDirector) {
@@ -566,8 +567,6 @@ void TTreeReader::SetTree(TTree* tree, TEntryList* entryList /*= nullptr*/)
    else {
       fDirector->SetTree(fTree);
       fDirector->SetReadEntry(-1);
-      // Distinguish from end-of-chain case:
-      fLoadTreeStatus = kLoadTreeNone;
    }
 }
 

--- a/tree/treeplayer/src/TTreeReader.cxx
+++ b/tree/treeplayer/src/TTreeReader.cxx
@@ -290,7 +290,7 @@ Bool_t TTreeReader::Notify()
       SetBit(kBitHaveWarnedAboutEntryListAttachedToTTree);
    }
 
-   fDirector->SetTree(fTree->GetTree());
+   fDirector->Notify();
    if (fProxiesSet) {
       for (auto value: fValues) {
          value->NotifyNewTree(fTree->GetTree());
@@ -473,7 +473,7 @@ TTreeReader::EEntryStatus TTreeReader::SetEntryBase(Long64_t entry, Bool_t local
       // The system is robust against issues with TTrees associated to the chain
       // when they are not at the end of it.
       if (loadResult == -3 && TestBit(kBitIsChain) && !fTree->GetTree()) {
-         fDirector->SetTree(fTree->GetTree());
+         fDirector->Notify();
          if (fProxiesSet) {
             for (auto value: fValues) {
                value->NotifyNewTree(fTree->GetTree());
@@ -487,7 +487,7 @@ TTreeReader::EEntryStatus TTreeReader::SetEntryBase(Long64_t entry, Bool_t local
       }
 
       if (loadResult == -2) {
-         fDirector->SetTree(fTree->GetTree());
+         fDirector->Notify();
          if (fProxiesSet) {
             for (auto value: fValues) {
                value->NotifyNewTree(fTree->GetTree());
@@ -506,7 +506,7 @@ TTreeReader::EEntryStatus TTreeReader::SetEntryBase(Long64_t entry, Bool_t local
       if (loadResult == -4) {
          // The TChainElement corresponding to the entry is missing or
          // the TTree is missing from the file.
-         fDirector->SetTree(fTree->GetTree());
+         fDirector->Notify();
          if (fProxiesSet) {
             for (auto value: fValues) {
                value->NotifyNewTree(fTree->GetTree());

--- a/tree/treeplayer/src/TTreeReader.cxx
+++ b/tree/treeplayer/src/TTreeReader.cxx
@@ -16,6 +16,7 @@
 #include "TEntryList.h"
 #include "TTreeCache.h"
 #include "TTreeReaderValue.h"
+#include "TFriendProxy.h"
 
 
 // clang-format off
@@ -224,6 +225,11 @@ TTreeReader::~TTreeReader()
    // Need to clear the map of proxies before deleting the director otherwise
    // they will have a dangling pointer.
    fProxies.clear();
+
+   for (auto feproxy: fFriendProxies) {
+      delete feproxy;
+   }
+   fFriendProxies.clear();
 
    delete fDirector;
 }

--- a/tree/treeplayer/src/TTreeReader.cxx
+++ b/tree/treeplayer/src/TTreeReader.cxx
@@ -554,9 +554,7 @@ void TTreeReader::SetTree(TTree* tree, TEntryList* entryList /*= nullptr*/)
 
    if (fTree) {
       fLoadTreeStatus = kLoadTreeNone;
-      if (fTree->InheritsFrom(TChain::Class())) {
-         SetBit(kBitIsChain);
-      }
+      SetBit(kBitIsChain, fTree->InheritsFrom(TChain::Class()));
    } else {
       fLoadTreeStatus = kNoTree;
    }

--- a/tree/treeplayer/src/TTreeReaderValue.cxx
+++ b/tree/treeplayer/src/TTreeReaderValue.cxx
@@ -194,6 +194,10 @@ ROOT::Internal::TTreeReaderValueBase::ProxyReadDefaultImpl() {
       }
       return (this->*fProxyReadFunc)();
    }
+
+   // If somehow the Setup fails call the original Read to
+   // have the proper error handling (message only if the Setup fails
+   // and the current proxy entry is different than the TTree's current entry)
    if (fProxy->Read()) {
       fReadStatus = kReadSuccess;
    } else {
@@ -216,6 +220,8 @@ std::string ROOT::Internal::TTreeReaderValueBase::GetElementTypeName(const std::
 /// The TTreeReader has switched to a new TTree. Update the leaf.
 
 void ROOT::Internal::TTreeReaderValueBase::NotifyNewTree(TTree* newTree) {
+   // Since the TTree structure might have change, let's make sure we
+   // use the right reading function.
    fProxyReadFunc = &TTreeReaderValueBase::ProxyReadDefaultImpl;
 
    if (!fHaveLeaf || !newTree) {

--- a/tree/treeplayer/src/TTreeReaderValue.cxx
+++ b/tree/treeplayer/src/TTreeReaderValue.cxx
@@ -158,8 +158,12 @@ std::string ROOT::Internal::TTreeReaderValueBase::GetElementTypeName(const std::
 /// The TTreeReader has switched to a new TTree. Update the leaf.
 
 void ROOT::Internal::TTreeReaderValueBase::NotifyNewTree(TTree* newTree) {
-   if (!fHaveLeaf)
+   fProxyReadFunc = &TTreeReaderValueBase::ProxyReadDefaultImpl;
+
+   if (!fHaveLeaf || !newTree) {
+      fLeaf = nullptr;
       return;
+   }
 
    TBranch *myBranch = newTree->GetBranch(fBranchName);
 


### PR DESCRIPTION
With the attached example, the direct case takes 23.6s while original TTreeReader version takes 34.2s.

With the included changes, the TTreeReader version is down to 28.7s.