### PR TITLE
[Exp PyROOT] Install public headers of Cppyy

### DIFF
--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/CMakeLists.txt
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/CMakeLists.txt
@@ -53,3 +53,6 @@ target_link_libraries(cppyy cppyy_backend ${PYTHON_LIBRARIES})
 
 set_property(GLOBAL APPEND PROPERTY ROOT_EXPORTED_TARGETS cppyy)
 install(TARGETS cppyy EXPORT ${CMAKE_PROJECT_NAME}Exports DESTINATION ${runtimedir})
+
+file(COPY ${headers} DESTINATION ${CMAKE_BINARY_DIR}/include)
+install(FILES ${headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -454,7 +454,6 @@ if(ROOT_python_FOUND)
                  tutorial-pyroot-tornado-py
                  tutorial-pyroot-tree-py
                  tutorial-roofit-rf106_plotdecoration-py
-                 tutorial-roofit-rf707_kernelestimation-py
                  tutorial-vecops-vo004_SortAndSelect-py
                  tutorial-vecops-vo005_Combinations-py)
 


### PR DESCRIPTION
Some headers of Cppyy (e.g. `TPython.h`) need to be public, so make sure they are placed both in the `${build_dir}/include` and `${install_dir}/include`.

This PR also re-enables a roofit tutorial that got fixed.