### PR TITLE
[PyROOT] Return enum object in enum lookups

### DIFF
--- a/bindings/pyroot/src/Converters.cxx
+++ b/bindings/pyroot/src/Converters.cxx
@@ -1495,11 +1495,13 @@ PyROOT::TConverter* PyROOT::CreateConverter( const std::string& fullType, Long_t
           result = new TValueCppObjectConverter( klass, kTRUE );
       }
    } else if ( Cppyy::IsEnum( realType ) ) {
-   // special case (Cling): represent enums as unsigned integers
-      if ( cpd == "&" )
-         h = isConst ? gConvFactories.find( "const long&" ) : gConvFactories.find( "long&" );
-      else
-         h = gConvFactories.find( "UInt_t" );
+      // Get underlying type of enum
+      std::string et(TClassEdit::ResolveTypedef(Cppyy::ResolveEnum(realType).c_str()));
+      if (cpd == "&") {
+         auto reft = et + "&";
+         h = isConst ? gConvFactories.find("const " + reft) : gConvFactories.find(reft);
+      } else
+         h = gConvFactories.find(et);
    } else if ( realType.find( "(*)" ) != std::string::npos ||
              ( realType.find( "::*)" ) != std::string::npos ) ) {
    // this is a function function pointer
@@ -1629,7 +1631,6 @@ namespace {
       NFp_t( "const int&",                &CreateConstIntRefConverter        ),
       NFp_t( "unsigned int",              &CreateUIntConverter               ),
       NFp_t( "const unsigned int&",       &CreateConstUIntRefConverter       ),
-      NFp_t( "UInt_t", /* enum */         &CreateIntConverter /* yes: Int */ ),
       NFp_t( "long",                      &CreateLongConverter               ),
       NFp_t( "long&",                     &CreateLongRefConverter            ),
       NFp_t( "const long&",               &CreateConstLongRefConverter       ),

--- a/bindings/pyroot/src/Cppyy.cxx
+++ b/bindings/pyroot/src/Cppyy.cxx
@@ -175,6 +175,18 @@ std::string Cppyy::ResolveName( const std::string& cppitem_name )
    return TClassEdit::ResolveTypedef( tclean.c_str(), true );
 }
 
+std::string Cppyy::ResolveEnum(const std::string& enum_type)
+{
+   auto en = TEnum::GetEnum(enum_type.c_str());
+   if (en) {
+      auto ut = en->GetUnderlyingType();
+      if (ut != EDataType::kNumDataTypes)
+         return TDataType::GetTypeName(ut);
+   }
+   // Can't get type of enum, use int as default
+   return "int";
+}
+
 Cppyy::TCppScope_t Cppyy::GetScope( const std::string& sname )
 {
    std::string scope_name;

--- a/bindings/pyroot/src/Cppyy.cxx
+++ b/bindings/pyroot/src/Cppyy.cxx
@@ -12,6 +12,8 @@
 #include "TCollection.h"
 #include "TDataMember.h"
 #include "TDataType.h"
+#include "TEnum.h"
+#include "TEnumConstant.h"
 #include "TError.h"
 #include "TFunction.h"
 #include "TGlobal.h"
@@ -1075,4 +1077,33 @@ Int_t Cppyy::GetDimensionSize( TCppScope_t scope, TCppIndex_t idata, int dimensi
       return m->GetMaxIndex( dimension );
    }
    return (Int_t)-1;
+}
+
+// enum properties -----------------------------------------------------------
+Cppyy::TCppEnum_t Cppyy::GetEnum(TCppScope_t scope, const std::string& enum_name)
+{
+    if (scope == GLOBAL_HANDLE)
+        return (TCppEnum_t)gROOT->GetListOfEnums(kTRUE)->FindObject(enum_name.c_str());
+
+    TClassRef& cr = type_from_handle(scope);
+    if (cr.GetClass())
+        return (TCppEnum_t)cr->GetListOfEnums(kTRUE)->FindObject(enum_name.c_str());
+
+    return (TCppEnum_t)0;
+}
+
+Cppyy::TCppIndex_t Cppyy::GetNumEnumData(TCppEnum_t etype)
+{
+    return (TCppIndex_t)((TEnum*)etype)->GetConstants()->GetSize();
+}
+
+std::string Cppyy::GetEnumDataName(TCppEnum_t etype, TCppIndex_t idata)
+{
+    return ((TEnumConstant*)((TEnum*)etype)->GetConstants()->At(idata))->GetName();
+}
+
+long long Cppyy::GetEnumDataValue(TCppEnum_t etype, TCppIndex_t idata)
+{
+     TEnumConstant* ecst = (TEnumConstant*)((TEnum*)etype)->GetConstants()->At(idata);
+     return (long long)ecst->GetValue();
 }

--- a/bindings/pyroot/src/Cppyy.h
+++ b/bindings/pyroot/src/Cppyy.h
@@ -13,6 +13,7 @@ namespace Cppyy {
    typedef TCppScope_t TCppType_t;
    typedef void*       TCppObject_t;
    typedef ptrdiff_t   TCppMethod_t;
+   typedef void*       TCppEnum_t;
 
    typedef Long_t      TCppIndex_t;
    typedef void* (*TCppMethPtrGetter_t)( TCppObject_t );
@@ -126,6 +127,12 @@ namespace Cppyy {
    Bool_t IsConstData( TCppScope_t scope, TCppIndex_t idata );
    Bool_t IsEnumData( TCppScope_t scope, TCppIndex_t idata );
    Int_t  GetDimensionSize( TCppScope_t scope, TCppIndex_t idata, int dimension );
+
+// enum properties -----------------------------------------------------------
+   TCppEnum_t  GetEnum(TCppScope_t scope, const std::string& enum_name);
+   TCppIndex_t GetNumEnumData(TCppEnum_t);
+   std::string GetEnumDataName(TCppEnum_t, TCppIndex_t idata);
+   long long   GetEnumDataValue(TCppEnum_t, TCppIndex_t idata);
 
 } // namespace Cppyy
 

--- a/bindings/pyroot/src/Cppyy.h
+++ b/bindings/pyroot/src/Cppyy.h
@@ -22,6 +22,7 @@ namespace Cppyy {
    TCppIndex_t GetNumScopes( TCppScope_t parent );
    std::string GetScopeName( TCppScope_t parent, TCppIndex_t iscope );
    std::string ResolveName( const std::string& cppitem_name );
+   std::string ResolveEnum(const std::string& enum_type);
    TCppScope_t GetScope( const std::string& scope_name );
    std::string GetName( const std::string& scope_name );
    TCppType_t  GetTemplate( const std::string& template_name );

--- a/bindings/pyroot/src/Executors.cxx
+++ b/bindings/pyroot/src/Executors.cxx
@@ -722,8 +722,9 @@ PyROOT::TExecutor* PyROOT::CreateExecutor( const std::string& fullType,
             result = new TCppObjectExecutor( klass );
       }
    } else if ( Cppyy::IsEnum( realType ) ) {
-   // enums don't resolve to unsigned ints, but that's what they are ...
-      h = gExecFactories.find( "UInt_t" + cpd );
+      // Get underlying type of enum
+      std::string et(TClassEdit::ResolveTypedef(Cppyy::ResolveEnum(realType).c_str()));
+      h = gExecFactories.find( et + cpd );
    } else {
    // handle (with warning) unknown types
       std::stringstream s;

--- a/bindings/pyroot/src/PropertyProxy.cxx
+++ b/bindings/pyroot/src/PropertyProxy.cxx
@@ -201,7 +201,8 @@ void PyROOT::PropertyProxy::Set( Cppyy::TCppScope_t scope, Cppyy::TCppIndex_t id
 
    std::string fullType = Cppyy::GetDatamemberType( scope, idata );
    if ( Cppyy::IsEnumData( scope, idata ) ) {
-      fullType = "UInt_t";
+      // Get underlying type of enum
+      fullType = Cppyy::ResolveEnum(fullType);
       fProperty |= kIsEnumData;
    }
 

--- a/bindings/pyroot/src/PyRootType.cxx
+++ b/bindings/pyroot/src/PyRootType.cxx
@@ -20,7 +20,6 @@
 #include <string>
 #include <vector>
 
-
 namespace PyROOT {
 
 namespace {
@@ -92,6 +91,7 @@ namespace {
 
       // filter for python specials and lookup qualified class or function
          std::string name = PyROOT_PyUnicode_AsString( pyname );
+
          if ( name.size() <= 2 || name.substr( 0, 2 ) != "__" ) {
             attr = CreateScopeProxy( name, pyclass );
 
@@ -105,7 +105,6 @@ namespace {
                Cppyy::TCppScope_t scope = Cppyy::GetScope( cppname );
                TClass* klass = TClass::GetClass( cppname );
                if ( Cppyy::IsNamespace( scope ) ) {
-
                // tickle lazy lookup of functions
                   if ( ! attr ) {
                      TObject *methObj = nullptr;
@@ -148,11 +147,40 @@ namespace {
                }
 
             // enums types requested as type (rather than the constants)
-               if ( ! attr && klass && klass->GetListOfEnums()->FindObject( name.c_str() ) ) {
-               // special case; enum types; for now, pretend int
-               // TODO: although fine for C++98, this isn't correct in C++11
-                  Py_INCREF( &PyInt_Type );
-                  attr = (PyObject*)&PyInt_Type;
+               if (!attr) {
+                  if (Cppyy::IsEnum(Cppyy::GetScopedFinalName(scope)+"::"+name)) {
+                     // enum types (incl. named and class enums)
+                     Cppyy::TCppEnum_t enumtype = Cppyy::GetEnum(scope, name);
+                     if (enumtype) {
+                        // collect the enum values
+                        Cppyy::TCppIndex_t ndata = Cppyy::GetNumEnumData(enumtype);
+                        PyObject* dct = PyDict_New();
+                        for (Cppyy::TCppIndex_t idata = 0; idata < ndata; ++idata) {
+                           PyObject* val = PyLong_FromLongLong(Cppyy::GetEnumDataValue(enumtype, idata));
+                           PyDict_SetItemString(dct, Cppyy::GetEnumDataName(enumtype, idata).c_str(), val);
+                           Py_DECREF(val);
+                        }
+
+                        // add the __cppname__ for templates
+                        PyObject* cppnamepy = PyROOT_PyUnicode_FromString((Cppyy::GetScopedFinalName(scope)+"::"+name).c_str());
+                        PyDict_SetItem(dct, PyStrings::gCppName, cppnamepy);
+                        Py_DECREF(cppnamepy);
+
+                        // create new type with labeled values in place
+                        PyObject* pybases = PyTuple_New(1);
+                        Py_INCREF(&PyInt_Type);
+                        PyTuple_SET_ITEM(pybases, 0, (PyObject*)&PyInt_Type);
+                        PyObject* args = Py_BuildValue((char*)"sOO", name.c_str(), pybases, dct);
+                        attr = Py_TYPE(&PyInt_Type)->tp_new(Py_TYPE(&PyInt_Type), args, nullptr);
+                        Py_DECREF(args);
+                        Py_DECREF(pybases);
+                        Py_DECREF(dct);
+                     } else {
+                        // presumably not a class enum; simply pretend int
+                        Py_INCREF(&PyInt_Type);
+                        attr = (PyObject*)&PyInt_Type;
+                     }
+                  }
                }
 
                if ( attr ) {

--- a/bindings/pyroot/src/RootModule.cxx
+++ b/bindings/pyroot/src/RootModule.cxx
@@ -207,10 +207,40 @@ namespace {
          if ( object != 0 )
             return BindCppObject( object, object->IsA()->GetName() );
 
-      // 5th attempt: global enum (pretend int, TODO: is fine for C++98, not in C++11)
-         if ( Cppyy::IsEnum( name ) ) {
-            Py_INCREF( &PyInt_Type );
-            return (PyObject*)&PyInt_Type;
+      // 5th attempt: global enum
+         if (Cppyy::IsEnum(name)) {
+            // enum types (incl. named and class enums)
+            Cppyy::TCppEnum_t enumtype = Cppyy::GetEnum(Cppyy::gGlobalScope, name);
+            if (enumtype) {
+               // collect the enum values
+               Cppyy::TCppIndex_t ndata = Cppyy::GetNumEnumData(enumtype);
+               PyObject* dct = PyDict_New();
+               for (Cppyy::TCppIndex_t idata = 0; idata < ndata; ++idata) {
+                  PyObject* val = PyLong_FromLongLong(Cppyy::GetEnumDataValue(enumtype, idata));
+                  PyDict_SetItemString(dct, Cppyy::GetEnumDataName(enumtype, idata).c_str(), val);
+                  Py_DECREF(val);
+               }
+
+               // add the __cppname__ for templates
+               PyObject* cppnamepy = PyROOT_PyUnicode_FromString(cname);
+               PyDict_SetItem(dct, PyStrings::gCppName, cppnamepy);
+               Py_DECREF(cppnamepy);
+
+               // create new type with labeled values in place
+               PyObject* pybases = PyTuple_New(1);
+               Py_INCREF(&PyInt_Type);
+               PyTuple_SET_ITEM(pybases, 0, (PyObject*)&PyInt_Type);
+               PyObject* argsnt = Py_BuildValue((char*)"sOO", name.c_str(), pybases, dct);
+               attr = Py_TYPE(&PyInt_Type)->tp_new(Py_TYPE(&PyInt_Type), argsnt, nullptr);
+               Py_DECREF(argsnt);
+               Py_DECREF(pybases);
+               Py_DECREF(dct);
+            } else {
+               // presumably not a class enum; simply pretend int
+               Py_INCREF(&PyInt_Type);
+               attr = (PyObject*)&PyInt_Type;
+            }
+            return attr;
          }
 
       // 6th attempt: check macro's (debatable, but this worked in CINT)


### PR DESCRIPTION
As reported here:

https://sft.its.cern.ch/jira/browse/ROOT-8935

when looking up an enum, the current PyROOT returns an unsigned integer. The changes of this PR, migrated from current Cppyy, allow to create an enum type during the lookup and inject the enum values in it. This is done both for global and non-global lookups.

This PR also includes a fix to get the underlying type of the enum when picking a converter for its values.
