### PR TITLE
[cmake] Randomize execution of gtests

### DIFF
--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -1408,7 +1408,7 @@ function(ROOT_ADD_GTEST test_suite)
   ROOT_PATH_TO_STRING(mangled_name ${test_suite} PATH_SEPARATOR_REPLACEMENT "-")
   ROOT_ADD_TEST(
     gtest${mangled_name}
-    COMMAND ${test_suite}
+    COMMAND ${test_suite} --gtest_shuffle
     WORKING_DIR ${CMAKE_CURRENT_BINARY_DIR}
   )
 endfunction()


### PR DESCRIPTION
Does this make sense? Could increase our test coverage.