### PR TITLE
Default GDML import units restored to Geant4 ones.

### DIFF
--- a/geom/gdml/inc/TGDMLParse.h
+++ b/geom/gdml/inc/TGDMLParse.h
@@ -12,13 +12,10 @@
 #ifndef ROOT_TGDMLParse
 #define ROOT_TGDMLParse
 
-#include "TGeoMatrix.h"
-
-#include "TXMLEngine.h"
-
-#include "TGeoVolume.h"
-
 #include "TFormula.h"
+#include "TXMLEngine.h"
+#include "TGeoMatrix.h"
+#include "TGeoVolume.h"
 
 #include <map>
 #include <vector>
@@ -105,21 +102,11 @@ public:
    TXMLEngine* fFileEngine[20]; //array of dom object pointers
    const char* fStartFile; //name of originating file
    const char* fCurrentFile; //current file name being parsed
-   std::string fDefault_lunit = "cm";
-   std::string fDefault_aunit = "deg";
+   std::string fDefault_lunit = "mm";
+   std::string fDefault_aunit = "rad";
 
-   TGDMLParse() { //constructor
-      fWorldName = "";
-      fWorld = 0;
-      fVolID = 0;
-      fFILENO = 0;
-      for (Int_t i=0; i<20; i++) fFileEngine[i] = 0;
-      fStartFile = 0;
-      fCurrentFile = 0;
-   }
-
-   virtual ~TGDMLParse() { //destructor
-   }
+   TGDMLParse();
+   virtual ~TGDMLParse() {}
 
    static TGeoVolume* StartGDML(const char* filename) {
       TGDMLParse* parser = new TGDMLParse;
@@ -128,8 +115,6 @@ public:
    }
 
    TGeoVolume*       GDMLReadFile(const char* filename = "test.gdml");
-   void              SetDefaultROOTUnits() { fDefault_lunit = "cm"; fDefault_aunit = "deg"; }
-   void              SetDefaultG4Units() { fDefault_lunit = "mm"; fDefault_aunit = "rad"; }
 
 private:
 

--- a/geom/gdml/src/TGDMLParse.cxx
+++ b/geom/gdml/src/TGDMLParse.cxx
@@ -123,6 +123,34 @@ When most solids or volumes are added to the geometry they
 ClassImp(TGDMLParse);
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Constructor
+
+TGDMLParse::TGDMLParse()
+{
+   fWorldName = "";
+   fWorld = 0;
+   fVolID = 0;
+   fFILENO = 0;
+   for (Int_t i=0; i<20; i++) fFileEngine[i] = 0;
+   fStartFile = 0;
+   fCurrentFile = 0;
+   auto def_units = TGeoManager::GetDefaultUnits();
+   switch (def_units) {
+      case TGeoManager::kG4Units:
+         fDefault_lunit = "mm";
+         fDefault_aunit = "rad";
+         break;
+      case TGeoManager::kRootUnits:
+         fDefault_lunit = "cm";
+         fDefault_aunit = "deg";
+         break;
+      default: // G4 units
+         fDefault_lunit = "mm";
+         fDefault_aunit = "rad";
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Creates the new instance of the XMLEngine called 'gdml', using the filename >>
 /// then parses the file and creates the DOM tree. Then passes the DOM to the
 /// next function to translate it.

--- a/geom/geom/inc/TGeoManager.h
+++ b/geom/geom/inc/TGeoManager.h
@@ -41,6 +41,12 @@ class TGeoBorderSurface;
 
 class TGeoManager : public TNamed
 {
+public:
+  enum EDefaultUnits {
+     kG4Units   = 0,
+     kRootUnits = 1
+  };
+
 protected:
    static std::mutex     fgMutex;           //! mutex for navigator booking in MT mode
    static Bool_t         fgLock;            //! Lock preventing a second geometry to be loaded
@@ -49,6 +55,7 @@ protected:
    static Int_t          fgMaxDaughters;    //! Maximum number of daughters
    static Int_t          fgMaxXtruVert;     //! Maximum number of Xtru vertices
    static UInt_t         fgExportPrecision; //! Precision to be used in ASCII exports
+   static EDefaultUnits  fgDefaultUnits;    //! Default units in GDML if not explicit in some tags
 
    TGeoManager(const TGeoManager&);
    TGeoManager& operator=(const TGeoManager&);
@@ -462,6 +469,9 @@ public:
    static Bool_t          IsLocked();
    static void            SetExportPrecision(UInt_t prec) {fgExportPrecision = prec;}
    static UInt_t          GetExportPrecision() {return fgExportPrecision;}
+   static void            SetDefaultG4Units() {fgDefaultUnits = kG4Units;}
+   static void            SetDefaultRootUnits() {fgDefaultUnits = kRootUnits;}
+   static EDefaultUnits   GetDefaultUnits();
    Bool_t                 IsStreamingVoxels() const {return fStreamVoxels;}
    Bool_t                 IsCleaning() const {return fIsGeomCleaning;}
 

--- a/geom/geom/src/TGeoManager.cxx
+++ b/geom/geom/src/TGeoManager.cxx
@@ -293,14 +293,15 @@ TGeoManager *gGeoManager = 0;
 ClassImp(TGeoManager);
 
 std::mutex TGeoManager::fgMutex;
-Bool_t TGeoManager::fgLock         = kFALSE;
-Bool_t TGeoManager::fgLockNavigators = kFALSE;
-Int_t  TGeoManager::fgVerboseLevel = 1;
-Int_t  TGeoManager::fgMaxLevel = 1;
-Int_t  TGeoManager::fgMaxDaughters = 1;
-Int_t  TGeoManager::fgMaxXtruVert = 1;
-Int_t  TGeoManager::fgNumThreads   = 0;
+Bool_t TGeoManager::fgLock            = kFALSE;
+Bool_t TGeoManager::fgLockNavigators  = kFALSE;
+Int_t  TGeoManager::fgVerboseLevel    = 1;
+Int_t  TGeoManager::fgMaxLevel        = 1;
+Int_t  TGeoManager::fgMaxDaughters    = 1;
+Int_t  TGeoManager::fgMaxXtruVert     = 1;
+Int_t  TGeoManager::fgNumThreads      = 0;
 UInt_t TGeoManager::fgExportPrecision = 17;
+TGeoManager::EDefaultUnits TGeoManager::fgDefaultUnits = TGeoManager::kG4Units;
 TGeoManager::ThreadsMap_t *TGeoManager::fgThreadId = 0;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -4129,4 +4130,9 @@ void TGeoManager::SetUseParallelWorldNav(Bool_t flag)
    }
    // Closing the parallel world geometry is mandatory
    if (fParallelWorld->CloseGeometry()) fUsePWNav=kTRUE;
+}
+
+TGeoManager::EDefaultUnits TGeoManager::GetDefaultUnits()
+{
+  return fgDefaultUnits;
 }


### PR DESCRIPTION
Default GDML import units restored to Geant4 ones. Can be changed before import using TGeoManager::SetDefaultRootUnits().