### PR TITLE
[TCling] Add kIsInlined bit to extra properties word

### DIFF
--- a/core/meta/inc/TDictionary.h
+++ b/core/meta/inc/TDictionary.h
@@ -121,7 +121,8 @@ enum EFunctionProperty {
    kIsConstructor = 0x00000001,
    kIsConversion  = 0x00000002,
    kIsDestructor  = 0x00000004,
-   kIsOperator    = 0x00000008
+   kIsOperator    = 0x00000008,
+   kIsInlined     = 0x00000010
 };
 
 enum EClassProperty {

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -8496,6 +8496,8 @@ Long_t TCling::FuncTempInfo_ExtraProperty(FuncTempInfo_t* ft_info) const
       property |= kIsConstructor;
    } else if (llvm::isa<clang::CXXDestructorDecl>(fd)) {
       property |= kIsDestructor;
+   } else if (fd->isInlined()) {
+      property |= kIsInlined;
    }
 
    return property;

--- a/core/metacling/src/TClingMethodInfo.cxx
+++ b/core/metacling/src/TClingMethodInfo.cxx
@@ -524,6 +524,8 @@ long TClingMethodInfo::ExtraProperty() const
       property |= kIsConstructor;
    } else if (llvm::isa<clang::CXXDestructorDecl>(fd)) {
       property |= kIsDestructor;
+   } else if (fd->isInlined()) {
+      property |= kIsInlined;
    }
    return property;
 }


### PR DESCRIPTION
In order to help Desislava fix an issue in the generation of the doxygen documentation, this PRs makes it possible to check if a given function is either marked "inline" or "constexpr" or is a member function of a class that was defined in the class body, by relying on:

https://clang.llvm.org/doxygen/classclang_1_1FunctionDecl.html#a246ca9296386dfded3561bc9d3f42c57

Now we can do:
```cpp
root [0] auto m = (TMethod*)TClass::GetClass("TAttMarker")->GetListOfMethods()->FindObject("GetMarkerColor");
root [1] m->ExtraProperty() & kIsInlined
(long) 16
root [2] auto m2 = (TMethod*)TClass::GetClass("TAttMarker")->GetListOfMethods()->FindObject("Copy");
root [3] m2->ExtraProperty() & kIsInlined
(long) 0

```
Not sure if the addition to the function template is also necessary, @Axel-Naumann .
