### PR TITLE
Clone roottest from release tag when configuring with release tarball

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -502,10 +502,6 @@ configure_file(${CMAKE_SOURCE_DIR}/cmake/modules/CTestCustom.cmake ${CMAKE_BINAR
 if(testing)
   include(RootCTest)
   if(roottest)
-    find_package(Git REQUIRED)
-    execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
-                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                    OUTPUT_VARIABLE GIT_BRANCH OUTPUT_STRIP_TRAILING_WHITESPACE)
     #---Is the roottest source directory around?
     if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/roottest)
       set(roottestdir ${CMAKE_CURRENT_SOURCE_DIR}/roottest)
@@ -520,9 +516,25 @@ if(testing)
       add_subdirectory(${roottestdir} roottest)
     else()
       message("-- Could not find roottest directory! Cloning from the repository...")
+
+      find_package(Git REQUIRED)
+
+      if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/.git)
+        execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
+                        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                        OUTPUT_VARIABLE GIT_BRANCH OUTPUT_STRIP_TRAILING_WHITESPACE)
+      else()
+        set(GIT_BRANCH v${ROOT_MAJOR_VERSION}-${ROOT_MINOR_VERSION}-${ROOT_PATCH_VERSION})
+      endif()
+
       execute_process(COMMAND ${GIT_EXECUTABLE} clone -b ${GIT_BRANCH}
                       https://github.com/root-project/roottest.git
                       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+      if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/roottest)
+        message(FATAL_ERROR "Error cloning roottest")
+      endif()
+
       add_subdirectory(roottest)
     endif()
   endif()


### PR DESCRIPTION
Fixes: [ROOT-9647](https://sft.its.cern.ch/jira/browse/ROOT-9647).