### PR TITLE
[TMVA::Experimental] RTensor C++ implementation

### DIFF
--- a/tmva/tmva/CMakeLists.txt
+++ b/tmva/tmva/CMakeLists.txt
@@ -166,6 +166,7 @@ set(TMVA_HEADERS
   TMVA/VarTransformHandler.h
   TMVA/Version.h
   TMVA/Volume.h
+  TMVA/RTensor.hxx
 )
 
 #---Assign source files to the implementations -----------------

--- a/tmva/tmva/CMakeLists.txt
+++ b/tmva/tmva/CMakeLists.txt
@@ -167,6 +167,7 @@ set(TMVA_HEADERS
   TMVA/Version.h
   TMVA/Volume.h
   TMVA/RTensor.hxx
+  TMVA/RTensorUtils.hxx
 )
 
 #---Assign source files to the implementations -----------------

--- a/tmva/tmva/inc/TMVA/RTensor.hxx
+++ b/tmva/tmva/inc/TMVA/RTensor.hxx
@@ -1,0 +1,460 @@
+#ifndef TMVA_RTENSOR
+#define TMVA_RTENSOR
+
+#include "ROOT/RVec.hxx"
+
+#include <type_traits>
+#include <cstdint>   // uint8_t
+#include <cstddef>   // std::size_t
+#include <stdexcept> // std::runtime_error
+#include <sstream>   // std::stringstream
+#include <algorithm> // std::remove, std::equal
+
+namespace TMVA {
+namespace Experimental {
+
+/// Memory order types
+struct MemoryOrder {
+   using type = uint8_t;
+   const static type RowMajor = 0;
+   const static type ColumnMajor = 1;
+};
+
+namespace Internal {
+
+/// \brief Get size of tensor from shape vector
+/// \param[in] shape Shape vector
+/// \return Size of contiguous memory
+template <typename T>
+std::size_t GetSizeFromShape(const T &shape)
+{
+   if (shape.size() == 0)
+      return 0;
+   std::size_t size = 1;
+   for (auto &s : shape)
+      size *= s;
+   return size;
+}
+
+/// \brief Compute strides from shape vector.
+/// \param[in] shape Shape vector
+/// \param[in] memoryOrder Memory order
+/// \return Size of contiguous memory
+///
+/// This information is needed for the multi-dimensional indexing. See here:
+/// https://en.wikipedia.org/wiki/Row-_and_column-major_order
+/// https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.strides.html
+template <typename T>
+std::vector<std::size_t> ComputeStrides(const T &shape, MemoryOrder::type memoryOrder)
+{
+   const auto size = shape.size();
+   T strides(size);
+   if (memoryOrder == MemoryOrder::RowMajor) {
+      for (std::size_t i = 0; i < size; i++) {
+         if (i == 0) {
+            strides[size - 1 - i] = 1;
+         } else {
+            strides[size - 1 - i] = strides[size - 1 - i + 1] * shape[size - 1 - i + 1];
+         }
+      }
+   } else if (memoryOrder == MemoryOrder::ColumnMajor) {
+      for (std::size_t i = 0; i < size; i++) {
+         if (i == 0) {
+            strides[i] = 1;
+         } else {
+            strides[i] = strides[i - 1] * shape[i - 1];
+         }
+      }
+   } else {
+      std::stringstream ss;
+      ss << "Memory order type " << memoryOrder << " is not known for calculating the strides.";
+      throw std::runtime_error(ss.str());
+   }
+   return strides;
+}
+
+/// \brief Type checking for all types of a parameter pack, e.g., used in combination with std::is_convertible
+template <class... Ts>
+struct and_types : std::true_type {
+};
+template <class T0, class... Ts>
+struct and_types<T0, Ts...> : std::integral_constant<bool, T0{} && and_types<Ts...>{}> {
+};
+
+/// \brief Copy slice of a tensor recursively from here to there
+/// \param[in] here Source tensor
+/// \param[in] there Target tensor (slice of source tensor)
+/// \param[in] mins Minimum of indices for each dimension
+/// \param[in] maxs Maximum of indices for each dimension
+/// \param[in] idx Current indices
+/// \param[in] active Active index needed to stop the recursion
+///
+/// Copy the content of a slice of a tensor from source to target. This is done
+/// by recursively iterating over the ranges of the slice for each dimension.
+template <typename T>
+void RecursiveCopy(T &here, T &there, std::vector<std::size_t> &mins, std::vector<std::size_t> &maxs,
+                   std::vector<std::size_t> idx, std::size_t active)
+{
+   const auto size = idx.size();
+   for (std::size_t i = mins[active]; i < maxs[active]; i++) {
+      idx[active] = i;
+      if (active == size - 1) {
+         auto idxThere = idx;
+         for (std::size_t j = 0; j < size; j++) {
+            idxThere[j] -= mins[j];
+         }
+         there(idxThere) = here(idx);
+      } else {
+         Internal::RecursiveCopy(here, there, mins, maxs, idx, active + 1);
+      }
+   }
+}
+
+} // namespace TMVA::Experimental::Internal
+
+/// \class TMVA::Experimental::RTensor
+/// \brief RTensor is a container with contiguous memory and shape information.
+/// \tparam T Data-type of the tensor
+///
+/// An RTensor is a vector-like container, which has additional shape information.
+/// The elements of the multi-dimensional container can be accessed by their
+/// indices in a coherent way without taking care about the one-dimensional memory
+/// layout of the contiguous storage. This also allows to manipulate the shape
+/// of the container without moving the actual elements in memory. Another feature
+/// is that an RTensor can own the underlying contiguous memory but also represent
+/// only a view on existing data without owning it.
+template <typename T>
+class RTensor {
+public:
+   // Typedefs
+   using Container_t = typename ROOT::VecOps::RVec<T>;
+   using Shape_t = typename std::vector<std::size_t>;
+   using Index_t = Shape_t;
+   using Slice_t = typename std::vector<int>;
+   using iterator = typename Container_t::iterator;
+   using const_iterator = typename Container_t::const_iterator;
+   using reverse_iterator = typename Container_t::reverse_iterator;
+   using const_reverse_iterator = typename Container_t::const_reverse_iterator;
+
+   // Constructors
+   RTensor(const Shape_t &shape, MemoryOrder::type memoryOrder = MemoryOrder::RowMajor);
+   RTensor(T *data, const Shape_t &shape, MemoryOrder::type memoryOrder = MemoryOrder::RowMajor);
+
+   // Access elements
+   template <typename... Idx>
+   T &At(Idx... idx);
+   T &At(const Index_t &idx);
+   template <typename... Idx>
+   T &operator()(Idx... idx);
+   T &operator()(const Index_t &idx);
+
+   // Iterator interface
+   iterator begin() noexcept { return fData.begin(); }
+   const_iterator begin() const noexcept { return fData.begin(); }
+   const_iterator cbegin() const noexcept { return fData.cbegin(); }
+   iterator end() noexcept { return fData.end(); }
+   const_iterator end() const noexcept { return fData.end(); }
+   const_iterator cend() const noexcept { return fData.cend(); }
+   reverse_iterator rbegin() noexcept { return fData.rbegin(); }
+   const_reverse_iterator rbegin() const noexcept { return fData.rbegin(); }
+   const_reverse_iterator crbegin() const noexcept { return fData.crbegin(); }
+   reverse_iterator rend() noexcept { return fData.rend(); }
+   const_reverse_iterator rend() const noexcept { return fData.rend(); }
+   const_reverse_iterator crend() const noexcept { return fData.crend(); }
+
+   // Slicing
+   RTensor<T> Slice(const Slice_t &slice);
+   template <typename... Idx>
+   RTensor<T> Slice(Idx... slice);
+
+   // Shape modifications
+   void Reshape(const Shape_t &shape);
+   void ExpandDims(int axis);
+   void Squeeze();
+   void Transpose();
+
+   // Get properties of container
+   std::size_t GetSize() const { return fData.size(); }        // Return size of contiguous memory
+   Shape_t GetShape() const { return fShape; }                 // Return shape
+   Shape_t GetStrides() const { return fStrides; }             // Return strides
+   T *GetData() { return fData.data(); }                       // Return pointer to data
+   Container_t &GetDataAsVec() { return fData; }               // Return data as reference to vector
+   MemoryOrder::type GetMemoryOrder() { return fMemoryOrder; } // Return memory order
+
+private:
+   Shape_t fShape;                 // Shape of tensor
+   Shape_t fStrides;               // Strides, needed for indexing
+   Container_t fData;              // Container for contiguous memory
+   MemoryOrder::type fMemoryOrder; // Memory ordering
+};
+
+/// \brief Construct a tensor from given shape initialized with zeros
+/// \param[in] shape Shape vector
+/// \param[in] memoryOrder Memory order
+template <typename T>
+RTensor<T>::RTensor(const Shape_t &shape, MemoryOrder::type memoryOrder)
+{
+   fShape = shape;
+   fStrides = Internal::ComputeStrides(shape, memoryOrder);
+   const auto size = Internal::GetSizeFromShape(shape);
+   fData = Container_t(size);
+   fMemoryOrder = memoryOrder;
+}
+
+/// \brief Construct a tensor adopting given data
+/// \param[in] data Pointer to data contiguous in memory
+/// \param[in] shape Shape vector
+/// \param[in] memoryOrder Memory order
+template <typename T>
+RTensor<T>::RTensor(T *data, const Shape_t &shape, MemoryOrder::type memoryOrder)
+{
+   fShape = shape;
+   fStrides = Internal::ComputeStrides(shape, memoryOrder);
+   const auto size = Internal::GetSizeFromShape(shape);
+   fData = Container_t(data, size);
+   fMemoryOrder = memoryOrder;
+}
+
+/// \brief Reshape tensor
+/// \param[in] shape Shape vector
+template <typename T>
+void RTensor<T>::Reshape(const Shape_t &shape)
+{
+   const auto sizeInput = Internal::GetSizeFromShape(shape);
+   if (sizeInput != GetSize()) {
+      std::stringstream ss;
+      ss << "Cannot reshape tensor with size " << GetSize() << " into shape { ";
+      for (std::size_t i = 0; i < shape.size(); i++) {
+         if (i != shape.size() - 1) {
+            ss << shape[i] << ", ";
+         } else {
+            ss << shape[i] << " }.";
+         }
+      }
+      throw std::runtime_error(ss.str());
+   }
+   fShape = shape;
+   fStrides = Internal::ComputeStrides(shape, fMemoryOrder);
+}
+
+/// \brief Expand dimensions
+/// \param[in] idx Index in shape vector where dimension is added
+template <typename T>
+void RTensor<T>::ExpandDims(int idx)
+{
+   // TODO: What happens if shape has size 0?
+   const int len = fShape.size();
+   if (idx < 0) {
+      if (len - idx < 0)
+         throw std::runtime_error("Given negative index is invalid.");
+      fShape.insert(fShape.end() + 1 + idx, 1);
+   } else {
+      if (idx > len - 1)
+         throw std::runtime_error("Given index is invalid.");
+      fShape.insert(fShape.begin() + idx, 1);
+   }
+
+   // Recompute strides
+   fStrides = Internal::ComputeStrides(fShape, fMemoryOrder);
+}
+
+/// \brief Squeeze dimensions
+template <typename T>
+void RTensor<T>::Squeeze()
+{
+   // If shape is empty, return early
+   if (fShape.size() == 0)
+      return;
+
+   // Remove dimensions of 1
+   fShape.erase(std::remove(fShape.begin(), fShape.end(), 1), fShape.end());
+
+   // If all dimensions are 1, we need to keep one.
+   if (fShape.size() == 0)
+      fShape.emplace_back(1);
+
+   // Recompute strides
+   fStrides = Internal::ComputeStrides(fShape, fMemoryOrder);
+}
+
+/// \brief Transpose
+template <typename T>
+void RTensor<T>::Transpose()
+{
+   // Invert memory order
+   if (fMemoryOrder == MemoryOrder::RowMajor) {
+      fMemoryOrder = MemoryOrder::ColumnMajor;
+   } else if (fMemoryOrder == MemoryOrder::ColumnMajor) {
+      fMemoryOrder = MemoryOrder::RowMajor;
+   } else {
+      std::runtime_error("Column order is not known.");
+   }
+
+   // Reverse shape
+   std::reverse(fShape.begin(), fShape.end());
+
+   // Recompute strides
+   fStrides = Internal::ComputeStrides(fShape, fMemoryOrder);
+}
+
+/// \brief Access elements
+/// \param[in] idx Index vector
+/// \return Reference to element
+template <typename T>
+T &RTensor<T>::At(const Index_t &idx)
+{
+   std::size_t globalIndex = 0;
+   const auto size = idx.size();
+   for (std::size_t i = 0; i < size; i++) {
+      globalIndex += fStrides[size - 1 - i] * idx[size - 1 - i];
+   }
+   return fData[globalIndex];
+}
+
+/// \brief Access elements
+/// \param[in] idx Indices
+/// \return Reference to element
+template <typename T>
+template <typename... Idx>
+T &RTensor<T>::At(Idx... idx)
+{
+   static_assert(Internal::and_types<std::is_convertible<Idx, std::size_t>...>{},
+                 "Given index is not convertible to std::size_t.");
+   return this->At({static_cast<std::size_t>(idx)...});
+}
+
+/// \brief Access elements
+/// \param[in] idx Index vector
+/// \return Reference to element
+template <typename T>
+T &RTensor<T>::operator()(const Index_t &idx)
+{
+   return this->At(idx);
+}
+
+/// \brief Access elements
+/// \param[in] idx Indices
+/// \return Reference to element
+template <typename T>
+template <typename... Idx>
+T &RTensor<T>::operator()(Idx... idx)
+{
+   static_assert(Internal::and_types<std::is_convertible<Idx, std::size_t>...>{},
+                 "Given index is not convertible to std::size_t.");
+   return this->At({static_cast<std::size_t>(idx)...});
+}
+
+/// \brief Slicing
+/// \param[in] idx Index vector
+/// \return New RTensor with elements of slice
+template <typename T>
+RTensor<T> RTensor<T>::Slice(const Slice_t &idx)
+{
+   const auto size = idx.size();
+   if (size != fShape.size()) {
+      throw std::runtime_error("Rank of given indices does not match shape.");
+   }
+
+   for (std::size_t i = 0; i < size; i++) {
+      if (idx[i] < 0 && idx[i] != -1) {
+         throw std::runtime_error("Negative indices of a slice can only be -1.");
+      }
+   }
+
+   // Calculate new shape of slice
+   Shape_t newShape;
+   for (std::size_t i = 0; i < size; i++) {
+      if (idx[i] == -1) {
+         newShape.emplace_back(fShape[i]);
+      } else {
+         newShape.emplace_back(1);
+      }
+   }
+
+   // Allocate new tensor
+   RTensor<T> x(newShape, fMemoryOrder);
+
+   // Copy over values
+   Shape_t mins(size), maxs(size);
+   for (std::size_t i = 0; i < size; i++) {
+      if (idx[i] == -1) {
+         mins[i] = 0;
+         maxs[i] = fShape[i];
+      } else {
+         mins[i] = idx[i];
+         maxs[i] = idx[i] + 1;
+      }
+   }
+   Internal::RecursiveCopy(*this, x, mins, maxs, mins, 0);
+
+   // Remove dimensions of 1
+   x.Squeeze();
+
+   return x;
+}
+
+/// \brief Slicing
+/// \param[in] idx Indices
+/// \return New RTensor with elements of slice
+template <typename T>
+template <typename... Idx>
+RTensor<T> RTensor<T>::Slice(Idx... idx)
+{
+   static_assert(Internal::and_types<std::is_convertible<Idx, int>...>{}, "Given index is not convertible to int.");
+   return this->Slice({static_cast<int>(idx)...});
+}
+
+/// \brief Pretty printing
+/// \param[in] os Output stream
+/// \param[in] x RTensor
+/// \return Modified output stream
+template <typename T>
+std::ostream &operator<<(std::ostream &os, RTensor<T> &x)
+{
+   const auto shapeSize = x.GetShape().size();
+   if (shapeSize == 1) {
+      os << "{ ";
+      auto data = x.GetData();
+      const auto size = x.GetSize();
+      for (std::size_t i = 0; i < size; i++) {
+         os << *(data + i);
+         if (i != size - 1)
+            os << ", ";
+      }
+      os << " }";
+   } else if (shapeSize == 2) {
+      os << "{";
+      const auto shape = x.GetShape();
+      for (std::size_t i = 0; i < shape[0]; i++) {
+         os << " { ";
+         for (std::size_t j = 0; j < shape[1]; j++) {
+            os << x(i, j);
+            if (j < shape[1] - 1) {
+               os << ", ";
+            } else {
+               os << " ";
+            }
+         }
+         os << "}";
+      }
+      os << " }";
+   } else {
+      os << "{ printing not yet implemented for this rank }";
+   }
+   return os;
+}
+
+} // namespace TMVA::Experimental
+} // namespace TMVA
+
+namespace cling {
+template <typename T>
+std::string printValue(TMVA::Experimental::RTensor<T> *x)
+{
+   std::stringstream ss;
+   ss << *x;
+   return ss.str();
+}
+} // namespace cling
+
+#endif // TMVA_RTENSOR

--- a/tmva/tmva/inc/TMVA/RTensorUtils.hxx
+++ b/tmva/tmva/inc/TMVA/RTensorUtils.hxx
@@ -1,0 +1,65 @@
+#ifndef TMVA_RTENSOR_UTILS
+#define TMVA_RTENSOR_UTILS
+
+#include <vector>
+#include <string>
+
+#include "TMVA/RTensor.hxx"
+#include "ROOT/RDataFrame.hxx"
+#include "ROOT/RDF/RInterface.hxx"
+
+namespace TMVA {
+namespace Experimental {
+
+/// \brief Convert the content of an RDataFrame to an RTensor
+/// \param[in] dataframe RDataFrame node
+/// \param[in] columns Vector of column names
+/// \param[in] memoryOrder Memory order
+/// \return RTensor with content from selected columns
+template <typename T, typename U>
+RTensor<T>
+AsTensor(U &dataframe, std::vector<std::string> columns = {}, MemoryOrder::type memoryOrder = MemoryOrder::RowMajor)
+{
+   // If no columns are specified, get all columns from dataframe
+   if (columns.size() == 0) {
+      columns = dataframe.GetColumnNames();
+   }
+
+   // Book actions to read-out columns of dataframe in vectors
+   using ResultPtr = ROOT::RDF::RResultPtr<std::vector<T>>;
+   std::vector<ResultPtr> resultPtrs;
+   for (auto &col : columns) {
+      resultPtrs.emplace_back(dataframe.template Take<T>(col));
+   }
+
+   // Copy data to tensor based on requested memory layout
+   const auto numCols = resultPtrs.size();
+   const auto numEntries = resultPtrs[0]->size();
+   RTensor<T> x({numEntries, numCols}, memoryOrder);
+   const auto data = x.GetData();
+   if (memoryOrder == MemoryOrder::RowMajor) {
+      for (std::size_t i = 0; i < numEntries; i++) {
+         const auto entry = data + numCols * i;
+         for (std::size_t j = 0; j < numCols; j++) {
+            entry[j] = resultPtrs[j]->at(i);
+         }
+      }
+   } else if (memoryOrder == MemoryOrder::ColumnMajor) {
+      for (std::size_t i = 0; i < numCols; i++) {
+         // TODO: Replace by RVec<T>::insert as soon as available.
+         std::memcpy(data + numEntries * i, &resultPtrs[i]->at(0), numEntries * sizeof(T));
+      }
+   } else {
+      throw std::runtime_error("Memory order is not known.");
+   }
+
+   // Remove dimensions of 1
+   x.Squeeze();
+
+   return x;
+}
+
+} // namespace TMVA::Experimental
+} // namespace TMVA
+
+#endif

--- a/tmva/tmva/test/CMakeLists.txt
+++ b/tmva/tmva/test/CMakeLists.txt
@@ -10,6 +10,7 @@ include_directories(${ROOT_INCLUDE_DIRS})
 ROOT_ADD_GTEST(TestRandomGenerator
                TestRandomGenerator.cxx
                LIBRARIES ${Libraries})
+ROOT_ADD_GTEST(rtensor rtensor.cxx LIBRARIES ROOTVecOps TMVA)
 
 project(tmva-tests)
 find_package(ROOT REQUIRED)

--- a/tmva/tmva/test/CMakeLists.txt
+++ b/tmva/tmva/test/CMakeLists.txt
@@ -11,6 +11,7 @@ ROOT_ADD_GTEST(TestRandomGenerator
                TestRandomGenerator.cxx
                LIBRARIES ${Libraries})
 ROOT_ADD_GTEST(rtensor rtensor.cxx LIBRARIES ROOTVecOps TMVA)
+ROOT_ADD_GTEST(rtensor-utils rtensor_utils.cxx LIBRARIES ROOTVecOps TMVA ROOTDataFrame)
 
 project(tmva-tests)
 find_package(ROOT REQUIRED)

--- a/tmva/tmva/test/rtensor.cxx
+++ b/tmva/tmva/test/rtensor.cxx
@@ -1,0 +1,396 @@
+#include <gtest/gtest.h>
+#include <TMVA/RTensor.hxx>
+
+using namespace TMVA::Experimental;
+
+TEST(RTensor, GetElement)
+{
+   float data[6] = {0, 1, 2, 3, 4, 5};
+   RTensor<float> x(data, {2, 3});
+   auto shape = x.GetShape();
+   float count = 0.0;
+   for (size_t i = 0; i < shape[0]; i++) {
+      for (size_t j = 0; j < shape[1]; j++) {
+         EXPECT_EQ(count, x.At({i, j}));
+         EXPECT_EQ(count, x.At(i, j));
+         EXPECT_EQ(count, x({i, j}));
+         EXPECT_EQ(count, x(i, j));
+         count++;
+      }
+   }
+}
+
+TEST(RTensor, SetElement)
+{
+   RTensor<float> x({2, 3});
+   auto shape = x.GetShape();
+   float count = 0.0;
+   for (size_t i = 0; i < shape[0]; i++) {
+      for (size_t j = 0; j < shape[1]; j++) {
+         x.At({i, j}) = count;
+         x.At(i, j) = count;
+         x({i, j}) = count;
+         x(i, j) = count;
+         count++;
+      }
+   }
+   auto data = x.GetData();
+   for (size_t i = 0; i < shape.size(); i++)
+      EXPECT_EQ((float)i, *(data + i));
+}
+
+TEST(RTensor, AdoptMemory)
+{
+   float data[4] = {0, 0, 0, 0};
+   RTensor<float> x(data, {4});
+   for (size_t i = 0; i < 4; i++)
+      x(i) = (float)i;
+   for (size_t i = 0; i < 4; i++)
+      EXPECT_EQ((float)i, data[i]);
+}
+
+TEST(RTensor, GetShape)
+{
+   RTensor<int> x({2, 3});
+   const auto s = x.GetShape();
+   EXPECT_EQ(s.size(), 2u);
+   EXPECT_EQ(s[0], 2u);
+   EXPECT_EQ(s[1], 3u);
+}
+
+TEST(RTensor, Reshape)
+{
+   RTensor<int> x({2, 3});
+   const auto s = x.GetShape();
+   EXPECT_EQ(s.size(), 2u);
+   EXPECT_EQ(s[0], 2u);
+   EXPECT_EQ(s[1], 3u);
+
+   x.Reshape({1, 6});
+   const auto s2 = x.GetShape();
+   EXPECT_EQ(s2.size(), 2u);
+   EXPECT_EQ(s2[0], 1u);
+   EXPECT_EQ(s2[1], 6u);
+
+   x.Reshape({6});
+   const auto s3 = x.GetShape();
+   EXPECT_EQ(s3.size(), 1u);
+   EXPECT_EQ(s3[0], 6u);
+}
+
+TEST(RTensor, ExpandDims)
+{
+   RTensor<int> x({2, 3});
+   x.ExpandDims(0);
+   const auto s = x.GetShape();
+   EXPECT_EQ(s.size(), 3u);
+   EXPECT_EQ(s[0], 1u);
+   EXPECT_EQ(s[1], 2u);
+   EXPECT_EQ(s[2], 3u);
+
+   RTensor<int> x1({2, 3});
+   x1.ExpandDims(1);
+   const auto s1 = x1.GetShape();
+   EXPECT_EQ(s1.size(), 3u);
+   EXPECT_EQ(s1[0], 2u);
+   EXPECT_EQ(s1[1], 1u);
+   EXPECT_EQ(s1[2], 3u);
+
+   RTensor<int> x2({2, 3});
+   x2.ExpandDims(-1);
+   const auto s2 = x2.GetShape();
+   EXPECT_EQ(s2.size(), 3u);
+   EXPECT_EQ(s2[0], 2u);
+   EXPECT_EQ(s2[1], 3u);
+   EXPECT_EQ(s2[2], 1u);
+}
+
+TEST(RTensor, Squeeze)
+{
+   RTensor<int> x({1, 2, 3});
+   x.Squeeze();
+   const auto s = x.GetShape();
+   EXPECT_EQ(s.size(), 2u);
+   EXPECT_EQ(s[0], 2u);
+   EXPECT_EQ(s[1], 3u);
+
+   RTensor<int> x1({1, 2, 1, 3, 1});
+   x1.Squeeze();
+   const auto s1 = x1.GetShape();
+   EXPECT_EQ(s1.size(), 2u);
+   EXPECT_EQ(s1[0], 2u);
+   EXPECT_EQ(s1[1], 3u);
+
+   RTensor<int> x2({1, 1, 1});
+   x2.Squeeze();
+   const auto s2 = x2.GetShape();
+   EXPECT_EQ(s2.size(), 1u);
+   EXPECT_EQ(s2[0], 1u);
+
+   RTensor<int> x3({});
+   x3.Squeeze();
+   const auto s3 = x3.GetShape();
+   EXPECT_EQ(s3.size(), 0u);
+}
+
+TEST(RTensor, Transpose)
+{
+   // Layout (physical):
+   // 0, 1, 2, 3, 4, 5
+   float data[6] = {0, 1, 2, 3, 4, 5};
+   RTensor<float> x(data, {2, 3});
+
+   // Layout (logical):
+   // 0, 1, 2
+   // 3, 4, 5
+   float count = 0;
+   for (size_t i = 0; i < 2; i++) {
+      for (size_t j = 0; j < 3; j++) {
+         x(i, j) = count;
+         count++;
+      }
+   }
+
+   // Layout (logical):
+   // 0, 3
+   // 1, 4
+   // 2, 5
+   x.Transpose();
+   EXPECT_EQ(x.GetShape().size(), 2u);
+   EXPECT_EQ(x.GetShape()[0], 3u);
+   EXPECT_EQ(x.GetShape()[1], 2u);
+   count = 0;
+   for (size_t i = 0; i < 2; i++) {
+      for (size_t j = 0; j < 3; j++) {
+         x(j, i) = count;
+         count++;
+      }
+   }
+}
+
+TEST(RTensor, InitWithZeros)
+{
+   RTensor<float> x({2, 3});
+   for (size_t i = 0; i < 2; i++) {
+      for (size_t j = 0; j < 3; j++) {
+         EXPECT_EQ(0.0, x(i, j));
+      }
+   }
+}
+
+TEST(RTensor, SetElementRowMajor)
+{
+   // Layout (logical):
+   // 0, 1, 2
+   // 3, 4, 5
+   RTensor<float> x({2, 3}, MemoryOrder::RowMajor);
+   float count = 0;
+   for (size_t i = 0; i < 2; i++) {
+      for (size_t j = 0; j < 3; j++) {
+         x(i, j) = count;
+         count++;
+      }
+   }
+
+   // Layout (physical):
+   // 0, 1, 2, 3, 4, 5
+   float ref[6] = {0, 1, 2, 3, 4, 5};
+   float *data = x.GetData();
+   for (size_t i = 0; i < 6; i++) {
+      EXPECT_EQ(data[i], ref[i]);
+   }
+}
+
+TEST(RTensor, SetElementColumnMajor)
+{
+   // Layout (logical):
+   // 0, 1, 2
+   // 3, 4, 5
+   RTensor<float> x({2, 3}, MemoryOrder::ColumnMajor);
+   float count = 0;
+   for (size_t i = 0; i < 2; i++) {
+      for (size_t j = 0; j < 3; j++) {
+         x(i, j) = count;
+         count++;
+      }
+   }
+
+   // Layout (physical):
+   // 0, 3, 1, 4, 2, 5
+   float ref[6] = {0, 3, 1, 4, 2, 5};
+   float *data = x.GetData();
+   for (size_t i = 0; i < 6; i++) {
+      EXPECT_EQ(data[i], ref[i]);
+   }
+}
+
+TEST(RTensor, GetElementRowMajor)
+{
+   // Layout (physical):
+   // 0, 1, 2, 3, 4, 5
+   float data[6] = {0, 1, 2, 3, 4, 5};
+   RTensor<float> x(data, {2, 3}, MemoryOrder::RowMajor);
+
+   // Layout (logical):
+   // 0, 1, 2
+   // 3, 4, 5
+   float count = 0;
+   for (size_t i = 0; i < 2; i++) {
+      for (size_t j = 0; j < 3; j++) {
+         EXPECT_EQ(x(i, j), count);
+         count++;
+      }
+   }
+}
+
+TEST(RTensor, GetElementColumnMajor)
+{
+   // Layout (physical):
+   // 0, 3, 1, 4, 2, 5
+   float data[6] = {0, 3, 1, 4, 2, 5};
+   RTensor<float> x(data, {2, 3}, MemoryOrder::ColumnMajor);
+
+   // Layout (logical):
+   // 0, 1, 2
+   // 3, 4, 5
+   float count = 0;
+   for (size_t i = 0; i < 2; i++) {
+      for (size_t j = 0; j < 3; j++) {
+         EXPECT_EQ(x(i, j), count);
+         count++;
+      }
+   }
+}
+
+TEST(RTensor, IteratorInterface)
+{
+   // Layout (logical):
+   // 0, 1, 2
+   // 3, 4, 5
+   RTensor<float> x({2, 3}, MemoryOrder::RowMajor);
+   float c = 0.0;
+   for (size_t i = 0; i < 2; i++) {
+      for (size_t j = 0; j < 3; j++) {
+         x(i, j) = c;
+         c++;
+      }
+   }
+   // Layout (physical):
+   // 0, 1, 2, 3, 4, 5
+   c = 0.0;
+   for (auto &v : x) {
+      EXPECT_EQ(v, c);
+      c++;
+   }
+
+   // Layout (physical):
+   // 1, 2, 3, 4, 5, 6
+   for (auto &v : x) {
+      v++;
+   }
+   // Layout (logical):
+   // 1, 2, 3
+   // 4, 5, 6
+   c = 1.0;
+   for (size_t i = 0; i < 2; i++) {
+      for (size_t j = 0; j < 3; j++) {
+         x(i, j) = c;
+         c++;
+      }
+   }
+
+   // Layout (physical):
+   // 0, 1, 2, 3, 4, 5
+   RTensor<float> x2({2, 3}, MemoryOrder::ColumnMajor);
+   c = 0.0;
+   for (auto &v : x2) {
+      v = c;
+      c++;
+   }
+   // Layout (logical):
+   // 0, 2, 4
+   // 1, 3, 5
+   std::vector<float> c2 = {0, 2, 4, 1, 3, 5};
+   size_t k = 0;
+   for (size_t i = 0; i < 2; i++) {
+      for (size_t j = 0; j < 3; j++) {
+         EXPECT_EQ(x2(i, j), c2[k]);
+         k++;
+      }
+   }
+}
+
+TEST(RTensor, Slice)
+{
+   // Data layout:
+   // [ [ 0, 1, 2 ], [ 3, 4, 5 ] ]
+   RTensor<float> x({2, 3});
+   float c = 0.0;
+   for (auto &v : x) {
+      v = c;
+      c++;
+   }
+
+   auto s1 = x.Slice({0, -1});
+   std::vector<float> ref1 = {0, 1, 2};
+   EXPECT_EQ(s1.GetSize(), ref1.size());
+   EXPECT_EQ(s1.GetShape().size(), 1u);
+   EXPECT_EQ(s1.GetShape()[0], 3u);
+   const auto d1 = s1.GetData();
+   for (size_t i = 0; i < ref1.size(); i++) {
+      EXPECT_EQ(ref1[i], d1[i]);
+   }
+
+   auto s2 = x.Slice(-1, 2);
+   std::vector<float> ref2 = {2, 5};
+   EXPECT_EQ(s2.GetSize(), ref2.size());
+   EXPECT_EQ(s2.GetShape().size(), 1u);
+   EXPECT_EQ(s2.GetShape()[0], 2u);
+   const auto d2 = s2.GetData();
+   for (size_t i = 0; i < ref2.size(); i++) {
+      EXPECT_EQ(ref2[i], d2[i]);
+   }
+
+   auto s3 = x.Slice(-1, -1);
+   std::vector<float> ref3 = {0, 1, 2, 3, 4, 5};
+   EXPECT_EQ(s3.GetSize(), ref3.size());
+   EXPECT_EQ(s3.GetShape().size(), 2u);
+   EXPECT_EQ(s3.GetShape()[0], 2u);
+   EXPECT_EQ(s3.GetShape()[1], 3u);
+   const auto d3 = s3.GetData();
+   for (size_t i = 0; i < ref3.size(); i++) {
+      EXPECT_EQ(ref3[i], d3[i]);
+   }
+
+   auto s4 = x.Slice({1, 1});
+   std::vector<float> ref4 = {4};
+   EXPECT_EQ(s4.GetSize(), ref4.size());
+   EXPECT_EQ(s4.GetShape().size(), 1u);
+   EXPECT_EQ(s4.GetShape()[0], 1u);
+   const auto d4 = s4.GetData();
+   for (size_t i = 0; i < ref4.size(); i++) {
+      EXPECT_EQ(ref4[i], d4[i]);
+   }
+
+   RTensor<float> x2({2, 2, 2});
+   c = 0.0;
+   for (auto &v : x2) {
+      v = c;
+      c++;
+   }
+
+   // Data layout:
+   // [ [ [ 0, 1 ], [ 2, 3 ] ], [ [ 4, 5 ], [ 6, 7 ] ] ]
+   // Selected:
+   // [ [ 2, 3 ], [ 6, 7 ] ]
+   auto s5 = x2.Slice({-1, 1, -1});
+   std::vector<float> ref5 = {2, 3, 6, 7};
+   EXPECT_EQ(s5.GetSize(), ref5.size());
+   EXPECT_EQ(s5.GetShape().size(), 2u);
+   EXPECT_EQ(s5.GetShape()[0], 2u);
+   EXPECT_EQ(s5.GetShape()[1], 2u);
+   const auto d5 = s5.GetData();
+   for (size_t i = 0; i < ref5.size(); i++) {
+      EXPECT_EQ(ref5[i], d5[i]);
+   }
+}

--- a/tmva/tmva/test/rtensor_utils.cxx
+++ b/tmva/tmva/test/rtensor_utils.cxx
@@ -1,0 +1,49 @@
+#include <gtest/gtest.h>
+#include "TMVA/RTensor.hxx"
+#include "TMVA/RTensorUtils.hxx"
+#include "ROOT/RDataFrame.hxx"
+
+using namespace ROOT;
+using namespace TMVA::Experimental;
+
+TEST(RTensor, AsTensor)
+{
+   RDataFrame df(10);
+   auto df2 = df.Define("a", "1.f * rdfentry_").Define("b", "-1.f * rdfentry_");
+   auto x = AsTensor<float>(df2, {"a", "b"});
+   EXPECT_EQ(x.GetShape().size(), 2u);
+   EXPECT_EQ(x.GetShape()[0], 10u);
+   EXPECT_EQ(x.GetShape()[1], 2u);
+   for (size_t i = 0; i < 10; i++) {
+      EXPECT_EQ(x(i, 0), 1.f * i);
+      EXPECT_EQ(x(i, 1), -1.f * i);
+   }
+}
+
+TEST(RTensor, AsTensorAllColumns)
+{
+   RDataFrame df(10);
+   auto df2 = df.Define("a", "1.f * rdfentry_").Define("b", "-1.f * rdfentry_");
+   auto x = AsTensor<float>(df2);
+   EXPECT_EQ(x.GetShape().size(), 2u);
+   EXPECT_EQ(x.GetShape()[0], 10u);
+   EXPECT_EQ(x.GetShape()[1], 2u);
+   for (size_t i = 0; i < 10; i++) {
+      EXPECT_EQ(x(i, 0), 1.f * i);
+      EXPECT_EQ(x(i, 1), -1.f * i);
+   }
+}
+
+TEST(RTensor, AsTensorColumnMajor)
+{
+   RDataFrame df(10);
+   auto df2 = df.Define("a", "1.f * rdfentry_").Define("b", "-1.f * rdfentry_");
+   auto x = AsTensor<float>(df2, {"a", "b"}, MemoryOrder::ColumnMajor);
+   EXPECT_EQ(x.GetShape().size(), 2u);
+   EXPECT_EQ(x.GetShape()[0], 10u);
+   EXPECT_EQ(x.GetShape()[1], 2u);
+   for (size_t i = 0; i < 10; i++) {
+      EXPECT_EQ(x(i, 0), 1.f * i);
+      EXPECT_EQ(x(i, 1), -1.f * i);
+   }
+}

--- a/tutorials/tmva/tmva001_RTensor.C
+++ b/tutorials/tmva/tmva001_RTensor.C
@@ -1,0 +1,85 @@
+/// \file
+/// \ingroup tutorial_dataframe
+/// \notebook -nodraw
+/// This tutorial illustrates the basic features of the RTensor class,
+/// RTensor is a std::vector-like container with additional shape information.
+/// The class serves as an interface in C++ between multi-dimensional data and
+/// the algorithm such as in machine learning workflows. The interface is similar
+/// to Numpy arrays and provides a subset of the functionality.
+///
+/// \macro_code
+/// \macro_output
+///
+/// \date December 2018
+/// \author Stefan Wunsch
+
+using namespace TMVA::Experimental;
+using namespace ROOT::VecOps;
+
+void tmva001_RTensor()
+{
+   // Instantiation of an RTensor
+
+   // An RTensor can be created from scratch, which will be filled with zeros.
+   RTensor<float> x1({2, 3});
+
+   std::cout << "RTensor initialized with zeros:\n" << x1 << "\n\n";
+
+   // However, an RTensor can also be used to create a view on existing data in
+   // memory and adopts the data but does not own it.
+   float data[] = {1, 2, 3, 4, 5, 6};
+   RTensor<float> x2(data, {2, 3});
+
+   std::cout << "RTensor with adopted data:\n" << x2 << "\n\n";
+
+   // You can get and set elements of the RTensor either through the At method
+   // or directly by putting the indices in braces. The methods access either
+   // single arguments as indices for each dimension or a vector of indices.
+   x2.At(0, 0) = -1;
+   x2.At({0, 1}) = -2;
+   x2(0, 2) = -3;
+   x2({1, 0}) = -4;
+
+   std::cout << "RTensor with modified elements:\n" << x2 << "\n\n";
+   std::cout << "Element (1, 1) of the RTensor: " << x2(1, 1) << "\n\n";
+
+   // The shape of the vector can be modified without touching the data with
+   // methods inspired by the Numpy interface.
+   std::cout << "Shape of RTensor: " << RVec<size_t>(x2.GetShape()) << "\n\n";
+
+   x2.Reshape({1, 6});
+   std::cout << "RTensor reshaped to shape (1, 6): " << RVec<size_t>(x2.GetShape()) << "\n\n";
+
+   x2.ExpandDims(-1);
+   std::cout << "Add additional dimension of 1 to the shape: " << RVec<size_t>(x2.GetShape()) << "\n\n";
+
+   x2.Squeeze();
+   std::cout << "Remove dimensions of 1 from the shape: " << RVec<size_t>(x2.GetShape()) << "\n\n";
+
+   // RTensor is also aware of the memory order used to store the data in memory.
+   float data2[] = {1, 4, 2, 5, 3, 6};
+   RTensor<float> x3(data2, {2, 3}, MemoryOrder::ColumnMajor);
+
+   std::cout << "RTensor as view on column-major ordered data:\n" << x3 << "\n\n";
+
+   // This allows to transpose an RTensor without moving the data in memory.
+   x3.Transpose();
+
+   std::cout << "Transposed RTensor:\n" << x3 << "\n\n";
+
+   // The container has a STL iterator interface, which allows you to iterator
+   // over the elements conveniently. Note that the iteration is always over
+   // the physical data-layout of the RTensor.
+   for (auto &v : x3)
+      v++;
+
+   std::cout << "RTensor modified using a range-based for loop:\n" << x3 << "\n\n";
+
+   // RTensor also supportes extracting slices, which returns a new RTensor.
+   // Note that a slice makes always a copy of the data.
+   auto x4 = x3.Slice({2, -1});
+   auto x5 = x3.Slice({-1, 0});
+
+   std::cout << "Slice { 2, -1 }:\n" << x4 << "\n\n";
+   std::cout << "Slice { -1, 0 }:\n" << x5 << "\n\n";
+}

--- a/tutorials/tmva/tmva002_RDataFrameAsTensor.C
+++ b/tutorials/tmva/tmva002_RDataFrameAsTensor.C
@@ -1,0 +1,31 @@
+/// \file
+/// \ingroup tutorial_dataframe
+/// \notebook -nodraw
+/// This tutorial shows how the content of an RDataFrame can be converted to an
+/// RTensor object.
+///
+/// \macro_code
+/// \macro_output
+///
+/// \date December 2018
+/// \author Stefan Wunsch
+
+using namespace TMVA::Experimental;
+
+void tmva002_RDataFrameAsTensor()
+{
+   // Creation of an RDataFrame with five entries filled with ascending numbers
+   ROOT::RDataFrame df(5);
+   auto df2 = df.Define("x", "1.f*rdfentry_").Define("y", "-1.f*rdfentry_");
+
+   // Convert content of columns to an RTensor object
+   auto x = AsTensor<float>(df2);
+
+   std::cout << "RTensor from an RDataFrame:\n" << x << "\n\n";
+
+   // The utility also supports reading only a part of the RDataFrame and different
+   // memory layouts.
+   auto x2 = AsTensor<float>(df2, {"x"}, MemoryOrder::ColumnMajor);
+
+   std::cout << "RTensor from a single column of the RDataFrame:\n" << x2 << "\n\n";
+}


### PR DESCRIPTION
Implementation of the C++ side of RTensor. This PR replaces #2593.

In addition, a second commit adds the feature `TMVA::Experimental::AsTensor`, which reads out an `RDataFrame` node as an `RTensor`. See the tutorials for examples or the short snipplets below.

**RTensor basics:**
```cpp
using namespace TMVA::Experimental;

// Create an RTensor from existing data
float data[] = {1, 2, 3, 4, 5, 6};
RTensor<float> x(data, {2, 3});
std::cout << x << std::endl;
// { { 1, 2, 3 }, { 4, 5, 6 } }

// Reshape the tensor without touching the data
x.Reshape({1, 6});
std::cout << x << std::endl;
// { { 1, 2, 3, 4, 5, 6 } }

// Remove dimensions of 1
x.Squeeze();
std::cout << x << std::endl;
// { 1, 2, 3, 4, 5, 6 }

// Add dimensions
x.ExpandDims(0);
std::cout << x << std::endl;
// { { 1, 2, 3, 4, 5, 6 } }

// Transpose the tensor
x.Transpose();
std::cout << x << std::endl;
// { {1}, {2}, {3}, {4}, {5}, {6} }

// Extract slices as new RTensor objects
x.Reshape({2, 3});
std::cout << x << std::endl;
// { { 1, 3, 5 }, { 2, 4, 6 } }

auto y = x.Slice({-1, 0});
std::cout << y << std::endl;
// { 1, 2 }

auto z = x.Slice({0, -1});
std::cout << z << std::endl;
// { 1, 3, 5 }

// STL iterator interface and range-based loops
for(auto &v: x) v++;
std::cout << x << std::endl;
// { { 2, 4, 6 }, { 3, 5, 7 } }
```

**TMVA::Experimental::AsTensor usage:**

```cpp
ROOT::RDataFrame df(5);
auto df2 = df.Define("x", "1.f*rdfentry_").Define("y", "-1.f*rdfentry_");
auto x = TMVA::Experimental::AsTensor<float>(df2);
std::cout << x << std::endl;
// { { 0, -0 }, { 1, -1 }, { 2, -2 }, { 3, -3 }, { 4, -4 } }
```