### PR TITLE
[CMAKE] Do not build stressHistFactory if GSL is not found

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -212,7 +212,7 @@ endif()
 
 #--stressHistFactory--------------------------------------------------------------------------------
 if(ROOT_roofit_FOUND)
-if(ROOT_xml_FOUND)
+if((xml OR ROOT_xml_FOUND) AND GSL_FOUND) # must use same check as in roofit/CMakeLists.txt
   ROOT_EXECUTABLE(stressHistFactory stressHistFactory.cxx LIBRARIES RooStats HistFactory XMLParser)
   configure_file(HistFactoryTest.tar HistFactoryTest.tar COPYONLY)
   configure_file(stressHistFactory_ref.root stressHistFactory_ref.root COPYONLY)


### PR DESCRIPTION
...because when GSL is not found, HistFactory is not built.

Without this change, when GSL is not present ROOT builds fail with the following error:

```
In file included from /home/eguiraud/ROOT/root/test/stressHistFactory_tests.cxx:25:0,
                 from /home/eguiraud/ROOT/root/test/stressHistFactory.cxx:26:
/home/eguiraud/ROOT/root/test/stressHistFactory_models.cxx:8:46: fatal error: RooStats/HistFactory/Measurement.h: No such file or directory
 #include "RooStats/HistFactory/Measurement.h"
                                              ^
compilation terminated.
test/CMakeFiles/stressHistFactory.dir/build.make:62: recipe for target 'test/CMakeFiles/stressHistFactory.dir/stressHistFactory.cxx.o' failed
```

@hageboeck this fixes the issue I was complaining about today :smile: 

@amadio maybe you can think of a nicer fix, this PR is most of all a bug report.