### PR TITLE
[Exp PyROOT] Re-enable RDF tests and tutorials

### DIFF
--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -43,6 +43,6 @@ ROOT_ADD_GTEST(datasource_csv datasource_csv.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(datasource_lazy datasource_lazy.cxx LIBRARIES ROOTDataFrame)
 
 #### PYTHON TESTS ####
-ROOT_ADD_PYUNITTEST(dataframe_misc dataframe_misc.py ${PYTESTS_WILLFAIL})
+ROOT_ADD_PYUNITTEST(dataframe_misc dataframe_misc.py)
 ROOT_ADD_PYUNITTEST(dataframe_histograms dataframe_histograms.py ${PYTESTS_WILLFAIL})
 ROOT_ADD_PYUNITTEST(dataframe_cache dataframe_cache.py ${PYTESTS_WILLFAIL})

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -426,22 +426,13 @@ if(ROOT_python_FOUND)
   set(roofit-rf104_classfactory-depends tutorial-roofit-rf104_classfactory) #Race condition
 
   #---Tutorials expected to fail in PyROOT experimental
-  set(pyexp_fail tutorial-dataframe-df001_introduction-py
-                 tutorial-dataframe-df002_dataModel-py
+  set(pyexp_fail tutorial-dataframe-df002_dataModel-py
                  tutorial-dataframe-df003_profiles-py
-                 tutorial-dataframe-df004_cutFlowReport-py
-                 tutorial-dataframe-df006_ranges-py
-                 tutorial-dataframe-df007_snapshot-py
-                 tutorial-dataframe-df008_createDataSetFromScratch-py
                  tutorial-dataframe-df010_trivialDataSource-py
                  tutorial-dataframe-df011_ROOTDataSource-py
-                 tutorial-dataframe-df012_DefinesAndFiltersAsStrings-py
                  tutorial-dataframe-df014_CSVDataSource-py
                  tutorial-dataframe-df016_vecOps-py
                  tutorial-dataframe-df017_vecOpsHEP-py
-                 tutorial-dataframe-df019_Cache-py
-                 tutorial-dataframe-df021_createTGraph-py
-                 tutorial-dataframe-df024_Display-py
                  tutorial-dataframe-df026_AsNumpyArrays-py
                  tutorial-hist-fillrandom-py
                  tutorial-math-Legendre-py


### PR DESCRIPTION
`string_view` support in Cppyy for < cxx14 fixed these tests:

https://github.com/root-project/root/pull/3455