### PR TITLE
[RDF] Add the `Stats` method to RInterface to get TStatistic instances

### DIFF
--- a/README/ReleaseNotes/v618/index.md
+++ b/README/ReleaseNotes/v618/index.md
@@ -98,6 +98,7 @@ Added necessary changes to allow [XRootD local redirection](https://github.com/x
   - Add `HasColumn` method to check whether a column is available to a given RDF node
   - PyROOT: add `AsRNode` helper function to convert RDF nodes to the common RNode type
   - PyROOT: add `AsNumpy` method to export contents of a RDataFrame as a dictionary of numpy arrays
+  - The `Stats` method has been added, allowing to retrieve a `TStatistic` object filled with the values of a column and, optionally, the values of a second column to be used as weights.
 
 ### TLeafF16 and TLeafD32
   - New leaf classes allowing to store `Float16_t` and `Double32_t` values using the truncation methods from `TBuffer`
@@ -149,6 +150,7 @@ Added necessary changes to allow [XRootD local redirection](https://github.com/x
 
 ## Math Libraries
   - Add to the documentation of TLorentzVector a link to ROOT::Math::LorentzVector, which is a superior tool.
+  - Add new implementation of `TStatistic::Merge` able to deal silently with empty TStatistic objects. This implementation is useful when filling TStatistics with one of ROOT's implicitly parallelised utilities such as `RDataFrame` or `TThreadExecutor`.
   - Add `T RVec<T>::at>(size_t, T)` method to allow users to specify a default value to be returned in case the vector is shorter than the position specified. No exception is thrown.
   - Add the `Concatenate` helper to merge the content of two `RVec<T>` instances.
   - Generalise the `VecOps::Map` utility allowing to apply a callable on a set of RVecs and not only to one.

--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -245,6 +245,14 @@ extern template void FillHelper::Exec(unsigned int, const std::vector<int> &, co
 extern template void
 FillHelper::Exec(unsigned int, const std::vector<unsigned int> &, const std::vector<unsigned int> &);
 
+template<typename T>
+void SetDirZero(T &){}
+
+inline void SetDirZero(TH1 &h)
+{
+   h.SetDirectory(nullptr);
+}
+
 template <typename HIST = Hist_t>
 class FillParHelper : public RActionImpl<FillParHelper<HIST>> {
    std::vector<HIST *> fObjects;
@@ -259,7 +267,7 @@ public:
       // Initialise all other slots
       for (unsigned int i = 1; i < nSlots; ++i) {
          fObjects[i] = new HIST(*fObjects[0]);
-         fObjects[i]->SetDirectory(nullptr);
+         SetDirZero(fObjects[i]);
       }
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -245,14 +245,6 @@ extern template void FillHelper::Exec(unsigned int, const std::vector<int> &, co
 extern template void
 FillHelper::Exec(unsigned int, const std::vector<unsigned int> &, const std::vector<unsigned int> &);
 
-template<typename T>
-void SetDirZero(T &){}
-
-inline void SetDirZero(TH1 &h)
-{
-   h.SetDirectory(nullptr);
-}
-
 template <typename HIST = Hist_t>
 class FillParHelper : public RActionImpl<FillParHelper<HIST>> {
    std::vector<HIST *> fObjects;
@@ -267,7 +259,9 @@ public:
       // Initialise all other slots
       for (unsigned int i = 1; i < nSlots; ++i) {
          fObjects[i] = new HIST(*fObjects[0]);
-         SetDirZero(fObjects[i]);
+         if (auto objAsHist = dynamic_cast<TH1*>(fObjects[i])) {
+            objAsHist->SetDirectory(nullptr);
+         }
       }
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -111,20 +111,7 @@ struct Display{};
 }
 // clang-format on
 
-template <int D, typename P, template <int, typename, template <typename> class> class... S>
-class THist;
-
-/// Check whether a histogram type is a classic or v7 histogram.
-template <typename T>
-struct IsV7Hist : public std::false_type {
-   static_assert(std::is_base_of<TH1, T>::value, "not implemented for this type");
-};
-
-template <int D, typename P, template <int, typename, template <typename> class> class... S>
-struct IsV7Hist<THist<D, P, S...>> : public std::true_type {
-};
-
-template <typename T, bool ISV7HISTO = IsV7Hist<T>::value>
+template <typename T, bool ISV6HISTO = std::is_base_of<TH1, T>::value>
 struct HistoUtils {
    static void SetCanExtendAllAxes(T &h) { h.SetCanExtend(::TH1::kAllAxes); }
    static bool HasAxisLimits(T &h)
@@ -135,7 +122,7 @@ struct HistoUtils {
 };
 
 template <typename T>
-struct HistoUtils<T, true> {
+struct HistoUtils<T, false> {
    static void SetCanExtendAllAxes(T &) {}
    static bool HasAxisLimits(T &) { return true; }
 };

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -1376,7 +1376,7 @@ public:
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Return a TStatistic object, filled once per event (*lazy action*)
    ///
-   /// \param[in] Column with the values to fill the statistics with.
+   /// \param[in] value The name of the column with the values to fill the statistics with.
    /// \return the filled TStatistic object wrapped in a `RResultPtr`.
    RResultPtr<TStatistic> Stats(std::string_view value = "")
    {
@@ -1391,8 +1391,8 @@ public:
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Return a TStatistic object, filled once per event (*lazy action*)
    ///
-   /// \param[in] Column with the values to fill the statistics with.
-   /// \param[in] Column with the weights to fill the statistics with.
+   /// \param[in] value The name of the column with the values to fill the statistics with.
+   /// \param[in] weight The name of the column with the weights to fill the statistics with.
    /// \return the filled TStatistic object wrapped in a `RResultPtr`.
    RResultPtr<TStatistic> Stats(std::string_view value, std::string_view weight)
    {

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -30,6 +30,7 @@
 #include "TH3.h"        // For Histo actions
 #include "TProfile.h"
 #include "TProfile2D.h"
+#include "TStatistic.h"
 
 #include <algorithm>
 #include <cstddef>
@@ -1370,6 +1371,34 @@ public:
          throw std::runtime_error("The absence of axes limits is not supported yet.");
       }
       return CreateAction<RDFInternal::ActionTags::Fill, RDFDetail::RInferredType>(bl, h, bl.size());
+   }
+
+   ////////////////////////////////////////////////////////////////////////////
+   /// \brief Return a TStatistic object, filled once per event (*lazy action*)
+   ///
+   /// \param[in] Column with the values to fill the statistics with.
+   /// \return the filled TStatistic object wrapped in a `RResultPtr`.
+   RResultPtr<TStatistic> Stats(std::string_view value = "")
+   {
+      ColumnNames_t columns;
+      if (!value.empty()) {
+         columns.emplace_back(std::string(value));
+      }
+      const auto validColumnNames = GetValidatedColumnNames(1, columns);
+      return Fill(TStatistic(), validColumnNames);
+   }
+
+   ////////////////////////////////////////////////////////////////////////////
+   /// \brief Return a TStatistic object, filled once per event (*lazy action*)
+   ///
+   /// \param[in] Column with the values to fill the statistics with.
+   /// \param[in] Column with the weights to fill the statistics with.
+   /// \return the filled TStatistic object wrapped in a `RResultPtr`.
+   RResultPtr<TStatistic> Stats(std::string_view value, std::string_view weight)
+   {
+      ColumnNames_t columns {std::string(value), std::string(weight)};
+      const auto validColumnNames = GetValidatedColumnNames(2, columns);
+      return Fill(TStatistic(), validColumnNames);
    }
 
    ////////////////////////////////////////////////////////////////////////////

--- a/tree/dataframe/test/dataframe_simple.cxx
+++ b/tree/dataframe/test/dataframe_simple.cxx
@@ -993,9 +993,13 @@ TEST_P(RDFSimpleTests, Stats)
               .Define("ones", [](){return std::vector<double>({1.,1.,1.});});
    
    auto s0 = rr.Stats("v");
+   auto m0 = rr.Mean<ULong64_t>("v");
+   auto v0 = rr.StdDev<ULong64_t>("v");
    auto s0prime = rr.Stats("v", "one");
    auto s0w = rr.Stats("v", "w");
    auto s1 = rr.Stats("vec_v");
+   auto m1 = rr.Mean<std::vector<ULong64_t>>("vec_v");
+   auto v1 = rr.StdDev<std::vector<ULong64_t>>("vec_v");
    auto s1w = rr.Stats("vec_v", "vec_w");
    auto s1prime0 = rr.Stats("vec_v", "one");
    auto s1prime1 = rr.Stats("vec_v", "ones");
@@ -1004,8 +1008,12 @@ TEST_P(RDFSimpleTests, Stats)
    EXPECT_FLOAT_EQ(s0->GetMean(), 127.5);
    EXPECT_FLOAT_EQ(s0w->GetMean(), 40.800388);
    EXPECT_FLOAT_EQ(s0->GetMean(), s0prime->GetMean());
+   EXPECT_FLOAT_EQ(s0->GetMean(), *m0);
+   EXPECT_FLOAT_EQ(s0->GetRMS(), *v0);
    EXPECT_FLOAT_EQ(s1->GetMean(), 128.5);
    EXPECT_FLOAT_EQ(s1w->GetMean(), 127.12541);
+   EXPECT_FLOAT_EQ(s1->GetMean(), *m1);
+   EXPECT_FLOAT_EQ(s1->GetRMS(), *v1);
    EXPECT_FLOAT_EQ(s1->GetMean(), s1prime0->GetMean());
    EXPECT_FLOAT_EQ(s1->GetMean(), s1prime1->GetMean());
 }

--- a/tree/dataframe/test/dataframe_simple.cxx
+++ b/tree/dataframe/test/dataframe_simple.cxx
@@ -982,6 +982,34 @@ TEST(RDFSimpleTests, NonExistingFile)
    EXPECT_EQ(0, ret);
 }
 
+TEST_P(RDFSimpleTests, Stats)
+{
+   ROOT::RDataFrame r(256);
+   auto rr = r.Define("v", [](ULong64_t e){return e;}, {"rdfentry_"})
+              .Define("vec_v", [](ULong64_t e){return std::vector<ULong64_t>({e, e+1, e+2});}, {"v"})
+              .Define("w", [](ULong64_t e){return 1./(e+1);}, {"v"})
+              .Define("vec_w", [](double w){return std::vector<double>({w, w+1, w+2});}, {"w"})
+              .Define("one", [](){return 1.;})
+              .Define("ones", [](){return std::vector<double>({1.,1.,1.});});
+   
+   auto s0 = rr.Stats("v");
+   auto s0prime = rr.Stats("v", "one");
+   auto s0w = rr.Stats("v", "w");
+   auto s1 = rr.Stats("vec_v");
+   auto s1w = rr.Stats("vec_v", "vec_w");
+   auto s1prime0 = rr.Stats("vec_v", "one");
+   auto s1prime1 = rr.Stats("vec_v", "ones");
+
+   // Checks
+   EXPECT_FLOAT_EQ(s0->GetMean(), 127.5);
+   EXPECT_FLOAT_EQ(s0w->GetMean(), 40.800388);
+   EXPECT_FLOAT_EQ(s0->GetMean(), s0prime->GetMean());
+   EXPECT_FLOAT_EQ(s1->GetMean(), 128.5);
+   EXPECT_FLOAT_EQ(s1w->GetMean(), 127.12541);
+   EXPECT_FLOAT_EQ(s1->GetMean(), s1prime0->GetMean());
+   EXPECT_FLOAT_EQ(s1->GetMean(), s1prime1->GetMean());
+}
+
 // run single-thread tests
 INSTANTIATE_TEST_CASE_P(Seq, RDFSimpleTests, ::testing::Values(false));
 


### PR DESCRIPTION
out of columns of a dataset.
The implementation is trivial and relies on the already present `RInterface::Fill`.
The `TStatistic::Merge` implementation needed to be changed to be well behaved in a MT context.
Other changes are present in the PR to allow better handling of the filling of non-TH1 objects via the `RInterface::Fill` method.