### PR TITLE
[clad] Bump clad version to v0.5.

### DIFF
--- a/README/ReleaseNotes/v618/index.md
+++ b/README/ReleaseNotes/v618/index.md
@@ -118,6 +118,21 @@ Added necessary changes to allow [XRootD local redirection](https://github.com/x
   - Add the `DeltaR2` and `DeltaR` helpers for RVec.
   - Add the `Max`, `Min`, `ArgMax`, and `ArgMin` helpers for RVec.
 
+### [Clad](https://github.com/vgvassilev/clad)
+  - Upgrade Clad to 0.5 The new release includes some improvements in both
+    Forward and Reverse mode:
+    * Extend the way to specify a dependent variables. Consider function,
+      `double f(double x, double y, double z) {...}`, `clad::differentiate(f, "z")`
+      is equivalent to `clad::differentiate(f, 2)`. `clad::gradient(f, "x, y")`
+      differentiates with respect to `x` and `y` but not `z`. The gradient results
+      are stored in a `_result` parameter in the same order as `x` and `y` were
+      specified. Namely, the result of `x` is stored in `_result[0]` and the result
+      of `y` in `_result[1]`. If we invert the arguments specified in the string to
+      `clad::gradient(f, "y, x")` the results will be stored inversely.
+    * Enable recursive differentiation.
+    * Support single- and multi-dimensional arrays -- works for arrays with constant
+      size like `double A[] = {1, 2, 3};`, `double A[3];` or `double A[1][2][3][4];`
+
 ## RooFit Libraries
 ### HistFactory
 hist2workspace performance optimisations. For a large, ATLAS-style Higgs-->bb workspace with > 100 systematic uncertainties and more than 10 channels, the run time decreases by a factor 11 to 12.

--- a/interpreter/cling/tools/plugins/clad/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/clad/CMakeLists.txt
@@ -29,7 +29,7 @@ if(MSVC)
   ExternalProject_Add(
     clad
     GIT_REPOSITORY https://github.com/vgvassilev/clad.git
-    GIT_TAG v0.4
+    GIT_TAG v0.5
     UPDATE_COMMAND ""
     CMAKE_ARGS -G ${CMAKE_GENERATOR} -DCLAD_BUILD_STATIC_ONLY=ON
                -DCMAKE_INSTALL_PREFIX=${clad_install_dir}/plugins
@@ -59,7 +59,7 @@ else()
   ExternalProject_Add(
     clad
     GIT_REPOSITORY https://github.com/vgvassilev/clad.git
-    GIT_TAG v0.4
+    GIT_TAG v0.5
     UPDATE_COMMAND ""
     CMAKE_ARGS -G ${CMAKE_GENERATOR}
                -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}


### PR DESCRIPTION
The new release includes some improvements in both Forward and
Reverse mode:
* Extend the way to specify a dependent variables. Consider function, `double f(double x, double y, double z) {...}`, `clad::differentiate(f, "z")` is equivalent to `clad::differentiate(f, 2)`. `clad::gradient(f, "x, y")` differentiates with respect to `x` and `y` but not `z`. The gradient results are stored in a `_result` parameter in the same order as `x` and `y` were specified. Namely, the result of `x` is stored in `_result[0]` and the result of `y` in `_result[1]`. If we invert the arguments specified in the string to `clad::gradient(f, "y, x")` the results will be stored inversely.
* Enable recursive differentiation.
* Support single- and multi-dimensional arrays -- works for arrays with constant size like `double A[] = {1, 2, 3};`, `double A[3];` or `double A[1][2][3][4];`

See more at: https://github.com/vgvassilev/clad/blob/v0.5/docs/ReleaseNotes.md

Kudos go to @efremale!