### PR TITLE
[build] makepchinput.py: Fix ceb925ae1e:

### DIFF
--- a/build/unix/makepchinput.py
+++ b/build/unix/makepchinput.py
@@ -192,8 +192,8 @@ def getDictNames(theDirName):
    allDictNames = []
    for wildcard in wildcards:
       allDictNames += glob.glob(wildcard)
-   stdDictpattern = os.path.join("core","metautils","src","G__std_", "roottest")
-   dictNames = filter (lambda dictName: not (stdDictpattern in dictName),allDictNames )
+   stdDictpattern = os.path.join("core","metautils","src","G__std_")
+   dictNames = filter (lambda dictName: not (stdDictpattern in dictName or "/roottest/" in dictName),allDictNames )
    return dictNames
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This was appending "roottest" to the filter string, instead of *also* filtering "roottest".
roottest dictionaries will always have full path names, so veto "/roottest/".
Fixes 19 incremental failures that ceb925ae1e claimed to fix:

    projectroot.roottest.root.meta.roottest_root_meta_drawing
    projectroot.roottest.root.tree.split.roottest_root_tree_split_make
    projectroot.roottest.root.treeformula.parse.roottest_root_treeformula_parse_make
    projectroot.roottest.root.treeformula.sync.roottest_root_treeformula_sync_make
    projectroot.roottest.root.tree.selector.roottest_root_tree_selector_make
    projectroot.roottest.root.io.fakeClass.roottest_root_io_fakeClass_make
    projectroot.roottest.root.tree.addresses.roottest_root_tree_addresses_make
    projectroot.roottest.root.treeformula.retobj.roottest_root_treeformula_retobj_make
    projectroot.roottest.root.treeproxy.roottest_root_treeproxy_make
    projectroot.roottest.root.treeformula.schemaEvolution.roottest_root_treeformula_schemaEvolution_make
    projectroot.roottest.root.tree.evolution.roottest_root_tree_evolution_make
    projectroot.roottest.root.treeformula.array.roottest_root_treeformula_array_make
    projectroot.roottest.root.meta.tclass.roottest_root_meta_tclass_execState
    projectroot.roottest.root.meta.roottest_root_meta_runautoload_auto
    projectroot.roottest.root.collection.roottest_root_collection_execMissing
    projectroot.test.test_stresstmva_interpreted
    projectroot.roottest.root.io.evolution.roottest_root_io_evolution_make
    projectroot.roottest.root.io.datamodelevolution.roottest_root_io_datamodelevolution_make
    projectroot.roottest.root.tree.friend.roottest_root_tree_friend_make.