### PR TITLE
[RF] Speed up hist2workspace

### DIFF
--- a/README/ReleaseNotes/v618/index.md
+++ b/README/ReleaseNotes/v618/index.md
@@ -18,6 +18,7 @@ The following people have contributed to this new version:
  Olivier Couet, CERN/SFT,\
  Gerri Ganis, CERN/SFT,\
  Andrei Gheata, CERN/SFT,\
+ Stephan Hageboeck, CERN/SFT,\
  Sergey Linev, GSI,\
  Pere Mato, CERN/SFT,\
  Lorenzo Moneta, CERN/SFT,\
@@ -73,7 +74,8 @@ The methods could be replaced by equivalent methods with other signature:
 
 
 ## RooFit Libraries
-
+  - HistFactory: hist2workspace performance optimisations. For a large, ATLAS-style Higgs-->bb workspace with > 100 systematic uncertainties and more than
+    10 channels, the run time decreases by a factor 11 to 12.
 
 ## 2D Graphics Libraries
 

--- a/roofit/histfactory/inc/LinkDef.h
+++ b/roofit/histfactory/inc/LinkDef.h
@@ -40,6 +40,7 @@
 #pragma link C++ class RooStats::HistFactory::StatError+ ;
 #pragma link C++ class RooStats::HistFactory::StatErrorConfig+ ;
 #pragma link C++ class RooStats::HistFactory::PreprocessFunction+ ;
+#pragma link C++ class RooStats::HistFactory::HistogramUncertaintyBase+ ;
 
 #pragma link C++ class std::vector< RooStats::HistFactory::Channel >+ ;
 #pragma link C++ class std::vector< RooStats::HistFactory::Sample >+ ;

--- a/roofit/histfactory/inc/RooStats/HistFactory/EstimateSummary.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/EstimateSummary.h
@@ -36,9 +36,9 @@ struct  EstimateSummary : public TObject {
 
    class ShapeSys{
    public:
-     ShapeSys() : name(""), hist(NULL) {;}
+     ShapeSys() : name(), hist(nullptr), constraint{} {;}
      std::string name;
-     TH1* hist;
+     const TH1* hist;
      ConstraintType constraint;
    };
       

--- a/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
@@ -116,7 +116,7 @@ namespace RooStats{
 
       RooArgList createStatConstraintTerms( RooWorkspace* proto, 
 					    std::vector<std::string>& constraintTerms, 
-					    ParamHistFunc& paramHist, TH1* uncertHist, 
+					    ParamHistFunc& paramHist, const TH1* uncertHist,
 					    Constraint::Type type, Double_t minSigma );
 
       void ConfigureHistFactoryDataset(RooDataSet* obsData, TH1* nominal, RooWorkspace* proto,

--- a/roofit/histfactory/inc/RooStats/HistFactory/Sample.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Sample.h
@@ -115,7 +115,9 @@ public:
   std::vector< RooStats::HistFactory::ShapeFactor >& GetShapeFactorList() { return fShapeFactorList; }
 
   RooStats::HistFactory::StatError& GetStatError() { return fStatError; }
-  void SetStatError( RooStats::HistFactory::StatError Error ) { fStatError = Error; }
+  void SetStatError( RooStats::HistFactory::StatError Error ) {
+    fStatError = std::move(Error);
+  }
 
 
 protected:

--- a/roofit/histfactory/inc/RooStats/HistFactory/Systematics.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Systematics.h
@@ -53,15 +53,15 @@ namespace HistFactory {
     OverallSys() : fLow(0), fHigh(0) {} 
 
     void SetName( const std::string& Name ) { fName = Name; }
-    std::string GetName() { return fName; }
+    std::string GetName() const { return fName; }
 
     void SetLow( double Low )   { fLow  = Low; }
     void SetHigh( double High ) { fHigh = High; }
-    double GetLow() { return fLow; }
-    double GetHigh() { return fHigh; }
+    double GetLow() const { return fLow; }
+    double GetHigh() const { return fHigh; }
 
-    void Print(std::ostream& = std::cout);  
-    void PrintXML(std::ostream&);
+    void Print(std::ostream& = std::cout) const;
+    void PrintXML(std::ostream&) const;
 
   protected:
     std::string fName;
@@ -81,21 +81,21 @@ namespace HistFactory {
     NormFactor();
 
     void SetName( const std::string& Name ) { fName = Name; }
-    std::string GetName() { return fName; }
+    std::string GetName() const { return fName; }
 
     void SetVal( double Val ) { fVal = Val; }
-    double GetVal() { return fVal; }
+    double GetVal() const { return fVal; }
 
     void SetConst( bool Const=true ) { fConst = Const; }
-    bool GetConst() { return fConst; }
+    bool GetConst() const { return fConst; }
 
     void SetLow( double Low )   { fLow  = Low; }
     void SetHigh( double High ) { fHigh = High; }
-    double GetLow() { return fLow; }
-    double GetHigh() { return fHigh; }
+    double GetLow() const { return fLow; }
+    double GetHigh() const { return fHigh; }
 
-    void Print(std::ostream& = std::cout);      
-    void PrintXML(std::ostream&);
+    void Print(std::ostream& = std::cout) const;
+    void PrintXML(std::ostream&) const;
 
   protected:
 
@@ -107,271 +107,261 @@ namespace HistFactory {
 
   };
 
+
+  /** ////////////////////////////////////////////////////////////////////////////////////////////
+   * \class HistogramUncertaintyBase
+   * \ingroup HistFactory
+   * Base class to store the up and down variations for histogram uncertainties.
+   * Use the derived classes for actual models.
+   */
+  class HistogramUncertaintyBase {
+
+  public:
+
+    HistogramUncertaintyBase() : fhLow(nullptr), fhHigh(nullptr) {}
+    HistogramUncertaintyBase(const std::string& Name) : fName(Name), fhLow(nullptr), fhHigh(nullptr) {}
+    HistogramUncertaintyBase(const HistogramUncertaintyBase& oth) :
+    fName{oth.fName},
+    fInputFileLow{oth.fInputFileLow}, fHistoNameLow{oth.fHistoNameLow}, fHistoPathLow{oth.fHistoPathLow},
+    fInputFileHigh{oth.fInputFileHigh}, fHistoNameHigh{oth.fHistoNameHigh}, fHistoPathHigh{oth.fHistoPathHigh},
+    fhLow{oth.fhLow ? static_cast<TH1*>(oth.fhLow->Clone()) : nullptr},
+    fhHigh{oth.fhHigh ? static_cast<TH1*>(oth.fhHigh->Clone()) : nullptr} {
+
+    }
+
+    virtual ~HistogramUncertaintyBase() {};
+
+    HistogramUncertaintyBase(HistogramUncertaintyBase&&) = default;
+    // Need deep copies because the class owns its histograms.
+    HistogramUncertaintyBase& operator=(const HistogramUncertaintyBase& oth) {
+      fName = oth.fName;
+      fInputFileLow = oth.fInputFileLow;
+      fHistoNameLow = oth.fHistoNameLow;
+      fHistoPathLow = oth.fHistoPathLow;
+      fInputFileHigh = oth.fInputFileHigh;
+      fHistoNameHigh = oth.fHistoNameHigh;
+      fHistoPathHigh = oth.fHistoPathHigh;
+      fhLow.reset(oth.fhLow ? static_cast<TH1*>(oth.fhLow->Clone()) : nullptr);
+      fhHigh.reset(oth.fhHigh ? static_cast<TH1*>(oth.fhHigh->Clone()) : nullptr);
+
+      return *this;
+    }
+    // Fine with unique_ptr
+    HistogramUncertaintyBase& operator=(HistogramUncertaintyBase&&) = default;
+
+    virtual void Print(std::ostream& = std::cout) const;
+    virtual void PrintXML(std::ostream&) const = 0;
+    virtual void writeToFile( const std::string& FileName, const std::string& DirName );
+
+    void SetHistoLow(TH1* Low ) {Low->SetDirectory(nullptr); fhLow.reset(Low);}
+    void SetHistoHigh(TH1* High ) {High->SetDirectory(nullptr); fhHigh.reset(High);}
+    
+    const TH1* GetHistoLow() const {return fhLow.get();}
+    const TH1* GetHistoHigh() const {return fhHigh.get();}
+    
+    void SetName( const std::string& Name ) { fName = Name; }
+    const std::string& GetName() const { return fName; }
+
+    void SetInputFileLow( const std::string& InputFileLow ) { fInputFileLow = InputFileLow; }
+    void SetInputFileHigh( const std::string& InputFileHigh ) { fInputFileHigh = InputFileHigh; }
+    
+    const std::string& GetInputFileLow() const { return fInputFileLow; }
+    const std::string& GetInputFileHigh() const { return fInputFileHigh; }
+
+    void SetHistoNameLow( const std::string& HistoNameLow ) { fHistoNameLow = HistoNameLow; }
+    void SetHistoNameHigh( const std::string& HistoNameHigh ) { fHistoNameHigh = HistoNameHigh; }
+    
+    const std::string& GetHistoNameLow() const { return fHistoNameLow; }
+    const std::string& GetHistoNameHigh() const { return fHistoNameHigh; }
+
+    void SetHistoPathLow( const std::string& HistoPathLow ) { fHistoPathLow = HistoPathLow; }
+    void SetHistoPathHigh( const std::string& HistoPathHigh ) { fHistoPathHigh = HistoPathHigh; }
+    
+    const std::string& GetHistoPathLow() const { return fHistoPathLow; }
+    const std::string& GetHistoPathHigh() const { return fHistoPathHigh; }
+
+  protected:
+
+    std::string fName;
+
+    std::string fInputFileLow;
+    std::string fHistoNameLow;
+    std::string fHistoPathLow;
+
+    std::string fInputFileHigh;
+    std::string fHistoNameHigh;
+    std::string fHistoPathHigh;
+
+    // The Low and High Histograms
+    std::unique_ptr<TH1> fhLow;
+    std::unique_ptr<TH1> fhHigh;
+
+  };
+
 /** \class HistoSys
  * \ingroup HistFactory
  * Configuration for a constrained, coherent shape variation of affected samples.
  */
-  class HistoSys {
-
-  public:
-
-    HistoSys() : fhLow(NULL), fhHigh(NULL) {;}
-    HistoSys(const std::string& Name) : fName(Name), fhLow(NULL), fhHigh(NULL) {;}
-
-    void Print(std::ostream& = std::cout);  
-    void PrintXML(std::ostream&);
-    void writeToFile( const std::string& FileName, const std::string& DirName );
-
-    void SetHistoLow( TH1* Low ) { fhLow = Low; }
-    void SetHistoHigh( TH1* High ) { fhHigh = High; }
-    
-    TH1* GetHistoLow();
-    TH1* GetHistoHigh();
-    
-    void SetName( const std::string& Name ) { fName = Name; }
-    std::string GetName() { return fName; }
-
-    void SetInputFileLow( const std::string& InputFileLow ) { fInputFileLow = InputFileLow; }
-    void SetInputFileHigh( const std::string& InputFileHigh ) { fInputFileHigh = InputFileHigh; }
-    
-    std::string GetInputFileLow() { return fInputFileLow; }
-    std::string GetInputFileHigh() { return fInputFileHigh; }
-
-    void SetHistoNameLow( const std::string& HistoNameLow ) { fHistoNameLow = HistoNameLow; }
-    void SetHistoNameHigh( const std::string& HistoNameHigh ) { fHistoNameHigh = HistoNameHigh; }
-    
-    std::string GetHistoNameLow() { return fHistoNameLow; }
-    std::string GetHistoNameHigh() { return fHistoNameHigh; }
-
-    void SetHistoPathLow( const std::string& HistoPathLow ) { fHistoPathLow = HistoPathLow; }
-    void SetHistoPathHigh( const std::string& HistoPathHigh ) { fHistoPathHigh = HistoPathHigh; }
-    
-    std::string GetHistoPathLow() { return fHistoPathLow; }
-    std::string GetHistoPathHigh() { return fHistoPathHigh; }
-
-  protected:
-
-    std::string fName;
-
-    std::string fInputFileLow;
-    std::string fHistoNameLow;
-    std::string fHistoPathLow;
-
-    std::string fInputFileHigh;
-    std::string fHistoNameHigh;
-    std::string fHistoPathHigh;
-
-    // The Low and High Histograms
-    HistRef fhLow;
-    HistRef fhHigh;
-
-  };
+class HistoSys final : public HistogramUncertaintyBase {
+public:
+  virtual ~HistoSys() {}
+  virtual void PrintXML(std::ostream&) const override;
+};
 
 /** \class HistoFactor
  * \ingroup HistFactory
- * Configuration for an \a unconstrained, coherent shape variation of affected samples.
+ * Configuration for an *un*constrained, coherent shape variation of affected samples.
  */
-  class HistoFactor {
-
+  class HistoFactor final : public HistogramUncertaintyBase {
   public:
-
-    HistoFactor() : fhLow(NULL), fhHigh(NULL) {;}
-
-    void SetName( const std::string& Name ) { fName = Name; }
-    std::string GetName() { return fName; }
-    
-    void SetInputFileLow( const std::string& InputFileLow ) { fInputFileLow = InputFileLow; }
-    void SetInputFileHigh( const std::string& InputFileHigh ) { fInputFileHigh = InputFileHigh; }
-    
-    std::string GetInputFileLow() { return fInputFileLow; }
-    std::string GetInputFileHigh() { return fInputFileHigh; }
-
-    void SetHistoNameLow( const std::string& HistoNameLow ) { fHistoNameLow = HistoNameLow; }
-    void SetHistoNameHigh( const std::string& HistoNameHigh ) { fHistoNameHigh = HistoNameHigh; }
-    
-    std::string GetHistoNameLow() { return fHistoNameLow; }
-    std::string GetHistoNameHigh() { return fHistoNameHigh; }
-
-    void SetHistoPathLow( const std::string& HistoPathLow ) { fHistoPathLow = HistoPathLow; }
-    void SetHistoPathHigh( const std::string& HistoPathHigh ) { fHistoPathHigh = HistoPathHigh; }
-    
-    std::string GetHistoPathLow() { return fHistoPathLow; }
-    std::string GetHistoPathHigh() { return fHistoPathHigh; }
-
-    void Print(std::ostream& = std::cout);  
-    void writeToFile( const std::string& FileName, const std::string& DirName );
-    void PrintXML(std::ostream&);
-
-    TH1* GetHistoLow();
-    TH1* GetHistoHigh();
-    void SetHistoLow( TH1* Low ) { fhLow = Low; }
-    void SetHistoHigh( TH1* High ) { fhHigh = High; }
-
-  protected:
-
-    std::string fName;
-
-    std::string fInputFileLow;
-    std::string fHistoNameLow;
-    std::string fHistoPathLow;
-
-    std::string fInputFileHigh;
-    std::string fHistoNameHigh;
-    std::string fHistoPathHigh;
-
-    // The Low and High Histograms
-    HistRef fhLow;
-    HistRef fhHigh;
-
+    virtual ~HistoFactor() {}
+    void PrintXML(std::ostream&) const override;
   };
 
 /** \class ShapeSys
  * \ingroup HistFactory
  * Constrained bin-by-bin variation of affected histogram.
  */
-  class ShapeSys {
+  class ShapeSys final : public HistogramUncertaintyBase {
 
   public:
 
-    ShapeSys() :  fConstraintType(Constraint::Gaussian), fhError(NULL) {}
+    ShapeSys() :
+      HistogramUncertaintyBase(),
+      fConstraintType(Constraint::Gaussian) {}
+    ShapeSys(const ShapeSys& other) :
+      HistogramUncertaintyBase(other),
+      fConstraintType(other.fConstraintType) {}
+    ShapeSys(ShapeSys&&) = default;
+    ShapeSys& operator=(ShapeSys&&) = default;
 
-    void SetName( const std::string& Name ) { fName = Name; }
-    std::string GetName() { return fName; }
+    void SetInputFile( const std::string& InputFile ) { fInputFileHigh = InputFile; }
+    std::string GetInputFile() const { return fInputFileHigh; }
 
-    void SetInputFile( const std::string& InputFile ) { fInputFile = InputFile; }
-    std::string GetInputFile() { return fInputFile; }
+    void SetHistoName( const std::string& HistoName ) { fHistoNameHigh = HistoName; }
+    std::string GetHistoName() const { return fHistoNameHigh; }
 
-    void SetHistoName( const std::string& HistoName ) { fHistoName = HistoName; }
-    std::string GetHistoName() { return fHistoName; }
+    void SetHistoPath( const std::string& HistoPath ) { fHistoPathHigh = HistoPath; }
+    std::string GetHistoPath() const { return fHistoPathHigh; }
 
-    void SetHistoPath( const std::string& HistoPath ) { fHistoPath = HistoPath; }
-    std::string GetHistoPath() { return fHistoPath; }
+    void Print(std::ostream& = std::cout) const override;
+    void PrintXML(std::ostream&) const override;
+    void writeToFile( const std::string& FileName, const std::string& DirName ) override;
 
-    void Print(std::ostream& = std::cout);  
-    void PrintXML(std::ostream&);
-    void writeToFile( const std::string& FileName, const std::string& DirName );
-
-    TH1* GetErrorHist();
-    void SetErrorHist(TH1* hError) { fhError = hError; }
+    const TH1* GetErrorHist() const {
+      return fhHigh.get();
+    }
+    void SetErrorHist(TH1* hError) {
+      fhHigh.reset(hError);
+    }
 
     void SetConstraintType( Constraint::Type ConstrType ) { fConstraintType = ConstrType; }
-    Constraint::Type GetConstraintType() { return fConstraintType; }
+    Constraint::Type GetConstraintType() const { return fConstraintType; }
 
   protected:
-
-    std::string fName;
-    std::string fInputFile;
-    std::string fHistoName;
-    std::string fHistoPath;
-    Constraint::Type fConstraintType; 
-
-    // The histogram holding the error
-    HistRef fhError;
-
+    Constraint::Type fConstraintType;
   };
 
 /** \class ShapeFactor
  * \ingroup HistFactory
- * \a Unconstrained bin-by-bin variation of affected histogram.
+ * *Un*constrained bin-by-bin variation of affected histogram.
  */
-  class ShapeFactor {
+  class ShapeFactor : public HistogramUncertaintyBase {
 
   public:
 
-    ShapeFactor();
-    
-    void SetName( const std::string& Name ) { fName = Name; }
-    std::string GetName() { return fName; }
+    ShapeFactor() :
+      HistogramUncertaintyBase(),
+      fConstant{false},
+      fHasInitialShape{false} {}
 
-    void Print(std::ostream& = std::cout);  
-    void PrintXML(std::ostream&);
-    void writeToFile( const std::string& FileName, const std::string& DirName);
+    void Print(std::ostream& = std::cout) const override;
+    void PrintXML(std::ostream&) const override;
+    void writeToFile( const std::string& FileName, const std::string& DirName) override;
 
-    void SetInitialShape(TH1* shape) { fhInitialShape = shape; }
-    TH1* GetInitialShape() { return fhInitialShape; }
+    void SetInitialShape(TH1* shape) {
+      fhHigh.reset(shape);
+    }
+    const TH1* GetInitialShape() const { return fhHigh.get(); }
 
     void SetConstant(bool constant) { fConstant = constant; }
-    bool IsConstant() { return fConstant; }
+    bool IsConstant() const { return fConstant; }
     
-    bool HasInitialShape() { return fHasInitialShape; }
+    bool HasInitialShape() const { return fHasInitialShape; }
 
     void SetInputFile( const std::string& InputFile ) { 
-      fInputFile = InputFile; 
+      fInputFileHigh = InputFile;
       fHasInitialShape=true;
     }
-    std::string GetInputFile() { return fInputFile; }
+    const std::string& GetInputFile() const { return fInputFileHigh; }
 
     void SetHistoName( const std::string& HistoName ) { 
-      fHistoName = HistoName; 
+      fHistoNameHigh = HistoName;
       fHasInitialShape=true; 
     }
-    std::string GetHistoName() { return fHistoName; }
+    const std::string& GetHistoName() const { return fHistoNameHigh; }
 
     void SetHistoPath( const std::string& HistoPath ) { 
-      fHistoPath = HistoPath; 
+      fHistoPathHigh = HistoPath;
       fHasInitialShape=true;
     }
-    std::string GetHistoPath() { return fHistoPath; }
+    const std::string& GetHistoPath() const { return fHistoPathHigh; }
 
   protected:
-    std::string fName;
 
     bool fConstant;
 
     // A histogram representing
     // the initial shape
     bool fHasInitialShape;
-    std::string fHistoName;
-    std::string fHistoPath;
-    std::string fInputFile;
-    TH1* fhInitialShape;
-
   };
 
 /** \class StatError
  * \ingroup HistFactory
  * Statistical error of Monte Carlo predictions.
  */
-  class StatError {
+  class StatError : public HistogramUncertaintyBase {
 
   public:
 
-    StatError() : fActivate(false), fUseHisto(false), fhError(NULL) {;}
+    StatError() :
+      HistogramUncertaintyBase(),
+      fActivate(false), fUseHisto(false) {}
+    StatError(StatError&&) = default;
+    StatError& operator=(StatError&&) = default;
+    StatError(const StatError&) = default;
 
-    void Print(std::ostream& = std::cout);  
-    void PrintXML(std::ostream&);
-    void writeToFile( const std::string& FileName, const std::string& DirName );
+    void Print(std::ostream& = std::cout) const override;
+    void PrintXML(std::ostream&) const override;
+    void writeToFile( const std::string& FileName, const std::string& DirName ) override;
 
     void Activate( bool IsActive=true ) { fActivate = IsActive; }
-    bool GetActivate() { return fActivate; }
+    bool GetActivate() const { return fActivate; }
 
     void SetUseHisto( bool UseHisto=true ) { fUseHisto = UseHisto; }
-    bool GetUseHisto() { return fUseHisto; }
+    bool GetUseHisto() const { return fUseHisto; }
 
-    void SetInputFile( const std::string& InputFile ) { fInputFile = InputFile; }
-    std::string GetInputFile() { return fInputFile; }
+    void SetInputFile( const std::string& InputFile ) { fInputFileHigh = InputFile; }
+    const std::string& GetInputFile() const { return fInputFileHigh; }
 
-    void SetHistoName( const std::string& HistoName ) { fHistoName = HistoName; }
-    std::string GetHistoName() { return fHistoName; }
+    void SetHistoName( const std::string& HistoName ) { fHistoNameHigh = HistoName; }
+    const std::string& GetHistoName() const { return fHistoNameHigh; }
 
-    void SetHistoPath( const std::string& HistoPath ) { fHistoPath = HistoPath; }
-    std::string GetHistoPath() { return fHistoPath; }
+    void SetHistoPath( const std::string& HistoPath ) { fHistoPathHigh = HistoPath; }
+    const std::string& GetHistoPath() const { return fHistoPathHigh; }
 
 
-    TH1* GetErrorHist();
-    void SetErrorHist(TH1* Error) { fhError = Error; }
+    const TH1* GetErrorHist() const {
+      return fhHigh.get();
+    }
+    void SetErrorHist(TH1* Error) {
+      fhHigh.reset(Error);
+    }
 
   protected:
 
     bool fActivate;
     bool fUseHisto; // Use an external histogram for the errors 
-    std::string fInputFile;
-    std::string fHistoName;
-    std::string fHistoPath;
-
-    // The histogram holding the error
-    HistRef fhError;
-
   };
 
 /** \class StatErrorConfig
@@ -384,14 +374,14 @@ namespace HistFactory {
   public:
 
     StatErrorConfig() : fRelErrorThreshold( .05 ), fConstraintType( Constraint::Gaussian ) {;}
-    void Print(std::ostream& = std::cout);  
-    void PrintXML(std::ostream&);
+    void Print(std::ostream& = std::cout) const;
+    void PrintXML(std::ostream&) const;
 
     void SetRelErrorThreshold( double Threshold ) { fRelErrorThreshold = Threshold; }
-    double GetRelErrorThreshold() { return fRelErrorThreshold; }
+    double GetRelErrorThreshold() const { return fRelErrorThreshold; }
 
     void SetConstraintType( Constraint::Type ConstrType ) { fConstraintType = ConstrType; }
-    Constraint::Type GetConstraintType() { return fConstraintType; }
+    Constraint::Type GetConstraintType() const { return fConstraintType; }
 
   protected:
 

--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -1539,12 +1539,12 @@ namespace HistFactory{
 	      
 	      // Set an initial shape, if requested
 	      if( shapeFactor.GetInitialShape() != NULL ) {
-		TH1* initialShape = shapeFactor.GetInitialShape();
-		std::cout << "Setting Shape Factor: " << shapeFactor.GetName()
-			  << " to have initial shape from hist: "
-			  << initialShape->GetName()
-			  << std::endl;
-		shapeFactorFunc.setShape( initialShape );
+	        TH1* initialShape = static_cast<TH1*>(shapeFactor.GetInitialShape()->Clone());
+	        std::cout << "Setting Shape Factor: " << shapeFactor.GetName()
+			      << " to have initial shape from hist: "
+			      << initialShape->GetName()
+			      << std::endl;
+	        shapeFactorFunc.setShape( initialShape );
 	      }
 	      
 	      // Set the variables constant, if requested
@@ -1662,7 +1662,7 @@ namespace HistFactory{
 	    // as well as the list of constraint terms (constraintTermNames)
 	    
 	    // The syst should be a fractional error
-	    TH1* shapeErrorHist = shapeSys.GetErrorHist();
+	    const TH1* shapeErrorHist = shapeSys.GetErrorHist();
 
 	    // Constraint::Type shapeConstraintType = Constraint::Gaussian;
 	    Constraint::Type systype = shapeSys.GetConstraintType();
@@ -2557,7 +2557,7 @@ namespace HistFactory{
 
   RooArgList HistoToWorkspaceFactoryFast::
   createStatConstraintTerms( RooWorkspace* proto, vector<string>& constraintTermNames,
-			     ParamHistFunc& paramHist, TH1* uncertHist, 
+			     ParamHistFunc& paramHist, const TH1* uncertHist,
 			     Constraint::Type type, Double_t minSigma ) {
 
 

--- a/roofit/histfactory/src/Systematics.cxx
+++ b/roofit/histfactory/src/Systematics.cxx
@@ -58,7 +58,7 @@ RooStats::HistFactory::NormFactor::NormFactor() : fName(""), fVal(1.0),
 						  fLow(1.0), fHigh(1.0), 
 						  fConst(true) {;}
 
-void RooStats::HistFactory::NormFactor::Print( std::ostream& stream ) {
+void RooStats::HistFactory::NormFactor::Print( std::ostream& stream ) const {
   stream << "\t \t Name: " << fName
 	 << "\t Val: " << fVal
 	 << "\t Low: " << fLow
@@ -67,7 +67,7 @@ void RooStats::HistFactory::NormFactor::Print( std::ostream& stream ) {
 	 << std::endl;
 }
 
-void RooStats::HistFactory::NormFactor::PrintXML( std::ostream& xml ) {
+void RooStats::HistFactory::NormFactor::PrintXML( std::ostream& xml ) const {
   xml << "      <NormFactor Name=\"" << GetName() << "\" "
       << " Val=\""   << GetVal()   << "\" "
       << " High=\""  << GetHigh()  << "\" "
@@ -77,32 +77,22 @@ void RooStats::HistFactory::NormFactor::PrintXML( std::ostream& xml ) {
 }
 
 // Overall Sys
-void RooStats::HistFactory::OverallSys::Print( std::ostream& stream ) {
+void RooStats::HistFactory::OverallSys::Print( std::ostream& stream ) const {
   stream << "\t \t Name: " << fName
 	 << "\t Low: " << fLow
 	 << "\t High: " << fHigh
 	 << std::endl;
 }
 
-void RooStats::HistFactory::OverallSys::PrintXML( std::ostream& xml ) {
+void RooStats::HistFactory::OverallSys::PrintXML( std::ostream& xml ) const {
   xml << "      <OverallSys Name=\"" << GetName() << "\" "
       << " High=\"" << GetHigh() << "\" "
       << " Low=\""  << GetLow()  << "\" "
       << "  /> " << std::endl;
 }
 
-// HistoSys
-TH1* RooStats::HistFactory::HistoSys::GetHistoLow() {
-  TH1* histo_low = (TH1*) fhLow.GetObject();
-  return histo_low;
-}
 
-TH1* RooStats::HistFactory::HistoSys::GetHistoHigh() {
-  TH1* histo_high = (TH1*) fhHigh.GetObject();
-  return histo_high;
-}
-
-void RooStats::HistFactory::HistoSys::Print( std::ostream& stream ) {
+void RooStats::HistFactory::HistogramUncertaintyBase::Print( std::ostream& stream ) const {
   stream << "\t \t Name: " << fName
 	 << "\t HistoFileLow: " << fInputFileLow
 	 << "\t HistoNameLow: " << fHistoNameLow
@@ -113,25 +103,13 @@ void RooStats::HistFactory::HistoSys::Print( std::ostream& stream ) {
 	 << std::endl;
 }
 
-void RooStats::HistFactory::HistoSys::PrintXML( std::ostream& xml ) {
-  xml << "      <HistoSys Name=\"" << GetName() << "\" "
-      << " HistoFileLow=\""  << GetInputFileLow()  << "\" "
-      << " HistoNameLow=\""  << GetHistoNameLow()  << "\" "
-      << " HistoPathLow=\""  << GetHistoPathLow()  << "\" "
-
-      << " HistoFileHigh=\""  << GetInputFileHigh()  << "\" "
-      << " HistoNameHigh=\""  << GetHistoNameHigh()  << "\" "
-      << " HistoPathHigh=\""  << GetHistoPathHigh()  << "\" "
-      << "  /> " << std::endl;
-}
-
-void RooStats::HistFactory::HistoSys::writeToFile( const std::string& FileName, 
+void RooStats::HistFactory::HistogramUncertaintyBase::writeToFile( const std::string& FileName,
 						   const std::string& DirName ) {
 
   // This saves the histograms to a file and 
   // changes the name of the local file and histograms
   
-  TH1* histLow = GetHistoLow();
+  auto histLow = GetHistoLow();
   if( histLow==NULL ) {
     std::cout << "Error: Cannot write " << GetName()
 	      << " to file: " << FileName
@@ -144,7 +122,7 @@ void RooStats::HistFactory::HistoSys::writeToFile( const std::string& FileName,
   fHistoPathLow = DirName;
   fHistoNameLow = histLow->GetName(); 
 
-  TH1* histHigh = GetHistoHigh();
+  auto histHigh = GetHistoHigh();
   if( histHigh==NULL ) {
     std::cout << "Error: Cannot write " << GetName()
 	      << " to file: " << FileName
@@ -162,24 +140,30 @@ void RooStats::HistFactory::HistoSys::writeToFile( const std::string& FileName,
 }
 
 
-// Shape Sys
+void RooStats::HistFactory::HistoSys::PrintXML( std::ostream& xml ) const {
+  xml << "      <HistoSys Name=\"" << GetName() << "\" "
+      << " HistoFileLow=\""  << GetInputFileLow()  << "\" "
+      << " HistoNameLow=\""  << GetHistoNameLow()  << "\" "
+      << " HistoPathLow=\""  << GetHistoPathLow()  << "\" "
 
-TH1* RooStats::HistFactory::ShapeSys::GetErrorHist() {
-  TH1* error_hist = (TH1*) fhError.GetObject();
-  return error_hist;
+      << " HistoFileHigh=\""  << GetInputFileHigh()  << "\" "
+      << " HistoNameHigh=\""  << GetHistoNameHigh()  << "\" "
+      << " HistoPathHigh=\""  << GetHistoPathHigh()  << "\" "
+      << "  /> " << std::endl;
 }
 
+// Shape Sys
 
-void RooStats::HistFactory::ShapeSys::Print( std::ostream& stream ) {
+void RooStats::HistFactory::ShapeSys::Print( std::ostream& stream ) const {
   stream << "\t \t Name: " << fName
-	 << "\t InputFile: " << fInputFile
-	 << "\t HistoName: " << fHistoName
-	 << "\t HistoPath: " << fHistoPath
+	 << "\t InputFile: " << fInputFileHigh
+	 << "\t HistoName: " << fHistoNameHigh
+	 << "\t HistoPath: " << fHistoPathHigh
 	 << std::endl;
 }
 
 
-void RooStats::HistFactory::ShapeSys::PrintXML( std::ostream& xml ) {
+void RooStats::HistFactory::ShapeSys::PrintXML( std::ostream& xml ) const {
   xml << "      <ShapeSys Name=\"" << GetName() << "\" "
       << " InputFile=\""  << GetInputFile()  << "\" "
       << " HistoName=\""  << GetHistoName()  << "\" "
@@ -192,7 +176,7 @@ void RooStats::HistFactory::ShapeSys::PrintXML( std::ostream& xml ) {
 void RooStats::HistFactory::ShapeSys::writeToFile( const std::string& FileName, 
 						   const std::string& DirName ) {
 
-  TH1* histError = GetErrorHist();
+  auto histError = GetErrorHist();
   if( histError==NULL ) {
     std::cout << "Error: Cannot write " << GetName()
 	      << " to file: " << FileName
@@ -201,9 +185,9 @@ void RooStats::HistFactory::ShapeSys::writeToFile( const std::string& FileName,
     throw hf_exc();
   }
   histError->Write();
-  fInputFile = FileName;
-  fHistoPath = DirName;
-  fHistoName = histError->GetName(); 
+  fInputFileHigh = FileName;
+  fHistoPathHigh = DirName;
+  fHistoNameHigh = histError->GetName();
 
   return;
 
@@ -214,67 +198,7 @@ void RooStats::HistFactory::ShapeSys::writeToFile( const std::string& FileName,
 
 // HistoFactor
 
-void RooStats::HistFactory::HistoFactor::Print( std::ostream& stream ) {
-  stream << "\t \t Name: " << fName
-	 << "\t InputFileLow: " << fInputFileLow
-	 << "\t HistoNameLow: " << fHistoNameLow
-	 << "\t HistoPathLow: " << fHistoPathLow
-	 << "\t InputFileHigh: " << fInputFileHigh
-	 << "\t HistoNameHigh: " << fHistoNameHigh
-	 << "\t HistoPathHigh: " << fHistoPathHigh
-	 << std::endl;
-}
-
-
-TH1* RooStats::HistFactory::HistoFactor::GetHistoLow() {
-  TH1* histo_low = (TH1*) fhLow.GetObject();
-  return histo_low;
-}
-
-TH1* RooStats::HistFactory::HistoFactor::GetHistoHigh() {
-  TH1* histo_high = (TH1*) fhHigh.GetObject();
-  return histo_high;
-}
-
-
-void RooStats::HistFactory::HistoFactor::writeToFile( const std::string& FileName, 
-						      const std::string& DirName ) {
-
-
-  // This saves the histograms to a file and 
-  // changes the name of the local file and histograms
-  
-  TH1* histLow = GetHistoLow();
-  if( histLow==NULL ) {
-    std::cout << "Error: Cannot write " << GetName()
-	      << " to file: " << FileName
-	      << " HistoLow is NULL" 
-	      << std::endl;
-    throw hf_exc();
-  }
-  histLow->Write();
-  fInputFileLow = FileName;
-  fHistoPathLow = DirName;
-  fHistoNameLow = histLow->GetName(); 
-
-  TH1* histHigh = GetHistoHigh();
-  if( histHigh==NULL ) {
-    std::cout << "Error: Cannot write " << GetName()
-	      << " to file: " << FileName
-	      << " HistoHigh is NULL" 
-	      << std::endl;
-    throw hf_exc();
-  }
-  histHigh->Write();
-  fInputFileHigh = FileName;
-  fHistoPathHigh = DirName;
-  fHistoNameHigh = histHigh->GetName();
-
-  return;
-
-}
-
-void RooStats::HistFactory::HistoFactor::PrintXML( std::ostream& xml ) {
+void RooStats::HistFactory::HistoFactor::PrintXML( std::ostream& xml ) const {
   xml << "      <HistoFactor Name=\"" << GetName() << "\" "
 
       << " InputFileLow=\""  << GetInputFileLow()  << "\" "
@@ -289,19 +213,15 @@ void RooStats::HistFactory::HistoFactor::PrintXML( std::ostream& xml ) {
 
 
 // Shape Factor
-RooStats::HistFactory::ShapeFactor::ShapeFactor() : fConstant(false), 
-						    fHasInitialShape(false),
-						    fhInitialShape(NULL) {;}
-
-void RooStats::HistFactory::ShapeFactor::Print( std::ostream& stream ) {
+void RooStats::HistFactory::ShapeFactor::Print( std::ostream& stream ) const {
 
   stream << "\t \t Name: " << fName << std::endl;
   
-  if( fHistoName != "" ) {
+  if( fHistoNameHigh != "" ) {
     stream << "\t \t "
-	   << " Shape Hist Name: " << fHistoName
-	   << " Shape Hist Path Name: " << fHistoPath
-	   << " Shape Hist FileName: " << fInputFile
+	   << " Shape Hist Name: " << fHistoNameHigh
+	   << " Shape Hist Path Name: " << fHistoPathHigh
+	   << " Shape Hist FileName: " << fInputFileHigh
 	   << std::endl;
   }
 
@@ -314,7 +234,7 @@ void RooStats::HistFactory::ShapeFactor::writeToFile( const std::string& FileNam
 						      const std::string& DirName ) {
 
   if( HasInitialShape() ) {
-    TH1* histInitialShape = GetInitialShape();
+    auto histInitialShape = GetInitialShape();
     if( histInitialShape==NULL ) {
       std::cout << "Error: Cannot write " << GetName()
 		<< " to file: " << FileName
@@ -323,9 +243,9 @@ void RooStats::HistFactory::ShapeFactor::writeToFile( const std::string& FileNam
       throw hf_exc();
     }
     histInitialShape->Write();
-    fInputFile = FileName;
-    fHistoPath = DirName;
-    fHistoName = histInitialShape->GetName(); 
+    fInputFileHigh = FileName;
+    fHistoPathHigh = DirName;
+    fHistoNameHigh = histInitialShape->GetName();
   }
 
   return;
@@ -333,7 +253,7 @@ void RooStats::HistFactory::ShapeFactor::writeToFile( const std::string& FileNam
 }
 
 
-void RooStats::HistFactory::ShapeFactor::PrintXML( std::ostream& xml ) {
+void RooStats::HistFactory::ShapeFactor::PrintXML( std::ostream& xml ) const {
   xml << "      <ShapeFactor Name=\"" << GetName() << "\" ";
   if( fHasInitialShape ) {
     xml << " InputFile=\""  << GetInputFile()  << "\" "
@@ -345,13 +265,13 @@ void RooStats::HistFactory::ShapeFactor::PrintXML( std::ostream& xml ) {
 
 
 // Stat Error Config
-void RooStats::HistFactory::StatErrorConfig::Print( std::ostream& stream ) {
+void RooStats::HistFactory::StatErrorConfig::Print( std::ostream& stream ) const {
   stream << "\t \t RelErrorThreshold: " << fRelErrorThreshold
 	 << "\t ConstraintType: " << Constraint::Name( fConstraintType )
 	 << std::endl;
 }  
 
-void RooStats::HistFactory::StatErrorConfig::PrintXML( std::ostream& xml ) {
+void RooStats::HistFactory::StatErrorConfig::PrintXML( std::ostream& xml ) const {
   xml << "    <StatErrorConfig RelErrorThreshold=\"" << GetRelErrorThreshold() 
       << "\" "
       << "ConstraintType=\"" << Constraint::Name( GetConstraintType() ) 
@@ -362,20 +282,15 @@ void RooStats::HistFactory::StatErrorConfig::PrintXML( std::ostream& xml ) {
 
 
 // Stat Error
-TH1* RooStats::HistFactory::StatError::GetErrorHist() {
-  return (TH1*) fhError.GetObject();
-}
-
-
-void RooStats::HistFactory::StatError::Print( std::ostream& stream ) {
+void RooStats::HistFactory::StatError::Print( std::ostream& stream ) const {
   stream << "\t \t Activate: " << fActivate
-	 << "\t InputFile: " << fInputFile
-	 << "\t HistoName: " << fHistoName
-	 << "\t histoPath: " << fHistoPath
+	 << "\t InputFile: " << fInputFileHigh
+	 << "\t HistoName: " << fHistoNameHigh
+	 << "\t histoPath: " << fHistoPathHigh
 	 << std::endl;
 }  
 
-void RooStats::HistFactory::StatError::PrintXML( std::ostream& xml ) {
+void RooStats::HistFactory::StatError::PrintXML( std::ostream& xml ) const {
 
   if( GetActivate() ) {
     xml << "      <StatError Activate=\"" 
@@ -397,16 +312,16 @@ void RooStats::HistFactory::StatError::writeToFile( const std::string& OutputFil
     
     std::string statErrorHistName = "statisticalErrors";
     
-    TH1* hStatError = GetErrorHist();
+    auto hStatError = GetErrorHist();
     if( hStatError == NULL ) {
       std::cout << "Error: Stat Error error hist is NULL" << std::endl;
       throw hf_exc();
     }
     hStatError->Write(statErrorHistName.c_str());
     
-    fInputFile = OutputFileName;
-    fHistoName = statErrorHistName;
-    fHistoPath = DirName;
+    fInputFileHigh = OutputFileName;
+    fHistoNameHigh = statErrorHistName;
+    fHistoPathHigh = DirName;
     
   }
 

--- a/roofit/histfactory/src/hist2workspace.cxx
+++ b/roofit/histfactory/src/hist2workspace.cxx
@@ -16,6 +16,8 @@
 #include <exception>
 #include <vector>
 
+#include <TROOT.h>
+
 //void topDriver(string input); // in MakeModelAndMeasurements
 //void fastDriver(string input); // in MakeModelAndMeasurementsFast
 
@@ -65,6 +67,10 @@ int main(int argc, char** argv) {
     std::cerr << "need input file" << std::endl;
     exit(1);
   }
+
+  //Switch off ROOT histogram memory management
+  gROOT->SetMustClean(false);
+  TDirectory::AddDirectory(false);
 
   if(argc==2){
     std::string input(argv[1]);


### PR DESCRIPTION
hist2workspace reads histograms from multiple files, which often contain numerous folders with a lot of histograms.
It therefore needlessly suffers from TList::RecursiveRemove slowdowns, although almost all
histograms and files are read only. Implementing the memory management for histograms without ROOT's TList, and implementing move semantics with better const correctness leads to a speed up of a factor 10 for a large ATLAS-style Higgs workspace with 28 channels and about 150 systematic uncertainties.