### PR TITLE
[No CI][PyROOT exp] Add feature to invoke Python callables from C++

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
@@ -31,6 +31,7 @@ set(py_sources
 )
 
 set(sources
+  src/CppCallablePyz.cxx
   src/PyROOTModule.cxx
   src/PyROOTStrings.cxx
   src/PyROOTWrapper.cxx

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_generic.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_generic.py
@@ -8,7 +8,7 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
-from libROOTPython import AddPrettyPrintingPyz
+from libROOTPython import AddPrettyPrintingPyz, GetCppCallableClass
 from ROOT import pythonization
 
 def _add_getitem_checked(klass):
@@ -44,3 +44,9 @@ def pythonizegeneric(klass, name):
     AddPrettyPrintingPyz(klass)
 
     return True
+
+
+# Add the decorator class to convert Python callables to C++ callables as
+# free function to the ROOT module
+import cppyy
+cppyy.gbl.DeclareCppCallable = GetCppCallableClass()

--- a/bindings/pyroot_experimental/PyROOT/src/CppCallablePyz.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/CppCallablePyz.cxx
@@ -1,0 +1,758 @@
+// Author: Stefan Wunsch, Enric Tejedor CERN  04/2019
+// Original PyROOT code by Wim Lavrijsen, LBL
+
+/*************************************************************************
+ * Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "Python.h"
+
+#include "CPyCppyy.h"
+#include "PyROOTPythonize.h"
+#include "CPPInstance.h"
+#include "Utility.h"
+#include "TInterpreter.h"
+#include "TInterpreterValue.h"
+
+#include <sstream>
+
+
+// Parse positional arguments of the decorator
+long ParsePositionalArgs(PyObject* args)
+{
+   if (!PyTuple_Check(args)) {
+      PyErr_SetString(PyExc_RuntimeError, "Failed to parse positional arguments: Invalid tuple.");
+      return NULL;
+   }
+
+   if (PyTuple_Size(args) != 3) {
+      PyErr_SetString(PyExc_RuntimeError, "Failed to parse positional arguments: Expect exactly two positional arguments (list of input types, return type).");
+      return NULL;
+   }
+
+   auto instance = PyTuple_GetItem(args, 0);
+   auto inputTypes = PyTuple_GetItem(args, 1);
+   auto returnType = PyTuple_GetItem(args, 2);
+
+   // Attach arguments to instance
+   PyObject_SetAttrString(instance, "input_types", inputTypes);
+   PyObject_SetAttrString(instance, "return_type", returnType);
+
+   return 1l;
+}
+
+
+// Attach keyword to instance
+long AttachKeyword(PyObject* kwargs, PyObject* instance, const char* name)
+{
+   PyObject* p;
+   if ((p = PyDict_GetItemString(kwargs, name))) {
+      const auto status = PyObject_IsTrue(p);
+      if (status == 1) {
+         PyObject_SetAttrString(instance, name, Py_True);
+      } else if (status == 0) {
+         PyObject_SetAttrString(instance, name, Py_False);
+      } else {
+         return NULL;
+      }
+   }
+   return 1l;
+}
+
+
+// Parse keyword arguments of the decorator
+long ParseKeywordArguments(PyObject* args, PyObject* kwargs)
+{
+   if (!PyDict_Check(kwargs)) {
+      PyErr_SetString(PyExc_RuntimeError, "Failed to parse keyword arguments: Invalid dictionary.");
+      return NULL;
+   }
+
+   // Attach optional name to instance
+   auto instance = PyTuple_GetItem(args, 0);
+   PyObject* p;
+   if ((p = PyDict_GetItemString(kwargs, "name"))) {
+      if (!CPyCppyy_PyUnicode_Check(p)) {
+         PyErr_SetString(PyExc_RuntimeError,
+                 "Failed to parse arguments: Given name is not a valid string.");
+         return NULL;
+      }
+      PyObject_SetAttrString(instance, "name", p);
+   }
+
+   // Attach optional numpy_only flag to instance
+   if ((AttachKeyword(kwargs, instance, "numba_only") == NULL)) {
+      PyErr_SetString(PyExc_RuntimeError,
+              "Failed to parse arguments: Given object for numba_only cannot be evaluated as a boolean.");
+      return NULL;
+   }
+
+   // Attach optional generic_only flag to instance
+   if ((AttachKeyword(kwargs, instance, "generic_only") == NULL)) {
+      PyErr_SetString(PyExc_RuntimeError,
+              "Failed to parse arguments: Given object for generic_only cannot be evaluated as a boolean.");
+      return NULL;
+   }
+
+   // Attach optional verbose flag
+   if ((AttachKeyword(kwargs, instance, "verbose") == NULL)) {
+      PyErr_SetString(PyExc_RuntimeError,
+              "Failed to parse arguments: Given object for verbose flag cannot be evaluated as a boolean.");
+      return NULL;
+   }
+
+   return 1l;
+}
+
+
+// Init of class used as decorator to create generic C++ wrapper
+// The init parses the arguments passed to the decorator.
+PyObject* GenericCallableImpl_init(PyObject * /*self*/, PyObject *args, PyObject *kwargs)
+{
+   if(ParsePositionalArgs(args) == NULL) return NULL;
+
+   if(kwargs != 0) {
+      if(ParseKeywordArguments(args, kwargs) == NULL) return NULL;
+   }
+
+   Py_RETURN_NONE;
+}
+
+
+// Check arguments given to call operator of the decorator
+long CheckCallArgs(PyObject* args)
+{
+   if (!PyTuple_Check(args)) {
+      PyErr_SetString(PyExc_RuntimeError, "Failed to parse arguments: Invalid tuple.");
+      return NULL;
+   }
+
+   if (!(PyTuple_Size(args) == 2)) {
+      PyErr_SetString(PyExc_RuntimeError, "Failed to parse arguments: Expect exactly one argument (Python callable).");
+      return NULL;
+   }
+
+   return 1l;
+}
+
+
+// Check instance passed from init to call operator of the decorator
+long CheckInstance(PyObject* instance)
+{
+   if (!PyObject_HasAttrString(instance, "input_types")) {
+      PyErr_SetString(PyExc_RuntimeError, "Failed to create C++ callable: No input_types attribute found.");
+      return NULL;
+   }
+
+   if (!PyObject_HasAttrString(instance, "return_type")) {
+      PyErr_SetString(PyExc_RuntimeError, "Failed to create C++ callable: No return_type attribute found.");
+      return NULL;
+   }
+
+   return 1l;
+}
+
+
+// Check callable passed to decorator
+long CheckCallable(PyObject* callable)
+{
+   if (!PyCallable_Check(callable)) {
+      PyErr_SetString(PyExc_RuntimeError, "Failed to create C++ callable: Given PyObject is not callable.");
+      return NULL;
+   }
+   return 1l;
+}
+
+
+// Extract name of callable passed to call operator of the decorator.
+// Either extract the name from the optional keyword argument or from the
+// __name__ property of the callable itself.
+std::string ExtractName(PyObject* instance, PyObject* pyfunc)
+{
+   PyObject* pyname;
+   if (PyObject_HasAttrString(instance, "name")) {
+      pyname = PyObject_GetAttrString(instance, "name");
+   } else {
+      if (!PyObject_HasAttrString(pyfunc, "__name__")) {
+         PyErr_SetString(PyExc_RuntimeError, "Failed to create C++ callable: Python callable does not have attribute __name__.");
+         return "";
+      }
+      pyname = PyObject_GetAttrString(pyfunc, "__name__");
+   }
+   std::string name = CPyCppyy_PyUnicode_AsString(pyname);
+   Py_DECREF(pyname);
+   return name;
+}
+
+
+// Call method of class used as decorator to create generic C++ wrapper
+// The call method creates the C++ wrapper class for the Python callable and
+// passes through the actual callable.
+PyObject* GenericCallableImpl_call(PyObject * /*self*/, PyObject *args)
+{
+   // Parse arguments
+   if(CheckCallArgs(args) == NULL) return NULL;
+   auto instance = PyTuple_GetItem(args, 0);
+   auto pyfunc = PyTuple_GetItem(args, 1);
+   if(CheckCallable(pyfunc) == NULL) return NULL;
+   Py_INCREF(pyfunc);
+   if(CheckInstance(instance) == NULL) return NULL;
+
+   auto inputTypes = PyObject_GetAttrString(instance, "input_types");
+   auto returnType = PyObject_GetAttrString(instance, "return_type");
+
+   // Extract name of Python callable
+   auto name = ExtractName(instance, pyfunc);
+   if (name.compare("") == 0) return NULL;
+
+   // Get C++ return type
+   if (!CPyCppyy_PyUnicode_Check(returnType)) {
+      PyErr_SetString(PyExc_RuntimeError, "Failed to create C++ callable: Return type argument cannot be interpreted as string.");
+      return NULL;
+   }
+   std::string returnTypeStr = CPyCppyy_PyUnicode_AsString(returnType);
+   Py_DECREF(returnType);
+   if (returnTypeStr.compare("") == 0) {
+      returnTypeStr = "void";
+   }
+
+   // Put function in namespace
+   std::stringstream code;
+   code << "namespace CppCallable {\n";
+
+   // Set return type
+   code << returnTypeStr << " ";
+
+   // Set name of Python callable as function name
+   code << name;
+
+   // Build function signature, type string and list of variables
+   code << "(";
+
+   auto iter = PyObject_GetIter(inputTypes);
+   auto inputTypesSize = PyObject_Size(inputTypes);
+   Py_DECREF(inputTypes);
+   if (!iter) {
+      PyErr_SetString(PyExc_RuntimeError, "Failed to create C++ callable: Failed to iterate over input types.");
+      return NULL;
+   }
+
+   // Map C++ types to type characters of Python/C API (PyObject_CallFunction)
+   std::map<std::string, std::string> typemap = {
+       {"float", "f"},
+       {"double", "f"},
+       {"int", "i"},
+       {"unsigned int", "I"},
+       {"long", "l"},
+       {"unsigned long", "k"},
+   };
+
+   PyObject *item;
+   auto idx = 0u;
+   std::stringstream typestr;
+   std::vector<std::string> pytypes(inputTypesSize);
+   std::vector<std::string> inputTypesStr(inputTypesSize);
+   std::stringstream vars;
+   while ((item = PyIter_Next(iter))) {
+      // Convert argument to string
+      if (!CPyCppyy_PyUnicode_Check(item)) {
+         Py_DECREF(iter);
+         Py_DECREF(item);
+         PyErr_SetString(PyExc_RuntimeError, "Failed to create C++ callable: Failed to interpret input type as string.");
+         return NULL;
+      }
+
+      inputTypesStr[idx] = CPyCppyy_PyUnicode_AsString(item);
+      Py_DECREF(item);
+
+      auto pytype = typemap.find(inputTypesStr[idx]);
+      if (pytype != typemap.end()) { // Types in typemap
+         pytypes[idx] = pytype->second;
+         vars << pytypes[idx] << "_" << idx;
+         code << inputTypesStr[idx] << " " << pytypes[idx] << "_" << idx;
+      } else if (inputTypesStr[idx].compare("") == 0) { // No input type
+         pytypes[idx] = "";
+      } else if (inputTypesStr[idx].compare("bool") == 0) { // Bool
+         pytypes[idx] = "O";
+         vars << "pyb_" << idx;
+         code << inputTypesStr[idx] << " b_" << idx;
+      } else { // C++ object
+         pytypes[idx] = "O";
+         vars << "pyo_" << idx;
+         code << inputTypesStr[idx] << "& o_" << idx;
+      }
+      typestr << pytypes[idx];
+
+      if (idx != inputTypesSize - 1 && pytypes[idx].compare("") != 0) {
+         code << ", ";
+         vars << ", ";
+      }
+
+      idx++;
+   }
+   Py_DECREF(iter);
+
+   // Acquire lock to protect multi-threaded scenarios
+   code << ") {\n"
+        << "   // Acquire lock to protect multi-threaded scenarios\n"
+        << "   R__WRITE_LOCKGUARD(ROOT::gCoreMutex);\n\n";
+
+   // Get pointer to Python callable
+   code << "   // Get Python callable from pointer\n"
+        << "   auto pyfunc = reinterpret_cast<PyObject*>(" << pyfunc << ");\n"
+        << "   if (!PyCallable_Check(pyfunc)) {\n"
+        << "      throw std::runtime_error(\"Python object " << name << " is not callable.\");\n"
+        << "   }\n\n";
+
+   // Build Python proxies of the C++ objects for Python
+   code << "   // Build Python proxies for C++ objects\n";
+   std::stringstream cleanup; // Register clean-up code
+   bool hasPyBoolIncref = false;
+   for (std::size_t i = 0; i < pytypes.size(); i++) {
+      if (inputTypesStr[i].compare("bool") == 0) { // Bool
+         if (!hasPyBoolIncref) {
+            code << "   Py_INCREF(Py_True);\n"
+                 << "   Py_INCREF(Py_False);\n";
+            cleanup << "   Py_DECREF(Py_True);\n"
+                    << "   Py_DECREF(Py_False);\n";
+            hasPyBoolIncref = true;
+         }
+         code << "   auto pyb_" << i << " = b_" << i << " ? Py_True : Py_False;\n";
+      } else if (pytypes[i] == "O") { // C++ objects
+         code << "   auto pyo_" << i << " = TPython::CPPInstance_FromVoidPtr("
+              << "&o_" << i << ", \"" << inputTypesStr[i] << "\");\n";
+         cleanup << "   Py_DECREF(pyo_" << i << ");\n";
+      }
+   }
+   code << "\n";
+
+   // Call Python callable
+   auto typestr_str = typestr.str();
+   auto vars_str = vars.str();
+   if (vars_str.compare("") != 0) {
+      vars_str = ", " + vars_str;
+   }
+   code << "   // Call Python callable\n"
+        << "   auto pyresult = PyObject_CallFunction(pyfunc, (char*)\"" << typestr_str << "\"" << vars_str << ");\n"
+        << "   if (pyresult == 0) {\n"
+        << "      PyErr_Print();\n"
+        << "      throw std::runtime_error(\"Failed to call Python callable " << name << ".\");\n"
+        << "   }\n\n";
+
+   // Clean-up Python proxies
+   code << "   // Clean-up Python proxies\n"
+        << cleanup.str()
+        << "\n";
+
+   // Convert result to C++ type
+   code << "   // Convert result to C++ type\n";
+   if (returnTypeStr.compare("void") == 0) {
+      code << "   Py_DECREF(pyresult);\n\n"
+           << "   return;\n";
+   } else if (returnTypeStr.compare("bool") == 0) {
+      code << "   if (pyresult == Py_True) {\n"
+           << "      Py_DECREF(pyresult);\n"
+           << "      return true;\n"
+           << "   } else if (pyresult == Py_False) {\n"
+           << "      Py_DECREF(pyresult);\n"
+           << "      return false;\n"
+           << "   } else {\n"
+           << "      PyErr_Print();\n"
+           << "      throw std::runtime_error(\"Failed to convert return value of Python callable to C++ object: Python object is not of type PyBool.\");\n"
+           << "   }\n";
+   } else {
+      auto pytype = typemap.find(returnTypeStr);
+      if (pytype != typemap.end()) {
+         if (pytype->second == "f") {
+            code << "   auto result = PyFloat_AsDouble(pyresult);\n";
+         } else if (pytype->second == "i" || pytype->second == "l") {
+            code << "   auto result = PyLong_AsLong(pyresult);\n";
+         } else if (pytype->second == "I" || pytype->second == "k") {
+            code << "   auto result = PyLong_AsUnsignedLong(pyresult);\n";
+         }
+      } else {
+         code << "   if (!TPython::CPPInstance_Check(pyresult)) {\n"
+              << "      throw std::runtime_error(\"Failed to convert return value of Python callable to C++ object: Python object is not created by cppyy (CPPInstance).\");\n"
+              << "      \n"
+              << "   }\n";
+         code << "   auto result = *reinterpret_cast<" << returnTypeStr << "*>(TPython::CPPInstance_AsVoidPtr(pyresult));\n";
+      }
+
+      code << "   Py_DECREF(pyresult);\n\n"
+           << "   return result;\n";
+   }
+   code << "}\n}";
+
+   // Attach C++ wrapper code to callable
+   auto code_str = code.str();
+   auto code_cstr = code_str.c_str();
+   auto pycode = CPyCppyy_PyUnicode_FromString(code_cstr);
+   PyObject_SetAttrString(pyfunc, "__cpp_wrapper__", pycode);
+   Py_DECREF(pycode);
+
+   // Jit C++ wrapper
+   auto err = gInterpreter->Declare("#include \"Python.h\"");
+   if (!err) {
+      PyErr_SetString(PyExc_RuntimeError, "Failed to compile C++ wrapper: Failed to include Python.h.");
+      return NULL;
+   }
+
+   err = gInterpreter->Declare("#include \"TPython.h\"");
+   if (!err) {
+      PyErr_SetString(PyExc_RuntimeError, "Failed to compile C++ wrapper: Failed to include TPython.h.");
+      return NULL;
+   }
+
+   err = gInterpreter->Declare(code_cstr);
+   if (!err) {
+      PyErr_SetString(PyExc_RuntimeError,
+              ("Failed to compile C++ wrapper: Compilation error from following wrapper code.\n" + code.str()).c_str());
+      return NULL;
+   }
+
+   // Pass through Python callable
+   return pyfunc;
+}
+
+
+// Call method of class used as decorator to create C++ wrapper using numba
+// The call method creates the C++ wrapper class for the Python callable and
+// passes through the actual callable.
+PyObject* NumbaCallableImpl_call(PyObject * /*self*/, PyObject *args)
+{
+   // Parse arguments
+   if(CheckCallArgs(args) == NULL) return NULL;
+   auto instance = PyTuple_GetItem(args, 0);
+   auto pyfunc = PyTuple_GetItem(args, 1);
+   if(CheckCallable(pyfunc) == NULL) return NULL;
+   Py_INCREF(pyfunc);
+   if(CheckInstance(instance) == NULL) return NULL;
+
+   auto inputTypes = PyObject_GetAttrString(instance, "input_types");
+   auto returnType = PyObject_GetAttrString(instance, "return_type");
+
+   // Extract name of Python callable
+   auto name = ExtractName(instance, pyfunc);
+   if (name.compare("") == 0) return NULL;
+
+   // Get C++ return type
+   if (!CPyCppyy_PyUnicode_Check(returnType)) {
+      PyErr_SetString(PyExc_RuntimeError, "Failed to create C++ callable: Return type argument cannot be interpreted as string.");
+      return NULL;
+   }
+   std::string returnTypeStr = CPyCppyy_PyUnicode_AsString(returnType);
+   Py_DECREF(returnType);
+   if (returnTypeStr.compare("") == 0) {
+      returnTypeStr = "void";
+   }
+
+   // Find numba types for C++ types
+   std::map<std::string, std::string> typemap = {
+       {"float", "float32"},
+       {"double", "float64"},
+       {"int", "int32"},
+       {"unsigned int", "uint32"},
+       {"long", "int64"},
+       {"unsigned long", "uint64"},
+       {"bool", "boolean"},
+   };
+
+   auto iter = PyObject_GetIter(inputTypes);
+   Py_DECREF(inputTypes);
+   if (!iter) {
+      PyErr_SetString(PyExc_RuntimeError, "Failed to create C++ callable: Failed to iterate over input types.");
+      return NULL;
+   }
+
+   PyObject *item;
+   std::vector<std::string> numbaTypes;
+   std::vector<std::string> cppTypes;
+   while ((item = PyIter_Next(iter))) {
+      // Convert argument to string
+      if (!CPyCppyy_PyUnicode_Check(item)) {
+         Py_DECREF(iter);
+         Py_DECREF(item);
+         PyErr_SetString(PyExc_RuntimeError, "Failed to create C++ callable: Failed to interpret input type as string.");
+         return NULL;
+      }
+
+      const std::string cpptype = CPyCppyy_PyUnicode_AsString(item);
+      Py_DECREF(item);
+
+      auto t = typemap.find(cpptype);
+      if (t != typemap.end()) { // Types in typemap
+         numbaTypes.emplace_back(t->second);
+         cppTypes.emplace_back(cpptype);
+      } else if (cpptype.compare("") == 0) { // No input, skip
+      } else {
+         Py_DECREF(iter);
+         Py_DECREF(item);
+         PyErr_SetString(PyExc_RuntimeError,
+                 ("Failed to create C++ callable: Input type " + cpptype + " is not valid for jitting with numba.").c_str());
+         return NULL;
+      }
+   }
+   Py_DECREF(iter);
+
+   // Import numba
+   auto numba = PyImport_ImportModule("numba");
+   if (!numba) {
+      PyErr_SetString(PyExc_RuntimeError, "Failed to import numba.");
+      return NULL;
+   }
+
+   // Get cfunc method
+   auto cfunc = PyObject_GetAttrString(numba, "cfunc");
+   Py_DECREF(numba);
+   if (!cfunc) {
+      PyErr_SetString(PyExc_RuntimeError, "Failed to import cfunc from numba.");
+      return NULL;
+   }
+
+   // Jit Python callable
+   std::stringstream numbaSignature;
+   auto t = typemap.find(returnTypeStr);
+   if (t != typemap.end()) {
+      numbaSignature << typemap[returnTypeStr] << "(";
+   } else if (returnTypeStr.compare("") == 0 || returnTypeStr.compare("void") == 0) {
+      numbaSignature << "void(";
+   } else {
+      PyErr_SetString(PyExc_RuntimeError, "Failed to create C++ callable: Return type is not valid for jitting with numba.");
+      return NULL;
+   }
+   for(std::size_t i = 0; i < numbaTypes.size(); i++) {
+      numbaSignature << numbaTypes[i];
+      if (i != numbaTypes.size() - 1) {
+         numbaSignature << ", ";
+      }
+   }
+   numbaSignature << ")";
+   auto numbaSignatureStr = numbaSignature.str();
+   auto args_ = Py_BuildValue("(s)", (char*)numbaSignatureStr.c_str());
+   auto kwargs_ = Py_BuildValue("{s:O}", (char*)"nopython", Py_True);
+   auto decorator = PyObject_Call(cfunc, args_, kwargs_);
+   Py_DECREF(cfunc);
+   if (!decorator) {
+      PyErr_SetString(PyExc_RuntimeError,
+              ("Failed to create C++ callable: Unable to create instance of numba.cfunc with signature "
+              + numbaSignatureStr + ".").c_str());
+      return NULL;
+   }
+   Py_DECREF(args_);
+   Py_DECREF(kwargs_);
+
+   auto jitted = PyObject_CallFunction(decorator, (char*)"O", pyfunc);
+   Py_DECREF(decorator);
+   if (!jitted) {
+      PyObject *type, *value, *traceback;
+      PyErr_Fetch(&type, &value, &traceback);
+      auto pyerr = PyObject_Str(value);
+      std::string pyerrstr = CPyCppyy_PyUnicode_AsString(pyerr);
+      PyErr_SetString(PyExc_RuntimeError,
+              ("Failed to create C++ callable: Unable to jit function using numba.cfunc with signature "
+               + numbaSignatureStr + ":\n" + pyerrstr).c_str());
+      Py_DECREF(pyerr);
+      Py_DECREF(type);
+      Py_DECREF(value);
+      Py_DECREF(traceback);
+      return NULL;
+   }
+
+   // Attach jitted function to callable
+   PyObject_SetAttrString(pyfunc, "__numba_cfunc__", jitted);
+   Py_DECREF(jitted);
+
+   // Extract function pointer
+   auto pyaddress = PyObject_GetAttrString(jitted, "address");
+   if (!pyaddress) {
+      PyErr_SetString(PyExc_RuntimeError, "Failed to create C++ callable: Unable to extract function pointer from numba.cfunc.");
+      return NULL;
+   }
+   auto address = PyLong_AsUnsignedLongLong(pyaddress);
+
+   // Put wrapper function in ROOT namespace
+   std::stringstream code;
+   code << "namespace CppCallable {\n";
+
+   // Set return type of wrapper functoin
+   code << returnTypeStr << " ";
+
+   // Set name of Python callable as function name
+   code << name;
+
+   // Build function signature, function pointer cast and variable list
+   code << "(";
+   std::stringstream vars;
+   std::stringstream fPtr;
+   fPtr << returnTypeStr << "(*)(";
+   for(std::size_t i = 0; i < cppTypes.size(); i++) {
+      code << cppTypes[i] << " x_" << i;
+      vars << "x_" << i;
+      fPtr << cppTypes[i];
+      if (i != cppTypes.size() - 1) {
+         code << ", ";
+         vars << ", ";
+         fPtr << ", ";
+      }
+   }
+   code << ") {\n";
+   fPtr << ")";
+
+   // Cast int to C function pointer
+   code << "   auto funcptr = reinterpret_cast<" << fPtr.str() << ">(" << address << ");\n";
+
+   // Return result
+   code << "   return funcptr(" << vars.str() << ");\n";
+
+   // Close function and namespace
+   code << "}\n}";
+
+   // Jit C++ wrapper
+   auto code_str = code.str();
+   auto code_cstr = code_str.c_str();
+
+   auto err = gInterpreter->Declare(code_cstr);
+   if (!err) {
+      PyErr_SetString(PyExc_RuntimeError,
+              ("Failed to compile C++ wrapper: Compilation error from following wrapper code.\n" + code.str()).c_str());
+      return NULL;
+   }
+
+   // Attach code function to callable
+   auto pycode = CPyCppyy_PyUnicode_FromString(code_cstr);
+   PyObject_SetAttrString(pyfunc, "__cpp_wrapper__", pycode);
+   Py_DECREF(pycode);
+
+   // Pass through Python callable
+   return pyfunc;
+}
+
+
+bool GetKeyword(PyObject* obj, const char* name, bool defaultVal)
+{
+   auto attr = PyObject_GetAttrString(obj, name);
+   bool prop = defaultVal;
+   if (attr != NULL) {
+      prop = PyObject_IsTrue(attr);
+      Py_DECREF(attr);
+   }
+   return prop;
+}
+
+
+// Emit a RuntimeWarning using the warnings module
+// Note that this function returns silently if something goes wrong.
+void EmitRuntimeWarning(const std::string message)
+{
+   // Load warnings.warn
+   auto warnings = PyImport_ImportModule("warnings");
+   if (warnings == NULL) return;
+   auto warn = PyObject_GetAttrString(warnings, "warn");
+   Py_DECREF(warnings);
+   if (warn == NULL) return;
+
+   // Load RuntimeWarning class
+#if PY_MAJOR_VERSION < 3
+   auto builtins = PyImport_ImportModule("__builtin__");
+#else
+   auto builtins = PyImport_ImportModule("builtins");
+#endif
+   if (builtins == NULL) {
+      Py_DECREF(warn);
+      return;
+   }
+   auto runtimeWarning = PyObject_GetAttrString(builtins, "RuntimeWarning");
+   Py_DECREF(builtins);
+   if (runtimeWarning == NULL) {
+      Py_DECREF(warn);
+      return;
+   }
+
+   // Call warn(message, RuntimeWarning)
+   PyObject_CallFunction(warn, "(sO)", message.c_str(), runtimeWarning);
+   Py_DECREF(warn);
+   Py_DECREF(runtimeWarning);
+}
+
+
+// Call method of class used as decorator to create either generic or numba C++ wrapper.
+// The call method creates the C++ wrapper class for the Python callable and
+// passes through the actual callable.
+PyObject* ProxyCallableImpl_call(PyObject * /*self*/, PyObject *args)
+{
+   // Get numba_only and generic_only optional arguments
+   // The arguments are interpreted as follows (in this order):
+   // 1) numba_only = true , generic_only = true or false: Just try numba implementation
+   // 2) numba_only = false, generic_only = true: Just try generic implementation
+   // 3) numba_only = false, generic_only = false: Try numba first, fail silently, go to generic (default setting)
+   auto instance = PyTuple_GetItem(args, 0);
+
+   auto numbaOnly = GetKeyword(instance, "numba_only", false);
+   auto genericOnly = GetKeyword(instance, "generic_only", false);
+   auto verbose = GetKeyword(instance, "verbose", true);
+
+   // Case 1) Use only numba
+   if (numbaOnly) {
+      return NumbaCallableImpl_call(NULL, args);
+   }
+
+   // Case 2) Use only generic
+   else if (genericOnly) {
+      return GenericCallableImpl_call(NULL, args);
+   }
+
+   // Case 3) Try first numba and then fall back to generic
+   else {
+      auto pyfunc = NumbaCallableImpl_call(NULL, args);
+      if (pyfunc) {
+         return pyfunc;
+      } else {
+         if (verbose) {
+            EmitRuntimeWarning("Failed to compile Python callable using numba, fall back to generic implementation. Note that the generic implementation is potentially slow.");
+         }
+         return GenericCallableImpl_call(NULL, args);
+      }
+   }
+}
+
+
+// Method definition for class used as decorator to create C++ wrapper
+static PyMethodDef CallableImplMethods[] =
+{
+    {"__init__", (PyCFunction)GenericCallableImpl_init, METH_VARARGS|METH_KEYWORDS, "Parse decorator arguments"},
+    {"__call__", ProxyCallableImpl_call, METH_VARARGS, "Create C++ wrapper function"},
+    {NULL},
+};
+
+
+// Proxy to return the C++ wrapper class which can be used as decorator
+PyObject *PyROOT::GetCppCallableClass(PyObject * /*self*/, PyObject * args) {
+   // Parse argument to get type of callable class
+   if (!PyTuple_Check(args)) {
+      PyErr_SetString(PyExc_RuntimeError, "Failed to create callable class: Invalid tuple.");
+      return NULL;
+   }
+
+   // Create wrapper class for decorator
+   auto classDict = PyDict_New();
+   auto className = PyString_FromString("CppCallableImpl");
+   auto callableClass = PyClass_New(NULL, classDict, className);
+   Py_DECREF(className);
+
+   // Add methods
+   for (auto def = CallableImplMethods; def->ml_name != NULL; def++) {
+      PyObject *func = PyCFunction_New(def, NULL);
+      PyObject *method = PyMethod_New(func, NULL, callableClass);
+	  PyDict_SetItemString(classDict, def->ml_name, method);
+	  Py_DECREF(func);
+	  Py_DECREF(method);
+   }
+   Py_DECREF(classDict);
+
+   // Return implementation class
+   return callableClass;
+}

--- a/bindings/pyroot_experimental/PyROOT/src/GenericPyz.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/GenericPyz.cxx
@@ -9,12 +9,16 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+#include "Python.h"
+
 #include "CPyCppyy.h"
 #include "PyROOTPythonize.h"
 #include "CPPInstance.h"
 #include "Utility.h"
 #include "TInterpreter.h"
 #include "TInterpreterValue.h"
+
+#include <sstream>
 
 using namespace CPyCppyy;
 

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
@@ -63,6 +63,8 @@ static PyMethodDef gPyROOTMethods[] = {{(char *)"AddDirectoryWritePyz", (PyCFunc
                                         (char *)"Get pointer to data of vector"},
                                        {(char *)"GetSizeOfType", (PyCFunction)PyROOT::GetSizeOfType, METH_VARARGS,
                                         (char *)"Get size of data-type"},
+                                       {(char *)"GetCppCallableClass", (PyCFunction)PyROOT::GetCppCallableClass, METH_VARARGS,
+                                        (char *)"Get class to wrap Python callable as C++ callable"},
                                        {(char *)"AsRVec", (PyCFunction)PyROOT::AsRVec, METH_O,
                                         (char *)"Get object with array interface as RVec"},
                                        {NULL, NULL, 0, NULL}};

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
@@ -32,6 +32,8 @@ PyObject *AddSetItemTCAPyz(PyObject *self, PyObject *args);
 
 PyObject *AsRVec(PyObject *self, PyObject *obj);
 
+PyObject *GetCppCallableClass(PyObject *self, PyObject *args);
+
 PyObject *AddUsingToClass(PyObject *self, PyObject *args);
 PyObject *GetEndianess(PyObject *self, PyObject *args);
 PyObject *GetVectorDataPointer(PyObject *self, PyObject *args);

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -90,3 +90,6 @@ endif()
 
 # std::string_view backport in CPyCppyy
 ROOT_ADD_PYUNITTEST(pyroot_string_view_backport string_view_backport.py)
+
+# Test wrapping Python callables for use in C++
+ROOT_ADD_PYUNITTEST(pyroot_cppcallable cppcallable.py)

--- a/bindings/pyroot_experimental/PyROOT/test/cppcallable.py
+++ b/bindings/pyroot_experimental/PyROOT/test/cppcallable.py
@@ -1,0 +1,616 @@
+import unittest
+import ROOT
+import sys
+
+
+default_test_inputs = [-1.0, 0.0, 100.0]
+
+
+class GenericCppCallable(unittest.TestCase):
+    """
+    Test decorator to create generic C++ wrapper for Python callables
+    """
+
+    test_inputs = default_test_inputs
+
+    # Test refcounts
+    def test_refcount_decorator(self):
+        """
+        Test refcount of decorator
+        """
+        x = ROOT.DeclareCppCallable([""], "", generic_only=True)
+        self.assertEqual(sys.getrefcount(x), 2)
+
+    def test_refcount_pycallable(self):
+        """
+        Test refcount of decorated callable
+        """
+        @ROOT.DeclareCppCallable([""], "", generic_only=True)
+        def f0():
+            pass
+        self.assertEqual(sys.getrefcount(f0), 2)
+
+    # Test attributes
+    def test_cpp_wrapper_code(self):
+        """
+        Test C++ wrapper code attribute
+        """
+        @ROOT.DeclareCppCallable([""], "", generic_only=True)
+        def f1():
+            pass
+        self.assertTrue(hasattr(f1, "__cpp_wrapper__"))
+        self.assertTrue(type(f1.__cpp_wrapper__) == str)
+        self.assertEqual(sys.getrefcount(f1.__cpp_wrapper__), 2)
+
+   # Test optional name
+    def test_optional_name(self):
+        """
+        Test optional name of wrapper function
+        """
+        optname = "optname1"
+        @ROOT.DeclareCppCallable([""], "", name=optname, generic_only=True)
+        def f():
+            pass
+        self.assertTrue(hasattr(ROOT.CppCallable, optname))
+
+    # Test wrappings
+    def test_wrapper_out_f(self):
+        """
+        Test wrapper with different input/output configurations
+        """
+        @ROOT.DeclareCppCallable(["float"], "float", generic_only=True)
+        def f2(x):
+            return float(x)
+        for v in self.test_inputs:
+            x1 = f2(v)
+            x2 = ROOT.CppCallable.f2(v)
+            self.assertEqual(x1, x2)
+            self.assertEqual(type(x1), type(x2))
+
+    def test_wrapper_out_d(self):
+        """
+        Test wrapper with different input/output configurations
+        """
+        @ROOT.DeclareCppCallable(["float"], "double", generic_only=True)
+        def f2d(x):
+            return float(x)
+        for v in self.test_inputs:
+            x1 = f2d(v)
+            x2 = ROOT.CppCallable.f2d(v)
+            self.assertEqual(x1, x2)
+            # NOTE: There is no double in Python because everything is a double.
+            self.assertEqual(type(x1), type(x2))
+
+    def test_wrapper_out_i(self):
+        """
+        Test wrapper with different input/output configurations
+        """
+        @ROOT.DeclareCppCallable(["float"], "int", generic_only=True)
+        def f3(x):
+            return int(x)
+        for v in self.test_inputs:
+            x1 = f3(v)
+            x2 = ROOT.CppCallable.f3(v)
+            self.assertEqual(x1, x2)
+            self.assertEqual(type(x1), type(x2))
+
+    def test_wrapper_out_l(self):
+        """
+        Test wrapper with different input/output configurations
+        """
+        @ROOT.DeclareCppCallable(["float"], "long", generic_only=True)
+        def f4(x):
+            return long(x)
+        for v in self.test_inputs:
+            x1 = f4(v)
+            x2 = ROOT.CppCallable.f4(v)
+            self.assertEqual(x1, x2)
+            self.assertEqual(type(x1), type(x2))
+
+    def test_wrapper_out_u(self):
+        """
+        Test wrapper with different input/output configurations
+        """
+        @ROOT.DeclareCppCallable(["float"], "unsigned int", generic_only=True)
+        def f5(x):
+            return int(abs(x))
+        for v in self.test_inputs:
+            x1 = f5(v)
+            x2 = ROOT.CppCallable.f5(v)
+            self.assertEqual(x1, x2)
+            self.assertEqual(type(x1), int)
+            # NOTE: cppyy does not return an Python int for unsigned int but a long.
+            # This could be fixed but as well should not have any impact.
+            self.assertEqual(type(x2), long)
+
+    def test_wrapper_out_k(self):
+        """
+        Test wrapper with different input/output configurations
+        """
+        @ROOT.DeclareCppCallable(["float"], "unsigned long", generic_only=True)
+        def f6(x):
+            return long(abs(x))
+        for v in self.test_inputs:
+            x1 = f6(v)
+            x2 = ROOT.CppCallable.f6(v)
+            self.assertEqual(x1, x2)
+            self.assertEqual(type(x1), type(x2))
+
+    def test_wrapper_out_b(self):
+        """
+        Test wrapper with different input/output configurations
+        """
+        @ROOT.DeclareCppCallable(["float"], "bool", generic_only=True)
+        def f6b(x):
+            return bool(x>0)
+        for v in self.test_inputs:
+            x1 = f6b(v)
+            x2 = ROOT.CppCallable.f6b(v)
+            self.assertEqual(x1, x2)
+            self.assertEqual(type(x1), type(x2))
+
+    def test_wrapper_inout_f(self):
+        """
+        Test wrapper with different input/output configurations
+        """
+        @ROOT.DeclareCppCallable(["float"], "float", generic_only=True)
+        def f7(x):
+            return float(x)
+        for v in self.test_inputs:
+            x1 = f7(v)
+            x2 = ROOT.CppCallable.f7(v)
+            self.assertEqual(x1, x2)
+            self.assertEqual(v, x2)
+
+    def test_wrapper_inout_d(self):
+        """
+        Test wrapper with different input/output configurations
+        """
+        @ROOT.DeclareCppCallable(["float"], "float", generic_only=True)
+        def f7d(x):
+            return float(x)
+        for v in self.test_inputs:
+            x1 = f7d(v)
+            x2 = ROOT.CppCallable.f7d(v)
+            self.assertEqual(x1, x2)
+            self.assertEqual(v, x2)
+
+    def test_wrapper_inout_i(self):
+        """
+        Test wrapper with different input/output configurations
+        """
+        @ROOT.DeclareCppCallable(["int"], "int", generic_only=True)
+        def f8(x):
+            return int(x)
+        for v in self.test_inputs:
+            v = int(v)
+            x1 = f8(v)
+            x2 = ROOT.CppCallable.f8(v)
+            self.assertEqual(x1, x2)
+            self.assertEqual(v, x2)
+
+    def test_wrapper_inout_l(self):
+        """
+        Test wrapper with different input/output configurations
+        """
+        @ROOT.DeclareCppCallable(["long"], "long", generic_only=True)
+        def f9(x):
+            return long(x)
+        for v in self.test_inputs:
+            v = long(v)
+            x1 = f9(v)
+            x2 = ROOT.CppCallable.f9(v)
+            self.assertEqual(x1, x2)
+            self.assertEqual(v, x2)
+
+    def test_wrapper_inout_u(self):
+        """
+        Test wrapper with different input/output configurations
+        """
+        @ROOT.DeclareCppCallable(["unsigned int"], "unsigned int", generic_only=True)
+        def f10(x):
+            return int(abs(x))
+        for v in self.test_inputs:
+            v = int(abs(v))
+            x1 = f10(v)
+            x2 = ROOT.CppCallable.f10(v)
+            self.assertEqual(x1, x2)
+            self.assertEqual(v, x2)
+
+    def test_wrapper_inout_k(self):
+        """
+        Test wrapper with different input/output configurations
+        """
+        @ROOT.DeclareCppCallable(["unsigned long"], "unsigned long", generic_only=True)
+        def f11(x):
+            return long(abs(x))
+        for v in self.test_inputs:
+            v = long(abs(v))
+            x1 = f11(v)
+            x2 = ROOT.CppCallable.f11(v)
+            self.assertEqual(x1, x2)
+            self.assertEqual(v, x2)
+
+    def test_wrapper_inout_u(self):
+        """
+        Test wrapper with different input/output configurations
+        """
+        @ROOT.DeclareCppCallable(["unsigned int"], "unsigned int", generic_only=True)
+        def f10(x):
+            return int(abs(x))
+        for v in self.test_inputs:
+            v = int(abs(v))
+            x1 = f10(v)
+            x2 = ROOT.CppCallable.f10(v)
+            self.assertEqual(x1, x2)
+            self.assertEqual(v, x2)
+
+    def test_wrapper_inout_k(self):
+        """
+        Test wrapper with different input/output configurations
+        """
+        @ROOT.DeclareCppCallable(["unsigned long"], "unsigned long", generic_only=True)
+        def f11(x):
+            return long(abs(x))
+        for v in self.test_inputs:
+            v = long(abs(v))
+            x1 = f11(v)
+            x2 = ROOT.CppCallable.f11(v)
+            self.assertEqual(x1, x2)
+            self.assertEqual(v, x2)
+
+    def test_wrapper_inout_b(self):
+        """
+        Test wrapper with different input/output configurations
+        """
+        @ROOT.DeclareCppCallable(["bool"], "bool", generic_only=True)
+        def f11b(x):
+            return bool(not x)
+        for v in [True, False]:
+            x1 = f11b(v)
+            x2 = ROOT.CppCallable.f11b(v)
+            self.assertEqual(x1, x2)
+            self.assertEqual(not v, x2)
+
+    # Test wrapper with STL vectors
+    def test_wrapper_in_vec(self):
+        """
+        Test wrapper with different input/output configurations
+        """
+        @ROOT.DeclareCppCallable(["vector<float>"], "unsigned int", generic_only=True)
+        def f14(x):
+            return x.size()
+        for v in self.test_inputs:
+            v = int(abs(v))
+            w = ROOT.std.vector["float"](v)
+            x1 = f14(w)
+            x2 = ROOT.CppCallable.f14(w)
+            self.assertEqual(x1, x2)
+            self.assertEqual(v, x2)
+
+    def test_wrapper_inout_vec(self):
+        """
+        Test wrapper with different input/output configurations
+        """
+        @ROOT.DeclareCppCallable(["vector<float>"], "vector<float>", generic_only=True)
+        def f15(x):
+            for i in range(x.size()):
+                x[i] *= 2.0
+            return x
+        for v in self.test_inputs:
+            v = int(abs(v))
+            w = ROOT.std.vector["float"](v)
+            w.resize(v)
+            for i in range(v):
+                w[i] = i
+            x1 = f15(w)
+            x2 = ROOT.CppCallable.f15(w)
+            self.assertEqual(x1, x2)
+
+    # Test custom types
+    def test_wrapper_in_customtype(self):
+        """
+        Test wrapper with custom types
+        """
+        ROOT.gInterpreter.Declare("""
+        struct Foo {
+            static const int foo = 42;
+        };
+        """)
+        @ROOT.DeclareCppCallable(["Foo"], "int", generic_only=True)
+        def f16(x):
+            return x.foo
+        x = ROOT.Foo()
+        y = ROOT.CppCallable.f16(x)
+        self.assertEqual(y, 42)
+
+    def test_wrapper_out_customtype(self):
+        """
+        Test wrapper with custom types
+        """
+        ROOT.gInterpreter.Declare("""
+        struct Foo2 {
+            static const int foo = 42;
+        };
+        """)
+        @ROOT.DeclareCppCallable([""], "Foo2", generic_only=True)
+        def f17():
+            return ROOT.Foo2()
+        y = ROOT.CppCallable.f17()
+        self.assertEqual(y.foo, 42)
+
+    # Test cling integration
+    def test_cling(self):
+        """
+        Test function call in cling
+        """
+        @ROOT.DeclareCppCallable(["float"], "float", generic_only=True)
+        def f12(x):
+            return 2.0 * x
+        ROOT.gInterpreter.ProcessLine("y12 = CppCallable::f12(42.0);")
+        self.assertEqual(f12(42.0), ROOT.y12)
+
+    # Test RDataFrame integration
+    def test_rdataframe(self):
+        """
+        Test function call as part of RDataFrame
+        """
+        @ROOT.DeclareCppCallable(["unsigned int"], "float", generic_only=True)
+        def f13(x):
+            return 2.0 * x
+        df = ROOT.ROOT.RDataFrame(4).Define("x", "rdfentry_").Define("y", "CppCallable::f13(x)")
+        mean_x = df.Mean("x")
+        mean_y = df.Mean("y")
+        self.assertEqual(mean_x.GetValue(), 1.5)
+        self.assertEqual(mean_y.GetValue(), 3.0)
+
+
+# Decorator which skips tests if numba is not found
+def needs_numba(f):
+    try:
+        import numba
+    except:
+        return unittest.skip("Numba not found.")(f)
+    return f
+
+
+class NumbaCppCallable(unittest.TestCase):
+    """
+    Test decorator to create C++ wrapper for Python callables using numba
+    """
+
+    test_inputs = default_test_inputs
+
+    # Test refcounts
+    @needs_numba
+    def test_refcount_decorator(self):
+        """
+        Test refcount of decorator
+        """
+        x = ROOT.DeclareCppCallable([""], "", numba_only=True)
+        self.assertEqual(sys.getrefcount(x), 2)
+
+    @needs_numba
+    def test_refcount_pycallable(self, numba_only=True):
+        """
+        Test refcount of decorated callable
+        """
+        def f1(x):
+            return x
+        def f2(x):
+            return x
+        fn0 = ROOT.DeclareCppCallable(["float"], "float")(f1)
+        import numba
+        ref = numba.cfunc("float32(float32)", nopython=True)(f2)
+        # ROOT holds an additional reference compared to plain numba
+        self.assertEqual(sys.getrefcount(f1), sys.getrefcount(f2) + 1)
+
+    # Test optional name
+    @needs_numba
+    def test_optional_name(self, numba_only=True):
+        """
+        Test optional name of wrapper function
+        """
+        optname = "optname2"
+        @ROOT.DeclareCppCallable([""], "", name=optname)
+        def f():
+            pass
+        self.assertTrue(hasattr(ROOT.CppCallable, optname))
+
+    # Test attributes
+    @needs_numba
+    def test_cpp_wrapper_code(self, numba_only=True):
+        """
+        Test C++ wrapper code attribute
+        """
+        @ROOT.DeclareCppCallable([""], "")
+        def fn1():
+            pass
+        self.assertTrue(hasattr(fn1, "__cpp_wrapper__"))
+        self.assertTrue(type(fn1.__cpp_wrapper__) == str)
+        self.assertEqual(sys.getrefcount(fn1.__cpp_wrapper__), 2)
+
+    # Test cling integration
+    @needs_numba
+    def test_cling(self, numba_only=True):
+        """
+        Test function call in cling
+        """
+        @ROOT.DeclareCppCallable(["float"], "float")
+        def fn12(x):
+            return 2.0 * x
+        ROOT.gInterpreter.ProcessLine("y12 = CppCallable::fn12(42.0);")
+        self.assertEqual(fn12(42.0), ROOT.y12)
+
+    # Test RDataFrame integration
+    @needs_numba
+    def test_rdataframe(self, numba_only=True):
+        """
+        Test function call as part of RDataFrame
+        """
+        @ROOT.DeclareCppCallable(["unsigned int"], "float")
+        def fn13(x):
+            return 2.0 * x
+        df = ROOT.ROOT.RDataFrame(4).Define("x", "rdfentry_").Define("y", "CppCallable::fn13(x)")
+        mean_x = df.Mean("x")
+        mean_y = df.Mean("y")
+        self.assertEqual(mean_x.GetValue(), 1.5)
+        self.assertEqual(mean_y.GetValue(), 3.0)
+
+    # Test wrappings
+    @needs_numba
+    def test_wrapper_out_f(self, numba_only=True):
+        """
+        Test wrapper with different input/output configurations
+        """
+        @ROOT.DeclareCppCallable(["float"], "float")
+        def fn2(x):
+            return float(x)
+        for v in self.test_inputs:
+            x1 = fn2(v)
+            x2 = ROOT.CppCallable.fn2(v)
+            self.assertEqual(x1, x2)
+            self.assertEqual(type(x1), type(x2))
+
+    @needs_numba
+    def test_wrapper_out_d(self, numba_only=True):
+        """
+        Test wrapper with different input/output configurations
+        """
+        @ROOT.DeclareCppCallable(["float"], "double")
+        def fn2d(x):
+            return float(x)
+        for v in self.test_inputs:
+            x1 = fn2d(v)
+            x2 = ROOT.CppCallable.fn2d(v)
+            self.assertEqual(x1, x2)
+            # NOTE: There is no double in Python because everything is a double.
+            self.assertEqual(type(x1), type(x2))
+
+    @needs_numba
+    def test_wrapper_out_i(self, numba_only=True):
+        """
+        Test wrapper with different input/output configurations
+        """
+        @ROOT.DeclareCppCallable(["float"], "int")
+        def fn3(x):
+            return int(x)
+        for v in self.test_inputs:
+            x1 = fn3(v)
+            x2 = ROOT.CppCallable.fn3(v)
+            self.assertEqual(x1, x2)
+            self.assertEqual(type(x1), type(x2))
+
+    @needs_numba
+    def test_wrapper_out_l(self, numba_only=True):
+        """
+        Test wrapper with different input/output configurations
+        """
+        @ROOT.DeclareCppCallable(["float"], "long")
+        def fn4(x):
+            return x
+        for v in self.test_inputs:
+            x1 = fn4(v)
+            x2 = ROOT.CppCallable.fn4(v)
+            self.assertEqual(x1, x2)
+            self.assertEqual(long, type(x2))
+
+    @needs_numba
+    def test_wrapper_out_u(self, numba_only=True):
+        """
+        Test wrapper with different input/output configurations
+        """
+        @ROOT.DeclareCppCallable(["float"], "unsigned int")
+        def fn5(x):
+            return abs(x)
+        for v in self.test_inputs:
+            x1 = fn5(v)
+            x2 = ROOT.CppCallable.fn5(v)
+            self.assertEqual(x1, x2)
+            # NOTE: cppyy does not return an Python int for unsigned int but a long.
+            # This could be fixed but as well should not have any impact.
+            self.assertEqual(type(x2), long)
+
+    @needs_numba
+    def test_wrapper_out_k(self, numba_only=True):
+        """
+        Test wrapper with different input/output configurations
+        """
+        @ROOT.DeclareCppCallable(["float"], "unsigned long")
+        def fn6(x):
+            return abs(x)
+        for v in self.test_inputs:
+            x1 = fn6(v)
+            x2 = ROOT.CppCallable.fn6(v)
+            self.assertEqual(x1, x2)
+            self.assertEqual(long, type(x2))
+
+    @needs_numba
+    def test_wrapper_out_b(self, numba_only=True):
+        """
+        Test wrapper with different input/output configurations
+        """
+        @ROOT.DeclareCppCallable(["float"], "bool")
+        def fn6b(x):
+            return x>0
+        for v in self.test_inputs:
+            x1 = fn6b(v)
+            x2 = ROOT.CppCallable.fn6b(v)
+            self.assertEqual(x1, x2)
+            self.assertEqual(type(x1), type(x2))
+
+
+class ProxyCppCallable(unittest.TestCase):
+    """
+    Test decorator to create C++ wrapper for Python callables using either numba
+    or the generic implementation
+    """
+
+    test_inputs = default_test_inputs
+
+    # Test refcounts
+    def test_refcount_decorator(self):
+        """
+        Test refcount of decorator
+        """
+        x = ROOT.DeclareCppCallable([""], "")
+        self.assertEqual(sys.getrefcount(x), 2)
+
+    # Test optional name
+    def test_optional_name(self):
+        """
+        Test optional name of wrapper function
+        """
+        optname = "optname3"
+        @ROOT.DeclareCppCallable([""], "", name=optname)
+        def f():
+            pass
+        self.assertTrue(hasattr(ROOT.CppCallable, optname))
+
+    # Test switching between numba and generic impl
+    @needs_numba
+    def test_use_numba(self):
+        """
+        Test switch to numba impl
+        """
+        @ROOT.DeclareCppCallable(["float"], "float")
+        def fp0(x):
+            return x
+        self.assertIn("auto funcptr = reinterpret_cast<float(*)(float)>",
+                fp0.__cpp_wrapper__)
+
+    def test_use_generic(self):
+        """
+        Test switch to generic impl
+        """
+        @ROOT.DeclareCppCallable(["float"], "vector<float>", verbose=False)
+        def fp1(x):
+            y = ROOT.std.vector("float")(1)
+            y[0] = x
+            return y
+        self.assertIn("auto pyresult = PyObject_CallFunction(pyfunc",
+                fp1.__cpp_wrapper__)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Alright, I've put in the comments from @etejedor (thanks!). Now we've a refined version regarding the user interface:

```python
@ROOT.DeclareCppCallable(["float"], "float")
def f(x)
    return 2.0 * x

# General use-cases
ROOT.CppCallable.f(21) # Returns 42
ROOT.gInterpreter.ProcessLine("cout << CppCallable::f(21.0) << endl;") # Prints 42.0

# Inject callable into dataframe
df = ROOT.ROOT.RDataFrame(10).Define("x", "rdfentry__").Define("CppCallable::f(x)")
```

You can set an optional name.

```python
@ROOT.DeclareCppCallable(["float"], "float", name="g")
def f(x)
    return 2.0 * x

ROOT.CppCallable.g(21.0) # Returns 42
```

By default, we try numba first and then fall back to the generic implementation. You can force only numba using `numba_only=True` as optional argument.

```python
@ROOT.DeclareCppCallable(["float"], "float", numba_only=True)
def f(x)
    return 2.0 * x
```

In addition, you can set a `verbose` flag to let PyROOT tell you if the decorator falls back to the generic implementation.

```python
@ROOT.DeclareCppCallable(["float"], "string", verbose=True)
def f(x)
    return ROOT.std.string(str(x))

ROOT.CppCallable.f(x)
# 1) Throws Python warning:
# /home/stefan/foo.py:5: RuntimeWarning: Failed to compile Python callable using numba. Fall back to generic implementation.
#  @ROOT.DeclareCppCallable(["float"], "string", verbose=True)
# 2) Falls back to generic impl and prints "42" (as string)
```

**DEPRECATED:**

I've cleaned up and improved the feature. Here's the basic workflow now:

```python
@ROOT.DeclareCallable(["float"], "float")
def f(x)
    return 2.0 * x

# General use-cases
ROOT.ROOT.f(21) # Returns 42
ROOT.gInterpreter.ProcessLine("cout << ROOT::f(21.0) << endl;") # Prints 42.0

# Inject callable into dataframe
df = ROOT.ROOT.RDataFrame(10).Define("x", "rdfentry__").Define("ROOT::f(x)")
```

The `DeclareCallable` dispatches between numba and the generic implementation. It tries to compile the thingy with numba (falls through silently) and otherwise tries the generic implementation (fails noisily).
However, you can force using the generic implementation or numba by using the decorators `DeclareGenericCallable` and `DeclareNumbaCallable`. The interface is exactly the same than for the general `DeclareCallable` decorator.

In addition, you can now give the wrapped function a custom name:

```python
@ROOT.DeclareCallable(["float"], "float", "my_name")
def f(x):
    return 2.0 * x

ROOT.ROOT.my_name(21) # Returns 42
```

**DEPRECATED:**

Add workflow to invoke Python callables from C++. The mechanism builds with cling a C++ wrapper class around Python callables and publishs them to the user. See following example for the basic mechanism.

```python
import ROOT

# Because C++ is strongly typed, we have to declare the types of the inputs and the output
@ROOT.DeclareCppCallable(["float"], "float")
def func(x):
    return 2.0 * x

print(func(1.0)) # Prints 2.0
print(ROOT.PyROOT.func(1.0)) # Prints 2.0
ROOT.gInterpreter.ProcessLine("cout << PyROOT::func(1.0) << endl;") # Prints 2.0
```

This allows us to run Python code in wrapped C++ workflow, e.g. for `RDataFrame`:

```python
import ROOT
import numpy

@ROOT.DeclareCppCallable(["unsigned int"], "float")
def func(x):
    return numpy.power(x, 2)

df = ROOT.RDataFrame(4).Define("x", "rdfentry_").Define("y", "PyROOT::func(x)")
npy = df.AsNumpy()
print(npy["x"]) # Prints [0, 1, 2, 3]
print(npy["y"]) # Prints [0.0, 1.0, 4.0, 9.0]
```

Finally, the approach is fully compatible with any custom C++ types you may have.

```python
import ROOT

ROOT.gInterpreter.Declare("""
    struct Foo {
        static const int foo = 42;
    };
""")

@ROOT.DeclareCppCallable(["Foo"], "")
def func(x):
    print(x.foo)

ROOT.gInterpreter.ProcessLine("Foo x; PyROOT::func(x);") # Prints 42
```
There are still some things to check before merging:

- [ ] Double check reference counting
- [ ] C++ wrapper takes (lvalue) references, what happens with rvalues? What is the universal thingy?
- [ ] We put the C++ callable in the `PyROOT::` namespace. This is fine? It can be everything, even the global namespace. What is a sane solution here?
- [ ] How many copies we are doing finally? What is the performance?
- [ ] What happens in MT scenarios? Put in a test case!
- [ ] We have to ship the public cppyy interface with the ROOT headers.