### PR TITLE
[Exp PyROOT] Make Cppyy memory management symbols accessible in facade

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/_facade.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/_facade.py
@@ -31,7 +31,8 @@ class ROOTFacade(types.ModuleType):
         self.gROOT = gROOT
 
         # Expose some functionality from CPyCppyy extension module
-        cppyy_exports = [ 'Double', 'Long', 'nullptr', 'addressof', 'bind_object' ]
+        cppyy_exports = [ 'Double', 'Long', 'nullptr', 'addressof', 'bind_object',
+                          'SetMemoryPolicy', 'kMemoryHeuristics', 'kMemoryStrict' ]
         for name in cppyy_exports:
             setattr(self, name, getattr(cppyy_backend, name))
 


### PR DESCRIPTION
Expose Cppyy's memory policy symbols in the ROOT facade to collaborate with:
https://github.com/root-project/roottest/pull/357