### PR TITLE
[cxxmodules] Do not use rdict files.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1318,15 +1318,9 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
       interpArgs.push_back(arg.c_str());
    }
 
-   // Add the Rdict module file extension.
-   cling::Interpreter::ModuleFileExtensions extensions;
-   EnvOpt = llvm::sys::Process::GetEnv("ROOTDEBUG_RDICT");
-   if (!EnvOpt.hasValue())
-      extensions.push_back(std::make_shared<TClingRdictModuleFileExtension>());
-
    fInterpreter = new cling::Interpreter(interpArgs.size(),
                                          &(interpArgs[0]),
-                                         llvmResourceDir, extensions);
+                                         llvmResourceDir);
 
    if (!fromRootCling) {
       fInterpreter->installLazyFunctionCreator(llvmLazyFunctionCreator);


### PR DESCRIPTION
We would like to get some performance evaluations from the cmssw side. This PR is a continuation from PR #3012 

@smuzaffar, @mrodozov, could you build ROOT's cxxmodule IB against this PR and see if there are performance difference with and without this PR? 