### PR TITLE
[VecOps] Use better solution to pick up M_PI on windows

### DIFF
--- a/math/vecops/CMakeLists.txt
+++ b/math/vecops/CMakeLists.txt
@@ -31,7 +31,6 @@ endif()
 
 if(MSVC)
   target_compile_options(ROOTVecOps PRIVATE -O2 /fp:fast)
-  target_compile_definitions(ROOTVecOps PRIVATE _USE_MATH_DEFINES)
 else()
   target_compile_options(ROOTVecOps PRIVATE -O3 -ffast-math)
 endif()

--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -26,7 +26,6 @@
 #include <ROOT/TypeTraits.hxx>
 
 #include <algorithm>
-#include <cmath>
 #include <numeric> // for inner_product
 #include <sstream>
 #include <stdexcept>
@@ -34,19 +33,18 @@
 #include <vector>
 #include <utility>
 
+#define _USE_MATH_DEFINES // enable definition of M_PI
+#ifdef _WIN32
+// cmath does not expose M_PI on windows
+#include <math.h>
+#else
+#include <cmath>
+#endif
+
 #ifdef R__HAS_VDT
 #include <vdt/vdtMath.h>
 #endif
 
-// TODO: Figure out best way to get pi on windows
-// TODO: ROOT::Internal::VecOps::pi is set to float because of narrowing errors on windows.
-#if defined(_MSC_VER)
-#include <math.h>
-#endif
-
-#ifndef M_PI
-#define M_PI 3.14159265358979323846264338328
-#endif
 
 namespace ROOT {
 namespace VecOps {
@@ -93,8 +91,6 @@ auto MapFromTuple(Tuple_t &&t, std::index_sequence<Is...>)
 
 namespace Internal {
 namespace VecOps {
-
-constexpr float pi = M_PI;
 
 // We use this helper to workaround a limitation of compilers such as
 // gcc 4.8 amd clang on osx 10.14 for which std::vector<bool>::emplace_back
@@ -1524,7 +1520,7 @@ RVec<Common_t> Concatenate(const RVec<T0> &v0, const RVec<T1> &v1)
 /// The computation is done per default in radians \f$c = \pi\f$ but can be switched
 /// to degrees \f$c = 180\f$.
 template <typename T>
-T DeltaPhi(T v1, T v2, const T c = ROOT::Internal::VecOps::pi)
+T DeltaPhi(T v1, T v2, const T c = M_PI)
 {
    static_assert(std::is_floating_point<T>::value,
                  "DeltaPhi must be called with floating point values.");
@@ -1545,7 +1541,7 @@ T DeltaPhi(T v1, T v2, const T c = ROOT::Internal::VecOps::pi)
 /// The computation is done per default in radians \f$c = \pi\f$ but can be switched
 /// to degrees \f$c = 180\f$.
 template <typename T>
-RVec<T> DeltaPhi(const RVec<T>& v1, const RVec<T>& v2, const T c = ROOT::Internal::VecOps::pi)
+RVec<T> DeltaPhi(const RVec<T>& v1, const RVec<T>& v2, const T c = M_PI)
 {
    using size_type = typename RVec<T>::size_type;
    const size_type size = v1.size();
@@ -1563,7 +1559,7 @@ RVec<T> DeltaPhi(const RVec<T>& v1, const RVec<T>& v2, const T c = ROOT::Interna
 /// The computation is done per default in radians \f$c = \pi\f$ but can be switched
 /// to degrees \f$c = 180\f$.
 template <typename T>
-RVec<T> DeltaPhi(const RVec<T>& v1, T v2, const T c = ROOT::Internal::VecOps::pi)
+RVec<T> DeltaPhi(const RVec<T>& v1, T v2, const T c = M_PI)
 {
    using size_type = typename RVec<T>::size_type;
    const size_type size = v1.size();
@@ -1581,7 +1577,7 @@ RVec<T> DeltaPhi(const RVec<T>& v1, T v2, const T c = ROOT::Internal::VecOps::pi
 /// The computation is done per default in radians \f$c = \pi\f$ but can be switched
 /// to degrees \f$c = 180\f$.
 template <typename T>
-RVec<T> DeltaPhi(T v1, const RVec<T>& v2, const T c = ROOT::Internal::VecOps::pi)
+RVec<T> DeltaPhi(T v1, const RVec<T>& v2, const T c = M_PI)
 {
    using size_type = typename RVec<T>::size_type;
    const size_type size = v2.size();
@@ -1614,8 +1610,7 @@ RVec<T> DeltaR2(const RVec<T>& eta1, const RVec<T>& eta2, const RVec<T>& phi1, c
 /// be set to radian or degrees using the optional argument c, see the documentation
 /// of the DeltaPhi helper.
 template <typename T>
-RVec<T> DeltaR(const RVec<T>& eta1, const RVec<T>& eta2, const RVec<T>& phi1, const RVec<T>& phi2,
-               const T c = ROOT::Internal::VecOps::pi)
+RVec<T> DeltaR(const RVec<T>& eta1, const RVec<T>& eta2, const RVec<T>& phi1, const RVec<T>& phi2, const T c = M_PI)
 {
    return sqrt(DeltaR2(eta1, eta2, phi1, phi2, c));
 }
@@ -1628,7 +1623,7 @@ RVec<T> DeltaR(const RVec<T>& eta1, const RVec<T>& eta2, const RVec<T>& phi1, co
 /// be set to radian or degrees using the optional argument c, see the documentation
 /// of the DeltaPhi helper.
 template <typename T>
-T DeltaR(T eta1, T eta2, T phi1, T phi2, const T c = ROOT::Internal::VecOps::pi)
+T DeltaR(T eta1, T eta2, T phi1, T phi2, const T c = M_PI)
 {
    const auto dphi = DeltaPhi(phi1, phi2, c);
    return std::sqrt((eta1 - eta2) * (eta1 - eta2) + dphi * dphi);


### PR DESCRIPTION
Many thanks to @bellenot !
Let's check whether the PR builds are happy with this.

Remaining issue with this: Is it ok to include `math.h` or `cmath` (or even both?) based on the platform? Could this interfere with picking up the overloads for the fast math functions since `math.h` and `cmath` define their API in different namespaces?

@lmoneta You have insights into this? The PR works but still, I feel a little uncomfortable since I do not fully understand the impact of the different includes.