### PR TITLE
[Exp PyROOT] Add pythonisations for getter methods of TGraph family

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
@@ -18,6 +18,7 @@ set(py_sources
   ROOT/pythonization/_tdirectory.py
   ROOT/pythonization/_tdirectoryfile.py
   ROOT/pythonization/_tfile.py
+  ROOT/pythonization/_tgraph.py
   ROOT/pythonization/_th1.py
   ROOT/pythonization/_titer.py
   ROOT/pythonization/_tobject.py

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tgraph.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tgraph.py
@@ -1,0 +1,43 @@
+# Author: Enric Tejedor CERN  03/2019
+
+################################################################################
+# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from ROOT import pythonization
+import cppyy
+
+def set_size(self, buf):
+    # Parameters:
+    # - self: graph object
+    # - buf: buffer of doubles
+    # Returns:
+    # - buffer whose size has been set
+    buf.reshape((self.GetN(),))
+    return buf
+
+# Create a composite pythonizor.
+#
+# A composite is a type of pythonizor, i.e. it is a callable that expects two
+# parameters: a class proxy and a string with the name of that class.
+# A composite is created with the following parameters:
+# - A string to match the class/es to be pythonized
+# - A string to match the method/s to be pythonized in the class/es
+# - A callable that will post-process the return value of the matched method/s
+#
+# Here we create a composite that will match TGraph, TGraph2D and their error
+# subclasses, and will pythonize their getter methods of the X,Y,Z coordinate
+# and error arrays, which in C++ return a pointer to a double.
+# The pythonization consists in setting the size of the array that the getter
+# method returns, so that it is known in Python and the array is fully usable
+# (its length can be obtained, it is iterable).
+comp = cppyy.py.compose_method('^TGraph(2D)?$|^TGraph.*Errors$', # class to match
+                               'GetE?[XYZ]$',                    # method to match
+                               set_size)                         # post-process function
+
+# Invoke the decorator with the composite as argument to add it to the list of pythonizors
+pythonization()(comp)

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -27,6 +27,9 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_branch ttree_branch.py
 # TH1 and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_th1_operators th1_operators.py)
 
+# TGraph, TGraph2D and error subclasses pythonizations
+ROOT_ADD_PYUNITTEST(pyroot_pyz_tgraph_getters tgraph_getters.py)
+
 # TCollection and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tcollection_len tcollection_len.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tcollection_listmethods tcollection_listmethods.py)

--- a/bindings/pyroot_experimental/PyROOT/test/tgraph_getters.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tgraph_getters.py
@@ -1,0 +1,76 @@
+import unittest
+import array
+
+import ROOT
+
+
+class TGraphGetters(unittest.TestCase):
+    """
+    Test for the pythonization of TGraph, TGraph2D and their error
+    subclasses, in particular of their X,Y,Z coordinates and errors
+    getters, which sets the size of the returned buffers.
+    """
+
+    # Tests
+    def test_graph(self):
+        N = 5
+        xval, yval = 1, 2
+
+        ax = array.array('d', map(lambda x: x*xval, range(N)))
+        ay = array.array('d', map(lambda x: x*yval, range(N)))
+
+        g = ROOT.TGraph(N, ax, ay)
+
+        # x and y are buffers of doubles
+        x = g.GetX()
+        y = g.GetY()
+
+        # We can get the size of the buffers
+        self.assertEqual(len(x), N)
+        self.assertEqual(len(y), N)
+
+        # The buffers are iterable
+        self.assertEqual(list(x), list(ax))
+        self.assertEqual(list(y), list(ay))
+
+    def test_graph2derrors(self):
+        N = 5
+        xval, yval, zval = 1, 2, 3
+        xerrval, yerrval, zerrval = 0.1, 0.2, 0.3
+
+        ax = array.array('d', map(lambda x: x*xval, range(N)))
+        ay = array.array('d', map(lambda x: x*yval, range(N)))
+        az = array.array('d', map(lambda x: x*zval, range(N)))
+        aex = array.array('d', map(lambda x: x*xerrval, range(N)))
+        aey = array.array('d', map(lambda x: x*yerrval, range(N)))
+        aez = array.array('d', map(lambda x: x*zerrval, range(N)))
+
+        g = ROOT.TGraph2DErrors(N, ax, ay, az, aex, aey, aez)
+
+        # x, y, z, ex, ey and ez are buffers of doubles
+        x = g.GetX()
+        y = g.GetY()
+        z = g.GetZ()
+        ex = g.GetEX()
+        ey = g.GetEY()
+        ez = g.GetEZ()
+
+        # We can get the size of the buffers
+        self.assertEqual(len(x), N)
+        self.assertEqual(len(y), N)
+        self.assertEqual(len(z), N)
+        self.assertEqual(len(ex), N)
+        self.assertEqual(len(ey), N)
+        self.assertEqual(len(ez), N)
+
+        # The buffers are iterable
+        self.assertEqual(list(x), list(ax))
+        self.assertEqual(list(y), list(ay))
+        self.assertEqual(list(z), list(az))
+        self.assertEqual(list(ex), list(aex))
+        self.assertEqual(list(ey), list(aey))
+        self.assertEqual(list(ez), list(aez))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This feature is implemented via a composite pythonizor that matches `TGraph`, `TGraph2D` and their error subclasses, and pythonises their getter methods of the X,Y,Z coordinate and error arrays, which in C++ return a pointer to double.

The pythonisation consists in setting the size of the array buffer that the getter method returns, so that it is known in Python and the buffer is fully usable (its length can be obtained, it is iterable).
