### PR TITLE
[ROOT-9707][DF] Defer declaration of type aliases to the interpreter until right before the event loop

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/GraphUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/GraphUtils.hxx
@@ -122,7 +122,7 @@ private:
    {
       auto loopManager = rInterface.GetLoopManager();
       if (!loopManager->fToJitExec.empty())
-         loopManager->BuildJittedNodes();
+         loopManager->Jit();
 
       return FromGraphLeafToDot(rInterface.GetProxiedPtr()->GetGraph());
    }
@@ -141,7 +141,7 @@ private:
       }
 
       if (!loopManager->fToJitExec.empty())
-         loopManager->BuildJittedNodes();
+         loopManager->Jit();
 
       auto actionPtr = resultPtr.fActionPtr;
       return FromGraphLeafToDot(actionPtr->GetGraph());

--- a/tree/dataframe/inc/ROOT/RDF/GraphUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/GraphUtils.hxx
@@ -121,7 +121,7 @@ private:
    std::string RepresentGraph(RInterface<Proxied, DataSource> &rInterface)
    {
       auto loopManager = rInterface.GetLoopManager();
-      if (!loopManager->fToJit.empty())
+      if (!loopManager->fToJitExec.empty())
          loopManager->BuildJittedNodes();
 
       return FromGraphLeafToDot(rInterface.GetProxiedPtr()->GetGraph());
@@ -140,7 +140,7 @@ private:
          return RepresentGraph(loopManager);
       }
 
-      if (!loopManager->fToJit.empty())
+      if (!loopManager->fToJitExec.empty())
          loopManager->BuildJittedNodes();
 
       auto actionPtr = resultPtr.fActionPtr;

--- a/tree/dataframe/inc/ROOT/RDF/GraphUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/GraphUtils.hxx
@@ -121,8 +121,7 @@ private:
    std::string RepresentGraph(RInterface<Proxied, DataSource> &rInterface)
    {
       auto loopManager = rInterface.GetLoopManager();
-      if (!loopManager->fToJitExec.empty())
-         loopManager->Jit();
+      loopManager->Jit();
 
       return FromGraphLeafToDot(rInterface.GetProxiedPtr()->GetGraph());
    }
@@ -140,8 +139,7 @@ private:
          return RepresentGraph(loopManager);
       }
 
-      if (!loopManager->fToJitExec.empty())
-         loopManager->Jit();
+      loopManager->Jit();
 
       auto actionPtr = resultPtr.fActionPtr;
       return FromGraphLeafToDot(actionPtr->GetGraph());

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -110,7 +110,8 @@ class RLoopManager : public RNodeBase {
    const unsigned int fNSlots{1};
    bool fMustRunNamedFilters{true};
    const ELoopType fLoopType; ///< The kind of event loop that is going to be run (e.g. on ROOT files, on no files)
-   std::string fToJit;        ///< code that should be jitted and executed right before the event loop
+   std::string fToJitDeclare; ///< Code that should be just-in-time declared right before the event loop
+   std::string fToJitExec;    ///< Code that should be just-in-time executed right before the event loop
    const std::unique_ptr<RDataSource> fDataSource; ///< Owning pointer to a data-source object. Null if no data-source
    std::map<std::string, std::string> fAliasColumnNameMap; ///< ColumnNameAlias-columnName pairs
    std::vector<TCallback> fCallbacks;                      ///< Registered callbacks
@@ -144,6 +145,7 @@ public:
    RLoopManager(const RLoopManager &) = delete;
    RLoopManager &operator=(const RLoopManager &) = delete;
 
+   void JitDeclarations();
    void BuildJittedNodes();
    RLoopManager *GetLoopManagerUnchecked() final { return this; }
    void Run();
@@ -167,7 +169,8 @@ public:
    void SetTree(const std::shared_ptr<TTree> &tree) { fTree = tree; }
    void IncrChildrenCount() final { ++fNChildren; }
    void StopProcessing() final { ++fNStopsReceived; }
-   void ToJit(const std::string &s) { fToJit.append(s); }
+   void ToJitDeclare(const std::string &s) { fToJitDeclare.append(s); }
+   void ToJitExec(const std::string &s) { fToJitExec.append(s); }
    void AddColumnAlias(const std::string &alias, const std::string &colName) { fAliasColumnNameMap[alias] = colName; }
    const std::map<std::string, std::string> &GetAliasMap() const { return fAliasColumnNameMap; }
    void RegisterCallback(ULong64_t everyNEvents, std::function<void(unsigned int)> &&f);

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -146,7 +146,7 @@ public:
    RLoopManager &operator=(const RLoopManager &) = delete;
 
    void JitDeclarations();
-   void BuildJittedNodes();
+   void Jit();
    RLoopManager *GetLoopManagerUnchecked() final { return this; }
    void Run();
    const ColumnNames_t &GetDefaultColumnNames() const;

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -162,7 +162,6 @@ public:
    void Deregister(RRangeBase *rangePtr);
    bool CheckFilters(unsigned int, Long64_t) final;
    unsigned int GetNSlots() const { return fNSlots; }
-   bool MustRunNamedFilters() const { return fMustRunNamedFilters; }
    void Report(ROOT::RDF::RCutFlowReport &rep) const final;
    /// End of recursive chain of calls, does nothing
    void PartialReport(ROOT::RDF::RCutFlowReport &) const final {}

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -54,7 +54,6 @@ class RRangeBase;
 /// The head node of a RDF computation graph.
 /// This class is responsible of running the event loop.
 class RLoopManager : public RNodeBase {
-   friend class ROOT::Internal::RDF::GraphDrawing::GraphCreatorHelper;
    using RDataSource = ROOT::RDF::RDataSource;
    enum class ELoopType { kROOTFiles, kROOTFilesMT, kNoFiles, kNoFilesMT, kDataSource, kDataSourceMT };
    using Callback_t = std::function<void(unsigned int)>;

--- a/tree/dataframe/src/RDFGraphUtils.cxx
+++ b/tree/dataframe/src/RDFGraphUtils.cxx
@@ -59,7 +59,7 @@ std::string GraphCreatorHelper::RepresentGraph(ROOT::RDataFrame &rDataFrame)
    auto loopManager = rDataFrame.GetLoopManager();
    // Jitting is triggered because nodes must not be empty at the time of the calling in order to draw the graph.
    if (!loopManager->fToJitExec.empty())
-      loopManager->BuildJittedNodes();
+      loopManager->Jit();
 
    return RepresentGraph(loopManager);
 }

--- a/tree/dataframe/src/RDFGraphUtils.cxx
+++ b/tree/dataframe/src/RDFGraphUtils.cxx
@@ -58,8 +58,7 @@ std::string GraphCreatorHelper::RepresentGraph(ROOT::RDataFrame &rDataFrame)
 {
    auto loopManager = rDataFrame.GetLoopManager();
    // Jitting is triggered because nodes must not be empty at the time of the calling in order to draw the graph.
-   if (!loopManager->fToJitExec.empty())
-      loopManager->Jit();
+   loopManager->Jit();
 
    return RepresentGraph(loopManager);
 }

--- a/tree/dataframe/src/RDFGraphUtils.cxx
+++ b/tree/dataframe/src/RDFGraphUtils.cxx
@@ -58,7 +58,7 @@ std::string GraphCreatorHelper::RepresentGraph(ROOT::RDataFrame &rDataFrame)
 {
    auto loopManager = rDataFrame.GetLoopManager();
    // Jitting is triggered because nodes must not be empty at the time of the calling in order to draw the graph.
-   if (!loopManager->fToJit.empty())
+   if (!loopManager->fToJitExec.empty())
       loopManager->BuildJittedNodes();
 
    return RepresentGraph(loopManager);

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -118,11 +118,6 @@ std::set<std::string> GetPotentialColumnNames(const std::string &expr)
 // the one in the vector
 class RActionBase;
 
-bool InterpreterDeclare(const std::string &code)
-{
-   return gInterpreter->Declare(code.c_str());
-}
-
 std::pair<Long64_t, int> InterpreterCalc(const std::string &code)
 {
    TInterpreter::EErrorCode errorCode(TInterpreter::kNoError);

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -626,6 +626,8 @@ void BookFilterJit(RJittedFilter *jittedFilter, void *prevNodeOnHeap, std::strin
    Ssiz_t matchedLen;
    const bool hasReturnStmt = re.Index(dotlessExpr, &matchedLen) != -1;
 
+   auto lm = jittedFilter->GetLoopManagerUnchecked();
+   lm->JitDeclarations(); // TryToJitExpression might need some of the Define'd column type aliases
    TryToJitExpression(dotlessExpr, varNames, usedColTypes, hasReturnStmt);
 
    const auto filterLambda = BuildLambdaString(dotlessExpr, varNames, usedColTypes, hasReturnStmt);
@@ -655,7 +657,7 @@ void BookFilterJit(RJittedFilter *jittedFilter, void *prevNodeOnHeap, std::strin
                     << "reinterpret_cast<ROOT::Internal::RDF::RBookedCustomColumns*>(" << columnsOnHeapAddr << ")"
                     << ");";
 
-   jittedFilter->GetLoopManagerUnchecked()->ToJit(filterInvocation.str());
+   lm->ToJitExec(filterInvocation.str());
 }
 
 // Jit a Define call
@@ -679,6 +681,7 @@ void BookDefineJit(std::string_view name, std::string_view expression, RLoopMana
    Ssiz_t matchedLen;
    const bool hasReturnStmt = re.Index(dotlessExpr, &matchedLen) != -1;
 
+   lm.JitDeclarations(); // TryToJitExpression might need some of the Define'd column type aliases
    TryToJitExpression(dotlessExpr, varNames, usedColTypes, hasReturnStmt);
 
    const auto definelambda = BuildLambdaString(dotlessExpr, varNames, usedColTypes, hasReturnStmt);
@@ -695,7 +698,7 @@ void BookDefineJit(std::string_view name, std::string_view expression, RLoopMana
    const auto defineDeclaration =
       "namespace " + ns + " { auto " + lambdaName + " = " + definelambda + ";\n" + "using " + std::string(name) +
       customColID + "_type = typename ROOT::TypeTraits::CallableTraits<decltype(" + lambdaName + " )>::ret_type;  }\n";
-   gInterpreter->Declare(defineDeclaration.c_str());
+   lm.ToJitDeclare(defineDeclaration);
 
    std::stringstream defineInvocation;
    defineInvocation << "ROOT::Internal::RDF::JitDefineHelper(" << definelambda << ", {";
@@ -713,7 +716,7 @@ void BookDefineJit(std::string_view name, std::string_view expression, RLoopMana
                     << "reinterpret_cast<ROOT::Internal::RDF::RBookedCustomColumns*>(" << customColumnsAddr << ")"
                     << ");";
 
-   lm.ToJit(defineInvocation.str());
+   lm.ToJitExec(defineInvocation.str());
 }
 
 // Jit and call something equivalent to "this->BuildAndBook<BranchTypes...>(params...)"

--- a/tree/dataframe/src/RJittedFilter.cxx
+++ b/tree/dataframe/src/RJittedFilter.cxx
@@ -105,7 +105,7 @@ void RJittedFilter::AddFilterName(std::vector<std::string> &filters)
 {
    if (fConcreteFilter == nullptr) {
       // No event loop performed yet, but the JITTING must be performed.
-      GetLoopManagerUnchecked()->BuildJittedNodes();
+      GetLoopManagerUnchecked()->Jit();
    }
    fConcreteFilter->AddFilterName(filters);
 }

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -434,7 +434,7 @@ void RLoopManager::JitDeclarations()
 
 /// Add RDF nodes that require just-in-time compilation to the computation graph.
 /// This method also invokes JitDeclarations() if needed, and clears the `fToJitExec` member variable.
-void RLoopManager::BuildJittedNodes()
+void RLoopManager::Jit()
 {
    JitDeclarations();
 
@@ -474,7 +474,7 @@ unsigned int RLoopManager::GetNextID()
 void RLoopManager::Run()
 {
    if (!fToJitExec.empty())
-      BuildJittedNodes();
+      Jit();
 
    InitNodes();
 

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -428,6 +428,9 @@ void RLoopManager::CleanUpTask(unsigned int slot)
 /// This method clears the `fToJitDeclare` member variable.
 void RLoopManager::JitDeclarations()
 {
+   if (fToJitDeclare.empty())
+      return;
+
    gInterpreter->Declare(fToJitDeclare.c_str());
    fToJitDeclare.clear();
 }
@@ -436,6 +439,9 @@ void RLoopManager::JitDeclarations()
 /// This method also invokes JitDeclarations() if needed, and clears the `fToJitExec` member variable.
 void RLoopManager::Jit()
 {
+   if (fToJitExec.empty())
+      return;
+
    JitDeclarations();
 
    auto error = TInterpreter::EErrorCode::kNoError;
@@ -473,8 +479,7 @@ unsigned int RLoopManager::GetNextID()
 /// Also perform a few setup and clean-up operations (jit actions if necessary, clear booked actions after the loop...).
 void RLoopManager::Run()
 {
-   if (!fToJitExec.empty())
-      Jit();
+   Jit();
 
    InitNodes();
 

--- a/tree/dataframe/test/dataframe_nodes.cxx
+++ b/tree/dataframe/test/dataframe_nodes.cxx
@@ -49,7 +49,7 @@ TEST(RDataFrameNodes, RLoopManagerGetLoopManagerUnchecked)
 TEST(RDataFrameNodes, RLoopManagerJit)
 {
    ROOT::Detail::RDF::RLoopManager lm(nullptr, {});
-   lm.ToJit("souble d = 3.14");
+   lm.ToJitExec("souble d = 3.14");
    int ret(1);
    try {
       testing::internal::CaptureStderr();


### PR DESCRIPTION
~~This PR should turn green when [ROOT-9790](https://sft.its.cern.ch/jira/browse/ROOT-9790) is resolved.~~ A temporary workaround for greedy jitting of `Cache` and `Snapshot` has been added.