### PR TITLE
WebGui6: Support interactive changes on TWebCanvas

### DIFF
--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -43,6 +43,7 @@ class TWebObjectOptions {
 public:
    std::string snapid; ///< id of the object
    std::string opt;    ///< drawing options
+   std::vector<double> fopt; ///< float array for custom options
 };
 
 /// Class used to transport ranges from JSROOT canvas

--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -41,9 +41,10 @@ class TWebPS;
 /// Class used to transport drawing options from the client
 class TWebObjectOptions {
 public:
-   std::string snapid; ///< id of the object
-   std::string opt;    ///< drawing options
-   std::vector<double> fopt; ///< float array for custom options
+   std::string snapid;       ///< id of the object
+   std::string opt;          ///< drawing options
+   std::string fcust;        ///< custom string
+   std::vector<double> fopt; ///< custom float array
 };
 
 /// Class used to transport ranges from JSROOT canvas

--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -137,8 +137,10 @@ protected:
    void CreateObjectSnapshot(TPadWebSnapshot &master, TPad *pad, TObject *obj, const char *opt, TWebPS *masterps = nullptr);
    void CreatePadSnapshot(TPadWebSnapshot &paddata, TPad *pad, Long64_t version, PadPaintingReady_t func);
 
-   TObject *FindPrimitive(const char *id, TPad *pad = nullptr, TObjLink **padlnk = nullptr);
+   TObject *FindPrimitive(const char *id, TPad *pad = nullptr, TObjLink **padlnk = nullptr, TPad **objpad = nullptr);
+   void ProcessObjectData(TWebObjectOptions &item, TPad *pad);
    Bool_t DecodeAllRanges(const char *arg);
+   Bool_t DecodeObjectData(const char *arg);
 
    Bool_t IsAnyPadModified(TPad *pad);
 

--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -138,7 +138,7 @@ protected:
    void CreatePadSnapshot(TPadWebSnapshot &paddata, TPad *pad, Long64_t version, PadPaintingReady_t func);
 
    TObject *FindPrimitive(const char *id, TPad *pad = nullptr, TObjLink **padlnk = nullptr, TPad **objpad = nullptr);
-   void ProcessObjectData(TWebObjectOptions &item, TPad *pad);
+   TPad *ProcessObjectData(TWebObjectOptions &item, TPad *pad);
    Bool_t DecodeAllRanges(const char *arg);
    Bool_t DecodeObjectData(const char *arg);
 

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -664,13 +664,26 @@ Bool_t TWebCanvas::DecodeAllRanges(const char *arg)
       pad->SetBottomMargin(r.mbottom);
 
       for (unsigned k = 0; k < r.primitives.size(); ++k) {
+         auto &item = r.primitives[k];
          TObjLink *lnk = nullptr;
-         TObject *obj = FindPrimitive(r.primitives[k].snapid.c_str(), pad, &lnk);
-         if (obj && lnk) {
+         TObject *obj = FindPrimitive(item.snapid.c_str(), pad, &lnk);
+
+         if (r.primitives[k].opt == "$frame$") {
+            if (obj && obj->InheritsFrom(TFrame::Class())) {
+               TFrame *frame = static_cast<TFrame *>(obj);
+               if (item.fopt.size() >= 4) {
+                  frame->SetX1(item.fopt[0]);
+                  frame->SetY1(item.fopt[1]);
+                  frame->SetX2(item.fopt[2]);
+                  frame->SetY2(item.fopt[3]);
+               }
+
+            }
+         } else if (obj && lnk) {
             if (gDebug > 1)
-               Info("DecodeAllRanges", "Set draw option \"%s\" for object %s %s", r.primitives[k].opt.c_str(),
+               Info("DecodeAllRanges", "Set draw option \"%s\" for object %s %s", item.opt.c_str(),
                     obj->ClassName(), obj->GetName());
-            lnk->SetOption(r.primitives[k].opt.c_str());
+            lnk->SetOption(item.opt.c_str());
          }
       }
 

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -96,7 +96,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 5/04/2019";
+   JSROOT.version = "dev 10/04/2019";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;

--- a/js/scripts/JSRootPainter.hist3d.js
+++ b/js/scripts/JSRootPainter.hist3d.js
@@ -3040,8 +3040,8 @@
             return JSROOT.draw(this.divid, this.GetObject(),arg);
 
          this.DecodeOptions(arg);
-         this.Redraw();
-         this.InteractiveRedraw(true,"drawopt");
+
+         this.InteractiveRedraw(true, "drawopt");
       });
    }
 

--- a/js/scripts/JSRootPainter.v6.js
+++ b/js/scripts/JSRootPainter.v6.js
@@ -1482,9 +1482,10 @@
          this.createAttLine({ attr: tframe, color: 'black' });
    }
 
+   /** Function called at the end of resize of frame
+     * One should apply changes to the pad
+     * @private */
    TFramePainter.prototype.SizeChanged = function() {
-      // function called at the end of resize of frame
-      // One should apply changes to the pad
 
       var pad = this.root_pad();
 
@@ -1496,7 +1497,7 @@
          this.SetRootPadRange(pad);
       }
 
-      this.RedrawPad();
+      this.InteractiveRedraw("pad", "frame");
    }
 
    TFramePainter.prototype.CleanXY = function() {
@@ -1739,10 +1740,7 @@
       // directly change attribute in the pad
       pad["fLog" + axis] = pad["fLog" + axis] ? 0 : 1;
 
-      this.RedrawPad();
-
-      var canp = this.canv_painter();
-      if (canp) canp.ProcessChanges("log"+axis, this.pad_painter());
+      this.InteractiveRedraw("pad", "log"+axis);
    }
 
    TFramePainter.prototype.FillContextMenu = function(menu, kind, obj) {
@@ -1838,12 +1836,18 @@
       menu.addchk(this.IsTooltipAllowed(), "Show tooltips", function() {
          this.SetTooltipAllowed("toggle");
       });
-      this.FillAttContextMenu(menu,alone ? "" : "Frame ");
+      this.FillAttContextMenu(menu, alone ? "" : "Frame ");
       menu.add("separator");
       menu.add("Save as frame.png", function() { this.pad_painter().SaveAs("png", 'frame', 'frame.png'); });
       menu.add("Save as frame.svg", function() { this.pad_painter().SaveAs("svg", 'frame', 'frame.svg'); });
 
       return true;
+   }
+
+   TFramePainter.prototype.FillWebObjectOptions = function(res) {
+      res.fcust = "frame",
+      res.fopt = [this.scale_xmin || 0, this.scale_ymin || 0, this.scale_xmax || 0, this.scale_ymax || 0];
+      return res;
    }
 
    TFramePainter.prototype.GetFrameRect = function() {
@@ -2557,6 +2561,7 @@
    }
 
    TFramePainter.prototype.ShowContextMenu = function(kind, evnt, obj) {
+
       // ignore context menu when touches zooming is ongoing
       if (('zoom_kind' in this) && (this.zoom_kind > 100)) return;
 
@@ -3243,7 +3248,7 @@
             delete this._current_primitive_indx;
             if (this._start_tm) {
                var spenttm = new Date().getTime() - this._start_tm;
-               if (spenttm > 200) console.log("Canvas drawing took " + (spenttm*1e-3).toFixed(2) + "s");
+               if (spenttm > 1000) console.log("Canvas drawing took " + (spenttm*1e-3).toFixed(2) + "s");
                delete this._start_tm;
                delete this._lasttm_tm;
             }
@@ -3308,10 +3313,7 @@
 
          function SetPadField(arg) {
             this.pad[arg.substr(1)] = parseInt(arg[0]);
-            var main = this.svg_pad(this.this_pad_name).property('mainpainter');
-            if (main && (typeof main.DrawAxes == 'function')) main.DrawAxes();
-            var canp = this.canv_painter();
-            if (canp) canp.ProcessChanges(arg.substr(1), this.pad_painter());
+            this.InteractiveRedraw("axes", arg.substr(1));
          }
 
          menu.addchk(this.pad.fGridx, 'Grid x', (this.pad.fGridx ? '0' : '1') + 'fGridx', SetPadField);
@@ -3800,8 +3802,10 @@
       }
    }
 
-   TPadPainter.prototype.GetAllRanges = function(arg) {
-      var is_top = (arg === undefined), elem = null;
+   /** Collects pad information for TWebCanvas, need to update different states */
+   TPadPainter.prototype.GetWebPadInfo = function(arg) {
+      var is_top = (arg === undefined), elem = null, scan_subpads = true;
+      if (arg === "only_this") { is_top = true; scan_subpads = false; }
       if (is_top) arg = [];
 
       if (this.snapid) {
@@ -3822,12 +3826,16 @@
             console.log('fail to get ranges for pad ' +  this.pad.fName);
       }
 
-      for (var k=0;k<this.painters.length;++k) {
+      for (var k=0; k<this.painters.length; ++k) {
          var sub = this.painters[k];
-         if (typeof sub.GetAllRanges == "function")
-            sub.GetAllRanges(arg);
-         else if (sub.snapid)
-            elem.primitives.push({ _typename: "TWebObjectOptions", snapid: sub.snapid.toString(), opt: sub.OptionsAsString() });
+         if (typeof sub.GetWebPadInfo == "function") {
+            if (scan_subpads) sub.GetWebPadInfo(arg);
+         } else if (sub.snapid) {
+            var opt = { _typename: "TWebObjectOptions", snapid: sub.snapid.toString(), opt: sub.OptionsAsString(), fcust: "", fopt: [] };
+            if (typeof sub.FillWebObjectOptions == "function")
+               opt = sub.FillWebObjectOptions(opt);
+            elem.primitives.push(opt);
+         }
       }
 
       if (is_top) return JSROOT.toJSON(arg);
@@ -4593,11 +4601,8 @@
 
          this.RedrawPadSnap(snap, function() {
             pthis.CompeteCanvasSnapDrawing();
-            var ranges = pthis.GetAllRanges();
-            if (ranges) {
-               // console.log("ranges: " + ranges);
-               ranges = ":" + ranges;
-            }
+            var ranges = pthis.GetWebPadInfo(); // all data, including subpads
+            if (ranges) ranges = ":" + ranges;
             handle.Send("READY6:" + snapid + ranges); // send ready message back when drawing completed
          });
       } else if (msg.substr(0,5)=='MENU:') {
@@ -4779,15 +4784,51 @@
       this.ShowSection("ToolTips", this.pad.TestBit(JSROOT.TCanvasStatusBits.kShowToolTips));
    }
 
-   /// method informs that something was changed in the canvas
-   /// used to update information on the server (when used with web6gui)
-   TCanvasPainter.prototype.ProcessChanges = function(kind, source_pad) {
+   /** Method informs that something was changed in the canvas
+     * used to update information on the server (when used with web6gui)
+     * @private */
+   TCanvasPainter.prototype.ProcessChanges = function(kind, painter) {
       // check if we could send at least one message more - for some meaningful actions
-      if (!this._websocket || !this._websocket.CanSend(2)) return;
+      if (!this._websocket || !this._websocket.CanSend(2) || (typeof kind !== "string")) return;
 
-      var msg = (kind == "sbits") ? "STATUSBITS:" + this.GetStatusBits() : "RANGES6:" + this.GetAllRanges();
+      var msg = "";
+      if (!painter) painter = this;
+      switch (kind) {
+         case "sbits":
+            msg = "STATUSBITS:" + this.GetStatusBits();
+            break;
+         case "frame": // when moving frame
+         case "zoom":  // when changing zoom inside frame
+            if (!painter.GetWebPadInfo)
+               painter = painter.pad_painter();
+            if (typeof painter.GetWebPadInfo == "function")
+               msg = "RANGES6:" + painter.GetWebPadInfo("only_this");
+            break;
+         case "pave_moved":
+            if (painter.FillWebObjectOptions) {
+               var info = painter.FillWebObjectOptions();
+               if (info) msg = "PRIMIT6:" + JSROOT.toJSON(info);
+            }
+            break;
+         default:
+            if ((kind.substr(0,5) == "exec:") && painter && painter.snapid) {
+               msg = "PRIMIT6:" + JSROOT.toJSON({
+                  _typename: "TWebObjectOptions",
+                  snapid: painter.snapid.toString(),
+                  opt: kind.substr(5),
+                  fcust: "exec",
+                  fopt: []
+               });
+            } else {
+               console.log("UNPROCESSED CHANGES", kind);
+            }
+      }
 
-      this._websocket.Send(msg);
+      if (msg) {
+         console.log("Sending " + msg.length + "  " + msg.substr(0,40));
+         this._websocket.Send(msg);
+      }
+
    }
 
    TCanvasPainter.prototype.SelectActivePad = function(pad_painter, obj_painter, click_pos) {

--- a/js/scripts/JSRootPainter.v7hist.js
+++ b/js/scripts/JSRootPainter.v7hist.js
@@ -688,7 +688,7 @@
       }
 
       this.CopyOptionsToOthers();
-      this.InteractiveRedraw("pad","drawopt");
+      this.InteractiveRedraw("pad", "drawopt");
    }
 
    THistPainter.prototype.PrepareColorDraw = function(args) {

--- a/ui5/canv/controller/Canvas.controller.js
+++ b/ui5/canv/controller/Canvas.controller.js
@@ -78,7 +78,7 @@ sap.ui.define([
          }
          
          if ((method.fName == "DrawPanel") || (method.fName == "SetLineAttributes") ||
-             (method.fName == "SetFillAttributes") || (method.fName == "SetMarkerAttributes")) {
+             (method.fName == "SetFillAttributes") || (method.fName == "SetMarkerAttributes") || (method.fName == "SetTextAttributes")) {
             this.openuiActivateGed(painter);
             return true;
          }

--- a/ui5/canv/controller/Ged.controller.js
+++ b/ui5/canv/controller/Ged.controller.js
@@ -99,8 +99,7 @@ sap.ui.define([
          opts.ErrorKind = parseInt(opts.ErrorKind);
 
          if (this.currentPadPainter)
-            this.currentPadPainter.InteractiveRedraw("object","drawopt");
-
+            this.currentPadPainter.InteractiveRedraw("pad","drawopt");
       },
 
       onObjectSelect : function(padpainter, painter, place) {


### PR DESCRIPTION
With the PR many interactive changes of objects in the browser immediately reflected on the server.
Like zooming, change frame/title/statbox/zaxis position, changing line/fill/marker attributes.
Modified canvas and primitives can be stored in ROOT file and used again with normal viewer.