### PR TITLE
WebEve: Fix use of virtual/override in REveSimpleProxyBuilderTemplate

### DIFF
--- a/graf3d/eve7/inc/ROOT/REveDataSimpleProxyBuilderTemplate.hxx
+++ b/graf3d/eve7/inc/ROOT/REveDataSimpleProxyBuilderTemplate.hxx
@@ -17,6 +17,7 @@ public:
    }
 
 protected:
+   using REveDataSimpleProxyBuilder::Build;
    void Build(const void *iData, int index, REveElement *itemHolder, const REveViewContext *context) override
    {
       if(iData) {
@@ -24,11 +25,12 @@ protected:
       }
    }
 
-   void Build(const T & /*iData*/, int /*index*/, REveElement * /*itemHolder*/, const REveViewContext * /*context*/) override
+   virtual void Build(const T & /*iData*/, int /*index*/, REveElement * /*itemHolder*/, const REveViewContext * /*context*/)
    {
       throw std::runtime_error("virtual Build(const T&, int, REveElement&, const REveViewContext*) not implemented by inherited class.");
    }
 
+   using REveDataSimpleProxyBuilder::BuildViewType;
    void BuildViewType(const void *iData, int index, REveElement *itemHolder, std::string viewType, const REveViewContext *context) override
    {
       if(iData) {
@@ -36,7 +38,7 @@ protected:
       }
    }
 
-   void BuildViewType(const T & /*iData*/, int /*index*/, REveElement * /*itemHolder*/, std::string /*viewType*/, const REveViewContext * /*context*/) override
+   virtual void BuildViewType(const T & /*iData*/, int /*index*/, REveElement * /*itemHolder*/, std::string /*viewType*/, const REveViewContext * /*context*/)
    {
       throw std::runtime_error("virtual BuildViewType(const T&, int, REveElement&, const REveViewContext*) not implemented by inherited class.");
    }

--- a/tutorials/eve7/collection_proxies.C
+++ b/tutorials/eve7/collection_proxies.C
@@ -145,10 +145,10 @@ public:
 //==============================================================================
 class XYJetProxyBuilder: public REX::REveDataSimpleProxyBuilderTemplate<XYJet>
 {
-   virtual bool HaveSingleProduct() const { return false; }
+   bool HaveSingleProduct() const override { return false; }
 
    using REveDataSimpleProxyBuilderTemplate<XYJet>::BuildViewType;
-   virtual void BuildViewType(const XYJet& dj, int /*idx*/, REX::REveElement* iItemHolder, std::string viewType, const REX::REveViewContext* context)
+   void BuildViewType(const XYJet& dj, int /*idx*/, REX::REveElement* iItemHolder, std::string viewType, const REX::REveViewContext* context) override
    {
       auto jet = new REX::REveJetCone();
       jet->SetCylinder(context->GetMaxR(), context->GetMaxZ());
@@ -206,7 +206,7 @@ class XYJetProxyBuilder: public REX::REveDataSimpleProxyBuilderTemplate<XYJet>
 class TrackProxyBuilder : public REX::REveDataSimpleProxyBuilderTemplate<TParticle>
 {
    using REveDataSimpleProxyBuilderTemplate<TParticle>::Build;
-   virtual void Build(const TParticle& p, int /*idx*/, REX::REveElement* iItemHolder, const REX::REveViewContext* context)
+   void Build(const TParticle& p, int /*idx*/, REX::REveElement* iItemHolder, const REX::REveViewContext* context) override
    {
       const TParticle *x = &p;
       // printf("==============  BUILD track %s (pt=%f, eta=%f) \n", iItemHolder->GetCName(), p.Pt(), p.Eta());


### PR DESCRIPTION
This changes are need for collection_proxies.C demo to work.
Tested this on Fedora 30.

