### PR TITLE
Add possibility to set model function (and also data) when using Fitter::FitFCN. 

### DIFF
--- a/hist/hist/src/TBinomialEfficiencyFitter.cxx
+++ b/hist/hist/src/TBinomialEfficiencyFitter.cxx
@@ -85,6 +85,8 @@ weighted histograms (because the likelihood computation will be incorrect).
 #include "Fit/Fitter.h"
 #include "TFitResult.h"
 #include "Math/Functor.h"
+#include "Math/Functor.h"
+#include "Math/WrappedTF1.h"
 
 #include <limits>
 
@@ -273,7 +275,9 @@ TFitResultPtr TBinomialEfficiencyFitter::Fit(TF1 *f1, Option_t* option)
       fFitter->Config().MinimizerOptions().SetPrintLevel(0);
    }
 
-
+   // set model function in fitter to have it in FitResult
+   // in this way one can compute for example the confidence intervals   
+   fFitter->SetFunction(ROOT::Math::WrappedTF1(*f1), false); 
 
    // perform the actual fit
 

--- a/hist/hist/src/TH2Poly.cxx
+++ b/hist/hist/src/TH2Poly.cxx
@@ -523,6 +523,7 @@ void TH2Poly::ClearBinContents()
 
    // Clears the statistics
    fTsumw   = 0;
+   fTsumw2  = 0;
    fTsumwx  = 0;
    fTsumwx2 = 0;
    fTsumwy  = 0;
@@ -661,6 +662,7 @@ Int_t TH2Poly::Fill(Double_t x, Double_t y, Double_t w)
 
          // Statistics
          fTsumw   = fTsumw + w;
+         fTsumw2  = fTsumw2 + w*w;
          fTsumwx  = fTsumwx + w*x;
          fTsumwx2 = fTsumwx2 + w*x*x;
          fTsumwy  = fTsumwy + w*y;
@@ -974,6 +976,7 @@ void TH2Poly::Initialize(Double_t xlow, Double_t xup,
    // Statistics
    fEntries = 0;   // The total number of entries
    fTsumw   = 0.;  // Total amount of content in the histogram
+   fTsumw2  = 0.;  // Sum square of the weights
    fTsumwx  = 0.;  // Weighted sum of x coordinates
    fTsumwx2 = 0.;  // Weighted sum of the squares of x coordinates
    fTsumwy2 = 0.;  // Weighted sum of the squares of y coordinates

--- a/tutorials/fit/TestBinomial.C
+++ b/tutorials/fit/TestBinomial.C
@@ -180,6 +180,7 @@ void TestBinomial(int nloop = 100, int nevts = 100, bool plot = false, bool debu
           TFitResultPtr res = hM2E->Fit(fM2Fit, optFit);
           if (plot) {
              hM2E->DrawCopy("E");
+             fM2Fit->SetLineColor(kBlue);
              fM2Fit->DrawCopy("SAME");
           }
           if (debug) res->Print();
@@ -201,8 +202,8 @@ void TestBinomial(int nloop = 100, int nevts = 100, bool plot = false, bool debu
           // gPad = pad;
 
           TBinomialEfficiencyFitter bef(hM2N, hM2D);
-          TString optFit = "RI";
-          if (debug) optFit += TString("SV");
+          TString optFit = "RI S";
+          if (debug) optFit += TString("V");
           TFitResultPtr res = bef.Fit(fM2Fit2,optFit);
           status = res;
           if (status !=0) {
@@ -214,6 +215,19 @@ void TestBinomial(int nloop = 100, int nevts = 100, bool plot = false, bool debu
           if (plot) {
              fM2Fit2->SetLineColor(kRed);
              fM2Fit2->DrawCopy("SAME");
+          
+             bool confint = (status == 0);
+             if (confint) {
+                // compute confidence interval on fitted function
+                auto htemp = fM2Fit2->GetHistogram();
+                ROOT::Fit::BinData xdata;
+                ROOT::Fit::FillData(xdata, fM2Fit2->GetHistogram() );
+                TGraphErrors gr(fM2Fit2->GetHistogram() );
+                res->GetConfidenceIntervals(xdata, gr.GetEY(), 0.68, false);
+                gr.SetFillColor(6);
+                gr.SetFillStyle(3005);
+                gr.DrawClone("4 same");
+             }
           }
           if (debug) {
              res->Print();


### PR DESCRIPTION
Add possibility to set model function (and also data) when using Fitter::FitFCN. 
This gives possibility to call FitResult::GetConfidenceIntervals for the fits done using Fitter::FitFCN, as in the  in case of TBinomialEfficiencyFitter. 

This commit fixes ROOT-7790.

The tutorial TesBinomial.C has been updated to compute as example the confidence interval of the fitted function. 

This PR also contains a commit fixing the missing statistics in th2poly