### PR TITLE
Use multiple different engines in VMC

### DIFF
--- a/montecarlo/vmc/CMakeLists.txt
+++ b/montecarlo/vmc/CMakeLists.txt
@@ -18,6 +18,10 @@ ROOT_STANDARD_LIBRARY_PACKAGE(VMC
     TVirtualMC.h
     TVirtualMCSensitiveDetector.h
     TVirtualMCStack.h
+    TMCManager.h
+    TMCManagerStack.h
+    TGeoMCBranchArrayContainer.h
+    TMCParticleStatus.h
   SOURCES
     src/TGeoMCGeometry.cxx
     src/TMCAutoLock.cxx
@@ -27,8 +31,12 @@ ROOT_STANDARD_LIBRARY_PACKAGE(VMC
     src/TVirtualMCGeometry.cxx
     src/TVirtualMCSensitiveDetector.cxx
     src/TVirtualMCStack.cxx
+    src/TMCManager.cxx
+    src/TMCManagerStack.cxx
+    src/TGeoMCBranchArrayContainer.cxx
   DEPENDENCIES
     EG
     Geom
     MathCore
+    Physics
 )

--- a/montecarlo/vmc/README.md
+++ b/montecarlo/vmc/README.md
@@ -1,0 +1,55 @@
+# The Virtual Monte Carlo (VMC) Package
+
+## Overview
+
+The VMC package provides an abstract interface for Monte Carlo transport engines. Interfaces are implemented for
+* [GEANT3](https://github.com/vmc-project/geant3)
+* [GEANT4](https://github.com/vmc-project/geant4_vmc)
+
+each deriving from `TVirtualMC` implementing all necessary methods.
+
+Before a user can instantiate an engine, an object deriving from `TVirtualMCApplication` needs to be present which has to be implemented by the user. It contains necessary hooks called from the `TVirtualMC`s depending on their internal state. At the same time it provides the bridge between the user code and VMC. For instance, the user code can contain the geometry construction routines somewhere which should be called from the implemented `UserApplication::ConstructGeometry()`.
+
+Further general information on the VMC project can be found [here](https://root.cern.ch/vmc)
+
+## Running multiple different engines
+
+The simulation of an event can be shared among multiple different engines deriving from `TVirtualMC` which are handled by a singleton `TMCManager` object. In such a scenario the user has to call `TVirtualMCApplication::RequestMCManager()` in the constructor of the user application. A pointer to the manager object is then available via the protected `TVirtualMCApplication::fMCManager` but can also be obtained using the static method `TMCManager *TMCManager::Instance()`.
+
+`TMCManager` provides the following interfaces:
+
+* `void SetUserStack(TVirtualMCStack* userStack)` notifies the manager on the user stack such that it will be kept up-to-date during the simulation. Running without having set the user stack is not possible and the `TMCManager` will abort in that case.
+* `void ForwardTrack(Int_t toBeDone, Int_t trackId, Int_t parentId, TParticle* userParticle)`: The user is still the owner of all track objects (aka `TParticle`) being created. Hence, all engine calls to `TVirtualMCStack::PushTrack(...)` are forwarded to the user stack. This can then invoke the `ForwardTrack(..)` method of the manager to pass the pointer to the constructed `TParticle` object. If a particle should be pushed to an engine other than the one currently running the engine's id has to be provided as the last argument.
+* `void TransferTrack(Int_t targetEngineId)`: E.g. during `TVirtualMCApplication::Stepping()` the user might decide that the current track should be transferred to another engine, for instance, if a certain volume is entered. Specifying the ID of the target engine the manager will take care of interrupting the track in the current engine, extracting the kinematics and geometry state and it will push this to the stack of the target engine.
+* `template <typename F> void Apply(F f)` assumes `f` to implement the `()` operator and taking a `TVirtualMC` pointer as an arument. `f` will be then called for all engines.
+* `template <typename F> void Init(F f)` works as `TMCManager::Apply` during the initialization of the engines. It can also be called without an argument such that no additional user routine is included.
+* `void Run(Int_t nEvents)` steers a run for the specified number of events.
+* `void ConnectEnginePointers(TVirtualMC *&mc)` gives the possibility for a user to pass a pointer which will always be set to point to the currently running engine.
+* `TVirtualMC *GetCurrentEngine()` provides the user with the currently running engine.
+
+An example of how the `TMCManager` is utilized in a multi-run can be found in `examples/EME` of the [GEANT4_VMC repository](https://github.com/vmc-project/geant4_vmc).
+
+### Workflow
+
+**Implementation**
+1. Implement your application as you have done before. Request the `TMCManager` in your constructor if needed via `TVirtualMCApplication::RequestMCManager()`
+2. Implement your user stack as you have done before. At an appropriate stage (e.g. in `UserStack::PushTrack(...)`) you should call `TMCManager::ForwardTrack(...)` to forward the pointers to your newly constructed `TParticle` objects.
+3. Set your stack using `TMCManager::SetUserStack(...)`.
+
+**Usage**
+1. Instantiate your application
+2. Instantiate the engines you want to use.
+3. Call `TMCManager::Init(...)`.
+4. Call `TMCManager::Run(...)`
+
+**Further comments**
+
+The geometry is built once centrally via the `TMCManager` calling
+
+1. `TVirtualMCApplication::ConstructGeometry()`
+2. `TVirtualMCApplication::MisalignGeometry()`
+2. `TVirtualMCApplication::ConstructOpGeometry()`
+
+so it is expected that these methods do not depend on any engine.
+
+If multiple engines have been instantiated, never call `TVirtualMC::ProcessRun(...)` or other steering methods on the engine since that would bypass the `TMCManager`

--- a/montecarlo/vmc/inc/LinkDef.h
+++ b/montecarlo/vmc/inc/LinkDef.h
@@ -21,5 +21,9 @@
 #pragma link C++ class TVirtualMCStack + ;
 #pragma link C++ class TMCVerbose + ;
 #pragma link C++ class TGeoMCGeometry + ;
+#pragma link C++ class TMCManager + ;
+#pragma link C++ class TMCManagerStack + ;
+#pragma link C++ struct TMCParticleStatus + ;
+#pragma link C++ class TGeoMCBranchArrayContainer + ;
 
 #endif

--- a/montecarlo/vmc/inc/TGeoMCBranchArrayContainer.h
+++ b/montecarlo/vmc/inc/TGeoMCBranchArrayContainer.h
@@ -1,0 +1,76 @@
+// @(#)root/vmc:$Id$
+// Authors: Benedikt Volkel 07/03/2019
+
+/*************************************************************************
+ * Copyright (C) 2019, Rene Brun and Fons Rademakers.                    *
+ * Copyright (C) 2019, ALICE Experiment at CERN.                         *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+// Class TGeoMCBranchArrayContainer
+// ---------------------
+// cache for storing TGeoBranchArray objects
+//
+
+#ifndef ROOT_TGeoMCBranchArrayContainer
+#define ROOT_TGeoMCBranchArrayContainer
+
+#include <vector>
+#include <memory>
+
+#include "TGeoBranchArray.h"
+
+class TGeoManager;
+
+class TGeoMCBranchArrayContainer {
+public:
+   /// Default constructor
+   TGeoMCBranchArrayContainer() = default;
+   /// Destructor
+   ~TGeoMCBranchArrayContainer() = default;
+
+   /// Initialize manually specifying initial number of internal
+   /// TGeoBranchArray objects
+   void Initialize(UInt_t maxlevels = 100, UInt_t size = 8);
+   /// Initialize from TGeoManager to extract maxlevels
+   void InitializeFromGeoManager(TGeoManager *man, UInt_t size = 8);
+   /// Clear the internal cache
+   void ResetCache();
+
+   /// Get a TGeoBranchArray to set to current geo state.
+   TGeoBranchArray *GetNewGeoState(UInt_t &userIndex);
+   /// Get a TGeoBranchArray to read the current state from.
+   const TGeoBranchArray *GetGeoState(UInt_t userIndex);
+   /// Free the index of this geo state such that it can be re-used
+   void FreeGeoState(UInt_t userIndex);
+   /// Free the index of this geo state such that it can be re-used
+   void FreeGeoState(const TGeoBranchArray *geoState);
+   /// Free all geo states at once but keep the container size
+   void FreeGeoStates();
+
+private:
+   /// Copying kept private
+   TGeoMCBranchArrayContainer(const TGeoMCBranchArrayContainer &);
+   /// Assignement kept private
+   TGeoMCBranchArrayContainer &operator=(const TGeoMCBranchArrayContainer &);
+   /// Resize the cache
+   void ExtendCache(UInt_t targetSize = 1);
+
+private:
+   /// Cache states via TGeoBranchArray
+   std::vector<std::unique_ptr<TGeoBranchArray>> fCache;
+   /// Maximum level of node array inside a chached state.
+   UInt_t fMaxLevels = 100;
+   /// Provide indices in fCachedStates which are already popped and can be
+   /// re-populated again.
+   std::vector<UInt_t> fFreeIndices;
+   /// Flag if initialized
+   Bool_t fIsInitialized = kFALSE;
+
+   ClassDefNV(TGeoMCBranchArrayContainer, 1)
+};
+
+#endif /* ROOT_TGeoMCBranchArrayContainer */

--- a/montecarlo/vmc/inc/TMCManager.h
+++ b/montecarlo/vmc/inc/TMCManager.h
@@ -1,0 +1,194 @@
+// @(#)root/vmc:$Id$
+// Authors: Benedikt Volkel 07/03/2019
+
+/*************************************************************************
+ * Copyright (C) 2019, Rene Brun and Fons Rademakers.                    *
+ * Copyright (C) 2019, ALICE Experiment at CERN.                         *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TMCManager
+#define ROOT_TMCManager
+//
+// Class TMCManager
+// ---------------------------
+// manager class for handling multiple TVirtualMC engines.
+//
+
+#include <functional>
+#include <memory>
+
+#include "TMCtls.h"
+#include "TGeoMCBranchArrayContainer.h"
+#include "TMCParticleStatus.h"
+#include "TGeoManager.h"
+#include "TVirtualMC.h"
+
+class TVirtualMC;
+class TVirtualMCApplication;
+class TParticle;
+class TVirtualMCStack;
+class TMCManagerStack;
+
+class TMCManager {
+
+   friend class TVirtualMCApplication;
+
+public:
+   /// Default constructor
+   TMCManager();
+
+   /// Destructor
+   virtual ~TMCManager();
+
+   /// Static access method
+   static TMCManager *Instance();
+
+   //
+   // Methods to manage multiple engines
+   //
+
+   /// A TVirtualMC will register itself via this method during construction
+   /// if a TMCManager was instanciated before.
+   /// The TMCManager will assign an ID to the engines.
+   void Register(TVirtualMC *engine);
+
+   /// The user application will register itself via this method when the
+   /// manager was requested.
+   void Register(TVirtualMCApplication *application);
+
+   /// Return the number of registered engines.
+   Int_t NEngines() const;
+
+   /// Get registered engine pointers
+   void GetEngines(std::vector<TVirtualMC *> &engines) const;
+
+   /// Get an engine pointer by ID
+   TVirtualMC *GetEngine(Int_t id) const;
+
+   /// Get engine ID by its name
+   Int_t GetEngineId(const char *name) const;
+
+   /// Get the current engine pointer
+   TVirtualMC *GetCurrentEngine() const;
+
+   /// Connect a pointer which is updated whenever the engine is changed
+   void ConnectEnginePointer(TVirtualMC **mc);
+
+   /// Connect a pointer which is updated whenever the engine is changed
+   void ConnectEnginePointer(TVirtualMC *&mc);
+
+   //
+   // Stack related methods
+   //
+
+   /// Set user stack
+   void SetUserStack(TVirtualMCStack *stack);
+
+   /// User interface to forward particle to specifiic engine.
+   /// It is assumed that the TParticle is owned by the user. It will not be
+   /// modified by the TMCManager.
+   void ForwardTrack(Int_t toBeDone, Int_t trackId, Int_t parentId, TParticle *particle, Int_t engineId);
+
+   /// User interface to forward particle to specifiic engine.
+   /// It is assumed that the TParticle is owned by the user. It will not be
+   /// modified by the TMCManager.
+   /// Assume current engine Id
+   void ForwardTrack(Int_t toBeDone, Int_t trackId, Int_t parentId, TParticle *particle);
+
+   /// Transfer track from current engine to engine with engineTargetId
+   void TransferTrack(Int_t engineTargetId);
+
+   /// Transfer track from current engine to target engine mc
+   void TransferTrack(TVirtualMC *mc);
+
+   //
+   // Steering and control
+   //
+
+   /// Apply something to all engines
+   template <typename F>
+   void Apply(F engineLambda)
+   {
+      for (auto &mc : fEngines) {
+         // We never know whether static method TVirtualMC::GetMC() is used in any way so update before calling the
+         // lambda.
+         UpdateEnginePointers(mc);
+         engineLambda(mc);
+      }
+   }
+
+   /// Initialize engines
+   void Init();
+   /// Further specific initialization
+   template <typename F>
+   void Init(F initFunction)
+   {
+      if (fIsInitializedUser) {
+         return;
+      }
+      Init();
+      for (auto &mc : fEngines) {
+         // Set to current engine and call user init procedure
+         UpdateEnginePointers(mc);
+         initFunction(mc);
+      }
+      fIsInitializedUser = kTRUE;
+   }
+
+   /// Run the event loop
+   void Run(Int_t nEvents);
+
+private:
+   /// Do necessary steps before an event is triggered
+   void PrepareNewEvent();
+   /// Find the  next engine
+   Bool_t GetNextEngine();
+   /// Update all engine pointers connected to the TMCManager
+   void UpdateEnginePointers(TVirtualMC *mc);
+   /// Terminate a run in all engines
+   void TerminateRun();
+
+private:
+   // static data members
+#if !defined(__CINT__)
+   static TMCThreadLocal TMCManager *fgInstance; ///< Singleton instance
+#else
+   static TMCManager *fgInstance; ///< Singleton instance
+#endif
+
+   /// Pointer to user application
+   TVirtualMCApplication *fApplication;
+   /// Pointer to current engine
+   TVirtualMC *fCurrentEngine;
+   /// Collecting pointers to all instanciated TVirtualMCs
+   std::vector<TVirtualMC *> fEngines;
+   /// Stacks connected to engines
+   std::vector<std::unique_ptr<TMCManagerStack>> fStacks;
+   /// All tracks (persistent)
+   std::vector<TParticle *> fParticles;
+   /// All particles' status (persistent)
+   std::vector<std::unique_ptr<TMCParticleStatus>> fParticlesStatus;
+   /// Total number of primaries ever pushed
+   Int_t fTotalNPrimaries;
+   /// Total number of tracks ever pushed
+   Int_t fTotalNTracks;
+   /// Connected engine pointers which will be updated everytime the current
+   /// engine changes
+   std::vector<TVirtualMC **> fConnectedEnginePointers;
+   /// Pointer to user stack
+   TVirtualMCStack *fUserStack;
+   /// Pointer to cache with geometry states
+   TGeoMCBranchArrayContainer fBranchArrayContainer;
+   /// Flag if engines are initilaized
+   Bool_t fIsInitialized;
+   /// Flag if specific initialization for engines was done
+   Bool_t fIsInitializedUser;
+
+   ClassDef(TMCManager, 0)
+};
+
+#endif

--- a/montecarlo/vmc/inc/TMCManagerStack.h
+++ b/montecarlo/vmc/inc/TMCManagerStack.h
@@ -1,0 +1,161 @@
+// @(#)root/vmc:$Id$
+// Authors: Benedikt Volkel 07/03/2019
+
+/*************************************************************************
+ * Copyright (C) 2019, Rene Brun and Fons Rademakers.                    *
+ * Copyright (C) 2019, ALICE Experiment at CERN.                         *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TMCManagerStack
+#define ROOT_TMCManagerStack
+
+// Class TMCManagerStack
+// ---------------------
+// stack used by the TMCManager when handling multiple engines
+//
+
+#include <vector>
+#include <stack>
+#include <memory>
+
+#include "TMCtls.h"
+#include "TLorentzVector.h"
+#include "TMCProcess.h"
+
+#include "TVirtualMCStack.h"
+
+struct TMCParticleStatus;
+class TGeoBranchArray;
+class TGeoMCBranchArrayContainer;
+
+class TMCManagerStack : public TVirtualMCStack {
+
+public:
+   /// Default constructor
+   TMCManagerStack();
+   /// Destructor
+   virtual ~TMCManagerStack() = default;
+
+   //
+   // Methods for stacking
+   //
+
+   /// This will just forward the call to the fUserStack's PushTrack
+   ///
+   /// Create a new particle and push into stack;
+   /// - toBeDone   - 1 if particles should go to tracking, 0 otherwise
+   /// - parent     - number of the parent track, -1 if track is primary
+   /// - pdg        - PDG encoding
+   /// - px, py, pz - particle momentum [GeV/c]
+   /// - e          - total energy [GeV]
+   /// - vx, vy, vz - position [cm]
+   /// - tof        - time of flight [s]
+   /// - polx, poly, polz - polarization
+   /// - mech       - creator process VMC code
+   /// - ntr        - track number (is filled by the stack
+   /// - weight     - particle weight
+   /// - is         - generation status code
+   void PushTrack(Int_t toBeDone, Int_t parent, Int_t pdg, Double_t px, Double_t py, Double_t pz, Double_t e,
+                  Double_t vx, Double_t vy, Double_t vz, Double_t tof, Double_t polx, Double_t poly, Double_t polz,
+                  TMCProcess mech, Int_t &ntr, Double_t weight, Int_t is) override final;
+
+   //
+   // Get methods
+   //
+
+   /// Pop next track
+   TParticle *PopNextTrack(Int_t &itrack) override final;
+
+   /// Pop i'th primar, that does not mean that this primariy also has ID==i
+   TParticle *PopPrimaryForTracking(Int_t i) override final;
+
+   /// Pop i'th primary, that does not mean that this primariy also has ID==i.
+   /// including actual index
+   TParticle *PopPrimaryForTracking(Int_t i, Int_t &itrack);
+
+   /// Get number of tracks on current sub-stack
+   Int_t GetNtrack() const override final;
+
+   /// Get only the number of currently stacked tracks
+   Int_t GetStackedNtrack() const;
+
+   /// Get number of primaries on current sub-stack
+   Int_t GetNprimary() const override final;
+
+   /// Get only the number of currently stacked primaries
+   Int_t GetStackedNprimary() const;
+
+   /// Current track
+   TParticle *GetCurrentTrack() const override final;
+
+   /// Current track number
+   Int_t GetCurrentTrackNumber() const override final;
+
+   /// Number of the parent of the current track
+   Int_t GetCurrentParentTrackNumber() const override final;
+
+   /// Set the current track id from the outside and forward this to the
+   /// user's stack
+   void SetCurrentTrack(Int_t trackId) override final;
+
+   /// Get TMCParticleStatus by trackId
+   const TMCParticleStatus *GetParticleStatus(Int_t trackId) const;
+
+   /// Get particle's geometry status by trackId
+   const TGeoBranchArray *GetGeoState(Int_t trackId) const;
+
+   //
+   // Action methods
+   //
+
+   /// To free the cached geo state which was associated to a track
+   void NotifyOnRestoredGeometry(Int_t trackId);
+   /// To free the cached geo state which was associated to a track
+   void NotifyOnRestoredGeometry(const TGeoBranchArray *geoState);
+
+private:
+   friend class TMCManager;
+   /// Check whether track trackId exists
+   Bool_t HasTrackId(Int_t trackId) const;
+   /// Set the user stack
+   void SetUserStack(TVirtualMCStack *stack);
+   /// Set the pointer to vector with all particles and status
+   void ConnectTrackContainers(std::vector<TParticle *> *particles,
+                               std::vector<std::unique_ptr<TMCParticleStatus>> *tracksStatus,
+                               TGeoMCBranchArrayContainer *branchArrayContainer, Int_t *totalNPrimaries,
+                               Int_t *totalNTracks);
+   /// Push primary id to be processed
+   void PushPrimaryTrackId(Int_t trackId);
+   /// Push secondary id to be processed
+   void PushSecondaryTrackId(Int_t trackId);
+   /// Reset internals, clear engine stack and fParticles and reset buffered values
+   void ResetInternals();
+
+private:
+   /// Pointer to current track
+   Int_t fCurrentTrackId;
+   /// Pointer to user stack for forwarding PushTrack calls
+   TVirtualMCStack *fUserStack;
+   /// Number of all primaries ever pushed linked from the TMCManager
+   Int_t *fTotalNPrimaries;
+   /// Number of all tracks ever pushed linked from the TMCManager
+   Int_t *fTotalNTracks;
+   /// All tracks linked from the TMCManager
+   std::vector<TParticle *> *fParticles;
+   /// All TMCParticleStatus linked from the TMCManager
+   std::vector<std::unique_ptr<TMCParticleStatus>> *fParticlesStatus;
+   /// Storage of TGeoBranchArray pointers
+   TGeoMCBranchArrayContainer *fBranchArrayContainer;
+   /// IDs of primaries to be tracked
+   std::stack<Int_t> fPrimariesStack;
+   /// IDs of secondaries to be trackedk
+   std::stack<Int_t> fSecondariesStack;
+
+   ClassDefOverride(TMCManagerStack, 1)
+};
+
+#endif // ROOT_TMCManagerStack

--- a/montecarlo/vmc/inc/TMCParticleStatus.h
+++ b/montecarlo/vmc/inc/TMCParticleStatus.h
@@ -1,0 +1,103 @@
+// @(#)root/vmc:$Id$
+// Authors: Benedikt Volkel 07/03/2019
+
+/*************************************************************************
+ * Copyright (C) 2019, Rene Brun and Fons Rademakers.                    *
+ * Copyright (C) 2019, ALICE Experiment at CERN.                         *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TMCParticleStatus
+#define ROOT_TMCParticleStatus
+
+// Class TMCParticleStatus
+// ---------------------
+// additional information on the current status of a TParticle
+//
+
+#include <iostream>
+
+#include "TVector3.h"
+#include "TLorentzVector.h"
+#include "TParticle.h"
+#include "TError.h"
+
+struct TMCParticleStatus {
+
+   /// Default constructor
+   TMCParticleStatus() = default;
+
+   /// Use TParticle information as a starting point
+   void InitFromParticle(const TParticle *particle)
+   {
+      particle->ProductionVertex(fPosition);
+      particle->Momentum(fMomentum);
+      particle->GetPolarisation(fPolarization);
+      fWeight = particle->GetWeight();
+   }
+
+   virtual ~TMCParticleStatus() = default;
+
+   //
+   // verbosity
+   //
+
+   /// Print all info at once
+   void Print() const
+   {
+      Info("Print", "Status of track");
+      std::cout << "\t"
+                << "ID: " << fId << "\n"
+                << "\t"
+                << "parentID: " << fParentId << "\n"
+                << "\t"
+                << "weight: " << fWeight << "\n"
+                << "\t"
+                << "geo state index: " << fGeoStateIndex << "\n"
+                << "\t"
+                << "step number: " << fStepNumber << "\n"
+                << "\t"
+                << "track length: " << fTrackLength << "\n"
+                << "\t"
+                << "position" << std::endl;
+      fPosition.Print();
+      std::cout << "\t"
+                << "momentum" << std::endl;
+      fMomentum.Print();
+      std::cout << "\t"
+                << "polarization" << std::endl;
+      fPolarization.Print();
+   }
+
+   /// Number of steps
+   Int_t fStepNumber = 0;
+   /// Track length
+   Double_t fTrackLength = 0.;
+   ///  position
+   TLorentzVector fPosition;
+   ///  momentum
+   TLorentzVector fMomentum;
+   ///  polarization
+   TVector3 fPolarization;
+   ///  weight
+   Double_t fWeight = 1.;
+   ///  geo state cache
+   UInt_t fGeoStateIndex = 0;
+   /// Unique ID assigned by the user
+   Int_t fId = -1;
+   /// Unique ID assigned by the user
+   Int_t fParentId = -1;
+
+private:
+   /// Copying kept private
+   TMCParticleStatus(const TMCParticleStatus &);
+   /// Assignement kept private
+   TMCParticleStatus &operator=(const TMCParticleStatus &);
+
+   ClassDef(TMCParticleStatus, 1)
+};
+
+#endif /* ROOT_TMCParticleStatus */

--- a/montecarlo/vmc/inc/TMCVerbose.h
+++ b/montecarlo/vmc/inc/TMCVerbose.h
@@ -27,8 +27,7 @@
 
 class TVirtualMCStack;
 
-class TMCVerbose : public TObject
-{
+class TMCVerbose : public TObject {
 public:
    TMCVerbose(Int_t level);
    TMCVerbose();
@@ -54,7 +53,10 @@ public:
    virtual void FinishEvent();
 
    // set methods
-   void  SetLevel(Int_t level);
+   void SetLevel(Int_t level);
+
+   // get methods
+   Int_t GetLevel() const;
 
 private:
    // methods
@@ -63,16 +65,22 @@ private:
    void PrintStepHeader() const;
 
    // data members
-   Int_t  fLevel;      ///< Verbose level
-   Int_t  fStepNumber; ///< Current step number
+   Int_t fLevel;      ///< Verbose level
+   Int_t fStepNumber; ///< Current step number
 
-   ClassDef(TMCVerbose,1)  //Verbose class for MC application
+   ClassDef(TMCVerbose, 1) // Verbose class for MC application
 };
 
 // inline functions
 
-inline void  TMCVerbose::SetLevel(Int_t level)
-{ fLevel = level; }
+inline void TMCVerbose::SetLevel(Int_t level)
+{
+   fLevel = level;
+}
 
-#endif //ROOT_TMCVerbose
+inline Int_t TMCVerbose::GetLevel() const
+{
+   return fLevel;
+}
 
+#endif // ROOT_TMCVerbose

--- a/montecarlo/vmc/inc/TVirtualMC.h
+++ b/montecarlo/vmc/inc/TVirtualMC.h
@@ -27,11 +27,11 @@
 #include "TMCtls.h"
 #include "TVirtualMCApplication.h"
 #include "TVirtualMCStack.h"
+#include "TMCManagerStack.h"
 #include "TVirtualMCDecayer.h"
 #include "TVirtualMagField.h"
 #include "TRandom.h"
 #include "TString.h"
-#include "TError.h"
 
 class TLorentzVector;
 class TGeoHMatrix;
@@ -41,13 +41,15 @@ class TVirtualMCSensitiveDetector;
 
 class TVirtualMC : public TNamed {
 
+   // To have access to private methods
+   friend class TMCManager;
+
 public:
    /// Standard constructor
    ///
    /// isRootGeometrySupported = True if implementation of TVirtualMC
    ///        supports geometry defined with TGeo
-   TVirtualMC(const char *name, const char *title,
-              Bool_t isRootGeometrySupported = kFALSE);
+   TVirtualMC(const char *name, const char *title, Bool_t isRootGeometrySupported = kFALSE);
 
    /// Default constructor
    TVirtualMC();
@@ -56,7 +58,7 @@ public:
    virtual ~TVirtualMC();
 
    /// Static access method
-   static TVirtualMC* GetMC();
+   static TVirtualMC *GetMC();
 
    //
    // ------------------------------------------------
@@ -86,14 +88,12 @@ public:
    ///               calculates it, if <0. -radl is taken
    /// - buf    pointer to an array of user words
    /// - nwbuf  number of user words
-   virtual void  Material(Int_t& kmat, const char* name, Double_t a,
-                    Double_t z, Double_t dens, Double_t radl, Double_t absl,
-                    Float_t* buf, Int_t nwbuf) = 0;
+   virtual void Material(Int_t &kmat, const char *name, Double_t a, Double_t z, Double_t dens, Double_t radl,
+                         Double_t absl, Float_t *buf, Int_t nwbuf) = 0;
 
    /// The same as previous but in double precision
-   virtual void  Material(Int_t& kmat, const char* name, Double_t a,
-                     Double_t z, Double_t dens, Double_t radl, Double_t absl,
-                     Double_t* buf, Int_t nwbuf) = 0;
+   virtual void Material(Int_t &kmat, const char *name, Double_t a, Double_t z, Double_t dens, Double_t radl,
+                         Double_t absl, Double_t *buf, Int_t nwbuf) = 0;
 
    /// Define a mixture or a compound
    /// with a number kmat composed by the basic nlmat materials defined
@@ -106,12 +106,12 @@ public:
    /// of a given kind into the molecule of the compound.
    /// In this case, wmat in output is changed to relative
    /// weights.
-   virtual void  Mixture(Int_t& kmat, const char *name, Float_t *a,
-                     Float_t *z, Double_t dens, Int_t nlmat, Float_t *wmat) = 0;
+   virtual void
+   Mixture(Int_t &kmat, const char *name, Float_t *a, Float_t *z, Double_t dens, Int_t nlmat, Float_t *wmat) = 0;
 
    /// The same as previous but in double precision
-   virtual void  Mixture(Int_t& kmat, const char *name, Double_t *a,
-                     Double_t *z, Double_t dens, Int_t nlmat, Double_t *wmat) = 0;
+   virtual void
+   Mixture(Int_t &kmat, const char *name, Double_t *a, Double_t *z, Double_t dens, Int_t nlmat, Double_t *wmat) = 0;
 
    /// Define a medium.
    /// - kmed      tracking medium number assigned
@@ -132,16 +132,14 @@ public:
    /// - stmin     min. step due to continuous processes (cm)
    /// - ubuf      pointer to an array of user words
    /// - nbuf      number of user words
-   virtual void  Medium(Int_t& kmed, const char *name, Int_t nmat,
-                     Int_t isvol, Int_t ifield, Double_t fieldm, Double_t tmaxfd,
-                     Double_t stemax, Double_t deemax, Double_t epsil,
-                     Double_t stmin, Float_t* ubuf, Int_t nbuf) = 0;
+   virtual void Medium(Int_t &kmed, const char *name, Int_t nmat, Int_t isvol, Int_t ifield, Double_t fieldm,
+                       Double_t tmaxfd, Double_t stemax, Double_t deemax, Double_t epsil, Double_t stmin, Float_t *ubuf,
+                       Int_t nbuf) = 0;
 
    /// The same as previous but in double precision
-   virtual void  Medium(Int_t& kmed, const char *name, Int_t nmat,
-                     Int_t isvol, Int_t ifield, Double_t fieldm, Double_t tmaxfd,
-                     Double_t stemax, Double_t deemax, Double_t epsil,
-                     Double_t stmin, Double_t* ubuf, Int_t nbuf) = 0;
+   virtual void Medium(Int_t &kmed, const char *name, Int_t nmat, Int_t isvol, Int_t ifield, Double_t fieldm,
+                       Double_t tmaxfd, Double_t stemax, Double_t deemax, Double_t epsil, Double_t stmin,
+                       Double_t *ubuf, Int_t nbuf) = 0;
 
    /// Define a rotation matrix
    /// - krot     rotation matrix number assigned
@@ -151,9 +149,8 @@ public:
    /// - phiY     azimuthal angle for axis Y
    /// - thetaZ   polar angle for axis Z
    /// - phiZ     azimuthal angle for axis Z
-   virtual void  Matrix(Int_t& krot, Double_t thetaX, Double_t phiX,
-                     Double_t thetaY, Double_t phiY, Double_t thetaZ,
-                     Double_t phiZ) = 0;
+   virtual void Matrix(Int_t &krot, Double_t thetaX, Double_t phiX, Double_t thetaY, Double_t phiY, Double_t thetaZ,
+                       Double_t phiZ) = 0;
 
    /// Change the value of cut or mechanism param
    /// to a new value parval for tracking medium itmed.
@@ -165,7 +162,7 @@ public:
    /// - itmed   tracking medium number
    /// - param   is a character string (variable name)
    /// - parval  must be given as a floating point.
-   virtual void  Gstpar(Int_t itmed, const char *param, Double_t parval) = 0;
+   virtual void Gstpar(Int_t itmed, const char *param, Double_t parval) = 0;
 
    //
    // functions from GGEOM
@@ -178,12 +175,10 @@ public:
    /// - nmed   Tracking medium number
    /// - np     Number of shape parameters
    /// - upar   Vector containing shape parameters
-   virtual Int_t  Gsvolu(const char *name, const char *shape, Int_t nmed,
-                          Float_t *upar, Int_t np) = 0;
+   virtual Int_t Gsvolu(const char *name, const char *shape, Int_t nmed, Float_t *upar, Int_t np) = 0;
 
    /// The same as previous but in double precision
-   virtual Int_t  Gsvolu(const char *name, const char *shape, Int_t nmed,
-                          Double_t *upar, Int_t np) = 0;
+   virtual Int_t Gsvolu(const char *name, const char *shape, Int_t nmed, Double_t *upar, Int_t np) = 0;
 
    /// Create a new volume by dividing an existing one.
    /// It divides a previously defined volume
@@ -192,15 +187,13 @@ public:
    /// - ndiv   Number of divisions
    /// - iaxis  Axis value:
    ///               X,Y,Z of CAXIS will be translated to 1,2,3 for IAXIS.
-   virtual void  Gsdvn(const char *name, const char *mother, Int_t ndiv,
-                         Int_t iaxis) = 0;
+   virtual void Gsdvn(const char *name, const char *mother, Int_t ndiv, Int_t iaxis) = 0;
 
    /// Create a new volume by dividing an existing one.
    /// Divide mother into ndiv divisions called name
    /// along axis iaxis starting at coordinate value c0i.
    /// The new volume created will be medium number numed.
-   virtual void  Gsdvn2(const char *name, const char *mother, Int_t ndiv,
-                         Int_t iaxis, Double_t c0i, Int_t numed) = 0;
+   virtual void Gsdvn2(const char *name, const char *mother, Int_t ndiv, Int_t iaxis, Double_t c0i, Int_t numed) = 0;
 
    /// Create a new volume by dividing an existing one
    /// Divide mother into divisions called name along
@@ -210,8 +203,7 @@ public:
    /// number numed. If numed is 0, numed of mother is taken.
    /// ndvmx is the expected maximum number of divisions
    /// (If 0, no protection tests are performed in Geant3)
-   virtual void  Gsdvt(const char *name, const char *mother, Double_t step,
-                         Int_t iaxis, Int_t numed, Int_t ndvmx) = 0;
+   virtual void Gsdvt(const char *name, const char *mother, Double_t step, Int_t iaxis, Int_t numed, Int_t ndvmx) = 0;
 
    /// Create a new volume by dividing an existing one
    /// Divides mother into divisions called name along
@@ -221,13 +213,13 @@ public:
    /// If numed is 0, numed of mother is taken.
    /// ndvmx is the expected maximum number of divisions
    /// (If 0, no protection tests are performed in Geant3)
-   virtual void  Gsdvt2(const char *name, const char *mother, Double_t step,
-                         Int_t iaxis, Double_t c0, Int_t numed, Int_t ndvmx) = 0;
+   virtual void
+   Gsdvt2(const char *name, const char *mother, Double_t step, Int_t iaxis, Double_t c0, Int_t numed, Int_t ndvmx) = 0;
 
    /// Flag volume name whose contents will have to be ordered
    /// along axis iax, by setting the search flag to -iax
    /// (Geant3 only)
-   virtual void  Gsord(const char *name, Int_t iax) = 0;
+   virtual void Gsord(const char *name, Int_t iax) = 0;
 
    /// Position a volume into an existing one.
    /// It positions a previously defined volume in the mother.
@@ -239,26 +231,23 @@ public:
    /// - z      Z coord. of the volume in mother ref. sys.
    /// - irot   Rotation matrix number w.r.t. mother ref. sys.
    /// - konly  ONLY/MANY flag
-   virtual void  Gspos(const char *name, Int_t nr, const char *mother,
-                         Double_t x, Double_t y, Double_t z, Int_t irot,
-                         const char *konly="ONLY") = 0;
+   virtual void Gspos(const char *name, Int_t nr, const char *mother, Double_t x, Double_t y, Double_t z, Int_t irot,
+                      const char *konly = "ONLY") = 0;
 
    /// Place a copy of generic volume name with user number
    ///  nr inside mother, with its parameters upar(1..np)
-   virtual void  Gsposp(const char *name, Int_t nr, const char *mother,
-                         Double_t x, Double_t y, Double_t z, Int_t irot,
-                         const char *konly, Float_t *upar, Int_t np) = 0;
+   virtual void Gsposp(const char *name, Int_t nr, const char *mother, Double_t x, Double_t y, Double_t z, Int_t irot,
+                       const char *konly, Float_t *upar, Int_t np) = 0;
 
    /// The same as previous but in double precision
-   virtual void  Gsposp(const char *name, Int_t nr, const char *mother,
-                         Double_t x, Double_t y, Double_t z, Int_t irot,
-                         const char *konly, Double_t *upar, Int_t np) = 0;
+   virtual void Gsposp(const char *name, Int_t nr, const char *mother, Double_t x, Double_t y, Double_t z, Int_t irot,
+                       const char *konly, Double_t *upar, Int_t np) = 0;
 
    /// Helper function for resolving MANY.
    /// Specify the ONLY volume that overlaps with the
    /// specified MANY and has to be substracted.
    /// (Geant4 only)
-   virtual void  Gsbool(const char* onlyVolName, const char* manyVolName) = 0;
+   virtual void Gsbool(const char *onlyVolName, const char *manyVolName) = 0;
 
    /// Define the tables for UV photon tracking in medium itmed.
    /// Please note that it is the user's responsibility to
@@ -271,12 +260,12 @@ public:
    ///                     - metals    : absorption fraction (0<=x<=1)
    /// - effic       Detection efficiency for UV photons
    /// - rindex      Refraction index (if=0 metal)
-   virtual void  SetCerenkov(Int_t itmed, Int_t npckov, Float_t *ppckov,
-                               Float_t *absco, Float_t *effic, Float_t *rindex) = 0;
+   virtual void
+   SetCerenkov(Int_t itmed, Int_t npckov, Float_t *ppckov, Float_t *absco, Float_t *effic, Float_t *rindex) = 0;
 
    /// The same as previous but in double precision
-   virtual void  SetCerenkov(Int_t itmed, Int_t npckov, Double_t *ppckov,
-                               Double_t *absco, Double_t *effic, Double_t *rindex) = 0;
+   virtual void
+   SetCerenkov(Int_t itmed, Int_t npckov, Double_t *ppckov, Double_t *absco, Double_t *effic, Double_t *rindex) = 0;
 
    //
    // functions for definition of surfaces
@@ -291,11 +280,8 @@ public:
    /// - surfaceFinish  surface quality (see #EMCOpSurfaceType values)
    /// - sigmaAlpha     an unified model surface parameter
    /// (Geant4 only)
-   virtual void  DefineOpSurface(const char* name,
-                         EMCOpSurfaceModel model,
-                         EMCOpSurfaceType surfaceType,
-                         EMCOpSurfaceFinish surfaceFinish,
-                         Double_t sigmaAlpha) = 0;
+   virtual void DefineOpSurface(const char *name, EMCOpSurfaceModel model, EMCOpSurfaceType surfaceType,
+                                EMCOpSurfaceFinish surfaceFinish, Double_t sigmaAlpha) = 0;
 
    /// Define the optical surface border
    /// - name        border surface name
@@ -305,19 +291,15 @@ public:
    /// - vol2CopyNo  second volume copy number
    /// - opSurfaceName  name of optical surface which this border belongs to
    /// (Geant4 only)
-   virtual void  SetBorderSurface(const char* name,
-                         const char* vol1Name, int vol1CopyNo,
-                         const char* vol2Name, int vol2CopyNo,
-                         const char* opSurfaceName) = 0;
+   virtual void SetBorderSurface(const char *name, const char *vol1Name, int vol1CopyNo, const char *vol2Name,
+                                 int vol2CopyNo, const char *opSurfaceName) = 0;
 
    /// Define the optical skin surface
    /// - name        skin surface name
    /// - volName     volume name
    /// - opSurfaceName  name of optical surface which this border belongs to
    /// (Geant4 only)
-   virtual void  SetSkinSurface(const char* name,
-                         const char* volName,
-                         const char* opSurfaceName) = 0;
+   virtual void SetSkinSurface(const char *name, const char *volName, const char *opSurfaceName) = 0;
 
    /// Define material property via a table of values
    /// - itmed         tracking medium id
@@ -326,18 +308,15 @@ public:
    /// - pp            value of photon momentum (in GeV)
    /// - values        property values
    /// (Geant4 only)
-   virtual void  SetMaterialProperty(
-                         Int_t itmed, const char* propertyName,
-                         Int_t np, Double_t* pp, Double_t* values) = 0;
+   virtual void
+   SetMaterialProperty(Int_t itmed, const char *propertyName, Int_t np, Double_t *pp, Double_t *values) = 0;
 
    /// Define material property via a value
    /// - itmed         tracking medium id
    /// - propertyName  property name
    /// - value         property value
    /// (Geant4 only)
-   virtual void  SetMaterialProperty(
-                         Int_t itmed, const char* propertyName,
-                         Double_t value) = 0;
+   virtual void SetMaterialProperty(Int_t itmed, const char *propertyName, Double_t value) = 0;
 
    /// Define optical surface property via a table of values
    /// - surfaceName   optical surface name
@@ -346,9 +325,8 @@ public:
    /// - pp            value of photon momentum (in GeV)
    /// - values        property values
    /// (Geant4 only)
-   virtual void  SetMaterialProperty(
-                         const char* surfaceName, const char* propertyName,
-                         Int_t np, Double_t* pp, Double_t* values) = 0;
+   virtual void
+   SetMaterialProperty(const char *surfaceName, const char *propertyName, Int_t np, Double_t *pp, Double_t *values) = 0;
 
    //
    // functions for access to geometry
@@ -357,35 +335,27 @@ public:
 
    /// Return the transformation matrix between the volume specified by
    /// the path volumePath and the top or master volume.
-   virtual Bool_t GetTransformation(const TString& volumePath,
-                         TGeoHMatrix& matrix) = 0;
+   virtual Bool_t GetTransformation(const TString &volumePath, TGeoHMatrix &matrix) = 0;
 
    /// Return the name of the shape (shapeType)  and its parameters par
    /// for the volume specified by the path volumePath .
-   virtual Bool_t GetShape(const TString& volumePath,
-                         TString& shapeType, TArrayD& par) = 0;
+   virtual Bool_t GetShape(const TString &volumePath, TString &shapeType, TArrayD &par) = 0;
 
    /// Return the material parameters for the material specified by
    /// the material Id
-   virtual Bool_t GetMaterial(Int_t imat, TString& name,
-                               Double_t& a, Double_t& z, Double_t& density,
-                               Double_t& radl, Double_t& inter, TArrayD& par) = 0;
+   virtual Bool_t GetMaterial(Int_t imat, TString &name, Double_t &a, Double_t &z, Double_t &density, Double_t &radl,
+                              Double_t &inter, TArrayD &par) = 0;
 
    /// Return the material parameters for the volume specified by
    /// the volumeName.
-   virtual Bool_t GetMaterial(const TString& volumeName,
-                               TString& name, Int_t& imat,
-                               Double_t& a, Double_t& z, Double_t& density,
-                               Double_t& radl, Double_t& inter, TArrayD& par) = 0;
+   virtual Bool_t GetMaterial(const TString &volumeName, TString &name, Int_t &imat, Double_t &a, Double_t &z,
+                              Double_t &density, Double_t &radl, Double_t &inter, TArrayD &par) = 0;
 
    /// Return the medium parameters for the volume specified by the
    /// volumeName.
-   virtual Bool_t GetMedium(const TString& volumeName,
-                             TString& name, Int_t& imed,
-                             Int_t& nmat, Int_t& isvol, Int_t& ifield,
-                             Double_t& fieldm, Double_t& tmaxfd, Double_t& stemax,
-                             Double_t& deemax, Double_t& epsil, Double_t& stmin,
-                             TArrayD& par) = 0;
+   virtual Bool_t GetMedium(const TString &volumeName, TString &name, Int_t &imed, Int_t &nmat, Int_t &isvol,
+                            Int_t &ifield, Double_t &fieldm, Double_t &tmaxfd, Double_t &stemax, Double_t &deemax,
+                            Double_t &epsil, Double_t &stmin, TArrayD &par) = 0;
 
    /// Write out the geometry of the detector in EUCLID file format
    /// - filnam  file name - will be with the extension .euc                 *
@@ -395,11 +365,10 @@ public:
    ///                to be written out, starting from topvol
    /// (Geant3 only)
    /// Deprecated
-   virtual void  WriteEuclid(const char* filnam, const char* topvol,
-                             Int_t number, Int_t nlevel) = 0;
+   virtual void WriteEuclid(const char *filnam, const char *topvol, Int_t number, Int_t nlevel) = 0;
 
    /// Set geometry from Root (built via TGeo)
-   virtual void  SetRootGeometry() = 0;
+   virtual void SetRootGeometry() = 0;
 
    /// Activate the parameters defined in tracking media
    /// (DEEMAX, STMIN, STEMAX), which are, be default, ignored.
@@ -413,13 +382,13 @@ public:
    //
 
    /// Return the unique numeric identifier for volume name volName
-   virtual Int_t VolId(const char* volName) const = 0;
+   virtual Int_t VolId(const char *volName) const = 0;
 
    /// Return the volume name for a given volume identifier id
-   virtual const char* VolName(Int_t id) const = 0;
+   virtual const char *VolName(Int_t id) const = 0;
 
    /// Return the unique numeric identifier for medium name mediumName
-   virtual Int_t MediumId(const char* mediumName) const = 0;
+   virtual Int_t MediumId(const char *mediumName) const = 0;
 
    /// Return total number of volumes in the geometry
    virtual Int_t NofVolumes() const = 0;
@@ -428,13 +397,13 @@ public:
    virtual Int_t VolId2Mate(Int_t id) const = 0;
 
    /// Return number of daughters of the volume specified by volName
-   virtual Int_t NofVolDaughters(const char* volName) const = 0;
+   virtual Int_t NofVolDaughters(const char *volName) const = 0;
 
    /// Return the name of i-th daughter of the volume specified by volName
-   virtual const char*  VolDaughterName(const char* volName, Int_t i) const = 0;
+   virtual const char *VolDaughterName(const char *volName, Int_t i) const = 0;
 
    /// Return the copyNo of i-th daughter of the volume specified by volName
-   virtual Int_t        VolDaughterCopyNo(const char* volName, Int_t i) const = 0;
+   virtual Int_t VolDaughterCopyNo(const char *volName, Int_t i) const = 0;
 
    //
    // ------------------------------------------------
@@ -468,10 +437,10 @@ public:
    //
 
    /// Set transport cuts for particles
-   virtual Bool_t   SetCut(const char* cutName, Double_t cutValue) = 0;
+   virtual Bool_t SetCut(const char *cutName, Double_t cutValue) = 0;
 
    /// Set process control
-   virtual Bool_t   SetProcess(const char* flagName, Int_t flagValue) = 0;
+   virtual Bool_t SetProcess(const char *flagName, Int_t flagValue) = 0;
 
    /// Set a user defined particle
    /// Function is ignored if particle with specified pdg
@@ -498,9 +467,8 @@ public:
    /// - antiEncoding  anti encoding
    /// - magMoment     magnetic moment
    /// - excitation    excitation energy [GeV]
-   virtual Bool_t   DefineParticle(Int_t pdg, const char* name,
-                        TMCParticleType mcType,
-                        Double_t mass, Double_t charge, Double_t lifetime) = 0;
+   virtual Bool_t DefineParticle(Int_t pdg, const char *name, TMCParticleType mcType, Double_t mass, Double_t charge,
+                                 Double_t lifetime) = 0;
 
    /// Set a user defined particle
    /// Function is ignored if particle with specified pdg
@@ -527,17 +495,11 @@ public:
    /// - antiEncoding  anti encoding
    /// - magMoment     magnetic moment
    /// - excitation    excitation energy [GeV]
-   virtual Bool_t   DefineParticle(Int_t pdg, const char* name,
-                        TMCParticleType mcType,
-                        Double_t mass, Double_t charge, Double_t lifetime,
-                        const TString& pType, Double_t width,
-                        Int_t iSpin, Int_t iParity, Int_t iConjugation,
-                        Int_t iIsospin, Int_t iIsospinZ, Int_t gParity,
-                        Int_t lepton, Int_t baryon,
-                        Bool_t stable, Bool_t shortlived = kFALSE,
-                        const TString& subType = "",
-                        Int_t antiEncoding = 0, Double_t magMoment = 0.0,
-                        Double_t excitation = 0.0) = 0;
+   virtual Bool_t DefineParticle(Int_t pdg, const char *name, TMCParticleType mcType, Double_t mass, Double_t charge,
+                                 Double_t lifetime, const TString &pType, Double_t width, Int_t iSpin, Int_t iParity,
+                                 Int_t iConjugation, Int_t iIsospin, Int_t iIsospinZ, Int_t gParity, Int_t lepton,
+                                 Int_t baryon, Bool_t stable, Bool_t shortlived = kFALSE, const TString &subType = "",
+                                 Int_t antiEncoding = 0, Double_t magMoment = 0.0, Double_t excitation = 0.0) = 0;
 
    /// Set a user defined ion.
    /// - name          ion name
@@ -547,20 +509,19 @@ public:
    /// - excitation    excitation energy [GeV]
    /// - mass          mass  [GeV] (if not specified by user, approximative
    ///                 mass is calculated)
-   virtual Bool_t   DefineIon(const char* name, Int_t Z, Int_t A,
-                        Int_t Q, Double_t excEnergy, Double_t mass = 0.) = 0;
+   virtual Bool_t DefineIon(const char *name, Int_t Z, Int_t A, Int_t Q, Double_t excEnergy, Double_t mass = 0.) = 0;
 
    /// Set a user phase space decay for a particle
    /// -  pdg           particle PDG encoding
    /// -  bratios       the array with branching ratios (in %)
    /// -  mode[6][3]    the array with daughters particles PDG codes  for each
    ///                 decay channel
-   virtual Bool_t   SetDecayMode(Int_t pdg, Float_t bratio[6], Int_t mode[6][3]) = 0;
+   virtual Bool_t SetDecayMode(Int_t pdg, Float_t bratio[6], Int_t mode[6][3]) = 0;
 
    /// Calculate X-sections
    /// (Geant3 only)
    /// Deprecated
-   virtual Double_t Xsec(char*, Double_t, Int_t, Int_t) = 0;
+   virtual Double_t Xsec(char *, Double_t, Int_t, Int_t) = 0;
 
    //
    // particle table usage
@@ -568,10 +529,10 @@ public:
    //
 
    /// Return MC specific code from a PDG and pseudo ENDF code (pdg)
-   virtual Int_t   IdFromPDG(Int_t pdg) const =0;
+   virtual Int_t IdFromPDG(Int_t pdg) const = 0;
 
    /// Return PDG code and pseudo ENDF code from MC specific code (id)
-   virtual Int_t   PDGFromId(Int_t id) const =0;
+   virtual Int_t PDGFromId(Int_t id) const = 0;
 
    //
    // get methods
@@ -579,16 +540,16 @@ public:
    //
 
    /// Return name of the particle specified by pdg.
-   virtual TString   ParticleName(Int_t pdg) const = 0;
+   virtual TString ParticleName(Int_t pdg) const = 0;
 
    /// Return mass of the particle specified by pdg.
-   virtual Double_t  ParticleMass(Int_t pdg) const = 0;
+   virtual Double_t ParticleMass(Int_t pdg) const = 0;
 
    /// Return charge (in e units) of the particle specified by pdg.
-   virtual Double_t  ParticleCharge(Int_t pdg) const = 0;
+   virtual Double_t ParticleCharge(Int_t pdg) const = 0;
 
    /// Return life time of the particle specified by pdg.
-   virtual Double_t  ParticleLifeTime(Int_t pdg) const = 0;
+   virtual Double_t ParticleLifeTime(Int_t pdg) const = 0;
 
    /// Return VMC type of the particle specified by pdg.
    virtual TMCParticleType ParticleMCType(Int_t pdg) const = 0;
@@ -636,38 +597,36 @@ public:
    //
 
    /// Return the current volume ID and copy number
-   virtual Int_t    CurrentVolID(Int_t& copyNo) const =0;
+   virtual Int_t CurrentVolID(Int_t &copyNo) const = 0;
 
    /// Return the current volume off upward in the geometrical tree
    /// ID and copy number
-   virtual Int_t    CurrentVolOffID(Int_t off, Int_t& copyNo) const =0;
+   virtual Int_t CurrentVolOffID(Int_t off, Int_t &copyNo) const = 0;
 
    /// Return the current volume name
-   virtual const char* CurrentVolName() const =0;
+   virtual const char *CurrentVolName() const = 0;
 
    /// Return the current volume off upward in the geometrical tree
    /// name and copy number'
    /// if name=0 no name is returned
-   virtual const char* CurrentVolOffName(Int_t off) const =0;
+   virtual const char *CurrentVolOffName(Int_t off) const = 0;
 
    /// Return the path in geometry tree for the current volume
-   virtual const char* CurrentVolPath() = 0;
+   virtual const char *CurrentVolPath() = 0;
 
    /// If track is on a geometry boundary, fill the normal vector of the crossing
    /// volume surface and return true, return false otherwise
-   virtual Bool_t   CurrentBoundaryNormal(
-                       Double_t &x, Double_t &y, Double_t &z) const = 0;
+   virtual Bool_t CurrentBoundaryNormal(Double_t &x, Double_t &y, Double_t &z) const = 0;
 
    /// Return the parameters of the current material during transport
-   virtual Int_t    CurrentMaterial(Float_t &a, Float_t &z,
-                       Float_t &dens, Float_t &radl, Float_t &absl) const =0;
+   virtual Int_t CurrentMaterial(Float_t &a, Float_t &z, Float_t &dens, Float_t &radl, Float_t &absl) const = 0;
 
    //// Return the number of the current medium
-   virtual Int_t    CurrentMedium() const = 0;
-                         // new function (to replace GetMedium() const)
+   virtual Int_t CurrentMedium() const = 0;
+   // new function (to replace GetMedium() const)
 
    /// Return the number of the current event
-   virtual Int_t    CurrentEvent() const =0;
+   virtual Int_t CurrentEvent() const = 0;
 
    /// Computes coordinates xd in daughter reference system
    /// from known coordinates xm in mother reference system.
@@ -676,10 +635,10 @@ public:
    /// - iflag
    ///   - IFLAG = 1  convert coordinates
    ///   - IFLAG = 2  convert direction cosines
-   virtual void     Gmtod(Float_t* xm, Float_t* xd, Int_t iflag) = 0;
+   virtual void Gmtod(Float_t *xm, Float_t *xd, Int_t iflag) = 0;
 
    /// The same as previous but in double precision
-   virtual void     Gmtod(Double_t* xm, Double_t* xd, Int_t iflag) = 0;
+   virtual void Gmtod(Double_t *xm, Double_t *xd, Int_t iflag) = 0;
 
    /// Computes coordinates xm in mother reference system
    /// from known coordinates xd in daughter reference system.
@@ -688,16 +647,16 @@ public:
    /// - iflag
    ///   - IFLAG = 1  convert coordinates
    ///   - IFLAG = 2  convert direction cosines
-   virtual void     Gdtom(Float_t* xd, Float_t* xm, Int_t iflag)= 0 ;
+   virtual void Gdtom(Float_t *xd, Float_t *xm, Int_t iflag) = 0;
 
    /// The same as previous but in double precision
-   virtual void     Gdtom(Double_t* xd, Double_t* xm, Int_t iflag)= 0 ;
+   virtual void Gdtom(Double_t *xd, Double_t *xm, Int_t iflag) = 0;
 
    /// Return the maximum step length in the current medium
-   virtual Double_t MaxStep() const =0;
+   virtual Double_t MaxStep() const = 0;
 
    /// Return the maximum number of steps allowed in the current medium
-   virtual Int_t    GetMaxNStep() const = 0;
+   virtual Int_t GetMaxNStep() const = 0;
 
    //
    // get methods
@@ -708,42 +667,52 @@ public:
 
    /// Return the current position in the master reference frame of the
    /// track being transported
-   virtual void     TrackPosition(TLorentzVector& position) const =0;
+   virtual void TrackPosition(TLorentzVector &position) const = 0;
 
-   /// Return the current position in the master reference frame of the
-   /// track being transported (as double)
-   virtual void     TrackPosition(Double_t &x, Double_t &y, Double_t &z) const =0;
+   /// Only return spatial coordinates (as double)
+   virtual void TrackPosition(Double_t &x, Double_t &y, Double_t &z) const = 0;
 
-   /// Return the current position in the master reference frame of the
-   /// track being transported (as float)
-   virtual void TrackPosition(Float_t &x, Float_t &y, Float_t &z) const =0;
+   /// Only return spatial coordinates (as float)
+   virtual void TrackPosition(Float_t &x, Float_t &y, Float_t &z) const = 0;
 
    /// Return the direction and the momentum (GeV/c) of the track
    /// currently being transported
-   virtual void     TrackMomentum(TLorentzVector& momentum) const =0;
+   virtual void TrackMomentum(TLorentzVector &momentum) const = 0;
 
    /// Return the direction and the momentum (GeV/c) of the track
    /// currently being transported (as double)
-   virtual void     TrackMomentum(Double_t &px, Double_t &py, Double_t &pz, Double_t &etot) const =0;
+   virtual void TrackMomentum(Double_t &px, Double_t &py, Double_t &pz, Double_t &etot) const = 0;
 
    /// Return the direction and the momentum (GeV/c) of the track
    /// currently being transported (as float)
-   virtual void TrackMomentum(Float_t &px, Float_t &py, Float_t &pz, Float_t &etot) const =0;
+   virtual void TrackMomentum(Float_t &px, Float_t &py, Float_t &pz, Float_t &etot) const = 0;
 
    /// Return the length in centimeters of the current step (in cm)
-   virtual Double_t TrackStep() const =0;
+   virtual Double_t TrackStep() const = 0;
 
    /// Return the length of the current track from its origin (in cm)
-   virtual Double_t TrackLength() const =0;
+   virtual Double_t TrackLength() const = 0;
 
    /// Return the current time of flight of the track being transported
-   virtual Double_t TrackTime() const =0;
+   virtual Double_t TrackTime() const = 0;
 
    /// Return the energy lost in the current step
-   virtual Double_t Edep() const =0;
+   virtual Double_t Edep() const = 0;
 
    /// Return the non-ionising energy lost (NIEL) in the current step
    virtual Double_t NIELEdep() const;
+
+   /// Return the current step number
+   virtual Int_t StepNumber() const;
+
+   /// Get the current weight
+   virtual Double_t TrackWeight() const;
+
+   /// Get the current polarization
+   virtual void TrackPolarization(Double_t &polX, Double_t &polY, Double_t &polZ) const;
+
+   /// Get the current polarization
+   virtual void TrackPolarization(TVector3 &pol) const;
 
    //
    // get methods
@@ -753,16 +722,16 @@ public:
    //
 
    /// Return the PDG of the particle transported
-   virtual Int_t    TrackPid() const =0;
+   virtual Int_t TrackPid() const = 0;
 
    /// Return the charge of the track currently transported
-   virtual Double_t TrackCharge() const =0;
+   virtual Double_t TrackCharge() const = 0;
 
    /// Return the mass of the track currently transported
-   virtual Double_t TrackMass() const =0;
+   virtual Double_t TrackMass() const = 0;
 
    /// Return the total energy of the current track
-   virtual Double_t Etot() const =0;
+   virtual Double_t Etot() const = 0;
 
    //
    // get methods - track status
@@ -770,31 +739,31 @@ public:
    //
 
    /// Return true when the track performs the first step
-   virtual Bool_t   IsNewTrack() const =0;
+   virtual Bool_t IsNewTrack() const = 0;
 
    /// Return true if the track is not at the boundary of the current volume
-   virtual Bool_t   IsTrackInside() const =0;
+   virtual Bool_t IsTrackInside() const = 0;
 
    /// Return true if this is the first step of the track in the current volume
-   virtual Bool_t   IsTrackEntering() const =0;
+   virtual Bool_t IsTrackEntering() const = 0;
 
    /// Return true if this is the last step of the track in the current volume
-   virtual Bool_t   IsTrackExiting() const =0;
+   virtual Bool_t IsTrackExiting() const = 0;
 
    /// Return true if the track is out of the setup
-   virtual Bool_t   IsTrackOut() const =0;
+   virtual Bool_t IsTrackOut() const = 0;
 
    /// Return true if the current particle has disappeared
    /// either because it decayed or because it underwent
    /// an inelastic collision
-   virtual Bool_t   IsTrackDisappeared() const =0;
+   virtual Bool_t IsTrackDisappeared() const = 0;
 
    /// Return true if the track energy has fallen below the threshold
-   virtual Bool_t   IsTrackStop() const =0;
+   virtual Bool_t IsTrackStop() const = 0;
 
    /// Return true if the current particle is alive and will continue to be
    /// transported
-   virtual Bool_t   IsTrackAlive() const=0;
+   virtual Bool_t IsTrackAlive() const = 0;
 
    //
    // get methods - secondaries
@@ -802,24 +771,22 @@ public:
    //
 
    /// Return the number of secondary particles generated in the current step
-   virtual Int_t    NSecondaries() const=0;
+   virtual Int_t NSecondaries() const = 0;
 
    /// Return the parameters of the secondary track number isec produced
    /// in the current step
-   virtual void     GetSecondary(Int_t isec, Int_t& particleId,
-                                 TLorentzVector& position, TLorentzVector& momentum) =0;
+   virtual void GetSecondary(Int_t isec, Int_t &particleId, TLorentzVector &position, TLorentzVector &momentum) = 0;
 
    /// Return the VMC code of the process that has produced the secondary
    /// particles in the current step
-   virtual TMCProcess ProdProcess(Int_t isec) const =0;
+   virtual TMCProcess ProdProcess(Int_t isec) const = 0;
 
    /// Return the array of the VMC code of the processes active in the current
    /// step
-   virtual Int_t    StepProcesses(TArrayI &proc) const = 0;
+   virtual Int_t StepProcesses(TArrayI &proc) const = 0;
 
    /// Return the information about the transport order needed by the stack
-   virtual Bool_t   SecondariesAreOrdered() const = 0;
-
+   virtual Bool_t SecondariesAreOrdered() const = 0;
 
    //
    // ------------------------------------------------
@@ -834,12 +801,17 @@ public:
    virtual void BuildPhysics() = 0;
 
    /// Process one event
-   /// Deprecated
-   virtual void ProcessEvent() = 0;
+   virtual void ProcessEvent(Int_t eventId);
+
+   /// Process one event (backward-compatibility)
+   virtual void ProcessEvent();
 
    /// Process one  run and return true if run has finished successfully,
    /// return false in other cases (run aborted by user)
    virtual Bool_t ProcessRun(Int_t nevent) = 0;
+
+   /// Additional cleanup after a run can be done here (optional)
+   virtual void TerminateRun() {}
 
    /// Set switches for lego transport
    virtual void InitLego() = 0;
@@ -860,59 +832,114 @@ public:
    //
 
    /// Set the particle stack
-   virtual void SetStack(TVirtualMCStack* stack);
+   virtual void SetStack(TVirtualMCStack *stack);
 
    /// Set the external decayer
-   virtual void SetExternalDecayer(TVirtualMCDecayer* decayer);
+   virtual void SetExternalDecayer(TVirtualMCDecayer *decayer);
 
    /// Set the random number generator
-   virtual void SetRandom(TRandom* random);
+   virtual void SetRandom(TRandom *random);
 
    /// Set the magnetic field
-   virtual void SetMagField(TVirtualMagField* field);
+   virtual void SetMagField(TVirtualMagField *field);
 
-    //
-    // ------------------------------------------------
-    // Get methods
-    // ------------------------------------------------
-    //
+   //
+   // ------------------------------------------------
+   // Get methods
+   // ------------------------------------------------
+   //
 
-    /// Return the particle stack
-    TVirtualMCStack*   GetStack() const   { return fStack; }
+   /// Return the particle stack
+   TVirtualMCStack *GetStack() const { return fStack; }
 
-    /// Return the external decayer
-    TVirtualMCDecayer* GetDecayer() const { return fDecayer; }
+   /// Return the particle stack managed by the TMCManager (if any)
+   TMCManagerStack *GetManagerStack() const { return fManagerStack; }
 
-    /// Return the random number generator
-    TRandom*           GetRandom() const  { return fRandom; }
+   /// Return the external decayer
+   TVirtualMCDecayer *GetDecayer() const { return fDecayer; }
 
-    /// Return the magnetic field
-    TVirtualMagField*  GetMagField() const  { return fMagField; }
+   /// Return the random number generator
+   TRandom *GetRandom() const { return fRandom; }
 
-protected:
-   TVirtualMCApplication* fApplication; //!< User MC application
+   /// Return the magnetic field
+   TVirtualMagField *GetMagField() const { return fMagField; }
+
+   /// Return the VMC's ID
+   Int_t GetId() const { return fId; }
+
+   /// Check whether external geometry construction should be used
+   Bool_t UseExternalGeometryConstruction() const { return fUseExternalGeometryConstruction; }
+
+   /// Check whether external particle generation should be used
+   Bool_t UseExternalParticleGeneration() const { return fUseExternalParticleGeneration; }
 
 private:
-   TVirtualMC(const TVirtualMC &mc);
-   TVirtualMC & operator=(const TVirtualMC &);
+   /// Set the VMC id
+   void SetId(UInt_t id);
 
+   /// Set container holding additional information for transported TParticles
+   void SetManagerStack(TMCManagerStack *stack);
+
+   /// Disables internal dispatch to TVirtualMCApplication::ConstructGeometry()
+   /// and hence rely on geometry construction being trigeered from outside.
+   void SetExternalGeometryConstruction(Bool_t value = kTRUE);
+
+   /// Disables internal dispatch to TVirtualMCApplication::GeneratePrimaries()
+   /// and tells the engine to not make any implicit assumptions on whether it's
+   /// a primary or a secondary. The track could have even been transported by
+   /// another engine to the current point.
+   void SetExternalParticleGeneration(Bool_t value = kTRUE);
+
+   /// An interruptible event can be paused and resumed at any time. It must not
+   /// call TVirtualMCApplication::BeginEvent() and ::FinishEvent()
+   /// Further, when tracks are popped from the TVirtualMCStack it must be
+   /// checked whether these are new tracks or whether they have been
+   /// transported up to their current point.
+   virtual void ProcessEvent(Int_t eventId, Bool_t isInterruptible);
+
+   /// That triggers stopping the transport of the current track without dispatching
+   /// to common routines like TVirtualMCApplication::PostTrack() etc.
+   virtual void InterruptTrack();
+
+   // Private, no copying.
+   TVirtualMC(const TVirtualMC &mc);
+   TVirtualMC &operator=(const TVirtualMC &);
+
+protected:
+   TVirtualMCApplication *fApplication; //!< User MC application
+
+private:
 #if !defined(__CINT__)
-   static TMCThreadLocal TVirtualMC*  fgMC; ///< Monte Carlo singleton instance
+   static TMCThreadLocal TVirtualMC *fgMC; ///< Static TVirtualMC pointer
 #else
-   static                TVirtualMC*  fgMC; ///< Monte Carlo singleton instance
+   static TVirtualMC *fgMC; ///< Static TVirtualMC pointer
 #endif
 
-   TVirtualMCStack*    fStack;   //!< Particles stack
-   TVirtualMCDecayer*  fDecayer; //!< External decayer
-   TRandom*            fRandom;  //!< Random number generator
-   TVirtualMagField*   fMagField;//!< Magnetic field
+private:
+   Int_t fId;                               //!< Unique identification of this VMC
+                                            // (don't use TObject::SetUniqueId since this
+                                            // is used to uniquely identify TObjects in
+                                            // in general)
+                                            // An ID is given by the running TVirtualMCApp
+                                            // and not by the user.
+   TVirtualMCStack *fStack;                 //!< Particles stack
+   TMCManagerStack *fManagerStack;          //!< Stack handled by the TMCManager
+   TVirtualMCDecayer *fDecayer;             //!< External decayer
+   TRandom *fRandom;                        //!< Random number generator
+   TVirtualMagField *fMagField;             //!< Magnetic field
+   Bool_t fUseExternalGeometryConstruction; //!< Don't attempt to
+                                            // call
+                                            // TVirtualMCApplication
+                                            // hooks related to geometry
+   // construction
+   Bool_t fUseExternalParticleGeneration;
 
-   ClassDef(TVirtualMC,1)  //Interface to Monte Carlo
+   ClassDef(TVirtualMC, 1) // Interface to Monte Carlo
 };
 
 // inline functions (with temorary implementation)
 
-inline void TVirtualMC::SetSensitiveDetector(const TString &/*volName*/, TVirtualMCSensitiveDetector */*sd*/)
+inline void TVirtualMC::SetSensitiveDetector(const TString & /*volName*/, TVirtualMCSensitiveDetector * /*sd*/)
 {
    /// Set a sensitive detector to a volume
    /// - volName - the volume name
@@ -921,7 +948,7 @@ inline void TVirtualMC::SetSensitiveDetector(const TString &/*volName*/, TVirtua
    Warning("SetSensitiveDetector(...)", "New function - not yet implemented.");
 }
 
-inline TVirtualMCSensitiveDetector *TVirtualMC::GetSensitiveDetector(const TString &/*volName*/) const
+inline TVirtualMCSensitiveDetector *TVirtualMC::GetSensitiveDetector(const TString & /*volName*/) const
 {
    /// Get a sensitive detector of a volume
    /// - volName - the volume name
@@ -951,5 +978,4 @@ inline Double_t TVirtualMC::NIELEdep() const
 
 #define gMC (TVirtualMC::GetMC())
 
-#endif //ROOT_TVirtualMC
-
+#endif // ROOT_TVirtualMC

--- a/montecarlo/vmc/src/TGeoMCBranchArrayContainer.cxx
+++ b/montecarlo/vmc/src/TGeoMCBranchArrayContainer.cxx
@@ -1,0 +1,123 @@
+// @(#)root/vmc:$Id$
+// Authors: Benedikt Volkel 07/03/2019
+
+/*************************************************************************
+ * Copyright (C) 2019, Rene Brun and Fons Rademakers.                    *
+ * Copyright (C) 2019, ALICE Experiment at CERN.                         *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+/** \class TGeoMCBranchArrayContainer
+    \ingroup vmc
+
+Storing and re-using geometry states of the TGeoManager in use by storing
+them as TGeoBranchArrays.
+
+After having initialized a navigator using a stored state, it can be freed
+to be used again for storing another geometry state. This makes it easy to
+handle many events with many stored geometry states and the memory used is
+kept as small as possible.
+*/
+
+#include "TGeoMCBranchArrayContainer.h"
+#include "TGeoManager.h"
+#include "TError.h"
+
+void TGeoMCBranchArrayContainer::Initialize(UInt_t maxLevels, UInt_t size)
+{
+   fMaxLevels = maxLevels;
+   if (fIsInitialized) {
+      ResetCache();
+   }
+   ExtendCache(size);
+   fIsInitialized = kTRUE;
+}
+
+void TGeoMCBranchArrayContainer::InitializeFromGeoManager(TGeoManager *man, UInt_t size)
+{
+   Initialize(man->GetMaxLevels(), size);
+}
+
+void TGeoMCBranchArrayContainer::ResetCache()
+{
+   fCache.clear();
+   fFreeIndices.clear();
+   fIsInitialized = kFALSE;
+}
+
+TGeoBranchArray *TGeoMCBranchArrayContainer::GetNewGeoState(UInt_t &userIndex)
+{
+   if (fFreeIndices.empty()) {
+      ExtendCache(2 * fCache.size());
+   }
+   // Get index from the back
+   UInt_t internalIndex = fFreeIndices.back();
+   fFreeIndices.pop_back();
+   // indices seen by the user are +1
+   userIndex = internalIndex + 1;
+   fCache[internalIndex]->SetUniqueID(userIndex);
+   return fCache[internalIndex].get();
+}
+
+const TGeoBranchArray *TGeoMCBranchArrayContainer::GetGeoState(UInt_t userIndex)
+{
+   if (userIndex == 0) {
+      return nullptr;
+   }
+   if (userIndex > fCache.size()) {
+      ::Fatal("TGeoMCBranchArrayContainer::GetGeoState",
+              "ID %u is not an index referring to TGeoBranchArray "
+              "managed by this TGeoMCBranchArrayContainer",
+              userIndex);
+   }
+   if (fCache[userIndex - 1]->GetUniqueID() == 0) {
+      ::Fatal("TGeoMCBranchArrayContainer::GetGeoState", "Passed index %u refers to an empty/unused geo state",
+              userIndex);
+   }
+   return fCache[userIndex - 1].get();
+}
+
+void TGeoMCBranchArrayContainer::FreeGeoState(UInt_t userIndex)
+{
+   if (userIndex > fCache.size() || userIndex == 0) {
+      return;
+   }
+   // Unlock this index so it is free for later use. No need to delete since TGeoBranchArray can be re-used
+   if (fCache[userIndex - 1]->GetUniqueID() > 0) {
+      fFreeIndices.push_back(userIndex - 1);
+      fCache[userIndex - 1]->SetUniqueID(0);
+   }
+}
+
+void TGeoMCBranchArrayContainer::FreeGeoState(const TGeoBranchArray *geoState)
+{
+   if (geoState) {
+      FreeGeoState(geoState->GetUniqueID());
+   }
+}
+
+void TGeoMCBranchArrayContainer::FreeGeoStates()
+{
+   // Start counting at 1 since that is the index seen by the user which is assumed by
+   // TGeoMCBranchArrayContainer::FreeGeoState(UInt_t userIndex)
+   for (UInt_t i = 0; i < fCache.size(); i++) {
+      FreeGeoState(i + 1);
+   }
+}
+
+void TGeoMCBranchArrayContainer::ExtendCache(UInt_t targetSize)
+{
+   if (targetSize <= fCache.size()) {
+      targetSize = 2 * fCache.size();
+   }
+   fFreeIndices.reserve(targetSize);
+   fCache.reserve(targetSize);
+   for (UInt_t i = fCache.size(); i < targetSize; i++) {
+      fCache.emplace_back(TGeoBranchArray::MakeInstance(fMaxLevels));
+      fCache.back()->SetUniqueID(0);
+      fFreeIndices.push_back(i);
+   }
+}

--- a/montecarlo/vmc/src/TMCManager.cxx
+++ b/montecarlo/vmc/src/TMCManager.cxx
@@ -1,0 +1,469 @@
+// @(#)root/vmc:$Id$
+// Authors: Benedikt Volkel 07/03/2019
+
+/*************************************************************************
+ * Copyright (C) 2019, Rene Brun and Fons Rademakers.                    *
+ * Copyright (C) 2019, ALICE Experiment at CERN.                         *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "TError.h"
+#include "TVector3.h"
+#include "TLorentzVector.h"
+#include "TParticle.h"
+#include "TGeoBranchArray.h"
+#include "TGeoNavigator.h"
+
+#include "TVirtualMCApplication.h"
+#include "TVirtualMCStack.h"
+#include "TMCManagerStack.h"
+#include "TMCParticleStatus.h"
+
+#include "TMCManager.h"
+
+/** \class TMCManager
+    \ingroup vmc
+
+Singleton manager class for handling and steering a run with multiple TVirtualMC
+engines sharing events.
+It provides interfaces to transfer tracks between engines and exposes the correct
+stacks to each running engine. A registered user stack is kept up-to-date
+automatically seeing a consistent history.
+Track objects (aka TParticle) are still owned by the user who must forward these to
+the manager after creation. Everything else is done automatically.
+*/
+
+TMCThreadLocal TMCManager *TMCManager::fgInstance = nullptr;
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Default and standard constructor
+///
+
+TMCManager::TMCManager()
+   : fApplication(nullptr), fCurrentEngine(nullptr), fTotalNPrimaries(0), fTotalNTracks(0), fUserStack(nullptr),
+     fBranchArrayContainer(), fIsInitialized(kFALSE), fIsInitializedUser(kFALSE)
+{
+   if (fgInstance) {
+      ::Fatal("TMCManager::TMCManager", "Attempt to create two instances of singleton.");
+   }
+   fgInstance = this;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Destructor
+///
+
+TMCManager::~TMCManager()
+{
+   for (auto &mc : fEngines) {
+      delete mc;
+   }
+   fgInstance = nullptr;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Static access method
+///
+
+TMCManager *TMCManager::Instance()
+{
+   return fgInstance;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// A TVirtualMC will register itself via this method during construction
+/// if a TMCManager was instanciated before.
+/// The TMCManager will assign an ID to the engines.
+///
+
+void TMCManager::Register(TVirtualMC *mc)
+{
+   // Do not register an engine twice.
+   for (auto &currMC : fEngines) {
+      if (currMC == mc) {
+         ::Fatal("TMCManager::RegisterMC", "This engine is already registered.");
+      }
+   }
+   // Set id and register.
+   mc->SetId(fEngines.size());
+   fEngines.push_back(mc);
+   fStacks.emplace_back(new TMCManagerStack());
+   mc->SetStack(fStacks.back().get());
+   mc->SetManagerStack(fStacks.back().get());
+   // Don't attempt to call TVirtualMCApplication hooks related to geometry
+   // construction
+   mc->SetExternalGeometryConstruction();
+   mc->SetExternalParticleGeneration();
+   // Must update engine pointers here since during construction of the concrete TVirtualMC
+   // implementation the static TVirtualMC::GetMC() or defined gMC might be used.
+   UpdateEnginePointers(mc);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// The user application will register itself via this method when the
+/// manager was requested.
+///
+
+void TMCManager::Register(TVirtualMCApplication *application)
+{
+   if (fApplication) {
+      ::Fatal("TMCManager::Register", "The application is already registered.");
+   }
+   ::Info("TMCManager::Register", "Register user application and construct geometry");
+   fApplication = application;
+   // TODO Can these 3 functions can be called directly here? Or could any of these depend on an implemented VMC?
+   fApplication->ConstructGeometry();
+   fApplication->MisalignGeometry();
+   fApplication->ConstructOpGeometry();
+   if (!gGeoManager->IsClosed()) {
+      // Setting the top volume is the duty of the user as well as closing it.
+      // Failing here is just an additional cross check. If not closed the user
+      // might have forgotten something.
+      ::Fatal("TMCManager::Register", "The TGeo geometry is not closed. Please check whether you just have to close "
+                                      "it or whether something was forgotten.");
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Return the number of registered engines.
+///
+
+Int_t TMCManager::NEngines() const
+{
+   return fEngines.size();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Get registered engine pointers
+///
+
+void TMCManager::GetEngines(std::vector<TVirtualMC *> &engines) const
+{
+   engines.clear();
+   engines.resize(fEngines.size(), nullptr);
+   for (UInt_t i = 0; i < fEngines.size(); i++) {
+      engines[i] = fEngines[i];
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Return the number of registered engines.
+///
+
+TVirtualMC *TMCManager::GetEngine(Int_t id) const
+{
+   if (id < 0 || id >= static_cast<Int_t>(fEngines.size())) {
+      ::Fatal("TMCManager::GetEngine", "Unknown engine ID.");
+   }
+   return fEngines[id];
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Get engine ID by its name
+///
+
+Int_t TMCManager::GetEngineId(const char *engineName) const
+{
+   for (UInt_t i = 0; i < fEngines.size(); i++) {
+      if (strcmp(engineName, fEngines[i]->GetName()) == 0) {
+         return i;
+      }
+   }
+   ::Warning("TMCManager::GetEngineId", "Unknown engine %s.", engineName);
+   return -1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Get the current engine pointer
+///
+
+TVirtualMC *TMCManager::GetCurrentEngine() const
+{
+   return fCurrentEngine;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Connect a pointer which is updated whenever the engine is changed
+///
+
+void TMCManager::ConnectEnginePointer(TVirtualMC **mc)
+{
+   fConnectedEnginePointers.push_back(mc);
+   if (fCurrentEngine) {
+      *mc = fCurrentEngine;
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Connect a pointer which is updated whenever the engine is changed
+///
+
+void TMCManager::ConnectEnginePointer(TVirtualMC *&mc)
+{
+   ConnectEnginePointer(&mc);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Set user stack
+///
+
+void TMCManager::SetUserStack(TVirtualMCStack *stack)
+{
+   fUserStack = stack;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// User interface to forward particle to specifiic engine.
+/// It is assumed that the TParticle is owned by the user. It will not be
+/// modified by the TMCManager.
+///
+
+void TMCManager::ForwardTrack(Int_t toBeDone, Int_t trackId, Int_t parentId, TParticle *particle, Int_t engineId)
+{
+   if (engineId < 0 || engineId >= static_cast<Int_t>(fEngines.size())) {
+      ::Fatal("TMCManager::ForwardTrack", "Engine ID %i out of bounds. Have %zu engines.", engineId, fEngines.size());
+   }
+   if (trackId >= static_cast<Int_t>(fParticles.size())) {
+      fParticles.resize(trackId + 1, nullptr);
+      fParticlesStatus.resize(trackId + 1);
+   }
+   fParticles[trackId] = particle;
+   fParticlesStatus[trackId].reset(new TMCParticleStatus());
+   fParticlesStatus[trackId]->fId = trackId;
+   fParticlesStatus[trackId]->fParentId = parentId;
+   fParticlesStatus[trackId]->InitFromParticle(particle);
+   fTotalNTracks++;
+   if (particle->IsPrimary()) {
+      fTotalNPrimaries++;
+   }
+
+   if (toBeDone > 0) {
+      if (particle->IsPrimary()) {
+         fStacks[engineId]->PushPrimaryTrackId(trackId);
+      } else {
+         fStacks[engineId]->PushSecondaryTrackId(trackId);
+      }
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// User interface to forward particle to specifiic engine.
+/// It is assumed that the TParticle is owned by the user. It will not be
+/// modified by the TMCManager.
+/// Assume current engine Id
+///
+
+void TMCManager::ForwardTrack(Int_t toBeDone, Int_t trackId, Int_t parentId, TParticle *particle)
+{
+   ForwardTrack(toBeDone, trackId, parentId, particle, fCurrentEngine->GetId());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Transfer track from current engine to engine with engineTargetId
+///
+
+void TMCManager::TransferTrack(Int_t engineTargetId)
+{
+   if (engineTargetId < 0 || engineTargetId >= static_cast<Int_t>(fEngines.size())) {
+      ::Fatal("TMCManager::TransferTrack",
+              "Target engine ID out of bounds. Have %zu engines. Requested target ID was %i", fEngines.size(),
+              engineTargetId);
+   }
+   TransferTrack(fEngines[engineTargetId]);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Transfer track from current engine to target engine mc
+///
+
+void TMCManager::TransferTrack(TVirtualMC *mc)
+{
+   // Do nothing if target and current engines are the same
+   if (mc == fCurrentEngine) {
+      return;
+   }
+
+   // Get information on current track and extract status from transporting engine
+   Int_t trackId = fStacks[fCurrentEngine->GetId()]->GetCurrentTrackNumber();
+
+   fCurrentEngine->TrackPosition(fParticlesStatus[trackId]->fPosition);
+   fCurrentEngine->TrackMomentum(fParticlesStatus[trackId]->fMomentum);
+   fCurrentEngine->TrackPolarization(fParticlesStatus[trackId]->fPolarization);
+   fParticlesStatus[trackId]->fStepNumber = fCurrentEngine->StepNumber();
+   fParticlesStatus[trackId]->fTrackLength = fCurrentEngine->TrackLength();
+   fParticlesStatus[trackId]->fWeight = fCurrentEngine->TrackWeight();
+
+   TGeoBranchArray *geoState = fBranchArrayContainer.GetNewGeoState(fParticlesStatus[trackId]->fGeoStateIndex);
+   geoState->InitFromNavigator(gGeoManager->GetCurrentNavigator());
+
+   // Push only the particle ID
+   if (fParticles[trackId]->IsPrimary()) {
+      fStacks[mc->GetId()]->PushPrimaryTrackId(trackId);
+   } else {
+      fStacks[mc->GetId()]->PushSecondaryTrackId(trackId);
+   }
+   fCurrentEngine->InterruptTrack();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Initialize engines
+///
+
+void TMCManager::Init()
+{
+   if (fIsInitialized) {
+      return;
+   }
+
+   if (!fUserStack) {
+      ::Fatal("TMCManager::Run", "Missing user stack pointer.");
+   }
+   if (fEngines.empty()) {
+      ::Fatal("TMCManager::Run", "No engines registered");
+   }
+
+   for (auto &mc : fEngines) {
+      // Must have geometry handling via TGeo
+      if (!mc->IsRootGeometrySupported()) {
+         ::Fatal("TMCManager::Run", "Engine %s does not support geometry built via ROOT's TGeoManager", mc->GetName());
+      }
+      Int_t currentEngineId = mc->GetId();
+      // To be able to forward info to the user stack
+      fStacks[currentEngineId]->SetUserStack(fUserStack);
+      // Connect the engine's stack to the centrally managed vectors
+      fStacks[currentEngineId]->ConnectTrackContainers(&fParticles, &fParticlesStatus, &fBranchArrayContainer,
+                                                       &fTotalNPrimaries, &fTotalNTracks);
+   }
+
+   // Initialize the fBranchArrayContainer to manage and cache TGeoBranchArrays
+   fBranchArrayContainer.InitializeFromGeoManager(gGeoManager);
+
+   fIsInitialized = kTRUE;
+
+   // Send warning if only one engine ==> overhead
+   if (fEngines.size() == 1) {
+      ::Warning("TMCManager::Run", "Only one engine registered. That will lead to overhead in "
+                                   "the simulation run due to additional hooks and dispatches "
+                                   "to the TMCManager.");
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Run the event loop
+///
+
+void TMCManager::Run(Int_t nEvents)
+{
+   if (!fIsInitialized) {
+      ::Fatal("TMCManager::Run", "Engines have not yet been initialized.");
+   }
+
+   // Set user initialize true in any case now so that this cannot happen by accident during a run
+   fIsInitializedUser = kTRUE;
+
+   if (nEvents < 1) {
+      ::Fatal("TMCManager::Run", "Need at least one event to process but %i events specified.", nEvents);
+   }
+
+   // Run 1 event nEvents times
+   for (Int_t i = 0; i < nEvents; i++) {
+      ::Info("TMCManager::Run", "Start event %i", i + 1);
+      PrepareNewEvent();
+      fApplication->BeginEvent();
+      // Loop as long as there are tracks in any engine stack
+      while (GetNextEngine()) {
+         fCurrentEngine->ProcessEvent(i, kTRUE);
+      }
+      fApplication->FinishEvent();
+   }
+   TerminateRun();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Choose next engines to be run in the loop
+///
+
+void TMCManager::PrepareNewEvent()
+{
+   fBranchArrayContainer.FreeGeoStates();
+   // Reset in event flag for all engines and clear stacks
+   for (auto &stack : fStacks) {
+      stack->ResetInternals();
+   }
+   for (UInt_t i = 0; i < fParticles.size(); i++) {
+      fParticlesStatus.clear();
+      fParticlesStatus.resize(fParticles.size());
+      fParticles[i] = nullptr;
+   }
+
+   // GeneratePrimaries centrally
+   fApplication->GeneratePrimaries();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Choose next engines to be run in the loop
+///
+
+Bool_t TMCManager::GetNextEngine()
+{
+   // Select next engine based on finite number of particles on the stack
+   for (UInt_t i = 0; i < fStacks.size(); i++) {
+      if (fStacks[i]->GetStackedNtrack() > 0) {
+         UpdateEnginePointers(fEngines[i]);
+         return kTRUE;
+      }
+   }
+   // No tracks to be processed.
+   return kFALSE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Update all engine pointers connected to the TMCManager
+///
+
+void TMCManager::UpdateEnginePointers(TVirtualMC *mc)
+{
+   fCurrentEngine = mc;
+   for (TVirtualMC **&mcPtr : fConnectedEnginePointers) {
+      *mcPtr = mc;
+   }
+   // Make sure TVirtualMC::GetMC() returns the current engine.
+   TVirtualMC::fgMC = mc;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Terminate the run for all engines
+///
+
+void TMCManager::TerminateRun()
+{
+   for (auto &mc : fEngines) {
+      mc->TerminateRun();
+   }
+}

--- a/montecarlo/vmc/src/TMCManagerStack.cxx
+++ b/montecarlo/vmc/src/TMCManagerStack.cxx
@@ -1,0 +1,318 @@
+// @(#)root/vmc:$Id$
+// Authors: Benedikt Volkel 07/03/2019
+
+/*************************************************************************
+ * Copyright (C) 2019, Rene Brun and Fons Rademakers.                    *
+ * Copyright (C) 2019, ALICE Experiment at CERN.                         *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "TError.h"
+#include "TParticle.h"
+#include "TGeoBranchArray.h"
+#include "TGeoMCBranchArrayContainer.h"
+#include "TMCParticleStatus.h"
+#include "TMCManagerStack.h"
+
+/** \class TMCManagerStack
+    \ingroup vmc
+
+Concrete implementation of particles stack used by the TMCManager.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Default constructor
+///
+
+TMCManagerStack::TMCManagerStack()
+   : TVirtualMCStack(), fCurrentTrackId(-1), fUserStack(nullptr), fTotalNPrimaries(nullptr), fTotalNTracks(nullptr),
+     fParticles(nullptr), fParticlesStatus(nullptr), fBranchArrayContainer(nullptr)
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// This will just forward the call to the fUserStack's PushTrack
+///
+
+void TMCManagerStack::PushTrack(Int_t toBeDone, Int_t parent, Int_t pdg, Double_t px, Double_t py, Double_t pz,
+                                Double_t e, Double_t vx, Double_t vy, Double_t vz, Double_t tof, Double_t polx,
+                                Double_t poly, Double_t polz, TMCProcess mech, Int_t &ntr, Double_t weight, Int_t is)
+{
+   // Just forward to user stack
+   fUserStack->PushTrack(toBeDone, parent, pdg, px, py, pz, e, vx, vy, vz, tof, polx, poly, polz, mech, ntr, weight,
+                         is);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Pop next track
+///
+
+TParticle *TMCManagerStack::PopNextTrack(Int_t &itrack)
+{
+
+   if (fPrimariesStack.empty() && fSecondariesStack.empty()) {
+      itrack = -1;
+      return nullptr;
+   }
+
+   std::stack<Int_t> *mcStack = &fPrimariesStack;
+
+   if (fPrimariesStack.empty()) {
+      mcStack = &fSecondariesStack;
+   }
+   itrack = mcStack->top();
+   mcStack->pop();
+   return fParticles->operator[](itrack);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Pop i'th primary; that does not mean that this primariy has ID==i
+///
+
+TParticle *TMCManagerStack::PopPrimaryForTracking(Int_t i)
+{
+   Int_t itrack = -1;
+   return PopPrimaryForTracking(i, itrack);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Pop i'th primary; that does not mean that this primariy has ID==i.
+/// including actual index
+///
+
+TParticle *TMCManagerStack::PopPrimaryForTracking(Int_t i, Int_t &itrack)
+{
+   // Completely ignore the index i, that is meaningless since the user does not
+   // know how the stack is handled internally.
+   Warning("PopPrimaryForTracking", "Lookup index %i is ignored.", i);
+   if (fPrimariesStack.empty()) {
+      itrack = -1;
+      return nullptr;
+   }
+   itrack = fPrimariesStack.top();
+   fPrimariesStack.pop();
+   return fParticles->operator[](itrack);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Get number of tracks on current sub-stack
+///
+
+Int_t TMCManagerStack::GetNtrack() const
+{
+   return *fTotalNTracks;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Get only the number of currently stacked tracks
+///
+
+Int_t TMCManagerStack::GetStackedNtrack() const
+{
+   return fPrimariesStack.size() + fSecondariesStack.size();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Get number of primaries on current sub-stack
+///
+
+Int_t TMCManagerStack::GetNprimary() const
+{
+   return *fTotalNPrimaries;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Get number of primaries on current sub-stack
+///
+
+Int_t TMCManagerStack::GetStackedNprimary() const
+{
+   return fPrimariesStack.size();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Current track
+///
+
+TParticle *TMCManagerStack::GetCurrentTrack() const
+{
+   if (fCurrentTrackId < 0) {
+      Fatal("GetCurrentTrack", "There is no current track set");
+   }
+   // That is not actually the current track but the user's TParticle at the
+   // vertex.
+   return fParticles->operator[](fCurrentTrackId);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Current track number
+///
+
+Int_t TMCManagerStack::GetCurrentTrackNumber() const
+{
+   return fCurrentTrackId;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Number of the parent of the current track
+///
+
+Int_t TMCManagerStack::GetCurrentParentTrackNumber() const
+{
+   return fParticlesStatus->operator[](fCurrentTrackId)->fParentId;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Set the current track id from the outside and forward this to the
+/// user's stack
+///
+
+void TMCManagerStack::SetCurrentTrack(Int_t trackId)
+{
+   if (!HasTrackId(trackId)) {
+      Fatal("SetCurrentTrack", "Invalid track ID %i", trackId);
+   }
+   fCurrentTrackId = trackId;
+   fUserStack->SetCurrentTrack(trackId);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Get TMCParticleStatus by trackId
+///
+
+const TMCParticleStatus *TMCManagerStack::GetParticleStatus(Int_t trackId) const
+{
+   if (!HasTrackId(trackId)) {
+      Fatal("GetParticleStatus", "Invalid track ID %i", trackId);
+   }
+   return fParticlesStatus->operator[](trackId).get();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Get particle's geometry status by trackId
+///
+
+const TGeoBranchArray *TMCManagerStack::GetGeoState(Int_t trackId) const
+{
+   if (!HasTrackId(trackId)) {
+      Fatal("GetParticleStatus", "Invalid track ID %i", trackId);
+   }
+   return fBranchArrayContainer->GetGeoState(fParticlesStatus->operator[](trackId)->fGeoStateIndex);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// To free the cached geo state which was associated to a track
+///
+
+void TMCManagerStack::NotifyOnRestoredGeometry(Int_t trackId)
+{
+   if (!HasTrackId(trackId)) {
+      Fatal("NotifyOnRestoredGeometry", "Invalid track ID %i", trackId);
+   }
+   fBranchArrayContainer->FreeGeoState(fParticlesStatus->operator[](trackId)->fGeoStateIndex);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// To free the cached geo state which was associated to a track
+///
+void TMCManagerStack::NotifyOnRestoredGeometry(const TGeoBranchArray *geoState)
+{
+   fBranchArrayContainer->FreeGeoState(geoState);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Check whether track trackId exists
+///
+
+Bool_t TMCManagerStack::HasTrackId(Int_t trackId) const
+{
+   if (trackId >= 0 && trackId < static_cast<Int_t>(fParticles->size()) && fParticles->operator[](trackId)) {
+      return kTRUE;
+   }
+   return kFALSE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Set the user stack
+///
+
+void TMCManagerStack::SetUserStack(TVirtualMCStack *stack)
+{
+   fUserStack = stack;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Connect an engine's stack to the centrally managed vectors
+///
+
+void TMCManagerStack::ConnectTrackContainers(std::vector<TParticle *> *particles,
+                                             std::vector<std::unique_ptr<TMCParticleStatus>> *tracksStatus,
+                                             TGeoMCBranchArrayContainer *branchArrayContainer, Int_t *totalNPrimaries,
+                                             Int_t *totalNTracks)
+{
+   fParticles = particles;
+   fParticlesStatus = tracksStatus;
+   fBranchArrayContainer = branchArrayContainer;
+   fTotalNPrimaries = totalNPrimaries;
+   fTotalNTracks = totalNTracks;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Push primary track id to be processed
+///
+
+void TMCManagerStack::PushPrimaryTrackId(Int_t trackId)
+{
+   fPrimariesStack.push(trackId);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Push secondary track id to be processed
+///
+
+void TMCManagerStack::PushSecondaryTrackId(Int_t trackId)
+{
+   fSecondariesStack.push(trackId);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Reset internals, clear engine stack and fParticles and reset buffered values
+///
+
+void TMCManagerStack::ResetInternals()
+{
+   // Reset current stack and track IDs
+   fCurrentTrackId = -1;
+   while (!fPrimariesStack.empty()) {
+      fPrimariesStack.pop();
+   }
+   while (!fSecondariesStack.empty()) {
+      fSecondariesStack.pop();
+   }
+}

--- a/montecarlo/vmc/src/TMCVerbose.cxx
+++ b/montecarlo/vmc/src/TMCVerbose.cxx
@@ -31,8 +31,6 @@ Defined levels:
 - 3  detailed info for each step
 */
 
-ClassImp(TMCVerbose);
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Standard constructor
 
@@ -324,4 +322,3 @@ void TMCVerbose::FinishEvent()
    if (fLevel>0)
       std::cout << "--- Finish event " << std::endl;
 }
-

--- a/montecarlo/vmc/src/TVirtualMC.cxx
+++ b/montecarlo/vmc/src/TVirtualMC.cxx
@@ -11,6 +11,7 @@
  *************************************************************************/
 
 #include "TVirtualMC.h"
+#include "TError.h"
 
 /** \class TVirtualMC
     \ingroup vmc
@@ -28,37 +29,26 @@ The concrete Monte Carlo (Geant3, Geant4) is selected at run time -
 when processing a ROOT macro where the concrete Monte Carlo is instantiated.
 */
 
-ClassImp(TVirtualMC);
-
-TMCThreadLocal TVirtualMC* TVirtualMC::fgMC=0;
-
+TMCThreadLocal TVirtualMC *TVirtualMC::fgMC = nullptr;
 ////////////////////////////////////////////////////////////////////////////////
 ///
 /// Standard constructor
 ///
 
-TVirtualMC::TVirtualMC(const char *name, const char *title,
-                       Bool_t /*isRootGeometrySupported*/)
-  : TNamed(name,title),
-    fApplication(0),
-    fStack(0),
-    fDecayer(0),
-    fRandom(0),
-    fMagField(0)
+TVirtualMC::TVirtualMC(const char *name, const char *title, Bool_t /*isRootGeometrySupported*/)
+   : TNamed(name, title), fApplication(nullptr), fId(0), fStack(nullptr), fManagerStack(nullptr), fDecayer(nullptr),
+     fRandom(nullptr), fMagField(nullptr), fUseExternalGeometryConstruction(kFALSE),
+     fUseExternalParticleGeneration(kFALSE)
 {
-   if(fgMC) {
-      Warning("TVirtualMC","Cannot initialise twice MonteCarlo class");
+   fApplication = TVirtualMCApplication::Instance();
+
+   if (fApplication) {
+      fApplication->Register(this);
    } else {
-      fgMC=this;
-
-      fApplication = TVirtualMCApplication::Instance();
-
-      if (!fApplication) {
-         Error("TVirtualMC", "No user MC application is defined.");
-      }
-
-      fRandom = gRandom;
+      ::Fatal("TVirtualMC::TVirtualMC", "No user MC application is defined.");
    }
+   fgMC = this;
+   fRandom = gRandom;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -67,12 +57,9 @@ TVirtualMC::TVirtualMC(const char *name, const char *title,
 ///
 
 TVirtualMC::TVirtualMC()
-  : TNamed(),
-    fApplication(0),
-    fStack(0),
-    fDecayer(0),
-    fRandom(0),
-    fMagField(0)
+   : TNamed(), fApplication(nullptr), fId(0), fStack(nullptr), fManagerStack(nullptr), fDecayer(nullptr),
+     fRandom(nullptr), fMagField(nullptr), fUseExternalGeometryConstruction(kFALSE),
+     fUseExternalParticleGeneration(kFALSE)
 {
 }
 
@@ -83,7 +70,7 @@ TVirtualMC::TVirtualMC()
 
 TVirtualMC::~TVirtualMC()
 {
-   fgMC=0;
+   fgMC = nullptr;
 }
 
 //
@@ -95,7 +82,8 @@ TVirtualMC::~TVirtualMC()
 /// Static access method
 ///
 
-TVirtualMC* TVirtualMC::GetMC() {
+TVirtualMC *TVirtualMC::GetMC()
+{
    return fgMC;
 }
 
@@ -104,7 +92,7 @@ TVirtualMC* TVirtualMC::GetMC() {
 /// Set particles stack.
 ///
 
-void TVirtualMC::SetStack(TVirtualMCStack* stack)
+void TVirtualMC::SetStack(TVirtualMCStack *stack)
 {
    fStack = stack;
 }
@@ -114,7 +102,7 @@ void TVirtualMC::SetStack(TVirtualMCStack* stack)
 /// Set external decayer.
 ///
 
-void TVirtualMC::SetExternalDecayer(TVirtualMCDecayer* decayer)
+void TVirtualMC::SetExternalDecayer(TVirtualMCDecayer *decayer)
 {
    fDecayer = decayer;
 }
@@ -124,7 +112,7 @@ void TVirtualMC::SetExternalDecayer(TVirtualMCDecayer* decayer)
 /// Set random number generator.
 ///
 
-void TVirtualMC::SetRandom(TRandom* random)
+void TVirtualMC::SetRandom(TRandom *random)
 {
    gRandom = random;
    fRandom = random;
@@ -135,7 +123,142 @@ void TVirtualMC::SetRandom(TRandom* random)
 /// Set magnetic field.
 ///
 
-void TVirtualMC::SetMagField(TVirtualMagField* field)
+void TVirtualMC::SetMagField(TVirtualMagField *field)
 {
    fMagField = field;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Process one event (backwards compatibility)
+///
+
+void TVirtualMC::ProcessEvent()
+{
+   Warning("ProcessEvent", "Not implemented.");
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Process one event (backwards compatibility)
+///
+
+void TVirtualMC::ProcessEvent(Int_t eventId)
+{
+   ProcessEvent(eventId, kFALSE);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Return the current step number
+///
+
+Int_t TVirtualMC::StepNumber() const
+{
+   Warning("StepNumber", "Not implemented.");
+   return 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Get the current weight
+///
+
+Double_t TVirtualMC::TrackWeight() const
+{
+   Warning("Weight", "Not implemented.");
+   return 1.;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Get the current polarization
+///
+
+void TVirtualMC::TrackPolarization(Double_t &polX, Double_t &polY, Double_t &polZ) const
+{
+   Warning("Polarization", "Not implemented.");
+   polX = 0.;
+   polY = 0.;
+   polZ = 0.;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Get the current polarization
+///
+
+void TVirtualMC::TrackPolarization(TVector3 &pol) const
+{
+   Warning("Polarization", "Not implemented.");
+   pol[0] = 0.;
+   pol[1] = 0.;
+   pol[2] = 0.;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Set the VMC id
+///
+
+void TVirtualMC::SetId(UInt_t id)
+{
+   fId = id;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Set container holding additional information for transported TParticles
+///
+void TVirtualMC::SetManagerStack(TMCManagerStack *stack)
+{
+   fManagerStack = stack;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Disables internal dispatch to TVirtualMCApplication::ConstructGeometry()
+/// and hence rely on geometry construction being trigeered from outside.
+///
+
+void TVirtualMC::SetExternalGeometryConstruction(Bool_t value)
+{
+   fUseExternalGeometryConstruction = value;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Disables internal dispatch to TVirtualMCApplication::ConstructGeometry()
+/// and hence rely on geometry construction being trigeered from outside.
+///
+
+void TVirtualMC::SetExternalParticleGeneration(Bool_t value)
+{
+   fUseExternalParticleGeneration = value;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// An interruptible event can be paused and resumed at any time. It must not
+/// call TVirtualMCApplication::BeginEvent() and ::FinishEvent()
+/// Further, when tracks are popped from the TVirtualMCStack it must be
+/// checked whether these are new tracks or whether they have been
+/// transported up to their current point.
+///
+
+void TVirtualMC::ProcessEvent(Int_t eventId, Bool_t isInterruptible)
+{
+   const char *interruptibleText = isInterruptible ? "interruptible" : "non-interruptible";
+   Warning("ProcessInterruptibleEvent", "Process %s event %i. Not implemented.", interruptibleText, eventId);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// That triggers stopping the transport of the current track without dispatching
+/// to common routines like TVirtualMCApplication::PostTrack() etc.
+///
+
+void TVirtualMC::InterruptTrack()
+{
+   Warning("InterruptTrack", "Not implemented.");
 }

--- a/montecarlo/vmc/src/TVirtualMCApplication.cxx
+++ b/montecarlo/vmc/src/TVirtualMCApplication.cxx
@@ -12,6 +12,8 @@
 
 #include "TVirtualMCApplication.h"
 #include "TError.h"
+#include "TVirtualMC.h"
+#include "TMCManager.h"
 
 /** \class TVirtualMCApplication
     \ingroup vmc
@@ -20,25 +22,30 @@ Interface to a user Monte Carlo application.
 
 */
 
-ClassImp(TVirtualMCApplication);
-
-TMCThreadLocal TVirtualMCApplication* TVirtualMCApplication::fgInstance = 0;
+TMCThreadLocal TVirtualMCApplication *TVirtualMCApplication::fgInstance = nullptr;
+Bool_t TVirtualMCApplication::fLockMultiThreading = kFALSE;
 
 ////////////////////////////////////////////////////////////////////////////////
 ///
 /// Standard constructor
 ///
 
-TVirtualMCApplication::TVirtualMCApplication(const char *name,
-                                             const char *title)
-  : TNamed(name,title)
+TVirtualMCApplication::TVirtualMCApplication(const char *name, const char *title) : TNamed(name, title)
 {
    if (fgInstance) {
-      Fatal("TVirtualMCApplication",
-            "Attempt to create two instances of singleton.");
+      ::Fatal("TVirtualMCApplication::TVirtualMCApplication", "Attempt to create two instances of singleton.");
+   }
+
+   // This is set to true if a TMCManager was reuqested.
+   if (fLockMultiThreading) {
+      ::Fatal("TVirtualMCApplication::TVirtualMCApplication", "In multi-engine run ==> multithreading is disabled.");
    }
 
    fgInstance = this;
+   // There cannot be a TVirtualMC since it must have registered to this
+   // TVirtualMCApplication
+   fMC = nullptr;
+   fMCManager = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -46,10 +53,11 @@ TVirtualMCApplication::TVirtualMCApplication(const char *name,
 /// Default constructor
 ///
 
-TVirtualMCApplication::TVirtualMCApplication()
-  : TNamed()
+TVirtualMCApplication::TVirtualMCApplication() : TNamed()
 {
    fgInstance = this;
+   fMC = nullptr;
+   fMCManager = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -59,7 +67,10 @@ TVirtualMCApplication::TVirtualMCApplication()
 
 TVirtualMCApplication::~TVirtualMCApplication()
 {
-   fgInstance = 0;
+   fgInstance = nullptr;
+   if (fMCManager) {
+      delete fMCManager;
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -67,7 +78,48 @@ TVirtualMCApplication::~TVirtualMCApplication()
 /// Static access method
 ///
 
-TVirtualMCApplication* TVirtualMCApplication::Instance()
+TVirtualMCApplication *TVirtualMCApplication::Instance()
 {
-  return fgInstance;
+   return fgInstance;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// For backwards compatibility provide a static GetMC method
+///
+
+void TVirtualMCApplication::RequestMCManager()
+{
+   fMCManager = new TMCManager();
+   fMCManager->Register(this);
+   fMCManager->ConnectEnginePointer(&fMC);
+   fLockMultiThreading = kTRUE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// /// Register the an engine.
+///
+
+void TVirtualMCApplication::Register(TVirtualMC *mc)
+{
+   // If there is already a transport engine, fail since only one is allowed.
+   if (fMC && !fMCManager) {
+      Fatal("Register", "Attempt to register a second TVirtualMC which "
+                        "is not allowed");
+   }
+   fMC = mc;
+   if (fMCManager) {
+      fMCManager->Register(mc);
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Return the current transport engine in use
+///
+
+TVirtualMC *TVirtualMCApplication::GetMC() const
+{
+   return fMC;
 }


### PR DESCRIPTION
This is an extension allowing the VMC package to run a simulation
with multiple different engines at a time. Tracks can be transferred
among engines during a simulation run based on conditions specified by
the user.

Important notes on the extensions:
  1) This extension preserves backward-compatibility in the sense that
     user code relying on the former version of VMC is still running
     with the extended version. Was tested with GEANT3_VMC@v2-6 and
     GEANT4_VMC@v3-6-p1.
  2) A shared simulation is only possible when TGeo is used for geometry
     construction and navigation.
  3) A TMCManager singleton object is responsible for handling multiple
     engines and can be obtained on request calling
     TVirtualMCApplication::RequestManager() during construction of the
     user application class.
  4) The introduced TMCParticleStatus objects hold additional
     information to keep track of properties when a track is transferred
     between engines.
  5) When a track is interrupted in one engine to be transferred to
     another, the geometry state is cached in the form of a
     TGeoBranchArray object. It will be used to initialize the navigator
     when this track is picked up for further transport in the next
     engine. This is especially useful/required when a track is
     transferred at a volume boundary in order to be picked up in the
     entered volume and not in the one just left. This is a main reason
     why geometry management is forced to be done via TGeo.

A more comprehensive introduction concerning the usage and
implementation in the user code can be found in the
montecarlo/vmc/README.md

Further note:
  This commit also applies the clang format to the modified and new
  files.