### PR TITLE
[DF] ROOT-9946 Fix some edge cases in jitting of expressions

### DIFF
--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -576,9 +576,10 @@ BuildLambdaString(const std::string &expr, const ColumnNames_t &vars, const Colu
       ss.seekp(-2, ss.cur);
 
    if (hasReturnStmt)
-      ss << "){\n" << expr << "\n}";
+      ss << "){";
    else
-      ss << "){return " << expr << "\n;}";
+      ss << "){return ";
+   ss << expr << "\n;}";
 
    return ss.str();
 }

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -70,7 +70,11 @@ namespace RDF {
 std::set<std::string> GetPotentialColumnNames(const std::string &expr)
 {
    lexertk::generator generator;
-   generator.process(expr);
+   const auto ok = generator.process(expr);
+   if (!ok) {
+      const auto msg = "Failed to tokenize expression:\n" + expr + "\n\nMake sure it is valid C++.";
+      throw std::runtime_error(msg);
+   }
 
    std::set<std::string> potCols;
    const auto nToks = generator.size();

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -609,7 +609,7 @@ void BookFilterJit(RJittedFilter *jittedFilter, void *prevNodeOnHeap, std::strin
    const auto usedColTypes =
       ColumnTypesAsString(usedBranches, varNames, aliasMap, tree, ds, dotlessExpr, namespaceID, customCols);
 
-   TRegexp re("[^a-zA-Z0-9_]return[^a-zA-Z0-9_]");
+   TRegexp re("[^a-zA-Z0-9_]?return[^a-zA-Z0-9_]");
    Ssiz_t matchedLen;
    const bool hasReturnStmt = re.Index(dotlessExpr, &matchedLen) != -1;
 
@@ -662,7 +662,7 @@ void BookDefineJit(std::string_view name, std::string_view expression, RLoopMana
    const auto usedColTypes =
       ColumnTypesAsString(usedBranches, varNames, aliasMap, tree, ds, dotlessExpr, namespaceID, customCols);
 
-   TRegexp re("[^a-zA-Z0-9_]return[^a-zA-Z0-9_]");
+   TRegexp re("[^a-zA-Z0-9_]?return[^a-zA-Z0-9_]");
    Ssiz_t matchedLen;
    const bool hasReturnStmt = re.Index(dotlessExpr, &matchedLen) != -1;
 

--- a/tree/dataframe/test/dataframe_simple.cxx
+++ b/tree/dataframe/test/dataframe_simple.cxx
@@ -218,7 +218,7 @@ TEST_P(RDFSimpleTests, Define_jitted_complex_array_sum)
 TEST_P(RDFSimpleTests, Define_jitted_defines_with_return)
 {
    RDataFrame tdf(10);
-   auto d = tdf.Define("my_return_x", "auto x = 3.0; return x")
+   auto d = tdf.Define("my_return_x", "return 3.0")
                .Define("return_y", "4.0 // with a comment")
                .Define("v", "std::array<double, 2> v{my_return_x, return_y}; return v; // also with comment")
                .Define("r", "double r2 = 0.0; for (auto&& w : v) r2 += w*w; return sqrt(r2);");

--- a/tree/dataframe/test/dataframe_simple.cxx
+++ b/tree/dataframe/test/dataframe_simple.cxx
@@ -218,7 +218,7 @@ TEST_P(RDFSimpleTests, Define_jitted_complex_array_sum)
 TEST_P(RDFSimpleTests, Define_jitted_defines_with_return)
 {
    RDataFrame tdf(10);
-   auto d = tdf.Define("my_return_x", "3.0")
+   auto d = tdf.Define("my_return_x", "auto x = 3.0; return x")
                .Define("return_y", "4.0 // with a comment")
                .Define("v", "std::array<double, 2> v{my_return_x, return_y}; return v; // also with comment")
                .Define("r", "double r2 = 0.0; for (auto&& w : v) r2 += w*w; return sqrt(r2);");


### PR DESCRIPTION
This fixes 2 out of 3 failing cases in ROOT-9946 (https://sft.its.cern.ch/jira/browse/ROOT-9946),
and throws an exception with a clearer error for the third case (i.e. escaped strings, which still requires fixing I think?)

@dpiparo in particular, lexertk fails to correctly tokenize a string like this, due to the escaped double quotes:
```c++
std::cout << \"check\" << std::endl; return x;
```