### PR TITLE
[RDF] Add Python version of Dimuon tutorial

### DIFF
--- a/math/vecops/CMakeLists.txt
+++ b/math/vecops/CMakeLists.txt
@@ -31,6 +31,7 @@ endif()
 
 if(MSVC)
   target_compile_options(ROOTVecOps PRIVATE -O2 /fp:fast)
+  target_compile_definitions(ROOTVecOps PRIVATE _USE_MATH_DEFINES)
 else()
   target_compile_options(ROOTVecOps PRIVATE -O3 -ffast-math)
 endif()

--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -37,6 +37,16 @@
 #include <vdt/vdtMath.h>
 #endif
 
+// TODO: Figure out best way to get pi on windows
+// TODO: ROOT::Internal::VecOps::pi is set to float because of narrowing errors on windows.
+#if defined(_MSC_VER)
+#include <math.h>
+#endif
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846264338328
+#endif
+
 namespace ROOT {
 namespace VecOps {
 template <typename T>
@@ -44,6 +54,8 @@ class RVec;
 }
 namespace Internal {
 namespace VecOps {
+
+constexpr float pi = M_PI;
 
 // We use this helper to workaround a limitation of compilers such as
 // gcc 4.8 amd clang on osx 10.14 for which std::vector<bool>::emplace_back
@@ -1454,7 +1466,7 @@ RVec<Common_t> Concatenate(const RVec<T0> &v0, const RVec<T1> &v1)
 /// The computation is done per default in radians \f$c = \pi\f$ but can be switched
 /// to degrees \f$c = 180\f$.
 template <typename T>
-T DeltaPhi(T v1, T v2, const T c = M_PI)
+T DeltaPhi(T v1, T v2, const T c = ROOT::Internal::VecOps::pi)
 {
    static_assert(std::is_floating_point<T>::value,
                  "DeltaPhi must be called with floating point values.");
@@ -1475,7 +1487,7 @@ T DeltaPhi(T v1, T v2, const T c = M_PI)
 /// The computation is done per default in radians \f$c = \pi\f$ but can be switched
 /// to degrees \f$c = 180\f$.
 template <typename T>
-RVec<T> DeltaPhi(const RVec<T>& v1, const RVec<T>& v2, const T c = M_PI)
+RVec<T> DeltaPhi(const RVec<T>& v1, const RVec<T>& v2, const T c = ROOT::Internal::VecOps::pi)
 {
    using size_type = typename RVec<T>::size_type;
    const size_type size = v1.size();
@@ -1493,7 +1505,7 @@ RVec<T> DeltaPhi(const RVec<T>& v1, const RVec<T>& v2, const T c = M_PI)
 /// The computation is done per default in radians \f$c = \pi\f$ but can be switched
 /// to degrees \f$c = 180\f$.
 template <typename T>
-RVec<T> DeltaPhi(const RVec<T>& v1, T v2, const T c = M_PI)
+RVec<T> DeltaPhi(const RVec<T>& v1, T v2, const T c = ROOT::Internal::VecOps::pi)
 {
    using size_type = typename RVec<T>::size_type;
    const size_type size = v1.size();
@@ -1511,7 +1523,7 @@ RVec<T> DeltaPhi(const RVec<T>& v1, T v2, const T c = M_PI)
 /// The computation is done per default in radians \f$c = \pi\f$ but can be switched
 /// to degrees \f$c = 180\f$.
 template <typename T>
-RVec<T> DeltaPhi(T v1, const RVec<T>& v2, const T c = M_PI)
+RVec<T> DeltaPhi(T v1, const RVec<T>& v2, const T c = ROOT::Internal::VecOps::pi)
 {
    using size_type = typename RVec<T>::size_type;
    const size_type size = v2.size();
@@ -1530,7 +1542,8 @@ RVec<T> DeltaPhi(T v1, const RVec<T>& v2, const T c = M_PI)
 /// be set to radian or degrees using the optional argument c, see the documentation
 /// of the DeltaPhi helper.
 template <typename T>
-RVec<T> DeltaR(const RVec<T>& eta1, const RVec<T>& eta2, const RVec<T>& phi1, const RVec<T>& phi2, const T c = M_PI)
+RVec<T> DeltaR(const RVec<T>& eta1, const RVec<T>& eta2, const RVec<T>& phi1, const RVec<T>& phi2,
+               const T c = ROOT::Internal::VecOps::pi)
 {
    const auto dphi = DeltaPhi(phi1, phi2, c);
    return sqrt((eta1 - eta2) * (eta1 - eta2) + dphi * dphi);
@@ -1544,7 +1557,7 @@ RVec<T> DeltaR(const RVec<T>& eta1, const RVec<T>& eta2, const RVec<T>& phi1, co
 /// be set to radian or degrees using the optional argument c, see the documentation
 /// of the DeltaPhi helper.
 template <typename T>
-T DeltaR(T eta1, T eta2, T phi1, T phi2, const T c = M_PI)
+T DeltaR(T eta1, T eta2, T phi1, T phi2, const T c = ROOT::Internal::VecOps::pi)
 {
    const auto dphi = DeltaPhi(phi1, phi2, c);
    return std::sqrt((eta1 - eta2) * (eta1 - eta2) + dphi * dphi);

--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -25,7 +25,6 @@
 #include <ROOT/TypeTraits.hxx>
 
 #include <algorithm>
-#define _USE_MATH_DEFINES // for M_PI on windows in cmath
 #include <cmath>
 #include <numeric> // for inner_product
 #include <sstream>
@@ -1810,7 +1809,5 @@ TVEC_EXTERN_VDT_UNARY_FUNCTION(double, fast_atan)
 using ROOT::VecOps::RVec;
 
 } // namespace ROOT
-
-#undef _USE_MATH_DEFINES // for M_PI on windows in cmath
 
 #endif // ROOT_TVEC

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -963,15 +963,15 @@ TEST(VecOps, DeltaPhi)
 TEST(VecOps, InvariantMass)
 {
    // Dummy particle collections
-   RVec<float> mass1 = {50,  50,  50,   50,   100};
-   RVec<float> pt1 =   {0,   5,   5,    10,   10};
-   RVec<float> eta1 =  {0.0, 0.0, -1.0, 0.5,  2.5};
-   RVec<float> phi1 =  {0.0, 0.0, 0.0,  -0.5, -2.4};
+   RVec<double> mass1 = {50,  50,  50,   50,   100};
+   RVec<double> pt1 =   {0,   5,   5,    10,   10};
+   RVec<double> eta1 =  {0.0, 0.0, -1.0, 0.5,  2.5};
+   RVec<double> phi1 =  {0.0, 0.0, 0.0,  -0.5, -2.4};
 
-   RVec<float> mass2 = {40,  40,  40,  40,  30};
-   RVec<float> pt2 =   {0,   5,   5,   10,  2};
-   RVec<float> eta2 =  {0.0, 0.0, 0.5, 0.4, 1.2};
-   RVec<float> phi2 =  {0.0, 0.0, 0.0, 0.5, 2.4};
+   RVec<double> mass2 = {40,  40,  40,  40,  30};
+   RVec<double> pt2 =   {0,   5,   5,   10,  2};
+   RVec<double> eta2 =  {0.0, 0.0, 0.5, 0.4, 1.2};
+   RVec<double> phi2 =  {0.0, 0.0, 0.0, 0.5, 2.4};
 
    // Compute invariant mass of two particle system using both collections
    const auto invMass = InvariantMass(pt1, eta1, phi1, mass1, pt2, eta2, phi2, mass2);
@@ -1013,10 +1013,10 @@ TEST(VecOps, InvariantMass)
 
 TEST(VecOps, DeltaR)
 {
-   RVec<float> eta1 =  {0.1, -1.0, -1.0, 0.5,  -2.5};
-   RVec<float> eta2 =  {0.0, 0.0, 0.5, 2.4, 1.2};
-   RVec<float> phi1 =  {1.0, 5.0, -1.0,  -0.5, -2.4};
-   RVec<float> phi2 =  {0.0, 3.0, 6.0, 1.5, 1.4};
+   RVec<double> eta1 =  {0.1, -1.0, -1.0, 0.5,  -2.5};
+   RVec<double> eta2 =  {0.0, 0.0, 0.5, 2.4, 1.2};
+   RVec<double> phi1 =  {1.0, 5.0, -1.0,  -0.5, -2.4};
+   RVec<double> phi2 =  {0.0, 3.0, 6.0, 1.5, 1.4};
 
    auto dr = DeltaR(eta1, eta2, phi1, phi2);
    auto dr2 = DeltaR(eta2, eta1, phi2, phi1);
@@ -1026,7 +1026,7 @@ TEST(VecOps, DeltaR)
       TLorentzVector p1, p2;
       p1.SetPtEtaPhiM(1.f, eta1[i], phi1[i], 1.f);
       p2.SetPtEtaPhiM(1.f, eta2[i], phi2[i], 1.f);
-      auto dr3 = float(p2.DeltaR(p1));
+      auto dr3 = p2.DeltaR(p1);
       EXPECT_NEAR(dr3, dr[i], 1e-6);
       EXPECT_NEAR(dr3, dr2[i], 1e-6);
 

--- a/tutorials/dataframe/df102_NanoAODDimuonAnalysis.py
+++ b/tutorials/dataframe/df102_NanoAODDimuonAnalysis.py
@@ -1,0 +1,72 @@
+## \file
+## \ingroup tutorial_dataframe
+## \notebook -draw
+## This tutorial illustrates how NanoAOD files can be processed with ROOT
+## dataframes. The NanoAOD-like input files are filled with 66 mio. events
+## from CMS OpenData containing muon candidates part of 2012 dataset
+## ([DOI: 10.7483/OPENDATA.CMS.YLIC.86ZZ](http://opendata.cern.ch/record/6004)
+## and [DOI: 10.7483/OPENDATA.CMS.M5AD.Y3V3](http://opendata.cern.ch/record/6030)).
+## The macro matches muon pairs and produces an histogram of the dimuon mass
+## spectrum showing resonances up to the Z mass.
+## Note that the bump at 30 GeV is not a resonance but a trigger effect.
+##
+## Some more details about the dataset:
+##   - It contains about 66 millions events (muon and electron collections, plus some other information, e.g. about primary vertices)
+##   - It spans two compressed ROOT files located on EOS for about a total size of 7.5 GB.
+##
+## \macro_image
+## \macro_code
+## \macro_output
+##
+## \date April 2019
+## \author Stefan Wunsch (KIT, CERN)
+
+import ROOT
+
+# Enable multi-threading
+ROOT.ROOT.EnableImplicitMT()
+
+# Create dataframe from NanoAOD files
+files = ROOT.std.vector("string")(2)
+files[0] = "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root"
+files[1] = "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012C_DoubleMuParked.root"
+df = ROOT.ROOT.RDataFrame("Events", files)
+
+# For simplicity, select only events with exactly two muons and require opposite charge
+df_2mu = df.Filter("nMuon == 2", "Events with exactly two muons")
+df_os = df_2mu.Filter("Muon_charge[0] != Muon_charge[1]", "Muons with opposite charge")
+
+# Compute invariant mass of the dimuon system
+df_mass = df_os.Define("Dimuon_mass", "InvariantMass(Muon_pt, Muon_eta, Muon_phi, Muon_mass)")
+
+# Make histogram of dimuon mass spectrum
+h = df_mass.Histo1D(("Dimuon_mass", "Dimuon_mass", 30000, 0.25, 300), "Dimuon_mass")
+
+# Request cut-flow report
+report = df_mass.Report()
+
+# Produce plot
+ROOT.gStyle.SetOptStat(0); ROOT.gStyle.SetTextFont(42)
+c = ROOT.TCanvas("c", "", 800, 700)
+c.SetLogx(); c.SetLogy()
+
+h.SetTitle("")
+h.GetXaxis().SetTitle("m_{#mu#mu} (GeV)"); h.GetXaxis().SetTitleSize(0.04)
+h.GetYaxis().SetTitle("N_{Events}"); h.GetYaxis().SetTitleSize(0.04)
+h.Draw()
+
+label = ROOT.TLatex(); label.SetNDC(True)
+label.DrawLatex(0.175, 0.740, "#eta")
+label.DrawLatex(0.205, 0.775, "#rho,#omega")
+label.DrawLatex(0.270, 0.740, "#phi")
+label.DrawLatex(0.400, 0.800, "J/#psi")
+label.DrawLatex(0.415, 0.670, "#psi'")
+label.DrawLatex(0.485, 0.700, "Y(1,2,3S)")
+label.DrawLatex(0.755, 0.680, "Z")
+label.SetTextSize(0.040); label.DrawLatex(0.100, 0.920, "#bf{CMS Open Data}")
+label.SetTextSize(0.030); label.DrawLatex(0.630, 0.920, "#sqrt{s} = 8 TeV, L_{int} = 11.6 fb^{-1}")
+
+c.SaveAs("dimuon_spectrum.pdf")
+
+# Print cut-flow report
+report.Print()


### PR DESCRIPTION
Add python version of RDF tutorial producing dimuon spectrum from CMS Open Data.

This PR depends on #3571.