### PR TITLE
[RF] Reactivate copy assignment for HistFactory classes

### DIFF
--- a/roofit/histfactory/CMakeLists.txt
+++ b/roofit/histfactory/CMakeLists.txt
@@ -91,3 +91,6 @@ install(FILES ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/prepareHistFactory
                             GROUP_EXECUTE GROUP_READ
                             WORLD_EXECUTE WORLD_READ
                 DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+ROOT_ADD_TEST_SUBDIRECTORY(test)
+

--- a/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
@@ -85,7 +85,7 @@ namespace RooStats{
 			   std::map<std::string,double> logNormSyst, 
 			   std::map<std::string,double> noSyst);
 
-      void LinInterpWithConstraint(RooWorkspace* proto, TH1* nominal, std::vector<HistoSys>,  
+      void LinInterpWithConstraint(RooWorkspace* proto, const TH1* nominal, std::vector<HistoSys>,
 				   std::string prefix, std::string productPrefix, 
 				   std::string systTerm, 
 				   std::vector<std::string>& likelihoodTermNames);
@@ -103,14 +103,14 @@ namespace RooStats{
 				RooArgList obsList,
 				RooCategory* channelCat);
 
-      void ProcessExpectedHisto(TH1* hist, RooWorkspace* proto, std::string prefix, 
+      void ProcessExpectedHisto(const TH1* hist, RooWorkspace* proto, std::string prefix,
 				std::string productPrefix, std::string systTerm );
 
       void SetObsToExpected(RooWorkspace* proto, std::string obsPrefix, std::string expPrefix, 
 			    int lowBin, int highBin);
 
       TH1* MakeScaledUncertaintyHist(const std::string& Name, 
-				     std::vector< std::pair<TH1*, TH1*> > HistVec );
+				     std::vector< std::pair<const TH1*, const TH1*> > HistVec );
 
       TH1* MakeAbsolUncertaintyHist( const std::string& Name, const TH1* Hist );
 
@@ -131,7 +131,7 @@ namespace RooStats{
 
     private:
     
-      void GuessObsNameVec(TH1* hist);
+      void GuessObsNameVec(const TH1* hist);
     
       std::vector<std::string> fObsNameVec;
       std::string fObsName;

--- a/roofit/histfactory/inc/RooStats/HistFactory/Sample.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Sample.h
@@ -36,11 +36,11 @@ public:
   Sample(std::string Name, std::string HistoName, std::string InputFile, std::string HistoPath="");
   ~Sample();
 
-  void Print(std::ostream& = std::cout);  
+  void Print(std::ostream& = std::cout) const;
   void PrintXML( std::ofstream& xml );
   void writeToFile( std::string FileName, std::string DirName );
 
-  TH1* GetHisto();
+  const TH1* GetHisto() const;
   // set histogram for this sample
   void SetHisto( TH1* histo ) { fhNominal = histo; fHistoName=histo->GetName(); }
   void SetValue( Double_t Val );
@@ -75,31 +75,31 @@ public:
   /// defines whether the normalization scale with luminosity
   void SetNormalizeByTheory( bool norm ) { fNormalizeByTheory = norm; }
   /// does the normalization scale with luminosity
-  bool GetNormalizeByTheory() { return fNormalizeByTheory; }
+  bool GetNormalizeByTheory() const { return fNormalizeByTheory; }
 
 
   /// get name of sample
-  std::string GetName() { return fName; }
+  std::string GetName() const { return fName; }
   /// set name of sample
   void SetName(const std::string& Name) { fName = Name; }
 
   /// get input ROOT file
-  std::string GetInputFile() { return fInputFile; }
+  std::string GetInputFile() const { return fInputFile; }
   /// set input ROOT file
   void SetInputFile(const std::string& InputFile) { fInputFile = InputFile; }
 
   /// get histogram name
-  std::string GetHistoName() { return fHistoName; }
+  std::string GetHistoName() const { return fHistoName; }
   /// set histogram name
   void SetHistoName(const std::string& HistoName) { fHistoName = HistoName; }
 
   /// get histogram path
-  std::string GetHistoPath() { return fHistoPath; }
+  std::string GetHistoPath() const { return fHistoPath; }
   /// set histogram path
   void SetHistoPath(const std::string& HistoPath) { fHistoPath = HistoPath; }
 
   /// get name of associated channel
-  std::string GetChannelName() { return fChannelName; }
+  std::string GetChannelName() const { return fChannelName; }
   /// set name of associated channel
   void SetChannelName(const std::string& ChannelName) { fChannelName = ChannelName; }
 

--- a/roofit/histfactory/inc/RooStats/HistFactory/Systematics.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Systematics.h
@@ -128,10 +128,11 @@ namespace HistFactory {
     fhHigh{oth.fhHigh ? static_cast<TH1*>(oth.fhHigh->Clone()) : nullptr} {
 
     }
+    HistogramUncertaintyBase(HistogramUncertaintyBase&&) = default;
 
     virtual ~HistogramUncertaintyBase() {};
 
-    HistogramUncertaintyBase(HistogramUncertaintyBase&&) = default;
+
     // Need deep copies because the class owns its histograms.
     HistogramUncertaintyBase& operator=(const HistogramUncertaintyBase& oth) {
       fName = oth.fName;
@@ -146,7 +147,6 @@ namespace HistFactory {
 
       return *this;
     }
-    // Fine with unique_ptr
     HistogramUncertaintyBase& operator=(HistogramUncertaintyBase&&) = default;
 
     virtual void Print(std::ostream& = std::cout) const;
@@ -232,8 +232,6 @@ public:
     ShapeSys(const ShapeSys& other) :
       HistogramUncertaintyBase(other),
       fConstraintType(other.fConstraintType) {}
-    ShapeSys(ShapeSys&&) = default;
-    ShapeSys& operator=(ShapeSys&&) = default;
 
     void SetInputFile( const std::string& InputFile ) { fInputFileHigh = InputFile; }
     std::string GetInputFile() const { return fInputFileHigh; }
@@ -327,9 +325,6 @@ public:
     StatError() :
       HistogramUncertaintyBase(),
       fActivate(false), fUseHisto(false) {}
-    StatError(StatError&&) = default;
-    StatError& operator=(StatError&&) = default;
-    StatError(const StatError&) = default;
 
     void Print(std::ostream& = std::cout) const override;
     void PrintXML(std::ostream&) const override;

--- a/roofit/histfactory/src/Channel.cxx
+++ b/roofit/histfactory/src/Channel.cxx
@@ -347,7 +347,7 @@ bool RooStats::HistFactory::Channel::CheckHistograms() {
 	// Check if any bins are negative
 	std::vector<int> NegativeBinNumber;
 	std::vector<double> NegativeBinContent;
-	TH1* histNominal = sample.GetHisto();
+	const TH1* histNominal = sample.GetHisto();
 	for(int ibin=1; ibin<=histNominal->GetNbinsX(); ++ibin) {
 	  if(histNominal->GetBinContent(ibin) < 0) {
 	    NegativeBinNumber.push_back(ibin);

--- a/roofit/histfactory/src/HistRef.cxx
+++ b/roofit/histfactory/src/HistRef.cxx
@@ -21,17 +21,12 @@
 namespace RooStats{
 namespace HistFactory {
 
-   TH1 * HistRef::CopyObject(TH1 * h) { 
+   TH1 * HistRef::CopyObject(const TH1 * h) {
       // implementation of method copying the contained pointer
       // (just use Clone)
       if (!h) return 0; 
-      return (TH1*) h->Clone(); 
-   } 
-
-   void HistRef::DeleteObject(TH1 * h) {
-      if (h) delete h;
-   } 
-
+      return static_cast<TH1*>(h->Clone());
+   }
 }
 }
 

--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -75,6 +75,7 @@
 #include "Helper.h"
 
 #include <algorithm>
+#include <utility>
 
 #define VERBOSE
 
@@ -322,7 +323,7 @@ namespace HistFactory{
 
   }
 
-  void HistoToWorkspaceFactoryFast::ProcessExpectedHisto(TH1* hist,RooWorkspace* proto, 
+  void HistoToWorkspaceFactoryFast::ProcessExpectedHisto(const TH1* hist,RooWorkspace* proto,
 							 string prefix, string productPrefix, 
 							 string systTerm ) {
     if(hist) {
@@ -350,7 +351,7 @@ namespace HistFactory{
     std::vector<std::string>::iterator itr = fObsNameVec.begin();
     for (int idx=0; itr!=fObsNameVec.end(); ++itr, ++idx ) {
       if ( !proto->var(itr->c_str()) ) {
-	TAxis* axis(0);
+	const TAxis* axis(0);
 	if (idx==0) { axis = hist->GetXaxis(); }
 	if (idx==1) { axis = hist->GetYaxis(); }
 	if (idx==2) { axis = hist->GetZaxis(); }
@@ -408,7 +409,7 @@ namespace HistFactory{
     constraintTermNames.push_back(constraint.GetName());
   }
 
-  void HistoToWorkspaceFactoryFast::LinInterpWithConstraint(RooWorkspace* proto, TH1* nominal, 
+  void HistoToWorkspaceFactoryFast::LinInterpWithConstraint(RooWorkspace* proto, const TH1* nominal,
 							    std::vector<HistoSys> histoSysList,
 							    string prefix, string productPrefix, 
 							    string systTerm, 
@@ -435,7 +436,7 @@ namespace HistFactory{
     std::vector<std::string>::iterator itr = fObsNameVec.begin();
     for (int idx=0; itr!=fObsNameVec.end(); ++itr, ++idx ) {
       if ( !proto->var(itr->c_str()) ) {
-	TAxis* axis(NULL);
+	const TAxis* axis(nullptr);
 	if (idx==0) { axis = nominal->GetXaxis(); }
 	else if (idx==1) { axis = nominal->GetYaxis(); }
 	else if (idx==2) { axis = nominal->GetZaxis(); }
@@ -1219,7 +1220,7 @@ namespace HistFactory{
     /// MB: label observables x,y,z, depending on histogram dimensionality
     /// GHL: Give it the first sample's nominal histogram as a template
     ///      since the data histogram may not be present
-    TH1* channel_hist_template = channel.GetSamples().at(0).GetHisto();
+    const TH1* channel_hist_template = channel.GetSamples().at(0).GetHisto();
     if (fObsNameVec.empty()) { GuessObsNameVec(channel_hist_template); }
 
     for ( unsigned int idx=0; idx<fObsNameVec.size(); ++idx ) {
@@ -1254,7 +1255,7 @@ namespace HistFactory{
     vector<string> likelihoodTermNames, constraintTermNames, totSystTermNames, syst_x_expectedPrefixNames, normalizationNames;
 
     vector< pair<string,string> >   statNamePairs;
-    vector< pair<TH1*,TH1*> >       statHistPairs; // <nominal, error>
+    vector< pair<const TH1*, const TH1*> > statHistPairs; // <nominal, error>
     std::string                     statFuncName; // the name of the ParamHistFunc
     std::string                     statNodeName; // the name of the McStat Node
     // Constraint::Type statConstraintType=Constraint::Gaussian;
@@ -1309,7 +1310,7 @@ namespace HistFactory{
 
       // get histogram
       //ES// TH1* nominal = it->nominal;
-      TH1* nominal = sample.GetHisto();
+      const TH1* nominal = sample.GetHisto();
 
       // MB : HACK no option to have both non-hist variations and hist variations ?
       // get histogram
@@ -1423,7 +1424,7 @@ namespace HistFactory{
 	
 	  // Save the nominal and error hists
 	  // for the building of constraint terms
-	  statHistPairs.push_back( pair<TH1*,TH1*>(nominal, statErrorHist) );
+	  statHistPairs.push_back( std::make_pair(nominal, statErrorHist) );
 
 	  // To do the 'conservative' version, we would need to do some
 	  // intervention here.  We would probably need to create a different
@@ -2073,7 +2074,7 @@ namespace HistFactory{
     }
   }
 
-  void HistoToWorkspaceFactoryFast::GuessObsNameVec(TH1* hist)
+  void HistoToWorkspaceFactoryFast::GuessObsNameVec(const TH1* hist)
   {
     fObsNameVec.clear();
 
@@ -2411,7 +2412,7 @@ namespace HistFactory{
   
   }
   
-  TH1* HistoToWorkspaceFactoryFast::MakeScaledUncertaintyHist( const std::string& Name, std::vector< std::pair<TH1*, TH1*> > HistVec ) {
+  TH1* HistoToWorkspaceFactoryFast::MakeScaledUncertaintyHist( const std::string& Name, std::vector< std::pair<const TH1*, const TH1*> > HistVec ) {
 
     // Take a list of < nominal, absolError > TH1* pairs
     // and construct a single histogram representing the 
@@ -2430,15 +2431,15 @@ namespace HistFactory{
       return NULL;
     }
     
-    TH1* HistTemplate = HistVec.at(0).first;
+    const TH1* HistTemplate = HistVec.at(0).first;
     Int_t numBins = HistTemplate->GetNbinsX()*HistTemplate->GetNbinsY()*HistTemplate->GetNbinsZ();
 
   // Check that all histograms
   // have the same bins
   for( unsigned int i = 0; i < HistVec.size(); ++i ) {
     
-    TH1* nominal = HistVec.at(i).first;
-    TH1* error   = HistVec.at(i).second;
+    const TH1* nominal = HistVec.at(i).first;
+    const TH1* error   = HistVec.at(i).second;
     
     if( nominal->GetNbinsX()*nominal->GetNbinsY()*nominal->GetNbinsZ() != numBins ) {
       std::cout << "Error: Provided hists have unequal bins" << std::endl;
@@ -2465,8 +2466,8 @@ namespace HistFactory{
     
     for( unsigned int i_hist = 0; i_hist < numHists; ++i_hist ) {
       
-      TH1* nominal = HistVec.at(i_hist).first;
-      TH1* error   = HistVec.at(i_hist).second;
+      const TH1* nominal = HistVec.at(i_hist).first;
+      const TH1* error   = HistVec.at(i_hist).second;
 
       //Int_t binNumber = i_bins + 1;
 

--- a/roofit/histfactory/src/Sample.cxx
+++ b/roofit/histfactory/src/Sample.cxx
@@ -66,7 +66,7 @@ RooStats::HistFactory::Sample::~Sample() {
     delete fhCountingHist;
 }
 
-TH1* RooStats::HistFactory::Sample::GetHisto()  {
+const TH1* RooStats::HistFactory::Sample::GetHisto() const {
   TH1* histo = (TH1*) fhNominal.GetObject();
   return histo;
 }
@@ -74,7 +74,7 @@ TH1* RooStats::HistFactory::Sample::GetHisto()  {
 
 void RooStats::HistFactory::Sample::writeToFile( std::string OutputFileName, std::string DirName ) {
 
-  TH1* histNominal = GetHisto();
+  const TH1* histNominal = GetHisto();
   histNominal->Write();
   
   // Set the location of the data
@@ -131,7 +131,7 @@ void RooStats::HistFactory::Sample::SetValue( Double_t val ) {
 
 
 
-void RooStats::HistFactory::Sample::Print( std::ostream& stream ) {
+void RooStats::HistFactory::Sample::Print( std::ostream& stream ) const {
 
 
   stream << "\t \t Name: " << fName

--- a/roofit/histfactory/test/CMakeLists.txt
+++ b/roofit/histfactory/test/CMakeLists.txt
@@ -1,0 +1,4 @@
+# @author Stephan Hageboeck CERN, 2019
+
+ROOT_ADD_GTEST(testHistFactory testHistFactory.cxx LIBRARIES RooFitCore RooFit RooStats HistFactory)
+

--- a/roofit/histfactory/test/testHistFactory.cxx
+++ b/roofit/histfactory/test/testHistFactory.cxx
@@ -1,0 +1,24 @@
+// Tests for the HistFactory
+// Authors: Stephan Hageboeck, CERN  01/2019
+
+#include "RooStats/HistFactory/Sample.h"
+#include "gtest/gtest.h"
+
+using namespace RooStats;
+using namespace RooStats::HistFactory;
+
+TEST(Sample, CopyAssignment)
+{
+  Sample s("s");
+  {
+    Sample s1("s1");
+    auto hist1 = new TH1D("hist1", "hist1", 10, 0, 10);
+    s1.SetHisto(hist1);
+    s = s1;
+    //Now go out of scope. Should delete hist1, that's owned by s1.
+  }
+  
+  auto hist = s.GetHisto();
+  ASSERT_EQ(hist->GetNbinsX(), 10);
+}
+


### PR DESCRIPTION
Rootbench depends on copy assignment for the `Sample` class. After implementing move semantics to speed up hist2workspace, the copy assignment had been implicitly deleted. This was fixed, and a gtest has been added.

Further, HistRef, a member of Sample, is now movable, and the histograms given back by Sample are now `const TH1*` instead of `TH1*`.