### PR TITLE
Fix for ROOT-10030

### DIFF
--- a/core/imt/CMakeLists.txt
+++ b/core/imt/CMakeLists.txt
@@ -3,6 +3,8 @@
 ############################################################################
 
 if(imt)
+  include_directories(BEFORE "inc")
+
   ROOT_GENERATE_DICTIONARY(G__Imt STAGE1
     ROOT/TFuture.hxx
     ROOT/TPoolManager.hxx
@@ -23,16 +25,15 @@ endif()
 ROOT_LINKER_LIBRARY(Imt
     src/base.cxx
     src/TTaskGroup.cxx
-  DEPENDENCIES
-    Core
-    Thread
   BUILTINS
     TBB
 )
 
+target_link_libraries(Imt PRIVATE Thread INTERFACE Core)
+
 if(imt)
   target_include_directories(Imt PRIVATE ${TBB_INCLUDE_DIRS})
-  target_link_libraries(Imt PUBLIC ${TBB_LIBRARIES})
+  target_link_libraries(Imt PRIVATE ${TBB_LIBRARIES})
 
   # G__Imt.cxx is automatically added by ROOT_LINKER_LIBRARY.
   target_sources(Imt PRIVATE


### PR DESCRIPTION
This syncs `core/imt/CMakeLists.txt` with the `master` branch, which does not have the problem of installed ROOT pointing to the build directory.