### PR TITLE
[IMT][ROOT-9892] Impose work isolation to TTaskGroup

### DIFF
--- a/core/imt/inc/ROOT/TTaskGroup.hxx
+++ b/core/imt/inc/ROOT/TTaskGroup.hxx
@@ -29,8 +29,11 @@ class TTaskGroup {
    */
 private:
    using TaskContainerPtr_t = void *; /// Shield completely from implementation
+   using TaskArenaPtr_t = void *;     /// Shield completely from implementation
    TaskContainerPtr_t fTaskContainer{nullptr};
+   TaskArenaPtr_t fTaskArena{nullptr};
    std::atomic<bool> fCanRun{true};
+   void ExecuteInIsolation(const std::function<void(void)> &operation);
 
 public:
    TTaskGroup();
@@ -43,7 +46,7 @@ public:
    void Run(const std::function<void(void)> &closure);
    void Wait();
 };
-}
-}
+} // namespace Experimental
+} // namespace ROOT
 
 #endif


### PR DESCRIPTION
otherwise, tasks while waiting for the completion of all tasks,
the workers can steal work items submitted to the TBB runtime by
ancestors.