### PR TITLE
Fix ROOT-7487, make TObject::Clone always proceed.

### DIFF
--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -147,7 +147,7 @@ TObject *TObject::Clone(const char *) const
      return gDirectory->CloneObject(this);
    } else {
      // Some of the streamer (eg. roofit's) expect(ed?) a valid gDirectory during streaming.
-     return gROOT->Clone();
+     return gROOT->CloneObject(this);
    }
 }
 

--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -146,8 +146,8 @@ TObject *TObject::Clone(const char *) const
    if (gDirectory) {
      return gDirectory->CloneObject(this);
    } else {
-     Fatal("Clone","No gDirectory set");
-     return 0;
+     // Some of the streamer (eg. roofit's) expect(ed?) a valid gDirectory during streaming.
+     return gROOT->Clone();
    }
 }
 


### PR DESCRIPTION
If gDirectory is a nullptr use gROOT.  TObject::Clone uses
TDirectory[File]::CloneObject and the TDirectoryFile object
actually change the behavior (set gFile to nullptr) in a way
that probably require significant surgery to avoid using the
virtual function.