### PR TITLE
[cxxmodules] Optimize IsWrapper

### DIFF
--- a/interpreter/cling/lib/Utils/AST.cpp
+++ b/interpreter/cling/lib/Utils/AST.cpp
@@ -67,9 +67,10 @@ namespace utils {
   bool Analyze::IsWrapper(const FunctionDecl* ND) {
     if (!ND)
       return false;
+    if (!ND->getDeclName().isIdentifier())
+      return false;
 
-    return StringRef(ND->getNameAsString())
-      .startswith(Synthesize::UniquePrefix);
+    return ND->getName().startswith(Synthesize::UniquePrefix);
   }
 
   void Analyze::maybeMangleDeclName(const GlobalDecl& GD,


### PR DESCRIPTION
The getNameAsString interface causes a lot of temporary allocations.
The analysis if a decl is a cling-style wrapper can work only on a
simple declarations on the global scope.

This patch filters out complex declarations (eg in namespaces) and
checks only the identifier content.

The patch reduces the memory footprint difference shown in root-project/root#3012.