### PR TITLE
[web geom] avoid binary data transfer, use JSON_base64

### DIFF
--- a/graf3d/eve7/inc/ROOT/REveGeomData.hxx
+++ b/graf3d/eve7/inc/ROOT/REveGeomData.hxx
@@ -114,7 +114,6 @@ public:
    int numnodes{0};                         ///< total number of nodes in description
    std::string drawopt;                     ///< draw options for TGeoPainter
    int nsegm{0};                            ///< number of segments for cylindrical shapes
-   int binlen{0};                           ///< extra binary data for that drawing
    std::vector<REveGeomNode*> nodes;        ///< all used nodes to display visible items and not known for client
    std::vector<REveGeomVisible> visibles;   ///< all visible items
 };
@@ -137,8 +136,6 @@ public:
    std::string shape_name; ///< shape class name (if any)
 
    REveShapeRenderInfo *ri{nullptr}; ///< rendering information (if applicable)
-
-   std::vector<unsigned char> rndr_binary; ///<  binary render data (if available)
 };
 
 using REveGeomScanFunc_t = std::function<bool(REveGeomNode &, std::vector<int> &, bool)>;
@@ -173,7 +170,6 @@ class REveGeomDescription {
    int fRndrOffest{0};              ///<! current render offset
 
    std::string fDrawJson;           ///<! JSON with main nodes drawn by client
-   std::vector<unsigned char> fDrawBinary;   ///<! binary data for main draw nodes
    int fDrawIdCut{0};               ///<! sortid used for selection of most-significant nodes
    int fFacesLimit{0};              ///<! maximal number of faces to be selected for drawing
    int fNodesLimit{0};              ///<! maximal number of nodes to be selected for drawing
@@ -195,8 +191,6 @@ class REveGeomDescription {
    ShapeDescr &FindShapeDescr(TGeoShape *shape);
 
    ShapeDescr &MakeShapeDescr(TGeoShape *shape, bool acc_rndr = false);
-
-   void BuildRndrBinary(std::vector<unsigned char> &buf);
 
    void CopyMaterialProperties(TGeoVolume *vol, REveGeomNode &node);
 
@@ -238,12 +232,11 @@ public:
 
    std::string ProcessBrowserRequest(const std::string &req = "");
 
-   bool HasDrawData() const { return (fDrawJson.length() > 0) && (fDrawBinary.size() > 0) && (fDrawIdCut > 0); }
+   bool HasDrawData() const { return (fDrawJson.length() > 0) && (fDrawIdCut > 0); }
    const std::string &GetDrawJson() const { return fDrawJson; }
-   const std::vector<unsigned char> &GetDrawBinary() const { return fDrawBinary; }
-   void ClearRawData();
+   void ClearDrawData();
 
-   int SearchVisibles(const std::string &find, std::string &hjson, std::string &json, std::vector<unsigned char> &binary);
+   int SearchVisibles(const std::string &find, std::string &hjson, std::string &json);
 
    int FindNodeId(const std::vector<int> &stack);
 
@@ -257,7 +250,7 @@ public:
 
    std::string MakePathByStack(const std::vector<int> &stack);
 
-   bool ProduceDrawingFor(int nodeid, std::string &json, std::vector<unsigned char> &binary, bool check_volume = false);
+   bool ProduceDrawingFor(int nodeid, std::string &json, bool check_volume = false);
 
    bool ChangeNodeVisibility(int nodeid, bool selected);
 

--- a/graf3d/eve7/inc/ROOT/REveGeomData.hxx
+++ b/graf3d/eve7/inc/ROOT/REveGeomData.hxx
@@ -81,14 +81,12 @@ public:
 class REveShapeRenderInfo {
 public:
    // render data, equivalent of REveElement::WriteCoreJson
-   int rnr_offset{-1};        ///< rnr_offset;
-   std::string rnr_func;      ///< fRenderData->GetRnrFunc();
-   int vert_size{0};          ///< fRenderData->SizeV();
-   int norm_size{0};          ///< fRenderData->SizeN();
-   int index_size{0};         ///< fRenderData->SizeI();
+   bool init{false};          ///<! indicates if data initialized
+   int v{0};                  ///< fRenderData->SizeV();
+   int n{0};                  ///< fRenderData->SizeN();
+   int i{0};                  ///< fRenderData->SizeI();
    TGeoShape *shape{nullptr}; ///< original shape - can be much less than binary data
    std::vector<unsigned char> raw;  ///< raw shape data with render information, JSON_base64
-   // int trans_size{0};      ///< fRenderData->SizeT(); not used in GeomViewer
 };
 
 /** REveGeomVisible contains description of visible node
@@ -155,7 +153,7 @@ class REveGeomDescription {
       ShapeDescr(TGeoShape *s) : fShape(s) {}
 
       /// Provide render info for visible item
-      REveShapeRenderInfo *rndr_info() { return (nfaces>0) && (fRenderInfo.rnr_offset>=0) ? &fRenderInfo : nullptr; }
+      REveShapeRenderInfo *rndr_info() { return (nfaces>0) && fRenderInfo.init ? &fRenderInfo : nullptr; }
    };
 
    std::vector<TGeoNode *> fNodes;  ///<! flat list of all nodes
@@ -166,8 +164,6 @@ class REveGeomDescription {
    std::vector<int> fSortMap;       ///<! nodes in order large -> smaller volume
    int fNSegments{0};               ///<! number of segments for cylindrical shapes
    std::vector<ShapeDescr> fShapes; ///<! shapes with created descriptions
-   std::vector<REveRenderData*> fRndrShapes; ///<! list of shapes which should be packet into binary
-   int fRndrOffest{0};              ///<! current render offset
 
    std::string fDrawJson;           ///<! JSON with main nodes drawn by client
    int fDrawIdCut{0};               ///<! sortid used for selection of most-significant nodes

--- a/graf3d/eve7/inc/ROOT/REveGeomData.hxx
+++ b/graf3d/eve7/inc/ROOT/REveGeomData.hxx
@@ -76,18 +76,19 @@ public:
 };
 
 
-/** Information block for render data, stored in binarz buffer */
+/** Information block for render data, stored in binary buffer */
 
 class REveShapeRenderInfo {
 public:
    // render data, equivalent of REveElement::WriteCoreJson
-   int rnr_offset{-1};   ///< rnr_offset;
-   std::string rnr_func; ///< fRenderData->GetRnrFunc();
-   int vert_size{0};     ///< fRenderData->SizeV();
-   int norm_size{0};     ///< fRenderData->SizeN();
-   int index_size{0};    ///< fRenderData->SizeI();
+   int rnr_offset{-1};        ///< rnr_offset;
+   std::string rnr_func;      ///< fRenderData->GetRnrFunc();
+   int vert_size{0};          ///< fRenderData->SizeV();
+   int norm_size{0};          ///< fRenderData->SizeN();
+   int index_size{0};         ///< fRenderData->SizeI();
    TGeoShape *shape{nullptr}; ///< original shape - can be much less than binary data
-   // int trans_size{0};     ///< fRenderData->SizeT(); not used in GeomViewer
+   std::vector<unsigned char> raw;  ///< raw shape data with render information, JSON_base64
+   // int trans_size{0};      ///< fRenderData->SizeT(); not used in GeomViewer
 };
 
 /** REveGeomVisible contains description of visible node

--- a/graf3d/eve7/src/REveGeomData.cxx
+++ b/graf3d/eve7/src/REveGeomData.cxx
@@ -676,23 +676,18 @@ ROOT::Experimental::REveGeomDescription::MakeShapeDescr(TGeoShape *shape, bool a
 
       if (!rd && (elem.nfaces == 1)) {
          ri.shape = shape;
-         ri.rnr_func.clear();
-         ri.rnr_offset = 0;
-         ri.vert_size = ri.norm_size = ri.index_size = 0;
-      } else if (rd && (ri.rnr_offset < 0)) {
+         ri.init = true;
+         ri.v = ri.n = ri.i = 0;
+      } else if (rd && !ri.init) {
          ri.shape = nullptr;
-         ri.rnr_offset = 0;
-
-         // fRndrOffest += rd->GetBinarySize();
-         // fRndrShapes.emplace_back(rd.get());
+         ri.init = true;
 
          ri.raw.resize(rd->GetBinarySize());
          rd->Write( reinterpret_cast<char *>(ri.raw.data()), ri.raw.size() );
 
-         ri.rnr_func = rd->GetRnrFunc();
-         ri.vert_size = rd->SizeV();
-         ri.norm_size = rd->SizeN();
-         ri.index_size = rd->SizeI();
+         ri.v = rd->SizeV();
+         ri.n = rd->SizeN();
+         ri.i = rd->SizeI();
       }
    }
 
@@ -738,11 +733,7 @@ void ROOT::Experimental::REveGeomDescription::CopyMaterialProperties(TGeoVolume 
 void ROOT::Experimental::REveGeomDescription::ResetRndrInfos()
 {
    for (auto &s: fShapes)
-      s.fRenderInfo.rnr_offset = -1;
-
-   fRndrShapes.clear();
-
-   fRndrOffest = 0;
+      s.fRenderInfo.init = false;
 }
 
 /////////////////////////////////////////////////////////////////////

--- a/graf3d/eve7/src/REveGeomData.cxx
+++ b/graf3d/eve7/src/REveGeomData.cxx
@@ -681,9 +681,13 @@ ROOT::Experimental::REveGeomDescription::MakeShapeDescr(TGeoShape *shape, bool a
          ri.vert_size = ri.norm_size = ri.index_size = 0;
       } else if (rd && (ri.rnr_offset < 0)) {
          ri.shape = nullptr;
-         ri.rnr_offset = fRndrOffest;
-         fRndrOffest += rd->GetBinarySize();
-         fRndrShapes.emplace_back(rd.get());
+         ri.rnr_offset = 0;
+
+         // fRndrOffest += rd->GetBinarySize();
+         // fRndrShapes.emplace_back(rd.get());
+
+         ri.raw.resize(rd->GetBinarySize());
+         rd->Write( reinterpret_cast<char *>(ri.raw.data()), ri.raw.size() );
 
          ri.rnr_func = rd->GetRnrFunc();
          ri.vert_size = rd->SizeV();

--- a/gui/qt5webdisplay/rootwebpage.cpp
+++ b/gui/qt5webdisplay/rootwebpage.cpp
@@ -23,7 +23,7 @@ void RootWebPage::javaScriptConsoleMessage(JavaScriptConsoleMessageLevel lvl, co
 {
    switch (lvl) {
    case InfoMessageLevel:
-      if (gDebug > 0)
+      //if (gDebug > 0)
          R__DEBUG_HERE("Qt") << Form("%s:%d: %s", src.toLatin1().constData(), lineNumber,
                                      message.toLatin1().constData());
       break;

--- a/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
@@ -56,6 +56,8 @@ public:
 
    RWebDisplayArgs(const char *browser);
 
+   RWebDisplayArgs(int width, int height, const std::string &browser = "");
+
    void SetBrowserKind(const std::string &kind);
    /// set browser kind, see EBrowserKind for allowed values
    void SetBrowserKind(EBrowserKind kind) { fKind = kind; }

--- a/gui/webdisplay/src/RWebDisplayArgs.cxx
+++ b/gui/webdisplay/src/RWebDisplayArgs.cxx
@@ -50,6 +50,17 @@ ROOT::Experimental::RWebDisplayArgs::RWebDisplayArgs(const char *browser)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
+/// Constructor - specify window width and height
+
+ROOT::Experimental::RWebDisplayArgs::RWebDisplayArgs(int width, int height, const std::string &browser)
+{
+   SetBrowserKind(browser);
+   SetWidth(width);
+   SetHeight(height);
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////
 /// Set browser kind as string argument
 /// Recognized values:
 ///  chrome  - use Google Chrome web browser, supports headless mode from v60, default

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -3008,6 +3008,8 @@ R__ALWAYS_INLINE void TBufferJSON::JsonWriteArrayCompress(const T *vname, Int_t 
          JsonWriteBasic(vname[indx]);
       }
       fValue.Append("]");
+   } else if (is_base64 && !arrsize) {
+      fValue.Append("[]");
    } else {
       fValue.Append("{");
       fValue.Append(TString::Format("\"$arr\":\"%s\"%s\"len\":%d", typname, fArraySepar.Data(), arrsize));

--- a/js/changes.md
+++ b/js/changes.md
@@ -6,6 +6,9 @@
 3. Implement monitoring of TGeoManager with THttpServer
 4. Provide "showtop" option for TGeoManager (equivalent to gGeoManager->SetTopVisible())
 5. Provide "no_screen" option to let ignore kVisOnScreen bits for display, checked first by default
+6. Support different marker styles in 3D drawings
+7. Implement interactive movement of TArrow class
+8. New and simpler TArrow drawing without use of svg markers
 
 
 ## Changes in 5.7.0

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -382,7 +382,7 @@
                   var dv = new DataView(arr.buffer, value.o || 0),
                       len = Math.min(buf.length, dv.byteLength);
                   for (var k=0; k<len; ++k)
-                     dv.setUint8(k, data.charCodeAt(k));
+                     dv.setUint8(k, buf.charCodeAt(k));
                } else {
                   throw new Error('base64 coding supported only for native arrays with binary data');
                }

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -96,7 +96,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 17/07/2019";
+   JSROOT.version = "dev 2/08/2019";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;

--- a/js/scripts/JSRootGeoBase.js
+++ b/js/scripts/JSRootGeoBase.js
@@ -3262,8 +3262,9 @@
                      setdefaults(chld);
                   }
                }
-            } else
-            if ((obj.$jsroot_depth===undefined) || (obj.$jsroot_depth < lvl)) traverse(chld, lvl, arr);
+            } else if ((obj.$jsroot_depth===undefined) || (obj.$jsroot_depth < lvl)) {
+               traverse(chld, lvl, arr);
+            }
          }
       }
 
@@ -3271,12 +3272,11 @@
          // resort meshes using ray caster and camera position
          // idea to identify meshes which are in front or behind
 
-         if (arr.length>300) {
+         if (arr.length > 300) {
             // too many of them, just set basic level and exit
             for (var i=0;i<arr.length;++i) arr[i].renderOrder = (minorder + maxorder)/2;
             return false;
          }
-
 
          var tmp_vect = new THREE.Vector3();
 

--- a/js/scripts/JSRootGeoPainter.js
+++ b/js/scripts/JSRootGeoPainter.js
@@ -812,10 +812,10 @@
       });
 
       appearance.addColor(this.options, 'background').name('Background').onChange( function() {
-          painter._renderer.setClearColor(painter.options.background, 1);
-          painter.Render3D(0);
-          var bkgr = new THREE.Color(painter.options.background);
-          painter._toolbar.changeBrightness((bkgr.r + bkgr.g + bkgr.b) < 1);
+         painter._renderer.setClearColor(painter.options.background, 1);
+         painter.Render3D(0);
+         var bkgr = new THREE.Color(painter.options.background);
+         painter._toolbar.changeBrightness((bkgr.r + bkgr.g + bkgr.b) < 1);
       });
 
       appearance.add(this, 'focusCamera').name('Reset camera position');
@@ -854,7 +854,7 @@
             'Mesh size': "size",
             'Central point': "pnt"
         } ).name("Rendering order").onChange( function ( value ) {
-           delete painter._last_camera_position; // used for testing depth
+           painter._forceProduceRenderOrder();
            painter.Render3D();
         } );
 
@@ -2102,14 +2102,11 @@
 
       if (!this._lookat || !this._camera0pos || !this._camera || !this.options) return;
 
-      var pos1 = new THREE.Vector3().add(this._camera0pos);
-      var pos2 = new THREE.Vector3().add(this._camera.position);
+      var pos1 = new THREE.Vector3().add(this._camera0pos).sub(this._lookat),
+          pos2 = new THREE.Vector3().add(this._camera.position).sub(this._lookat),
+          len1 = pos1.length(), len2 = pos2.length(),
+          zoom = this.options.zoom * len2 / len1 * 100;
 
-      pos1.sub(this._lookat);
-      pos2.sub(this._lookat);
-
-      var len1 = pos1.length(), len2 = pos2.length();
-      var zoom = this.options.zoom * len2 / len1 * 100;
       if (zoom < 1) zoom = 1; else if (zoom>10000) zoom = 10000;
 
       pos1.normalize();
@@ -2170,7 +2167,14 @@
 
       this._camera.updateProjectionMatrix();
 
-      var k = 2*this.options.zoom, max_all = Math.max(sizex,sizey,sizez);
+      var k = 2, max_all = Math.max(sizex,sizey,sizez);
+
+      if (this.options.zoom1) {
+         k = 2*this.options.zoom1;
+         delete this.options.zoom1;
+      } else {
+         k = 2*this.options.zoom;
+      }
 
       if ((this.options.rotatey || this.options.rotatez) && this.options.can_rotate) {
 
@@ -2197,7 +2201,7 @@
       }
 
       this._lookat = new THREE.Vector3(midx, midy, midz);
-      this._camera0pos = new THREE.Vector3(-k*max_all, 0, 0); // virtual 0 position, where rotation starts
+      this._camera0pos = new THREE.Vector3(-2*max_all, 0, 0); // virtual 0 position, where rotation starts
       this._camera.lookAt(this._lookat);
 
       this._pointLight.position.set(sizex/5, sizey/5, sizez/5);
@@ -2216,7 +2220,14 @@
       if (!this.options) return;
       this.options.rotatey = rotatey || 0;
       this.options.rotatez = rotatez || 0;
-      if (zoom && !isNaN(zoom)) this.options.zoom = zoom;
+      if (zoom && !isNaN(zoom)) {
+         this.options.zoom = zoom;
+      } else if (this._camera0pos && this._camera && this._lookat) {
+         var pos1 = new THREE.Vector3().add(this._camera0pos).sub(this._lookat),
+             pos2 = new THREE.Vector3().add(this._camera.position).sub(this._lookat);
+
+         this.options.zoom1 = pos2.length() / pos1.length();
+      }
       this.adjustCameraPosition();
    }
 
@@ -2664,6 +2675,7 @@
       var lineMaterial = new THREE.LineBasicMaterial({ color: track_color, linewidth: track_width }),
           line = JSROOT.Painter.createLineSegments(buf, lineMaterial);
 
+      line.renderOrder = 1000000; // to bring line to the front
       line.geo_name = itemname;
       line.geo_object = track;
       line.hightlightWidthScale = 2;
@@ -2703,6 +2715,7 @@
       var lineMaterial = new THREE.LineBasicMaterial({ color: track_color, linewidth: track_width }),
           line = JSROOT.Painter.createLineSegments(buf, lineMaterial);
 
+      line.renderOrder = 1000000; // to bring line to the front
       line.geo_name = itemname;
       line.geo_object = track;
       line.hightlightWidthScale = 2;
@@ -2734,8 +2747,11 @@
                        projy ? projv : hit.fP[i*3+1],
                        projz ? projv : hit.fP[i*3+2]);
 
-      var mesh = pnts.CreatePoints(JSROOT.Painter.root_colors[hit.fMarkerColor] || "rgb(0,0,255)");
+      var mesh = pnts.CreatePoints({ color: JSROOT.Painter.root_colors[hit.fMarkerColor] || "rgb(0,0,255)",
+                                     style: hit.fMarkerStyle,
+                                     callback: function(delayed) { if (delayed) this.Render3D(100); }.bind(this) });
 
+      mesh.renderOrder = 1000000; // to bring points to the front
       mesh.highlightScale = 2;
 
       mesh.geo_name = itemname;
@@ -3105,15 +3121,18 @@
       this.completeDraw(true);
    }
 
+   /** @brief Checks camera position and recalculate rendering order if needed
+    * @param force - if specified, forces calculations of render order
+    * @private
+    */
    TGeoPainter.prototype.TestCameraPosition = function(force) {
-
       this._camera.updateMatrixWorld();
       var origin = this._camera.position.clone();
 
       if (!force && this._last_camera_position) {
          // if camera position does not changed a lot, ignore such change
          var dist = this._last_camera_position.distanceTo(origin);
-         if (dist < (this._overall_size || 1000)/1e4) return;
+         if (dist < (this._overall_size || 1000)*1e-4) return;
       }
 
       this._last_camera_position = origin; // remember current camera position
@@ -3476,13 +3495,18 @@
          this.options._axis = true;
          this.drawSimpleAxis();
          if (force_draw !== true) {
-            this.TestCameraPosition(true);
+            this._forceProduceRenderOrder(); // used for testing depth
             this.Render3D();
          }
       }
    }
 
-   /** set axes visibility */
+   /** @brief Forces recalculation of rendering order before next rendering @private */
+   TGeoPainter.prototype._forceProduceRenderOrder = function() {
+      delete this._last_camera_position;
+   }
+
+   /** @brief Set axes visibility */
    TGeoPainter.prototype.setAxesDraw = function(on) {
       if (on != this.options._axis)
          this.toggleAxesDraw();
@@ -3523,7 +3547,7 @@
       if (this._full_redrawing) {
          this._full_redrawing = false;
          full_redraw = true;
-         this.TestCameraPosition(true); // recheck position
+         this._forceProduceRenderOrder();
       }
 
       if (this._first_drawing) {
@@ -3696,9 +3720,11 @@
       this._scene_height = 0;
       this._renderer = null;
       this._toplevel = null;
-      this._full_geom = null;
-      this._camera = null;
-      this._selected_mesh = null;
+      delete this._full_geom;
+      delete this._camera;
+      delete this._camera0pos;
+      delete this._lookat;
+      delete this._selected_mesh;
 
       if (this._clones && this._clones_owner)
          this._clones.Cleanup(this._draw_nodes, this._build_shapes);

--- a/js/scripts/JSRootPainter.hist.js
+++ b/js/scripts/JSRootPainter.hist.js
@@ -2072,7 +2072,6 @@
       this.nbinsy = 0;
       this.accept_drops = true; // indicate that one can drop other objects like doing Draw("same")
       this.mode3d = false;
-      this.DecomposeTitle();
    }
 
    THistPainter.prototype = Object.create(JSROOT.TObjectPainter.prototype);
@@ -2315,8 +2314,6 @@
             histo.fBins = obj.fBins;
          }
 
-         this.DecomposeTitle();
-
          if (obj.fFunctions && this.options.Func) {
             for (var n=0;n<obj.fFunctions.arr.length;++n) {
                var func = obj.fFunctions.arr[n];
@@ -2445,21 +2442,6 @@
       if (arg==='only-check') return !histo.TestBit(JSROOT.TH1StatusBits.kNoTitle);
       histo.InvertBit(JSROOT.TH1StatusBits.kNoTitle);
       this.DrawTitle();
-   }
-
-   THistPainter.prototype.DecomposeTitle = function() {
-      // if histogram title includes ;, set axis title
-
-      var histo = this.GetHisto();
-
-      if (!histo || !histo.fTitle) return;
-
-      var arr = histo.fTitle.split(';');
-      if (arr.length===3) {
-         histo.fTitle = arr[0];
-         histo.fXaxis.fTitle = arr[1];
-         histo.fYaxis.fTitle = arr[2];
-      }
    }
 
    THistPainter.prototype.DrawTitle = function() {

--- a/js/scripts/JSRootPainter.v6.js
+++ b/js/scripts/JSRootPainter.v6.js
@@ -685,10 +685,10 @@
       }
 
       if (JSROOT.gStyle.Zooming && !this.disable_zooming) {
-         var r =  axis_g.append("svg:rect")
-                        .attr("class", "axis_zoom")
-                        .style("opacity", "0")
-                        .style("cursor", "crosshair");
+         var r = axis_g.append("svg:rect")
+                       .attr("class", "axis_zoom")
+                       .style("opacity", "0")
+                       .style("cursor", "crosshair");
 
          if (vertical)
             r.attr("x", (side>0) ? (-2*labelsize - 3) : 3)
@@ -772,10 +772,10 @@
    TAxisPainter.prototype.Redraw = function() {
 
       var gaxis = this.GetObject(),
-          x1 = this.AxisToSvg("x", gaxis.fX1, "pad"),
-          y1 = this.AxisToSvg("y", gaxis.fY1, "pad"),
-          x2 = this.AxisToSvg("x", gaxis.fX2, "pad"),
-          y2 = this.AxisToSvg("y", gaxis.fY2, "pad"),
+          x1 = this.AxisToSvg("x", gaxis.fX1),
+          y1 = this.AxisToSvg("y", gaxis.fY1),
+          x2 = this.AxisToSvg("x", gaxis.fX2),
+          y2 = this.AxisToSvg("y", gaxis.fY2),
           w = x2 - x1, h = y1 - y2,
           vertical = Math.abs(w) < Math.abs(h),
           func = null, reverse = false, kind = "normal",
@@ -1167,8 +1167,7 @@
 
       if (this.x_kind == 'time') {
          this.x = d3.scaleTime();
-      } else
-      if (this.swap_xy ? pad.fLogy : pad.fLogx) {
+      } else if (this.swap_xy ? pad.fLogy : pad.fLogx) {
          this.logx = true;
 
          if (this.scale_xmax <= 0) this.scale_xmax = 0;
@@ -1196,8 +1195,7 @@
       if (this.x_kind == 'time') {
          // we emulate scale functionality
          this.grx = function(val) { return this.x(this.ConvertX(val)); }
-      } else
-      if (this.logx) {
+      } else if (this.logx) {
          this.grx = function(val) { return (val < this.scale_xmin) ? (this.swap_xy ? this.x.range()[0]+5 : -5) : this.x(val); }
       } else {
          this.grx = this.x;
@@ -1672,9 +1670,10 @@
               .attr("height", h)
               .attr("viewBox", "0 0 " + w + " " + h);
 
-      var tooltip_rect = this.draw_g.select(".interactive_rect");
+      // var tooltip_rect = this.draw_g.select(".interactive_rect");
+      // if (JSROOT.BatchMode) return tooltip_rect.remove();
 
-      if (JSROOT.BatchMode) return tooltip_rect.remove();
+      if (JSROOT.BatchMode) return;
 
       this.draw_g.attr("x", lm)
                  .attr("y", tm)
@@ -1685,15 +1684,19 @@
          this.AddDrag({ obj: this, only_resize: true, minwidth: 20, minheight: 20,
                         redraw: this.SizeChanged.bind(this) });
 
-      if (tooltip_rect.empty())
-         tooltip_rect =
-            this.draw_g
-                .append("rect")
-                .attr("class","interactive_rect")
-                .style('opacity',0)
-                .style('fill',"none")
-                .style("pointer-events","visibleFill")
-                .property('handlers_set', 0);
+      var tooltip_rect = main_svg;
+      tooltip_rect.style("pointer-events","visibleFill")
+                  .property('handlers_set', 0);
+
+      //  if (tooltip_rect.empty())
+      //     tooltip_rect =
+      //       this.draw_g
+      //          .append("rect")
+      //          .attr("class","interactive_rect")
+      //          .style('opacity',0)
+      //          .style('fill',"none")
+      //          .style("pointer-events","visibleFill")
+      //          .property('handlers_set', 0);
 
       var handlers_set = (pp && pp._fast_drawing) ? 0 : 1;
 

--- a/js/scripts/JSRootPainter.v7.js
+++ b/js/scripts/JSRootPainter.v7.js
@@ -786,10 +786,10 @@
    TAxisPainter.prototype.Redraw = function() {
 
       var gaxis = this.GetObject(),
-          x1 = this.AxisToSvg("x", gaxis.fX1, "pad"),
-          y1 = this.AxisToSvg("y", gaxis.fY1, "pad"),
-          x2 = this.AxisToSvg("x", gaxis.fX2, "pad"),
-          y2 = this.AxisToSvg("y", gaxis.fY2, "pad"),
+          x1 = this.AxisToSvg("x", gaxis.fX1),
+          y1 = this.AxisToSvg("y", gaxis.fY1),
+          x2 = this.AxisToSvg("x", gaxis.fX2),
+          y2 = this.AxisToSvg("y", gaxis.fY2),
           w = x2 - x1, h = y1 - y2,
           vertical = Math.abs(w) < Math.abs(h),
           func = null, reverse = false, kind = "normal",
@@ -1364,9 +1364,9 @@
               .attr("height", h)
               .attr("viewBox", "0 0 " + w + " " + h);
 
-      var tooltip_rect = this.draw_g.select(".interactive_rect");
-
-      if (JSROOT.BatchMode) return tooltip_rect.remove();
+      // var tooltip_rect = this.draw_g.select(".interactive_rect");
+      // if (JSROOT.BatchMode) return tooltip_rect.remove();
+      if (JSROOT.BatchMode) return;
 
       this.draw_g.attr("x", lm)
                  .attr("y", tm)
@@ -1377,15 +1377,19 @@
          this.AddDrag({ obj: this, only_resize: true, minwidth: 20, minheight: 20,
                         redraw: this.SizeChanged.bind(this) });
 
-      if (tooltip_rect.empty())
-         tooltip_rect =
-            this.draw_g
-                .append("rect")
-                .attr("class","interactive_rect")
-                .style('opacity',0)
-                .style('fill',"none")
-                .style("pointer-events","visibleFill")
-                .property('handlers_set', 0);
+      var tooltip_rect = main_svg;
+      tooltip_rect.style("pointer-events","visibleFill")
+                  .property('handlers_set', 0);
+
+      //if (tooltip_rect.empty())
+      //   tooltip_rect =
+      //      this.draw_g
+      //          .append("rect")
+      //          .attr("class","interactive_rect")
+      //          .style('opacity',0)
+      //          .style('fill',"none")
+      //          .style("pointer-events","visibleFill")
+      //          .property('handlers_set', 0);
 
       var handlers_set = (pp && pp._fast_drawing) ? 0 : 1;
 

--- a/js/scripts/JSRootPainter.v7hist.js
+++ b/js/scripts/JSRootPainter.v7hist.js
@@ -37,7 +37,6 @@
       this.accept_drops = true; // indicate that one can drop other objects like doing Draw("same")
       this.mode3d = false;
       this.zoom_changed_interactive = 0;
-      // this.DecomposeTitle();
    }
 
    THistPainter.prototype = Object.create(JSROOT.TObjectPainter.prototype);
@@ -295,9 +294,6 @@
 
    THistPainter.prototype.ToggleTitle = function(arg) {
       return false;
-   }
-
-   THistPainter.prototype.DecomposeTitle = function() {
    }
 
    THistPainter.prototype.DrawTitle = function() {

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -189,10 +189,8 @@ sap.ui.define(['sap/ui/core/Component',
       /** Entry point for all data from server */
       OnWebsocketMsg: function(handle, msg, offset) {
 
-         // binary data can be send only as addition to draw message
-         // here data can be placed in the queue and processed when all other prerequicities are done
          if (typeof msg != "string")
-            return this.checkDrawMsg("binary", null, msg, offset);
+            return console.error("Browser do not uses binary messages len = " + mgs.byteLength);
 
          var mhdr = msg.substr(0,6);
          msg = msg.substr(6);
@@ -221,12 +219,6 @@ sap.ui.define(['sap/ui/core/Component',
                   //    tt.autoResizeColumn(k);
                }
             }
-            break;
-         case "MODIF:":
-            this.modifyDescription(msg);
-            break;
-         case "APPND:":
-            this.checkDrawMsg("append", JSROOT.parse(msg));
             break;
          default:
             console.error('Non recognized msg ' + mhdr + ' len=' + msg.length);

--- a/ui5/eve7/controller/GeomViewer.controller.js
+++ b/ui5/eve7/controller/GeomViewer.controller.js
@@ -342,7 +342,7 @@ sap.ui.define(['sap/ui/core/Component',
             }
 
             item.server_shape = rd.server_shape =
-               this.createServerShape(rd, draw_msg.raw, draw_msg.offset);
+               this.createServerShape(rd /*, draw_msg.raw, draw_msg.offset*/);
          }
 
          if (old_gradpersegm)
@@ -352,7 +352,7 @@ sap.ui.define(['sap/ui/core/Component',
       },
 
       /** Create single shape from provided raw data */
-      createServerShape: function(rd, raw, off) {
+      createServerShape: function(rd) {
 
          if (rd.shape) {
             // case when TGeoShape provided as is
@@ -365,20 +365,30 @@ sap.ui.define(['sap/ui/core/Component',
             }
          }
 
-         off = (off || 0) + rd.rnr_offset;
+         if (!rd.raw || (rd.raw.length==0)) {
+            console.error('No raw data at all');
+            return null;
+         }
+
+         if (!rd.raw.buffer) {
+            console.error('No raw buffer');
+            return null;
+         }
+
+         var off = 0;
 
          if (rd.vert_size) {
-            rd.vtxBuff = new Float32Array(raw, off, rd.vert_size);
+            rd.vtxBuff = new Float32Array(rd.raw.buffer, off, rd.vert_size);
             off += rd.vert_size*4;
          }
 
          if (rd.norm_size) {
-            rd.nrmBuff = new Float32Array(raw, off, rd.norm_size);
+            rd.nrmBuff = new Float32Array(rd.raw.buffer, off, rd.norm_size);
             off += rd.norm_size*4;
          }
 
          if (rd.index_size) {
-            rd.idxBuff = new Uint32Array(raw, off, rd.index_size);
+            rd.idxBuff = new Uint32Array(rd.raw.buffer, off, rd.index_size);
             off += rd.index_size*4;
          }
 
@@ -892,8 +902,8 @@ sap.ui.define(['sap/ui/core/Component',
 
          var server_shape = null;
 
-         if (info.ri && info.rndr_binary)
-            server_shape = this.createServerShape(info.ri, info.rndr_binary.buffer, 0);
+         if (info.ri /* && info.rndr_binary*/)
+            server_shape = this.createServerShape(info.ri /*, info.rndr_binary.buffer, 0*/);
 
          this.drawNodeShape(server_shape, false);
       },

--- a/ui5/eve7/controller/GeomViewer.controller.js
+++ b/ui5/eve7/controller/GeomViewer.controller.js
@@ -377,19 +377,19 @@ sap.ui.define(['sap/ui/core/Component',
 
          var off = 0;
 
-         if (rd.vert_size) {
-            rd.vtxBuff = new Float32Array(rd.raw.buffer, off, rd.vert_size);
-            off += rd.vert_size*4;
+         if (rd.v) {
+            rd.vtxBuff = new Float32Array(rd.raw.buffer, off, rd.v);
+            off += rd.v*4;
          }
 
-         if (rd.norm_size) {
-            rd.nrmBuff = new Float32Array(rd.raw.buffer, off, rd.norm_size);
-            off += rd.norm_size*4;
+         if (rd.n) {
+            rd.nrmBuff = new Float32Array(rd.raw.buffer, off, rd.n);
+            off += rd.n*4;
          }
 
-         if (rd.index_size) {
-            rd.idxBuff = new Uint32Array(rd.raw.buffer, off, rd.index_size);
-            off += rd.index_size*4;
+         if (rd.i) {
+            rd.idxBuff = new Uint32Array(rd.raw.buffer, off, rd.i);
+            off += rd.i*4;
          }
 
          // shape handle is similar to created in JSROOT.GeoPainter
@@ -397,18 +397,15 @@ sap.ui.define(['sap/ui/core/Component',
             _typename: "$$Shape$$", // indicate that shape can be used as is
             ready: true,
             geom: this.creator.makeEveGeometry(rd),
-            nfaces: (rd.index_size-2)/3
+            nfaces: (rd.i-2)/3
          };
       },
 
       /** function to accumulate and process all drawings messages
        * if not all scripts are loaded, messages are quied and processed later */
 
-      checkDrawMsg: function(kind, msg, _raw, _offset) {
-         if (kind == "binary") {
-            if (_raw)
-               return console.error("Did not process raw data " + _raw.byteLength + " offset " + _offset);
-         } else if (kind) {
+      checkDrawMsg: function(kind, msg) {
+         if (kind) {
             if (!msg)
                return console.error("No message is provided for " + kind);
 
@@ -483,7 +480,7 @@ sap.ui.define(['sap/ui/core/Component',
          // binary data can be send only as addition to draw message
          // here data can be placed in the queue and processed when all other prerequicities are done
          if (typeof msg != "string")
-            return this.checkDrawMsg("binary", null, msg, offset);
+            return console.error("Geom viewer do not uses binary messages len = " + mgs.byteLength);
 
          var mhdr = msg.substr(0,6);
          msg = msg.substr(6);

--- a/ui5/eve7/controller/GeomViewer.controller.js
+++ b/ui5/eve7/controller/GeomViewer.controller.js
@@ -342,7 +342,7 @@ sap.ui.define(['sap/ui/core/Component',
             }
 
             item.server_shape = rd.server_shape =
-               this.createServerShape(rd /*, draw_msg.raw, draw_msg.offset*/);
+               this.createServerShape(rd);
          }
 
          if (old_gradpersegm)
@@ -406,15 +406,6 @@ sap.ui.define(['sap/ui/core/Component',
 
       checkDrawMsg: function(kind, msg, _raw, _offset) {
          if (kind == "binary") {
-            for (var k = 0; k < this.queue.length; ++k) {
-               if (this.queue[k].binlen && !this.queue[k].raw) {
-                  this.queue[k].raw = _raw;
-                  this.queue[k].offset = _offset;
-                  _raw = null;
-                  break;
-               }
-            }
-
             if (_raw)
                return console.error("Did not process raw data " + _raw.byteLength + " offset " + _offset);
          } else if (kind) {
@@ -429,10 +420,6 @@ sap.ui.define(['sap/ui/core/Component',
          if (!this.creator ||            // complete JSROOT/EVE7 TGeo functionality is loaded
             !this.queue.length ||        // drawing messages are created
             !this.renderingDone) return; // UI5 rendering is performed
-
-         // first message in the queue still waiting for raw data
-         if (this.queue[0].binlen && !this.queue[0].raw)
-            return;
 
          // only from here we can start to analyze messages and create TGeo painter, clones objects and so on
 
@@ -460,7 +447,7 @@ sap.ui.define(['sap/ui/core/Component',
             case "found":
                // only extend nodes and decode shapes
                if (this.extractRawShapes(msg))
-                  this.paintFoundNodes(msg.visibles, true, msg.binlen > 0);
+                  this.paintFoundNodes(msg.visibles, true);
                break;
 
             case "append":
@@ -742,10 +729,10 @@ sap.ui.define(['sap/ui/core/Component',
       },
 
       /** Paint extra node - or remove them from painting */
-      paintFoundNodes: function(visibles, append_more, with_binaries) {
+      paintFoundNodes: function(visibles, append_more) {
          if (!this.geo_painter) return;
 
-         if (append_more && (with_binaries || !visibles))
+         if (append_more)
             this.geo_painter.appendMoreNodes(visibles || null);
 
          if (visibles && visibles.length && (visibles.length < 100)) {
@@ -902,8 +889,8 @@ sap.ui.define(['sap/ui/core/Component',
 
          var server_shape = null;
 
-         if (info.ri /* && info.rndr_binary*/)
-            server_shape = this.createServerShape(info.ri /*, info.rndr_binary.buffer, 0*/);
+         if (info.ri)
+            server_shape = this.createServerShape(info.ri);
 
          this.drawNodeShape(server_shape, false);
       },


### PR DESCRIPTION
Binary data has to be transferred as separate data packet
This makes logic complicated especially when many small raw packets should be used
Using `JSON_base64` marker in class info, one can insert raw data in ROOT JSON and 
use such binary at the place. This significantly simplifies data handling. 
Same approach can be later used for eve7