### PR TITLE
[webgui] disable some qt5 cleanup during application exit

### DIFF
--- a/gui/qt5webdisplay/rootqt5.cpp
+++ b/gui/qt5webdisplay/rootqt5.cpp
@@ -74,8 +74,10 @@ protected:
 
       virtual ~Qt5Creator()
       {
-         if (fHandler)
-            QWebEngineProfile::defaultProfile()->removeUrlSchemeHandler(fHandler.get());
+         /** Code executed during exit and sometime crashes.
+          *  Disable it, while not clear if defaultProfile can be still used - seems to be not */
+         // if (fHandler)
+         //   QWebEngineProfile::defaultProfile()->removeUrlSchemeHandler(fHandler.get());
       }
 
       std::unique_ptr<RWebDisplayHandle> Display(const RWebDisplayArgs &args) override


### PR DESCRIPTION
Newest qt 5.13.0 crashes here during exit.
Disable it, while is not clear if defaultProfile can be still used -
seems to be not