### PR TITLE
[metacling & PyROOT] TClingMethodInfo, skip over template instantiations (reloaded)

### DIFF
--- a/bindings/pyroot/src/Cppyy.cxx
+++ b/bindings/pyroot/src/Cppyy.cxx
@@ -538,6 +538,9 @@ size_t Cppyy::GetFunctionArgTypeoffset()\
 // scope reflection information ----------------------------------------------
 Bool_t Cppyy::IsNamespace( TCppScope_t scope ) {
 // Test if this scope represents a namespace.
+   if (scope == GLOBAL_HANDLE)
+      return kTRUE;
+
    TClassRef& cr = type_from_handle( scope );
    if ( cr.GetClass() )
       return cr->Property() & kIsNamespace;
@@ -815,6 +818,33 @@ Bool_t Cppyy::IsConstMethod( TCppMethod_t method )
    return kFALSE;
 }
 
+
+bool Cppyy::ExistsMethodTemplate(TCppScope_t scope, const std::string& name)
+{
+   if (scope == (TCppScope_t)GLOBAL_HANDLE) {
+      return (bool)gROOT->GetFunctionTemplate(name.c_str());
+   } else {
+      TClassRef& cr = type_from_handle(scope);
+      if (cr.GetClass())
+         return (bool)cr->GetFunctionTemplate(name.c_str());
+   }
+
+   return false;
+}
+
+Cppyy::TCppMethod_t Cppyy::GetMethodTemplate(
+   TCppScope_t scope, const std::string& name, const std::string& proto)
+{
+   if (scope == (TCppScope_t)GLOBAL_HANDLE) {
+      return (TCppMethod_t)gROOT->GetGlobalFunctionWithPrototype(name.c_str(), proto.c_str());
+   } else {
+      TClassRef& cr = type_from_handle(scope);
+      if (cr.GetClass())
+         return (TCppMethod_t)cr->GetMethodWithPrototype(name.c_str(), proto.c_str());
+   }
+
+   return (TCppMethod_t)nullptr;
+}
 
 Bool_t Cppyy::IsMethodTemplate( TCppMethod_t method )
 {

--- a/bindings/pyroot/src/Cppyy.h
+++ b/bindings/pyroot/src/Cppyy.h
@@ -99,6 +99,8 @@ namespace Cppyy {
    std::string GetMethodSignature( TCppScope_t scope, TCppIndex_t imeth );
    Bool_t      IsConstMethod( TCppMethod_t );
 
+   bool        ExistsMethodTemplate(TCppScope_t scope, const std::string& name);
+   TCppMethod_t GetMethodTemplate(TCppScope_t scope, const std::string& name, const std::string& proto);
    Bool_t      IsMethodTemplate( TCppMethod_t );
    TCppIndex_t GetMethodNumTemplateArgs( TCppScope_t scope, TCppIndex_t imeth );
    std::string GetMethodTemplateArgName( TCppScope_t scope, TCppIndex_t imeth, TCppIndex_t iarg );

--- a/bindings/pyroot/src/RootWrapper.cxx
+++ b/bindings/pyroot/src/RootWrapper.cxx
@@ -789,6 +789,11 @@ PyObject* PyROOT::GetCppGlobal( const std::string& name )
       return (PyObject*)MethodProxy_New( name, overloads );
    }
 
+   // Try function templates
+   if (Cppyy::ExistsMethodTemplate(Cppyy::gGlobalScope, name)) {
+      return (PyObject*)TemplateProxy_New(name, CreateScopeProxy(""));
+   }
+
 // allow lookup into std as if global (historic)
    TDataMember* dm = TClass::GetClass( "std" )->GetDataMember( name.c_str() );
    if ( dm ) {

--- a/bindings/pyroot/src/TemplateProxy.cxx
+++ b/bindings/pyroot/src/TemplateProxy.cxx
@@ -231,7 +231,8 @@ namespace {
                default:  ptrname = "void*";  // TODO: verify if this is right
             }
             if ( ptrname ) {
-               PyObject* pyptrname = PyBytes_FromString( ptrname );
+               //PyObject* pyptrname = PyBytes_FromString( ptrname );
+               PyObject *pyptrname = PyROOT_PyUnicode_FromString(ptrname);
                PyTuple_SET_ITEM( tpArgs, i, pyptrname );
             // string added, but not counted towards nStrings
             } else {

--- a/bindings/pyroot/src/TemplateProxy.cxx
+++ b/bindings/pyroot/src/TemplateProxy.cxx
@@ -286,7 +286,7 @@ namespace {
 
     // case 4a: instantiating obj->method< T0, T1, ... >( type(a0), type(a1), ... )( a0, a1, ... )
       if ( ! isType && ! ( nStrings == nArgs ) ) {    // no types among args and not all strings
-         PyObject* pyname_v2 = Utility::BuildTemplateName( NULL, tpArgs, 0 );
+         PyObject* pyname_v2 = Utility::BuildTemplateName( NULL, tpArgs, 0, true );
          if ( pyname_v2 ) {
             std::string mname = PyROOT_PyUnicode_AsString( pyname_v2 );
             Py_DECREF( pyname_v2 );

--- a/bindings/pyroot/src/TemplateProxy.cxx
+++ b/bindings/pyroot/src/TemplateProxy.cxx
@@ -276,7 +276,10 @@ namespace {
    // still here? try instantiating methods
 
       PyObject* clName = PyObject_GetAttr( pytmpl->fPyClass, PyStrings::gCppName );
-      if ( ! clName ) clName = PyObject_GetAttr( pytmpl->fPyClass, PyStrings::gName );
+      if (!clName) {
+         PyErr_Clear();
+         clName = PyObject_GetAttr(pytmpl->fPyClass, PyStrings::gName);
+      }
       auto clNameStr = std::string(PyROOT_PyUnicode_AsString(clName));
       if (clNameStr == "_global_cpp")
          clNameStr = ""; // global namespace

--- a/bindings/pyroot/src/Utility.cxx
+++ b/bindings/pyroot/src/Utility.cxx
@@ -459,7 +459,7 @@ Bool_t PyROOT::Utility::AddBinaryOperator( PyObject* pyclass, const std::string&
 /// for a class as in MakeRootTemplateClass in RootModule.cxx) or for method lookup
 /// (as in TemplatedMemberHook, below).
 
-PyObject* PyROOT::Utility::BuildTemplateName( PyObject* pyname, PyObject* args, int argoff )
+PyObject* PyROOT::Utility::BuildTemplateName( PyObject* pyname, PyObject* args, int argoff, bool inferredTypes )
 {
    if ( pyname )
       pyname = PyROOT_PyUnicode_FromString( PyROOT_PyUnicode_AsString( pyname ) );
@@ -482,9 +482,15 @@ PyObject* PyROOT::Utility::BuildTemplateName( PyObject* pyname, PyObject* args, 
             tpName = PyObject_GetAttr( tn, PyStrings::gName );
          }
          // special case for strings
-         if ( strcmp( PyROOT_PyUnicode_AsString( tpName ), "str" ) == 0 ) {
+         auto tpNameStr = PyROOT_PyUnicode_AsString(tpName);
+         if ( strcmp( tpNameStr, "str" ) == 0 ) {
             Py_DECREF( tpName );
             tpName = PyROOT_PyUnicode_FromString( "std::string" );
+         }
+         // and Python float (should be double in C++) if types have been inferred
+         else if (inferredTypes && strcmp(tpNameStr, "float") == 0) {
+            Py_DECREF(tpName);
+            tpName = PyROOT_PyUnicode_FromString("double");
          }
          PyROOT_PyUnicode_AppendAndDel( &pyname, tpName );
       } else if ( PyInt_Check( tn ) || PyLong_Check( tn ) || PyFloat_Check( tn ) ) {

--- a/bindings/pyroot/src/Utility.h
+++ b/bindings/pyroot/src/Utility.h
@@ -40,7 +40,7 @@ namespace PyROOT {
          const char* op, const char* label, const char* alt_label = NULL );
 
    // helper for template classes and methods
-      PyObject* BuildTemplateName( PyObject* pyname, PyObject* args, int argoff );
+      PyObject* BuildTemplateName( PyObject* pyname, PyObject* args, int argoff, bool inferredTypes = false );
 
    // initialize proxy type objects
       Bool_t InitProxy( PyObject* module, PyTypeObject* pytype, const char* name );

--- a/core/metacling/src/TClingMethodInfo.h
+++ b/core/metacling/src/TClingMethodInfo.h
@@ -53,22 +53,20 @@ class TClingTypeInfo;
 
 class TClingMethodInfo final : public TClingDeclInfo {
 private:
-   class SpecIterator;
-
    cling::Interpreter                          *fInterp; // Cling interpreter, we do *not* own.
    llvm::SmallVector<clang::DeclContext *, 2>   fContexts; // Set of DeclContext that we will iterate over.
    bool                                         fFirstTime; // Flag for first time incrementing iterator, cint semantics are weird.
    unsigned int                                 fContextIdx; // Index in fContexts of DeclContext we are iterating over.
    clang::DeclContext::decl_iterator            fIter; // Our iterator.
    std::string                                  fTitle; // The meta info for the method.
-   SpecIterator                                *fTemplateSpecIter; // Iter over template specialization. [We own]
+   const clang::FunctionDecl                   *fTemplateSpec; // an all-default-template-args function.
 
    const clang::Decl* GetDeclSlow() const;
 
 public:
    explicit TClingMethodInfo(cling::Interpreter *interp)
       : TClingDeclInfo(nullptr), fInterp(interp), fFirstTime(true), fContextIdx(0U), fTitle(""),
-        fTemplateSpecIter(0) {}
+        fTemplateSpec(0) {}
 
    TClingMethodInfo(const TClingMethodInfo&);
    TClingMethodInfo& operator=(const TClingMethodInfo &in);


### PR DESCRIPTION
This is a continuation of https://github.com/root-project/root/pull/3858/ with some fixes for the failing tests:

- projectroot.roottest.cling.functionTemplate.roottest_cling_functionTemplate_cintrun
- projectroot.roottest.cling.functionTemplate.roottest_cling_functionTemplate_testcint
- projectroot.roottest.python.basic.roottest_python_basic_overload
-  projectroot.roottest.python.cpp.roottest_python_cpp_advanced

