### PR TITLE
[RDF] Reenable Higgs tutorial with pyroot experimental

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -478,7 +478,6 @@ if(ROOT_python_FOUND)
 
   #---Tutorials expected to fail in PyROOT experimental
   set(pyexp_fail tutorial-dataframe-df017_vecOpsHEP-py
-                 tutorial-dataframe-df103_NanoAODHiggsAnalysis-py
                  tutorial-pyroot-benchmarks-py
                  tutorial-pyroot-pyroot002_TTreeAsMatrix-py
                  tutorial-pyroot-shapes-py


### PR DESCRIPTION
The issue that prevented the higgs tutorial from running with pyroot experimental has been fixed by #4135. Now the tutorial should be removed from the failing list in the CMakeLists file.