### PR TITLE
[RF] Fix usage of unnamed temporaries in python tutorials

### DIFF
--- a/tutorials/roofit/rf110_normintegration.py
+++ b/tutorials/roofit/rf110_normintegration.py
@@ -45,8 +45,8 @@ x.setRange("signal", -5, 5)
 # Create an integral of gx_Norm[x] over x in range "signal"
 # ROOT.This is the fraction of of p.d.f. gx_Norm[x] which is in the
 # range named "signal"
-igx_sig = gx.createIntegral(ROOT.RooArgSet(x), ROOT.RooFit.NormSet(
-    ROOT.RooArgSet(x)), ROOT.RooFit.Range("signal"))
+xset = ROOT.RooArgSet(x)
+igx_sig = gx.createIntegral(xset, ROOT.RooFit.NormSet(xset), ROOT.RooFit.Range("signal"))
 print("gx_Int[x|signal]_Norm[x] = ", igx_sig.getVal())
 
 # Construct cumulative distribution function from pdf

--- a/tutorials/roofit/rf204_extrangefit.C
+++ b/tutorials/roofit/rf204_extrangefit.C
@@ -1,8 +1,13 @@
 /// \file
 /// \ingroup tutorial_roofit
 /// \notebook -nodraw
-/// Addition and convolution: extended maximum likelihood fit with alternate range definition for observed number of
-/// events.
+///  'ADDITION AND CONVOLUTION' RooFit tutorial macro #204
+///
+///  Extended maximum likelihood fit with alternate range definition
+///  for observed number of events.
+///  If multiple ranges are used, or only a part of the data is fitted,
+///  it is advisable to use a RooAddPdf to extend the model. See tutorial
+///  204a.
 ///
 /// \macro_output
 /// \macro_code
@@ -46,6 +51,8 @@ void rf204_extrangefit()
    RooRealVar sig1frac("sig1frac", "fraction of component 1 in signal", 0.8, 0., 1.);
    RooAddPdf sig("sig", "Signal", RooArgList(sig1, sig2), sig1frac);
 
+   // C o n s t r u c t   e x t e n d e d   c o m p s   wi t h   r a n g e   s p e c
+   // ------------------------------------------------------------------------------
 
    // Define signal range in which events counts are to be defined
    x.setRange("signalRange", 4, 6);
@@ -81,54 +88,5 @@ void rf204_extrangefit()
    // Perform unbinned ML fit to data, full range
    RooFitResult* r = model.fitTo(*data,Save()) ;
    r->Print() ;
-   
-   RooPlot * frame = x.frame(Title("Full range fitted"));
-   data->plotOn(frame);
-   model.plotOn(frame, VisualizeError(*r));
-   model.plotOn(frame);
-   model.paramOn(frame);
-   frame->Draw();
-   
-   
-   // Fit in two regions
-   // -------------------------------------------
-   
-   canv->cd(2);
-   x.setRange("left",  0., 4.);
-   x.setRange("right", 6., 10.);
-   
-   RooFitResult* r2 = model2.fitTo(*data,
-      Range("left,right"),
-      Save()) ;
-   r2->Print();
-   
-   
-   RooPlot * frame2 = x.frame(Title("Fit in left/right sideband"));
-   data->plotOn(frame2);
-   model2.plotOn(frame2, VisualizeError(*r2));
-   model2.plotOn(frame2);
-   model2.paramOn(frame2);
-   frame2->Draw();
-   
-   
-   // Fit in one region
-   // -------------------------------------------
-   
-   canv->cd(3);
-   x.setRange("leftToMiddle",  0., 5.);
-   
-   RooFitResult* r3 = model3.fitTo(*data,
-      Range("leftToMiddle"),
-      Save()) ;
-   r3->Print();
-   
-   
-   RooPlot * frame3 = x.frame(Title("Fit from left to middle"));
-   data->plotOn(frame3);
-   model3.plotOn(frame3, VisualizeError(*r3));
-   model3.plotOn(frame3);
-   model3.paramOn(frame3);
-   frame3->Draw();
-   
-   canv->Draw();
+
 }

--- a/tutorials/roofit/rf204_extrangefit.C
+++ b/tutorials/roofit/rf204_extrangefit.C
@@ -46,23 +46,22 @@ void rf204_extrangefit()
    RooRealVar sig1frac("sig1frac", "fraction of component 1 in signal", 0.8, 0., 1.);
    RooAddPdf sig("sig", "Signal", RooArgList(sig1, sig2), sig1frac);
 
-   // C o n s t r u c t   e x t e n d e d   c o m p s   wi t h   r a n g e   s p e c
-   // ------------------------------------------------------------------------------
 
    // Define signal range in which events counts are to be defined
    x.setRange("signalRange", 4, 6);
 
    // Associated nsig/nbkg as expected number of events with sig/bkg _in_the_range_ "signalRange"
-   RooRealVar nsig("nsig", "number of signal events in signalRange", 500, 0., 10000);
-   RooRealVar nbkg("nbkg", "number of background events in signalRange", 500, 0, 10000);
-   RooExtendPdf esig("esig", "extended signal p.d.f", sig, nsig, "signalRange");
-   RooExtendPdf ebkg("ebkg", "extended background p.d.f", bkg, nbkg, "signalRange");
+   RooRealVar nsig("nsig", "number of signal events in signalRange", 500, 0., 10000) ;
+   RooRealVar nbkg("nbkg", "number of background events in signalRange", 500, 0, 10000) ;
+   
+   // Use AddPdf to extend the model:
+   RooAddPdf  model("model","(g1+g2)+a", RooArgList(bkg,sig), RooArgList(nbkg,nsig)) ;
+   
+   // Clone these models here because the interpretation of normalisation coefficients changes
+   // when different ranges are used:
+   RooAddPdf model2(model);
+   RooAddPdf model3(model);
 
-   // S u m   e x t e n d e d   c o m p o n e n t s
-   // ---------------------------------------------
-
-   // Construct sum of two extended p.d.f. (no coefficients required)
-   RooAddPdf model("model", "(g1+g2)+a", RooArgList(ebkg, esig));
 
    // S a m p l e   d a t a ,   f i t   m o d e l
    // -------------------------------------------
@@ -70,7 +69,66 @@ void rf204_extrangefit()
    // Generate 1000 events from model so that nsig,nbkg come out to numbers <<500 in fit
    RooDataSet *data = model.generate(x, 1000);
 
-   // Perform unbinned extended ML fit to data
-   RooFitResult *r = model.fitTo(*data, Extended(kTRUE), Save());
-   r->Print();
+   
+   auto canv = new TCanvas("Canvas", "Canvas", 1500, 600);
+   canv->Divide(3,1);
+
+   // Fit full range
+   // -------------------------------------------
+
+   canv->cd(1);
+
+   // Perform unbinned ML fit to data, full range
+   RooFitResult* r = model.fitTo(*data,Save()) ;
+   r->Print() ;
+   
+   RooPlot * frame = x.frame(Title("Full range fitted"));
+   data->plotOn(frame);
+   model.plotOn(frame, VisualizeError(*r));
+   model.plotOn(frame);
+   model.paramOn(frame);
+   frame->Draw();
+   
+   
+   // Fit in two regions
+   // -------------------------------------------
+   
+   canv->cd(2);
+   x.setRange("left",  0., 4.);
+   x.setRange("right", 6., 10.);
+   
+   RooFitResult* r2 = model2.fitTo(*data,
+      Range("left,right"),
+      Save()) ;
+   r2->Print();
+   
+   
+   RooPlot * frame2 = x.frame(Title("Fit in left/right sideband"));
+   data->plotOn(frame2);
+   model2.plotOn(frame2, VisualizeError(*r2));
+   model2.plotOn(frame2);
+   model2.paramOn(frame2);
+   frame2->Draw();
+   
+   
+   // Fit in one region
+   // -------------------------------------------
+   
+   canv->cd(3);
+   x.setRange("leftToMiddle",  0., 5.);
+   
+   RooFitResult* r3 = model3.fitTo(*data,
+      Range("leftToMiddle"),
+      Save()) ;
+   r3->Print();
+   
+   
+   RooPlot * frame3 = x.frame(Title("Fit from left to middle"));
+   data->plotOn(frame3);
+   model3.plotOn(frame3, VisualizeError(*r3));
+   model3.plotOn(frame3);
+   model3.paramOn(frame3);
+   frame3->Draw();
+   
+   canv->Draw();
 }

--- a/tutorials/roofit/rf204a_extrangefit_RooAddPdf.C
+++ b/tutorials/roofit/rf204a_extrangefit_RooAddPdf.C
@@ -1,0 +1,153 @@
+/// \file
+/// \ingroup tutorial_roofit
+/// \notebook -js
+///  'ADDITION AND CONVOLUTION' RooFit tutorial macro #204a
+///
+///  Extended maxiimum likelihood fit in multiple ranges.
+///  When an extended pdf and multiple ranges are used, the
+///  RooExtendPdf cannot correctly interpret the coefficients
+///  used for extension.
+///  This can be solved by using a RooAddPdf for extending the model.
+///
+/// \macro_output
+/// \macro_code
+/// \author 12/2018 - Stephan Hageboeck 
+
+
+#include "RooRealVar.h"
+#include "RooDataSet.h"
+#include "RooGaussian.h"
+#include "RooChebychev.h"
+#include "RooAddPdf.h"
+#include "RooExtendPdf.h"
+#include "RooFitResult.h"
+#include "TCanvas.h"
+#include "TAxis.h"
+#include "RooPlot.h"
+using namespace RooFit ;
+
+
+void rf204a_extrangefit_RooAddPdf()
+{
+
+
+   // S e t u p   c o m p o n e n t   p d f s 
+   // ---------------------------------------
+
+   // Declare observable x
+   RooRealVar x("x","x",0,11) ;
+
+   // Create two Gaussian PDFs g1(x,mean1,sigma) anf g2(x,mean2,sigma) and their parameters
+   RooRealVar mean("mean","mean of gaussians",5) ;
+   RooRealVar sigma1("sigma1","width of gaussians",0.5) ;
+   RooRealVar sigma2("sigma2","width of gaussians",1) ;
+
+   RooGaussian sig1("sig1","Signal component 1",x,mean,sigma1) ;  
+   RooGaussian sig2("sig2","Signal component 2",x,mean,sigma2) ;  
+
+   // Build Chebychev polynomial p.d.f.  
+   RooRealVar a0("a0","a0",0.5,0.,1.) ;
+   RooRealVar a1("a1","a1",0.2,0.,1.) ;
+   RooChebychev bkg("bkg","Background",x,RooArgSet(a0,a1)) ;
+
+   // Sum the signal components into a composite signal p.d.f.
+   RooRealVar sig1frac("sig1frac","fraction of component 1 in signal",0.8,0.,1.) ;
+   RooAddPdf sig("sig","Signal",RooArgList(sig1,sig2),sig1frac) ;
+
+
+   // E x t e n d   t h e   p d f s
+   // -----------------------------
+
+
+   // Define signal range in which events counts are to be defined
+   x.setRange("signalRange",4,6) ;
+
+   // Associated nsig/nbkg as expected number of events with sig/bkg _in_the_range_ "signalRange"
+   RooRealVar nsig("nsig","number of signal events in signalRange",500,0.,10000) ;
+   RooRealVar nbkg("nbkg","number of background events in signalRange",500,0,10000) ;
+   
+   // Use AddPdf to extend the model. Giving as many coefficients as pdfs switches
+   // on extension.
+   RooAddPdf  model("model","(g1+g2)+a", RooArgList(bkg,sig), RooArgList(nbkg,nsig)) ;
+
+
+   // S a m p l e   d a t a ,   f i t   m o d e l
+   // -------------------------------------------
+
+   // Generate 1000 events from model so that nsig,nbkg come out to numbers <<500 in fit
+   RooDataSet *data = model.generate(x,1000) ;
+
+
+
+   auto canv = new TCanvas("Canvas", "Canvas", 1500, 600);
+   canv->Divide(3,1);
+
+   // Fit full range
+   // -------------------------------------------
+
+   canv->cd(1);
+
+   // Perform unbinned ML fit to data, full range
+   
+   // IMPORTANT:
+   // The model needs to be copied when fitting with different ranges because
+   // the interpretation of the coefficients is tied to the fit range
+   // that's used in the first fit
+   RooAddPdf model1(model);
+   RooFitResult* r = model1.fitTo(*data,Save()) ;
+   r->Print() ;
+   
+   RooPlot * frame = x.frame(Title("Full range fitted"));
+   data->plotOn(frame);
+   model1.plotOn(frame, VisualizeError(*r));
+   model1.plotOn(frame);
+   model1.paramOn(frame);
+   frame->Draw();
+   
+   
+   // Fit in two regions
+   // -------------------------------------------
+   
+   canv->cd(2);
+   x.setRange("left",  0., 4.);
+   x.setRange("right", 6., 10.);
+   
+   RooAddPdf model2(model);
+   RooFitResult* r2 = model2.fitTo(*data,
+      Range("left,right"),
+      Save()) ;
+   r2->Print();
+   
+   
+   RooPlot * frame2 = x.frame(Title("Fit in left/right sideband"));
+   data->plotOn(frame2);
+   model2.plotOn(frame2, VisualizeError(*r2));
+   model2.plotOn(frame2);
+   model2.paramOn(frame2);
+   frame2->Draw();
+   
+   
+   // Fit in one region
+   // -------------------------------------------
+   // Note how restricting the region to only the left tail increases
+   // the fit uncertainty
+   
+   canv->cd(3);
+   x.setRange("leftToMiddle",  0., 5.);
+   
+   RooAddPdf model3(model);
+   RooFitResult* r3 = model3.fitTo(*data,
+      Range("leftToMiddle"),
+      Save()) ;
+   r3->Print();
+   
+   
+   RooPlot * frame3 = x.frame(Title("Fit from left to middle"));
+   data->plotOn(frame3);
+   model3.plotOn(frame3, VisualizeError(*r3));
+   model3.plotOn(frame3);
+   model3.paramOn(frame3);
+   frame3->Draw();
+   
+   canv->Draw();
+}

--- a/tutorials/roofit/rf204a_extrangefit_RooAddPdf.C
+++ b/tutorials/roofit/rf204a_extrangefit_RooAddPdf.C
@@ -3,7 +3,7 @@
 /// \notebook -js
 ///  'ADDITION AND CONVOLUTION' RooFit tutorial macro #204a
 ///
-///  Extended maxiimum likelihood fit in multiple ranges.
+///  Extended maximum likelihood fit in multiple ranges.
 ///  When an extended pdf and multiple ranges are used, the
 ///  RooExtendPdf cannot correctly interpret the coefficients
 ///  used for extension.

--- a/tutorials/roofit/rf308_normintegration2d.py
+++ b/tutorials/roofit/rf308_normintegration2d.py
@@ -40,7 +40,8 @@ print("gx_Norm[x,y] = ", gxy.getVal(nset_xy))
 
 # Create object representing integral over gx
 # which is used to calculate  gx_Norm[x,y] == gx / gx_Int[x,y]
-igxy = gxy.createIntegral(ROOT.RooArgSet(x, y))
+x_and_y = ROOT.RooArgSet(x, y)
+igxy = gxy.createIntegral(x_and_y)
 print("gx_Int[x,y] = ", igxy.getVal())
 
 # NB: it is also possible to do the following
@@ -65,8 +66,9 @@ y.setRange("signal", -3, 3)
 # Create an integral of gxy_Norm[x,y] over x and y in range "signal"
 # ROOT.This is the fraction of of p.d.f. gxy_Norm[x,y] which is in the
 # range named "signal"
-igxy_sig = gxy.createIntegral(ROOT.RooArgSet(x, y), ROOT.RooFit.NormSet(
-    ROOT.RooArgSet(x, y)), ROOT.RooFit.Range("signal"))
+
+igxy_sig = gxy.createIntegral(x_and_y, ROOT.RooFit.NormSet(
+    x_and_y), ROOT.RooFit.Range("signal"))
 print("gx_Int[x,y|signal]_Norm[x,y] = ", igxy_sig.getVal())
 
 # Construct cumulative distribution function from pdf

--- a/tutorials/roofit/rf501_simultaneouspdf.py
+++ b/tutorials/roofit/rf501_simultaneouspdf.py
@@ -112,27 +112,23 @@ frame1 = x.frame(ROOT.RooFit.Bins(30), ROOT.RooFit.Title("Physics sample"))
 combData.plotOn(frame1, ROOT.RooFit.Cut("sample==sample::physics"))
 
 # Plot "physics" slice of simultaneous pdf.
-# NBL You _must_ project the sample index category with data using ProjWData
+# NB: You *must* project the sample index category with data using ProjWData
 # as a RooSimultaneous makes no prediction on the shape in the index category
 # and can thus not be integrated
+# NB2: The sampleSet *must* be named. It will not work to pass this as a temporary
+# because python will delete it. The same holds for fitTo() and plotOn() below.
+sampleSet = ROOT.RooArgSet(sample)
 simPdf.plotOn(frame1, ROOT.RooFit.Slice(sample, "physics"),
-              ROOT.RooFit.ProjWData(ROOT.RooArgSet(sample), combData))
-simPdf.plotOn(
-    frame1, ROOT.RooFit.Slice(
-        sample, "physics"), ROOT.RooFit.Components("px"), ROOT.RooFit.ProjWData(
-            ROOT.RooArgSet(sample), combData), ROOT.RooFit.LineStyle(
-                ROOT.kDashed))
+simPdf.plotOn(frame1, ROOT.RooFit.Slice(sample, "physics"), ROOT.RooFit.Components(
+    "px"), ROOT.RooFit.ProjWData(sampleSet, combData), ROOT.RooFit.LineStyle(ROOT.kDashed))
 
 # The same plot for the control sample slice
 frame2 = x.frame(ROOT.RooFit.Bins(30), ROOT.RooFit.Title("Control sample"))
 combData.plotOn(frame2, ROOT.RooFit.Cut("sample==sample::control"))
 simPdf.plotOn(frame2, ROOT.RooFit.Slice(sample, "control"),
-              ROOT.RooFit.ProjWData(ROOT.RooArgSet(sample), combData))
-simPdf.plotOn(
-    frame2, ROOT.RooFit.Slice(
-        sample, "control"), ROOT.RooFit.Components("px_ctl"), ROOT.RooFit.ProjWData(
-            ROOT.RooArgSet(sample), combData), ROOT.RooFit.LineStyle(
-                ROOT.kDashed))
+                ROOT.RooFit.ProjWData(sampleSet, combData))
+simPdf.plotOn(frame2, ROOT.RooFit.Slice(sample, "control"), ROOT.RooFit.Components(
+    "px_ctl"), ROOT.RooFit.ProjWData(sampleSet, combData), ROOT.RooFit.LineStyle(ROOT.kDashed))
 
 c = ROOT.TCanvas("rf501_simultaneouspdf",
                  "rf501_simultaneouspdf", 800, 400)

--- a/tutorials/roofit/rf501_simultaneouspdf.py
+++ b/tutorials/roofit/rf501_simultaneouspdf.py
@@ -118,7 +118,6 @@ combData.plotOn(frame1, ROOT.RooFit.Cut("sample==sample::physics"))
 # NB2: The sampleSet *must* be named. It will not work to pass this as a temporary
 # because python will delete it. The same holds for fitTo() and plotOn() below.
 sampleSet = ROOT.RooArgSet(sample)
-simPdf.plotOn(frame1, ROOT.RooFit.Slice(sample, "physics"),
 simPdf.plotOn(frame1, ROOT.RooFit.Slice(sample, "physics"), ROOT.RooFit.Components(
     "px"), ROOT.RooFit.ProjWData(sampleSet, combData), ROOT.RooFit.LineStyle(ROOT.kDashed))
 

--- a/tutorials/roofit/rf503_wspaceread.C
+++ b/tutorials/roofit/rf503_wspaceread.C
@@ -45,7 +45,6 @@ void rf503_wspaceread()
 
    // Print structure of composite p.d.f.
    model->Print("t") ;
-   model->Print("V");
 
 
    // F i t   m o d e l   t o   d a t a ,   p l o t   m o d e l

--- a/tutorials/roofit/rf503_wspaceread.C
+++ b/tutorials/roofit/rf503_wspaceread.C
@@ -44,8 +44,7 @@ void rf503_wspaceread()
    RooAbsData *data = w->data("modelData");
 
    // Print structure of composite p.d.f.
-   model->Print("t") ;
-
+   model->Print("t");
 
    // F i t   m o d e l   t o   d a t a ,   p l o t   m o d e l
    // ---------------------------------------------------------

--- a/tutorials/roofit/rf503_wspaceread.C
+++ b/tutorials/roofit/rf503_wspaceread.C
@@ -44,7 +44,9 @@ void rf503_wspaceread()
    RooAbsData *data = w->data("modelData");
 
    // Print structure of composite p.d.f.
-   model->Print("t");
+   model->Print("t") ;
+   model->Print("V");
+
 
    // F i t   m o d e l   t o   d a t a ,   p l o t   m o d e l
    // ---------------------------------------------------------

--- a/tutorials/roofit/rf505_asciicfg.C
+++ b/tutorials/roofit/rf505_asciicfg.C
@@ -52,11 +52,11 @@ void rf505_asciicfg()
    // Write parameters to file
    params->writeToFile("rf505_asciicfg_example.txt");
 
-   TString dir1 = gROOT->GetTutorialDir();
-   dir1.Append("/roofit/rf505_asciicfg.txt");
-   TString dir2 = gROOT->GetTutorialDir();
-   dir2.Append("/roofit/rf505_asciicfg_example.txt");
-   // R e a d    p a r a m e t e r s   f r o m    a s c i i   f i l e
+   TString dir1 = gROOT->GetTutorialDir() ;
+   dir1.Append("/roofit/rf505_asciicfg.txt") ;
+   TString dir2 = "rf505_asciicfg_example.txt";
+
+   // R e a d    p a r a m e t e r s   f r o m    a s c i i   f i l e 
    // ----------------------------------------------------------------
 
    // Read parameters from file

--- a/tutorials/roofit/rf505_asciicfg.py
+++ b/tutorials/roofit/rf505_asciicfg.py
@@ -1,4 +1,4 @@
-## \file
+## \file rf505_asciicfg.py 
 ## \ingroup tutorial_roofit
 ## \notebook -nodraw
 ##
@@ -53,13 +53,15 @@ params.writeToFile("rf505_asciicfg_example.txt")
 params.readFromFile("rf505_asciicfg_example.txt")
 params.Print("v")
 
+configFile = ROOT.gROOT.GetTutorialDir().Data() + "/roofit/rf505_asciicfg.txt"
+
 # Read parameters from section 'Section2' of file
-params.readFromFile("rf505_asciicfg.txt", "", "Section2")
+params.readFromFile(configFile, "", "Section2")
 params.Print("v")
 
 # Read parameters from section 'Section3' of file. Mark all
 # variables that were processed with the "READ" attribute
-params.readFromFile("rf505_asciicfg.txt", "READ", "Section3")
+params.readFromFile(configFile, "READ", "Section3")
 
 # Print the list of parameters that were not read from Section3
 print("The following parameters of the were _not_ read from Section3: ",
@@ -68,5 +70,5 @@ print("The following parameters of the were _not_ read from Section3: ",
 # Read parameters from section 'Section4' of file, contains
 # 'include file' statement of rf505_asciicfg_example.txt
 # so that we effective read the same
-params.readFromFile("rf505_asciicfg.txt", "", "Section4")
+params.readFromFile(configFile, "", "Section4")
 params.Print("v")


### PR DESCRIPTION
Python deletes temporary objects that are referenced by a C++ object. When the objects are named, the tutorials work.
Further, add a more elaborate tutorial rf204a on how to extend PDFs when fits in multiple ranges are desired.