### PR TITLE
Avoid complaint about external changes when calling TTreeReader::GetEntries(true).

### DIFF
--- a/tree/treeplayer/inc/TTreeReader.h
+++ b/tree/treeplayer/inc/TTreeReader.h
@@ -220,7 +220,8 @@ public:
 
    EEntryStatus GetEntryStatus() const { return fEntryStatus; }
 
-   Long64_t GetEntries(Bool_t force) const;
+   Long64_t GetEntries() const;
+   Long64_t GetEntries(Bool_t force);
 
    /// Returns the index of the current entry being read.
    ///

--- a/tree/treeplayer/test/basic.cxx
+++ b/tree/treeplayer/test/basic.cxx
@@ -367,6 +367,16 @@ TEST(TTreeReaderBasic, DisappearingBranch)
    EXPECT_EQ(*rv,42);
    EXPECT_FALSE(r.Next());
    
+   // Make the warnings fatal.
+   gErrorAbortLevel = kWarning;
+   TChain c2("t");
+   c2.Add("DisappearingBranch0.root");
+   c2.Add("DisappearingBranch0.root");
+   c2.Add("DisappearingBranch0.root");
+   TTreeReader r2(&c2);
+   EXPECT_EQ(r2.GetEntries(true),3);
+   EXPECT_FALSE(r2.SetEntry(0));
+   gErrorAbortLevel = kFatal;
 
    gSystem->Unlink("DisappearingBranch0.root");
    gSystem->Unlink("DisappearingBranch1.root");


### PR DESCRIPTION


See https://root-forum.cern.ch/t/warning-in-ttreereader-with-tchain/34484/2.