### PR TITLE
[TMVA] Add keras tutorials to documentation

### DIFF
--- a/tutorials/tmva/keras/ApplicationClassificationKeras.py
+++ b/tutorials/tmva/keras/ApplicationClassificationKeras.py
@@ -1,4 +1,13 @@
 #!/usr/bin/env python
+## \file
+## \ingroup tutorial_tmva
+## \notebook -nodraw
+## This tutorial shows how to apply a trained model to new data.
+##
+## \macro_code
+##
+## \date 2017
+## \author TMVA Team
 
 from ROOT import TMVA, TFile, TString
 from array import array

--- a/tutorials/tmva/keras/ApplicationClassificationKeras.py
+++ b/tutorials/tmva/keras/ApplicationClassificationKeras.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 ## \file
-## \ingroup tutorial_tmva
+## \ingroup tutorial_tmva_keras
 ## \notebook -nodraw
 ## This tutorial shows how to apply a trained model to new data.
 ##

--- a/tutorials/tmva/keras/ApplicationRegressionKeras.py
+++ b/tutorials/tmva/keras/ApplicationRegressionKeras.py
@@ -1,4 +1,13 @@
 #!/usr/bin/env python
+## \file
+## \ingroup tutorial_tmva
+## \notebook -nodraw
+## This tutorial shows how to apply a trained model to new data (regression).
+##
+## \macro_code
+##
+## \date 2017
+## \author TMVA Team
 
 from ROOT import TMVA, TFile, TString
 from array import array

--- a/tutorials/tmva/keras/ApplicationRegressionKeras.py
+++ b/tutorials/tmva/keras/ApplicationRegressionKeras.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 ## \file
-## \ingroup tutorial_tmva
+## \ingroup tutorial_tmva_keras
 ## \notebook -nodraw
 ## This tutorial shows how to apply a trained model to new data (regression).
 ##

--- a/tutorials/tmva/keras/ClassificationKeras.py
+++ b/tutorials/tmva/keras/ClassificationKeras.py
@@ -1,4 +1,14 @@
 #!/usr/bin/env python
+## \file
+## \ingroup tutorial_tmva
+## \notebook -nodraw
+## This tutorial shows how to do classification in TMVA with neural networks
+## trained with keras.
+##
+## \macro_code
+##
+## \date 2017
+## \author TMVA Team
 
 from ROOT import TMVA, TFile, TTree, TCut
 from subprocess import call

--- a/tutorials/tmva/keras/ClassificationKeras.py
+++ b/tutorials/tmva/keras/ClassificationKeras.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 ## \file
-## \ingroup tutorial_tmva
+## \ingroup tutorial_tmva_keras
 ## \notebook -nodraw
 ## This tutorial shows how to do classification in TMVA with neural networks
 ## trained with keras.

--- a/tutorials/tmva/keras/GenerateModel.py
+++ b/tutorials/tmva/keras/GenerateModel.py
@@ -1,4 +1,14 @@
 #!/usr/bin/env python
+## \file
+## \ingroup tutorial_tmva
+## \notebook -nodraw
+## This tutorial shows how to define and generate a keras model for use with
+## TMVA.
+##
+## \macro_code
+##
+## \date 2017
+## \author TMVA Team
 
 from keras.models import Sequential
 from keras.layers.core import Dense, Activation

--- a/tutorials/tmva/keras/GenerateModel.py
+++ b/tutorials/tmva/keras/GenerateModel.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 ## \file
-## \ingroup tutorial_tmva
+## \ingroup tutorial_tmva_keras
 ## \notebook -nodraw
 ## This tutorial shows how to define and generate a keras model for use with
 ## TMVA.

--- a/tutorials/tmva/keras/MulticlassKeras.py
+++ b/tutorials/tmva/keras/MulticlassKeras.py
@@ -1,4 +1,14 @@
 #!/usr/bin/env python
+## \file
+## \ingroup tutorial_tmva
+## \notebook -nodraw
+## This tutorial shows how to do multiclass classification in TMVA with neural
+## networks trained with keras.
+##
+## \macro_code
+##
+## \date 2017
+## \author TMVA Team
 
 from ROOT import TMVA, TFile, TTree, TCut, gROOT
 from os.path import isfile

--- a/tutorials/tmva/keras/MulticlassKeras.py
+++ b/tutorials/tmva/keras/MulticlassKeras.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 ## \file
-## \ingroup tutorial_tmva
+## \ingroup tutorial_tmva_keras
 ## \notebook -nodraw
 ## This tutorial shows how to do multiclass classification in TMVA with neural
 ## networks trained with keras.

--- a/tutorials/tmva/keras/RegressionKeras.py
+++ b/tutorials/tmva/keras/RegressionKeras.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 ## \file
-## \ingroup tutorial_tmva
+## \ingroup tutorial_tmva_keras
 ## \notebook -nodraw
 ## This tutorial shows how to do regression in TMVA with neural networks
 ## trained with keras.

--- a/tutorials/tmva/keras/RegressionKeras.py
+++ b/tutorials/tmva/keras/RegressionKeras.py
@@ -1,4 +1,14 @@
 #!/usr/bin/env python
+## \file
+## \ingroup tutorial_tmva
+## \notebook -nodraw
+## This tutorial shows how to do regression in TMVA with neural networks
+## trained with keras.
+##
+## \macro_code
+##
+## \date 2017
+## \author TMVA Team
 
 from ROOT import TMVA, TFile, TTree, TCut
 from subprocess import call

--- a/tutorials/tmva/keras/index.md
+++ b/tutorials/tmva/keras/index.md
@@ -1,0 +1,3 @@
+\defgroup tutorial_tmva_keras TMVA Keras tutorials
+\ingroup tutorial_tmva
+\brief Example code which illustrates how to use keras with the python interface of TMVA


### PR DESCRIPTION
They were missing a crucial comment header, making the documentation
generation system not pick them up.