### PR TITLE
[VecOps] Preallocate some memory for RVec<T> where T is a "common" fundamental type

### DIFF
--- a/math/vecops/inc/LinkDef.h
+++ b/math/vecops/inc/LinkDef.h
@@ -45,4 +45,6 @@
 #pragma link C++ class ROOT::VecOps::RVec<unsigned long>::Impl_t+;
 #pragma link C++ class ROOT::VecOps::RVec<unsigned long long>::Impl_t+;
 
+#pragma link C++ class ROOT::Internal::VecOps::RBufferStack-;
+
 #endif

--- a/math/vecops/src/RAdoptAllocator.cxx
+++ b/math/vecops/src/RAdoptAllocator.cxx
@@ -1,1 +1,50 @@
 #include <ROOT/RAdoptAllocator.hxx>
+#include <Rtypes.h>
+
+// All this code a workaround. It is needed because cling
+// cannot handle thread_local yet.
+
+const unsigned int gBuffersNumber = 32U;
+
+namespace ROOT {
+namespace Internal {
+namespace VecOps {
+
+// This wrapper allows to deallocate the memory at tear down
+class RBufferStackWrapper {
+   using StdAlloc_t = std::allocator<char>;
+   std::stack<void *> fBufStack;
+   const std::size_t fBuffersSize;
+   std::allocator<char> fCharAlloc;
+
+public:
+   RBufferStackWrapper(std::size_t typeSize)
+      : fBuffersSize(::ROOT::Internal::VecOps::gBuffersSize * typeSize * typeSize / sizeof(char))
+   {
+      char *p;
+      for (auto i = 0U; i < gBuffersNumber; ++i) {
+         p = std::allocator_traits<StdAlloc_t>::allocate(fCharAlloc, fBuffersSize);
+         fBufStack.push((void*)p);
+      }
+   }
+
+   std::stack<void *> *Get() { return &fBufStack; }
+
+   ~RBufferStackWrapper()
+   {
+      while (!fBufStack.empty()) {
+         auto p = (char *) fBufStack.top();
+         std::allocator_traits<StdAlloc_t>::deallocate(fCharAlloc, p, fBuffersSize);
+         fBufStack.pop();
+      }
+   }
+};
+
+std::stack<void *> *RBufferStack::Get(std::size_t typeSize)
+{
+   thread_local RBufferStackWrapper bsw(typeSize);
+   return bsw.Get();
+}
+} // namespace VecOps
+} // namespace Internal
+} // namespace ROOT


### PR DESCRIPTION
the goal of this commit is to avoid too many allocations/deallocations in two cases:
1. sophisticated expressions manipulating RVec<T> instances: churn kicks in due to temporaries
2. RDataFrame runs with Defines returning RVec<T>s which are saved within custom columns via a copy. For every event, the old value is deallocated and the new one allocated.

This change implements a thread local stack of buffers in the RAdoptAllocator.
If the allocation is smaller than RAdoptAllocator<T>::fgBuffersSize, before allocating
a fresh region of memory through the stl allocator, a pop from the aforementioned stack is tried.
At deallocation time, the memory taken from the stak, is put back in the stack.
In some sense, this is an optimisation for short (defined by RAdoptAllocator<T>::fgBuffersSize) RVec<T>s.