### PR TITLE
[ntuple] Move page memory management to page storage classes

### DIFF
--- a/tree/ntuple/CMakeLists.txt
+++ b/tree/ntuple/CMakeLists.txt
@@ -21,6 +21,7 @@ HEADERS
   ROOT/RNTupleUtil.hxx
   ROOT/RNTupleView.hxx
   ROOT/RPage.hxx
+  ROOT/RPageAllocator.hxx
   ROOT/RPagePool.hxx
   ROOT/RPageStorage.hxx
   ROOT/RPageStorageRoot.hxx
@@ -32,6 +33,7 @@ SOURCES
   v7/src/RNTupleDescriptor.cxx
   v7/src/RNTupleModel.cxx
   v7/src/RPage.cxx
+  v7/src/RPageAllocator.cxx
   v7/src/RPagePool.cxx
   v7/src/RPageStorage.cxx
   v7/src/RPageStorageRoot.cxx

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -63,7 +63,7 @@ public:
    explicit RColumn(const RColumnModel& model);
    RColumn(const RColumn&) = delete;
    RColumn& operator =(const RColumn&) = delete;
-   ~RColumn() = default;
+   ~RColumn();
 
    void Connect(RPageStorage* pageStorage);
 

--- a/tree/ntuple/v7/inc/ROOT/RPage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPage.hxx
@@ -118,6 +118,7 @@ public:
 
    bool IsNull() const { return fBuffer == nullptr; }
    bool operator ==(const RPage &other) const { return fBuffer == other.fBuffer; }
+   bool operator !=(const RPage &other) const { return !(*this == other); }
 };
 
 } // namespace Detail

--- a/tree/ntuple/v7/inc/ROOT/RPage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPage.hxx
@@ -34,8 +34,8 @@ namespace Detail {
 
 The page provides an opaque memory buffer for uncompressed, unpacked data. It does not interpret
 the contents but it does now about the size (and thus the number) of the elements inside as well as the element
-number range within the backing column. The memory buffer is not managed by the page.  It normally registered with
-the page pool and managed (allocated) by the page storage.
+number range within the backing column/cluster. The memory buffer is not managed by the page. It is normally registered
+with the page pool and allocated/freed by the page storage.
 */
 // clang-format on
 class RPage {
@@ -86,6 +86,7 @@ public:
    std::size_t GetCapacity() const { return fCapacity; }
    /// The space taken by column elements in the buffer
    std::size_t GetSize() const { return fSize; }
+   std::size_t GetElementSize() const { return fElementSize; }
    NTupleSize_t GetNElements() const { return fSize / fElementSize; }
    NTupleSize_t GetRangeFirst() const { return fRangeFirst; }
    NTupleSize_t GetRangeLast() const { return fRangeFirst + fNElements - 1; }

--- a/tree/ntuple/v7/inc/ROOT/RPage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPage.hxx
@@ -30,11 +30,12 @@ namespace Detail {
 /**
 \class ROOT::Experimental::Detail::RPage
 \ingroup NTuple
-\brief A page is a fixed size slice of a column that is mapped into memory
+\brief A page is a slice of a column that is mapped into memory
 
-The page provides a fixed-size opaque memory buffer for uncompressed data. It does not know how to interpret
+The page provides an opaque memory buffer for uncompressed, unpacked data. It does not interpret
 the contents but it does now about the size (and thus the number) of the elements inside as well as the element
-number range within the backing column. The memory buffer is not managed by the page but normally by the page pool.
+number range within the backing column. The memory buffer is not managed by the page.  It normally registered with
+the page pool and managed (allocated) by the page storage.
 */
 // clang-format on
 class RPage {

--- a/tree/ntuple/v7/inc/ROOT/RPageAllocator.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageAllocator.hxx
@@ -27,35 +27,22 @@ namespace Detail {
 
 // clang-format off
 /**
-\class ROOT::Experimental::Detail::RPageAllocator
+\class ROOT::Experimental::Detail::RPageAllocatorHeap
 \ingroup NTuple
-\brief Basic memory management of column pages: reserve and release
+\brief Uses standard C++ memory allocation for the column data pages
 
 The page allocator acquires and releases memory for pages.  It does not populate the pages, the returned pages
 are empty but guaranteed to have enough contiguous space for the given number of elements.  While a common
 concrete implementation uses the heap, other implementations are possible, e.g. using arenas or mmap().
 */
 // clang-format on
-class RPageAllocator {
+class RPageAllocatorHeap {
 public:
-   /// Reserves memory large enough to hold nElements of the given size; the page is immediately tagged with a column id
-   virtual RPage AllocatePage(ColumnId_t columnId, std::size_t elementSize, std::size_t nElements) = 0;
-   /// Frees the memory pointed to by page and resets the page's information
-   virtual void ReleasePage(RPage &page) = 0;
-};
-
-
-// clang-format off
-/**
-\class ROOT::Experimental::Detail::RPageAllocatorHeap
-\ingroup NTuple
-\brief Uses standard C++ memory allocation for the pages
-*/
-// clang-format on
-class RPageAllocatorHeap : public RPageAllocator {
-public:
-   RPage AllocatePage(ColumnId_t columnId, std::size_t elementSize, std::size_t nElements) final;
-   void ReleasePage(RPage& page) final;
+   /// Reserves memory large enough to hold nElements of the given size. The page is immediately tagged with
+   /// a column id.
+   RPage NewPage(ColumnId_t columnId, std::size_t elementSize, std::size_t nElements);
+   /// Releases the memory pointed to by page and resets the page's information
+   void DeletePage(const RPage& page);
 };
 
 } // namespace Detail

--- a/tree/ntuple/v7/inc/ROOT/RPageAllocator.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageAllocator.hxx
@@ -1,0 +1,65 @@
+/// \file ROOT/RPageAllocator.hxx
+/// \ingroup NTuple ROOT7
+/// \author Jakob Blomer <jblomer@cern.ch>
+/// \date 2019-06-25
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RPageAllocator
+#define ROOT7_RPageAllocator
+
+#include <ROOT/RNTupleUtil.hxx>
+#include <ROOT/RPage.hxx>
+
+#include <cstddef>
+
+namespace ROOT {
+namespace Experimental {
+namespace Detail {
+
+// clang-format off
+/**
+\class ROOT::Experimental::Detail::RPageAllocator
+\ingroup NTuple
+\brief Basic memory management of column pages: reserve and release
+
+The page allocator acquires and releases memory for pages.  It does not populate the pages, the returned pages
+are empty but guaranteed to have enough contiguous space for the given number of elements.  While a common
+concrete implementation uses the heap, other implementations are possible, e.g. using arenas or mmap().
+*/
+// clang-format on
+class RPageAllocator {
+public:
+   /// Reserves memory large enough to hold nElements of the given size; the page is immediately tagged with a column id
+   virtual RPage AllocatePage(ColumnId_t columnId, std::size_t elementSize, std::size_t nElements) = 0;
+   /// Frees the memory pointed to by page and resets the page's information
+   virtual void ReleasePage(RPage &page) = 0;
+};
+
+
+// clang-format off
+/**
+\class ROOT::Experimental::Detail::RPageAllocatorHeap
+\ingroup NTuple
+\brief Uses standard C++ memory allocation for the pages
+*/
+// clang-format on
+class RPageAllocatorHeap : public RPageAllocator {
+public:
+   RPage AllocatePage(ColumnId_t columnId, std::size_t elementSize, std::size_t nElements) final;
+   void ReleasePage(RPage& page) final;
+};
+
+} // namespace Detail
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
@@ -35,9 +35,10 @@ class RColumn;
 \ingroup NTuple
 \brief A thread-safe cache of column pages.
 
-The page pool encapsulated memory management for data written into a tree or read from a tree. Adding and removing
-pages is thread-safe. All pages have the same size, which means different pages do not necessarily contain the same
-number of elements. Multiple page caches can coexist.
+The page pool provides memory tracking for data written into an ntuple or read from an ntuple. Adding and removing
+pages is thread-safe. The page pool does not allocate the memory -- allocation and deallocation is performed by the
+page storage, which might do it in a way optimized to the backing store (e.g., mmap()).
+Multiple page caches can coexist.
 
 TODO(jblomer): it should be possible to register pages and to find them by column and index; this would
 facilitate pre-filling a cache, e.g. by read-ahead.
@@ -62,7 +63,7 @@ public:
    RPagePool& operator =(const RPagePool&) = delete;
    ~RPagePool();
 
-   /// Get a new, empty page from the cache. Return a "null Page" if there is no more free space.
+   /// Get a new, empty page from the cache. Return a "null page" if there is no more free space.  Used for writing.
    RPage ReservePage(RColumn* column);
    /// Registers a page that has previously been acquired by ReservePage() and was meanwhile filled with content.
    void CommitPage(const RPage& page);

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -52,7 +52,7 @@ The tree meta-data contains of a list of fields, a unique identifier, and proven
 // clang-format on
 class RPageStorage {
 protected:
-   /// All data is shipped to and from physical storage in pages, and moderated through a page pool
+   /// All data is shipped to and from physical storage in pages, moderated through a page pool
    std::unique_ptr<RPagePool> fPagePool;
 
 public:
@@ -63,17 +63,19 @@ public:
 
    struct RColumnHandle {
       RColumnHandle() : fId(-1), fColumn(nullptr) {}
-      RColumnHandle(int id, RColumn* column) : fId(id), fColumn(column) {}
+      RColumnHandle(int id, const RColumn *column) : fId(id), fColumn(column) {}
       int fId;
-      RColumn *fColumn;
+      const RColumn *fColumn;
    };
    /// The column handle identfies a column with the current open page storage
    using ColumnHandle_t = RColumnHandle;
 
-   /// Register a new column.  When reading, the column must exist in the tree on disk corresponding to the meta-data.
+   /// Register a new column.  When reading, the column must exist in the ntuple on disk corresponding to the meta-data.
    /// When writing, every column can only be attached once.
-   virtual ColumnHandle_t AddColumn(RColumn *column) = 0;
+   virtual ColumnHandle_t AddColumn(const RColumn &column) = 0;
    virtual EPageStorageType GetType() = 0;
+
+   // Page memory management
    RPagePool* GetPagePool() const { return fPagePool.get(); }
 };
 
@@ -81,10 +83,10 @@ public:
 /**
 \class ROOT::Experimental::Detail::RPageSink
 \ingroup NTuple
-\brief Abstract interface to write data into a tree
+\brief Abstract interface to write data into an ntuple
 
 The page sink takes the list of columns and afterwards a series of page commits and cluster commits.
-The user is responsible to commit clusters at consistent point, i.e. when all pages corresponding to data
+The user is responsible to commit clusters at a consistent point, i.e. when all pages corresponding to data
 up to the given entry number are committed.
 */
 // clang-format on
@@ -94,8 +96,9 @@ public:
    virtual ~RPageSink();
    EPageStorageType GetType() final { return EPageStorageType::kSink; }
 
-   /// Physically creates the storage container to hold the tree (e.g., a directory in a TFile or a S3 bucket)
-   virtual void Create(RNTupleModel* model) = 0;
+   /// Physically creates the storage container to hold the ntuple (e.g., a keys a TFile or an S3 bucket)
+   /// Create() associates column handles to the columns referenced by the model
+   virtual void Create(RNTupleModel &model) = 0;
    /// Write a page to the storage. The column must have been added before.
    virtual void CommitPage(ColumnHandle_t columnHandle, const RPage &page) = 0;
    /// Finalize the current cluster and create a new one for the following data.

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
@@ -172,16 +172,13 @@ public:
 /**
 \class ROOT::Experimental::Detail::RPageAllocatorKey
 \ingroup NTuple
-\brief Adopts the memory return by TKey->ReadObject()
+\brief Adopts the memory returned by TKey->ReadObject()
 */
 // clang-format on
 class RPageAllocatorKey {
-private:
-  std::unordered_map<void *, ROOT::Experimental::Internal::RPagePayload *> fPage2Payload;
 public:
-   RPage NewPage(ColumnId_t columnId, std::size_t elementSize, std::size_t nElements,
-                 ROOT::Experimental::Internal::RPagePayload &payload);
-   void DeletePage(const RPage& page);
+   static RPage NewPage(ColumnId_t columnId, void *mem, std::size_t elementSize, std::size_t nElements);
+   static void DeletePage(const RPage& page, ROOT::Experimental::Internal::RPagePayload *payload);
 };
 
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
@@ -156,8 +156,8 @@ public:
    RPageSinkRoot(std::string_view ntupleName, std::string_view path);
    virtual ~RPageSinkRoot();
 
-   ColumnHandle_t AddColumn(RColumn* column) final;
-   void Create(RNTupleModel* model) final;
+   ColumnHandle_t AddColumn(const RColumn &column) final;
+   void Create(RNTupleModel &model) final;
    void CommitPage(ColumnHandle_t columnHandle, const RPage &page) final;
    void CommitCluster(NTupleSize_t nEntries) final;
    void CommitDataset() final;
@@ -192,7 +192,7 @@ public:
    RPageSourceRoot(std::string_view ntupleName, std::string_view path);
    virtual ~RPageSourceRoot();
 
-   ColumnHandle_t AddColumn(RColumn* column) final;
+   ColumnHandle_t AddColumn(const RColumn &column) final;
    void Attach() final;
    std::unique_ptr<ROOT::Experimental::RNTupleModel> GenerateModel() final;
    void PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t index, RPage* page) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
@@ -201,6 +201,7 @@ public:
 
 private:
    std::unique_ptr<RPageAllocatorKey> fPageAllocator;
+   std::shared_ptr<RPagePool> fPagePool;
 
    /// Currently, an ntuple is stored as a directory in a TFile
    TDirectory *fDirectory;

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -34,12 +34,12 @@ void ROOT::Experimental::Detail::RColumn::Connect(RPageStorage* pageStorage)
    switch (pageStorage->GetType()) {
    case EPageStorageType::kSink:
       fPageSink = static_cast<RPageSink*>(pageStorage); // the page sink initializes fHeadPage on AddColumn
-      fHandleSink = fPageSink->AddColumn(this);
+      fHandleSink = fPageSink->AddColumn(*this);
       fHeadPage = fPageSink->GetPagePool()->ReservePage(this);
       break;
    case EPageStorageType::kSource:
       fPageSource = static_cast<RPageSource*>(pageStorage);
-      fHandleSource = fPageSource->AddColumn(this);
+      fHandleSource = fPageSource->AddColumn(*this);
       fNElements = fPageSource->GetNElements(fHandleSource);
       fColumnIdSource = fPageSource->GetColumnId(fHandleSource);
       break;

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -63,6 +63,8 @@ ROOT::Experimental::RNTupleReader::RNTupleReader(std::unique_ptr<ROOT::Experimen
 
 ROOT::Experimental::RNTupleReader::~RNTupleReader()
 {
+   // needs to be destructed before the page source
+   fModel = nullptr;
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleReader> ROOT::Experimental::RNTupleReader::Open(
@@ -118,6 +120,8 @@ ROOT::Experimental::RNTupleWriter::~RNTupleWriter()
 {
    CommitCluster();
    fSink->CommitDataset();
+   // needs to be destructed before the page sink
+   fModel = nullptr;
 }
 
 

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -111,7 +111,7 @@ ROOT::Experimental::RNTupleWriter::RNTupleWriter(
    , fClusterSizeEntries(kDefaultClusterSizeEntries)
    , fLastCommitted(0)
 {
-   fSink->Create(fModel.get());
+   fSink->Create(*fModel.get());
 }
 
 ROOT::Experimental::RNTupleWriter::~RNTupleWriter()

--- a/tree/ntuple/v7/src/RPageAllocator.cxx
+++ b/tree/ntuple/v7/src/RPageAllocator.cxx
@@ -1,0 +1,41 @@
+/// \file RPageAllocator.cxx
+/// \ingroup NTuple ROOT7
+/// \author Jakob Blomer <jblomer@cern.ch>
+/// \date 2019-06-25
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+
+#include <ROOT/RPageAllocator.hxx>
+
+#include <TError.h>
+
+namespace ROOT {
+namespace Experimental {
+namespace Detail {
+
+RPage RPageAllocatorHeap::AllocatePage(ColumnId_t columnId, std::size_t elementSize, std::size_t nElements)
+{
+   R__ASSERT((elementSize > 0) && (nElements > 0));
+   auto nbytes = elementSize * nElements;
+   auto buffer = new unsigned char[nbytes];
+   return RPage(columnId, buffer, nbytes, elementSize);
+}
+
+void RPageAllocatorHeap::ReleasePage(RPage& page)
+{
+   delete[] reinterpret_cast<unsigned char *>(page.GetBuffer());
+   page = RPage();
+}
+
+} // namespace Detail
+} // namespace Experimental
+} // namespace ROOT

--- a/tree/ntuple/v7/src/RPageAllocator.cxx
+++ b/tree/ntuple/v7/src/RPageAllocator.cxx
@@ -22,7 +22,7 @@ namespace ROOT {
 namespace Experimental {
 namespace Detail {
 
-RPage RPageAllocatorHeap::AllocatePage(ColumnId_t columnId, std::size_t elementSize, std::size_t nElements)
+RPage RPageAllocatorHeap::NewPage(ColumnId_t columnId, std::size_t elementSize, std::size_t nElements)
 {
    R__ASSERT((elementSize > 0) && (nElements > 0));
    auto nbytes = elementSize * nElements;
@@ -30,10 +30,9 @@ RPage RPageAllocatorHeap::AllocatePage(ColumnId_t columnId, std::size_t elementS
    return RPage(columnId, buffer, nbytes, elementSize);
 }
 
-void RPageAllocatorHeap::ReleasePage(RPage& page)
+void RPageAllocatorHeap::DeletePage(const RPage& page)
 {
    delete[] reinterpret_cast<unsigned char *>(page.GetBuffer());
-   page = RPage();
 }
 
 } // namespace Detail

--- a/tree/ntuple/v7/src/RPageAllocator.cxx
+++ b/tree/ntuple/v7/src/RPageAllocator.cxx
@@ -18,11 +18,8 @@
 
 #include <TError.h>
 
-namespace ROOT {
-namespace Experimental {
-namespace Detail {
-
-RPage RPageAllocatorHeap::NewPage(ColumnId_t columnId, std::size_t elementSize, std::size_t nElements)
+ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageAllocatorHeap::NewPage(
+   ColumnId_t columnId, std::size_t elementSize, std::size_t nElements)
 {
    R__ASSERT((elementSize > 0) && (nElements > 0));
    auto nbytes = elementSize * nElements;
@@ -30,11 +27,7 @@ RPage RPageAllocatorHeap::NewPage(ColumnId_t columnId, std::size_t elementSize, 
    return RPage(columnId, buffer, nbytes, elementSize);
 }
 
-void RPageAllocatorHeap::DeletePage(const RPage& page)
+void ROOT::Experimental::Detail::RPageAllocatorHeap::DeletePage(const RPage& page)
 {
    delete[] reinterpret_cast<unsigned char *>(page.GetBuffer());
 }
-
-} // namespace Detail
-} // namespace Experimental
-} // namespace ROOT

--- a/tree/ntuple/v7/src/RPagePool.cxx
+++ b/tree/ntuple/v7/src/RPagePool.cxx
@@ -20,77 +20,41 @@
 
 #include <cstdlib>
 
-ROOT::Experimental::Detail::RPagePool::RPagePool(std::size_t pageSize, std::size_t nPages)
-   : fMemory(nullptr), fPageSize(pageSize), fNPages(nPages)
+void ROOT::Experimental::Detail::RPagePool::RegisterPage(const RPage &page)
 {
-   if (nPages > 0) {
-      fMemory = malloc(pageSize * nPages);
-      R__ASSERT(fMemory != nullptr);
-      fPages.resize(nPages);
-      fReferences.resize(nPages, 0);
-   }
+   fPages.emplace_back(page);
+   fReferences.emplace_back(1);
+
 }
 
-
-ROOT::Experimental::Detail::RPagePool::~RPagePool()
+bool ROOT::Experimental::Detail::RPagePool::ReturnPage(const RPage& page)
 {
-   free(fMemory);
-}
+   if (page.IsNull()) return false;
 
-
-ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPagePool::ReservePage(RColumn* column)
-{
-   RPage result;
-   for (std::size_t i = 0; i < fNPages; ++i) {
-      if (fPages[i].IsNull()) {
-         void* buffer = static_cast<unsigned char *>(fMemory) + (fPageSize * i);
-         result = RPage(column->GetColumnIdSource(), buffer, fPageSize, column->GetModel().GetElementSize());
-         fPages[i] = result;
-         return result;
-      }
-   }
-   /// No space left
-   return result;
-}
-
-
-void ROOT::Experimental::Detail::RPagePool::CommitPage(const RPage& page)
-{
-   for (unsigned i = 0; i < fNPages; ++i) {
-      if (fPages[i] == page) {
-         fReferences[i] = 1;
-         return;
-      }
-   }
-   R__ASSERT(false);
-}
-
-void ROOT::Experimental::Detail::RPagePool::ReleasePage(const RPage& page)
-{
-   if (page.IsNull()) return;
-   for (unsigned i = 0; i < fNPages; ++i) {
+   unsigned int N = fPages.size();
+   for (unsigned i = 0; i < N; ++i) {
       if (fPages[i] == page) {
          if (--fReferences[i] == 0) {
             fPages[i] = RPage();
+            return true;
          }
-         return;
+         return false;
       }
    }
    R__ASSERT(false);
+   return false;
 }
 
-ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPagePool::GetPage(RColumn* column, NTupleSize_t index)
+ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPagePool::GetPage(
+   ColumnId_t columnId, NTupleSize_t index)
 {
-   for (unsigned i = 0; i < fNPages; ++i) {
+   unsigned int N = fPages.size();
+   for (unsigned int i = 0; i < N; ++i) {
       if (fReferences[i] == 0) continue;
-      if (fPages[i].GetColumnId() != column->GetColumnIdSource()) continue;
+      if (fPages[i].GetColumnId() != columnId) continue;
       if (!fPages[i].Contains(index)) continue;
       fReferences[i]++;
       return fPages[i];
    }
-   RPage newPage = ReservePage(column);
-   // TODO
-   //column->GetPageSource()->PopulatePage(column->GetHandleSource(), index, &newPage);
-   CommitPage(newPage);
-   return newPage;
+   return RPage();
 }

--- a/tree/ntuple/v7/src/RPagePool.cxx
+++ b/tree/ntuple/v7/src/RPagePool.cxx
@@ -89,7 +89,8 @@ ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPagePool::GetPage
       return fPages[i];
    }
    RPage newPage = ReservePage(column);
-   column->GetPageSource()->PopulatePage(column->GetHandleSource(), index, &newPage);
+   // TODO
+   //column->GetPageSource()->PopulatePage(column->GetHandleSource(), index, &newPage);
    CommitPage(newPage);
    return newPage;
 }

--- a/tree/ntuple/v7/src/RPagePool.cxx
+++ b/tree/ntuple/v7/src/RPagePool.cxx
@@ -35,7 +35,10 @@ bool ROOT::Experimental::Detail::RPagePool::ReturnPage(const RPage& page)
    for (unsigned i = 0; i < N; ++i) {
       if (fPages[i] == page) {
          if (--fReferences[i] == 0) {
-            fPages[i] = RPage();
+            fPages[i] = fPages[N-1];
+            fReferences[i] = fReferences[N-1];
+            fPages.resize(N-1);
+            fReferences.resize(N-1);
             return true;
          }
          return false;

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -19,26 +19,34 @@
 
 #include <ROOT/RStringView.hxx>
 
-ROOT::Experimental::Detail::RPageStorage::RPageStorage()
+namespace ROOT {
+namespace Experimental {
+namespace Detail {
+
+RPageStorage::RPageStorage(std::string_view name) : fNTupleName(name)
 {
 }
 
-ROOT::Experimental::Detail::RPageStorage::~RPageStorage()
+RPageStorage::~RPageStorage()
 {
 }
 
-ROOT::Experimental::Detail::RPageSource::RPageSource(std::string_view /*treeName*/)
+RPageSource::RPageSource(std::string_view name) : RPageStorage(name)
 {
 }
 
-ROOT::Experimental::Detail::RPageSource::~RPageSource()
+RPageSource::~RPageSource()
 {
 }
 
-ROOT::Experimental::Detail::RPageSink::RPageSink(std::string_view /*treeName*/)
+RPageSink::RPageSink(std::string_view name) : RPageStorage(name)
 {
 }
 
-ROOT::Experimental::Detail::RPageSink::~RPageSink()
+RPageSink::~RPageSink()
 {
 }
+
+} // namespace Detail
+} // namespace Experimental
+} // namespace ROOT

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -19,34 +19,26 @@
 
 #include <ROOT/RStringView.hxx>
 
-namespace ROOT {
-namespace Experimental {
-namespace Detail {
-
-RPageStorage::RPageStorage(std::string_view name) : fNTupleName(name)
+ROOT::Experimental::Detail::RPageStorage::RPageStorage(std::string_view name) : fNTupleName(name)
 {
 }
 
-RPageStorage::~RPageStorage()
+ROOT::Experimental::Detail::RPageStorage::~RPageStorage()
 {
 }
 
-RPageSource::RPageSource(std::string_view name) : RPageStorage(name)
+ROOT::Experimental::Detail::RPageSource::RPageSource(std::string_view name) : RPageStorage(name)
 {
 }
 
-RPageSource::~RPageSource()
+ROOT::Experimental::Detail::RPageSource::~RPageSource()
 {
 }
 
-RPageSink::RPageSink(std::string_view name) : RPageStorage(name)
+ROOT::Experimental::Detail::RPageSink::RPageSink(std::string_view name) : RPageStorage(name)
 {
 }
 
-RPageSink::~RPageSink()
+ROOT::Experimental::Detail::RPageSink::~RPageSink()
 {
 }
-
-} // namespace Detail
-} // namespace Experimental
-} // namespace ROOT

--- a/tree/ntuple/v7/src/RPageStorageRoot.cxx
+++ b/tree/ntuple/v7/src/RPageStorageRoot.cxx
@@ -28,11 +28,7 @@
 #include <iostream>
 #include <utility>
 
-namespace ROOT {
-namespace Experimental {
-namespace Detail {
-
-RPageSinkRoot::RPageSinkRoot(std::string_view ntupleName, RSettings settings)
+ROOT::Experimental::Detail::RPageSinkRoot::RPageSinkRoot(std::string_view ntupleName, RSettings settings)
    : RPageSink(ntupleName)
    , fPageAllocator(std::make_unique<RPageAllocatorHeap>())
    , fDirectory(nullptr)
@@ -43,7 +39,7 @@ RPageSinkRoot::RPageSinkRoot(std::string_view ntupleName, RSettings settings)
       "Do not store real data with this version of RNTuple!";
 }
 
-RPageSinkRoot::RPageSinkRoot(std::string_view ntupleName, std::string_view path)
+ROOT::Experimental::Detail::RPageSinkRoot::RPageSinkRoot(std::string_view ntupleName, std::string_view path)
    : RPageSink(ntupleName)
    , fPageAllocator(std::make_unique<RPageAllocatorHeap>())
    , fDirectory(nullptr)
@@ -55,7 +51,7 @@ RPageSinkRoot::RPageSinkRoot(std::string_view ntupleName, std::string_view path)
    fSettings.fTakeOwnership = true;
 }
 
-RPageSinkRoot::~RPageSinkRoot()
+ROOT::Experimental::Detail::RPageSinkRoot::~RPageSinkRoot()
 {
    if (fSettings.fTakeOwnership) {
       fSettings.fFile->Close();
@@ -63,7 +59,8 @@ RPageSinkRoot::~RPageSinkRoot()
    }
 }
 
-RPageStorage::ColumnHandle_t RPageSinkRoot::AddColumn(const RColumn &column)
+ROOT::Experimental::Detail::RPageStorage::ColumnHandle_t
+ROOT::Experimental::Detail::RPageSinkRoot::AddColumn(const RColumn &column)
 {
    ROOT::Experimental::Internal::RColumnHeader columnHeader;
    columnHeader.fName = column.GetModel().GetName();
@@ -79,7 +76,7 @@ RPageStorage::ColumnHandle_t RPageSinkRoot::AddColumn(const RColumn &column)
 }
 
 
-void RPageSinkRoot::Create(RNTupleModel &model)
+void ROOT::Experimental::Detail::RPageSinkRoot::Create(RNTupleModel &model)
 {
    fDirectory = fSettings.fFile->mkdir(fNTupleName.c_str());
 
@@ -106,7 +103,7 @@ void RPageSinkRoot::Create(RNTupleModel &model)
    fDirectory->WriteObject(&fNTupleHeader, RMapper::kKeyNTupleHeader);
 }
 
-void RPageSinkRoot::CommitPage(ColumnHandle_t columnHandle, const RPage &page)
+void ROOT::Experimental::Detail::RPageSinkRoot::CommitPage(ColumnHandle_t columnHandle, const RPage &page)
 {
    auto columnId = columnHandle.fId;
    ROOT::Experimental::Internal::RPagePayload pagePayload;
@@ -121,7 +118,7 @@ void RPageSinkRoot::CommitPage(ColumnHandle_t columnHandle, const RPage &page)
    fNTupleFooter.fNElementsPerColumn[columnId] += page.GetNElements();
 }
 
-void RPageSinkRoot::CommitCluster(ROOT::Experimental::NTupleSize_t nEntries)
+void ROOT::Experimental::Detail::RPageSinkRoot::CommitCluster(ROOT::Experimental::NTupleSize_t nEntries)
 {
    fCurrentCluster.fNEntries = nEntries - fPrevClusterNEntries;
    fPrevClusterNEntries = nEntries;
@@ -136,13 +133,14 @@ void RPageSinkRoot::CommitCluster(ROOT::Experimental::NTupleSize_t nEntries)
    fCurrentCluster.fEntryRangeStart = fNTupleFooter.fNEntries;
 }
 
-void RPageSinkRoot::CommitDataset()
+void ROOT::Experimental::Detail::RPageSinkRoot::CommitDataset()
 {
    if (fDirectory)
       fDirectory->WriteObject(&fNTupleFooter, RMapper::kKeyNTupleFooter);
 }
 
-RPage RPageSinkRoot::ReservePage(ColumnHandle_t columnHandle, std::size_t nElements)
+ROOT::Experimental::Detail::RPage
+ROOT::Experimental::Detail::RPageSinkRoot::ReservePage(ColumnHandle_t columnHandle, std::size_t nElements)
 {
    if (nElements == 0)
       nElements = kDefaultElementsPerPage;
@@ -150,7 +148,7 @@ RPage RPageSinkRoot::ReservePage(ColumnHandle_t columnHandle, std::size_t nEleme
    return fPageAllocator->NewPage(columnHandle.fId, elementSize, nElements);
 }
 
-void RPageSinkRoot::ReleasePage(RPage &page)
+void ROOT::Experimental::Detail::RPageSinkRoot::ReleasePage(RPage &page)
 {
    fPageAllocator->DeletePage(page);
 }
@@ -159,14 +157,16 @@ void RPageSinkRoot::ReleasePage(RPage &page)
 ////////////////////////////////////////////////////////////////////////////////
 
 
-RPage RPageAllocatorKey::NewPage(ColumnId_t columnId, void *mem, std::size_t elementSize, std::size_t nElements)
+ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageAllocatorKey::NewPage(
+   ColumnId_t columnId, void *mem, std::size_t elementSize, std::size_t nElements)
 {
    RPage newPage(columnId, mem, elementSize * nElements, elementSize);
    newPage.TryGrow(nElements);
    return newPage;
 }
 
-void RPageAllocatorKey::DeletePage(const RPage& page, ROOT::Experimental::Internal::RPagePayload *payload)
+void ROOT::Experimental::Detail::RPageAllocatorKey::DeletePage(
+   const RPage& page, ROOT::Experimental::Internal::RPagePayload *payload)
 {
    if (page.IsNull())
       return;
@@ -179,7 +179,7 @@ void RPageAllocatorKey::DeletePage(const RPage& page, ROOT::Experimental::Intern
 ////////////////////////////////////////////////////////////////////////////////
 
 
-RPageSourceRoot::RPageSourceRoot(std::string_view ntupleName, RSettings settings)
+ROOT::Experimental::Detail::RPageSourceRoot::RPageSourceRoot(std::string_view ntupleName, RSettings settings)
    : RPageSource(ntupleName)
    , fPageAllocator(std::make_unique<RPageAllocatorKey>())
    , fPagePool(std::make_shared<RPagePool>())
@@ -188,7 +188,7 @@ RPageSourceRoot::RPageSourceRoot(std::string_view ntupleName, RSettings settings
 {
 }
 
-RPageSourceRoot::RPageSourceRoot(std::string_view ntupleName, std::string_view path)
+ROOT::Experimental::Detail::RPageSourceRoot::RPageSourceRoot(std::string_view ntupleName, std::string_view path)
    : RPageSource(ntupleName)
    , fPageAllocator(std::make_unique<RPageAllocatorKey>())
    , fPagePool(std::make_shared<RPagePool>())
@@ -200,7 +200,7 @@ RPageSourceRoot::RPageSourceRoot(std::string_view ntupleName, std::string_view p
 }
 
 
-RPageSourceRoot::~RPageSourceRoot()
+ROOT::Experimental::Detail::RPageSourceRoot::~RPageSourceRoot()
 {
    if (fSettings.fTakeOwnership) {
       fSettings.fFile->Close();
@@ -209,7 +209,8 @@ RPageSourceRoot::~RPageSourceRoot()
 }
 
 
-RPageStorage::ColumnHandle_t RPageSourceRoot::AddColumn(const RColumn &column)
+ROOT::Experimental::Detail::RPageStorage::ColumnHandle_t
+ROOT::Experimental::Detail::RPageSourceRoot::AddColumn(const RColumn &column)
 {
    auto& model = column.GetModel();
    auto columnId = fMapper.fColumnName2Id[model.GetName()];
@@ -221,7 +222,7 @@ RPageStorage::ColumnHandle_t RPageSourceRoot::AddColumn(const RColumn &column)
 }
 
 
-void RPageSourceRoot::Attach()
+void ROOT::Experimental::Detail::RPageSourceRoot::Attach()
 {
    fDirectory = fSettings.fFile->GetDirectory(fNTupleName.c_str());
    auto keyNTupleHeader = fDirectory->GetKey(RMapper::kKeyNTupleHeader);
@@ -304,7 +305,7 @@ void RPageSourceRoot::Attach()
 }
 
 
-std::unique_ptr<ROOT::Experimental::RNTupleModel> RPageSourceRoot::GenerateModel()
+std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::Detail::RPageSourceRoot::GenerateModel()
 {
    auto model = std::make_unique<RNTupleModel>();
    for (auto& f : fMapper.fRootFields) {
@@ -314,7 +315,8 @@ std::unique_ptr<ROOT::Experimental::RNTupleModel> RPageSourceRoot::GenerateModel
    return model;
 }
 
-RPage RPageSourceRoot::PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t index)
+ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceRoot::PopulatePage(
+   ColumnHandle_t columnHandle, NTupleSize_t index)
 {
    auto columnId = columnHandle.fId;
    auto cachedPage = fPagePool->GetPage(columnId, index);
@@ -377,27 +379,23 @@ RPage RPageSourceRoot::PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t in
    return newPage;
 }
 
-void RPageSourceRoot::ReleasePage(RPage &page)
+void ROOT::Experimental::Detail::RPageSourceRoot::ReleasePage(RPage &page)
 {
    fPagePool->ReturnPage(page);
 }
 
-ROOT::Experimental::NTupleSize_t RPageSourceRoot::GetNEntries()
+ROOT::Experimental::NTupleSize_t ROOT::Experimental::Detail::RPageSourceRoot::GetNEntries()
 {
    return fMapper.fNEntries;
 }
 
-ROOT::Experimental::NTupleSize_t RPageSourceRoot::GetNElements(ColumnHandle_t columnHandle)
+ROOT::Experimental::NTupleSize_t ROOT::Experimental::Detail::RPageSourceRoot::GetNElements(ColumnHandle_t columnHandle)
 {
    return fMapper.fColumnIndex[columnHandle.fId].fNElements;
 }
 
-ROOT::Experimental::ColumnId_t RPageSourceRoot::GetColumnId(ColumnHandle_t columnHandle)
+ROOT::Experimental::ColumnId_t ROOT::Experimental::Detail::RPageSourceRoot::GetColumnId(ColumnHandle_t columnHandle)
 {
    // TODO(jblomer) distinguish trees
    return columnHandle.fId;
 }
-
-} // namespace Detail
-} // namespace Exprimental
-} // namespace ROOT

--- a/tree/ntuple/v7/src/RPageStorageRoot.cxx
+++ b/tree/ntuple/v7/src/RPageStorageRoot.cxx
@@ -60,34 +60,34 @@ ROOT::Experimental::Detail::RPageSinkRoot::~RPageSinkRoot()
 }
 
 ROOT::Experimental::Detail::RPageStorage::ColumnHandle_t
-ROOT::Experimental::Detail::RPageSinkRoot::AddColumn(RColumn* column)
+ROOT::Experimental::Detail::RPageSinkRoot::AddColumn(const RColumn &column)
 {
    ROOT::Experimental::Internal::RColumnHeader columnHeader;
-   columnHeader.fName = column->GetModel().GetName();
-   columnHeader.fType = column->GetModel().GetType();
-   columnHeader.fIsSorted = column->GetModel().GetIsSorted();
-   if (column->GetOffsetColumn() != nullptr) {
-      columnHeader.fOffsetColumn = column->GetOffsetColumn()->GetModel().GetName();
+   columnHeader.fName = column.GetModel().GetName();
+   columnHeader.fType = column.GetModel().GetType();
+   columnHeader.fIsSorted = column.GetModel().GetIsSorted();
+   if (column.GetOffsetColumn() != nullptr) {
+      columnHeader.fOffsetColumn = column.GetOffsetColumn()->GetModel().GetName();
    }
    auto columnId = fNTupleHeader.fColumns.size();
    fNTupleHeader.fColumns.emplace_back(columnHeader);
    //printf("Added column %s type %d\n", columnHeader.fName.c_str(), (int)columnHeader.fType);
-   return ColumnHandle_t(columnId, column);
+   return ColumnHandle_t(columnId, &column);
 }
 
 
-void ROOT::Experimental::Detail::RPageSinkRoot::Create(RNTupleModel *model)
+void ROOT::Experimental::Detail::RPageSinkRoot::Create(RNTupleModel &model)
 {
    fNTupleHeader.fPageSize = kPageSize;
    fDirectory = fSettings.fFile->mkdir(fNTupleName.c_str());
 
    unsigned int nColumns = 0;
-   for (auto& f : *model->GetRootField()) {
+   for (const auto& f : *model.GetRootField()) {
       nColumns += f.GetNColumns();
    }
    fPagePool = std::make_unique<RPagePool>(fNTupleHeader.fPageSize, nColumns);
 
-   for (auto& f : *model->GetRootField()) {
+   for (auto& f : *model.GetRootField()) {
       ROOT::Experimental::Internal::RFieldHeader fieldHeader;
       fieldHeader.fName = f.GetName();
       fieldHeader.fType = f.GetType();
@@ -174,15 +174,15 @@ ROOT::Experimental::Detail::RPageSourceRoot::~RPageSourceRoot()
 
 
 ROOT::Experimental::Detail::RPageStorage::ColumnHandle_t
-ROOT::Experimental::Detail::RPageSourceRoot::AddColumn(RColumn* column)
+ROOT::Experimental::Detail::RPageSourceRoot::AddColumn(const RColumn &column)
 {
-   auto& model = column->GetModel();
+   auto& model = column.GetModel();
    auto columnId = fMapper.fColumnName2Id[model.GetName()];
    R__ASSERT(model == *fMapper.fId2ColumnModel[columnId]);
    //printf("Attaching column %s id %d type %d length %lu\n",
    //   column->GetModel().GetName().c_str(), columnId, (int)(column->GetModel().GetType()),
    //   fMapper.fColumnIndex[columnId].fNElements);
-   return ColumnHandle_t(columnId, column);
+   return ColumnHandle_t(columnId, &column);
 }
 
 

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -11,3 +11,4 @@ ROOT_STANDARD_LIBRARY_PACKAGE(CustomStruct
                               LINKDEF CustomStructLinkDef.h
                               DEPENDENCIES RIO)
 ROOT_ADD_GTEST(ntuple ntuple.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)
+ROOT_ADD_GTEST(ntuple_pages ntuple_pages.cxx LIBRARIES ROOTNTuple)

--- a/tree/ntuple/v7/test/ntuple.cxx
+++ b/tree/ntuple/v7/test/ntuple.cxx
@@ -65,7 +65,7 @@ TEST(RNTuple, ReconstructModel)
    auto fieldKlass = model->MakeField<CustomStruct>("klass");
    {
       RPageSinkRoot sinkRoot("myTree", "test.root");
-      sinkRoot.Create(model.get());
+      sinkRoot.Create(*model.get());
       sinkRoot.CommitDataset();
    }
 
@@ -97,7 +97,7 @@ TEST(RNTuple, StorageRoot)
    auto fieldJet = model->MakeField<std::vector<float>>("jets" /* TODO(jblomer), {1.0, 2.0}*/);
    auto nnlo = model->MakeField<std::vector<std::vector<float>>>("nnlo");
 
-   sinkRoot.Create(model.get());
+   sinkRoot.Create(*model.get());
    sinkRoot.CommitDataset();
    file->Close();
 

--- a/tree/ntuple/v7/test/ntuple.cxx
+++ b/tree/ntuple/v7/test/ntuple.cxx
@@ -67,6 +67,7 @@ TEST(RNTuple, ReconstructModel)
       RPageSinkRoot sinkRoot("myTree", "test.root");
       sinkRoot.Create(*model.get());
       sinkRoot.CommitDataset();
+      model = nullptr;
    }
 
    RPageSourceRoot sourceRoot("myTree", "test.root");

--- a/tree/ntuple/v7/test/ntuple_pages.cxx
+++ b/tree/ntuple/v7/test/ntuple_pages.cxx
@@ -1,0 +1,5 @@
+#include "gtest/gtest.h"
+
+TEST(Pages, Basics)
+{
+}

--- a/tree/ntuple/v7/test/ntuple_pages.cxx
+++ b/tree/ntuple/v7/test/ntuple_pages.cxx
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 
 #include <ROOT/RPageAllocator.hxx>
+#include <ROOT/RPagePool.hxx>
 
 TEST(Pages, Allocation)
 {
@@ -11,8 +12,33 @@ TEST(Pages, Allocation)
    EXPECT_EQ(64U, page.GetCapacity());
    EXPECT_EQ(0U, page.GetNElements());
    EXPECT_EQ(0U, page.GetSize());
-
    allocator.DeletePage(page);
+}
+
+TEST(Pages, Pool)
+{
+   ROOT::Experimental::Detail::RPagePool pool;
+
+   auto page = pool.GetPage(0, 0);
    EXPECT_TRUE(page.IsNull());
-   EXPECT_EQ(0U, page.GetCapacity());
+   EXPECT_FALSE(pool.ReturnPage(page));
+
+   ROOT::Experimental::Detail::RPage::RClusterInfo clusterInfo;
+   page = ROOT::Experimental::Detail::RPage(1, &page, 10, 1);
+   EXPECT_NE(nullptr, page.TryGrow(10));
+   page.SetWindow(50, clusterInfo);
+   EXPECT_FALSE(page.IsNull());
+   pool.RegisterPage(page);
+
+   page = pool.GetPage(0, 0);
+   EXPECT_TRUE(page.IsNull());
+   page = pool.GetPage(0, 55);
+   EXPECT_TRUE(page.IsNull());
+   page = pool.GetPage(1, 55);
+   EXPECT_FALSE(page.IsNull());
+   EXPECT_EQ(50U, page.GetRangeFirst());
+   EXPECT_EQ(59U, page.GetRangeLast());
+
+   EXPECT_FALSE(pool.ReturnPage(page));
+   EXPECT_TRUE(pool.ReturnPage(page));
 }

--- a/tree/ntuple/v7/test/ntuple_pages.cxx
+++ b/tree/ntuple/v7/test/ntuple_pages.cxx
@@ -1,5 +1,18 @@
 #include "gtest/gtest.h"
 
-TEST(Pages, Basics)
+#include <ROOT/RPageAllocator.hxx>
+
+TEST(Pages, Allocation)
 {
+   ROOT::Experimental::Detail::RPageAllocatorHeap allocator;
+
+   auto page = allocator.AllocatePage(42, 4, 16);
+   EXPECT_FALSE(page.IsNull());
+   EXPECT_EQ(64U, page.GetCapacity());
+   EXPECT_EQ(0U, page.GetNElements());
+   EXPECT_EQ(0U, page.GetSize());
+
+   allocator.ReleasePage(page);
+   EXPECT_TRUE(page.IsNull());
+   EXPECT_EQ(0U, page.GetCapacity());
 }

--- a/tree/ntuple/v7/test/ntuple_pages.cxx
+++ b/tree/ntuple/v7/test/ntuple_pages.cxx
@@ -34,7 +34,7 @@ TEST(Pages, Pool)
    page.SetWindow(50, clusterInfo);
    EXPECT_FALSE(page.IsNull());
    unsigned int nCallDeleter = 0;
-   pool.RegisterPage(page, RPageDeleter([&nCallDeleter](const RPage &/*page*/, void */*userData*/) {
+   pool.RegisterPage(page, RPageDeleter([&nCallDeleter](const RPage & /*page*/, void * /*userData*/) {
       nCallDeleter++;
    }));
 

--- a/tree/ntuple/v7/test/ntuple_pages.cxx
+++ b/tree/ntuple/v7/test/ntuple_pages.cxx
@@ -41,4 +41,6 @@ TEST(Pages, Pool)
 
    EXPECT_FALSE(pool.ReturnPage(page));
    EXPECT_TRUE(pool.ReturnPage(page));
+   page = pool.GetPage(1, 55);
+   EXPECT_TRUE(page.IsNull());
 }

--- a/tree/ntuple/v7/test/ntuple_pages.cxx
+++ b/tree/ntuple/v7/test/ntuple_pages.cxx
@@ -6,13 +6,13 @@ TEST(Pages, Allocation)
 {
    ROOT::Experimental::Detail::RPageAllocatorHeap allocator;
 
-   auto page = allocator.AllocatePage(42, 4, 16);
+   auto page = allocator.NewPage(42, 4, 16);
    EXPECT_FALSE(page.IsNull());
    EXPECT_EQ(64U, page.GetCapacity());
    EXPECT_EQ(0U, page.GetNElements());
    EXPECT_EQ(0U, page.GetSize());
 
-   allocator.ReleasePage(page);
+   allocator.DeletePage(page);
    EXPECT_TRUE(page.IsNull());
    EXPECT_EQ(0U, page.GetCapacity());
 }


### PR DESCRIPTION
Change primary responsible for page memory management from page pool to page storage. This is a preparation for asynchronous interfaces.

In the new scheme, RColumn uses `RPageStorage::ReservePage` (writing) or `RPageStorage::PopulatePage` (reading) to allocate pages and `RPageStorage::ReleasePage` for freeing them.  The page storage, in turn, may use a shared page pool.  In this case, ownership of a page's memory is transferred to the page pool, which will free a page if there are no further users.

Addresses ROOT-10205