### PR TITLE
[Tutorial] Veto Python version of df103 if xrootd is not found

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -450,7 +450,9 @@ if(ROOT_python_FOUND)
   endif()
 
  if(NOT XROOTD_FOUND)
-   list(APPEND pyveto dataframe/df102_NanoAODDimuonAnalysis.py)
+   list(APPEND pyveto
+       dataframe/df102_NanoAODDimuonAnalysis.py
+       dataframe/df103_NanoAODHiggsAnalysis.py)
  endif()
 
   list(REMOVE_ITEM pytutorials ${pyveto})
@@ -483,6 +485,7 @@ if(ROOT_python_FOUND)
                  tutorial-dataframe-df016_vecOps-py
                  tutorial-dataframe-df017_vecOpsHEP-py
                  tutorial-dataframe-df102_NanoAODDimuonAnalysis-py
+                 tutorial-dataframe-df103_NanoAODHiggsAnalysis-py
                  tutorial-pyroot-benchmarks-py
                  tutorial-pyroot-pyroot002_TTreeAsMatrix-py
                  tutorial-pyroot-shapes-py


### PR DESCRIPTION
Fixes following failing nightlies: http://cdash.cern.ch/testSummary.php?project=1&name=tutorial-dataframe-df103_NanoAODHiggsAnalysis-py&date=2019-07-30