### PR TITLE
 json: implement base64 coding for std::vector 

### DIFF
--- a/io/io/inc/TBufferJSON.h
+++ b/io/io/inc/TBufferJSON.h
@@ -250,7 +250,7 @@ protected:
 
    TJSONStackObj *PushStack(Int_t inclevel = 0, void *readnode = nullptr);
    TJSONStackObj *PopStack();
-   TJSONStackObj *Stack() { return fStack.back(); }
+   TJSONStackObj *Stack() { return fStack.back().get(); }
 
    void WorkWithClass(TStreamerInfo *info, const TClass *cl = nullptr);
    void WorkWithElement(TStreamerElement *elem, Int_t);
@@ -314,7 +314,7 @@ protected:
    TString *fOutput{nullptr};          ///<!  current output buffer for json code
    TString fValue;                     ///<!  buffer for current value
    unsigned fJsonrCnt{0};              ///<!  counter for all objects, used for referencing
-   std::deque<TJSONStackObj *> fStack; ///<!  hierarchy of currently streamed element
+   std::deque<std::unique_ptr<TJSONStackObj>> fStack; ///<!  hierarchy of currently streamed element
    Int_t fCompact{0};                  ///<!  0 - no any compression, 1 - no spaces in the begin, 2 - no new lines, 3 - no spaces at all
    Bool_t fMapAsObject{kFALSE};        ///<! when true, std::map will be converted into JSON object
    TString fSemicolon;                 ///<!  depending from compression level, " : " or ":"

--- a/io/io/inc/TBufferJSON.h
+++ b/io/io/inc/TBufferJSON.h
@@ -18,6 +18,7 @@
 #include <deque>
 #include <memory>
 #include <string>
+#include <vector>
 
 class TVirtualStreamerInfo;
 class TStreamerInfo;
@@ -326,7 +327,7 @@ protected:
    TString fNumericLocale;             ///<!  stored value of setlocale(LC_NUMERIC), which should be recovered at the end
    TString fTypeNameTag;               ///<! JSON member used for storing class name, when empty - no class name will be stored
    TString fTypeVersionTag;            ///<! JSON member used to store class version, default empty
-   TObjArray *fSkipClasses{nullptr};   ///<! list of classes, which class info is not stored
+   std::vector<const TClass *> fSkipClasses; ///<! list of classes, which class info is not stored
 
    ClassDef(TBufferJSON, 1) // a specialized TBuffer to only write objects into JSON format
 };

--- a/io/io/inc/TBufferJSON.h
+++ b/io/io/inc/TBufferJSON.h
@@ -57,6 +57,7 @@ public:
    Bool_t IsSkipClassInfo(const TClass *cl) const;
 
    TString StoreObject(const void *obj, const TClass *cl);
+   void *RestoreObject(const char *str, TClass **cl);
 
    static TString ConvertToJSON(const TObject *obj, Int_t compact = 0, const char *member_name = nullptr);
    static TString

--- a/io/io/inc/TBufferJSON.h
+++ b/io/io/inc/TBufferJSON.h
@@ -56,6 +56,8 @@ public:
    void SetSkipClassInfo(const TClass *cl);
    Bool_t IsSkipClassInfo(const TClass *cl) const;
 
+   TString StoreObject(const void *obj, const TClass *cl);
+
    static TString ConvertToJSON(const TObject *obj, Int_t compact = 0, const char *member_name = nullptr);
    static TString
    ConvertToJSON(const void *obj, const TClass *cl, Int_t compact = 0, const char *member_name = nullptr);

--- a/io/io/inc/TBufferJSON.h
+++ b/io/io/inc/TBufferJSON.h
@@ -39,9 +39,10 @@ public:
 
      kMapAsObject   = 5,             ///< store std::map, std::unodered_map as JSON object
 
-     // algorithms for array compression
+     // algorithms for array compression - exclusive
      kZeroSuppression = 10,          ///< if array has much zeros in begin and/or end, they will be removed
      kSameSuppression = 20,          ///< zero suppression plus compress many similar values together
+     kBase64          = 30,          ///< all binary arrays will be compressed with base64 coding, supported by JSROOT
 
      kSkipTypeInfo  = 100            // do not store typenames in JSON
    };

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -1105,7 +1105,7 @@ TJSONStackObj *TBufferJSON::PushStack(Int_t inclevel, void *readnode)
       next->fLevel += prev->fLevel;
       next->fMemberPtr = prev->fMemberPtr;
    }
-   fStack.push_back(next);
+   fStack.emplace_back(next);
    return next;
 }
 
@@ -1114,12 +1114,10 @@ TJSONStackObj *TBufferJSON::PushStack(Int_t inclevel, void *readnode)
 
 TJSONStackObj *TBufferJSON::PopStack()
 {
-   if (fStack.size() > 0) {
-      delete fStack.back();
+   if (fStack.size() > 0)
       fStack.pop_back();
-   }
 
-   return fStack.size() > 0 ? Stack() : nullptr;
+   return fStack.size() > 0 ? fStack.back().get() : nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2080,7 +2078,7 @@ void TBufferJSON::WorkWithElement(TStreamerElement *elem, Int_t)
    Int_t number = info ? info->GetElements()->IndexOf(elem) : -1;
 
    if (!elem) {
-      Error("WorkWithElement", "streamer info returns elem = 0");
+      Error("WorkWithElement", "streamer info returns elem = nullptr");
       return;
    }
 

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -2718,12 +2718,10 @@ R__ALWAYS_INLINE void TBufferJSON::JsonReadFastArray(T *arr, Int_t arrsize, bool
       if (json->count("b") == 1) {
          auto base64 = json->at("b").get<std::string>();
 
+         int offset = (json->count("o") == 1) ? json->at("o").get<int>() : 0;
+
          // TODO: provide TBase64::Decode with direct write into target buffer
          auto decode = TBase64::Decode(base64.c_str());
-
-         int offset = 0;
-         if (json->count("o") == 1)
-            offset = json->at("o").get<int>();
 
          if (arrsize * (long) sizeof(T) < (offset + decode.Length())) {
             Error("ReadFastArray", "Base64 data %ld larger than target array size %ld", (long) decode.Length() + offset, (long) (arrsize*sizeof(T)));
@@ -2990,6 +2988,10 @@ R__ALWAYS_INLINE void TBufferJSON::JsonWriteArrayCompress(const T *vname, Int_t 
          bindx--;
 
       if (is_base64) {
+         // small initial offset makes no sense - JSON code is large then size gain
+         if ((aindx * sizeof(T) < 5) && (aindx < bindx))
+            aindx = 0;
+
          if ((aindx > 0) && (aindx < bindx))
             fValue.Append(TString::Format("%s\"o\":%ld", fArraySepar.Data(), (long) (aindx * (int) sizeof(T))));
 

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -484,7 +484,7 @@ TBufferJSON::TBufferJSON(TBuffer::EMode mode)
    // checks if setlocale(LC_NUMERIC) returns others than "C"
    // in this case locale will be changed and restored at the end of object conversion
 
-   char *loc = setlocale(LC_NUMERIC, 0);
+   char *loc = setlocale(LC_NUMERIC, nullptr);
    if (loc && (strcmp(loc, "C") != 0)) {
       fNumericLocale = loc;
       setlocale(LC_NUMERIC, "C");
@@ -501,9 +501,6 @@ TBufferJSON::~TBufferJSON()
 
    if (fNumericLocale.Length() > 0)
       setlocale(LC_NUMERIC, fNumericLocale.Data());
-
-   if (fSkipClasses)
-      delete fSkipClasses;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -607,12 +604,8 @@ void TBufferJSON::SetTypeversionTag(const char *tag)
 
 void TBufferJSON::SetSkipClassInfo(const TClass *cl)
 {
-   if (!cl)
-      return;
-   if (!fSkipClasses)
-      fSkipClasses = new TObjArray();
-
-   fSkipClasses->Add(const_cast<TClass *>(cl));
+   if (cl && (std::find(fSkipClasses.begin(), fSkipClasses.end(), cl) == fSkipClasses.end()))
+      fSkipClasses.emplace_back(cl);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -620,9 +613,7 @@ void TBufferJSON::SetSkipClassInfo(const TClass *cl)
 
 Bool_t TBufferJSON::IsSkipClassInfo(const TClass *cl) const
 {
-   if (!cl || !fSkipClasses) return kFALSE;
-
-   return fSkipClasses->FindObject(cl) != nullptr;
+   return cl && (std::find(fSkipClasses.begin(), fSkipClasses.end(), cl) != fSkipClasses.end());
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
For some applications large binary buffer need to be transferred 
with JSON. Standard solution is base64 coding. It can be enabled by
JSON_base64 string in class comments or with kBase64 = 30 value in
compress parameter

Also provide convenience methods `StoreObject()`/`RestoreObject()`
to be able configure different TBufferJSON properties before streaming objects.
Only for special use-cases.

Also include fixe from #3916 