### PR TITLE
[GSoC] [WIP] ROOT I/O Compression refactoring

### DIFF
--- a/core/lz4/inc/ZipLZ4.h
+++ b/core/lz4/inc/ZipLZ4.h
@@ -13,8 +13,10 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-void R__zipLZ4(int cxlevel, int *srcsize, char *src, int *tgtsize, char *tgt, int *irep);
-void R__unzipLZ4(int *srcsize, unsigned char *src, int *tgtsize, unsigned char *tgt, int *irep);
+
+void R__zipLZ4(int cxlevel, int srcsize, char * src, int tgtsize, char * tgt, int & irep);
+void R__unzipLZ4(int srcsize, unsigned char * src, int tgtsize, unsigned char * tgt, int & irep);
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/lzma/CMakeLists.txt
+++ b/core/lzma/CMakeLists.txt
@@ -2,8 +2,8 @@
 # CMakeLists.txt file for building ROOT core/lzma package
 ############################################################################
 
-include_directories(${LZMA_INCLUDE_DIR})
+ROOT_OBJECT_LIBRARY(Lzma src/ZipLZMA.cxx BUILTINS LZMA)
+target_include_directories(Lzma PRIVATE ${LZMA_INCLUDE_DIR} ${xxHash_INCLUDE_DIR})
 
-ROOT_OBJECT_LIBRARY(Lzma src/ZipLZMA.c BUILTINS LZMA)
 
 ROOT_INSTALL_HEADERS()

--- a/core/lzma/inc/ZipLZMA.h
+++ b/core/lzma/inc/ZipLZMA.h
@@ -13,9 +13,8 @@
 extern "C" {
 #endif
 
-void R__zipLZMA(int cxlevel, int *srcsize, char *src, int *tgtsize, char *tgt, int *irep);
-
-void R__unzipLZMA(int *srcsize, unsigned char *src, int *tgtsize, unsigned char *tgt, int *irep);
+void R__zipLZMA(int cxlevel, int srcsize, char * src, int tgtsize, char * tgt, int & irep);
+void R__unzipLZMA(int srcsize, unsigned char * src, int tgtsize, unsigned char * tgt, int & irep);
 
 #ifdef __cplusplus
 }

--- a/core/lzma/src/ZipLZMA.cxx
+++ b/core/lzma/src/ZipLZMA.cxx
@@ -15,10 +15,10 @@
 
 static const int kHeaderSize = 9;
 
-void R__zipLZMA(int cxlevel, int *srcsize, char *src, int *tgtsize, char *tgt, int *irep)
+void R__zipLZMA(int cxlevel, int srcsize, char * src, int tgtsize, char * tgt, int & irep)
 {
    uint64_t out_size;             /* compressed size */
-   unsigned in_size   = (unsigned) (*srcsize);
+   unsigned in_size   = (unsigned) srcsize;
    uint32_t dict_size_est = in_size/4;
    lzma_stream stream = LZMA_STREAM_INIT;
    lzma_options_lzma opt_lzma2;
@@ -28,13 +28,13 @@ void R__zipLZMA(int cxlevel, int *srcsize, char *src, int *tgtsize, char *tgt, i
    };
    lzma_ret returnStatus;
 
-   *irep = 0;
+   irep = 0;
 
-   if (*tgtsize <= 0) {
+   if (tgtsize <= 0) {
       return;
    }
 
-   if (*srcsize > 0xffffff || *srcsize < 0) {
+   if (srcsize > 0xffffff || srcsize < 0) {
       return;
    }
 
@@ -62,10 +62,10 @@ void R__zipLZMA(int cxlevel, int *srcsize, char *src, int *tgtsize, char *tgt, i
    }
 
    stream.next_in   = (const uint8_t *)src;
-   stream.avail_in  = (size_t)(*srcsize);
+   stream.avail_in  = (size_t) srcsize;
 
    stream.next_out  = (uint8_t *)(&tgt[kHeaderSize]);
-   stream.avail_out = (size_t)(*tgtsize);
+   stream.avail_out = (size_t) tgtsize;
 
    returnStatus = lzma_code(&stream, LZMA_FINISH);
    if (returnStatus != LZMA_STREAM_END) {
@@ -82,7 +82,7 @@ void R__zipLZMA(int cxlevel, int *srcsize, char *src, int *tgtsize, char *tgt, i
    tgt[1] = 'Z';
    tgt[2] = 0;
 
-   in_size   = (unsigned) (*srcsize);
+   in_size   = (unsigned) srcsize;
    out_size  = stream.total_out;             /* compressed size */
 
    tgt[3] = (char)(out_size & 0xff);
@@ -93,15 +93,15 @@ void R__zipLZMA(int cxlevel, int *srcsize, char *src, int *tgtsize, char *tgt, i
    tgt[7] = (char)((in_size >> 8) & 0xff);
    tgt[8] = (char)((in_size >> 16) & 0xff);
 
-   *irep = (int)stream.total_out + kHeaderSize;
+   irep = (int)stream.total_out + kHeaderSize;
 }
 
-void R__unzipLZMA(int *srcsize, unsigned char *src, int *tgtsize, unsigned char *tgt, int *irep)
+void R__unzipLZMA(int srcsize, unsigned char * src, int tgtsize, unsigned char * tgt, int & irep)
 {
    lzma_stream stream = LZMA_STREAM_INIT;
    lzma_ret returnStatus;
 
-   *irep = 0;
+   irep = 0;
 
    returnStatus = lzma_stream_decoder(&stream,
                                       UINT64_MAX,
@@ -114,9 +114,9 @@ void R__unzipLZMA(int *srcsize, unsigned char *src, int *tgtsize, unsigned char 
    }
 
    stream.next_in   = (const uint8_t *)(&src[kHeaderSize]);
-   stream.avail_in  = (size_t)(*srcsize);
+   stream.avail_in  = (size_t) srcsize;
    stream.next_out  = (uint8_t *)tgt;
-   stream.avail_out = (size_t)(*tgtsize);
+   stream.avail_out = (size_t) tgtsize;
 
    returnStatus = lzma_code(&stream, LZMA_FINISH);
    if (returnStatus != LZMA_STREAM_END) {
@@ -128,5 +128,5 @@ void R__unzipLZMA(int *srcsize, unsigned char *src, int *tgtsize, unsigned char 
    }
    lzma_end(&stream);
 
-   *irep = (int)stream.total_out;
+   irep = (int)stream.total_out;
 }

--- a/core/zip/inc/RZip.h
+++ b/core/zip/inc/RZip.h
@@ -21,15 +21,15 @@ extern "C" unsigned long R__crc32(unsigned long crc, const unsigned char* buf, u
 
 extern "C" unsigned long R__memcompress(char *tgt, unsigned long tgtsize, char *src, unsigned long srcsize);
 
-extern "C" void R__zipMultipleAlgorithm(int cxlevel, int *srcsize, char *src, int *tgtsize, char *tgt, int *irep, ROOT::RCompressionSetting::EAlgorithm::EValues);
+extern "C" void R__zipMultipleAlgorithm(int cxlevel, int srcsize, char *src, int tgtsize, char *tgt, int & irep, ROOT::RCompressionSetting::EAlgorithm::EValues);
 
 /**
  * This is a historical definition, prior to ROOT supporting multiple algorithms in a single file.  Use
  * R__zipMultipleAlgorithm instead.
  */
-extern "C" void R__zip(int cxlevel, int *srcsize, char *src, int *tgtsize, char *tgt, int *irep);
+extern "C" void R__zip(int cxlevel, int srcsize, char *src, int tgtsize, char *tgt, int & irep);
 
-extern "C" void R__unzip(int *srcsize, unsigned char *src, int *tgtsize, unsigned char *tgt, int *irep);
+extern "C" void R__unzip(int srcsize, unsigned char *src, int tgtsize, unsigned char *tgt, int & irep);
 
 extern "C" int R__unzip_header(int *srcsize, unsigned char *src, int *tgtsize);
 

--- a/core/zip/src/ZInflate.c
+++ b/core/zip/src/ZInflate.c
@@ -19,8 +19,6 @@ static const int qflag = 0;
 
 #include "zlib.h"
 #include "RConfigure.h"
-#include "ZipLZMA.h"
-#include "ZipLZ4.h"
 
 /* inflate.c -- put in the public domain by Mark Adler
    version c14o, 23 August 1994 */

--- a/io/io/src/TKey.cxx
+++ b/io/io/src/TKey.cxx
@@ -265,7 +265,7 @@ TKey::TKey(const TObject *obj, const char *name, Int_t bufsize, TDirectory* moth
       for (Int_t i = 0; i < nbuffers; ++i) {
          if (i == nbuffers - 1) bufmax = fObjlen - nzip;
          else               bufmax = kMAXZIPBUF;
-         R__zipMultipleAlgorithm(cxlevel, &bufmax, objbuf, &bufmax, bufcur, &nout, cxAlgorithm);
+         R__zipMultipleAlgorithm(cxlevel, bufmax, objbuf, bufmax, bufcur, nout, cxAlgorithm);
          if (nout == 0 || nout >= fObjlen) { //this happens when the buffer cannot be compressed
             fBuffer = fBufferRef->Buffer();
             Create(fObjlen);
@@ -356,7 +356,7 @@ TKey::TKey(const void *obj, const TClass *cl, const char *name, Int_t bufsize, T
       for (Int_t i = 0; i < nbuffers; ++i) {
          if (i == nbuffers - 1) bufmax = fObjlen - nzip;
          else               bufmax = kMAXZIPBUF;
-         R__zipMultipleAlgorithm(cxlevel, &bufmax, objbuf, &bufmax, bufcur, &nout, cxAlgorithm);
+         R__zipMultipleAlgorithm(cxlevel, bufmax, objbuf, bufmax, bufcur, nout, cxAlgorithm);
          if (nout == 0 || nout >= fObjlen) { //this happens when the buffer cannot be compressed
             fBuffer = fBufferRef->Buffer();
             Create(fObjlen);
@@ -794,7 +794,7 @@ TObject *TKey::ReadObj()
       while (1) {
          Int_t hc = R__unzip_header(&nin, bufcur, &nbuf);
          if (hc!=0) break;
-         R__unzip(&nin, bufcur, &nbuf, (unsigned char*) objbuf, &nout);
+         R__unzip(nin, bufcur, nbuf, (unsigned char*) objbuf, nout);
          if (!nout) break;
          noutot += nout;
          if (noutot >= fObjlen) break;
@@ -925,7 +925,7 @@ TObject *TKey::ReadObjWithBuffer(char *bufferRead)
       while (1) {
          Int_t hc = R__unzip_header(&nin, bufcur, &nbuf);
          if (hc!=0) break;
-         R__unzip(&nin, bufcur, &nbuf, (unsigned char*) objbuf, &nout);
+         R__unzip(nin, bufcur, nbuf, (unsigned char*) objbuf, nout);
          if (!nout) break;
          noutot += nout;
          if (noutot >= fObjlen) break;
@@ -1072,7 +1072,7 @@ void *TKey::ReadObjectAny(const TClass* expectedClass)
       while (1) {
          Int_t hc = R__unzip_header(&nin, bufcur, &nbuf);
          if (hc!=0) break;
-         R__unzip(&nin, bufcur, &nbuf, (unsigned char*) objbuf, &nout);
+         R__unzip(nin, bufcur, nbuf, (unsigned char*) objbuf, nout);
          if (!nout) break;
          noutot += nout;
          if (noutot >= fObjlen) break;
@@ -1163,7 +1163,7 @@ Int_t TKey::Read(TObject *obj)
       while (1) {
          Int_t hc = R__unzip_header(&nin, bufcur, &nbuf);
          if (hc!=0) break;
-         R__unzip(&nin, bufcur, &nbuf, (unsigned char*) objbuf, &nout);
+         R__unzip(nin, bufcur, nbuf, (unsigned char*) objbuf, nout);
          if (!nout) break;
          noutot += nout;
          if (noutot >= fObjlen) break;

--- a/io/xml/src/TBufferXML.cxx
+++ b/io/xml/src/TBufferXML.cxx
@@ -425,7 +425,7 @@ void TBufferXML::XmlWriteBlock(XMLNodePointer_t node)
       fZipBuffer = new char[zipBufferSize + 9];
       int dataSize = Length();
       int compressedSize = 0;
-      R__zipMultipleAlgorithm(compressionLevel, &dataSize, Buffer(), &zipBufferSize, fZipBuffer, &compressedSize,
+      R__zipMultipleAlgorithm(compressionLevel, dataSize, Buffer(), zipBufferSize, fZipBuffer, compressedSize,
                               compressionAlgorithm);
       if (compressedSize > 0) {
          src = fZipBuffer;
@@ -522,7 +522,7 @@ void TBufferXML::XmlReadBlock(XMLNodePointer_t blocknode)
       int status = R__unzip_header(&srcsize, (UChar_t *)fUnzipBuffer, &tgtsize);
 
       if (status == 0)
-         R__unzip(&readSize, (unsigned char *)fUnzipBuffer, &blockSize, (unsigned char *)Buffer(), &unzipRes);
+         R__unzip(readSize, (unsigned char *)fUnzipBuffer, blockSize, (unsigned char *)Buffer(), unzipRes);
 
       if (status != 0 || unzipRes != blockSize)
          Error("XmlReadBlock", "Decompression error %d", unzipRes);

--- a/net/net/src/TMessage.cxx
+++ b/net/net/src/TMessage.cxx
@@ -345,7 +345,7 @@ Int_t TMessage::Compress()
          bufmax = messlen - nzip;
       else
          bufmax = kMAXZIPBUF;
-      R__zipMultipleAlgorithm(compressionLevel, &bufmax, messbuf, &bufmax, bufcur, &nout,
+      R__zipMultipleAlgorithm(compressionLevel, bufmax, messbuf, bufmax, bufcur, nout,
                               static_cast<ROOT::RCompressionSetting::EAlgorithm::EValues>(compressionAlgorithm));
       if (nout == 0 || nout >= messlen) {
          //this happens when the buffer cannot be compressed
@@ -405,7 +405,7 @@ Int_t TMessage::Uncompress()
    while (1) {
       Int_t hc = R__unzip_header(&nin, bufcur, &nbuf);
       if (hc!=0) break;
-      R__unzip(&nin, bufcur, &nbuf, (unsigned char*) messbuf, &nout);
+      R__unzip(nin, bufcur, nbuf, (unsigned char*) messbuf, nout);
       if (!nout) break;
       noutot += nout;
       if (noutot >= buflen - hdrlen) break;

--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -612,7 +612,7 @@ Int_t TBasket::ReadBasketBuffers(Long64_t pos, Int_t len, TFile *file)
             goto AfterBuffer;
          }
 
-         R__unzip(&nin, rawCompressedObjectBuffer, &nbuf, (unsigned char*) rawUncompressedObjectBuffer, &nout);
+         R__unzip(nin, rawCompressedObjectBuffer, nbuf, (unsigned char*) rawUncompressedObjectBuffer, nout);
          if (!nout) break;
          noutot += nout;
          nintot += nin;
@@ -1159,7 +1159,7 @@ Int_t TBasket::WriteBuffer()
          // NOTE this is declared with C linkage, so it shouldn't except.  Also, when
          // USE_IMT is defined, we are guaranteed that the compression buffer is unique per-branch.
          // (see fCompressedBufferRef in constructor).
-         R__zipMultipleAlgorithm(cxlevel, &bufmax, objbuf, &bufmax, bufcur, &nout, cxAlgorithm);
+         R__zipMultipleAlgorithm(cxlevel, bufmax, objbuf, bufmax, bufcur, nout, cxAlgorithm);
 #ifdef R__USE_IMT
          sentry.lock();
 #endif  // R__USE_IMT


### PR DESCRIPTION
I am refactoring the old code of ROOT I/O for compression. Some part of the code are up to 30 years old and from my experience that the C style code that is used is prone to errors for developers that are not familiar with the code. Since one of the goals of ROOT is to be maintainable, I think that this can be very helpful.
Nonetheless, even the simplest change has side effects across the code base so I would like to reach a consensus regarding how changes should be done.

The changes that have been done so far are the following:

 ### Removed pointers https://github.com/fylux/root/commit/155c405ba6beb21075f436a0380d1cb8378213c3
Most of the compression functions take pointers for values that should be constant, mainly the source and target size of the compression buffer. Also, the irep now is a reference rather than a pointer. However, I think that it would be better to make the function not void and instead of using irep just return a value.

## TODO
 - Decide what type should be given for `tgtsize` and `srcsize`. The most suitable could be const unsigned but perhaps in some section of the code a negative value is used to represent something.
 - Instead of using `&irep` for returning information about the compressed size or possible errors better make that the function instead of being void is int so the return value would be `&irep`.
 - ZLIB right now does not have separated files but it is embedded inside RZIP what is not desirable. It would be better to make it follow the same structure of LZ4 or LZMA.
 - [To be extended]

