### PR TITLE
Add templated TDirectoryFile::Get

### DIFF
--- a/io/io/inc/TDirectoryFile.h
+++ b/io/io/inc/TDirectoryFile.h
@@ -75,6 +75,11 @@ public:
    virtual TObject    *FindObjectAny(const char *name) const;
    virtual TObject    *FindObjectAnyFile(const char *name) const;
    virtual TObject    *Get(const char *namecycle);
+   /// See documentation of TDirectoryFile::Get(const char *namecycle)
+   template <class T> inline T* Get(const char* namecycle)
+   {
+      return static_cast<T*>(GetObjectChecked(namecycle, TClass::GetClass<T>()));
+   }
    virtual TDirectory *GetDirectory(const char *apath, Bool_t printError = false, const char *funcname = "GetDirectory");
    template <class T> inline void GetObject(const char* namecycle, T*& ptr) // See TDirectory::Get for information
       {

--- a/io/io/src/TDirectoryFile.cxx
+++ b/io/io/src/TDirectoryFile.cxx
@@ -874,17 +874,16 @@ TObject *TDirectoryFile::FindObjectAny(const char *aname) const
 /// |  foo;1  | get cycle 1 of foo on file |
 ///
 /// The retrieved object should in principle derive from TObject.
-/// If not, the function TDirectoryFile::GetObject should be called.
+/// If not, the function TDirectoryFile::Get<T> should be called.
 /// However, this function will still work for a non-TObject, provided that
 /// the calling application cast the return type to the correct type (which
 /// is the actual type of the object).
 ///
-/// ### The GetObjectMethod
-/// The method GetObject offers better protection and avoids the need
-/// for any cast:
+/// ### The Get<T> Method
+/// The method Get<T> offers better protection and avoids the need for any
+/// cast:
 /// ~~~{.cpp}
-/// MyClass *obj;
-/// directory->GetObject("some object",obj);
+/// auto obj = directory->Get<MyClass>("some object");
 /// if (obj) { ... the object exist and inherits from MyClass ... }
 /// ~~~
 ///
@@ -1009,10 +1008,9 @@ void *TDirectoryFile::GetObjectChecked(const char *namecycle, const char* classn
 ///
 /// auto objPtr = (MyClass*)directory->GetObjectChecked("some object of MyClass","MyClass"));
 ///
-/// Note: We recommend using the method TDirectoryFile::GetObject:
+/// Note: We recommend using the method TDirectoryFile::Get<T>:
 /// ~~~{.cpp}
-/// MyClass *obj = nullptr;
-/// directory->GetObject("some object inheriting from MyClass",obj);
+/// auto obj = directory->Get<MyClass>("some object inheriting from MyClass");
 /// if (obj) { ... we found what we are looking for ... }
 /// ~~~
 

--- a/io/io/src/TDirectoryFile.cxx
+++ b/io/io/src/TDirectoryFile.cxx
@@ -883,8 +883,8 @@ TObject *TDirectoryFile::FindObjectAny(const char *aname) const
 /// The method Get<T> offers better protection and avoids the need for any
 /// cast:
 /// ~~~{.cpp}
-/// auto obj = directory->Get<MyClass>("some object");
-/// if (obj) { ... the object exist and inherits from MyClass ... }
+/// auto objPtr = directory->Get<MyClass>("some object");
+/// if (objPtr) { ... the object exist and inherits from MyClass ... }
 /// ~~~
 ///
 /// ### Very important note about inheritance
@@ -1010,8 +1010,8 @@ void *TDirectoryFile::GetObjectChecked(const char *namecycle, const char* classn
 ///
 /// Note: We recommend using the method TDirectoryFile::Get<T>:
 /// ~~~{.cpp}
-/// auto obj = directory->Get<MyClass>("some object inheriting from MyClass");
-/// if (obj) { ... we found what we are looking for ... }
+/// auto objPtr = directory->Get<MyClass>("some object inheriting from MyClass");
+/// if (objPtr) { ... we found what we are looking for ... }
 /// ~~~
 
 void *TDirectoryFile::GetObjectChecked(const char *namecycle, const TClass* expectedClass)


### PR DESCRIPTION
Quality-of-life improvement for getting typed objects from a TDirectoryFile. Essentially `GetObject` but with return value.

Allows
```
root -l tutorials/tmva/data/toy_sigbkg_categ_offset.root
root [0] _file0->Get("TreeS")
(TObject *) 0x7f86f7d078f0
root [1] _file0->Get<TTree>("TreeS")
(TTree *) 0x7f86f7d078f0
root [2] _file0->Get<TBranch>("TreeS")
(TBranch *) nullptr
root [3] _file0->Get<TObject>("TreeS")
(TObject *) 0x7f86f7d078f0
```

Question for tests, how should these be added? I found no examples for testing GetObject.

For the documentation maybe the suggested usage should be changed to `MyClass * obj = file->Get<MyClass>("key");` to be explicit that a pointer is returned. It currently is `auto obj = file->Get<MyClass>("key");`.