### PR TITLE
Attempt to fix a bug with cut order

### DIFF
--- a/tree/treeplayer/inc/TTreeFormula.h
+++ b/tree/treeplayer/inc/TTreeFormula.h
@@ -92,9 +92,9 @@ protected:
       Int_t fVirtAccumCache = 0;
    };
 
-   TTree       *fTree;            //! pointer to Tree
-   Int_t        fCodes[kMAXCODES]; //  List of leaf numbers referenced in formula
-   Int_t       fNdata[kMAXCODES]; //! This caches the physical number of element in the leaf or datamember.
+   TTree      *fTree;             //! pointer to Tree
+   Int_t       fCodes[kMAXCODES]; //  List of leaf numbers referenced in formula
+   Int_t       fNdata[kMAXCODES]; //! This caches the physical number of element in the leaf or data member.
    Int_t       fNcodes;           //  Number of leaves referenced in formula
    Bool_t      fHasCast;          //  Record whether the formula contain a cast operation or not
    Int_t       fMultiplicity;     //  Indicator of the variability of the formula
@@ -106,7 +106,7 @@ protected:
    TObjArray   fExternalCuts;     //!  List of TCutG and TEntryList used in the formula
    TObjArray   fAliases;          //!  List of TTreeFormula for each alias used.
    TObjArray   fLeafNames;        //   List of TNamed describing leaves
-   TObjArray   fBranches;         //!  List of branches to read.  Similar to fLeaces but duplicates are zeroed out.
+   TObjArray   fBranches;         //!  List of branches to read.  Similar to fLeaves but duplicates are zeroed out.
    Bool_t      fQuickLoad;        //!  If true, branch GetEntry is only called when the entry number changes.
    Bool_t      fNeedLoading;      //!  If true, the current entry has not been loaded yet.
 

--- a/tree/treeplayer/src/TTreeFormula.cxx
+++ b/tree/treeplayer/src/TTreeFormula.cxx
@@ -3979,6 +3979,10 @@ T TTreeFormula::EvalInstance(Int_t instance, const char *stringStackArg[])
             TCutG *gcut = (TCutG*)fExternalCuts.At(0);
             TTreeFormula *fx = (TTreeFormula *)gcut->GetObjectX();
             TTreeFormula *fy = (TTreeFormula *)gcut->GetObjectY();
+            if (fDidBooleanOptimization) {
+               fx->ResetLoading();
+               fy->ResetLoading();
+            }
             T xcut = fx->EvalInstance<T>(instance);
             T ycut = fy->EvalInstance<T>(instance);
             return gcut->IsInside(xcut,ycut);
@@ -3986,6 +3990,9 @@ T TTreeFormula::EvalInstance(Int_t instance, const char *stringStackArg[])
          case -1: {
             TCutG *gcut = (TCutG*)fExternalCuts.At(0);
             TTreeFormula *fx = (TTreeFormula *)gcut->GetObjectX();
+            if (fDidBooleanOptimization) {
+               fx->ResetLoading();
+            }
             return fx->EvalInstance<T>(instance);
          }
          default: return 0;
@@ -4240,6 +4247,10 @@ T TTreeFormula::EvalInstance(Int_t instance, const char *stringStackArg[])
                   TCutG *gcut = (TCutG*)fExternalCuts.At(code);
                   TTreeFormula *fx = (TTreeFormula *)gcut->GetObjectX();
                   TTreeFormula *fy = (TTreeFormula *)gcut->GetObjectY();
+                  if (fDidBooleanOptimization) {
+                     fx->ResetLoading();
+                     fy->ResetLoading();
+                  }
                   T xcut = fx->EvalInstance<T>(instance);
                   T ycut = fy->EvalInstance<T>(instance);
                   tab[pos++] = gcut->IsInside(xcut,ycut);
@@ -4248,6 +4259,9 @@ T TTreeFormula::EvalInstance(Int_t instance, const char *stringStackArg[])
                case -1: {
                   TCutG *gcut = (TCutG*)fExternalCuts.At(code);
                   TTreeFormula *fx = (TTreeFormula *)gcut->GetObjectX();
+                  if (fDidBooleanOptimization) {
+                     fx->ResetLoading();
+                  }
                   tab[pos++] = fx->EvalInstance<T>(instance);
                   continue;
                }
@@ -4943,6 +4957,13 @@ void TTreeFormula::ResetLoading()
       TTreeFormula *f = static_cast<TTreeFormula*>(fAliases.UncheckedAt(k));
       if (f) {
          f->ResetLoading();
+      }
+   }
+   for (int i=0; i<fExternalCuts.GetSize(); i++) {
+      auto c = dynamic_cast<TCutG*>(fExternalCuts.At(i));
+      if (c) {
+         ((TTreeFormula *)(c->GetObjectX()))->ResetLoading();
+         ((TTreeFormula *)(c->GetObjectY()))->ResetLoading();
       }
    }
 }


### PR DESCRIPTION
This pull request is a attempt to fix the problem described here:
https://root-forum.cern.ch/t/graphical-and-variable-cuts-in-ttree-draw/32862

When a selection including a graphical cut and and other cut is done on a tree having array variables, the selected entries depend in the order in which the graphical and the normal cut are done. The simplest macro showing the problem (using the root file attached to the forum) is:

```
{
   auto file = new TFile("ptmac.root");
   auto C = new TCanvas();
   C->Divide(2,1);

   TCutG *gcut = new TCutG("CUTG",5);
   gcut->SetVarX("z");
   gcut->SetVarY("theta");
   gcut->SetPoint(0,-30,2);
   gcut->SetPoint(1,-10,5);
   gcut->SetPoint(2,-5,40);
   gcut->SetPoint(3,-50,25);
   gcut->SetPoint(4,-30,2);


   C->cd(1); tree->Draw("z","z>-20 && CUTG","",10000);
   C->cd(2); tree->Draw("z","CUTG && z>-20","",10000);
}
```

without this fix the two plots are different whereas they should be the same. 

Not being an expert in that part of the ROOT code, I am not completely sure this fix is the best.