### PR TITLE
Fixing notfn a bit more clearly

### DIFF
--- a/core/foundation/inc/ROOT/RNotFn.hxx
+++ b/core/foundation/inc/ROOT/RNotFn.hxx
@@ -14,7 +14,10 @@
 #ifndef ROOT_RNotFn
 #define ROOT_RNotFn
 
-#if __cplusplus < 201703L && !defined(_MSC_VER)
+#include <functional>
+
+// Backport if not_fn is not available
+#ifndef __cpp_lib_not_fn
 
 #include <type_traits> // std::decay
 #include <utility>     // std::forward, std::declval
@@ -54,8 +57,6 @@ Detail::not_fn_t<F> not_fn(F &&f)
 }
 }
 
-#else
-#include <functional>
 #endif
 
 #endif

--- a/core/foundation/test/testNotFn.cxx
+++ b/core/foundation/test/testNotFn.cxx
@@ -1,9 +1,6 @@
-// Including functional for __cpp_lib_not_fn
-#include <functional>
+#include "ROOT/RNotFn.hxx"
 
 #ifndef __cpp_lib_not_fn
-
-#include "ROOT/RNotFn.hxx"
 
 #include "gtest/gtest.h"
 


### PR DESCRIPTION
This is a better fix for not_fn, where the check is now applied in the right place, and the test runs regardless (it could check for the not_fn define as well). Followup to #3413 . 