### PR TITLE
Fix some windows compiler warnings

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -7179,7 +7179,7 @@ int TCling::SetClassAutoloading(int autoload) const
    // If no state change is required, exit early.
    // FIXME: In future we probably want to complain if we made a request which
    // was with the same state as before in order to catch programming errors.
-   if (autoload == IsClassAutoloadingEnabled())
+   if ((bool) autoload == IsClassAutoloadingEnabled())
       return autoload;
 
    assert(fClingCallbacks && "We must have callbacks!");

--- a/graf2d/graf/src/TMathText.cxx
+++ b/graf2d/graf/src/TMathText.cxx
@@ -227,9 +227,9 @@ public:
       const bool cyrillic_or_cjk = is_cyrillic_or_cjk(character);
 
       if (cyrillic_or_cjk) {
-         TTF::SetTextFont(root_cjk_face_number());
+         TTF::SetTextFont((Font_t) root_cjk_face_number());
       } else {
-         TTF::SetTextFont(root_face_number(family));
+         TTF::SetTextFont((Font_t) root_face_number(family));
       }
       FT_Load_Glyph(
          TTF::fgFace[TTF::fgCurFontIdx],
@@ -294,7 +294,7 @@ public:
           const std::wstring string,
           const unsigned int family = FAMILY_PLAIN)
    {
-      SetTextFont(root_face_number(family));
+      SetTextFont((Font_t) root_face_number(family));
       SetTextSize(_current_font_size[family]);
       TAttText::Modify();
 
@@ -307,7 +307,7 @@ public:
          const bool cyrillic_or_cjk = is_cyrillic_or_cjk(buf[0]);
 
          if (cyrillic_or_cjk) {
-            SetTextFont(root_cjk_face_number());
+            SetTextFont((Font_t) root_cjk_face_number());
             TAttText::Modify();
          }
 
@@ -320,7 +320,7 @@ public:
          gPad->PaintText(xt, yt, buf);
          advance += b.advance();
          if (cyrillic_or_cjk) {
-            SetTextFont(root_face_number(family));
+            SetTextFont((Font_t) root_face_number(family));
             TAttText::Modify();
          }
       }

--- a/tree/dataframe/inc/ROOT/RDF/RDisplay.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDisplay.hxx
@@ -183,6 +183,8 @@ private:
    /// If the number of required rows has been parsed, returns false.
    bool HasNext() { return fEntries > 0; }
 
+   void EnsureCurrentColumnWidth(size_t w);
+
 public:
    ////////////////////////////////////////////////////////////////////////////
    /// Creates an RDisplay to print the event values

--- a/tree/dataframe/src/RDFDisplay.cxx
+++ b/tree/dataframe/src/RDFDisplay.cxx
@@ -2,6 +2,7 @@
 #include "TInterpreter.h"
 
 #include <iomanip>
+#include <limits>
 
 namespace ROOT {
 namespace Internal {
@@ -89,12 +90,23 @@ bool RDisplayElement::IsEmpty() const
 } // namespace Internal
 
 namespace RDF {
+
+void RDisplay::EnsureCurrentColumnWidth(size_t w)
+{
+   // If the current element is wider than the widest element found, update the width
+   if (fWidths[fCurrentColumn] < w) {
+      if (w > std::numeric_limits<unsigned short>::max()) {
+         w = std::numeric_limits<unsigned short>::max();
+      }
+      fWidths[fCurrentColumn] = (unsigned short) w;
+   }
+}
+
 void RDisplay::AddToRow(const std::string &stringEle)
 {
    // If the current element is wider than the widest element found, update the width
-   if (fWidths[fCurrentColumn] < stringEle.length()) {
-      fWidths[fCurrentColumn] = stringEle.length();
-   }
+   EnsureCurrentColumnWidth(stringEle.length());
+
    // Save the element...
    fTable[fCurrentRow][fCurrentColumn] = DElement_t(stringEle);
 
@@ -113,18 +125,14 @@ void RDisplay::AddCollectionToRow(const std::vector<std::string> &collection)
       auto element = DElement_t(stringEle);
 
       // Update the width if this element is the biggest found
-      if (fWidths[fCurrentColumn] < stringEle.length()) {
-         fWidths[fCurrentColumn] = stringEle.length();
-      }
+      EnsureCurrentColumnWidth(stringEle.length());
 
       if (index == 0 || index == collectionSize - 1) {
          // Do nothing, by default DisplayElement is printed
       } else if (index == 1) {
          element.SetDots();
          // Be sure the "..." fit
-         if (fWidths[fCurrentColumn] < 3) {
-            fWidths[fCurrentColumn] = 3;
-         }
+         EnsureCurrentColumnWidth(3);
       } else {
          // In the Print(), after the dots, all element will just be ignored except the last one.
          element.SetIgnore();

--- a/tree/dataframe/src/lexertk.hpp
+++ b/tree/dataframe/src/lexertk.hpp
@@ -965,6 +965,7 @@ public:
 
    inline void ignore_symbol(const std::string &symbol) { ignore_set_.insert(symbol); }
 
+   using token_inserter::insert;
    inline int insert(const lexertk::token &t0, const lexertk::token &t1, lexertk::token &new_token)
    {
       new_token.type = lexertk::token::e_mul;
@@ -1088,6 +1089,7 @@ public:
       error_token_.clear();
    }
 
+   using token_scanner::operator();
    bool operator()(const lexertk::token &t)
    {
       if (!t.value.empty() && (lexertk::token::e_string != t.type) && (lexertk::token::e_symbol != t.type) &&
@@ -1216,6 +1218,7 @@ public:
 
    bool result() { return error_list_.empty(); }
 
+   using token_scanner::operator();
    bool operator()(const lexertk::token &t0, const lexertk::token &t1)
    {
       set_t::value_type p = std::make_pair(t0.type, t1.type);


### PR DESCRIPTION
Fixes ~20 from 100 existing warnings on Windows, 
remaining warnings are from llvm and clang, which is hard to patch now.