### PR TITLE
Fixed bug which made Canvas remain in Batch Mode after it was appended to an open file

### DIFF
--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -5129,6 +5129,8 @@ void TPad::Print(const char *filenam, Option_t *option)
       } else {
          gVirtualPS->SetTitle("PDF");
       }
+      if (noScreen) GetCanvas()->SetBatch(kFALSE);
+
       if (mustClose) {
          if (cclose) Info("Print", "Current canvas added to %s file %s and file closed", opt.Data(), psname.Data());
          else        Info("Print", "%s file %s has been closed", opt.Data(), psname.Data());


### PR DESCRIPTION
Hi,

I noticed a strange behaviour:
When a TCanvas is being appended to an already open file via TPad::Print, it can happen that afterwards the Canvas is in Batch Mode which it was not before.

Looking to the implementation of TPad::Print gives the reason:
When a Canvas is drawn which is not in Batch Mode, but the Canvas ID is -1, it is set to Batch Mode for Drawing. This Batch Mode Flag is afterwards being reset in the implementation of printing to a new file, but it is missing in the implementation of printing to an already open file. I'm very sure that this is a bug and the Canvas is not intended to stay in Batch Mode, so I added a corresponding line which resets the Batch Mode.

If this behaviour should be intended, please correct me, but that would really surprise me.
All the best,
Simon Spies