### PR TITLE
[Exp PyROOT] Pythonisations for TObject

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
@@ -17,6 +17,7 @@ set(py_sources
   ROOT/pythonization/_tdirectory.py
   ROOT/pythonization/_tdirectoryfile.py
   ROOT/pythonization/_tfile.py
+  ROOT/pythonization/_tobject.py
   ROOT/pythonization/_tseqcollection.py
   ROOT/pythonization/_ttree.py
 )

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tobject.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tobject.py
@@ -1,0 +1,33 @@
+# Author: Enric Tejedor CERN  02/2019
+
+################################################################################
+# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from ROOT import pythonization
+import cppyy
+
+# Searching
+
+def _contains(self, o):
+	# Relies on TObject::FindObject
+    # Parameters:
+    # - self: object where to search
+    # - o: object to be searched in self
+    # Returns:
+    # - True if self contains o
+    return bool(self.FindObject(o))
+
+
+@pythonization(lazy = False)
+def pythonize_tobject():
+	klass = cppyy.gbl.TObject
+
+	# Allow 'obj in container' syntax for searching
+	klass.__contains__ = _contains
+
+	return True

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tobject.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tobject.py
@@ -14,7 +14,7 @@ import cppyy
 # Searching
 
 def _contains(self, o):
-	# Relies on TObject::FindObject
+    # Relies on TObject::FindObject
     # Parameters:
     # - self: object where to search
     # - o: object to be searched in self
@@ -22,12 +22,58 @@ def _contains(self, o):
     # - True if self contains o
     return bool(self.FindObject(o))
 
+# Comparison operators
+
+def _eq(self, o):
+    if isinstance(o, cppyy.gbl.TObject):
+        return self.IsEqual(o)
+    else:
+        return False
+
+def _ne(self, o):
+    if isinstance(o, cppyy.gbl.TObject):
+        return not self.IsEqual(o)
+    else:
+        return True
+
+def _lt(self, o):
+    if isinstance(o, cppyy.gbl.TObject):
+        return self.Compare(o) == -1
+    else:
+        return NotImplemented
+
+def _le(self, o):
+    if isinstance(o, cppyy.gbl.TObject):
+        return self.Compare(o) <= 0
+    else:
+        return NotImplemented
+
+def _gt(self, o):
+    if isinstance(o, cppyy.gbl.TObject):
+        return self.Compare(o) == 1
+    else:
+        return NotImplemented
+
+def _ge(self, o):
+    if isinstance(o, cppyy.gbl.TObject):
+        return self.Compare(o) >= 0
+    else:
+        return NotImplemented
+
 
 @pythonization(lazy = False)
 def pythonize_tobject():
-	klass = cppyy.gbl.TObject
+    klass = cppyy.gbl.TObject
 
-	# Allow 'obj in container' syntax for searching
-	klass.__contains__ = _contains
+    # Allow 'obj in container' syntax for searching
+    klass.__contains__ = _contains
 
-	return True
+    # Inject comparison operators
+    klass.__eq__ = _eq
+    klass.__ne__ = _ne
+    klass.__lt__ = _lt
+    klass.__le__ = _le
+    klass.__gt__ = _gt
+    klass.__ge__ = _ge
+
+    return True

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -4,6 +4,7 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_array_interface array_interface.py)
 
 # TObject and subclasses pythonisations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tobject_contains tobject_contains.py)
+ROOT_ADD_PYUNITTEST(pyroot_pyz_tobject_comparisonops tobject_comparisonops.py)
 
 # TDirectory and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tdirectory_attrsyntax tdirectory_attrsyntax.py)

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -2,6 +2,9 @@
 ROOT_ADD_PYUNITTEST(pyroot_pyz_pretty_printing pretty_printing.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_array_interface array_interface.py)
 
+# TObject and subclasses pythonisations
+ROOT_ADD_PYUNITTEST(pyroot_pyz_tobject_contains tobject_contains.py)
+
 # TDirectory and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tdirectory_attrsyntax tdirectory_attrsyntax.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tdirectoryfile_attrsyntax_get tdirectoryfile_attrsyntax_get.py)

--- a/bindings/pyroot_experimental/PyROOT/test/tobject_comparisonops.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tobject_comparisonops.py
@@ -1,0 +1,99 @@
+import unittest
+
+import ROOT
+from ROOT import TUrl
+
+
+class TObjectComparisonOps(unittest.TestCase):
+    """
+    Test for the comparison operators of TObject and subclasses:
+    __eq__, __ne__, __lt__, __le__, __gt__, __ge__.
+    Such pythonisations rely on TObject::IsEqual and TObject::Compare,
+    which can be reimplemented in subclasses.
+    """
+
+    num_elems = 3
+
+    # Tests
+    def test_eq(self):
+        o = ROOT.TObject()
+
+        # TObject::IsEqual compares internal address
+        self.assertTrue(o == o)
+
+        # Test comparison with no TObject
+        self.assertFalse(o == 1)
+
+    def test_ne(self):
+        o = ROOT.TObject()
+
+        # TObject::IsEqual compares internal address
+        self.assertFalse(o != o)
+
+        # Test comparison with no TObject
+        self.assertTrue(o != 1)
+
+    def test_lt(self):
+        a = TUrl("a")
+        b = TUrl("b")
+
+        # TUrl::Compare compares URL strings
+        self.assertTrue(a < b)
+        self.assertFalse(b < a)
+
+        # Test comparison with no TObject
+        self.assertEqual(a.__lt__(1), NotImplemented)
+
+    def test_le(self):
+        a1 = TUrl("a")
+        a2 = TUrl("a")
+        b  = TUrl("b")
+
+        # TUrl::Compare compares URL strings
+        self.assertTrue(a1 <= a2)
+        self.assertTrue(a2 <= a1)
+        self.assertTrue(a1 <= b)
+        self.assertFalse(b <= a1)
+
+        # Test comparison with no TObject
+        self.assertEqual(a1.__le__(1), NotImplemented)
+
+    def test_gt(self):
+        a = TUrl("a")
+        b = TUrl("b")
+
+        # TUrl::Compare compares URL strings
+        self.assertFalse(a > b)
+        self.assertTrue(b > a)
+
+        # Test comparison with no TObject
+        self.assertEqual(a.__gt__(1), NotImplemented)
+
+    def test_ge(self):
+        a1 = TUrl("a")
+        a2 = TUrl("a")
+        b  = TUrl("b")
+
+        # TUrl::Compare compares URL strings
+        self.assertTrue(a1 >= a2)
+        self.assertTrue(a2 >= a1)
+        self.assertTrue(b >= a1)
+        self.assertFalse(a1 >= b)
+
+        # Test comparison with no TObject
+        self.assertEqual(a1.__ge__(1), NotImplemented)
+
+    def test_list_sort(self):
+        l1 = [ ROOT.TUrl(str(i)) for i in range(self.num_elems) ]
+        l2 = list(reversed(l1))
+
+        self.assertNotEqual(l1, l2)
+
+        # Test that comparison operators enable list sorting
+        l2.sort()
+
+        self.assertEqual(l1, l2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bindings/pyroot_experimental/PyROOT/test/tobject_contains.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tobject_contains.py
@@ -1,0 +1,44 @@
+import unittest
+
+import ROOT
+from libcppyy import SetOwnership
+
+
+class TObjectContains(unittest.TestCase):
+    """
+    Test for the __contains__ pythonisation of TObject and subclasses.
+    Such pythonisation relies on TObject::FindObject, which is redefined
+    in some of its subclasses, such as TCollection.
+    Thanks to this pythonisation, we can use the syntax `obj in col`
+    to know if col contains obj.
+    """
+
+    num_elems = 3
+
+    # Helpers
+    def create_tlist(self):
+        l = ROOT.TList()
+        for _ in range(self.num_elems):
+            o = ROOT.TObject()
+            # Prevent immediate deletion of C++ TObjects
+            SetOwnership(o, False)
+            l.Add(o)
+
+        return l
+
+    # Tests
+    def test_contains(self):
+        l = self.create_tlist()
+
+        for elem in l:
+            self.assertTrue(elem in l)
+            # Make sure it does not work just because of __iter__
+            self.assertTrue(l.__contains__(elem))
+
+        o = ROOT.TObject()
+        self.assertFalse(o in l)
+        self.assertFalse(l.__contains__(o))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR includes two sets of pythonisations for `TObject`:
- Injection of `__contains__` to support 'obj1 in obj2` syntax
https://sft.its.cern.ch/jira/browse/ROOT-9968
- Addition of comparison operators
https://sft.its.cern.ch/jira/browse/ROOT-9969