### PR TITLE
[RF][ROOT-9777] Replay "Fix cloning workspaces"

### DIFF
--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -220,6 +220,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     RooUnitTest.h
     RooVectorDataStore.h
     RooWorkspace.h
+    RooWorkspaceHandle.h
     RooXYChi2Var.h
   SOURCES
     src/BidirMMapPipe.cxx

--- a/roofit/roofitcore/inc/LinkDef3.h
+++ b/roofit/roofitcore/inc/LinkDef3.h
@@ -49,6 +49,7 @@
 #pragma link C++ class RooWorkspace- ;
 #pragma link C++ class RooWorkspace::CodeRepo- ;
 #pragma link C++ class RooWorkspace::WSDir+ ;
+#pragma link C++ class RooWorkspaceHandle+;
 #pragma link C++ class std::list<TObject*>+ ;
 #pragma link C++ class std::list<RooAbsData*>+ ;
 #pragma link C++ class RooProfileLL+ ;

--- a/roofit/roofitcore/inc/RooWorkspaceHandle.h
+++ b/roofit/roofitcore/inc/RooWorkspaceHandle.h
@@ -1,0 +1,37 @@
+// Author: Stephan Hageboeck, CERN  01/2019
+
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOFIT_ROOFITCORE_INC_ROOWORKSPACEHANDLE_H_
+#define ROOFIT_ROOFITCORE_INC_ROOWORKSPACEHANDLE_H_
+
+#include "RooWorkspace.h"
+
+/// An interface to set and retrieve a workspace.
+/// This is needed for all generic objects that can be saved in a workspace, which itself depend
+/// on the workspace (e.g. the RooStats::ModelConfig).
+/// Because of a circular dependency, a workspace with a ModelConfig cannot be (deep) cloned.
+/// The handle hides this dependency.
+class RooWorkspaceHandle {
+public:
+   virtual ~RooWorkspaceHandle() {}
+
+   ///Set the workspace. If it exists, it is up to the implementing class to decide how to proceed.
+   virtual void SetWS(RooWorkspace &ws) = 0;
+
+   ///Set the workspace irrespective of what the previous workspace is.
+   virtual void ReplaceWS(RooWorkspace *ws) = 0;
+
+   ///Retrieve the workspace.
+   virtual RooWorkspace *GetWS() const = 0;
+
+   ClassDef(RooWorkspaceHandle, 0)
+};
+
+#endif /* ROOFIT_ROOFITCORE_INC_ROOWORKSPACEHANDLE_H_ */

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -34,8 +34,9 @@ This process is also organized by the workspace through the
 `importClassCode()` method.
 **/
 
-#include "RooFit.h"
 #include "RooWorkspace.h"
+#include "RooWorkspaceHandle.h"
+#include "RooFit.h"
 #include "RooAbsPdf.h"
 #include "RooRealVar.h"
 #include "RooCategory.h"
@@ -73,17 +74,14 @@ using namespace std ;
 #include <string.h>
 
 ClassImp(RooWorkspace);
-;
 
 ////////////////////////////////////////////////////////////////////////////////
 
 ClassImp(RooWorkspace::CodeRepo);
-;
 
 ////////////////////////////////////////////////////////////////////////////////
 
 ClassImp(RooWorkspace::WSDir);
-;
 
 list<string> RooWorkspace::_classDeclDirList ;
 list<string> RooWorkspace::_classImplDirList ;
@@ -205,7 +203,14 @@ RooWorkspace::RooWorkspace(const RooWorkspace& other) :
   TIterator* iter4 = other._genObjects.MakeIterator() ;
   TObject* gobj ;
   while((gobj=iter4->Next())) {
-    _genObjects.Add(gobj->Clone()) ;
+    TObject *theClone = gobj->Clone();
+
+    auto handle = dynamic_cast<RooWorkspaceHandle*>(theClone);
+    if (handle) {
+      handle->ReplaceWS(this);
+    }
+
+    _genObjects.Add(theClone);
   }
   delete iter4 ;
   

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -1,3 +1,4 @@
 # @author Danilo Piparo CERN, 2018
 
 ROOT_ADD_GTEST(simple simple.cxx LIBRARIES RooFitCore)
+ROOT_ADD_GTEST(testWorkspace testWorkspace.cxx LIBRARIES RooFitCore RooFit RooStats)

--- a/roofit/roofitcore/test/testWorkspace.cxx
+++ b/roofit/roofitcore/test/testWorkspace.cxx
@@ -1,0 +1,70 @@
+/// Tests for the RooWorkspace
+
+#include "RooGlobalFunc.h"
+#include "RooGaussian.h"
+#include "RooArgList.h"
+#include "RooRealVar.h"
+#include "RooAbsReal.h"
+#include "RooStats/ModelConfig.h"
+
+#include "TFile.h"
+#include "TSystem.h"
+
+#include "gtest/gtest.h"
+
+using namespace RooStats;
+
+/// ROOT-9777, cloning a RooWorkspace. The ModelConfig did not get updated
+/// when a workspace was cloned, and was hence pointing to a non-existing workspace.
+///
+TEST(RooWorkspace, CloneModelConfig_ROOT_9777)
+{
+   const char* filename = "ROOT-9777.root";
+
+   RooRealVar x("x", "x", 1, 0, 10);
+   RooRealVar mu("mu", "mu", 1, 0, 10);
+   RooRealVar sigma("sigma", "sigma", 1, 0, 10);
+
+   RooGaussian pdf("Gauss", "Gauss", x, mu, sigma);
+
+   {
+      TFile outfile(filename, "RECREATE");
+      
+      // now create the model config for this problem
+      RooWorkspace* w = new RooWorkspace("ws");
+      ModelConfig modelConfig("ModelConfig", w);
+      modelConfig.SetPdf(pdf);
+      modelConfig.SetParametersOfInterest(RooArgSet(sigma));
+      modelConfig.SetGlobalObservables(RooArgSet(mu));
+      w->import(modelConfig);
+
+      outfile.WriteObject(w, "ws");
+      delete w;
+   }
+   
+   RooWorkspace *w2;
+   {
+      TFile infile(filename, "READ");
+      RooWorkspace *w;
+      infile.GetObject("ws", w);
+      ASSERT_TRUE(w) << "Workspace not read from file.";
+
+      w2 = new RooWorkspace(*w);
+      delete w;
+   }
+   
+   w2->Print();
+
+   ModelConfig *mc = dynamic_cast<ModelConfig*>(w2->genobj("ModelConfig"));
+   ASSERT_TRUE(mc) << "ModelConfig not retrieved.";
+   mc->Print();
+
+   ASSERT_TRUE(mc->GetGlobalObservables()) << "GlobalObsevables in mc broken.";
+   mc->GetGlobalObservables()->Print();
+
+   ASSERT_TRUE(mc->GetParametersOfInterest()) << "ParametersOfInterest in mc broken.";
+   mc->GetParametersOfInterest()->Print();
+
+   gSystem->Unlink(filename);
+}
+

--- a/roofit/roostats/inc/RooStats/ModelConfig.h
+++ b/roofit/roostats/inc/RooStats/ModelConfig.h
@@ -18,7 +18,7 @@
 
 #include "RooArgSet.h"
 
-#include "RooWorkspace.h"
+#include "RooWorkspaceHandle.h"
 
 #include "TRef.h"
 
@@ -27,7 +27,7 @@
 
 namespace RooStats {
 
-class ModelConfig : public TNamed {
+class ModelConfig final : public TNamed, public RooWorkspaceHandle {
 
 public:
 
@@ -51,7 +51,7 @@ public:
 
 
    /// clone
-   virtual ModelConfig * Clone(const char * name = "") const {
+   virtual ModelConfig * Clone(const char * name = "") const override {
       ModelConfig * mc =  new ModelConfig(*this);
       if(strcmp(name,"")==0)
    mc->SetName(this->GetName());
@@ -60,10 +60,16 @@ public:
       return mc;
    }
 
-   /// set a workspace that owns all the necessary components for the analysis
-   virtual void SetWS(RooWorkspace & ws);
+   /// Set a workspace that owns all the necessary components for the analysis.
+   virtual void SetWS(RooWorkspace & ws) override;
    //// alias for SetWS(...)
    virtual void SetWorkspace(RooWorkspace & ws) { SetWS(ws); }
+
+   /// Remove the existing reference to a workspace and replace it with this new one.
+   virtual void ReplaceWS(RooWorkspace *ws) override {
+     fRefWS = nullptr;
+     SetWS(*ws);
+   }
 
    /// Set the proto DataSet, add to the the workspace if not already there
    virtual void SetProtoData(RooAbsData & data) {
@@ -250,7 +256,7 @@ public:
 
    void LoadSnapshot() const;
 
-   RooWorkspace * GetWS() const;
+   RooWorkspace * GetWS() const override;
    /// alias for GetWS()
    RooWorkspace * GetWorkspace() const { return GetWS(); }
 
@@ -258,7 +264,7 @@ public:
    void GuessObsAndNuisance(const RooAbsData& data);
 
    /// overload the print method
-   virtual void Print(Option_t* option = "") const;
+   virtual void Print(Option_t* option = "") const override;
 
 protected:
 
@@ -294,7 +300,7 @@ protected:
 
    std::string fObservablesName; /// name for RooArgSet specifying observable parameters.
 
-   ClassDef(ModelConfig,4) /// A class that holds configuration information for a model using a workspace as a store
+   ClassDefOverride(ModelConfig,4) /// A class that holds configuration information for a model using a workspace as a store
 
 };
 

--- a/roofit/roostats/src/ModelConfig.cxx
+++ b/roofit/roostats/src/ModelConfig.cxx
@@ -156,7 +156,8 @@ void ModelConfig::Print(Option_t*) const {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// set a workspace that owns all the necessary components for the analysis
+/// If a workspace already exists in this ModelConfig, RooWorkspace::merge(ws) will be called
+/// on the existing workspace.
 
 void ModelConfig::SetWS(RooWorkspace & ws) {
    if( !fRefWS.GetObject() ) {


### PR DESCRIPTION
- When RooWorkspaces that contain a ModelConfig are cloned, the ModelConfig did not get updated. It would still point to the old workspace.
- Add unit test.

This reverts commit fdab28c0ca4782733527e6b74a4f795c252a877e.