### PR TITLE
[gpad] always set fXUpNDC/fYUpNDC members in TPad::SetPad()

### DIFF
--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -5893,6 +5893,8 @@ void TPad::SetPad(Double_t xlow, Double_t ylow, Double_t xup, Double_t yup)
 
    fXlowNDC = xlow;
    fYlowNDC = ylow;
+   fXUpNDC  = xup;
+   fYUpNDC  = yup;
    fWNDC    = xup - xlow;
    fHNDC    = yup - ylow;
 

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -131,11 +131,11 @@ The transformation coefficients are explained in TPad::ResizePad.
 TPad::TPad()
 {
    fModified   = kTRUE;
-   fTip        = 0;
-   fPadPointer = 0;
-   fPrimitives = 0;
-   fExecs      = 0;
-   fCanvas     = 0;
+   fTip        = nullptr;
+   fPadPointer = nullptr;
+   fPrimitives = nullptr;
+   fExecs      = nullptr;
+   fCanvas     = nullptr;
    fPadPaint   = 0;
    fPixmapID   = -1;
    fGLDevice   = -1;
@@ -148,7 +148,7 @@ TPad::TPad()
    fEditable   = kTRUE;
    fCrosshair  = 0;
    fCrosshairPos = 0;
-   fPadView3D  = 0;
+   fPadView3D  = nullptr;
    fMother     = (TPad*)gPad;
 
    fAbsHNDC      = 0.;
@@ -183,7 +183,7 @@ TPad::TPad()
 
    fNumPaletteColor = 0;
    fNextPaletteColor = 0;
-   fCollideGrid = 0;
+   fCollideGrid = nullptr;
    fCGnx = 0;
    fCGny = 0;
 
@@ -194,8 +194,8 @@ TPad::TPad()
    fGridy = 0;
    fTickx = 0;
    fTicky = 0;
-   fFrame = 0;
-   fView  = 0;
+   fFrame = nullptr;
+   fView  = nullptr;
 
    fUxmin = fUymin = fUxmax = fUymax = 0;
 
@@ -211,7 +211,7 @@ TPad::TPad()
    fWNDC    = 1;
    fHNDC    = 1;
 
-   fViewer3D = 0;
+   fViewer3D = nullptr;
    SetBit(kMustCleanup);
 
    // the following line is temporarily disabled. It has side effects
@@ -249,7 +249,7 @@ TPad::TPad(const char *name, const char *title, Double_t xlow,
           : TVirtualPad(name,title,xlow,ylow,xup,yup,color,bordersize,bordermode)
 {
    fModified   = kTRUE;
-   fTip        = 0;
+   fTip        = nullptr;
    fBorderSize = bordersize;
    fBorderMode = bordermode;
    if (gPad)   fCanvas = gPad->GetCanvas();
@@ -257,17 +257,17 @@ TPad::TPad(const char *name, const char *title, Double_t xlow,
    fMother     = (TPad*)gPad;
    fPrimitives = new TList;
    fExecs      = new TList;
-   fPadPointer = 0;
+   fPadPointer = nullptr;
    fTheta      = 30;
    fPhi        = 30;
    fGridx      = gStyle->GetPadGridX();
    fGridy      = gStyle->GetPadGridY();
    fTickx      = gStyle->GetPadTickX();
    fTicky      = gStyle->GetPadTickY();
-   fFrame      = 0;
-   fView       = 0;
+   fFrame      = nullptr;
+   fView       = nullptr;
    fPadPaint   = 0;
-   fPadView3D  = 0;
+   fPadView3D  = nullptr;
    fPixmapID   = -1;      // -1 means pixmap will be created by ResizePad()
    fCopyGLDevice = kFALSE;
    fEmbeddedGL = kFALSE;
@@ -316,11 +316,11 @@ TPad::TPad(const char *name, const char *title, Double_t xlow,
 
    fNumPaletteColor = 0;
    fNextPaletteColor = 0;
-   fCollideGrid = 0;
+   fCollideGrid = nullptr;
    fCGnx = 0;
    fCGny = 0;
 
-   fViewer3D = 0;
+   fViewer3D = nullptr;
 
    fGLDevice = fCanvas->GetGLDevice();
    // Set default world coordinates to NDC [0,1]
@@ -631,7 +631,7 @@ void TPad::Clear(Option_t *option)
       if (fPrimitives) fPrimitives->Clear(option);
       if (fFrame) {
          if (fFrame->TestBit(kNotDeleted)) delete fFrame;
-         fFrame = 0;
+         fFrame = nullptr;
       }
    }
    if (fCanvas) fCanvas->Cleared(this);
@@ -652,7 +652,7 @@ void TPad::Clear(Option_t *option)
    fNumPaletteColor = 0;
    if (fCollideGrid) {
       delete [] fCollideGrid;
-      fCollideGrid = 0;
+      fCollideGrid = nullptr;
       fCGnx = 0;
       fCGny = 0;
    }
@@ -995,11 +995,11 @@ void TPad::Close(Option_t *)
       fPrimitives->Clear();
    if (fView) {
       if (fView->TestBit(kNotDeleted)) delete fView;
-      fView = 0;
+      fView = nullptr;
    }
    if (fFrame) {
       if (fFrame->TestBit(kNotDeleted)) delete fFrame;
-      fFrame = 0;
+      fFrame = nullptr;
    }
 
    // emit signal
@@ -1035,8 +1035,8 @@ void TPad::Close(Option_t *)
          fCanvas->SetClickSelectedPad(0);
    }
 
-   fMother = 0;
-   if (gROOT->GetSelectedPad() == this) gROOT->SetSelectedPad(0);
+   fMother = nullptr;
+   if (gROOT->GetSelectedPad() == this) gROOT->SetSelectedPad(nullptr);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2588,7 +2588,7 @@ void TPad::ExecuteEventAxis(Int_t event, Int_t px, Int_t py, TAxis *axis)
 
 TObject *TPad::FindObject(const char *name) const
 {
-   if (!fPrimitives) return 0;
+   if (!fPrimitives) return nullptr;
    TObject *found = fPrimitives->FindObject(name);
    if (found) return found;
    TObject *cur;
@@ -2599,7 +2599,7 @@ TObject *TPad::FindObject(const char *name) const
          if (found) return found;
       }
    }
-    return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2609,7 +2609,7 @@ TObject *TPad::FindObject(const char *name) const
 
 TObject *TPad::FindObject(const TObject *obj) const
 {
-   if (!fPrimitives) return 0;
+   if (!fPrimitives) return nullptr;
    TObject *found = fPrimitives->FindObject(obj);
    if (found) return found;
    TObject *cur;
@@ -2620,7 +2620,7 @@ TObject *TPad::FindObject(const TObject *obj) const
          if (found) return found;
       }
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2636,7 +2636,7 @@ Int_t TPad::GetCanvasID() const
 
 TCanvasImp *TPad::GetCanvasImp() const
 {
-   return fCanvas ? fCanvas->GetCanvasImp() : 0;
+   return fCanvas ? fCanvas->GetCanvasImp() : nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2668,7 +2668,7 @@ Int_t TPad::GetEventY() const
 
 TVirtualPad *TPad::GetVirtCanvas() const
 {
-   return  fCanvas ? (TVirtualPad*) fCanvas : 0;
+   return  fCanvas ? (TVirtualPad*) fCanvas : nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2692,8 +2692,8 @@ Int_t TPad::GetMaxPickDistance()
 
 TObject *TPad::GetSelected() const
 {
-   if (fCanvas == this) return 0;
-   return  fCanvas ? fCanvas->GetSelected() : 0;
+   if (fCanvas == this) return nullptr;
+   return  fCanvas ? fCanvas->GetSelected() : nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2701,8 +2701,8 @@ TObject *TPad::GetSelected() const
 
 TVirtualPad *TPad::GetSelectedPad() const
 {
-   if (fCanvas == this) return 0;
-   return  fCanvas ? fCanvas->GetSelectedPad() : 0;
+   if (fCanvas == this) return nullptr;
+   return  fCanvas ? fCanvas->GetSelectedPad() : nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2710,8 +2710,8 @@ TVirtualPad *TPad::GetSelectedPad() const
 
 TVirtualPad *TPad::GetPadSave() const
 {
-   if (fCanvas == this) return 0;
-   return  fCanvas ? fCanvas->GetPadSave() : 0;
+   if (fCanvas == this) return nullptr;
+   return  fCanvas ? fCanvas->GetPadSave() : nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2746,7 +2746,7 @@ void TPad::HideToolTip(Int_t event)
 
 Bool_t TPad::IsBatch() const
 {
-   return  fCanvas ? fCanvas->IsBatch() : 0;
+   return  fCanvas ? fCanvas->IsBatch() : kFALSE;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2754,7 +2754,7 @@ Bool_t TPad::IsBatch() const
 
 Bool_t TPad::IsRetained() const
 {
-   return  fCanvas ? fCanvas->IsRetained() : 0;
+   return  fCanvas ? fCanvas->IsRetained() : kFALSE;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2762,7 +2762,7 @@ Bool_t TPad::IsRetained() const
 
 Bool_t TPad::OpaqueMoving() const
 {
-   return  fCanvas ? fCanvas->OpaqueMoving() : 0;
+   return  fCanvas ? fCanvas->OpaqueMoving() : kFALSE;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2770,7 +2770,7 @@ Bool_t TPad::OpaqueMoving() const
 
 Bool_t TPad::OpaqueResizing() const
 {
-   return  fCanvas ? fCanvas->OpaqueResizing() : 0;
+   return  fCanvas ? fCanvas->OpaqueResizing() : kFALSE;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2850,7 +2850,7 @@ TFrame *TPad::GetFrame()
 
 TObject *TPad::GetPrimitive(const char *name) const
 {
-   if (!fPrimitives) return 0;
+   if (!fPrimitives) return nullptr;
    TIter next(fPrimitives);
    TObject *found, *obj;
    while ((obj=next())) {
@@ -2859,7 +2859,7 @@ TObject *TPad::GetPrimitive(const char *name) const
       found = obj->FindObject(name);
       if (found) return found;
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2872,7 +2872,7 @@ TVirtualPad *TPad::GetPad(Int_t subpadnumber) const
    }
 
    TObject *obj;
-   if (!fPrimitives) return 0;
+   if (!fPrimitives) return nullptr;
    TIter    next(GetListOfPrimitives());
    while ((obj = next())) {
       if (obj->InheritsFrom(TVirtualPad::Class())) {
@@ -2880,7 +2880,7 @@ TVirtualPad *TPad::GetPad(Int_t subpadnumber) const
          if (pad->GetNumber() == subpadnumber) return pad;
       }
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -3013,7 +3013,7 @@ void TPad::FillCollideGrid(TObject *oi)
          fCGnx = CGnx;
          fCGny = CGny;
          delete [] fCollideGrid;
-         fCollideGrid = 0;
+         fCollideGrid = nullptr;
       }
    }
 
@@ -5214,7 +5214,7 @@ void TPad::RecursiveRemove(TObject *obj)
 {
    if (obj == fCanvas->GetSelected()) fCanvas->SetSelected(0);
    if (obj == fCanvas->GetClickSelected()) fCanvas->SetClickSelected(0);
-   if (obj == fView) fView = 0;
+   if (obj == fView) fView = nullptr;
    if (!fPrimitives) return;
    Int_t nold = fPrimitives->GetSize();
    fPrimitives->RecursiveRemove(obj);
@@ -5842,7 +5842,7 @@ void TPad::SetFillStyle(Style_t fstyle)
 void TPad::SetLogx(Int_t value)
 {
    fLogx = value;
-   delete fView; fView=0;
+   delete fView; fView = nullptr;
    Modified();
    RangeAxisChanged();
 }
@@ -5856,7 +5856,7 @@ void TPad::SetLogx(Int_t value)
 void TPad::SetLogy(Int_t value)
 {
    fLogy = value;
-   delete fView; fView=0;
+   delete fView; fView = nullptr;
    Modified();
    RangeAxisChanged();
 }
@@ -5867,7 +5867,7 @@ void TPad::SetLogy(Int_t value)
 void TPad::SetLogz(Int_t value)
 {
    fLogz = value;
-   delete fView; fView=0;
+   delete fView; fView = nullptr;
    Modified();
    RangeAxisChanged();
 }
@@ -6429,11 +6429,11 @@ void TPad::SetToolTipText(const char *text, Long_t delayms)
 {
    if (fTip) {
       DeleteToolTip(fTip);
-      fTip = 0;
+      fTip = nullptr;
    }
 
    if (text && strlen(text))
-      fTip = CreateToolTip((TBox*)0, text, delayms);
+      fTip = CreateToolTip((TBox*)nullptr, text, delayms);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -6476,7 +6476,7 @@ void TPad::Streamer(TBuffer &b)
          }
 
          fModified = kTRUE;
-         fPadPointer = 0;
+         fPadPointer = nullptr;
          gReadLevel--;
          if (gReadLevel == 0 && IsA() == TPad::Class()) ResizePad();
          gROOT->SetReadingObject(kFALSE);
@@ -6636,7 +6636,7 @@ void TPad::Streamer(TBuffer &b)
          b >> fTheta;
          b >> fPhi;
       }
-      fPadPointer = 0;
+      fPadPointer = nullptr;
       b >> fNumber;
       b >> fAbsCoord;
       if (v > 1) {
@@ -6953,7 +6953,7 @@ TVirtualViewer3D *TPad::GetViewer3D(Option_t *type)
 
 void TPad::ReleaseViewer3D(Option_t * /*type*/ )
 {
-   fViewer3D = 0;
+   fViewer3D = nullptr;
 
    // We would like to ensure the pad is repainted
    // when external viewer is closed down. However
@@ -6993,7 +6993,7 @@ void TPad::RecordLatex(const TObject *obj)
 
 TVirtualPadPainter *TPad::GetPainter()
 {
-   if (!fCanvas) return 0;
+   if (!fCanvas) return nullptr;
    return fCanvas->GetCanvasPainter();
 }
 


### PR DESCRIPTION
Otherwise direct call to SetBoxX1/SetBoxY1 will fail.
Only works now while fXUpNDC recalculated when start interactive
movement of frame

Also use `nullptr` instead 0 and kFALSE instead of 0