### PR TITLE
Properly handle TTree aliases contain just function calls.

### DIFF
--- a/tree/treeplayer/src/TTreeFormula.cxx
+++ b/tree/treeplayer/src/TTreeFormula.cxx
@@ -2606,7 +2606,7 @@ Int_t TTreeFormula::FindLeafForExpression(const char* expression, TLeaf*& leaf, 
 
       // Check for an alias.
       const char *aliasValue = fTree->GetAlias(left);
-      if (aliasValue && strcspn(aliasValue,"[]+*/-%&!=<>|")==strlen(aliasValue)) {
+      if (aliasValue && strcspn(aliasValue,"()[]+*/-%&!=<>|")==strlen(aliasValue)) {
          // First check whether we are using this alias recursively (this would
          // lead to an infinite recursion).
          if (find(aliasUsed.begin(),
@@ -2844,7 +2844,7 @@ Int_t TTreeFormula::DefinedVariable(TString &name, Int_t &action)
          }
 
 
-         if (strcspn(aliasValue,"+*/-%&!=<>|")!=strlen(aliasValue)) {
+         if (strcspn(aliasValue,"()+*/-%&!=<>|")!=strlen(aliasValue)) {
             // If the alias contains an operator, we need to use a nested formula
             // (since DefinedVariable must only add one entry to the operation's list).
 


### PR DESCRIPTION
See https://root-forum.cern.ch/t/ttree-setalias-with-tmath-min-tmath-max-issue/33881.