### PR TITLE
stl modulemap: cuchar is available starting from gcc6

### DIFF
--- a/build/unix/stl.modulemap
+++ b/build/unix/stl.modulemap
@@ -361,10 +361,6 @@ module "stl" [system] {
     export *
     header "codecvt"
   }
-  module "cuchar" {
-    export *
-    header "cuchar"
-  }
   //module "experimental/algorithm" {
   //  export *
   //  header "experimental/algorithm"


### PR DESCRIPTION
$ find /usr -name "cuchar"
/usr/include/c++/8/cuchar
/usr/include/c++/7/cuchar
/usr/include/c++/6/cuchar

PR fixes a broken CI build on Ubuntu 16 (gcc 5.4): /mnt/build/workspace/root-pullrequests-build/build/include/stl.modulemap:366:12: error: header 'cuchar' not found
