### PR TITLE
[RDF] Fix ROOT-9898

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -16,6 +16,7 @@
 #include "ROOT/RDF/NodesUtils.hxx" // InitRDFValues
 #include "ROOT/RDF/Utils.hxx"      // ColumnNames_t
 #include "ROOT/RDF/RColumnValue.hxx"
+#include "ROOT/RDF/RLoopManager.hxx"
 
 #include <cstddef> // std::size_t
 #include <memory>
@@ -117,6 +118,9 @@ public:
 
    RActionCRTP(const RActionCRTP &) = delete;
    RActionCRTP &operator=(const RActionCRTP &) = delete;
+   // must call Deregister here, before fPrevDataFrame is destroyed,
+   // otherwise if fPrevDataFrame is fLoopManager we get a use after delete
+   ~RActionCRTP() { fLoopManager->Deregister(this); }
 
    Helper &GetHelper() { return fHelper; }
 

--- a/tree/dataframe/inc/ROOT/RDF/RActionBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RActionBase.hxx
@@ -42,11 +42,12 @@ bool CheckIfDefaultOrDSColumn(const std::string &name,
 } // namespace GraphDrawing
 
 class RActionBase {
-private:
+protected:
    /// A raw pointer to the RLoopManager at the root of this functional graph.
    /// Never null: children nodes have shared ownership of parent nodes in the graph.
    RLoopManager *fLoopManager;
 
+private:
    const unsigned int fNSlots; ///< Number of thread slots used by this node.
    bool fHasRun = false;
    const ColumnNames_t fColumnNames;

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -16,6 +16,7 @@
 #include "ROOT/RDF/NodesUtils.hxx"
 #include "ROOT/RDF/Utils.hxx"
 #include "ROOT/RDF/RFilterBase.hxx"
+#include "ROOT/RDF/RLoopManager.hxx"
 #include "ROOT/RIntegerSequence.hxx"
 #include "ROOT/TypeTraits.hxx"
 #include "RtypesCore.h"
@@ -69,6 +70,9 @@ public:
 
    RFilter(const RFilter &) = delete;
    RFilter &operator=(const RFilter &) = delete;
+   // must call Deregister here, before fPrevDataFrame is destroyed,
+   // otherwise if fPrevDataFrame is fLoopManager we get a use after delete
+   ~RFilter() { fLoopManager->Deregister(this); }
 
    bool CheckFilters(unsigned int slot, Long64_t entry) final
    {

--- a/tree/dataframe/inc/ROOT/RDF/RRange.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RRange.hxx
@@ -11,6 +11,7 @@
 #ifndef ROOT_RDFRANGE
 #define ROOT_RDFRANGE
 
+#include "ROOT/RDF/RLoopManager.hxx"
 #include "ROOT/RDF/RRangeBase.hxx"
 #include "RtypesCore.h"
 
@@ -43,6 +44,9 @@ public:
 
    RRange(const RRange &) = delete;
    RRange &operator=(const RRange &) = delete;
+   // must call Deregister here, before fPrevDataFrame is destroyed,
+   // otherwise if fPrevDataFrame is fLoopManager we get a use after delete
+   ~RRange() { fLoopManager->Deregister(this); }
 
    /// Ranges act as filters when it comes to selecting entries that downstream nodes should process
    bool CheckFilters(unsigned int slot, Long64_t entry) final

--- a/tree/dataframe/src/RActionBase.cxx
+++ b/tree/dataframe/src/RActionBase.cxx
@@ -16,7 +16,5 @@ using namespace ROOT::Internal::RDF;
 RActionBase::RActionBase(RLoopManager *lm, const ColumnNames_t &colNames, const RBookedCustomColumns &customColumns)
    : fLoopManager(lm), fNSlots(lm->GetNSlots()), fColumnNames(colNames), fCustomColumns(customColumns) { }
 
-RActionBase::~RActionBase()
-{
-   fLoopManager->Deregister(this);
-}
+// outlined to pin virtual table
+RActionBase::~RActionBase() {}

--- a/tree/dataframe/src/RFilterBase.cxx
+++ b/tree/dataframe/src/RFilterBase.cxx
@@ -9,8 +9,8 @@
  *************************************************************************/
 
 #include "ROOT/RDF/RCutFlowReport.hxx"
-#include "ROOT/RDF/RLoopManager.hxx"
 #include "ROOT/RDF/RFilterBase.hxx"
+#include <numeric> // std::accumulate
 
 using namespace ROOT::Detail::RDF;
 
@@ -19,10 +19,8 @@ RFilterBase::RFilterBase(RLoopManager *implPtr, std::string_view name, const uns
    : RNodeBase(implPtr), fLastResult(nSlots), fAccepted(nSlots), fRejected(nSlots), fName(name), fNSlots(nSlots),
      fCustomColumns(customColumns) {}
 
-RFilterBase::~RFilterBase()
-{
-   fLoopManager->Deregister(this);
-}
+// outlined to pin virtual table
+RFilterBase::~RFilterBase() {}
 
 bool RFilterBase::HasName() const
 {

--- a/tree/dataframe/src/RRangeBase.cxx
+++ b/tree/dataframe/src/RRangeBase.cxx
@@ -8,7 +8,6 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include "ROOT/RDF/RLoopManager.hxx"
 #include "ROOT/RDF/RRangeBase.hxx"
 
 using ROOT::Detail::RDF::RRangeBase;
@@ -25,7 +24,5 @@ void RRangeBase::ResetCounters()
    fHasStopped = false;
 }
 
-RRangeBase::~RRangeBase()
-{
-   fLoopManager->Deregister(this);
-}
+// outlined to pin virtual table
+RRangeBase::~RRangeBase() { }


### PR DESCRIPTION
Before this patch: the destructor of a derived node type destroyed
its shared_ptr to the previous node. The destructor of the base node
type, called _afterwards_, called fLoopManager->Deregister(this).
In the special case in which the previous node was precisely
RLoopManager and no other RInterfaces or nodes held a shared_ptr to
it, the RLoopManager was being destructed (in the dtor of the derived class)
just before that same node called Deregister on it (in the dtor of the
base class).

After this patch: the derived node types are responsible for calling
Deregister, before destroying the shared_ptr to previous node.

This fixes the use after delete reported in ROOT-9898.