### PR TITLE
[TCling] Add method to get using declarations of namespaces

### DIFF
--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -287,6 +287,7 @@ public:
    virtual DeclId_t GetFunctionTemplate(ClassInfo_t *cl, const char *funcname) = 0;
    virtual void     GetFunctionOverloads(ClassInfo_t *cl, const char *funcname, std::vector<DeclId_t>& res) const = 0;
    virtual void     LoadFunctionTemplates(TClass* cl) const = 0;
+   virtual std::vector<std::string> GetUsingNamespaces(ClassInfo_t *cl) const = 0;
 
    // CallFunc interface
    virtual void   CallFunc_Delete(CallFunc_t * /* func */) const {;}

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -3959,6 +3959,16 @@ void TCling::LoadFunctionTemplates(TClass* cl) const
       }
    }
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get the scopes representing using declarations of namespace
+
+std::vector<std::string> TCling::GetUsingNamespaces(ClassInfo_t *cl) const
+{
+   TClingClassInfo *ci = (TClingClassInfo*)cl;
+   return ci->GetUsingNamespaces();
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Create list of pointers to data members for TClass cl.
 /// This is now a nop.  The creation and updating is handled in

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -277,6 +277,8 @@ public: // Public Interface
    void     GetFunctionOverloads(ClassInfo_t *cl, const char *funcname, std::vector<DeclId_t>& res) const;
    virtual void     LoadFunctionTemplates(TClass* cl) const;
 
+   virtual std::vector<std::string> GetUsingNamespaces(ClassInfo_t *cl) const;
+
    void    GetInterpreterTypeName(const char* name, std::string &output, Bool_t full = kFALSE);
    void    Execute(const char* function, const char* params, int* error = 0);
    void    Execute(TObject* obj, TClass* cl, const char* method, const char* params, int* error = 0);

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -642,20 +642,14 @@ std::vector<std::string> TClingClassInfo::GetUsingNamespaces()
    R__LOCKGUARD(gInterpreterMutex);
 
    cling::Interpreter::PushTransactionRAII RAII(fInterp);
-   const clang::DeclContext *DC = cast<DeclContext>(fDecl);
+   const auto DC = dyn_cast<DeclContext>(fDecl);
    if (!DC)
-       return res;
+      return res;
 
-   clang::DeclContext::decl_iterator iter = DC->noload_decls_begin();
-   while (iter != DC->noload_decls_end()) {
-      if (iter->getKind() == Decl::UsingDirective) {
-         UsingDirectiveDecl *udecl = llvm::cast<UsingDirectiveDecl>(*iter);
-         if (udecl) {
-             NamespaceDecl *target = udecl->getNominatedNamespace();
-             if (target) res.push_back(target->getName().str());
-         }
-      }
-      ++iter;
+   for (auto UD : DC->using_directives()) {
+      NamespaceDecl *NS = UD->getNominatedNamespace();
+      if (NS)
+         res.push_back(NS->getName().str());
    }
 
    return res;

--- a/core/metacling/src/TClingClassInfo.h
+++ b/core/metacling/src/TClingClassInfo.h
@@ -115,6 +115,7 @@ public:
    long                 GetOffset(const clang::CXXMethodDecl* md) const;
    ptrdiff_t            GetBaseOffset(TClingClassInfo* toBase, void* address, bool isDerivedObject);
    const clang::Type   *GetType() const { return fType; } // Underlying representation with Double32_t
+   std::vector<std::string> GetUsingNamespaces();
    bool                 HasDefaultConstructor() const;
    bool                 HasMethod(const char *name) const;
    void                 Init(const char *name);


### PR DESCRIPTION
When updating `cppyy-backend` to v1.7.3 in PyROOT experimental, a compilation error appears because of a missing functionality in `TCling`, in particular a method to get using declarations of namespaces.

This functionality was added to Cppyy's ROOT recently, and a patch was created for it:
https://bitbucket.org/wlav/cppyy-backend/src/59a4a747d03c6e94eaaa28062daf83104334f27d/cling/patches/using_directives.diff

This PR proposes to add such functionality to mainstream ROOT. 

Inviting @Axel-Naumann and @wlav to the party.