### PR TITLE
[cxxmodules] The bloom filter bloom size depends on the arch bitness.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -6092,7 +6092,8 @@ static StringRef GetGnuHashSection(llvm::object::ObjectFile *file) {
 // PE and Mach-O files doesn't have .gnu.hash bloomfilter section, so this is a specific optimization for ELF.
 // This is fine because performance critical part (data centers) are running on Linux :)
 static bool LookupBloomFilter(llvm::object::ObjectFile *soFile, uint32_t hash) {
-   const int bits = 64;
+   // LLVM9: soFile->makeTriple().is64Bit()
+   const int bits = 8 * soFile->getBytesInAddress();
 
    StringRef contents = GetGnuHashSection(soFile);
    if (contents.size() < 16)


### PR DESCRIPTION
This should appease our 32bit bots.