### PR TITLE
[Exp PyROOT] Add item setting pythonisation for TClonesArray

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 set(py_sources
   ROOT/__init__.py
+  ROOT/_facade.py
   ROOT/pythonization/__init__.py
   ROOT/pythonization/_generic.py
   ROOT/pythonization/_rooabscollection.py

--- a/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
@@ -11,6 +11,7 @@ set(py_sources
   ROOT/pythonization/_rvec.py
   ROOT/pythonization/_stl_vector.py
   ROOT/pythonization/_tarray.py
+  ROOT/pythonization/_tclonesarray.py
   ROOT/pythonization/_tcollection.py
   ROOT/pythonization/_tdirectory.py
   ROOT/pythonization/_tdirectoryfile.py
@@ -26,6 +27,7 @@ set(sources
   src/TDirectoryPyz.cxx
   src/TFilePyz.cxx
   src/TTreePyz.cxx
+  src/TClonesArrayPyz.cxx
   src/GenericPyz.cxx
   src/RVecPyz.cxx
   src/PyzPythonHelpers.cxx

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tclonesarray.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tclonesarray.py
@@ -1,0 +1,25 @@
+# Author: Enric Tejedor CERN  02/2019
+
+################################################################################
+# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from ROOT import pythonization
+from libROOTPython import AddSetItemTCAPyz
+
+
+@pythonization()
+def pythonize_tclonesarray(klass, name):
+    # Parameters:
+    # klass: class to be pythonized
+    # name: string containing the name of the class
+
+    if name == 'TClonesArray':
+        # Add item setter method
+        AddSetItemTCAPyz(klass)
+
+    return True

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
@@ -49,6 +49,8 @@ static PyMethodDef gPyROOTMethods[] = {{(char *)"AddDirectoryWritePyz", (PyCFunc
                                         (char *)"Fully enable the use of TTree::SetBranchAddress from Python"},
                                        {(char *)"BranchPyz", (PyCFunction)PyROOT::BranchPyz, METH_VARARGS,
                                         (char *)"Fully enable the use of TTree::Branch from Python"},
+                                       {(char *)"AddSetItemTCAPyz", (PyCFunction)PyROOT::AddSetItemTCAPyz, METH_VARARGS,
+                                        (char *)"Customize the setting of an item of a TClonesArray"},
                                        {(char *)"AddPrettyPrintingPyz", (PyCFunction)PyROOT::AddPrettyPrintingPyz, METH_VARARGS,
                                         (char *)"Add pretty printing pythonization"},
                                        {(char *)"GetEndianess", (PyCFunction)PyROOT::GetEndianess, METH_NOARGS,

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
@@ -21,6 +21,7 @@ PyObject *AddDirectoryWritePyz(PyObject *self, PyObject *args);
 PyObject *AddDirectoryAttrSyntaxPyz(PyObject *self, PyObject *args);
 PyObject *AddBranchAttrSyntax(PyObject *self, PyObject *args);
 PyObject *AddFileOpenPyz(PyObject *self, PyObject *args);
+PyObject *AddSetItemTCAPyz(PyObject *self, PyObject *args);
 PyObject *SetBranchAddressPyz(PyObject *self, PyObject *args);
 PyObject *BranchPyz(PyObject *self, PyObject *args);
 PyObject *GetEndianess(PyObject *self);

--- a/bindings/pyroot_experimental/PyROOT/src/PyzCppHelpers.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyzCppHelpers.cxx
@@ -24,10 +24,7 @@ pythonizations.
 PyObject *CallPyObjMethod(PyObject *obj, const char *meth)
 {
    // Helper; call method with signature: obj->meth()
-   Py_INCREF(obj);
-   PyObject* result = PyObject_CallMethod(obj, const_cast<char*>(meth), const_cast<char*>(""));
-   Py_DECREF(obj);
-   return result;
+   return PyObject_CallMethod(obj, const_cast<char*>(meth), const_cast<char*>(""));
 }
 
 TClass *GetTClass(const CPyCppyy::CPPInstance *pyobj)

--- a/bindings/pyroot_experimental/PyROOT/src/PyzCppHelpers.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyzCppHelpers.cxx
@@ -21,11 +21,11 @@ pythonizations.
 #include "CPPInstance.h"
 #include "TClass.h"
 
-PyObject *CallPyObjMethod(PyObject *obj, const char *meth, PyObject *arg1)
+PyObject *CallPyObjMethod(PyObject *obj, const char *meth)
 {
-   // Helper; call method with signature: obj->meth(arg1).
+   // Helper; call method with signature: obj->meth()
    Py_INCREF(obj);
-   PyObject *result = PyObject_CallMethod(obj, const_cast<char *>(meth), const_cast<char *>("O"), arg1);
+   PyObject* result = PyObject_CallMethod(obj, const_cast<char*>(meth), const_cast<char*>(""));
    Py_DECREF(obj);
    return result;
 }

--- a/bindings/pyroot_experimental/PyROOT/src/PyzCppHelpers.hxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyzCppHelpers.hxx
@@ -16,5 +16,5 @@ namespace CPyCppyy {
    class CPPInstance;
 }
 
-PyObject *CallPyObjMethod(PyObject *obj, const char *meth, PyObject *arg1);
+PyObject *CallPyObjMethod(PyObject *obj, const char *meth);
 TClass *GetTClass(const CPyCppyy::CPPInstance *pyobj);

--- a/bindings/pyroot_experimental/PyROOT/src/TClonesArrayPyz.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/TClonesArrayPyz.cxx
@@ -64,7 +64,7 @@ static PyObject *PyStyleIndex(PyObject *self, PyObject *index)
    // To know the capacity of a TClonesArray, we need to invoke GetSize
    PyObject *pysize = CallPyObjMethod(self, "GetSize");
    if (!pysize) {
-      PyErr_Clear();
+      PyErr_SetString(PyExc_RuntimeError, "unable to get the size of TClonesArray");
       return nullptr;
    }
 

--- a/bindings/pyroot_experimental/PyROOT/src/TClonesArrayPyz.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/TClonesArrayPyz.cxx
@@ -83,6 +83,7 @@ static PyObject *PyStyleIndex(PyObject *self, PyObject *index)
       pyindex = PyLong_FromSsize_t(size + idx);
    }
 
+   // We transfer ownership to the caller, who needs to decref
    return pyindex;
 }
 

--- a/bindings/pyroot_experimental/PyROOT/src/TClonesArrayPyz.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/TClonesArrayPyz.cxx
@@ -1,0 +1,125 @@
+// Author: Enric Tejedor CERN  02/2019
+// Original PyROOT code by Wim Lavrijsen, LBL
+
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+// Bindings
+#include "CPyCppyy.h"
+#include "PyROOTPythonize.h"
+#include "CPPInstance.h"
+#include "MemoryRegulator.h"
+#include "Utility.h"
+#include "PyzCppHelpers.hxx"
+
+// ROOT
+#include "TClass.h"
+#include "TClonesArray.h"
+
+using namespace CPyCppyy;
+
+// Helper: converts Python index into straight C index.
+static PyObject *PyStyleIndex(PyObject *self, PyObject *index)
+{
+   Py_ssize_t idx = PyInt_AsSsize_t(index);
+   if (idx == (Py_ssize_t)-1 && PyErr_Occurred())
+      return nullptr;
+
+   // To know the capacity of a TClonesArray, we need to invoke GetSize
+   PyObject *pysize = CallPyObjMethod(self, "GetSize");
+   if (!pysize) {
+      PyErr_Clear();
+      return nullptr;
+   }
+
+   Py_ssize_t size = PyInt_AsSsize_t(pysize);
+   Py_DECREF(pysize);
+   if (idx >= size || (idx < 0 && idx < -size)) {
+      PyErr_SetString(PyExc_IndexError, "index out of range");
+      return nullptr;
+   }
+
+   PyObject *pyindex = nullptr;
+   if (idx >= 0) {
+      Py_INCREF(index);
+      pyindex = index;
+   } else {
+      pyindex = PyLong_FromSsize_t(size + idx);
+   }
+
+   return pyindex;
+}
+
+// Customize item setting
+PyObject *SetItem(CPPInstance *self, PyObject *args)
+{
+   CPPInstance *pyobj = nullptr;
+   PyObject *idx = nullptr;
+   if (!PyArg_ParseTuple(args, const_cast<char *>("OO!:__setitem__"), &idx, &CPPInstance_Type, &pyobj))
+      return nullptr;
+
+   if (!self->GetObject()) {
+      PyErr_SetString(PyExc_TypeError, "unsubscriptable object");
+      return nullptr;
+   }
+
+   PyObject *pyindex = PyStyleIndex((PyObject *)self, idx);
+   if (!pyindex)
+      return nullptr;
+   int index = (int)PyLong_AsLong(pyindex);
+   Py_DECREF(pyindex);
+
+   // Get hold of the actual TClonesArray
+   auto cla = (TClonesArray *)GetTClass(self)->DynamicCast(TClonesArray::Class(), self->GetObject());
+
+   if (!cla) {
+      PyErr_SetString(PyExc_TypeError, "attempt to call with null object");
+      return nullptr;
+   }
+
+   if (Cppyy::GetScope(cla->GetClass()->GetName()) != pyobj->ObjectIsA()) {
+      PyErr_Format(PyExc_TypeError, "require object of type %s, but %s given", cla->GetClass()->GetName(),
+                   Cppyy::GetFinalName(pyobj->ObjectIsA()).c_str());
+   }
+
+   // Destroy old object, if applicable
+   if (((const TClonesArray &)*cla)[index]) {
+      cla->RemoveAt(index);
+   }
+
+   if (pyobj->GetObject()) {
+      // Accessing an entry will result in new, uninitialized memory (if properly used)
+      TObject *object = (*cla)[index];
+      pyobj->CppOwns();
+      MemoryRegulator::RegisterPyObject(pyobj, object);
+      memcpy((void *)object, pyobj->GetObject(), cla->GetClass()->Size());
+   }
+
+   Py_RETURN_NONE;
+}
+
+////////////////////////////////////////////////////////////////////////////
+/// \brief Customize the setting of an item of a TClonesArray.
+/// \param[in] self Always null, since this is a module function.
+/// \param[in] args Pointer to a Python tuple object containing the arguments
+/// received from Python.
+///
+/// Inject a __setitem__ implementation that customizes the setting of an item
+/// into a TClonesArray.
+///
+/// The __setitem__ pythonization that TClonesArray inherits from TSeqCollection
+/// does not apply in this case and a redefinition is required. The reason is
+/// TClonesArray sets objects by constructing them in-place, which is impossible
+/// to support as the Python object given as value must exist a priori. It can,
+/// however, be memcpy'd and stolen.
+PyObject *PyROOT::AddSetItemTCAPyz(PyObject * /* self */, PyObject *args)
+{
+   PyObject *pyclass = PyTuple_GetItem(args, 0);
+   Utility::AddToClass(pyclass, "__setitem__", (PyCFunction)SetItem);
+   Py_RETURN_NONE;
+}

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -27,6 +27,9 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_tcollection_iterable tcollection_iterable.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tseqcollection_itemaccess tseqcollection_itemaccess.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tseqcollection_listmethods tseqcollection_listmethods.py)
 
+# TClonesArray pythonisations
+ROOT_ADD_PYUNITTEST(pyroot_pyz_tclonesarray_itemaccess tclonesarray_itemaccess.py)
+
 # TArray and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tarray_len tarray_len.py)
 

--- a/bindings/pyroot_experimental/PyROOT/test/tclonesarray_itemaccess.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tclonesarray_itemaccess.py
@@ -1,0 +1,29 @@
+import unittest
+
+import ROOT
+
+
+class TClonesArrayItemAccess(unittest.TestCase):
+    """
+    Test for the item access method added to TClonesArray:
+    __setitem__.
+    """
+
+    num_elems = 3
+
+    # Helpers
+    def create_tclonesarray_and_list(self):
+        ca = ROOT.TClonesArray("TObject", self.num_elems)
+        l = [ ROOT.TObject() for _ in range(self.num_elems) ]
+        return ca, l
+
+    # Tests
+    def test_setitem(self):
+        ca, l = self.create_tclonesarray_and_list()
+        for item, i in zip(l, range(self.num_elems)):
+            ca[i] = item
+            self.assertEqual(ca[i], item)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The pythonisation proposed in this PR injects a `__setitem__` implementation into `TClonesArray` that customizes the setting of an item.

The `__setitem__` pythonization that `TClonesArray` inherits from `TSeqCollection` does not apply in this case and a redefinition is required. The reason is `TClonesArray `sets objects by constructing them in-place, which is impossible to support as the Python object given as value must exist a priori. It can, however, be memcpy'd and stolen, which is the approach used in this redefinition. This is also the reason why this pythonisation needs to be implemented in C++.