### PR TITLE
Silent gcc8 warning when specify callback function for gluTessCallback

### DIFF
--- a/graf3d/ftgl/src/FTVectoriser.cxx
+++ b/graf3d/ftgl/src/FTVectoriser.cxx
@@ -183,11 +183,20 @@ void FTVectoriser::MakeMesh( FTGL_DOUBLE zNormal)
 
     GLUtesselator* tobj = gluNewTess();
 
+#if defined(__GNUC__) && __GNUC__ >= 8
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
+
     gluTessCallback( tobj, GLU_TESS_BEGIN_DATA,     (GLUTesselatorFunction)ftglBegin);
     gluTessCallback( tobj, GLU_TESS_VERTEX_DATA,    (GLUTesselatorFunction)ftglVertex);
     gluTessCallback( tobj, GLU_TESS_COMBINE_DATA,   (GLUTesselatorFunction)ftglCombine);
     gluTessCallback( tobj, GLU_TESS_END_DATA,       (GLUTesselatorFunction)ftglEnd);
     gluTessCallback( tobj, GLU_TESS_ERROR_DATA,     (GLUTesselatorFunction)ftglError);
+
+#if defined(__GNUC__) && __GNUC__ >= 8
+#pragma GCC diagnostic pop
+#endif
 
     if( contourFlag & ft_outline_even_odd_fill) // ft_outline_reverse_fill
     {


### PR DESCRIPTION
Unfortunately, gluTessCallback uses same function pointer type for
absolutely different functions kinds. Only inside gluTessCallback proper
casting done. Therefore the only solution - suppress warings