### PR TITLE
Fix gcc9 warnings in GUI

### DIFF
--- a/gui/gui/inc/TGDimension.h
+++ b/gui/gui/inc/TGDimension.h
@@ -31,8 +31,7 @@ public:
 
    TGDimension(): fWidth(0), fHeight(0) { }
    TGDimension(UInt_t width, UInt_t height): fWidth(width), fHeight(height) { }
-   TGDimension(const TGDimension &d): fWidth(d.fWidth), fHeight(d.fHeight) { }
-   virtual ~TGDimension() { }
+   ~TGDimension() = default;
 
    Bool_t operator==(const TGDimension &b) const
       { return ((fWidth == b.fWidth) && (fHeight == b.fHeight)); }
@@ -40,8 +39,6 @@ public:
       { return TGDimension(fWidth - b.fWidth, fHeight - b.fHeight); }
    TGDimension operator+(const TGDimension &b) const
       { return TGDimension(fWidth + b.fWidth, fHeight + b.fHeight); }
-
-   ClassDef(TGDimension,0)  // Dimension object (width, height)
 };
 
 
@@ -52,8 +49,7 @@ public:
 
    TGPosition(): fX(0), fY(0) { }
    TGPosition(Int_t xc, Int_t yc): fX(xc), fY(yc) { }
-   TGPosition(const TGPosition &p): fX(p.fX), fY(p.fY) { }
-   virtual ~TGPosition() { }
+   ~TGPosition() = default;
 
    Bool_t operator==(const TGPosition &b) const
       { return ((fX == b.fX) && (fY == b.fY)); }
@@ -61,8 +57,6 @@ public:
       { return TGPosition(fX - b.fX, fY - b.fY); }
    TGPosition operator+(const TGPosition &b) const
       { return TGPosition(fX + b.fX, fY + b.fY); }
-
-   ClassDef(TGPosition,0)  // Position object (x and y are Int_t)
 };
 
 
@@ -73,8 +67,7 @@ public:
 
    TGLongPosition(): fX(0), fY(0) { }
    TGLongPosition(Long_t xc, Long_t yc): fX(xc), fY(yc) { }
-   TGLongPosition(const TGLongPosition &p): fX(p.fX), fY(p.fY) { }
-   virtual ~TGLongPosition() { }
+   ~TGLongPosition() = default;
 
    Bool_t operator==(const TGLongPosition &b) const
       { return ((fX == b.fX) && (fY == b.fY)); }
@@ -82,8 +75,6 @@ public:
       { return TGLongPosition(fX - b.fX, fY - b.fY); }
    TGLongPosition operator+(const TGLongPosition &b) const
       { return TGLongPosition(fX + b.fX, fY + b.fY); }
-
-   ClassDef(TGLongPosition,0)  // Position object (x and y are Long_t)
 };
 
 
@@ -97,14 +88,10 @@ public:
    TGInsets(): fL(0), fR(0), fT(0), fB(0) { }
    TGInsets(Int_t lf, Int_t rg, Int_t tp, Int_t bt):
       fL(lf), fR(rg), fT(tp), fB(bt) { }
-   TGInsets(const TGInsets &in):
-      fL(in.fL), fR(in.fR), fT(in.fT), fB(in.fB) { }
-   virtual ~TGInsets() { }
+   ~TGInsets() = default;
 
    Bool_t operator==(const TGInsets &in) const
       { return ((fL == in.fL) && (fR == in.fR) && (fT == in.fT) && (fB == in.fB)); }
-
-   ClassDef(TGInsets,0)   // Inset (left, right, top, bottom)
 };
 
 
@@ -121,9 +108,7 @@ public:
                 fX(rx), fY(ry), fW(rw), fH(rh) { }
    TGRectangle(const TGPosition &p, const TGDimension &d):
                 fX(p.fX), fY(p.fY), fW(d.fWidth), fH(d.fHeight) { }
-   TGRectangle(const TGRectangle &r):
-                fX(r.fX), fY(r.fY), fW(r.fW), fH(r.fH) { }
-   virtual ~TGRectangle() { }
+   ~TGRectangle() = default;
 
    // methods
    Bool_t Contains(Int_t px, Int_t py) const
@@ -146,8 +131,6 @@ public:
    void Merge(const TGRectangle &r);
    void Empty() { fX = fY = 0; fW = fH = 0; }
    Bool_t IsEmpty() const { return ((fW == 0) && (fH == 0)); }
-
-   ClassDef(TGRectangle, 0)  // Rectangle object
 };
 
 #endif

--- a/gui/gui/src/TGCanvas.cxx
+++ b/gui/gui/src/TGCanvas.cxx
@@ -564,7 +564,6 @@ void TGContainer::SelectAll()
    TIter next(fList);
    TGFrameElement *el;
    TGFrame *fr;
-   TGPosition pos = GetPagePosition();
 
    while ((el = (TGFrameElement *) next())) {
       fr = el->fFrame;
@@ -586,7 +585,6 @@ void TGContainer::UnSelectAll()
 {
    TIter next(fList);
    TGFrameElement *el;
-   TGPosition pos = GetPagePosition();
    TGFrame *fr;
 
    while ((el = (TGFrameElement *) next())) {

--- a/gui/gui/src/TGListTree.cxx
+++ b/gui/gui/src/TGListTree.cxx
@@ -1235,7 +1235,6 @@ void TGListTree::LineUp(Bool_t /*select*/)
    Int_t height = 0;
    if (!fCurrent) return;
 
-   TGDimension dim = GetPageDimension();
    TGPosition pos = GetPagePosition();
    const TGPicture *pic1 = fCurrent->GetPicture();
    if (pic1) height = pic1->GetHeight() + fVspacing;


### PR DESCRIPTION
As suggested by Axel:
TGDimension.h: Remove the copy constructors (rely on the compiler generated ones), add default (non virtual) destructors, and remove useless ClassDefs
TGCanvas.cxx, TGListTree.cxx: Remove unused variables (fixes [-Wunused-but-set-variable] warnings)