### PR TITLE
Copy RootMacros.cmake to build directory and use relative include

### DIFF
--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -679,6 +679,10 @@ get_filename_component(ROOT_BINARY_DIR \"\${ROOT_BINDIR}\" ABSOLUTE)
 ")
 set(ROOT_MODULE_PATH "\${_thisdir}/modules")
 
+# used by ROOTConfig.cmake from the build directory
+configure_file(${CMAKE_SOURCE_DIR}/cmake/modules/RootMacros.cmake
+               ${CMAKE_BINARY_DIR}/RootMacros.cmake COPYONLY)
+
 configure_file(${CMAKE_SOURCE_DIR}/cmake/scripts/ROOTConfig.cmake.in
                ${CMAKE_BINARY_DIR}/installtree/ROOTConfig.cmake @ONLY NEWLINE_STYLE UNIX)
 configure_file(${CMAKE_SOURCE_DIR}/cmake/scripts/RootUseFile.cmake.in

--- a/cmake/scripts/ROOTConfig.cmake.in
+++ b/cmake/scripts/ROOTConfig.cmake.in
@@ -64,7 +64,7 @@ get_filename_component(_thisdir "${CMAKE_CURRENT_LIST_FILE}" PATH)
 
 #----------------------------------------------------------------------------
 # Include RootMacros.cmake to get ROOT's CMake macros
-include(@ROOT_MODULE_PATH@/RootMacros.cmake)
+include("${_thisdir}/RootMacros.cmake")
 
 #----------------------------------------------------------------------------
 # Include the file listing all the imported targets and options


### PR DESCRIPTION
This fixes a reported problem with relocatability of the `ROOTConfig.cmake` file.