### PR TITLE
Revert changes in cling module.modulemap

### DIFF
--- a/interpreter/cling/include/cling/module.modulemap
+++ b/interpreter/cling/include/cling/module.modulemap
@@ -1,3 +1,19 @@
+// Only included at runtime.
+module Cling_Runtime {
+  module "RuntimeUniverse.h" { header "Interpreter/RuntimeUniverse.h" export * }
+  module "DynamicLookupRuntimeUniverse.h" { header "Interpreter/DynamicLookupRuntimeUniverse.h" export * }
+  module "RuntimePrintValue.h" { header "Interpreter/RuntimePrintValue.h" export * }
+  export *
+}
+
+// Included in both compile time and runtime.
+module Cling_Runtime_Extra {
+  module "DynamicExprInfo.h" { header "Interpreter/DynamicExprInfo.h" export * }
+  module "DynamicLookupLifetimeHandler.h" { header "Interpreter/DynamicLookupLifetimeHandler.h" export * }
+  module "Value.h" { header "Interpreter/Value.h" export * }
+  export *
+}
+
 module Cling_Interpreter {
   requires cplusplus
   umbrella "Interpreter"


### PR DESCRIPTION
This reverts commit 3854aa142b82202d36d066ad9ce80f57a00f8276.
It fixes:
"While building module 'Cling_Interpreter' imported from /.../root/core/metacling/src/TClingCallbacks.h:12:
In file included from <module-includes>:11:

/.../root/interpreter/cling/include/cling/Interpreter/DynamicLookupRuntimeUniverse.h:13:2: error: "This file must not be included by compiled programs."

 ^
While building module 'Cling_Interpreter' imported from /.../root/core/metacling/src/TClingCallbacks.h:12:
In file included from <module-includes>:17:"