### PR TITLE
Revert "Reduced ExcludeModules by one"

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1296,8 +1296,8 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
          "ROOT_Foundation_Stage1_NoRTTI", "Core", "RIO"};
       // These modules contain global variables which conflict with users' code such as "PI".
       // FIXME: Reducing those will let us be less dependent on rootmap files
-      static constexpr std::array<const char*, 3> ExcludeModules =
-         { { "Rtools", "RSQLite", "RInterface"} }; 
+      static constexpr std::array<const char*, 4> ExcludeModules =
+         { { "Rtools", "RSQLite", "RInterface", "RMVA"} };
 
       LoadModules(CoreModules, *fInterpreter);
 


### PR DESCRIPTION
This reverts commit 3efc1356fcd48771c821314fab6c4427078480bd.

`/mnt/build/night/LABEL/ROOT-ubuntu18.04/SPEC/rtcxxmod/root/tutorials/hist/ContourList.C:23:19: error: expected unqualified-id
   const Double_t PI = TMath::Pi();
/usr/share/R/include/R_ext/Constants.h:36:24: note: expanded from macro 'PI'
#define PI             M_PI
/usr/include/math.h:777:16: note: expanded from macro M_PI
CMake Error at /mnt/build/night/LABEL/ROOT-ubuntu18.04/SPEC/rtcxxmod/root/cmake/modules/RootTestDriver.cmake:230 (message):
  error code: 1`