### PR TITLE
[foundation] libC++ does not set __cpp_lib_not_fn:

### DIFF
--- a/core/foundation/inc/ROOT/RNotFn.hxx
+++ b/core/foundation/inc/ROOT/RNotFn.hxx
@@ -16,8 +16,12 @@
 
 #include <functional>
 
-// Backport if not_fn is not available
-#ifndef __cpp_lib_not_fn
+// Backport if not_fn is not available.
+// libc++ does not define __cpp_lib_not_fn.
+// Assume we have not_fn if libc++ is compiled with C++14 and up.
+#if !defined(__cpp_lib_not_fn) && !(defined(_LIBCPP_VERSION) && __cplusplus > 201103L)
+
+#define R__NOTFN_BACKPORT
 
 #include <type_traits> // std::decay
 #include <utility>     // std::forward, std::declval

--- a/core/foundation/test/testNotFn.cxx
+++ b/core/foundation/test/testNotFn.cxx
@@ -1,6 +1,8 @@
 #include "ROOT/RNotFn.hxx"
 
-#ifndef __cpp_lib_not_fn
+// libc++ does not define __cpp_lib_not_fn.
+// Assume we have not_fn if
+#if defined(R__NOTFN_BACKPORT)
 
 #include "gtest/gtest.h"
 


### PR DESCRIPTION
Instead, test for libC++ and language version.
This fixes MacOS builds with >=C++14 and tests enabled.