### PR TITLE
[ROOT-9789] Support member function templates in PyROOT

### DIFF
--- a/bindings/pyroot/src/Pythonize.cxx
+++ b/bindings/pyroot/src/Pythonize.cxx
@@ -2660,6 +2660,9 @@ Bool_t PyROOT::Pythonize( PyObject* pyclass, const std::string& name )
    // add safety for non-TObject derived Get() results
       Utility::AddToClass( pyclass, "Get", (PyCFunction) TDirectoryFileGet,     METH_O );
 
+      // Re-inject here too, since TDirectoryFile redefines GetObject
+      Utility::AddToClass(pyclass, "GetObject", (PyCFunction)TDirectoryGetObject);
+
       return kTRUE;
    }
 
@@ -2745,7 +2748,6 @@ Bool_t PyROOT::Pythonize( PyObject* pyclass, const std::string& name )
 
    // allow member-style access to entries in file
       Utility::AddToClass( pyclass, "__getattr__", (PyCFunction) TFileGetAttr, METH_O );
-
    }
 
    else if ( name.substr(0,8) == "TVector3" ) {

--- a/bindings/pyroot/src/RootWrapper.cxx
+++ b/bindings/pyroot/src/RootWrapper.cxx
@@ -31,6 +31,7 @@
 #include "TGlobal.h"
 #include "DllImport.h"
 #include "TFunctionTemplate.h"
+#include "TCollection.h"
 
 // Standard
 #include <map>
@@ -210,9 +211,7 @@ static int BuildScopeProxyDict( Cppyy::TCppScope_t scope, PyObject* pyclass ) {
 
    // Add function templates that have not been instantiated to the class dictionary
    auto cppClass = TClass::GetClass(Cppyy::GetFinalName(scope).c_str());
-   TIter next(cppClass->GetListOfFunctionTemplates());
-   TFunctionTemplate *templ = nullptr;
-   while ((templ = (TFunctionTemplate*)next())) {
+   for (auto templ : ROOT::Detail::TRangeStaticCast<TFunctionTemplate>(cppClass->GetListOfFunctionTemplates())) {
       if (templ->Property() & kIsPublic) { // Discard private templates
          auto templName = templ->GetName();
          auto attr = PyObject_GetAttrString(pyclass, templName);

--- a/bindings/pyroot/src/RootWrapper.cxx
+++ b/bindings/pyroot/src/RootWrapper.cxx
@@ -214,9 +214,14 @@ static int BuildScopeProxyDict( Cppyy::TCppScope_t scope, PyObject* pyclass ) {
    TFunctionTemplate *templ = nullptr;
    while ((templ = (TFunctionTemplate*)next())) {
       if (templ->Property() & kIsPublic) { // Discard private templates
-         auto templProxy = TemplateProxy_New(templ->GetName(), pyclass);
-         PyObject_SetAttrString(pyclass, templ->GetName(), (PyObject*)templProxy);
-         Py_DECREF(templProxy);
+         auto templName = templ->GetName();
+         auto attr = PyObject_GetAttrString(pyclass, templName);
+         if (!TemplateProxy_Check(attr)) {
+            auto templProxy = TemplateProxy_New(templName, pyclass);
+            PyObject_SetAttrString(pyclass, templName, (PyObject*)templProxy);
+            Py_DECREF(templProxy);
+         }
+         Py_XDECREF(attr);
       }
    }
 


### PR DESCRIPTION
This PR makes sure that member function templates are added to the dictionary of class proxies, so that they are found when the user is trying to access them. For instance:

```python
import ROOT

ROOT.gInterpreter.Declare("""
struct TestClass {
    template<class T> void templatedMember(const T& value) { }
};
""")

t = ROOT.TestClass()
t.templatedMember('int')(1)
```
The example also works if there are non-templated overloads and the user tries to instantiate the templated one, thanks to https://github.com/root-project/root/pull/3226.

The re-injection of the pythonization of `GetObject` in `TDirectoryFile` is now necessary because, as a result of these changes, `GetObject` will be added to the dictionary of `TDirectoryFile` as a `TemplateProxy`. If we want the pythonization to prevail, we need to inject it (it will replace the `TemplateProxy`, just like in `TDirectory`). `TFile` will inherit that pythonization too, so we keep the current behaviour and all tests green.

An extension of the PyROOT tests for templates is coming in another PR.