### PR TITLE
Get rid of CMake warnings on 6.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.4.3 FATAL_ERROR)
 
-set(policy_new CMP0068)
+set(policy_new CMP0068 CMP0072)
 foreach(policy ${policy_new})
   if(POLICY ${policy})
     cmake_policy(SET ${policy} NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.4.3 FATAL_ERROR)
 
-set(policy_new CMP0068 CMP0072)
+set(policy_new CMP0068 CMP0072 CMP0077)
 foreach(policy ${policy_new})
   if(POLICY ${policy})
     cmake_policy(SET ${policy} NEW)

--- a/interpreter/llvm/src/CMakeLists.txt
+++ b/interpreter/llvm/src/CMakeLists.txt
@@ -23,6 +23,10 @@ if(POLICY CMP0075)
   cmake_policy(SET CMP0075 NEW)
 endif()
 
+if(POLICY CMP0077)
+  cmake_policy(SET CMP0077 NEW)
+endif()
+
 if(NOT DEFINED LLVM_VERSION_MAJOR)
   set(LLVM_VERSION_MAJOR 5)
 endif()

--- a/interpreter/llvm/src/CMakeLists.txt
+++ b/interpreter/llvm/src/CMakeLists.txt
@@ -19,6 +19,10 @@ if(POLICY CMP0057)
   cmake_policy(SET CMP0057 NEW)
 endif()
 
+if(POLICY CMP0075)
+  cmake_policy(SET CMP0075 NEW)
+endif()
+
 if(NOT DEFINED LLVM_VERSION_MAJOR)
   set(LLVM_VERSION_MAJOR 5)
 endif()

--- a/interpreter/llvm/src/tools/clang/CMakeLists.txt
+++ b/interpreter/llvm/src/tools/clang/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.4.3)
 
+if(POLICY CMP0075)
+  cmake_policy(SET CMP0075 NEW)
+endif()
+
 # If we are not building as a part of LLVM, build Clang as an
 # standalone project, using LLVM as an external library:
 if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )


### PR DESCRIPTION
We've had these commits on 6.16 and master for a while, should be ok for 6.14 as well.
Warnings are shown in CDash: https://cdash.cern.ch/viewConfigure.php?buildid=620083.