### PR TITLE
[RF] Increment class version of RooStats::ModelConfig.

### DIFF
--- a/roofit/roostats/inc/RooStats/ModelConfig.h
+++ b/roofit/roostats/inc/RooStats/ModelConfig.h
@@ -300,7 +300,7 @@ protected:
 
    std::string fObservablesName; /// name for RooArgSet specifying observable parameters.
 
-   ClassDefOverride(ModelConfig,4) /// A class that holds configuration information for a model using a workspace as a store
+   ClassDefOverride(ModelConfig,5) /// A class that holds configuration information for a model using a workspace as a store
 
 };
 


### PR DESCRIPTION
As an aftermath of the fix for ROOT-9777, the class version of ModelConfig
needed to be incremented to silence a warning when reading old versions of
the class.