### PR TITLE
[RF] Add warnings for RooDataSet with weight errors.

### DIFF
--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -160,6 +160,8 @@ private:
   typedef MemPoolForRooSets<RooDataSet, 5*150> MemPool; // 150 = about 100kb
   static MemPool * memPool();
 #endif
+  unsigned short _errorMsgCount{0}; //! Counter to silence error messages when filling dataset.
+  bool _doWeightErrorCheck{true}; //! When adding events with weights, check that weights can actually be stored.
 
   ClassDef(RooDataSet,2) // Unbinned data set
 };


### PR DESCRIPTION
- When weight errors are added to a RooDataSet, but the dataset hasn't
been set up to store weights, these are silently ignored. Users will now
see warnings.
- After adding the last event, the weight variable will keep the value
of the weight error until a new error is set. RooDataSet::add()
therefore now resets weight and weight error after adding an entry.

[ROOT-10259]