### PR TITLE
RooAbsAnaConvPdf: allow different time acceptance for different categories

### DIFF
--- a/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
@@ -79,7 +79,6 @@
 using namespace std;
 
 ClassImp(RooAbsAnaConvPdf); 
-;
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -246,6 +245,9 @@ Bool_t RooAbsAnaConvPdf::changeModel(const RooResolutionModel& newModel)
   // Replace old convolutions with new set
   _convSet.removeAll() ;
   _convSet.addOwned(newConvSet) ;
+
+  // Update server link by hand, since _model.setArg() below will not do this
+  replaceServer((RooAbsArg&)_model.arg(),(RooAbsArg&)newModel,kFALSE,kFALSE) ;
 
   _model.setArg((RooResolutionModel&)newModel) ;
   return kFALSE ;


### PR DESCRIPTION
This patch came from Sean Benson and Wouter Verkerke, and is needed
to allow LHCb's P2VV-style analyses to have different time acceptances
for different categories of events. All tests continue to pass.