### PR TITLE
[RF] Deactivate mempool for RooSetProxy.

### DIFF
--- a/roofit/roofitcore/inc/RooSetProxy.h
+++ b/roofit/roofitcore/inc/RooSetProxy.h
@@ -24,7 +24,7 @@
 class RooSetProxy final : public RooArgSet, public RooAbsProxy  {
 public:
 
-#ifdef USEMEMPOOL
+#ifdef USEMEMPOOLFORARGSET
   void* operator new (size_t bytes);
   void operator delete (void *ptr);
 #endif

--- a/roofit/roofitcore/src/RooSetProxy.cxx
+++ b/roofit/roofitcore/src/RooSetProxy.cxx
@@ -45,7 +45,7 @@ ClassImp(RooSetProxy);
 ;
 
 
-#ifdef USEMEMPOOL
+#ifdef USEMEMPOOLFORARGSET
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Overload new operator must be implemented because it is overloaded


### PR DESCRIPTION
When the mempool for RooArgSet was modernised to prevent crashes during the teardown of
global statics, the macro name for RooSetProxy didn't get updated. Therefore, new-ed
RooSetProxys will also end up in the mempool, which was not intended.