### PR TITLE
[Exp PyROOT] Add plotOn overloads of RooAbsData to RooDataHist

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
@@ -8,6 +8,7 @@ set(py_sources
   ROOT/pythonization/__init__.py
   ROOT/pythonization/_generic.py
   ROOT/pythonization/_rooabscollection.py
+  ROOT/pythonization/_roodatahist.py
   ROOT/pythonization/_rdataframe.py
   ROOT/pythonization/_rvec.py
   ROOT/pythonization/_stl_vector.py

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_roodatahist.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_roodatahist.py
@@ -1,0 +1,26 @@
+# Author: Enric Tejedor CERN  03/2019
+
+################################################################################
+# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from ROOT import pythonization
+
+from libROOTPython import AddUsingToClass
+
+
+@pythonization()
+def pythonize_roodatahist(klass, name):
+    # Parameters:
+    # klass: class to be pythonized
+    # name: string containing the name of the class
+
+    if name == 'RooDataHist':
+        # Add 'using' overloads for plotOn from RooAbsData
+        AddUsingToClass(klass, 'plotOn')
+
+    return True

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
@@ -55,6 +55,8 @@ static PyMethodDef gPyROOTMethods[] = {{(char *)"AddDirectoryWritePyz", (PyCFunc
                                         (char *)"Customize the setting of an item of a TClonesArray"},
                                        {(char *)"AddPrettyPrintingPyz", (PyCFunction)PyROOT::AddPrettyPrintingPyz, METH_VARARGS,
                                         (char *)"Add pretty printing pythonization"},
+                                       {(char *)"AddUsingToClass", (PyCFunction)PyROOT::AddUsingToClass, METH_VARARGS,
+                                        (char *)"Add 'using' overloads for a given method to a class"},
                                        {(char *)"GetEndianess", (PyCFunction)PyROOT::GetEndianess, METH_NOARGS,
                                         (char *)"Get endianess of the system"},
                                        {(char *)"GetVectorDataPointer", (PyCFunction)PyROOT::GetVectorDataPointer, METH_VARARGS,

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
@@ -32,6 +32,7 @@ PyObject *AddSetItemTCAPyz(PyObject *self, PyObject *args);
 
 PyObject *AsRVec(PyObject *self, PyObject *obj);
 
+PyObject *AddUsingToClass(PyObject *self, PyObject *args);
 PyObject *GetEndianess(PyObject *self);
 PyObject *GetVectorDataPointer(PyObject *self, PyObject *args);
 PyObject *GetSizeOfType(PyObject *self, PyObject *args);

--- a/bindings/pyroot_experimental/PyROOT/src/PyzPythonHelpers.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyzPythonHelpers.cxx
@@ -19,7 +19,10 @@ PyROOT extension module.
 
 #include "CPyCppyy.h"
 #include "CPPInstance.h"
+#include "Utility.h"
+
 #include "PyROOTPythonize.h"
+
 #include "RConfig.h"
 #include "TInterpreter.h"
 
@@ -94,4 +97,28 @@ PyObject *PyROOT::GetEndianess(PyObject * /* self */)
 #else
    return CPyCppyy_PyUnicode_FromString(">");
 #endif
+}
+
+////////////////////////////////////////////////////////////////////////////
+/// \brief Add base class overloads of a given method to a derived class
+/// \param[in] self Always null, since this is a module function.
+/// \param[in] args[0] Derived class.
+/// \param[in] args[1] Name of the method whose base class overloads to
+///                    inject in the derived class.
+///
+/// This function adds base class overloads to a derived class for a given
+/// method. This covers the 'using' case, which is not supported by default
+/// by the bindings.
+PyObject *PyROOT::AddUsingToClass(PyObject * /* self */, PyObject *args)
+{
+   // Get derived class to pythonize
+   PyObject *pyclass = PyTuple_GetItem(args, 0);
+
+   // Get method name where to add overloads
+   PyObject *pyname = PyTuple_GetItem(args, 1);
+   auto cppname = CPyCppyy_PyUnicode_AsString(pyname);
+
+   CPyCppyy::Utility::AddUsingToClass(pyclass, cppname);
+
+   Py_RETURN_NONE;
 }

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -71,7 +71,10 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_rvec_asrvec rvec_asrvec.py)
 # RDataFrame and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_rdataframe_asnumpy rdataframe_asnumpy.py)
 
-# RooAbsCollection and subclasses pythonizations
-if(ROOT_roofit_FOUND)
+if(roofit)
+  # RooAbsCollection and subclasses pythonizations
   ROOT_ADD_PYUNITTEST(pyroot_pyz_rooabscollection_len rooabscollection_len.py)
+
+  # RooDataHist pythonisations
+  ROOT_ADD_PYUNITTEST(pyroot_pyz_roodatahist_ploton roodatahist_ploton.py)
 endif()

--- a/bindings/pyroot_experimental/PyROOT/test/rooabscollection_len.py
+++ b/bindings/pyroot_experimental/PyROOT/test/rooabscollection_len.py
@@ -19,6 +19,11 @@ class RooAbsCollectionLen(unittest.TestCase):
         for elem in cls.rooabsarg_list:
             cls.tlist.Add(elem)
 
+    @classmethod
+    def tearDownClass(cls):
+        # Clear TList before Python list deletes the objects
+        cls.tlist.Clear()
+
     # Helpers
     def check_len(self, c):
         self.assertEqual(len(c), self.num_elems)
@@ -34,4 +39,3 @@ class RooAbsCollectionLen(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/bindings/pyroot_experimental/PyROOT/test/roodatahist_ploton.py
+++ b/bindings/pyroot_experimental/PyROOT/test/roodatahist_ploton.py
@@ -1,0 +1,64 @@
+import unittest
+
+import ROOT
+
+
+class RooDataHistPlotOn(unittest.TestCase):
+    """
+    Test for the pythonization that allows RooDataHist to use the
+    overloads of plotOn defined in RooAbsData.
+    """
+
+    # Helpers
+    def create_hist_and_frame(self):
+        # Inspired by the code of rf402_datahandling.py
+
+        x = ROOT.RooRealVar('x', 'x', -10, 10)
+        y = ROOT.RooRealVar('y', 'y', 0, 40)
+        x.setBins(10)
+        y.setBins(10)
+
+        d = ROOT.RooDataSet('d', 'd', ROOT.RooArgSet(x, y))
+        for i in range(10):
+            x.setVal(i / 2)
+            y.setVal(i)
+            d.add(ROOT.RooArgSet(x, y))
+
+        dh = ROOT.RooDataHist('dh', 'binned version of d', ROOT.RooArgSet(x, y), d)
+
+        yframe = y.frame(ROOT.RooFit.Bins(10), ROOT.RooFit.Title('Operations on binned datasets'))
+
+        return dh, yframe
+
+    # Tests
+    def test_overload1(self):
+        dh, yframe = self.create_hist_and_frame()
+
+        # Overload in RooDataHist
+        # RooPlot* RooDataHist::plotOn(RooPlot* frame, RooAbsData::PlotOpt o)
+        res = dh.plotOn(yframe, ROOT.RooAbsData.PlotOpt())
+        self.assertEqual(type(res), ROOT.RooPlot)
+
+    def test_overload2(self):
+        dh, yframe = self.create_hist_and_frame()
+
+        # Overload taken from RooAbsData
+        # RooPlot* RooAbsData::plotOn(RooPlot* frame, const RooCmdArg& arg1 = RooCmdArg::none(),
+        # const RooCmdArg& arg2 = RooCmdArg::none(), const RooCmdArg& arg3 = RooCmdArg::none(),
+        # const RooCmdArg& arg4 = RooCmdArg::none(), const RooCmdArg& arg5 = RooCmdArg::none(),
+        # const RooCmdArg& arg6 = RooCmdArg::none(), const RooCmdArg& arg7 = RooCmdArg::none(),
+        # const RooCmdArg& arg8 = RooCmdArg::none())
+        res = dh.plotOn(yframe)
+        self.assertEqual(type(res), ROOT.RooPlot)
+
+    def test_overload3(self):
+        dh, yframe = self.create_hist_and_frame()
+
+        # Overload taken from RooAbsData
+        # RooPlot* RooAbsData::plotOn(RooPlot* frame, const RooLinkedList& cmdList)
+        res = dh.plotOn(yframe, ROOT.RooLinkedList())
+        self.assertEqual(type(res), ROOT.RooPlot)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Cppyy does not automatically add to a class the method overloads that come from a `using` statement. For this reason, a pythonisation is needed for `RooDataHist` to see (in Python) the `plotOn` overloads it is using from `RooAbsData`.