### PR TITLE
[RF] Documentation updates

### DIFF
--- a/math/fftw/src/TFFTComplex.cxx
+++ b/math/fftw/src/TFFTComplex.cxx
@@ -10,30 +10,30 @@
  *************************************************************************/
 
 //////////////////////////////////////////////////////////////////////////
-//
-// TFFTComplex
-// One of the interface classes to the FFTW package, can be used directly
-// or via the TVirtualFFT class. Only the basic interface of FFTW is implemented.
-// Computes complex input/output discrete Fourier transforms (DFT)
-// in one or more dimensions. For the detailed information on the computed
-// transforms please refer to the FFTW manual, chapter "What FFTW really computes".
-//
-// How to use it:
-// 1) Create an instance of TFFTComplex - this will allocate input and output
-//    arrays (unless an in-place transform is specified)
-// 2) Run the Init() function with the desired flags and settings
-// 3) Set the data (via SetPoints(), SetPoint() or SetPointComplex() functions)
-// 4) Run the Transform() function
-// 5) Get the output (via GetPoints(), GetPoint() or GetPointComplex() functions)
-// 6) Repeat steps 3)-5) as needed
-//
-// For a transform of the same size, but with different flags or sign, rerun the Init()
-// function and continue with steps 3)-5)
-// NOTE: 1) running Init() function will overwrite the input array! Don't set any data
-//          before running the Init() function
-//       2) FFTW computes unnormalized transform, so doing a transform followed by
-//          its inverse will lead to the original array scaled by the transform size
-//
+/// \class TFFTComplex
+///
+/// One of the interface classes to the FFTW package, can be used directly
+/// or via the TVirtualFFT class. Only the basic interface of FFTW is implemented.
+/// Computes complex input/output discrete Fourier transforms (DFT)
+/// in one or more dimensions. For the detailed information on the computed
+/// transforms please refer to the FFTW manual, chapter "What FFTW really computes".
+///
+/// How to use it:
+/// 1) Create an instance of TFFTComplex - this will allocate input and output
+///    arrays (unless an in-place transform is specified)
+/// 2) Run the Init() function with the desired flags and settings
+/// 3) Set the data (via SetPoints(), SetPoint() or SetPointComplex() functions)
+/// 4) Run the Transform() function
+/// 5) Get the output (via GetPoints(), GetPoint() or GetPointComplex() functions)
+/// 6) Repeat steps 3)-5) as needed
+///
+/// For a transform of the same size, but with different flags or sign, rerun the Init()
+/// function and continue with steps 3)-5)
+/// NOTE: 1) running Init() function will overwrite the input array! Don't set any data
+///          before running the Init() function
+///       2) FFTW computes unnormalized transform, so doing a transform followed by
+///          its inverse will lead to the original array scaled by the transform size
+///
 //////////////////////////////////////////////////////////////////////////
 
 #include "TFFTComplex.h"

--- a/roofit/roofit/src/RooUnblindUniform.cxx
+++ b/roofit/roofit/src/RooUnblindUniform.cxx
@@ -17,16 +17,16 @@
 /** \class RooUnblindUniform
     \ingroup Roofit
 
-Implementation of BlindTools' offset blinding method
-A RooUnblindUniform object is a real valued function
-object, constructed from a blind value holder and a
-set of unblinding parameters. When supplied to a PDF
-in lieu of a regular parameter, the blind value holder
-supplied to the unblinded objects will in a fit be minimized
-to blind value corresponding to the actual minimum of the
-parameter. The transformation is chosen such that the
-the error on the blind parameters is identical to that
-of the unblind parameter
+Implementation of BlindTools' offset blinding method.
+A RooUnblindUniform object is a real-valued function
+object, constructed from a parameter to be blinded and a
+set of config parameters to change the blinding method.
+When supplied to a PDF in lieu of the regular parameter,
+a transformation will be applied such that the likelihood is computed with the actual
+value of the parameter, but RooFit (, the user, MINUIT) see only
+the transformed (blinded) value. The transformation is chosen such that
+the error of the blind parameter is identical to that
+of the original parameter.
 **/
 
 #include "RooFit.h"
@@ -48,12 +48,19 @@ RooUnblindUniform::RooUnblindUniform()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Constructor from a given RooAbsReal (to hold the blind value) and a set of blinding parameters
+/// Constructor from a given RooAbsReal (to hold the blinded value) and a set
+/// of blinding parameters.
+/// \param name Name of this transformation
+/// \param title Title (for plotting)
+/// \param blindString String to initialise the random generator
+/// \param scale Scale the offset. High values make the blinding more violent.
+/// \param blindValue The parameter to be blinded. After the fit, this parameter will
+/// only hold the blinded values.
 
 RooUnblindUniform::RooUnblindUniform(const char *name, const char *title,
-                const char *blindString, Double_t scale, RooAbsReal& cpasym)
+                const char *blindString, Double_t scale, RooAbsReal& blindValue)
   : RooAbsHiddenReal(name,title),
-  _value("value","Uniform blinded value",this,cpasym),
+  _value("value","Uniform blinded value",this,blindValue),
   _blindEngine(blindString,RooBlindTools::full,0.,scale)
 {
 }

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -204,15 +204,15 @@ public:
     return kFALSE;
   }
 
-  // Create a fundamental-type object that stores our type of value. The
-  // created object will have a valid value, but not necessarily the same
-  // as our value. The caller is responsible for deleting the returned object.
+  /// Create a fundamental-type object that stores our type of value. The
+  /// created object will have a valid value, but not necessarily the same
+  /// as our value. The caller is responsible for deleting the returned object.
   virtual RooAbsArg *createFundamental(const char* newname=0) const = 0;
 
+  /// Is this argument an l-value, i.e., can it appear on the left-hand side
+  /// of an assignment expression? LValues are also special since they can
+  /// potentially be analytically integrated and generated.
   inline virtual Bool_t isLValue() const {
-    // Is this argument an l-value, ie, can it appear on the left-hand side
-    // of an assignment expression? LValues are also special since they can
-    // potentially be analytically integrated and generated.
     return kFALSE;
   }
 
@@ -224,13 +224,13 @@ public:
   friend class RooAddPdfOrig ;
   RooArgSet* getVariables(Bool_t stripDisconnected=kTRUE) const ;
   RooArgSet* getParameters(const RooAbsData* data, Bool_t stripDisconnected=kTRUE) const ;
+  /// Return the parameters of this p.d.f when used in conjuction with dataset 'data'
   RooArgSet* getParameters(const RooAbsData& data, Bool_t stripDisconnected=kTRUE) const {
-    // Return the parameters of this p.d.f when used in conjuction with dataset 'data'
     return getParameters(&data,stripDisconnected) ;
   }
-  RooArgSet* getParameters(const RooArgSet& set, Bool_t stripDisconnected=kTRUE) const {
-    // Return the parameters of the p.d.f given the provided set of observables
-    return getParameters(&set,stripDisconnected) ;
+  /// Return the parameters of the p.d.f given the provided set of observables
+  RooArgSet* getParameters(const RooArgSet& observables, Bool_t stripDisconnected=kTRUE) const {
+    return getParameters(&observables,stripDisconnected);
   }
   virtual RooArgSet* getParameters(const RooArgSet* depList, Bool_t stripDisconnected=kTRUE) const ;
   /// Return the observables of this pdf given a set of observables
@@ -238,7 +238,7 @@ public:
     return getObservables(&set,valueOnly) ;
   }
   RooArgSet* getObservables(const RooAbsData* data) const ;
-  // Return the observables of this pdf given the observables defined by `data`.
+  /// Return the observables of this pdf given the observables defined by `data`.
   RooArgSet* getObservables(const RooAbsData& data) const {
     return getObservables(&data) ;
   }

--- a/roofit/roofitcore/inc/RooAbsRealLValue.h
+++ b/roofit/roofitcore/inc/RooAbsRealLValue.h
@@ -64,15 +64,33 @@ public:
 
   // Get fit range limits
 
+  /// Retrive binning configuration with given name or default binning.
   virtual const RooAbsBinning& getBinning(const char* name=0, Bool_t verbose=kTRUE, Bool_t createOnTheFly=kFALSE) const = 0 ;
+  /// Retrive binning configuration with given name or default binning.
   virtual RooAbsBinning& getBinning(const char* name=0, Bool_t verbose=kTRUE, Bool_t createOnTheFly=kFALSE) = 0 ;
+  /// Check if binning with given name has been defined.
   virtual Bool_t hasBinning(const char* name) const = 0 ;
   virtual Bool_t inRange(const char* name) const ;
+  /// Get number of bins of currently defined range.
+  /// \param name Optionally, request number of bins for range with given name.
   virtual Int_t getBins(const char* name=0) const { return getBinning(name).numBins(); }
+  /// Get miniminum of currently defined range.
+  /// \param name Optionally, request minimum of range with given name.
   virtual Double_t getMin(const char* name=0) const { return getBinning(name).lowBound(); }
+  /// Get maximum of currently defined range.
+  /// \param name Optionally, request maximum of range with given name.
   virtual Double_t getMax(const char* name=0) const { return getBinning(name).highBound(); }
+  /// Get low and high bound of the variable.
+  /// \param name Optional range name. If not given, the default range will be used.
+  /// \return A pair with [lowerBound, upperBound]
+  std::pair<double, double> getRange(const char* name = 0) const {
+    return {getMin(name), getMax(name)};
+  }
+  /// Check if variable has a lower bound.
   inline Bool_t hasMin(const char* name=0) const { return !RooNumber::isInfinite(getMin(name)); }
+  /// Check if variable has an upper bound.
   inline Bool_t hasMax(const char* name=0) const { return !RooNumber::isInfinite(getMax(name)); }
+  /// Check if variable has a binning with given name.
   virtual Bool_t hasRange(const char* name) const { return hasBinning(name) ; }
 
   // Jacobian term management

--- a/roofit/roofitcore/src/RooAbsMCStudyModule.cxx
+++ b/roofit/roofitcore/src/RooAbsMCStudyModule.cxx
@@ -21,14 +21,14 @@
 
 RooAbsMCStudyModule is a base class for add-on modules to RooMCStudy that
 can perform additional calculations on each generate+fit cycle managed
-by RooMCStudy
+by RooMCStudy.
 
 This class can insert code to be executed before each generation step,
 between the generation and fitting step and after the fitting step.
 Any summary output variables declared in the RooDataSet exported through
-summaryData() is merged with the 'master' summary dataset in RooMCStudy
+summaryData() is merged with the 'master' summary dataset in RooMCStudy.
 
-Look at RooDLLSignificanceMCStudyModule for an example of an implementation
+Look at RooDLLSignificanceMCStudyModule for an example of an implementation.
 **/
 
 #include "RooFit.h"

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1735,8 +1735,9 @@ RooAbsGenContext* RooAbsPdf::autoGenContext(const RooArgSet &vars, const RooData
 /// <tr><td> `Name(const char* name)`            <td> Name of the output dataset
 /// <tr><td> `Verbose(Bool_t flag)`              <td> Print informational messages during event generation
 /// <tr><td> `NumEvent(int nevt)`                <td> Generate specified number of events
-/// <tr><td> `Extended()`                        <td> The actual number of events generated will be sampled from a Poisson distribution with mu=nevt.
-///                                                 For use with extended maximum likelihood fits
+/// <tr><td> `Extended()`                        <td> If no number of events to be generated is given,
+/// use expected number of events from extended likelihood term.
+/// This evidently only works for extended PDFs.
 /// <tr><td> `GenBinned(const char* tag)`        <td> Use binned generation for all component pdfs that have 'setAttribute(tag)' set
 /// <tr><td> `AutoBinned(Bool_t flag)`           <td> Automatically deploy binned generation for binned distributions (e.g. RooHistPdf, sums and products of
 ///                                                 RooHistPdfs etc)
@@ -1780,6 +1781,7 @@ RooDataSet *RooAbsPdf::generate(const RooArgSet& whatVars, const RooCmdArg& arg1
   pc.defineDouble("nEventsD","NumEventsD",0,-1.) ;
   pc.defineString("binnedTag","GenBinned",0,"") ;
   pc.defineMutex("GenBinned","ProtoData") ;
+  pc.defineMutex("Extended", "NumEvents");
     
   // Process and check varargs 
   pc.process(arg1,arg2,arg3,arg4,arg5,arg6) ;
@@ -1810,11 +1812,6 @@ RooDataSet *RooAbsPdf::generate(const RooArgSet& whatVars, const RooCmdArg& arg1
 
   if (extended) {
      if (nEvents == 0) nEvents = expectedEvents(&whatVars);
-     //  nEvents = RooRandom::randomGenerator()->Poisson(nEvents==0 ? expectedEvents(&whatVars) : nEvents  ) ;
-    // // If Poisson fluctuation results in zero events, stop here
-    // if (nEvents==0) {
-    //   return new RooDataSet("emptyData","emptyData",whatVars) ;
-    // }
   } else if (nEvents==0) {
     cxcoutI(Generation) << "No number of events specified , number of events generated is " 
 			  << GetName() << "::expectedEvents() = " << expectedEvents(&whatVars)<< endl ;

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1083,11 +1083,26 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
 ///                                                \attention Use of this option excludes use of any of the new style steering options.
 ///
 /// <tr><td> `SumW2Error(Bool_t flag)`         <td>  Apply correction to errors and covariance matrix.
-///                                               This uses sum-of-weights covariance matrix
-///                                               to obtain correct error for weighted likelihood fits. If this option is activated the
-///                                               corrected covariance matrix is calculated as \f$ V_\mathrm{corr} = V C^{-1} V \f$, where V is the original
-///                                               covariance matrix and C is the inverse of the covariance matrix calculated using the
-///                                               weights squared
+///       This uses two covariance matrices, one with the weights, the other with squared weights,
+///       to obtain the correct errors for weighted likelihood fits. If this option is activated, the
+///       corrected covariance matrix is calculated as \f$ V_\mathrm{corr} = V C^{-1} V \f$, where \f$ V \f$ is the original
+///       covariance matrix and \f$ C \f$ is the inverse of the covariance matrix calculated using the
+///       squared weights. This allows to switch between two interpretations of errors:
+///       <table>
+///       <tr><th> SumW2Error <th> Interpretation
+///       <tr><td> true       <td> The errors reflect the uncertainty of the Monte Carlo simulation.
+///                                Use this if you want to know how much accuracy you can get from the available Monte Carlo statistics.
+///
+///                                **Example**: Simulation with 1000 events, the average weight is 0.1.
+///                                The errors are as big as if one fitted to 1000 events.
+///       <tr><td> false      <td> The errors reflect the errors of a dataset, which is as big as the sum of weights.
+///                                Use this if you want to know what statistical errors you would get if you had a dataset with as many
+///                                events as the (weighted) Monte Carlo simulation represents.
+///
+///                                **Example** (Data as above):
+///                                The errors are as big as if one fitted to 100 events.
+///       </table>
+///
 ///
 /// <tr><th><th> Options to control informational output
 /// <tr><td> `Verbose(Bool_t flag)`            <td>  Flag controls if verbose output is printed (NLL, parameter changes during fit
@@ -1198,17 +1213,17 @@ RooFitResult* RooAbsPdf::fitTo(RooAbsData& data, const RooLinkedList& cmdList)
 
   // Warn user that a SumW2Error() argument should be provided if weighted data is offered
   if (weightedData && doSumW2==-1) {
-    coutW(InputArguments) << "RooAbsPdf::fitTo(" << GetName() << ") WARNING: a likelihood fit is request of what appears to be weighted data. " << endl
-                          << "       While the estimated values of the parameters will always be calculated taking the weights into account, " << endl 
-			  << "       there are multiple ways to estimate the errors on these parameter values. You are advised to make an " << endl 
-			  << "       explicit choice on the error calculation: " << endl
-			  << "           - Either provide SumW2Error(kTRUE), to calculate a sum-of-weights corrected HESSE error matrix " << endl
-			  << "             (error will be proportional to the number of events)" << endl 
-			  << "           - Or provide SumW2Error(kFALSE), to return errors from original HESSE error matrix" << endl 
-			  << "             (which will be proportional to the sum of the weights)" << endl 
-			  << "       If you want the errors to reflect the information contained in the provided dataset, choose kTRUE. " << endl
-			  << "       If you want the errors to reflect the precision you would be able to obtain with an unweighted dataset " << endl 
-			  << "       with 'sum-of-weights' events, choose kFALSE." << endl ;
+    coutW(InputArguments) << "RooAbsPdf::fitTo(" << GetName() << ") WARNING: a likelihood fit is requested of what appears to be weighted data.\n"
+                          << "       While the estimated values of the parameters will always be calculated taking the weights into account,\n"
+			  << "       there are multiple ways to estimate the errors of the parameters. You are advised to make an'n"
+			  << "       explicit choice for the error calculation:\n"
+			  << "           - Either provide SumW2Error(true), to calculate a sum-of-weights-corrected HESSE error matrix\n"
+			  << "             (error will be proportional to the number of events in MC).\n"
+			  << "           - Or provide SumW2Error(false), to return errors from original HESSE error matrix\n"
+			  << "             (which will be proportional to the sum of the weights, i.e., a dataset with <sum of weights> events).\n"
+			  << "       If you want the errors to reflect the information contained in the provided simulation, choose true.\n"
+			  << "       If you want the errors to reflect the precision you would be able to obtain with an unweighted dataset\n"
+			  << "       with <sum of weights> events, choose false." << endl ;
   }
 
 

--- a/roofit/roofitcore/src/RooAddGenContext.cxx
+++ b/roofit/roofitcore/src/RooAddGenContext.cxx
@@ -24,7 +24,7 @@ generator context specific for RooAddPdf PDFs. The strategy
 of RooAddGenContext is to defer generation of each component
 to a dedicated generator context for that component and to
 randomly choose one of those context to generate an event,
-with a probability proportional to its associated coefficient
+with a probability proportional to its associated coefficient.
 **/
 
 

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -363,7 +363,7 @@ RooAddPdf::~RooAddPdf()
 /// interpretation of the coefficients to be done in the given set of
 /// observables. If frozen, fractions are automatically transformed
 /// from the reference normalization set to the contextual normalization
-/// set by ratios of integrals
+/// set by ratios of integrals.
 
 void RooAddPdf::fixCoefNormalization(const RooArgSet& refCoefNorm) 
 {

--- a/roofit/roofitcore/src/RooCurve.cxx
+++ b/roofit/roofitcore/src/RooCurve.cxx
@@ -32,7 +32,7 @@ p->setDrawOptions("curve_y","PL");
 p->Draw();
 ```
 
-To retrieve a RooCurve form a RooPlot, use RooPlot::getCurve().
+To retrieve a RooCurve from a RooPlot, use RooPlot::getCurve().
 **/
 
 #include "RooFit.h"

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -19,9 +19,9 @@
 \class RooDataHist
 \ingroup Roofitcore
 
-RooDataSet is a container class to hold N-dimensional binned data. Each bins central 
-coordinates in N-dimensional space are represented by a RooArgSet of RooRealVar, RooCategory 
-or RooStringVar objects, thus data can be binned in real and/or discrete dimensions
+The RooDataHist is a container class to hold N-dimensional binned data. Each bin's central
+coordinates in N-dimensional space are represented by a RooArgSet containing RooRealVar, RooCategory
+or RooStringVar objects, thus data can be binned in real and/or discrete dimensions.
 **/
 
 #include "RooFit.h"

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -604,7 +604,9 @@ RooDataSet::RooDataSet(const char *name, const char *title, const RooArgSet& var
 /// any variable in the source dataset. For cuts involving variables
 /// other than those contained in the source data set, such as
 /// intermediate formula objects, use the equivalent constructor
-/// accepting RooFormulaVar reference as cut specification
+/// accepting RooFormulaVar reference as cut specification.
+///
+/// This constructor will internally store the data in a TTree.
 ///
 /// For most uses the RooAbsData::reduce() wrapper function, which
 /// uses this constructor, is the most convenient way to create a
@@ -645,6 +647,8 @@ RooDataSet::RooDataSet(const char *name, const char *title, RooDataSet *dset,
 /// exclusively and directly on the data set dimensions, the
 /// equivalent constructor with a string based cut expression is
 /// recommended.
+///
+/// This constructor will internally store the data in a TTree.
 ///
 /// For most uses the RooAbsData::reduce() wrapper function, which
 /// uses this constructor, is the most convenient way to create a

--- a/roofit/roofitcore/src/RooEffProd.cxx
+++ b/roofit/roofitcore/src/RooEffProd.cxx
@@ -13,14 +13,13 @@
 
 
 /////////////////////////////////////////////////////////////////////////////////////
-// BEGIN_HTML
-// The class RooEffProd implements the product of a PDF with an efficiency function.
-// The normalization integral of the product is calculated numerically, but the
-// event generation is handled by a specialized generator context that implements
-// the event generation in a more efficient for cases where the PDF has an internal
-// generator that is smarter than accept reject. 
-// END_HTML
-//
+/// \class RooEffProd
+/// The class RooEffProd implements the product of a PDF with an efficiency function.
+/// The normalization integral of the product is calculated numerically, but the
+/// event generation is handled by a specialized generator context that implements
+/// the event generation in a more efficient for cases where the PDF has an internal
+/// generator that is smarter than accept reject.
+///
 
 #include "RooFit.h"
 #include "RooEffProd.h"

--- a/roofit/roofitcore/src/RooFormulaVar.cxx
+++ b/roofit/roofitcore/src/RooFormulaVar.cxx
@@ -15,26 +15,27 @@
  *****************************************************************************/
 
 //////////////////////////////////////////////////////////////////////////////
-//
-// RooFormulaVar is a generic implementation of a real valued object
-// which takes a RooArgList of servers and a C++ expression string defining how
-// its value should be calculated from the given list of servers.
-// RooFormulaVar uses a RooFormula object to perform the expression evaluation.
-//
-// If RooAbsPdf objects are supplied to RooFormulaVar as servers, their
-// raw (unnormalized) values will be evaluated. Use RooGenericPdf, which
-// constructs generic PDF functions, to access their properly normalized
-// values.
-//
-// The string expression can be any valid TFormula expression referring to the
-// listed servers either by name or by their ordinal list position:
-//
-//   RooFormulaVar("gen","x*y",RooArgList(x,y))  or
-//   RooFormulaVar("gen","@0*@1",RooArgList(x,y)) 
-//
-// The latter form, while slightly less readable, is more versatile because it
-// doesn't hardcode any of the variable names it expects
-//
+/// \class RooFormulaVar
+///
+/// A RooFormulaVar is a generic implementation of a real-valued object,
+/// which takes a RooArgList of servers and a C++ expression string defining how
+/// its value should be calculated from the given list of servers.
+/// RooFormulaVar uses a RooFormula object to perform the expression evaluation.
+///
+/// If RooAbsPdf objects are supplied to RooFormulaVar as servers, their
+/// raw (unnormalized) values will be evaluated. Use RooGenericPdf, which
+/// constructs generic PDF functions, to access their properly normalized
+/// values.
+///
+/// The string expression can be any valid TFormula expression referring to the
+/// listed servers either by name or by their ordinal list position:
+/// ```
+///   RooFormulaVar("gen","x*y",RooArgList(x,y))  or
+///   RooFormulaVar("gen","@0*@1",RooArgList(x,y))
+/// ```
+/// The latter form, while slightly less readable, is more versatile because it
+/// doesn't hardcode any of the variable names it expects
+///
 
 
 #include "RooFit.h"

--- a/roofit/roofitcore/src/RooFunctor.cxx
+++ b/roofit/roofitcore/src/RooFunctor.cxx
@@ -20,7 +20,7 @@
 \class RooFunctor
 \ingroup Roofitcore
 
-Lightweight interface adaptor that exports a RooAbsPdf as a functor
+Lightweight interface adaptor that exports a RooAbsPdf as a functor.
 **/
 
 

--- a/roofit/roofitcore/src/RooInvTransform.cxx
+++ b/roofit/roofitcore/src/RooInvTransform.cxx
@@ -19,7 +19,7 @@
 \class RooInvTransform
 \ingroup Roofitcore
 
-Lightweight function binding that returns the inverse of an input function binding
+Lightweight function binding that returns the inverse of an input function binding.
 Apply the change of variables transformation x -> 1/x to the input
 function and its range. The function must be one dimensional and its
 range cannot include zero.

--- a/roofit/roofitcore/src/RooMCStudy.cxx
+++ b/roofit/roofitcore/src/RooMCStudy.cxx
@@ -19,9 +19,9 @@
 \class RooMCStudy
 \ingroup Roofitcore
 
-RooMCStudy is a help class to facilitate Monte Carlo studies
+RooMCStudy is a helper class to facilitate Monte Carlo studies
 such as 'goodness-of-fit' studies, that involve fitting a PDF 
-to multiple toy Monte Carlo sets generated from the same PDF 
+to multiple toy Monte Carlo sets generated from either same PDF
 or another PDF.
 
 Given a fit PDF and a generator PDF, RooMCStudy can produce
@@ -31,10 +31,10 @@ Additional plotting routines simplify the task of plotting
 the distribution of the minimized likelihood, the fitted parameter values,
 fitted error and pull distribution.
 RooMCStudy provides the option to insert add-in modules
-that modify the generate and fit cycle and allow to perform
+that modify the generate-and-fit cycle and allow to perform
 extra steps in the cycle. Output of these modules can be stored
 alongside the fit results in the aggregate results dataset.
-These study modules should derive from class RooAbsMCStudyModel
+These study modules should derive from the class RooAbsMCStudyModule.
 
 **/
 
@@ -72,10 +72,10 @@ ClassImp(RooMCStudy);
 
 /**
 Construct Monte Carlo Study Manager. This class automates generating data from a given PDF,
-fitting the PDF to that data and accumulating the fit statistics.
+fitting the PDF to data and accumulating the fit statistics.
 
 \param[in] model The PDF to be studied
-\param[in] observables The variables of the PDF to be considered the observables
+\param[in] observables The variables of the PDF to be considered observables
 \param[in] argX Arguments from the table below
 
 <table>

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -2020,7 +2020,7 @@ RooArgSet* RooProdPdf::findPdfNSet(RooAbsPdf& pdf) const
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return all parameter constraint p.d.f.s on parameters listed in constrainedParams
+/// Return all parameter constraint p.d.f.s on parameters listed in constrainedParams.
 /// The observables set is required to distinguish unambiguously p.d.f in terms
 /// of observables and parameters, which are not constraints, and p.d.fs in terms
 /// of parameters only, which can serve as constraints p.d.f.s

--- a/roofit/roofitcore/src/RooProduct.cxx
+++ b/roofit/roofitcore/src/RooProduct.cxx
@@ -19,9 +19,7 @@
 \class RooProduct
 \ingroup Roofitcore
 
-
-RooProduct a RooAbsReal implementation that represent the product
-of a given set of other RooAbsReal objects
+A RooProduct represents the product of a given set of RooAbsReal objects.
 
 **/
 

--- a/roofit/roofitcore/src/RooRealSumPdf.cxx
+++ b/roofit/roofitcore/src/RooRealSumPdf.cxx
@@ -19,7 +19,7 @@
     \ingroup Roofitcore
 
 
-Class RooRealSumPdf implements a PDF constructed from a sum of functions:
+The class RooRealSumPdf implements a PDF constructed from a sum of functions:
 \f[
   \mathrm{PDF}(x) = \frac{ \sum_{i=1}^{n-1} \mathrm{coef}_i * \mathrm{func}_i(x) + \left[ 1 - \sum_{i=1}^{n-1} \mathrm{coef}_i \right] * \mathrm{func}_n(x) }
             {\sum_{i=1}^{n-1} \mathrm{coef}_i * \int \mathrm{func}_i(x)dx  + \left[ 1 - \sum_{i=1}^{n-1} \mathrm{coef}_i \right] * \int \mathrm{func}_n(x) dx }
@@ -31,8 +31,10 @@ In the present version \f$\mathrm{coef}_i\f$ may not depend on \f$ x \f$, but th
 If the number of coefficients is one less than the number of functions, the PDF is assumed to be normalised. Due to this additional constraint,
 \f$\mathrm{coef}_n\f$ is computed from the other coefficients.
 
-If an \f$ n^\mathrm{th} \f$ coefficient is provided, the PDF will behave as an extended PDF, *i.e.* the total number of events will be measured in addition
-to the fractions of the various functions.
+### Extending the PDF
+If an \f$ n^\mathrm{th} \f$ coefficient is provided, the PDF **can** be used as an extended PDF, *i.e.* the total number of events will be measured in addition
+to the fractions of the various functions. This requires setting the last argument of the constructor
+
 
 */
 

--- a/roofit/roostats/inc/RooStats/HypoTestCalculatorGeneric.h
+++ b/roofit/roostats/inc/RooStats/HypoTestCalculatorGeneric.h
@@ -55,19 +55,19 @@ namespace RooStats {
       const RooAbsData * GetData(void) const { return fData; }
       const ModelConfig* GetNullModel(void) const { return fNullModel; }
       virtual const RooArgSet* GetFitInfo() const { return NULL; }
-      // set the model for the alternate hypothesis  (S+B)
+      /// Set the model for the alternate hypothesis  (S+B)
       virtual void SetAlternateModel(const ModelConfig &altModel) { fAltModel = &altModel; }
       const ModelConfig* GetAlternateModel(void) const { return fAltModel; }
-      // Set the DataSet
+      /// Set the DataSet
       virtual void SetData(RooAbsData &data) { fData = &data; }
 
-      // Returns instance of TestStatSampler. Use to change properties of
-      // TestStatSampler, e.g. GetTestStatSampler.SetTestSize(Double_t size);
+      /// Returns instance of TestStatSampler. Use to change properties of
+      /// TestStatSampler, e.g. GetTestStatSampler.SetTestSize(Double_t size);
       TestStatSampler* GetTestStatSampler(void) const { return fTestStatSampler; }
 
-      // set this for re-using always the same toys for alternate hypothesis in
-      // case of calls at different null parameter points
-      // This is useful to get more stable bands when running the HypoTest inversion
+      /// Set this for re-using always the same toys for alternate hypothesis in
+      /// case of calls at different null parameter points
+      /// This is useful to get more stable bands when running the HypoTest inversion
       void UseSameAltToys();
 
 

--- a/roofit/roostats/inc/RooStats/ProfileLikelihoodCalculator.h
+++ b/roofit/roostats/inc/RooStats/ProfileLikelihoodCalculator.h
@@ -45,11 +45,11 @@ namespace RooStats {
       virtual ~ProfileLikelihoodCalculator();
 
       /// Return a likelihood interval. A global fit to the likelihood is performed and
-      /// the interval is constructed using the the profile likelihood ratio function of the POI
+      /// the interval is constructed using the profile likelihood ratio function of the POI.
       virtual LikelihoodInterval* GetInterval() const ;
 
       /// Return the hypothesis test result obtained from the likelihood ratio of the
-      /// maximum likelihood value with the null parameters fixed to their values, with respect keeping all parameters
+      /// maximum likelihood value with the null parameters fixed to their values, with respect to keeping all parameters
       /// floating (global maximum likelihood value).
       virtual HypoTestResult* GetHypoTest() const;
 

--- a/roofit/roostats/src/AsymptoticCalculator.cxx
+++ b/roofit/roostats/src/AsymptoticCalculator.cxx
@@ -14,24 +14,28 @@
 Hypothesis Test Calculator based on the asymptotic formulae for the profile
 likelihood ratio.
 
- Performs hypothesis tests using asymptotic formula for the profile likelihood and
-Asimov data set
+It performs hypothesis tests using the asymptotic formula for the profile likelihood and
+the "Asimov" data set.
 
 See G. Cowan, K. Cranmer, E. Gross and O. Vitells: Asymptotic formulae for
 likelihood- based tests of new physics. Eur. Phys. J., C71:1–19, 2011.
-It provides method to perform an hypothesis tests using the likelihood function
-and computes the p values for the null and the alternate using the asymptotic
+It provides methods to perform a hypothesis test using the likelihood function,
+and computes the \f$ p \f$-values for the null and the alternate hypothesis using the asymptotic
 formulae for the profile likelihood ratio described in the given paper.
 
-The calculator provides methods to produce the Asimov dataset, i.e a dataset
+The calculator provides methods to produce the Asimov dataset, i.e, a dataset
 generated where the observed values are equal to the expected ones.
-The Asimov data set is then used to compute the observed asymptotic p-value for
-the alternate hypothesis and the asymptotic expected p-values.
+The Asimov data set is then used to compute the observed asymptotic \f$ p \f$-value for
+the alternate hypothesis and the asymptotic expected \f$ p \f$-value.
 
 The asymptotic formulae are valid only for one POI (parameter of interest). So
-the calculator works only for one-dimensional (one POI) model.
-If more than one POI exists consider as POI only the first one is used.
+the calculator works only for one-dimensional (one POI) models.
 
+If more than one POI exists, only the first one is used for calculations.
+
+The calculator can generate Asimov datasets from two kinds of PDFs:
+- "Counting" distributions: RooPoisson, RooGaussian, or products of RooPoissons.
+- Extended, *i.e.* number of events can be read off from extended likelihood term.
 */
 
 
@@ -912,7 +916,8 @@ void AsymptoticCalculator::FillBins(const RooAbsPdf & pdf, const RooArgList &obs
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// iterate a Prod pdf to find all the Poisson or Gaussian part to set the observed value to expected one
+/// Inpspect a product pdf to find all the Poisson or Gaussian parts to set the observed
+/// values to expected ones.
 
 bool AsymptoticCalculator::SetObsToExpected(RooProdPdf &prod, const RooArgSet &obs)
 {
@@ -1003,9 +1008,9 @@ bool AsymptoticCalculator::SetObsToExpected(RooAbsPdf &pdf, const RooArgSet &obs
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// generate counting Asimov data for the case when the pdf cannot be extended
-/// assume pdf is a RooPoisson or can be decomposed in a product of RooPoisson,
-/// otherwise we cannot know how to make the Asimov data sets in the other cases
+/// Generate counting Asimov data for the case when the pdf cannot be extended.
+/// This function assumes that the pdf is a RooPoisson or can be decomposed in a product of RooPoisson,
+/// or is a RooGaussian. Otherwise, we cannot know how to make the Asimov data sets.
 
 RooAbsData * AsymptoticCalculator::GenerateCountingAsimovData(RooAbsPdf & pdf, const RooArgSet & observables,  const RooRealVar & , RooCategory * channelCat) {
     RooArgSet obs(observables);
@@ -1040,10 +1045,10 @@ RooAbsData * AsymptoticCalculator::GenerateCountingAsimovData(RooAbsPdf & pdf, c
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// compute the asimov data set for an observable of a pdf
-/// use the number of bins sets in the observables
-/// to do :  (possibility to change number of bins)
-/// implement integration over bin content
+/// Compute the asimov data set for an observable of a pdf.
+/// It generates binned data following the binning of the observables.
+// TODO: (possibility to change number of bins)
+// TODO: implement integration over bin content
 
 RooAbsData * AsymptoticCalculator::GenerateAsimovDataSinglePdf(const RooAbsPdf & pdf, const RooArgSet & allobs,  const RooRealVar & weightVar, RooCategory * channelCat) {
 

--- a/roofit/roostats/src/AsymptoticCalculator.cxx
+++ b/roofit/roostats/src/AsymptoticCalculator.cxx
@@ -14,24 +14,23 @@
 Hypothesis Test Calculator based on the asymptotic formulae for the profile
 likelihood ratio.
 
-It performs hypothesis tests using the asymptotic formula for the profile likelihood and
-the "Asimov" data set.
+It performs hypothesis tests using the asymptotic formula for the profile likelihood, and
+uses the Asimov data set to compute expected significances or limits.
 
 See G. Cowan, K. Cranmer, E. Gross and O. Vitells: Asymptotic formulae for
 likelihood- based tests of new physics. Eur. Phys. J., C71:1–19, 2011.
-It provides methods to perform a hypothesis test using the likelihood function,
-and computes the \f$ p \f$-values for the null and the alternate hypothesis using the asymptotic
+It provides methods to perform hypothesis tests using the likelihood function,
+and computes the \f$p\f$-values for the null and the alternate hypothesis using the asymptotic
 formulae for the profile likelihood ratio described in the given paper.
 
-The calculator provides methods to produce the Asimov dataset, i.e, a dataset
+The calculator provides methods to produce the Asimov dataset, *i.e.* a dataset
 generated where the observed values are equal to the expected ones.
-The Asimov data set is then used to compute the observed asymptotic \f$ p \f$-value for
-the alternate hypothesis and the asymptotic expected \f$ p \f$-value.
+The Asimov data set is then used to compute the observed asymptotic \f$p\f$-value for
+the alternate hypothesis and the asymptotic expected \f$p\f$-values.
 
 The asymptotic formulae are valid only for one POI (parameter of interest). So
 the calculator works only for one-dimensional (one POI) models.
-
-If more than one POI exists, only the first one is used for calculations.
+If more than one POI exists, only the first one is used.
 
 The calculator can generate Asimov datasets from two kinds of PDFs:
 - "Counting" distributions: RooPoisson, RooGaussian, or products of RooPoissons.

--- a/roofit/roostats/src/ProfileLikelihoodCalculator.cxx
+++ b/roofit/roostats/src/ProfileLikelihoodCalculator.cxx
@@ -12,42 +12,42 @@
 /** \class RooStats::ProfileLikelihoodCalculator
     \ingroup Roostats
 
-ProfileLikelihoodCalculator is a concrete implementation of CombinedCalculator
-(the interface class for a tools which can produce both RooStats HypoTestResults
-and ConfIntervals). The tool uses the profile likelihood ratio as a test statistic,
-and assumes that Wilks' theorem is valid. Wilks' theorem states that -2* log
-(profile likelihood ratio) is asymptotically distributed as a chi^2 distribution
-with N-dof, where N is the number of degrees of freedom. Thus, p-values can be
-constructed and the profile likelihood ratio can be used to construct a
+The ProfileLikelihoodCalculator is a concrete implementation of CombinedCalculator
+(the interface class for tools which can produce both a RooStats HypoTestResult
+and ConfInterval). The tool uses the profile likelihood ratio as a test statistic,
+and assumes that Wilks' theorem is valid. Wilks' theorem states that \f$ -2 \cdot \ln(\lambda) \f$
+(profile likelihood ratio) is asymptotically distributed as a \f$ \chi^2 \f$ distribution
+with \f$ N \f$ degrees of freedom. Thus, \f$p\f$-values can be
+constructed, and the profile likelihood ratio can be used to construct a
 LikelihoodInterval. (In the future, this class could be extended to use toy
 Monte Carlo to calibrate the distribution of the test statistic).
 
 Usage: It uses the interface of the CombinedCalculator, so that it can be
 configured by specifying:
 
-  - a model common model (eg. a family of specific models which includes both
-    the null and alternate),
-  - a data set,
-  - a set of parameters of interest. The nuisance parameters will be all other
-    parameters of the model
-  - a set of parameters of which specify the null hypothesis (including values
-    and const/non-const status)
+  - A model common model (*e.g.* a family of specific models, which includes both
+    the null and alternate)
+  - A data set
+  - A set of parameters of interest. The nuisance parameters will be all other
+    parameters of the model.
+  - A set of parameters which specify the null hypothesis (including values
+    and const/non-const status).
 
 The interface allows one to pass the model, data, and parameters either directly
 or via a ModelConfig class. The alternate hypothesis leaves the parameter free
-to take any value other than those specified by the null hypotesis. There is
+to take any value other than those specified by the null hypothesis. There is
 therefore no need to specify the alternate parameters.
 
-After configuring the calculator, one only needs to ask GetHypoTest() (which
-will return a HypoTestResult pointer) or GetInterval() (which will return an
+After configuring the calculator, one only needs to call GetHypoTest() (which
+will return a HypoTestResult pointer) or GetInterval() (which will return a
 ConfInterval pointer).
 
 This calculator can work with both one-dimensional intervals or multi-
-dimensional ones (contours)
+dimensional ones (contours).
 
 Note that for hypothesis tests, it is often better to use the
-RooStats::AsymptoricCalculator class, which can compute in addition the expected
-p-value using an Asimov data set.
+AsymptoticCalculator, which can compute in addition the expected
+\f$p\f$-value using an Asimov data set.
 
 */
 
@@ -214,7 +214,7 @@ RooFitResult * ProfileLikelihoodCalculator::DoMinimizeNLL(RooAbsReal * nll)  {
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Main interface to get a RooStats::ConfInterval.
-/// It constructs a profile likelihood ratio and uses that to construct a RooStats::LikelihoodInterval.
+/// It constructs a profile likelihood ratio, and uses that to construct a RooStats::LikelihoodInterval.
 
 LikelihoodInterval* ProfileLikelihoodCalculator::GetInterval() const {
 //    RooAbsPdf* pdf   = fWS->pdf(fPdfName);
@@ -287,10 +287,12 @@ LikelihoodInterval* ProfileLikelihoodCalculator::GetInterval() const {
 ////////////////////////////////////////////////////////////////////////////////
 /// Main interface to get a HypoTestResult.
 /// It does two fits:
-/// the first lets the null parameters float, so it's a maximum likelihood estimate
-/// the second is to the null (fixing null parameters to their specified values): eg. a conditional maximum likelihood
-/// the ratio of the likelihood at the conditional MLE to the MLE is the profile likelihood ratio.
-/// Wilks' theorem is used to get p-values
+/// 1. The first lets the null parameters float, so it's a maximum likelihood estimate.
+/// 2. The second is to the null model (fixing null parameters to their specified values): *e.g.* a conditional maximum likelihood.
+/// Since not all parameters are floating, this likelihood will be lower than the unconditional model.
+///
+/// The ratio of the likelihood obtained from the conditional MLE to the MLE is the profile likelihood ratio.
+/// Wilks' theorem is used to get \f$p\f$-values.
 
 HypoTestResult* ProfileLikelihoodCalculator::GetHypoTest() const {
 //    RooAbsPdf* pdf   = fWS->pdf(fPdfName);

--- a/roofit/roostats/src/ProfileLikelihoodTestStat.cxx
+++ b/roofit/roostats/src/ProfileLikelihoodTestStat.cxx
@@ -19,8 +19,8 @@ either use:
 
   - the ProfileLikelihoodCalculator that relies on asymptotic properties of the
     Profile Likelihood Ratio
-  - the Neyman Construction classes with this class as a test statistic
-  - the Hybrid Calculator class with this class as a test statistic
+  - the NeymanConstruction class with this class as a test statistic
+  - the HybridCalculator class with this class as a test statistic
 
 
 */

--- a/tutorials/roofit/rf604_constraints.C
+++ b/tutorials/roofit/rf604_constraints.C
@@ -48,7 +48,7 @@ void rf604_constraints()
    // -----------------------------------------
 
    // Construct Gaussian constraint p.d.f on parameter f at 0.8 with resolution of 0.1
-   RooGaussian fconstraint("fconstraint", "fconstraint", f, RooConst(0.8), RooConst(0.1));
+   RooGaussian fconstraint("fconstraint", "fconstraint", f, RooConst(0.8), RooConst(0.2));
 
    // M E T H O D   1   -   A d d   i n t e r n a l   c o n s t r a i n t   t o   m o d e l
    // -------------------------------------------------------------------------------------
@@ -68,7 +68,7 @@ void rf604_constraints()
    // M E T H O D   2   -     S p e c i f y   e x t e r n a l   c o n s t r a i n t   w h e n   f i t t i n g
    // -------------------------------------------------------------------------------------------------------
 
-   // Construct another Gaussian constraint p.d.f on parameter f at 0.8 with resolution of 0.1
+   // Construct another Gaussian constraint p.d.f on parameter f at 0.2 with resolution of 0.1
    RooGaussian fconstext("fconstext", "fconstext", f, RooConst(0.2), RooConst(0.1));
 
    // Fit with external constraint


### PR DESCRIPTION
- Make various '//' comments appear in doxygen
- Fix various typos
- Improve explanations of unclear docs
- Add getRange() to RooAbsRealLValue as a shortcut for getMin() followed by getMax(). Users were rightfully pointing out that there is no equivalent to setRange().