### PR TITLE
[DF] Avoid forward declarations of Define'd types

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -1992,21 +1992,17 @@ private:
 
       // Declare return type to the interpreter, for future use by jitted actions
       auto retTypeName = RDFInternal::TypeID2TypeName(typeid(RetType));
-      std::string retTypeNameFwdDecl; // different from "" only if the type does not exist
       if (retTypeName.empty()) {
-         // If we are here, it means that the type is not known to the interpreter.
-         // We extract its name, forward declare it and add a meaningful comment.
-         // This string will be jitted flawlessly. If the user later on uses the product of this define
-         // and therefore an incomplete type, the interpreter will prompt an error and also display
-         // the comment we nicely built which reminds the user about the absence of information about
-         // this type in the interpreter.
-         retTypeName = RDFInternal::DemangleTypeIdName(typeid(RetType));
-         retTypeNameFwdDecl =
-            "class " + retTypeName + ";/* Did you forget to declare type " + retTypeName + " in the interpreter?*/";
+         // The type is not known to the interpreter.
+         // Forward-declare it as void + helpful comment, so that if this Define'd quantity is
+         // ever used by jitted code users will have some way to know what went wrong
+         const auto demangledType = RDFInternal::DemangleTypeIdName(typeid(RetType));
+         retTypeName = "void /* The type of column \"" + std::string(name) + "\" (" + demangledType +
+                       ") is not known to the interpreter. */";
       }
-      const auto retTypeDeclaration = "namespace __tdf" + std::to_string(fLoopManager->GetID()) + " { " +
-                                      retTypeNameFwdDecl + " using " + std::string(name) +
-                                      std::to_string(newColumn->GetID()) + "_type = " + retTypeName + "; }";
+      const auto retTypeDeclaration = "namespace __tdf" + std::to_string(fLoopManager->GetID()) +
+                                      " { " + +" using " + std::string(name) + std::to_string(newColumn->GetID()) +
+                                      "_type = " + retTypeName + "; }";
       RDFInternal::InterpreterDeclare(retTypeDeclaration);
 
       fLoopManager->RegisterCustomColumn(newColumn.get());

--- a/tree/dataframe/test/dataframe_simple.cxx
+++ b/tree/dataframe/test/dataframe_simple.cxx
@@ -11,6 +11,7 @@
 #include <TTree.h>
 
 #include <algorithm> // std::sort
+#include <array>
 #include <chrono>
 #include <thread>
 #include <set>
@@ -181,6 +182,7 @@ TEST_P(RDFSimpleTests, Define_jitted_type_unknown_to_interpreter)
 {
    RDataFrame tdf(10);
    auto d = tdf.Define("foo", [](){return RFoo();});
+   auto d2 = tdf.Define("foo2", [](){return std::array<RFoo, 2>();});
 
    // We check that the if nothing is done with RFoo in jitted strings
    // everything works fine


### PR DESCRIPTION
Either the interpreter knows them, or we alias them to `void`.
Just as before, the end result is that if users return a type
that is unknown to the interpreter from a Define, and then try
to read that Define'd column from jitted RDF nodes, the interpreter
(and consequently RDF) errors out.

This is missing a test.