### PR TITLE
Update higgs cpp tutorial with `DeltaR` function

### DIFF
--- a/tutorials/dataframe/df103_NanoAODHiggsAnalysis.C
+++ b/tutorials/dataframe/df103_NanoAODHiggsAnalysis.C
@@ -334,7 +334,7 @@ template <typename T>
 void plot(T sig, T bkg, T data, const std::string &x_label, const std::string &filename)
 {
    // Canvas and general style options
-   // gStyle->SetOptStat(0);
+   gStyle->SetOptStat(0);
    gStyle->SetTextFont(42);
    auto c = new TCanvas("c", "", 800, 700);
    c->SetLeftMargin(0.15);

--- a/tutorials/dataframe/df103_NanoAODHiggsAnalysis.C
+++ b/tutorials/dataframe/df103_NanoAODHiggsAnalysis.C
@@ -95,8 +95,8 @@ RNode selection_2el2mu(RNode df)
    };
    auto df_pt = df_eta.Filter(pt_cuts, {"Muon_pt", "Electron_pt"}, "Pt cuts");
    auto dr_cuts = [](rvec_f mu_eta, rvec_f mu_phi, rvec_f el_eta, rvec_f el_phi) {
-      auto mu_dr = sqrt(pow(mu_eta[0] - mu_eta[1], 2) + pow(mu_phi[0] - mu_phi[1], 2));
-      auto el_dr = sqrt(pow(el_eta[0] - el_eta[1], 2) + pow(el_phi[0] - el_phi[1], 2));
+      auto mu_dr = DeltaR(mu_eta[0], mu_eta[1], mu_phi[0], mu_phi[1]);
+      auto el_dr = DeltaR(el_eta[0], el_eta[1], el_eta[0], el_eta[1]);
       if (mu_dr < 0.02 || el_dr < 0.02) {
          return false;
       }
@@ -211,7 +211,7 @@ RNode reco_higgs_to_4mu(RNode df)
       for (size_t i = 0; i < 2; i++) {
          const auto i1 = idx[i][0];
          const auto i2 = idx[i][1];
-         const auto dr = sqrt(pow(eta[i1] - eta[i2], 2) + pow(phi[i1] - phi[i2], 2));
+         const auto dr = DeltaR(eta[i1], eta[i2], phi[i1], phi[i2]);
          if (dr < 0.02) {
             return false;
          }

--- a/tutorials/dataframe/df103_NanoAODHiggsAnalysis.C
+++ b/tutorials/dataframe/df103_NanoAODHiggsAnalysis.C
@@ -96,7 +96,7 @@ RNode selection_2el2mu(RNode df)
    auto df_pt = df_eta.Filter(pt_cuts, {"Muon_pt", "Electron_pt"}, "Pt cuts");
    auto dr_cuts = [](rvec_f mu_eta, rvec_f mu_phi, rvec_f el_eta, rvec_f el_phi) {
       auto mu_dr = DeltaR(mu_eta[0], mu_eta[1], mu_phi[0], mu_phi[1]);
-      auto el_dr = DeltaR(el_eta[0], el_eta[1], el_eta[0], el_eta[1]);
+      auto el_dr = DeltaR(el_eta[0], el_eta[1], el_phi[0], el_phi[1]);
       if (mu_dr < 0.02 || el_dr < 0.02) {
          return false;
       }
@@ -250,7 +250,7 @@ RNode reco_higgs_to_4el(RNode df)
       for (size_t i = 0; i < 2; i++) {
          const auto i1 = idx[i][0];
          const auto i2 = idx[i][1];
-         const auto dr = sqrt(pow(eta[i1] - eta[i2], 2) + pow(phi[i1] - phi[i2], 2));
+         const auto dr = DeltaR(eta[i1], eta[i2], phi[i1], phi[i2]);
          if (dr < 0.02) {
             return false;
          }
@@ -334,7 +334,7 @@ template <typename T>
 void plot(T sig, T bkg, T data, const std::string &x_label, const std::string &filename)
 {
    // Canvas and general style options
-   gStyle->SetOptStat(0);
+   // gStyle->SetOptStat(0);
    gStyle->SetTextFont(42);
    auto c = new TCanvas("c", "", 800, 700);
    c->SetLeftMargin(0.15);


### PR DESCRIPTION
As discussed in #4019 and #4071, the higgs tutorial should use the proper `DeltaR` function from the `VecOps` namespace.