### PR TITLE
[Exp PyROOT] Prevent cppyy from checking the PCH

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/__init__.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/__init__.py
@@ -16,9 +16,8 @@ if not any(var in environ for var in ('LD_LIBRARY_PATH','DYLD_LIBRARY_PATH')):
     _lcb_path = path.join(_lib_dir, 'libcppyy_backend')
     environ['CPPYY_BACKEND_LIBRARY'] = _lcb_path
 
-# Inform cppyy that we have already generated the PCH
-_etc_dir = path.join(path.dirname(path.dirname(path.dirname(__file__))), 'etc')
-environ['CLING_STANDARD_PCH'] = path.join(_etc_dir, 'allDict.cxx.pch')
+# Prevent cppyy's check for the PCH
+environ['CLING_STANDARD_PCH'] = 'none'
 
 import cppyy
 import ROOT.pythonization as pyz


### PR DESCRIPTION
Before importing cppyy from PyROOT, instead of specifying the location of the PCH, we can just use the magic word 'none' to tell cppyy not to check the PCH. In both cases, the objective is to avoid a warning from cppyy when importing it.

This needs to be merged after the next update of `cppyy-backend`, when a new release is out.

The related discussion with Wim is here:
https://bitbucket.org/wlav/cppyy/issues/62/new-check-in-loaderpy-uses-wrong-include