### PR TITLE
Fix ROOT-9779 and improve performance for ROOT-9133

### DIFF
--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -73,6 +73,9 @@ public:
    /** Returns the current value of the auto save setting in bytes (default = 0). */
    size_t GetAutoSave() const;
 
+   /** Returns the current merge options. */
+   const char* GetMergeOptions();
+
    /** By default, TBufferMerger will call TFileMerger::PartialMerge() for each
     *  buffer pushed onto its merge queue. This function lets the user change
     *  this behaviour by telling TBufferMerger to accumulate at least size
@@ -82,6 +85,13 @@ public:
     *  written to disk can be reduced.
     */
    void SetAutoSave(size_t size);
+
+   /** Sets the merge options. SetMergeOptions("fast") will disable
+    * recompression of input data into the output if they have different
+    * compression settings.
+    * @param options TFileMerger/TFileMergeInfo merge options
+    */
+   void SetMergeOptions(const TString& options);
 
    friend class TBufferMergerFile;
 

--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -75,7 +75,7 @@ public:
 
    /** By default, TBufferMerger will call TFileMerger::PartialMerge() for each
     *  buffer pushed onto its merge queue. This function lets the user change
-    *  this behaviour by telling TBufferMerger to accumulate at least @param size
+    *  this behaviour by telling TBufferMerger to accumulate at least size
     *  bytes in memory before performing a partial merge and flushing to disk.
     *  This can be useful to avoid an excessive amount of work to happen in the
     *  output thread, as the number of TTree headers (which require compression)

--- a/io/io/inc/TMemFile.h
+++ b/io/io/inc/TMemFile.h
@@ -82,6 +82,7 @@ public:
             Int_t compress = ROOT::RCompressionSetting::EDefaults::kUseGeneralPurpose, Long64_t defBlockSize = 0LL);
    TMemFile(const char *name, char *buffer, Long64_t size, Option_t *option="", const char *ftitle="", Int_t compress = ROOT::RCompressionSetting::EDefaults::kUseGeneralPurpose);
    TMemFile(const char *name, ExternalDataPtr_t data);
+   TMemFile(const char *name, std::unique_ptr<TBufferFile> buffer);
    TMemFile(const TMemFile &orig);
    virtual ~TMemFile();
 

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -110,8 +110,7 @@ void TBufferMerger::Merge()
 
       while (!queue.empty()) {
          std::unique_ptr<TBufferFile> buffer{queue.front()};
-         fMerger.AddAdoptFile(
-            new TMemFile(fMerger.GetOutputFileName(), buffer->Buffer(), buffer->BufferSize(), "READ"));
+         fMerger.AddAdoptFile(new TMemFile(fMerger.GetOutputFileName(), std::move(buffer)));
          queue.pop();
       }
 

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -82,9 +82,20 @@ size_t TBufferMerger::GetAutoSave() const
    return fAutoSave;
 }
 
+const char *TBufferMerger::GetMergeOptions()
+{
+   return fMerger.GetMergeOptions();
+}
+
+
 void TBufferMerger::SetAutoSave(size_t size)
 {
    fAutoSave = size;
+}
+
+void TBufferMerger::SetMergeOptions(const TString& options)
+{
+   fMerger.SetMergeOptions(options);
 }
 
 void TBufferMerger::Merge()

--- a/io/io/src/TBufferMergerFile.cxx
+++ b/io/io/src/TBufferMergerFile.cxx
@@ -32,7 +32,7 @@ Int_t TBufferMergerFile::Write(const char *name, Int_t opt, Int_t bufsize)
    Int_t nbytes = TMemFile::Write(name, opt, bufsize);
 
    if (nbytes) {
-      TBufferFile *buffer = new TBufferFile(TBuffer::kWrite, nbytes);
+      TBufferFile *buffer = new TBufferFile(TBuffer::kWrite, GetSize());
       CopyTo(*buffer);
       buffer->SetReadMode();
       fMerger.Push(buffer);

--- a/io/io/src/TMemFile.cxx
+++ b/io/io/src/TMemFile.cxx
@@ -116,23 +116,22 @@ TMemFile::EMode TMemFile::ParseOption(Option_t *option)
 /// Constructor to create a TMemFile re-using external storage.
 
 TMemFile::TMemFile(const char *path, ExternalDataPtr_t data) :
-   TFile(path, "WEB", "read-only memfile", 0 /*compress*/),
+   TFile(path, "WEB", "read-only TMemFile", 0 /*compress*/),
    fBlockList(reinterpret_cast<UChar_t*>(const_cast<char*>(data->data())), data->size()),
    fExternalData(std::move(data)), fSize(fExternalData->size()), fSysOffset(0), fBlockSeek(nullptr), fBlockOffset(0)
 {
-   EMode optmode = ParseOption("READ");
-   if (NeedsToWrite(optmode)) {
-      SysError("TMemFile", "file %s can not be opened", path);
-      // Error in opening file; make this a zombie
+   fD = 0;
+   fOption = "READ";
+   fWritable = kFALSE;
+
+   // This is read-only, so become a zombie if created with an empty buffer
+   if (!fBlockList.fBuffer) {
       MakeZombie();
       gDirectory = gROOT;
       return;
    }
 
-   fD = 0;
-   fWritable = kFALSE;
-
-   Init(!NeedsExistingFile(optmode));
+   Init(/* create */ false);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////

--- a/io/io/src/TMemFile.cxx
+++ b/io/io/src/TMemFile.cxx
@@ -17,6 +17,7 @@ A TMemFile is like a normal TFile except that it reads and writes
 only from memory.
 */
 
+#include "TBufferFile.h"
 #include "TMemFile.h"
 #include "TError.h"
 #include "TSystem.h"
@@ -132,6 +133,33 @@ TMemFile::TMemFile(const char *path, ExternalDataPtr_t data) :
    fWritable = kFALSE;
 
    Init(!NeedsExistingFile(optmode));
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+/// Constructor to create a read-only TMemFile using an std::unique_ptr<TBufferFile>
+
+TMemFile::TMemFile(const char *name, std::unique_ptr<TBufferFile> buffer) :
+   TFile(name, "WEB", "read-only TMemFile", 0 /* compress */),
+   fBlockList(reinterpret_cast<UChar_t*>(buffer->Buffer()), buffer->BufferSize()),
+   fSize(buffer->BufferSize()), fSysOffset(0), fBlockSeek(&(fBlockList)), fBlockOffset(0)
+{
+   fD = 0;
+   fOption = "READ";
+   fWritable = false;
+
+   // Note: We need to release the buffer here to avoid double delete.
+   // The memory of a TBufferFile is allocated with new[], so we can let
+   // TMemBlock delete it, as its destructor calls "delete [] fBuffer;"
+   buffer.release();
+
+   // This is read-only, so become a zombie if created with an empty buffer
+   if (!fBlockList.fBuffer) {
+      MakeZombie();
+      gDirectory = gROOT;
+      return;
+   }
+
+   Init(/* create */ false);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Here is some performance information for the reproducer code attached to [ROOT-9133](https://sft.its.cern.ch/jira/browse/ROOT-9133):

**perf stat (before)**
```
 Performance counter stats for 'root-9133':

     135566.779101      task-clock (msec)         #    4.167 CPUs utilized          
           481,078      context-switches          #    0.004 M/sec                  
               710      cpu-migrations            #    0.005 K/sec                  
         3,512,992      page-faults               #    0.026 M/sec                  
   456,851,617,713      cycles                    #    3.370 GHz                    
   310,271,051,553      instructions              #    0.68  insn per cycle         
    65,664,345,345      branches                  #  484.369 M/sec                  
       723,033,852      branch-misses             #    1.10% of all branches        

      32.535328793 seconds time elapsed
```
**perf stat (after)**
```
 Performance counter stats for 'root-9133':

     115840.232563      task-clock (msec)         #    6.254 CPUs utilized          
           343,733      context-switches          #    0.003 M/sec                  
               327      cpu-migrations            #    0.003 K/sec                  
         1,567,401      page-faults               #    0.014 M/sec                  
   391,763,587,760      cycles                    #    3.382 GHz                    
   273,699,878,762      instructions              #    0.70  insn per cycle         
    57,799,809,349      branches                  #  498.961 M/sec                  
       635,168,730      branch-misses             #    1.10% of all branches        

      18.522277829 seconds time elapsed
```
*Note the reduced number of cpu-migrations, page-faults, and context switches, as well as lower runtime.*

**massif (before)**
![screenshot](https://user-images.githubusercontent.com/249404/52358705-ca2d1c80-2a38-11e9-823e-ea35219fbca1.png)
![screenshot](https://user-images.githubusercontent.com/249404/52359262-d5cd1300-2a39-11e9-8159-73730cbd79e6.png)

**massif (after)**
![screenshot](https://user-images.githubusercontent.com/249404/52358746-db762900-2a38-11e9-9f63-5d2340860f4d.png)
![screenshot](https://user-images.githubusercontent.com/249404/52359437-30666f00-2a3a-11e9-94ed-67dfad3cdbec.png)
*Note how `TBuffer::Expand()` goes from 1.8GB allocated memory down to just ~50MB. Also, total memory used drops from 3.8GB to 3.1GB. The size of the output file is 3.1GB. The total amount of used memory is still high since tasks are accumulating large chunks of data into the `TBufferMergerFile`s before calling `Write()` to get it flushed out. We need to break the total run into more tasks or call `Write()` more often to further reduce memory usage.*