### PR TITLE
[metacling] TClingMethodInfo, skip over template instantiations

### DIFF
--- a/core/metacling/src/TClingMethodInfo.cxx
+++ b/core/metacling/src/TClingMethodInfo.cxx
@@ -57,31 +57,6 @@ compiler, not CINT.
 
 using namespace clang;
 
-class TClingMethodInfo::SpecIterator
-{
-public:
-   typedef clang::FunctionTemplateDecl::spec_iterator Iterator;
-
-   SpecIterator(Iterator begin, Iterator end) : fIter(begin), fEnd(end) {}
-   explicit SpecIterator(clang::FunctionTemplateDecl *decl) : fIter(decl->spec_begin()), fEnd(decl->spec_end()) {}
-
-   FunctionDecl *operator* () const { return *fIter; }
-   FunctionDecl *operator-> () const { return *fIter; }
-   SpecIterator & operator++ () { ++fIter; return *this; }
-   SpecIterator   operator++ (int) {
-      SpecIterator tmp(fIter,fEnd);
-      ++(*this);
-      return tmp;
-   }
-   bool operator!() { return fIter == fEnd; }
-   operator bool() { return fIter != fEnd; }
-
-private:
-
-   Iterator fIter;
-   Iterator fEnd;
-};
-
 TClingMethodInfo::TClingMethodInfo(const TClingMethodInfo &rhs) :
    TClingDeclInfo(rhs),
    fInterp(rhs.fInterp),
@@ -90,20 +65,15 @@ TClingMethodInfo::TClingMethodInfo(const TClingMethodInfo &rhs) :
    fContextIdx(rhs.fContextIdx),
    fIter(rhs.fIter),
    fTitle(rhs.fTitle),
-   fTemplateSpecIter(nullptr)
+   fTemplateSpec(rhs.fTemplateSpec)
 {
-   if (rhs.fTemplateSpecIter) {
-      // The SpecIterator query the decl.
-      R__LOCKGUARD(gInterpreterMutex);
-      fTemplateSpecIter = new SpecIterator(*rhs.fTemplateSpecIter);
-   }
 }
 
 
 TClingMethodInfo::TClingMethodInfo(cling::Interpreter *interp,
                                    TClingClassInfo *ci)
    : TClingDeclInfo(nullptr), fInterp(interp), fFirstTime(true), fContextIdx(0U), fTitle(""),
-     fTemplateSpecIter(0)
+     fTemplateSpec(0)
 {
    R__LOCKGUARD(gInterpreterMutex);
 
@@ -132,14 +102,14 @@ TClingMethodInfo::TClingMethodInfo(cling::Interpreter *interp,
 TClingMethodInfo::TClingMethodInfo(cling::Interpreter *interp,
                                    const clang::FunctionDecl *FD)
    : TClingDeclInfo(FD), fInterp(interp), fFirstTime(true), fContextIdx(0U), fTitle(""),
-     fTemplateSpecIter(0)
+     fTemplateSpec(0)
 {
 
 }
 
 TClingMethodInfo::~TClingMethodInfo()
 {
-   delete fTemplateSpecIter;
+   delete fTemplateSpec;
 }
 
 TDictionary::DeclId_t TClingMethodInfo::GetDeclId() const
@@ -191,8 +161,7 @@ void TClingMethodInfo::Init(const clang::FunctionDecl *decl)
    fFirstTime = true;
    fContextIdx = 0U;
    fIter = clang::DeclContext::decl_iterator();
-   delete fTemplateSpecIter;
-   fTemplateSpecIter = 0;
+   fTemplateSpec = 0;
    fDecl = decl;
 }
 
@@ -209,11 +178,8 @@ void *TClingMethodInfo::InterfaceMethod(const ROOT::TMetaUtils::TNormalizedCtxt 
 
 const clang::Decl* TClingMethodInfo::GetDeclSlow() const
 {
-   if (fTemplateSpecIter) {
-      // Could trigger deserialization of decls.
-      R__LOCKGUARD(gInterpreterMutex);
-      cling::Interpreter::PushTransactionRAII RAII(fInterp);
-      return *(*fTemplateSpecIter);
+   if (fTemplateSpec) {
+      return fTemplateSpec;
    }
    return *fIter;
 }
@@ -255,33 +221,34 @@ static bool HasUnexpandedParameterPack(clang::QualType QT, clang::Sema& S) {
 }
  */
 
-static void InstantiateFuncTemplateWithDefaults(clang::FunctionTemplateDecl* FTDecl,
-                                                clang::Sema& S,
-                                                const cling::LookupHelper& LH) {
+static const clang::FunctionDecl *
+GetOrInstantiateFuncTemplateWithDefaults(clang::FunctionTemplateDecl* FTDecl,
+                                         clang::Sema& S,
+                                         const cling::LookupHelper& LH) {
    // Force instantiation if it doesn't exist yet, by looking it up.
    using namespace clang;
 
    auto templateParms = FTDecl->getTemplateParameters();
    if (templateParms->containsUnexpandedParameterPack())
-      return;
+      return nullptr;
 
    if (templateParms->getMinRequiredArguments() > 0)
-      return;
+      return nullptr;
 
    if (templateParms->size() > 0) {
       NamedDecl *arg0 = *templateParms->begin();
       if (arg0->isTemplateParameterPack())
-         return;
+         return nullptr;
       if (auto TTP = dyn_cast<TemplateTypeParmDecl>(*templateParms->begin())) {
          if (!TTP->hasDefaultArgument())
-            return;
+            return nullptr;
       } else if (auto NTTP = dyn_cast<NonTypeTemplateParmDecl>(
          *templateParms->begin())) {
          if (!NTTP->hasDefaultArgument())
-            return;
+            return nullptr;
       } else {
          // TemplateTemplateParmDecl, pack
-         return;
+         return nullptr;
       }
    }
 
@@ -302,7 +269,7 @@ static void InstantiateFuncTemplateWithDefaults(clang::FunctionTemplateDecl* FTD
       if (templateParm->isTemplateParameterPack()) {
          // shouldn't end up here
          assert(0 && "unexpected template parameter pack");
-         return;
+         return nullptr;
       } if (auto TTP = dyn_cast<TemplateTypeParmDecl>(templateParm)) {
          defaultTemplateArgs[iParam] = TemplateArgument(TTP->getDefaultArgument());
       } else if (auto NTTP = dyn_cast<NonTypeTemplateParmDecl>(templateParm)) {
@@ -312,7 +279,7 @@ static void InstantiateFuncTemplateWithDefaults(clang::FunctionTemplateDecl* FTD
       } else {
          // shouldn't end up here
          assert(0 && "unexpected template parameter kind");
-         return;
+         return nullptr;
       }
    }
 
@@ -350,15 +317,15 @@ static void InstantiateFuncTemplateWithDefaults(clang::FunctionTemplateDecl* FTD
          if (paramType.isNull() || paramType->isDependentType()) {
             // Even after resolving the types through the surrounding template
             // this argument type is still dependent: do not look it up.
-            return;
+            return nullptr;
          }
       }
       paramTypes.push_back(paramType);
    }
 
-   LH.findFunctionProto(declCtxDecl, FTDecl->getNameAsString(),
-                        paramTypes, LH.NoDiagnostics,
-                        templatedDecl->getType().isConstQualified());
+   return LH.findFunctionProto(declCtxDecl, FTDecl->getNameAsString(),
+                               paramTypes, LH.NoDiagnostics,
+                               templatedDecl->getType().isConstQualified());
 }
 
 int TClingMethodInfo::InternalNext()
@@ -373,25 +340,17 @@ int TClingMethodInfo::InternalNext()
       return 0;
    }
    while (true) {
+      // If we had fTemplateSpec we don't need it anymore, but advance
+      // to the next decl.
+      fTemplateSpec = nullptr;
+
       // Advance to the next decl.
       if (fFirstTime) {
          // The cint semantics are weird.
          fFirstTime = false;
       }
       else {
-         if (fTemplateSpecIter) {
-            ++(*fTemplateSpecIter);
-            if ( !(*fTemplateSpecIter) ) {
-               // We reached the end of the template specialization.
-               delete fTemplateSpecIter;
-               fTemplateSpecIter = 0;
-               ++fIter;
-            } else {
-               return 1;
-            }
-         } else {
-            ++fIter;
-         }
+         ++fIter;
       }
       // Fix it if we have gone past the end of the current decl context.
       while (!*fIter) {
@@ -411,29 +370,17 @@ int TClingMethodInfo::InternalNext()
          }
       }
 
-      clang::FunctionTemplateDecl *templateDecl =
-         llvm::dyn_cast<clang::FunctionTemplateDecl>(*fIter);
-
-      if ( templateDecl ) {
-         // SpecIterator calls clang::FunctionTemplateDecl::spec_begin
-         // which calls clang::FunctionTemplateDecl::LoadLazySpecializations.
-         // Instantiation below can also trigger deserialization.
+      if (const auto templateDecl = llvm::dyn_cast<clang::FunctionTemplateDecl>(*fIter)) {
+         // Instantiation below can trigger deserialization.
          cling::Interpreter::PushTransactionRAII RAII(fInterp);
 
          // If this function template can be instantiated without template
          // arguments then it's worth having it. This commonly happens for
          // enable_if'ed functions.
-         // Whatever this finds / instantiates will be picked up by the
-         // SpecIterator below.
-         InstantiateFuncTemplateWithDefaults(templateDecl, fInterp->getSema(),
-                                             fInterp->getLookupHelper());
-
-         SpecIterator subiter(templateDecl);
-         if (subiter) {
-            delete fTemplateSpecIter;
-            fTemplateSpecIter = new SpecIterator(templateDecl);
+         fTemplateSpec = GetOrInstantiateFuncTemplateWithDefaults(templateDecl, fInterp->getSema(),
+                                                                  fInterp->getLookupHelper());
+         if (fTemplateSpec)
             return 1;
-         }
       }
 
       // Return if this decl is a function or method.

--- a/core/metacling/src/TClingMethodInfo.h
+++ b/core/metacling/src/TClingMethodInfo.h
@@ -53,22 +53,20 @@ class TClingTypeInfo;
 
 class TClingMethodInfo final : public TClingDeclInfo {
 private:
-   class SpecIterator;
-
    cling::Interpreter                          *fInterp; // Cling interpreter, we do *not* own.
    llvm::SmallVector<clang::DeclContext *, 2>   fContexts; // Set of DeclContext that we will iterate over.
    bool                                         fFirstTime; // Flag for first time incrementing iterator, cint semantics are weird.
    unsigned int                                 fContextIdx; // Index in fContexts of DeclContext we are iterating over.
    clang::DeclContext::decl_iterator            fIter; // Our iterator.
    std::string                                  fTitle; // The meta info for the method.
-   SpecIterator                                *fTemplateSpecIter; // Iter over template specialization. [We own]
+   const clang::FunctionDecl                   *fTemplateSpec; // an all-default-template-args function.
 
    const clang::Decl* GetDeclSlow() const;
 
 public:
    explicit TClingMethodInfo(cling::Interpreter *interp)
       : TClingDeclInfo(nullptr), fInterp(interp), fFirstTime(true), fContextIdx(0U), fTitle(""),
-        fTemplateSpecIter(0) {}
+        fTemplateSpec(0) {}
 
    TClingMethodInfo(const TClingMethodInfo&);
 


### PR DESCRIPTION
…ations:

TClingMethodInfo keeps track of what can be called.
Whether someone else has created an instantiation of a template is of no relevance for that questions.
OTOH templates that have default argumemnts of all template parameters *can* be invoked without templateargument,
so that *is* significant for "callability", and TClingMethodInfo will enumerate them.

This might fix https://bitbucket.org/wlav/cppyy/issues/102/wrong-resolution-in-template-method-call