### PR TITLE
[geom] fix TGeoArb8 copy constr and assign operator (ROOT-10528) 

### DIFF
--- a/geom/geom/inc/TGeoArb8.h
+++ b/geom/geom/inc/TGeoArb8.h
@@ -24,9 +24,9 @@ protected:
       kArb8Tra  = BIT(28)  // general twisted trapezoid
    };
    // data members
-   Double_t              fDz;          // half length in Z
-   Double_t             *fTwist;       //! [4] tangents of twist angles
-   Double_t              fXY[8][2];    // list of vertices
+   Double_t              fDz{0};             // half length in Z
+   Double_t             *fTwist{nullptr};    //! [4] tangents of twist angles
+   Double_t              fXY[8][2];          // list of vertices
 
    TGeoArb8(const TGeoArb8&);
    TGeoArb8& operator=(const TGeoArb8&);

--- a/geom/geom/inc/TGeoArb8.h
+++ b/geom/geom/inc/TGeoArb8.h
@@ -31,6 +31,8 @@ protected:
    TGeoArb8(const TGeoArb8&);
    TGeoArb8& operator=(const TGeoArb8&);
 
+   void CopyTwist(Double_t *twist = nullptr);
+
 public:
    // constructors
    TGeoArb8();

--- a/geom/geom/src/TGeoArb8.cxx
+++ b/geom/geom/src/TGeoArb8.cxx
@@ -209,12 +209,13 @@ TGeoArb8::TGeoArb8(const char *name, Double_t dz, Double_t *vertices)
 TGeoArb8::TGeoArb8(const TGeoArb8& ga8) :
   TGeoBBox(ga8),
   fDz(ga8.fDz),
-  fTwist(ga8.fTwist)
+  fTwist(nullptr)
 {
    for(Int_t i=0; i<8; i++) {
       fXY[i][0]=ga8.fXY[i][0];
       fXY[i][1]=ga8.fXY[i][1];
    }
+   CopyTwist(ga8.fTwist);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -225,7 +226,7 @@ TGeoArb8& TGeoArb8::operator=(const TGeoArb8& ga8)
    if(this!=&ga8) {
       TGeoBBox::operator=(ga8);
       fDz=ga8.fDz;
-      fTwist=ga8.fTwist;
+      CopyTwist(ga8.fTwist);
       for(Int_t i=0; i<8; i++) {
          fXY[i][0]=ga8.fXY[i][0];
          fXY[i][1]=ga8.fXY[i][1];
@@ -240,6 +241,20 @@ TGeoArb8& TGeoArb8::operator=(const TGeoArb8& ga8)
 TGeoArb8::~TGeoArb8()
 {
    if (fTwist) delete [] fTwist;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Copy twist values from source array
+
+void TGeoArb8::CopyTwist(Double_t *twist)
+{
+   if (twist) {
+      if (!fTwist) fTwist = new Double_t[4];
+      memcpy(fTwist, twist, 4*sizeof(Double_t));
+   } else if (fTwist) {
+      delete [] fTwist;
+      fTwist = nullptr;
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/geom/geom/src/TGeoArb8.cxx
+++ b/geom/geom/src/TGeoArb8.cxx
@@ -145,7 +145,6 @@ End_Macro
 TGeoArb8::TGeoArb8()
 {
    fDz = 0;
-   fTwist = 0;
    for (Int_t i=0; i<8; i++) {
       fXY[i][0] = 0.0;
       fXY[i][1] = 0.0;
@@ -161,7 +160,6 @@ TGeoArb8::TGeoArb8(Double_t dz, Double_t *vertices)
          :TGeoBBox(0,0,0)
 {
    fDz = dz;
-   fTwist = 0;
    SetShapeBit(kGeoArb8);
    if (vertices) {
       for (Int_t i=0; i<8; i++) {
@@ -186,7 +184,6 @@ TGeoArb8::TGeoArb8(const char *name, Double_t dz, Double_t *vertices)
          :TGeoBBox(name, 0,0,0)
 {
    fDz = dz;
-   fTwist = 0;
    SetShapeBit(kGeoArb8);
    if (vertices) {
       for (Int_t i=0; i<8; i++) {
@@ -208,8 +205,7 @@ TGeoArb8::TGeoArb8(const char *name, Double_t dz, Double_t *vertices)
 
 TGeoArb8::TGeoArb8(const TGeoArb8& ga8) :
   TGeoBBox(ga8),
-  fDz(ga8.fDz),
-  fTwist(nullptr)
+  fDz(ga8.fDz)
 {
    for(Int_t i=0; i<8; i++) {
       fXY[i][0]=ga8.fXY[i][0];
@@ -334,11 +330,9 @@ void TGeoArb8::ComputeTwist()
       twist[i] = TMath::Sign(1.,twist[i]);
       twisted = kTRUE;
    }
-   if (twisted) {
-      if (fTwist) delete [] fTwist;
-      fTwist = new Double_t[4];
-      memcpy(fTwist, &twist[0], 4*sizeof(Double_t));
-   }
+
+   CopyTwist(twisted ? twist : nullptr);
+
    if (singleBottom) {
       for (i=0; i<4; i++) {
          fXY[i][0] += 1.E-8*fXY[i+4][0];
@@ -397,9 +391,7 @@ void TGeoArb8::ComputeTwist()
 
 Double_t TGeoArb8::GetTwist(Int_t iseg) const
 {
-   if (!fTwist) return 0.;
-   if (iseg<0 || iseg>3) return 0.;
-   return fTwist[iseg];
+   return (!fTwist || iseg<0 || iseg>3) ? 0. : fTwist[iseg];
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
fTwist array should be recreated when copied from other instance

Also fix problem in TGeoArb8::ComputeTwist
When new twist values are calculated, indicating that fTwist does not
required, they were not correctly set back to fTwist member. May lead to
wrong calculations.