### PR TITLE
Add string and SQLite3 support to TTreeSQL

### DIFF
--- a/tree/tree/inc/TTreeSQL.h
+++ b/tree/tree/inc/TTreeSQL.h
@@ -37,7 +37,7 @@
 class TSQLServer;
 class TSQLRow;
 class TBasketSQL;
-class TSQLTableInfo; 
+class TSQLTableInfo;
 
 class TTreeSQL : public TTree {
 
@@ -51,7 +51,7 @@ protected:
    TSQLRow               *fRow;
    TSQLServer            *fServer;
    Bool_t                 fBranchChecked;
-   TSQLTableInfo         *fTableInfo; 
+   TSQLTableInfo         *fTableInfo;
 
    void                   CheckBasket(TBranch * tb);
    Bool_t                 CheckBranch(TBranch * tb);
@@ -90,7 +90,7 @@ public:
    virtual Long64_t       PrepEntry(Long64_t entry);
            void           Refresh();
 
-   virtual ~TTreeSQL(); 
+   virtual ~TTreeSQL();
    ClassDef(TTreeSQL,2);  // TTree Implementation read and write to a SQL database.
 };
 

--- a/tree/tree/inc/TTreeSQL.h
+++ b/tree/tree/inc/TTreeSQL.h
@@ -37,6 +37,7 @@
 class TSQLServer;
 class TSQLRow;
 class TBasketSQL;
+class TSQLTableInfo; 
 
 class TTreeSQL : public TTree {
 
@@ -50,11 +51,12 @@ protected:
    TSQLRow               *fRow;
    TSQLServer            *fServer;
    Bool_t                 fBranchChecked;
+   TSQLTableInfo         *fTableInfo; 
 
    void                   CheckBasket(TBranch * tb);
    Bool_t                 CheckBranch(TBranch * tb);
    Bool_t                 CheckTable(const TString &table) const;
-   TString                CreateBranches(TSQLResult * rs);
+   void                   CreateBranches();
    std::vector<Int_t>    *GetColumnIndice(TBranch *branch);
    void                   Init();
    void                   ResetQuery();
@@ -88,7 +90,8 @@ public:
    virtual Long64_t       PrepEntry(Long64_t entry);
            void           Refresh();
 
-   ClassDef(TTreeSQL,1);  // TTree Implementation read and write to a SQL database.
+   virtual ~TTreeSQL(); 
+   ClassDef(TTreeSQL,2);  // TTree Implementation read and write to a SQL database.
 };
 
 

--- a/tree/tree/src/TBufferSQL.cxx
+++ b/tree/tree/src/TBufferSQL.cxx
@@ -297,7 +297,8 @@ void TBufferSQL::ReadCharP(Char_t *str)
 
 void TBufferSQL::ReadTString(TString   &s)
 {
-   TBufferFile::ReadTString(s);
+   s = (*fRowPtr)->GetField(*fIter);
+   if (fIter != fColumnVec->end()) ++fIter;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -305,8 +306,12 @@ void TBufferSQL::ReadTString(TString   &s)
 
 void TBufferSQL::WriteTString(const TString   &s)
 {
-   TBufferFile::WriteTString(s);
+   (*fInsertQuery) += s;
+   (*fInsertQuery) += ",";
+   if (fIter != fColumnVec->end()) ++fIter;
 }
+
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Read a std::string
@@ -587,7 +592,7 @@ void TBufferSQL::WriteFastArray(const Double_t  *d, Int_t n)
 
 void TBufferSQL::WriteFastArray(void*, const TClass*, Int_t, TMemberStreamer *)
 {
-   Fatal("riteFastArray(void*, const TClass*, Int_t, TMemberStreamer *)","Not implemented yet");
+   Fatal("WriteFastArray(void*, const TClass*, Int_t, TMemberStreamer *)","Not implemented yet");
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/tree/src/TTreeSQL.cxx
+++ b/tree/tree/src/TTreeSQL.cxx
@@ -32,8 +32,8 @@ Implement TTree for a SQL backend
 #include "TSQLRow.h"
 #include "TSQLResult.h"
 #include "TSQLServer.h"
-#include "TSQLTableInfo.h" 
-#include "TSQLColumnInfo.h" 
+#include "TSQLTableInfo.h"
+#include "TSQLColumnInfo.h"
 
 #include "TTreeSQL.h"
 #include "TBasketSQL.h"
@@ -48,7 +48,7 @@ TTreeSQL::TTreeSQL(TSQLServer *server, TString DB, const TString& table) :
    fTable(table.Data()),
    fResult(0), fRow(0),
    fServer(server),
-   fBranchChecked(kFALSE), 
+   fBranchChecked(kFALSE),
    fTableInfo(0)
 {
    fCurrentEntry = -1;
@@ -120,7 +120,7 @@ TBranch* TTreeSQL::Bronch(const char *, const char *, void *,
                           Int_t, Int_t)
 {
    Fatal("Bronch","Not implemented yet");
-   return 0; 
+   return 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -140,7 +140,7 @@ TBranch *TTreeSQL::Branch(const char *, const char *, void *,
                           Int_t, Int_t)
 {
    Fatal("Branch","Not implemented yet");
-   return 0; 
+   return 0;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -162,7 +162,7 @@ TBranch * TTreeSQL::Branch(const char *name, void *address,
          // So if you want to allow duplicate branch, just comment Fatal() line and uncomment commented
          // below Fatal() line
 
-         Fatal("Branch()", "Duplicate branch!!!"); 
+         Fatal("Branch()", "Duplicate branch!!!");
 
          /* Commented. If uncommented, should comment Fatal line.
          // this is a duplicate branch. So reset data structure memory address and return.
@@ -330,7 +330,7 @@ TString TTreeSQL::ConvertTypeName(const TString& typeName )
    else if( typeName == "TString") {
       tn = "TEXT";
    }
- 
+
    else {
       Error("ConvertTypeName","TypeName (%s) not found",typeName.Data());
       return "";
@@ -384,23 +384,23 @@ void TTreeSQL::CreateBranch(const TString &branchName, const TString &typeName)
 
 void TTreeSQL::CreateBranches()
 {
-   TList * columns = fTableInfo->GetColumns(); 
+   TList * columns = fTableInfo->GetColumns();
    if(!columns) return;
 
-   TIter next(columns); 
+   TIter next(columns);
 
    TString branchName;
-   TString type; 
+   TString type;
    TString leafName;
    TBranch * br = 0;
-   TSQLColumnInfo * info; 
+   TSQLColumnInfo * info;
    while ( (info = ((TSQLColumnInfo*) next()) ))
    {
-      type = info->GetTypeName(); 
-      branchName = info->GetName(); 
+      type = info->GetTypeName();
+      branchName = info->GetName();
 
 
-      Int_t pos; 
+      Int_t pos;
       if ((pos=branchName.Index("__"))!=kNPOS) {
           leafName = branchName(pos+2,branchName.Length());
           branchName.Remove(pos);
@@ -408,61 +408,61 @@ void TTreeSQL::CreateBranches()
           leafName = branchName;
       }
 
-      TString str; 
-      int i; 
-      unsigned ui; 
+      TString str;
+      int i;
+      unsigned ui;
       double d;
-      float f; 
+      float f;
 
-      br = 0; 
+      br = 0;
 
-      if(type.CompareTo("varchar",TString::kIgnoreCase)==0 || 
-         type.CompareTo("varchar2",TString::kIgnoreCase)==0 || 
+      if(type.CompareTo("varchar",TString::kIgnoreCase)==0 ||
+         type.CompareTo("varchar2",TString::kIgnoreCase)==0 ||
          type.CompareTo("char",TString::kIgnoreCase)==0 ||
          type.CompareTo("longvarchar",TString::kIgnoreCase)==0 ||
          type.CompareTo("longvarbinary",TString::kIgnoreCase)==0 ||
          type.CompareTo("varbinary",TString::kIgnoreCase)==0 ||
          type.CompareTo("text",TString::kIgnoreCase )==0 ) {
-          br = TTree::Branch(leafName,&str); 
+         br = TTree::Branch(leafName,&str);
 
       }
       else if(type.CompareTo("int",TString::kIgnoreCase)==0 ){
-          br = TTree::Branch(leafName,&i); 
+         br = TTree::Branch(leafName,&i);
       }
 
       //Somehow it should be possible to special-case the time classes
-      //but I think we'd need to create a new TSQLTime or something like that... 
+      //but I think we'd need to create a new TSQLTime or something like that...
       else if( type.CompareTo("date",TString::kIgnoreCase)==0 ||
                type.CompareTo("time",TString::kIgnoreCase)==0 ||
-              type.CompareTo("timestamp",TString::kIgnoreCase)==0 ||
+               type.CompareTo("timestamp",TString::kIgnoreCase)==0 ||
                type.CompareTo("datetime",TString::kIgnoreCase)==0 ) {
-          br = TTree::Branch(leafName,&str);  
+         br = TTree::Branch(leafName,&str);
 
       }
 
       else if(type.CompareTo("bit",TString::kIgnoreCase)==0 ||
               type.CompareTo("tinyint",TString::kIgnoreCase)==0 ||
               type.CompareTo("smallint",TString::kIgnoreCase)==0 ) {
-          br = TTree::Branch(leafName,&ui); 
+         br = TTree::Branch(leafName,&ui);
       }
 
-      else if( type.CompareTo("decimal",TString::kIgnoreCase)==0 || 
-               type.CompareTo("numeric",TString::kIgnoreCase)==0 || 
+      else if( type.CompareTo("decimal",TString::kIgnoreCase)==0 ||
+               type.CompareTo("numeric",TString::kIgnoreCase)==0 ||
                type.CompareTo("double",TString::kIgnoreCase)==0 ||
                type.CompareTo("float",TString::kIgnoreCase)==0 )
       {
-          br = TTree::Branch(leafName,&f); 
+         br = TTree::Branch(leafName,&f);
       }
       else if( type.CompareTo("bigint",TString::kIgnoreCase)==0 ||
-               type.CompareTo("real",TString::kIgnoreCase) == 0) 
+               type.CompareTo("real",TString::kIgnoreCase) == 0)
       {
-          br = TTree::Branch(leafName,&d); 
+         br = TTree::Branch(leafName,&d);
       }
-         
+
       if (br == 0)
       {
-        Error("Skipped %s",branchName); 
-        continue; 
+         Error("Skipped %s",branchName);
+         continue;
       }
 
       br->ResetAddress();
@@ -551,11 +551,10 @@ void TTreeSQL::Init()
    fResult = fServer->Query(fQuery.Data());
    if(!fResult) return;
 
-   if (fDB != "") 
-   {
-     fServer->SelectDataBase(fDB); 
+   if (fDB != "") {
+      fServer->SelectDataBase(fDB);
    }
-   fTableInfo = fServer->GetTableInfo(fTable); 
+   fTableInfo = fServer->GetTableInfo(fTable);
    CreateBranches();
 }
 
@@ -625,17 +624,19 @@ std::vector<Int_t> *TTreeSQL::GetColumnIndice(TBranch *branch)
    std::vector<TString> names;
 
    TList *col_list = fTableInfo->GetColumns();
-   if (col_list==0) { delete columns; return 0; }
+   if (col_list==0) {
+      delete columns;
+      return 0;
+   }
 
    std::pair<TString,Int_t> value;
 
-   TIter next(col_list); 
+   TIter next(col_list);
    TSQLColumnInfo * cinfo;
-   int rows = 0; 
-   while ((cinfo = (TSQLColumnInfo*) next()))
-   {
+   int rows = 0;
+   while ((cinfo = (TSQLColumnInfo*) next())) {
       names.push_back( cinfo->GetName() );
-      rows++; 
+      rows++;
    }
 
    for(int j=0;j<nl;j++) {
@@ -669,7 +670,8 @@ std::vector<Int_t> *TTreeSQL::GetColumnIndice(TBranch *branch)
       } else Error("GetColumnIndice","Error finding column %d %s",j,str.Data());
    }
    if (columns->empty()) {
-      delete columns; return 0;
+      delete columns;
+      return 0;
    } else
       return columns;
 }
@@ -808,7 +810,7 @@ void TTreeSQL::ResetQuery()
 
 TTreeSQL::~TTreeSQL()
 {
-  delete fTableInfo; 
-  delete fResult; 
-  delete fRow; 
+   delete fTableInfo;
+   delete fResult;
+   delete fRow;
 }

--- a/tree/tree/src/TTreeSQL.cxx
+++ b/tree/tree/src/TTreeSQL.cxx
@@ -32,6 +32,8 @@ Implement TTree for a SQL backend
 #include "TSQLRow.h"
 #include "TSQLResult.h"
 #include "TSQLServer.h"
+#include "TSQLTableInfo.h" 
+#include "TSQLColumnInfo.h" 
 
 #include "TTreeSQL.h"
 #include "TBasketSQL.h"
@@ -46,7 +48,8 @@ TTreeSQL::TTreeSQL(TSQLServer *server, TString DB, const TString& table) :
    fTable(table.Data()),
    fResult(0), fRow(0),
    fServer(server),
-   fBranchChecked(kFALSE)
+   fBranchChecked(kFALSE), 
+   fTableInfo(0)
 {
    fCurrentEntry = -1;
    fQuery = TString("Select * from " + fTable);
@@ -81,7 +84,6 @@ TBranch* TTreeSQL::BranchImp(const char *, TClass *,
    Fatal("BranchImp","Not implemented yet");
    return 0;
 }
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Not implemented yet
 
@@ -117,8 +119,8 @@ Int_t TTreeSQL::Branch(const char *, Int_t ,
 TBranch* TTreeSQL::Bronch(const char *, const char *, void *,
                           Int_t, Int_t)
 {
-   Fatal("Bronc","Not implemented yet");
-   return 0;
+   Fatal("Bronch","Not implemented yet");
+   return 0; 
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -138,10 +140,10 @@ TBranch *TTreeSQL::Branch(const char *, const char *, void *,
                           Int_t, Int_t)
 {
    Fatal("Branch","Not implemented yet");
-   return 0;
+   return 0; 
 }
 
-////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
 /// Create a branch
 
 TBranch * TTreeSQL::Branch(const char *name, void *address,
@@ -160,7 +162,7 @@ TBranch * TTreeSQL::Branch(const char *name, void *address,
          // So if you want to allow duplicate branch, just comment Fatal() line and uncomment commented
          // below Fatal() line
 
-         Fatal("Branch()", "Duplicate branch!!!");
+         Fatal("Branch()", "Duplicate branch!!!"); 
 
          /* Commented. If uncommented, should comment Fatal line.
          // this is a duplicate branch. So reset data structure memory address and return.
@@ -169,6 +171,7 @@ TBranch * TTreeSQL::Branch(const char *name, void *address,
          */
       }
    }
+
    return TTree::Branch(name, address, leaflist, bufsize);
 }
 
@@ -324,6 +327,10 @@ TString TTreeSQL::ConvertTypeName(const TString& typeName )
    else if( typeName == "Bool_t") {
       tn = "BOOL";
    }
+   else if( typeName == "TString") {
+      tn = "TEXT";
+   }
+ 
    else {
       Error("ConvertTypeName","TypeName (%s) not found",typeName.Data());
       return "";
@@ -375,108 +382,98 @@ void TTreeSQL::CreateBranch(const TString &branchName, const TString &typeName)
 ////////////////////////////////////////////////////////////////////////////////
 /// determine leaf description string
 
-TString TTreeSQL::CreateBranches(TSQLResult * rs)
+void TTreeSQL::CreateBranches()
 {
-   if(!rs) return "";
+   TList * columns = fTableInfo->GetColumns(); 
+   if(!columns) return;
 
-   Int_t rows;
-   TString type;
-   TString res;
+   TIter next(columns); 
+
    TString branchName;
+   TString type; 
    TString leafName;
-   Int_t prec=0;
    TBranch * br = 0;
-   rows = rs->GetRowCount();
-   TString decl;
-   TString prevBranch;
+   TSQLColumnInfo * info; 
+   while ( (info = ((TSQLColumnInfo*) next()) ))
+   {
+      type = info->GetTypeName(); 
+      branchName = info->GetName(); 
 
-   for( int i=0; i < rows; ++i ) {
-      TSQLRow * row = rs->Next();
-      if (!row) continue;
-      type = row->GetField(1);
-      Int_t index = type.First('(');
-      if(index>0){
-         prec = atoi(type(index+1,type.First(')')-1).Data());
-         type = type(0,index);
-      }
-      branchName = row->GetField(0);
-      Int_t pos;
+
+      Int_t pos; 
       if ((pos=branchName.Index("__"))!=kNPOS) {
-         leafName = branchName(pos+2,branchName.Length());
-         branchName.Remove(pos);
+          leafName = branchName(pos+2,branchName.Length());
+          branchName.Remove(pos);
       } else {
-         leafName = branchName;
-      }
-      if (prevBranch.Length()) {
-         if (prevBranch != branchName) {
-            // new branch let's flush.
-            if (decl.Length()) decl.Remove(decl.Length()-1);
-            br = TTree::Branch(prevBranch,0,decl);
-            br->ResetAddress();
-
-            (br->GetBasketEntry())[0] = 0;
-            (br->GetBasketEntry())[1] = fEntries;
-
-            br->SetEntries(fEntries);
-
-            //++(br->fNBaskets);
-            br->GetListOfBaskets()->AddAtAndExpand(CreateBasket(br),0);
-
-            prevBranch = branchName;
-            decl = "";
-         }
-      } else {
-         prevBranch = branchName;
+          leafName = branchName;
       }
 
-      if(type.CompareTo("varchar",TString::kIgnoreCase)==0 || type.CompareTo("varchar2",TString::kIgnoreCase)==0 || type.CompareTo("char",TString::kIgnoreCase)==0 ) {
-         char siz[6];
-         snprintf(siz,6,"[%d]",prec);
-         decl.Append( leafName+siz+"/C:" );
+      TString str; 
+      int i; 
+      unsigned ui; 
+      double d;
+      float f; 
+
+      br = 0; 
+
+      if(type.CompareTo("varchar",TString::kIgnoreCase)==0 || 
+         type.CompareTo("varchar2",TString::kIgnoreCase)==0 || 
+         type.CompareTo("char",TString::kIgnoreCase)==0 ||
+         type.CompareTo("longvarchar",TString::kIgnoreCase)==0 ||
+         type.CompareTo("longvarbinary",TString::kIgnoreCase)==0 ||
+         type.CompareTo("varbinary",TString::kIgnoreCase)==0 ||
+         type.CompareTo("text",TString::kIgnoreCase )==0 ) {
+          br = TTree::Branch(leafName,&str); 
+
       }
-      else if(type.CompareTo("int",TString::kIgnoreCase)==0){
-         decl.Append( leafName+"/I:" );
+      else if(type.CompareTo("int",TString::kIgnoreCase)==0 ){
+          br = TTree::Branch(leafName,&i); 
       }
+
+      //Somehow it should be possible to special-case the time classes
+      //but I think we'd need to create a new TSQLTime or something like that... 
       else if( type.CompareTo("date",TString::kIgnoreCase)==0 ||
                type.CompareTo("time",TString::kIgnoreCase)==0 ||
-               type.CompareTo("timestamp",TString::kIgnoreCase)==0 ) {
-         decl.Append( leafName+"/I:" );
+              type.CompareTo("timestamp",TString::kIgnoreCase)==0 ||
+               type.CompareTo("datetime",TString::kIgnoreCase)==0 ) {
+          br = TTree::Branch(leafName,&str);  
+
       }
+
       else if(type.CompareTo("bit",TString::kIgnoreCase)==0 ||
               type.CompareTo("tinyint",TString::kIgnoreCase)==0 ||
               type.CompareTo("smallint",TString::kIgnoreCase)==0 ) {
-         decl.Append( leafName+"/i:" );
-      }
-      else if(type.CompareTo("real",TString::kIgnoreCase)==0 || type.CompareTo("longvarchar",TString::kIgnoreCase)==0 || type.CompareTo("longvarbinary",TString::kIgnoreCase)==0 || type.CompareTo("varbinary",TString::kIgnoreCase)==0 ){
-         decl.Append( leafName+"/S:" );
+          br = TTree::Branch(leafName,&ui); 
       }
 
-      //   case kLONGVARCHAR: // not resolved yet how to handle
-      // case kLONGVARBINARY:
-      //case kVARBINARY:
-      //  break;
-      else /*if(type.CompareTo("bigint",TString::kIgnoreCase)==0 || type.CompareTo("decimal",TString::kIgnoreCase)==0 || type.CompareTo("numeric",TString::kIgnoreCase)==0 || type.CompareTo("double",TString::kIgnoreCase)==0 ||
-      type.CompareTo("float",TString::kIgnoreCase)==0 )*/{
-
-         decl.Append( leafName+"/F:" );
+      else if( type.CompareTo("decimal",TString::kIgnoreCase)==0 || 
+               type.CompareTo("numeric",TString::kIgnoreCase)==0 || 
+               type.CompareTo("double",TString::kIgnoreCase)==0 ||
+               type.CompareTo("float",TString::kIgnoreCase)==0 )
+      {
+          br = TTree::Branch(leafName,&f); 
+      }
+      else if( type.CompareTo("bigint",TString::kIgnoreCase)==0 ||
+               type.CompareTo("real",TString::kIgnoreCase) == 0) 
+      {
+          br = TTree::Branch(leafName,&d); 
+      }
+         
+      if (br == 0)
+      {
+        Error("Skipped %s",branchName); 
+        continue; 
       }
 
-   }
-
-   // new branch let's flush.
-   if (decl.Length()) decl.Remove(decl.Length()-1);
-   if (prevBranch.Length()) {
-      br = TTree::Branch(prevBranch,0,decl);
       br->ResetAddress();
 
       (br->GetBasketEntry())[0] = 0;
       (br->GetBasketEntry())[1] = fEntries;
       br->SetEntries(fEntries);
+
+      //++(br->fNBaskets);
       br->GetListOfBaskets()->AddAtAndExpand(CreateBasket(br),0);
    }
-
-   if(!res.IsNull()) res.Resize(res.Length()-1);   // cut off last ":"
-   return res;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -554,7 +551,12 @@ void TTreeSQL::Init()
    fResult = fServer->Query(fQuery.Data());
    if(!fResult) return;
 
-   CreateBranches(fServer->GetColumns(fDB,fTable));
+   if (fDB != "") 
+   {
+     fServer->SelectDataBase(fDB); 
+   }
+   fTableInfo = fServer->GetTableInfo(fTable); 
+   CreateBranches();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -622,18 +624,19 @@ std::vector<Int_t> *TTreeSQL::GetColumnIndice(TBranch *branch)
 
    std::vector<TString> names;
 
-   TSQLResult *rs = fServer->GetColumns(fDB,fTable);
-   if (rs==0) { delete columns; return 0; }
-   Int_t rows = rs->GetRowCount();
+   TList *col_list = fTableInfo->GetColumns();
+   if (col_list==0) { delete columns; return 0; }
 
    std::pair<TString,Int_t> value;
 
-   for (Int_t i=0;i<rows;++i) {
-      TSQLRow *row = rs->Next();
-      names.push_back( row->GetField(0) );
-      delete row;
+   TIter next(col_list); 
+   TSQLColumnInfo * cinfo;
+   int rows = 0; 
+   while ((cinfo = (TSQLColumnInfo*) next()))
+   {
+      names.push_back( cinfo->GetName() );
+      rows++; 
    }
-   delete rs;
 
    for(int j=0;j<nl;j++) {
 
@@ -797,4 +800,15 @@ void TTreeSQL::Refresh()
 void TTreeSQL::ResetQuery()
 {
    fInsertQuery = "INSERT INTO " + fTable + " VALUES (";
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Destructor
+
+TTreeSQL::~TTreeSQL()
+{
+  delete fTableInfo; 
+  delete fResult; 
+  delete fRow; 
 }


### PR DESCRIPTION
Dear ROOT maintainers, 

The TTreeSQL class seems a bit broken. 
 - It does not support sqlite (which nowadays might be the most likely format someone might use a TTree for) because of the way it parses columns. 
  - Some of the data type conversions don't make sense to me (but maybe I misunderstand).  In particular the string conversions don't seem like they'd work. 

Here is a commit to address those issues.  I wanted to also add proper support for database date/datetime/timestamp types (right now I turn them into a string) but I was not sure how to do that. I think what would work is to have an e.g. TDateSQL class that uses a TString for storage (since I believe that's what the SQL API right now would give us) that could then be transparently converted to TDatime or TTimeStamp as needed. This would be easy to implement, but I have not yet because there must be a better way... 

Below is the commit message. There are also a few typo fixes that I included. 

This commit has a few changes:
  -Column names are now obtained from the Table metadata, ensuring that sqlite will work properly
  -Variable length strings are properly supported (using TString)
  -The data type mapping was modified to make a bit more sense (in my opinion), but could still use some work.