### PR TITLE
[cling,core] Improve .x arg parsing (ROOT-10097):

### DIFF
--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -4157,7 +4157,12 @@ TString TSystem::SplitAclicMode(const char* filename, TString &aclicMode,
 {
    char *fname = Strip(filename);
    TString filenameCopy = fname;
+   filenameCopy = filenameCopy.Strip();
 
+   if (filenameCopy.EndsWith(";")) {
+     filenameCopy.Remove(filenameCopy.Length() - 1);
+     filenameCopy = filenameCopy.Strip();
+   }
    if (filenameCopy.EndsWith(")")) {
       Ssiz_t posArgEnd = filenameCopy.Length() - 1;
       // There is an argument; find its start!

--- a/interpreter/cling/lib/MetaProcessor/MetaParser.cpp
+++ b/interpreter/cling/lib/MetaProcessor/MetaParser.cpp
@@ -276,13 +276,39 @@ namespace cling {
     const Token& Tok = getCurTok();
     if (Tok.is(tok::ident) && (Tok.getIdent().equals("x")
                                || Tok.getIdent().equals("X"))) {
-      // There might be ArgList
-      consumeAnyStringToken(tok::l_paren);
-      llvm::StringRef file(getCurTok().getIdent());
       consumeToken();
-      // '(' to end of string:
+      skipWhitespace();
 
-      std::string args = getCurTok().getBufStart();
+      // There might be an ArgList:
+      int forward = 0;
+      std::string args;
+      llvm::StringRef file(getCurTok().getBufStart());
+      while (!lookAhead(forward).is(tok::eof))
+	++forward;
+      // Now track back to find the opening '('.
+      if (lookAhead(forward - 1).is(tok::r_paren)) {
+	// Trailing ')' - we interpret that as an argument.
+	--forward; // skip ')'
+	int nesting = 1;
+	while (--forward > 0 && nesting) {
+	  if (lookAhead(forward).is(tok::l_paren))
+	    --nesting;
+	  else if (lookAhead(forward).is(tok::r_paren))
+	    ++nesting;
+	}
+	if (forward == 0) {
+	  cling::errs() << "cling::MetaParser::isXCommand():"
+	    "error parsing argument in " << getCurTok().getBufStart() << '\n';
+	  // interpret everything as "the file"
+	} else {
+	  while (forward--)
+	    consumeToken();
+	  consumeToken(); // the forward-0 token.
+	  args = getCurTok().getBufStart();
+	  file = file.drop_back(args.length());
+	}
+      }
+
       if (args.empty())
         args = "()";
       actionResult = m_Actions->actOnxCommand(file, args, resultValue);

--- a/interpreter/cling/lib/MetaProcessor/MetaParser.cpp
+++ b/interpreter/cling/lib/MetaProcessor/MetaParser.cpp
@@ -285,6 +285,11 @@ namespace cling {
       llvm::StringRef file(getCurTok().getBufStart());
       while (!lookAhead(forward).is(tok::eof))
 	++forward;
+
+      // Skip any trailing ';':
+      if (lookAhead(forward - 1).is(tok::semicolon))
+	--forward;
+
       // Now track back to find the opening '('.
       if (lookAhead(forward - 1).is(tok::r_paren)) {
 	// Trailing ')' - we interpret that as an argument.


### PR DESCRIPTION
Dropbox folders (among others) can contain parentheses.
Without this patch, ROOT and cling misinterpret those directories as arguments.
Instead, first find the end of the ".x" line.
If the previous token was a closing paren, we assume that the preceding
tokens (up to the non-nested opening paren) belong to the argument.