### PR TITLE
Re-Implement methods in TH2Poly from TH1 or TH2 to emit an error message. 

### DIFF
--- a/hist/hist/inc/TH2Poly.h
+++ b/hist/hist/inc/TH2Poly.h
@@ -81,6 +81,15 @@ public:
    void          ClearBinContents();                 // Clears the content of all bins
    TObject      *Clone(const char* newname = "") const;
    void          ChangePartition(Int_t n, Int_t m);  // Sets the number of partition cells to another value
+   using TH2::Multiply;
+   using TH2::Divide;
+   using TH2::Interpolate;
+   virtual Bool_t Divide(TF1 *, Double_t);
+   virtual Bool_t Multiply(TF1 *, Double_t);
+   virtual Double_t ComputeIntegral(Bool_t);
+   virtual TH1 *  FFT(TH1*, Option_t * );
+   virtual TH1 *  GetAsymmetry(TH1* , Double_t,  Double_t);
+   virtual Double_t Interpolate(Double_t, Double_t);
    virtual Int_t Fill(Double_t x,Double_t y);
    virtual Int_t Fill(Double_t x,Double_t y, Double_t w);
    virtual Int_t Fill(const char* name, Double_t w);

--- a/hist/hist/src/TH2Poly.cxx
+++ b/hist/hist/src/TH2Poly.cxx
@@ -371,24 +371,6 @@ Bool_t TH2Poly::Add(const TH1 *h1, Double_t c1)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Performs the operation: this = this + c1*f1.
-
-Bool_t TH2Poly::Add(TF1 *, Double_t, Option_t *)
-{
-   Warning("Add","Not implement for TH2Poly");
-   return kFALSE;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Replace contents of this histogram by the addition of h1 and h2.
-
-Bool_t TH2Poly::Add(const TH1 *, const TH1 *, Double_t, Double_t)
-{
-   Warning("Add","Not implement for TH2Poly");
-   return kFALSE;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Adds the input bin into the partition cell matrix. This method is called
 /// in AddBin() and ChangePartition().
 
@@ -1581,4 +1563,69 @@ Bool_t TH2PolyBin::IsInside(Double_t x, Double_t y) const
    }
 
    return in;
+}
+
+////////////////////////////////////////////////////////////////////////
+/// RE-implement dummy functions to avoid users calling the
+/// corresponding implemntations in TH1 or TH2
+//////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////
+/// Performs the operation: this = this + c1*f1. NOT IMPLEMENTED for TH2Poly
+Bool_t TH2Poly::Add(TF1 *, Double_t, Option_t *)
+{
+   Error("Add","Not implement for TH2Poly");
+   return kFALSE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Replace contents of this histogram by the addition of h1 and h2. NOT IMPLEMENTED for TH2Poly
+Bool_t TH2Poly::Add(const TH1 *, const TH1 *, Double_t, Double_t)
+{
+   Error("Add","Not implement for TH2Poly");
+   return kFALSE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Performs the operation: this = this / c1*f1. NOT IMPLEMENTED for TH2Poly
+Bool_t TH2Poly::Divide(TF1 *, Double_t)
+{
+   Error("Divide","Not implement for TH2Poly");
+   return kFALSE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// NOT IMPLEMENTED for TH2Poly
+Bool_t TH2Poly::Multiply(TF1 *, Double_t)
+{
+   Error("Multiply","Not implement for TH2Poly");
+   return kFALSE;
+}
+////////////////////////////////////////////////////////////////////////////////
+/// NOT IMPLEMENTED for TH2Poly
+Double_t TH2Poly::ComputeIntegral(Bool_t )
+{
+   Error("ComputeIntegral","Not implement for TH2Poly");
+   return TMath::QuietNaN();
+}
+////////////////////////////////////////////////////////////////////////////////
+/// NOT IMPLEMENTED for TH2Poly
+TH1 * TH2Poly::FFT(TH1*, Option_t * )
+{
+   Error("FFT","Not implement for TH2Poly");
+   return nullptr;
+}
+////////////////////////////////////////////////////////////////////////////////
+/// NOT IMPLEMENTED for TH2Poly
+TH1 * TH2Poly::GetAsymmetry(TH1* , Double_t,  Double_t)
+{
+   Error("GetAsymmetry","Not implement for TH2Poly");
+   return nullptr;
+}
+////////////////////////////////////////////////////////////////////////////////
+/// NOT IMPLEMENTED for TH2Poly
+Double_t TH2Poly::Interpolate(Double_t, Double_t)
+{
+   Error("Interpolate","Not implement for TH2Poly");
+   return TMath::QuietNaN();
 }


### PR DESCRIPTION
Methods from TH1 that are using GetNbinsX and GetNbinsY that do not make sense for a TH2Poly and will compute sometiung wrong. They are re-implemented now in TH2Poly and an error message is printed. 

This fixes  ROOT-7139