### PR TITLE
[rdf] Improve automatic axis titles:

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -985,7 +985,7 @@ public:
    RResultPtr<::TH1D> Histo1D(std::string_view vName)
    {
       const auto h_name = std::string(vName);
-      const auto h_title = h_name + ";" + h_name + ";";
+      const auto h_title = h_name + ";" + h_name + ";count";
       return Histo1D<V>({h_name.c_str(), h_title.c_str(), 128u, 0., 0.}, vName);
    }
 
@@ -1047,8 +1047,10 @@ public:
    RResultPtr<::TH1D> Histo1D(std::string_view vName, std::string_view wName)
    {
       // We build name and title based on the value and weight column names
-      const auto h_name = std::string(vName) + "*" + std::string(wName);
-      const auto h_title = h_name + ";" + h_name + ";";
+      std::string str_vName{vName};
+      std::string str_wName{wName};
+      const auto h_name = str_vName + "_weighted_" + str_wName;
+      const auto h_title = str_vName + ", weights: " + str_wName + ";" + str_vName + ";count * " + str_wName;
       return Histo1D<V, W>({h_name.c_str(), h_title.c_str(), 128u, 0., 0.}, vName, wName);
    }
 
@@ -1293,11 +1295,11 @@ public:
 
       // We build a default name and title based on the input columns
       if (!(validatedColumns[0].empty() && validatedColumns[1].empty())) {
-         const auto v2Name_str = std::string(v2Name);
-         const auto g_name = std::string(v1Name) + "*" + v2Name_str;
-         graph->SetNameTitle(g_name.c_str(), g_name.c_str());
-         graph->GetXaxis()->SetTitle(g_name.c_str());
-         graph->GetYaxis()->SetTitle(v2Name_str.c_str());
+         const auto g_name = std::string(v1Name) + "_vs_" + std::string(v2Name);
+         const auto g_title = std::string(v1Name) + " vs " + std::string(v2Name);
+         graph->SetNameTitle(g_name.c_str(), g_title.c_str());
+         graph->GetXaxis()->SetTitle(std::string(v1Name).c_str());
+         graph->GetYaxis()->SetTitle(std::string(v2Name).c_str());
       }
 
       return CreateAction<RDFInternal::ActionTags::Graph, V1, V2>(validatedColumns, graph);

--- a/tree/dataframe/test/dataframe_simple.cxx
+++ b/tree/dataframe/test/dataframe_simple.cxx
@@ -571,6 +571,8 @@ TEST_P(RDFSimpleTests, Graph)
 
    auto dfGraph = dd.Graph("x1", "x2");
    EXPECT_EQ(dfGraph->GetN(), NR_ELEMENTS);
+   EXPECT_STREQ(dfGraph->GetXaxis()->GetTitle(), "x1");
+   EXPECT_STREQ(dfGraph->GetYaxis()->GetTitle(), "x2");
 
    //To perform the test, it's easier to sort
    dfGraph->Sort();
@@ -899,12 +901,14 @@ TEST(RDFSimpleTests, AutomaticNamesOfHisto1DAndGraph)
    EXPECT_STREQ(hx->GetName(), "x");
    EXPECT_STREQ(hx->GetTitle(), "x");
    EXPECT_STREQ(hx->GetXaxis()->GetTitle(), "x");
-   EXPECT_STREQ(hxy->GetName(), "x*y");
-   EXPECT_STREQ(hxy->GetTitle(), "x*y");
-   EXPECT_STREQ(hxy->GetXaxis()->GetTitle(), "x*y");
-   EXPECT_STREQ(gxy->GetName(), "x*y");
-   EXPECT_STREQ(gxy->GetTitle(), "x*y"); // current behaviour of TGraph
-   EXPECT_STREQ(gxy->GetXaxis()->GetTitle(), "x*y");
+   EXPECT_STREQ(hx->GetYaxis()->GetTitle(), "count");
+   EXPECT_STREQ(hxy->GetName(), "x_weighted_y");
+   EXPECT_STREQ(hxy->GetTitle(), "x, weights: y");
+   EXPECT_STREQ(hxy->GetXaxis()->GetTitle(), "x");
+   EXPECT_STREQ(hxy->GetYaxis()->GetTitle(), "count * y");
+   EXPECT_STREQ(gxy->GetName(), "x_vs_y");
+   EXPECT_STREQ(gxy->GetTitle(), "x vs y");
+   EXPECT_STREQ(gxy->GetXaxis()->GetTitle(), "x");
    EXPECT_STREQ(gxy->GetYaxis()->GetTitle(), "y");
 
 }


### PR DESCRIPTION
drawing a TGraph of x vs y should not title the x axis with "x*y".
"x*y" is also a bad name for a TGraph as it is not a C++ identifier; think SavePrimitive().
And while we are at it, why not introduce "count"!