### PR TITLE
[cxxmodules] Move back the stdlib library in the main libc module.

### DIFF
--- a/build/unix/libc.modulemap
+++ b/build/unix/libc.modulemap
@@ -32,6 +32,10 @@ module "libc" [system] [extern_c] [no_undeclared_includes] {
     export *
     header "setjmp.h"
   }
+  module "signal.h" {
+    export *
+    header "signal.h"
+  }
   module "stdio.h" {
     export *
     header "stdio.h"
@@ -54,9 +58,3 @@ module "xlocale.h" [system] [extern_c] {
   export *
   header "xlocale.h"
 }
-
-module "signal.h" [system] [extern_c] {
-  export *
-  header "signal.h"
-}
-

--- a/build/unix/libc.modulemap
+++ b/build/unix/libc.modulemap
@@ -55,12 +55,6 @@ module "xlocale.h" [system] [extern_c] {
   header "xlocale.h"
 }
 
-// System header that we have difficult with merging.
-module "sys_types.h" [system] [extern_c] {
-  export *
-  header "sys/types.h"
-}
-
 module "signal.h" [system] [extern_c] {
   export *
   header "signal.h"

--- a/build/unix/libc.modulemap
+++ b/build/unix/libc.modulemap
@@ -36,6 +36,10 @@ module "libc" [system] [extern_c] [no_undeclared_includes] {
     export *
     header "stdio.h"
   }
+  module "stdlib.h" {
+    export *
+    header "stdlib.h"
+  }
   module "wchar.h" {
     export *
     header "wchar.h"
@@ -62,7 +66,3 @@ module "signal.h" [system] [extern_c] {
   header "signal.h"
 }
 
-module "stdlib.h" [system] [extern_c] {
-  export *
-  header "stdlib.h"
-}


### PR DESCRIPTION
The no_undeclared_includes attributes will not allow cycle.