### PR TITLE
Test for not function in the stdlib

### DIFF
--- a/core/foundation/test/testNotFn.cxx
+++ b/core/foundation/test/testNotFn.cxx
@@ -1,4 +1,7 @@
-#if __cplusplus < 201703L && !defined(_MSC_VER)
+// Including functional for __cpp_lib_not_fn
+#include <functional>
+
+#ifdef __cpp_lib_not_fn
 
 #include "ROOT/RNotFn.hxx"
 


### PR DESCRIPTION
This should be more accurate than the current check. Follow up to #3096 and will remove a patch for the conda package.