### PR TITLE
Fix GDML parsing for material/surface property tables

### DIFF
--- a/geom/gdml/inc/TGDMLWrite.h
+++ b/geom/gdml/inc/TGDMLWrite.h
@@ -74,7 +74,7 @@ public:
    //wrapper of all main methods for extraction
    void WriteGDMLfile(TGeoManager * geomanager, const char* filename = "test.gdml", TString option = "");
    // Wrapper to only selectively write one branch of the volume hierarchy to file
-   void WriteGDMLfile(TGeoManager * geomanager, TGeoVolume* volume, const char* filename = "test.gdml", TString option = "");
+   void WriteGDMLfile(TGeoManager * geomanager, TGeoNode* top_node, const char* filename = "test.gdml", TString option = "");
 
    enum ENamingType {
       kelegantButSlow = 0,
@@ -145,7 +145,7 @@ private:
    //1. Main methods to extract everything from ROOT gGeoManager
    XMLNodePointer_t ExtractMaterials(TList* materialsLst); //result <materials>...
    TString          ExtractSolid(TGeoShape* volShape);     //adds <shape> to <solids>
-   void             ExtractVolumes(TGeoVolume* volume);    //result <volume> node...  + corresp. shape
+   void             ExtractVolumes(TGeoNode* topNode);    //result <volume> node...  + corresp. shape
    void             ExtractMatrices(TObjArray *matrices);  //adds <matrix> to <define>
    void             ExtractConstants(TGeoManager *geom);   //adds <constant> to <define>
    void             ExtractOpticalSurfaces(TObjArray *surfaces); //adds <opticalsurface> to <solids>
@@ -153,7 +153,7 @@ private:
    void             ExtractBorderSurfaces(TObjArray *surfaces);  //adds <bordersurface> to <structure>
 
    // Combined implementation to extract GDML information from the geometry tree
-   void WriteGDMLfile(TGeoManager * geomanager, TGeoVolume* volume, TList* materialsLst, const char* filename, TString option);
+   void WriteGDMLfile(TGeoManager * geomanager, TGeoNode* top_node, TList* materialsLst, const char* filename, TString option);
 
    //1.1 Materials sub methods - creating Nodes
    XMLNodePointer_t CreateAtomN(Double_t atom, const char * unit = "g/mole");

--- a/geom/gdml/src/TGDMLParse.cxx
+++ b/geom/gdml/src/TGDMLParse.cxx
@@ -581,7 +581,8 @@ XMLNodePointer_t TGDMLParse::MatrixProcess(TXMLEngine* gdml, XMLNodePointer_t no
    {
       std::string matrixValue;
       valueStream >> matrixValue;
-
+      // protect against trailing '\n' and other white spaces
+      if ( matrixValue.empty() ) continue;
       valueList.push_back(Value(matrixValue.c_str()));
    }
 
@@ -1664,8 +1665,10 @@ XMLNodePointer_t TGDMLParse::BorderSurfaceProcess(TXMLEngine* gdml, XMLNodePoint
    TGeoNode *node1 = fpvolmap[nodename[0].Data()];
    TGeoNode *node2 = fpvolmap[nodename[1].Data()];
    if (!node1 || !node2)
-      Fatal("BorderSurfaceProcess", "Border surface %s: not found nodes %s or %s",
-            name.Data(), nodename[0].Data(), nodename[1].Data());
+      Fatal("BorderSurfaceProcess", "Border surface %s: not found nodes %s [%s] or %s [%s]",
+            name.Data(),
+            nodename[0].Data(), node1 ? "present" : "missing",
+            nodename[1].Data(), node2 ? "present" : "missing");
 
    TGeoBorderSurface *border = new TGeoBorderSurface(name, surfname, surf, node1, node2);
    gGeoManager->AddBorderSurface(border);

--- a/geom/gdml/src/TGDMLWrite.cxx
+++ b/geom/gdml/src/TGDMLWrite.cxx
@@ -315,12 +315,12 @@ void TGDMLWrite::WriteGDMLfile(TGeoManager * geomanager,
    fGdmlFile = fGdmlE->NewDoc();
 
    //create root node and add it to blank GDML file
-   XMLNodePointer_t rootNode = fGdmlE->NewChild(0, 0, krootNodeName, 0);
+   XMLNodePointer_t rootNode = fGdmlE->NewChild(nullptr, nullptr, krootNodeName, 0);
    fGdmlE->DocSetRootElement(fGdmlFile, rootNode);
 
    //add namespaces to root node
    fGdmlE->NewNS(rootNode, knsRefGeneral, knsNameGeneral);
-   fGdmlE->NewAttr(rootNode, 0, knsNameGdml, knsRefGdml);
+   fGdmlE->NewAttr(rootNode, nullptr, knsNameGdml, knsRefGdml);
 
    //initialize general lists and <define>, <solids>, <structure> nodes
    fIsotopeList  = new StructLst;
@@ -328,9 +328,9 @@ void TGDMLWrite::WriteGDMLfile(TGeoManager * geomanager,
 
    fNameList     = new NameLst;
 
-   fDefineNode = fGdmlE->NewChild(0, 0, "define", 0);
-   fSolidsNode = fGdmlE->NewChild(0, 0, "solids", 0);
-   fStructureNode = fGdmlE->NewChild(0, 0, "structure", 0);
+   fDefineNode = fGdmlE->NewChild(nullptr, nullptr, "define", 0);
+   fSolidsNode = fGdmlE->NewChild(nullptr, nullptr, "solids", 0);
+   fStructureNode = fGdmlE->NewChild(nullptr, nullptr, "structure", 0);
    //========================
 
    //initialize list of accepted patterns for divisions (in ExtractVolumes)
@@ -500,7 +500,7 @@ XMLNodePointer_t TGDMLWrite::ExtractMaterials(TList* materialsLst)
 {
    Info("ExtractMaterials", "Extracting materials");
    //crate main <materials> node
-   XMLNodePointer_t materialsN = fGdmlE->NewChild(0, 0, "materials", 0);
+   XMLNodePointer_t materialsN = fGdmlE->NewChild(nullptr, nullptr, "materials", 0);
    Int_t matcnt = 0;
 
    //go through materials  - iterator and object declaration
@@ -650,11 +650,11 @@ void TGDMLWrite::ExtractVolumes(TGeoNode* node)
          lz = geoNode->GetMatrix()->GetRotationMatrix()[8];
          if (geoNode->GetMatrix()->IsReflection()
              && TMath::Abs(lx) == 1 &&  TMath::Abs(ly) == 1 && TMath::Abs(lz) == 1) {
-            scaleN = fGdmlE->NewChild(0, 0, "scale", 0);
-            fGdmlE->NewAttr(scaleN, 0, "name", (nodename + "scl").Data());
-            fGdmlE->NewAttr(scaleN, 0, "x", TString::Format(fltPrecision.Data(), lx));
-            fGdmlE->NewAttr(scaleN, 0, "y", TString::Format(fltPrecision.Data(), ly));
-            fGdmlE->NewAttr(scaleN, 0, "z", TString::Format(fltPrecision.Data(), lz));
+            scaleN = fGdmlE->NewChild(nullptr, nullptr, "scale", 0);
+            fGdmlE->NewAttr(scaleN, nullptr, "name", (nodename + "scl").Data());
+            fGdmlE->NewAttr(scaleN, nullptr, "x", TString::Format(fltPrecision.Data(), lx));
+            fGdmlE->NewAttr(scaleN, nullptr, "y", TString::Format(fltPrecision.Data(), ly));
+            fGdmlE->NewAttr(scaleN, nullptr, "z", TString::Format(fltPrecision.Data(), lz));
             //experimentally found out, that rotation should be updated like this
             if (lx == -1) {
                zangle = 180;
@@ -714,9 +714,9 @@ void TGDMLWrite::ExtractVolumes(TGeoNode* node)
 XMLNodePointer_t TGDMLWrite::CreateAtomN(Double_t atom, const char * unit)
 {
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
-   XMLNodePointer_t atomN = fGdmlE->NewChild(0, 0, "atom", 0);
-   fGdmlE->NewAttr(atomN, 0, "unit", unit);
-   fGdmlE->NewAttr(atomN, 0, "value", TString::Format(fltPrecision.Data(), atom));
+   XMLNodePointer_t atomN = fGdmlE->NewChild(nullptr, nullptr, "atom", 0);
+   fGdmlE->NewAttr(atomN, nullptr, "unit", unit);
+   fGdmlE->NewAttr(atomN, nullptr, "value", TString::Format(fltPrecision.Data(), atom));
    return atomN;
 }
 
@@ -726,9 +726,9 @@ XMLNodePointer_t TGDMLWrite::CreateAtomN(Double_t atom, const char * unit)
 XMLNodePointer_t TGDMLWrite::CreateDN(Double_t density, const char * unit)
 {
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
-   XMLNodePointer_t densN = fGdmlE->NewChild(0, 0, "D", 0);
-   fGdmlE->NewAttr(densN, 0, "unit", unit);
-   fGdmlE->NewAttr(densN, 0, "value", TString::Format(fltPrecision.Data(), density));
+   XMLNodePointer_t densN = fGdmlE->NewChild(nullptr, nullptr, "D", 0);
+   fGdmlE->NewAttr(densN, nullptr, "unit", unit);
+   fGdmlE->NewAttr(densN, nullptr, "value", TString::Format(fltPrecision.Data(), density));
    return densN;
 }
 
@@ -738,9 +738,9 @@ XMLNodePointer_t TGDMLWrite::CreateDN(Double_t density, const char * unit)
 XMLNodePointer_t TGDMLWrite::CreateFractionN(Double_t percentage, const char * refName)
 {
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
-   XMLNodePointer_t fractN = fGdmlE->NewChild(0, 0, "fraction", 0);
-   fGdmlE->NewAttr(fractN, 0, "n", TString::Format(fltPrecision.Data(), percentage));
-   fGdmlE->NewAttr(fractN, 0, "ref", refName);
+   XMLNodePointer_t fractN = fGdmlE->NewChild(nullptr, nullptr, "fraction", 0);
+   fGdmlE->NewAttr(fractN, nullptr, "n", TString::Format(fltPrecision.Data(), percentage));
+   fGdmlE->NewAttr(fractN, nullptr, "ref", refName);
    return fractN;
 }
 
@@ -749,9 +749,9 @@ XMLNodePointer_t TGDMLWrite::CreateFractionN(Double_t percentage, const char * r
 
 XMLNodePointer_t TGDMLWrite::CreatePropertyN(TNamed const &property)
 {
-  XMLNodePointer_t propertyN = fGdmlE->NewChild(0, 0, "property", 0);
-  fGdmlE->NewAttr(propertyN, 0, "name", property.GetName());
-  fGdmlE->NewAttr(propertyN, 0, "ref", property.GetTitle());
+  XMLNodePointer_t propertyN = fGdmlE->NewChild(nullptr, nullptr, "property", 0);
+  fGdmlE->NewAttr(propertyN, nullptr, "name", property.GetName());
+  fGdmlE->NewAttr(propertyN, nullptr, "ref", property.GetTitle());
   return propertyN;
 }
 
@@ -760,10 +760,10 @@ XMLNodePointer_t TGDMLWrite::CreatePropertyN(TNamed const &property)
 
 XMLNodePointer_t TGDMLWrite::CreateIsotopN(TGeoIsotope * isotope, const char * name)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "isotope", 0);
-   fGdmlE->NewAttr(mainN, 0, "name", name);
-   fGdmlE->NewAttr(mainN, 0, "N", TString::Format("%i", isotope->GetN()));
-   fGdmlE->NewAttr(mainN, 0, "Z", TString::Format("%i", isotope->GetZ()));
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "isotope", 0);
+   fGdmlE->NewAttr(mainN, nullptr, "name", name);
+   fGdmlE->NewAttr(mainN, nullptr, "N", TString::Format("%i", isotope->GetN()));
+   fGdmlE->NewAttr(mainN, nullptr, "Z", TString::Format("%i", isotope->GetZ()));
    fGdmlE->AddChild(mainN, CreateAtomN(isotope->GetA()));
    return mainN;
 }
@@ -774,8 +774,8 @@ XMLNodePointer_t TGDMLWrite::CreateIsotopN(TGeoIsotope * isotope, const char * n
 
 XMLNodePointer_t TGDMLWrite::CreateElementN(TGeoElement * element, XMLNodePointer_t materials, const char * name)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "element", 0);
-   fGdmlE->NewAttr(mainN, 0, "name", name);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "element", 0);
+   fGdmlE->NewAttr(mainN, nullptr, "name", name);
    //local associative arrays for saving isotopes and their weight
    //inside element
    NameListF wPercentage;
@@ -821,11 +821,11 @@ XMLNodePointer_t TGDMLWrite::CreateElementN(TGeoElement * element, XMLNodePointe
          fGdmlE->AddChild(mainN, CreateFractionN(wPercentage[itr->first], itr->first.Data()));
       }
    } else {
-      fGdmlE->NewAttr(mainN, 0, "formula", element->GetName());
+      fGdmlE->NewAttr(mainN, nullptr, "formula", element->GetName());
       Int_t valZ = element->Z();
       // Z can't be <1 in Geant4 and Z is optional parameter
       if (valZ >= 1) {
-         fGdmlE->NewAttr(mainN, 0, "Z", TString::Format("%i", valZ));
+         fGdmlE->NewAttr(mainN, nullptr, "Z", TString::Format("%i", valZ));
       }
       fGdmlE->AddChild(mainN, CreateAtomN(element->A()));
    }
@@ -837,8 +837,8 @@ XMLNodePointer_t TGDMLWrite::CreateElementN(TGeoElement * element, XMLNodePointe
 
 XMLNodePointer_t TGDMLWrite::CreateMixtureN(TGeoMixture * mixture, XMLNodePointer_t materials, TString mname)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "material", 0);
-   fGdmlE->NewAttr(mainN, 0, "name", mname);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "material", 0);
+   fGdmlE->NewAttr(mainN, nullptr, "name", mname);
    fGdmlE->AddChild(mainN, CreateDN(mixture->GetDensity()));
    //local associative arrays for saving elements and their weight
    //inside mixture
@@ -907,8 +907,8 @@ XMLNodePointer_t TGDMLWrite::CreateMixtureN(TGeoMixture * mixture, XMLNodePointe
 
 XMLNodePointer_t TGDMLWrite::CreateMaterialN(TGeoMaterial * material, TString mname)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "material", 0);
-   fGdmlE->NewAttr(mainN, 0, "name", mname);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "material", 0);
+   fGdmlE->NewAttr(mainN, nullptr, "name", mname);
    Double_t valZ = material->GetZ();
    //Z can't be zero in Geant4 so this is workaround for vacuum
    TString tmpname = mname;
@@ -927,7 +927,7 @@ XMLNodePointer_t TGDMLWrite::CreateMaterialN(TGeoMaterial * material, TString mn
          }
       }
    }
-   fGdmlE->NewAttr(mainN, 0, "Z", TString::Format(fltPrecision.Data(), valZ)); //material->GetZ()));
+   fGdmlE->NewAttr(mainN, nullptr, "Z", TString::Format(fltPrecision.Data(), valZ)); //material->GetZ()));
    fGdmlE->AddChild(mainN, CreateDN(material->GetDensity()));
    fGdmlE->AddChild(mainN, CreateAtomN(material->GetA()));
    // Create properties if any
@@ -954,20 +954,20 @@ XMLNodePointer_t TGDMLWrite::CreateMaterialN(TGeoMaterial * material, TString mn
 
 XMLNodePointer_t TGDMLWrite::CreateBoxN(TGeoBBox * geoShape)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "box", 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "box", 0);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
-   fGdmlE->NewAttr(mainN, 0, "name", lname);
+   fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetDX(), "DX", lname) ||
        IsNullParam(geoShape->GetDY(), "DY", lname) ||
        IsNullParam(geoShape->GetDZ(), "DZ", lname)) {
       return NULL;
    }
-   fGdmlE->NewAttr(mainN, 0, "x", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDX()));
-   fGdmlE->NewAttr(mainN, 0, "y", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDY()));
-   fGdmlE->NewAttr(mainN, 0, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDZ()));
+   fGdmlE->NewAttr(mainN, nullptr, "x", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDX()));
+   fGdmlE->NewAttr(mainN, nullptr, "y", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDY()));
+   fGdmlE->NewAttr(mainN, nullptr, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDZ()));
 
-   fGdmlE->NewAttr(mainN, 0, "lunit", "cm");
+   fGdmlE->NewAttr(mainN, nullptr, "lunit", "cm");
    return mainN;
 }
 
@@ -976,19 +976,19 @@ XMLNodePointer_t TGDMLWrite::CreateBoxN(TGeoBBox * geoShape)
 
 XMLNodePointer_t TGDMLWrite::CreateParaboloidN(TGeoParaboloid * geoShape)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "paraboloid", 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "paraboloid", 0);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
-   fGdmlE->NewAttr(mainN, 0, "name", lname);
+   fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetRhi(), "Rhi", lname) ||
        IsNullParam(geoShape->GetDz(), "Dz", lname)) {
       return NULL;
    }
-   fGdmlE->NewAttr(mainN, 0, "rlo", TString::Format(fltPrecision.Data(), geoShape->GetRlo()));
-   fGdmlE->NewAttr(mainN, 0, "rhi", TString::Format(fltPrecision.Data(), geoShape->GetRhi()));
-   fGdmlE->NewAttr(mainN, 0, "dz", TString::Format(fltPrecision.Data(), geoShape->GetDz()));
+   fGdmlE->NewAttr(mainN, nullptr, "rlo", TString::Format(fltPrecision.Data(), geoShape->GetRlo()));
+   fGdmlE->NewAttr(mainN, nullptr, "rhi", TString::Format(fltPrecision.Data(), geoShape->GetRhi()));
+   fGdmlE->NewAttr(mainN, nullptr, "dz", TString::Format(fltPrecision.Data(), geoShape->GetDz()));
 
-   fGdmlE->NewAttr(mainN, 0, "lunit", "cm");
+   fGdmlE->NewAttr(mainN, nullptr, "lunit", "cm");
    return mainN;
 }
 
@@ -997,23 +997,23 @@ XMLNodePointer_t TGDMLWrite::CreateParaboloidN(TGeoParaboloid * geoShape)
 
 XMLNodePointer_t TGDMLWrite::CreateSphereN(TGeoSphere * geoShape)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "sphere", 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "sphere", 0);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
-   fGdmlE->NewAttr(mainN, 0, "name", lname);
+   fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetRmax(), "Rmax", lname)) {
       return NULL;
    }
 
-   fGdmlE->NewAttr(mainN, 0, "rmin", TString::Format(fltPrecision.Data(), geoShape->GetRmin()));
-   fGdmlE->NewAttr(mainN, 0, "rmax", TString::Format(fltPrecision.Data(), geoShape->GetRmax()));
-   fGdmlE->NewAttr(mainN, 0, "startphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi1()));
-   fGdmlE->NewAttr(mainN, 0, "deltaphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi2() - geoShape->GetPhi1()));
-   fGdmlE->NewAttr(mainN, 0, "starttheta", TString::Format(fltPrecision.Data(), geoShape->GetTheta1()));
-   fGdmlE->NewAttr(mainN, 0, "deltatheta", TString::Format(fltPrecision.Data(), geoShape->GetTheta2() - geoShape->GetTheta1()));
+   fGdmlE->NewAttr(mainN, nullptr, "rmin", TString::Format(fltPrecision.Data(), geoShape->GetRmin()));
+   fGdmlE->NewAttr(mainN, nullptr, "rmax", TString::Format(fltPrecision.Data(), geoShape->GetRmax()));
+   fGdmlE->NewAttr(mainN, nullptr, "startphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi1()));
+   fGdmlE->NewAttr(mainN, nullptr, "deltaphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi2() - geoShape->GetPhi1()));
+   fGdmlE->NewAttr(mainN, nullptr, "starttheta", TString::Format(fltPrecision.Data(), geoShape->GetTheta1()));
+   fGdmlE->NewAttr(mainN, nullptr, "deltatheta", TString::Format(fltPrecision.Data(), geoShape->GetTheta2() - geoShape->GetTheta1()));
 
-   fGdmlE->NewAttr(mainN, 0, "aunit", "deg");
-   fGdmlE->NewAttr(mainN, 0, "lunit", "cm");
+   fGdmlE->NewAttr(mainN, nullptr, "aunit", "deg");
+   fGdmlE->NewAttr(mainN, nullptr, "lunit", "cm");
    return mainN;
 }
 
@@ -1022,33 +1022,33 @@ XMLNodePointer_t TGDMLWrite::CreateSphereN(TGeoSphere * geoShape)
 
 XMLNodePointer_t TGDMLWrite::CreateArb8N(TGeoArb8 * geoShape)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "arb8", 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "arb8", 0);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
-   fGdmlE->NewAttr(mainN, 0, "name", lname);
+   fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetDz(), "Dz", lname)) {
       return NULL;
    }
 
-   fGdmlE->NewAttr(mainN, 0, "v1x", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[0]));
-   fGdmlE->NewAttr(mainN, 0, "v1y", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[1]));
-   fGdmlE->NewAttr(mainN, 0, "v2x", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[2]));
-   fGdmlE->NewAttr(mainN, 0, "v2y", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[3]));
-   fGdmlE->NewAttr(mainN, 0, "v3x", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[4]));
-   fGdmlE->NewAttr(mainN, 0, "v3y", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[5]));
-   fGdmlE->NewAttr(mainN, 0, "v4x", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[6]));
-   fGdmlE->NewAttr(mainN, 0, "v4y", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[7]));
-   fGdmlE->NewAttr(mainN, 0, "v5x", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[8]));
-   fGdmlE->NewAttr(mainN, 0, "v5y", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[9]));
-   fGdmlE->NewAttr(mainN, 0, "v6x", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[10]));
-   fGdmlE->NewAttr(mainN, 0, "v6y", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[11]));
-   fGdmlE->NewAttr(mainN, 0, "v7x", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[12]));
-   fGdmlE->NewAttr(mainN, 0, "v7y", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[13]));
-   fGdmlE->NewAttr(mainN, 0, "v8x", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[14]));
-   fGdmlE->NewAttr(mainN, 0, "v8y", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[15]));
-   fGdmlE->NewAttr(mainN, 0, "dz", TString::Format(fltPrecision.Data(), geoShape->GetDz()));
+   fGdmlE->NewAttr(mainN, nullptr, "v1x", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[0]));
+   fGdmlE->NewAttr(mainN, nullptr, "v1y", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[1]));
+   fGdmlE->NewAttr(mainN, nullptr, "v2x", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[2]));
+   fGdmlE->NewAttr(mainN, nullptr, "v2y", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[3]));
+   fGdmlE->NewAttr(mainN, nullptr, "v3x", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[4]));
+   fGdmlE->NewAttr(mainN, nullptr, "v3y", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[5]));
+   fGdmlE->NewAttr(mainN, nullptr, "v4x", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[6]));
+   fGdmlE->NewAttr(mainN, nullptr, "v4y", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[7]));
+   fGdmlE->NewAttr(mainN, nullptr, "v5x", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[8]));
+   fGdmlE->NewAttr(mainN, nullptr, "v5y", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[9]));
+   fGdmlE->NewAttr(mainN, nullptr, "v6x", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[10]));
+   fGdmlE->NewAttr(mainN, nullptr, "v6y", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[11]));
+   fGdmlE->NewAttr(mainN, nullptr, "v7x", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[12]));
+   fGdmlE->NewAttr(mainN, nullptr, "v7y", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[13]));
+   fGdmlE->NewAttr(mainN, nullptr, "v8x", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[14]));
+   fGdmlE->NewAttr(mainN, nullptr, "v8y", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[15]));
+   fGdmlE->NewAttr(mainN, nullptr, "dz", TString::Format(fltPrecision.Data(), geoShape->GetDz()));
 
-   fGdmlE->NewAttr(mainN, 0, "lunit", "cm");
+   fGdmlE->NewAttr(mainN, nullptr, "lunit", "cm");
    return mainN;
 }
 
@@ -1057,24 +1057,24 @@ XMLNodePointer_t TGDMLWrite::CreateArb8N(TGeoArb8 * geoShape)
 
 XMLNodePointer_t TGDMLWrite::CreateConeN(TGeoConeSeg * geoShape)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "cone", 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "cone", 0);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
-   fGdmlE->NewAttr(mainN, 0, "name", lname);
+   fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetDz(), "Dz", lname)) {
       return NULL;
    }
 
-   fGdmlE->NewAttr(mainN, 0, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDz()));
-   fGdmlE->NewAttr(mainN, 0, "rmin1", TString::Format(fltPrecision.Data(), geoShape->GetRmin1()));
-   fGdmlE->NewAttr(mainN, 0, "rmin2", TString::Format(fltPrecision.Data(), geoShape->GetRmin2()));
-   fGdmlE->NewAttr(mainN, 0, "rmax1", TString::Format(fltPrecision.Data(), geoShape->GetRmax1()));
-   fGdmlE->NewAttr(mainN, 0, "rmax2", TString::Format(fltPrecision.Data(), geoShape->GetRmax2()));
-   fGdmlE->NewAttr(mainN, 0, "startphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi1()));
-   fGdmlE->NewAttr(mainN, 0, "deltaphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi2() - geoShape->GetPhi1()));
+   fGdmlE->NewAttr(mainN, nullptr, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDz()));
+   fGdmlE->NewAttr(mainN, nullptr, "rmin1", TString::Format(fltPrecision.Data(), geoShape->GetRmin1()));
+   fGdmlE->NewAttr(mainN, nullptr, "rmin2", TString::Format(fltPrecision.Data(), geoShape->GetRmin2()));
+   fGdmlE->NewAttr(mainN, nullptr, "rmax1", TString::Format(fltPrecision.Data(), geoShape->GetRmax1()));
+   fGdmlE->NewAttr(mainN, nullptr, "rmax2", TString::Format(fltPrecision.Data(), geoShape->GetRmax2()));
+   fGdmlE->NewAttr(mainN, nullptr, "startphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi1()));
+   fGdmlE->NewAttr(mainN, nullptr, "deltaphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi2() - geoShape->GetPhi1()));
 
-   fGdmlE->NewAttr(mainN, 0, "aunit", "deg");
-   fGdmlE->NewAttr(mainN, 0, "lunit", "cm");
+   fGdmlE->NewAttr(mainN, nullptr, "aunit", "deg");
+   fGdmlE->NewAttr(mainN, nullptr, "lunit", "cm");
    return mainN;
 }
 
@@ -1083,24 +1083,24 @@ XMLNodePointer_t TGDMLWrite::CreateConeN(TGeoConeSeg * geoShape)
 
 XMLNodePointer_t TGDMLWrite::CreateConeN(TGeoCone * geoShape)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "cone", 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "cone", 0);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
-   fGdmlE->NewAttr(mainN, 0, "name", lname);
+   fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetDz(), "Dz", lname)) {
       return NULL;
    }
 
-   fGdmlE->NewAttr(mainN, 0, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDz()));
-   fGdmlE->NewAttr(mainN, 0, "rmin1", TString::Format(fltPrecision.Data(), geoShape->GetRmin1()));
-   fGdmlE->NewAttr(mainN, 0, "rmin2", TString::Format(fltPrecision.Data(), geoShape->GetRmin2()));
-   fGdmlE->NewAttr(mainN, 0, "rmax1", TString::Format(fltPrecision.Data(), geoShape->GetRmax1()));
-   fGdmlE->NewAttr(mainN, 0, "rmax2", TString::Format(fltPrecision.Data(), geoShape->GetRmax2()));
-   fGdmlE->NewAttr(mainN, 0, "startphi", TString::Format("%i", 0));
-   fGdmlE->NewAttr(mainN, 0, "deltaphi", TString::Format("%i", 360));
+   fGdmlE->NewAttr(mainN, nullptr, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDz()));
+   fGdmlE->NewAttr(mainN, nullptr, "rmin1", TString::Format(fltPrecision.Data(), geoShape->GetRmin1()));
+   fGdmlE->NewAttr(mainN, nullptr, "rmin2", TString::Format(fltPrecision.Data(), geoShape->GetRmin2()));
+   fGdmlE->NewAttr(mainN, nullptr, "rmax1", TString::Format(fltPrecision.Data(), geoShape->GetRmax1()));
+   fGdmlE->NewAttr(mainN, nullptr, "rmax2", TString::Format(fltPrecision.Data(), geoShape->GetRmax2()));
+   fGdmlE->NewAttr(mainN, nullptr, "startphi", TString::Format("%i", 0));
+   fGdmlE->NewAttr(mainN, nullptr, "deltaphi", TString::Format("%i", 360));
 
-   fGdmlE->NewAttr(mainN, 0, "aunit", "deg");
-   fGdmlE->NewAttr(mainN, 0, "lunit", "cm");
+   fGdmlE->NewAttr(mainN, nullptr, "aunit", "deg");
+   fGdmlE->NewAttr(mainN, nullptr, "lunit", "cm");
    return mainN;
 }
 
@@ -1109,19 +1109,19 @@ XMLNodePointer_t TGDMLWrite::CreateConeN(TGeoCone * geoShape)
 
 XMLNodePointer_t TGDMLWrite::CreateParaN(TGeoPara * geoShape)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "para", 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "para", 0);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
-   fGdmlE->NewAttr(mainN, 0, "name", GenName(geoShape->GetName(), TString::Format("%p", geoShape)));
+   fGdmlE->NewAttr(mainN, nullptr, "name", GenName(geoShape->GetName(), TString::Format("%p", geoShape)));
 
-   fGdmlE->NewAttr(mainN, 0, "x", TString::Format(fltPrecision.Data(), 2 * geoShape->GetX()));
-   fGdmlE->NewAttr(mainN, 0, "y", TString::Format(fltPrecision.Data(), 2 * geoShape->GetY()));
-   fGdmlE->NewAttr(mainN, 0, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetZ()));
-   fGdmlE->NewAttr(mainN, 0, "alpha", TString::Format(fltPrecision.Data(), geoShape->GetAlpha()));
-   fGdmlE->NewAttr(mainN, 0, "theta", TString::Format(fltPrecision.Data(), geoShape->GetTheta()));
-   fGdmlE->NewAttr(mainN, 0, "phi", TString::Format(fltPrecision.Data(), geoShape->GetPhi()));
+   fGdmlE->NewAttr(mainN, nullptr, "x", TString::Format(fltPrecision.Data(), 2 * geoShape->GetX()));
+   fGdmlE->NewAttr(mainN, nullptr, "y", TString::Format(fltPrecision.Data(), 2 * geoShape->GetY()));
+   fGdmlE->NewAttr(mainN, nullptr, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetZ()));
+   fGdmlE->NewAttr(mainN, nullptr, "alpha", TString::Format(fltPrecision.Data(), geoShape->GetAlpha()));
+   fGdmlE->NewAttr(mainN, nullptr, "theta", TString::Format(fltPrecision.Data(), geoShape->GetTheta()));
+   fGdmlE->NewAttr(mainN, nullptr, "phi", TString::Format(fltPrecision.Data(), geoShape->GetPhi()));
 
-   fGdmlE->NewAttr(mainN, 0, "aunit", "deg");
-   fGdmlE->NewAttr(mainN, 0, "lunit", "cm");
+   fGdmlE->NewAttr(mainN, nullptr, "aunit", "deg");
+   fGdmlE->NewAttr(mainN, nullptr, "lunit", "cm");
    return mainN;
 }
 
@@ -1146,28 +1146,28 @@ XMLNodePointer_t TGDMLWrite::CreateTrapN(TGeoTrap * geoShape)
       return mainN;
    }
 
-   mainN = fGdmlE->NewChild(0, 0, "trap", 0);
+   mainN = fGdmlE->NewChild(nullptr, nullptr, "trap", 0);
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
-   fGdmlE->NewAttr(mainN, 0, "name", lname);
+   fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetDz(), "Dz", lname)) {
       return NULL;
    }
 
-   fGdmlE->NewAttr(mainN, 0, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDz()));
-   fGdmlE->NewAttr(mainN, 0, "theta", TString::Format(fltPrecision.Data(), geoShape->GetTheta()));
-   fGdmlE->NewAttr(mainN, 0, "phi", TString::Format(fltPrecision.Data(), geoShape->GetPhi()));
-   fGdmlE->NewAttr(mainN, 0, "x1", TString::Format(fltPrecision.Data(), 2 * geoShape->GetBl1()));
-   fGdmlE->NewAttr(mainN, 0, "x2", TString::Format(fltPrecision.Data(), 2 * geoShape->GetTl1()));
-   fGdmlE->NewAttr(mainN, 0, "x3", TString::Format(fltPrecision.Data(), 2 * geoShape->GetBl2()));
-   fGdmlE->NewAttr(mainN, 0, "x4", TString::Format(fltPrecision.Data(), 2 * geoShape->GetTl2()));
-   fGdmlE->NewAttr(mainN, 0, "y1", TString::Format(fltPrecision.Data(), 2 * geoShape->GetH1()));
-   fGdmlE->NewAttr(mainN, 0, "y2", TString::Format(fltPrecision.Data(), 2 * geoShape->GetH2()));
+   fGdmlE->NewAttr(mainN, nullptr, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDz()));
+   fGdmlE->NewAttr(mainN, nullptr, "theta", TString::Format(fltPrecision.Data(), geoShape->GetTheta()));
+   fGdmlE->NewAttr(mainN, nullptr, "phi", TString::Format(fltPrecision.Data(), geoShape->GetPhi()));
+   fGdmlE->NewAttr(mainN, nullptr, "x1", TString::Format(fltPrecision.Data(), 2 * geoShape->GetBl1()));
+   fGdmlE->NewAttr(mainN, nullptr, "x2", TString::Format(fltPrecision.Data(), 2 * geoShape->GetTl1()));
+   fGdmlE->NewAttr(mainN, nullptr, "x3", TString::Format(fltPrecision.Data(), 2 * geoShape->GetBl2()));
+   fGdmlE->NewAttr(mainN, nullptr, "x4", TString::Format(fltPrecision.Data(), 2 * geoShape->GetTl2()));
+   fGdmlE->NewAttr(mainN, nullptr, "y1", TString::Format(fltPrecision.Data(), 2 * geoShape->GetH1()));
+   fGdmlE->NewAttr(mainN, nullptr, "y2", TString::Format(fltPrecision.Data(), 2 * geoShape->GetH2()));
 
-   fGdmlE->NewAttr(mainN, 0, "alpha1", TString::Format(fltPrecision.Data(), geoShape->GetAlpha1()));
-   fGdmlE->NewAttr(mainN, 0, "alpha2", TString::Format(fltPrecision.Data(), geoShape->GetAlpha2()));
+   fGdmlE->NewAttr(mainN, nullptr, "alpha1", TString::Format(fltPrecision.Data(), geoShape->GetAlpha1()));
+   fGdmlE->NewAttr(mainN, nullptr, "alpha2", TString::Format(fltPrecision.Data(), geoShape->GetAlpha2()));
 
-   fGdmlE->NewAttr(mainN, 0, "aunit", "deg");
-   fGdmlE->NewAttr(mainN, 0, "lunit", "cm");
+   fGdmlE->NewAttr(mainN, nullptr, "aunit", "deg");
+   fGdmlE->NewAttr(mainN, nullptr, "lunit", "cm");
    return mainN;
 }
 
@@ -1198,24 +1198,24 @@ XMLNodePointer_t TGDMLWrite::CreateTwistedTrapN(TGeoGtra * geoShape)
       return mainN;
    }
 
-   mainN = fGdmlE->NewChild(0, 0, "twistedtrap", 0);
+   mainN = fGdmlE->NewChild(nullptr, nullptr, "twistedtrap", 0);
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
-   fGdmlE->NewAttr(mainN, 0, "name", lname);
+   fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetDz(), "Dz", lname)) {
       return NULL;
    }
 
-   fGdmlE->NewAttr(mainN, 0, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDz()));
-   fGdmlE->NewAttr(mainN, 0, "Theta", TString::Format(fltPrecision.Data(), geoShape->GetTheta()));
-   fGdmlE->NewAttr(mainN, 0, "Phi", TString::Format(fltPrecision.Data(), geoShape->GetPhi()));
-   fGdmlE->NewAttr(mainN, 0, "x1", TString::Format(fltPrecision.Data(), 2 * geoShape->GetBl1()));
-   fGdmlE->NewAttr(mainN, 0, "x2", TString::Format(fltPrecision.Data(), 2 * geoShape->GetTl1()));
-   fGdmlE->NewAttr(mainN, 0, "x3", TString::Format(fltPrecision.Data(), 2 * geoShape->GetBl2()));
-   fGdmlE->NewAttr(mainN, 0, "x4", TString::Format(fltPrecision.Data(), 2 * geoShape->GetTl2()));
-   fGdmlE->NewAttr(mainN, 0, "y1", TString::Format(fltPrecision.Data(), 2 * geoShape->GetH1()));
-   fGdmlE->NewAttr(mainN, 0, "y2", TString::Format(fltPrecision.Data(), 2 * geoShape->GetH2()));
+   fGdmlE->NewAttr(mainN, nullptr, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDz()));
+   fGdmlE->NewAttr(mainN, nullptr, "Theta", TString::Format(fltPrecision.Data(), geoShape->GetTheta()));
+   fGdmlE->NewAttr(mainN, nullptr, "Phi", TString::Format(fltPrecision.Data(), geoShape->GetPhi()));
+   fGdmlE->NewAttr(mainN, nullptr, "x1", TString::Format(fltPrecision.Data(), 2 * geoShape->GetBl1()));
+   fGdmlE->NewAttr(mainN, nullptr, "x2", TString::Format(fltPrecision.Data(), 2 * geoShape->GetTl1()));
+   fGdmlE->NewAttr(mainN, nullptr, "x3", TString::Format(fltPrecision.Data(), 2 * geoShape->GetBl2()));
+   fGdmlE->NewAttr(mainN, nullptr, "x4", TString::Format(fltPrecision.Data(), 2 * geoShape->GetTl2()));
+   fGdmlE->NewAttr(mainN, nullptr, "y1", TString::Format(fltPrecision.Data(), 2 * geoShape->GetH1()));
+   fGdmlE->NewAttr(mainN, nullptr, "y2", TString::Format(fltPrecision.Data(), 2 * geoShape->GetH2()));
 
-   fGdmlE->NewAttr(mainN, 0, "Alph", TString::Format(fltPrecision.Data(), geoShape->GetAlpha1()));
+   fGdmlE->NewAttr(mainN, nullptr, "Alph", TString::Format(fltPrecision.Data(), geoShape->GetAlpha1()));
 
    //check if alpha1 equals to alpha2 (converting to string - to avoid problems with floats)
    if (TString::Format(fltPrecision.Data(), geoShape->GetAlpha1()) != TString::Format(fltPrecision.Data(), geoShape->GetAlpha2())) {
@@ -1224,10 +1224,10 @@ XMLNodePointer_t TGDMLWrite::CreateTwistedTrapN(TGeoGtra * geoShape)
            lname.Data());
    }
    //fGdmlE->NewAttr(mainN,0, "alpha2", TString::Format(fltPrecision.Data(), geoShape->GetAlpha2()));
-   fGdmlE->NewAttr(mainN, 0, "PhiTwist", TString::Format(fltPrecision.Data(), geoShape->GetTwistAngle()));
+   fGdmlE->NewAttr(mainN, nullptr, "PhiTwist", TString::Format(fltPrecision.Data(), geoShape->GetTwistAngle()));
 
-   fGdmlE->NewAttr(mainN, 0, "aunit", "deg");
-   fGdmlE->NewAttr(mainN, 0, "lunit", "cm");
+   fGdmlE->NewAttr(mainN, nullptr, "aunit", "deg");
+   fGdmlE->NewAttr(mainN, nullptr, "lunit", "cm");
    return mainN;
 }
 
@@ -1236,21 +1236,21 @@ XMLNodePointer_t TGDMLWrite::CreateTwistedTrapN(TGeoGtra * geoShape)
 
 XMLNodePointer_t TGDMLWrite::CreateTrdN(TGeoTrd1 * geoShape)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "trd", 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "trd", 0);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
-   fGdmlE->NewAttr(mainN, 0, "name", lname);
+   fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetDz(), "Dz", lname)) {
       return NULL;
    }
 
-   fGdmlE->NewAttr(mainN, 0, "x1", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDx1()));
-   fGdmlE->NewAttr(mainN, 0, "x2", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDx2()));
-   fGdmlE->NewAttr(mainN, 0, "y1", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDy()));
-   fGdmlE->NewAttr(mainN, 0, "y2", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDy()));
-   fGdmlE->NewAttr(mainN, 0, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDz()));
+   fGdmlE->NewAttr(mainN, nullptr, "x1", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDx1()));
+   fGdmlE->NewAttr(mainN, nullptr, "x2", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDx2()));
+   fGdmlE->NewAttr(mainN, nullptr, "y1", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDy()));
+   fGdmlE->NewAttr(mainN, nullptr, "y2", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDy()));
+   fGdmlE->NewAttr(mainN, nullptr, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDz()));
 
-   fGdmlE->NewAttr(mainN, 0, "lunit", "cm");
+   fGdmlE->NewAttr(mainN, nullptr, "lunit", "cm");
    return mainN;
 }
 
@@ -1259,21 +1259,21 @@ XMLNodePointer_t TGDMLWrite::CreateTrdN(TGeoTrd1 * geoShape)
 
 XMLNodePointer_t TGDMLWrite::CreateTrdN(TGeoTrd2 * geoShape)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "trd", 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "trd", 0);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
-   fGdmlE->NewAttr(mainN, 0, "name", lname);
+   fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetDz(), "Dz", lname)) {
       return NULL;
    }
 
-   fGdmlE->NewAttr(mainN, 0, "x1", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDx1()));
-   fGdmlE->NewAttr(mainN, 0, "x2", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDx2()));
-   fGdmlE->NewAttr(mainN, 0, "y1", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDy1()));
-   fGdmlE->NewAttr(mainN, 0, "y2", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDy2()));
-   fGdmlE->NewAttr(mainN, 0, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDz()));
+   fGdmlE->NewAttr(mainN, nullptr, "x1", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDx1()));
+   fGdmlE->NewAttr(mainN, nullptr, "x2", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDx2()));
+   fGdmlE->NewAttr(mainN, nullptr, "y1", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDy1()));
+   fGdmlE->NewAttr(mainN, nullptr, "y2", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDy2()));
+   fGdmlE->NewAttr(mainN, nullptr, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDz()));
 
-   fGdmlE->NewAttr(mainN, 0, "lunit", "cm");
+   fGdmlE->NewAttr(mainN, nullptr, "lunit", "cm");
    return mainN;
 }
 
@@ -1282,23 +1282,23 @@ XMLNodePointer_t TGDMLWrite::CreateTrdN(TGeoTrd2 * geoShape)
 
 XMLNodePointer_t TGDMLWrite::CreateTubeN(TGeoTubeSeg * geoShape)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "tube", 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "tube", 0);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
-   fGdmlE->NewAttr(mainN, 0, "name", lname);
+   fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetRmax(), "Rmax", lname) ||
        IsNullParam(geoShape->GetDz(), "Dz", lname)) {
       return NULL;
    }
 
-   fGdmlE->NewAttr(mainN, 0, "rmin", TString::Format(fltPrecision.Data(), geoShape->GetRmin()));
-   fGdmlE->NewAttr(mainN, 0, "rmax", TString::Format(fltPrecision.Data(), geoShape->GetRmax()));
-   fGdmlE->NewAttr(mainN, 0, "z", TString::Format(fltPrecision.Data(),  2 * geoShape->GetDz()));
-   fGdmlE->NewAttr(mainN, 0, "startphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi1()));
-   fGdmlE->NewAttr(mainN, 0, "deltaphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi2() - geoShape->GetPhi1()));
+   fGdmlE->NewAttr(mainN, nullptr, "rmin", TString::Format(fltPrecision.Data(), geoShape->GetRmin()));
+   fGdmlE->NewAttr(mainN, nullptr, "rmax", TString::Format(fltPrecision.Data(), geoShape->GetRmax()));
+   fGdmlE->NewAttr(mainN, nullptr, "z", TString::Format(fltPrecision.Data(),  2 * geoShape->GetDz()));
+   fGdmlE->NewAttr(mainN, nullptr, "startphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi1()));
+   fGdmlE->NewAttr(mainN, nullptr, "deltaphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi2() - geoShape->GetPhi1()));
 
-   fGdmlE->NewAttr(mainN, 0, "aunit", "deg");
-   fGdmlE->NewAttr(mainN, 0, "lunit", "cm");
+   fGdmlE->NewAttr(mainN, nullptr, "aunit", "deg");
+   fGdmlE->NewAttr(mainN, nullptr, "lunit", "cm");
    return mainN;
 }
 
@@ -1310,9 +1310,9 @@ XMLNodePointer_t TGDMLWrite::CreateCutTubeN(TGeoCtub * geoShape)
    XMLNodePointer_t mainN;
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
 
-   mainN = fGdmlE->NewChild(0, 0, "cutTube", 0);
+   mainN = fGdmlE->NewChild(nullptr, nullptr, "cutTube", 0);
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
-   fGdmlE->NewAttr(mainN, 0, "name", lname);
+   fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetRmax(), "Rmax", lname) ||
        IsNullParam(geoShape->GetDz(), "Dz", lname)) {
       return NULL;
@@ -1329,20 +1329,20 @@ XMLNodePointer_t TGDMLWrite::CreateCutTubeN(TGeoCtub * geoShape)
            lname.Data());
       return mainN;
    }
-   fGdmlE->NewAttr(mainN, 0, "rmin", TString::Format(fltPrecision.Data(), geoShape->GetRmin()));
-   fGdmlE->NewAttr(mainN, 0, "rmax", TString::Format(fltPrecision.Data(), geoShape->GetRmax()));
-   fGdmlE->NewAttr(mainN, 0, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDz()));
-   fGdmlE->NewAttr(mainN, 0, "startphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi1()));
-   fGdmlE->NewAttr(mainN, 0, "deltaphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi2() - geoShape->GetPhi1()));
-   fGdmlE->NewAttr(mainN, 0, "lowX", TString::Format(fltPrecision.Data(), geoShape->GetNlow()[0]));
-   fGdmlE->NewAttr(mainN, 0, "lowY", TString::Format(fltPrecision.Data(), geoShape->GetNlow()[1]));
-   fGdmlE->NewAttr(mainN, 0, "lowZ", TString::Format(fltPrecision.Data(), geoShape->GetNlow()[2]));
-   fGdmlE->NewAttr(mainN, 0, "highX", TString::Format(fltPrecision.Data(), geoShape->GetNhigh()[0]));
-   fGdmlE->NewAttr(mainN, 0, "highY", TString::Format(fltPrecision.Data(), geoShape->GetNhigh()[1]));
-   fGdmlE->NewAttr(mainN, 0, "highZ", TString::Format(fltPrecision.Data(), geoShape->GetNhigh()[2]));
+   fGdmlE->NewAttr(mainN, nullptr, "rmin", TString::Format(fltPrecision.Data(), geoShape->GetRmin()));
+   fGdmlE->NewAttr(mainN, nullptr, "rmax", TString::Format(fltPrecision.Data(), geoShape->GetRmax()));
+   fGdmlE->NewAttr(mainN, nullptr, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDz()));
+   fGdmlE->NewAttr(mainN, nullptr, "startphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi1()));
+   fGdmlE->NewAttr(mainN, nullptr, "deltaphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi2() - geoShape->GetPhi1()));
+   fGdmlE->NewAttr(mainN, nullptr, "lowX", TString::Format(fltPrecision.Data(), geoShape->GetNlow()[0]));
+   fGdmlE->NewAttr(mainN, nullptr, "lowY", TString::Format(fltPrecision.Data(), geoShape->GetNlow()[1]));
+   fGdmlE->NewAttr(mainN, nullptr, "lowZ", TString::Format(fltPrecision.Data(), geoShape->GetNlow()[2]));
+   fGdmlE->NewAttr(mainN, nullptr, "highX", TString::Format(fltPrecision.Data(), geoShape->GetNhigh()[0]));
+   fGdmlE->NewAttr(mainN, nullptr, "highY", TString::Format(fltPrecision.Data(), geoShape->GetNhigh()[1]));
+   fGdmlE->NewAttr(mainN, nullptr, "highZ", TString::Format(fltPrecision.Data(), geoShape->GetNhigh()[2]));
 
-   fGdmlE->NewAttr(mainN, 0, "aunit", "deg");
-   fGdmlE->NewAttr(mainN, 0, "lunit", "cm");
+   fGdmlE->NewAttr(mainN, nullptr, "aunit", "deg");
+   fGdmlE->NewAttr(mainN, nullptr, "lunit", "cm");
 
    return mainN;
 }
@@ -1352,23 +1352,23 @@ XMLNodePointer_t TGDMLWrite::CreateCutTubeN(TGeoCtub * geoShape)
 
 XMLNodePointer_t TGDMLWrite::CreateTubeN(TGeoTube * geoShape)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "tube", 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "tube", 0);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
-   fGdmlE->NewAttr(mainN, 0, "name", lname);
+   fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetRmax(), "Rmax", lname) ||
        IsNullParam(geoShape->GetDz(), "Dz", lname)) {
       return NULL;
    }
 
-   fGdmlE->NewAttr(mainN, 0, "rmin", TString::Format(fltPrecision.Data(), geoShape->GetRmin()));
-   fGdmlE->NewAttr(mainN, 0, "rmax", TString::Format(fltPrecision.Data(), geoShape->GetRmax()));
-   fGdmlE->NewAttr(mainN, 0, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDz()));
-   fGdmlE->NewAttr(mainN, 0, "startphi", TString::Format("%i", 0));
-   fGdmlE->NewAttr(mainN, 0, "deltaphi", TString::Format("%i", 360));
+   fGdmlE->NewAttr(mainN, nullptr, "rmin", TString::Format(fltPrecision.Data(), geoShape->GetRmin()));
+   fGdmlE->NewAttr(mainN, nullptr, "rmax", TString::Format(fltPrecision.Data(), geoShape->GetRmax()));
+   fGdmlE->NewAttr(mainN, nullptr, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDz()));
+   fGdmlE->NewAttr(mainN, nullptr, "startphi", TString::Format("%i", 0));
+   fGdmlE->NewAttr(mainN, nullptr, "deltaphi", TString::Format("%i", 360));
 
-   fGdmlE->NewAttr(mainN, 0, "aunit", "deg");
-   fGdmlE->NewAttr(mainN, 0, "lunit", "cm");
+   fGdmlE->NewAttr(mainN, nullptr, "aunit", "deg");
+   fGdmlE->NewAttr(mainN, nullptr, "lunit", "cm");
    return mainN;
 }
 
@@ -1377,12 +1377,12 @@ XMLNodePointer_t TGDMLWrite::CreateTubeN(TGeoTube * geoShape)
 
 XMLNodePointer_t TGDMLWrite::CreateZplaneN(Double_t z, Double_t rmin, Double_t rmax)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "zplane", 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "zplane", 0);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
 
-   fGdmlE->NewAttr(mainN, 0, "z", TString::Format(fltPrecision.Data(), z));
-   fGdmlE->NewAttr(mainN, 0, "rmin", TString::Format(fltPrecision.Data(), rmin));
-   fGdmlE->NewAttr(mainN, 0, "rmax", TString::Format(fltPrecision.Data(), rmax));
+   fGdmlE->NewAttr(mainN, nullptr, "z", TString::Format(fltPrecision.Data(), z));
+   fGdmlE->NewAttr(mainN, nullptr, "rmin", TString::Format(fltPrecision.Data(), rmin));
+   fGdmlE->NewAttr(mainN, nullptr, "rmax", TString::Format(fltPrecision.Data(), rmax));
 
    return mainN;
 }
@@ -1392,16 +1392,16 @@ XMLNodePointer_t TGDMLWrite::CreateZplaneN(Double_t z, Double_t rmin, Double_t r
 
 XMLNodePointer_t TGDMLWrite::CreatePolyconeN(TGeoPcon * geoShape)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "polycone", 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "polycone", 0);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
-   fGdmlE->NewAttr(mainN, 0, "name", lname);
+   fGdmlE->NewAttr(mainN, nullptr, "name", lname);
 
-   fGdmlE->NewAttr(mainN, 0, "startphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi1()));
-   fGdmlE->NewAttr(mainN, 0, "deltaphi", TString::Format(fltPrecision.Data(), geoShape->GetDphi()));
+   fGdmlE->NewAttr(mainN, nullptr, "startphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi1()));
+   fGdmlE->NewAttr(mainN, nullptr, "deltaphi", TString::Format(fltPrecision.Data(), geoShape->GetDphi()));
 
-   fGdmlE->NewAttr(mainN, 0, "aunit", "deg");
-   fGdmlE->NewAttr(mainN, 0, "lunit", "cm");
+   fGdmlE->NewAttr(mainN, nullptr, "aunit", "deg");
+   fGdmlE->NewAttr(mainN, nullptr, "lunit", "cm");
    Int_t nZPlns = geoShape->GetNz();
    for (Int_t it = 0; it < nZPlns; it++) {
       //add zplane child node
@@ -1445,22 +1445,22 @@ XMLNodePointer_t TGDMLWrite::CreatePolyconeN(TGeoPcon * geoShape)
 
 XMLNodePointer_t TGDMLWrite::CreateTorusN(TGeoTorus * geoShape)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "torus", 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "torus", 0);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
-   fGdmlE->NewAttr(mainN, 0, "name", lname);
+   fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetRmax(), "Rmax", lname)) {
       return NULL;
    }
 
-   fGdmlE->NewAttr(mainN, 0, "rtor", TString::Format(fltPrecision.Data(), geoShape->GetR()));
-   fGdmlE->NewAttr(mainN, 0, "rmin", TString::Format(fltPrecision.Data(), geoShape->GetRmin()));
-   fGdmlE->NewAttr(mainN, 0, "rmax", TString::Format(fltPrecision.Data(), geoShape->GetRmax()));
-   fGdmlE->NewAttr(mainN, 0, "startphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi1()));
-   fGdmlE->NewAttr(mainN, 0, "deltaphi", TString::Format(fltPrecision.Data(), geoShape->GetDphi()));
+   fGdmlE->NewAttr(mainN, nullptr, "rtor", TString::Format(fltPrecision.Data(), geoShape->GetR()));
+   fGdmlE->NewAttr(mainN, nullptr, "rmin", TString::Format(fltPrecision.Data(), geoShape->GetRmin()));
+   fGdmlE->NewAttr(mainN, nullptr, "rmax", TString::Format(fltPrecision.Data(), geoShape->GetRmax()));
+   fGdmlE->NewAttr(mainN, nullptr, "startphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi1()));
+   fGdmlE->NewAttr(mainN, nullptr, "deltaphi", TString::Format(fltPrecision.Data(), geoShape->GetDphi()));
 
-   fGdmlE->NewAttr(mainN, 0, "aunit", "deg");
-   fGdmlE->NewAttr(mainN, 0, "lunit", "cm");
+   fGdmlE->NewAttr(mainN, nullptr, "aunit", "deg");
+   fGdmlE->NewAttr(mainN, nullptr, "lunit", "cm");
 
    return mainN;
 }
@@ -1470,16 +1470,16 @@ XMLNodePointer_t TGDMLWrite::CreateTorusN(TGeoTorus * geoShape)
 
 XMLNodePointer_t TGDMLWrite::CreatePolyhedraN(TGeoPgon * geoShape)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "polyhedra", 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "polyhedra", 0);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
-   fGdmlE->NewAttr(mainN, 0, "name", GenName(geoShape->GetName(), TString::Format("%p", geoShape)));
+   fGdmlE->NewAttr(mainN, nullptr, "name", GenName(geoShape->GetName(), TString::Format("%p", geoShape)));
 
-   fGdmlE->NewAttr(mainN, 0, "startphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi1()));
-   fGdmlE->NewAttr(mainN, 0, "deltaphi", TString::Format(fltPrecision.Data(), geoShape->GetDphi()));
-   fGdmlE->NewAttr(mainN, 0, "numsides", TString::Format("%i", geoShape->GetNedges()));
+   fGdmlE->NewAttr(mainN, nullptr, "startphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi1()));
+   fGdmlE->NewAttr(mainN, nullptr, "deltaphi", TString::Format(fltPrecision.Data(), geoShape->GetDphi()));
+   fGdmlE->NewAttr(mainN, nullptr, "numsides", TString::Format("%i", geoShape->GetNedges()));
 
-   fGdmlE->NewAttr(mainN, 0, "aunit", "deg");
-   fGdmlE->NewAttr(mainN, 0, "lunit", "cm");
+   fGdmlE->NewAttr(mainN, nullptr, "aunit", "deg");
+   fGdmlE->NewAttr(mainN, nullptr, "lunit", "cm");
    for (Int_t it = 0; it < geoShape->GetNz(); it++) {
       //add zplane child node
       fGdmlE->AddChild(mainN, CreateZplaneN(geoShape->GetZ(it), geoShape->GetRmin(it), geoShape->GetRmax(it)));
@@ -1492,21 +1492,21 @@ XMLNodePointer_t TGDMLWrite::CreatePolyhedraN(TGeoPgon * geoShape)
 
 XMLNodePointer_t TGDMLWrite::CreateEltubeN(TGeoEltu * geoShape)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "eltube", 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "eltube", 0);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
-   fGdmlE->NewAttr(mainN, 0, "name", lname);
+   fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetA(), "A", lname) ||
        IsNullParam(geoShape->GetB(), "B", lname) ||
        IsNullParam(geoShape->GetDz(), "Dz", lname)) {
       return NULL;
    }
 
-   fGdmlE->NewAttr(mainN, 0, "dx", TString::Format(fltPrecision.Data(), geoShape->GetA()));
-   fGdmlE->NewAttr(mainN, 0, "dy", TString::Format(fltPrecision.Data(), geoShape->GetB()));
-   fGdmlE->NewAttr(mainN, 0, "dz", TString::Format(fltPrecision.Data(), geoShape->GetDz()));
+   fGdmlE->NewAttr(mainN, nullptr, "dx", TString::Format(fltPrecision.Data(), geoShape->GetA()));
+   fGdmlE->NewAttr(mainN, nullptr, "dy", TString::Format(fltPrecision.Data(), geoShape->GetB()));
+   fGdmlE->NewAttr(mainN, nullptr, "dz", TString::Format(fltPrecision.Data(), geoShape->GetDz()));
 
-   fGdmlE->NewAttr(mainN, 0, "lunit", "cm");
+   fGdmlE->NewAttr(mainN, nullptr, "lunit", "cm");
 
    return mainN;
 }
@@ -1516,23 +1516,23 @@ XMLNodePointer_t TGDMLWrite::CreateEltubeN(TGeoEltu * geoShape)
 
 XMLNodePointer_t TGDMLWrite::CreateHypeN(TGeoHype * geoShape)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "hype", 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "hype", 0);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
-   fGdmlE->NewAttr(mainN, 0, "name", lname);
+   fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetDz(), "Dz", lname)) {
       return NULL;
    }
 
 
-   fGdmlE->NewAttr(mainN, 0, "rmin", TString::Format(fltPrecision.Data(), geoShape->GetRmin()));
-   fGdmlE->NewAttr(mainN, 0, "rmax", TString::Format(fltPrecision.Data(), geoShape->GetRmax()));
-   fGdmlE->NewAttr(mainN, 0, "inst", TString::Format(fltPrecision.Data(), geoShape->GetStIn()));
-   fGdmlE->NewAttr(mainN, 0, "outst", TString::Format(fltPrecision.Data(), geoShape->GetStOut()));
-   fGdmlE->NewAttr(mainN, 0, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDz()));
+   fGdmlE->NewAttr(mainN, nullptr, "rmin", TString::Format(fltPrecision.Data(), geoShape->GetRmin()));
+   fGdmlE->NewAttr(mainN, nullptr, "rmax", TString::Format(fltPrecision.Data(), geoShape->GetRmax()));
+   fGdmlE->NewAttr(mainN, nullptr, "inst", TString::Format(fltPrecision.Data(), geoShape->GetStIn()));
+   fGdmlE->NewAttr(mainN, nullptr, "outst", TString::Format(fltPrecision.Data(), geoShape->GetStOut()));
+   fGdmlE->NewAttr(mainN, nullptr, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDz()));
 
-   fGdmlE->NewAttr(mainN, 0, "aunit", "deg");
-   fGdmlE->NewAttr(mainN, 0, "lunit", "cm");
+   fGdmlE->NewAttr(mainN, nullptr, "aunit", "deg");
+   fGdmlE->NewAttr(mainN, nullptr, "lunit", "cm");
 
    return mainN;
 }
@@ -1542,12 +1542,12 @@ XMLNodePointer_t TGDMLWrite::CreateHypeN(TGeoHype * geoShape)
 
 XMLNodePointer_t TGDMLWrite::CreateXtrusionN(TGeoXtru * geoShape)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "xtru", 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "xtru", 0);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
-   fGdmlE->NewAttr(mainN, 0, "name", lname);
+   fGdmlE->NewAttr(mainN, nullptr, "name", lname);
 
-   fGdmlE->NewAttr(mainN, 0, "lunit", "cm");
+   fGdmlE->NewAttr(mainN, nullptr, "lunit", "cm");
    XMLNodePointer_t childN;
    Int_t vertNum =  geoShape->GetNvert();
    Int_t secNum = geoShape->GetNz();
@@ -1559,19 +1559,19 @@ XMLNodePointer_t TGDMLWrite::CreateXtrusionN(TGeoXtru * geoShape)
    }
    for (Int_t it = 0; it < vertNum; it++) {
       //add twoDimVertex child node
-      childN = fGdmlE->NewChild(0, 0, "twoDimVertex", 0);
-      fGdmlE->NewAttr(childN, 0, "x", TString::Format(fltPrecision.Data(), geoShape->GetX(it)));
-      fGdmlE->NewAttr(childN, 0, "y", TString::Format(fltPrecision.Data(), geoShape->GetY(it)));
+      childN = fGdmlE->NewChild(nullptr, nullptr, "twoDimVertex", 0);
+      fGdmlE->NewAttr(childN, nullptr, "x", TString::Format(fltPrecision.Data(), geoShape->GetX(it)));
+      fGdmlE->NewAttr(childN, nullptr, "y", TString::Format(fltPrecision.Data(), geoShape->GetY(it)));
       fGdmlE->AddChild(mainN, childN);
    }
    for (Int_t it = 0; it < secNum; it++) {
       //add section child node
-      childN = fGdmlE->NewChild(0, 0, "section", 0);
-      fGdmlE->NewAttr(childN, 0, "zOrder", TString::Format("%i", it));
-      fGdmlE->NewAttr(childN, 0, "zPosition", TString::Format(fltPrecision.Data(), geoShape->GetZ(it)));
-      fGdmlE->NewAttr(childN, 0, "xOffset", TString::Format(fltPrecision.Data(), geoShape->GetXOffset(it)));
-      fGdmlE->NewAttr(childN, 0, "yOffset", TString::Format(fltPrecision.Data(), geoShape->GetYOffset(it)));
-      fGdmlE->NewAttr(childN, 0, "scalingFactor", TString::Format(fltPrecision.Data(), geoShape->GetScale(it)));
+      childN = fGdmlE->NewChild(nullptr, nullptr, "section", 0);
+      fGdmlE->NewAttr(childN, nullptr, "zOrder", TString::Format("%i", it));
+      fGdmlE->NewAttr(childN, nullptr, "zPosition", TString::Format(fltPrecision.Data(), geoShape->GetZ(it)));
+      fGdmlE->NewAttr(childN, nullptr, "xOffset", TString::Format(fltPrecision.Data(), geoShape->GetXOffset(it)));
+      fGdmlE->NewAttr(childN, nullptr, "yOffset", TString::Format(fltPrecision.Data(), geoShape->GetYOffset(it)));
+      fGdmlE->NewAttr(childN, nullptr, "scalingFactor", TString::Format(fltPrecision.Data(), geoShape->GetScale(it)));
       fGdmlE->AddChild(mainN, childN);
    }
    return mainN;
@@ -1585,13 +1585,13 @@ XMLNodePointer_t TGDMLWrite::CreateXtrusionN(TGeoXtru * geoShape)
 
 XMLNodePointer_t TGDMLWrite::CreateEllipsoidN(TGeoCompositeShape * geoShape, TString elName)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "ellipsoid", 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "ellipsoid", 0);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    TGeoScaledShape *leftS = (TGeoScaledShape *)geoShape->GetBoolNode()->GetLeftShape(); //ScaledShape
    TGeoBBox *rightS = (TGeoBBox *)geoShape->GetBoolNode()->GetRightShape(); //BBox
 
 
-   fGdmlE->NewAttr(mainN, 0, "name", elName.Data());
+   fGdmlE->NewAttr(mainN, nullptr, "name", elName.Data());
    Double_t sx = leftS->GetScale()->GetScale()[0];
    Double_t sy = leftS->GetScale()->GetScale()[1];
    Double_t radius = ((TGeoSphere *) leftS->GetShape())->GetRmax();
@@ -1607,12 +1607,12 @@ XMLNodePointer_t TGDMLWrite::CreateEllipsoidN(TGeoCompositeShape * geoShape, TSt
    Double_t zcut1 = 2 * zorig - zcut2;
 
 
-   fGdmlE->NewAttr(mainN, 0, "ax", TString::Format(fltPrecision.Data(), ax));
-   fGdmlE->NewAttr(mainN, 0, "by", TString::Format(fltPrecision.Data(), by));
-   fGdmlE->NewAttr(mainN, 0, "cz", TString::Format(fltPrecision.Data(), cz));
-   fGdmlE->NewAttr(mainN, 0, "zcut1", TString::Format(fltPrecision.Data(), zcut1));
-   fGdmlE->NewAttr(mainN, 0, "zcut2", TString::Format(fltPrecision.Data(), zcut2));
-   fGdmlE->NewAttr(mainN, 0, "lunit", "cm");
+   fGdmlE->NewAttr(mainN, nullptr, "ax", TString::Format(fltPrecision.Data(), ax));
+   fGdmlE->NewAttr(mainN, nullptr, "by", TString::Format(fltPrecision.Data(), by));
+   fGdmlE->NewAttr(mainN, nullptr, "cz", TString::Format(fltPrecision.Data(), cz));
+   fGdmlE->NewAttr(mainN, nullptr, "zcut1", TString::Format(fltPrecision.Data(), zcut1));
+   fGdmlE->NewAttr(mainN, nullptr, "zcut2", TString::Format(fltPrecision.Data(), zcut2));
+   fGdmlE->NewAttr(mainN, nullptr, "lunit", "cm");
 
    return mainN;
 }
@@ -1624,9 +1624,9 @@ XMLNodePointer_t TGDMLWrite::CreateEllipsoidN(TGeoCompositeShape * geoShape, TSt
 
 XMLNodePointer_t TGDMLWrite::CreateElConeN(TGeoScaledShape * geoShape)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "elcone", 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "elcone", 0);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
-   fGdmlE->NewAttr(mainN, 0, "name", GenName(geoShape->GetName(), TString::Format("%p", geoShape)));
+   fGdmlE->NewAttr(mainN, nullptr, "name", GenName(geoShape->GetName(), TString::Format("%p", geoShape)));
    Double_t zcut = ((TGeoCone *) geoShape->GetShape())->GetDz();
    Double_t rx1 = ((TGeoCone *) geoShape->GetShape())->GetRmax1();
    Double_t rx2 = ((TGeoCone *) geoShape->GetShape())->GetRmax2();
@@ -1637,11 +1637,11 @@ XMLNodePointer_t TGDMLWrite::CreateElConeN(TGeoScaledShape * geoShape)
    Double_t ry1 = sy * rx1;
 
    std::string format(TString::Format("%s/%s", fltPrecision.Data(), fltPrecision.Data()).Data());
-   fGdmlE->NewAttr(mainN, 0, "dx", TString::Format(format.c_str(), rx1, z));
-   fGdmlE->NewAttr(mainN, 0, "dy", TString::Format(format.c_str(), ry1, z));
-   fGdmlE->NewAttr(mainN, 0, "zmax", TString::Format(fltPrecision.Data(), zmax));
-   fGdmlE->NewAttr(mainN, 0, "zcut", TString::Format(fltPrecision.Data(), zcut));
-   fGdmlE->NewAttr(mainN, 0, "lunit", "cm");
+   fGdmlE->NewAttr(mainN, nullptr, "dx", TString::Format(format.c_str(), rx1, z));
+   fGdmlE->NewAttr(mainN, nullptr, "dy", TString::Format(format.c_str(), ry1, z));
+   fGdmlE->NewAttr(mainN, nullptr, "zmax", TString::Format(fltPrecision.Data(), zmax));
+   fGdmlE->NewAttr(mainN, nullptr, "zcut", TString::Format(fltPrecision.Data(), zcut));
+   fGdmlE->NewAttr(mainN, nullptr, "lunit", "cm");
 
    return mainN;
 }
@@ -1735,17 +1735,17 @@ XMLNodePointer_t TGDMLWrite::CreateCommonBoolN(TGeoCompositeShape *geoShape)
     *   <rotation .../>
     * </union>
    */
-   mainN = fGdmlE->NewChild(0, 0, lboolType.Data(), 0);
-   fGdmlE->NewAttr(mainN, 0, "name", nodeName);
+   mainN = fGdmlE->NewChild(nullptr, nullptr, lboolType.Data(), 0);
+   fGdmlE->NewAttr(mainN, nullptr, "name", nodeName);
 
    //<first> (left)
-   childN = fGdmlE->NewChild(0, 0, "first", 0);
-   fGdmlE->NewAttr(childN, 0, "ref", lname);
+   childN = fGdmlE->NewChild(nullptr, nullptr, "first", 0);
+   fGdmlE->NewAttr(childN, nullptr, "ref", lname);
    fGdmlE->AddChild(mainN, childN);
 
    //<second> (right)
-   childN = fGdmlE->NewChild(0, 0, "second", 0);
-   fGdmlE->NewAttr(childN, 0, "ref", rname);
+   childN = fGdmlE->NewChild(nullptr, nullptr, "second", 0);
+   fGdmlE->NewAttr(childN, nullptr, "ref", rname);
    fGdmlE->AddChild(mainN, childN);
 
    //<firstposition> (left)
@@ -1777,13 +1777,13 @@ XMLNodePointer_t TGDMLWrite::CreateCommonBoolN(TGeoCompositeShape *geoShape)
 
 XMLNodePointer_t TGDMLWrite::CreateOpticalSurfaceN(TGeoOpticalSurface * geoSurf)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "opticalsurface", 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "opticalsurface", 0);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
-   fGdmlE->NewAttr(mainN, 0, "name", geoSurf->GetName());
-   fGdmlE->NewAttr(mainN, 0, "model", TGeoOpticalSurface::ModelToString(geoSurf->GetModel()));
-   fGdmlE->NewAttr(mainN, 0, "finish", TGeoOpticalSurface::FinishToString(geoSurf->GetFinish()));
-   fGdmlE->NewAttr(mainN, 0, "type", TGeoOpticalSurface::TypeToString(geoSurf->GetType()));
-   fGdmlE->NewAttr(mainN, 0, "value", TString::Format(fltPrecision.Data(), geoSurf->GetValue()));
+   fGdmlE->NewAttr(mainN, nullptr, "name", geoSurf->GetName());
+   fGdmlE->NewAttr(mainN, nullptr, "model", TGeoOpticalSurface::ModelToString(geoSurf->GetModel()));
+   fGdmlE->NewAttr(mainN, nullptr, "finish", TGeoOpticalSurface::FinishToString(geoSurf->GetFinish()));
+   fGdmlE->NewAttr(mainN, nullptr, "type", TGeoOpticalSurface::TypeToString(geoSurf->GetType()));
+   fGdmlE->NewAttr(mainN, nullptr, "value", TString::Format(fltPrecision.Data(), geoSurf->GetValue()));
 
    // Write properties
    TList const &properties = geoSurf->GetProperties();
@@ -1801,12 +1801,12 @@ XMLNodePointer_t TGDMLWrite::CreateOpticalSurfaceN(TGeoOpticalSurface * geoSurf)
 
 XMLNodePointer_t TGDMLWrite::CreateSkinSurfaceN(TGeoSkinSurface * geoSurf)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "skinsurface", 0);
-   fGdmlE->NewAttr(mainN, 0, "name", geoSurf->GetName());
-   fGdmlE->NewAttr(mainN, 0, "surfaceproperty", geoSurf->GetTitle());
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "skinsurface", 0);
+   fGdmlE->NewAttr(mainN, nullptr, "name", geoSurf->GetName());
+   fGdmlE->NewAttr(mainN, nullptr, "surfaceproperty", geoSurf->GetTitle());
    // Cretate the logical volume reference node
-   auto childN = fGdmlE->NewChild(0, 0, "volumeref", 0);
-   fGdmlE->NewAttr(childN, 0, "ref", geoSurf->GetVolume()->GetName());
+   auto childN = fGdmlE->NewChild(nullptr, nullptr, "volumeref", 0);
+   fGdmlE->NewAttr(childN, nullptr, "ref", geoSurf->GetVolume()->GetName());
    fGdmlE->AddChild(mainN, childN);
    return mainN;
 }
@@ -1816,13 +1816,13 @@ XMLNodePointer_t TGDMLWrite::CreateSkinSurfaceN(TGeoSkinSurface * geoSurf)
 
 XMLNodePointer_t TGDMLWrite::CreateBorderSurfaceN(TGeoBorderSurface * geoSurf)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "bordersurface", 0);
-   fGdmlE->NewAttr(mainN, 0, "name", geoSurf->GetName());
-   fGdmlE->NewAttr(mainN, 0, "surfaceproperty", geoSurf->GetTitle());
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "bordersurface", 0);
+   fGdmlE->NewAttr(mainN, nullptr, "name", geoSurf->GetName());
+   fGdmlE->NewAttr(mainN, nullptr, "surfaceproperty", geoSurf->GetTitle());
    // Cretate the logical volume reference node
-   auto childN = fGdmlE->NewChild(0, 0, "physvolref", 0);
-   fGdmlE->NewAttr(childN, 0, "ref", geoSurf->GetNode1()->GetName());
-   fGdmlE->NewAttr(childN, 0, "ref", geoSurf->GetNode2()->GetName());
+   auto childN = fGdmlE->NewChild(nullptr, nullptr, "physvolref", 0);
+   fGdmlE->NewAttr(childN, nullptr, "ref", geoSurf->GetNode1()->GetName());
+   fGdmlE->NewAttr(childN, nullptr, "ref", geoSurf->GetNode2()->GetName());
    fGdmlE->AddChild(mainN, childN);
    return mainN;
 }
@@ -1832,13 +1832,13 @@ XMLNodePointer_t TGDMLWrite::CreateBorderSurfaceN(TGeoBorderSurface * geoSurf)
 
 XMLNodePointer_t TGDMLWrite::CreatePositionN(const char * name, Xyz position, const char * type, const char * unit)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, type, 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, type, 0);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
-   fGdmlE->NewAttr(mainN, 0, "name", name);
-   fGdmlE->NewAttr(mainN, 0, "x", TString::Format(fltPrecision.Data(), position.x));
-   fGdmlE->NewAttr(mainN, 0, "y", TString::Format(fltPrecision.Data(), position.y));
-   fGdmlE->NewAttr(mainN, 0, "z", TString::Format(fltPrecision.Data(), position.z));
-   fGdmlE->NewAttr(mainN, 0, "unit", unit);
+   fGdmlE->NewAttr(mainN, nullptr, "name", name);
+   fGdmlE->NewAttr(mainN, nullptr, "x", TString::Format(fltPrecision.Data(), position.x));
+   fGdmlE->NewAttr(mainN, nullptr, "y", TString::Format(fltPrecision.Data(), position.y));
+   fGdmlE->NewAttr(mainN, nullptr, "z", TString::Format(fltPrecision.Data(), position.z));
+   fGdmlE->NewAttr(mainN, nullptr, "unit", unit);
    return mainN;
 }
 
@@ -1847,13 +1847,13 @@ XMLNodePointer_t TGDMLWrite::CreatePositionN(const char * name, Xyz position, co
 
 XMLNodePointer_t TGDMLWrite::CreateRotationN(const char * name, Xyz rotation, const char * type, const char * unit)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, type, 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, type, 0);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
-   fGdmlE->NewAttr(mainN, 0, "name", name);
-   fGdmlE->NewAttr(mainN, 0, "x", TString::Format(fltPrecision.Data(), rotation.x));
-   fGdmlE->NewAttr(mainN, 0, "y", TString::Format(fltPrecision.Data(), rotation.y));
-   fGdmlE->NewAttr(mainN, 0, "z", TString::Format(fltPrecision.Data(), rotation.z));
-   fGdmlE->NewAttr(mainN, 0, "unit", unit);
+   fGdmlE->NewAttr(mainN, nullptr, "name", name);
+   fGdmlE->NewAttr(mainN, nullptr, "x", TString::Format(fltPrecision.Data(), rotation.x));
+   fGdmlE->NewAttr(mainN, nullptr, "y", TString::Format(fltPrecision.Data(), rotation.y));
+   fGdmlE->NewAttr(mainN, nullptr, "z", TString::Format(fltPrecision.Data(), rotation.z));
+   fGdmlE->NewAttr(mainN, nullptr, "unit", unit);
    return mainN;
 }
 
@@ -1865,9 +1865,9 @@ XMLNodePointer_t TGDMLWrite::CreateMatrixN(TGDMLMatrix const *matrix)
    std::stringstream vals;
    size_t cols = matrix->GetCols();
    size_t rows = matrix->GetRows();
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "matrix", 0);
-   fGdmlE->NewAttr(mainN, 0, "name", matrix->GetName());
-   fGdmlE->NewAttr(mainN, 0, "coldim", TString::Format("%zu", cols));
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "matrix", 0);
+   fGdmlE->NewAttr(mainN, nullptr, "name", matrix->GetName());
+   fGdmlE->NewAttr(mainN, nullptr, "coldim", TString::Format("%zu", cols));
    for(size_t i=0; i<rows; ++i)  {
      for(size_t j=0; j<cols; ++j)  {
        vals << matrix->Get(i,j);
@@ -1875,7 +1875,7 @@ XMLNodePointer_t TGDMLWrite::CreateMatrixN(TGDMLMatrix const *matrix)
      }
      if ( i < rows-1 ) vals << '\n';
    }
-   fGdmlE->NewAttr(mainN, 0, "values", vals.str().c_str());
+   fGdmlE->NewAttr(mainN, nullptr, "values", vals.str().c_str());
    return mainN;
 }
 
@@ -1884,10 +1884,10 @@ XMLNodePointer_t TGDMLWrite::CreateMatrixN(TGDMLMatrix const *matrix)
 
 XMLNodePointer_t TGDMLWrite::CreateConstantN(const char *name, Double_t value)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "constant", 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "constant", 0);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
-   fGdmlE->NewAttr(mainN, 0, "name", name);
-   fGdmlE->NewAttr(mainN, 0, "value", TString::Format(fltPrecision.Data(), value));
+   fGdmlE->NewAttr(mainN, nullptr, "name", name);
+   fGdmlE->NewAttr(mainN, nullptr, "value", TString::Format(fltPrecision.Data(), value));
    return mainN;
 }
 
@@ -1896,11 +1896,11 @@ XMLNodePointer_t TGDMLWrite::CreateConstantN(const char *name, Double_t value)
 
 XMLNodePointer_t TGDMLWrite::CreateSetupN(const char * topVolName, const char * name, const char * version)
 {
-   XMLNodePointer_t setupN = fGdmlE->NewChild(0, 0, "setup", 0);
-   fGdmlE->NewAttr(setupN, 0, "name", name);
-   fGdmlE->NewAttr(setupN, 0, "version", version);
+   XMLNodePointer_t setupN = fGdmlE->NewChild(nullptr, nullptr, "setup", 0);
+   fGdmlE->NewAttr(setupN, nullptr, "name", name);
+   fGdmlE->NewAttr(setupN, nullptr, "version", version);
    XMLNodePointer_t fworldN = fGdmlE->NewChild(setupN, 0, "world", 0);
-   fGdmlE->NewAttr(fworldN, 0, "ref", topVolName);
+   fGdmlE->NewAttr(fworldN, nullptr, "ref", topVolName);
    return setupN;
 }
 
@@ -1910,15 +1910,15 @@ XMLNodePointer_t TGDMLWrite::CreateSetupN(const char * topVolName, const char * 
 XMLNodePointer_t TGDMLWrite::StartVolumeN(const char * name, const char * solid, const char * material)
 {
    XMLNodePointer_t childN;
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "volume", 0);
-   fGdmlE->NewAttr(mainN, 0, "name", name);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "volume", 0);
+   fGdmlE->NewAttr(mainN, nullptr, "name", name);
 
-   childN = fGdmlE->NewChild(0, 0, "materialref", 0);
-   fGdmlE->NewAttr(childN, 0, "ref", material);
+   childN = fGdmlE->NewChild(nullptr, nullptr, "materialref", 0);
+   fGdmlE->NewAttr(childN, nullptr, "ref", material);
    fGdmlE->AddChild(mainN, childN);
 
-   childN = fGdmlE->NewChild(0, 0, "solidref", 0);
-   fGdmlE->NewAttr(childN, 0, "ref", solid);
+   childN = fGdmlE->NewChild(nullptr, nullptr, "solidref", 0);
+   fGdmlE->NewAttr(childN, nullptr, "ref", solid);
    fGdmlE->AddChild(mainN, childN);
 
    return mainN;
@@ -1929,8 +1929,8 @@ XMLNodePointer_t TGDMLWrite::StartVolumeN(const char * name, const char * solid,
 
 XMLNodePointer_t TGDMLWrite::StartAssemblyN(const char * name)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "assembly", 0);
-   fGdmlE->NewAttr(mainN, 0, "name", name);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "assembly", 0);
+   fGdmlE->NewAttr(mainN, nullptr, "name", name);
 
    return mainN;
 }
@@ -1942,22 +1942,22 @@ XMLNodePointer_t TGDMLWrite::CreatePhysVolN(const char *name, Int_t copyno, cons
 {
    fPhysVolCnt++;
    XMLNodePointer_t childN;
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "physvol", 0);
-   fGdmlE->NewAttr(mainN, 0, "name", name);
-   fGdmlE->NewAttr(mainN, 0, "copynumber", TString::Format("%d",copyno));
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "physvol", 0);
+   fGdmlE->NewAttr(mainN, nullptr, "name", name);
+   fGdmlE->NewAttr(mainN, nullptr, "copynumber", TString::Format("%d",copyno));
 
-   childN = fGdmlE->NewChild(0, 0, "volumeref", 0);
-   fGdmlE->NewAttr(childN, 0, "ref", volref);
+   childN = fGdmlE->NewChild(nullptr, nullptr, "volumeref", 0);
+   fGdmlE->NewAttr(childN, nullptr, "ref", volref);
    fGdmlE->AddChild(mainN, childN);
 
-   childN = fGdmlE->NewChild(0, 0, "positionref", 0);
-   fGdmlE->NewAttr(childN, 0, "ref", posref);
+   childN = fGdmlE->NewChild(nullptr, nullptr, "positionref", 0);
+   fGdmlE->NewAttr(childN, nullptr, "ref", posref);
    fGdmlE->AddChild(mainN, childN);
 
    //if is not empty string add this node
    if (strcmp(rotref, "") != 0) {
-      childN = fGdmlE->NewChild(0, 0, "rotationref", 0);
-      fGdmlE->NewAttr(childN, 0, "ref", rotref);
+      childN = fGdmlE->NewChild(nullptr, nullptr, "rotationref", 0);
+      fGdmlE->NewAttr(childN, nullptr, "ref", rotref);
       fGdmlE->AddChild(mainN, childN);
    }
    if (scaleN != NULL) {
@@ -1973,9 +1973,9 @@ XMLNodePointer_t TGDMLWrite::CreatePhysVolN(const char *name, Int_t copyno, cons
 XMLNodePointer_t TGDMLWrite::CreateDivisionN(Double_t offset, Double_t width, Int_t number, const char * axis, const char * unit, const char * volref)
 {
    XMLNodePointer_t childN = 0;
-   XMLNodePointer_t mainN = fGdmlE->NewChild(0, 0, "divisionvol", 0);
-   fGdmlE->NewAttr(mainN, 0, "axis", axis);
-   fGdmlE->NewAttr(mainN, 0, "number", TString::Format("%i", number));
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "divisionvol", 0);
+   fGdmlE->NewAttr(mainN, nullptr, "axis", axis);
+   fGdmlE->NewAttr(mainN, nullptr, "number", TString::Format("%i", number));
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    if (fgG4Compatibility  == kTRUE) {
       //if eg. full length is 20 and width * number = 20,0001 problem in geant4
@@ -1988,13 +1988,13 @@ XMLNodePointer_t TGDMLWrite::CreateDivisionN(Double_t offset, Double_t width, In
          offset = (offsetI % 360) + decimals - 360;
       }
    }
-   fGdmlE->NewAttr(mainN, 0, "width", TString::Format(fltPrecision.Data(), width));
+   fGdmlE->NewAttr(mainN, nullptr, "width", TString::Format(fltPrecision.Data(), width));
 
-   fGdmlE->NewAttr(mainN, 0, "offset", TString::Format(fltPrecision.Data(), offset));
-   fGdmlE->NewAttr(mainN, 0, "unit", unit);
+   fGdmlE->NewAttr(mainN, nullptr, "offset", TString::Format(fltPrecision.Data(), offset));
+   fGdmlE->NewAttr(mainN, nullptr, "unit", unit);
    if (strcmp(volref, "") != 0) {
-      childN = fGdmlE->NewChild(0, 0, "volumeref", 0);
-      fGdmlE->NewAttr(childN, 0, "ref", volref);
+      childN = fGdmlE->NewChild(nullptr, nullptr, "volumeref", 0);
+      fGdmlE->NewAttr(childN, nullptr, "ref", volref);
    }
    fGdmlE->AddChild(mainN, childN);
 


### PR DESCRIPTION
- TGDMLWrite: Fix interface to write partial trees. Partial trees must be identified by a TGeoNode and not by a TGeoVolume. Otherwise surfaces cannot be attached to the top level nodes of a partial tree.
- TGDMLWrite: add values of material/surface property tables to output
- TGDMLWrite: add output of CONST properties
- TGDMLParse: protect against trailing '\n' and other white spaces when reading property table values