### PR TITLE
Avoid crash during doxygen generation

### DIFF
--- a/gui/gui/src/TGTable.cxx
+++ b/gui/gui/src/TGTable.cxx
@@ -72,7 +72,7 @@ then creating the TGTable using this interface.
 <br><br>
 A simple macro to use a TGTable with a TGSimpleTableInterface:
 End_Html
-Begin_Macro(source, gui)
+~~~
 {
    Int_t i = 0, j = 0;
    UInt_t nrows = 6, ncolumns = 5;
@@ -111,13 +111,13 @@ Begin_Macro(source, gui)
 
    return mainframe;
 }
-End_Macro
+~~~
 Begin_Html
 
 It is also possible to visualise data from a tree. A simple macro
 showing the use of a TTreeTableInterface follows.
 End_Html
-Begin_Macro(source, gui)
+~~~
 {
    // Open a root file.
    TFile *file = new TFile("$ROOTSYS/tutorials/hsimple.root");
@@ -153,7 +153,7 @@ Begin_Macro(source, gui)
 
    return mainframe;
 }
-End_Macro
+~~~
 */
 
 // const TGGC *TGTable::fgDefaultSelectGC = 0;


### PR DESCRIPTION
This file has a comment section that contains old HTML markup not yet rewritten for doxygen.
This would normally just be ignored, and not cause problems.
However, this comment section contains code blocks enclosed in

    Begin_Macro(source, gui)
    End_Macro

The "gui" qualifier is no longer supported. The two usages in this file are the only remaining ones in the whole source tree.

These macros are inside a normal non-doxygen comment block, so these macros do not appear in the documentation.

However, the doxygen filter does not keep track of this and tries to create images for these macros.

The "gui" qualifier used to indicate that the macro must not be run in batch mode. But since the doxygen filter does not know about it, the filter tries to run the macro in batch mode anyway, and root crashes. This results in that all doxygen markup in this file is ignored. As can be seen on this page:

https://root.cern/doc/v616/classTGTable.html

where the generated documentation is missing information.
