### PR TITLE
Importing 'Imt.ROOT/TTaskGroup.hxx' modules  required by TThreadExecutor

### DIFF
--- a/core/imt/src/TThreadExecutor.cxx
+++ b/core/imt/src/TThreadExecutor.cxx
@@ -1,4 +1,5 @@
 #include "ROOT/TThreadExecutor.hxx"
+#include "ROOT/TTaskGroup.hxx"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"


### PR DESCRIPTION
It is fixing explicit C++ modules failing with:

`In file included from /data/sftnight/workspace/root-benchmark-compile-cxxmodule/BUILDTYPE/Release/COMPILER/clang_gcc62/LABEL/performance-cc7/root/core/imt/src/TThreadExecutor.cxx:8:
In file included from /data/sftnight/workspace/root-benchmark-compile-cxxmodule/BUILDTYPE/Release/COMPILER/clang_gcc62/LABEL/performance-cc7/build/include/tbb/tbb.h:76:
/data/sftnight/workspace/root-benchmark-compile-cxxmodule/BUILDTYPE/Release/COMPILER/clang_gcc62/LABEL/performance-cc7/build/include/tbb/recursive_mutex.h:54:47: error: declaration of 'PTHREAD_MUTEX_RECURSIVE' must be imported from module 'Imt.ROOT/TTaskGroup.hxx' before it is required
        pthread_mutexattr_settype( &mtx_attr, PTHREAD_MUTEX_RECURSIVE );
                                              ^
In module 'Imt' imported from /data/sftnight/workspace/root-benchmark-compile-cxxmodule/BUILDTYPE/Release/COMPILER/clang_gcc62/LABEL/performance-cc7/root/core/imt/src/TThreadExecutor.cxx:1:
/usr/include/pthread.h:51:3: note: previous declaration is here
  PTHREAD_MUTEX_RECURSIVE = PTHREAD_MUTEX_RECURSIVE_NP,
  ^
1 error generated.`
