### PR TITLE
[TMVA] Fix GUI can't find all trained BDT's for plots

### DIFF
--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -2018,17 +2018,14 @@ TDirectory *TMVA::MethodBase::MethodBaseDir() const
 
    const TString datasetName = DataInfo().GetName();
 
-   Log() << kDEBUG << Form("Dataset[%s] : ", datasetName)
-         << " Base Directory for " << GetMethodTypeName()
+   Log() << kDEBUG << Form("Dataset[%s] : ", datasetName) << " Base Directory for " << GetMethodTypeName()
          << " not set yet --> check if already there.." << Endl;
-
 
    TDirectory *fFactoryBaseDir = GetFile();
 
    fMethodBaseDir = fFactoryBaseDir->GetDirectory(datasetName);
    if (!fMethodBaseDir) {
-      fMethodBaseDir = fFactoryBaseDir->mkdir(datasetName,
-         Form("Base directory for dataset %s",datasetName));
+      fMethodBaseDir = fFactoryBaseDir->mkdir(datasetName, Form("Base directory for dataset %s", datasetName));
       if (!fMethodBaseDir) {
          Log() << kFATAL << "Can not create dir " << datasetName;
       }
@@ -2038,18 +2035,14 @@ TDirectory *TMVA::MethodBase::MethodBaseDir() const
 
    if (!fMethodBaseDir) {
       TDirectory *datasetDir = fFactoryBaseDir->GetDirectory(datasetName);
-      TString methodTypeDirHelpStr = Form("Directory for all %s methods",
-                                          GetMethodTypeName().Data());
-      fMethodBaseDir = datasetDir->mkdir(methodTypeDir.Data(),
-                                         methodTypeDirHelpStr);
-      Log() << kDEBUG << Form("Dataset[%s] : ",datasetName)
-            << " Base Directory for " << GetMethodName()
+      TString methodTypeDirHelpStr = Form("Directory for all %s methods", GetMethodTypeName().Data());
+      fMethodBaseDir = datasetDir->mkdir(methodTypeDir.Data(), methodTypeDirHelpStr);
+      Log() << kDEBUG << Form("Dataset[%s] : ", datasetName) << " Base Directory for " << GetMethodName()
             << " does not exist yet--> created it" << Endl;
    }
 
-   Log() << kDEBUG << Form("Dataset[%s] : ",datasetName)
-         << "Return from MethodBaseDir() after creating base directory "
-         << Endl;
+   Log() << kDEBUG << Form("Dataset[%s] : ", datasetName)
+         << "Return from MethodBaseDir() after creating base directory " << Endl;
    return fMethodBaseDir;
 }
 

--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -2010,25 +2010,28 @@ TDirectory* TMVA::MethodBase::BaseDir() const
 /// returns the ROOT directory where all instances of the
 /// corresponding MVA method are stored
 
- TDirectory* TMVA::MethodBase::MethodBaseDir() const
- {
-    if (fMethodBaseDir != 0) return fMethodBaseDir;
+TDirectory* TMVA::MethodBase::MethodBaseDir() const
+{
+   if (fMethodBaseDir != 0) {
+      return fMethodBaseDir;
+   }
 
-    Log()<<kDEBUG<<Form("Dataset[%s] : ",DataInfo().GetName())<<" Base Directory for " << GetMethodTypeName() << " not set yet --> check if already there.." <<Endl;
+   Log()<<kDEBUG<<Form("Dataset[%s] : ",DataInfo().GetName())<<" Base Directory for " << GetMethodTypeName() << " not set yet --> check if already there.." <<Endl;
 
 
-    TDirectory *fFactoryBaseDir=GetFile();
+   TDirectory *fFactoryBaseDir=GetFile();
 
    fMethodBaseDir = fFactoryBaseDir->GetDirectory(DataInfo().GetName());
-   if(!fMethodBaseDir) //creating dataset directory
-      {
-         fMethodBaseDir = fFactoryBaseDir->mkdir(DataInfo().GetName(),Form("Base directory for dataset %s",DataInfo().GetName()));
-         if(!fMethodBaseDir)Log()<<kFATAL<<"Can not create dir "<<DataInfo().GetName();
+   if(!fMethodBaseDir) {
+      fMethodBaseDir = fFactoryBaseDir->mkdir(DataInfo().GetName(),Form("Base directory for dataset %s",DataInfo().GetName()));
+      if(!fMethodBaseDir) {
+         Log()<<kFATAL<<"Can not create dir "<<DataInfo().GetName();
       }
+   }
    TString _methodDir = Form("Method_%s", GetMethodTypeName().Data());
    fMethodBaseDir = fMethodBaseDir->GetDirectory(_methodDir.Data());
 
-   if(!fMethodBaseDir){
+   if(!fMethodBaseDir) {
       fMethodBaseDir = fFactoryBaseDir->GetDirectory(DataInfo().GetName())->mkdir(_methodDir.Data(),Form("Directory for all %s methods", GetMethodTypeName().Data()));
       Log()<<kDEBUG<<Form("Dataset[%s] : ",DataInfo().GetName())<<" Base Directory for " << GetMethodName() << " does not exist yet--> created it" <<Endl;
    }

--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -2021,11 +2021,10 @@ TDirectory *TMVA::MethodBase::MethodBaseDir() const
    Log() << kDEBUG << Form("Dataset[%s] : ", datasetName) << " Base Directory for " << GetMethodTypeName()
          << " not set yet --> check if already there.." << Endl;
 
-   TDirectory *fFactoryBaseDir = GetFile();
-
-   fMethodBaseDir = fFactoryBaseDir->GetDirectory(datasetName);
+   TDirectory *factoryBaseDir = GetFile();
+   fMethodBaseDir = factoryBaseDir->GetDirectory(datasetName);
    if (!fMethodBaseDir) {
-      fMethodBaseDir = fFactoryBaseDir->mkdir(datasetName, Form("Base directory for dataset %s", datasetName));
+      fMethodBaseDir = factoryBaseDir->mkdir(datasetName, Form("Base directory for dataset %s", datasetName));
       if (!fMethodBaseDir) {
          Log() << kFATAL << "Can not create dir " << datasetName;
       }
@@ -2034,7 +2033,7 @@ TDirectory *TMVA::MethodBase::MethodBaseDir() const
    fMethodBaseDir = fMethodBaseDir->GetDirectory(methodTypeDir.Data());
 
    if (!fMethodBaseDir) {
-      TDirectory *datasetDir = fFactoryBaseDir->GetDirectory(datasetName);
+      TDirectory *datasetDir = factoryBaseDir->GetDirectory(datasetName);
       TString methodTypeDirHelpStr = Form("Directory for all %s methods", GetMethodTypeName().Data());
       fMethodBaseDir = datasetDir->mkdir(methodTypeDir.Data(), methodTypeDirHelpStr);
       Log() << kDEBUG << Form("Dataset[%s] : ", datasetName) << " Base Directory for " << GetMethodName()

--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -2025,7 +2025,7 @@ TDirectory* TMVA::MethodBase::BaseDir() const
          fMethodBaseDir = fFactoryBaseDir->mkdir(DataInfo().GetName(),Form("Base directory for dataset %s",DataInfo().GetName()));
          if(!fMethodBaseDir)Log()<<kFATAL<<"Can not create dir "<<DataInfo().GetName();
       }
-   TString _methodDir = Form("Method_%s",GetMethodName().Data());
+   TString _methodDir = Form("Method_%s", GetMethodTypeName().Data());
    fMethodBaseDir = fMethodBaseDir->GetDirectory(_methodDir.Data());
 
    if(!fMethodBaseDir){

--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -2016,27 +2016,29 @@ TDirectory* TMVA::MethodBase::MethodBaseDir() const
       return fMethodBaseDir;
    }
 
-   Log()<<kDEBUG<<Form("Dataset[%s] : ",DataInfo().GetName())<<" Base Directory for " << GetMethodTypeName() << " not set yet --> check if already there.." <<Endl;
+   const TString datasetName = DataInfo().GetName();
+
+   Log()<<kDEBUG<<Form("Dataset[%s] : ",datasetName)<<" Base Directory for " << GetMethodTypeName() << " not set yet --> check if already there.." <<Endl;
 
 
    TDirectory *fFactoryBaseDir=GetFile();
 
-   fMethodBaseDir = fFactoryBaseDir->GetDirectory(DataInfo().GetName());
+   fMethodBaseDir = fFactoryBaseDir->GetDirectory(datasetName);
    if(!fMethodBaseDir) {
-      fMethodBaseDir = fFactoryBaseDir->mkdir(DataInfo().GetName(),Form("Base directory for dataset %s",DataInfo().GetName()));
+      fMethodBaseDir = fFactoryBaseDir->mkdir(datasetName,Form("Base directory for dataset %s",datasetName));
       if(!fMethodBaseDir) {
-         Log()<<kFATAL<<"Can not create dir "<<DataInfo().GetName();
+         Log()<<kFATAL<<"Can not create dir "<<datasetName;
       }
    }
    TString _methodDir = Form("Method_%s", GetMethodTypeName().Data());
    fMethodBaseDir = fMethodBaseDir->GetDirectory(_methodDir.Data());
 
    if(!fMethodBaseDir) {
-      fMethodBaseDir = fFactoryBaseDir->GetDirectory(DataInfo().GetName())->mkdir(_methodDir.Data(),Form("Directory for all %s methods", GetMethodTypeName().Data()));
-      Log()<<kDEBUG<<Form("Dataset[%s] : ",DataInfo().GetName())<<" Base Directory for " << GetMethodName() << " does not exist yet--> created it" <<Endl;
+      fMethodBaseDir = fFactoryBaseDir->GetDirectory(datasetName)->mkdir(_methodDir.Data(),Form("Directory for all %s methods", GetMethodTypeName().Data()));
+      Log()<<kDEBUG<<Form("Dataset[%s] : ",datasetName)<<" Base Directory for " << GetMethodName() << " does not exist yet--> created it" <<Endl;
    }
 
-   Log()<<kDEBUG<<Form("Dataset[%s] : ",DataInfo().GetName())<<"Return from MethodBaseDir() after creating base directory "<<Endl;
+   Log()<<kDEBUG<<Form("Dataset[%s] : ",datasetName)<<"Return from MethodBaseDir() after creating base directory "<<Endl;
    return fMethodBaseDir;
 }
 

--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -2016,7 +2016,7 @@ TDirectory *TMVA::MethodBase::MethodBaseDir() const
       return fMethodBaseDir;
    }
 
-   const TString datasetName = DataInfo().GetName();
+   const char *datasetName = DataInfo().GetName();
 
    Log() << kDEBUG << Form("Dataset[%s] : ", datasetName) << " Base Directory for " << GetMethodTypeName()
          << " not set yet --> check if already there.." << Endl;

--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -2010,7 +2010,7 @@ TDirectory* TMVA::MethodBase::BaseDir() const
 /// returns the ROOT directory where all instances of the
 /// corresponding MVA method are stored
 
-TDirectory* TMVA::MethodBase::MethodBaseDir() const
+TDirectory *TMVA::MethodBase::MethodBaseDir() const
 {
    if (fMethodBaseDir != 0) {
       return fMethodBaseDir;
@@ -2026,20 +2026,22 @@ TDirectory* TMVA::MethodBase::MethodBaseDir() const
    TDirectory *fFactoryBaseDir = GetFile();
 
    fMethodBaseDir = fFactoryBaseDir->GetDirectory(datasetName);
-   if(!fMethodBaseDir) {
+   if (!fMethodBaseDir) {
       fMethodBaseDir = fFactoryBaseDir->mkdir(datasetName,
          Form("Base directory for dataset %s",datasetName));
-      if(!fMethodBaseDir) {
+      if (!fMethodBaseDir) {
          Log() << kFATAL << "Can not create dir " << datasetName;
       }
    }
-   TString _methodDir = Form("Method_%s", GetMethodTypeName().Data());
-   fMethodBaseDir = fMethodBaseDir->GetDirectory(_methodDir.Data());
+   TString methodTypeDir = Form("Method_%s", GetMethodTypeName().Data());
+   fMethodBaseDir = fMethodBaseDir->GetDirectory(methodTypeDir.Data());
 
-   if(!fMethodBaseDir) {
-      fMethodBaseDir = fFactoryBaseDir->GetDirectory(datasetName)->mkdir(
-         _methodDir.Data(), Form("Directory for all %s methods",
-                                 GetMethodTypeName().Data()));
+   if (!fMethodBaseDir) {
+      TDirectory *datasetDir = fFactoryBaseDir->GetDirectory(datasetName);
+      TString methodTypeDirHelpStr = Form("Directory for all %s methods",
+                                          GetMethodTypeName().Data());
+      fMethodBaseDir = datasetDir->mkdir(methodTypeDir.Data(),
+                                         methodTypeDirHelpStr);
       Log() << kDEBUG << Form("Dataset[%s] : ",datasetName)
             << " Base Directory for " << GetMethodName()
             << " does not exist yet--> created it" << Endl;

--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -2018,27 +2018,36 @@ TDirectory* TMVA::MethodBase::MethodBaseDir() const
 
    const TString datasetName = DataInfo().GetName();
 
-   Log()<<kDEBUG<<Form("Dataset[%s] : ",datasetName)<<" Base Directory for " << GetMethodTypeName() << " not set yet --> check if already there.." <<Endl;
+   Log() << kDEBUG << Form("Dataset[%s] : ", datasetName)
+         << " Base Directory for " << GetMethodTypeName()
+         << " not set yet --> check if already there.." << Endl;
 
 
-   TDirectory *fFactoryBaseDir=GetFile();
+   TDirectory *fFactoryBaseDir = GetFile();
 
    fMethodBaseDir = fFactoryBaseDir->GetDirectory(datasetName);
    if(!fMethodBaseDir) {
-      fMethodBaseDir = fFactoryBaseDir->mkdir(datasetName,Form("Base directory for dataset %s",datasetName));
+      fMethodBaseDir = fFactoryBaseDir->mkdir(datasetName,
+         Form("Base directory for dataset %s",datasetName));
       if(!fMethodBaseDir) {
-         Log()<<kFATAL<<"Can not create dir "<<datasetName;
+         Log() << kFATAL << "Can not create dir " << datasetName;
       }
    }
    TString _methodDir = Form("Method_%s", GetMethodTypeName().Data());
    fMethodBaseDir = fMethodBaseDir->GetDirectory(_methodDir.Data());
 
    if(!fMethodBaseDir) {
-      fMethodBaseDir = fFactoryBaseDir->GetDirectory(datasetName)->mkdir(_methodDir.Data(),Form("Directory for all %s methods", GetMethodTypeName().Data()));
-      Log()<<kDEBUG<<Form("Dataset[%s] : ",datasetName)<<" Base Directory for " << GetMethodName() << " does not exist yet--> created it" <<Endl;
+      fMethodBaseDir = fFactoryBaseDir->GetDirectory(datasetName)->mkdir(
+         _methodDir.Data(), Form("Directory for all %s methods",
+                                 GetMethodTypeName().Data()));
+      Log() << kDEBUG << Form("Dataset[%s] : ",datasetName)
+            << " Base Directory for " << GetMethodName()
+            << " does not exist yet--> created it" << Endl;
    }
 
-   Log()<<kDEBUG<<Form("Dataset[%s] : ",datasetName)<<"Return from MethodBaseDir() after creating base directory "<<Endl;
+   Log() << kDEBUG << Form("Dataset[%s] : ",datasetName)
+         << "Return from MethodBaseDir() after creating base directory "
+         << Endl;
    return fMethodBaseDir;
 }
 

--- a/tmva/tmva/test/envelope/testClassification.cxx
+++ b/tmva/tmva/test/envelope/testClassification.cxx
@@ -229,7 +229,7 @@ TEST_F(ClassifierTest2, TestsOverOutput)
    auto ds = (TDirectoryFile *)outfile->Get("dataset"); // get dataset dir
    ASSERT_NE(ds, nullptr);
 
-   auto Method_BDTB = (TDirectoryFile *)ds->Get("Method_BDTB"); // get method 1 training output dir
+   auto Method_BDTB = (TDirectoryFile *)ds->Get("Method_BDT"); // get method 1 training output dir
    ASSERT_NE(Method_BDTB, nullptr);
 
    auto BDTB = (TDirectoryFile *)Method_BDTB->Get("BDTB");


### PR DESCRIPTION
When writing trained methods to the output file, there was a typo in the target directory. This lead to the results of a  method of type "BDT" and name "MyBDT" being placed (incorrectly) in a folder named
"Method_MyBDT/MyBDT".

This patch places the data correctly in "Method_BDT/BDT". This is important since e.g. the GUI relies on all BDT's being placed in the "MethodBDT" folder. This will affect all methods, not only BDT's.

This can be seen e.g. in the output of the `TMVAClassification.C` macro with several BDT's enabled: The GUI cannot generate plots for all BDT's.

That the previous implementation was a typo is corroborated by this line:
```
Log() << kDEBUG << Form("Dataset[%s] : ", datasetName) << " Base Directory for "
      << GetMethodTypeName() << " not set yet --> check if already there.." << Endl;
```
, where it is implied that a directory of name `GetMethodTypeName()` should be created. However, in the old implementation a directory with name `GetMethodName()` was created instead.

The issue was reported [here](https://root-forum.cern.ch/t/tmvagui-not-working-for-multiple-methods-of-bdt-in-file/32267) initially.