### PR TITLE
[forest] move template specializations in corresponding namespace

### DIFF
--- a/tree/forest/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/forest/v7/inc/ROOT/RColumnElement.hxx
@@ -109,15 +109,9 @@ public:
    }
 };
 
-} // namespace Detail
-
-} // namespace Experimental
-} // namespace ROOT
-
 
 template <>
-class ROOT::Experimental::Detail::RColumnElement<float, ROOT::Experimental::EColumnType::kReal32>
-   : public ROOT::Experimental::Detail::RColumnElementBase {
+class RColumnElement<float, EColumnType::kReal32> : public RColumnElementBase {
 public:
    static constexpr bool kIsMappable = true;
    static constexpr size_t kSize = sizeof(float);
@@ -125,8 +119,7 @@ public:
 };
 
 template <>
-class ROOT::Experimental::Detail::RColumnElement<double, ROOT::Experimental::EColumnType::kReal64>
-   : public ROOT::Experimental::Detail::RColumnElementBase {
+class RColumnElement<double, EColumnType::kReal64> : public RColumnElementBase {
 public:
    static constexpr bool kIsMappable = true;
    static constexpr size_t kSize = sizeof(double);
@@ -134,8 +127,7 @@ public:
 };
 
 template <>
-class ROOT::Experimental::Detail::RColumnElement<std::int32_t, ROOT::Experimental::EColumnType::kInt32>
-   : public ROOT::Experimental::Detail::RColumnElementBase {
+class RColumnElement<std::int32_t, EColumnType::kInt32> : public RColumnElementBase {
 public:
    static constexpr bool kIsMappable = true;
    static constexpr size_t kSize = sizeof(std::int32_t);
@@ -143,8 +135,7 @@ public:
 };
 
 template <>
-class ROOT::Experimental::Detail::RColumnElement<std::uint32_t, ROOT::Experimental::EColumnType::kInt32>
-   : public ROOT::Experimental::Detail::RColumnElementBase {
+class RColumnElement<std::uint32_t, EColumnType::kInt32> : public RColumnElementBase {
 public:
    static constexpr bool kIsMappable = true;
    static constexpr size_t kSize = sizeof(std::uint32_t);
@@ -152,8 +143,7 @@ public:
 };
 
 template <>
-class ROOT::Experimental::Detail::RColumnElement<std::int64_t, ROOT::Experimental::EColumnType::kInt64>
-   : public ROOT::Experimental::Detail::RColumnElementBase {
+class RColumnElement<std::int64_t, EColumnType::kInt64> : public RColumnElementBase {
 public:
    static constexpr bool kIsMappable = true;
    static constexpr size_t kSize = sizeof(std::int64_t);
@@ -161,8 +151,7 @@ public:
 };
 
 template <>
-class ROOT::Experimental::Detail::RColumnElement<std::uint64_t, ROOT::Experimental::EColumnType::kInt64>
-   : public ROOT::Experimental::Detail::RColumnElementBase {
+class RColumnElement<std::uint64_t, EColumnType::kInt64> : public RColumnElementBase {
 public:
    static constexpr bool kIsMappable = true;
    static constexpr size_t kSize = sizeof(std::uint64_t);
@@ -170,22 +159,23 @@ public:
 };
 
 template <>
-class ROOT::Experimental::Detail::RColumnElement<
-   ROOT::Experimental::ClusterSize_t, ROOT::Experimental::EColumnType::kIndex>
-   : public ROOT::Experimental::Detail::RColumnElementBase {
+class RColumnElement<ClusterSize_t, EColumnType::kIndex> : public RColumnElementBase {
 public:
    static constexpr bool kIsMappable = true;
    static constexpr size_t kSize = sizeof(ROOT::Experimental::ClusterSize_t);
-   explicit RColumnElement(ROOT::Experimental::ClusterSize_t* value) : RColumnElementBase(value, kSize, kIsMappable) {}
+   explicit RColumnElement(ClusterSize_t* value) : RColumnElementBase(value, kSize, kIsMappable) {}
 };
 
 template <>
-class ROOT::Experimental::Detail::RColumnElement<char, ROOT::Experimental::EColumnType::kByte>
-   : public ROOT::Experimental::Detail::RColumnElementBase {
+class RColumnElement<char, EColumnType::kByte> : public RColumnElementBase {
 public:
    static constexpr bool kIsMappable = true;
    static constexpr size_t kSize = sizeof(char);
    explicit RColumnElement(char* value) : RColumnElementBase(value, kSize, kIsMappable) {}
 };
+
+} // namespace Detail
+} // namespace Experimental
+} // namespace ROOT
 
 #endif

--- a/tree/forest/v7/inc/ROOT/RField.hxx
+++ b/tree/forest/v7/inc/ROOT/RField.hxx
@@ -343,12 +343,12 @@ public:
    void CommitCluster() final;
 };
 
-} // namespace Experimental
-} // namespace ROOT
+
+/// Template specializations for concrete C++ types
 
 
 template <>
-class ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t> : public ROOT::Experimental::Detail::RFieldBase {
+class RField<ClusterSize_t> : public Detail::RFieldBase {
 public:
    static std::string MyTypeName() { return "ROOT::Experimental::ClusterSize_t"; }
    explicit RField(std::string_view name)
@@ -392,11 +392,8 @@ public:
 };
 
 
-/// Template specializations for concrete C++ types
-
-
 template <>
-class ROOT::Experimental::RField<float> : public ROOT::Experimental::Detail::RFieldBase {
+class RField<float> : public Detail::RFieldBase {
 public:
    static std::string MyTypeName() { return "float"; }
    explicit RField(std::string_view name)
@@ -436,7 +433,7 @@ public:
 
 
 template <>
-class ROOT::Experimental::RField<double> : public ROOT::Experimental::Detail::RFieldBase {
+class RField<double> : public Detail::RFieldBase {
 public:
    static std::string MyTypeName() { return "double"; }
    explicit RField(std::string_view name)
@@ -475,7 +472,7 @@ public:
 };
 
 template <>
-class ROOT::Experimental::RField<std::int32_t> : public ROOT::Experimental::Detail::RFieldBase {
+class RField<std::int32_t> : public Detail::RFieldBase {
 public:
    static std::string MyTypeName() { return "std::int32_t"; }
    explicit RField(std::string_view name)
@@ -514,7 +511,7 @@ public:
 };
 
 template <>
-class ROOT::Experimental::RField<std::uint32_t> : public ROOT::Experimental::Detail::RFieldBase {
+class RField<std::uint32_t> : public Detail::RFieldBase {
 public:
    static std::string MyTypeName() { return "std::uint32_t"; }
    explicit RField(std::string_view name)
@@ -553,7 +550,7 @@ public:
 };
 
 template <>
-class ROOT::Experimental::RField<std::uint64_t> : public ROOT::Experimental::Detail::RFieldBase {
+class RField<std::uint64_t> : public Detail::RFieldBase {
 public:
    static std::string MyTypeName() { return "std::uint64_t"; }
    explicit RField(std::string_view name)
@@ -593,7 +590,7 @@ public:
 
 
 template <>
-class ROOT::Experimental::RField<std::string> : public ROOT::Experimental::Detail::RFieldBase {
+class RField<std::string> : public Detail::RFieldBase {
 private:
    ClusterSize_t fIndex;
    Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex> fElemIndex;
@@ -637,7 +634,7 @@ public:
 
 
 template <typename ItemT>
-class ROOT::Experimental::RField<std::vector<ItemT>> : public ROOT::Experimental::RFieldVector {
+class RField<std::vector<ItemT>> : public RFieldVector {
    using ContainerT = typename std::vector<ItemT>;
 public:
    static std::string MyTypeName() { return "std::vector<" + RField<ItemT>::MyTypeName() + ">"; }
@@ -670,7 +667,7 @@ public:
  * RVec implementation as we can with std::vector
  */
 template <typename ItemT>
-class ROOT::Experimental::RField<ROOT::VecOps::RVec<ItemT>> : public Detail::RFieldBase {
+class RField<ROOT::VecOps::RVec<ItemT>> : public Detail::RFieldBase {
    using ContainerT = typename ROOT::VecOps::RVec<ItemT>;
 private:
    size_t fItemSize;
@@ -756,5 +753,8 @@ public:
    }
    size_t GetValueSize() const final { return sizeof(ContainerT); }
 };
+
+} // namespace Experimental
+} // namespace ROOT
 
 #endif


### PR DESCRIPTION
This is a workaround for GCC bug #56480, #78274, present in gcc 4.8 -- 7.0.