### PR TITLE
[cxxmodules] Add a tiny comment for undefining macros

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1300,7 +1300,7 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
       // This should be vector in order to be able to pass it to LoadModules
       std::vector<std::string> CoreModules = {"ROOT_Foundation_C","ROOT_Config",
          "ROOT_Foundation_Stage1_NoRTTI", "Core", "RIO"};
-      // These modules contain global variables which conflict with users' code such as "PI".
+
       // FIXME: Reducing those will let us be less dependent on rootmap files
       static constexpr std::array<const char*, 3> ExcludeModules =
          { { "Rtools", "RSQLite", "RInterface"} };
@@ -1342,6 +1342,9 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
       // core modules have defined it:
       // https://www.gnu.org/software/libc/manual/html_node/Complex-Numbers.html
       fInterpreter->declare("#ifdef I\n #undef I\n #endif\n");
+
+      // These macros are from loading R related modules, which conflict with
+      // user's code.
       fInterpreter->declare("#ifdef PI\n #undef PI\n #endif\n");
       fInterpreter->declare("#ifdef ERROR\n #undef ERROR\n #endif\n");
    }


### PR DESCRIPTION
Follow up on #3580, adding a comment for the explanation.