### PR TITLE
[RF] Fix testing if fit results are identical.

### DIFF
--- a/roofit/roofitcore/inc/RooFitResult.h
+++ b/roofit/roofitcore/inc/RooFitResult.h
@@ -151,7 +151,7 @@ public:
   // Generate random perturbations of the final parameters using the covariance matrix
   const RooArgList& randomizePars() const;
 
-  Bool_t isIdentical(const RooFitResult& other, Double_t tol=5e-5, Double_t tolCorr=1e-4, Bool_t verbose=kTRUE) const ;
+  Bool_t isIdentical(const RooFitResult& other, Double_t tol=1e-6, Double_t tolCorr=1e-4, Bool_t verbose=kTRUE) const ;
 
   void SetName(const char *name) ;
   void SetNameTitle(const char *name, const char* title) ;

--- a/roofit/roofitcore/inc/RooUnitTest.h
+++ b/roofit/roofitcore/inc/RooUnitTest.h
@@ -61,8 +61,8 @@ public:
 #else
   virtual Double_t ctol() { return 4e-3 ; } // curve test tolerance
 #endif
-  virtual Double_t fptol() { return 1e-3 ; } // fit parameter test tolerance
-  virtual Double_t fctol() { return 1e-3 ; } // fit correlation test tolerance
+  virtual Double_t fptol() { return 1e-5 ; } // fit parameter test tolerance
+  virtual Double_t fctol() { return 1e-4 ; } // fit correlation test tolerance
   virtual Double_t vtol() { return 1e-3 ; } // value test tolerance
 
   static void setMemDir(TDirectory* memDir);


### PR DESCRIPTION
When comparing fit results, RooFit was comparing the absolute
difference. For parameters with small values, differences are missed,
and for parameters with large values, small relative differences are
flagged.
Now, parameters and NLL are compared with a relative precision of 1.E-6,
(before absolute precision of 5.E-5), and correlation coefficients
are compared with an absolute precision of 1.E-4.