### PR TITLE
Fix copy constructor of RooFitResult

### DIFF
--- a/roofit/roofitcore/src/RooFitResult.cxx
+++ b/roofit/roofitcore/src/RooFitResult.cxx
@@ -91,7 +91,8 @@ RooFitResult::RooFitResult(const RooFitResult& other) :
   _Lt(0),
   _CM(0),
   _VM(0),
-  _GC(0)
+  _GC(0),
+  _statusHistory(other._statusHistory)
 {
   _constPars = (RooArgList*) other._constPars->snapshot() ;
   _initPars = (RooArgList*) other._initPars->snapshot() ;


### PR DESCRIPTION
The `_statusHistory` member was not properly copied over before this. This
resulted in the `_statusHistory` not being persisted in a `RooWorkspace`, when a
`RooFitResult` was imported into it, since the original `RooFitResult` is cloned
during this operation. Consequently, it was not possible to store the status
history of a fit into a `RooWorkspace` and retrieve this information later on.