### PR TITLE
[PyROOT] Fix array interface for empty arrays

### DIFF
--- a/bindings/pyroot/src/Pythonize.cxx
+++ b/bindings/pyroot/src/Pythonize.cxx
@@ -2334,7 +2334,9 @@ namespace {
 
       // Pointer
       auto ptr = reinterpret_cast<unsigned long long>(cobj->data());
-      if (cobj->empty()) ptr = 1; // Numpy breaks for data pointer of 0 even though the array is empty.
+      // Numpy breaks for data pointer of 0 even though the array is empty.
+      // We set the pointer to 1 but the value itself is arbitrary and never accessed.
+      if (cobj->empty()) ptr = 1;
       auto pyptr = PyLong_FromUnsignedLongLong(ptr);
       auto pydata = PyTuple_Pack(2, pyptr, Py_False);
       PyDict_SetItemString(dict, "data", pydata);

--- a/bindings/pyroot/test/array_interface.py
+++ b/bindings/pyroot/test/array_interface.py
@@ -31,7 +31,7 @@ class ArrayInterface(unittest.TestCase):
         self.assertEqual(expected_shape, np_obj.shape)
 
     # Tests
-    def test_TVec(self):
+    def test_RVec(self):
         for dtype in self.dtypes:
             root_obj = ROOT.VecOps.RVec(dtype)(2)
             np_obj = np.asarray(root_obj)
@@ -44,6 +44,18 @@ class ArrayInterface(unittest.TestCase):
             np_obj = np.asarray(root_obj)
             self.check_memory_adoption(root_obj, np_obj)
             self.check_shape((2, ), np_obj)
+
+    def test_STLVector_empty(self):
+        root_obj = ROOT.std.vector("float")()
+        np_obj = np.asarray(root_obj)
+        self.assertEqual(np_obj.shape, (0,))
+        self.assertEqual(np_obj.__array_interface__["data"][0], 1)
+
+    def test_RVec_empty(self):
+        root_obj = ROOT.VecOps.RVec("float")()
+        np_obj = np.asarray(root_obj)
+        self.assertEqual(np_obj.shape, (0,))
+        self.assertEqual(np_obj.__array_interface__["data"][0], 1)
 
 
 if __name__ == '__main__':

--- a/bindings/pyroot/test/rdataframe_asnumpy.py
+++ b/bindings/pyroot/test/rdataframe_asnumpy.py
@@ -194,6 +194,17 @@ class RDataFrameAsNumpy(unittest.TestCase):
         self.assertTrue(all(x == ref))
         self.assertTrue(hasattr(x, "result_ptr"))
 
+    def test_empty_array(self):
+        df = ROOT.RDataFrame(1).Define("x", "std::vector<float>()")
+        npy = df.AsNumpy(["x"])
+        self.assertEqual(npy["x"].size, 1)
+        self.assertTrue(npy["x"][0].empty())
+
+    def test_empty_selection(self):
+        df = ROOT.RDataFrame(10).Define("x", "1.0").Filter("x<0")
+        npy = df.AsNumpy(["x"])
+        self.assertEqual(npy["x"].size, 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_rvec.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_rvec.py
@@ -33,7 +33,10 @@ def get_array_interface(self):
             dtype_size = GetSizeOfType(dtype)
             endianess = GetEndianess()
             size = self.size()
-            pointer = GetVectorDataPointer(self, cppname)
+            if self.empty(): # Numpy sees a null pointer as error even though the data is never accessed.
+                pointer = 1
+            else:
+                pointer = GetVectorDataPointer(self, cppname)
             return {
                 "shape": (size, ),
                 "typestr": "{}{}{}".format(endianess, dtype_numpy, dtype_size),

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_rvec.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_rvec.py
@@ -33,7 +33,9 @@ def get_array_interface(self):
             dtype_size = GetSizeOfType(dtype)
             endianess = GetEndianess()
             size = self.size()
-            if self.empty(): # Numpy sees a null pointer as error even though the data is never accessed.
+            # Numpy breaks for data pointer of 0 even though the array is empty.
+            # We set the pointer to 1 but the value itself is arbitrary and never accessed.
+            if self.empty():
                 pointer = 1
             else:
                 pointer = GetVectorDataPointer(self, cppname)

--- a/bindings/pyroot_experimental/PyROOT/src/PyzPythonHelpers.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyzPythonHelpers.cxx
@@ -69,14 +69,14 @@ PyObject *PyROOT::GetVectorDataPointer(PyObject * /*self*/, PyObject *args)
    std::string cppname = CPyCppyy_PyUnicode_AsString(pycppname);
 
    // Call interpreter to get pointer to data (using `data` method)
-   long pointer;
+   unsigned long long pointer;
    std::stringstream code;
    code << "*((long*)" << &pointer << ") = reinterpret_cast<long>(reinterpret_cast<" << cppname << "*>(" << cppobj
         << ")->data())";
    gInterpreter->Calc(code.str().c_str());
 
    // Return pointer as integer
-   PyObject *pypointer = PyInt_FromLong(pointer);
+   PyObject *pypointer = PyLong_FromUnsignedLongLong(pointer);
    return pypointer;
 }
 

--- a/bindings/pyroot_experimental/PyROOT/test/array_interface.py
+++ b/bindings/pyroot_experimental/PyROOT/test/array_interface.py
@@ -4,6 +4,11 @@ import numpy as np
 
 
 class ArrayInterface(unittest.TestCase):
+    """
+    Test memory adoption of std::vector and ROOT::RVec with the numpy
+    array interface.
+    """
+
     # Helpers
     dtypes = [
         "int", "unsigned int", "long", "unsigned long", "float", "double"
@@ -32,6 +37,9 @@ class ArrayInterface(unittest.TestCase):
 
     # Tests
     def test_RVec(self):
+        """
+        Test correct adoption of different datatypes for std::vector
+        """
         for dtype in self.dtypes:
             root_obj = ROOT.ROOT.VecOps.RVec(dtype)(2)
             np_obj = np.asarray(root_obj)
@@ -39,11 +47,32 @@ class ArrayInterface(unittest.TestCase):
             self.check_shape((2, ), np_obj)
 
     def test_STLVector(self):
+        """
+        Test correct adoption of different datatypes for ROOT::RVec
+        """
         for dtype in self.dtypes:
             root_obj = ROOT.std.vector(dtype)(2)
             np_obj = np.asarray(root_obj)
             self.check_memory_adoption(root_obj, np_obj)
             self.check_shape((2, ), np_obj)
+
+    def test_STLVector_empty(self):
+        """
+        Test adoption of empty std::vector
+        """
+        root_obj = ROOT.std.vector("float")()
+        np_obj = np.asarray(root_obj)
+        self.assertEqual(np_obj.shape, (0,))
+        self.assertEqual(np_obj.__array_interface__["data"][0], 1)
+
+    def test_RVec_empty(self):
+        """
+        Test adoption of empty ROOT::RVec
+        """
+        root_obj = ROOT.ROOT.VecOps.RVec("float")()
+        np_obj = np.asarray(root_obj)
+        self.assertEqual(np_obj.shape, (0,))
+        self.assertEqual(np_obj.__array_interface__["data"][0], 1)
 
 
 if __name__ == '__main__':

--- a/bindings/pyroot_experimental/PyROOT/test/rdataframe_asnumpy.py
+++ b/bindings/pyroot_experimental/PyROOT/test/rdataframe_asnumpy.py
@@ -239,6 +239,23 @@ class RDataFrameAsNumpy(unittest.TestCase):
         self.assertTrue(all(x == ref))
         self.assertTrue(hasattr(x, "result_ptr"))
 
+    def test_empty_array(self):
+        """
+        Testing readout of empty std::vectors
+        """
+        df = ROOT.ROOT.RDataFrame(1).Define("x", "std::vector<float>()")
+        npy = df.AsNumpy(["x"])
+        self.assertEqual(npy["x"].size, 1)
+        self.assertTrue(npy["x"][0].empty())
+
+    def test_empty_selection(self):
+        """
+        Testing readout of empty selection
+        """
+        df = ROOT.ROOT.RDataFrame(10).Define("x", "1.0").Filter("x<0")
+        npy = df.AsNumpy(["x"])
+        self.assertEqual(npy["x"].size, 0)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Thanks to @cwiel for pointing out the issue. I've refactored the code and reduced code duplication massively.

The bug is fixed by writing a pointer unequal zero in the array interface since numpy does not take this as exception. Actually, it does not matter at all what is written in the `"data"` field of the array interface since it is never accessed.

Edit: Added a backport for experimental pyroot.