### PR TITLE
Fix a crash with TBrowser when using the Web GUI (root --web)

### DIFF
--- a/gui/gui/inc/TRootBrowser.h
+++ b/gui/gui/inc/TRootBrowser.h
@@ -13,6 +13,7 @@
 #define ROOT_TRootBrowser
 
 #include "TGFrame.h"
+#include "TEnv.h"
 
 #include "TBrowserImp.h"
 

--- a/gui/gui/inc/TRootBrowser.h
+++ b/gui/gui/inc/TRootBrowser.h
@@ -13,7 +13,6 @@
 #define ROOT_TRootBrowser
 
 #include "TGFrame.h"
-#include "TEnv.h"
 
 #include "TBrowserImp.h"
 
@@ -165,8 +164,6 @@ public:
    virtual void      Show() { MapRaised(); }
    Option_t         *GetDrawOption() const;
    TGMainFrame      *GetMainFrame() const { return (TGMainFrame *)this; }
-   Bool_t            IsWebGUI() { TString factory = gEnv->GetValue("Gui.Factory", "native");
-                                  return (factory.Contains("web", TString::kIgnoreCase)); }
 
    virtual Long_t    ExecPlugin(const char *name = 0, const char *fname = 0,
                                 const char *cmd = 0, Int_t pos = kRight,
@@ -176,6 +173,7 @@ public:
 
    virtual void      ShowCloseTab(Bool_t show) { fShowCloseTab = show; }
    virtual Bool_t    IsCloseTabShown() const { return fShowCloseTab; }
+   Bool_t            IsWebGUI();
 
    // overridden from TGMainFrame
    virtual void      ReallyDelete();

--- a/gui/gui/inc/TRootBrowser.h
+++ b/gui/gui/inc/TRootBrowser.h
@@ -164,6 +164,8 @@ public:
    virtual void      Show() { MapRaised(); }
    Option_t         *GetDrawOption() const;
    TGMainFrame      *GetMainFrame() const { return (TGMainFrame *)this; }
+   Bool_t            IsWebGUI() { TString factory = gEnv->GetValue("Gui.Factory", "native");
+                                  return (factory.Contains("web", TString::kIgnoreCase)); }
 
    virtual Long_t    ExecPlugin(const char *name = 0, const char *fname = 0,
                                 const char *cmd = 0, Int_t pos = kRight,

--- a/gui/gui/src/TRootBrowser.cxx
+++ b/gui/gui/src/TRootBrowser.cxx
@@ -911,6 +911,15 @@ void TRootBrowser::InitPlugins(Option_t *opt)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Check if the GUI factory is set to use the Web GUI.
+
+Bool_t TRootBrowser::IsWebGUI()
+{
+   TString factory = gEnv->GetValue("Gui.Factory", "native");
+   return (factory.Contains("web", TString::kIgnoreCase));
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Really delete the browser and the this GUI.
 
 void TRootBrowser::ReallyDelete()


### PR DESCRIPTION
Don't embed a TCanvas in the ROOT Browser when using the Web GUI (root --web), but spawn a Web Canvas when needed