### PR TITLE
Possible fix to error and warning when using ROOT in pytest tests

### DIFF
--- a/bindings/pyroot/ROOT.py
+++ b/bindings/pyroot/ROOT.py
@@ -95,7 +95,7 @@ except:
 if sys.platform == 'darwin':
    import warnings
    warnings.filterwarnings( action='ignore', category=RuntimeWarning, module='ROOT',\
-      message='class \S* already in TClassTable$' )
+      message=r'class \S* already in TClassTable$' )
 
 ### load PyROOT C++ extension module, special case for linux and Sun ------------
 _root = cppyy._backend


### PR DESCRIPTION
While testing my packages which use PyROOT, I stumbled across a little problem with ROOT and pytest which I propose to fix.

Assume you have this very minimal (basically empty) python package:
```
.
├── setup.py
└── tests
    └── test_test.py

1 directory, 2 files
```
Content of `setup.py`:
```python
from setuptools import setup, find_packages

setup(
    name="root_cleanup_test",
    packages=find_packages(),
    setup_requires=["pytest-runner"],
    test_suite="tests",
)
```
Content of `test_test.py`
```
import unittest
import ROOT

class TestTest(unittest.TestCase):
    def test_test(self):
        pass
```

Now if you run the tests with `python setup.py pytest` which gives you the warning and error I attach to the bottom of this post. I think this is maybe related to some multithreading in the pytest runner. When you run the test alone with `pytest tests/test_test.py`, you won't get the error. My setup: ROOT 6.16/00 and Python 3.7.

Let me know if I can do anything else to test this! It would be great if pytest works smoothly with ROOT.

````
========== warnings summary ==========
/usr/lib/python3.7/site-packages/ROOT.py:98: DeprecationWarning: invalid escape sequence \S
  message='class \S* already in TClassTable$' )

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========== 1 passed, 1 warnings in 0.41 seconds ==========
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/ROOT.py", line 782, in cleanup
    facade = sys.modules[ __name__ ]
KeyError: "ROOT"