### PR TITLE
Rename RootNewMacros.cmake to RootMacros.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 #---Load some basic macros which are needed later for the confiuration and build----------------
 include(RootBuildOptions)
-include(RootNewMacros)
+include(RootMacros)
 include(CheckCompiler)
 include(CheckAssembler)
 include(CheckIntrinsics)

--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -5,7 +5,7 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
 #---------------------------------------------------------------------------------------------------
-#  RootNewMacros.cmake
+#  RootMacros.cmake
 #---------------------------------------------------------------------------------------------------
 
 set(THISDIR ${CMAKE_CURRENT_LIST_DIR})

--- a/cmake/modules/RootNewMacros.cmake
+++ b/cmake/modules/RootNewMacros.cmake
@@ -1,0 +1,6 @@
+include(RootMacros)
+
+message(DEPRECATION "RootNewMacros.cmake has been renamed to RootMacros.cmake and is deprecated. "
+  "Including this file is no longer necessary, as ROOT macros are now available after a call to "
+  "find_package(ROOT). Please use 'include(\${ROOT_USE_FILE})' if you still need to inherit "
+  "compilation options from ROOT as well as enabling the macros.")

--- a/cmake/scripts/ROOTConfig.cmake.in
+++ b/cmake/scripts/ROOTConfig.cmake.in
@@ -62,6 +62,10 @@ get_filename_component(_thisdir "${CMAKE_CURRENT_LIST_FILE}" PATH)
 @ROOT_BINARY_DIR_SETUP@
 
 #----------------------------------------------------------------------------
+# Include RootMacros.cmake to get ROOT's CMake macros
+include(@ROOT_MODULE_PATH@/RootMacros.cmake)
+
+#----------------------------------------------------------------------------
 # Include the file listing all the imported targets and options
 if(NOT CMAKE_PROJECT_NAME STREQUAL ROOT)
   include("${_thisdir}/ROOTConfig-targets.cmake")

--- a/cmake/scripts/RootUseFile.cmake.in
+++ b/cmake/scripts/RootUseFile.cmake.in
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.4.3 FATAL_ERROR)
 
 #---Define the Standard macros for ROOT-----------------------------------------------------------
-include(@ROOT_MODULE_PATH@/RootNewMacros.cmake)
+include(@ROOT_MODULE_PATH@/RootMacros.cmake)
 
 #---Set Link and include directories--------------------------------------------------------------
 include_directories(${ROOT_INCLUDE_DIRS})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,7 +31,7 @@ if(DEFINED ROOT_SOURCE_DIR)  # Testing using the binary tree
 else()                       # Testing using an installation (assuming access to ROOT CMake modules)
   include_directories(${ROOT_INCLUDE_DIRS}/../tutorials)
   add_definitions(${ROOT_DEFINITIONS})
-  include(RootNewMacros)
+  include(RootMacros)
 endif()
 
 #---environment-------------------------------------------------------------------------------

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -26,7 +26,7 @@ else()                       # testing using an installation
   include(${ROOT_USE_FILE})
   if(DEFINED ROOT_CONFIG_EXECUTABLE) #---If ROOT was built with the classic configure/make---
     set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/../cmake/modules)
-    include(RootNewMacros)
+    include(RootMacros)
     set(ROOT_root_CMD root.exe)
   endif()
   enable_testing()


### PR DESCRIPTION
This file is not new, so let's just remove the `New` part from the name.