### PR TITLE
Windows: Fix pyroot_experimental

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
@@ -34,5 +34,8 @@ foreach(py_source ${py_sources})
 endforeach()
 
 ROOT_LINKER_LIBRARY(ROOTPython ${sources} LIBRARIES Core Tree cppyy)
+if(MSVC)
+  set_target_properties(ROOTPython PROPERTIES SUFFIX ".pyd")
+endif()
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/bindings/pyroot_experimental/PyROOT/src/PyzPythonHelpers.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyzPythonHelpers.cxx
@@ -41,7 +41,7 @@ PyObject *PyROOT::GetSizeOfType(PyObject * /*self*/, PyObject *args)
    // Call interpreter to get size of data-type using `sizeof`
    long size;
    std::stringstream code;
-   code << "*((long*)" << &size << ") = (long)sizeof(" << dtype << ")";
+   code << "*((long*)" << std::hex << std::showbase << (size_t)&size << ") = (long)sizeof(" << dtype << ")";
    gInterpreter->Calc(code.str().c_str());
 
    // Return size of data-type as integer
@@ -71,8 +71,8 @@ PyObject *PyROOT::GetVectorDataPointer(PyObject * /*self*/, PyObject *args)
    // Call interpreter to get pointer to data (using `data` method)
    long pointer;
    std::stringstream code;
-   code << "*((long*)" << &pointer << ") = reinterpret_cast<long>(reinterpret_cast<" << cppname << "*>(" << cppobj
-        << ")->data())";
+   code << "*((long*)" << std::hex << std::showbase << (size_t)&pointer << ") = reinterpret_cast<long>(reinterpret_cast<" << cppname
+        << "*>(" << std::hex << std::showbase << (size_t)cppobj << ")->data())";
    gInterpreter->Calc(code.str().c_str());
 
    // Return pointer as integer

--- a/bindings/pyroot_experimental/cppyy/CMakeLists.txt
+++ b/bindings/pyroot_experimental/cppyy/CMakeLists.txt
@@ -1,4 +1,8 @@
-set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
+if(MSVC)
+  set(CMAKE_SHARED_LIBRARY_SUFFIX ".dll")
+else()
+  set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
+endif()
 
 add_subdirectory(cppyy-backend)
 add_subdirectory(CPyCppyy)

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/CMakeLists.txt
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/CMakeLists.txt
@@ -38,8 +38,15 @@ set(sources
 )
 
 add_library(cppyy SHARED ${headers} ${sources})
-target_compile_options(cppyy PRIVATE
-  -Wno-shadow -Wno-strict-aliasing -Wno-unused-but-set-parameter)
+
+if(MSVC)
+  set_target_properties(cppyy PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
+  set_target_properties(cppyy PROPERTIES PREFIX "lib")
+  set_target_properties(cppyy PROPERTIES SUFFIX ".pyd")
+else()
+  target_compile_options(cppyy PRIVATE
+    -Wno-shadow -Wno-strict-aliasing -Wno-unused-but-set-parameter)
+endif()
 target_include_directories(cppyy PUBLIC ${PYTHON_INCLUDE_DIRS}
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>)

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CPPInstance.h
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CPPInstance.h
@@ -98,12 +98,7 @@ private:
 
 
 //- object proxy type and type verification ----------------------------------
-#ifdef _MSC_VER
-__declspec(dllimport) PyTypeObject CPPInstance_Type;
-#else
-extern PyTypeObject CPPInstance_Type;
-#endif
-
+RPY_EXPORT PyTypeObject CPPInstance_Type;
 
 template<typename T>
 inline bool CPPInstance_Check(T* object)

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CPPInstance.h
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CPPInstance.h
@@ -98,7 +98,12 @@ private:
 
 
 //- object proxy type and type verification ----------------------------------
+#ifdef _MSC_VER
+__declspec(dllimport) PyTypeObject CPPInstance_Type;
+#else
 extern PyTypeObject CPPInstance_Type;
+#endif
+
 
 template<typename T>
 inline bool CPPInstance_Check(T* object)

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CPPOverload.h
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CPPOverload.h
@@ -73,11 +73,7 @@ private:
 
 
 //- method proxy type and type verification ----------------------------------
-#ifdef _MSC_VER
-__declspec(dllimport) PyTypeObject CPPOverload_Type;
-#else
-extern PyTypeObject CPPOverload_Type;
-#endif
+RPY_EXPORT PyTypeObject CPPOverload_Type;
 
 template<typename T>
 inline bool CPPOverload_Check(T* object)

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CPPOverload.h
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CPPOverload.h
@@ -73,7 +73,11 @@ private:
 
 
 //- method proxy type and type verification ----------------------------------
+#ifdef _MSC_VER
+__declspec(dllimport) PyTypeObject CPPOverload_Type;
+#else
 extern PyTypeObject CPPOverload_Type;
+#endif
 
 template<typename T>
 inline bool CPPOverload_Check(T* object)

--- a/bindings/pyroot_experimental/cppyy/cppyy-backend/CMakeLists.txt
+++ b/bindings/pyroot_experimental/cppyy/cppyy-backend/CMakeLists.txt
@@ -19,6 +19,10 @@ endforeach()
 add_library(cppyy_backend SHARED clingwrapper/src/clingwrapper.cxx)
 target_include_directories(cppyy_backend PRIVATE clingwrapper/src)
 target_link_libraries(cppyy_backend Core ${CMAKE_DL_LIBS})
+if(MSVC)
+  set_target_properties(cppyy_backend PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
+  set_target_properties(cppyy_backend PROPERTIES PREFIX "lib")
+endif()
 
 # cppyy uses ROOT headers from binary directory
 add_dependencies(cppyy_backend move_headers)

--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -1356,10 +1356,15 @@ endfunction()
 # ROOT_ADD_PYUNITTESTS( <name> )
 #----------------------------------------------------------------------------
 function(ROOT_ADD_PYUNITTESTS name)
+if(MSVC)
+  set(ROOT_ENV ROOTSYS=${ROOTSYS}
+      PYTHONPATH=${ROOTSYS}/bin;$ENV{PYTHONPATH})
+else()
   set(ROOT_ENV ROOTSYS=${ROOTSYS}
       PATH=${ROOTSYS}/bin:$ENV{PATH}
       LD_LIBRARY_PATH=${ROOTSYS}/lib:$ENV{LD_LIBRARY_PATH}
       PYTHONPATH=${ROOTSYS}/lib:$ENV{PYTHONPATH})
+endif()
   string(REGEX REPLACE "[_]" "-" good_name "${name}")
   ROOT_ADD_TEST(pyunittests-${good_name}
                 COMMAND ${PYTHON_EXECUTABLE} -B -m unittest discover -s ${CMAKE_CURRENT_SOURCE_DIR} -p "*.py" -v
@@ -1372,10 +1377,15 @@ endfunction()
 function(ROOT_ADD_PYUNITTEST name file)
   CMAKE_PARSE_ARGUMENTS(ARG "WILLFAIL" "" "COPY_TO_BUILDDIR" ${ARGN})
 
+if(MSVC)
+  set(ROOT_ENV ROOTSYS=${ROOTSYS}
+      PYTHONPATH=${ROOTSYS}/bin;$ENV{PYTHONPATH})
+else()
   set(ROOT_ENV ROOTSYS=${ROOTSYS}
       PATH=${ROOTSYS}/bin:$ENV{PATH}
       LD_LIBRARY_PATH=${ROOTSYS}/lib:$ENV{LD_LIBRARY_PATH}
       PYTHONPATH=${ROOTSYS}/lib:$ENV{PYTHONPATH})
+endif()
   string(REGEX REPLACE "[_]" "-" good_name "${name}")
   get_filename_component(file_name ${file} NAME)
   get_filename_component(file_dir ${file} DIRECTORY)


### PR DESCRIPTION
- Fix dynamic libraries extensions (.so/.dll/.pyd)
- Fix path for the tests and tutorials
- Make sure hexadecimal pointer values have the correct '0x' prefix (not automatic on Windows)