### PR TITLE
[rootcling] Enable stack trace printout on crash.

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -3831,7 +3831,8 @@ int RootClingMain(int argc,
               bool isGenreflex = false)
 {
    // Copied from cling driver.
-   llvm::llvm_shutdown_obj shutdownTrigger;
+   // FIXME: Uncomment once we fix ROOT's teardown order.
+   //llvm::llvm_shutdown_obj shutdownTrigger;
 
    llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);
    llvm::PrettyStackTraceProgram X(argc, argv);


### PR DESCRIPTION
Before:
```
Segmentation fault
```

After:
```
rootcling_stage1         0x000000010ea2ba98 llvm::sys::PrintStackTrace(llvm::raw_ostream&) + 40
1  rootcling_stage1         0x000000010ea2ad46 llvm::sys::RunSignalHandlers() + 86
2  rootcling_stage1         0x000000010ea2bffe SignalHandler(int) + 270
3  libsystem_platform.dylib 0x00007fff65610b3d _sigtramp + 29
4  rootcling_stage1         0x000000010c7b68dd clang::operator==(clang::QualType const&, clang::QualType const&) + 29
5  rootcling_stage1         0x000000010d531b20 clang::Preprocessor::getModuleHeaderToIncludeForDiagnostics(clang::SourceLocation, clang::Module*, clang::SourceLocation) + 48
6  rootcling_stage1         0x000000010d95bfc7 clang::Sema::diagnoseMissingImport(clang::SourceLocation, clang::NamedDecl*, clang::SourceLocation, llvm::ArrayRef<clang::Module*>, clang::Sema::MissingImportKind, bool) + 535
7  rootcling_stage1         0x000000010d95b6eb clang::Sema::diagnoseMissingImport(clang::SourceLocation, clang::NamedDecl*, clang::Sema::MissingImportKind, bool) + 395
8  rootcling_stage1         0x000000010d95b199 clang::Sema::diagnoseTypo(clang::TypoCorrection const&, clang::PartialDiagnostic const&, clang::PartialDiagnostic const&, bool) + 441
9  rootcling_stage1         0x000000010d95af83 clang::Sema::diagnoseTypo(clang::TypoCorrection const&, clang::PartialDiagnostic const&, bool) + 51
10 rootcling_stage1         0x000000010d6f0a39 clang::Sema::DiagnoseUnknownTypeName(clang::IdentifierInfo*&, clang::SourceLocation, clang::Scope*, clang::CXXScopeSpec*, clang::OpaquePtr<clang::QualType>&, bool) + 985
11 rootcling_stage1         0x000000010d57ef20 clang::Parser::ParseImplicitInt(clang::DeclSpec&, clang::CXXScopeSpec*, clang::Parser::ParsedTemplateInfo const&, clang::AccessSpecifier, clang::Parser::DeclSpecContext, clang::Parser::ParsedAttributesWithRange&) + 2288
12 rootcling_stage1         0x000000010d579427 clang::Parser::ParseDeclarationSpecifiers(clang::DeclSpec&, clang::Parser::ParsedTemplateInfo const&, clang::AccessSpecifier, clang::Parser::DeclSpecContext, clang::Parser::LateParsedAttrList*) + 6855
13 rootcling_stage1         0x000000010d5f8a6a clang::Parser::ParseDeclOrFunctionDefInternal(clang::Parser::ParsedAttributesWithRange&, clang::ParsingDeclSpec&, clang::AccessSpecifier) + 138
14 rootcling_stage1         0x000000010d5f8725 clang::Parser::ParseDeclarationOrFunctionDefinition(clang::Parser::ParsedAttributesWithRange&, clang::ParsingDeclSpec*, clang::AccessSpecifier) + 373
15 rootcling_stage1         0x000000010d5f7477 clang::Parser::ParseExternalDeclaration(clang::Parser::ParsedAttributesWithRange&, clang::ParsingDeclSpec*) + 2423
16 rootcling_stage1         0x000000010d5f641c clang::Parser::ParseTopLevelDecl(clang::OpaquePtr<clang::DeclGroupRef>&) + 588
17 rootcling_stage1         0x000000010cd68a90 cling::IncrementalParser::ParseInternal(llvm::StringRef) + 2704
18 rootcling_stage1         0x000000010cd6ca91 cling::IncrementalParser::Compile(llvm::StringRef, cling::CompilationOptions const&) + 81
19 rootcling_stage1         0x000000010cd94044 cling::Interpreter::DeclareInternal(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, cling::CompilationOptions const&, cling::Transaction**) const + 884
20 rootcling_stage1         0x000000010cd9110e cling::Interpreter::declare(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, cling::Transaction**) + 110
21 rootcling_stage1         0x000000010c964389 RootClingMain(int, char**, bool, bool) + 68009
22 rootcling_stage1         0x000000010c989685 ROOT_rootcling_Driver + 1381
23 rootcling_stage1         0x000000010c76db68 main + 104
24 libdyld.dylib            0x00007fff65427085 start + 1
25 libdyld.dylib            0x00000000000000e5 start + 2596114529
Stack dump:
0.	Program arguments: /Users/vvassilev/workspace/builds/root/core/rootcling_stage1/src/rootcling_stage1 -v2 -f G__Core.cxx -cxxmodule -s /Users/vvassilev/workspace/builds/root/lib/libCore.so -excludePath /Users/vvassilev/workspace/sources/root -excludePath /Users/vvassilev/workspace/builds/root -rml libCore.so -rmf /Users/vvassilev/workspace/builds/root/lib/libCore.rootmap -I/Users/vvassilev/workspace/sources/root -I/Users/vvassilev/workspace/builds/root/etc/cling/ -I/Users/vvassilev/workspace/builds/root/include -I/Users/vvassilev/workspace/sources/root/builtins/zlib -I/Users/vvassilev/workspace/sources/root/core/base/inc -I/Users/vvassilev/workspace/sources/root/core/clib/inc -I/Users/vvassilev/workspace/sources/root/core/cont/inc -I/Users/vvassilev/workspace/sources/root/core/foundation/inc -I/Users/vvassilev/workspace/sources/root/core/macosx/inc -I/Users/vvassilev/workspace/sources/root/core/unix/inc -I/Users/vvassilev/workspace/sources/root/core/winnt/inc -I/Users/vvassilev/workspace/sources/root/core/clingutils/inc -I/Users/vvassilev/workspace/sources/root/core/meta/inc -I/Users/vvassilev/workspace/sources/root/core/textinput/inc -I/Users/vvassilev/workspace/sources/root/core -writeEmptyRootPCM -DSYSTEM_TYPE_macosx ROOT/StringConv.hxx ROOT/TExecutor.hxx ROOT/TSequentialExecutor.hxx Buttons.h Bytes.h Byteswap.h Gtypes.h GuiTypes.h KeySymbols.h MessageTypes.h Riostream.h Rtypes.h TApplication.h TApplicationImp.h TAtt3D.h TAttAxis.h TAttBBox2D.h TAttBBox.h TAttFill.h TAttLine.h TAttMarker.h TAttPad.h TAttText.h TBase64.h TBenchmark.h TBrowser.h TBrowserImp.h TBuffer3D.h TBuffer3DTypes.h TBuffer.h TCanvasImp.h TColorGradient.h TColor.h TContextMenu.h TContextMenuImp.h TControlBarImp.h TDatime.h TDirectory.h TEnv.h TError.h TException.h TExec.h TFileCollection.h TFileInfo.h TFolder.h TGuiFactory.h TInetAddress.h TInspectorImp.h TMacro.h TMathBase.h TMD5.h TMemberInspector.h TMessageHandler.h TNamed.h TNotifyLink.h TObject.h TObjectSpy.h TObjString.h TParameter.h TPluginManager.h TPoint.h TPRegexp.h TProcessID.h TProcessUUID.h TQClass.h TQCommand.h TQConnection.h TQObject.h TRedirectOutputGuard.h TRefCnt.h TRef.h TRegexp.h TRemoteObject.h TROOT.h TRootIOCtor.h TStopwatch.h TStorage.h TString.h TStringLong.h TStyle.h TSysEvtHandler.h TSystemDirectory.h TSystemFile.h TSystem.h TTask.h TThreadSlots.h TTime.h TTimer.h TTimeStamp.h TUri.h TUrl.h TUUID.h TVersionCheck.h TVirtualAuth.h TVirtualFFT.h TVirtualGL.h TVirtualMonitoring.h TVirtualMutex.h TVirtualPadEditor.h TVirtualPad.h TVirtualPadPainter.h TVirtualPerfStats.h TVirtualPS.h TVirtualQConnection.h TVirtualRWMutex.h TVirtualTableInterface.h TVirtualViewer3D.h TVirtualX.h strlcpy.h snprintf.h ROOT/TSeq.hxx TArrayC.h TArrayD.h TArrayF.h TArray.h TArrayI.h TArrayL64.h TArrayL.h TArrayS.h TBits.h TBtree.h TClassTable.h TClonesArray.h TCollection.h TCollectionProxyInfo.h TExMap.h THashList.h THashTable.h TIterator.h TList.h TMap.h TObjArray.h TObjectTable.h TOrdCollection.h TRefArray.h TRefTable.h TSeqCollection.h TSortedList.h TVirtualCollectionProxy.h ESTLType.h RStringView.h TClassEdit.h ROOT/RIntegerSequence.hxx ROOT/RMakeUnique.hxx ROOT/RNotFn.hxx ROOT/RSpan.hxx ROOT/RStringView.hxx ROOT/span.hxx ROOT/TypeTraits.hxx TMacOSXSystem.h TUnixSystem.h root_std_complex.h TClingRuntime.h TBaseClass.h TClassGenerator.h TClass.h TClassMenuItem.h TClassRef.h TClassStreamer.h TDataMember.h TDataType.h TDictAttributeMap.h TDictionary.h TEnumConstant.h TEnum.h TFileMergeInfo.h TFunction.h TFunctionTemplate.h TGenericClassInfo.h TGlobal.h TInterpreter.h TInterpreterValue.h TIsAProxy.h TListOfDataMembers.h TListOfEnums.h TListOfEnumsWithLock.h TListOfFunctions.h TListOfFunctionTemplates.h TMemberStreamer.h TMethodArg.h TMethodCall.h TMethod.h TProtoClass.h TRealData.h TSchemaHelper.h TSchemaRule.h TSchemaRuleSet.h TStatusBitsChecker.h TStreamerElement.h TStreamer.h TToggleGroup.h TToggle.h TVirtualIsAProxy.h TVirtualRefProxy.h TVirtualStreamerInfo.h Getline.h /Users/vvassilev/workspace/sources/root/core/base/inc/LinkDef.h 
```
