### PR TITLE
Make sure the output file is closed before committing

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -5027,6 +5027,9 @@ int RootClingMain(int argc,
    // Add the warnings
    rootclingRetCode += ROOT::TMetaUtils::GetNumberOfErrors();
 
+   // make sure the file is closed before committing
+   fileout.close();
+
    // Before returning, rename the files if no errors occurred
    // otherwise clean them to avoid remnants (see ROOT-10015)
    if(rootclingRetCode == 0) {


### PR DESCRIPTION
This solves a potential incomplete dictionary generation issue on Windows (the file was copied before being properly closed and temporary files were left on the file system)