### PR TITLE
[Exp PyROOT] Changes to fix python-cpp tests

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
@@ -44,6 +44,7 @@ set(sources
   src/TClonesArrayPyz.cxx
   src/TDirectoryPyz.cxx
   src/TFilePyz.cxx
+  src/TObjectPyz.cxx
   src/TTreePyz.cxx
   src/PyzCppHelpers.cxx
   src/PyzPythonHelpers.cxx

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/_facade.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/_facade.py
@@ -30,7 +30,7 @@ class ROOTFacade(types.ModuleType):
         self.gROOT = gROOT
 
         # Expose some functionality from CPyCppyy extension module
-        cppyy_exports = [ 'Double', 'Long', 'nullptr' ]
+        cppyy_exports = [ 'Double', 'Long', 'nullptr', 'addressof' ]
         for name in cppyy_exports:
             setattr(self, name, getattr(cppyy_backend, name))
 

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/_facade.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/_facade.py
@@ -30,7 +30,7 @@ class ROOTFacade(types.ModuleType):
         self.gROOT = gROOT
 
         # Expose some functionality from CPyCppyy extension module
-        cppyy_exports = [ 'Double', 'Long', 'nullptr', 'addressof' ]
+        cppyy_exports = [ 'Double', 'Long', 'nullptr', 'addressof', 'bind_object' ]
         for name in cppyy_exports:
             setattr(self, name, getattr(cppyy_backend, name))
 

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tobject.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tobject.py
@@ -9,6 +9,7 @@
 ################################################################################
 
 from ROOT import pythonization
+from libROOTPython import AddTObjectEqNePyz
 import cppyy
 
 # Searching
@@ -23,18 +24,6 @@ def _contains(self, o):
     return bool(self.FindObject(o))
 
 # Comparison operators
-
-def _eq(self, o):
-    if isinstance(o, cppyy.gbl.TObject):
-        return self.IsEqual(o)
-    else:
-        return False
-
-def _ne(self, o):
-    if isinstance(o, cppyy.gbl.TObject):
-        return not self.IsEqual(o)
-    else:
-        return True
 
 def _lt(self, o):
     if isinstance(o, cppyy.gbl.TObject):
@@ -69,8 +58,7 @@ def pythonize_tobject():
     klass.__contains__ = _contains
 
     # Inject comparison operators
-    klass.__eq__ = _eq
-    klass.__ne__ = _ne
+    AddTObjectEqNePyz(klass)
     klass.__lt__ = _lt
     klass.__le__ = _le
     klass.__gt__ = _gt

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
@@ -48,6 +48,8 @@ static PyMethodDef gPyROOTMethods[] = {{(char *)"AddDirectoryWritePyz", (PyCFunc
                                         (char *)"Make TFile::Open a constructor, adjusting for example the reference count"},
                                         {(char *)"AddTClassDynamicCastPyz", (PyCFunction)PyROOT::AddTClassDynamicCastPyz, METH_VARARGS,
                                         (char *)"Cast the void* returned by TClass::DynamicCast to the right type"},
+                                        {(char *)"AddTObjectEqNePyz", (PyCFunction)PyROOT::AddTObjectEqNePyz, METH_VARARGS,
+                                        (char *)"Add equality and inequality comparison operators to TObject"},
                                        {(char *)"SetBranchAddressPyz", (PyCFunction)PyROOT::SetBranchAddressPyz, METH_VARARGS,
                                         (char *)"Fully enable the use of TTree::SetBranchAddress from Python"},
                                        {(char *)"BranchPyz", (PyCFunction)PyROOT::BranchPyz, METH_VARARGS,

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
@@ -28,6 +28,8 @@ PyObject *SetBranchAddressPyz(PyObject *self, PyObject *args);
 
 PyObject *AddTClassDynamicCastPyz(PyObject *self, PyObject *args);
 
+PyObject *AddTObjectEqNePyz(PyObject *self, PyObject *args);
+
 PyObject *AddSetItemTCAPyz(PyObject *self, PyObject *args);
 
 PyObject *AsRVec(PyObject *self, PyObject *obj);

--- a/bindings/pyroot_experimental/PyROOT/src/PyzCppHelpers.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyzCppHelpers.cxx
@@ -21,12 +21,33 @@ pythonizations.
 #include "CPPInstance.h"
 #include "TClass.h"
 
+// Call method with signature: obj->meth()
 PyObject *CallPyObjMethod(PyObject *obj, const char *meth)
 {
-   // Helper; call method with signature: obj->meth()
-   return PyObject_CallMethod(obj, const_cast<char*>(meth), const_cast<char*>(""));
+   return PyObject_CallMethod(obj, const_cast<char *>(meth), const_cast<char *>(""));
 }
 
+// Call method with signature: obj->meth(arg1)
+PyObject *CallPyObjMethod(PyObject *obj, const char *meth, PyObject *arg1)
+{
+   return PyObject_CallMethod(obj, const_cast<char *>(meth), const_cast<char *>("O"), arg1);
+}
+
+// Convert generic python object into a boolean value
+PyObject *BoolNot(PyObject *value)
+{
+   if (PyObject_IsTrue(value) == 1) {
+      Py_INCREF(Py_False);
+      Py_DECREF(value);
+      return Py_False;
+   } else {
+      Py_INCREF(Py_True);
+      Py_XDECREF(value);
+      return Py_True;
+   }
+}
+
+// Get the TClass of the C++ object proxied by pyobj
 TClass *GetTClass(const CPyCppyy::CPPInstance *pyobj)
 {
    return TClass::GetClass(Cppyy::GetFinalName(pyobj->ObjectIsA()).c_str());

--- a/bindings/pyroot_experimental/PyROOT/src/PyzCppHelpers.hxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyzCppHelpers.hxx
@@ -17,4 +17,6 @@ namespace CPyCppyy {
 }
 
 PyObject *CallPyObjMethod(PyObject *obj, const char *meth);
+PyObject *CallPyObjMethod(PyObject *obj, const char *meth, PyObject *arg1);
+PyObject *BoolNot(PyObject *value);
 TClass *GetTClass(const CPyCppyy::CPPInstance *pyobj);

--- a/bindings/pyroot_experimental/PyROOT/src/TObjectPyz.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/TObjectPyz.cxx
@@ -1,0 +1,63 @@
+// Author: Enric Tejedor CERN  05/2019
+// Original PyROOT code by Wim Lavrijsen, LBL
+
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+// Bindings
+#include "CPyCppyy.h"
+#include "CPPInstance.h"
+#include "Utility.h"
+#include "PyROOTPythonize.h"
+#include "PyzCppHelpers.hxx"
+
+// ROOT
+#include "TObject.h"
+
+using namespace CPyCppyy;
+
+// Implement Python's __eq__ with TObject::IsEqual
+PyObject *TObjectIsEqual(PyObject *self, PyObject *obj)
+{
+   if (!CPPInstance_Check(obj) || !((CPPInstance *)obj)->fObject)
+      return CPPInstance_Type.tp_richcompare(self, obj, Py_EQ);
+
+   return CallPyObjMethod(self, "IsEqual", obj);
+}
+
+// Implement Python's __ne__ with TObject::IsEqual
+PyObject *TObjectIsNotEqual(PyObject *self, PyObject *obj)
+{
+   if (!CPPInstance_Check(obj) || !((CPPInstance *)obj)->fObject)
+      return CPPInstance_Type.tp_richcompare(self, obj, Py_NE);
+
+   return BoolNot(CallPyObjMethod(self, "IsEqual", obj));
+}
+
+////////////////////////////////////////////////////////////////////////////
+/// \brief Add pythonization for equality and inequality operators in
+///        TObject
+/// \param[in] self Always null, since this is a module function.
+/// \param[in] args Pointer to a Python tuple object containing the arguments
+/// received from Python.
+///
+/// The equality and inequality operators are better implemented in C++,
+/// since we need to need to rely on Cppyy's rich comparison if the object
+/// we are comparing ourselves with is not a Python proxy or if it contains
+/// a null pointer. For example, we need to support the comparison to None.
+///
+/// The rest of comparison operators (i.e. those that define order)
+/// can be implemented in Python, throwing a NotImplemented exception
+/// if we are not comparing two proxies to TObject or derivate.
+PyObject *PyROOT::AddTObjectEqNePyz(PyObject * /* self */, PyObject *args)
+{
+   PyObject *pyclass = PyTuple_GetItem(args, 0);
+   Utility::AddToClass(pyclass, "__eq__", (PyCFunction)TObjectIsEqual, METH_O);
+   Utility::AddToClass(pyclass, "__ne__", (PyCFunction)TObjectIsNotEqual, METH_O);
+   Py_RETURN_NONE;
+}

--- a/bindings/pyroot_experimental/PyROOT/test/tobject_comparisonops.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tobject_comparisonops.py
@@ -24,6 +24,9 @@ class TObjectComparisonOps(unittest.TestCase):
         # Test comparison with no TObject
         self.assertFalse(o == 1)
 
+        # Test comparison with None
+        self.assertFalse(o == None)
+
     def test_ne(self):
         o = ROOT.TObject()
 
@@ -32,6 +35,9 @@ class TObjectComparisonOps(unittest.TestCase):
 
         # Test comparison with no TObject
         self.assertTrue(o != 1)
+
+        # Test comparison with None
+        self.assertTrue(o != None)
 
     def test_lt(self):
         a = TUrl("a")

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
@@ -431,7 +431,7 @@ PyObject* AsCObject(PyObject* dummy, PyObject* args)
 // Return object proxy as an opaque CObject.
     void* addr = GetCPPInstanceAddress(dummy, args);
     if (addr)
-        return CPyCppyy_PyCapsule_New((void*)(*(intptr_t*)addr), nullptr, nullptr);
+        return CPyCppyy_PyCapsule_New((void*)addr, nullptr, nullptr);
 
     return nullptr;
 }


### PR DESCRIPTION
New functionality and fixes in experimental PyROOT and Cppyy to make `roottest-python-cpp-cpp` and `roottest-python-cpp-cpp11` pass.

The changes in the tests themselves coming in another PR for roottest:
https://github.com/root-project/roottest/pull/326