### PR TITLE
fix ROOT-10060. Invalid pointer to fMother in TPad

### DIFF
--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -986,6 +986,7 @@ void TPad::Close(Option_t *)
 {
    if (!TestBit(kNotDeleted)) return;
    if (!fMother) return;
+   if (!fMother->TestBit(kNotDeleted)) return;
 
    if (fPrimitives)
       fPrimitives->Clear();
@@ -1288,7 +1289,7 @@ void TPad::Draw(Option_t *option)
    // pad cannot be in itself and it can only be in one other pad at a time
    if (!fPrimitives) fPrimitives = new TList;
    if (gPad != this) {
-      if (fMother) fMother->GetListOfPrimitives()->Remove(this);
+      if (fMother && fMother->TestBit(kNotDeleted)) fMother->GetListOfPrimitives()->Remove(this);
       TPad *oldMother = fMother;
       fCanvas = gPad->GetCanvas();
       //
@@ -4612,6 +4613,7 @@ TPad *TPad::Pick(Int_t px, Int_t py, TObjLink *&pickobj)
 void TPad::Pop()
 {
    if (!fMother) return;
+   if (!fMother->TestBit(kNotDeleted)) return;
    if (!fPrimitives) fPrimitives = new TList;
    if (this == fMother->GetListOfPrimitives()->Last()) return;
 


### PR DESCRIPTION
Attempt to fix https://sft.its.cern.ch/jira/browse/ROOT-10060.
Before this fix ehe following macro crashed:

```
{
   auto c = new TCanvas("canvas", "canvas"); // gPad=c;
   auto p = new TPad("pad", "pad", .2, .05, .8, .35 ); // fMother = gPad = c;
   delete c;
   p->Close();
}
```