### PR TITLE
Don't install eve7 files if eve7 is not built

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,17 +446,16 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_INSTALL_PREFIX)
   else()
     install(DIRECTORY README DESTINATION ${CMAKE_INSTALL_DOCDIR})
   endif()
+  if (NOT root7)
+    set(excludeeve7 PATTERN "eve7" EXCLUDE)
+  endif()
   install(DIRECTORY etc/ DESTINATION ${CMAKE_INSTALL_SYSCONFDIR} USE_SOURCE_PERMISSIONS
                          PATTERN "system.rootrc" EXCLUDE
                          PATTERN "system.rootauthrc" EXCLUDE
                          PATTERN "system.rootdaemonrc" EXCLUDE
-                         PATTERN "rootd.rc.d" EXCLUDE
-                         PATTERN "proofd.rc.d" EXCLUDE
-                         PATTERN "rootd.xinetd" EXCLUDE
-                         PATTERN "proofd.xinetd" EXCLUDE
                          PATTERN "root.mimes" EXCLUDE
-                         PATTERN "cmake" EXCLUDE
-                         PATTERN "*.in" EXCLUDE)
+                         PATTERN "*.in" EXCLUDE
+                         ${excludeeve7})
   install(DIRECTORY fonts/  DESTINATION ${CMAKE_INSTALL_FONTDIR})
   install(DIRECTORY icons/  DESTINATION ${CMAKE_INSTALL_ICONDIR})
   install(DIRECTORY macros/ DESTINATION ${CMAKE_INSTALL_MACRODIR})


### PR DESCRIPTION
The eve7 extension is built conditionally when the root7 option is enabled. The files in etc/eve7 used by this extension should only be installed when the extension is built.
In addition this PR also removes some obsolete patterns from the install rule that are no longer necessary because the files they refer to are no longer in the source tree.
