### PR TITLE
[Core][ROOT-9959] Stop early manipulation of commandline args

### DIFF
--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -496,6 +496,8 @@ void TApplication::GetOptions(Int_t *argc, char **argv)
          char *arg = strchr(argv[i], '(');
          if (arg) *arg = '\0';
          char *dir = gSystem->ExpandPathName(argv[i]);
+         // ROOT-9959: we do not continue if we could not expand the path
+         if (!dir) continue;
          TUrl udir(dir, kTRUE);
          // remove options and anchor to check the path
          TString sfx = udir.GetFileAndOptions();


### PR DESCRIPTION
if path expansion failed, otherwise ROOT applications inviked with
commandline arguments can badly crash.