### PR TITLE
[http] fix failure when sending data to websocket in threads 

### DIFF
--- a/net/http/src/THttpWSEngine.h
+++ b/net/http/src/THttpWSEngine.h
@@ -33,7 +33,6 @@ private:
 
    std::thread fSendThrd;    ///<! dedicated thread for all send operations
    bool fHasSendThrd{false}; ///<! if thread was started one have to call join method for it
-   std::mutex fCondMutex;    ///<! mutex used to access condition
    std::condition_variable fCond; ///<! condition used to sync with sending thread
 
    std::mutex fDataMutex;                              ///<! protects data submitted for send operation

--- a/net/http/src/THttpWSEngine.h
+++ b/net/http/src/THttpWSEngine.h
@@ -33,11 +33,12 @@ private:
 
    std::thread fSendThrd;    ///<! dedicated thread for all send operations
    bool fHasSendThrd{false}; ///<! if thread was started one have to call join method for it
-   std::condition_variable fCond; ///<! condition used to sync with sending thread
 
-   std::mutex fDataMutex;                              ///<! protects data submitted for send operation
+   std::mutex fMutex;                                  ///<! protects all data behind
+   std::condition_variable fCond;                      ///<! condition used to sync with sending thread
+   bool fWaiting{false};                               ///<! if condition wait is called
+   bool fSending{false};                               ///<! performing send operation in other thread
    enum { kNone, kData, kHeader, kText } fKind{kNone}; ///<! kind of operation
-   bool fDoingSend{false};                             ///<! doing send operation in other thread
    std::string fData;                                  ///<! data (binary or text)
    std::string fHdr;                                   ///<! header
 

--- a/net/http/src/THttpWSHandler.cxx
+++ b/net/http/src/THttpWSHandler.cxx
@@ -91,7 +91,8 @@ THttpWSHandler::~THttpWSHandler()
       eng->fDisabled = true;
       if (eng->fHasSendThrd) {
          eng->fHasSendThrd = false;
-         eng->fCond.notify_all();
+         if (eng->fWaiting)
+            eng->fCond.notify_all();
          eng->fSendThrd.join();
       }
       eng->ClearHandle(kTRUE); // terminate connection before starting destructor
@@ -172,7 +173,8 @@ void THttpWSHandler::RemoveEngine(std::shared_ptr<THttpWSEngine> &engine, Bool_t
 
    if (engine->fHasSendThrd) {
       engine->fHasSendThrd = false;
-      engine->fCond.notify_all();
+      if (engine->fWaiting)
+         engine->fCond.notify_all();
       engine->fSendThrd.join();
    }
 }
@@ -259,12 +261,6 @@ void THttpWSHandler::CloseWS(UInt_t wsid)
 
 Int_t THttpWSHandler::RunSendingThrd(std::shared_ptr<THttpWSEngine> engine)
 {
-   if (engine->fHasSendThrd) {
-      // all data are prepared - just notify thread
-      engine->fCond.notify_all();
-      return 1;
-   }
-
    if (IsSyncMode() || !engine->SupportSendThrd()) {
       // this is case of longpoll engine, no extra thread is required for it
       if (engine->CanSendDirectly())
@@ -298,9 +294,12 @@ Int_t THttpWSHandler::RunSendingThrd(std::shared_ptr<THttpWSEngine> engine)
       while (!IsDisabled() && !engine->fDisabled) {
          PerformSend(engine);
          if (IsDisabled() || engine->fDisabled) break;
-         std::unique_lock<std::mutex> lk(engine->fDataMutex);
-         if (engine->fKind == THttpWSEngine::kNone)
+         std::unique_lock<std::mutex> lk(engine->fMutex);
+         if (engine->fKind == THttpWSEngine::kNone) {
+            engine->fWaiting = true;
             engine->fCond.wait(lk);
+            engine->fWaiting = false;
+         }
       }
    });
 
@@ -318,15 +317,15 @@ Int_t THttpWSHandler::RunSendingThrd(std::shared_ptr<THttpWSEngine> engine)
 Int_t THttpWSHandler::PerformSend(std::shared_ptr<THttpWSEngine> engine)
 {
    {
-      std::lock_guard<std::mutex> grd(engine->fDataMutex);
+      std::lock_guard<std::mutex> grd(engine->fMutex);
 
       // no need to do something - operation was processed already by somebody else
       if (engine->fKind == THttpWSEngine::kNone)
          return 0;
 
-      if (engine->fDoingSend)
+      if (engine->fSending)
          return 1;
-      engine->fDoingSend = true;
+      engine->fSending = true;
    }
 
    if (IsDisabled() || engine->fDisabled)
@@ -350,8 +349,8 @@ Int_t THttpWSHandler::PerformSend(std::shared_ptr<THttpWSEngine> engine)
    engine->fHdr.clear();
 
    {
-      std::lock_guard<std::mutex> grd(engine->fDataMutex);
-      engine->fDoingSend = false;
+      std::lock_guard<std::mutex> grd(engine->fMutex);
+      engine->fSending = false;
       engine->fKind = THttpWSEngine::kNone;
    }
 
@@ -387,20 +386,28 @@ Int_t THttpWSHandler::SendWS(UInt_t wsid, const void *buf, int len)
       return CompleteSend(engine);
    }
 
+   bool notify = false;
+
    // now we indicate that there is data and any thread can access it
    {
-      std::lock_guard<std::mutex> grd(engine->fDataMutex);
+      std::lock_guard<std::mutex> grd(engine->fMutex);
 
       if (engine->fKind != THttpWSEngine::kNone) {
          Error("SendWS", "Data kind is not empty - something screwed up");
          return -1;
       }
 
+      notify = engine->fWaiting;
+
+      engine->fKind = THttpWSEngine::kData;
+
       engine->fData.resize(len);
       std::copy((const char *)buf, (const char *)buf + len, engine->fData.begin());
+   }
 
-      engine->fDoingSend = false;
-      engine->fKind = THttpWSEngine::kData;
+   if (engine->fHasSendThrd) {
+      if (notify) engine->fCond.notify_all();
+      return 1;
    }
 
    return RunSendingThrd(engine);
@@ -423,21 +430,29 @@ Int_t THttpWSHandler::SendHeaderWS(UInt_t wsid, const char *hdr, const void *buf
       return CompleteSend(engine);
    }
 
+   bool notify = false;
+
    // now we indicate that there is data and any thread can access it
    {
-      std::lock_guard<std::mutex> grd(engine->fDataMutex);
+      std::lock_guard<std::mutex> grd(engine->fMutex);
 
       if (engine->fKind != THttpWSEngine::kNone) {
          Error("SendWS", "Data kind is not empty - something screwed up");
          return -1;
       }
 
+      notify = engine->fWaiting;
+
+      engine->fKind = THttpWSEngine::kHeader;
+
       engine->fHdr = hdr;
       engine->fData.resize(len);
       std::copy((const char *)buf, (const char *)buf + len, engine->fData.begin());
+   }
 
-      engine->fDoingSend = false;
-      engine->fKind = THttpWSEngine::kHeader;
+   if (engine->fHasSendThrd) {
+      if (notify) engine->fCond.notify_all();
+      return 1;
    }
 
    return RunSendingThrd(engine);
@@ -459,19 +474,26 @@ Int_t THttpWSHandler::SendCharStarWS(UInt_t wsid, const char *str)
       return CompleteSend(engine);
    }
 
+   bool notify = false;
+
    // now we indicate that there is data and any thread can access it
    {
-      std::lock_guard<std::mutex> grd(engine->fDataMutex);
+      std::lock_guard<std::mutex> grd(engine->fMutex);
 
       if (engine->fKind != THttpWSEngine::kNone) {
          Error("SendWS", "Data kind is not empty - something screwed up");
          return -1;
       }
 
-      engine->fData = str;
+      notify = engine->fWaiting;
 
-      engine->fDoingSend = false;
       engine->fKind = THttpWSEngine::kText;
+      engine->fData = str;
+   }
+
+   if (engine->fHasSendThrd) {
+      if (notify) engine->fCond.notify_all();
+      return 1;
    }
 
    return RunSendingThrd(engine);

--- a/net/http/src/THttpWSHandler.cxx
+++ b/net/http/src/THttpWSHandler.cxx
@@ -298,8 +298,9 @@ Int_t THttpWSHandler::RunSendingThrd(std::shared_ptr<THttpWSEngine> engine)
       while (!IsDisabled() && !engine->fDisabled) {
          PerformSend(engine);
          if (IsDisabled() || engine->fDisabled) break;
-         std::unique_lock<std::mutex> lk(engine->fCondMutex);
-         engine->fCond.wait(lk);
+         std::unique_lock<std::mutex> lk(engine->fDataMutex);
+         if (engine->fKind == THttpWSEngine::kNone)
+            engine->fCond.wait(lk);
       }
    });
 


### PR DESCRIPTION
Can be activated for RWebWindow. 
Avoids blocking of application code due-to single slow client.
Use `cond.notify_all()` only when really condition in the wait state