### PR TITLE
[tmva standalone reader codegen] replace vectors by arrays

### DIFF
--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -3058,8 +3058,7 @@ void TMVA::MethodBase::MakeClass( const TString& theClassFileName ) const
    fout << "   // constructor" << std::endl;
    fout << "   " << className << "( std::vector<std::string>& theInputVars )" << std::endl;
    fout << "      : IClassifierReader()," << std::endl;
-   fout << "        fClassName( \"" << className << "\" )," << std::endl;
-   fout << "        fNvars( " << GetNvar() << " )" << std::endl;
+   fout << "        fClassName( \"" << className << "\" )" << std::endl;
    fout << "   {" << std::endl;
    fout << "      // the training input variables" << std::endl;
    fout << "      const char* inputVars[] = { ";
@@ -3135,7 +3134,7 @@ void TMVA::MethodBase::MakeClass( const TString& theClassFileName ) const
    fout << "   // common member variables" << std::endl;
    fout << "   const char* fClassName;" << std::endl;
    fout << std::endl;
-   fout << "   const size_t fNvars;" << std::endl;
+   fout << "   constexpr static size_t fNvars{ " << GetNvar() << " };" << std::endl;
    fout << "   size_t GetNvar()           const { return fNvars; }" << std::endl;
    fout << "   char   GetType( int ivar ) const { return fType[ivar]; }" << std::endl;
    fout << std::endl;

--- a/tmva/tmva/src/VariableGaussTransform.cxx
+++ b/tmva/tmva/src/VariableGaussTransform.cxx
@@ -780,8 +780,7 @@ void TMVA::VariableGaussTransform::MakeFunction( std::ostream& fout, const TStri
 
       fout << "   // copy the variables which are going to be transformed                                "<< std::endl;
       VariableTransformBase::MakeFunction(fout, fcncName, 0, trCounter, 0 );
-      fout << "   static std::vector<double> dv;                                                          "<< std::endl;
-      fout << "   dv.resize(nvar);                                                                       "<< std::endl;
+      fout << "   std::array<double, nvar> dv;                                                           "<< std::endl;
       fout << "   for (int ivar=0; ivar<nvar; ivar++) dv[ivar] = iv[indicesGet.at(ivar)];                "<< std::endl;
       fout << "                                                                                          "<< std::endl;
       fout << "   bool FlatNotGauss = "<< (fFlatNotGauss? "true": "false") <<";                          "<< std::endl;

--- a/tmva/tmva/src/VariableNormalizeTransform.cxx
+++ b/tmva/tmva/src/VariableNormalizeTransform.cxx
@@ -606,9 +606,8 @@ void TMVA::VariableNormalizeTransform::MakeFunction( std::ostream& fout, const T
       fout << "   const int nVar = " << nVar << ";" << std::endl << std::endl;
       fout << "   // get indices of used variables" << std::endl;
       VariableTransformBase::MakeFunction(fout, fcncName, 0, trCounter, 0);
-      fout << "   static std::vector<double> dv;"
-           << std::endl; // simply made it static so it doesn't need to be re-booked every time
-      fout << "   dv.resize(nVar);" << std::endl;
+      fout << "   std::array<double, nVar> dv;"
+           << std::endl; // simply made it an array so it is on the stack
       fout << "   for (int ivar=0; ivar<nVar; ivar++) dv[ivar] = iv[indicesGet.at(ivar)];" << std::endl;
 
       fout << "   for (int ivar=0;ivar<" << nVar << ";ivar++) {" << std::endl;

--- a/tmva/tmva/src/VariableTransformBase.cxx
+++ b/tmva/tmva/src/VariableTransformBase.cxx
@@ -822,10 +822,7 @@ void TMVA::VariableTransformBase::MakeFunction( std::ostream& fout, const TStrin
    if( part == 0 ){ // definitions
       fout << std::endl;
       fout << "   // define the indices of the variables which are transformed by this transformation" << std::endl;
-      fout << "   static std::vector<int> indicesGet;" << std::endl;
-      fout << "   static std::vector<int> indicesPut;" << std::endl << std::endl;
-      fout << "   if ( indicesGet.empty() ) {" << std::endl;
-      fout << "      indicesGet.reserve(fNvars);" << std::endl;
+      fout << "   std::array<int, fNvars> indicesGet{" << std::endl;
 
       for( ItVarTypeIdxConst itEntry = fGet.begin(), itEntryEnd = fGet.end(); itEntry != itEntryEnd; ++itEntry ) {
          Char_t type = (*itEntry).first;
@@ -833,7 +830,7 @@ void TMVA::VariableTransformBase::MakeFunction( std::ostream& fout, const TStrin
 
          switch( type ) {
          case 'v':
-            fout << "      indicesGet.push_back( " << idx << ");" << std::endl;
+            fout << "      " << idx << ", " << std::endl;
             break;
          case 't':
             Log() << kWARNING << "MakeClass doesn't work with transformation of targets. The results will be wrong!" << Endl;
@@ -845,17 +842,16 @@ void TMVA::VariableTransformBase::MakeFunction( std::ostream& fout, const TStrin
             Log() << kFATAL << "VariableTransformBase/GetInput : unknown type '" << type << "'." << Endl;
          }
       }
-      fout << "   }" <<  std::endl;
-      fout << "   if ( indicesPut.empty() ) {" << std::endl;
-      fout << "      indicesPut.reserve(fNvars);" << std::endl;
+      fout << "};" << std::endl << std::endl;
 
+      fout << "   std::array<int, fNvars> indicesPut{" << std::endl;
       for( ItVarTypeIdxConst itEntry = fPut.begin(), itEntryEnd = fPut.end(); itEntry != itEntryEnd; ++itEntry ) {
          Char_t type = (*itEntry).first;
          Int_t  idx  = (*itEntry).second;
 
          switch( type ) {
          case 'v':
-            fout << "      indicesPut.push_back( " << idx << ");" << std::endl;
+            fout << "      " << idx << "," << std::endl;
             break;
          case 't':
             Log() << kWARNING << "MakeClass doesn't work with transformation of targets. The results will be wrong!" << Endl;
@@ -867,9 +863,7 @@ void TMVA::VariableTransformBase::MakeFunction( std::ostream& fout, const TStrin
             Log() << kFATAL << "VariableTransformBase/PutInput : unknown type '" << type << "'." << Endl;
          }
       }
-
-      fout << "   }" <<  std::endl;
-      fout << std::endl;
+      fout << "};" << std::endl << std::endl;
 
    }else if( part == 1){
    }

--- a/tmva/tmva/src/VariableTransformBase.cxx
+++ b/tmva/tmva/src/VariableTransformBase.cxx
@@ -842,7 +842,7 @@ void TMVA::VariableTransformBase::MakeFunction( std::ostream& fout, const TStrin
             Log() << kFATAL << "VariableTransformBase/GetInput : unknown type '" << type << "'." << Endl;
          }
       }
-      fout << "};" << std::endl << std::endl;
+      fout << "   };" << std::endl << std::endl;
 
       fout << "   std::array<int, fNvars> indicesPut{" << std::endl;
       for( ItVarTypeIdxConst itEntry = fPut.begin(), itEntryEnd = fPut.end(); itEntry != itEntryEnd; ++itEntry ) {
@@ -863,7 +863,7 @@ void TMVA::VariableTransformBase::MakeFunction( std::ostream& fout, const TStrin
             Log() << kFATAL << "VariableTransformBase/PutInput : unknown type '" << type << "'." << Endl;
          }
       }
-      fout << "};" << std::endl << std::endl;
+      fout << "   };" << std::endl << std::endl;
 
    }else if( part == 1){
    }


### PR DESCRIPTION
The static vectors look like a thread safety issue in our tests.
std::array avoid memory allocation on every execution in the same way
the static vector does.

NB: `#include <array>` is already present in the codegen from `MethodBase.cxx`

WIP: local building and testing