### PR TITLE
[meta][TCling] Add TEnum::IsScopedEnum(), GetUnderlyingType() (ROOT-6988):

### DIFF
--- a/core/meta/inc/TDictionary.h
+++ b/core/meta/inc/TDictionary.h
@@ -86,6 +86,7 @@ enum EProperty {
    kIsConstant      = 0x00100000,
    kIsVirtualBase   = 0x00200000,
    kIsConstPointer  = 0x00400000,
+   kIsScopedEnum    = 0x00800000,
    kIsExplicit      = 0x04000000,
    kIsNamespace     = 0x08000000,
    kIsConstMethod   = 0x10000000,

--- a/core/meta/inc/TEnum.h
+++ b/core/meta/inc/TEnum.h
@@ -20,21 +20,27 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-#include "TNamed.h"
-#include "THashList.h"
-#include "TString.h"
+#include "TDataType.h"
 #include "TDictionary.h"
+#include "THashList.h"
+#include "TNamed.h"
+#include "TString.h"
 
+class ClassInfo_t;
 class TClass;
 class TEnumConstant;
 
 class TEnum : public TDictionary {
 
 private:
-   THashList fConstantList;     //list of constants the enum type
-   void     *fInfo;             //!interpreter implementation provided declaration
-   TClass   *fClass;            //!owning class
-   std::string fQualName;       // fully qualified type name
+   THashList    fConstantList;  //list of constants the enum type
+   ClassInfo_t *fInfo;          //!interpreter information, owned by TEnum
+   TClass      *fClass;         //!owning class
+   std::string  fQualName;      // fully qualified type name
+
+   enum EBits {
+     kBitIsScopedEnum = BIT(14) ///< The enum is an enum class.
+   };
 
 public:
 
@@ -45,7 +51,7 @@ public:
                       };
 
    TEnum(): fInfo(0), fClass(0) {}
-   TEnum(const char *name, void *info, TClass *cls);
+   TEnum(const char *name, DeclId_t declid, TClass *cls);
    virtual ~TEnum();
 
    void                  AddConstant(TEnumConstant *constant);
@@ -58,9 +64,8 @@ public:
    const TEnumConstant  *GetConstant(const char *name) const {
       return (TEnumConstant *) fConstantList.FindObject(name);
    }
-   DeclId_t              GetDeclId() const {
-      return (DeclId_t)fInfo;
-   }
+   DeclId_t              GetDeclId() const;
+   EDataType             GetUnderlyingType() const;
    Bool_t                IsValid();
    Long_t                Property() const;
    void                  SetClass(TClass *cl) {

--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -22,6 +22,7 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
+#include "TDataType.h"
 #include "TDictionary.h"
 #include "TInterpreterValue.h"
 #include "TVirtualRWMutex.h"
@@ -399,6 +400,7 @@ public:
    virtual ClassInfo_t  *ClassInfo_Factory(Bool_t /*all*/ = kTRUE) const = 0;
    virtual ClassInfo_t  *ClassInfo_Factory(ClassInfo_t * /* cl */) const = 0;
    virtual ClassInfo_t  *ClassInfo_Factory(const char * /* name */) const = 0;
+   virtual ClassInfo_t  *ClassInfo_Factory(DeclId_t declid) const = 0;
    virtual Long_t   ClassInfo_GetBaseOffset(ClassInfo_t* /* fromDerived */,
                                             ClassInfo_t* /* toBase */, void* /* address */ = 0, bool /*isderived*/ = true) const {return 0;}
    virtual int    ClassInfo_GetMethodNArg(ClassInfo_t * /* info */, const char * /* method */,const char * /* proto */, Bool_t /* objectIsConst */ = false, ROOT::EFunctionMatchMode /* mode */ = ROOT::kConversionMatch) const {return 0;}
@@ -408,6 +410,8 @@ public:
    virtual void   ClassInfo_Init(ClassInfo_t * /* info */, int /* tagnum */) const {;}
    virtual Bool_t ClassInfo_IsBase(ClassInfo_t * /* info */, const char * /* name */) const {return 0;}
    virtual Bool_t ClassInfo_IsEnum(const char * /* name */) const {return 0;}
+   virtual Bool_t ClassInfo_IsScopedEnum(ClassInfo_t * /* info */) const {return 0;}
+   virtual EDataType ClassInfo_GetUnderlyingType(ClassInfo_t * /* info */) const {return kNumDataTypes;}
    virtual Bool_t ClassInfo_IsLoaded(ClassInfo_t * /* info */) const {return 0;}
    virtual Bool_t ClassInfo_IsValid(ClassInfo_t * /* info */) const {return 0;}
    virtual Bool_t ClassInfo_IsValidMethod(ClassInfo_t * /* info */, const char * /* method */,const char * /* proto */, Long_t * /* offset */, ROOT::EFunctionMatchMode /* mode */ = ROOT::kConversionMatch) const {return 0;}

--- a/core/meta/src/TEnum.cxx
+++ b/core/meta/src/TEnum.cxx
@@ -30,13 +30,13 @@ ClassImp(TEnum);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor for TEnum class.
-/// It take the name of the TEnum type, specification if it is global
-/// and interpreter info.
+/// It takes the name of the TEnum type, interpreter info and surrounding class
+/// the enum it is not globalat namespace scope.
 /// Constant List is owner if enum not on global scope (thus constants not
 /// in TROOT::GetListOfGlobals).
 
-TEnum::TEnum(const char *name, void *info, TClass *cls)
-   : fInfo(info), fClass(cls)
+TEnum::TEnum(const char *name, DeclId_t declid, TClass *cls)
+   : fInfo(nullptr), fClass(cls)
 {
    SetName(name);
    if (cls) {
@@ -53,6 +53,8 @@ TEnum::TEnum(const char *name, void *info, TClass *cls)
    else { // it is in the global scope
       fQualName = GetName();
    }
+
+   Update(declid);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -60,6 +62,7 @@ TEnum::TEnum(const char *name, void *info, TClass *cls)
 
 TEnum::~TEnum()
 {
+   gInterpreter->ClassInfo_Delete(fInfo);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -80,9 +83,8 @@ Bool_t TEnum::IsValid()
    // Register the transaction when checking the validity of the object.
    if (!fInfo && UpdateInterpreterStateMarker()) {
       DeclId_t newId = gInterpreter->GetEnum(fClass, fName);
-      if (newId) {
+      if (newId)
          Update(newId);
-      }
       return newId != 0;
    }
    return fInfo != 0;
@@ -93,14 +95,47 @@ Bool_t TEnum::IsValid()
 
 Long_t TEnum::Property() const
 {
-   return kIsEnum;
+   return kIsEnum | (TestBit(kBitIsScopedEnum) ? kIsScopedEnum : 0);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get the unterlying integer type of the enum:
+///     enum E { kOne }; //  ==> int
+///     enum F: long; //  ==> long
+/// Returns kNumDataTypes if the enum is unknown / invalid.
+
+EDataType TEnum::GetUnderlyingType() const
+{
+   if (fInfo)
+      return gInterpreter->ClassInfo_GetUnderlyingType(fInfo);
+   return kNumDataTypes;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TDictionary::DeclId_t TEnum::GetDeclId() const
+{
+   if (fInfo)
+      return gInterpreter->GetDeclId(fInfo);
+
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 void TEnum::Update(DeclId_t id)
 {
-   fInfo = (void *)id;
+   if (fInfo)
+      gInterpreter->ClassInfo_Delete(fInfo);
+   if (!id) {
+      fInfo = nullptr;
+      return;
+   }
+
+   fInfo = gInterpreter->ClassInfo_Factory(id);
+
+   if (fInfo)
+      SetBit(kBitIsScopedEnum, gInterpreter->ClassInfo_IsScopedEnum(fInfo));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/meta/test/CMakeLists.txt
+++ b/core/meta/test/CMakeLists.txt
@@ -7,5 +7,6 @@
 ROOT_ADD_GTEST(testStatusBitsChecker testStatusBitsChecker.cxx LIBRARIES Core)
 ROOT_ADD_GTEST(testHashRecursiveRemove testHashRecursiveRemove.cxx LIBRARIES Core)
 ROOT_ADD_GTEST(testTClass testTClass.cxx LIBRARIES Core)
+ROOT_ADD_GTEST(testTEnum testTEnum.cxx LIBRARIES Core)
 configure_file(stlDictCheck.h . COPYONLY)
 configure_file(stlDictCheckAux.h . COPYONLY)

--- a/core/meta/test/testTEnum.cxx
+++ b/core/meta/test/testTEnum.cxx
@@ -1,0 +1,76 @@
+#include "TEnum.h"
+#include "TInterpreter.h"
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+TEST(TEnum, UnderlyingType)
+{
+   gInterpreter->Declare(R"CODE(
+enum E0 { kE0One };
+enum E1 { kE1One = LONG_MAX };
+enum E2 { kE2One = ULONG_MAX };
+enum E3: char { kE3One };
+
+enum Eb: bool { kEbOne };
+enum Euc: unsigned char { kEucOne };
+enum Esc: signed char { kEscOne };
+enum Eus: unsigned short { kEusOne };
+enum Ess: signed short { kEssOne };
+enum Eui: unsigned int { kEuiOne };
+enum Esi: signed int { kEsiOne };
+enum Eul: unsigned long { kEulOne };
+enum Esl: signed long { kEslOne };
+enum Eull: unsigned long long { kEullOne };
+enum Esll: signed long long { kEsllOne };
+
+enum Ecl: short;
+
+enum class ECb: bool { kOne };
+enum class ECuc: unsigned char { kOne };
+enum class ECsc: signed char { kOne };
+enum class ECus: unsigned short { kOne };
+enum class ECss: signed short { kOne };
+enum class ECui: unsigned int { kOne };
+enum class ECsi: signed int { kOne };
+enum class ECul: unsigned long { kOne };
+enum class ECsl: signed long { kOne };
+enum class ECull: unsigned long long { kOne };
+enum class ECsll: signed long long { kOne };
+
+enum class ECcl: short;
+)CODE"
+			);
+
+   EXPECT_EQ(TEnum::GetEnum("E0")->GetUnderlyingType(), kUInt_t);
+   EXPECT_EQ(TEnum::GetEnum("E1")->GetUnderlyingType(), kULong_t);
+   EXPECT_EQ(TEnum::GetEnum("E2")->GetUnderlyingType(), kULong_t);
+   EXPECT_EQ(TEnum::GetEnum("E3")->GetUnderlyingType(), kChar_t);
+
+   EXPECT_EQ(TEnum::GetEnum("Eb")->GetUnderlyingType(), kBool_t);
+   EXPECT_EQ(TEnum::GetEnum("Euc")->GetUnderlyingType(), kUChar_t);
+   EXPECT_EQ(TEnum::GetEnum("Esc")->GetUnderlyingType(), kChar_t);
+   EXPECT_EQ(TEnum::GetEnum("Eus")->GetUnderlyingType(), kUShort_t);
+   EXPECT_EQ(TEnum::GetEnum("Ess")->GetUnderlyingType(), kShort_t);
+   EXPECT_EQ(TEnum::GetEnum("Eui")->GetUnderlyingType(), kUInt_t);
+   EXPECT_EQ(TEnum::GetEnum("Esi")->GetUnderlyingType(), kInt_t);
+   EXPECT_EQ(TEnum::GetEnum("Eul")->GetUnderlyingType(), kULong_t);
+   EXPECT_EQ(TEnum::GetEnum("Esl")->GetUnderlyingType(), kLong_t);
+   EXPECT_EQ(TEnum::GetEnum("Eull")->GetUnderlyingType(), kULong64_t);
+   EXPECT_EQ(TEnum::GetEnum("Esll")->GetUnderlyingType(), kLong64_t);
+   EXPECT_EQ(TEnum::GetEnum("Ecl")->GetUnderlyingType(), kShort_t);
+}
+
+
+TEST(TEnum, Scoped)
+{
+   gInterpreter->Declare(R"CODE(
+enum class EC { kOne };
+enum class EC1: long { kOne };
+enum ED { kEDOne };
+)CODE"
+			);
+   EXPECT_EQ(TEnum::GetEnum("EC")->Property() & kIsScopedEnum, kIsScopedEnum);
+   EXPECT_EQ(TEnum::GetEnum("EC1")->Property() & kIsScopedEnum, kIsScopedEnum);
+   EXPECT_EQ(TEnum::GetEnum("ED")->Property() & kIsScopedEnum, 0);
+}

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -7795,6 +7795,13 @@ ClassInfo_t* TCling::ClassInfo_Factory(const char* name) const
    return (ClassInfo_t*) new TClingClassInfo(fInterpreter, name);
 }
 
+ClassInfo_t* TCling::ClassInfo_Factory(DeclId_t declid) const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return (ClassInfo_t*) new TClingClassInfo(fInterpreter, (const clang::Decl*)declid);
+}
+
+
 ////////////////////////////////////////////////////////////////////////////////
 
 int TCling::ClassInfo_GetMethodNArg(ClassInfo_t* cinfo, const char* method, const char* proto, Bool_t objectIsConst /* = false */, EFunctionMatchMode mode /* = kConversionMatch */) const
@@ -7851,6 +7858,24 @@ bool TCling::ClassInfo_IsEnum(const char* name) const
 {
    return TClingClassInfo::IsEnum(fInterpreter, name);
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+Bool_t TCling::ClassInfo_IsScopedEnum(ClassInfo_t *info) const
+{
+   TClingClassInfo* TClinginfo = (TClingClassInfo*) info;
+   return TClinginfo->IsScopedEnum();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+EDataType TCling::ClassInfo_GetUnderlyingType(ClassInfo_t* info) const
+{
+   TClingClassInfo* TClinginfo = (TClingClassInfo*) info;
+   return TClinginfo->GetUnderlyingType();
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -399,6 +399,7 @@ public: // Public Interface
    virtual ClassInfo_t*  ClassInfo_Factory(Bool_t all = kTRUE) const;
    virtual ClassInfo_t*  ClassInfo_Factory(ClassInfo_t* cl) const;
    virtual ClassInfo_t*  ClassInfo_Factory(const char* name) const;
+   virtual ClassInfo_t*  ClassInfo_Factory(DeclId_t declid) const;
    virtual Long_t   ClassInfo_GetBaseOffset(ClassInfo_t* fromDerived, ClassInfo_t* toBase, void * address, bool isDerivedObject) const;
    virtual int    ClassInfo_GetMethodNArg(ClassInfo_t* info, const char* method, const char* proto, Bool_t objectIsConst = false, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch) const;
    virtual bool   ClassInfo_HasDefaultConstructor(ClassInfo_t* info) const;
@@ -407,6 +408,8 @@ public: // Public Interface
    virtual void   ClassInfo_Init(ClassInfo_t* info, int tagnum) const;
    virtual bool   ClassInfo_IsBase(ClassInfo_t* info, const char* name) const;
    virtual bool   ClassInfo_IsEnum(const char* name) const;
+   virtual bool   ClassInfo_IsScopedEnum(ClassInfo_t* info) const;
+   virtual EDataType ClassInfo_GetUnderlyingType(ClassInfo_t* info) const;
    virtual bool   ClassInfo_IsLoaded(ClassInfo_t* info) const;
    virtual bool   ClassInfo_IsValid(ClassInfo_t* info) const;
    virtual bool   ClassInfo_IsValidMethod(ClassInfo_t* info, const char* method, const char* proto, Long_t* offset, ROOT::EFunctionMatchMode /* mode */ = ROOT::kConversionMatch) const;

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -801,6 +801,61 @@ bool TClingClassInfo::IsEnum(cling::Interpreter *interp, const char *name)
    return false;
 }
 
+bool TClingClassInfo::IsScopedEnum() const
+{
+   if (auto *ED = llvm::dyn_cast<clang::EnumDecl>(GetDecl()))
+      return ED->isScoped();
+   return false;
+}
+
+EDataType TClingClassInfo::GetUnderlyingType() const
+{
+   if (!IsValid())
+      return kNumDataTypes;
+   if (GetDecl() == 0)
+      return kNumDataTypes;
+
+   if (auto ED = llvm::dyn_cast<EnumDecl>(GetDecl())) {
+      R__LOCKGUARD(gInterpreterMutex);
+      auto Ty = ED->getIntegerType().getTypePtrOrNull();
+      if (auto BTy = llvm::dyn_cast<BuiltinType>(Ty)) {
+         switch (BTy->getKind()) {
+         case BuiltinType::Bool:
+            return kBool_t;
+
+         case BuiltinType::Char_U:
+         case BuiltinType::UChar:
+            return kUChar_t;
+
+         case BuiltinType::Char_S:
+         case BuiltinType::SChar:
+            return kChar_t;
+
+         case BuiltinType::UShort:
+            return kUShort_t;
+         case BuiltinType::Short:
+            return kShort_t;
+         case BuiltinType::UInt:
+            return kUInt_t;
+         case BuiltinType::Int:
+            return kInt_t;
+         case BuiltinType::ULong:
+            return kULong_t;
+         case BuiltinType::Long:
+            return kLong_t;
+         case BuiltinType::ULongLong:
+            return kULong64_t;
+         case BuiltinType::LongLong:
+            return kLong64_t;
+         default:
+            return kNumDataTypes;
+         };
+      }
+   }
+   return kNumDataTypes;
+}
+
+
 bool TClingClassInfo::IsLoaded() const
 {
    // IsLoaded in CINT was meaning is known to the interpreter

--- a/core/metacling/src/TClingClassInfo.h
+++ b/core/metacling/src/TClingClassInfo.h
@@ -27,6 +27,7 @@
 
 #include "TClingDeclInfo.h"
 #include "TClingMethodInfo.h"
+#include "TDataType.h"
 #include "TDictionary.h"
 
 #include <vector>
@@ -128,6 +129,8 @@ public:
    void                 Init(const clang::Type &);
    bool                 IsBase(const char *name) const;
    static bool          IsEnum(cling::Interpreter *interp, const char *name);
+   bool                 IsScopedEnum() const;
+   EDataType            GetUnderlyingType() const;
    bool                 IsLoaded() const;
    bool                 IsValidMethod(const char *method, const char *proto, Bool_t objectIsConst, long *offset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch) const;
    int                  InternalNext();


### PR DESCRIPTION
Provide access to whether the enum is a scoped enum through TEnum::Property().
Add an interface to determine the underlying type of an enum, as EDataType.