### PR TITLE
[Exp PyROOT] Disable strict aliasing warnings

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
@@ -62,6 +62,11 @@ endforeach()
 ROOT_LINKER_LIBRARY(ROOTPython ${sources} LIBRARIES Core Tree cppyy)
 ROOT_INSTALL_HEADERS(inc)
 
+# Disables warnings caused by Py_RETURN_TRUE/Py_RETURN_FALSE
+if(NOT MSVC)
+    target_compile_options(ROOTPython PRIVATE -Wno-strict-aliasing)
+endif()
+
 # Disables warnings originating from deprecated register keyword in Python
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_STANDARD GREATER_EQUAL 11)
     target_compile_options(ROOTPython PRIVATE -Wno-register)

--- a/bindings/pyroot_experimental/PyROOT/src/PyzCppHelpers.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyzCppHelpers.cxx
@@ -37,13 +37,11 @@ PyObject *CallPyObjMethod(PyObject *obj, const char *meth, PyObject *arg1)
 PyObject *BoolNot(PyObject *value)
 {
    if (PyObject_IsTrue(value) == 1) {
-      Py_INCREF(Py_False);
       Py_DECREF(value);
-      return Py_False;
+      Py_RETURN_FALSE;
    } else {
-      Py_INCREF(Py_True);
       Py_XDECREF(value);
-      return Py_True;
+      Py_RETURN_TRUE;
    }
 }
 

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/CMakeLists.txt
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/CMakeLists.txt
@@ -42,8 +42,10 @@ ROOT_STANDARD_LIBRARY_PACKAGE(cppyy
     -writeEmptyRootPCM
 )
 
-target_compile_options(cppyy PRIVATE
-  -Wno-shadow -Wno-strict-aliasing -Wno-unused-but-set-parameter)
+if(NOT MSVC)
+  target_compile_options(cppyy PRIVATE
+    -Wno-shadow -Wno-strict-aliasing -Wno-unused-but-set-parameter)
+endif()
 
 # Disables warnings coming from PyCFunction casts
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL 8)


### PR DESCRIPTION
The following warnings:

http://cdash.cern.ch/viewBuildError.php?type=1&buildid=660547

are triggered when calling `Py_INCREF(Py_True)` and `Py_INCREF(Py_False)`, either directly or via the Python C API macros `Py_RETURN_TRUE` and `Py_RETURN_FALSE`. The use of these macros is necessary and can't be worked around.

This PR disables such warnings in PyROOT experimental (they were already disabled in the current PyROOT and in Cppyy).