### PR TITLE
[PyROOT experimental] Shuffle includes to fix redefines

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/src/PyzCppHelpers.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyzCppHelpers.cxx
@@ -17,11 +17,6 @@ pythonizations.
 
 #include "PyzCppHelpers.hxx"
 
-#include "CPyCppyy.h"
-#include "CPPInstance.h"
-#include "TClass.h"
-#include "RConfig.h"
-
 // Call method with signature: obj->meth()
 PyObject *CallPyObjMethod(PyObject *obj, const char *meth)
 {

--- a/bindings/pyroot_experimental/PyROOT/src/PyzCppHelpers.hxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyzCppHelpers.hxx
@@ -11,15 +11,12 @@
 #ifndef PYROOT_PYZCPPHELPERS
 #define PYROOT_PYZCPPHELPERS
 
+#include "CPyCppyy.h"
+#include "CPPInstance.h"
+#include "TClass.h"
+#include "RConfig.h"
+
 #include <string>
-
-struct _object;
-typedef _object PyObject;
-
-class TClass;
-namespace CPyCppyy {
-   class CPPInstance;
-}
 
 PyObject *CallPyObjMethod(PyObject *obj, const char *meth);
 PyObject *CallPyObjMethod(PyObject *obj, const char *meth, PyObject *arg1);


### PR DESCRIPTION
Python.h **always** has to be included first. In our case, we have to
put cppyy in first place (which includes Python.h first).

This should fix the warnings [here](http://cdash.cern.ch/viewBuildError.php?type=1&buildid=687201).