### PR TITLE
Fix enabled Apache Arrow support for ROOT

### DIFF
--- a/tree/dataframe/test/datasource_arrow.cxx
+++ b/tree/dataframe/test/datasource_arrow.cxx
@@ -11,7 +11,7 @@
 #include <arrow/memory_pool.h>
 #include <arrow/record_batch.h>
 #include <arrow/table.h>
-#include <arrow/test-util.h>
+#include <arrow/compute/test-util.h>
 #if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
Latest binary of Apache Arrow actually has test-utils.h in arrow/compute/

[ 94%] Building CXX object tree/dataframe/test/CMakeFiles/dataframe_interface.dir/dataframe_interface.cxx.o
/.../root/tree/dataframe/test/datasource_arrow.cxx:14:10: fatal error: arrow/test-util.h: No such file or directory
 #include <arrow/test-util.h>
          ^~~~~~~~~~~~~~~~~~~
compilation terminated.
