### PR TITLE
[forest] fix RFieldValue class design

### DIFF
--- a/tree/forest/v7/inc/ROOT/RField.hxx
+++ b/tree/forest/v7/inc/ROOT/RField.hxx
@@ -91,8 +91,8 @@ protected:
 
    /// Operations on values of complex types, e.g. ones that involve multiple columns or for which no direct
    /// column type exists.
-   virtual void DoAppend(const RFieldValueBase& value);
-   virtual void DoRead(ForestSize_t index, RFieldValueBase* value);
+   virtual void DoAppend(const RFieldValue& value);
+   virtual void DoRead(ForestSize_t index, RFieldValue* value);
    virtual void DoReadV(ForestSize_t index, ForestSize_t count, void* dst);
 
 public:
@@ -151,20 +151,20 @@ public:
    virtual unsigned int GetNColumns() const = 0;
 
    /// Generates a tree value of the field type and allocates new initialized memory according to the type.
-   RFieldValueBase GenerateValue();
+   RFieldValue GenerateValue();
    /// Generates a tree value in a given location of size at least GetValueSize(). Assumes that where has been
    /// allocated by malloc().
-   virtual RFieldValueBase GenerateValue(void *where) = 0;
+   virtual RFieldValue GenerateValue(void *where) = 0;
    /// Releases the resources acquired during GenerateValue (memory and constructor)
    /// This implementation works for simple types but needs to be overwritten for complex ones
-   virtual void DestroyValue(const RFieldValueBase &value, bool dtorOnly = false);
+   virtual void DestroyValue(const RFieldValue &value, bool dtorOnly = false);
    /// Creates a value from a memory location with an already constructed object
-   virtual RFieldValueBase CaptureValue(void *where) = 0;
+   virtual RFieldValue CaptureValue(void *where) = 0;
    /// The number of bytes taken by a value of the appropriate type
    virtual size_t GetValueSize() const = 0;
 
-   /// Write the given value to a tree. The value object has to be of the same type as the field.
-   void Append(const RFieldValueBase& value) {
+   /// Write the given value into columns. The value object has to be of the same type as the field.
+   void Append(const RFieldValue& value) {
       if (!fIsSimple) {
          DoAppend(value);
          return;
@@ -175,7 +175,7 @@ public:
 
    /// Populate a single value with data from the tree, which needs to be of the fitting type.
    /// Reading copies data into the memory wrapped by the tree value.
-   void Read(ForestSize_t index, RFieldValueBase* value) {
+   void Read(ForestSize_t index, RFieldValue* value) {
       if (!fIsSimple) {
          DoRead(index, value);
          return;
@@ -230,8 +230,8 @@ public:
    void DoGenerateColumns() final {}
    unsigned int GetNColumns() const final { return 0; }
    using Detail::RFieldBase::GenerateValue;
-   Detail::RFieldValueBase GenerateValue(void*) { return Detail::RFieldValueBase(); }
-   Detail::RFieldValueBase CaptureValue(void*) final { return Detail::RFieldValueBase(); }
+   Detail::RFieldValue GenerateValue(void*) { return Detail::RFieldValue(); }
+   Detail::RFieldValue CaptureValue(void*) final { return Detail::RFieldValue(); }
    size_t GetValueSize() const final { return 0; }
 
    /// Generates managed values for the top-level sub fields
@@ -243,8 +243,8 @@ class RFieldClass : public Detail::RFieldBase {
 private:
    TClass* fClass;
 protected:
-   void DoAppend(const Detail::RFieldValueBase& value) final;
-   void DoRead(ForestSize_t index, Detail::RFieldValueBase* value) final;
+   void DoAppend(const Detail::RFieldValue& value) final;
+   void DoRead(ForestSize_t index, Detail::RFieldValue* value) final;
 public:
    RFieldClass(std::string_view fieldName, std::string_view className);
    RFieldClass(RFieldClass&& other) = default;
@@ -255,9 +255,9 @@ public:
    void DoGenerateColumns() final;
    unsigned int GetNColumns() const final;
    using Detail::RFieldBase::GenerateValue;
-   Detail::RFieldValueBase GenerateValue(void* where) override;
-   void DestroyValue(const Detail::RFieldValueBase& value, bool dtorOnly = false) final;
-   Detail::RFieldValueBase CaptureValue(void *where) final;
+   Detail::RFieldValue GenerateValue(void* where) override;
+   void DestroyValue(const Detail::RFieldValue& value, bool dtorOnly = false) final;
+   Detail::RFieldValue CaptureValue(void *where) final;
    size_t GetValueSize() const override;
 };
 
@@ -268,8 +268,8 @@ private:
    ClusterSize_t fNWritten;
 
 protected:
-   void DoAppend(const Detail::RFieldValueBase& value) final;
-   void DoRead(ForestSize_t index, Detail::RFieldValueBase* value) final;
+   void DoAppend(const Detail::RFieldValue& value) final;
+   void DoRead(ForestSize_t index, Detail::RFieldValue* value) final;
 
 public:
    RFieldVector(std::string_view fieldName, std::unique_ptr<Detail::RFieldBase> itemField);
@@ -281,9 +281,9 @@ public:
    void DoGenerateColumns() final;
    unsigned int GetNColumns() const final;
    using Detail::RFieldBase::GenerateValue;
-   Detail::RFieldValueBase GenerateValue(void* where) override;
-   void DestroyValue(const Detail::RFieldValueBase& value, bool dtorOnly = false) final;
-   Detail::RFieldValueBase CaptureValue(void *where) override;
+   Detail::RFieldValue GenerateValue(void* where) override;
+   void DestroyValue(const Detail::RFieldValue& value, bool dtorOnly = false) final;
+   Detail::RFieldValue CaptureValue(void *where) override;
    size_t GetValueSize() const override;
    void CommitCluster() final;
 };
@@ -303,11 +303,11 @@ public:
 
    using Detail::RFieldBase::GenerateValue;
    template <typename... ArgsT>
-   ROOT::Experimental::Detail::RFieldValueBase GenerateValue(void* where, ArgsT&&... args)
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
-      return ROOT::Experimental::RFieldValue<T>(this, static_cast<T*>(where), std::forward<ArgsT>(args)...);
+      return Detail::RFieldValue(this, static_cast<T*>(where), std::forward<ArgsT>(args)...);
    }
-   ROOT::Experimental::Detail::RFieldValueBase GenerateValue(void* where) final { return GenerateValue(where, T()); }
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, T()); }
 };
 
 
@@ -329,15 +329,14 @@ public:
    unsigned int GetNColumns() const final { return 1; }
 
    using Detail::RFieldBase::GenerateValue;
-   ROOT::Experimental::Detail::RFieldValueBase GenerateValue(void* where) final {
-      return ROOT::Experimental::RFieldValue<ClusterSize_t>(
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final {
+      return Detail::RFieldValue(
          Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex>(static_cast<ClusterSize_t*>(where)),
          this, static_cast<ClusterSize_t*>(where));
    }
-   Detail::RFieldValueBase CaptureValue(void* where) final {
-      return ROOT::Experimental::RFieldValue<ClusterSize_t>(true,
-         Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex>(static_cast<ClusterSize_t*>(where)),
-         this, static_cast<ClusterSize_t*>(where));
+   Detail::RFieldValue CaptureValue(void* where) final {
+      return Detail::RFieldValue(true /* captureFlag */,
+         Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex>(static_cast<ClusterSize_t*>(where)), this, where);
    }
    size_t GetValueSize() const final { return 0; }
    void CommitCluster() final;
@@ -369,19 +368,16 @@ public:
 
    using Detail::RFieldBase::GenerateValue;
    template <typename... ArgsT>
-   ROOT::Experimental::Detail::RFieldValueBase GenerateValue(void* where, ArgsT&&... args)
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
-      ROOT::Experimental::RFieldValue<ClusterSize_t> v(
+      return Detail::RFieldValue(
          Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex>(static_cast<ClusterSize_t*>(where)),
          this, static_cast<ClusterSize_t*>(where), std::forward<ArgsT>(args)...);
-      return v;
    }
-   ROOT::Experimental::Detail::RFieldValueBase GenerateValue(void* where) final { return GenerateValue(where, 0); }
-   Detail::RFieldValueBase CaptureValue(void *where) final {
-      ROOT::Experimental::RFieldValue<ClusterSize_t> v(true,
-         Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex>(static_cast<ClusterSize_t*>(where)),
-         this, static_cast<ClusterSize_t*>(where));
-      return v;
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0); }
+   Detail::RFieldValue CaptureValue(void *where) final {
+      return Detail::RFieldValue(true /* captureFlag */,
+         Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex>(static_cast<ClusterSize_t*>(where)), this, where);
    }
    size_t GetValueSize() const final { return sizeof(ClusterSize_t); }
 
@@ -417,19 +413,16 @@ public:
 
    using Detail::RFieldBase::GenerateValue;
    template <typename... ArgsT>
-   ROOT::Experimental::Detail::RFieldValueBase GenerateValue(void* where, ArgsT&&... args)
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
-      ROOT::Experimental::RFieldValue<float> v(
+      return Detail::RFieldValue(
          Detail::RColumnElement<float, EColumnType::kReal32>(static_cast<float*>(where)),
          this, static_cast<float*>(where), std::forward<ArgsT>(args)...);
-      return v;
    }
-   ROOT::Experimental::Detail::RFieldValueBase GenerateValue(void* where) final { return GenerateValue(where, 0.0); }
-   Detail::RFieldValueBase CaptureValue(void *where) final {
-      ROOT::Experimental::RFieldValue<float> v(true,
-         Detail::RColumnElement<float, EColumnType::kReal32>(static_cast<float*>(where)),
-         this, static_cast<float*>(where));
-      return v;
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0.0); }
+   Detail::RFieldValue CaptureValue(void *where) final {
+      return Detail::RFieldValue(true /* captureFlag */,
+         Detail::RColumnElement<float, EColumnType::kReal32>(static_cast<float*>(where)), this, where);
    }
    size_t GetValueSize() const final { return sizeof(float); }
 };
@@ -457,19 +450,16 @@ public:
 
    using Detail::RFieldBase::GenerateValue;
    template <typename... ArgsT>
-   ROOT::Experimental::Detail::RFieldValueBase GenerateValue(void* where, ArgsT&&... args)
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
-      ROOT::Experimental::RFieldValue<double> v(
+      return Detail::RFieldValue(
          Detail::RColumnElement<double, EColumnType::kReal64>(static_cast<double*>(where)),
          this, static_cast<double*>(where), std::forward<ArgsT>(args)...);
-      return v;
    }
-   ROOT::Experimental::Detail::RFieldValueBase GenerateValue(void* where) final { return GenerateValue(where, 0.0); }
-   Detail::RFieldValueBase CaptureValue(void *where) final {
-      ROOT::Experimental::RFieldValue<double> v(true,
-         Detail::RColumnElement<double, EColumnType::kReal64>(static_cast<double*>(where)),
-         this, static_cast<double*>(where));
-      return v;
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0.0); }
+   Detail::RFieldValue CaptureValue(void *where) final {
+      return Detail::RFieldValue(true /* captureFlag */,
+         Detail::RColumnElement<double, EColumnType::kReal64>(static_cast<double*>(where)), this, where);
    }
    size_t GetValueSize() const final { return sizeof(double); }
 };
@@ -496,19 +486,16 @@ public:
 
    using Detail::RFieldBase::GenerateValue;
    template <typename... ArgsT>
-   ROOT::Experimental::Detail::RFieldValueBase GenerateValue(void* where, ArgsT&&... args)
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
-      ROOT::Experimental::RFieldValue<std::int32_t> v(
+      return Detail::RFieldValue(
          Detail::RColumnElement<std::int32_t, EColumnType::kInt32>(static_cast<std::int32_t*>(where)),
          this, static_cast<std::int32_t*>(where), std::forward<ArgsT>(args)...);
-      return v;
    }
-   ROOT::Experimental::Detail::RFieldValueBase GenerateValue(void* where) final { return GenerateValue(where, 0); }
-   Detail::RFieldValueBase CaptureValue(void *where) final {
-      ROOT::Experimental::RFieldValue<std::int32_t> v(true,
-         Detail::RColumnElement<std::int32_t, EColumnType::kInt32>(static_cast<std::int32_t*>(where)),
-         this, static_cast<std::int32_t*>(where));
-      return v;
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0); }
+   Detail::RFieldValue CaptureValue(void *where) final {
+      return Detail::RFieldValue(true /* captureFlag */,
+         Detail::RColumnElement<std::int32_t, EColumnType::kInt32>(static_cast<std::int32_t*>(where)), this, where);
    }
    size_t GetValueSize() const final { return sizeof(std::int32_t); }
 };
@@ -535,19 +522,16 @@ public:
 
    using Detail::RFieldBase::GenerateValue;
    template <typename... ArgsT>
-   ROOT::Experimental::Detail::RFieldValueBase GenerateValue(void* where, ArgsT&&... args)
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
-      ROOT::Experimental::RFieldValue<std::uint32_t> v(
+      return Detail::RFieldValue(
          Detail::RColumnElement<std::uint32_t, EColumnType::kInt32>(static_cast<std::uint32_t*>(where)),
          this, static_cast<std::uint32_t*>(where), std::forward<ArgsT>(args)...);
-      return v;
    }
-   ROOT::Experimental::Detail::RFieldValueBase GenerateValue(void* where) final { return GenerateValue(where, 0); }
-   Detail::RFieldValueBase CaptureValue(void *where) final {
-      ROOT::Experimental::RFieldValue<std::uint32_t> v(true,
-         Detail::RColumnElement<std::uint32_t, EColumnType::kInt32>(static_cast<std::uint32_t*>(where)),
-         this, static_cast<std::uint32_t*>(where));
-      return v;
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0); }
+   Detail::RFieldValue CaptureValue(void *where) final {
+      return Detail::RFieldValue(true /* captureFlag */,
+         Detail::RColumnElement<std::uint32_t, EColumnType::kInt32>(static_cast<std::uint32_t*>(where)), this, where);
    }
    size_t GetValueSize() const final { return sizeof(std::uint32_t); }
 };
@@ -574,19 +558,16 @@ public:
 
    using Detail::RFieldBase::GenerateValue;
    template <typename... ArgsT>
-   ROOT::Experimental::Detail::RFieldValueBase GenerateValue(void* where, ArgsT&&... args)
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
-      ROOT::Experimental::RFieldValue<std::uint64_t> v(
+      return Detail::RFieldValue(
          Detail::RColumnElement<std::uint64_t, EColumnType::kInt64>(static_cast<std::uint64_t*>(where)),
          this, static_cast<std::uint64_t*>(where), std::forward<ArgsT>(args)...);
-      return v;
    }
-   ROOT::Experimental::Detail::RFieldValueBase GenerateValue(void* where) final { return GenerateValue(where, 0); }
-   Detail::RFieldValueBase CaptureValue(void *where) final {
-      ROOT::Experimental::RFieldValue<std::uint64_t> v(true,
-         Detail::RColumnElement<std::uint64_t, EColumnType::kInt64>(static_cast<std::uint64_t*>(where)),
-         this, static_cast<std::uint64_t*>(where));
-      return v;
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0); }
+   Detail::RFieldValue CaptureValue(void *where) final {
+      return Detail::RFieldValue(true /* captureFlag */,
+         Detail::RColumnElement<std::uint64_t, EColumnType::kInt64>(static_cast<std::uint64_t*>(where)), this, where);
    }
    size_t GetValueSize() const final { return sizeof(std::uint64_t); }
 };
@@ -598,8 +579,8 @@ private:
    ClusterSize_t fIndex;
    Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex> fElemIndex;
 
-   void DoAppend(const ROOT::Experimental::Detail::RFieldValueBase& value) final;
-   void DoRead(ROOT::Experimental::ForestSize_t index, ROOT::Experimental::Detail::RFieldValueBase* value) final;
+   void DoAppend(const ROOT::Experimental::Detail::RFieldValue& value) final;
+   void DoRead(ROOT::Experimental::ForestSize_t index, ROOT::Experimental::Detail::RFieldValue* value) final;
 
 public:
    static std::string MyTypeName() { return "std::string"; }
@@ -616,20 +597,19 @@ public:
 
    using Detail::RFieldBase::GenerateValue;
    template <typename... ArgsT>
-   ROOT::Experimental::Detail::RFieldValueBase GenerateValue(void* where, ArgsT&&... args)
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
-      return ROOT::Experimental::RFieldValue<std::string>(
-         this, static_cast<std::string*>(where), std::forward<ArgsT>(args)...);
+      return Detail::RFieldValue(this, static_cast<std::string*>(where), std::forward<ArgsT>(args)...);
    }
-   ROOT::Experimental::Detail::RFieldValueBase GenerateValue(void* where) final { return GenerateValue(where, ""); }
-   void DestroyValue(const Detail::RFieldValueBase& value, bool dtorOnly = false) {
-      auto str = static_cast<std::string*>(value.GetRawPtr());
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, ""); }
+   void DestroyValue(const Detail::RFieldValue& value, bool dtorOnly = false) {
+      auto str = value.Get<std::string>();
       str->~basic_string(); // TODO(jblomer) C++17 std::destroy_at
       if (!dtorOnly)
          free(str);
    }
-   Detail::RFieldValueBase CaptureValue(void *where) {
-      return ROOT::Experimental::RFieldValue<std::string>(true, this, static_cast<std::string*>(where));
+   Detail::RFieldValue CaptureValue(void *where) {
+      return Detail::RFieldValue(true /* captureFlag */, this, where);
    }
    size_t GetValueSize() const final { return sizeof(std::string); }
    void CommitCluster() final;
@@ -650,16 +630,15 @@ public:
 
    using Detail::RFieldBase::GenerateValue;
    template <typename... ArgsT>
-   ROOT::Experimental::Detail::RFieldValueBase GenerateValue(void* where, ArgsT&&... args)
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
-      return ROOT::Experimental::RFieldValue<ContainerT>(
-         this, static_cast<ContainerT*>(where), std::forward<ArgsT>(args)...);
+      return Detail::RFieldValue(this, static_cast<ContainerT*>(where), std::forward<ArgsT>(args)...);
    }
-   ROOT::Experimental::Detail::RFieldValueBase GenerateValue(void* where) final {
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final {
       return GenerateValue(where, ContainerT());
    }
-   Detail::RFieldValueBase CaptureValue(void *where) final {
-      return ROOT::Experimental::RFieldValue<ContainerT>(true, this, static_cast<ContainerT*>(where));
+   Detail::RFieldValue CaptureValue(void *where) final {
+      return Detail::RFieldValue(true /* captureFlag */, this, where);
    }
    size_t GetValueSize() const final { return sizeof(ContainerT); }
 };
@@ -677,8 +656,8 @@ private:
    ClusterSize_t fNWritten;
 
 protected:
-   void DoAppend(const Detail::RFieldValueBase& value) final {
-      auto typedValue = reinterpret_cast<ContainerT*>(value.GetRawPtr());
+   void DoAppend(const Detail::RFieldValue& value) final {
+      auto typedValue = value.Get<ContainerT>();
       auto count = typedValue->size();
       for (unsigned i = 0; i < count; ++i) {
          auto itemValue = fSubFields[0]->CaptureValue(&typedValue->data()[i]);
@@ -688,8 +667,8 @@ protected:
       fNWritten += count;
       fColumns[0]->Append(elemIndex);
    }
-   void DoRead(ForestSize_t index, Detail::RFieldValueBase* value) final {
-      auto typedValue = reinterpret_cast<ContainerT*>(value->GetRawPtr());
+   void DoRead(ForestSize_t index, Detail::RFieldValue* value) final {
+      auto typedValue = value->Get<ContainerT>();
       ClusterSize_t nItems;
       ForestSize_t idxStart;
       fPrincipalColumn->GetCollectionInfo(index, &idxStart, &nItems);
@@ -726,7 +705,7 @@ public:
       fPrincipalColumn = fColumns[0].get();
    }
    unsigned int GetNColumns() const final { return 1; }
-   void DestroyValue(const Detail::RFieldValueBase& value, bool dtorOnly = false) final {
+   void DestroyValue(const Detail::RFieldValue& value, bool dtorOnly = false) final {
       auto vec = reinterpret_cast<ContainerT*>(value.GetRawPtr());
       auto nItems = vec->size();
       for (unsigned i = 0; i < nItems; ++i) {
@@ -743,16 +722,15 @@ public:
 
    using Detail::RFieldBase::GenerateValue;
    template <typename... ArgsT>
-   ROOT::Experimental::Detail::RFieldValueBase GenerateValue(void* where, ArgsT&&... args)
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
-      return ROOT::Experimental::RFieldValue<ContainerT>(
-         this, static_cast<ContainerT*>(where), std::forward<ArgsT>(args)...);
+      return Detail::RFieldValue(this, static_cast<ContainerT*>(where), std::forward<ArgsT>(args)...);
    }
-   ROOT::Experimental::Detail::RFieldValueBase GenerateValue(void* where) final {
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final {
       return GenerateValue(where, ContainerT());
    }
-   Detail::RFieldValueBase CaptureValue(void *where) final {
-      return ROOT::Experimental::RFieldValue<ContainerT>(true, this, static_cast<ContainerT*>(where));
+   Detail::RFieldValue CaptureValue(void *where) final {
+      return Detail::RFieldValue(true /* captureFlag */, this, static_cast<ContainerT*>(where));
    }
    size_t GetValueSize() const final { return sizeof(ContainerT); }
 };

--- a/tree/forest/v7/inc/ROOT/RForestEntry.hxx
+++ b/tree/forest/v7/inc/ROOT/RForestEntry.hxx
@@ -40,7 +40,7 @@ that are associated to values are managed.
 */
 // clang-format on
 class RForestEntry {
-   std::vector<Detail::RFieldValueBase> fValues;
+   std::vector<Detail::RFieldValue> fValues;
    /// The objects involed in serialization and deserialization might be used long after the entry is gone:
    /// hence the shared pointer
    std::vector<std::shared_ptr<void>> fValuePtrs;
@@ -54,26 +54,26 @@ public:
    ~RForestEntry();
 
    /// Adds a value whose storage is managed by the entry
-   void AddValue(const Detail::RFieldValueBase& value);
+   void AddValue(const Detail::RFieldValue& value);
 
    /// Adds a value whose storage is _not_ managed by the entry
-   void CaptureValue(const Detail::RFieldValueBase& value);
+   void CaptureValue(const Detail::RFieldValue& value);
 
    /// While building the entry, adds a new value to the list and return the value's shared pointer
    template<typename T, typename... ArgsT>
    std::shared_ptr<T> AddValue(RField<T>* field, ArgsT&&... args) {
       auto ptr = std::make_shared<T>(std::forward<ArgsT>(args)...);
-      fValues.emplace_back(Detail::RFieldValueBase(field->CaptureValue(ptr.get())));
+      fValues.emplace_back(Detail::RFieldValue(field->CaptureValue(ptr.get())));
       fValuePtrs.emplace_back(ptr);
       return ptr;
    }
 
-   Detail::RFieldValueBase GetValue(std::string_view fieldName) {
+   Detail::RFieldValue GetValue(std::string_view fieldName) {
       for (auto& v : fValues) {
          if (v.GetField()->GetName() == fieldName)
             return v;
       }
-      return Detail::RFieldValueBase();
+      return Detail::RFieldValue();
    }
 
    template<typename T>

--- a/tree/forest/v7/inc/ROOT/RForestView.hxx
+++ b/tree/forest/v7/inc/ROOT/RForestView.hxx
@@ -87,7 +87,7 @@ class RForestView {
 
 protected:
    RField<T> fField;
-   RFieldValue<T> fValue;
+   Detail::RFieldValue fValue;
    RForestView(std::string_view fieldName, Detail::RPageSource* pageSource)
      : fField(fieldName), fValue(fField.GenerateValue())
    {
@@ -106,7 +106,7 @@ public:
 
    const T& operator()(ForestSize_t index) {
       fField.Read(index, &fValue);
-      return *fValue.Get();
+      return *fValue.Get<T>();
    }
 };
 

--- a/tree/forest/v7/src/RForestEntry.cxx
+++ b/tree/forest/v7/src/RForestEntry.cxx
@@ -23,13 +23,13 @@ ROOT::Experimental::RForestEntry::~RForestEntry()
    }
 }
 
-void ROOT::Experimental::RForestEntry::AddValue(const Detail::RFieldValueBase& value)
+void ROOT::Experimental::RForestEntry::AddValue(const Detail::RFieldValue& value)
 {
    fManagedValues.emplace_back(fValues.size());
    fValues.push_back(value);
 }
 
-void ROOT::Experimental::RForestEntry::CaptureValue(const Detail::RFieldValueBase& value)
+void ROOT::Experimental::RForestEntry::CaptureValue(const Detail::RFieldValue& value)
 {
    fValues.push_back(value);
 }


### PR DESCRIPTION
Remove class hierarchy in RFieldValue.  The templated, type-safe
inherited classes made the design vulnerable to slicing, because the
RField interface uses the base class.  Instead, we use now templated
constructors and templated member functions in RFieldValue.