### PR TITLE
[cxxmodules] Resolve possible symlinks in the path of rdict files.

### DIFF
--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -590,7 +590,7 @@ private: // Private Utility Functions and Classes
    std::map<std::string, llvm::StringRef> fPendingRdicts;
    friend void TCling__RegisterRdictForLoadPCM(const std::string &pcmFileNameFullPath, llvm::StringRef *pcmContent);
    void RegisterRdictForLoadPCM(const std::string &pcmFileNameFullPath, llvm::StringRef *pcmContent);
-   bool LoadPCM(const std::string &pcmFileNameFullPath);
+   bool LoadPCM(std::string pcmFileNameFullPath);
    bool LoadPCMImpl(TFile &pcmFile);
 
    void InitRootmapFile(const char *name);


### PR DESCRIPTION
When reading rdict files from the module we use the module name to form an
entry in a pending rdict map. It is later used when a library is loaded to
locate the corresponding rdict file.

This patch resolves a potential symlinks and allows ROOT to find its rdict
files. It fixes the cmssw C++ modules setup.