### PR TITLE
[RF] Make sure that categories in multi-layer SimPdfs get updated.

### DIFF
--- a/roofit/roofitcore/inc/RooGenContext.h
+++ b/roofit/roofitcore/inc/RooGenContext.h
@@ -46,7 +46,7 @@ protected:
   RooAbsPdf *_pdfClone;   // Clone of input p.d.f
   RooArgSet _directVars,_uniformVars,_otherVars; // List of observables generated internally, randomly, and by accept/reject sampling
   Int_t _code;                        // Internal generation code
-  Double_t _maxProb, _area, _norm;    // Maximum probability, p.d.f area and normalization
+  Double_t _maxProb{0.}, _area{0.}, _norm{0.};    // Maximum probability, p.d.f area and normalization
   RooRealIntegral *_acceptRejectFunc; // Projection function to be passed to accept/reject sampler
   RooAbsNumGenerator *_generator;     // MC sampling generation engine
   RooRealVar *_maxVar ;               // Variable holding maximum value of p.d.f

--- a/roofit/roofitcore/src/RooBinnedGenContext.cxx
+++ b/roofit/roofitcore/src/RooBinnedGenContext.cxx
@@ -20,7 +20,7 @@
 \ingroup Roofitcore
 
 RooBinnedGenContext is an efficient implementation of the
-generator context specific for binned pdfs
+generator context specific for binned pdfs.
 **/
 
 

--- a/roofit/roofitcore/src/RooSimGenContext.cxx
+++ b/roofit/roofitcore/src/RooSimGenContext.cxx
@@ -22,6 +22,12 @@
 RooSimGenContext is an efficient implementation of the generator context
 specific for RooSimultaneous PDFs when generating more than one of the
 component pdfs.
+It runs in two modes:
+- Proto data with category entries are given: An event from the same category as
+in the proto data is created.
+- No proto data: A category is chosen randomly.
+\note This requires that the PDFs are extended, to determine the relative probabilities
+that an event originates from a certain category.
 **/
 
 #include "RooFit.h"
@@ -283,10 +289,11 @@ void RooSimGenContext::generateEvent(RooArgSet &theEvent, Int_t remaining)
     Int_t i=0 ;
     for (i=0 ; i<_numPdf ; i++) {
       if (rand>_fracThresh[i] && rand<_fracThresh[i+1]) {
-	RooAbsGenContext* gen=_gcList[i] ;	  
-	gen->generateEvent(theEvent,remaining) ;
-	_idxCat->setIndexFast(_gcIndex[i]) ;
-	return ;
+        RooAbsGenContext* gen=_gcList[i] ;
+        gen->generateEvent(theEvent,remaining) ;
+        //Write through to sub-categories because they might be written to dataset:
+        _idxCat->setIndex(_gcIndex[i]);
+        return ;
       }
     }
 

--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -21,8 +21,8 @@
 
 RooSimultaneous facilitates simultaneous fitting of multiple PDFs
 to subsets of a given dataset.
-The class takes an index category, which is interpreted as
-the data subset indicator, and a list of PDFs, each associated
+The class takes an index category, which is used as a selector
+for PDFs, and a list of PDFs, each associated
 with a state of the index category. RooSimultaneous always returns
 the value of the PDF that is associated with the current value
 of the index category.
@@ -30,6 +30,20 @@ of the index category.
 Extended likelihood fitting is supported if all components support
 extended likelihood mode. The expected number of events by a RooSimultaneous
 is that of the component p.d.f. selected by the index category.
+
+The index category can be accessed using indexCategory().
+
+###Generating events
+When generating events from a RooSimultaneous, the index category has to be added to
+the dataset. Further, the PDF needs to know the relative probabilities of each category, i.e.,
+how many events are in which category. This can be achieved in two ways:
+- Generating with proto data that have category entries: An event from the same category as
+in the proto data is created for each event in the proto data.
+See RooAbsPdf::generate(const RooArgSet&,const RooDataSet&,Int_t,Bool_t,Bool_t,Bool_t) const.
+- No proto data: A category is chosen randomly.
+\note This requires that the PDFs building the simultaneous are extended. In this way,
+the relative probability of each category can be calculated from the number of events
+in each category.
 **/
 
 #include "RooFit.h"
@@ -91,7 +105,7 @@ RooSimultaneous::RooSimultaneous(const char *name, const char *title,
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor from index category and full list of PDFs. 
 /// In this constructor form, a PDF must be supplied for each indexCat state
-/// to avoid ambiguities. The PDFS are associated in order with the state of the
+/// to avoid ambiguities. The PDFs are associated in order with the state of the
 /// index category as listed by the index categories type iterator.
 ///
 /// PDFs may not overlap (i.e. share any variables) with the index category (function)
@@ -351,14 +365,14 @@ RooAbsPdf* RooSimultaneous::getPdf(const char* catName) const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Associate given PDF with index category state label 'catLabel'.
-/// The names state must be already defined in the index category
+/// The name state must be already defined in the index category.
 ///
 /// RooSimultaneous can function without having a PDF associated
 /// with every single state. The normalization in such cases is taken
 /// from the number of registered PDFs, but getVal() will assert if
 /// when called for an unregistered index state.
 ///
-/// PDFs may not overlap (i.e. share any variables) with the index category (function)
+/// PDFs may not overlap (i.e. share any variables) with the index category (function).
 
 Bool_t RooSimultaneous::addPdf(const RooAbsPdf& pdf, const char* catLabel)
 {

--- a/roofit/roofitcore/src/RooSuperCategory.cxx
+++ b/roofit/roofitcore/src/RooSuperCategory.cxx
@@ -19,15 +19,15 @@
 \class RooSuperCategory
 \ingroup Roofitcore
 
-RooSuperCategory consolidates several RooAbsCategoryLValue objects into
+RooSuperCategory can join several RooAbsCategoryLValue objects into
 a single category. The states of the super category consist of all the permutations
 of the input categories. The super category is an lvalue and requires that
-all input categories are lvalues as well as modification
+all input categories are lvalues as well. This is because a modification
 of its state will back propagate into a modification of its input categories.
-To define a consolidated category of multiple non-lvalye categories
-use class RooMultiCategory
-RooSuperCategory state are automatically defined and updated whenever an input
-category modifies its list of states
+To define a joined category of multiple non-lvalue categories,
+use the class RooMultiCategory.
+RooSuperCategory states are automatically defined and updated whenever an input
+category modifies its list of states.
 **/
 
 #include "RooFit.h"


### PR DESCRIPTION
[ROOT-10093] When generating events with simultaneous PDFs that contain
further simultaneous PDFs, the category tags of each generated event have to be updated to yield a usable dataset.