### PR TITLE
[Exp PyROOT] Pythonisations for TString and TObjString

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
@@ -20,6 +20,7 @@ set(py_sources
   ROOT/pythonization/_titer.py
   ROOT/pythonization/_tobject.py
   ROOT/pythonization/_tseqcollection.py
+  ROOT/pythonisation/_tstring.py
   ROOT/pythonization/_ttree.py
 )
 

--- a/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
@@ -21,6 +21,7 @@ set(py_sources
   ROOT/pythonization/_tobject.py
   ROOT/pythonization/_tseqcollection.py
   ROOT/pythonisation/_tstring.py
+  ROOT/pythonisation/_tobjstring.py
   ROOT/pythonization/_ttree.py
 )
 

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_generic.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_generic.py
@@ -11,12 +11,6 @@
 from libROOTPython import AddPrettyPrintingPyz
 from ROOT import pythonization
 
-def add_len(klass, getter_name):
-    # Parameters:
-    # klass: class to be pythonized
-    # getter_name: name of the method to be associated with `len` in `klass`
-
-    klass.__len__ = getattr(klass, getter_name)
 
 @pythonization()
 def pythonizegeneric(klass, name):

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_rooabscollection.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_rooabscollection.py
@@ -10,7 +10,6 @@
 
 from ROOT import pythonization
 
-from ._generic import add_len
 
 @pythonization()
 def pythonize_rooabscollection(klass, name):
@@ -20,4 +19,4 @@ def pythonize_rooabscollection(klass, name):
 
     if name == 'RooAbsCollection':
         # Support `len(c)` as `c.getSize()`
-        add_len(klass, 'getSize')
+        klass.__len__ = klass.getSize

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tarray.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tarray.py
@@ -10,7 +10,6 @@
 
 from ROOT import pythonization
 
-from ._generic import add_len
 
 @pythonization()
 def pythonize_tarray(klass, name):
@@ -20,4 +19,4 @@ def pythonize_tarray(klass, name):
 
     if name == 'TArray':
         # Support `len(a)` as `a.GetSize()`
-        add_len(klass, 'GetSize')
+        klass.__len__ = klass.GetSize

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tcollection.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tcollection.py
@@ -11,8 +11,6 @@
 from ROOT import pythonization
 import cppyy
 
-from ._generic import add_len
-
 
 # Python-list-like methods
 
@@ -101,7 +99,7 @@ def pythonize_tcollection(klass, name):
 
     if name == 'TCollection':
         # Support `len(c)` as `c.GetEntries()`
-        add_len(klass, 'GetEntries')
+        klass.__len__ = klass.GetEntries
 
         # Add Python lists methods
         klass.append = klass.Add

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tobjstring.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tobjstring.py
@@ -1,0 +1,36 @@
+# Author: Enric Tejedor CERN  02/2019
+
+################################################################################
+# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from ROOT import pythonization
+
+
+@pythonization()
+def pythonize_tobjstring(klass, name):
+    # Parameters:
+    # klass: class to be pythonized
+    # name: name of the class
+
+    if name == 'TObjString':
+        # `len(s)` is the length of string representation
+        klass.__len__ = lambda self: len(str(self))
+
+        # Add string representation
+        klass.__str__  = klass.GetName
+        klass.__repr__ = lambda self: "'{}'".format(self)
+
+        # Add comparison operators
+        klass.__eq__ = lambda self, o: str(self) == o
+        klass.__ne__ = lambda self, o: str(self) != o
+        klass.__lt__ = lambda self, o: str(self) <  o
+        klass.__le__ = lambda self, o: str(self) <= o
+        klass.__gt__ = lambda self, o: str(self) >  o
+        klass.__ge__ = lambda self, o: str(self) >= o
+
+    return True

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tstring.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tstring.py
@@ -1,0 +1,36 @@
+# Author: Enric Tejedor CERN  02/2019
+
+################################################################################
+# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from ROOT import pythonization
+
+
+@pythonization()
+def pythonize_tstring(klass, name):
+    # Parameters:
+    # klass: class to be pythonized
+    # name: name of the class
+
+    if name == 'TString':
+        # Support `len(s)` as `s.Length()`
+        klass.__len__ = klass.Length
+
+        # Add string representation
+        klass.__str__  = klass.Data
+        klass.__repr__ = lambda self: "'{}'".format(self)
+
+        # Add comparison operators
+        klass.__eq__ = lambda self, o: str(self) == o
+        klass.__ne__ = lambda self, o: str(self) != o
+        klass.__lt__ = lambda self, o: str(self) <  o
+        klass.__le__ = lambda self, o: str(self) <= o
+        klass.__gt__ = lambda self, o: str(self) >  o
+        klass.__ge__ = lambda self, o: str(self) >= o
+
+    return True

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -48,6 +48,11 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_tstring_len tstring_len.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tstring_str_repr tstring_str_repr.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tstring_comparisonops tstring_comparisonops.py)
 
+# TObjString pythonisations
+ROOT_ADD_PYUNITTEST(pyroot_pyz_tobjstring_len tobjstring_len.py)
+ROOT_ADD_PYUNITTEST(pyroot_pyz_tobjstring_str_repr tobjstring_str_repr.py)
+ROOT_ADD_PYUNITTEST(pyroot_pyz_tobjstring_comparisonops tobjstring_comparisonops.py)
+
 # RVec and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_rvec_asrvec rvec_asrvec.py)
 

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -43,6 +43,11 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_tclonesarray_itemaccess tclonesarray_itemaccess.p
 # TArray and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tarray_len tarray_len.py)
 
+# TString pythonisations
+ROOT_ADD_PYUNITTEST(pyroot_pyz_tstring_len tstring_len.py)
+ROOT_ADD_PYUNITTEST(pyroot_pyz_tstring_str_repr tstring_str_repr.py)
+ROOT_ADD_PYUNITTEST(pyroot_pyz_tstring_comparisonops tstring_comparisonops.py)
+
 # RVec and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_rvec_asrvec rvec_asrvec.py)
 

--- a/bindings/pyroot_experimental/PyROOT/test/tobjstring_comparisonops.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tobjstring_comparisonops.py
@@ -1,0 +1,153 @@
+import unittest
+
+from ROOT import TObjString, TString
+
+class TObjStringComparisonOps(unittest.TestCase):
+    """
+    Test for the comparison operators of TObjString:
+    __eq__, __ne__, __lt__, __le__, __gt__, __ge__.
+    """
+
+    num_elems = 3
+    test_str1 = 'test1'
+    test_str2 = 'test2'
+
+    # Tests
+    def test_eq(self):
+        tos1 = TObjString(self.test_str1)
+        tos2 = TObjString(self.test_str1)
+        tos3 = TObjString(self.test_str2)
+
+        # Comparison between TObjStrings
+        self.assertTrue(tos1 == tos2)
+        self.assertFalse(tos1 == tos3)
+
+        # Comparison with TString
+        ts1 = TString(self.test_str1)
+        ts2 = TString(self.test_str2)
+        self.assertTrue(tos1 == ts1)
+        self.assertFalse(tos1 == ts2)
+
+        # Comparison with Python string
+        self.assertTrue(tos1 == self.test_str1)
+        self.assertFalse(tos1 == self.test_str2)
+
+        # Comparison with non-string
+        self.assertFalse(tos1 == 1)
+
+    def test_ne(self):
+        tos1 = TObjString(self.test_str1)
+        tos2 = TObjString(self.test_str1)
+        tos3 = TObjString(self.test_str2)
+
+        # Comparison between TObjStrings
+        self.assertFalse(tos1 != tos2)
+        self.assertTrue(tos1 != tos3)
+
+        # Comparison with TString
+        ts1 = TString(self.test_str1)
+        ts2 = TString(self.test_str2)
+        self.assertFalse(tos1 != ts1)
+        self.assertTrue(tos1 != ts2)
+
+        # Comparison with Python string
+        self.assertFalse(tos1 != self.test_str1)
+        self.assertTrue(tos1 != self.test_str2)
+
+        # Comparison with non-string
+        self.assertTrue(tos1 != 1)
+
+    def test_lt(self):
+        tos1 = TObjString(self.test_str1)
+        tos2 = TObjString(self.test_str2)
+
+        # Comparison between TObjStrings
+        self.assertTrue(tos1 < tos2)
+        self.assertFalse(tos2 < tos1)
+
+        # Comparison with TString
+        ts1 = TString(self.test_str1)
+        ts2 = TString(self.test_str2)
+        self.assertTrue(tos1 < ts2)
+        self.assertFalse(tos2 < ts1)
+
+        # Comparison with Python string
+        self.assertTrue(tos1 < self.test_str2)
+        self.assertFalse(tos2 < self.test_str1)
+
+    def test_le(self):
+        tos1 = TObjString(self.test_str1)
+        tos2 = TObjString(self.test_str1)
+        tos3 = TObjString(self.test_str2)
+
+        # Comparison between TObjStrings
+        self.assertTrue(tos1 <= tos2)
+        self.assertTrue(tos1 <= tos3)
+        self.assertFalse(tos3 <= tos1)
+
+        # Comparison with TString
+        ts1 = TString(self.test_str1)
+        ts2 = TString(self.test_str2)
+        self.assertTrue(tos1 <= ts1)
+        self.assertTrue(tos1 <= ts2)
+        self.assertFalse(tos3 <= ts1)
+
+        # Comparison with Python string
+        self.assertTrue(tos1 <= self.test_str1)
+        self.assertTrue(tos1 <= self.test_str2)
+        self.assertFalse(tos3 <= self.test_str1)
+
+    def test_gt(self):
+        tos1 = TObjString(self.test_str1)
+        tos2 = TObjString(self.test_str2)
+
+        # Comparison between TObjStrings
+        self.assertFalse(tos1 > tos2)
+        self.assertTrue(tos2 > tos1)
+
+        # Comparison with TString
+        ts1 = TString(self.test_str1)
+        ts2 = TString(self.test_str2)
+        self.assertFalse(tos1 > ts2)
+        self.assertTrue(tos2 > ts1)
+
+        # Comparison with Python string
+        self.assertFalse(tos1 > self.test_str2)
+        self.assertTrue(tos2 > self.test_str1)
+
+    def test_ge(self):
+        tos1 = TObjString(self.test_str1)
+        tos2 = TObjString(self.test_str1)
+        tos3 = TObjString(self.test_str2)
+
+        # Comparison between TObjStrings
+        self.assertTrue(tos1 >= tos2)
+        self.assertFalse(tos1 >= tos3)
+        self.assertTrue(tos3 >= tos1)
+
+        # Comparison with TString
+        ts1 = TString(self.test_str1)
+        ts2 = TString(self.test_str2)
+        self.assertTrue(tos1 >= ts1)
+        self.assertFalse(tos1 >= ts2)
+        self.assertTrue(tos3 >= ts1)
+
+        # Comparison with Python string
+        self.assertTrue(tos1 >= self.test_str1)
+        self.assertFalse(tos1 >= self.test_str2)
+        self.assertTrue(tos3 >= self.test_str1)
+
+    def test_list_sort(self):
+        l1 = [ TObjString(str(i)) for i in range(self.num_elems) ]
+        l2 = list(reversed(l1))
+
+        self.assertNotEqual(l1, l2)
+
+        # Test that comparison operators enable list sorting
+        l2.sort()
+
+        self.assertEqual(l1, l2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bindings/pyroot_experimental/PyROOT/test/tobjstring_len.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tobjstring_len.py
@@ -1,0 +1,20 @@
+import unittest
+
+import ROOT
+
+
+class TObjStringLen(unittest.TestCase):
+    """
+    Test for the pythonization that provides the length of a
+    TObjString instance `s` via `len(s)`.
+    """
+
+    # Tests
+    def test_len(self):
+        s = 'test'
+        tos = ROOT.TObjString(s)
+        self.assertEqual(len(tos), len(s))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bindings/pyroot_experimental/PyROOT/test/tobjstring_str_repr.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tobjstring_str_repr.py
@@ -1,0 +1,25 @@
+import unittest
+
+import ROOT
+
+
+class TObjStringStrRepr(unittest.TestCase):
+    """
+    Test for the pythonizations that provide a string representation
+    for instances of TObjString (__str__, __repr__).
+    """
+
+    # Tests
+    def test_str(self):
+        s = 'test'
+        tos = ROOT.TObjString(s)
+        self.assertEqual(str(tos), s)
+
+    def test_repr(self):
+        s = 'test'
+        tos = ROOT.TObjString(s)
+        self.assertEqual(repr(tos), repr(s))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bindings/pyroot_experimental/PyROOT/test/tstring_comparisonops.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tstring_comparisonops.py
@@ -1,0 +1,115 @@
+import unittest
+
+from ROOT import TString
+
+class TStringComparisonOps(unittest.TestCase):
+    """
+    Test for the comparison operators of TString:
+    __eq__, __ne__, __lt__, __le__, __gt__, __ge__.
+    """
+
+    num_elems = 3
+    test_str1 = 'test1'
+    test_str2 = 'test2'
+
+    # Tests
+    def test_eq(self):
+        ts1 = TString(self.test_str1)
+        ts2 = TString(self.test_str1)
+        ts3 = TString(self.test_str2)
+
+        # Comparison between TStrings
+        self.assertTrue(ts1 == ts2)
+        self.assertFalse(ts1 == ts3)
+
+        # Comparison with Python string
+        self.assertTrue(ts1 == self.test_str1)
+        self.assertFalse(ts1 == self.test_str2)
+
+        # Comparison with non-string
+        self.assertFalse(ts1 == 1)
+
+    def test_ne(self):
+        ts1 = TString(self.test_str1)
+        ts2 = TString(self.test_str1)
+        ts3 = TString(self.test_str2)
+
+        # Comparison between TStrings
+        self.assertFalse(ts1 != ts2)
+        self.assertTrue(ts1 != ts3)
+
+        # Comparison with Python string
+        self.assertFalse(ts1 != self.test_str1)
+        self.assertTrue(ts1 != self.test_str2)
+
+        # Comparison with non-string
+        self.assertTrue(ts1 != 1)
+
+    def test_lt(self):
+        ts1 = TString(self.test_str1)
+        ts2 = TString(self.test_str2)
+
+        # Comparison between TStrings
+        self.assertTrue(ts1 < ts2)
+        self.assertFalse(ts2 < ts1)
+
+        # Comparison with Python string
+        self.assertTrue(ts1 < self.test_str2)
+        self.assertFalse(ts2 < self.test_str1)
+
+    def test_le(self):
+        ts1 = TString(self.test_str1)
+        ts2 = TString(self.test_str1)
+        ts3 = TString(self.test_str2)
+
+        # Comparison between TStrings
+        self.assertTrue(ts1 <= ts2)
+        self.assertTrue(ts1 <= ts3)
+        self.assertFalse(ts3 <= ts1)
+
+        # Comparison with Python string
+        self.assertTrue(ts1 <= self.test_str1)
+        self.assertTrue(ts1 <= self.test_str2)
+        self.assertFalse(ts3 <= self.test_str1)
+
+    def test_gt(self):
+        ts1 = TString(self.test_str1)
+        ts2 = TString(self.test_str2)
+
+        # Comparison between TStrings
+        self.assertFalse(ts1 > ts2)
+        self.assertTrue(ts2 > ts1)
+
+        # Comparison with Python string
+        self.assertFalse(ts1 > self.test_str2)
+        self.assertTrue(ts2 > self.test_str1)
+
+    def test_ge(self):
+        ts1 = TString(self.test_str1)
+        ts2 = TString(self.test_str1)
+        ts3 = TString(self.test_str2)
+
+        # Comparison between TStrings
+        self.assertTrue(ts1 >= ts2)
+        self.assertFalse(ts1 >= ts3)
+        self.assertTrue(ts3 >= ts1)
+
+        # Comparison with Python string
+        self.assertTrue(ts1 >= self.test_str1)
+        self.assertFalse(ts1 >= self.test_str2)
+        self.assertTrue(ts3 >= self.test_str1)
+
+    def test_list_sort(self):
+        l1 = [ TString(str(i)) for i in range(self.num_elems) ]
+        l2 = list(reversed(l1))
+
+        self.assertNotEqual(l1, l2)
+
+        # Test that comparison operators enable list sorting
+        l2.sort()
+
+        self.assertEqual(l1, l2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bindings/pyroot_experimental/PyROOT/test/tstring_len.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tstring_len.py
@@ -1,0 +1,20 @@
+import unittest
+
+import ROOT
+
+
+class TStringLen(unittest.TestCase):
+    """
+    Test for the pythonization that provides the length of a
+    TString instance `s` via `len(s)`.
+    """
+
+    # Tests
+    def test_len(self):
+        s = 'test'
+        ts = ROOT.TString(s)
+        self.assertEqual(len(ts), len(s))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bindings/pyroot_experimental/PyROOT/test/tstring_str_repr.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tstring_str_repr.py
@@ -1,0 +1,25 @@
+import unittest
+
+import ROOT
+
+
+class TStringStrRepr(unittest.TestCase):
+    """
+    Test for the pythonizations that provide a string representation
+    for instances of TString (__str__, __repr__).
+    """
+
+    # Tests
+    def test_str(self):
+        s = 'test'
+        ts = ROOT.TString(s)
+        self.assertEqual(str(ts), s)
+
+    def test_repr(self):
+        s = 'test'
+        ts = ROOT.TString(s)
+        self.assertEqual(repr(ts), repr(s))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR makes it possible that `TString` and `TObjString` instances behave more like regular Python strings when used from Python. This is achieved by adding the following properties:
- Getting the length with len(s)
- Getting string representations with repr(s) and str(s)
- Implementing comparison operators for strings

