### PR TITLE
[RDF][ROOT-10092] Signal at runtime invalid types used to fill histogram

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -224,6 +224,16 @@ public:
       thisWBuf.insert(thisWBuf.end(), vs.size(), w);
    }
 
+   // ROOT-10092: no scalar value and array weights
+   template <typename T, typename W,
+             typename std::enable_if<IsContainer<W>::value && !IsContainer<T>::value, int>::type = 0>
+   void Exec(unsigned int, const T &, const W &)
+   {
+      throw std::runtime_error(
+        "Cannot fill object if the type of the first column is a scalar and the one of the second a container. "
+        "Did you try to fill a histogram with scalar values and weights stored in containers?");
+   }
+
    Hist_t &PartialUpdate(unsigned int);
 
    void Initialize() { /* noop */}
@@ -294,6 +304,16 @@ public:
       for (auto &x0 : x0s) {
          thisSlotH->Fill(x0); // TODO: Can be optimised in case T == vector<double>
       }
+   }
+
+   // ROOT-10092: no scalar value and array weights
+   template <typename X0, typename X1,
+             typename std::enable_if<IsContainer<X1>::value && !IsContainer<X0>::value, int>::type = 0>
+   void Exec(unsigned int , const X0 &, const X1 &)
+   {
+      throw std::runtime_error(
+        "Cannot fill object if the type of the first column is a scalar and the one of the second a container."
+        "Did you try to fill an object with scalar values and weights stored in containers?");
    }
 
    template <typename X0, typename X1,

--- a/tree/dataframe/test/dataframe_simple.cxx
+++ b/tree/dataframe/test/dataframe_simple.cxx
@@ -1040,6 +1040,24 @@ TEST_P(RDFSimpleTests, Stats)
    EXPECT_EQ(0, ret);
 }
 
+// ROOT-10092
+TEST(RDFSimpleTests, ScalarValuesCollectionWeights)
+{
+   ROOT::RDataFrame r(1);
+   auto h = r.Define("x", [](){return 10;})
+             .Define("y", [](){return ROOT::RVec<int>{1,2,3}; })
+             .Histo1D<int, ROOT::RVec<int>>("x","y");
+   
+   // Check that the exception is thrown
+   auto ret = 1;
+   try {
+      *h;
+   } catch (const std::runtime_error &) {
+      ret = 0;
+   }
+   EXPECT_EQ(0, ret);
+}
+
 // run single-thread tests
 INSTANTIATE_TEST_CASE_P(Seq, RDFSimpleTests, ::testing::Values(false));
 


### PR DESCRIPTION
This can be done at compile time with a static_assert too but the message offered to the user is not as clear.