### PR TITLE
Reland simplify loadpcm

### DIFF
--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -190,6 +190,28 @@ macro(REFLEX_GENERATE_DICTIONARY dictionary)
 endmacro()
 
 #---------------------------------------------------------------------------------------------------
+#---ROOT_GENERATE_DICTIONARY( result_var )
+# Returns the path to the .so file or .dll file. In the latter case Windows defines the dll files as
+# executables and puts them in the $ROOTSYS/bin folder.
+function(ROOT_GET_LIBRARY_OUTPUT_DIR result)
+  set(library_output_dir)
+  if(MSVC)
+    if(DEFINED CMAKE_RUNTIME_OUTPUT_DIRECTORY AND NOT CMAKE_RUNTIME_OUTPUT_DIRECTORY STREQUAL "")
+      set(library_output_dir ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+    else()
+      set(library_output_dir ${CMAKE_CURRENT_BINARY_DIR})
+    endif()
+  else()
+    if(DEFINED CMAKE_LIBRARY_OUTPUT_DIRECTORY AND NOT CMAKE_LIBRARY_OUTPUT_DIRECTORY STREQUAL "")
+      set(library_output_dir ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+    else()
+      set(library_output_dir ${CMAKE_CURRENT_BINARY_DIR})
+    endif()
+  endif()
+  SET(${result} "${library_output_dir}" PARENT_SCOPE)
+endfunction(ROOT_GET_LIBRARY_OUTPUT_DIR)
+
+#---------------------------------------------------------------------------------------------------
 #---ROOT_GENERATE_DICTIONARY( dictionary headerfiles NODEPHEADERS ghdr1 ghdr2 ...
 #                                                    MODULE module DEPENDENCIES dep1 dep2
 #                                                    BUILTINS dep1 dep2
@@ -320,12 +342,7 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
   endif()
 
   #---Set the library output directory-----------------------
-  if(DEFINED CMAKE_LIBRARY_OUTPUT_DIRECTORY AND NOT CMAKE_LIBRARY_OUTPUT_DIRECTORY STREQUAL "")
-    set(library_output_dir ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
-  else()
-    set(library_output_dir ${CMAKE_CURRENT_BINARY_DIR})
-  endif()
-
+  ROOT_GET_LIBRARY_OUTPUT_DIR(library_output_dir)
   if(ARG_MODULE)
     set(library_name ${libprefix}${ARG_MODULE}${libsuffix})
     if(ARG_MULTIDICT)
@@ -777,11 +794,7 @@ function(ROOT_GENERATE_ROOTMAP library)
   get_filename_component(path ${library} PATH)
 
   #---Set the library output directory-----------------------
-  if(DEFINED CMAKE_LIBRARY_OUTPUT_DIRECTORY)
-    set(library_output_dir ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
-  else()
-    set(library_output_dir ${CMAKE_CURRENT_BINARY_DIR})
-  endif()
+  ROOT_GET_LIBRARY_OUTPUT_DIR(library_output_dir)
 
   set(outfile ${library_output_dir}/${libprefix}${libname}.rootmap)
   foreach( f ${ARG_LINKDEF})
@@ -812,7 +825,7 @@ function(ROOT_GENERATE_ROOTMAP library)
   set_target_properties(${libprefix}${library}.rootmap PROPERTIES FOLDER RootMaps )
   #---Install the rootmap file------------------------------------
   install(FILES ${outfile} DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
-endfunction()
+endfunction(ROOT_GENERATE_ROOTMAP)
 
 #---------------------------------------------------------------------------------------------------
 #---ROOT_FIND_DIRS_WITH_HEADERS([dir1 dir2 ...] OPTIONS [options])

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1504,22 +1504,19 @@ static bool R__InitStreamerInfoFactory()
 
 bool TCling::LoadPCM(TString pcmFileName,
                      const char** headers,
-                     void (*triggerFunc)()) const {
+                     const std::string& libraryFullPath) const {
    // pcmFileName is an intentional copy; updated by FindFile() below.
 
+   assert(libraryFullPath.empty());
+   assert(llvm::sys::path::is_absolute(libraryFullPath));
    TString searchPath;
 
-   if (triggerFunc) {
-      const char *libraryName = FindLibraryName(triggerFunc);
-      if (libraryName) {
-         searchPath = llvm::sys::path::parent_path(libraryName);
+   searchPath = llvm::sys::path::parent_path(libraryFullPath);
 #ifdef R__WIN32
-         searchPath += ";";
+   searchPath += ";";
 #else
-         searchPath += ":";
+   searchPath += ":";
 #endif
-      }
-   }
    // Note: if we know where the library is, we probably shouldn't even
    // look in other places.
    searchPath.Append( gSystem->GetDynamicPath() );
@@ -1991,7 +1988,7 @@ void TCling::RegisterModule(const char* modulename,
 
    if (gIgnoredPCMNames.find(modulename) == gIgnoredPCMNames.end()) {
       TString pcmFileName(ROOT::TMetaUtils::GetModuleFileName(modulename).c_str());
-      if (!LoadPCM(pcmFileName, headers, triggerFunc)) {
+      if (!LoadPCM(pcmFileName, headers, dyLibName)) {
          ::Error("TCling::RegisterModule", "cannot find dictionary module %s",
                  ROOT::TMetaUtils::GetModuleFileName(modulename).c_str());
       }

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1976,18 +1976,31 @@ void TCling::RegisterModule(const char* modulename,
    }
 
    if (gIgnoredPCMNames.find(modulename) == gIgnoredPCMNames.end()) {
-      std::string pcmFileNameFullPath;
+      llvm::SmallString<256> pcmFileNameFullPath;
       if (dyLibName)
          pcmFileNameFullPath = dyLibName;
       else {
          // if we were in the case of late registration
          assert(lateRegistration);
          pcmFileNameFullPath = FindLibraryName(triggerFunc);
+         // FIXME: A horrible workaround for ctest. ROOT_ADD_TEST adds a test by
+         // invoking ${CMAKE_COMMAND} -DCMD=blah. This does not work well with
+         // statically linked executables such as stress* (referencing libEvent)
+         // because FindLibraryName relies on dladdr which gets confused by the
+         // outer executable. Explicitly add the current working directory to
+         // the library.
+         // Note, we do not take this branch outside of ctest.
+         if (!llvm::sys::path::is_absolute(pcmFileNameFullPath)) {
+            llvm::SmallString<128> curr_path;
+            llvm::sys::fs::current_path(curr_path);
+            llvm::sys::fs::make_absolute(curr_path, pcmFileNameFullPath);
+         }
       }
-      pcmFileNameFullPath =
-         llvm::sys::path::parent_path(pcmFileNameFullPath).str() + "/";
-      pcmFileNameFullPath += ROOT::TMetaUtils::GetModuleFileName(modulename);
-      if (!LoadPCM(pcmFileNameFullPath)) {
+      llvm::sys::path::remove_filename(pcmFileNameFullPath);
+
+      llvm::sys::path::append(pcmFileNameFullPath,
+                              ROOT::TMetaUtils::GetModuleFileName(modulename));
+      if (!LoadPCM(pcmFileNameFullPath.str().str())) {
          ::Error("TCling::RegisterModule", "cannot find dictionary module %s",
                  ROOT::TMetaUtils::GetModuleFileName(modulename).c_str());
       }

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -567,8 +567,7 @@ private: // Private Utility Functions and Classes
    void RegisterLoadedSharedLibrary(const char* name);
    void AddFriendToClass(clang::FunctionDecl*, clang::CXXRecordDecl*) const;
 
-   bool LoadPCM(TString pcmFileName, const char** headers,
-                const std::string& libraryFullPath) const;
+   bool LoadPCM(const std::string& pcmFileNameFullPath) const;
    void InitRootmapFile(const char *name);
    int  ReadRootmapFile(const char *rootmapfile, TUniqueString* uniqueString = nullptr);
    Bool_t HandleNewTransaction(const cling::Transaction &T);

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -568,7 +568,7 @@ private: // Private Utility Functions and Classes
    void AddFriendToClass(clang::FunctionDecl*, clang::CXXRecordDecl*) const;
 
    bool LoadPCM(TString pcmFileName, const char** headers,
-                void (*triggerFunc)()) const;
+                const std::string& libraryFullPath) const;
    void InitRootmapFile(const char *name);
    int  ReadRootmapFile(const char *rootmapfile, TUniqueString* uniqueString = nullptr);
    Bool_t HandleNewTransaction(const cling::Transaction &T);


### PR DESCRIPTION
We implement a workaround for ctest.

ROOT_ADD_TEST cmake macro adds a test executable by invoking CMAKE_COMMAND -DCMD=... This breaks our FindLibraryName function which depends on dladdr and the cmake executable confuses it.

This branch is not taken outside of ctest where the code just works.

This was broken before but worked because we scanned all possible dynamic paths for rdict files which is redundant.