### PR TITLE
Adding directories needed to use LibXML

### DIFF
--- a/io/xmlparser/CMakeLists.txt
+++ b/io/xmlparser/CMakeLists.txt
@@ -3,7 +3,7 @@
 # @author Pere Mato, CERN
 ############################################################################
 
-include_directories(${LIBXML2_INCLUDE_DIR})
+include_directories(${LIBXML2_INCLUDE_DIR} ${LIBXML2_INCLUDE_DIRS})
 add_definitions(${LIBXML2_DEFINITIONS})
 
 if(WIN32)


### PR DESCRIPTION
Both of these directories are needed if you have a non-standard location for LibXML2's needs. This is currently a manual patch in the root-feedstock for conda-forge.

See <https://github.com/Kitware/CMake/blob/master/Modules/FindLibXml2.cmake>.