### PR TITLE
Add missing #include TError.h

### DIFF
--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -26,6 +26,7 @@
 #include "TList.h"
 #include "TH1.h"
 #include "TEnv.h"
+#include "TError.h"
 #include "TGraph.h"
 #include "TBufferJSON.h"
 #include "Riostream.h"


### PR DESCRIPTION
It fixes broken builds on Ubuntu 16:
`[ 92%] Building CXX object roofit/roofitcore/CMakeFiles/RooFitCore.dir/src/RooProdPdf.cxx.o
/mnt/build/workspace/lcg_ext_rootcov/BUILDTYPE/Release/COMPILER/native/LABEL/ubuntu16/build/projects/ROOT-HEAD/src/ROOT/HEAD/gui/webgui6/src/TWebCanvas.cxx: In member function ‘void TWebCanvas::ShowCmd(const char*, Bool_t)’:
/mnt/build/workspace/lcg_ext_rootcov/BUILDTYPE/Release/COMPILER/native/LABEL/ubuntu16/build/projects/ROOT-HEAD/src/ROOT/HEAD/gui/webgui6/src/TWebCanvas.cxx:516:77: error: ‘Warning’ was not declared in this scope
          Warning("ShowCmd", "Send operation not empty when try show %s", arg)
                                                                             ^
`