### PR TITLE
[IO][ROOT-8425] Fix streamerinfo build check for string

### DIFF
--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -749,6 +749,13 @@ void TStreamerInfo::BuildCheck(TFile *file /* = 0 */)
             return;
          }
       }
+
+      if (0 == strcmp("string",fClass->GetName())) {
+         // We know we do not need any offset check for a string
+         SetBit(kCanDelete);
+         return;
+      }
+
       const TObjArray *array = fClass->GetStreamerInfos();
       TStreamerInfo* info = 0;
 


### PR DESCRIPTION
since it is a special class: we are not interested in the actual
layout, it is opaque for the ROOT IO being it part of the STL.