### PR TITLE
[WIP] cxxmodule, I/O and std::tuple

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -3651,7 +3651,7 @@ void TCling::SetClassInfo(TClass* cl, Bool_t reload)
    // Handle the special case of 'tuple' where we ignore the real implementation
    // details and just overlay a 'simpler'/'simplistic' version that is easy
    // for the I/O to understand and handle.
-   if (!(fCxxModulesEnabled && IsFromRootCling()) && strncmp(cl->GetName(),"tuple<",strlen("tuple<"))==0) {
+   if (strncmp(cl->GetName(),"tuple<",strlen("tuple<"))==0) {
 
       name = AlternateTuple(cl->GetName());
 


### PR DESCRIPTION
Revert "[cxxmodules] Fix R.M by displacing TEmulatedTuple only withou…t cxxmodules"

This reverts commit a74297ac32fbe9f1aec0be246d0bef1c430b9bc6.

This repairs the support for I/O of std::tuple.  The previous code leads to
the actual std::tuple implementation to be attempted (and failing) to be used
for I/O:

See https://epsft-jenkins.cern.ch/job/root-pullrequests-build/59119/testReport/projectroot.roottest.root.io/tuple/roottest_root_io_tuple_make/

