### PR TITLE
[Exp PyROOT] Re-enable tutorial, ROOT facade is there

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -464,7 +464,6 @@ if(ROOT_python_FOUND)
                  tutorial-pyroot-staff-py
                  tutorial-pyroot-tornado-py
                  tutorial-pyroot-tree-py
-                 tutorial-roofit-rf104_classfactory-py
                  tutorial-roofit-rf106_plotdecoration-py
                  tutorial-roofit-rf315_projectpdf-py
                  tutorial-roofit-rf402_datahandling-py


### PR DESCRIPTION
Tutorial is now working after changes of https://github.com/root-project/root/pull/3351