### PR TITLE
[webgui] provide client version for RWebWindow

### DIFF
--- a/gui/webdisplay/inc/ROOT/RWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindow.hxx
@@ -135,6 +135,7 @@ private:
    unsigned fWidth{0};                              ///<! initial window width when displayed
    unsigned fHeight{0};                             ///<! initial window height when displayed
    float fOperationTmout{50.};                      ///<! timeout in seconds to perform synchronous operation, default 50s
+   std::string fClientVersion;                      ///<! configured client version, used as prefix in scripts URL
    std::string fProtocolFileName;                   ///<! local file where communication protocol will be written
    int fProtocolCnt{-1};                            ///<! counter for protocol recording
    unsigned fProtocolConnId{0};                     ///<! connection id, which is used for writing protocol
@@ -237,6 +238,17 @@ public:
    /////////////////////////////////////////////////////////////////////////
    /// returns true if only native (own-created) connections are allowed
    bool IsNativeOnlyConn() const { return fNativeOnlyConn; }
+
+   /////////////////////////////////////////////////////////////////////////
+   /// Set client version, used as prefix in scripts URL
+   /// When changed, web browser will reload all related JS files while full URL will be different
+   /// Default is empty value - no extra string in URL
+   /// Version should be string like "1.2" or "ver1.subv2" and not contain any special symbols
+   void SetClientVersion(const std::string &vers) { fClientVersion = vers; }
+
+   /////////////////////////////////////////////////////////////////////////
+   /// Returns current client version
+   std::string GetClientVersion() const { return fClientVersion; }
 
    int NumConnections();
 

--- a/gui/webdisplay/src/RWebWindowWSHandler.hxx
+++ b/gui/webdisplay/src/RWebWindowWSHandler.hxx
@@ -20,6 +20,10 @@
 
 #include <ROOT/RWebWindow.hxx>
 
+#include <string>
+
+using namespace std::string_literals;
+
 namespace ROOT {
 namespace Experimental {
 
@@ -31,6 +35,18 @@ protected:
    Bool_t ProcessBatchHolder(std::shared_ptr<THttpCallArg> &arg) override
    {
       return IsDisabled() ? kFALSE : fWindow.ProcessBatchHolder(arg);
+   }
+
+   void VerifyDefaultPageContent(std::shared_ptr<THttpCallArg> &arg) override
+   {
+      auto version = fWindow.GetClientVersion();
+      if (!version.empty()) {
+         std::string search = "jsrootsys/scripts/JSRootCore."s;
+         std::string replace = version + "/jsrootsys/scripts/JSRootCore."s;
+         // replace link to JSROOT main script to emulate new version
+         arg->ReplaceAllinContent(search, replace, true);
+         arg->AddNoCacheHeader();
+      }
    }
 
 public:

--- a/net/http/inc/THttpCallArg.h
+++ b/net/http/inc/THttpCallArg.h
@@ -63,6 +63,9 @@ protected:
 
    void ReplaceAllinContent(const std::string &from, const std::string &to, bool once = false);
 
+   /** Method used to modify content of web page used by web socket handler */
+   virtual void CheckWSPageContent(THttpWSHandler *) {}
+
 private:
    std::shared_ptr<THttpWSEngine> fWSEngine; ///<!  web-socket engine, which supplied to run created web socket
 
@@ -71,9 +74,6 @@ private:
 
    void AssignWSId();
    std::shared_ptr<THttpWSEngine> TakeWSEngine();
-
-   /** Method used to modify content of web page used by web socket handler */
-   virtual void CheckWSPageContent(THttpWSHandler *) {}
 
 public:
    explicit THttpCallArg() = default;

--- a/net/http/inc/THttpCallArg.h
+++ b/net/http/inc/THttpCallArg.h
@@ -61,8 +61,6 @@ protected:
 
    TString CountHeader(const TString &buf, Int_t number = -1111) const;
 
-   void ReplaceAllinContent(const std::string &from, const std::string &to, bool once = false);
-
    /** Method used to modify content of web page used by web socket handler */
    virtual void CheckWSPageContent(THttpWSHandler *) {}
 
@@ -201,6 +199,7 @@ public:
 
    void SetContent(const char *cont);
    void SetContent(std::string &&cont);
+   void ReplaceAllinContent(const std::string &from, const std::string &to, bool once = false);
 
    Bool_t CompressWithGzip();
 

--- a/net/http/inc/THttpServer.h
+++ b/net/http/inc/THttpServer.h
@@ -38,6 +38,7 @@ protected:
    Long_t fMainThrdId{0};               ///<! id of the thread for processing requests
    Bool_t fOwnThread{kFALSE};           ///<! true when specialized thread allocated for processing requests
    std::thread fThrd;                   ///<! own thread
+   Bool_t fOldProcessSignature{kFALSE}; ///<! flag used to detect usage of old signature of Process() method
 
    TString fJSROOTSYS;       ///<! location of local JSROOT files
    TString fTopName{"ROOT"}; ///<! name of top folder, default - "ROOT"

--- a/net/http/inc/THttpWSHandler.h
+++ b/net/http/inc/THttpWSHandler.h
@@ -55,6 +55,10 @@ protected:
    /// Method used to accept or reject root_batch_holder.js request
    virtual Bool_t ProcessBatchHolder(std::shared_ptr<THttpCallArg> &) { return kFALSE; }
 
+   /// Method called when default page content is prepared for use
+   /// By default no-cache header is provided
+   virtual void VerifyDefaultPageContent(std::shared_ptr<THttpCallArg> &arg) { arg->AddNoCacheHeader(); }
+
 public:
    virtual ~THttpWSHandler();
 

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -706,23 +706,19 @@ void THttpServer::ProcessRequest(std::shared_ptr<THttpCallArg> arg)
 {
    if (fTerminated) {
       arg->Set404();
-   } else if ((arg->fFileName == "root.websocket") || (arg->fFileName == "root.longpoll")) {
-      ExecuteWS(arg);
-   } else {
-      ProcessRequest(arg.get());
+      return;
    }
-}
 
-////////////////////////////////////////////////////////////////////////////////
-/// \deprecated  One should use signature with std::shared_ptr
-/// Process single http request
-/// Depending from requested path and filename different actions will be performed.
-/// In most cases information is provided by TRootSniffer class
+   if ((arg->fFileName == "root.websocket") || (arg->fFileName == "root.longpoll")) {
+      ExecuteWS(arg);
+      return;
+   }
 
-void THttpServer::ProcessRequest(THttpCallArg *arg)
-{
-   if (fTerminated) {
-      arg->Set404();
+   // this is just to support old Process(), should be deprecated after 6.20
+   fOldProcessSignature = kTRUE;
+   ProcessRequest(arg.get());
+   if (fOldProcessSignature) {
+      Error("ProcessRequest", "Deprecated signature is used, please used std::shared_ptr<THttpCallArg>");
       return;
    }
 
@@ -944,7 +940,7 @@ void THttpServer::ProcessRequest(THttpCallArg *arg)
       arg->SetContentType(GetMimeType(filename.Data()));
    } else {
       // miss request, user may process
-      MissedRequest(arg);
+      MissedRequest(arg.get());
    }
 
    if (arg->Is404())
@@ -966,6 +962,14 @@ void THttpServer::ProcessRequest(THttpCallArg *arg)
    // potentially add cors header
    if (IsCors())
       arg->AddHeader("Access-Control-Allow-Origin", GetCors());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// \deprecated  One should use signature with std::shared_ptr
+
+void THttpServer::ProcessRequest(THttpCallArg *)
+{
+   fOldProcessSignature = kFALSE;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -714,7 +714,7 @@ void THttpServer::ProcessRequest(std::shared_ptr<THttpCallArg> arg)
       return;
    }
 
-   // this is just to support old Process(), should be deprecated after 6.20
+   // this is just to support old Process(THttpCallArg*), should be deprecated after 6.20
    fOldProcessSignature = kTRUE;
    ProcessRequest(arg.get());
    if (fOldProcessSignature) {
@@ -745,8 +745,9 @@ void THttpServer::ProcessRequest(std::shared_ptr<THttpCallArg> arg)
                TString resolve;
                if (!IsFileRequested(fname, resolve)) resolve = fname;
                arg->fContent = ReadFileContent(resolve.Data());
-               arg->AddNoCacheHeader();
             }
+
+            handler->VerifyDefaultPageContent(arg);
 
             arg->CheckWSPageContent(handler);
          }

--- a/tutorials/webgui/panel/server.cxx
+++ b/tutorials/webgui/panel/server.cxx
@@ -74,9 +74,14 @@ void server()
    window = ROOT::Experimental::RWebWindow::Create();
 
    // Important - defines name of openui5 widget
-   // "localapp" prefix indicates that all files located in current directory
+   // "localapp" prefix will be point on current directory, where script executed
    // "localapp.view.TestPanel" means file ./view/TestPanel.view.xml will be loaded
    window->SetPanelName("localapp.view.TestPanel");
+
+   // Provide window client version to control browser cache
+   // When value changed, URL for JSROOT, UI5 and local files will differ
+   // Therefore web browser automatically reload all these files
+   // window->SetClientVersion("1.2");
 
    // these are different callbacks
    window->SetCallBacks(ProcessConnection, ProcessData, ProcessCloseConnection);

--- a/ui5/panel/panel.html
+++ b/ui5/panel/panel.html
@@ -7,7 +7,7 @@
       <title>ROOT7 web panel</title>
       <script type="text/javascript" src="jsrootsys/scripts/JSRootCore.js"></script>
    </head>
-   
+
    <style>
       html { height: 100%; }
       body { min-height: 100%; margin: 0; overflow: hidden }
@@ -26,26 +26,30 @@
          loading scripts...
       </div>
    </body>
-   
+
    <script type='text/javascript'>
 
       function ShowOpenui5Panel(panel_handle, arg) {
-         
+
          if (!panel_handle || !arg.first_msg || !sap) return false;
-           
+
          var panelid = "TopPanelId";
-         
+
          var viewName = arg.first_msg;
-         
+
          if ((viewName.indexOf("rootui5.") !== 0) && (viewName.indexOf("jsroot.") !== 0) && (viewName.indexOf("sap.") !== 0)) {
             var p = viewName.indexOf(".");
             if ((p > 1) && (p < viewName.length - 1)) {
-               console.log('Register module path', viewName.substr(0,p));
-               var _paths = {}; _paths[viewName.substr(0,p)] = "/currentdir/"; 
+               var tgtpath = "/currentdir/";
+               var pp = JSROOT.source_dir.indexOf("/jsrootsys/");
+               if (pp>0) tgtpath = JSROOT.source_dir.substr(0,pp) + "currentdir/";
+               var _paths = {};
+               _paths[viewName.substr(0,p)] = tgtpath;
+               console.log('Register module path', viewName.substr(0,p), ' as ', tgtpath);
                sap.ui.loader.config({ paths: _paths });
             }
          }
-         
+
          sap.ui.require(["sap/ui/core/mvc/XMLView"], function(XMLView) {
             XMLView.create({
                id: panelid,
@@ -57,7 +61,7 @@
 
          });
       }
-      
+
       JSROOT.ConnectWebWindow({
          prereq_logdiv: "PanelDiv",
          // openui5src: "jsroot",


### PR DESCRIPTION
When specified, all kinds of JS scripts and ui5 files will be loaded from
URL path, which includes such version tag. Therefore when version is
changed in C++, all related scripts will be automatically reloaded. 

This helps to solve browser cache problem, especially for
development phase. Normally browser heavily uses cached files, but if
one changes these files, one should explain every user that he/she must
clear the cache. With provided solution no any user intervention are
required.