### PR TITLE
Web Fitpanel: organize data and function objects 

### DIFF
--- a/gui/fitpanelv7/inc/LinkDef.h
+++ b/gui/fitpanelv7/inc/LinkDef.h
@@ -13,6 +13,7 @@
 #pragma link C++ struct ROOT::Experimental::RFitFuncParameter+;
 #pragma link C++ struct ROOT::Experimental::RFitFuncParsList+;
 #pragma link C++ struct ROOT::Experimental::RFitPanelModel+;
+#pragma link C++ struct ROOT::Experimental::RFitPanelModel::RMinimezerAlgorithm+;
 #pragma link C++ class ROOT::Experimental::RFitPanel+;
 
 #endif

--- a/gui/fitpanelv7/inc/LinkDef.h
+++ b/gui/fitpanelv7/inc/LinkDef.h
@@ -11,9 +11,9 @@
 #pragma link C++ struct ROOT::Experimental::RFitPanelModel+;
 #pragma link C++ struct ROOT::Experimental::RFitPanelModel::RComboBoxItem+;
 #pragma link C++ struct ROOT::Experimental::RFitPanelModel::RMinimezerAlgorithm+;
-#pragma link C++ struct ROOT::Experimental::RFitPanelModel::RFitFuncInfo+;
-#pragma link C++ struct ROOT::Experimental::RFitPanelModel::RFitFuncParameter+;
-#pragma link C++ struct ROOT::Experimental::RFitPanelModel::RFitFuncParsList+;
+#pragma link C++ struct ROOT::Experimental::RFitPanelModel::RItemInfo+;
+#pragma link C++ struct ROOT::Experimental::RFitPanelModel::RFuncPar+;
+#pragma link C++ struct ROOT::Experimental::RFitPanelModel::RFuncParsList+;
 #pragma link C++ class ROOT::Experimental::RFitPanel+;
 
 #endif

--- a/gui/fitpanelv7/inc/LinkDef.h
+++ b/gui/fitpanelv7/inc/LinkDef.h
@@ -8,12 +8,12 @@
 
 #ifdef __CINT__
 
-#pragma link C++ struct ROOT::Experimental::RComboBoxItem+;
-#pragma link C++ struct ROOT::Experimental::RFitFuncInfo+;
-#pragma link C++ struct ROOT::Experimental::RFitFuncParameter+;
-#pragma link C++ struct ROOT::Experimental::RFitFuncParsList+;
 #pragma link C++ struct ROOT::Experimental::RFitPanelModel+;
+#pragma link C++ struct ROOT::Experimental::RFitPanelModel::RComboBoxItem+;
 #pragma link C++ struct ROOT::Experimental::RFitPanelModel::RMinimezerAlgorithm+;
+#pragma link C++ struct ROOT::Experimental::RFitPanelModel::RFitFuncInfo+;
+#pragma link C++ struct ROOT::Experimental::RFitPanelModel::RFitFuncParameter+;
+#pragma link C++ struct ROOT::Experimental::RFitPanelModel::RFitFuncParsList+;
 #pragma link C++ class ROOT::Experimental::RFitPanel+;
 
 #endif

--- a/gui/fitpanelv7/inc/ROOT/RFitPanel.hxx
+++ b/gui/fitpanelv7/inc/ROOT/RFitPanel.hxx
@@ -53,7 +53,7 @@ class RFitPanel {
 
    std::vector<std::unique_ptr<TF1>> fSystemFuncs; ///<! local copy of all internal system funcs
 
-   std::unordered_map<std::string, std::unique_ptr<TF1>> fPrevFuncs; ///<! all previous functions used for fitting
+   std::unordered_multimap<std::string, std::unique_ptr<TF1>> fPrevFuncs; ///<! all previous functions used for fitting
 
    TF1* copyTF1(TF1* f);
 
@@ -76,12 +76,9 @@ class RFitPanel {
    TObject *GetSelectedObject(const std::string &objid, int *kind = nullptr);
    void UpdateDataSet();
 
-
+   void UpdateFunctionsList();
    TF1 *FindFunction(const std::string &funcname);
-
    std::unique_ptr<TF1> GetFitFunction(const std::string &funcname);
-
-
    void SelectFunction(const std::string &funcid);
 
    TPad *GetDrawPad(TObject *obj);

--- a/gui/fitpanelv7/inc/ROOT/RFitPanel.hxx
+++ b/gui/fitpanelv7/inc/ROOT/RFitPanel.hxx
@@ -45,17 +45,17 @@ class RFitPanel {
    std::vector<TObject*> fObjects;    ///<! objects provided directly to panel for fitting
    std::string fCanvName;             ///<! v6 canvas name used to display fit, will be created if not exists
 
-   std::shared_ptr<RCanvas> fCanvas; ///!< v7 canvas used to display results
-   std::shared_ptr<RH1D> fFitHist;   ///!< v7 histogram for fitting
+   std::shared_ptr<RCanvas> fCanvas; ///<! v7 canvas used to display results
+   std::shared_ptr<RH1D> fFitHist;   ///<! v7 histogram for fitting
 
-   std::shared_ptr<RWebWindow> fWindow; ///!< configured display
-   unsigned fConnId{0};              ///<! client connection id
+   std::shared_ptr<RWebWindow> fWindow;  ///<! configured display
+   unsigned fConnId{0};                  ///<! client connection id
 
    std::vector<std::unique_ptr<TF1>> fSystemFuncs; ///<! local copy of all internal system funcs
 
    std::unordered_multimap<std::string, std::unique_ptr<TF1>> fPrevFuncs; ///<! all previous functions used for fitting
 
-   TF1* copyTF1(TF1* f);
+   TF1 *copyTF1(TF1 *f);
 
    void GetFunctionsFromSystem();
 
@@ -65,6 +65,7 @@ class RFitPanel {
    int UpdateModel(const std::string &json);
 
    bool DoFit();
+   bool DoDraw();
 
    void DrawContour(const std::string &model);
 
@@ -73,15 +74,15 @@ class RFitPanel {
    RFitPanelModel &model();
 
    void SelectObject(const std::string &objid);
-   TObject *GetSelectedObject(const std::string &objid, int *kind = nullptr);
+   TObject *GetSelectedObject(const std::string &objid, int &kind);
    void UpdateDataSet();
 
    void UpdateFunctionsList();
-   TF1 *FindFunction(const std::string &funcname);
-   std::unique_ptr<TF1> GetFitFunction(const std::string &funcname);
+   TF1 *FindFunction(const std::string &funcid);
+   std::unique_ptr<TF1> GetFitFunction(const std::string &funcid);
    void SelectFunction(const std::string &funcid);
 
-   TPad *GetDrawPad(TObject *obj);
+   TPad *GetDrawPad(TObject *obj, bool force = false);
 
    void SendModel();
 

--- a/gui/fitpanelv7/inc/ROOT/RFitPanel.hxx
+++ b/gui/fitpanelv7/inc/ROOT/RFitPanel.hxx
@@ -52,7 +52,7 @@ class RFitPanel {
 
    int UpdateModel(const std::string &json);
 
-   void DoFit(const std::string &model);
+   bool DoFit();
 
    void DrawContour(const std::string &model);
 

--- a/gui/fitpanelv7/inc/ROOT/RFitPanel.hxx
+++ b/gui/fitpanelv7/inc/ROOT/RFitPanel.hxx
@@ -43,7 +43,7 @@ class RFitPanel {
    std::unique_ptr<RFitPanelModel> fModel;
 
    std::vector<TObject*> fObjects;    ///<! objects provided directly to panel for fitting
-   std::string fCanvName{"c1"};       ///<! v6 canvas name used to display fit, will be created if not exists
+   std::string fCanvName;             ///<! v6 canvas name used to display fit, will be created if not exists
 
    std::shared_ptr<RCanvas> fCanvas; ///!< v7 canvas used to display results
    std::shared_ptr<RH1D> fFitHist;   ///!< v7 histogram for fitting

--- a/gui/fitpanelv7/inc/ROOT/RFitPanel.hxx
+++ b/gui/fitpanelv7/inc/ROOT/RFitPanel.hxx
@@ -27,6 +27,7 @@
 
 #include <memory>
 #include <vector>
+#include <unordered_map>
 
 #include "TF1.h"
 
@@ -50,8 +51,9 @@ class RFitPanel {
    std::shared_ptr<RWebWindow> fWindow; ///!< configured display
    unsigned fConnId{0};              ///<! client connection id
 
-   std::vector<std::unique_ptr<TF1>> fSystemFuncs; ///!< local copy of all internal system funcs
+   std::vector<std::unique_ptr<TF1>> fSystemFuncs; ///<! local copy of all internal system funcs
 
+   std::unordered_map<std::string, std::unique_ptr<TF1>> fPrevFuncs; ///<! all previous functions used for fitting
 
    TF1* copyTF1(TF1* f);
 
@@ -69,6 +71,10 @@ class RFitPanel {
    void DrawScan(const std::string &model);
 
    RFitPanelModel &model();
+
+   TF1 *FindFunction(const std::string &funcname);
+
+   std::unique_ptr<TF1> GetFitFunction(const std::string &funcname);
 
    TPad *GetDrawPad(TH1 *hist);
 

--- a/gui/fitpanelv7/inc/ROOT/RFitPanel.hxx
+++ b/gui/fitpanelv7/inc/ROOT/RFitPanel.hxx
@@ -28,8 +28,11 @@
 #include <memory>
 #include <vector>
 
+#include "TF1.h"
+
 class TPad;
 class TH1;
+class TF1;
 
 namespace ROOT {
 namespace Experimental {
@@ -46,6 +49,13 @@ class RFitPanel {
 
    std::shared_ptr<RWebWindow> fWindow; ///!< configured display
    unsigned fConnId{0};              ///<! client connection id
+
+   std::vector<std::unique_ptr<TF1>> fSystemFuncs; ///!< local copy of all internal system funcs
+
+
+   TF1* copyTF1(TF1* f);
+
+   void GetFunctionsFromSystem();
 
    /// process data from UI
    void ProcessData(unsigned connid, const std::string &arg);

--- a/gui/fitpanelv7/inc/ROOT/RFitPanel.hxx
+++ b/gui/fitpanelv7/inc/ROOT/RFitPanel.hxx
@@ -42,8 +42,8 @@ class RFitPanel {
 
    std::unique_ptr<RFitPanelModel> fModel;
 
-   TH1 *fHist{nullptr};              ///<! explicit histogram used for fitting
-   std::string fCanvName{"c1"};      ///<! v6 canvas name used to display fit, will be created if not exists
+   std::vector<TObject*> fObjects;    ///<! objects provided directly to panel for fitting
+   std::string fCanvName{"c1"};       ///<! v6 canvas name used to display fit, will be created if not exists
 
    std::shared_ptr<RCanvas> fCanvas; ///!< v7 canvas used to display results
    std::shared_ptr<RH1D> fFitHist;   ///!< v7 histogram for fitting
@@ -72,11 +72,19 @@ class RFitPanel {
 
    RFitPanelModel &model();
 
+   void SelectObject(const std::string &objid);
+   TObject *GetSelectedObject(const std::string &objid, int *kind = nullptr);
+   void UpdateDataSet();
+
+
    TF1 *FindFunction(const std::string &funcname);
 
    std::unique_ptr<TF1> GetFitFunction(const std::string &funcname);
 
-   TPad *GetDrawPad(TH1 *hist);
+
+   void SelectFunction(const std::string &funcid);
+
+   TPad *GetDrawPad(TObject *obj);
 
    void SendModel();
 

--- a/gui/fitpanelv7/inc/ROOT/RFitPanelModel.hxx
+++ b/gui/fitpanelv7/inc/ROOT/RFitPanelModel.hxx
@@ -52,18 +52,19 @@ struct RFitPanelModel {
    };
 
    /// Basic function info, used in combo boxes
-   struct RFitFuncInfo {
+   struct RItemInfo {
       std::string group;
-      std::string name;
       std::string id;
+      std::string name;
 
-      RFitFuncInfo() = default;
-      RFitFuncInfo(const std::string &_name) : group("Prefefined"), name(_name) { id = "dflt::"; id.append(_name); }
+      RItemInfo() = default;
+      RItemInfo(const std::string &_name) : group("Predefined"), name(_name) { id = "dflt::"; id.append(_name); }
+      RItemInfo(const std::string &_group, const std::string &_id, const std::string &_name) : group(_group), id(_id), name(_name) {}
    };
 
    /// Function parameter info, used in edit parameters dialog
 
-   struct RFitFuncParameter {
+   struct RFuncPar {
       int ipar{0};
       std::string name;
       std::string value;
@@ -71,15 +72,16 @@ struct RFitPanelModel {
       std::string error;
       std::string min;
       std::string max;
-      RFitFuncParameter() = default;
-      RFitFuncParameter(int _ipar, const std::string &_name) : ipar(_ipar), name(_name) {}
+      RFuncPar() = default;
+      RFuncPar(int _ipar, const std::string &_name) : ipar(_ipar), name(_name) {}
    };
 
    /// Class used to transfer functions parameters list from/to client
-   struct RFitFuncParsList {
+   struct RFuncParsList {
       bool haspars{false};
-      std::string name;
-      std::vector<RFitFuncParameter> pars;
+      std::string id;                ///< function id in the FitPanel
+      std::string name;              ///< display name
+      std::vector<RFuncPar> pars;    ///< parameters
       void GetParameters(TF1 *f1);
       void SetParameters(TF1 *f1);
       void Clear();
@@ -87,12 +89,12 @@ struct RFitPanelModel {
 
    std::string fTitle;                      ///< title of the fit panel
 
-   std::vector<RComboBoxItem> fDataSet;     ///< list of available data sources
+   std::vector<RItemInfo> fDataSet;     ///< list of available data sources
    std::string fSelectedData;               ///< selected data
 
    int fDim{0};                             ///< number of dimensions in selected data object
 
-   std::vector<RFitFuncInfo> fFuncList;     ///< all available fit functions
+   std::vector<RItemInfo> fFuncList;     ///< all available fit functions
    std::string fSelectedFunc;               ///< id of selected fit function like dflt::gaus
 
 
@@ -150,7 +152,7 @@ struct RFitPanelModel {
 
    /// Parameters
 
-   RFitFuncParsList fFuncPars;
+   RFuncParsList fFuncPars;
 
    /////////Advanced Options
 
@@ -176,13 +178,15 @@ struct RFitPanelModel {
    int fScanMin{0};
    int fScanMax{0};
 
-   bool fInitialized{false};    ///<! indicates if data were initialized
+   bool fInitialized{false};        ///<! indicates if data were initialized
 
-   RFitPanelModel() { Initialize(); }
+   RFitPanelModel() = default;
 
    void Initialize();
 
    bool SelectHistogram(const std::string &hname, TH1 *hist);
+
+   bool HasFunction(const std::string &id);
 
    void SelectedFunc(const std::string &name, TF1 *func);
 
@@ -190,10 +194,7 @@ struct RFitPanelModel {
 
    void UpdateAdvanced(TF1 *func);
 
-   void UpdateFuncList();
-
    bool IsDataSelected() const { return !fSelectedData.empty(); }
-
 
    void GetRanges(ROOT::Fit::DataRange &drange);
    void GetFitOptions(Foption_t &fitOpts);

--- a/gui/fitpanelv7/inc/ROOT/RFitPanelModel.hxx
+++ b/gui/fitpanelv7/inc/ROOT/RFitPanelModel.hxx
@@ -99,6 +99,8 @@ struct RFitPanelModel {
    std::string fSelectedFunc;               ///< id of selected fit function like dflt::gaus
 
 
+   std::string fSelectedTab;               ///< key of selected tab, useful for drawing
+
    // General tab
 
    // Method
@@ -158,6 +160,8 @@ struct RFitPanelModel {
    /////////Advanced Options
 
    bool fHasAdvanced{false};
+   std::string fAdvancedTab;
+
    std::vector<RComboBoxItem> fContour1;
    std::string fContourPar1Id;
    std::vector<RComboBoxItem> fContour2;

--- a/gui/fitpanelv7/inc/ROOT/RFitPanelModel.hxx
+++ b/gui/fitpanelv7/inc/ROOT/RFitPanelModel.hxx
@@ -30,51 +30,17 @@ class TF1;
 namespace ROOT {
 namespace Experimental {
 
-/// Generic item for ui5 ComboBox
-struct RComboBoxItem {
-   std::string key;
-   std::string value;
-   RComboBoxItem() = default;
-   RComboBoxItem(const std::string &_key, const std::string &_value) : key(_key), value(_value) {}
-};
-
-/// Basic function info, used in combo boxes
-struct RFitFuncInfo {
-   std::string name;
-   bool linear{false};
-
-   RFitFuncInfo() = default;
-   RFitFuncInfo(const std::string &_name, bool _linear = false) : name(_name), linear(_linear) {}
-};
-
-/// Function parameter info, used in edit parameters dialog
-
-struct RFitFuncParameter {
-   int ipar{0};
-   std::string name;
-   std::string value;
-   bool fixed{false};
-   std::string error;
-   std::string min;
-   std::string max;
-   RFitFuncParameter() = default;
-   RFitFuncParameter(int _ipar, const std::string &_name) : ipar(_ipar), name(_name) {}
-};
-
-/// Class used to transfer functions parameters list from/to client
-struct RFitFuncParsList {
-   bool haspars{false};
-   std::string name;
-   std::vector<RFitFuncParameter> pars;
-   void GetParameters(TF1 *f1);
-   void SetParameters(TF1 *f1);
-   void Clear();
-};
-
-
 /** Data structure for the fit panel */
 
 struct RFitPanelModel {
+
+   /// Generic item for ui5 ComboBox
+   struct RComboBoxItem {
+      std::string key;
+      std::string value;
+      RComboBoxItem() = default;
+      RComboBoxItem(const std::string &_key, const std::string &_value) : key(_key), value(_value) {}
+   };
 
    /// Entry in minimizer algorithm combo
    struct RMinimezerAlgorithm {
@@ -85,6 +51,39 @@ struct RFitPanelModel {
       RMinimezerAlgorithm(int _lib, int _id, const std::string &_text) : lib(_lib), id(_id), text(_text) {}
    };
 
+   /// Basic function info, used in combo boxes
+   struct RFitFuncInfo {
+      std::string group;
+      std::string name;
+      std::string id;
+
+      RFitFuncInfo() = default;
+      RFitFuncInfo(const std::string &_name) : group("Prefefined"), name(_name) { id = "dflt::"; id.append(_name); }
+   };
+
+   /// Function parameter info, used in edit parameters dialog
+
+   struct RFitFuncParameter {
+      int ipar{0};
+      std::string name;
+      std::string value;
+      bool fixed{false};
+      std::string error;
+      std::string min;
+      std::string max;
+      RFitFuncParameter() = default;
+      RFitFuncParameter(int _ipar, const std::string &_name) : ipar(_ipar), name(_name) {}
+   };
+
+   /// Class used to transfer functions parameters list from/to client
+   struct RFitFuncParsList {
+      bool haspars{false};
+      std::string name;
+      std::vector<RFitFuncParameter> pars;
+      void GetParameters(TF1 *f1);
+      void SetParameters(TF1 *f1);
+      void Clear();
+   };
 
    std::string fTitle;                      ///< title of the fit panel
 
@@ -93,8 +92,8 @@ struct RFitPanelModel {
 
    int fDim{0};                             ///< number of dimensions in selected data object
 
-   std::vector<RFitFuncInfo>   fFuncList;   ///< all available fit functions
-   std::string fSelectedFunc;               ///< name of selected fit function
+   std::vector<RFitFuncInfo> fFuncList;     ///< all available fit functions
+   std::string fSelectedFunc;               ///< id of selected fit function like dflt::gaus
 
 
    // General tab
@@ -137,7 +136,7 @@ struct RFitPanelModel {
    int fPrint{0};
 
 
-   // range selection, shown dependning on fDim
+   // range selection, shown depending on fDim
    float fMinRangeX{0};
    float fMaxRangeX{1};
    float fStepX{0.01};
@@ -147,14 +146,6 @@ struct RFitPanelModel {
    float fMaxRangeY{1};
    float fStepY{0.01};
    float fRangeY[2] = {0,1};
-
-   // float fOperation{0};
-   float fFitOptions{0};
-
-   // convert fSelectTypeID from string to int
-   int fTypeId{0};
-
-   // bool fImproveFit {false};
 
 
    /// Parameters
@@ -191,23 +182,21 @@ struct RFitPanelModel {
 
    bool SelectHistogram(const std::string &hname, TH1 *hist);
 
-   bool SelectFunc(const std::string &name, TH1 *hist);
+   void SelectedFunc(const std::string &name, TF1 *func);
 
    void UpdateRange(TH1 *hist);
 
    void UpdateAdvanced(TF1 *func);
 
-   TF1 *UpdateFuncList(TH1 *hist = nullptr, bool select_hist_func = false);
+   void UpdateFuncList();
 
    bool IsSelectedHistogram() const { return !fSelectedData.empty(); }
 
    TH1* GetSelectedHistogram(TH1 *hist = nullptr);
 
-   TF1 *FindFunction(const std::string &fname, TH1 *hist = nullptr);
-
    void GetRanges(ROOT::Fit::DataRange &drange);
-
-   void RetrieveOptions(Foption_t &fitOpts, ROOT::Math::MinimizerOptions &minOpts);
+   void GetFitOptions(Foption_t &fitOpts);
+   void GetMinimizerOptions(ROOT::Math::MinimizerOptions &minOpts);
 
    std::string GetDrawOption();
 

--- a/gui/fitpanelv7/inc/ROOT/RFitPanelModel.hxx
+++ b/gui/fitpanelv7/inc/ROOT/RFitPanelModel.hxx
@@ -26,11 +26,12 @@ class TF1;
 namespace ROOT {
 namespace Experimental {
 
+/// Generic item for ui5 ComboBox
 struct RComboBoxItem {
-   std::string fId;
-   std::string fSet;
+   std::string key;
+   std::string value;
    RComboBoxItem() = default;
-   RComboBoxItem(const std::string &id, const std::string &set) : fId(id), fSet(set) {}
+   RComboBoxItem(const std::string &_key, const std::string &_value) : key(_key), value(_value) {}
 };
 
 /// Basic function info, used in combo boxes

--- a/gui/fitpanelv7/inc/ROOT/RFitPanelModel.hxx
+++ b/gui/fitpanelv7/inc/ROOT/RFitPanelModel.hxx
@@ -77,8 +77,33 @@ struct RFitPanelModel {
    std::string fSelectedData;               ///< selected data
    std::vector<RFitFuncInfo>   fFuncList;   ///< all available fit functions
    std::string fSelectedFunc;               ///< name of selected fit function
-   std::vector<RComboBoxItem> fMethod;
-   std::string fSelectMethodId;
+
+
+   // General tab
+
+   // Method
+   std::vector<RComboBoxItem> fFitMethods;   ///< all supported fit methods
+   std::string fFitMethod;                   ///< selected fit method
+
+   bool fLinearFit{false};
+   bool fRobust{false};
+   float fRobustLevel{0.95};
+
+   // Fit Options
+   bool fIntegral{false};
+   bool fUseRange{false};
+   bool fBestErrors{false};
+   bool fImproveFitResults{false};
+   bool fAllWeights1{false};
+   bool fAddToList{false};
+   bool fEmptyBins1{false};
+   bool fUseGradient{false};
+
+   // Draw Options
+   bool fSame{false};
+   bool fNoDrawing{false};
+   bool fNoStoreDraw{false};
+
 
    // all combo items for all methods
 
@@ -102,8 +127,6 @@ struct RFitPanelModel {
 
    // float fOperation{0};
    float fFitOptions{0};
-   bool fLinear{false};
-   bool fRobust{false};
    int fPrint{0};
    float fErrorDef{1.00};
    float fMaxTol{0.01};
@@ -112,18 +135,7 @@ struct RFitPanelModel {
    // convert fSelectTypeID from string to int
    int fTypeId{0};
 
-   // Checkboxes Options
-   bool fIntegral{false};
-   bool fMinusErrors{false};
-   bool fWeights{false};
-   bool fBins{false};
-   bool fUseRange{false};
    // bool fImproveFit {false};
-   bool fAddList{false};
-   bool fUseGradient{false};
-   bool fSame{false};
-   bool fNoDrawing{false};
-   bool fNoStore{false};
 
 
    /// Parameters

--- a/gui/fitpanelv7/inc/ROOT/RFitPanelModel.hxx
+++ b/gui/fitpanelv7/inc/ROOT/RFitPanelModel.hxx
@@ -17,6 +17,10 @@
 #ifndef ROOT_RFitPanelModel
 #define ROOT_RFitPanelModel
 
+#include "Foption.h"
+#include "Fit/DataRange.h"
+#include "Math/MinimizerOptions.h"
+
 #include <vector>
 #include <string>
 
@@ -72,10 +76,23 @@ struct RFitFuncParsList {
 
 struct RFitPanelModel {
 
+   /// Entry in minimizer algorithm combo
+   struct RMinimezerAlgorithm {
+      int lib{0};        // to which library belongs
+      int id{0};         // identifier
+      std::string text;  // text shown in combobox
+      RMinimezerAlgorithm() = default;
+      RMinimezerAlgorithm(int _lib, int _id, const std::string &_text) : lib(_lib), id(_id), text(_text) {}
+   };
+
+
    std::string fTitle;                      ///< title of the fit panel
 
    std::vector<RComboBoxItem> fDataSet;     ///< list of available data sources
    std::string fSelectedData;               ///< selected data
+
+   int fDim{0};                             ///< number of dimensions in selected data object
+
    std::vector<RFitFuncInfo>   fFuncList;   ///< all available fit functions
    std::string fSelectedFunc;               ///< name of selected fit function
 
@@ -109,18 +126,23 @@ struct RFitPanelModel {
    // all combo items for all methods
 
    // Minimization Tab
-   int fLibrary{0};   ///< selected minimization library
-   std::vector<RComboBoxItem> fMethodMinAll;  // all items for all methods
-   std::string fSelectMethodMin;
+   int fLibrary{0};                                 ///< selected minimization library
+   bool fHasGenetics{false};                        ///< is genetics available
+   std::vector<RMinimezerAlgorithm> fMethodMinAll;  ///< all items for all methods
+   int fSelectMethodMin{0};
 
-   // range selection
-   bool fShowRangeX{true};
+   float fErrorDef{1.00};
+   float fMaxTolerance{0.01};
+   int fMaxIterations{0};
+   int fPrint{0};
+
+
+   // range selection, shown dependning on fDim
    float fMinRangeX{0};
    float fMaxRangeX{1};
    float fStepX{0.01};
    float fRangeX[2] = {0,1};
 
-   bool fShowRangeY{false};
    float fMinRangeY{0};
    float fMaxRangeY{1};
    float fStepY{0.01};
@@ -128,10 +150,6 @@ struct RFitPanelModel {
 
    // float fOperation{0};
    float fFitOptions{0};
-   int fPrint{0};
-   float fErrorDef{1.00};
-   float fMaxTol{0.01};
-   int fMaxInter{0};
 
    // convert fSelectTypeID from string to int
    int fTypeId{0};
@@ -186,6 +204,12 @@ struct RFitPanelModel {
    TH1* GetSelectedHistogram(TH1 *hist = nullptr);
 
    TF1 *FindFunction(const std::string &fname, TH1 *hist = nullptr);
+
+   void GetRanges(ROOT::Fit::DataRange &drange);
+
+   void RetrieveOptions(Foption_t &fitOpts, ROOT::Math::MinimizerOptions &minOpts);
+
+   std::string GetDrawOption();
 
    std::string GetFitOption();
 };

--- a/gui/fitpanelv7/inc/ROOT/RFitPanelModel.hxx
+++ b/gui/fitpanelv7/inc/ROOT/RFitPanelModel.hxx
@@ -20,6 +20,7 @@
 #include "Foption.h"
 #include "Fit/DataRange.h"
 #include "Math/MinimizerOptions.h"
+#include "TString.h"
 
 #include <vector>
 #include <string>
@@ -196,13 +197,11 @@ struct RFitPanelModel {
 
    bool IsDataSelected() const { return !fSelectedData.empty(); }
 
-   void GetRanges(ROOT::Fit::DataRange &drange);
-   void GetFitOptions(Foption_t &fitOpts);
-   void GetMinimizerOptions(ROOT::Math::MinimizerOptions &minOpts);
+   ROOT::Fit::DataRange GetRanges();
+   Foption_t GetFitOptions();
+   ROOT::Math::MinimizerOptions GetMinimizerOptions();
 
-   std::string GetDrawOption();
-
-   std::string GetFitOption();
+   TString GetDrawOption();
 };
 
 } // namespace Experimental

--- a/gui/fitpanelv7/inc/ROOT/RFitPanelModel.hxx
+++ b/gui/fitpanelv7/inc/ROOT/RFitPanelModel.hxx
@@ -176,6 +176,8 @@ struct RFitPanelModel {
    int fScanMin{0};
    int fScanMax{0};
 
+   bool fInitialized{false};    ///<! indicates if data were initialized
+
    RFitPanelModel() { Initialize(); }
 
    void Initialize();
@@ -190,9 +192,8 @@ struct RFitPanelModel {
 
    void UpdateFuncList();
 
-   bool IsSelectedHistogram() const { return !fSelectedData.empty(); }
+   bool IsDataSelected() const { return !fSelectedData.empty(); }
 
-   TH1* GetSelectedHistogram(TH1 *hist = nullptr);
 
    void GetRanges(ROOT::Fit::DataRange &drange);
    void GetFitOptions(Foption_t &fitOpts);

--- a/gui/fitpanelv7/inc/ROOT/RFitPanelModel.hxx
+++ b/gui/fitpanelv7/inc/ROOT/RFitPanelModel.hxx
@@ -79,15 +79,13 @@ struct RFitPanelModel {
    std::string fSelectedFunc;               ///< name of selected fit function
    std::vector<RComboBoxItem> fMethod;
    std::string fSelectMethodId;
-   std::string fMinLibrary;
 
    // all combo items for all methods
 
    // Minimization Tab
-   std::vector<std::vector<RComboBoxItem>> fMethodMinAll;
-
-
-   std::string fSelectMethodMinId;
+   int fLibrary{0};   ///< selected minimization library
+   std::vector<RComboBoxItem> fMethodMinAll;  // all items for all methods
+   std::string fSelectMethodMin;
 
    // range selection
    bool fShowRangeX{true};
@@ -106,7 +104,6 @@ struct RFitPanelModel {
    float fFitOptions{0};
    bool fLinear{false};
    bool fRobust{false};
-   int fLibrary{0};
    int fPrint{0};
    float fErrorDef{1.00};
    float fMaxTol{0.01};

--- a/gui/fitpanelv7/src/RFitPanel.cxx
+++ b/gui/fitpanelv7/src/RFitPanel.cxx
@@ -365,8 +365,8 @@ bool ROOT::Experimental::RFitPanel::DoFit()
    if (m.fSelectedFunc.empty())
       m.fSelectedFunc = "gaus";
 
-   if (!m.fMinLibrary.empty())
-      minOption.SetMinimizerAlgorithm(m.fMinLibrary.c_str());
+   if (!m.fSelectMethodMin.empty())
+      minOption.SetMinimizerAlgorithm(m.fSelectMethodMin.c_str());
 
    if (m.fErrorDef == 0)
       minOption.SetErrorDef(1.00);

--- a/gui/fitpanelv7/src/RFitPanelModel.cxx
+++ b/gui/fitpanelv7/src/RFitPanelModel.cxx
@@ -157,6 +157,8 @@ void ROOT::Experimental::RFitPanelModel::Initialize()
    fSelectedFunc = "";
    fDim = 1;
 
+   fSelectedTab = "General";
+
    // corresponds when Type == User Func (fSelectedTypeID == 1)
 
    // ComboBox for General Tab --- Method
@@ -209,6 +211,8 @@ void ROOT::Experimental::RFitPanelModel::Initialize()
 
    // fOperation = 0;
    fPrint = 0;
+
+   fAdvancedTab = "Contour";
 }
 
 /// Update advanced parameters associated with fit function for histogram

--- a/gui/fitpanelv7/src/RFitPanelModel.cxx
+++ b/gui/fitpanelv7/src/RFitPanelModel.cxx
@@ -246,29 +246,18 @@ void ROOT::Experimental::RFitPanelModel::Initialize()
    fMethod.emplace_back("4", "Binned Likelihood");
    fSelectMethodId = "1";
 
-   // Sub ComboBox for Minimization Tab --- Method
-   fSelectMethodMinId = "1";
 
+   // Minimization method
    fLibrary = 0;
-
    // corresponds to library == 0
-   fMethodMinAll.emplace_back();
-   fMethodMinAll.back() = {{ "1", "MIGRAD" }, {"2", "SIMPLEX"}, {"3", "SCAN"}, {"4", "Combination"}};
-
-   // corresponds to library == 1
-   fMethodMinAll.emplace_back();
-   fMethodMinAll.back() = {{ "1", "MIGRAD" }, {"2", "SIMPLEX"}, {"3", "SCAN"}, {"4", "Combination"}};
-
-   // corresponds to library == 2
-   fMethodMinAll.emplace_back();
-   fMethodMinAll.back() = {{ "1", "FUMILI" }};
-
-   // corresponds to library == 3
-   fMethodMinAll.emplace_back();
-
-   // corresponds to library == 4
-   fMethodMinAll.emplace_back();
-   fMethodMinAll.back() = {{ "1", "TMVA Genetic Algorithm" }};
+   fMethodMinAll = {
+         {"0", "MIGRAD"}, {"0", "SIMPLEX"}, {"0", "SCAN"}, {"0", "Combination"},
+         {"1", "MIGRAD"}, {"1", "SIMPLEX"}, {"1", "SCAN"}, {"1", "Combination"},
+         {"2", "FUMILI"},
+         {"3", "none"},
+         {"4", "TMVA Genetic Algorithm"}
+   };
+   fSelectMethodMin = "MIGRAD";
 
    // fOperation = 0;
    fFitOptions = 3;

--- a/gui/fitpanelv7/src/RFitPanelModel.cxx
+++ b/gui/fitpanelv7/src/RFitPanelModel.cxx
@@ -90,65 +90,6 @@ void ROOT::Experimental::RFitPanelModel::RFitFuncParsList::SetParameters(TF1 *fu
    }
 }
 
-///////////////////////////////
-
-TH1* ROOT::Experimental::RFitPanelModel::GetSelectedHistogram(TH1 *hist)
-{
-   if (fSelectedData == "__hist__") return hist;
-   if ((fSelectedData.compare(0,6,"gdir::") != 0) || !gDirectory) return nullptr;
-
-   std::string hname = fSelectedData.substr(6);
-
-   return dynamic_cast<TH1*> (gDirectory->GetList()->FindObject(hname.c_str()));
-}
-
-
-// Configure usage of histogram
-
-bool ROOT::Experimental::RFitPanelModel::SelectHistogram(const std::string &hname, TH1 *hist)
-{
-
-   std::string histid;
-
-   fDataSet.clear();
-   TH1 *selected = nullptr;
-
-   if (gDirectory) {
-      TIter iter(gDirectory->GetList());
-      TObject *item = nullptr;
-
-       while ((item = iter()) != nullptr)
-         if (item->InheritsFrom(TH1::Class())) {
-            std::string dataid = "gdir::"s + item->GetName();
-
-            if (hist && (hist == item)) {
-               histid = dataid;
-               selected = hist;
-            } else if (!hname.empty() && hname.compare(item->GetName())) {
-               histid = dataid;
-               selected = dynamic_cast<TH1 *> (item);
-            }
-            fDataSet.emplace_back(dataid, Form("%s::%s", item->ClassName(), item->GetName()));
-         }
-   }
-
-   if (hist && histid.empty()) {
-      selected = hist;
-      histid = "__hist__";
-      fDataSet.emplace_back(histid, Form("%s::%s", hist->ClassName(), hist->GetName()));
-   }
-
-   fSelectedData = histid;
-
-   UpdateRange(selected);
-
-   UpdateFuncList();
-
-   UpdateAdvanced(nullptr);
-
-   return selected != nullptr;
-}
-
 void ROOT::Experimental::RFitPanelModel::UpdateRange(TH1 *hist)
 {
    fDim = hist ? hist->GetDimension() : 0;
@@ -197,7 +138,7 @@ void ROOT::Experimental::RFitPanelModel::UpdateFuncList()
    if (fDim == 1) {
       fFuncList = { {"gaus"}, {"gausn"}, {"expo"}, {"landau"},{"landaun"},
                     {"pol0"},{"pol1"},{"pol2"},{"pol3"},{"pol4"},{"pol5"},{"pol6"},{"pol7"},{"pol8"},{"pol9"},
-                    {"cheb0"}, {"cheb1"}, {"cheb2"}, {"cheb3"}, {"cheb4"}, {"cheb5"}, {"cheb6"}, {"cheb7"}, {"cheb8"}, {"use9"} };
+                    {"cheb0"}, {"cheb1"}, {"cheb2"}, {"cheb3"}, {"cheb4"}, {"cheb5"}, {"cheb6"}, {"cheb7"}, {"cheb8"}, {"cheb9"} };
    } else if (fDim == 2) {
       fFuncList = { {"xygaus"}, {"bigaus"}, {"xyexpo"}, {"xylandau"}, {"xylandaun"} };
    }

--- a/gui/fitpanelv7/src/RFitPanelModel.cxx
+++ b/gui/fitpanelv7/src/RFitPanelModel.cxx
@@ -238,44 +238,22 @@ void ROOT::Experimental::RFitPanelModel::UpdateAdvanced(TF1 *func)
 }
 
 
-std::string ROOT::Experimental::RFitPanelModel::GetFitOption()
+ROOT::Fit::DataRange ROOT::Experimental::RFitPanelModel::GetRanges()
 {
-   std::string opt = fFitMethod;
+   ROOT::Fit::DataRange drange;
 
-   if (fIntegral) opt.append("I");
-   if (fUseRange) opt.append("R");
-   if (fBestErrors) opt.append("E");
-   if (fImproveFitResults) opt.append("M");
-   if (fAddToList) opt.append("+");
-   if (fUseGradient) opt.append("G");
-
-   if (fEmptyBins1)
-      opt.append("WW");
-   else if (fAllWeights1)
-      opt.append("W");
-
-   if (fNoStoreDraw)
-      opt.append("N");
-   else if (fNoDrawing)
-      opt.append("O");
-
-   return opt;
-}
-
-void ROOT::Experimental::RFitPanelModel::GetRanges(ROOT::Fit::DataRange &drange)
-{
-   if (fDim > 0)  {
+   if (fDim > 0)
       drange.AddRange(0, fRangeX[0], fRangeX[1]);
-   }
 
-   if ( fDim > 1 ) {
+   if ( fDim > 1 )
       drange.AddRange(1, fRangeY[0], fRangeY[1]);
-   }
 
+   return drange;
 }
 
-void ROOT::Experimental::RFitPanelModel::GetFitOptions(Foption_t &fitOpts)
+Foption_t ROOT::Experimental::RFitPanelModel::GetFitOptions()
 {
+   Foption_t fitOpts;
    fitOpts.Range    = fUseRange;
    fitOpts.Integral = fIntegral;
    fitOpts.More     = fImproveFitResults;
@@ -312,10 +290,14 @@ void ROOT::Experimental::RFitPanelModel::GetFitOptions(Foption_t &fitOpts)
       fitOpts.Robust = 1;
       fitOpts.hRobust = fRobustLevel;
    }
+
+   return fitOpts;
 }
 
-void ROOT::Experimental::RFitPanelModel::GetMinimizerOptions(ROOT::Math::MinimizerOptions &minOpts)
+ROOT::Math::MinimizerOptions ROOT::Experimental::RFitPanelModel::GetMinimizerOptions()
 {
+   ROOT::Math::MinimizerOptions minOpts;
+
    if (fLibrary == 0)
       minOpts.SetMinimizerType ( "Minuit");
    else if (fLibrary == 1)
@@ -363,11 +345,14 @@ void ROOT::Experimental::RFitPanelModel::GetMinimizerOptions(ROOT::Math::Minimiz
    minOpts.SetTolerance(fMaxTolerance);
    minOpts.SetMaxIterations(fMaxIterations);
    minOpts.SetMaxFunctionCalls(fMaxIterations);
+
+   return minOpts;
 }
 
-std::string ROOT::Experimental::RFitPanelModel::GetDrawOption()
+TString ROOT::Experimental::RFitPanelModel::GetDrawOption()
 {
-   return "";
+   TString res;
+   return res;
 }
 
 

--- a/gui/fitpanelv7/src/RFitPanelModel.cxx
+++ b/gui/fitpanelv7/src/RFitPanelModel.cxx
@@ -240,11 +240,25 @@ void ROOT::Experimental::RFitPanelModel::Initialize()
    // corresponds when Type == User Func (fSelectedTypeID == 1)
 
    // ComboBox for General Tab --- Method
-   fMethod.emplace_back("1", "Linear Chi-square");
-   fMethod.emplace_back("2", "Non-Linear Chi-square");
-   fMethod.emplace_back("3", "Linear Chi-square with Robust");
-   fMethod.emplace_back("4", "Binned Likelihood");
-   fSelectMethodId = "1";
+   fFitMethods = { {"P", "Chi-square"},
+                   {"L", "Log Likelihood"},
+                   {"WL", "Binned LogLikelihood"} };
+   fFitMethod = "P";
+
+   fLinearFit = false;
+   fRobust = false;
+   fRobustLevel = 0.95;
+
+   fIntegral = false;
+   fAllWeights1 = false;
+   fAddToList = false;
+   fEmptyBins1 = false;
+   fUseGradient = false;
+
+   fSame = false;
+   fNoDrawing = false;
+   fNoStoreDraw = false;
+
 
 
    // Minimization method
@@ -261,26 +275,7 @@ void ROOT::Experimental::RFitPanelModel::Initialize()
 
    // fOperation = 0;
    fFitOptions = 3;
-   fRobust = false;
    fPrint = 0;
-
-   // Checkboxes Values
-   fIntegral = false;
-   fWeights = false;
-   fBins = false;
-   // fUseRange = false;
-   fAddList = false;
-   fUseGradient = false;
-   fSame = false;
-   fNoStore = false;
-   fMinusErrors = false;
-   // fImproveFit = false;
-
-   if (fNoStore) {
-      fNoDrawing = true;
-   } else {
-      fNoDrawing = false;
-   }
 }
 
 TF1 *ROOT::Experimental::RFitPanelModel::FindFunction(const std::string &funcname, TH1 *hist)
@@ -324,27 +319,24 @@ void ROOT::Experimental::RFitPanelModel::UpdateAdvanced(TF1 *func)
 
 std::string ROOT::Experimental::RFitPanelModel::GetFitOption()
 {
-   std::string opt;
+   std::string opt = fFitMethod;
 
-   if (fIntegral) {
-      opt = "I";
-   } else if (fMinusErrors) {
-      opt = "E";
-   } else if (fWeights) {
-      opt = "W";
-   } else if (fUseRange) {
-      opt = "R";
-   } else if (fNoDrawing) {
-      opt = "O";
-   } else if (fWeights && fBins) {
-      opt = "WW";
-   } else if (fAddList) {
-      opt = "+";
-   } else if (fSelectMethodId == "1") {
-      opt = "P";
-   } else if (fSelectMethodId == "2") {
-      opt = "L";
-   }
+   if (fIntegral) opt.append("I");
+   if (fUseRange) opt.append("R");
+   if (fBestErrors) opt.append("E");
+   if (fImproveFitResults) opt.append("M");
+   if (fAddToList) opt.append("+");
+   if (fUseGradient) opt.append("G");
+
+   if (fEmptyBins1)
+      opt.append("WW");
+   else if (fAllWeights1)
+      opt.append("W");
+
+   if (fNoStoreDraw)
+      opt.append("N");
+   else if (fNoDrawing)
+      opt.append("O");
 
    return opt;
 }

--- a/ui5/fitpanel/controller/FitPanel.controller.js
+++ b/ui5/fitpanel/controller/FitPanel.controller.js
@@ -85,10 +85,20 @@ sap.ui.define([
          }
       },
 
-      //Fitting Button
+      // Update Button
+      doUpdate: function() {
+         if (this.websocket)
+            this.websocket.Send("RELOAD");
+      },
+
+      // Fit Button
       doFit: function() {
-         console.log('method', this.data().fSelectMethodMin, typeof this.data().fSelectMethodMin);
          this.sendModel("DOFIT:");
+      },
+
+      // Draw Button
+      doDraw: function() {
+         this.sendModel("DODRAW:");
       },
 
       onPanelExit: function(){

--- a/ui5/fitpanel/controller/FitPanel.controller.js
+++ b/ui5/fitpanel/controller/FitPanel.controller.js
@@ -24,7 +24,7 @@ sap.ui.define([
          this.inputId = "";
          var opText = this.getView().byId("OperationText");
          var data = {
-               fDataSet:[ { fId:"1", fSet: "----" } ],
+               fDataSet:[ { key:"1", value: "----" } ],
                fSelectedData: "1",
                fMinRangeX: -1,
                fShowRangeX: false,
@@ -134,15 +134,15 @@ sap.ui.define([
       // approve current fSelectMethodMin value - and change if require
       verifySelectedMethodMin: function(data) {
 
-         this.getView().byId("MethodMin").getBinding("items").filter(new Filter("fId", FilterOperator.EQ, data.fLibrary.toString()));
+         this.getView().byId("MethodMin").getBinding("items").filter(new Filter("key", FilterOperator.EQ, data.fLibrary.toString()));
 
          var first = "";
 
          for (var k=0;k<data.fMethodMinAll.length;++k) {
             var item = data.fMethodMinAll[k];
-            if (item.fId != data.fLibrary) continue;
-            if (!first) first = item.fSet;
-            if (item.fSet === data.fSelectMethodMin) return;
+            if (item.key != data.fLibrary) continue;
+            if (!first) first = item.value;
+            if (item.value === data.fSelectMethodMin) return;
          }
 
          data.fSelectMethodMin = first;

--- a/ui5/fitpanel/controller/FitPanel.controller.js
+++ b/ui5/fitpanel/controller/FitPanel.controller.js
@@ -87,24 +87,6 @@ sap.ui.define([
 
       //Fitting Button
       doFit: function() {
-         //Keep the #times the button is clicked
-         //Data is a new model. With getValue() we select the value of the parameter specified from id
-
-         var errorDefinition = parseFloat(this.getView().byId("errorDef").getValue());
-         var maxTolerance = parseFloat(this.getView().byId("maxTolerance").getValue());
-         var maxInterations = Number(this.getView().byId("maxInterations").getValue());
-
-         var data = this.data();
-
-         data.fErrorDef = errorDefinition;
-         data.fMaxTol = maxTolerance;
-         data.fMaxInter = maxInterations;
-
-         //Refresh the model
-         this.refresh();
-         //Each time we click the button, we keep the current state of the model
-
-
          this.sendModel("DOFIT:");
       },
 
@@ -134,15 +116,15 @@ sap.ui.define([
       // approve current fSelectMethodMin value - and change if require
       verifySelectedMethodMin: function(data) {
 
-         this.getView().byId("MethodMin").getBinding("items").filter(new Filter("key", FilterOperator.EQ, data.fLibrary.toString()));
+         this.getView().byId("MethodMin").getBinding("items").filter(new Filter("lib", FilterOperator.EQ, data.fLibrary));
 
-         var first = "";
+         var first = 0;
 
          for (var k=0;k<data.fMethodMinAll.length;++k) {
             var item = data.fMethodMinAll[k];
-            if (item.key != data.fLibrary) continue;
-            if (!first) first = item.value;
-            if (item.value === data.fSelectMethodMin) return;
+            if (item.lib != data.fLibrary) continue;
+            if (!first) first = item.id;
+            if (item.id === data.fSelectMethodMin) return;
          }
 
          data.fSelectMethodMin = first;

--- a/ui5/fitpanel/controller/FitPanel.controller.js
+++ b/ui5/fitpanel/controller/FitPanel.controller.js
@@ -20,9 +20,7 @@ sap.ui.define([
          // for linev.github.io
          // JSROOT.loadScript('../rootui5/fitpanel/style/style.css');
 
-         var id = this.getView().getId();
          this.inputId = "";
-         var opText = this.getView().byId("OperationText");
          var data = {
                fDataSet:[ { key:"1", value: "----" } ],
                fSelectedData: "1",
@@ -69,13 +67,15 @@ sap.ui.define([
       // Assign the new JSONModel to data
       OnWebsocketMsg: function(handle, msg) {
 
-         if(msg.startsWith("MODEL:")){
+         if(msg.startsWith("MODEL:")) {
             var data = JSROOT.parse(msg.substr(6));
 
             if(data) {
+               this.getView().setModel(new JSONModel(data));
+
                this.verifySelectedMethodMin(data);
 
-               this.getView().setModel(new JSONModel(data));
+               this.refresh();
             }
          } else if (msg.startsWith("PARS:")) {
 
@@ -87,6 +87,7 @@ sap.ui.define([
 
       //Fitting Button
       doFit: function() {
+         console.log('method', this.data().fSelectMethodMin, typeof this.data().fSelectMethodMin);
          this.sendModel("DOFIT:");
       },
 
@@ -106,11 +107,6 @@ sap.ui.define([
 
          if (this.websocket && func)
             this.websocket.Send("GETPARS:" + func);
-
-         //updates the text area and text in selected tab, depending on the choice in TypeXY ComboBox
-         this.byId("OperationText").setValueLiveUpdate();
-         this.byId("OperationText").setValue(func);
-         this.byId("selectedOpText").setText(func);
       },
 
       // approve current fSelectMethodMin value - and change if require

--- a/ui5/fitpanel/view/FitPanel.view.xml
+++ b/ui5/fitpanel/view/FitPanel.view.xml
@@ -7,9 +7,9 @@
            <Text text="Data Set:"/>
            <ComboBox id="DataSet" class="sapUiSmallMarginBeginEnd"
                selectedKey="{/fSelectedData}"
-               items="{ path: '/fDataSet', sorter: { path: 'fSet' } }"
+               items="{ path: '/fDataSet', sorter: { path: 'key' } }"
                change="onSelectedDataChange">
-               <core:Item key="{fId}" text="{fSet}" />
+               <core:Item key="{key}" text="{value}" />
            </ComboBox>
            <Text text="Function:"/>
            <ComboBox id="selectedFuncCombo" class="sapUiSmallMarginBeginEnd"
@@ -28,7 +28,7 @@
                         hSpacing="0.5" vSpacing="0">
                         <ComboBox id="MethodCombo" selectedKey="{/fFitMethod}"
                            items="{ path: '/fFitMethods' }">
-                           <core:Item key="{fId}" text="{fSet}" />
+                           <core:Item key="{key}" text="{value}" />
                            <layoutData>
                               <l:GridData span="XL12 L12 M12 S12" />
                            </layoutData>
@@ -115,8 +115,8 @@
                      </RadioButtonGroup>
                      <Title level="H3" text="Method" />
                      <ComboBox id="MethodMin" selectedKey="{/fSelectMethodMin}"
-                        items="{ path: '/fMethodMinAll', filters: { path: 'fId', operator: 'EQ', value1: '0' },  sorter: { path: 'fId' } }">
-                        <core:Item key="{fSet}" text="{fSet}" />
+                        items="{ path: '/fMethodMinAll', filters: { path: 'key', operator: 'EQ', value1: '0' },  sorter: { path: 'key' } }">
+                        <core:Item key="{value}" text="{value}" />
                      </ComboBox>
                      <Title level="H3" text="Settings" />
                      <l:Grid class="sapUiSizeCompact" hSpacing="0.5" vSpacing="0">
@@ -213,14 +213,14 @@
                               <Text text="Parameter 1:" />
                               <ComboBox id="ContourPar1"
                                  selectedKey="{/fContourPar1Id}"
-                                 items="{ path: '/fContour1', sorter: { path: 'fSet' } }">
-                                 <core:Item key="{fId}" text="{fSet}" />
+                                 items="{ path: '/fContour1', sorter: { path: 'value' } }">
+                                 <core:Item key="{key}" text="{value}" />
                               </ComboBox>
                               <Text text="Parameter 2:" />
                               <ComboBox id="ContourPar2"
                                  selectedKey="{/fContourPar2Id}"
-                                 items="{ path: '/fContour2', sorter: { path: 'fSet' } }">
-                                 <core:Item key="{fId}" text="{fSet}" />
+                                 items="{ path: '/fContour2', sorter: { path: 'value' } }">
+                                 <core:Item key="{key}" text="{value}" />
                               </ComboBox>
                               <Text text="Confidene Level:" />
                               <StepInput id="ConfLevel" value="0.683"
@@ -247,8 +247,8 @@
                               <Text text="Parameter:" />
                               <ComboBox id="ScanPar"
                                  selectedKey="{/fScanId}"
-                                 items="{ path: '/fScan', sorter: { path: 'fSet' } }">
-                                 <core:Item key="{fId}" text="{fSet}" />
+                                 items="{ path: '/fScan', sorter: { path: 'value' } }">
+                                 <core:Item key="{key}" text="{value}" />
                               </ComboBox>
                               <Text text="Min:" />
                               <StepInput id="scanMin" value="0.0001"

--- a/ui5/fitpanel/view/FitPanel.view.xml
+++ b/ui5/fitpanel/view/FitPanel.view.xml
@@ -3,20 +3,34 @@
    xmlns:l="sap.ui.layout" controllerName="rootui5.fitpanel.controller.FitPanel">
    <Page id="simplefitpanel_page" title="Simple Fit Panel" showHeader="false">
       <VBox class="sapUiSizeCompact sapUiSmallMarginStart" width="100%">
-         <l:Grid class="sapUiSizeCompact" defaultSpan="XL6 L6 M6 S6"  hSpacing="0.5" vSpacing="0">
-           <Text text="Data Set:"/>
+         <l:Grid class="sapUiSizeCompact" hSpacing="0.5" vSpacing="0">
+           <Text text="Data Set:">
+               <layoutData>
+                  <l:GridData span="XL4 L4 M4 S4" />
+               </layoutData>
+           </Text>
            <ComboBox id="DataSet" class="sapUiSmallMarginBeginEnd"
                selectedKey="{/fSelectedData}"
                items="{ path: '/fDataSet', sorter: { path: 'key' } }"
                change="onSelectedDataChange">
                <core:Item key="{key}" text="{value}" />
+               <layoutData>
+                  <l:GridData span="XL8 L8 M8 S8" />
+               </layoutData>
            </ComboBox>
-           <Text text="Function:"/>
+           <Text text="Function:">
+               <layoutData>
+                  <l:GridData span="XL4 L4 M4 S4" />
+               </layoutData>
+           </Text>
            <ComboBox id="selectedFuncCombo" class="sapUiSmallMarginBeginEnd"
                selectedKey="{/fSelectedFunc}"
-               items="{ path: '/fFuncList', sorter: { path: 'name' } }"
+               items="{ path: '/fFuncList', sorter: { path: 'group', group: true, descending: false } }"
                change="onSelectedFuncChange">
-               <core:Item key="{name}" text="{name}" />
+               <core:Item key="{id}" text="{name}" />
+               <layoutData>
+                  <l:GridData span="XL8 L8 M8 S8" />
+               </layoutData>
            </ComboBox>
          </l:Grid>
          <IconTabBar id="Gen-Min" headerMode="Inline">
@@ -54,9 +68,9 @@
                         <CheckBox text="Use range" selected="{/fUseRange}"
                            tooltip="'R'-fit only data..." />
                         <CheckBox text="Best errors" selected="{/fBestErrors}"
-                           tooltip="'E'-better ..." />
-                        <CheckBox text="Improve fit results"
-                           selected="{/fImproveFitResults}" tooltip="'M'-after medium is found ..." />
+                           enabled="{= ${/fLinearFit} !== true}" tooltip="'E'-better ..." />
+                        <CheckBox text="Improve fit results" selected="{/fImproveFitResults}"
+                           enabled="{= ${/fLinearFit} !== true}" tooltip="'M'-after medium is found ..." />
                         <CheckBox text="All weights = 1"
                            selected="{/fAllWeights1}" enabled="true"
                            tooltip="'W'-all weights=1 for non-empty bins; eroors bars ignored" />

--- a/ui5/fitpanel/view/FitPanel.view.xml
+++ b/ui5/fitpanel/view/FitPanel.view.xml
@@ -98,9 +98,8 @@
                <IconTabFilter text="Minimization">
                   <VBox>
                      <Title level="H3" text="Library" />
-                     <RadioButtonGroup id="libraryRB"
-                        columns="3" width="100%" selectedIndex="{/fLibrary}"
-                        select="selectRB">
+                     <RadioButtonGroup columns="3" width="100%" selectedIndex="{/fLibrary}"
+                        select="selectMinimizationLibrary">
                         <buttons>
                            <RadioButton id="RB2-1" text="Minuit" />
                            <RadioButton id="RB2-2" text="Minuit2" />
@@ -110,9 +109,9 @@
                         </buttons>
                      </RadioButtonGroup>
                      <Title level="H3" text="Method" />
-                     <ComboBox id="MethodMin" selectedKey="{/fSelectMethodMinId}"
-                        items="{ path: '/fMethodMin', sorter: { path: 'fMethodMin' } }">
-                        <core:Item key="{fId}" text="{fSet}" />
+                     <ComboBox id="MethodMin" selectedKey="{/fSelectMethodMin}"
+                        items="{ path: '/fMethodMinAll', filters: { path: 'fId', operator: 'EQ', value1: '0' },  sorter: { path: 'fId' } }">
+                        <core:Item key="{fSet}" text="{fSet}" />
                      </ComboBox>
                      <Title level="H3" text="Settings" />
                      <l:Grid class="sapUiSizeCompact" hSpacing="0.5" vSpacing="0">

--- a/ui5/fitpanel/view/FitPanel.view.xml
+++ b/ui5/fitpanel/view/FitPanel.view.xml
@@ -26,18 +26,20 @@
                      <Title level="H3" text="Method" />
                      <l:Grid defaultSpan="XL6 L6 M6 S6" class="sapUiSizeCompact"
                         hSpacing="0.5" vSpacing="0">
-                        <ComboBox id="MethodCombo" selectedKey="{/fSelectMethodId}"
-                           items="{ path: '/fMethod', sorter: { path: 'fMethod' } }">
+                        <ComboBox id="MethodCombo" selectedKey="{/fFitMethod}"
+                           items="{ path: '/fFitMethods' }">
                            <core:Item key="{fId}" text="{fSet}" />
+                           <layoutData>
+                              <l:GridData span="XL12 L12 M12 S12" />
+                           </layoutData>
                         </ComboBox>
-                        <Button text="User-Defined..." press="pressUserDefined" />
-                        <CheckBox text="Linear fit" selected="{/fLinear}" />
+                        <CheckBox text="Linear fit" selected="{/fLinearFit}" />
                         <HBox>
                            <CheckBox id="robust123" text="Robust"
-                              enabled="{= ${/fSelectMethodId} === '3'}"
+                              enabled="{= ${/fLinearFit} === true}"
                               selected="{/fRobust}"
                               tooltip="Perform Linear Robust fitter if selected" />
-                           <StepInput value="0.95" min="0.01"
+                           <StepInput value="{/fRobustLevel}" min="0.01"
                               max="1" step="0.01" displayValuePrecision="2"
                               enabled="{= ${/fRobust} === true}"
                               tooltip="Available only for graphs" />
@@ -56,12 +58,12 @@
                         <CheckBox text="Improve fit results"
                            selected="{/fImproveFitResults}" tooltip="'M'-after medium is found ..." />
                         <CheckBox text="All weights = 1"
-                           selected="{/fWeights}" enabled="{= ${/fBins} === false}"
+                           selected="{/fAllWeights1}" enabled="true"
                            tooltip="'W'-all weights=1 for non-empty bins; eroors bars ignored" />
-                        <CheckBox text="Add to list" selected="{/fAddList}"
+                        <CheckBox text="Add to list" selected="{/fAddToList}"
                            tooltip="'+'-add function to the list without deleting the previous" />
                         <CheckBox text="Empty bins, weights=1"
-                           selected="{/fBins}" enabled="{= ${/fWeights} === false}"
+                           selected="{/fEmptyBins1}" enabled="true"
                            tooltip="'WW'-all weights=1 including empty bins; errors bars ignored" />
                         <CheckBox text="Use Gradient" selected="{/fUseGradient}"
                            tooltip="'G'-Use gradient" />
@@ -69,14 +71,17 @@
                      <Title level="H3" text="Draw Options" />
                      <l:Grid class="sapUiSizeCompact" hSpacing="0.5"
                         vSpacing="0">
-                        <CheckBox text="SAME" selected="{/fSame}" />
-                        <CheckBox text="No Drawing" selected="{/fNoDrawing}">
+                        <CheckBox text="SAME" selected="{/fSame}"
+                                  tooltip="Superimpose on previous picture in the same pad"/>
+                        <CheckBox text="No Drawing" selected="{/fNoDrawing}"
+                                  tooltip="'O'-do not draw graphic function">
                            <layoutData>
                               <l:GridData linebreak="true" />
                            </layoutData>
                         </CheckBox>
                         <CheckBox text="Do not store/draw"
-                           selected="{/fNoStoreDraw}">
+                           selected="{/fNoStoreDraw}"
+                           tooltip="'N'-do not store function, do not draw it">
                            <layoutData>
                               <l:GridData linebreak="true"
                                  span="XL6 L6 M6 S6" />
@@ -101,11 +106,11 @@
                      <RadioButtonGroup columns="3" width="100%" selectedIndex="{/fLibrary}"
                         select="selectMinimizationLibrary">
                         <buttons>
-                           <RadioButton id="RB2-1" text="Minuit" />
-                           <RadioButton id="RB2-2" text="Minuit2" />
-                           <RadioButton id="RB2-3" text="Fumili" />
-                           <RadioButton id="RB2-4" text="GSL" />
-                           <RadioButton id="RB2-5" text="Genetics" />
+                           <RadioButton text="Minuit" />
+                           <RadioButton text="Minuit2" />
+                           <RadioButton text="Fumili" />
+                           <RadioButton text="GSL" />
+                           <RadioButton text="Genetics" />
                         </buttons>
                      </RadioButtonGroup>
                      <Title level="H3" text="Method" />

--- a/ui5/fitpanel/view/FitPanel.view.xml
+++ b/ui5/fitpanel/view/FitPanel.view.xml
@@ -11,9 +11,9 @@
            </Text>
            <ComboBox id="DataSet" class="sapUiSmallMarginBeginEnd"
                selectedKey="{/fSelectedData}"
-               items="{ path: '/fDataSet', sorter: { path: 'key' } }"
-               change="onSelectedDataChange">
-               <core:Item key="{key}" text="{value}" />
+               items="{ path: '/fDataSet', sorter: { path: 'group', group: true, descending: false } }"
+                  change="onSelectedDataChange">
+               <core:Item key="{id}" text="{name}" />
                <layoutData>
                   <l:GridData span="XL8 L8 M8 S8" />
                </layoutData>

--- a/ui5/fitpanel/view/FitPanel.view.xml
+++ b/ui5/fitpanel/view/FitPanel.view.xml
@@ -88,12 +88,12 @@
                            </layoutData>
                         </CheckBox>
                      </l:Grid>
-                     <RangeSlider id="SliderX" visible="{/fShowRangeX}"
+                     <RangeSlider id="SliderX" visible="{= ${/fDim} > 0}"
                         showAdvancedTooltip="true" range="{/fRangeX}"
                         min="{/fMinRangeX}" max="{/fMaxRangeX}" step="{/fStepX}"
                         width="100%" showHandleTooltip="false"
                         inputsAsTooltips="true" class="sapUiSmallMarginBottom" />
-                     <RangeSlider id="SliderY" visible="{/fShowRangeY}"
+                     <RangeSlider id="SliderY" visible="{= ${/fDim} > 1}"
                         showAdvancedTooltip="true" range="{/fRangeY}"
                         min="{/fMinRangeY}" max="{/fMaxRangeY}" step="{/fStepY}"
                         width="100%" showHandleTooltip="false"
@@ -110,13 +110,13 @@
                            <RadioButton text="Minuit2" />
                            <RadioButton text="Fumili" />
                            <RadioButton text="GSL" />
-                           <RadioButton text="Genetics" />
+                           <RadioButton text="Genetics" enabled="{/fHasGenetics}"/>
                         </buttons>
                      </RadioButtonGroup>
                      <Title level="H3" text="Method" />
                      <ComboBox id="MethodMin" selectedKey="{/fSelectMethodMin}"
-                        items="{ path: '/fMethodMinAll', filters: { path: 'key', operator: 'EQ', value1: '0' },  sorter: { path: 'key' } }">
-                        <core:Item key="{value}" text="{value}" />
+                        items="{ path: '/fMethodMinAll', filters: { path: 'lib', operator: 'EQ', value1: 0 } }">
+                        <core:Item key="{id}" text="{text}" />
                      </ComboBox>
                      <Title level="H3" text="Settings" />
                      <l:Grid class="sapUiSizeCompact" hSpacing="0.5" vSpacing="0">
@@ -131,8 +131,7 @@
                               <l:GridData span="XL8 L8 M8 S8" />
                            </layoutData>
                         </Text>
-                        <Input id="errorDef" type="Number"
-                           placeholder="1.00">
+                        <Input type="Number" value="{/fErrorDef}" placeholder="1.00">
                            <layoutData>
                               <l:GridData span="XL4 L4 M4 S4" />
                            </layoutData>
@@ -142,8 +141,7 @@
                               <l:GridData span="XL8 L8 M8 S8" />
                            </layoutData>
                         </Text>
-                        <Input id="maxTolerance" type="Number"
-                           placeholder="0.01">
+                        <Input type="Number" value="{/fMaxTolerance}" placeholder="0.01">
                            <layoutData>
                               <l:GridData span="XL4 L4 M4 S4" />
                            </layoutData>
@@ -153,8 +151,7 @@
                               <l:GridData span="XL8 L8 M8 S8" />
                            </layoutData>
                         </Text>
-                        <Input id="maxInterations" type="Number"
-                           placeholder="0">
+                        <Input type="Number" value="{/fMaxIterations}"  placeholder="0">
                            <layoutData>
                               <l:GridData span="XL4 L4 M4 S4" />
                            </layoutData>

--- a/ui5/fitpanel/view/FitPanel.view.xml
+++ b/ui5/fitpanel/view/FitPanel.view.xml
@@ -33,9 +33,9 @@
                </layoutData>
            </ComboBox>
          </l:Grid>
-         <IconTabBar id="Gen-Min" headerMode="Inline">
+         <IconTabBar expandable="false" headerMode="Inline" selectedKey="{/fSelectedTab}">
             <items>
-               <IconTabFilter text="General">
+               <IconTabFilter key="General" text="General">
                   <VBox>
                      <Title level="H3" text="Method" />
                      <l:Grid defaultSpan="XL6 L6 M6 S6" class="sapUiSizeCompact"
@@ -114,7 +114,7 @@
                         inputsAsTooltips="true" class="sapUiSmallMarginBottom"/>
                   </VBox>
                </IconTabFilter>
-               <IconTabFilter text="Minimization">
+               <IconTabFilter key="Minimization" text="Minimization">
                   <VBox>
                      <Title level="H3" text="Library" />
                      <RadioButtonGroup columns="3" width="100%" selectedIndex="{/fLibrary}"
@@ -182,7 +182,7 @@
                      </RadioButtonGroup>
                   </VBox>
                </IconTabFilter>
-               <IconTabFilter text="Pars" visible="{/fFuncPars/haspars}">
+               <IconTabFilter key="Pars" text="Pars" visible="{/fFuncPars/haspars}">
                    <HBox>
                       <Text text="Func: {/fFuncPars/name}"/>
                       <Button press="pressApplyPars" text="Apply" tooltip="Set parameters"/>
@@ -210,10 +210,10 @@
                       </items>
                    </Table>
                </IconTabFilter>
-               <IconTabFilter text="Advanced" visible="{/fHasAdvanced}">
-                  <IconTabBar id="AdvancedOptions" headerMode="Inline">
+               <IconTabFilter key="Advanced" text="Advanced" visible="{/fHasAdvanced}">
+                  <IconTabBar headerMode="Inline" expandable="false" selectedKey="{/fAdvancedTab}">
                      <items>
-                        <IconTabFilter text="Contour">
+                        <IconTabFilter key="Contour" text="Contour">
                            <l:Grid defaultSpan="XL6 L6 M6 S6"
                               class="sapUiSizeCompact" hSpacing="0.5"
                               vSpacing="0">
@@ -247,7 +247,7 @@
                                  text="Super impose" selected="{/fContourImpose}" />
                            </l:Grid>
                         </IconTabFilter>
-                        <IconTabFilter text="Scan">
+                        <IconTabFilter key="Scan" text="Scan">
                            <l:Grid defaultSpan="XL6 L6 M6 S6"
                               class="sapUiSizeCompact" hSpacing="0.5"
                               vSpacing="0">
@@ -271,7 +271,7 @@
                                  editable="true" displayValuePrecision="4" />
                            </l:Grid>
                         </IconTabFilter>
-                        <IconTabFilter text="Conf Intervals">
+                        <IconTabFilter key="Intervals" text="Conf Intervals">
                            <l:Grid defaultSpan="XL6 L6 M6 S6"
                               class="sapUiSizeCompact" hSpacing="0.5"
                               vSpacing="0">
@@ -285,16 +285,16 @@
                         </IconTabFilter>
                      </items>
                   </IconTabBar>
-                  <Button text="Draw" press="" />
-                  <Button text="Close" press="" />
                </IconTabFilter>
             </items>
          </IconTabBar>
       </VBox>
       <footer>
          <Toolbar>
+            <Button text="Update" press="doUpdate" tooltip="Update panel content from server" />
             <ToolbarSpacer/>
             <Button text="Fit" press="doFit" tooltip="Fit the histogram" />
+            <Button text="Draw" press="doDraw" tooltip="Draw histogram and selected function" />
             <Button text="Close" press="closePanel" tooltip="Close the Fit Panel" />
          </Toolbar>
       </footer>


### PR DESCRIPTION
ui5 ComboBox allow grouping of items. 
This is used now to show different data and TF1 groups in same combo box

For data it can be:
  - objects from gDirectory
  - local list of FitPanel itself

For functions these are:
  - existing system functions;
  - predefined list of 1d and 2d function like "gaus" or "xygaus"
  - list of previous fits for selected data

Provide support of other data types (excluding TTree for the moment)

Provide preliminary code for Draw button.

Constantly improving layout, removing unused code

Not the end of the story, but layout is clarified now.