### PR TITLE
Windows: Fix pointer formatting in Eve7

### DIFF
--- a/graf3d/eve7/src/REveDataClasses.cxx
+++ b/graf3d/eve7/src/REveDataClasses.cxx
@@ -51,9 +51,9 @@ void REveDataCollection::SetFilterExpr(const TString& filter)
    fFilterExpr = filter;
 
    std::stringstream s;
-   s << "*((std::function<bool(" << fItemClass->GetName() << "*)>*)" << std::hex << std::showbase
-     << (size_t)&fFilterFoo << ") = [](" << fItemClass->GetName() << "* p){" << fItemClass->GetName()
-     << " &i=*p; return (" << fFilterExpr.Data() << "); }";
+   s << "*((std::function<bool(" << fItemClass->GetName() << "*)>*)" << std::hex << std::showbase << (size_t)&fFilterFoo
+     << ") = [](" << fItemClass->GetName() << "* p){" << fItemClass->GetName() << " &i=*p; return ("
+     << fFilterExpr.Data() << "); }";
 
    // printf("%s\n", s.Data());
    try {
@@ -209,9 +209,9 @@ void REveDataColumn::SetExpressionAndType(const TString& expr, FieldType_e type)
    }
 
    std::stringstream s;
-   s << "*((std::function<" << rtyp << "(" << icls->GetName() << "*)>*)" << std::hex
-     << std::showbase << (size_t)fooptr << ") = [](" << icls->GetName() << "* p){"
-     << icls->GetName() << " &i=*p; return (" << fExpression.Data() << "); }";
+   s << "*((std::function<" << rtyp << "(" << icls->GetName() << "*)>*)" << std::hex << std::showbase << (size_t)fooptr
+     << ") = [](" << icls->GetName() << "* p){" << icls->GetName() << " &i=*p; return (" << fExpression.Data()
+     << "); }";
 
    // printf("%s\n", s.Data());
    try {

--- a/graf3d/eve7/src/REveDataClasses.cxx
+++ b/graf3d/eve7/src/REveDataClasses.cxx
@@ -16,6 +16,7 @@
 #include "TMethodArg.h"
 
 #include "json.hpp"
+#include <sstream>
 
 
 using namespace ROOT::Experimental;
@@ -49,20 +50,14 @@ void REveDataCollection::SetFilterExpr(const TString& filter)
 
    fFilterExpr = filter;
 
-   TString s;
-#ifdef _MSC_VER
-   s.Form("*((std::function<bool(%s*)>*)0x%p) = [](%s* p){%s &i=*p; return (%s); }",
-          fItemClass->GetName(), &fFilterFoo, fItemClass->GetName(), fItemClass->GetName(),
-          fFilterExpr.Data());
-#else
-   s.Form("*((std::function<bool(%s*)>*)%p) = [](%s* p){%s &i=*p; return (%s); }",
-          fItemClass->GetName(), &fFilterFoo, fItemClass->GetName(), fItemClass->GetName(),
-          fFilterExpr.Data());
-#endif
+   std::stringstream s;
+   s << "*((std::function<bool(" << fItemClass->GetName() << "*)>*)" << std::hex << std::showbase
+     << (size_t)&fFilterFoo << ") = [](" << fItemClass->GetName() << "* p){" << fItemClass->GetName()
+     << " &i=*p; return (" << fFilterExpr.Data() << "); }";
 
    // printf("%s\n", s.Data());
    try {
-      gROOT->ProcessLine(s.Data());
+      gROOT->ProcessLine(s.str().c_str());
    }
    catch (const std::exception &exc)
    {
@@ -213,20 +208,14 @@ void REveDataColumn::SetExpressionAndType(const TString& expr, FieldType_e type)
       case FT_String: rtyp = "std::string"; fooptr = &fStringFoo; break;
    }
 
-   TString s;
-#ifdef _MSC_VER
-   s.Form("*((std::function<%s(%s*)>*)0x%p) = [](%s* p){%s &i=*p; return (%s); }",
-          rtyp, icls->GetName(), fooptr, icls->GetName(), icls->GetName(),
-          fExpression.Data());
-#else
-   s.Form("*((std::function<%s(%s*)>*)%p) = [](%s* p){%s &i=*p; return (%s); }",
-          rtyp, icls->GetName(), fooptr, icls->GetName(), icls->GetName(),
-          fExpression.Data());
-#endif
+   std::stringstream s;
+   s << "*((std::function<" << rtyp << "(" << icls->GetName() << "*)>*)" << std::hex
+     << std::showbase << (size_t)fooptr << ") = [](" << icls->GetName() << "* p){"
+     << icls->GetName() << " &i=*p; return (" << fExpression.Data() << "); }";
 
    // printf("%s\n", s.Data());
    try {
-      gROOT->ProcessLine(s.Data());
+      gROOT->ProcessLine(s.str().c_str());
    }
    catch (const std::exception &exc)
    {

--- a/graf3d/eve7/src/REveDataClasses.cxx
+++ b/graf3d/eve7/src/REveDataClasses.cxx
@@ -50,9 +50,15 @@ void REveDataCollection::SetFilterExpr(const TString& filter)
    fFilterExpr = filter;
 
    TString s;
+#ifdef _MSC_VER
+   s.Form("*((std::function<bool(%s*)>*)0x%p) = [](%s* p){%s &i=*p; return (%s); }",
+          fItemClass->GetName(), &fFilterFoo, fItemClass->GetName(), fItemClass->GetName(),
+          fFilterExpr.Data());
+#else
    s.Form("*((std::function<bool(%s*)>*)%p) = [](%s* p){%s &i=*p; return (%s); }",
           fItemClass->GetName(), &fFilterFoo, fItemClass->GetName(), fItemClass->GetName(),
           fFilterExpr.Data());
+#endif
 
    // printf("%s\n", s.Data());
    try {
@@ -208,9 +214,15 @@ void REveDataColumn::SetExpressionAndType(const TString& expr, FieldType_e type)
    }
 
    TString s;
+#ifdef _MSC_VER
+   s.Form("*((std::function<%s(%s*)>*)0x%p) = [](%s* p){%s &i=*p; return (%s); }",
+          rtyp, icls->GetName(), fooptr, icls->GetName(), icls->GetName(),
+          fExpression.Data());
+#else
    s.Form("*((std::function<%s(%s*)>*)%p) = [](%s* p){%s &i=*p; return (%s); }",
           rtyp, icls->GetName(), fooptr, icls->GetName(), icls->GetName(),
           fExpression.Data());
+#endif
 
    // printf("%s\n", s.Data());
    try {

--- a/graf3d/eve7/src/REveManager.cxx
+++ b/graf3d/eve7/src/REveManager.cxx
@@ -840,7 +840,11 @@ void REveManager::HttpServerCallback(unsigned connid, const std::string &arg)
 
       auto el =  FindElementById(id);
       char cmd[128];
+#ifdef _MSC_VER
+      sprintf(cmd, "((%s*)0x%p)->%s;", ctype.c_str(), el, mir.c_str());
+#else
       sprintf(cmd, "((%s*)%p)->%s;", ctype.c_str(), el, mir.c_str());
+#endif
       printf("MIR cmd %s\n", cmd);
       gROOT->ProcessLine(cmd);
 

--- a/graf3d/eve7/src/REveManager.cxx
+++ b/graf3d/eve7/src/REveManager.cxx
@@ -38,7 +38,8 @@
 #include "Riostream.h"
 
 #include "json.hpp"
-
+#include <sstream>
+#include <iostream>
 
 using namespace ROOT::Experimental;
 namespace REX = ROOT::Experimental;
@@ -839,14 +840,10 @@ void REveManager::HttpServerCallback(unsigned connid, const std::string &arg)
       int id = cj["fElementId"];
 
       auto el =  FindElementById(id);
-      char cmd[128];
-#ifdef _MSC_VER
-      sprintf(cmd, "((%s*)0x%p)->%s;", ctype.c_str(), el, mir.c_str());
-#else
-      sprintf(cmd, "((%s*)%p)->%s;", ctype.c_str(), el, mir.c_str());
-#endif
-      printf("MIR cmd %s\n", cmd);
-      gROOT->ProcessLine(cmd);
+      std::stringstream cmd;
+      cmd << "((" << ctype << "*)" << std::hex << std::showbase << (size_t)el << ")->" << mir << ";";
+      std::cout << "MIR cmd " << cmd.str() << std::endl;
+      gROOT->ProcessLine(cmd.str().c_str());
 
       fScenes->AcceptChanges(false);
       Redraw3D();


### PR DESCRIPTION
Make sure hexadecimal pointer values have the correct '0x' prefix (not automatic on Windows)