### PR TITLE
Fix ROOT-9760

### DIFF
--- a/documentation/doxygen/libs.C
+++ b/documentation/doxygen/libs.C
@@ -4,9 +4,33 @@ void libs(TString classname)
 
    // Find in which library classname sits
    classname.ReplaceAll("_1",":");
+   classname.ReplaceAll("_01"," ");
+   int i = classname.Index("_3");
+   if (i>0) classname.Remove(i,classname.Length()-i);
+
    libname = gInterpreter->GetClassSharedLibs(classname.Data());
 
-   if(!libname) return;
+   // Library was not found, try to find it from a template in $ROOTSYS/lib/*.rootmap
+   if (!libname) {
+      gSystem->Exec(Form("grep %s $ROOTSYS/lib/*.rootmap | grep -m 1 map:class | sed -e 's/^.*class //' > classname.txt",classname.Data()));
+      FILE *f = fopen("classname.txt", "r");
+      char c[160];
+      char *str = fgets(c,160,f);
+      fclose(f);
+      remove("classname.txt");
+      if (!str) {
+         printf("%s cannot be found in any of the .rootmap files\n", classname.Data());
+         remove("libslist.dot");
+         return;
+      }
+      TString cname = c;
+      cname.Remove(cname.Length()-1, 1);
+      libname = gInterpreter->GetClassSharedLibs(cname.Data());
+      if (!libname) {
+         printf("Cannot find library for the class %s\n",cname.Data());
+         return;
+      }
+   }
 
    // Print the library name in a external file
    TString mainlib = libname;

--- a/documentation/doxygen/makelibs.sh
+++ b/documentation/doxygen/makelibs.sh
@@ -2,18 +2,23 @@
 
 HTMLPATH=$DOXYGEN_OUTPUT_DIRECTORY/html
 
+# Find the libraries for the class $1
+root -l -b -q "libs.C(\"$1\")"
+
+# No dot file, the class was not found. Remove the collaboration graph
+if [[ ! -f libslist.dot ]] ; then
+   sed -i'.back' -e 's/^Collaboration diagram for.*$/<\/div>/g'  $HTMLPATH/class$1.html
+   sed -i'.back' '/__coll__graph.svg/I,+2 d'  $HTMLPATH/class$1.html
+   sed -i'.back' -e 's/<hr\/>The documentation for/<\/div><hr\/>The documentation for/g'  $HTMLPATH/class$1.html
+   rm $HTMLPATH/class$1.html.back
+   exit
+fi
+
 sed -i'.back' -e 's/Collaboration diagram for /Libraries for /g'  $HTMLPATH/class$1.html
 rm $HTMLPATH/class$1.html.back
 
 # Picture name containing the "coll graph"
 PICNAME=$HTMLPATH/"class"$1"__coll__graph.svg"
-
-# Find the libraries for the class $1
-root -l -b -q "libs.C(\"$1\")"
-
-if [[ ! -f libslist.dot ]] ; then
-   exit
-fi
 
 sed -i'.back' -e "s/\.so.*$/\";/" libslist.dot
 rm libslist.dot.back


### PR DESCRIPTION
Web page for RVec did not mention libVecOps.
Do not produce a graph if the libraries are not found.