### PR TITLE
[DF] Breaking change: expose type of Defined column from RInterface 

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -48,9 +48,9 @@ class RNodeBase;
 namespace RDF {
 template <typename T>
 class RResultPtr;
-template<typename T, typename V>
+template<typename T, typename DS, typename Def>
 class RInterface;
-using RNode = RInterface<::ROOT::Detail::RDF::RNodeBase, void>;
+using RNode = RInterface<::ROOT::Detail::RDF::RNodeBase, void, void>;
 class RDataSource;
 } // namespace RDF
 
@@ -77,7 +77,7 @@ bool InterpreterDeclare(const std::string &code);
 //   - 1 otherwise
 std::pair<Long64_t, int> InterpreterCalc(const std::string &code);
 
-using HeadNode_t = ::ROOT::RDF::RResultPtr<RInterface<RLoopManager, void>>;
+using HeadNode_t = ::ROOT::RDF::RResultPtr<RInterface<RLoopManager, void, void>>;
 HeadNode_t CreateSnaphotRDF(const ColumnNames_t &validCols,
                             std::string_view treeName,
                             std::string_view fileName,

--- a/tree/dataframe/inc/ROOT/RDFHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFHelpers.hxx
@@ -101,9 +101,6 @@ auto PassAsVec(F &&f) -> RDFInternal::PassAsVecHelper<std::make_index_sequence<N
 {
    return RDFInternal::PassAsVecHelper<std::make_index_sequence<N>, T, F>(std::forward<F>(f));
 }
-template <typename Proxied, typename DataSource>
-class RInterface;
-
 
 // clang-format off
 /// Create a graphviz representation of the dataframe computation graph, return it as a string.

--- a/tree/dataframe/test/dataframe_callbacks.cxx
+++ b/tree/dataframe/test/dataframe_callbacks.cxx
@@ -14,7 +14,7 @@ static constexpr ULong64_t gNEvents = 8ull;
 class RDFCallbacks : public ::testing::Test {
 private:
    ROOT::RDataFrame fLoopManager;
-   RInterface<RLoopManager> DefineRandomCol()
+   RNode DefineRandomCol()
    {
       TRandom r;
       return fLoopManager.Define("x", [r]() mutable { return r.Gaus(); });
@@ -22,7 +22,7 @@ private:
 
 protected:
    RDFCallbacks() : fLoopManager(gNEvents), tdf(DefineRandomCol()) {}
-   RInterface<RLoopManager> tdf;
+   RNode tdf;
 };
 
 #ifdef R__USE_IMT
@@ -40,7 +40,7 @@ class RDFCallbacksMT : public ::testing::Test {
 private:
    TIMTEnabler fIMTEnabler;
    ROOT::RDataFrame fLoopManager;
-   RInterface<RLoopManager> DefineRandomCol()
+   RNode DefineRandomCol()
    {
       std::vector<TRandom> rs(gNSlots);
       return fLoopManager.DefineSlot("x", [rs](unsigned int slot) mutable { return rs[slot].Gaus(); });
@@ -48,7 +48,7 @@ private:
 
 protected:
    RDFCallbacksMT() : fIMTEnabler(gNSlots), fLoopManager(gNEvents), tdf(DefineRandomCol()) {}
-   RInterface<RLoopManager> tdf;
+   RNode tdf;
 };
 #endif
 

--- a/tree/dataframe/test/dataframe_snapshot.cxx
+++ b/tree/dataframe/test/dataframe_snapshot.cxx
@@ -20,14 +20,14 @@ protected:
 
 private:
    RDataFrame fTdf;
-   RInterface<RLoopManager> DefineAns()
+   RNode DefineAns()
    {
       return fTdf.Define("ans", []() { return 42; });
    }
 
 protected:
    RDFSnapshot() : fTdf(nEvents), tdf(DefineAns()) {}
-   RInterface<RLoopManager> tdf;
+   RNode tdf;
 };
 
 #ifdef R__USE_IMT
@@ -47,14 +47,14 @@ protected:
 private:
    TIMTEnabler fIMTEnabler;
    RDataFrame fTdf;
-   RInterface<RLoopManager> DefineAns()
+   RNode DefineAns()
    {
       return fTdf.Define("ans", []() { return 42; });
    }
 
 protected:
    RDFSnapshotMT() : fIMTEnabler(kNSlots), fTdf(kNEvents), tdf(DefineAns()) {}
-   RInterface<RLoopManager> tdf;
+   RNode tdf;
 };
 #endif // R__USE_IMT
 
@@ -168,7 +168,7 @@ TEST_F(RDFSnapshot, Snapshot_nocolumnmatch)
    gSystem->Unlink(fname);
 }
 
-void test_snapshot_update(RInterface<RLoopManager> &tdf)
+void test_snapshot_update(RNode tdf)
 {
    // test snapshotting two trees to the same file with two snapshots and the "UPDATE" option
    const auto outfile = "snapshot_test_update.root";
@@ -210,7 +210,7 @@ TEST_F(RDFSnapshot, Snapshot_update)
    test_snapshot_update(tdf);
 }
 
-void test_snapshot_options(RInterface<RLoopManager> &tdf)
+void test_snapshot_options(RNode tdf)
 {
    RSnapshotOptions opts;
    opts.fAutoFlush = 10;


### PR DESCRIPTION
This allows to write the following:

```c++
auto df2 = df.Define("x", [](int x, int y) { return SomeFunction(x, y); }, {"y", "z"});
using x_type = decltype(df2)::DefinedCol_t;
auto df3 = df.Define("w", [](x_type x) { return x*x; }, {"x"});
```

where `x_type` is the type of the Defined column "x".

EDIT: the breakage comes from a change in the type returned by a non-jitted `Define`.
Very few and expert users should ever even care what this type is in the first place, but still.