### PR TITLE
json: differently handle infinite values

### DIFF
--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -3628,7 +3628,9 @@ void TBufferJSON::JsonWriteBasic(Long64_t value)
 void TBufferJSON::JsonWriteBasic(Float_t value)
 {
    char buf[200];
-   if (std::isnan(value) || std::isinf(value))
+   if (std::isinf(value))
+      strcpy(buf, (value < 0.) ? "-2e308" : "2e308"); // Number.MAX_VALUE is approx 1.79e308
+   else if (std::isnan(value))
       strcpy(buf, "null");
    else
       ConvertFloat(value, buf, sizeof(buf));
@@ -3641,7 +3643,9 @@ void TBufferJSON::JsonWriteBasic(Float_t value)
 void TBufferJSON::JsonWriteBasic(Double_t value)
 {
    char buf[200];
-   if (std::isnan(value) || std::isinf(value))
+   if (std::isinf(value))
+      strcpy(buf, (value < 0.) ? "-2e308" : "2e308"); // Number.MAX_VALUE is approx 1.79e308
+   else if (std::isnan(value))
       strcpy(buf, "null");
    else
       ConvertDouble(value, buf, sizeof(buf));

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -3627,14 +3627,15 @@ void TBufferJSON::JsonWriteBasic(Long64_t value)
 
 void TBufferJSON::JsonWriteBasic(Float_t value)
 {
-   char buf[200];
-   if (std::isinf(value))
-      strcpy(buf, (value < 0.) ? "-2e308" : "2e308"); // Number.MAX_VALUE is approx 1.79e308
-   else if (std::isnan(value))
-      strcpy(buf, "null");
-   else
+   if (std::isinf(value)) {
+      fValue.Append((value < 0.) ? "-2e308" : "2e308"); // Number.MAX_VALUE is approx 1.79e308
+   } else if (std::isnan(value)) {
+      fValue.Append("null");
+   } else {
+      char buf[200];
       ConvertFloat(value, buf, sizeof(buf));
-   fValue.Append(buf);
+      fValue.Append(buf);
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -3642,14 +3643,15 @@ void TBufferJSON::JsonWriteBasic(Float_t value)
 
 void TBufferJSON::JsonWriteBasic(Double_t value)
 {
-   char buf[200];
-   if (std::isinf(value))
-      strcpy(buf, (value < 0.) ? "-2e308" : "2e308"); // Number.MAX_VALUE is approx 1.79e308
-   else if (std::isnan(value))
-      strcpy(buf, "null");
-   else
+   if (std::isinf(value)) {
+      fValue.Append((value < 0.) ? "-2e308" : "2e308"); // Number.MAX_VALUE is approx 1.79e308
+   } else if (std::isnan(value)) {
+      fValue.Append("null");
+   } else {
+      char buf[200];
       ConvertDouble(value, buf, sizeof(buf));
-   fValue.Append(buf);
+      fValue.Append(buf);
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
JSON standard does not have special coding for infinite values.
null is not sufficient, while cannot be used in numeric compare
operations. Therefore use 2e308 and -2e308 as +Infite and -Infinite
values. When parsed in JavaScript such values automatically appears as
Infinite

Partial solution for https://root-forum.cern.ch/t/root-json-and-nan-inf/32754