### PR TITLE
Get/SetTimestamp functions with TTimeStamp; bug fixed

### DIFF
--- a/net/net/inc/TSQLStatement.h
+++ b/net/net/inc/TSQLStatement.h
@@ -15,6 +15,7 @@
 #include "TObject.h"
 #include "TString.h"
 #include "TDatime.h"
+#include "TTimeStamp.h"
 #include<vector>
 
 class TSQLStatement : public TObject {
@@ -53,6 +54,7 @@ public:
    virtual Bool_t      SetDatime(Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t) { return kFALSE; }
            Bool_t      SetDatime(Int_t, const TDatime&);
    virtual Bool_t      SetTimestamp(Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t = 0) { return kFALSE; }
+   virtual Bool_t      SetTimestamp(Int_t, const TTimeStamp&) { return kFALSE; }
            Bool_t      SetTimestamp(Int_t, const TDatime&);
    virtual void        SetTimeFormating(const char*) {}
    virtual Bool_t      SetBinary(Int_t, void*, Long_t, Long_t = 0x1000) { return kFALSE; }
@@ -97,6 +99,7 @@ public:
            Int_t       GetMinute(Int_t);
            Int_t       GetSecond(Int_t);
    virtual Bool_t      GetTimestamp(Int_t, Int_t&, Int_t&, Int_t&, Int_t&, Int_t&, Int_t&, Int_t&) { return kFALSE; }
+   virtual Bool_t      GetTimestamp(Int_t, TTimeStamp&) { return kFALSE; }
            TDatime     GetTimestamp(Int_t);
 #ifndef __MAKECINT__
    virtual Bool_t      GetVInt(Int_t, std::vector<Int_t>&) { return kFALSE; }

--- a/sql/pgsql/inc/TPgSQLStatement.h
+++ b/sql/pgsql/inc/TPgSQLStatement.h
@@ -77,6 +77,7 @@ public:
    virtual Bool_t      SetTime(Int_t npar, Int_t hour, Int_t min, Int_t sec);
    virtual Bool_t      SetDatime(Int_t npar, Int_t year, Int_t month, Int_t day, Int_t hour, Int_t min, Int_t sec);
    virtual Bool_t      SetTimestamp(Int_t npar, Int_t year, Int_t month, Int_t day, Int_t hour, Int_t min, Int_t sec, Int_t frac = 0);
+   virtual Bool_t      SetTimestamp(Int_t npar, const TTimeStamp& tm);
 
    virtual Bool_t      NextIteration();
 
@@ -102,6 +103,7 @@ public:
    virtual Bool_t      GetTime(Int_t npar, Int_t& hour, Int_t& min, Int_t& sec);
    virtual Bool_t      GetDatime(Int_t npar, Int_t& year, Int_t& month, Int_t& day, Int_t& hour, Int_t& min, Int_t& sec);
    virtual Bool_t      GetTimestamp(Int_t npar, Int_t& year, Int_t& month, Int_t& day, Int_t& hour, Int_t& min, Int_t& sec, Int_t&);
+   virtual Bool_t      GetTimestamp(Int_t npar, TTimeStamp& tm);
 
    ClassDef(TPgSQLStatement, 0);  // SQL statement class for PgSQL DB
 };


### PR DESCRIPTION
Add Get/SetTimestamp functions with TTimeStamp class to work with microseconds
Bugs fixed:
1. Writing date/time in local time (default) to PostgreSQL but returning in UTC. So, one gets a value being different from the written one in case of timestamp fields with time zone
2. kBindStringSize was not enough for timestamp with microseconds