### PR TITLE
[ntuple] Encapsulate RNTuple meta-data in RNTupleDescriptor

### DIFF
--- a/tree/ntuple/inc/LinkDef.h
+++ b/tree/ntuple/inc/LinkDef.h
@@ -25,6 +25,7 @@
 #pragma link C++ class ROOT::Experimental::RNTupleWriter-;
 #pragma link C++ class ROOT::Experimental::RNTupleModel-;
 
+#pragma link C++ class ROOT::Experimental::Internal::RNTupleBlob+;
 #pragma link C++ class ROOT::Experimental::Internal::RNTupleHeader+;
 #pragma link C++ class ROOT::Experimental::Internal::RNTupleFooter+;
 #pragma link C++ class ROOT::Experimental::Internal::RFieldHeader+;

--- a/tree/ntuple/inc/LinkDef.h
+++ b/tree/ntuple/inc/LinkDef.h
@@ -32,6 +32,5 @@
 #pragma link C++ class ROOT::Experimental::Internal::RColumnHeader+;
 #pragma link C++ class ROOT::Experimental::Internal::RClusterFooter+;
 #pragma link C++ class ROOT::Experimental::Internal::RPageInfo+;
-#pragma link C++ class ROOT::Experimental::Internal::RPagePayload+;
 
 #endif

--- a/tree/ntuple/inc/LinkDef.h
+++ b/tree/ntuple/inc/LinkDef.h
@@ -26,11 +26,5 @@
 #pragma link C++ class ROOT::Experimental::RNTupleModel-;
 
 #pragma link C++ class ROOT::Experimental::Internal::RNTupleBlob+;
-#pragma link C++ class ROOT::Experimental::Internal::RNTupleHeader+;
-#pragma link C++ class ROOT::Experimental::Internal::RNTupleFooter+;
-#pragma link C++ class ROOT::Experimental::Internal::RFieldHeader+;
-#pragma link C++ class ROOT::Experimental::Internal::RColumnHeader+;
-#pragma link C++ class ROOT::Experimental::Internal::RClusterFooter+;
-#pragma link C++ class ROOT::Experimental::Internal::RPageInfo+;
 
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -44,6 +44,11 @@ logical data layer.
 class RColumn {
 private:
    RColumnModel fModel;
+   /**
+    * Columns belonging to the same field are distinguished by their order.  E.g. for an std::string field, there is
+    * the offset column with index 0 and the character value column with index 1.
+    */
+   std::uint32_t fIndex;
    RPageSink* fPageSink;
    RPageSource* fPageSource;
    RPageStorage::ColumnHandle_t fHandleSink;
@@ -60,7 +65,7 @@ private:
    RColumn* fOffsetColumn;
 
 public:
-   explicit RColumn(const RColumnModel& model);
+   explicit RColumn(const RColumnModel& model, std::uint32_t index);
    RColumn(const RColumn&) = delete;
    RColumn& operator =(const RColumn&) = delete;
    ~RColumn();
@@ -164,6 +169,7 @@ public:
    void MapPage(const NTupleSize_t index);
    NTupleSize_t GetNElements() { return fNElements; }
    const RColumnModel& GetModel() const { return fModel; }
+   std::uint32_t GetIndex() const { return fIndex; }
    ColumnId_t GetColumnIdSource() const { return fColumnIdSource; }
    RPageSource* GetPageSource() const { return fPageSource; }
    RPageStorage::ColumnHandle_t GetHandleSource() const { return fHandleSource; }

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -173,6 +173,7 @@ public:
    ColumnId_t GetColumnIdSource() const { return fColumnIdSource; }
    RPageSource* GetPageSource() const { return fPageSource; }
    RPageStorage::ColumnHandle_t GetHandleSource() const { return fHandleSource; }
+   RPageStorage::ColumnHandle_t GetHandleSink() const { return fHandleSink; }
    void SetOffsetColumn(RColumn* offsetColumn) { fOffsetColumn = offsetColumn; }
    RColumn* GetOffsetColumn() const { return fOffsetColumn; }
    RNTupleVersion GetVersion() const { return RNTupleVersion(); }

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -169,6 +169,7 @@ public:
    RPageStorage::ColumnHandle_t GetHandleSource() const { return fHandleSource; }
    void SetOffsetColumn(RColumn* offsetColumn) { fOffsetColumn = offsetColumn; }
    RColumn* GetOffsetColumn() const { return fOffsetColumn; }
+   RNTupleVersion GetVersion() const { return RNTupleVersion(); }
 };
 
 } // namespace Detail

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -70,7 +70,7 @@ public:
    RColumn& operator =(const RColumn&) = delete;
    ~RColumn();
 
-   void Connect(RPageStorage* pageStorage);
+   void Connect(DescriptorId_t fieldId, RPageStorage *pageStorage);
 
    void Append(const RColumnElementBase& element) {
       void* dst = fHeadPage.TryGrow(1);

--- a/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
@@ -68,7 +68,7 @@ constexpr std::size_t kColumnElementSizes[] =
 // clang-format on
 class RColumnModel {
 private:
-   std::string fName;
+   std::string fName;  // TODO(jblomer): remove me
    EColumnType fType;
    bool fIsSorted;
 

--- a/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
@@ -84,7 +84,7 @@ public:
 
    Detail::RColumnElementBase *GenerateElement();
    bool operator ==(const RColumnModel &other) const {
-      return (fName == other.fName) && (fType == other.fType) && (fIsSorted == other.fIsSorted);
+      return /*(fName == other.fName) &&*/ (fType == other.fType) && (fIsSorted == other.fIsSorted);
    }
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
@@ -68,23 +68,20 @@ constexpr std::size_t kColumnElementSizes[] =
 // clang-format on
 class RColumnModel {
 private:
-   std::string fName;  // TODO(jblomer): remove me
    EColumnType fType;
    bool fIsSorted;
 
 public:
    RColumnModel() : fType(EColumnType::kUnknown), fIsSorted(false) {}
-   RColumnModel(std::string_view name, EColumnType type, bool isSorted)
-      : fName(name), fType(type), fIsSorted(isSorted) {}
+   RColumnModel(EColumnType type, bool isSorted) : fType(type), fIsSorted(isSorted) {}
 
    std::size_t GetElementSize() const { return kColumnElementSizes[static_cast<int>(fType)]; }
-   std::string GetName() const { return fName; }
    EColumnType GetType() const { return fType; }
    bool GetIsSorted() const { return fIsSorted; }
 
    Detail::RColumnElementBase *GenerateElement();
    bool operator ==(const RColumnModel &other) const {
-      return /*(fName == other.fName) &&*/ (fType == other.fType) && (fIsSorted == other.fIsSorted);
+      return (fType == other.fType) && (fIsSorted == other.fIsSorted);
    }
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -229,12 +229,12 @@ can be read or written.
 // clang-format on
 class RFieldFuse {
 public:
-   static void Connect(RPageStorage &pageStorage, RFieldBase &field);
+   static void Connect(DescriptorId_t fieldId, RPageStorage &pageStorage, RFieldBase &field);
 };
 
 } // namespace Detail
 
-/// The container field for a tree model, which itself has no physical representation
+/// The container field for an ntuple model, which itself has no physical representation
 class RFieldRoot : public Detail::RFieldBase {
 public:
    RFieldRoot() : Detail::RFieldBase("", "", ENTupleStructure::kRecord, false /* isSimple */) {}

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -699,7 +699,7 @@ public:
    }
 
    void DoGenerateColumns() final {
-      RColumnModel modelIndex(GetName(), EColumnType::kIndex, true /* isSorted*/);
+      RColumnModel modelIndex(EColumnType::kIndex, true /* isSorted*/);
       fColumns.emplace_back(std::make_unique<Detail::RColumn>(modelIndex, 0));
       fPrincipalColumn = fColumns[0].get();
    }

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -147,8 +147,6 @@ public:
 
    /// Registeres (or re-registers) the backing columns with the physical storage
    void ConnectColumns(Detail::RPageStorage *pageStorage);
-   /// Returns the number of columns generated to store data for the field; defaults to 1
-   virtual unsigned int GetNColumns() const = 0;
 
    /// Generates a tree value of the field type and allocates new initialized memory according to the type.
    RFieldValue GenerateValue();
@@ -228,7 +226,6 @@ public:
    RFieldBase* Clone(std::string_view newName);
 
    void DoGenerateColumns() final {}
-   unsigned int GetNColumns() const final { return 0; }
    using Detail::RFieldBase::GenerateValue;
    Detail::RFieldValue GenerateValue(void*) { return Detail::RFieldValue(); }
    Detail::RFieldValue CaptureValue(void*) final { return Detail::RFieldValue(); }
@@ -253,7 +250,6 @@ public:
    RFieldBase* Clone(std::string_view newName) final;
 
    void DoGenerateColumns() final;
-   unsigned int GetNColumns() const final;
    using Detail::RFieldBase::GenerateValue;
    Detail::RFieldValue GenerateValue(void* where) override;
    void DestroyValue(const Detail::RFieldValue& value, bool dtorOnly = false) final;
@@ -279,7 +275,6 @@ public:
    RFieldBase* Clone(std::string_view newName) final;
 
    void DoGenerateColumns() final;
-   unsigned int GetNColumns() const final;
    using Detail::RFieldBase::GenerateValue;
    Detail::RFieldValue GenerateValue(void* where) override;
    void DestroyValue(const Detail::RFieldValue& value, bool dtorOnly = false) final;
@@ -326,7 +321,6 @@ public:
    RFieldBase* Clone(std::string_view newName) final;
 
    void DoGenerateColumns() final;
-   unsigned int GetNColumns() const final { return 1; }
 
    using Detail::RFieldBase::GenerateValue;
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final {
@@ -358,7 +352,6 @@ public:
    RFieldBase* Clone(std::string_view newName) final { return new RField(newName); }
 
    void DoGenerateColumns() final;
-   unsigned int GetNColumns() const final { return 1; }
 
    ClusterSize_t* Map(NTupleSize_t index) {
       static_assert(Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex>::kIsMappable,
@@ -400,7 +393,6 @@ public:
    RFieldBase* Clone(std::string_view newName) final { return new RField(newName); }
 
    void DoGenerateColumns() final;
-   unsigned int GetNColumns() const final { return 1; }
 
    float* Map(NTupleSize_t index) {
       static_assert(Detail::RColumnElement<float, EColumnType::kReal32>::kIsMappable,
@@ -437,7 +429,6 @@ public:
    RFieldBase* Clone(std::string_view newName) final { return new RField(newName); }
 
    void DoGenerateColumns() final;
-   unsigned int GetNColumns() const final { return 1; }
 
    double* Map(NTupleSize_t index) {
       static_assert(Detail::RColumnElement<double, EColumnType::kReal64>::kIsMappable,
@@ -473,7 +464,6 @@ public:
    RFieldBase* Clone(std::string_view newName) final { return new RField(newName); }
 
    void DoGenerateColumns() final;
-   unsigned int GetNColumns() const final { return 1; }
 
    std::int32_t* Map(NTupleSize_t index) {
       static_assert(Detail::RColumnElement<std::int32_t, EColumnType::kInt32>::kIsMappable,
@@ -509,7 +499,6 @@ public:
    RFieldBase* Clone(std::string_view newName) final { return new RField(newName); }
 
    void DoGenerateColumns() final;
-   unsigned int GetNColumns() const final { return 1; }
 
    std::uint32_t* Map(NTupleSize_t index) {
       static_assert(Detail::RColumnElement<std::uint32_t, EColumnType::kInt32>::kIsMappable,
@@ -545,7 +534,6 @@ public:
    RFieldBase* Clone(std::string_view newName) final { return new RField(newName); }
 
    void DoGenerateColumns() final;
-   unsigned int GetNColumns() const final { return 1; }
 
    std::uint64_t* Map(NTupleSize_t index) {
       static_assert(Detail::RColumnElement<std::uint64_t, EColumnType::kInt64>::kIsMappable,
@@ -590,7 +578,6 @@ public:
    RFieldBase* Clone(std::string_view newName) final { return new RField(newName); }
 
    void DoGenerateColumns() final;
-   unsigned int GetNColumns() const final { return 2; }
 
    using Detail::RFieldBase::GenerateValue;
    template <typename... ArgsT>
@@ -701,7 +688,6 @@ public:
       fColumns.emplace_back(std::make_unique<Detail::RColumn>(modelIndex));
       fPrincipalColumn = fColumns[0].get();
    }
-   unsigned int GetNColumns() const final { return 1; }
    void DestroyValue(const Detail::RFieldValue& value, bool dtorOnly = false) final {
       auto vec = reinterpret_cast<ContainerT*>(value.GetRawPtr());
       auto nItems = vec->size();

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -50,6 +50,7 @@ class RFieldCollection;
 
 namespace Detail {
 
+class RFieldFuse;
 class RPageStorage;
 
 // clang-format off
@@ -65,7 +66,9 @@ The field knows based on its type and the field name the type(s) and name(s) of 
 */
 // clang-format on
 class RFieldBase {
+   friend class ROOT::Experimental::Detail::RFieldFuse; // to connect the columns to a page storage
    friend class ROOT::Experimental::RFieldCollection; // to change the field names when collections are attached
+
 private:
    /// The field name is a unique within a tree and also the basis for the column name(s)
    std::string fName;
@@ -145,9 +148,6 @@ public:
    /// Get the name for an item sub field that is part of a collection, e.g. the float field of std::vector<float>
    static std::string GetCollectionName(const std::string &parentName);
 
-   /// Registeres (or re-registers) the backing columns with the physical storage
-   void ConnectColumns(Detail::RPageStorage *pageStorage);
-
    /// Generates a tree value of the field type and allocates new initialized memory according to the type.
    RFieldValue GenerateValue();
    /// Generates a tree value in a given location of size at least GetValueSize(). Assumes that where has been
@@ -215,6 +215,21 @@ public:
 
    RIterator begin();
    RIterator end();
+};
+
+// clang-format off
+/**
+\class ROOT::Experimental::RFieldFuse
+\ingroup NTuple
+\brief A friend of RFieldBase responsible for connecting a field's columns to the physical page storage
+
+Fields and their columns live in the void until connected to a physical page storage.  Only once connected, data
+can be read or written.
+*/
+// clang-format on
+class RFieldFuse {
+public:
+   static void Connect(RPageStorage &pageStorage, RFieldBase &field);
 };
 
 } // namespace Detail

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -685,7 +685,7 @@ public:
 
    void DoGenerateColumns() final {
       RColumnModel modelIndex(GetName(), EColumnType::kIndex, true /* isSorted*/);
-      fColumns.emplace_back(std::make_unique<Detail::RColumn>(modelIndex));
+      fColumns.emplace_back(std::make_unique<Detail::RColumn>(modelIndex, 0));
       fPrincipalColumn = fColumns[0].get();
    }
    void DestroyValue(const Detail::RFieldValue& value, bool dtorOnly = false) final {

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -95,6 +95,8 @@ class RNTupleReader : public Detail::RNTuple {
 private:
    std::unique_ptr<Detail::RPageSource> fSource;
 
+   void ConnectModel();
+
 public:
    // Browse through the entries
    class RIterator : public std::iterator<std::forward_iterator_tag, NTupleSize_t> {
@@ -146,9 +148,13 @@ public:
    /// GetView<double>("particles.pt") or GetView<std::vector<double>>("particle").  It can as well be the index
    /// field of a collection itself, like GetView<NTupleSize_t>("particle")
    template <typename T>
-   RNTupleView<T> GetView(std::string_view fieldName) { return RNTupleView<T>(fieldName, fSource.get()); }
+   RNTupleView<T> GetView(std::string_view fieldName) {
+      auto fieldId = fSource->GetDescriptor().FindFieldId(fieldName, kInvalidDescriptorId);
+      return RNTupleView<T>(fieldId, fSource.get());
+   }
    RNTupleViewCollection GetViewCollection(std::string_view fieldName) {
-      return RNTupleViewCollection(fieldName, fSource.get());
+      auto fieldId = fSource->GetDescriptor().FindFieldId(fieldName, kInvalidDescriptorId);
+      return RNTupleViewCollection(fieldId, fSource.get());
    }
 
    RIterator begin() { return RIterator(0); }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -20,6 +20,7 @@
 #include <ROOT/RNTupleUtil.hxx>
 #include <ROOT/RStringView.hxx>
 
+#include <memory>
 #include <vector>
 #include <string>
 #include <unordered_map>
@@ -28,6 +29,7 @@ namespace ROOT {
 namespace Experimental {
 
 class RNTupleDescriptorBuilder;
+class RNTupleModel;
 
 class RFieldDescriptor {
    friend class RNTupleDescriptorBuilder;
@@ -210,7 +212,10 @@ public:
    std::size_t GetNClusters() const { return fClusterDescriptors.size(); }
 
    DescriptorId_t FindFieldId(std::string_view fieldName, DescriptorId_t parentId) const;
-   DescriptorId_t FindColumnId(DescriptorId_t fieldId, std::uint32_t columnIndex);
+   DescriptorId_t FindColumnId(DescriptorId_t fieldId, std::uint32_t columnIndex) const;
+
+   /// Re-create the C++ model from the stored meta-data
+   std::unique_ptr<RNTupleModel> GenerateModel() const;
 };
 
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -215,6 +215,10 @@ public:
    std::size_t GetNColumns() const { return fColumnDescriptors.size(); }
    std::size_t GetNClusters() const { return fClusterDescriptors.size(); }
 
+   // Note that this is the number of entries as seen with the currently loaded cluster meta-data; there might be more
+   NTupleSize_t GetNEntries() const;
+   NTupleSize_t GetNElements(DescriptorId_t columnId) const;
+
    DescriptorId_t FindFieldId(std::string_view fieldName, DescriptorId_t parentId) const;
    DescriptorId_t FindColumnId(DescriptorId_t fieldId, std::uint32_t columnIndex) const;
    DescriptorId_t FindClusterId(DescriptorId_t columnId, NTupleSize_t index) const;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -71,6 +71,7 @@ private:
    DescriptorId_t fColumnId = kInvalidDescriptorId;;
    RNTupleVersion fVersion;
    RColumnModel fModel;
+   std::uint32_t fIndex;
    /// Every column belongs to one and only one field
    DescriptorId_t fFieldId = kInvalidDescriptorId;;
    /// Pointer to the parent column with offsets
@@ -84,6 +85,7 @@ public:
    DescriptorId_t GetId() const { return fColumnId; }
    RNTupleVersion GetVersion() const { return fVersion; }
    RColumnModel GetModel() const { return fModel; }
+   std::uint32_t GetIndex() const { return fIndex; }
    DescriptorId_t GetFieldId() const { return fFieldId; }
    DescriptorId_t GetOffsetId() const { return fOffsetId; }
    std::vector<DescriptorId_t> GetLinkIds() const { return fLinkIds; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -38,6 +38,8 @@ private:
    RNTupleVersion fTypeVersion;
    /// The leaf name, not including parent fields
    std::string fFieldName;
+   /// Free text set by the user
+   std::string fFieldDescription;
    /// The C++ type that was used when writing the field
    std::string fTypeName;
    /// The structural information carried by this field in the data model tree
@@ -54,6 +56,7 @@ public:
    RNTupleVersion GetFieldVersion() const { return fFieldVersion; }
    RNTupleVersion GetTypeVersion() const { return fTypeVersion; }
    std::string GetFieldName() const { return fFieldName; }
+   std::string GetFieldDescription() const { return fFieldDescription; }
    std::string GetTypeName() const { return fTypeName; }
    ENTupleStructure GetStructure() const { return fStructure; }
    DescriptorId_t GetParentId() const { return fParentId; }
@@ -134,6 +137,7 @@ private:
    static constexpr std::uint32_t kByteProtocol = 0;
 
    std::string fName;
+   std::string fDescription;
    RNTupleVersion fVersion;
    /// Every NTuple gets a unique identifier
    Uuid_t fOwnUuid;
@@ -169,6 +173,7 @@ public:
       return fClusterDescriptors.at(clusterId);
    }
    std::string GetName() const { return fName; }
+   std::string GetDescription() const { return fDescription; }
    RNTupleVersion GetVersion() const { return fVersion; }
    Uuid_t GetOwnUuid() const { return fOwnUuid; }
    Uuid_t GetGroupUuid() const { return fGroupUuid; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -26,6 +26,9 @@
 
 namespace ROOT {
 namespace Experimental {
+namespace Detail {
+class RFieldBase;
+}
 
 class RNTupleDescriptorBuilder;
 
@@ -208,6 +211,8 @@ public:
    std::size_t GetNFields() const { return fFieldDescriptors.size(); }
    std::size_t GetNColumns() const { return fColumnDescriptors.size(); }
    std::size_t GetNClusters() const { return fClusterDescriptors.size(); }
+
+   DescriptorId_t FindFieldId(const Detail::RFieldBase &field) const;
 };
 
 
@@ -231,7 +236,7 @@ public:
    void AddFieldLink(DescriptorId_t fieldId, DescriptorId_t linkId);
 
    void AddColumn(DescriptorId_t columnId, DescriptorId_t fieldId,
-                  const RNTupleVersion &version, const RColumnModel &model);
+                  const RNTupleVersion &version, const RColumnModel &model, std::uint32_t index);
    void SetColumnOffset(DescriptorId_t columnId, DescriptorId_t offsetId);
    void AddColumnLink(DescriptorId_t columnId, DescriptorId_t linkId);
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -140,13 +140,15 @@ class RClusterDescriptor {
 
 public:
    /// Generic information about the physical location of data. Values depend on the concrete storage type.  E.g.,
-   /// for a local file fUrl might be unsused and fPosition might be a file offset.
+   /// for a local file fUrl might be unsused and fPosition might be a file offset. Objects on storage can be compressed
+   /// and therefore we need to store their actual size.
    struct RLocator {
-      std::string fUrl;
       std::int64_t fPosition = 0;
+      std::uint32_t fBytesOnStorage = 0;
+      std::string fUrl;
 
       bool operator==(const RLocator &other) const {
-         return fUrl == other.fUrl && fPosition == other.fPosition;
+         return fPosition == other.fPosition && fBytesOnStorage == other.fBytesOnStorage && fUrl == other.fUrl;
       }
    };
 
@@ -176,7 +178,7 @@ public:
 
    /// Records the parition of data into pages for a particular column in a particular cluster
    struct RPageRange {
-      /// We do not need to store the element size / page size because we know to which column
+      /// We do not need to store the element size / uncompressed page size because we know to which column
       /// the page belongs
       struct RPageInfo {
          /// The sum of the elements of all the pages must match the corresponding fNElements field in fColumnRanges
@@ -206,7 +208,6 @@ private:
    ClusterSize_t fNEntries = kInvalidClusterIndex;
    /// For pre-fetching / caching an entire contiguous cluster
    RLocator fLocator;
-   std::int64_t fBytesOnStorage = 0;
 
    std::unordered_map<DescriptorId_t, RColumnRange> fColumnRanges;
    std::unordered_map<DescriptorId_t, RPageRange> fPageRanges;
@@ -223,7 +224,6 @@ public:
    NTupleSize_t GetFirstEntryIndex() const { return fFirstEntryIndex; }
    ClusterSize_t GetNEntries() const { return fNEntries; }
    RLocator GetLocator() const { return fLocator; }
-   std::int64_t GetBytesOnStorage() const { return fBytesOnStorage; }
    RColumnRange GetColumnRange(DescriptorId_t columnId) const { return fColumnRanges.at(columnId); }
    RPageRange GetPageRange(DescriptorId_t columnId) const { return fPageRanges.at(columnId); }
 };
@@ -363,7 +363,6 @@ public:
    void AddCluster(DescriptorId_t clusterId, RNTupleVersion version,
                    NTupleSize_t firstEntryIndex, ClusterSize_t nEntries);
    void SetClusterLocator(DescriptorId_t clusterId, RClusterDescriptor::RLocator locator);
-   void SetClusterSize(DescriptorId_t clusterId, std::int64_t bytesOnStorage);
    void AddClusterColumnRange(DescriptorId_t clusterId, const RClusterDescriptor::RColumnRange &columnRange);
    void AddClusterPageRange(DescriptorId_t clusterId, const RClusterDescriptor::RPageRange &pageRange);
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -250,12 +250,19 @@ class RNTupleDescriptor {
    friend class RNTupleDescriptorBuilder;
 
 private:
+   /// The ntuple name needs to be unique in a given storage location (file)
    std::string fName;
+   /// Free text from the user
    std::string fDescription;
+   /// The origin of the data
    std::string fAuthor;
+   /// The current responsible for storing the data
    std::string fCustodian;
+   /// The time stamp of the ntuple data (immutable)
    std::chrono::system_clock::time_point fTimeStampData;
+   /// The time stamp of writing the data to storage, which gets updated when re-written
    std::chrono::system_clock::time_point fTimeStampWritten;
+   /// The version evolves with the ntuple summary meta-data
    RNTupleVersion fVersion;
    /// Every NTuple gets a unique identifier
    RNTupleUuid fOwnUuid;
@@ -276,15 +283,11 @@ public:
 
    bool operator ==(const RNTupleDescriptor &other) const;
 
-   // We deliberately do not use ROOT's built-in serialization in order to allow for use of RNTuple's outside ROOT
-   /**
-    * Serializes the global ntuple information as well as the column and field schemata
-    * Returns the number of bytes and fills buffer if it is not nullptr.
-    */
+   /// We deliberately do not use ROOT's built-in serialization in order to allow for use of RNTuple's without libCore
+   /// Serializes the global ntuple information as well as the column and field schemata
+   /// Returns the number of bytes and fills buffer if it is not nullptr.
    std::uint32_t SerializeHeader(void* buffer) const;
-   /**
-    * Serializes cluster meta data. Returns the number of bytes and fills buffer if it is not nullptr.
-    */
+   /// Serializes cluster meta data. Returns the number of bytes and fills buffer if it is not nullptr.
    std::uint32_t SerializeFooter(void* buffer) const;
 
    const RFieldDescriptor& GetFieldDescriptor(DescriptorId_t fieldId) const { return fFieldDescriptors.at(fieldId); }
@@ -308,7 +311,7 @@ public:
    std::size_t GetNColumns() const { return fColumnDescriptors.size(); }
    std::size_t GetNClusters() const { return fClusterDescriptors.size(); }
 
-   // Note that this is the number of entries as seen with the currently loaded cluster meta-data; there might be more
+   // The number of entries as seen with the currently loaded cluster meta-data; there might be more
    NTupleSize_t GetNEntries() const;
    NTupleSize_t GetNElements(DescriptorId_t columnId) const;
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -54,7 +54,7 @@ private:
    std::string fFieldDescription;
    /// The C++ type that was used when writing the field
    std::string fTypeName;
-   /// The number of elements for fixed-size arrays
+   /// The number of elements per entry for fixed-size arrays
    std::uint64_t fNRepetitions;
    /// The structural information carried by this field in the data model tree
    ENTupleStructure fStructure;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -140,10 +140,10 @@ private:
    std::string fDescription;
    RNTupleVersion fVersion;
    /// Every NTuple gets a unique identifier
-   Uuid_t fOwnUuid;
+   RNTupleUuid fOwnUuid;
    /// Column sets that are created as derived sets from existing NTuples share the same group id.
    /// NTuples in the same group have the same number of entries and are supposed to contain associated data.
-   Uuid_t fGroupUuid;
+   RNTupleUuid fGroupUuid;
 
    std::unordered_map<DescriptorId_t, RFieldDescriptor> fFieldDescriptors;
    std::unordered_map<DescriptorId_t, RColumnDescriptor> fColumnDescriptors;
@@ -159,11 +159,11 @@ public:
     * Serializes the global ntuple information as well as the column and field schemata
     * Returns the number of bytes and fills buffer if it is not nullptr.
     */
-   std::uint32_t SerializeHeader(void* buffer);
+   std::uint32_t SerializeHeader(void* buffer) const;
    /**
     * Serializes cluster meta data. Returns the number of bytes and fills buffer if it is not nullptr.
     */
-   std::uint32_t SerializeFooter(void* buffer);
+   std::uint32_t SerializeFooter(void* buffer) const;
 
    const RFieldDescriptor& GetFieldDescriptor(DescriptorId_t fieldId) const { return fFieldDescriptors.at(fieldId); }
    const RColumnDescriptor& GetColumnDescriptor(DescriptorId_t columnId) const {
@@ -175,8 +175,12 @@ public:
    std::string GetName() const { return fName; }
    std::string GetDescription() const { return fDescription; }
    RNTupleVersion GetVersion() const { return fVersion; }
-   Uuid_t GetOwnUuid() const { return fOwnUuid; }
-   Uuid_t GetGroupUuid() const { return fGroupUuid; }
+   RNTupleUuid GetOwnUuid() const { return fOwnUuid; }
+   RNTupleUuid GetGroupUuid() const { return fGroupUuid; }
+
+   std::size_t GetNFields() const { return fFieldDescriptors.size(); }
+   std::size_t GetNColumns() const { return fColumnDescriptors.size(); }
+   std::size_t GetNClusters() const { return fClusterDescriptors.size(); }
 };
 
 
@@ -190,7 +194,8 @@ private:
 public:
    const RNTupleDescriptor& GetDescriptor() const { return fDescriptor; }
 
-   void SetNTuple(const std::string_view &name, const RNTupleVersion &version, const Uuid_t &uuid);
+   void SetNTuple(const std::string_view &name, const std::string_view &description, const RNTupleVersion &version,
+                  const RNTupleUuid &uuid);
 
    void AddField(DescriptorId_t fieldId, const RNTupleVersion &fieldVersion, const RNTupleVersion &typeVersion,
                  std::string_view fieldName, std::string_view typeName, ENTupleStructure structure);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -109,6 +109,10 @@ public:
          return fColumnId == other.fColumnId && fFirstElementIndex == other.fFirstElementIndex &&
                 fNElements == other.fNElements;
       }
+
+      bool Contains(NTupleSize_t index) const {
+         return (fFirstElementIndex <= index && (fFirstElementIndex + fNElements) > index);
+      }
    };
 
    struct RPageRange {
@@ -213,6 +217,7 @@ public:
 
    DescriptorId_t FindFieldId(std::string_view fieldName, DescriptorId_t parentId) const;
    DescriptorId_t FindColumnId(DescriptorId_t fieldId, std::uint32_t columnIndex) const;
+   DescriptorId_t FindClusterId(DescriptorId_t columnId, NTupleSize_t index) const;
 
    /// Re-create the C++ model from the stored meta-data
    std::unique_ptr<RNTupleModel> GenerateModel() const;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -157,13 +157,16 @@ public:
       NTupleSize_t fFirstElementIndex = kInvalidNTupleIndex;
       /// A 32bit value for the number of column elements in the cluster
       ClusterSize_t fNElements = kInvalidClusterIndex;
+      /// The usual format for ROOT compression settings (see TCompression.h).
+      /// The pages of a particular column in a particular cluster are all compressed with the same settings.
+      std::int64_t fCompressionSettings = 0;
 
       // TODO(jblomer): we perhaps want to store summary information, such as average, min/max, etc.
       // Should this be done on the field level?
 
       bool operator==(const RColumnRange &other) const {
          return fColumnId == other.fColumnId && fFirstElementIndex == other.fFirstElementIndex &&
-                fNElements == other.fNElements;
+                fNElements == other.fNElements && fCompressionSettings == other.fCompressionSettings;
       }
 
       bool Contains(NTupleSize_t index) const {

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -111,6 +111,15 @@ class RClusterDescriptor {
    friend class RNTupleDescriptorBuilder;
 
 public:
+   struct RLocator {
+      std::string fUrl;
+      std::int64_t fPosition = 0;
+
+      bool operator==(const RLocator &other) const {
+         return fUrl == other.fUrl && fPosition == other.fPosition;
+      }
+   };
+
    struct RColumnRange {
       DescriptorId_t fColumnId = kInvalidDescriptorId;
       NTupleSize_t fFirstElementIndex = kInvalidNTupleIndex;
@@ -136,7 +145,7 @@ public:
          ClusterSize_t fNElements = kInvalidClusterIndex;
          /// The meaning of fLocator depends on the storage backend.  It indicates where on the storage
          /// medium the page resides.  For file based storage, for instance, it can be the offset in the file.
-         std::int64_t fLocator = 0;
+         RLocator fLocator;
 
          bool operator==(const RPageInfo &other) const {
             return fNElements == other.fNElements && fLocator == other.fLocator;
@@ -156,6 +165,9 @@ private:
    RNTupleVersion fVersion;
    NTupleSize_t fFirstEntryIndex = kInvalidNTupleIndex;
    ClusterSize_t fNEntries = kInvalidClusterIndex;
+   RLocator fLocator;
+   std::int64_t fBytesOnStorage = 0;
+
    std::unordered_map<DescriptorId_t, RColumnRange> fColumnRanges;
    std::unordered_map<DescriptorId_t, RPageRange> fPageRanges;
 
@@ -170,6 +182,8 @@ public:
    RNTupleVersion GetVersion() const { return fVersion; }
    NTupleSize_t GetFirstEntryIndex() const { return fFirstEntryIndex; }
    ClusterSize_t GetNEntries() const { return fNEntries; }
+   RLocator GetLocator() const { return fLocator; }
+   std::int64_t GetBytesOnStorage() const { return fBytesOnStorage; }
    RColumnRange GetColumnRange(DescriptorId_t columnId) const { return fColumnRanges.at(columnId); }
    RPageRange GetPageRange(DescriptorId_t columnId) const { return fPageRanges.at(columnId); }
 };
@@ -283,6 +297,8 @@ public:
 
    void AddCluster(DescriptorId_t clusterId, RNTupleVersion version,
                    NTupleSize_t firstEntryIndex, ClusterSize_t nEntries);
+   void SetClusterLocator(DescriptorId_t clusterId, RClusterDescriptor::RLocator locator);
+   void SetClusterSize(DescriptorId_t clusterId, std::int64_t bytesOnStorage);
    void AddClusterColumnRange(DescriptorId_t clusterId, const RClusterDescriptor::RColumnRange &columnRange);
    void AddClusterPageRange(DescriptorId_t clusterId, const RClusterDescriptor::RPageRange &pageRange);
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -26,9 +26,6 @@
 
 namespace ROOT {
 namespace Experimental {
-namespace Detail {
-class RFieldBase;
-}
 
 class RNTupleDescriptorBuilder;
 
@@ -212,7 +209,8 @@ public:
    std::size_t GetNColumns() const { return fColumnDescriptors.size(); }
    std::size_t GetNClusters() const { return fClusterDescriptors.size(); }
 
-   DescriptorId_t FindFieldId(const Detail::RFieldBase &field) const;
+   DescriptorId_t FindFieldId(std::string_view fieldName, DescriptorId_t parentId) const;
+   DescriptorId_t FindColumnId(DescriptorId_t fieldId, std::uint32_t columnIndex);
 };
 
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -83,7 +83,7 @@ public:
    RColumnModel GetModel() const { return fModel; }
    DescriptorId_t GetFieldId() const { return fFieldId; }
    DescriptorId_t GetOffsetId() const { return fOffsetId; }
-   std::vector<DescriptorId_t> GetLinkIds() { return fLinkIds; }
+   std::vector<DescriptorId_t> GetLinkIds() const { return fLinkIds; }
 };
 
 
@@ -143,6 +143,8 @@ private:
 
    std::unordered_map<DescriptorId_t, RFieldDescriptor> fFieldDescriptors;
    std::unordered_map<DescriptorId_t, RColumnDescriptor> fColumnDescriptors;
+   /// May contain only a subset of all the available clusters, e.g. the clusters of the current file
+   /// from a chain of files
    std::unordered_map<DescriptorId_t, RClusterDescriptor> fClusterDescriptors;
 
 public:
@@ -158,10 +160,6 @@ public:
     * Serializes cluster meta data. Returns the number of bytes and fills buffer if it is not nullptr.
     */
    std::uint32_t SerializeFooter(void* buffer);
-   /**
-    * Reconstructs the ntuple descriptor from a header and a footer
-    */
-   static RNTupleDescriptor Deserialize(void* headerBuffer, void* footerBuffer);
 
    const RFieldDescriptor& GetFieldDescriptor(DescriptorId_t fieldId) const { return fFieldDescriptors.at(fieldId); }
    const RColumnDescriptor& GetColumnDescriptor(DescriptorId_t columnId) const {
@@ -170,9 +168,10 @@ public:
    const RClusterDescriptor& GetClusterDescriptor(DescriptorId_t clusterId) const {
       return fClusterDescriptors.at(clusterId);
    }
+   std::string GetName() const { return fName; }
+   RNTupleVersion GetVersion() const { return fVersion; }
    Uuid_t GetOwnUuid() const { return fOwnUuid; }
    Uuid_t GetGroupUuid() const { return fGroupUuid; }
-   std::string GetName() const { return fName; }
 };
 
 
@@ -198,9 +197,13 @@ public:
    void SetColumnOffset(DescriptorId_t columnId, DescriptorId_t offsetId);
    void AddColumnLink(DescriptorId_t columnId, DescriptorId_t linkId);
 
+   void SetFromHeader(void* headerBuffer);
+
    void AddCluster(DescriptorId_t clusterId, RNTupleVersion version,
                    NTupleSize_t firstEntryIndex, ClusterSize_t nEntries);
    void AddClusterColumnRange(DescriptorId_t clusterId, const RClusterDescriptor::RColumnRange &columnRange);
+
+   void AddClustersFromFooter(void* footerBuffer);
 };
 
 } // namespace Experimental

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -18,6 +18,7 @@
 
 #include <ROOT/REntry.hxx>
 #include <ROOT/RField.hxx>
+#include <ROOT/RNTupleUtil.hxx>
 #include <ROOT/RFieldValue.hxx>
 #include <ROOT/RStringView.hxx>
 
@@ -90,6 +91,9 @@ public:
    RFieldRoot* GetRootField() { return fRootField.get(); }
    REntry* GetDefaultEntry() { return fDefaultEntry.get(); }
    std::unique_ptr<REntry> CreateEntry();
+   RNTupleVersion GetVersion() const { return RNTupleVersion(); }
+   std::string GetDescription() const { return ""; /* TODO */ }
+   RNTupleUuid GetUuid() const { return RNTupleUuid(); /* TODO */ }
 };
 
 } // namespace Exerimental

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -65,6 +65,9 @@ constexpr ColumnId_t kInvalidColumnId = -1;
 using DescriptorId_t = std::uint64_t;
 constexpr DescriptorId_t kInvalidDescriptorId = std::uint64_t(-1);
 
+/// Every NTuple is identified by a UUID.  TODO(jblomer): should this be a TUUID?
+using Uuid_t = std::string;
+
 
 /// 64 possible flags to apply to all versioned entities (so far unused).
 using NTupleFlags_t = std::uint64_t;
@@ -86,6 +89,10 @@ public:
    RNTupleVersion(std::uint32_t versionUse, std::uint32_t versionMin, NTupleFlags_t flags)
      : fVersionUse(versionUse), fVersionMin(versionMin), fFlags(flags)
    {}
+
+   bool operator ==(const RNTupleVersion &other) const {
+      return fVersionUse == other.fVersionUse && fVersionMin == other.fVersionMin && fFlags == other.fFlags;
+   }
 
    std::uint32_t GetVersionUse() const { return fVersionUse; }
    std::uint32_t GetVersionMin() const { return fVersionMin; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -66,7 +66,7 @@ using DescriptorId_t = std::uint64_t;
 constexpr DescriptorId_t kInvalidDescriptorId = std::uint64_t(-1);
 
 /// Every NTuple is identified by a UUID.  TODO(jblomer): should this be a TUUID?
-using Uuid_t = std::string;
+using RNTupleUuid = std::string;
 
 
 /// 64 possible flags to apply to all versioned entities (so far unused).

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -99,8 +99,7 @@ protected:
    {
       Detail::RFieldFuse::Connect(fieldId, *pageSource, fField);
       for (auto &f : fField) {
-         auto subFieldId =
-            pageSource->GetDescriptor().FindFieldId(Detail::RFieldBase::GetLeafName(f.GetName()), fieldId);
+         auto subFieldId = pageSource->GetDescriptor().FindFieldId(f.GetName(), fieldId);
          Detail::RFieldFuse::Connect(subFieldId, *pageSource, f);
       }
    }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -93,9 +93,9 @@ protected:
    RNTupleView(std::string_view fieldName, Detail::RPageSource* pageSource)
      : fField(fieldName), fValue(fField.GenerateValue())
    {
-      fField.ConnectColumns(pageSource);
+      Detail::RFieldFuse::Connect(*pageSource, fField);
       for (auto& f : fField) {
-         f.ConnectColumns(pageSource);
+         Detail::RFieldFuse::Connect(*pageSource, f);
       }
    }
 
@@ -122,7 +122,7 @@ class RNTupleView<float> {
 protected:
    RField<float> fField;
    RNTupleView(std::string_view fieldName, Detail::RPageSource* pageSource) : fField(fieldName) {
-      fField.ConnectColumns(pageSource);
+      Detail::RFieldFuse::Connect(*pageSource, fField);
    }
 
 public:

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -150,8 +150,10 @@ class RNTupleView<double> {
 
 protected:
    RField<double> fField;
-   RNTupleView(std::string_view fieldName, Detail::RPageSource* pageSource) : fField(fieldName) {
-      fField.ConnectColumns(pageSource);
+   RNTupleView(DescriptorId_t fieldId, Detail::RPageSource* pageSource)
+      : fField(pageSource->GetDescriptor().GetFieldDescriptor(fieldId).GetFieldName())
+   {
+      Detail::RFieldFuse::Connect(fieldId, *pageSource, fField);
    }
 
 public:
@@ -172,8 +174,10 @@ class RNTupleView<int> {
 
 protected:
    RField<int> fField;
-   RNTupleView(std::string_view fieldName, Detail::RPageSource* pageSource) : fField(fieldName) {
-      fField.ConnectColumns(pageSource);
+   RNTupleView(DescriptorId_t fieldId, Detail::RPageSource* pageSource)
+      : fField(pageSource->GetDescriptor().GetFieldDescriptor(fieldId).GetFieldName())
+   {
+      Detail::RFieldFuse::Connect(fieldId, *pageSource, fField);
    }
 
 public:

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -74,7 +74,7 @@ public:
 
    /// Register a new column.  When reading, the column must exist in the ntuple on disk corresponding to the meta-data.
    /// When writing, every column can only be attached once.
-   virtual ColumnHandle_t AddColumn(const RColumn &column) = 0;
+   virtual ColumnHandle_t AddColumn(DescriptorId_t fieldId, const RColumn &column) = 0;
    /// Whether the concrete implementation is a sink or a source
    virtual EPageStorageType GetType() = 0;
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -135,9 +135,6 @@ public:
    /// Open the physical storage container for the tree
    virtual void Attach() = 0;
 
-   /// Re-create the C++ model from the stored meta-data
-   virtual std::unique_ptr<ROOT::Experimental::RNTupleModel> GenerateModel() = 0;
-
    virtual NTupleSize_t GetNEntries() = 0;
    virtual NTupleSize_t GetNElements(ColumnHandle_t columnHandle) = 0;
    virtual ColumnId_t GetColumnId(ColumnHandle_t columnHandle) = 0;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
@@ -174,7 +174,7 @@ public:
    RPageSinkRoot(std::string_view ntupleName, std::string_view path);
    virtual ~RPageSinkRoot();
 
-   ColumnHandle_t AddColumn(const RColumn &column) final;
+   ColumnHandle_t AddColumn(DescriptorId_t fieldId, const RColumn &column) final;
    void Create(RNTupleModel &model) final;
    void CommitPage(ColumnHandle_t columnHandle, const RPage &page) final;
    void CommitCluster(NTupleSize_t nEntries) final;
@@ -229,7 +229,7 @@ public:
    RPageSourceRoot(std::string_view ntupleName, std::string_view path);
    virtual ~RPageSourceRoot();
 
-   ColumnHandle_t AddColumn(const RColumn &column) final;
+   ColumnHandle_t AddColumn(DescriptorId_t fieldId, const RColumn &column) final;
    void Attach() final;
    std::unique_ptr<ROOT::Experimental::RNTupleModel> GenerateModel() final;
    NTupleSize_t GetNEntries() final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
@@ -231,7 +231,6 @@ public:
 
    ColumnHandle_t AddColumn(DescriptorId_t fieldId, const RColumn &column) final;
    void Attach() final;
-   std::unique_ptr<ROOT::Experimental::RNTupleModel> GenerateModel() final;
    NTupleSize_t GetNEntries() final;
    NTupleSize_t GetNElements(ColumnHandle_t columnHandle) final;
    ColumnId_t GetColumnId(ColumnHandle_t columnHandle) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
@@ -74,12 +74,6 @@ struct RClusterFooter {
    std::vector<RPageInfo> fPagesPerColumn;
 };
 
-struct RPagePayload {
-   std::int32_t fVersion = 0;
-   int fSize = 0;
-   unsigned char* fContent = nullptr; //[fSize]
-};
-
 struct RNTupleBlob {
    RNTupleBlob() {}
    RNTupleBlob(int size, unsigned char *content) : fSize(size), fContent(content) {}
@@ -196,7 +190,7 @@ public:
 class RPageAllocatorKey {
 public:
    static RPage NewPage(ColumnId_t columnId, void *mem, std::size_t elementSize, std::size_t nElements);
-   static void DeletePage(const RPage& page, ROOT::Experimental::Internal::RPagePayload *payload);
+   static void DeletePage(const RPage& page, ROOT::Experimental::Internal::RNTupleBlob *payload);
 };
 
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
@@ -80,6 +80,18 @@ struct RPagePayload {
    unsigned char* fContent = nullptr; //[fSize]
 };
 
+struct RNTupleBlob {
+   RNTupleBlob() {}
+   RNTupleBlob(int size, unsigned char *content) : fSize(size), fContent(content) {}
+   RNTupleBlob(const RNTupleBlob &other) = delete;
+   RNTupleBlob &operator =(const RNTupleBlob &other) = delete;
+   ~RNTupleBlob() = default;
+
+   std::int32_t fVersion = 0;
+   int fSize = 0;
+   unsigned char* fContent = nullptr; //[fSize]
+};
+
 } // namespace Internal
 
 
@@ -150,7 +162,13 @@ private:
    ROOT::Experimental::Internal::RNTupleFooter fNTupleFooter;
 
    RMapper fMapper;
-   NTupleSize_t fPrevClusterNEntries;
+   NTupleSize_t fPrevClusterNEntries = 0;
+
+   /// Field, column, and cluster ids are issued sequentially starting with 0
+   DescriptorId_t fLastFieldId = 0;
+   DescriptorId_t fLastColumnId = 0;
+   DescriptorId_t fLastClusterId = 0;
+   RNTupleDescriptorBuilder fDescriptorBuilder;
 
 public:
    RPageSinkRoot(std::string_view ntupleName, RSettings settings);

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
@@ -164,6 +164,9 @@ private:
    DescriptorId_t fLastClusterId = 0;
    RNTupleDescriptorBuilder fDescriptorBuilder;
 
+   /// Keeps track of the number of elements in the currently open cluster. Indexed by column id.
+   std::vector<RClusterDescriptor::RColumnRange> fOpenColumnRanges;
+
 public:
    RPageSinkRoot(std::string_view ntupleName, RSettings settings);
    RPageSinkRoot(std::string_view ntupleName, std::string_view path);

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
@@ -166,6 +166,8 @@ private:
 
    /// Keeps track of the number of elements in the currently open cluster. Indexed by column id.
    std::vector<RClusterDescriptor::RColumnRange> fOpenColumnRanges;
+   /// Keeps track of the written pages in the currently open cluster. Indexed by column id.
+   std::vector<RClusterDescriptor::RPageRange> fOpenPageRanges;
 
 public:
    RPageSinkRoot(std::string_view ntupleName, RSettings settings);

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
@@ -158,10 +158,11 @@ private:
    RMapper fMapper;
    NTupleSize_t fPrevClusterNEntries = 0;
 
-   /// Field, column, and cluster ids are issued sequentially starting with 0
+   /// Field, column, cluster ids and page indexes per cluster are issued sequentially starting with 0
    DescriptorId_t fLastFieldId = 0;
    DescriptorId_t fLastColumnId = 0;
    DescriptorId_t fLastClusterId = 0;
+   DescriptorId_t fLastPageIdx = 0;
    RNTupleDescriptorBuilder fDescriptorBuilder;
 
    /// Keeps track of the number of elements in the currently open cluster. Indexed by column id.

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -37,17 +37,17 @@ ROOT::Experimental::Detail::RColumn::~RColumn()
       fPageSource->ReleasePage(fCurrentPage);
 }
 
-void ROOT::Experimental::Detail::RColumn::Connect(RPageStorage* pageStorage)
+void ROOT::Experimental::Detail::RColumn::Connect(DescriptorId_t fieldId, RPageStorage *pageStorage)
 {
    switch (pageStorage->GetType()) {
    case EPageStorageType::kSink:
       fPageSink = static_cast<RPageSink*>(pageStorage); // the page sink initializes fHeadPage on AddColumn
-      fHandleSink = fPageSink->AddColumn(*this);
+      fHandleSink = fPageSink->AddColumn(fieldId, *this);
       fHeadPage = fPageSink->ReservePage(fHandleSink);
       break;
    case EPageStorageType::kSource:
       fPageSource = static_cast<RPageSource*>(pageStorage);
-      fHandleSource = fPageSource->AddColumn(*this);
+      fHandleSource = fPageSource->AddColumn(fieldId, *this);
       fNElements = fPageSource->GetNElements(fHandleSource);
       fColumnIdSource = fPageSource->GetColumnId(fHandleSource);
       break;

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -21,8 +21,8 @@
 
 #include <iostream>
 
-ROOT::Experimental::Detail::RColumn::RColumn(const RColumnModel& model)
-   : fModel(model), fPageSink(nullptr), fPageSource(nullptr), fHeadPage(), fNElements(0),
+ROOT::Experimental::Detail::RColumn::RColumn(const RColumnModel& model, std::uint32_t index)
+   : fModel(model), fIndex(index), fPageSink(nullptr), fPageSource(nullptr), fHeadPage(), fNElements(0),
      fCurrentPage(),
      fColumnIdSource(kInvalidColumnId),
      fOffsetColumn(nullptr)

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -34,6 +34,21 @@
 #include <iostream>
 #include <utility>
 
+void ROOT::Experimental::Detail::RFieldFuse::Connect(RPageStorage &pageStorage, RFieldBase &field)
+{
+   if (field.fColumns.empty())
+      field.DoGenerateColumns();
+   for (auto& column : field.fColumns) {
+      if ((field.fParent != nullptr) && (column->GetOffsetColumn() == nullptr))
+         column->SetOffsetColumn(field.fParent->fPrincipalColumn);
+      column->Connect(&pageStorage);
+   }
+}
+
+
+//------------------------------------------------------------------------------
+
+
 ROOT::Experimental::Detail::RFieldBase::RFieldBase(
    std::string_view name, std::string_view type, ENTupleStructure structure, bool isSimple)
    : fName(name), fType(type), fStructure(structure), fIsSimple(isSimple), fParent(nullptr), fPrincipalColumn(nullptr)
@@ -146,17 +161,6 @@ void ROOT::Experimental::Detail::RFieldBase::Flush() const
 {
    for (auto& column : fColumns) {
       column->Flush();
-   }
-}
-
-void ROOT::Experimental::Detail::RFieldBase::ConnectColumns(RPageStorage *pageStorage)
-{
-   if (fColumns.empty())
-      DoGenerateColumns();
-   for (auto& column : fColumns) {
-      if ((fParent != nullptr) && (column->GetOffsetColumn() == nullptr))
-         column->SetOffsetColumn(fParent->fPrincipalColumn);
-      column->Connect(pageStorage);
    }
 }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -34,14 +34,14 @@
 #include <iostream>
 #include <utility>
 
-void ROOT::Experimental::Detail::RFieldFuse::Connect(RPageStorage &pageStorage, RFieldBase &field)
+void ROOT::Experimental::Detail::RFieldFuse::Connect(DescriptorId_t fieldId, RPageStorage &pageStorage, RFieldBase &field)
 {
    if (field.fColumns.empty())
       field.DoGenerateColumns();
    for (auto& column : field.fColumns) {
       if ((field.fParent != nullptr) && (column->GetOffsetColumn() == nullptr))
          column->SetOffsetColumn(field.fParent->fPrincipalColumn);
-      column->Connect(&pageStorage);
+      column->Connect(fieldId, &pageStorage);
    }
 }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -369,11 +369,6 @@ void ROOT::Experimental::RFieldClass::DoGenerateColumns()
 {
 }
 
-unsigned int ROOT::Experimental::RFieldClass::GetNColumns() const
-{
-   return 0;
-}
-
 ROOT::Experimental::Detail::RFieldValue ROOT::Experimental::RFieldClass::GenerateValue(void* where)
 {
    return Detail::RFieldValue(true /* captureFlag */, this, fClass->New(where));
@@ -447,11 +442,6 @@ void ROOT::Experimental::RFieldVector::DoGenerateColumns()
    RColumnModel modelIndex(GetName(), EColumnType::kIndex, true /* isSorted*/);
    fColumns.emplace_back(std::make_unique<Detail::RColumn>(modelIndex));
    fPrincipalColumn = fColumns[0].get();
-}
-
-unsigned int ROOT::Experimental::RFieldVector::GetNColumns() const
-{
-   return 1;
 }
 
 ROOT::Experimental::Detail::RFieldValue ROOT::Experimental::RFieldVector::GenerateValue(void* where)

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -231,7 +231,7 @@ ROOT::Experimental::REntry* ROOT::Experimental::RFieldRoot::GenerateEntry()
 
 void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::DoGenerateColumns()
 {
-   RColumnModel model(GetName(), EColumnType::kIndex, true /* isSorted*/);
+   RColumnModel model(EColumnType::kIndex, true /* isSorted*/);
    fColumns.emplace_back(std::make_unique<Detail::RColumn>(model, 0));
    fPrincipalColumn = fColumns[0].get();
 }
@@ -242,7 +242,7 @@ void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::DoGenerateCo
 
 void ROOT::Experimental::RField<float>::DoGenerateColumns()
 {
-   RColumnModel model(GetName(), EColumnType::kReal32, false /* isSorted*/);
+   RColumnModel model(EColumnType::kReal32, false /* isSorted*/);
    fColumns.emplace_back(std::make_unique<Detail::RColumn>(model, 0));
    fPrincipalColumn = fColumns[0].get();
 }
@@ -251,7 +251,7 @@ void ROOT::Experimental::RField<float>::DoGenerateColumns()
 
 void ROOT::Experimental::RField<double>::DoGenerateColumns()
 {
-   RColumnModel model(GetName(), EColumnType::kReal64, false /* isSorted*/);
+   RColumnModel model(EColumnType::kReal64, false /* isSorted*/);
    fColumns.emplace_back(std::make_unique<Detail::RColumn>(model, 0));
    fPrincipalColumn = fColumns[0].get();
 }
@@ -261,7 +261,7 @@ void ROOT::Experimental::RField<double>::DoGenerateColumns()
 
 void ROOT::Experimental::RField<std::int32_t>::DoGenerateColumns()
 {
-   RColumnModel model(GetName(), EColumnType::kInt32, false /* isSorted*/);
+   RColumnModel model(EColumnType::kInt32, false /* isSorted*/);
    fColumns.emplace_back(std::make_unique<Detail::RColumn>(model, 0));
    fPrincipalColumn = fColumns[0].get();
 }
@@ -270,7 +270,7 @@ void ROOT::Experimental::RField<std::int32_t>::DoGenerateColumns()
 
 void ROOT::Experimental::RField<std::uint32_t>::DoGenerateColumns()
 {
-   RColumnModel model(GetName(), EColumnType::kInt32, false /* isSorted*/);
+   RColumnModel model(EColumnType::kInt32, false /* isSorted*/);
    fColumns.emplace_back(std::make_unique<Detail::RColumn>(model, 0));
    fPrincipalColumn = fColumns[0].get();
 }
@@ -279,7 +279,7 @@ void ROOT::Experimental::RField<std::uint32_t>::DoGenerateColumns()
 
 void ROOT::Experimental::RField<std::uint64_t>::DoGenerateColumns()
 {
-   RColumnModel model(GetName(), EColumnType::kInt64, false /* isSorted*/);
+   RColumnModel model(EColumnType::kInt64, false /* isSorted*/);
    fColumns.emplace_back(std::make_unique<Detail::RColumn>(model, 0));
    fPrincipalColumn = fColumns[0].get();
 }
@@ -289,10 +289,10 @@ void ROOT::Experimental::RField<std::uint64_t>::DoGenerateColumns()
 
 void ROOT::Experimental::RField<std::string>::DoGenerateColumns()
 {
-   RColumnModel modelIndex(GetName(), EColumnType::kIndex, true /* isSorted*/);
+   RColumnModel modelIndex(EColumnType::kIndex, true /* isSorted*/);
    fColumns.emplace_back(std::make_unique<Detail::RColumn>(modelIndex, 0));
 
-   RColumnModel modelChars(GetCollectionName(GetName()), EColumnType::kByte, false /* isSorted*/);
+   RColumnModel modelChars(EColumnType::kByte, false /* isSorted*/);
    fColumns.emplace_back(std::make_unique<Detail::RColumn>(modelChars, 1));
    fPrincipalColumn = fColumns[0].get();
    fColumns[1]->SetOffsetColumn(fPrincipalColumn);
@@ -444,7 +444,7 @@ void ROOT::Experimental::RFieldVector::DoRead(NTupleSize_t index, Detail::RField
 
 void ROOT::Experimental::RFieldVector::DoGenerateColumns()
 {
-   RColumnModel modelIndex(GetName(), EColumnType::kIndex, true /* isSorted*/);
+   RColumnModel modelIndex(EColumnType::kIndex, true /* isSorted*/);
    fColumns.emplace_back(std::make_unique<Detail::RColumn>(modelIndex, 0));
    fPrincipalColumn = fColumns[0].get();
 }
@@ -510,7 +510,7 @@ ROOT::Experimental::RFieldCollection::RFieldCollection(
 
 void ROOT::Experimental::RFieldCollection::DoGenerateColumns()
 {
-   RColumnModel modelIndex(GetName(), EColumnType::kIndex, true /* isSorted*/);
+   RColumnModel modelIndex(EColumnType::kIndex, true /* isSorted*/);
    fColumns.emplace_back(std::make_unique<Detail::RColumn>(modelIndex, 0));
    fPrincipalColumn = fColumns[0].get();
 }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -151,7 +151,8 @@ void ROOT::Experimental::Detail::RFieldBase::Flush() const
 
 void ROOT::Experimental::Detail::RFieldBase::ConnectColumns(RPageStorage *pageStorage)
 {
-   if (fColumns.empty()) DoGenerateColumns();
+   if (fColumns.empty())
+      DoGenerateColumns();
    for (auto& column : fColumns) {
       if ((fParent != nullptr) && (column->GetOffsetColumn() == nullptr))
          column->SetOffsetColumn(fParent->fPrincipalColumn);
@@ -227,7 +228,7 @@ ROOT::Experimental::REntry* ROOT::Experimental::RFieldRoot::GenerateEntry()
 void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::DoGenerateColumns()
 {
    RColumnModel model(GetName(), EColumnType::kIndex, true /* isSorted*/);
-   fColumns.emplace_back(std::make_unique<Detail::RColumn>(model));
+   fColumns.emplace_back(std::make_unique<Detail::RColumn>(model, 0));
    fPrincipalColumn = fColumns[0].get();
 }
 
@@ -238,7 +239,7 @@ void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::DoGenerateCo
 void ROOT::Experimental::RField<float>::DoGenerateColumns()
 {
    RColumnModel model(GetName(), EColumnType::kReal32, false /* isSorted*/);
-   fColumns.emplace_back(std::make_unique<Detail::RColumn>(model));
+   fColumns.emplace_back(std::make_unique<Detail::RColumn>(model, 0));
    fPrincipalColumn = fColumns[0].get();
 }
 
@@ -247,7 +248,7 @@ void ROOT::Experimental::RField<float>::DoGenerateColumns()
 void ROOT::Experimental::RField<double>::DoGenerateColumns()
 {
    RColumnModel model(GetName(), EColumnType::kReal64, false /* isSorted*/);
-   fColumns.emplace_back(std::make_unique<Detail::RColumn>(model));
+   fColumns.emplace_back(std::make_unique<Detail::RColumn>(model, 0));
    fPrincipalColumn = fColumns[0].get();
 }
 
@@ -257,7 +258,7 @@ void ROOT::Experimental::RField<double>::DoGenerateColumns()
 void ROOT::Experimental::RField<std::int32_t>::DoGenerateColumns()
 {
    RColumnModel model(GetName(), EColumnType::kInt32, false /* isSorted*/);
-   fColumns.emplace_back(std::make_unique<Detail::RColumn>(model));
+   fColumns.emplace_back(std::make_unique<Detail::RColumn>(model, 0));
    fPrincipalColumn = fColumns[0].get();
 }
 
@@ -266,7 +267,7 @@ void ROOT::Experimental::RField<std::int32_t>::DoGenerateColumns()
 void ROOT::Experimental::RField<std::uint32_t>::DoGenerateColumns()
 {
    RColumnModel model(GetName(), EColumnType::kInt32, false /* isSorted*/);
-   fColumns.emplace_back(std::make_unique<Detail::RColumn>(model));
+   fColumns.emplace_back(std::make_unique<Detail::RColumn>(model, 0));
    fPrincipalColumn = fColumns[0].get();
 }
 
@@ -275,7 +276,7 @@ void ROOT::Experimental::RField<std::uint32_t>::DoGenerateColumns()
 void ROOT::Experimental::RField<std::uint64_t>::DoGenerateColumns()
 {
    RColumnModel model(GetName(), EColumnType::kInt64, false /* isSorted*/);
-   fColumns.emplace_back(std::make_unique<Detail::RColumn>(model));
+   fColumns.emplace_back(std::make_unique<Detail::RColumn>(model, 0));
    fPrincipalColumn = fColumns[0].get();
 }
 
@@ -285,10 +286,10 @@ void ROOT::Experimental::RField<std::uint64_t>::DoGenerateColumns()
 void ROOT::Experimental::RField<std::string>::DoGenerateColumns()
 {
    RColumnModel modelIndex(GetName(), EColumnType::kIndex, true /* isSorted*/);
-   fColumns.emplace_back(std::make_unique<Detail::RColumn>(modelIndex));
+   fColumns.emplace_back(std::make_unique<Detail::RColumn>(modelIndex, 0));
 
    RColumnModel modelChars(GetCollectionName(GetName()), EColumnType::kByte, false /* isSorted*/);
-   fColumns.emplace_back(std::make_unique<Detail::RColumn>(modelChars));
+   fColumns.emplace_back(std::make_unique<Detail::RColumn>(modelChars, 1));
    fPrincipalColumn = fColumns[0].get();
    fColumns[1]->SetOffsetColumn(fPrincipalColumn);
 }
@@ -440,7 +441,7 @@ void ROOT::Experimental::RFieldVector::DoRead(NTupleSize_t index, Detail::RField
 void ROOT::Experimental::RFieldVector::DoGenerateColumns()
 {
    RColumnModel modelIndex(GetName(), EColumnType::kIndex, true /* isSorted*/);
-   fColumns.emplace_back(std::make_unique<Detail::RColumn>(modelIndex));
+   fColumns.emplace_back(std::make_unique<Detail::RColumn>(modelIndex, 0));
    fPrincipalColumn = fColumns[0].get();
 }
 
@@ -506,7 +507,7 @@ ROOT::Experimental::RFieldCollection::RFieldCollection(
 void ROOT::Experimental::RFieldCollection::DoGenerateColumns()
 {
    RColumnModel modelIndex(GetName(), EColumnType::kIndex, true /* isSorted*/);
-   fColumns.emplace_back(std::make_unique<Detail::RColumn>(modelIndex));
+   fColumns.emplace_back(std::make_unique<Detail::RColumn>(modelIndex, 0));
    fPrincipalColumn = fColumns[0].get();
 }
 

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -44,7 +44,7 @@ ROOT::Experimental::RNTupleReader::RNTupleReader(
 {
    fSource->Attach();
    for (auto& field : *fModel->GetRootField()) {
-      field.ConnectColumns(fSource.get());
+      Detail::RFieldFuse::Connect(*fSource, field);
    }
    fNEntries = fSource->GetNEntries();
 }
@@ -56,7 +56,7 @@ ROOT::Experimental::RNTupleReader::RNTupleReader(std::unique_ptr<ROOT::Experimen
    fSource->Attach();
    fModel = fSource->GenerateModel();
    for (auto& field : *fModel->GetRootField()) {
-      field.ConnectColumns(fSource.get());
+      Detail::RFieldFuse::Connect(*fSource, field);
    }
    fNEntries = fSource->GetNEntries();
 }

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -42,7 +42,7 @@ void ROOT::Experimental::RNTupleReader::ConnectModel() {
    fieldPtr2Id[fModel->GetRootField()] = kInvalidDescriptorId;
    for (auto& field : *fModel->GetRootField()) {
       auto parentId = fieldPtr2Id[field.GetParent()];
-      auto fieldId = fSource->GetDescriptor().FindFieldId(Detail::RFieldBase::GetLeafName(field.GetName()), parentId);
+      auto fieldId = fSource->GetDescriptor().FindFieldId(field.GetName(), parentId);
       R__ASSERT(fieldId != kInvalidDescriptorId);
       fieldPtr2Id[&field] = fieldId;
       Detail::RFieldFuse::Connect(fieldId, *fSource, field);

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -65,7 +65,7 @@ ROOT::Experimental::RNTupleReader::RNTupleReader(std::unique_ptr<ROOT::Experimen
    , fSource(std::move(source))
 {
    fSource->Attach();
-   fModel = fSource->GenerateModel();
+   fModel = fSource->GetDescriptor().GenerateModel();
    ConnectModel();
    fNEntries = fSource->GetNEntries();
 }

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -164,6 +164,7 @@ std::uint32_t SerializeColumn(const RColumnDescriptor &val, void* buffer) {
    pos += SerializeString(val.GetModel().GetName(), *where);
    pos += SerializeInt32(static_cast<int>(val.GetModel().GetType()), *where);
    pos += SerializeInt32(static_cast<int>(val.GetModel().GetIsSorted()), *where);
+   pos += SerializeUInt32(val.GetIndex(), *where);
    pos += SerializeUInt64(val.GetFieldId(), *where);
    pos += SerializeUInt64(val.GetOffsetId(), *where);
    pos += SerializeUInt32(val.GetLinkIds().size(), *where);
@@ -198,6 +199,7 @@ bool RColumnDescriptor::operator==(const RColumnDescriptor &other) const {
    return fColumnId == other.fColumnId &&
           fVersion == other.fVersion &&
           fModel == other.fModel &&
+          fIndex == other.fIndex &&
           fFieldId == other.fFieldId &&
           fOffsetId == other.fOffsetId &&
           fLinkIds == other.fLinkIds;
@@ -361,6 +363,7 @@ void RNTupleDescriptorBuilder::SetFromHeader(void* headerBuffer) {
       pos += DeserializeInt32(pos, &type);
       pos += DeserializeInt32(pos, &isSorted);
       c.fModel = RColumnModel(name, static_cast<EColumnType>(type), isSorted);
+      pos += DeserializeUInt32(pos, &c.fIndex);
       pos += DeserializeUInt64(pos, &c.fFieldId);
       pos += DeserializeUInt64(pos, &c.fOffsetId);
 

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -13,7 +13,6 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include <ROOT/RField.hxx>
 #include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 #include <ROOT/RStringView.hxx>
@@ -319,17 +318,22 @@ std::uint32_t ROOT::Experimental::RNTupleDescriptor::SerializeFooter(void* buffe
 
 
 ROOT::Experimental::DescriptorId_t
-ROOT::Experimental::RNTupleDescriptor::FindFieldId(const Detail::RFieldBase &field) const
+ROOT::Experimental::RNTupleDescriptor::FindFieldId(std::string_view fieldName, DescriptorId_t parentId) const
 {
-   DescriptorId_t parentId = kInvalidDescriptorId;
-   if (field.GetParent() != nullptr)
-      parentId = FindFieldId(*field.GetParent());
    for (const auto &fd : fFieldDescriptors) {
-      if (fd.second.GetParentId() == parentId &&
-          fd.second.GetFieldName() == Detail::RFieldBase::GetLeafName(field.GetName()))
-      {
+      if (fd.second.GetParentId() == parentId && fd.second.GetFieldName() == fieldName)
          return fd.second.GetId();
-      }
+   }
+   return kInvalidDescriptorId;
+}
+
+
+ROOT::Experimental::DescriptorId_t
+ROOT::Experimental::RNTupleDescriptor::FindColumnId(DescriptorId_t fieldId, std::uint32_t columnIndex)
+{
+   for (const auto &cd : fColumnDescriptors) {
+      if (cd.second.GetFieldId() == fieldId && cd.second.GetIndex() == columnIndex)
+        return cd.second.GetId();
    }
    return kInvalidDescriptorId;
 }

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -17,12 +17,153 @@
 #include <ROOT/RNTupleUtil.hxx>
 #include <ROOT/RStringView.hxx>
 
-void ROOT::Experimental::RNTupleDescriptorBuilder::SetNTuple(std::string_view name, const RNTupleVersion &version) {
-   fDescriptor.fName = std::string(name);
-   fDescriptor.fVersion = version;
+#include <TError.h>
+
+#include <cstring>
+
+namespace ROOT {
+namespace Experimental {
+
+namespace {
+
+std::uint32_t SerializeInt32(std::int32_t val, void* buffer) {
+   if (buffer != nullptr) {
+      auto bytes = reinterpret_cast<unsigned char *>(buffer);
+      bytes[0] = (val & 0x000000FF);
+      bytes[1] = (val & 0x0000FF00) >> 8;
+      bytes[2] = (val & 0x00FF0000) >> 16;
+      bytes[3] = (val & 0xFF000000) >> 24;
+   }
+   return sizeof(val);
 }
 
-void ROOT::Experimental::RNTupleDescriptorBuilder::AddField(
+
+std::uint32_t DeserializeInt32(void* buffer, std::int32_t *val) {
+   auto bytes = reinterpret_cast<unsigned char *>(buffer);
+   *val = bytes[0] + (bytes[1] << 8) + (bytes[2] << 16) + (bytes[3] << 24);
+   return sizeof(*val);
+}
+
+
+std::uint32_t SerializeString(const std::string &val, void* buffer) {
+   if (buffer != nullptr) {
+      auto pos = reinterpret_cast<unsigned char *>(buffer);
+      pos += SerializeInt32(val.length(), pos);
+      memcpy(pos, val.data(), val.length());
+   }
+   return SerializeInt32(val.length(), nullptr) + val.length();
+}
+
+std::uint32_t DeserializeString(void* buffer, std::string *val) {
+   auto base = reinterpret_cast<unsigned char *>(buffer);
+   auto bytes = base;
+   std::int32_t length;
+   bytes += DeserializeInt32(buffer, &length);
+   val->resize(length);
+   memcpy(&(*val)[0], bytes, length);
+   return bytes - base;
+}
+
+} // anonymous namespace
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+bool RFieldDescriptor::operator==(const RFieldDescriptor &other) const {
+   return fFieldId == other.fFieldId &&
+          fFieldVersion == other.fFieldVersion &&
+          fTypeVersion == other.fTypeVersion &&
+          fFieldName == other.fFieldName &&
+          fTypeName == other.fTypeName &&
+          fStructure == other.fStructure &&
+          fParentId == other.fParentId &&
+          fLinkIds == other.fLinkIds;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+bool RColumnDescriptor::operator==(const RColumnDescriptor &other) const {
+   return fColumnId == other.fColumnId &&
+          fVersion == other.fVersion &&
+          fModel == other.fModel &&
+          fFieldId == other.fFieldId &&
+          fOffsetId == other.fOffsetId &&
+          fLinkIds == other.fLinkIds;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+bool RClusterDescriptor::operator==(const RClusterDescriptor &other) const {
+   return fClusterId == other.fClusterId &&
+          fVersion == other.fVersion &&
+          fFirstEntryIndex == other.fFirstEntryIndex &&
+          fNEntries == other.fNEntries &&
+          fColumnRanges == other.fColumnRanges;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+bool RNTupleDescriptor::operator==(const RNTupleDescriptor &other) const {
+   return fName == other.fName &&
+          fVersion == other.fVersion &&
+          fOwnUuid == other.fOwnUuid &&
+          fGroupUuid == other.fGroupUuid &&
+          fFieldDescriptors == other.fFieldDescriptors &&
+          fColumnDescriptors == other.fColumnDescriptors &&
+          fClusterDescriptors == other.fClusterDescriptors;
+}
+
+
+std::uint32_t RNTupleDescriptor::SerializeHeader(void* buffer)
+{
+   if (buffer != nullptr) {
+      auto pos = reinterpret_cast<unsigned char *>(buffer);
+      pos += SerializeInt32(kByteProtocol, pos);
+      pos += SerializeString(fName, pos);
+   }
+   return SerializeInt32(kByteProtocol, nullptr) + SerializeString(fName, nullptr);
+}
+
+std::uint32_t RNTupleDescriptor::SerializeFooter(void* /*buffer*/)
+{
+   return 0;
+}
+
+RNTupleDescriptor RNTupleDescriptor::Deserialize(void* headerBuffer, void* /*footer*/)
+{
+   auto pos = reinterpret_cast<unsigned char *>(headerBuffer);
+   std::int32_t byteProtocol;
+   pos += DeserializeInt32(pos, &byteProtocol);
+   R__ASSERT(byteProtocol == 0);
+
+   RNTupleDescriptorBuilder descBuilder;
+   std::string name;
+   pos += DeserializeString(pos, &name);
+   descBuilder.SetNTuple(name, RNTupleVersion(), Uuid_t());
+   return descBuilder.GetDescriptor();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void RNTupleDescriptorBuilder::SetNTuple(
+   const std::string_view &name, const RNTupleVersion &version, const Uuid_t &uuid)
+{
+   fDescriptor.fName = std::string(name);
+   fDescriptor.fVersion = version;
+   fDescriptor.fOwnUuid = uuid;
+   fDescriptor.fGroupUuid = uuid;
+}
+
+void RNTupleDescriptorBuilder::AddField(
    DescriptorId_t fieldId, const RNTupleVersion &fieldVersion, const RNTupleVersion &typeVersion,
    std::string_view fieldName, std::string_view typeName, ENTupleStructure structure)
 {
@@ -36,17 +177,17 @@ void ROOT::Experimental::RNTupleDescriptorBuilder::AddField(
    fDescriptor.fFieldDescriptors[fieldId] = f;
 }
 
-void ROOT::Experimental::RNTupleDescriptorBuilder::SetFieldParent(DescriptorId_t fieldId, DescriptorId_t parentId)
+void RNTupleDescriptorBuilder::SetFieldParent(DescriptorId_t fieldId, DescriptorId_t parentId)
 {
    fDescriptor.fFieldDescriptors[fieldId].fParentId = parentId;
 }
 
-void ROOT::Experimental::RNTupleDescriptorBuilder::AddFieldLink(DescriptorId_t fieldId, DescriptorId_t linkId)
+void RNTupleDescriptorBuilder::AddFieldLink(DescriptorId_t fieldId, DescriptorId_t linkId)
 {
    fDescriptor.fFieldDescriptors[fieldId].fLinkIds.push_back(linkId);
 }
 
-void ROOT::Experimental::RNTupleDescriptorBuilder::AddColumn(
+void RNTupleDescriptorBuilder::AddColumn(
    DescriptorId_t columnId, DescriptorId_t fieldId, const RNTupleVersion &version, const RColumnModel &model)
 {
    RColumnDescriptor c;
@@ -57,17 +198,17 @@ void ROOT::Experimental::RNTupleDescriptorBuilder::AddColumn(
    fDescriptor.fColumnDescriptors[columnId] = c;
 }
 
-void ROOT::Experimental::RNTupleDescriptorBuilder::SetColumnOffset(DescriptorId_t columnId, DescriptorId_t offsetId)
+void RNTupleDescriptorBuilder::SetColumnOffset(DescriptorId_t columnId, DescriptorId_t offsetId)
 {
    fDescriptor.fColumnDescriptors[columnId].fOffsetId = offsetId;
 }
 
-void ROOT::Experimental::RNTupleDescriptorBuilder::AddColumnLink(DescriptorId_t columnId, DescriptorId_t linkId)
+void RNTupleDescriptorBuilder::AddColumnLink(DescriptorId_t columnId, DescriptorId_t linkId)
 {
    fDescriptor.fColumnDescriptors[columnId].fLinkIds.push_back(linkId);
 }
 
-void ROOT::Experimental::RNTupleDescriptorBuilder::AddCluster(
+void RNTupleDescriptorBuilder::AddCluster(
    DescriptorId_t clusterId, RNTupleVersion version, NTupleSize_t firstEntryIndex, ClusterSize_t nEntries)
 {
    RClusterDescriptor c;
@@ -78,9 +219,11 @@ void ROOT::Experimental::RNTupleDescriptorBuilder::AddCluster(
    fDescriptor.fClusterDescriptors[clusterId] = c;
 }
 
-void ROOT::Experimental::RNTupleDescriptorBuilder::AddClusterColumnInfo(
-   DescriptorId_t clusterId, const RClusterDescriptor::RColumnInfo &columnInfo)
+void RNTupleDescriptorBuilder::AddClusterColumnRange(
+   DescriptorId_t clusterId, const RClusterDescriptor::RColumnRange &columnRange)
 {
-   fDescriptor.fClusterDescriptors[clusterId].fColumnInfos[columnInfo.fColumnId] = columnInfo;
+   fDescriptor.fClusterDescriptors[clusterId].fColumnRanges[columnRange.fColumnId] = columnRange;
 }
 
+} // namespace Experimental
+} // namespace ROOT

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -312,7 +312,7 @@ std::uint32_t DeserializeColumnModel(const void *buffer, ROOT::Experimental::RCo
 
 std::uint32_t SerializeTimeStamp(const std::chrono::system_clock::time_point &val, void *buffer)
 {
-   return SerializeUInt64(std::chrono::system_clock::to_time_t(val), buffer);
+   return SerializeInt64(std::chrono::system_clock::to_time_t(val), buffer);
 }
 
 std::uint32_t DeserializeTimeStamp(const void *buffer, std::chrono::system_clock::time_point *timeStamp)

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -28,6 +28,22 @@
 
 namespace {
 
+/// The machine-independent serialization of meta-data wraps the header and footer as well as sub structures in
+/// frames.  The frame layout is
+///
+/// -----------------------------------------------------------
+/// |  TYPE           | DESCRIPTION                           |
+/// |----------------------------------------------------------
+/// | std::uint16_t   | Version used to write the frame       |
+/// | std::uint16_t   | Minimum version for reading the frame |
+/// | std::uint32_t   | Length of the frame incl. preamble    |
+/// -----------------------------------------------------------
+///
+/// In addition, the header and footer store a 4 byte CRC32 checksum of the frame immediately after the frame.
+/// Within the frames, integers of different lengths are stored in a machine-independent representation. Strings and
+/// vectors store the number of items followed by the items. Time stamps are stored in number of seconds since the
+/// UNIX epoch.
+
 std::uint32_t SerializeInt64(std::int64_t val, void *buffer)
 {
    if (buffer != nullptr) {

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -340,6 +340,19 @@ ROOT::Experimental::RNTupleDescriptor::FindColumnId(DescriptorId_t fieldId, std:
 }
 
 
+ROOT::Experimental::DescriptorId_t
+ROOT::Experimental::RNTupleDescriptor::FindClusterId(DescriptorId_t columnId, NTupleSize_t index) const
+{
+   // TODO(jblomer): binary search?
+   for (const auto &cd : fClusterDescriptors) {
+      auto columnRange = cd.second.GetColumnRange(columnId);
+      if (columnRange.Contains(index))
+         return cd.second.GetId();
+   }
+   return kInvalidDescriptorId;
+}
+
+
 std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleDescriptor::GenerateModel() const
 {
    auto model = std::make_unique<RNTupleModel>();

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -231,7 +231,7 @@ bool RNTupleDescriptor::operator==(const RNTupleDescriptor &other) const {
 }
 
 
-std::uint32_t RNTupleDescriptor::SerializeHeader(void* buffer)
+std::uint32_t RNTupleDescriptor::SerializeHeader(void* buffer) const
 {
    auto base = reinterpret_cast<unsigned char *>((buffer != nullptr) ? buffer : 0);
    auto pos = base;
@@ -259,7 +259,7 @@ std::uint32_t RNTupleDescriptor::SerializeHeader(void* buffer)
    return size;
 }
 
-std::uint32_t RNTupleDescriptor::SerializeFooter(void* buffer)
+std::uint32_t RNTupleDescriptor::SerializeFooter(void* buffer) const
 {
    auto base = reinterpret_cast<unsigned char *>((buffer != nullptr) ? buffer : 0);
    auto pos = base;
@@ -309,8 +309,8 @@ void RNTupleDescriptorBuilder::SetFromHeader(void* headerBuffer) {
    pos += DeserializeString(pos, &fDescriptor.fDescription);
    pos += DeserializeVersion(pos, &fDescriptor.fVersion);
    // TODO
-   fDescriptor.fOwnUuid = Uuid_t();
-   fDescriptor.fGroupUuid = Uuid_t();
+   fDescriptor.fOwnUuid = RNTupleUuid();
+   fDescriptor.fGroupUuid = RNTupleUuid();
 
    std::uint32_t nFields;
    pos += DeserializeUInt32(pos, &nFields);
@@ -402,9 +402,11 @@ void RNTupleDescriptorBuilder::AddClustersFromFooter(void* footerBuffer) {
 
 
 void RNTupleDescriptorBuilder::SetNTuple(
-   const std::string_view &name, const RNTupleVersion &version, const Uuid_t &uuid)
+   const std::string_view &name, const std::string_view &description, const RNTupleVersion &version,
+   const RNTupleUuid &uuid)
 {
    fDescriptor.fName = std::string(name);
+   fDescriptor.fDescription = std::string(description);
    fDescriptor.fVersion = version;
    fDescriptor.fOwnUuid = uuid;
    fDescriptor.fGroupUuid = uuid;

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -174,7 +174,6 @@ std::uint32_t SerializeColumn(const ROOT::Experimental::RColumnDescriptor &val, 
 
    pos += SerializeUInt64(val.GetId(), *where);
    pos += SerializeVersion(val.GetVersion(), *where);
-   pos += SerializeString(val.GetModel().GetName(), *where);
    pos += SerializeInt32(static_cast<int>(val.GetModel().GetType()), *where);
    pos += SerializeInt32(static_cast<int>(val.GetModel().GetIsSorted()), *where);
    pos += SerializeUInt32(val.GetIndex(), *where);
@@ -436,13 +435,11 @@ void ROOT::Experimental::RNTupleDescriptorBuilder::SetFromHeader(void* headerBuf
       RColumnDescriptor c;
       pos += DeserializeUInt64(pos, &c.fColumnId);
       pos += DeserializeVersion(pos, &c.fVersion);
-      std::string name;
       std::int32_t type;
       std::int32_t isSorted;
-      pos += DeserializeString(pos, &name);
       pos += DeserializeInt32(pos, &type);
       pos += DeserializeInt32(pos, &isSorted);
-      c.fModel = RColumnModel(name, static_cast<EColumnType>(type), isSorted);
+      c.fModel = RColumnModel(static_cast<EColumnType>(type), isSorted);
       pos += DeserializeUInt32(pos, &c.fIndex);
       pos += DeserializeUInt64(pos, &c.fFieldId);
       pos += DeserializeUInt64(pos, &c.fOffsetId);

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -14,6 +14,7 @@
  *************************************************************************/
 
 #include <ROOT/RNTupleDescriptor.hxx>
+#include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 #include <ROOT/RStringView.hxx>
 
@@ -329,13 +330,26 @@ ROOT::Experimental::RNTupleDescriptor::FindFieldId(std::string_view fieldName, D
 
 
 ROOT::Experimental::DescriptorId_t
-ROOT::Experimental::RNTupleDescriptor::FindColumnId(DescriptorId_t fieldId, std::uint32_t columnIndex)
+ROOT::Experimental::RNTupleDescriptor::FindColumnId(DescriptorId_t fieldId, std::uint32_t columnIndex) const
 {
    for (const auto &cd : fColumnDescriptors) {
       if (cd.second.GetFieldId() == fieldId && cd.second.GetIndex() == columnIndex)
         return cd.second.GetId();
    }
    return kInvalidDescriptorId;
+}
+
+
+std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleDescriptor::GenerateModel() const
+{
+   auto model = std::make_unique<RNTupleModel>();
+   for (const auto& fd : fFieldDescriptors) {
+      if (fd.second.GetParentId() != kInvalidDescriptorId)
+         continue;
+      auto field = Detail::RFieldBase::Create(fd.second.GetFieldName(), fd.second.GetTypeName());
+      model->AddField(std::unique_ptr<Detail::RFieldBase>(field));
+   }
+   return model;
 }
 
 

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -331,8 +331,9 @@ std::uint32_t SerializeColumnRange(const ROOT::Experimental::RClusterDescriptor:
       // The column id is stored in SerializeFooter() for the column range and the page range altogether
       pos += SerializeUInt64(val.fFirstElementIndex, pos);
       pos += SerializeClusterSize(val.fNElements, pos);
+      pos += SerializeInt64(val.fCompressionSettings, pos);
    }
-   return 12;
+   return 20;
 }
 
 std::uint32_t DeserializeColumnRange(const void *buffer,
@@ -342,7 +343,8 @@ std::uint32_t DeserializeColumnRange(const void *buffer,
    // The column id is set elsewhere (see AddClustersFromFooter())
    bytes += DeserializeUInt64(bytes, &columnRange->fFirstElementIndex);
    bytes += DeserializeClusterSize(bytes, &columnRange->fNElements);
-   return 12;
+   bytes += DeserializeInt64(bytes, &columnRange->fCompressionSettings);
+   return 20;
 }
 
 std::uint32_t SerializePageInfo(const ROOT::Experimental::RClusterDescriptor::RPageRange::RPageInfo &val, void *buffer)

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -144,6 +144,7 @@ std::uint32_t SerializeField(const RFieldDescriptor &val, void* buffer) {
    pos += SerializeVersion(val.GetFieldVersion(), *where);
    pos += SerializeVersion(val.GetTypeVersion(), *where);
    pos += SerializeString(val.GetFieldName(), *where);
+   pos += SerializeString(val.GetFieldDescription(), *where);
    pos += SerializeString(val.GetTypeName(), *where);
    pos += SerializeUInt32(static_cast<int>(val.GetStructure()), *where);
    pos += SerializeUInt64(val.GetParentId(), *where);
@@ -182,6 +183,7 @@ bool RFieldDescriptor::operator==(const RFieldDescriptor &other) const {
           fFieldVersion == other.fFieldVersion &&
           fTypeVersion == other.fTypeVersion &&
           fFieldName == other.fFieldName &&
+          fFieldDescription == other.fFieldDescription &&
           fTypeName == other.fTypeName &&
           fStructure == other.fStructure &&
           fParentId == other.fParentId &&
@@ -219,6 +221,7 @@ bool RClusterDescriptor::operator==(const RClusterDescriptor &other) const {
 
 bool RNTupleDescriptor::operator==(const RNTupleDescriptor &other) const {
    return fName == other.fName &&
+          fDescription == other.fDescription &&
           fVersion == other.fVersion &&
           fOwnUuid == other.fOwnUuid &&
           fGroupUuid == other.fGroupUuid &&
@@ -239,6 +242,7 @@ std::uint32_t RNTupleDescriptor::SerializeHeader(void* buffer)
    pos += SerializeUInt32(0, *where); // placeholder for the size
 
    pos += SerializeString(fName, *where);
+   pos += SerializeString(fDescription, *where);
    pos += SerializeVersion(fVersion, *where);
    pos += SerializeUInt32(fFieldDescriptors.size(), *where);
    for (const auto& f : fFieldDescriptors) {
@@ -302,6 +306,7 @@ void RNTupleDescriptorBuilder::SetFromHeader(void* headerBuffer) {
    // TODO: verify crc32
 
    pos += DeserializeString(pos, &fDescriptor.fName);
+   pos += DeserializeString(pos, &fDescriptor.fDescription);
    pos += DeserializeVersion(pos, &fDescriptor.fVersion);
    // TODO
    fDescriptor.fOwnUuid = Uuid_t();
@@ -315,6 +320,7 @@ void RNTupleDescriptorBuilder::SetFromHeader(void* headerBuffer) {
       pos += DeserializeVersion(pos, &f.fFieldVersion);
       pos += DeserializeVersion(pos, &f.fTypeVersion);
       pos += DeserializeString(pos, &f.fFieldName);
+      pos += DeserializeString(pos, &f.fFieldDescription);
       pos += DeserializeString(pos, &f.fTypeName);
       std::int32_t structure;
       pos += DeserializeInt32(pos, &structure);

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -20,6 +20,7 @@
 
 #include <TError.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <iostream>
@@ -317,6 +318,25 @@ std::uint32_t ROOT::Experimental::RNTupleDescriptor::SerializeFooter(void* buffe
    return size;
 }
 
+
+ROOT::Experimental::NTupleSize_t ROOT::Experimental::RNTupleDescriptor::GetNEntries() const
+{
+   NTupleSize_t result = 0;
+   for (const auto &cd : fClusterDescriptors) {
+      result = std::max(result, cd.second.GetFirstEntryIndex() + cd.second.GetNEntries());
+   }
+   return result;
+}
+
+ROOT::Experimental::NTupleSize_t ROOT::Experimental::RNTupleDescriptor::GetNElements(DescriptorId_t columnId) const
+{
+   NTupleSize_t result = 0;
+   for (const auto &cd : fClusterDescriptors) {
+      auto columnRange = cd.second.GetColumnRange(columnId);
+      result = std::max(result, columnRange.fFirstElementIndex + columnRange.fNElements);
+   }
+   return result;
+}
 
 ROOT::Experimental::DescriptorId_t
 ROOT::Experimental::RNTupleDescriptor::FindFieldId(std::string_view fieldName, DescriptorId_t parentId) const

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -13,6 +13,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+#include <ROOT/RField.hxx>
 #include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 #include <ROOT/RStringView.hxx>
@@ -23,12 +24,10 @@
 #include <cstring>
 #include <iostream>
 
-namespace ROOT {
-namespace Experimental {
-
 namespace {
 
-std::uint32_t SerializeInt64(std::int64_t val, void* buffer) {
+std::uint32_t SerializeInt64(std::int64_t val, void* buffer)
+{
    if (buffer != nullptr) {
       auto bytes = reinterpret_cast<unsigned char *>(buffer);
       bytes[0] = (val & 0x00000000000000FF);
@@ -44,12 +43,14 @@ std::uint32_t SerializeInt64(std::int64_t val, void* buffer) {
 }
 
 
-std::uint32_t SerializeUInt64(std::uint64_t val, void* buffer) {
+std::uint32_t SerializeUInt64(std::uint64_t val, void* buffer)
+{
    return SerializeInt64(val, buffer);
 }
 
 
-std::uint32_t DeserializeInt64(void* buffer, std::int64_t *val) {
+std::uint32_t DeserializeInt64(void* buffer, std::int64_t *val)
+{
    auto bytes = reinterpret_cast<unsigned char *>(buffer);
    *val = std::int64_t(bytes[0]) + (std::int64_t(bytes[1]) << 8) +
           (std::int64_t(bytes[2]) << 16) + (std::int64_t(bytes[3]) << 24) +
@@ -59,12 +60,14 @@ std::uint32_t DeserializeInt64(void* buffer, std::int64_t *val) {
 }
 
 
-std::uint32_t DeserializeUInt64(void* buffer, std::uint64_t *val) {
+std::uint32_t DeserializeUInt64(void* buffer, std::uint64_t *val)
+{
    return DeserializeInt64(buffer, reinterpret_cast<std::int64_t*>(val));
 }
 
 
-std::uint32_t SerializeInt32(std::int32_t val, void* buffer) {
+std::uint32_t SerializeInt32(std::int32_t val, void* buffer)
+{
    if (buffer != nullptr) {
       auto bytes = reinterpret_cast<unsigned char *>(buffer);
       bytes[0] = (val & 0x000000FF);
@@ -76,12 +79,14 @@ std::uint32_t SerializeInt32(std::int32_t val, void* buffer) {
 }
 
 
-std::uint32_t SerializeUInt32(std::uint32_t val, void* buffer) {
+std::uint32_t SerializeUInt32(std::uint32_t val, void* buffer)
+{
    return SerializeInt32(val, buffer);
 }
 
 
-std::uint32_t DeserializeInt32(void* buffer, std::int32_t *val) {
+std::uint32_t DeserializeInt32(void* buffer, std::int32_t *val)
+{
    auto bytes = reinterpret_cast<unsigned char *>(buffer);
    *val = std::int32_t(bytes[0]) + (std::int32_t(bytes[1]) << 8) +
           (std::int32_t(bytes[2]) << 16) + (std::int32_t(bytes[3]) << 24);
@@ -89,12 +94,14 @@ std::uint32_t DeserializeInt32(void* buffer, std::int32_t *val) {
 }
 
 
-std::uint32_t DeserializeUInt32(void* buffer, std::uint32_t *val) {
+std::uint32_t DeserializeUInt32(void* buffer, std::uint32_t *val)
+{
    return DeserializeInt32(buffer, reinterpret_cast<std::int32_t*>(val));
 }
 
 
-std::uint32_t SerializeString(const std::string &val, void* buffer) {
+std::uint32_t SerializeString(const std::string &val, void* buffer)
+{
    if (buffer != nullptr) {
       auto pos = reinterpret_cast<unsigned char *>(buffer);
       pos += SerializeUInt32(val.length(), pos);
@@ -103,7 +110,8 @@ std::uint32_t SerializeString(const std::string &val, void* buffer) {
    return SerializeUInt32(val.length(), nullptr) + val.length();
 }
 
-std::uint32_t DeserializeString(void* buffer, std::string *val) {
+std::uint32_t DeserializeString(void* buffer, std::string *val)
+{
    auto base = reinterpret_cast<unsigned char *>(buffer);
    auto bytes = base;
    std::uint32_t length;
@@ -113,7 +121,8 @@ std::uint32_t DeserializeString(void* buffer, std::string *val) {
    return bytes + length - base;
 }
 
-std::uint32_t SerializeVersion(const RNTupleVersion &val, void* buffer) {
+std::uint32_t SerializeVersion(const ROOT::Experimental::RNTupleVersion &val, void* buffer)
+{
    if (buffer != nullptr) {
       auto pos = reinterpret_cast<unsigned char *>(buffer);
       pos += SerializeUInt32(val.GetVersionUse(), pos);
@@ -123,7 +132,8 @@ std::uint32_t SerializeVersion(const RNTupleVersion &val, void* buffer) {
    return 16;
 }
 
-std::uint32_t DeserializeVersion(void* buffer, RNTupleVersion *version) {
+std::uint32_t DeserializeVersion(void* buffer, ROOT::Experimental::RNTupleVersion *version)
+{
    auto bytes = reinterpret_cast<unsigned char *>(buffer);
    std::uint32_t versionUse;
    std::uint32_t versionMin;
@@ -131,11 +141,12 @@ std::uint32_t DeserializeVersion(void* buffer, RNTupleVersion *version) {
    bytes += DeserializeUInt32(bytes, &versionUse);
    bytes += DeserializeUInt32(bytes, &versionMin);
    bytes += DeserializeUInt64(bytes, &flags);
-   *version = RNTupleVersion(versionUse, versionMin, flags);
+   *version = ROOT::Experimental::RNTupleVersion(versionUse, versionMin, flags);
    return 16;
 }
 
-std::uint32_t SerializeField(const RFieldDescriptor &val, void* buffer) {
+std::uint32_t SerializeField(const ROOT::Experimental::RFieldDescriptor &val, void* buffer)
+{
    auto base = reinterpret_cast<unsigned char *>((buffer != nullptr) ? buffer : 0);
    auto pos = base;
    void** where = (buffer == nullptr) ? &buffer : reinterpret_cast<void**>(&pos);
@@ -154,7 +165,8 @@ std::uint32_t SerializeField(const RFieldDescriptor &val, void* buffer) {
    return pos - base;
 }
 
-std::uint32_t SerializeColumn(const RColumnDescriptor &val, void* buffer) {
+std::uint32_t SerializeColumn(const ROOT::Experimental::RColumnDescriptor &val, void* buffer)
+{
    auto base = reinterpret_cast<unsigned char *>((buffer != nullptr) ? buffer : 0);
    auto pos = base;
    void** where = (buffer == nullptr) ? &buffer : reinterpret_cast<void**>(&pos);
@@ -179,7 +191,7 @@ std::uint32_t SerializeColumn(const RColumnDescriptor &val, void* buffer) {
 ////////////////////////////////////////////////////////////////////////////////
 
 
-bool RFieldDescriptor::operator==(const RFieldDescriptor &other) const {
+bool ROOT::Experimental::RFieldDescriptor::operator==(const RFieldDescriptor &other) const {
    return fFieldId == other.fFieldId &&
           fFieldVersion == other.fFieldVersion &&
           fTypeVersion == other.fTypeVersion &&
@@ -195,7 +207,7 @@ bool RFieldDescriptor::operator==(const RFieldDescriptor &other) const {
 ////////////////////////////////////////////////////////////////////////////////
 
 
-bool RColumnDescriptor::operator==(const RColumnDescriptor &other) const {
+bool ROOT::Experimental::RColumnDescriptor::operator==(const RColumnDescriptor &other) const {
    return fColumnId == other.fColumnId &&
           fVersion == other.fVersion &&
           fModel == other.fModel &&
@@ -209,7 +221,7 @@ bool RColumnDescriptor::operator==(const RColumnDescriptor &other) const {
 ////////////////////////////////////////////////////////////////////////////////
 
 
-bool RClusterDescriptor::operator==(const RClusterDescriptor &other) const {
+bool ROOT::Experimental::RClusterDescriptor::operator==(const RClusterDescriptor &other) const {
    return fClusterId == other.fClusterId &&
           fVersion == other.fVersion &&
           fFirstEntryIndex == other.fFirstEntryIndex &&
@@ -222,7 +234,7 @@ bool RClusterDescriptor::operator==(const RClusterDescriptor &other) const {
 ////////////////////////////////////////////////////////////////////////////////
 
 
-bool RNTupleDescriptor::operator==(const RNTupleDescriptor &other) const {
+bool ROOT::Experimental::RNTupleDescriptor::operator==(const RNTupleDescriptor &other) const {
    return fName == other.fName &&
           fDescription == other.fDescription &&
           fVersion == other.fVersion &&
@@ -234,7 +246,7 @@ bool RNTupleDescriptor::operator==(const RNTupleDescriptor &other) const {
 }
 
 
-std::uint32_t RNTupleDescriptor::SerializeHeader(void* buffer) const
+std::uint32_t ROOT::Experimental::RNTupleDescriptor::SerializeHeader(void* buffer) const
 {
    auto base = reinterpret_cast<unsigned char *>((buffer != nullptr) ? buffer : 0);
    auto pos = base;
@@ -262,7 +274,7 @@ std::uint32_t RNTupleDescriptor::SerializeHeader(void* buffer) const
    return size;
 }
 
-std::uint32_t RNTupleDescriptor::SerializeFooter(void* buffer) const
+std::uint32_t ROOT::Experimental::RNTupleDescriptor::SerializeFooter(void* buffer) const
 {
    auto base = reinterpret_cast<unsigned char *>((buffer != nullptr) ? buffer : 0);
    auto pos = base;
@@ -306,10 +318,27 @@ std::uint32_t RNTupleDescriptor::SerializeFooter(void* buffer) const
 }
 
 
+ROOT::Experimental::DescriptorId_t
+ROOT::Experimental::RNTupleDescriptor::FindFieldId(const Detail::RFieldBase &field) const
+{
+   DescriptorId_t parentId = kInvalidDescriptorId;
+   if (field.GetParent() != nullptr)
+      parentId = FindFieldId(*field.GetParent());
+   for (const auto &fd : fFieldDescriptors) {
+      if (fd.second.GetParentId() == parentId &&
+          fd.second.GetFieldName() == Detail::RFieldBase::GetLeafName(field.GetName()))
+      {
+         return fd.second.GetId();
+      }
+   }
+   return kInvalidDescriptorId;
+}
+
+
 ////////////////////////////////////////////////////////////////////////////////
 
 
-void RNTupleDescriptorBuilder::SetFromHeader(void* headerBuffer) {
+void ROOT::Experimental::RNTupleDescriptorBuilder::SetFromHeader(void* headerBuffer) {
    auto pos = reinterpret_cast<unsigned char *>(headerBuffer);
    std::uint32_t byteProtocol;
    pos += DeserializeUInt32(pos, &byteProtocol);
@@ -379,7 +408,7 @@ void RNTupleDescriptorBuilder::SetFromHeader(void* headerBuffer) {
 }
 
 
-void RNTupleDescriptorBuilder::AddClustersFromFooter(void* footerBuffer) {
+void ROOT::Experimental::RNTupleDescriptorBuilder::AddClustersFromFooter(void* footerBuffer) {
    auto pos = reinterpret_cast<unsigned char *>(footerBuffer);
    std::uint32_t byteProtocol;
    pos += DeserializeUInt32(pos, &byteProtocol);
@@ -430,7 +459,7 @@ void RNTupleDescriptorBuilder::AddClustersFromFooter(void* footerBuffer) {
 }
 
 
-void RNTupleDescriptorBuilder::SetNTuple(
+void ROOT::Experimental::RNTupleDescriptorBuilder::SetNTuple(
    const std::string_view &name, const std::string_view &description, const RNTupleVersion &version,
    const RNTupleUuid &uuid)
 {
@@ -441,7 +470,7 @@ void RNTupleDescriptorBuilder::SetNTuple(
    fDescriptor.fGroupUuid = uuid;
 }
 
-void RNTupleDescriptorBuilder::AddField(
+void ROOT::Experimental::RNTupleDescriptorBuilder::AddField(
    DescriptorId_t fieldId, const RNTupleVersion &fieldVersion, const RNTupleVersion &typeVersion,
    std::string_view fieldName, std::string_view typeName, ENTupleStructure structure)
 {
@@ -455,38 +484,40 @@ void RNTupleDescriptorBuilder::AddField(
    fDescriptor.fFieldDescriptors[fieldId] = f;
 }
 
-void RNTupleDescriptorBuilder::SetFieldParent(DescriptorId_t fieldId, DescriptorId_t parentId)
+void ROOT::Experimental::RNTupleDescriptorBuilder::SetFieldParent(DescriptorId_t fieldId, DescriptorId_t parentId)
 {
    fDescriptor.fFieldDescriptors[fieldId].fParentId = parentId;
 }
 
-void RNTupleDescriptorBuilder::AddFieldLink(DescriptorId_t fieldId, DescriptorId_t linkId)
+void ROOT::Experimental::RNTupleDescriptorBuilder::AddFieldLink(DescriptorId_t fieldId, DescriptorId_t linkId)
 {
    fDescriptor.fFieldDescriptors[fieldId].fLinkIds.push_back(linkId);
 }
 
-void RNTupleDescriptorBuilder::AddColumn(
-   DescriptorId_t columnId, DescriptorId_t fieldId, const RNTupleVersion &version, const RColumnModel &model)
+void ROOT::Experimental::RNTupleDescriptorBuilder::AddColumn(
+   DescriptorId_t columnId, DescriptorId_t fieldId, const RNTupleVersion &version, const RColumnModel &model,
+   std::uint32_t index)
 {
    RColumnDescriptor c;
    c.fColumnId = columnId;
    c.fFieldId = fieldId;
    c.fVersion = version;
    c.fModel = model;
+   c.fIndex = index;
    fDescriptor.fColumnDescriptors[columnId] = c;
 }
 
-void RNTupleDescriptorBuilder::SetColumnOffset(DescriptorId_t columnId, DescriptorId_t offsetId)
+void ROOT::Experimental::RNTupleDescriptorBuilder::SetColumnOffset(DescriptorId_t columnId, DescriptorId_t offsetId)
 {
    fDescriptor.fColumnDescriptors[columnId].fOffsetId = offsetId;
 }
 
-void RNTupleDescriptorBuilder::AddColumnLink(DescriptorId_t columnId, DescriptorId_t linkId)
+void ROOT::Experimental::RNTupleDescriptorBuilder::AddColumnLink(DescriptorId_t columnId, DescriptorId_t linkId)
 {
    fDescriptor.fColumnDescriptors[columnId].fLinkIds.push_back(linkId);
 }
 
-void RNTupleDescriptorBuilder::AddCluster(
+void ROOT::Experimental::RNTupleDescriptorBuilder::AddCluster(
    DescriptorId_t clusterId, RNTupleVersion version, NTupleSize_t firstEntryIndex, ClusterSize_t nEntries)
 {
    RClusterDescriptor c;
@@ -497,17 +528,14 @@ void RNTupleDescriptorBuilder::AddCluster(
    fDescriptor.fClusterDescriptors[clusterId] = c;
 }
 
-void RNTupleDescriptorBuilder::AddClusterColumnRange(
+void ROOT::Experimental::RNTupleDescriptorBuilder::AddClusterColumnRange(
    DescriptorId_t clusterId, const RClusterDescriptor::RColumnRange &columnRange)
 {
    fDescriptor.fClusterDescriptors[clusterId].fColumnRanges[columnRange.fColumnId] = columnRange;
 }
 
-void RNTupleDescriptorBuilder::AddClusterPageRange(
+void ROOT::Experimental::RNTupleDescriptorBuilder::AddClusterPageRange(
    DescriptorId_t clusterId, const RClusterDescriptor::RPageRange &pageRange)
 {
    fDescriptor.fClusterDescriptors[clusterId].fPageRanges[pageRange.fColumnId] = pageRange;
 }
-
-} // namespace Experimental
-} // namespace ROOT

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -19,12 +19,50 @@
 
 #include <TError.h>
 
+#include <cstdint>
 #include <cstring>
+#include <iostream>
 
 namespace ROOT {
 namespace Experimental {
 
 namespace {
+
+std::uint32_t SerializeInt64(std::int64_t val, void* buffer) {
+   if (buffer != nullptr) {
+      auto bytes = reinterpret_cast<unsigned char *>(buffer);
+      bytes[0] = (val & 0x00000000000000FF);
+      bytes[1] = (val & 0x000000000000FF00) >> 8;
+      bytes[2] = (val & 0x0000000000FF0000) >> 16;
+      bytes[3] = (val & 0x00000000FF000000) >> 24;
+      bytes[4] = (val & 0x000000FF00000000) >> 32;
+      bytes[5] = (val & 0x0000FF0000000000) >> 40;
+      bytes[6] = (val & 0x00FF000000000000) >> 48;
+      bytes[7] = (val & 0xFF00000000000000) >> 56;
+   }
+   return 8;
+}
+
+
+std::uint32_t SerializeUInt64(std::uint64_t val, void* buffer) {
+   return SerializeInt64(val, buffer);
+}
+
+
+std::uint32_t DeserializeInt64(void* buffer, std::int64_t *val) {
+   auto bytes = reinterpret_cast<unsigned char *>(buffer);
+   *val = std::int64_t(bytes[0]) + (std::int64_t(bytes[1]) << 8) +
+          (std::int64_t(bytes[2]) << 16) + (std::int64_t(bytes[3]) << 24) +
+          (std::int64_t(bytes[4]) << 32) + (std::int64_t(bytes[5]) << 40) +
+          (std::int64_t(bytes[6]) << 48) + (std::int64_t(bytes[7]) << 56);
+   return 8;
+}
+
+
+std::uint32_t DeserializeUInt64(void* buffer, std::uint64_t *val) {
+   return DeserializeInt64(buffer, reinterpret_cast<std::int64_t*>(val));
+}
+
 
 std::uint32_t SerializeInt32(std::int32_t val, void* buffer) {
    if (buffer != nullptr) {
@@ -34,34 +72,103 @@ std::uint32_t SerializeInt32(std::int32_t val, void* buffer) {
       bytes[2] = (val & 0x00FF0000) >> 16;
       bytes[3] = (val & 0xFF000000) >> 24;
    }
-   return sizeof(val);
+   return 4;
+}
+
+
+std::uint32_t SerializeUInt32(std::uint32_t val, void* buffer) {
+   return SerializeInt32(val, buffer);
 }
 
 
 std::uint32_t DeserializeInt32(void* buffer, std::int32_t *val) {
    auto bytes = reinterpret_cast<unsigned char *>(buffer);
-   *val = bytes[0] + (bytes[1] << 8) + (bytes[2] << 16) + (bytes[3] << 24);
-   return sizeof(*val);
+   *val = std::int32_t(bytes[0]) + (std::int32_t(bytes[1]) << 8) +
+          (std::int32_t(bytes[2]) << 16) + (std::int32_t(bytes[3]) << 24);
+   return 4;
+}
+
+
+std::uint32_t DeserializeUInt32(void* buffer, std::uint32_t *val) {
+   return DeserializeInt32(buffer, reinterpret_cast<std::int32_t*>(val));
 }
 
 
 std::uint32_t SerializeString(const std::string &val, void* buffer) {
    if (buffer != nullptr) {
       auto pos = reinterpret_cast<unsigned char *>(buffer);
-      pos += SerializeInt32(val.length(), pos);
+      pos += SerializeUInt32(val.length(), pos);
       memcpy(pos, val.data(), val.length());
    }
-   return SerializeInt32(val.length(), nullptr) + val.length();
+   return SerializeUInt32(val.length(), nullptr) + val.length();
 }
 
 std::uint32_t DeserializeString(void* buffer, std::string *val) {
    auto base = reinterpret_cast<unsigned char *>(buffer);
    auto bytes = base;
-   std::int32_t length;
-   bytes += DeserializeInt32(buffer, &length);
+   std::uint32_t length;
+   bytes += DeserializeUInt32(buffer, &length);
    val->resize(length);
    memcpy(&(*val)[0], bytes, length);
-   return bytes - base;
+   return bytes + length - base;
+}
+
+std::uint32_t SerializeVersion(const RNTupleVersion &val, void* buffer) {
+   if (buffer != nullptr) {
+      auto pos = reinterpret_cast<unsigned char *>(buffer);
+      pos += SerializeUInt32(val.GetVersionUse(), pos);
+      pos += SerializeUInt32(val.GetVersionMin(), pos);
+      pos += SerializeUInt64(val.GetFlags(), pos);
+   }
+   return 16;
+}
+
+std::uint32_t DeserializeVersion(void* buffer, RNTupleVersion *version) {
+   auto bytes = reinterpret_cast<unsigned char *>(buffer);
+   std::uint32_t versionUse;
+   std::uint32_t versionMin;
+   std::uint64_t flags;
+   bytes += DeserializeUInt32(bytes, &versionUse);
+   bytes += DeserializeUInt32(bytes, &versionMin);
+   bytes += DeserializeUInt64(bytes, &flags);
+   *version = RNTupleVersion(versionUse, versionMin, flags);
+   return 16;
+}
+
+std::uint32_t SerializeField(const RFieldDescriptor &val, void* buffer) {
+   auto base = reinterpret_cast<unsigned char *>((buffer != nullptr) ? buffer : 0);
+   auto pos = base;
+   void** where = (buffer == nullptr) ? &buffer : reinterpret_cast<void**>(&pos);
+
+   pos += SerializeUInt64(val.GetId(), *where);
+   pos += SerializeVersion(val.GetFieldVersion(), *where);
+   pos += SerializeVersion(val.GetTypeVersion(), *where);
+   pos += SerializeString(val.GetFieldName(), *where);
+   pos += SerializeString(val.GetTypeName(), *where);
+   pos += SerializeUInt32(static_cast<int>(val.GetStructure()), *where);
+   pos += SerializeUInt64(val.GetParentId(), *where);
+   pos += SerializeUInt32(val.GetLinkIds().size(), *where);
+   for (const auto& l : val.GetLinkIds())
+      pos += SerializeUInt64(l, *where);
+   return pos - base;
+}
+
+std::uint32_t SerializeColumn(const RColumnDescriptor &val, void* buffer) {
+   auto base = reinterpret_cast<unsigned char *>((buffer != nullptr) ? buffer : 0);
+   auto pos = base;
+   void** where = (buffer == nullptr) ? &buffer : reinterpret_cast<void**>(&pos);
+
+   pos += SerializeUInt64(val.GetId(), *where);
+   pos += SerializeVersion(val.GetVersion(), *where);
+   pos += SerializeString(val.GetModel().GetName(), *where);
+   pos += SerializeInt32(static_cast<int>(val.GetModel().GetType()), *where);
+   pos += SerializeInt32(static_cast<int>(val.GetModel().GetIsSorted()), *where);
+   pos += SerializeUInt64(val.GetFieldId(), *where);
+   pos += SerializeUInt64(val.GetOffsetId(), *where);
+   pos += SerializeUInt32(val.GetLinkIds().size(), *where);
+   for (const auto& l : val.GetLinkIds())
+      pos += SerializeUInt64(l, *where);
+   return pos - base;
 }
 
 } // anonymous namespace
@@ -123,35 +230,169 @@ bool RNTupleDescriptor::operator==(const RNTupleDescriptor &other) const {
 
 std::uint32_t RNTupleDescriptor::SerializeHeader(void* buffer)
 {
-   if (buffer != nullptr) {
-      auto pos = reinterpret_cast<unsigned char *>(buffer);
-      pos += SerializeInt32(kByteProtocol, pos);
-      pos += SerializeString(fName, pos);
+   auto base = reinterpret_cast<unsigned char *>((buffer != nullptr) ? buffer : 0);
+   auto pos = base;
+   void** where = (buffer == nullptr) ? &buffer : reinterpret_cast<void**>(&pos);
+
+   pos += SerializeUInt32(kByteProtocol, *where);
+   void *ptrSize = *where;
+   pos += SerializeUInt32(0, *where); // placeholder for the size
+
+   pos += SerializeString(fName, *where);
+   pos += SerializeVersion(fVersion, *where);
+   pos += SerializeUInt32(fFieldDescriptors.size(), *where);
+   for (const auto& f : fFieldDescriptors) {
+      pos += SerializeField(f.second, *where);
    }
-   return SerializeInt32(kByteProtocol, nullptr) + SerializeString(fName, nullptr);
+   pos += SerializeUInt32(fColumnDescriptors.size(), *where);
+   for (const auto& c : fColumnDescriptors) {
+      pos += SerializeColumn(c.second, *where);
+   }
+
+   pos += SerializeUInt32(0 /* TODO CRC32 */, *where);
+   std::uint32_t size = pos - base;
+   SerializeUInt32(size, ptrSize);
+   return size;
 }
 
-std::uint32_t RNTupleDescriptor::SerializeFooter(void* /*buffer*/)
+std::uint32_t RNTupleDescriptor::SerializeFooter(void* buffer)
 {
-   return 0;
-}
+   auto base = reinterpret_cast<unsigned char *>((buffer != nullptr) ? buffer : 0);
+   auto pos = base;
+   void** where = (buffer == nullptr) ? &buffer : reinterpret_cast<void**>(&pos);
 
-RNTupleDescriptor RNTupleDescriptor::Deserialize(void* headerBuffer, void* /*footer*/)
-{
-   auto pos = reinterpret_cast<unsigned char *>(headerBuffer);
-   std::int32_t byteProtocol;
-   pos += DeserializeInt32(pos, &byteProtocol);
-   R__ASSERT(byteProtocol == 0);
+   pos += SerializeUInt32(kByteProtocol, *where);
+   void *ptrSize = *where;
+   pos += SerializeUInt32(0, *where); // placeholder for the size
 
-   RNTupleDescriptorBuilder descBuilder;
-   std::string name;
-   pos += DeserializeString(pos, &name);
-   descBuilder.SetNTuple(name, RNTupleVersion(), Uuid_t());
-   return descBuilder.GetDescriptor();
+   // TODO UUid again
+   pos += SerializeUInt64(fClusterDescriptors.size(), *where);
+   for (const auto& cluster : fClusterDescriptors) {
+      pos += SerializeUInt64(cluster.second.GetId(), *where);
+      pos += SerializeVersion(cluster.second.GetVersion(), *where);
+      pos += SerializeUInt64(cluster.second.GetFirstEntryIndex(), *where);
+      pos += SerializeUInt64(cluster.second.GetNEntries(), *where);
+      pos += SerializeUInt32(fColumnDescriptors.size(), *where);
+      for (const auto& column : fColumnDescriptors) {
+         auto range = cluster.second.GetColumnRanges(column.first);
+         R__ASSERT(range.fColumnId == column.first);
+         pos += SerializeUInt64(range.fColumnId, *where);
+         pos += SerializeUInt64(range.fFirstElementIndex, *where);
+         pos += SerializeUInt64(range.fNElements, *where);
+      }
+   }
+
+   pos += SerializeUInt32(0 /* TODO CRC32 */, *where);
+   std::uint32_t size = pos - base;
+   SerializeUInt32(size, ptrSize);
+   return size;
 }
 
 
 ////////////////////////////////////////////////////////////////////////////////
+
+
+void RNTupleDescriptorBuilder::SetFromHeader(void* headerBuffer) {
+   auto pos = reinterpret_cast<unsigned char *>(headerBuffer);
+   std::uint32_t byteProtocol;
+   pos += DeserializeUInt32(pos, &byteProtocol);
+   R__ASSERT(byteProtocol == 0);
+   std::uint32_t size;
+   pos += DeserializeUInt32(pos, &size);
+   // TODO: verify crc32
+
+   pos += DeserializeString(pos, &fDescriptor.fName);
+   pos += DeserializeVersion(pos, &fDescriptor.fVersion);
+   // TODO
+   fDescriptor.fOwnUuid = Uuid_t();
+   fDescriptor.fGroupUuid = Uuid_t();
+
+   std::uint32_t nFields;
+   pos += DeserializeUInt32(pos, &nFields);
+   for (std::uint32_t i = 0; i < nFields; ++i) {
+      RFieldDescriptor f;
+      pos += DeserializeUInt64(pos, &f.fFieldId);
+      pos += DeserializeVersion(pos, &f.fFieldVersion);
+      pos += DeserializeVersion(pos, &f.fTypeVersion);
+      pos += DeserializeString(pos, &f.fFieldName);
+      pos += DeserializeString(pos, &f.fTypeName);
+      std::int32_t structure;
+      pos += DeserializeInt32(pos, &structure);
+      f.fStructure = static_cast<ENTupleStructure>(structure);
+      pos += DeserializeUInt64(pos, &f.fParentId);
+
+      std::uint32_t nLinks;
+      pos += DeserializeUInt32(pos, &nLinks);
+      f.fLinkIds.resize(nLinks);
+      for (std::uint32_t j = 0; j < nLinks; ++j) {
+         pos += DeserializeUInt64(pos, &f.fLinkIds[j]);
+      }
+
+      fDescriptor.fFieldDescriptors[f.fFieldId] = f;
+   }
+
+   std::uint32_t nColumns;
+   pos += DeserializeUInt32(pos, &nColumns);
+   for (std::uint32_t i = 0; i < nColumns; ++i) {
+      RColumnDescriptor c;
+      pos += DeserializeUInt64(pos, &c.fColumnId);
+      pos += DeserializeVersion(pos, &c.fVersion);
+      std::string name;
+      std::int32_t type;
+      std::int32_t isSorted;
+      pos += DeserializeString(pos, &name);
+      pos += DeserializeInt32(pos, &type);
+      pos += DeserializeInt32(pos, &isSorted);
+      c.fModel = RColumnModel(name, static_cast<EColumnType>(type), isSorted);
+      pos += DeserializeUInt64(pos, &c.fFieldId);
+      pos += DeserializeUInt64(pos, &c.fOffsetId);
+
+      std::uint32_t nLinks;
+      pos += DeserializeUInt32(pos, &nLinks);
+      c.fLinkIds.resize(nLinks);
+      for (std::uint32_t j = 0; j < nLinks; ++j) {
+         pos += DeserializeUInt64(pos, &c.fLinkIds[j]);
+      }
+
+      fDescriptor.fColumnDescriptors[c.fColumnId] = c;
+   }
+}
+
+
+void RNTupleDescriptorBuilder::AddClustersFromFooter(void* footerBuffer) {
+   auto pos = reinterpret_cast<unsigned char *>(footerBuffer);
+   std::uint32_t byteProtocol;
+   pos += DeserializeUInt32(pos, &byteProtocol);
+   R__ASSERT(byteProtocol == 0);
+   std::uint32_t size;
+   pos += DeserializeUInt32(pos, &size);
+   // TODO: verify crc32
+
+   std::uint64_t nClusters;
+   pos += DeserializeUInt64(pos, &nClusters);
+   for (std::uint64_t i = 0; i < nClusters; ++i) {
+      std::uint64_t clusterId;
+      RNTupleVersion version;
+      std::uint64_t firstEntry;
+      std::uint64_t nEntries;
+      pos += DeserializeUInt64(pos, &clusterId);
+      pos += DeserializeVersion(pos, &version);
+      pos += DeserializeUInt64(pos, &firstEntry);
+      pos += DeserializeUInt64(pos, &nEntries);
+      AddCluster(clusterId, version, firstEntry, ROOT::Experimental::ClusterSize_t(nEntries));
+      std::uint32_t nColumns;
+      pos += DeserializeUInt32(pos, &nColumns);
+      for (std::uint32_t j = 0; j < nColumns; ++j) {
+         RClusterDescriptor::RColumnRange range;
+         uint64_t nElements;
+         pos += DeserializeUInt64(pos, &range.fColumnId);
+         pos += DeserializeUInt64(pos, &range.fFirstElementIndex);
+         pos += DeserializeUInt64(pos, &nElements);
+         range.fNElements = nElements;
+         AddClusterColumnRange(clusterId, range);
+      }
+   }
+}
 
 
 void RNTupleDescriptorBuilder::SetNTuple(

--- a/tree/ntuple/v7/src/RPageStorageRoot.cxx
+++ b/tree/ntuple/v7/src/RPageStorageRoot.cxx
@@ -90,12 +90,13 @@ void ROOT::Experimental::Detail::RPageSinkRoot::Create(RNTupleModel &model)
    fDirectory->SetBit(TDirectoryFile::kCustomBrowse);
    fDirectory->SetTitle("ROOT::Experimental::Detail::RNTupleBrowser");
 
-   fDescriptorBuilder.SetNTuple(fNTupleName, model.GetDescription(), model.GetVersion(), model.GetUuid());
+   fDescriptorBuilder.SetNTuple(fNTupleName, model.GetDescription(), "undefined author",
+                                model.GetVersion(), model.GetUuid());
 
    std::unordered_map<const RFieldBase *, DescriptorId_t> fieldPtr2Id; // necessary to find parent field ids
    for (auto& f : *model.GetRootField()) {
       fDescriptorBuilder.AddField(fLastFieldId, f.GetFieldVersion(), f.GetTypeVersion(), f.GetName(), f.GetType(),
-                                  f.GetStructure());
+                                  0 /* TODO(jblomer) */, f.GetStructure());
       if (f.GetParent() != model.GetRootField()) {
          fDescriptorBuilder.SetFieldParent(fLastFieldId, fieldPtr2Id[f.GetParent()]);
       }

--- a/tree/ntuple/v7/src/RPageStorageRoot.cxx
+++ b/tree/ntuple/v7/src/RPageStorageRoot.cxx
@@ -94,8 +94,8 @@ void ROOT::Experimental::Detail::RPageSinkRoot::Create(RNTupleModel &model)
 
    std::unordered_map<const RFieldBase *, DescriptorId_t> fieldPtr2Id; // necessary to find parent field ids
    for (auto& f : *model.GetRootField()) {
-      fDescriptorBuilder.AddField(fLastFieldId, f.GetFieldVersion(), f.GetTypeVersion(),
-                                  RFieldBase::GetLeafName(f.GetName()), f.GetType(), f.GetStructure());
+      fDescriptorBuilder.AddField(fLastFieldId, f.GetFieldVersion(), f.GetTypeVersion(), f.GetName(), f.GetType(),
+                                  f.GetStructure());
       if (f.GetParent() != model.GetRootField()) {
          fDescriptorBuilder.SetFieldParent(fLastFieldId, fieldPtr2Id[f.GetParent()]);
       }

--- a/tree/ntuple/v7/src/RPageStorageRoot.cxx
+++ b/tree/ntuple/v7/src/RPageStorageRoot.cxx
@@ -139,7 +139,7 @@ void ROOT::Experimental::Detail::RPageSinkRoot::CommitPage(ColumnHandle_t column
    fOpenColumnRanges[columnId].fNElements += page.GetNElements();
    RClusterDescriptor::RPageRange::RPageInfo pageInfo;
    pageInfo.fNElements = page.GetNElements();
-   pageInfo.fLocator = fLastPageIdx++;
+   pageInfo.fLocator.fPosition = fLastPageIdx++;
    fOpenPageRanges[columnId].fPageInfos.emplace_back(pageInfo);
 }
 
@@ -319,7 +319,7 @@ ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceRoot::P
 
    std::string keyName = std::string(kKeyPagePayload) +
       std::to_string(clusterId) + kKeySeparator +
-      std::to_string(pageInfo.fLocator);
+      std::to_string(pageInfo.fLocator.fPosition);
    auto pageKey = fDirectory->GetKey(keyName.c_str());
    auto pagePayload = pageKey->ReadObject<ROOT::Experimental::Internal::RNTupleBlob>();
    auto elementSize = pagePayload->fSize / pageInfo.fNElements;

--- a/tree/ntuple/v7/src/RPageStorageRoot.cxx
+++ b/tree/ntuple/v7/src/RPageStorageRoot.cxx
@@ -79,7 +79,7 @@ ROOT::Experimental::Detail::RPageSinkRoot::AddColumn(const RColumn &column)
 
    /// We use the fact the AddColumn is called during Create() just after the field that corresponds to the
    /// current set of columns has been added.
-   fDescriptorBuilder.AddColumn(fLastColumnId, fLastFieldId, column.GetVersion(), column.GetModel());
+   fDescriptorBuilder.AddColumn(fLastColumnId, fLastFieldId, column.GetVersion(), column.GetModel(), column.GetIndex());
 
    //printf("Added column %s type %d\n", columnHeader.fName.c_str(), (int)columnHeader.fType);
    auto columnId = fLastColumnId++;

--- a/tree/ntuple/v7/src/RPageStorageRoot.cxx
+++ b/tree/ntuple/v7/src/RPageStorageRoot.cxx
@@ -304,7 +304,7 @@ void ROOT::Experimental::Detail::RPageSourceRoot::Attach()
 
    // TODO(jblomer): replace RMapper by a ntuple descriptor
    RNTupleDescriptorBuilder descBuilder;
-   descBuilder.SetNTuple(fNTupleName, RNTupleVersion());
+   descBuilder.SetNTuple(fNTupleName, RNTupleVersion(), Uuid_t());
    fDescriptor = descBuilder.GetDescriptor();
 }
 

--- a/tree/ntuple/v7/src/RPageStorageRoot.cxx
+++ b/tree/ntuple/v7/src/RPageStorageRoot.cxx
@@ -77,9 +77,7 @@ ROOT::Experimental::Detail::RPageSinkRoot::AddColumn(DescriptorId_t fieldId, con
    }
    fNTupleHeader.fColumns.emplace_back(columnHeader);
 
-   /// We use the fact the AddColumn is called during Create() just after the field that corresponds to the
-   /// current set of columns has been added.
-   fDescriptorBuilder.AddColumn(fLastColumnId, fLastFieldId, column.GetVersion(), column.GetModel(), column.GetIndex());
+   fDescriptorBuilder.AddColumn(fLastColumnId, fieldId, column.GetVersion(), column.GetModel(), column.GetIndex());
 
    //printf("Added column %s type %d\n", columnHeader.fName.c_str(), (int)columnHeader.fType);
    auto columnId = fLastColumnId++;
@@ -279,7 +277,6 @@ ROOT::Experimental::Detail::RPageSourceRoot::AddColumn(DescriptorId_t fieldId, c
 {
    R__ASSERT(fieldId != kInvalidDescriptorId);
    auto& model = column.GetModel();
-   //auto columnId = fMapper.fColumnName2Id[model.GetName()];
    auto columnId = fDescriptor.FindColumnId(fieldId, column.GetIndex());
    R__ASSERT(columnId != kInvalidDescriptorId);
    R__ASSERT(model == *fMapper.fId2ColumnModel[columnId]);
@@ -383,16 +380,6 @@ void ROOT::Experimental::Detail::RPageSourceRoot::Attach()
    delete ntupleHeader;
 }
 
-
-std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::Detail::RPageSourceRoot::GenerateModel()
-{
-   auto model = std::make_unique<RNTupleModel>();
-   for (auto& f : fMapper.fRootFields) {
-      auto field = Detail::RFieldBase::Create(f.fFieldName, f.fTypeName);
-      model->AddField(std::unique_ptr<Detail::RFieldBase>(field));
-   }
-   return model;
-}
 
 ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceRoot::PopulatePage(
    ColumnHandle_t columnHandle, NTupleSize_t index)

--- a/tree/ntuple/v7/src/RPageStorageRoot.cxx
+++ b/tree/ntuple/v7/src/RPageStorageRoot.cxx
@@ -110,7 +110,7 @@ void ROOT::Experimental::Detail::RPageSinkRoot::Create(RNTupleModel &model)
          fDescriptorBuilder.SetFieldParent(fLastFieldId, fFieldPtr2Id[f.GetParent()]);
       }
 
-      f.ConnectColumns(this); // issues in turn one or several calls to AddColumn()
+      Detail::RFieldFuse::Connect(*this, f); // issues in turn one or several calls to AddColumn()
       fFieldPtr2Id[&f] = fLastFieldId++;
    }
 

--- a/tree/ntuple/v7/src/RPageStorageRoot.cxx
+++ b/tree/ntuple/v7/src/RPageStorageRoot.cxx
@@ -290,8 +290,8 @@ void ROOT::Experimental::Detail::RPageSourceRoot::Attach()
    auto keyRawNTupleFooter = fDirectory->GetKey(kKeyNTupleFooter);
    auto ntupleRawFooter = keyRawNTupleFooter->ReadObject<ROOT::Experimental::Internal::RNTupleBlob>();
    descBuilder.AddClustersFromFooter(ntupleRawFooter->fContent);
-   free(ntupleRawHeader->fContent);
-   delete ntupleRawHeader;
+   free(ntupleRawFooter->fContent);
+   delete ntupleRawFooter;
 
    auto keyNTupleHeader = fDirectory->GetKey(RMapper::kKeyNTupleHeader);
    auto ntupleHeader = keyNTupleHeader->ReadObject<ROOT::Experimental::Internal::RNTupleHeader>();

--- a/tree/ntuple/v7/test/ntuple.cxx
+++ b/tree/ntuple/v7/test/ntuple.cxx
@@ -614,6 +614,10 @@ TEST(RNTuple, Descriptor)
    EXPECT_EQ(ROOT::Experimental::kInvalidDescriptorId, reference.FindColumnId(42, 2));
    EXPECT_EQ(ROOT::Experimental::kInvalidDescriptorId, reference.FindColumnId(43, 0));
 
+   EXPECT_EQ(DescriptorId_t(0), reference.FindClusterId(3, 0));
+   EXPECT_EQ(DescriptorId_t(1), reference.FindClusterId(3, 100));
+   EXPECT_EQ(ROOT::Experimental::kInvalidDescriptorId, reference.FindClusterId(3, 40000));
+
    delete[] footerBuffer;
    delete[] headerBuffer;
 }

--- a/tree/ntuple/v7/test/ntuple.cxx
+++ b/tree/ntuple/v7/test/ntuple.cxx
@@ -24,6 +24,7 @@
 using DescriptorId_t = ROOT::Experimental::DescriptorId_t;
 using EColumnType = ROOT::Experimental::EColumnType;
 using ENTupleStructure = ROOT::Experimental::ENTupleStructure;
+using NTupleSize_t = ROOT::Experimental::NTupleSize_t;
 using RColumnModel = ROOT::Experimental::RColumnModel;
 using RNTupleDescriptor = ROOT::Experimental::RNTupleDescriptor;
 using RNTupleDescriptorBuilder = ROOT::Experimental::RNTupleDescriptorBuilder;
@@ -602,6 +603,10 @@ TEST(RNTuple, Descriptor)
    reco.SetFromHeader(headerBuffer);
    reco.AddClustersFromFooter(footerBuffer);
    EXPECT_EQ(reference, reco.GetDescriptor());
+
+   EXPECT_EQ(NTupleSize_t(1100), reference.GetNEntries());
+   EXPECT_EQ(NTupleSize_t(1100), reference.GetNElements(3));
+   EXPECT_EQ(NTupleSize_t(3300), reference.GetNElements(4));
 
    EXPECT_EQ(DescriptorId_t(1), reference.FindFieldId("list", ROOT::Experimental::kInvalidDescriptorId));
    EXPECT_EQ(DescriptorId_t(2), reference.FindFieldId("list", 1));

--- a/tree/ntuple/v7/test/ntuple.cxx
+++ b/tree/ntuple/v7/test/ntuple.cxx
@@ -526,8 +526,8 @@ TEST(RNTuple, Descriptor)
    descBuilder.AddField(2, RNTupleVersion(), RNTupleVersion(), "list", "std::int32_t", ENTupleStructure::kLeaf);
    descBuilder.AddField(42, RNTupleVersion(), RNTupleVersion(), "x", "std::string", ENTupleStructure::kLeaf);
    descBuilder.SetFieldParent(2, 1);
-   descBuilder.AddColumn(3, 42, RNTupleVersion(), RColumnModel("idx_x", EColumnType::kIndex, true), 0);
-   descBuilder.AddColumn(4, 42, RNTupleVersion(), RColumnModel("x", EColumnType::kByte, true), 1);
+   descBuilder.AddColumn(3, 42, RNTupleVersion(), RColumnModel(EColumnType::kIndex, true), 0);
+   descBuilder.AddColumn(4, 42, RNTupleVersion(), RColumnModel(EColumnType::kByte, true), 1);
 
    ROOT::Experimental::RClusterDescriptor::RColumnRange columnRange;
    ROOT::Experimental::RClusterDescriptor::RPageRange pageRange;

--- a/tree/ntuple/v7/test/ntuple.cxx
+++ b/tree/ntuple/v7/test/ntuple.cxx
@@ -522,25 +522,63 @@ TEST(RNTuple, Descriptor)
    descBuilder.AddField(42, RNTupleVersion(), RNTupleVersion(), "x", "std::string", ENTupleStructure::kLeaf);
    descBuilder.AddColumn(3, 42, RNTupleVersion(), RColumnModel("idx_x", EColumnType::kIndex, true));
    descBuilder.AddColumn(4, 42, RNTupleVersion(), RColumnModel("x", EColumnType::kByte, true));
+
+   ROOT::Experimental::RClusterDescriptor::RColumnRange columnRange;
+   ROOT::Experimental::RClusterDescriptor::RPageRange pageRange;
+   ROOT::Experimental::RClusterDescriptor::RPageRange::RPageInfo pageInfo;
+   // Description of cluster #0
    descBuilder.AddCluster(0, RNTupleVersion(), 0, ROOT::Experimental::ClusterSize_t(100));
-   ROOT::Experimental::RClusterDescriptor::RColumnRange range;
-   range.fColumnId = 3;
-   range.fFirstElementIndex = 0;
-   range.fNElements = 100;
-   descBuilder.AddClusterColumnRange(0, range);
-   range.fColumnId = 4;
-   range.fFirstElementIndex = 0;
-   range.fNElements = 300;
-   descBuilder.AddClusterColumnRange(0, range);
+   columnRange.fColumnId = 3;
+   columnRange.fFirstElementIndex = 0;
+   columnRange.fNElements = 100;
+   descBuilder.AddClusterColumnRange(0, columnRange);
+   pageRange.fPageInfos.clear();
+   pageRange.fColumnId = 3;
+   pageInfo.fNElements = 40;
+   pageInfo.fLocator = 0;
+   pageRange.fPageInfos.emplace_back(pageInfo);
+   pageInfo.fNElements = 60;
+   pageInfo.fLocator = 1024;
+   pageRange.fPageInfos.emplace_back(pageInfo);
+   descBuilder.AddClusterPageRange(0, pageRange);
+
+   columnRange.fColumnId = 4;
+   columnRange.fFirstElementIndex = 0;
+   columnRange.fNElements = 300;
+   descBuilder.AddClusterColumnRange(0, columnRange);
+   pageRange.fPageInfos.clear();
+   pageRange.fColumnId = 4;
+   pageInfo.fNElements = 200;
+   pageInfo.fLocator = 2048;
+   pageRange.fPageInfos.emplace_back(pageInfo);
+   pageInfo.fNElements = 100;
+   pageInfo.fLocator = 4096;
+   pageRange.fPageInfos.emplace_back(pageInfo);
+   descBuilder.AddClusterPageRange(0, pageRange);
+
+   // Description of cluster #1
    descBuilder.AddCluster(1, RNTupleVersion(), 100, ROOT::Experimental::ClusterSize_t(1000));
-   range.fColumnId = 3;
-   range.fFirstElementIndex = 100;
-   range.fNElements = 1000;
-   descBuilder.AddClusterColumnRange(1, range);
-   range.fColumnId = 4;
-   range.fFirstElementIndex = 300;
-   range.fNElements = 3000;
-   descBuilder.AddClusterColumnRange(1, range);
+   columnRange.fColumnId = 3;
+   columnRange.fFirstElementIndex = 100;
+   columnRange.fNElements = 1000;
+   descBuilder.AddClusterColumnRange(1, columnRange);
+   pageRange.fPageInfos.clear();
+   pageRange.fColumnId = 3;
+   pageInfo.fNElements = 1000;
+   pageInfo.fLocator = 8192;
+   pageRange.fPageInfos.emplace_back(pageInfo);
+   descBuilder.AddClusterPageRange(1, pageRange);
+
+   columnRange.fColumnId = 4;
+   columnRange.fFirstElementIndex = 300;
+   columnRange.fNElements = 3000;
+   descBuilder.AddClusterColumnRange(1, columnRange);
+   pageRange.fPageInfos.clear();
+   pageRange.fColumnId = 4;
+   pageInfo.fNElements = 3000;
+   pageInfo.fLocator = 16384;
+   pageRange.fPageInfos.emplace_back(pageInfo);
+   descBuilder.AddClusterPageRange(1, pageRange);
 
    auto reference = descBuilder.GetDescriptor();
    EXPECT_EQ("MyTuple", reference.GetName());

--- a/tree/ntuple/v7/test/ntuple.cxx
+++ b/tree/ntuple/v7/test/ntuple.cxx
@@ -21,6 +21,7 @@
 #include <string>
 #include <utility>
 
+using DescriptorId_t = ROOT::Experimental::DescriptorId_t;
 using EColumnType = ROOT::Experimental::EColumnType;
 using ENTupleStructure = ROOT::Experimental::ENTupleStructure;
 using RColumnModel = ROOT::Experimental::RColumnModel;
@@ -602,12 +603,16 @@ TEST(RNTuple, Descriptor)
    reco.AddClustersFromFooter(footerBuffer);
    EXPECT_EQ(reference, reco.GetDescriptor());
 
-   auto model = RNTupleModel::Create();
-   model->MakeField<std::vector<std::int32_t>>("list");
-   model->MakeField<std::string>("x");
-   for (const auto &f : *model->GetRootField()) {
-      EXPECT_NE(ROOT::Experimental::kInvalidDescriptorId, reference.FindFieldId(f));
-   }
+   EXPECT_EQ(DescriptorId_t(1), reference.FindFieldId("list", ROOT::Experimental::kInvalidDescriptorId));
+   EXPECT_EQ(DescriptorId_t(2), reference.FindFieldId("list", 1));
+   EXPECT_EQ(DescriptorId_t(42), reference.FindFieldId("x", ROOT::Experimental::kInvalidDescriptorId));
+   EXPECT_EQ(ROOT::Experimental::kInvalidDescriptorId, reference.FindFieldId("listX", 1));
+   EXPECT_EQ(ROOT::Experimental::kInvalidDescriptorId, reference.FindFieldId("list", 1024));
+
+   EXPECT_EQ(DescriptorId_t(3), reference.FindColumnId(42, 0));
+   EXPECT_EQ(DescriptorId_t(4), reference.FindColumnId(42, 1));
+   EXPECT_EQ(ROOT::Experimental::kInvalidDescriptorId, reference.FindColumnId(42, 2));
+   EXPECT_EQ(ROOT::Experimental::kInvalidDescriptorId, reference.FindColumnId(43, 0));
 
    delete[] footerBuffer;
    delete[] headerBuffer;

--- a/tree/ntuple/v7/test/ntuple.cxx
+++ b/tree/ntuple/v7/test/ntuple.cxx
@@ -1,5 +1,6 @@
 #include <ROOT/RDataFrame.hxx>
 #include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleDS.hxx>
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RPageStorage.hxx>
@@ -19,9 +20,12 @@
 #include <string>
 #include <utility>
 
+using RNTupleDescriptor = ROOT::Experimental::RNTupleDescriptor;
+using RNTupleDescriptorBuilder = ROOT::Experimental::RNTupleDescriptorBuilder;
 using RNTupleReader = ROOT::Experimental::RNTupleReader;
 using RNTupleWriter = ROOT::Experimental::RNTupleWriter;
 using RNTupleModel = ROOT::Experimental::RNTupleModel;
+using RNTupleVersion = ROOT::Experimental::RNTupleVersion;
 using RPageSource = ROOT::Experimental::Detail::RPageSource;
 using RPageSinkRoot = ROOT::Experimental::Detail::RPageSinkRoot;
 using RPageSourceRoot = ROOT::Experimental::Detail::RPageSourceRoot;
@@ -504,4 +508,24 @@ TEST(RNTuple, RDF)
 
    auto rdf = ROOT::Experimental::MakeNTupleDataFrame("f", "test.root");
    EXPECT_EQ(42.0, *rdf.Min("pt"));
+}
+
+
+TEST(RNTuple, Descriptor)
+{
+   RNTupleDescriptorBuilder descBuilder;
+   descBuilder.SetNTuple("MyTuple", RNTupleVersion(), ROOT::Experimental::Uuid_t());
+
+   auto reference = descBuilder.GetDescriptor();
+   EXPECT_EQ("MyTuple", reference.GetName());
+
+   auto szHeader = reference.SerializeHeader(nullptr);
+   auto headerBuffer = new unsigned char[szHeader];
+   reference.SerializeHeader(headerBuffer);
+
+   auto reconstructed = RNTupleDescriptor::Deserialize(headerBuffer, nullptr);
+
+   EXPECT_EQ(reconstructed, reference);
+
+   delete[] headerBuffer;
 }

--- a/tree/ntuple/v7/test/ntuple.cxx
+++ b/tree/ntuple/v7/test/ntuple.cxx
@@ -541,10 +541,10 @@ TEST(RNTuple, Descriptor)
    pageRange.fPageInfos.clear();
    pageRange.fColumnId = 3;
    pageInfo.fNElements = 40;
-   pageInfo.fLocator = 0;
+   pageInfo.fLocator.fPosition = 0;
    pageRange.fPageInfos.emplace_back(pageInfo);
    pageInfo.fNElements = 60;
-   pageInfo.fLocator = 1024;
+   pageInfo.fLocator.fPosition = 1024;
    pageRange.fPageInfos.emplace_back(pageInfo);
    descBuilder.AddClusterPageRange(0, pageRange);
 
@@ -555,10 +555,10 @@ TEST(RNTuple, Descriptor)
    pageRange.fPageInfos.clear();
    pageRange.fColumnId = 4;
    pageInfo.fNElements = 200;
-   pageInfo.fLocator = 2048;
+   pageInfo.fLocator.fPosition = 2048;
    pageRange.fPageInfos.emplace_back(pageInfo);
    pageInfo.fNElements = 100;
-   pageInfo.fLocator = 4096;
+   pageInfo.fLocator.fPosition = 4096;
    pageRange.fPageInfos.emplace_back(pageInfo);
    descBuilder.AddClusterPageRange(0, pageRange);
 
@@ -571,7 +571,7 @@ TEST(RNTuple, Descriptor)
    pageRange.fPageInfos.clear();
    pageRange.fColumnId = 3;
    pageInfo.fNElements = 1000;
-   pageInfo.fLocator = 8192;
+   pageInfo.fLocator.fPosition = 8192;
    pageRange.fPageInfos.emplace_back(pageInfo);
    descBuilder.AddClusterPageRange(1, pageRange);
 
@@ -582,7 +582,7 @@ TEST(RNTuple, Descriptor)
    pageRange.fPageInfos.clear();
    pageRange.fColumnId = 4;
    pageInfo.fNElements = 3000;
-   pageInfo.fLocator = 16384;
+   pageInfo.fLocator.fPosition = 16384;
    pageRange.fPageInfos.emplace_back(pageInfo);
    descBuilder.AddClusterPageRange(1, pageRange);
 

--- a/tree/ntuple/v7/test/ntuple.cxx
+++ b/tree/ntuple/v7/test/ntuple.cxx
@@ -518,7 +518,7 @@ TEST(RNTuple, RDF)
 TEST(RNTuple, Descriptor)
 {
    RNTupleDescriptorBuilder descBuilder;
-   descBuilder.SetNTuple("MyTuple", RNTupleVersion(1, 2, 3), ROOT::Experimental::Uuid_t());
+   descBuilder.SetNTuple("MyTuple", "Description", RNTupleVersion(1, 2, 3), ROOT::Experimental::RNTupleUuid());
    descBuilder.AddField(42, RNTupleVersion(), RNTupleVersion(), "x", "std::string", ENTupleStructure::kLeaf);
    descBuilder.AddColumn(3, 42, RNTupleVersion(), RColumnModel("idx_x", EColumnType::kIndex, true));
    descBuilder.AddColumn(4, 42, RNTupleVersion(), RColumnModel("x", EColumnType::kByte, true));

--- a/tree/ntuple/v7/test/ntuple.cxx
+++ b/tree/ntuple/v7/test/ntuple.cxx
@@ -82,7 +82,7 @@ TEST(RNTuple, ReconstructModel)
    RPageSourceRoot sourceRoot("myTree", "test.root");
    sourceRoot.Attach();
 
-   auto modelReconstructed = sourceRoot.GenerateModel();
+   auto modelReconstructed = sourceRoot.GetDescriptor().GenerateModel();
    EXPECT_EQ(nullptr, modelReconstructed->GetDefaultEntry()->Get<float>("xyz"));
    auto vecPtr = modelReconstructed->GetDefaultEntry()->Get<std::vector<std::vector<float>>>("nnlo");
    EXPECT_TRUE(vecPtr != nullptr);

--- a/tree/ntuple/v7/test/ntuple.cxx
+++ b/tree/ntuple/v7/test/ntuple.cxx
@@ -520,11 +520,11 @@ TEST(RNTuple, RDF)
 TEST(RNTuple, Descriptor)
 {
    RNTupleDescriptorBuilder descBuilder;
-   descBuilder.SetNTuple("MyTuple", "Description", RNTupleVersion(1, 2, 3), ROOT::Experimental::RNTupleUuid());
+   descBuilder.SetNTuple("MyTuple", "Description", "Me", RNTupleVersion(1, 2, 3), ROOT::Experimental::RNTupleUuid());
    descBuilder.AddField(1, RNTupleVersion(), RNTupleVersion(), "list", "std::vector<std::int32_t>",
-                        ENTupleStructure::kCollection);
-   descBuilder.AddField(2, RNTupleVersion(), RNTupleVersion(), "list", "std::int32_t", ENTupleStructure::kLeaf);
-   descBuilder.AddField(42, RNTupleVersion(), RNTupleVersion(), "x", "std::string", ENTupleStructure::kLeaf);
+                        0, ENTupleStructure::kCollection);
+   descBuilder.AddField(2, RNTupleVersion(), RNTupleVersion(), "list", "std::int32_t", 0, ENTupleStructure::kLeaf);
+   descBuilder.AddField(42, RNTupleVersion(), RNTupleVersion(), "x", "std::string", 0, ENTupleStructure::kLeaf);
    descBuilder.SetFieldParent(2, 1);
    descBuilder.AddColumn(3, 42, RNTupleVersion(), RColumnModel(EColumnType::kIndex, true), 0);
    descBuilder.AddColumn(4, 42, RNTupleVersion(), RColumnModel(EColumnType::kByte, true), 1);


### PR DESCRIPTION
Introduces an RNTupleDescriptor directory class that stores the field structure, the attached columns and their structure, as well as the cluster structure.  The descriptor can be used independently of the concrete page storage implementation. Serialization and deserialization of header and footer does not depend on libCore.

Along the way, this PR also straightens up naming: field names are now relative to their parent fields, i.e. fields are identified by (name, parent id). Columns have no names anymore. Columns are identified by (field id, column index).  At some point we can add the possibility to address nested fields by a fully qualified name, e.g. in views. At the moment that's not yet necessary.