### PR TITLE
[TMVA] Optimizer choice simplification (Update of #3414)

### DIFF
--- a/tmva/tmva/inc/TMVA/OptimizeConfigParameters.h
+++ b/tmva/tmva/inc/TMVA/OptimizeConfigParameters.h
@@ -40,6 +40,8 @@
 
 #include "TH1.h"
 
+class TestOptimizeConfigParameters;
+
 namespace TMVA {
 
    class MethodBase;
@@ -47,6 +49,7 @@ namespace TMVA {
    class OptimizeConfigParameters : public IFitterTarget  {
 
    public:
+      friend TestOptimizeConfigParameters;
 
       //default constructor
       OptimizeConfigParameters(MethodBase * const method, std::map<TString,TMVA::Interval*> tuneParameters, TString fomType="Separation", TString optimizationType = "GA");

--- a/tmva/tmva/src/OptimizeConfigParameters.cxx
+++ b/tmva/tmva/src/OptimizeConfigParameters.cxx
@@ -358,12 +358,20 @@ Double_t TMVA::OptimizeConfigParameters::GetFOM()
    }else{
       if      (fFOMType == "Separation")  fom = GetSeparation();
       else if (fFOMType == "ROCIntegral") fom = GetROCIntegral();
-      else if (fFOMType == "SigEffAtBkgEff01")  fom = GetSigEffAtBkgEff(0.1);
-      else if (fFOMType == "SigEffAtBkgEff001") fom = GetSigEffAtBkgEff(0.01);
-      else if (fFOMType == "SigEffAtBkgEff002") fom = GetSigEffAtBkgEff(0.02);
-      else if (fFOMType == "BkgRejAtSigEff05")  fom = GetBkgRejAtSigEff(0.5);
-      else if (fFOMType == "BkgEffAtSigEff05")  fom = GetBkgEffAtSigEff(0.5);
-      else {
+      else if (fFOMType.BeginsWith("SigEffAtBkgEff0")){
+         TString percent=TString(fFOMType(14,fFOMType.Sizeof())); //Strip down to number
+         //Support users giving a fraction and old formatting, both cases must start with a 0
+         if (!percent.CountChar('.')) percent.Insert(1,".");
+         fom = GetSigEffAtBkgEff(percent.Atof());
+      }else if (fFOMType.BeginsWith("BkgRejAtSigEff0")){
+         TString percent=TString(fFOMType(14,fFOMType.Sizeof())); 
+         if (!percent.CountChar('.')) percent.Insert(1,".");
+         fom = GetBkgRejAtSigEff(percent.Atof());
+      }else if (fFOMType.BeginsWith("BkgEffAtSigEff0")){
+         TString percent=TString(fFOMType(14,fFOMType.Sizeof())); 
+         if (!percent.CountChar('.')) percent.Insert(1,".");
+         fom = GetBkgEffAtSigEff(percent.Atof());
+      }else {
          Log()<<kFATAL << " ERROR, you've specified as Figure of Merit in the "
               << " parameter optimisation " << fFOMType << " which has not"
               << " been implemented yet!! ---> exit " << Endl;

--- a/tmva/tmva/src/OptimizeConfigParameters.cxx
+++ b/tmva/tmva/src/OptimizeConfigParameters.cxx
@@ -365,7 +365,7 @@ Double_t TMVA::OptimizeConfigParameters::GetFOM()
       }
    };
 
-   Double_t fom=0;
+   Double_t fom = 0;
    if (fMethod->DoRegression()){
       std::cout << " ERROR: Sorry, Regression is not yet implement for automatic parameter optimisation"
                 << " --> exit" << std::endl;
@@ -382,6 +382,7 @@ Double_t TMVA::OptimizeConfigParameters::GetFOM()
               << " been implemented yet!! ---> exit " << Endl;
       }
    }
+
    fFOMvsIter.push_back(fom);
    //   std::cout << "fom="<<fom<<std::endl; // should write that into a debug log (as option)
    return fom;

--- a/tmva/tmva/test/CMakeLists.txt
+++ b/tmva/tmva/test/CMakeLists.txt
@@ -10,6 +10,9 @@ include_directories(${ROOT_INCLUDE_DIRS})
 ROOT_ADD_GTEST(TestRandomGenerator
                TestRandomGenerator.cxx
                LIBRARIES ${Libraries})
+ROOT_ADD_GTEST(TestOptimizeConfigParameters
+               TestOptimizeConfigParameters.cxx
+               LIBRARIES ${Libraries})
 
 project(tmva-tests)
 find_package(ROOT REQUIRED)

--- a/tmva/tmva/test/TestOptimizeConfigParameters.cxx
+++ b/tmva/tmva/test/TestOptimizeConfigParameters.cxx
@@ -1,0 +1,271 @@
+
+// ROOT
+#include "TRandom3.h"
+
+// TMVA
+#include "TMVA/DataLoader.h"
+#include "TMVA/Factory.h"
+#include "TMVA/Interval.h"
+#include "TMVA/OptimizeConfigParameters.h"
+#include "TMVA/Config.h"
+
+// Stdlib
+#include <iostream>
+
+// External
+#include "gtest/gtest.h"
+
+class TestOptimizeConfigParametersFixture : public ::testing::Test {
+public:
+   TestOptimizeConfigParametersFixture()
+   : fDataloader(GetDataloader()),
+     fFactory(GetFactory()),
+     fMethod(GetMethod(fFactory, fDataloader))
+   {
+      TMVA::MsgLogger::InhibitOutput();
+   }
+
+   TMVA::MethodBase * GetMethod() {return fMethod;}
+
+protected:
+   void SetUp() override {}
+   void TearDown () override {}
+
+   TMVA::DataLoader * GetDataloader()
+   {
+      TRandom3 rng(100);
+
+      auto dl = new TMVA::DataLoader{"Dataloader"};
+      dl->AddVariable("x");
+      for (Int_t n = 0; n < 100; ++n) {
+         dl->AddSignalTrainingEvent({rng.Gaus()+0.1});
+         dl->AddSignalTestEvent({rng.Gaus()+0.1});
+         dl->AddBackgroundTrainingEvent({rng.Gaus()-0.1});
+         dl->AddBackgroundTestEvent({rng.Gaus()-0.1});
+      }
+
+      dl->PrepareTrainingAndTestTree("", "!V");
+
+      return dl;
+   }
+
+   TMVA::Factory * GetFactory()
+   {
+      TMVA::gConfig().SetSilent(true);
+      return new TMVA::Factory{"", "!V:Silent:!DrawProgressBar"};
+   }
+
+   TMVA::MethodBase * GetMethod(TMVA::Factory * f,
+                                TMVA::DataLoader * dl)
+   {
+      f->BookMethod(dl, TMVA::Types::kBDT, "BDT",
+                     "!V:NTrees=1:BoostType=Grad:NCuts=10");
+      f->TrainAllMethods();
+      auto * m = f->GetMethod(dl->GetName(), "BDT");
+      return dynamic_cast<TMVA::MethodBase *>(m);
+   }
+
+   TMVA::DataLoader * fDataloader;
+   TMVA::Factory * fFactory;
+   TMVA::MethodBase * fMethod;
+};
+
+/*
+ * This class is a friend class to the unit under test and its main purpose is
+ * to forward calls to private functions.
+ *
+ * It also provides a static test environment so that the creation of dataset
+ * and any potetial shared operations (e.g. training) is executed only once
+ * for all tests.
+ */
+class TestOptimizeConfigParameters {
+public:
+   TestOptimizeConfigParameters(TString fomType, TMVA::MethodBase * method)
+   :  fOpt(GetOptimiser(fomType, method))
+   {}
+
+   Double_t GetFOM() {
+      return fOpt.GetFOM();
+   }
+
+   Double_t GetSigEffAtBkgEff(double x) {
+      return fOpt.GetSigEffAtBkgEff(x);
+   }
+
+   Double_t GetBkgRejAtSigEff(double x) {
+      return fOpt.GetBkgRejAtSigEff(x);
+   }
+
+   Double_t GetBkgEffAtSigEff(double x) {
+      return fOpt.GetBkgEffAtSigEff(x);
+   }
+
+private:
+   TMVA::OptimizeConfigParameters GetOptimiser(TString fomType, TMVA::MethodBase * method)
+   {
+      std::map<TString, TMVA::Interval *> params{};
+      params.insert(std::pair<TString, TMVA::Interval *>("NTrees", new TMVA::Interval(10, 1000, 5)));
+      return TMVA::OptimizeConfigParameters(method, params, fomType);
+   }
+
+   TMVA::OptimizeConfigParameters fOpt;
+};
+
+
+TEST_F(TestOptimizeConfigParametersFixture, FOM_SigEffAtBkgEff)
+{
+   {   
+      auto opt0 = TestOptimizeConfigParameters("SigEffAtBkgEff0.001", GetMethod());
+      EXPECT_EQ(opt0.GetFOM(), opt0.GetSigEffAtBkgEff(0.001));
+
+      auto opt1 = TestOptimizeConfigParameters("SigEffAtBkgEff0001", GetMethod());
+      EXPECT_EQ(opt1.GetFOM(), opt1.GetSigEffAtBkgEff(0.001));
+
+      std::cout << "opt0.GetSigEffAtBkgEff(0.001): "
+                << opt0.GetSigEffAtBkgEff(0.001) << std::endl;
+   }
+
+   {
+      auto opt0 = TestOptimizeConfigParameters("SigEffAtBkgEff0.01", GetMethod());
+      EXPECT_EQ(opt0.GetFOM(), opt0.GetSigEffAtBkgEff(0.01));
+
+      auto opt1 = TestOptimizeConfigParameters("SigEffAtBkgEff001", GetMethod());
+      EXPECT_EQ(opt1.GetFOM(), opt1.GetSigEffAtBkgEff(0.01));
+
+      std::cout << "opt0.GetSigEffAtBkgEff(0.01): "
+                << opt0.GetSigEffAtBkgEff(0.01) << std::endl;
+   }
+
+   {
+      auto opt0 = TestOptimizeConfigParameters("SigEffAtBkgEff0.1", GetMethod());
+      EXPECT_EQ(opt0.GetFOM(), opt0.GetSigEffAtBkgEff(0.1));
+
+      auto opt1 = TestOptimizeConfigParameters("SigEffAtBkgEff01", GetMethod());
+      EXPECT_EQ(opt1.GetFOM(), opt1.GetSigEffAtBkgEff(0.1));
+
+      std::cout << "opt0.GetSigEffAtBkgEff(0.1): "
+                << opt0.GetSigEffAtBkgEff(0.1) << std::endl;
+   }
+
+   {
+      auto opt0 = TestOptimizeConfigParameters("SigEffAtBkgEff0.5", GetMethod());
+      EXPECT_EQ(opt0.GetFOM(), opt0.GetSigEffAtBkgEff(0.5));
+
+      auto opt1 = TestOptimizeConfigParameters("SigEffAtBkgEff05", GetMethod());
+      EXPECT_EQ(opt1.GetFOM(), opt1.GetSigEffAtBkgEff(0.5));
+
+      std::cout << "opt0.GetSigEffAtBkgEff(0.5): "
+                << opt0.GetSigEffAtBkgEff(0.5) << std::endl;
+   }
+
+
+   // auto opt = TestOptimizeConfigParameters("SigEffAtBkg1", GetMethod());
+   // auto opt = TestOptimizeConfigParameters("SigEffAtBkg10", GetMethod());
+   // Expect crash
+}
+
+
+TEST_F(TestOptimizeConfigParametersFixture, FOM_BkgRejAtSigEff)
+{
+   {   
+      auto opt0 = TestOptimizeConfigParameters("BkgRejAtSigEff0.001", GetMethod());
+      EXPECT_EQ(opt0.GetFOM(), opt0.GetBkgRejAtSigEff(0.001));
+
+      auto opt1 = TestOptimizeConfigParameters("BkgRejAtSigEff0001", GetMethod());
+      EXPECT_EQ(opt1.GetFOM(), opt1.GetBkgRejAtSigEff(0.001));
+
+      std::cout << "opt0.GetBkgRejAtSigEff(0.001): "
+                << opt0.GetBkgRejAtSigEff(0.001) << std::endl;
+   }
+
+   {
+      auto opt0 = TestOptimizeConfigParameters("BkgRejAtSigEff0.01", GetMethod());
+      EXPECT_EQ(opt0.GetFOM(), opt0.GetBkgRejAtSigEff(0.01));
+
+      auto opt1 = TestOptimizeConfigParameters("BkgRejAtSigEff001", GetMethod());
+      EXPECT_EQ(opt1.GetFOM(), opt1.GetBkgRejAtSigEff(0.01));
+
+      std::cout << "opt0.GetBkgRejAtSigEff(0.01): "
+                << opt0.GetBkgRejAtSigEff(0.01) << std::endl;
+   }
+
+   {
+      auto opt0 = TestOptimizeConfigParameters("BkgRejAtSigEff0.1", GetMethod());
+      EXPECT_EQ(opt0.GetFOM(), opt0.GetBkgRejAtSigEff(0.1));
+
+      auto opt1 = TestOptimizeConfigParameters("BkgRejAtSigEff01", GetMethod());
+      EXPECT_EQ(opt1.GetFOM(), opt1.GetBkgRejAtSigEff(0.1));
+
+      std::cout << "opt0.GetBkgRejAtSigEff(0.1): "
+                << opt0.GetBkgRejAtSigEff(0.1) << std::endl;
+   }
+
+   {
+      auto opt0 = TestOptimizeConfigParameters("BkgRejAtSigEff0.5", GetMethod());
+      EXPECT_EQ(opt0.GetFOM(), opt0.GetBkgRejAtSigEff(0.5));
+
+      auto opt1 = TestOptimizeConfigParameters("BkgRejAtSigEff05", GetMethod());
+      EXPECT_EQ(opt1.GetFOM(), opt1.GetBkgRejAtSigEff(0.5));
+
+      std::cout << "opt0.GetBkgRejAtSigEff(0.5): "
+                << opt0.GetBkgRejAtSigEff(0.5) << std::endl;
+   }
+
+
+   // auto opt = TestOptimizeConfigParameters("BkgRejAtSigEff1", GetMethod());
+   // auto opt = TestOptimizeConfigParameters("BkgRejAtSigEff10", GetMethod());
+   // Expect crash
+}
+
+
+TEST_F(TestOptimizeConfigParametersFixture, FOM_BkgEffAtSigEff)
+{
+   {   
+      auto opt0 = TestOptimizeConfigParameters("BkgEffAtSigEff0.001", GetMethod());
+      EXPECT_EQ(opt0.GetFOM(), opt0.GetBkgEffAtSigEff(0.001));
+
+      auto opt1 = TestOptimizeConfigParameters("BkgEffAtSigEff0001", GetMethod());
+      EXPECT_EQ(opt1.GetFOM(), opt1.GetBkgEffAtSigEff(0.001));
+
+      std::cout << "opt0.GetBkgEffAtSigEff(0.001): "
+                << opt0.GetBkgEffAtSigEff(0.001) << std::endl;
+   }
+
+   {
+      auto opt0 = TestOptimizeConfigParameters("BkgEffAtSigEff0.01", GetMethod());
+      EXPECT_EQ(opt0.GetFOM(), opt0.GetBkgEffAtSigEff(0.01));
+
+      auto opt1 = TestOptimizeConfigParameters("BkgEffAtSigEff001", GetMethod());
+      EXPECT_EQ(opt1.GetFOM(), opt1.GetBkgEffAtSigEff(0.01));
+
+      std::cout << "opt0.GetBkgEffAtSigEff(0.01): "
+                << opt0.GetBkgEffAtSigEff(0.01) << std::endl;
+   }
+
+   {
+      auto opt0 = TestOptimizeConfigParameters("BkgEffAtSigEff0.1", GetMethod());
+      EXPECT_EQ(opt0.GetFOM(), opt0.GetBkgEffAtSigEff(0.1));
+
+      auto opt1 = TestOptimizeConfigParameters("BkgEffAtSigEff01", GetMethod());
+      EXPECT_EQ(opt1.GetFOM(), opt1.GetBkgEffAtSigEff(0.1));
+
+      std::cout << "opt0.GetBkgEffAtSigEff(0.1): "
+                << opt0.GetBkgEffAtSigEff(0.1) << std::endl;
+   }
+
+   {
+      auto opt0 = TestOptimizeConfigParameters("BkgEffAtSigEff0.5", GetMethod());
+      EXPECT_EQ(opt0.GetFOM(), opt0.GetBkgEffAtSigEff(0.5));
+
+      auto opt1 = TestOptimizeConfigParameters("BkgEffAtSigEff05", GetMethod());
+      EXPECT_EQ(opt1.GetFOM(), opt1.GetBkgEffAtSigEff(0.5));
+
+      std::cout << "opt0.GetBkgEffAtSigEff(0.5): "
+                << opt0.GetBkgEffAtSigEff(0.5) << std::endl;
+   }
+
+
+   // auto opt = TestOptimizeConfigParameters("BkgEffAtSigEff1", GetMethod());
+   // auto opt = TestOptimizeConfigParameters("BkgEffAtSigEff10", GetMethod());
+   // Expect crash
+}

--- a/tutorials/tmva/TMVAClassification.C
+++ b/tutorials/tmva/TMVAClassification.C
@@ -518,7 +518,7 @@ int TMVAClassification( TString myMethodList = "" )
    //  Now you can optimize the setting (configuration) of the MVAs using the set of training events
    // STILL EXPERIMENTAL and only implemented for BDT's !
    //
-   //     factory->OptimizeAllMethods("SigEffAt001","Scan");
+   //     factory->OptimizeAllMethods("SigEffAtBkg0.01","Scan");
    //     factory->OptimizeAllMethods("ROCIntegral","FitGA");
    //
    // --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
See old [PR#3414](https://github.com/root-project/root/pull/3414) for initial discussion. This PR cleans of the code a bit and adds tests.

@josephmckenna Creating the testing code was slightly involved, hence the new PR and not asking you to submit a fix.

I think the idea is a nice and natural improvement on the functionality that was already implemented.

Motivation from original submitter:
> To explore the performance of a range of settings for BDTs, we often find a 0.1% background level most interesting for our physics applications for us in the ALPHA collaboration. Instead of adding one additional use case, I have added a general form such that users could set:
> // factory->OptimizeAllMethods("SigEffAtBkgEff0001","Scan");