### PR TITLE
webgui: check ROOTWebDisplay library when --web option specified, ROOT-9927

### DIFF
--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -423,8 +423,12 @@ void TApplication::GetOptions(Int_t *argc, char **argv)
          TString argw;
          if (gROOT->IsBatch()) argw = "batch";
          if (*opt == '=') argw.Append(opt+1);
-         gROOT->SetWebDisplay(argw.Data());
-         gEnv->SetValue("Gui.Factory", "web");
+         if (gSystem->Load("libROOTWebDisplay") == 0) {
+            gROOT->SetWebDisplay(argw.Data());
+            gEnv->SetValue("Gui.Factory", "web");
+         } else {
+            Error("GetOptions", "--web option not supported, ROOT should be build with at least c++14 enabled");
+         }
       } else if (!strcmp(argv[i], "-e")) {
          argv[i] = null;
          ++i;


### PR DESCRIPTION
When starting ROOT with --web option, check if necessary libraries are
build. Only in that case change Gui.Factory and call
gROOT->SetWebDisplay. 

Fixes https://sft.its.cern.ch/jira/browse/ROOT-9927