### PR TITLE
[Exp PyROOT] Configure preliminar module facade for ROOT

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/__init__.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/__init__.py
@@ -55,6 +55,7 @@ def pythonization(lazy = True):
 for _, module_name, _ in  pkgutil.walk_packages(pyz.__path__):
     module = importlib.import_module(pyz.__name__ + '.' + module_name)
 
-# Redirect ROOT to cppyy.gbl
+# Configure ROOT facade module
 import sys
-sys.modules['ROOT'] = cppyy.gbl
+from ._facade import ROOTFacade
+sys.modules[__name__] = ROOTFacade(sys.modules[__name__])

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/_facade.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/_facade.py
@@ -1,0 +1,23 @@
+import types
+
+from cppyy import gbl as gbl_namespace
+from libROOTPython import gROOT
+
+class ROOTFacade(types.ModuleType):
+    """Facade class for ROOT module"""
+
+    def __init__(self, module):
+        types.ModuleType.__init__(self, module.__name__)
+
+        self.module = module
+
+        self.__doc__  = module.__doc__
+        self.__name__ = module.__name__
+        self.__file__ = module.__file__
+
+        # Inject gROOT global
+        self.gROOT = gROOT
+
+        # Redirect lookups to cppyy's global namespace
+        self.__class__.__getattr__ = lambda self, name: getattr(gbl_namespace, name)
+        self.__class__.__setattr__ = lambda self, name, val: setattr(gbl_namespace, name, val)


### PR DESCRIPTION
This PR puts in place a facade for ROOT to become a Python module with custom behaviour, in a similar way it is done for the current PyROOT.
https://github.com/root-project/root/blob/master/bindings/pyroot/ROOT.py#L560

For now this is just a simple skeleton that redirects lookups to cppyy's global namespace, and more investigation on the logic implemented by the facade of the current PyROOT is necessary.