### PR TITLE
[PyROOT experimental] Fix warning about incompatible function types

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/src/CPPInstancePyz.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/CPPInstancePyz.cxx
@@ -69,7 +69,7 @@ PyObject *PyROOT::CPPInstanceExpand(PyObject * /*self*/, PyObject *args)
 /// Turn the object proxy instance into a character stream and return for
 /// pickle, together with the callable object that can restore the stream
 /// into the object proxy instance.
-PyObject *op_reduce(CPPInstance *self)
+PyObject *op_reduce(CPPInstance *self, PyObject *)
 {
    // keep a borrowed reference around to the callable function for expanding;
    // because it is borrowed, it means that there can be no pickling during the


### PR DESCRIPTION
To be compatible with the definition of PyCFunction, op_reduce has to
take two PyObject* as arguments.