### PR TITLE
[webgui] split data callback on three different handlers

### DIFF
--- a/graf3d/eve7/inc/ROOT/REveManager.hxx
+++ b/graf3d/eve7/inc/ROOT/REveManager.hxx
@@ -126,7 +126,9 @@ protected:
    std::shared_ptr<ROOT::Experimental::RWebWindow>  fWebWindow;
    std::vector<Conn>                                fConnList;
 
-   void GeomWindowCallback(unsigned connid, const std::string &arg);
+   void WindowConnect(unsigned connid);
+   void WindowData(unsigned connid, const std::string &arg);
+   void WindowDisconnect(unsigned connid);
 
 public:
    REveManager(); // (Bool_t map_window=kTRUE, Option_t* opt="FI");
@@ -216,7 +218,6 @@ public:
 
    void EnforceTimerActive (Bool_t ta) { fTimerActive = ta; }
 
-   void HttpServerCallback(unsigned connid, const std::string &arg);
    // void Send(void* buff, unsigned connid);
    void Send(unsigned connid, const std::string &data);
    void SendBinary(unsigned connid, const void *data, std::size_t len);

--- a/graf3d/eve7/src/REveGeomViewer.cxx
+++ b/graf3d/eve7/src/REveGeomViewer.cxx
@@ -11,8 +11,8 @@
 
 #include <ROOT/REveGeomViewer.hxx>
 
-#include <ROOT/RWebWindowsManager.hxx>
 #include <ROOT/RLogger.hxx>
+#include <ROOT/RWebWindow.hxx>
 
 #include "TSystem.h"
 #include "TROOT.h"
@@ -28,7 +28,7 @@ using namespace std::string_literals;
 
 ROOT::Experimental::REveGeomViewer::REveGeomViewer(TGeoManager *mgr)
 {
-   fWebWindow = ROOT::Experimental::RWebWindowsManager::Instance()->CreateWindow();
+   fWebWindow = RWebWindow::Create();
    fWebWindow->SetDefaultPage("file:rootui5sys/eve7/geom.html");
 
    // this is call-back, invoked when message received via websocket
@@ -158,7 +158,7 @@ void ROOT::Experimental::REveGeomViewer::WebWindowCallback(unsigned connid, cons
 
    } else if (arg == "QUIT_ROOT") {
 
-      RWebWindowsManager::Instance()->Terminate();
+      fWebWindow->TerminateROOT();
 
    } else if (arg.compare(0, 7, "SEARCH:") == 0) {
 

--- a/graf3d/eve7/src/REveGeomViewer.cxx
+++ b/graf3d/eve7/src/REveGeomViewer.cxx
@@ -150,9 +150,7 @@ void ROOT::Experimental::REveGeomViewer::WebWindowCallback(unsigned connid, cons
 {
    printf("Recv %s\n", arg.c_str());
 
-   if (arg == "CONN_READY") {
-
-   } else if (arg == "GETDRAW") {
+   if (arg == "GETDRAW") {
 
       SendGeometry(connid);
 

--- a/graf3d/eve7/src/REveManager.cxx
+++ b/graf3d/eve7/src/REveManager.cxx
@@ -17,7 +17,7 @@
 #include <ROOT/REveScene.hxx>
 #include <ROOT/REveClient.hxx>
 #include <ROOT/REveGeomViewer.hxx>
-#include <ROOT/RWebWindowsManager.hxx>
+#include <ROOT/RWebWindow.hxx>
 
 #include "TGeoManager.h"
 #include "TObjString.h"
@@ -136,7 +136,7 @@ REveManager::REveManager() : // (Bool_t map_window, Option_t* opt) :
    // !!! AMT increase threshold to enable color pick on client
    TColor::SetColorThreshold(0.1);
 
-   fWebWindow = ROOT::Experimental::RWebWindowsManager::Instance()->CreateWindow();
+   fWebWindow = RWebWindow::Create();
    fWebWindow->SetDefaultPage("file:rootui5sys/eve7/index.html");
 
    // this is call-back, invoked when message received via websocket

--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -15,7 +15,6 @@
 
 #include <ROOT/RBrowser.hxx>
 
-#include <ROOT/RWebWindowsManager.hxx>
 #include <ROOT/RBrowserItem.hxx>
 #include <ROOT/RLogger.hxx>
 #include "ROOT/RMakeUnique.hxx"
@@ -44,7 +43,7 @@ web-based ROOT Browser prototype.
 
 ROOT::Experimental::RBrowser::RBrowser()
 {
-   fWebWindow = ROOT::Experimental::RWebWindowsManager::Instance()->CreateWindow();
+   fWebWindow = RWebWindow::Create();
    fWebWindow->SetDefaultPage("file:rootui5sys/browser/browser.html");
 
    // this is call-back, invoked when message received via websocket
@@ -286,7 +285,7 @@ void ROOT::Experimental::RBrowser::WebWindowCallback(unsigned connid, const std:
 
    } else if (arg == "QUIT_ROOT") {
 
-      RWebWindowsManager::Instance()->Terminate();
+      fWebWindow->TerminateROOT();
 
    } else if (arg.compare(0,6, "BRREQ:") == 0) {
       // central place for processing browser requests

--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -47,7 +47,8 @@ ROOT::Experimental::RBrowser::RBrowser()
    fWebWindow->SetDefaultPage("file:rootui5sys/browser/browser.html");
 
    // this is call-back, invoked when message received via websocket
-   fWebWindow->SetDataCallBack([this](unsigned connid, const std::string &arg) { this->WebWindowCallback(connid, arg); });
+   fWebWindow->SetCallBacks([this](unsigned connid) { fConnId = connid; },
+                            [this](unsigned connid, const std::string &arg) { WebWindowCallback(connid, arg); });
    fWebWindow->SetGeometry(1200, 700); // configure predefined window geometry
    fWebWindow->SetConnLimit(1); // the only connection is allowed
    fWebWindow->SetMaxQueueLength(30); // number of allowed entries in the window queue
@@ -279,11 +280,7 @@ void ROOT::Experimental::RBrowser::WebWindowCallback(unsigned connid, const std:
 {
    printf("Recv %s\n", arg.c_str());
 
-   if (arg == "CONN_READY") {
-
-      fConnId = connid;
-
-   } else if (arg == "QUIT_ROOT") {
+   if (arg == "QUIT_ROOT") {
 
       fWebWindow->TerminateROOT();
 

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -21,7 +21,6 @@
 #include <ROOT/RMenuItem.hxx>
 
 #include <ROOT/RWebWindow.hxx>
-#include <ROOT/RWebWindowsManager.hxx>
 
 #include <memory>
 #include <string>
@@ -487,8 +486,8 @@ void ROOT::Experimental::TCanvasPainter::ProcessData(unsigned connid, const std:
       cdata.erase(0, 8);
       conn->fGetMenu = cdata;
    } else if (arg == "QUIT") {
-      // use window manager to correctly terminate http server
-      RWebWindowsManager::Instance()->Terminate();
+      // use window manager to correctly terminate http server and ROOT session
+      fWindow->TerminateROOT();
       return;
    } else if (arg == "RELOAD") {
       conn->fSend = 0; // reset send version, causes new data sending
@@ -542,7 +541,7 @@ void ROOT::Experimental::TCanvasPainter::CreateWindow()
 {
    if (fWindow) return;
 
-   fWindow = RWebWindowsManager::Instance()->CreateWindow();
+   fWindow = RWebWindow::Create();
    fWindow->SetConnLimit(0); // allow any number of connections
    fWindow->SetDefaultPage("file:rootui5sys/canv/canvas.html");
    fWindow->SetDataCallBack([this](unsigned connid, const std::string &arg) { ProcessData(connid, arg); });

--- a/gui/fitpanelv7/src/RFitPanel.cxx
+++ b/gui/fitpanelv7/src/RFitPanel.cxx
@@ -16,7 +16,6 @@
 
 #include <ROOT/RFitPanel.hxx>
 
-#include <ROOT/RWebWindowsManager.hxx>
 #include <ROOT/RMakeUnique.hxx>
 #include <ROOT/RLogger.hxx>
 
@@ -104,7 +103,7 @@ ROOT::Experimental::RFitPanel::~RFitPanel()
 std::shared_ptr<ROOT::Experimental::RWebWindow> ROOT::Experimental::RFitPanel::GetWindow()
 {
    if (!fWindow) {
-      fWindow = RWebWindowsManager::Instance()->CreateWindow();
+      fWindow = RWebWindow::Create();
 
       fWindow->SetPanelName("rootui5.fitpanel.view.FitPanel");
 

--- a/gui/fitpanelv7/src/RFitPanel.cxx
+++ b/gui/fitpanelv7/src/RFitPanel.cxx
@@ -107,7 +107,17 @@ std::shared_ptr<ROOT::Experimental::RWebWindow> ROOT::Experimental::RFitPanel::G
 
       fWindow->SetPanelName("rootui5.fitpanel.view.FitPanel");
 
-      fWindow->SetDataCallBack([this](unsigned connid, const std::string &arg) { ProcessData(connid, arg); });
+      fWindow->SetCallBacks(
+            [this](unsigned connid)
+            {
+               fConnId = connid;
+               fWindow->Send(fConnId, "INITDONE");
+               if (!model().fInitialized)
+                  SelectObject("$$$");
+               SendModel();
+            },
+            [this](unsigned connid, const std::string &arg) { ProcessData(connid, arg); },
+            [this](unsigned) { fConnId = 0; });
 
       fWindow->SetGeometry(400, 650); // configure predefined geometry
    }
@@ -384,21 +394,9 @@ void ROOT::Experimental::RFitPanel::SendModel()
 /// Process data from FitPanel
 /// OpenUI5-based FitPanel sends commands or status changes
 
-void ROOT::Experimental::RFitPanel::ProcessData(unsigned connid, const std::string &arg)
+void ROOT::Experimental::RFitPanel::ProcessData(unsigned, const std::string &arg)
 {
-   if (arg == "CONN_READY") {
-      fConnId = connid;
-      fWindow->Send(fConnId, "INITDONE");
-      if (!model().fInitialized)
-         SelectObject("$$$");
-
-      SendModel();
-
-   } else if (arg == "CONN_CLOSED") {
-
-      fConnId = 0;
-
-   } else if (arg == "RELOAD") {
+   if (arg == "RELOAD") {
 
       GetFunctionsFromSystem();
 

--- a/gui/webdisplay/inc/ROOT/RWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindow.hxx
@@ -282,6 +282,7 @@ public:
 
    int WaitForTimed(WebWindowWaitFunc_t check, double duration);
 
+   static std::shared_ptr<RWebWindow> Create();
 };
 
 } // namespace Experimental

--- a/gui/webdisplay/inc/ROOT/RWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindow.hxx
@@ -282,6 +282,8 @@ public:
 
    int WaitForTimed(WebWindowWaitFunc_t check, double duration);
 
+   void TerminateROOT();
+
    static std::shared_ptr<RWebWindow> Create();
 };
 

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -19,7 +19,6 @@
 #include <ROOT/RLogger.hxx>
 
 #include "ROOT/RWebWindow.hxx"
-#include "ROOT/RWebWindowsManager.hxx"
 
 #include "THttpServer.h"
 

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -1142,3 +1142,13 @@ std::shared_ptr<ROOT::Experimental::RWebWindow> ROOT::Experimental::RWebWindow::
    return ROOT::Experimental::RWebWindowsManager::Instance()->CreateWindow();
 }
 
+/////////////////////////////////////////////////////////////////////////////////
+/// Terminate ROOT session
+/// Tries to correctly close THttpServer, associated with RWebWindowsManager
+/// After that exit from process
+
+void ROOT::Experimental::RWebWindow::TerminateROOT()
+{
+   fMgr->Terminate();
+}
+

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -1132,3 +1132,13 @@ void ROOT::Experimental::RWebWindow::Run(double tm)
       WaitForTimed([](double) { return 0; }, tm);
    }
 }
+
+/////////////////////////////////////////////////////////////////////////////////
+/// Create new RWebWindow
+/// Using default RWebWindowsManager
+
+std::shared_ptr<ROOT::Experimental::RWebWindow> ROOT::Experimental::RWebWindow::Create()
+{
+   return ROOT::Experimental::RWebWindowsManager::Instance()->CreateWindow();
+}
+

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -1051,7 +1051,7 @@ void ROOT::Experimental::RWebWindow::SendBinary(unsigned connid, const void *dat
 ///
 /// Most simple way to assign call-back - use of c++11 lambdas like:
 /// ~~~ {.cpp}
-/// std::shared_ptr<RWebWindow> win = RWebWindowsManager::Instance()->CreateWindow();
+/// auto win = RWebWindow::Create();
 /// win->SetDefaultPage("file:./page.htm");
 /// win->SetDataCallBack(
 ///          [](unsigned connid, const std::string &data) {

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -497,8 +497,8 @@ void ROOT::Experimental::RWebWindow::CheckInactiveConnections()
       fConn.erase(std::remove_if(fConn.begin(), fConn.end(), pred), fConn.end());
    }
 
-   for (auto &&entry : clr)
-      ProvideQueueEntry(entry->fConnId, kind_Disconnect, "CONN_CLOSED");
+   for (auto &entry : clr)
+      ProvideQueueEntry(entry->fConnId, kind_Disconnect, ""s);
 
 }
 
@@ -540,7 +540,7 @@ bool ROOT::Experimental::RWebWindow::ProcessWS(THttpCallArg &arg)
       auto conn = RemoveConnection(arg.GetWSId());
 
       if (conn)
-         ProvideQueueEntry(conn->fConnId, kind_Disconnect, "CONN_CLOSED");
+         ProvideQueueEntry(conn->fConnId, kind_Disconnect, ""s);
 
       return true;
    }
@@ -641,17 +641,17 @@ bool ROOT::Experimental::RWebWindow::ProcessWS(THttpCallArg &arg)
             Send(conn->fConnId, "SHOWPANEL:"s + fPanelName);
             conn->fReady = 5;
          } else {
-            ProvideQueueEntry(conn->fConnId, kind_Connect, "CONN_READY");
+            ProvideQueueEntry(conn->fConnId, kind_Connect, ""s);
             conn->fReady = 10;
          }
       }
    } else if (fPanelName.length() && (conn->fReady < 10)) {
       if (cdata == "PANEL_READY") {
          R__DEBUG_HERE("webgui") << "Get panel ready " << fPanelName;
-         ProvideQueueEntry(conn->fConnId, kind_Connect, "CONN_READY");
+         ProvideQueueEntry(conn->fConnId, kind_Connect, ""s);
          conn->fReady = 10;
       } else {
-         ProvideQueueEntry(conn->fConnId, kind_Disconnect, "CONN_CLOSED");
+         ProvideQueueEntry(conn->fConnId, kind_Disconnect, ""s);
          RemoveConnection(conn->fWSId);
       }
    } else if (nchannel == 1) {

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -18,7 +18,6 @@
 #include <ROOT/RLogger.hxx>
 #include <ROOT/RWebDisplayArgs.hxx>
 #include <ROOT/RWebDisplayHandle.hxx>
-#include <ROOT/RWebWindowsManager.hxx>
 
 #include "RWebWindowWSHandler.hxx"
 

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -37,7 +37,6 @@
 #include "TAtt3D.h"
 #include "TView.h"
 
-#include <ROOT/RWebWindowsManager.hxx>
 #include <ROOT/RMakeUnique.hxx>
 
 #include <stdio.h>
@@ -531,7 +530,7 @@ void TWebCanvas::Close()
 void TWebCanvas::ShowWebWindow(const ROOT::Experimental::RWebDisplayArgs &args)
 {
    if (!fWindow) {
-      fWindow = ROOT::Experimental::RWebWindowsManager::Instance()->CreateWindow();
+      fWindow = ROOT::Experimental::RWebWindow::Create();
 
       fWindow->SetConnLimit(0); // configure connections limit
 
@@ -663,7 +662,7 @@ Bool_t TWebCanvas::ProcessData(unsigned connid, const std::string &arg)
    } else if (arg == "QUIT") {
 
       // use window manager to correctly terminate http server
-      ROOT::Experimental::RWebWindowsManager::Instance()->Terminate();
+      fWindow->TerminateROOT();
 
    } else if (arg.compare(0, 7, "READY6:") == 0) {
 

--- a/tutorials/webgui/panel/Readme.md
+++ b/tutorials/webgui/panel/Readme.md
@@ -1,0 +1,26 @@
+## OPENUI5 Panel example
+
+This is special kind of openui5-based widget.
+
+It is normal xml::View, but controller should be derived from sap.ui.jsroot.GuiPanelController class.
+This class provides number of methods, which should simplify handling of communication between server and client
+
+First of all, when creating RWebWindow, one should configure panel name. Like:
+
+     auto win = ROOT::Experimental::RWebWindowsManager::Instance()->CreateWindow();
+
+     // this is very important, it defines name of openui5 widget, which
+     // will run on the client side
+     win->SetPanelName("localapp.view.TestPanel");
+
+ 
+ Namespace "localapp" in this case corresponds to openui5 files, which will be loaded from current directory.
+ Therefore `"localapp.view.TestPanel"` means view, which will be loaded from `./view/TestPanel.view.xml` file.
+ 
+ Controller is configured in the XML file and called `"localapp.controller.TestPanel"`. 
+ Means it will be loaded from `./controller/TestPanel.controller.js` file.
+ 
+ In the controller one use `onPanelInit` and `onPanelExit` methods to handle initialization and close of widget.
+ Also  
+  
+ 

--- a/tutorials/webgui/panel/Readme.md
+++ b/tutorials/webgui/panel/Readme.md
@@ -1,26 +1,20 @@
 ## OPENUI5 Panel example
 
-This is special kind of openui5-based widget.
+This is simplest way to use openui5 widget with RWebWindow.
 
-It is normal xml::View, but controller should be derived from sap.ui.jsroot.GuiPanelController class.
+It is normal xml::View, but controller should be derived from rootui5/panel/Controller.
 This class provides number of methods, which should simplify handling of communication between server and client
 
 First of all, when creating RWebWindow, one should configure panel name. Like:
 
-     auto win = ROOT::Experimental::RWebWindowsManager::Instance()->CreateWindow();
+     auto win = ROOT::Experimental::RWebWindow::Create();
 
-     // this is very important, it defines name of openui5 widget, which
-     // will run on the client side
      win->SetPanelName("localapp.view.TestPanel");
 
- 
- Namespace "localapp" in this case corresponds to openui5 files, which will be loaded from current directory.
- Therefore `"localapp.view.TestPanel"` means view, which will be loaded from `./view/TestPanel.view.xml` file.
- 
- Controller is configured in the XML file and called `"localapp.controller.TestPanel"`. 
- Means it will be loaded from `./controller/TestPanel.controller.js` file.
- 
- In the controller one use `onPanelInit` and `onPanelExit` methods to handle initialization and close of widget.
- Also  
-  
- 
+Namespace "localapp" in this case corresponds to openui5 files, which will be loaded from current directory. Therefore `"localapp.view.TestPanel"` means view, which will be loaded from `./view/TestPanel.view.xml` file.
+
+Controller is configured in the XML file and called `"localapp.controller.TestPanel"`.
+Means it will be loaded from `./controller/TestPanel.controller.js` file.
+
+In the controller one use `onPanelInit` and `onPanelExit` methods to handle initialization and close of widget. Method `panelSend` should be used to send string data to the server.
+

--- a/tutorials/webgui/panel/controller/TestPanel.controller.js
+++ b/tutorials/webgui/panel/controller/TestPanel.controller.js
@@ -1,0 +1,51 @@
+sap.ui.define([
+   'rootui5/panel/Controller',
+   'sap/ui/model/json/JSONModel',
+   'sap/m/MessageToast'
+], function (GuiPanelController, JSONModel, MessageToast) {
+   "use strict";
+
+   return GuiPanelController.extend("localapp.controller.TestPanel", {
+
+      // function called from rootui5.panel.Controller
+      onPanelInit : function() {
+         if (document) document.title = "TestPanel";
+      },
+
+      // function called from rootui5.panel.Controller
+      onPanelExit : function() {
+      },
+
+      OnWebsocketMsg: function(handle, msg, offset) {
+         if (typeof msg != "string") {
+            // binary data transfer not used in this example
+            var arr = new Float32Array(msg, offset);
+            return;
+         }
+
+         if (msg.indexOf("MODEL:")==0) {
+            var data = JSROOT.parse(msg.substr(6));
+            if (data)
+               this.getView().setModel(new JSONModel(data));
+         } else {
+            this.getView().byId("SampleText").setText("Get message:\n" + msg);
+         }
+      },
+
+      handleButtonPress: function() {
+         MessageToast.show("Press sample button");
+      },
+
+      handleSendPress: function() {
+         // just send model as is to the server back
+         if (this.websocket)
+            this.websocket.Send("MODEL:" + this.getView().getModel().getJSON());
+      },
+
+      handleRefreshPress: function() {
+         if (this.websocket)
+            this.websocket.Send("REFRESH");
+      }
+   });
+
+});

--- a/tutorials/webgui/panel/controller/TestPanel.controller.js
+++ b/tutorials/webgui/panel/controller/TestPanel.controller.js
@@ -16,7 +16,7 @@ sap.ui.define([
       onPanelExit : function() {
       },
 
-      OnWebsocketMsg: function(handle, msg, offset) {
+      onPanelReceive: function(msg, offset) {
          if (typeof msg != "string") {
             // binary data transfer not used in this example
             var arr = new Float32Array(msg, offset);
@@ -28,7 +28,7 @@ sap.ui.define([
             if (data)
                this.getView().setModel(new JSONModel(data));
          } else {
-            this.getView().byId("SampleText").setText("Get message:\n" + msg);
+            MessageToast.show("Receive msg: " + msg.substr(0,30));
          }
       },
 

--- a/tutorials/webgui/panel/controller/TestPanel.controller.js
+++ b/tutorials/webgui/panel/controller/TestPanel.controller.js
@@ -9,7 +9,7 @@ sap.ui.define([
 
       // function called from rootui5.panel.Controller
       onPanelInit : function() {
-         if (document) document.title = "TestPanel";
+         this.setPanelTitle("TestPanel");
       },
 
       // function called from rootui5.panel.Controller
@@ -36,15 +36,13 @@ sap.ui.define([
          MessageToast.show("Press sample button");
       },
 
+      // just send model as is to the server back
       handleSendPress: function() {
-         // just send model as is to the server back
-         if (this.websocket)
-            this.websocket.Send("MODEL:" + this.getView().getModel().getJSON());
+         this.panelSend("MODEL:" + this.getView().getModel().getJSON());
       },
 
       handleRefreshPress: function() {
-         if (this.websocket)
-            this.websocket.Send("REFRESH");
+         this.panelSend("REFRESH");
       }
    });
 

--- a/tutorials/webgui/panel/server.cxx
+++ b/tutorials/webgui/panel/server.cxx
@@ -55,7 +55,7 @@ void ProcessData(unsigned connid, const std::string &arg)
 
       auto m = TBufferJSON::FromJSON<TestPanelModel>(arg.substr(6));
       if (m) {
-         printf("New model, selected %s\n", m->fSelectId.c_str());
+         printf("New model, selected: %s\n", m->fSelectId.c_str());
          std::swap(model, m);
       }
    }

--- a/tutorials/webgui/panel/server.cxx
+++ b/tutorials/webgui/panel/server.cxx
@@ -1,0 +1,90 @@
+/// \file
+/// \ingroup tutorial_webgui
+///  This macro demonstrates simple openui5 panel, shown with RWebWindow
+/// \macro_code
+///
+/// \author Sergey Linev
+
+
+#include <ROOT/RWebWindowsManager.hxx>
+#include "TBufferJSON.h"
+#include <vector>
+#include <string>
+
+/** Simple structure for ComboBox item */
+struct ComboBoxItem {
+   std::string fId;
+   std::string fName;
+   ComboBoxItem() = default;
+   ComboBoxItem(const std::string &id, const std::string &name) : fId(id), fName(name) {}
+};
+
+/** Full model used to configure openui5 widget */
+struct TestPanelModel {
+   std::string fSampleText;
+   std::vector<ComboBoxItem> fComboItems;
+   std::string fSelectId;
+   std::string fButtonText;
+};
+
+std::shared_ptr<ROOT::Experimental::RWebWindow> window;
+std::unique_ptr<TestPanelModel> model;
+
+void ProcessData(unsigned connid, const std::string &arg)
+{
+   if (arg == "CONN_READY") {
+      printf("connection established %u\n", connid);
+
+      TString json = TBufferJSON::ToJSON(model.get());
+      window->Send(connid, std::string("MODEL:") + json.Data());
+      return;
+   }
+
+   if (arg == "CONN_CLOSED") {
+      printf("connection closed\n");
+      return;
+   }
+
+   if (arg == "REFRESH") {
+      // send model to client again
+      printf("Resend model\n");
+      TString json = TBufferJSON::ToJSON(model.get());
+      window->Send(connid, std::string("MODEL:") + json.Data());
+      return;
+   }
+
+   if (arg.find("MODEL:") == 0) {
+      printf("Decode model %s\n", arg.c_str());
+
+      auto m = TBufferJSON::FromJSON<TestPanelModel>(arg.substr(6));
+      if (m) {
+         printf("Selected %s\n", m->fSelectId.c_str());
+         std::swap(model, m);
+      }
+      return;
+   }
+}
+
+void server()
+{
+   // prepare model
+   model = std::make_unique<TestPanelModel>();
+   model->fSampleText = "This is openui5 widget";
+   model->fComboItems = {{"item1", "Text 1"}, {"item2", "Text 2"}, {"item3", "Text 3"}, {"item4", "Text 4"}};
+   model->fSelectId = "item2";
+   model->fButtonText = "Custom button";
+
+   // create window
+   window = ROOT::Experimental::RWebWindowsManager::Instance()->CreateWindow();
+
+   // this is very important, it defines name of openui5 widget
+   // "localapp" prefix indicates that all files located in current directory
+   window->SetPanelName("localapp.view.TestPanel");
+
+   // this is call-back, invoked when message received via websocket
+   window->SetDataCallBack(ProcessData);
+
+   window->SetGeometry(400, 500); // configure window geometry
+
+   window->Show();
+}

--- a/tutorials/webgui/panel/server.cxx
+++ b/tutorials/webgui/panel/server.cxx
@@ -6,7 +6,7 @@
 /// \author Sergey Linev
 
 
-#include <ROOT/RWebWindowsManager.hxx>
+#include <ROOT/RWebWindow.hxx>
 #include "TBufferJSON.h"
 #include <vector>
 #include <string>
@@ -75,7 +75,7 @@ void server()
    model->fButtonText = "Custom button";
 
    // create window
-   window = ROOT::Experimental::RWebWindowsManager::Instance()->CreateWindow();
+   window = ROOT::Experimental::RWebWindow::Create();
 
    // this is very important, it defines name of openui5 widget
    // "localapp" prefix indicates that all files located in current directory

--- a/tutorials/webgui/panel/view/TestPanel.view.xml
+++ b/tutorials/webgui/panel/view/TestPanel.view.xml
@@ -1,0 +1,26 @@
+<mvc:View class="sapUiSizeCompact" height="100%" controllerName="localapp.controller.TestPanel"
+   xmlns:mvc="sap.ui.core.mvc" xmlns:core="sap.ui.core"  xmlns="sap.m">
+   <Page id="testpanel_page" title="Test Panel" showHeader="true">
+       <content>
+         <VBox class="sapUiSmallMargin">
+            <Label text="Text:" labelFor="SampleText"/>
+            <Text id="SampleText" text="{/fSampleText}"/>
+            <Label text="ComboBox:" labelFor="SamleComboBox"/>
+            <ComboBox id="SamleComboBox" selectedKey="{/fSelectId}" items="{ path: '/fComboItems', sorter: { path: 'fName' } }">
+               <core:Item key="{fId}" text="{fName}" />
+            </ComboBox>
+            <Label text="Button:" labelFor="SampleButton"/>
+            <Button id="SampleButton" text="{/fButtonText}" press="handleButtonPress"/>
+         </VBox>
+      </content>
+      <footer>
+         <Bar>
+            <contentRight>
+               <Button text="Send" press="handleSendPress" />
+               <Button text="Refresh" press="handleRefreshPress" />
+               <Button text="Close" press="closePanel" />
+            </contentRight>
+         </Bar>
+      </footer>
+   </Page>
+</mvc:View>

--- a/tutorials/webgui/webwindow/server.cxx
+++ b/tutorials/webgui/webwindow/server.cxx
@@ -37,7 +37,7 @@ void ProcessData(unsigned connid, const std::string &arg)
 
 void server()
 {
-   // create window, manager can handle many windows a time
+   // create window
    window = ROOT::Experimental::RWebWindow::Create();
 
    // configure default html page

--- a/tutorials/webgui/webwindow/server.cxx
+++ b/tutorials/webgui/webwindow/server.cxx
@@ -8,8 +8,7 @@
 ///
 /// \author Sergey Linev
 
-
-#include <ROOT/RWebWindowsManager.hxx>
+#include <ROOT/RWebWindow.hxx>
 
 std::shared_ptr<ROOT::Experimental::RWebWindow> window;
 
@@ -42,14 +41,14 @@ void ProcessData(unsigned connid, const std::string &arg)
       window->SendBinary(connid, arr, sizeof(arr));
    } else if (arg == "halt") {
       // terminate ROOT
-      ROOT::Experimental::RWebWindowsManager::Instance()->Terminate();
+      window->TerminateROOT();
    }
 }
 
 void server()
 {
    // create window, manager can handle many windows a time
-   window = ROOT::Experimental::RWebWindowsManager::Instance()->CreateWindow();
+   window = ROOT::Experimental::RWebWindow::Create();
 
    // configure default html page
    // either HTML code can be specified or just name of file after 'file:' prefix

--- a/tutorials/webgui/webwindow/server.cxx
+++ b/tutorials/webgui/webwindow/server.cxx
@@ -16,16 +16,6 @@ int counter{0};
 
 void ProcessData(unsigned connid, const std::string &arg)
 {
-   if (arg == "CONN_READY") {
-      printf("connection established %u\n", connid);
-      return;
-   }
-
-   if (arg == "CONN_CLOSED") {
-      printf("connection closed\n");
-      return;
-   }
-
    printf("Get msg %s \n", arg.c_str());
 
    counter++;

--- a/ui5/panel/Controller.js
+++ b/ui5/panel/Controller.js
@@ -14,7 +14,7 @@ sap.ui.define([
             this.websocket.SetReceiver(this); // redirect websocket handling on controller itself
             this.websocket.Send("PANEL_READY"); // confirm panel creation, only then GUI can send commands
          }
-         
+
          // TODO: use more specific API between Canvas and Panel
          if (data && data.masterPanel) {
             this.masterPanel = data.masterPanel;
@@ -27,7 +27,7 @@ sap.ui.define([
          console.log('Connection established - should never happen');
       },
 
-      OnWebsocketMsg: function(handle, msg) {
+      OnWebsocketMsg: function(handle, msg, offset) {
           console.log('GuiPanel Get message ' + msg);
       },
 
@@ -37,8 +37,20 @@ sap.ui.define([
           delete this.websocket; // remove reference on websocket
       },
 
+      setPanelTitle: function(title) {
+         if (!this.masterPanel && document)
+            document.title = title;
+      },
+
+      panelSend: function(msg) {
+         if (this.websocket)
+            this.websocket.Send(msg);
+         else
+            console.error('No connection available to send message');
+      },
+
       onExit: function() {
-         if (this.onPanelExit) 
+         if (this.onPanelExit)
             this.onPanelExit();
          if (this.websocket) {
             this.websocket.Close();
@@ -46,8 +58,9 @@ sap.ui.define([
          }
       },
 
+      /** Method should be used to close panel
+       * Depending from used window manager different functionality can be used here */
       closePanel: function() {
-         
          if (this.masterPanel) {
             if (this.masterPanel.showLeftArea) this.masterPanel.showLeftArea("");
          } else {

--- a/ui5/panel/Controller.js
+++ b/ui5/panel/Controller.js
@@ -6,6 +6,12 @@ sap.ui.define([
 
    return Controller.extend("rootui5.panel.Controller", {
 
+      // one could define in derived classes followin methods
+      //   onPanelInit: function() {},
+      //   onPanelReceive: function(msg, offset) {},
+      //   onPanelExit: function(),
+
+
       onInit: function() {
          var data = this.getView().getViewData();
 
@@ -20,7 +26,8 @@ sap.ui.define([
             this.masterPanel = data.masterPanel;
          }
 
-         if (this.onPanelInit) this.onPanelInit();
+         if (typeof this.onPanelInit == "function")
+            this.onPanelInit();
       },
 
       OnWebsocketOpened: function(handle) {
@@ -28,7 +35,10 @@ sap.ui.define([
       },
 
       OnWebsocketMsg: function(handle, msg, offset) {
-          console.log('GuiPanel Get message ' + msg);
+         if (typeof this.onPanelReceive == 'function')
+            this.onPanelReceive(msg, offset);
+         else
+            console.log('GuiPanel Get message ' + msg);
       },
 
       OnWebsocketClosed: function(handle) {
@@ -50,7 +60,7 @@ sap.ui.define([
       },
 
       onExit: function() {
-         if (this.onPanelExit)
+         if (typeof this.onPanelExit == 'function')
             this.onPanelExit();
          if (this.websocket) {
             this.websocket.Close();


### PR DESCRIPTION
Introduce special handler for connecting and disconnecting events
Avoid usage of predefined "CONN_READY" and "CONN_CLOSED" arguments
Adjust existing widgets and tutorials
These changes in callbacks **brakes backward compatibility** - in my mind, it was necessary

Hide RWebWindowsManager for ordinary users - provide convenience `RWebWindow::Create()` and `RWebWindow::TerinateROOT()` methods. Now one can include just `ROOT/RWebWindow.hxx` to get all necessary functionality.

Provide tutorial with simple openui5 panel - of course, using new methods