### PR TITLE
[TMVA][ROOT-10136] Fix gcc9 warnings (-Wdeprecated-copy)

### DIFF
--- a/tmva/tmva/inc/TMVA/Event.h
+++ b/tmva/tmva/inc/TMVA/Event.h
@@ -71,6 +71,12 @@ namespace TMVA {
 
       ~Event();
 
+      // operators
+      // NOTE: Because we do not want to change the behaviour of the Event class
+      // as a public interface, we use the explicit default assignment operator,
+      // which is similar to the implicit one but silences gcc9 warnings.
+      Event& operator=( const Event& ) = default;
+
       // accessors
       Bool_t  IsDynamic()         const {return fDynamic; }
 

--- a/tmva/tmva/inc/TMVA/OptionMap.h
+++ b/tmva/tmva/inc/TMVA/OptionMap.h
@@ -101,16 +101,6 @@ namespace TMVA {
            OptionMap(const Char_t *options,const TString name="Option"):fName(name),fLogger(name.Data()),fBinder(fOptMap,""){
                ParseOption(options);
            }
-           OptionMap(const OptionMap &obj):fBinder(obj.fBinder)
-           {
-               fName   = obj.fName;
-               fLogger = obj.fLogger;
-               fOptMap = obj.fOptMap;
-           }
-//            OptionMap(const Char_t *options,const TString name="Option"):fName(name),fLogger(name.Data()),fBinder(fOptMap,"")
-//            {
-//              ParseOption(options);
-//            }
 
            virtual ~OptionMap(){}
 

--- a/tmva/tmva/inc/TMVA/Volume.h
+++ b/tmva/tmva/inc/TMVA/Volume.h
@@ -61,6 +61,9 @@ namespace TMVA {
       // destructor
       virtual ~Volume( void );
 
+      // operators
+      Volume& operator=( const Volume& );
+
       // destruct the volue 
       void Delete       ( void );
       // "scale" the volume by multiplying each upper and lower boundary by "f" 

--- a/tmva/tmva/src/Volume.cxx
+++ b/tmva/tmva/src/Volume.cxx
@@ -130,6 +130,24 @@ TMVA::Volume::Volume( Volume& V )
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// assignment operator
+
+TMVA::Volume& TMVA::Volume::operator=( const Volume& V )
+{
+   if (fOwnerShip) {
+      if (fLower) delete fLower;
+      if (fUpper) delete fUpper;
+      fLower = new std::vector<Double_t>( *V.fLower );
+      fUpper = new std::vector<Double_t>( *V.fUpper );
+   }
+   else {
+      fLower = V.fLower;
+      fUpper = V.fUpper;
+   }
+   return *this;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
 TMVA::Volume::~Volume( void )


### PR DESCRIPTION
- Implement assignment operator explicitely for Volume
- Set copy contructor of OptionMap to default since implementation is
not needed
- Set explicitely the default for Event.h which happened before
implicitely.