### PR TITLE
Fixes the redefinition symbol error for 'Point' for cxxmodules(macosx)

### DIFF
--- a/test/testGenVectorVc.cxx
+++ b/test/testGenVectorVc.cxx
@@ -49,7 +49,7 @@ int compare(double x, double y, double tolerance = 1.0e-12)
       std::cerr.precision(pr);
       return 1;
    }
-   
+
    return 0;
 }
 
@@ -191,7 +191,7 @@ inline typename FTYPE::mask_type reflectPlane(POINT &position, VECTOR &direction
 }
 
 template <typename T>
-using Point = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<T>, ROOT::Math::DefaultCoordinateSystemTag>;
+using PositionVector = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<T>, ROOT::Math::DefaultCoordinateSystemTag>;
 template <typename T>
 using Vector = ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<T>, ROOT::Math::DefaultCoordinateSystemTag>;
 template <typename T>
@@ -207,10 +207,10 @@ int main(int /*argc*/, char ** /*argv*/)
       std::cout << "Creating " << nPhotons << " random photons ..." << std::endl;
 
       // Scalar Types
-      Data<Point<double>, Vector<double>, Plane<double>, double>::Vector scalar_data(nPhotons);
+      Data<PositionVector<double>, Vector<double>, Plane<double>, double>::Vector scalar_data(nPhotons);
 
       // Vc Types
-      Data<Point<Vc::double_v>, Vector<Vc::double_v>, Plane<Vc::double_v>, Vc::double_v>::Vector vc_data;
+      Data<PositionVector<Vc::double_v>, Vector<Vc::double_v>, Plane<Vc::double_v>, Vc::double_v>::Vector vc_data;
       // Clone the exact random values from the Scalar vector
       // Note we are making the same number of entries in the container, but each entry is a vector entry
       // with Vc::double_t::Size entries.
@@ -248,20 +248,20 @@ int main(int /*argc*/, char ** /*argv*/)
          auto &sc = scalar_data[i];
          auto &vc = vc_data[i];
 
-         // make 6 random scalar Points
-         Point<double> sp1(p_x(gen), p_y(gen), p_z(gen));
-         Point<double> sp2(p_x(gen), p_y(gen), p_z(gen));
-         Point<double> sp3(p_x(gen), p_y(gen), p_z(gen));
-         Point<double> sp4(p_x(gen), p_y(gen), p_z(gen));
-         Point<double> sp5(p_x(gen), p_y(gen), p_z(gen));
-         Point<double> sp6(p_x(gen), p_y(gen), p_z(gen));
+         // make 6 random scalar PositionVectors
+         PositionVector<double> sp1(p_x(gen), p_y(gen), p_z(gen));
+         PositionVector<double> sp2(p_x(gen), p_y(gen), p_z(gen));
+         PositionVector<double> sp3(p_x(gen), p_y(gen), p_z(gen));
+         PositionVector<double> sp4(p_x(gen), p_y(gen), p_z(gen));
+         PositionVector<double> sp5(p_x(gen), p_y(gen), p_z(gen));
+         PositionVector<double> sp6(p_x(gen), p_y(gen), p_z(gen));
          // clone to Vc versions
-         Point<Vc::double_v> vp1(sp1.x(), sp1.y(), sp1.z());
-         Point<Vc::double_v> vp2(sp2.x(), sp2.y(), sp2.z());
-         Point<Vc::double_v> vp3(sp3.x(), sp3.y(), sp3.z());
-         Point<Vc::double_v> vp4(sp4.x(), sp4.y(), sp4.z());
-         Point<Vc::double_v> vp5(sp5.x(), sp5.y(), sp5.z());
-         Point<Vc::double_v> vp6(sp6.x(), sp6.y(), sp6.z());
+         PositionVector<Vc::double_v> vp1(sp1.x(), sp1.y(), sp1.z());
+         PositionVector<Vc::double_v> vp2(sp2.x(), sp2.y(), sp2.z());
+         PositionVector<Vc::double_v> vp3(sp3.x(), sp3.y(), sp3.z());
+         PositionVector<Vc::double_v> vp4(sp4.x(), sp4.y(), sp4.z());
+         PositionVector<Vc::double_v> vp5(sp5.x(), sp5.y(), sp5.z());
+         PositionVector<Vc::double_v> vp6(sp6.x(), sp6.y(), sp6.z());
 
          // Make transformations from points
          // note warnings about axis not having the same angles expected here...
@@ -332,9 +332,9 @@ int main(int /*argc*/, char ** /*argv*/)
       const unsigned int nTests = 1000; // number of tests to run
 
       // scalar data
-      Data<Point<double>, Vector<double>, Plane<double>, double>::Vector scalar_data(nPhotons);
+      Data<PositionVector<double>, Vector<double>, Plane<double>, double>::Vector scalar_data(nPhotons);
       // vector data with total equal number of photons (including vectorised size)
-      Data<Point<Vc::double_v>, Vector<Vc::double_v>, Plane<Vc::double_v>, Vc::double_v>::Vector vc_data(
+      Data<PositionVector<Vc::double_v>, Vector<Vc::double_v>, Plane<Vc::double_v>, Vc::double_v>::Vector vc_data(
          nPhotons / Vc::double_v::Size);
 
       TStopwatch t;


### PR DESCRIPTION

/build/jenkins/night/LABEL/mac1014/SPEC/cxxmod-noimt/root/test/testGenVectorVc.cxx:194:1: error: redefinition of 'Point' as different kind of symbol
using Point = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<T>, ROOT::Math::DefaultCoordinateSystemTag>;
^
In module 'Darwin' imported from /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/assert.h:42:
/Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/MacTypes.h:538:8: note: previous definition is here
struct Point {
^