### PR TITLE
[cling] Force flush cout after execution

### DIFF
--- a/interpreter/cling/lib/Interpreter/IncrementalExecutor.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalExecutor.cpp
@@ -148,8 +148,8 @@ void unresolvedSymbol()
   // throw exception instead?
 }
 
-void* IncrementalExecutor::HandleMissingFunction(const std::string& mangled_name)
-{
+void*
+IncrementalExecutor::HandleMissingFunction(const std::string& mangled_name) const {
   // Not found in the map, add the symbol in the list of unresolved symbols
   if (m_unresolvedSymbols.insert(mangled_name).second) {
     //cling::errs() << "IncrementalExecutor: use of undefined symbol '"
@@ -159,10 +159,9 @@ void* IncrementalExecutor::HandleMissingFunction(const std::string& mangled_name
   return utils::FunctionToVoidPtr(&unresolvedSymbol);
 }
 
-void* IncrementalExecutor::NotifyLazyFunctionCreators(const std::string& mangled_name)
-{
-  for (std::vector<LazyFunctionCreatorFunc_t>::iterator it
-         = m_lazyFuncCreator.begin(), et = m_lazyFuncCreator.end();
+void*
+IncrementalExecutor::NotifyLazyFunctionCreators(const std::string& mangled_name) const {
+  for (auto it = m_lazyFuncCreator.begin(), et = m_lazyFuncCreator.end();
        it != et; ++it) {
     void* ret = (void*)((LazyFunctionCreatorFunc_t)*it)(mangled_name);
     if (ret)
@@ -208,7 +207,7 @@ freeCallersOfUnresolvedSymbols(llvm::SmallVectorImpl<llvm::Function*>&
 #endif
 
 IncrementalExecutor::ExecutionResult
-IncrementalExecutor::runStaticInitializersOnce(const Transaction& T) {
+IncrementalExecutor::runStaticInitializersOnce(const Transaction& T) const {
   auto m = T.getModule();
   assert(m.get() && "Module must not be null");
 
@@ -326,7 +325,7 @@ static void flushOutBuffers() {
 
 IncrementalExecutor::ExecutionResult
 IncrementalExecutor::executeWrapper(llvm::StringRef function,
-                                    Value* returnValue/* =0*/) {
+                                    Value* returnValue/* =0*/) const {
   // Set the value to cling::invalid.
   if (returnValue)
     *returnValue = Value();
@@ -351,12 +350,12 @@ IncrementalExecutor::installLazyFunctionCreator(LazyFunctionCreatorFunc_t fp)
 
 bool
 IncrementalExecutor::addSymbol(const char* Name,  void* Addr,
-                               bool Jit) {
+                               bool Jit) const {
   return m_JIT->lookupSymbol(Name, Addr, Jit).second;
 }
 
 void* IncrementalExecutor::getAddressOfGlobal(llvm::StringRef symbolName,
-                                              bool* fromJIT /*=0*/) {
+                                              bool* fromJIT /*=0*/) const {
   // Return a symbol's address, and whether it was jitted.
   void* address = m_JIT->lookupSymbol(symbolName).first;
 
@@ -371,7 +370,7 @@ void* IncrementalExecutor::getAddressOfGlobal(llvm::StringRef symbolName,
 }
 
 void*
-IncrementalExecutor::getPointerToGlobalFromJIT(const llvm::GlobalValue& GV) {
+IncrementalExecutor::getPointerToGlobalFromJIT(const llvm::GlobalValue& GV) const {
   // Get the function / variable pointer referenced by GV.
 
   // We don't care whether something was unresolved before.
@@ -386,7 +385,7 @@ IncrementalExecutor::getPointerToGlobalFromJIT(const llvm::GlobalValue& GV) {
 }
 
 bool IncrementalExecutor::diagnoseUnresolvedSymbols(llvm::StringRef trigger,
-                                                    llvm::StringRef title) {
+                                                  llvm::StringRef title) const {
   if (m_unresolvedSymbols.empty())
     return false;
 

--- a/interpreter/cling/lib/Interpreter/IncrementalExecutor.h
+++ b/interpreter/cling/lib/Interpreter/IncrementalExecutor.h
@@ -182,21 +182,7 @@ namespace cling {
 
     ///\brief Runs a wrapper function.
     ExecutionResult executeWrapper(llvm::StringRef function,
-                                   Value* returnValue = 0) {
-      // Set the value to cling::invalid.
-      if (returnValue) {
-        *returnValue = Value();
-      }
-      typedef void (*InitFun_t)(void*);
-      InitFun_t fun;
-      ExecutionResult res = jitInitOrWrapper(function, fun);
-      if (res != kExeSuccess)
-        return res;
-      EnterUserCodeRAII euc(m_Callbacks);
-      (*fun)(returnValue);
-      return kExeSuccess;
-    }
-
+                                   Value* returnValue = 0);
     ///\brief Adds a symbol (function) to the execution engine.
     ///
     /// Allows runtime declaration of a function passing its pointer for being

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -59,9 +59,10 @@
 #include "llvm/IR/Module.h"
 #include "llvm/Support/Path.h"
 
+#include <iostream>
+#include <sstream>
 #include <string>
 #include <vector>
-#include <sstream>
 
 using namespace clang;
 
@@ -1084,6 +1085,10 @@ namespace cling {
     utils::Analyze::maybeMangleDeclName(FD, mangledNameIfNeeded);
     IncrementalExecutor::ExecutionResult ExeRes =
        m_Executor->executeWrapper(mangledNameIfNeeded, res);
+
+    // Force-flush as we might be printing on screen with printf.
+    std::cout.flush();
+
     return ConvertExecutionResult(ExeRes);
   }
 

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -59,7 +59,6 @@
 #include "llvm/IR/Module.h"
 #include "llvm/Support/Path.h"
 
-#include <iostream>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -1085,10 +1084,6 @@ namespace cling {
     utils::Analyze::maybeMangleDeclName(FD, mangledNameIfNeeded);
     IncrementalExecutor::ExecutionResult ExeRes =
        m_Executor->executeWrapper(mangledNameIfNeeded, res);
-
-    // Force-flush as we might be printing on screen with printf.
-    std::cout.flush();
-
     return ConvertExecutionResult(ExeRes);
   }
 

--- a/interpreter/cling/test/Prompt/Regression.C
+++ b/interpreter/cling/test/Prompt/Regression.C
@@ -79,3 +79,13 @@ class MyClass;
 extern MyClass* my;
 class MyClass {public: MyClass* getMyClass() {return 0;}} cl;
 MyClass* my = cl.getMyClass();
+
+//
+printf("Auto flush printf\n");
+//CHECK-NEXT: Auto flush printf
+cout << "Auto flush cout\n";
+//CHECK-NEXT: Auto flush cout
+printf("Must flush print\n"); cout.flush();
+//CHECK-NEXT: Must flush printf
+
+.q


### PR DESCRIPTION
The user might use utilities which print on cout and expects the output
to be shown immediately.

This patch automatically flushes std::cout after each execution of a wrapper.