### PR TITLE
Added TVirtualMCApplication::EndOfEvent():

### DIFF
--- a/montecarlo/vmc/inc/TMCVerbose.h
+++ b/montecarlo/vmc/inc/TMCVerbose.h
@@ -50,6 +50,7 @@ public:
    virtual void Stepping();
    virtual void PostTrack();
    virtual void FinishPrimary();
+   virtual void EndOfEvent();
    virtual void FinishEvent();
 
    // set methods

--- a/montecarlo/vmc/inc/TVirtualMCApplication.h
+++ b/montecarlo/vmc/inc/TVirtualMCApplication.h
@@ -97,6 +97,9 @@ public:
    /// Define actions at the end of the primary track
    virtual void FinishPrimary() = 0;
 
+   /// Define actions at the end of the event before calling SD's end of the event
+   virtual void EndOfEvent() {}
+
    /// Define actions at the end of the event
    virtual void FinishEvent() = 0;
 

--- a/montecarlo/vmc/src/TMCVerbose.cxx
+++ b/montecarlo/vmc/src/TMCVerbose.cxx
@@ -315,6 +315,15 @@ void TMCVerbose::FinishPrimary()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// End of event info
+
+void TMCVerbose::EndOfEvent()
+{
+   if (fLevel>0)
+      std::cout << "--- End of event " << std::endl;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Finish of an event info
 
 void TMCVerbose::FinishEvent()


### PR DESCRIPTION
This function is needed for newly introduced sensitive detectors framework
to provide a hook for a central call to fill ROOT trees before resetting data
in sensitive detector's end of event.
It would be nice if it could be still included in 6.18