### PR TITLE
[RF] Fix I/O of RooFit datasets

### DIFF
--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -77,8 +77,8 @@ public:
   RooAbsArg(const char *name, const char *title);
   RooAbsArg(const RooAbsArg& other, const char* name=0) ;
   virtual TObject* clone(const char* newname=0) const = 0 ;
-  virtual TObject* Clone(const char* newname=0) const {
-    return clone(newname) ;
+  virtual TObject* Clone(const char* newname = 0) const {
+    return clone(newname && newname != std::string("") ? newname : nullptr);
   }
   virtual RooAbsArg* cloneTree(const char* newname=0) const ;
 

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -78,7 +78,7 @@ public:
   RooAbsArg(const RooAbsArg& other, const char* name=0) ;
   virtual TObject* clone(const char* newname=0) const = 0 ;
   virtual TObject* Clone(const char* newname = 0) const {
-    return clone(newname && newname != std::string("") ? newname : nullptr);
+    return clone(newname && newname[0] != '\0' ? newname : nullptr);
   }
   virtual RooAbsArg* cloneTree(const char* newname=0) const ;
 

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -53,7 +53,9 @@ public:
   RooDataHist& operator=(const RooDataHist&) = delete;
 
   RooDataHist(const RooDataHist& other, const char* newname = 0) ;
-  virtual TObject* Clone(const char* newname=0) const { return new RooDataHist(*this,newname?newname:GetName()) ; }
+  virtual TObject* Clone(const char* newname) const {
+    return new RooDataHist(*this, newname && newname != std::string("") ? newname : GetName());
+  }
   virtual ~RooDataHist() ;
 
   virtual RooAbsData* emptyClone(const char* newName=0, const char* newTitle=0, const RooArgSet*vars=0, const char* /*wgtVarName*/=0) const {

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -54,7 +54,7 @@ public:
 
   RooDataHist(const RooDataHist& other, const char* newname = 0) ;
   virtual TObject* Clone(const char* newname) const {
-    return new RooDataHist(*this, newname && newname != std::string("") ? newname : GetName());
+    return new RooDataHist(*this, newname && newname[0] != '\0' ? newname : GetName());
   }
   virtual ~RooDataHist() ;
 

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -63,8 +63,8 @@ public:
   
 
   RooDataSet(RooDataSet const & other, const char* newname=0) ;  
-  virtual TObject* Clone(const char* newname = "") const override {
-    return new RooDataSet(*this, newname && newname != std::string("") ? newname : GetName());
+  virtual TObject* Clone(const char* newname = "") const {
+    return new RooDataSet(*this, newname && newname[0] != '\0' ? newname : GetName());
   }
   virtual ~RooDataSet() ;
 

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -63,7 +63,9 @@ public:
   
 
   RooDataSet(RooDataSet const & other, const char* newname=0) ;  
-  virtual TObject* Clone(const char* newname=0) const { return new RooDataSet(*this,newname?newname:GetName()) ; }
+  virtual TObject* Clone(const char* newname = "") const override {
+    return new RooDataSet(*this, newname && newname != std::string("") ? newname : GetName());
+  }
   virtual ~RooDataSet() ;
 
   virtual RooAbsData* emptyClone(const char* newName=0, const char* newTitle=0, const RooArgSet* vars=0, const char* wgtVarName=0) const ;

--- a/roofit/roofitcore/inc/RooTreeDataStore.h
+++ b/roofit/roofitcore/inc/RooTreeDataStore.h
@@ -122,7 +122,7 @@ public:
   
   const RooArgSet& row() { return _varsww ; }
 
- protected:
+ private:
 
   friend class RooVectorDataStore ;
 
@@ -136,6 +136,8 @@ public:
   void setBranchBufferSize(Int_t size) { _defTreeBufSize = size ; }
   Int_t getBranchBufferSize() const { return _defTreeBufSize ; }
 
+  std::string makeTreeName() const;
+
   static Int_t _defTreeBufSize ;  
 
   void createTree(const char* name, const char* title) ; 
@@ -147,10 +149,10 @@ public:
   RooArgSet _varsww ;
   RooRealVar* _wgtVar ;     // Pointer to weight variable (if set)
 
-  Double_t* _extWgtArray ;         //! External weight array
-  Double_t* _extWgtErrLoArray ;    //! External weight array - low error
-  Double_t* _extWgtErrHiArray ;    //! External weight array - high error
-  Double_t* _extSumW2Array ;       //! External sum of weights array
+  const Double_t* _extWgtArray{nullptr};         //! External weight array
+  const Double_t* _extWgtErrLoArray{nullptr};    //! External weight array - low error
+  const Double_t* _extWgtErrHiArray{nullptr};    //! External weight array - high error
+  const Double_t* _extSumW2Array{nullptr};       //! External sum of weights array
 
   mutable Double_t  _curWgt ;      // Weight of current event
   mutable Double_t  _curWgtErrLo ; // Weight of current event
@@ -159,7 +161,7 @@ public:
 
   RooArgSet _attachedBuffers ; //! Currently attached buffers (if different from _varsww)
 
-  ClassDef(RooTreeDataStore,2) // TTree-based Data Storage class
+  ClassDef(RooTreeDataStore, 2) // TTree-based Data Storage class
 };
 
 

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -3240,11 +3240,6 @@ void RooAbsReal::attachToTree(TTree& t, Int_t bufSize)
       coutE(InputArguments) << "RooAbsReal::attachToTree(" << GetName() << ") data type " << typeName << " is not supported" << endl ;
     }
 
-    if (branch->GetCompressionLevel()<0) {
-      // cout << "RooAbsReal::attachToTree(" << GetName() << ") Fixing compression level of branch " << cleanName << endl ;
-      branch->SetCompressionLevel(ROOT::RCompressionSetting::EDefaults::kUseGlobal % 100) ;
-    }
-
 //      cout << "RooAbsReal::attachToTree(" << cleanName << "): branch already exists in tree " << (void*)&t << ", changing address" << endl ;
 
   } else {
@@ -3252,7 +3247,6 @@ void RooAbsReal::attachToTree(TTree& t, Int_t bufSize)
     TString format(cleanName);
     format.Append("/D");
     branch = t.Branch(cleanName, &_value, (const Text_t*)format, bufSize);
-    branch->SetCompressionLevel(ROOT::RCompressionSetting::EDefaults::kUseGlobal % 100) ;
     //      cout << "RooAbsReal::attachToTree(" << cleanName << "): creating new branch in tree " << (void*)&t << endl ;
   }
 

--- a/roofit/roofitcore/src/RooCompositeDataStore.cxx
+++ b/roofit/roofitcore/src/RooCompositeDataStore.cxx
@@ -19,8 +19,13 @@
 \class RooCompositeDataStore
 \ingroup Roofitcore
 
-RooCompositeDataStore is the abstract base class for data collection that
-use a TTree as internal storage mechanism
+RooCompositeDataStore combines several disjunct datasets into one. This is useful for simultaneous PDFs
+that do not depend on the same observable such as a PDF depending on `x` combined with another one depending
+on `y`.
+The composite storage will store two different datasets, `{x}` and `{y}`, but they can be passed as a single
+dataset to RooFit operations. A category tag will define which dataset has to be passed to which likelihood.
+
+When iterated from start to finish, datasets will be traversed in the order of the category index.
 **/
 
 #include "RooFit.h"

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -28,23 +28,23 @@ There are two storage backends:
 cannot be serialised if the dataset exceeds a size of 1 Gb
 - RooTreeDataStore: Uses a TTree, which can be file backed if a file is opened
 before creating the dataset. This significantly reduces the memory pressure, as the
-baskets of the tree can be written to a file.
-Enable tree-backed storage similar to this:
-```
-TFile outputFile("filename.root", "RECREATE");
-RooAbsData::setDefaultStorageType(RooAbsData::Tree);
-RooDataSet mydata(...);
-```
-or convert an existing memory-backed data storage:
-```
-RooDataSet mydata(...);
+baskets of the tree can be written to a file, and only the basket that's currently
+being read stays in RAM.
+  - Enable tree-backed storage similar to this:
+  ```
+  TFile outputFile("filename.root", "RECREATE");
+  RooAbsData::setDefaultStorageType(RooAbsData::Tree);
+  RooDataSet mydata(...);
+  ```
+  - Or convert an existing memory-backed data storage:
+  ```
+  RooDataSet mydata(...);
 
-TFile outputFile("filename.root", "RECREATE");
-mydata.convertToTreeStore();
-```
+  TFile outputFile("filename.root", "RECREATE");
+  mydata.convertToTreeStore();
+  ```
 
-Tree-backed storage can be converted like this:
-`RooAbsData::convertToTreeStore()`.
+For the inverse conversion, see `RooAbsData::convertToVectorStore()`.
 
 **/
 

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -22,6 +22,30 @@
 RooDataSet is a container class to hold unbinned data. Each data point
 in N-dimensional space is represented by a RooArgSet of RooRealVar, RooCategory 
 or RooStringVar objects.
+
+There are two storage backends:
+- RooVectorDataStore (default): std::vectors in memory. They are fast, but they
+cannot be serialised if the dataset exceeds a size of 1 Gb
+- RooTreeDataStore: Uses a TTree, which can be file backed if a file is opened
+before creating the dataset. This significantly reduces the memory pressure, as the
+baskets of the tree can be written to a file.
+Enable tree-backed storage similar to this:
+```
+TFile outputFile("filename.root", "RECREATE");
+RooAbsData::setDefaultStorageType(RooAbsData::Tree);
+RooDataSet mydata(...);
+```
+or convert an existing memory-backed data storage:
+```
+RooDataSet mydata(...);
+
+TFile outputFile("filename.root", "RECREATE");
+mydata.convertToTreeStore();
+```
+
+Tree-backed storage can be converted like this:
+`RooAbsData::convertToTreeStore()`.
+
 **/
 
 #include "RooFit.h"


### PR DESCRIPTION
RooFit has the option to hold fitting data in memory as std::vectors or
to use Tree-backed storage. The latter only makes sense when streaming
from files is desired, and is therefore not the default.
However, Tree-backed storage was using memory-resident trees, which
could not be written when larger than 1 Gb. Now, the tree-backed storage
is file-backed, and stays connected to the file when reading back.

This fixes ROOT-10188.

Further, fix ROOT-6260, datasets are losing their name when copied and missing compression for branches.