### PR TITLE
Simplify check for out-of-source build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,12 @@
 
 cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
 
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
+  message(FATAL_ERROR
+    " ROOT must be built out-of-source.\n"
+    " Please see README/INSTALL for more information.")
+endif()
+
 set(policy_new CMP0072 CMP0077)
 foreach(policy ${policy_new})
   if(POLICY ${policy})
@@ -157,9 +163,6 @@ endif()
 if(testing)
   enable_testing()
 endif()
-
-#---Check if the user wants to build the project in the source directory------------------------
-ROOT_CHECK_OUT_OF_SOURCE_BUILD()
 
 #---Here we look for installed software and switch on and of the different build options--------
 include(SearchInstalledSoftware)

--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -1175,20 +1175,6 @@ function(REFLEX_BUILD_DICTIONARY dictionary headerfiles selectionfile )
   install(CODE "EXECUTE_PROCESS(COMMAND ${merge_rootmap_cmd} --do-merge --input-file ${srcRootMap} --merged-file ${mergedRootMap})")
 endfunction()
 
-#---------------------------------------------------------------------------------------------------
-#---ROOT_CHECK_OUT_OF_SOURCE_BUILD( )
-#---------------------------------------------------------------------------------------------------
-macro(ROOT_CHECK_OUT_OF_SOURCE_BUILD)
-  get_filename_component(bindir_parent ${CMAKE_BINARY_DIR} PATH)
-  if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
-     file(REMOVE_RECURSE ${CMAKE_SOURCE_DIR}/Testing)
-     file(REMOVE ${CMAKE_SOURCE_DIR}/DartConfiguration.tcl)
-     message(FATAL_ERROR "ROOT should be built as an out of source build, to keep the source directory clean. Please create a extra build directory and run the command 'cmake <path_to_source_dir>' in this newly created directory. You have also to delete the directory CMakeFiles and the file CMakeCache.txt in the source directory. Otherwise cmake will complain even if you run it from an out-of-source directory.")
-  elseif(IS_SYMLINK ${CMAKE_BINARY_DIR} AND CMAKE_SOURCE_DIR STREQUAL bindir_parent)
-     message(FATAL_ERROR "ROOT cannot be built from a sub-directory of the source tree that is a symlink. This is a current limitation of CMake. Please create a real build directory and run the command 'cmake <path_to_source_dir>' in this newly created directory.")
-  endif()
-endmacro()
-
 #----------------------------------------------------------------------------
 # function ROOT_ADD_TEST( <name> COMMAND cmd [arg1... ]
 #                        [PRECMD cmd [arg1...]] [POSTCMD cmd [arg1...]]


### PR DESCRIPTION
After testing it, the IS_SYMLINK part is no longer necessary.
It's also better to just move the check as early as possible,
and not try to remove anything, as that doesn't work anyway,
since CMake creates the files and directories only at the end.