### PR TITLE
Fix incorrect navigation when exactly on the frontier of an overlappiing volume

### DIFF
--- a/geom/geom/src/TGeoNavigator.cxx
+++ b/geom/geom/src/TGeoNavigator.cxx
@@ -881,9 +881,7 @@ TGeoNode *TGeoNavigator::FindNextBoundary(Double_t stepmax, const char *path, Bo
                current->MasterToLocal(&mothpt[0], &dpt[0]);
                current->MasterToLocalVect(&vecpt[0], &dvec[0]);
                // Current point may be inside the other node - geometry error that we ignore
-               snext = TGeoShape::Big();
-               if (!current->GetVolume()->Contains(dpt))
-                  snext = current->GetVolume()->GetShape()->DistFromOutside(&dpt[0], &dvec[0], iact, fStep, &safe);
+               snext = current->GetVolume()->GetShape()->DistFromOutside(&dpt[0], &dvec[0], iact, fStep, &safe);
                if (snext<fStep-gTolerance) {
                   if (computeGlobal) {
                      fCurrentMatrix->CopyFrom(fGlobalMatrix);
@@ -1409,10 +1407,7 @@ TGeoNode *TGeoNavigator::FindNextBoundaryAndStep(Double_t stepmax, Bool_t compsa
                current->cd();
                current->MasterToLocal(&mothpt[0], &dpt[0]);
                current->MasterToLocalVect(&vecpt[0], &dvec[0]);
-               // Current point may be inside the other node - geometry error that we ignore
-               snext = TGeoShape::Big();
-               if (!current->GetVolume()->Contains(dpt))
-                  snext = current->GetVolume()->GetShape()->DistFromOutside(dpt, dvec, iact, fStep);
+               snext = current->GetVolume()->GetShape()->DistFromOutside(dpt, dvec, iact, fStep);
                if (snext<fStep-gTolerance) {
                   PopDummy();
                   PushPath(safelevel+1);

--- a/test/stressGeometry.cxx
+++ b/test/stressGeometry.cxx
@@ -148,7 +148,7 @@ const Int_t versions[NG] =  {5, //aleph
                              4, //ams
                              3, //brahms
                              5, //gem
-                             3, //tesla
+                             4, //tesla
                              3, //btev
                              6, //cdf
                              4, //hades2


### PR DESCRIPTION
This is a backport of commit 68509691, fixing bug [ROOT-9907](https://sft.its.cern.ch/jira/browse/ROOT-9907).