### PR TITLE
[tmemfile] Disallow aggregate initialization for ExternalDataRange_t.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1670,7 +1670,7 @@ bool TCling::LoadPCM(const std::string &pcmFileNameFullPath)
    auto pendingRdict = fPendingRdicts.find(pcmFileNameFullPath);
    if (pendingRdict != fPendingRdicts.end()) {
       llvm::StringRef pcmContent = pendingRdict->second;
-      TMemFile::ExternalDataRange_t range{pcmContent.data(), pcmContent.size()};
+      TMemFile::ZeroCopyView_t range{pcmContent.data(), pcmContent.size()};
       std::string RDictFileOpts = pcmFileNameFullPath + "?filetype=pcm";
       TMemFile pcmMemFile(RDictFileOpts.c_str(), range);
 

--- a/io/io/inc/TMemFile.h
+++ b/io/io/inc/TMemFile.h
@@ -23,7 +23,7 @@ public:
    struct ExternalDataRange_t {
       const char *fStart;
       const size_t fSize;
-      ExternalDataRange_t(const char * start, const size_t size) : fStart(start), fSize(size) {}
+      explicit ExternalDataRange_t(const char * start, const size_t size) : fStart(start), fSize(size) {}
    };
 
 protected:

--- a/io/io/inc/TMemFile.h
+++ b/io/io/inc/TMemFile.h
@@ -20,10 +20,10 @@ class TMemFile : public TFile {
 public:
    using ExternalDataPtr_t = std::shared_ptr<const std::vector<char>>;
    /// A read-only memory range which we do not control.
-   struct ExternalDataRange_t {
+   struct ZeroCopyView_t {
       const char *fStart;
       const size_t fSize;
-      explicit ExternalDataRange_t(const char * start, const size_t size) : fStart(start), fSize(size) {}
+      explicit ZeroCopyView_t(const char * start, const size_t size) : fStart(start), fSize(size) {}
    };
 
 protected:
@@ -91,7 +91,7 @@ public:
             Int_t compress = ROOT::RCompressionSetting::EDefaults::kUseGeneralPurpose, Long64_t defBlockSize = 0LL);
    TMemFile(const char *name, char *buffer, Long64_t size, Option_t *option="", const char *ftitle="", Int_t compress = ROOT::RCompressionSetting::EDefaults::kUseGeneralPurpose);
    TMemFile(const char *name, ExternalDataPtr_t data);
-   TMemFile(const char *name, const ExternalDataRange_t &datarange);
+   TMemFile(const char *name, const ZeroCopyView_t &datarange);
    TMemFile(const char *name, std::unique_ptr<TBufferFile> buffer);
    TMemFile(const TMemFile &orig);
    virtual ~TMemFile();

--- a/io/io/src/TMemFile.cxx
+++ b/io/io/src/TMemFile.cxx
@@ -115,7 +115,7 @@ TMemFile::EMode TMemFile::ParseOption(Option_t *option)
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor to create a TMemFile re-using external C-Style storage.
 
-TMemFile::TMemFile(const char *path, const ExternalDataRange_t &datarange)
+TMemFile::TMemFile(const char *path, const ZeroCopyView_t &datarange)
    : TFile(path, "WEB", "read-only TMemFile", 0 /*compress*/),
      fBlockList(reinterpret_cast<UChar_t *>(const_cast<char *>(datarange.fStart)), datarange.fSize),
      fIsOwnedByROOT(false), fSize(datarange.fSize), fSysOffset(0), fBlockSeek(&(fBlockList)), fBlockOffset(0)
@@ -138,7 +138,7 @@ TMemFile::TMemFile(const char *path, const ExternalDataRange_t &datarange)
 /// Constructor to create a TMemFile re-using external storage.
 
 TMemFile::TMemFile(const char *path, ExternalDataPtr_t data)
-   : TMemFile(path, ExternalDataRange_t(data->data(), data->size()))
+   : TMemFile(path, ZeroCopyView_t(data->data(), data->size()))
 {
    fExternalData = data;
 }
@@ -147,7 +147,7 @@ TMemFile::TMemFile(const char *path, ExternalDataPtr_t data)
 /// Constructor to create a read-only TMemFile using an std::unique_ptr<TBufferFile>
 
 TMemFile::TMemFile(const char *name, std::unique_ptr<TBufferFile> buffer)
-   : TMemFile(name, ExternalDataRange_t(buffer->Buffer(), (size_t)buffer->BufferSize()))
+   : TMemFile(name, ZeroCopyView_t(buffer->Buffer(), (size_t)buffer->BufferSize()))
 {
    assert(!fD && !fWritable);
 

--- a/io/io/test/TROMemFileTests.cxx
+++ b/io/io/test/TROMemFileTests.cxx
@@ -70,7 +70,7 @@ TEST(TROMemFile, RealNoMemCopy)
    std::string expected = "Hello from TMemFile!";
    // Include the 0 terminator to later compare the strings.
    size_t expected_size = expected.size() + 1;
-   TMemFile::ExternalDataRange_t externalDataRange{expected.c_str(), expected_size};
+   TMemFile::ZeroCopyView_t externalDataRange{expected.c_str(), expected_size};
    TMemFile rosmf("hello.bin?filetype=raw", externalDataRange);
 
    std::vector<char> seen;


### PR DESCRIPTION
This patch makes it more difficult for people to avoid the 'automatic' memory
ownership done by TMemFile. It forces people to explicitly construct the
data structure describing memory blob and makes it easier to grep for.