### PR TITLE
[PyROOT][ROOT-9903] Do not invoke TPython::Exec upon ROOT import from ipython

### DIFF
--- a/bindings/pyroot/ROOT.py
+++ b/bindings/pyroot/ROOT.py
@@ -721,8 +721,6 @@ class ModuleFacade( types.ModuleType ):
 
     # must be called after gApplication creation:
       if _is_ipython:
-       # IPython's FakeModule hack otherwise prevents usage of python from Cling (TODO: verify necessity)
-         _root.gROOT.ProcessLine( 'TPython::Exec( "" );' )
          sys.modules[ '__main__' ].__builtins__ = __builtins__
 
     # special case for cout (backwards compatibility)


### PR DESCRIPTION
and therewith notebooks.
This was necessary to work around fakemodule, which has been removed
from ipython a long time ago.
The invocation to TPython triggers the loading of the TPyClassGenerator
TClassGenerator. Such generator acquires the GIL from within C++ code
unavoidably leading to deadlocks if ROOT thread safety is enabled.

As a side effect, importing Python from within notebooks and ipython significantly speeds up.