### PR TITLE
[RF] Fix plotting and normalisation problems

### DIFF
--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -282,7 +282,6 @@ Double_t RooAbsPdf::getValV(const RooArgSet* nset) const
     Bool_t error = traceEvalPdf(val) ;
 
     if (error) {
-//       raiseEvalError() ;
       return 0 ;
     }
     return val ;
@@ -305,21 +304,22 @@ Double_t RooAbsPdf::getValV(const RooArgSet* nset) const
     // Evaluate denominator
     Double_t normVal(_norm->getVal()) ;
     
-    if (normVal<=0.) {
+    if (normVal < 0. || (normVal == 0. && rawVal != 0)) {
+      //Unreasonable normalisations. A zero integral can be tolerated if the function vanishes.
       error=kTRUE ;
-      logEvalError("p.d.f normalization integral is zero or negative") ;  
+      std::stringstream msg;
+      msg << "p.d.f normalization integral is zero or negative: " << normVal;
+      logEvalError(msg.str().c_str());
     }
 
     // Raise global error flag if problems occur
-    if (error) {
-//       raiseEvalError() ;
+    if (error || (rawVal == 0. && normVal == 0.)) {
       _value = 0 ;
     } else {
       _value = rawVal / normVal ;
-//       cout << "RooAbsPdf::getValV(" << GetName() << ") writing _value = " << rawVal << "/" << normVal << " = " << _value << endl ;
     }
 
-    clearValueAndShapeDirty() ; //setValueDirty(kFALSE) ;
+    clearValueAndShapeDirty();
   } 
 
   return _value ;

--- a/test/stressRooFit_tests.cxx
+++ b/test/stressRooFit_tests.cxx
@@ -1212,7 +1212,7 @@ public:
     // Make plot frame in x and add data and fitted model
     RooPlot* frame = x.frame(Title("Fitting a sub range")) ;
     modelData->plotOn(frame) ;
-    model.plotOn(frame,Range("Full"),LineStyle(kDashed),LineColor(kRed)) ; // Add shape in full ranged dashed
+    model.plotOn(frame,LineStyle(kDashed),LineColor(kRed)) ; // Add shape in full ranged dashed
     model.plotOn(frame) ; // By default only fitted range is shown
 
     regPlot(frame,"rf203_plot") ;


### PR DESCRIPTION
- When a plot in overlapping ranges is requested, the normalisation is not
computed correctly. Now, any overlap between plot ranges is removed
before plotting.
- [RF4756] When integrating a peaked function in a side band, the normalisation integral
might vanish. This will raise an evaluation error. Now, if the function
value also vanishes, this is accepted without error.