### PR TITLE
Protect possibly predefined preprocessor symbol

### DIFF
--- a/interpreter/cling/lib/Interpreter/ValuePrinter.cpp
+++ b/interpreter/cling/lib/Interpreter/ValuePrinter.cpp
@@ -297,7 +297,9 @@ namespace cling {
     if (IsValid) {
       // If we're gonnd do this, better make sure the end is valid too
       // FIXME: getpagesize() & GetSystemInfo().dwPageSize might be better
+#if !defined(PAGE_SIZE)
       enum { PAGE_SIZE = 1024 };
+#endif
       while (!(IsValid = utils::isAddressValid(End)) && N > 1024) {
         N -= PAGE_SIZE;
         End = Start + N;


### PR DESCRIPTION
On my systems (RHEL7 and Android Termux) PAGE_SIZE is defined to 4096 in /usr/include/sys/user.h .  The enum then produces a compile-term error.
Adding this change resolves this error for me.