### PR TITLE
[metacling] Optimize TCling*Info interfaces

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -4266,6 +4266,10 @@ int RootClingMain(int argc,
 
    if (!isPCH && cxxmodule) {
 #ifndef R__MACOSX
+      // Add the overlay file. Note that we cannot factor it out for both root
+      // and rootcling because rootcling activates modules only if -cxxmodule
+      // flag is passed.
+
       // includeDir is where modulemaps exist.
       clingArgsInterpreter.push_back("-modulemap_overlay=" + includeDir);
 #endif //R__MACOSX

--- a/core/metacling/src/CMakeLists.txt
+++ b/core/metacling/src/CMakeLists.txt
@@ -44,6 +44,7 @@ ROOT_OBJECT_LIBRARY(MetaCling
   TClingClassInfo.cxx
   TCling.cxx
   TClingDataMemberInfo.cxx
+  TClingDeclInfo.cxx
   TClingMethodArgInfo.cxx
   TClingMethodInfo.cxx
   TClingTypedefInfo.cxx

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1206,14 +1206,16 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
       }
    }
 
-   if (fCxxModulesEnabled) {
-      clingArgsStorage.push_back("-modulemap_overlay=" + std::string(TROOT::GetIncludeDir().Data()));
-   }
-
    // FIXME: This only will enable frontend timing reports.
    EnvOpt = llvm::sys::Process::GetEnv("ROOT_CLING_TIMING");
    if (EnvOpt.hasValue())
      clingArgsStorage.push_back("-ftime-report");
+
+   // Add the overlay file. Note that we cannot factor it out for both root
+   // and rootcling because rootcling activates modules only if -cxxmodule
+   // flag is passed.
+   if (fCxxModulesEnabled && !fromRootCling)
+      clingArgsStorage.push_back("-modulemap_overlay=" + std::string(TROOT::GetIncludeDir().Data()));
 
    std::vector<const char*> interpArgs;
    for (std::vector<std::string>::const_iterator iArg = clingArgsStorage.begin(),

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -8414,7 +8414,7 @@ const char* TCling::MethodInfo_GetMangledName(MethodInfo_t* minfo) const
 const char* TCling::MethodInfo_GetPrototype(MethodInfo_t* minfo) const
 {
    TClingMethodInfo* info = (TClingMethodInfo*) minfo;
-   return info->GetPrototype(*fNormalizedCtxt);
+   return info->GetPrototype();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -8422,7 +8422,7 @@ const char* TCling::MethodInfo_GetPrototype(MethodInfo_t* minfo) const
 const char* TCling::MethodInfo_Name(MethodInfo_t* minfo) const
 {
    TClingMethodInfo* info = (TClingMethodInfo*) minfo;
-   return info->Name(*fNormalizedCtxt);
+   return info->Name();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/metacling/src/TClingBaseClassInfo.cxx
+++ b/core/metacling/src/TClingBaseClassInfo.cxx
@@ -163,7 +163,7 @@ TClingClassInfo *TClingBaseClassInfo::GetBase() const
 }
 
 OffsetPtrFunc_t
-TClingBaseClassInfo::GenerateBaseOffsetFunction(const TClingClassInfo * fromDerivedClass,
+TClingBaseClassInfo::GenerateBaseOffsetFunction(TClingClassInfo * fromDerivedClass,
                                                 TClingClassInfo* toBaseClass,
                                                 void* address, bool isDerivedObject) const
 {
@@ -262,6 +262,7 @@ int TClingBaseClassInfo::InternalNext(int onlyDirect)
          (fIter == llvm::dyn_cast<clang::CXXRecordDecl>(fDecl)->bases_end())) {
       return 0;
    }
+
    // Advance to the next valid base.
    while (1) {
       // Advance the iterator.

--- a/core/metacling/src/TClingBaseClassInfo.h
+++ b/core/metacling/src/TClingBaseClassInfo.h
@@ -79,7 +79,7 @@ public:
    const char   *TmpltName() const;
 
 private:
-   OffsetPtrFunc_t GenerateBaseOffsetFunction(const TClingClassInfo* derivedClass, TClingClassInfo* targetClass, void* address, bool isDerivedObject) const;
+   OffsetPtrFunc_t GenerateBaseOffsetFunction(TClingClassInfo* derivedClass, TClingClassInfo* targetClass, void* address, bool isDerivedObject) const;
 };
 
 #endif // ROOT_TClingBaseClassInfo

--- a/core/metacling/src/TClingCallFunc.cxx
+++ b/core/metacling/src/TClingCallFunc.cxx
@@ -1483,7 +1483,7 @@ void TClingCallFunc::exec(void *address, void *ret)
       if (num_args < GetMinRequiredArguments()) {
          ::Error("TClingCallFunc::exec",
                "Not enough arguments provided for %s (%d instead of the minimum %d)",
-               fMethod->Name(ROOT::TMetaUtils::TNormalizedCtxt(fInterp->getLookupHelper())),
+               fMethod->Name(),
                num_args, (int)GetMinRequiredArguments());
          return;
       }
@@ -1492,7 +1492,7 @@ void TClingCallFunc::exec(void *address, void *ret)
           && !dyn_cast<CXXConstructorDecl>(FD)) {
          ::Error("TClingCallFunc::exec",
                "The method %s is called without an object.",
-               fMethod->Name(ROOT::TMetaUtils::TNormalizedCtxt(fInterp->getLookupHelper())));
+               fMethod->Name());
          return;
       }
       vh_ary.reserve(num_args);

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -75,7 +75,7 @@ TClingClassInfo::TClingClassInfo(cling::Interpreter *interp, Bool_t all)
    TranslationUnitDecl *TU =
       interp->getCI()->getASTContext().getTranslationUnitDecl();
    fFirstTime = true;
-   fDecl = TU;
+   SetDecl(TU);
    fType = 0;
 }
 
@@ -104,11 +104,11 @@ TClingClassInfo::TClingClassInfo(cling::Interpreter *interp, const char *name)
          decl = tagtype->getDecl();
       }
    }
-   fDecl = decl;
+   SetDecl(decl);
    fType = type;
    if (decl && decl->isInvalidDecl()) {
       Error("TClingClassInfo", "Found an invalid decl for %s.",name);
-      fDecl = nullptr;
+      SetDecl(nullptr);
       fType = nullptr;
    }
 }
@@ -144,7 +144,7 @@ long TClingClassInfo::ClassProperty() const
       return 0L;
    }
    long property = 0L;
-   const RecordDecl *RD = llvm::dyn_cast<RecordDecl>(fDecl);
+   const RecordDecl *RD = llvm::dyn_cast<RecordDecl>(GetDecl());
    if (!RD) {
       // We are an enum or namespace.
       // The cint interface always returns 0L for these guys.
@@ -156,7 +156,7 @@ long TClingClassInfo::ClassProperty() const
    }
    // We now have a class or a struct.
    const CXXRecordDecl *CRD =
-      llvm::dyn_cast<CXXRecordDecl>(fDecl);
+      llvm::dyn_cast<CXXRecordDecl>(GetDecl());
    property |= kClassIsValid;
    if (CRD->isAbstract()) {
       property |= kClassIsAbstract;
@@ -201,7 +201,7 @@ void TClingClassInfo::Delete(void *arena, const ROOT::TMetaUtils::TNormalizedCtx
    }
    if (!IsLoaded()) {
       Error("TClingClassInfo::Delete()", "Class is not loaded: %s",
-            FullyQualifiedName(fDecl).c_str());
+            FullyQualifiedName(GetDecl()).c_str());
       return;
    }
    TClingCallFunc cf(fInterp,normCtxt);
@@ -252,7 +252,7 @@ const FunctionTemplateDecl *TClingClassInfo::GetFunctionTemplate(const char *fna
       if (TT) {
          llvm::StringRef tname(TT->getDecl()->getName());
          if (tname.equals(fname)) {
-            const NamedDecl *ndecl = llvm::dyn_cast<NamedDecl>(fDecl);
+            const NamedDecl *ndecl = llvm::dyn_cast<NamedDecl>(GetDecl());
             if (ndecl && !ndecl->getName().equals(fname)) {
                // Constructor name matching the typedef type, use the decl name instead.
                return GetFunctionTemplate(ndecl->getName().str().c_str());
@@ -262,7 +262,7 @@ const FunctionTemplateDecl *TClingClassInfo::GetFunctionTemplate(const char *fna
    }
    const cling::LookupHelper &lh = fInterp->getLookupHelper();
    const FunctionTemplateDecl *fd
-      = lh.findFunctionTemplate(fDecl, fname,
+      = lh.findFunctionTemplate(GetDecl(), fname,
                                 gDebug > 5 ? cling::LookupHelper::WithDiagnostics
                                 : cling::LookupHelper::NoDiagnostics, false);
    if (fd) return fd->getCanonicalDecl();
@@ -276,7 +276,7 @@ const clang::ValueDecl *TClingClassInfo::GetDataMember(const char *name) const
 
    const cling::LookupHelper &lh = fInterp->getLookupHelper();
    const ValueDecl *vd
-      = lh.findDataMember(fDecl, name,
+      = lh.findDataMember(GetDecl(), name,
                           gDebug > 5 ? cling::LookupHelper::WithDiagnostics
                           : cling::LookupHelper::NoDiagnostics);
    if (vd) return llvm::dyn_cast<ValueDecl>(vd->getCanonicalDecl());
@@ -299,7 +299,7 @@ TClingMethodInfo TClingClassInfo::GetMethod(const char *fname) const
       if (TT) {
          llvm::StringRef tname(TT->getDecl()->getName());
          if (tname.equals(fname)) {
-            const NamedDecl *ndecl = llvm::dyn_cast<NamedDecl>(fDecl);
+            const NamedDecl *ndecl = llvm::dyn_cast<NamedDecl>(GetDecl());
             if (ndecl && !ndecl->getName().equals(fname)) {
                // Constructor name matching the typedef type, use the decl name instead.
                return GetMethod(ndecl->getName().str().c_str());
@@ -309,7 +309,7 @@ TClingMethodInfo TClingClassInfo::GetMethod(const char *fname) const
    }
    const cling::LookupHelper &lh = fInterp->getLookupHelper();
    const FunctionDecl *fd
-      = lh.findAnyFunction(fDecl, fname,
+      = lh.findAnyFunction(GetDecl(), fname,
                            gDebug > 5 ? cling::LookupHelper::WithDiagnostics
                            : cling::LookupHelper::NoDiagnostics,
                            false);
@@ -350,7 +350,7 @@ TClingMethodInfo TClingClassInfo::GetMethod(const char *fname,
       if (TT) {
          llvm::StringRef tname(TT->getDecl()->getName());
          if (tname.equals(fname)) {
-            const NamedDecl *ndecl = llvm::dyn_cast<NamedDecl>(fDecl);
+            const NamedDecl *ndecl = llvm::dyn_cast<NamedDecl>(GetDecl());
             if (ndecl && !ndecl->getName().equals(fname)) {
                // Constructor name matching the typedef type, use the decl name instead.
                return GetMethod(ndecl->getName().str().c_str(),proto,
@@ -364,12 +364,12 @@ TClingMethodInfo TClingClassInfo::GetMethod(const char *fname,
    const cling::LookupHelper& lh = fInterp->getLookupHelper();
    const FunctionDecl *fd;
    if (mode == kConversionMatch) {
-      fd = lh.findFunctionProto(fDecl, fname, proto,
+      fd = lh.findFunctionProto(GetDecl(), fname, proto,
                                 gDebug > 5 ? cling::LookupHelper::WithDiagnostics
                                 : cling::LookupHelper::NoDiagnostics,
                                 objectIsConst);
    } else if (mode == kExactMatch) {
-      fd = lh.matchFunctionProto(fDecl, fname, proto,
+      fd = lh.matchFunctionProto(GetDecl(), fname, proto,
                                  gDebug > 5 ? cling::LookupHelper::WithDiagnostics
                                  : cling::LookupHelper::NoDiagnostics,
                                  objectIsConst);
@@ -393,7 +393,7 @@ TClingMethodInfo TClingClassInfo::GetMethod(const char *fname,
       // derived class's function overloads (or used, which is fine). Only
       // if there is none will we find those from the base, in which case
       // we will reject them here:
-      const clang::DeclContext* ourDC = llvm::dyn_cast<clang::DeclContext>(fDecl);
+      const clang::DeclContext* ourDC = llvm::dyn_cast<clang::DeclContext>(GetDecl());
       if (!fd->getDeclContext()->Equals(ourDC)
           && !(fd->getDeclContext()->isTransparentContext()
                && fd->getDeclContext()->getParent()->Equals(ourDC)))
@@ -444,7 +444,7 @@ TClingMethodInfo TClingClassInfo::GetMethod(const char *fname,
       if (TT) {
          llvm::StringRef tname(TT->getDecl()->getName());
          if (tname.equals(fname)) {
-            const NamedDecl *ndecl = llvm::dyn_cast<NamedDecl>(fDecl);
+            const NamedDecl *ndecl = llvm::dyn_cast<NamedDecl>(GetDecl());
             if (ndecl && !ndecl->getName().equals(fname)) {
                // Constructor name matching the typedef type, use the decl name instead.
                return GetMethod(ndecl->getName().str().c_str(),proto,objectIsConst,poffset,
@@ -457,12 +457,12 @@ TClingMethodInfo TClingClassInfo::GetMethod(const char *fname,
    const cling::LookupHelper& lh = fInterp->getLookupHelper();
    const FunctionDecl *fd;
    if (mode == kConversionMatch) {
-      fd = lh.findFunctionProto(fDecl, fname, proto,
+      fd = lh.findFunctionProto(GetDecl(), fname, proto,
                                 gDebug > 5 ? cling::LookupHelper::WithDiagnostics
                                 : cling::LookupHelper::NoDiagnostics,
                                 objectIsConst);
    } else if (mode == kExactMatch) {
-      fd = lh.matchFunctionProto(fDecl, fname, proto,
+      fd = lh.matchFunctionProto(GetDecl(), fname, proto,
                                  gDebug > 5 ? cling::LookupHelper::WithDiagnostics
                                  : cling::LookupHelper::NoDiagnostics,
                                  objectIsConst);
@@ -510,7 +510,7 @@ TClingMethodInfo TClingClassInfo::GetMethodWithArgs(const char *fname,
       if (TT) {
          llvm::StringRef tname(TT->getDecl()->getName());
          if (tname.equals(fname)) {
-            const NamedDecl *ndecl = llvm::dyn_cast<NamedDecl>(fDecl);
+            const NamedDecl *ndecl = llvm::dyn_cast<NamedDecl>(GetDecl());
             if (ndecl && !ndecl->getName().equals(fname)) {
                // Constructor name matching the typedef type, use the decl name instead.
                return GetMethod(ndecl->getName().str().c_str(),arglist,
@@ -534,7 +534,7 @@ TClingMethodInfo TClingClassInfo::GetMethodWithArgs(const char *fname,
    }
    const cling::LookupHelper &lh = fInterp->getLookupHelper();
    const FunctionDecl *fd
-      = lh.findFunctionArgs(fDecl, fname, arglist,
+      = lh.findFunctionArgs(GetDecl(), fname, arglist,
                             gDebug > 5 ? cling::LookupHelper::WithDiagnostics
                             : cling::LookupHelper::NoDiagnostics,
                             objectIsConst);
@@ -584,7 +584,7 @@ long TClingClassInfo::GetOffset(const CXXMethodDecl* md) const
    long offset = 0L;
    const CXXRecordDecl* definer = md->getParent();
    const CXXRecordDecl* accessor =
-      llvm::cast<CXXRecordDecl>(fDecl);
+      llvm::cast<CXXRecordDecl>(GetDecl());
    if (definer != accessor) {
       // This function may not be accessible using a pointer
       // to the declaring class, get the adjustment necessary
@@ -647,7 +647,7 @@ bool TClingClassInfo::HasDefaultConstructor() const
    if (!IsLoaded()) {
       return false;
    }
-   const CXXRecordDecl* CRD = llvm::dyn_cast<CXXRecordDecl>(fDecl);
+   const CXXRecordDecl* CRD = llvm::dyn_cast<CXXRecordDecl>(GetDecl());
    if (!CRD) {
       // Namespaces do not have constructors.
       return false;
@@ -660,9 +660,9 @@ bool TClingClassInfo::HasDefaultConstructor() const
 bool TClingClassInfo::HasMethod(const char *name) const
 {
    R__LOCKGUARD(gInterpreterMutex);
-   if (IsLoaded() && !llvm::isa<EnumDecl>(fDecl)) {
+   if (IsLoaded() && !llvm::isa<EnumDecl>(GetDecl())) {
       return fInterp->getLookupHelper()
-         .hasFunction(fDecl, name,
+         .hasFunction(GetDecl(), name,
                       gDebug > 5 ? cling::LookupHelper::WithDiagnostics
                       : cling::LookupHelper::NoDiagnostics);
    }
@@ -675,25 +675,25 @@ void TClingClassInfo::Init(const char *name)
    fDescend = false;
    fIsIter = false;
    fIter = DeclContext::decl_iterator();
-   fDecl = nullptr;
+   SetDecl(nullptr);
    fType = 0;
    fIterStack.clear();
    const cling::LookupHelper& lh = fInterp->getLookupHelper();
-   fDecl = lh.findScope(name, gDebug > 5 ? cling::LookupHelper::WithDiagnostics
-                          : cling::LookupHelper::NoDiagnostics,
-                        &fType, /* intantiateTemplate= */ true );
-   if (!fDecl) {
+   SetDecl(lh.findScope(name, gDebug > 5 ? cling::LookupHelper::WithDiagnostics
+                        : cling::LookupHelper::NoDiagnostics,
+                        &fType, /* intantiateTemplate= */ true ));
+   if (!GetDecl()) {
       std::string buf = TClassEdit::InsertStd(name);
       if (buf != name) {
-         fDecl = lh.findScope(buf, gDebug > 5 ? cling::LookupHelper::WithDiagnostics
+         SetDecl(lh.findScope(buf, gDebug > 5 ? cling::LookupHelper::WithDiagnostics
                               : cling::LookupHelper::NoDiagnostics,
-                              &fType, /* intantiateTemplate= */ true );
+                              &fType, /* intantiateTemplate= */ true ));
       }
    }
-   if (!fDecl && fType) {
+   if (!GetDecl() && fType) {
       const TagType *tagtype =fType->getAs<TagType>();
       if (tagtype) {
-         fDecl = tagtype->getDecl();
+         SetDecl(tagtype->getDecl());
       }
    }
 }
@@ -704,7 +704,7 @@ void TClingClassInfo::Init(const Decl* decl)
    fDescend = false;
    fIsIter = false;
    fIter = DeclContext::decl_iterator();
-   fDecl = decl;
+   SetDecl(decl);
    fType = 0;
    fIterStack.clear();
 }
@@ -723,12 +723,12 @@ void TClingClassInfo::Init(const Type &tag)
 
    const TagType *tagtype = fType->getAs<TagType>();
    if (tagtype) {
-      fDecl = tagtype->getDecl();
+      SetDecl(tagtype->getDecl());
    }
    else {
-      fDecl = 0;
+      SetDecl(nullptr);
    }
-   if (!fDecl) {
+   if (!GetDecl()) {
       QualType qType(fType,0);
       static PrintingPolicy printPol(fInterp->getCI()->getLangOpts());
       printPol.SuppressScope = false;
@@ -751,7 +751,7 @@ bool TClingClassInfo::IsBase(const char *name) const
    R__LOCKGUARD(gInterpreterMutex);
 
    const CXXRecordDecl *CRD =
-      llvm::dyn_cast<CXXRecordDecl>(fDecl);
+      llvm::dyn_cast<CXXRecordDecl>(GetDecl());
    if (!CRD) {
       // We are an enum, namespace, or translation unit,
       // we cannot be the base of anything.
@@ -781,19 +781,19 @@ bool TClingClassInfo::IsLoaded() const
    if (!IsValid()) {
       return false;
    }
-   if (fDecl == 0) {
+   if (GetDecl() == 0) {
       return false;
    }
 
    R__LOCKGUARD(gInterpreterMutex);
 
-   const CXXRecordDecl *CRD = llvm::dyn_cast<CXXRecordDecl>(fDecl);
+   const CXXRecordDecl *CRD = llvm::dyn_cast<CXXRecordDecl>(GetDecl());
    if ( CRD ) {
       if (!CRD->hasDefinition()) {
          return false;
       }
    } else {
-      const TagDecl *TD = llvm::dyn_cast<TagDecl>(fDecl);
+      const TagDecl *TD = llvm::dyn_cast<TagDecl>(GetDecl());
       if (TD && TD->getDefinition() == 0) {
          return false;
       }
@@ -827,8 +827,8 @@ int TClingClassInfo::InternalNext()
 
    cling::Interpreter::PushTransactionRAII RAII(fInterp);
    if (fFirstTime) {
-      // fDecl must be a DeclContext in order to iterate.
-      const clang::DeclContext *DC = cast<DeclContext>(fDecl);
+      // GetDecl() must be a DeclContext in order to iterate.
+      const clang::DeclContext *DC = cast<DeclContext>(GetDecl());
       if (fIterAll)
          fIter = DC->decls_begin();
       else
@@ -837,11 +837,11 @@ int TClingClassInfo::InternalNext()
 
    if (!fIsIter) {
       // Object was not setup for iteration.
-      if (fDecl) {
+      if (GetDecl()) {
          std::string buf;
          if (const NamedDecl* ND =
-               llvm::dyn_cast<NamedDecl>(fDecl)) {
-            PrintingPolicy Policy(fDecl->getASTContext().
+               llvm::dyn_cast<NamedDecl>(GetDecl())) {
+            PrintingPolicy Policy(GetDecl()->getASTContext().
                getPrintingPolicy());
             llvm::raw_string_ostream stream(buf);
             ND->getNameForDiagnostic(stream, Policy, /*Qualified=*/false);
@@ -896,7 +896,7 @@ int TClingClassInfo::InternalNext()
          // Check for final termination.
          if (!*fIter) {
             // We have reached the end of the translation unit, all done.
-            fDecl = 0;
+            SetDecl(nullptr);
             fType = 0;
             return 0;
          }
@@ -930,14 +930,14 @@ int TClingClassInfo::InternalNext()
             }
          }
          // Iterator is now valid.
-         fDecl = *fIter;
+         SetDecl(*fIter);
          fType = 0;
-         if (fDecl) {
-            if (fDecl->isInvalidDecl()) {
+         if (GetDecl()) {
+            if (GetDecl()->isInvalidDecl()) {
                Warning("TClingClassInfo::Next()","Reached an invalid decl.");
             }
             if (const RecordDecl *RD =
-                  llvm::dyn_cast<RecordDecl>(fDecl)) {
+                  llvm::dyn_cast<RecordDecl>(GetDecl())) {
                fType = RD->getASTContext().getRecordType(RD).getTypePtr();
             }
          }
@@ -961,21 +961,21 @@ void *TClingClassInfo::New(const ROOT::TMetaUtils::TNormalizedCtxt &normCtxt) co
    }
    if (!IsLoaded()) {
       Error("TClingClassInfo::New()", "Class is not loaded: %s",
-            FullyQualifiedName(fDecl).c_str());
+            FullyQualifiedName(GetDecl()).c_str());
       return 0;
    }
    {
       R__LOCKGUARD(gInterpreterMutex);
-      const CXXRecordDecl* RD = dyn_cast<CXXRecordDecl>(fDecl);
+      const CXXRecordDecl* RD = dyn_cast<CXXRecordDecl>(GetDecl());
       if (!RD) {
          Error("TClingClassInfo::New()", "This is a namespace!: %s",
-               FullyQualifiedName(fDecl).c_str());
+               FullyQualifiedName(GetDecl()).c_str());
          return 0;
       }
       if (!HasDefaultConstructor()) {
          // FIXME: We fail roottest root/io/newdelete if we issue this message!
          //Error("TClingClassInfo::New()", "Class has no default constructor: %s",
-         //      FullyQualifiedName(fDecl).c_str());
+         //      FullyQualifiedName(GetDecl()).c_str());
          return 0;
       }
    } // End of Lock section.
@@ -985,7 +985,7 @@ void *TClingClassInfo::New(const ROOT::TMetaUtils::TNormalizedCtxt &normCtxt) co
    if (!obj) {
       Error("TClingClassInfo::New()", "Call of default constructor "
             "failed to return an object for class: %s",
-            FullyQualifiedName(fDecl).c_str());
+            FullyQualifiedName(GetDecl()).c_str());
       return 0;
    }
    return obj;
@@ -1002,24 +1002,24 @@ void *TClingClassInfo::New(int n, const ROOT::TMetaUtils::TNormalizedCtxt &normC
    }
    if (!IsLoaded()) {
       Error("TClingClassInfo::New(n)", "Class is not loaded: %s",
-            FullyQualifiedName(fDecl).c_str());
+            FullyQualifiedName(GetDecl()).c_str());
       return 0;
    }
 
    {
       R__LOCKGUARD(gInterpreterMutex);
 
-      const CXXRecordDecl* RD = dyn_cast<CXXRecordDecl>(fDecl);
+      const CXXRecordDecl* RD = dyn_cast<CXXRecordDecl>(GetDecl());
       if (!RD) {
          Error("TClingClassInfo::New(n)", "This is a namespace!: %s",
-               FullyQualifiedName(fDecl).c_str());
+               FullyQualifiedName(GetDecl()).c_str());
          return 0;
       }
       if (!HasDefaultConstructor()) {
          // FIXME: We fail roottest root/io/newdelete if we issue this message!
          //Error("TClingClassInfo::New(n)",
          //      "Class has no default constructor: %s",
-         //      FullyQualifiedName(fDecl).c_str());
+         //      FullyQualifiedName(GetDecl()).c_str());
          return 0;
       }
    } // End of Lock section.
@@ -1030,7 +1030,7 @@ void *TClingClassInfo::New(int n, const ROOT::TMetaUtils::TNormalizedCtxt &normC
    if (!obj) {
       Error("TClingClassInfo::New(n)", "Call of default constructor "
             "failed to return an array of class: %s",
-            FullyQualifiedName(fDecl).c_str());
+            FullyQualifiedName(GetDecl()).c_str());
       return 0;
    }
    return obj;
@@ -1048,23 +1048,23 @@ void *TClingClassInfo::New(int n, void *arena, const ROOT::TMetaUtils::TNormaliz
    }
    if (!IsLoaded()) {
       Error("TClingClassInfo::New(n, arena)", "Class is not loaded: %s",
-            FullyQualifiedName(fDecl).c_str());
+            FullyQualifiedName(GetDecl()).c_str());
       return 0;
    }
    {
       R__LOCKGUARD(gInterpreterMutex);
 
-      const CXXRecordDecl* RD = dyn_cast<CXXRecordDecl>(fDecl);
+      const CXXRecordDecl* RD = dyn_cast<CXXRecordDecl>(GetDecl());
       if (!RD) {
          Error("TClingClassInfo::New(n, arena)", "This is a namespace!: %s",
-               FullyQualifiedName(fDecl).c_str());
+               FullyQualifiedName(GetDecl()).c_str());
          return 0;
       }
       if (!HasDefaultConstructor()) {
          // FIXME: We fail roottest root/io/newdelete if we issue this message!
          //Error("TClingClassInfo::New(n, arena)",
          //      "Class has no default constructor: %s",
-         //      FullyQualifiedName(fDecl).c_str());
+         //      FullyQualifiedName(GetDecl()).c_str());
          return 0;
       }
    } // End of Lock section
@@ -1087,23 +1087,23 @@ void *TClingClassInfo::New(void *arena, const ROOT::TMetaUtils::TNormalizedCtxt 
    }
    if (!IsLoaded()) {
       Error("TClingClassInfo::New(arena)", "Class is not loaded: %s",
-            FullyQualifiedName(fDecl).c_str());
+            FullyQualifiedName(GetDecl()).c_str());
       return 0;
    }
    {
       R__LOCKGUARD(gInterpreterMutex);
 
-      const CXXRecordDecl* RD = dyn_cast<CXXRecordDecl>(fDecl);
+      const CXXRecordDecl* RD = dyn_cast<CXXRecordDecl>(GetDecl());
       if (!RD) {
          Error("TClingClassInfo::New(arena)", "This is a namespace!: %s",
-               FullyQualifiedName(fDecl).c_str());
+               FullyQualifiedName(GetDecl()).c_str());
          return 0;
       }
       if (!HasDefaultConstructor()) {
          // FIXME: We fail roottest root/io/newdelete if we issue this message!
          //Error("TClingClassInfo::New(arena)",
          //      "Class has no default constructor: %s",
-         //      FullyQualifiedName(fDecl).c_str());
+         //      FullyQualifiedName(GetDecl()).c_str());
          return 0;
       }
    } // End of Locked section.
@@ -1128,7 +1128,7 @@ long TClingClassInfo::Property() const
    // Modules can deserialize while querying the various decls for information.
    cling::Interpreter::PushTransactionRAII RAII(fInterp);
 
-   const clang::DeclContext *ctxt = fDecl->getDeclContext();
+   const clang::DeclContext *ctxt = GetDecl()->getDeclContext();
    clang::NamespaceDecl *std_ns =fInterp->getSema().getStdNamespace();
    while (! ctxt->isTranslationUnit())  {
       if (ctxt->Equals(std_ns)) {
@@ -1137,13 +1137,13 @@ long TClingClassInfo::Property() const
       }
       ctxt = ctxt->getParent();
    }
-   Decl::Kind DK = fDecl->getKind();
+   Decl::Kind DK = GetDecl()->getKind();
    if ((DK == Decl::Namespace) || (DK == Decl::TranslationUnit)) {
       property |= kIsNamespace;
       return property;
    }
    // Note: Now we have class, enum, struct, union only.
-   const TagDecl *TD = llvm::dyn_cast<TagDecl>(fDecl);
+   const TagDecl *TD = llvm::dyn_cast<TagDecl>(GetDecl());
    if (!TD) {
       return 0L;
    }
@@ -1153,7 +1153,7 @@ long TClingClassInfo::Property() const
    }
    // Note: Now we have class, struct, union only.
    const CXXRecordDecl *CRD =
-      llvm::dyn_cast<CXXRecordDecl>(fDecl);
+      llvm::dyn_cast<CXXRecordDecl>(GetDecl());
    if (CRD->isClass()) {
       property |= kIsClass;
    }
@@ -1183,14 +1183,14 @@ int TClingClassInfo::Size() const
    if (!IsValid()) {
       return -1;
    }
-   if (!fDecl) {
+   if (!GetDecl()) {
       // A forward declared class.
       return 0;
    }
 
    R__LOCKGUARD(gInterpreterMutex);
 
-   Decl::Kind DK = fDecl->getKind();
+   Decl::Kind DK = GetDecl()->getKind();
    if (DK == Decl::Namespace) {
       // Namespaces are special for cint.
       return 1;
@@ -1199,7 +1199,7 @@ int TClingClassInfo::Size() const
       // Enums are special for cint.
       return 0;
    }
-   const RecordDecl *RD = llvm::dyn_cast<RecordDecl>(fDecl);
+   const RecordDecl *RD = llvm::dyn_cast<RecordDecl>(GetDecl());
    if (!RD) {
       // Should not happen.
       return -1;
@@ -1208,7 +1208,7 @@ int TClingClassInfo::Size() const
       // Forward-declared class.
       return 0;
    }
-   ASTContext &Context = fDecl->getASTContext();
+   ASTContext &Context = GetDecl()->getASTContext();
    cling::Interpreter::PushTransactionRAII RAII(fInterp);
    const ASTRecordLayout &Layout = Context.getASTRecordLayout(RD);
    int64_t size = Layout.getSize().getQuantity();
@@ -1221,7 +1221,7 @@ long TClingClassInfo::Tagnum() const
    if (!IsValid()) {
       return -1L;
    }
-   return reinterpret_cast<long>(fDecl);
+   return reinterpret_cast<long>(GetDecl());
 }
 
 const char *TClingClassInfo::FileName()
@@ -1247,8 +1247,8 @@ void TClingClassInfo::FullName(std::string &output, const ROOT::TMetaUtils::TNor
    }
    else {
       if (const NamedDecl* ND =
-            llvm::dyn_cast<NamedDecl>(fDecl)) {
-         PrintingPolicy Policy(fDecl->getASTContext().
+            llvm::dyn_cast<NamedDecl>(GetDecl())) {
+         PrintingPolicy Policy(GetDecl()->getASTContext().
             getPrintingPolicy());
          llvm::raw_string_ostream stream(output);
          ND->getNameForDiagnostic(stream, Policy, /*Qualified=*/true);
@@ -1307,7 +1307,7 @@ const char *TClingClassInfo::TmpltName() const
    // Note: This *must* be static/thread_local because we are returning a pointer inside it!
    TTHREAD_TLS_DECL( std::string, buf);
    buf.clear();
-   if (const NamedDecl* ND = llvm::dyn_cast<NamedDecl>(fDecl)) {
+   if (const NamedDecl* ND = llvm::dyn_cast<NamedDecl>(GetDecl())) {
       // Note: This does *not* include the template arguments!
       buf = ND->getNameAsString();
    }

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -69,8 +69,8 @@ static std::string FullyQualifiedName(const Decl *decl) {
 }
 
 TClingClassInfo::TClingClassInfo(cling::Interpreter *interp, Bool_t all)
-   : fInterp(interp), fFirstTime(true), fDescend(false), fIterAll(all),
-     fIsIter(true), fDecl(0), fType(0), fOffsetCache(0)
+   : TClingDeclInfo(nullptr), fInterp(interp), fFirstTime(true), fDescend(false), fIterAll(all),
+     fIsIter(true), fType(0), fOffsetCache(0)
 {
    TranslationUnitDecl *TU =
       interp->getCI()->getASTContext().getTranslationUnitDecl();
@@ -80,7 +80,7 @@ TClingClassInfo::TClingClassInfo(cling::Interpreter *interp, Bool_t all)
 }
 
 TClingClassInfo::TClingClassInfo(cling::Interpreter *interp, const char *name)
-   : fInterp(interp), fFirstTime(true), fDescend(false), fIterAll(kTRUE), fIsIter(false), fDecl(0),
+   : TClingDeclInfo(nullptr), fInterp(interp), fFirstTime(true), fDescend(false), fIterAll(kTRUE), fIsIter(false),
      fType(0), fTitle(""), fOffsetCache(0)
 {
    const cling::LookupHelper& lh = fInterp->getLookupHelper();
@@ -115,16 +115,16 @@ TClingClassInfo::TClingClassInfo(cling::Interpreter *interp, const char *name)
 
 TClingClassInfo::TClingClassInfo(cling::Interpreter *interp,
                                  const Type &tag)
-   : fInterp(interp), fFirstTime(true), fDescend(false), fIterAll(kTRUE),
-     fIsIter(false), fDecl(0), fType(0), fTitle(""), fOffsetCache(0)
+   : TClingDeclInfo(nullptr), fInterp(interp), fFirstTime(true), fDescend(false), fIterAll(kTRUE),
+     fIsIter(false), fType(0), fTitle(""), fOffsetCache(0)
 {
    Init(tag);
 }
 
 TClingClassInfo::TClingClassInfo(cling::Interpreter *interp,
                                  const Decl *D)
-   : fInterp(interp), fFirstTime(true), fDescend(false), fIterAll(kTRUE),
-     fIsIter(false), fDecl(0), fType(0), fTitle(""), fOffsetCache(0)
+   : TClingDeclInfo(nullptr), fInterp(interp), fFirstTime(true), fDescend(false), fIterAll(kTRUE),
+     fIsIter(false), fType(0), fTitle(""), fOffsetCache(0)
 {
    Init(D);
 }
@@ -675,7 +675,7 @@ void TClingClassInfo::Init(const char *name)
    fDescend = false;
    fIsIter = false;
    fIter = DeclContext::decl_iterator();
-   fDecl = 0;
+   fDecl = nullptr;
    fType = 0;
    fIterStack.clear();
    const cling::LookupHelper& lh = fInterp->getLookupHelper();
@@ -802,11 +802,6 @@ bool TClingClassInfo::IsLoaded() const
    return true;
 }
 
-bool TClingClassInfo::IsValid() const
-{
-   return fDecl;
-}
-
 bool TClingClassInfo::IsValidMethod(const char *method, const char *proto,
                                     Bool_t objectIsConst,
                                     long *offset,
@@ -828,6 +823,7 @@ int TClingClassInfo::InternalNext()
    R__LOCKGUARD(gInterpreterMutex);
 
    fDeclFileName.clear(); // invalidate decl file name.
+   fNameCache.clear(); // invalidate the cache.
 
    cling::Interpreter::PushTransactionRAII RAII(fInterp);
    if (fFirstTime) {
@@ -1258,24 +1254,6 @@ void TClingClassInfo::FullName(std::string &output, const ROOT::TMetaUtils::TNor
          ND->getNameForDiagnostic(stream, Policy, /*Qualified=*/true);
       }
    }
-}
-
-const char *TClingClassInfo::Name() const
-{
-   // Return unqualified name.
-   if (!IsValid()) {
-      return 0;
-   }
-   // Note: This *must* be static/thread_local because we are returning a pointer inside it!
-   TTHREAD_TLS_DECL( std::string, buf);
-
-   buf.clear();
-   if (const NamedDecl* ND = llvm::dyn_cast<NamedDecl>(fDecl)) {
-      PrintingPolicy Policy(fDecl->getASTContext().getPrintingPolicy());
-      llvm::raw_string_ostream stream(buf);
-      ND->getNameForDiagnostic(stream, Policy, /*Qualified=*/false);
-   }
-   return buf.c_str();
 }
 
 const char *TClingClassInfo::Title()

--- a/core/metacling/src/TClingClassInfo.h
+++ b/core/metacling/src/TClingClassInfo.h
@@ -89,6 +89,11 @@ public:
    void                 DeleteArray(void *arena, bool dtorOnly, const ROOT::TMetaUtils::TNormalizedCtxt &normCtxt) const;
    void                 Destruct(void *arena, const ROOT::TMetaUtils::TNormalizedCtxt &normCtxt) const;
    const clang::ValueDecl *GetDataMember(const char *name) const;
+   void SetDecl(const clang::Decl* D) {
+     // FIXME: We should track down all sets and potentially avoid them.
+     fDecl = D;
+     fNameCache.clear(); // invalidate the cache.
+   }
    TDictionary::DeclId_t   GetDeclId() const { return (const clang::Decl*)(fDecl->getCanonicalDecl()); }
    const clang::FunctionTemplateDecl *GetFunctionTemplate(const char *fname) const;
    TClingMethodInfo     GetMethod(const char *fname) const;

--- a/core/metacling/src/TClingClassInfo.h
+++ b/core/metacling/src/TClingClassInfo.h
@@ -2,7 +2,7 @@
 // Author: Paul Russo   30/07/2012
 
 /*************************************************************************
- * Copyright (C) 1995-2000, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -25,6 +25,7 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
+#include "TClingDeclInfo.h"
 #include "TClingMethodInfo.h"
 #include "TDictionary.h"
 
@@ -50,7 +51,7 @@ namespace ROOT {
 
 extern "C" typedef ptrdiff_t (*OffsetPtrFunc_t)(void*, bool);
 
-class TClingClassInfo {
+class TClingClassInfo final : public TClingDeclInfo {
 
 private:
 
@@ -60,7 +61,6 @@ private:
    bool                  fIterAll : 1;  // Flag whether iteration should be as complete as possible.
    bool                  fIsIter : 1;   // Flag whether this object was setup for iteration.
    clang::DeclContext::decl_iterator fIter; // Current decl in scope.
-   const clang::Decl    *fDecl; // Current decl, we do *not* own.
    const clang::Type    *fType; // Type representing the decl (conserves typedefs like Double32_t). (we do *not* own)
    std::vector<clang::DeclContext::decl_iterator> fIterStack; // Recursion stack for traversing nested scopes.
    std::string           fTitle; // The meta info for the class.
@@ -89,7 +89,6 @@ public:
    void                 DeleteArray(void *arena, bool dtorOnly, const ROOT::TMetaUtils::TNormalizedCtxt &normCtxt) const;
    void                 Destruct(void *arena, const ROOT::TMetaUtils::TNormalizedCtxt &normCtxt) const;
    const clang::ValueDecl *GetDataMember(const char *name) const;
-   const clang::Decl      *GetDecl() const { return fDecl; } // Underlying representation without Double32_t
    TDictionary::DeclId_t   GetDeclId() const { return (const clang::Decl*)(fDecl->getCanonicalDecl()); }
    const clang::FunctionTemplateDecl *GetFunctionTemplate(const char *fname) const;
    TClingMethodInfo     GetMethod(const char *fname) const;
@@ -124,7 +123,6 @@ public:
    bool                 IsBase(const char *name) const;
    static bool          IsEnum(cling::Interpreter *interp, const char *name);
    bool                 IsLoaded() const;
-   bool                 IsValid() const;
    bool                 IsValidMethod(const char *method, const char *proto, Bool_t objectIsConst, long *offset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch) const;
    int                  InternalNext();
    int                  Next();
@@ -138,7 +136,6 @@ public:
    long                 Tagnum() const;
    const char          *FileName();
    void                 FullName(std::string &output, const ROOT::TMetaUtils::TNormalizedCtxt &normCtxt) const;
-   const char          *Name() const;
    const char          *Title();
    const char          *TmpltName() const;
 

--- a/core/metacling/src/TClingDataMemberInfo.cxx
+++ b/core/metacling/src/TClingDataMemberInfo.cxx
@@ -47,7 +47,7 @@ using namespace clang;
 
 TClingDataMemberInfo::TClingDataMemberInfo(cling::Interpreter *interp,
                                            TClingClassInfo *ci)
-: fInterp(interp), fClassInfo(0), fFirstTime(true), fTitle(""), fSingleDecl(0), fContextIdx(0U), fIoType(""), fIoName("")
+: TClingDeclInfo(nullptr), fInterp(interp), fClassInfo(0), fFirstTime(true), fTitle(""), fContextIdx(0U), fIoType(""), fIoName("")
 {
    if (!ci) {
       // We are meant to iterate over the global namespace (well at least CINT did).
@@ -78,8 +78,8 @@ TClingDataMemberInfo::TClingDataMemberInfo(cling::Interpreter *interp,
 TClingDataMemberInfo::TClingDataMemberInfo(cling::Interpreter *interp,
                                            const clang::ValueDecl *ValD,
                                            TClingClassInfo *ci)
-: fInterp(interp), fClassInfo(ci ? new TClingClassInfo(*ci) : new TClingClassInfo(interp, ValD)), fFirstTime(true),
-    fTitle(""), fSingleDecl(ValD), fContextIdx(0U), fIoType(""), fIoName(""){
+: TClingDeclInfo(ValD), fInterp(interp), fClassInfo(ci ? new TClingClassInfo(*ci) : new TClingClassInfo(interp, ValD)), fFirstTime(true),
+  fTitle(""), fContextIdx(0U), fIoType(""), fIoName(""){
 
    using namespace llvm;
    assert((ci || isa<TranslationUnitDecl>(ValD->getDeclContext()) ||
@@ -235,8 +235,10 @@ int TClingDataMemberInfo::MaxIndex(int dim) const
 
 int TClingDataMemberInfo::InternalNext()
 {
-   assert(!fSingleDecl && "This is not an iterator!");
+   assert(!fDecl
+          && "This is a single decl, not an iterator!");
 
+   fNameCache.clear(); // invalidate the cache.
    bool increment = true;
    // Move to next acceptable data member.
    while (fFirstTime || *fIter) {
@@ -581,7 +583,7 @@ const char *TClingDataMemberInfo::TypeTrueName(const ROOT::TMetaUtils::TNormaliz
    return 0;
 }
 
-const char *TClingDataMemberInfo::Name() const
+const char *TClingDataMemberInfo::Name()
 {
    if (!IsValid()) {
       return 0;
@@ -590,18 +592,7 @@ const char *TClingDataMemberInfo::Name() const
    CheckForIoTypeAndName();
    if (!fIoName.empty()) return fIoName.c_str();
 
-   // Note: This must be static because we return a pointer inside it!
-   static std::string buf;
-   buf.clear();
-
-   if (const clang::NamedDecl *nd = llvm::dyn_cast<clang::NamedDecl>(GetDecl())) {
-      clang::PrintingPolicy policy(GetDecl()->getASTContext().getPrintingPolicy());
-      llvm::raw_string_ostream stream(buf);
-      nd->getNameForDiagnostic(stream, policy, /*Qualified=*/false);
-      stream.flush();
-      return buf.c_str();
-   }
-   return 0;
+   return TClingDeclInfo::Name();
 }
 
 const char *TClingDataMemberInfo::Title()

--- a/core/metacling/src/TClingDeclInfo.cxx
+++ b/core/metacling/src/TClingDeclInfo.cxx
@@ -1,0 +1,45 @@
+/// \file TClingDeclInfo.cxx
+///
+/// \brief The file contains a base class of TCling*Info classes.
+///
+/// \author Vassil Vassilev <vvasilev@cern.ch>
+///
+/// \date March, 2019
+///
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "TClingDeclInfo.h"
+
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
+
+using namespace clang;
+
+// pin the vtable here.
+TClingDeclInfo::~TClingDeclInfo() {}
+
+const char* TClingDeclInfo::Name()
+{
+   if (!IsValid())
+      return 0;
+
+   if (!fNameCache.empty())
+      return fNameCache.c_str();
+
+   const Decl* D = GetDecl();
+   if (!isa<NamedDecl>(D))
+      return 0;
+
+   const NamedDecl* ND = cast<NamedDecl>(D);
+   clang::PrintingPolicy policy(ND->getASTContext().getPrintingPolicy());
+   llvm::raw_string_ostream stream(fNameCache);
+   ND->getNameForDiagnostic(stream, policy, /*Qualified=*/false);
+   stream.flush();
+   return fNameCache.c_str();
+}

--- a/core/metacling/src/TClingDeclInfo.h
+++ b/core/metacling/src/TClingDeclInfo.h
@@ -1,0 +1,42 @@
+/// \file TClingDeclInfo.h
+///
+/// \brief The file contains a base class of TCling*Info classes.
+///
+/// \author Vassil Vassilev <vvasilev@cern.ch>
+///
+/// \date March, 2019
+///
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TClingDeclInfo
+#define ROOT_TClingDeclInfo
+
+#include <string>
+
+namespace clang {
+   class Decl;
+}
+
+class TClingDeclInfo {
+protected:
+   const clang::Decl* fDecl = nullptr;
+   std::string fNameCache;
+public:
+   TClingDeclInfo(const clang::Decl* D) : fDecl(D) {}
+   virtual ~TClingDeclInfo();
+
+   virtual const clang::Decl* GetDecl() const { return fDecl; }
+   clang::Decl* GetDecl() {
+      return const_cast<clang::Decl*>(const_cast<const TClingDeclInfo*>(this)->GetDecl());
+   }
+   virtual bool IsValid() const { return GetDecl(); }
+   virtual const char* Name();
+};
+
+#endif // ROOT_TClingDeclInfo

--- a/core/metacling/src/TClingTypedefInfo.h
+++ b/core/metacling/src/TClingTypedefInfo.h
@@ -26,6 +26,8 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
+#include "TClingDeclInfo.h"
+
 #include "cling/Interpreter/Interpreter.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
@@ -40,7 +42,7 @@ namespace ROOT {
    }
 }
 
-class TClingTypedefInfo {
+class TClingTypedefInfo final : public TClingDeclInfo {
 
 private:
 
@@ -48,14 +50,13 @@ private:
    bool                 fFirstTime; // We need to skip the first increment to support the cint Next() semantics.
    bool                 fDescend; // Flag for signaling the need to descend on this advancement.
    clang::DeclContext::decl_iterator fIter; // Current decl in scope.
-   const clang::Decl    *fDecl; // Current decl.
    std::vector<clang::DeclContext::decl_iterator> fIterStack; // Recursion stack for traversing nested scopes.
    std::string          fTitle; // The meta info for the typedef.
 
 public:
 
    explicit TClingTypedefInfo(cling::Interpreter *interp)
-      : fInterp(interp), fFirstTime(true), fDescend(false), fDecl(0), fTitle("")
+      : TClingDeclInfo(nullptr), fInterp(interp), fFirstTime(true), fDescend(false), fTitle("")
    {
       const clang::TranslationUnitDecl *TU = fInterp->getCI()->getASTContext().getTranslationUnitDecl();
       const clang::DeclContext *DC = llvm::cast<clang::DeclContext>(TU);
@@ -67,15 +68,13 @@ public:
 
    explicit TClingTypedefInfo(cling::Interpreter *, const clang::TypedefNameDecl *);
 
-   const clang::Decl   *GetDecl() const;
    void                 Init(const char *name);
-   bool                 IsValid() const;
    int                  InternalNext();
    int                  Next();
    long                 Property() const;
    int                  Size() const;
    const char          *TrueName(const ROOT::TMetaUtils::TNormalizedCtxt &normCtxt) const;
-   const char          *Name() const;
+   const char          *Name() override;
    const char          *Title();
 
 };


### PR DESCRIPTION
Currently, if ::Name() interface is called we pretty print the Decl name. This is suboptimal because it causes many memory allocations for something which is essentially immutable.

This PR introduces step-by-step working cache if ::Name() was called. It reduces the temporary memory allocations by 12 Mb in standard ROOT and 130Mb in -Druntime_cxxmodules=On cache. The benchmarking test was provided by @pcanal in #3012.

It is important to reduce the temporary allocations because they can contribute to increasing of the peak memory usage of ROOT.