### PR TITLE
[RF] Fix spurious binning warning in RooDataHist

### DIFF
--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -201,6 +201,7 @@ protected:
 
 
 private:
+  void _adjustBinning(RooRealVar &theirVar, const TAxis &axis, RooRealVar *ourVar, Int_t *offset);
 
   ClassDef(RooDataHist,4) // Binned data set
 };

--- a/roofit/roofitcore/inc/RooHelpers.h
+++ b/roofit/roofitcore/inc/RooHelpers.h
@@ -19,8 +19,11 @@
 
 #include "RooMsgService.h"
 
+#include <sstream>
+
 namespace RooHelpers {
 
+/// Switches the message service to verbose while the instance alive.
 class MakeVerbose {
   public:
     MakeVerbose() {
@@ -42,6 +45,21 @@ class MakeVerbose {
   private:
     RooFit::MsgLevel fOldKillBelow;
     RooMsgService::StreamConfig fOldConf;
+};
+
+
+/// Hijacks all messages with given level and topic (and optionally object name) while alive.
+/// Use like ostringstream afterwards. Useful for unit tests and debugging.
+class HijackMessageStream : public std::ostringstream {
+  public:
+    HijackMessageStream(RooFit::MsgLevel level, RooFit::MsgTopic topics, const char* objectName = nullptr);
+
+    virtual ~HijackMessageStream();
+
+  private:
+    RooFit::MsgLevel _oldKillBelow;
+    std::vector<RooMsgService::StreamConfig> _oldConf;
+    Int_t _thisStream;
 };
 
 std::vector<std::string> tokenise(const std::string &str, const std::string &delims);

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -2,3 +2,4 @@
 
 ROOT_ADD_GTEST(simple simple.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testWorkspace testWorkspace.cxx LIBRARIES RooFitCore RooFit RooStats)
+ROOT_ADD_GTEST(testRooDataHist testRooDataHist.cxx LIBRARIES RooFitCore)

--- a/roofit/roofitcore/test/testRooDataHist.cxx
+++ b/roofit/roofitcore/test/testRooDataHist.cxx
@@ -1,0 +1,24 @@
+// Tests for the RooWorkspace
+// Authors: Stephan Hageboeck, CERN  01/2019
+
+#include "RooDataHist.h"
+#include "RooGlobalFunc.h"
+#include "RooRealVar.h"
+#include "RooHelpers.h"
+#include "TH1D.h"
+
+#include "gtest/gtest.h"
+
+/// ROOT-8163
+/// The RooDataHist warns that it has to adjust the binning of x to the next bin boundary
+/// although the boundaries match perfectly.
+TEST(RooDataHist, BinningRangeCheck_8163)
+{
+  RooHelpers::HijackMessageStream hijack(RooFit::INFO, RooFit::DataHandling, "dataHist");
+
+  RooRealVar x("x", "x", 0., 1.);
+  TH1D hist("hist", "", 10, 0., 1.);
+
+  RooDataHist dataHist("dataHist", "", RooArgList(x), &hist);
+  EXPECT_TRUE(hijack.str().empty()) << "Messages issued were: " << hijack.str();
+}


### PR DESCRIPTION
RooDataHist warns that it has to readjust the binning of a variable
although no such adjustment is happening.

Fixes: ROOT-8163