### PR TITLE
Add explicit dependency between Imt and G__Imt targets

### DIFF
--- a/core/imt/CMakeLists.txt
+++ b/core/imt/CMakeLists.txt
@@ -39,6 +39,8 @@ if(imt)
     src/TThreadExecutor.cxx
   )
 
+  add_dependencies(Imt G__Imt)
+
   ROOT_ADD_TEST_SUBDIRECTORY(test)
 endif()
 


### PR DESCRIPTION
CMake should detect this, but since the output `G__Imt.cxx` is used both by `G__Imt` (custom target created by `ROOT_GENERATE_DICTIONARY()`) and `Imt` (via `target_sources()`), it leads to problems in parallel builds.