### PR TITLE
Fix incorrect navigation when exactly on the frontier of a node with overlaps [ROOT-9907]

### DIFF
--- a/geom/geom/src/TGeoNavigator.cxx
+++ b/geom/geom/src/TGeoNavigator.cxx
@@ -883,9 +883,7 @@ TGeoNode *TGeoNavigator::FindNextBoundary(Double_t stepmax, const char *path, Bo
                current->MasterToLocal(&mothpt[0], &dpt[0]);
                current->MasterToLocalVect(&vecpt[0], &dvec[0]);
                // Current point may be inside the other node - geometry error that we ignore
-               snext = TGeoShape::Big();
-               if (!current->GetVolume()->Contains(dpt))
-                  snext = current->GetVolume()->GetShape()->DistFromOutside(&dpt[0], &dvec[0], iact, fStep, &safe);
+               snext = current->GetVolume()->GetShape()->DistFromOutside(&dpt[0], &dvec[0], iact, fStep, &safe);
                if (snext<fStep-gTolerance) {
                   if (computeGlobal) {
                      fCurrentMatrix->CopyFrom(fGlobalMatrix);
@@ -1411,10 +1409,7 @@ TGeoNode *TGeoNavigator::FindNextBoundaryAndStep(Double_t stepmax, Bool_t compsa
                current->cd();
                current->MasterToLocal(&mothpt[0], &dpt[0]);
                current->MasterToLocalVect(&vecpt[0], &dvec[0]);
-               // Current point may be inside the other node - geometry error that we ignore
-               snext = TGeoShape::Big();
-               if (!current->GetVolume()->Contains(dpt))
-                  snext = current->GetVolume()->GetShape()->DistFromOutside(dpt, dvec, iact, fStep);
+               snext = current->GetVolume()->GetShape()->DistFromOutside(dpt, dvec, iact, fStep);
                if (snext<fStep-gTolerance) {
                   PopDummy();
                   PushPath(safelevel+1);

--- a/test/stressGeometry.cxx
+++ b/test/stressGeometry.cxx
@@ -148,7 +148,7 @@ const Int_t versions[NG] =  {5, //aleph
                              4, //ams
                              3, //brahms
                              5, //gem
-                             3, //tesla
+                             4, //tesla
                              3, //btev
                              6, //cdf
                              4, //hades2


### PR DESCRIPTION
This patch is a tentative fix to JIRA bug [ROOT-9907](https://sft.its.cern.ch/jira/browse/ROOT-9907) (TGeoNavigator::FindNextBoundaryAndStep yields nonsensical answers with overlapping volumes). The bug seems to be due to the fact that `/CUVE_1/FAIS_1/PLAQUE_2` fails the `Contains()` check on line 1416, despite the fact that (or because?) the point is exactly on the volume boundary. Therefore, `PLAQUE_2` is not considered **at all** for limiting the current step length, which is unsound.

By suppressing the `Contains()` check, we allow `snext` to be set to 0.0, which is a sensible response in this situation.

I am not sure whether suppressing this check is entirely reasonable. I perused the source code for a few `TGeoShape`s and I have the impression that `DistFromOutside()` returne `TGeoShape::Big()` if the point happens to be inside the shape, but I could not find any documentation where this post-condition is clearly spelt out. If this is true for any shape, then I would argue that it is safe to omit the `Contains()` check (at worst we will end up with `snext=TGeoShape::Big()`, which is exactly what we had with the check anyway).

@agheata, I hope you can take a look at this patch. Perhaps you are also aware of other places in `TGeoNavigator` where it may be wise to apply a similar correction...? Thanks.