### PR TITLE
Temporary revert of new discovery routine

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1502,16 +1502,27 @@ static bool R__InitStreamerInfoFactory()
 ////////////////////////////////////////////////////////////////////////////////
 /// Tries to load a PCM; returns true on success.
 
-bool TCling::LoadPCM(const std::string& pcmFileNameFullPath) const {
+bool TCling::LoadPCM(TString pcmFileName,
+                     const char** headers,
+                     const std::string& libraryFullPath) const {
+   // pcmFileName is an intentional copy; updated by FindFile() below.
 
-   assert(!pcmFileNameFullPath.empty());
-   assert(llvm::sys::path::is_absolute(pcmFileNameFullPath));
-   if (!llvm::sys::fs::exists(pcmFileNameFullPath)) {
-     return false;
-   }
+   assert(libraryFullPath.empty());
+   assert(llvm::sys::path::is_absolute(libraryFullPath));
+   TString searchPath;
 
-   // Easier to work with the ROOT interfaces.
-   TString pcmFileName = pcmFileNameFullPath;
+   searchPath = llvm::sys::path::parent_path(libraryFullPath);
+#ifdef R__WIN32
+   searchPath += ";";
+#else
+   searchPath += ":";
+#endif
+   // Note: if we know where the library is, we probably shouldn't even
+   // look in other places.
+   searchPath.Append( gSystem->GetDynamicPath() );
+
+   if (!gSystem->FindFile(searchPath, pcmFileName))
+      return kFALSE;
 
    // Prevent the ROOT-PCMs hitting this during auto-load during
    // JITting - which will cause recursive compilation.
@@ -1976,18 +1987,8 @@ void TCling::RegisterModule(const char* modulename,
    }
 
    if (gIgnoredPCMNames.find(modulename) == gIgnoredPCMNames.end()) {
-      std::string pcmFileNameFullPath;
-      if (dyLibName)
-         pcmFileNameFullPath = dyLibName;
-      else {
-         // if we were in the case of late registration
-         assert(lateRegistration);
-         pcmFileNameFullPath = FindLibraryName(triggerFunc);
-      }
-      pcmFileNameFullPath =
-         llvm::sys::path::parent_path(pcmFileNameFullPath).str() + "/";
-      pcmFileNameFullPath += ROOT::TMetaUtils::GetModuleFileName(modulename);
-      if (!LoadPCM(pcmFileNameFullPath)) {
+      TString pcmFileName(ROOT::TMetaUtils::GetModuleFileName(modulename).c_str());
+      if (!LoadPCM(pcmFileName, headers, dyLibName)) {
          ::Error("TCling::RegisterModule", "cannot find dictionary module %s",
                  ROOT::TMetaUtils::GetModuleFileName(modulename).c_str());
       }

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -568,7 +568,7 @@ private: // Private Utility Functions and Classes
    void AddFriendToClass(clang::FunctionDecl*, clang::CXXRecordDecl*) const;
 
    bool LoadPCM(TString pcmFileName, const char** headers,
-                const std::string& libraryFullPath) const;
+                void (*triggerFunc)()) const;
    void InitRootmapFile(const char *name);
    int  ReadRootmapFile(const char *rootmapfile, TUniqueString* uniqueString = nullptr);
    Bool_t HandleNewTransaction(const cling::Transaction &T);

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -567,7 +567,8 @@ private: // Private Utility Functions and Classes
    void RegisterLoadedSharedLibrary(const char* name);
    void AddFriendToClass(clang::FunctionDecl*, clang::CXXRecordDecl*) const;
 
-   bool LoadPCM(const std::string& pcmFileNameFullPath) const;
+   bool LoadPCM(TString pcmFileName, const char** headers,
+                const std::string& libraryFullPath) const;
    void InitRootmapFile(const char *name);
    int  ReadRootmapFile(const char *rootmapfile, TUniqueString* uniqueString = nullptr);
    Bool_t HandleNewTransaction(const cling::Transaction &T);


### PR DESCRIPTION
Fixing failures in stress-test:
`
Error in <TCling::RegisterModule>: cannot find dictionary module libEvent_rdict.pcm
`