### PR TITLE
[PyROOT experimental] Add __version__ to ROOT module

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/_facade.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/_facade.py
@@ -72,3 +72,8 @@ class ROOTFacade(types.ModuleType):
         self._finalSetup()
 
         return setattr(self, name, val)
+
+    # Inject version as __version__ property in ROOT module
+    @property
+    def __version__(self):
+        return self.gROOT.GetVersion()

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -4,6 +4,9 @@
 # For the licensing terms see $ROOTSYS/LICENSE.
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
+# Test ROOT module
+ROOT_ADD_PYUNITTEST(pyroot_root_module root_module.py)
+
 # General pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_pretty_printing pretty_printing.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_array_interface array_interface.py)

--- a/bindings/pyroot_experimental/PyROOT/test/root_module.py
+++ b/bindings/pyroot_experimental/PyROOT/test/root_module.py
@@ -1,0 +1,46 @@
+import unittest
+
+
+class ROOTModule(unittest.TestCase):
+    """
+    Testing features of the ROOT module implemented in the ROOT module facade
+    """
+
+    def test_import(self):
+        """
+        Test import
+        """
+        import ROOT
+        self.assertEqual(ROOT.__name__, "ROOT")
+
+
+    def test_relative_import(self):
+        """
+        Test relative import
+        """
+        from ROOT import TH1F
+        self.assertEqual(TH1F.__name__, "TH1F")
+        from ROOT import TH1F as Foo
+        self.assertEqual(Foo.__name__, "TH1F")
+        self.assertEqual(TH1F, Foo)
+
+
+    def test_version(self):
+        """
+        Test __version__ property
+        """
+        import ROOT
+        v = ROOT.__version__
+        self.assertTrue(type(v) == str)
+        self.assertIn("/", v)
+        self.assertIn(".", v)
+        self.assertEqual(v, ROOT.gROOT.GetVersion())
+
+
+    def test_ignore_cmdline_options(self):
+        """
+        Test module flag to ignore command line options
+        """
+        import ROOT
+        self.assertEqual(ROOT.PyConfig.IgnoreCommandLineOptions, False)
+        ROOT.PyConfig.IgnoreCommandLineOptions = True


### PR DESCRIPTION
I think it would be really nice to be compliant with other Python packages and provide a `__version__` magic for the ROOT module.

~~But be careful: This comes at the cost of a direct use of ROOT at startup time (non-lazy! Am I right?). I don't see how we could do this besides doing some template/macro magic and copying the version number to the sources at configure time.~~

Since the ROOT module is actually a class instance, we can add a `property`, which is evaluated lazily. Nice! :)

And added tests for the ROOT module!