### PR TITLE
Increase test tolerence

### DIFF
--- a/test/stress.cxx
+++ b/test/stress.cxx
@@ -406,7 +406,7 @@ void stress3()
 #else
    constexpr Long64_t lastgood = 51886;
 #endif
-   constexpr Long64_t tolerance = 100;
+   constexpr Long64_t tolerance = 150;
 #ifdef R__HAS_DEFAULT_LZ4
       constexpr Long64_t difflastgoodlz4 = 5500;
       if (last < lastgood - tolerance || last > lastgood + difflastgoodlz4 + tolerance || comp < 1.5 || comp > 2.1)


### PR DESCRIPTION
Test fails on aarch64 and ppc64le on Fedora 30 and Fedora rawhide:
Test  3 : Purge, Reuse of gaps in TFile......................... FAILED
         File size= 52010 (expected 51886 +/- 100)
         Comp Fact=  2.00 (expected 2.1 +/- 0.3)