### PR TITLE
[DF][ROOT-9929] Extract branches names which are nested from jitted

### DIFF
--- a/tree/dataframe/test/dataframe_colnames.cxx
+++ b/tree/dataframe/test/dataframe_colnames.cxx
@@ -30,6 +30,20 @@ TEST(ColNames, HasColumn)
 
 }
 
+// ROOT-9929
+TEST(ColNames, ContainedNames)
+{
+   TTree t("t","t");
+   int i = 1;
+   t.Branch("a", &i);
+   t.Branch("aa", &i);
+   t.Fill();
+
+   ROOT::RDataFrame df(t);
+   auto c = df.Filter("a == aa").Count();
+   EXPECT_EQ(1U, *c);
+}
+
 TEST(Aliases, DefineOnAlias)
 {
    ROOT::RDataFrame tdf(2);


### PR DESCRIPTION
strings

properly, for example treating cases such as 'branch0' and 'branch01'.
The code of the helper FindUsedColumnNames has been simplified.
A test has been added.