### PR TITLE
[rootcling] Complain if no headers files are specified.

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -1084,6 +1084,11 @@ function(ROOT_STANDARD_LIBRARY_PACKAGE libname)
                        )
   endif(ARG_OBJECT_LIBRARY)
 
+  if (NOT (ARG_HEADERS OR ARG_NODEPHEADERS))
+    message(AUTHOR_WARNING "Called with no HEADERS and no NODEPHEADER. The generated "
+      "dictionary will be empty. Consider using ROOT_LINKER_LIBRARY instead.")
+  endif()
+
   ROOT_GENERATE_DICTIONARY(G__${libname} ${ARG_HEADERS}
                           ${MODULE_GEN_ARG}
                           ${STAGE1_FLAG}

--- a/graf2d/quartz/CMakeLists.txt
+++ b/graf2d/quartz/CMakeLists.txt
@@ -11,9 +11,8 @@
 
 add_definitions("-ObjC++")
 
-ROOT_STANDARD_LIBRARY_PACKAGE(GQuartz
-  NO_HEADERS
-  SOURCES
+# Dictionary not needed.
+ROOT_LINKER_LIBRARY(GQuartz
     src/QuartzFillArea.mm
     src/QuartzLine.mm
     src/QuartzMarker.mm

--- a/graf2d/quartz/inc/LinkDef.h
+++ b/graf2d/quartz/inc/LinkDef.h
@@ -1,7 +1,0 @@
-#ifdef __CINT__
-
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
-
-#endif


### PR DESCRIPTION
Calling rootcling with no header files creates an empty and useless dictionary.
Users should be notified as usually that's not what they want.