### PR TITLE
[Doc] improve TStatistic documentation

### DIFF
--- a/math/mathcore/inc/TStatistic.h
+++ b/math/mathcore/inc/TStatistic.h
@@ -35,12 +35,12 @@
 class TStatistic : public TObject {
 
 private:
-   TString     fName;
-   Long64_t    fN;       // Number of fills
-   Double_t    fW;       // Sum of weights
-   Double_t    fW2;      // Sum of weights**2
-   Double_t    fM;       // Sum of elements ( i.e. mean * sum_of_weights)
-   Double_t    fM2;      // Second order momentum
+   TString     fName;    ///< Name given to the TStatistic object
+   Long64_t    fN;       ///< Number of fills
+   Double_t    fW;       ///< Sum of weights
+   Double_t    fW2;      ///< Sum of squared weights
+   Double_t    fM;       ///< Sum of elements (i.e. sum of (val * weight) pairs
+   Double_t    fM2;      ///< Second order momentum
 
 public:
 
@@ -57,7 +57,7 @@ public:
    inline       Double_t GetM2() const { return fM2; }
    inline       Double_t GetMean() const { return (fW > 0) ? fM/fW : 0; }
    inline       Double_t GetMeanErr() const { return  (fW > 0.) ?  TMath::Sqrt( GetVar()/ GetNeff() ) : 0; }
-   inline       Double_t GetRMS() const { double var = GetVar(); return (var>0) ? TMath::Sqrt(var) : -1; }  
+   inline       Double_t GetRMS() const { double var = GetVar(); return (var>0) ? TMath::Sqrt(var) : -1; }
    inline       Double_t GetVar() const { return (fW>0) ? ( (fN>1) ? (fM2 / fW)*(fN / (fN-1.)) : 0 ) : -1; }
    inline       Double_t GetW() const { return fW; }
    inline       Double_t GetW2() const { return fW2; }
@@ -72,7 +72,7 @@ public:
    void Print(Option_t * = "") const;
    void ls(Option_t *opt = "") const { Print(opt); }
 
-   ClassDef(TStatistic,2)  //Named statistical variable
+   ClassDef(TStatistic,2)  ///< Named statistical variable
 };
 
 #endif


### PR DESCRIPTION
Documentation present in the TStatistic files has been updated to match Doxygen syntax. Data members with a little description are now visible in the docs, Class member functions documentation has been
pulled out of their definitions and changed a bit to better explain the algorithms involved.