### PR TITLE
Implement TImage:ls()

### DIFF
--- a/graf2d/graf/inc/TImage.h
+++ b/graf2d/graf/inc/TImage.h
@@ -255,6 +255,8 @@ public:
    TImage    &operator+=(const TImage &i) { Append(&i, "+"); return *this; }
    TImage    &operator/=(const TImage &i) { Append(&i, "/"); return *this; }
 
+   virtual void  ls(Option_t *option="") const;
+
    ClassDef(TImage,1)  // Abstract image class
 };
 

--- a/graf2d/graf/src/TImage.cxx
+++ b/graf2d/graf/src/TImage.cxx
@@ -105,6 +105,15 @@ TImage::EImageFileTypes TImage::GetImageFileTypeFromFilename(const char* filenam
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// List this image with its attributes.
+
+void TImage::ls(Option_t *) const
+{
+   TROOT::IndentLevel();
+   printf("TImage: \"%s\"\n", GetName() );
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Open a specified image file.
 
 TImage *TImage::Open(const char *file, EImageFileTypes type)


### PR DESCRIPTION
Because the TImage Title has a special use (not used to store a title), the ls() method inherited from TObject crashed. 