### PR TITLE
v5-34-00-patches mysql v8 fix

### DIFF
--- a/sql/mysql/inc/TMySQLStatement.h
+++ b/sql/mysql/inc/TMySQLStatement.h
@@ -29,6 +29,14 @@ typedef struct { int dummy; } MYSQL_STMT;
 typedef struct { int dummy; } MYSQL_BIND;
 #endif
 
+// MariaDB is fork of MySQL and still include definition of my_bool
+// MariaDB major version is 10, therefore it confuses version ID here
+#ifndef MARIADB_VERSION_ID
+#if MYSQL_VERSION_ID > 80000
+typedef bool my_bool;
+#endif
+#endif
+
 #else
 struct MYSQL_STMT;
 struct MYSQL_BIND;
@@ -70,7 +78,7 @@ protected:
    void        SetBuffersNumber(Int_t n);
 
    void       *BeforeSet(const char* method, Int_t npar, Int_t sqltype, Bool_t sig = kTRUE, ULong_t size = 0);
-   
+
    static ULong64_t fgAllocSizeLimit;
 
 private:
@@ -80,7 +88,7 @@ private:
 public:
    TMySQLStatement(MYSQL_STMT* stmt, Bool_t errout = kTRUE);
    virtual ~TMySQLStatement();
-   
+
    static ULong_t GetAllocSizeLimit() { return fgAllocSizeLimit; }
    static void SetAllocSizeLimit(ULong_t sz) { fgAllocSizeLimit = sz; }
 

--- a/sql/mysql/src/TMySQLServer.cxx
+++ b/sql/mysql/src/TMySQLServer.cxx
@@ -52,8 +52,9 @@
 #include "TObjString.h"
 #include "TObjArray.h"
 
+#if MYSQL_VERSION_ID < 80000
 #include <my_global.h>
-
+#endif
 
 ClassImp(TMySQLServer)
 


### PR DESCRIPTION
Fixes ROOT v5-34 `TMySQLStatement.h` incompatibility with mysql v8 as was done with the master branch some time ago:

[https://sft.its.cern.ch/jira/browse/ROOT-9624](https://sft.its.cern.ch/jira/browse/ROOT-9624)

[https://github.com/root-project/root/pull/2726](https://github.com/root-project/root/pull/2726)

N.B. - the current fix does not change the `my_bool` var on line 162 of `TMySQLServer.cxx` (as in the above-linked PR) because this seems to break other things. The current fix also adds a preprocessor directive to TMySQLServer.cxx on line 55 to include `<my_global.h>` (which does not exist in mysql v8) if mysql < v8.