### PR TITLE
fixing default constructor of RooThresholdCategory

### DIFF
--- a/roofit/roofitcore/inc/RooThresholdCategory.h
+++ b/roofit/roofitcore/inc/RooThresholdCategory.h
@@ -25,7 +25,7 @@ class RooThresholdCategory : public RooAbsCategory {
 
 public:
   // Constructors etc.
-  inline RooThresholdCategory() { }
+  RooThresholdCategory();
   RooThresholdCategory(const char *name, const char *title, RooAbsReal& inputVar, const char* defCatName="Default", Int_t defCatIdx=0);
   RooThresholdCategory(const RooThresholdCategory& other, const char *name=0) ;
   virtual TObject* clone(const char* newname) const { return new RooThresholdCategory(*this, newname); }

--- a/roofit/roofitcore/src/RooThresholdCategory.cxx
+++ b/roofit/roofitcore/src/RooThresholdCategory.cxx
@@ -72,6 +72,11 @@ RooThresholdCategory::RooThresholdCategory(const RooThresholdCategory& other, co
   _threshIter = _threshList.MakeIterator() ;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Default Constructor
+
+RooThresholdCategory::RooThresholdCategory() : RooAbsCategory(), _defCat(0), _threshIter(0){
+}
 
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
RooThresholdCategory cannot be successfully streamed because not all members are initialized safely in the default constructor.

This PR fixes that.