### PR TITLE
[RF] Silence RooWorkspace unit test

### DIFF
--- a/roofit/roofitcore/test/testWorkspace.cxx
+++ b/roofit/roofitcore/test/testWorkspace.cxx
@@ -144,9 +144,17 @@ TEST_F(TestRooWorkspaceWithGaussian, ImportFromFile)
 
   //Expect successful import:
   EXPECT_FALSE(w.import(spec.str().c_str()));
+
+
   //Expect import failures:
+  RooHelpers::HijackMessageStream hijack(RooFit::ERROR, RooFit::InputArguments, "ws");
   EXPECT_TRUE(w.import("bogus:abc"));
+  EXPECT_FALSE(hijack.str().empty());
+
+  hijack.str("");
+  ASSERT_TRUE(hijack.str().empty());
   EXPECT_TRUE(w.import( (spec.str()+"bogus").c_str()));
+  EXPECT_FALSE(hijack.str().empty());
 }
 
 


### PR DESCRIPTION
The unit test for RooWorkspace tests failures when importing models into the workspace.
Since RooFit will print `ERROR` messages, it looks like there is a problem in the test.
The error messages are now silenced.