### PR TITLE
 Replace CXX_STANDARD with STANDARD_COMPILE_OPTION

### DIFF
--- a/cmake/modules/CheckCompiler.cmake
+++ b/cmake/modules/CheckCompiler.cmake
@@ -115,7 +115,7 @@ if(NOT CMAKE_CXX_STANDARD MATCHES "11|14|17")
 endif()
 
 # needed by roottest, to be removed once roottest is fixed
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++${CMAKE_CXX_STANDARD}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX${CMAKE_CXX_STANDARD}_STANDARD_COMPILE_OPTION}")
 
 #---Check for libcxx option------------------------------------------------------------
 if(libcxx)


### PR DESCRIPTION
When compiling for conda we enable C++17 support but the compiler only supports `--std=cxx1z`. 

Uses the same [fix as is used for `root-config`](https://github.com/root-project/root/blob/88ed0c6ea16f962b89168417bfff23891429dd63/cmake/modules/RootConfiguration.cmake#L570).