### PR TITLE
Fix issue with popup (and context) menus on Windows

### DIFF
--- a/graf2d/win32gdk/gdk/src/gdk/win32/gdkevents-win32.c
+++ b/graf2d/win32gdk/gdk/src/gdk/win32/gdkevents-win32.c
@@ -62,6 +62,9 @@
 
 #define WINDOW_PRIVATE(wp) GDK_WINDOW_WIN32DATA (wp)
 
+#define GET_X_LPARAM(lp)   ((int)(short)LOWORD(lp))
+#define GET_Y_LPARAM(lp)   ((int)(short)HIWORD(lp))
+
 typedef struct _GdkIOClosure GdkIOClosure;
 typedef struct _GdkEventPrivate GdkEventPrivate;
 
@@ -167,8 +170,8 @@ inner_window_proc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
    msg.lParam = lParam;
    msg.time = GetTickCount();
    pos = GetMessagePos();
-   msg.pt.x = LOWORD(pos);
-   msg.pt.y = HIWORD(pos);
+   msg.pt.x = GET_X_LPARAM(pos);
+   msg.pt.y = GET_Y_LPARAM(pos);
 
    event.flags = GDK_EVENT_PENDING;
    if (gdk_event_translate(&event.event, &msg, &ret_val_flag, &ret_val)) {
@@ -4506,8 +4509,8 @@ static void synthesize_crossing_events(GdkWindow * window, MSG * xevent)
       gdk_window_ref(event->crossing.window);
       event->crossing.subwindow = NULL;
       event->crossing.time = xevent->time;
-      event->crossing.x = LOWORD(xevent->lParam);
-      event->crossing.y = HIWORD(xevent->lParam);
+      event->crossing.x = GET_X_LPARAM(xevent->lParam);
+      event->crossing.y = GET_Y_LPARAM(xevent->lParam);
       event->crossing.x_root = (gfloat) xevent->pt.x;
       event->crossing.y_root = (gfloat) xevent->pt.y;
       event->crossing.mode = GDK_CROSSING_NORMAL;
@@ -4559,8 +4562,8 @@ translate_mouse_coords(GdkWindow * window1,
 {
    POINT pt;
 
-   pt.x = LOWORD(xevent->lParam);
-   pt.y = HIWORD(xevent->lParam);
+   pt.x = GET_X_LPARAM(xevent->lParam);
+   pt.y = GET_Y_LPARAM(xevent->lParam);
    ClientToScreen(GDK_DRAWABLE_XID(window1), &pt);
    ScreenToClient(GDK_DRAWABLE_XID(window2), &pt);
    xevent->lParam = MAKELPARAM(pt.x, pt.y);
@@ -4880,8 +4883,8 @@ gdk_event_translate(GdkEvent * event,
        * around that. Also, the position is in screen coordinates, not
        * client coordinates as with the button messages.
        */
-      pt.x = LOWORD(xevent->lParam);
-      pt.y = HIWORD(xevent->lParam);
+      pt.x = GET_X_LPARAM(xevent->lParam);
+      pt.y = GET_Y_LPARAM(xevent->lParam);
       if ((hwnd = WindowFromPoint(pt)) == NULL)
          goto bypass_switch;
 
@@ -4914,8 +4917,8 @@ gdk_event_translate(GdkEvent * event,
       event->scroll.time = xevent->time;
       event->scroll.x = (gint16) pt.x;
       event->scroll.y = (gint16) pt.y;
-      event->scroll.x_root = (gint16) LOWORD(xevent->lParam);
-      event->scroll.y_root = (gint16) HIWORD(xevent->lParam);
+      event->scroll.x_root = (gint16) GET_X_LPARAM(xevent->lParam);
+      event->scroll.y_root = (gint16) GET_Y_LPARAM(xevent->lParam);
       event->scroll.pressure = 0.5;
       event->scroll.xtilt = 0;
       event->scroll.ytilt = 0;
@@ -5479,7 +5482,7 @@ gdk_event_translate(GdkEvent * event,
                g_print("WM_%cBUTTONDOWN: %#x  (%d,%d)\n",
                        " LMR"[button],
                        xevent->hwnd,
-                       LOWORD(xevent->lParam), HIWORD(xevent->lParam)));
+                       GET_X_LPARAM(xevent->lParam), GET_Y_LPARAM(xevent->lParam)));
 
       if (((GdkWindowPrivate *) window)->extension_events != 0
           && gdk_input_ignore_core) {
@@ -5527,8 +5530,8 @@ gdk_event_translate(GdkEvent * event,
       event->button.time = xevent->time;
       if (window != orig_window)
          translate_mouse_coords(orig_window, window, xevent);
-      event->button.x = curX = (gint16) LOWORD(xevent->lParam);
-      event->button.y = curY = (gint16) HIWORD(xevent->lParam);
+      event->button.x = curX = (gint16) GET_X_LPARAM(xevent->lParam);
+      event->button.y = curY = (gint16) GET_Y_LPARAM(xevent->lParam);
       event->button.x_root = xevent->pt.x;
       event->button.y_root = xevent->pt.y;
       event->button.pressure = 0.5;
@@ -5558,7 +5561,7 @@ gdk_event_translate(GdkEvent * event,
                g_print("WM_%cBUTTONUP: %#x  (%d,%d)\n",
                        " LMR"[button],
                        xevent->hwnd,
-                       LOWORD(xevent->lParam), HIWORD(xevent->lParam)));
+                       GET_X_LPARAM(xevent->lParam), GET_Y_LPARAM(xevent->lParam)));
 
       window = find_window_for_pointer_event (window, xevent);
 
@@ -5583,8 +5586,8 @@ gdk_event_translate(GdkEvent * event,
 
          event->button.window = window;
          event->button.time = xevent->time;
-         event->button.x = (gint16) LOWORD(xevent->lParam);
-         event->button.y = (gint16) HIWORD(xevent->lParam);
+         event->button.x = (gint16) GET_X_LPARAM(xevent->lParam);
+         event->button.y = (gint16) GET_Y_LPARAM(xevent->lParam);
          event->button.x_root = xevent->pt.x;
          event->button.y_root = xevent->pt.y;
          event->button.pressure = 0.5;
@@ -5645,7 +5648,7 @@ gdk_event_translate(GdkEvent * event,
       GDK_NOTE(EVENTS,
                g_print("WM_MOUSEMOVE: %#x  %#x (%d,%d)\n",
                        xevent->hwnd, xevent->wParam,
-                       LOWORD(xevent->lParam), HIWORD(xevent->lParam)));
+                       GET_X_LPARAM(xevent->lParam), GET_Y_LPARAM(xevent->lParam)));
 
       track_mouse_event(xevent->hwnd);
 
@@ -5673,11 +5676,11 @@ gdk_event_translate(GdkEvent * event,
          translate_mouse_coords(orig_window, window, xevent);
 
       if (window == curWnd
-         && (gint16) LOWORD(xevent->lParam) == curX
-         && (gint16) HIWORD(xevent->lParam) == curY) break;
+         && (gint16) GET_X_LPARAM(xevent->lParam) == curX
+         && (gint16) GET_Y_LPARAM(xevent->lParam) == curY) break;
 
-      event->motion.x = curX = (gint16) LOWORD(xevent->lParam);
-      event->motion.y = curY = (gint16) HIWORD(xevent->lParam);
+      event->motion.x = curX = (gint16) GET_X_LPARAM(xevent->lParam);
+      event->motion.y = curY = (gint16) GET_Y_LPARAM(xevent->lParam);
       event->motion.x_root = xevent->pt.x;
       event->motion.y_root = xevent->pt.y;
       curXroot = event->motion.x_root;
@@ -5703,7 +5706,7 @@ gdk_event_translate(GdkEvent * event,
       GDK_NOTE(EVENTS,
                g_print("WM_NCMOUSEMOVE: %#x  x,y: %d %d\n",
                        xevent->hwnd,
-                       LOWORD(xevent->lParam), HIWORD(xevent->lParam)));
+                       GET_X_LPARAM(xevent->lParam), GET_Y_LPARAM(xevent->lParam)));
       if (p_TrackMouseEvent == NULL
           && curWnd != NULL
           && (GDK_WINDOW_WIN32DATA(curWnd)->
@@ -5747,8 +5750,8 @@ gdk_event_translate(GdkEvent * event,
        * coordinates as with the button messages. I love the
        * consistency of Windows.
        */
-      pt.x = LOWORD(xevent->lParam);
-      pt.y = HIWORD(xevent->lParam);
+      pt.x = GET_X_LPARAM(xevent->lParam);
+      pt.y = GET_Y_LPARAM(xevent->lParam);
       if ((hwnd = WindowFromPoint(pt)) == NULL)
          break;
 
@@ -5792,8 +5795,8 @@ gdk_event_translate(GdkEvent * event,
       event->scroll.time = xevent->time;
       event->scroll.x = (gint16) pt.x;
       event->scroll.y = (gint16) pt.y;
-      event->scroll.x_root = (gint16) LOWORD(xevent->lParam);
-      event->scroll.y_root = (gint16) HIWORD(xevent->lParam);
+      event->scroll.x_root = (gint16) GET_X_LPARAM(xevent->lParam);
+      event->scroll.y_root = (gint16) GET_Y_LPARAM(xevent->lParam);
       event->scroll.pressure = 0.5;
       event->scroll.xtilt = 0;
       event->scroll.ytilt = 0;
@@ -6189,8 +6192,8 @@ gdk_event_translate(GdkEvent * event,
    case WM_MOVE:
       GDK_NOTE(EVENTS, g_print("WM_MOVE: %#x  (%d,%d)\n",
                                xevent->hwnd,
-                               LOWORD(xevent->lParam),
-                               HIWORD(xevent->lParam)));
+                               GET_X_LPARAM(xevent->lParam),
+                               GET_Y_LPARAM(xevent->lParam)));
 
       if (!(GDK_WINDOW_WIN32DATA(window)->event_mask & GDK_STRUCTURE_MASK))
          break;
@@ -6201,8 +6204,8 @@ gdk_event_translate(GdkEvent * event,
          event->type = GDK_CONFIGURE;
          event->configure.type = GDK_CONFIGURE;
          event->configure.window = window;
-         event->configure.x = LOWORD(xevent->lParam);
-         event->configure.y = HIWORD(xevent->lParam);
+         event->configure.x = GET_X_LPARAM(xevent->lParam);
+         event->configure.y = GET_Y_LPARAM(xevent->lParam);
          GetClientRect(xevent->hwnd, &rect);
          event->configure.width = rect.right;
          event->configure.height = rect.bottom;

--- a/graf2d/win32gdk/gdk/src/gdk/win32/gdkwindow-win32.c
+++ b/graf2d/win32gdk/gdk/src/gdk/win32/gdkwindow-win32.c
@@ -1515,17 +1515,28 @@ gdk_window_get_geometry(GdkWindow * window,
    if (!GDK_DRAWABLE_DESTROYED(window)) {
       RECT rect;
 
-      if (!GetClientRect(GDK_DRAWABLE_XID(window), &rect))
-         WIN32_API_FAILED("GetClientRect");
-
-      if (x)
-         *x = rect.left;
-      if (y)
-         *y = rect.top;
-      if (width)
-         *width = rect.right - rect.left;
-      if (height)
-         *height = rect.bottom - rect.top;
+      if (window == gdk_parent_root) {
+         if (x)
+            *x = GetSystemMetrics(76 /*SM_XVIRTUALSCREEN*/);
+         if (y)
+            *y = GetSystemMetrics(77 /*SM_YVIRTUALSCREEN*/);
+         if (width)
+            *width = GetSystemMetrics(78 /*SM_CXVIRTUALSCREEN*/);
+         if (height)
+            *height = GetSystemMetrics(79 /*SM_CYVIRTUALSCREEN*/);
+      }
+      else {
+         if (!GetClientRect(GDK_DRAWABLE_XID(window), &rect))
+            WIN32_API_FAILED("GetClientRect");
+         if (x)
+            *x = rect.left;
+         if (y)
+            *y = rect.top;
+         if (width)
+            *width = rect.right - rect.left;
+         if (height)
+            *height = rect.bottom - rect.top;
+      }
       if (depth)
          *depth = gdk_drawable_get_visual(window)->depth;
    }

--- a/graf2d/win32gdk/gdk/src/gdk/win32/gdkwindow-win32.c
+++ b/graf2d/win32gdk/gdk/src/gdk/win32/gdkwindow-win32.c
@@ -137,6 +137,8 @@ void gdk_window_init(void)
    SystemParametersInfo(SPI_GETWORKAREA, 0, &r, 0);
    width = r.right - r.left;
    height = r.bottom - r.top;
+   width = GetSystemMetrics(78 /*SM_CXVIRTUALSCREEN*/);
+   height = GetSystemMetrics(79 /*SM_CYVIRTUALSCREEN*/);
 
    gdk_parent_root = gdk_win32_window_alloc();
    private = (GdkWindowPrivate *) gdk_parent_root;
@@ -396,7 +398,7 @@ GdkWindow *gdk_window_new(GdkWindow * parent,
       rect.right = rect.left + private->drawable.width;
       rect.bottom = rect.top + private->drawable.height;
 
-      SafeAdjustWindowRectEx(&rect, dwStyle, FALSE, dwExStyle);
+      //SafeAdjustWindowRectEx(&rect, dwStyle, FALSE, dwExStyle);
 
       if (x != CW_USEDEFAULT) {
          x = rect.left;
@@ -768,7 +770,7 @@ void gdk_window_move(GdkWindow * window, gint x, gint y)
 
          dwStyle = GetWindowLong(GDK_DRAWABLE_XID(window), GWL_STYLE);
          dwExStyle = GetWindowLong(GDK_DRAWABLE_XID(window), GWL_EXSTYLE);
-         SafeAdjustWindowRectEx(&rect, dwStyle, FALSE, dwExStyle);
+         //SafeAdjustWindowRectEx(&rect, dwStyle, FALSE, dwExStyle);
 
          x = rect.left;
          y = rect.top;

--- a/gui/ged/src/TGedPatternSelect.cxx
+++ b/gui/ged/src/TGedPatternSelect.cxx
@@ -300,10 +300,17 @@ void TGedPopup::PlacePopup(Int_t x, Int_t y, UInt_t w, UInt_t h)
    // Parent is root window for the popup:
    gVirtualX->GetWindowSize(fParent->GetId(), rx, ry, rw, rh);
 
-   if (x < 0) x = 0;
-   if (x + fWidth > rw) x = rw - fWidth;
-   if (y < 0) y = 0;
-   if (y + fHeight > rh) y = rh - fHeight;
+   if (gVirtualX->InheritsFrom("TGWin32")) {
+      if ((x > 0) && ((x + abs(rx) + (Int_t)fWidth) > (Int_t)rw))
+         x = rw - abs(rx) - fWidth;
+      if ((y > 0) && (y + abs(ry) + (Int_t)fHeight > (Int_t)rh))
+         y = rh - fHeight;
+   } else {
+      if (x < 0) x = 0;
+      if (x + fWidth > rw) x = rw - fWidth;
+      if (y < 0) y = 0;
+      if (y + fHeight > rh) y = rh - fHeight;
+   }
 
    MoveResize(x, y, w, h);
    MapSubwindows();

--- a/gui/gui/src/TGColorSelect.cxx
+++ b/gui/gui/src/TGColorSelect.cxx
@@ -261,10 +261,17 @@ void TGColorPopup::PlacePopup(Int_t x, Int_t y, UInt_t w, UInt_t h)
    // Parent is root window for the popup:
    gVirtualX->GetWindowSize(fParent->GetId(), rx, ry, rw, rh);
 
-   if (x < 0) x = 0;
-   if (x + fWidth > rw) x = rw - fWidth;
-   if (y < 0) y = 0;
-   if (y + fHeight > rh) y = rh - fHeight;
+   if (gVirtualX->InheritsFrom("TGWin32")) {
+      if ((x > 0) && ((x + abs(rx) + (Int_t)fWidth) > (Int_t)rw))
+         x = rw - abs(rx) - fWidth;
+      if ((y > 0) && (y + abs(ry) + (Int_t)fHeight > (Int_t)rh))
+         y = rh - fHeight;
+   } else {
+      if (x < 0) x = 0;
+      if (x + fWidth > rw) x = rw - fWidth;
+      if (y < 0) y = 0;
+      if (y + fHeight > rh) y = rh - fHeight;
+   }
 
    MoveResize(x, y, w, h);
    MapSubwindows();

--- a/gui/gui/src/TGComboBox.cxx
+++ b/gui/gui/src/TGComboBox.cxx
@@ -136,10 +136,17 @@ void TGComboBoxPopup::PlacePopup(Int_t x, Int_t y, UInt_t w, UInt_t h)
    // Parent is root window for the popup:
    gVirtualX->GetWindowSize(fParent->GetId(), rx, ry, rw, rh);
 
-   if (x < 0) x = 0;
-   if (x + fWidth > rw) x = rw - fWidth;
-   if (y < 0) y = 0;
-   if (y + fHeight > rh) y = rh - fHeight;
+   if (gVirtualX->InheritsFrom("TGWin32")) {
+      if ((x > 0) && ((x + abs(rx) + (Int_t)fWidth) > (Int_t)rw))
+         x = rw - abs(rx) - fWidth;
+      if ((y > 0) && (y + abs(ry) + (Int_t)fHeight > (Int_t)rh))
+         y = rh - fHeight;
+   } else {
+      if (x < 0) x = 0;
+      if (x + fWidth > rw) x = rw - fWidth;
+      if (y < 0) y = 0;
+      if (y + fHeight > rh) y = rh - fHeight;
+   }
 
    // remember the current selected entry
    if (fListBox == 0) {

--- a/gui/gui/src/TGFrame.cxx
+++ b/gui/gui/src/TGFrame.cxx
@@ -1961,15 +1961,17 @@ void TGTransientFrame::CenterOnParent(Bool_t croot, EPlacement pos)
 
       gVirtualX->TranslateCoordinates(fMain->GetId(), GetParent()->GetId(),
                                       x, y, ax, ay, wdummy);
-      if (ax < 10)
-         ax = 10;
-      else if (ax + fWidth + 10 > dw)
-         ax = dw - fWidth - 10;
+      if (!gVirtualX->InheritsFrom("TGWin32")) {
+         if (ax < 10)
+            ax = 10;
+         else if (ax + fWidth + 10 > dw)
+            ax = dw - fWidth - 10;
 
-      if (ay < 20)
-         ay = 20;
-      else if (ay + fHeight + 50 > dh)
-         ay = dh - fHeight - 50;
+         if (ay < 20)
+            ay = 20;
+         else if (ay + fHeight + 50 > dh)
+            ay = dh - fHeight - 50;
+      }
 
    } else if (croot) {
 

--- a/gui/gui/src/TGMenu.cxx
+++ b/gui/gui/src/TGMenu.cxx
@@ -1254,8 +1254,7 @@ void TGPopupMenu::PlaceMenu(Int_t x, Int_t y, Bool_t stick_mode, Bool_t grab_poi
          x = rw - abs(rx) - fMenuWidth;
       if ((y > 0) && (y + abs(ry) + (Int_t)fMenuHeight > (Int_t)rh))
          y = rh - fMenuHeight;
-   }
-   else {
+   } else {
       if (x < 0) x = 0;
       if (x + fMenuWidth > rw) x = rw - fMenuWidth;
       if (y < 0) y = 0;

--- a/gui/gui/src/TGMenu.cxx
+++ b/gui/gui/src/TGMenu.cxx
@@ -1249,10 +1249,18 @@ void TGPopupMenu::PlaceMenu(Int_t x, Int_t y, Bool_t stick_mode, Bool_t grab_poi
    // Parent is root window for a popup menu
    gVirtualX->GetWindowSize(fParent->GetId(), rx, ry, rw, rh);
 
-   if (x < 0) x = 0;
-   if (x + fMenuWidth > rw) x = rw - fMenuWidth;
-   if (y < 0) y = 0;
-   if (y + fMenuHeight > rh) y = rh - fMenuHeight;
+   if (gVirtualX->InheritsFrom("TGWin32")) {
+      if ((x > 0) && ((x + abs(rx) + (Int_t)fMenuWidth) > (Int_t)rw))
+         x = rw - abs(rx) - fMenuWidth;
+      if ((y > 0) && (y + abs(ry) + (Int_t)fMenuHeight > (Int_t)rh))
+         y = rh - fMenuHeight;
+   }
+   else {
+      if (x < 0) x = 0;
+      if (x + fMenuWidth > rw) x = rw - fMenuWidth;
+      if (y < 0) y = 0;
+      if (y + fMenuHeight > rh) y = rh - fMenuHeight;
+   }
 
    Move(x, y);
    MapRaised();

--- a/gui/gui/src/TGToolTip.cxx
+++ b/gui/gui/src/TGToolTip.cxx
@@ -330,7 +330,7 @@ Bool_t TGToolTip::HandleTimer(TTimer *)
       fLabel->SetWrapLength((screenW/2)-15);
    Resize(GetDefaultSize());
 
-   if (x + fWidth > screenW) {
+   if (x + (Int_t)fWidth > (Int_t)screenW) {
       x = screenW - fWidth;
       move += 1;
    }


### PR DESCRIPTION
Fix a long standing issue with popup (and context) menus popping up on wrong display on Windows with multiple display configuration