### PR TITLE
[Math] Fix divide by zero in TFoam.

### DIFF
--- a/math/foam/src/TFoam.cxx
+++ b/math/foam/src/TFoam.cxx
@@ -619,7 +619,7 @@ void TFoam::Explore(TFoamCell *cell)
       if (ceSum[3]>wt) ceSum[3]=wt;  // minimum weight;
       if (ceSum[4]<wt) ceSum[4]=wt;  // maximum weight
       // test MC loop exit condition
-      nevEff = ceSum[0]*ceSum[0]/ceSum[1];
+      nevEff = ceSum[1] == 0. ? 0. : ceSum[0]*ceSum[0]/ceSum[1];
       if( nevEff >= fNBin*fEvPerBin) break;
    }   // ||||||||||||||||||||||||||END MC LOOP|||||||||||||||||||||||||||||
    //------------------------------------------------------------------


### PR DESCRIPTION
When TFoam is pre-sampling a phase space, it may divide by zero if for
some reason the event weight being generated is zero. This stops the generator
loop, and leads to a fp exception when enabled.
With this fix, the loop is kept running until the desired number of events
has been generated.