### PR TITLE
Adding corrected C++ std flags for current compiler for root-config

### DIFF
--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -560,6 +560,7 @@ string(REPLACE "c++11" "cxx11" features ${features}) # change the name of the c+
 set(configfeatures ${features})
 set(configargs ${ROOT_CONFIGARGS})
 set(configoptions ${ROOT_CONFIGARGS})
+set(configstd ${CMAKE_CXX${CMAKE_CXX_STANDARD}_STANDARD_COMPILE_OPTION})
 get_filename_component(altcc ${CMAKE_C_COMPILER} NAME)
 get_filename_component(altcxx ${CMAKE_CXX_COMPILER} NAME)
 get_filename_component(altf77 "${CMAKE_Fortran_COMPILER}" NAME)

--- a/config/root-config.in
+++ b/config/root-config.in
@@ -145,7 +145,7 @@ fi
 ### machine dependent settings ###
 
 # Set the C++ standard version
-cxxversionflag="-std=c++@CMAKE_CXX_STANDARD@ "
+cxxversionflag="@configstd@ "
 
 case $arch in
 aix5)


### PR DESCRIPTION
ROOT can get the incorrect flags if a compiler needs c++1z or something similar. This patch makes sure the compiler matches exactly what CMake uses. The old version can cause issues activating C++17 mode on AppleClang, for example, and then using `root-config`.