### PR TITLE
[PyROOT exp] Add MakeNumpyDataFrame feature

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
@@ -8,6 +8,7 @@ set(py_sources
   ROOT/pythonization/_generic.py
   ROOT/pythonization/_rooabscollection.py
   ROOT/pythonization/_rvec.py
+  ROOT/pythonization/_rdataframe.py
   ROOT/pythonization/_stl_vector.py
   ROOT/pythonization/_tarray.py
   ROOT/pythonization/_tcollection.py
@@ -27,6 +28,7 @@ set(sources
   src/TTreePyz.cxx
   src/GenericPyz.cxx
   src/RVecPyz.cxx
+  src/RDataFramePyz.cxx
   src/PyzPythonHelpers.cxx
   src/PyzCppHelpers.cxx
 )

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_rdataframe.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_rdataframe.py
@@ -9,9 +9,9 @@
 ################################################################################
 
 from ROOT import pythonization
-from libROOTPython import MakeRDataFrame
+from libROOTPython import MakeNumpyDataFrame
 
 
-# Add MakeRDataFrame feature as free function to the ROOT module
+# Add MakeNumpyDataFrame feature as free function to the ROOT module
 import cppyy
-cppyy.gbl.ROOT.RDF.MakeRDataFrame = MakeRDataFrame
+cppyy.gbl.ROOT.RDF.MakeNumpyDataFrame = MakeNumpyDataFrame

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_rdataframe.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_rdataframe.py
@@ -1,0 +1,17 @@
+# Author: Stefan Wunsch CERN  02/2019
+
+################################################################################
+# Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from ROOT import pythonization
+from libROOTPython import MakeRDataFrame
+
+
+# Add MakeRDataFrame feature as free function to the ROOT module
+import cppyy
+cppyy.gbl.ROOT.RDF.MakeRDataFrame = MakeRDataFrame

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
@@ -59,7 +59,7 @@ static PyMethodDef gPyROOTMethods[] = {{(char *)"AddDirectoryWritePyz", (PyCFunc
                                         (char *)"Get size of data-type"},
                                        {(char *)"AsRVec", (PyCFunction)PyROOT::AsRVec, METH_O,
                                         (char *)"Get object with array interface as RVec"},
-                                       {(char *)"MakeRDataFrame", (PyCFunction)PyROOT::MakeRDataFrame, METH_O,
+                                       {(char *)"MakeNumpyDataFrame", (PyCFunction)PyROOT::MakeNumpyDataFrame, METH_O,
                                         (char *)"Make RDataFrame from dictionary of numpy arrays"},
                                        {NULL, NULL, 0, NULL}};
 

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
@@ -59,6 +59,8 @@ static PyMethodDef gPyROOTMethods[] = {{(char *)"AddDirectoryWritePyz", (PyCFunc
                                         (char *)"Get size of data-type"},
                                        {(char *)"AsRVec", (PyCFunction)PyROOT::AsRVec, METH_O,
                                         (char *)"Get object with array interface as RVec"},
+                                       {(char *)"MakeRDataFrame", (PyCFunction)PyROOT::MakeRDataFrame, METH_O,
+                                        (char *)"Make RDataFrame from dictionary of numpy arrays"},
                                        {NULL, NULL, 0, NULL}};
 
 #if PY_VERSION_HEX >= 0x03000000

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
@@ -27,7 +27,7 @@ PyObject *GetEndianess(PyObject *self);
 PyObject *GetVectorDataPointer(PyObject *self, PyObject *args);
 PyObject *GetSizeOfType(PyObject *self, PyObject *args);
 PyObject *AsRVec(PyObject *self, PyObject *obj);
-PyObject *MakeRDataFrame(PyObject *self, PyObject *obj);
+PyObject *MakeNumpyDataFrame(PyObject *self, PyObject *obj);
 
 } // namespace PyROOT
 

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
@@ -27,6 +27,7 @@ PyObject *GetEndianess(PyObject *self);
 PyObject *GetVectorDataPointer(PyObject *self, PyObject *args);
 PyObject *GetSizeOfType(PyObject *self, PyObject *args);
 PyObject *AsRVec(PyObject *self, PyObject *obj);
+PyObject *MakeRDataFrame(PyObject *self, PyObject *obj);
 
 } // namespace PyROOT
 

--- a/bindings/pyroot_experimental/PyROOT/src/RDataFramePyz.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/RDataFramePyz.cxx
@@ -40,6 +40,11 @@ PyObject *PyROOT::MakeNumpyDataFrame(PyObject * /*self*/, PyObject * pydata)
       return NULL;
    }
 
+   if (PyDict_Size(pydata) == 0) {
+      PyErr_SetString(PyExc_RuntimeError, "Object not convertible: Dictionary is empty.");
+      return NULL;
+   }
+
    // Iterate over dictionary, convert numpy arrays to RVecs and put together interpreter code
    PyObject *key, *value;
    Py_ssize_t pos = 0;

--- a/bindings/pyroot_experimental/PyROOT/src/RDataFramePyz.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/RDataFramePyz.cxx
@@ -28,7 +28,7 @@
 ///
 /// This function takes a dictionary of numpy arrays and creates an RDataFrame
 /// using the keys as column names and the numpy arrays as data.
-PyObject *PyROOT::MakeRDataFrame(PyObject * /*self*/, PyObject * pydata)
+PyObject *PyROOT::MakeNumpyDataFrame(PyObject * /*self*/, PyObject * pydata)
 {
    if (!pydata) {
       PyErr_SetString(PyExc_RuntimeError, "Object not convertible: Invalid Python object.");

--- a/bindings/pyroot_experimental/PyROOT/src/RDataFramePyz.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/RDataFramePyz.cxx
@@ -1,0 +1,95 @@
+// Author: Stefan Wunsch CERN  02/2019
+// Original PyROOT code by Wim Lavrijsen, LBL
+
+/*************************************************************************
+ * Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "CPyCppyy.h"
+#include "CPPInstance.h"
+#include "ProxyWrappers.h"
+#include "PyROOTPythonize.h"
+#include "RConfig.h"
+#include "TInterpreter.h"
+
+#include "ROOT/RDataFrame.hxx"
+#include "ROOT/RDF/PyROOTHelpers.hxx" // RResultPtrDummy
+
+#include <utility> // std::pair
+#include <sstream> // std::stringstream
+
+////////////////////////////////////////////////////////////////////////////
+/// \brief Make an RDataFrame from a dictionary of numpy arrays
+/// \param[in] pydata Dictionary with numpy arrays
+///
+/// This function takes a dictionary of numpy arrays and creates an RDataFrame
+/// using the keys as column names and the numpy arrays as data.
+PyObject *PyROOT::MakeRDataFrame(PyObject * /*self*/, PyObject * pydata)
+{
+   if (!pydata) {
+      PyErr_SetString(PyExc_RuntimeError, "Object not convertible: Invalid Python object.");
+      return NULL;
+   }
+
+   if (!PyDict_Check(pydata)) {
+      PyErr_SetString(PyExc_RuntimeError, "Object not convertible: Python object is not a dictionary.");
+      return NULL;
+   }
+
+   // Iterate over dictionary, convert numpy arrays to RVecs and put together interpreter code
+   PyObject *key, *value;
+   Py_ssize_t pos = 0;
+   std::string code = "ROOT::Internal::RDF::NewLazyDataFrame(";
+   auto pyvecs = PyDict_New();
+   while (PyDict_Next(pydata, &pos, &key, &value)) {
+      // Get name of key
+      if (!CPyCppyy_PyUnicode_Check(key)) {
+         PyErr_SetString(PyExc_RuntimeError, "Object not convertible: Dictionary key is not convertible to a string.");
+         return NULL;
+      }
+      std::string keystr = CPyCppyy_PyUnicode_AsString(key);
+
+      // Convert value to RVec and attach to dictionary
+      auto pyvec = PyROOT::AsRVec(NULL, value);
+      if (pyvec == NULL) {
+         PyErr_SetString(PyExc_RuntimeError,
+                         ("Object not convertible: Dictionary entry " + keystr + " is not convertible with AsRVec.").c_str());
+         return NULL;
+      }
+      PyDict_SetItem(pyvecs, key, pyvec);
+
+      // Prepare interpreter code
+      std::string vectype = Cppyy::GetScopedFinalName(((CPyCppyy::CPPInstance*)pyvec)->ObjectIsA());
+      std::string ptrtype = "ROOT::Internal::RDF::RResultPtrDummy<" + vectype + ">";
+      std::stringstream ss;
+      ss << ((CPyCppyy::CPPInstance*)pyvec)->GetObject();
+      auto vecaddress = ss.str();
+      code += "std::pair<std::string," + ptrtype +  ">(\"" + keystr
+           + "\"," + ptrtype + "(*reinterpret_cast<" + vectype+ "*>(" + vecaddress + ")))";
+      code += ",";
+   }
+   code.pop_back();
+   code += ");";
+
+   // Create RDataFrame and build Python proxy
+   auto address = (void*) gInterpreter->Calc(code.c_str());
+   auto klass = (Cppyy::TCppType_t)Cppyy::GetScope("ROOT::RDataFrame");
+   auto pyobj = CPyCppyy::BindCppObject(address, klass);
+
+   // Give Python the ownership of the underlying C++ object
+   ((CPyCppyy::CPPInstance*)pyobj)->PythonOwns();
+
+   // Bind pyobject holding adopted memory to the RVec
+   // TODO: Do we need to keep a reference to the data dictionary or is this
+   // already fixed by the reference from the rvec to the numpy arrays?
+   if (PyObject_SetAttrString(pyobj, "__data__", pyvecs)) {
+      PyErr_SetString(PyExc_RuntimeError, "Object not convertible: Failed to set dictionary as attribute __data__.");
+      return NULL;
+   }
+
+   return pyobj;
+}

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -33,6 +33,9 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_tarray_len tarray_len.py)
 # RVec and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_rvec_asrvec rvec_asrvec.py)
 
+# RDataFrame and subclasses pythonizations
+ROOT_ADD_PYUNITTEST(pyroot_pyz_rdataframe_makerdataframe rdataframe_makerdataframe.py)
+
 # RooAbsCollection and subclasses pythonizations
 if(ROOT_roofit_FOUND)
   ROOT_ADD_PYUNITTEST(pyroot_pyz_rooabscollection_len rooabscollection_len.py)

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -34,7 +34,7 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_tarray_len tarray_len.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_rvec_asrvec rvec_asrvec.py)
 
 # RDataFrame and subclasses pythonizations
-ROOT_ADD_PYUNITTEST(pyroot_pyz_rdataframe_makerdataframe rdataframe_makerdataframe.py)
+ROOT_ADD_PYUNITTEST(pyroot_pyz_rdataframe_numpy rdataframe_numpy.py)
 
 # RooAbsCollection and subclasses pythonizations
 if(ROOT_roofit_FOUND)

--- a/bindings/pyroot_experimental/PyROOT/test/rdataframe_makerdataframe.py
+++ b/bindings/pyroot_experimental/PyROOT/test/rdataframe_makerdataframe.py
@@ -1,0 +1,65 @@
+import unittest
+import ROOT
+import numpy as np
+import sys
+
+
+class MakeRDataFrame(unittest.TestCase):
+    """
+    Tests for the MakeRDataFrame feature enabling to read numpy arrays
+    with RDataFrame.
+    """
+
+    dtypes = [
+        "int32", "int64", "uint32", "uint64", "float32", "float64"
+    ]
+
+    def test_dtypes(self):
+        """
+        Test reading different datatypes
+        """
+        for dtype in self.dtypes:
+            data = {"x": np.array([1, 2, 3], dtype=dtype)}
+            df = ROOT.ROOT.RDF.MakeRDataFrame(data)
+            self.assertEqual(df.Mean("x").GetValue(), 2)
+
+    def test_multiple_columns(self):
+        """
+        Test reading multiple columns
+        """
+        data = {}
+        for dtype in self.dtypes:
+            data[dtype] = np.array([1, 2, 3], dtype=dtype)
+        df = ROOT.ROOT.RDF.MakeRDataFrame(data)
+        colnames = df.GetColumnNames()
+        # Test column names
+        for dtype in colnames:
+            self.assertIn(dtype, self.dtypes)
+        # Test mean
+        for dtype in self.dtypes:
+            self.assertEqual(df.Mean(dtype).GetValue(), 2)
+
+    def test_refcount(self):
+        """
+        Check refcounts of associated PyObjects
+        """
+        data = {"x": np.array([1, 2, 3], dtype="float32")}
+        self.assertEqual(sys.getrefcount(data), 2)
+        self.assertEqual(sys.getrefcount(data["x"]), 2)
+        df = ROOT.ROOT.RDF.MakeRDataFrame(data)
+        self.assertTrue(hasattr(df, "__data__"))
+        self.assertEqual(sys.getrefcount(data["x"]), 3)
+
+    def test_transformations(self):
+        """
+        Test the use of transformations
+        """
+        data = {"x": np.array([1, 2, 3], dtype="float32")}
+        df = ROOT.ROOT.RDF.MakeRDataFrame(data)
+        df2 = df.Filter("x>1").Define("y", "2*x")
+        self.assertEqual(df2.Mean("x").GetValue(), 2.5)
+        self.assertEqual(df2.Mean("y").GetValue(), 5)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bindings/pyroot_experimental/PyROOT/test/rdataframe_numpy.py
+++ b/bindings/pyroot_experimental/PyROOT/test/rdataframe_numpy.py
@@ -4,9 +4,9 @@ import numpy as np
 import sys
 
 
-class MakeRDataFrame(unittest.TestCase):
+class MakeNumpyDataFrame(unittest.TestCase):
     """
-    Tests for the MakeRDataFrame feature enabling to read numpy arrays
+    Tests for the MakeNumpyDataFrame feature enabling to read numpy arrays
     with RDataFrame.
     """
 
@@ -20,7 +20,7 @@ class MakeRDataFrame(unittest.TestCase):
         """
         for dtype in self.dtypes:
             data = {"x": np.array([1, 2, 3], dtype=dtype)}
-            df = ROOT.ROOT.RDF.MakeRDataFrame(data)
+            df = ROOT.ROOT.RDF.MakeNumpyDataFrame(data)
             self.assertEqual(df.Mean("x").GetValue(), 2)
 
     def test_multiple_columns(self):
@@ -30,7 +30,7 @@ class MakeRDataFrame(unittest.TestCase):
         data = {}
         for dtype in self.dtypes:
             data[dtype] = np.array([1, 2, 3], dtype=dtype)
-        df = ROOT.ROOT.RDF.MakeRDataFrame(data)
+        df = ROOT.ROOT.RDF.MakeNumpyDataFrame(data)
         colnames = df.GetColumnNames()
         # Test column names
         for dtype in colnames:
@@ -46,7 +46,7 @@ class MakeRDataFrame(unittest.TestCase):
         data = {"x": np.array([1, 2, 3], dtype="float32")}
         self.assertEqual(sys.getrefcount(data), 2)
         self.assertEqual(sys.getrefcount(data["x"]), 2)
-        df = ROOT.ROOT.RDF.MakeRDataFrame(data)
+        df = ROOT.ROOT.RDF.MakeNumpyDataFrame(data)
         self.assertTrue(hasattr(df, "__data__"))
         self.assertEqual(sys.getrefcount(data["x"]), 3)
 
@@ -55,7 +55,7 @@ class MakeRDataFrame(unittest.TestCase):
         Test the use of transformations
         """
         data = {"x": np.array([1, 2, 3], dtype="float32")}
-        df = ROOT.ROOT.RDF.MakeRDataFrame(data)
+        df = ROOT.ROOT.RDF.MakeNumpyDataFrame(data)
         df2 = df.Filter("x>1").Define("y", "2*x")
         self.assertEqual(df2.Mean("x").GetValue(), 2.5)
         self.assertEqual(df2.Mean("y").GetValue(), 5)

--- a/bindings/pyroot_experimental/PyROOT/test/rdataframe_numpy.py
+++ b/bindings/pyroot_experimental/PyROOT/test/rdataframe_numpy.py
@@ -60,6 +60,15 @@ class MakeNumpyDataFrame(unittest.TestCase):
         self.assertEqual(df2.Mean("x").GetValue(), 2.5)
         self.assertEqual(df2.Mean("y").GetValue(), 5)
 
+    def test_delete_dict(self):
+        """
+        Test behaviour with data dictionary going out of scope
+        """
+        data = {"x": np.array([1, 2, 3], dtype="float32")}
+        df = ROOT.ROOT.RDF.MakeNumpyDataFrame(data)
+        del data
+        self.assertEqual(df.Mean("x").GetValue(), 2)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -2098,7 +2098,7 @@ private:
       RDFInternal::CheckTypesAndPars(sizeof...(BranchTypes), columnList.size());
 
       auto colHolders = std::make_tuple(Take<BranchTypes>(columnList[S])...);
-      auto ds = std::make_unique<RLazyDS<BranchTypes...>>(std::make_pair(columnList[S], std::get<S>(colHolders))...);
+      auto ds = std::make_unique<RLazyDS<RResultPtr<std::vector<BranchTypes>>...>>(std::make_pair(columnList[S], std::get<S>(colHolders))...);
 
       RInterface<RLoopManager> cachedRDF(std::make_shared<RLoopManager>(std::move(ds), columnList));
 

--- a/tree/dataframe/inc/ROOT/RLazyDS.hxx
+++ b/tree/dataframe/inc/ROOT/RLazyDS.hxx
@@ -24,11 +24,11 @@ namespace RDF {
 /// \brief Factory method to create a Lazy RDataFrame.
 /// \param[in] colNameProxyPairs the series of pairs to describe the columns of the data source, first element of the pair is the name of the column and the second is the RResultPtr to the column in the parent data frame.
 // clang-format on
-template <typename... ColumnTypes>
-RDataFrame MakeLazyDataFrame(std::pair<std::string, RResultPtr<std::vector<ColumnTypes>>> &&... colNameProxyPairs)
+template <typename... Columns>
+RDataFrame MakeLazyDataFrame(std::pair<std::string, Columns> &&... colNameProxyPairs)
 {
-   RDataFrame tdf(std::make_unique<RLazyDS<ColumnTypes...>>(
-      std::forward<std::pair<std::string, RResultPtr<std::vector<ColumnTypes>>>>(colNameProxyPairs)...));
+   RDataFrame tdf(std::make_unique<RLazyDS<Columns...>>(
+      std::forward<std::pair<std::string, Columns>>(colNameProxyPairs)...));
    return tdf;
 }
 

--- a/tree/dataframe/inc/ROOT/RLazyDS.hxx
+++ b/tree/dataframe/inc/ROOT/RLazyDS.hxx
@@ -27,9 +27,8 @@ namespace RDF {
 template <typename... Columns>
 RDataFrame MakeLazyDataFrame(std::pair<std::string, Columns> &&... colNameProxyPairs)
 {
-   RDataFrame tdf(std::make_unique<RLazyDS<Columns...>>(
+   return RDataFrame(std::make_unique<RLazyDS<Columns...>>(
       std::forward<std::pair<std::string, Columns>>(colNameProxyPairs)...));
-   return tdf;
 }
 
 } // ns RDF

--- a/tree/dataframe/test/datasource_lazy.cxx
+++ b/tree/dataframe/test/datasource_lazy.cxx
@@ -1,5 +1,6 @@
 #include <ROOT/RDataFrame.hxx>
 #include <ROOT/RLazyDS.hxx>
+#include <ROOT/RResultPtr.hxx>
 #include <ROOT/TSeq.hxx>
 
 #include <gtest/gtest.h>
@@ -17,7 +18,7 @@ TEST(RLazyDS, Constructor)
    auto col1Init = 1.f;
    auto col0 = d.Define(col0Name, [&col0Init]() { return col0Init += 1.; }).Take<double>(col0Name);
    auto col1 = d.Define(col1Name, [&col1Init]() { return col1Init += 1.f; }).Take<float>(col1Name);
-   RLazyDS<double, float> tds({col0Name, col0}, {col1Name, col1});
+   RLazyDS<RResultPtr<std::vector<double>>, RResultPtr<std::vector<float>>> tds({col0Name, col0}, {col1Name, col1});
 
    auto colNames = tds.GetColumnNames();
    EXPECT_EQ(2U, colNames.size());
@@ -67,7 +68,7 @@ TEST(RLazyDS, RangesOneSlot)
    auto col0Name = "col0";
    auto col0Init = 0.;
    auto col0 = d.Define(col0Name, [&col0Init]() { return col0Init += 1.; }).Take<double>(col0Name);
-   RLazyDS<double> tds({col0Name, col0});
+   RLazyDS<RResultPtr<std::vector<double>>> tds({col0Name, col0});
 
    tds.SetNSlots(1);
    auto col0Readers = tds.GetColumnReaders<double>(col0Name);
@@ -87,7 +88,7 @@ TEST(RLazyDS, ColSizesCheck)
    auto col0 = d0.Define(colName, gend).Take<double>(colName);
    ROOT::RDataFrame d1(2);
    auto col1 = d1.Define(colName, genf).Take<float>(colName);
-   RLazyDS<double, float> tds({"zero", col0}, {"one", col1});
+   RLazyDS<RResultPtr<std::vector<double>>, RResultPtr<std::vector<float>>> tds({"zero", col0}, {"one", col1});
    tds.SetNSlots(4);
    int ret(1);
    try {


### PR DESCRIPTION
This PR implements the feature to read numpy arrays with `RDataFrame`. See following example for the use-case:

```python
data = {
    "x": numpy.array([1, 2, 3]),
    "y": numpy.array([4, 5, 6])
}

df = ROOT.ROOT.RDF.MakeNumpyDataFrame(data)
df2 = df.Filter("x>1").Define("z", "x*y")

assert(df2.Mean("z").GetValue(), 14)
```

Edit: Up to now it works only with C++17 since `std::string_view` is not yet available in experimental PyROOT as backport.
Edit: Renamed `MakeRDataFrame` to `MakeNumpyDataFrame`.