### PR TITLE
[DOC] Change "`flagOpenGL.CanvasPreferGL`" to flag "`openGL.CanvasPreferGL`" in comments

### DIFF
--- a/core/base/src/TAttFill.cxx
+++ b/core/base/src/TAttFill.cxx
@@ -61,7 +61,7 @@ itself remains fully opaque.
 histo->SetFillColorAlpha(kBlue, 0.35);
 ~~~
 
-The transparency is available on all platforms when the `flagOpenGL.CanvasPreferGL` is set to `1`
+The transparency is available on all platforms when the flag `OpenGL.CanvasPreferGL` is set to `1`
 in `$ROOTSYS/etc/system.rootrc`, or on Mac with the Cocoa backend. On the file output
 it is visible with PDF, PNG, Gif, JPEG, SVG, TeX ... but not PostScript.
 

--- a/core/base/src/TAttLine.cxx
+++ b/core/base/src/TAttLine.cxx
@@ -63,7 +63,7 @@ itself remains fully opaque.
 histo->SetLineColorAlpha(kBlue, 0.35);
 ~~~
 
-The transparency is available on all platforms when the `flagOpenGL.CanvasPreferGL` is set to `1`
+The transparency is available on all platforms when the flag `OpenGL.CanvasPreferGL` is set to `1`
 in `$ROOTSYS/etc/system.rootrc`, or on Mac with the Cocoa backend. On the file output
 it is visible with PDF, PNG, Gif, JPEG, SVG ... but not PostScript.
 

--- a/core/base/src/TAttMarker.cxx
+++ b/core/base/src/TAttMarker.cxx
@@ -64,7 +64,7 @@ itself remains fully opaque.
 histo->SetMarkerColorAlpha(kBlue, 0.35);
 ~~~
 
-The transparency is available on all platforms when the `flagOpenGL.CanvasPreferGL` is set to `1`
+The transparency is available on all platforms when the flag `OpenGL.CanvasPreferGL` is set to `1`
 in `$ROOTSYS/etc/system.rootrc`, or on Mac with the Cocoa backend. On the file output
 it is visible with PDF, PNG, Gif, JPEG, SVG ... but not PostScript.
 

--- a/core/base/src/TAttText.cxx
+++ b/core/base/src/TAttText.cxx
@@ -131,7 +131,7 @@ itself remains fully opaque.
 text->SetTextColorAlpha(kBlue, 0.35);
 ~~~
 
-The transparency is available on all platforms when the `flagOpenGL.CanvasPreferGL` is set to `1`
+The transparency is available on all platforms when the flag `OpenGL.CanvasPreferGL` is set to `1`
 in `$ROOTSYS/etc/system.rootrc`, or on Mac with the Cocoa backend. On the file output
 it is visible with PDF, PNG, Gif, JPEG, SVG ... but not PostScript.
 


### PR DESCRIPTION
In the files TAttFill, TAttLine, TAttMarker and TAttText reference is made to a
flag to set in `$ROOTSYS/etc/system.rootrc` to enable transparency. In
`system.rootrc` the flag is `openGL.CanvasPreferGL` not
`flagOpenGL.CanvasPreferGL`. This commit moves the word "flag" outside the
backticks in the comments in the source files.