### PR TITLE
 Disable ROOT history when running tests via ctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -419,14 +419,14 @@ add_dependencies(hsimple onepcm)
 if(WIN32)
   add_custom_command(OUTPUT tutorials/hsimple.root
                      COMMAND set PATH=${CMAKE_RUNTIME_OUTPUT_DIRECTORY} &&
-                             set ROOTIGNOREPREFIX=1 &&
+                             set ROOTIGNOREPREFIX=1 && set ROOT_HIST=0 &&
                              $<TARGET_FILE:root.exe> -l -q -b -n -x hsimple.C -e return
                      WORKING_DIRECTORY tutorials
                      DEPENDS $<TARGET_FILE:root.exe> Cling Hist Tree Gpad Graf HistPainter move_artifacts)
 else()
   add_custom_command(OUTPUT tutorials/hsimple.root
                      COMMAND ${ld_library_path}=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}:$ENV{${ld_library_path}}
-                             ROOTIGNOREPREFIX=1
+                             ROOTIGNOREPREFIX=1 ROOT_HIST=0
                              $<TARGET_FILE:root.exe> -l -q -b -n -x hsimple.C -e return
                      WORKING_DIRECTORY tutorials
                      DEPENDS $<TARGET_FILE:root.exe> Cling Hist Tree Gpad Graf HistPainter move_artifacts)

--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -1268,6 +1268,8 @@ function(ROOT_ADD_TEST test)
     endif()
   endif()
 
+  set_property(TEST ${test} APPEND PROPERTY ENVIRONMENT ROOT_HIST=0)
+
   #- Handle TIMOUT and DEPENDS arguments
   if(ARG_TIMEOUT)
     set_property(TEST ${test} PROPERTY TIMEOUT ${ARG_TIMEOUT})


### PR DESCRIPTION
Fixes [ROOT-7836](https://sft.its.cern.ch/jira/browse/ROOT-7836).