### PR TITLE
[PyROOT] Fix for AsNumpy when column is empty

### DIFF
--- a/bindings/pyroot/ROOT.py
+++ b/bindings/pyroot/ROOT.py
@@ -436,6 +436,8 @@ def _RDataFrameAsNumpy(df, columns=None, exclude=None):
     for column in columns:
         cpp_reference = result_ptrs[column].GetValue()
         if hasattr(cpp_reference, "__array_interface__"):
+            if cpp_reference.isempty():
+              cpp_reference = []
             tmp = numpy.array(cpp_reference) # This adopts the memory of the C++ object.
             py_arrays[column] = ndarray(tmp, result_ptrs[column])
         else:

--- a/bindings/pyroot/ROOT.py
+++ b/bindings/pyroot/ROOT.py
@@ -436,7 +436,7 @@ def _RDataFrameAsNumpy(df, columns=None, exclude=None):
     for column in columns:
         cpp_reference = result_ptrs[column].GetValue()
         if hasattr(cpp_reference, "__array_interface__"):
-            if cpp_reference.isempty():
+            if cpp_reference.empty():
               cpp_reference = []
             tmp = numpy.array(cpp_reference) # This adopts the memory of the C++ object.
             py_arrays[column] = ndarray(tmp, result_ptrs[column])

--- a/bindings/pyroot/ROOT.py
+++ b/bindings/pyroot/ROOT.py
@@ -436,8 +436,6 @@ def _RDataFrameAsNumpy(df, columns=None, exclude=None):
     for column in columns:
         cpp_reference = result_ptrs[column].GetValue()
         if hasattr(cpp_reference, "__array_interface__"):
-            if cpp_reference.empty():
-              cpp_reference = []
             tmp = numpy.array(cpp_reference) # This adopts the memory of the C++ object.
             py_arrays[column] = ndarray(tmp, result_ptrs[column])
         else:

--- a/bindings/pyroot/src/Pythonize.cxx
+++ b/bindings/pyroot/src/Pythonize.cxx
@@ -2324,8 +2324,14 @@ namespace {
 
       PyObject *dict = FillArrayInterfaceDict<dtype>(typestr);
       PyDict_SetItemString(dict, "shape", PyTuple_Pack(1, PyLong_FromLong(cobj->size())));
-      PyDict_SetItemString(dict, "data",
-                           PyTuple_Pack(2, PyLong_FromLong(reinterpret_cast<long>(cobj->data())), Py_False));
+      if(cobj->empty()){
+         PyDict_SetItemString(dict, "data",
+                           PyTuple_Pack(2, PyLong_FromLong(-1l), Py_False));
+      }
+      else{
+         PyDict_SetItemString(dict, "data",
+                           PyTuple_Pack(2, PyLong_FromLong(reinterpret_cast<long>(cobj->data())), Py_False));         
+      }
 
       return dict;
    }


### PR DESCRIPTION
Currently the `RDataFrame.AsNumpy` function can not handle empty columns.

This minimal example produces an `ValueError: setting an array element with a sequence.`

```
def fill_tree(treeName, fileName):
    ROOT.gRandom.SetSeed(1)
    tdf = ROOT.ROOT.RDataFrame(100)
    tdf.Define("b1", "2.")

treeName = 'tree'
fileName = treeName+".root"
fill_tree(treeName, treeName+".root")
base = ROOT.ROOT.RDataFrame(treeName, fileName)

base.Filter("b1>3").AsNumpy(columns=["b1"])  
```

```
---------------------------------------
File "ROOT.py", line 441, in _RDataFrameAsNumpy
    tmp = numpy.array(cpp_reference) # This adopts the memory of the C++ object.
ValueError: setting an array element with a sequence.
```
