### PR TITLE
Allow to select system of units (TGeo/Geant4) at run-time

### DIFF
--- a/geom/geom/CMakeLists.txt
+++ b/geom/geom/CMakeLists.txt
@@ -100,6 +100,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Geom
     src/TGeoTrd1.cxx
     src/TGeoTrd2.cxx
     src/TGeoTube.cxx
+    src/TGeoUnit.cxx
     src/TGeoVolume.cxx
     src/TGeoVoxelFinder.cxx
     src/TGeoXtru.cxx

--- a/geom/geom/inc/TGeant4PhysicalConstants.h
+++ b/geom/geom/inc/TGeant4PhysicalConstants.h
@@ -1,0 +1,117 @@
+/*************************************************************************
+ * Copyright (C) 1995-2000, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+// ----------------------------------------------------------------------
+// HEP coherent Physical Constants
+// Adapted for ROOT by Marko Petric
+//
+// This file has been provided by Geant4 (simulation toolkit for HEP).
+//
+// Below is a non exhaustive list of Physical CONSTANTS,
+// computed in the Internal HEP System Of Units.
+//
+// Most of them are extracted from the Particle Data Book :
+//        Phys. Rev. D  volume 50 3-1 (1994) page 1233
+//
+//
+// Author: M.Maire
+//
+// History:
+//
+// 23.02.96 Created
+// 26.03.96 Added constants for standard conditions of temperature
+//          and pressure; also added Gas threshold.
+// 29.04.08   use PDG 2006 values
+// 03.11.08   use PDG 2008 values
+// 02.10.17   addopted constant from CLHEP 2.3.4.3
+
+#ifndef TGEANT4_PHYSICAL_CONSTANTS_H
+#define TGEANT4_PHYSICAL_CONSTANTS_H
+
+#include "TGeant4SystemOfUnits.h"
+
+namespace TGeant4Unit {
+
+//
+//
+//
+static constexpr double Avogadro = 6.02214179e+23 / mole;
+
+//
+// c   = 299.792458 mm/ns
+// c^2 = 898.7404 (mm/ns)^2
+//
+static constexpr double c_light = 2.99792458e+8 * m / s;
+static constexpr double c_squared = c_light * c_light;
+
+//
+// h     = 4.13566e-12 MeV*ns
+// hbar  = 6.58212e-13 MeV*ns
+// hbarc = 197.32705e-12 MeV*mm
+//
+static constexpr double h_Planck = 6.62606896e-34 * joule * s;
+static constexpr double hbar_Planck = h_Planck / twopi;
+static constexpr double hbarc = hbar_Planck * c_light;
+static constexpr double hbarc_squared = hbarc * hbarc;
+
+//
+//
+//
+static constexpr double electron_charge = -eplus; // see SystemOfUnits.h
+static constexpr double e_squared = eplus * eplus;
+
+//
+// amu_c2 - atomic equivalent mass unit
+//        - AKA, unified atomic mass unit (u)
+// amu    - atomic mass unit
+//
+static constexpr double electron_mass_c2 = 0.510998910 * MeV;
+static constexpr double proton_mass_c2 = 938.272013 * MeV;
+static constexpr double neutron_mass_c2 = 939.56536 * MeV;
+static constexpr double amu_c2 = 931.494028 * MeV;
+static constexpr double amu = amu_c2 / c_squared;
+
+//
+// permeability of free space mu0    = 2.01334e-16 Mev*(ns*eplus)^2/mm
+// permittivity of free space epsil0 = 5.52636e+10 eplus^2/(MeV*mm)
+//
+static constexpr double mu0 = 4 * pi * 1.e-7 * henry / m;
+static constexpr double epsilon0 = 1. / (c_squared * mu0);
+
+//
+// electromagnetic coupling = 1.43996e-12 MeV*mm/(eplus^2)
+//
+static constexpr double elm_coupling = e_squared / (4 * pi * epsilon0);
+static constexpr double fine_structure_const = elm_coupling / hbarc;
+static constexpr double classic_electr_radius = elm_coupling / electron_mass_c2;
+static constexpr double electron_Compton_length = hbarc / electron_mass_c2;
+static constexpr double Bohr_radius = electron_Compton_length / fine_structure_const;
+
+static constexpr double alpha_rcl2 = fine_structure_const * classic_electr_radius * classic_electr_radius;
+
+static constexpr double twopi_mc2_rcl2 = twopi * electron_mass_c2 * classic_electr_radius * classic_electr_radius;
+//
+//
+//
+static constexpr double k_Boltzmann = 8.617343e-11 * MeV / kelvin;
+
+//
+//
+//
+static constexpr double STP_Temperature = 273.15 * kelvin;
+static constexpr double STP_Pressure = 1. * atmosphere;
+static constexpr double kGasThreshold = 10. * mg / cm3;
+
+//
+//
+//
+static constexpr double universe_mean_density = 1.e-25 * g / cm3;
+
+} // namespace TGeant4Unit
+
+#endif /* TGEANT4_PHYSICAL_CONSTANTS_H */

--- a/geom/geom/inc/TGeant4SystemOfUnits.h
+++ b/geom/geom/inc/TGeant4SystemOfUnits.h
@@ -51,14 +51,10 @@
 // 12.01.16   added symbols for microsecond (us) and picosecond (ps) (mma)
 // 02.10.17   addopted units from CLHEP 2.3.4.3 and converted to TGeo unit base
 
-#ifndef TGEO_SYSTEM_OF_UNITS_H
-#define TGEO_SYSTEM_OF_UNITS_H
+#ifndef TGEANT4_SYSTEM_OF_UNITS_H
+#define TGEANT4_SYSTEM_OF_UNITS_H
 
-#ifndef HAVE_GEANT4_UNITS
-//#define HAVE_GEANT4_UNITS
-#endif
-
-namespace TGeoUnit {
+namespace TGeant4Unit {
 
   //
   // TGeo follows Geant3 convention as specified in manual
@@ -76,7 +72,7 @@ namespace TGeoUnit {
   //
   // Length [L]
   //
-  static constexpr double millimeter = 0.1;
+  static constexpr double millimeter = 1.0;
   static constexpr double millimeter2 = millimeter * millimeter;
   static constexpr double millimeter3 = millimeter * millimeter * millimeter;
 
@@ -151,7 +147,7 @@ namespace TGeoUnit {
   //
   // Time [T]
   //
-  static constexpr double nanosecond = 1.e-9;
+  static constexpr double nanosecond = 1.0;
   static constexpr double second = 1.e+9 * nanosecond; // Base unit
   static constexpr double millisecond = 1.e-3 * second;
   static constexpr double microsecond = 1.e-6 * second;
@@ -178,7 +174,7 @@ namespace TGeoUnit {
   //
   // Energy [E]
   //
-  static constexpr double megaelectronvolt = 1.e-3;
+  static constexpr double megaelectronvolt = 1.0;
   static constexpr double electronvolt = 1.e-6 * megaelectronvolt;
   static constexpr double kiloelectronvolt = 1.e-3 * megaelectronvolt;
   static constexpr double gigaelectronvolt = 1.e+3 * megaelectronvolt; // Base unit
@@ -330,11 +326,12 @@ namespace TGeoUnit {
   static constexpr double perThousand = 0.001;
   static constexpr double perMillion = 0.000001;
 
-  /// System of units flavor. Must be kept in sync with TGeant4Units::UnitType
+  /// System of units flavor. Must be kept in sync with TGeoUnits::UnitType
   enum  UnitType {
-    kTGeoUnits    = 1<<0,
+    kTGeoUnits   = 1<<0,
     kTGeant4Units = 1<<1
   };
+
   /// Access the currently set units type
   UnitType unitType();
   /// Set the currently used unit type (Only ONCE possible)
@@ -342,4 +339,4 @@ namespace TGeoUnit {
   
 } // namespace TGeoUnit
 
-#endif /* TGEO_SYSTEM_OF_UNITS_H */
+#endif /* TGEANT4_SYSTEM_OF_UNITS_H */

--- a/geom/geom/src/TGeoElement.cxx
+++ b/geom/geom/src/TGeoElement.cxx
@@ -46,6 +46,7 @@ Table of elements
 #include "TGeoElement.h"
 #include "TMath.h"
 #include "TGeoPhysicalConstants.h"
+#include "TGeant4PhysicalConstants.h"
 
 // statics and globals
 static const Int_t gMaxElem  = 110;
@@ -87,6 +88,7 @@ ClassImp(TGeoElement);
 
 TGeoElement::TGeoElement()
 {
+   TGeoUnit::setUnitType(TGeoUnit::unitType()); // Ensure nobody changes the units afterwards
    SetDefined(kFALSE);
    SetUsed(kFALSE);
    fZ = 0;
@@ -103,6 +105,7 @@ TGeoElement::TGeoElement()
 TGeoElement::TGeoElement(const char *name, const char *title, Int_t z, Double_t a)
             :TNamed(name, title)
 {
+   TGeoUnit::setUnitType(TGeoUnit::unitType()); // Ensure nobody changes the units afterwards
    SetDefined(kFALSE);
    SetUsed(kFALSE);
    fZ = z;
@@ -120,6 +123,7 @@ TGeoElement::TGeoElement(const char *name, const char *title, Int_t z, Double_t 
 TGeoElement::TGeoElement(const char *name, const char *title, Int_t nisotopes)
             :TNamed(name, title)
 {
+   TGeoUnit::setUnitType(TGeoUnit::unitType()); // Ensure nobody changes the units afterwards
    SetDefined(kFALSE);
    SetUsed(kFALSE);
    fZ = 0;
@@ -136,6 +140,7 @@ TGeoElement::TGeoElement(const char *name, const char *title, Int_t nisotopes)
 TGeoElement::TGeoElement(const char *name, const char *title, Int_t z, Int_t n, Double_t a)
             :TNamed(name, title)
 {
+   TGeoUnit::setUnitType(TGeoUnit::unitType()); // Ensure nobody changes the units afterwards
    SetDefined(kFALSE);
    SetUsed(kFALSE);
    fZ = z;
@@ -160,9 +165,10 @@ void TGeoElement::ComputeDerivedQuantities()
 
 void TGeoElement::ComputeCoulombFactor()
 {
-   static const Double_t k1 = 0.0083 , k2 = 0.20206 ,k3 = 0.0020 , k4 = 0.0369 ;
-
-   Double_t az2 = (TGeoUnit::fine_structure_const*fZ)*(TGeoUnit::fine_structure_const*fZ);
+   static constexpr Double_t k1 = 0.0083 , k2 = 0.20206 ,k3 = 0.0020 , k4 = 0.0369;
+   Double_t fsc = TGeoUnit::unitType() == TGeoUnit::kTGeoUnits
+     ? TGeoUnit::fine_structure_const : TGeant4Unit::fine_structure_const;
+   Double_t az2 = (fsc*fZ)*(fsc*fZ);
    Double_t az4 = az2 * az2;
 
    fCoulomb = (k1*az4 + k2 + 1./(1.+az2))*az2 - (k3*az4 + k4)*az4;
@@ -172,21 +178,23 @@ void TGeoElement::ComputeCoulombFactor()
 
 void TGeoElement::ComputeLradTsaiFactor()
 {
-   static const Double_t Lrad_light[]  = {5.31  , 4.79  , 4.74 ,  4.71} ;
-   static const Double_t Lprad_light[] = {6.144 , 5.621 , 5.805 , 5.924} ;
+   static constexpr Double_t Lrad_light[]  = {5.31  , 4.79  , 4.74 ,  4.71} ;
+   static constexpr Double_t Lprad_light[] = {6.144 , 5.621 , 5.805 , 5.924} ;
 
    fRadTsai = 0.0;
    if (fZ == 0) return;
    const Double_t logZ3 = TMath::Log(fZ)/3.;
 
    Double_t Lrad, Lprad;
+   Double_t alpha_rcl2 = TGeoUnit::unitType() == TGeoUnit::kTGeoUnits
+     ? TGeoUnit::alpha_rcl2 : TGeant4Unit::alpha_rcl2;
    Int_t iz = static_cast<Int_t>(fZ+0.5) - 1 ; // The static cast comes from G4lrint
-   static const Double_t log184 = TMath::Log(184.15);
+   static const Double_t log184  = TMath::Log(184.15);
    static const Double_t log1194 = TMath::Log(1194.);
    if (iz <= 3) { Lrad = Lrad_light[iz] ;  Lprad = Lprad_light[iz] ; }
    else { Lrad = log184 - logZ3 ; Lprad = log1194 - 2*logZ3;}
 
-   fRadTsai = 4*TGeoUnit::alpha_rcl2*fZ*(fZ*(Lrad-fCoulomb) + Lprad);
+   fRadTsai = 4*alpha_rcl2*fZ*(fZ*(Lrad-fCoulomb) + Lprad);
 }
 ////////////////////////////////////////////////////////////////////////////////
 /// Print this isotope

--- a/geom/geom/src/TGeoMaterial.cxx
+++ b/geom/geom/src/TGeoMaterial.cxx
@@ -26,6 +26,7 @@ Base class describing materials.
 #include "TGeoExtension.h"
 #include "TGeoMaterial.h"
 #include "TGeoPhysicalConstants.h"
+#include "TGeant4PhysicalConstants.h"
 #include "TGDMLMatrix.h"
 
 // statics and globals
@@ -52,6 +53,7 @@ TGeoMaterial::TGeoMaterial()
               fUserExtension(0),
               fFWExtension(0)
 {
+   TGeoUnit::setUnitType(TGeoUnit::unitType()); // Ensure nobody changes the units afterwards
    SetUsed(kFALSE);
    fIndex    = -1;
    fTemperature = STP_temperature;
@@ -79,6 +81,7 @@ TGeoMaterial::TGeoMaterial(const char *name)
               fUserExtension(0),
               fFWExtension(0)
 {
+   TGeoUnit::setUnitType(TGeoUnit::unitType()); // Ensure nobody changes the units afterwards
    fName = fName.Strip();
    SetUsed(kFALSE);
    fIndex    = -1;
@@ -113,6 +116,7 @@ TGeoMaterial::TGeoMaterial(const char *name, Double_t a, Double_t z,
               fUserExtension(0),
               fFWExtension(0)
 {
+   TGeoUnit::setUnitType(TGeoUnit::unitType()); // Ensure nobody changes the units afterwards
    fName = fName.Strip();
    SetUsed(kFALSE);
    fIndex    = -1;
@@ -153,6 +157,7 @@ TGeoMaterial::TGeoMaterial(const char *name, Double_t a, Double_t z, Double_t rh
               fUserExtension(0),
               fFWExtension(0)
 {
+   TGeoUnit::setUnitType(TGeoUnit::unitType()); // Ensure nobody changes the units afterwards
    fName = fName.Strip();
    SetUsed(kFALSE);
    fIndex    = -1;
@@ -186,6 +191,7 @@ TGeoMaterial::TGeoMaterial(const char *name, TGeoElement *elem, Double_t rho)
               fUserExtension(0),
               fFWExtension(0)
 {
+   TGeoUnit::setUnitType(TGeoUnit::unitType()); // Ensure nobody changes the units afterwards
    fName = fName.Strip();
    SetUsed(kFALSE);
    fIndex    = -1;
@@ -226,6 +232,7 @@ TGeoMaterial::TGeoMaterial(const TGeoMaterial& gm) :
 
 {
    //copy constructor
+   TGeoUnit::setUnitType(TGeoUnit::unitType()); // Ensure nobody changes the units afterwards
    fProperties.SetOwner();
    TIter next(&fProperties);
    TNamed *property;
@@ -436,29 +443,50 @@ void TGeoMaterial::SetRadLen(Double_t radlen, Double_t intlen)
       if (intlen>=0) fIntLen = 1.E30;
       return;
    }
+   TGeoUnit::UnitType typ = TGeoUnit::unitType();
    // compute radlen systematically with G3 formula for a valid material
-   if (radlen>=0) {
+   if ( typ == TGeoUnit::kTGeoUnits && radlen>=0 ) {
       //taken grom Geant3 routine GSMATE
-      const Double_t alr2av=1.39621E-03, al183=5.20948;
+      constexpr Double_t alr2av = 1.39621E-03*TGeoUnit::cm2;
+      constexpr Double_t al183  = 5.20948;
       fRadLen = fA/(alr2av*fDensity*fZ*(fZ +TGeoMaterial::ScreenFactor(fZ))*
-             (al183-TMath::Log(fZ)/3-TGeoMaterial::Coulomb(fZ)));
+                   (al183-TMath::Log(fZ)/3-TGeoMaterial::Coulomb(fZ)));
+      fRadLen *= TGeoUnit::cm;
+   }
+   else if ( typ == TGeoUnit::kTGeant4Units && radlen>=0 ) {
+      //taken grom Geant3 routine GSMATE
+      constexpr Double_t alr2av = 1.39621E-03*TGeant4Unit::cm2;
+      constexpr Double_t al183  = 5.20948;
+      fRadLen = fA/(alr2av*fDensity*fZ*(fZ +TGeoMaterial::ScreenFactor(fZ))*
+                   (al183-TMath::Log(fZ)/3-TGeoMaterial::Coulomb(fZ)));
+      fRadLen *= TGeant4Unit::cm;
    }
    // Compute interaction length using the same formula as in GEANT4
-   if (intlen>=0) {
-      const Double_t cm = 1.;
-      const Double_t g = 6.2415e21; // [gram = 1E-3*joule*s*s/(m*m)]
-      const Double_t amu = 1.03642688246781065e-02; // [MeV/c^2]
-      const Double_t lambda0 = 35.*g/(cm*cm);  // [g/cm^2]
+   if ( typ == TGeoUnit::kTGeoUnits && intlen>=0 ) {
+      constexpr Double_t lambda0 = 35.*TGeoUnit::g/TGeoUnit::cm2;  // [g/cm^2]
       Double_t nilinv = 0.0;
       TGeoElement *elem = GetElement();
       if (!elem) {
          Fatal("SetRadLen", "Element not found for material %s", GetName());
          return;
       }
-      Double_t nbAtomsPerVolume = TMath::Na()*fDensity/elem->A();
+      Double_t nbAtomsPerVolume = TGeoUnit::Avogadro*fDensity/elem->A();
       nilinv += nbAtomsPerVolume*TMath::Power(elem->Neff(), 0.6666667);
-      nilinv *= amu/lambda0;
-      fIntLen = (nilinv<=0) ? TGeoShape::Big() : (1./nilinv);
+      nilinv *= TGeoUnit::amu/lambda0;
+      fIntLen = (nilinv<=0) ? TGeoShape::Big() : (TGeoUnit::cm/nilinv);
+   }
+   else if ( typ == TGeoUnit::kTGeant4Units && intlen>=0 ) {
+      constexpr Double_t lambda0 = 35.*TGeant4Unit::g/TGeant4Unit::cm2;  // [g/cm^2]
+      Double_t nilinv = 0.0;
+      TGeoElement *elem = GetElement();
+      if (!elem) {
+         Fatal("SetRadLen", "Element not found for material %s", GetName());
+         return;
+      }
+      Double_t nbAtomsPerVolume = TGeant4Unit::Avogadro*fDensity/elem->A();
+      nilinv += nbAtomsPerVolume*TMath::Power(elem->Neff(), 0.6666667);
+      nilinv *= TGeant4Unit::amu/lambda0;
+      fIntLen = (nilinv<=0) ? TGeoShape::Big() : (TGeant4Unit::cm/nilinv);
    }
 }
 
@@ -470,11 +498,10 @@ void TGeoMaterial::SetRadLen(Double_t radlen, Double_t intlen)
 
 Double_t TGeoMaterial::Coulomb(Double_t z)
 {
-   const Double_t alpha = 7.29927E-03;
-
-   Double_t az    = alpha*z;
+   Double_t az    = TGeoUnit::unitType() == TGeoUnit::kTGeoUnits
+     ? TGeoUnit::fine_structure_const*z : TGeant4Unit::fine_structure_const*z;
    Double_t az2   = az*az;
-   Double_t az4   =   az2 * az2;
+   Double_t az4   = az2 * az2;
    Double_t fp    = ( 0.0083*az4 + 0.20206 + 1./(1.+az2) ) * az2;
    Double_t fm    = ( 0.0020*az4 + 0.0369  ) * az4;
    return fp - fm;
@@ -750,11 +777,15 @@ TGeoMixture::~TGeoMixture()
 
 void TGeoMixture::AverageProperties()
 {
-   const Double_t alr2av = 1.39621E-03 , al183 =5.20948;
-   const Double_t cm = 1.;
-   const Double_t g = 6.2415e21; // [gram = 1E-3*joule*s*s/(m*m)]
-   const Double_t amu = 1.03642688246781065e-02; // [MeV/c^2]
-   const Double_t lambda0 = 35.*g/(cm*cm);  // [g/cm^2]
+   TGeoUnit::UnitType typ = TGeoUnit::unitType();
+   const Double_t cm   = (typ==TGeoUnit::kTGeoUnits) ? TGeoUnit::cm   : TGeant4Unit::cm;
+   const Double_t cm2  = (typ==TGeoUnit::kTGeoUnits) ? TGeoUnit::cm2  : TGeant4Unit::cm2;
+   const Double_t amu  = (typ==TGeoUnit::kTGeoUnits) ? TGeoUnit::amu  : TGeant4Unit::amu; // [MeV/c^2]
+   const Double_t gram = (typ==TGeoUnit::kTGeoUnits) ? TGeoUnit::gram : TGeant4Unit::gram;
+   const Double_t na   = (typ==TGeoUnit::kTGeoUnits) ? TGeoUnit::Avogadro : TGeant4Unit::Avogadro;
+   const Double_t alr2av  = 1.39621E-03 * cm2;
+   const Double_t al183   = 5.20948;
+   const Double_t lambda0 = 35.*gram/cm2;  // [g/cm^2]
    Double_t radinv = 0.0;
    Double_t nilinv = 0.0;
    Double_t nbAtomsPerVolume;
@@ -764,7 +795,7 @@ void TGeoMixture::AverageProperties()
       if (fWeights[j] <= 0) continue;
       fA += fWeights[j]*fAmixture[j];
       fZ += fWeights[j]*fZmixture[j];
-      nbAtomsPerVolume = TMath::Na()*fDensity*fWeights[j]/GetElement(j)->A();
+      nbAtomsPerVolume = na*fDensity*fWeights[j]/GetElement(j)->A();
       nilinv += nbAtomsPerVolume*TMath::Power(GetElement(j)->Neff(), 0.6666667);
       Double_t zc = fZmixture[j];
       Double_t alz = TMath::Log(zc)/3.;
@@ -773,10 +804,10 @@ void TGeoMixture::AverageProperties()
       radinv += xinv*fWeights[j];
    }
    radinv *= alr2av*fDensity;
-   if (radinv > 0) fRadLen = 1/radinv;
+   if (radinv > 0) fRadLen = cm/radinv;
    // Compute interaction length
    nilinv *= amu/lambda0;
-   fIntLen = (nilinv<=0) ? TGeoShape::Big() : (1./nilinv);
+   fIntLen = (nilinv<=0) ? TGeoShape::Big() : (cm/nilinv);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1195,11 +1226,16 @@ Double_t TGeoMaterial::ScreenFactor(Double_t z)
 
 void TGeoMixture::ComputeDerivedQuantities()
 {
+   const Double_t Na = (TGeoUnit::unitType()==TGeoUnit::kTGeoUnits)
+     ? TGeoUnit::Avogadro : TGeant4Unit::Avogadro;
+
+   if ( fVecNbOfAtomsPerVolume ) delete [] fVecNbOfAtomsPerVolume;
+
    fVecNbOfAtomsPerVolume = new Double_t[fNelements];
 
    // Formula taken from G4Material.cxx L312
    for (Int_t i=0; i<fNelements; ++i) {
-      fVecNbOfAtomsPerVolume[i] = TGeoUnit::Avogadro*fDensity*fWeights[i]/((TGeoElement*)fElements->At(i))->A();
+      fVecNbOfAtomsPerVolume[i] = Na*fDensity*fWeights[i]/((TGeoElement*)fElements->At(i))->A();
    }
    ComputeRadiationLength();
    ComputeNuclearInterLength();
@@ -1212,21 +1248,25 @@ void TGeoMixture::ComputeDerivedQuantities()
 void TGeoMixture::ComputeRadiationLength()
 {
    // Formula taken from G4Material.cxx L556
+   const Double_t cm = (TGeoUnit::unitType()==TGeoUnit::kTGeoUnits) ? TGeoUnit::cm : TGeant4Unit::cm;
    Double_t radinv = 0.0 ;
    for (Int_t i=0;i<fNelements;++i) {
      radinv += fVecNbOfAtomsPerVolume[i]*((TGeoElement*)fElements->At(i))->GetfRadTsai();
    }
-   fRadLen = (radinv <= 0.0 ? DBL_MAX : 1./radinv);
+   fRadLen = (radinv <= 0.0 ? DBL_MAX : cm/radinv);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute Nuclear Interaction Length based on Geant4 formula
 void TGeoMixture::ComputeNuclearInterLength()
 {
-
    // Formula taken from G4Material.cxx L567
-   constexpr Double_t lambda0  = 35*TGeoUnit::g/TGeoUnit::cm2;
-   constexpr Double_t twothird = 2.0/3.0;
+   TGeoUnit::UnitType typ = TGeoUnit::unitType();
+   const Double_t g   = (typ==TGeoUnit::kTGeoUnits) ? TGeoUnit::g   : TGeant4Unit::g;
+   const Double_t cm  = (typ==TGeoUnit::kTGeoUnits) ? TGeoUnit::cm  : TGeant4Unit::cm;
+   const Double_t amu = (typ==TGeoUnit::kTGeoUnits) ? TGeoUnit::amu : TGeant4Unit::amu;
+   const Double_t lambda0  = 35*g/(cm*cm);
+   const Double_t twothird = 2.0/3.0;
    Double_t NILinv = 0.0;
    for (Int_t i=0; i<fNelements; ++i) {
       Int_t Z = static_cast<Int_t>(((TGeoElement*)fElements->At(i))->Z()+0.5);
@@ -1237,6 +1277,6 @@ void TGeoMixture::ComputeNuclearInterLength()
          NILinv += fVecNbOfAtomsPerVolume[i]*TMath::Exp(twothird*TMath::Log(A));
       }
    }
-   NILinv *= TGeoUnit::amu/lambda0;
-   fIntLen = (NILinv <= 0.0 ? DBL_MAX : 1./NILinv);
+   NILinv *= amu/lambda0;
+   fIntLen = (NILinv <= 0.0 ? DBL_MAX : cm/NILinv);
 }

--- a/geom/geom/src/TGeoUnit.cxx
+++ b/geom/geom/src/TGeoUnit.cxx
@@ -1,0 +1,59 @@
+// @(#)root/geom:$Id$
+// Author: Markus Frank   25/06/19
+
+/*************************************************************************
+ * Copyright (C) 1995-2000, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+/** \class TGeoUnit
+\ingroup Geometry_classes
+
+Base class describing materials.
+
+*/
+#include "TError.h"
+#include "TGeoSystemOfUnits.h"
+#include "TGeant4SystemOfUnits.h"
+
+namespace   {
+  static bool s_type_changed = false;
+  union _unit_type {
+    TGeoUnit::UnitType    tgeo_unit_type;
+    TGeant4Unit::UnitType tgeant4_unit_type;
+    _unit_type(TGeoUnit::UnitType t) { tgeo_unit_type = t; }
+  } s_unit_type(TGeoUnit::kTGeoUnits);
+}
+
+TGeoUnit::UnitType TGeoUnit::unitType()    {
+  return s_unit_type.tgeo_unit_type;
+}
+
+TGeoUnit::UnitType TGeoUnit::setUnitType(UnitType new_type)    {
+  UnitType tmp = s_unit_type.tgeo_unit_type;
+  if ( !s_type_changed || new_type == s_unit_type.tgeo_unit_type )    {
+    s_unit_type.tgeo_unit_type = new_type;
+    s_type_changed = true;
+    return tmp;
+  }
+  Fatal("TGeoUnit","The system of units may only be changed once at the beginning of the program!");
+  return tmp;
+}
+
+TGeant4Unit::UnitType TGeant4Unit::unitType()    {
+  return s_unit_type.tgeant4_unit_type;
+}
+
+TGeant4Unit::UnitType TGeant4Unit::setUnitType(UnitType new_type)    {
+  UnitType tmp = s_unit_type.tgeant4_unit_type;
+  if ( !s_type_changed || new_type == s_unit_type.tgeant4_unit_type )    {
+    s_unit_type.tgeant4_unit_type = new_type;
+    s_type_changed = true;
+    return tmp;
+  }
+  Fatal("TGeoUnit","The system of units may only be changed once at the beginning of the program!");
+  return tmp;
+}


### PR DESCRIPTION
Allow to select the system of units in TGeo at run-time and allow to switch to
Geant4 (mm,ns,MeV) from the TGeo default TGeo (mm,s,keV).

Example:
```
#include "TGeant4SystemOfUnits.h"
....
TGeant4Unit::setUnitType(TGeant4Unit::kTGeant4Units)
```
Then the material properties shall be as described in TGeant4SystemOfUnits.h.

The default is:
```
#include "TGeoSystemOfUnits.h"
....
TGeo4Unit::setUnitType(TGeoUnit::kTGeoUnits)
```
Please note: 
1) This code is not necessary. If users do nothing the behavior stays as it is now.
2) Units have to be set *before* the first TElement or TMaterial constructor is called,
Otherwise a fatal error is issued (TError::Fatal).
