### PR TITLE
Correctly create dictionary for v7 classes in libCore

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -42,6 +42,10 @@ if(cocoa)
   set(dict_opts -DSYSTEM_TYPE_macosx)
 endif()
 
+if(root7)
+  set(dict_v7opts -DGENERATE_v7_DICT)
+endif()
+
 set(CORE_OS_DICT_CXX_FLAGS ${dict_opts} PARENT_SCOPE)
 
 #---G__Core--------------------------------------------------------------------
@@ -88,6 +92,7 @@ ROOT_GENERATE_DICTIONARY(G__Core
   OPTIONS
     -writeEmptyRootPCM
     ${dict_opts}
+    ${dict_v7opts}
   LINKDEF
     base/inc/LinkDef.h
 )

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -44,7 +44,6 @@ endif()
 
 if(CMAKE_CXX_STANDARD GREATER 11)
   set(dict_v7dirs base/v7/inc)
-  set(dict_v7opts -DGENERATE_v7_DICT)
 endif()
 
 set(CORE_OS_DICT_CXX_FLAGS ${dict_opts} PARENT_SCOPE)
@@ -94,7 +93,6 @@ ROOT_GENERATE_DICTIONARY(G__Core
   OPTIONS
     -writeEmptyRootPCM
     ${dict_opts}
-    ${dict_v7opts}
   LINKDEF
     base/inc/LinkDef.h
 )

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -42,7 +42,8 @@ if(cocoa)
   set(dict_opts -DSYSTEM_TYPE_macosx)
 endif()
 
-if(root7)
+if(CMAKE_CXX_STANDARD GREATER 11)
+  set(dict_v7dirs base/v7/inc)
   set(dict_v7opts -DGENERATE_v7_DICT)
 endif()
 
@@ -64,6 +65,7 @@ set(CORE_OS_DICT_CXX_FLAGS ${dict_opts} PARENT_SCOPE)
 include_directories(
   ${ZLIB_INCLUDE_DIR}
   base/inc
+  ${dict_v7dirs}
   clib/inc
   cont/inc
   foundation/inc
@@ -76,7 +78,7 @@ include_directories(
 )
 
 ROOT_GENERATE_DICTIONARY(G__Core
-  ${BASE_HEADERS}
+  ${Core_dict_headers}
   ${Clib_dict_headers}
   ${Cont_dict_headers}
   ${Foundation_dict_headers}

--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -113,8 +113,6 @@ set(BASE_HEADERS
   TVirtualTableInterface.h
   TVirtualViewer3D.h
   TVirtualX.h
-
-  PARENT_SCOPE
 )
 
 set(BASE_SOURCES
@@ -227,6 +225,10 @@ if(root7)
       v7/src/RDrawable.cxx
   )
 endif()
+
+
+# only here complete list of headers can be propogated to parent cmake file
+set(Core_dict_headers ${BASE_HEADERS} PARENT_SCOPE)
 
 ROOT_OBJECT_LIBRARY(Base ${BASE_SOURCES})
 target_include_directories(Base PRIVATE ${PCRE_INCLUDE_DIR})

--- a/core/base/inc/LinkDef3.h
+++ b/core/base/inc/LinkDef3.h
@@ -270,8 +270,7 @@
 #pragma link C++ class TParameter<Long_t>+;
 #pragma link C++ class TParameter<Long64_t>+;
 
-#ifdef GENERATE_v7_DICT
-#pragma link C++ namespace ROOT::Experimental;
+#ifdef ROOT7_RDrawable
 #pragma link C++ class ROOT::Experimental::RDrawable+;
 #endif
 

--- a/core/base/inc/LinkDef3.h
+++ b/core/base/inc/LinkDef3.h
@@ -271,6 +271,7 @@
 #pragma link C++ class TParameter<Long64_t>+;
 
 #ifdef GENERATE_v7_DICT
+#pragma link C++ namespace ROOT::Experimental;
 #pragma link C++ class ROOT::Experimental::RDrawable+;
 #endif
 

--- a/core/base/inc/LinkDef3.h
+++ b/core/base/inc/LinkDef3.h
@@ -270,7 +270,7 @@
 #pragma link C++ class TParameter<Long_t>+;
 #pragma link C++ class TParameter<Long64_t>+;
 
-#ifdef ROOT7_RDrawable
+#ifdef GENERATE_v7_DICT
 #pragma link C++ class ROOT::Experimental::RDrawable+;
 #endif
 


### PR DESCRIPTION
Main problem that cmake `list(APPEND BASE_HEADERS ...)` command was not exported to parent scope - as original `BASE_HEADERS` variable. Once done, several other dictionary options should be adjusted.
