### PR TITLE
Windows: fix stressHistoFit when interpreted

### DIFF
--- a/test/stressHistoFit.cxx
+++ b/test/stressHistoFit.cxx
@@ -113,6 +113,7 @@
 #include <cmath>
 
 #ifdef R__WIN32
+#ifndef __CLING__
 #define FOREGROUND_BLUE      1
 #define FOREGROUND_GREEN     2
 #define FOREGROUND_RED       4
@@ -123,6 +124,7 @@ extern "C" {
    bool __stdcall SetConsoleTextAttribute(void *, unsigned int);
 }
 #pragma comment(lib, "Kernel32.lib")
+#endif
 #endif
 
 #include "Riostream.h"
@@ -511,10 +513,12 @@ void setColor(int red = 0)
       snprintf(command,13, "%c[%dm", 0x1B, 0); // reset to default
    printf("%s", command);
 #else
+#ifndef __CLING__
    if ( red )
       SetConsoleTextAttribute(GetStdHandle((unsigned long)-11), FOREGROUND_RED );
    else
       SetConsoleTextAttribute(GetStdHandle((unsigned long)-11), FOREGROUND_GREY );
+#endif
 #endif
 }
 


### PR DESCRIPTION
This fixes the following failure of the test-stresshistofit-interpreted test:

151: Processing C:/Users/sftnight/git/master/test/stressHistoFit.cxx...
151: In file included from input_line_10:1:
151: C:\Users\sftnight\git\master\test\stressHistoFit.cxx:117:9: warning: 'FOREGROUND_BLUE' macro redefined [-Wmacro-redefined]
151: #define FOREGROUND_BLUE      1
151:         ^
151: C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\consoleapi2.h:35:9: note: previous definition is here
151: #define FOREGROUND_BLUE      0x0001 // text color contains blue.
151:         ^
151: In file included from input_line_10:1:
151: C:\Users\sftnight\git\master\test\stressHistoFit.cxx:118:9: warning: 'FOREGROUND_GREEN' macro redefined [-Wmacro-redefined]
151: #define FOREGROUND_GREEN     2
151:         ^
151: C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\consoleapi2.h:36:9: note: previous definition is here
151: #define FOREGROUND_GREEN     0x0002 // text color contains green.
151:         ^
151: In file included from input_line_10:1:
151: C:\Users\sftnight\git\master\test\stressHistoFit.cxx:119:9: warning: 'FOREGROUND_RED' macro redefined [-Wmacro-redefined]
151: #define FOREGROUND_RED       4
151:         ^
151: C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\consoleapi2.h:37:9: note: previous definition is here
151: #define FOREGROUND_RED       0x0004 // text color contains red.
151:         ^
151: In file included from input_line_10:1:
151: C:\Users\sftnight\git\master\test\stressHistoFit.cxx:120:9: warning: 'FOREGROUND_INTENSITY' macro redefined [-Wmacro-redefined]
151: #define FOREGROUND_INTENSITY 8
151:         ^
151: C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\consoleapi2.h:38:9: note: previous definition is here
151: #define FOREGROUND_INTENSITY 0x0008 // text color is intensified.
151:         ^
151: In file included from input_line_10:1:
151: C:\Users\sftnight\git\master\test\stressHistoFit.cxx:124:19: error: functions that differ only in their return type cannot be overloaded
151:    bool __stdcall SetConsoleTextAttribute(void *, unsigned int);
151:                   ^
151: C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\consoleapi2.h:245:1: note: previous declaration is here
151: SetConsoleTextAttribute(
151: ^
151: Error in <TInterpreter::AutoParse>: Error parsing payload code for class TUnuranContDist with content:
151:
151: #line 1 "libUnuran dictionary payload"
151:
151: #ifndef HAVE_CONFIG_H
151:   #define HAVE_CONFIG_H 1
151: #endif
151:
151: #define _BACKWARD_BACKWARD_WARNING_H
151: #include "TUnuran.h"
151: #include "TUnuranBaseDist.h"
151: #include "TUnuranContDist.h"
151: #include "TUnuranDiscrDist.h"
151: #include "TUnuranEmpDist.h"
151: #include "TUnuranMultiContDist.h"
151: #include "TUnuranSampler.h"
151:
151: #undef  _BACKWARD_BACKWARD_WARNING_H
151:
151: Error in <TInterpreter::AutoParse>: Error parsing payload code for class TUnuranDiscrDist with content:
151:
151: #line 1 "libUnuran dictionary payload"
151:
151: #ifndef HAVE_CONFIG_H
151:   #define HAVE_CONFIG_H 1
151: #endif
151:
151: #define _BACKWARD_BACKWARD_WARNING_H
151: #include "TUnuran.h"
151: #include "TUnuranBaseDist.h"
151: #include "TUnuranContDist.h"
151: #include "TUnuranDiscrDist.h"
151: #include "TUnuranEmpDist.h"
151: #include "TUnuranMultiContDist.h"
151: #include "TUnuranSampler.h"
151:
151: #undef  _BACKWARD_BACKWARD_WARNING_H
151:
151: Error in <TInterpreter::AutoParse>: Error parsing payload code for class TUnuranEmpDist with content:
151:
151: #line 1 "libUnuran dictionary payload"
151:
151: #ifndef HAVE_CONFIG_H
151:   #define HAVE_CONFIG_H 1
151: #endif
151:
151: #define _BACKWARD_BACKWARD_WARNING_H
151: #include "TUnuran.h"
151: #include "TUnuranBaseDist.h"
151: #include "TUnuranContDist.h"
151: #include "TUnuranDiscrDist.h"
151: #include "TUnuranEmpDist.h"
151: #include "TUnuranMultiContDist.h"
151: #include "TUnuranSampler.h"
151:
151: #undef  _BACKWARD_BACKWARD_WARNING_H
151:
151: CMake Error at C:/Users/sftnight/git/master/cmake/modules/RootTestDriver.cmake:232 (message):
151:   error code: 1
151:
151:
2/2 Test #151: test-stresshistofit-interpreted ...***Failed  Error regular expression found in output. Regex=[FAILED|Error in] 10.55 sec
