### PR TITLE
[qt5web] accept download action

### DIFF
--- a/gui/qt5webdisplay/rootqt5.cpp
+++ b/gui/qt5webdisplay/rootqt5.cpp
@@ -126,6 +126,8 @@ protected:
             if (!fHandler) {
                fHandler = std::make_unique<RootUrlSchemeHandler>();
                QWebEngineProfile::defaultProfile()->installUrlSchemeHandler("rootscheme", fHandler.get());
+               QWebEngineProfile::defaultProfile()->connect(QWebEngineProfile::defaultProfile(), &QWebEngineProfile::downloadRequested,
+                              [](QWebEngineDownloadItem *item) { item->accept(); });
             }
 
             fullurl = fHandler->MakeFullUrl(args.GetHttpServer(), fullurl);

--- a/gui/qt5webdisplay/rooturlschemehandler.cpp
+++ b/gui/qt5webdisplay/rooturlschemehandler.cpp
@@ -20,7 +20,6 @@
 #include <QByteArray>
 #include <QFile>
 #include <QWebEngineUrlRequestJob>
-#include <QWebEngineProfile>
 
 #include <ROOT/RLogger.hxx>
 
@@ -36,17 +35,27 @@
 /// from the request to clear pointer
 ////////////////////////////////////////////////////////////////////////////////////
 
+
+/////////////////////////////////////////////////////////////////
+/// Constructor
+
 UrlRequestJobHolder::UrlRequestJobHolder(QWebEngineUrlRequestJob *req) : QObject(), fRequest(req)
 {
    if (fRequest)
       connect(fRequest, &QObject::destroyed, this, &UrlRequestJobHolder::onRequestDeleted);
 }
 
+/////////////////////////////////////////////////////////////////
+/// destroyed signal handler
+
 void UrlRequestJobHolder::onRequestDeleted(QObject *obj)
 {
    if (fRequest == obj)
       fRequest = nullptr;
 }
+
+/////////////////////////////////////////////////////////////////
+/// Reset holder
 
 void UrlRequestJobHolder::reset()
 {
@@ -56,6 +65,11 @@ void UrlRequestJobHolder::reset()
 }
 
 // ===================================================================
+
+/////////////////////////////////////////////////////////////////////////////////////
+/// Class TWebGuiCallArg
+/// Specialized handler of requests in THttpServer with QWebEngine
+////////////////////////////////////////////////////////////////////////////////////
 
 class TWebGuiCallArg : public THttpCallArg {
 
@@ -99,7 +113,7 @@ public:
       }
    }
 
-   virtual void HttpReplied()
+   void HttpReplied() override
    {
       QWebEngineUrlRequestJob *req = fRequest.req();
 

--- a/gui/qt5webdisplay/rooturlschemehandler.h
+++ b/gui/qt5webdisplay/rooturlschemehandler.h
@@ -28,7 +28,7 @@ class UrlRequestJobHolder : public QObject {
 public:
    UrlRequestJobHolder(QWebEngineUrlRequestJob *req);
 
-   QWebEngineUrlRequestJob *req() { return fRequest; }
+   QWebEngineUrlRequestJob *req() const { return fRequest; }
 
    void reset();
 


### PR DESCRIPTION
By default QWebEngine does not process download actions.
Required when png image created directly from JSROOT code.