### PR TITLE
[Math] Suggest Math::LorentzVector instead of TLorentzVector

### DIFF
--- a/README/ReleaseNotes/v618/index.md
+++ b/README/ReleaseNotes/v618/index.md
@@ -109,7 +109,7 @@ Added necessary changes to allow [XRootD local redirection](https://github.com/x
 
 
 ## Math Libraries
-
+  - Add to the documentation of TLorentzVector a link to ROOT::Math::LorentzVector, which is a superior tool.
 
 ## RooFit Libraries
 ### HistFactory

--- a/math/genvector/inc/Math/GenVector/LorentzVector.h
+++ b/math/genvector/inc/Math/GenVector/LorentzVector.h
@@ -753,7 +753,18 @@ namespace ROOT {
 
 } // end namespace ROOT
 
+#include <sstream>
+namespace cling
+{
+template<typename CoordSystem>
+std::string printValue(const ROOT::Math::LorentzVector<CoordSystem> *v)
+{
+   std::stringstream s;
+   s << *v;
+   return s.str();
+}
 
+} // end namespace cling
 
 #endif
 

--- a/math/genvector/inc/Math/GenVector/PtEtaPhiE4D.h
+++ b/math/genvector/inc/Math/GenVector/PtEtaPhiE4D.h
@@ -324,7 +324,7 @@ public:
    }
    bool operator != (const PtEtaPhiE4D & rhs) const {return !(operator==(rhs));}
 
-   // ============= Compatibility secition ==================
+   // ============= Compatibility section ==================
 
    // The following make this coordinate system look enough like a CLHEP
    // vector that an assignment member template can work with either

--- a/math/genvector/inc/Math/GenVector/PtEtaPhiM4D.h
+++ b/math/genvector/inc/Math/GenVector/PtEtaPhiM4D.h
@@ -345,7 +345,7 @@ public:
    }
    bool operator != (const PtEtaPhiM4D & rhs) const {return !(operator==(rhs));}
 
-   // ============= Compatibility secition ==================
+   // ============= Compatibility section ==================
 
    // The following make this coordinate system look enough like a CLHEP
    // vector that an assignment member template can work with either

--- a/math/physics/src/TLorentzVector.cxx
+++ b/math/physics/src/TLorentzVector.cxx
@@ -9,14 +9,15 @@
     \ingroup Physics
 
 ## Disclaimer
-In order to represent 4-vectors, TLorentzVector shall not be used.
+TLorentzVector is a legacy class.
+It is slower and worse for serialization than the recommended superior ROOT::Math::LorentzVector.
 ROOT provides specialisations of the ROOT::Math::LorentzVector template which
 are superior from the runtime performance offered, i.e.:
-  - ROOT::Math::XYZTVector vector based on x,y,z,t coordinates (cartesian) in double precision
-  - ROOT::Math::XYZTVectorF vector based on x,y,z,t coordinates (cartesian) in float precision
-  - ROOT::Math::PtEtaPhiEVector vector based on pt (rho),eta,phi and E (t) coordinates in double precision
-  - ROOT::Math::PtEtaPhiMVector vector based on pt (rho),eta,phi and M (t) coordinates in double precision
-  - ROOT::Math::PxPyPzMVector vector based on px,py,pz and M (mass) coordinates in double precision
+  - ROOT::Math::PtEtaPhiMVector based on pt (rho),eta,phi and M (t) coordinates in double precision
+  - ROOT::Math::PtEtaPhiEVector based on pt (rho),eta,phi and E (t) coordinates in double precision
+  - ROOT::Math::PxPyPzMVector based on px,py,pz and M (mass) coordinates in double precision
+  - ROOT::Math::XYZTVector based on x,y,z,t coordinates (cartesian) in double precision
+  - ROOT::Math::XYZTVectorF based on x,y,z,t coordinates (cartesian) in float precision
 
 More details about the GenVector package can be found [here](Vector.html).
 

--- a/math/physics/src/TLorentzVector.cxx
+++ b/math/physics/src/TLorentzVector.cxx
@@ -5,9 +5,22 @@
 //    Oct 20 1999: dito in Double_t operator()
 //    Jan 25 2000: implemented as (fP,fE) instead of (fX,fY,fZ,fE)
 
-
 /** \class TLorentzVector
     \ingroup Physics
+
+## Disclaimer
+In order to represent 4-vectors, TLorentzVector shall not be used.
+ROOT provides specialisations of the ROOT::Math::LorentzVector template which
+are superior from the runtime performance offered, i.e.:
+  - ROOT::Math::XYZTVector vector based on x,y,z,t coordinates (cartesian) in double precision
+  - ROOT::Math::XYZTVectorF vector based on x,y,z,t coordinates (cartesian) in float precision
+  - ROOT::Math::PtEtaPhiEVector vector based on pt (rho),eta,phi and E (t) coordinates in double precision
+  - ROOT::Math::PtEtaPhiMVector vector based on pt (rho),eta,phi and M (t) coordinates in double precision
+  - ROOT::Math::PxPyPzMVector vector based on px,py,pz and M (mass) coordinates in double precision
+
+More details about the GenVector package can be found [here](Vector.html).
+
+### Description
 TLorentzVector is a general four-vector class, which can be used
 either for the description of position and time (x,y,z,t) or momentum and
 energy (px,py,pz,E).

--- a/tutorials/dataframe/df102_NanoAODDimuonAnalysis.C
+++ b/tutorials/dataframe/df102_NanoAODDimuonAnalysis.C
@@ -26,7 +26,7 @@
 #include "TCanvas.h"
 #include "TH1D.h"
 #include "TLatex.h"
-#include "TLorentzVector.h"
+#include "Math/Vector4Dfwd.h"
 #include "TStyle.h"
 
 using namespace ROOT::VecOps;
@@ -48,9 +48,8 @@ void df102_NanoAODDimuonAnalysis()
    // Compute invariant mass of the dimuon system
    auto compute_mass = [](RVec<float> &pt, RVec<float> &eta, RVec<float> &phi, RVec<float> &mass) {
       // Compose four-vectors of both muons
-      TLorentzVector p1, p2;
-      p1.SetPtEtaPhiM(pt[0], eta[0], phi[0], mass[0]);
-      p2.SetPtEtaPhiM(pt[1], eta[1], phi[1], mass[1]);
+      ROOT::Math::PtEtaPhiMVector p1(pt[0], eta[0], phi[0], mass[0]);
+      ROOT::Math::PtEtaPhiMVector p2(pt[1], eta[1], phi[1], mass[1]);
 
       // Add four-vectors to build dimuon system and return the invariant mass
       return (p1 + p2).M();

--- a/tutorials/dataframe/df102_NanoAODDimuonAnalysis.C
+++ b/tutorials/dataframe/df102_NanoAODDimuonAnalysis.C
@@ -26,7 +26,7 @@
 #include "TCanvas.h"
 #include "TH1D.h"
 #include "TLatex.h"
-#include "Math/Vector4Dfwd.h"
+#include "Math/Vector4D.h"
 #include "TStyle.h"
 
 using namespace ROOT::VecOps;

--- a/tutorials/dataframe/df103_NanoAODHiggsAnalysis.C
+++ b/tutorials/dataframe/df103_NanoAODHiggsAnalysis.C
@@ -35,7 +35,7 @@
 #include "TH1D.h"
 #include "TLatex.h"
 #include "TLegend.h"
-#include "TLorentzVector.h"
+#include "Math/Vector4Dfwd.h"
 #include "TStyle.h"
 
 using namespace ROOT::VecOps;
@@ -135,9 +135,8 @@ RVec<RVec<size_t>> reco_zz_to_4l(rvec_f pt, rvec_f eta, rvec_f phi, rvec_f mass,
       const auto i1 = idx_cmb[0][i];
       const auto i2 = idx_cmb[1][i];
       if (charge[i1] != charge[i2]) {
-         TLorentzVector p1, p2;
-         p1.SetPtEtaPhiM(pt[i1], eta[i1], phi[i1], mass[i1]);
-         p2.SetPtEtaPhiM(pt[i2], eta[i2], phi[i2], mass[i2]);
+         ROOT::Math::PtEtaPhiMVector p1(pt[i1], eta[i1], phi[i1], mass[i1]);
+         ROOT::Math::PtEtaPhiMVector p2(pt[i2], eta[i2], phi[i2], mass[i2]);
          const auto this_mass = (p1 + p2).M();
          if (std::abs(z_mass - this_mass) < std::abs(z_mass - best_mass)) {
             best_mass = this_mass;
@@ -165,10 +164,9 @@ RVec<float> compute_z_masses_4l(const RVec<RVec<size_t>> &idx, rvec_f pt, rvec_f
 {
    RVec<float> z_masses(2);
    for (size_t i = 0; i < 2; i++) {
-      TLorentzVector p1, p2;
       const auto i1 = idx[i][0]; const auto i2 = idx[i][1];
-      p1.SetPtEtaPhiM(pt[i1], eta[i1], phi[i1], mass[i1]);
-      p2.SetPtEtaPhiM(pt[i2], eta[i2], phi[i2], mass[i2]);
+      ROOT::Math::PtEtaPhiMVector p1(pt[i1], eta[i1], phi[i1], mass[i1]);
+      ROOT::Math::PtEtaPhiMVector p2(pt[i2], eta[i2], phi[i2], mass[i2]);
       z_masses[i] = (p1 + p2).M();
    }
    if (std::abs(z_masses[0] - z_mass) < std::abs(z_masses[1] - z_mass)) {
@@ -181,13 +179,12 @@ RVec<float> compute_z_masses_4l(const RVec<RVec<size_t>> &idx, rvec_f pt, rvec_f
 // Compute mass of Higgs from four leptons of the same kind
 float compute_higgs_mass_4l(const RVec<RVec<size_t>> &idx, rvec_f pt, rvec_f eta, rvec_f phi, rvec_f mass)
 {
-   TLorentzVector p1, p2, p3, p4;
    const auto i1 = idx[0][0]; const auto i2 = idx[0][1];
    const auto i3 = idx[1][0]; const auto i4 = idx[1][1];
-   p1.SetPtEtaPhiM(pt[i1], eta[i1], phi[i1], mass[i1]);
-   p2.SetPtEtaPhiM(pt[i2], eta[i2], phi[i2], mass[i2]);
-   p3.SetPtEtaPhiM(pt[i3], eta[i3], phi[i3], mass[i3]);
-   p4.SetPtEtaPhiM(pt[i4], eta[i4], phi[i4], mass[i4]);
+   ROOT::Math::PtEtaPhiMVector p1(pt[i1], eta[i1], phi[i1], mass[i1]);
+   ROOT::Math::PtEtaPhiMVector p2(pt[i2], eta[i2], phi[i2], mass[i2]);
+   ROOT::Math::PtEtaPhiMVector p3(pt[i3], eta[i3], phi[i3], mass[i3]);
+   ROOT::Math::PtEtaPhiMVector p4(pt[i4], eta[i4], phi[i4], mass[i4]);
    return (p1 + p2 + p3 + p4).M();
 }
 
@@ -281,11 +278,10 @@ RNode reco_higgs_to_4el(RNode df)
 RVec<float> compute_z_masses_2el2mu(rvec_f el_pt, rvec_f el_eta, rvec_f el_phi, rvec_f el_mass, rvec_f mu_pt,
                                   rvec_f mu_eta, rvec_f mu_phi, rvec_f mu_mass)
 {
-   TLorentzVector p1, p2, p3, p4;
-   p1.SetPtEtaPhiM(mu_pt[0], mu_eta[0], mu_phi[0], mu_mass[0]);
-   p2.SetPtEtaPhiM(mu_pt[1], mu_eta[1], mu_phi[1], mu_mass[1]);
-   p3.SetPtEtaPhiM(el_pt[0], el_eta[0], el_phi[0], el_mass[0]);
-   p4.SetPtEtaPhiM(el_pt[1], el_eta[1], el_phi[1], el_mass[1]);
+   ROOT::Math::PtEtaPhiMVector p1(mu_pt[0], mu_eta[0], mu_phi[0], mu_mass[0]);
+   ROOT::Math::PtEtaPhiMVector p2(mu_pt[1], mu_eta[1], mu_phi[1], mu_mass[1]);
+   ROOT::Math::PtEtaPhiMVector p3(el_pt[0], el_eta[0], el_phi[0], el_mass[0]);
+   ROOT::Math::PtEtaPhiMVector p4(el_pt[1], el_eta[1], el_phi[1], el_mass[1]);
    auto mu_z = (p1 + p2).M();
    auto el_z = (p3 + p4).M();
    RVec<float> z_masses(2);
@@ -303,11 +299,10 @@ RVec<float> compute_z_masses_2el2mu(rvec_f el_pt, rvec_f el_eta, rvec_f el_phi, 
 float compute_higgs_mass_2el2mu(rvec_f el_pt, rvec_f el_eta, rvec_f el_phi, rvec_f el_mass, rvec_f mu_pt, rvec_f mu_eta,
                                 rvec_f mu_phi, rvec_f mu_mass)
 {
-   TLorentzVector p1, p2, p3, p4;
-   p1.SetPtEtaPhiM(mu_pt[0], mu_eta[0], mu_phi[0], mu_mass[0]);
-   p2.SetPtEtaPhiM(mu_pt[1], mu_eta[1], mu_phi[1], mu_mass[1]);
-   p3.SetPtEtaPhiM(el_pt[0], el_eta[0], el_phi[0], el_mass[0]);
-   p4.SetPtEtaPhiM(el_pt[1], el_eta[1], el_phi[1], el_mass[1]);
+   ROOT::Math::PtEtaPhiMVector p1(mu_pt[0], mu_eta[0], mu_phi[0], mu_mass[0]);
+   ROOT::Math::PtEtaPhiMVector p2(mu_pt[1], mu_eta[1], mu_phi[1], mu_mass[1]);
+   ROOT::Math::PtEtaPhiMVector p3(el_pt[0], el_eta[0], el_phi[0], el_mass[0]);
+   ROOT::Math::PtEtaPhiMVector p4(el_pt[1], el_eta[1], el_phi[1], el_mass[1]);
    return (p1 + p2 + p3 + p4).M();
 }
 


### PR DESCRIPTION
this commit suggests to prefer the usage of ROOT::Math::TLorentzVector
specialisations instead of the TLorentzVector class given the
advantages of the former.
- Release notes are changes
- The documentation of TLorentzVector updated to point to the specialisations of ROOT::Math::TLorentzVector
- The RDF tutorials using TLorentzVector upgraded