### PR TITLE
[CMake] Disable all tmva related options if tmva is OFF

### DIFF
--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -195,11 +195,20 @@ if (runtime_cxxmodules)
   set(pch_defvalue OFF)
 endif(runtime_cxxmodules)
 
+#--- TMVA --------------------------------------------------------------------------------------
 # User can specify either old name or new name for enabling rmva
-if (r OR tmva-rmva)
-   set(r ON)
-   set(tmva-rmva ON)
+if (tmva)
+  if (r OR tmva-rmva)
+    set(r ON)
+    set(tmva-rmva ON)
+  endif()
+else()
+  set(tmva-cpu OFF CACHE BOOL "Disabled because tmva is disabled (${tmva-cpu_description})" FORCE)
+  set(tmva-gpu OFF CACHE BOOL "Disabled because tmva is disabled (${tmva-gpu_description})" FORCE)
+  set(tmva-rmva OFF CACHE BOOL "Disabled because tmva is disabled (${tmva-rmva_description})" FORCE)
+  set(tmva-pymva OFF CACHE BOOL "Disabled because tmva is disabled (${tmva-pymva_description})" FORCE)
 endif()
+
 
 #--- Compression algorithms in ROOT-------------------------------------------------------------
 set(compression_default "zlib" CACHE STRING "Default compression algorithm (zlib (default), lz4, or lzma)")


### PR DESCRIPTION
otherwise, tmva-pymva is marked as enabled even if tmva is OFF.