### PR TITLE
[PyROOT Exp] Use cppyy directly instead of TPython interface

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/src/TFilePyz.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/TFilePyz.cxx
@@ -30,7 +30,7 @@ PyObject *PyROOT::AddFileOpenPyz(PyObject * /* self */, PyObject *args)
    PyObject *pyclass = PyTuple_GetItem(args, 0);
    // TFile::Open really is a constructor
    PyObject *attr = PyObject_GetAttrString(pyclass, (char *)"Open");
-   if (TPython::CPPOverload_Check(attr)) {
+   if (CPPOverload_Check(attr)) {
       ((CPPOverload *)attr)->fMethodInfo->fFlags |= CallContext::kIsCreator;
    }
    Py_XDECREF(attr);


### PR DESCRIPTION
TPython::CPPOverload_Check does an additional check for the
initialization of the Python interpreter that we don't need.