### PR TITLE
Fix order of includes on case-insensitive filesystems

### DIFF
--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -421,7 +421,7 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
   #---call rootcint------------------------------------------
   add_custom_command(OUTPUT ${dictionary}.cxx ${pcm_name} ${rootmap_name} ${cpp_module_file}
                      COMMAND ${command} -v2 -f  ${dictionary}.cxx ${newargs} ${excludepathsargs} ${rootmapargs}
-                                        ${definitions} ${includedirs} ${ARG_OPTIONS} ${headerfiles} ${_linkdef}
+                                        ${definitions} ${ARG_OPTIONS} ${includedirs} ${headerfiles} ${_linkdef}
                      IMPLICIT_DEPENDS ${_implicitdeps}
                      DEPENDS ${_list_of_header_dependencies} ${_linkdef} ${ROOTCINTDEP} ${ARG_DEPENDENCIES})
   get_filename_component(dictname ${dictionary} NAME)

--- a/core/foundation/test/testNotFn.cxx
+++ b/core/foundation/test/testNotFn.cxx
@@ -1,6 +1,8 @@
 #include "ROOT/RNotFn.hxx"
 
-#ifndef __cpp_lib_not_fn
+// libc++ does not define __cpp_lib_not_fn.
+// Assume we have not_fn if
+#if defined(R__NOTFN_BACKPORT)
 
 #include "gtest/gtest.h"
 

--- a/math/rtools/CMakeLists.txt
+++ b/math/rtools/CMakeLists.txt
@@ -8,11 +8,15 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Rtools
     Math/RMinimizer.h
   SOURCES
     src/RMinimizer.cxx
+  DICTIONARY_OPTIONS
+    -I${R_INCLUDE_DIR}
   DEPENDENCIES
     Core
     MathCore
     RInterface
 )
+
+target_include_directories(Rtools BEFORE PRIVATE ${R_INCLUDE_DIR})
 
 file(COPY "${CMAKE_SOURCE_DIR}/etc/plugins/ROOT@@Math@@Minimizer/P090_RMinimizer.C"
   DESTINATION "${CMAKE_BINARY_DIR}/etc/plugins/ROOT@@Math@@Minimizer/")

--- a/tmva/rmva/CMakeLists.txt
+++ b/tmva/rmva/CMakeLists.txt
@@ -15,6 +15,8 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RMVA
     src/MethodRSVM.cxx
     src/MethodRXGB.cxx
     src/RMethodBase.cxx
+  DICTIONARY_OPTIONS
+    -I${R_INCLUDE_DIR}
   DEPENDENCIES
     Core
     Matrix
@@ -23,3 +25,5 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RMVA
     Thread
     TMVA
 )
+
+target_include_directories(RMVA BEFORE PRIVATE ${R_INCLUDE_DIR})


### PR DESCRIPTION
Fixes [ROOT-10070](https://sft.its.cern.ch/jira/browse/ROOT-10070).