### PR TITLE
Update all TH1 derived class version number.

### DIFF
--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -462,7 +462,7 @@ public:
    virtual void     Reset(Option_t *option="");
    virtual void     SetBinsLength(Int_t n=-1);
 
-   ClassDef(TH1C,2)  //1-Dim histograms (one char per channel)
+   ClassDef(TH1C,3)  //1-Dim histograms (one char per channel)
 
    friend  TH1C     operator*(Double_t c1, const TH1C &h1);
    friend  TH1C     operator*(const TH1C &h1, Double_t c1);
@@ -503,7 +503,7 @@ public:
    virtual void     Reset(Option_t *option="");
    virtual void     SetBinsLength(Int_t n=-1);
 
-   ClassDef(TH1S,2)  //1-Dim histograms (one short per channel)
+   ClassDef(TH1S,3)  //1-Dim histograms (one short per channel)
 
    friend  TH1S     operator*(Double_t c1, const TH1S &h1);
    friend  TH1S     operator*(const TH1S &h1, Double_t c1);
@@ -544,7 +544,7 @@ public:
    virtual void     Reset(Option_t *option="");
    virtual void     SetBinsLength(Int_t n=-1);
 
-   ClassDef(TH1I,2)  //1-Dim histograms (one 32 bits integer per channel)
+   ClassDef(TH1I,3)  //1-Dim histograms (one 32 bits integer per channel)
 
    friend  TH1I     operator*(Double_t c1, const TH1I &h1);
    friend  TH1I     operator*(const TH1I &h1, Double_t c1);
@@ -587,7 +587,7 @@ public:
    virtual void     Reset(Option_t *option="");
    virtual void     SetBinsLength(Int_t n=-1);
 
-   ClassDef(TH1F,2)  //1-Dim histograms (one float per channel)
+   ClassDef(TH1F,3)  //1-Dim histograms (one float per channel)
 
    friend  TH1F     operator*(Double_t c1, const TH1F &h1);
    friend  TH1F     operator*(const TH1F &h1, Double_t c1);
@@ -630,7 +630,7 @@ public:
    virtual void     Reset(Option_t *option="");
    virtual void     SetBinsLength(Int_t n=-1);
 
-   ClassDef(TH1D,2)  //1-Dim histograms (one double per channel)
+   ClassDef(TH1D,3)  //1-Dim histograms (one double per channel)
 
    friend  TH1D     operator*(Double_t c1, const TH1D &h1);
    friend  TH1D     operator*(const TH1D &h1, Double_t c1);

--- a/hist/hist/inc/TH1K.h
+++ b/hist/hist/inc/TH1K.h
@@ -56,7 +56,7 @@ public:
 
    void    SetKOrd(Int_t k){fKOrd=k;}
 
-   ClassDef(TH1K,1)  //1-Dim Nearest Kth neighbour method
+   ClassDef(TH1K,2)  //1-Dim Nearest Kth neighbour method
 };
 
 #endif

--- a/hist/hist/inc/TH2.h
+++ b/hist/hist/inc/TH2.h
@@ -122,7 +122,7 @@ public:
    virtual Int_t    ShowPeaks(Double_t sigma=2, Option_t *option="", Double_t threshold=0.05); // *MENU*
    virtual void     Smooth(Int_t ntimes=1, Option_t *option=""); // *MENU*
 
-   ClassDef(TH2,4)  //2-Dim histogram base class
+   ClassDef(TH2,5)  //2-Dim histogram base class
 };
 
 
@@ -161,7 +161,7 @@ protected:
    virtual Double_t RetrieveBinContent(Int_t bin) const { return Double_t (fArray[bin]); }
    virtual void     UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = Char_t (content); }
 
-   ClassDef(TH2C,3)  //2-Dim histograms (one char per channel)
+   ClassDef(TH2C,4)  //2-Dim histograms (one char per channel)
 };
 
 
@@ -200,7 +200,7 @@ protected:
    virtual Double_t RetrieveBinContent(Int_t bin) const { return Double_t (fArray[bin]); }
    virtual void     UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = Short_t (content); }
 
-   ClassDef(TH2S,3)  //2-Dim histograms (one short per channel)
+   ClassDef(TH2S,4)  //2-Dim histograms (one short per channel)
 };
 
 
@@ -239,7 +239,7 @@ protected:
    virtual Double_t RetrieveBinContent(Int_t bin) const { return Double_t (fArray[bin]); }
    virtual void     UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = Int_t (content); }
 
-   ClassDef(TH2I,3)  //2-Dim histograms (one 32 bits integer per channel)
+   ClassDef(TH2I,4)  //2-Dim histograms (one 32 bits integer per channel)
 };
 
 
@@ -280,7 +280,7 @@ protected:
    virtual Double_t RetrieveBinContent(Int_t bin) const { return Double_t (fArray[bin]); }
    virtual void     UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = Float_t (content); }
 
-   ClassDef(TH2F,3)  //2-Dim histograms (one float per channel)
+   ClassDef(TH2F,4)  //2-Dim histograms (one float per channel)
 };
 
 
@@ -321,7 +321,7 @@ protected:
    virtual Double_t RetrieveBinContent(Int_t bin) const { return fArray[bin]; }
    virtual void     UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = content; }
 
-   ClassDef(TH2D,3)  //2-Dim histograms (one double per channel)
+   ClassDef(TH2D,4)  //2-Dim histograms (one double per channel)
 };
 
 #endif

--- a/hist/hist/inc/TH2Poly.h
+++ b/hist/hist/inc/TH2Poly.h
@@ -169,7 +169,7 @@ protected:
       return (bin>=kNOverflow) ? SetBinContent(bin-kNOverflow+1,content) : SetBinContent(-bin-1,content);
    }
 
-   ClassDef(TH2Poly,1)  //2-Dim histogram with polygon bins
+   ClassDef(TH2Poly,2)  //2-Dim histogram with polygon bins
  };
 
 #endif

--- a/hist/hist/inc/TH3.h
+++ b/hist/hist/inc/TH3.h
@@ -148,7 +148,7 @@ protected:
       return h.DoProject2D(name, title, projX,projY, computeErrors, originalRange, useUF, useOF);
    }
 
-   ClassDef(TH3,5)  //3-Dim histogram base class
+   ClassDef(TH3,6)  //3-Dim histogram base class
 };
 
 //________________________________________________________________________
@@ -184,7 +184,7 @@ protected:
    virtual Double_t RetrieveBinContent(Int_t bin) const { return Double_t (fArray[bin]); }
    virtual void     UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = Char_t (content); }
 
-   ClassDef(TH3C,3)  //3-Dim histograms (one char per channel)
+   ClassDef(TH3C,4)  //3-Dim histograms (one char per channel)
 };
 
 //________________________________________________________________________
@@ -220,7 +220,7 @@ protected:
    virtual Double_t RetrieveBinContent(Int_t bin) const { return Double_t (fArray[bin]); }
    virtual void     UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = Short_t (content); }
 
-   ClassDef(TH3S,3)  //3-Dim histograms (one short per channel)
+   ClassDef(TH3S,4)  //3-Dim histograms (one short per channel)
 };
 
 //________________________________________________________________________
@@ -256,7 +256,7 @@ protected:
    virtual Double_t RetrieveBinContent(Int_t bin) const { return Double_t (fArray[bin]); }
    virtual void     UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = Int_t (content); }
 
-   ClassDef(TH3I,3)  //3-Dim histograms (one 32 bits integer per channel)
+   ClassDef(TH3I,4)  //3-Dim histograms (one 32 bits integer per channel)
 };
 
 
@@ -294,7 +294,7 @@ protected:
    virtual Double_t RetrieveBinContent(Int_t bin) const { return Double_t (fArray[bin]); }
    virtual void     UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = Float_t (content); }
 
-   ClassDef(TH3F,3)  //3-Dim histograms (one float per channel)
+   ClassDef(TH3F,4)  //3-Dim histograms (one float per channel)
 };
 
 //________________________________________________________________________
@@ -331,7 +331,7 @@ protected:
    virtual Double_t RetrieveBinContent(Int_t bin) const { return fArray[bin]; }
    virtual void     UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = content; }
 
-   ClassDef(TH3D,3)  //3-Dim histograms (one double per channel)
+   ClassDef(TH3D,4)  //3-Dim histograms (one double per channel)
 };
 
 #endif

--- a/hist/hist/inc/TProfile.h
+++ b/hist/hist/inc/TProfile.h
@@ -133,7 +133,7 @@ public:
    virtual void     SetErrorOption(Option_t *option=""); // *MENU*
    virtual void     Sumw2(Bool_t flag = kTRUE);
 
-   ClassDef(TProfile,6)  //Profile histogram class
+   ClassDef(TProfile,7)  //Profile histogram class
 };
 
 #endif

--- a/hist/hist/inc/TProfile2D.h
+++ b/hist/hist/inc/TProfile2D.h
@@ -143,7 +143,7 @@ public:
    virtual void      Sumw2(Bool_t flag = kTRUE);
    Double_t GetNumberOfBins() { return fBinEntries.GetSize(); }
 
-   ClassDef(TProfile2D,7)  //Profile2D histogram class
+   ClassDef(TProfile2D,8)  //Profile2D histogram class
 };
 
 #endif

--- a/hist/hist/inc/TProfile2Poly.h
+++ b/hist/hist/inc/TProfile2Poly.h
@@ -111,6 +111,6 @@ protected:
    Int_t OverflowIdxToArrayIdx(Int_t val) { return -val - 1; }
 
 
-   ClassDefOverride(TProfile2Poly, 1)
+   ClassDefOverride(TProfile2Poly, 2)
 };
 #endif

--- a/hist/hist/inc/TProfile3D.h
+++ b/hist/hist/inc/TProfile3D.h
@@ -142,7 +142,7 @@ public:
    virtual void      SetErrorOption(Option_t *option=""); // *MENU*
    virtual void      Sumw2(Bool_t flag = kTRUE);
 
-   ClassDef(TProfile3D,7)  //Profile3D histogram class
+   ClassDef(TProfile3D,8)  //Profile3D histogram class
 };
 
 #endif


### PR DESCRIPTION
This is a follow-up on 8c9c1a3fbe3a1c5704635f8941abeb9596104c77.

At the moment, the derived class StreamerInfo contains the base class version number :(
This means we need to update the derived class version number when the base class number increases ...

This solves the problem seen at: https://root-forum.cern.ch/t/problem-in-opening-past-rootfile-tclonesarray-with-th1s-with-root-v6-16-and-ubuntu18/33293/1