### PR TITLE
Fix documentation generation bug

### DIFF
--- a/core/cont/src/TList.cxx
+++ b/core/cont/src/TList.cxx
@@ -552,9 +552,10 @@ void TList::Delete(Option_t *option)
    Changed();
 }
 
+#if 0
 ////////////////////////////////////////////////////////////////////////////////
 /// Delete a TObjLink object.
-#if 0
+
 void TList::DeleteLink(TObjLink *lnk)
 {
    R__COLLECTION_WRITE_GUARD();


### PR DESCRIPTION
If the comment is left in the code, the html documentation renderer shows it as part of the next member function which is misleading.

See this [link](https://root.cern.ch/doc/master/classTList.html#a85c8734ab131c0db5f68c724e47496a7) with wrong doc string.

Someone who knows which button to press to generate the docs should check if this really fixes the issue. I haven't found the button ;)