### PR TITLE
[Doc] Resolving grammatical errors and spellings in user-guides

### DIFF
--- a/documentation/users-guide/AddingaClass.md
+++ b/documentation/users-guide/AddingaClass.md
@@ -48,7 +48,7 @@ some methods that use Introspection to help you see the data in the
 object or class. For instance:
 
 ``` {.cpp}
-obj->Dump();      // lists all data members and their current valsue
+obj->Dump();      // lists all data members and their current values
 obj->Inspect();   // opens a window to browse data members
 obj->DrawClass(); // Draws the class inheritance tree
 ```
@@ -161,8 +161,8 @@ enum EObjBits {
 
 For example, the bits `kMustCleanup` and `kCanDelete` are used in
 **`TObject`**. See "The kCanDelete Bit" and "The kMustCleanup Bit". They
-can be set by any object and should not be reused. Make sure to no
-overlap in any given hierarchy them. The bit 13 (`kInvalidObject`) is
+can be set by any object and should not be reused. Make sure not
+to overlap them in any given hierarchy. The bit 13 (`kInvalidObject`) is
 set when an object could not be read from a ROOT file. It will check
 this bit and will skip to the next object on the file.
 

--- a/documentation/users-guide/FittingHistograms.md
+++ b/documentation/users-guide/FittingHistograms.md
@@ -247,7 +247,7 @@ the function.
 Now we use the function:
 
 ``` {.cpp}
-   // this function used fitf to fit a histogram
+   // this function uses fitf to fit a histogram
    void fitexample() {
 
       // open a file and get a histogram
@@ -1099,13 +1099,13 @@ data). As above the user can select an extended likelihood fit by passing the op
 #### Customised Fit methods
 
 Above we described the pre-defined methods used for fitting. A user can also implement its own fitting methods, thus its version of the chi-square or likelihood function he wants to minimize.
-In this cas, the user does not really need to build as input a `ROOT::Fit` data set and model function as we described before. He can implements its own version of the method function using on its own
+In this case, the user does not really need to build as input a `ROOT::Fit` data set and model function as we described before. He can implements its own version of the method function using on its own
 data set objects and functions.
 
 In this case `ROOT::Fit::Fitter::SetFCN` is used to set the method function  and `ROOT::Fit::FitFCN` is used for fitting. The method function can be passed also in `ROOT::Fit::FitFCN`, but in this
 case a previously defined fitting configuration is used.
 
-The possible type of method functions that can be bassed in `ROOT::Fit::Fitter::SetFCN` are:
+The possible type of method functions that are based in `ROOT::Fit::Fitter::SetFCN` are:
 
 * A generic functor object implementing `operator()(const double * p)` where **`p`** is the parameter vectors. In this case one needs to pass the number of parameters,
   the function object and optionally a vector of initial parameter values. Other optional parameter include the size of the data sets and a flag specifying if it is a chi2 (least-square fit).

--- a/documentation/users-guide/Geometry.md
+++ b/documentation/users-guide/Geometry.md
@@ -1859,7 +1859,7 @@ will illustrate them by examples.
     row-beside-row inside the container, making life much easier for its
     navigation algorithms. The problem is that in order to reproduce the
     honeycomb structure out of rows of cells, we have to overlap row
-    containers. Woops - we have not obeyed rule No. 2 in positioning.
+    containers. Whoops - we have not obeyed rule No. 2 in positioning.
     The way out is to position our rows with a special prototype:
 
 ``` {.cpp}
@@ -1933,7 +1933,7 @@ few chambers, but definitely not for 1000. Fortunately the modeller is
 smarter than that and creates for each volume some optimization
 structures called `voxels` to minimize the penalty having too many
 daughters, but if you have 100 pads like this in your geometry you will
-anyway loose a lot in your tracking performance. The way out when
+anyway lose a lot in your tracking performance. The way out when
 volumes can be arranged according to simple patterns is the usage of
 divisions. We will describe them in detail later on. Let's think now at
 a different situation: instead of 1000 chambers of the same type, we may
@@ -3368,8 +3368,8 @@ name): `gGeoManager->GetVolume("vol_name")->Draw();`
 
 Supposing you now understand the basic things to do for drawing the
 geometry or parts of it, you still might be not happy and wishing to
-have more control on it. We will describe below how you can tune some
-fine settings. Since the corresponding attributes are flags belonging to
+have more control on it. We will describe below how you can fine-tune some
+ settings. Since the corresponding attributes are flags belonging to
 volume and node objects, you can change them at any time (even when the
 picture is already drawn) and see immediately the result.
 
@@ -3610,7 +3610,7 @@ Option_t *opt="vg")
     TGeoBBox\_0x1, TGeoBBox\_0x2, ...). If `"f"` option is set then then
     suffix will contain pointer of object (e.g. TGeoBBox\_0xAAAAA01,
     ...). Finally if option `"n"` is set then no suffix will be added,
-    though in this case uniqness of the names is not ensured and it can
+    though in this case uniqueness of the names is not ensured and it can
     cause that file will be invalid.
 
 Loading geometry from a root file can be done in the same way as for any


### PR DESCRIPTION
There are some grammatical mistakes and cases of misspelling in the users-guide directory. I corrected the misspellings and corrected the grammar in some of the sentences. 