### PR TITLE
Provide default initializers for all TUrl members

### DIFF
--- a/core/base/inc/TUrl.h
+++ b/core/base/inc/TUrl.h
@@ -45,8 +45,8 @@ private:
    TString fOptions;        // options/search (after ?)
    mutable TString fFileOA; //!file with option and anchor
    mutable TString fHostFQ; //!fully qualified host name
-   Int_t   fPort;           // port through which to contact remote server
-   mutable TMap *fOptionsMap; //!map containing options key/value pairs
+   Int_t   fPort{-1};       // port through which to contact remote server
+   mutable TMap *fOptionsMap{nullptr}; //!map containing options key/value pairs
 
    static TObjArray  *fgSpecialProtocols;  // list of special protocols
    static THashList  *fgHostFQDNs;         // list of resolved host FQDNs
@@ -56,8 +56,7 @@ private:
    enum EStatusBits { kUrlWithDefaultPort = BIT(14), kUrlHasDefaultPort = BIT(15) };
 
 public:
-   TUrl() : fUrl(), fProtocol(), fUser(), fPasswd(), fHost(), fFile(),
-            fAnchor(), fOptions(), fFileOA(), fHostFQ(), fPort(-1), fOptionsMap(0) { }
+   TUrl() = default;
    TUrl(const char *url, Bool_t defaultIsFile = kFALSE);
    TUrl(const TUrl &url);
    TUrl &operator=(const TUrl &rhs);

--- a/core/base/src/TUrl.cxx
+++ b/core/base/src/TUrl.cxx
@@ -30,8 +30,8 @@ an URL. The supported url format is:
 #include "TMap.h"
 #include "TROOT.h"
 
-TObjArray *TUrl::fgSpecialProtocols = 0;
-THashList *TUrl::fgHostFQDNs = 0;
+TObjArray *TUrl::fgSpecialProtocols = nullptr;
+THashList *TUrl::fgHostFQDNs = nullptr;
 
 #ifdef R__COMPLETE_MEM_TERMINATION
 namespace {
@@ -107,7 +107,7 @@ TUrl::~TUrl()
 
 void TUrl::SetUrl(const char *url, Bool_t defaultIsFile)
 {
-   fOptionsMap = 0;
+   fOptionsMap = nullptr;
 
    if (!url || !url[0]) {
       fPort = -1;
@@ -352,7 +352,7 @@ TUrl::TUrl(const TUrl &url) : TObject(url)
    fPort       = url.fPort;
    fFileOA     = url.fFileOA;
    fHostFQ     = url.fHostFQ;
-   fOptionsMap = 0;
+   fOptionsMap = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -373,7 +373,7 @@ TUrl &TUrl::operator=(const TUrl &rhs)
       fPort       = rhs.fPort;
       fFileOA     = rhs.fFileOA;
       fHostFQ     = rhs.fHostFQ;
-      fOptionsMap = 0;
+      fOptionsMap = nullptr;
    }
    return *this;
 }
@@ -645,10 +645,10 @@ void TUrl::ParseOptions() const
 
 const char *TUrl::GetValueFromOptions(const char *key) const
 {
-   if (!key) return 0;
+   if (!key) return nullptr;
    ParseOptions();
-   TObject *option = fOptionsMap ? fOptionsMap->GetValue(key) : 0;
-   return (option ? ((TObjString*)fOptionsMap->GetValue(key))->GetName(): 0);
+   TObject *option = fOptionsMap ? fOptionsMap->GetValue(key) : nullptr;
+   return (option ? ((TObjString*)fOptionsMap->GetValue(key))->GetName(): nullptr);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -659,7 +659,7 @@ Int_t TUrl::GetIntValueFromOptions(const char *key) const
 {
    if (!key) return -1;
    ParseOptions();
-   TObject *option = fOptionsMap ? fOptionsMap->GetValue(key) : 0;
+   TObject *option = fOptionsMap ? fOptionsMap->GetValue(key) : nullptr;
    return (option ? (atoi(((TObjString*)fOptionsMap->GetValue(key))->GetName())) : -1);
 }
 


### PR DESCRIPTION
Fixes warning from Travis:
```
include/TUrl.h:59:4: note: Calling default constructor for
'\''TObject'\''
   TUrl() : fUrl(), fProtocol(), fUser(), fPasswd(), fHost(), fFile(),
```   

Also use nullptr instead 0 where it makes sense