### PR TITLE
Switch to FindLibLZMA.cmake and enforce minimal version

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -154,7 +154,7 @@ endif()
 #---Check for LZMA-------------------------------------------------------------------
 if(NOT builtin_lzma)
   message(STATUS "Looking for LZMA")
-  find_package(LZMA)
+  find_package(LibLZMA 5.0.4)
   if(NOT LZMA_FOUND)
     message(STATUS "LZMA not found. Switching on builtin_lzma option")
     set(builtin_lzma ON CACHE BOOL "Enabled because LZMA not found (${builtin_lzma_description})" FORCE)


### PR DESCRIPTION
When building ROOT on slc6, it will detect and use xz (version 4.999.9) provided by OS, which is reported to have compatibility issues (`R__unzipLZMA: error 8 in lzma_code`). The proposed change fixes that by using CMake's own module (present since CMake 3.0.2) for detecting xz *and* checking it's version.