### PR TITLE
[cxxmodules] Teach ACLiC to build modules.

### DIFF
--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -190,7 +190,7 @@ macro(REFLEX_GENERATE_DICTIONARY dictionary)
 endmacro()
 
 #---------------------------------------------------------------------------------------------------
-#---ROOT_GENERATE_DICTIONARY( result_var )
+#---ROOT_GET_LIBRARY_OUTPUT_DIR( result_var )
 # Returns the path to the .so file or .dll file. In the latter case Windows defines the dll files as
 # executables and puts them in the $ROOTSYS/bin folder.
 function(ROOT_GET_LIBRARY_OUTPUT_DIR result)

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -3524,16 +3524,11 @@ int TSystem::CompileMacro(const char *filename, Option_t *opt,
    rcling += "\" -f \"";
    rcling.Append(dict).Append("\" ");
 
-   if (useCxxModules)
-      rcling += " -cxxmodule ";
-
-   if (produceRootmap) {
+   if (produceRootmap && !useCxxModules) {
       rcling += " -rml " + libname + " -rmf \"" + libmapfilename + "\" ";
-   }
-   rcling.Append(GetIncludePath()).Append(" -D__ACLIC__ ");
-   if (produceRootmap) {
       rcling.Append("-DR__ACLIC_ROOTMAP ");
    }
+   rcling.Append(GetIncludePath()).Append(" -D__ACLIC__ ");
    if (gEnv) {
       TString fromConfig = gEnv->GetValue("ACLiC.IncludePaths","");
       rcling.Append(fromConfig);
@@ -3541,7 +3536,8 @@ int TSystem::CompileMacro(const char *filename, Option_t *opt,
 
    // Create a modulemap
    // FIXME: Merge the modulemap generation from cmake and here in rootcling.
-   if (useCxxModules) {
+   if (useCxxModules && produceRootmap) {
+      rcling += " -cxxmodule ";
       // TString moduleMapFileName = file_dirname + "/" + libname + ".modulemap";
       TString moduleName = libname + "_ACLiC_dict";
       if (moduleName.BeginsWith("lib"))

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -29,6 +29,7 @@ allows a simple partial implementation for new OS'es.
 #include <algorithm>
 #include <sys/stat.h>
 
+#include <ROOT/FoundationUtils.hxx>
 #include "Riostream.h"
 #include "TSystem.h"
 #include "TApplication.h"
@@ -3551,9 +3552,11 @@ int TSystem::CompileMacro(const char *filename, Option_t *opt,
       if (verboseLevel > 3 && !AccessPathName(moduleMapFullPath))
          ::Info("ACLiC", "File %s already exists!", moduleMapFullPath.Data());
 
+      std::string curDir = ROOT::FoundationUtils::GetCurrentDir();
+      std::string relative_path = ROOT::FoundationUtils::MakePathRelative(filename_fullpath.Data(), curDir);
       std::ofstream moduleMapFile(moduleMapFullPath, std::ios::out);
       moduleMapFile << "module \"" << moduleName << "\" {" << std::endl;
-      moduleMapFile << "  header \"" << filename_fullpath << "\"" << std::endl;
+      moduleMapFile << "  header \"" << relative_path << "\"" << std::endl;
       moduleMapFile << "  export *" << std::endl;
       moduleMapFile << "  link \"" << libname_ext << "\"" << std::endl;
       moduleMapFile << "}" << std::endl;

--- a/core/foundation/CMakeLists.txt
+++ b/core/foundation/CMakeLists.txt
@@ -17,6 +17,7 @@ set(Foundation_dict_headers
 )
 
 set(sources
+  src/FoundationUtils.cxx
   src/RConversionRuleParser.cxx
   src/TClassEdit.cxx
 )

--- a/core/foundation/res/ROOT/FoundationUtils.hxx
+++ b/core/foundation/res/ROOT/FoundationUtils.hxx
@@ -1,0 +1,45 @@
+/// \file FoundationUtils.hxx
+///
+/// \brief The file contains utilities which are foundational and could be used
+/// across the core component of ROOT.
+///
+///
+/// \author Vassil Vassilev <vvasilev@cern.ch>
+///
+/// \date June, 2019
+///
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_CORE_FOUNDATION_FOUNDATIONUTILS_HXX
+#define ROOT_CORE_FOUNDATION_FOUNDATIONUTILS_HXX
+
+#include <string>
+
+namespace ROOT {
+namespace FoundationUtils {
+
+   ///\returns the $PWD.
+   std::string GetCurrentDir();
+
+   ///\returns the relative path of \c path with respect to \c base.
+   /// For instance, for path being "/a/b/c/d" and base "/a/b", returns "c/d".
+   ///
+   ///\param path - the input path
+   ///
+   ///\param base - the base path to be removed from \c path.
+   ///
+   ///\param isBuildingROOT - if true, it converts module directories such as
+   ///                        core/base/inc/ to include/
+   std::string MakePathRelative(const std::string &path, const std::string &base,
+                                bool isBuildingROOT = false);
+
+   } // namespace FoundationUtils
+} // namespace ROOT
+
+#endif // ROOT_CORE_FOUNDATION_FOUNDATIONUTILS_HXX

--- a/core/foundation/src/FoundationUtils.cxx
+++ b/core/foundation/src/FoundationUtils.cxx
@@ -1,0 +1,92 @@
+/// \file FoundationUtils.hxx
+///
+/// \brief The file contains utilities which are foundational and could be used
+/// across the core component of ROOT.
+///
+///
+/// \author Vassil Vassilev <vvasilev@cern.ch>
+///
+/// \date June, 2019
+///
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include <ROOT/FoundationUtils.hxx>
+
+#include <algorithm>
+
+#include <errno.h>
+#include <string.h>
+#ifdef _WIN32
+#include <direct.h>
+#else
+#include <unistd.h>
+#endif // _WIN32
+
+namespace ROOT {
+namespace FoundationUtils {
+std::string GetCurrentDir()
+{
+   char fixedLength[1024];
+   char *currWorkDir = fixedLength;
+   size_t len = 1024;
+   char *result = currWorkDir;
+
+   do {
+      if (result == 0) {
+         len = 2 * len;
+         if (fixedLength != currWorkDir) {
+            delete[] currWorkDir;
+         }
+         currWorkDir = new char[len];
+      }
+#ifdef WIN32
+      result = ::_getcwd(currWorkDir, len);
+#else
+      result = getcwd(currWorkDir, len);
+#endif
+   } while (result == 0 && errno == ERANGE);
+
+   std::string output = currWorkDir;
+   output += '/';
+#ifdef WIN32
+   // convert backslashes into forward slashes
+   std::replace(output.begin(), output.end(), '\\', '/');
+#endif
+
+   if (fixedLength != currWorkDir) {
+      delete[] currWorkDir;
+   }
+   return output;
+}
+
+std::string MakePathRelative(const std::string &path, const std::string &base, bool isBuildingROOT /* = false*/)
+{
+   std::string result(path);
+
+   const char *currWorkDir = base.c_str();
+   size_t lenCurrWorkDir = strlen(currWorkDir);
+   if (result.substr(0, lenCurrWorkDir) == currWorkDir) {
+      // Convert to path relative to $PWD.
+      // If that's not what the caller wants, she should pass -I to rootcling and a
+      // different relative path to the header files.
+      result.erase(0, lenCurrWorkDir);
+   }
+   // FIXME: This is not a generic approach for an interface. We should rework
+   // this part.
+   if (isBuildingROOT) {
+      // For ROOT, convert module directories like core/base/inc/ to include/
+      int posInc = result.find("/inc/");
+      if (posInc != -1) {
+         result = /*std::string("include") +*/ result.substr(posInc + 5, -1);
+      }
+   }
+   return result;
+}
+} // namespace FoundationUtils
+} // namespace ROOT

--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -176,6 +176,8 @@ public:
    virtual Long_t   ProcessLine(const char *line, EErrorCode *error = 0) = 0;
    virtual Long_t   ProcessLineSynch(const char *line, EErrorCode *error = 0) = 0;
    virtual void     PrintIntro() = 0;
+   virtual bool     RegisterPrebuiltModulePath(const std::string& FullPath,
+                                               const std::string& ModuleMapName = "module.modulemap") const = 0;
    virtual void     RegisterModule(const char* /*modulename*/,
                                    const char** /*headers*/,
                                    const char** /*includePaths*/,

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1046,7 +1046,7 @@ std::string TCling::ToString(const char* type, void* obj)
 
 ////////////////////////////////////////////////////////////////////////////////
 ///\returns true if the module was loaded.
-static bool LoadModule(const std::string &ModuleName, cling::Interpreter &interp, bool Complain = true)
+static bool LoadModule(const std::string &ModuleName, cling::Interpreter &interp)
 {
    // When starting up ROOT, cling would load all modulemap files on the include
    // paths. However, in a ROOT session, it is very common to run aclic which
@@ -1058,7 +1058,7 @@ static bool LoadModule(const std::string &ModuleName, cling::Interpreter &interp
    std::string currentDir = gSystem->WorkingDirectory();
    assert(!currentDir.empty());
    gCling->RegisterPrebuiltModulePath(currentDir);
-   return interp.loadModule(ModuleName, Complain);
+   return interp.loadModule(ModuleName, /*Complain=*/true);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2045,7 +2045,7 @@ void TCling::RegisterModule(const char* modulename,
 
       // FIXME: We should only complain for modules which we know to exist. For example, we should not complain about
       // modules such as GenVector32 because it needs to fall back to GenVector.
-      ModuleWasSuccessfullyLoaded = LoadModule(ModuleName, *fInterpreter, /*Complain=*/true);
+      ModuleWasSuccessfullyLoaded = LoadModule(ModuleName, *fInterpreter);
       if (!ModuleWasSuccessfullyLoaded) {
          // Only report if we found the module in the modulemap.
          clang::HeaderSearch &headerSearch = PP.getHeaderSearchInfo();

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -223,6 +223,8 @@ public: // Public Interface
    Long_t  ProcessLineAsynch(const char* line, EErrorCode* error = 0);
    Long_t  ProcessLineSynch(const char* line, EErrorCode* error = 0);
    void    PrintIntro();
+   bool    RegisterPrebuiltModulePath(const std::string& FullPath,
+                                      const std::string& ModuleMapName = "module.modulemap") const;
    void    RegisterModule(const char* modulename,
                           const char** headers,
                           const char** includePaths,

--- a/core/metacling/src/TClingCallbacks.cxx
+++ b/core/metacling/src/TClingCallbacks.cxx
@@ -97,8 +97,8 @@ void TClingCallbacks::InclusionDirective(clang::SourceLocation sLoc/*HashLoc*/,
                                          llvm::StringRef /*RelativePath*/,
                                          const clang::Module * Imported) {
    // We found a module. Do not try to do anything else.
+   Sema &SemaR = m_Interpreter->getSema();
    if (Imported) {
-      Sema &SemaR = m_Interpreter->getSema();
       // FIXME: We should make the module visible at that point.
       if (!SemaR.isModuleVisible(Imported))
          ROOT::TMetaUtils::Info("TClingCallbacks::InclusionDirective",
@@ -124,7 +124,6 @@ void TClingCallbacks::InclusionDirective(clang::SourceLocation sLoc/*HashLoc*/,
 
    std::string localString(FileName.str());
 
-   Sema &SemaR = m_Interpreter->getSema();
    DeclarationName Name = &SemaR.getASTContext().Idents.get(localString.c_str());
    LookupResult RHeader(SemaR, Name, sLoc, Sema::LookupOrdinaryName);
 

--- a/interpreter/cling/include/cling/Interpreter/InterpreterCallbacks.h
+++ b/interpreter/cling/include/cling/Interpreter/InterpreterCallbacks.h
@@ -110,6 +110,9 @@ namespace cling {
                                    llvm::StringRef /*SearchPath*/,
                                    llvm::StringRef /*RelativePath*/,
                                    const clang::Module* /*Imported*/) {}
+    virtual void EnteredSubmodule(clang::Module* M,
+                                  clang::SourceLocation ImportLoc,
+                                  bool ForPragma) {}
 
     virtual bool FileNotFound(llvm::StringRef FileName,
                               llvm::SmallVectorImpl<char>& RecoveryPath);

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -1237,6 +1237,13 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
                                       PP.getTargetInfo().getTriple());
     }
 
+    for (const auto& Filename : FrontendOpts.ModuleMapFiles) {
+      if (auto* File = FM.getFile(Filename))
+        PP.getHeaderSearchInfo().loadModuleMapFile(File, /*IsSystem*/ false);
+      else
+        CI->getDiagnostics().Report(diag::err_module_map_not_found) << Filename;
+    }
+
     return CI.release(); // Passes over the ownership to the caller.
   }
 

--- a/interpreter/cling/lib/Interpreter/InterpreterCallbacks.cpp
+++ b/interpreter/cling/lib/Interpreter/InterpreterCallbacks.cpp
@@ -49,6 +49,12 @@ namespace cling {
                                       SearchPath, RelativePath, Imported);
     }
 
+    void EnteredSubmodule(clang::Module* M,
+                          clang::SourceLocation ImportLoc,
+                          bool ForPragma) override {
+      m_Callbacks->EnteredSubmodule(M, ImportLoc, ForPragma);
+    }
+
     virtual bool FileNotFound(llvm::StringRef FileName,
                               llvm::SmallVectorImpl<char>& RecoveryPath) {
       if (m_Callbacks)

--- a/interpreter/cling/lib/Interpreter/MultiplexInterpreterCallbacks.h
+++ b/interpreter/cling/lib/Interpreter/MultiplexInterpreterCallbacks.h
@@ -41,6 +41,12 @@ namespace cling {
                                Imported);
     }
 
+    void EnteredSubmodule(clang::Module* M, clang::SourceLocation ImportLoc,
+                          bool ForPragma) override {
+      for (auto&& cb : m_Callbacks)
+        cb->EnteredSubmodule(M, ImportLoc, ForPragma);
+    }
+
     bool FileNotFound(llvm::StringRef FileName,
                       llvm::SmallVectorImpl<char>& RecoveryPath) override {
       bool result = false;

--- a/interpreter/llvm/src/tools/clang/include/clang/Lex/PPCallbacks.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/Lex/PPCallbacks.h
@@ -128,6 +128,29 @@ public:
                                   const Module *Imported) {
   }
 
+  /// Callback invoked whenever a submodule was entered.
+  ///
+  /// \param M The submodule we have entered.
+  ///
+  /// \param ImportLoc The location of import directive token.
+  ///
+  /// \param ForPragma If entering from pragma directive.
+  ///
+  virtual void EnteredSubmodule(Module *M, SourceLocation ImportLoc,
+                                bool ForPragma) { }
+
+  /// Callback invoked whenever a submodule was left.
+  ///
+  /// \param M The submodule we have left.
+  ///
+  /// \param ImportLoc The location of import directive token.
+  ///
+  /// \param ForPragma If entering from pragma directive.
+  ///
+  virtual void LeftSubmodule(Module *M, SourceLocation ImportLoc,
+                             bool ForPragma) { }
+
+
   /// \brief Callback invoked whenever there was an explicit module-import
   /// syntax.
   ///
@@ -363,6 +386,18 @@ public:
     Second->InclusionDirective(HashLoc, IncludeTok, FileName, IsAngled,
                                FilenameRange, File, SearchPath, RelativePath,
                                Imported);
+  }
+
+  void EnteredSubmodule(Module *M, SourceLocation ImportLoc,
+                        bool ForPragma) override {
+    First->EnteredSubmodule(M, ImportLoc, ForPragma);
+    Second->EnteredSubmodule(M, ImportLoc, ForPragma);
+  }
+
+  void LeftSubmodule(Module *M, SourceLocation ImportLoc,
+                     bool ForPragma) override {
+    First->LeftSubmodule(M, ImportLoc, ForPragma);
+    Second->LeftSubmodule(M, ImportLoc, ForPragma);
   }
 
   void moduleImport(SourceLocation ImportLoc, ModuleIdPath Path,

--- a/interpreter/llvm/src/tools/clang/lib/Lex/PPLexerChange.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Lex/PPLexerChange.cpp
@@ -665,6 +665,8 @@ void Preprocessor::EnterSubmodule(Module *M, SourceLocation ImportLoc,
     BuildingSubmoduleStack.push_back(
         BuildingSubmoduleInfo(M, ImportLoc, ForPragma, CurSubmoduleState,
                               PendingModuleMacroNames.size()));
+    if (Callbacks)
+      Callbacks->EnteredSubmodule(M, ImportLoc, ForPragma);
     return;
   }
 
@@ -709,6 +711,9 @@ void Preprocessor::EnterSubmodule(Module *M, SourceLocation ImportLoc,
       BuildingSubmoduleInfo(M, ImportLoc, ForPragma, CurSubmoduleState,
                             PendingModuleMacroNames.size()));
 
+  if (Callbacks)
+    Callbacks->EnteredSubmodule(M, ImportLoc, ForPragma);
+
   // Switch to this submodule as the current submodule.
   CurSubmoduleState = &State;
 
@@ -749,6 +754,10 @@ Module *Preprocessor::LeaveSubmodule(bool ForPragma) {
     // are tracking macro visibility, don't build any, and preserve the list
     // of pending names for the surrounding submodule.
     BuildingSubmoduleStack.pop_back();
+
+    if (Callbacks)
+      Callbacks->LeftSubmodule(LeavingMod, ImportLoc, ForPragma);
+
     makeModuleVisible(LeavingMod, ImportLoc);
     return LeavingMod;
   }
@@ -832,6 +841,9 @@ Module *Preprocessor::LeaveSubmodule(bool ForPragma) {
     CurSubmoduleState = Info.OuterSubmoduleState;
 
   BuildingSubmoduleStack.pop_back();
+
+  if (Callbacks)
+    Callbacks->LeftSubmodule(LeavingMod, ImportLoc, ForPragma);
 
   // A nested #include makes the included submodule visible.
   makeModuleVisible(LeavingMod, ImportLoc);


### PR DESCRIPTION
ACLiC now synthesizes a modulemap with a suffix _ACLiC_dict.modulemap. The file contains the source file to be compiled and the corresponding library.
    
The modulemap is then passed to rootcling via -fmodule-map-file= flag to avoid naming clashes with possibly existing other modulemap files.
    
This patch teaches cling to work with the -fmodule-map-file= flag.
    
ACLiC supports automatic inclusion of Rtypes.h (making ClassDef macro available). Modules are built in isolation and are resilient to #include of Rtypes.h at rootcling startup time. We make module Core (containing Rtypes.h) visible via a newly implemented callback.

Depends on #3798 