### PR TITLE
[Exp PyROOT] Prevent error at teardown of RooPlot

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/test/roodatahist_ploton.py
+++ b/bindings/pyroot_experimental/PyROOT/test/roodatahist_ploton.py
@@ -26,7 +26,7 @@ class RooDataHistPlotOn(unittest.TestCase):
 
         dh = ROOT.RooDataHist('dh', 'binned version of d', ROOT.RooArgSet(x, y), d)
 
-        yframe = y.frame(ROOT.RooFit.Bins(10), ROOT.RooFit.Title('Operations on binned datasets'))
+        yframe = ROOT.RooPlot('yplot', 'Operations on binned datasets', y, 0, 40, 10)
 
         return dh, yframe
 


### PR DESCRIPTION
Fix test error:
https://epsft-jenkins.cern.ch/job/root-exp-pyroot/62/LABEL=mac1014,SPEC=default/testReport/junit/projectroot.bindings.pyroot_experimental.PyROOT/test/pyunittests_pyroot_pyz_roodatahist_ploton/