### PR TITLE
Removed cuda flag

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1361,6 +1361,7 @@ endif()
 #---Check for CUDA and BLAS ---------------------------------------------------------
 if(tmva AND tmva-gpu)
   message(STATUS "Looking for CUDA for optional parts of TMVA")
+  set(cuda ON CACHE BOOL "Enabled the cuda flag for TMVA-GPU" FORCE)
 
   if(CMAKE_CXX_STANDARD EQUAL 11)
     find_package(CUDA 7.5)

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1359,7 +1359,7 @@ if (vecgeom)
 endif()
 
 #---Check for CUDA and BLAS ---------------------------------------------------------
-if(tmva AND cuda AND tmva-gpu)
+if(tmva AND tmva-gpu)
   message(STATUS "Looking for CUDA for optional parts of TMVA")
 
   if(CMAKE_CXX_STANDARD EQUAL 11)


### PR DESCRIPTION
TMVA GPU features are enabled only when both the cuda and tmva-gpu flags are enabled. These flags are not used anywhere else. It looks like the cuda flag is redundant in this case. 

Related forum post - https://root-forum.cern.ch/t/feature-request-enable-cuda-if-detected/32764