### PR TITLE
Do not redefine the alternative tuple when it already exists.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -3562,11 +3562,16 @@ static ETupleOrdering IsTupleAscending()
    }
 }
 
-std::string AlternateTuple(const char *classname)
+static std::string AlternateTuple(const char *classname, const cling::LookupHelper& lh)
 {
    TClassEdit::TSplitType tupleContent(classname);
    std::string alternateName = "TEmulatedTuple";
    alternateName.append( classname + 5 );
+
+   std::string fullname = "ROOT::Internal::" + alternateName;
+   if (lh.findScope(fullname, cling::LookupHelper::NoDiagnostics,
+                    /*resultType*/nullptr, /* intantiateTemplate= */ false))
+      return fullname;
 
    std::string guard_name;
    ROOT::TMetaUtils::GetCppName(guard_name,alternateName.c_str());
@@ -3651,9 +3656,9 @@ void TCling::SetClassInfo(TClass* cl, Bool_t reload)
    // Handle the special case of 'tuple' where we ignore the real implementation
    // details and just overlay a 'simpler'/'simplistic' version that is easy
    // for the I/O to understand and handle.
-   if (!(fCxxModulesEnabled && IsFromRootCling()) && strncmp(cl->GetName(),"tuple<",strlen("tuple<"))==0) {
+   if (strncmp(cl->GetName(),"tuple<",strlen("tuple<"))==0) {
 
-      name = AlternateTuple(cl->GetName());
+      name = AlternateTuple(cl->GetName(), fInterpreter->getLookupHelper());
 
    }
 


### PR DESCRIPTION
This fixes a bug visible only in runtime_cxxmodules where the include guards
are ignored. This can happen when we are building a two modules which need
the same definition. In this case the usual include guards will only work if
we call a proper `#include "something"` and this something should be defined
in a modulemap.

There is no better solution for this at the moment. This is a rare case which
will likely not affect external use-cases.

Revert "[cxxmodules] Fix R.M by displacing TEmulatedTuple only without cxxmodules"

This reverts commit a74297ac32fbe9f1aec0be246d0bef1c430b9bc6 and puts in place
a better fix. Now roottest-root-io-tuple-make should work with modules.

Patch by Philippe Canal and me!

This PR should supersede PR#3982.