### PR TITLE
[webgui6] let load custom JS code when painting canvas

### DIFF
--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -69,6 +69,7 @@ protected:
    Int_t fPrimitivesMerge{100};    ///<! number of PS primitives, which will be merged together
    Int_t fJsonComp{0};             ///<! compression factor for messages send to the client
    std::string fCustomScripts;     ///<! custom JavaScript code or URL on JavaScript files to load before start drawing
+   std::vector<std::string> fCustomClasses;  ///<! list of custom classes, which can be delivered as is to client
 
    UpdatedSignal_t fUpdatedSignal; ///<! signal emitted when canvas updated or state is changed
 
@@ -160,10 +161,10 @@ public:
    void SetPrimitivesMerge(Int_t cnt) { fPrimitivesMerge = cnt; }
    Int_t GetPrimitivesMerge() const { return fPrimitivesMerge; }
 
-   /** Configures custom script for canvas.
-    * If started from "load:" or "assert:" prefix will be loaded with JSROOT.AssertPrerequisites function */
-   void SetCustomScripts(const std::string &src) { fCustomScripts = src; }
-   std::string GetCustomScripts() const { return fCustomScripts; }
+   void SetCustomScripts(const std::string &src);
+
+   void AddCustomClass(const std::string &clname, bool with_derived = false);
+   bool IsCustomClass(TClass *cl);
 
    static TString CreateCanvasJSON(TCanvas *c, Int_t json_compression = 0);
    static Int_t StoreCanvasJSON(TCanvas *c, const char *filename, const char *option = "");

--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -164,7 +164,7 @@ public:
    void SetCustomScripts(const std::string &src);
 
    void AddCustomClass(const std::string &clname, bool with_derived = false);
-   bool IsCustomClass(TClass *cl);
+   bool IsCustomClass(const TClass *cl) const;
 
    static TString CreateCanvasJSON(TCanvas *c, Int_t json_compression = 0);
    static Int_t StoreCanvasJSON(TCanvas *c, const char *filename, const char *option = "");

--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -68,6 +68,7 @@ protected:
    Int_t fPaletteDelivery{1};      ///<! colors palette delivery 0:never, 1:once, 2:always, 3:per subpad
    Int_t fPrimitivesMerge{100};    ///<! number of PS primitives, which will be merged together
    Int_t fJsonComp{0};             ///<! compression factor for messages send to the client
+   std::string fCustomScripts;     ///<! custom JavaScript code or URL on JavaScript files to load before start drawing
 
    UpdatedSignal_t fUpdatedSignal; ///<! signal emitted when canvas updated or state is changed
 
@@ -158,6 +159,11 @@ public:
 
    void SetPrimitivesMerge(Int_t cnt) { fPrimitivesMerge = cnt; }
    Int_t GetPrimitivesMerge() const { return fPrimitivesMerge; }
+
+   /** Configures custom script for canvas.
+    * If started from "load:" or "assert:" prefix will be loaded with JSROOT.AssertPrerequisites function */
+   void SetCustomScripts(const std::string &src) { fCustomScripts = src; }
+   std::string GetCustomScripts() const { return fCustomScripts; }
 
    static TString CreateCanvasJSON(TCanvas *c, Int_t json_compression = 0);
    static Int_t StoreCanvasJSON(TCanvas *c, const char *filename, const char *option = "");

--- a/gui/webgui6/inc/TWebSnapshot.h
+++ b/gui/webgui6/inc/TWebSnapshot.h
@@ -96,11 +96,14 @@ public:
 class TCanvasWebSnapshot : public TPadWebSnapshot {
 protected:
    Long64_t fVersion{0};           ///< actual canvas version
+   std::string fScripts;           ///< custom scripts to load
 public:
    TCanvasWebSnapshot() = default;
    TCanvasWebSnapshot(bool readonly, Long64_t v) : TPadWebSnapshot(readonly), fVersion(v) {}
 
    Long64_t GetVersion() const { return fVersion; }
+
+   void SetScripts(const std::string &src) { fScripts = src; }
 
    ClassDef(TCanvasWebSnapshot, 1) // Canvas painting snapshot, used for JSROOT
 };

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -500,6 +500,10 @@ void TWebCanvas::CheckDataToSend(unsigned connid)
 
          TCanvasWebSnapshot holder(IsReadOnly(), fCanvVersion);
 
+         // scripts send only when canvas drawn for the first time
+         if (!conn.fSendVersion)
+            holder.SetScripts(fCustomScripts);
+
          CreatePadSnapshot(holder, Canvas(), conn.fSendVersion, [&buf,this](TPadWebSnapshot *snap) {
             buf.append(TBufferJSON::ToJSON(snap, fJsonComp).Data());
          });

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -151,7 +151,7 @@ void TWebCanvas::AddCustomClass(const std::string &clname, bool with_derived)
 //////////////////////////////////////////////////////////////////////////////////////////////////
 /// Checks if class belongs to custom
 
-bool TWebCanvas::IsCustomClass(TClass *cl)
+bool TWebCanvas::IsCustomClass(const TClass *cl) const
 {
    for (auto &name : fCustomClasses) {
       if (name[0] == '+') {
@@ -163,8 +163,6 @@ bool TWebCanvas::IsCustomClass(TClass *cl)
    }
    return false;
 }
-
-
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 /// Creates representation of the object for painting in web browser

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -123,8 +123,48 @@ Bool_t TWebCanvas::IsJSSupportedClass(TObject *obj)
          if (obj->InheritsFrom(supported_classes[i].name))
             return kTRUE;
 
-   return kFALSE;
+   return IsCustomClass(obj->IsA());
 }
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+/// Configures custom script for canvas.
+/// If started from "load:" or "assert:" prefix will be loaded with JSROOT.AssertPrerequisites function
+/// Script should implement custom user classes, which transferred as is to client
+/// In the script draw handler for appropriate classes whould be assigned
+
+void TWebCanvas::SetCustomScripts(const std::string &src)
+{
+   fCustomScripts = src;
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+/// Assign custom class
+
+void TWebCanvas::AddCustomClass(const std::string &clname, bool with_derived)
+{
+   if (with_derived)
+      fCustomClasses.emplace_back("+"s + clname);
+   else
+      fCustomClasses.emplace_back(clname);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+/// Checks if class belongs to custom
+
+bool TWebCanvas::IsCustomClass(TClass *cl)
+{
+   for (auto &name : fCustomClasses) {
+      if (name[0] == '+') {
+         if (cl->InheritsFrom(name.substr(1).c_str()))
+            return true;
+      } else if (name.compare(cl->GetName()) == 0) {
+         return true;
+      }
+   }
+   return false;
+}
+
+
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 /// Creates representation of the object for painting in web browser

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -96,7 +96,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 9/07/2019";
+   JSROOT.version = "dev 17/07/2019";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;
@@ -564,8 +564,7 @@
    JSROOT.parse = function(json) {
       if (!json) return null;
       var obj = JSON.parse(json);
-      if (obj) obj = this.JSONR_unref(obj);
-      return obj;
+      return obj ? this.JSONR_unref(obj) : obj;
    }
 
    /**
@@ -1265,8 +1264,8 @@
       if (kind.indexOf("mathjax;")>=0) {
 
          if (typeof MathJax == 'undefined') {
-            mainfiles += (use_bower ? "###MathJax/MathJax.js" : "https://root.cern/js/mathjax/latest/MathJax.js") +
-                           "?config=TeX-AMS-MML_SVG&delayStartupUntil=configured";
+            mainfiles += (use_bower ? "###MathJax" : "https://root.cern/js/mathjax/latest") +
+                          "/MathJax.js?config=TeX-AMS-MML_SVG&delayStartupUntil=configured;";
             modules.push('MathJax');
 
             load_callback = function() {

--- a/js/scripts/JSRootPainter.js
+++ b/js/scripts/JSRootPainter.js
@@ -3942,6 +3942,26 @@
       return false;
    }
 
+   /** @brief Invoke method for object via WebCanvas functionality
+    * @desc Requires that painter marked with object identifier (this.snapid) or identifier provided as second argument
+    * Canvas painter should exists and in non-readonly mode
+    * Execution string can look like "Print()".
+    * Many methods call can be chained with "Print();;Update();;Clear()"
+    * @private */
+
+   TObjectPainter.prototype.WebCanvasExec = function(exec, snapid) {
+      if (!exec || (typeof exec != 'string')) return;
+
+      if (!snapid) snapid = this.snapid;
+      if (!snapid || (typeof snapid != 'string')) return;
+
+      var canp = this.canv_painter();
+      if (canp && !canp._readonly && canp._websocket) {
+         console.log('execute ' + exec + ' for object ' + snapid);
+         canp.SendWebsocket("OBJEXEC:" + snapid + ":" + exec);
+      }
+   }
+
    /** @summary Fill object menu in web canvas
     * @private */
    TObjectPainter.prototype.FillObjectExecMenu = function(menu, kind, call_back) {
@@ -3970,10 +3990,8 @@
 
          if (execp.ExecuteMenuCommand(item)) return;
 
-         if (cp._websocket && execp.args_menu_id && !cp._readonly) {
-            console.log('execute method ' + item.fExec + ' for object ' + execp.args_menu_id);
-            cp.SendWebsocket('OBJEXEC:' + execp.args_menu_id + ":" + item.fExec);
-         }
+         if (execp.args_menu_id)
+            execp.WebCanvasExec(item.fExec, execp.args_menu_id);
       }
 
       function DoFillMenu(_menu, _reqid, _call_back, reply) {

--- a/js/scripts/JSRootPainter.more.js
+++ b/js/scripts/JSRootPainter.more.js
@@ -1745,11 +1745,11 @@
    }
 
    TGraphPainter.prototype.endPntHandler = function() {
-      if (this.snapid && this.interactive_bin) {
+      if (this.interactive_bin) {
          var exec = "SetPoint(" + this.interactive_bin.indx + "," + this.interactive_bin.x + "," + this.interactive_bin.y + ")";
-         var canp = this.canv_painter();
-         if (canp && !canp._readonly)
-            canp.SendWebsocket("OBJEXEC:" + this.snapid + ":" + exec);
+         if ((this.interactive_bin.indx == 0) && this.MatchObjectType('TCutG'))
+            exec += ";;SetPoint(" + (this.GetObject().fNpoints-1) + "," + this.interactive_bin.x + "," + this.interactive_bin.y + ")";
+         this.WebCanvasExec(exec);
       }
 
       delete this.interactive_bin;
@@ -1799,9 +1799,7 @@
                 usery = main && main.RevertY ? main.RevertY(pnt.y) : 0;
             canp.ShowMessage('InsertPoint(' + userx.toFixed(3) + ',' + usery.toFixed(3) + ') not yet implemented');
          } else if (this.args_menu_id && hint && (hint.binindx !== undefined)) {
-            var exec = "RemovePoint(" + hint.binindx + ")";
-            console.log('execute ' + exec + ' for object ' + this.args_menu_id);
-            canp.SendWebsocket('OBJEXEC:' + this.args_menu_id + ":" + exec);
+            this.WebCanvasExec("RemovePoint(" + hint.binindx + ")", this.args_menu_id);
          }
 
          return true; // call is processed

--- a/js/scripts/JSRootPainter.v6.js
+++ b/js/scripts/JSRootPainter.v6.js
@@ -3733,7 +3733,26 @@
          if (!this.batch_mode)
             this.AddOnlineButtons();
 
-         this.DrawNextSnap(snap.fPrimitives, -1, call_back);
+         if (snap.fScripts && (typeof snap.fScripts == "string")) {
+            var arg = "";
+
+            if (snap.fScripts.indexOf("load:") == 0) arg = snap.fScripts; else
+            if (snap.fScripts.indexOf("assert:") == 0) arg = snap.fScripts.substr(7);
+            if (arg) {
+               var painter = this;
+               JSROOT.AssertPrerequisites(arg, function() {
+                  painter.DrawNextSnap(snap.fPrimitives, -1, call_back);
+               });
+            } else {
+               console.log('Calling eval ' + snap.fScripts.length);
+               eval(snap.fScripts);
+               console.log('Calling eval done');
+               this.DrawNextSnap(snap.fPrimitives, -1, call_back);
+            }
+         } else {
+            this.DrawNextSnap(snap.fPrimitives, -1, call_back);
+         }
+
          return;
       }
 
@@ -5002,10 +5021,9 @@
       if (painter.enlarge_main('verify'))
          painter.AddButton(JSROOT.ToolbarIcons.circle, "Enlarge canvas", "EnlargePad");
 
-      // JSROOT.Painter.drawFrame(divid, null);
-
       painter.RedrawPadSnap(snap, function() { painter.ShowButtons(); painter.DrawingReady(); });
 
+      // JSROOT.Painter.drawFrame(divid, null);
       return painter;
    }
 


### PR DESCRIPTION
This is first attempt to provide support of custom classes in web-based canvas
For now one has to register list of such classes and provide JavaScript code where painters are implemented. 

Similar approach can be implemented in the future for ROOT7 RCanvas.
Probably, such custom JS code can be "embed" directly into C++ code making maintenance much easier.

Update JSROOT with many improvements for TGeo monitoring