### PR TITLE
Fix Jira issue #9469: TGFileBrowser "ExpandDirectories" Network FS detection

### DIFF
--- a/gui/gui/src/TGFileBrowser.cxx
+++ b/gui/gui/src/TGFileBrowser.cxx
@@ -1676,8 +1676,7 @@ void TGFileBrowser::GotoDir(const char *path)
    // check also AFS_SUPER_MAGIC, NFS_SUPER_MAGIC, FUSE_SUPER_MAGIC,
    // CIFS_MAGIC_NUMBER and SMB_SUPER_MAGIC
    if (!gSystem->GetFsInfo(path, &id, &bsize, &blocks, &bfree))
-      if (id == 0x5346414f || id == 0x6969 || id == 0x65735546 ||
-          id == 0xff534d42 || id == 0x517b)
+      if (id == 0x5346414f || id == 0x6969 || id == 0x65735546 || id == 0xff534d42 || id == 0x517b)
          expand = kFALSE;
    if (first.Length() == 2 && first.EndsWith(":")) {
       TList *curvol  = gSystem->GetVolumes("cur");


### PR DESCRIPTION

Do not expand the parent directory tree on network file systems. Thanks to Oliver Freyermuth for the report and the list of file systems