### PR TITLE
[RDF] Disable autoparsing during jitting.

### DIFF
--- a/tree/dataframe/src/RDFUtils.cxx
+++ b/tree/dataframe/src/RDFUtils.cxx
@@ -296,6 +296,7 @@ void InterpreterDeclare(const std::string &code)
 
 Long64_t InterpreterCalc(const std::string &code, const std::string &context)
 {
+   TInterpreter::SuspendAutoParsing SAPRAII(gInterpreter);
    TInterpreter::EErrorCode errorCode(TInterpreter::kNoError);
    auto res = gInterpreter->Calc(code.c_str(), &errorCode);
    if (errorCode != TInterpreter::EErrorCode::kNoError) {


### PR DESCRIPTION
When composing the expressions to jit autoparsing is redundant as we
know what and when to synthesize.

This patch has two effects, first it limits the recursive behavior of
autoparse and autoload (useful for modules); and secondly avoids deep call
chains of virtual function calls.

EDIT: Rationale -- I was working on a new, cxxmodules-based implementation of TCling::GetClassSharedLibs which does not rely on rootmap files. I had to debug a few failures in RDF and I noticed the recursive calls to autoparse and autoload always without success. I thought it might be a simplification (and performance optimization) if we disabled that part.