### PR TITLE
[Exp PyROOT] Expose cppyy functionality in ROOT module

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/_facade.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/_facade.py
@@ -1,5 +1,6 @@
 import types
 
+import libcppyy as cppyy_backend
 from cppyy import gbl as gbl_namespace
 from libROOTPython import gROOT
 
@@ -17,6 +18,11 @@ class ROOTFacade(types.ModuleType):
 
         # Inject gROOT global
         self.gROOT = gROOT
+
+        # Expose some functionality from CPyCppyy extension module
+        cppyy_exports = [ 'Double', 'Long', 'nullptr' ]
+        for name in cppyy_exports:
+            setattr(self, name, getattr(cppyy_backend, name))
 
         # Redirect lookups to cppyy's global namespace
         self.__class__.__getattr__ = lambda self, name: getattr(gbl_namespace, name)

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
@@ -110,12 +110,6 @@ extern "C" void initlibROOTPython()
    // keep gRootModule, but do not increase its reference count even as it is borrowed,
    // or a self-referencing cycle would be created
 
-   // policy labels
-   PyModule_AddObject(gRootModule, (char *)"kMemoryHeuristics", PyInt_FromLong((int)CallContext::kUseHeuristics));
-   PyModule_AddObject(gRootModule, (char *)"kMemoryStrict", PyInt_FromLong((int)CallContext::kUseStrict));
-   PyModule_AddObject(gRootModule, (char *)"kSignalFast", PyInt_FromLong((int)CallContext::kFast));
-   PyModule_AddObject(gRootModule, (char *)"kSignalSafe", PyInt_FromLong((int)CallContext::kSafe));
-
    // setup PyROOT
    PyROOT::Init();
 


### PR DESCRIPTION
With the objective of fixing tests, this PR exposes in the ROOT module some functionality of the CPyCppyy extension module. Such functionality is available in the current PyROOT and some tests rely on it.

A more exhaustive investigation on which functionality of cppyy we want to expose via the ROOT module is required.