### PR TITLE
Remove dependencies of TUnixSystem & TWinNTSystem on net/net/inc

### DIFF
--- a/core/base/inc/TSystem.h
+++ b/core/base/inc/TSystem.h
@@ -214,6 +214,26 @@ struct RedirectHandle_t {
                   fStdOutDup = -1; fStdErrDup = -1; fReadOffSet = -1; }
 };
 
+enum ESockOptions {
+   kSendBuffer,        // size of send buffer
+   kRecvBuffer,        // size of receive buffer
+   kOobInline,         // OOB message inline
+   kKeepAlive,         // keep socket alive
+   kReuseAddr,         // allow reuse of local portion of address 5-tuple
+   kNoDelay,           // send without delay
+   kNoBlock,           // non-blocking I/O
+   kProcessGroup,      // socket process group (used for SIGURG and SIGIO)
+   kAtMark,            // are we at out-of-band mark (read only)
+   kBytesToRead        // get number of bytes to read, FIONREAD (read only)
+};
+
+enum ESendRecvOptions {
+   kDefault,           // default option (= 0)
+   kOob,               // send or receive out-of-band data
+   kPeek,              // peek at incoming message (receive only)
+   kDontBlock          // send/recv as much data as possible without blocking
+};
+
 #ifdef __CINT__
 typedef void *Func_t;
 #else

--- a/core/unix/CMakeLists.txt
+++ b/core/unix/CMakeLists.txt
@@ -6,8 +6,7 @@ ROOT_GLOB_SOURCES(sources ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cxx)
 
 set(Unix_dict_headers  ${CMAKE_CURRENT_SOURCE_DIR}/inc/TUnixSystem.h PARENT_SCOPE)
 
-include_directories(${CMAKE_SOURCE_DIR}/net/net/inc
-  ${CMAKE_SOURCE_DIR}/core/clib/res)
+include_directories(${CMAKE_SOURCE_DIR}/core/clib/res)
 ROOT_OBJECT_LIBRARY(Unix ${sources})
 
 ROOT_INSTALL_HEADERS()

--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -28,7 +28,6 @@
 #include "TException.h"
 #include "Demangle.h"
 #include "TEnv.h"
-#include "TSocket.h"
 #include "Getline.h"
 #include "TInterpreter.h"
 #include "TApplication.h"

--- a/core/winnt/CMakeLists.txt
+++ b/core/winnt/CMakeLists.txt
@@ -6,8 +6,6 @@ ROOT_GLOB_SOURCES(sources ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cxx)
 
 set(Winnt_dict_headers  ${CMAKE_CURRENT_SOURCE_DIR}/inc/TWinNTSystem.h PARENT_SCOPE)
 
-include_directories(${CMAKE_SOURCE_DIR}/net/net/inc)
-
 ROOT_OBJECT_LIBRARY(Winnt ${sources})
 
 ROOT_INSTALL_HEADERS()

--- a/core/winnt/src/TWinNTSystem.cxx
+++ b/core/winnt/src/TWinNTSystem.cxx
@@ -30,7 +30,6 @@
 #include "TRegexp.h"
 #include "TException.h"
 #include "TEnv.h"
-#include "TSocket.h"
 #include "TApplication.h"
 #include "TWin32SplashThread.h"
 #include "Win32Constants.h"

--- a/net/net/inc/TSocket.h
+++ b/net/net/inc/TSocket.h
@@ -24,6 +24,7 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
+#include "TSystem.h"
 #include "Compression.h"
 #include "TNamed.h"
 #include "TBits.h"
@@ -33,27 +34,6 @@
 #include "TSecContext.h"
 #include "TTimeStamp.h"
 #include "TVirtualMutex.h"
-
-enum ESockOptions {
-   kSendBuffer,        // size of send buffer
-   kRecvBuffer,        // size of receive buffer
-   kOobInline,         // OOB message inline
-   kKeepAlive,         // keep socket alive
-   kReuseAddr,         // allow reuse of local portion of address 5-tuple
-   kNoDelay,           // send without delay
-   kNoBlock,           // non-blocking I/O
-   kProcessGroup,      // socket process group (used for SIGURG and SIGIO)
-   kAtMark,            // are we at out-of-band mark (read only)
-   kBytesToRead        // get number of bytes to read, FIONREAD (read only)
-};
-
-enum ESendRecvOptions {
-   kDefault,           // default option (= 0)
-   kOob,               // send or receive out-of-band data
-   kPeek,              // peek at incoming message (receive only)
-   kDontBlock          // send/recv as much data as possible without blocking
-};
-
 
 class TMessage;
 class THostAuth;


### PR DESCRIPTION
Move declaration of ESockOptions and ESendRecvOptions enums from TSocket.h to TSystem.h, to get rid of this include dependencies in CMake:
include_directories(${CMAKE_SOURCE_DIR}/net/net/inc)