### PR TITLE
Do not install internal CMake modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -477,7 +477,7 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_INSTALL_PREFIX)
   endif()
   install(DIRECTORY man/    DESTINATION ${CMAKE_INSTALL_MANDIR})
   install(DIRECTORY tutorials/ DESTINATION ${CMAKE_INSTALL_TUTDIR} COMPONENT tests)
-  install(DIRECTORY cmake/modules DESTINATION ${CMAKE_INSTALL_CMAKEDIR} PATTERN "Find*.cmake" EXCLUDE)
+  install(FILES cmake/modules/RootMacros.cmake DESTINATION ${CMAKE_INSTALL_CMAKEDIR})
 endif()
 
 #---Make sure the Jupyter ROOT C++ kernel runs with the same Python version as ROOT-----


### PR DESCRIPTION
ROOT CMake modules are really only used during the build. Users only need `ROOTConfig.cmake` and related files like `ROOTConfig-{version,targets*}.cmake`, `ROOTUseFile.cmake`, and `RootMacros.cmake`. Not installing the internal modules gives us more freedom to change them without worrying about breaking backward compatibility for users.

Fixes: https://sft.its.cern.ch/jira/browse/ROOT-9828