### PR TITLE
[RF] Cleanup Histogram classes

### DIFF
--- a/roofit/roofitcore/inc/RooAbsDataStore.h
+++ b/roofit/roofitcore/inc/RooAbsDataStore.h
@@ -77,7 +77,7 @@ public:
   virtual void attachBuffers(const RooArgSet& extObs) = 0 ; 
   virtual void resetBuffers() = 0 ;
 
-  virtual void setExternalWeightArray(Double_t* /*arrayWgt*/, Double_t* /*arrayWgtErrLo*/, Double_t* /*arrayWgtErrHi*/, Double_t* /*arraySumW2*/) {} ;
+  virtual void setExternalWeightArray(const Double_t* /*arrayWgt*/, const Double_t* /*arrayWgtErrLo*/, const Double_t* /*arrayWgtErrHi*/, const Double_t* /*arraySumW2*/) {} ;
 
   // Printing interface (human readable)
   inline virtual void Print(Option_t *options= 0) const {

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -274,7 +274,7 @@ public:
   virtual RooAbsGenContext* autoGenContext(const RooArgSet &vars, const RooDataSet* prototype=0, const RooArgSet* auxProto=0, 
 					   Bool_t verbose=kFALSE, Bool_t autoBinned=kTRUE, const char* binnedTag="") const ;
 
-protected:
+private:
 
   RooDataSet *generate(RooAbsGenContext& context, const RooArgSet& whatVars, const RooDataSet* prototype,
 		       Double_t nEvents, Bool_t verbose, Bool_t randProtoOrder, Bool_t resampleProto, Bool_t skipInit=kFALSE, 
@@ -285,7 +285,7 @@ protected:
                            const char *label= "", Int_t sigDigits = 2, Option_t *options = "NELU", Double_t xmin=0.65,
 			   Double_t xmax= 0.99,Double_t ymax=0.95, const RooCmdArg* formatCmd=0) ;
 
-
+protected:
   virtual RooPlot *plotOn(RooPlot *frame, PlotOpt o) const;  
 
   friend class RooEffGenContext ;

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -182,7 +182,6 @@ protected:
   Double_t*      _binv ; //[_arrSize] Bin volume array  
 
   RooArgSet  _realVars ; // Real dimensions of the dataset 
-  TIterator* _realIter ; //! Iterator over realVars
   Bool_t*    _binValid ; //! Valid bins with current range definition
  
   mutable Double_t _curWeight{0.}; // Weight associated with the current coordinate

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -160,17 +160,17 @@ protected:
 
   virtual RooAbsData* cacheClone(const RooAbsArg* newCacheOwner, const RooArgSet* newCacheVars, const char* newName=0) ;
 
-  virtual Double_t get_wgt(const Int_t &idx) const { return _wgt[idx]; }
-  virtual Double_t get_errLo(const Int_t &idx) const { return _errLo[idx]; }
-  virtual Double_t get_errHi(const Int_t &idx) const { return _errHi[idx]; }
-  virtual Double_t get_sumw2(const Int_t &idx) const { return _sumw2[idx]; }
+  Double_t get_wgt(const Int_t &idx) const { return _wgt[idx]; }
+  Double_t get_errLo(const Int_t &idx) const { return _errLo[idx]; }
+  Double_t get_errHi(const Int_t &idx) const { return _errHi[idx]; }
+  Double_t get_sumw2(const Int_t &idx) const { return _sumw2[idx]; }
 
-  virtual Double_t get_curWeight() const { return _curWeight; }
-  virtual Double_t get_curWgtErrLo() const { return _curWgtErrLo; }
-  virtual Double_t get_curWgtErrHi() const { return _curWgtErrHi; }
-  virtual Double_t get_curSumW2() const { return _curSumW2; }
+  Double_t get_curWeight() const { return _curWeight; }
+  Double_t get_curWgtErrLo() const { return _curWgtErrLo; }
+  Double_t get_curWgtErrHi() const { return _curWgtErrHi; }
+  Double_t get_curSumW2() const { return _curSumW2; }
 
-  virtual Int_t get_curIndex() const { return _curIndex; }
+  Int_t get_curIndex() const { return _curIndex; }
 
   Int_t       _arrSize ; //  Size of the weight array
   std::vector<Int_t> _idxMult ; // Multiplier jump table for index calculation

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -195,7 +195,7 @@ RooCmdArg SumCoefRange(const char* rangeName) ;
 RooCmdArg Constrain(const RooArgSet& params) ;
 RooCmdArg GlobalObservables(const RooArgSet& globs) ;
 RooCmdArg GlobalObservablesTag(const char* tagName) ;
-RooCmdArg Constrained() ;
+//RooCmdArg Constrained() ;
 RooCmdArg ExternalConstraints(const RooArgSet& constraintPdfs) ;
 RooCmdArg PrintEvalErrors(Int_t numErrors) ;
 RooCmdArg EvalErrorWall(Bool_t flag) ;

--- a/roofit/roofitcore/inc/RooHistFunc.h
+++ b/roofit/roofitcore/inc/RooHistFunc.h
@@ -88,8 +88,6 @@ protected:
 
   RooArgSet         _histObsList ; // List of observables defining dimensions of histogram
   RooSetProxy       _depList ;  // List of observables mapped onto histogram observables
-  TIterator*         _histObsIter ; //! 
-  TIterator*         _pdfObsIter ; //! 
   RooDataHist*      _dataHist ;  // Unowned pointer to underlying histogram
   mutable RooAICRegistry _codeReg ; //! Auxiliary class keeping tracking of analytical integration code
   Int_t             _intOrder ; // Interpolation order

--- a/roofit/roofitcore/inc/RooHistPdf.h
+++ b/roofit/roofitcore/inc/RooHistPdf.h
@@ -97,8 +97,6 @@ protected:
   RooArgSet         _histObsList ; // List of observables defining dimensions of histogram
   RooSetProxy       _pdfObsList ;  // List of observables mapped onto histogram observables
   RooDataHist*      _dataHist ;  // Unowned pointer to underlying histogram
-  TIterator*         _histObsIter ; //! 
-  TIterator*         _pdfObsIter ; //! 
   mutable RooAICRegistry _codeReg ; //! Auxiliary class keeping tracking of analytical integration code
   Int_t             _intOrder ; // Interpolation order
   Bool_t            _cdfBoundaries ; // Use boundary conditions for CDFs.

--- a/roofit/roofitcore/inc/RooRealSumPdf.h
+++ b/roofit/roofitcore/inc/RooRealSumPdf.h
@@ -82,12 +82,8 @@ protected:
   mutable RooObjCacheManager _normIntMgr ; // The integration cache manager
 
 
-  Bool_t _haveLastCoef ;
-
   RooListProxy _funcList ;   //  List of component FUNCs
   RooListProxy _coefList ;  //  List of coefficients
-  TIterator* _funcIter ;     //! Iterator over FUNC list
-  TIterator* _coefIter ;    //! Iterator over coefficient list
   Bool_t _extended ;        // Allow use as extended p.d.f.
 
   Bool_t _doFloor ; // Introduce floor at zero in pdf
@@ -95,7 +91,11 @@ protected:
   
 private:
 
-  ClassDef(RooRealSumPdf,3) // PDF constructed from a sum of (non-pdf) functions
+  constexpr bool haveLastCoef() const {
+    return _funcList.size() == _coefList.size();
+  }
+
+  ClassDef(RooRealSumPdf, 4) // PDF constructed from a sum of (non-pdf) functions
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooRealSumPdf.h
+++ b/roofit/roofitcore/inc/RooRealSumPdf.h
@@ -91,7 +91,7 @@ protected:
   
 private:
 
-  constexpr bool haveLastCoef() const {
+  bool haveLastCoef() const {
     return _funcList.size() == _coefList.size();
   }
 

--- a/roofit/roofitcore/inc/RooSimGenContext.h
+++ b/roofit/roofitcore/inc/RooSimGenContext.h
@@ -47,20 +47,20 @@ protected:
 
   RooSimGenContext(const RooSimGenContext& other) ;
 
-  RooAbsCategoryLValue* _idxCat ; // Clone of index category
-  RooArgSet*            _idxCatSet ; // Owner of index category components
-  const RooDataSet *_prototype;   // Prototype data set
-  const RooSimultaneous *_pdf ;   // Original PDF
+  RooAbsCategoryLValue* _idxCat{nullptr}; // Clone of index category
+  RooArgSet*            _idxCatSet{nullptr}; // Owner of index category components
+  const RooDataSet *_prototype{nullptr};   // Prototype data set
+  const RooSimultaneous *_pdf{nullptr};   // Original PDF
   std::vector<RooAbsGenContext*> _gcList ; // List of component generator contexts
   std::vector<int>               _gcIndex ; // Index value corresponding to component
-  Bool_t _haveIdxProto ;          // Flag set if generation of index is requested
-  TString _idxCatName ;           // Name of index category
-  Int_t _numPdf ;                 // Number of generated PDFs
-  Double_t* _fracThresh ;         //[_numPdf] Fraction threshold array
-  RooDataSet* _protoData ;        //! Prototype dataset
+  Bool_t _haveIdxProto{false};          // Flag set if generation of index is requested
+  TString _idxCatName{};           // Name of index category
+  Int_t _numPdf{0};                 // Number of generated PDFs
+  Double_t* _fracThresh{nullptr};         //[_numPdf] Fraction threshold array
+  RooDataSet* _protoData{nullptr};        //! Prototype dataset
 
-  RooArgSet _allVarsPdf ; // All pdf variables
-  TIterator* _proxyIter ; // Iterator over pdf proxies
+  RooArgSet _allVarsPdf{}; // All pdf variables
+  TIterator* _proxyIter{nullptr}; // Iterator over pdf proxies
 
   ClassDef(RooSimGenContext,0) // Context for efficiently generating a dataset from a RooSimultaneous PDF
 };

--- a/roofit/roofitcore/inc/RooTreeDataStore.h
+++ b/roofit/roofitcore/inc/RooTreeDataStore.h
@@ -113,7 +113,8 @@ public:
 
   virtual void checkInit() const;
 
-  void setExternalWeightArray(Double_t* arrayWgt, Double_t* arrayWgtErrLo, Double_t* arrayWgtErrHi, Double_t* arraySumW2) { 
+  void setExternalWeightArray(const Double_t* arrayWgt, const Double_t* arrayWgtErrLo,
+      const Double_t* arrayWgtErrHi, const Double_t* arraySumW2) {
     _extWgtArray = arrayWgt ; 
     _extWgtErrLoArray = arrayWgtErrLo ;
     _extWgtErrHiArray = arrayWgtErrHi ;

--- a/roofit/roofitcore/inc/RooVectorDataStore.h
+++ b/roofit/roofitcore/inc/RooVectorDataStore.h
@@ -114,7 +114,8 @@ public:
   
   void dump() ;
 
-  void setExternalWeightArray(Double_t* arrayWgt, Double_t* arrayWgtErrLo, Double_t* arrayWgtErrHi, Double_t* arraySumW2) { 
+  void setExternalWeightArray(const Double_t* arrayWgt, const Double_t* arrayWgtErrLo,
+      const Double_t* arrayWgtErrHi, const Double_t* arraySumW2) {
     _extWgtArray = arrayWgt ; 
     _extWgtErrLoArray = arrayWgtErrLo ;
     _extWgtErrHiArray = arrayWgtErrHi ;
@@ -739,10 +740,10 @@ public:
   Double_t _sumWeight ; 
   Double_t _sumWeightCarry;
 
-  Double_t* _extWgtArray ;         //! External weight array
-  Double_t* _extWgtErrLoArray ;    //! External weight array - low error
-  Double_t* _extWgtErrHiArray ;    //! External weight array - high error
-  Double_t* _extSumW2Array ;       //! External sum of weights array
+  const Double_t* _extWgtArray ;         //! External weight array
+  const Double_t* _extWgtErrLoArray ;    //! External weight array - low error
+  const Double_t* _extWgtErrHiArray ;    //! External weight array - high error
+  const Double_t* _extSumW2Array ;       //! External sum of weights array
 
   mutable Double_t  _curWgt ;      // Weight of current event
   mutable Double_t  _curWgtErrLo ; // Weight of current event

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -1101,17 +1101,15 @@ Double_t RooDataHist::weight(const RooArgSet& bin, Int_t intOrder, Bool_t correc
   if (_realVars.getSize()==1) {
 
     // 1-dimensional interpolation
-    RooFIter realIter = _realVars.fwdIterator() ;
-    RooRealVar* real=(RooRealVar*)realIter.next() ;
+    const auto real = static_cast<RooRealVar*>(_realVars[static_cast<std::size_t>(0)]);
     const RooAbsBinning* binning = real->getBinningPtr(0) ;
     wInt = interpolateDim(*real,binning,((RooAbsReal*)bin.find(*real))->getVal(), intOrder, correctForBinSize, cdfBoundaries) ;
     
   } else if (_realVars.getSize()==2) {
 
     // 2-dimensional interpolation
-    RooFIter realIter = _realVars.fwdIterator() ;
-    RooRealVar* realX=(RooRealVar*)realIter.next() ;
-    RooRealVar* realY=(RooRealVar*)realIter.next() ;
+    const auto realX = static_cast<RooRealVar*>(_realVars[static_cast<std::size_t>(0)]);
+    const auto realY = static_cast<RooRealVar*>(_realVars[static_cast<std::size_t>(1)]);
     Double_t xval = ((RooAbsReal*)bin.find(*realX))->getVal() ;
     Double_t yval = ((RooAbsReal*)bin.find(*realY))->getVal() ;
     

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -71,7 +71,6 @@ RooDataHist::RooDataHist() : _pbinvCacheMgr(0,10)
   _pbinv = 0 ;
   _curWeight = 0 ;
   _curIndex = -1 ;
-  _realIter = _realVars.createIterator() ;
   _binValid = 0 ;
   _curSumW2 = 0 ;
   _curVolume = 1 ;
@@ -677,7 +676,6 @@ void RooDataHist::initialize(const char* binningName, Bool_t fillTree)
   for (const auto real : _vars) {
     if (dynamic_cast<RooAbsReal*>(real)) _realVars.add(*real);
   }
-  _realIter = _realVars.createIterator() ;
 
   // Fill array of LValue pointers to variables
   for (const auto rvarg : _vars) {
@@ -807,7 +805,6 @@ RooDataHist::RooDataHist(const RooDataHist& other, const char* newname) :
   for (const auto arg : _vars) {
     if (dynamic_cast<RooAbsReal*>(arg) != nullptr) _realVars.add(*arg) ;
   }
-  _realIter = _realVars.createIterator() ;
 
   // Fill array of LValue pointers to variables
   for (const auto rvarg : _vars) {
@@ -951,7 +948,6 @@ RooDataHist::~RooDataHist()
   if (_errHi) delete[] _errHi ;
   if (_sumw2) delete[] _sumw2 ;
   if (_binv) delete[] _binv ;
-  if (_realIter) delete _realIter ;
   if (_binValid) delete[] _binValid ;
   vector<const RooAbsBinning*>::iterator iter = _lvbins.begin() ;
   while(iter!=_lvbins.end()) {
@@ -988,14 +984,13 @@ Int_t RooDataHist::getIndex(const RooArgSet& coord, Bool_t fast)
 
 Int_t RooDataHist::calcTreeIndex() const 
 {
-  Int_t masterIdx(0), i(0) ;
-  vector<RooAbsLValue*>::const_iterator iter = _lvvars.begin() ;
-  vector<const RooAbsBinning*>::const_iterator biter = _lvbins.begin() ;
-  for (;iter!=_lvvars.end() ; ++iter) {
-    const RooAbsBinning* binning = (*biter) ;
-    masterIdx += _idxMult[i++]*(*iter)->getBin(binning) ;
-    ++biter ;
+  int masterIdx(0);
+  for (unsigned int i=0; i < _lvvars.size(); ++i) {
+    const RooAbsLValue*  lvvar = _lvvars[i];
+    const RooAbsBinning* binning = _lvbins[i];
+    masterIdx += _idxMult[i] * lvvar->getBin(binning);
   }
+
   return masterIdx ;
 }
 

--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -197,7 +197,7 @@ namespace RooFit {
   RooCmdArg Constrain(const RooArgSet& params)           { return RooCmdArg("Constrain",0,0,0,0,0,0,0,0,0,0,&params) ; }
   RooCmdArg GlobalObservables(const RooArgSet& globs)    { return RooCmdArg("GlobalObservables",0,0,0,0,0,0,0,0,0,0,&globs) ; }
   RooCmdArg GlobalObservablesTag(const char* tagName)    { return RooCmdArg("GlobalObservablesTag",0,0,0,0,tagName,0,0,0) ; }
-  RooCmdArg Constrained()                                { return RooCmdArg("Constrained",kTRUE,0,0,0,0,0,0,0) ; }
+//  RooCmdArg Constrained()                                { return RooCmdArg("Constrained",kTRUE,0,0,0,0,0,0,0) ; }
   RooCmdArg ExternalConstraints(const RooArgSet& cpdfs)  { return RooCmdArg("ExternalConstraints",0,0,0,0,0,0,&cpdfs,0,0,0,&cpdfs) ; }
   RooCmdArg PrintEvalErrors(Int_t numErrors)             { return RooCmdArg("PrintEvalErrors",numErrors,0,0,0,0,0,0,0) ; }
   RooCmdArg EvalErrorWall(Bool_t flag)                   { return RooCmdArg("EvalErrorWall",flag,0,0,0,0,0,0,0) ; }

--- a/roofit/roofitcore/src/RooMCStudy.cxx
+++ b/roofit/roofitcore/src/RooMCStudy.cxx
@@ -899,14 +899,12 @@ Bool_t RooMCStudy::addFitResult(const RooFitResult& fr)
 
 void RooMCStudy::calcPulls() 
 {
-  TIterator* iter = _fitParams->createIterator()  ;
-  RooRealVar* par ;
-  while((par=(RooRealVar*)iter->Next())) {
-    
-    RooErrorVar* err = par->errorVar() ;
-    _fitParData->addColumn(*err) ;
-    delete err ;
-    
+  for (const auto elm : *_fitParams) {
+    const auto par = static_cast<RooRealVar*>(elm);
+    RooErrorVar* err = par->errorVar();
+    _fitParData->addColumn(*err);
+    delete err;
+
     TString name(par->GetName()), title(par->GetTitle()) ;
     name.Append("pull") ;
     title.Append(" Pull") ;    
@@ -921,21 +919,19 @@ void RooMCStudy::calcPulls()
     } else {
       // If not use fixed generator value
       genParOrig = (RooAbsReal*)_genInitParams->find(par->GetName()) ;
-      
+
       if (genParOrig) {
-	RooAbsReal* genPar = (RooAbsReal*) genParOrig->Clone("truth") ;
-	RooPullVar pull(name,title,*par,*genPar) ;
-	
-	_fitParData->addColumn(pull,kFALSE) ;
-	delete genPar ;
-	
+        RooAbsReal* genPar = (RooAbsReal*) genParOrig->Clone("truth") ;
+        RooPullVar pull(name,title,*par,*genPar) ;
+
+        _fitParData->addColumn(pull,kFALSE) ;
+        delete genPar ;
+
       }
 
     }
 
   }
-  delete iter ;
-  
 }
 
 
@@ -1134,8 +1130,8 @@ RooPlot* RooMCStudy::plotNLL(const RooCmdArg& arg1, const RooCmdArg& arg2,
 ///     for list of allowed arguments
 /// </table>
 ///
-/// If no frame specifications are given, the AutoRange() feature will be used to set the range
-/// Any other named argument is passed to the RooAbsData::plotOn() call. See that function for allowed options
+/// If no frame specifications are given, the AutoRange() feature will be used to set a default range.
+/// Any other named argument is passed to the RooAbsData::plotOn() call. See that function for allowed options.
 
 RooPlot* RooMCStudy::plotError(const RooRealVar& param, const RooCmdArg& arg1, const RooCmdArg& arg2,
                      const RooCmdArg& arg3, const RooCmdArg& arg4,
@@ -1159,10 +1155,11 @@ RooPlot* RooMCStudy::plotError(const RooRealVar& param, const RooCmdArg& arg1, c
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Plot the distribution of pull values for the specified parameter on a newly created frame. If asymmetric
-/// errors are calculated in the fit (by MINOS) those will be used in the pull calculation
+/// errors are calculated in the fit (by MINOS) those will be used in the pull calculation.
 ///
+/// Further options:
 /// <table>
-/// <tr><th> Optional arguments <th>
+/// <tr><th> Arguments <th> Effect
 /// <tr><td> FrameRange(double lo, double hi) <td> Set range of frame to given specification
 /// <tr><td> FrameBins(int bins)              <td> Set default number of bins of frame to given number
 /// <tr><td> Frame()                       <td> Pass supplied named arguments to RooAbsRealLValue::frame() function. See there
@@ -1170,8 +1167,8 @@ RooPlot* RooMCStudy::plotError(const RooRealVar& param, const RooCmdArg& arg1, c
 /// <tr><td> FitGauss(Bool_t flag)            <td> Add a gaussian fit to the frame
 /// </table>
 ///
-/// If no frame specifications are given, the AutoSymRange() feature will be used to set the range
-/// Any other named argument is passed to the RooAbsData::plotOn() call. See that function for allowed options
+/// If no frame specifications are given, the AutoSymRange() feature will be used to set a default range.
+/// Any other named argument is passed to the RooAbsData::plotOn(). See that function for allowed options.
 
 RooPlot* RooMCStudy::plotPull(const RooRealVar& param, const RooCmdArg& arg1, const RooCmdArg& arg2,
                      const RooCmdArg& arg3, const RooCmdArg& arg4,

--- a/roofit/roofitcore/src/RooRealSumPdf.cxx
+++ b/roofit/roofitcore/src/RooRealSumPdf.cxx
@@ -70,8 +70,6 @@ Bool_t RooRealSumPdf::_doFloorGlobal = kFALSE ;
 
 RooRealSumPdf::RooRealSumPdf() 
 {
-  _funcIter  = _funcList.createIterator() ;
-  _coefIter  = _coefList.createIterator() ;
   _extended = kFALSE ;
   _doFloor = kFALSE ;
 }
@@ -84,14 +82,12 @@ RooRealSumPdf::RooRealSumPdf()
 RooRealSumPdf::RooRealSumPdf(const char *name, const char *title) :
   RooAbsPdf(name,title), 
   _normIntMgr(this,10),
-  _haveLastCoef(kFALSE),
   _funcList("!funcList","List of functions",this),
   _coefList("!coefList","List of coefficients",this),
   _extended(kFALSE),
   _doFloor(kFALSE)
 {
-  _funcIter   = _funcList.createIterator() ;
-  _coefIter  = _coefList.createIterator() ;
+
 }
 
 
@@ -105,15 +101,12 @@ RooRealSumPdf::RooRealSumPdf(const char *name, const char *title,
 		     RooAbsReal& func1, RooAbsReal& func2, RooAbsReal& coef1) : 
   RooAbsPdf(name,title),
   _normIntMgr(this,10),
-  _haveLastCoef(kFALSE),
   _funcList("!funcList","List of functions",this),
   _coefList("!coefList","List of coefficients",this),
   _extended(kFALSE),
   _doFloor(kFALSE)
 {
   // Special constructor with two functions and one coefficient
-  _funcIter  = _funcList.createIterator() ;
-  _coefIter = _coefList.createIterator() ;
 
   _funcList.add(func1) ;  
   _funcList.add(func2) ;
@@ -123,7 +116,8 @@ RooRealSumPdf::RooRealSumPdf(const char *name, const char *title,
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Constructor for a PDF implementing
+/// Constructor for a PDF from a list of functions and coefficients.
+/// It implements
 /// \f[
 ///   \sum_i \mathrm{coef}_i \cdot \mathrm{func}_i,
 /// \f]
@@ -139,11 +133,17 @@ RooRealSumPdf::RooRealSumPdf(const char *name, const char *title,
 /// 
 /// All coefficients and functions are allowed to be negative
 /// but the sum (*i.e.* the PDF) is not, which is enforced at runtime.
+///
+/// \param name Name of the PDF
+/// \param title Title (for plotting)
+/// \param inFuncList List of functions to sum
+/// \param inCoefList List of coefficients
+/// \param extended   Interpret as extended PDF (requires equal number of functions and coefficients)
 
-RooRealSumPdf::RooRealSumPdf(const char *name, const char *title, const RooArgList& inFuncList, const RooArgList& inCoefList, Bool_t extended) :
+RooRealSumPdf::RooRealSumPdf(const char *name, const char *title,
+    const RooArgList& inFuncList, const RooArgList& inCoefList, Bool_t extended) :
   RooAbsPdf(name,title),
   _normIntMgr(this,10),
-  _haveLastCoef(kFALSE),
   _funcList("!funcList","List of functions",this),
   _coefList("!coefList","List of coefficients",this),
   _extended(extended),
@@ -154,44 +154,33 @@ RooRealSumPdf::RooRealSumPdf(const char *name, const char *title, const RooArgLi
 			  << ") number of pdfs and coefficients inconsistent, must have Nfunc=Ncoef or Nfunc=Ncoef+1" << endl ;
     assert(0) ;
   }
-
-  _funcIter  = _funcList.createIterator() ;
-  _coefIter = _coefList.createIterator() ;
  
   // Constructor with N functions and N or N-1 coefs
-  TIterator* funcIter = inFuncList.createIterator() ;
-  TIterator* coefIter = inCoefList.createIterator() ;
-  RooAbsArg* func ;
-  RooAbsArg* coef ;
+  for (unsigned int i = 0; i < inCoefList.size(); ++i) {
+    const auto& func = inFuncList[i];
+    const auto& coef = inCoefList[i];
 
-  while((coef = (RooAbsArg*)coefIter->Next())) {
-    func = (RooAbsArg*) funcIter->Next() ;
-
-    if (!dynamic_cast<RooAbsReal*>(coef)) {
-      coutW(InputArguments) << "RooRealSumPdf::RooRealSumPdf(" << GetName() << ") coefficient " << coef->GetName() << " is not of type RooAbsReal, ignored" << endl ;
+    if (!dynamic_cast<const RooAbsReal*>(&coef)) {
+      coutW(InputArguments) << "RooRealSumPdf::RooRealSumPdf(" << GetName() << ") coefficient " << coef.GetName() << " is not of type RooAbsReal, ignored" << endl ;
       continue ;
     }
-    if (!dynamic_cast<RooAbsReal*>(func)) {
-      coutW(InputArguments) << "RooRealSumPdf::RooRealSumPdf(" << GetName() << ") func " << func->GetName() << " is not of type RooAbsReal, ignored" << endl ;
+    if (!dynamic_cast<const RooAbsReal*>(&func)) {
+      coutW(InputArguments) << "RooRealSumPdf::RooRealSumPdf(" << GetName() << ") func " << func.GetName() << " is not of type RooAbsReal, ignored" << endl ;
       continue ;
     }
-    _funcList.add(*func) ;
-    _coefList.add(*coef) ;    
+    _funcList.add(func) ;
+    _coefList.add(coef) ;
   }
 
-  func = (RooAbsReal*) funcIter->Next() ;
-  if (func) {
-    if (!dynamic_cast<RooAbsReal*>(func)) {
-      coutE(InputArguments) << "RooRealSumPdf::RooRealSumPdf(" << GetName() << ") last func " << coef->GetName() << " is not of type RooAbsReal, fatal error" << endl ;
+  if (inFuncList.size() == inCoefList.size() + 1) {
+    const auto& func = inFuncList[inFuncList.size()-1];
+    if (!dynamic_cast<const RooAbsReal*>(&func)) {
+      coutE(InputArguments) << "RooRealSumPdf::RooRealSumPdf(" << GetName() << ") last func " << func.GetName() << " is not of type RooAbsReal, fatal error" << endl ;
       assert(0) ;
     }
-    _funcList.add(*func) ;  
-  } else {
-    _haveLastCoef = kTRUE ;
+    _funcList.add(func);
   }
   
-  delete funcIter ;
-  delete coefIter  ;
 }
 
 
@@ -203,14 +192,12 @@ RooRealSumPdf::RooRealSumPdf(const char *name, const char *title, const RooArgLi
 RooRealSumPdf::RooRealSumPdf(const RooRealSumPdf& other, const char* name) :
   RooAbsPdf(other,name),
   _normIntMgr(other._normIntMgr,this),
-  _haveLastCoef(other._haveLastCoef),
   _funcList("!funcList",this,other._funcList),
   _coefList("!coefList",this,other._coefList),
   _extended(other._extended),
   _doFloor(other._doFloor)
 {
-  _funcIter  = _funcList.createIterator() ;
-  _coefIter = _coefList.createIterator() ;
+
 }
 
 
@@ -220,8 +207,7 @@ RooRealSumPdf::RooRealSumPdf(const RooRealSumPdf& other, const char* name) :
 
 RooRealSumPdf::~RooRealSumPdf()
 {
-  delete _funcIter ;
-  delete _coefIter ;
+
 }
 
 
@@ -265,7 +251,7 @@ Double_t RooRealSumPdf::evaluate() const
     }
   }
   
-  if (!_haveLastCoef) {
+  if (!haveLastCoef()) {
     assert(funcIt != _funcList.end());
     // Add last func with correct coefficient
     auto func = static_cast<const RooAbsReal*>(*funcIt);
@@ -296,29 +282,27 @@ Double_t RooRealSumPdf::evaluate() const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Check if FUNC is valid for given normalization set.
-/// Coeffient and FUNC must be non-overlapping, but func-coefficient 
-/// pairs may overlap each other
+/// Coefficient and FUNC must be non-overlapping, but func-coefficient
+/// pairs may overlap each other.
 ///
 /// In the present implementation, coefficients may not be observables or derive
-/// from observables
+/// from observables.
 
 Bool_t RooRealSumPdf::checkObservables(const RooArgSet* nset) const 
 {
   Bool_t ret(kFALSE) ;
 
-  _funcIter->Reset() ;
-  _coefIter->Reset() ;
-  RooAbsReal* coef ;
-  RooAbsReal* func ;
-  while((coef=(RooAbsReal*)_coefIter->Next())) {
-    func = (RooAbsReal*)_funcIter->Next() ;
-    if (func->observableOverlaps(nset,*coef)) {
-      coutE(InputArguments) << "RooRealSumPdf::checkObservables(" << GetName() << "): ERROR: coefficient " << coef->GetName() 
-			    << " and FUNC " << func->GetName() << " have one or more observables in common" << endl ;
+  for (unsigned int i=0; i < _coefList.size(); ++i) {
+    const auto& coef = _coefList[i];
+    const auto& func = _funcList[i];
+
+    if (func.observableOverlaps(nset, coef)) {
+      coutE(InputArguments) << "RooRealSumPdf::checkObservables(" << GetName() << "): ERROR: coefficient " << coef.GetName()
+			    << " and FUNC " << func.GetName() << " have one or more observables in common" << endl ;
       ret = kTRUE ;
     }
-    if (coef->dependsOn(*nset)) {
-      coutE(InputArguments) << "RooRealPdf::checkObservables(" << GetName() << "): ERROR coefficient " << coef->GetName() 
+    if (coef.dependsOn(*nset)) {
+      coutE(InputArguments) << "RooRealPdf::checkObservables(" << GetName() << "): ERROR coefficient " << coef.GetName()
 			    << " depends on one or more of the following observables" ; nset->Print("1") ;
       ret = kTRUE ;
     }
@@ -357,9 +341,9 @@ Int_t RooRealSumPdf::getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& anal
   cache = new CacheElem ;
 
   // Make list of function projection and normalization integrals 
-  _funcIter->Reset() ;
-  RooAbsReal *func ;
-  while((func=(RooAbsReal*)_funcIter->Next())) {
+  for (const auto elm : _funcList) {
+    const auto func = static_cast<RooAbsReal*>(elm);
+
     RooAbsReal* funcInt = func->createIntegral(analVars,rangeName) ;
     if(funcInt->InheritsFrom(RooRealIntegral::Class())) ((RooRealIntegral*)funcInt)->setAllowComponentSelection(true);
     cache->_funcIntList.addOwned(*funcInt) ;
@@ -407,17 +391,18 @@ Double_t RooRealSumPdf::analyticalIntegralWN(Int_t code, const RooArgSet* normSe
      R__ASSERT(cache!=0);
   }
 
-  RooFIter funcIntIter = cache->_funcIntList.fwdIterator() ;
-  RooFIter coefIter = _coefList.fwdIterator() ;
-  RooFIter funcIter = _funcList.fwdIterator() ;
-  RooAbsReal *coef(0), *funcInt(0), *func(0) ;
   Double_t value(0) ;
 
   // N funcs, N-1 coefficients 
   Double_t lastCoef(1) ;
-  while((coef=(RooAbsReal*)coefIter.next())) {
-    funcInt = (RooAbsReal*)funcIntIter.next() ;
-    func    = (RooAbsReal*)funcIter.next() ;
+  auto funcIt = _funcList.begin();
+  auto funcIntIt = cache->_funcIntList.begin();
+  for (const auto coefArg : _coefList) {
+    assert(funcIt != _funcList.end());
+    const auto coef = static_cast<const RooAbsReal*>(coefArg);
+    const auto func = static_cast<const RooAbsReal*>(*funcIt++);
+    const auto funcInt = static_cast<RooAbsReal*>(*funcIntIt++);
+
     Double_t coefVal = coef->getVal(normSet2) ;
     if (coefVal) {
       assert(func);
@@ -429,9 +414,12 @@ Double_t RooRealSumPdf::analyticalIntegralWN(Int_t code, const RooArgSet* normSe
     }
   }
   
-  if (!_haveLastCoef) {
+  if (!haveLastCoef()) {
     // Add last func with correct coefficient
-    funcInt = (RooAbsReal*) funcIntIter.next() ;
+    const auto func = static_cast<const RooAbsReal*>(*funcIt);
+    const auto funcInt = static_cast<RooAbsReal*>(*funcIntIt);
+    assert(func);
+
     if (normSet2 ==0 || func->isSelectedComp()) {
       assert(funcInt);
       value += funcInt->getVal()*lastCoef ;
@@ -450,23 +438,24 @@ Double_t RooRealSumPdf::analyticalIntegralWN(Int_t code, const RooArgSet* normSe
     normVal = 0 ;
 
     // N funcs, N-1 coefficients 
-    RooAbsReal* funcNorm ;
-    RooFIter funcNormIter = cache->_funcNormList.fwdIterator() ;
-    RooFIter coefIter2 = _coefList.fwdIterator() ;
-    while((coef=(RooAbsReal*)coefIter2.next())) {
-      funcNorm = (RooAbsReal*)funcNormIter.next() ;
-      Double_t coefVal = coef->getVal(normSet2) ;
+    auto funcNormIter = cache->_funcNormList.begin();
+    for (const auto coefAsArg : _coefList) {
+      auto coef = static_cast<RooAbsReal*>(coefAsArg);
+      auto funcNorm = static_cast<RooAbsReal*>(*funcNormIter++);
+
+      Double_t coefVal = coef->getVal(normSet2);
       if (coefVal) {
-	assert(funcNorm);
-	normVal += funcNorm->getVal()*coefVal ;
+        assert(funcNorm);
+        normVal += funcNorm->getVal()*coefVal ;
       }
     }
-    
+
     // Add last func with correct coefficient
-    if (!_haveLastCoef) {
-      funcNorm = (RooAbsReal*) funcNormIter.next() ;
+    if (!haveLastCoef()) {
+      auto funcNorm = static_cast<RooAbsReal*>(*funcNormIter);
       assert(funcNorm);
-      normVal += funcNorm->getVal()*lastCoef ;
+
+      normVal += funcNorm->getVal()*lastCoef;
     }      
   }
 
@@ -493,10 +482,9 @@ std::list<Double_t>* RooRealSumPdf::binBoundaries(RooAbsRealLValue& obs, Double_
   list<Double_t>* sumBinB = 0 ;
   Bool_t needClean(kFALSE) ;
   
-  RooFIter iter = _funcList.fwdIterator() ;
-  RooAbsReal* func ;
   // Loop over components pdf
-  while((func=(RooAbsReal*)iter.next())) {
+  for (const auto elm : _funcList) {
+    auto func = static_cast<RooAbsReal*>(elm);
 
     list<Double_t>* funcBinB = func->binBoundaries(obs,xlo,xhi) ;
     
@@ -537,9 +525,9 @@ Bool_t RooRealSumPdf::isBinnedDistribution(const RooArgSet& obs) const
 {
   // If all components that depend on obs are binned that so is the product
   
-  RooFIter iter = _funcList.fwdIterator() ;
-  RooAbsReal* func ;
-  while((func=(RooAbsReal*)iter.next())) {
+  for (const auto elm : _funcList) {
+    auto func = static_cast<RooAbsReal*>(elm);
+
     if (func->dependsOn(obs) && !func->isBinnedDistribution(obs)) {
       return kFALSE ;
     }
@@ -559,10 +547,9 @@ std::list<Double_t>* RooRealSumPdf::plotSamplingHint(RooAbsRealLValue& obs, Doub
   list<Double_t>* sumHint = 0 ;
   Bool_t needClean(kFALSE) ;
   
-  RooFIter iter = _funcList.fwdIterator() ;
-  RooAbsReal* func ;
   // Loop over components pdf
-  while((func=(RooAbsReal*)iter.next())) {
+  for (const auto elm : _funcList) {
+    auto func = static_cast<RooAbsReal*>(elm);
 
     list<Double_t>* funcHint = func->plotSamplingHint(obs,xlo,xhi) ;
     
@@ -605,9 +592,7 @@ std::list<Double_t>* RooRealSumPdf::plotSamplingHint(RooAbsRealLValue& obs, Doub
 
 void RooRealSumPdf::setCacheAndTrackHints(RooArgSet& trackNodes) 
 {
-  RooFIter siter = funcList().fwdIterator() ;
-  RooAbsArg* sarg ;
-  while ((sarg=siter.next())) {
+  for (const auto sarg : _funcList) {
     if (sarg->canNodeBeCached()==Always) {
       trackNodes.add(*sarg) ;
       //cout << "tracking node RealSumPdf component " << sarg->IsA()->GetName() << "::" << sarg->GetName() << endl ;
@@ -623,33 +608,32 @@ void RooRealSumPdf::setCacheAndTrackHints(RooArgSet& trackNodes)
 
 void RooRealSumPdf::printMetaArgs(ostream& os) const 
 {
-  _funcIter->Reset() ;
-  _coefIter->Reset() ;
 
   Bool_t first(kTRUE) ;
     
-  RooAbsArg* coef, *func ;
-  if (_coefList.getSize()!=0) { 
-    while((coef=(RooAbsArg*)_coefIter->Next())) {
+  if (_coefList.getSize()!=0) {
+    auto funcIter = _funcList.begin();
+
+    for (const auto coef : _coefList) {
       if (!first) {
-	os << " + " ;
+        os << " + " ;
       } else {
-	first = kFALSE ;
+        first = kFALSE ;
       }
-      func=(RooAbsArg*)_funcIter->Next() ;
-      os << coef->GetName() << " * " << func->GetName() ;
+      const auto func = *(funcIter++);
+      os << coef->GetName() << " * " << func->GetName();
     }
-    func = (RooAbsArg*) _funcIter->Next() ;
-    if (func) {
-      os << " + [%] * " << func->GetName() ;
+
+    if (funcIter != _funcList.end()) {
+      os << " + [%] * " << (*funcIter)->GetName() ;
     }
   } else {
-    
-    while((func=(RooAbsArg*)_funcIter->Next())) {
+
+    for (const auto func : _funcList) {
       if (!first) {
-	os << " + " ;
+        os << " + " ;
       } else {
-	first = kFALSE ;
+        first = kFALSE ;
       }
       os << func->GetName() ; 
     }  


### PR DESCRIPTION
Cleanup RooDataHist and RooHistFunc to facilitate future development. Specifically, remove iterators that are members, which carry unnecessary state around in between iterations. These were replaced by range-based for loops.