### PR TITLE
[TMVA ANN codegen] adding linebreak in codegen

### DIFF
--- a/tmva/tmva/src/MethodANNBase.cxx
+++ b/tmva/tmva/src/MethodANNBase.cxx
@@ -1117,7 +1117,7 @@ void TMVA::MethodANNBase::MakeClassSpecific( std::ostream& fout, const TString& 
          fout << "         buffer[i] = fWeightMatrix" << i << "to" << i + 1 << "[o][i] * inputValues[i];" << std::endl;
          fout << "      } // loop over i" << std::endl;
          fout << "      buffer.back() = fWeightMatrix" << i << "to" << i + 1 << "[o]["
-              << ((TObjArray *)fNetwork->At(i))->GetEntries() - 1 << "];";
+              << ((TObjArray *)fNetwork->At(i))->GetEntries() - 1 << "];" << std::endl;
       } else {
          fout << "      std::array<double, " << ((TObjArray *)fNetwork->At(i))->GetEntries()
               << "> buffer; // no need to initialise" << std::endl;


### PR DESCRIPTION
otherwise the next for loop trails in this line like that:
```
   // layer 0 to 1
   for (int o=0; o<9; o++) {
      std::array<double, 5> buffer; // no need to initialise
      for (int i = 0; i<5 - 1; i++) {
         buffer[i] = fWeightMatrix0to1[o][i] * inputValues[i];
      } // loop over i
      buffer.back() = fWeightMatrix0to1[o][4];      for (int i=0; i<5; i++) {
         fWeights1[o] += buffer[i];
      } // loop over i
    } // loop over o
```
(from running TMVAClassification.C in the tutorials dir.)