### PR TITLE
webui: improve CEF and QT5 handling

### DIFF
--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -213,7 +213,7 @@ ROOT::Experimental::TCanvasPainter::~TCanvasPainter()
 void ROOT::Experimental::TCanvasPainter::CancelUpdates()
 {
    fSnapshotDelivered = 0;
-   for (auto &&item: fUpdatesLst)
+   for (auto &item: fUpdatesLst)
       item.fCallback(false);
    fUpdatesLst.clear();
 }
@@ -244,7 +244,7 @@ void ROOT::Experimental::TCanvasPainter::CheckDataToSend()
 {
    uint64_t min_delivered = 0;
 
-   for (auto &&conn : fWebConn) {
+   for (auto &conn : fWebConn) {
 
       if (conn.fDelivered && (!min_delivered || (min_delivered < conn.fDelivered)))
          min_delivered = conn.fDelivered;

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -447,7 +447,7 @@ void ROOT::Experimental::TCanvasPainter::ProcessData(unsigned connid, const std:
    };
 
    auto conn =
-      std::find_if(fWebConn.begin(), fWebConn.begin(), [connid](WebConn &item) { return item.fConnId == connid; });
+      std::find_if(fWebConn.begin(), fWebConn.end(), [connid](WebConn &item) { return item.fConnId == connid; });
 
    if (conn == fWebConn.end())
       return; // no connection found

--- a/gui/cefdisplay/src/simple_app.cxx
+++ b/gui/cefdisplay/src/simple_app.cxx
@@ -58,6 +58,11 @@ protected:
 
    CefRefPtr<CefCallback> fCallBack{nullptr};
 
+   void CheckWSPageContent(THttpWSHandler *) override
+   {
+
+   }
+
 public:
    explicit TCefHttpCallArg() = default;
 

--- a/gui/cefdisplay/src/simple_app.cxx
+++ b/gui/cefdisplay/src/simple_app.cxx
@@ -60,7 +60,10 @@ protected:
 
    void CheckWSPageContent(THttpWSHandler *) override
    {
+      std::string search = "JSROOT.ConnectWebWindow({";
+      std::string replace = search + "platform:\"cef3\",socket_kind:\"longpoll\",";
 
+      ReplaceAllinContent(search, replace, true);
    }
 
 public:
@@ -357,12 +360,6 @@ void SimpleApp::StartWindow(const std::string &addr, bool batch, CefRect &rect)
    if (gHandlingServer) {
       url = "http://rootserver.local";
       url.append(addr);
-      if (url.find("?") != std::string::npos)
-         url.append("&");
-      else
-         url.append("?");
-
-      url.append("platform=cef3&ws=longpoll");
    } else {
       url = addr;
    }

--- a/gui/qt5webdisplay/rootqt5.cpp
+++ b/gui/qt5webdisplay/rootqt5.cpp
@@ -110,7 +110,7 @@ protected:
             }
          }
 
-         QString fullurl = QString(args.GetUrl().c_str());
+         QString fullurl = QString(args.GetFullUrl().c_str());
 
          // if no server provided - normal HTTP will be allowed to use
          if (args.GetHttpServer()) {
@@ -123,11 +123,6 @@ protected:
          }
 
          QWidget *qparent = (QWidget *) args.GetDriverData();
-
-         if (!args.GetUrlOpt().empty()) {
-            fullurl.append(QString("&"));
-            fullurl.append(QString(args.GetUrlOpt().c_str()));
-         }
 
          auto handle = std::make_unique<RQt5WebDisplayHandle>(fullurl.toLatin1().constData());
 

--- a/gui/qt5webdisplay/rooturlschemehandler.cpp
+++ b/gui/qt5webdisplay/rooturlschemehandler.cpp
@@ -62,6 +62,10 @@ class TWebGuiCallArg : public THttpCallArg {
 protected:
    UrlRequestJobHolder fRequest;
 
+   void CheckWSPageContent(THttpWSHandler *) override
+   {
+   }
+
 public:
    explicit TWebGuiCallArg(QWebEngineUrlRequestJob *req = nullptr) : THttpCallArg(), fRequest(req) {}
 

--- a/gui/qt5webdisplay/rooturlschemehandler.cpp
+++ b/gui/qt5webdisplay/rooturlschemehandler.cpp
@@ -64,6 +64,10 @@ protected:
 
    void CheckWSPageContent(THttpWSHandler *) override
    {
+      std::string search = "JSROOT.ConnectWebWindow({";
+      std::string replace = search + "platform:\"qt5\",socket_kind:\"rawlongpoll\",";
+
+      ReplaceAllinContent(search, replace, true);
    }
 
 public:
@@ -142,13 +146,6 @@ QString RootUrlSchemeHandler::MakeFullUrl(THttpServer *serv, const QString &url)
 
    QString res = "rootscheme://root.server1";
    res.append(url);
-   if (url.indexOf("?") < 0)
-      res.append("?");
-   else
-      res.append("&");
-
-   // TODO: with should be solved different way - maybe via replacements in main HTML page
-   res.append("platform=qt5&ws=rawlongpoll");
    return res;
 }
 

--- a/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
@@ -84,6 +84,9 @@ public:
    /// returns window url options
    std::string GetUrlOpt() const { return fUrlOpt; }
 
+   /// append extra url options, add "&" as separator if required
+   void AppendUrlOpt(const std::string &opt);
+
    /// returns window url with append options
    std::string GetFullUrl() const;
 

--- a/gui/webdisplay/inc/ROOT/RWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindowsManager.hxx
@@ -62,7 +62,7 @@ private:
 
    static bool IsMainThrd();
 
-   std::string GetUrl(const RWebWindow &win, bool batch_mode, bool remote = false);
+   std::string GetUrl(const RWebWindow &win, bool remote = false);
 
    bool CreateServer(bool with_http = false);
 

--- a/gui/webdisplay/src/RWebDisplayArgs.cxx
+++ b/gui/webdisplay/src/RWebDisplayArgs.cxx
@@ -110,6 +110,21 @@ std::string ROOT::Experimental::RWebDisplayArgs::GetBrowserName() const
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
+/// Append string to url options
+/// Add "&" as separator if any options already exsists
+
+void ROOT::Experimental::RWebDisplayArgs::AppendUrlOpt(const std::string &opt)
+{
+   if (opt.empty()) return;
+
+   if (!fUrlOpt.empty())
+      fUrlOpt.append("&");
+
+   fUrlOpt.append(opt);
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////
 /// Returns full url, which is combined from URL and extra URL options
 /// Takes into account "#" symbol in url - options are inserted before that symbol
 

--- a/gui/webdisplay/src/RWebDisplayArgs.cxx
+++ b/gui/webdisplay/src/RWebDisplayArgs.cxx
@@ -33,6 +33,7 @@ ROOT::Experimental::RWebDisplayArgs::RWebDisplayArgs()
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 /// Constructor - browser kind specified as std::string
+/// See SetBrowserKind() method for description of allowed parameters
 
 ROOT::Experimental::RWebDisplayArgs::RWebDisplayArgs(const std::string &browser)
 {
@@ -41,6 +42,7 @@ ROOT::Experimental::RWebDisplayArgs::RWebDisplayArgs(const std::string &browser)
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 /// Constructor - browser kind specified as const char *
+/// See SetBrowserKind() method for description of allowed parameters
 
 ROOT::Experimental::RWebDisplayArgs::RWebDisplayArgs(const char *browser)
 {
@@ -48,7 +50,16 @@ ROOT::Experimental::RWebDisplayArgs::RWebDisplayArgs(const char *browser)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-/// Set browser kind using string argument
+/// Set browser kind as string argument
+/// Recognized values:
+///  chrome  - use Google Chrome web browser, supports headless mode from v60, default
+///  firefox - use Mozilla Firefox browser, supports headless mode from v57
+///   native - (or empty string) either chrome or firefox, only these browsers support batch (headless) mode
+///  browser - default system web-browser, no batch mode
+///      cef - Chromium Embeded Framework, local display, local communication
+///      qt5 - Qt5 WebEngine, local display, local communication
+///    local - either cef or qt5
+///   <prog> - any program name which will be started instead of default browser, like /usr/bin/opera
 
 void ROOT::Experimental::RWebDisplayArgs::SetBrowserKind(const std::string &_kind)
 {
@@ -71,9 +82,9 @@ void ROOT::Experimental::RWebDisplayArgs::SetBrowserKind(const std::string &_kin
       SetBrowserKind(kFirefox);
    else if ((kind == "chrome") || (kind == "chromium"))
       SetBrowserKind(kChrome);
-   else if (kind == "cef")
+   else if ((kind == "cef") || (kind == "cef3"))
       SetBrowserKind(kCEF);
-   else if (kind == "qt5")
+   else if ((kind == "qt") || (kind == "qt5"))
       SetBrowserKind(kQt5);
    else
       SetCustomExec(kind);
@@ -100,17 +111,21 @@ std::string ROOT::Experimental::RWebDisplayArgs::GetBrowserName() const
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 /// Returns full url, which is combined from URL and extra URL options
+/// Takes into account "#" symbol in url - options are inserted before that symbol
 
 std::string ROOT::Experimental::RWebDisplayArgs::GetFullUrl() const
 {
    std::string url = GetUrl(), urlopt = GetUrlOpt();
    if (url.empty() || urlopt.empty()) return url;
 
+   auto rpos = url.find("#");
+   if (rpos == std::string::npos) rpos = url.length();
+
    if (url.find("?") != std::string::npos)
-      url.append("&");
+      url.insert(rpos, "&");
    else
-      url.append("?");
-   url.append(urlopt);
+      url.insert(rpos, "?");
+   url.insert(rpos+1, urlopt);
 
    return url;
 }

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -45,11 +45,20 @@
 #endif
 
 
+//////////////////////////////////////////////////////////////////////////////////////////////////
+/// Static holder of registered creators of web displays
+
 std::map<std::string, std::unique_ptr<ROOT::Experimental::RWebDisplayHandle::Creator>> &ROOT::Experimental::RWebDisplayHandle::GetMap()
 {
    static std::map<std::string, std::unique_ptr<ROOT::Experimental::RWebDisplayHandle::Creator>> sMap;
    return sMap;
 }
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+/// Search for specific browser creator
+/// If not found, try to add one
+/// \param name - creator name like ChromeCreator
+/// \param libname - shared library name where creator could be provided
 
 std::unique_ptr<ROOT::Experimental::RWebDisplayHandle::Creator> &ROOT::Experimental::RWebDisplayHandle::FindCreator(const std::string &name, const std::string &libname)
 {
@@ -79,6 +88,10 @@ std::unique_ptr<ROOT::Experimental::RWebDisplayHandle::Creator> &ROOT::Experimen
 
 namespace ROOT {
 namespace Experimental {
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+/// Specialized handle to hold information about running browser process
+/// Used to correctly cleanup all processes and temporary directories
 
 class RWebBrowserHandle : public RWebDisplayHandle {
 
@@ -119,6 +132,7 @@ public:
 } // namespace ROOT
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
+/// Class to handle starting of web-browsers like Chrome or Firefox
 
 ROOT::Experimental::RWebDisplayHandle::BrowserCreator::BrowserCreator(bool custom, const std::string &exec)
 {
@@ -134,6 +148,9 @@ ROOT::Experimental::RWebDisplayHandle::BrowserCreator::BrowserCreator(bool custo
       fExec = "xdg-open \'$url\' &";
    }
 }
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+/// Check if browser executable exists and can be used
 
 void ROOT::Experimental::RWebDisplayHandle::BrowserCreator::TestProg(const std::string &nexttry, bool check_std_paths)
 {
@@ -165,6 +182,9 @@ void ROOT::Experimental::RWebDisplayHandle::BrowserCreator::TestProg(const std::
       TestProg(ProgramFilesx86 + nexttry, false);
 #endif
 }
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+/// Display given URL in web browser
 
 std::unique_ptr<ROOT::Experimental::RWebDisplayHandle>
 ROOT::Experimental::RWebDisplayHandle::BrowserCreator::Display(const RWebDisplayArgs &args)
@@ -307,6 +327,7 @@ ROOT::Experimental::RWebDisplayHandle::ChromeCreator::ChromeCreator() : BrowserC
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
+/// Constructor
 
 ROOT::Experimental::RWebDisplayHandle::FirefoxCreator::FirefoxCreator() : BrowserCreator(true)
 {
@@ -332,6 +353,9 @@ ROOT::Experimental::RWebDisplayHandle::FirefoxCreator::FirefoxCreator() : Browse
    fExec = gEnv->GetValue("WebGui.FirefoxInteractive", "$prog -width $width -height $height $profile \'$url\' &");
 #endif
 }
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+/// Create Firefox profile to run independent browser window
 
 std::string ROOT::Experimental::RWebDisplayHandle::FirefoxCreator::MakeProfile(TString &exec, bool batch_mode)
 {
@@ -378,9 +402,9 @@ std::string ROOT::Experimental::RWebDisplayHandle::FirefoxCreator::MakeProfile(T
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 /// Create web display
-/// \param where - defines kind of display
-/// \param func - creates local or remote URL
-
+/// \param args - defines where and how to display web window
+/// Returns RWebDisplayHandle, which holds information of running browser application
+/// Can be used fully independent from RWebWindow classes just to show any web page
 
 std::unique_ptr<ROOT::Experimental::RWebDisplayHandle> ROOT::Experimental::RWebDisplayHandle::Display(const RWebDisplayArgs &args)
 {

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -136,7 +136,7 @@ ROOT::Experimental::RWebWindow::CreateWSHandler(std::shared_ptr<RWebWindowsManag
 
 std::string ROOT::Experimental::RWebWindow::GetUrl(bool remote)
 {
-   return fMgr->GetUrl(*this, false, remote);
+   return fMgr->GetUrl(*this, remote);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -347,7 +347,10 @@ std::string ROOT::Experimental::RWebWindowsManager::GetUrl(const ROOT::Experimen
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-/// Show window in specified location
+/// Show web window in specified location.
+///
+/// One could provide string like "chrome" or "firefox".
+/// More details see in RWebDisplayArgs constructor description
 /// Parameter "where" specifies that kind of window display should be used. Possible values:
 ///
 ///  chrome  - use Google Chrome web browser, supports headless mode from v60, default

--- a/net/http/inc/THttpCallArg.h
+++ b/net/http/inc/THttpCallArg.h
@@ -61,6 +61,8 @@ protected:
 
    TString CountHeader(const TString &buf, Int_t number = -1111) const;
 
+   void ReplaceAllinContent(const std::string &from, const std::string &to, bool once = false);
+
 private:
    std::shared_ptr<THttpWSEngine> fWSEngine; ///<!  web-socket engine, which supplied to run created web socket
 
@@ -69,8 +71,6 @@ private:
 
    void AssignWSId();
    std::shared_ptr<THttpWSEngine> TakeWSEngine();
-
-   void ReplaceAllinContent(const std::string &from, const std::string &to);
 
    /** Method used to modify content of web page used by web socket handler */
    virtual void CheckWSPageContent(THttpWSHandler *) {}

--- a/net/http/inc/THttpCallArg.h
+++ b/net/http/inc/THttpCallArg.h
@@ -25,6 +25,7 @@ class THttpWSEngine;
 class THttpWSHandler;
 
 class THttpCallArg : public TObject {
+
    friend class THttpServer;
    friend class THttpWSEngine;
    friend class THttpWSHandler;
@@ -63,13 +64,16 @@ protected:
 private:
    std::shared_ptr<THttpWSEngine> fWSEngine; ///<!  web-socket engine, which supplied to run created web socket
 
-   std::string  fContent;  ///!< content - text or binary
+   std::string  fContent;  ///<! content - text or binary
    std::string  fPostData; ///<! data received with post request - text - or binary
 
    void AssignWSId();
    std::shared_ptr<THttpWSEngine> TakeWSEngine();
 
    void ReplaceAllinContent(const std::string &from, const std::string &to);
+
+   /** Method used to modify content of web page used by web socket handler */
+   virtual void CheckWSPageContent(THttpWSHandler *) {}
 
 public:
    explicit THttpCallArg() = default;

--- a/net/http/src/THttpCallArg.cxx
+++ b/net/http/src/THttpCallArg.cxx
@@ -257,11 +257,12 @@ std::shared_ptr<THttpWSEngine> THttpCallArg::TakeWSEngine()
 /// Replace all occurrences of \param from by \param to in content
 /// Used only internally
 
-void THttpCallArg::ReplaceAllinContent(const std::string &from, const std::string &to)
+void THttpCallArg::ReplaceAllinContent(const std::string &from, const std::string &to, bool once)
 {
    std::size_t start_pos = 0;
    while((start_pos = fContent.find(from, start_pos)) != std::string::npos) {
       fContent.replace(start_pos, from.length(), to);
+      if (once) return;
       start_pos += to.length(); // Handles case where 'to' is a substring of 'from'
    }
 }

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -751,6 +751,8 @@ void THttpServer::ProcessRequest(THttpCallArg *arg)
                arg->fContent = ReadFileContent(resolve.Data());
                arg->AddNoCacheHeader();
             }
+
+            arg->CheckWSPageContent(handler);
          }
       }
 


### PR DESCRIPTION
1. Do not expose special parameters to URL string - now in default HTML file special attributes can be inserted together with `JSROOT.ConnectWebWindow` call
2. Correctly handle `#` in WebWindow URL. Such symbol used for routing inside webpage and will be often used with openui5
3. Unify handling of URL options with RWebDisplayArgs. For now only `key` and `batch_mode` parameters are exposed to web window URL
4. Update/extend doxygen docu
5. Fix error in v7 CanvasPainter - v616 already fixed
