### PR TITLE
[cxxmodules] Implement global module indexing to improve performance.

### DIFF
--- a/.ci/format_script.sh
+++ b/.ci/format_script.sh
@@ -22,7 +22,9 @@ else
   echo -e "\n\nPlease apply the code formatting changes without bloating the history."
   echo -e "\tConsider running:"
   echo -e "\t\tgit checkout $TRAVIS_BRANCH"
-  echo -e "\t\tgit rebase -i --autosquash -x 'git-clang-format-7 master && git commit -a --amend --no-edit' master"
+  echo -e "\t\tgit rebase -i -x \"git-clang-format-7 master && git commit -a --allow-empty --fixup=HEAD\" --strategy-option=theirs origin/master"
+  echo -e "\t Then inspect the results with git log --oneline"
+  echo -e "\t Then squash without poluting the history with: git rebase --autosquash -i master"
 
   exit 1
 fi

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1170,7 +1170,7 @@ static void RegisterCommonCxxModules(cling::Interpreter &clingInterp)
       LoadModules(CommonModules, clingInterp);
 
       // These modules should not be preloaded but they fix issues.
-      std::vector<std::string> FIXMEModules = {"Hist", "Gpad", "Graf"};
+      std::vector<std::string> FIXMEModules = {"Hist", "Gpad", "Graf", "GenVector"};
       LoadModules(FIXMEModules, clingInterp);
 
       loadGlobalModuleIndex(SourceLocation(), clingInterp);

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1169,7 +1169,10 @@ static void RegisterCommonCxxModules(cling::Interpreter &clingInterp)
       LoadModules(CommonModules, clingInterp);
 
       // These modules should not be preloaded but they fix issues.
-      std::vector<std::string> FIXMEModules = {"Hist", "Gpad", "Graf", "GenVector", "Tree", "Physics"};
+      std::vector<std::string> FIXMEModules = {"Hist", "Gpad", "Graf",
+                                               "GenVector", "Smatrix", "Tree",
+                                               "TreePlayer", "Physics",
+                                               "Proof", "Geom"};
       LoadModules(FIXMEModules, clingInterp);
 
       loadGlobalModuleIndex(SourceLocation(), clingInterp);

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1170,7 +1170,7 @@ static void RegisterCommonCxxModules(cling::Interpreter &clingInterp)
       LoadModules(CommonModules, clingInterp);
 
       // These modules should not be preloaded but they fix issues.
-      std::vector<std::string> FIXMEModules = {"Hist", "Gpad"};
+      std::vector<std::string> FIXMEModules = {"Hist", "Gpad", "Graf"};
       LoadModules(FIXMEModules, clingInterp);
 
       loadGlobalModuleIndex(SourceLocation(), clingInterp);

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1169,7 +1169,7 @@ static void RegisterCommonCxxModules(cling::Interpreter &clingInterp)
       LoadModules(CommonModules, clingInterp);
 
       // These modules should not be preloaded but they fix issues.
-      std::vector<std::string> FIXMEModules = {"Hist", "Gpad", "Graf", "GenVector", "Tree"};
+      std::vector<std::string> FIXMEModules = {"Hist", "Gpad", "Graf", "GenVector", "Tree", "Physics"};
       LoadModules(FIXMEModules, clingInterp);
 
       loadGlobalModuleIndex(SourceLocation(), clingInterp);

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1169,7 +1169,7 @@ static void RegisterCommonCxxModules(cling::Interpreter &clingInterp)
       LoadModules(CommonModules, clingInterp);
 
       // These modules should not be preloaded but they fix issues.
-      std::vector<std::string> FIXMEModules = {"Hist", "Gpad", "Graf", "GenVector"};
+      std::vector<std::string> FIXMEModules = {"Hist", "Gpad", "Graf", "GenVector", "Tree"};
       LoadModules(FIXMEModules, clingInterp);
 
       loadGlobalModuleIndex(SourceLocation(), clingInterp);

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1170,7 +1170,7 @@ static void RegisterCommonCxxModules(cling::Interpreter &clingInterp)
       LoadModules(CommonModules, clingInterp);
 
       // These modules should not be preloaded but they fix issues.
-      std::vector<std::string> FIXMEModules = {"Gpad"};
+      std::vector<std::string> FIXMEModules = {"Hist", "Gpad"};
       LoadModules(FIXMEModules, clingInterp);
 
       loadGlobalModuleIndex(SourceLocation(), clingInterp);

--- a/core/metacling/src/TClingCallbacks.cxx
+++ b/core/metacling/src/TClingCallbacks.cxx
@@ -384,8 +384,8 @@ bool TClingCallbacks::LookupObject(clang::TagDecl* Tag) {
    // Clang needs Tag's complete definition. Can we parse it?
    if (fIsAutoLoadingRecursively || fIsAutoParsingSuspended) return false;
 
-   if (findInGlobalModuleIndex(Tag->getDeclName(), /*loadFirstMatchOnly*/ false))
-      return true;
+   // if (findInGlobalModuleIndex(Tag->getDeclName(), /*loadFirstMatchOnly*/false))
+   //    return true;
 
    Sema &SemaR = m_Interpreter->getSema();
 

--- a/core/metacling/src/TClingCallbacks.cxx
+++ b/core/metacling/src/TClingCallbacks.cxx
@@ -76,11 +76,11 @@ extern "C" {
                                     cling::Interpreter &interpreter, bool searchSystem);
 }
 
-TClingCallbacks::TClingCallbacks(cling::Interpreter* interp, bool hasCodeGen)
-   : InterpreterCallbacks(interp),
-     fLastLookupCtx(0), fROOTSpecialNamespace(0),
-     fFirstRun(true), fIsAutoLoading(false), fIsAutoLoadingRecursively(false),
-     fIsAutoParsingSuspended(false), fPPOldFlag(false), fPPChanged(false) {
+TClingCallbacks::TClingCallbacks(cling::Interpreter *interp, bool hasCodeGen)
+   : InterpreterCallbacks(interp), fLastLookupCtx(0), fROOTSpecialNamespace(0), fFirstRun(true), fIsAutoloading(false),
+     fIsAutoloadingRecursively(false), fIsAutoParsingSuspended(false), fPPOldFlag(false), fPPChanged(false),
+     fIsCodeGening(false)
+{
    if (hasCodeGen) {
       Transaction* T = 0;
       m_Interpreter->declare("namespace __ROOT_SpecialObjects{}", &T);
@@ -322,6 +322,8 @@ bool TClingCallbacks::LookupObject(const DeclContext* DC, DeclarationName Name) 
    const LangOptions &LangOpts = SemaR.getPreprocessor().getLangOpts();
    if (LangOpts.Modules) {
       if (LangOpts.isCompilingModule())
+         return false;
+      if (fIsCodeGening)
          return false;
 
       // FIXME: We should load only the first available and rely on other callbacks

--- a/core/metacling/src/TClingCallbacks.cxx
+++ b/core/metacling/src/TClingCallbacks.cxx
@@ -76,10 +76,7 @@ extern "C" {
                                     cling::Interpreter &interpreter, bool searchSystem);
 }
 
-TClingCallbacks::TClingCallbacks(cling::Interpreter *interp, bool hasCodeGen)
-   : InterpreterCallbacks(interp), fLastLookupCtx(0), fROOTSpecialNamespace(0), fFirstRun(true), fIsAutoloading(false),
-     fIsAutoloadingRecursively(false), fIsAutoParsingSuspended(false), fPPOldFlag(false), fPPChanged(false),
-     fIsCodeGening(false)
+TClingCallbacks::TClingCallbacks(cling::Interpreter *interp, bool hasCodeGen) : InterpreterCallbacks(interp)
 {
    if (hasCodeGen) {
       Transaction* T = 0;

--- a/core/metacling/src/TClingCallbacks.cxx
+++ b/core/metacling/src/TClingCallbacks.cxx
@@ -284,7 +284,7 @@ bool TClingCallbacks::LookupObject(LookupResult &R, Scope *S) {
    return tryResolveAtRuntimeInternal(R, S);
 }
 
-bool TClingCallbacks::findInGlobalModuleIndex(DeclarationName Name, bool loadFirstMatchOnly /*=true*/) const
+bool TClingCallbacks::findInGlobalModuleIndex(DeclarationName Name, bool loadFirstMatchOnly /*=true*/)
 {
    const CompilerInstance *CI = m_Interpreter->getCI();
    const LangOptions &LangOpts = CI->getPreprocessor().getLangOpts();
@@ -312,7 +312,9 @@ bool TClingCallbacks::findInGlobalModuleIndex(DeclarationName Name, bool loadFir
    if (Index->lookupIdentifier(Name.getAsString(), FoundModules)) {
       for (auto FileName : FoundModules) {
          StringRef ModuleName = llvm::sys::path::stem(*FileName);
+         fIsLoadingModule = true;
          m_Interpreter->loadModule(ModuleName);
+         fIsLoadingModule = false;
          if (loadFirstMatchOnly)
             break;
       }
@@ -326,6 +328,9 @@ bool TClingCallbacks::LookupObject(const DeclContext* DC, DeclarationName Name) 
       // init error or rootcling
       return false;
    }
+
+   if (fIsLoadingModule)
+      return false;
 
    if (!IsAutoLoadingEnabled() || fIsAutoLoadingRecursively) return false;
 
@@ -380,6 +385,9 @@ bool TClingCallbacks::LookupObject(clang::TagDecl* Tag) {
       // init error or rootcling
       return false;
    }
+
+   if (fIsLoadingModule)
+      return false;
 
    // Clang needs Tag's complete definition. Can we parse it?
    if (fIsAutoLoadingRecursively || fIsAutoParsingSuspended) return false;

--- a/core/metacling/src/TClingCallbacks.h
+++ b/core/metacling/src/TClingCallbacks.h
@@ -47,6 +47,7 @@ private:
    bool fPPOldFlag = false;
    bool fPPChanged = false;
    bool fIsCodeGening = false;
+   bool fIsLoadingModule = false;
 
 public:
    TClingCallbacks(cling::Interpreter* interp, bool hasCodeGen);
@@ -130,5 +131,5 @@ private:
    bool tryResolveAtRuntimeInternal(clang::LookupResult &R, clang::Scope *S);
    bool shouldResolveAtRuntime(clang::LookupResult &R, clang::Scope *S);
    bool tryInjectImplicitAutoKeyword(clang::LookupResult &R, clang::Scope *S);
-   bool findInGlobalModuleIndex(clang::DeclarationName Name, bool loadFirstMatchOnly = true) const;
+   bool findInGlobalModuleIndex(clang::DeclarationName Name, bool loadFirstMatchOnly = true);
 };

--- a/core/metacling/src/TClingCallbacks.h
+++ b/core/metacling/src/TClingCallbacks.h
@@ -37,15 +37,15 @@ namespace llvm {
 //
 class TClingCallbacks : public cling::InterpreterCallbacks {
 private:
-   void *fLastLookupCtx;
-   clang::NamespaceDecl *fROOTSpecialNamespace;
-   bool fFirstRun;
-   bool fIsAutoLoading;
-   bool fIsAutoLoadingRecursively;
-   bool fIsAutoParsingSuspended;
-   bool fPPOldFlag;
-   bool fPPChanged;
-   bool fIsCodeGening;
+   void *fLastLookupCtx = nullptr;
+   clang::NamespaceDecl *fROOTSpecialNamespace = nullptr;
+   bool fFirstRun = true;
+   bool fIsAutoLoading = false;
+   bool fIsAutoLoadingRecursively = false;
+   bool fIsAutoParsingSuspended = false;
+   bool fPPOldFlag = false;
+   bool fPPChanged = false;
+   bool fIsCodeGening = false;
 
 public:
    TClingCallbacks(cling::Interpreter* interp, bool hasCodeGen);

--- a/core/metacling/src/TClingCallbacks.h
+++ b/core/metacling/src/TClingCallbacks.h
@@ -15,6 +15,7 @@
 
 namespace clang {
    class Decl;
+   class DeclarationName;
    class LookupResult;
    class NamespaceDecl;
    class Scope;
@@ -129,4 +130,5 @@ private:
    bool tryResolveAtRuntimeInternal(clang::LookupResult &R, clang::Scope *S);
    bool shouldResolveAtRuntime(clang::LookupResult &R, clang::Scope *S);
    bool tryInjectImplicitAutoKeyword(clang::LookupResult &R, clang::Scope *S);
+   bool findInGlobalModuleIndex(clang::DeclarationName Name, bool loadFirstMatchOnly = true) const;
 };

--- a/core/metacling/src/TClingCallbacks.h
+++ b/core/metacling/src/TClingCallbacks.h
@@ -60,36 +60,29 @@ public:
    void SetAutoParsingSuspended(bool val = true) { fIsAutoParsingSuspended = val; }
    bool IsAutoParsingSuspended() { return fIsAutoParsingSuspended; }
 
-   virtual bool LibraryLoadingFailed(const std::string&, const std::string&, bool, bool);
+   bool LibraryLoadingFailed(const std::string &, const std::string &, bool, bool) override;
 
-   virtual void InclusionDirective(clang::SourceLocation /*HashLoc*/,
-                                   const clang::Token &/*IncludeTok*/,
-                                   llvm::StringRef FileName,
-                                   bool /*IsAngled*/,
-                                   clang::CharSourceRange /*FilenameRange*/,
-                                   const clang::FileEntry * /*File*/,
-                                   llvm::StringRef /*SearchPath*/,
-                                   llvm::StringRef /*RelativePath*/,
-                                   const clang::Module * /*Imported*/);
+   void InclusionDirective(clang::SourceLocation /*HashLoc*/, const clang::Token & /*IncludeTok*/,
+                           llvm::StringRef FileName, bool /*IsAngled*/, clang::CharSourceRange /*FilenameRange*/,
+                           const clang::FileEntry * /*File*/, llvm::StringRef /*SearchPath*/,
+                           llvm::StringRef /*RelativePath*/, const clang::Module * /*Imported*/) override;
 
    // Preprocessor callbacks used to handle special cases like for example:
    // #include "myMacro.C+"
    //
-   virtual bool FileNotFound(llvm::StringRef FileName,
-                             llvm::SmallVectorImpl<char>& RecoveryPath);
+   bool FileNotFound(llvm::StringRef FileName, llvm::SmallVectorImpl<char> &RecoveryPath) override;
 
-   virtual bool LookupObject(clang::LookupResult &R, clang::Scope *S);
-   virtual bool LookupObject(const clang::DeclContext* DC,
-                             clang::DeclarationName Name);
-   virtual bool LookupObject(clang::TagDecl* Tag);
+   bool LookupObject(clang::LookupResult &R, clang::Scope *S) override;
+   bool LookupObject(const clang::DeclContext *DC, clang::DeclarationName Name) override;
+   bool LookupObject(clang::TagDecl *Tag) override;
 
    // The callback is used to update the list of globals in ROOT.
    //
-   virtual void TransactionCommitted(const cling::Transaction &T);
+   void TransactionCommitted(const cling::Transaction &T) override;
 
    // The callback is used to inform ROOT when cling started code generation.
    //
-   virtual void TransactionCodeGenStarted(const cling::Transaction &T)
+   void TransactionCodeGenStarted(const cling::Transaction &T) override
    {
       assert(!fIsCodeGening);
       fIsCodeGening = true;
@@ -97,7 +90,7 @@ public:
 
    // The callback is used to inform ROOT when cling finished code generation.
    //
-   virtual void TransactionCodeGenFinished(const cling::Transaction &T)
+   void TransactionCodeGenFinished(const cling::Transaction &T) override
    {
       assert(fIsCodeGening);
       fIsCodeGening = false;
@@ -105,31 +98,29 @@ public:
 
    // The callback is used to update the list of globals in ROOT.
    //
-   virtual void TransactionUnloaded(const cling::Transaction &T);
+   void TransactionUnloaded(const cling::Transaction &T) override;
 
    // The callback is used to clear the autoparsing caches.
    //
-   virtual void TransactionRollback(const cling::Transaction &T);
+   void TransactionRollback(const cling::Transaction &T) override;
 
    ///\brief A previous definition has been shadowed; invalidate TCling' stored
    /// data about the old (global) decl.
-   virtual void DefinitionShadowed(const clang::NamedDecl *D);
+   void DefinitionShadowed(const clang::NamedDecl *D) override;
 
    // Used to inform client about a new decl read by the ASTReader.
    //
-   virtual void DeclDeserialized(const clang::Decl* D);
+   void DeclDeserialized(const clang::Decl *D) override;
 
-   virtual void LibraryLoaded(const void* dyLibHandle,
-                              llvm::StringRef canonicalName);
-   virtual void LibraryUnloaded(const void* dyLibHandle,
-                                llvm::StringRef canonicalName);
+   void LibraryLoaded(const void *dyLibHandle, llvm::StringRef canonicalName) override;
+   void LibraryUnloaded(const void *dyLibHandle, llvm::StringRef canonicalName) override;
 
-   virtual void PrintStackTrace();
+   void PrintStackTrace() override;
 
-   virtual void *EnteringUserCode();
-   virtual void ReturnedFromUserCode(void *stateInfo);
-   virtual void *LockCompilationDuringUserCodeExecution();
-   virtual void UnlockCompilationDuringUserCodeExecution(void *StateInfo);
+   void *EnteringUserCode() override;
+   void ReturnedFromUserCode(void *stateInfo) override;
+   void *LockCompilationDuringUserCodeExecution() override;
+   void UnlockCompilationDuringUserCodeExecution(void *StateInfo) override;
 
 private:
    bool tryAutoParseInternal(llvm::StringRef Name, clang::LookupResult &R,

--- a/core/metacling/src/TClingCallbacks.h
+++ b/core/metacling/src/TClingCallbacks.h
@@ -45,6 +45,8 @@ private:
    bool fIsAutoParsingSuspended;
    bool fPPOldFlag;
    bool fPPChanged;
+   bool fIsCodeGening;
+
 public:
    TClingCallbacks(cling::Interpreter* interp, bool hasCodeGen);
 
@@ -84,6 +86,22 @@ public:
    // The callback is used to update the list of globals in ROOT.
    //
    virtual void TransactionCommitted(const cling::Transaction &T);
+
+   // The callback is used to inform ROOT when cling started code generation.
+   //
+   virtual void TransactionCodeGenStarted(const cling::Transaction &T)
+   {
+      assert(!fIsCodeGening);
+      fIsCodeGening = true;
+   }
+
+   // The callback is used to inform ROOT when cling finished code generation.
+   //
+   virtual void TransactionCodeGenFinished(const cling::Transaction &T)
+   {
+      assert(fIsCodeGening);
+      fIsCodeGening = false;
+   }
 
    // The callback is used to update the list of globals in ROOT.
    //

--- a/interpreter/cling/include/cling/Interpreter/InterpreterCallbacks.h
+++ b/interpreter/cling/include/cling/Interpreter/InterpreterCallbacks.h
@@ -141,6 +141,20 @@ namespace cling {
     ///
     virtual void TransactionCommitted(const Transaction&) {}
 
+    /// This callback is invoked whenever interpreter has started code
+    /// generation for the transaction.
+    ///
+    ///\param[in] - The transaction that is being codegen-ed.
+    ///
+    virtual void TransactionCodeGenStarted(const Transaction&) {}
+
+    /// This callback is invoked whenever interpreter has finished code
+    /// generation for the transaction.
+    ///
+    ///\param[in] - The transaction that is being codegen-ed.
+    ///
+    virtual void TransactionCodeGenFinished(const Transaction&) {}
+
     ///\brief This callback is invoked whenever interpreter has reverted a
     /// transaction that has been fully committed.
     ///

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -547,17 +547,15 @@ namespace {
     for (StringRef ModulePath : Paths) {
       // FIXME: If we have a prebuilt module path that is equal to our module
       // cache we fail to compile the clang builtin modules for some reason.
-      // This can't be reproduced in clang, so I assume we have some strange
-      // error in our interpreter setup where this is causing errors (or maybe
-      // clang is doing the same check in some hidden place).
-      // The error looks like this:
-      //   .../include/stddef.h error: unknown type name '__PTRDIFF_TYPE__'
-      //   typedef __PTRDIFF_TYPE__ ptrdiff_t;
-      //   <similar follow up errors>
+      // This makes clang to think it failed to build a dependency module, i.e.
+      // if we are building module C, clang goes off and builds B and A first.
+      // If the module cache points to the same location as the prebuilt module
+      // path, clang errors out on building module A, however, it builds it.
+      // Next time we run, it will build module B and issue diagnostics.
+      // If we run third time, it'd build successfully C and continue.
       // For now it is fixed by just checking those two paths are not identical.
-      if (normalizePath(ModulePath) != normalizePath(Opts.ModuleCachePath)) {
+      if (normalizePath(ModulePath) != normalizePath(Opts.ModuleCachePath))
         Opts.AddPrebuiltModulePath(ModulePath);
-      }
     }
   }
 

--- a/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
@@ -657,6 +657,9 @@ namespace cling {
     // This llvm::Module is done; finalize it and pass it to the execution
     // engine.
     if (!T->isNestedTransaction() && hasCodeGenerator()) {
+      if (InterpreterCallbacks* callbacks = m_Interpreter->getCallbacks())
+        callbacks->TransactionCodeGenStarted(*T);
+
       // The initializers are emitted to the symbol "_GLOBAL__sub_I_" + filename.
       // Make that unique!
       deserT = beginTransaction(CompilationOptions());
@@ -677,6 +680,9 @@ namespace cling {
         Diags.Reset(/*soft=*/true);
         Diags.getClient()->clear();
       }
+
+      if (InterpreterCallbacks* callbacks = m_Interpreter->getCallbacks())
+        callbacks->TransactionCodeGenFinished(*T);
 
       // Create a new module.
       StartModule();

--- a/interpreter/cling/lib/Interpreter/MultiplexInterpreterCallbacks.h
+++ b/interpreter/cling/lib/Interpreter/MultiplexInterpreterCallbacks.h
@@ -83,6 +83,18 @@ namespace cling {
        }
      }
 
+     void TransactionCodeGenStarted(const Transaction& T) override {
+       for (auto&& cb : m_Callbacks) {
+         cb->TransactionCodeGenStarted(T);
+       }
+     }
+
+     void TransactionCodeGenFinished(const Transaction& T) override {
+       for (auto&& cb : m_Callbacks) {
+         cb->TransactionCodeGenFinished(T);
+       }
+     }
+
      bool LibraryLoadingFailed(const std::string& errmessage, const std::string& libStem, bool permanent,
          bool resolved) override {
        for (auto&& cb : m_Callbacks) {

--- a/interpreter/llvm/src/tools/clang/include/clang/Serialization/GlobalModuleIndex.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/Serialization/GlobalModuleIndex.h
@@ -45,6 +45,7 @@ namespace serialization {
 using llvm::SmallVector;
 using llvm::SmallVectorImpl;
 using llvm::StringRef;
+using llvm::StringSet;
 using serialization::ModuleFile;
 
 /// \brief A global index for a set of module files, providing information about
@@ -159,6 +160,8 @@ public:
   /// \param ModuleFiles Will be populated with the set of module files that
   /// have been indexed.
   void getKnownModules(SmallVectorImpl<ModuleFile *> &ModuleFiles);
+
+  void getKnownModuleFileNames(StringSet<> &ModuleFiles);
 
   /// \brief Retrieve the set of module files on which the given module file
   /// directly depends.

--- a/interpreter/llvm/src/tools/clang/include/clang/Serialization/GlobalModuleIndex.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/Serialization/GlobalModuleIndex.h
@@ -179,6 +179,9 @@ public:
   /// \returns true if the identifier is known to the index, false otherwise.
   bool lookupIdentifier(StringRef Name, HitSet &Hits);
 
+  typedef llvm::SmallPtrSet<std::string *, 4> FileNameHitSet;
+  bool lookupIdentifier(StringRef Name, FileNameHitSet &Hits);
+
   /// \brief Note that the given module file has been loaded.
   ///
   /// \returns false if the global module index has information about this

--- a/interpreter/llvm/src/tools/clang/lib/Sema/SemaDecl.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Sema/SemaDecl.cpp
@@ -16196,7 +16196,7 @@ DeclResult Sema::ActOnModuleImport(SourceLocation StartLoc,
 
   VisibleModules.setVisible(Mod, ImportLoc);
 
-  checkModuleImportContext(*this, Mod, ImportLoc, CurContext);
+  // checkModuleImportContext(*this, Mod, ImportLoc, CurContext);
 
   // FIXME: we should support importing a submodule within a different submodule
   // of the same top-level module. Until we do, make it an error rather than

--- a/interpreter/llvm/src/tools/clang/lib/Serialization/GlobalModuleIndex.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Serialization/GlobalModuleIndex.cpp
@@ -300,7 +300,7 @@ bool GlobalModuleIndex::lookupIdentifier(StringRef Name, HitSet &Hits) {
     = *static_cast<IdentifierIndexTable *>(IdentifierIndex);
   IdentifierIndexTable::iterator Known = Table.find(Name);
   if (Known == Table.end()) {
-    return true;
+    return false;
   }
 
   SmallVector<unsigned, 2> ModuleIDs = *Known;
@@ -326,7 +326,7 @@ bool GlobalModuleIndex::lookupIdentifier(StringRef Name, FileNameHitSet &Hits) {
       *static_cast<IdentifierIndexTable *>(IdentifierIndex);
   IdentifierIndexTable::iterator Known = Table.find(Name);
   if (Known == Table.end()) {
-    return true;
+    return false;
   }
 
   SmallVector<unsigned, 2> ModuleIDs = *Known;

--- a/interpreter/llvm/src/tools/clang/lib/Serialization/GlobalModuleIndex.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Serialization/GlobalModuleIndex.cpp
@@ -269,6 +269,13 @@ GlobalModuleIndex::getKnownModules(SmallVectorImpl<ModuleFile *> &ModuleFiles) {
   }
 }
 
+void GlobalModuleIndex::getKnownModuleFileNames(StringSet<> &ModuleFiles) {
+  ModuleFiles.clear();
+  for (unsigned I = 0, N = Modules.size(); I != N; ++I) {
+    ModuleFiles[Modules[I].FileName];
+  }
+}
+
 void GlobalModuleIndex::getModuleDependencies(
        ModuleFile *File,
        SmallVectorImpl<ModuleFile *> &Dependencies) {


### PR DESCRIPTION
The global module index represents an efficient on-disk hash table which stores identifier->module mapping. Every time clang finds a unknown identifier we are informed and we can load the corresponding module on demand.

This way we can provide minimal set of loaded modules. Currently, we see that for hsimple.C only the half of the modules are loaded. This can be further improved because we currently load all modules which have an identifier, that is when looking for (for example TPad) we will load all modules which have the identifier TPad, including modules which contain only a forward declaration of it.
    
Kudos Arpitha Raghunandan (@arpi-r)!

We still need some performance measurements but the preliminary results are promising.

Performance
===

Methodology
---

We have a forwarding root.exe which essentially calls /usr/bin/time -v root.exe $@. We have processed and stored this information in csv files. We have run in three modes:
  1) root master without modules (modulesoff)
  2) root master with modules (moduleson)
  3) root master with this PR with modules (gmi)

Run on `Ubuntu 18.10 on Intel® Core™ i5-8250U CPU @ 1.60GHz × 8`

Results Interpretation
---
  A general comparison between 2) and 3) show that this PR makes ROOT about 3% faster and 25% more memory efficient.

  A general comparison between 1) and 3) shows that modules are still less efficient in a few cases which is expected because the PR loads more modules than it should. This will be addressed in subsequent PRs. A good trend is that some test already show that 3) is better than 1).

  The raw data could be found [here](https://docs.google.com/spreadsheets/d/12tZ_tmenR7fytcZpigfLOarNq1tIqPubTXWWMwz8lJg/edit#gid=1476035460). [work was done by Arpitha Raghunandan (@arpi-r)]

Depends on #4005.