### PR TITLE
[ROOT-10211][Graphics] Add assignment operator to TStyle

### DIFF
--- a/core/base/inc/TStyle.h
+++ b/core/base/inc/TStyle.h
@@ -141,6 +141,7 @@ public:
    TStyle();
    TStyle(const char *name, const char *title);
    TStyle(const TStyle &style);
+   TStyle& operator=(const TStyle& style);
    virtual          ~TStyle();
    inline Int_t     AxisChoice(Option_t *axis) const {
       // Return axis number (1 for X, 2 for Y, 3 for Z)

--- a/core/base/src/TStyle.cxx
+++ b/core/base/src/TStyle.cxx
@@ -404,12 +404,12 @@ TStyle::~TStyle()
 
 TStyle::TStyle(const TStyle &style) : TNamed(style), TAttLine(style), TAttFill(style), TAttMarker(style), TAttText(style)
 {
-   ((TStyle&)style).Copy(*this);
+   style.Copy(*this);
 }
 
 TStyle& TStyle::operator=(const TStyle& style)
 {
-   ((TStyle&)style).Copy(*this);
+   style.Copy(*this);
    return *this;
 }
 

--- a/core/base/src/TStyle.cxx
+++ b/core/base/src/TStyle.cxx
@@ -400,11 +400,17 @@ TStyle::~TStyle()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Copy constructor.
+/// Copy constructor and assignment operator.
 
 TStyle::TStyle(const TStyle &style) : TNamed(style), TAttLine(style), TAttFill(style), TAttMarker(style), TAttText(style)
 {
    ((TStyle&)style).Copy(*this);
+}
+
+TStyle& TStyle::operator=(const TStyle& style)
+{
+   ((TStyle&)style).Copy(*this);
+   return *this;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes the gcc9 warning "deprecated copy" because a custom copy constructor
is implemented but the assignment operator is implicitly declared.