### PR TITLE
[cxxmodules] Optimize dyld to not scan through the C/C++ runtime.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -6997,6 +6997,15 @@ static std::string GetSharedLibImmediateDepsSlow(std::string lib,
          if (SymName.empty())
             continue;
 
+         // Skip the symbols which are part of the C/C++ runtime and have a
+         // fixed library version. See binutils ld VERSION. Those reside in
+         // 'system' libraries, which we avoid in ResolveSymbol.
+         if (BinObjFile->isELF() && (SymName.contains("@@GLIBCXX") ||
+                                     SymName.contains("@@CXXABI") ||
+                                     SymName.contains("@@GLIBC") ||
+                                     SymName.contains("@@GCC")))
+            continue;
+
          // If we can find the address of the symbol, we have loaded it. Skip.
          if (skipLoadedLibs && llvm::sys::DynamicLibrary::SearchForAddressOfSymbol(SymName))
             continue;


### PR DESCRIPTION
GNU ld has a way to control the symbol versions by 'fixing' the library
appending @@somelib_version.

In practice, ROOT's libraries contain a lot of undefined symbols which
are supposed to be resolved either in libc or glibc which are system
libraries. Our symbol dependency chain builder does not look into system
libraries for performance (and legacy reasons). Thus the undefined symbols
from the C/C++ runtime cause us to scan every time all non-system libraries
when we know what would be the outcome.

More information can be found in the binutils documentation:
https://sourceware.org/binutils/docs/ld/VERSION.html

This patch optimizes dependency resolution speed for libTreePlayer by 450%