### PR TITLE
[Exp PyROOT] Add TSeqCollection pythonizations

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
@@ -5,11 +5,17 @@
 set(py_sources
   ROOT/__init__.py
   ROOT/pythonization/__init__.py
+  ROOT/pythonization/_generic.py
+  ROOT/pythonization/_rooabscollection.py
+  ROOT/pythonization/_rvec.py
+  ROOT/pythonization/_stl_vector.py
+  ROOT/pythonization/_tarray.py
+  ROOT/pythonization/_tcollection.py
   ROOT/pythonization/_tdirectory.py
   ROOT/pythonization/_tdirectoryfile.py
   ROOT/pythonization/_tfile.py
+  ROOT/pythonization/_tseqcollection.py
   ROOT/pythonization/_ttree.py
-  ROOT/pythonization/_generic.py
 )
 
 set(sources

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tcollection.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tcollection.py
@@ -29,10 +29,9 @@ def _extend_pyz(self, c):
     # Parameters:
     # - self: collection
     # - c: collection to extend self with
-    lenc = c.GetEntries()
-    it = TIter(c)
-    for _ in range(lenc):
-        self.Add(it.Next())
+    it = iter(c)
+    for _ in range(len(c)):
+        self.Add(next(it))
 
 def _count_pyz(self, o):
     # Parameters:
@@ -42,12 +41,9 @@ def _count_pyz(self, o):
     # - Number of occurrences of the object in the collection
     n = 0
 
-    it = TIter(self)
-    obj = it.Next()
-    while obj:
-        if obj == o:
+    for elem in self:
+        if elem == o:
             n += 1
-        obj = it.Next()
 
     return n
 

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tseqcollection.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tseqcollection.py
@@ -9,7 +9,6 @@
 ################################################################################
 
 from ROOT import pythonization
-from cppyy.gbl import TIter
 from libcppyy import SetOwnership
 
 import sys

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tseqcollection.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tseqcollection.py
@@ -70,10 +70,6 @@ def _setitem_pyz(self, idx, val):
             raise TypeError('can only assign an iterable')
 
         indices = idx.indices(len(self))
-        step = indices[2]
-        if step == 0:
-            raise ValueError('slice step cannot be zero')
-
         rg = range(*indices)
         for elem in val:
             # Prevent this new Python proxy from owning the C++ object
@@ -100,13 +96,9 @@ def _delitem_pyz(self, idx):
     # Slice
     if isinstance(idx, slice):
         indices = idx.indices(len(self))
-
-        step = indices[2]
-        if step == 0:
-            raise ValueError('slice step cannot be zero')
-
         rg = range(*indices)
 
+        step = indices[2]
         if step > 0:
             # Need to remove starting from the end
             rg = reversed(rg)

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tseqcollection.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tseqcollection.py
@@ -1,0 +1,60 @@
+# Author: Enric Tejedor CERN  02/2019
+
+################################################################################
+# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from ROOT import pythonization
+from cppyy.gbl import TIter
+
+
+# Item access
+
+def _getitem_pyz(self, idx):
+    # Parameters:
+    # - self: collection to get item from
+    # - idx: index of the item
+    # Returns:
+    # - self[idx]
+    res = self.At(idx)
+
+    if not res:
+        raise IndexError('list index out of range')
+
+    return res
+
+def _setitem_pyz(self, idx, val):
+    # Parameters:
+    # - self: collection where to set item
+    # - idx: index of the item
+    # - val: value of the item
+    _delitem_pyz(self, idx)
+
+    self.AddAt(val, idx)
+
+def _delitem_pyz(self, idx):
+    # Parameters:
+    # - self: collection to delete item from
+    # - idx: index of the item
+    res = self.RemoveAt(idx)
+
+    if not res:
+        raise IndexError('list assignment index out of range')
+
+
+@pythonization()
+def pythonize_tseqcollection(klass, name):
+    # Parameters:
+    # klass: class to be pythonized
+    # name: string containing the name of the class
+
+    if name == 'TSeqCollection':
+        klass.__getitem__ = _getitem_pyz
+        klass.__setitem__ = _setitem_pyz
+        klass.__delitem__ = _delitem_pyz
+
+    return True

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tseqcollection.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tseqcollection.py
@@ -152,6 +152,10 @@ def _pop_pyz(self, *args):
     # Parameters:
     # - self: collection where to pop an item from
     # - args: either empty or index to pop
+    # Returns:
+    # - If args is empty, it returns the last element of
+    # the collection, else it returns the element for
+    # which the index was specified.
 
     # Check arguments
     nargs = len(args)
@@ -213,6 +217,8 @@ def _index_pyz(self, val):
     # Parameters:
     # - self: collection
     # - val: element to find the index of
+    # Returns:
+    # - Index of the element in the collection
 
     idx = self.IndexOf(val)
 

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tseqcollection.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tseqcollection.py
@@ -86,17 +86,17 @@ def _setitem_pyz(self, idx, val):
             raise TypeError('can only assign an iterable')
 
         indices = idx.indices(len(self))
-        rg = range(*indices)
+        it = iter(range(*indices))
         for elem in val:
             # Prevent this new Python proxy from owning the C++ object
             # Otherwise we get an 'already deleted' error in
             # TList::Clear when the application ends
             SetOwnership(elem, False)
             try:
-                i = rg.pop(0)
+                i = next(it)
                 self[i] = elem
-            except IndexError:
-                # Empty range, just append
+            except StopIteration:
+                # No more indices in range, just append
                 self.append(elem)
     # Number
     else:

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tseqcollection.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tseqcollection.py
@@ -18,6 +18,14 @@ import sys
 # Item access
 
 def _check_index(self, idx):
+    # Parameters:
+    # - self: collection
+    # - idx: index to be checked
+    # Returns:
+    # - An index >= 0, equivalent to the input idx, which is verified
+    # to be an integer and within the boundaries of the collection
+
+    # Python2 also allows long indices
     if sys.version_info >= (3,0):
         allowed_types = (int,)
     else:

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -25,6 +25,7 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_tcollection_iterable tcollection_iterable.py)
 
 # TSeqCollection and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tseqcollection_itemaccess tseqcollection_itemaccess.py)
+ROOT_ADD_PYUNITTEST(pyroot_pyz_tseqcollection_listmethods tseqcollection_listmethods.py)
 
 # TArray and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tarray_len tarray_len.py)

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -23,6 +23,9 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_tcollection_listmethods tcollection_listmethods.p
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tcollection_operators tcollection_operators.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tcollection_iterable tcollection_iterable.py)
 
+# TSeqCollection and subclasses pythonizations
+ROOT_ADD_PYUNITTEST(pyroot_pyz_tseqcollection_itemaccess tseqcollection_itemaccess.py)
+
 # TArray and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tarray_len tarray_len.py)
 

--- a/bindings/pyroot_experimental/PyROOT/test/tseqcollection_itemaccess.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tseqcollection_itemaccess.py
@@ -130,9 +130,9 @@ class TSeqCollectionItemAccess(unittest.TestCase):
 
         # Replace all items
         sc1[:] = sc2
-        self.assertEquals(sc1.GetEntries(), self.num_elems)
+        self.assertEqual(sc1.GetEntries(), self.num_elems)
         for i in range(self.num_elems):
-            self.assertEquals(sc1[i], sc2[i])
+            self.assertEqual(sc1[i], sc2[i])
 
         # Append items
         sc1 = self.create_tseqcollection()
@@ -140,13 +140,13 @@ class TSeqCollectionItemAccess(unittest.TestCase):
 
         sc1[self.num_elems:] = sc2
 
-        self.assertEquals(sc1.GetEntries(), 2 * self.num_elems)
+        self.assertEqual(sc1.GetEntries(), 2 * self.num_elems)
         i = 0
         for elem in l: # first half
-            self.assertEquals(sc1[i], elem)
+            self.assertEqual(sc1[i], elem)
             i += 1
         for elem in sc2: # second half
-            self.assertEquals(sc1[i], elem)
+            self.assertEqual(sc1[i], elem)
             i += 1
 
         # Assign second item.
@@ -157,10 +157,10 @@ class TSeqCollectionItemAccess(unittest.TestCase):
 
         sc3[1:2] = l2
 
-        self.assertEquals(sc3.GetEntries(), self.num_elems)
-        self.assertEquals(sc3[0], l3[0])
-        self.assertEquals(sc3[1], l2[0])
-        self.assertEquals(sc3[2], l3[2])
+        self.assertEqual(sc3.GetEntries(), self.num_elems)
+        self.assertEqual(sc3[0], l3[0])
+        self.assertEqual(sc3[1], l2[0])
+        self.assertEqual(sc3[2], l3[2])
 
         # Assign with step
         sc4 = self.create_tseqcollection()
@@ -170,18 +170,18 @@ class TSeqCollectionItemAccess(unittest.TestCase):
 
         sc4[::2] = l4
 
-        self.assertEquals(sc4.GetEntries(), self.num_elems)
-        self.assertEquals(sc4[0], l4[0])
-        self.assertEquals(sc4[1], o)
-        self.assertEquals(sc4[2], l4[1])
+        self.assertEqual(sc4.GetEntries(), self.num_elems)
+        self.assertEqual(sc4[0], l4[0])
+        self.assertEqual(sc4[1], o)
+        self.assertEqual(sc4[2], l4[1])
 
         # Assign with step (start from end)
         sc4[::-2] = l4
 
-        self.assertEquals(sc4.GetEntries(), self.num_elems)
-        self.assertEquals(sc4[0], l4[1])
-        self.assertEquals(sc4[1], o)
-        self.assertEquals(sc4[2], l4[0])
+        self.assertEqual(sc4.GetEntries(), self.num_elems)
+        self.assertEqual(sc4[0], l4[1])
+        self.assertEqual(sc4[1], o)
+        self.assertEqual(sc4[2], l4[0])
 
         # Step cannot be zero
         sc5 = self.create_tseqcollection()
@@ -230,36 +230,36 @@ class TSeqCollectionItemAccess(unittest.TestCase):
         # Delete all items
         sc1 = self.create_tseqcollection()
         del sc1[:]
-        self.assertEquals(sc1.GetEntries(), 0)
+        self.assertEqual(sc1.GetEntries(), 0)
 
         # Do not delete anything (slice out of range)
         sc2 = self.create_tseqcollection()
         l2 = [ elem for elem in sc2 ]
         del sc2[self.num_elems:]
-        self.assertEquals(sc2.GetEntries(), self.num_elems)
+        self.assertEqual(sc2.GetEntries(), self.num_elems)
         for el1, el2 in zip(sc2, l2):
-            self.assertEquals(el1, el2)
+            self.assertEqual(el1, el2)
 
         # Delete first two items
         sc3 = self.create_tseqcollection()
         o = sc3[2]
         del sc3[0:2]
-        self.assertEquals(sc3.GetEntries(), 1)
-        self.assertEquals(sc3[0], o)
+        self.assertEqual(sc3.GetEntries(), 1)
+        self.assertEqual(sc3[0], o)
 
         # Delete first and third items
         sc4 = self.create_tseqcollection()
         o = sc4[1]
         del sc4[::2]
-        self.assertEquals(sc4.GetEntries(), 1)
-        self.assertEquals(sc4[0], o)
+        self.assertEqual(sc4.GetEntries(), 1)
+        self.assertEqual(sc4[0], o)
 
         # Delete first and third items (start from end)
         sc5 = self.create_tseqcollection()
         o = sc5[1]
         del sc5[::-2]
-        self.assertEquals(sc5.GetEntries(), 1)
-        self.assertEquals(sc5[0], o)
+        self.assertEqual(sc5.GetEntries(), 1)
+        self.assertEqual(sc5[0], o)
 
         # Step cannot be zero
         sc6 = self.create_tseqcollection()

--- a/bindings/pyroot_experimental/PyROOT/test/tseqcollection_itemaccess.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tseqcollection_itemaccess.py
@@ -1,0 +1,93 @@
+import unittest
+
+import ROOT
+from libcppyy import SetOwnership
+
+
+class TSeqCollectionItemAccess(unittest.TestCase):
+    """
+    Test for the item access methods added to TSeqCollection (and subclasses):
+    __getitem__, __setitem__, __delitem__.
+    Both the index (l[i]) and slice (l[i:j]) syntaxes are tested.
+    """
+
+    num_elems = 3
+
+    # Helpers
+    def create_tseqcollection(self):
+        sc = ROOT.TList()
+        for _ in range(self.num_elems):
+            o = ROOT.TObject()
+            # Prevent immediate deletion of C++ TObjects
+            SetOwnership(o, False)
+            sc.Add(o)
+
+        return sc
+
+    # Tests
+    def test_getitem(self):
+        sc = self.create_tseqcollection()
+
+        # Get elements in collection
+        it = ROOT.TIter(sc)
+        for i in range(self.num_elems):
+            self.assertEqual(it.Next(), sc[i])
+
+        # Check invalid index case
+        with self.assertRaises(IndexError):
+            sc[self.num_elems]
+
+    def test_setitem(self):
+        sc = self.create_tseqcollection()
+        l = []
+        
+        # Set items
+        for i in range(self.num_elems):
+            o = ROOT.TObject()
+            sc[i] = o
+            l.append(o)
+
+        # Check previously set items
+        it = ROOT.TIter(sc)
+        for i in range(self.num_elems):
+            self.assertEqual(it.Next(), l[i])
+
+        # Check invalid index case
+        with self.assertRaises(IndexError):
+            sc[self.num_elems] = ROOT.TObject()
+
+    def test_delitem(self):
+        sc = self.create_tseqcollection()
+
+        self.assertEqual(sc.GetEntries(), self.num_elems)
+
+        # Delete all elements
+        for _ in range(self.num_elems):
+            del sc[0]
+
+        self.assertEqual(sc.GetEntries(), 0)
+
+        sc = ROOT.TList()
+        o1 = ROOT.TObject()
+        o2 = ROOT.TObject()
+        sc.Add(o1)
+        sc.Add(o2)
+        sc.Add(o1)
+
+        # Delete o2
+        del sc[1]
+
+        # Only o1s should be there
+        self.assertEqual(sc.GetEntries(), 2)
+
+        it = ROOT.TIter(sc)
+        for _ in range(2):
+            self.assertEqual(it.Next(), o1)
+
+        # Check invalid index case
+        with self.assertRaises(IndexError):
+            del sc[2]
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bindings/pyroot_experimental/PyROOT/test/tseqcollection_itemaccess.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tseqcollection_itemaccess.py
@@ -8,7 +8,7 @@ class TSeqCollectionItemAccess(unittest.TestCase):
     """
     Test for the item access methods added to TSeqCollection (and subclasses):
     __getitem__, __setitem__, __delitem__.
-    Both the index (l[i]) and slice (l[i:j]) syntaxes are tested.
+    Both the index (l[i]) and slice (l[i:j:k]) syntaxes are tested.
     """
 
     num_elems = 3
@@ -72,12 +72,12 @@ class TSeqCollectionItemAccess(unittest.TestCase):
         self.assertEqual(sc[0], slice4[0])
         self.assertEqual(sc[2], slice4[1])
 
-        # All items, reversed order
+        # All items, reverse order
         slice5 = sc[::-1]
         for i in range(slice5.GetEntries()):
             self.assertEqual(sc[i], slice5[self.num_elems - 1 - i])
 
-        # First and third items, reversed order
+        # First and third items, reverse order
         slice6 = sc[::-2]
         self.assertEqual(sc[0], slice6[1])
         self.assertEqual(sc[2], slice6[0])

--- a/bindings/pyroot_experimental/PyROOT/test/tseqcollection_itemaccess.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tseqcollection_itemaccess.py
@@ -89,7 +89,7 @@ class TSeqCollectionItemAccess(unittest.TestCase):
     def test_setitem(self):
         sc = self.create_tseqcollection()
         l = []
-        
+
         # Set items
         for i in range(self.num_elems):
             o = ROOT.TObject()

--- a/bindings/pyroot_experimental/PyROOT/test/tseqcollection_itemaccess.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tseqcollection_itemaccess.py
@@ -82,6 +82,10 @@ class TSeqCollectionItemAccess(unittest.TestCase):
         self.assertEqual(sc[0], slice6[1])
         self.assertEqual(sc[2], slice6[0])
 
+        # Step cannot be zero
+        with self.assertRaises(ValueError):
+            sc[::0]
+
     def test_setitem(self):
         sc = self.create_tseqcollection()
         l = []

--- a/bindings/pyroot_experimental/PyROOT/test/tseqcollection_itemaccess.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tseqcollection_itemaccess.py
@@ -28,14 +28,26 @@ class TSeqCollectionItemAccess(unittest.TestCase):
     def test_getitem(self):
         sc = self.create_tseqcollection()
 
-        # Get elements in collection
+        # Get items
         it = ROOT.TIter(sc)
         for i in range(self.num_elems):
             self.assertEqual(it.Next(), sc[i])
 
-        # Check invalid index case
+        # Get items, negative indices
+        it2 = ROOT.TIter(sc)
+        neg_idcs = [ -i-1 for i in reversed(range(self.num_elems)) ]
+        for i in neg_idcs:
+            self.assertEqual(it2.Next(), sc[i])
+
+        # Check invalid index cases
         with self.assertRaises(IndexError):
             sc[self.num_elems]
+
+        with self.assertRaises(IndexError):
+            sc[-(self.num_elems + 1)]
+
+        with self.assertRaises(TypeError):
+            sc[1.0]
 
     def test_getitem_slice(self):
         sc = self.create_tseqcollection()
@@ -85,9 +97,28 @@ class TSeqCollectionItemAccess(unittest.TestCase):
         for i in range(self.num_elems):
             self.assertEqual(it.Next(), l[i])
 
-        # Check invalid index case
+        # Set items, negative indices
+        l2 = []
+        neg_idcs = [ -i-1 for i in reversed(range(self.num_elems)) ]
+        for i in neg_idcs:
+            o = ROOT.TObject()
+            sc[i] = o
+            l2.append(o)
+
+        # Check previously set items
+        it2 = ROOT.TIter(sc)
+        for i in range(self.num_elems):
+            self.assertEqual(it2.Next(), l2[i])
+
+        # Check invalid index cases
         with self.assertRaises(IndexError):
             sc[self.num_elems] = ROOT.TObject()
+
+        with self.assertRaises(IndexError):
+            sc[-(self.num_elems + 1)] = ROOT.TObject()
+
+        with self.assertRaises(TypeError):
+            sc[1.0] = ROOT.TObject()
 
     def test_setitem_slice(self):
         sc1 = self.create_tseqcollection()
@@ -181,9 +212,15 @@ class TSeqCollectionItemAccess(unittest.TestCase):
         for _ in range(2):
             self.assertEqual(it.Next(), o1)
 
-        # Check invalid index case
+        # Check invalid index cases
         with self.assertRaises(IndexError):
             del sc[2]
+
+        with self.assertRaises(IndexError):
+            del sc[-3]
+
+        with self.assertRaises(TypeError):
+            del sc[1.0]
 
     def test_delitem_slice(self):
         # Delete all items

--- a/bindings/pyroot_experimental/PyROOT/test/tseqcollection_listmethods.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tseqcollection_listmethods.py
@@ -1,0 +1,152 @@
+import unittest
+
+import ROOT
+from libcppyy import SetOwnership
+
+
+class TSeqCollectionListMethods(unittest.TestCase):
+    """
+    Test for the Python-list-like methods added to TSeqCollection
+    (and subclasses): insert, pop, reverse, sort, index
+    """
+
+    num_elems = 3
+
+    # Helpers
+    def create_tseqcollection(self):
+        sc = ROOT.TList()
+        for i in reversed(range(self.num_elems)):
+            o = ROOT.TObjString(str(i))
+            # Prevent immediate deletion of C++ TObjStrings
+            SetOwnership(o, False)
+            sc.Add(o)
+
+        return sc
+
+    # Tests
+    def test_insert(self):
+        sc = self.create_tseqcollection()
+
+        # Insert with positive index
+        o = ROOT.TObject()
+        sc.insert(1, o)
+        self.assertEqual(sc.GetEntries(), self.num_elems + 1)
+        self.assertEqual(sc.At(1), o)
+
+        # Insert with negative index (starts from end)
+        o2 = ROOT.TObject()
+        sc.insert(-1, o2)
+        self.assertEqual(sc.GetEntries(), self.num_elems + 2)
+        self.assertEqual(sc.At(self.num_elems), o2)
+
+        # Insert with index beyond lower boundary.
+        # Inserts at the beginning
+        o3 = ROOT.TObject()
+        sc.insert(-(self.num_elems + 3), o3)
+        self.assertEqual(sc.GetEntries(), self.num_elems + 3)
+        self.assertEqual(sc.At(0), o3)
+
+        # Insert with index beyond upper boundary.
+        # Inserts at the end
+        o4 = ROOT.TObject()
+        sc.insert(self.num_elems + 4, o4)
+        self.assertEqual(sc.GetEntries(), self.num_elems + 4)
+        self.assertEqual(sc.At(self.num_elems + 3), o4)
+
+    def test_pop(self):
+        sc = self.create_tseqcollection()
+        l = [ elem for elem in sc ]
+
+        # No arguments, pop last item
+        self.assertEqual(sc.pop(), l[-1])
+        self.assertEqual(sc.GetEntries(), self.num_elems - 1)
+
+        # Pop first item, positive index
+        self.assertEqual(sc.pop(0), l[0])
+        self.assertEqual(sc.GetEntries(), self.num_elems - 2)
+
+        # Pop last item, negative index
+        self.assertEqual(sc.pop(-1), l[1])
+        self.assertEqual(sc.GetEntries(), self.num_elems - 3)
+
+        # Pop from empty collection
+        with self.assertRaises(IndexError):
+            sc.pop()
+
+        # Index out of range, positive
+        sc2 = self.create_tseqcollection()
+        with self.assertRaises(IndexError):
+            sc2.pop(self.num_elems)
+
+        # Index out of range, negative
+        with self.assertRaises(IndexError):
+            sc2.pop(-(self.num_elems + 1))
+
+        # Pop with non-integer argument
+        with self.assertRaises(TypeError):
+            sc2.pop(1.0)
+
+    def test_reverse(self):
+        sc = self.create_tseqcollection()
+        l = [ elem for elem in sc ]
+
+        sc.reverse()
+
+        self.assertEqual(sc.GetEntries(), self.num_elems)
+        for i,elem in zip(range(self.num_elems), sc):
+            self.assertEqual(elem, l[-(i+1)])
+
+        # Empty collection
+        sc2 = ROOT.TList()
+        sc2.reverse()
+        self.assertEqual(sc2.GetEntries(), 0)
+
+    def test_sort(self):
+        sc = self.create_tseqcollection()
+        l = [ elem for elem in sc ]
+        
+        # Regular sort, rely on TList::Sort
+        sc.sort()
+        # We need to set `key` until the pythonization to
+        # make TObjString comparable is there
+        l.sort(key = lambda s: s.GetName())
+
+        self.assertEqual(sc.GetEntries(), self.num_elems)
+        self.assertEqual(l[0], sc[0])
+        for el1, el2 in zip(sc, l):
+            self.assertEqual(el1, el2)
+
+        # Python sort, key and reverse arguments.
+        # Sort by hash in reverse order
+        sc2 = self.create_tseqcollection()
+        l2 = [ elem for elem in sc2 ]
+
+        fsort = lambda elem: elem.Hash()
+        rev = True
+        sc2.sort(key = fsort, reverse = rev)
+        l2.sort(key = fsort, reverse = rev)
+
+        self.assertEqual(sc2.GetEntries(), self.num_elems)
+        for el1, el2 in zip(sc2, l2):
+            self.assertEqual(el1, el2)
+
+        # Empty collection
+        sc4 = ROOT.TList()
+        sc4.sort()
+        self.assertEqual(sc4.GetEntries(), 0)
+
+    def test_index(self):
+        sc = self.create_tseqcollection()
+
+        # Check all elements of collection
+        for i, elem in zip(range(self.num_elems), sc):
+            self.assertEqual(sc.index(elem), i)
+
+        # Check element not in collection
+        o = ROOT.TObjString(str(self.num_elems))
+        with self.assertRaises(ValueError):
+            sc.index(o)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bindings/pyroot_experimental/PyROOT/test/tseqcollection_listmethods.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tseqcollection_listmethods.py
@@ -104,7 +104,7 @@ class TSeqCollectionListMethods(unittest.TestCase):
     def test_sort(self):
         sc = self.create_tseqcollection()
         l = [ elem for elem in sc ]
-        
+
         # Regular sort, rely on TList::Sort
         sc.sort()
         # We need to set `key` until the pythonization to

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -447,7 +447,6 @@ if(ROOT_python_FOUND)
                  tutorial-hist-fillrandom-py
                  tutorial-math-Legendre-py
                  tutorial-math-tStudent-py
-                 tutorial-pyroot-DynamicSlice-py
                  tutorial-pyroot-benchmarks-py
                  tutorial-pyroot-fillrandom-py
                  tutorial-pyroot-fit1-py


### PR DESCRIPTION
This PR adds two sets of pythonizations to `TSeqCollection` and its subclasses:
- Injection of item access methods (`__getitem__`, `__setitem__`, `__delitem__`), both for integer indices and slices.
- Injection of Python-list-like methods (`insert`, `pop`, `reverse`, `sort`, `index`).

The PR also includes the corresponding unit tests.