### PR TITLE
SPlot: enable fitTo options in s-weight generation

### DIFF
--- a/roofit/roostats/inc/RooStats/SPlot.h
+++ b/roofit/roostats/inc/RooStats/SPlot.h
@@ -40,7 +40,11 @@ namespace RooStats{
     SPlot(const char* name, const char* title, const RooDataSet &data);
     SPlot(const char* name, const char* title,RooDataSet& data, RooAbsPdf* pdf,
      const RooArgList &yieldsList,const RooArgSet &projDeps=RooArgSet(),
-     bool includeWeights=kTRUE, bool copyDataSet = kFALSE, const char* newName = "");
+     bool includeWeights=kTRUE, bool copyDataSet = kFALSE, const char* newName = "",
+     const RooCmdArg& fitToarg5=RooCmdArg::none(),
+     const RooCmdArg& fitToarg6=RooCmdArg::none(),
+     const RooCmdArg& fitToarg7=RooCmdArg::none(),
+     const RooCmdArg& fitToarg8=RooCmdArg::none());
 
     RooDataSet* SetSData(RooDataSet* data);
 
@@ -51,7 +55,11 @@ namespace RooStats{
     Int_t GetNumSWeightVars() const;
 
     void AddSWeight(RooAbsPdf* pdf, const RooArgList &yieldsTmp,
-          const RooArgSet &projDeps=RooArgSet(), bool includeWeights=kTRUE);
+          const RooArgSet &projDeps=RooArgSet(), bool includeWeights=kTRUE,
+          const RooCmdArg& fitToarg5=RooCmdArg::none(),
+          const RooCmdArg& fitToarg6=RooCmdArg::none(),
+          const RooCmdArg& fitToarg7=RooCmdArg::none(),
+          const RooCmdArg& fitToarg8=RooCmdArg::none());
 
     Double_t GetSumOfEventSWeight(Int_t numEvent) const;
 

--- a/roofit/roostats/src/SPlot.cxx
+++ b/roofit/roostats/src/SPlot.cxx
@@ -130,6 +130,9 @@ SPlot::SPlot(const SPlot &other):
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+//Construct a new SPlot class,
+//calculate sWeights, and include them
+//in the RooDataSet of this class.
 
 SPlot::SPlot(const char* name, const char* title, RooDataSet& data, RooAbsPdf* pdf,
         const RooArgList &yieldsList, const RooArgSet &projDeps,

--- a/roofit/roostats/src/SPlot.cxx
+++ b/roofit/roostats/src/SPlot.cxx
@@ -136,7 +136,8 @@ SPlot::SPlot(const SPlot &other):
 
 SPlot::SPlot(const char* name, const char* title, RooDataSet& data, RooAbsPdf* pdf,
         const RooArgList &yieldsList, const RooArgSet &projDeps,
-        bool includeWeights, bool cloneData, const char* newName):
+        bool includeWeights, bool cloneData, const char* newName,
+        const RooCmdArg& arg5, const RooCmdArg& arg6, const RooCmdArg& arg7, const RooCmdArg& arg8):
   TNamed(name, title)
 {
    if(cloneData == 1) {
@@ -162,7 +163,7 @@ SPlot::SPlot(const char* name, const char* title, RooDataSet& data, RooAbsPdf* p
   //calculate sWeights, and include them
   //in the RooDataSet of this class.
 
-  this->AddSWeight(pdf, yieldsList, projDeps, includeWeights);
+  this->AddSWeight(pdf, yieldsList, projDeps, includeWeights, arg5, arg6, arg7, arg8);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -342,9 +343,17 @@ Int_t SPlot::GetNumSWeightVars() const
 ///
 /// Find Parameters in the PDF to be considered fixed when calculating the SWeights
 /// and be sure to NOT include the yields in that list
+///
+/// After fixing non-yield parameters, calls
+/// `pdf->fitTo(*fSData, RooFit::Extended(kTRUE), RooFit::SumW2Error(kTRUE), RooFit::PrintLevel(-1), RooFit::PrintEvalErrors(-1))`.
+/// One can pass additional arguments to `fitTo`, such as `RooFit::Range("fitrange")`, as `arg5`, `arg6`, `arg7`, `arg8`.
+/// Note that `RooFit::Range` may be necessary to get expected results if you initially fit in a range
+/// and/or called `pdf->fixCoefRange("fitrange")` on `pdf`.
+/// CALL `arg5`, `arg6`, `arg7`, `arg8` AT YOUR OWN RISK.
 
 void SPlot::AddSWeight( RooAbsPdf* pdf, const RooArgList &yieldsTmp,
-         const RooArgSet &projDeps, bool includeWeights)
+         const RooArgSet &projDeps, bool includeWeights,
+         const RooCmdArg& arg5, const RooCmdArg& arg6, const RooCmdArg& arg7, const RooCmdArg& arg8)
 {
 
   RooFit::MsgLevel currentLevel =  RooMsgService::instance().globalKillBelow();
@@ -370,7 +379,7 @@ void SPlot::AddSWeight( RooAbsPdf* pdf, const RooArgList &yieldsTmp,
   // Fit yields to the data with all other variables held constant
   // This is necessary because SPlot assumes the yields minimise -Log(likelihood)
 
-  pdf->fitTo(*fSData, RooFit::Extended(kTRUE), RooFit::SumW2Error(kTRUE), RooFit::PrintLevel(-1), RooFit::PrintEvalErrors(-1) );
+  pdf->fitTo(*fSData, RooFit::Extended(kTRUE), RooFit::SumW2Error(kTRUE), RooFit::PrintLevel(-1), RooFit::PrintEvalErrors(-1), arg5, arg6, arg7, arg8);
 
   // Hold the value of the fitted yields
   std::vector<double> yieldsHolder;

--- a/roofit/roostats/src/SPlot.cxx
+++ b/roofit/roostats/src/SPlot.cxx
@@ -130,10 +130,18 @@ SPlot::SPlot(const SPlot &other):
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-//Construct a new SPlot class,
-//calculate sWeights, and include them
-//in the RooDataSet of this class.
-
+///Construct a new SPlot instance, calculate sWeights, and include them
+///in the RooDataSet held by this instance.
+///\param[in] name Name of the instance.
+///\param[in] title Title of the instance.
+///\param[in] data Dataset to fit to.
+///\param[in] pdf PDF to compute s weights for.
+///\param[in] yieldsList List of parameters in `pdf` that are yields.
+///\param[in] projDeps Don't normalise over these parameters when calculating the sWeights. Will be passed on to AddSWeight(). 
+///\param[in] includeWeights Whether or not to include the weights in `data`. Passed on to AddSWeight().
+///\param[in] cloneData Make a clone of the incoming data before adding weights.
+///\param[in] newName New name for the data.
+///\param[in] argX Additional arguments for the fitting step in AddSWeight().
 SPlot::SPlot(const char* name, const char* title, RooDataSet& data, RooAbsPdf* pdf,
         const RooArgList &yieldsList, const RooArgSet &projDeps,
         bool includeWeights, bool cloneData, const char* newName,
@@ -330,27 +338,30 @@ Int_t SPlot::GetNumSWeightVars() const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Method which adds the sWeights to the dataset.
-/// Input is the PDF, a RooArgList of the yields (floating)
-/// and a RooArgSet of the projDeps.
 ///
-/// The projDeps will not be normalized over when calculating the SWeights
-/// and will be considered parameters, not observables.
-///
-/// The SPlot will contain two new variables for each specie of name "varname":
-///
-/// L_varname is the value of the pdf for the variable "varname" at values of this event
-/// varname_sw is the value of the sWeight for the variable "varname" for this event
+/// The SPlot will contain two new variables for each yield parameter:
+/// - `L_<varname>` is the value of the pdf for the variable "varname" for each event.
+/// - `varname_sw` is the value of the sWeight for the variable "varname" for each event.
 ///
 /// Find Parameters in the PDF to be considered fixed when calculating the SWeights
-/// and be sure to NOT include the yields in that list
+/// and be sure to NOT include the yields in that list.
 ///
-/// After fixing non-yield parameters, calls
-/// `pdf->fitTo(*fSData, RooFit::Extended(kTRUE), RooFit::SumW2Error(kTRUE), RooFit::PrintLevel(-1), RooFit::PrintEvalErrors(-1))`.
+/// After fixing non-yield parameters, this function will start a fit by calling
+/// ```
+/// pdf->fitTo(*fSData, RooFit::Extended(kTRUE), RooFit::SumW2Error(kTRUE), RooFit::PrintLevel(-1), RooFit::PrintEvalErrors(-1)).
+/// ```
 /// One can pass additional arguments to `fitTo`, such as `RooFit::Range("fitrange")`, as `arg5`, `arg6`, `arg7`, `arg8`.
-/// Note that `RooFit::Range` may be necessary to get expected results if you initially fit in a range
+/// 
+/// \note A `RooFit::Range` may be necessary to get expected results if you initially fit in a range
 /// and/or called `pdf->fixCoefRange("fitrange")` on `pdf`.
-/// CALL `arg5`, `arg6`, `arg7`, `arg8` AT YOUR OWN RISK.
-
+/// Pass `arg5`, `arg6`, `arg7`, `arg8` AT YOUR OWN RISK.
+///
+/// \param[in] pdf PDF to fit to data to compute s weights.
+/// \param[in] yieldsTmp 
+/// \param[in] projDeps These will not be normalized over when calculating the sWeights,
+/// and will be considered parameters, not observables.
+/// \param[in] includeWeights
+/// \param[in] argX Optional arguments for the fitting step.
 void SPlot::AddSWeight( RooAbsPdf* pdf, const RooArgList &yieldsTmp,
          const RooArgSet &projDeps, bool includeWeights,
          const RooCmdArg& arg5, const RooCmdArg& arg6, const RooCmdArg& arg7, const RooCmdArg& arg8)

--- a/roofit/roostats/src/SPlot.cxx
+++ b/roofit/roostats/src/SPlot.cxx
@@ -137,7 +137,7 @@ SPlot::SPlot(const SPlot &other):
 ///\param[in] data Dataset to fit to.
 ///\param[in] pdf PDF to compute s weights for.
 ///\param[in] yieldsList List of parameters in `pdf` that are yields.
-///\param[in] projDeps Don't normalise over these parameters when calculating the sWeights. Will be passed on to AddSWeight(). 
+///\param[in] projDeps Don't normalise over these parameters when calculating the sWeights. Will be passed on to AddSWeight().
 ///\param[in] includeWeights Whether or not to include the weights in `data`. Passed on to AddSWeight().
 ///\param[in] cloneData Make a clone of the incoming data before adding weights.
 ///\param[in] newName New name for the data.
@@ -341,7 +341,7 @@ Int_t SPlot::GetNumSWeightVars() const
 ///
 /// The SPlot will contain two new variables for each yield parameter:
 /// - `L_<varname>` is the value of the pdf for the variable "varname" for each event.
-/// - `varname_sw` is the value of the sWeight for the variable "varname" for each event.
+/// - `<varname>_sw` is the value of the sWeight for the variable "varname" for each event.
 ///
 /// Find Parameters in the PDF to be considered fixed when calculating the SWeights
 /// and be sure to NOT include the yields in that list.
@@ -351,17 +351,17 @@ Int_t SPlot::GetNumSWeightVars() const
 /// pdf->fitTo(*fSData, RooFit::Extended(kTRUE), RooFit::SumW2Error(kTRUE), RooFit::PrintLevel(-1), RooFit::PrintEvalErrors(-1)).
 /// ```
 /// One can pass additional arguments to `fitTo`, such as `RooFit::Range("fitrange")`, as `arg5`, `arg6`, `arg7`, `arg8`.
-/// 
+///
 /// \note A `RooFit::Range` may be necessary to get expected results if you initially fit in a range
 /// and/or called `pdf->fixCoefRange("fitrange")` on `pdf`.
 /// Pass `arg5`, `arg6`, `arg7`, `arg8` AT YOUR OWN RISK.
 ///
 /// \param[in] pdf PDF to fit to data to compute s weights.
-/// \param[in] yieldsTmp 
+/// \param[in] yieldsTmp Yields to use to compute s weights.
 /// \param[in] projDeps These will not be normalized over when calculating the sWeights,
 /// and will be considered parameters, not observables.
 /// \param[in] includeWeights
-/// \param[in] argX Optional arguments for the fitting step.
+/// \param[in] argX Optional additional arguments for the fitting step.
 void SPlot::AddSWeight( RooAbsPdf* pdf, const RooArgList &yieldsTmp,
          const RooArgSet &projDeps, bool includeWeights,
          const RooCmdArg& arg5, const RooCmdArg& arg6, const RooCmdArg& arg7, const RooCmdArg& arg8)


### PR DESCRIPTION
Adds ability for user to specify additional `RooCmdArg`s to be used in the call to `fitTo` within `AddSWeight`. Especially useful if the fit was done in a range and `pdf->fixCoefRange` was called.