### PR TITLE
[cxxmodules] Do not attach an overlay file if no -cxxmodule is specif…

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -4266,6 +4266,10 @@ int RootClingMain(int argc,
 
    if (!isPCH && cxxmodule) {
 #ifndef R__MACOSX
+      // Add the overlay file. Note that we cannot factor it out for both root
+      // and rootcling because rootcling activates modules only if -cxxmodule
+      // flag is passed.
+
       // includeDir is where modulemaps exist.
       clingArgsInterpreter.push_back("-modulemap_overlay=" + includeDir);
 #endif //R__MACOSX

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1206,14 +1206,16 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
       }
    }
 
-   if (fCxxModulesEnabled) {
-      clingArgsStorage.push_back("-modulemap_overlay=" + std::string(TROOT::GetIncludeDir().Data()));
-   }
-
    // FIXME: This only will enable frontend timing reports.
    EnvOpt = llvm::sys::Process::GetEnv("ROOT_CLING_TIMING");
    if (EnvOpt.hasValue())
      clingArgsStorage.push_back("-ftime-report");
+
+   // Add the overlay file. Note that we cannot factor it out for both root
+   // and rootcling because rootcling activates modules only if -cxxmodule
+   // flag is passed.
+   if (fCxxModulesEnabled && !fromRootCling)
+      clingArgsStorage.push_back("-modulemap_overlay=" + std::string(TROOT::GetIncludeDir().Data()));
 
    std::vector<const char*> interpArgs;
    for (std::vector<std::string>::const_iterator iArg = clingArgsStorage.begin(),


### PR DESCRIPTION
…ied.

We cannot merge both codepaths because root.exe should always run with modules
if -Druntime_cxxmodules is specified, however, rootcling enables modules only
if -cxxmodule flag is passed.

This patch fixes asserts when ROOT is built in -Druntime_cxxmodules=On but
no -cxxmodule flag is specified (in tree/test for instance).