### PR TITLE
[RF] Fix compiler warnings.

### DIFF
--- a/roofit/roofitcore/src/RooAbsSelfCachedPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsSelfCachedPdf.cxx
@@ -105,19 +105,14 @@ void RooAbsSelfCachedPdf::fillCacheObject(RooAbsCachedPdf::PdfCacheElem& cache) 
 RooArgSet* RooAbsSelfCachedPdf::actualObservables(const RooArgSet& /*nset*/) const 
 {
   // Make list of servers
-  RooArgSet servers ;
+  RooArgSet *serverSet = new RooArgSet;
 
-  TIterator* siter = serverIterator() ;
-  siter->Reset() ;
-  RooAbsArg* server ;
-  while((server=(RooAbsArg*)siter->Next())) {
-    servers.add(*server) ;
+  for (auto server : _serverList) {
+    serverSet->add(*server) ;
   }
   
   // Return servers that are in common with given normalization set
-  return new RooArgSet(servers) ;
-  //return (RooArgSet*) servers.selectCommon(nset) ;
-  
+  return serverSet;
 }
 
 
@@ -129,19 +124,16 @@ RooArgSet* RooAbsSelfCachedPdf::actualObservables(const RooArgSet& /*nset*/) con
 
 RooArgSet* RooAbsSelfCachedPdf::actualParameters(const RooArgSet& nset) const 
 {  
-  RooArgSet *servers = new RooArgSet ;
+  RooArgSet *serverSet = new RooArgSet;
 
-  TIterator* siter = serverIterator() ;
-  siter->Reset() ;
-  RooAbsArg* server ;
-  while((server=(RooAbsArg*)siter->Next())) {
-    servers->add(*server) ;
+  for (auto server : _serverList) {
+    serverSet->add(*server) ;
   }
   
   // Remove all given observables from server list
-  servers->remove(nset,kTRUE,kTRUE) ;
+  serverSet->remove(nset,kTRUE,kTRUE);
 
-  return servers ;
+  return serverSet;
 }
 
 

--- a/roofit/roofitcore/src/RooAbsSelfCachedReal.cxx
+++ b/roofit/roofitcore/src/RooAbsSelfCachedReal.cxx
@@ -103,17 +103,14 @@ void RooAbsSelfCachedReal::fillCacheObject(RooAbsCachedReal::FuncCacheElem& cach
 RooArgSet* RooAbsSelfCachedReal::actualObservables(const RooArgSet& nset) const 
 {
   // Make list of servers
-  RooArgSet servers ;
+  RooArgSet serverSet;
 
-  TIterator* siter = serverIterator() ;
-  siter->Reset() ;
-  RooAbsArg* server ;
-  while((server=(RooAbsArg*)siter->Next())) {
-    servers.add(*server) ;
+  for (auto server : _serverList) {
+    serverSet.add(*server);
   }
   
   // Return servers that are in common with given normalization set
-  return (RooArgSet*) servers.selectCommon(nset) ;
+  return (RooArgSet*) serverSet.selectCommon(nset);
   
 }
 
@@ -126,19 +123,16 @@ RooArgSet* RooAbsSelfCachedReal::actualObservables(const RooArgSet& nset) const
 RooArgSet* RooAbsSelfCachedReal::actualParameters(const RooArgSet& nset) const 
 {  
   // Make list of servers
-  RooArgSet *servers = new RooArgSet ;
-
-  TIterator* siter = serverIterator() ;
-  siter->Reset() ;
-  RooAbsArg* server ;
-  while((server=(RooAbsArg*)siter->Next())) {
-    servers->add(*server) ;
+  RooArgSet *serverSet = new RooArgSet;
+  
+  for (auto server : _serverList) {
+    serverSet->add(*server);
   }
   
   // Remove all given observables from server list
-  servers->remove(nset,kTRUE,kTRUE) ;
+  serverSet->remove(nset,kTRUE,kTRUE);
 
-  return servers ;
+  return serverSet;
 }
 
 


### PR DESCRIPTION
RooAbsSelfCached* were using a local variable that has the same name as a function.