### PR TITLE
Fix copy of TF1Convolution and TF1NormSum

### DIFF
--- a/hist/hist/src/TF1NormSum.cxx
+++ b/hist/hist/src/TF1NormSum.cxx
@@ -65,10 +65,12 @@ void TF1NormSum::InitializeDataMembers(const std::vector<TF1 *> &functions, cons
    // fill fFunctions with unique_ptr's
    fFunctions = std::vector<std::unique_ptr<TF1>>(functions.size());
    for (unsigned int n = 0; n < fNOfFunctions; n++) {
-      TF1 *f = new TF1();
+      // use TF1::Copy and not clone to copy the TF1 pointers
+      // and use IsA()::New() in case we have base class pointers 
+      TF1 * f = (TF1*) functions[n]->IsA()->New();
       functions[n]->Copy(*f);
       fFunctions[n] = std::unique_ptr<TF1>(f);
-      // Use Copy, not Clone
+     
 
       if (!fFunctions[n])
          Fatal("InitializeDataMembers", "Invalid input function -- abort");
@@ -418,6 +420,8 @@ void TF1NormSum::Copy(TObject &obj) const
    // Clone objects in unique_ptr's
    ((TF1NormSum &)obj).fFunctions = std::vector<std::unique_ptr<TF1>>(fNOfFunctions);
    for (unsigned int n = 0; n < fNOfFunctions; n++) {
-      ((TF1NormSum &)obj).fFunctions[n] = std::unique_ptr<TF1>((TF1 *)fFunctions[n]->Clone());
+      TF1 * f = (TF1*) fFunctions[n]->IsA()->New();   
+      fFunctions[n]->Copy(*f);
+      ((TF1NormSum &)obj).fFunctions[n] = std::unique_ptr<TF1>(f);
    }
 }


### PR DESCRIPTION
The copy constructor of TF1Convolution and TF1NormSum where usinog TF1::Clone for the contained TF1 pointers. TF1::Clone does not work when the TF1 objects are based on compiled functors and not formula. 
Use now the correct TF1::Copy function to copy the contained objects. 

This fixes the problem reported at  https://root-forum.cern.ch/t/tf1convolution-zero-in-root-6-18/35421