### PR TITLE
Remove cstdlib from stl modulemap

### DIFF
--- a/build/unix/stl.modulemap
+++ b/build/unix/stl.modulemap
@@ -1,4 +1,4 @@
-module "stl" [system] {
+module "std" [system] {
   export *
   module "algorithm" {
     export *

--- a/build/unix/stl.modulemap
+++ b/build/unix/stl.modulemap
@@ -112,10 +112,10 @@ module "stl" [system] {
   // See the include for stdlib.h (which is forwarded
   // to this C++ header) in clang's mm_malloc.h for the
   // problematic code which we can't fix.
-  module "cstdlib" {
-    export *
-    textual header "cstdlib"
-  }
+  //module "cstdlib" {
+  //  export *
+  //  textual header "cstdlib"
+  //}
   module "cstring" {
     export *
     header "cstring"

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1293,7 +1293,7 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
       // Setup core C++ modules if we have any to setup.
 
       // Load libc and stl first.
-      LoadModules({"libc", "stl"}, *fInterpreter);
+      LoadModules({"libc", "std"}, *fInterpreter);
 
       // Load core modules
       // This should be vector in order to be able to pass it to LoadModules


### PR DESCRIPTION
As explained in reviews.llvm.org/D43871, having cstdlib as part
of the stl module causes cyclic references between Clang's builtin
module and our stl module. The best fix is to not have cstdlib
in our module (which is anyway just a wrapping header around
stdlib.h).