### PR TITLE
[cxxmodules] Finish the revert in root-project/root@533dd5e50d7

### DIFF
--- a/interpreter/cling/include/cling/module.modulemap
+++ b/interpreter/cling/include/cling/module.modulemap
@@ -1,19 +1,3 @@
-// Only included at runtime.
-module Cling_Runtime {
-  module "RuntimeUniverse.h" { header "Interpreter/RuntimeUniverse.h" export * }
-  module "DynamicLookupRuntimeUniverse.h" { header "Interpreter/DynamicLookupRuntimeUniverse.h" export * }
-  module "RuntimePrintValue.h" { header "Interpreter/RuntimePrintValue.h" export * }
-  export *
-}
-
-// Included in both compile time and runtime.
-module Cling_Runtime_Extra {
-  module "DynamicExprInfo.h" { header "Interpreter/DynamicExprInfo.h" export * }
-  module "DynamicLookupLifetimeHandler.h" { header "Interpreter/DynamicLookupLifetimeHandler.h" export * }
-  module "Value.h" { header "Interpreter/Value.h" export * }
-  export *
-}
-
 module Cling_Interpreter {
   requires cplusplus
   umbrella "Interpreter"


### PR DESCRIPTION
Duplicating Cling_Runtime and Cling_Runtime_Extra in both module.modulemap
and module.modulemap.build causes redefinition errors if -Dbuiltin_clang=Off.
We should not duplicate the cling runtime modules in both modulemaps.