### PR TITLE
Fix the logic when using TMVA::gConfig().EnableMT/DIsableMT()

### DIFF
--- a/tmva/tmva/inc/TMVA/Config.h
+++ b/tmva/tmva/inc/TMVA/Config.h
@@ -83,7 +83,7 @@ namespace TMVA {
       Executor & GetThreadExecutor() { return fExecutor; }
 
       /// Enable MT in TMVA (by default is on when ROOT::EnableImplicitMT() is set
-      void EnableMT(int numthreads) { fExecutor = Executor(numthreads); }
+      void EnableMT(int numthreads = 0) { fExecutor = Executor(numthreads); }
 
       /// Force disabling MT running and release the thread pool by using instead seriaql execution
       void DisableMT() {  fExecutor = Executor(1); }


### PR DESCRIPTION
- when ROOT::IsEnableImplicitMT() TMVA will run by default in MT
- when TMVA::gConfig().EnableMT(0) or TMVA::gConfig().EnableMT(nthreads > 1)  TMVA will run in MT independently of ROOT::IsEnabledImplicitMT()
- when TMVA::gConfig().EnableMT(1) or TMVA::gConfig().DisableMT()  TMVA will run sequentially and its thread pool will be released