### PR TITLE
Introduce a new directory bit to indicate custom browsing

### DIFF
--- a/io/io/inc/TDirectoryFile.h
+++ b/io/io/inc/TDirectoryFile.h
@@ -54,7 +54,7 @@ private:
 
 public:
    // TDirectory status bits
-   enum { kCloseDirectory = BIT(7) };
+   enum { kCloseDirectory = BIT(7), kCustomBrowse = BIT(9) };
 
    TDirectoryFile();
    TDirectoryFile(const char *name, const char *title, Option_t *option="", TDirectory* motherDir = 0);

--- a/tree/ntuple/v7/src/RPageStorageRoot.cxx
+++ b/tree/ntuple/v7/src/RPageStorageRoot.cxx
@@ -28,9 +28,6 @@
 #include <iostream>
 #include <utility>
 
-namespace {
-constexpr int kDirectoryCustomBrowse = BIT(9);
-}
 
 ROOT::Experimental::Detail::RPageSinkRoot::RPageSinkRoot(std::string_view ntupleName, RSettings settings)
    : RPageSink(ntupleName)
@@ -84,7 +81,7 @@ void ROOT::Experimental::Detail::RPageSinkRoot::Create(RNTupleModel &model)
 {
    fDirectory = fSettings.fFile->mkdir(fNTupleName.c_str());
    // In TBrowser, use RNTupleBrowser(TDirectory *directory) in order to show the ntuple contents
-   fDirectory->SetBit(kDirectoryCustomBrowse);
+   fDirectory->SetBit(TDirectoryFile::kCustomBrowse);
    fDirectory->SetTitle("ROOT::Experimental::Detail::RNTupleBrowser");
 
    unsigned int nColumns = 0;

--- a/tree/ntuple/v7/src/RPageStorageRoot.cxx
+++ b/tree/ntuple/v7/src/RPageStorageRoot.cxx
@@ -28,6 +28,10 @@
 #include <iostream>
 #include <utility>
 
+namespace {
+constexpr int kDirectoryCustomBrowse = BIT(9);
+}
+
 ROOT::Experimental::Detail::RPageSinkRoot::RPageSinkRoot(std::string_view ntupleName, RSettings settings)
    : RPageSink(ntupleName)
    , fPageAllocator(std::make_unique<RPageAllocatorHeap>())
@@ -79,6 +83,9 @@ ROOT::Experimental::Detail::RPageSinkRoot::AddColumn(const RColumn &column)
 void ROOT::Experimental::Detail::RPageSinkRoot::Create(RNTupleModel &model)
 {
    fDirectory = fSettings.fFile->mkdir(fNTupleName.c_str());
+   // In TBrowser, use RNTupleBrowser(TDirectory *directory) in order to show the ntuple contents
+   fDirectory->SetBit(kDirectoryCustomBrowse);
+   fDirectory->SetTitle("ROOT::Experimental::Detail::RNTupleBrowser");
 
    unsigned int nColumns = 0;
    for (const auto& f : *model.GetRootField()) {


### PR DESCRIPTION
RNTuple stores data in a directory. Upon opening this directory in TBrowser, not the opaque internal keys should be displayed but a user-friendly representation of the ntuple structure (fields). Thus, a new TDirectoryFile bit is introduced that should indicate to the TBrowser that an object of the type set in the directory's title shall take care of the in-directory browsing.

@bellenot @Axel-Naumann Please have a look.