### PR TITLE
RooChebychev: scalable implementation

### DIFF
--- a/roofit/roofit/inc/RooChebychev.h
+++ b/roofit/roofit/inc/RooChebychev.h
@@ -45,7 +45,7 @@ private:
   mutable TNamed* _refRangeName ; 
 
   Double_t evaluate() const;
-  Double_t evalAnaInt(const Double_t x) const;
+  Double_t evalAnaInt(const Double_t a, const Double_t b) const;
 
   ClassDef(RooChebychev,2) // Chebychev polynomial PDF
 };

--- a/roofit/roofit/src/RooChebychev.cxx
+++ b/roofit/roofit/src/RooChebychev.cxx
@@ -16,11 +16,11 @@
 /** \class RooChebychev
    \ingroup Roofit
 
-Chebychev polynomial p.d.f. of the first kind
+Chebychev polynomial p.d.f. of the first kind.
 
-The coefficient that goes with T_0(x)=1 (i.e. the constant polynomial) is
+The coefficient that goes with \f$ T_0(x)=1 \f$ (i.e. the constant polynomial) is
 implicitly assumed to be 1, and the list of coefficients supplied by callers
-starts with the coefficient that goes with T_1(x)=x (i.e. the linear term).
+starts with the coefficient that goes with \f$ T_1(x)=x \f$ (i.e. the linear term).
 **/
 
 #include <cmath>
@@ -67,9 +67,9 @@ enum class Kind : int { First = 1, Second = 2 };
 template <typename T, Kind KIND>
 class ChebychevIterator {
 private:
-   T m_last = 1;
-   T m_curr = 0;
-   T m_twox = 0;
+   T _last = 1;
+   T _curr = 0;
+   T _twox = 0;
 
 public:
    /// default constructor
@@ -80,7 +80,7 @@ public:
    ChebychevIterator(ChebychevIterator &&) = default;
    /// construct from given x in [-1, 1]
    constexpr ChebychevIterator(const T &x)
-       : m_curr(static_cast<int>(KIND) * x), m_twox(2 * x)
+       : _curr(static_cast<int>(KIND) * x), _twox(2 * x)
    {}
 
    /// (copy) assignment
@@ -89,15 +89,15 @@ public:
    ChebychevIterator &operator=(ChebychevIterator &&) = default;
 
    /// get value of Chebychev polynomial at current order
-   constexpr inline T operator*() const noexcept { return m_last; }
+   constexpr inline T operator*() const noexcept { return _last; }
    // get value of Chebychev polynomial at (current + 1) order
-   constexpr inline T lookahead() const noexcept { return m_curr; }
+   constexpr inline T lookahead() const noexcept { return _curr; }
    /// move on to next order, return reference to new value
    inline ChebychevIterator &operator++() noexcept
    {
-      T newval = fast_fma(m_twox, m_curr, -m_last);
-      m_last = m_curr;
-      m_curr = newval;
+      T newval = fast_fma(_twox, _curr, -_last);
+      _last = _curr;
+      _curr = newval;
       return *this;
    }
    /// move on to next order, return copy of new value

--- a/roofit/roofit/src/RooChebychev.cxx
+++ b/roofit/roofit/src/RooChebychev.cxx
@@ -17,6 +17,10 @@
    \ingroup Roofit
 
 Chebychev polynomial p.d.f. of the first kind
+
+The coefficient that goes with T_0(x)=1 (i.e. the constant polynomial) is
+implicitly assumed to be 1, and the list of coefficients supplied by callers
+starts with the coefficient that goes with T_1(x)=x (i.e. the linear term).
 **/
 
 #include <cmath>
@@ -34,16 +38,75 @@ Chebychev polynomial p.d.f. of the first kind
 
 #include "TError.h"
 
-#if defined(__my_func__)
-#undef __my_func__
-#endif
-#if defined(WIN32)
-#define __my_func__ __FUNCTION__
-#else
-#define __my_func__ __func__
-#endif
-
 ClassImp(RooChebychev);
+
+namespace { // anonymous namespace to hide implementation details
+/// use fast FMA if available, fall back to normal arithmetic if not
+static inline double fast_fma(
+	const double x, const double y, const double z) noexcept
+{
+#if defined(FP_FAST_FMA) // check if std::fma has fast hardware implementation
+   return std::fma(x, y, z);
+#else // defined(FP_FAST_FMA)
+   // std::fma might be slow, so use a more pedestrian implementation
+#pragma STDC FP_CONTRACT ON // hint clang that using an FMA is okay here
+   return (x * y) + z;
+#endif // defined(FP_FAST_FMA)
+}
+
+/// Chebychev polynomials of first or second kind
+enum class Kind : int { First = 1, Second = 2 };
+
+/** @brief ChebychevIterator evaluates increasing orders at given x
+ *
+ * @author Manuel Schiller <Manuel.Schiller@glasgow.ac.uk>
+ * @date 2019-03-24
+ */
+template <typename T, Kind KIND>
+class ChebychevIterator {
+private:
+   T m_last = 1;
+   T m_twox = 0;
+   T m_curr = 0;
+
+public:
+   /// default constructor
+   constexpr ChebychevIterator() = default;
+   /// copy constructor
+   ChebychevIterator(const ChebychevIterator &) = default;
+   /// move constructor
+   ChebychevIterator(ChebychevIterator &&) = default;
+   /// construct from given x in [-1, 1]
+   constexpr ChebychevIterator(const T &x)
+       : m_twox(2 * x), m_curr(static_cast<int>(KIND) * x)
+   {}
+
+   /// (copy) assignment
+   ChebychevIterator &operator=(const ChebychevIterator &) = default;
+   /// move assignment
+   ChebychevIterator &operator=(ChebychevIterator &&) = default;
+
+   /// get value of Chebychev polynomial at current order
+   constexpr inline T operator*() const noexcept { return m_last; }
+   // get value of Chebychev polynomial at (current + 1) order
+   constexpr inline T lookahead() const noexcept { return m_curr; }
+   /// move on to next order, return reference to new value
+   constexpr inline ChebychevIterator &operator++() noexcept
+   {
+      T newval = fast_fma(m_twox, m_curr, -m_last);
+      m_last = m_curr;
+      m_curr = newval;
+      return *this;
+   }
+   /// move on to next order, return copy of new value
+   constexpr inline ChebychevIterator operator++(int) noexcept
+   {
+      ChebychevIterator retVal(*this);
+      operator++();
+      return retVal;
+   }
+};
+} // anonymous namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -86,12 +149,6 @@ RooChebychev::RooChebychev(const RooChebychev& other, const char* name) :
 {
 }
 
-//inline static double p0(double ,double a) { return a; }
-inline static double p1(double t,double a,double b) { return a*t+b; }
-inline static double p2(double t,double a,double b,double c) { return p1(t,p1(t,a,b),c); }
-inline static double p3(double t,double a,double b,double c,double d) { return p2(t,p1(t,a,b),c,d); }
-//inline static double p4(double t,double a,double b,double c,double d,double e) { return p3(t,p1(t,a,b),c,d,e); }
-
 ////////////////////////////////////////////////////////////////////////////////
 
 void RooChebychev::selectNormalizationRange(const char* rangeName, Bool_t force)
@@ -108,23 +165,24 @@ void RooChebychev::selectNormalizationRange(const char* rangeName, Bool_t force)
 
 Double_t RooChebychev::evaluate() const
 {
-  Double_t xmin = _x.min(_refRangeName?_refRangeName->GetName():0) ; Double_t xmax = _x.max(_refRangeName?_refRangeName->GetName():0);
-  Double_t x(-1+2*(_x-xmin)/(xmax-xmin));
-  Double_t x2(x*x);
-  Double_t sum(0) ;
-  switch (_coefList.getSize()) {
-  case  7: sum+=((RooAbsReal&)_coefList[6]).getVal()*x*p3(x2,64,-112,56,-7);
-  case  6: sum+=((RooAbsReal&)_coefList[5]).getVal()*p3(x2,32,-48,18,-1);
-  case  5: sum+=((RooAbsReal&)_coefList[4]).getVal()*x*p2(x2,16,-20,5);
-  case  4: sum+=((RooAbsReal&)_coefList[3]).getVal()*p2(x2,8,-8,1);
-  case  3: sum+=((RooAbsReal&)_coefList[2]).getVal()*x*p1(x2,4,-3);
-  case  2: sum+=((RooAbsReal&)_coefList[1]).getVal()*p1(x2,2,-1);
-  case  1: sum+=((RooAbsReal&)_coefList[0]).getVal()*x;
-  case  0: sum+=1; break;
-  default: std::cerr << "In " << __my_func__ << " (" << __FILE__ << ", line " <<
-          __LINE__ << "): Higher order Chebychev polynomials currently "
-          "unimplemented." << std::endl;
-      R__ASSERT(false);
+  // first bring the range of the variable _x to the normalised range [-1, 1]
+  // calculate sum_k c_k T_k(x) where x is given in the normalised range,
+  // c_0 = 1, and the higher coefficients are given in _coefList
+  const Double_t xmax = _x.max(_refRangeName?_refRangeName->GetName():0);
+  const Double_t xmin = _x.min(_refRangeName?_refRangeName->GetName():0);
+  // transform to range [-1, +1]
+  const Double_t x = (_x - 0.5 * (xmax + xmin)) / (0.5 * (xmax - xmin));
+  // extract current values of coefficients
+  using size_type = typename RooListProxy::Storage_t::size_type;
+  const size_type iend = _coefList.size();
+  double sum = 1.;
+  if (iend > 0) {
+     ChebychevIterator<double, Kind::First> chit(x);
+     ++chit;
+     for (size_type i = 0; iend != i; ++i, ++chit) {
+        auto c = static_cast<const RooAbsReal &>(_coefList[i]).getVal();
+        sum = fast_fma(*chit, c, sum);
+     }
   }
   return sum;
 }
@@ -143,48 +201,49 @@ Double_t RooChebychev::analyticalIntegral(Int_t code, const char* rangeName) con
 {
   R__ASSERT(1 == code);
 
+  const Double_t xmax = _x.max(_refRangeName?_refRangeName->GetName():0);
+  const Double_t xmin = _x.min(_refRangeName?_refRangeName->GetName():0);
+  const Double_t halfrange = .5 * (xmax - xmin), mid = .5 * (xmax + xmin);
   // the full range of the function is mapped to the normalised [-1, 1] range
+  const Double_t b = (_x.max(rangeName) - mid) / halfrange;
+  const Double_t a = (_x.min(rangeName) - mid) / halfrange;
 
-  const Double_t xminfull(_x.min(_refRangeName?_refRangeName->GetName():0)) ;
-  const Double_t xmaxfull(_x.max(_refRangeName?_refRangeName->GetName():0)) ;
-
-  const Double_t fullRange = xmaxfull - xminfull;
-
-  // define limits of the integration range on a normalised scale
-  Double_t minScaled = -1., maxScaled = +1.;
-
-  minScaled = -1. + 2. * (_x.min(rangeName) - xminfull) / fullRange;
-  maxScaled = +1. - 2. * (xmaxfull - _x.max(rangeName)) / fullRange;
-
-  // return half of the range since the normalised range runs from -1 to 1
-  // which has a range of two
-  double val =  0.5 * fullRange * (evalAnaInt(maxScaled) - evalAnaInt(minScaled));
-  //std::cout << " integral = " << val << std::endl;
-  return val;
+  // take care to multiply with the right factor to account for the mapping to
+  // normalised range [-1, 1]
+  return halfrange * evalAnaInt(a, b);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Double_t RooChebychev::evalAnaInt(const Double_t x) const
+Double_t RooChebychev::evalAnaInt(const Double_t a, const Double_t b) const
 {
-  const Double_t x2 = x * x;
-  Double_t sum = 0.;
-  switch (_coefList.getSize()) {
-    case  7: sum+=((RooAbsReal&)_coefList[6]).getVal()*x2*p3(x2,8.,-112./6.,14.,-7./2.);
-    case  6: sum+=((RooAbsReal&)_coefList[5]).getVal()*x*p3(x2,32./7.,-48./5.,6.,-1.);
-    case  5: sum+=((RooAbsReal&)_coefList[4]).getVal()*x2*p2(x2,16./6.,-5.,2.5);
-    case  4: sum+=((RooAbsReal&)_coefList[3]).getVal()*x*p2(x2,8./5.,-8./3.,1.);
-    case  3: sum+=((RooAbsReal&)_coefList[2]).getVal()*x2*p1(x2,1.,-3./2.);
-    case  2: sum+=((RooAbsReal&)_coefList[1]).getVal()*x*p1(x2,2./3.,-1.);
-    case  1: sum+=((RooAbsReal&)_coefList[0]).getVal()*x2*.5;
-    case  0: sum+=x; break;
+   // coefficient for integral(T_0(x)) is 1 (implicit), integrate by hand
+   // T_0(x) and T_1(x), and use for n > 1: integral(T_n(x) dx) =
+   // (T_n+1(x) / (n + 1) - T_n-1(x) / (n - 1)) / 2
+   double sum = b - a; // integrate T_0(x) by hand
 
-    default: std::cerr << "In " << __my_func__ << " (" << __FILE__ << ", line " <<
-        __LINE__ << "): Higher order Chebychev polynomials currently "
-       "unimplemented." << std::endl;
-        R__ASSERT(false);
+   using size_type = typename RooListProxy::Storage_t::size_type;
+   const size_type iend = _coefList.size();
+   if (iend > 0) {
+      {
+         // integrate T_1(x) by hand...
+         const double c = static_cast<const RooAbsReal &>(_coefList[0]).getVal();
+         sum = fast_fma(0.5 * (b + a) * (b - a), c, sum);
+      }
+      if (1 < iend) {
+         ChebychevIterator<double, Kind::First> bit(b), ait(a);
+         ++bit, ++ait;
+         double nminus1 = 1.;
+         for (size_type i = 1; iend != i; ++i) {
+            // integrate using recursion relation
+            const double c = static_cast<const RooAbsReal &>(_coefList[i]).getVal();
+            const double term2 = (*bit - *ait) / nminus1;
+            ++bit, ++ait, ++nminus1;
+            const double term1 = (bit.lookahead() - ait.lookahead()) / (nminus1 + 1.);
+            const double intTn = 0.5 * (term1 - term2);
+            sum = fast_fma(intTn, c, sum);
+         }
+      }
   }
   return sum;
 }
-
-#undef __my_func__


### PR DESCRIPTION
use a more scalable implementation for RooChebychev which allows use of
Chebychev polynomial of arbitrarily high orders; also the extra effort
for every new order used is constant, so the effort (CPU) for evaluating
a RooChebychev grows linearly with the highest order Chebychev order
used, and comes in at only a couple of FLOPS per order (getting the
value of the coefficients is likely much more expensive)

FMA is used if supported by the underlying architecture/compiler,
otherwise the code falls back to normal floating point arithmetic.

RooChebychev is used in the stressRooFit test, which continues to run just fine.