### PR TITLE
[cxxmodules] Sink the interface for loading a module in cling.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1077,9 +1077,17 @@ static bool LoadModule(const std::string &ModuleName, cling::Interpreter &interp
    if (interp.loadModule(ModuleName, Complain))
       return true;
 
-   // Load modulemap if we have one in current directory
+   // When starting up ROOT, cling would load all modulemap files on the include
+   // paths. However, in a ROOT session, it is very common to run aclic which
+   // will invoke rootcling and possibly produce a modulemap and a module in
+   // the current folder.
+   //
+   // Before failing, try loading the modulemap in the current folder and try
+   // loading the requested module from it.
    Preprocessor &PP = interp.getCI()->getPreprocessor();
    FileManager& FM = PP.getFileManager();
+   // FIXME: In a ROOT session we can add an include path (through .I /inc/path)
+   // We should look for modulemap files there too.
    const DirectoryEntry *DE = FM.getDirectory(".");
    if (DE) {
       HeaderSearch& HS = PP.getHeaderSearchInfo();

--- a/interpreter/cling/include/cling/Interpreter/Interpreter.h
+++ b/interpreter/cling/include/cling/Interpreter/Interpreter.h
@@ -40,6 +40,7 @@ namespace clang {
   class FunctionDecl;
   class GlobalDecl;
   class MacroInfo;
+  class Module;
   class NamedDecl;
   class Parser;
   class Preprocessor;
@@ -479,16 +480,23 @@ namespace cling {
     ///
     CompilationResult parse(const std::string& input,
                             Transaction** T = 0) const;
+    /// Loads a C++ Module with a given name by synthesizing an Import decl.
+    /// This routine checks if there is a modulemap in the current directory
+    /// and loads it.
+    ///
+    /// This is useful when we start up the interpreter and programatically,
+    /// later generate a modulemap.
+    ///
+    ///\returns true if the module was loaded.
+    ///
+    bool loadModule(const std::string& moduleName, bool complain = true);
 
-    ///\brief Looks for a already generated PCM for the given header file and
-    /// loads it.
+    /// Loads a C++ Module with a given name by synthesizing an Import decl.
+    /// This routine checks if there is a modulemap in the current directory
+    /// and loads it.
     ///
-    ///\param[in] headerFile - The header file for which a module should be
-    ///                        loaded.
-    ///
-    ///\returns Whether the operation was fully successful.
-    ///
-    CompilationResult loadModuleForHeader(const std::string& headerFile);
+    ///\returns true if the module was loaded or already visible.
+    bool loadModule(clang::Module* M, bool complain = true);
 
     ///\brief Parses input line, which doesn't contain statements. Code
     /// generation needed to make the module functional.


### PR DESCRIPTION
This patch prepares the infrastructure to be able to work with a
global module index.