### PR TITLE
WIP: Avoid link on Python on macOS clang

### DIFF
--- a/bindings/pyroot/CMakeLists.txt
+++ b/bindings/pyroot/CMakeLists.txt
@@ -64,7 +64,15 @@ ROOT_ADD_CXX_FLAG(_PyROOT_FLAGS -Wno-register)
 separate_arguments(_PyROOT_FLAGS)
 
 target_compile_options(PyROOT PRIVATE ${_PyROOT_FLAGS})
-target_link_libraries(PyROOT PRIVATE ${PYTHON_LIBRARIES})
+
+if(ROOT_PYTHON_NO_LINK)
+    if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+        set_property(TARGET PyROOT APPEND PROPERTY LINK_FLAGS "-undefined dynamic_lookup")
+    endif()
+else()
+    target_link_libraries(PyROOT PRIVATE ${PYTHON_LIBRARIES})
+endif()
+
 target_include_directories(PyROOT PRIVATE ${PYTHON_INCLUDE_DIRS})
 
 ROOT_LINKER_LIBRARY(JupyROOT JupyROOT/src/IOHandler.cxx DEPENDENCIES Core CMAKENOEXPORT)

--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -178,6 +178,9 @@ option(rootbench "Build rootbench if rootbench exists in root or if it is a sibl
 option(roottest "Build roottest if roottest exists in root or if it is a sibling directory." OFF)
 option(testing "Enable testing with CTest" OFF)
 
+option(ROOT_PYTHON_NO_LINK "Avoid linking to Python for package managers like Conda" OFF)
+mark_as_advanced(ROOT_PYTHON_NO_LINK)
+
 set(gcctoolchain "" CACHE PATH "Set path to GCC toolchain used to build llvm/clang")
 
 if (runtime_cxxmodules)

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -440,6 +440,8 @@ if(python)
   message(STATUS "Looking for python")
   find_package(PythonInterp ${python_version} REQUIRED)
   find_package(PythonLibs ${python_version} REQUIRED)
+  get_filename_component(ROOT_PYTHON_LIB_NAME "${PYTHON_LIBRARY}" NAME)
+
   if (tmva AND tmva-pymva)
     message(STATUS "Looking for numpy (python package)")
     find_package(NumPy)

--- a/config/RConfigure.in
+++ b/config/RConfigure.in
@@ -17,6 +17,9 @@
 #define TTFFONTDIR    "@ttffontdir@"
 #endif
 
+#cmakedefine ROOT_PYTHON_NO_LINK
+#define ROOT_PYTHON_LIB_NAME "@ROOT_PYTHON_LIB_NAME@"
+
 #define EXTRAICONPATH "@extraiconpath@"
 
 #@setresuid@ R__HAS_SETRESUID   /**/

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -1884,6 +1884,12 @@ int TSystem::Load(const char *module, const char *entry, Bool_t system)
 
    int ret = -1;
    if (path) {
+      // If ROOT does not make a link to python, then try to load libpython for the user
+      #ifdef ROOT_PYTHON_NO_LINK
+      if(moduleBasename.Contains("PyROOT") || moduleBasename.Contains("PyMVA"))
+          gSystem->Load(ROOT_PYTHON_LIB_NAME);
+      #endif ROOT_PYTHON_NO_LINK
+
       // load any dependent libraries
       TString deplibs = gInterpreter->GetSharedLibDeps(moduleBasename);
       if (deplibs.IsNull()) {

--- a/tmva/pymva/CMakeLists.txt
+++ b/tmva/pymva/CMakeLists.txt
@@ -17,9 +17,18 @@ set(PY_HEADERS ${CMAKE_SOURCE_DIR}/tmva/pymva/inc/TMVA/PyMethodBase.h
                ${CMAKE_SOURCE_DIR}/tmva/pymva/inc/TMVA/MethodPyGTB.h
                ${CMAKE_SOURCE_DIR}/tmva/pymva/inc/TMVA/MethodPyKeras.h)
 
-ROOT_STANDARD_LIBRARY_PACKAGE(PyMVA
-                              HEADERS ${PY_HEADERS}
-                              LIBRARIES ${PYTHON_LIBRARIES}
-                              DEPENDENCIES Core Matrix Thread RIO TMVA)
+if(ROOT_PYTHON_NO_LINK)
+    ROOT_STANDARD_LIBRARY_PACKAGE(PyMVA
+                                  HEADERS ${PY_HEADERS}
+                                  DEPENDENCIES Core Matrix Thread RIO TMVA)
+    if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+        set_property(TARGET PyMVA APPEND PROPERTY LINK_FLAGS "-undefined dynamic_lookup")
+    endif()
+else()
+    ROOT_STANDARD_LIBRARY_PACKAGE(PyMVA
+                                  HEADERS ${PY_HEADERS}
+                                  LIBRARIES ${PYTHON_LIBRARIES}
+                                  DEPENDENCIES Core Matrix Thread RIO TMVA)
+endif()
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)


### PR DESCRIPTION
It is not recommended to link directly to the Python libraries, but instead, use `-undefined dynamic_lookup` (macOS flag). Depending on how Python was built, using dynamic or static links to the libPython, a direct link can cause it to segfault. This uses that method, and was a necessary change for the conda-forge package for Python 3 macOS.

See, for example:
https://pybind11.readthedocs.io/en/stable/compiling.html#building-manually

Note: This might be reasonable to do for Linux too, but maybe with the appropriate flags. The current patch is as conservative as possible.