### PR TITLE
[HistPainter][ROOT-10137] Silence warnings (-Wformat-truncation)

### DIFF
--- a/hist/histpainter/CMakeLists.txt
+++ b/hist/histpainter/CMakeLists.txt
@@ -34,3 +34,8 @@ ROOT_STANDARD_LIBRARY_PACKAGE(HistPainter
     Matrix
     ${HISTPAINTER_V7_LIBRARIES}
 )
+
+# Silence -Wformat=truncation warnings starting with gcc7
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL 7)
+    target_compile_options(HistPainter PRIVATE -Wno-format-truncation)
+endif()


### PR DESCRIPTION
Alternatively we could enlarge the buffer for `snprintf`. However, this would change the print-out since the truncation feature of `snprintf` could be intended.

@lmoneta What do you think?