### PR TITLE
[RF] Sanitise integral of RooCBShape.

### DIFF
--- a/roofit/roofit/src/RooCBShape.cxx
+++ b/roofit/roofit/src/RooCBShape.cxx
@@ -166,7 +166,7 @@ Double_t RooCBShape::analyticalIntegral(Int_t code, const char* rangeName) const
     result += term1 + term2;
   }
 
-  return result != 0. ? result : std::numeric_limits<double>::min();
+  return result != 0. ? result : 1.E-300;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The integral of the crystal ball shape might vanish quickly due to
a finite precision when integrating far from the centre.
This leads to divisions by zero.
Now, a very small value is returned.