### PR TITLE
[Exp PyROOT] Add operator to multiply TH1 by constant

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
@@ -17,11 +17,12 @@ set(py_sources
   ROOT/pythonization/_tdirectory.py
   ROOT/pythonization/_tdirectoryfile.py
   ROOT/pythonization/_tfile.py
+  ROOT/pythonization/_th1.py
   ROOT/pythonization/_titer.py
   ROOT/pythonization/_tobject.py
+  ROOT/pythonisation/_tobjstring.py
   ROOT/pythonization/_tseqcollection.py
   ROOT/pythonisation/_tstring.py
-  ROOT/pythonisation/_tobjstring.py
   ROOT/pythonization/_ttree.py
 )
 

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_th1.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_th1.py
@@ -1,0 +1,36 @@
+# Author: Enric Tejedor CERN  02/2019
+
+################################################################################
+# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from ROOT import pythonization
+
+
+# Multiplication by constant
+
+def _imul(self, c):
+    # Parameters:
+    # - self: histogram
+    # - c: constant by which to multiply the histogram
+    # Returns:
+    # - A multiplied histogram (in place)
+    self.Scale(c)
+    return self
+
+
+@pythonization()
+def pythonize_th1(klass, name):
+    # Parameters:
+    # klass: class to be pythonized
+    # name: name of the class
+
+    if name == 'TH1':
+        # Support hist *= scalar
+        klass.__imul__ = _imul
+
+    return True

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -24,6 +24,9 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_setbranchaddress ttree_setbranchaddress.py
 ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_branch ttree_branch.py
                     COPY_TO_BUILDDIR TreeHelper.h)
 
+# TH1 and subclasses pythonizations
+ROOT_ADD_PYUNITTEST(pyroot_pyz_th1_operators th1_operators.py)
+
 # TCollection and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tcollection_len tcollection_len.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tcollection_listmethods tcollection_listmethods.py)

--- a/bindings/pyroot_experimental/PyROOT/test/th1_operators.py
+++ b/bindings/pyroot_experimental/PyROOT/test/th1_operators.py
@@ -1,0 +1,30 @@
+import unittest
+
+import ROOT
+
+
+class TH1Operators(unittest.TestCase):
+    """
+    Test for the __imul__ operator of TH1 and subclasses, which
+    multiplies the histogram by a constant.
+    """
+
+    # Tests
+    def test_imul(self):
+        nbins = 64
+        h = ROOT.TH1F("testHist", "", nbins, -4, 4)
+        h.FillRandom("gaus")
+
+        initial_bins = [ h.GetBinContent(i) for i in range(nbins) ]
+        c = 2
+
+        # Multiply in place
+        h *= c
+
+        # Check new value of bins
+        for i in range(nbins):
+            self.assertEqual(h.GetBinContent(i), initial_bins[i] * c)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pythonisation provides a similar functionality as the one of `TH1::Scale`, which multiplies a histogram by a certain constant. However, the syntax proposed here is the one of the `__imul__` operator (`*=`)