### PR TITLE
[Exp PyROOT] Add a converter for TString to Cppyy

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -60,6 +60,9 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_tstring_len tstring_len.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tstring_str_repr tstring_str_repr.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tstring_comparisonops tstring_comparisonops.py)
 
+# TString converter
+ROOT_ADD_PYUNITTEST(pyroot_conv_tstring tstring_converter.py)
+
 # TObjString pythonisations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tobjstring_len tobjstring_len.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tobjstring_str_repr tobjstring_str_repr.py)

--- a/bindings/pyroot_experimental/PyROOT/test/tstring_converter.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tstring_converter.py
@@ -32,6 +32,13 @@ class TStringConverter(unittest.TestCase):
 
     def test_by_reference(self):
         ROOT.gInterpreter.Declare("""
+        const char* myfun(TString &s) { return s.Data(); }
+        """)
+
+        self.check_type_conversion()
+
+    def test_by_const_reference(self):
+        ROOT.gInterpreter.Declare("""
         const char* myfun(const TString &s) { return s.Data(); }
         """)
 

--- a/bindings/pyroot_experimental/PyROOT/test/tstring_converter.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tstring_converter.py
@@ -1,0 +1,42 @@
+import unittest
+
+import ROOT
+
+
+class TStringConverter(unittest.TestCase):
+    """
+    Tests for passing a Python string to a C++ function that expects a TString.
+
+    This feature is not implemented by a PyROOT pythonization, but by a converter
+    that was added to Cppyy to create a TString out of a Python string.
+    """
+
+    test_str = "test"
+
+    # Helpers
+    def check_type_conversion(self):
+        s = ROOT.TString(self.test_str)
+
+        # Works with TString...
+        self.assertEqual(ROOT.myfun(s), self.test_str)
+        # ... and Python string
+        self.assertEqual(ROOT.myfun(self.test_str), self.test_str)
+
+    # Tests
+    def test_by_value(self):
+        ROOT.gInterpreter.Declare("""
+        const char* myfun(TString s) { return s.Data(); }
+        """)
+
+        self.check_type_conversion()
+
+    def test_by_reference(self):
+        ROOT.gInterpreter.Declare("""
+        const char* myfun(const TString &s) { return s.Data(); }
+        """)
+
+        self.check_type_conversion()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Converters.cxx
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Converters.cxx
@@ -2070,6 +2070,7 @@ public:
 
     // factories for special cases
         gf["TString"] =                     (cf_t)+[](long) { return new TStringConverter{}; };
+        gf["TString&"] =                    (cf_t)+[](long) { return new TStringConverter{}; };
         gf["const TString&"] =              (cf_t)+[](long) { return new TStringConverter{}; };
         gf["const char*"] =                 (cf_t)+[](long) { return new CStringConverter{}; };
         gf["const char[]"] =                (cf_t)+[](long) { return new CStringConverter{}; };

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Converters.cxx
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Converters.cxx
@@ -1026,6 +1026,7 @@ bool CPyCppyy::name##Converter::ToMemory(PyObject* value, void* address)     \
     return InstancePtrConverter::ToMemory(value, address);                   \
 }
 
+CPPYY_IMPL_STRING_AS_PRIMITIVE_CONVERTER(TString, TString, Data, Length)
 CPPYY_IMPL_STRING_AS_PRIMITIVE_CONVERTER(STLString, std::string, c_str, size)
 CPPYY_IMPL_STRING_AS_PRIMITIVE_CONVERTER(STLStringViewBase, std::string_view, data, size)
 bool CPyCppyy::STLStringViewConverter::SetArg(
@@ -2068,6 +2069,8 @@ public:
         gf["const ULong64_t&"] =            gf["const unsigned long long&"];
 
     // factories for special cases
+        gf["TString"] =                     (cf_t)+[](long) { return new TStringConverter{}; };
+        gf["const TString&"] =              (cf_t)+[](long) { return new TStringConverter{}; };
         gf["const char*"] =                 (cf_t)+[](long) { return new CStringConverter{}; };
         gf["const char[]"] =                (cf_t)+[](long) { return new CStringConverter{}; };
         gf["char*"] =                       (cf_t)+[](long) { return new NonConstCStringConverter{}; };

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/DeclareConverters.h
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/DeclareConverters.h
@@ -9,6 +9,9 @@
 #include <string>
 #include "ROOT/RStringView.hxx"
 
+// ROOT
+#include "TString.h"
+
 
 namespace CPyCppyy {
 
@@ -264,6 +267,7 @@ protected:                                                                   \
     strtype fBuffer;                                                         \
 }
 
+CPPYY_DECLARE_STRING_CONVERTER(TString, TString);
 CPPYY_DECLARE_STRING_CONVERTER(STLString, std::string);
 CPPYY_DECLARE_STRING_CONVERTER(STLStringViewBase, std::string_view);
 class STLStringViewConverter : public STLStringViewBaseConverter {

--- a/bindings/pyroot_experimental/cppyy/patches/tstring_converter.patch
+++ b/bindings/pyroot_experimental/cppyy/patches/tstring_converter.patch
@@ -1,0 +1,43 @@
+diff --git a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Converters.cxx b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Converters.cxx
+index a470a41..e1b4961 100644
+--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Converters.cxx
++++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Converters.cxx
+@@ -1026,6 +1026,7 @@ bool CPyCppyy::name##Converter::ToMemory(PyObject* value, void* address)     \
+     return InstancePtrConverter::ToMemory(value, address);                   \
+ }
+ 
++CPPYY_IMPL_STRING_AS_PRIMITIVE_CONVERTER(TString, TString, Data, Length)
+ CPPYY_IMPL_STRING_AS_PRIMITIVE_CONVERTER(STLString, std::string, c_str, size)
+ CPPYY_IMPL_STRING_AS_PRIMITIVE_CONVERTER(STLStringViewBase, std::string_view, data, size)
+ bool CPyCppyy::STLStringViewConverter::SetArg(
+@@ -2068,6 +2069,8 @@ public:
+         gf["const ULong64_t&"] =            gf["const unsigned long long&"];
+ 
+     // factories for special cases
++        gf["TString"] =                     (cf_t)+[](long) { return new TStringConverter{}; };
++        gf["const TString&"] =              (cf_t)+[](long) { return new TStringConverter{}; };
+         gf["const char*"] =                 (cf_t)+[](long) { return new CStringConverter{}; };
+         gf["const char[]"] =                (cf_t)+[](long) { return new CStringConverter{}; };
+         gf["char*"] =                       (cf_t)+[](long) { return new NonConstCStringConverter{}; };
+diff --git a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/DeclareConverters.h b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/DeclareConverters.h
+index 172d19a..880ae04 100644
+--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/DeclareConverters.h
++++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/DeclareConverters.h
+@@ -9,6 +9,9 @@
+ #include <string>
+ #include "ROOT/RStringView.hxx"
+ 
++// ROOT
++#include "TString.h"
++
+ 
+ namespace CPyCppyy {
+ 
+@@ -264,6 +267,7 @@ protected:                                                                   \
+     strtype fBuffer;                                                         \
+ }
+ 
++CPPYY_DECLARE_STRING_CONVERTER(TString, TString);
+ CPPYY_DECLARE_STRING_CONVERTER(STLString, std::string);
+ CPPYY_DECLARE_STRING_CONVERTER(STLStringViewBase, std::string_view);
+ class STLStringViewConverter : public STLStringViewBaseConverter {

--- a/bindings/pyroot_experimental/cppyy/patches/tstring_converter.patch
+++ b/bindings/pyroot_experimental/cppyy/patches/tstring_converter.patch
@@ -1,5 +1,5 @@
 diff --git a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Converters.cxx b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Converters.cxx
-index a470a41..e1b4961 100644
+index a470a41..56d486d 100644
 --- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Converters.cxx
 +++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Converters.cxx
 @@ -1026,6 +1026,7 @@ bool CPyCppyy::name##Converter::ToMemory(PyObject* value, void* address)     \
@@ -10,11 +10,12 @@ index a470a41..e1b4961 100644
  CPPYY_IMPL_STRING_AS_PRIMITIVE_CONVERTER(STLString, std::string, c_str, size)
  CPPYY_IMPL_STRING_AS_PRIMITIVE_CONVERTER(STLStringViewBase, std::string_view, data, size)
  bool CPyCppyy::STLStringViewConverter::SetArg(
-@@ -2068,6 +2069,8 @@ public:
+@@ -2068,6 +2069,9 @@ public:
          gf["const ULong64_t&"] =            gf["const unsigned long long&"];
  
      // factories for special cases
 +        gf["TString"] =                     (cf_t)+[](long) { return new TStringConverter{}; };
++        gf["TString&"] =                    (cf_t)+[](long) { return new TStringConverter{}; };
 +        gf["const TString&"] =              (cf_t)+[](long) { return new TStringConverter{}; };
          gf["const char*"] =                 (cf_t)+[](long) { return new CStringConverter{}; };
          gf["const char[]"] =                (cf_t)+[](long) { return new CStringConverter{}; };


### PR DESCRIPTION
Cppyy allows to add custom pythonisations for classes, but it does not yet provide an API for adding custom type converters.

Until that API exists, we need to patch Cppyy with a converter Python string -> `TString`, so that we do not have to create a `TString` in Python when calling a C++ method that expects it.