### PR TITLE
config: fix platform check for dataframe to match source

### DIFF
--- a/config/root-config.in
+++ b/config/root-config.in
@@ -76,7 +76,7 @@ rootlibs="-lCore -lImt -lRIO -lNet -lHist -lGraf -lGraf3d -lGpad -lROOTVecOps -l
           -lRint -lPostscript -lMatrix -lPhysics -lMathCore -lThread\
           -lMultiProc"
 
-if [ `uname -m` != 'i686' ]; then
+if [ "@UNIX@" != "1" ] || [ "@CMAKE_SIZEOF_VOID_P@" != "4" ]; then
    rootlibs="$rootlibs -lROOTDataFrame"
 fi
 


### PR DESCRIPTION
There's a bug on 32-bit non-intel such as armv7l where root-config lists `-lROOTDataFrame`  because it passes the check this patch adjusts, but libROOTDataFrame is not built on any 32-bit due to https://github.com/root-project/root/blob/v6-16-00-patches/tree/dataframe/CMakeLists.txt#L7 .

Old check only hid DataFrame on i686; this patch changes the check to have the exact same conditions as the check for building DataFrame itself to prevent build failures in apps using root-config.