### PR TITLE
[meta] Determine the clang-based file name lazily (ROOT-9963):

### DIFF
--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -392,7 +392,7 @@ public:
    Int_t              GetClassSize() const { return Size(); }
    TDataMember       *GetDataMember(const char *datamember) const;
    Long_t             GetDataMemberOffset(const char *membername) const;
-   const char        *GetDeclFileName() const { return fDeclFileName; }
+   const char        *GetDeclFileName() const;
    Short_t            GetDeclFileLine() const { return fDeclFileLine; }
    ROOT::DelFunc_t    GetDelete() const;
    ROOT::DesFunc_t    GetDestructor() const;

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -123,6 +123,9 @@ using namespace std;
 TVirtualMutex* gInterpreterMutex = 0;
 
 namespace {
+
+   static constexpr const char kUndeterminedClassInfoName[] = "<NOT YET DETERMINED FROM fClassInfo>";
+
    class TMmallocDescTemp {
    private:
       void *fSave;
@@ -1525,7 +1528,7 @@ void TClass::Init(const char *name, Version_t cversion,
    if (fClassInfo) {
       SetTitle(gCling->ClassInfo_Title(fClassInfo));
       if ( fDeclFileName == 0 || fDeclFileName[0] == '\0' ) {
-         fDeclFileName = gInterpreter->ClassInfo_FileName( fClassInfo );
+	fDeclFileName = kUndeterminedClassInfoName;
          // Missing interface:
          // fDeclFileLine = gInterpreter->ClassInfo_FileLine( fClassInfo );
 
@@ -3294,6 +3297,16 @@ TDataMember *TClass::GetDataMember(const char *datamember) const
    } else {
       return (TDataMember *)((TClass*)this)->GetListOfDataMembers(kFALSE)->FindObject(start_name);
    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Return name of the file containing the declaration of this class.
+
+const char *TClass::GetDeclFileName() const
+{
+   if (fDeclFileName == kUndeterminedClassInfoName)
+      return gInterpreter->ClassInfo_FileName( fClassInfo );
+   return fDeclFileName;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -827,6 +827,8 @@ int TClingClassInfo::InternalNext()
 {
    R__LOCKGUARD(gInterpreterMutex);
 
+   fDeclFileName.clear(); // invalidate decl file name.
+
    cling::Interpreter::PushTransactionRAII RAII(fInterp);
    if (fFirstTime) {
       // fDecl must be a DeclContext in order to iterate.
@@ -1231,7 +1233,8 @@ const char *TClingClassInfo::FileName()
    if (!IsValid()) {
       return 0;
    }
-   fDeclFileName = ROOT::TMetaUtils::GetFileName(*GetDecl(), *fInterp);
+   if (fDeclFileName.empty())
+     fDeclFileName = ROOT::TMetaUtils::GetFileName(*GetDecl(), *fInterp);
    return fDeclFileName.c_str();
 }
 


### PR DESCRIPTION
HeaderSearch consumes considerable wallclock time and memory for ATLAS; this should reduce it.