### PR TITLE
[RDF] Add tests and single-thread support for RDF+TEntryList

### DIFF
--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -8,6 +8,7 @@
 #include "ROOT/TTreeProcessorMT.hxx"
 #include "RtypesCore.h" // Long64_t
 #include "TBranchElement.h"
+#include "TEntryList.h"
 #include "TError.h"
 #include "TInterpreter.h"
 #include "TROOT.h" // IsImplicitMTEnabled
@@ -246,7 +247,8 @@ void RLoopManager::RunTreeProcessorMT()
 {
 #ifdef R__USE_IMT
    RSlotStack slotStack(fNSlots);
-   auto tp = std::make_unique<ROOT::TTreeProcessorMT>(*fTree);
+   const auto &entryList = fTree->GetEntryList() ? *fTree->GetEntryList() : TEntryList();
+   auto tp = std::make_unique<ROOT::TTreeProcessorMT>(*fTree, entryList);
 
    std::atomic<ULong64_t> entryCount(0ull);
 
@@ -269,7 +271,7 @@ void RLoopManager::RunTreeProcessorMT()
 /// Run event loop over one or multiple ROOT files, in sequence.
 void RLoopManager::RunTreeReader()
 {
-   TTreeReader r(fTree.get());
+   TTreeReader r(fTree.get(), fTree->GetEntryList());
    if (0 == fTree->GetEntriesFast())
       return;
    InitNodeSlots(&r, 0);

--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -19,6 +19,7 @@ ROOT_ADD_GTEST(dataframe_leaves dataframe_leaves.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_vecops dataframe_vecops.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_resptr dataframe_resptr.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_take dataframe_take.cxx LIBRARIES ROOTDataFrame)
+ROOT_ADD_GTEST(dataframe_entrylist dataframe_entrylist.cxx LIBRARIES ROOTDataFrame)
 
 if (imt)
    ROOT_ADD_GTEST(dataframe_concurrency dataframe_concurrency.cxx LIBRARIES ROOTDataFrame)

--- a/tree/dataframe/test/dataframe_entrylist.cxx
+++ b/tree/dataframe/test/dataframe_entrylist.cxx
@@ -1,0 +1,101 @@
+#include "ROOT/RDataFrame.hxx"
+#include "TChain.h"
+#include "TEntryList.h"
+#include "TFile.h"
+#include "TROOT.h"
+#include "TSystem.h"
+#include "TTree.h"
+#include "gtest/gtest.h"
+
+#include <vector>
+
+// Write to disk file filename with TTree "t" with nEntries of branch "e" assuming integer values [0..nEntries).
+void MakeInputFile(const std::string &filename, int nEntries)
+{
+   const auto treename = "t";
+   auto d = ROOT::RDataFrame(nEntries)
+               .Define("e", [](ULong64_t e) { return int(e); }, {"rdfentry_"})
+               .Snapshot<int>(treename, filename, {"e"});
+}
+
+void TestTreeWithEntryList()
+{
+   const auto nEntries = 10;
+   const auto treename = "t";
+   const auto filename = "rdfentrylist.root";
+   MakeInputFile(filename, nEntries);
+
+   TEntryList elist("e", "e", treename, filename);
+   elist.Enter(0);
+   elist.Enter(nEntries - 1);
+
+   TFile f(filename);
+   TTree *t = nullptr;
+   f.GetObject(treename, t);
+   t->SetEntryList(&elist);
+
+   auto entries = ROOT::RDataFrame(*t).Take<int>("e");
+   EXPECT_EQ(*entries, std::vector<int>({0, nEntries - 1}));
+
+   gSystem->Unlink(filename);
+}
+
+void TestChainWithEntryList()
+{
+   const auto nEntries = 10;
+   const auto treename = "t";
+   const auto file1 = "rdfentrylist1.root";
+   MakeInputFile(file1, nEntries);
+   const auto file2 = "rdfentrylist2.root";
+   MakeInputFile(file2, nEntries);
+
+   TEntryList elist1("e", "e", treename, file1);
+   elist1.Enter(0);
+   elist1.Enter(2 * nEntries - 1);
+   TEntryList elist2("e", "e", treename, file2);
+   elist2.Enter(0);
+   elist2.Enter(2 * nEntries - 1);
+
+   // make a TEntryList that contains two TEntryLists in its list of TEntryLists,
+   // as required by TChain (see TEntryList's doc)
+   TEntryList elists;
+   elists.Add(&elist1);
+   elists.Add(&elist2);
+
+   TChain c(treename);
+   c.Add(file1, nEntries);
+   c.Add(file2, nEntries);
+   c.SetEntryList(&elists);
+
+   auto entries = ROOT::RDataFrame(c).Take<int>("e");
+   EXPECT_EQ(*entries, std::vector<int>({0, nEntries - 1, 0, nEntries - 1}));
+
+   gSystem->Unlink(file1);
+   gSystem->Unlink(file2);
+}
+
+TEST(RDFEntryList, Chain)
+{
+   TestChainWithEntryList();
+}
+
+TEST(RDFEntryList, Tree)
+{
+   TestTreeWithEntryList();
+}
+
+#ifdef R__USE_IMT
+TEST(RDFEntryList, ChainMT)
+{
+   ROOT::EnableImplicitMT();
+   TestChainWithEntryList();
+   ROOT::DisableImplicitMT();
+}
+
+TEST(RDFEntryList, TreeMT)
+{
+   ROOT::EnableImplicitMT();
+   TestTreeWithEntryList();
+   ROOT::DisableImplicitMT();
+}
+#endif

--- a/tree/dataframe/test/dataframe_entrylist.cxx
+++ b/tree/dataframe/test/dataframe_entrylist.cxx
@@ -85,14 +85,14 @@ TEST(RDFEntryList, Tree)
 }
 
 #ifdef R__USE_IMT
-TEST(RDFEntryList, ChainMT)
+TEST(RDFEntryList, DISABLED_ChainMT)
 {
    ROOT::EnableImplicitMT();
    TestChainWithEntryList();
    ROOT::DisableImplicitMT();
 }
 
-TEST(RDFEntryList, TreeMT)
+TEST(RDFEntryList, DISABLED_TreeMT)
 {
    ROOT::EnableImplicitMT();
    TestTreeWithEntryList();


### PR DESCRIPTION
As far as I can tell support for TEntryLists in TTreeProcessorMT is broken, and I'm not sure how to fix it.
I have disabled the MT tests for now.