### PR TITLE
Fix v7 line tutorial when running in batch mode

### DIFF
--- a/tutorials/v7/line.cxx
+++ b/tutorials/v7/line.cxx
@@ -6,7 +6,6 @@
 /// "normal" coordinates' system and changing the line color linearly from black
 /// to red.
 ///
-/// \macro_image (line.png)
 /// \macro_code
 ///
 /// \date 2018-03-18
@@ -43,6 +42,5 @@ void line()
    canvas->Draw(RLine({0.1_normal, 0.1_normal}, {0.1_normal,0.9_normal}));
    canvas->Draw(RLine({0.0_normal, 1.0_normal}, {1.0_normal,0.0_normal}));
 
-  // canvas->Show();
-   canvas->SaveAs("line.png");
+   canvas->Show();
 }


### PR DESCRIPTION
The v7/line.cxx tutorial fails when run in batch mode with an error about that the DISPLAY can not be opened. Since this tutorial is part of the test suite this causes the tests to fail. This problem started due to some recent changes to the test. This PR reverts some of those changes to make the test work again.
