### PR TITLE
TGraph::InsertPointBefore(): Allow to insert at the beginning of the graph

### DIFF
--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -1735,8 +1735,8 @@ Int_t TGraph::InsertPoint()
 
 void TGraph::InsertPointBefore(Int_t ipoint, Double_t x, Double_t y)
 {
-   if (ipoint <= 0) {
-      Error("TGraph", "Inserted point index should be > 0");
+   if (ipoint < 0) {
+      Error("TGraph", "Inserted point index should be >= 0");
       return;
    }
 


### PR DESCRIPTION
There's no reason not to allow insertion before point 0. This would allow
insertion of a point in the very beginning of the graph.