### PR TITLE
WebEve: Add interface for custom GUI in REveManger

### DIFF
--- a/graf3d/eve7/inc/ROOT/REveManager.hxx
+++ b/graf3d/eve7/inc/ROOT/REveManager.hxx
@@ -210,8 +210,8 @@ public:
 
    void ClearROOTClassSaved();
 
-   void AddLocation(std::string name, std::string path);
-   void SetDefaultHtmlPage(std::string path);
+   void AddLocation(std::string& name, std::string& path);
+   void SetDefaultHtmlPage(std::string& path);
    
    static REveManager* Create();
    static void         Terminate();

--- a/graf3d/eve7/inc/ROOT/REveManager.hxx
+++ b/graf3d/eve7/inc/ROOT/REveManager.hxx
@@ -210,8 +210,8 @@ public:
 
    void ClearROOTClassSaved();
 
-   void AddLocation(std::string& name, std::string& path);
-   void SetDefaultHtmlPage(std::string& path);
+   void AddLocation(const std::string& name, const std::string& path);
+   void SetDefaultHtmlPage(const std::string& path);
    
    static REveManager* Create();
    static void         Terminate();

--- a/graf3d/eve7/inc/ROOT/REveManager.hxx
+++ b/graf3d/eve7/inc/ROOT/REveManager.hxx
@@ -210,6 +210,9 @@ public:
 
    void ClearROOTClassSaved();
 
+   void AddLocation(std::string name, std::string path);
+   void SetDefaultHtmlPage(std::string path);
+   
    static REveManager* Create();
    static void         Terminate();
 

--- a/graf3d/eve7/src/REveManager.cxx
+++ b/graf3d/eve7/src/REveManager.cxx
@@ -686,7 +686,7 @@ void REveManager::ClearROOTClassSaved()
 /// Register new directory to THttpServer
 //  For example: AddLocation("mydir/", "/test/EveWebApp/ui5");
 //
-void REveManager::AddLocation(std::string locationName, std::string path)
+void REveManager::AddLocation(std::string& locationName, std::string& path)
 {
    fWebWindow->GetServer()->AddLocation(locationName.c_str(), path.c_str());
 }
@@ -695,7 +695,7 @@ void REveManager::AddLocation(std::string locationName, std::string path)
 /// Set content of default window HTML page
 //  Got example: SetDefaultHtmlPage("file:currentdir/test.html")
 //
-void REveManager::SetDefaultHtmlPage(std::string path)
+void REveManager::SetDefaultHtmlPage(std::string& path)
 {
    fWebWindow->SetDefaultPage(path.c_str());
 }

--- a/graf3d/eve7/src/REveManager.cxx
+++ b/graf3d/eve7/src/REveManager.cxx
@@ -683,6 +683,24 @@ void REveManager::ClearROOTClassSaved()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Register new directory to THttpServer
+//  For example: AddLocation("mydir/", "/test/EveWebApp/ui5");
+//
+void REveManager::AddLocation(std::string locationName, std::string path)
+{
+   fWebWindow->GetServer()->AddLocation(locationName.c_str(), path.c_str());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set content of default window HTML page
+//  Got example: SetDefaultHtmlPage("file:currentdir/test.html")
+//
+void REveManager::SetDefaultHtmlPage(std::string path)
+{
+   fWebWindow->SetDefaultPage(path.c_str());
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// If global REveManager* REX::gEve is not set initialize it.
 /// Returns REX::gEve.
 

--- a/graf3d/eve7/src/REveManager.cxx
+++ b/graf3d/eve7/src/REveManager.cxx
@@ -686,7 +686,7 @@ void REveManager::ClearROOTClassSaved()
 /// Register new directory to THttpServer
 //  For example: AddLocation("mydir/", "/test/EveWebApp/ui5");
 //
-void REveManager::AddLocation(std::string& locationName, std::string& path)
+void REveManager::AddLocation(const std::string& locationName, const std::string& path)
 {
    fWebWindow->GetServer()->AddLocation(locationName.c_str(), path.c_str());
 }
@@ -695,7 +695,7 @@ void REveManager::AddLocation(std::string& locationName, std::string& path)
 /// Set content of default window HTML page
 //  Got example: SetDefaultHtmlPage("file:currentdir/test.html")
 //
-void REveManager::SetDefaultHtmlPage(std::string& path)
+void REveManager::SetDefaultHtmlPage(const std::string& path)
 {
    fWebWindow->SetDefaultPage(path.c_str());
 }


### PR DESCRIPTION
Here is an example of setting custom openui5 client GUI:

 auto eveMng = REX::REveManager::Create();
 eveMng->AddLocation("mydir/", "/home/alja/root-dev/EveWebApp/ui5");
 eveMng->SetDefaultHtmlPage("file:mydir/xxx.html");
 
Here is test repository:
https://github.com/alja/EveWebApp

