### PR TITLE
[Exp PyROOT] Pythonization of RDataFrame.Histo*D and RDataFrame.Profile*D and seven tutorials fixed

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -477,14 +477,7 @@ if(ROOT_python_FOUND)
   set(roofit-rf104_classfactory-depends tutorial-roofit-rf104_classfactory) #Race condition
 
   #---Tutorials expected to fail in PyROOT experimental
-  set(pyexp_fail tutorial-dataframe-df002_dataModel-py
-                 tutorial-dataframe-df003_profiles-py
-                 tutorial-dataframe-df010_trivialDataSource-py
-                 tutorial-dataframe-df011_ROOTDataSource-py
-                 tutorial-dataframe-df014_CSVDataSource-py
-                 tutorial-dataframe-df016_vecOps-py
-                 tutorial-dataframe-df017_vecOpsHEP-py
-                 tutorial-dataframe-df102_NanoAODDimuonAnalysis-py
+  set(pyexp_fail tutorial-dataframe-df017_vecOpsHEP-py
                  tutorial-dataframe-df103_NanoAODHiggsAnalysis-py
                  tutorial-pyroot-benchmarks-py
                  tutorial-pyroot-pyroot002_TTreeAsMatrix-py


### PR DESCRIPTION
Thanks to the pythonization of the five RDataFrame methods Histo*D (1, 2, 3) and Profile*D (1, 2) seven failing tutorials were fixed. 
The key is the mostly possibility to call these methods, when they receive a TH*Model or TProfile*DModel as argument, by typing e.g.:
`rdf.Histo1D(("h", "h", 100, 0, 100), "x")`
instead of:
`rdf..Histo1D(ROOT.RDF.TH1DModel("h", "h", 100, 0, 100), "x")`
The converters that did the magic in the old PyROOT are not implemented anymore in the new Cppyy, that's why we decided to introduce them. 

