### PR TITLE
[cxxmodule] Fix a warning in modules build

### DIFF
--- a/build/unix/module.modulemap
+++ b/build/unix/module.modulemap
@@ -14,7 +14,8 @@ module ROOT_Foundation_C  {
 module ROOT_Config  {
   // These headers are supposed to be only textually expanded for each TU.
   module "RVersion.h" { textual header "RVersion.h" export * }
-  module "RConfig.h" { textual header "RConfig.h" export * }
+  module "RConfig.h" { header "RConfig.h" export * }
+  module "ROOT/RConfig.h" { textual header "ROOT/RConfig.h" export * }
   module "RConfigure.h" { textual header "RConfigure.h" export * }
   // FIXME: There is little benefit in keeping DllImport as a separate header.
   // The majority of its uses already include Rtypes.h which includes DllImport.

--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -5,7 +5,6 @@
 include_directories(res ../foundation/res)
 
 set(BASE_HEADERS
-  ROOT/RConfig.h
   ROOT/StringConv.hxx
   ROOT/TExecutor.hxx
   ROOT/TSequentialExecutor.hxx


### PR DESCRIPTION
Not expose ROOT/RConfig.h to rootcling, but to add the header to ROOT_Config pcm.