### PR TITLE
Use default copy constructor and assignment operator for Plane3D

### DIFF
--- a/math/genvector/inc/Math/GenVector/Plane3D.h
+++ b/math/genvector/inc/Math/GenVector/Plane3D.h
@@ -117,20 +117,14 @@ public:
    }
 
    // compiler-generated copy ctor and dtor are fine.
+   Plane3D(const Plane3D &) = default;
 
    // ------ assignment ------
 
    /**
       Assignment operator from other Plane3D class
    */
-   Plane3D &operator=(const Plane3D &plane)
-   {
-      fA = plane.fA;
-      fB = plane.fB;
-      fC = plane.fC;
-      fD = plane.fD;
-      return *this;
-   }
+   Plane3D &operator=(const Plane3D &) = default;
 
    /**
       Return the a coefficient of the plane equation \f$ a*x + b*y + c*z + d = 0 \f$. It is also the


### PR DESCRIPTION
Fixes GCC 9 warnings. See http://cdash.cern.ch/viewBuildError.php?type=1&buildid=667454.