### PR TITLE
More than one \author line confuses the doxygen filter

### DIFF
--- a/tutorials/eve7/geodemo.C
+++ b/tutorials/eve7/geodemo.C
@@ -4,8 +4,7 @@
 ///
 /// \macro_code
 ///
-/// \author Andrei Gheata
-/// \author Sergey Linev
+/// \author Andrei Gheata and Sergey Linev
 
 #include "TMath.h"
 #include "TControlBar.h"


### PR DESCRIPTION
warning: Conditional section does not have a corresponding \endcond command within this file.