### PR TITLE
[RF] Fix memory leaks in RooFit/Stats.

### DIFF
--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -139,12 +139,12 @@ namespace HistFactory{
     }
     cout << endl;
 
-    RooArgSet * params= new RooArgSet;
+    RooArgSet params;
     for( unsigned int i = 0; i < poi_list.size(); ++i ) {
       std::string poi_name = poi_list.at(i);
       RooRealVar* poi = (RooRealVar*) ws_single->var( poi_name.c_str() );
       if(poi){
-	params->add(*poi);
+        params.add(*poi);
       }
       else {
 	std::cout << "WARNING: Can't find parameter of interest: " << poi_name 
@@ -152,7 +152,7 @@ namespace HistFactory{
 	//throw hf_exc();
       }
     }
-    proto_config->SetParametersOfInterest(*params);
+    proto_config->SetParametersOfInterest(params);
 
     // Name of an 'edited' model, if necessary
     std::string NewModelName = "newSimPdf"; // <- This name is hard-coded in HistoToWorkspaceFactoryFast::EditSyt.  Probably should be changed to : std::string("new") + ModelName;

--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -129,8 +129,8 @@ protected:
   // The cache object
   class CacheElem : public RooAbsCacheElement {
   public:
-    CacheElem() : _isRearranged(kFALSE), _rearrangedNum(0), _rearrangedDen(0) {} 
-    virtual ~CacheElem() ;
+    CacheElem() : _isRearranged(kFALSE) { } 
+    virtual ~CacheElem();
     // Payload
     RooArgList _partList ;
     RooArgList _numList ;
@@ -138,8 +138,8 @@ protected:
     RooArgList _ownedList ;
     RooLinkedList _normList ;    
     Bool_t _isRearranged ;
-    RooAbsReal* _rearrangedNum ;
-    RooAbsReal* _rearrangedDen ;
+    std::unique_ptr<RooAbsReal> _rearrangedNum{};
+    std::unique_ptr<RooAbsReal> _rearrangedDen{};
     // Cache management functions
     virtual RooArgList containedArgs(Action) ;
     virtual void printCompactTreeHook(std::ostream&, const char *, Int_t, Int_t) ;

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -1368,8 +1368,8 @@ void RooProdPdf::rearrangeProduct(RooProdPdf::CacheElem& cache) const
   // WVE DEBUG
   //RooMsgService::instance().debugWorkspace()->import(RooArgSet(*numerator,*norm)) ;
 
-  cache._rearrangedNum = numerator ;
-  cache._rearrangedDen = norm ;
+  cache._rearrangedNum.reset(numerator);
+  cache._rearrangedDen.reset(norm);
   cache._isRearranged = kTRUE ;
 
 }
@@ -1969,8 +1969,6 @@ void RooProdPdf::generateEvent(Int_t code)
 RooProdPdf::CacheElem::~CacheElem()
 {
   _normList.Delete() ; //WVE THIS IS AN INTENTIAL LEAK -- MUST FIX LATER
-  if (_rearrangedNum) delete _rearrangedNum ;
-  if (_rearrangedDen) delete _rearrangedDen ;
 //   cout << "RooProdPdf::CacheElem dtor, this = " << this << endl ;
 }
 

--- a/roofit/roostats/src/AsymptoticCalculator.cxx
+++ b/roofit/roostats/src/AsymptoticCalculator.cxx
@@ -1165,6 +1165,11 @@ RooAbsData * AsymptoticCalculator::GenerateAsimovData(const RooAbsPdf & pdf, con
        return 0;
     }
 
+    if (asimovDataMap.count(string(channelCat.getLabel())) != 0) {
+      oocoutE((TObject*)0,Generation) << "AsymptoticCalculator::GenerateAsimovData(): The PDF for " << channelCat.getLabel()
+          << " was already defined. It will be overridden. The faulty category definitions follow:" << endl;
+      channelCat.Print("V");
+    }
 
     asimovDataMap[string(channelCat.getLabel())] = (RooDataSet*) dataSinglePdf;
 
@@ -1182,6 +1187,10 @@ RooAbsData * AsymptoticCalculator::GenerateAsimovData(const RooAbsPdf & pdf, con
 
   RooDataSet* asimovData = new RooDataSet("asimovDataFullModel","asimovDataFullModel",RooArgSet(obsAndWeight,channelCat),
                                           RooFit::Index(channelCat),RooFit::Import(asimovDataMap),RooFit::WeightVar(*weightVar));
+
+  for (auto element : asimovDataMap) {
+    delete element.second;
+  }
 
   return asimovData;
 


### PR DESCRIPTION
[ROOT-5236]
The RooProdPdf was leaking memory when caching values.
HistoToWorkspaceFactoryFast was keeping RooArgSets alive (hence never freeing memory arenas).
AsymptoticCalculator was leaking datasets.