### PR TITLE
[NOBUILD][PyROOT exp] Fix implicit import of TIter

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tcollection.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tcollection.py
@@ -9,7 +9,7 @@
 ################################################################################
 
 from ROOT import pythonization
-from cppyy.gbl import TIter
+import cppyy
 
 from ._generic import add_len
 
@@ -87,7 +87,7 @@ def _iter_pyz(self):
     # Generator function to iterate on TCollections
     # Parameters:
     # - self: collection to be iterated
-    it = TIter(self)
+    it = cppyy.gbl.TIter(self)
     o = it.Next()
     while o:
         yield o


### PR DESCRIPTION
Omit explicit import of TIter since this triggers cppyy to fetch the class upon importing ROOT. Acessing TIter through cppyy.gbl.TIter does the same job lazily.