### PR TITLE
Fix Dropout for Dense layers in MethodDL

### DIFF
--- a/tmva/tmva/inc/TMVA/DNN/DeepNet.h
+++ b/tmva/tmva/inc/TMVA/DNN/DeepNet.h
@@ -332,6 +332,9 @@ public:
    inline void SetInitialization(EInitialization I) { fI = I; }
    inline void SetRegularization(ERegularization R) { fR = R; }
    inline void SetWeightDecay(Scalar_t weightDecay) { fWeightDecay = weightDecay; }
+
+   void SetDropoutProbabilities(const std::vector<Double_t> & probabilities);
+
 };
 
 //
@@ -1160,6 +1163,22 @@ auto TDeepNet<Architecture_t, Layer_t>::Print() const -> void
       fLayers[i]->Print();
    }
 }
+
+//______________________________________________________________________________
+template <typename Architecture_t, typename Layer_t>
+void TDeepNet<Architecture_t, Layer_t>::SetDropoutProbabilities(
+    const std::vector<Double_t> & probabilities)
+{
+   for (size_t i = 0; i < fLayers.size(); i++) {
+      if (i < probabilities.size()) {
+         fLayers[i]->SetDropoutProbability(probabilities[i]);
+      } else {
+         fLayers[i]->SetDropoutProbability(1.0);
+      }
+   }
+}
+
+
 } // namespace DNN
 } // namespace TMVA
 

--- a/tmva/tmva/inc/TMVA/DNN/DenseLayer.h
+++ b/tmva/tmva/inc/TMVA/DNN/DenseLayer.h
@@ -33,6 +33,7 @@
 #include "TMVA/DNN/Functions.h"
 
 #include <iostream>
+#include <iomanip>
 
 namespace TMVA {
 namespace DNN {
@@ -200,15 +201,17 @@ auto TDenseLayer<Architecture_t>::Backward(std::vector<Matrix_t> &gradients_back
 template <typename Architecture_t>
 void TDenseLayer<Architecture_t>::Print() const
 {
-   std::cout << " DENSE Layer: \t ";
-   std::cout << " ( Input = " << this->GetWeightsAt(0).GetNcols();  // input size 
-   std::cout << " , Width = " << this->GetWeightsAt(0).GetNrows() << " ) ";  // layer width
+   std::cout << " DENSE Layer: \t";
+   std::cout << " ( Input =" << std::setw(6) << this->GetWeightsAt(0).GetNcols();  // input size 
+   std::cout << " , Width =" << std::setw(6) << this->GetWeightsAt(0).GetNrows() << " ) ";  // layer width
    if (this->GetOutput().size() > 0) {
-      std::cout << "\tOutput = ( " << this->GetOutput().size() << " , " << this->GetOutput()[0].GetNrows() << " , " << this->GetOutput()[0].GetNcols() << " ) ";
+      std::cout << "\tOutput = ( " << std::setw(2) << this->GetOutput().size() << " ," << std::setw(6) << this->GetOutput()[0].GetNrows() << " ," << std::setw(6) << this->GetOutput()[0].GetNcols() << " ) ";
    }
    std::vector<std::string> activationNames = { "Identity","Relu","Sigmoid","Tanh","SymmRelu","SoftSign","Gauss" };
    std::cout << "\t Activation Function = ";
-   std::cout << activationNames[ static_cast<int>(fF) ] << std::endl;
+   std::cout << activationNames[ static_cast<int>(fF) ];
+   if (fDropoutProbability != 1.) std::cout << "\t Dropout prob. = " << fDropoutProbability;
+   std::cout << std::endl;
 }
 
 //______________________________________________________________________________

--- a/tmva/tmva/inc/TMVA/DNN/DenseLayer.h
+++ b/tmva/tmva/inc/TMVA/DNN/DenseLayer.h
@@ -103,6 +103,8 @@ public:
    /*! Read the information and the weights about the layer from XML node. */
    virtual void ReadWeightsFromXML(void *parent);
 
+   /*! Set dropout probabilities */
+   virtual void SetDropoutProbability(Scalar_t dropoutProbability) { fDropoutProbability = dropoutProbability; }
 
    /*! Getters */
    Scalar_t GetDropoutProbability() const { return fDropoutProbability; }

--- a/tmva/tmva/inc/TMVA/DNN/GeneralLayer.h
+++ b/tmva/tmva/inc/TMVA/DNN/GeneralLayer.h
@@ -137,6 +137,9 @@ public:
    /*! Read the information and the weights about the layer from XML node. */
    virtual void ReadWeightsFromXML(void *parent) = 0;
 
+   /*! Set Dropout probability. Reimplemented for layesrs supporting droput */
+   virtual void SetDropoutProbability(Scalar_t ) {}
+
    /*! Getters */
    size_t GetBatchSize() const { return fBatchSize; }
    size_t GetInputDepth() const { return fInputDepth; }

--- a/tmva/tmva/inc/TMVA/MethodDL.h
+++ b/tmva/tmva/inc/TMVA/MethodDL.h
@@ -66,6 +66,7 @@ struct TTrainingSettings {
    size_t maxEpochs; 
    DNN::ERegularization regularization;
    DNN::EOptimizer optimizer;
+   TString optimizerName; 
    Double_t learningRate;
    Double_t momentum;
    Double_t weightDecay;

--- a/tmva/tmva/src/DNN/Architectures/Cpu/Dropout.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Cpu/Dropout.cxx
@@ -32,6 +32,8 @@ void TCpu<AFloat>::Dropout(TCpuMatrix<AFloat> &A,
    size_t nElements =  A.GetNoElements();
    const size_t nSteps = TCpuMatrix<AFloat>::GetNWorkItems(nElements);
 
+   // apply droput. The probability is actually the probability to keep the node
+   // (i.e. 1 - dropout_prob)
    auto f = [&data, dropoutProbability, &nSteps, &nElements, &seed](UInt_t workerID)
    {
       TRandom rand(seed+workerID);

--- a/tmva/tmva/src/DNN/Architectures/Cpu/LossFunctions.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Cpu/LossFunctions.cxx
@@ -87,7 +87,13 @@ AFloat TCpu<AFloat>::CrossEntropy(const TCpuMatrix<AFloat> &Y, const TCpuMatrix<
    auto f = [&dataY, &dataOutput, &dataWeights, &temp, m](UInt_t workerID) {
       AFloat y   = dataY[workerID];
       AFloat sig = 1.0 / (1.0 + exp(- dataOutput[workerID]));
-      temp[workerID] = - (y * log(sig) + (1.0 - y) * log(1.0 - sig));
+      if (y == 0) 
+         temp[workerID] = - log(1.0 - sig);
+      else if ( y == 1.)
+         temp[workerID] = - log(sig); 
+      else 
+         temp[workerID] = - (y * log(sig) + (1.0 - y) * log(1.0 - sig));
+
       temp[workerID] *= dataWeights[workerID % m];
       return 0;
    };

--- a/tmva/tmva/src/DNN/Architectures/Cuda/Kernels.cuh
+++ b/tmva/tmva/src/DNN/Architectures/Cuda/Kernels.cuh
@@ -813,8 +813,14 @@ __global__ void CrossEntropy(AFloat * result,
    if ((i < m) && (j < n)) {
        AFloat norm = 1 / ((AFloat) (m * n));
        AFloat sig  = 1.0 / (1.0 + exp(-output[index]));
-       AFloat ce   = Y[index] * log(sig) + (1.0 - Y[index]) * log(1.0 - sig);
-       sdata[tid]  = -weights[i] * norm * ce;
+       if (Y[index] == 0)
+          sdata[tid] = -weights[i] * norm * log(1.0 - sig);
+       else if (Y[index] == 1.0)
+          sdata[tid] = -weights[i] * norm * log(sig);
+       else {
+          AFloat ce  = Y[index] * log(sig) + (1.0 - Y[index]) * log(1.0 - sig);
+          sdata[tid] = -weights[i] * norm * ce;
+       }
    } else {
        sdata[tid] = 0.0;
    }

--- a/tmva/tmva/src/MethodDL.cxx
+++ b/tmva/tmva/src/MethodDL.cxx
@@ -1174,6 +1174,9 @@ void MethodDL::TrainDeepNet()
       // Add all appropriate layers to deepNet and (if fBuildNet is true) also to fNet
       CreateDeepNet(deepNet, nets);
 
+      // set droput probabilities
+      deepNet.SetDropoutProbabilities(settings.dropoutProbabilities);
+
       if (trainingPhase > 1) {
          // copy initial weights from fNet to deepnet
          for (size_t i = 0; i < deepNet.GetDepth(); ++i) {

--- a/tmva/tmva/src/MethodDL.cxx
+++ b/tmva/tmva/src/MethodDL.cxx
@@ -1180,7 +1180,12 @@ void MethodDL::TrainDeepNet()
       CreateDeepNet(deepNet, nets);
 
       // set droput probabilities
-      deepNet.SetDropoutProbabilities(settings.dropoutProbabilities);
+      // use convention to store in the layer 1.- dropout probabilities
+      std::vector<Double_t> dropoutVector(settings.dropoutProbabilities);
+      for (auto & p : dropoutVector) {
+         p = 1.0 - p;
+      }
+      deepNet.SetDropoutProbabilities(dropoutVector);
 
       if (trainingPhase > 1) {
          // copy initial weights from fNet to deepnet

--- a/tmva/tmva/src/MethodDL.cxx
+++ b/tmva/tmva/src/MethodDL.cxx
@@ -61,7 +61,9 @@ using TMVA::DNN::EInitialization;
 using TMVA::DNN::EOutputFunction;
 using TMVA::DNN::EOptimizer;
 
+
 namespace TMVA {
+
 
 ////////////////////////////////////////////////////////////////////////////////
 TString fetchValueTmp(const std::map<TString, TString> &keyValueMap, TString key)
@@ -359,6 +361,7 @@ void MethodDL::ProcessOptions()
       }
 
       TString optimizer = fetchValueTmp(block, "Optimizer", TString("ADAM"));
+      settings.optimizerName = optimizer;
       if (optimizer == "SGD") {
          settings.optimizer = DNN::EOptimizer::kSGD;
       } else if (optimizer == "ADAM") {
@@ -373,7 +376,9 @@ void MethodDL::ProcessOptions()
          // Make Adam as default choice if the input string is
          // incorrect.
          settings.optimizer = DNN::EOptimizer::kAdam;
+         settings.optimizerName = "ADAM";
       }
+      
 
       TString strMultithreading = fetchValueTmp(block, "Multithreading", TString("True"));
 
@@ -1282,8 +1287,9 @@ void MethodDL::TrainDeepNet()
       std::chrono::time_point<std::chrono::system_clock> tstart, tend;
       tstart = std::chrono::system_clock::now();
 
-      Log() << "Training phase " << trainingPhase << " of " << this->GetTrainingSettings().size() << ":    "
-            << "Learning rate = " << settings.learningRate 
+      Log() << "Training phase " << trainingPhase << " of " << this->GetTrainingSettings().size() << ": "
+            << " Optimizer " << settings.optimizerName 
+            << " Learning rate = " << settings.learningRate 
             << " regularization " << (char) settings.regularization 
             << " minimum error = " << minValError
             << Endl;


### PR DESCRIPTION
As reported by @behrenhoff MethodDL did not have so far an implementation for the dropout. 
(see https://root-forum.cern.ch/t/method-kdl-in-tmva/32863)
This PR fixes the dropout for dense layers, implementing what has been done for the previous MethodDNN. 

The implementation removes (by setting to zero) randomly input nodes and re-scale the surviving ones by a factor 1/(1.- dropout_probability). In this way no changes are needed for testing and evaluating a trained network with dropout. 

The PR applies also some other small improvements such as print out of optimizer names and some fixes in the cross-evaluation function to avoid NaN outputs. 