### PR TITLE
[Exp PyROOT] Fix cast-function-type warnings

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/src/GenericPyz.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/GenericPyz.cxx
@@ -18,12 +18,12 @@
 
 using namespace CPyCppyy;
 
-std::string GetCppName(CPPInstance *self)
+std::string GetCppName(const CPPInstance *self)
 {
    return Cppyy::GetScopedFinalName(self->ObjectIsA());
 }
 
-PyObject *ClingPrintValue(CPPInstance *self)
+PyObject *ClingPrintValue(const CPPInstance *self, PyObject * /* args */)
 {
    const std::string className = GetCppName(self);
    auto printResult = gInterpreter->ToString(className.c_str(), self->GetObject());

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
@@ -33,7 +33,7 @@ PyObject *AddSetItemTCAPyz(PyObject *self, PyObject *args);
 PyObject *AsRVec(PyObject *self, PyObject *obj);
 
 PyObject *AddUsingToClass(PyObject *self, PyObject *args);
-PyObject *GetEndianess(PyObject *self);
+PyObject *GetEndianess(PyObject *self, PyObject *args);
 PyObject *GetVectorDataPointer(PyObject *self, PyObject *args);
 PyObject *GetSizeOfType(PyObject *self, PyObject *args);
 

--- a/bindings/pyroot_experimental/PyROOT/src/PyzPythonHelpers.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyzPythonHelpers.cxx
@@ -86,11 +86,12 @@ PyObject *PyROOT::GetVectorDataPointer(PyObject * /*self*/, PyObject *args)
 ////////////////////////////////////////////////////////////////////////////
 /// \brief Get endianess of the system
 /// \param[in] self Always null, since this is a module function.
+/// \param[in] args Pointer to an empty Python tuple.
 /// \param[out] Endianess as Python string
 ///
 /// This function returns endianess of the system as a Python integer. The
 /// return value is either '<' or '>' for little or big endian, respectively.
-PyObject *PyROOT::GetEndianess(PyObject * /* self */)
+PyObject *PyROOT::GetEndianess(PyObject * /* self */, PyObject * /* args */)
 {
 #ifdef R__BYTESWAP
    return CPyCppyy_PyUnicode_FromString("<");

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/CMakeLists.txt
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/CMakeLists.txt
@@ -39,8 +39,13 @@ set(sources
 
 add_library(cppyy SHARED ${headers} ${sources})
 target_include_directories(cppyy PRIVATE ${CMAKE_BINARY_DIR}/include) # needed for string_view backport
+
 target_compile_options(cppyy PRIVATE
   -Wno-shadow -Wno-strict-aliasing -Wno-unused-but-set-parameter)
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL 8)
+  target_compile_options(cppyy PRIVATE -Wno-cast-function-type)
+endif()
+
 target_include_directories(cppyy PUBLIC ${PYTHON_INCLUDE_DIRS}
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>)


### PR DESCRIPTION
In the PyROOT experimental nightlies there are a number of warnings:
http://cdash.cern.ch/viewBuildError.php?type=1&buildid=633548

Most of them are related to casting function pointers and come from Cppyy code. As Wim pointed out in this ticket:

https://sft.its.cern.ch/jira/browse/ROOT-9612

those casts are not incorrect and do not produce any malfunctioning. They correspond to casts to `PyCFunction`, used to implement Python callables in C, whose signature is `PyObject* (*)(PyObject*, PyObject*)`, the first argument being a pointer to `self` and the second a pointer to a tuple with the arguments received from Python. Sometimes, a function that only receives one `PyObject*` is cast to `PyCFunction`, since there is an extra `METH_XYZ` flag that determines how the function will be called:
https://github.com/root-project/root/blob/master/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Pythonize.cxx#L1028
https://github.com/root-project/root/blob/master/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Pythonize.cxx#L807

This PR disables the `cast-function-type` warning when building Cppyy and fixes a couple of equivalent warnings in PyROOT experimental.