### PR TITLE
[Exp PyROOT] Add pythonisations for TIter

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
@@ -17,6 +17,7 @@ set(py_sources
   ROOT/pythonization/_tdirectory.py
   ROOT/pythonization/_tdirectoryfile.py
   ROOT/pythonization/_tfile.py
+  ROOT/pythonization/_titer.py
   ROOT/pythonization/_tobject.py
   ROOT/pythonization/_tseqcollection.py
   ROOT/pythonization/_ttree.py

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tcollection.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tcollection.py
@@ -88,10 +88,9 @@ def _iter_pyz(self):
     # Parameters:
     # - self: collection to be iterated
     it = cppyy.gbl.TIter(self)
-    o = it.Next()
-    while o:
+    # TIter instances are iterable
+    for o in it:
         yield o
-        o = it.Next()
 
 
 @pythonization()

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_titer.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_titer.py
@@ -1,0 +1,37 @@
+# Author: Enric Tejedor CERN  02/2019
+
+################################################################################
+# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from ROOT import pythonization
+import cppyy
+
+def _next_pyz(self):
+    # Parameters:
+    # - self: iterator on a collection
+    # Returns:
+    # - next object in the collection, or raises StopIteration if none
+	o = self.Next()
+	if o:
+		return o
+	else:
+		raise StopIteration()
+
+
+@pythonization(lazy = False)
+def pythonize_titer():
+    klass = cppyy.gbl.TIter
+
+    # Make TIter a Python iterable
+    klass.__iter__ = lambda self: self
+
+    # Make TIter a Python iterator
+    klass.__next__ = _next_pyz  # Py3
+    klass.next     = _next_pyz  # Py2
+
+    return True

--- a/bindings/pyroot_experimental/PyROOT/src/TClonesArrayPyz.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/TClonesArrayPyz.cxx
@@ -27,8 +27,8 @@ using namespace CPyCppyy;
 // Clone an object into a position of a TClonesArray
 static TObject *CloneObjectInPlace(const TObject *obj, TClonesArray *cla, int index)
 {
-   // Create object with default constructor at index
-   char *arrObj = (char *)cla->New(index);
+   // Get or create object with default constructor at index
+   char *arrObj = (char *)cla->ConstructedAt(index);
    if (!arrObj) {
       PyErr_Format(PyExc_RuntimeError, "Failed to create new object at index %d of TClonesArray", index);
       return nullptr;

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -34,6 +34,9 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_tcollection_iterable tcollection_iterable.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tseqcollection_itemaccess tseqcollection_itemaccess.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tseqcollection_listmethods tseqcollection_listmethods.py)
 
+# TIter pythonisations
+ROOT_ADD_PYUNITTEST(pyroot_pyz_titer_iterator titer_iterator.py)
+
 # TClonesArray pythonisations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tclonesarray_itemaccess tclonesarray_itemaccess.py)
 

--- a/bindings/pyroot_experimental/PyROOT/test/titer_iterator.py
+++ b/bindings/pyroot_experimental/PyROOT/test/titer_iterator.py
@@ -1,0 +1,55 @@
+import unittest
+
+import ROOT
+from libcppyy import SetOwnership
+
+
+class TIterIterator(unittest.TestCase):
+    """
+    Test for the pythonization that allows instances of TIter to
+    behave as Python iterators.
+    """
+
+    num_elems = 3
+
+    # Helpers
+    def create_tcollection(self):
+        c = ROOT.TList()
+        for _ in range(self.num_elems):
+            o = ROOT.TObject()
+            # Prevent immediate deletion of C++ TObjects
+            SetOwnership(o, False)
+            c.Add(o)
+
+        return c
+
+    # Tests
+    def test_iterable(self):
+        # Check that TIter instances are iterable
+        c = self.create_tcollection()
+
+        itc = ROOT.TIter(c)
+        # An iterator of an iterator is itself
+        self.assertEqual(itc, iter(itc))
+
+    def test_iterator(self):
+        # Check that TIter instances are iterators
+        c = self.create_tcollection()
+
+        itc1 = ROOT.TIter(c)
+        itc2 = ROOT.TIter(c)
+        for _ in range(c.GetEntries()):
+            self.assertEqual(next(itc1), itc2.Next())
+
+    def test_for_loop_syntax(self):
+        # Somehow redundant, but good to test with real syntax
+        c = self.create_tcollection()
+
+        itc1 = ROOT.TIter(c)
+        itc2 = ROOT.TIter(c)
+        for elem1, elem2 in zip(itc1, itc2):
+            self.assertEqual(elem1, elem2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR makes instances of `TIter` both iterables (providing `__iter__`) and iterators (providing `__next__`), just like e.g. Python list iterators.

In addition, we provide a fix for the item setting pythonisation of `TClonesArray`, using `ConstructedAt` instead of `New`.