### PR TITLE
Fix dupe G__Imt target v6 16

### DIFF
--- a/core/imt/CMakeLists.txt
+++ b/core/imt/CMakeLists.txt
@@ -2,20 +2,7 @@
 # CMakeLists.txt file for building ROOT core/imt package
 ############################################################################
 
-ROOT_LINKER_LIBRARY(Imt
-    src/base.cxx
-    src/TTaskGroup.cxx
-  DEPENDENCIES
-    Core
-    Thread
-  BUILTINS
-    TBB
-)
-
 if(imt)
-  target_include_directories(Imt PRIVATE ${TBB_INCLUDE_DIRS})
-  target_link_libraries(Imt PUBLIC ${TBB_LIBRARIES})
-
   ROOT_GENERATE_DICTIONARY(G__Imt STAGE1
     ROOT/TFuture.hxx
     ROOT/TPoolManager.hxx
@@ -31,9 +18,24 @@ if(imt)
     BUILTINS
       TBB
   )
+endif()
 
+ROOT_LINKER_LIBRARY(Imt
+    src/base.cxx
+    src/TTaskGroup.cxx
+  DEPENDENCIES
+    Core
+    Thread
+  BUILTINS
+    TBB
+)
+
+if(imt)
+  target_include_directories(Imt PRIVATE ${TBB_INCLUDE_DIRS})
+  target_link_libraries(Imt PUBLIC ${TBB_LIBRARIES})
+
+  # G__Imt.cxx is automatically added by ROOT_LINKER_LIBRARY.
   target_sources(Imt PRIVATE
-    G__Imt.cxx
     src/TImplicitMT.cxx
     src/TPoolManager.cxx
     src/TThreadExecutor.cxx


### PR DESCRIPTION
ROOT_LINKER_LIBRARY implicitly adds G__XYZ as dependency if that target exists.
This causes Imt to depend both on G__Imt and G__Imt.cxx, triggering the dictionary build twice.
See the result of $ grep -r "Generating G__Imt" core/imt
   core/imt/CMakeFiles/Imt.dir/build.make:@$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --blue --bold --progress-dir=/Users/axel/build/root/cmake/CMakeFiles --progress-num=$(CMAKE_PROGRESS_1) "Generating G__Imt.cxx, ../../lib/libImt.rootmap"
   core/imt/CMakeFiles/G__Imt.dir/build.make:@$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --blue --bold --progress-dir=/Users/axel/build/root/cmake/CMakeFiles --progress-num=$(CMAKE_PROGRESS_1) "Generating G__Imt.cxx, ../../lib/libImt.rootmap"

With this change, G__Imt.cxx has only one target:
$ grep -r "Generating G__Imt" core/imt
   core/imt/CMakeFiles/G__Imt.dir/build.make:@$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --blue --bold --progress-dir=/Users/axel/build/root/cmake/CMakeFiles --progress-num=$(CMAKE_PROGRESS_1) "Generating G__Imt.cxx, ../../lib/libImt.rootmap"

This fixes sporadic build problems due to two targets creating the same output file concurrently:
[ 73%] Generating G__Imt.cxx, ../../lib/libImt.rootmap
Scanning dependencies of target G__Imt
[ 73%] Generating G__Imt.cxx, ../../lib/libImt.rootmap
[ 73%] Building CXX object core/imt/CMakeFiles/Imt.dir/G__Imt.cxx.o
g++: error: /mnt/build/workspace/lcg_release_tar/BUILDTYPE/Debug/COMPILER/native/LABEL/ubuntu16/build/projects/ROOT-6.16.00/src/ROOT-6.16.00-build/core/imt/G__Imt.cxx: No such file or directory
g++: fatal error: no input files
compilation terminated.
core/imt/CMakeFiles/Imt.dir/build.make:106: recipe for target 'core/imt/CMakeFiles/Imt.dir/G__Imt.cxx.o' failed
make[5]: *** [core/imt/CMakeFiles/Imt.dir/G__Imt.cxx.o] Error 1
[ 73%] Built target G__Imt
make[5]: Target 'core/imt/CMakeFiles/Imt.dir/build' not remade because of errors.
CMakeFiles/Makefile2:18311: recipe for target 'core/imt/CMakeFiles/Imt.dir/all' failed
make[4]: *** [core/imt/CMakeFiles/Imt.dir/all] Error 2

(cherry picked from commit a3e7a3c535b80c3a6cf0883a0bf8de66eca7d93f)