### PR TITLE
Fix TFormulaTests

### DIFF
--- a/test/TFormulaParsingTests.h
+++ b/test/TFormulaParsingTests.h
@@ -975,7 +975,7 @@ bool test49() {
              "return ok; }");
 
    m.SaveSource("TFormulaTest49.C");
-   int ret = gSystem->Exec("root -q -l -i TFormulaTest49.C");
+   int ret = gSystem->Exec("root.exe -q -l -i TFormulaTest49.C");
    ok |= (ret == 0);
    return ok;
 }


### PR DESCRIPTION
use root.exe instead of root for test49 where a ROOT macro is run using gSystem->Exec