### PR TITLE
[Exp PyROOT] Create an RPyROOTApplication when importing ROOT

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 set(py_sources
   ROOT/__init__.py
+  ROOT/_application.py
   ROOT/_facade.py
   ROOT/pythonization/__init__.py
   ROOT/pythonization/_generic.py
@@ -34,6 +35,7 @@ set(sources
   src/PyROOTModule.cxx
   src/PyROOTStrings.cxx
   src/PyROOTWrapper.cxx
+  src/RPyROOTApplication.cxx
   src/GenericPyz.cxx
   src/RDataFramePyz.cxx
   src/RVecPyz.cxx

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/__init__.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/__init__.py
@@ -54,6 +54,10 @@ def pythonization(lazy = True):
 for _, module_name, _ in  pkgutil.walk_packages(pyz.__path__):
     module = importlib.import_module(pyz.__name__ + '.' + module_name)
 
+# Setup interactive usage from Python
+from ._application import create_application
+create_application()
+
 # Configure ROOT facade module
 import sys
 from ._facade import ROOTFacade

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/__init__.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/__init__.py
@@ -54,10 +54,6 @@ def pythonization(lazy = True):
 for _, module_name, _ in  pkgutil.walk_packages(pyz.__path__):
     module = importlib.import_module(pyz.__name__ + '.' + module_name)
 
-# Setup interactive usage from Python
-from ._application import create_application
-create_application()
-
 # Configure ROOT facade module
 import sys
 from ._facade import ROOTFacade

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/_application.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/_application.py
@@ -22,9 +22,9 @@ class PyROOTApplication(object):
     Configures the interactive usage of ROOT from Python.
     """
 
-    def __init__(self):
+    def __init__(self, config):
         # Construct a TApplication for PyROOT
-        InitApplication()
+        InitApplication(config.IgnoreCommandLineOptions)
 
     @staticmethod
     def _ipython_config():

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/_application.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/_application.py
@@ -1,0 +1,14 @@
+# Author: Enric Tejedor CERN  04/2019
+
+################################################################################
+# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from libROOTPython import InitApplication
+
+def create_application():
+    InitApplication()

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/_facade.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/_facade.py
@@ -4,6 +4,9 @@ import libcppyy as cppyy_backend
 from cppyy import gbl as gbl_namespace
 from libROOTPython import gROOT
 
+from ._application import PyROOTApplication
+
+
 class ROOTFacade(types.ModuleType):
     """Facade class for ROOT module"""
 
@@ -24,6 +27,28 @@ class ROOTFacade(types.ModuleType):
         for name in cppyy_exports:
             setattr(self, name, getattr(cppyy_backend, name))
 
+        # Redirect lookups to temporary helper methods
+        # This lets the user do some actions before all the machinery is in place:
+        # - Set batch mode in gROOT
+        self.__class__.__getattr__ = self._getattr
+        self.__class__.__setattr__ = self._setattr
+
+    def _finalSetup(self):
+        # Setup interactive usage from Python
+        self.__dict__['app'] = PyROOTApplication()
+        if not self.gROOT.IsBatch():
+            self.app.init_graphics()
+
         # Redirect lookups to cppyy's global namespace
         self.__class__.__getattr__ = lambda self, name: getattr(gbl_namespace, name)
         self.__class__.__setattr__ = lambda self, name, val: setattr(gbl_namespace, name, val)
+
+    def _getattr(self, name):
+        self._finalSetup()
+
+        return getattr(self, name)
+
+    def _setattr(self, name, val):
+        self._finalSetup()
+
+        return setattr(self, name, val)

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/_facade.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/_facade.py
@@ -7,6 +7,13 @@ from libROOTPython import gROOT
 from ._application import PyROOTApplication
 
 
+class PyROOTConfiguration(object):
+    """Class for configuring PyROOT"""
+
+    def __init__(self):
+        self.IgnoreCommandLineOptions = False
+
+
 class ROOTFacade(types.ModuleType):
     """Facade class for ROOT module"""
 
@@ -27,15 +34,19 @@ class ROOTFacade(types.ModuleType):
         for name in cppyy_exports:
             setattr(self, name, getattr(cppyy_backend, name))
 
+        # Initialize configuration
+        self.PyConfig = PyROOTConfiguration()
+
         # Redirect lookups to temporary helper methods
         # This lets the user do some actions before all the machinery is in place:
         # - Set batch mode in gROOT
+        # - Set options in PyConfig
         self.__class__.__getattr__ = self._getattr
         self.__class__.__setattr__ = self._setattr
 
     def _finalSetup(self):
         # Setup interactive usage from Python
-        self.__dict__['app'] = PyROOTApplication()
+        self.__dict__['app'] = PyROOTApplication(self.PyConfig)
         if not self.gROOT.IsBatch():
             self.app.init_graphics()
 

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
@@ -13,6 +13,7 @@
 #include "PyROOTPythonize.h"
 #include "PyROOTStrings.h"
 #include "PyROOTWrapper.h"
+#include "RPyROOTApplication.h"
 
 // Cppyy
 #include "CPyCppyy.h"
@@ -67,6 +68,8 @@ static PyMethodDef gPyROOTMethods[] = {{(char *)"AddDirectoryWritePyz", (PyCFunc
                                         (char *)"Get object with array interface as RVec"},
                                        {(char *)"MakeNumpyDataFrame", (PyCFunction)PyROOT::MakeNumpyDataFrame, METH_O,
                                         (char *)"Make RDataFrame from dictionary of numpy arrays"},
+                                       {(char *)"InitApplication", (PyCFunction)PyROOT::RPyROOTApplication::InitApplication, METH_NOARGS,
+                                        (char *)"Initialize interactive ROOT use from Python"},
                                        {NULL, NULL, 0, NULL}};
 
 #if PY_VERSION_HEX >= 0x03000000

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
@@ -70,6 +70,8 @@ static PyMethodDef gPyROOTMethods[] = {{(char *)"AddDirectoryWritePyz", (PyCFunc
                                         (char *)"Make RDataFrame from dictionary of numpy arrays"},
                                        {(char *)"InitApplication", (PyCFunction)PyROOT::RPyROOTApplication::InitApplication, METH_NOARGS,
                                         (char *)"Initialize interactive ROOT use from Python"},
+                                       {(char *)"InstallGUIEventInputHook", (PyCFunction)PyROOT::RPyROOTApplication::InstallGUIEventInputHook, METH_NOARGS,
+                                        (char *)"Install an input hook to process GUI events"},
                                        {NULL, NULL, 0, NULL}};
 
 #if PY_VERSION_HEX >= 0x03000000

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
@@ -68,7 +68,7 @@ static PyMethodDef gPyROOTMethods[] = {{(char *)"AddDirectoryWritePyz", (PyCFunc
                                         (char *)"Get object with array interface as RVec"},
                                        {(char *)"MakeNumpyDataFrame", (PyCFunction)PyROOT::MakeNumpyDataFrame, METH_O,
                                         (char *)"Make RDataFrame from dictionary of numpy arrays"},
-                                       {(char *)"InitApplication", (PyCFunction)PyROOT::RPyROOTApplication::InitApplication, METH_NOARGS,
+                                       {(char *)"InitApplication", (PyCFunction)PyROOT::RPyROOTApplication::InitApplication, METH_VARARGS,
                                         (char *)"Initialize interactive ROOT use from Python"},
                                        {(char *)"InstallGUIEventInputHook", (PyCFunction)PyROOT::RPyROOTApplication::InstallGUIEventInputHook, METH_NOARGS,
                                         (char *)"Install an input hook to process GUI events"},

--- a/bindings/pyroot_experimental/PyROOT/src/RPyROOTApplication.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/RPyROOTApplication.cxx
@@ -1,0 +1,151 @@
+// Author: Enric Tejedor CERN  04/2019
+// Original PyROOT code by Wim Lavrijsen, LBL
+
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+// Bindings
+#include "Python.h"
+#include "RPyROOTApplication.h"
+
+// ROOT
+#include "TInterpreter.h"
+#include "TSystem.h"
+#include "TBenchmark.h"
+#include "TStyle.h"
+#include "TError.h"
+#include "Getline.h"
+#include "TVirtualMutex.h"
+#ifdef R__WIN32
+#include "TVirtualX.h"
+#endif
+
+////////////////////////////////////////////////////////////////////////////
+/// \brief Create an RPyROOTApplication.
+/// \return false if gApplication is not null, true otherwise.
+bool PyROOT::RPyROOTApplication::CreateApplication()
+{
+   if (!gApplication) {
+      int argc = 1;
+      char **argv = new char *[argc];
+
+      // TODO: Consider parsing arguments for the RPyROOTApplication here
+
+#if PY_VERSION_HEX < 0x03000000
+      if (Py_GetProgramName() && strlen(Py_GetProgramName()) != 0)
+         argv[0] = Py_GetProgramName();
+      else
+         argv[0] = (char *)"python";
+#else
+      argv[0] = (char *)"python";
+#endif
+
+      gApplication = new RPyROOTApplication("PyROOT", &argc, argv);
+      delete[] argv; // TApplication ctor has copied argv, so done with it
+
+      return true;
+   }
+
+   return false;
+}
+
+////////////////////////////////////////////////////////////////////////////
+/// \brief Setup the basic ROOT globals gBenchmark, gStyle and gProgname,
+/// if not already set.
+void PyROOT::RPyROOTApplication::InitROOTGlobals()
+{
+   if (!gBenchmark)
+      gBenchmark = new TBenchmark();
+   if (!gStyle)
+      gStyle = new TStyle();
+
+   if (!gProgName) // should have been set by TApplication
+#if PY_VERSION_HEX < 0x03000000
+      gSystem->SetProgname(Py_GetProgramName());
+#else
+      gSystem->SetProgname("python");
+#endif
+}
+
+////////////////////////////////////////////////////////////////////////////
+/// \brief Translate ROOT error/warning to Python.
+static void ErrMsgHandler(int level, Bool_t abort, const char *location, const char *msg)
+{
+   // Initialization from gEnv (the default handler will return w/o msg b/c level too low)
+   if (gErrorIgnoreLevel == kUnset)
+      ::DefaultErrorHandler(kUnset - 1, kFALSE, "", "");
+
+   if (level < gErrorIgnoreLevel)
+      return;
+
+   // Turn warnings into Python warnings
+   if (level >= kError) {
+      ::DefaultErrorHandler(level, abort, location, msg);
+   } else if (level >= kWarning) {
+      static const char *emptyString = "";
+      if (!location)
+         location = emptyString;
+      // This warning might be triggered while holding the ROOT lock, while
+      // some other thread is holding the GIL and waiting for the ROOT lock.
+      // That will trigger a deadlock.
+      // So if ROOT is in MT mode, use ROOT's error handler that doesn't take
+      // the GIL.
+      if (!gGlobalMutex) {
+         // Either printout or raise exception, depending on user settings
+         PyErr_WarnExplicit(NULL, (char *)msg, (char *)location, 0, (char *)"ROOT", NULL);
+      } else {
+         ::DefaultErrorHandler(level, abort, location, msg);
+      }
+   } else {
+      ::DefaultErrorHandler(level, abort, location, msg);
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////
+/// \brief Install the ROOT message handler which will turn ROOT error
+/// messages into Python exceptions.
+void PyROOT::RPyROOTApplication::InitROOTMessageCallback()
+{
+   SetErrorHandler((ErrorHandlerFunc_t)&ErrMsgHandler);
+}
+
+////////////////////////////////////////////////////////////////////////////
+/// \brief Initialize an RPyROOTApplication.
+PyObject *PyROOT::RPyROOTApplication::InitApplication()
+{
+   if (CreateApplication()) {
+      InitROOTGlobals();
+      InitROOTMessageCallback();
+   }
+
+   Py_RETURN_NONE;
+}
+
+////////////////////////////////////////////////////////////////////////////
+/// \brief Construct a TApplication for PyROOT.
+/// \param[in] acn Application class name.
+/// \param[in] argc Number of arguments.
+/// \param[in] argv Arguments.
+PyROOT::RPyROOTApplication::RPyROOTApplication(const char *acn, int *argc, char **argv) : TApplication(acn, argc, argv)
+{
+#ifdef WIN32
+   // Switch win32 proxy main thread id
+   if (gVirtualX)
+      ProcessLine("((TGWin32 *)gVirtualX)->SetUserThreadId(0);", true);
+#endif
+
+   // Save current interpreter context
+   gInterpreter->SaveContext();
+   gInterpreter->SaveGlobalsContext();
+
+   // Prevent crashes on accessing history
+   Gl_histinit((char *)"-");
+
+   // Prevent ROOT from exiting python
+   SetReturnFromRun(true);
+}

--- a/bindings/pyroot_experimental/PyROOT/src/RPyROOTApplication.h
+++ b/bindings/pyroot_experimental/PyROOT/src/RPyROOTApplication.h
@@ -30,14 +30,14 @@ namespace PyROOT {
 
 class RPyROOTApplication : public TApplication {
 public:
-   static PyObject *InitApplication();
+   static PyObject *InitApplication(PyObject *self, PyObject *args);
    static PyObject *InstallGUIEventInputHook();
 
    RPyROOTApplication(const char *acn, int *argc, char **argv);
    virtual ~RPyROOTApplication() {}
 
 private:
-   static bool CreateApplication();
+   static bool CreateApplication(int ignoreCmdLineOpts);
    static void InitROOTGlobals();
    static void InitROOTMessageCallback();
 };

--- a/bindings/pyroot_experimental/PyROOT/src/RPyROOTApplication.h
+++ b/bindings/pyroot_experimental/PyROOT/src/RPyROOTApplication.h
@@ -1,0 +1,47 @@
+// Author: Enric Tejedor CERN  04/2019
+// Original PyROOT code by Wim Lavrijsen, LBL
+
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_PyROOTApplication
+#define ROOT_PyROOTApplication
+
+// ROOT
+#include "TApplication.h"
+
+namespace PyROOT {
+
+// clang-format off
+/**
+\class PyROOT::RPyROOTApplication
+\brief Interactive application for Python.
+
+ The RPyROOTApplication sets up the nuts and bolts for interactive ROOT use
+ from Python, closely following TRint. Note that not everything is done here,
+ some bits (such as e.g. the use of exception hook for shell escapes) are more
+ easily done in Python.
+*/
+// clang-format on
+
+class RPyROOTApplication : public TApplication {
+public:
+   static PyObject *InitApplication();
+
+   RPyROOTApplication(const char *acn, int *argc, char **argv);
+   virtual ~RPyROOTApplication() {}
+
+private:
+   static bool CreateApplication();
+   static void InitROOTGlobals();
+   static void InitROOTMessageCallback();
+};
+
+} // namespace PyROOT
+
+#endif

--- a/bindings/pyroot_experimental/PyROOT/src/RPyROOTApplication.h
+++ b/bindings/pyroot_experimental/PyROOT/src/RPyROOTApplication.h
@@ -24,14 +24,14 @@ namespace PyROOT {
 
  The RPyROOTApplication sets up the nuts and bolts for interactive ROOT use
  from Python, closely following TRint. Note that not everything is done here,
- some bits (such as e.g. the use of exception hook for shell escapes) are more
- easily done in Python.
+ some bits are more easily done in Python and can be found in _application.py.
 */
 // clang-format on
 
 class RPyROOTApplication : public TApplication {
 public:
    static PyObject *InitApplication();
+   static PyObject *InstallGUIEventInputHook();
 
    RPyROOTApplication(const char *acn, int *argc, char **argv);
    virtual ~RPyROOTApplication() {}

--- a/main/python/cmdLineUtils.py
+++ b/main/python/cmdLineUtils.py
@@ -75,13 +75,11 @@ def stderrRedirected():
 
 ##
 # redirect output (escape characters during ROOT importation...)
-# The gymnastic with sys argv  is necessary to workaround for ROOT-7577
-argvTmp = sys.argv[:]
-sys.argv = []
 with stdoutRedirected():
     import ROOT
+# Silence Davix warning (see ROOT-7577)
+ROOT.PyConfig.IgnoreCommandLineOptions = True
 ROOT.gROOT.GetVersion()
-sys.argv = argvTmp
 
 import argparse
 import glob

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -444,7 +444,6 @@ if(ROOT_python_FOUND)
                  tutorial-math-tStudent-py
                  tutorial-pyroot-benchmarks-py
                  tutorial-pyroot-fillrandom-py
-                 tutorial-pyroot-fit1-py
                  tutorial-pyroot-geometry-py
                  tutorial-pyroot-h1draw-py
                  tutorial-pyroot-hsimple-py
@@ -453,11 +452,9 @@ if(ROOT_python_FOUND)
                  tutorial-pyroot-ntuple1-py
                  tutorial-pyroot-pyroot002_TTreeAsMatrix-py
                  tutorial-pyroot-ratioplot-py
-                 tutorial-pyroot-rootmarks-py
                  tutorial-pyroot-shapes-py
                  tutorial-pyroot-staff-py
                  tutorial-pyroot-tornado-py
-                 tutorial-pyroot-tree-py
                  tutorial-roofit-rf106_plotdecoration-py
                  tutorial-roofit-rf315_projectpdf-py
                  tutorial-roofit-rf402_datahandling-py


### PR DESCRIPTION
The `RPyROOTApplication` is a `TApplication` that sets up the nuts and bolts for interactive ROOT use from Python, closely following `TRint`.

This PR adds the basic behaviour for `TApplication` implemented in C++, i.e. parsing of arguments, configuration of some ROOT globals and setup of an error message handler that is able to translate ROOT warnings into Python warnings. The custom parsing of arguments can be disabled by the user by specifying a configuration option after importing ROOT:
```python
import ROOT
ROOT.PyConfig.IgnoreCommandLineOptions = True
```

Moreover, this PR also brings in some logic that is located in `ROOT.py` in the current PyROOT. Such logic makes it possible to use ROOT interactive graphics from Python. The graphics are activated only if the batch mode is off, and they are configured by means of hooks: no thread is explicitly created to process the GUI events as before. The batch mode can be activated by doing:
```python
import ROOT
ROOT.gROOT.SetBatch(True)
```
or in the command line:
```bash
> python my_script.py -b
```