### PR TITLE
Reduce ExcludeModules: Removed RInterface

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1275,8 +1275,8 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
          "ROOT_Foundation_Stage1_NoRTTI", "Core", "RIO"};
 
       // FIXME: Reducing those will let us be less dependent on rootmap files
-      static constexpr std::array<const char*, 3> ExcludeModules =
-         { { "Rtools", "RSQLite", "RInterface"} };
+      static constexpr std::array<const char*, 2> ExcludeModules =
+         { { "Rtools", "RSQLite"} };
 
       LoadModules(CoreModules, *fInterpreter);
 


### PR DESCRIPTION
This reduces dependency on rootmap files