### PR TITLE
[RF] RooDataSet::sumEntries not callable from Python.

### DIFF
--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -1028,7 +1028,7 @@ Double_t RooDataSet::sumEntries(const char* cutSpec, const char* cutRange) const
 {
   // Setup RooFormulaVar for cutSpec if it is present
   RooFormula* select = 0 ;
-  if (cutSpec) {
+  if (cutSpec && strlen(cutSpec) > 0) {
     select = new RooFormula("select",cutSpec,*get()) ;
   }
   


### PR DESCRIPTION
Due to a missing converter in the old cppyy, one cannot call a function
that takes a `const char*` with a nullptr.
To make it callable from Python already now, one can also call with an
empty string now.

See also:
https://root-forum.cern.ch/t/sumentries-cutrange-in-pyroot/33499