### PR TITLE
[io] Teach TMemFile to work with regions with no extra memory copy

### DIFF
--- a/io/io/inc/TMemFile.h
+++ b/io/io/inc/TMemFile.h
@@ -26,7 +26,7 @@ public:
       ExternalDataRange_t(const char * start, const size_t size) : fStart(start), fSize(size) {}
    };
 
-private:
+protected:
    struct TMemBlock {
    private:
       TMemBlock(const TMemBlock&);            // Not implemented

--- a/io/io/inc/TMemFile.h
+++ b/io/io/inc/TMemFile.h
@@ -45,7 +45,7 @@ protected:
       Long64_t   fSize;
    };
    TMemBlock    fBlockList;               ///< Collection of memory blocks of size fgDefaultBlockSize
-   ExternalDataPtr_t fExternalData; ///< shared file data / content
+   ExternalDataPtr_t fExternalData;       ///< shared file data / content
    Bool_t       fIsOwnedByROOT;           ///< if this is a C-style memory region
    Long64_t     fSize;                    ///< Total file size (sum of the size of the chunks)
    Long64_t     fSysOffset;               ///< Seek offset in file

--- a/io/io/src/TMemFile.cxx
+++ b/io/io/src/TMemFile.cxx
@@ -147,27 +147,16 @@ TMemFile::TMemFile(const char *path, ExternalDataPtr_t data)
 /// Constructor to create a read-only TMemFile using an std::unique_ptr<TBufferFile>
 
 TMemFile::TMemFile(const char *name, std::unique_ptr<TBufferFile> buffer)
-   : TFile(name, "WEB", "read-only TMemFile", 0 /* compress */),
-     fBlockList(reinterpret_cast<UChar_t *>(buffer->Buffer()), buffer->BufferSize()), fIsOwnedByROOT(true),
-     fSize(buffer->BufferSize()), fSysOffset(0), fBlockSeek(&(fBlockList)), fBlockOffset(0)
+   : TMemFile(name, ExternalDataRange_t(buffer->Buffer(), (size_t)buffer->BufferSize()))
 {
-   fD = 0;
-   fOption = "READ";
-   fWritable = false;
+   assert(!fD && !fWritable);
+
+   fIsOwnedByROOT = true;
 
    // Note: We need to release the buffer here to avoid double delete.
    // The memory of a TBufferFile is allocated with new[], so we can let
    // TMemBlock delete it, as its destructor calls "delete [] fBuffer;"
    buffer.release();
-
-   // This is read-only, so become a zombie if created with an empty buffer
-   if (!fBlockList.fBuffer) {
-      MakeZombie();
-      gDirectory = gROOT;
-      return;
-   }
-
-   Init(/* create */ false);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/io/io/src/TMemFile.cxx
+++ b/io/io/src/TMemFile.cxx
@@ -118,7 +118,7 @@ TMemFile::EMode TMemFile::ParseOption(Option_t *option)
 TMemFile::TMemFile(const char *path, const ExternalDataRange_t &datarange)
    : TFile(path, "WEB", "read-only TMemFile", 0 /*compress*/),
      fBlockList(reinterpret_cast<UChar_t *>(const_cast<char *>(datarange.fStart)), datarange.fSize),
-     fIsOwnedByROOT(false), fSize(datarange.fSize), fSysOffset(0), fBlockSeek(nullptr), fBlockOffset(0)
+     fIsOwnedByROOT(false), fSize(datarange.fSize), fSysOffset(0), fBlockSeek(&(fBlockList)), fBlockOffset(0)
 {
    fD = 0;
    fOption = "READ";

--- a/io/io/test/TROMemFileTests.cxx
+++ b/io/io/test/TROMemFileTests.cxx
@@ -64,6 +64,7 @@ TEST(TROMemFile, NoInternalMemCopy)
    EXPECT_STREQ(title2, readN->GetTitle());
 }
 
+/// Check that TMemFile do not (re-)allocate the external contents.
 TEST(TROMemFile, RealNoMemCopy)
 {
    std::string expected = "Hello from TMemFile!";
@@ -78,4 +79,10 @@ TEST(TROMemFile, RealNoMemCopy)
 
    ASSERT_EQ(expected_size, seen.size());
    ASSERT_STREQ(expected.c_str(), &seen[0]);
+
+   // Make sure that the ptr is the same assuming no allocations happened internally.
+   struct MemBlockPtrGetter : public TMemFile {
+      static void *GetBlockStart(TMemFile *M) { return static_cast<MemBlockPtrGetter *>(M)->fBlockList.fBuffer; }
+   };
+   ASSERT_EQ(expected.c_str(), MemBlockPtrGetter::GetBlockStart(&rosmf));
 }

--- a/io/io/test/TROMemFileTests.cxx
+++ b/io/io/test/TROMemFileTests.cxx
@@ -44,7 +44,7 @@ TEST(TROMemFile, NoWriting)
 }
 
 /// Check that TMemFile uses the original buffer, not a copy
-TEST(TROMemFile, NoMemCopy)
+TEST(TROMemFile, NoInternalMemCopy)
 {
    // Create a TNamed with this original title, and open the TMemFile with it.
    constexpr const char title1[] = "This is a title for TMemFile shared data test NoMemCopy";
@@ -62,4 +62,20 @@ TEST(TROMemFile, NoMemCopy)
    TObject *readN = rosmf.Get("name");
    ASSERT_NE(nullptr, readN);
    EXPECT_STREQ(title2, readN->GetTitle());
+}
+
+TEST(TROMemFile, RealNoMemCopy)
+{
+   std::string expected = "Hello from TMemFile!";
+   // Include the 0 terminator to later compare the strings.
+   size_t expected_size = expected.size() + 1;
+   TMemFile::ExternalDataRange_t externalDataRange{expected.c_str(), expected_size};
+   TMemFile rosmf("hello.bin?filetype=raw", externalDataRange);
+
+   std::vector<char> seen;
+   seen.resize(rosmf.GetSize());
+   rosmf.CopyTo(&seen.front(), seen.size());
+
+   ASSERT_EQ(expected_size, seen.size());
+   ASSERT_STREQ(expected.c_str(), &seen[0]);
 }


### PR DESCRIPTION
This is useful for moving the rdict files into the cxxmodule file as an extension. The relevant PR is coming soon.