### PR TITLE
Fix issue with case insensitive file systems

### DIFF
--- a/core/base/inc/RConfig.h
+++ b/core/base/inc/RConfig.h
@@ -20,6 +20,7 @@
  *                                                                       *
  *************************************************************************/
 
-#include <ROOT/RConfig.h>
+// This include must use double quotes on case-insensitive file systems
+#include "ROOT/RConfig.h"
 
 #endif // ROOT_RConfig_fwd


### PR DESCRIPTION
This is needed to fix MacPorts, https://trac.macports.org/ticket/57007, HomeBrew https://github.com/Homebrew/homebrew-core/pull/36585, and any similar system with case insensitivity. `RConfig.h` includes itself instead of `ROOT/RConfig.h`.

This prioritizes relative imports for RConfig on most compilers. *Any similar changes should use double-quote imports too* to avoid this ambiguity.