### PR TITLE
[treeplayer] TTreeReader was chopping composite names incorrectly:

### DIFF
--- a/tree/treeplayer/src/TTreeReaderValue.cxx
+++ b/tree/treeplayer/src/TTreeReaderValue.cxx
@@ -307,7 +307,7 @@ TBranch *ROOT::Internal::TTreeReaderValueBase::SearchBranchWithCompositeName(TLe
 
       while (!branch && branchName.Contains(".")){
          leafName = branchName(leafNameExpression);
-         branchName = branchName(0, fBranchName.Length() - leafName.Length());
+         branchName = branchName(0, branchName.Length() - leafName.Length());
          branch = fTreeReader->GetTree()->GetBranch(branchName);
          if (!branch) branch = fTreeReader->GetTree()->GetBranch(branchName + ".");
          nameStack.push_back(leafName.Strip(TString::kBoth, '.'));


### PR DESCRIPTION
This caused an infinite loop e.g. with a branch "0.2.0.eventEnergy" which was never getting shorter.
See https://root-forum.cern.ch/t/ttreereader-hang-infinite-loop/33446