### PR TITLE
Add Sum to TStatistic

### DIFF
--- a/math/mathcore/inc/TStatistic.h
+++ b/math/mathcore/inc/TStatistic.h
@@ -12,7 +12,6 @@
 #ifndef ROOT_TStatistic
 #define ROOT_TStatistic
 
-
 //////////////////////////////////////////////////////////////////////////
 //                                                                      //
 // TStatistic                                                           //
@@ -23,27 +22,23 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "TObject.h"
-
 #include "TCollection.h"
-
 #include "TMath.h"
-
 #include "TString.h"
-
 #include "TROOT.h"
 
 class TStatistic : public TObject {
 
 private:
-   TString     fName;    ///< Name given to the TStatistic object
-   Long64_t    fN;       ///< Number of fills
-   Double_t    fW;       ///< Sum of weights
-   Double_t    fW2;      ///< Sum of squared weights
-   Double_t    fM;       ///< Sum of elements (i.e. sum of (val * weight) pairs
-   Double_t    fM2;      ///< Second order momentum
-   Double_t    fMin;     ///< Minimum value in the Tstatistic object
-   Double_t    fMax;     ///< Maximum value in the TStatistic object
-   Double_t fSum;        ///< Sum of the values in the TStatistic object
+   TString fName; ///< Name given to the TStatistic object
+   Long64_t fN;   ///< Number of fills
+   Double_t fW;   ///< Sum of weights
+   Double_t fW2;  ///< Sum of squared weights
+   Double_t fM;   ///< Sum of elements (i.e. sum of (val * weight)) pairs
+   Double_t fM2;  ///< Second order momentum
+   Double_t fMin; ///< Minimum value in the Tstatistic object
+   Double_t fMax; ///< Maximum value in the TStatistic object
+   Double_t fSum; ///< Sum of the values in the TStatistic object
 
 public:
    TStatistic(const char *name = "")
@@ -55,21 +50,26 @@ public:
    ~TStatistic();
 
    // Getters
-   const char    *GetName() const { return fName; }
-   ULong_t        Hash() const { return fName.Hash(); }
+   const char *GetName() const { return fName; }
+   ULong_t Hash() const { return fName.Hash(); }
 
-   inline       Long64_t GetN() const { return fN; }
-   inline       Long64_t GetNeff() const { return fW*fW/fW2; }
-   inline       Double_t GetM2() const { return fM2; }
-   inline       Double_t GetMean() const { return (fW > 0) ? fM/fW : 0; }
-   inline       Double_t GetMeanErr() const { return  (fW > 0.) ?  TMath::Sqrt( GetVar()/ GetNeff() ) : 0; }
-   inline       Double_t GetRMS() const { double var = GetVar(); return (var>0) ? TMath::Sqrt(var) : -1; }
-   inline       Double_t GetVar() const { return (fW>0) ? ( (fN>1) ? (fM2 / fW)*(fN / (fN-1.)) : 0 ) : -1; }
-   inline       Double_t GetW() const { return fW; }
-   inline       Double_t GetW2() const { return fW2; }
-   inline       Double_t GetMin() const { return fMin; }
-   inline       Double_t GetMax() const { return fMax; }
+   inline Long64_t GetN() const { return fN; }
+   inline Long64_t GetNeff() const { return fW * fW / fW2; }
+   inline Double_t GetM() const { return fM; }
+   inline Double_t GetM2() const { return fM2; }
+   inline Double_t GetMean() const { return (fW > 0) ? fM / fW : 0; }
+   inline Double_t GetMeanErr() const { return (fW > 0.) ? TMath::Sqrt(GetVar() / GetNeff()) : 0; }
+   inline Double_t GetVar() const { return (fW > 0) ? ((fN > 1) ? (fM2 / fW) * (fN / (fN - 1.)) : 0) : -1; }
+   inline Double_t GetW() const { return fW; }
+   inline Double_t GetW2() const { return fW2; }
+   inline Double_t GetMin() const { return fMin; }
+   inline Double_t GetMax() const { return fMax; }
    inline Double_t GetSum() const { return fSum; }
+   inline Double_t GetRMS() const
+   {
+      auto var = GetVar();
+      return (var > 0) ? TMath::Sqrt(var) : -1;
+   }
 
    // Merging
    Int_t Merge(TCollection *in);

--- a/math/mathcore/inc/TStatistic.h
+++ b/math/mathcore/inc/TStatistic.h
@@ -43,10 +43,13 @@ private:
    Double_t    fM2;      ///< Second order momentum
    Double_t    fMin;     ///< Minimum value in the Tstatistic object
    Double_t    fMax;     ///< Maximum value in the TStatistic object
+   Double_t    fSum;     ///< Sum of the values in the TStatistic object
 
 public:
 
-   TStatistic(const char *name = "") : fName(name), fN(0), fW(0.), fW2(0.), fM(0.), fM2(0.), fMin(TMath::Limits<Double_t>::Max()), fMax(TMath::Limits<Double_t>::Min()) { }
+   TStatistic(const char *name = "")
+      : fName(name), fN(0), fW(0.), fW2(0.), fM(0.), fM2(0.), fSum(0.)
+      , fMin(TMath::Limits<Double_t>::Max()), fMax(TMath::Limits<Double_t>::Min()) { }
    TStatistic(const char *name, Int_t n, const Double_t *val, const Double_t *w = 0);
    ~TStatistic();
 
@@ -65,6 +68,7 @@ public:
    inline       Double_t GetW2() const { return fW2; }
    inline       Double_t GetMin() const { return fMin; }
    inline       Double_t GetMax() const { return fMax; }
+   inline       Double_t GetSum() const { return fSum; }
 
    // Merging
    Int_t Merge(TCollection *in);
@@ -76,7 +80,7 @@ public:
    void Print(Option_t * = "") const;
    void ls(Option_t *opt = "") const { Print(opt); }
 
-   ClassDef(TStatistic,3)  // Named statistical variable
+   ClassDef(TStatistic,4)  // Named statistical variable
 };
 
 #endif

--- a/math/mathcore/inc/TStatistic.h
+++ b/math/mathcore/inc/TStatistic.h
@@ -42,8 +42,8 @@ private:
 
 public:
    TStatistic(const char *name = "")
-      : fName(name), fN(0), fW(0.), fW2(0.), fM(0.), fM2(0.), fSum(0.), fMin(TMath::Limits<Double_t>::Max()),
-        fMax(TMath::Limits<Double_t>::Min())
+      : fName(name), fN(0), fW(0.), fW2(0.), fM(0.), fM2(0.), fMin(TMath::Limits<Double_t>::Max()),
+        fMax(TMath::Limits<Double_t>::Min()), fSum(0.)
    {
    }
    TStatistic(const char *name, Int_t n, const Double_t *val, const Double_t *w = 0);

--- a/math/mathcore/inc/TStatistic.h
+++ b/math/mathcore/inc/TStatistic.h
@@ -43,13 +43,14 @@ private:
    Double_t    fM2;      ///< Second order momentum
    Double_t    fMin;     ///< Minimum value in the Tstatistic object
    Double_t    fMax;     ///< Maximum value in the TStatistic object
-   Double_t    fSum;     ///< Sum of the values in the TStatistic object
+   Double_t fSum;        ///< Sum of the values in the TStatistic object
 
 public:
-
    TStatistic(const char *name = "")
-      : fName(name), fN(0), fW(0.), fW2(0.), fM(0.), fM2(0.), fSum(0.)
-      , fMin(TMath::Limits<Double_t>::Max()), fMax(TMath::Limits<Double_t>::Min()) { }
+      : fName(name), fN(0), fW(0.), fW2(0.), fM(0.), fM2(0.), fSum(0.), fMin(TMath::Limits<Double_t>::Max()),
+        fMax(TMath::Limits<Double_t>::Min())
+   {
+   }
    TStatistic(const char *name, Int_t n, const Double_t *val, const Double_t *w = 0);
    ~TStatistic();
 
@@ -68,7 +69,7 @@ public:
    inline       Double_t GetW2() const { return fW2; }
    inline       Double_t GetMin() const { return fMin; }
    inline       Double_t GetMax() const { return fMax; }
-   inline       Double_t GetSum() const { return fSum; }
+   inline Double_t GetSum() const { return fSum; }
 
    // Merging
    Int_t Merge(TCollection *in);
@@ -80,7 +81,7 @@ public:
    void Print(Option_t * = "") const;
    void ls(Option_t *opt = "") const { Print(opt); }
 
-   ClassDef(TStatistic,4)  // Named statistical variable
+   ClassDef(TStatistic, 4) // Named statistical variable
 };
 
 #endif

--- a/math/mathcore/src/TStatistic.cxx
+++ b/math/mathcore/src/TStatistic.cxx
@@ -31,8 +31,8 @@ templateClassImp(TStatistic);
 ///
 /// Recursively calls the TStatistic::Fill() function to fill the object.
 TStatistic::TStatistic(const char *name, Int_t n, const Double_t *val, const Double_t *w)
-   : fName(name), fN(0), fW(0.), fW2(0.), fM(0.), fM2(0.), fSum(0.), fMin(TMath::Limits<Double_t>::Max()),
-     fMax(TMath::Limits<Double_t>::Min())
+   : fName(name), fN(0), fW(0.), fW2(0.), fM(0.), fM2(0.), fMin(TMath::Limits<Double_t>::Max()),
+     fMax(TMath::Limits<Double_t>::Min()), fSum(0.)
 {
    if (n > 0) {
       for (Int_t i = 0; i < n; i++) {

--- a/math/mathcore/src/TStatistic.cxx
+++ b/math/mathcore/src/TStatistic.cxx
@@ -30,11 +30,9 @@ templateClassImp(TStatistic);
 /// \param[in] w The vector of weights for the values
 ///
 /// Recursively calls the TStatistic::Fill() function to fill the object.
-TStatistic::TStatistic(const char *name, Int_t n,
-                        const Double_t *val, const Double_t *w)
-         : fName(name), fN(0), fW(0.), fW2(0.), fM(0.), fM2(0.), fSum(0.)
-         , fMin(TMath::Limits<Double_t>::Max())
-         , fMax(TMath::Limits<Double_t>::Min())
+TStatistic::TStatistic(const char *name, Int_t n, const Double_t *val, const Double_t *w)
+   : fName(name), fN(0), fW(0.), fW2(0.), fM(0.), fM2(0.), fSum(0.), fMin(TMath::Limits<Double_t>::Max()),
+     fMax(TMath::Limits<Double_t>::Min())
 {
    if (n > 0) {
       for (Int_t i = 0; i < n; i++) {
@@ -100,7 +98,7 @@ void TStatistic::Fill(Double_t val, Double_t w) {
       return;
    }
 
-   if (fW != 0) {  // From the second time
+   if (fW != 0) { // From the second time
       Double_t rr = ( tW * val - fM);
       fM2 += w * rr * rr / (tW * fW);
    }
@@ -120,9 +118,9 @@ void TStatistic::Fill(Double_t val, Double_t w) {
 /// and the maximum.
 void TStatistic::Print(Option_t *) const {
    TROOT::IndentLevel();
-   Printf("OBJ: TStatistic\t %s \t Mean = %.5g +- %.4g \t RMS = %.5g \t Count = %lld \t Sum = %.5g \t Min = %.5g \t Max = %.5g",
-          fName.Data(), GetMean(), GetMeanErr(), GetRMS(), GetN(), GetSum()
-          , GetMin(), GetMax());
+   Printf("OBJ: TStatistic\t %s \t Mean = %.5g +- %.4g \t RMS = %.5g \t Count = %lld \t Sum = %.5g \t Min = %.5g \t "
+          "Max = %.5g",
+          fName.Data(), GetMean(), GetMeanErr(), GetRMS(), GetN(), GetSum(), GetMin(), GetMax());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/math/mathcore/src/TStatistic.cxx
+++ b/math/mathcore/src/TStatistic.cxx
@@ -74,10 +74,11 @@ TStatistic::~TStatistic()
 ///
 /// The minimum(maximum) is computed by checking that the fill value is either
 /// less(greater) than the current minimum(maximum).
-void TStatistic::Fill(Double_t val, Double_t w) {
+void TStatistic::Fill(Double_t val, Double_t w)
+{
 
-
-   if (w == 0) return;
+   if (w == 0)
+      return;
    // Increase data count
    fN++;
 
@@ -93,19 +94,19 @@ void TStatistic::Fill(Double_t val, Double_t w) {
 
    // Check sum of weights
    if (tW == 0) {
-      Warning("Fill","Sum of weights is zero - ignore current data point");
+      Warning("Fill", "Sum of weights is zero - ignore current data point");
       fN--;
       return;
    }
 
    if (fW != 0) { // From the second time
-      Double_t rr = ( tW * val - fM);
+      Double_t rr = (tW * val - fM);
       fM2 += w * rr * rr / (tW * fW);
    }
    // Update sum of weights in the TStatistic object
    fW = tW;
    // Update sum of weights squared
-   fW2 += w*w;
+   fW2 += w * w;
    // Update sum of values
    fSum += val;
 }
@@ -113,19 +114,21 @@ void TStatistic::Fill(Double_t val, Double_t w) {
 ////////////////////////////////////////////////////////////////////////////////
 /// \brief Print the content of the object
 ///
-/// Prints the statistics held by the object in one line. These include the
-/// mean, mean error, RMS, the total number of values and their sum, the minimum
-/// and the maximum.
-void TStatistic::Print(Option_t *) const {
+/// Prints the statistics held by the object in one line. These include the mean,
+/// mean error, RMS, the total number of values, their sum (both unweighted and
+/// weighted), the minimum and the maximum.
+void TStatistic::Print(Option_t *) const
+{
    TROOT::IndentLevel();
-   Printf("OBJ: TStatistic\t %s \t Mean = %.5g +- %.4g \t RMS = %.5g \t Count = %lld \t Sum = %.5g \t Min = %.5g \t "
-          "Max = %.5g",
-          fName.Data(), GetMean(), GetMeanErr(), GetRMS(), GetN(), GetSum(), GetMin(), GetMax());
+   Printf("OBJ: TStatistic\t %s \t Mean = %.5g +- %.4g \t RMS = %.5g \t Count = %lld \t Sum(values) = %.5g \t"
+          "Sum(weighted values) = %.5g \t Min = %.5g \t Max = %.5g",
+          fName.Data(), GetMean(), GetMeanErr(), GetRMS(), GetN(), GetSum(), GetM(), GetMin(), GetMax());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// \brief Merge implementation of TStatistic
 /// \param[in] in Other TStatistic objects to be added to the current one
+/// \return The number of TStatistic objects that have been merged
 ///
 /// The function merges the statistics of all objects together to form a new
 /// one. Merging quantities is done via simple addition for the following class
@@ -142,11 +145,13 @@ void TStatistic::Print(Option_t *) const {
 /// The minimum(maximum) is updated by checking that the minimum(maximum) of
 /// the next TStatistic object in the queue is either less(greater) than the
 /// current minimum(maximum).
-Int_t TStatistic::Merge(TCollection *in) {
+Int_t TStatistic::Merge(TCollection *in)
+{
 
    // Let's organise the list of objects to merge excluding the empty ones
-   std::vector<TStatistic*> statPtrs;
-   if (this->fN != 0LL) statPtrs.push_back(this);
+   std::vector<TStatistic *> statPtrs;
+   if (this->fN != 0LL)
+      statPtrs.push_back(this);
    TStatistic *statPtr;
    for (auto o : *in) {
       if ((statPtr = dynamic_cast<TStatistic *>(o)) && statPtr->fN != 0LL) {
@@ -158,7 +163,8 @@ Int_t TStatistic::Merge(TCollection *in) {
    const auto nStatsPtrs = statPtrs.size();
 
    // Early return possible in case nothing has been filled
-   if (nStatsPtrs == 0) return 0;
+   if (nStatsPtrs == 0)
+      return 0;
 
    // Merge the statistic quantities into local variables to then
    // update the data members of this object
@@ -196,5 +202,4 @@ Int_t TStatistic::Merge(TCollection *in) {
    fSum = Sum;
 
    return nStatsPtrs;
-
 }

--- a/math/mathcore/test/testTStatistic.cxx
+++ b/math/mathcore/test/testTStatistic.cxx
@@ -28,7 +28,7 @@ void testTStatistic(Int_t n = 10000)
    // Find minimum and maximum
    double min = TMath::Limits<Double_t>::Max(); // The minimum value in the array
    double max = TMath::Limits<Double_t>::Min(); // The maximum value in the array
-   double eps_min_max = 0.000001; // Epsilon to check for GetMin and GetMax functions
+   double eps_min_max = 0.000001;               // Epsilon to check for GetMin and GetMax functions
 
    double sum = 0; // Sum of values in the vector
    double eps_sum = eps_min_max;
@@ -51,7 +51,10 @@ void testTStatistic(Int_t n = 10000)
    if (!TMath::AreEqualAbs(st0.GetRMS(),true_sigma, eps2) )   { Error("TestTStatistic-GetRMS","Different value obtained for the unweighted data"); error = true; }
    if (!TMath::AreEqualAbs(st0.GetMin(), min, eps_min_max) )   { Error("TestTStatistic-GetMin","Different value obtained for the unweighted data"); error = true; }
    if (!TMath::AreEqualAbs(st0.GetMax(), max, eps_min_max) )   { Error("TestTStatistic-GetMax","Different value obtained for the unweighted data"); error = true; }
-   if (!TMath::AreEqualAbs(st0.GetSum(), sum, eps_sum) )   { Error("TestTStatistic-GetMax","Different value obtained for the unweighted data"); error = true; }
+   if (!TMath::AreEqualAbs(st0.GetSum(), sum, eps_sum)) {
+      Error("TestTStatistic-GetMax", "Different value obtained for the unweighted data");
+      error = true;
+   }
    if (error) printf("Failed\n");
    else printf("OK\n");
    if (error || gVerbose) {
@@ -87,12 +90,12 @@ void testTStatistic(Int_t n = 10000)
    if (!TMath::AreEqualAbs(st1.GetRMS(),true_sigma, eps2) )  {  Error("TestTStatistic-GetRMS","Different value obtained for the weighted data"); error = true; }
 
    if (error) printf("Failed\n");
-   else printf("OK\n");
+   else
+      printf("OK\n");
    if (error || gVerbose) {
       stp.Print();
       st1.Print();
    }
-
 
    // Incremental test
    printf("\nTest incremental filling :          ");
@@ -108,7 +111,8 @@ void testTStatistic(Int_t n = 10000)
    if (!TMath::AreEqualRel(st1.GetRMS(),st2.GetRMS(), 1.E-15) )    { Error("TestTStatistic-GetRMS","2 Different values obtained for the weighted data"); error = true; }
 
    if (error) printf("Failed\n");
-   else printf("OK\n");
+   else
+      printf("OK\n");
    if (error || gVerbose) {
       stp.Print();
       st2.Print();
@@ -119,8 +123,7 @@ void testTStatistic(Int_t n = 10000)
    int n1 = rand3.Uniform(10,n-10);
 
    // sort the data to have then two biased samples
-   std::sort(xx.begin(), xx.end() );
-
+   std::sort(xx.begin(), xx.end());
 
    printf("\nTest merge :                        ");
    error = false;
@@ -140,7 +143,8 @@ void testTStatistic(Int_t n = 10000)
    if (!TMath::AreEqualAbs(sta.GetRMS(),true_sigma, eps2) )   { Error("TestTStatistic-GetRMS","Different value obtained for the merged data"); error = true; }
 
    if (error) printf("Failed\n");
-   else printf("OK\n");
+   else
+      printf("OK\n");
    if (error || gVerbose) {
       stp.Print();
       sta.Print();
@@ -156,7 +160,8 @@ void testTStatistic(Int_t n = 10000)
    if (!TMath::AreEqualAbs(st3.GetRMS(), sta.GetRMS() , 1.E-10 ) )  {  Error("TestTStatistic-GetRMS","Different value obtained for the sorted data");  error = true; }
 
    if (error) printf("Failed\n");
-   else printf("OK\n");
+   else
+      printf("OK\n");
    if (error || gVerbose) {
       stp.Print();
       st3.Print();
@@ -167,7 +172,7 @@ void testTStatistic(Int_t n = 10000)
    printf("\nTest TMath with weights :           ");
    error = false;
    stp.Start();
-   double meanw = TMath::Mean(xx.begin(), xx.end(), ww.begin() );
+   double meanw = TMath::Mean(xx.begin(), xx.end(), ww.begin());
    double rmsw  = TMath::RMS(xx.begin(), xx.end(), ww.begin() );
    double neff = st2.GetW() * st2.GetW() / st2.GetW2();
    stp.Stop();
@@ -176,30 +181,29 @@ void testTStatistic(Int_t n = 10000)
    if (!TMath::AreEqualAbs(rmsw,true_sigma, eps2) )  {  Error("TestTStatistic::TMath::RMS","Different value obtained for the weighted data"); error = true; }
 
    if (error) printf("Failed\n");
-   else printf("OK\n");
+   else
+      printf("OK\n");
    if (error || gVerbose) {
       stp.Print();
       printf("  TMATH         mu =  %.5g +- %.4g \t RMS = %.5g \n",meanw, rmsw/sqrt(neff ), rmsw);
    }
-
-
 }
 
 int main(int argc, char **argv)
 {
-  // Parse command line arguments
-  for (Int_t i=1 ;  i<argc ; i++) {
-     std::string arg = argv[i] ;
-     if (arg == "-v") {
-      gVerbose = true;
-     }
-     if (arg == "-h") {
-        std::cout << "Usage: " << argv[0] << " [-v]\n";
-        std::cout << "  where:\n";
-        std::cout << "     -v : verbose  mode";
-        std::cout << std::endl;
-        return -1;
-     }
+   // Parse command line arguments
+   for (Int_t i = 1; i < argc; i++) {
+      std::string arg = argv[i];
+      if (arg == "-v") {
+         gVerbose = true;
+      }
+      if (arg == "-h") {
+         std::cout << "Usage: " << argv[0] << " [-v]\n";
+         std::cout << "  where:\n";
+         std::cout << "     -v : verbose  mode";
+         std::cout << std::endl;
+         return -1;
+      }
    }
 
    testTStatistic();

--- a/math/mathcore/test/testTStatistic.cxx
+++ b/math/mathcore/test/testTStatistic.cxx
@@ -33,10 +33,13 @@ void testTStatistic(Int_t n = 10000)
    double sum = 0; // Sum of values in the vector
    double eps_sum = eps_min_max;
 
+   double weighted_sum = 0; // Sum of (value*weight) pairs in the vector
+
    for (Int_t i = 0; i < n; ++i) {
       min = (xx[i] < min) ? xx[i] : min;
       max = (xx[i] > max) ? xx[i] : max;
       sum += xx[i];
+      weighted_sum += xx[i] * ww[i];
    }
 
    TStopwatch stp;
@@ -52,7 +55,12 @@ void testTStatistic(Int_t n = 10000)
    if (!TMath::AreEqualAbs(st0.GetMin(), min, eps_min_max) )   { Error("TestTStatistic-GetMin","Different value obtained for the unweighted data"); error = true; }
    if (!TMath::AreEqualAbs(st0.GetMax(), max, eps_min_max) )   { Error("TestTStatistic-GetMax","Different value obtained for the unweighted data"); error = true; }
    if (!TMath::AreEqualAbs(st0.GetSum(), sum, eps_sum)) {
-      Error("TestTStatistic-GetMax", "Different value obtained for the unweighted data");
+      Error("TestTStatistic-GetSum", "Different value obtained for the unweighted data");
+      error = true;
+   }
+   // fM and fSum should hold the same value in the unweighted test
+   if (!TMath::AreEqualAbs(st0.GetM(), sum, eps_sum)) {
+      Error("TestTStatistic-GetM", "Different value obtained for the unweighted data");
       error = true;
    }
    if (error) printf("Failed\n");
@@ -81,13 +89,17 @@ void testTStatistic(Int_t n = 10000)
 
    // Test using Weights
    printf("\nTest using Weights :                ");
-   error = false; 
+   error = false;
    stp.Start();
    TStatistic st1("st1", n, xx.data(), ww.data());
    stp.Stop();
 
    if (!TMath::AreEqualAbs(st1.GetMean(),true_mean, eps1) )  {  Error("TestTStatistic-GetMean","Different value obtained for the weighted data"); error = true; }
    if (!TMath::AreEqualAbs(st1.GetRMS(),true_sigma, eps2) )  {  Error("TestTStatistic-GetRMS","Different value obtained for the weighted data"); error = true; }
+   if (!TMath::AreEqualAbs(st1.GetM(), weighted_sum, eps_sum)) {
+      Error("TestTStatistic-GetM", "Different value obtained for the weighted data");
+      error = true;
+   }
 
    if (error) printf("Failed\n");
    else


### PR DESCRIPTION
The sum of all the values passed to fill the `TStatistic` object has been added as a class data member. Meanwhile, `Fill`,`Print`, and `Merge` functions have been changed to accomodate the new statistic. The sum is initialized to zero when calling the constructor of TStatistic. Docs and test have been updated
accordingly.