### PR TITLE
[RDF][ROOT-9674] Infer properly type of data members of split TClonesArrays

### DIFF
--- a/tree/dataframe/src/RDFUtils.cxx
+++ b/tree/dataframe/src/RDFUtils.cxx
@@ -169,8 +169,18 @@ std::string GetBranchOrLeafTypeName(TTree &t, const std::string &colName)
          auto be = static_cast<TBranchElement *>(branch);
          if (auto currentClass = be->GetCurrentClass())
             return currentClass->GetName();
-         else
+         else {
+            // Here we have a special case for getting right the type of data members
+            // of classes sorted in TClonesArrays: ROOT-9674
+            auto mother = be->GetMother();
+            if (mother && mother->InheritsFrom(tbranchelement)) {
+               auto beMom = static_cast<TBranchElement *>(mother);
+               auto beMomClass = beMom->GetClass();
+               if (beMomClass && 0 == strcmp("TClonesArray", beMomClass->GetName()))
+                  return be->GetTypeName();
+            }
             return be->GetClassName();
+         }
       }
    }
 


### PR DESCRIPTION
A test is still missing, I'll add it.