### PR TITLE
add min, max to TStatistic

### DIFF
--- a/math/mathcore/inc/TStatistic.h
+++ b/math/mathcore/inc/TStatistic.h
@@ -46,7 +46,7 @@ private:
 
 public:
 
-   TStatistic(const char *name = "") : fName(name), fN(0), fW(0.), fW2(0.), fM(0.), fM2(0.) { }
+   TStatistic(const char *name = "") : fName(name), fN(0), fW(0.), fW2(0.), fM(0.), fM2(0.), fMin(TMath::Limits<Double_t>::Max()), fMax(TMath::Limits<Double_t>::Min()) { }
    TStatistic(const char *name, Int_t n, const Double_t *val, const Double_t *w = 0);
    ~TStatistic();
 
@@ -76,7 +76,7 @@ public:
    void Print(Option_t * = "") const;
    void ls(Option_t *opt = "") const { Print(opt); }
 
-   ClassDef(TStatistic,2)  ///< Named statistical variable
+   ClassDef(TStatistic,3)  // Named statistical variable
 };
 
 #endif

--- a/math/mathcore/inc/TStatistic.h
+++ b/math/mathcore/inc/TStatistic.h
@@ -41,6 +41,8 @@ private:
    Double_t    fW2;      ///< Sum of squared weights
    Double_t    fM;       ///< Sum of elements (i.e. sum of (val * weight) pairs
    Double_t    fM2;      ///< Second order momentum
+   Double_t    fMin;     ///< Minimum value in the Tstatistic object
+   Double_t    fMax;     ///< Maximum value in the TStatistic object
 
 public:
 
@@ -61,6 +63,8 @@ public:
    inline       Double_t GetVar() const { return (fW>0) ? ( (fN>1) ? (fM2 / fW)*(fN / (fN-1.)) : 0 ) : -1; }
    inline       Double_t GetW() const { return fW; }
    inline       Double_t GetW2() const { return fW2; }
+   inline       Double_t GetMin() const { return fMin; }
+   inline       Double_t GetMax() const { return fMax; }
 
    // Merging
    Int_t Merge(TCollection *in);

--- a/math/mathcore/src/TStatistic.cxx
+++ b/math/mathcore/src/TStatistic.cxx
@@ -30,7 +30,7 @@ templateClassImp(TStatistic);
 ///
 /// Recursively calls the TStatistic::Fill() function to fill the object.
 TStatistic::TStatistic(const char *name, Int_t n, const Double_t *val, const Double_t *w)
-         : fName(name), fN(0), fW(0.), fW2(0.), fM(0.), fM2(0.)
+         : fName(name), fN(0), fW(0.), fW2(0.), fM(0.), fM2(0.), fMin(TMath::Limits<Double_t>::Max()), fMax(TMath::Limits<Double_t>::Min())
 {
    if (n > 0) {
       for (Int_t i = 0; i < n; i++) {
@@ -75,11 +75,18 @@ void TStatistic::Fill(Double_t val, Double_t w) {
 
 
    if (w == 0) return;
-
+   // increase data count
    fN++;
 
+   // update sum of weights
    Double_t tW = fW + w;
+
+   // update sum of (value * weight) pairs
    fM += w * val;
+
+   // update minimum and maximum values
+   fMin = (val < fMin) ? val : fMin;
+   fMax = (val > fMax) ? val : fMax;
 
 //      Double_t dt = val - fM ;
    if (tW == 0) {
@@ -87,15 +94,7 @@ void TStatistic::Fill(Double_t val, Double_t w) {
       fN--;
       return;
    }
-   // Initialize min and max when filling with first value
-   if (fN == 1) {
-      fMin = val;
-      fMax = val;
-   // Update min and max at each iteration
-   } else if (fN > 1) {
-      fMin = (val < fMin) ? val : fMin;
-      fMax = (val > fMax) ? val : fMax;
-   }
+
    if (fW != 0) {  // from the second time
       Double_t rr = ( tW * val - fM);
       fM2 += w * rr * rr / (tW * fW);

--- a/math/mathcore/test/testTStatistic.cxx
+++ b/math/mathcore/test/testTStatistic.cxx
@@ -4,7 +4,7 @@
 #include "TStopwatch.h"
 #include <iostream>
 
-bool gVerbose = false; 
+bool gVerbose = false;
 
 void testTStatistic(Int_t n = 10000)
 {
@@ -25,19 +25,32 @@ void testTStatistic(Int_t n = 10000)
       ww[i] = rand3.Uniform(0.01, 3.00);
    }
 
+   // Find minimum and maximum
+   double min = xx[0]; // the minimum value in the array
+   double max = xx[0]; // the maximum value in the array
+   double eps_min_max = 0.000001; // epsilon to check for GetMin and GetMax functions
+   for (Int_t i = 0; i < n; ++i) {
+      if (xx[i] < min) {
+         min = xx[i];
+      } else if (xx[i] > max) {
+         max = xx[i];
+      }
+   }
 
    TStopwatch stp;
-   bool error = false; 
+   bool error = false;
 
    printf("\nTest without using weights :        ");
-   
+
    TStatistic st0("st0", n, xx.data());
    stp.Stop();
    if (!TMath::AreEqualAbs(st0.GetMean(),true_mean, eps1) )   { Error("TestTStatistic-GetMean","Different value obtained for the unweighted data"); error = true; }
    if (!TMath::AreEqualAbs(st0.GetRMS(),true_sigma, eps2) )   { Error("TestTStatistic-GetRMS","Different value obtained for the unweighted data"); error = true; }
+   if (!TMath::AreEqualAbs(st0.GetMin(), min, eps_min_max) )   { Error("TestTStatistic-GetMin","Different value obtained for the unweighted data"); error = true; }
+   if (!TMath::AreEqualAbs(st0.GetMax(), max, eps_min_max) )   { Error("TestTStatistic-GetMax","Different value obtained for the unweighted data"); error = true; }
 
    if (error) printf("Failed\n");
-   else printf("OK\n");                  
+   else printf("OK\n");
    if (error || gVerbose) {
       stp.Print();
       st0.Print();
@@ -45,16 +58,16 @@ void testTStatistic(Int_t n = 10000)
 
    // test with TMath
    printf("\nTest using TMath:                   ");
-   error = false; 
+   error = false;
    stp.Start();
-   double mean = TMath::Mean(xx.begin(), xx.end() ); 
+   double mean = TMath::Mean(xx.begin(), xx.end() );
    double rms  = TMath::RMS(xx.begin(), xx.end() );
-   stp.Stop();  
+   stp.Stop();
    if (!TMath::AreEqualAbs(mean,true_mean, eps1) )  {  Error("TestTStatistic::TMath::Mean","Different value obtained for the unweighted data"); error = true; }
    if (!TMath::AreEqualAbs(rms,true_sigma, eps2) )  {  Error("TestTStatistic::TMath::RMS","Different value obtained for the unweighted data"); error = true; }
 
    if (error) printf("Failed\n");
-   else printf("OK\n");                  
+   else printf("OK\n");
    if (error || gVerbose) {
       stp.Print();
       printf("  TMATH         mu =  %.5g +- %.4g \t RMS = %.5g \n",mean, rms/sqrt(double(xx.size()) ), rms);


### PR DESCRIPTION
The TStatistic class now includes computation of minimum and maximum values
of the vector passed to the constructor.

These values have been added both to the `Print` and `Merge` functions.

The testTStatistic.cxx test file has been updated accordingly to check that the class
correctly computes min and max values.