### PR TITLE
[VecOps] Add physics helpers

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -1506,6 +1506,61 @@ RVec<T> DeltaPhi(T v1, const RVec<T>& v2, const T c = M_PI)
    return r;
 }
 
+/// Return the invariant mass of two particles given the collections of the quantities
+/// transverse momentum (pt), rapidity (eta), azimuth (phi) and mass.
+///
+/// The function computes the invariant mass of two particles with the four-vectors
+/// (pt1, eta2, phi1, mass1) and (pt2, eta2, phi2, mass2).
+template <typename T>
+RVec<T> InvariantMass(
+        const RVec<T>& pt1, const RVec<T>& eta1, const RVec<T>& phi1, const RVec<T>& mass1,
+        const RVec<T>& pt2, const RVec<T>& eta2, const RVec<T>& phi2, const RVec<T>& mass2)
+{
+   // Conversion from (pt, eta, phi, mass) to (x, y, z, e) coordinate system
+   const auto x1 = pt1 * cos(phi1);
+   const auto y1 = pt1 * sin(phi1);
+   const auto z1 = pt1 * sinh(eta1);
+   const auto e1 = sqrt(x1 * x1 + y1 * y1 + z1 * z1 + mass1 * mass1);
+
+   const auto x2 = pt2 * cos(phi2);
+   const auto y2 = pt2 * sin(phi2);
+   const auto z2 = pt2 * sinh(eta2);
+   const auto e2 = sqrt(x2 * x2 + y2 * y2 + z2 * z2 + mass2 * mass2);
+
+   // Addition of particle four-vectors
+   const auto e = e1 + e2;
+   const auto x = x1 + x2;
+   const auto y = y1 + y2;
+   const auto z = z1 + z2;
+
+   // Return invariant mass with (+, -, -, -) metric
+   return sqrt(e * e - x * x - y * y - z * z);
+}
+
+/// Return the invariant mass of multiple particles given the collections of the
+/// quantities transverse momentum (pt), rapidity (eta), azimuth (phi) and mass.
+///
+/// The function computes the invariant mass of multiple particles with the
+/// four-vectors (pt, eta, phi, mass).
+template <typename T>
+T InvariantMass(const RVec<T>& pt, const RVec<T>& eta, const RVec<T>& phi, const RVec<T>& mass)
+{
+   // Conversion from (mass, pt, eta, phi) to (e, x, y, z) coordinate system
+   const auto x = pt * cos(phi);
+   const auto y = pt * sin(phi);
+   const auto z = pt * sinh(eta);
+   const auto e = sqrt(x * x + y * y + z * z + mass * mass);
+
+   // Addition of particle four-vectors
+   const auto xs = Sum(x);
+   const auto ys = Sum(y);
+   const auto zs = Sum(z);
+   const auto es = Sum(e);
+
+   // Return invariant mass with (+, -, -, -) metric
+   return std::sqrt(es * es - xs * xs - ys * ys - zs * zs);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Print a RVec at the prompt:
 template <class T>

--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -1506,6 +1506,34 @@ RVec<T> DeltaPhi(T v1, const RVec<T>& v2, const T c = M_PI)
    return r;
 }
 
+/// Return the distance on the \f$\eta\f$-\f$\phi\f$ plane (\f$\Delta R\f$) from
+/// the collections eta1, eta2, phi1 and phi2.
+///
+/// The function computes \f$\Delta R = \sqrt{(\eta_1 - \eta_2)^2 + (\phi_1 - \phi_2)^2}\f$
+/// of the given collections eta1, eta2, phi1 and phi2. The angle \f$\phi\f$ can
+/// be set to radian or degrees using the optional argument c, see the documentation
+/// of the DeltaPhi helper.
+template <typename T>
+RVec<T> DeltaR(const RVec<T>& eta1, const RVec<T>& eta2, const RVec<T>& phi1, const RVec<T>& phi2, const T c = M_PI)
+{
+   const auto dphi = DeltaPhi(phi1, phi2, c);
+   return sqrt((eta1 - eta2) * (eta1 - eta2) + dphi * dphi);
+}
+
+/// Return the distance on the \f$\eta\f$-\f$\phi\f$ plane (\f$\Delta R\f$) from
+/// the scalars eta1, eta2, phi1 and phi2.
+///
+/// The function computes \f$\Delta R = \sqrt{(\eta_1 - \eta_2)^2 + (\phi_1 - \phi_2)^2}\f$
+/// of the given scalars eta1, eta2, phi1 and phi2. The angle \f$\phi\f$ can
+/// be set to radian or degrees using the optional argument c, see the documentation
+/// of the DeltaPhi helper.
+template <typename T>
+T DeltaR(T eta1, T eta2, T phi1, T phi2, const T c = M_PI)
+{
+   const auto dphi = DeltaPhi(phi1, phi2, c);
+   return std::sqrt((eta1 - eta2) * (eta1 - eta2) + dphi * dphi);
+}
+
 /// Return the invariant mass of two particles given the collections of the quantities
 /// transverse momentum (pt), rapidity (eta), azimuth (phi) and mass.
 ///
@@ -1766,4 +1794,4 @@ using ROOT::VecOps::RVec;
 
 } // namespace ROOT
 
-#endif
+#endif // ROOT_TVEC

--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -1431,6 +1431,81 @@ RVec<Common_t> Concatenate(const RVec<T0> &v0, const RVec<T1> &v1)
    return res;
 }
 
+/// Return the angle difference \f$\Delta \phi\f$ of two scalars.
+///
+/// The function computes the closest angle from v1 to v2 with sign and is
+/// therefore in the range \f$[-\pi, \pi]\f$.
+/// The computation is done per default in radians \f$c = \pi\f$ but can be switched
+/// to degrees \f$c = 180\f$.
+template <typename T>
+T DeltaPhi(T v1, T v2, const T c = M_PI)
+{
+   static_assert(std::is_floating_point<T>::value,
+                 "DeltaPhi must be called with floating point values.");
+   auto r = std::fmod(v2 - v1, 2.0 * c);
+   if (r < -c) {
+      r += 2.0 * c;
+   }
+   else if (r > c) {
+      r -= 2.0 * c;
+   }
+   return r;
+}
+
+/// Return the angle difference \f$\Delta \phi\f$ in radians of two vectors.
+///
+/// The function computes the closest angle from v1 to v2 with sign and is
+/// therefore in the range \f$[-\pi, \pi]\f$.
+/// The computation is done per default in radians \f$c = \pi\f$ but can be switched
+/// to degrees \f$c = 180\f$.
+template <typename T>
+RVec<T> DeltaPhi(const RVec<T>& v1, const RVec<T>& v2, const T c = M_PI)
+{
+   using size_type = typename RVec<T>::size_type;
+   const size_type size = v1.size();
+   auto r = RVec<T>(size);
+   for (size_type i = 0; i < size; i++) {
+      r[i] = DeltaPhi(v1[i], v2[i], c);
+   }
+   return r;
+}
+
+/// Return the angle difference \f$\Delta \phi\f$ in radians of a vector and a scalar.
+///
+/// The function computes the closest angle from v1 to v2 with sign and is
+/// therefore in the range \f$[-\pi, \pi]\f$.
+/// The computation is done per default in radians \f$c = \pi\f$ but can be switched
+/// to degrees \f$c = 180\f$.
+template <typename T>
+RVec<T> DeltaPhi(const RVec<T>& v1, T v2, const T c = M_PI)
+{
+   using size_type = typename RVec<T>::size_type;
+   const size_type size = v1.size();
+   auto r = RVec<T>(size);
+   for (size_type i = 0; i < size; i++) {
+      r[i] = DeltaPhi(v1[i], v2, c);
+   }
+   return r;
+}
+
+/// Return the angle difference \f$\Delta \phi\f$ in radians of a scalar and a vector.
+///
+/// The function computes the closest angle from v1 to v2 with sign and is
+/// therefore in the range \f$[-\pi, \pi]\f$.
+/// The computation is done per default in radians \f$c = \pi\f$ but can be switched
+/// to degrees \f$c = 180\f$.
+template <typename T>
+RVec<T> DeltaPhi(T v1, const RVec<T>& v2, const T c = M_PI)
+{
+   using size_type = typename RVec<T>::size_type;
+   const size_type size = v2.size();
+   auto r = RVec<T>(size);
+   for (size_type i = 0; i < size; i++) {
+      r[i] = DeltaPhi(v1, v2[i], c);
+   }
+   return r;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Print a RVec at the prompt:
 template <class T>

--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -25,6 +25,7 @@
 #include <ROOT/TypeTraits.hxx>
 
 #include <algorithm>
+#define _USE_MATH_DEFINES // for M_PI on windows in cmath
 #include <cmath>
 #include <numeric> // for inner_product
 #include <sstream>
@@ -1793,5 +1794,7 @@ TVEC_EXTERN_VDT_UNARY_FUNCTION(double, fast_atan)
 using ROOT::VecOps::RVec;
 
 } // namespace ROOT
+
+#undef _USE_MATH_DEFINES // for M_PI on windows in cmath
 
 #endif // ROOT_TVEC

--- a/math/vecops/test/CMakeLists.txt
+++ b/math/vecops/test/CMakeLists.txt
@@ -1,2 +1,2 @@
-ROOT_ADD_GTEST(vecops_rvec vecops_rvec.cxx LIBRARIES ROOTVecOps RIO Tree)
+ROOT_ADD_GTEST(vecops_rvec vecops_rvec.cxx LIBRARIES Physics ROOTVecOps RIO Tree)
 ROOT_ADD_GTEST(vecops_radoptallocator vecops_radoptallocator.cxx LIBRARIES Core ROOTVecOps)

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -934,10 +934,10 @@ TEST(VecOps, DeltaPhi)
 
    // Check against TLorentzVector
    for (std::size_t i = 0; i < v1.size(); i++) {
-       TLorentzVector p1, p2;
-       p1.SetPtEtaPhiM(1.f, 1.f, v1[i], 1.f);
-       p2.SetPtEtaPhiM(1.f, 1.f, v2[i], 1.f);
-       EXPECT_NEAR(float(p2.DeltaPhi(p1)), dphi1[i], 1e-6);
+      TLorentzVector p1, p2;
+      p1.SetPtEtaPhiM(1.f, 1.f, v1[i], 1.f);
+      p2.SetPtEtaPhiM(1.f, 1.f, v2[i], 1.f);
+      EXPECT_NEAR(float(p2.DeltaPhi(p1)), dphi1[i], 1e-6);
    }
 
    // Vector and scalar
@@ -1001,4 +1001,29 @@ TEST(VecOps, InvariantMass)
    }
 
    EXPECT_NEAR(p5.M(), invMass3, 1e-4);
+}
+
+TEST(VecOps, DeltaR)
+{
+   RVec<float> eta1 =  {0.1, -1.0, -1.0, 0.5,  -2.5};
+   RVec<float> eta2 =  {0.0, 0.0, 0.5, 2.4, 1.2};
+   RVec<float> phi1 =  {1.0, 5.0, -1.0,  -0.5, -2.4};
+   RVec<float> phi2 =  {0.0, 3.0, 6.0, 1.5, 1.4};
+
+   auto dr = DeltaR(eta1, eta2, phi1, phi2);
+   auto dr2 = DeltaR(eta2, eta1, phi2, phi1);
+
+   for (std::size_t i = 0; i < eta1.size(); i++) {
+      // Check against TLorentzVector
+      TLorentzVector p1, p2;
+      p1.SetPtEtaPhiM(1.f, eta1[i], phi1[i], 1.f);
+      p2.SetPtEtaPhiM(1.f, eta2[i], phi2[i], 1.f);
+      auto dr3 = float(p2.DeltaR(p1));
+      EXPECT_NEAR(dr3, dr[i], 1e-6);
+      EXPECT_NEAR(dr3, dr2[i], 1e-6);
+
+      // Check scalar implementation
+      auto dr4 = DeltaR(eta1[i], eta2[i], phi1[i], phi2[i]);
+      EXPECT_NEAR(dr3, dr4, 1e-6);
+   }
 }

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -900,8 +900,6 @@ TEST(VecOps, Concatenate)
 
 TEST(VecOps, DeltaPhi)
 {
-   using namespace ROOT::VecOps;
-
    // Two scalars (radians)
    // NOTE: These tests include the checks of the poundary effects
    const float c1 = M_PI;
@@ -952,4 +950,55 @@ TEST(VecOps, DeltaPhi)
    auto dphi4 = DeltaPhi(v4, v3);
    auto r4 = -1.f * r3;
    CheckEqual(dphi4, r4);
+}
+
+TEST(VecOps, InvariantMass)
+{
+   // Dummy particle collections
+   RVec<float> mass1 = {50,  50,  50,   50,   100};
+   RVec<float> pt1 =   {0,   5,   5,    10,   10};
+   RVec<float> eta1 =  {0.0, 0.0, -1.0, 0.5,  2.5};
+   RVec<float> phi1 =  {0.0, 0.0, 0.0,  -0.5, -2.4};
+
+   RVec<float> mass2 = {40,  40,  40,  40,  30};
+   RVec<float> pt2 =   {0,   5,   5,   10,  2};
+   RVec<float> eta2 =  {0.0, 0.0, 0.5, 0.4, 1.2};
+   RVec<float> phi2 =  {0.0, 0.0, 0.0, 0.5, 2.4};
+
+   // Compute invariant mass of two particle system using both collections
+   const auto invMass = InvariantMass(pt1, eta1, phi1, mass1, pt2, eta2, phi2, mass2);
+
+   for(size_t i=0; i<mass1.size(); i++) {
+      TLorentzVector p1, p2;
+      p1.SetPtEtaPhiM(pt1[i], eta1[i], phi1[i], mass1[i]);
+      p2.SetPtEtaPhiM(pt2[i], eta2[i], phi2[i], mass2[i]);
+      // NOTE: The accuracy of the optimized trigonometric functions is relatively
+      // low and the test start to fail with an accuracy of 1e-5.
+      EXPECT_NEAR((p1 + p2).M(), invMass[i], 1e-4);
+   }
+
+   // Compute invariant mass of multiple-particle system using a single collection
+   const auto invMass2 = InvariantMass(pt1, eta1, phi1, mass1);
+
+   TLorentzVector p3;
+   p3.SetPtEtaPhiM(pt1[0], eta1[0], phi1[0], mass1[0]);
+   for(size_t i=1; i<mass1.size(); i++) {
+      TLorentzVector p4;
+      p4.SetPtEtaPhiM(pt1[i], eta1[i], phi1[i], mass1[i]);
+      p3 += p4;
+   }
+
+   EXPECT_NEAR(p3.M(), invMass2, 1e-4);
+
+   const auto invMass3 = InvariantMass(pt2, eta2, phi2, mass2);
+
+   TLorentzVector p5;
+   p5.SetPtEtaPhiM(pt2[0], eta2[0], phi2[0], mass2[0]);
+   for(size_t i=1; i<mass2.size(); i++) {
+      TLorentzVector p6;
+      p6.SetPtEtaPhiM(pt2[i], eta2[i], phi2[i], mass2[i]);
+      p5 += p6;
+   }
+
+   EXPECT_NEAR(p5.M(), invMass3, 1e-4);
 }

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -5,8 +5,10 @@
 #include <TInterpreter.h>
 #include <TTree.h>
 #include <TSystem.h>
+#include <TLorentzVector.h>
 #include <vector>
 #include <sstream>
+#include <cmath>
 
 using namespace ROOT::VecOps;
 
@@ -894,4 +896,60 @@ TEST(VecOps, Concatenate)
    const auto res = Concatenate(rvf, rvi);
    const RVec<float> ref { 0.00000f, 1.00000f, 2.00000f, 7.00000f, 8.00000f, 9.00000f };
    CheckEqual(res, ref);
+}
+
+TEST(VecOps, DeltaPhi)
+{
+   using namespace ROOT::VecOps;
+
+   // Two scalars (radians)
+   // NOTE: These tests include the checks of the poundary effects
+   const float c1 = M_PI;
+   EXPECT_EQ(DeltaPhi(0.f, 2.f), 2.f);
+   EXPECT_EQ(DeltaPhi(1.f, 0.f), -1.f);
+   EXPECT_EQ(DeltaPhi(-0.5f, 0.5f), 1.f);
+   EXPECT_EQ(DeltaPhi(0.f, 2.f * c1 - 1.f), -1.f);
+   EXPECT_EQ(DeltaPhi(0.f, 4.f * c1 - 1.f), -1.f);
+   EXPECT_EQ(DeltaPhi(0.f, -2.f * c1 + 1.f), 1.f);
+   EXPECT_EQ(DeltaPhi(0.f, -4.f * c1 + 1.f), 1.f);
+
+   // Two scalars (degrees)
+   const float c2 = 180.f;
+   EXPECT_EQ(DeltaPhi(0.f, 2.f, c2), 2.f);
+   EXPECT_EQ(DeltaPhi(1.f, 0.f, c2), -1.f);
+   EXPECT_EQ(DeltaPhi(-0.5f, 0.5f, c2), 1.f);
+   EXPECT_EQ(DeltaPhi(0.f, 2.f * c2 - 1.f, c2), -1.f);
+   EXPECT_EQ(DeltaPhi(0.f, 4.f * c2 - 1.f, c2), -1.f);
+   EXPECT_EQ(DeltaPhi(0.f, -2.f * c2 + 1.f, c2), 1.f);
+   EXPECT_EQ(DeltaPhi(0.f, -4.f * c2 + 1.f, c2), 1.f);
+
+   // Two vectors
+   RVec<float> v1 = {0.f, 1.f, -0.5f, 0.f, 0.f, 0.f, 0.f};
+   RVec<float> v2 = {2.f, 0.f, 0.5f, 2.f * c1 - 1.f, 4.f * c1 - 1.f, -2.f * c1 + 1.f, -4.f * c1 + 1.f};
+   auto dphi1 = DeltaPhi(v1, v2);
+   RVec<float> r1 = {2.f, -1.f, 1.f, -1.f, -1.f, 1.f, 1.f};
+   CheckEqual(dphi1, r1);
+
+   auto dphi2 = DeltaPhi(v2, v1);
+   auto r2 = r1 * -1.f;
+   CheckEqual(dphi2, r2);
+
+   // Check against TLorentzVector
+   for (std::size_t i = 0; i < v1.size(); i++) {
+       TLorentzVector p1, p2;
+       p1.SetPtEtaPhiM(1.f, 1.f, v1[i], 1.f);
+       p2.SetPtEtaPhiM(1.f, 1.f, v2[i], 1.f);
+       EXPECT_NEAR(float(p2.DeltaPhi(p1)), dphi1[i], 1e-6);
+   }
+
+   // Vector and scalar
+   RVec<float> v3 = {0.f, 1.f, c1, c1 + 1.f, 2.f * c1, 2.f * c1 + 1.f, -1.f, -c1, -c1 + 1.f, -2.f * c1, -2.f * c1 + 1.f};
+   float v4 = 1.f;
+   auto dphi3 = DeltaPhi(v3, v4);
+   RVec<float> r3 = {1.f, 0.f, 1.f - c1, c1, 1.f, 0.f, 2.f, -c1 + 1.f, c1, 1.f, 0.f};
+   CheckEqual(dphi3, r3);
+
+   auto dphi4 = DeltaPhi(v4, v3);
+   auto r4 = -1.f * r3;
+   CheckEqual(dphi4, r4);
 }

--- a/tutorials/vecops/vo007_PhysicsHelpers.C
+++ b/tutorials/vecops/vo007_PhysicsHelpers.C
@@ -2,7 +2,7 @@
 /// \ingroup tutorial_vecops
 /// \notebook -nodraw
 /// In this tutorial we demonstrate RVec helpers for physics computations such
-/// as angle differences \f$\Delta \phi\f$.
+/// as angle differences \f$\Delta \phi\f$ and invariant mass.
 ///
 /// \macro_code
 /// \macro_output
@@ -30,6 +30,39 @@ void vo007_PhysicsHelpers()
 
    std::cout << "Phi values: " << phis << std::endl;
    for(std::size_t i = 0; i < idx[0].size(); i++) {
-      std::cout << "DeltaPhi(" << phis[idx[0][i]] << ", " << phis[idx[1][i]] << ") = " << dphi[i] << std::endl;
+      std::cout << "DeltaPhi(" << phis[idx[0][i]] << ", " << phis[idx[1][i]]
+                << ") = " << dphi[i] << std::endl;
    }
+
+   // The InvariantMass helper computes the invariant mass of a two particle system
+   // given the properties transverse momentum (pt), rapidity (eta), azimuth (phi)
+   // and mass.
+   RVec<float> pt1 = {40, 20, 30};
+   RVec<float> eta1 = {2.5, 0.5, -1.0};
+   RVec<float> phi1 = {-0.5, 0.0, 1.0};
+   RVec<float> mass1 = {10, 10, 10};
+
+   RVec<float> pt2 = {20, 10, 40};
+   RVec<float> eta2 = {0.5, -0.5, 1.0};
+   RVec<float> phi2 = {0.0, 1.0, -1.0};
+   RVec<float> mass2 = {2, 2, 2};
+
+   auto invMass = InvariantMass(pt1, eta1, phi1, mass1, pt2, eta2, phi2, mass2);
+
+   std::cout << std::endl;
+   for(std::size_t i = 0; i < pt1.size(); i++) {
+      std::cout << "InvariantMass("
+                << pt1[i] << ", " << eta1[i] << ", " << phi1[i] << ", " << mass1[i] << ", "
+                << pt2[i] << ", " << eta2[i] << ", " << phi2[i] << ", " << mass2[i]
+                << ") = " << invMass[i] << std::endl;
+   }
+
+   // The helper also accepts a single set of (pt, eta, phi, mass) vectors. Then,
+   // the invariant mass of all particles in the collection is computed.
+
+   auto invMass2 = InvariantMass(pt1, eta1, phi1, mass1);
+
+   std::cout << std::endl;
+   std::cout << "InvariantMass(" << pt1 << ", " << eta1 << ", " << phi1 << ", "
+             << mass1 << ") = " << invMass2 << std::endl;
 }

--- a/tutorials/vecops/vo007_PhysicsHelpers.C
+++ b/tutorials/vecops/vo007_PhysicsHelpers.C
@@ -2,7 +2,8 @@
 /// \ingroup tutorial_vecops
 /// \notebook -nodraw
 /// In this tutorial we demonstrate RVec helpers for physics computations such
-/// as angle differences \f$\Delta \phi\f$ and invariant mass.
+/// as angle differences \f$\Delta \phi\f$, the distance in the \f$\eta\f$-\f$\phi\f$
+/// plane \f$\Delta R\f$ and the invariant mass.
 ///
 /// \macro_code
 /// \macro_output
@@ -24,45 +25,61 @@ void vo007_PhysicsHelpers()
    RVec<float> phis = {0.0, 1.0, -0.5, M_PI + 1.0};
    auto idx = Combinations(phis, 2);
 
-   auto phi_1 = Take(phis, idx[0]);
-   auto phi_2 = Take(phis, idx[1]);
-   auto dphi = DeltaPhi(phi_1, phi_2);
+   auto phi1 = Take(phis, idx[0]);
+   auto phi2 = Take(phis, idx[1]);
+   auto dphi = DeltaPhi(phi1, phi2);
 
-   std::cout << "Phi values: " << phis << std::endl;
-   for(std::size_t i = 0; i < idx[0].size(); i++) {
-      std::cout << "DeltaPhi(" << phis[idx[0][i]] << ", " << phis[idx[1][i]]
-                << ") = " << dphi[i] << std::endl;
-   }
+   std::cout << "DeltaPhi(phi1 = " << phi1 << ",\n"
+             << "         phi2 = " << phi2 << ")\n"
+             << " = " << dphi << "\n";
+
+   // The DeltaR helper is similar to the DeltaPhi helper and computes the distance
+   // in the \f$\eta\f$-\f$\phi\f$ plane.
+   RVec<float> etas = {2.4, -1.5, 1.0, 0.0};
+
+   auto eta1 = Take(etas, idx[0]);
+   auto eta2 = Take(etas, idx[1]);
+   auto dr = DeltaR(eta1, eta2, phi1, phi2);
+
+   std::cout << "\nDeltaR(eta1 = " << eta1 << ",\n"
+             << "       eta2 = " << eta2 << ",\n"
+             << "       phi1 = " << phi1 << ",\n"
+             << "       phi2 = " << phi2 << ")\n"
+             << " = " << dr << "\n";
 
    // The InvariantMass helper computes the invariant mass of a two particle system
    // given the properties transverse momentum (pt), rapidity (eta), azimuth (phi)
    // and mass.
-   RVec<float> pt1 = {40, 20, 30};
-   RVec<float> eta1 = {2.5, 0.5, -1.0};
-   RVec<float> phi1 = {-0.5, 0.0, 1.0};
-   RVec<float> mass1 = {10, 10, 10};
+   RVec<float> pt3 = {40, 20, 30};
+   RVec<float> eta3 = {2.5, 0.5, -1.0};
+   RVec<float> phi3 = {-0.5, 0.0, 1.0};
+   RVec<float> mass3 = {10, 10, 10};
 
-   RVec<float> pt2 = {20, 10, 40};
-   RVec<float> eta2 = {0.5, -0.5, 1.0};
-   RVec<float> phi2 = {0.0, 1.0, -1.0};
-   RVec<float> mass2 = {2, 2, 2};
+   RVec<float> pt4 = {20, 10, 40};
+   RVec<float> eta4 = {0.5, -0.5, 1.0};
+   RVec<float> phi4 = {0.0, 1.0, -1.0};
+   RVec<float> mass4 = {2, 2, 2};
 
-   auto invMass = InvariantMass(pt1, eta1, phi1, mass1, pt2, eta2, phi2, mass2);
+   auto invMass = InvariantMass(pt3, eta3, phi3, mass3, pt4, eta4, phi4, mass4);
 
-   std::cout << std::endl;
-   for(std::size_t i = 0; i < pt1.size(); i++) {
-      std::cout << "InvariantMass("
-                << pt1[i] << ", " << eta1[i] << ", " << phi1[i] << ", " << mass1[i] << ", "
-                << pt2[i] << ", " << eta2[i] << ", " << phi2[i] << ", " << mass2[i]
-                << ") = " << invMass[i] << std::endl;
-   }
+   std::cout << "\nInvariantMass(pt1 = " << pt3 << ",\n"
+             << "              eta1 = " << eta3 << ",\n"
+             << "              phi1 = " << phi3 << ",\n"
+             << "              mass1 = " << mass3 << ",\n"
+             << "              pt2 = " << pt4 << ",\n"
+             << "              eta2 = " << eta4 << ",\n"
+             << "              phi2 = " << phi4 << ",\n"
+             << "              mass2 = " << mass4 << ")\n"
+             << " = " << invMass << "\n";
 
    // The helper also accepts a single set of (pt, eta, phi, mass) vectors. Then,
    // the invariant mass of all particles in the collection is computed.
 
-   auto invMass2 = InvariantMass(pt1, eta1, phi1, mass1);
+   auto invMass2 = InvariantMass(pt3, eta3, phi3, mass3);
 
-   std::cout << std::endl;
-   std::cout << "InvariantMass(" << pt1 << ", " << eta1 << ", " << phi1 << ", "
-             << mass1 << ") = " << invMass2 << std::endl;
+   std::cout << "\nInvariantMass(pt = " << pt3 << ",\n"
+             << "              eta = " << eta3 << ",\n"
+             << "              phi = " << phi3 << ",\n"
+             << "              mass = " << mass3 << ")\n"
+             << " = " << invMass2 << "\n";
 }

--- a/tutorials/vecops/vo007_PhysicsHelpers.C
+++ b/tutorials/vecops/vo007_PhysicsHelpers.C
@@ -1,0 +1,35 @@
+/// \file
+/// \ingroup tutorial_vecops
+/// \notebook -nodraw
+/// In this tutorial we demonstrate RVec helpers for physics computations such
+/// as angle differences \f$\Delta \phi\f$.
+///
+/// \macro_code
+/// \macro_output
+///
+/// \date March 2019
+/// \author Stefan Wunsch
+
+using namespace ROOT::VecOps;
+
+void vo007_PhysicsHelpers()
+{
+   // The DeltaPhi helper computes the closest angle between angles.
+   // This means that the resulting value is in the range [-pi, pi].
+
+   // Note that the helper also supports to compute the angle difference of an
+   // RVec and a scalar and two scalars. In addition, the computation of the
+   // difference and the behaviour at the boundary can be adjusted to radian and
+   // degrees.
+   RVec<float> phis = {0.0, 1.0, -0.5, M_PI + 1.0};
+   auto idx = Combinations(phis, 2);
+
+   auto phi_1 = Take(phis, idx[0]);
+   auto phi_2 = Take(phis, idx[1]);
+   auto dphi = DeltaPhi(phi_1, phi_2);
+
+   std::cout << "Phi values: " << phis << std::endl;
+   for(std::size_t i = 0; i < idx[0].size(); i++) {
+      std::cout << "DeltaPhi(" << phis[idx[0][i]] << ", " << phis[idx[1][i]] << ") = " << dphi[i] << std::endl;
+   }
+}


### PR DESCRIPTION
Implements different physics helpers for RVec collections:
 - `DeltaPhi`: Angle difference with correct handling of boundaries at modulo 2 * pi
 - `DeltaR`: Distance on eta-phi plane
 - `InvariantMass`: Invariant mass of four-vector collections

As follows the output of the tutorial showing the functionality of the helpers.

```bash
DeltaPhi(phi1 = { 0, 0, 0, 1, 1, -0.5 },
         phi2 = { 1, -0.5, 4.14159, -0.5, 4.14159, 4.14159 })
 = { 1, -0.5, -2.14159, -1.5, 3.14159, -1.64159 }

DeltaR(eta1 = { 2.4, 2.4, 2.4, -1.5, -1.5, 1 },
       eta2 = { -1.5, 1, 0, 1, 0, 0 },
       phi1 = { 0, 0, 0, 1, 1, -0.5 },
       phi2 = { 1, -0.5, 4.14159, -0.5, 4.14159, 4.14159 })
 = { 4.02616, 1.48661, 3.21659, 2.91548, 3.48132, 1.92219 }

InvariantMass(pt1 = { 40, 20, 30 },
              eta1 = { 2.5, 0.5, -1 },
              phi1 = { -0.5, 0, 1 },
              mass1 = { 10, 10, 10 },
              pt2 = { 20, 10, 40 },
              eta2 = { 0.5, -0.5, 1 },
              phi2 = { 0, 1, -1 },
              mass2 = { 2, 2, 2 })
 = { 69.0799, 23.6971, 101.326 }

InvariantMass(pt = { 40, 20, 30 },
              eta = { 2.5, 0.5, -1 },
              phi = { -0.5, 0, 1 },
              mass = { 10, 10, 10 })
 = 220.308
```