### PR TITLE
[RF] Fix gcc9 warnings.

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/Data.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Data.h
@@ -27,9 +27,11 @@ public:
   //friend class Channel;
 
   Data();
-  Data( const Data& other );
+  Data( const Data& other ) = default;
   /// constructor from name, file and path. Name of the histogram should not include the path
   Data( std::string HistoName, std::string InputFile, std::string HistoPath="" );
+
+  Data& operator=(const Data& other) = default;
 
   std::string GetName() { return fName; }
   void SetName(const std::string& name) { fName=name; }

--- a/roofit/histfactory/inc/RooStats/HistFactory/Data.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Data.h
@@ -27,11 +27,8 @@ public:
   //friend class Channel;
 
   Data();
-  Data( const Data& other ) = default;
   /// constructor from name, file and path. Name of the histogram should not include the path
   Data( std::string HistoName, std::string InputFile, std::string HistoPath="" );
-
-  Data& operator=(const Data& other) = default;
 
   std::string GetName() { return fName; }
   void SetName(const std::string& name) { fName=name; }

--- a/roofit/histfactory/inc/RooStats/HistFactory/Sample.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Sample.h
@@ -32,6 +32,7 @@ public:
   Sample();
   Sample(std::string Name);
   Sample(const Sample& other);
+  Sample& operator=(const Sample& other);
   /// constructor from name, file and path. Name of the histogram should not include the path
   Sample(std::string Name, std::string HistoName, std::string InputFile, std::string HistoPath="");
   ~Sample();

--- a/roofit/histfactory/src/Data.cxx
+++ b/roofit/histfactory/src/Data.cxx
@@ -21,14 +21,6 @@ RooStats::HistFactory::Data::Data() : fName("") {
   ;
 }
 
-RooStats::HistFactory::Data::Data( const Data& other ) :
-  fName( other.fName ),
-  fInputFile( other.fInputFile ),
-  fHistoName( other.fHistoName ),
-  fHistoPath( other.fHistoPath ),
-  fhData( other.fhData )
-{ ; }
-
 RooStats::HistFactory::Data::Data( std::string HistoName, std::string InputFile, 
 				   std::string HistoPath ) :
   fInputFile( InputFile ), fHistoName( HistoName ), fHistoPath( HistoPath ) {;}

--- a/roofit/histfactory/src/Sample.cxx
+++ b/roofit/histfactory/src/Sample.cxx
@@ -48,6 +48,36 @@ RooStats::HistFactory::Sample::Sample(const Sample& other) :
     }
   }
 
+RooStats::HistFactory::Sample& RooStats::HistFactory::Sample::operator=(const Sample& other)
+{
+  fName = other.fName; fInputFile = other.fInputFile;
+  fHistoName = other.fHistoName; fHistoPath = other.fHistoPath;
+  fChannelName = other.fChannelName;
+
+  fOverallSysList = other.fOverallSysList;
+  fNormFactorList = other.fNormFactorList;
+  fHistoSysList = other.fHistoSysList;
+  fHistoFactorList = other.fHistoFactorList;
+  fShapeSysList = other.fShapeSysList;
+  fShapeFactorList = other.fShapeFactorList;
+
+  fStatError = other.fStatError;
+  fNormalizeByTheory = other.fNormalizeByTheory;
+  fStatErrorActivate = other.fStatErrorActivate;
+  fhNominal = other.fhNominal;
+
+  if (fhCountingHist)
+    delete fhCountingHist;
+
+  if( other.fhCountingHist ) {
+    SetValue( other.fhCountingHist->GetBinContent(1) );
+  } else {
+    fhCountingHist = NULL;
+  }
+
+  return *this;
+}
+
 
 RooStats::HistFactory::Sample::Sample(std::string SampName, std::string SampHistoName, std::string SampInputFile, std::string SampHistoPath) : 
   fName( SampName ),   fInputFile( SampInputFile), 

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -41,6 +41,7 @@ public:
   RooAbsData() ; 
   RooAbsData(const char *name, const char *title, const RooArgSet& vars, RooAbsDataStore* store=0) ;
   RooAbsData(const RooAbsData& other, const char* newname = 0) ;
+  RooAbsData& operator=(const RooAbsData& other);
   virtual ~RooAbsData() ;
   virtual RooAbsData* emptyClone(const char* newName=0, const char* newTitle=0, const RooArgSet* vars=0, const char* wgtVarName=0) const = 0 ;
 
@@ -258,9 +259,6 @@ protected:
   // Column structure definition
   RooArgSet _vars;         // Dimensions of this data set
   RooArgSet _cachedVars ;  //! External variables cached with this data set
-
-  TIterator *_iterator;    //! Iterator over dimension variables
-  TIterator *_cacheIter ;  //! Iterator over cached variables
 
   RooAbsDataStore* _dstore ; // Data storage implementation
 

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -50,7 +50,7 @@ public:
   //RooDataHist(const char *name, const char *title, const RooArgList& vars, Double_t initWgt=1.0) ;
   RooDataHist(const char *name, const char *title, const RooArgList& vars, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg(), const RooCmdArg& arg3=RooCmdArg(),
 	      const RooCmdArg& arg4=RooCmdArg(),const RooCmdArg& arg5=RooCmdArg(),const RooCmdArg& arg6=RooCmdArg(),const RooCmdArg& arg7=RooCmdArg(),const RooCmdArg& arg8=RooCmdArg()) ;
-
+  RooDataHist& operator=(const RooDataHist&) = delete;
 
   RooDataHist(const RooDataHist& other, const char* newname = 0) ;
   virtual TObject* Clone(const char* newname=0) const { return new RooDataHist(*this,newname?newname:GetName()) ; }
@@ -183,12 +183,12 @@ protected:
   TIterator* _realIter ; //! Iterator over realVars
   Bool_t*    _binValid ; //! Valid bins with current range definition
  
-  mutable Double_t _curWeight ; // Weight associated with the current coordinate
-  mutable Double_t _curWgtErrLo ; // Error on weight associated with the current coordinate
-  mutable Double_t _curWgtErrHi ; // Error on weight associated with the current coordinate
-  mutable Double_t _curSumW2 ; // Current sum of weights^2
-  mutable Double_t _curVolume ; // Volume of bin enclosing current coordinate
-  mutable Int_t    _curIndex ; // Current index
+  mutable Double_t _curWeight{0.}; // Weight associated with the current coordinate
+  mutable Double_t _curWgtErrLo{0.}; // Error on weight associated with the current coordinate
+  mutable Double_t _curWgtErrHi{0.}; // Error on weight associated with the current coordinate
+  mutable Double_t _curSumW2{0.}; // Current sum of weights^2
+  mutable Double_t _curVolume{0.}; // Volume of bin enclosing current coordinate
+  mutable Int_t    _curIndex{0}; // Current index
 
   mutable std::vector<Double_t>* _pbinv ; //! Partial bin volume array
   mutable RooCacheManager<std::vector<Double_t> > _pbinvCacheMgr ; //! Cache manager for arrays of partial bin volumes
@@ -196,8 +196,8 @@ protected:
   std::vector<const RooAbsBinning*> _lvbins ; //! List of used binnings associated with lvalues
   mutable std::vector<std::vector<Double_t> > _binbounds; //! list of bin bounds per dimension
 
-  mutable Int_t _cache_sum_valid ; //! Is cache sum valid
-  mutable Double_t _cache_sum ; //! Cache for sum of entries ;
+  mutable Int_t _cache_sum_valid{0}; //! Is cache sum valid
+  mutable Double_t _cache_sum{0.}; //! Cache for sum of entries ;
 
 
 private:

--- a/roofit/roofitcore/src/RooDataHistSliceIter.cxx
+++ b/roofit/roofitcore/src/RooDataHistSliceIter.cxx
@@ -60,10 +60,8 @@ RooDataHistSliceIter::RooDataHistSliceIter(RooDataHist& hist, RooAbsArg& sliceAr
 //   hist.Print() ;
 //   cout << "hist._iterator = " << hist._iterator << endl ;
 
-  hist._iterator->Reset() ;
-  RooAbsArg* arg ;
   Int_t i=0 ;
-  while((arg=(RooAbsArg*)hist._iterator->Next())) {
+  for (const auto arg : hist._vars) {
     if (arg==sliceArgInt) break ;
     i++ ;
   }


### PR DESCRIPTION
- Fixing gcc9 warnings by either defaulting, implementing or deleting assignment operators.
- Implementing the assignment operator of RooAbsData required removing members that were
iterators. They have been replaced by range-based for loops.
- This entailed cleaning of RooDataHist code.

ROOT-10135