### PR TITLE
Fix to merge request #4160 - backwards compatibility for old DD4hep versions

### DIFF
--- a/geom/gdml/inc/TGDMLWrite.h
+++ b/geom/gdml/inc/TGDMLWrite.h
@@ -228,6 +228,11 @@ private:
    UInt_t GetFltPrecision() const { return fFltPrecision; }
    void SetFltPrecision(UInt_t prec) { fFltPrecision = prec; }
 
+   ////////////////////////////////////////////////////////////////////////////////
+   //
+   // Backwards compatibility for old DD4hep version (to be removed in the future)
+   //
+   ////////////////////////////////////////////////////////////////////////////////
 public:
    // Backwards compatibility (to be removed in the future): Wrapper to only selectively write one branch
    void WriteGDMLfile(TGeoManager * geomanager, TGeoVolume* top_vol, const char* filename = "test.gdml", TString option = "");

--- a/geom/gdml/inc/TGDMLWrite.h
+++ b/geom/gdml/inc/TGDMLWrite.h
@@ -228,6 +228,14 @@ private:
    UInt_t GetFltPrecision() const { return fFltPrecision; }
    void SetFltPrecision(UInt_t prec) { fFltPrecision = prec; }
 
+public:
+   // Backwards compatibility (to be removed in the future): Wrapper to only selectively write one branch
+   void WriteGDMLfile(TGeoManager * geomanager, TGeoVolume* top_vol, const char* filename = "test.gdml", TString option = "");
+private:
+   // Backwards compatibility (to be removed in the future): Combined implementation to extract GDML information from the geometry tree
+   void WriteGDMLfile(TGeoManager * geomanager, TGeoVolume* top_vol, TList* materialsLst, const char* filename, TString option);
+   void ExtractVolumes(TGeoVolume* topVolume);    //result <volume> node...  + corresp. shape
+  
    ClassDef(TGDMLWrite, 0)    //imports GDML using DOM and binds it to ROOT
 };
 

--- a/geom/gdml/src/TGDMLWrite.cxx
+++ b/geom/gdml/src/TGDMLWrite.cxx
@@ -1899,7 +1899,7 @@ XMLNodePointer_t TGDMLWrite::CreateSetupN(const char * topVolName, const char * 
    XMLNodePointer_t setupN = fGdmlE->NewChild(nullptr, nullptr, "setup", nullptr);
    fGdmlE->NewAttr(setupN, nullptr, "name", name);
    fGdmlE->NewAttr(setupN, nullptr, "version", version);
-   XMLNodePointer_t fworldN = fGdmlE->NewChild(setupN, 0, "world", nullptr);
+   XMLNodePointer_t fworldN = fGdmlE->NewChild(setupN, nullptr, "world", nullptr);
    fGdmlE->NewAttr(fworldN, nullptr, "ref", topVolName);
    return setupN;
 }

--- a/geom/gdml/src/TGDMLWrite.cxx
+++ b/geom/gdml/src/TGDMLWrite.cxx
@@ -315,7 +315,7 @@ void TGDMLWrite::WriteGDMLfile(TGeoManager * geomanager,
    fGdmlFile = fGdmlE->NewDoc();
 
    //create root node and add it to blank GDML file
-   XMLNodePointer_t rootNode = fGdmlE->NewChild(nullptr, nullptr, krootNodeName, 0);
+   XMLNodePointer_t rootNode = fGdmlE->NewChild(nullptr, nullptr, krootNodeName, nullptr);
    fGdmlE->DocSetRootElement(fGdmlFile, rootNode);
 
    //add namespaces to root node
@@ -328,9 +328,9 @@ void TGDMLWrite::WriteGDMLfile(TGeoManager * geomanager,
 
    fNameList     = new NameLst;
 
-   fDefineNode = fGdmlE->NewChild(nullptr, nullptr, "define", 0);
-   fSolidsNode = fGdmlE->NewChild(nullptr, nullptr, "solids", 0);
-   fStructureNode = fGdmlE->NewChild(nullptr, nullptr, "structure", 0);
+   fDefineNode = fGdmlE->NewChild(nullptr, nullptr, "define", nullptr);
+   fSolidsNode = fGdmlE->NewChild(nullptr, nullptr, "solids", nullptr);
+   fStructureNode = fGdmlE->NewChild(nullptr, nullptr, "structure", nullptr);
    //========================
 
    //initialize list of accepted patterns for divisions (in ExtractVolumes)
@@ -500,7 +500,7 @@ XMLNodePointer_t TGDMLWrite::ExtractMaterials(TList* materialsLst)
 {
    Info("ExtractMaterials", "Extracting materials");
    //crate main <materials> node
-   XMLNodePointer_t materialsN = fGdmlE->NewChild(nullptr, nullptr, "materials", 0);
+   XMLNodePointer_t materialsN = fGdmlE->NewChild(nullptr, nullptr, "materials", nullptr);
    Int_t matcnt = 0;
 
    //go through materials  - iterator and object declaration
@@ -650,7 +650,7 @@ void TGDMLWrite::ExtractVolumes(TGeoNode* node)
          lz = geoNode->GetMatrix()->GetRotationMatrix()[8];
          if (geoNode->GetMatrix()->IsReflection()
              && TMath::Abs(lx) == 1 &&  TMath::Abs(ly) == 1 && TMath::Abs(lz) == 1) {
-            scaleN = fGdmlE->NewChild(nullptr, nullptr, "scale", 0);
+            scaleN = fGdmlE->NewChild(nullptr, nullptr, "scale", nullptr);
             fGdmlE->NewAttr(scaleN, nullptr, "name", (nodename + "scl").Data());
             fGdmlE->NewAttr(scaleN, nullptr, "x", TString::Format(fltPrecision.Data(), lx));
             fGdmlE->NewAttr(scaleN, nullptr, "y", TString::Format(fltPrecision.Data(), ly));
@@ -714,7 +714,7 @@ void TGDMLWrite::ExtractVolumes(TGeoNode* node)
 XMLNodePointer_t TGDMLWrite::CreateAtomN(Double_t atom, const char * unit)
 {
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
-   XMLNodePointer_t atomN = fGdmlE->NewChild(nullptr, nullptr, "atom", 0);
+   XMLNodePointer_t atomN = fGdmlE->NewChild(nullptr, nullptr, "atom", nullptr);
    fGdmlE->NewAttr(atomN, nullptr, "unit", unit);
    fGdmlE->NewAttr(atomN, nullptr, "value", TString::Format(fltPrecision.Data(), atom));
    return atomN;
@@ -726,7 +726,7 @@ XMLNodePointer_t TGDMLWrite::CreateAtomN(Double_t atom, const char * unit)
 XMLNodePointer_t TGDMLWrite::CreateDN(Double_t density, const char * unit)
 {
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
-   XMLNodePointer_t densN = fGdmlE->NewChild(nullptr, nullptr, "D", 0);
+   XMLNodePointer_t densN = fGdmlE->NewChild(nullptr, nullptr, "D", nullptr);
    fGdmlE->NewAttr(densN, nullptr, "unit", unit);
    fGdmlE->NewAttr(densN, nullptr, "value", TString::Format(fltPrecision.Data(), density));
    return densN;
@@ -738,7 +738,7 @@ XMLNodePointer_t TGDMLWrite::CreateDN(Double_t density, const char * unit)
 XMLNodePointer_t TGDMLWrite::CreateFractionN(Double_t percentage, const char * refName)
 {
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
-   XMLNodePointer_t fractN = fGdmlE->NewChild(nullptr, nullptr, "fraction", 0);
+   XMLNodePointer_t fractN = fGdmlE->NewChild(nullptr, nullptr, "fraction", nullptr);
    fGdmlE->NewAttr(fractN, nullptr, "n", TString::Format(fltPrecision.Data(), percentage));
    fGdmlE->NewAttr(fractN, nullptr, "ref", refName);
    return fractN;
@@ -749,7 +749,7 @@ XMLNodePointer_t TGDMLWrite::CreateFractionN(Double_t percentage, const char * r
 
 XMLNodePointer_t TGDMLWrite::CreatePropertyN(TNamed const &property)
 {
-  XMLNodePointer_t propertyN = fGdmlE->NewChild(nullptr, nullptr, "property", 0);
+  XMLNodePointer_t propertyN = fGdmlE->NewChild(nullptr, nullptr, "property", nullptr);
   fGdmlE->NewAttr(propertyN, nullptr, "name", property.GetName());
   fGdmlE->NewAttr(propertyN, nullptr, "ref", property.GetTitle());
   return propertyN;
@@ -760,7 +760,7 @@ XMLNodePointer_t TGDMLWrite::CreatePropertyN(TNamed const &property)
 
 XMLNodePointer_t TGDMLWrite::CreateIsotopN(TGeoIsotope * isotope, const char * name)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "isotope", 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "isotope", nullptr);
    fGdmlE->NewAttr(mainN, nullptr, "name", name);
    fGdmlE->NewAttr(mainN, nullptr, "N", TString::Format("%i", isotope->GetN()));
    fGdmlE->NewAttr(mainN, nullptr, "Z", TString::Format("%i", isotope->GetZ()));
@@ -774,7 +774,7 @@ XMLNodePointer_t TGDMLWrite::CreateIsotopN(TGeoIsotope * isotope, const char * n
 
 XMLNodePointer_t TGDMLWrite::CreateElementN(TGeoElement * element, XMLNodePointer_t materials, const char * name)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "element", 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "element", nullptr);
    fGdmlE->NewAttr(mainN, nullptr, "name", name);
    //local associative arrays for saving isotopes and their weight
    //inside element
@@ -837,7 +837,7 @@ XMLNodePointer_t TGDMLWrite::CreateElementN(TGeoElement * element, XMLNodePointe
 
 XMLNodePointer_t TGDMLWrite::CreateMixtureN(TGeoMixture * mixture, XMLNodePointer_t materials, TString mname)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "material", 0);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "material", nullptr);
    fGdmlE->NewAttr(mainN, nullptr, "name", mname);
    fGdmlE->AddChild(mainN, CreateDN(mixture->GetDensity()));
    //local associative arrays for saving elements and their weight
@@ -2360,7 +2360,7 @@ void TGDMLWrite::UnsetTemporaryBits(TGeoManager * geoMng)
 
 ////////////////////////////////////////////////////////////////////////////////
 //
-// Backwards compatibility (to be removed in the future)
+// Backwards compatibility for old DD4hep version (to be removed in the future)
 //
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -2434,7 +2434,7 @@ void TGDMLWrite::WriteGDMLfile(TGeoManager * geomanager,
    fGdmlFile = fGdmlE->NewDoc();
 
    //create root node and add it to blank GDML file
-   XMLNodePointer_t rootNode = fGdmlE->NewChild(nullptr, nullptr, krootNodeName, 0);
+   XMLNodePointer_t rootNode = fGdmlE->NewChild(nullptr, nullptr, krootNodeName, nullptr);
    fGdmlE->DocSetRootElement(fGdmlFile, rootNode);
 
    //add namespaces to root node
@@ -2447,9 +2447,9 @@ void TGDMLWrite::WriteGDMLfile(TGeoManager * geomanager,
 
    fNameList     = new NameLst;
 
-   fDefineNode = fGdmlE->NewChild(nullptr, nullptr, "define", 0);
-   fSolidsNode = fGdmlE->NewChild(nullptr, nullptr, "solids", 0);
-   fStructureNode = fGdmlE->NewChild(nullptr, nullptr, "structure", 0);
+   fDefineNode = fGdmlE->NewChild(nullptr, nullptr, "define", nullptr);
+   fSolidsNode = fGdmlE->NewChild(nullptr, nullptr, "solids", nullptr);
+   fStructureNode = fGdmlE->NewChild(nullptr, nullptr, "structure", nullptr);
    //========================
 
    //initialize list of accepted patterns for divisions (in ExtractVolumes)
@@ -2620,7 +2620,7 @@ void TGDMLWrite::ExtractVolumes(TGeoVolume* volume)
          lz = geoNode->GetMatrix()->GetRotationMatrix()[8];
          if (geoNode->GetMatrix()->IsReflection()
              && TMath::Abs(lx) == 1 &&  TMath::Abs(ly) == 1 && TMath::Abs(lz) == 1) {
-            scaleN = fGdmlE->NewChild(0, 0, "scale", 0);
+            scaleN = fGdmlE->NewChild(0, 0, "scale", nullptr);
             fGdmlE->NewAttr(scaleN, 0, "name", (nodename + "scl").Data());
             fGdmlE->NewAttr(scaleN, 0, "x", TString::Format(fltPrecision.Data(), lx));
             fGdmlE->NewAttr(scaleN, 0, "y", TString::Format(fltPrecision.Data(), ly));

--- a/geom/gdml/src/TGDMLWrite.cxx
+++ b/geom/gdml/src/TGDMLWrite.cxx
@@ -359,7 +359,7 @@ void TGDMLWrite::WriteGDMLfile(TGeoManager * geomanager,
 
    //calling main extraction functions (with measuring time)
    time_t startT, endT;
-   startT = time(NULL);
+   startT = time(nullptr);
    ExtractMatrices(geomanager->GetListOfGDMLMatrices());
    ExtractConstants(geomanager);
    fMaterialsNode = ExtractMaterials(materialsLst);
@@ -372,7 +372,7 @@ void TGDMLWrite::WriteGDMLfile(TGeoManager * geomanager,
    ExtractSkinSurfaces(geomanager->GetListOfSkinSurfaces());
    ExtractBorderSurfaces(geomanager->GetListOfBorderSurfaces());
    ExtractOpticalSurfaces(geomanager->GetListOfOpticalSurfaces());
-   endT = time(NULL);
+   endT = time(nullptr);
    //<gdml>
    fGdmlE->AddChild(rootNode, fDefineNode);                 //  <define>...</define>
    fGdmlE->AddChild(rootNode, fMaterialsNode);              //  <materials>...</materials>
@@ -534,7 +534,7 @@ TString TGDMLWrite::ExtractSolid(TGeoShape* volShape)
    TString solname = "";
    solidN = ChooseObject(volShape);  //volume->GetShape()
    fGdmlE->AddChild(fSolidsNode, solidN);
-   if (solidN != NULL) fSolCnt++;
+   if (solidN != nullptr) fSolCnt++;
    solname = fNameList->fLst[TString::Format("%p", volShape)];
    if (solname.Contains("missing_")) {
       solname = "-1";
@@ -641,7 +641,7 @@ void TGDMLWrite::ExtractVolumes(TGeoNode* node)
          childN = CreatePositionN(posname.Data(), nodPos);
          fGdmlE->AddChild(fDefineNode, childN); //adding node to <define> node
          //Deal with reflection
-         XMLNodePointer_t scaleN = NULL;
+         XMLNodePointer_t scaleN = nullptr;
          Double_t lx, ly, lz;
          Double_t xangle = 0;
          Double_t zangle = 0;
@@ -961,7 +961,7 @@ XMLNodePointer_t TGDMLWrite::CreateBoxN(TGeoBBox * geoShape)
    if (IsNullParam(geoShape->GetDX(), "DX", lname) ||
        IsNullParam(geoShape->GetDY(), "DY", lname) ||
        IsNullParam(geoShape->GetDZ(), "DZ", lname)) {
-      return NULL;
+      return nullptr;
    }
    fGdmlE->NewAttr(mainN, nullptr, "x", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDX()));
    fGdmlE->NewAttr(mainN, nullptr, "y", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDY()));
@@ -982,7 +982,7 @@ XMLNodePointer_t TGDMLWrite::CreateParaboloidN(TGeoParaboloid * geoShape)
    fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetRhi(), "Rhi", lname) ||
        IsNullParam(geoShape->GetDz(), "Dz", lname)) {
-      return NULL;
+      return nullptr;
    }
    fGdmlE->NewAttr(mainN, nullptr, "rlo", TString::Format(fltPrecision.Data(), geoShape->GetRlo()));
    fGdmlE->NewAttr(mainN, nullptr, "rhi", TString::Format(fltPrecision.Data(), geoShape->GetRhi()));
@@ -1002,7 +1002,7 @@ XMLNodePointer_t TGDMLWrite::CreateSphereN(TGeoSphere * geoShape)
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
    fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetRmax(), "Rmax", lname)) {
-      return NULL;
+      return nullptr;
    }
 
    fGdmlE->NewAttr(mainN, nullptr, "rmin", TString::Format(fltPrecision.Data(), geoShape->GetRmin()));
@@ -1027,7 +1027,7 @@ XMLNodePointer_t TGDMLWrite::CreateArb8N(TGeoArb8 * geoShape)
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
    fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetDz(), "Dz", lname)) {
-      return NULL;
+      return nullptr;
    }
 
    fGdmlE->NewAttr(mainN, nullptr, "v1x", TString::Format(fltPrecision.Data(), geoShape->GetVertices()[0]));
@@ -1062,7 +1062,7 @@ XMLNodePointer_t TGDMLWrite::CreateConeN(TGeoConeSeg * geoShape)
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
    fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetDz(), "Dz", lname)) {
-      return NULL;
+      return nullptr;
    }
 
    fGdmlE->NewAttr(mainN, nullptr, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDz()));
@@ -1088,7 +1088,7 @@ XMLNodePointer_t TGDMLWrite::CreateConeN(TGeoCone * geoShape)
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
    fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetDz(), "Dz", lname)) {
-      return NULL;
+      return nullptr;
    }
 
    fGdmlE->NewAttr(mainN, nullptr, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDz()));
@@ -1150,7 +1150,7 @@ XMLNodePointer_t TGDMLWrite::CreateTrapN(TGeoTrap * geoShape)
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
    fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetDz(), "Dz", lname)) {
-      return NULL;
+      return nullptr;
    }
 
    fGdmlE->NewAttr(mainN, nullptr, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDz()));
@@ -1202,7 +1202,7 @@ XMLNodePointer_t TGDMLWrite::CreateTwistedTrapN(TGeoGtra * geoShape)
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
    fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetDz(), "Dz", lname)) {
-      return NULL;
+      return nullptr;
    }
 
    fGdmlE->NewAttr(mainN, nullptr, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDz()));
@@ -1241,7 +1241,7 @@ XMLNodePointer_t TGDMLWrite::CreateTrdN(TGeoTrd1 * geoShape)
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
    fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetDz(), "Dz", lname)) {
-      return NULL;
+      return nullptr;
    }
 
    fGdmlE->NewAttr(mainN, nullptr, "x1", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDx1()));
@@ -1264,7 +1264,7 @@ XMLNodePointer_t TGDMLWrite::CreateTrdN(TGeoTrd2 * geoShape)
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
    fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetDz(), "Dz", lname)) {
-      return NULL;
+      return nullptr;
    }
 
    fGdmlE->NewAttr(mainN, nullptr, "x1", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDx1()));
@@ -1288,7 +1288,7 @@ XMLNodePointer_t TGDMLWrite::CreateTubeN(TGeoTubeSeg * geoShape)
    fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetRmax(), "Rmax", lname) ||
        IsNullParam(geoShape->GetDz(), "Dz", lname)) {
-      return NULL;
+      return nullptr;
    }
 
    fGdmlE->NewAttr(mainN, nullptr, "rmin", TString::Format(fltPrecision.Data(), geoShape->GetRmin()));
@@ -1315,7 +1315,7 @@ XMLNodePointer_t TGDMLWrite::CreateCutTubeN(TGeoCtub * geoShape)
    fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetRmax(), "Rmax", lname) ||
        IsNullParam(geoShape->GetDz(), "Dz", lname)) {
-      return NULL;
+      return nullptr;
    }
    //This is not needed, because cutTube is already supported by Geant4 9.5
    if (fgG4Compatibility == kTRUE && kFALSE) {
@@ -1358,7 +1358,7 @@ XMLNodePointer_t TGDMLWrite::CreateTubeN(TGeoTube * geoShape)
    fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetRmax(), "Rmax", lname) ||
        IsNullParam(geoShape->GetDz(), "Dz", lname)) {
-      return NULL;
+      return nullptr;
    }
 
    fGdmlE->NewAttr(mainN, nullptr, "rmin", TString::Format(fltPrecision.Data(), geoShape->GetRmin()));
@@ -1450,7 +1450,7 @@ XMLNodePointer_t TGDMLWrite::CreateTorusN(TGeoTorus * geoShape)
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
    fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetRmax(), "Rmax", lname)) {
-      return NULL;
+      return nullptr;
    }
 
    fGdmlE->NewAttr(mainN, nullptr, "rtor", TString::Format(fltPrecision.Data(), geoShape->GetR()));
@@ -1499,7 +1499,7 @@ XMLNodePointer_t TGDMLWrite::CreateEltubeN(TGeoEltu * geoShape)
    if (IsNullParam(geoShape->GetA(), "A", lname) ||
        IsNullParam(geoShape->GetB(), "B", lname) ||
        IsNullParam(geoShape->GetDz(), "Dz", lname)) {
-      return NULL;
+      return nullptr;
    }
 
    fGdmlE->NewAttr(mainN, nullptr, "dx", TString::Format(fltPrecision.Data(), geoShape->GetA()));
@@ -1521,7 +1521,7 @@ XMLNodePointer_t TGDMLWrite::CreateHypeN(TGeoHype * geoShape)
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
    fGdmlE->NewAttr(mainN, nullptr, "name", lname);
    if (IsNullParam(geoShape->GetDz(), "Dz", lname)) {
-      return NULL;
+      return nullptr;
    }
 
 
@@ -1554,7 +1554,7 @@ XMLNodePointer_t TGDMLWrite::CreateXtrusionN(TGeoXtru * geoShape)
    if (vertNum < 3 || secNum < 2) {
       Info("CreateXtrusionN", "ERROR! TGeoXtru %s has only %i vertices and %i sections. It was not exported",
            lname.Data(), vertNum, secNum);
-      mainN = NULL;
+      mainN = nullptr;
       return mainN;
    }
    for (Int_t it = 0; it < vertNum; it++) {
@@ -1706,22 +1706,22 @@ XMLNodePointer_t TGDMLWrite::CreateCommonBoolN(TGeoCompositeShape *geoShape)
    TString rname = fNameList->fLst[TString::Format("%p", geoShape->GetBoolNode()->GetRightShape())];
 
    //left and right nodes appended to main structure of nodes (if they are not already there)
-   if (ndL != NULL) {
+   if (ndL != nullptr) {
       fGdmlE->AddChild(fSolidsNode, ndL);
       fSolCnt++;
    } else {
       if (lname.Contains("missing_") || lname == "") {
          Info("CreateCommonBoolN", "ERROR! Left node is NULL - Boolean Shape will be skipped");
-         return NULL;
+         return nullptr;
       }
    }
-   if (ndR != NULL) {
+   if (ndR != nullptr) {
       fGdmlE->AddChild(fSolidsNode, ndR);
       fSolCnt++;
    } else {
       if (rname.Contains("missing_") || rname == "") {
          Info("CreateCommonBoolN", "ERROR! Right node is NULL - Boolean Shape will be skipped");
-         return NULL;
+         return nullptr;
       }
    }
 
@@ -1960,7 +1960,7 @@ XMLNodePointer_t TGDMLWrite::CreatePhysVolN(const char *name, Int_t copyno, cons
       fGdmlE->NewAttr(childN, nullptr, "ref", rotref);
       fGdmlE->AddChild(mainN, childN);
    }
-   if (scaleN != NULL) {
+   if (scaleN != nullptr) {
       fGdmlE->AddChild(mainN, scaleN);
    }
 
@@ -2011,7 +2011,7 @@ XMLNodePointer_t TGDMLWrite::ChooseObject(TGeoShape *geoShape)
    XMLNodePointer_t solidN;
 
    if (CanProcess((TObject *)geoShape) == kFALSE) {
-      return NULL;
+      return nullptr;
    }
 
    //process different shapes
@@ -2080,9 +2080,9 @@ XMLNodePointer_t TGDMLWrite::ChooseObject(TGeoShape *geoShape)
    } else {
       Info("ChooseObject", "ERROR! %s Solid CANNOT be processed, solid is NOT supported",
            clsname);
-      solidN = NULL;
+      solidN = nullptr;
    }
-   if (solidN == NULL) {
+   if (solidN == nullptr) {
       if (fNameList->fLst[TString::Format("%p", geoShape)] == "") {
          TString missingName = geoShape->GetName();
          GenName("missing_" + missingName, TString::Format("%p", geoShape));
@@ -2478,7 +2478,7 @@ void TGDMLWrite::WriteGDMLfile(TGeoManager * geomanager,
 
    //calling main extraction functions (with measuring time)
    time_t startT, endT;
-   startT = time(NULL);
+   startT = time(nullptr);
    ExtractMatrices(geomanager->GetListOfGDMLMatrices());
    ExtractConstants(geomanager);
    fMaterialsNode = ExtractMaterials(materialsLst);
@@ -2491,7 +2491,7 @@ void TGDMLWrite::WriteGDMLfile(TGeoManager * geomanager,
    ExtractSkinSurfaces(geomanager->GetListOfSkinSurfaces());
    ExtractBorderSurfaces(geomanager->GetListOfBorderSurfaces());
    ExtractOpticalSurfaces(geomanager->GetListOfOpticalSurfaces());
-   endT = time(NULL);
+   endT = time(nullptr);
    //<gdml>
    fGdmlE->AddChild(rootNode, fDefineNode);                 //  <define>...</define>
    fGdmlE->AddChild(rootNode, fMaterialsNode);              //  <materials>...</materials>
@@ -2524,7 +2524,7 @@ void TGDMLWrite::ExtractVolumes(TGeoVolume* volume)
 {
    XMLNodePointer_t volumeN, childN;
    TString volname, matname, solname, pattClsName, nodeVolNameBak;
-   TGeoPatternFinder *pattFinder = 0;
+   TGeoPatternFinder *pattFinder = nullptr;
    Bool_t isPattern = kFALSE;
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
 
@@ -2611,7 +2611,7 @@ void TGDMLWrite::ExtractVolumes(TGeoVolume* volume)
          childN = CreatePositionN(posname.Data(), nodPos);
          fGdmlE->AddChild(fDefineNode, childN); //adding node to <define> node
          //Deal with reflection
-         XMLNodePointer_t scaleN = NULL;
+         XMLNodePointer_t scaleN = nullptr;
          Double_t lx, ly, lz;
          Double_t xangle = 0;
          Double_t zangle = 0;
@@ -2620,11 +2620,11 @@ void TGDMLWrite::ExtractVolumes(TGeoVolume* volume)
          lz = geoNode->GetMatrix()->GetRotationMatrix()[8];
          if (geoNode->GetMatrix()->IsReflection()
              && TMath::Abs(lx) == 1 &&  TMath::Abs(ly) == 1 && TMath::Abs(lz) == 1) {
-            scaleN = fGdmlE->NewChild(0, 0, "scale", nullptr);
-            fGdmlE->NewAttr(scaleN, 0, "name", (nodename + "scl").Data());
-            fGdmlE->NewAttr(scaleN, 0, "x", TString::Format(fltPrecision.Data(), lx));
-            fGdmlE->NewAttr(scaleN, 0, "y", TString::Format(fltPrecision.Data(), ly));
-            fGdmlE->NewAttr(scaleN, 0, "z", TString::Format(fltPrecision.Data(), lz));
+            scaleN = fGdmlE->NewChild(nullptr, nullptr, "scale", nullptr);
+            fGdmlE->NewAttr(scaleN, nullptr, "name", (nodename + "scl").Data());
+            fGdmlE->NewAttr(scaleN, nullptr, "x", TString::Format(fltPrecision.Data(), lx));
+            fGdmlE->NewAttr(scaleN, nullptr, "y", TString::Format(fltPrecision.Data(), ly));
+            fGdmlE->NewAttr(scaleN, nullptr, "z", TString::Format(fltPrecision.Data(), lz));
             //experimentally found out, that rotation should be updated like this
             if (lx == -1) {
                zangle = 180;


### PR DESCRIPTION
The change of the interface of TGDMLWrite is in conflict with old DD4hep versions.

To temporarily overcome this problem the old interface is kept. 
The old interface however should be removed when standard installations use a compatible pairs of DD4hep and ROOT >= 6.20.

DD4hep when using ROOT 6.20.0 or greater will only use the new interface, where a partial tree is exported to GDML identified by it's TGeoNode instance.
