### PR TITLE
Drop MathCore and ROOTVecOps from PyROOT dependencies

### DIFF
--- a/bindings/pyroot/CMakeLists.txt
+++ b/bindings/pyroot/CMakeLists.txt
@@ -50,8 +50,6 @@ ROOT_STANDARD_LIBRARY_PACKAGE(PyROOT
     -writeEmptyRootPCM
   DEPENDENCIES
     Core
-    MathCore
-    ROOTVecOps
     Tree
 )
 


### PR DESCRIPTION
These two libraries do not need to be linked, they can be loaded at runtime when necessary. `ROOTVecOps` in particular forces `libPyROOT.so` to link against Vdt when that is enabled, which we would like to avoid.

*Note:* `RVec` pythonization has been recently made lazy in 3017be2d80c160d8726c887fad2ede81c295c27a.