### PR TITLE
Reset the instance cache at the beginning of each entry.

### DIFF
--- a/tree/treeplayer/src/TTreeFormula.cxx
+++ b/tree/treeplayer/src/TTreeFormula.cxx
@@ -4966,6 +4966,9 @@ void TTreeFormula::ResetLoading()
          ((TTreeFormula *)(c->GetObjectY()))->ResetLoading();
       }
    }
+   fRealInstanceCache.fInstanceCache = 0;
+   fRealInstanceCache.fLocalIndexCache = 0;
+   fRealInstanceCache.fVirtAccumCache = 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Previously it detected the change of entry by comparing the 'current' instance to the last 'instance'
recorded.  If all instance are used, this worked perfectly.  If the instance are used sparsely (eg. with
selection in TTree::Draw) then from entry to the other, the 'first' instance used in an entry might be later/higher
than the last 'instance' used in the previous entry.

This corrects the behavior introduced in 064e0a7d49b08e03667f9312421b6fb5b8d82285.

This fixes ROOT-10170