### PR TITLE
Small fix for geometry state recovery in VMC

### DIFF
--- a/montecarlo/vmc/inc/TMCManagerStack.h
+++ b/montecarlo/vmc/inc/TMCManagerStack.h
@@ -108,14 +108,17 @@ public:
    /// Get particle's geometry status by trackId
    const TGeoBranchArray *GetGeoState(Int_t trackId) const;
 
+   /// Get current particle's geometry status
+   const TGeoBranchArray *GetCurrentGeoState() const;
+
    //
    // Action methods
    //
 
    /// To free the cached geo state which was associated to a track
    void NotifyOnRestoredGeometry(Int_t trackId);
-   /// To free the cached geo state which was associated to a track
-   void NotifyOnRestoredGeometry(const TGeoBranchArray *geoState);
+   /// To free the cached geo state which was associated to the current track
+   void NotifyOnRestoredGeometry();
 
 private:
    friend class TMCManager;

--- a/montecarlo/vmc/src/TMCManagerStack.cxx
+++ b/montecarlo/vmc/src/TMCManagerStack.cxx
@@ -220,6 +220,27 @@ const TGeoBranchArray *TMCManagerStack::GetGeoState(Int_t trackId) const
 
 ////////////////////////////////////////////////////////////////////////////////
 ///
+/// Get current particle's geometry status
+///
+
+const TGeoBranchArray *TMCManagerStack::GetCurrentGeoState() const
+{
+   return fBranchArrayContainer->GetGeoState(fParticlesStatus->operator[](fCurrentTrackId)->fGeoStateIndex);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// To free the cached geo state which was associated to the current track
+///
+
+void TMCManagerStack::NotifyOnRestoredGeometry()
+{
+   fBranchArrayContainer->FreeGeoState(fParticlesStatus->operator[](fCurrentTrackId)->fGeoStateIndex);
+   fParticlesStatus->operator[](fCurrentTrackId)->fGeoStateIndex = 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
 /// To free the cached geo state which was associated to a track
 ///
 
@@ -229,15 +250,7 @@ void TMCManagerStack::NotifyOnRestoredGeometry(Int_t trackId)
       Fatal("NotifyOnRestoredGeometry", "Invalid track ID %i", trackId);
    }
    fBranchArrayContainer->FreeGeoState(fParticlesStatus->operator[](trackId)->fGeoStateIndex);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///
-/// To free the cached geo state which was associated to a track
-///
-void TMCManagerStack::NotifyOnRestoredGeometry(const TGeoBranchArray *geoState)
-{
-   fBranchArrayContainer->FreeGeoState(geoState);
+   fParticlesStatus->operator[](trackId)->fGeoStateIndex = 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The index of the geometry state belonging to a track is now reset
properly when the TMCManagerStack is notified on the restored geometry.