### PR TITLE
[ntuple] fix conflict between default move assignment and const members in RColumnElement

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -46,10 +46,10 @@ protected:
    /// Points to valid C++ data, either a single value or an array of values
    void* fRawContent;
    /// Size of the C++ value pointed to by fRawContent (not necessarily equal to the on-disk element size)
-   const unsigned int fSize;
+   unsigned int fSize;
 
    /// Indicates that *fRawContent is bitwise identical to the physical column element
-   const bool fIsMappable;
+   bool fIsMappable;
 
    virtual void DoSerialize(void* /* destination */, std::size_t /*count*/) const { }
    virtual void DoDeserialize(void* /* source */, std::size_t /*count*/) const { }


### PR DESCRIPTION
We might possibly introduce a small inefficiency by removing `const` from the two members but this class is anyway up for changes as the unpacking of column elements should be moved out and to the page mapping code.