### PR TITLE
[eve7] fix windows warnings

### DIFF
--- a/graf3d/eve7/glu/gluos.h
+++ b/graf3d/eve7/glu/gluos.h
@@ -38,7 +38,9 @@
 #define WIN32_LEAN_AND_MEAN
 #define NOGDI
 #define NOIME
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 
 #ifdef __MINGW64_VERSION_MAJOR
   #undef _WIN32_WINNT

--- a/graf3d/eve7/inc/ROOT/REveDataSimpleProxyBuilderTemplate.hxx
+++ b/graf3d/eve7/inc/ROOT/REveDataSimpleProxyBuilderTemplate.hxx
@@ -24,7 +24,7 @@ protected:
       }
    }
 
-   void Build(const T & /*iData*/, int /*index*/, REveElement */*itemHolder*/, const REveViewContext */*context*/) override
+   void Build(const T & /*iData*/, int /*index*/, REveElement * /*itemHolder*/, const REveViewContext * /*context*/) override
    {
       throw std::runtime_error("virtual Build(const T&, int, REveElement&, const REveViewContext*) not implemented by inherited class.");
    }
@@ -36,7 +36,7 @@ protected:
       }
    }
 
-   void BuildViewType(const T &/*iData*/, int /*index*/, REveElement */*itemHolder*/, std::string /*viewType*/, const REveViewContext */*context*/) override
+   void BuildViewType(const T & /*iData*/, int /*index*/, REveElement * /*itemHolder*/, std::string /*viewType*/, const REveViewContext * /*context*/) override
    {
       throw std::runtime_error("virtual BuildViewType(const T&, int, REveElement&, const REveViewContext*) not implemented by inherited class.");
    }

--- a/graf3d/eve7/src/REveGluTess.cxx
+++ b/graf3d/eve7/src/REveGluTess.cxx
@@ -69,9 +69,9 @@ void TestTriangleHandler::tess_vertex(Int_t *vi, TriangleCollector *tc)
 //////////////////////////////////////////////////////////////////////////////////////
 /// tess_combine
 
-void TestTriangleHandler::tess_combine(GLdouble /*coords*/[3], void* /*vertex_data*/[4],
-                                     GLfloat  /*weight*/[4], void** /*outData*/,
-                                     TriangleCollector */*tc*/)
+void TestTriangleHandler::tess_combine(GLdouble /*coords*/[3], void * /*vertex_data*/[4],
+                                     GLfloat  /*weight*/[4], void ** /*outData*/,
+                                     TriangleCollector * /*tc*/)
 {
    throw std::runtime_error("GLU::TriangleCollector tesselator requested vertex combining -- not supported yet.");
 }


### PR DESCRIPTION
C4005: 'NOMINMAX': macro redefinition
C4138: '*/' found outside of comment