### PR TITLE
webgui: support Qt 5.6..5.11 with QWebEngine

### DIFF
--- a/gui/qt5webdisplay/rootqt5.cpp
+++ b/gui/qt5webdisplay/rootqt5.cpp
@@ -19,7 +19,11 @@
 #include <QThread>
 #include <QWebEngineSettings>
 #include <QWebEngineProfile>
+#include <QtGlobal>
+
+#if QT_VERSION >= 0x051200
 #include <QWebEngineUrlScheme>
+#endif
 
 #include "TROOT.h"
 #include "TApplication.h"
@@ -86,14 +90,17 @@ protected:
                return nullptr;
             }
 
+            #if QT_VERSION >= 0x051200
             QWebEngineUrlScheme scheme("rootscheme");
             scheme.setSyntax(QWebEngineUrlScheme::Syntax::HostAndPort);
             scheme.setDefaultPort(2345);
             scheme.setFlags(QWebEngineUrlScheme::SecureScheme);
             QWebEngineUrlScheme::registerScheme(scheme);
+            #endif
 
             qargv[0] = gApplication->Argv(0);
             qargv[1] = nullptr;
+            
             qapp = new QApplication(qargc, qargv);
          }
 
@@ -128,8 +135,10 @@ protected:
 
          if (args.IsHeadless()) {
             RootWebPage *page = new RootWebPage();
+            #if QT_VERSION >= 0x050700
             page->settings()->resetAttribute(QWebEngineSettings::WebGLEnabled);
             page->settings()->resetAttribute(QWebEngineSettings::Accelerated2dCanvasEnabled);
+            #endif
             page->settings()->resetAttribute(QWebEngineSettings::PluginsEnabled);
             page->load(QUrl(fullurl));
          } else {


### PR DESCRIPTION
Previous changes were tested with Qt 5.12, which is very new and very rare up to now.
Plus there are new functions, which were not exists before