### PR TITLE
[PyROOT exp] Add AsRVec method

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
@@ -20,6 +20,7 @@ set(sources
   src/TFilePyz.cxx
   src/TTreePyz.cxx
   src/GenericPyz.cxx
+  src/RVecPyz.cxx
   src/PyzPythonHelpers.cxx
   src/PyzCppHelpers.cxx
 )

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_rvec.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_rvec.py
@@ -9,7 +9,7 @@
 ################################################################################
 
 from ROOT import pythonization
-from libROOTPython import GetEndianess, GetVectorDataPointer, GetSizeOfType
+from libROOTPython import GetEndianess, GetVectorDataPointer, GetSizeOfType, AsRVec
 
 _array_interface_dtypes = [
     "float", "double", "int", "long", "unsigned int", "unsigned long"
@@ -60,3 +60,8 @@ def pythonize_rvec(klass, name):
         add_array_interface_property(klass, name)
 
     return True
+
+
+# Add AsRVec feature as free function to the ROOT module
+import cppyy
+cppyy.gbl.ROOT.VecOps.AsRVec = AsRVec

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
@@ -57,6 +57,8 @@ static PyMethodDef gPyROOTMethods[] = {{(char *)"AddDirectoryWritePyz", (PyCFunc
                                         (char *)"Get pointer to data of vector"},
                                        {(char *)"GetSizeOfType", (PyCFunction)PyROOT::GetSizeOfType, METH_VARARGS,
                                         (char *)"Get size of data-type"},
+                                       {(char *)"AsRVec", (PyCFunction)PyROOT::AsRVec, METH_O,
+                                        (char *)"Get object with array interface as RVec"},
                                        {NULL, NULL, 0, NULL}};
 
 #if PY_VERSION_HEX >= 0x03000000

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
@@ -26,6 +26,7 @@ PyObject *BranchPyz(PyObject *self, PyObject *args);
 PyObject *GetEndianess(PyObject *self);
 PyObject *GetVectorDataPointer(PyObject *self, PyObject *args);
 PyObject *GetSizeOfType(PyObject *self, PyObject *args);
+PyObject *AsRVec(PyObject *self, PyObject *obj);
 
 } // namespace PyROOT
 

--- a/bindings/pyroot_experimental/PyROOT/src/RVecPyz.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/RVecPyz.cxx
@@ -1,0 +1,129 @@
+// Author: Stefan Wunsch CERN  02/2019
+// Original PyROOT code by Wim Lavrijsen, LBL
+
+/*************************************************************************
+ * Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "CPyCppyy.h"
+#include "CPPInstance.h"
+#include "ProxyWrappers.h"
+#include "PyROOTPythonize.h"
+#include "RConfig.h"
+#include "TInterpreter.h"
+
+////////////////////////////////////////////////////////////////////////////
+/// \brief Get size of C++ data-type
+/// \param[in] obj PyObject with array interface
+///
+/// This function returns an RVec which adopts the memory of the given
+/// PyObject. The RVec takes the data pointer and the size from the array
+/// interface dictionary.
+PyObject *PyROOT::AsRVec(PyObject * /*self*/, PyObject * obj)
+{
+   if (!obj) {
+      PyErr_SetString(PyExc_RuntimeError, "Object not convertible: Invalid Python object.");
+      return NULL;
+   }
+
+   // Get array interface of object
+   auto pyinterface = PyObject_GetAttrString(obj, "__array_interface__");
+   if (!pyinterface) {
+      PyErr_SetString(PyExc_RuntimeError, "Object not convertible: __array_interface__ does not exist.");
+      return NULL;
+   }
+   if (!PyDict_Check(pyinterface)) {
+      PyErr_SetString(PyExc_RuntimeError, "Object not convertible: __array_interface__ is not a dictionary.");
+      return NULL;
+   }
+
+   // Get the data-pointer
+   auto pydata = PyDict_GetItemString(pyinterface, "data");
+   if (!pydata) {
+      PyErr_SetString(PyExc_RuntimeError, "Object not convertible: __array_interface__['data'] does not exist.");
+      return NULL;
+   }
+   long data = PyLong_AsLong(PyTuple_GetItem(pydata, 0));
+
+   // Get the size of the contiguous memory
+   auto pyshape = PyDict_GetItemString(pyinterface, "shape");
+   if (!pyshape) {
+      PyErr_SetString(PyExc_RuntimeError, "Object not convertible: __array_interface__['shape'] does not exist.");
+      return NULL;
+   }
+   long size = 0;
+   for (unsigned int i = 0; i < PyTuple_Size(pyshape); i++) {
+      if (size == 0) size = 1;
+      size *= PyLong_AsLong(PyTuple_GetItem(pyshape, i));
+   }
+
+   // Get the typestring
+   auto pytypestr = PyDict_GetItemString(pyinterface, "typestr");
+   if (!pytypestr) {
+      PyErr_SetString(PyExc_RuntimeError, "Object not convertible: __array_interface__['typestr'] does not exist.");
+      return NULL;
+   }
+   std::string typestr = CPyCppyy_PyUnicode_AsString(pytypestr);
+   const auto length = typestr.length();
+   if(length != 3) {
+      PyErr_SetString(PyExc_RuntimeError,
+              ("Object not convertible: __array_interface__['typestr'] returned '" + typestr + "' with invalid length unequal 3.").c_str());
+      return NULL;
+   }
+
+   // Verify correct endianess
+   const auto endianess = typestr.substr(1, 2);
+#ifdef R__BYTESWAP
+   const auto byteswap = "<";
+#else
+   const auto byteswap = ">";
+#endif
+   if (!endianess.compare(byteswap)) {
+      PyErr_SetString(PyExc_RuntimeError, "Object not convertible: Endianess of __array_interface__['typestr'] does not match endianess of ROOT.");
+      return NULL;
+   }
+
+   const auto dtype = typestr.substr(1, length);
+   std::string cppdtype;
+   if (dtype == "i4") {
+      cppdtype = "int";
+   } else if (dtype == "u4") {
+      cppdtype = "unsigned int";
+   } else if (dtype == "i8") {
+      cppdtype = "long";
+   } else if (dtype == "u8") {
+      cppdtype = "unsigned long";
+   } else if (dtype == "f4") {
+      cppdtype = "float";
+   } else if (dtype == "f8") {
+      cppdtype = "double";
+   } else {
+      PyErr_SetString(PyExc_RuntimeError, ("Object not convertible: Python object has unknown data-type '" + dtype + "'.").c_str());
+      return NULL;
+   }
+
+   // Construct an RVec of the correct data-type
+   const std::string klassname = "ROOT::VecOps::RVec<" + cppdtype + ">";
+   auto address = (void*) gInterpreter->Calc("new " + klassname + "(reinterpret_cast<" + cppdtype + "*>(" + data + ")," + size + ")");
+
+   // Bind the object to a Python-side proxy
+   auto klass = (Cppyy::TCppType_t)Cppyy::GetScope(klassname);
+   auto pyobj = CPyCppyy::BindCppObject(address, klass);
+
+   // Give Python the ownership of the underlying C++ object
+   ((CPyCppyy::CPPInstance*)pyobj)->PythonOwns();
+
+   // Bind pyobject holding adopted memory to the RVec
+   if (PyObject_SetAttrString(pyobj, "__adopted__", obj)) {
+      PyErr_SetString(PyExc_RuntimeError, "Object not convertible: Failed to set Python object as attribute __adopted__.");
+      return NULL;
+   }
+
+   // Clean-up and return
+   Py_DECREF(pyinterface);
+   return pyobj;
+}

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -23,6 +23,9 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_tcollection_len tcollection_len.py)
 # TArray and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tarray_len tarray_len.py)
 
+# RVec and subclasses pythonizations
+ROOT_ADD_PYUNITTEST(pyroot_pyz_rvec_asrvec rvec_asrvec.py)
+
 # RooAbsCollection and subclasses pythonizations
 if(ROOT_roofit_FOUND)
   ROOT_ADD_PYUNITTEST(pyroot_pyz_rooabscollection_len rooabscollection_len.py)

--- a/bindings/pyroot_experimental/PyROOT/test/rvec_asrvec.py
+++ b/bindings/pyroot_experimental/PyROOT/test/rvec_asrvec.py
@@ -1,0 +1,115 @@
+import unittest
+import ROOT
+import numpy as np
+import sys
+
+
+def get_maximum_for_dtype(dtype):
+    if np.issubdtype(dtype, np.integer):
+        return np.iinfo(dtype).max
+    if np.issubdtype(dtype, np.floating):
+        return np.finfo(dtype).max
+
+def get_minimum_for_dtype(dtype):
+    if np.issubdtype(dtype, np.integer):
+        return np.iinfo(dtype).min
+    if np.issubdtype(dtype, np.floating):
+        return np.finfo(dtype).min
+
+
+class AsRVec(unittest.TestCase):
+    """
+    Tests for the AsRVec feature enabling to adopt memory of Python objects
+    with an array interface member using RVec as C++ container.
+    """
+
+    # Helpers
+    dtypes = [
+        "int32", "int64", "uint32", "uint64", "float32", "float64"
+    ]
+
+    def check_memory_adoption(self, root_obj, np_obj):
+        np_obj[0] = get_maximum_for_dtype(np_obj.dtype)
+        np_obj[1] = get_minimum_for_dtype(np_obj.dtype)
+        self.assertEqual(root_obj[0], np_obj[0])
+        self.assertEqual(root_obj[1], np_obj[1])
+
+    def check_size(self, expected_size, obj):
+        self.assertEqual(expected_size, obj.size())
+
+    # Tests
+    def test_dtypes(self):
+        """
+        Test adoption of numpy arrays with different data types
+        """
+        for dtype in self.dtypes:
+            np_obj = np.empty(2, dtype=dtype)
+            root_obj = ROOT.ROOT.VecOps.AsRVec(np_obj)
+            self.check_memory_adoption(root_obj, np_obj)
+            self.check_size(2, root_obj)
+
+    def test_multidim(self):
+        """
+        Test adoption of multi-dimensional numpy arrays
+        """
+        np_obj = np.array([[1, 2], [3, 4]], dtype="float32")
+        rvec = ROOT.ROOT.VecOps.AsRVec(np_obj)
+        self.assertEqual(rvec.size(), 4)
+
+    def test_size_zero(self):
+        """
+        Test adoption of numpy array with size 0
+        """
+        np_obj = np.array([], dtype="float32")
+        rvec = ROOT.ROOT.VecOps.AsRVec(np_obj)
+        self.assertEqual(rvec.size(), 0)
+
+    def test_adopt_rvec(self):
+        """
+        Test adoption of RVecs
+        """
+        rvec = ROOT.ROOT.VecOps.RVec("float")(1)
+        rvec[0] = 42
+        rvec2 = ROOT.ROOT.VecOps.AsRVec(rvec)
+        self.assertEqual(rvec.size(), rvec2.size())
+        self.assertEqual(rvec[0], rvec2[0])
+        rvec2[0] = 43
+        self.assertEqual(rvec[0], rvec2[0])
+
+    def test_ownership(self):
+        """
+        Test ownership of returned RVec (to be owned by Python)
+        """
+        np_obj = np.array([1, 2])
+        rvec = ROOT.ROOT.VecOps.AsRVec(np_obj)
+        self.assertEqual(rvec.__python_owns__, True)
+
+    def test_attribute_adopted(self):
+        """
+        Test __adopted__ attribute of returned RVecs
+        """
+        np_obj = np.array([1, 2])
+        rvec = ROOT.ROOT.VecOps.AsRVec(np_obj)
+        self.assertTrue(hasattr(rvec, "__adopted__"))
+        self.assertEqual(id(rvec.__adopted__), id(np_obj))
+
+    def test_refcount(self):
+        """
+        Test reference count of returned RVec
+
+        We expect a refcount of 2 for the RVec because the call to sys.getrefcount
+        creates a second reference by itself.
+        We attach the adopted pyobject to the RVec and increase the refcount of the
+        numpy array. After deletion of the rvec, the refcount of the numpy array
+        is decreased.
+        """
+        np_obj = np.array([1, 2])
+        rvec = ROOT.ROOT.VecOps.AsRVec(np_obj)
+        self.assertEqual(sys.getrefcount(rvec), 2)
+        self.assertEqual(sys.getrefcount(np_obj), 3)
+        del rvec
+        self.assertEqual(sys.getrefcount(np_obj), 2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This feature is able to adopt memory from PyObjects defining an
`__array_interface__` as RVecs.

The workflow is as follows:

```python
import ROOT
import numpy

np = numpy.array([1, 2, 3])
rvec = ROOT.AsRVec(np)

print(np) # [1 2 3]
print(rvec) # { 1, 2, 3 }

rvec[0] = 42
print(np) # [42 2 3]
```