### PR TITLE
[WIP][RDF] add Merge function to RCutFlowReport

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RCutFlowReport.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RCutFlowReport.hxx
@@ -33,8 +33,8 @@ class TCutInfo {
 
 private:
    const std::string fName;
-   const ULong64_t fPass;
-   const ULong64_t fAll;
+   ULong64_t fPass;
+   ULong64_t fAll;
    TCutInfo(const std::string &name, ULong64_t pass, ULong64_t all) : fName(name), fPass(pass), fAll(all) {}
 
 public:
@@ -42,6 +42,7 @@ public:
    ULong64_t GetAll() const { return fAll; }
    ULong64_t GetPass() const { return fPass; }
    float GetEff() const { return 100.f * (fPass / float(fAll)); }
+   void Merge(const TCutInfo &other);
 };
 
 class RCutFlowReport {

--- a/tree/dataframe/inc/ROOT/RDF/RCutFlowReport.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RCutFlowReport.hxx
@@ -58,6 +58,7 @@ public:
    const TCutInfo &At(std::string_view cutName) { return operator[](cutName); }
    const_iterator begin() const { return fCutInfos.begin(); }
    const_iterator end() const { return fCutInfos.end(); }
+   void Merge(RCutFlowReport &other);
 };
 
 } // End NS RDF

--- a/tree/dataframe/src/RCutFlowReport.cxx
+++ b/tree/dataframe/src/RCutFlowReport.cxx
@@ -49,6 +49,28 @@ const TCutInfo &RCutFlowReport::operator[](std::string_view cutName)
    return *it;
 }
 
+void RCutFlowReport::Merge(RCutFlowReport &other)
+{
+   auto old_infos = fCutInfos;
+
+   fCutInfos.clear();
+   for (auto &&this_info : old_infos) {
+
+      const auto &this_name = this_info.GetName();
+      auto this_all = this_info.GetAll();
+      auto this_pass = this_info.GetPass();
+
+      auto other_info = other.At(this_name);
+      auto other_all = other_info.GetAll();
+      auto other_pass = other_info.GetPass();
+
+      this_all += other_all;
+      this_pass += other_pass;
+
+      this->AddCut({this_name, this_pass, this_all});
+   }
+}
+
 } // End NS RDF
 
 } // End NS ROOT

--- a/tree/dataframe/src/RCutFlowReport.cxx
+++ b/tree/dataframe/src/RCutFlowReport.cxx
@@ -49,25 +49,25 @@ const TCutInfo &RCutFlowReport::operator[](std::string_view cutName)
    return *it;
 }
 
+void TCutInfo::Merge(const TCutInfo &other)
+{
+   // Check the two cuts have the same name
+   if (fName == other.GetName()) {
+      fAll += other.GetAll();  // Update All
+      fPass += other.GetPass();  // Update Pass
+   } else { // throw error showing the different names
+      std::string err = "Current cut \"" + fName + "\" ";
+      err += "is not the same as \"" + other.GetName() + "\"";
+      throw std::runtime_error(err);
+   }
+}
+
 void RCutFlowReport::Merge(RCutFlowReport &other)
 {
-   auto old_infos = fCutInfos;
-
-   fCutInfos.clear();
-   for (auto &&this_info : old_infos) {
-
-      const auto &this_name = this_info.GetName();
-      auto this_all = this_info.GetAll();
-      auto this_pass = this_info.GetPass();
-
-      auto other_info = other.At(this_name);
-      auto other_all = other_info.GetAll();
-      auto other_pass = other_info.GetPass();
-
-      this_all += other_all;
-      this_pass += other_pass;
-
-      this->AddCut({this_name, this_pass, this_all});
+   for (auto &&this_info : fCutInfos) {
+      // Retrieve TCutInfo object with the same name
+      auto other_info = other[this_info.GetName()];
+      this_info.Merge(other_info);  // Merge the two TCutInfo
    }
 }
 

--- a/tree/dataframe/test/dataframe_report.cxx
+++ b/tree/dataframe/test/dataframe_report.cxx
@@ -97,3 +97,28 @@ TEST(RDataFrameReport, ActionLazyness)
    EXPECT_TRUE(hasRun);
 
 }
+
+TEST(RDataFrameReport, Merging)
+{
+   ROOT::RDataFrame d(10);
+   auto rep = d.Define("a", "rdfentry_")
+               .Filter("a < 5", "less_than_5")
+               .Report();
+
+   auto this_rep_val = *rep;
+   auto other_rep_val = this_rep_val;
+
+   auto cut = this_rep_val.At("less_than_5");
+
+   auto old_all = cut.GetAll();
+   auto old_pass = cut.GetPass();
+   auto old_eff = cut.GetEff();
+
+   this_rep_val.Merge(other_rep_val);
+
+   auto merged_cut = this_rep_val.At("less_than_5");
+
+   EXPECT_EQ(merged_cut.GetAll(), old_all*2);
+   EXPECT_EQ(merged_cut.GetPass(), old_pass*2);
+   EXPECT_EQ(merged_cut.GetEff(), old_eff);
+}


### PR DESCRIPTION
The RCutFlowReport class could benefit of a Merge method since it would ease the implementation of the Report RDataFrame operation in a distributed environment.
In a situation where two chunks of a dataset have been processed separately, a report for each chunk would only contain filtering information of that chunk. In this case, merging the two reports together should provide general information on the cut flow of the entire dataset.

Right now, the Merge function works as follows:
It takes another RCutFlowReport as argument (passed by reference).
The fCutInfos member of the current RCutFlowReport is stored in a temporary variable and then cleared.
For each TCutInfo, another TCutInfo with the same name is searched in the other report.
The information on all the entries and the passed entries is then summed up between the two objects.
Finally a new TCutInfo with the resulting information is added to the initial RCutFlowReport.

The clearing of fCutInfos is needed since the fPass and fAll members of TCutInfo are const.
If seen appropriate, the const keyword can be removed, then the fCutInfos could be just updated each time.

A very simple test has been added.

TODO:
- [ ] Add more thorough tests.
- [ ] Decide on the return type of the Merge function (now is void).
- [ ] Possibly overload the function with RCutFlowReport* as argument.
- [ ] Finally add documentation when everything is set.