### PR TITLE
[Exp PyROOT] Add TCollection and TIter pythonisations and tests

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tcollection.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tcollection.py
@@ -18,8 +18,8 @@ from ._generic import add_len
 
 def remove_pyz(self, o):
 	# Parameters:
-    # self: collection
-    # o: object to remove from the collection
+    # - self: collection
+    # - o: object to remove from the collection
 	res = self.Remove(o)
 
 	if not res:
@@ -27,8 +27,8 @@ def remove_pyz(self, o):
 
 def extend_pyz(self, c):
 	# Parameters:
-    # self: collection
-    # c: collection to extend self with
+    # - self: collection
+    # - c: collection to extend self with
     lenc = c.GetEntries()
     it = TIter(c)
     for i in range(lenc):
@@ -36,8 +36,10 @@ def extend_pyz(self, c):
 
 def count_pyz(self, o):
 	# Parameters:
-    # self: collection
-    # o: object to be counted in the collection
+    # - self: collection
+    # - o: object to be counted in the collection
+    # Returns:
+    # - Number of occurrences of the object in the collection
 	n = 0
 
 	it = TIter(self)

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tcollection.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tcollection.py
@@ -29,11 +29,10 @@ def extend_pyz(self, c):
 	# Parameters:
     # self: collection
     # c: collection to extend self with
-	it = TIter(c)
-	o = it.Next()
-	while o:
-		self.Add(o)
-		o = it.Next()
+    lenc = c.GetEntries()
+    it = TIter(c)
+    for i in range(lenc):
+    	self.Add(it.Next())
 
 def count_pyz(self, o):
 	# Parameters:
@@ -49,6 +48,40 @@ def count_pyz(self, o):
 		obj = it.Next()
 
 	return n
+
+# Python operators
+
+def add_pyz(self, c):
+	# Parameters:
+    # - self: first collection to be added
+    # - c: second collection to be added
+    # Returns:
+    # - self + c
+	res = self.__class__()
+	extend_pyz(res, self)
+	extend_pyz(res, c)
+	return res
+
+def mul_pyz(self, n):
+	# Parameters:
+    # - self: collection to be multiplied
+    # - n: factor to multiply the collection by
+    # Returns:
+    # - self * n
+	res = self.__class__()
+	for _ in range(n):
+		extend_pyz(res, self)
+	return res
+
+def imul_pyz(self, n):
+	# Parameters:
+    # - self: collection to be multiplied (in place)
+    # - n: factor to multiply the collection by
+    # Returns:
+    # - self *= n
+	for _ in range(n - 1):
+		extend_pyz(self, self)
+	return self
 
 
 @pythonization()
@@ -66,3 +99,9 @@ def pythonize_tcollection(klass, name):
         klass.remove = remove_pyz
         klass.extend = extend_pyz
         klass.count = count_pyz
+
+        # Define Python operators
+        klass.__add__ = add_pyz
+        klass.__mul__ = mul_pyz
+        klass.__rmul__ = mul_pyz
+        klass.__imul__ = imul_pyz

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tcollection.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tcollection.py
@@ -1,7 +1,7 @@
-# Author: Enric Tejedor CERN  11/2018
+# Author: Enric Tejedor CERN  01/2019
 
 ################################################################################
-# Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.                      #
+# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.                      #
 # All rights reserved.                                                         #
 #                                                                              #
 # For the licensing terms see $ROOTSYS/LICENSE.                                #
@@ -9,8 +9,47 @@
 ################################################################################
 
 from ROOT import pythonization
+from cppyy.gbl import TIter
 
 from ._generic import add_len
+
+
+# Python-list-like methods
+
+def remove_pyz(self, o):
+	# Parameters:
+    # self: collection
+    # o: object to remove from the collection
+	res = self.Remove(o)
+
+	if not res:
+		raise ValueError('list.remove(x): x not in list')
+
+def extend_pyz(self, c):
+	# Parameters:
+    # self: collection
+    # c: collection to extend self with
+	it = TIter(c)
+	o = it.Next()
+	while o:
+		self.Add(o)
+		o = it.Next()
+
+def count_pyz(self, o):
+	# Parameters:
+    # self: collection
+    # o: object to be counted in the collection
+	n = 0
+
+	it = TIter(self)
+	obj = it.Next()
+	while obj:
+		if obj == o:
+			n += 1
+		obj = it.Next()
+
+	return n
+
 
 @pythonization()
 def pythonize_tcollection(klass, name):
@@ -21,3 +60,9 @@ def pythonize_tcollection(klass, name):
     if name == 'TCollection':
         # Support `len(c)` as `c.GetEntries()`
         add_len(klass, 'GetEntries')
+
+        # Add Python lists methods
+        klass.append = klass.Add
+        klass.remove = remove_pyz
+        klass.extend = extend_pyz
+        klass.count = count_pyz

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tcollection.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tcollection.py
@@ -16,7 +16,7 @@ from ._generic import add_len
 
 # Python-list-like methods
 
-def remove_pyz(self, o):
+def _remove_pyz(self, o):
 	# Parameters:
     # - self: collection
     # - o: object to remove from the collection
@@ -25,7 +25,7 @@ def remove_pyz(self, o):
 	if not res:
 		raise ValueError('list.remove(x): x not in list')
 
-def extend_pyz(self, c):
+def _extend_pyz(self, c):
 	# Parameters:
     # - self: collection
     # - c: collection to extend self with
@@ -34,7 +34,7 @@ def extend_pyz(self, c):
     for i in range(lenc):
     	self.Add(it.Next())
 
-def count_pyz(self, o):
+def _count_pyz(self, o):
 	# Parameters:
     # - self: collection
     # - o: object to be counted in the collection
@@ -53,18 +53,18 @@ def count_pyz(self, o):
 
 # Python operators
 
-def add_pyz(self, c):
+def _add_pyz(self, c):
 	# Parameters:
     # - self: first collection to be added
     # - c: second collection to be added
     # Returns:
     # - self + c
 	res = self.__class__()
-	extend_pyz(res, self)
-	extend_pyz(res, c)
+	_extend_pyz(res, self)
+	_extend_pyz(res, c)
 	return res
 
-def mul_pyz(self, n):
+def _mul_pyz(self, n):
 	# Parameters:
     # - self: collection to be multiplied
     # - n: factor to multiply the collection by
@@ -72,17 +72,17 @@ def mul_pyz(self, n):
     # - self * n
 	res = self.__class__()
 	for _ in range(n):
-		extend_pyz(res, self)
+		_extend_pyz(res, self)
 	return res
 
-def imul_pyz(self, n):
+def _imul_pyz(self, n):
 	# Parameters:
     # - self: collection to be multiplied (in place)
     # - n: factor to multiply the collection by
     # Returns:
     # - self *= n
 	for _ in range(n - 1):
-		extend_pyz(self, self)
+		_extend_pyz(self, self)
 	return self
 
 
@@ -98,12 +98,12 @@ def pythonize_tcollection(klass, name):
 
         # Add Python lists methods
         klass.append = klass.Add
-        klass.remove = remove_pyz
-        klass.extend = extend_pyz
-        klass.count = count_pyz
+        klass.remove = _remove_pyz
+        klass.extend = _extend_pyz
+        klass.count = _count_pyz
 
         # Define Python operators
-        klass.__add__ = add_pyz
-        klass.__mul__ = mul_pyz
-        klass.__rmul__ = mul_pyz
-        klass.__imul__ = imul_pyz
+        klass.__add__ = _add_pyz
+        klass.__mul__ = _mul_pyz
+        klass.__rmul__ = _mul_pyz
+        klass.__imul__ = _imul_pyz

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_titer.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_titer.py
@@ -1,0 +1,39 @@
+# Author: Enric Tejedor CERN  01/2019
+
+################################################################################
+# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from ROOT import pythonization
+import cppyy
+
+def _next_pyz(self):
+    # Parameters:
+    # - self: iterator on a collection
+    # Returns:
+    # - next object in the collection, or raises StopIteration if none
+	o = self.Next()
+	if o:
+		return o
+	else:
+		raise StopIteration()
+
+# The TIter class does not go through the mechanism of lazy pythonisations of
+# cppyy, since it is used before such mechanism is put in place. Therefore, we
+# define here the pythonisations for TIter as immediate, i.e. executed upon
+# import of the ROOT module
+@pythonization(lazy = False)
+def pythonize_titer():
+    klass = cppyy.gbl.TIter
+
+    # Make TIter a Python iterator.
+    # This makes it possible to iterate over TCollections, since Cppyy
+    # injects on them an `__iter__` method that returns a TIter.
+    klass.__next__ = _next_pyz  # Py3
+    klass.next     = _next_pyz  # Py2
+
+    return True

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -17,6 +17,9 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_setbranchaddress ttree_setbranchaddress.py
 ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_branch ttree_branch.py
                     COPY_TO_BUILDDIR TreeHelper.h)
 
+# TIter pythonisations
+ROOT_ADD_PYUNITTEST(pyroot_pyz_titer_iterator titer_iterator.py)
+
 # TCollection and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tcollection_len tcollection_len.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tcollection_listmethods tcollection_listmethods.py)

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -24,6 +24,7 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_titer_iterator titer_iterator.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tcollection_len tcollection_len.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tcollection_listmethods tcollection_listmethods.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tcollection_operators tcollection_operators.py)
+ROOT_ADD_PYUNITTEST(pyroot_pyz_tcollection_iterable tcollection_iterable.py)
 
 # TArray and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tarray_len tarray_len.py)

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -20,6 +20,7 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_branch ttree_branch.py
 # TCollection and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tcollection_len tcollection_len.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tcollection_listmethods tcollection_listmethods.py)
+ROOT_ADD_PYUNITTEST(pyroot_pyz_tcollection_operators tcollection_operators.py)
 
 # TArray and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tarray_len tarray_len.py)
@@ -28,4 +29,3 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_tarray_len tarray_len.py)
 if(ROOT_roofit_FOUND)
   ROOT_ADD_PYUNITTEST(pyroot_pyz_rooabscollection_len rooabscollection_len.py)
 endif()
-

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -19,6 +19,7 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_branch ttree_branch.py
 
 # TCollection and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tcollection_len tcollection_len.py)
+ROOT_ADD_PYUNITTEST(pyroot_pyz_tcollection_listmethods tcollection_listmethods.py)
 
 # TArray and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tarray_len tarray_len.py)

--- a/bindings/pyroot_experimental/PyROOT/test/tcollection_iterable.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tcollection_iterable.py
@@ -1,0 +1,35 @@
+import unittest
+
+import ROOT
+from libcppyy import SetOwnership
+
+
+class TCollectionIterable(unittest.TestCase):
+    """
+    Test for the pythonization that makes instances of TCollection subclasses
+    iterable in Python.
+    For example, this allows to do:
+    `for elem in collection:`
+         `...`
+    """
+
+    num_elems = 3
+
+    # Helpers
+    def create_tcollection(self):
+        c = ROOT.TList()
+        for _ in range(self.num_elems):
+            o = ROOT.TObject()
+            # Prevent immediate deletion of C++ TObjects
+            SetOwnership(o, False)
+            c.Add(o)
+
+        return c
+
+    # Tests
+    def test_iterable(self):
+        c = self.create_tcollection()
+
+        itc = ROOT.TIter(c)
+        for elem in c:
+            self.assertEqual(elem, itc.Next())

--- a/bindings/pyroot_experimental/PyROOT/test/tcollection_listmethods.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tcollection_listmethods.py
@@ -1,0 +1,107 @@
+import unittest
+
+import ROOT
+from libcppyy import SetOwnership
+
+
+class TCollectionListMethods(unittest.TestCase):
+    """
+    Test for the Python-list-like methods added to TCollection (and subclasses):
+    append, remove, extend, count
+    """
+
+    num_elems = 3
+
+    # Helpers
+    def create_tcollection(self):
+        c = ROOT.TList()
+        for _ in range(self.num_elems):
+            o = ROOT.TObject()
+            # Prevent immediate deletion of C++ TObjects
+            SetOwnership(o, False)
+            c.Add(o)
+
+        return c
+
+    # Tests
+    def test_append(self):
+        c = self.create_tcollection()
+
+        o = ROOT.TObject()
+        self.assertFalse(c.Contains(o))
+        len1 = c.GetEntries()
+
+        c.append(o)
+
+        len2 = c.GetEntries()
+        self.assertEqual(len1 + 1, len2)
+        self.assertTrue(c.Contains(o))
+
+        # Skip elements that were already there
+        itc = ROOT.TIter(c)
+        for _ in range(len1):
+            itc.Next()
+
+        # Check that `o` is indeed the last element
+        self.assertEqual(o, itc.Next())
+
+    def test_remove(self):
+        c = ROOT.TList()
+
+        o1 = ROOT.TObject()
+        o2 = ROOT.TObject()
+
+        c.Add(o1)
+        c.Add(o2)
+        c.Add(o1)
+
+        self.assertTrue(c.Contains(o1))
+        self.assertEqual(c.GetEntries(), 3)
+
+        c.remove(o1)
+
+        self.assertEqual(c.GetEntries(), 2)
+
+        c.remove(o1)
+
+        self.assertEqual(c.GetEntries(), 1)
+        self.assertFalse(c.Contains(o1))
+
+        with self.assertRaises(ValueError):
+            c.remove(o1)
+
+    def test_extend(self):
+        c1 = self.create_tcollection()
+        c2 = self.create_tcollection()
+
+        len1 = c1.GetEntries()
+        len2 = c2.GetEntries()
+
+        c1.extend(c2)
+
+        len1_final = c1.GetEntries()
+
+        self.assertEqual(len1_final, len1 + len2)
+
+        # Skip elements that were already there
+        itc1 = ROOT.TIter(c1)
+        for _ in range(len1):
+            itc1.Next()
+
+        # Compare with elements of second collection
+        itc2 = ROOT.TIter(c2)
+        for _ in range(len2):
+            self.assertEqual(itc1.Next(), itc2.Next())
+
+    def test_count(self):
+        c = ROOT.TList()
+
+        o1 = ROOT.TObject()
+        o2 = ROOT.TObject()
+
+        c.Add(o1)
+        c.Add(o2)
+        c.Add(o1)
+
+        self.assertEqual(c.count(o1), 2)
+        self.assertEqual(c.count(o2), 1)

--- a/bindings/pyroot_experimental/PyROOT/test/tcollection_operators.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tcollection_operators.py
@@ -1,0 +1,98 @@
+import unittest
+
+import ROOT
+from libcppyy import SetOwnership
+
+
+class TCollectionOperators(unittest.TestCase):
+    """
+    Test for the Python operators defined in TCollection (and subclasses):
+    __add__, __mul__, __rmul__, __imul__
+    """
+
+    num_elems = 3
+    factor = 2
+
+    # Helpers
+    def create_tcollection(self):
+        c = ROOT.TList()
+        for _ in range(self.num_elems):
+            o = ROOT.TObject()
+            # Prevent immediate deletion of C++ TObjects
+            SetOwnership(o, False)
+            c.Add(o)
+
+        return c
+
+    def check_mul_result(self, c, cmul):
+        lenc = c.GetEntries()
+
+        self.assertEqual(cmul.GetEntries(), lenc * self.factor)
+
+        itmul = ROOT.TIter(cmul)
+        for _ in range(self.factor):
+            itc = ROOT.TIter(c)
+            for _ in range(lenc):
+                oc = itc.Next()
+                omul = itmul.Next()
+                self.assertEqual(oc, omul)
+
+    # Tests
+    def test_add(self):
+        c1 = self.create_tcollection()
+        c2 = self.create_tcollection()
+
+        len1 = c1.GetEntries()
+        len2 = c2.GetEntries()
+
+        cadd = c1 + c2
+
+        len_add = cadd.GetEntries()
+
+        self.assertEqual(len_add, len1 + len2)
+
+        # Compare with elements of first collection
+        itc1 = ROOT.TIter(c1)
+        itadd = ROOT.TIter(cadd)
+        for _ in range(len1):
+            oc1 = itc1.Next()
+            oadd = itadd.Next()
+            self.assertEqual(oc1, oadd)
+
+        # Compare with elements of second collection
+        itc2 = ROOT.TIter(c2)
+        for _ in range(len2):
+            oc2 = itc2.Next()
+            oadd = itadd.Next()
+            self.assertEqual(oc2, oadd)
+
+    def test_mul(self):
+        c = self.create_tcollection()
+
+        cmul = c * self.factor
+
+        self.check_mul_result(c, cmul)
+
+    def test_rmul(self):
+        c = self.create_tcollection()
+
+        cmul = self.factor * c
+
+        self.check_mul_result(c, cmul)
+
+    def test_imul(self):
+        c = self.create_tcollection()
+        lenc = c.GetEntries()
+
+        c *= self.factor
+
+        self.assertEqual(c.GetEntries(), lenc * self.factor)
+
+        it = ROOT.TIter(c)
+        subc = []
+        for _ in range(lenc):
+            subc.append(it.Next())
+
+        for _ in range(self.factor - 1):
+            for o in subc:
+                self.assertEqual(o, it.Next())

--- a/bindings/pyroot_experimental/PyROOT/test/titer_iterator.py
+++ b/bindings/pyroot_experimental/PyROOT/test/titer_iterator.py
@@ -1,0 +1,33 @@
+import unittest
+
+import ROOT
+from libcppyy import SetOwnership
+
+
+class TIterIterator(unittest.TestCase):
+    """
+    Test for the pythonization that allows instances of TIter to
+    behave as Python iterators.
+    """
+
+    num_elems = 3
+
+    # Helpers
+    def create_tcollection(self):
+        c = ROOT.TList()
+        for _ in range(self.num_elems):
+            o = ROOT.TObject()
+            # Prevent immediate deletion of C++ TObjects
+            SetOwnership(o, False)
+            c.Add(o)
+
+        return c
+
+    # Tests
+    def test_iterator(self):
+        c = self.create_tcollection()
+
+        itc1 = ROOT.TIter(c)
+        itc2 = ROOT.TIter(c)
+        for _ in range(c.GetEntries()):
+            self.assertEqual(next(itc1), itc2.Next())


### PR DESCRIPTION
This PR mainly adds pythonisations for `TCollection` and its subclasses. It also adds a pythonisation for `TIter`, which is necessary to iterate over `TCollection`s.

The corresponding unit tests for every pythonisation are also proposed.