### PR TITLE
[Exp PyROOT] Temporarily disable PyROOT tests and tutorials in experimental mode

### DIFF
--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -43,7 +43,9 @@ ROOT_ADD_GTEST(datasource_csv datasource_csv.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(datasource_lazy datasource_lazy.cxx LIBRARIES ROOTDataFrame)
 
 #### PYTHON TESTS ####
-ROOT_ADD_PYUNITTEST(dataframe_misc dataframe_misc.py)
-ROOT_ADD_PYUNITTEST(dataframe_histograms dataframe_histograms.py)
-# deactivate until Cache will be available through PyROOT
-#ROOT_ADD_PYUNITTEST(dataframe_cache dataframe_cache.py)
+if(NOT pyroot_experimental)
+  ROOT_ADD_PYUNITTEST(dataframe_misc dataframe_misc.py)
+  ROOT_ADD_PYUNITTEST(dataframe_histograms dataframe_histograms.py)
+  # deactivate until Cache will be available through PyROOT
+  #ROOT_ADD_PYUNITTEST(dataframe_cache dataframe_cache.py)
+endif()

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -389,7 +389,7 @@ endforeach()
 
 
 #---Python tutorials-----------------------------------------------------
-if(ROOT_python_FOUND)
+if(ROOT_python_FOUND AND NOT pyroot_experimental)
   find_package(PythonInterp REQUIRED)
 
   file(GLOB pytutorials RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} */*.py)


### PR DESCRIPTION
A number of test failures have to be fixed in the experimental PyROOT builds:

https://epsft-jenkins.cern.ch/job/root-exp-pyroot/8/

This PR temporarily disables those failing tests for the experimental PyROOT builds, and they will be re-enabled progressively as they are fixed.