### PR TITLE
Actually fix ROOT-7487.

### DIFF
--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -147,7 +147,7 @@ TObject *TObject::Clone(const char *) const
      return gDirectory->CloneObject(this);
    } else {
      // Some of the streamer (eg. roofit's) expect(ed?) a valid gDirectory during streaming.
-     return gROOT->Clone();
+     return gROOT->CloneObject(this);
    }
 }
 


### PR DESCRIPTION
Previous fix was cloning the gROOT object rather than the user object (and
in practice was leading to an infinite recursion).  This corrects 3317c2027c976c4f5d2b4eece00bc6c4aae9773b.