### PR TITLE
[Exp PyROOT] Fixed two other failing tests (AsNumpyArrays-py and tStudent-py) with commit 832989c

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -475,10 +475,8 @@ if(ROOT_python_FOUND)
                  tutorial-dataframe-df014_CSVDataSource-py
                  tutorial-dataframe-df016_vecOps-py
                  tutorial-dataframe-df017_vecOpsHEP-py
-                 tutorial-dataframe-df026_AsNumpyArrays-py
                  tutorial-dataframe-df102_NanoAODDimuonAnalysis-py
                  tutorial-math-Legendre-py
-                 tutorial-math-tStudent-py
                  tutorial-pyroot-benchmarks-py
                  tutorial-pyroot-geometry-py
                  tutorial-pyroot-na49view-py


### PR DESCRIPTION
The two tests mentioned in the title were fixed after the corrections implemented for pythonizations of templated classes and try/exception blocks in Cppyy, on top of which the possibility to use ROOT.Namespace instead of ROOT.ROOT.Namespace was added.
Commits that fixed the tests:
832989cd2cd3dea7a2f96aa53272ecdd34e45b8b
f45d07c7a0b2414159e81a957a4fe86afc63fa87
f45d07c7a0b2414159e81a957a4fe86afc63fa87