### PR TITLE
Fix optimal step size when computating gradient for  confidence intervals in FitResult

### DIFF
--- a/math/mathcore/src/FitResult.cxx
+++ b/math/mathcore/src/FitResult.cxx
@@ -610,6 +610,7 @@ void FitResult::GetConfidenceIntervals(unsigned int n, unsigned int stride1, uns
                d.SetStepSize( std::max( fErrors[ipar]*1.E-5, 1.E-15) ); 
             else
                d.SetStepSize( std::min(std::max(fParams[ipar]*1.E-5, 1.E-15), 0.0001 ) );
+            
             grad[ipar] = d(fParams[ipar] ); // evaluate df/dp
          }
          else 

--- a/math/mathcore/src/FitResult.cxx
+++ b/math/mathcore/src/FitResult.cxx
@@ -599,16 +599,21 @@ void FitResult::GetConfidenceIntervals(unsigned int n, unsigned int stride1, uns
       }
 
       // calculate gradient of fitted function w.r.t the parameters
-
-      // check first if fFitFunction provides parameter gradient or not
-
-      // does not provide gradient
-      // t.b.d : skip calculation for fixed parameters
       ROOT::Math::RichardsonDerivator d;
       for (unsigned int ipar = 0; ipar < npar; ++ipar) {
-         ROOT::Math::OneDimParamFunctionAdapter<const ROOT::Math::IParamMultiFunction &> fadapter(*fFitFunc,&xpoint.front(),&fParams.front(),ipar);
-         d.SetFunction(fadapter);
-         grad[ipar] = d(fParams[ipar] ); // evaluate df/dp
+         if (!IsParameterFixed(ipar)) {
+            ROOT::Math::OneDimParamFunctionAdapter<const ROOT::Math::IParamMultiFunction &> fadapter(*fFitFunc,&xpoint.front(),&fParams.front(),ipar);
+            d.SetFunction(fadapter);
+            // compute step size as a small fraction of the error
+            // (see numerical recipes in C 5.7.8)   1.E-5 is ~ (eps)^1/3
+            if ( fErrors[ipar] > 0 ) 
+               d.SetStepSize( std::max( fErrors[ipar]*1.E-5, 1.E-15) ); 
+            else
+               d.SetStepSize( std::min(std::max(fParams[ipar]*1.E-5, 1.E-15), 0.0001 ) );
+            grad[ipar] = d(fParams[ipar] ); // evaluate df/dp
+         }
+         else 
+            grad[ipar] = 0.;  // for fixed parameters
       }
 
       // multiply covariance matrix with gradient


### PR DESCRIPTION
This fixes ROOT-9839 by computing an optimal stepwise depending on the result fit error. 
Now for parameter which have a very small error the step size is correctly estimated. 
The difference can be seen by fitting a gaussian with very small sigma (~ 10^-5) and computing the
confidence intervals. 

Also the fixed parameters are now correctly handled, although before, their contribution was not included due to their zero value in the covariance matrix

