### PR TITLE
Add a TMVA::Executor class to control MT in TMVA

### DIFF
--- a/tmva/tmva/CMakeLists.txt
+++ b/tmva/tmva/CMakeLists.txt
@@ -42,6 +42,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(TMVA
     TMVA/Envelope.h
     TMVA/Event.h
     TMVA/ExpectedErrorPruneTool.h
+    TMVA/Executor.h
     TMVA/Factory.h
     TMVA/FitterBase.h
     TMVA/GeneticAlgorithm.h

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu/CpuMatrix.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu/CpuMatrix.h
@@ -152,7 +152,7 @@ public:
    AFloat *       GetRawDataPointer()        {return fBuffer;}
    const AFloat * GetRawDataPointer()  const {return fBuffer;}
 
-   static ROOT::TThreadExecutor &GetThreadExecutor() { return TMVA::Config::Instance().GetThreadExecutor(); }
+   static Executor &GetThreadExecutor() { return TMVA::Config::Instance().GetThreadExecutor(); }
 
     // static function to get the number of elements for task
    static size_t GetNWorkItems(size_t nelements);
@@ -214,12 +214,11 @@ inline void TCpuMatrix<AFloat>::Map(Function_t &f)
    };
 
    if (nsteps < nelements) {
-#ifdef DL_USE_MTE
       TMVA::Config::Instance().GetThreadExecutor().Foreach(ff, ROOT::TSeqI(0,nelements,nsteps));
-#else
-      for (size_t i = 0;  i < nelements; i+=nsteps)
-         ff(i);
-#endif
+
+      // for (size_t i = 0;  i < nelements; i+=nsteps)
+      //    ff(i);
+
    }
    else {
       R__ASSERT(nelements == nsteps);
@@ -248,12 +247,10 @@ inline void TCpuMatrix<AFloat>::MapFrom(Function_t &f, const TCpuMatrix &A)
       return 0;
    };
    if (nsteps < nelements) { 
-#ifdef DL_USE_MTE
       TMVA::Config::Instance().GetThreadExecutor().Foreach(ff, ROOT::TSeqI(0,nelements,nsteps));
-#else
-      for (size_t i = 0;  i < nelements; i+=nsteps)
-         ff(i);
-#endif
+      // for (size_t i = 0;  i < nelements; i+=nsteps)
+      //    ff(i);
+
    }
    else {
       R__ASSERT(nelements == nsteps);

--- a/tmva/tmva/inc/TMVA/Executor.h
+++ b/tmva/tmva/inc/TMVA/Executor.h
@@ -110,6 +110,21 @@ public:
       if (fMTExecImpl) return fMTExecImpl->MapReduce(func, args, redfunc);
       else return fSeqExecImpl->MapReduce(func, args, redfunc); 
    }
+   template<class F, class INTEGER, class R, class Cond = noReferenceCond<F, INTEGER>>
+   auto MapReduce(F func, ROOT::TSeq<INTEGER> args, R redfunc, unsigned nChunks) -> typename std::result_of<F(INTEGER)>::type {
+      if (fMTExecImpl) return fMTExecImpl->MapReduce(func, args, redfunc, nChunks);
+      else return fSeqExecImpl->MapReduce(func, args, redfunc); 
+   }
+  
+   
+
+   ///Wrap Reduce function
+   template<class T, class R>
+   auto Reduce(const std::vector<T> &objs, R redfunc) -> decltype(redfunc(objs)) {
+      if (fMTExecImpl) return fMTExecImpl->Reduce(objs, redfunc);
+      else return fSeqExecImpl->Reduce(objs, redfunc); 
+   }
+   //template<class T> T* Reduce(const std::vector<T*> &mergeObjs);
    
 #ifdef R__USE_IMT
    std::unique_ptr<ROOT::TThreadExecutor>  fMTExecImpl;

--- a/tmva/tmva/inc/TMVA/Executor.h
+++ b/tmva/tmva/inc/TMVA/Executor.h
@@ -61,6 +61,7 @@ public:
          fSeqExecImpl = std::unique_ptr<ROOT::TSequentialExecutor>(new ROOT::TSequentialExecutor());
    }
 
+#ifdef R__USE_IMT
    ROOT::TThreadExecutor * GetMultiThreadExecutor() {
       if (fMTExecImpl) return fMTExecImpl.get();
       else {
@@ -69,6 +70,7 @@ public:
          return fMTExecImpl.get();
       }
    }
+#endif
 
    unsigned int GetPoolSize() const {
       if (!fMTExecImpl) return 1;
@@ -116,8 +118,6 @@ public:
       else return fSeqExecImpl->MapReduce(func, args, redfunc); 
    }
   
-   
-
    ///Wrap Reduce function
    template<class T, class R>
    auto Reduce(const std::vector<T> &objs, R redfunc) -> decltype(redfunc(objs)) {

--- a/tmva/tmva/inc/TMVA/Executor.h
+++ b/tmva/tmva/inc/TMVA/Executor.h
@@ -1,0 +1,124 @@
+// @(#)root/tmva $Id$   
+// Author: Lorenzo Moneta
+/*************************************************************************
+ * Copyright (C) 2019, ROOT/TMVA                                         *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+//////////////////////////////////////////////////////////////////////////
+//
+//  Defining Executor classes to be used in TMVA
+// wrapping the functionality of the ROOT TThreadExecutor and
+// ROOT TSequential Executor 
+//  
+/////////////////////////////////////////////////////////////////////////
+#ifndef ROOT_TMVA_Executor
+#define ROOT_TMVA_Executor
+
+#include <memory>
+
+#include <ROOT/TSequentialExecutor.hxx>
+#ifdef R__USE_IMT
+#include <ROOT/TThreadExecutor.hxx>
+#endif
+
+
+namespace TMVA {
+
+
+/// Base Excutor class
+class Executor {
+
+public:
+
+   template< class F, class... T>
+   using noReferenceCond = typename std::enable_if<"Function can't return a reference" &&
+                                                   !(std::is_reference<typename std::result_of<F(T...)>::type>::value)>::type;
+
+  
+
+   //////////////////////////////////////
+   /// constructor of TMVA Executor class
+   /// if ROOT::EnableIMplicitMT has not been called then by default a serial executor will be created
+   /// A user can create a thread pool and enable multi-thread excution by calling TMVA::Config::Instance()::EnableMT(nthreads)
+   /// FOr releasing the thread pool used by TMVA one can do it by calling  TMVA::Config::Instance()::DisableMT() or
+   /// calling TMVA::Config::Instance()::EnableMT with only one thread 
+   ////////////////////////////////////////////
+   explicit Executor(int nthreads  = 0) {
+      if (ROOT::IsImplicitMTEnabled() || nthreads > 1 ) {
+#ifdef R__USE_IMT 
+         fMTExecImpl = (nthreads == 0) ? std::unique_ptr< ROOT::TThreadExecutor>(new ROOT::TThreadExecutor()) :
+            std::unique_ptr< ROOT::TThreadExecutor>(new ROOT::TThreadExecutor(nthreads));
+#else
+         ::Error("Executor","Cannot have multi threads when ROOT is built without IMT");
+#endif
+      }
+      // case of single thread usage
+      if (!fMTExecImpl)
+         fSeqExecImpl = std::unique_ptr<ROOT::TSequentialExecutor>(new ROOT::TSequentialExecutor());
+   }
+
+   ROOT::TThreadExecutor * GetMultiThreadExecutor() {
+      if (fMTExecImpl) return fMTExecImpl.get();
+      else {
+         fMTExecImpl =  std::unique_ptr< ROOT::TThreadExecutor>(new ROOT::TThreadExecutor());
+         Info("GetThreadExecutor","Creating a TThread executor with a pool with a defult size of %d",fMTExecImpl->GetPoolSize()); 
+         return fMTExecImpl.get();
+      }
+   }
+
+   unsigned int GetPoolSize() const {
+      if (!fMTExecImpl) return 1;
+      return fMTExecImpl->GetPoolSize(); 
+   }
+
+   /// wrap TExecutor::Foreach
+   template<class Function> 
+   void Foreach(Function func, unsigned int nTimes, unsigned nChunks = 0) {
+      if (fMTExecImpl) fMTExecImpl->Foreach(func,nTimes, nChunks);
+      else fSeqExecImpl->Foreach(func,nTimes); 
+   }
+   template<class Function, class T> 
+   void Foreach(Function func, std::vector<T> & args, unsigned nChunks = 0) {
+      if (fMTExecImpl) fMTExecImpl->Foreach(func,args, nChunks);
+      else fSeqExecImpl->Foreach(func, args); 
+   }
+   template<class Function, class INTEGER>
+   void Foreach(Function func, ROOT::TSeq<INTEGER> args, unsigned nChunks = 0){
+      if (fMTExecImpl) fMTExecImpl->Foreach(func,args, nChunks);
+      else fSeqExecImpl->Foreach(func, args); 
+   }
+
+   /// Wrap TExecutor::Map functions
+   template<class F, class Cond = noReferenceCond<F>>
+   auto Map(F func, unsigned nTimes) -> std::vector<typename std::result_of<F()>::type>  {
+      if (fMTExecImpl) return fMTExecImpl->Map(func,nTimes);
+      else return fSeqExecImpl->Map(func, nTimes); 
+   }
+   template<class F, class INTEGER, class Cond = noReferenceCond<F, INTEGER>>
+   auto Map(F func, ROOT::TSeq<INTEGER> args) -> std::vector<typename std::result_of<F(INTEGER)>::type> { 
+      if (fMTExecImpl) return fMTExecImpl->Map(func,args);
+      else return fSeqExecImpl->Map(func, args); 
+   }
+
+   /// Wrap TExecutor::MapReduce functions
+   template<class F, class INTEGER, class R, class Cond = noReferenceCond<F, INTEGER>>
+   auto MapReduce(F func, ROOT::TSeq<INTEGER> args, R redfunc) -> typename std::result_of<F(INTEGER)>::type {
+      if (fMTExecImpl) return fMTExecImpl->MapReduce(func, args, redfunc);
+      else return fSeqExecImpl->MapReduce(func, args, redfunc); 
+   }
+   
+#ifdef R__USE_IMT
+   std::unique_ptr<ROOT::TThreadExecutor>  fMTExecImpl;
+#else
+   std::unique_ptr<ROOT::TSequentialExecutor> fMTExecImpl; // if not using MT the two pointers will be of same type 
+#endif
+   std::unique_ptr<ROOT::TSequentialExecutor> fSeqExecImpl; 
+};
+
+}  // end namespace TMVA
+
+#endif

--- a/tmva/tmva/inc/TMVA/Executor.h
+++ b/tmva/tmva/inc/TMVA/Executor.h
@@ -25,6 +25,8 @@
 #include <ROOT/TThreadExecutor.hxx>
 #endif
 
+#include <TROOT.h>
+#include <TError.h>
 
 namespace TMVA {
 

--- a/tmva/tmva/inc/TMVA/Executor.h
+++ b/tmva/tmva/inc/TMVA/Executor.h
@@ -74,7 +74,11 @@ public:
 
    unsigned int GetPoolSize() const {
       if (!fMTExecImpl) return 1;
-      return fMTExecImpl->GetPoolSize(); 
+#ifdef R__USE_IMT
+      return fMTExecImpl->GetPoolSize();
+#else
+      return 1;
+#endif
    }
 
    /// wrap TExecutor::Foreach

--- a/tmva/tmva/src/Config.cxx
+++ b/tmva/tmva/src/Config.cxx
@@ -77,9 +77,6 @@ TMVA::Config::Config() :
    fIONames.fWeightFileExtension     = "weights";
    fIONames.fOptionsReferenceFileDir = "optionInfo";
 
-   // get number of CPU allocated (i.e. pool size)
-   // need to have created an instance of TThreadExecutor before
-   fNCpu = ROOT::GetImplicitMTPoolSize();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/src/MethodDL.cxx
+++ b/tmva/tmva/src/MethodDL.cxx
@@ -1488,7 +1488,10 @@ void MethodDL::Train()
       return;
    } else if (this->GetArchitectureString() == "CPU") {
 #ifdef R__HAS_TMVACPU
-      Log() << kINFO << "Start of deep neural network training on CPU." << Endl << Endl;
+      // note that number of threads used for BLAS might be different
+      // e.g use openblas_set_num_threads(num_threads) for OPENBLAS backend      
+      Log() << kINFO << "Start of deep neural network training on CPU using (for ROOT-IMT) nthreads = "
+            << gConfig().GetNCpu() << Endl << Endl;
       TrainDeepNet<DNN::TCpu<ScalarImpl_t> >(); 
 #else
       Log() << kFATAL << "Multi-core CPU backend not enabled. Please make sure "


### PR DESCRIPTION
In order to fix ROOT-10034 a new Executor class has been created.
The class wraps the TExecutor types of ROOT and create in MT running a TThreadExecutor or a TSequentialExecutor. 
This allows to use exactly same code in all TMVA depending on sequential or MT running. 
In addition now the TMVA::Config can control  the MT running. The behaviour is the following: 
-  ROOT::IsImplicitMTEnabled() = false     TMVA uses TSequentialExecutor (no MT)
-  ROOT::IsImplicitMTEnabled() = true     TMVA uses TThreadExecutor with the number of threads provided in ROOT::EnableImplicitMT
- TMVA::gConfig.EnableMT(nthreads)  :   run MT using TThreadExecutor  with nthreads (if  the ROOT thread pool has not been created before) otherwise use existing pool
- TMVA::gConfig.DisableMT()    - delete TThreadExecutor if it has been created (i.e. release the thread pool) and use TSequentialExecutor


