### PR TITLE
[RF] Sanitise integral of RooCBShape.

### DIFF
--- a/roofit/roofit/src/RooCBShape.cxx
+++ b/roofit/roofit/src/RooCBShape.cxx
@@ -17,7 +17,7 @@
 /** \class RooCBShape
     \ingroup Roofit
 
-P.d.f implementing the Crystal Ball line shape
+PDF implementing the Crystal Ball line shape.
 **/
 
 #include "RooFit.h"
@@ -166,7 +166,7 @@ Double_t RooCBShape::analyticalIntegral(Int_t code, const char* rangeName) const
     result += term1 + term2;
   }
 
-  return result;
+  return result != 0. ? result : std::numeric_limits<double>::min();
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
When integrating a region next to a narrow Crystal Ball shape, the integral
can evaluate to zero. Since RooFit cannot deal with zero integrals,
the CBShape will now return the smallest possible double.

See also https://root-forum.cern.ch/t/fit-a-double-crystal-ball-with-roofitranges/34599