### PR TITLE
[Exp PyROOT] Implementation of __radd__, __rsub__, __rmul__ and __rtruediv__/__rdiv__ for TComplex bindings

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
@@ -16,6 +16,7 @@ set(py_sources
   ROOT/pythonization/_tarray.py
   ROOT/pythonization/_tclonesarray.py
   ROOT/pythonization/_tcollection.py
+  ROOT/pythonization/_tcomplex.py
   ROOT/pythonization/_tdirectory.py
   ROOT/pythonization/_tdirectoryfile.py
   ROOT/pythonization/_tfile.py

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tcomplex.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tcomplex.py
@@ -1,0 +1,71 @@
+# Author: Massimiliano Galli CERN  05/2019
+
+################################################################################
+# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from ROOT import pythonization
+import cppyy
+
+def _rsub(self, other):
+    # Parameters:
+    # - self: complex number
+    # - other: other (in general not complex) number
+    return -self+other
+
+def _perform_division(self, other):
+    # Parameters:
+    # - self: complex number
+    # - other: int, float of long (Py2) number
+    TComplex = cppyy.gbl.TComplex
+    other_complex = TComplex.TComplex(other,0)
+    return other_complex/self
+
+def _rdiv(self, other):
+    # Parameters:
+    # - self: complex number
+    # - other: other term
+    if isinstance(other, (int, long, float)):
+        return _perform_division(self, other)
+    else:
+        return NotImplemented
+
+def _rtruediv(self, other):
+    # Parameters:
+    # - self: complex number
+    # - other: other term
+    if isinstance(other, (int, float)):
+        return _perform_division(self, other)
+    else:
+        return NotImplemented
+
+@pythonization()
+def pythonize_tcomplex(klass, name):
+    # Parameters:
+    # klass: class to be pythonized
+    # name: string containing the name of the class
+    if name == 'TComplex':
+
+        # implements __radd__ as equal to __add__
+        klass.__radd__ = klass.__add__
+
+        # implements __rsub__ by assigning the function previously defined
+        klass.__rsub__ = _rsub
+
+        # implements __rmul__ as equal to __mul__
+        klass.__rmul__ = klass.__mul__
+
+        # implements __rtruediv__ by assigning the function previously defined
+        # necessary for Python3
+        klass.__rtruediv__ = _rtruediv
+
+        # implements __rtruediv__ by assigning the function previously defined
+        # necessary for Python2
+        klass.__rdiv__ = _rdiv
+
+    return True
+

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -94,3 +94,6 @@ ROOT_ADD_PYUNITTEST(pyroot_string_view_backport string_view_backport.py)
 
 # Test wrapping Python callables for use in C++
 ROOT_ADD_PYUNITTEST(pyroot_cppcallable cppcallable.py)
+
+# TComplex pythonizations
+ROOT_ADD_PYUNITTEST(pyroot_tcomplex tcomplex_operators.py)

--- a/bindings/pyroot_experimental/PyROOT/test/tcomplex_operators.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tcomplex_operators.py
@@ -1,0 +1,40 @@
+import unittest
+import ROOT
+from ROOT import TComplex
+
+class TestTComplexOperators(unittest.TestCase):
+    """
+    Test for the operators of TComplex:
+    __radd__, __rsub__, __rmul__, __rtruediv__/__rdiv__.
+    """
+
+    c = TComplex(4.,0)
+
+    d = 2.
+
+    s = 'string'
+
+    # check the expected result for d + c and that Re(c + d) == Re(d + c)
+    def test_radd(self):
+        self.assertEqual((self.d + self.c).Re(), 6.0)
+        self.assertEqual((self.c + self.d).Re(), (self.d + self.c).Re())
+
+    # check the expected result for d - c and that Re(c - d) == -Re(d - c)
+    def test_rsub(self):
+        self.assertEqual((self.d - self.c).Re(), -2.0)
+        self.assertEqual((self.c - self.d).Re(), -((self.d - self.c).Re()))
+
+    # check the expected result for d * c and that Re(c * d) == Re(d * c)
+    def test_rmul(self):
+        self.assertEqual((self.d * self.c).Re(), 8.0)
+        self.assertEqual((self.c * self.d).Re(), (self.d * self.c).Re())
+
+    # check the expected result for d / c
+    def test_rdiv(self):
+        self.assertEqual((self.d / self.c).Re(), 0.5)
+        with self.assertRaises(TypeError):
+            self.s / self.c
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The implementation of these two methods was requested in order to fix the bug here described:

https://sft.its.cern.ch/jira/browse/ROOT-9798

https://sft.its.cern.ch/jira/browse/ROOT-8580
