### PR TITLE
[Exp PyROOT] Make sure cppyy libraries on OSX have .so suffix

### DIFF
--- a/bindings/pyroot_experimental/cppyy/CMakeLists.txt
+++ b/bindings/pyroot_experimental/cppyy/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
+
 add_subdirectory(cppyy-backend)
 add_subdirectory(CPyCppyy)
 add_subdirectory(cppyy)


### PR DESCRIPTION
Otherwise `libcppyy` and `libcppyy_backend` are generated with the`.dylib` suffix on OSX. This causes a crash when importing cppyy, since it tries to load `libcppyy_backend.so` using ctypes.

Thank you @amadio for the suggestion of setting `CMAKE_SHARED_LIBRARY_SUFFIX`.