### PR TITLE
[rootcling] Rework the command line option parsing.

### DIFF
--- a/README/ReleaseNotes/v620/index.md
+++ b/README/ReleaseNotes/v620/index.md
@@ -60,7 +60,9 @@ instead of the splash screen. The splash screen can still be seen with `root -a`
 or in `TBrowser` by opening `Browser Help → About ROOT`.
 
 ## Deprecation and Removal
- * rootcling flags `-cint`, `-reflex` and `-gccxml` have no effect and will be
+ * rootcling flags `-cint`, `-reflex`, `-gccxml`, `-p` and `-c` have no effect
+   and will be removed. Please remove them from the rootcling invocations.
+ * rootcling legacy cint flags `+P`, `+V` and `+STUB` have no effect and will be
    removed. Please remove them from the rootcling invocations.
  * genreflex flag `--deep` has no effect and will be removed. Please remove it
    from the genreflex invocation.

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -3908,6 +3908,9 @@ int RootClingMain(int argc,
    }
 #endif
 
+   // Hide options from llvm which we got from static initialization of libCling.
+   llvm::cl::HideUnrelatedOptions(/*keep*/gRootclingOptions);
+
    llvm::cl::ParseCommandLineOptions(argc, argv, "rootcling");
 
    std::string dictname;

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -3857,9 +3857,6 @@ int RootClingMain(int argc,
       return 1;
    }
 
-   // Store the temp files
-   tempFileNamesCatalog tmpCatalog;
-
    if (ic < argc && IsImplementationName(argv[ic])) {
       FILE *fp;
       if (!ignoreExistingDict && (fp = fopen(argv[ic], "r")) != 0) {
@@ -4487,6 +4484,8 @@ int RootClingMain(int argc,
    std::ofstream fileout;
    string main_dictname(dictpathname);
    std::ostream *dictStreamPtr = NULL;
+   // Store the temp files
+   tempFileNamesCatalog tmpCatalog;
    if (!ignoreExistingDict) {
       if (!dictpathname.empty()) {
          tmpCatalog.addFileName(dictpathname);

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -2886,7 +2886,7 @@ void TFile::MakeProject(const char *dirname, const char * /*classes*/,
          fprintf(fpMAKE,"genreflex %sProjectHeaders.h -o %sProjectDict.cxx --comments --iocomments %s ",subdirname.Data(),subdirname.Data(),gSystem->GetIncludePath());
          path.Form("%s/%sSelection.xml",clean_dirname.Data(),subdirname.Data());
       } else {
-         fprintf(fpMAKE,"rootcint -v1 -f %sProjectDict.cxx -c %s ", subdirname.Data(), gSystem->GetIncludePath());
+         fprintf(fpMAKE,"rootcint -v1 -f %sProjectDict.cxx %s ", subdirname.Data(), gSystem->GetIncludePath());
          path.Form("%s/%sLinkDef.h",clean_dirname.Data(),subdirname.Data());
       }
    } else {
@@ -3302,7 +3302,7 @@ Int_t TFile::MakeProjectParMake(const char *pack, const char *filemake)
    fprintf(fmk, "\n");
    fprintf(fmk, "%sProjectDict.$(SrcSuf): %sProjectHeaders.h %sLinkDef.h\n", pack, pack, pack);
    fprintf(fmk, "\t\t@echo \"Generating dictionary $@...\"\n");
-   fprintf(fmk, "\t\t@rootcint -f $@ -c $^\n");
+   fprintf(fmk, "\t\t@rootcint -f $@ $^\n");
    fprintf(fmk, "\n");
    fprintf(fmk, ".$(SrcSuf).$(ObjSuf):\n");
    fprintf(fmk, "\t\t$(CXX) $(CXXFLAGS) -c $<\n");


### PR DESCRIPTION
The argument parsing in rootcling has become quite hard (if not impossible) to maintain. This PR replaces the handmade argument parsing with the [LLVM's CommandLine](https://github.com/root-project/root/blob/master/interpreter/llvm/src/docs/CommandLine.rst) framework.
Use the llvm command line option parser and phase out the hand crafted one.

It uses declarative-style option specification, improves type-safety and most importantly moves out from rootcling the cumbersome argument parsing logic.

One of the major advantages is that help messages are automatically generated:
 ```
    OVERVIEW: rootcling
    USAGE: rootcling [options] <output dictionary file> <list of dictionary header files> <LinkDef file>
    
    OPTIONS:
    
    Generic Options:
    
      -help                 - Display available options (-help-hidden for more)
      -help-list            - Display list of available options (-help-list-hidden for more)
      -version              - Display the version of this program
    
    rootcling common options:
    
      -D=<string>           - Specify defined macros.
      -I=<string>           - Specify an include path.
      -W=<string>           - Specify compiler diagnostics options.
      -c                    - Deprecated, legacy flag which is ignored.
      -cxxmodule            - Generate a C++ module.
      -excludePath=<string> - Do not store the <path> in the dictionary.
      -f                    - Overwrite <file>s.
      -failOnWarnings       - Fail if there are warnings.
      -inlineInputHeader    - Does not generate #include <header> but expands the header content.
      -interpreteronly      - Generate minimal dictionary for interactivity (without IO information).
      -m=<string>           - The list of dependent modules of the dictionary.
      -multiDict            - If this library has multiple separate LinkDef files.
      -noIncludePaths       - Do not store include paths but rely on the env variable ROOT_INCLUDE_PATH.
      -p                    - Deprecated, legacy flag which is ignored.
      -rmf=<string>         - Generate a rootmap file with the specified name.
      -rml=<string>         - Generate rootmap file.
      -s=<string>           - The path to the library of the built dictionary.
      -selSyntaxOnly        - Check the selection syntax only.
      -split                - Split the dictionary into two parts: one containing the IO (ClassDef)information and another the interactivity support.
      Choose verbosity level:
        -v                  - Show errors (default).
        -v0                 - Show only fatal errors.
        -v1                 - Show errors (the same as -v).
        -v2                 - Show warnings.
        -v3                 - Show notes.
        -v4                 - Show information.
 ```
    
 This patch deprecates:
   1) +P, +V, +STUB, -gccxml, -cint, -reflex -- they are old CINT legacy options which had no meaning in rootcling.
   2) -p, -c -- remove old options used by rootcling -generate-pch as now the build system does not export its lists of flags directly to roocling.
    
The implementation of 2) was quite permissive as it tried to send all possible unknown options directly to rootcling. As a side effect of reworking of 2) we can restrict the options being sent and unknown options are not sent to rootcling anymore, improving encapsulation.
    
If there is a need to do so please contact us or use the EXTRA_CLING_ARGS env option.

PS: The end goal is fixing the incremental builds when -Druntime_cxxmodules=On. We will have something like `rootcling --bare-cling="-fmodules -fno-implicit-module-maps -fmodule-map-file=... -emit-module=std`.