### PR TITLE
[RFC]: Reproducible ROOT files (DO NOT MERGE)

### DIFF
--- a/core/base/inc/TDirectory.h
+++ b/core/base/inc/TDirectory.h
@@ -93,6 +93,7 @@ protected:
    mutable std::atomic_flag fSpinLock; //! MSVC doesn't support = ATOMIC_FLAG_INIT;
 
    static Bool_t fgAddDirectory;   //!flag to add histograms, graphs,etc to the directory
+   static Bool_t fgReproducible;   //!Whether fixed values should be used for name, title, UUID, and datimes
 
           Bool_t  cd1(const char *path);
    static Bool_t  Cd1(const char *path);
@@ -210,6 +211,9 @@ public:
    static Bool_t       Cd(const char *path);
    static void         DecodeNameCycle(const char *namecycle, char *name, Short_t &cycle, const size_t namesize = 0);
    static void         EncodeNameCycle(char *buffer, const char *name, Short_t cycle);
+
+   static void         MakeReproducible(Bool_t reproducible = kTRUE) {fgReproducible = reproducible;}
+   static Bool_t       IsReproducible() {return fgReproducible;}
 
    ClassDef(TDirectory,5)  //Describe directory structure in memory
 };

--- a/core/base/src/TDatime.cxx
+++ b/core/base/src/TDatime.cxx
@@ -39,6 +39,7 @@ required, use TTimeStamp.
 #include "TError.h"
 #include "Bytes.h"
 #include "TString.h"
+#include "TDirectory.h"
 
 
 ClassImp(TDatime);
@@ -287,6 +288,11 @@ void TDatime::ReadBuffer(char *&buffer)
 
 void TDatime::Set()
 {
+   if (TDirectory::IsReproducible()) {
+      fDatime = UInt_t(0);
+      return;
+   }
+
 #ifndef WIN32
    time_t tloc   = time(0);
 #ifdef _REENTRANT

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -29,6 +29,7 @@
 #include "TSpinLockGuard.h"
 
 Bool_t TDirectory::fgAddDirectory = kTRUE;
+Bool_t TDirectory::fgReproducible = kFALSE;
 
 const Int_t  kMaxLen = 2048;
 

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -645,6 +645,10 @@ void TFile::Init(Bool_t create)
       new TFree(fFree, fBEGIN, Long64_t(kStartBigFile));  //Create new free list
 
       //*-* Write Directory info
+      if (fgReproducible) {
+         fName = "ReproducibleRootFile";
+         fUUID.SetUUID("00000000-0000-0000-0000-000000000000");
+      }
       Int_t namelen= TNamed::Sizeof();
       Int_t nbytes = namelen + TDirectoryFile::Sizeof();
       TKey *key    = new TKey(fName, fTitle, IsA(), nbytes, this);


### PR DESCRIPTION
Hi @Axel-Naumann,

This is not really a pull request but I thought it might be a good way to get feedback from you guys and maybe some help improving it. This is not meant for merging, we are fine with an out of tree patch for now, but we would of course be very happy if something like this becomes upstream eventually.

This is a very "hacky" try to be able to create ROOT files with
deterministic checksum that is not dependent on timestamp or hostname or
anything: Create a file with the same content twice on different
machines should yield the same checksum (assuming they have the same root file format version and same class definitions ...)

We cannot really modify the software using these checksums and it's not just ROOT files but also other files in there so a distinction between "content checksum" and "file checksum" would be rather tricky. That's why we went for the brutal approach.

We need this mostly for small files in a well controlled environment:
The file is created in one place at one time and not incrementally over
a long time, no threads. 

So we would be fine with a global flag to not store time dependent information in files but it is of course ugly.

A slightly less horrific version might be to have a `TDeterministicFile` which behaves like `TFile` with the only difference that it has a zeros for dates/uuids but I don't know the classes well enough to judge if that is feasible. 