### PR TITLE
[Exp PyROOT] Fixed 'tutorial-math-Legendre-py' test

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -483,7 +483,6 @@ if(ROOT_python_FOUND)
                  tutorial-dataframe-df016_vecOps-py
                  tutorial-dataframe-df017_vecOpsHEP-py
                  tutorial-dataframe-df102_NanoAODDimuonAnalysis-py
-                 tutorial-math-Legendre-py
                  tutorial-pyroot-benchmarks-py
                  tutorial-pyroot-geometry-py
                  tutorial-pyroot-na49view-py

--- a/tutorials/math/Legendre.py
+++ b/tutorials/math/Legendre.py
@@ -6,7 +6,7 @@
 ## \macro_image
 ## \macro_code
 ##
-## \author Alberto Ferro
+## \author Alberto Ferro, Massimiliano Galli
 
 
 import ROOT
@@ -28,11 +28,14 @@ for nu in range(5):
 L[0].SetMaximum(1)
 L[0].SetMinimum(-1)
 L[0].SetTitle("Legendre polynomials")
-leg.AddEntry(L[0].Draw(), " L_{0}(x)", "l")
-leg.AddEntry(L[1].Draw("same"), " L_{1}(x)", "l")
-leg.AddEntry(L[2].Draw("same"), " L_{2}(x)", "l")
-leg.AddEntry(L[3].Draw("same"), " L_{3}(x)", "l")
-leg.AddEntry(L[4].Draw("same"), " L_{4}(x)", "l")
-leg.Draw()
+
+for idx, val in enumerate(L):
+    leg.AddEntry(val, " L_{}(x)".format(idx), "l")
+    if idx == 0:
+        val.Draw()
+    else:
+        val.Draw("same")
+
+leg.Draw("same")
 
 


### PR DESCRIPTION
The test mentioned above was rewritten in order to pass in Experimental PyROOT.
What made the test passing in the current PyROOT and failing in the Experimental one is the absence in Cppyy of a converter function which works with Python objects of type NoneType and is fired in lines like the following:
`leg.AddEntry(L[0].Draw(), " L_{0}(x)", "l")`
The presence of this function basically splits the above command like the following: 
1. the function is drawn on the canvas with the command
`L[0].Draw()`
2. the entry is added to the legend with the command
`leg.AddEntry(None, " L_{0}(x)", "l")`
Since it's also conceptually wrong to put the Draw() method as argument of the AddEntry function, it was decided to do the two things separately with a loop over the elements of the L list.