### PR TITLE
Fix memory leak when fitting histograms using linear fitter

### DIFF
--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -1052,15 +1052,14 @@ TFitResultPtr TGraph::Fit(const char *fname, Option_t *option, Option_t *, Axis_
 {
    char *linear;
    linear = (char*) strstr(fname, "++");
-   TF1 *f1 = 0;
-   if (linear)
-      f1 = new TF1(fname, fname, xmin, xmax);
-   else {
-      f1 = (TF1*)gROOT->GetFunction(fname);
-      if (!f1) {
-         Printf("Unknown function: %s", fname);
-         return -1;
-      }
+   if (linear) { 
+      TF1 f1(fname, fname, xmin, xmax);
+      return Fit(&f1, option, "", xmin, xmax);
+   }
+   TF1 * f1 = (TF1*)gROOT->GetFunction(fname);
+   if (!f1) {
+      Printf("Unknown function: %s", fname);
+      return -1;
    }
    return Fit(f1, option, "", xmin, xmax);
 }

--- a/hist/hist/src/TGraph2D.cxx
+++ b/hist/hist/src/TGraph2D.cxx
@@ -760,15 +760,15 @@ TFitResultPtr TGraph2D::Fit(const char *fname, Option_t *option, Option_t *)
 
    char *linear;
    linear = (char*)strstr(fname, "++");
-   TF2 *f2 = 0;
-   if (linear)
-      f2 = new TF2(fname, fname);
-   else {
-      f2 = (TF2*)gROOT->GetFunction(fname);
-      if (!f2) {
-         Printf("Unknown function: %s", fname);
-         return -1;
-      }
+
+   if (linear) { 
+      TF2 f2(fname, fname);
+      return Fit(&f2, option, "");
+   }
+   TF2 * f2 = (TF2*)gROOT->GetFunction(fname);
+   if (!f2) {
+      Printf("Unknown function: %s", fname);
+      return -1;
    }
    return Fit(f2, option, "");
 

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -3800,16 +3800,16 @@ TFitResultPtr TH1::Fit(const char *fname ,Option_t *option ,Option_t *goption, D
    Int_t ndim=GetDimension();
    if (linear){
       if (ndim<2){
-         f1=new TF1(fname, fname, xxmin, xxmax);
-         return Fit(f1,option,goption,xxmin,xxmax);
+         TF1 f1(fname, fname, xxmin, xxmax);
+         return Fit(&f1,option,goption,xxmin,xxmax);
       }
       else if (ndim<3){
-         f2=new TF2(fname, fname);
-         return Fit(f2,option,goption,xxmin,xxmax);
+         TF2 f2(fname, fname);
+         return Fit(&f2,option,goption,xxmin,xxmax);
       }
       else{
-         f3=new TF3(fname, fname);
-         return Fit(f3,option,goption,xxmin,xxmax);
+         TF3 f3(fname, fname);
+         return Fit(&f3,option,goption,xxmin,xxmax);
       }
    }
 

--- a/hist/hist/src/TMultiGraph.cxx
+++ b/hist/hist/src/TMultiGraph.cxx
@@ -481,14 +481,13 @@ TFitResultPtr TMultiGraph::Fit(const char *fname, Option_t *option, Option_t *, 
 {
    char *linear;
    linear= (char*)strstr(fname, "++");
-   TF1 *f1=0;
-   if (linear)
-      f1=new TF1(fname, fname, xmin, xmax);
-   else {
-      f1 = (TF1*)gROOT->GetFunction(fname);
-      if (!f1) { Printf("Unknown function: %s",fname); return -1; }
+   if (linear) { 
+      TF1 f1(fname, fname, xmin, xmax);
+      return Fit(&f1,option,"",xmin,xmax);
    }
-
+   TF1 * f1 = (TF1*)gROOT->GetFunction(fname);
+   if (!f1) { Printf("Unknown function: %s",fname); return -1; }
+   
    return Fit(f1,option,"",xmin,xmax);
 }
 


### PR DESCRIPTION
This fixes a memory leak when fitting using functions built from expression with special operator ++
(a special case of Linear fitter).  
The leak was present when fitting both histograms and all types of graphs

This PR fixes ROOT-10147