### PR TITLE
Fix RArrowDS to support rewinding

### DIFF
--- a/tree/dataframe/src/RArrowDS.cxx
+++ b/tree/dataframe/src/RArrowDS.cxx
@@ -265,6 +265,7 @@ public:
       auto chunk = fChunks.at(fLastChunkPerSlot[slot]);
       assert(slot < fArrayVisitorPerSlot.size());
       fArrayVisitorPerSlot[slot].SetEntry(entry - fFirstEntryPerChunk[fLastChunkPerSlot[slot]]);
+      fLastEntryPerSlot[slot] = entry;
       auto status = chunk->Accept(fArrayVisitorPerSlot.data() + slot);
       if (!status.ok()) {
          std::string msg = "Could not get pointer for slot ";


### PR DESCRIPTION
Without this it currently works fine because RDataFrame does not rewind a DataSource while doing a run on it. However the new RCombinedDS (a RDataSource which iterates on the cartesian product of two other datasources) which I just implemented exposes the issue  because the above mentioned condition is not true anymore. This corrects the bug by effectively moving the cached cursor.