### PR TITLE
[RF] Remove fixed-length char buffers from RooWorkspace

### DIFF
--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -222,6 +222,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     RooWorkspace.h
     RooWorkspaceHandle.h
     RooXYChi2Var.h
+    RooHelpers.h
   SOURCES
     src/BidirMMapPipe.cxx
     src/BidirMMapPipe.h
@@ -439,6 +440,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     src/RooVectorDataStore.cxx
     src/RooWorkspace.cxx
     src/RooXYChi2Var.cxx
+    src/RooHelpers.cxx
   DICTIONARY_OPTIONS
     "-writeEmptyRootPCM"
   DEPENDENCIES

--- a/roofit/roofitcore/inc/RooHelpers.h
+++ b/roofit/roofitcore/inc/RooHelpers.h
@@ -1,0 +1,51 @@
+// Author: Stephan Hageboeck, CERN  01/2019
+
+/*****************************************************************************
+ * RooFit
+ * Authors:                                                                  *
+ *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
+ *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
+ *                                                                           *
+ * Copyright (c) 2000-2019, Regents of the University of California          *
+ *                          and Stanford University. All rights reserved.    *
+ *                                                                           *
+ * Redistribution and use in source and binary forms,                        *
+ * with or without modification, are permitted according to the terms        *
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
+ *****************************************************************************/
+
+#ifndef ROOFIT_ROOFITCORE_INC_ROOHELPERS_H_
+#define ROOFIT_ROOFITCORE_INC_ROOHELPERS_H_
+
+#include "RooMsgService.h"
+
+namespace RooHelpers {
+
+class MakeVerbose {
+  public:
+    MakeVerbose() {
+      auto& msg = RooMsgService::instance();
+      fOldKillBelow = msg.globalKillBelow();
+      msg.setGlobalKillBelow(RooFit::DEBUG);
+      fOldConf = msg.getStream(0);
+      msg.getStream(0).minLevel= RooFit::DEBUG;
+      msg.setStreamStatus(0, true);
+    }
+
+    ~MakeVerbose() {
+      auto& msg = RooMsgService::instance();
+      msg.setGlobalKillBelow(fOldKillBelow);
+      msg.getStream(0) = fOldConf;
+      msg.setStreamStatus(0, true);
+    }
+
+  private:
+    RooFit::MsgLevel fOldKillBelow;
+    RooMsgService::StreamConfig fOldConf;
+};
+
+std::vector<std::string> tokenise(const std::string &str, const std::string &delims);
+
+}
+
+#endif /* ROOFIT_ROOFITCORE_INC_ROOHELPERS_H_ */

--- a/roofit/roofitcore/src/RooHelpers.cxx
+++ b/roofit/roofitcore/src/RooHelpers.cxx
@@ -1,0 +1,38 @@
+// Author: Stephan Hageboeck, CERN  01/2019
+
+/*****************************************************************************
+ * RooFit
+ * Authors:                                                                  *
+ *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
+ *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
+ *                                                                           *
+ * Copyright (c) 2000-2019, Regents of the University of California          *
+ *                          and Stanford University. All rights reserved.    *
+ *                                                                           *
+ * Redistribution and use in source and binary forms,                        *
+ * with or without modification, are permitted according to the terms        *
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
+ *****************************************************************************/
+
+#include "RooHelpers.h"
+
+namespace RooHelpers {
+
+/// Tokenise the string by splitting at the characters in delims.
+/// Consecutive delimiters are collapsed, so that no delimiters will appear in the
+/// tokenised strings, and no emtpy strings are returned.
+std::vector<std::string> tokenise(const std::string &str, const std::string &delims) {
+  std::vector<std::string> tokens;
+
+  auto beg = str.find_first_not_of(delims, 0);
+  auto end = str.find_first_of(delims, beg);
+  do {
+    tokens.emplace_back(str.substr(beg, end-beg));
+    beg = str.find_first_not_of(delims, end);
+    end = str.find_first_of(delims, beg);
+  } while (beg != std::string::npos);
+
+  return tokens;
+}
+
+}

--- a/roofit/roofitcore/test/testWorkspace.cxx
+++ b/roofit/roofitcore/test/testWorkspace.cxx
@@ -1,6 +1,8 @@
-/// Tests for the RooWorkspace
-
+// Tests for the RooWorkspace
+// Authors: Stephan Hageboeck, CERN  01/2019
+#include "RooWorkspace.h"
 #include "RooGlobalFunc.h"
+#include "RooHelpers.h"
 #include "RooGaussian.h"
 #include "RooArgList.h"
 #include "RooRealVar.h"
@@ -67,4 +69,85 @@ TEST(RooWorkspace, CloneModelConfig_ROOT_9777)
 
    gSystem->Unlink(filename);
 }
+
+
+
+/// Set up a simple workspace for later tests.
+class TestRooWorkspaceWithGaussian : public ::testing::Test {
+protected:
+  TestRooWorkspaceWithGaussian() :
+  Test()
+  {
+    RooRealVar x("x", "x", 1, 0, 10);
+    RooRealVar mu("mu", "mu", 1, 0, 10);
+    RooRealVar sigma("sigma", "sigma", 1, 0, 10);
+
+    RooGaussian pdf("Gauss", "Gauss", x, mu, sigma);
+
+    TFile outfile(_filename, "RECREATE");
+
+    // now create the model config for this problem
+    RooWorkspace w("ws");
+    RooStats::ModelConfig modelConfig("ModelConfig", &w);
+    modelConfig.SetPdf(pdf);
+    modelConfig.SetParametersOfInterest(RooArgSet(sigma));
+    modelConfig.SetGlobalObservables(RooArgSet(mu));
+    w.import(modelConfig);
+
+    outfile.WriteObject(&w, "ws");
+  }
+
+  ~TestRooWorkspaceWithGaussian() {
+    gSystem->Unlink(_filename);
+  }
+
+  const char* _filename = "ROOT-9777.root";
+};
+
+
+/// Test the string tokeniser that does all the string splitting for the RooWorkspace
+/// implementation.
+TEST(RooHelpers, Tokeniser)
+{
+  std::vector<std::string> tok = RooHelpers::tokenise("abc, def, ghi", ", ");
+  EXPECT_EQ(tok.size(), 3U);
+  EXPECT_EQ(tok[0], "abc");
+  EXPECT_EQ(tok[1], "def");
+  EXPECT_EQ(tok[2], "ghi");
+
+  std::vector<std::string> tok2 = RooHelpers::tokenise("abc, def", ":");
+  EXPECT_EQ(tok2.size(), 1U);
+  EXPECT_EQ(tok2[0], "abc, def");
+
+  std::vector<std::string> tok3 = RooHelpers::tokenise(",  ,abc, def,", ", ");
+  EXPECT_EQ(tok3.size(), 2U);
+  EXPECT_EQ(tok3[0], "abc");
+  EXPECT_EQ(tok3[1], "def");
+
+  std::vector<std::string> tok4 = RooHelpers::tokenise(",  ,abc, def,", ",");
+  EXPECT_EQ(tok4.size(), 3U);
+  EXPECT_EQ(tok4[0], "  ");
+  EXPECT_EQ(tok4[1], "abc");
+  EXPECT_EQ(tok4[2], " def");
+
+
+}
+
+/// Test proper string handling when importing an object from a workspace
+/// in a different file.
+TEST_F(TestRooWorkspaceWithGaussian, ImportFromFile)
+{
+  std::ostringstream spec;
+  spec << _filename << ":" << "ws:Gauss";
+
+  RooWorkspace w("ws");
+
+  //Expect successful import:
+  EXPECT_FALSE(w.import(spec.str().c_str()));
+  //Expect import failures:
+  EXPECT_TRUE(w.import("bogus:abc"));
+  EXPECT_TRUE(w.import( (spec.str()+"bogus").c_str()));
+}
+
+
 


### PR DESCRIPTION
The RooWorkspace used 'char buf[xx]' in various places to process user strings.
Supplying a long string to e.g. import stuff to a workspace would lead to the
rest being ignored silently.

Fixes: ROOT-9486