### PR TITLE
[Core] 1MB less RSS at root startup with simple optimisations

### DIFF
--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -254,6 +254,7 @@ ROOT_GENERATE_DICTIONARY(G__Core
   MODULE
     Core
   OPTIONS
+    -writeEmptyRootPCM 
     ${dict_opts}
   LINKDEF
     LinkDef.h

--- a/core/thread/CMakeLists.txt
+++ b/core/thread/CMakeLists.txt
@@ -57,6 +57,8 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Thread
     src/TThreadImp.cxx
   OBJECT_LIBRARY
   STAGE1
+  DICTIONARY_OPTIONS
+    -writeEmptyRootPCM 
   DEPENDENCIES
     Core
   INSTALL_OPTIONS ${installoptions}

--- a/io/io/CMakeLists.txt
+++ b/io/io/CMakeLists.txt
@@ -86,7 +86,7 @@ else()
   set_source_files_properties(src/TStreamerInfoReadBuffer.cxx COMPILE_FLAGS "-O3")
 endif()
 
-ROOT_GENERATE_DICTIONARY(G__RIO ${headers} STAGE1 MODULE RIO LINKDEF LinkDef.h DEPENDENCIES Core Thread)
+ROOT_GENERATE_DICTIONARY(G__RIO ${headers} STAGE1 MODULE RIO LINKDEF LinkDef.h OPTIONS -writeEmptyRootPCM DEPENDENCIES Core Thread)
 
 if(root7)
    ROOT_OBJECT_LIBRARY(RIOObjs G__RIO.cxx ${sources} ${sourcesv7})


### PR DESCRIPTION
Do not add information for autoparsing. The interpreter can just draw the info it needs from the PCH without parsing the full payload (which happens still trhough the PCH, but it's more)