### PR TITLE
[Core] Extend usage of TClass::GetClass<T> 

### DIFF
--- a/core/base/inc/TDirectory.h
+++ b/core/base/inc/TDirectory.h
@@ -138,7 +138,7 @@ public:
    virtual TDirectory *GetDirectory(const char *namecycle, Bool_t printError = false, const char *funcname = "GetDirectory");
    template <class T> inline void GetObject(const char* namecycle, T*& ptr) // See TDirectory::Get for information
       {
-         ptr = (T*)GetObjectChecked(namecycle,TBuffer::GetClass(typeid(T)));
+         ptr = (T *)GetObjectChecked(namecycle, TClass::GetClass<T>());
       }
    virtual void       *GetObjectChecked(const char *namecycle, const char* classname);
    virtual void       *GetObjectChecked(const char *namecycle, const TClass* cl);
@@ -195,7 +195,7 @@ private:
 public:
    template <class T> inline Int_t WriteObject(const T* obj, const char* name, Option_t *option="", Int_t bufsize=0) // see TDirectory::WriteTObject or TDirectoryWriteObjectAny for explanation
       {
-         return WriteObjectAny(obj,TBuffer::GetClass(typeid(T)),name,option,bufsize);
+         return WriteObjectAny(obj, TClass::GetClass<T>(), name, option, bufsize);
       }
    virtual Int_t       WriteObjectAny(const void *, const char * /*classname*/, const char * /*name*/, Option_t * /*option*/="", Int_t /*bufsize*/ =0) {return 0;}
    virtual Int_t       WriteObjectAny(const void *, const TClass * /*cl*/, const char * /*name*/, Option_t * /*option*/="", Int_t /*bufsize*/ =0) {return 0;}

--- a/core/base/v7/inc/ROOT/TDirectoryEntry.hxx
+++ b/core/base/v7/inc/ROOT/TDirectoryEntry.hxx
@@ -20,7 +20,6 @@
 
 #include <chrono>
 #include <memory>
-#include <typeinfo>
 
 namespace ROOT {
 namespace Experimental {
@@ -47,7 +46,7 @@ public:
    {}
 
    template <class T>
-   explicit TDirectoryEntry(const std::shared_ptr<T> &ptr): fType(TClass::GetClass(typeid(T))), fObj(ptr)
+   explicit TDirectoryEntry(const std::shared_ptr<T> &ptr): fType(TClass::GetClass<T>()), fObj(ptr)
    {}
 
    /// Get the last change date of the entry.
@@ -78,7 +77,7 @@ public:
 template <class U>
 std::shared_ptr<U> TDirectoryEntry::CastPointer() const
 {
-   if (auto ptr = fType->DynamicCast(TClass::GetClass(typeid(U)), fObj.get()))
+   if (auto ptr = fType->DynamicCast(TClass::GetClass<U>(), fObj.get()))
       return std::shared_ptr<U>(fObj, static_cast<U *>(ptr));
    return std::shared_ptr<U>();
 }

--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -600,15 +600,15 @@ TClass *TClass::GetClass(Bool_t load, Bool_t silent)
 
 namespace ROOT {
 
-template <typename T> TClass *GetClass(T * /* dummy */)       { return TClass::GetClass(typeid(T)); }
-template <typename T> TClass *GetClass(const T * /* dummy */) { return TClass::GetClass(typeid(T)); }
+template <typename T> TClass *GetClass(T * /* dummy */)       { return TClass::GetClass<T>(); }
+template <typename T> TClass *GetClass(const T * /* dummy */) { return TClass::GetClass<T>(); }
 
 #ifndef R__NO_CLASS_TEMPLATE_SPECIALIZATION
    // This can only be used when the template overload resolution can distinguish between T* and T**
-   template <typename T> TClass* GetClass(      T**       /* dummy */) { return GetClass((T*)0); }
-   template <typename T> TClass* GetClass(const T**       /* dummy */) { return GetClass((T*)0); }
-   template <typename T> TClass* GetClass(      T* const* /* dummy */) { return GetClass((T*)0); }
-   template <typename T> TClass* GetClass(const T* const* /* dummy */) { return GetClass((T*)0); }
+   template <typename T> TClass* GetClass(      T**       /* dummy */) { return TClass::GetClass<T>(); }
+   template <typename T> TClass* GetClass(const T**       /* dummy */) { return TClass::GetClass<T>(); }
+   template <typename T> TClass* GetClass(      T* const* /* dummy */) { return TClass::GetClass<T>(); }
+   template <typename T> TClass* GetClass(const T* const* /* dummy */) { return TClass::GetClass<T>(); }
 #endif
 
    extern TClass *CreateClass(const char *cname, Version_t id,

--- a/core/multiproc/inc/MPSendRecv.h
+++ b/core/multiproc/inc/MPSendRecv.h
@@ -90,7 +90,7 @@ T ReadBuffer(TBufferFile *buf);
 template<class T, typename std::enable_if<std::is_class<T>::value>::type *>
 int MPSend(TSocket *s, unsigned code, T obj)
 {
-   TClass *c = TClass::GetClass(typeid(T));
+   TClass *c = TClass::GetClass<T>();
    if (!c) {
       Error("MPSend", "[E] Could not find cling definition for class %s\n", typeid(T).name());
       return -1;

--- a/graf2d/primitives/v7/src/RDrawingOptsBase.cxx
+++ b/graf2d/primitives/v7/src/RDrawingOptsBase.cxx
@@ -80,7 +80,7 @@ public:
 /// Invoke func with each attribute as argument.
 void ROOT::Experimental::RDrawingOptsBase::VisitAttributes(const RDrawingOptsBase::VisitFunc_t &func)
 {
-   TClass* clThis = TClass::GetClass(typeid(*this));
+   TClass* clThis = ROOT::GetClass(this);
    if (!clThis) {
       R__ERROR_HERE("Graf2d") << "Cannot find dictionary for the derived class with typeid " << typeid(*this).name();
       return;

--- a/io/io/inc/TBufferJSON.h
+++ b/io/io/inc/TBufferJSON.h
@@ -50,7 +50,7 @@ public:
    template <class T>
    static TString ToJSON(const T *obj, Int_t compact = 0, const char *member_name = nullptr)
    {
-      return ConvertToJSON(obj, TBuffer::GetClass(typeid(T)), compact, member_name);
+      return ConvertToJSON(obj, TClass::GetClass<T>(), compact, member_name);
    }
 
    template <class T>
@@ -58,7 +58,7 @@ public:
    {
       if (obj)
          return kFALSE;
-      obj = (T *)ConvertFromJSONChecked(json, TBuffer::GetClass(typeid(T)));
+      obj = (T *)ConvertFromJSONChecked(json, TClass::GetClass<T>());
       return obj != nullptr;
    }
 

--- a/io/io/inc/TKey.h
+++ b/io/io/inc/TKey.h
@@ -96,7 +96,7 @@ protected:
    /// This is more user friendly version of TKey::ReadObjectAny.
    /// See TKey::ReadObjectAny for more details.
    template <typename T> T *ReadObject() {
-      return reinterpret_cast<T*>(ReadObjectAny(TClass::GetClass(typeid(T))));
+      return reinterpret_cast<T*>(ReadObjectAny(TClass::GetClass<T>()));
    }
    virtual void       *ReadObjectAny(const TClass *expectedClass);
    virtual void        ReadBuffer(char *&buffer);

--- a/io/io/v7/inc/ROOT/TFile.hxx
+++ b/io/io/v7/inc/ROOT/TFile.hxx
@@ -22,7 +22,6 @@
 
 #include "ROOT/RStringView.hxx"
 #include <memory>
-#include <typeinfo>
 
 namespace ROOT {
 namespace Experimental {
@@ -145,14 +144,14 @@ public:
    template <class T>
    void Write(std::string_view name, const T &obj)
    {
-      WriteMemoryWithType(name, &obj, TClass::GetClass(typeid(T)));
+      WriteMemoryWithType(name, &obj, TClass::GetClass<T>());
    }
 
    /// Write an object that is not lifetime managed by this TFileImplBase.
    template <class T>
    void Write(std::string_view name, const T *obj)
    {
-      WriteMemoryWithType(name, obj, TClass::GetClass(typeid(T)));
+      WriteMemoryWithType(name, obj, TClass::GetClass<T>());
    }
 
    /// Write an object that is already lifetime managed by this TFileImplBase.

--- a/io/xml/inc/TBufferXML.h
+++ b/io/xml/inc/TBufferXML.h
@@ -49,7 +49,7 @@ public:
    template <class T>
    static TString ToXML(const T *obj, Bool_t GenericLayout = kFALSE, Bool_t UseNamespaces = kFALSE)
    {
-      return ConvertToXML(obj, TBuffer::GetClass(typeid(T)), GenericLayout, UseNamespaces);
+      return ConvertToXML(obj, TClass::GetClass<T>(), GenericLayout, UseNamespaces);
    }
 
    static TObject *ConvertFromXML(const char *str, Bool_t GenericLayout = kFALSE, Bool_t UseNamespaces = kFALSE);
@@ -61,7 +61,7 @@ public:
    {
       if (obj)
          return kFALSE;
-      obj = (T *)ConvertFromXMLChecked(xml, TBuffer::GetClass(typeid(T)), GenericLayout, UseNamespaces);
+      obj = (T *)ConvertFromXMLChecked(xml, TClass::GetClass<T>(), GenericLayout, UseNamespaces);
       return obj != nullptr;
    }
 

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -336,22 +336,22 @@ public:
    template <class T> TBranch *Branch(const char* name, const char* classname, T* obj, Int_t bufsize = 32000, Int_t splitlevel = 99)
    {
       // See BranchImpRed for details. Here we __ignore
-      return BranchImpRef(name, classname, TBuffer::GetClass(typeid(T)), obj, bufsize, splitlevel);
+      return BranchImpRef(name, classname, TClass::GetClass<T>(), obj, bufsize, splitlevel);
    }
    template <class T> TBranch *Branch(const char* name, const char* classname, T** addobj, Int_t bufsize = 32000, Int_t splitlevel = 99)
    {
       // See BranchImp for details
-      return BranchImp(name, classname, TBuffer::GetClass(typeid(T)), addobj, bufsize, splitlevel);
+      return BranchImp(name, classname, TClass::GetClass<T>(), addobj, bufsize, splitlevel);
    }
    template <class T> TBranch *Branch(const char* name, T** addobj, Int_t bufsize = 32000, Int_t splitlevel = 99)
    {
       // See BranchImp for details
-      return BranchImp(name, TBuffer::GetClass(typeid(T)), addobj, bufsize, splitlevel);
+      return BranchImp(name, TClass::GetClass<T>(), addobj, bufsize, splitlevel);
    }
    template <class T> TBranch *Branch(const char* name, T* obj, Int_t bufsize = 32000, Int_t splitlevel = 99)
    {
       // See BranchImp for details
-      return BranchImpRef(name, TBuffer::GetClass(typeid(T)), TDataType::GetType(typeid(T)), obj, bufsize, splitlevel);
+      return BranchImpRef(name, TClass::GetClass<T>(), TDataType::GetType(typeid(T)), obj, bufsize, splitlevel);
    }
    virtual TBranch        *Bronch(const char* name, const char* classname, void* addobj, Int_t bufsize = 32000, Int_t splitlevel = 99);
    virtual TBranch        *BranchOld(const char* name, const char* classname, void* addobj, Int_t bufsize = 32000, Int_t splitlevel = 1);
@@ -522,7 +522,7 @@ public:
    virtual Int_t           SetBranchAddress(const char *bname,void *add, TClass *realClass, EDataType datatype, Bool_t isptr);
    virtual Int_t           SetBranchAddress(const char *bname,void *add, TBranch **ptr, TClass *realClass, EDataType datatype, Bool_t isptr);
    template <class T> Int_t SetBranchAddress(const char *bname, T **add, TBranch **ptr = 0) {
-      TClass *cl = TClass::GetClass(typeid(T));
+      TClass *cl = TClass::GetClass<T>();
       EDataType type = kOther_t;
       if (cl==0) type = TDataType::GetType(typeid(T));
       return SetBranchAddress(bname,add,ptr,cl,type,true);
@@ -531,7 +531,7 @@ public:
    // This can only be used when the template overload resolution can distinguish between
    // T* and T**
    template <class T> Int_t SetBranchAddress(const char *bname, T *add, TBranch **ptr = 0) {
-      TClass *cl = TClass::GetClass(typeid(T));
+      TClass *cl = TClass::GetClass<T>();
       EDataType type = kOther_t;
       if (cl==0) type = TDataType::GetType(typeid(T));
       return SetBranchAddress(bname,add,ptr,cl,type,false);

--- a/tree/treeplayer/inc/TBranchProxyTemplate.h
+++ b/tree/treeplayer/inc/TBranchProxyTemplate.h
@@ -178,7 +178,7 @@ namespace Internal {
 
       TVirtualCollectionProxy* GetCollection() {
          if (fCollection==0) {
-            TClass *cl = TClass::GetClass(typeid(T));
+            TClass *cl = TClass::GetClass<T>();
             if (cl && cl->GetCollectionProxy()) {
                fCollection =  cl->GetCollectionProxy()->Generate();
             }

--- a/tutorials/dataframe/df001_introduction.C
+++ b/tutorials/dataframe/df001_introduction.C
@@ -93,7 +93,7 @@ int df001_introduction()
    for (auto b1_entry : *b1List)
       std::cout << b1_entry << " ";
    std::cout << std::endl;
-   auto b1VecCl = TClass::GetClass(typeid(*b1Vec));
+   auto b1VecCl = ROOT::GetClass(b1Vec.GetPtr());
    std::cout << "The type of b1Vec is " << b1VecCl->GetName() << std::endl;
 
    // ### `Histo1D` action


### PR DESCRIPTION
- Re-implement {ROOT,TClass}::GetClass methods in terms of TClass::GetClass<T>  where possible.
- Use TClass::GetClass<T> where possible and in tutorials.

Proof is left intentionally aside because not further developed. Rootcling is left aside since it runs exclusively in sequential mode.