### PR TITLE
[TTree] Call GetEntriesUnsafe instead of GetEntriesFast when possible

### DIFF
--- a/core/cont/inc/TObjArray.h
+++ b/core/cont/inc/TObjArray.h
@@ -64,6 +64,7 @@ public:
    Int_t            GetEntriesFast() const {
       return GetAbsLast() + 1;   //only OK when no gaps
    }
+   Int_t            GetEntriesUnsafe() const;
    Int_t            GetLast() const;
    TObject        **GetObjectRef() const { return fCont; };
    TObject        **GetObjectRef(const TObject *obj) const;

--- a/core/cont/src/TObjArray.cxx
+++ b/core/cont/src/TObjArray.cxx
@@ -555,6 +555,19 @@ Int_t TObjArray::GetAbsLast() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Return the number of objects in array (i.e. number of non-empty slots).
+/// This is a thread-unsafe version of GetEntriesFast. Use it only if sure
+/// it will not be invoked concurrently.
+
+Int_t TObjArray::GetEntriesUnsafe() const
+{
+   if (R__unlikely(fLast == -2))
+      return GetEntriesFast();
+   else
+      return fLast + 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Return index of last object in array. Returns lowerBound-1 in case
 /// array is empty.
 

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -5415,7 +5415,7 @@ Int_t TTree::GetEntry(Long64_t entry, Int_t getall)
    if (fCacheDoAutoInit)
       SetCacheSizeAux();
 
-   Int_t nbranches = fBranches.GetEntriesFast();
+   Int_t nbranches = fBranches.GetEntriesUnsafe();
    Int_t nb=0;
 
    auto seqprocessing = [&]() {


### PR DESCRIPTION
`GetEntriesFast` is not as fast as it could be: it constructs and
destructs a `TReadLockGuard`, and might need to modify `TObjArray::fLast`.
This PR introduced `GetEntriesUnsafe`, a thread-unsafe version of `GetEntriesFast`
that side-steps these operations when possible.

Measurements for the benchmarks in the `philippe` branch of the [df_bench](https://gitlab.com/bluehood/df_bench) repository:

With `GetEntriesFast`:
```
-----------------------------------------------------------------------------------
Benchmark                                         Time             CPU   Iterations
-----------------------------------------------------------------------------------
TreeGetEntryOneBranch                        192943 ns       192939 ns         3664
TreeGetEntryTwoBranchesAndAllStatusFalse     110524 ns       110521 ns         6433
TreeGetEntryTwoBranches                      195864 ns       195859 ns         3430
TreeGetEntryTwoBranchesWithoutSetStatus      317772 ns       317761 ns         2095
BranchGetEntryOneBranch                      103652 ns       103650 ns         6730
BranchGetEntryTwoBranches                    104072 ns       104070 ns         6707
```

With `GetEntriesUnsafe`:
```
-----------------------------------------------------------------------------------
Benchmark                                         Time             CPU   Iterations
-----------------------------------------------------------------------------------
TreeGetEntryOneBranch                        152708 ns       152690 ns         4579
TreeGetEntryTwoBranchesAndAllStatusFalse      91277 ns        91274 ns         7731
TreeGetEntryTwoBranches                      173940 ns       173922 ns         4024
TreeGetEntryTwoBranchesWithoutSetStatus      279271 ns       279261 ns         2514
BranchGetEntryOneBranch                      104515 ns       104503 ns         6721
BranchGetEntryTwoBranches                    104180 ns       104177 ns         6652
```