### PR TITLE
Missing lines from modulemap from previous revert

### DIFF
--- a/interpreter/cling/include/cling/module.modulemap
+++ b/interpreter/cling/include/cling/module.modulemap
@@ -4,6 +4,11 @@ module Cling_Interpreter {
 
   textual header "Interpreter/ClingOptions.inc"
 
+  // Only included at runtime.
+  exclude header "Interpreter/RuntimeUniverse.h"
+  exclude header "Interpreter/DynamicLookupRuntimeUniverse.h"
+  exclude header "Interpreter/RuntimePrintValue.h"
+
   module * { export * }
 }
 


### PR DESCRIPTION
From V.Vasilev, it fixes:
[ 72%] Building CXX object interpreter/llvm/src/tools/clang/lib/CodeGen/CMakeFiles/clangCodeGen.dir/CodeGenModule.cpp.o
While building module 'Cling_Interpreter' imported from /.../root/core/clingutils/src/RStl.cxx:25:
In file included from <module-includes>:5:
 /.../root/interpreter/cling/include/cling/Interpreter/RuntimeUniverse.h:13:2: error: "This file must not be included by compiled programs."
 #error "This file must not be included by compiled programs."
 ^