### PR TITLE
[WIP] Implement schema printing for NTuple

### DIFF
--- a/tree/ntuple/CMakeLists.txt
+++ b/tree/ntuple/CMakeLists.txt
@@ -24,6 +24,7 @@ HEADERS
   ROOT/RPagePool.hxx
   ROOT/RPageStorage.hxx
   ROOT/RPageStorageRoot.hxx
+  ROOT/RFieldVisitor.hxx
 SOURCES
   v7/src/RColumn.cxx
   v7/src/RField.cxx
@@ -35,6 +36,7 @@ SOURCES
   v7/src/RPagePool.cxx
   v7/src/RPageStorage.cxx
   v7/src/RPageStorageRoot.cxx
+  v7/src/RFieldVisitor.cxx
 LINKDEF
   LinkDef.h
 DEPENDENCIES

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -24,7 +24,6 @@
 #include <ROOT/RStringView.hxx>
 #include <ROOT/RVec.hxx>
 #include <ROOT/TypeTraits.hxx>
-//#include <ROOT/RFieldVisitor.hxx>
 
 #include <TGenericClassInfo.h>
 #include <TError.h>
@@ -222,10 +221,10 @@ public:
 
    RIterator begin();
    RIterator end();
+
+   /// Used for the visitor design pattern, called by RNTupleReader::Print()
    virtual void AcceptVisitor(RNTupleVisitor &fVisitor) const;
-   //virtual void Accept(RNTupleVisitor fVisitor, int index);
-   int getOrder() {return fOrder;}
-    ///auto getSubfields() {return fSubFields;}
+   int GetOrder() const {return fOrder;}
 
 
   };
@@ -236,8 +235,6 @@ class RFieldRoot : public Detail::RFieldBase {
 public:
    RFieldRoot() : Detail::RFieldBase("", "", ENTupleStructure::kRecord, false /* isSimple */) {}
    RFieldBase* Clone(std::string_view newName);
-    /*
-    friend void ROOT::Experimental::TNtuplePrintVisitor::visitNtuple(ROOT::Experimental::RNTupleReader* fReader); /// To print list of branches*/
 
    void DoGenerateColumns() final {}
    unsigned int GetNColumns() const final { return 0; }
@@ -248,8 +245,6 @@ public:
 
    /// Generates managed values for the top-level sub fields
    REntry* GenerateEntry();
-   ///void AcceptVisitor(RPrintVisitor fPrintVisitor) override;
-    virtual void AcceptVisitor(RNTupleVisitor &fVisitor) const;
 };
 
 /// The field for a class with dictionary
@@ -624,8 +619,6 @@ public:
    }
    size_t GetValueSize() const final { return sizeof(std::string); }
    void CommitCluster() final;
-    //void Accept(RNTupleVisitor fVisitor, int index);
-    //void Accept(RPrintVisitor fPrintVisitor, int index) { fPrintVisitor.visitField<std::string>(this, index);}
 };
 
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -222,7 +222,7 @@ public:
    RIterator begin();
    RIterator end();
 
-   /// Used for the visitor design pattern, called by RNTupleReader::Print()
+   /// Used for the visitor design pattern, currently only called by RNTupleReader::Print()
    virtual void AcceptVisitor(RNTupleVisitor &fVisitor) const;
    int GetOrder() const {return fOrder;}
 

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -20,14 +20,13 @@
 #include <sstream>
 #include <string>
 
-
 namespace ROOT {
 namespace Experimental {
-    class RFieldRoot;
+class RFieldRoot;
 namespace Detail {
-    class RFieldBase;
-    }
-    
+class RFieldBase;
+}
+
 // clang-format off
 /**
 \class ROOT::Experimental::RNTupleVisitor
@@ -39,9 +38,9 @@ Currently only has a virtual visitField() function, used by the RPrintVisitor cl
 // clang-format on
 class RNTupleVisitor {
 public:
-    virtual void visitField(const ROOT::Experimental::Detail::RFieldBase& fField) = 0;
+   virtual void visitField(const ROOT::Experimental::Detail::RFieldBase &fField) = 0;
 };
-    
+
 // clang-format off
 /**
 \class ROOT::Experimental::RPrintVisitor
@@ -52,20 +51,23 @@ public:
 */
 // clang-format on
 
-    
-class RPrintVisitor: public RNTupleVisitor {
+class RPrintVisitor : public RNTupleVisitor {
 private:
-    /// Holds ostream which is used for holding the printed output
-    std::ostream &fOutput;
-    /// Indicates maximal number of allowed characters per line
-    int fWidth;
-    unsigned int maxNoFields;
+   /// Holds ostream which is used for holding the printed output
+   std::ostream &fOutput;
+   /// Indicates maximal number of allowed characters per line
+   int fWidth;
+   unsigned int maxNoFields;
+
 public:
-    RPrintVisitor(std::ostream& out = std::cout, int width = 69, unsigned int fNoFields = 1000): fOutput{out}, fWidth{width}, maxNoFields{fNoFields} { }
-    /// Prints summary of Field
-    void visitField(const ROOT::Experimental::Detail::RFieldBase& fField);
+   RPrintVisitor(std::ostream &out = std::cout, int width = 69, unsigned int fNoFields = 1000)
+      : fOutput{out}, fWidth{width}, maxNoFields{fNoFields}
+   {
+   }
+   /// Prints summary of Field
+   void visitField(const ROOT::Experimental::Detail::RFieldBase &fField);
 };
-    
+
 int NumDigits(int x);
 int FieldDistance(unsigned int fNoFields);
 std::string CutIfNecessary(const std::string &fToCut, unsigned int maxAvailableSpace);

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -1,0 +1,13 @@
+//
+//  RFieldVisitor.hpp
+//  
+//
+//  Created by Simon Leisibach on 11.06.19.
+//
+
+#ifndef RFieldVisitor_hpp
+#define RFieldVisitor_hpp
+
+#include <stdio.h>
+
+#endif /* RFieldVisitor_hpp */

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -28,20 +28,41 @@ namespace Detail {
     class RFieldBase;
     }
     
-    
+// clang-format off
+/**
+\class ROOT::Experimental::RNTupleVisitor
+\ingroup NTuple
+\brief Pure virtual parentclass for classes implementing the visitor design pattern.
+     
+Currently only has a virtual visitField() function, used by the RPrintVisitor class.
+*/
+// clang-format on
 class RNTupleVisitor {
 public:
     virtual void visitField(const ROOT::Experimental::Detail::RFieldBase& fField) = 0;
 };
     
+// clang-format off
+/**
+\class ROOT::Experimental::RPrintVisitor
+\ingroup NTuple
+\brief Contains settings for printing and prints a summary of an RField instance.
+     
+ Instances of this class are currently only invoked by RNTupleReader::Print() -> RFieldBase::AcceptVisitor()
+*/
+// clang-format on
+
+    
 class RPrintVisitor: public RNTupleVisitor {
 private:
-    /// holds ostream which is used for output
+    /// Holds ostream which is used for holding the printed output
     std::ostream &fOutput;
+    /// Indicates maximal number of allowed characters per line
     int fWidth;
-    int maxNoFields;
+    unsigned int maxNoFields;
 public:
-    RPrintVisitor(std::ostream& out = std::cout, int width = 69, int fNoFields = 1000): fOutput{out}, fWidth{width}, maxNoFields{fNoFields} { }
+    RPrintVisitor(std::ostream& out = std::cout, int width = 69, unsigned int fNoFields = 1000): fOutput{out}, fWidth{width}, maxNoFields{fNoFields} { }
+    /// Prints summary of Field
     void visitField(const ROOT::Experimental::Detail::RFieldBase& fField);
 };
     

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -1,13 +1,66 @@
-//
-//  RFieldVisitor.hpp
-//  
-//
-//  Created by Simon Leisibach on 11.06.19.
-//
+/// \file ROOT/RFieldVisitor.hxx
+/// \ingroup NTuple ROOT7
+/// \author Simon Leisibach <simon.satoshi.rene.leisibach@cern.ch>
+/// \date 2019-06-11
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
 
-#ifndef RFieldVisitor_hpp
-#define RFieldVisitor_hpp
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
 
-#include <stdio.h>
+#ifndef ROOT7_RFieldVisitor
+#define ROOT7_RFieldVisitor
 
-#endif /* RFieldVisitor_hpp */
+
+//#include "ROOT/RField.hxx"
+
+namespace ROOT {
+namespace Experimental {
+    //template<typename T, typename T2>
+    //class RField;
+    class RFieldRoot;
+namespace Detail {
+    class RFieldBase;
+    
+    }
+    
+    
+class RNTupleVisitor {
+public:
+    virtual void visitField(const ROOT::Experimental::Detail::RFieldBase& fField) = 0;
+    virtual void visitField(const ROOT::Experimental::RFieldRoot& fRootField) = 0;
+    //virtual void visitField(ROOT::Experimental::Detail::RFieldBase* fField, int floop);
+    //virtual void visitField(ROOT::Experimental::RField<std::string, void>* fField, int floop);
+};
+    
+class RPrintVisitor: public RNTupleVisitor {
+public:
+    void visitField(const ROOT::Experimental::Detail::RFieldBase& fField);
+    void visitField(const ROOT::Experimental::RFieldRoot& fRootField);
+    //void visitField(ROOT::Experimental::Detail::RFieldBase* fField, int floop);
+    //void visitField(ROOT::Experimental::RField<std::string, void>* fField, int floop);
+};
+    
+int NumDigits(int x);
+    /*
+class RNTupleReader;
+
+class VBaseNtupleVisitor {
+public:
+    virtual void visitNtuple(ROOT::Experimental::RNTupleReader* fReader) = 0;
+};
+
+class TNtuplePrintVisitor: public VBaseNtupleVisitor {
+public:
+    void visitNtuple(ROOT::Experimental::RNTupleReader* fReader);
+};
+    */
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -16,50 +16,38 @@
 #ifndef ROOT7_RFieldVisitor
 #define ROOT7_RFieldVisitor
 
+#include <iostream>
+#include <sstream>
+#include <string>
 
-//#include "ROOT/RField.hxx"
 
 namespace ROOT {
 namespace Experimental {
-    //template<typename T, typename T2>
-    //class RField;
     class RFieldRoot;
 namespace Detail {
     class RFieldBase;
-    
     }
     
     
 class RNTupleVisitor {
 public:
     virtual void visitField(const ROOT::Experimental::Detail::RFieldBase& fField) = 0;
-    virtual void visitField(const ROOT::Experimental::RFieldRoot& fRootField) = 0;
-    //virtual void visitField(ROOT::Experimental::Detail::RFieldBase* fField, int floop);
-    //virtual void visitField(ROOT::Experimental::RField<std::string, void>* fField, int floop);
 };
     
 class RPrintVisitor: public RNTupleVisitor {
+private:
+    /// holds ostream which is used for output
+    std::ostream &fOutput;
+    int fWidth;
+    int maxNoFields;
 public:
+    RPrintVisitor(std::ostream& out = std::cout, int width = 69, int fNoFields = 1000): fOutput{out}, fWidth{width}, maxNoFields{fNoFields} { }
     void visitField(const ROOT::Experimental::Detail::RFieldBase& fField);
-    void visitField(const ROOT::Experimental::RFieldRoot& fRootField);
-    //void visitField(ROOT::Experimental::Detail::RFieldBase* fField, int floop);
-    //void visitField(ROOT::Experimental::RField<std::string, void>* fField, int floop);
 };
     
 int NumDigits(int x);
-    /*
-class RNTupleReader;
-
-class VBaseNtupleVisitor {
-public:
-    virtual void visitNtuple(ROOT::Experimental::RNTupleReader* fReader) = 0;
-};
-
-class TNtuplePrintVisitor: public VBaseNtupleVisitor {
-public:
-    void visitNtuple(ROOT::Experimental::RNTupleReader* fReader);
-};
-    */
+int FieldDistance(unsigned int fNoFields);
+std::string CutIfNecessary(const std::string &fToCut, unsigned int maxAvailableSpace);
 } // namespace Experimental
 } // namespace ROOT
 

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -25,13 +25,13 @@
 #include <iterator>
 #include <memory>
 #include <utility>
+#include <sstream>
 
 namespace ROOT {
 namespace Experimental {
 
 class REntry;
 class RNTupleModel;
-//class RPrintVisitor;
 
 namespace Detail {
 class RPageSink;
@@ -128,19 +128,18 @@ public:
    RNTupleReader(std::unique_ptr<Detail::RPageSource> source);
    ~RNTupleReader();
 
-   NTupleSize_t GetNEntries() { return fNEntries; }
+   NTupleSize_t GetNEntries() const { return fNEntries; }
 
    std::string GetInfo(const ENTupleInfo what = ENTupleInfo::kSummary);
    
-    /// Print() and Accept() are used for printing a detailed summary of the ntuple.
-    void Print();
-    /*
-   void Accept(ROOT::Experimental::VBaseNtupleVisitor &fVisitor);*/
-    std::string GetName() {
+    /// Prints a detailed summary of the ntuple, including a list of fields.
+    void Print(std::ostream &output = std::cout, int width = 69, unsigned int fNoFields = 1000u);
+    
+    // Returns name associated to the ntuple
+    std::string GetName() const {
         return fSource->GetDescriptor().GetName();
     }
     
-   //const auto fSourceGetter() {return fSource;}
 
    /// Analogous to Fill(), fills the default entry of the model. Returns false at the end of the ntuple.
    /// On I/O errors, raises an expection.
@@ -154,7 +153,7 @@ public:
 
    RNTupleViewRange GetViewRange() { return RNTupleViewRange(0, fNEntries); }
 
-   /// Provides access to an individual field that can contain either a skalar value or a collection, e.g.
+   /// Provides access to an individual field that can contain either a scalar value or a collection, e.g.
    /// GetView<double>("particles.pt") or GetView<std::vector<double>>("particle").  It can as well be the index
    /// field of a collection itself, like GetView<NTupleSize_t>("particle")
    template <typename T>

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -16,6 +16,7 @@
 #ifndef ROOT7_RNTuple
 #define ROOT7_RNTuple
 
+//#include <ROOT/RFieldVisitor.hxx>
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 #include <ROOT/RNTupleView.hxx>
@@ -30,6 +31,7 @@ namespace Experimental {
 
 class REntry;
 class RNTupleModel;
+//class RPrintVisitor;
 
 namespace Detail {
 class RPageSink;
@@ -129,6 +131,16 @@ public:
    NTupleSize_t GetNEntries() { return fNEntries; }
 
    std::string GetInfo(const ENTupleInfo what = ENTupleInfo::kSummary);
+   
+    /// Print() and Accept() are used for printing a detailed summary of the ntuple.
+    void Print();
+    /*
+   void Accept(ROOT::Experimental::VBaseNtupleVisitor &fVisitor);*/
+    std::string GetName() {
+        return fSource->GetDescriptor().GetName();
+    }
+    
+   //const auto fSourceGetter() {return fSource;}
 
    /// Analogous to Fill(), fills the default entry of the model. Returns false at the end of the ntuple.
    /// On I/O errors, raises an expection.

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -135,7 +135,7 @@ public:
     /// Prints a detailed summary of the ntuple, including a list of fields.
     void Print(std::ostream &output = std::cout, int width = 69, unsigned int fNoFields = 1000u);
     
-    // Returns name associated to the ntuple
+    /// Returns name associated to the ntuple
     std::string GetName() const {
         return fSource->GetDescriptor().GetName();
     }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -92,7 +92,7 @@ public:
    std::unique_ptr<REntry> CreateEntry();
 };
 
-} // namespace Exerimental
+} // namespace Experimental
 } // namespace ROOT
 
 #endif

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -20,6 +20,7 @@
 #include <ROOT/RFieldValue.hxx>
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RFieldVisitor.hxx>
 
 #include <TClass.h>
 #include <TCollection.h>
@@ -126,6 +127,7 @@ void ROOT::Experimental::Detail::RFieldBase::Attach(
 {
    child->fParent = this;
    fSubFields.emplace_back(std::move(child));
+   fOrder = fSubFields.size();
 }
 
 std::string ROOT::Experimental::Detail::RFieldBase::GetLeafName(const std::string &fullName)
@@ -158,6 +160,28 @@ void ROOT::Experimental::Detail::RFieldBase::ConnectColumns(RPageStorage *pageSt
       column->Connect(pageStorage);
    }
 }
+/*
+void ROOT::Experimental::Detail::RFieldBase::AcceptVisitor(RNTupleVisitor fVisitor) {
+    //fPrintVisitor.visitField(this);
+    for(std::size_t i = 0; i < fSubFields.size(); ++i) {
+        //std::cout << "Calling for each loop\n";
+        (*fSubFields.at(i)).Accept(fVisitor, i);
+    }
+}
+*/
+void ROOT::Experimental::Detail::RFieldBase::AcceptVisitor (RNTupleVisitor &fVisitor) const {
+    fVisitor.visitField(*this);
+}
+void ROOT::Experimental::RFieldRoot::AcceptVisitor (RNTupleVisitor &fVisitor) const {
+    fVisitor.visitField(*this);
+}
+/*
+void ROOT::Experimental::Detail::RFieldRoot::AcceptVisitor(RPrintVisitor fPrintVisitor) {
+    fPrintVisitor.visitField(this);
+}*/
+
+//void ROOT::Experimental::RField<std::string, void>::Accept(RNTupleVisitor fVisitor, int index) { fVisitor.visitField(this, index);}
+
 
 ROOT::Experimental::Detail::RFieldBase::RIterator ROOT::Experimental::Detail::RFieldBase::begin()
 {
@@ -169,6 +193,12 @@ ROOT::Experimental::Detail::RFieldBase::RIterator ROOT::Experimental::Detail::RF
 {
    return RIterator(this, -1);
 }
+
+/*
+ * NTupleSize_t GetNItems() {
+ *   return 1; // missing, to be implemented later.
+ * }
+ */
 
 
 //-----------------------------------------------------------------------------

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -126,8 +126,8 @@ void ROOT::Experimental::Detail::RFieldBase::Attach(
    std::unique_ptr<ROOT::Experimental::Detail::RFieldBase> child)
 {
    child->fParent = this;
+   child->fOrder = fSubFields.size();
    fSubFields.emplace_back(std::move(child));
-   fOrder = fSubFields.size();
 }
 
 std::string ROOT::Experimental::Detail::RFieldBase::GetLeafName(const std::string &fullName)
@@ -160,28 +160,13 @@ void ROOT::Experimental::Detail::RFieldBase::ConnectColumns(RPageStorage *pageSt
       column->Connect(pageStorage);
    }
 }
-/*
-void ROOT::Experimental::Detail::RFieldBase::AcceptVisitor(RNTupleVisitor fVisitor) {
-    //fPrintVisitor.visitField(this);
-    for(std::size_t i = 0; i < fSubFields.size(); ++i) {
-        //std::cout << "Calling for each loop\n";
-        (*fSubFields.at(i)).Accept(fVisitor, i);
-    }
-}
-*/
+
 void ROOT::Experimental::Detail::RFieldBase::AcceptVisitor (RNTupleVisitor &fVisitor) const {
     fVisitor.visitField(*this);
 }
 void ROOT::Experimental::RFieldRoot::AcceptVisitor (RNTupleVisitor &fVisitor) const {
     fVisitor.visitField(*this);
 }
-/*
-void ROOT::Experimental::Detail::RFieldRoot::AcceptVisitor(RPrintVisitor fPrintVisitor) {
-    fPrintVisitor.visitField(this);
-}*/
-
-//void ROOT::Experimental::RField<std::string, void>::Accept(RNTupleVisitor fVisitor, int index) { fVisitor.visitField(this, index);}
-
 
 ROOT::Experimental::Detail::RFieldBase::RIterator ROOT::Experimental::Detail::RFieldBase::begin()
 {
@@ -193,12 +178,6 @@ ROOT::Experimental::Detail::RFieldBase::RIterator ROOT::Experimental::Detail::RF
 {
    return RIterator(this, -1);
 }
-
-/*
- * NTupleSize_t GetNItems() {
- *   return 1; // missing, to be implemented later.
- * }
- */
 
 
 //-----------------------------------------------------------------------------

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -164,9 +164,6 @@ void ROOT::Experimental::Detail::RFieldBase::ConnectColumns(RPageStorage *pageSt
 void ROOT::Experimental::Detail::RFieldBase::AcceptVisitor (RNTupleVisitor &fVisitor) const {
     fVisitor.visitField(*this);
 }
-void ROOT::Experimental::RFieldRoot::AcceptVisitor (RNTupleVisitor &fVisitor) const {
-    fVisitor.visitField(*this);
-}
 
 ROOT::Experimental::Detail::RFieldBase::RIterator ROOT::Experimental::Detail::RFieldBase::begin()
 {

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -1,8 +1,85 @@
-//
-//  RFieldVisitor.cpp
-//  
-//
-//  Created by Simon Leisibach on 11.06.19.
-//
+/// \file ROOT/RFieldVisitor.hxx
+/// \ingroup NTuple ROOT7
+/// \author Simon Leisibach <simon.satoshi.rene.leisibach@cern.ch>
+/// \date 2019-06-11
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
 
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+//#include "ROOT/RNTuple.hxx"
 #include "ROOT/RFieldVisitor.hxx"
+#include "ROOT/RField.hxx"
+#include <iostream>
+#include <iomanip>
+
+
+void ROOT::Experimental::RPrintVisitor::visitField(const ROOT::Experimental::Detail::RFieldBase& fField) { std::cout << "Called visitField for any normal field\n";}
+void ROOT::Experimental::RPrintVisitor::visitField(const ROOT::Experimental::RFieldRoot& fRootField) {
+    std::cout << "Called function for RootField\n";
+}
+/*void ROOT::Experimental::RPrintVisitor::visitField(ROOT::Experimental::Detail::RFieldBase* fField, int fIndex) {
+    /// content here: Each line has 69 char.
+    //std::cout << "Calling visitField\n";
+    std::cout << "* Br " << std::setw(5-NumDigits(fIndex)) << fIndex << " : " << fField->GetName() << ": " << fField->GetType() << std::setw(56-(fField->GetName().size()) - (fField->GetType().size())) <<"*\n";
+    std::cout << "* Entries : \n"; //Does this even make sense?!
+    std::cout << "* Baskets : \n"; //WTF is a basket.
+    std::cout << "*********************************************************************\n";
+}
+
+void ROOT::Experimental::RPrintVisitor::visitField(ROOT::Experimental::RField<std::string, void>* fField, int fIndex) {
+    std::cout << "* Br " << std::setw(5-NumDigits(fIndex)) << fIndex << " : " << fField->GetName() << ": " << fField->GetType() << std::setw(56-(fField->GetName().size()) - (fField->GetType().size())) <<"*\n";
+    std::cout << "* Invoked templated version because data type was std::string" << std::setw(9) << "*\n";
+    std::cout << "*********************************************************************\n";
+}*/
+
+int ROOT::Experimental::NumDigits(int x)
+{
+    x = abs(x);
+    return (x < 10 ? 1 :
+            (x < 100 ? 2 :
+             (x < 1000 ? 3 :
+              (x < 10000 ? 4 :
+               (x < 100000 ? 5 :
+                (x < 1000000 ? 6 :
+                 (x < 10000000 ? 7 :
+                  (x < 100000000 ? 8 :
+                   (x < 1000000000 ? 9 :
+                    10)))))))));
+}
+    /*
+    std::cout << "****************************** NTUPLE *******************************\n";
+    std::cout << "* Ntuple  : " << fField->GetName() << std::setw(58-fField->GetName().size()) << "*\n";
+    std::cout << "*********************************************************************\n";*/
+
+
+
+
+/*
+void ROOT::Experimental::TNtuplePrintVisitor::visitNtuple(ROOT::Experimental::RNTupleReader* fReader)  {
+    /// content here: Each line has 69 char.
+    auto Rootfield = fReader->GetModel()->GetRootField();
+    std::cout << "****************************** NTUPLE *******************************\n";
+    std::cout << "* Ntuple  : " << fReader->getName() << std::setw(58-fReader->getName().size()) << "*\n";
+    std::cout << "* Entries : " << fReader->GetNEntries() << std::setw(58-NumDigits(fReader->GetNEntries())) << "*\n";
+    std::cout << "*********************************************************************\n";
+    /// From here on entry specific for each branch.
+    for(size_t i = 0; i < Rootfield->fSubFields.size(); ++i) {
+    // for(size_t i = 0; i < fReader->GetModel()->GetRootField()->(Detail::GetNItems()); ++i) {
+        std::cout << "* Br " << std::setw(5-NumDigits(i)) << i << " : " << Rootfield->fSubFields.at(i)->fName << ": " << Rootfield->fSubFields.at(i)->fType << std::setw(56-(Rootfield->fSubFields.at(i)->fName.size()) - (Rootfield->fSubFields.at(i)->fType.size())) <<"*\n";
+        std::cout << "* Entries : \n"; //Does this even make sense?!
+        std::cout << "* Baskets : \n"; //WTF is a basket.
+        std::cout << "*********************************************************************\n";
+    } // end for loop
+    // for(auto subfieldptr: fReader->GetModel()->GetRootField()->fSubFields) {  }
+    
+    
+    
+}
+*/

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -1,0 +1,8 @@
+//
+//  RFieldVisitor.cpp
+//  
+//
+//  Created by Simon Leisibach on 11.06.19.
+//
+
+#include "ROOT/RFieldVisitor.hxx"

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -13,31 +13,19 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-//#include "ROOT/RNTuple.hxx"
 #include "ROOT/RFieldVisitor.hxx"
 #include "ROOT/RField.hxx"
+#include "ROOT/RNTuple.hxx"
 #include <iostream>
+#include <sstream>
 #include <iomanip>
+#include <string>
 
 
-void ROOT::Experimental::RPrintVisitor::visitField(const ROOT::Experimental::Detail::RFieldBase& fField) { std::cout << "Called visitField for any normal field\n";}
-void ROOT::Experimental::RPrintVisitor::visitField(const ROOT::Experimental::RFieldRoot& fRootField) {
-    std::cout << "Called function for RootField\n";
+void ROOT::Experimental::RPrintVisitor::visitField(const ROOT::Experimental::Detail::RFieldBase& fField) {
+    std::string fNameAndType{fField.GetName() +" (" + fField.GetType()+")"};
+    fOutput << " Field " << std::setw(FieldDistance(maxNoFields)+5-NumDigits(fField.GetOrder())) << fField.GetOrder() << " : " << CutIfNecessary(fNameAndType, fWidth-FieldDistance(maxNoFields)-16) << std::setw(fWidth-17-FieldDistance(maxNoFields)-fField.GetName().size()-fField.GetType().size());
 }
-/*void ROOT::Experimental::RPrintVisitor::visitField(ROOT::Experimental::Detail::RFieldBase* fField, int fIndex) {
-    /// content here: Each line has 69 char.
-    //std::cout << "Calling visitField\n";
-    std::cout << "* Br " << std::setw(5-NumDigits(fIndex)) << fIndex << " : " << fField->GetName() << ": " << fField->GetType() << std::setw(56-(fField->GetName().size()) - (fField->GetType().size())) <<"*\n";
-    std::cout << "* Entries : \n"; //Does this even make sense?!
-    std::cout << "* Baskets : \n"; //WTF is a basket.
-    std::cout << "*********************************************************************\n";
-}
-
-void ROOT::Experimental::RPrintVisitor::visitField(ROOT::Experimental::RField<std::string, void>* fField, int fIndex) {
-    std::cout << "* Br " << std::setw(5-NumDigits(fIndex)) << fIndex << " : " << fField->GetName() << ": " << fField->GetType() << std::setw(56-(fField->GetName().size()) - (fField->GetType().size())) <<"*\n";
-    std::cout << "* Invoked templated version because data type was std::string" << std::setw(9) << "*\n";
-    std::cout << "*********************************************************************\n";
-}*/
 
 int ROOT::Experimental::NumDigits(int x)
 {
@@ -53,33 +41,20 @@ int ROOT::Experimental::NumDigits(int x)
                    (x < 1000000000 ? 9 :
                     10)))))))));
 }
-    /*
-    std::cout << "****************************** NTUPLE *******************************\n";
-    std::cout << "* Ntuple  : " << fField->GetName() << std::setw(58-fField->GetName().size()) << "*\n";
-    std::cout << "*********************************************************************\n";*/
 
-
-
-
-/*
-void ROOT::Experimental::TNtuplePrintVisitor::visitNtuple(ROOT::Experimental::RNTupleReader* fReader)  {
-    /// content here: Each line has 69 char.
-    auto Rootfield = fReader->GetModel()->GetRootField();
-    std::cout << "****************************** NTUPLE *******************************\n";
-    std::cout << "* Ntuple  : " << fReader->getName() << std::setw(58-fReader->getName().size()) << "*\n";
-    std::cout << "* Entries : " << fReader->GetNEntries() << std::setw(58-NumDigits(fReader->GetNEntries())) << "*\n";
-    std::cout << "*********************************************************************\n";
-    /// From here on entry specific for each branch.
-    for(size_t i = 0; i < Rootfield->fSubFields.size(); ++i) {
-    // for(size_t i = 0; i < fReader->GetModel()->GetRootField()->(Detail::GetNItems()); ++i) {
-        std::cout << "* Br " << std::setw(5-NumDigits(i)) << i << " : " << Rootfield->fSubFields.at(i)->fName << ": " << Rootfield->fSubFields.at(i)->fType << std::setw(56-(Rootfield->fSubFields.at(i)->fName.size()) - (Rootfield->fSubFields.at(i)->fType.size())) <<"*\n";
-        std::cout << "* Entries : \n"; //Does this even make sense?!
-        std::cout << "* Baskets : \n"; //WTF is a basket.
-        std::cout << "*********************************************************************\n";
-    } // end for loop
-    // for(auto subfieldptr: fReader->GetModel()->GetRootField()->fSubFields) {  }
-    
-    
-    
+int ROOT::Experimental::FieldDistance(unsigned int x) {
+    return (x < 10000 ? 0 :
+             (x < 100000 ? 1 :
+              (x < 1000000 ? 2 :
+               (x < 10000000 ? 3 :
+                (x < 100000000 ? 4 :
+                 (x < 1000000000 ? 5 :
+                  10))))));
 }
-*/
+
+std::string ROOT::Experimental::CutIfNecessary(const std::string &toCut, unsigned int maxAvailableSpace) {
+    if(toCut.size() > maxAvailableSpace) {
+        return std::string(toCut, 0, maxAvailableSpace-3) + "...";
+    }
+   return toCut;
+}

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -13,50 +13,57 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+
 #include "ROOT/RFieldVisitor.hxx"
 #include "ROOT/RField.hxx"
 #include "ROOT/RNTuple.hxx"
-#include <iostream>
-#include <sstream>
-#include <iomanip>
-#include <string>
+
 
 // Entire function only prints a single line.
-void ROOT::Experimental::RPrintVisitor::visitField(const ROOT::Experimental::Detail::RFieldBase& fField) {
-    std::string fNameAndType{fField.GetName() +" (" + fField.GetType()+")"};
-    fOutput << " Field " << std::setw(FieldDistance(maxNoFields)+5-NumDigits(fField.GetOrder())) << fField.GetOrder() << " : " << CutIfNecessary(fNameAndType, fWidth-FieldDistance(maxNoFields)-16) << std::setw(fWidth-17-FieldDistance(maxNoFields)-fField.GetName().size()-fField.GetType().size());
+void ROOT::Experimental::RPrintVisitor::visitField(const ROOT::Experimental::Detail::RFieldBase &Field)
+{
+   std::string fNameAndType{Field.GetName() + " (" + Field.GetType() + ")"};
+   fOutput << " Field " << std::setw(FieldDistance(maxNoFields) + 5 - NumDigits(Field.GetOrder())) << Field.GetOrder()
+           << " : " << CutIfNecessary(fNameAndType, fWidth - FieldDistance(maxNoFields) - 16)
+           << std::setw(fWidth - 17 - FieldDistance(maxNoFields) - Field.GetName().size() - Field.GetType().size());
 }
 
 int ROOT::Experimental::NumDigits(int x)
 {
-    x = abs(x);
-    return (x < 10 ? 1 :
-            (x < 100 ? 2 :
-             (x < 1000 ? 3 :
-              (x < 10000 ? 4 :
-               (x < 100000 ? 5 :
-                (x < 1000000 ? 6 :
-                 (x < 10000000 ? 7 :
-                  (x < 100000000 ? 8 :
-                   (x < 1000000000 ? 9 :
-                    10)))))))));
+   x = abs(x);
+   return (
+      x < 10 ? 1
+             : (x < 100
+                   ? 2
+                   : (x < 1000
+                         ? 3
+                         : (x < 10000
+                               ? 4
+                               : (x < 100000
+                                     ? 5
+                                     : (x < 1000000
+                                           ? 6
+                                           : (x < 10000000 ? 7 : (x < 100000000 ? 8 : (x < 1000000000 ? 9 : 10)))))))));
 }
 
 // Used for RPrintVisitor::visitField(RFieldBase*). Returns number of additional
 // spaces needed so that larger field indexes can be shown properly alligned.
-int ROOT::Experimental::FieldDistance(unsigned int x) {
-    return (x < 10000 ? 0 :
-             (x < 100000 ? 1 :
-              (x < 1000000 ? 2 :
-               (x < 10000000 ? 3 :
-                (x < 100000000 ? 4 :
-                 (x < 1000000000 ? 5 :
-                  10))))));
+int ROOT::Experimental::FieldDistance(unsigned int x)
+{
+   return (
+      x < 10000
+         ? 0
+         : (x < 100000 ? 1 : (x < 1000000 ? 2 : (x < 10000000 ? 3 : (x < 100000000 ? 4 : (x < 1000000000 ? 5 : 10))))));
 }
 
-std::string ROOT::Experimental::CutIfNecessary(const std::string &toCut, unsigned int maxAvailableSpace) {
-    if(toCut.size() > maxAvailableSpace) {
-        return std::string(toCut, 0, maxAvailableSpace-3) + "...";
-    }
+std::string ROOT::Experimental::CutIfNecessary(const std::string &toCut, unsigned int maxAvailableSpace)
+{
+   if (toCut.size() > maxAvailableSpace) {
+      return std::string(toCut, 0, maxAvailableSpace - 3) + "...";
+   }
    return toCut;
 }

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -21,7 +21,7 @@
 #include <iomanip>
 #include <string>
 
-
+// Entire function only prints a single line.
 void ROOT::Experimental::RPrintVisitor::visitField(const ROOT::Experimental::Detail::RFieldBase& fField) {
     std::string fNameAndType{fField.GetName() +" (" + fField.GetType()+")"};
     fOutput << " Field " << std::setw(FieldDistance(maxNoFields)+5-NumDigits(fField.GetOrder())) << fField.GetOrder() << " : " << CutIfNecessary(fNameAndType, fWidth-FieldDistance(maxNoFields)-16) << std::setw(fWidth-17-FieldDistance(maxNoFields)-fField.GetName().size()-fField.GetType().size());
@@ -42,6 +42,8 @@ int ROOT::Experimental::NumDigits(int x)
                     10)))))))));
 }
 
+// Used for RPrintVisitor::visitField(RFieldBase*). Returns number of additional
+// spaces needed so that larger field indexes can be shown properly alligned.
 int ROOT::Experimental::FieldDistance(unsigned int x) {
     return (x < 10000 ? 0 :
              (x < 100000 ? 1 :

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -103,37 +103,28 @@ std::string ROOT::Experimental::RNTupleReader::GetInfo(const ENTupleInfo what) {
    return "";
 }
 
-void ROOT::Experimental::RNTupleReader::Print() {
-    //std::cout << "CallingPrint\n";
-    //std::cout << "****************************** NTUPLE *******************************\n";
-    //std::cout << "* Ntuple  : " << GetName() << std::setw(58-GetName().size()) << "*\n";
-    //std::cout << "* Entries : " << GetNEntries() << std::setw(58-NumDigits(GetNEntries())) << "*\n";
-    //std::cout << "*********************************************************************\n";
-    
-    RPrintVisitor fPrintVisitor;
-    GetModel()->GetRootField()->AcceptVisitor(fPrintVisitor);
-    for(const auto& field: *(GetModel()->GetRootField()))
-    
-    //for(int i = 0; i < GetModel()->GetRootField()->getSubfields().size(); ++i)
-    {
+void ROOT::Experimental::RNTupleReader::Print(std::ostream &output, int width, unsigned int fNoFields) {
+    if(width < 30) {
+        std::cout << "The width is too small! Should be at least 30.\n";
+        return;
+    }
+    RPrintVisitor fPrintVisitor(output, width, fNoFields);
+    for(int i = 0; i < (width/2 + width%2 -4); ++i)
+        output << '*'; output << " NTUPLE ";
+    for(int i = 0; i < (width/2 -4); ++i) output << '*'; output << '\n';
+    //CutIfNecessary defined in RFieldVisitor.hxx
+    output << "* Ntuple  : " << CutIfNecessary(GetName(),width-13) << std::setw(width-11-GetName().size()) << "*\n";
+    output << "* Entries : " << GetNEntries() << std::setw(width-11-NumDigits(GetNEntries())) << "*\n";
+    for(int i = 0; i < width; ++i)
+        output << "*"; output << '\n';
+    for(const auto& field: *(GetModel()->GetRootField())) {
+        output << "*";
         field.AcceptVisitor(fPrintVisitor);
+        output << "*\n";
+        for(int i = 0; i < width; ++i)
+            output << "*"; output << '\n';
      }
-    //GetModel()->GetRootField()->AcceptVisitor(fPrintVisitor);
-    /*
-    for (auto field : GetModel()->GetRootField())
-        field.AcceptVisitor(...)
-    GetModel()->GetRootField()->AcceptVisitor(fPrintVisitor);*/
 }
-/*
-void ROOT::Experimental::RNTupleReader::Print() {
-    TNtuplePrintVisitor fPrintVisitor;
-    Accept(fPrintVisitor);
-}
-
-void ROOT::Experimental::RNTupleReader::Accept(ROOT::Experimental::VBaseNtupleVisitor &fVisitor) {
-    fVisitor.visitNtuple(this);
-}
-*/
 //------------------------------------------------------------------------------
 
 ROOT::Experimental::RNTupleWriter::RNTupleWriter(

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -103,6 +103,7 @@ std::string ROOT::Experimental::RNTupleReader::GetInfo(const ENTupleInfo what) {
    return "";
 }
 
+
 void ROOT::Experimental::RNTupleReader::Print(std::ostream &output, int width, unsigned int fNoFields) {
     if(width < 30) {
         std::cout << "The width is too small! Should be at least 30.\n";

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -15,6 +15,7 @@
 
 #include "ROOT/RNTuple.hxx"
 
+#include "ROOT/RFieldVisitor.hxx"
 #include "ROOT/RNTupleModel.hxx"
 #include "ROOT/RPageStorage.hxx"
 #include "ROOT/RPageStorageRoot.hxx"
@@ -23,6 +24,7 @@
 #include <sstream>
 #include <string>
 #include <utility>
+#include <iostream>
 
 ROOT::Experimental::Detail::RNTuple::RNTuple(std::unique_ptr<ROOT::Experimental::RNTupleModel> model)
    : fModel(std::move(model))
@@ -88,7 +90,7 @@ std::string ROOT::Experimental::RNTupleReader::GetInfo(const ENTupleInfo what) {
 
    switch (what) {
    case ENTupleInfo::kSummary:
-      os << "****************************** NTUPLE *******************************"  << std::endl
+      os << "****************************** NTUPLE ******************************"  << std::endl
          << "* Name:    " << name << std::setw(57 - name.length())           << "*" << std::endl
          << "* Entries: " << std::setw(10) << fNEntries << std::setw(47)     << "*" << std::endl
          << "********************************************************************"  << std::endl;
@@ -101,6 +103,37 @@ std::string ROOT::Experimental::RNTupleReader::GetInfo(const ENTupleInfo what) {
    return "";
 }
 
+void ROOT::Experimental::RNTupleReader::Print() {
+    //std::cout << "CallingPrint\n";
+    //std::cout << "****************************** NTUPLE *******************************\n";
+    //std::cout << "* Ntuple  : " << GetName() << std::setw(58-GetName().size()) << "*\n";
+    //std::cout << "* Entries : " << GetNEntries() << std::setw(58-NumDigits(GetNEntries())) << "*\n";
+    //std::cout << "*********************************************************************\n";
+    
+    RPrintVisitor fPrintVisitor;
+    GetModel()->GetRootField()->AcceptVisitor(fPrintVisitor);
+    for(const auto& field: *(GetModel()->GetRootField()))
+    
+    //for(int i = 0; i < GetModel()->GetRootField()->getSubfields().size(); ++i)
+    {
+        field.AcceptVisitor(fPrintVisitor);
+     }
+    //GetModel()->GetRootField()->AcceptVisitor(fPrintVisitor);
+    /*
+    for (auto field : GetModel()->GetRootField())
+        field.AcceptVisitor(...)
+    GetModel()->GetRootField()->AcceptVisitor(fPrintVisitor);*/
+}
+/*
+void ROOT::Experimental::RNTupleReader::Print() {
+    TNtuplePrintVisitor fPrintVisitor;
+    Accept(fPrintVisitor);
+}
+
+void ROOT::Experimental::RNTupleReader::Accept(ROOT::Experimental::VBaseNtupleVisitor &fVisitor) {
+    fVisitor.visitNtuple(this);
+}
+*/
 //------------------------------------------------------------------------------
 
 ROOT::Experimental::RNTupleWriter::RNTupleWriter(

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -11,4 +11,4 @@ ROOT_STANDARD_LIBRARY_PACKAGE(CustomStruct
                               LINKDEF CustomStructLinkDef.h
                               DEPENDENCIES RIO)
 ROOT_ADD_GTEST(ntuple ntuple.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)
-ROOT_ADD_GTEST(ntupleprint ntupleprint.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)
+ROOT_ADD_GTEST(ntuple_print ntuple_print.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -11,3 +11,4 @@ ROOT_STANDARD_LIBRARY_PACKAGE(CustomStruct
                               LINKDEF CustomStructLinkDef.h
                               DEPENDENCIES RIO)
 ROOT_ADD_GTEST(ntuple ntuple.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)
+ROOT_ADD_GTEST(ntupleprint ntupleprint.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)

--- a/tree/ntuple/v7/test/ntuple_print.cxx
+++ b/tree/ntuple/v7/test/ntuple_print.cxx
@@ -1,0 +1,93 @@
+#include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RFieldVisitor.hxx>
+
+#include <TClass.h>
+#include <TFile.h>
+
+#include "gtest/gtest.h"
+
+#include <sstream>
+#include <iostream>
+
+using RNTupleReader = ROOT::Experimental::RNTupleReader;
+using RNTupleWriter = ROOT::Experimental::RNTupleWriter;
+using RNTupleModel = ROOT::Experimental::RNTupleModel;
+using RFieldBase = ROOT::Experimental::Detail::RFieldBase;
+using RPrintVisitor = ROOT::Experimental::RPrintVisitor;
+template <class T>
+using RField = ROOT::Experimental::RField<T>;
+
+namespace {
+    
+    /**
+     * An RAII wrapper around an open temporary file on disk. It cleans up the guarded file when the wrapper object
+     * goes out of scope.
+     */
+    class FileRaii {
+    private:
+        std::string fPath;
+    public:
+        FileRaii(const std::string &path) : fPath(path)
+        {
+        }
+        FileRaii(const FileRaii&) = delete;
+        FileRaii& operator=(const FileRaii&) = delete;
+        ~FileRaii() {
+            std::remove(fPath.c_str());
+        }
+    };
+    
+} // anonymous namespace
+
+TEST(RNtuplePrint, FullString)
+{
+    TFile *file = TFile::Open("test.root", "RECREATE");
+    FileRaii fileGuard("test.root");
+    {
+    auto model = RNTupleModel::Create();
+    auto fieldPt = model->MakeField<float>("pt");
+    auto ntuple = RNTupleWriter::Recreate(std::move(model), "Staff", "test.root");
+    //*fieldPt = 5.0f;
+    //ntuple->Fill();
+    }
+    auto model2 = RNTupleModel::Create();
+    auto fieldPt2 = model2->MakeField<float>("pt");
+    auto ntuple2 = RNTupleReader::Open(std::move(model2), "Staff", "test.root");
+    std::ostringstream os;
+    ntuple2->Print(os);
+    std::string fString{"******************************* NTUPLE ******************************\n* Ntuple  : Staff                                                   *\n* Entries : 0                                                       *\n*********************************************************************\n* Field    0 : pt (float)                                           *\n*********************************************************************\n"};
+    EXPECT_EQ(fString, os.str());
+    file->Close();
+}
+
+TEST(RNtuplePrint, IntTest)
+{
+    std::stringstream os;
+    RPrintVisitor fPrintVisitor(os);
+    RField<int> fTestname("fIntTest");
+    fTestname.AcceptVisitor(fPrintVisitor);
+    std::string expected{"* Field   -1 : fIntTest (std::int32_t)                              *\n"};
+    EXPECT_EQ(expected, os.str());
+}
+
+TEST(RNtuplePrint, FloatTest)
+{
+    std::stringstream os;
+    RPrintVisitor fPrintVisitor(os);
+    RField<float> fTestname("fFloatTest");
+    fTestname.AcceptVisitor(fPrintVisitor);
+    std::string expected{"* Field   -1 : fFloatTest (float)                                   *\n"};
+    EXPECT_EQ(expected, os.str());
+}
+
+/*
+TEST(RNtuplePrint, ShortTest)
+{
+    std::stringstream os;
+    RPrintVisitor fPrintVisitor(os);
+    RField<short> fTestname("fShortTest");
+    fTestname.AcceptVisitor(fPrintVisitor);
+    std::string expected{"* Field   -1 : fShortTest (short)                                   *\n"};
+    EXPECT_EQ(expected, os.str());
+}*/

--- a/tree/ntuple/v7/test/ntupleprint.cxx
+++ b/tree/ntuple/v7/test/ntupleprint.cxx
@@ -1,0 +1,5 @@
+#include "gtest/gtest.h"
+
+TEST(RNtuplePrint, Basics)
+{
+}

--- a/tree/ntuple/v7/test/ntupleprint.cxx
+++ b/tree/ntuple/v7/test/ntupleprint.cxx
@@ -1,5 +1,0 @@
-#include "gtest/gtest.h"
-
-TEST(RNtuplePrint, Basics)
-{
-}

--- a/tutorials/v7/ntuple/ntpl001_staff.C
+++ b/tutorials/v7/ntuple/ntpl001_staff.C
@@ -93,6 +93,9 @@ void Analyze() {
 
    // Quick overview of the ntuple's key meta-data
    std::cout << ntuple->GetInfo();
+    
+   // Quick overview of the ntuple and list of fields.
+   ntuple->Print();
    // In a future version of RNTuple, there will be support for ntuple->Show() and ntuple->Scan()
 
    auto c = new TCanvas("c", "", 200, 10, 700, 500);

--- a/tutorials/v7/ntuple/ntpl001_staff.C
+++ b/tutorials/v7/ntuple/ntpl001_staff.C
@@ -91,8 +91,8 @@ void Analyze() {
    // Create an ntuple and attach the read model to it
    auto ntuple = RNTupleReader::Open(std::move(model), "Staff", kNTupleFileName);
 
-   // Quick overview of the ntuple's key meta-data
-   std::cout << ntuple->GetInfo();
+   // Quick overview of the ntuple's key meta-data, uncomment to see it.
+   //std::cout << ntuple->GetInfo();
     
    // Quick overview of the ntuple and list of fields.
    ntuple->Print();


### PR DESCRIPTION
This pull request adds a visitor infrastructure for the RField class.  A concrete implementation, the print visitor, is used to show information about the field names and types of an ntuple on the terminal. 