### PR TITLE
[TCling] Add iterator of using declarations to TClingMethodInfo

### DIFF
--- a/core/meta/inc/TListOfFunctions.h
+++ b/core/meta/inc/TListOfFunctions.h
@@ -79,7 +79,7 @@ public:
 
 
    TFunction *Find(DeclId_t id) const;
-   TFunction *Get(DeclId_t id);
+   TFunction *Get(DeclId_t id, bool verify = true);
 
    void       AddFirst(TObject *obj);
    void       AddFirst(TObject *obj, Option_t *opt);

--- a/core/meta/src/TListOfFunctions.cxx
+++ b/core/meta/src/TListOfFunctions.cxx
@@ -259,7 +259,7 @@ TFunction *TListOfFunctions::Find(DeclId_t id) const
 /// Return (after creating it if necessary) the TMethod or TFunction
 /// describing the function corresponding to the Decl 'id'.
 
-TFunction *TListOfFunctions::Get(DeclId_t id)
+TFunction *TListOfFunctions::Get(DeclId_t id, bool verify)
 {
    if (!id) return 0;
 
@@ -268,10 +268,12 @@ TFunction *TListOfFunctions::Get(DeclId_t id)
    TFunction *f = Find(id);
    if (f) return f;
 
-   if (fClass) {
-      if (!gInterpreter->ClassInfo_Contains(fClass->GetClassInfo(),id)) return 0;
-   } else {
-      if (!gInterpreter->ClassInfo_Contains(0,id)) return 0;
+   if (verify) {
+      if (fClass) {
+         if (!gInterpreter->ClassInfo_Contains(fClass->GetClassInfo(),id)) return 0;
+      } else {
+         if (!gInterpreter->ClassInfo_Contains(0,id)) return 0;
+      }
    }
 
    MethodInfo_t *m = gInterpreter->MethodInfo_Factory(id);
@@ -393,7 +395,7 @@ void TListOfFunctions::Load()
          TDictionary::DeclId_t mid = gInterpreter->GetDeclId(t);
          // Get will check if there is already there or create a new one
          // (or re-use a previously unloaded version).
-         Get(mid);
+         Get(mid, false /* verify */);
       }
    }
    gInterpreter->MethodInfo_Delete(t);

--- a/core/metacling/src/TClingMethodInfo.h
+++ b/core/metacling/src/TClingMethodInfo.h
@@ -54,6 +54,7 @@ class TClingTypeInfo;
 class TClingMethodInfo final : public TClingDeclInfo {
 private:
    class SpecIterator;
+   class UsingIterator;
 
    cling::Interpreter                          *fInterp; // Cling interpreter, we do *not* own.
    llvm::SmallVector<clang::DeclContext *, 2>   fContexts; // Set of DeclContext that we will iterate over.
@@ -62,13 +63,14 @@ private:
    clang::DeclContext::decl_iterator            fIter; // Our iterator.
    std::string                                  fTitle; // The meta info for the method.
    SpecIterator                                *fTemplateSpecIter; // Iter over template specialization. [We own]
+   UsingIterator                               *fUsingIter; // for internal loop over using functions
 
    const clang::Decl* GetDeclSlow() const;
 
 public:
    explicit TClingMethodInfo(cling::Interpreter *interp)
       : TClingDeclInfo(nullptr), fInterp(interp), fFirstTime(true), fContextIdx(0U), fTitle(""),
-        fTemplateSpecIter(0) {}
+        fTemplateSpecIter(0), fUsingIter(0) {}
 
    TClingMethodInfo(const TClingMethodInfo&);
 


### PR DESCRIPTION
Ported from Cppyy patch by @wlav :`
https://bitbucket.org/wlav/cppyy-backend/src/master/cling/patches/using_decls.diff

Adds an iterator for using declarations to `TClingMethodInfo`.

it should make redundant the pythonisations that add the method overloads from a base class to the derived class that uses them:
https://github.com/root-project/root/blob/master/bindings/pyroot_experimental/PyROOT/src/PyzPythonHelpers.cxx#L113

Instead of relying on pythonisations for specific classes, this PR adds the necessary logic to have this functionality solved in a generic way in the bindings.
