### PR TITLE
jsroot: better grouping for context menus

### DIFF
--- a/README/ReleaseNotes/v618/index.md
+++ b/README/ReleaseNotes/v618/index.md
@@ -342,13 +342,13 @@ In addition we have :
    - Provide initial WebVR support, thanks to Diego Marcos
    - Use gStyle attributes to draw histogram title
    - Enable projections drawing also with TH2 lego plots
-   - Many adjustment with new TWebCanvas - interactivity, attributes/position updates
+   - Many adjustment with new TWebCanvas - interactivity, attributes/position updates, context menus
    - Upgrade three.js 86 -> 102, use SoftwareRenderer instead of CanvasRenderer
    - Upgrade d3.js 4.4.4 -> 5.7.0
    - Fix - support clipping for tracks and points in geo painter
    - Fix - drawing of TGeoNode with finder
    - Fix - key press events processed only in active pad (ROOT-9128)
-   - Fix - use X0/Y0 in xtru shape (#182), thanks to @altavir
+   - Fix - use X0/Y0 in xtru shape, thanks to @altavir
 
 
 ### New files location

--- a/js/scripts/JSRootPainter.jquery.js
+++ b/js/scripts/JSRootPainter.jquery.js
@@ -39,7 +39,7 @@
 
       var menu = { painter: painter,  element: null, code: "", cnt: 1, funcs: {}, separ: false };
 
-      menu.add = function(name, arg, func) {
+      menu.add = function(name, arg, func, title) {
          if (name == "separator") { this.code += "<li>-</li>"; this.separ = true; return; }
 
          if (name.indexOf("header:")==0) {
@@ -48,12 +48,12 @@
          }
 
          if (name=="endsub:") { this.code += "</ul></li>"; return; }
-         var close_tag = "</li>", style = "";
-         if (name.indexOf("sub:")==0) { name = name.substr(4); close_tag="<ul>"; /* style += ";padding-right:2em" */}
+
+         var item = "", close_tag = "</li>";
+         title = title ? " title='" + title + "'" : "";
+         if (name.indexOf("sub:")==0) { name = name.substr(4); close_tag = "<ul>"; }
 
          if (typeof arg == 'function') { func = arg; arg = name;  }
-
-         var item = "";
 
          if (name.indexOf("chk:")==0) { item = "<span class='ui-icon ui-icon-check' style='margin:1px'></span>"; name = name.substr(4); } else
          if (name.indexOf("unk:")==0) { item = "<span class='ui-icon ui-icon-blank' style='margin:1px'></span>"; name = name.substr(4); }
@@ -61,13 +61,12 @@
          // special handling of first versions with menu support
          if (($.ui.version.indexOf("1.10")==0) || ($.ui.version.indexOf("1.9")==0))
             item = '<a href="#">' + item + name + '</a>';
-         else
-         if ($.ui.version.indexOf("1.11")==0)
+         else if ($.ui.version.indexOf("1.11")==0)
             item += name;
          else
-            item = '<div>' + item + name + '</div>';
+            item = "<div" + title + ">" + item + name + "</div>";
 
-         this.code += "<li cnt='" + this.cnt + "' arg='" + arg + "' style='" + style + "'>" + item + close_tag;
+         this.code += "<li cnt='" + this.cnt + ((arg !== undefined) ? "' arg='" + arg : "") + "'>" + item + close_tag;
          if (typeof func == 'function') this.funcs[this.cnt] = func; // keep call-back function
 
          this.cnt++;

--- a/js/scripts/JSRootPainter.js
+++ b/js/scripts/JSRootPainter.js
@@ -3971,7 +3971,6 @@
 
          if (items && items.length) {
             _menu.add("separator");
-            _menu.add("sub:Online");
 
             this.args_menu_items = items;
             this.args_menu_id = reply.fId;
@@ -3981,8 +3980,14 @@
             for (var n=0;n<items.length;++n) {
                var item = items[n];
 
-               if (item.fClassName && lastclname && (lastclname!=item.fClassName)) _menu.add("separator");
-               lastclname = item.fClassName;
+               if (item.fClassName && lastclname && (lastclname!=item.fClassName)) {
+                  _menu.add("endsub:");
+                  lastclname = "";
+               }
+               if (lastclname != item.fClassName) {
+                  lastclname = item.fClassName;
+                  _menu.add("sub:" + lastclname, undefined, null, "Context menu for class " + lastclname);
+               }
 
                if ((item.fChecked === undefined) || (item.fChecked < 0))
                   _menu.add(item.fName, n, DoExecMenu);
@@ -3990,7 +3995,7 @@
                   _menu.addchk(item.fChecked, item.fName, n, DoExecMenu);
             }
 
-            _menu.add("endsub:");
+            if (lastclname) _menu.add("endsub:");
          }
 
          JSROOT.CallBack(_call_back);


### PR DESCRIPTION
While context menu can be too long, group them by class names.
Makes much easier task gor jquery-ui to render such menu in small web
pages