### PR TITLE
Rename "stl" module to "std"

### DIFF
--- a/build/unix/stl.modulemap
+++ b/build/unix/stl.modulemap
@@ -1,4 +1,4 @@
-module "stl" [system] {
+module "std" [system] {
   export *
   module "algorithm" {
     export *

--- a/build/unix/stl.modulemap
+++ b/build/unix/stl.modulemap
@@ -112,10 +112,10 @@ module "stl" [system] {
   // See the include for stdlib.h (which is forwarded
   // to this C++ header) in clang's mm_malloc.h for the
   // problematic code which we can't fix.
-  module "cstdlib" {
-    export *
-    textual header "cstdlib"
-  }
+  //module "cstdlib" {
+  //  export *
+  //  textual header "cstdlib"
+  //}
   module "cstring" {
     export *
     header "cstring"

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1293,7 +1293,7 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
       // Setup core C++ modules if we have any to setup.
 
       // Load libc and stl first.
-      LoadModules({"libc", "stl"}, *fInterpreter);
+      LoadModules({"libc", "std"}, *fInterpreter);
 
       // Load core modules
       // This should be vector in order to be able to pass it to LoadModules


### PR DESCRIPTION
libc++ comes with a builtin modulemap and is using "std" as the
module name for the STL. To stay consistent we should use the same
name (and "std" is anyway a better name).