### PR TITLE
[Exp PyROOT] Pythonisations for TVectorT, TVector3 and TArray

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
@@ -24,6 +24,7 @@ set(py_sources
   ROOT/pythonization/_tseqcollection.py
   ROOT/pythonisation/_tstring.py
   ROOT/pythonization/_ttree.py
+  ROOT/pythonization/_tvectort.py
 )
 
 set(sources

--- a/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
@@ -24,6 +24,7 @@ set(py_sources
   ROOT/pythonization/_tseqcollection.py
   ROOT/pythonisation/_tstring.py
   ROOT/pythonization/_ttree.py
+  ROOT/pythonization/_tvector3.py
   ROOT/pythonization/_tvectort.py
 )
 

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_generic.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_generic.py
@@ -29,7 +29,7 @@ def _add_getitem_checked(klass):
             return o._getitem__unchecked(i)
         else:
             raise IndexError('index out of range')
-    
+
     klass._getitem__unchecked = klass.__getitem__
     klass.__getitem__ = getitem_checked
 

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_generic.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_generic.py
@@ -1,7 +1,7 @@
-# Author: Stefan Wunsch CERN  06/2018
+# Author: Stefan Wunsch, Enric Tejedor CERN  06/2018
 
 ################################################################################
-# Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.                      #
+# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.                      #
 # All rights reserved.                                                         #
 #                                                                              #
 # For the licensing terms see $ROOTSYS/LICENSE.                                #
@@ -10,6 +10,28 @@
 
 from libROOTPython import AddPrettyPrintingPyz
 from ROOT import pythonization
+
+def _add_getitem_checked(klass):
+    # Parameters:
+    # - klass: class where to add a __getitem__ method that raises
+    # IndexError if index is out of range
+
+    def getitem_checked(o, i):
+        # Get item of `o` at `i` or raise IndexError if index is
+        # out of range.
+        # Assumes `o` has `__len__`.
+        # Parameters:
+        # - o: object
+        # - i: index to be checked in object
+        # Returns:
+        # - o[i]
+        if i >= 0 and i < len(o):
+            return o._getitem__unchecked(i)
+        else:
+            raise IndexError('index out of range')
+    
+    klass._getitem__unchecked = klass.__getitem__
+    klass.__getitem__ = getitem_checked
 
 
 @pythonization()

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tarray.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tarray.py
@@ -20,3 +20,5 @@ def pythonize_tarray(klass, name):
     if name == 'TArray':
         # Support `len(a)` as `a.GetSize()`
         klass.__len__ = klass.GetSize
+
+    return True

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tarray.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tarray.py
@@ -1,7 +1,7 @@
 # Author: Enric Tejedor CERN  11/2018
 
 ################################################################################
-# Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.                      #
+# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.                      #
 # All rights reserved.                                                         #
 #                                                                              #
 # For the licensing terms see $ROOTSYS/LICENSE.                                #
@@ -9,6 +9,8 @@
 ################################################################################
 
 from ROOT import pythonization
+
+from ._generic import _add_getitem_checked
 
 
 @pythonization()
@@ -20,5 +22,12 @@ def pythonize_tarray(klass, name):
     if name == 'TArray':
         # Support `len(a)` as `a.GetSize()`
         klass.__len__ = klass.GetSize
+
+    elif name.startswith('TArray'):
+        # Add checked __getitem__. It has to be directly added to the TArray
+        # subclasses, which have a default __getitem__.
+        # The new __getitem__ allows to throw pythonic IndexError when index
+        # is out of range and to iterate over the array.
+        _add_getitem_checked(klass)
 
     return True

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tvector3.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tvector3.py
@@ -10,6 +10,8 @@
 
 from ROOT import pythonization
 
+from ._generic import _add_getitem_checked
+
 
 @pythonization()
 def pythonize_tvector3(klass, name):
@@ -20,5 +22,10 @@ def pythonize_tvector3(klass, name):
     if name == 'TVector3':
         # `len(v)` is always 3
         klass.__len__ = lambda _: 3
+
+        # Add checked __getitem__.
+        # Allows to throw pythonic IndexError when index is out of range
+        # and to iterate over the vector.
+        _add_getitem_checked(klass)
 
     return True

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tvector3.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tvector3.py
@@ -1,0 +1,24 @@
+# Author: Enric Tejedor CERN  02/2019
+
+################################################################################
+# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from ROOT import pythonization
+
+
+@pythonization()
+def pythonize_tvector3(klass, name):
+    # Parameters:
+    # klass: class to be pythonized
+    # name: string containing the name of the class
+
+    if name == 'TVector3':
+        # `len(v)` is always 3
+        klass.__len__ = lambda _: 3
+
+    return True

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tvectort.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tvectort.py
@@ -10,6 +10,8 @@
 
 from ROOT import pythonization
 
+from ._generic import _add_getitem_checked
+
 
 @pythonization()
 def pythonize_tvectort(klass, name):
@@ -20,5 +22,10 @@ def pythonize_tvectort(klass, name):
     if name.startswith('TVectorT'):
         # Support `len(v)` as `v.GetNoElements()`
         klass.__len__ = klass.GetNoElements
+
+        # Add checked __getitem__.
+        # Allows to throw pythonic IndexError when index is out of range
+        # and to iterate over the vector.
+        _add_getitem_checked(klass)
 
     return True

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tvectort.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tvectort.py
@@ -1,0 +1,24 @@
+# Author: Enric Tejedor CERN  02/2019
+
+################################################################################
+# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from ROOT import pythonization
+
+
+@pythonization()
+def pythonize_tvectort(klass, name):
+    # Parameters:
+    # klass: class to be pythonized
+    # name: string containing the name of the class
+
+    if name.startswith('TVectorT'):
+        # Support `len(v)` as `v.GetNoElements()`
+        klass.__len__ = klass.GetNoElements
+
+    return True

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -52,6 +52,7 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_tvectort_getitem tvectort_getitem.py)
 
 # TVector3 pythonisations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tvector3_len tvector3_len.py)
+ROOT_ADD_PYUNITTEST(pyroot_pyz_tvector3_getitem tvector3_getitem.py)
 
 # TString pythonisations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tstring_len tstring_len.py)

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -45,6 +45,7 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_tclonesarray_itemaccess tclonesarray_itemaccess.p
 
 # TArray and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tarray_len tarray_len.py)
+ROOT_ADD_PYUNITTEST(pyroot_pyz_tarray_getitem tarray_getitem.py)
 
 # TVectorT pythonisations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tvectort_len tvectort_len.py)

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -46,6 +46,9 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_tclonesarray_itemaccess tclonesarray_itemaccess.p
 # TArray and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tarray_len tarray_len.py)
 
+# TVectorT pythonisations
+ROOT_ADD_PYUNITTEST(pyroot_pyz_tvectort_len tvectort_len.py)
+
 # TString pythonisations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tstring_len tstring_len.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tstring_str_repr tstring_str_repr.py)

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -48,6 +48,7 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_tarray_len tarray_len.py)
 
 # TVectorT pythonisations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tvectort_len tvectort_len.py)
+ROOT_ADD_PYUNITTEST(pyroot_pyz_tvectort_getitem tvectort_getitem.py)
 
 # TString pythonisations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tstring_len tstring_len.py)

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -50,6 +50,9 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_tarray_len tarray_len.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tvectort_len tvectort_len.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tvectort_getitem tvectort_getitem.py)
 
+# TVector3 pythonisations
+ROOT_ADD_PYUNITTEST(pyroot_pyz_tvector3_len tvector3_len.py)
+
 # TString pythonisations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tstring_len tstring_len.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tstring_str_repr tstring_str_repr.py)

--- a/bindings/pyroot_experimental/PyROOT/test/tarray_getitem.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tarray_getitem.py
@@ -1,0 +1,41 @@
+import unittest
+
+import ROOT
+
+
+class TArrayGetItem(unittest.TestCase):
+    """
+    Test for the pythonization that allows to: (i) get an item of a
+    TArray with boundary check for the index and (ii) iterate over
+    a TArray.
+    """
+
+    num_elems = 3
+
+    # Tests
+    def test_boundary_check(self):
+        a = ROOT.TArrayI(self.num_elems)
+
+        # In range
+        self.assertEqual(a[0], a[0])
+
+        # Out of range
+        with self.assertRaises(IndexError):
+            a[-1]
+
+        # Out of range
+        with self.assertRaises(IndexError):
+            a[self.num_elems]
+
+    def test_iterable(self):
+        a = ROOT.TArrayI(self.num_elems)
+        val = 1
+
+        for i in range(self.num_elems):
+            a[i] = val
+
+        self.assertEquals(list(a), [ val for _ in range(self.num_elems) ])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bindings/pyroot_experimental/PyROOT/test/tvector3_getitem.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tvector3_getitem.py
@@ -1,0 +1,35 @@
+import unittest
+
+import ROOT
+
+
+class TVector3GetItem(unittest.TestCase):
+    """
+    Test for the pythonization that allows to: (i) get an item of a
+    TVector3 with boundary check for the index and (ii) iterate over
+    a TVector3.
+    """
+
+    # Tests
+    def test_boundary_check(self):
+        v = ROOT.TVector3(1., 2., 3.)
+
+        # In range
+        self.assertEqual(v[0], v[0])
+
+        # Out of range
+        with self.assertRaises(IndexError):
+            v[-1]
+
+        # Out of range
+        with self.assertRaises(IndexError):
+            v[3]
+
+    def test_iterable(self):
+        v = ROOT.TVector3(1., 2., 3.)
+
+        self.assertEquals(list(v), [1., 2., 3.])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bindings/pyroot_experimental/PyROOT/test/tvector3_len.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tvector3_len.py
@@ -1,0 +1,19 @@
+import unittest
+
+import ROOT
+
+
+class TVector3Len(unittest.TestCase):
+    """
+    Test for the pythonization that allows to get the size of a
+    TVector3 (always 3) by calling `len` on it.
+    """
+
+    # Tests
+    def test_len(self):
+        v = ROOT.TVector3(1., 2., 3.)
+        self.assertEqual(len(v), 3)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bindings/pyroot_experimental/PyROOT/test/tvectort_getitem.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tvectort_getitem.py
@@ -1,0 +1,41 @@
+import unittest
+
+import ROOT
+
+
+class TVectorTGetItem(unittest.TestCase):
+    """
+    Test for the pythonization that allows to: (i) get an item of a
+    TVectorT with boundary check for the index and (ii) iterate over
+    a TVectorT.
+    """
+
+    num_elems = 3
+
+    # Tests
+    def test_boundary_check(self):
+        v = ROOT.TVectorT[float](self.num_elems)
+
+        # In range
+        self.assertEqual(v[0], v[0])
+
+        # Out of range
+        with self.assertRaises(IndexError):
+            v[-1]
+
+        # Out of range
+        with self.assertRaises(IndexError):
+            v[self.num_elems]
+
+    def test_iterable(self):
+        v = ROOT.TVectorT[float](self.num_elems)
+        val = 1
+
+        for i in range(self.num_elems):
+            v[i] = val
+
+        self.assertEquals(list(v), [ val for _ in range(self.num_elems) ])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bindings/pyroot_experimental/PyROOT/test/tvectort_len.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tvectort_len.py
@@ -1,0 +1,21 @@
+import unittest
+
+import ROOT
+
+
+class TVectorTLen(unittest.TestCase):
+    """
+    Test for the pythonization that allows to get the size of a
+    TVectorT by calling `len` on it.
+    """
+
+    num_elems = 3
+
+    # Tests
+    def test_len(self):
+        v = ROOT.TVectorT[float](self.num_elems)
+        self.assertEqual(len(v), self.num_elems)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR includes a series of pythonisations for `TVectorT`, `TVector3` and `TArray` in order to:
- Get their length with `len(o)`
- Add a `__getitem__` implementation that raises `IndexError` when the index is out of range, which also makes those classes iterable.