### PR TITLE
Fix RVec move constructor and assignment operators

### DIFF
--- a/math/vecops/inc/ROOT/RAdoptAllocator.hxx
+++ b/math/vecops/inc/ROOT/RAdoptAllocator.hxx
@@ -47,23 +47,22 @@ v.emplace_back(0.);
 now the vector *v* owns its memory as a regular vector.
 **/
 
-template <typename T, bool IsCopyConstructible = std::is_copy_constructible<T>::value>
-class RConstructHelper {
-public:
-   template <class... Args>
-   static void Construct(std::allocator<T> &alloc, T *p, Args &&... args)
-   {
-      alloc.construct(p, args...);
-   }
+template<typename T, bool IsCopyConstructible = std::is_copy_constructible<T>::value>
+class RConstructHelper
+{
+   public:
+      template <class... Args>
+      static void Construct(std::allocator<T> &alloc, T *p, Args &&... args)
+      {
+         alloc.construct(p, args...);
+      }
 };
 
 template <typename T>
 class RConstructHelper<T, false> {
 public:
    template <class... Args>
-   static void Construct(std::allocator<T> &, T *, Args &&...)
-   {
-   }
+   static void Construct(std::allocator<T> &, T *, Args &&... ){}
 };
 
 template <typename T>
@@ -107,7 +106,12 @@ public:
    RAdoptAllocator &operator=(RAdoptAllocator &&) = default;
    RAdoptAllocator(const RAdoptAllocator<bool> &);
 
-   std::size_t GetBufferSize() const { return fBufferSize; }
+   std::size_t GetBufferSize() const { return fBufferSize;}
+   bool IsAdoptingExternalMemory() const {
+      return fBufferSize == 0 &&
+             fInitialAddress != nullptr &&
+             fAllocType != EAllocType::kOwning;
+   }
 
    /// Construct an object at a certain memory address
    /// \tparam U The type of the memory address at which the object needs to be constructed
@@ -122,7 +126,7 @@ public:
       if (fBufferSize == 0 && EAllocType::kAdopting == fAllocType)
          return;
       RConstructHelper<U>::Construct(fStdAllocator, p, args...);
-      // fStdAllocator.construct(p, args...);
+      //fStdAllocator.construct(p, args...);
    }
 
    /// \brief Allocate some memory
@@ -166,6 +170,7 @@ public:
    bool operator!=(const RAdoptAllocator<T> &other) { return !(*this == other); }
 
    size_type max_size() const { return fStdAllocator.max_size(); };
+
 };
 
 // The different semantics of std::vector<bool> make  memory adoption through a
@@ -209,6 +214,7 @@ public:
    bool *allocate(std::size_t n) { return fStdAllocator.allocate(n); }
 
    std::size_t GetBufferSize() const { return 0; }
+   bool IsAdoptingExternalMemory() const { return false; }
 
    template <typename U, class... Args>
    void construct(U *p, Args &&... args)
@@ -264,9 +270,17 @@ std::size_t GetBufferSize(const Alloc_t &alloc)
    return alloc.GetBufferSize();
 }
 
-inline std::size_t GetBufferSize(const std::allocator<bool> &)
+inline std::size_t GetBufferSize(const std::allocator<bool> &) { return 0;}
+
+template <typename Alloc_t>
+bool IsAdoptingExternalMemory(const Alloc_t &alloc)
 {
-   return 0;
+   return alloc.IsAdoptingExternalMemory();
+}
+
+inline bool IsAdoptingExternalMemory(const std::allocator<bool> &)
+{
+   return false;
 }
 
 } // namespace VecOps

--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -442,10 +442,13 @@ public:
 
    RVec<T> &operator=(RVec<T> &&v)
    {
-      if (CanUseBuffer(v)) {
-         fData.assign(v.fData.begin(), v.fData.end());
-      } else {
+      if (v.IsAdoptingExternalMemory()) {
          fAlloc = std::move(v.fAlloc);
+         fData = std::move(v.fData);
+      } else if (CanUseBuffer(v)) {
+         resize(v.size());
+         std::copy(v.begin(), v.end(), fData.begin());
+      } else {
          fData = std::move(v.fData);
       }
       return *this;

--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -318,7 +318,7 @@ public:
    using const_iterator = typename Impl_t::const_iterator;
    using reverse_iterator = typename Impl_t::reverse_iterator;
    using const_reverse_iterator = typename Impl_t::const_reverse_iterator;
-   static constexpr std::size_t fgBufferSize = std::is_arithmetic<T>::value && !fgIsVecBool ? 16 : 0;
+   static constexpr std::size_t fgBufferSize = std::is_arithmetic<T>::value && !fgIsVecBool ? 32 : 0;
 
 private:
    // We need this class for the case where fgBufferSize is 0, otherwise array<NonCopiable, 0>
@@ -346,9 +346,17 @@ private:
    /// The default storage std::vector, initialised with the allocator
    Impl_t fData{fAlloc};
 
+   bool CanUseBuffer(std::size_t s)
+   {
+      const auto thisBufSize = ::ROOT::Detail::VecOps::GetBufferSize(fAlloc);
+      return thisBufSize && s <= thisBufSize;
+   }
    bool CanUseBuffer(const RVec &v)
    {
       const auto thisBufSize = ::ROOT::Detail::VecOps::GetBufferSize(fAlloc);
+      const auto otherBufSize = ::ROOT::Detail::VecOps::GetBufferSize(v.fAlloc);
+      if (thisBufSize == 0 && otherBufSize == 0)
+         return false;
       return thisBufSize && v.size() <= thisBufSize;
    }
 

--- a/tree/dataframe/test/dataframe_nodes.cxx
+++ b/tree/dataframe/test/dataframe_nodes.cxx
@@ -94,8 +94,8 @@ TEST(RDataFrameNodes, InheritanceOfCustomColumns)
    ROOT::RDataFrame df(1);
    const auto nBinsExpected = 42;
    // Read the TH1F as a TH1
-   df.Define("b", []() { return TH1F("b", "b", nBinsExpected, 0, 1); })
-      .Foreach([&nBinsExpected](TH1 &h) { EXPECT_EQ(h.GetNbinsX(), nBinsExpected);}, {"b"});
+   df.Define("b", [&]() { return TH1F("b", "b", nBinsExpected, 0, 1); })
+      .Foreach([&](TH1 &h) { EXPECT_EQ(h.GetNbinsX(), nBinsExpected);}, {"b"});
 
    const auto ofileName = "InheritanceOfCustomColumns.root";
 


### PR DESCRIPTION
Related JIRA issue: [ROOT-10079](https://sft.its.cern.ch/jira/browse/ROOT-10079).